### PR TITLE
fix: governor issue count returns 0 due to unauthenticated API

### DIFF
--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -199,8 +199,13 @@ count_actionable() {
   local name="${repo##*/}"
   local cache_dir="$STATE_DIR/repo_cache"
   mkdir -p "$cache_dir" 2>/dev/null || true
-  unset GITHUB_TOKEN
-  [ -n "$HIVE_GITHUB_TOKEN" ] && export GH_TOKEN="$HIVE_GITHUB_TOKEN"
+  # Use HIVE_GITHUB_TOKEN if set; otherwise let gh use its stored credentials.
+  # Never unset GITHUB_TOKEN without a replacement — that causes unauthenticated
+  # API calls that hit the 60 req/hr rate limit and return empty results.
+  if [ -n "$HIVE_GITHUB_TOKEN" ]; then
+    unset GITHUB_TOKEN
+    export GH_TOKEN="$HIVE_GITHUB_TOKEN"
+  fi
   local issues prs
 
   # REST API: list open issues (excludes PRs), filter out exempt labels client-side


### PR DESCRIPTION
## Summary
- Governor's `count_actionable()` unconditionally ran `unset GITHUB_TOKEN` before checking `HIVE_GITHUB_TOKEN` (which was never set in governor.env)
- This wiped `gh`'s stored credentials, forcing unauthenticated API calls (60 req/hr limit)
- When rate-limited, API returned empty results → `0` cached → governor showed 0 issues despite 15+ open
- Fix: only unset `GITHUB_TOKEN` when `HIVE_GITHUB_TOKEN` is available as replacement

## Test plan
- [ ] After deploy, verify `issues` column in governor log shows non-zero count matching actual open issues
- [ ] Verify dashboard Governor block shows correct issue count