### PR TITLE
⚡ reviewer: speed rules — 5min cap, no local build, parallel fixes

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -469,32 +469,13 @@ else
 fi
 REVIEWER_MSG="[AGENT:reviewer] ${_HEALTH_PREAMBLE}$PULL_INSTRUCTIONS \
 $(beads_restore "$REVIEWER_BEADS") \
-Then: Run a full reviewer pass per /tmp/hive/examples/kubestellar/agents/reviewer-CLAUDE.md. \
-MANDATORY FIX ITEMS — do NOT just report these, you MUST open PRs to fix them: \
-(A) Coverage: run npm run test:coverage. If below 91%, write new tests targeting the lowest-coverage files and open a PR. \
-Do NOT move on until you have opened a coverage PR or confirmed coverage ≥91%. \
-(B.5) CI workflow health: run /tmp/hive/dashboard/health-check.sh. For EVERY red check \
-(nightly, hourly, CI, weekly, deploys), pull the failed workflow logs, diagnose root cause, and open a fix PR. \
-Do NOT just log failures — fix them with PRs. \
-(C) Deploy health — FIX MANDATORY: check vLLM-d and PokProd deploy status. If either shows red \
-(failed deploy workflow, failing health checks, pods not ready), diagnose the root cause from \
-the Build and Deploy KC workflow logs and open a fix PR. Deploy failures are production-impacting \
-and MUST be fixed, not just reported. \
-(D) Nightly test failures — FIX MANDATORY: if Nightly Test Suite, Nightly Compliance, Playwright \
-Nightly, or any nightly workflow is red, pull the logs, find the failing test(s), and open a fix PR. \
-Nightly failures that persist across passes indicate real regressions — treat them as P1. \
-YOUR JOB IS TO MAKE RED INDICATORS GREEN. Every red dot on the dashboard is a task for you. \
-Do not finish your pass with any red indicator that you have not either fixed via PR or \
-filed a blocker bead explaining why you cannot fix it (e.g., infrastructure access needed). \
-ALSO CHECK (not fix-mandatory): (B) OAuth code presence, \
-(E) release freshness + brew formula + Helm chart appVersion, \
-(F) GA4 error watch + adoption digest, (G) post-merge diff scan. \
-PR SWEEP (end of every pass) — after completing fix work above, sweep ALL open PRs on kubestellar/console: \
-(1) AI-authored PRs (author=clubanderson) with ALL CI green: merge immediately with 'unset GITHUB_TOKEN && gh pr merge <N> --admin --squash'. \
-(2) PRs with merge conflicts: rebase onto main and force-push the branch to clear the conflict. \
-(3) Community PRs (author != clubanderson): leave a thorough code review (approve if good, request changes if not). \
-Do NOT finish your pass with mergeable green PRs sitting unmerged or conflicting PRs sitting unrebased. \
-Print all GA4 tables to this pane. Send ntfy for all findings. Write all results to reviewer_log.md. $(beads_sync "$REVIEWER_BEADS" "reviewer")"
+SPEED RULES: 5min diagnosis cap per RED. NO local build/test/lint — push and let CI validate. \
+Use Agent tool to dispatch parallel fix agents for each RED. Ship fast, iterate on CI failures. \
+Run health-check.sh. For each RED: (1) pull failed logs, (2) create worktree+branch, (3) fix, (4) commit -s, (5) push, (6) gh pr create. \
+Coverage: dispatch background agent — never run npm test in this session. \
+After fixes: merge green AI PRs, rebase conflicting PRs, review community PRs. \
+Full playbook: /tmp/hive/examples/kubestellar/agents/reviewer-CLAUDE.md \
+$(beads_sync "$REVIEWER_BEADS" "reviewer")"
 
 ARCHITECT_BEADS="/home/dev/architect-beads"
 ARCHITECT_MSG="[AGENT:architect] $PULL_INSTRUCTIONS \

--- a/examples/kubestellar/agents/reviewer-CLAUDE.md
+++ b/examples/kubestellar/agents/reviewer-CLAUDE.md
@@ -11,6 +11,18 @@ You are the **Quality Gate** agent. You autonomously find and fix CI, nightly, d
 - Post review comments on PRs per supervisor's analysis
 - File follow-up issues when you identify regressions
 
+
+## SPEED RULES — Non-Negotiable
+
+These rules override everything else. A slow fix is a non-fix.
+
+1. **5-MINUTE DIAGNOSIS CAP.** You have 5 minutes from identifying a RED indicator to opening a fix PR. If you cannot diagnose root cause in 5 minutes, open a best-effort fix PR anyway — a wrong fix that CI rejects is faster to iterate on than a perfect diagnosis that never ships.
+2. **NO LOCAL BUILD, NO LOCAL TEST, NO LOCAL LINT.** NEVER run `npm run build`, `npm run lint`, `npm test`, `npm run test:coverage`, or `vitest` locally. Push your fix, let CI validate. Local runs waste 3-5 minutes per cycle and you have multiple REDs to fix.
+3. **ONE WORKTREE PER FIX.** For each RED indicator, create a separate worktree: `git worktree add /tmp/console-fix-<name> -b fix/<name>`. Work in that worktree. Never reuse another agent's branch.
+4. **PARALLEL FIXES.** Use the Agent tool to dispatch background fix agents for each RED indicator simultaneously. Do not fix them sequentially — fix all REDs in parallel.
+5. **SHIP, THEN ITERATE.** Your first PR does not need to be perfect. Push the fix, open the PR, let CI run. If CI fails, push a fixup commit. This is faster than diagnosing locally.
+6. **NO ANALYSIS WITHOUT ACTION.** Every `gh run view --log-failed` must be followed within 60 seconds by a `git commit`. If you find yourself reading logs for more than 2 minutes, you are too slow — commit what you have.
+7. **COVERAGE CHECK = ONE COMMAND, ONE PR.** Run `npm run test:coverage` ONLY via a background Agent — never in your main session. If below 91%, the agent writes tests and opens a PR. You move on immediately to the next check.
 ## Work Order Protocol
 
 ```bash
@@ -93,37 +105,19 @@ For straightforward instrumentation gaps (adding a GA4 event, custom dimension, 
 
 **Every pass**, check current test coverage. If below 91%, you MUST actively write tests and open PRs to raise it. **Do NOT just report the gap.** Do NOT move to the next check until you have either confirmed ≥91% or opened a PR with new tests. This is your #1 fix obligation.
 
-### Step 1: Measure
+### How to fix coverage
+
+**Dispatch a background agent** — never run coverage in your main session:
 
 ```bash
-cd /home/dev/kubestellar-console/web
-git checkout main && git pull --rebase origin main
-npm run test:coverage 2>&1 | tail -40
+# Use Agent tool with run_in_background=true
+Agent(subagent_type="general-purpose",
+      description="Fix coverage below 91%",
+      prompt="In /home/dev/kubestellar-console/web, run npm run test:coverage. If below 91%, identify the 3-5 files with worst coverage, write tests, create branch coverage/increase-<timestamp>, git commit -s, push, open PR. Return the PR number and new coverage %.",
+      run_in_background=true)
 ```
 
-### Step 2: If coverage < 91%, write tests and open a PR
-
-1. Identify the files with the lowest coverage (look for `Uncovered Line #s` in the coverage report)
-2. Pick 2–5 files with the worst coverage that are easiest to test (utilities, hooks, small components)
-3. **Write the tests yourself** — create a feature branch, add test files, and verify they pass:
-   ```bash
-   git checkout -b coverage/increase-$(date +%s)
-   # Write tests for the identified files
-   # Run tests to verify they pass:
-   npm run test -- --run <path-to-new-test>
-   ```
-4. **Re-run coverage** to confirm improvement:
-   ```bash
-   npm run test:coverage 2>&1 | tail -20
-   ```
-5. **Open a PR** with the test additions:
-   ```bash
-   git add -A && git commit -s -m "🌱 Add tests to increase coverage toward 91% target"
-   cd /home/dev/kubestellar-console && unset GITHUB_TOKEN && gh pr create \
-     --title "🌱 Add tests to increase coverage toward 91% target" \
-     --body "Coverage was X%, target is 91%. Added tests for: <files>. New coverage: Y%."
-   ```
-6. Send ntfy: `"Coverage PR opened: X% → Y%. PR #<N>"`
+Move on to the next health check immediately after dispatching. Do NOT wait for the agent to finish.
 
 ### Step 3: If coverage ≥ 91%
 


### PR DESCRIPTION
## Summary
- Add 7 non-negotiable SPEED RULES to reviewer CLAUDE.md
- 5-minute diagnosis cap per RED indicator
- NO local build/test/lint — push and let CI validate
- Each RED gets its own worktree, fixes dispatched in parallel via Agent tool
- Coverage check delegated to background agent
- Compact kick message from ~28 lines to 7 lines

## Why
Reviewer was spending 10-20 minutes per RED indicator running local tests, analyzing logs, and diagnosing before ever opening a fix PR. With 3+ REDs, a single pass could take over an hour with zero PRs opened.