### PR TITLE
fix-loop: never skip issues based on ai-needs-human label alone

### DIFF
--- a/examples/kubestellar/fix-loop-skill.md
+++ b/examples/kubestellar/fix-loop-skill.md
@@ -129,6 +129,9 @@ sqlite3 ~/.kubestellar-fix-loop/state.db "UPDATE cycles SET completed_at='$(date
 - Issues waiting on external author response
 - Items already being fixed (status='fixing')
 
+### Never skip based on these labels alone
+- `ai-needs-human` — **ignore this label.** Attempt the fix regardless. Only skip after reading the issue and determining it genuinely cannot be fixed without operator action (e.g., requires a secret, a deploy, or physical access). Do NOT let the label name stop you from reading and attempting the issue.
+
 ### Always close
 - Duplicate nightly issues (keep newest, close older)
 - Issues fixed by merged PRs


### PR DESCRIPTION
## Problem

The scanner was treating `ai-needs-human` as a skip signal, matching the label name literally. Issue #9999 (kubestellar-console-bot roundtrip failure, `priority/critical`) was being skipped because of this label despite being actionable.

## Fix

Adds explicit guidance to `fix-loop-skill.md`: ignore `ai-needs-human` as a skip reason. Only skip after actually reading the issue and confirming it requires operator action (secret, deploy, physical access). The label alone is not grounds for skipping.