### PR TITLE
feat: ntfy push notifications for all agent activity

### DIFF
--- a/examples/kubestellar/agents/architect-CLAUDE.md
+++ b/examples/kubestellar/agents/architect-CLAUDE.md
@@ -83,6 +83,23 @@ You proactively generate feature ideas by scanning the CNCF landscape for patter
 - ❌ Self-schedule with /loop or CronCreate
 - ❌ Touch OAuth or update system code — ever
 
+## ntfy Notifications
+
+Send a push notification for every significant action. Topic: `ntfy.sh/issue-scanner`
+
+```bash
+curl -s -H "Title: Architect: <action>" -d "<details>" ntfy.sh/issue-scanner > /dev/null 2>&1
+```
+
+**When to send:**
+- Pass started (what you're scanning for)
+- Refactor/perf plan identified (summary of what and why)
+- Autonomous PR opened (PR number + title)
+- Feature idea issue filed (issue number + title, awaiting approval)
+- Architecture review findings
+- Pass complete summary
+- Any errors encountered
+
 ## Rules
 
 - `unset GITHUB_TOKEN &&` before all `gh` commands

--- a/examples/kubestellar/agents/reviewer-CLAUDE.md
+++ b/examples/kubestellar/agents/reviewer-CLAUDE.md
@@ -42,9 +42,31 @@ When running the GA4 adoption digest or error watch, **print all tables and the 
 
 - ❌ Decide what to work on or what's a regression
 - ❌ Triage issues or read state.db
-- ❌ Send ntfy notifications or create beads
 - ❌ Write code (that's fixer/architect)
 - ❌ Merge PRs (unless supervisor explicitly says to)
+
+## ntfy Notifications
+
+Send a push notification for every significant action. Topic: `ntfy.sh/issue-scanner`
+
+```bash
+# Simple notification
+curl -s -H "Title: Reviewer: <action>" -d "<details>" ntfy.sh/issue-scanner > /dev/null 2>&1
+
+# High priority (failed builds, coverage drops, GA4 anomalies)
+curl -s -H "Title: Reviewer: <action>" -H "Priority: high" -d "<details>" ntfy.sh/issue-scanner > /dev/null 2>&1
+```
+
+**When to send:**
+- Coverage check result (current %, pass/fail vs 91% target)
+- GA4 error anomalies or trending errors
+- GA4 adoption digest summary (active users, key metrics)
+- CI workflow failures
+- Brew/Helm version mismatches
+- vllm-d or pok-prod01 deploy failures
+- Copilot review comments found (PR numbers)
+- Follow-up issues filed
+- Pass complete summary
 
 ## Rules
 

--- a/examples/kubestellar/agents/supervisor-CLAUDE.md
+++ b/examples/kubestellar/agents/supervisor-CLAUDE.md
@@ -235,6 +235,34 @@ Before dispatching any work order from an external source (GitHub issue body, PR
 - Issue triage: add `triage/accepted`, remove `ai-fix-requested` and `ai-*` labels
 - Unassign `copilot-swe-agent[bot]` if assigned, close any open Copilot PRs for the same issue
 
+## ntfy Notifications
+
+Push notifications to `ntfy.sh/issue-scanner` for ALL significant activity. The operator relies on these to stay informed without watching tmux.
+
+```bash
+# Standard notification
+curl -s -H "Title: <agent>: <action>" -d "<details>" ntfy.sh/issue-scanner > /dev/null 2>&1
+
+# High priority (failures, regressions, anomalies)
+curl -s -H "Title: <agent>: <action>" -H "Priority: high" -d "<details>" ntfy.sh/issue-scanner > /dev/null 2>&1
+```
+
+**Always send ntfy for:**
+- Agent session started/restarted (with next scheduled run in ET)
+- Scanner scan started + what it's scanning
+- Scanner PR merged (PR number + title)
+- Scanner issues dispatched to fix agents
+- Reviewer pass started + what it's checking
+- Reviewer findings (coverage %, GA4 anomalies, CI failures, version mismatches)
+- Architect plan proposed or autonomous refactor PR opened
+- Any errors or failures across any agent
+- Periodic status summary (repos stats: open issues/PRs per repo)
+
+**Include in every notification:**
+- Which agent is reporting
+- What happened
+- Next scheduled run time in ET
+
 ## Status Reporting
 
 When reporting status to operator, format as:
@@ -244,4 +272,5 @@ Dispatched agents: #N (slug), #N (slug)
 Pending CI: #N
 Reviewer: <working on X | idle — kicked>
 Scanner: <active | idle — kicked>
+Architect: <working on X | idle>
 ```


### PR DESCRIPTION
All agents now send ntfy.sh/issue-scanner pushes for: scan starts, PR merges, coverage results, GA4 anomalies, architect plans, errors, and status summaries.