### PR TITLE
feat: hive pin command + dashboard pin toggle

### DIFF
--- a/bin/hive.sh
+++ b/bin/hive.sh
@@ -131,6 +131,7 @@ ${BLD}COMMANDS${RST}
   logs    [governor|scanner|reviewer|architect|outreach|supervisor]
   stop    [all|agent]
   switch  <agent> <backend>            Switch agent to a different CLI backend (pins CLI)
+  pin     <agent>                      Pin current CLI -- governor will not change it
   unpin   <agent>                      Unpin CLI â let governor manage backend again
 
 ${BLD}BACKENDS${RST}  (set HIVE_BACKENDS in hive.conf)
@@ -966,6 +967,29 @@ cmd_stop() {
 
 # ── switch ───────────────────────────────────────────────────────────────────
 
+cmd_pin() {
+  local agent="${1:-}"
+  [[ -z "$agent" ]] && die "Usage: hive pin <agent>"
+  local envfile supervised_envfile
+  case "$agent" in
+    scanner)            envfile="issue-scanner"; supervised_envfile="scanner" ;;
+    reviewer)           envfile="reviewer";      supervised_envfile="reviewer" ;;
+    architect|feature)  envfile="architect";    supervised_envfile="architect" ;;
+    outreach)           envfile="outreach";      supervised_envfile="outreach" ;;
+    *) die "Unknown agent: $agent" ;;
+  esac
+  for envpath in "$ENV_DIR/${envfile}.env" "/etc/supervised-agent/${supervised_envfile}.env"; do
+    if [[ -f "$envpath" ]]; then
+      if grep -q "^AGENT_CLI_PINNED=" "$envpath" 2>/dev/null; then
+        sudo sed -i "s|^AGENT_CLI_PINNED=.*|AGENT_CLI_PINNED=true|" "$envpath"
+      else
+        echo "AGENT_CLI_PINNED=true" | sudo tee -a "$envpath" >/dev/null
+      fi
+    fi
+  done
+  ok "Pinned $agent to current CLI -- governor will not change it"
+}
+
 cmd_unpin() {
   local agent="${1:-}"
   [[ -z "$agent" ]] && die "Usage: hive unpin <agent>"
@@ -1194,6 +1218,7 @@ main() {
     kick)     shift; cmd_kick    "${1:-all}" ;;
     logs)     shift; cmd_logs    "${1:-governor}" ;;
     stop)     shift; cmd_stop    "${1:-all}" ;;
+    pin)      shift; cmd_pin     "$@" ;;
     unpin)    shift; cmd_unpin   "$@" ;;
     switch)   shift; cmd_switch  "$@" ;;
     model)    shift; cmd_model   "$@" ;;

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -361,6 +361,8 @@
     .budget-bar-fill.danger { background: var(--red); }
 
     /* Model chip on agent cards */
+    .pin-toggle { cursor: pointer; background: none; border: none; font-size: 0.7rem; padding: 0 2px; opacity: 0.6; transition: opacity 0.2s; }
+    .pin-toggle:hover { opacity: 1; }
     .model-chip { display: inline-flex; align-items: center; gap: 4px; font-size: 0.65rem; padding: 2px 6px; border-radius: 4px; }
     .model-chip.free { background: rgba(63,185,80,0.12); color: var(--green); }
     .model-chip.paid { background: rgba(210,153,34,0.12); color: var(--yellow); }
@@ -699,7 +701,7 @@
         const indEl = agentIndicators(a.name);
         return `<div class="agent-card ${cls}">
           <div class="agent-name"><span class="dot ${dotCls}"></span>${a.name} ${toggleBtn} <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a></div>
-          <div class="agent-field"><span class="label">cli</span><span class="value">${cliChip(a.cli, a.pinned)}</span></div>
+          <div class="agent-field"><span class="label">cli</span><span class="value">${cliChip(a.cli, a.pinned)} ${a.name !== 'supervisor' ? `<button class="pin-toggle" onclick="togglePin('${a.name}', ${!!a.pinned})" title="${a.pinned ? 'Unpin — let governor manage CLI' : 'Pin — lock current CLI'}">${a.pinned ? '🔓' : '📌'}</button>` : ''}</span></div>
           <div class="agent-field"><span class="label">model</span><span class="value">${modelChip(a.model, a.govReason)}</span></div>
           <div class="agent-field"><span class="label">interval</span><span class="value">${isPaused ? 'paused' : a.cadence}</span></div>
           <div class="agent-field"><span class="label">last run</span><span class="value">${a.lastKick || '—'}</span></div>
@@ -1346,6 +1348,13 @@ function intensityGauge() {
       const res = await fetch(`/api/model/${agent}/${encodeURIComponent(model)}`, { method: 'POST' });
       const data = await res.json();
       if (!data.ok) alert('Model switch failed: ' + (data.error || 'unknown'));
+    }
+
+    async function togglePin(agent, currentlyPinned) {
+      const action = currentlyPinned ? 'unpin' : 'pin';
+      const res = await fetch(`/api/${action}/${agent}`, { method: 'POST' });
+      const data = await res.json();
+      if (!data.ok) alert(`${action} failed: ` + (data.error || 'unknown'));
     }
 
     // Git version indicator

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -549,6 +549,31 @@ app.post('/api/resume/:agent', (req, res) => {
   });
 });
 
+// Pin / Unpin agent CLI — prevents governor from changing the CLI backend
+app.post('/api/pin/:agent', (req, res) => {
+  const agent = req.params.agent;
+  const allowed = ['scanner', 'reviewer', 'architect', 'outreach'];
+  if (!allowed.includes(agent)) {
+    return res.status(400).json({ error: `cannot pin ${agent}` });
+  }
+  execFile('/usr/local/bin/hive', ['pin', agent], { timeout: 10000 }, (err, stdout) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ ok: true, output: stdout.trim() });
+  });
+});
+
+app.post('/api/unpin/:agent', (req, res) => {
+  const agent = req.params.agent;
+  const allowed = ['scanner', 'reviewer', 'architect', 'outreach'];
+  if (!allowed.includes(agent)) {
+    return res.status(400).json({ error: `cannot unpin ${agent}` });
+  }
+  execFile('/usr/local/bin/hive', ['unpin', agent], { timeout: 10000 }, (err, stdout) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ ok: true, output: stdout.trim() });
+  });
+});
+
 // Token usage
 app.get('/api/tokens', (_req, res) => {
   res.json(tokenCache || { error: 'no data yet' });


### PR DESCRIPTION
## Summary
- Adds `hive pin <agent>` command that pins the current CLI without restarting
- Adds `/api/pin/:agent` and `/api/unpin/:agent` REST endpoints
- Adds pin toggle button (📌 to pin, 🔓 to unpin) on the CLI row in dashboard agent cards
- Supervisor is excluded from pinning (governor doesn't manage it)

Previously the only way to pin was `hive switch` which also restarts the agent. Now you can pin/unpin from the dashboard with one click.

## Test plan
- [ ] `hive pin scanner` sets AGENT_CLI_PINNED=true in both env files
- [ ] `hive unpin scanner` removes AGENT_CLI_PINNED from both env files
- [ ] Dashboard shows 📌 button next to CLI chip — click to pin
- [ ] Pinned agents show 🔓 button — click to unpin
- [ ] Pin icon (📌) appears on the CLI chip when pinned