### PR TITLE
fix: include pinned field in hive status JSON

### DIFF
--- a/bin/hive.sh
+++ b/bin/hive.sh
@@ -797,7 +797,7 @@ cmd_status_json() {
     restarts_24h=$(head -1 "/var/run/kick-governor/restarts_${s}" 2>/dev/null | tr -dc '0-9' || echo "0")
     [[ -z "$restarts_24h" ]] && restarts_24h=0
     [[ $i -gt 0 ]] && agents_json+=","
-    agents_json+="{\"name\":\"$label\",\"session\":\"$s\",\"state\":\"$state\",\"cli\":\"$cli\",\"model\":\"$model\",\"cadence\":\"$cadence\",\"busy\":\"$busy\",\"doing\":\"$doing\",\"nextKick\":\"$nk\",\"lastKick\":\"$lk_fmt\",\"needsLogin\":$needs_login,\"restarts\":$restarts_24h,\"govBackend\":\"$gov_backend\",\"govModel\":\"$gov_model\",\"govCostWeight\":$gov_cost,\"govReason\":\"$gov_reason\"}"
+    agents_json+="{\"name\":\"$label\",\"session\":\"$s\",\"state\":\"$state\",\"cli\":\"$cli\",\"pinned\":$pinned,\"model\":\"$model\",\"cadence\":\"$cadence\",\"busy\":\"$busy\",\"doing\":\"$doing\",\"nextKick\":\"$nk\",\"lastKick\":\"$lk_fmt\",\"needsLogin\":$needs_login,\"restarts\":$restarts_24h,\"govBackend\":\"$gov_backend\",\"govModel\":\"$gov_model\",\"govCostWeight\":$gov_cost,\"govReason\":\"$gov_reason\"}"
   done
   agents_json+="]"
 


### PR DESCRIPTION
## Summary
- `pinned` was computed from `AGENT_CLI_PINNED` in the env file but never emitted in the `hive status --json` output
- Dashboard frontend already had `cliChip(a.cli, a.pinned)` rendering a 📌 icon — it just never received the data
- One-line fix: add `"pinned":$pinned` to the JSON agent object

## Test plan
- [ ] `hive status --json | jq '.agents[0].pinned'` returns `true` for pinned agents
- [ ] Dashboard CLI chip shows 📌 next to pinned agents