### PR TITLE
fix: normalize model version format per backend in agent-launch.sh

### DIFF
--- a/bin/agent-launch.sh
+++ b/bin/agent-launch.sh
@@ -86,6 +86,17 @@ esac
 
 FULL_CMD=("$CMD" "$PERM_FLAG")
 if [[ -n "$MODEL" ]]; then
+  # Normalize model version format: claude uses hyphens (4-5), copilot uses dots (4.5)
+  case "$BACKEND" in
+    copilot)
+      # claude-haiku-4-5 → claude-haiku-4.5 (last hyphen before final digit becomes dot)
+      MODEL=$(echo "$MODEL" | sed -E 's/([0-9]+)-([0-9]+)$/\1.\2/')
+      ;;
+    claude)
+      # claude-haiku-4.5 → claude-haiku-4-5 (dot in version becomes hyphen)
+      MODEL=$(echo "$MODEL" | sed -E 's/([0-9]+)\.([0-9]+)$/\1-\2/')
+      ;;
+  esac
   FULL_CMD+=("$MODEL_FLAG" "$MODEL")
 fi
 if [[ ${#EXTRA_ARGS[@]} -gt 0 ]]; then


### PR DESCRIPTION
## Summary
- Copilot uses dots in model versions (`claude-haiku-4.5`), claude uses hyphens (`claude-haiku-4-5`)
- Without normalization, copilot silently falls back to default model when given hyphen format
- `agent-launch.sh` is the single normalization point — all other code uses canonical hyphen format
- Fixes: switch supervisor to copilot+haiku via dashboard → copilot ignores `claude-haiku-4-5` and runs Sonnet 4.6

## Test plan
- [ ] Switch supervisor to copilot+haiku → verify copilot status bar shows Haiku, not Sonnet
- [ ] Switch to claude+haiku → verify claude uses hyphen format
- [ ] Run full 7-model rotation test

🤖 Generated with [Claude Code](https://claude.com/claude-code)