### PR TITLE
dashboard: governor cadence matrix + mandatory agent status reporting

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -58,6 +58,9 @@
     .value.copilot { color: var(--cyan); }
     .value.claude { color: var(--purple); }
     .doing { font-size: 0.75rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: pre-line; line-height: 1.5; min-height: 3.4em; }
+    .summary-age { display: inline-block; font-size: 0.6rem; font-style: normal; border-radius: 3px; padding: 1px 5px; margin-right: 5px; vertical-align: middle; white-space: nowrap; }
+    .summary-age.age-recent { background: rgba(210,153,34,0.15); color: #d29922; border: 1px solid rgba(210,153,34,0.3); }
+    .summary-age.age-stale  { background: rgba(248,81,73,0.15);  color: #f85149; border: 1px solid rgba(248,81,73,0.3); }
     /* Agent metric gauges — removed, replaced by health panel */
     .agent-actions { margin-top: 10px; display: flex; gap: 6px; }
 
@@ -429,7 +432,20 @@
         const cls = needsLogin ? 'needs-login' : (a.state === 'stopped' ? 'stopped' : a.busy);
         const dotCls = a.state === 'stopped' ? 'stopped' : 'running';
         // liveSummary is pushed via SSE every 5s — no separate fetch needed
-        const summaryEl = a.liveSummary ? `<div class="doing">${esc(a.liveSummary)}</div>` : '';
+        let summaryEl = '';
+        if (a.liveSummary) {
+          let ageBadge = '';
+          if (!a.doing && a.summaryUpdated) {
+            const ageMs = Date.now() - new Date(a.summaryUpdated).getTime();
+            const ageMin = Math.floor(ageMs / 60000);
+            if (ageMin >= 5) {
+              const ageStr = ageMin >= 60 ? `${Math.floor(ageMin/60)}h ${ageMin%60}m ago` : `${ageMin}m ago`;
+              const ageCls = ageMin >= 120 ? 'age-stale' : 'age-recent';
+              ageBadge = `<span class="summary-age ${ageCls}">${ageStr}</span>`;
+            }
+          }
+          summaryEl = `<div class="doing">${ageBadge}${esc(a.liveSummary)}</div>`;
+        }
         const indEl = agentIndicators(a.name);
         return `<div class="agent-card ${cls}">
           <div class="agent-name"><span class="dot ${dotCls}"></span>${a.name}</div>

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -567,7 +567,7 @@
 
     function renderCadenceMatrix(matrix, currentMode, modes) {
       if (!matrix || !matrix.length) return '';
-      const agentOrder = ['scanner', 'reviewer', 'architect', 'outreach', 'supervisor'];
+      const agentOrder = ['supervisor', 'scanner', 'reviewer', 'architect', 'outreach'];
       const rows = agentOrder.map(aname => {
         const row = matrix.find(r => r.agent === aname);
         if (!row) return '';

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>🐝 Hive Dashboard</title>
+  <title>🐝 KubeStellar Hive Dashboard</title>
   <style>
     :root {
       --bg: #0d1117; --surface: #161b22; --border: #30363d;
@@ -18,7 +18,7 @@
       padding: 24px; min-height: 100vh;
     }
     h1 { font-size: 1.4rem; margin-bottom: 20px; display: flex; align-items: center; }
-    h1 span.bee { font-size: 1.6rem; }
+    h1 span.bee { font-size: 1.6rem; margin-right: 8px; }
     .timestamp { color: var(--muted); font-size: 0.8rem; margin-left: 12px; }
     .header-spacer { flex: 1; }
     .widget-dl {
@@ -271,7 +271,7 @@
     <span class="dot-live">●</span> live
   </div>
 
-  <h1><span class="bee">🐝</span> Hive Dashboard <span class="timestamp" id="ts"></span>
+  <h1><span class="bee">🐝</span> KubeStellar Hive Dashboard <span class="timestamp" id="ts"></span>
     <a href="/api/widget" class="widget-dl" title="Download Übersicht widget">⬇ Widget</a>
   </h1>
 
@@ -507,8 +507,8 @@
       const modeColor = modeColors[gov.mode] || '#8b949e';
 
       // Timeline strip from history
-      const modes = historyData.map(s => s.govMode || 'unknown');
-      const ticks = modes.map(m => `<div class="tick tick-${m}"></div>`).join('');
+      const historyModes = historyData.map(s => s.govMode || 'unknown');
+      const ticks = historyModes.map(m => `<div class="tick tick-${m}"></div>`).join('');
       const firstTime = historyData.length > 0 ? new Date(historyData[0].t).toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'}) : '';
       const lastTime = historyData.length > 0 ? new Date(historyData[historyData.length-1].t).toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'}) : '';
 

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -190,6 +190,27 @@
     .tl-busy { color: #d29922; }
     .tl-surge { color: #f85149; }
 
+    /* Governor cadence matrix table */
+    .gov-matrix { margin-top: 14px; width: 100%; border-collapse: collapse; font-size: 0.72rem; }
+    .gov-matrix th { color: var(--muted); font-weight: 600; padding: 3px 8px; text-align: center; border-bottom: 1px solid var(--border); }
+    .gov-matrix th.mode-active { border-radius: 4px 4px 0 0; padding: 4px 10px; font-weight: 700; }
+    .gov-matrix th.mode-idle  { color: #238636; }
+    .gov-matrix th.mode-quiet { color: #1f6feb; }
+    .gov-matrix th.mode-busy  { color: #d29922; }
+    .gov-matrix th.mode-surge { color: #f85149; }
+    .gov-matrix th.mode-active.mode-idle  { background: rgba(35,134,54,0.15); }
+    .gov-matrix th.mode-active.mode-quiet { background: rgba(31,111,235,0.15); }
+    .gov-matrix th.mode-active.mode-busy  { background: rgba(210,153,34,0.15); }
+    .gov-matrix th.mode-active.mode-surge { background: rgba(248,81,73,0.15); }
+    .gov-matrix td { padding: 3px 8px; text-align: center; color: var(--muted); border-bottom: 1px solid rgba(48,54,61,0.5); }
+    .gov-matrix td:first-child { text-align: left; color: var(--text); font-weight: 600; min-width: 72px; }
+    .gov-matrix td.col-active { font-weight: 700; color: var(--text); }
+    .gov-matrix td.col-active.mode-idle  { background: rgba(35,134,54,0.08); color: #3fb950; }
+    .gov-matrix td.col-active.mode-quiet { background: rgba(31,111,235,0.08); color: #58a6ff; }
+    .gov-matrix td.col-active.mode-busy  { background: rgba(210,153,34,0.08); color: #d29922; }
+    .gov-matrix td.col-active.mode-surge { background: rgba(248,81,73,0.08); color: #f85149; }
+    .gov-matrix td.paused { color: #484f58; font-style: italic; }
+
     /* Timeline strip */
     .gov-timeline { margin-top: 10px; }
     .gov-timeline-label { display: flex; justify-content: space-between; font-size: 0.6rem; color: var(--muted); margin-bottom: 2px; }
@@ -468,7 +489,7 @@
       }).join('');
     }
 
-    function renderGovernor(gov) {
+    function renderGovernor(gov, cadenceMatrix) {
       const el = document.getElementById('governor');
       const cls = gov.active ? 'active' : 'dead';
       el.className = `governor ${cls}`;
@@ -476,6 +497,8 @@
       const prsSpark = sparkSvg(getHistorySeries('govPrs'), '#bc8cff');
       const totalSpark = sparkSvg(getHistorySeries('govTotal'), '#3fb950');
       const total = (gov.issues || 0) + (gov.prs || 0);
+      const currentMode = gov.mode || 'idle';
+      const modes = ['idle', 'quiet', 'busy', 'surge'];
 
       // Gauge bar — thresholds: idle≤2, quiet≤10, busy≤20, surge>20
       const maxQ = 30;
@@ -522,7 +545,35 @@
             <span class="tl-busy">busy</span>
             <span class="tl-surge">surge</span>
           </div>
-        </div>`;
+        </div>
+        ${renderCadenceMatrix(cadenceMatrix, currentMode, modes)}`;
+    }
+
+    function renderCadenceMatrix(matrix, currentMode, modes) {
+      if (!matrix || !matrix.length) return '';
+      const agentOrder = ['scanner', 'reviewer', 'architect', 'outreach', 'supervisor'];
+      const rows = agentOrder.map(aname => {
+        const row = matrix.find(r => r.agent === aname);
+        if (!row) return '';
+        const cells = modes.map(m => {
+          const val = row[m] || '?';
+          const isActive = m === currentMode;
+          const isPaused = val === 'paused';
+          const colCls = isActive ? `col-active mode-${m}` : '';
+          const pausedCls = isPaused ? ' paused' : '';
+          return `<td class="${colCls}${pausedCls}">${isPaused ? '—' : val}</td>`;
+        }).join('');
+        return `<tr><td>${aname}</td>${cells}</tr>`;
+      }).join('');
+      const headers = modes.map(m => {
+        const isActive = m === currentMode;
+        const cls = `mode-${m}${isActive ? ' mode-active' : ''}`;
+        return `<th class="${cls}">${m}${isActive ? ' ◀' : ''}</th>`;
+      }).join('');
+      return `<table class="gov-matrix">
+        <thead><tr><th></th>${headers}</tr></thead>
+        <tbody>${rows}</tbody>
+      </table>`;
     }
 
     function renderRepos(repos) {
@@ -556,7 +607,7 @@
       currentAgentMetrics = data.agentMetrics || {};
       window._healthData = data.health || {};
       renderAgents(data.agents || []);
-      renderGovernor(data.governor || {});
+      renderGovernor(data.governor || {}, data.cadenceMatrix || []);
       renderRepos(data.repos || []);
       renderBeads(data.beads || {});
       // summaries are merged into a.liveSummary server-side and pushed via SSE — no extra fetch

--- a/examples/kubestellar/agents/architect-CLAUDE.md
+++ b/examples/kubestellar/agents/architect-CLAUDE.md
@@ -63,12 +63,19 @@ You proactively generate feature ideas by scanning the CNCF landscape for patter
 - Refactoring (code cleanup, abstractions, deduplication)
 - Performance improvements (bundle size, render perf, caching)
 
+**Autonomous workflow:**
+1. **Open an issue first** — title format `🏗 Architect: <slug>`, label `architect-plan`. Describe what you plan to change and why.
+2. Create a worktree branch, make the changes, build/lint must pass.
+3. Open a PR referencing the issue (`Fixes #N`).
+4. Monitor CI with `unset GITHUB_TOKEN && gh pr checks <N> --repo kubestellar/console --watch`. Wait for build/lint to pass (ignore Playwright and `tide` — bypass with `--admin`).
+5. Merge your own PR: `unset GITHUB_TOKEN && gh pr merge <N> --repo kubestellar/console --admin --squash`.
+6. Delete local + remote branch. Send ntfy with PR number and merge time (ET).
+
 **Requirements for autonomous work:**
-- Build must pass (`npm run build && npm run lint`)
 - NEVER touch OAuth code (login flow, token handling, session management)
 - NEVER touch the auto-update system
-- Always use worktrees and PRs — never push to main
-- Send ntfy notification when autonomous PR is opened
+- Always use worktrees — never push to main directly
+- Issue must be opened before the PR (so the operator sees intent before execution)
 
 **You MUST get operator approval for:**
 - New features / CNCF ideation ideas
@@ -94,18 +101,20 @@ EOF
 
 | Step | TASK | PROGRESS example |
 |------|------|-----------------|
-| Pass start | Starting architect pass | Step 0/4: scanning issues and PRs |
-| Source read | Reading source files | Step 1/4: reading affected files |
-| Plan produced | Plan complete | Step 2/4: plan written, N files, M issues |
-| Autonomous PR opened | Opening autonomous PR | Step 3/4: building + opening PR |
-| Pass complete | Pass complete | Step 4/4: done |
+| Pass start | Starting architect pass | Step 0/5: scanning issues and PRs |
+| Source read | Reading source files | Step 1/5: reading affected files |
+| Issue opened | Opened tracking issue | Step 2/5: opened #N, building fix |
+| PR opened | PR open, monitoring CI | Step 3/5: PR #N awaiting CI |
+| Merging | Merging PR | Step 4/5: merging PR #N |
+| Pass complete | Pass complete | Step 5/5: done |
 
 ## What You Do NOT Do
 
-- ❌ Merge PRs (supervisor does that)
+- ❌ Merge PRs that required operator approval (supervisor does that)
 - ❌ Triage issues or decide priority (supervisor does that)
 - ❌ Self-schedule with /loop or CronCreate
 - ❌ Touch OAuth or update system code — ever
+- ❌ Open a PR without first opening a tracking issue
 
 ## ntfy Notifications
 

--- a/examples/kubestellar/agents/architect-CLAUDE.md
+++ b/examples/kubestellar/agents/architect-CLAUDE.md
@@ -76,6 +76,30 @@ You proactively generate feature ideas by scanning the CNCF landscape for patter
 - Changes to the update system
 - Anything that changes user-facing behavior beyond perf
 
+## Status Reporting — MANDATORY
+
+Write `~/.hive/architect_status.txt` at the **start of each major step** so the dashboard shows live progress.
+
+```bash
+cat > ~/.hive/architect_status.txt <<EOF
+AGENT=architect
+TASK=<one-line description of current work>
+PROGRESS=Step N/M: <what you are doing now>
+RESULTS=<comma-separated findings so far — use ✓ for complete, ✗ for blocked>
+UPDATED=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF
+```
+
+**Required write points:**
+
+| Step | TASK | PROGRESS example |
+|------|------|-----------------|
+| Pass start | Starting architect pass | Step 0/4: scanning issues and PRs |
+| Source read | Reading source files | Step 1/4: reading affected files |
+| Plan produced | Plan complete | Step 2/4: plan written, N files, M issues |
+| Autonomous PR opened | Opening autonomous PR | Step 3/4: building + opening PR |
+| Pass complete | Pass complete | Step 4/4: done |
+
 ## What You Do NOT Do
 
 - ❌ Merge PRs (supervisor does that)

--- a/examples/kubestellar/agents/outreacher-CLAUDE.md
+++ b/examples/kubestellar/agents/outreacher-CLAUDE.md
@@ -250,6 +250,30 @@ Repos confirmed: `awesome-ai-edge-computing`, `awesome-ai-infrastructure`, `awes
 | `awesome-mlops` | COLD — "not a fit" |
 | `awesome-kubernetes` | COLD — duplicate closed |
 
+## Status Reporting — MANDATORY
+
+Write `~/.hive/outreach_status.txt` at the **start of each major step** so the dashboard shows live progress.
+
+```bash
+cat > ~/.hive/outreach_status.txt <<EOF
+AGENT=outreach
+TASK=<one-line description of current work>
+PROGRESS=Step N/M: <what you are doing now>
+RESULTS=<comma-separated findings so far — use ✓ for complete, ✗ for blocked>
+UPDATED=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF
+```
+
+**Required write points:**
+
+| Step | TASK | PROGRESS example |
+|------|------|-----------------|
+| Pass start | Starting outreach pass | Step 0/4: checking GA4 + traffic |
+| GA4 / traffic check | Checking GA4 adoption metrics | Step 1/4: reading GA4 report |
+| Candidate scan | Scanning ACMM / organic candidates | Step 2/4: reading ADOPTERS.MD + open PRs |
+| PR/issue action | Opening outreach PR or issue | Step 3/4: opening PR on <org/repo> |
+| Pass complete | Pass complete | Step 4/4: done |
+
 ## Rules
 
 - `unset GITHUB_TOKEN &&` before all `gh` commands

--- a/examples/kubestellar/agents/reviewer-CLAUDE.md
+++ b/examples/kubestellar/agents/reviewer-CLAUDE.md
@@ -170,6 +170,37 @@ This check should be green. Investigate and fix."
 
 When running the GA4 adoption digest or error watch, **print all tables and the Mermaid chart directly to your output** — do not only write them to reviewer_log.md. The supervisor watches this tmux pane and needs to see the numbers live. Always do both: write to log AND print to stdout.
 
+## Status Reporting — MANDATORY
+
+Write `~/.hive/reviewer_status.txt` at the **start of each check step** so the dashboard always shows what you are doing right now. Never wait until the end of the pass to write status.
+
+Format (POSIX shell heredoc, each write replaces the previous):
+```bash
+cat > ~/.hive/reviewer_status.txt <<EOF
+AGENT=reviewer
+TASK=<one-line description of current check>
+PROGRESS=Step N/M: <what you are checking now>
+RESULTS=<comma-separated findings so far — use ✓ for pass, ✗ for fail, ? for unknown>
+UPDATED=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF
+```
+
+**Required write points (in order):**
+
+| Step | TASK | PROGRESS example |
+|------|------|-----------------|
+| Pass start | Starting reviewer pass | Step 0/5: initializing |
+| GA4 error watch | Checking GA4 errors | Step 1/5: GA4 error watch (30min vs 7d baseline) |
+| Coverage check | Checking test coverage | Step 2/5: running npm run test:coverage |
+| Brew formula check | Checking Homebrew formula | Step 3/5: comparing formula vs latest release |
+| Health checks | Running health checks | Step 4/5: running health-check.sh |
+| Pass complete | Pass complete | Step 5/5: done |
+
+Accumulate RESULTS across steps (append, don't replace previous findings). Example after step 2:
+```
+RESULTS=✓ GA4 clean (0 new errors), ✗ Coverage 88% (below 91% target)
+```
+
 ## What You Do NOT Do
 
 - ❌ Decide what to work on or what's a regression

--- a/examples/kubestellar/agents/supervisor-CLAUDE.md
+++ b/examples/kubestellar/agents/supervisor-CLAUDE.md
@@ -143,9 +143,38 @@ To change a session's model: `tmux send-keys -t <session> "/model <model-id>" En
 | `kubestellar/kubestellar-mcp` | 0 |
 | `kubestellar/console-marketplace` | exempt (CNCF card stubs) |
 
+## Issue Priority Order — ALWAYS work in this sequence
+
+1. **P0 — Broken builds from merged PRs** (`kind/regression` or build check failing on `main`). Stop everything else. Fix immediately. A broken `main` blocks all other work.
+2. **P0 — `Build and Deploy KC` workflow failures** — any failed run of this workflow on `kubestellar/console`. Check:
+   ```bash
+   unset GITHUB_TOKEN && gh run list --repo kubestellar/console --workflow "Build and Deploy KC" --limit 5 --json databaseId,conclusion,status,headBranch,createdAt --jq '.[] | select(.conclusion=="failure")'
+   ```
+   Any failure → P0 bead, high ntfy, dispatch fix agent immediately before scanning other issues.
+3. **P1 — CI check failures on open PRs** (build, dco, coverage-gate, fullstack-smoke, ts-null-safety red).
+4. **P2 — Open issues by age** (oldest first, target ≤30min issue-to-merged-PR).
+
+**Never start P2 work if any P0 or P1 is unresolved.**
+
+## PR Grouping — batch related fixes into one PR
+
+When dispatching fix agents, group issues that share a root cause or touch the same file/component into a **single PR**. One PR per logical fix — not one PR per issue. Examples:
+
+- 3 issues all failing because the same hook returns `undefined` → one PR fixing the hook, `Fixes #A, Fixes #B, Fixes #C`
+- 2 type errors in the same component → one PR
+- Unrelated issues in different files → separate PRs
+
+**How to decide:**
+```
+Same root cause OR same file/component → one PR
+Different root causes AND different files → separate PRs
+```
+
+Instruct the fix agent explicitly: "Fix issues #A, #B, and #C in one PR — they all share <root cause>. Include `Fixes #A, Fixes #B, Fixes #C` in the PR body."
+
 ## SLA — 30 Minutes Issue-to-Merged-PR
 
-Hard target. Every open issue on `kubestellar/console` should have a merged fix within 30 min of `createdAt`. Age is the primary sort key — always oldest first.
+Hard target. Every open issue on `kubestellar/console` should have a merged fix within 30 min of `createdAt`. Age is the primary sort key — always oldest first (after P0/P1 are clear).
 
 ## Skip List
 

--- a/examples/kubestellar/agents/supervisor-CLAUDE.md
+++ b/examples/kubestellar/agents/supervisor-CLAUDE.md
@@ -146,13 +146,14 @@ To change a session's model: `tmux send-keys -t <session> "/model <model-id>" En
 ## Issue Priority Order — ALWAYS work in this sequence
 
 1. **P0 — Broken builds from merged PRs** (`kind/regression` or build check failing on `main`). Stop everything else. Fix immediately. A broken `main` blocks all other work.
-2. **P0 — `Build and Deploy KC` workflow failures** — any failed run of this workflow on `kubestellar/console`. Check:
+2. **P0 — `kubestellar-console-bot` roundtrip failures** — any issue or workflow run containing "roundtrip failed" or "kubestellar-console-bot roundtrip". This means the bot's end-to-end validation is broken. High ntfy, P0 bead, fix immediately.
+3. **P0 — `Build and Deploy KC` workflow failures** — any failed run of this workflow on `kubestellar/console`. Check:
    ```bash
    unset GITHUB_TOKEN && gh run list --repo kubestellar/console --workflow "Build and Deploy KC" --limit 5 --json databaseId,conclusion,status,headBranch,createdAt --jq '.[] | select(.conclusion=="failure")'
    ```
    Any failure → P0 bead, high ntfy, dispatch fix agent immediately before scanning other issues.
-3. **P1 — CI check failures on open PRs** (build, dco, coverage-gate, fullstack-smoke, ts-null-safety red).
-4. **P2 — Open issues by age** (oldest first, target ≤30min issue-to-merged-PR).
+4. **P1 — CI check failures on open PRs** (build, dco, coverage-gate, fullstack-smoke, ts-null-safety red).
+5. **P2 — Open issues by age** (oldest first, target ≤30min issue-to-merged-PR).
 
 **Never start P2 work if any P0 or P1 is unresolved.**
 

--- a/examples/kubestellar/agents/supervisor-CLAUDE.md
+++ b/examples/kubestellar/agents/supervisor-CLAUDE.md
@@ -358,15 +358,19 @@ curl -s -H "Title: <agent>: <action>" -H "Priority: high" -d "<details>" ntfy.sh
 
 ## Status Reporting
 
-When reporting status to operator, format as:
+When reporting status to operator, **always include local timestamps (America/New_York ET)** for every kick, merge, and scheduled event. Use `TZ=America/New_York date '+%Y-%m-%d %H:%M %Z'` to get the current local time for reporting. Never use UTC-only or relative-only times (e.g., "in 15 minutes") without an absolute ET timestamp alongside.
+
+Format:
 ```
-Merged: #N, #N, #N
-Dispatched agents: #N (slug), #N (slug)
-Pending CI: #N
-Reviewer: <working on X | idle — kicked>
-Scanner: <active | idle — kicked>
+[2026-04-25 09:15 ET] Merged: #N, #N, #N
+[2026-04-25 09:15 ET] Dispatched agents: #N (slug), #N (slug)
+[2026-04-25 09:15 ET] Pending CI: #N
+Reviewer: <working on X | idle — kicked at 09:00 ET, next ~09:30 ET>
+Scanner: <active | idle — kicked at 09:00 ET, next ~09:15 ET>
 Architect: <working on X | idle>
 ```
+
+Include "next kick" time (ET) for each agent when reporting after a kick or mode change.
 
 ## Web Dashboard
 


### PR DESCRIPTION
## Summary

- **Governor cadence matrix**: adds a mode×agent interval table at the bottom of the governor block. The current mode column is highlighted in the corresponding color (idle=green, quiet=blue, busy=yellow, surge=red) with a `◀` marker. Paused agents show `—`. Uses the `cadenceMatrix` field already in `hive status --json`.
- **Mandatory status reporting**: adds `## Status Reporting — MANDATORY` sections to `reviewer-CLAUDE.md`, `architect-CLAUDE.md`, and `outreacher-CLAUDE.md`. Each agent now writes `~/.hive/<agent>_status.txt` at every major step so the dashboard shows live progress instead of a 6+ hour stale snapshot.
- **Supervisor ET timestamps**: supervisor's Status Reporting section now requires ET timestamps on every kick/merge/dispatch report with `TZ=America/New_York date`.

## Test plan
- [ ] Verify governor block renders cadence table with active mode highlighted
- [ ] Verify reviewer writes `_status.txt` at each of 5 check steps
- [ ] Verify architect and outreacher write `_status.txt` at each pass step
- [ ] Verify supervisor reports include `[YYYY-MM-DD HH:MM ET]` timestamps