### PR TITLE
Support dedicated HIVE_GITHUB_TOKEN for rate limit isolation

### DIFF
--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -193,6 +193,7 @@ count_actionable() {
   local cache_dir="$STATE_DIR/repo_cache"
   mkdir -p "$cache_dir" 2>/dev/null || true
   unset GITHUB_TOKEN
+  [ -n "$HIVE_GITHUB_TOKEN" ] && export GH_TOKEN="$HIVE_GITHUB_TOKEN"
   local issues prs
 
   # REST API: list open issues (excludes PRs), filter out exempt labels client-side

--- a/config/agent.env.example
+++ b/config/agent.env.example
@@ -131,3 +131,11 @@ SLACK_WEBHOOK=
 # Leave blank to disable Discord notifications.
 # hive appends /slack to use Discord's Slack-compatible endpoint.
 DISCORD_WEBHOOK=
+
+# GitHub PAT for dashboard and governor scripts (health-check.sh,
+# agent-metrics.sh, kick-governor.sh). Uses its own rate-limit bucket so
+# hive doesn't compete with the operator's personal gh CLI token.
+# Create a fine-grained PAT with read-only Actions, Contents, Issues,
+# Pull requests, Metadata on the repos hive monitors.
+# Leave blank to fall back to the default gh auth credential.
+HIVE_GITHUB_TOKEN=

--- a/dashboard/agent-metrics.sh
+++ b/dashboard/agent-metrics.sh
@@ -2,6 +2,7 @@
 
 set +e
 unset GITHUB_TOKEN
+[ -n "$HIVE_GITHUB_TOKEN" ] && export GH_TOKEN="$HIVE_GITHUB_TOKEN"
 
 # Get live agent status (includes doing field with live spinner updates)
 agent_status=$(hive status --json 2>/dev/null)
@@ -77,7 +78,7 @@ outreach_tmp=$(mktemp -d)
 (gh api repos/kubestellar/console --jq '.forks_count' > "$outreach_tmp/forks" 2>/dev/null || echo 0 > "$outreach_tmp/forks") &
 (c=$(gh api repos/kubestellar/console/contributors?per_page=1 -i 2>/dev/null | grep -oP 'page=\K\d+(?=>; rel="last")' || echo 0); [ "$c" = "0" ] && c=$(gh api repos/kubestellar/console/contributors --jq 'length' 2>/dev/null || echo 0); echo "$c" > "$outreach_tmp/contribs") &
 (a=$(gh api repos/kubestellar/console/contents/ADOPTERS.MD --jq '.content' 2>/dev/null | base64 -d 2>/dev/null | grep -cP '^\|.*\|.*\|' || echo 0); a=$(( a > 2 ? a - 2 : 0 )); echo "$a" > "$outreach_tmp/adopters") &
-(unset GITHUB_TOKEN && gh api repos/kubestellar/docs/contents/src/app/%5Blocale%5D/acmm-leaderboard/page.tsx --jq '.content' 2>/dev/null | base64 -d 2>/dev/null | sed -n '/BADGE_PARTICIPANTS = new Set/,/\]);/p' | grep -cP '^\s+"[a-zA-Z]' > "$outreach_tmp/acmm" 2>/dev/null || echo 0 > "$outreach_tmp/acmm") &
+(unset GITHUB_TOKEN; [ -n "$HIVE_GITHUB_TOKEN" ] && export GH_TOKEN="$HIVE_GITHUB_TOKEN"; gh api repos/kubestellar/docs/contents/src/app/%5Blocale%5D/acmm-leaderboard/page.tsx --jq '.content' 2>/dev/null | base64 -d 2>/dev/null | sed -n '/BADGE_PARTICIPANTS = new Set/,/\]);/p' | grep -cP '^\s+"[a-zA-Z]' > "$outreach_tmp/acmm" 2>/dev/null || echo 0 > "$outreach_tmp/acmm") &
 wait
 stars=$(cat "$outreach_tmp/stars" 2>/dev/null || echo 0)
 forks=$(cat "$outreach_tmp/forks" 2>/dev/null || echo 0)

--- a/dashboard/health-check.sh
+++ b/dashboard/health-check.sh
@@ -2,6 +2,7 @@
 # Health checks for hive dashboard — outputs JSON
 set +e
 unset GITHUB_TOKEN
+[ -n "$HIVE_GITHUB_TOKEN" ] && export GH_TOKEN="$HIVE_GITHUB_TOKEN"
 
 # CI pass rate (last 10 completed runs)
 ci=$(gh run list --repo kubestellar/console --limit 10 --json conclusion,status \


### PR DESCRIPTION
## Summary
- Add `HIVE_GITHUB_TOKEN` env var to `agent.env.example`
- Dashboard scripts (`health-check.sh`, `agent-metrics.sh`) and `kick-governor.sh` now use it when set
- Falls back to default `gh auth` credential if not configured
- Gives hive its own 5000/hr rate limit bucket, isolated from the operator's CLI token

## Setup
1. Create a fine-grained GitHub PAT with read-only Actions, Contents, Issues, Pull requests, Metadata
2. Add `HIVE_GITHUB_TOKEN=ghp_xxx` to `/etc/hive/agent.env` on the dev server
3. Restart healthcheck timer: `sudo systemctl restart hive-healthcheck.timer`