### PR TITLE
🐛 narrow Cancelling detection to last 5 pane lines

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -170,8 +170,9 @@ session_exists() {
 session_idle() {
   local pane_text
   pane_text=$($TMUX_BIN capture-pane -t "$1" -p 2>/dev/null || true)
-  # Not idle if CLI is mid-cancellation — prompt is visible but not accepting input
-  if echo "$pane_text" | grep -qE "Cancelling|◎ Cancelling|○ Cancelling"; then
+  # Not idle if CLI is CURRENTLY mid-cancellation (check last 5 lines only —
+  # full pane buffer has historical "Cancelling" text from prior cycles)
+  if echo "$pane_text" | tail -5 | grep -qE "Cancelling|◎ Cancelling|○ Cancelling"; then
     return 1
   fi
   echo "$pane_text" | grep -q "❯"

--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -685,8 +685,9 @@ done)"
 for _fa in scanner reviewer supervisor; do
   [[ -f "$STATE_DIR/paused_${_fa}" ]] && continue
   _pane_text=$(tmux capture-pane -t "$_fa" -p 2>/dev/null || true)
-  # Skip if agent is mid-cancellation — let it finish
-  if echo "$_pane_text" | grep -qE "Cancelling"; then
+  # Skip if agent is CURRENTLY mid-cancellation (check last 5 lines only —
+  # full pane buffer has historical "Cancelling" text from prior cycles)
+  if echo "$_pane_text" | tail -5 | grep -qE "Cancelling"; then
     continue
   fi
   _prompt_line=$(echo "$_pane_text" | grep "❯" | tail -1)


### PR DESCRIPTION
## Summary
Check only last 5 lines for Cancelling state, not full pane scrollback.

## Root cause
tmux capture-pane returns the full scrollback buffer. Historical Cancelling text from 30+ min ago was still matching, causing the governor flush to permanently skip the reviewer even after cancellation completed.