### PR TITLE
all agents: mandatory in-progress beads for live dashboard status

### DIFF
--- a/examples/kubestellar/agents/architect-CLAUDE.md
+++ b/examples/kubestellar/agents/architect-CLAUDE.md
@@ -83,6 +83,23 @@ You proactively generate feature ideas by scanning the CNCF landscape for patter
 - Changes to the update system
 - Anything that changes user-facing behavior beyond perf
 
+## Live Status via Beads — MANDATORY
+
+The dashboard shows your current work to the operator. It reads your in-progress bead title as your live status. **You MUST maintain an in-progress bead at all times during a pass.**
+
+```bash
+# At pass start
+cd /home/dev/feature-beads && bd add --in-progress "Architect: implementing container-query rollout for #8695"
+
+# As work progresses — update title to reflect current action
+cd /home/dev/feature-beads && bd update <bead_id> --title "Architect: PR #10051 opened, waiting for CI"
+
+# At pass end
+cd /home/dev/feature-beads && bd update <bead_id> --status done --notes "Pass complete: PR #10051 merged"
+```
+
+Without this, the dashboard shows stale status from hours ago. The operator cannot see what you are doing.
+
 ## Status Reporting — MANDATORY
 
 Write `~/.hive/architect_status.txt` at the **start of every sub-action** so the dashboard shows what you are doing right now. Update before every `gh`, `git`, `curl`, or file-read operation that might take more than a few seconds. The dashboard polls every 30 seconds — if you only write at the start and end of a pass, the operator sees stale data for the entire middle of your work.

--- a/examples/kubestellar/agents/outreacher-CLAUDE.md
+++ b/examples/kubestellar/agents/outreacher-CLAUDE.md
@@ -261,6 +261,23 @@ Repos confirmed: `awesome-ai-edge-computing`, `awesome-ai-infrastructure`, `awes
 | `awesome-mlops` | COLD — "not a fit" |
 | `awesome-kubernetes` | COLD — duplicate closed |
 
+## Live Status via Beads — MANDATORY
+
+The dashboard shows your current work to the operator. It reads your in-progress bead title as your live status. **You MUST maintain an in-progress bead at all times during a pass.**
+
+```bash
+# At pass start
+cd /home/dev/outreach-beads && bd add --in-progress "Outreach: scanning open PRs for review feedback"
+
+# As work progresses — update title to reflect current action
+cd /home/dev/outreach-beads && bd update <bead_id> --title "Outreach: opening PR on awesome-kubernetes"
+
+# At pass end
+cd /home/dev/outreach-beads && bd update <bead_id> --status done --notes "Pass complete: 3 PRs opened, 2 review comments addressed"
+```
+
+Without this, the dashboard shows stale status from hours ago. The operator cannot see what you are doing.
+
 ## Status Reporting — MANDATORY
 
 Write `~/.hive/outreach_status.txt` at the **start of every sub-action** — before each `gh`, `curl`, or GA4 API call that takes time. Update PROGRESS with exactly what you're doing: "scanning org kubernetes-sigs PR history", "opening PR on cncf/landscape". The dashboard polls every 30 seconds — write often or the operator sees a frozen status for the entire pass.

--- a/examples/kubestellar/agents/reviewer-CLAUDE.md
+++ b/examples/kubestellar/agents/reviewer-CLAUDE.md
@@ -170,6 +170,23 @@ This check should be green. Investigate and fix."
 
 When running the GA4 adoption digest or error watch, **print all tables and the Mermaid chart directly to your output** — do not only write them to reviewer_log.md. The supervisor watches this tmux pane and needs to see the numbers live. Always do both: write to log AND print to stdout.
 
+## Live Status via Beads — MANDATORY
+
+The dashboard shows your current work to the operator. It reads your in-progress bead title as your live status. **You MUST maintain an in-progress bead at all times during a pass.**
+
+```bash
+# At pass start
+cd /home/dev/reviewer-beads && bd add --in-progress "Reviewing: checking CI health and coverage"
+
+# As work progresses — update title to reflect current action
+cd /home/dev/reviewer-beads && bd update <bead_id> --title "Reviewing: PR #10050 CI green, merging"
+
+# At pass end
+cd /home/dev/reviewer-beads && bd update <bead_id> --status done --notes "Pass complete: coverage 94%, all CI green"
+```
+
+Without this, the dashboard shows stale status from hours ago. The operator cannot see what you are doing.
+
 ## Status Reporting — MANDATORY
 
 Write `~/.hive/reviewer_status.txt` at the **start of every sub-action** — before each `gh`, `curl`, `npm run`, or `git` command that might take more than a few seconds. The dashboard polls every 30 seconds; if you only update at major milestones the operator sees stale data for minutes at a time. Be specific: "running npm run test:coverage" beats "checking coverage".

--- a/examples/kubestellar/agents/supervisor-CLAUDE.md
+++ b/examples/kubestellar/agents/supervisor-CLAUDE.md
@@ -356,6 +356,23 @@ curl -s -H "Title: <agent>: <action>" -H "Priority: high" -d "<details>" ntfy.sh
 - What happened
 - Next scheduled run time in ET
 
+## Live Status via Beads — MANDATORY
+
+The dashboard shows your current work to the operator. It reads your in-progress bead title as your live status. **You MUST maintain an in-progress bead at all times during a pass.**
+
+```bash
+# At pass start — create or update your in-progress bead
+cd /home/dev/supervisor-beads && bd add --in-progress "Monitoring pass: checking agent health, CI, PRs"
+
+# As work progresses — update the title to reflect current action
+cd /home/dev/supervisor-beads && bd update <bead_id> --title "Monitoring: dispatching scanner to fix #9999"
+
+# At pass end — mark done
+cd /home/dev/supervisor-beads && bd update <bead_id> --status done --notes "Pass complete: 3 agents kicked, 2 PRs merged"
+```
+
+Without this, the dashboard shows "14h ago" stale status from your last pass. The operator cannot see what you are doing.
+
 ## Status Reporting
 
 When reporting status to operator, **always include local timestamps (America/New_York ET)** for every kick, merge, and scheduled event. Use `TZ=America/New_York date '+%Y-%m-%d %H:%M %Z'` to get the current local time for reporting. Never use UTC-only or relative-only times (e.g., "in 15 minutes") without an absolute ET timestamp alongside.


### PR DESCRIPTION
## Summary

Adds a **Live Status via Beads — MANDATORY** section to all 5 agent CLAUDE.md files (supervisor, scanner already had it, reviewer, architect, outreach).

**Problem:** Dashboard showed "14h 18m ago" stale data for all agents except scanner. Agents were not creating in-progress beads during their passes, so the dashboard had nothing fresh to display.

**Fix:** Each agent must now:
1. `bd add --in-progress "<description>"` at pass start
2. `bd update <id> --title "<current action>"` as work progresses
3. `bd update <id> --status done` at pass end

Combined with PR #50 (agent-summaries prefers beads over stale status files), this gives the dashboard real-time visibility into all agents.

## Agents updated
- `supervisor-CLAUDE.md` — beads dir: `/home/dev/supervisor-beads`
- `reviewer-CLAUDE.md` — beads dir: `/home/dev/reviewer-beads`
- `architect-CLAUDE.md` — beads dir: `/home/dev/feature-beads`
- `outreacher-CLAUDE.md` — beads dir: `/home/dev/outreach-beads`