### PR TITLE
dashboard: pass HIVE_TZ to hive status subprocess so nextKick shows ET not UTC

### DIFF
--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -109,7 +109,8 @@ setTimeout(persistSnapshot, 10000);
 
 function fetchStatus() {
   return new Promise((resolve) => {
-    execFile('hive', ['status', '--json'], { timeout: 30000 }, (err, stdout) => {
+    const hiveEnv = { ...process.env, HIVE_TZ: process.env.HIVE_TZ || 'America/New_York' };
+    execFile('hive', ['status', '--json'], { timeout: 30000, env: hiveEnv }, (err, stdout) => {
       if (err) {
         console.error('hive status --json failed:', err.message);
         resolve(statusCache); // return stale data


### PR DESCRIPTION
The dashboard server calls `hive status --json` via `execFile` which does not inherit shell env vars. Without `HIVE_TZ` set, `hive.sh` defaults to UTC and emits `nextKick: "4:15 PM UTC"` instead of local ET time.

Fix: pass `HIVE_TZ=America/New_York` explicitly in the `env` option of the `execFile` call, falling back to `process.env.HIVE_TZ` if already set.