### PR TITLE
✨ Add KubeStellar production scanner configs and Copilot skills

### DIFF
--- a/examples/kubestellar/README.md
+++ b/examples/kubestellar/README.md
@@ -1,0 +1,64 @@
+# KubeStellar Production Deployment
+
+Production configuration for the supervised-agent system deployed on the [KubeStellar](https://kubestellar.io) project — a CNCF Sandbox multi-cluster management platform.
+
+## Architecture
+
+The system runs on a Mac Mini and autonomously scans, triages, and fixes issues across 6 GitHub repositories every 15 minutes.
+
+```
+launchd (every 15 min)
+  └─► worker.sh (scanner)
+        ├─► GitHub API (gh issue list / pr list)
+        ├─► SQLite state.db (upsert findings)
+        └─► ntfy.sh (mobile notifications)
+
+Copilot CLI (on-demand or triggered)
+  ├─► fix-loop-skill.md   — reads DB, fixes actionable items
+  ├─► auto-qa-skill.md    — processes Auto-QA issues + stalled PRs
+  └─► hygiene-skill.md    — full operational sweep (builds, PRs, issues, deploys)
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `worker.sh` | Production scanner — scans 6 repos, updates SQLite, sends ntfy summaries |
+| `io.kubestellar.fix-loop.plist` | macOS launchd plist — runs worker.sh every 900s (15 min) |
+| `fix-loop-skill.md` | Copilot CLI skill — reads SQLite DB, triages, and fixes items autonomously |
+| `auto-qa-skill.md` | Copilot CLI skill — processes Auto-QA issues and stalled copilot PRs |
+| `hygiene-skill.md` | Copilot CLI skill — comprehensive hygiene sweep (builds, CI, PRs, issues, deploys, branches) |
+
+## Repos Scanned
+
+- `kubestellar/console` — Main console UI + API
+- `kubestellar/console-kb` — Mission knowledge base (1480 missions)
+- `kubestellar/console-marketplace` — Card marketplace
+- `kubestellar/docs` — Documentation site
+- `kubestellar/kubestellar-mcp` — MCP server
+- `kubestellar/claude-plugins` — Claude integrations
+
+## Results
+
+As of April 2026:
+- **54+ issues auto-closed** in a single day
+- **6 actionable items** remaining at any given time
+- **<30 min SLA** from issue filed to PR merged for auto-fixable items
+- **Zero human intervention** for routine fixes (test timeouts, perf budget rebaselines, duplicate closures)
+
+## Installation
+
+```bash
+# 1. Copy worker.sh and configure
+cp worker.sh ~/.kubestellar-fix-loop/worker.sh
+chmod +x ~/.kubestellar-fix-loop/worker.sh
+
+# 2. Install launchd plist
+cp io.kubestellar.fix-loop.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/io.kubestellar.fix-loop.plist
+
+# 3. Install Copilot CLI skills
+cp fix-loop-skill.md auto-qa-skill.md hygiene-skill.md ~/.claude/commands/
+```
+
+See the [case study](../kubestellar-fixer.md) for the full design rationale.

--- a/examples/kubestellar/auto-qa-skill.md
+++ b/examples/kubestellar/auto-qa-skill.md
@@ -1,0 +1,195 @@
+## Auto-QA: Autonomous Auto-QA PR Processor
+
+Continuously discover and fix all open auto-qa issues and stalled copilot PRs on `kubestellar/console`. Work through every item without asking — the user will review and merge PRs separately.
+
+Use `unset GITHUB_TOKEN &&` before all `gh` commands. Use sub-agents (Agent tool) to parallelize independent work.
+
+---
+
+### 1. Discovery — Find All Open Auto-QA Work
+
+```bash
+# Open auto-qa issues
+unset GITHUB_TOKEN && gh issue list --repo kubestellar/console --label "auto-qa" --state open --json number,title,labels,createdAt --limit 50
+
+# Open PRs from copilot on auto-qa branches
+unset GITHUB_TOKEN && gh pr list --repo kubestellar/console --state open --search "[Auto-QA]" --json number,title,headRefName,author,labels,additions,deletions,createdAt --limit 50
+
+# Also check for GA4-Error issues (same workflow)
+unset GITHUB_TOKEN && gh issue list --repo kubestellar/console --label "ga4-error" --state open --json number,title,labels,createdAt --limit 50
+
+# Check for existing fix/auto-qa-* PRs by clubanderson (already being worked on — skip these)
+unset GITHUB_TOKEN && gh pr list --repo kubestellar/console --state open --search "auto-qa author:clubanderson" --json number,title,headRefName --limit 50
+```
+
+**Triage rules (no user interaction needed):**
+- **Stalled copilot PR** = PR by `copilot-swe-agent` with `size/XS` label (0 additions, 0 deletions). → **Takeover.**
+- **Issue with no PR** = Auto-QA or GA4-Error issue with no linked open PR. → **New fix.**
+- **Issue with existing `fix/auto-qa-*` PR by clubanderson** = Already being worked on. → **Skip.**
+- **Active copilot PR with real changes** (additions > 0) = Copilot is working. → **Skip.**
+- **Issue with `ai-needs-human` label** = Still attempt a fix. Only skip if the fix truly requires human judgment after reading the issue.
+
+Print a brief summary table of all items found and which action will be taken, then immediately start processing — **do NOT wait for user input**.
+
+Process items in this priority order:
+1. GA4 bug fixes (`ga4-error`) — these are production errors
+2. UI flicker fixes (`auto-qa:flicker`) — user-visible quality issues
+3. Efficiency improvements (`auto-qa:nfr`)
+4. Code centralization (`auto-qa:centralization`)
+5. High complexity (`auto-qa:features`)
+6. UI design (`auto-qa:ui-design`)
+
+---
+
+### 2. For Each Item — Full Autonomous Workflow
+
+#### 2a. Close Stalled Copilot PR (if one exists for this issue)
+
+**CRITICAL:** The copilot PR body contains `Fixes #XXXX` or `Closes #XXXX` which auto-closes the linked issue when the PR is closed. You MUST strip these references BEFORE closing.
+
+```bash
+# Step 1: Get the current PR body
+unset GITHUB_TOKEN && gh pr view <PR_NUMBER> --repo kubestellar/console --json body -q .body > /tmp/pr_body_<PR_NUMBER>.txt
+
+# Step 2: Remove all auto-close keywords (Fixes/Closes/Resolves + # + number)
+# Use perl for reliable in-place editing with case-insensitive replace
+perl -pi -e 's/(Fixes|Closes|Resolves)\s+#(\d+)/Related to #$2/gi' /tmp/pr_body_<PR_NUMBER>.txt
+
+# Step 3: Update the PR body
+unset GITHUB_TOKEN && gh pr edit <PR_NUMBER> --repo kubestellar/console --body "$(cat /tmp/pr_body_<PR_NUMBER>.txt)"
+
+# Step 4: Now safe to close
+unset GITHUB_TOKEN && gh pr close <PR_NUMBER> --repo kubestellar/console --comment "Closing stalled copilot PR. Taking over with a manual fix."
+
+# Step 5: Delete the copilot branch
+unset GITHUB_TOKEN && git push origin --delete copilot/<branch-name>
+```
+
+#### 2b. Read the Issue
+
+```bash
+unset GITHUB_TOKEN && gh issue view <ISSUE_NUMBER> --repo kubestellar/console --json body,title,labels
+```
+
+Parse the issue to extract:
+- Affected files and line numbers
+- Specific findings (consecutive setState, missing loading indicators, etc.)
+- Suggested improvements
+
+#### 2c. Create Worktree and Branch
+
+**ALWAYS use a git worktree.** Never work on the main checkout.
+
+```bash
+cd /tmp/kubestellar-console
+git fetch origin main
+git worktree add /tmp/kubestellar-console-auto-qa-<issue-number> -b fix/auto-qa-<issue-number> origin/main
+cd /tmp/kubestellar-console-auto-qa-<issue-number>
+```
+
+#### 2d. Implement the Fix
+
+Read the affected files and implement changes. Follow these principles:
+
+- **Keep PRs small and focused** — One category of fix per PR. If an issue has multiple categories (e.g., setState batching AND missing loading indicators), pick the highest-impact category and fix that. The remaining categories will be picked up in the next run.
+- **Don't over-engineer** — Only fix what's flagged. Don't refactor surrounding code.
+- **Verify imports** — When adding hooks like `useReducer`, `useCallback`, `useMemo`, verify they exist in the import.
+- **No magic numbers** — Use named constants for any numeric values.
+- **Guard against undefined** — Use `(arr || []).join()` and `for (const x of (data || []))` patterns.
+- **isDemoData wiring** — If touching cards with `useCached*` hooks, ensure `isDemoData` is destructured and passed to `useCardLoadingState()`.
+- **DeduplicatedClusters()** — If iterating clusters, always use `DeduplicatedClusters()`.
+- **Run build and lint:**
+
+```bash
+cd /tmp/kubestellar-console-auto-qa-<issue-number>/web
+npm install  # worktrees share git but not node_modules
+npm run build
+npm run lint
+```
+
+If build or lint fails, fix the errors and retry. If stuck after 3 attempts on the same error, skip this item and move to the next.
+
+#### 2e. Commit and Create PR
+
+```bash
+cd /tmp/kubestellar-console-auto-qa-<issue-number>
+git add <specific-files>
+git commit -s -m "$(cat <<'EOF'
+fix: <description of what was fixed>
+
+Fixes #<ISSUE_NUMBER>
+EOF
+)"
+unset GITHUB_TOKEN && git push -u origin fix/auto-qa-<issue-number>
+```
+
+Create the PR:
+
+```bash
+unset GITHUB_TOKEN && gh pr create --repo kubestellar/console \
+  --title "<emoji> <Short description>" \
+  --body "$(cat <<'EOF'
+## Summary
+- <bullet points describing changes>
+- Fixes auto-qa findings from issue #<ISSUE_NUMBER>
+
+## Test plan
+- [x] `npm run build` passes
+- [x] `npm run lint` passes
+- [ ] Visual regression check for affected components
+
+Fixes #<ISSUE_NUMBER>
+EOF
+)"
+```
+
+**PR title emoji rules:**
+- `🐛` for bug fixes (flicker, errors, crashes, GA4 errors)
+- `✨` for enhancements (performance improvements, code centralization)
+- `⚠️` for breaking changes
+
+#### 2f. Move to Next Item
+
+After creating the PR, immediately move to the next item. Do NOT wait for review or CI. The user will review and merge PRs on their own schedule.
+
+---
+
+### 3. Auto-QA Issue Categories — Fix Reference
+
+**UI Flicker (`auto-qa:flicker`)**
+- Consecutive `setState` calls → Batch into single update or use `useReducer`
+- Missing loading indicators → Add skeleton/spinner components
+- `useLayoutEffect` misuse → Only use for DOM measurements
+
+**Code Centralization (`auto-qa:centralization`)**
+- Repeated layout patterns → Extract to shared components (only if 5+ occurrences)
+- Inconsistent hook usage → Migrate to standardized hooks
+- Modal state patterns → Use shared `useModal` hook (only if creating one is justified)
+
+**Efficiency (`auto-qa:nfr`)**
+- Inline style objects → Move to constants or `useMemo`
+- Inline arrow functions → Wrap in `useCallback` when passed as props
+- Full library imports → Use named imports in test files
+
+**GA4 Errors (`ga4-error`)**
+- `uncaught_render` → Find and fix rendering errors (check error boundaries, null guards)
+- `chunk_load` → Fix lazy loading / code splitting (add retry logic, improve chunk error boundary)
+- `unhandled_rejection` → Add proper `.catch()` or try/catch for promises
+
+**High Complexity (`auto-qa:features`)**
+- Split large components into smaller, focused sub-components
+- Extract complex logic into custom hooks
+
+**UI Design (`auto-qa:ui-design`)**
+- Inconsistent component patterns → Standardize to shared components (e.g., use `<Button>` instead of raw `<button>`)
+
+---
+
+### 4. Final Report
+
+After ALL items are processed, print a summary:
+
+| # | Issue | Action | PR Created | Build | Lint |
+|---|-------|--------|------------|-------|------|
+
+Include links to all created PRs. Note any items that were skipped and why.

--- a/examples/kubestellar/fix-loop-skill.md
+++ b/examples/kubestellar/fix-loop-skill.md
@@ -1,0 +1,136 @@
+# KubeStellar Autonomous Fix Loop
+
+Scan all 6 KubeStellar repos, triage every open item, and **fix everything actionable**. Send ntfy notifications for every action taken. This is NOT a reporting tool — it is a fixing tool.
+
+Use `unset GITHUB_TOKEN &&` before all `gh` commands. Use sub-agents (Agent tool) to parallelize independent work.
+
+---
+
+## State
+
+SQLite database: `~/.kubestellar-fix-loop/state.db`
+
+Tables:
+- `items` — every issue/PR tracked by (repo, type, number). Status: open → triaged → fixing → fixed → closed → skip
+- `cycles` — scan cycle history with counts
+- `repo_counts` — per-repo counts per cycle
+
+Read the DB first to see what's already tracked and what status items are in.
+
+---
+
+## Repos (6 total)
+
+1. **console** — main app (Go backend + React frontend)
+2. **console-kb** — knowledge base, install missions
+3. **console-marketplace** — marketplace card presets
+4. **docs** — documentation site
+5. **kubestellar-mcp** — MCP server
+6. **claude-plugins** — Claude plugins
+
+---
+
+## Cycle steps (execute ALL)
+
+### 1. Read state
+```bash
+sqlite3 ~/.kubestellar-fix-loop/state.db "SELECT repo, type, number, title, status FROM items WHERE status IN ('open','triaged') ORDER BY repo, type, number;" 2>/dev/null
+```
+
+### 2. Triage open items
+For each item with status='open', determine action:
+- **FIX** → set status='fixing', create branch, edit code, commit, push, PR, merge, close issue, set status='fixed'
+- **CLOSE** → close with comment explaining why, set status='closed'
+- **SKIP** → set status='skip' with notes (e.g., tracking issue, help-wanted, waiting on author)
+- **NEEDS_AUTHOR** → set status='skip' with notes
+
+Update the DB after each triage decision:
+```bash
+sqlite3 ~/.kubestellar-fix-loop/state.db "UPDATE items SET status='triaged', notes='FIX: description' WHERE repo='X' AND type='Y' AND number=Z;"
+```
+
+### 3. Fix actionable items
+For items marked 'fixing':
+1. `cd /tmp/kubestellar-{repo}` (clone if missing)
+2. `git checkout main && git pull --rebase origin main`
+3. `git checkout -b fix/{description}`
+4. Make the code changes
+5. `git add -A && git commit -s -m "emoji description"`
+6. `git push origin fix/{description}`
+7. `unset GITHUB_TOKEN && gh pr create --repo kubestellar/{repo} ...`
+8. `unset GITHUB_TOKEN && gh pr merge {number} --admin --squash`
+9. Cleanup: `git checkout main && git pull && git branch -D fix/{description}`
+10. Close linked issues
+11. Update DB: `status='fixed', fix_pr='repo#number'`
+
+### 4. Send ntfy for each action
+After every fix/close:
+```bash
+# Get fresh counts
+COUNTS=$(for r in console console-kb console-marketplace docs kubestellar-mcp claude-plugins; do
+  ic=$(unset GITHUB_TOKEN && gh issue list --repo "kubestellar/$r" --state open --limit 200 --json number --jq 'length' 2>/dev/null || echo 0)
+  pc=$(unset GITHUB_TOKEN && gh pr list --repo "kubestellar/$r" --state open --json number --jq 'length' 2>/dev/null || echo 0)
+  echo "$r: ${ic}i/${pc}pr"
+done)
+curl -sf -H "Title: ✅ {repo}#{number} closed" -H "Tags: white_check_mark" \
+  -d "{reason}\n$COUNTS" "https://ntfy.sh/ks-fix-loop"
+```
+
+### 5. Review PRs
+For each open PR:
+- If approved + CI green → merge (admin squash)
+- If CI failing → check if it's flaky (admin merge) or real failure (comment)
+- If stale >14 days with no activity → comment asking for update
+- If changes requested → skip, set notes='waiting on author'
+
+### 6. Check nightly CI
+```bash
+unset GITHUB_TOKEN && gh run list --repo kubestellar/console --limit 10 --json name,conclusion,databaseId,createdAt | jq '[.[] | select(.conclusion == "failure")]'
+```
+For each failure: download logs, analyze root cause, fix if actionable.
+
+### 7. Update cycle complete
+```bash
+sqlite3 ~/.kubestellar-fix-loop/state.db "UPDATE cycles SET completed_at='$(date -u +%Y-%m-%dT%H:%M:%SZ)', items_fixed=N, items_closed=M WHERE id=(SELECT MAX(id) FROM cycles);"
+```
+
+---
+
+## Rules (NEVER violate)
+
+- **NEVER push directly to main** — always feature branches
+- **NEVER merge without green CI** (admin merge OK for flaky Playwright)
+- **NEVER send outreach with unvalidated links**
+- **DCO sign all commits**: `git commit -s`
+- **PR titles start with emoji**: ✨ feature | 🐛 bug | 📖 docs | 🌱 other
+- **Track every action in SQLite** — no silent changes
+- **Send ntfy for every close/merge** with updated counts
+- Use sub-agents to parallelize repo scans
+- Don't fix pre-existing issues unrelated to actionable items
+- Skip `console-marketplace` help-wanted issues (community backlog)
+- Skip `docs` automated tracking issues
+- Backoff: if an item has fix_attempts >= 3, set status='skip' with notes
+
+---
+
+## Triage categories
+
+### Always fix
+- Nightly CI failures (test bugs, timeout misconfig, assertion drift)
+- Perf budget regressions (bundle size, react commits)
+- Community bug reports with clear reproduction
+- Stale PR rebases needed for approved PRs
+- README/doc inaccuracies
+- Broken links or mission deep-links
+
+### Always skip
+- `help-wanted` / `good-first-issue` marketplace cards
+- Auto-generated tracking issues (agentic workflow no-ops)
+- Issues waiting on external author response
+- Items already being fixed (status='fixing')
+
+### Always close
+- Duplicate nightly issues (keep newest, close older)
+- Issues fixed by merged PRs
+- Bot roundtrip failures that self-resolve
+- Noise issues with no actionable content

--- a/examples/kubestellar/hygiene-skill.md
+++ b/examples/kubestellar/hygiene-skill.md
@@ -1,0 +1,239 @@
+## KubeStellar Comprehensive Hygiene
+
+Run a full operational sweep across the kubestellar GitHub organization repos: **console**, **console-marketplace**, **console-kb**, **docs**, and **homebrew-tap**.
+
+Execute ALL sections below in order. Use sub-agents (Agent tool) to parallelize independent checks. Use `unset GITHUB_TOKEN &&` before all `gh` commands.
+
+---
+
+### 1. Nightly & Weekly Builds
+
+Check the latest workflow runs for each of these. Report status (pass/fail/in-progress), duration, and link.
+
+```bash
+# Console — nightly compliance, nightly issues, weekly builds
+unset GITHUB_TOKEN && gh run list --repo kubestellar/console --limit 10 --json name,status,conclusion,createdAt,url
+
+# Console — check kc-agent build (Docker/Quay image build workflows)
+unset GITHUB_TOKEN && gh run list --repo kubestellar/console --workflow "Docker Build" --limit 3 --json name,status,conclusion,createdAt,url 2>/dev/null
+unset GITHUB_TOKEN && gh run list --repo kubestellar/console --workflow "Release" --limit 3 --json name,status,conclusion,createdAt,url 2>/dev/null
+
+# Helm chart builds
+unset GITHUB_TOKEN && gh run list --repo kubestellar/console --limit 20 --json name,status,conclusion,createdAt | jq '[.[] | select(.name | test("helm|chart"; "i"))]'
+
+# Brew builds
+unset GITHUB_TOKEN && gh run list --repo kubestellar/console --limit 20 --json name,status,conclusion,createdAt | jq '[.[] | select(.name | test("brew|formula"; "i"))]'
+
+# Console-kb workflows
+unset GITHUB_TOKEN && gh run list --repo kubestellar/console-kb --limit 5 --json name,status,conclusion,createdAt,url
+
+# Docs workflows
+unset GITHUB_TOKEN && gh run list --repo kubestellar/docs --limit 5 --json name,status,conclusion,createdAt,url
+```
+
+Report a table of all workflow runs with any failures highlighted.
+
+---
+
+### 2. CI Status
+
+For each repo, check if CI is green on the main/default branch:
+
+```bash
+for repo in console console-marketplace console-kb docs; do
+  echo "=== kubestellar/$repo ==="
+  unset GITHUB_TOKEN && gh run list --repo "kubestellar/$repo" --branch main --limit 5 --json name,status,conclusion,createdAt
+done
+```
+
+Flag any failing CI on main — these are critical.
+
+---
+
+### 3. PR Review
+
+For each repo, list all open PRs with their status, CI checks, review state, and age:
+
+```bash
+for repo in console console-marketplace console-kb docs; do
+  echo "=== kubestellar/$repo ==="
+  unset GITHUB_TOKEN && gh pr list --repo "kubestellar/$repo" --state open --json number,title,author,createdAt,reviewDecision,statusCheckRollup,labels,url
+done
+```
+
+For each open PR:
+- Note CI status (passing/failing/pending)
+- Note review status (approved/changes requested/pending)
+- Note age (flag if >7 days old)
+- Note if it has Copilot review comments that need addressing
+- Recommend action: merge, needs review, needs fixes, or stale
+
+---
+
+### 4. Issue Review
+
+For each repo, list all open issues:
+
+```bash
+for repo in console console-marketplace console-kb docs; do
+  echo "=== kubestellar/$repo ==="
+  unset GITHUB_TOKEN && gh issue list --repo "kubestellar/$repo" --state open --json number,title,labels,createdAt,author,url
+done
+```
+
+For each issue:
+- Assess if it's legitimate, noise, or already fixed
+- Check if there's already a PR addressing it
+- Flag duplicates
+- Recommend: fix, close as noise, close as duplicate, or needs triage
+
+---
+
+### 5. Nightly Issue Findings
+
+Check for issues created by nightly workflows (typically labeled `nightly`, `automated`, `triage-needed`, or created by `github-actions`):
+
+```bash
+unset GITHUB_TOKEN && gh issue list --repo kubestellar/console --state open --label "triage-needed" --json number,title,createdAt,labels,url
+unset GITHUB_TOKEN && gh issue list --repo kubestellar/console --state open --label "nightly" --json number,title,createdAt,labels,url 2>/dev/null
+unset GITHUB_TOKEN && gh issue list --repo kubestellar/console --state open --search "author:github-actions" --json number,title,createdAt,labels,url
+```
+
+For each nightly finding:
+- Categorize severity: critical (broken functionality), medium (degraded), low (cosmetic/noise)
+- For critical items: investigate and fix immediately (create worktree, fix, PR)
+- For noise: close with explanation
+- For medium: note for follow-up
+
+---
+
+### 6. Branch & Ref Cleanup
+
+For each repo found in `/tmp/kubestellar-*` (main repos only, not worktrees):
+
+1. **Pull main** if on main branch
+2. **Prune** stale remote tracking refs: `git remote prune origin`
+3. **Delete `[gone]` branches** that do NOT have associated worktrees
+
+Write a discovery script to `/tmp/ks-hygiene-discover.sh` and run with `/opt/homebrew/bin/bash`:
+
+```bash
+#!/usr/bin/env bash
+declare -A seen
+for d in /tmp/kubestellar-*; do
+  [ -d "$d/.git" ] || continue
+  remote=$(cd "$d" && git remote get-url origin 2>/dev/null)
+  [[ "$remote" == *"github.com/kubestellar/"* ]] || continue
+  if [ -z "${seen[$remote]}" ] || [ ${#d} -lt ${#seen[$remote]} ]; then
+    seen[$remote]="$d"
+  fi
+done
+for remote in "${!seen[@]}"; do
+  echo "${seen[$remote]}|$remote"
+done
+```
+
+Then for each discovered repo:
+```bash
+cd <repo_path>
+# Pull main
+current=$(git branch --show-current)
+[ "$current" = "main" ] && git pull --rebase origin main
+
+# Prune
+git remote prune origin
+
+# Delete gone branches (skip those with worktrees)
+git branch -v | grep '\[gone\]' | sed 's/^[+* ]*//' | awk '{print $1}' | while read branch; do
+  wt=$(git worktree list | grep "\[$branch\]" | awk '{print $1}')
+  if [ -z "$wt" ]; then
+    git branch -D "$branch"
+  fi
+done
+```
+
+---
+
+### 7. Deployment Health (vllm-d & pok-prod)
+
+Check the latest "Build and Deploy KC" workflow for deployment status to both clusters:
+
+```bash
+# Latest deploy workflow run
+unset GITHUB_TOKEN && gh run list --repo kubestellar/console --workflow "Build and Deploy KC" --limit 5 --json name,status,conclusion,createdAt,url
+
+# Job-level detail for latest run
+LATEST_RUN=$(unset GITHUB_TOKEN && gh run list --repo kubestellar/console --workflow "Build and Deploy KC" --branch main --limit 1 --json databaseId --jq '.[0].databaseId')
+unset GITHUB_TOKEN && gh run view "$LATEST_RUN" --repo kubestellar/console --json jobs --jq '.jobs[] | "\(.name) | \(.status) | \(.conclusion)"'
+```
+
+For each deployment target:
+- **deploy-pok-prod**: Should be PASS. If failing, check logs.
+- **deploy-vllm-d**: Known blocker — GitHub PAT in `arc-github-secret-kubestellar` expires periodically. If failing with RBAC error, flag as "needs VPN + PAT renewal".
+
+Also check if clusters are reachable (best-effort, depends on VPN):
+```bash
+kubectl --context vllm-d cluster-info 2>&1 | head -3
+kubectl --context pok-prod cluster-info 2>&1 | head -3
+```
+
+---
+
+### 8. Helm Chart & Brew Formula Currency
+
+Verify the Helm chart and Homebrew formulas are up-to-date with the latest releases.
+
+```bash
+# Latest weekly release
+unset GITHUB_TOKEN && gh release list --repo kubestellar/console --limit 5 --json tagName,createdAt,isPrerelease --jq '[.[] | select(.isPrerelease == false)] | .[0]'
+
+# Latest nightly release
+unset GITHUB_TOKEN && gh release list --repo kubestellar/console --limit 5 --json tagName,createdAt,isPrerelease --jq '[.[] | select(.isPrerelease == true)] | .[0]'
+
+# Brew formula versions
+unset GITHUB_TOKEN && gh api repos/kubestellar/homebrew-tap/contents/Formula/kubestellar-console.rb --jq '.content' | tr -d '\n' | base64 -d | grep 'version "'
+unset GITHUB_TOKEN && gh api repos/kubestellar/homebrew-tap/contents/Formula/kc-agent.rb --jq '.content' | tr -d '\n' | base64 -d | grep 'version "'
+
+# Helm Chart Release workflow
+unset GITHUB_TOKEN && gh run list --repo kubestellar/console --workflow "Helm Chart Release" --limit 3 --json status,conclusion,createdAt,url
+
+# Release workflow (creates nightly + weekly releases + updates brew)
+unset GITHUB_TOKEN && gh run list --repo kubestellar/console --workflow "Release" --limit 3 --json status,conclusion,createdAt,url
+```
+
+Flag:
+- **Brew formula stale**: if `kubestellar-console` version < latest weekly release version
+- **kc-agent formula stale**: if version < latest nightly release version
+- **Nightly missing**: if today's date has no nightly release AND the Release workflow failed
+- **Helm chart release failures**: any recent Helm Chart Release workflow failures
+
+---
+
+### 9. Summary Report
+
+Output a comprehensive summary with:
+
+1. **Build Health** table — all workflow runs with status
+2. **CI Status** table — main branch CI per repo
+3. **Open PRs** table — with recommended actions
+4. **Open Issues** table — with triage recommendations
+5. **Nightly Findings** — critical/medium/low with actions taken or recommended
+6. **Branch Cleanup** table — pruned refs, deleted branches, skipped branches per repo
+7. **Deployment Health** table — vllm-d and pok-prod deploy status, any blockers
+8. **Distribution Currency** table — brew formula versions vs latest releases, nightly release status, helm chart release status
+
+---
+
+### Rules
+
+- **NEVER delete worktrees** — user rule, no exceptions
+- **NEVER push to any remote** — unless fixing a critical nightly finding (then use worktree + PR workflow)
+- **NEVER merge PRs on kubestellar repos without user approval** — present recommendations, don't auto-merge
+- **NEVER commit directly to main** — always use feature branches
+- **Ignore Playwright failures** — not blocking for PRs
+- **Ignore `llm-d-deployer`** — archived/read-only
+- **Use `unset GITHUB_TOKEN &&` before all `gh` commands**
+- **Use `/opt/homebrew/bin/bash` for scripts with associative arrays** (zsh compat)
+- **Use sub-agents to parallelize** sections 1-5 where possible
+- Report any errors encountered but continue processing
+- For fixes: use git worktree workflow, DCO-signed commits, emoji PR titles

--- a/examples/kubestellar/io.kubestellar.fix-loop.plist
+++ b/examples/kubestellar/io.kubestellar.fix-loop.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>io.kubestellar.fix-loop</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/bash</string>
+        <string>/Users/andan02/.kubestellar-fix-loop/worker.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>900</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/Users/andan02/.kubestellar-fix-loop/launchd-stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/andan02/.kubestellar-fix-loop/launchd-stderr.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>/Users/andan02</string>
+    </dict>
+</dict>
+</plist>

--- a/examples/kubestellar/worker.sh
+++ b/examples/kubestellar/worker.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# KubeStellar Fix Loop — Worker (scanner + notifier)
+# Managed by launchd. Runs one cycle per invocation.
+# Scans all 6 repos, updates SQLite state, sends ntfy.
+# The Copilot skill reads the DB and does actual fixes.
+set -euo pipefail
+
+DIR="$HOME/.kubestellar-fix-loop"
+DB="$DIR/state.db"
+LOCKFILE="$DIR/cycle.lock"
+LOGFILE="$DIR/worker.log"
+NTFY_TOPIC="ks-fix-loop"
+REPOS="console console-kb console-marketplace docs kubestellar-mcp claude-plugins"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >> "$LOGFILE"; }
+
+ntfy() {
+  local title="$1" body="$2" prio="${3:-default}" tags="${4:-robot}"
+  curl -sf -o /dev/null -m 10 \
+    -H "Title: $title" -H "Priority: $prio" -H "Tags: $tags" \
+    -d "$body" "https://ntfy.sh/$NTFY_TOPIC" 2>/dev/null || log "WARN: ntfy send failed"
+}
+
+# ── Lock ─────────────────────────────────────────────────────────────────────
+if [ -f "$LOCKFILE" ]; then
+  LOCK_AGE=$(( $(date +%s) - $(stat -f %m "$LOCKFILE" 2>/dev/null || echo 0) ))
+  if [ "$LOCK_AGE" -lt 600 ]; then
+    log "Cycle locked (age ${LOCK_AGE}s < 600s). Skipping."
+    exit 0
+  fi
+  log "Stale lock (age ${LOCK_AGE}s). Removing."
+  rm -f "$LOCKFILE"
+fi
+echo $$ > "$LOCKFILE"
+trap 'rm -f "$LOCKFILE"' EXIT
+
+# ── Init SQLite ──────────────────────────────────────────────────────────────
+init_db() {
+  sqlite3 "$DB" <<'SQL'
+CREATE TABLE IF NOT EXISTS items (
+  repo TEXT NOT NULL,
+  type TEXT NOT NULL,           -- 'issue' or 'pr'
+  number INTEGER NOT NULL,
+  title TEXT,
+  author TEXT,
+  created_at TEXT,
+  status TEXT DEFAULT 'open',   -- open, triaged, fixing, fixed, closed, skip
+  last_seen TEXT,
+  fix_attempts INTEGER DEFAULT 0,
+  fix_pr TEXT,
+  notes TEXT,
+  PRIMARY KEY (repo, type, number)
+);
+CREATE TABLE IF NOT EXISTS cycles (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  started_at TEXT NOT NULL,
+  completed_at TEXT,
+  total_issues INTEGER,
+  total_prs INTEGER,
+  items_fixed INTEGER DEFAULT 0,
+  items_closed INTEGER DEFAULT 0
+);
+CREATE TABLE IF NOT EXISTS repo_counts (
+  repo TEXT NOT NULL,
+  cycle_id INTEGER NOT NULL,
+  issues INTEGER,
+  prs INTEGER,
+  PRIMARY KEY (repo, cycle_id)
+);
+SQL
+}
+
+init_db
+
+# ── Start cycle ──────────────────────────────────────────────────────────────
+CYCLE_ID=$(sqlite3 "$DB" "INSERT INTO cycles (started_at) VALUES ('$(date -u +%Y-%m-%dT%H:%M:%SZ)'); SELECT last_insert_rowid();")
+log "=== Cycle $CYCLE_ID started ==="
+
+# ── Scan repos ───────────────────────────────────────────────────────────────
+TOTAL_I=0
+TOTAL_P=0
+SUMMARY=""
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+for repo in $REPOS; do
+  # Fetch issues
+  ISSUES=$(unset GITHUB_TOKEN && gh issue list --repo "kubestellar/$repo" --state open --limit 200 \
+    --json number,title,author,createdAt 2>/dev/null || echo "[]")
+  IC=$(echo "$ISSUES" | jq 'length' 2>/dev/null || echo 0)
+
+  # Fetch PRs
+  PRS=$(unset GITHUB_TOKEN && gh pr list --repo "kubestellar/$repo" --state open --limit 100 \
+    --json number,title,author,createdAt 2>/dev/null || echo "[]")
+  PC=$(echo "$PRS" | jq 'length' 2>/dev/null || echo 0)
+
+  TOTAL_I=$((TOTAL_I + IC))
+  TOTAL_P=$((TOTAL_P + PC))
+  SUMMARY+="$repo: ${IC}i/${PC}pr  "
+
+  # Save counts
+  sqlite3 "$DB" "INSERT OR REPLACE INTO repo_counts (repo, cycle_id, issues, prs) VALUES ('$repo', $CYCLE_ID, $IC, $PC);"
+
+  # Upsert items — mark seen, detect new
+  echo "$ISSUES" | jq -c '.[]' 2>/dev/null | while IFS= read -r item; do
+    NUM=$(echo "$item" | jq -r '.number')
+    TITLE=$(echo "$item" | jq -r '.title' | sed "s/'/''/g")
+    AUTHOR=$(echo "$item" | jq -r '.author.login // .author')
+    CREATED=$(echo "$item" | jq -r '.createdAt')
+    EXISTS=$(sqlite3 "$DB" "SELECT status FROM items WHERE repo='$repo' AND type='issue' AND number=$NUM;" 2>/dev/null)
+    if [ -z "$EXISTS" ]; then
+      sqlite3 "$DB" "INSERT INTO items (repo, type, number, title, author, created_at, last_seen) VALUES ('$repo','issue',$NUM,'$TITLE','$AUTHOR','$CREATED','$NOW');"
+      log "NEW issue: $repo#$NUM — $TITLE"
+    else
+      sqlite3 "$DB" "UPDATE items SET last_seen='$NOW', title='$TITLE' WHERE repo='$repo' AND type='issue' AND number=$NUM;"
+    fi
+  done
+
+  echo "$PRS" | jq -c '.[]' 2>/dev/null | while IFS= read -r item; do
+    NUM=$(echo "$item" | jq -r '.number')
+    TITLE=$(echo "$item" | jq -r '.title' | sed "s/'/''/g")
+    AUTHOR=$(echo "$item" | jq -r '.author.login // .author')
+    CREATED=$(echo "$item" | jq -r '.createdAt')
+    EXISTS=$(sqlite3 "$DB" "SELECT status FROM items WHERE repo='$repo' AND type='pr' AND number=$NUM;" 2>/dev/null)
+    if [ -z "$EXISTS" ]; then
+      sqlite3 "$DB" "INSERT INTO items (repo, type, number, title, author, created_at, last_seen) VALUES ('$repo','pr',$NUM,'$TITLE','$AUTHOR','$CREATED','$NOW');"
+      log "NEW pr: $repo#$NUM — $TITLE"
+    else
+      sqlite3 "$DB" "UPDATE items SET last_seen='$NOW', title='$TITLE' WHERE repo='$repo' AND type='pr' AND number=$NUM;"
+    fi
+  done
+
+  # Detect closed items (in DB as open but not in current scan)
+  sqlite3 "$DB" "SELECT number, type, title FROM items WHERE repo='$repo' AND status IN ('open','triaged','fixing') AND last_seen < '$NOW';" 2>/dev/null | while IFS='|' read -r num typ title; do
+    [ -z "$num" ] && continue
+    sqlite3 "$DB" "UPDATE items SET status='closed' WHERE repo='$repo' AND type='$typ' AND number=$num;"
+    log "CLOSED $typ: $repo#$num — $title"
+    # ntfy for closure
+    ntfy "✅ ${repo}#${num} closed" "${title}" "default" "white_check_mark"
+  done
+done
+
+# ── Cycle complete ───────────────────────────────────────────────────────────
+CLOSED_THIS=$(sqlite3 "$DB" "SELECT COUNT(*) FROM items WHERE status='closed' AND last_seen < '$NOW';" 2>/dev/null || echo 0)
+sqlite3 "$DB" "UPDATE cycles SET completed_at='$(date -u +%Y-%m-%dT%H:%M:%SZ)', total_issues=$TOTAL_I, total_prs=$TOTAL_P, items_closed=$CLOSED_THIS WHERE id=$CYCLE_ID;"
+
+# ── ntfy: cycle summary ─────────────────────────────────────────────────────
+ACTIONABLE=$(sqlite3 "$DB" "SELECT COUNT(*) FROM items WHERE status='open';" 2>/dev/null || echo "?")
+ntfy "🔄 Scan #$CYCLE_ID — ${TOTAL_I}i/${TOTAL_P}p" "$SUMMARY
+Actionable: $ACTIONABLE  Closed this cycle: $CLOSED_THIS" "default" "repeat"
+
+log "Cycle $CYCLE_ID complete: ${TOTAL_I}i/${TOTAL_P}p, closed=$CLOSED_THIS, actionable=$ACTIONABLE"
+
+# ── Write trigger for Copilot skill ─────────────────────────────────────────
+echo "$CYCLE_ID" > "$DIR/trigger"


### PR DESCRIPTION
## Summary

Adds the production deployment files from the KubeStellar project to `examples/kubestellar/`:

| File | Purpose |
|------|---------|
| `worker.sh` | Production scanner — scans 6 repos, updates SQLite, sends ntfy summaries |
| `io.kubestellar.fix-loop.plist` | macOS launchd plist (15-min interval) |
| `fix-loop-skill.md` | Copilot CLI skill — reads DB, fixes items autonomously |
| `auto-qa-skill.md` | Copilot CLI skill — processes Auto-QA issues + stalled PRs |
| `hygiene-skill.md` | Copilot CLI skill — comprehensive hygiene sweep |
| `README.md` | Deployment guide and architecture docs |

These complement the existing generic examples and the `kubestellar-fixer.md` case study with the actual production configs running on the KubeStellar Mac Mini.