### PR TITLE
fix: unbound needs_login crash in hive status --json + reviewer coverage policy

### DIFF
--- a/bin/hive.sh
+++ b/bin/hive.sh
@@ -659,9 +659,9 @@ cmd_status_json() {
   local agents_json="["
   for i in "${!SESSIONS[@]}"; do
     local s="${SESSIONS[$i]}" label="${LABELS[$i]}"
-    local cli cadence state busy doing model
+    local cli cadence state busy doing model needs_login
     cadence=$(cat "${GOV_STATE}/cadence_${label}" 2>/dev/null || echo "?")
-    state="stopped"; cli="?"; busy="idle"; doing=""; model="?"
+    state="stopped"; cli="?"; busy="idle"; doing=""; model="?"; needs_login="false"
 
     if tmux has-session -t "$s" 2>/dev/null; then
       state="running"
@@ -682,7 +682,6 @@ cmd_status_json() {
       model=${model:-"?"}
       # Detect login required — only check footer (last 5 lines) to avoid
       # false positives from pane content mentioning "not logged in"
-      local needs_login="false"
       if echo "$pane_tail" | grep -qE "Not logged in|Run /login|Please run /login"; then
         needs_login="true"
       fi

--- a/examples/kubestellar/agents/reviewer-CLAUDE.md
+++ b/examples/kubestellar/agents/reviewer-CLAUDE.md
@@ -88,6 +88,34 @@ unset GITHUB_TOKEN && gh issue create --repo kubestellar/console \
 
 For straightforward instrumentation gaps (adding a GA4 event, custom dimension, or error context), you MAY also spawn a background fix agent to implement the fix immediately — don't just file the issue and wait. Open the issue first, then dispatch the agent referencing it.
 
+## Code Coverage — maintain ≥91%
+
+**Every pass**, check current test coverage and actively work to raise it if below target.
+
+```bash
+cd ~/.kubestellar-agents/reviewer/console
+git checkout main && git pull --rebase origin main
+# Run tests with coverage
+npm run test:coverage 2>&1 | tail -20
+```
+
+**If coverage < 91%:**
+1. Identify the files with the lowest coverage (look for `Uncovered Line #s` in jest output)
+2. For each uncovered file, dispatch a fix agent to add tests:
+   ```bash
+   # Example: file src/components/SomeCard.tsx has 60% coverage
+   # Dispatch: "Add unit tests for src/components/SomeCard.tsx — coverage is 60%, target 91%"
+   ```
+3. File a bead if coverage has been below 91% for >2 consecutive passes:
+   ```bash
+   cd ~/reviewer-beads && bd add "coverage-gap" "Test coverage below 91% for <N> consecutive passes. Current: <X>%. Files needing tests: <list>"
+   ```
+4. Send high-priority ntfy: `"Coverage <X>% — below 91% target. Dispatching test additions for: <files>"`
+
+**If coverage ≥ 91%:** Send simple ntfy: `"Coverage <X>% ✓"`. No action needed.
+
+**Do NOT skip low coverage silently.** The target is ≥91%. If agents before you raised it, acknowledge the improvement in ntfy.
+
 ## Brew Formula Check — every pass
 
 Check `kubestellar/homebrew-tap` for staleness every pass:


### PR DESCRIPTION
## Summary
- **`bin/hive.sh`**: `needs_login` was declared `local` inside the `if tmux has-session` block, making it unbound when any agent session is stopped. `hive status --json` crashed with `needs_login: unbound variable` on every call, causing the dashboard to always return stale data and `liveSummary` to never populate. Fix: initialize `needs_login="false"` alongside the other per-agent locals before the `if` block.
- **`reviewer-CLAUDE.md`**: Added an active code coverage section — reviewer must check coverage every pass, dispatch fix agents if <91%, and file a bead after 2 consecutive failing passes. Previously the policy only mentioned reporting the number.

## Test plan
- [ ] `hive status --json` succeeds even when one or more agent sessions are stopped
- [ ] Dashboard `liveSummary` fields populate on the next SSE tick after the fix is deployed
- [ ] Reviewer agent actively dispatches test-addition fix agents when coverage is below 91%

🤖 Generated with [Claude Code](https://claude.com/claude-code)