### PR TITLE
🐛 Fix model-switch race condition in kick-agents.sh

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -264,18 +264,30 @@ kick() {
   local message="$2"
   local agent="$3"
 
+  # After model switch, poll for the session to reappear before checking existence.
+  # apply_model_if_changed() sends /exit + agent-launch.sh, which kills the old
+  # session and starts a new one. Without polling, session_exists fails because
+  # the new CLI hasn't created its tmux session yet.
+  if [[ "${MODEL_SWITCHED[$agent]:-}" == "1" ]]; then
+    local MODEL_SWITCH_STARTUP_WAIT=30
+    local POLL_INTERVAL=3
+    local waited=0
+    log "MODEL SWITCH $agent — waiting up to ${MODEL_SWITCH_STARTUP_WAIT}s for session to start"
+    while (( waited < MODEL_SWITCH_STARTUP_WAIT )); do
+      if session_exists "$session" && session_idle "$session"; then
+        log "MODEL SWITCH $agent — session ready after ${waited}s"
+        break
+      fi
+      sleep "$POLL_INTERVAL"
+      (( waited += POLL_INTERVAL ))
+    done
+    MODEL_SWITCHED[$agent]=0
+  fi
+
   if ! session_exists "$session"; then
     log "SKIP $session — session not found"
     ntfy "$agent — not found" "Session $session does not exist. Next try: $(next_run "$agent")"
     return
-  fi
-
-  # After model switch, wait for CLI to finish starting up
-  if [[ "${MODEL_SWITCHED[$agent]:-}" == "1" ]]; then
-    local MODEL_SWITCH_STARTUP_WAIT=30
-    log "MODEL SWITCH $agent — waiting ${MODEL_SWITCH_STARTUP_WAIT}s for CLI startup"
-    sleep "$MODEL_SWITCH_STARTUP_WAIT"
-    MODEL_SWITCHED[$agent]=0
   fi
 
   if ! session_idle "$session"; then


### PR DESCRIPTION
## Summary
- **Race condition**: After `apply_model_if_changed()` sends `/exit` + `agent-launch.sh`, the old tmux session dies before the new CLI creates its session. `kick()` checked `session_exists()` *before* the startup wait, hitting "session not found" and bailing — leaving the agent unkicked after every model switch.
- **Fix**: When `MODEL_SWITCHED` is set, poll for the session to appear (every 3s, up to 30s) before the existence check. `kick()` now waits for `agent-launch.sh` to bring the session up, then injects the work order.
- **Already deployed** to dev server and governor timer re-enabled.

## Test plan
- [x] Fix deployed to `/usr/local/bin/kick-agents.sh` on dev server
- [x] `kick-governor.timer` re-enabled and firing every 5 min
- [ ] Next model switch should show "session ready after Ns" instead of "session not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)