### PR TITLE
fix: CLI detection + billable-only budget + override indicators

### DIFF
--- a/bin/hive.sh
+++ b/bin/hive.sh
@@ -720,12 +720,13 @@ cmd_status_json() {
     elif [[ "$cadence" == "paused" ]]; then nk="paused"
     fi
     # Governor-assigned model
-    local gov_backend gov_model gov_cost
+    local gov_backend gov_model gov_cost gov_reason
     gov_backend=$(grep '^BACKEND=' "$GOV_STATE/model_${label}" 2>/dev/null | cut -d= -f2 || echo "")
     gov_model=$(grep '^MODEL=' "$GOV_STATE/model_${label}" 2>/dev/null | cut -d= -f2 || echo "")
     gov_cost=$(grep '^COST_WEIGHT=' "$GOV_STATE/model_${label}" 2>/dev/null | cut -d= -f2 || echo "0")
+    gov_reason=$(grep '^REASON=' "$GOV_STATE/model_${label}" 2>/dev/null | cut -d= -f2 || echo "")
     [[ $i -gt 0 ]] && agents_json+=","
-    agents_json+="{\"name\":\"$label\",\"session\":\"$s\",\"state\":\"$state\",\"cli\":\"$cli\",\"model\":\"$model\",\"cadence\":\"$cadence\",\"busy\":\"$busy\",\"doing\":\"$doing\",\"nextKick\":\"$nk\",\"needsLogin\":$needs_login,\"govBackend\":\"$gov_backend\",\"govModel\":\"$gov_model\",\"govCostWeight\":$gov_cost}"
+    agents_json+="{\"name\":\"$label\",\"session\":\"$s\",\"state\":\"$state\",\"cli\":\"$cli\",\"model\":\"$model\",\"cadence\":\"$cadence\",\"busy\":\"$busy\",\"doing\":\"$doing\",\"nextKick\":\"$nk\",\"needsLogin\":$needs_login,\"govBackend\":\"$gov_backend\",\"govModel\":\"$gov_model\",\"govCostWeight\":$gov_cost,\"govReason\":\"$gov_reason\"}"
   done
   agents_json+="]"
 

--- a/bin/hive.sh
+++ b/bin/hive.sh
@@ -539,7 +539,7 @@ cmd_status() {
       pane=$(tmux capture-pane -t "$s" -p 2>/dev/null || echo "")
       pane_tail=$(echo "$pane" | tail -5)
       # Detect CLI
-      if echo "$pane_tail" | grep -q "bypass permissions\|claude doctor\|Claude Code v"; then
+      if echo "$pane_tail" | grep -q "bypass permissions\|claude doctor\|Claude Code v\|Claude Opus\|Claude Sonnet\|Claude Haiku"; then
         cli="claude"
       elif echo "$pane_tail" | grep -q "ctrl+q enqueue\|/ commands.*help"; then
         cli="copilot"
@@ -668,7 +668,7 @@ cmd_status_json() {
       local pane pane_tail
       pane=$(tmux capture-pane -t "$s" -p 2>/dev/null || echo "")
       pane_tail=$(echo "$pane" | tail -5)
-      if echo "$pane_tail" | grep -q "bypass permissions\|claude doctor\|Claude Code v"; then
+      if echo "$pane_tail" | grep -q "bypass permissions\|claude doctor\|Claude Code v\|Claude Opus\|Claude Sonnet\|Claude Haiku"; then
         cli="claude"
       elif echo "$pane_tail" | grep -q "ctrl+q enqueue\|/ commands.*help"; then
         cli="copilot"

--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -372,18 +372,25 @@ compute_budget_state() {
   local used=0 burn_hourly=0
 
   if [[ -f "$TOKEN_COLLECTOR_JSON" ]]; then
+    # Count only billable tokens (input + output). Cache read is free/discounted.
     read -r used burn_hourly <<< "$(python3 -c "
 import json
 try:
     with open('$TOKEN_COLLECTOR_JSON') as f:
         d = json.load(f)
     weekly = d.get('weekly', {})
-    used = weekly.get('totalTokens', 0)
-    hourly = d.get('hourlyBurnRate', {}).get('total', 0)
-    if used == 0 and hourly == 0:
-        ba = d.get('byAgent', {})
-        for stats in ba.values():
-            used += stats.get('input', 0) + stats.get('output', 0) + stats.get('cacheRead', 0)
+    used = weekly.get('billableTokens', 0)
+    if used == 0:
+        wt = weekly.get('totals', {})
+        used = wt.get('input', 0) + wt.get('output', 0)
+    hourly = d.get('hourlyBurnRate', {}).get('billable', 0)
+    if hourly == 0:
+        hb = d.get('hourlyBurnRate', {})
+        total_hr = hb.get('total', 0)
+        wt = weekly.get('totals', {})
+        wall = wt.get('input', 0) + wt.get('output', 0) + wt.get('cacheRead', 0)
+        ratio = (wt.get('input', 0) + wt.get('output', 0)) / wall if wall > 0 else 0.01
+        hourly = int(total_hr * ratio)
     print(used, hourly)
 except Exception:
     print(0, 0)

--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -441,8 +441,10 @@ optimize_model_assignment() {
   projected_pct=$(compute_budget_state)
 
   declare -A assignments
+  declare -A override_reasons
   for agent in "${agents[@]}"; do
     assignments[$agent]=$(get_model_selection "$agent" "$mode")
+    override_reasons[$agent]=""
   done
 
   if (( projected_pct > TOKEN_BUDGET_SAFETY_PCT )); then
@@ -456,6 +458,7 @@ optimize_model_assignment() {
         local copilot_model
         copilot_model=$(convert_model_notation "$model" "copilot")
         assignments[$agent]="copilot:${copilot_model}"
+        override_reasons[$agent]="budget_downgrade"
         log "  budget override: $agent -> copilot (was $backend)"
       fi
     done
@@ -469,11 +472,13 @@ optimize_model_assignment() {
           *opus*)
             local new_model="${model/opus/sonnet}"
             assignments[$agent]="${backend}:${new_model}"
+            override_reasons[$agent]="budget_downgrade"
             log "  budget override: $agent opus->sonnet"
             ;;
           *sonnet*)
             local new_model="${model/sonnet/haiku}"
             assignments[$agent]="${backend}:${new_model}"
+            override_reasons[$agent]="budget_downgrade"
             log "  budget override: $agent sonnet->haiku"
             ;;
         esac
@@ -487,6 +492,7 @@ optimize_model_assignment() {
         local copilot_model
         copilot_model=$(convert_model_notation "$model" "copilot")
         assignments[$agent]="copilot:${copilot_model}"
+        override_reasons[$agent]="budget_critical"
       done
       log "  BUDGET CRITICAL: all agents -> copilot"
     fi
@@ -522,7 +528,7 @@ optimize_model_assignment() {
 BACKEND=$backend
 MODEL=$model
 COST_WEIGHT=$cost_weight
-REASON=${mode}_mode
+REASON=${override_reasons[$agent]:-${mode}_mode}
 PREV_BACKEND=${prev_backend:-}
 PREV_MODEL=${prev_model:-}
 UPDATED=$(date -Iseconds)

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -775,18 +775,37 @@
       if (!budget || !budget.BUDGET_WEEKLY) return '';
       const PCT_SAFE = 50;
       const PCT_WARN = 85;
-      const pct = budget.PROJECTED_PCT || 0;
       const used = budget.BUDGET_USED || 0;
       const weekly = budget.BUDGET_WEEKLY;
-      const fillCls = pct < PCT_SAFE ? 'safe' : pct < PCT_WARN ? 'warning' : 'danger';
+      const pctUsed = budget.BUDGET_PCT_USED || 0;
+      const projPct = budget.PROJECTED_PCT || 0;
       const burnRate = budget.BURN_RATE_HOURLY || 0;
       const hoursLeft = budget.HOURS_REMAINING || 0;
+      const HOURS_PER_DAY = 24;
+      const dailyRate = burnRate * HOURS_PER_DAY;
+      const usedFillCls = pctUsed < PCT_SAFE ? 'safe' : pctUsed < PCT_WARN ? 'warning' : 'danger';
+      const projFillCls = projPct < PCT_SAFE ? 'safe' : projPct < PCT_WARN ? 'warning' : 'danger';
+
+      let govAction = '';
+      if (projPct > PCT_WARN) {
+        govAction = '<span style="color:var(--red)">Governor downgrading models to stay within budget</span>';
+      } else if (projPct > PCT_SAFE) {
+        govAction = '<span style="color:var(--yellow)">Governor may downgrade non-priority agents if burn increases</span>';
+      } else {
+        govAction = '<span style="color:var(--green)">Budget healthy — governor using preferred models</span>';
+      }
+
       return `<div class="budget-bar">
         <div class="budget-bar-label">
-          <span>Token Budget: ${fmtTokens(used)} / ${fmtTokens(weekly)} (${budget.BUDGET_PCT_USED || 0}% used)</span>
-          <span>Projected: ${pct}% · ${fmtTokens(burnRate)}/hr · ${hoursLeft}h left</span>
+          <span>Used: ${fmtTokens(used)} / ${fmtTokens(weekly)} (${pctUsed}%)</span>
+          <span>${hoursLeft}h until reset</span>
         </div>
-        <div class="budget-bar-track"><div class="budget-bar-fill ${fillCls}" style="width:${Math.min(pct, 100)}%"></div></div>
+        <div class="budget-bar-track"><div class="budget-bar-fill ${usedFillCls}" style="width:${Math.min(pctUsed, 100)}%"></div></div>
+        <div style="display:flex;justify-content:space-between;font-size:0.68rem;color:var(--muted);margin-top:4px">
+          <span>Burn: ${fmtTokens(burnRate)}/hr · ${fmtTokens(dailyRate)}/day</span>
+          <span>Projected: ${fmtTokens(used + burnRate * hoursLeft)} (${projPct}%)</span>
+        </div>
+        <div style="font-size:0.68rem;margin-top:3px">${govAction}</div>
       </div>`;
     }
 

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -581,7 +581,7 @@
         return `<div class="agent-card ${cls}">
           <div class="agent-name"><span class="dot ${dotCls}"></span>${a.name}</div>
           <div class="agent-field"><span class="label">cli</span><span class="value ${a.cli}">${a.cli}</span></div>
-          <div class="agent-field"><span class="label">model</span><span class="value">${a.model || ''} ${a.govBackend ? modelChip(a.govBackend, a.govModel) : ''}</span></div>
+          <div class="agent-field"><span class="label">model</span><span class="value">${a.model || ''} ${a.govBackend ? modelChip(a.govBackend, a.govModel, a.govReason) : ''}</span></div>
           <div class="agent-field"><span class="label">interval</span><span class="value">${a.cadence}</span></div>
           <div class="agent-field"><span class="label">next run</span><span class="value">${a.nextKick || '—'}</span></div>
           ${agentTokenRow(a.name, a.cadence)}
@@ -725,7 +725,7 @@
           return `<td class="${colCls}${pausedCls}">${isPaused ? '—' : val}</td>`;
         }).join('');
         const agentData = agents.find(a => a.name === aname);
-        const mChip = agentData && agentData.govBackend ? modelChip(agentData.govBackend, agentData.govModel) : '';
+        const mChip = agentData && agentData.govBackend ? modelChip(agentData.govBackend, agentData.govModel, agentData.govReason) : '';
         return `<tr><td>${aname}</td>${cells}<td>${mChip}</td></tr>`;
       }).join('');
       const headers = modes.map(m => {
@@ -809,7 +809,7 @@
       </div>`;
     }
 
-    function modelChip(backend, model) {
+    function modelChip(backend, model, reason) {
       if (!backend || backend === 'unknown') return '';
       const isFree = backend === 'copilot' || backend === 'goose';
       let tier = 'sonnet';
@@ -818,7 +818,10 @@
       else if (model && model.includes('opus')) tier = 'opus';
       const shortModel = model ? model.replace(/^claude-/, '').replace(/-\d+-\d+$/, m => m.replace(/-/g, '.').slice(0, 4)) : '?';
       const label = isFree ? `${backend}` : shortModel;
-      return `<span class="model-chip ${tier}" title="${backend}:${model}">${label}</span>`;
+      const isBudgetOverride = reason && (reason.includes('budget_downgrade') || reason.includes('budget_critical'));
+      const overrideIcon = isBudgetOverride ? ' ⬇' : '';
+      const overrideTitle = isBudgetOverride ? ` (${reason})` : '';
+      return `<span class="model-chip ${tier}" title="${backend}:${model}${overrideTitle}">${label}${overrideIcon}</span>`;
     }
 
     function buildCadenceAdvisor(byAgent) {

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -158,6 +158,7 @@ function fetchStatus() {
               a.govBackend = m.BACKEND;
               a.govModel = m.MODEL;
               a.govCostWeight = Number(m.COST_WEIGHT || 0);
+              a.govReason = m.REASON || '';
             }
           } catch (_) {}
         }

--- a/dashboard/token-collector.sh
+++ b/dashboard/token-collector.sh
@@ -235,12 +235,15 @@ for aname, astats in by_agent.items():
     total = astats["input"] + astats["output"] + astats["cacheRead"]
     astats["avgPerSession"] = total // s if s > 0 else 0
 
-# Compute hourly burn rate per agent
+# Compute hourly burn rate per agent (all tokens and billable-only)
 hourly_rates = {}
+hourly_billable = {}
 for aname, hstats in hourly_by_agent.items():
     hourly_rates[aname] = hstats["input"] + hstats["output"] + hstats["cacheRead"]
+    hourly_billable[aname] = hstats["input"] + hstats["output"]
 
 weekly_total_tokens = weekly_totals["input"] + weekly_totals["output"] + weekly_totals["cacheRead"]
+weekly_billable_tokens = weekly_totals["input"] + weekly_totals["output"]
 
 result = {
     "timestamp": int(time.time() * 1000),
@@ -253,12 +256,15 @@ result = {
     "weekly": {
         "totals": weekly_totals,
         "totalTokens": weekly_total_tokens,
+        "billableTokens": weekly_billable_tokens,
         "byAgent": dict(weekly_by_agent),
         "resetDay": budget_reset_day,
     },
     "hourlyBurnRate": {
         "total": sum(hourly_rates.values()),
+        "billable": sum(hourly_billable.values()),
         "byAgent": hourly_rates,
+        "byAgentBillable": hourly_billable,
     },
 }
 


### PR DESCRIPTION
## Summary
- Fix architect showing `cli: ?` — detect `Claude Opus/Sonnet/Haiku` in pane footer
- Budget engine counts only billable tokens (input+output), not cache_read (was inflating to 17138%)
- Token-collector adds `billableTokens` and `billable` hourly burn rate fields
- Budget bar redesigned: used/budget fill, hourly + daily burn rates, projected total, governor action status
- Governor writes `budget_downgrade` / `budget_critical` reason per agent when overriding models
- Model chips show ⬇ indicator when governor is downgrading due to budget pressure
- `govReason` passed through hive.sh → server.js → dashboard

## Test plan
- [ ] Architect shows correct CLI (claude/copilot) instead of `?`
- [ ] Budget bar shows reasonable % (not 17138%)
- [ ] Budget bar shows hourly + daily burn rates
- [ ] Budget bar shows governor action status (healthy/may downgrade/downgrading)
- [ ] Model chips show ⬇ when governor overrides for budget