### PR TITLE
feat: 24h timeline, coverage goal, 12hr clock

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -375,6 +375,11 @@ Send ntfy for every new listing secured. One outreach per project — never spam
 _now_et=$(TZ=America/New_York date '+%Y-%m-%d %I:%M %p %Z')
 SUPERVISOR_MSG="MONITORING PASS — Pass started: ${_now_et}
 
+HARD RULE — 12-HOUR CLOCK ONLY: Every timestamp you output MUST use 12-hour format with AM/PM. \
+Use: TZ=America/New_York date '+%Y-%m-%d %I:%M %p %Z' \
+CORRECT: 1:17 PM EDT, 10:32 AM EDT. WRONG: 13:17, 22:32. \
+If you see yourself writing a number >12 for the hour, STOP and fix it. No exceptions.
+
 Do all of the following right now:
 1. Record pass start time at the TOP of your monitoring summary: \"Pass started: ${_now_et}\"
 2. Check every agent session for questions, stalls, or errors: \

--- a/dashboard/agent-metrics.sh
+++ b/dashboard/agent-metrics.sh
@@ -61,7 +61,15 @@ reviewer_json=$(jq -n --arg doing "$reviewer_doing" --arg model "$reviewer_model
 architect_json=$(jq -n --arg doing "$architect_doing" --arg model "$architect_model" '{doing: $doing, model: $model}')
 outreach_json=$(jq -n --arg doing "$outreach_doing" --arg model "$outreach_model" '{doing: $doing, model: $model}')
 
-# ── Reviewer: health checks come from health-check.sh separately ──
+# ── Reviewer: coverage from reviewer.json ──
+REVIEWER_METRICS_FILE="/var/run/hive-metrics/reviewer.json"
+coverage_value=0
+coverage_target=91
+if [ -f "$REVIEWER_METRICS_FILE" ]; then
+  coverage_value=$(jq -r '.coverage.value // 0' "$REVIEWER_METRICS_FILE" 2>/dev/null || echo 0)
+  coverage_target=$(jq -r '.coverage.target // 91' "$REVIEWER_METRICS_FILE" 2>/dev/null || echo 91)
+fi
+reviewer_json=$(echo "$reviewer_json" | jq --argjson cv "$coverage_value" --argjson ct "$coverage_target" '. + {coverage: $cv, coverageTarget: $ct}')
 
 # ── Outreach: growth, adoption, reach metrics ──
 # Growth stats (REST API)

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -380,6 +380,18 @@
 
       if (name === 'reviewer') {
         const h = window._healthData || {};
+        const cov = m.coverage || 0;
+        const covTarget = m.coverageTarget || 91;
+        const covCls = cov >= covTarget ? 'ind-ok' : cov >= covTarget - 10 ? 'ind-warn' : 'ind-err';
+        const covBar = `<div class="agent-indicators"><div class="ind-group"><span class="ind-group-label">COVERAGE</span><div class="ind-dots">
+          <span class="ind-dot-item"><span class="ind-num ${covCls}">${cov}%</span><span class="ind-dlabel">current</span></span>
+          <span class="ind-dot-item"><span class="ind-dlabel">goal: ${covTarget}%</span></span>
+          <span class="ind-dot-item" style="flex:1;max-width:120px">
+            <div style="background:var(--border);border-radius:3px;height:6px;width:100%;position:relative">
+              <div style="background:${cov >= covTarget ? 'var(--green)' : cov >= covTarget - 10 ? 'var(--yellow)' : 'var(--red)'};height:100%;border-radius:3px;width:${Math.min(cov / covTarget * 100, 100)}%"></div>
+            </div>
+          </span>
+        </div></div></div>`;
         const groups = [
           { label: 'Artifacts', items: [
             { key: 'brew', label: 'Brew' },
@@ -408,7 +420,7 @@
           const dotCls = v === 1 ? 'ok' : v === 0 ? 'fail' : 'unknown';
           return `<span class="ind-dot-item"><span class="health-dot ${dotCls}"></span><span class="ind-dlabel">${d.label}</span></span>`;
         };
-        return `<div class="agent-indicators">${groups.map(g =>
+        return `${covBar}<div class="agent-indicators">${groups.map(g =>
           `<div class="ind-group"><span class="ind-group-label">${g.label}</span><div class="ind-dots">${g.items.map(renderItem).join('')}</div></div>`
         ).join('')}</div>`;
       }
@@ -545,11 +557,12 @@
       const modeColors = { idle: '#238636', quiet: '#58a6ff', busy: '#d29922', surge: '#f85149' };
       const modeColor = modeColors[gov.mode] || '#8b949e';
 
-      // Timeline strip from history
-      const historyModes = historyData.map(s => s.govMode || 'unknown');
-      const ticks = historyModes.map(m => `<div class="tick tick-${m}"></div>`).join('');
-      const firstTime = historyData.length > 0 ? new Date(historyData[0].t).toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'}) : '';
-      const lastTime = historyData.length > 0 ? new Date(historyData[historyData.length-1].t).toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'}) : '';
+      // Timeline strip from 24h persistent timeline data
+      const tlData = window._timelineData || [];
+      const tlModes = tlData.map(s => s.mode || 'unknown');
+      const ticks = tlModes.map(m => `<div class="tick tick-${m}"></div>`).join('');
+      const firstTime = tlData.length > 0 ? new Date(tlData[0].t).toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true}) : '';
+      const lastTime = tlData.length > 0 ? new Date(tlData[tlData.length-1].t).toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true}) : '';
 
       el.innerHTML = `
         <div class="gov-title">Governor</div>
@@ -642,7 +655,7 @@
 
     function render(data) {
       if (!data || data.error) return;
-      document.getElementById('ts').textContent = new Date(data.timestamp).toLocaleTimeString();
+      document.getElementById('ts').textContent = new Date(data.timestamp).toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true});
       currentAgentMetrics = data.agentMetrics || {};
       window._healthData = data.health || {};
       renderAgents(data.agents || []);
@@ -731,9 +744,18 @@
     window._trendData = [];
     fetch('/api/trends?range=week').then(r => r.json()).then(d => { window._trendData = d; }).catch(() => {});
     // Refresh trends every 15 min
+    const TREND_REFRESH_MS = 900000;
     setInterval(() => {
       fetch('/api/trends?range=week').then(r => r.json()).then(d => { window._trendData = d; }).catch(() => {});
-    }, 900000);
+    }, TREND_REFRESH_MS);
+    // Fetch 24h timeline for governor mode strip
+    window._timelineData = [];
+    function fetchTimeline() {
+      fetch('/api/timeline').then(r => r.json()).then(d => { window._timelineData = d; }).catch(() => {});
+    }
+    fetchTimeline();
+    const TIMELINE_REFRESH_MS = 60000;
+    setInterval(fetchTimeline, TIMELINE_REFRESH_MS);
     connect();
   </script>
 </body>

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -212,6 +212,21 @@ app.get('/api/trends', (req, res) => {
   res.json(sampled);
 });
 
+// Timeline API — 24h of mode snapshots for the governor timeline strip
+const TIMELINE_24H_MS = 24 * 60 * 60 * 1000;
+app.get('/api/timeline', (_req, res) => {
+  const cutoff = Date.now() - TIMELINE_24H_MS;
+  // Combine persistent (15-min) + recent (5s) history, deduped by time
+  const combined = [...persistentHistory, ...history]
+    .filter(s => s.t >= cutoff)
+    .sort((a, b) => a.t - b.t);
+  // Downsample to ~200 ticks for the strip
+  const MAX_TICKS = 200;
+  const step = Math.max(1, Math.floor(combined.length / MAX_TICKS));
+  const sampled = combined.filter((_, i) => i % step === 0 || i === combined.length - 1);
+  res.json(sampled.map(s => ({ t: s.t, mode: s.govMode || 'unknown' })));
+});
+
 // SSE stream
 app.get('/api/events', (req, res) => {
   res.writeHead(200, {

--- a/examples/kubestellar/agents/supervisor-CLAUDE.md
+++ b/examples/kubestellar/agents/supervisor-CLAUDE.md
@@ -17,6 +17,7 @@ These are non-negotiable. Violating any of these is a supervisor failure.
 5. **NEVER skip backend verification.** On every startup and monitoring pass, run `hive status` to confirm all agents are on their correct CLI backend (copilot on this host).
 6. **NEVER forget beads.** You read your beads at startup. Agents read theirs via the BEADS_RESTORE instructions you send. If an agent isn't reading/writing beads, that's YOUR failure — you sent an incomplete work order.
 7. **NEVER ignore agent questions.** Monitor all 4 panes. If an agent is stuck or asking a question, answer it immediately via tmux send-keys.
+8. **NEVER use 24-hour clock.** Every timestamp you output MUST be 12-hour with AM/PM. Use `TZ=America/New_York date '+%Y-%m-%d %I:%M %p %Z'`. Correct: `1:17 PM EDT`. Wrong: `13:17 EDT`. If you find yourself writing an hour > 12, stop and fix it.
 
 ## Session Bootstrap (do this automatically on every start)
 


### PR DESCRIPTION
## Summary
- **24h governor timeline**: New `/api/timeline` endpoint combines persistent (15-min) + recent (5s) history, serves 24h of mode snapshots. Timeline strip now covers full 24h window instead of ~2h.
- **Reviewer coverage goal**: Reads coverage data from `/var/run/hive-metrics/reviewer.json`. Shows coverage %, goal target (91%), and progress bar on the reviewer card.
- **12-hour clock enforcement**: Added NEVER DO rule #8 to supervisor-CLAUDE.md and HARD RULE block to supervisor kick message with explicit correct/wrong examples. Fixed dashboard header timestamp to use 12hr format.

## Test plan
- [ ] Verify timeline strip shows 24h of data with 12hr labels
- [ ] Verify reviewer card shows coverage % and progress bar
- [ ] Verify dashboard header timestamp uses 12hr format
- [ ] Kick supervisor and verify output uses 12hr timestamps