### PR TITLE
feat: burn rate metrics + architect cadence increase

### DIFF
--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -9,28 +9,28 @@
 # entirely under load. Scanner and reviewer always have priority.
 #
 #   SURGE (queue > SURGE_THRESHOLD, default 20):
-#     scanner   → every 10 min
-#     reviewer  → every 10 min
+#     scanner   → every 15 min
+#     reviewer  → every 30 min
 #     architect → PAUSED
-#     outreach  → PAUSED
+#     outreach  → every 30 min
 #
 #   BUSY (queue > BUSY_THRESHOLD, default 10):
 #     scanner   → every 15 min
 #     reviewer  → every 15 min
-#     architect → PAUSED
-#     outreach  → PAUSED
+#     architect → every 1 hour
+#     outreach  → every 1 hour
 #
 #   QUIET (queue > IDLE_THRESHOLD, default 2):
 #     scanner   → every 15 min
 #     reviewer  → every 30 min
-#     architect → every 1 hour
+#     architect → every 30 min
 #     outreach  → every 2 hours
 #
 #   IDLE (queue ≤ IDLE_THRESHOLD):
 #     scanner   → every 30 min
 #     reviewer  → every 1 hour
 #     architect → every 30 min  (jam — queue is clear)
-#     outreach  → every 30 min  (jam — queue is clear)
+#     outreach  → every 2 hours
 #
 # State lives in STATE_DIR (tmpfs — cleared on reboot, fine for kick timing).
 # Logs go to journald via stdout + LOG_FILE for human review.
@@ -69,9 +69,9 @@ CADENCE_REVIEWER_BUSY_SEC="${CADENCE_REVIEWER_BUSY_SEC:-900}"     # 15 min
 CADENCE_REVIEWER_QUIET_SEC="${CADENCE_REVIEWER_QUIET_SEC:-1800}"  # 30 min
 CADENCE_REVIEWER_IDLE_SEC="${CADENCE_REVIEWER_IDLE_SEC:-3600}"    # 1 hour
 
-CADENCE_ARCHITECT_SURGE_SEC="${CADENCE_ARCHITECT_SURGE_SEC:-0}"   # PAUSED
-CADENCE_ARCHITECT_BUSY_SEC="${CADENCE_ARCHITECT_BUSY_SEC:-0}"     # PAUSED
-CADENCE_ARCHITECT_QUIET_SEC="${CADENCE_ARCHITECT_QUIET_SEC:-3600}"  # 1 hour
+CADENCE_ARCHITECT_SURGE_SEC="${CADENCE_ARCHITECT_SURGE_SEC:-0}"     # PAUSED
+CADENCE_ARCHITECT_BUSY_SEC="${CADENCE_ARCHITECT_BUSY_SEC:-3600}"    # 1 hour
+CADENCE_ARCHITECT_QUIET_SEC="${CADENCE_ARCHITECT_QUIET_SEC:-1800}"  # 30 min
 CADENCE_ARCHITECT_IDLE_SEC="${CADENCE_ARCHITECT_IDLE_SEC:-1800}"    # 30 min (jam)
 
 CADENCE_SUPERVISOR_SURGE_SEC="${CADENCE_SUPERVISOR_SURGE_SEC:-300}"   # 5 min

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -488,15 +488,35 @@
       return '';
     }
 
-    function agentTokenRow(name) {
+    function parseCadenceMinutes(cadence) {
+      if (!cadence || cadence === 'paused') return 0;
+      const m = cadence.match(/^(\d+)(m|h)$/);
+      if (!m) return 0;
+      const MINUTES_PER_HOUR = 60;
+      return m[2] === 'h' ? parseInt(m[1]) * MINUTES_PER_HOUR : parseInt(m[1]);
+    }
+
+    function agentTokenRow(name, cadence) {
       const byAgent = window._tokensByAgent || {};
       const t = byAgent[name];
       if (!t || (t.messages === 0 && t.sessions === 0)) return '';
       const total = (t.input || 0) + (t.output || 0) + (t.cacheRead || 0);
-      if (total > 0) {
-        return `<div class="agent-field"><span class="label">tokens (24h)</span><span class="value" style="color:var(--cyan)">${fmtTokens(total)} <span style="color:var(--muted);font-size:0.65rem">(${t.sessions} sess)</span></span></div>`;
+      if (total === 0) {
+        return `<div class="agent-field"><span class="label">tokens (24h)</span><span class="value" style="color:var(--muted)">${t.sessions} sess · ${t.messages} msgs</span></div>`;
       }
-      return `<div class="agent-field"><span class="label">tokens (24h)</span><span class="value" style="color:var(--muted)">${t.sessions} sess · ${t.messages} msgs</span></div>`;
+      const avg = t.avgPerSession || (t.sessions > 0 ? Math.floor(total / t.sessions) : 0);
+      let rows = `<div class="agent-field"><span class="label">tokens (24h)</span><span class="value" style="color:var(--cyan)">${fmtTokens(total)} <span style="color:var(--muted);font-size:0.65rem">(${t.sessions} sess)</span></span></div>`;
+      rows += `<div class="agent-field"><span class="label">avg/pass</span><span class="value">${fmtTokens(avg)}</span></div>`;
+      const intervalMin = parseCadenceMinutes(cadence);
+      if (intervalMin > 0 && avg > 0) {
+        const MINUTES_PER_HOUR = 60;
+        const HOURS_PER_WEEK = 168;
+        const passesPerHour = MINUTES_PER_HOUR / intervalMin;
+        const tokensPerHour = avg * passesPerHour;
+        const tokensPerWeek = tokensPerHour * HOURS_PER_WEEK;
+        rows += `<div class="agent-field"><span class="label">burn rate</span><span class="value" style="color:var(--yellow)">${fmtTokens(tokensPerHour)}/hr · ${fmtTokens(tokensPerWeek)}/wk</span></div>`;
+      }
+      return rows;
     }
 
     function renderAgents(agents) {
@@ -527,7 +547,7 @@
           <div class="agent-field"><span class="label">model</span><span class="value">${a.model || ''}</span></div>
           <div class="agent-field"><span class="label">interval</span><span class="value">${a.cadence}</span></div>
           <div class="agent-field"><span class="label">next run</span><span class="value">${a.nextKick || '—'}</span></div>
-          ${agentTokenRow(a.name)}
+          ${agentTokenRow(a.name, a.cadence)}
           <div class="agent-state ${a.busy}">${a.busy}</div>
           ${needsLogin ? '<div class="login-warning">⚠ NOT LOGGED IN — run /login</div>' : ''}
           ${summaryEl}${indEl}

--- a/dashboard/token-collector.sh
+++ b/dashboard/token-collector.sh
@@ -187,6 +187,11 @@ for proj_name in os.listdir(projects_dir):
 # Sort sessions by most recent first
 sessions.sort(key=lambda s: s.get("mtime", 0), reverse=True)
 
+for aname, astats in by_agent.items():
+    s = astats["sessions"]
+    total = astats["input"] + astats["output"] + astats["cacheRead"]
+    astats["avgPerSession"] = total // s if s > 0 else 0
+
 result = {
     "timestamp": int(time.time() * 1000),
     "lookbackHours": lookback_hours,


### PR DESCRIPTION
## Summary
- **Burn rate metrics on agent cards** — token collector computes `avgPerSession` per agent. Dashboard shows avg/pass and projected burn rate (tokens/hr, tokens/wk) based on current governor cadence. Enables tuning cadence to stay within token budgets.
- **Architect cadence increase** — un-paused architect in busy mode (→ 1hr), doubled quiet frequency (1hr → 30min). With 13% weekly Claude usage, there's headroom for more architecture passes. Architect remains paused only in surge mode.
- **Removed header CLI token pills** (PR #58) already merged separately.

## Cadence matrix (new)
| Agent | Surge | Busy | Quiet | Idle |
|-------|-------|------|-------|------|
| scanner | 15m | 15m | 15m | 30m |
| reviewer | 30m | 15m | 30m | 1h |
| **architect** | paused | **1h** | **30m** | 30m |
| outreach | 30m | 1h | 2h | 2h |

## Files changed
- `dashboard/token-collector.sh` — `avgPerSession` computation per agent
- `dashboard/public/index.html` — `parseCadenceMinutes()`, burn rate display in `agentTokenRow()`
- `bin/kick-governor.sh` — architect busy 0→3600, quiet 3600→1800

## Test plan
- [x] Verified `avgPerSession` in `/api/tokens` response (scanner: 43.1M avg/pass)
- [x] Dashboard deployed and showing burn rate on agent cards
- [x] Governor config deployed to dev server