### PR TITLE
feat: governor model optimizer — budget-driven model selection

### DIFF
--- a/bin/hive.sh
+++ b/bin/hive.sh
@@ -719,8 +719,13 @@ cmd_status_json() {
       fi
     elif [[ "$cadence" == "paused" ]]; then nk="paused"
     fi
+    # Governor-assigned model
+    local gov_backend gov_model gov_cost
+    gov_backend=$(grep '^BACKEND=' "$GOV_STATE/model_${label}" 2>/dev/null | cut -d= -f2 || echo "")
+    gov_model=$(grep '^MODEL=' "$GOV_STATE/model_${label}" 2>/dev/null | cut -d= -f2 || echo "")
+    gov_cost=$(grep '^COST_WEIGHT=' "$GOV_STATE/model_${label}" 2>/dev/null | cut -d= -f2 || echo "0")
     [[ $i -gt 0 ]] && agents_json+=","
-    agents_json+="{\"name\":\"$label\",\"session\":\"$s\",\"state\":\"$state\",\"cli\":\"$cli\",\"model\":\"$model\",\"cadence\":\"$cadence\",\"busy\":\"$busy\",\"doing\":\"$doing\",\"nextKick\":\"$nk\",\"needsLogin\":$needs_login}"
+    agents_json+="{\"name\":\"$label\",\"session\":\"$s\",\"state\":\"$state\",\"cli\":\"$cli\",\"model\":\"$model\",\"cadence\":\"$cadence\",\"busy\":\"$busy\",\"doing\":\"$doing\",\"nextKick\":\"$nk\",\"needsLogin\":$needs_login,\"govBackend\":\"$gov_backend\",\"govModel\":\"$gov_model\",\"govCostWeight\":$gov_cost}"
   done
   agents_json+="]"
 
@@ -797,8 +802,24 @@ for a in agents:
 print('[' + ','.join(rows) + ']')
 " 2>/dev/null || echo "[]")
 
+  # Budget state from governor
+  local _budget_json="{}"
+  local _bf="$GOV_STATE/budget_state"
+  if [[ -f "$_bf" ]]; then
+    _budget_json=$(python3 -c "
+import json
+d = {}
+for line in open('$_bf'):
+    k, _, v = line.strip().partition('=')
+    if k and v:
+        try: d[k] = int(v)
+        except ValueError: d[k] = v
+print(json.dumps(d))
+" 2>/dev/null || echo "{}")
+  fi
+
   cat <<ENDJSON
-{"timestamp":"$now","agents":$agents_json,"governor":{"mode":"$gov_mode","active":$([ "$gov_active" = "active" ] && echo true || echo false),"issues":$gov_qi,"prs":$gov_qp,"nextKick":"$gov_next"},"cadenceMatrix":$_cm,"repos":$repos_json,"beads":{"workers":$beads_workers,"supervisor":$beads_supervisor}}
+{"timestamp":"$now","agents":$agents_json,"governor":{"mode":"$gov_mode","active":$([ "$gov_active" = "active" ] && echo true || echo false),"issues":$gov_qi,"prs":$gov_qp,"nextKick":"$gov_next"},"budget":$_budget_json,"cadenceMatrix":$_cm,"repos":$repos_json,"beads":{"workers":$beads_workers,"supervisor":$beads_supervisor}}
 ENDJSON
 }
 

--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -372,6 +372,62 @@ If you find a bug or improvement idea, file a beads issue for the scanner — do
 Fork under clubanderson account for all external PRs to third-party repos. \
 Send ntfy for every new listing secured. One outreach per project — never spam. $(beads_sync "$OUTREACH_BEADS" "outreach")"
 
+# ── Governor model integration ──────────────────────────────────────
+# Reads /var/run/kick-governor/model_<agent> written by the governor's
+# optimize_model_assignment(). If the model changed, restarts the agent
+# with the new backend/model and returns 1 (skip this kick cycle).
+GOVERNOR_STATE_DIR="/var/run/kick-governor"
+
+apply_model_if_changed() {
+  local agent="$1" session="$2"
+  local model_file="$GOVERNOR_STATE_DIR/model_${agent}"
+  [[ ! -f "$model_file" ]] && return 0
+
+  local gov_backend gov_model
+  gov_backend=$(grep '^BACKEND=' "$model_file" 2>/dev/null | cut -d= -f2)
+  gov_model=$(grep '^MODEL=' "$model_file" 2>/dev/null | cut -d= -f2)
+  [[ -z "$gov_backend" || -z "$gov_model" ]] && return 0
+
+  local cur_backend
+  cur_backend=$(get_current_backend "$agent")
+  local cur_model
+  cur_model=$(get_model_for "$agent" "$cur_backend")
+
+  if [[ "$cur_backend" == "$gov_backend" && "$cur_model" == "$gov_model" ]]; then
+    return 0
+  fi
+
+  log "MODEL SWITCH $agent: ${cur_backend}:${cur_model} → ${gov_backend}:${gov_model} (governor)"
+
+  if ! session_exists "$session"; then
+    set_current_backend "$agent" "$gov_backend"
+    BACKEND_MODEL[$gov_backend]="$gov_model"
+    AGENT_MODEL_OVERRIDE["${agent}-${gov_backend}"]="$gov_model"
+    return 0
+  fi
+
+  if ! session_idle "$session"; then
+    log "MODEL SWITCH $agent — session busy, will apply on next kick"
+    return 0
+  fi
+
+  capture_handoff_state "$session" "$agent"
+
+  $TMUX_BIN send-keys -t "$session" "/exit" 2>/dev/null || true
+  $TMUX_BIN send-keys -t "$session" Enter 2>/dev/null || true
+  sleep 3
+
+  $TMUX_BIN send-keys -t "$session" "agent-launch.sh --backend $gov_backend --model $gov_model" 2>/dev/null || true
+  $TMUX_BIN send-keys -t "$session" Enter 2>/dev/null || true
+
+  set_current_backend "$agent" "$gov_backend"
+  BACKEND_MODEL[$gov_backend]="$gov_model"
+  AGENT_MODEL_OVERRIDE["${agent}-${gov_backend}"]="$gov_model"
+
+  log "MODEL SWITCH $agent — relaunched with ${gov_backend}:${gov_model}"
+  return 1
+}
+
 _now_et=$(TZ=America/New_York date '+%Y-%m-%d %I:%M %p %Z')
 SUPERVISOR_MSG="MONITORING PASS — Pass started: ${_now_et}
 
@@ -395,25 +451,25 @@ Do all of the following right now:
 
 case "$TARGET" in
   scanner)
-    kick "issue-scanner" "$SCANNER_MSG" "scanner"
+    apply_model_if_changed "scanner" "issue-scanner" && kick "issue-scanner" "$SCANNER_MSG" "scanner"
     ;;
   reviewer)
-    kick "reviewer" "$REVIEWER_MSG" "reviewer"
+    apply_model_if_changed "reviewer" "reviewer" && kick "reviewer" "$REVIEWER_MSG" "reviewer"
     ;;
   architect)
-    kick "feature" "$ARCHITECT_MSG" "architect"
+    apply_model_if_changed "architect" "feature" && kick "feature" "$ARCHITECT_MSG" "architect"
     ;;
   outreach)
-    kick "outreach" "$OUTREACH_MSG" "outreach"
+    apply_model_if_changed "outreach" "outreach" && kick "outreach" "$OUTREACH_MSG" "outreach"
     ;;
   supervisor)
-    kick "supervisor" "$SUPERVISOR_MSG" "supervisor"
+    apply_model_if_changed "supervisor" "supervisor" && kick "supervisor" "$SUPERVISOR_MSG" "supervisor"
     ;;
   all)
-    kick "issue-scanner" "$SCANNER_MSG" "scanner"
-    kick "reviewer" "$REVIEWER_MSG" "reviewer"
-    kick "feature" "$ARCHITECT_MSG" "architect"
-    kick "outreach" "$OUTREACH_MSG" "outreach"
+    apply_model_if_changed "scanner" "issue-scanner" && kick "issue-scanner" "$SCANNER_MSG" "scanner"
+    apply_model_if_changed "reviewer" "reviewer" && kick "reviewer" "$REVIEWER_MSG" "reviewer"
+    apply_model_if_changed "architect" "feature" && kick "feature" "$ARCHITECT_MSG" "architect"
+    apply_model_if_changed "outreach" "outreach" && kick "outreach" "$OUTREACH_MSG" "outreach"
     # supervisor is NOT kicked in "all" — it has its own cadence via governor
     ;;
   *)

--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -84,6 +84,48 @@ CADENCE_OUTREACH_BUSY_SEC="${CADENCE_OUTREACH_BUSY_SEC:-3600}"      # 1 hour
 CADENCE_OUTREACH_QUIET_SEC="${CADENCE_OUTREACH_QUIET_SEC:-7200}"    # 2 hours
 CADENCE_OUTREACH_IDLE_SEC="${CADENCE_OUTREACH_IDLE_SEC:-7200}"      # 2 hours
 
+# ── Token budget ────────────────────────────────────────────────────────────
+TOKEN_BUDGET_WEEKLY="${TOKEN_BUDGET_WEEKLY:-50000000}"
+TOKEN_BUDGET_SAFETY_PCT="${TOKEN_BUDGET_SAFETY_PCT:-85}"
+TOKEN_BUDGET_RESET_DAY="${TOKEN_BUDGET_RESET_DAY:-0}"  # 0=Sunday
+TOKEN_COLLECTOR_JSON="/var/run/hive-metrics/tokens.json"
+
+# ── Cost weights (relative to Haiku=1) ──────────────────────────────────────
+COST_WEIGHT_OPUS="${COST_WEIGHT_OPUS:-15}"
+COST_WEIGHT_SONNET="${COST_WEIGHT_SONNET:-3}"
+COST_WEIGHT_HAIKU="${COST_WEIGHT_HAIKU:-1}"
+
+# ── Model selection table: MODEL_<MODE>_<AGENT>=backend:model ───────────────
+# Priority agents (scanner, reviewer) get metered Claude in surge/busy.
+# Non-priority agents (architect, outreach) use copilot (free/unlimited).
+# Supervisor is lightweight — Haiku or copilot.
+MODEL_SURGE_SCANNER="${MODEL_SURGE_SCANNER:-claude:claude-sonnet-4-6}"
+MODEL_SURGE_REVIEWER="${MODEL_SURGE_REVIEWER:-claude:claude-sonnet-4-6}"
+MODEL_SURGE_ARCHITECT="${MODEL_SURGE_ARCHITECT:-claude:claude-opus-4-6}"
+MODEL_SURGE_OUTREACH="${MODEL_SURGE_OUTREACH:-copilot:claude-opus-4.6}"
+MODEL_SURGE_SUPERVISOR="${MODEL_SURGE_SUPERVISOR:-claude:claude-haiku-4-5}"
+
+MODEL_BUSY_SCANNER="${MODEL_BUSY_SCANNER:-claude:claude-sonnet-4-6}"
+MODEL_BUSY_REVIEWER="${MODEL_BUSY_REVIEWER:-claude:claude-sonnet-4-6}"
+MODEL_BUSY_ARCHITECT="${MODEL_BUSY_ARCHITECT:-copilot:claude-sonnet-4.6}"
+MODEL_BUSY_OUTREACH="${MODEL_BUSY_OUTREACH:-copilot:claude-sonnet-4.6}"
+MODEL_BUSY_SUPERVISOR="${MODEL_BUSY_SUPERVISOR:-claude:claude-haiku-4-5}"
+
+MODEL_QUIET_SCANNER="${MODEL_QUIET_SCANNER:-claude:claude-haiku-4-5}"
+MODEL_QUIET_REVIEWER="${MODEL_QUIET_REVIEWER:-copilot:claude-sonnet-4.6}"
+MODEL_QUIET_ARCHITECT="${MODEL_QUIET_ARCHITECT:-copilot:claude-opus-4.6}"
+MODEL_QUIET_OUTREACH="${MODEL_QUIET_OUTREACH:-copilot:claude-sonnet-4.6}"
+MODEL_QUIET_SUPERVISOR="${MODEL_QUIET_SUPERVISOR:-claude:claude-haiku-4-5}"
+
+MODEL_IDLE_SCANNER="${MODEL_IDLE_SCANNER:-copilot:claude-sonnet-4.6}"
+MODEL_IDLE_REVIEWER="${MODEL_IDLE_REVIEWER:-copilot:claude-sonnet-4.6}"
+MODEL_IDLE_ARCHITECT="${MODEL_IDLE_ARCHITECT:-copilot:claude-opus-4.6}"
+MODEL_IDLE_OUTREACH="${MODEL_IDLE_OUTREACH:-copilot:claude-sonnet-4.6}"
+MODEL_IDLE_SUPERVISOR="${MODEL_IDLE_SUPERVISOR:-copilot:claude-sonnet-4.6}"
+
+RATE_LIMIT_FALLBACK_BACKEND="${RATE_LIMIT_FALLBACK_BACKEND:-copilot}"
+RATE_LIMIT_COOLDOWN="${RATE_LIMIT_COOLDOWN:-1800}"  # 30 min
+
 # ── Paths ───────────────────────────────────────────────────────────────────
 STATE_DIR="/var/run/kick-governor"
 LOG_FILE="/var/log/kick-governor.log"
@@ -275,6 +317,216 @@ get_cadence() {
   esac
 }
 
+# ── Model selection ──────────────────────────────────────────────────────────
+
+convert_model_notation() {
+  local model="$1" target_backend="$2"
+  case "$target_backend" in
+    copilot) echo "$model" | sed -E 's/([0-9])-([0-9])/\1.\2/g' ;;
+    *)       echo "$model" | sed -E 's/([0-9])\.([0-9])/\1-\2/g' ;;
+  esac
+}
+
+get_model_selection() {
+  local agent="$1" mode="$2"
+  local upper_mode upper_agent
+  upper_mode=$(echo "$mode" | tr '[:lower:]' '[:upper:]')
+  upper_agent=$(echo "$agent" | tr '[:lower:]' '[:upper:]')
+  local var_name="MODEL_${upper_mode}_${upper_agent}"
+  local selection="${!var_name}"
+  if [[ -z "$selection" ]]; then
+    selection="copilot:claude-sonnet-4.6"
+  fi
+  echo "$selection"
+}
+
+get_cost_weight() {
+  local backend="$1" model="$2"
+  case "$backend" in
+    copilot|goose) echo 0; return ;;
+  esac
+  case "$model" in
+    *opus*)   echo "${COST_WEIGHT_OPUS}" ;;
+    *sonnet*) echo "${COST_WEIGHT_SONNET}" ;;
+    *haiku*)  echo "${COST_WEIGHT_HAIKU}" ;;
+    *)        echo "${COST_WEIGHT_SONNET}" ;;
+  esac
+}
+
+is_rate_limited() {
+  local backend="$1"
+  local rl_file="$STATE_DIR/rate_limits"
+  [[ ! -f "$rl_file" ]] && return 1
+  local now
+  now=$(date +%s)
+  while IFS=: read -r rl_backend rl_time _rl_agent; do
+    if [[ "$rl_backend" == "$backend" ]] && (( now - rl_time < RATE_LIMIT_COOLDOWN )); then
+      return 0
+    fi
+  done < "$rl_file"
+  return 1
+}
+
+compute_budget_state() {
+  local budget_file="$STATE_DIR/budget_state"
+  local used=0 burn_hourly=0
+
+  if [[ -f "$TOKEN_COLLECTOR_JSON" ]]; then
+    read -r used burn_hourly <<< "$(python3 -c "
+import json
+try:
+    with open('$TOKEN_COLLECTOR_JSON') as f:
+        d = json.load(f)
+    weekly = d.get('weekly', {})
+    used = weekly.get('totalTokens', 0)
+    hourly = d.get('hourlyBurnRate', {}).get('total', 0)
+    if used == 0 and hourly == 0:
+        ba = d.get('byAgent', {})
+        for stats in ba.values():
+            used += stats.get('input', 0) + stats.get('output', 0) + stats.get('cacheRead', 0)
+    print(used, hourly)
+except Exception:
+    print(0, 0)
+" 2>/dev/null || echo "0 0")"
+  fi
+
+  local remaining=$((TOKEN_BUDGET_WEEKLY - used))
+  [[ "$remaining" -lt 0 ]] && remaining=0
+  local pct_used=0
+  [[ "$TOKEN_BUDGET_WEEKLY" -gt 0 ]] && pct_used=$((used * 100 / TOKEN_BUDGET_WEEKLY))
+
+  local hours_left
+  hours_left=$(python3 -c "
+import datetime
+now = datetime.datetime.now()
+reset_day = $TOKEN_BUDGET_RESET_DAY
+days_ahead = (reset_day - now.weekday()) % 7
+if days_ahead == 0 and now.hour > 0: days_ahead = 7
+reset = (now + datetime.timedelta(days=days_ahead)).replace(hour=0, minute=0, second=0, microsecond=0)
+print(max(1, int((reset - now).total_seconds() // 3600)))
+" 2>/dev/null || echo 168)
+
+  local projected=$((used + burn_hourly * hours_left))
+  local projected_pct=0
+  [[ "$TOKEN_BUDGET_WEEKLY" -gt 0 ]] && projected_pct=$((projected * 100 / TOKEN_BUDGET_WEEKLY))
+
+  cat > "$budget_file" <<BUDGETEOF
+BUDGET_WEEKLY=$TOKEN_BUDGET_WEEKLY
+BUDGET_USED=$used
+BUDGET_REMAINING=$remaining
+BUDGET_PCT_USED=$pct_used
+BURN_RATE_HOURLY=$burn_hourly
+HOURS_REMAINING=$hours_left
+PROJECTED_WEEKLY=$projected
+PROJECTED_PCT=$projected_pct
+LAST_UPDATED=$(date -Iseconds)
+BUDGETEOF
+
+  echo "$projected_pct"
+}
+
+optimize_model_assignment() {
+  local mode="$1"
+  local agents=(scanner reviewer architect outreach supervisor)
+  local priority_agents=(scanner reviewer)
+
+  local projected_pct
+  projected_pct=$(compute_budget_state)
+
+  declare -A assignments
+  for agent in "${agents[@]}"; do
+    assignments[$agent]=$(get_model_selection "$agent" "$mode")
+  done
+
+  if (( projected_pct > TOKEN_BUDGET_SAFETY_PCT )); then
+    log "BUDGET PRESSURE: projected ${projected_pct}% > safety ${TOKEN_BUDGET_SAFETY_PCT}%"
+
+    for agent in outreach architect supervisor; do
+      local current="${assignments[$agent]}"
+      local backend="${current%%:*}"
+      if [[ "$backend" != "copilot" && "$backend" != "goose" ]]; then
+        local model="${current#*:}"
+        local copilot_model
+        copilot_model=$(convert_model_notation "$model" "copilot")
+        assignments[$agent]="copilot:${copilot_model}"
+        log "  budget override: $agent -> copilot (was $backend)"
+      fi
+    done
+
+    if (( projected_pct > 95 )); then
+      for agent in "${priority_agents[@]}"; do
+        local current="${assignments[$agent]}"
+        local backend="${current%%:*}"
+        local model="${current#*:}"
+        case "$model" in
+          *opus*)
+            local new_model="${model/opus/sonnet}"
+            assignments[$agent]="${backend}:${new_model}"
+            log "  budget override: $agent opus->sonnet"
+            ;;
+          *sonnet*)
+            local new_model="${model/sonnet/haiku}"
+            assignments[$agent]="${backend}:${new_model}"
+            log "  budget override: $agent sonnet->haiku"
+            ;;
+        esac
+      done
+    fi
+
+    if (( projected_pct > 99 )); then
+      for agent in "${agents[@]}"; do
+        local current="${assignments[$agent]}"
+        local model="${current#*:}"
+        local copilot_model
+        copilot_model=$(convert_model_notation "$model" "copilot")
+        assignments[$agent]="copilot:${copilot_model}"
+      done
+      log "  BUDGET CRITICAL: all agents -> copilot"
+    fi
+  fi
+
+  for agent in "${agents[@]}"; do
+    local selection="${assignments[$agent]}"
+    local backend="${selection%%:*}"
+    local model="${selection#*:}"
+
+    if is_rate_limited "$backend"; then
+      local fallback="${RATE_LIMIT_FALLBACK_BACKEND}"
+      local fb_model
+      fb_model=$(convert_model_notation "$model" "$fallback")
+      backend="$fallback"
+      model="$fb_model"
+      log "  rate-limit swap: $agent -> $fallback"
+    fi
+
+    local lock_file="$STATE_DIR/model_lock_${agent}"
+    if [[ -f "$lock_file" ]]; then
+      log "  LOCKED: $agent (manual override — skipping)"
+      continue
+    fi
+
+    local cost_weight
+    cost_weight=$(get_cost_weight "$backend" "$model")
+    local prev_backend prev_model
+    prev_backend=$(grep '^BACKEND=' "$STATE_DIR/model_${agent}" 2>/dev/null | cut -d= -f2)
+    prev_model=$(grep '^MODEL=' "$STATE_DIR/model_${agent}" 2>/dev/null | cut -d= -f2)
+
+    cat > "$STATE_DIR/model_${agent}" <<MODELEOF
+BACKEND=$backend
+MODEL=$model
+COST_WEIGHT=$cost_weight
+REASON=${mode}_mode
+PREV_BACKEND=${prev_backend:-}
+PREV_MODEL=${prev_model:-}
+UPDATED=$(date -Iseconds)
+MODELEOF
+
+    if [[ -n "$prev_backend" && ("$prev_backend" != "$backend" || "$prev_model" != "$model") ]]; then
+      log "MODEL CHANGE ${agent}: ${prev_backend}:${prev_model} -> ${backend}:${model}"
+    fi
+  done
+}
+
 # ── Last-kick tracking ───────────────────────────────────────────────────────
 
 last_kick_file() { echo "$STATE_DIR/last_kick_${1}"; }
@@ -370,6 +622,9 @@ for _agent in scanner reviewer architect outreach supervisor; do
   fi > "$STATE_DIR/cadence_${_agent}"
 done
 
+# Run model optimizer — writes model state files before agents are kicked
+optimize_model_assignment "$mode"
+
 # Report mode transitions
 if [ -n "$prev_mode" ] && [ "$prev_mode" != "$mode" ]; then
   log "MODE CHANGE ${prev_mode} → ${mode} (queue=${queue_depth} threshold=${BUSY_THRESHOLD_ISSUES})"
@@ -380,6 +635,14 @@ if [ -n "$prev_mode" ] && [ "$prev_mode" != "$mode" ]; then
 fi
 
 log "MODE=${mode} queue=${queue_depth} scanner=$(secs_to_label "$(get_cadence scanner "$mode")") reviewer=$(secs_to_label "$(get_cadence reviewer "$mode")") architect=$(secs_to_label "$(get_cadence architect "$mode")") outreach=$(secs_to_label "$(get_cadence outreach "$mode")")"
+
+# Log model assignments
+budget_pct=$(grep '^PROJECTED_PCT=' "$STATE_DIR/budget_state" 2>/dev/null | cut -d= -f2 || echo "?")
+log "BUDGET projected=${budget_pct}% models: $(for _a in scanner reviewer architect outreach supervisor; do
+  _b=$(grep '^BACKEND=' "$STATE_DIR/model_${_a}" 2>/dev/null | cut -d= -f2 || echo "?")
+  _m=$(grep '^MODEL=' "$STATE_DIR/model_${_a}" 2>/dev/null | cut -d= -f2 || echo "?")
+  printf '%s=%s:%s ' "$_a" "$_b" "$_m"
+done)"
 
 maybe_kick scanner    "$mode"
 maybe_kick reviewer   "$mode"

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -309,6 +309,22 @@
     .advisor-tip { font-size: 0.72rem; color: var(--text); padding: 4px 8px; background: rgba(210,153,34,0.08); border-left: 2px solid var(--yellow); border-radius: 0 4px 4px 0; }
     .advisor-tip b { color: var(--cyan); }
 
+    /* Budget bar */
+    .budget-bar { margin: 8px 0; }
+    .budget-bar-label { font-size: 0.72rem; color: var(--muted); margin-bottom: 3px; display: flex; justify-content: space-between; }
+    .budget-bar-track { height: 8px; background: var(--bg); border-radius: 4px; overflow: hidden; }
+    .budget-bar-fill { height: 100%; border-radius: 4px; transition: width 0.5s ease; }
+    .budget-bar-fill.safe { background: var(--green); }
+    .budget-bar-fill.warning { background: var(--yellow); }
+    .budget-bar-fill.danger { background: var(--red); }
+
+    /* Model chip on agent cards */
+    .model-chip { display: inline-flex; align-items: center; gap: 4px; font-size: 0.65rem; padding: 2px 6px; border-radius: 4px; }
+    .model-chip.free { background: rgba(63,185,80,0.12); color: var(--green); }
+    .model-chip.haiku { background: rgba(88,166,255,0.12); color: var(--blue); }
+    .model-chip.sonnet { background: rgba(210,153,34,0.12); color: var(--yellow); }
+    .model-chip.opus { background: rgba(248,81,73,0.12); color: var(--red); }
+
     /* Health dots (reused inside reviewer indicators) */
     .health-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; display: inline-block; }
     .health-dot.ok { background: #3fb950; }
@@ -559,7 +575,7 @@
         return `<div class="agent-card ${cls}">
           <div class="agent-name"><span class="dot ${dotCls}"></span>${a.name}</div>
           <div class="agent-field"><span class="label">cli</span><span class="value ${a.cli}">${a.cli}</span></div>
-          <div class="agent-field"><span class="label">model</span><span class="value">${a.model || ''}</span></div>
+          <div class="agent-field"><span class="label">model</span><span class="value">${a.model || ''} ${a.govBackend ? modelChip(a.govBackend, a.govModel) : ''}</span></div>
           <div class="agent-field"><span class="label">interval</span><span class="value">${a.cadence}</span></div>
           <div class="agent-field"><span class="label">next run</span><span class="value">${a.nextKick || '—'}</span></div>
           ${agentTokenRow(a.name, a.cadence)}
@@ -616,7 +632,7 @@
       }).join('');
     }
 
-    function renderGovernor(gov, cadenceMatrix) {
+    function renderGovernor(gov, cadenceMatrix, data) {
       const el = document.getElementById('governor');
       const cls = gov.active ? 'active' : 'dead';
       el.className = `governor ${cls}`;
@@ -674,11 +690,13 @@
             <span class="tl-surge">surge</span>
           </div>
         </div>
+        ${renderBudgetBar(data.budget || {})}
         ${renderCadenceMatrix(cadenceMatrix, currentMode, modes)}`;
     }
 
     function renderCadenceMatrix(matrix, currentMode, modes) {
       if (!matrix || !matrix.length) return '';
+      const agents = window._lastAgents || [];
       const agentOrder = ['supervisor', 'scanner', 'reviewer', 'architect', 'outreach'];
       const rows = agentOrder.map(aname => {
         const row = matrix.find(r => r.agent === aname);
@@ -691,7 +709,9 @@
           const pausedCls = isPaused ? ' paused' : '';
           return `<td class="${colCls}${pausedCls}">${isPaused ? '—' : val}</td>`;
         }).join('');
-        return `<tr><td>${aname}</td>${cells}</tr>`;
+        const agentData = agents.find(a => a.name === aname);
+        const mChip = agentData && agentData.govBackend ? modelChip(agentData.govBackend, agentData.govModel) : '';
+        return `<tr><td>${aname}</td>${cells}<td>${mChip}</td></tr>`;
       }).join('');
       const headers = modes.map(m => {
         const isActive = m === currentMode;
@@ -699,7 +719,7 @@
         return `<th class="${cls}">${m}${isActive ? ' ◀' : ''}</th>`;
       }).join('');
       return `<table class="gov-matrix">
-        <thead><tr><th></th>${headers}</tr></thead>
+        <thead><tr><th></th>${headers}<th>model</th></tr></thead>
         <tbody>${rows}</tbody>
       </table>`;
     }
@@ -734,6 +754,37 @@
       if (n >= 1e6) return (n / 1e6).toFixed(1) + 'M';
       if (n >= 1e3) return (n / 1e3).toFixed(1) + 'K';
       return String(n);
+    }
+
+    function renderBudgetBar(budget) {
+      if (!budget || !budget.BUDGET_WEEKLY) return '';
+      const PCT_SAFE = 50;
+      const PCT_WARN = 85;
+      const pct = budget.PROJECTED_PCT || 0;
+      const used = budget.BUDGET_USED || 0;
+      const weekly = budget.BUDGET_WEEKLY;
+      const fillCls = pct < PCT_SAFE ? 'safe' : pct < PCT_WARN ? 'warning' : 'danger';
+      const burnRate = budget.BURN_RATE_HOURLY || 0;
+      const hoursLeft = budget.HOURS_REMAINING || 0;
+      return `<div class="budget-bar">
+        <div class="budget-bar-label">
+          <span>Token Budget: ${fmtTokens(used)} / ${fmtTokens(weekly)} (${budget.BUDGET_PCT_USED || 0}% used)</span>
+          <span>Projected: ${pct}% · ${fmtTokens(burnRate)}/hr · ${hoursLeft}h left</span>
+        </div>
+        <div class="budget-bar-track"><div class="budget-bar-fill ${fillCls}" style="width:${Math.min(pct, 100)}%"></div></div>
+      </div>`;
+    }
+
+    function modelChip(backend, model) {
+      if (!backend || backend === 'unknown') return '';
+      const isFree = backend === 'copilot' || backend === 'goose';
+      let tier = 'sonnet';
+      if (isFree) tier = 'free';
+      else if (model && model.includes('haiku')) tier = 'haiku';
+      else if (model && model.includes('opus')) tier = 'opus';
+      const shortModel = model ? model.replace(/^claude-/, '').replace(/-\d+-\d+$/, m => m.replace(/-/g, '.').slice(0, 4)) : '?';
+      const label = isFree ? `${backend}` : shortModel;
+      return `<span class="model-chip ${tier}" title="${backend}:${model}">${label}</span>`;
     }
 
     function buildCadenceAdvisor(byAgent) {
@@ -791,6 +842,38 @@
       for (const r of rows) {
         if (r.cli === 'copilot' && r.avg === 0 && !r.isPaused) {
           tips.push(`<b>${r.name}</b> runs on copilot (unlimited tokens, no metering). Token burn unknown — consider switching to claude CLI for visibility.`);
+        }
+      }
+
+      // Model-aware tips from governor assignments
+      const OPUS_COST = 15;
+      const SONNET_COST = 3;
+      for (const r of rows) {
+        const agentData = agents.find(a => a.name === r.name);
+        if (!agentData) continue;
+        const gb = agentData.govBackend;
+        const gm = agentData.govModel || '';
+        if (gb === 'copilot' || gb === 'goose') {
+          if (r.weeklyBurn > 0) {
+            tips.push(`<b>${r.name}</b> assigned to ${gb} (free) — ${fmtTokens(r.weeklyBurn)}/wk savings vs metered CLI.`);
+          }
+        } else if (gm.includes('opus') && r.weeklyBurn > 0) {
+          const sonnetBurn = Math.round(r.weeklyBurn * SONNET_COST / OPUS_COST);
+          tips.push(`<b>${r.name}</b> on Opus (${OPUS_COST}x) — switching to Sonnet would save ~${fmtTokens(r.weeklyBurn - sonnetBurn)}/wk in cost-adjusted tokens.`);
+        }
+      }
+
+      const budget = window._lastBudget || {};
+      if (budget.PROJECTED_PCT) {
+        const SAFE_THRESHOLD = 50;
+        const WARN_THRESHOLD = 85;
+        if (budget.PROJECTED_PCT > WARN_THRESHOLD) {
+          tips.push(`Budget projected at <b>${budget.PROJECTED_PCT}%</b> — governor is auto-downgrading models to stay within budget.`);
+        } else if (budget.PROJECTED_PCT < SAFE_THRESHOLD) {
+          const paused = rows.filter(r => r.isPaused);
+          if (paused.length > 0) {
+            tips.push(`Budget at ${budget.PROJECTED_PCT}% — headroom to enable paused agents: ${paused.map(r => `<b>${r.name}</b>`).join(', ')}.`);
+          }
         }
       }
 
@@ -875,8 +958,9 @@
       window._healthData = data.health || {};
       window._tokensByAgent = (data.tokens || {}).byAgent || {};
       window._lastAgents = data.agents || [];
+      window._lastBudget = data.budget || {};
       renderAgents(data.agents || []);
-      renderGovernor(data.governor || {}, data.cadenceMatrix || []);
+      renderGovernor(data.governor || {}, data.cadenceMatrix || [], data);
       renderTokens(data.tokens || {});
       renderRepos(data.repos || []);
       renderBeads(data.beads || {});

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -138,6 +138,29 @@ function fetchStatus() {
         statusCache.ciPassRate = ciPassRate;
         statusCache.agentMetrics = agentMetrics;
         statusCache.tokens = tokenCache;
+        // Attach governor model/budget state
+        try {
+          const budgetFile = path.join(GOVERNOR_STATE_DIR, 'budget_state');
+          if (fs.existsSync(budgetFile)) {
+            const blines = fs.readFileSync(budgetFile, 'utf8').trim().split('\n');
+            const budget = {};
+            for (const l of blines) { const [k,v] = l.split('='); if (k && v) budget[k] = isNaN(v) ? v : Number(v); }
+            statusCache.budget = budget;
+          }
+        } catch (_) {}
+        for (const a of (statusCache.agents || [])) {
+          try {
+            const mf = path.join(GOVERNOR_STATE_DIR, `model_${a.name}`);
+            if (fs.existsSync(mf)) {
+              const ml = fs.readFileSync(mf, 'utf8').trim().split('\n');
+              const m = {};
+              for (const l of ml) { const [k,v] = l.split('='); if (k && v) m[k] = v; }
+              a.govBackend = m.BACKEND;
+              a.govModel = m.MODEL;
+              a.govCostWeight = Number(m.COST_WEIGHT || 0);
+            }
+          } catch (_) {}
+        }
         // Single exec summary per agent: live pane when working, status file when idle
         statusCache.summaries = summariesCache;
         for (const a of (statusCache.agents || [])) {
@@ -344,6 +367,58 @@ app.post('/api/model/:agent/:model', (req, res) => {
 // Token usage
 app.get('/api/tokens', (_req, res) => {
   res.json(tokenCache || { error: 'no data yet' });
+});
+
+// Model advisor — reads governor state files
+const GOVERNOR_STATE_DIR = '/var/run/kick-governor';
+app.get('/api/model-advisor', (_req, res) => {
+  const agents = ['scanner', 'reviewer', 'architect', 'outreach', 'supervisor'];
+  const result = { mode: 'unknown', budget: {}, agents: [] };
+
+  try {
+    const modeFile = path.join(GOVERNOR_STATE_DIR, 'mode');
+    if (fs.existsSync(modeFile)) result.mode = fs.readFileSync(modeFile, 'utf8').trim();
+  } catch (_) {}
+
+  try {
+    const budgetFile = path.join(GOVERNOR_STATE_DIR, 'budget_state');
+    if (fs.existsSync(budgetFile)) {
+      const lines = fs.readFileSync(budgetFile, 'utf8').trim().split('\n');
+      for (const line of lines) {
+        const [k, v] = line.split('=');
+        if (k && v) result.budget[k] = isNaN(v) ? v : Number(v);
+      }
+    }
+  } catch (_) {}
+
+  for (const agent of agents) {
+    const entry = { name: agent, backend: 'unknown', model: 'unknown', costWeight: 0, reason: '' };
+    try {
+      const mf = path.join(GOVERNOR_STATE_DIR, `model_${agent}`);
+      if (fs.existsSync(mf)) {
+        const lines = fs.readFileSync(mf, 'utf8').trim().split('\n');
+        for (const line of lines) {
+          const [k, v] = line.split('=');
+          if (k === 'BACKEND') entry.backend = v;
+          else if (k === 'MODEL') entry.model = v;
+          else if (k === 'COST_WEIGHT') entry.costWeight = Number(v);
+          else if (k === 'REASON') entry.reason = v;
+          else if (k === 'PREV_BACKEND' && v) entry.prevBackend = v;
+          else if (k === 'PREV_MODEL' && v) entry.prevModel = v;
+        }
+        entry.changed = (entry.prevBackend && entry.prevBackend !== entry.backend) ||
+                         (entry.prevModel && entry.prevModel !== entry.model);
+      }
+    } catch (_) {}
+
+    try {
+      const cf = path.join(GOVERNOR_STATE_DIR, `cadence_${agent}`);
+      if (fs.existsSync(cf)) entry.cadence = fs.readFileSync(cf, 'utf8').trim();
+    } catch (_) {}
+
+    result.agents.push(entry);
+  }
+  res.json(result);
 });
 
 // Comprehensive exec summaries (task + progress + results)

--- a/dashboard/token-collector.sh
+++ b/dashboard/token-collector.sh
@@ -21,13 +21,28 @@ mkdir -p "$METRICS_DIR"
 # Find JSONL files modified in the lookback window
 cutoff=$(date -d "-${LOOKBACK_SECS} seconds" +%s 2>/dev/null || date -v-${LOOKBACK_SECS}S +%s 2>/dev/null || echo 0)
 
-python3 - "$CLAUDE_PROJECTS" "$cutoff" "$LOOKBACK_HOURS" <<'PYEOF'
-import json, os, sys, glob, time
+BUDGET_RESET_DAY="${TOKEN_BUDGET_RESET_DAY:-6}"  # 0=Mon, 6=Sun
+
+python3 - "$CLAUDE_PROJECTS" "$cutoff" "$LOOKBACK_HOURS" "$BUDGET_RESET_DAY" <<'PYEOF'
+import json, os, sys, glob, time, datetime
 from collections import defaultdict
 
 projects_dir = sys.argv[1]
 cutoff = int(sys.argv[2])
 lookback_hours = int(sys.argv[3])
+budget_reset_day = int(sys.argv[4])
+
+now = time.time()
+SECONDS_PER_HOUR = 3600
+one_hour_ago = now - SECONDS_PER_HOUR
+
+now_dt = datetime.datetime.now()
+days_since_reset = (now_dt.weekday() - budget_reset_day) % 7
+if days_since_reset == 0 and now_dt.hour == 0:
+    days_since_reset = 7
+weekly_cutoff = (now_dt - datetime.timedelta(days=days_since_reset)).replace(
+    hour=0, minute=0, second=0, microsecond=0
+).timestamp()
 
 if not os.path.isdir(projects_dir):
     print(json.dumps({"error": "no claude projects dir", "sessions": [], "byModel": {}, "totals": {}}))
@@ -38,6 +53,10 @@ by_model = defaultdict(lambda: {"input": 0, "output": 0, "cacheRead": 0, "cacheC
 by_cli = defaultdict(lambda: {"input": 0, "output": 0, "cacheRead": 0, "cacheCreate": 0, "messages": 0, "sessions": 0})
 by_agent = defaultdict(lambda: {"input": 0, "output": 0, "cacheRead": 0, "cacheCreate": 0, "messages": 0, "sessions": 0})
 totals = {"input": 0, "output": 0, "cacheRead": 0, "cacheCreate": 0, "messages": 0, "sessions": 0}
+
+weekly_by_agent = defaultdict(lambda: {"input": 0, "output": 0, "cacheRead": 0, "sessions": 0})
+weekly_totals = {"input": 0, "output": 0, "cacheRead": 0, "sessions": 0}
+hourly_by_agent = defaultdict(lambda: {"input": 0, "output": 0, "cacheRead": 0, "sessions": 0})
 
 AGENT_KEYWORDS = {
     "scanner": ["scanner", "scanner-beads"],
@@ -56,7 +75,8 @@ for proj_name in os.listdir(projects_dir):
             mtime = os.path.getmtime(fpath)
         except OSError:
             continue
-        if mtime < cutoff:
+        scan_cutoff = min(cutoff, weekly_cutoff)
+        if mtime < scan_cutoff:
             continue
 
         sid = ""
@@ -140,6 +160,29 @@ for proj_name in os.listdir(projects_dir):
             cli = "other"
 
         session_tokens = inp + out + cache_read
+
+        # Weekly aggregation (for budget engine)
+        if mtime >= weekly_cutoff and cli == "claude":
+            weekly_by_agent[agent]["input"] += inp
+            weekly_by_agent[agent]["output"] += out
+            weekly_by_agent[agent]["cacheRead"] += cache_read
+            weekly_by_agent[agent]["sessions"] += 1
+            weekly_totals["input"] += inp
+            weekly_totals["output"] += out
+            weekly_totals["cacheRead"] += cache_read
+            weekly_totals["sessions"] += 1
+
+        # Hourly aggregation (for burn rate)
+        if mtime >= one_hour_ago and cli == "claude":
+            hourly_by_agent[agent]["input"] += inp
+            hourly_by_agent[agent]["output"] += out
+            hourly_by_agent[agent]["cacheRead"] += cache_read
+            hourly_by_agent[agent]["sessions"] += 1
+
+        # 24h aggregation (existing behavior)
+        if mtime < cutoff:
+            continue
+
         sessions.append({
             "id": sid[:12] if sid else os.path.basename(fpath)[:12],
             "model": model,
@@ -192,6 +235,13 @@ for aname, astats in by_agent.items():
     total = astats["input"] + astats["output"] + astats["cacheRead"]
     astats["avgPerSession"] = total // s if s > 0 else 0
 
+# Compute hourly burn rate per agent
+hourly_rates = {}
+for aname, hstats in hourly_by_agent.items():
+    hourly_rates[aname] = hstats["input"] + hstats["output"] + hstats["cacheRead"]
+
+weekly_total_tokens = weekly_totals["input"] + weekly_totals["output"] + weekly_totals["cacheRead"]
+
 result = {
     "timestamp": int(time.time() * 1000),
     "lookbackHours": lookback_hours,
@@ -199,7 +249,17 @@ result = {
     "byModel": dict(by_model),
     "byCli": dict(by_cli),
     "byAgent": dict(by_agent),
-    "sessions": sessions[:20],  # top 20 most recent
+    "sessions": sessions[:20],
+    "weekly": {
+        "totals": weekly_totals,
+        "totalTokens": weekly_total_tokens,
+        "byAgent": dict(weekly_by_agent),
+        "resetDay": budget_reset_day,
+    },
+    "hourlyBurnRate": {
+        "total": sum(hourly_rates.values()),
+        "byAgent": hourly_rates,
+    },
 }
 
 print(json.dumps(result))


### PR DESCRIPTION
## Summary

- Governor now manages both **cadence AND model assignment** as a unified cost surface
- Measures token burn, projects weekly usage, selects the right model per agent per mode
- Auto-downgrades when budget is under pressure (opus→sonnet→haiku→copilot)
- Dashboard shows budget bar, model chips on agent cards + cadence matrix, model-aware advisor tips
- `hive status --json` includes per-agent model assignments and budget state

## Changes

| File | Change |
|---|---|
| `bin/kick-governor.sh` | Model selection table, cost weights, budget config, 6 new functions, wired into main loop |
| `bin/kick-agents.sh` | `apply_model_if_changed()` — restarts agents when governor assigns new model |
| `bin/hive.sh` | `govBackend`/`govModel`/`govCostWeight` per agent + `budget` object in status JSON |
| `dashboard/token-collector.sh` | Weekly totals + hourly burn rate per agent (Claude CLI only) |
| `dashboard/server.js` | `/api/model-advisor` endpoint, budget+model enrichment in SSE stream |
| `dashboard/public/index.html` | Budget bar, model chips, model column in cadence matrix, advisor tips |

## Test plan

- [ ] Dry run: `GOVERNOR_DRY_RUN=true` — check `/var/run/kick-governor/model_*` files
- [ ] Budget override: set `TOKEN_BUDGET_WEEKLY=1000` — verify all agents move to copilot
- [ ] Dashboard: budget bar renders, model chips appear on cards + matrix
- [ ] `hive status --json` includes budget and model fields
- [ ] Model switch: force mode transition — verify agents restart with new model

🤖 Generated with [Claude Code](https://claude.com/claude-code)