### PR TITLE
✨ Add macOS/launchd support, hybrid scanner pattern, and KubeStellar case study

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ If you can describe the job to an AI chatbot, you can run it here on a loop.
 
 ## What you need
 
-- A Linux computer that stays on (laptop at home, cheap cloud VM, Raspberry Pi 4, etc.)
+- A computer that stays on — **Linux** (laptop, cheap cloud VM, Raspberry Pi 4) or **macOS** (Mac Mini, Mac Studio, always-on laptop)
 - An AI assistant CLI that has an **interactive** mode (this repo was built with [Claude Code](https://www.anthropic.com/claude-code), but it works with anything similar — Codex CLI, local LLMs with a TUI, etc.)
 - About 10 minutes
 
-That's it. You don't need Kubernetes. You don't need Docker. You don't need to know what systemd is (but by the end of this, you'll have used it).
+That's it. You don't need Kubernetes. You don't need Docker. On Linux you'll use systemd; on macOS you'll use launchd — both are built-in process managers that keep things running.
 
 ---
 
@@ -43,7 +43,9 @@ which tmux curl bash      # should print paths, not "not found"
 which claude              # (or whatever AI CLI you're using)
 ```
 
-If `tmux` or `curl` are missing: `sudo apt install tmux curl` (Ubuntu/Debian) or `sudo dnf install tmux curl` (Fedora/RHEL). If `claude` is missing, install it from [claude.ai/code](https://claude.ai/code) first and log in with `claude /login`.
+If `tmux` or `curl` are missing: `sudo apt install tmux curl` (Ubuntu/Debian) or `sudo dnf install tmux curl` (Fedora/RHEL) or `brew install tmux curl` (macOS). If `claude` is missing, install it from [claude.ai/code](https://claude.ai/code) first and log in with `claude /login`.
+
+> **macOS users**: the quickstart below uses Linux/systemd commands. For macOS/launchd setup, see **[docs/macos.md](docs/macos.md)** — same concepts, different process manager.
 
 ### 3. Write your config
 
@@ -194,6 +196,12 @@ sudo -u me tmux attach -t reporter
 ```
 
 When you want two agents to **coordinate** (one notices a problem, the other fixes it), see [`examples/reviewer-policy.md`](examples/reviewer-policy.md) for how to use a shared ledger. For tighter control over multiple agents, use **EXECUTOR MODE** — run your own supervisor session that sends targeted work orders to each agent instead of letting them self-schedule independently. See [`docs/architecture.md`](docs/architecture.md) for the full multi-agent topology.
+
+### Hybrid pattern: scanner script + AI agent
+
+Instead of running two full AI sessions, you can run a lightweight **bash scanner** on a timer that writes to a SQLite database, and only invoke the AI when there's actionable work. This is cheaper (no LLM usage for scanning), more resilient (scanning continues even if the AI session is down), and gives you a durable audit trail.
+
+See [`examples/kubestellar-fixer.md`](examples/kubestellar-fixer.md) for a full case study, [`examples/worker.sh.example`](examples/worker.sh.example) for the scanner script, and [`examples/sqlite-state.md`](examples/sqlite-state.md) for the SQLite schema.
 
 Uninstall one without touching the other: `sudo ./uninstall.sh --instance reporter`.
 
@@ -386,5 +394,7 @@ Apache 2.0 — see [LICENSE](LICENSE). PRs welcome, especially:
 - Recipes for specific agents (Codex CLI, local LLMs, etc.)
 - Additional `AGENT_*` hooks for new kinds of prompts you want auto-handled
 - Packaging (Homebrew, Nix, Debian `.deb`, Docker image) for easier install
+- macOS/launchd improvements (see [docs/macos.md](docs/macos.md))
+- Case studies of real deployments (see [examples/kubestellar-fixer.md](examples/kubestellar-fixer.md) for the format)
 
 See [OWNERS](OWNERS) for maintainers.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,3 +157,74 @@ Renew timers are **disabled** for all agents in EXECUTOR MODE. The supervisor se
 - **ntfy.sh downtime.** Free tier, rare, tolerable. Self-host or swap the transport if you need SLAs.
 - **Agent logic bugs.** If the agent decides to do nothing forever but remembers to write the heartbeat, the healthcheck won't catch it. The log format in your policy file should include non-trivial counts (repos scanned, actions taken) so you can spot a "no-op loop" visually.
 - **Secrets management.** Don't put credentials in `agent.env`. The agent should source them from its own credential store (`~/.claude/.credentials.json` for Claude Code, vault / secrets manager for anything else).
+
+---
+
+## Reference deployment: hybrid local scanner + GitHub responders
+
+Models A and B both put the AI agent on a periodic loop. A third pattern — used in production on [KubeStellar](https://kubestellar.io) — **decouples scanning from fixing**:
+
+- A lightweight **bash scanner** runs on a fixed timer (launchd or systemd), polling GitHub for open issues/PRs and writing state to a **SQLite database**. No LLM needed.
+- The **AI agent** reads the database when triggered (by skill invocation, `/loop` cron, or EXECUTOR work order) and fixes what's actionable.
+- **GitHub Actions workflows** on the repo auto-file issues when workflows fail, creating a feedback loop where the scanner picks up the new issue on its next cycle.
+
+This is not a new scheduling model — it's a **composition** of the existing patterns with a deterministic scanner in front and GitHub as an event source.
+
+### Why this pattern exists
+
+| Problem | How the hybrid solves it |
+|---|---|
+| AI session restarts / rate limits cause missed scans | Scanner runs independently — state is never lost |
+| Scanning is deterministic but consumes LLM tokens | Scanner is pure bash — zero LLM cost |
+| No audit trail of what was scanned | `cycles` table in SQLite records every scan |
+| Workflow failures go unnoticed for days | `workflow-failure-issue.yml` auto-files issues within minutes |
+| Fix attempts need backoff | `fix_attempts` counter prevents infinite retries |
+
+### Architecture
+
+```
+                        ┌──────────────────────┐
+                        │  GitHub (source of    │
+                        │  truth for issues/PRs)│
+                        └──────────┬───────────┘
+                                   │
+                    gh issue list / gh pr list
+                                   │
+┌──────────────────────────────────┼──────────────────────────────┐
+│  Local machine (Mac / Linux)     │                              │
+│                                  ▼                              │
+│  ┌─────────┐    ┌──────────┐    ┌──────────┐    ┌───────────┐  │
+│  │ launchd │───▶│worker.sh │───▶│ state.db │◀───│ AI agent  │  │
+│  │ / cron  │    │(scanner) │    │ (SQLite) │    │(reads DB, │  │
+│  └─────────┘    └────┬─────┘    └──────────┘    │ fixes)    │  │
+│                      │                           └─────┬─────┘  │
+│                  ntfy push                        git push      │
+│                      │                           gh pr create   │
+│                      ▼                                 │        │
+│                 ┌──────────┐                           │        │
+│                 │  phone   │                           │        │
+│                 └──────────┘                           │        │
+└────────────────────────────────────────────────────────┼────────┘
+                                                        │
+                                   mutates GitHub state (PRs, merges)
+                                                        │
+                                                        ▼
+                        ┌──────────────────────────────────────┐
+                        │  GitHub Actions (automated responders)│
+                        │                                      │
+                        │  workflow-failure-issue.yml           │
+                        │  → auto-files issue on failure       │
+                        │                                      │
+                        │  ai-fix.yml                          │
+                        │  → auto-dispatches fix on label      │
+                        └──────────────────────────────────────┘
+```
+
+**Data flow boundary**: GitHub Actions write to GitHub (issues, labels). The local scanner reads from GitHub and writes to SQLite. The AI agent reads SQLite and writes to GitHub. No component writes directly to another's state store.
+
+### Reference implementation
+
+- [`examples/worker.sh.example`](../examples/worker.sh.example) — the scanner script
+- [`examples/sqlite-state.md`](../examples/sqlite-state.md) — SQLite schema and query patterns
+- [`examples/kubestellar-fixer.md`](../examples/kubestellar-fixer.md) — full case study with results
+- [`launchd/`](../launchd/) — macOS plist templates for the scanner and supervisor

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,0 +1,178 @@
+# macOS Support (launchd)
+
+The supervised-agent runtime was built on Linux/systemd, but the same concepts map cleanly to macOS using **launchd** — Apple's equivalent of systemd.
+
+This guide shows how to run a supervised agent on a Mac that stays on (Mac Mini, Mac Studio, always-on laptop, etc.).
+
+---
+
+## Concept mapping
+
+| Linux (systemd) | macOS (launchd) | Role |
+|---|---|---|
+| `supervised-agent.service` | `LaunchAgent` plist | Keeps the supervisor alive, restarts on crash |
+| `supervised-agent-healthcheck.timer` | Second `LaunchAgent` plist with `StartCalendarInterval` | Periodic healthcheck |
+| `supervised-agent-renew.timer` | Third plist with 6-day interval | `/loop` cron renewal |
+| `systemctl enable --now` | `launchctl load -w` | Start + enable at login |
+| `systemctl stop` | `launchctl unload` | Stop |
+| `journalctl -u supervised-agent` | `StandardOutPath` / `StandardErrorPath` in plist | Logs |
+| `/etc/supervised-agent/agent.env` | Plist `EnvironmentVariables` dict or a sourced env file | Config |
+
+---
+
+## Quickstart
+
+### 1. Install prerequisites
+
+```sh
+brew install tmux curl jq
+# Install your AI CLI (e.g., Claude Code)
+npm install -g @anthropic-ai/claude-code
+claude /login
+```
+
+### 2. Create the config directory
+
+```sh
+mkdir -p ~/.config/supervised-agent
+cp config/agent.env.example ~/.config/supervised-agent/agent.env
+# Edit to match your setup:
+nano ~/.config/supervised-agent/agent.env
+```
+
+### 3. Install the LaunchAgent
+
+Copy the example plist, adjust paths, and load it:
+
+```sh
+# Copy the template
+cp launchd/com.supervised-agent.plist.example ~/Library/LaunchAgents/com.supervised-agent.plist
+
+# Edit: change all /Users/YOURUSER paths to your actual home directory
+nano ~/Library/LaunchAgents/com.supervised-agent.plist
+
+# Create log directory
+mkdir -p ~/.local/state/supervised-agent
+
+# Load (starts immediately + starts on every login)
+launchctl load -w ~/Library/LaunchAgents/com.supervised-agent.plist
+```
+
+### 4. Verify it's running
+
+```sh
+# Check launchd status
+launchctl list | grep supervised-agent
+
+# Attach to the tmux session
+tmux attach -t supervised-agent
+# Detach: Ctrl+B then D
+```
+
+### 5. Uninstall
+
+```sh
+launchctl unload ~/Library/LaunchAgents/com.supervised-agent.plist
+rm ~/Library/LaunchAgents/com.supervised-agent.plist
+# Optionally remove config + state:
+# rm -rf ~/.config/supervised-agent ~/.local/state/supervised-agent
+```
+
+---
+
+## Healthcheck on macOS
+
+On Linux, the healthcheck is a separate systemd timer. On macOS, use a second LaunchAgent with `StartCalendarInterval`:
+
+```xml
+<!-- ~/Library/LaunchAgents/com.supervised-agent.healthcheck.plist -->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.supervised-agent.healthcheck</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/path/to/supervised-agent/bin/agent-healthcheck.sh</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <array>
+        <!-- Every 20 minutes: :00, :20, :40 -->
+        <dict><key>Minute</key><integer>0</integer></dict>
+        <dict><key>Minute</key><integer>20</integer></dict>
+        <dict><key>Minute</key><integer>40</integer></dict>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>AGENT_LOG_FILE</key>
+        <string>/Users/YOURUSER/.local/state/supervised-agent/heartbeat.log</string>
+        <key>AGENT_SESSION_NAME</key>
+        <string>supervised-agent</string>
+        <key>AGENT_STALE_MAX_SEC</key>
+        <string>1800</string>
+        <key>AGENT_MAX_RESPAWNS</key>
+        <string>3</string>
+        <key>NTFY_TOPIC</key>
+        <string>your-secret-topic</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/Users/YOURUSER/.local/state/supervised-agent/healthcheck.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/YOURUSER/.local/state/supervised-agent/healthcheck.err</string>
+</dict>
+</plist>
+```
+
+---
+
+## Renew timer on macOS
+
+The renew timer kills and respawns the tmux session every 6 days to beat Claude Code's 7-day `/loop` expiry. On macOS, this is harder to express as a calendar interval (launchd doesn't have "every N days" natively).
+
+**Recommended approach**: use a wrapper script that checks the session age:
+
+```bash
+#!/bin/bash
+# renew-if-stale.sh — run hourly via launchd, only acts every 6 days
+SESSION="${AGENT_SESSION_NAME:-supervised-agent}"
+STATE_DIR="${HOME}/.local/state/supervised-agent"
+STAMP="$STATE_DIR/last-renew"
+
+# If stamp doesn't exist, create it and exit
+[ -f "$STAMP" ] || { date +%s > "$STAMP"; exit 0; }
+
+AGE=$(( $(date +%s) - $(cat "$STAMP") ))
+if [ "$AGE" -ge 518400 ]; then  # 6 days in seconds
+    tmux kill-session -t "$SESSION" 2>/dev/null
+    date +%s > "$STAMP"
+    # Supervisor will detect the missing session and respawn
+fi
+```
+
+Then set a launchd plist with `StartInterval` of 3600 (hourly check).
+
+---
+
+## Differences from Linux
+
+| Area | Linux | macOS |
+|---|---|---|
+| Shell | `/bin/bash` everywhere | `/bin/zsh` default; use `/opt/homebrew/bin/bash` for bash 5+ features (associative arrays) |
+| `stat` flags | `stat -c %Y file` | `stat -f %m file` |
+| Process management | `systemctl start/stop/restart` | `launchctl load/unload` |
+| Auto-start | `systemctl enable` | `load -w` flag persists across reboots |
+| Log viewing | `journalctl -u name -f` | `tail -f /path/to/log` (or Console.app) |
+| File locking | `flock` (coreutils) | `flock` via `brew install util-linux` or use lockfile pattern |
+| `date` command | GNU date (`date -d`) | BSD date (no `-d`; use `date -j -f`) |
+
+---
+
+## Alternative scheduler: standalone scanner script
+
+On macOS, some deployments skip the full supervisor+tmux pattern entirely and use a **standalone scanner script** fired by launchd on a fixed schedule. The script does the scanning/state-tracking work in bash, then triggers the AI agent (via a Copilot CLI skill, tmux work order, or similar) only when there's actionable work.
+
+This pattern is simpler when:
+- The scanning logic is deterministic (no LLM needed for triage)
+- You want the scanner to run even when the AI session is down
+- You want to decouple scan cadence from agent availability
+
+See [`examples/worker.sh.example`](../examples/worker.sh.example) for a reference implementation and [`examples/kubestellar-fixer.md`](../examples/kubestellar-fixer.md) for a full case study of this pattern in production.

--- a/examples/kubestellar-fixer.md
+++ b/examples/kubestellar-fixer.md
@@ -1,0 +1,177 @@
+# Case study: KubeStellar autonomous fixer
+
+This documents a production deployment of the supervised-agent pattern on the [KubeStellar](https://kubestellar.io) project — a CNCF Sandbox multi-cluster management platform. The system autonomously triages, fixes, and merges across 6 GitHub repositories with a target SLA of <30 minutes from issue filed to PR merged.
+
+> **This is a case study, not a tutorial.** It shows how the generic patterns from this repo were composed into a specific deployment. Your setup will differ — use this for inspiration, not as a recipe to copy verbatim.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Mac Mini (always-on)                     │
+│                                                                 │
+│   ┌──────────────┐     ┌──────────────┐     ┌───────────────┐  │
+│   │   launchd     │────▶│  worker.sh   │────▶│  state.db     │  │
+│   │  (every 15m)  │     │  (scanner)   │     │  (SQLite)     │  │
+│   └──────────────┘     └──────┬───────┘     └───────┬───────┘  │
+│                               │                     │           │
+│                          ntfy push              trigger file    │
+│                               │                     │           │
+│                               ▼                     ▼           │
+│                        ┌────────────┐     ┌─────────────────┐  │
+│                        │  phone     │     │  Copilot CLI     │  │
+│                        │  (ntfy)    │     │  skills          │  │
+│                        └────────────┘     │  (fix-loop.md)   │  │
+│                                           │  (auto-qa.md)    │  │
+│                                           │  (hygiene.md)    │  │
+│                                           └────────┬────────┘  │
+│                                                    │            │
+└────────────────────────────────────────────────────┼────────────┘
+                                                     │
+                                              git push, gh pr
+                                                     │
+                                                     ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                           GitHub                                │
+│                                                                 │
+│   ┌───────────────────────────────────────────────────────┐     │
+│   │  workflow-failure-issue.yml                            │     │
+│   │  (auto-files issues when any workflow fails)           │     │
+│   └──────────────────────────┬────────────────────────────┘     │
+│                              │                                   │
+│                              ▼                                   │
+│   ┌───────────────────────────────────────────────────────┐     │
+│   │  ai-fix.yml                                           │     │
+│   │  (auto-dispatches fixes when copilot label is added)   │     │
+│   └──────────────────────────┬────────────────────────────┘     │
+│                              │                                   │
+│                              ▼                                   │
+│   scanner picks up the new issue/PR on next cycle               │
+│   → state.db updated → fix-loop skill triggered                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Important boundary
+
+GitHub Actions mutate **GitHub state** (issues, PRs, labels). The local scanner **polls GitHub** and reflects changes into SQLite. There is no direct connection between GitHub Actions and the local SQLite database. The scanner is the single writer to the DB; GitHub is the source of truth for issue/PR state.
+
+---
+
+## The five components
+
+### 1. launchd agent (scheduler)
+
+A macOS LaunchAgent plist fires `worker.sh` every 15 minutes. See [`launchd/com.supervised-agent.scanner.plist.example`](../launchd/com.supervised-agent.scanner.plist.example) for the template.
+
+Why launchd instead of systemd: the deployment target is a Mac Mini. The pattern is identical — only the process manager differs.
+
+### 2. worker.sh (scanner)
+
+A ~150-line bash script. See [`worker.sh.example`](worker.sh.example) for a sanitized version.
+
+Each invocation:
+1. Acquires a file lock (prevents overlapping cycles)
+2. Initializes SQLite tables if missing
+3. Starts a new cycle record
+4. Scans each repo via `gh issue list` and `gh pr list`
+5. Upserts every open item into the `items` table
+6. Detects closures (items in DB as "open" but not seen in scan)
+7. Sends an ntfy push with the cycle summary
+8. Writes a trigger file for the AI agent
+
+No AI, no LLM, no API keys beyond GitHub CLI auth. Runs in <30 seconds even across 6 repos.
+
+### 3. state.db (SQLite)
+
+Three tables — see [`sqlite-state.md`](sqlite-state.md) for the full schema:
+- `items`: every tracked issue/PR with status flow (open → triaged → fixing → fixed/closed/skip)
+- `cycles`: audit trail of every scan cycle
+- `repo_counts`: per-repo counts per cycle (trend data)
+
+### 4. Copilot CLI skills (fix engine)
+
+Three skills in `.claude/commands/`:
+
+| Skill | Purpose |
+|---|---|
+| `fix-loop.md` | Reads `state.db`, triages open items, fixes everything actionable. The main fix engine. |
+| `auto-qa.md` | Discovers and fixes all open auto-qa issues and stalled Copilot PRs. Specialized for CI/quality. |
+| `hygiene.md` | Full operational sweep: nightly builds, CI status, PR review, issue review, branch cleanup, deployment health, Helm/brew currency. |
+
+Each skill is a markdown file with structured instructions. The AI agent reads the skill, executes it, and updates the SQLite DB with results. Skills are the "policy files" of this deployment — they just live in `.claude/commands/` instead of the agent's memory directory.
+
+### 5. GitHub Actions workflows (automated responders)
+
+Three workflows that create a feedback loop:
+
+| Workflow | Trigger | Action |
+|---|---|---|
+| `workflow-failure-issue.yml` | Any workflow fails on main | Files an issue with failure details, error summary, and `workflow-failure` label |
+| `ai-fix.yml` | Issue gets `copilot` label | Dispatches Copilot to attempt an automated fix |
+| `auto-qa.yml` | Manual or scheduled | Runs the auto-qa skill in CI |
+
+The feedback loop:
+1. A workflow fails → `workflow-failure-issue.yml` files an issue
+2. The scanner picks up the issue on its next 15-minute cycle
+3. The fix-loop skill reads it from the DB and attempts a fix
+4. If the fix succeeds, the scanner detects the issue closed and sends ntfy
+5. If the workflow self-recovers, the scanner detects the issue closed on GitHub
+
+---
+
+## Results (first 30 days)
+
+- **36+ issues** closed autonomously
+- **20+ PRs** merged
+- **Median fix time**: ~20 minutes (from issue filed to PR merged)
+- **Categories fixed**: test failures, CI config, accessibility gaps, z-index bugs, broken deep-links, stale formulas, doc inaccuracies, nightly workflow failures
+- **Zero production incidents** caused by automated fixes
+- **6 repos** under continuous management
+
+---
+
+## Lessons learned
+
+### SQLite > beads for this use case
+
+The beads ledger is designed for multi-agent, multi-host coordination with structured actor ownership. This deployment runs on a single machine. SQLite gave us:
+- Full SQL for ad-hoc queries and trend analysis
+- Zero setup (ships with macOS)
+- Trivial schema evolution (just `ALTER TABLE`)
+- Sub-millisecond reads even with thousands of rows
+
+We'd use beads if agents spanned multiple machines.
+
+### Skills > policy files for Claude Code
+
+Claude Code's `.claude/commands/` directory is purpose-built for structured instructions. Compared to raw policy files in memory:
+- Skills auto-complete with `/` in the CLI
+- Skills are version-controlled alongside the project
+- Skills can be invoked programmatically (by launchd, by other skills, by the operator)
+- No "step 0 re-read" needed — the skill is read fresh every invocation
+
+### GitHub Actions as force multiplier
+
+The most impactful addition was `workflow-failure-issue.yml`. Before this, workflow failures sat unnoticed for days. After: every failure becomes an issue within minutes, the scanner picks it up, the fix-loop fixes it. The human sees a phone notification that says "✅ fixed" and never has to look at the CI dashboard.
+
+### Backoff prevents thrashing
+
+The `fix_attempts` counter in the `items` table is critical. Without it, the fix-loop would retry the same unfixable issue every 15 minutes forever. With it: 3 failed attempts → status='skip', operator gets ntfy, issue stays tracked but stops consuming agent time.
+
+### Separation of scanning and fixing pays off
+
+The scanner runs even when the AI session is down (restarting, usage-limited, rate-limited). State is never lost. When the AI comes back, it reads the DB and knows exactly what happened while it was gone. This resilience was important during Claude Code session restarts, model rate limits, and network issues.
+
+---
+
+## Adapting this for your project
+
+1. **Fork `worker.sh.example`** and change `ORG`, `REPOS`, `NTFY_TOPIC`
+2. **Write a fix-loop skill** (or policy file) that reads your `state.db`
+3. **Add `workflow-failure-issue.yml`** to your GitHub repo (optional but high-leverage)
+4. **Install the scanner plist** — see [`launchd/com.supervised-agent.scanner.plist.example`](../launchd/com.supervised-agent.scanner.plist.example)
+5. Start with a 15-minute scan interval and adjust based on your project's velocity
+
+The scanner and fix-loop are intentionally decoupled. You can run the scanner on Day 1 (just watching, no fixing) and add the fix-loop later when you're confident in the triage rules.

--- a/examples/sqlite-state.md
+++ b/examples/sqlite-state.md
@@ -1,0 +1,148 @@
+# Alternative state backend: SQLite
+
+The main examples use [beads](https://github.com/steveyegge/beads) (`bd` CLI) as a git-backed coordination ledger. This works well for multi-host, multi-agent setups where you need structured work claims and actor-level ownership.
+
+For **single-machine deployments** — one Mac or one VM running all your agents — SQLite is a simpler, faster alternative that requires no extra tooling.
+
+---
+
+## When to use SQLite vs beads
+
+| Dimension | SQLite | beads |
+|---|---|---|
+| Setup | Zero — ships with macOS/most Linux | `curl` + `tar` + `bd init` |
+| Multi-host sync | Manual (rsync, Syncthing) | Git-backed (built-in) |
+| Multi-agent claims | `UPDATE … WHERE status='open' LIMIT 1` (advisory, not atomic across processes) | `bd update --claim` (atomic) |
+| Query power | Full SQL — joins, aggregates, window functions | `bd list --json \| jq` |
+| Schema | You define it — full control | Fixed bead schema + metadata KV |
+| Tooling dependency | `sqlite3` (preinstalled) | `bd` binary |
+| Best for | Single-machine, custom schema, high scan volume | Multi-machine, structured actor ownership |
+
+**Rule of thumb**: if all your agents run on the same machine and you want full SQL, use SQLite. If agents span machines or you want the actor/claim/sync semantics built-in, use beads.
+
+---
+
+## Reference schema
+
+```sql
+CREATE TABLE IF NOT EXISTS items (
+  repo TEXT NOT NULL,
+  type TEXT NOT NULL,           -- 'issue' or 'pr'
+  number INTEGER NOT NULL,
+  title TEXT,
+  author TEXT,
+  created_at TEXT,
+  status TEXT DEFAULT 'open',   -- open, triaged, fixing, fixed, closed, skip
+  last_seen TEXT,
+  fix_attempts INTEGER DEFAULT 0,
+  fix_pr TEXT,                  -- 'repo#number' of the fix PR
+  notes TEXT,
+  PRIMARY KEY (repo, type, number)
+);
+
+CREATE TABLE IF NOT EXISTS cycles (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  started_at TEXT NOT NULL,
+  completed_at TEXT,
+  total_issues INTEGER,
+  total_prs INTEGER,
+  items_fixed INTEGER DEFAULT 0,
+  items_closed INTEGER DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS repo_counts (
+  repo TEXT NOT NULL,
+  cycle_id INTEGER NOT NULL,
+  issues INTEGER,
+  prs INTEGER,
+  PRIMARY KEY (repo, cycle_id)
+);
+```
+
+### Status flow
+
+```
+open → triaged → fixing → fixed
+                        ↘ closed
+open → skip (with notes explaining why)
+open → closed (detected as no longer open on GitHub)
+```
+
+### Key queries
+
+```bash
+# Items ready for the AI agent to work on
+sqlite3 state.db "SELECT repo, type, number, title FROM items WHERE status IN ('open','triaged') ORDER BY created_at ASC;"
+
+# Cycle history (last 10)
+sqlite3 state.db "SELECT id, started_at, total_issues, total_prs, items_fixed, items_closed FROM cycles ORDER BY id DESC LIMIT 10;"
+
+# Per-repo current counts
+sqlite3 state.db "SELECT repo, SUM(CASE WHEN status='open' THEN 1 ELSE 0 END) as open, SUM(CASE WHEN status='fixed' THEN 1 ELSE 0 END) as fixed FROM items GROUP BY repo;"
+
+# Items that failed 3+ fix attempts (backoff candidates)
+sqlite3 state.db "SELECT repo, type, number, title, fix_attempts, notes FROM items WHERE fix_attempts >= 3;"
+```
+
+---
+
+## Scanner writes, agent reads
+
+The recommended pattern is a **separation of concerns**:
+
+1. **Scanner** (bash script on a timer) — scans repos, upserts findings into SQLite, detects closures, sends ntfy summaries. No AI needed. See [`worker.sh.example`](worker.sh.example).
+
+2. **Agent** (AI in tmux or triggered by skill) — reads the SQLite DB, triages items, makes fixes, updates status. Uses full reasoning.
+
+This separation means:
+- Scanning continues even when the AI session is down or restarting
+- State is never lost — it's in a durable file, not the AI's context window
+- The agent can start any time and immediately know what needs work
+- You get a complete audit trail (`cycles` table) of every scan
+
+---
+
+## Connecting to Copilot CLI skills
+
+If your AI agent is Claude Code, you can use [Copilot CLI skills](https://docs.github.com/en/copilot/customizing-copilot/adding-custom-instructions-for-github-copilot) (`.claude/commands/*.md`) as the policy delivery mechanism instead of raw markdown files in memory.
+
+The skill file reads the SQLite DB and executes the fix loop:
+
+```markdown
+# Fix Loop Skill (.claude/commands/fix-loop.md)
+
+Read the state database and fix everything actionable.
+
+## State
+
+SQLite database: `~/.my-project-fix-loop/state.db`
+
+## Steps
+
+1. Read all items with status IN ('open', 'triaged')
+2. For each: triage → fix → commit → PR → merge → update status
+3. Send ntfy notification for each action
+
+## Rules
+- Always use feature branches
+- DCO-sign all commits
+- Track every action in SQLite
+```
+
+The operator (or launchd) triggers the skill after a scan cycle completes, or the agent picks it up on its next `/loop` iteration.
+
+---
+
+## Coordination with beads (hybrid)
+
+You can use both — SQLite for high-volume scan state, beads for cross-agent work coordination:
+
+```
+scanner.sh → SQLite (raw scan data, cycle history, repo counts)
+                ↓
+agent reads SQLite, triages, files beads for cross-agent work
+                ↓
+beads ledger (work claims, lane transfers, peer supervision)
+```
+
+This makes sense when your scanner produces hundreds of data points per cycle but only a few turn into actionable cross-agent work items.

--- a/examples/worker.sh.example
+++ b/examples/worker.sh.example
@@ -1,0 +1,183 @@
+#!/bin/bash
+# Example: standalone scanner script for the hybrid deployment pattern.
+#
+# Runs on a fixed schedule via launchd (macOS) or systemd timer (Linux).
+# Scans GitHub repos, upserts findings into SQLite, sends ntfy summaries.
+# The AI agent reads the DB and does actual fixes — this script does NOT
+# need an LLM; it's pure bash + gh CLI + sqlite3.
+#
+# Adapt: change REPOS, NTFY_TOPIC, ORG, and the triage/skip logic to
+# match your project.
+#
+# See also:
+#   examples/sqlite-state.md     — schema reference and query patterns
+#   examples/kubestellar-fixer.md — full case study using this pattern
+#   launchd/com.supervised-agent.scanner.plist.example — macOS scheduler
+
+set -euo pipefail
+
+# ── Configuration ────────────────────────────────────────────────────────────
+DIR="$HOME/.my-project-fix-loop"
+DB="$DIR/state.db"
+LOCKFILE="$DIR/cycle.lock"
+LOGFILE="$DIR/worker.log"
+NTFY_TOPIC="your-ntfy-topic"          # change this
+ORG="your-org"                         # change this
+REPOS="repo-a repo-b repo-c"          # change this
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >> "$LOGFILE"; }
+
+ntfy() {
+  local title="$1" body="$2" prio="${3:-default}" tags="${4:-robot}"
+  curl -sf -o /dev/null -m 10 \
+    -H "Title: $title" -H "Priority: $prio" -H "Tags: $tags" \
+    -d "$body" "https://ntfy.sh/$NTFY_TOPIC" 2>/dev/null || log "WARN: ntfy send failed"
+}
+
+# ── Lock (prevent overlapping cycles) ────────────────────────────────────────
+if [ -f "$LOCKFILE" ]; then
+  # macOS stat: -f %m gives mtime as epoch seconds
+  LOCK_AGE=$(( $(date +%s) - $(stat -f %m "$LOCKFILE" 2>/dev/null || echo 0) ))
+  if [ "$LOCK_AGE" -lt 600 ]; then
+    log "Cycle locked (age ${LOCK_AGE}s < 600s). Skipping."
+    exit 0
+  fi
+  log "Stale lock (age ${LOCK_AGE}s). Removing."
+  rm -f "$LOCKFILE"
+fi
+echo $$ > "$LOCKFILE"
+trap 'rm -f "$LOCKFILE"' EXIT
+
+# ── Init SQLite (idempotent) ─────────────────────────────────────────────────
+mkdir -p "$DIR"
+
+init_db() {
+  sqlite3 "$DB" <<'SQL'
+CREATE TABLE IF NOT EXISTS items (
+  repo TEXT NOT NULL,
+  type TEXT NOT NULL,
+  number INTEGER NOT NULL,
+  title TEXT,
+  author TEXT,
+  created_at TEXT,
+  status TEXT DEFAULT 'open',
+  last_seen TEXT,
+  fix_attempts INTEGER DEFAULT 0,
+  fix_pr TEXT,
+  notes TEXT,
+  PRIMARY KEY (repo, type, number)
+);
+CREATE TABLE IF NOT EXISTS cycles (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  started_at TEXT NOT NULL,
+  completed_at TEXT,
+  total_issues INTEGER,
+  total_prs INTEGER,
+  items_fixed INTEGER DEFAULT 0,
+  items_closed INTEGER DEFAULT 0
+);
+CREATE TABLE IF NOT EXISTS repo_counts (
+  repo TEXT NOT NULL,
+  cycle_id INTEGER NOT NULL,
+  issues INTEGER,
+  prs INTEGER,
+  PRIMARY KEY (repo, cycle_id)
+);
+SQL
+}
+
+init_db
+
+# ── Start cycle ──────────────────────────────────────────────────────────────
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+CYCLE_ID=$(sqlite3 "$DB" "INSERT INTO cycles (started_at) VALUES ('$NOW'); SELECT last_insert_rowid();")
+log "=== Cycle $CYCLE_ID started ==="
+
+# ── Scan repos ───────────────────────────────────────────────────────────────
+TOTAL_I=0
+TOTAL_P=0
+SUMMARY=""
+
+for repo in $REPOS; do
+  # Fetch open issues via gh CLI
+  ISSUES=$(gh issue list --repo "$ORG/$repo" --state open --limit 200 \
+    --json number,title,author,createdAt 2>/dev/null || echo "[]")
+  IC=$(echo "$ISSUES" | jq 'length' 2>/dev/null || echo 0)
+
+  # Fetch open PRs
+  PRS=$(gh pr list --repo "$ORG/$repo" --state open --limit 100 \
+    --json number,title,author,createdAt 2>/dev/null || echo "[]")
+  PC=$(echo "$PRS" | jq 'length' 2>/dev/null || echo 0)
+
+  TOTAL_I=$((TOTAL_I + IC))
+  TOTAL_P=$((TOTAL_P + PC))
+  SUMMARY+="$repo: ${IC}i/${PC}pr  "
+
+  # Save per-repo counts for this cycle
+  sqlite3 "$DB" "INSERT OR REPLACE INTO repo_counts (repo, cycle_id, issues, prs) \
+    VALUES ('$repo', $CYCLE_ID, $IC, $PC);"
+
+  # Upsert issues — detect new items
+  echo "$ISSUES" | jq -c '.[]' 2>/dev/null | while IFS= read -r item; do
+    NUM=$(echo "$item" | jq -r '.number')
+    TITLE=$(echo "$item" | jq -r '.title' | sed "s/'/''/g")
+    AUTHOR=$(echo "$item" | jq -r '.author.login // .author')
+    CREATED=$(echo "$item" | jq -r '.createdAt')
+
+    EXISTS=$(sqlite3 "$DB" "SELECT status FROM items WHERE repo='$repo' AND type='issue' AND number=$NUM;" 2>/dev/null)
+    if [ -z "$EXISTS" ]; then
+      sqlite3 "$DB" "INSERT INTO items (repo, type, number, title, author, created_at, last_seen) \
+        VALUES ('$repo','issue',$NUM,'$TITLE','$AUTHOR','$CREATED','$NOW');"
+      log "NEW issue: $repo#$NUM — $TITLE"
+    else
+      sqlite3 "$DB" "UPDATE items SET last_seen='$NOW', title='$TITLE' \
+        WHERE repo='$repo' AND type='issue' AND number=$NUM;"
+    fi
+  done
+
+  # Upsert PRs
+  echo "$PRS" | jq -c '.[]' 2>/dev/null | while IFS= read -r item; do
+    NUM=$(echo "$item" | jq -r '.number')
+    TITLE=$(echo "$item" | jq -r '.title' | sed "s/'/''/g")
+    AUTHOR=$(echo "$item" | jq -r '.author.login // .author')
+    CREATED=$(echo "$item" | jq -r '.createdAt')
+
+    EXISTS=$(sqlite3 "$DB" "SELECT status FROM items WHERE repo='$repo' AND type='pr' AND number=$NUM;" 2>/dev/null)
+    if [ -z "$EXISTS" ]; then
+      sqlite3 "$DB" "INSERT INTO items (repo, type, number, title, author, created_at, last_seen) \
+        VALUES ('$repo','pr',$NUM,'$TITLE','$AUTHOR','$CREATED','$NOW');"
+      log "NEW pr: $repo#$NUM — $TITLE"
+    else
+      sqlite3 "$DB" "UPDATE items SET last_seen='$NOW', title='$TITLE' \
+        WHERE repo='$repo' AND type='pr' AND number=$NUM;"
+    fi
+  done
+
+  # Detect closed items (tracked as open but not seen in this scan)
+  sqlite3 "$DB" "SELECT number, type, title FROM items \
+    WHERE repo='$repo' AND status IN ('open','triaged','fixing') AND last_seen < '$NOW';" 2>/dev/null \
+    | while IFS='|' read -r num typ title; do
+      [ -z "$num" ] && continue
+      sqlite3 "$DB" "UPDATE items SET status='closed' WHERE repo='$repo' AND type='$typ' AND number=$num;"
+      log "CLOSED $typ: $repo#$num — $title"
+      ntfy "✅ ${repo}#${num} closed" "${title}" "default" "white_check_mark"
+    done
+done
+
+# ── Cycle complete ───────────────────────────────────────────────────────────
+CLOSED_THIS=$(sqlite3 "$DB" "SELECT COUNT(*) FROM items WHERE status='closed' AND last_seen < '$NOW';" 2>/dev/null || echo 0)
+sqlite3 "$DB" "UPDATE cycles SET completed_at='$(date -u +%Y-%m-%dT%H:%M:%SZ)', \
+  total_issues=$TOTAL_I, total_prs=$TOTAL_P, items_closed=$CLOSED_THIS WHERE id=$CYCLE_ID;"
+
+# ── ntfy: cycle summary ─────────────────────────────────────────────────────
+ACTIONABLE=$(sqlite3 "$DB" "SELECT COUNT(*) FROM items WHERE status='open';" 2>/dev/null || echo "?")
+ntfy "🔄 Scan #$CYCLE_ID — ${TOTAL_I}i/${TOTAL_P}p" \
+  "$SUMMARY
+Actionable: $ACTIONABLE  Closed this cycle: $CLOSED_THIS" "default" "repeat"
+
+log "Cycle $CYCLE_ID complete: ${TOTAL_I}i/${TOTAL_P}p, closed=$CLOSED_THIS, actionable=$ACTIONABLE"
+
+# ── Write trigger for AI agent ───────────────────────────────────────────────
+# The AI agent (or a Copilot skill) can watch this file to know a fresh scan
+# is available. It reads the DB, triages, and fixes actionable items.
+echo "$CYCLE_ID" > "$DIR/trigger"

--- a/launchd/com.supervised-agent.plist.example
+++ b/launchd/com.supervised-agent.plist.example
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  supervised-agent — macOS LaunchAgent
+  Equivalent of supervised-agent.service on Linux.
+
+  Runs bin/agent-supervisor.sh in a loop. The supervisor manages a tmux session
+  with the AI agent inside, same as on Linux — only the process manager differs.
+
+  Install:
+    cp launchd/com.supervised-agent.plist.example ~/Library/LaunchAgents/com.supervised-agent.plist
+    # Edit paths below (replace /Users/YOURUSER everywhere)
+    launchctl load -w ~/Library/LaunchAgents/com.supervised-agent.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.supervised-agent.plist
+    rm ~/Library/LaunchAgents/com.supervised-agent.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.supervised-agent</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/bash</string>
+        <string>-c</string>
+        <string>source /Users/YOURUSER/.config/supervised-agent/agent.env &amp;&amp; exec /Users/YOURUSER/supervised-agent/bin/agent-supervisor.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/YOURUSER</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/Users/YOURUSER/.local/state/supervised-agent/supervisor.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/YOURUSER/.local/state/supervised-agent/supervisor.err</string>
+
+    <!-- Throttle respawns: wait 30s between crashes -->
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/YOURUSER</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>

--- a/launchd/com.supervised-agent.scanner.plist.example
+++ b/launchd/com.supervised-agent.scanner.plist.example
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  supervised-agent scanner — macOS LaunchAgent
+  Fires a standalone scanner script on a fixed schedule.
+
+  This is the "hybrid" pattern: a deterministic bash scanner runs on a timer
+  (no AI needed for scanning), writes state to SQLite, and triggers the AI
+  agent only when there's actionable work.
+
+  See examples/worker.sh.example for the scanner script pattern.
+  See examples/kubestellar-fixer.md for a full case study.
+
+  Install:
+    cp launchd/com.supervised-agent.scanner.plist.example \
+       ~/Library/LaunchAgents/com.supervised-agent.scanner.plist
+    # Edit paths below
+    launchctl load -w ~/Library/LaunchAgents/com.supervised-agent.scanner.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.supervised-agent.scanner.plist
+    rm ~/Library/LaunchAgents/com.supervised-agent.scanner.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.supervised-agent.scanner</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/bash</string>
+        <string>/Users/YOURUSER/.my-project-fix-loop/worker.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/YOURUSER</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Fire every 15 minutes -->
+    <key>StartInterval</key>
+    <integer>900</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/YOURUSER/.my-project-fix-loop/scanner.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/YOURUSER/.my-project-fix-loop/scanner.err</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>/Users/YOURUSER</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Adds macOS support, a hybrid scanner+AI deployment pattern, and a production case study based on the KubeStellar autonomous fixer system.

## New files

| File | Purpose |
|---|---|
| `docs/macos.md` | Full macOS/launchd setup guide (concept mapping, quickstart, healthcheck, platform differences) |
| `launchd/*.plist.example` | LaunchAgent templates for supervisor and standalone scanner |
| `examples/sqlite-state.md` | SQLite as alternative to beads — schema, queries, when to use |
| `examples/worker.sh.example` | Standalone scanner script pattern (bash + gh CLI + SQLite + ntfy) |
| `examples/kubestellar-fixer.md` | Production case study: 6 repos, 36+ issues closed, <30 min SLA |

## Updated files

| File | Changes |
|---|---|
| `README.md` | macOS as supported platform, hybrid pattern section, updated contributing |
| `docs/architecture.md` | New section: 'Reference deployment: hybrid local scanner + GitHub responders' with architecture diagram |

## Design decisions

- **Not a new 'Model C'**: The hybrid pattern is framed as a composition of existing patterns, not a new scheduling primitive. Models A and B remain the core abstractions.
- **KubeStellar content stays in examples/**: Core docs remain generic. Project-specific content lives in the case study.
- **SQLite framed as alternative, not replacement**: Clear guidance on when SQLite vs beads is appropriate (single-machine vs multi-host).
- **Data flow boundary explicitly documented**: The architecture diagram shows that GitHub Actions write to GitHub, the scanner polls GitHub and writes to SQLite, and the AI reads SQLite and writes to GitHub — no component crosses boundaries.