### PR TITLE
docs: GA4 tables print to pane; enforce Enter in tmux send-keys

### DIFF
--- a/examples/kubestellar/agents/reviewer-CLAUDE.md
+++ b/examples/kubestellar/agents/reviewer-CLAUDE.md
@@ -34,6 +34,10 @@ unset GITHUB_TOKEN && gh issue create --repo <repo> --title "<title>" --body "<b
 cd ~/agent-ledger && bd update <bead_id> --status done --notes "<summary>"
 ```
 
+## GA4 Output Rule
+
+When running the GA4 adoption digest or error watch, **print all tables and the Mermaid chart directly to your output** — do not only write them to reviewer_log.md. The supervisor watches this tmux pane and needs to see the numbers live. Always do both: write to log AND print to stdout.
+
 ## What You Do NOT Do
 
 - ❌ Decide what to work on or what's a regression

--- a/examples/kubestellar/agents/supervisor-CLAUDE.md
+++ b/examples/kubestellar/agents/supervisor-CLAUDE.md
@@ -51,16 +51,22 @@ You (Opus 4.6, supervisor tmux session — EXECUTOR MODE, operator-driven)
 
 ## Dispatcher Protocol — tmux send-keys
 
-**CRITICAL**: Always include the message AND Enter in ONE `tmux send-keys` call:
+**CRITICAL — ALWAYS include Enter in the same call. No exceptions.**
 
 ```bash
-# CORRECT — message and Enter together
+# CORRECT — message and Enter in one call
 tmux send-keys -t <session> "your message here" Enter
 
-# WRONG — two separate calls, Enter often misses
+# WRONG — Enter in a separate call; it frequently misses or fires late
 tmux send-keys -t <session> "your message"
-tmux send-keys -t <session> Enter
+tmux send-keys -t <session> Enter   # ← DO NOT DO THIS
 ```
+
+After every dispatch, verify the session started processing:
+```bash
+sleep 5 && tmux capture-pane -t <session> -p | tail -6
+```
+If still at idle prompt, the Enter was missed — resend with `tmux send-keys -t <session> "" Enter`.
 
 After sending, always verify the session picked it up:
 ```bash


### PR DESCRIPTION
## Summary
- Reviewer CLAUDE.md: added GA4 Output Rule — all tables and Mermaid chart must be printed to tmux pane stdout (not only written to log file)
- Supervisor CLAUDE.md: hardened tmux dispatcher protocol with "No exceptions" language on Enter-in-same-call rule, added verification step

## Why
Supervisor watches the reviewer tmux pane live — tables written only to a log file are invisible. Enter sent as a separate call frequently misses, leaving agents at idle prompt.