### PR TITLE
fix: scanner-supervisor claude fallback model flag + jq pairs extraction

### DIFF
--- a/bin/scanner-supervisor.sh
+++ b/bin/scanner-supervisor.sh
@@ -17,7 +17,7 @@ LOOP_PROMPT="${AGENT_LOOP_PROMPT:-You are the KubeStellar Scanner in EXECUTOR MO
 
 # ─── CLI detection & failover ───────────────────────────────────────────────
 
-CLAUDE_CMD="/usr/bin/claude --dangerously-skip-permissions --model claude-opus-4.6"
+CLAUDE_CMD="/usr/bin/claude --dangerously-skip-permissions --model claude-opus-4-6"
 COPILOT_CMD="/usr/bin/copilot --allow-all"
 ACTIVE_CLI="${AGENT_CLI:-claude}"
 

--- a/dashboard/agent-metrics.sh
+++ b/dashboard/agent-metrics.sh
@@ -25,9 +25,9 @@ if command -v gh &>/dev/null; then
   scanner_pairs_json=$(echo "$raw_prs" | jq '[
     .[] |
     . as $p |
-    # extract first "Fixes #NNN" or "Closes #NNN" issue ref
-    ($p.body | capture("(?i)(fixes|closes|resolves) #(?P<issue>[0-9]+)") // null) as $ref |
-    if $ref then { issue: ($ref.issue | tonumber), pr: $p.pr } else empty end
+    # extract first "Fixes/Closes/Resolves #NNN" issue ref using match()
+    ($p.body | match("(?i)(fixes|closes|resolves) #([0-9]+)"; "g") // null) as $m |
+    if $m then { issue: ($m.captures[1].string | tonumber), pr: $p.pr } else empty end
   ]' 2>/dev/null || echo "[]")
 fi
 


### PR DESCRIPTION
- scanner-supervisor.sh: claude fallback --model claude-opus-4.6 → claude-opus-4-6 (dot notation rejected by Claude Code CLI; caused model error on rate-limit failover)
- agent-metrics.sh: switch from jq capture() to match() for issue ref extraction (jq 1.7 lacks named capture group support)