### PR TITLE
Increase healthcheck interval from 20min to 30min

### DIFF
--- a/systemd/hive-healthcheck.timer
+++ b/systemd/hive-healthcheck.timer
@@ -1,11 +1,11 @@
 [Unit]
-Description=Run the hive healthcheck every 20 minutes
+Description=Run the hive healthcheck every 30 minutes
 
 [Timer]
 # First check 5 minutes after boot so the agent has time to come up.
 OnBootSec=5min
-# Then every 20 minutes.
-OnUnitActiveSec=20min
+# Then every 30 minutes (reduced from 20min to lower GH API rate limit pressure).
+OnUnitActiveSec=30min
 Unit=hive-healthcheck.service
 
 [Install]


### PR DESCRIPTION
Reduces GitHub API calls by ~9/hr to help stay within rate limits.