### PR TITLE
dashboard: per-agent custom kick prompt

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -62,7 +62,14 @@
     .summary-age.age-recent { background: rgba(210,153,34,0.15); color: #d29922; border: 1px solid rgba(210,153,34,0.3); }
     .summary-age.age-stale  { background: rgba(248,81,73,0.15);  color: #f85149; border: 1px solid rgba(248,81,73,0.3); }
     /* Agent metric gauges — removed, replaced by health panel */
-    .agent-actions { margin-top: 10px; display: flex; gap: 6px; }
+    .agent-actions { margin-top: 10px; display: flex; gap: 6px; flex-wrap: wrap; }
+    .kick-prompt {
+      flex: 1 1 100%; background: var(--bg); border: 1px solid var(--border);
+      color: var(--text); padding: 4px 8px; border-radius: 4px; font-size: 0.75rem;
+      font-family: inherit; outline: none; min-width: 0;
+    }
+    .kick-prompt:focus { border-color: var(--accent); }
+    .kick-prompt::placeholder { color: var(--muted); }
 
     /* Health status panel */
     .health { margin-bottom: 24px; }
@@ -463,6 +470,7 @@
           ${needsLogin ? '<div class="login-warning">⚠ NOT LOGGED IN — run /login</div>' : ''}
           ${summaryEl}${indEl}
           ${a.name !== 'supervisor' ? `<div class="agent-actions">
+            <input type="text" class="kick-prompt" id="kick-prompt-${a.name}" placeholder="custom prompt (optional)" />
             <button class="btn" onclick="kick('${a.name}')">kick</button>
             <select class="btn backend-select" onchange="switchCli('${a.name}', this.value); this.selectedIndex=0">
               <option value="" disabled selected>cli ▾</option>
@@ -642,9 +650,14 @@
     }
 
     async function kick(agent) {
-      const res = await fetch(`/api/kick/${agent}`, { method: 'POST' });
+      const input = document.getElementById(`kick-prompt-${agent}`);
+      const prompt = input ? input.value.trim() : '';
+      const opts = { method: 'POST', headers: { 'Content-Type': 'application/json' } };
+      if (prompt) opts.body = JSON.stringify({ prompt });
+      const res = await fetch(`/api/kick/${agent}`, opts);
       const data = await res.json();
-      if (!data.ok) alert('Kick failed: ' + (data.error || 'unknown'));
+      if (!data.ok) { alert('Kick failed: ' + (data.error || 'unknown')); return; }
+      if (input) input.value = '';
     }
 
     async function switchCli(agent, backend) {

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -4,6 +4,7 @@ const path = require('path');
 const fs = require('fs');
 
 const app = express();
+app.use(express.json());
 const PORT = process.env.HIVE_DASHBOARD_PORT || 3001;
 const REFRESH_MS = 5000;
 const HISTORY_DIR = '/var/run/hive-metrics/history';
@@ -246,6 +247,15 @@ app.get('/api/widget', (_req, res) => {
   tar.on('error', () => res.status(500).end());
 });
 
+// Map dashboard agent names to tmux session names
+const TMUX_SESSION = {
+  scanner: 'issue-scanner',
+  reviewer: 'reviewer',
+  architect: 'feature',
+  outreach: 'outreach',
+  supervisor: 'supervisor',
+};
+
 // Control endpoints
 app.post('/api/kick/:agent', (req, res) => {
   const agent = req.params.agent;
@@ -253,10 +263,25 @@ app.post('/api/kick/:agent', (req, res) => {
   if (!allowed.includes(agent)) {
     return res.status(400).json({ error: `invalid agent: ${agent}` });
   }
-  execFile('hive', ['kick', agent], { timeout: 30000 }, (err, stdout) => {
-    if (err) return res.status(500).json({ error: err.message });
-    res.json({ ok: true, output: stdout.trim() });
-  });
+  const extraPrompt = (req.body && req.body.prompt) ? req.body.prompt.trim() : '';
+  if (extraPrompt && agent !== 'all') {
+    const session = TMUX_SESSION[agent];
+    if (!session) {
+      return res.status(400).json({ error: `no tmux session for ${agent}` });
+    }
+    execFile('tmux', ['send-keys', '-t', session, '-l', `OPERATOR DIRECTIVE: ${extraPrompt}`], { timeout: 10000 }, (err) => {
+      if (err) return res.status(500).json({ error: err.message });
+      execFile('tmux', ['send-keys', '-t', session, 'Enter'], { timeout: 5000 }, (err2) => {
+        if (err2) return res.status(500).json({ error: err2.message });
+        res.json({ ok: true, output: `Sent custom prompt to ${agent}` });
+      });
+    });
+  } else {
+    execFile('hive', ['kick', agent], { timeout: 30000 }, (err, stdout) => {
+      if (err) return res.status(500).json({ error: err.message });
+      res.json({ ok: true, output: stdout.trim() });
+    });
+  }
 });
 
 app.post('/api/switch/:agent/:backend', (req, res) => {


### PR DESCRIPTION
## Summary

Adds a text input field on each agent card in the dashboard. When filled, clicking "kick" sends the custom prompt directly to the agent's tmux session prefixed with `OPERATOR DIRECTIVE:` instead of going through the standard `hive kick`.

**Changes:**
- `server.js`: Added `express.json()` middleware, tmux session name mapping, custom prompt handling in `/api/kick/:agent` — sends via `tmux send-keys -l` (text) then `tmux send-keys Enter` (separate call per memory rule)
- `index.html`: Added `.kick-prompt` text input per agent card, updated `kick()` function to read input and POST as JSON body

**How it works:**
1. Operator types a prompt in the text input (e.g., "work on issue #9999 immediately")
2. Clicks kick
3. Dashboard POSTs `{"prompt": "..."}` to `/api/kick/:agent`
4. Server sends `OPERATOR DIRECTIVE: <prompt>` to the agent's tmux session
5. Input clears on success

Leaving the input empty falls back to the standard `hive kick` behavior.