### PR TITLE
governor: set HIVE_TZ=America/New_York; supervisor: pass timestamps in monitoring summary

### DIFF
--- a/examples/kubestellar/agents/governor.env
+++ b/examples/kubestellar/agents/governor.env
@@ -2,6 +2,9 @@
 # Edit this file to tune thresholds and cadences; takes effect on next timer fire.
 # Supervisor adjusts these values directly — no script edit needed.
 
+# Local timezone for all time displays in hive status and dashboard.
+HIVE_TZ=America/New_York
+
 # ntfy topic for kick notifications
 NTFY_TOPIC=issue-scanner
 

--- a/examples/kubestellar/agents/supervisor-CLAUDE.md
+++ b/examples/kubestellar/agents/supervisor-CLAUDE.md
@@ -372,6 +372,23 @@ Architect: <working on X | idle>
 
 Include "next kick" time (ET) for each agent when reporting after a kick or mode change.
 
+**Monitoring summary MUST include run start and finish timestamps:**
+
+Every monitoring summary table must be preceded by a start time and followed by a finish time, both in ET:
+
+```
+Pass started: 2026-04-25 10:15 ET
+
+Monitoring summary:
+| Item          | Status |
+...
+
+Pass finished: 2026-04-25 10:17 ET
+```
+
+Get timestamps with: `TZ=America/New_York date '+%Y-%m-%d %H:%M %Z'`
+Run this at the very start of the pass (before any gh/git commands) and again immediately after printing the summary table.
+
 ## Web Dashboard
 
 The hive web dashboard runs on port 3001 via systemd (`hive-dashboard.service`). It shows agent status, governor state, repo counts, and beads — all updating live via SSE.

--- a/examples/kubestellar/fix-loop-skill.md
+++ b/examples/kubestellar/fix-loop-skill.md
@@ -129,6 +129,9 @@ sqlite3 ~/.kubestellar-fix-loop/state.db "UPDATE cycles SET completed_at='$(date
 - Issues waiting on external author response
 - Items already being fixed (status='fixing')
 
+### Never skip based on these labels alone
+- `ai-needs-human` — **ignore this label.** Attempt the fix regardless. Only skip after reading the issue and determining it genuinely cannot be fixed without operator action (e.g., requires a secret, a deploy, or physical access). Do NOT let the label name stop you from reading and attempting the issue.
+
 ### Always close
 - Duplicate nightly issues (keep newest, close older)
 - Issues fixed by merged PRs


### PR DESCRIPTION
## Changes

### `governor.env` — set `HIVE_TZ=America/New_York`

The `hive status --json` governor block was emitting `nextKick: "4:15 PM UTC"` because `HIVE_TZ` defaulted to `UTC` when not set. Adding `HIVE_TZ=America/New_York` to `governor.env` (sourced by the kick-governor systemd service as `EnvironmentFile`) fixes the display for the dashboard and terminal output.

### `supervisor-CLAUDE.md` — monitoring summary must include run timestamps

Every monitoring summary table must now show:
```
Pass started: 2026-04-25 10:15 ET

Monitoring summary:
...

Pass finished: 2026-04-25 10:17 ET
```

Operator can see at a glance whether the summary is fresh or from a previous kick.