### PR TITLE
fix: show paused badge in all cadence matrix columns

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -841,7 +841,7 @@
           const val = row[m] || '?';
           const isActive = m === currentMode;
           const isPaused = val === 'paused';
-          const showPaused = isPaused || (isActive && agentPaused);
+          const showPaused = isPaused || agentPaused;
           const colCls = isActive ? `col-active mode-${m}` : '';
           const pausedCls = showPaused ? ' paused' : '';
           const dot = (isActive && isWorking && !agentPaused) ? '<span class="active-dot"></span>' : '';


### PR DESCRIPTION
## Summary
- When an agent is paused, all mode columns now show the paused badge (not just the active mode column)
- One-line fix: `showPaused = isPaused || agentPaused` instead of `isPaused || (isActive && agentPaused)`