### PR TITLE
docs: add vllm-d and pok-prod01 deployment health checks to reviewer

### DIFF
--- a/examples/kubestellar/agents/supervisor-CLAUDE.md
+++ b/examples/kubestellar/agents/supervisor-CLAUDE.md
@@ -186,6 +186,12 @@ The `reviewer` session (Sonnet 4.6) handles post-merge work:
   unset GITHUB_TOKEN && gh api /repos/kubestellar/console/contents/deploy/helm/Chart.yaml --jq '.content' | base64 -d | grep 'appVersion\|version'
   ```
   Mismatch → high ntfy + file issue on `kubestellar/console` + dispatch fix agent to bump Chart.yaml.
+- **vllm-d deployment health**: check the last 5 runs of the `Build and Deploy KC` workflow for jobs named `deploy-vllm-d`. Any failure → high ntfy + regression issue + bead P1.
+  ```bash
+  unset GITHUB_TOKEN && gh run list --repo kubestellar/console --workflow "Build and Deploy KC" --limit 5 --json databaseId,conclusion,status,createdAt
+  # Then: gh run view <id> --repo kubestellar/console --json jobs --jq '.jobs[] | select(.name | test("vllm|pok"; "i")) | {name, conclusion, status}'
+  ```
+- **pok-prod01 deployment health**: check the same `Build and Deploy KC` workflow runs for jobs named `deploy-pok-prod`. Verify the deployed version matches the latest stable release tag. Any failure or version mismatch → high ntfy + regression issue + bead P1.
 
 Reviewer is NOT a /loop — send it work orders when needed:
 ```bash


### PR DESCRIPTION
## Summary

Reviewer now monitors production deployment health on every pass:

- **vllm-d**: checks `Build and Deploy KC` workflow for deploy-vllm-d job failures
- **pok-prod01**: checks same workflow for deploy-pok-prod job failures + verifies deployed version matches latest stable release

Both trigger high ntfy + regression issue + bead P1 on failure or version mismatch.

No kubectl required — uses GitHub Actions run history via `gh api`.

Signed-off-by: Andy Anderson <andy@clubanderson.com>