### PR TITLE
dashboard: enrich agent status with top in-progress bead when status file is empty

### DIFF
--- a/dashboard/agent-summaries.sh
+++ b/dashboard/agent-summaries.sh
@@ -5,6 +5,24 @@
 set +e
 mkdir -p ~/.hive
 
+# Map agent name → beads directory
+declare -A BEADS_DIR
+BEADS_DIR[supervisor]="/home/dev/supervisor-beads"
+BEADS_DIR[scanner]="/home/dev/scanner-beads"
+BEADS_DIR[reviewer]="/home/dev/reviewer-beads"
+BEADS_DIR[architect]="/home/dev/feature-beads"
+BEADS_DIR[outreach]="/home/dev/outreach-beads"
+
+# Read top in-progress bead title for an agent (returns empty if none)
+bead_in_progress() {
+  local dir="${BEADS_DIR[$1]:-}"
+  [ -z "$dir" ] || [ ! -d "$dir" ] && return
+  local line
+  line=$(cd "$dir" && bd list 2>/dev/null | grep '^●' | head -1 || true)
+  # Strip leading "● <id> ● P<N> " prefix to get the title
+  echo "$line" | sed 's/^● [^ ]* ● P[0-9]* //' | sed 's/"/'\''/g'
+}
+
 {
   echo "{"
   echo '  "summaries": {'
@@ -22,6 +40,12 @@ mkdir -p ~/.hive
       progress=""
       results=""
       updated=""
+    fi
+
+    # Enrich task with top in-progress bead when status file is empty or missing
+    if [ -z "$task" ]; then
+      bead=$(bead_in_progress "$agent")
+      [ -n "$bead" ] && task="$bead (from beads)"
     fi
 
     [ $first -eq 0 ] && echo ","


### PR DESCRIPTION
## Problem

When an agent starts a new pass, it writes a generic "scanning..." status then the dashboard reverts to showing the old stale status file content for the rest of the pass. The status file is only updated at major milestones.

## Fix

When an agent's status file has no `TASK` entry (empty or missing), `agent-summaries.sh` now reads the top in-progress bead from the agent's beads directory (`bd list | grep ^●`). Beads are updated continuously during work and contain the current priority item being worked on.

The bead title is shown with a `(from beads)` suffix so the operator knows the source.

## Beads directory mapping

| Agent | Beads dir |
|---|---|
| supervisor | `/home/dev/supervisor-beads` |
| scanner | `/home/dev/scanner-beads` |
| reviewer | `/home/dev/reviewer-beads` |
| architect | `/home/dev/feature-beads` |
| outreach | `/home/dev/outreach-beads` |