### PR TITLE
feat: kick-agents.sh + systemd timers for scanner/reviewer cadence

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# kick-agents.sh — fires work orders at the scanner and reviewer tmux sessions.
+# Called by systemd timers (or manually). Does NOT require Claude to be running
+# as a supervisor — it speaks directly to the named tmux sessions.
+#
+# Usage:
+#   kick-agents.sh scanner   # kick scanner only
+#   kick-agents.sh reviewer  # kick reviewer only
+#   kick-agents.sh all       # kick both (default)
+#
+# Systemd timer fires this every 15 min for scanner, every 30 min for reviewer.
+
+set -euo pipefail
+
+TARGET="${1:-all}"
+TMUX_BIN="${TMUX_BIN:-tmux}"
+LOG="/var/log/kick-agents.log"
+TIMESTAMP="$(TZ=America/New_York date '+%Y-%m-%d %H:%M:%S %Z')"
+
+log() { echo "[$TIMESTAMP] $*" | tee -a "$LOG"; }
+
+session_exists() {
+  $TMUX_BIN has-session -t "$1" 2>/dev/null
+}
+
+session_idle() {
+  # Returns 0 (idle) if the pane's last line is the shell prompt (❯ or $)
+  local pane
+  pane="$($TMUX_BIN capture-pane -t "$1" -p | tail -5)"
+  echo "$pane" | grep -qE '^\s*(❯|\$)\s*$'
+}
+
+kick() {
+  local session="$1"
+  local message="$2"
+
+  if ! session_exists "$session"; then
+    log "SKIP $session — session not found"
+    return
+  fi
+
+  # Don't interrupt if the session is actively working (not at idle prompt)
+  if ! session_idle "$session"; then
+    log "SKIP $session — already working"
+    return
+  fi
+
+  log "KICK $session"
+  $TMUX_BIN send-keys -t "$session" "$message" Enter
+}
+
+SCANNER_MSG="Run a full scan pass per your policy (project_scanner_policy.md). \
+Oldest-first. Check all 5 repos: kubestellar/console, console-kb, docs, \
+console-marketplace, kubestellar-mcp. Dispatch fix agents for open issues \
+(skip epics owned by other sessions — check for active PRs first). \
+Merge AI-authored PRs with green CI. Log to cron_scan_log.md."
+
+REVIEWER_MSG="Run a full reviewer pass per your policy (project_reviewer_policy.md). \
+Check: (A) coverage ≥91%, (B) OAuth code presence, (B.5) CI workflow health sweep, \
+(C) release freshness + brew formula + Helm chart appVersion + vllm-d + pok-prod01 \
+deploy health, (D) GA4 error watch + adoption digest, (F) post-merge diff scan. \
+Write all results to reviewer_log.md."
+
+case "$TARGET" in
+  scanner)
+    kick "issue-scanner" "$SCANNER_MSG"
+    ;;
+  reviewer)
+    kick "reviewer" "$REVIEWER_MSG"
+    ;;
+  all)
+    kick "issue-scanner" "$SCANNER_MSG"
+    kick "reviewer" "$REVIEWER_MSG"
+    ;;
+  *)
+    echo "Usage: $0 [scanner|reviewer|all]" >&2
+    exit 1
+    ;;
+esac
+
+log "DONE"

--- a/systemd/kick-reviewer.service
+++ b/systemd/kick-reviewer.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Kick reviewer agent to run a review pass
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=dev
+Environment=TMUX_BIN=tmux
+ExecStart=/usr/local/bin/kick-agents.sh reviewer
+StandardOutput=journal
+StandardError=journal

--- a/systemd/kick-reviewer.timer
+++ b/systemd/kick-reviewer.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Kick reviewer every 30 minutes
+Requires=kick-reviewer.service
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=30min
+AccuracySec=60s
+Unit=kick-reviewer.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/kick-scanner.service
+++ b/systemd/kick-scanner.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Kick issue-scanner agent to run a scan pass
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=dev
+Environment=TMUX_BIN=tmux
+ExecStart=/usr/local/bin/kick-agents.sh scanner
+StandardOutput=journal
+StandardError=journal

--- a/systemd/kick-scanner.timer
+++ b/systemd/kick-scanner.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Kick issue-scanner every 15 minutes
+Requires=kick-scanner.service
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=15min
+AccuracySec=30s
+Unit=kick-scanner.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Adds an external bash system that drives the scanner and reviewer sessions on a fixed cadence — completely outside Claude. No supervisor /loop needed.

### New files

**`bin/kick-agents.sh`**
- Sends pre-written work orders to `issue-scanner` and `reviewer` tmux sessions
- Checks if the session exists and is idle before sending (won't interrupt active work)
- Logs every kick to `/var/log/kick-agents.log`
- Usage: `kick-agents.sh [scanner|reviewer|all]`

**`systemd/kick-scanner.{service,timer}`**
- Fires `kick-agents.sh scanner` every **15 minutes**
- Starts 2 min after boot

**`systemd/kick-reviewer.{service,timer}`**
- Fires `kick-agents.sh reviewer` every **30 minutes**
- Starts 5 min after boot

### Install

```bash
sudo cp bin/kick-agents.sh /usr/local/bin/
sudo chmod +x /usr/local/bin/kick-agents.sh
sudo cp systemd/kick-{scanner,reviewer}.{service,timer} /etc/systemd/system/
sudo systemctl daemon-reload
sudo systemctl enable --now kick-scanner.timer kick-reviewer.timer

# Verify
systemctl list-timers kick-*
```

### How it works

The script uses `tmux capture-pane` to detect whether a session is at an idle prompt before sending. If the agent is mid-task, the kick is skipped and logged — the agent finishes its current work and gets kicked again on the next timer firing.

Signed-off-by: Andy Anderson <andy@clubanderson.com>