### PR TITLE
feat(dashboard): show 5 activity lines per agent instead of 3

### DIFF
--- a/dashboard/agent-activity.py
+++ b/dashboard/agent-activity.py
@@ -2,7 +2,7 @@
 """Extract live activity summaries from Claude Code JSONL session files.
 
 Tails active session files efficiently using byte offset tracking.
-Produces human-readable 1-3 line summaries via template-based extraction.
+Produces human-readable 1-5 line summaries via template-based extraction.
 Called by server.js every 5s, outputs JSON to stdout.
 """
 
@@ -259,7 +259,7 @@ def summarize_entries(entries):
         msg = entry.get("message", {})
         for content in msg.get("content", []):
             ct = content.get("type")
-            if ct == "tool_use" and len(tools) < 3:
+            if ct == "tool_use" and len(tools) < 5:
                 desc = describe_tool(content)
                 if desc and desc not in tools:
                     tools.append(desc)
@@ -310,7 +310,7 @@ def scrape_tmux(session):
     for l in lines:
         if l not in unique:
             unique.append(l)
-    result = unique[-3:] if unique else []
+    result = unique[-5:] if unique else []
     return ("\n".join(result), is_working) if result else None
 
 

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -64,7 +64,7 @@
     .value.idle { color: var(--muted); }
     .value.copilot { color: var(--cyan); }
     .value.claude { color: var(--purple); }
-    .doing { font-size: 0.75rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: pre-line; line-height: 1.5; min-height: 5.6em; }
+    .doing { font-size: 0.75rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: pre-line; line-height: 1.5; min-height: 7.5em; }
     .summary-age { display: inline-block; font-size: 0.6rem; font-style: normal; border-radius: 3px; padding: 1px 5px; margin-right: 5px; vertical-align: middle; white-space: nowrap; }
     .summary-age.age-recent { background: rgba(210,153,34,0.15); color: #d29922; border: 1px solid rgba(210,153,34,0.3); }
     .summary-age.age-stale  { background: rgba(248,81,73,0.15);  color: #f85149; border: 1px solid rgba(248,81,73,0.3); }


### PR DESCRIPTION
Increases agent activity summary display from 3 to 5 lines:
- `agent-activity.py`: tmux scrape limit `unique[-3:]` → `unique[-5:]`, JSONL tool limit `< 3` → `< 5`
- `index.html`: CSS `.doing` min-height `5.6em` → `7.5em` to fit 5 lines