### PR TITLE
fix: split long kick messages into sub-kicks for reliable delivery

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -326,6 +326,73 @@ check_rate_limit() {
   ) &
 }
 
+send_chunked() {
+  # Split a long message into chunks at sentence boundaries and send each
+  # chunk + Enter separately.  This prevents CLI input buffer overflow that
+  # causes Enter to not be delivered on messages >~1KB.
+  local session="$1"
+  local message="$2"
+  local MAX_CHUNK=400
+
+  if [ ${#message} -le "$MAX_CHUNK" ]; then
+    $TMUX_BIN send-keys -t "$session" -l "$message"
+    sleep 1
+    $TMUX_BIN send-keys -t "$session" Enter
+    sleep 2
+    return
+  fi
+
+  local remaining="$message"
+  local chunk_num=0
+  while [ -n "$remaining" ]; do
+    (( chunk_num++ ))
+    if [ ${#remaining} -le "$MAX_CHUNK" ]; then
+      $TMUX_BIN send-keys -t "$session" -l "$remaining"
+      sleep 1
+      $TMUX_BIN send-keys -t "$session" Enter
+      sleep 2
+      remaining=""
+    else
+      # Find last sentence boundary (". ") within MAX_CHUNK
+      local window="${remaining:0:$MAX_CHUNK}"
+      local cut_at=-1
+      local search_pos=0
+      while true; do
+        local rest="${window:$search_pos}"
+        case "$rest" in
+          *". "*)
+            local before="${rest%%". "*}"
+            local pos=$(( search_pos + ${#before} + 2 ))
+            cut_at=$pos
+            search_pos=$pos
+            ;;
+          *) break ;;
+        esac
+      done
+      if [ "$cut_at" -lt 20 ]; then
+        # No good sentence boundary — split at last space
+        local rev
+        rev=$(echo "$window" | rev)
+        local tail_rev="${rev%%[[:space:]]*}"
+        local tail_len=${#tail_rev}
+        if [ "$tail_len" -lt "$MAX_CHUNK" ] && [ "$tail_len" -gt 0 ]; then
+          cut_at=$(( MAX_CHUNK - tail_len ))
+        else
+          cut_at=$MAX_CHUNK
+        fi
+      fi
+      local chunk="${remaining:0:$cut_at}"
+      remaining="${remaining:$cut_at}"
+      # Strip leading whitespace from remainder
+      remaining="${remaining#"${remaining%%[![:space:]]*}"}"
+      $TMUX_BIN send-keys -t "$session" -l "$chunk"
+      sleep 1
+      $TMUX_BIN send-keys -t "$session" Enter
+      sleep 2
+    fi
+  done
+}
+
 kick() {
   local session="$1"
   local message="$2"
@@ -425,10 +492,8 @@ kick() {
     sleep 1
   fi
 
-  log "KICK $session"
-  $TMUX_BIN send-keys -t "$session" -l "$message"
-  sleep 2  # let tmux flush long message text before sending Enter
-  $TMUX_BIN send-keys -t "$session" Enter
+  log "KICK $session (${#message} chars)"
+  send_chunked "$session" "$message"
   # Verify Enter was delivered — retry if text still in prompt after 3s
   sleep 3
   local _vline _vtext


### PR DESCRIPTION
## Summary
- Adds `send_chunked()` function that splits messages >400 chars at sentence boundaries (`. `) into multiple sub-kicks
- Each chunk is sent via `tmux send-keys -l` + Enter with sleep between deliveries
- Fixes CLI input buffer overflow that prevented Enter from being delivered on messages >~1KB (reviewer kicks are ~1.3KB expanded)

## Test plan
- [x] Syntax check passes (`bash -n`)
- [x] Tested chunking logic: 1286-char reviewer message splits into 4 chunks (287, 393, 355, 251 chars)
- [ ] Verify on live system: reviewer kick delivers all chunks and agent starts working