### PR TITLE
🌱 Add governor watchdog to auto-restart dead governor timer

### DIFF
--- a/systemd/governor-watchdog.service
+++ b/systemd/governor-watchdog.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Governor watchdog — re-enables kick-governor.timer if it goes inactive
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c 'if ! systemctl is-active --quiet kick-governor.timer; then systemctl enable --now kick-governor.timer && logger -t governor-watchdog "re-enabled kick-governor.timer"; fi'

--- a/systemd/governor-watchdog.timer
+++ b/systemd/governor-watchdog.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Check kick-governor.timer health every 10 minutes
+
+[Timer]
+OnCalendar=*:02/10
+AccuracySec=30s
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- New `governor-watchdog.timer` (every 10 min) checks if `kick-governor.timer` is active
- If dead, `governor-watchdog.service` re-enables it and logs via syslog
- Prevents indefinite governor outages — no agent can self-heal this since they all depend on the governor to kick them
- Already deployed and running on dev server

## Test plan
- [x] Deployed to dev server, timer active and firing
- [ ] `sudo systemctl stop kick-governor.timer` → watchdog should re-enable within 10 min
- [ ] Verify syslog entry: `grep governor-watchdog /var/log/syslog`

🤖 Generated with [Claude Code](https://claude.com/claude-code)