### PR TITLE
dashboard: org/repo names, issue pill titles, governor next-run label

### DIFF
--- a/dashboard/agent-metrics.sh
+++ b/dashboard/agent-metrics.sh
@@ -27,8 +27,21 @@ if command -v gh &>/dev/null; then
     . as $p |
     # extract first "Fixes/Closes/Resolves #NNN" issue ref using match()
     ($p.body | match("(?i)(fixes|closes|resolves) #([0-9]+)"; "g") // null) as $m |
-    if $m then { issue: ($m.captures[1].string | tonumber), pr: $p.pr } else empty end
+    if $m then { issue: ($m.captures[1].string | tonumber), pr: $p.pr, prTitle: $p.title } else empty end
   ]' 2>/dev/null || echo "[]")
+  # Enrich pairs with issue titles via GitHub API
+  if [ "$scanner_pairs_json" != "[]" ]; then
+    enriched="[]"
+    while IFS= read -r pair; do
+      issue_num=$(echo "$pair" | jq -r '.issue')
+      pr_num=$(echo "$pair" | jq -r '.pr')
+      pr_title=$(echo "$pair" | jq -r '.prTitle')
+      issue_title=$(gh api "repos/kubestellar/console/issues/${issue_num}" --jq '.title' 2>/dev/null || echo "")
+      enriched=$(echo "$enriched" | jq --argjson n "$issue_num" --argjson p "$pr_num" --arg pt "$pr_title" --arg it "$issue_title" \
+        '. + [{issue: $n, pr: $p, prTitle: $pt, issueTitle: $it}]')
+    done < <(echo "$scanner_pairs_json" | jq -c '.[]')
+    scanner_pairs_json="$enriched"
+  fi
 fi
 
 # Build agent JSON with live summaries and model

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -348,11 +348,17 @@
       if (name === 'issue-scanner' || name === 'scanner') {
         const pairs = m.pairs || [];
         if (pairs.length === 0) return '<div class="agent-indicators"><span class="ind-empty">no active fixes</span></div>';
-        const rows = pairs.map(p => `<div class="ind-pair">
-          <a class="ind-tag ind-issue" href="https://github.com/kubestellar/console/issues/${p.issue}" target="_blank">⊙ #${p.issue}</a>
+        const rows = pairs.map(p => {
+          const issueLabel = p.issueTitle ? `⊙ #${p.issue} — ${esc(p.issueTitle.length > 48 ? p.issueTitle.slice(0, 48) + '…' : p.issueTitle)}` : `⊙ #${p.issue}`;
+          const issueTip = p.issueTitle ? esc(p.issueTitle) : '';
+          const prLabel = p.prTitle ? `⎇ #${p.pr}` : `⎇ #${p.pr}`;
+          const prTip = p.prTitle ? esc(p.prTitle) : '';
+          return `<div class="ind-pair">
+          <a class="ind-tag ind-issue" href="https://github.com/kubestellar/console/issues/${p.issue}" target="_blank" title="${issueTip}">${issueLabel}</a>
           <span class="ind-arrow">→</span>
-          <a class="ind-tag ind-pr" href="https://github.com/kubestellar/console/pull/${p.pr}" target="_blank">⎇ #${p.pr}</a>
-        </div>`).join('');
+          <a class="ind-tag ind-pr" href="https://github.com/kubestellar/console/pull/${p.pr}" target="_blank" title="${prTip}">${prLabel}</a>
+        </div>`;
+        }).join('');
         return `<div class="agent-indicators"><span class="ind-label">Fixes (${pairs.length}):</span>${rows}</div>`;
       }
 
@@ -536,7 +542,7 @@
           <div class="gov-stat"><div class="label">actionable</div><div class="spark-row"><span class="val">${total}</span>${totalSpark}</div></div>
           <div class="gov-stat"><div class="label">issues</div><div class="spark-row"><span class="val">${gov.issues}</span>${issuesSpark}</div></div>
           <div class="gov-stat"><div class="label">PRs</div><div class="spark-row"><span class="val">${gov.prs}</span>${prsSpark}</div></div>
-          <div class="gov-stat"><div class="label">next kick</div><div class="val">${gov.nextKick || '—'}</div></div>
+          <div class="gov-stat"><div class="label">next run</div><div class="val">${gov.nextKick || '—'}</div></div>
         </div>
         <div class="temp-gauge">
           <div class="temp-gauge-label"><span>Queue: ${total}</span><span>max ${maxQ}</span></div>
@@ -599,7 +605,7 @@
         const pSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.prs ?? 0), '#bc8cff');
         return `
         <div class="repo-card">
-          <div class="repo-name">${r.name}</div>
+          <div class="repo-name">${r.full || r.name}</div>
           <div class="repo-stats">
             <div class="repo-stat"><div class="spark-row"><span class="num">${r.issues >= 0 ? r.issues : '?'}</span>${iSpark}</div><div class="label">issues</div></div>
             <div class="repo-stat"><div class="spark-row"><span class="num">${r.prs >= 0 ? r.prs : '?'}</span>${pSpark}</div><div class="label">PRs</div></div>


### PR DESCRIPTION
## Changes

- **Repo names show org/repo** — repo cards now display `kubestellar/console` (using `r.full`) instead of just `console`
- **Issue pill titles** — scanner card issue pills now show truncated issue title inline (≤48 chars) with full title as tooltip; `agent-metrics.sh` enriches pairs with `issueTitle` via GitHub API
- **Governor "next run" label** — renamed "next kick" → "next run" in governor block for operator clarity

## TODOs completed

- [x] Repository names show org/repo
- [x] Issue pills include title
- [x] Governor "next kick" → "next run"

Fixes #40, Fixes #41, Fixes #42