### PR TITLE
feat: token panel layout + sparklines on all stats

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -931,9 +931,11 @@
 
       const modelChips = models.map(([name, m]) => {
         const mTotal = m.input + m.output + m.cacheRead;
+        const mSpark = sparkSvg(historyData.map(s => s.tokenModels?.[name] ?? 0), '#bc8cff');
         return `<div class="token-model-chip">
           <span class="mname">${esc(name)}</span>
           <span class="mcount">${fmtTokens(mTotal)} tokens · ${m.messages} msgs</span>
+          ${mSpark}
         </div>`;
       }).join('');
 
@@ -967,13 +969,13 @@
         <div class="token-title">Token Usage <span class="lookback">${tokens.lookbackHours || 24}h window · ${t.sessions} sessions</span></div>
         <div class="token-grid">
           <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--cyan)">${fmtTokens(totalTokens)}</span>${totalSpark}</div><div class="tlabel">total tokens</div></div>
-          <div class="token-stat"><div class="tval" style="color:var(--blue)">${fmtTokens(t.input)}</div><div class="tlabel">input</div></div>
-          <div class="token-stat"><div class="tval" style="color:var(--purple)">${fmtTokens(t.output)}</div><div class="tlabel">output</div></div>
-          <div class="token-stat"><div class="tval" style="color:var(--green)">${fmtTokens(t.cacheRead)}</div><div class="tlabel">cache read</div></div>
-          <div class="token-stat"><div class="tval" style="color:var(--yellow)">${fmtTokens(t.cacheCreate)}</div><div class="tlabel">cache create</div></div>
-          <div class="token-stat"><div class="tval">${t.messages}</div><div class="tlabel">messages</div></div>
-          ${agentSparkRows}
+          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--blue)">${fmtTokens(t.input)}</span>${sparkSvg(getHistorySeries('tokenInput'), '#58a6ff')}</div><div class="tlabel">input</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--purple)">${fmtTokens(t.output)}</span>${sparkSvg(getHistorySeries('tokenOutput'), '#bc8cff')}</div><div class="tlabel">output</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--green)">${fmtTokens(t.cacheRead)}</span>${sparkSvg(getHistorySeries('tokenCacheRead'), '#3fb950')}</div><div class="tlabel">cache read</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--yellow)">${fmtTokens(t.cacheCreate)}</span>${sparkSvg(getHistorySeries('tokenCacheCreate'), '#d29922')}</div><div class="tlabel">cache create</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval">${t.messages}</span>${sparkSvg(getHistorySeries('tokenMessages'), '#8b949e')}</div><div class="tlabel">messages</div></div>
         </div>
+        ${agentSparkRows ? `<div class="token-grid" style="margin-top:4px">${agentSparkRows}</div>` : ''}
         ${advisorHtml}
         <div class="token-models">${modelChips}</div>
         ${sessions.length > 0 ? `<details class="token-sessions"><summary>Active Sessions (${sessions.length})</summary>${sessionRows}</details>` : ''}
@@ -1057,11 +1059,23 @@
           // Token sparkline data
           snap.tokens = {};
           snap.tokenTotal = 0;
+          const _tt = data.tokens?.totals || {};
+          snap.tokenInput = _tt.input || 0;
+          snap.tokenOutput = _tt.output || 0;
+          snap.tokenCacheRead = _tt.cacheRead || 0;
+          snap.tokenCacheCreate = _tt.cacheCreate || 0;
+          snap.tokenMessages = _tt.messages || 0;
           const _ba = data.tokens?.byAgent || {};
           for (const [name, stats] of Object.entries(_ba)) {
             const t = (stats.input || 0) + (stats.output || 0) + (stats.cacheRead || 0);
             snap.tokens[name] = t;
             snap.tokenTotal += t;
+          }
+          // Per-model token data
+          snap.tokenModels = {};
+          const _bm = data.tokens?.byModel || {};
+          for (const [name, stats] of Object.entries(_bm)) {
+            snap.tokenModels[name] = (stats.input || 0) + (stats.output || 0) + (stats.cacheRead || 0);
           }
           historyData.push(snap);
           if (historyData.length > 200) historyData.shift();

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -196,6 +196,11 @@ function fetchStatus() {
           adopterPrs: agentMetrics?.outreach?.adopterPending || 0,
           tokens: {},
           tokenTotal: 0,
+          tokenInput: 0,
+          tokenOutput: 0,
+          tokenCacheRead: 0,
+          tokenCacheCreate: 0,
+          tokenMessages: 0,
         };
         // Token sparkline data
         const tc = tokenCache || {};
@@ -207,6 +212,18 @@ function fetchStatus() {
           tokenTotal += t;
         }
         snap.tokenTotal = tokenTotal;
+        const tt = tc.totals || {};
+        snap.tokenInput = tt.input || 0;
+        snap.tokenOutput = tt.output || 0;
+        snap.tokenCacheRead = tt.cacheRead || 0;
+        snap.tokenCacheCreate = tt.cacheCreate || 0;
+        snap.tokenMessages = tt.messages || 0;
+        // Per-model token data
+        snap.tokenModels = {};
+        const bm = tc.byModel || {};
+        for (const [name, stats] of Object.entries(bm)) {
+          snap.tokenModels[name] = (stats.input || 0) + (stats.output || 0) + (stats.cacheRead || 0);
+        }
         for (const r of (statusCache.repos || [])) {
           snap.repos[r.name] = { issues: r.issues || 0, prs: r.prs || 0 };
         }
@@ -277,6 +294,19 @@ app.get('/api/timeline', (_req, res) => {
 });
 
 // SSE stream
+// Tmux pane preview — last N lines of an agent's tmux session
+const TMUX_PREVIEW_LINES = 30;
+app.get('/api/pane/:agent', (req, res) => {
+  const agent = req.params.agent;
+  const session = TMUX_SESSION[agent];
+  if (!session) return res.status(400).json({ error: `unknown agent: ${agent}` });
+  execFile('tmux', ['capture-pane', '-t', session, '-p', '-S', `-${TMUX_PREVIEW_LINES}`],
+    { timeout: 5000 }, (err, stdout) => {
+      if (err) return res.status(500).json({ error: err.message });
+      res.json({ agent, session, lines: stdout.split('\n').slice(-TMUX_PREVIEW_LINES) });
+    });
+});
+
 app.get('/api/events', (req, res) => {
   res.writeHead(200, {
     'Content-Type': 'text/event-stream',


### PR DESCRIPTION
## Summary

- Per-agent token rows moved to separate grid below totals
- Sparklines on all 6 totals (total, input, output, cache read, cache create, messages)
- Sparklines on model chips (per-model token history)
- All token data persisted in sparkline history (survives restarts)
- `/api/pane/:agent` endpoint for tmux session preview

## Test plan

- [ ] Token panel shows totals on first row, agents on second row
- [ ] All stats have sparklines
- [ ] Model chips show sparklines
- [ ] Sparklines persist after dashboard restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)