### PR TITLE
fix: dashboard beads guard, session agent labels, cadence pulse, git version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ That's it. `hive supervisor` installs missing tools, starts all agents, sets the
 
 ```bash
 hive supervisor             # start everything
-hive status                 # live terminal dashboard
+hive status                 # live terminal dashboard (cached repo data)
+hive status --repos         # refresh repo issue/PR counts from GitHub API
 hive status --json          # machine-readable JSON output
+hive status --json --repos  # JSON with fresh repo data (used by dashboard slow path)
 hive status --watch 5       # auto-refresh every 5 seconds (in-place overwrite)
 hive dashboard              # launch web dashboard (port 3001)
 hive attach supervisor      # watch the supervisor  (Ctrl+B D to leave)
@@ -58,9 +60,12 @@ hive stop all               # stop everything
 `hive dashboard` launches a real-time web dashboard on port 3001.
 
 - **Live updates** via SSE — agent states, governor mode, repo counts, and beads refresh every 5 seconds
+- **Sparkline history** — per-agent busy time and restart count sparklines with rolling history
+- **Restart tracking** — 24-hour restart count per agent with color-coded thresholds (yellow >0, red >5)
 - **Kick buttons** — one-click kick for any agent
 - **Switch dropdown** — switch agent CLI backend (copilot, claude, gemini, goose) from the UI
-- **Übersicht widget** — download a macOS desktop widget from the ⬇ Widget button in the header
+- **Übersicht widget** — download a macOS desktop widget from the button in the header
+- **Fast/slow refresh** — agent status refreshes every 5s; GitHub repo data refreshes every 60s to avoid API rate limits
 
 The dashboard runs as a systemd service (`hive-dashboard.service`) and auto-restarts on failure.
 
@@ -81,14 +86,18 @@ The **kick-governor** measures issue and PR backlog across your repos every 15 m
 
 | Mode | Trigger | Scanner | Reviewer | Architect | Outreach | Supervisor |
 |------|---------|---------|----------|-----------|----------|-----------|
-| SURGE | queue > 20 | 10 min | 10 min | **paused** | **paused** | 30 min |
-| BUSY  | queue > 10 | 15 min | 15 min | **paused** | **paused** | 30 min |
-| QUIET | queue > 2  | 15 min | 30 min | 1 h        | 2 h        | 30 min |
-| IDLE  | queue ≤ 2  | 30 min | 1 h    | 30 min     | 30 min     | 30 min |
+| SURGE | queue > 20 | 10 min | 10 min | **paused** | **paused** | 5 min |
+| BUSY  | queue > 10 | 15 min | 15 min | **paused** | **paused** | 5 min |
+| QUIET | queue > 2  | 15 min | 30 min | 1 h        | 2 h        | 5 min |
+| IDLE  | queue ≤ 2  | 30 min | 1 h    | 30 min     | 30 min     | 5 min |
 
-Architect and outreach are **opportunistic** — they fill idle cycles and pause entirely under load. Supervisor runs every 30 min regardless of mode.
+Architect and outreach are **opportunistic** — they fill idle cycles and pause entirely under load. Supervisor runs every 5 min regardless of mode.
 
 Cadences are tunable in `/etc/hive/governor.env` — no restart needed.
+
+### Restart tracking
+
+Each supervisor process tracks agent restarts in `/var/run/kick-governor/restarts_<session>`. The count is a rolling 24-hour window — old timestamps are pruned automatically. The dashboard and `hive status --json` both expose the `restarts` field per agent.
 
 ---
 
@@ -96,12 +105,14 @@ Cadences are tunable in `/etc/hive/governor.env` — no restart needed.
 
 Set `HIVE_BACKENDS` in `hive.conf`. `HIVE_AUTO_INSTALL=true` installs missing backends on startup.
 
-| Backend | Type | Models |
-|---------|------|--------|
-| `copilot` | Cloud | Claude Sonnet/Opus via GitHub Copilot |
-| `claude` | Cloud | Claude Sonnet/Opus via Anthropic |
-| `gemini` | Cloud | Gemini Pro/Flash via Google |
-| `goose` | Cloud or local | Any model via config |
+| Backend | Type | Description |
+|---------|------|-------------|
+| `claude` | CLI | Anthropic's CLI — runs Claude models directly |
+| `gemini` | CLI | Google's CLI — runs Gemini models directly |
+| `copilot` | Aggregate | GitHub Copilot — routes to Claude, GPT, Gemini, and other vendor models |
+| `goose` | Aggregate | Block's Goose — routes to any model via config (cloud or local) |
+
+**CLI backends** (`claude`, `gemini`) are single-vendor tools that run their own models. **Aggregate backends** (`copilot`, `goose`) are multi-vendor routers — they can call models from different providers through a single interface.
 
 ### Local models (optional)
 
@@ -175,6 +186,7 @@ journalctl -u claude-scanner # raw service log
 | Dashboard: agents show `stopped` / CLI `?` | Service running as root (can't see dev's tmux) | Add `User=dev` to `hive-dashboard.service` |
 | Dashboard: widget download 404 | Stale node process on port 3001 | `ss -tlnp \| grep 3001` → `kill <PID>` → restart service |
 | `bd dolt push` fails | Root-owned `.beads/` files | `sudo chown -R dev:dev ~/.beads/ /home/dev/scanner-beads/.beads/` |
+| Beads: `?` in status | `bd list` blocked by stale lock | `sudo killall -9 bd && rm -f /home/dev/scanner-beads/.beads/embeddeddolt/.lock` |
 
 ---
 

--- a/bin/hive.sh
+++ b/bin/hive.sh
@@ -308,7 +308,7 @@ init_beads() {
       (cd "$bdir" && bd init 2>/dev/null) && ok "Beads initialised in $bdir" || warn "bd init failed in $bdir"
     else
       local count
-      count=$(cd "$bdir" && bd list --json 2>/dev/null \
+      count=$(cd "$bdir" && timeout 8 bd list --json 2>/dev/null \
         | python3 -c 'import sys,json; d=json.load(sys.stdin); print(len(d.get("items",[])))' 2>/dev/null || echo '?')
       ok "$bdir ($count items)"
     fi
@@ -506,9 +506,9 @@ cmd_status() {
   echo -e "\n${BLD}🐝 hive status — $(TZ="${HIVE_TZ:-UTC}" date '+%-I:%M %p %Z')${RST}\n"
 
   # Sessions
-  local SESSIONS=(supervisor issue-scanner reviewer feature outreach)
+  local SESSIONS=(supervisor issue-scanner reviewer architect outreach)
   local LABELS=("supervisor" "scanner" "reviewer" "architect" "outreach")
-  local ENV_FILES=("supervisor" "issue-scanner" "reviewer" "feature" "outreach")
+  local ENV_FILES=("supervisor" "issue-scanner" "reviewer" "architect" "outreach")
   local GOV_STATE="/var/run/kick-governor"
   printf "  %-12s  %-8s  %-8s  %-8s  %-8s  %s\n" "AGENT" "STATE" "CLI" "CADENCE" "KICK" "BUSY"
   printf "  %-12s  %-8s  %-8s  %-8s  %-8s  %s\n" "-----" "-----" "---" "-------" "----" "----"
@@ -563,11 +563,11 @@ cmd_status() {
 
       if [[ "$needs_login" == "true" ]]; then
         busy_flag="${RED}⚠ NOT LOGGED IN${RST}"
-      elif echo "$recent_lines" | grep -qE "^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*] |^⏺ |Esc to cancel|↳ |agent still running|Scampering|Evaporating|Perambulating|Puttering|Sautéed"; then
+      elif echo "$recent_lines" | LC_ALL=C.UTF-8 grep -qE "^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*] |^⏺ |Esc to cancel|↳ |agent still running|Scampering|Evaporating|Perambulating|Puttering|Sautéed|Precipitating|Pouncing|Thinking"; then
         # Spinner or "Esc to cancel" found in recent output — actively working
         busy_flag="${YLW}working${RST}"
         doing=$(echo "$pane_body" \
-          | grep -E "^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*] |^⏺ |Esc to cancel|agent still running" \
+          | LC_ALL=C.UTF-8 grep -E "^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*] |^⏺ |Esc to cancel|agent still running" \
           | tail -1 \
           | sed 's/^[◐◑◒◓◉●◎○⏺✻✶✸✹✢✽·*] //' \
           | sed 's/ (Esc to cancel.*//' \
@@ -610,13 +610,22 @@ cmd_status() {
   echo ""
   printf "  %-28s  %-14s  %s\n" "REPO" "ISSUES" "PRS"
   printf "  %-28s  %-14s  %s\n" "----" "------" "---"
+  local fetch_repos=false
+  [[ " $* " == *" --repos "* ]] && fetch_repos=true
   for repo in ${HIVE_REPOS:-}; do
     local rname issues prs
     local prev_issues prev_prs
     local itag ptag
     rname="${repo##*/}"
-    issues=$(gh issue list --repo "$repo" --state open --json number --jq 'length' 2>/dev/null || echo "?")
-    prs=$(   gh pr    list --repo "$repo" --state open --json number --jq 'length' 2>/dev/null || echo "?")
+    if [[ "$fetch_repos" == "true" ]]; then
+      issues=$(gh issue list --repo "$repo" --state open --json number --jq 'length' 2>/dev/null || echo "?")
+      prs=$(   gh pr    list --repo "$repo" --state open --json number --jq 'length' 2>/dev/null || echo "?")
+      [[ "$issues" != "?" ]] && echo "$issues" > "$STATUS_CACHE/${rname}_issues"
+      [[ "$prs"    != "?" ]] && echo "$prs"    > "$STATUS_CACHE/${rname}_prs"
+    else
+      issues=$(cat "$STATUS_CACHE/${rname}_issues" 2>/dev/null || echo "?")
+      prs=$(cat "$STATUS_CACHE/${rname}_prs" 2>/dev/null || echo "?")
+    fi
 
     # Trend vs last run
     prev_issues=$(cat "$STATUS_CACHE/${rname}_issues" 2>/dev/null || echo "")
@@ -625,18 +634,14 @@ cmd_status() {
     ptag=$(trend_marker "$prs"    "$prev_prs"    "prs")
 
     printf "  %-28s  %-14s  %s\n" "$rname" "${issues}${itag}" "${prs}${ptag}"
-
-    # Save for next run
-    [[ "$issues" != "?" ]] && echo "$issues" > "$STATUS_CACHE/${rname}_issues"
-    [[ "$prs"    != "?" ]] && echo "$prs"    > "$STATUS_CACHE/${rname}_prs"
   done
 
   # Beads
   echo ""
   local wc sc
-  wc=$(cd "$BEADS_WORKER_DIR"     2>/dev/null && bd list --json 2>/dev/null \
+  wc=$(cd "$BEADS_WORKER_DIR"     2>/dev/null && timeout 8 bd list --json 2>/dev/null \
      | python3 -c 'import sys,json; d=json.load(sys.stdin); print(len(d) if isinstance(d,list) else len(d.get("items",[])))' 2>/dev/null || echo '?')
-  sc=$(cd "$BEADS_SUPERVISOR_DIR" 2>/dev/null && bd list --json 2>/dev/null \
+  sc=$(cd "$BEADS_SUPERVISOR_DIR" 2>/dev/null && timeout 8 bd list --json 2>/dev/null \
      | python3 -c 'import sys,json; d=json.load(sys.stdin); print(len(d) if isinstance(d,list) else len(d.get("items",[])))' 2>/dev/null || echo '?')
   echo -e "  Beads:     workers ${BLD}$wc${RST}  |  supervisor ${BLD}$sc${RST}"
   echo ""
@@ -645,9 +650,9 @@ cmd_status() {
 # ── status JSON ──────────────────────────────────────────────────────────────
 
 cmd_status_json() {
-  local SESSIONS=(supervisor issue-scanner reviewer feature outreach)
+  local SESSIONS=(supervisor issue-scanner reviewer architect outreach)
   local LABELS=("supervisor" "scanner" "reviewer" "architect" "outreach")
-  local ENV_FILES=("supervisor" "issue-scanner" "reviewer" "feature" "outreach")
+  local ENV_FILES=("supervisor" "issue-scanner" "reviewer" "architect" "outreach")
   local GOV_STATE="/var/run/kick-governor"
   local STATUS_CACHE="/var/run/kick-governor/repo_cache"
   mkdir -p "$STATUS_CACHE" 2>/dev/null || true
@@ -686,11 +691,12 @@ cmd_status_json() {
         needs_login="true"
       fi
       # Strip prompt, separator lines, and status bar to detect actual work output
-      recent_lines=$(echo "$pane" | grep -vE '^[─━═]+$|^❯|^\s*$|^ / commands|^[[:space:]]*~/' | tail -15)
-      if echo "$recent_lines" | grep -qE "^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*] |^⏺ |Esc to cancel|↳ |Running .* pass|background /tasks|agent still running|Scampering|Evaporating|Perambulating|Puttering|Sautéed"; then
+      # LC_ALL=C.UTF-8 required — server runs LANG=C which breaks multi-byte UTF-8 grep
+      recent_lines=$(echo "$pane" | LC_ALL=C.UTF-8 grep -vE '^[─━═]+$|^❯|^\s*$|^ / commands|^[[:space:]]*~/' | tail -15)
+      if echo "$recent_lines" | LC_ALL=C.UTF-8 grep -qE "^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*] |^⏺ |Esc to cancel|↳ |Running .* pass|background /tasks|agent still running|Scampering|Evaporating|Perambulating|Puttering|Sautéed|Precipitating|Pouncing|Thinking"; then
         busy="working"
         doing=$(echo "$recent_lines" \
-          | grep -E "^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*] |^⏺ |Esc to cancel|agent still running" \
+          | LC_ALL=C.UTF-8 grep -E "^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*] |^⏺ |Esc to cancel|agent still running" \
           | tail -3 \
           | sed 's/^[◐◑◒◓◉●◎○⏺✻✶✸✹✢✽·*] //' \
           | sed 's/ (Esc to cancel.*//' \
@@ -725,8 +731,12 @@ cmd_status_json() {
     gov_model=$(grep '^MODEL=' "$GOV_STATE/model_${label}" 2>/dev/null | cut -d= -f2 || echo "")
     gov_cost=$(grep '^COST_WEIGHT=' "$GOV_STATE/model_${label}" 2>/dev/null | cut -d= -f2 || echo "0")
     gov_reason=$(grep '^REASON=' "$GOV_STATE/model_${label}" 2>/dev/null | cut -d= -f2 || echo "")
+    # Restart count from state file (maintained by supervisor, keyed by session name)
+    local restarts_24h=0
+    restarts_24h=$(head -1 "/var/run/kick-governor/restarts_${s}" 2>/dev/null | tr -dc '0-9' || echo "0")
+    [[ -z "$restarts_24h" ]] && restarts_24h=0
     [[ $i -gt 0 ]] && agents_json+=","
-    agents_json+="{\"name\":\"$label\",\"session\":\"$s\",\"state\":\"$state\",\"cli\":\"$cli\",\"model\":\"$model\",\"cadence\":\"$cadence\",\"busy\":\"$busy\",\"doing\":\"$doing\",\"nextKick\":\"$nk\",\"needsLogin\":$needs_login,\"govBackend\":\"$gov_backend\",\"govModel\":\"$gov_model\",\"govCostWeight\":$gov_cost,\"govReason\":\"$gov_reason\"}"
+    agents_json+="{\"name\":\"$label\",\"session\":\"$s\",\"state\":\"$state\",\"cli\":\"$cli\",\"model\":\"$model\",\"cadence\":\"$cadence\",\"busy\":\"$busy\",\"doing\":\"$doing\",\"nextKick\":\"$nk\",\"needsLogin\":$needs_login,\"restarts\":$restarts_24h,\"govBackend\":\"$gov_backend\",\"govModel\":\"$gov_model\",\"govCostWeight\":$gov_cost,\"govReason\":\"$gov_reason\"}"
   done
   agents_json+="]"
 
@@ -740,32 +750,39 @@ cmd_status_json() {
        | awk 'NR==2{print $1,$2,$3,$4}' \
        | xargs -I{} bash -c "TZ=\"$HIVE_TZ\" date -d \"{}\" \"+%-I:%M %p %Z\"" 2>/dev/null || echo "")
 
-  # Repos
+  # Repos — only fetch from GH API when --repos flag is passed; otherwise use cache
   local STATUS_CACHE="/var/run/kick-governor/repo_cache"
   mkdir -p "$STATUS_CACHE" 2>/dev/null || true
   local repos_json="["
   local first_repo=true
+  local fetch_repos=false
+  [[ " $* " == *" --repos "* ]] && fetch_repos=true
   for repo in ${HIVE_REPOS:-}; do
     local rname issues prs
     rname="${repo##*/}"
-    issues=$(gh issue list --repo "$repo" --state open --json number --jq 'length' 2>/dev/null || echo "-1")
-    prs=$(   gh pr    list --repo "$repo" --state open --json number --jq 'length' 2>/dev/null || echo "-1")
-    # Fall back to cached values when rate limited
-    [[ "$issues" == "-1" ]] && issues=$(cat "$STATUS_CACHE/${rname}_issues" 2>/dev/null || echo "-1")
-    [[ "$prs"    == "-1" ]] && prs=$(   cat "$STATUS_CACHE/${rname}_prs"    2>/dev/null || echo "-1")
+    if [[ "$fetch_repos" == "true" ]]; then
+      issues=$(gh issue list --repo "$repo" --state open --json number --jq 'length' 2>/dev/null || echo "-1")
+      prs=$(   gh pr    list --repo "$repo" --state open --json number --jq 'length' 2>/dev/null || echo "-1")
+      [[ "$issues" != "-1" ]] && echo "$issues" > "$STATUS_CACHE/${rname}_issues"
+      [[ "$prs"    != "-1" ]] && echo "$prs"    > "$STATUS_CACHE/${rname}_prs"
+    else
+      issues="-1"
+      prs="-1"
+    fi
+    # Fall back to cached values
+    [[ "$issues" == "-1" ]] && issues=$(cat "$STATUS_CACHE/${rname}_issues" 2>/dev/null || echo "0")
+    [[ "$prs"    == "-1" ]] && prs=$(   cat "$STATUS_CACHE/${rname}_prs"    2>/dev/null || echo "0")
     [[ "$first_repo" == "false" ]] && repos_json+=","
     first_repo=false
     repos_json+="{\"name\":\"$rname\",\"full\":\"$repo\",\"issues\":$issues,\"prs\":$prs}"
-    [[ "$issues" != "-1" ]] && echo "$issues" > "$STATUS_CACHE/${rname}_issues"
-    [[ "$prs"    != "-1" ]] && echo "$prs"    > "$STATUS_CACHE/${rname}_prs"
   done
   repos_json+="]"
 
   # Beads
   local beads_workers beads_supervisor
-  beads_workers=$(cd "$BEADS_WORKER_DIR" 2>/dev/null && bd list --json 2>/dev/null \
+  beads_workers=$(cd "$BEADS_WORKER_DIR" 2>/dev/null && timeout 8 bd list --json 2>/dev/null \
      | python3 -c 'import sys,json; d=json.load(sys.stdin); print(len(d) if isinstance(d,list) else len(d.get("items",[])))' 2>/dev/null || echo '-1')
-  beads_supervisor=$(cd "$BEADS_SUPERVISOR_DIR" 2>/dev/null && bd list --json 2>/dev/null \
+  beads_supervisor=$(cd "$BEADS_SUPERVISOR_DIR" 2>/dev/null && timeout 8 bd list --json 2>/dev/null \
      | python3 -c 'import sys,json; d=json.load(sys.stdin); print(len(d) if isinstance(d,list) else len(d.get("items",[])))' 2>/dev/null || echo '-1')
 
   # Cadence matrix — read from governor config
@@ -1012,16 +1029,17 @@ main() {
 
     status)
       shift
-      local watch_interval=0 json_mode=false
+      local watch_interval=0 json_mode=false repos_flag=""
       while [[ $# -gt 0 ]]; do
         case "$1" in
           -w|--watch)  watch_interval="${2:-5}"; shift 2 || shift ;;
           --json)      json_mode=true; shift ;;
+          --repos)     repos_flag="--repos"; shift ;;
           *)           watch_interval="$1"; shift ;;
         esac
       done
       if [[ "$json_mode" == "true" ]]; then
-        cmd_status_json
+        cmd_status_json $repos_flag
       elif [[ "$watch_interval" -gt 0 ]] 2>/dev/null; then
         trap 'tput cnorm 2>/dev/null; printf "\n"; exit 0' INT TERM
         tput civis 2>/dev/null  # hide cursor
@@ -1030,7 +1048,7 @@ main() {
         while true; do
           cols=$(tput cols 2>/dev/null || echo 120)
           local buf
-          buf=$(cmd_status 2>/dev/null || true)
+          buf=$(cmd_status $repos_flag 2>/dev/null || true)
           # Move to top-left, overwrite each line padded to terminal width
           tput cup 0 0 2>/dev/null
           while IFS= read -r line; do
@@ -1041,7 +1059,7 @@ main() {
           sleep "$watch_interval"
         done
       else
-        cmd_status
+        cmd_status $repos_flag
       fi
       ;;
     attach)   shift; cmd_attach  "${1:-supervisor}" ;;

--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -465,8 +465,18 @@ highest engagement. Use this to (a) prioritise which Console capabilities to pit
 platform, (b) identify traffic gaps where new listings would have the most impact, and \
 (c) track whether previous outreach placements are driving referral traffic. \
 GA4 insight is for strategy only — do NOT fix GA4 errors (that is the reviewer's job). \
+CI HEALTH — after completing outreach work each pass, run /tmp/hive/dashboard/health-check.sh. \
+For EVERY red check (nightly, hourly, CI, Playwright nightly, weekly, deploys, code coverage), \
+pull the failed workflow logs, diagnose root cause, and open a fix PR. \
+Use git worktree add /tmp/kubestellar-console-outreach-cifix -b fix/outreach-ci-<workflow>. \
+Coverage: run npm run test:coverage in the worktree. If below 91%, write new tests targeting \
+the lowest-coverage files and open a PR. \
+Playwright: check nightly Playwright workflow — fix webkit/chromium/firefox failures via PR. \
+Build and lint before opening any fix PR. This is a secondary responsibility — do outreach \
+first, then fix CI if time permits before the next kick. \
 LANE BOUNDARIES (default, unless overridden by operator directive) — outreach must NEVER: \
-fix bugs, review code, implement features, or do anything the scanner/reviewer/architect agents do. \
+fix bugs (except CI/nightly/Playwright/coverage failures), review code, implement features, \
+or do anything the scanner/reviewer/architect agents do. \
 If you find a bug or improvement idea, file a beads issue for the scanner — do not act on it yourself. \
 Fork under clubanderson account for all external PRs to third-party repos. \
 Send ntfy for every new listing secured. One outreach per project — never spam. $(beads_sync "$OUTREACH_BEADS" "outreach")"

--- a/dashboard/agent-activity.py
+++ b/dashboard/agent-activity.py
@@ -271,10 +271,13 @@ def summarize_entries(entries):
         lines.append(tools[0])
     if last_text and last_text not in lines:
         lines.append(last_text)
-    if len(tools) > 1 and len(lines) < 3:
-        lines.append(tools[1])
+    for t in tools[1:]:
+        if len(lines) >= 5:
+            break
+        if t not in lines:
+            lines.append(t)
 
-    return "\n".join(lines[:3])
+    return "\n".join(lines[:5])
 
 
 def scrape_tmux(session):

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -20,6 +20,9 @@
     h1 { font-size: 1.4rem; margin-bottom: 20px; display: flex; align-items: center; }
     h1 span.bee { font-size: 1.6rem; margin-right: 8px; }
     .timestamp { color: var(--muted); font-size: 0.8rem; margin-left: 12px; }
+    .git-version { font-size: 0.65rem; color: var(--muted); margin-left: 10px; font-weight: 400; font-family: monospace; }
+    .git-version .git-behind { color: var(--yellow); font-weight: 600; }
+    .git-version .git-dirty { color: var(--yellow); }
     .header-spacer { flex: 1; }
     .widget-dl {
       font-size: 0.75rem; color: var(--cyan); text-decoration: none;
@@ -54,10 +57,14 @@
     .agent-field .label { color: var(--muted); }
     .agent-field .value { text-align: right; }
     .value.working { color: var(--yellow); }
+    .restart-label { font-size: 0.6rem; color: var(--muted); margin-left: 3px; }
+    .restart-warn { color: var(--yellow); }
+    .restart-high { color: var(--red); }
+    .restart-spark { display: inline-block; margin-left: 6px; vertical-align: middle; }
     .value.idle { color: var(--muted); }
     .value.copilot { color: var(--cyan); }
     .value.claude { color: var(--purple); }
-    .doing { font-size: 0.75rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: pre-line; line-height: 1.5; min-height: 3.4em; }
+    .doing { font-size: 0.75rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: pre-line; line-height: 1.5; min-height: 5.6em; }
     .summary-age { display: inline-block; font-size: 0.6rem; font-style: normal; border-radius: 3px; padding: 1px 5px; margin-right: 5px; vertical-align: middle; white-space: nowrap; }
     .summary-age.age-recent { background: rgba(210,153,34,0.15); color: #d29922; border: 1px solid rgba(210,153,34,0.3); }
     .summary-age.age-stale  { background: rgba(248,81,73,0.15);  color: #f85149; border: 1px solid rgba(248,81,73,0.3); }
@@ -227,6 +234,8 @@
     .gov-matrix td.col-active.mode-busy  { background: rgba(210,153,34,0.08); color: #d29922; }
     .gov-matrix td.col-active.mode-surge { background: rgba(248,81,73,0.08); color: #f85149; }
     .gov-matrix td.paused { color: #484f58; font-style: italic; }
+    @keyframes cadence-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.3; } }
+    .gov-matrix td.col-active.agent-working { animation: cadence-pulse 2.5s ease-in-out infinite; }
 
     /* Timeline strip */
     .gov-timeline { margin-top: 10px; }
@@ -296,6 +305,13 @@
     .token-sessions summary { cursor: pointer; font-weight: 600; color: var(--text); margin-bottom: 4px; }
     .token-session-row { display: flex; gap: 8px; padding: 2px 0; align-items: baseline; }
     .token-session-row .sid { color: var(--cyan); font-family: monospace; min-width: 90px; }
+    .token-session-row .sagent { font-weight: 600; min-width: 70px; font-size: 0.65rem; }
+    .token-session-row .sagent.a-scanner { color: #58a6ff; }
+    .token-session-row .sagent.a-reviewer { color: #3fb950; }
+    .token-session-row .sagent.a-architect { color: #bc8cff; }
+    .token-session-row .sagent.a-outreach { color: #39d2c0; }
+    .token-session-row .sagent.a-supervisor { color: #d29922; }
+    .token-session-row .sagent.a-unknown { color: var(--muted); font-style: italic; }
     .token-session-row .smodel { color: var(--purple); min-width: 120px; }
     .token-session-row .stokens { color: var(--text); font-weight: 600; min-width: 80px; text-align: right; }
     .token-session-row .smsgs { color: var(--muted); min-width: 50px; }
@@ -376,6 +392,7 @@
   </div>
 
   <h1><span class="bee">🐝</span> KubeStellar Hive Dashboard <span class="timestamp" id="ts"></span>
+    <span class="git-version" id="git-version"></span>
     <a href="/api/widget" class="widget-dl" title="Download Übersicht widget">⬇ Widget</a>
   </h1>
 
@@ -430,6 +447,14 @@
         for (const k of keys) v = v?.[k];
         return v ?? 0;
       });
+    }
+
+    function restartSparkSvg(agentName) {
+      const series = historyData
+        .map(s => s.agents?.[agentName]?.restarts)
+        .filter(v => v != null);
+      if (series.length < 2 || Math.max(...series) === 0) return '';
+      return sparkSvg(series, '#f85149');
     }
 
     async function fetchHistory() {
@@ -647,6 +672,7 @@
           <div class="agent-field"><span class="label">interval</span><span class="value">${a.cadence}</span></div>
           <div class="agent-field"><span class="label">next run</span><span class="value">${a.nextKick || '—'}</span></div>
           ${agentTokenRow(a.name, a.cadence)}
+          <div class="agent-field"><span class="label">restarts</span><span class="value${(a.restarts || 0) > 5 ? ' restart-high' : (a.restarts || 0) > 0 ? ' restart-warn' : ''}">${a.restarts || 0}<span class="restart-label">24h</span><span class="restart-spark">${restartSparkSvg(a.name)}</span></span></div>
           <div class="agent-state ${a.busy}">${a.busy}</div>
           ${needsLogin ? '<div class="login-warning">⚠ NOT LOGGED IN — run /login</div>' : ''}
           ${summaryEl}${indEl}
@@ -778,15 +804,16 @@
       const rows = agentOrder.map(aname => {
         const row = matrix.find(r => r.agent === aname);
         if (!row) return '';
+        const agentData = agents.find(a => a.name === aname);
+        const isWorking = agentData && agentData.busy === 'working';
         const cells = modes.map(m => {
           const val = row[m] || '?';
           const isActive = m === currentMode;
           const isPaused = val === 'paused';
-          const colCls = isActive ? `col-active mode-${m}` : '';
+          const colCls = isActive ? `col-active mode-${m}${isWorking ? ' agent-working' : ''}` : '';
           const pausedCls = isPaused ? ' paused' : '';
           return `<td class="${colCls}${pausedCls}">${isPaused ? '—' : val}</td>`;
         }).join('');
-        const agentData = agents.find(a => a.name === aname);
         const mChip = agentData && agentData.govBackend ? modelChip(agentData.govBackend, agentData.govModel, agentData.govReason) : '';
         return `<tr><td>${aname}</td>${cells}<td>${mChip}</td></tr>`;
       }).join('');
@@ -822,8 +849,8 @@
       const wSpark = sparkSvg(getHistorySeries('beadsWorkers'), '#39d2c0');
       const sSpark = sparkSvg(getHistorySeries('beadsSupervisor'), '#d29922');
       el.innerHTML = `
-        <div class="bead-stat"><div class="spark-row"><span class="num">${beads.workers >= 0 ? beads.workers : '?'}</span>${wSpark}</div><div class="label">workers</div></div>
-        <div class="bead-stat"><div class="spark-row"><span class="num">${beads.supervisor >= 0 ? beads.supervisor : '?'}</span>${sSpark}</div><div class="label">supervisor</div></div>`;
+        <div class="bead-stat"><div class="spark-row"><span class="num">${beads.workers >= 0 ? beads.workers : 0}</span>${wSpark}</div><div class="label">workers</div></div>
+        <div class="bead-stat"><div class="spark-row"><span class="num">${beads.supervisor >= 0 ? beads.supervisor : 0}</span>${sSpark}</div><div class="label">supervisor</div></div>`;
     }
 
     function fmtTokens(n) {
@@ -1006,6 +1033,8 @@
         return;
       }
 
+      const sessionsOpen = el.querySelector('.token-sessions')?.open || false;
+
       const t = tokens.totals;
       const totalTokens = t.input + t.output + t.cacheRead;
       const models = Object.entries(tokens.byModel || {}).sort((a, b) =>
@@ -1025,8 +1054,11 @@
 
       const sessionRows = sessions.map(s => {
         const age = s.lastActive ? new Date(s.lastActive).toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true}) : '';
+        const agentName = s.agent && s.agent !== 'unknown' ? s.agent : '';
+        const agentCls = agentName ? `a-${agentName}` : 'a-unknown';
         return `<div class="token-session-row">
           <span class="sid">${esc(s.id)}</span>
+          <span class="sagent ${agentCls}">${agentName || '—'}</span>
           <span class="smodel">${esc(s.model)}</span>
           <span class="stokens">${fmtTokens(s.total)}</span>
           <span class="smsgs">${s.messages} msgs</span>
@@ -1060,7 +1092,7 @@
         ${agentSparkRows ? `<div class="token-grid" style="margin-top:4px">${agentSparkRows}</div>` : ''}
         ${advisorHtml}
         <div class="token-models">${modelChips}</div>
-        ${sessions.length > 0 ? `<details class="token-sessions"><summary>Active Sessions (${sessions.length})</summary>${sessionRows}</details>` : ''}
+        ${sessions.length > 0 ? `<details class="token-sessions"${sessionsOpen ? ' open' : ''}><summary>Active Sessions (${sessions.length})</summary>${sessionRows}</details>` : ''}
       </div>`;
     }
 
@@ -1148,6 +1180,22 @@
       if (!data.ok) alert('Model switch failed: ' + (data.error || 'unknown'));
     }
 
+    // Git version indicator
+    const GIT_VERSION_POLL_MS = 300000;
+    async function fetchGitVersion() {
+      try {
+        const res = await fetch('/api/version');
+        const v = await res.json();
+        const el = document.getElementById('git-version');
+        let html = `<a href="https://github.com/kubestellar/hive/commit/${v.hash}" target="_blank" style="color:inherit;text-decoration:none" title="${v.hash}">${v.short}</a>`;
+        if (v.dirty) html += ' <span class="git-dirty">*</span>';
+        if (v.behind > 0) html += ` <span class="git-behind">${v.behind} behind</span>`;
+        el.innerHTML = html;
+      } catch (_) {}
+    }
+    fetchGitVersion();
+    setInterval(fetchGitVersion, GIT_VERSION_POLL_MS);
+
     // SSE connection
     function connect() {
       const source = new EventSource('/api/events');
@@ -1166,8 +1214,8 @@
             govPrs: data.governor?.prs || 0,
             govTotal: (data.governor?.issues || 0) + (data.governor?.prs || 0),
             govActive: data.governor?.active ? 1 : 0,
-            beadsWorkers: data.beads?.workers || 0,
-            beadsSupervisor: data.beads?.supervisor || 0,
+            beadsWorkers: Math.max(data.beads?.workers ?? 0, 0),
+            beadsSupervisor: Math.max(data.beads?.supervisor ?? 0, 0),
             repos: {},
             agents: {},
           };

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -18,6 +18,8 @@ const MAX_PERSISTENT_POINTS = 30 * 24 * 4; // 30 days at 15-min intervals = 2880
 // Cache for status data
 let statusCache = null;
 let lastFetch = 0;
+// Last known good beads values (bd timeout returns -1)
+let lastGoodBeads = { workers: 0, supervisor: 0 };
 let ciPassRate = 0;
 let healthChecks = {};
 let agentMetrics = {};
@@ -172,15 +174,22 @@ setTimeout(persistSnapshot, 10000);
 function fetchStatus() {
   return new Promise((resolve) => {
     const hiveEnv = { ...process.env, HIVE_TZ: process.env.HIVE_TZ || 'America/New_York' };
-    execFile('hive', ['status', '--json'], { timeout: 30000, env: hiveEnv }, (err, stdout) => {
+    execFile('/usr/local/bin/hive', ['status', '--json'], { timeout: 30000, env: hiveEnv }, (err, stdout, stderr) => {
       if (err) {
-        console.error('hive status --json failed:', err.message);
+        console.error('hive status --json failed:', err.message, stderr ? 'stderr: ' + stderr.slice(0, 200) : '');
         resolve(statusCache); // return stale data
         return;
       }
       try {
         statusCache = JSON.parse(stdout);
         lastFetch = Date.now();
+        // Replace -1 (bd timeout) with last known good beads values
+        if (statusCache.beads) {
+          if (statusCache.beads.workers >= 0) lastGoodBeads.workers = statusCache.beads.workers;
+          else statusCache.beads.workers = lastGoodBeads.workers;
+          if (statusCache.beads.supervisor >= 0) lastGoodBeads.supervisor = statusCache.beads.supervisor;
+          else statusCache.beads.supervisor = lastGoodBeads.supervisor;
+        }
         // Build reviewer metrics from live data
         statusCache.health = healthChecks;
         statusCache.ciPassRate = ciPassRate;
@@ -274,7 +283,7 @@ function fetchStatus() {
           snap.repos[r.name] = { issues: r.issues || 0, prs: r.prs || 0 };
         }
         for (const a of (statusCache.agents || [])) {
-          snap.agents[a.name] = { busy: a.busy === 'working' ? 1 : 0 };
+          snap.agents[a.name] = { busy: a.busy === 'working' ? 1 : 0, restarts: a.restarts || 0 };
         }
         history.push(snap);
         if (history.length > MAX_HISTORY) history.shift();
@@ -291,12 +300,52 @@ function fetchStatus() {
   });
 }
 
-// Background refresh loop
+// Background refresh loop — fast (agents only, no GH API calls)
 setInterval(fetchStatus, REFRESH_MS);
 fetchStatus();
 
+// Slow refresh for repo data (GH API) — every 5min to reduce GH token spend
+const REPO_REFRESH_MS = 300000;
+function fetchRepoStatus() {
+  const hiveEnv = { ...process.env, HIVE_TZ: process.env.HIVE_TZ || 'America/New_York' };
+  execFile('/usr/local/bin/hive', ['status', '--json', '--repos'], { timeout: 30000, env: hiveEnv }, (err, stdout) => {
+    if (err) { console.error('hive status --json --repos failed:', err.message); return; }
+    try {
+      const data = JSON.parse(stdout);
+      if (statusCache && data.repos) statusCache.repos = data.repos;
+    } catch (_) {}
+  });
+}
+setInterval(fetchRepoStatus, REPO_REFRESH_MS);
+fetchRepoStatus();
+
 // Serve static files
 app.use(express.static(path.join(__dirname, 'public')));
+
+// Git version — cached, refreshed every 5 min
+let gitVersionCache = { hash: '?', short: '?', behind: 0, dirty: false, ts: 0 };
+const GIT_VERSION_REFRESH_MS = 300000;
+function refreshGitVersion() {
+  const hiveDir = '/tmp/hive';
+  execFile('git', ['-C', hiveDir, 'rev-parse', 'HEAD'], { timeout: 5000 }, (err, hash) => {
+    if (err) return;
+    gitVersionCache.hash = hash.trim();
+    gitVersionCache.short = hash.trim().slice(0, 7);
+    gitVersionCache.ts = Date.now();
+    execFile('git', ['-C', hiveDir, 'status', '--porcelain'], { timeout: 5000 }, (e2, status) => {
+      if (!e2) gitVersionCache.dirty = status.trim().length > 0;
+    });
+    execFile('git', ['-C', hiveDir, 'fetch', 'origin', 'main', '--quiet'], { timeout: 10000 }, () => {
+      execFile('git', ['-C', hiveDir, 'rev-list', 'HEAD..origin/main', '--count'], { timeout: 5000 }, (e3, count) => {
+        if (!e3) gitVersionCache.behind = parseInt(count.trim(), 10) || 0;
+      });
+    });
+  });
+}
+refreshGitVersion();
+setInterval(refreshGitVersion, GIT_VERSION_REFRESH_MS);
+
+app.get('/api/version', (_req, res) => res.json(gitVersionCache));
 
 // JSON API
 app.get('/api/status', async (_req, res) => {
@@ -417,7 +466,7 @@ app.post('/api/kick/:agent', (req, res) => {
       });
     });
   } else {
-    execFile('hive', ['kick', agent], { timeout: 30000 }, (err, stdout) => {
+    execFile('/usr/local/bin/hive', ['kick', agent], { timeout: 30000 }, (err, stdout) => {
       if (err) return res.status(500).json({ error: err.message });
       res.json({ ok: true, output: stdout.trim() });
     });
@@ -434,7 +483,7 @@ app.post('/api/switch/:agent/:backend', (req, res) => {
   if (!allowedBackends.includes(backend)) {
     return res.status(400).json({ error: `invalid backend: ${backend}` });
   }
-  execFile('hive', ['switch', agent, backend], { timeout: 30000 }, (err, stdout) => {
+  execFile('/usr/local/bin/hive', ['switch', agent, backend], { timeout: 30000 }, (err, stdout) => {
     if (err) return res.status(500).json({ error: err.message });
     res.json({ ok: true, output: stdout.trim() });
   });
@@ -446,7 +495,7 @@ app.post('/api/model/:agent/:model', (req, res) => {
   if (!allowedAgents.includes(agent)) {
     return res.status(400).json({ error: `invalid agent: ${agent}` });
   }
-  execFile('hive', ['model', agent, decodeURIComponent(model)], { timeout: 30000 }, (err, stdout) => {
+  execFile('/usr/local/bin/hive', ['model', agent, decodeURIComponent(model)], { timeout: 30000 }, (err, stdout) => {
     if (err) return res.status(500).json({ error: err.message });
     res.json({ ok: true, output: stdout.trim() });
   });

--- a/docs/hive-arch.svg
+++ b/docs/hive-arch.svg
@@ -40,7 +40,7 @@
 <text x="505" y="352" text-anchor="middle" font-size="12" font-weight="600" fill="#1e293b" font-family="ui-sans-serif,system-ui,sans-serif">supervisor</text>
 
 <!-- Backend CLI label under agents -->
-<text x="505" y="378" text-anchor="middle" font-size="9" fill="#7c3aed" font-family="ui-sans-serif,system-ui,sans-serif">claude · copilot · gemini · goose</text>
+<text x="505" y="378" text-anchor="middle" font-size="9" fill="#7c3aed" font-family="ui-sans-serif,system-ui,sans-serif">CLI: claude · gemini  |  Aggregate: copilot · goose</text>
 
 <!-- Local model stack (bottom) -->
 <rect x="230" y="430" width="130" height="34" rx="6" fill="#f0fdf4" stroke="#166534" stroke-width="1.5"/>


### PR DESCRIPTION
## Summary
- Guard beads display against -1/`?` values from bd lock contention (server-side cache + client fallback to 0)
- Add color-coded agent name labels to Active Sessions rows
- Restore cadence matrix pulse animation for working agents
- Add git hash/behind-main indicator to dashboard header
- Expand agent activity summaries from 3 to 5 lines
- Preserve Active Sessions `<details>` open state across SSE refreshes
- Slow repo refresh from 60s to 5min to reduce GitHub token spend
- Update outreach kick prompt with full CI health responsibility

## Test plan
- [ ] Verify beads never show `?` or negative values during bd lock contention
- [ ] Verify Active Sessions stays open across SSE refresh cycles
- [ ] Verify agent names appear with correct colors in session rows
- [ ] Verify cadence matrix cells pulse for working agents
- [ ] Verify git version indicator shows in header