### PR TITLE
fix: per-agent beads, correct models, supervisor workdir + policy wiring

### DIFF
--- a/bin/hive.sh
+++ b/bin/hive.sh
@@ -57,8 +57,12 @@ load_conf() {
   SLACK_WEBHOOK="${SLACK_WEBHOOK:-}"
   DISCORD_WEBHOOK="${DISCORD_WEBHOOK:-}"
   SUPERVISOR_CLI="${SUPERVISOR_CLI:-copilot}"
-  SUPERVISOR_WORKDIR="${SUPERVISOR_WORKDIR:-/home/dev/kubestellar-console}"
-  BEADS_SUPERVISOR_DIR="${BEADS_SUPERVISOR_DIR:-/home/dev/kubestellar-console}"
+  SUPERVISOR_WORKDIR="${SUPERVISOR_WORKDIR:-/home/dev/hive-supervisor}"
+  BEADS_SUPERVISOR_DIR="${BEADS_SUPERVISOR_DIR:-/home/dev/supervisor-beads}"
+  BEADS_SCANNER_DIR="${BEADS_SCANNER_DIR:-/home/dev/scanner-beads}"
+  BEADS_REVIEWER_DIR="${BEADS_REVIEWER_DIR:-/home/dev/reviewer-beads}"
+  BEADS_FEATURE_DIR="${BEADS_FEATURE_DIR:-/home/dev/feature-beads}"
+  BEADS_OUTREACH_DIR="${BEADS_OUTREACH_DIR:-/home/dev/outreach-beads}"
   BEADS_WORKER_DIR="${BEADS_WORKER_DIR:-/home/dev/scanner-beads}"
   AGENT_USER="${AGENT_USER:-dev}"
   HIVE_BACKENDS="${HIVE_BACKENDS:-copilot}"           # space-separated: copilot claude gemini goose
@@ -395,17 +399,35 @@ kick_agents() {
   hdr "Kicking agents"
   sleep 4  # let sessions initialise
 
-  local msg="STARTUP: read your beads (cd $BEADS_WORKER_DIR && bd list --json). Resume any in_progress item. For new work: bd ready --json. Read your policy file from memory. Report status."
+  # Per-agent beads dirs — each agent reads and writes only its own ledger.
+  declare -A AGENT_BEADS_DIR
+  AGENT_BEADS_DIR["issue-scanner"]="${BEADS_SCANNER_DIR:-/home/${AGENT_USER:-dev}/scanner-beads}"
+  AGENT_BEADS_DIR["reviewer"]="${BEADS_REVIEWER_DIR:-/home/${AGENT_USER:-dev}/reviewer-beads}"
+  AGENT_BEADS_DIR["feature"]="${BEADS_FEATURE_DIR:-/home/${AGENT_USER:-dev}/feature-beads}"
+  AGENT_BEADS_DIR["outreach"]="${BEADS_OUTREACH_DIR:-/home/${AGENT_USER:-dev}/outreach-beads}"
+
+  # Expected model substring — must be visible in pane before kick is safe to send.
+  # Copilot shows "claude-opus-4.6" in bottom-right; Claude Code shows "Opus 4.6".
+  local expected_model="4.6"
 
   for session in issue-scanner reviewer feature outreach; do
-    if tmux has-session -t "$session" 2>/dev/null; then
-      tmux send-keys -t "$session" "$msg" 2>/dev/null || true
-      sleep 0.3
-      tmux send-keys -t "$session" Enter 2>/dev/null || true
-      ok "$session kicked"
-    else
+    if ! tmux has-session -t "$session" 2>/dev/null; then
       warn "$session session not ready yet — governor will kick on next cycle"
+      continue
     fi
+    # Verify model before sending work — skip if wrong model is running
+    local pane
+    pane=$(tmux capture-pane -t "$session" -p 2>/dev/null || true)
+    if ! echo "$pane" | grep -qF "$expected_model"; then
+      warn "$session: expected model $expected_model not visible in pane — skipping kick (check AGENT_LAUNCH_CMD)"
+      continue
+    fi
+    local bdir="${AGENT_BEADS_DIR[$session]}"
+    local msg="STARTUP: read your beads (cd ${bdir} && bd list --json). Resume any in_progress item. For new work: bd ready --json. Read your policy file from memory. Report status."
+    tmux send-keys -t "$session" "$msg" 2>/dev/null || true
+    sleep 0.3
+    tmux send-keys -t "$session" Enter 2>/dev/null || true
+    ok "$session kicked (model $expected_model confirmed, beads: $bdir)"
   done
 }
 
@@ -425,8 +447,8 @@ start_supervisor() {
 
   local launch_cmd
   case "$cli" in
-    copilot) launch_cmd="/usr/bin/copilot --allow-all" ;;
-    claude)  launch_cmd="/usr/bin/claude --dangerously-skip-permissions" ;;
+    copilot) launch_cmd="/usr/bin/copilot --allow-all --model claude-opus-4.6" ;;
+    claude)  launch_cmd="/usr/bin/claude --dangerously-skip-permissions --model opus-4-6" ;;
     *)       die "Unknown CLI: $cli. Use --copilot or --claude" ;;
   esac
 
@@ -864,7 +886,7 @@ cmd_switch() {
   local launch_cmd
   case "$backend" in
     copilot) launch_cmd="/usr/bin/copilot --allow-all --model claude-opus-4.6" ;;
-    claude)  launch_cmd="/usr/bin/claude --dangerously-skip-permissions --model claude-opus-4.6" ;;
+    claude)  launch_cmd="/usr/bin/claude --dangerously-skip-permissions --model opus-4-6" ;;
     gemini)  launch_cmd="/usr/bin/gemini --yolo" ;;
     goose)   launch_cmd="/usr/bin/goose --no-confirm" ;;
     *) die "Unknown backend: $backend (valid: copilot claude gemini goose)" ;;

--- a/config/agent.env.example
+++ b/config/agent.env.example
@@ -22,7 +22,11 @@ AGENT_WORKDIR=/home/dev/my-project
 # For Claude Code, do NOT pass -p; it exits after one reply.
 # IMPORTANT: quote multi-word values. install.sh sources this file with
 # `set -a; . "$ENV_FILE"` so any unquoted flags get parsed as commands.
-AGENT_LAUNCH_CMD="/usr/bin/claude --dangerously-skip-permissions --model claude-opus-4.6"
+#
+# GitHub Copilot CLI (default backend):
+AGENT_LAUNCH_CMD="/usr/bin/copilot --allow-all --model claude-opus-4.6"
+# Claude Code (alternative backend — uncomment and comment out the line above):
+# AGENT_LAUNCH_CMD="/usr/bin/claude --dangerously-skip-permissions --model claude-opus-4.6"
 
 # The text sent to the agent after its TUI is ready. Two patterns are common:
 #
@@ -47,9 +51,10 @@ AGENT_LOG_FILE=/home/dev/.local/state/hive/heartbeat.log
 AGENT_SESSION_NAME=hive
 
 # String the supervisor waits for in the pane before sending AGENT_LOOP_PROMPT.
-# For Claude Code v2.x this is the footer hint "bypass permissions on".
-# If your agent's footer changes, update this or the /loop will never fire.
-AGENT_READY_MARKER=bypass permissions on
+# If your agent's footer changes, update this or the loop prompt will never fire.
+# GitHub Copilot CLI: "Environment loaded"
+# Claude Code v2.x: "bypass permissions on"
+AGENT_READY_MARKER="Environment loaded"
 
 # Seconds to wait for the ready marker before giving up (supervisor retries
 # on the next poll tick).

--- a/systemd/hive.service
+++ b/systemd/hive.service
@@ -7,7 +7,7 @@ Wants=network-online.target
 Type=simple
 User=__AGENT_USER__
 Group=__AGENT_USER__
-EnvironmentFile=/etc/hive/agent.env
+EnvironmentFile=/etc/hive/supervisor.env
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ExecStart=/usr/local/bin/agent-supervisor.sh
 Restart=always


### PR DESCRIPTION
## Summary

- **hive.service** now loads `supervisor.env` instead of `agent.env`
- **Supervisor workdir**: `/home/dev/hive-supervisor` with its own `.github/copilot-instructions.md` (from `supervisor-CLAUDE.md`)
- **Per-agent beads**: each agent reads/writes only its own dir (`supervisor-beads`, `scanner-beads`, `reviewer-beads`, `feature-beads`, `outreach-beads`) — never shared
- **kick_agents()**: verifies model `4.6` is visible in pane before sending kick; skips if wrong model detected
- **kick_agents()**: sends each agent to its own beads dir explicitly
- **AGENT_LOOP_PROMPT**: on every startup, supervisor pulls hive repo + refreshes `supervisor-CLAUDE.md` as its copilot-instructions
- **Model names**: Copilot → `claude-opus-4.6`, Claude Code → `opus-4-6` (new CLI flag name)
- **config/agent.env.example**: shows Copilot as default backend, Claude Code as commented alternative

## Why

Supervisor was getting the scanner's loop prompt (wrong policy), running in kubestellar-console instead of its own workdir, and sharing beads across all agents. Model 4.7 was being used instead of 4.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)