### PR TITLE
dashboard: push live summaries via SSE instead of one-shot fetch

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -316,7 +316,6 @@
     }
 
     let currentAgentMetrics = {};
-    let currentSummaries = {};
 
     function agentIndicators(name) {
       const m = currentAgentMetrics[name];
@@ -416,16 +415,8 @@
         const needsLogin = a.needsLogin === true;
         const cls = needsLogin ? 'needs-login' : (a.state === 'stopped' ? 'stopped' : a.busy);
         const dotCls = a.state === 'stopped' ? 'stopped' : 'running';
-        // Use comprehensive summary instead of doing spinner
-        const summary = currentSummaries[a.name] || {};
-        let summaryEl = '';
-        if (summary.task) {
-          const parts = [];
-          if (summary.task) parts.push(summary.task);
-          if (summary.progress) parts.push(`▫ ${summary.progress}`);
-          if (summary.results) parts.push(`✓ ${summary.results}`);
-          summaryEl = parts.length > 0 ? `<div class="doing">${esc(parts.join('\n'))}</div>` : '';
-        }
+        // liveSummary is pushed via SSE every 5s — no separate fetch needed
+        const summaryEl = a.liveSummary ? `<div class="doing">${esc(a.liveSummary)}</div>` : '';
         const indEl = agentIndicators(a.name);
         return `<div class="agent-card ${cls}">
           <div class="agent-name"><span class="dot ${dotCls}"></span>${a.name}</div>
@@ -447,7 +438,6 @@
             </select>
             <select class="btn backend-select" onchange="switchModel('${a.name}', this.value); this.selectedIndex=0">
               <option value="" disabled selected>model ▾</option>
-              <option value="claude-opus-4-7">Opus 4.7</option>
               <option value="claude-opus-4-6">Opus 4.6</option>
               <option value="claude-sonnet-4-6">Sonnet 4.6</option>
               <option value="claude-sonnet-4-5">Sonnet 4.5</option>
@@ -577,12 +567,7 @@
       renderGovernor(data.governor || {});
       renderRepos(data.repos || []);
       renderBeads(data.beads || {});
-      // Fetch comprehensive summaries
-      fetch('/api/summaries').then(r => r.json()).then(d => {
-        currentSummaries = d.summaries || {};
-        // Re-render agents with updated summaries
-        renderAgents(data.agents || []);
-      }).catch(() => {});
+      // summaries are merged into a.liveSummary server-side and pushed via SSE — no extra fetch
     }
 
     function esc(s) {

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -17,6 +17,7 @@ let lastFetch = 0;
 let ciPassRate = 0;
 let healthChecks = {};
 let agentMetrics = {};
+let summariesCache = {};
 
 // Fetch CI pass rate + binary health checks every 60s
 function fetchHealthChecks() {
@@ -43,6 +44,20 @@ function fetchAgentMetrics() {
 }
 fetchAgentMetrics();
 setInterval(fetchAgentMetrics, 300000);  // every 5 min (REST API)
+
+// Fetch agent summaries from ~/.hive/<agent>_status.txt on every status refresh cycle
+function fetchSummaries() {
+  execFile(path.join(__dirname, 'agent-summaries.sh'), [], { timeout: 10000 }, (err, stdout) => {
+    if (!err && stdout.trim()) {
+      try {
+        const d = JSON.parse(stdout.trim());
+        summariesCache = d.summaries || {};
+      } catch (_) {}
+    }
+  });
+}
+fetchSummaries();
+setInterval(fetchSummaries, REFRESH_MS);
 
 // Historical data — keep last 2 hours of snapshots (5s intervals = ~1440 points)
 const MAX_HISTORY = 1440;
@@ -98,6 +113,19 @@ function fetchStatus() {
         statusCache.health = healthChecks;
         statusCache.ciPassRate = ciPassRate;
         statusCache.agentMetrics = agentMetrics;
+        // Merge live summaries into each agent: prefer live pane `doing`, fall back to status file
+        statusCache.summaries = summariesCache;
+        for (const a of (statusCache.agents || [])) {
+          const s = summariesCache[a.name] || {};
+          // Build a merged summary string: live doing takes priority; file fields fill the rest
+          const parts = [];
+          if (a.doing) parts.push(a.doing);
+          if (s.task && s.task !== a.doing) parts.push(s.task);
+          if (s.progress) parts.push(`▫ ${s.progress}`);
+          if (s.results) parts.push(`✓ ${s.results}`);
+          a.liveSummary = parts.join('\n');
+          a.summaryUpdated = s.updated || null;
+        }
         // Record snapshot for sparklines
         const snap = {
           t: lastFetch,


### PR DESCRIPTION
## Summary
- `server.js` polls `agent-summaries.sh` every 5s and merges `TASK/PROGRESS/RESULTS` with the live pane `doing` field into `a.liveSummary` on each agent object in the SSE payload
- `index.html` now reads `a.liveSummary` directly from the SSE stream — summaries update every ~5s without a separate network request
- Removes the stale one-shot `fetch('/api/summaries')` that caused the dashboard to show outdated summaries after page load
- Removes unused `currentSummaries` variable
- Drops `Opus 4.7` from the model switcher dropdown (we only use 4.6 and below)

## Test plan
- [ ] Open dashboard, attach an agent, watch the summary block update within 5s of the agent writing to its `_status.txt` file
- [ ] Verify no `fetch('/api/summaries')` call appears in browser DevTools network tab
- [ ] Confirm model switcher no longer shows Opus 4.7 option

🤖 Generated with [Claude Code](https://claude.com/claude-code)