### PR TITLE
feat: centralized GitHub API collector reduces 340→35 calls/hr

### DIFF
--- a/bin/hive.sh
+++ b/bin/hive.sh
@@ -825,28 +825,20 @@ cmd_status_json() {
        | awk 'NR==2{print $1,$2,$3,$4}' \
        | xargs -I{} bash -c "TZ=\"$HIVE_TZ\" date -d \"{}\" \"+%-I:%M %p %Z\"" 2>/dev/null || echo "")
 
-  # Repos — only fetch from GH API when --repos flag is passed; otherwise use cache
-  local STATUS_CACHE="/var/run/kick-governor/repo_cache"
-  mkdir -p "$STATUS_CACHE" 2>/dev/null || true
+  # Repos — read from centralized api-collector cache
+  local GITHUB_CACHE="${HIVE_METRICS_DIR:-/var/run/hive-metrics}/github-cache.json"
   local repos_json="["
   local first_repo=true
-  local fetch_repos=false
-  [[ " $* " == *" --repos "* ]] && fetch_repos=true
   for repo in ${HIVE_REPOS:-}; do
     local rname issues prs
     rname="${repo##*/}"
-    if [[ "$fetch_repos" == "true" ]]; then
-      issues=$(gh issue list --repo "$repo" --state open --json number --jq 'length' 2>/dev/null || echo "-1")
-      prs=$(   gh pr    list --repo "$repo" --state open --json number --jq 'length' 2>/dev/null || echo "-1")
-      [[ "$issues" != "-1" ]] && echo "$issues" > "$STATUS_CACHE/${rname}_issues"
-      [[ "$prs"    != "-1" ]] && echo "$prs"    > "$STATUS_CACHE/${rname}_prs"
+    if [[ -f "$GITHUB_CACHE" ]]; then
+      issues=$(jq -r ".repos[] | select(.name == \"$rname\") | .issues // 0" "$GITHUB_CACHE" 2>/dev/null || echo "0")
+      prs=$(jq -r ".repos[] | select(.name == \"$rname\") | .prs // 0" "$GITHUB_CACHE" 2>/dev/null || echo "0")
     else
-      issues="-1"
-      prs="-1"
+      issues=0
+      prs=0
     fi
-    # Fall back to cached values
-    [[ "$issues" == "-1" ]] && issues=$(cat "$STATUS_CACHE/${rname}_issues" 2>/dev/null || echo "0")
-    [[ "$prs"    == "-1" ]] && prs=$(   cat "$STATUS_CACHE/${rname}_prs"    2>/dev/null || echo "0")
     [[ "$first_repo" == "false" ]] && repos_json+=","
     first_repo=false
     repos_json+="{\"name\":\"$rname\",\"full\":\"$repo\",\"issues\":$issues,\"prs\":$prs}"

--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -190,51 +190,18 @@ secs_to_label() {
 }
 
 # ── Queue depth measurement ──────────────────────────────────────────────────
-# Counts open issues that are not exempt from the actionable queue.
-# Uses REST API (separate 5000 req/hr pool) instead of GraphQL to avoid rate limits.
+# Reads from centralized api-collector cache (written by dashboard/api-collector.sh).
+# Falls back to per-repo cache files if the main cache is missing.
+GITHUB_CACHE="${HIVE_METRICS_DIR:-/var/run/hive-metrics}/github-cache.json"
 
 count_actionable() {
   local repo="$1"
-  local owner="${repo%%/*}"
   local name="${repo##*/}"
   local cache_dir="$STATE_DIR/repo_cache"
-  mkdir -p "$cache_dir" 2>/dev/null || true
-  # Use HIVE_GITHUB_TOKEN if set; otherwise let gh use its stored credentials.
-  # Never unset GITHUB_TOKEN without a replacement — that causes unauthenticated
-  # API calls that hit the 60 req/hr rate limit and return empty results.
-  if [ -n "$HIVE_GITHUB_TOKEN" ]; then
-    unset GITHUB_TOKEN
-    export GH_TOKEN="$HIVE_GITHUB_TOKEN"
-  fi
   local issues prs
 
-  # REST API: list open issues (excludes PRs), filter out exempt labels client-side
-  local issues_json
-  issues_json=$($GH_BIN api "repos/${repo}/issues?state=open&per_page=100" --paginate 2>/dev/null)
-  if [ -n "$issues_json" ]; then
-    issues=$(echo "$issues_json" | jq --arg rx "$EXEMPT_LABEL_REGEX" \
-      '[.[] | select(.pull_request == null) | select(.labels | map(.name) | any(test($rx; "i")) | not)] | length' 2>/dev/null || echo "-1")
-  else
-    issues="-1"
-  fi
-
-  # REST API: list open PRs, filter out exempt labels
-  local prs_json
-  prs_json=$($GH_BIN api "repos/${repo}/pulls?state=open&per_page=100" --paginate 2>/dev/null)
-  if [ -n "$prs_json" ]; then
-    prs=$(echo "$prs_json" | jq --arg rx "$EXEMPT_LABEL_REGEX" \
-      '[.[] | select(.labels | map(.name) | any(test($rx; "i")) | not)] | length' 2>/dev/null || echo "-1")
-  else
-    prs="-1"
-  fi
-
-  # Fall back to cached values when API fails
-  [[ "$issues" == "-1" ]] && issues=$(cat "$cache_dir/${name}_actionable_issues" 2>/dev/null || echo "0")
-  [[ "$prs"    == "-1" ]] && prs=$(   cat "$cache_dir/${name}_actionable_prs"    2>/dev/null || echo "0")
-
-  # Cache successful results
-  [[ "$issues" != "-1" ]] && echo "$issues" > "$cache_dir/${name}_actionable_issues"
-  [[ "$prs"    != "-1" ]] && echo "$prs"    > "$cache_dir/${name}_actionable_prs"
+  issues=$(cat "$cache_dir/${name}_actionable_issues" 2>/dev/null || echo "0")
+  prs=$(cat "$cache_dir/${name}_actionable_prs" 2>/dev/null || echo "0")
 
   echo "${issues} ${prs}"
 }

--- a/dashboard/api-collector.sh
+++ b/dashboard/api-collector.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Centralized GitHub API collector — single script fetches all data, writes to cache.
+# All consumers (governor, dashboard, hive status) read from cache instead of calling
+# the GitHub API independently. Reduces ~340 API calls/hour to ~35.
+#
+# Output: /var/run/hive-metrics/github-cache.json
+# Called by: server.js on a 5-minute cycle
+
+set -euo pipefail
+
+CACHE_DIR="${HIVE_METRICS_DIR:-/var/run/hive-metrics}"
+CACHE_FILE="$CACHE_DIR/github-cache.json"
+CACHE_TMP="$CACHE_DIR/github-cache.tmp.$$"
+mkdir -p "$CACHE_DIR" 2>/dev/null || true
+
+# Source project config if available
+if [[ -f /usr/local/bin/hive-config.sh ]]; then
+  source /usr/local/bin/hive-config.sh 2>/dev/null || true
+fi
+
+REPOS_STR="${HIVE_REPOS:-${PROJECT_REPOS:-kubestellar/console kubestellar/console-kb kubestellar/docs kubestellar/console-marketplace kubestellar/kubestellar-mcp}}"
+IFS=' ' read -ra REPOS <<< "$REPOS_STR"
+
+PRIMARY_REPO="${PROJECT_PRIMARY_REPO:-kubestellar/console}"
+AI_AUTHOR="${PROJECT_AI_AUTHOR:-clubanderson}"
+PROJECT_ORG="${PROJECT_ORG:-kubestellar}"
+PROJECT="${PROJECT_NAME:-KubeStellar}"
+
+EXEMPT_LABEL_REGEX="nightly-tests|LFX|do-not-merge|meta-tracker|auto-qa-tuning-report|hold|adopters|changes-requested|waiting-on-author"
+
+# Auth: use HIVE_GITHUB_TOKEN if set
+if [ -n "${HIVE_GITHUB_TOKEN:-}" ]; then
+  unset GITHUB_TOKEN 2>/dev/null || true
+  export GH_TOKEN="$HIVE_GITHUB_TOKEN"
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# ── Fetch per-repo issue + PR counts (parallel, using gh issue/pr list = GraphQL) ──
+for repo in "${REPOS[@]}"; do
+  rname="${repo##*/}"
+  (
+    issues=$(gh issue list --repo "$repo" --state open --json number --jq 'length' 2>/dev/null || echo "-1")
+    prs=$(gh pr list --repo "$repo" --state open --json number --jq 'length' 2>/dev/null || echo "-1")
+    echo "${issues} ${prs}" > "$tmpdir/repo_${rname}"
+  ) &
+done
+
+# ── Fetch actionable counts (issues excluding exempt labels) ──
+for repo in "${REPOS[@]}"; do
+  rname="${repo##*/}"
+  (
+    # Use gh search which is GraphQL-backed and more reliable than REST /issues
+    actionable_issues=$(gh issue list --repo "$repo" --state open --json "number,labels" \
+      --jq "[.[] | select(.labels | map(.name) | any(test(\"${EXEMPT_LABEL_REGEX}\"; \"i\")) | not)] | length" 2>/dev/null || echo "-1")
+    actionable_prs=$(gh pr list --repo "$repo" --state open --json "number,labels" \
+      --jq "[.[] | select(.labels | map(.name) | any(test(\"${EXEMPT_LABEL_REGEX}\"; \"i\")) | not)] | length" 2>/dev/null || echo "-1")
+    echo "${actionable_issues} ${actionable_prs}" > "$tmpdir/actionable_${rname}"
+  ) &
+done
+
+# ── Fetch primary repo metadata (stars, forks, contributors, adopters) ──
+(gh api "repos/${PRIMARY_REPO}" --jq '.stargazers_count' > "$tmpdir/stars" 2>/dev/null || echo 0 > "$tmpdir/stars") &
+(gh api "repos/${PRIMARY_REPO}" --jq '.forks_count' > "$tmpdir/forks" 2>/dev/null || echo 0 > "$tmpdir/forks") &
+(
+  c=$(gh api "repos/${PRIMARY_REPO}/contributors?per_page=1" -i 2>/dev/null | grep -oP 'page=\K\d+(?=>; rel="last")' || echo 0)
+  [ "$c" = "0" ] && c=$(gh api "repos/${PRIMARY_REPO}/contributors" --jq 'length' 2>/dev/null || echo 0)
+  echo "$c" > "$tmpdir/contribs"
+) &
+(
+  a=$(gh api "repos/${PRIMARY_REPO}/contents/ADOPTERS.MD" --jq '.content' 2>/dev/null | base64 -d 2>/dev/null | grep -cP '^\|.*\|.*\|' || echo 0)
+  a=$(( a > 2 ? a - 2 : 0 ))
+  echo "$a" > "$tmpdir/adopters"
+) &
+
+# ── Fetch ACMM badge count (kubestellar-specific) ──
+if [ "${PROJECT_ORG}" = "kubestellar" ]; then
+  (gh api repos/kubestellar/docs/contents/src/app/%5Blocale%5D/acmm-leaderboard/page.tsx --jq '.content' 2>/dev/null \
+    | base64 -d 2>/dev/null \
+    | sed -n '/BADGE_PARTICIPANTS = new Set/,/\]);/p' \
+    | grep -cP '^\s+"[a-zA-Z]' > "$tmpdir/acmm" 2>/dev/null || echo 0 > "$tmpdir/acmm") &
+else
+  echo 0 > "$tmpdir/acmm" &
+fi
+
+# ── Fetch outreach PR counts ──
+(gh api "search/issues?q=author:${AI_AUTHOR}+type:pr+is:open+${PROJECT}+in:title+-org:${PROJECT_ORG}" --jq '.total_count' > "$tmpdir/outreach_open" 2>/dev/null || echo 0 > "$tmpdir/outreach_open") &
+(gh api "search/issues?q=author:${AI_AUTHOR}+type:pr+is:merged+${PROJECT}+in:title+-org:${PROJECT_ORG}" --jq '.total_count' > "$tmpdir/outreach_merged" 2>/dev/null || echo 0 > "$tmpdir/outreach_merged") &
+
+wait
+
+# ── Assemble JSON ──
+repos_json="["
+first=true
+total_issues=0
+total_prs=0
+total_actionable_issues=0
+total_actionable_prs=0
+
+for repo in "${REPOS[@]}"; do
+  rname="${repo##*/}"
+
+  raw=$(cat "$tmpdir/repo_${rname}" 2>/dev/null || echo "-1 -1")
+  issues="${raw%% *}"
+  prs="${raw##* }"
+
+  araw=$(cat "$tmpdir/actionable_${rname}" 2>/dev/null || echo "-1 -1")
+  ai="${araw%% *}"
+  ap="${araw##* }"
+
+  # Fall back to previous cache if API failed
+  if [[ "$issues" == "-1" ]] && [[ -f "$CACHE_FILE" ]]; then
+    issues=$(jq -r ".repos[] | select(.name == \"$rname\") | .issues // 0" "$CACHE_FILE" 2>/dev/null || echo 0)
+  fi
+  [[ "$issues" == "-1" ]] && issues=0
+
+  if [[ "$prs" == "-1" ]] && [[ -f "$CACHE_FILE" ]]; then
+    prs=$(jq -r ".repos[] | select(.name == \"$rname\") | .prs // 0" "$CACHE_FILE" 2>/dev/null || echo 0)
+  fi
+  [[ "$prs" == "-1" ]] && prs=0
+
+  if [[ "$ai" == "-1" ]] && [[ -f "$CACHE_FILE" ]]; then
+    ai=$(jq -r ".repos[] | select(.name == \"$rname\") | .actionableIssues // 0" "$CACHE_FILE" 2>/dev/null || echo 0)
+  fi
+  [[ "$ai" == "-1" ]] && ai=0
+
+  if [[ "$ap" == "-1" ]] && [[ -f "$CACHE_FILE" ]]; then
+    ap=$(jq -r ".repos[] | select(.name == \"$rname\") | .actionablePrs // 0" "$CACHE_FILE" 2>/dev/null || echo 0)
+  fi
+  [[ "$ap" == "-1" ]] && ap=0
+
+  total_issues=$(( total_issues + issues ))
+  total_prs=$(( total_prs + prs ))
+  total_actionable_issues=$(( total_actionable_issues + ai ))
+  total_actionable_prs=$(( total_actionable_prs + ap ))
+
+  [[ "$first" == "true" ]] && first=false || repos_json+=","
+  repos_json+="{\"name\":\"$rname\",\"full\":\"$repo\",\"issues\":$issues,\"prs\":$prs,\"actionableIssues\":$ai,\"actionablePrs\":$ap}"
+done
+repos_json+="]"
+
+stars=$(cat "$tmpdir/stars" 2>/dev/null || echo 0)
+forks=$(cat "$tmpdir/forks" 2>/dev/null || echo 0)
+contributors=$(cat "$tmpdir/contribs" 2>/dev/null || echo 0)
+adopters=$(cat "$tmpdir/adopters" 2>/dev/null || echo 0)
+acmm=$(cat "$tmpdir/acmm" 2>/dev/null || echo 0)
+outreach_open=$(cat "$tmpdir/outreach_open" 2>/dev/null || echo 0)
+outreach_merged=$(cat "$tmpdir/outreach_merged" 2>/dev/null || echo 0)
+
+now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+cat > "$CACHE_TMP" <<ENDJSON
+{
+  "timestamp": "$now",
+  "repos": $repos_json,
+  "totals": {
+    "issues": $total_issues,
+    "prs": $total_prs,
+    "actionableIssues": $total_actionable_issues,
+    "actionablePrs": $total_actionable_prs
+  },
+  "primary": {
+    "stars": ${stars:-0},
+    "forks": ${forks:-0},
+    "contributors": ${contributors:-0},
+    "adopters": ${adopters:-0},
+    "acmm": ${acmm:-0}
+  },
+  "outreach": {
+    "open": ${outreach_open:-0},
+    "merged": ${outreach_merged:-0}
+  }
+}
+ENDJSON
+
+# Atomic move
+mv "$CACHE_TMP" "$CACHE_FILE"
+
+# Also write governor-compatible cache files for backward compat
+gov_cache="${STATE_DIR:-/var/run/kick-governor}/repo_cache"
+mkdir -p "$gov_cache" 2>/dev/null || true
+for repo in "${REPOS[@]}"; do
+  rname="${repo##*/}"
+  araw=$(cat "$tmpdir/actionable_${rname}" 2>/dev/null || echo "0 0")
+  ai="${araw%% *}"; [[ "$ai" == "-1" ]] && ai=0
+  ap="${araw##* }"; [[ "$ap" == "-1" ]] && ap=0
+  echo "$ai" > "$gov_cache/${rname}_actionable_issues"
+  echo "$ap" > "$gov_cache/${rname}_actionable_prs"
+done
+
+echo "$total_actionable_issues" > "${STATE_DIR:-/var/run/kick-governor}/queue_issues"
+echo "$total_actionable_prs" > "${STATE_DIR:-/var/run/kick-governor}/queue_prs"

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -120,6 +120,16 @@ function fetchAgentMetrics() {
 fetchAgentMetrics();
 setInterval(fetchAgentMetrics, 300000);  // every 5 min (REST API)
 
+// Centralized GitHub API collector — runs once, writes cache read by governor + dashboard
+function fetchGitHubCache() {
+  execFile(path.join(__dirname, 'api-collector.sh'), [], { timeout: 120000 }, (err) => {
+    if (err) console.error('api-collector.sh failed:', err.message);
+  });
+}
+fetchGitHubCache();
+const API_COLLECTOR_INTERVAL_MS = 300000;
+setInterval(fetchGitHubCache, API_COLLECTOR_INTERVAL_MS);
+
 // Fetch agent summaries from ~/.hive/<agent>_status.txt on every status refresh cycle
 function fetchSummaries() {
   execFile(path.join(__dirname, 'agent-summaries.sh'), [], { timeout: 10000 }, (err, stdout) => {
@@ -334,17 +344,15 @@ function fetchStatus() {
 setInterval(fetchStatus, REFRESH_MS);
 fetchStatus();
 
-// Slow refresh for repo data (GH API) — every 5min to reduce GH token spend
-const REPO_REFRESH_MS = 300000;
+// Repo data — read from centralized api-collector cache (no additional GH API calls)
+const REPO_REFRESH_MS = 60000;
+const GITHUB_CACHE_PATH = path.join(process.env.HIVE_METRICS_DIR || '/var/run/hive-metrics', 'github-cache.json');
 function fetchRepoStatus() {
-  const hiveEnv = { ...process.env, HIVE_TZ: process.env.HIVE_TZ || 'America/New_York' };
-  execFile('/usr/local/bin/hive', ['status', '--json', '--repos'], { timeout: 30000, env: hiveEnv }, (err, stdout) => {
-    if (err) { console.error('hive status --json --repos failed:', err.message); return; }
-    try {
-      const data = JSON.parse(stdout);
-      if (statusCache && data.repos) statusCache.repos = data.repos;
-    } catch (_) {}
-  });
+  try {
+    const raw = fs.readFileSync(GITHUB_CACHE_PATH, 'utf8');
+    const data = JSON.parse(raw);
+    if (statusCache && data.repos) statusCache.repos = data.repos;
+  } catch (_) {}
 }
 setInterval(fetchRepoStatus, REPO_REFRESH_MS);
 fetchRepoStatus();


### PR DESCRIPTION
## Summary
- New `dashboard/api-collector.sh` fetches all GitHub data once per 5-min cycle using `gh issue/pr list` (GraphQL — resilient to REST API outages like today's)
- Writes to `/var/run/hive-metrics/github-cache.json` + governor-compatible per-repo cache files
- **Governor** now reads from cache instead of calling REST API (which was returning 0 issues due to outage + broken token)
- **`hive status --repos`** reads from cache instead of calling `gh issue/pr list` per repo
- **Dashboard** reads repo data from cache file instead of spawning `hive status --json --repos`
- Reduces ~340 API calls/hour to ~35 (one collector run per 5 min)

## Root cause of 0-issue bug
1. Governor used REST `/issues` endpoint which returns issues+PRs mixed — during GitHub outages, returns empty `[]`
2. The `HIVE_GITHUB_TOKEN` PAT in governor.env was a fine-grained token that lacked issue read permission
3. Collector now uses `gh issue list` (GraphQL search) which works even during REST API outages

## Test plan
- [ ] Deploy to dev server, verify `api-collector.sh` writes cache
- [ ] Verify governor reads correct issue count from cache
- [ ] Verify dashboard Repositories section shows correct data from cache
- [ ] Verify during GitHub outage: cache fallback returns last-known-good values