### PR TITLE
fix: refine idle detection — check for activity near prompt

### DIFF
--- a/bin/hive.sh
+++ b/bin/hive.sh
@@ -561,14 +561,16 @@ cmd_status() {
       local queued_tasks
       queued_tasks=$(echo "$pane" | grep -oP '\d+(?= background /tasks)' | tail -1 || true)
 
-      local at_prompt=false
+      local at_idle_prompt=false
       if echo "$pane" | tail -5 | LC_ALL=C.UTF-8 grep -qE '^❯'; then
-        at_prompt=true
+        if ! echo "$pane" | tail -8 | LC_ALL=C.UTF-8 grep -qE 'local agent|background.*/tasks|agent still running|Esc to cancel|Spinning|tokens\)|^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*] |^⏺ '; then
+          at_idle_prompt=true
+        fi
       fi
 
       if [[ "$needs_login" == "true" ]]; then
         busy_flag="${RED}⚠ NOT LOGGED IN${RST}"
-      elif [[ "$at_prompt" == "false" ]] && echo "$recent_lines" | LC_ALL=C.UTF-8 grep -qE "^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*] |^⏺ |Esc to cancel|↳ |agent still running|Scampering|Evaporating|Perambulating|Puttering|Sautéed|Precipitating|Pouncing|Thinking"; then
+      elif [[ "$at_idle_prompt" == "false" ]] && echo "$recent_lines" | LC_ALL=C.UTF-8 grep -qE "^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*] |^⏺ |Esc to cancel|↳ |agent still running|Scampering|Evaporating|Perambulating|Puttering|Sautéed|Precipitating|Pouncing|Thinking"; then
         # Spinner or "Esc to cancel" found in recent output — actively working
         busy_flag="${YLW}working${RST}"
         doing=$(echo "$pane_body" \
@@ -697,12 +699,14 @@ cmd_status_json() {
       fi
       # Strip prompt, separator lines, and status bar to detect actual work output
       # LC_ALL=C.UTF-8 required — server runs LANG=C which breaks multi-byte UTF-8 grep
-      local at_prompt_json=false
+      local at_idle_prompt_json=false
       if echo "$pane" | tail -5 | LC_ALL=C.UTF-8 grep -qE '^❯'; then
-        at_prompt_json=true
+        if ! echo "$pane" | tail -8 | LC_ALL=C.UTF-8 grep -qE 'local agent|background.*/tasks|agent still running|Esc to cancel|Spinning|tokens\)|^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*] |^⏺ '; then
+          at_idle_prompt_json=true
+        fi
       fi
       recent_lines=$(echo "$pane" | LC_ALL=C.UTF-8 grep -vE '^[─━═]+$|^❯|^\s*$|^ / commands|^[[:space:]]*~/' | tail -15)
-      if [[ "$at_prompt_json" == "false" ]] && echo "$recent_lines" | LC_ALL=C.UTF-8 grep -qE "^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*] |^⏺ |Esc to cancel|↳ |Running .* pass|background /tasks|agent still running|Scampering|Evaporating|Perambulating|Puttering|Sautéed|Precipitating|Pouncing|Thinking"; then
+      if [[ "$at_idle_prompt_json" == "false" ]] && echo "$recent_lines" | LC_ALL=C.UTF-8 grep -qE "^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*] |^⏺ |Esc to cancel|↳ |Running .* pass|background /tasks|agent still running|Scampering|Evaporating|Perambulating|Puttering|Sautéed|Precipitating|Pouncing|Thinking"; then
         busy="working"
         doing=$(echo "$recent_lines" \
           | LC_ALL=C.UTF-8 grep -E "^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*] |^⏺ |Esc to cancel|agent still running" \

--- a/dashboard/agent-activity.py
+++ b/dashboard/agent-activity.py
@@ -290,9 +290,6 @@ def scrape_tmux(session):
     except (subprocess.SubprocessError, OSError):
         return None
 
-    raw_stripped = [l for l in raw.splitlines() if l.strip()]
-    at_prompt = any(l.strip().startswith('❯') for l in raw_stripped[-3:]) if raw_stripped else False
-
     lines = []
     is_working = False
     for line in raw.splitlines():
@@ -309,7 +306,12 @@ def scrape_tmux(session):
         elif line.strip() and len(line.strip()) > 5:
             lines.append(line.strip())
 
-    if at_prompt:
+    raw_stripped = [l for l in raw.splitlines() if l.strip()]
+    tail_text = "\n".join(raw_stripped[-8:]) if raw_stripped else ""
+    has_prompt = any(l.strip().startswith('❯') for l in raw_stripped[-3:]) if raw_stripped else False
+    ACTIVE_RE = re.compile(r'local agent|background.*/tasks|agent still running|Esc to cancel|Spinning|tokens\)')
+    has_activity = bool(ACTIVE_RE.search(tail_text)) or any(SPINNER_RE.search(l) for l in raw_stripped[-8:])
+    if has_prompt and not has_activity:
         is_working = False
 
     unique = []


### PR DESCRIPTION
## Summary
- v1 fix (PR #87) overcorrected — `❯` prompt is visible even while agents work (background agents, streaming, permission prompts)
- Now checks last 8 lines for activity signals before overriding to idle
- Activity signals: spinners (`◉●·*⏺`), `Esc to cancel`, `local agent`, `background tasks`, `Spinning`, `tokens)`
- Only marks idle when `❯` is present AND none of these activity indicators are nearby

## Tested
- Scanner with 1 local agent running → `busy=working` ✅
- Reviewer actively running commands → `busy=working` ✅  
- Architect streaming/spinning → `busy=working` ✅
- Outreach at idle prompt → `busy=idle` ✅
- Supervisor at idle prompt → `busy=idle` ✅