### PR TITLE
fix: compact kick messages <300 chars + auto-restart stuck agents

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -32,6 +32,8 @@ NOTIFY_LIB="${NOTIFY_LIB:-/usr/local/bin/notify.sh}"
 BACKEND_STATE_DIR="/var/run/agent-backends"
 mkdir -p "$BACKEND_STATE_DIR" 2>/dev/null || true
 
+GOVERNOR_FLAG_DIR="/var/run/kick-governor"
+
 # Agent handoff state — captures last N lines of work context when switching backends
 HANDOFF_DIR="/tmp/agent-handoff"
 mkdir -p "$HANDOFF_DIR" 2>/dev/null || true
@@ -472,6 +474,15 @@ kick() {
       ntfy "$agent — busy" "Still working, skipped kick at $ET_NOW. Next: $(next_run "$agent")"
       return
     fi
+  fi
+
+  # Check if governor flagged this agent for restart (buffer completely stuck)
+  local _restart_flag="$GOVERNOR_FLAG_DIR/needs_restart_${agent}"
+  if [ -f "$_restart_flag" ]; then
+    log "RESTART $session — governor flagged buffer stuck, killing CLI"
+    rm -f "$_restart_flag"
+    restart_stuck_agent "$session" "$agent"
+    # After restart, fall through to kick below
   fi
 
   # Clear any stale input before sending new kick

--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -196,6 +196,39 @@ flush_pending_input() {
   return 1
 }
 
+restart_stuck_agent() {
+  # Kill the stuck CLI process and relaunch it in the same tmux pane.
+  # Used when the input buffer is completely full and won't accept any keys.
+  local session="$1" agent="$2"
+  local pane_pid
+  pane_pid=$($TMUX_BIN display-message -t "$session" -p '#{pane_pid}' 2>/dev/null || true)
+  if [ -n "$pane_pid" ]; then
+    log "RESTART $session — killing pane process tree (pid $pane_pid)"
+    kill -9 "$pane_pid" 2>/dev/null || true
+    sleep 2
+  fi
+  # Relaunch the agent CLI
+  local _cur_backend _cur_model
+  _cur_backend=$(get_current_backend "$agent")
+  _cur_model=$(get_model_for "$agent" "$_cur_backend")
+  log "RESTART $session — relaunching with ${_cur_backend}:${_cur_model}"
+  $TMUX_BIN send-keys -t "$session" -l "agent-launch.sh --backend $_cur_backend --model $_cur_model" 2>/dev/null || true
+  sleep 1
+  $TMUX_BIN send-keys -t "$session" Enter 2>/dev/null || true
+  local RESTART_WAIT=90
+  local waited=0
+  while (( waited < RESTART_WAIT )); do
+    if session_cli_ready "$session"; then
+      log "RESTART $session — CLI ready after ${waited}s"
+      return 0
+    fi
+    sleep 3
+    (( waited += 3 ))
+  done
+  log "RESTART $session — CLI did not start within ${RESTART_WAIT}s"
+  return 1
+}
+
 session_cli_ready() {
   # Returns 0 if the CLI has fully started (not just shell prompt visible).
   # After a model switch, the old scrollback still has ❯ from the previous
@@ -454,14 +487,26 @@ kick() {
 
   log "KICK $session (${#message} chars)"
   send_chunked "$session" "$message"
-  # Verify Enter was delivered — retry if text still in prompt after 3s
+  # Verify Enter was delivered — retry then restart if buffer is stuck
   sleep 3
   local _vline _vtext
   _vline=$($TMUX_BIN capture-pane -t "$session" -p 2>/dev/null | grep "❯" | tail -1)
   _vtext=$(echo "$_vline" | sed 's/.*❯[[:space:]]*//')
   if [ -n "$_vtext" ] && [ ${#_vtext} -gt 2 ]; then
-    log "RETRY $session — Enter not delivered, resending"
+    log "RETRY $session — Enter not delivered (${#_vtext} chars stuck), retrying"
     $TMUX_BIN send-keys -t "$session" Enter
+    sleep 3
+    _vline=$($TMUX_BIN capture-pane -t "$session" -p 2>/dev/null | grep "❯" | tail -1)
+    _vtext=$(echo "$_vline" | sed 's/.*❯[[:space:]]*//')
+    if [ -n "$_vtext" ] && [ ${#_vtext} -gt 2 ]; then
+      log "STUCK $session — buffer overflow, killing and relaunching CLI"
+      ntfy "$agent — restarting" "Input buffer stuck (${#_vtext} chars). Killing CLI process."
+      restart_stuck_agent "$session" "$agent"
+      # Re-kick after restart
+      sleep 5
+      send_chunked "$session" "$message"
+      sleep 3
+    fi
   fi
   ntfy "$agent started" "Kicked at $ET_NOW. Next: $(next_run "$agent")"
 
@@ -469,55 +514,14 @@ kick() {
   check_rate_limit "$session" "$agent" 60
 }
 
-# GitHub API rate limit handling instructions — included in every agent's kick message.
-# These are DIFFERENT from Claude/Copilot CLI usage limits. GitHub API limits should
-# never cause an agent restart — they should be worked around.
-GH_RATE_LIMIT_INSTRUCTIONS="GITHUB RATE LIMITS — if gh commands fail with rate limit errors \
-(API rate limit exceeded, secondary rate limit, 403 rate, Resource not accessible), \
-do NOT stop working. Strategies: (1) wait 60s and retry, (2) use 'gh api' with '--cache 1h' \
-for read operations, (3) switch from GraphQL to REST or vice versa, (4) continue with \
-non-GitHub work while waiting. NEVER treat a GitHub rate limit as a reason to stop your pass."
+# ── Compact kick messages ──────────────────────────────────────────
+# All standing instructions (pull, beads, rate limits, hold rules, speed rules,
+# lane boundaries) are in each agent's CLAUDE.md. Kicks only carry the trigger
+# + any live dynamic data (e.g. current RED indicators).
 
-PULL_INSTRUCTIONS="First: cd /tmp/hive && git pull --rebase origin main. Re-read your CLAUDE.md for any updated instructions. \
-HARD RULE — enforced before any other action: never touch any issue or PR that carries a label containing the word 'hold' (case-insensitive). \
-Do not comment on it, do not merge it, do not reference it in other PRs, do not create sub-issues from it. Treat it as if it does not exist. \
-$GH_RATE_LIMIT_INSTRUCTIONS"
+SCANNER_MSG="[KICK] git pull /tmp/hive. Read your CLAUDE.md. Full scan pass — fix issues, merge green PRs. Beads: ~/scanner-beads"
 
-# Beads startup restore + end-of-pass sync.
-# Each agent has its own beads directory.
-beads_restore() {
-  local dir="$1"
-  echo "Then read your beads from $dir: run 'cd $dir && bd list --json' to see all open/in-progress items. \
-Resume any item with status in_progress first (bd show <id>). \
-For new work, run 'cd $dir && bd ready --json' to find unblocked items. \
-Claim each item before starting it: cd $dir && bd update <id> --claim. \
-ALL bd commands must be run from $dir — never from a different directory."
-}
-
-beads_sync() {
-  local dir="$1"
-  local agent_name="$2"
-  echo "At the END of this pass: update beads for everything you worked on \
-(cd $dir && bd close <id> --reason '...' for completed, bd update <id> --status blocked --description '...' for blockers). \
-Then run: cd $dir && bd dolt push. \
-EXEC SUMMARY — write a ONE-LINE status (max 140 chars) summarizing what you did this pass to /var/run/hive-metrics/${agent_name}_summary.txt. \
-Example: echo 'Fixed 3 issues, opened 2 PRs, merged 1. Nightly tests still red.' > /var/run/hive-metrics/${agent_name}_summary.txt \
-Use your agent name: ${agent_name}. This line appears on the hive dashboard."
-}
-
-SCANNER_BEADS="/home/dev/scanner-beads"
-SCANNER_MSG="[AGENT:scanner] $PULL_INSTRUCTIONS \
-$(beads_restore "$SCANNER_BEADS") \
-Then: Run a full scan pass per /tmp/hive/examples/kubestellar/agents/scanner-CLAUDE.md. \
-Oldest-first. Check all 5 repos: kubestellar/console, console-kb, docs, \
-console-marketplace, kubestellar-mcp. \
-For EVERY open issue that does not already have an active PR, dispatch a background fix agent using the Agent tool with worktrees. \
-Do NOT just count issues and stop — your job is to FIX them, not report them. \
-Merge AI-authored PRs with green CI. Send ntfy (curl -s -H 'Title: Scanner: <action>' -d '<details>' ntfy.sh/hive) for every merge and external PR review. \
-Log to cron_scan_log.md. $(beads_sync "$SCANNER_BEADS" "scanner")"
-
-REVIEWER_BEADS="/home/dev/reviewer-beads"
-# Build live health preamble — tells reviewer exactly what's red RIGHT NOW
+# Build live health preamble for reviewer — tells it exactly what's red RIGHT NOW
 _rh_json=$(/tmp/hive/dashboard/health-check.sh 2>/dev/null || echo '{}')
 _rh_reds=""
 _rh_ci=$(echo "$_rh_json" | jq -r '.ci // 0' 2>/dev/null || echo 0)
@@ -533,52 +537,15 @@ done
 _rh_cvg=$(curl -sf "${BADGE_URL:-https://gist.githubusercontent.com/clubanderson/b9a9ae8469f1897a22d5a40629bc1e82/raw/coverage-badge.json}" 2>/dev/null | jq -r '.message // "0"' | tr -d '%' || echo 0)
 [ "${_rh_cvg:-0}" -lt 91 ] && _rh_reds="${_rh_reds} coverage=${_rh_cvg}%<91%"
 if [ -n "$_rh_reds" ]; then
-  _HEALTH_PREAMBLE="URGENT — DASHBOARD HAS RED INDICATORS:${_rh_reds}. Your ONLY job this pass is to FIX these. Do NOT acknowledge and stand by. Do NOT skip health checks. Run /tmp/hive/dashboard/health-check.sh, diagnose each failure, and open fix PRs. "
+  _HEALTH_PREAMBLE="URGENT — RED INDICATORS:${_rh_reds}. Fix these first. "
 else
   _HEALTH_PREAMBLE=""
 fi
-REVIEWER_MSG="[AGENT:reviewer] ${_HEALTH_PREAMBLE}$PULL_INSTRUCTIONS \
-$(beads_restore "$REVIEWER_BEADS") \
-SPEED RULES: 5min diagnosis cap per RED. NO local build/test/lint — push and let CI validate. \
-Use Agent tool to dispatch parallel fix agents for each RED. Ship fast, iterate on CI failures. \
-Run health-check.sh. For each RED: (1) pull failed logs, (2) create worktree+branch, (3) fix, (4) commit -s, (5) push, (6) gh pr create. \
-Coverage: dispatch background agent — never run npm test in this session. \
-After fixes: merge green AI PRs, rebase conflicting PRs, review community PRs. \
-Full playbook: /tmp/hive/examples/kubestellar/agents/reviewer-CLAUDE.md \
-$(beads_sync "$REVIEWER_BEADS" "reviewer")"
+REVIEWER_MSG="[KICK] ${_HEALTH_PREAMBLE}git pull /tmp/hive. Read your CLAUDE.md. Full reviewer pass — fix REDs, merge green PRs. Beads: ~/reviewer-beads"
 
-ARCHITECT_BEADS="/home/dev/architect-beads"
-ARCHITECT_MSG="[AGENT:architect] $PULL_INSTRUCTIONS \
-$(beads_restore "$ARCHITECT_BEADS") \
-Then: Run an architect pass per /tmp/hive/examples/kubestellar/agents/architect-CLAUDE.md. \
-Pull main, scan the codebase for refactor or perf improvement opportunities. \
-You may work autonomously on refactors and perf as long as you do not break \
-the build, touch OAuth, or touch the update system. For new feature ideas, \
-open an issue with label architect-idea and wait for operator approval. \
-Send ntfy for all plans and PRs. Print your plan to this pane. $(beads_sync "$ARCHITECT_BEADS" "architect")"
+ARCHITECT_MSG="[KICK] git pull /tmp/hive. Read your CLAUDE.md. Full architect pass — refactor/perf scan. Beads: ~/architect-beads"
 
-OUTREACH_BEADS="/home/dev/outreach-beads"
-OUTREACH_MSG="[AGENT:outreach] $PULL_INSTRUCTIONS \
-$(beads_restore "$OUTREACH_BEADS") \
-Then: Run an outreach pass per /tmp/hive/examples/kubestellar/agents/outreach-CLAUDE.md. \
-LANE — outreach owns: awesome lists, directories, comparison sites, aggregators, \
-community forums, package registries, CNCF landscape entries, and any public index where \
-KubeStellar Console should be listed. Target 200+ awesome-list placements. \
-OPERATOR-DIRECTED WORK — when the operator sends a custom kick prompt referencing a specific \
-issue, PR, or task, you may work on it regardless of lane boundaries. Follow the operator's \
-instructions exactly. This override applies ONLY to the specific work the operator requested. \
-GA4 STRATEGY — read GA4 data for console.kubestellar.io to inform outreach decisions: \
-which pages get the most traffic, which search terms bring visitors, which features have \
-highest engagement. Use this to (a) prioritise which Console capabilities to pitch on each \
-platform, (b) identify traffic gaps where new listings would have the most impact, and \
-(c) track whether previous outreach placements are driving referral traffic. \
-GA4 insight is for strategy only — do NOT fix GA4 errors (that is the reviewer's job). \
-LANE BOUNDARIES (default, unless overridden by operator directive) — outreach must NEVER: \
-fix bugs, fix CI/nightly/Playwright/coverage failures, review code, implement features, \
-or do anything the scanner/reviewer/architect agents do. CI and test fixes are the reviewer's job. \
-If you find a bug or improvement idea, file a beads issue for the scanner — do not act on it yourself. \
-Fork under clubanderson account for all external PRs to third-party repos. \
-Send ntfy for every new listing secured. One outreach per project — never spam. $(beads_sync "$OUTREACH_BEADS" "outreach")"
+OUTREACH_MSG="[KICK] git pull /tmp/hive. Read your CLAUDE.md. Full outreach pass. Beads: ~/outreach-beads"
 
 # ── Governor model integration ──────────────────────────────────────
 # Reads /var/run/kick-governor/model_<agent> written by the governor's
@@ -652,25 +619,7 @@ apply_model_if_changed() {
 }
 
 _now_et=$(TZ=America/New_York date '+%Y-%m-%d %I:%M %p %Z')
-SUPERVISOR_MSG="[AGENT:supervisor] MONITORING PASS — Pass started: ${_now_et}
-
-HARD RULE — 12-HOUR CLOCK ONLY: Every timestamp you output MUST use 12-hour format with AM/PM. \
-Use: TZ=America/New_York date '+%Y-%m-%d %I:%M %p %Z' \
-CORRECT: 1:17 PM EDT, 10:32 AM EDT. WRONG: 13:17, 22:32. \
-If you see yourself writing a number >12 for the hour, STOP and fix it. No exceptions.
-
-Do all of the following right now:
-1. Record pass start time at the TOP of your monitoring summary: \"Pass started: ${_now_et}\"
-2. Check every agent session for questions, stalls, or errors: \
-   tmux capture-pane -t scanner -p | tail -20 \
-   tmux capture-pane -t reviewer -p | tail -20 \
-   tmux capture-pane -t architect -p | tail -20 \
-   tmux capture-pane -t outreach -p | tail -20 \
-   If any agent has an unresolved question or idle prompt, respond immediately via tmux send-keys. \
-3. Check for AI-authored PRs with CI green across all kubestellar repos — merge any that are ready. \
-4. Check for rate-limited agents — switch their backend if needed (hive switch <agent> <backend>). \
-5. Run: bd dolt push
-6. After printing the monitoring summary table, compute the next run time and add: \"Pass finished: \$(TZ=America/New_York date '+%Y-%m-%d %I:%M %p %Z') | Next run: ~\$(TZ=America/New_York date -d '+15 minutes' '+%I:%M %p %Z' 2>/dev/null || TZ=America/New_York date -v+15M '+%I:%M %p %Z' 2>/dev/null || echo '~15min')\""
+SUPERVISOR_MSG="[KICK] MONITORING PASS ${_now_et}. Read your CLAUDE.md. Check all agent panes, merge green PRs, unstick idle agents. Beads: ~/supervisor-beads"
 
 case "$TARGET" in
   scanner)

--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -680,10 +680,10 @@ log "BUDGET projected=${budget_pct}% models: $(for _a in scanner reviewer archit
 done)"
 
 # Clear stuck input on every tick — C-c + C-u to discard, not Enter to execute.
-# Stale queued text (from old direct kicks or piled-up messages) should be
-# discarded so the next cadence kick delivers a clean message.
-for _fa in scanner reviewer supervisor; do
+# If C-c + C-u fails (buffer completely stuck), flag agent for restart.
+for _fa in scanner reviewer supervisor architect outreach; do
   [[ -f "$STATE_DIR/paused_${_fa}" ]] && continue
+  tmux has-session -t "$_fa" 2>/dev/null || continue
   _pane_text=$(tmux capture-pane -t "$_fa" -p 2>/dev/null || true)
   _prompt_line=$(echo "$_pane_text" | grep "❯" | tail -1)
   _after=$(echo "$_prompt_line" | sed 's/.*❯[[:space:]]*//')
@@ -692,7 +692,13 @@ for _fa in scanner reviewer supervisor; do
     tmux send-keys -t "$_fa" C-c 2>/dev/null || true
     sleep 1
     tmux send-keys -t "$_fa" C-u 2>/dev/null || true
-    sleep 1
+    sleep 2
+    # Verify clear worked — if text persists, buffer is frozen
+    _after2=$(tmux capture-pane -t "$_fa" -p 2>/dev/null | grep "❯" | tail -1 | sed 's/.*❯[[:space:]]*//')
+    if [ -n "$_after2" ] && [ ${#_after2} -gt 2 ]; then
+      log "STUCK ${_fa} — buffer frozen (${#_after2} chars), flagging for restart"
+      touch "$STATE_DIR/needs_restart_${_fa}"
+    fi
   fi
 done
 


### PR DESCRIPTION
## Summary
- **Root cause**: Kick messages were 1.5-2.8KB which overflowed the CLI input buffer, making Enter undeliverable. Even chunked delivery didn't help because the CLI has a max input line length.
- **Fix**: All standing instructions (pull, beads, rate limits, hold rules, speed rules, lane boundaries) are already in each agent's CLAUDE.md. Kicks now only carry the trigger + live health data (~100-200 chars).
- **Auto-restart**: When Enter fails twice after a kick, `restart_stuck_agent()` kills the pane process and relaunches the CLI, then re-delivers the kick.
- **Governor detection**: Flush loop now verifies C-c+C-u worked; if text persists after clearing, flags agent for restart via `needs_restart_<agent>` file. Covers all 5 agents (was only 3).

## Test plan
- [x] Syntax check passes for both scripts
- [x] All kick messages confirmed <200 chars (scanner=116, reviewer=138+preamble, architect=114, outreach=91, supervisor=142)
- [ ] Verify on live: reviewer receives compact kick and starts working
- [ ] Verify stuck detection: if Enter fails, CLI auto-restarts