### PR TITLE
fix: governor pipefail hang + token-collector file write

### DIFF
--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -508,8 +508,8 @@ optimize_model_assignment() {
     local cost_weight
     cost_weight=$(get_cost_weight "$backend" "$model")
     local prev_backend prev_model
-    prev_backend=$(grep '^BACKEND=' "$STATE_DIR/model_${agent}" 2>/dev/null | cut -d= -f2)
-    prev_model=$(grep '^MODEL=' "$STATE_DIR/model_${agent}" 2>/dev/null | cut -d= -f2)
+    prev_backend=$(grep '^BACKEND=' "$STATE_DIR/model_${agent}" 2>/dev/null | cut -d= -f2 || true)
+    prev_model=$(grep '^MODEL=' "$STATE_DIR/model_${agent}" 2>/dev/null | cut -d= -f2 || true)
 
     cat > "$STATE_DIR/model_${agent}" <<MODELEOF
 BACKEND=$backend

--- a/dashboard/token-collector.sh
+++ b/dashboard/token-collector.sh
@@ -262,5 +262,11 @@ result = {
     },
 }
 
-print(json.dumps(result))
+output = json.dumps(result)
+print(output)
+try:
+    with open(os.environ.get('TOKEN_OUTPUT_FILE', '/var/run/hive-metrics/tokens.json'), 'w') as f:
+        f.write(output)
+except (OSError, IOError):
+    pass
 PYEOF


### PR DESCRIPTION
## Summary
- Governor `optimize_model_assignment()` hangs on first run when model state files don't exist — `grep` returns non-zero through pipeline, `set -euo pipefail` aborts. Fixed with `|| true`.
- Token-collector now writes output JSON to file (`TOKEN_OUTPUT_FILE` env or `/var/run/hive-metrics/tokens.json`) so governor `compute_budget_state()` can read weekly/hourly budget data.

## Test plan
- [ ] Governor completes first run without hanging when no model state files exist
- [ ] `/var/run/hive-metrics/tokens.json` is created after token-collector runs
- [ ] Governor reads budget data and writes `/var/run/kick-governor/budget_state`