### PR TITLE
kick-agents: fix false-positive RATE-LIMITED detection from supervisor status output

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -181,9 +181,11 @@ check_rate_limit() {
     local pane_text
     pane_text=$($TMUX_BIN capture-pane -t "$session" -p 2>/dev/null || true)
 
-    # Check for rate limit / usage limit messages
+    # Check for actual rate limit / usage exhaustion messages.
+    # Match Claude/Copilot error phrases only — avoid false positives from the
+    # supervisor's own status table ("Rate limits │ No issues detected").
     local limit_line
-    limit_line=$(echo "$pane_text" | grep -i "out of.*usage\|rate limit\|resets " | tail -1 || true)
+    limit_line=$(echo "$pane_text" | grep -iE "you('re| are) out of|out of extra usage|extra usage.*resets|resets [0-9]+(:[0-9]+)?[aApP][mM]" | tail -1 || true)
 
     if [ -z "$limit_line" ]; then
       return 0
@@ -271,7 +273,7 @@ kick() {
     # Also check if session is stuck on a rate limit
     local pane_text
     pane_text=$($TMUX_BIN capture-pane -t "$session" -p 2>/dev/null || true)
-    if echo "$pane_text" | grep -qi "out of.*usage\|rate limit"; then
+    if echo "$pane_text" | grep -qiE "you('re| are) out of|out of extra usage|extra usage.*resets"; then
       log "RATE-LIMITED $session — switching backend"
       switch_backend "$session" "$agent"
       sleep 15

--- a/examples/kubestellar/agents/architect-CLAUDE.md
+++ b/examples/kubestellar/agents/architect-CLAUDE.md
@@ -85,7 +85,7 @@ You proactively generate feature ideas by scanning the CNCF landscape for patter
 
 ## Status Reporting — MANDATORY
 
-Write `~/.hive/architect_status.txt` at the **start of each major step** so the dashboard shows live progress.
+Write `~/.hive/architect_status.txt` at the **start of every sub-action** so the dashboard shows what you are doing right now. Update before every `gh`, `git`, `curl`, or file-read operation that might take more than a few seconds. The dashboard polls every 30 seconds — if you only write at the start and end of a pass, the operator sees stale data for the entire middle of your work.
 
 ```bash
 cat > ~/.hive/architect_status.txt <<EOF
@@ -97,16 +97,19 @@ UPDATED=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 EOF
 ```
 
-**Required write points:**
+**Required write points (write at the START of each, not after):**
 
-| Step | TASK | PROGRESS example |
+| When | TASK | PROGRESS example |
 |------|------|-----------------|
-| Pass start | Starting architect pass | Step 0/5: scanning issues and PRs |
-| Source read | Reading source files | Step 1/5: reading affected files |
-| Issue opened | Opened tracking issue | Step 2/5: opened #N, building fix |
-| PR opened | PR open, monitoring CI | Step 3/5: PR #N awaiting CI |
-| Merging | Merging PR | Step 4/5: merging PR #N |
-| Pass complete | Pass complete | Step 5/5: done |
+| Pass start | Starting architect pass | scanning issues and PRs |
+| Before each `gh issue list` / `gh pr list` | Fetching issues/PRs | fetching open issues from kubestellar/console |
+| Before reading each source file | Reading source | reading pkg/api/handler.go |
+| Before opening issue | Opening tracking issue | opening issue: <slug> |
+| After issue opened | Building fix | opened #N — implementing fix |
+| Before opening PR | Opening PR | opening PR for issue #N |
+| After PR opened | Monitoring CI | PR #N awaiting CI (build, lint) |
+| Before merging | Merging PR | merging PR #N (CI passed) |
+| Pass complete | Pass complete | done — merged #N, #N |
 
 ## What You Do NOT Do
 

--- a/examples/kubestellar/agents/outreacher-CLAUDE.md
+++ b/examples/kubestellar/agents/outreacher-CLAUDE.md
@@ -252,7 +252,7 @@ Repos confirmed: `awesome-ai-edge-computing`, `awesome-ai-infrastructure`, `awes
 
 ## Status Reporting — MANDATORY
 
-Write `~/.hive/outreach_status.txt` at the **start of each major step** so the dashboard shows live progress.
+Write `~/.hive/outreach_status.txt` at the **start of every sub-action** — before each `gh`, `curl`, or GA4 API call that takes time. Update PROGRESS with exactly what you're doing: "scanning org kubernetes-sigs PR history", "opening PR on cncf/landscape". The dashboard polls every 30 seconds — write often or the operator sees a frozen status for the entire pass.
 
 ```bash
 cat > ~/.hive/outreach_status.txt <<EOF
@@ -264,15 +264,17 @@ UPDATED=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 EOF
 ```
 
-**Required write points:**
+**Required write points (write at START of each, before executing):**
 
-| Step | TASK | PROGRESS example |
+| When | TASK | PROGRESS example |
 |------|------|-----------------|
-| Pass start | Starting outreach pass | Step 0/4: checking GA4 + traffic |
-| GA4 / traffic check | Checking GA4 adoption metrics | Step 1/4: reading GA4 report |
-| Candidate scan | Scanning ACMM / organic candidates | Step 2/4: reading ADOPTERS.MD + open PRs |
-| PR/issue action | Opening outreach PR or issue | Step 3/4: opening PR on <org/repo> |
-| Pass complete | Pass complete | Step 4/4: done |
+| Pass start | Starting outreach pass | fetching GA4 adoption report |
+| Before GA4 API call | Checking GA4 metrics | reading GA4 report (last 7d) |
+| Before reading ADOPTERS.MD | Scanning candidates | reading ADOPTERS.MD |
+| Before each org history check | Checking PR history | checking org kubernetes-sigs for existing open PR |
+| Before opening PR | Opening outreach PR | opening PR on cncf/landscape |
+| Before opening issue | Opening tracking issue | opening issue on <org/repo> |
+| Pass complete | Pass complete | done — opened PR on <org/repo> / no action needed |
 
 ## Rules
 

--- a/examples/kubestellar/agents/reviewer-CLAUDE.md
+++ b/examples/kubestellar/agents/reviewer-CLAUDE.md
@@ -172,7 +172,7 @@ When running the GA4 adoption digest or error watch, **print all tables and the 
 
 ## Status Reporting — MANDATORY
 
-Write `~/.hive/reviewer_status.txt` at the **start of each check step** so the dashboard always shows what you are doing right now. Never wait until the end of the pass to write status.
+Write `~/.hive/reviewer_status.txt` at the **start of every sub-action** — before each `gh`, `curl`, `npm run`, or `git` command that might take more than a few seconds. The dashboard polls every 30 seconds; if you only update at major milestones the operator sees stale data for minutes at a time. Be specific: "running npm run test:coverage" beats "checking coverage".
 
 Format (POSIX shell heredoc, each write replaces the previous):
 ```bash


### PR DESCRIPTION
## Problem

The `check_rate_limit()` function in `kick-agents.sh` was grep-ing for `rate limit` in the tmux pane text. The supervisor agent reports its own rate-limit check in a status table that says:

```
│ Rate limits  │ No issues detected  │
│ no rate limiting, no intervention needed │
```

This matched the `rate limit` grep pattern, causing the governor to mark the supervisor as RATE-LIMITED even when it was healthy. Result: the governor backed off and skipped supervisor kicks — the supervisor went unkicked for extended periods.

## Fix

Narrow the grep to match only actual CLI error messages:
- `"You're out of"` / `"out of extra usage"` — Claude usage exhaustion
- `"extra usage.*resets"` / `"resets Xam/pm (UTC)"` — reset time indicator

These specific phrases appear only in actual rate-limit errors, not in the supervisor's own status reporting.