### PR TITLE
docs: add EXECUTOR MODE pattern and multi-agent topology

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ Now if the agent stalls or hits a usage limit, your phone buzzes.
 
 ## Telling the agent what to do
 
-The `AGENT_LOOP_PROMPT` in your config is just plain English instructions. The agent re-reads them every iteration. Examples:
+### Option A — Self-scheduling (simple)
+
+The `AGENT_LOOP_PROMPT` in your config is just plain English instructions. The agent registers its own timer and re-fires on that cadence forever.
 
 ```sh
 # simplest: ask it to do one thing every N minutes
@@ -135,7 +137,39 @@ AGENT_LOOP_PROMPT="/loop 15m Read /home/me/my-policy.md and do what it says."
 
 The second pattern scales better. If you start writing complex rules, stop stuffing them into the env var and put them in a markdown file. Your agent can re-read the file every iteration — edit the markdown, behavior updates, no restart needed.
 
-See [`examples/scanner-policy.md`](examples/scanner-policy.md) for a full example (a GitHub issue scanner that watches 5 repos and fixes small bugs automatically).
+See [`examples/scanner-policy.md`](examples/scanner-policy.md) for a full example.
+
+### Option B — EXECUTOR MODE (operator-driven)
+
+Instead of the agent self-scheduling, you send it work orders directly via `tmux send-keys`. The agent starts, reads its policy, then **waits at the prompt** for instructions. You decide when it fires and what it does.
+
+```sh
+# startup prompt — no /loop
+AGENT_LOOP_PROMPT="You are in EXECUTOR MODE. Read my-policy.md from memory. Report current status. Then WAIT for work orders via tmux. Between orders: monitor open PRs and merge AI-authored ones when CI is green."
+```
+
+Then from any shell:
+
+```sh
+# IMPORTANT: always split text and Enter into two calls.
+# tmux send-keys -l "…text… Enter" sends the word "Enter" as literal text.
+tmux send-keys -t my-agent -l "Fix issue #42 and open a PR."
+sleep 1
+tmux send-keys -t my-agent Enter
+```
+
+**When to use EXECUTOR MODE:**
+- You're running multiple agents and want a single supervisor session to prioritize across all of them
+- You want to inspect the agent's output before triggering the next step
+- The agent keeps re-registering its own cron despite being told not to (EXECUTOR MODE removes the cron entirely)
+
+**Disable the renew timer** when using EXECUTOR MODE — there is no cron to renew:
+
+```sh
+sudo systemctl disable --now supervised-agent-renew@my-agent.timer
+```
+
+See [`docs/architecture.md`](docs/architecture.md) for the full EXECUTOR MODE sequence diagram and multi-agent topology.
 
 ---
 
@@ -159,7 +193,7 @@ sudo -u me tmux attach -t watcher
 sudo -u me tmux attach -t reporter
 ```
 
-When you want two agents to **coordinate** (one notices a problem, the other fixes it), see [`examples/reviewer-policy.md`](examples/reviewer-policy.md) for how to use a shared ledger.
+When you want two agents to **coordinate** (one notices a problem, the other fixes it), see [`examples/reviewer-policy.md`](examples/reviewer-policy.md) for how to use a shared ledger. For tighter control over multiple agents, use **EXECUTOR MODE** — run your own supervisor session that sends targeted work orders to each agent instead of letting them self-schedule independently. See [`docs/architecture.md`](docs/architecture.md) for the full multi-agent topology.
 
 Uninstall one without touching the other: `sudo ./uninstall.sh --instance reporter`.
 

--- a/config/agent.env.example
+++ b/config/agent.env.example
@@ -24,11 +24,17 @@ AGENT_WORKDIR=/home/dev/my-project
 # `set -a; . "$ENV_FILE"` so any unquoted flags get parsed as commands.
 AGENT_LAUNCH_CMD="/usr/bin/claude --dangerously-skip-permissions --model claude-opus-4-7"
 
-# The text sent to the agent after its TUI is ready. For Claude Code this is
-# almost always a /loop command. Keep it short and point the agent at a policy
-# file for detailed instructions so you can edit policy without respawning.
-# IMPORTANT: quote the whole value (same shell-parsing reason as above).
-AGENT_LOOP_PROMPT="/loop 15m Follow every rule in scanner-policy.md from memory. At the START of each iteration, print SCAN_START_ET=\$(TZ=America/New_York date \"+%Y-%m-%d %H:%M:%S %Z\"). At the END, print SCAN_END_ET and NEXT_RUN_ET. All timestamps in America/New_York."
+# The text sent to the agent after its TUI is ready. Two patterns are common:
+#
+# EXECUTOR MODE (recommended for supervisor-driven agents):
+#   The agent does NOT self-schedule. The supervisor sends work orders as needed.
+#   Policy file governs what the agent does when it receives a directive.
+#   IMPORTANT: quote the whole value (same shell-parsing reason as above).
+AGENT_LOOP_PROMPT="You are in EXECUTOR MODE — no self-scheduling, no /loop cron. First CronList and CronDelete any existing cron jobs. Then stay at the prompt and wait for work orders from the supervisor. If no directive arrives within 45 min, run one proactive pass per your policy file (scanner-policy.md), log it to heartbeat.log, then return to idle."
+#
+# CRON MODE (self-paced agent, fires on its own schedule):
+#   Uncomment the line below and comment out EXECUTOR MODE above.
+# AGENT_LOOP_PROMPT="/loop 15m Follow every rule in scanner-policy.md from memory. At the START of each iteration, print SCAN_START_ET=\$(TZ=America/New_York date \"+%Y-%m-%d %H:%M:%S %Z\"). At the END, print SCAN_END_ET and NEXT_RUN_ET. All timestamps in America/New_York."
 
 # Absolute path the agent appends its heartbeat to. Healthcheck watches this
 # file's mtime. The agent MUST write to it on every iteration (put that

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,15 +1,45 @@
 # Architecture
 
+## Two scheduling models
+
+supervised-agent supports two fundamentally different ways to drive an agent. Choose based on how much control you want to keep.
+
+### Model A — Self-scheduling (/loop cron)
+
+The agent registers its own cron job (`/loop 15m …`) and fires on that cadence indefinitely. The supervisor's only job is to keep the session alive and respawn it if it crashes. Low operator involvement; the agent runs autonomously.
+
+**Best for:** Single-agent setups, batch jobs, anything where the cadence is fixed and you trust the agent to stay on task.
+
+### Model B — EXECUTOR MODE (supervisor-driven)
+
+The agent starts, reads its policy, then **waits at the prompt** for the supervisor to send work orders via `tmux send-keys`. No cron, no self-scheduling. The supervisor (another Claude Code session, a script, or a human) decides when to fire and what to do.
+
+**Best for:** Multi-agent setups where you want a single controller to prioritize across several agents, production workflows where you need to inspect output before triggering the next step, or any situation where the agent kept re-starting its own loop despite being told not to.
+
+> **Gotcha — session restore bakes in old crons.** Claude Code restores its previous conversation context on respawn. If the agent ever registered a `/loop` cron before, that cron comes back in the restored context even if the new `AGENT_LOOP_PROMPT` says not to. The fix: after sending the startup prompt, send a second message ~30 seconds later that says "CronList — delete every cron job you find." The [`scanner-supervisor.sh`](../systemd/scanner-supervisor.sh.example) reference implementation does this automatically via a background `send_cron_nuke` call.
+
+> **Gotcha — tmux `-l` makes Enter literal.** When dispatching work orders, always split text and Enter into **two separate** `tmux send-keys` calls:
+> ```sh
+> tmux send-keys -t session -l "do the thing"
+> sleep 1
+> tmux send-keys -t session Enter
+> ```
+> Combining them as `tmux send-keys -t session -l "do the thing" Enter` sends the word "Enter" as part of the literal text, leaving the agent stuck with text in its input box.
+
+---
+
 ## Four components, four failure modes
 
 | # | Unit | Trigger | Catches |
 |---|---|---|---|
-| 1 | `supervised-agent.service` | Always running; internal poll every `AGENT_POLL_SEC` (default 10s) | Agent process crash, tmux session killed, TUI-ready detection for `/loop` prompt injection, auto-approval of a known sensitive-file prompt |
-| 2 | `supervised-agent-renew.timer` | Every 6 days + 5 min after boot | Claude Code `/loop` cron auto-expires at 7 days — kills the session so the supervisor re-registers a fresh one |
+| 1 | `supervised-agent.service` | Always running; internal poll every `AGENT_POLL_SEC` (default 10s) | Agent process crash, tmux session killed, TUI-ready detection for startup prompt injection, auto-approval of a known sensitive-file prompt |
+| 2 | `supervised-agent-renew.timer` | Every 6 days + 5 min after boot | Claude Code `/loop` cron auto-expires at 7 days — kills the session so the supervisor re-registers a fresh one. **Disable this in EXECUTOR MODE** — there is no cron to renew. |
 | 3 | `supervised-agent-healthcheck.timer` | Every 20 min + 5 min after boot | Agent is "alive" but not making progress (auth loop, stuck prompt, model stuck thinking) — watches heartbeat-file mtime |
 | 4 | ntfy push inside the healthcheck | On stall, on recovery, on escalation | Operator not watching the box — phone push |
 
 ## Reactions to each failure mode
+
+### Model A (self-scheduling)
 
 ```mermaid
 sequenceDiagram
@@ -26,7 +56,7 @@ sequenceDiagram
     S->>T: new-session
     T->>A: spawn agent
     S->>T: wait for AGENT_READY_MARKER
-    S->>A: send AGENT_LOOP_PROMPT
+    S->>A: send AGENT_LOOP_PROMPT (/loop 15m …)
     A->>A: register /loop 15m cron
 
     loop every 15m (agent's own cron)
@@ -53,6 +83,73 @@ sequenceDiagram
     H->>N: "manual intervention needed"
     H->>H: stop auto-respawning until recovery
 ```
+
+### Model B (EXECUTOR MODE)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Op as operator / supervisor session
+    participant S as supervisor service
+    participant T as tmux session
+    participant A as agent
+    participant H as healthcheck.timer
+    participant N as ntfy.sh
+
+    Note over S,T: boot-time / crash recovery
+    S->>T: new-session
+    T->>A: spawn agent
+    S->>T: wait for AGENT_READY_MARKER
+    S->>A: send EXECUTOR startup prompt (no /loop)
+    S->>A: (30s later) CronList — delete every cron
+    A->>A: reads policy, reports status, waits
+
+    loop operator-driven
+        Op->>T: tmux send-keys -l "work order text"
+        Op->>T: tmux send-keys Enter
+        A->>A: execute work order
+        A->>Op: (visible in pane) result summary
+    end
+
+    Note over H: every 20m
+    H->>H: stat heartbeat mtime (agent writes on each work order)
+    alt mtime stale
+        H->>T: kill-session
+        S->>T: new-session (EXECUTOR startup, cron nuke)
+        H->>N: "stalled, respawning"
+    end
+```
+
+---
+
+## Multi-agent topology
+
+When running several agents on the same machine, the EXECUTOR pattern lets a single supervisor session coordinate all of them without the agents conflicting:
+
+```
+┌─────────────────────────────────────┐
+│   supervisor session (Mac)          │
+│   /loop — sweeps every 20-25 min    │
+│   sends tmux work orders to agents  │
+└──────┬──────────┬──────────┬────────┘
+       │          │          │
+       ▼          ▼          ▼
+  scanner      reviewer   outreach
+  (Opus 4.7)  (Sonnet)   (Sonnet)
+  claude-dev   claude-dev  claude-dev
+  tmux         tmux        tmux
+```
+
+Each agent:
+- Has its own tmux session and systemd service
+- Reads its own policy file from the shared memory directory
+- Writes to a shared work ledger (`bd` / beads) using `--actor <name>` to claim work
+- Skips items already claimed by another actor (`bd list --actor=<other> --status=in_progress`)
+- Notifies the operator via ntfy for decisions that require human judgment
+
+Renew timers are **disabled** for all agents in EXECUTOR MODE. The supervisor sends a fresh startup + cron-nuke on every respawn automatically.
+
+---
 
 ## What this deliberately does NOT handle
 


### PR DESCRIPTION
## Summary

- **Architecture doc**: adds EXECUTOR MODE as a first-class alternative to self-scheduling `/loop`. Includes sequence diagram, multi-agent topology diagram (scanner/reviewer/outreach), and two field-learned gotchas:
  - Session-restore cron bleed (Claude Code restores previous crons on respawn; fix: send a cron-nuke 30s after startup prompt)
  - `tmux send-keys -l` makes "Enter" literal — always split text and Enter into two separate calls
- **README**: "Telling the agent what to do" now has Option A (self-scheduling) and Option B (EXECUTOR MODE) with usage examples, when-to-use guidance, and a note to disable the renew timer

These patterns emerged from running scanner/reviewer/outreach agents in production on a multi-agent kubestellar/console workflow.

## Test plan
- [ ] Read architecture.md — sequence diagrams render correctly in GitHub markdown
- [ ] Read README.md — Option A/B section is clear to a first-time user
- [ ] Verify links to `docs/architecture.md` and `examples/reviewer-policy.md` resolve