### PR TITLE
🐛 always clear stale input — remove Cancelling skip

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -170,11 +170,8 @@ session_exists() {
 session_idle() {
   local pane_text
   pane_text=$($TMUX_BIN capture-pane -t "$1" -p 2>/dev/null || true)
-  # Not idle if CLI is CURRENTLY mid-cancellation (check last 5 lines only —
-  # full pane buffer has historical "Cancelling" text from prior cycles)
-  if echo "$pane_text" | tail -5 | grep -qE "Cancelling|◎ Cancelling|○ Cancelling"; then
-    return 1
-  fi
+  # Check for idle prompt — ignore "Cancelling" in scrollback since it can
+  # be caused by stale queued text (which we clear before kicking)
   echo "$pane_text" | grep -q "❯"
 }
 

--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -685,11 +685,6 @@ done)"
 for _fa in scanner reviewer supervisor; do
   [[ -f "$STATE_DIR/paused_${_fa}" ]] && continue
   _pane_text=$(tmux capture-pane -t "$_fa" -p 2>/dev/null || true)
-  # Skip if agent is CURRENTLY mid-cancellation (check last 5 lines only —
-  # full pane buffer has historical "Cancelling" text from prior cycles)
-  if echo "$_pane_text" | tail -5 | grep -qE "Cancelling"; then
-    continue
-  fi
   _prompt_line=$(echo "$_pane_text" | grep "❯" | tail -1)
   _after=$(echo "$_prompt_line" | sed 's/.*❯[[:space:]]*//')
   if [ -n "$_after" ] && [ ${#_after} -gt 2 ]; then


### PR DESCRIPTION
## Summary
Remove Cancelling state detection from governor flush and session_idle. Always clear stale queued text with C-c + C-u.

## Why
The Cancelling state is itself caused by stale text in the prompt buffer. Skipping the clear during Cancelling was preventing the fix from ever running. C-c + C-u during cancellation helps break the loop.