### PR TITLE
fix: process-based CLI detection, split backend/model pills

### DIFF
--- a/bin/hive.sh
+++ b/bin/hive.sh
@@ -43,6 +43,31 @@ trend_marker() {
 die()   { fail "$*"; exit 1; }
 hdr()   { echo -e "\n${BLD}$*${RST}"; }
 
+# Detect CLI binary from tmux pane process tree via /proc
+detect_cli_from_proc() {
+  local session="$1" pane_pid child_cmd
+  pane_pid=$(tmux list-panes -t "$session" -F '#{pane_pid}' 2>/dev/null | head -1)
+  [[ -z "$pane_pid" ]] && echo "?" && return
+  local shell_cmd
+  shell_cmd=$(cat "/proc/$pane_pid/cmdline" 2>/dev/null | tr '\0' ' ')
+  if [[ "$shell_cmd" == */claude\ * || "$shell_cmd" == */claude ]]; then
+    echo "claude" && return
+  fi
+  for cpid in $(ps -o pid= --ppid "$pane_pid" 2>/dev/null); do
+    child_cmd=$(cat "/proc/$cpid/cmdline" 2>/dev/null | tr '\0' ' ' | head -c 500)
+    if echo "$child_cmd" | grep -q "copilot"; then
+      echo "copilot" && return
+    elif echo "$child_cmd" | grep -q "/claude "; then
+      echo "claude" && return
+    elif echo "$child_cmd" | grep -q "goose"; then
+      echo "goose" && return
+    elif echo "$child_cmd" | grep -q "gemini"; then
+      echo "gemini" && return
+    fi
+  done
+  echo "?"
+}
+
 # ── load config ────────────────────────────────────────────────────
 
 load_conf() {
@@ -538,12 +563,9 @@ cmd_status() {
       local pane pane_tail
       pane=$(tmux capture-pane -t "$s" -p 2>/dev/null || echo "")
       pane_tail=$(echo "$pane" | tail -5)
-      # Detect CLI
-      if echo "$pane_tail" | grep -q "bypass permissions\|claude doctor\|Claude Code v\|Claude Opus\|Claude Sonnet\|Claude Haiku"; then
-        cli="claude"
-      elif echo "$pane_tail" | grep -q "ctrl+q enqueue\|/ commands.*help"; then
-        cli="copilot"
-      else
+      # Detect CLI from process tree
+      cli=$(detect_cli_from_proc "$s")
+      if [[ "$cli" == "?" ]]; then
         cli=$(grep "^AGENT_CLI=" "$ENV_DIR/${ENV_FILES[$i]}.env" 2>/dev/null | cut -d= -f2 | tr -d '"' || echo "?")
       fi
       # Detect login required — only check footer (last 5 lines) to avoid
@@ -680,11 +702,8 @@ cmd_status_json() {
       local pane pane_tail
       pane=$(tmux capture-pane -t "$s" -p 2>/dev/null || echo "")
       pane_tail=$(echo "$pane" | tail -5)
-      if echo "$pane_tail" | grep -q "bypass permissions\|claude doctor\|Claude Code v\|Claude Opus\|Claude Sonnet\|Claude Haiku"; then
-        cli="claude"
-      elif echo "$pane_tail" | grep -q "ctrl+q enqueue\|/ commands.*help"; then
-        cli="copilot"
-      else
+      cli=$(detect_cli_from_proc "$s")
+      if [[ "$cli" == "?" ]]; then
         cli=$(grep "^AGENT_CLI=" "$ENV_DIR/${ENV_FILES[$i]}.env" 2>/dev/null | cut -d= -f2 | tr -d '"' || echo "?")
       fi
       local recent_lines

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -363,6 +363,7 @@
     /* Model chip on agent cards */
     .model-chip { display: inline-flex; align-items: center; gap: 4px; font-size: 0.65rem; padding: 2px 6px; border-radius: 4px; }
     .model-chip.free { background: rgba(63,185,80,0.12); color: var(--green); }
+    .model-chip.paid { background: rgba(210,153,34,0.12); color: var(--yellow); }
     .model-chip.haiku { background: rgba(88,166,255,0.12); color: var(--blue); }
     .model-chip.sonnet { background: rgba(210,153,34,0.12); color: var(--yellow); }
     .model-chip.opus { background: rgba(248,81,73,0.12); color: var(--red); }
@@ -697,8 +698,8 @@
         const indEl = agentIndicators(a.name);
         return `<div class="agent-card ${cls}">
           <div class="agent-name"><span class="dot ${dotCls}"></span>${a.name} ${toggleBtn} <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a></div>
-          <div class="agent-field"><span class="label">cli</span><span class="value ${a.cli}">${a.cli}</span></div>
-          <div class="agent-field"><span class="label">model</span><span class="value">${a.model || ''} ${a.govBackend ? modelChip(a.govBackend, a.govModel, a.govReason) : ''}</span></div>
+          <div class="agent-field"><span class="label">cli</span><span class="value ${a.cli}">${a.cli}${a.govBackend ? backendChip(a.govBackend) : ''}</span></div>
+          <div class="agent-field"><span class="label">model</span><span class="value">${a.govModel ? modelChip(a.govModel, a.govReason) : (a.model || '?')}</span></div>
           <div class="agent-field"><span class="label">interval</span><span class="value">${isPaused ? 'paused' : a.cadence}</span></div>
           <div class="agent-field"><span class="label">next run</span><span class="value">${isPaused ? 'paused' : (a.nextKick || '—')}</span></div>
           ${agentTokenRow(a.name, a.cadence)}
@@ -849,7 +850,7 @@
         }).join('');
         const nameDot = isWorking ? '<span class="agent-dot"></span>' : '';
         const pauseBadge = agentPaused ? '<span class="pause-badge">paused</span>' : '';
-        const mChip = agentData && agentData.govBackend ? modelChip(agentData.govBackend, agentData.govModel, agentData.govReason) : '';
+        const mChip = agentData && agentData.govModel ? modelChip(agentData.govModel, agentData.govReason) : '';
         return `<tr><td>${nameDot}${aname}${pauseBadge}</td>${cells}<td>${mChip}</td></tr>`;
       }).join('');
       const headers = modes.map(m => {
@@ -933,19 +934,23 @@
       </div>`;
     }
 
-    function modelChip(backend, model, reason) {
+    function backendChip(backend) {
       if (!backend || backend === 'unknown') return '';
       const isFree = backend === 'copilot' || backend === 'goose';
+      const tier = isFree ? 'free' : 'paid';
+      return ` <span class="model-chip ${tier}" title="billing: ${backend}">${backend}</span>`;
+    }
+
+    function modelChip(model, reason) {
+      if (!model || model === '?' || model === 'unknown') return '';
+      const shortModel = model.replace(/^claude-/, '').replace(/-\d+-\d+$/, m => m.replace(/-/g, '.').slice(0, 4));
       let tier = 'sonnet';
-      if (isFree) tier = 'free';
-      else if (model && model.includes('haiku')) tier = 'haiku';
-      else if (model && model.includes('opus')) tier = 'opus';
-      const shortModel = model ? model.replace(/^claude-/, '').replace(/-\d+-\d+$/, m => m.replace(/-/g, '.').slice(0, 4)) : '?';
-      const label = isFree ? `${backend}` : shortModel;
+      if (model.includes('haiku')) tier = 'haiku';
+      else if (model.includes('opus')) tier = 'opus';
       const isBudgetOverride = reason && (reason.includes('budget_downgrade') || reason.includes('budget_critical'));
       const overrideIcon = isBudgetOverride ? ' ⬇' : '';
       const overrideTitle = isBudgetOverride ? ` (${reason})` : '';
-      return `<span class="model-chip ${tier}" title="${backend}:${model}${overrideTitle}">${label}${overrideIcon}</span>`;
+      return `<span class="model-chip ${tier}" title="${model}${overrideTitle}">${shortModel}${overrideIcon}</span>`;
     }
 
     function buildCadenceAdvisor(byAgent) {


### PR DESCRIPTION
## Summary
- CLI detection now uses `/proc` cmdline of tmux pane child processes instead of unreliable footer pattern matching
- Backend pill (copilot/claude/openrouter) moved from model row to CLI row
- Model name (opus-4-6, sonnet-4.6, haiku-4-5) shown as its own pill in model row
- Added `detect_cli_from_proc()` helper function to `hive.sh`

## Test plan
- [x] Deployed to dev server, verified CLI detection: copilot agents show `copilot`, claude agents show `claude`
- [x] Dashboard shows backend pill on CLI row, model pill on model row
- [x] Cadence matrix table updated to use new `modelChip()` signature