### PR TITLE
docs: add brew formula and Helm chart freshness checks to reviewer scope

### DIFF
--- a/examples/kubestellar/agents/supervisor-CLAUDE.md
+++ b/examples/kubestellar/agents/supervisor-CLAUDE.md
@@ -175,6 +175,17 @@ The `reviewer` session (Sonnet 4.6) handles post-merge work:
 - Copilot review comments on merged PRs
 - GA4 error watch: new error classes (30m vs 7d baseline), trending errors (>3× baseline), login_failure spikes
 - GA4 adoption digest: active users, engagement, top content, traffic sources, conversions, 7-day trend chart
+- **Brew formula freshness**: `kubestellar/homebrew-tap` formula version must match latest stable console release
+  ```bash
+  unset GITHUB_TOKEN && gh api /repos/kubestellar/console/releases --jq '[.[] | select(.draft==false and .prerelease==false)] | .[0].tag_name'
+  unset GITHUB_TOKEN && gh api /repos/kubestellar/homebrew-tap/contents/Formula/kubestellar-console.rb --jq '.content' | base64 -d | grep 'version\|tag'
+  ```
+  Mismatch → high ntfy + file issue on `homebrew-tap` + dispatch fix agent to bump the formula.
+- **Helm chart freshness**: `deploy/helm/Chart.yaml` `appVersion` must match latest stable console release.
+  ```bash
+  unset GITHUB_TOKEN && gh api /repos/kubestellar/console/contents/deploy/helm/Chart.yaml --jq '.content' | base64 -d | grep 'appVersion\|version'
+  ```
+  Mismatch → high ntfy + file issue on `kubestellar/console` + dispatch fix agent to bump Chart.yaml.
 
 Reviewer is NOT a /loop — send it work orders when needed:
 ```bash


### PR DESCRIPTION
## Summary

Reviewer now checks on every pass that release artifacts stay in sync with the latest stable console release:

- **Homebrew formula** (`kubestellar/homebrew-tap`) — formula version must match latest non-prerelease, non-draft GitHub release. Mismatch → high ntfy + issue filed + fix agent dispatched to bump the formula.
- **Helm chart** (`deploy/helm/Chart.yaml` `appVersion`) — must match latest stable release. Mismatch → high ntfy + issue filed + fix agent dispatched to bump Chart.yaml.

These were previously only checked during manual `/hygiene` runs. Now they're part of every reviewer iteration.

Signed-off-by: Andy Anderson <andy@clubanderson.com>