### PR TITLE
fix: 12-hour timestamps, next-run after pass, scanner merged-today pairs

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 TARGET="${1:-all}"
 TMUX_BIN="${TMUX_BIN:-tmux}"
 LOG="/var/log/kick-agents.log"
-TIMESTAMP="$(TZ=America/New_York date '+%Y-%m-%d %H:%M:%S %Z')"
+TIMESTAMP="$(TZ=America/New_York date '+%Y-%m-%d %I:%M:%S %p %Z')"
 ET_NOW="$(TZ=America/New_York date '+%I:%M %p ET')"
 NTFY_TOPIC="${NTFY_TOPIC:-ntfy.sh/issue-scanner}"
 NTFY_SERVER="${NTFY_SERVER:-https://ntfy.sh}"
@@ -361,9 +361,8 @@ If you find a bug or improvement idea, file a beads issue for the scanner — do
 Fork under clubanderson account for all external PRs to third-party repos. \
 Send ntfy for every new listing secured. One outreach per project — never spam. $BEADS_SYNC"
 
-_now_et=$(TZ=America/New_York date '+%Y-%m-%d %H:%M %Z')
-_next_et=$(TZ=America/New_York date -d '+15 minutes' '+%H:%M %Z' 2>/dev/null || TZ=America/New_York date -v+15M '+%H:%M %Z' 2>/dev/null || echo "~15min")
-SUPERVISOR_MSG="MONITORING PASS — Pass started: ${_now_et} | Next run: ~${_next_et}
+_now_et=$(TZ=America/New_York date '+%Y-%m-%d %I:%M %p %Z')
+SUPERVISOR_MSG="MONITORING PASS — Pass started: ${_now_et}
 
 Do all of the following right now:
 1. Record pass start time at the TOP of your monitoring summary: \"Pass started: ${_now_et}\"
@@ -376,7 +375,7 @@ Do all of the following right now:
 3. Check for AI-authored PRs with CI green across all kubestellar repos — merge any that are ready. \
 4. Check for rate-limited agents — switch their backend if needed (hive switch <agent> <backend>). \
 5. Run: bd dolt push
-6. After printing the monitoring summary table, add: \"Pass finished: \$(TZ=America/New_York date '+%Y-%m-%d %H:%M %Z') | Next run: ~${_next_et}\""
+6. After printing the monitoring summary table, compute the next run time and add: \"Pass finished: \$(TZ=America/New_York date '+%Y-%m-%d %I:%M %p %Z') | Next run: ~\$(TZ=America/New_York date -d '+15 minutes' '+%I:%M %p %Z' 2>/dev/null || TZ=America/New_York date -v+15M '+%I:%M %p %Z' 2>/dev/null || echo '~15min')\""
 
 case "$TARGET" in
   scanner)

--- a/dashboard/agent-metrics.sh
+++ b/dashboard/agent-metrics.sh
@@ -16,29 +16,40 @@ architect_model=$(echo "$agent_status" | jq -r '.agents[] | select(.name == "arc
 outreach_doing=$(echo "$agent_status" | jq -r '.agents[] | select(.name == "outreach") | .doing' 2>/dev/null || echo "")
 outreach_model=$(echo "$agent_status" | jq -r '.agents[] | select(.name == "outreach") | .model' 2>/dev/null || echo "?")
 
-# ── Scanner: active issue→PR pairs from open AI-authored PRs ──
-# Reads open PRs by clubanderson that reference an issue number in title/body
+# ── Scanner: issue→PR pairs from open + recently merged AI-authored PRs ──
+RECENT_MERGED_HOURS=24
 scanner_pairs_json="[]"
 if command -v gh &>/dev/null; then
-  raw_prs=$(gh api 'repos/kubestellar/console/pulls?state=open&per_page=50' \
-    --jq '[.[] | select(.user.login == "clubanderson") | {pr: .number, title: .title, body: (.body // "")}]' 2>/dev/null || echo "[]")
-  scanner_pairs_json=$(echo "$raw_prs" | jq '[
+  # Open PRs
+  open_prs=$(gh api 'repos/kubestellar/console/pulls?state=open&per_page=50' \
+    --jq '[.[] | select(.user.login == "clubanderson") | {pr: .number, title: .title, body: (.body // ""), created: .created_at, state: "open"}]' 2>/dev/null || echo "[]")
+  # Recently merged PRs (last 24h)
+  since=$(date -u -d "-${RECENT_MERGED_HOURS} hours" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -v-${RECENT_MERGED_HOURS}H '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "")
+  merged_prs="[]"
+  if [ -n "$since" ]; then
+    merged_prs=$(gh api "repos/kubestellar/console/pulls?state=closed&per_page=30&sort=updated&direction=desc" \
+      --jq "[.[] | select(.user.login == \"clubanderson\" and .merged_at != null and .merged_at >= \"$since\") | {pr: .number, title: .title, body: (.body // \"\"), merged: .merged_at, state: \"merged\"}]" 2>/dev/null || echo "[]")
+  fi
+  all_prs=$(echo "$open_prs" "$merged_prs" | jq -s 'add' 2>/dev/null || echo "[]")
+  scanner_pairs_json=$(echo "$all_prs" | jq '[
     .[] |
     . as $p |
-    # extract first "Fixes/Closes/Resolves #NNN" issue ref using match()
     ($p.body | match("(?i)(fixes|closes|resolves) #([0-9]+)"; "g") // null) as $m |
-    if $m then { issue: ($m.captures[1].string | tonumber), pr: $p.pr, prTitle: $p.title } else empty end
+    if $m then { issue: ($m.captures[1].string | tonumber), pr: $p.pr, prTitle: $p.title, state: $p.state, created: ($p.created // null), merged: ($p.merged // null) } else empty end
   ]' 2>/dev/null || echo "[]")
-  # Enrich pairs with issue titles via GitHub API
+  # Enrich with issue titles
   if [ "$scanner_pairs_json" != "[]" ]; then
     enriched="[]"
     while IFS= read -r pair; do
       issue_num=$(echo "$pair" | jq -r '.issue')
       pr_num=$(echo "$pair" | jq -r '.pr')
       pr_title=$(echo "$pair" | jq -r '.prTitle')
+      pr_state=$(echo "$pair" | jq -r '.state')
+      pr_created=$(echo "$pair" | jq -r '.created // empty')
+      pr_merged=$(echo "$pair" | jq -r '.merged // empty')
       issue_title=$(gh api "repos/kubestellar/console/issues/${issue_num}" --jq '.title' 2>/dev/null || echo "")
-      enriched=$(echo "$enriched" | jq --argjson n "$issue_num" --argjson p "$pr_num" --arg pt "$pr_title" --arg it "$issue_title" \
-        '. + [{issue: $n, pr: $p, prTitle: $pt, issueTitle: $it}]')
+      enriched=$(echo "$enriched" | jq --argjson n "$issue_num" --argjson p "$pr_num" --arg pt "$pr_title" --arg it "$issue_title" --arg st "$pr_state" --arg cr "$pr_created" --arg mr "$pr_merged" \
+        '. + [{issue: $n, pr: $p, prTitle: $pt, issueTitle: $it, state: $st, created: $cr, merged: $mr}]')
     done < <(echo "$scanner_pairs_json" | jq -c '.[]')
     scanner_pairs_json="$enriched"
   fi

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -248,6 +248,8 @@
     .ind-issue:hover { background: rgba(35,134,54,0.3); }
     .ind-pr { background: rgba(138,99,210,0.15); color: #bc8cff; border-color: rgba(138,99,210,0.3); }
     .ind-pr:hover { background: rgba(138,99,210,0.3); }
+    .ind-merged { background: rgba(63,185,80,0.15); color: #3fb950; border-color: rgba(63,185,80,0.3); }
+    .ind-merged:hover { background: rgba(63,185,80,0.3); }
     .ind-arrow { color: var(--muted); font-size: 0.7rem; }
     .ind-dots { display: flex; flex-wrap: wrap; gap: 8px; }
     .ind-dot-item { display: flex; align-items: center; gap: 3px; }
@@ -355,18 +357,25 @@
       if (name === 'issue-scanner' || name === 'scanner') {
         const pairs = m.pairs || [];
         if (pairs.length === 0) return '<div class="agent-indicators"><span class="ind-empty">no active fixes</span></div>';
-        const rows = pairs.map(p => {
+        const openPairs = pairs.filter(p => p.state !== 'merged');
+        const mergedPairs = pairs.filter(p => p.state === 'merged');
+        const renderPair = (p) => {
           const issueLabel = p.issueTitle ? `⊙ #${p.issue} — ${esc(p.issueTitle.length > 48 ? p.issueTitle.slice(0, 48) + '…' : p.issueTitle)}` : `⊙ #${p.issue}`;
           const issueTip = p.issueTitle ? esc(p.issueTitle) : '';
-          const prLabel = p.prTitle ? `⎇ #${p.pr}` : `⎇ #${p.pr}`;
+          const prIcon = p.state === 'merged' ? '✓' : '⎇';
+          const prCls = p.state === 'merged' ? 'ind-pr ind-merged' : 'ind-pr';
           const prTip = p.prTitle ? esc(p.prTitle) : '';
           return `<div class="ind-pair">
           <a class="ind-tag ind-issue" href="https://github.com/kubestellar/console/issues/${p.issue}" target="_blank" title="${issueTip}">${issueLabel}</a>
           <span class="ind-arrow">→</span>
-          <a class="ind-tag ind-pr" href="https://github.com/kubestellar/console/pull/${p.pr}" target="_blank" title="${prTip}">${prLabel}</a>
+          <a class="ind-tag ${prCls}" href="https://github.com/kubestellar/console/pull/${p.pr}" target="_blank" title="${prTip}">${prIcon} #${p.pr}</a>
         </div>`;
-        }).join('');
-        return `<div class="agent-indicators"><span class="ind-label">Fixes (${pairs.length}):</span>${rows}</div>`;
+        };
+        let html = '';
+        if (openPairs.length > 0) html += `<div class="agent-indicators"><span class="ind-label">In progress (${openPairs.length}):</span>${openPairs.map(renderPair).join('')}</div>`;
+        if (mergedPairs.length > 0) html += `<div class="agent-indicators"><span class="ind-label">Merged today (${mergedPairs.length}):</span>${mergedPairs.map(renderPair).join('')}</div>`;
+        if (!html) html = '<div class="agent-indicators"><span class="ind-empty">no active fixes</span></div>';
+        return html;
       }
 
       if (name === 'reviewer') {

--- a/examples/kubestellar/agents/supervisor-CLAUDE.md
+++ b/examples/kubestellar/agents/supervisor-CLAUDE.md
@@ -375,15 +375,15 @@ Without this, the dashboard shows "14h ago" stale status from your last pass. Th
 
 ## Status Reporting
 
-When reporting status to operator, **always include local timestamps (America/New_York ET)** for every kick, merge, and scheduled event. Use `TZ=America/New_York date '+%Y-%m-%d %H:%M %Z'` to get the current local time for reporting. Never use UTC-only or relative-only times (e.g., "in 15 minutes") without an absolute ET timestamp alongside.
+When reporting status to operator, **always use 12-hour clock with AM/PM in America/New_York ET** for every timestamp. Use `TZ=America/New_York date '+%Y-%m-%d %I:%M %p %Z'` to get the current local time. **NEVER use 24-hour format (13:14, 17:30).** Always use 12-hour (1:14 PM, 5:30 PM).
 
 Format:
 ```
-[2026-04-25 09:15 ET] Merged: #N, #N, #N
-[2026-04-25 09:15 ET] Dispatched agents: #N (slug), #N (slug)
-[2026-04-25 09:15 ET] Pending CI: #N
-Reviewer: <working on X | idle — kicked at 09:00 ET, next ~09:30 ET>
-Scanner: <active | idle — kicked at 09:00 ET, next ~09:15 ET>
+[2026-04-25 09:15 AM ET] Merged: #N, #N, #N
+[2026-04-25 09:15 AM ET] Dispatched agents: #N (slug), #N (slug)
+[2026-04-25 09:15 AM ET] Pending CI: #N
+Reviewer: <working on X | idle — kicked at 09:00 AM ET, next ~09:30 AM ET>
+Scanner: <active | idle — kicked at 09:00 AM ET, next ~09:15 AM ET>
 Architect: <working on X | idle>
 ```
 
@@ -391,20 +391,21 @@ Include "next kick" time (ET) for each agent when reporting after a kick or mode
 
 **Monitoring summary MUST include run start and finish timestamps:**
 
-Every monitoring summary table must be preceded by a start time and followed by a finish time, both in ET:
+Every monitoring summary table must be preceded by a start time and followed by a finish time, both in ET. The "Next run" time MUST be computed at pass END (not pass start) so it is always in the future:
 
 ```
-Pass started: 2026-04-25 10:15 ET
+Pass started: 2026-04-25 10:15 AM EDT
 
 Monitoring summary:
 | Item          | Status |
 ...
 
-Pass finished: 2026-04-25 10:17 ET
+Pass finished: 2026-04-25 10:17 AM EDT | Next run: ~10:32 AM EDT
 ```
 
-Get timestamps with: `TZ=America/New_York date '+%Y-%m-%d %H:%M %Z'`
-Run this at the very start of the pass (before any gh/git commands) and again immediately after printing the summary table.
+Get timestamps with: `TZ=America/New_York date '+%Y-%m-%d %I:%M %p %Z'`
+Compute next run at pass end: `TZ=America/New_York date -d '+15 minutes' '+%I:%M %p %Z'`
+Run the start timestamp at the very start of the pass (before any gh/git commands). Run the finish + next-run timestamps immediately after printing the summary table.
 
 ## Web Dashboard
 


### PR DESCRIPTION
## Summary

**Timestamp fixes (kick-agents.sh + supervisor-CLAUDE.md):**
- Switch all timestamps to 12-hour format (1:14 PM EDT, not 13:14)
- Next run time is now computed at pass END by the supervisor (shell command), not pre-baked at kick start — fixes the bug where "Next run: ~1:03 PM" appeared before "Pass finished: 1:14 PM"

**Scanner pairs freshness (agent-metrics.sh + index.html):**
- Fetch recently merged PRs (last 24h) alongside open PRs
- Dashboard splits into "In progress" (purple) and "Merged today" (green) sections
- Stale open-only pairs no longer dominate the display