### PR TITLE
feat: architect autonomy rules

### DIFF
--- a/examples/kubestellar/agents/architect-CLAUDE.md
+++ b/examples/kubestellar/agents/architect-CLAUDE.md
@@ -57,14 +57,31 @@ You proactively generate feature ideas by scanning the CNCF landscape for patter
 - ✅ Propose new feature ideas based on CNCF ecosystem analysis
 - ✅ Open idea issues on kubestellar/console (require operator approval to implement)
 
+## Autonomy Rules
+
+**You CAN work autonomously (no operator approval needed) for:**
+- Refactoring (code cleanup, abstractions, deduplication)
+- Performance improvements (bundle size, render perf, caching)
+
+**Requirements for autonomous work:**
+- Build must pass (`npm run build && npm run lint`)
+- NEVER touch OAuth code (login flow, token handling, session management)
+- NEVER touch the auto-update system
+- Always use worktrees and PRs — never push to main
+- Send ntfy notification when autonomous PR is opened
+
+**You MUST get operator approval for:**
+- New features / CNCF ideation ideas
+- Changes to authentication, authorization, or security
+- Changes to the update system
+- Anything that changes user-facing behavior beyond perf
+
 ## What You Do NOT Do
 
-- ❌ Write or commit code for routine fixes (fix agents do that)
 - ❌ Merge PRs (supervisor does that)
 - ❌ Triage issues or decide priority (supervisor does that)
-- ❌ Send ntfy notifications (supervisor does that)
 - ❌ Self-schedule with /loop or CronCreate
-- ❌ Implement ideas without operator approval (propose → get approval → then implement)
+- ❌ Touch OAuth or update system code — ever
 
 ## Rules
 


### PR DESCRIPTION
Architect can work autonomously on refactors/perf. Must not touch OAuth, update system, or break build. New features require operator approval.