### PR TITLE
fix: governor uses process detection for CLI pin

### DIFF
--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -160,6 +160,23 @@ log() {
   echo "$msg" >> "$LOG_FILE" 2>/dev/null || true
 }
 
+detect_running_backend() {
+  local session="$1"
+  local pane_pid
+  pane_pid=$(tmux display-message -t "$session" -p '#{pane_pid}' 2>/dev/null) || return 1
+  local cmdline
+  cmdline=$(ps -o args= --ppid "$pane_pid" 2>/dev/null | head -1) || return 1
+  if echo "$cmdline" | grep -q '/copilot\b\|^copilot\b'; then
+    echo "copilot"
+  elif echo "$cmdline" | grep -q '/gemini\b\|^gemini\b'; then
+    echo "gemini"
+  elif echo "$cmdline" | grep -q '/claude\b\|^claude\b'; then
+    echo "claude"
+  else
+    return 1
+  fi
+}
+
 ntfy() {
   # Legacy wrapper — maps old 4-arg ntfy() calls to notify()
   # ntfy <priority> <title> <body> <tags>
@@ -531,9 +548,12 @@ optimize_model_assignment() {
 
     if [[ "$gov_pin_cli" == "1" ]]; then
       local pinned_backend
-      pinned_backend=$(grep '^BACKEND=' "$STATE_DIR/model_${agent}" 2>/dev/null | cut -d= -f2 || true)
+      pinned_backend=$(detect_running_backend "$agent" 2>/dev/null || true)
+      if [[ -z "$pinned_backend" ]]; then
+        pinned_backend=$(grep '^BACKEND=' "$STATE_DIR/model_${agent}" 2>/dev/null | cut -d= -f2 || true)
+      fi
       if [[ -n "$pinned_backend" && "$pinned_backend" != "$backend" ]]; then
-        log "  PIN_CLI: $agent backend pinned to $pinned_backend, overriding $backend"
+        log "  PIN_CLI: $agent backend pinned to $pinned_backend (from process), overriding $backend"
         backend="$pinned_backend"
       fi
     fi

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -567,6 +567,8 @@ app.post('/api/switch/:agent/:backend', (req, res) => {
   } catch (e) {
     return res.status(500).json({ error: `failed to write model file: ${e.message}` });
   }
+  // Keep backend state file in sync for kick-agents.sh
+  try { fs.writeFileSync(`/var/run/agent-backends/${agent}`, backend); } catch (_) {}
   execFile('/tmp/hive/bin/kick-agents.sh', [agent], { timeout: 60000 }, (err, stdout) => {
     if (err) return res.status(500).json({ error: err.message });
     res.json({ ok: true, output: `switched ${agent} backend to ${backend}` });
@@ -628,6 +630,9 @@ app.post('/api/model/:agent/:model', (req, res) => {
   } catch (e) {
     return res.status(500).json({ error: `failed to write model file: ${e.message}` });
   }
+  // Keep backend state file in sync for kick-agents.sh
+  const BACKEND_STATE_DIR = '/var/run/agent-backends';
+  try { fs.writeFileSync(`${BACKEND_STATE_DIR}/${agent}`, currentBackend); } catch (_) {}
   execFile('/tmp/hive/bin/kick-agents.sh', [agent], { timeout: 60000 }, (err, stdout) => {
     if (err) return res.status(500).json({ error: err.message });
     res.json({ ok: true, output: `switched ${agent} model to ${decodedModel} (backend: ${currentBackend})` });


### PR DESCRIPTION
## Summary
- Governor was reading pinned backend from the model file it was about to overwrite — circular dependency that always reflected governor's own last assignment instead of what's actually running
- Added `detect_running_backend()` to governor — checks tmux pane's child process binary (copilot/claude/gemini)
- Dashboard `/api/model` and `/api/switch` now sync `/var/run/agent-backends/<agent>` for kick-agents.sh consistency
- Fixes: user pins copilot CLI, governor next cycle overwrites model file with `BACKEND=claude`, pin becomes meaningless

## Test plan
- [ ] Pin supervisor CLI to copilot, switch model — verify governor preserves copilot in model file
- [ ] Run 7-model rotation test on supervisor with CLI pinned
- [ ] Verify governor log shows "from process" in PIN_CLI messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)