### PR TITLE
fix: model format mismatch triggers restart

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -667,12 +667,8 @@ apply_model_if_changed() {
     fi
   fi
 
-  # Normalize model names for comparison (dots vs hyphens)
-  local norm_gov norm_cur
-  norm_gov=$(echo "$gov_model" | sed -E 's/([0-9])\.([0-9])/\1-\2/g')
-  norm_cur=$(echo "$cur_model" | sed -E 's/([0-9])\.([0-9])/\1-\2/g')
-
-  if [[ "$cur_backend" == "$gov_backend" && "$norm_cur" == "$norm_gov" ]]; then
+  # Compare exact model strings — format matters (copilot needs dots, claude needs hyphens)
+  if [[ "$cur_backend" == "$gov_backend" && "$cur_model" == "$gov_model" ]]; then
     return 0
   fi
 

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -629,7 +629,14 @@ app.post('/api/model/:agent/:model', (req, res) => {
       currentBackend = 'gemini';
     }
   }
-  const newContent = `BACKEND=${currentBackend}\nMODEL=${decodedModel}\n`;
+  // Normalize model version format for the target backend
+  let normalizedModel = decodedModel;
+  if (currentBackend === 'copilot') {
+    normalizedModel = decodedModel.replace(/(\d+)-(\d+)$/, '$1.$2');
+  } else if (currentBackend === 'claude') {
+    normalizedModel = decodedModel.replace(/(\d+)\.(\d+)$/, '$1-$2');
+  }
+  const newContent = `BACKEND=${currentBackend}\nMODEL=${normalizedModel}\n`;
   const modelFile = path.join(GOVERNOR_STATE_DIR, `model_${agent}`);
   try {
     fs.writeFileSync(modelFile, newContent);


### PR DESCRIPTION
## Summary
- Dashboard normalizes model names to backend-native format when writing governor model file (copilot→dots, claude→hyphens)
- kick-agents.sh uses exact string comparison instead of normalizing both to hyphens
- Format mismatch (running `claude-haiku-4-5` but governor says `claude-haiku-4.5`) now triggers restart
- Fixes: copilot silently falls back to Sonnet 4.6 when given hyphen-format model names

## Test plan
- [ ] Switch supervisor (copilot) model to haiku → verify copilot shows Haiku in status bar, not Sonnet
- [ ] Run 7-model rotation on supervisor
- [ ] Verify claude backend still works with hyphen format

🤖 Generated with [Claude Code](https://claude.com/claude-code)