### PR TITLE
fix: move pin icon inside model chip pill

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -710,7 +710,7 @@
         return `<div class="agent-card ${cls}">
           <div class="agent-name"><span class="dot ${dotCls}"></span>${a.name} ${toggleBtn} <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a></div>
           <div class="agent-field"><span class="label">cli</span><span class="value">${cliChip(a.cli, a.pinnedBoth || a.pinnedCli)} <button class="pin-toggle" onclick="togglePin('${a.name}', 'cli', ${!!(a.pinnedBoth || a.pinnedCli)})" title="${(a.pinnedBoth || a.pinnedCli) ? 'Unpin CLI — let governor change backend' : 'Pin CLI — lock current backend'}">${(a.pinnedBoth || a.pinnedCli) ? '🔓' : '📌'}</button></span></div>
-          <div class="agent-field"><span class="label">model</span><span class="value">${modelChip(a.model, a.govReason)}${(a.pinnedBoth || a.pinnedModel) ? ' 📌' : ''} <button class="pin-toggle" onclick="togglePin('${a.name}', 'model', ${!!(a.pinnedBoth || a.pinnedModel)})" title="${(a.pinnedBoth || a.pinnedModel) ? 'Unpin model — let governor change model' : 'Pin model — lock current model'}">${(a.pinnedBoth || a.pinnedModel) ? '🔓' : '📌'}</button></span></div>
+          <div class="agent-field"><span class="label">model</span><span class="value">${modelChip(a.model, a.govReason, a.pinnedBoth || a.pinnedModel)} <button class="pin-toggle" onclick="togglePin('${a.name}', 'model', ${!!(a.pinnedBoth || a.pinnedModel)})" title="${(a.pinnedBoth || a.pinnedModel) ? 'Unpin model — let governor change model' : 'Pin model — lock current model'}">${(a.pinnedBoth || a.pinnedModel) ? '🔓' : '📌'}</button></span></div>
           <div class="agent-field"><span class="label">interval</span><span class="value">${isPaused ? 'paused' : a.cadence}</span></div>
           <div class="agent-field"><span class="label">last run</span><span class="value">${a.lastKick || '—'}</span></div>
           <div class="agent-field"><span class="label">next run</span><span class="value">${isPaused ? 'paused' : (a.nextKick || '—')}</span></div>
@@ -865,9 +865,8 @@
         const cliPinned = agentData && (agentData.pinnedBoth || agentData.pinnedCli);
         const modelPinned = agentData && (agentData.pinnedBoth || agentData.pinnedModel);
         const cChip = agentData && agentData.cli ? cliChip(agentData.cli, cliPinned) : '?';
-        const mChip = agentData && agentData.model ? modelChip(agentData.model, agentData.govReason) : '';
-        const mPin = modelPinned ? ' 📌' : '';
-        return `<tr><td>${nameDot}${aname}${pauseBadge}</td>${cells}<td>${cChip}</td><td>${mChip}${mPin}</td></tr>`;
+        const mChip = agentData && agentData.model ? modelChip(agentData.model, agentData.govReason, modelPinned) : '';
+        return `<tr><td>${nameDot}${aname}${pauseBadge}</td>${cells}<td>${cChip}</td><td>${mChip}</td></tr>`;
       }).join('');
       const headers = modes.map(m => {
         const isActive = m === currentMode;
@@ -966,7 +965,7 @@
       return ` <span class="model-chip ${tier}" title="billing: ${backend}">${backend}</span>`;
     }
 
-    function modelChip(model, reason) {
+    function modelChip(model, reason, pinned) {
       if (!model || model === '?' || model === 'unknown') return '?';
       // Normalize: "Claude Opus 4.6" → "claude-opus-4-6", "Opus 4.6" → "opus-4.6"
       const normalized = model.toLowerCase().replace(/\s+/g, '-');
@@ -978,7 +977,9 @@
       const isBudgetOverride = reason && (reason.includes('budget_downgrade') || reason.includes('budget_critical'));
       const overrideIcon = isBudgetOverride ? ' ⬇' : '';
       const overrideTitle = isBudgetOverride ? ` (${reason})` : '';
-      return `<span class="model-chip ${tier}" title="${model}${overrideTitle}">${shortModel}${overrideIcon}</span>`;
+      const pin = pinned ? ' \u{1F4CC}' : '';
+      const pinTitle = pinned ? ' (pinned)' : '';
+      return `<span class="model-chip ${tier}" title="${model}${overrideTitle}${pinTitle}">${shortModel}${overrideIcon}${pin}</span>`;
     }
 
     function buildCadenceAdvisor(byAgent) {


### PR DESCRIPTION
## Summary
- Pin 📌 icon now renders inside the model chip (green/blue pill), consistent with CLI chip
- Previously the pin appeared outside the pill, visually disconnected

## Test plan
- [ ] Pin model for any agent — verify 📌 appears inside the colored pill
- [ ] Verify CLI pin still shows inside its pill

🤖 Generated with [Claude Code](https://claude.com/claude-code)