### PR TITLE
fix: exclude kubestellar org from outreach PR counts

### DIFF
--- a/dashboard/agent-metrics.sh
+++ b/dashboard/agent-metrics.sh
@@ -79,8 +79,8 @@ outreach_tmp=$(mktemp -d)
 (c=$(gh api repos/kubestellar/console/contributors?per_page=1 -i 2>/dev/null | grep -oP 'page=\K\d+(?=>; rel="last")' || echo 0); [ "$c" = "0" ] && c=$(gh api repos/kubestellar/console/contributors --jq 'length' 2>/dev/null || echo 0); echo "$c" > "$outreach_tmp/contribs") &
 (a=$(gh api repos/kubestellar/console/contents/ADOPTERS.MD --jq '.content' 2>/dev/null | base64 -d 2>/dev/null | grep -cP '^\|.*\|.*\|' || echo 0); a=$(( a > 2 ? a - 2 : 0 )); echo "$a" > "$outreach_tmp/adopters") &
 (unset GITHUB_TOKEN; [ -n "$HIVE_GITHUB_TOKEN" ] && export GH_TOKEN="$HIVE_GITHUB_TOKEN"; gh api repos/kubestellar/docs/contents/src/app/%5Blocale%5D/acmm-leaderboard/page.tsx --jq '.content' 2>/dev/null | base64 -d 2>/dev/null | sed -n '/BADGE_PARTICIPANTS = new Set/,/\]);/p' | grep -cP '^\s+"[a-zA-Z]' > "$outreach_tmp/acmm" 2>/dev/null || echo 0 > "$outreach_tmp/acmm") &
-(gh api 'search/issues?q=author:clubanderson+type:pr+is:open+KubeStellar+in:title' --jq '.total_count' > "$outreach_tmp/outreach_open" 2>/dev/null || echo 0 > "$outreach_tmp/outreach_open") &
-(gh api 'search/issues?q=author:clubanderson+type:pr+is:merged+KubeStellar+in:title' --jq '.total_count' > "$outreach_tmp/outreach_merged" 2>/dev/null || echo 0 > "$outreach_tmp/outreach_merged") &
+(gh api 'search/issues?q=author:clubanderson+type:pr+is:open+KubeStellar+in:title+-org:kubestellar' --jq '.total_count' > "$outreach_tmp/outreach_open" 2>/dev/null || echo 0 > "$outreach_tmp/outreach_open") &
+(gh api 'search/issues?q=author:clubanderson+type:pr+is:merged+KubeStellar+in:title+-org:kubestellar' --jq '.total_count' > "$outreach_tmp/outreach_merged" 2>/dev/null || echo 0 > "$outreach_tmp/outreach_merged") &
 wait
 stars=$(cat "$outreach_tmp/stars" 2>/dev/null || echo 0)
 forks=$(cat "$outreach_tmp/forks" 2>/dev/null || echo 0)


### PR DESCRIPTION
## Summary
- Add `-org:kubestellar` to outreach PR search queries to exclude internal PRs
- Previous query counted all PRs with "KubeStellar" in title including console/docs/hive PRs
- Corrects: open 289→286, merged 251→68

## Test plan
- [ ] Verify dashboard shows ~286 open, ~68 merged (not 289/251)