### PR TITLE
dashboard: remove duplicate status lines + scanner issue→PR pairs

### DIFF
--- a/dashboard/agent-metrics.sh
+++ b/dashboard/agent-metrics.sh
@@ -16,8 +16,23 @@ architect_model=$(echo "$agent_status" | jq -r '.agents[] | select(.name == "arc
 outreach_doing=$(echo "$agent_status" | jq -r '.agents[] | select(.name == "outreach") | .doing' 2>/dev/null || echo "")
 outreach_model=$(echo "$agent_status" | jq -r '.agents[] | select(.name == "outreach") | .model' 2>/dev/null || echo "?")
 
+# ── Scanner: active issue→PR pairs from open AI-authored PRs ──
+# Reads open PRs by clubanderson that reference an issue number in title/body
+scanner_pairs_json="[]"
+if command -v gh &>/dev/null; then
+  raw_prs=$(gh api 'repos/kubestellar/console/pulls?state=open&per_page=50' \
+    --jq '[.[] | select(.user.login == "clubanderson") | {pr: .number, title: .title, body: (.body // "")}]' 2>/dev/null || echo "[]")
+  scanner_pairs_json=$(echo "$raw_prs" | jq '[
+    .[] |
+    . as $p |
+    # extract first "Fixes #NNN" or "Closes #NNN" issue ref
+    ($p.body | capture("(?i)(fixes|closes|resolves) #(?P<issue>[0-9]+)") // null) as $ref |
+    if $ref then { issue: ($ref.issue | tonumber), pr: $p.pr } else empty end
+  ]' 2>/dev/null || echo "[]")
+fi
+
 # Build agent JSON with live summaries and model
-scanner_json=$(jq -n --arg doing "$scanner_doing" --arg model "$scanner_model" '{doing: $doing, model: $model}')
+scanner_json=$(jq -n --arg doing "$scanner_doing" --arg model "$scanner_model" --argjson pairs "$scanner_pairs_json" '{doing: $doing, model: $model, pairs: $pairs}')
 reviewer_json=$(jq -n --arg doing "$reviewer_doing" --arg model "$reviewer_model" '{doing: $doing, model: $model}')
 architect_json=$(jq -n --arg doing "$architect_doing" --arg model "$architect_model" '{doing: $doing, model: $model}')
 outreach_json=$(jq -n --arg doing "$outreach_doing" --arg model "$outreach_model" '{doing: $doing, model: $model}')

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -322,21 +322,17 @@
       if (!m) return '';
 
       if (name === 'issue-scanner' || name === 'scanner') {
-        const doing = m.doing || '';
         const pairs = m.pairs || [];
-        const doingHtml = doing ? `<div class="ind-summary">${esc(doing)}</div>` : '';
-        if (pairs.length === 0) return doingHtml + '<div class="agent-indicators"><span class="ind-empty">no active fixes</span></div>';
+        if (pairs.length === 0) return '<div class="agent-indicators"><span class="ind-empty">no active fixes</span></div>';
         const rows = pairs.map(p => `<div class="ind-pair">
           <a class="ind-tag ind-issue" href="https://github.com/kubestellar/console/issues/${p.issue}" target="_blank">⊙ #${p.issue}</a>
           <span class="ind-arrow">→</span>
           <a class="ind-tag ind-pr" href="https://github.com/kubestellar/console/pull/${p.pr}" target="_blank">⎇ #${p.pr}</a>
         </div>`).join('');
-        return doingHtml + `<div class="agent-indicators"><span class="ind-label">Fixes (${pairs.length}):</span>${rows}</div>`;
+        return `<div class="agent-indicators"><span class="ind-label">Fixes (${pairs.length}):</span>${rows}</div>`;
       }
 
       if (name === 'reviewer') {
-        const doing = m.doing || '';
-        const doingHtml = doing ? `<div class="ind-summary">${esc(doing)}</div>` : '';
         const h = window._healthData || {};
         const groups = [
           { label: 'Artifacts', items: [
@@ -366,7 +362,7 @@
           const dotCls = v === 1 ? 'ok' : v === 0 ? 'fail' : 'unknown';
           return `<span class="ind-dot-item"><span class="health-dot ${dotCls}"></span><span class="ind-dlabel">${d.label}</span></span>`;
         };
-        return doingHtml + `<div class="agent-indicators">${groups.map(g =>
+        return `<div class="agent-indicators">${groups.map(g =>
           `<div class="ind-group"><span class="ind-group-label">${g.label}</span><div class="ind-dots">${g.items.map(renderItem).join('')}</div></div>`
         ).join('')}</div>`;
       }


### PR DESCRIPTION
## Summary
- Strip doingHtml from agentIndicators() for all remaining agents (scanner, reviewer) — status display is owned by renderAgents via liveSummary, not the indicator block. Every agent now shows exactly one status line.
- agent-metrics.sh: populate scanner.pairs[] from open PRs authored by clubanderson on kubestellar/console that contain Fixes/Closes/Resolves #NNN in their body. The scanner card indicator block now shows live issue→PR links.

Generated with Claude Code