### PR TITLE
fix: session detection + remove CI-fixing from outreach

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -404,7 +404,7 @@ Use your agent name: ${agent_name}. This line appears on the hive dashboard."
 }
 
 SCANNER_BEADS="/home/dev/scanner-beads"
-SCANNER_MSG="$PULL_INSTRUCTIONS \
+SCANNER_MSG="[AGENT:scanner] $PULL_INSTRUCTIONS \
 $(beads_restore "$SCANNER_BEADS") \
 Then: Run a full scan pass per your policy (project_scanner_policy.md). \
 Oldest-first. Check all 5 repos: kubestellar/console, console-kb, docs, \
@@ -415,7 +415,7 @@ Merge AI-authored PRs with green CI. Send ntfy (curl -s -H 'Title: Scanner: <act
 Log to cron_scan_log.md. $(beads_sync "$SCANNER_BEADS" "scanner")"
 
 REVIEWER_BEADS="/home/dev/reviewer-beads"
-REVIEWER_MSG="$PULL_INSTRUCTIONS \
+REVIEWER_MSG="[AGENT:reviewer] $PULL_INSTRUCTIONS \
 $(beads_restore "$REVIEWER_BEADS") \
 Then: Run a full reviewer pass per /tmp/hive/examples/kubestellar/agents/reviewer-CLAUDE.md. \
 MANDATORY FIX ITEMS — do NOT just report these, you MUST open PRs to fix them: \
@@ -440,7 +440,7 @@ ALSO CHECK (not fix-mandatory): (B) OAuth code presence, \
 Print all GA4 tables to this pane. Send ntfy for all findings. Write all results to reviewer_log.md. $(beads_sync "$REVIEWER_BEADS" "reviewer")"
 
 ARCHITECT_BEADS="/home/dev/architect-beads"
-ARCHITECT_MSG="$PULL_INSTRUCTIONS \
+ARCHITECT_MSG="[AGENT:architect] $PULL_INSTRUCTIONS \
 $(beads_restore "$ARCHITECT_BEADS") \
 Then: Run an architect pass per /tmp/hive/examples/kubestellar/agents/architect-CLAUDE.md. \
 Pull main, scan the codebase for refactor or perf improvement opportunities. \
@@ -450,7 +450,7 @@ open an issue with label architect-idea and wait for operator approval. \
 Send ntfy for all plans and PRs. Print your plan to this pane. $(beads_sync "$ARCHITECT_BEADS" "architect")"
 
 OUTREACH_BEADS="/home/dev/outreach-beads"
-OUTREACH_MSG="$PULL_INSTRUCTIONS \
+OUTREACH_MSG="[AGENT:outreach] $PULL_INSTRUCTIONS \
 $(beads_restore "$OUTREACH_BEADS") \
 Then: Run an outreach pass per /tmp/hive/examples/kubestellar/agents/outreacher-CLAUDE.md. \
 LANE — outreach owns: awesome lists, directories, comparison sites, aggregators, \
@@ -465,18 +465,9 @@ highest engagement. Use this to (a) prioritise which Console capabilities to pit
 platform, (b) identify traffic gaps where new listings would have the most impact, and \
 (c) track whether previous outreach placements are driving referral traffic. \
 GA4 insight is for strategy only — do NOT fix GA4 errors (that is the reviewer's job). \
-CI HEALTH — after completing outreach work each pass, run /tmp/hive/dashboard/health-check.sh. \
-For EVERY red check (nightly, hourly, CI, Playwright nightly, weekly, deploys, code coverage), \
-pull the failed workflow logs, diagnose root cause, and open a fix PR. \
-Use git worktree add /tmp/kubestellar-console-outreach-cifix -b fix/outreach-ci-<workflow>. \
-Coverage: run npm run test:coverage in the worktree. If below 91%, write new tests targeting \
-the lowest-coverage files and open a PR. \
-Playwright: check nightly Playwright workflow — fix webkit/chromium/firefox failures via PR. \
-Build and lint before opening any fix PR. This is a secondary responsibility — do outreach \
-first, then fix CI if time permits before the next kick. \
 LANE BOUNDARIES (default, unless overridden by operator directive) — outreach must NEVER: \
-fix bugs (except CI/nightly/Playwright/coverage failures), review code, implement features, \
-or do anything the scanner/reviewer/architect agents do. \
+fix bugs, fix CI/nightly/Playwright/coverage failures, review code, implement features, \
+or do anything the scanner/reviewer/architect agents do. CI and test fixes are the reviewer's job. \
 If you find a bug or improvement idea, file a beads issue for the scanner — do not act on it yourself. \
 Fork under clubanderson account for all external PRs to third-party repos. \
 Send ntfy for every new listing secured. One outreach per project — never spam. $(beads_sync "$OUTREACH_BEADS" "outreach")"
@@ -553,7 +544,7 @@ apply_model_if_changed() {
 }
 
 _now_et=$(TZ=America/New_York date '+%Y-%m-%d %I:%M %p %Z')
-SUPERVISOR_MSG="MONITORING PASS — Pass started: ${_now_et}
+SUPERVISOR_MSG="[AGENT:supervisor] MONITORING PASS — Pass started: ${_now_et}
 
 HARD RULE — 12-HOUR CLOCK ONLY: Every timestamp you output MUST use 12-hour format with AM/PM. \
 Use: TZ=America/New_York date '+%Y-%m-%d %I:%M %p %Z' \

--- a/dashboard/agent-activity.py
+++ b/dashboard/agent-activity.py
@@ -45,13 +45,13 @@ SPINNER_RE = re.compile(r"^[◐◑◒◓◉●◎○✻✶✸✹✢✽·*⏺] |E
                         r"Scampering|Evaporating|Perambulating|Puttering|"
                         r"Sautéed|Razzle-dazzling|Pondering|Cogitating")
 
-AGENT_KEYWORDS = {
-    "scanner": ["scanner", "scanner-beads"],
-    "reviewer": ["reviewer", "reviewer-beads"],
-    "architect": ["architect", "architect-beads"],
-    "outreach": ["outreach", "outreach-beads"],
-    "supervisor": ["supervisor"],
-}
+AGENT_PATTERNS = [
+    ("supervisor", ["[agent:supervisor]", "supervisor-beads", "supervisor agent", "monitoring pass"]),
+    ("architect",  ["[agent:architect]", "architect-beads"]),
+    ("reviewer",   ["[agent:reviewer]", "reviewer-beads"]),
+    ("outreach",   ["[agent:outreach]", "outreach-beads"]),
+    ("scanner",    ["[agent:scanner]", "scanner-beads"]),
+]
 
 BASH_PATTERNS = [
     (re.compile(r"gh pr create"), "Creating pull request"),
@@ -115,10 +115,14 @@ AGENT_NAME_MAP = {
 KICK_PREFIX = "you are the kubestellar"
 
 
+MAX_AGENT_SCAN = 5
+
+
 def detect_agent(filepath, agent_map):
     if filepath in agent_map:
         return agent_map[filepath]
     try:
+        scan_count = 0
         with open(filepath) as f:
             for line in f:
                 try:
@@ -141,15 +145,15 @@ def detect_agent(filepath, agent_map):
                         )
                     if isinstance(raw, str):
                         rl = raw.lower()
-                        if not rl.startswith(KICK_PREFIX) and "executor mode" not in rl:
-                            agent_map[filepath] = ""
-                            return ""
-                        for aname, kws in AGENT_KEYWORDS.items():
-                            if any(kw in rl for kw in kws):
+                        for aname, patterns in AGENT_PATTERNS:
+                            if any(p in rl for p in patterns):
                                 agent_map[filepath] = aname
                                 return aname
-                    agent_map[filepath] = ""
-                    return ""
+                    scan_count += 1
+                    if scan_count >= MAX_AGENT_SCAN:
+                        break
+        agent_map[filepath] = ""
+        return ""
     except OSError:
         pass
     return ""

--- a/dashboard/token-collector.sh
+++ b/dashboard/token-collector.sh
@@ -58,13 +58,20 @@ weekly_by_agent = defaultdict(lambda: {"input": 0, "output": 0, "cacheRead": 0, 
 weekly_totals = {"input": 0, "output": 0, "cacheRead": 0, "sessions": 0}
 hourly_by_agent = defaultdict(lambda: {"input": 0, "output": 0, "cacheRead": 0, "sessions": 0})
 
-AGENT_KEYWORDS = {
-    "scanner": ["scanner", "scanner-beads"],
-    "reviewer": ["reviewer", "reviewer-beads"],
-    "architect": ["architect", "architect-beads"],
-    "outreach": ["outreach", "outreach-beads"],
-    "supervisor": ["supervisor"],
-}
+AGENT_PATTERNS = [
+    ("supervisor", ["[agent:supervisor]", "supervisor-beads", "supervisor agent", "monitoring pass"]),
+    ("architect",  ["[agent:architect]", "architect-beads"]),
+    ("reviewer",   ["[agent:reviewer]", "reviewer-beads"]),
+    ("outreach",   ["[agent:outreach]", "outreach-beads"]),
+    ("scanner",    ["[agent:scanner]", "scanner-beads"]),
+]
+
+def detect_agent_from_text(text):
+    tl = text.lower()
+    for aname, patterns in AGENT_PATTERNS:
+        if any(p in tl for p in patterns):
+            return aname
+    return "unknown"
 
 for proj_name in os.listdir(projects_dir):
     proj_dir = os.path.join(projects_dir, proj_name)
@@ -90,6 +97,8 @@ for proj_name in os.listdir(projects_dir):
         first_ts = ""
         last_ts = ""
         agent_detected = False
+        agent_scan_count = 0
+        MAX_AGENT_SCAN = 5
 
         try:
             with open(fpath) as f:
@@ -107,12 +116,13 @@ for proj_name in os.listdir(projects_dir):
                         if isinstance(raw, dict):
                             raw = raw.get("content", "")
                         if isinstance(raw, str):
-                            rl = raw.lower()
-                            for aname, kws in AGENT_KEYWORDS.items():
-                                if any(kw in rl for kw in kws):
-                                    agent = aname
-                                    break
-                        agent_detected = True
+                            detected = detect_agent_from_text(raw)
+                            if detected != "unknown":
+                                agent = detected
+                                agent_detected = True
+                        agent_scan_count += 1
+                        if agent_scan_count >= MAX_AGENT_SCAN:
+                            agent_detected = True
 
                     if d.get("type") == "assistant" and "message" in d:
                         msg = d["message"]


### PR DESCRIPTION
## Summary
- Add `[AGENT:name]` identity tags to all kick messages for reliable session detection
- Replace greedy keyword matching with ordered beads-first patterns — fixes sessions being mislabeled as "scanner"
- Scan first 5 user messages (not just first) to catch kick prompts injected after startup
- Remove CI/Playwright/coverage fixing from outreach lane — that's reviewer's job

## Test plan
- [ ] Verify dashboard Active Sessions shows correct agent labels for all 5 agents
- [ ] Verify outreach stops picking up CI fix work after next kick