### PR TITLE
refactor: standardize agent naming across codebase

### DIFF
--- a/bin/gh-rate-check.sh
+++ b/bin/gh-rate-check.sh
@@ -10,13 +10,13 @@
 set -euo pipefail
 
 METRICS_FILE="/var/run/hive-metrics/gh_rate_limits.json"
-NTFY_TOPIC="${NTFY_TOPIC:-ntfy.sh/issue-scanner}"
+NTFY_TOPIC="${NTFY_TOPIC:-ntfy.sh/hive}"
 TMUX_BIN="${TMUX_BIN:-tmux}"
 TTL_SECONDS=3600  # 1 hour — alerts older than this are pruned
 
 # Agent name -> tmux session name
 declare -A AGENT_SESSIONS=(
-  [scanner]=issue-scanner
+  [scanner]=scanner
   [reviewer]=reviewer
   [architect]=architect
   [outreach]=outreach

--- a/bin/hive.sh
+++ b/bin/hive.sh
@@ -102,7 +102,7 @@ load_conf() {
   BEADS_SUPERVISOR_DIR="${BEADS_SUPERVISOR_DIR:-/home/dev/supervisor-beads}"
   BEADS_SCANNER_DIR="${BEADS_SCANNER_DIR:-/home/dev/scanner-beads}"
   BEADS_REVIEWER_DIR="${BEADS_REVIEWER_DIR:-/home/dev/reviewer-beads}"
-  BEADS_FEATURE_DIR="${BEADS_FEATURE_DIR:-/home/dev/feature-beads}"
+  BEADS_ARCHITECT_DIR="${BEADS_ARCHITECT_DIR:-${BEADS_FEATURE_DIR:-/home/dev/architect-beads}}"
   BEADS_OUTREACH_DIR="${BEADS_OUTREACH_DIR:-/home/dev/outreach-beads}"
   BEADS_WORKER_DIR="${BEADS_WORKER_DIR:-/home/dev/scanner-beads}"
   AGENT_USER="${AGENT_USER:-dev}"
@@ -111,6 +111,19 @@ load_conf() {
   HIVE_TZ="${HIVE_TZ:-UTC}"                           # local timezone for status display
   HIVE_AUTO_INSTALL="${HIVE_AUTO_INSTALL:-true}"      # auto-install missing backends/services
 }
+
+# ── Canonical agent names ─────────────────────────────────────────────────────
+# Each agent has ONE canonical name used everywhere: config files, tmux sessions,
+# systemd services, governor state, beads dirs, and CLI commands.
+#
+#   AGENT       SESSION    SYSTEMD SERVICE              ENV FILE (both dirs)
+#   scanner     scanner    supervised-agent@scanner      scanner.env
+#   reviewer    reviewer   supervised-agent@reviewer     reviewer.env
+#   architect   architect  supervised-agent@architect    architect.env
+#   outreach    outreach   supervised-agent@outreach     outreach.env
+#   supervisor  supervisor supervised-agent@supervisor   supervisor.env
+#
+# Legacy aliases accepted by CLI: issue-scanner → scanner, feature → architect
 
 
 usage() {
@@ -444,16 +457,16 @@ kick_agents() {
 
   # Per-agent beads dirs — each agent reads and writes only its own ledger.
   declare -A AGENT_BEADS_DIR
-  AGENT_BEADS_DIR["issue-scanner"]="${BEADS_SCANNER_DIR:-/home/${AGENT_USER:-dev}/scanner-beads}"
+  AGENT_BEADS_DIR["scanner"]="${BEADS_SCANNER_DIR:-/home/${AGENT_USER:-dev}/scanner-beads}"
   AGENT_BEADS_DIR["reviewer"]="${BEADS_REVIEWER_DIR:-/home/${AGENT_USER:-dev}/reviewer-beads}"
-  AGENT_BEADS_DIR["architect"]="${BEADS_FEATURE_DIR:-/home/${AGENT_USER:-dev}/feature-beads}"
+  AGENT_BEADS_DIR["architect"]="${BEADS_ARCHITECT_DIR:-/home/${AGENT_USER:-dev}/architect-beads}"
   AGENT_BEADS_DIR["outreach"]="${BEADS_OUTREACH_DIR:-/home/${AGENT_USER:-dev}/outreach-beads}"
 
   # Expected model substring — must be visible in pane before kick is safe to send.
   # Copilot shows "claude-opus-4.6" in bottom-right; Claude Code shows "Opus 4.6".
   local expected_model="4.6"
 
-  for session in issue-scanner reviewer architect outreach; do
+  for session in scanner reviewer architect outreach; do
     if ! tmux has-session -t "$session" 2>/dev/null; then
       warn "$session session not ready yet — governor will kick on next cycle"
       continue
@@ -549,9 +562,9 @@ cmd_status() {
   echo -e "\n${BLD}🐝 hive status — $(TZ="${HIVE_TZ:-UTC}" date '+%-I:%M %p %Z')${RST}\n"
 
   # Sessions
-  local SESSIONS=(supervisor issue-scanner reviewer architect outreach)
+  local SESSIONS=(supervisor scanner reviewer architect outreach)
   local LABELS=("supervisor" "scanner" "reviewer" "architect" "outreach")
-  local ENV_FILES=("supervisor" "issue-scanner" "reviewer" "architect" "outreach")
+  local ENV_FILES=("supervisor" "scanner" "reviewer" "architect" "outreach")
   local GOV_STATE="/var/run/kick-governor"
   printf "  %-12s  %-8s  %-8s  %-8s  %-8s  %s\n" "AGENT" "STATE" "CLI" "CADENCE" "KICK" "BUSY"
   printf "  %-12s  %-8s  %-8s  %-8s  %-8s  %s\n" "-----" "-----" "---" "-------" "----" "----"
@@ -697,9 +710,9 @@ cmd_status() {
 # ── status JSON ──────────────────────────────────────────────────────────────
 
 cmd_status_json() {
-  local SESSIONS=(supervisor issue-scanner reviewer architect outreach)
+  local SESSIONS=(supervisor scanner reviewer architect outreach)
   local LABELS=("supervisor" "scanner" "reviewer" "architect" "outreach")
-  local ENV_FILES=("supervisor" "issue-scanner" "reviewer" "architect" "outreach")
+  local ENV_FILES=("supervisor" "scanner" "reviewer" "architect" "outreach")
   local GOV_STATE="/var/run/kick-governor"
   local STATUS_CACHE="/var/run/kick-governor/repo_cache"
   mkdir -p "$STATUS_CACHE" 2>/dev/null || true
@@ -909,7 +922,7 @@ cmd_attach() {
   local name="${1:-supervisor}"
   # map friendly names to session names
   case "$name" in
-    scanner|issue-scanner) name="issue-scanner" ;;
+    scanner|issue-scanner) name="scanner" ;;
     architect|feature)     name="architect" ;;
     supervisor|reviewer|outreach) ;;
     *) die "Unknown agent: $name. Use: supervisor scanner reviewer architect outreach" ;;
@@ -970,15 +983,15 @@ cmd_stop() {
 cmd_pin() {
   local agent="${1:-}"
   [[ -z "$agent" ]] && die "Usage: hive pin <agent>"
-  local envfile supervised_envfile
+  local envfile
   case "$agent" in
-    scanner)            envfile="issue-scanner"; supervised_envfile="scanner" ;;
-    reviewer)           envfile="reviewer";      supervised_envfile="reviewer" ;;
-    architect|feature)  envfile="architect";    supervised_envfile="architect" ;;
-    outreach)           envfile="outreach";      supervised_envfile="outreach" ;;
+    scanner)            envfile="scanner" ;;
+    reviewer)           envfile="reviewer" ;;
+    architect|feature)  envfile="architect" ;;
+    outreach)           envfile="outreach" ;;
     *) die "Unknown agent: $agent" ;;
   esac
-  for envpath in "$ENV_DIR/${envfile}.env" "/etc/supervised-agent/${supervised_envfile}.env"; do
+  for envpath in "$ENV_DIR/${envfile}.env" "/etc/supervised-agent/${envfile}.env"; do
     if [[ -f "$envpath" ]]; then
       if grep -q "^AGENT_CLI_PINNED=" "$envpath" 2>/dev/null; then
         sudo sed -i "s|^AGENT_CLI_PINNED=.*|AGENT_CLI_PINNED=true|" "$envpath"
@@ -993,15 +1006,15 @@ cmd_pin() {
 cmd_unpin() {
   local agent="${1:-}"
   [[ -z "$agent" ]] && die "Usage: hive unpin <agent>"
-  local envfile supervised_envfile
+  local envfile
   case "$agent" in
-    scanner)            envfile="issue-scanner"; supervised_envfile="scanner" ;;
-    reviewer)           envfile="reviewer";      supervised_envfile="reviewer" ;;
-    architect|feature)  envfile="architect";    supervised_envfile="architect" ;;
-    outreach)           envfile="outreach";      supervised_envfile="outreach" ;;
+    scanner)            envfile="scanner" ;;
+    reviewer)           envfile="reviewer" ;;
+    architect|feature)  envfile="architect" ;;
+    outreach)           envfile="outreach" ;;
     *) die "Unknown agent: $agent" ;;
   esac
-  for envpath in "$ENV_DIR/${envfile}.env" "/etc/supervised-agent/${supervised_envfile}.env"; do
+  for envpath in "$ENV_DIR/${envfile}.env" "/etc/supervised-agent/${envfile}.env"; do
     if [[ -f "$envpath" ]]; then
       sudo sed -i "/^AGENT_CLI_PINNED=/d" "$envpath"
     fi
@@ -1015,13 +1028,13 @@ cmd_switch() {
 
   # Map agent name → session, env files, and systemd service.
   # Two env dirs: /etc/hive (kick-agents) and /etc/supervised-agent (systemd supervisor.sh).
-  local session envfile supervised_envfile service
+  local session service
   case "$agent" in
-    scanner)            session="issue-scanner"; envfile="issue-scanner"; supervised_envfile="scanner"; service="supervised-agent@scanner" ;;
-    reviewer)           session="reviewer";      envfile="reviewer";      supervised_envfile="reviewer"; service="supervised-agent@reviewer" ;;
-    architect|feature)  session="architect";    envfile="architect";    supervised_envfile="architect"; service="supervised-agent@architect" ;;
-    outreach)           session="outreach";      envfile="outreach";      supervised_envfile="outreach"; service="supervised-agent@outreach" ;;
-    supervisor)         session="supervisor";    envfile="supervisor";    supervised_envfile="supervisor"; service="supervised-agent@supervisor" ;;
+    scanner)            session="scanner";    service="supervised-agent@scanner" ;;
+    reviewer)           session="reviewer";   service="supervised-agent@reviewer" ;;
+    architect|feature)  session="architect";  service="supervised-agent@architect" ;;
+    outreach)           session="outreach";   service="supervised-agent@outreach" ;;
+    supervisor)         session="supervisor"; service="supervised-agent@supervisor" ;;
     *) die "Unknown agent: $agent (valid: scanner reviewer architect outreach supervisor)" ;;
   esac
 
@@ -1038,8 +1051,8 @@ cmd_switch() {
   info "Switching $agent → $backend"
 
   # Update both env files: /etc/hive (kick-agents) and /etc/supervised-agent (supervisor.sh)
-  local ef="$ENV_DIR/${envfile}.env"
-  local sef="/etc/supervised-agent/${supervised_envfile}.env"
+  local ef="$ENV_DIR/${session}.env"
+  local sef="/etc/supervised-agent/${session}.env"
 
   for envpath in "$ef" "$sef"; do
     if [[ -f "$envpath" ]]; then
@@ -1092,21 +1105,21 @@ cmd_model() {
 
   # Map agent name → session, env files, and systemd service.
   # Two env dirs: /etc/hive (kick-agents) and /etc/supervised-agent (systemd supervisor.sh).
-  local session envfile supervised_envfile service
+  local session service
   case "$agent" in
-    scanner)            session="issue-scanner"; envfile="issue-scanner"; supervised_envfile="scanner"; service="supervised-agent@scanner" ;;
-    reviewer)           session="reviewer";      envfile="reviewer";      supervised_envfile="reviewer"; service="supervised-agent@reviewer" ;;
-    architect|feature)  session="architect";    envfile="architect";    supervised_envfile="architect"; service="supervised-agent@architect" ;;
-    outreach)           session="outreach";      envfile="outreach";      supervised_envfile="outreach"; service="supervised-agent@outreach" ;;
-    supervisor)         session="supervisor";    envfile="supervisor";    supervised_envfile="supervisor"; service="supervised-agent@supervisor" ;;
+    scanner)            session="scanner";    service="supervised-agent@scanner" ;;
+    reviewer)           session="reviewer";   service="supervised-agent@reviewer" ;;
+    architect|feature)  session="architect";  service="supervised-agent@architect" ;;
+    outreach)           session="outreach";   service="supervised-agent@outreach" ;;
+    supervisor)         session="supervisor"; service="supervised-agent@supervisor" ;;
     *) die "Unknown agent: $agent (valid: scanner reviewer architect outreach supervisor)" ;;
   esac
 
   info "Restarting $agent with model $model"
 
   # Update both env files: /etc/hive (kick-agents) and /etc/supervised-agent (supervisor.sh)
-  local ef="$ENV_DIR/${envfile}.env"
-  local sef="/etc/supervised-agent/${supervised_envfile}.env"
+  local ef="$ENV_DIR/${session}.env"
+  local sef="/etc/supervised-agent/${session}.env"
 
   for envpath in "$ef" "$sef"; do
     if [[ -f "$envpath" ]]; then

--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -20,7 +20,7 @@ TMUX_BIN="${TMUX_BIN:-tmux}"
 LOG="/var/log/kick-agents.log"
 TIMESTAMP="$(TZ=America/New_York date '+%Y-%m-%d %I:%M:%S %p %Z')"
 ET_NOW="$(TZ=America/New_York date '+%I:%M %p ET')"
-NTFY_TOPIC="${NTFY_TOPIC:-ntfy.sh/issue-scanner}"
+NTFY_TOPIC="${NTFY_TOPIC:-ntfy.sh/hive}"
 NTFY_SERVER="${NTFY_SERVER:-https://ntfy.sh}"
 SLACK_WEBHOOK="${SLACK_WEBHOOK:-}"
 DISCORD_WEBHOOK="${DISCORD_WEBHOOK:-}"
@@ -411,7 +411,7 @@ Oldest-first. Check all 5 repos: kubestellar/console, console-kb, docs, \
 console-marketplace, kubestellar-mcp. \
 For EVERY open issue that does not already have an active PR, dispatch a background fix agent using the Agent tool with worktrees. \
 Do NOT just count issues and stop — your job is to FIX them, not report them. \
-Merge AI-authored PRs with green CI. Send ntfy (curl -s -H 'Title: Scanner: <action>' -d '<details>' ntfy.sh/issue-scanner) for every merge and external PR review. \
+Merge AI-authored PRs with green CI. Send ntfy (curl -s -H 'Title: Scanner: <action>' -d '<details>' ntfy.sh/hive) for every merge and external PR review. \
 Log to cron_scan_log.md. $(beads_sync "$SCANNER_BEADS" "scanner")"
 
 REVIEWER_BEADS="/home/dev/reviewer-beads"
@@ -490,7 +490,7 @@ apply_model_if_changed() {
   # Respect manual CLI pin -- operator used hive switch or dashboard dropdown
   local pin_file
   case "$agent" in
-    scanner) pin_file="/etc/hive/issue-scanner.env" ;;
+    scanner) pin_file="/etc/hive/scanner.env" ;;
     *) pin_file="/etc/hive/${agent}.env" ;;
   esac
   if grep -q "^AGENT_CLI_PINNED=true" "$pin_file" 2>/dev/null; then
@@ -559,7 +559,7 @@ If you see yourself writing a number >12 for the hour, STOP and fix it. No excep
 Do all of the following right now:
 1. Record pass start time at the TOP of your monitoring summary: \"Pass started: ${_now_et}\"
 2. Check every agent session for questions, stalls, or errors: \
-   tmux capture-pane -t issue-scanner -p | tail -20 \
+   tmux capture-pane -t scanner -p | tail -20 \
    tmux capture-pane -t reviewer -p | tail -20 \
    tmux capture-pane -t architect -p | tail -20 \
    tmux capture-pane -t outreach -p | tail -20 \
@@ -571,7 +571,7 @@ Do all of the following right now:
 
 case "$TARGET" in
   scanner)
-    apply_model_if_changed "scanner" "issue-scanner" && kick "issue-scanner" "$SCANNER_MSG" "scanner"
+    apply_model_if_changed "scanner" "scanner" && kick "scanner" "$SCANNER_MSG" "scanner"
     ;;
   reviewer)
     apply_model_if_changed "reviewer" "reviewer" && kick "reviewer" "$REVIEWER_MSG" "reviewer"
@@ -586,7 +586,7 @@ case "$TARGET" in
     apply_model_if_changed "supervisor" "supervisor" && kick "supervisor" "$SUPERVISOR_MSG" "supervisor"
     ;;
   all)
-    apply_model_if_changed "scanner" "issue-scanner" && kick "issue-scanner" "$SCANNER_MSG" "scanner"
+    apply_model_if_changed "scanner" "scanner" && kick "scanner" "$SCANNER_MSG" "scanner"
     apply_model_if_changed "reviewer" "reviewer" && kick "reviewer" "$REVIEWER_MSG" "reviewer"
     apply_model_if_changed "architect" "architect" && kick "architect" "$ARCHITECT_MSG" "architect"
     apply_model_if_changed "outreach" "outreach" && kick "outreach" "$OUTREACH_MSG" "outreach"

--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -38,13 +38,13 @@
 set -euo pipefail
 
 # ── Repos to scan ───────────────────────────────────────────────────────────
-REPOS=(
-  kubestellar/console
-  kubestellar/console-kb
-  kubestellar/docs
-  kubestellar/console-marketplace
-  kubestellar/kubestellar-mcp
-)
+# Read from governor.env (written by hive.sh from HIVE_REPOS in hive.conf).
+# Falls back to HIVE_REPOS env var if governor.env doesn't set it.
+if [[ -f /etc/hive/governor.env ]]; then
+  # shellcheck disable=SC1091
+  . /etc/hive/governor.env
+fi
+IFS=' ' read -ra REPOS <<< "${HIVE_REPOS:-kubestellar/console kubestellar/console-kb kubestellar/docs kubestellar/console-marketplace kubestellar/kubestellar-mcp}"
 
 # ── Exempt-label filter ─────────────────────────────────────────────────────
 # Issues matching any of these labels are NOT counted toward the actionable queue.

--- a/dashboard/agent-activity.py
+++ b/dashboard/agent-activity.py
@@ -19,7 +19,7 @@ STALE_SECONDS = 300
 
 AGENT_TMUX_SESSION = {
     "supervisor": "supervisor",
-    "scanner": "issue-scanner",
+    "scanner": "scanner",
     "reviewer": "reviewer",
     "architect": "architect",
     "outreach": "outreach",

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -480,7 +480,7 @@
       const m = currentAgentMetrics[name];
       if (!m) return '';
 
-      if (name === 'issue-scanner' || name === 'scanner') {
+      if (name === 'scanner') {
         const pairs = m.pairs || [];
         if (pairs.length === 0) return '<div class="agent-indicators"><span class="ind-empty">no active fixes</span></div>';
         const openPairs = pairs.filter(p => p.state !== 'merged');
@@ -632,7 +632,7 @@
 
     const AGENT_TMUX_SESSION = {
       supervisor: 'supervisor',
-      scanner: 'issue-scanner',
+      scanner: 'scanner',
       reviewer: 'reviewer',
       architect: 'feature',
       outreach: 'outreach',

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -502,7 +502,7 @@
       const m = currentAgentMetrics[name];
       if (!m) return '';
 
-      if (name === 'issue-scanner' || name === 'scanner') {
+      if (name === 'scanner') {
         const pairs = m.pairs || [];
         if (pairs.length === 0) return '<div class="agent-indicators"><span class="ind-empty">no active fixes</span></div>';
         const openPairs = pairs.filter(p => p.state !== 'merged');
@@ -654,7 +654,7 @@
 
     const AGENT_TMUX_SESSION = {
       supervisor: 'supervisor',
-      scanner: 'issue-scanner',
+      scanner: 'scanner',
       reviewer: 'reviewer',
       architect: 'architect',
       outreach: 'outreach',

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -446,7 +446,7 @@ app.get('/api/widget', (_req, res) => {
 
 // Map dashboard agent names to tmux session names
 const TMUX_SESSION = {
-  scanner: 'issue-scanner',
+  scanner: 'scanner',
   reviewer: 'reviewer',
   architect: 'feature',
   outreach: 'outreach',

--- a/examples/kubestellar/agents/architect-CLAUDE.md
+++ b/examples/kubestellar/agents/architect-CLAUDE.md
@@ -138,10 +138,10 @@ EOF
 
 ## ntfy Notifications
 
-Send a push notification for every significant action. Topic: `ntfy.sh/issue-scanner`
+Send a push notification for every significant action. Topic: `ntfy.sh/hive`
 
 ```bash
-curl -s -H "Title: Architect: <action>" -d "<details>" ntfy.sh/issue-scanner > /dev/null 2>&1
+curl -s -H "Title: Architect: <action>" -d "<details>" ntfy.sh/hive > /dev/null 2>&1
 ```
 
 **When to send:**

--- a/examples/kubestellar/agents/feature.env
+++ b/examples/kubestellar/agents/feature.env
@@ -1,2 +1,0 @@
-AGENT_CLI=copilot
-AGENT_LAUNCH_CMD="/usr/bin/copilot --allow-all --model claude-opus-4.6"

--- a/examples/kubestellar/agents/issue-scanner.env
+++ b/examples/kubestellar/agents/issue-scanner.env
@@ -1,3 +1,0 @@
-AGENT_CLI=copilot
-AGENT_LAUNCH_CMD="/usr/bin/copilot --allow-all --model claude-opus-4.6"
-AGENT_CLI_PINNED=true

--- a/examples/kubestellar/agents/outreach-CLAUDE.md
+++ b/examples/kubestellar/agents/outreach-CLAUDE.md
@@ -71,10 +71,10 @@ Goal: Maximize KubeStellar Console's presence across every discoverable surface 
 
 ## ntfy Notifications
 
-Send a push notification for every outreach action. Topic: `ntfy.sh/issue-scanner`
+Send a push notification for every outreach action. Topic: `ntfy.sh/hive`
 
 ```bash
-curl -s -H "Title: Outreach: <action>" -d "<details>" ntfy.sh/issue-scanner > /dev/null 2>&1
+curl -s -H "Title: Outreach: <action>" -d "<details>" ntfy.sh/hive > /dev/null 2>&1
 ```
 
 **When to send:**
@@ -231,7 +231,7 @@ After opening PRs on external repos, you MUST monitor them for review comments a
    - Make the requested changes in a new commit on the same branch
    - Push the update
    - Reply to the review comment acknowledging the fix
-5. Send ntfy for every PR update: `curl -s -H "Title: Outreach: PR updated" -d "<repo>#<N>: addressed <reviewer> feedback" ntfy.sh/issue-scanner`
+5. Send ntfy for every PR update: `curl -s -H "Title: Outreach: PR updated" -d "<repo>#<N>: addressed <reviewer> feedback" ntfy.sh/hive`
 
 **Do NOT ignore review comments.** Unresponsive PRs get closed. Address feedback within the same pass you discover it.
 

--- a/examples/kubestellar/agents/outreach.env
+++ b/examples/kubestellar/agents/outreach.env
@@ -25,7 +25,7 @@ AGENT_NOTIFY_ON_PHRASE_BODY="Outreach session at hive hit a quota. /login anothe
 AGENT_STALE_MAX_SEC=7200
 AGENT_MAX_RESPAWNS=3
 
-NTFY_TOPIC=issue-scanner
+NTFY_TOPIC=hive
 
 AGENT_TMUX_STATUS_STYLE="fg=colour255,bg=colour208"
 AGENT_TMUX_PANE_BORDER_STYLE="fg=colour208"

--- a/examples/kubestellar/agents/reviewer-CLAUDE.md
+++ b/examples/kubestellar/agents/reviewer-CLAUDE.md
@@ -155,7 +155,7 @@ unset GITHUB_TOKEN && gh release list --repo kubestellar/console --limit 5 \
   --json tagName,publishedAt,isDraft --jq '[.[] | select(.isDraft==false)] | .[0]'
 ```
 
-If formula version ≠ latest release tag → file a P2 bead + ntfy (topic: `ntfy.sh/issue-scanner`, priority: default).
+If formula version ≠ latest release tag → file a P2 bead + ntfy (topic: `ntfy.sh/hive`, priority: default).
 
 ## Health Check Monitoring — every pass — FIX MANDATORY
 
@@ -261,14 +261,14 @@ RESULTS=✓ GA4 clean (0 new errors), ✗ Coverage 88% (below 91% target)
 
 ## ntfy Notifications
 
-Send a push notification for every significant action. Topic: `ntfy.sh/issue-scanner`
+Send a push notification for every significant action. Topic: `ntfy.sh/hive`
 
 ```bash
 # Simple notification
-curl -s -H "Title: Reviewer: <action>" -d "<details>" ntfy.sh/issue-scanner > /dev/null 2>&1
+curl -s -H "Title: Reviewer: <action>" -d "<details>" ntfy.sh/hive > /dev/null 2>&1
 
 # High priority (failed builds, coverage drops, GA4 anomalies)
-curl -s -H "Title: Reviewer: <action>" -H "Priority: high" -d "<details>" ntfy.sh/issue-scanner > /dev/null 2>&1
+curl -s -H "Title: Reviewer: <action>" -H "Priority: high" -d "<details>" ntfy.sh/hive > /dev/null 2>&1
 ```
 
 **When to send:**

--- a/examples/kubestellar/agents/reviewer.env
+++ b/examples/kubestellar/agents/reviewer.env
@@ -32,7 +32,7 @@ AGENT_NOTIFY_ON_PHRASE_BODY="Reviewer session at hive hit a quota. /login anothe
 AGENT_STALE_MAX_SEC=2400
 AGENT_MAX_RESPAWNS=3
 
-NTFY_TOPIC=issue-scanner
+NTFY_TOPIC=hive
 
 # Display persistence across respawns
 AGENT_TMUX_STATUS_STYLE="bg=colour22,fg=white"

--- a/examples/kubestellar/agents/scanner-CLAUDE.md
+++ b/examples/kubestellar/agents/scanner-CLAUDE.md
@@ -1,5 +1,5 @@
 ---
-The scanner runs on claude-dev (192.168.4.56) in the `issue-scanner` tmux session. The supervisor (dispatcher on the Mac) sends work orders directly. No cron, no self-scheduling. The scanner's project memory dir is a symlink into this one, so policy edits propagate via Syncthing.
+The scanner runs on claude-dev (192.168.4.56) in the `scanner` tmux session. The supervisor (dispatcher on the Mac) sends work orders directly. No cron, no self-scheduling. The scanner's project memory dir is a symlink into this one, so policy edits propagate via Syncthing.
 
 ## EXECUTOR MODE (DEFAULT — 2026-04-19, supervisor-driven)
 

--- a/examples/kubestellar/agents/scanner.env
+++ b/examples/kubestellar/agents/scanner.env
@@ -2,7 +2,7 @@
 # Uses unified supervisor.sh with rate-limit failover enabled.
 
 AGENT_USER=dev
-AGENT_SESSION_NAME=issue-scanner
+AGENT_SESSION_NAME=scanner
 AGENT_WORKDIR=/home/dev/kubestellar-console
 AGENT_LAUNCH_CMD="/usr/bin/copilot --allow-all --model claude-opus-4-6"
 AGENT_CLI=copilot
@@ -11,7 +11,7 @@ AGENT_LOOP_PROMPT="You are the KubeStellar Scanner in EXECUTOR MODE — no self-
 
 AGENT_STALE_MAX_SEC=1800
 AGENT_MAX_RESPAWNS=3
-NTFY_TOPIC=issue-scanner
+NTFY_TOPIC=hive
 
 AGENT_POLL_SEC=10
 AGENT_AUTO_APPROVE_PHRASE="Yes, and always allow access to"

--- a/examples/kubestellar/agents/supervisor-CLAUDE.md
+++ b/examples/kubestellar/agents/supervisor-CLAUDE.md
@@ -46,7 +46,7 @@ You (Opus 4.6, supervisor tmux session — EXECUTOR MODE, operator-driven)
   ├── triage + root-cause + plan fixes
   ├── dispatch work orders to executors via tmux send-keys
   │
-  ├─► issue-scanner (Opus 4.6)  — inbound GitHub triage, fix dispatch, PR merge
+  ├─► scanner (Opus 4.6)  — inbound GitHub triage, fix dispatch, PR merge
   ├─► architect    (Opus 4.6)  — multi-file refactor planning, architecture review
   ├─► reviewer     (Sonnet 4.6) — post-merge review, CI health, coverage, CodeQL
   ├─► outreach     (Sonnet 4.6) — ADOPTERS PRs, ecosystem integration
@@ -126,7 +126,7 @@ hive stop [all|agent]                # Stop agent
 | Session | Model |
 |---------|-------|
 | `supervisor` | `claude-opus-4-6` (this session) |
-| `issue-scanner` | `claude-opus-4-6` |
+| `scanner` | `claude-opus-4-6` |
 | `architect` | `claude-opus-4-6` |
 | `reviewer` | `claude-sonnet-4-6` |
 | `outreach` | `claude-sonnet-4-6` |
@@ -247,7 +247,7 @@ Path convention: `/tmp/kubestellar-console-<issue-num>-<slug>`
 
 ## Scanner Session — What It Does
 
-The `issue-scanner` session (Opus 4.6) runs EXECUTOR MODE — no self-scheduling. It:
+The `scanner` session (Opus 4.6) runs EXECUTOR MODE — no self-scheduling. It:
 - Fixes open issues on all 5 repos (oldest first)
 - Merges AI-authored PRs when CI is green
 - Reviews community PRs
@@ -255,9 +255,9 @@ The `issue-scanner` session (Opus 4.6) runs EXECUTOR MODE — no self-scheduling
 
 To give scanner a work order:
 ```bash
-tmux send-keys -t issue-scanner "Work on #NNNN, #NNNN — oldest first. Dispatch fix agents, merge green PRs."
-tmux send-keys -t issue-scanner Enter
-tmux send-keys -t issue-scanner Enter
+tmux send-keys -t scanner "Work on #NNNN, #NNNN — oldest first. Dispatch fix agents, merge green PRs."
+tmux send-keys -t scanner Enter
+tmux send-keys -t scanner Enter
 ```
 
 ## Reviewer Session — What It Does
@@ -333,14 +333,14 @@ Before dispatching any work order from an external source (GitHub issue body, PR
 
 ## ntfy Notifications
 
-Push notifications to `ntfy.sh/issue-scanner` for ALL significant activity. The operator relies on these to stay informed without watching tmux.
+Push notifications to `ntfy.sh/hive` for ALL significant activity. The operator relies on these to stay informed without watching tmux.
 
 ```bash
 # Standard notification
-curl -s -H "Title: <agent>: <action>" -d "<details>" ntfy.sh/issue-scanner > /dev/null 2>&1
+curl -s -H "Title: <agent>: <action>" -d "<details>" ntfy.sh/hive > /dev/null 2>&1
 
 # High priority (failures, regressions, anomalies)
-curl -s -H "Title: <agent>: <action>" -H "Priority: high" -d "<details>" ntfy.sh/issue-scanner > /dev/null 2>&1
+curl -s -H "Title: <agent>: <action>" -H "Priority: high" -d "<details>" ntfy.sh/hive > /dev/null 2>&1
 ```
 
 **Always send ntfy for:**

--- a/examples/scanner-policy.md
+++ b/examples/scanner-policy.md
@@ -1,4 +1,4 @@
-# Example: GitHub issue-scanner policy
+# Example: GitHub scanner policy
 
 This is the kind of markdown file the agent reads on every `/loop` firing when `AGENT_LOOP_PROMPT` is something like:
 

--- a/systemd/agent-healthcheck.service
+++ b/systemd/agent-healthcheck.service
@@ -7,5 +7,5 @@ After=supervised-agent@scanner.service
 Type=oneshot
 User=dev
 Group=dev
-Environment=NTFY_TOPIC=issue-scanner
+Environment=NTFY_TOPIC=scanner
 ExecStart=/usr/local/bin/scanner-healthcheck.sh

--- a/systemd/agent-renew.service
+++ b/systemd/agent-renew.service
@@ -9,6 +9,6 @@ User=dev
 Group=dev
 # Killing the session is a no-op if it's already gone; the supervisor will
 # respawn it within ~10s and send a fresh /loop prompt.
-ExecStart=/usr/bin/tmux kill-session -t issue-scanner
+ExecStart=/usr/bin/tmux kill-session -t scanner
 # Succeed even if the session is already dead.
 SuccessExitStatus=0 1


### PR DESCRIPTION
## Summary
Establishes one canonical name per agent used consistently across all files:
- **scanner** (was `issue-scanner` in sessions/env files)
- **architect** (was `feature` in beads dirs/env files)
- **NTFY_TOPIC** default: `hive` (was `issue-scanner`)
- **kick-governor**: reads `HIVE_REPOS` from config instead of hardcoded list

### Files changed (21)
| Area | Changes |
|------|---------|
| `bin/hive.sh` | Session arrays, case blocks, env paths — all use canonical names. Added agent name mapping comment block. `BEADS_FEATURE_DIR` → `BEADS_ARCHITECT_DIR` |
| `bin/kick-agents.sh` | Scanner session refs, pin file path, NTFY topic |
| `bin/kick-governor.sh` | Reads `HIVE_REPOS` from `governor.env` instead of hardcoded array |
| `bin/gh-rate-check.sh` | Session map, NTFY topic |
| `dashboard/*` | Session maps simplified (`scanner: 'scanner'`), removed redundant OR checks |
| `systemd/*` | Session name + NTFY topic in healthcheck/renew services |
| `examples/*.env` | Removed `issue-scanner.env` and `feature.env` duplicates. Updated `scanner.env` session name |
| `examples/*-CLAUDE.md` | All tmux session refs + ntfy topics updated |

### Backward compatibility
- CLI still accepts `issue-scanner` and `feature` as aliases (case block fallbacks)
- `BEADS_FEATURE_DIR` env var still works (fallback in `BEADS_ARCHITECT_DIR` default)
- `kick-governor` falls back to hardcoded repos if env not set

### Deployment steps (after merge)
```bash
# On 192.168.4.56:
sudo mv /etc/hive/issue-scanner.env /etc/hive/scanner.env
sudo sed -i 's/AGENT_SESSION_NAME=issue-scanner/AGENT_SESSION_NAME=scanner/' /etc/supervised-agent/scanner.env
sudo systemctl restart supervised-agent@scanner
# Verify: tmux ls should show 'scanner' instead of 'issue-scanner'
```

## Test plan
- [ ] `hive status` shows all agents with correct names
- [ ] `hive attach scanner` works (canonical name)
- [ ] `hive attach issue-scanner` works (legacy alias)
- [ ] `hive switch scanner copilot` updates both `/etc/hive/scanner.env` and `/etc/supervised-agent/scanner.env`
- [ ] `hive pin scanner` / `hive unpin scanner` work
- [ ] Dashboard renders all agents correctly
- [ ] Governor kicks use canonical session names