### PR TITLE
feat: per-agent token counts + supervisor custom prompt

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -506,6 +506,17 @@
       return '';
     }
 
+    function agentTokenRow(name) {
+      const byAgent = window._tokensByAgent || {};
+      const t = byAgent[name];
+      if (!t || (t.messages === 0 && t.sessions === 0)) return '';
+      const total = (t.input || 0) + (t.output || 0) + (t.cacheRead || 0);
+      if (total > 0) {
+        return `<div class="agent-field"><span class="label">tokens (24h)</span><span class="value" style="color:var(--cyan)">${fmtTokens(total)} <span style="color:var(--muted);font-size:0.65rem">(${t.sessions} sess)</span></span></div>`;
+      }
+      return `<div class="agent-field"><span class="label">tokens (24h)</span><span class="value" style="color:var(--muted)">${t.sessions} sess · ${t.messages} msgs</span></div>`;
+    }
+
     function renderAgents(agents) {
       const el = document.getElementById('agents');
       const cards = agents.map(a => {
@@ -534,10 +545,11 @@
           <div class="agent-field"><span class="label">model</span><span class="value">${a.model || ''}</span></div>
           <div class="agent-field"><span class="label">interval</span><span class="value">${a.cadence}</span></div>
           <div class="agent-field"><span class="label">next run</span><span class="value">${a.nextKick || '—'}</span></div>
+          ${agentTokenRow(a.name)}
           <div class="agent-state ${a.busy}">${a.busy}</div>
           ${needsLogin ? '<div class="login-warning">⚠ NOT LOGGED IN — run /login</div>' : ''}
           ${summaryEl}${indEl}
-          ${a.name !== 'supervisor' ? `<div class="agent-actions">
+          <div class="agent-actions">
             <input type="text" class="kick-prompt" id="kick-prompt-${a.name}" placeholder="custom prompt (optional)" />
             <button class="btn" onclick="kick('${a.name}')">kick</button>
             <select class="btn backend-select" onchange="switchCli('${a.name}', this.value); this.selectedIndex=0">
@@ -556,7 +568,7 @@
               <option value="gpt-5.4">GPT-5.4</option>
               <option value="gpt-5.2">GPT-5.2</option>
             </select>
-          </div>` : ''}
+          </div>
         </div>`;
       });
       el.innerHTML = cards.join('');
@@ -775,6 +787,7 @@
       document.getElementById('ts').textContent = new Date(data.timestamp).toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true});
       currentAgentMetrics = data.agentMetrics || {};
       window._healthData = data.health || {};
+      window._tokensByAgent = (data.tokens || {}).byAgent || {};
       renderAgents(data.agents || []);
       renderGovernor(data.governor || {}, data.cadenceMatrix || []);
       renderTokens(data.tokens || {});

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -288,7 +288,7 @@ const TMUX_SESSION = {
 // Control endpoints
 app.post('/api/kick/:agent', (req, res) => {
   const agent = req.params.agent;
-  const allowed = ['scanner', 'reviewer', 'architect', 'outreach', 'all'];
+  const allowed = ['scanner', 'reviewer', 'architect', 'outreach', 'supervisor', 'all'];
   if (!allowed.includes(agent)) {
     return res.status(400).json({ error: `invalid agent: ${agent}` });
   }

--- a/dashboard/token-collector.sh
+++ b/dashboard/token-collector.sh
@@ -36,7 +36,16 @@ if not os.path.isdir(projects_dir):
 sessions = []
 by_model = defaultdict(lambda: {"input": 0, "output": 0, "cacheRead": 0, "cacheCreate": 0, "messages": 0})
 by_cli = defaultdict(lambda: {"input": 0, "output": 0, "cacheRead": 0, "cacheCreate": 0, "messages": 0, "sessions": 0})
+by_agent = defaultdict(lambda: {"input": 0, "output": 0, "cacheRead": 0, "cacheCreate": 0, "messages": 0, "sessions": 0})
 totals = {"input": 0, "output": 0, "cacheRead": 0, "cacheCreate": 0, "messages": 0, "sessions": 0}
+
+AGENT_KEYWORDS = {
+    "scanner": ["scanner", "scanner-beads"],
+    "reviewer": ["reviewer", "reviewer-beads"],
+    "architect": ["architect", "feature-beads"],
+    "outreach": ["outreach", "outreach-beads"],
+    "supervisor": ["supervisor"],
+}
 
 for proj_name in os.listdir(projects_dir):
     proj_dir = os.path.join(projects_dir, proj_name)
@@ -52,6 +61,7 @@ for proj_name in os.listdir(projects_dir):
 
         sid = ""
         model = "unknown"
+        agent = "unknown"
         inp = 0
         out = 0
         cache_read = 0
@@ -59,6 +69,7 @@ for proj_name in os.listdir(projects_dir):
         msg_count = 0
         first_ts = ""
         last_ts = ""
+        agent_detected = False
 
         try:
             with open(fpath) as f:
@@ -70,6 +81,18 @@ for proj_name in os.listdir(projects_dir):
 
                     if "sessionId" in d and not sid:
                         sid = d["sessionId"]
+
+                    if not agent_detected and d.get("type") == "user":
+                        raw = d.get("message", "")
+                        if isinstance(raw, dict):
+                            raw = raw.get("content", "")
+                        if isinstance(raw, str):
+                            rl = raw.lower()
+                            for aname, kws in AGENT_KEYWORDS.items():
+                                if any(kw in rl for kw in kws):
+                                    agent = aname
+                                    break
+                        agent_detected = True
 
                     if d.get("type") == "assistant" and "message" in d:
                         msg = d["message"]
@@ -121,6 +144,7 @@ for proj_name in os.listdir(projects_dir):
             "id": sid[:12] if sid else os.path.basename(fpath)[:12],
             "model": model,
             "cli": cli,
+            "agent": agent,
             "input": inp,
             "output": out,
             "cacheRead": cache_read,
@@ -146,6 +170,13 @@ for proj_name in os.listdir(projects_dir):
         by_cli[cli]["messages"] += msg_count
         by_cli[cli]["sessions"] += 1
 
+        by_agent[agent]["input"] += inp
+        by_agent[agent]["output"] += out
+        by_agent[agent]["cacheRead"] += cache_read
+        by_agent[agent]["cacheCreate"] += cache_create
+        by_agent[agent]["messages"] += msg_count
+        by_agent[agent]["sessions"] += 1
+
         totals["input"] += inp
         totals["output"] += out
         totals["cacheRead"] += cache_read
@@ -162,6 +193,7 @@ result = {
     "totals": totals,
     "byModel": dict(by_model),
     "byCli": dict(by_cli),
+    "byAgent": dict(by_agent),
     "sessions": sessions[:20],  # top 20 most recent
 }
 


### PR DESCRIPTION
## Summary
- **Per-agent token counts on agent cards** — token-collector.sh now detects agent identity from the first user message in each JSONL session (keywords: scanner, reviewer, architect, outreach, supervisor + beads dir names). Adds `byAgent` aggregation to token API. Dashboard shows a "tokens (24h)" row on each agent card with total tokens + session count (claude CLI) or sessions + messages (copilot CLI where token metadata is unavailable).
- **Supervisor custom prompt** — removed the `a.name !== 'supervisor'` exclusion in index.html so supervisor gets the same custom prompt input, kick button, CLI/model selectors as other agents. Added `supervisor` to the allowed agents list in the server.js kick endpoint.

## Files changed
- `dashboard/token-collector.sh` — agent identity detection via AGENT_KEYWORDS + byAgent aggregation
- `dashboard/public/index.html` — `agentTokenRow()` function, `window._tokensByAgent`, removed supervisor exclusion from agent-actions
- `dashboard/server.js` — added `supervisor` to kick endpoint allowed list

## Test plan
- [x] Verified token-collector.sh on dev server — correctly identifies scanner (36 sess), outreach (1), supervisor (1) from 24h window
- [x] Verified `/api/tokens` returns `byAgent` data
- [x] Verified SSE status endpoint includes `byAgent` in tokens payload
- [x] Dashboard restarted on dev server and serving updated UI