### PR TITLE
feat: add awesome-list PR metrics to outreach dashboard

### DIFF
--- a/dashboard/agent-metrics.sh
+++ b/dashboard/agent-metrics.sh
@@ -79,6 +79,8 @@ outreach_tmp=$(mktemp -d)
 (c=$(gh api repos/kubestellar/console/contributors?per_page=1 -i 2>/dev/null | grep -oP 'page=\K\d+(?=>; rel="last")' || echo 0); [ "$c" = "0" ] && c=$(gh api repos/kubestellar/console/contributors --jq 'length' 2>/dev/null || echo 0); echo "$c" > "$outreach_tmp/contribs") &
 (a=$(gh api repos/kubestellar/console/contents/ADOPTERS.MD --jq '.content' 2>/dev/null | base64 -d 2>/dev/null | grep -cP '^\|.*\|.*\|' || echo 0); a=$(( a > 2 ? a - 2 : 0 )); echo "$a" > "$outreach_tmp/adopters") &
 (unset GITHUB_TOKEN; [ -n "$HIVE_GITHUB_TOKEN" ] && export GH_TOKEN="$HIVE_GITHUB_TOKEN"; gh api repos/kubestellar/docs/contents/src/app/%5Blocale%5D/acmm-leaderboard/page.tsx --jq '.content' 2>/dev/null | base64 -d 2>/dev/null | sed -n '/BADGE_PARTICIPANTS = new Set/,/\]);/p' | grep -cP '^\s+"[a-zA-Z]' > "$outreach_tmp/acmm" 2>/dev/null || echo 0 > "$outreach_tmp/acmm") &
+(gh api 'search/issues?q=author:clubanderson+type:pr+is:open+KubeStellar+in:title&per_page=100' --jq '[.items[] | select(.repository_url | test("awesome"))] | length' > "$outreach_tmp/awesome_open" 2>/dev/null || echo 0 > "$outreach_tmp/awesome_open") &
+(gh api 'search/issues?q=author:clubanderson+type:pr+is:closed+KubeStellar+in:title&per_page=100' --jq '[.items[] | select(.repository_url | test("awesome") and .pull_request.merged_at != null)] | length' > "$outreach_tmp/awesome_merged" 2>/dev/null || echo 0 > "$outreach_tmp/awesome_merged") &
 wait
 stars=$(cat "$outreach_tmp/stars" 2>/dev/null || echo 0)
 forks=$(cat "$outreach_tmp/forks" 2>/dev/null || echo 0)
@@ -86,6 +88,8 @@ contributors=$(cat "$outreach_tmp/contribs" 2>/dev/null || echo 0)
 adopters_total=$(cat "$outreach_tmp/adopters" 2>/dev/null || echo 0)
 acmm_count=$(cat "$outreach_tmp/acmm" 2>/dev/null || echo 0)
 acmm_count=${acmm_count:-0}
+awesome_open=$(cat "$outreach_tmp/awesome_open" 2>/dev/null || echo 0)
+awesome_merged=$(cat "$outreach_tmp/awesome_merged" 2>/dev/null || echo 0)
 rm -rf "$outreach_tmp"
 
 # ── Architect: PR counts from tmux (live doing is summary) ──
@@ -100,6 +104,6 @@ cat <<OUT
   "scanner": $scanner_json,
   "reviewer": $reviewer_json,
   "architect": $(jq -n --argjson json "$architect_json" --arg prs "$architect_prs" --arg closed "$architect_closed" '$json | .prs = ($prs|tonumber) | .closed = ($closed|tonumber)'),
-  "outreach": $(jq -n --argjson json "$outreach_json" --argjson stars "$stars" --argjson forks "$forks" --argjson contribs "$contributors" --argjson adopters "$adopters_total" --argjson acmm "$acmm_count" '$json | .stars = $stars | .forks = $forks | .contributors = $contribs | .adopters = $adopters | .acmm = $acmm')
+  "outreach": $(jq -n --argjson json "$outreach_json" --argjson stars "$stars" --argjson forks "$forks" --argjson contribs "$contributors" --argjson adopters "$adopters_total" --argjson acmm "$acmm_count" --argjson awOpen "$awesome_open" --argjson awMerged "$awesome_merged" '$json | .stars = $stars | .forks = $forks | .contributors = $contribs | .adopters = $adopters | .acmm = $acmm | .awesomeOpen = $awOpen | .awesomeMerged = $awMerged')
 }
 OUT

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -571,7 +571,11 @@
         const contribs = m.contributors || 0;
         const adopters = m.adopters || 0;
         const acmm = m.acmm || 0;
+        const awOpen = m.awesomeOpen || 0;
+        const awMerged = m.awesomeMerged || 0;
         const starSpark = sparkSvg((window._trendData || []).map(s => s.stars || 0), '#e3b341');
+        const awOpenSpark = sparkSvg((window._trendData || []).map(s => s.awesomeOpen || 0), '#58a6ff');
+        const awMergedSpark = sparkSvg((window._trendData || []).map(s => s.awesomeMerged || 0), '#3fb950');
         return `<div class="agent-indicators">
           <div class="ind-group"><span class="ind-group-label">GROWTH</span><div class="ind-dots">
             <span class="ind-dot-item"><span class="ind-num">⭐ ${stars}</span><span class="ind-dlabel">stars ${starSpark}</span></span>
@@ -581,6 +585,10 @@
           <div class="ind-group"><span class="ind-group-label">ADOPTION</span><div class="ind-dots">
             <span class="ind-dot-item"><span class="ind-num">${adopters}</span><span class="ind-dlabel">adopters</span></span>
             <span class="ind-dot-item"><span class="ind-num">${acmm}</span><span class="ind-dlabel">ACMM badges</span></span>
+          </div></div>
+          <div class="ind-group"><span class="ind-group-label">AWESOME LISTS</span><div class="ind-dots">
+            <span class="ind-dot-item"><span class="ind-num">${awOpen}</span><span class="ind-dlabel">open ${awOpenSpark}</span></span>
+            <span class="ind-dot-item"><span class="ind-num">${awMerged}</span><span class="ind-dlabel">merged ${awMergedSpark}</span></span>
           </div></div>
         </div>`;
       }

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -157,6 +157,8 @@ function persistSnapshot() {
     adopters: am.outreach?.adoptersTotal || 0,
     adopterPrs: am.outreach?.adopterPending || 0,
     ciPassRate: ciPassRate || 0,
+    awesomeOpen: am.outreach?.awesomeOpen || 0,
+    awesomeMerged: am.outreach?.awesomeMerged || 0,
   };
   persistentHistory.push(snap);
   if (persistentHistory.length > MAX_PERSISTENT_POINTS) {
@@ -249,6 +251,8 @@ function fetchStatus() {
           ga4Errors: agentMetrics?.outreach?.ga4Errors || 0,
           adopters: agentMetrics?.outreach?.adoptersTotal || 0,
           adopterPrs: agentMetrics?.outreach?.adopterPending || 0,
+          awesomeOpen: agentMetrics?.outreach?.awesomeOpen || 0,
+          awesomeMerged: agentMetrics?.outreach?.awesomeMerged || 0,
           tokens: {},
           tokenTotal: 0,
           tokenInput: 0,


### PR DESCRIPTION
## Summary
- Adds open and merged awesome-list PR counts to the outreach agent card
- Uses GitHub search API to find PRs by clubanderson on awesome-* repos
- Merged count filters on pull_request.merged_at (excludes rejected PRs)
- Both metrics include sparklines for historical trends

## Files changed
- `dashboard/agent-metrics.sh` — two new parallel gh API search calls
- `dashboard/server.js` — awesomeOpen/awesomeMerged in snapshot recording
- `dashboard/public/index.html` — AWESOME LISTS group with sparklines

## Test
Verified on dev server: awesomeOpen=86, awesomeMerged filters correctly
