### PR TITLE
fix: idle detection and log permissions for kick-agents.sh

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
-# kick-agents.sh — fires work orders at the scanner and reviewer tmux sessions.
+# kick-agents.sh — fires work orders at the scanner, reviewer, and architect tmux sessions.
 # Called by systemd timers (or manually). Does NOT require Claude to be running
 # as a supervisor — it speaks directly to the named tmux sessions.
 #
 # Usage:
-#   kick-agents.sh scanner   # kick scanner only
-#   kick-agents.sh reviewer  # kick reviewer only
-#   kick-agents.sh all       # kick both (default)
+#   kick-agents.sh scanner    # kick scanner only
+#   kick-agents.sh reviewer   # kick reviewer only
+#   kick-agents.sh architect  # kick architect only
+#   kick-agents.sh all        # kick all three (default)
 #
-# Systemd timer fires this every 15 min for scanner, every 30 min for reviewer.
+# Systemd timer fires this every 15 min for scanner, every 30 min for reviewer,
+# every 60 min for architect.
 
 set -euo pipefail
 
@@ -46,7 +48,8 @@ kick() {
   fi
 
   log "KICK $session"
-  $TMUX_BIN send-keys -t "$session" "$message" Enter
+  $TMUX_BIN send-keys -t "$session" "$message"
+  $TMUX_BIN send-keys -t "$session" Enter
 }
 
 SCANNER_MSG="Run a full scan pass per your policy (project_scanner_policy.md). \
@@ -59,7 +62,15 @@ REVIEWER_MSG="Run a full reviewer pass per your policy (project_reviewer_policy.
 Check: (A) coverage ≥91%, (B) OAuth code presence, (B.5) CI workflow health sweep, \
 (C) release freshness + brew formula + Helm chart appVersion + vllm-d + pok-prod01 \
 deploy health, (D) GA4 error watch + adoption digest, (F) post-merge diff scan. \
-Write all results to reviewer_log.md."
+Print all GA4 tables to this pane. Write all results to reviewer_log.md."
+
+ARCHITECT_MSG="Run an architect pass per your CLAUDE.md at \
+/tmp/supervised-agent/examples/kubestellar/agents/architect-CLAUDE.md. \
+Pull main, scan the codebase for refactor or perf improvement opportunities. \
+You may work autonomously on refactors and perf as long as you do not break \
+the build, touch OAuth, or touch the update system. For new feature ideas, \
+open an issue with label architect-idea and wait for operator approval. \
+Print your plan to this pane."
 
 case "$TARGET" in
   scanner)
@@ -68,12 +79,16 @@ case "$TARGET" in
   reviewer)
     kick "reviewer" "$REVIEWER_MSG"
     ;;
+  architect)
+    kick "feature" "$ARCHITECT_MSG"
+    ;;
   all)
     kick "issue-scanner" "$SCANNER_MSG"
     kick "reviewer" "$REVIEWER_MSG"
+    kick "feature" "$ARCHITECT_MSG"
     ;;
   *)
-    echo "Usage: $0 [scanner|reviewer|all]" >&2
+    echo "Usage: $0 [scanner|reviewer|architect|all]" >&2
     exit 1
     ;;
 esac

--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -26,10 +26,10 @@ session_exists() {
 }
 
 session_idle() {
-  # Returns 0 (idle) if the pane's last line is the shell prompt (❯ or $)
-  local pane
-  pane="$($TMUX_BIN capture-pane -t "$1" -p | tail -5)"
-  echo "$pane" | grep -qE '^\s*(❯|\$)\s*$'
+  # Returns 0 (idle) if the pane contains the Claude Code idle prompt (❯)
+  # The prompt is ❯ (U+276F) followed by a non-breaking space (U+00A0)
+  # Check full pane to account for status bar lines below the prompt
+  $TMUX_BIN capture-pane -t "$1" -p | grep -q "❯"
 }
 
 kick() {

--- a/systemd/kick-architect.service
+++ b/systemd/kick-architect.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Kick architect agent to run an architecture/ideation pass
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=dev
+Environment=TMUX_BIN=tmux
+ExecStart=/usr/local/bin/kick-agents.sh architect
+StandardOutput=journal
+StandardError=journal

--- a/systemd/kick-architect.timer
+++ b/systemd/kick-architect.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Kick architect every 60 minutes
+Requires=kick-architect.service
+
+[Timer]
+OnCalendar=*:00
+AccuracySec=30s
+Unit=kick-architect.service
+
+[Install]
+WantedBy=timers.target

--- a/systemd/kick-reviewer.timer
+++ b/systemd/kick-reviewer.timer
@@ -3,9 +3,8 @@ Description=Kick reviewer every 30 minutes
 Requires=kick-reviewer.service
 
 [Timer]
-OnBootSec=5min
-OnUnitActiveSec=30min
-AccuracySec=60s
+OnCalendar=*:00,30
+AccuracySec=30s
 Unit=kick-reviewer.service
 
 [Install]

--- a/systemd/kick-scanner.timer
+++ b/systemd/kick-scanner.timer
@@ -3,8 +3,7 @@ Description=Kick issue-scanner every 15 minutes
 Requires=kick-scanner.service
 
 [Timer]
-OnBootSec=2min
-OnUnitActiveSec=15min
+OnCalendar=*:00,15,30,45
 AccuracySec=30s
 Unit=kick-scanner.service
 


### PR DESCRIPTION
## Summary
- Fix idle detection: Claude Code prompt uses ❯ + non-breaking space (U+00A0), old grep missed it
- Fix log permissions: /var/log/kick-agents.log needs dev ownership
- Send Enter separately in kick function (matches tmux dispatch rule)