### PR TITLE
fix: detect idle prompt to prevent false-positive working state

### DIFF
--- a/bin/hive.sh
+++ b/bin/hive.sh
@@ -561,9 +561,14 @@ cmd_status() {
       local queued_tasks
       queued_tasks=$(echo "$pane" | grep -oP '\d+(?= background /tasks)' | tail -1 || true)
 
+      local at_prompt=false
+      if echo "$pane" | tail -5 | LC_ALL=C.UTF-8 grep -qE '^❯'; then
+        at_prompt=true
+      fi
+
       if [[ "$needs_login" == "true" ]]; then
         busy_flag="${RED}⚠ NOT LOGGED IN${RST}"
-      elif echo "$recent_lines" | LC_ALL=C.UTF-8 grep -qE "^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*] |^⏺ |Esc to cancel|↳ |agent still running|Scampering|Evaporating|Perambulating|Puttering|Sautéed|Precipitating|Pouncing|Thinking"; then
+      elif [[ "$at_prompt" == "false" ]] && echo "$recent_lines" | LC_ALL=C.UTF-8 grep -qE "^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*] |^⏺ |Esc to cancel|↳ |agent still running|Scampering|Evaporating|Perambulating|Puttering|Sautéed|Precipitating|Pouncing|Thinking"; then
         # Spinner or "Esc to cancel" found in recent output — actively working
         busy_flag="${YLW}working${RST}"
         doing=$(echo "$pane_body" \
@@ -692,8 +697,12 @@ cmd_status_json() {
       fi
       # Strip prompt, separator lines, and status bar to detect actual work output
       # LC_ALL=C.UTF-8 required — server runs LANG=C which breaks multi-byte UTF-8 grep
+      local at_prompt_json=false
+      if echo "$pane" | tail -5 | LC_ALL=C.UTF-8 grep -qE '^❯'; then
+        at_prompt_json=true
+      fi
       recent_lines=$(echo "$pane" | LC_ALL=C.UTF-8 grep -vE '^[─━═]+$|^❯|^\s*$|^ / commands|^[[:space:]]*~/' | tail -15)
-      if echo "$recent_lines" | LC_ALL=C.UTF-8 grep -qE "^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*] |^⏺ |Esc to cancel|↳ |Running .* pass|background /tasks|agent still running|Scampering|Evaporating|Perambulating|Puttering|Sautéed|Precipitating|Pouncing|Thinking"; then
+      if [[ "$at_prompt_json" == "false" ]] && echo "$recent_lines" | LC_ALL=C.UTF-8 grep -qE "^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*] |^⏺ |Esc to cancel|↳ |Running .* pass|background /tasks|agent still running|Scampering|Evaporating|Perambulating|Puttering|Sautéed|Precipitating|Pouncing|Thinking"; then
         busy="working"
         doing=$(echo "$recent_lines" \
           | LC_ALL=C.UTF-8 grep -E "^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*] |^⏺ |Esc to cancel|agent still running" \

--- a/dashboard/agent-activity.py
+++ b/dashboard/agent-activity.py
@@ -290,6 +290,9 @@ def scrape_tmux(session):
     except (subprocess.SubprocessError, OSError):
         return None
 
+    raw_stripped = [l for l in raw.splitlines() if l.strip()]
+    at_prompt = any(l.strip().startswith('❯') for l in raw_stripped[-3:]) if raw_stripped else False
+
     lines = []
     is_working = False
     for line in raw.splitlines():
@@ -305,6 +308,9 @@ def scrape_tmux(session):
                 lines.append(cleaned)
         elif line.strip() and len(line.strip()) > 5:
             lines.append(line.strip())
+
+    if at_prompt:
+        is_working = False
 
     unique = []
     for l in lines:


### PR DESCRIPTION
## Summary
- Agents at the Claude `❯` prompt were reported as `busy: working` because old tool output in the tmux scroll buffer matched spinner patterns
- Fix: check last 5 lines for `❯` prompt before spinner detection — if at prompt, force idle
- Applied to both `agent-activity.py` (Python scraper) and `hive.sh` (display + JSON status functions)

## Verification
All 5 agents now correctly show `busy: idle` when at the prompt. Tested on live dashboard.