### PR TITLE
Fix bd commands + add beads health check to supervisor

### DIFF
--- a/examples/kubestellar/agents/architect-CLAUDE.md
+++ b/examples/kubestellar/agents/architect-CLAUDE.md
@@ -89,7 +89,7 @@ The dashboard shows your current work to the operator. It reads your in-progress
 
 ```bash
 # At pass start
-cd /home/dev/architect-beads && bd add --in-progress "Architect: implementing container-query rollout for #8695"
+cd /home/dev/architect-beads && bd create --title "Architect: implementing container-query rollout for #8695" --type task --status in_progress
 
 # As work progresses — update title to reflect current action
 cd /home/dev/architect-beads && bd update <bead_id> --title "Architect: PR #10051 opened, waiting for CI"

--- a/examples/kubestellar/agents/outreach-CLAUDE.md
+++ b/examples/kubestellar/agents/outreach-CLAUDE.md
@@ -267,7 +267,7 @@ The dashboard shows your current work to the operator. It reads your in-progress
 
 ```bash
 # At pass start
-cd /home/dev/outreach-beads && bd add --in-progress "Outreach: scanning open PRs for review feedback"
+cd /home/dev/outreach-beads && bd create --title "Outreach: scanning open PRs for review feedback" --type task --status in_progress
 
 # As work progresses — update title to reflect current action
 cd /home/dev/outreach-beads && bd update <bead_id> --title "Outreach: opening PR on awesome-kubernetes"

--- a/examples/kubestellar/agents/reviewer-CLAUDE.md
+++ b/examples/kubestellar/agents/reviewer-CLAUDE.md
@@ -132,7 +132,7 @@ Send simple ntfy: `"Coverage <X>% ✓"`. No further action needed.
 - **Target the biggest gaps first**: sort by uncovered lines, pick 2–5 files with the worst coverage.
 - File a bead if coverage has been below 91% for >2 consecutive passes:
   ```bash
-  cd ~/reviewer-beads && bd add "coverage-gap" "Test coverage below 91% for <N> consecutive passes. Current: <X>%. Files needing tests: <list>"
+  cd ~/reviewer-beads && bd create --title "coverage-gap: Test coverage below 91% for <N> consecutive passes. Current: <X>%." --type bug --priority 2
   ```
 
 ## Brew Formula Check — every pass
@@ -204,7 +204,7 @@ The dashboard shows your current work to the operator. It reads your in-progress
 
 ```bash
 # At pass start
-cd /home/dev/reviewer-beads && bd add --in-progress "Reviewing: checking CI health and coverage"
+cd /home/dev/reviewer-beads && bd create --title "Reviewing: checking CI health and coverage" --type task --status in_progress
 
 # As work progresses — update title to reflect current action
 cd /home/dev/reviewer-beads && bd update <bead_id> --title "Reviewing: PR #10050 CI green, merging"

--- a/examples/kubestellar/agents/supervisor-CLAUDE.md
+++ b/examples/kubestellar/agents/supervisor-CLAUDE.md
@@ -372,7 +372,7 @@ The dashboard shows your current work to the operator. It reads your in-progress
 
 ```bash
 # At pass start — create or update your in-progress bead
-cd /home/dev/supervisor-beads && bd add --in-progress "Monitoring pass: checking agent health, CI, PRs"
+cd /home/dev/supervisor-beads && bd create --title "Monitoring pass: checking agent health, CI, PRs" --type task --status in_progress
 
 # As work progresses — update the title to reflect current action
 cd /home/dev/supervisor-beads && bd update <bead_id> --title "Monitoring: dispatching scanner to fix #9999"

--- a/examples/kubestellar/agents/supervisor-CLAUDE.md
+++ b/examples/kubestellar/agents/supervisor-CLAUDE.md
@@ -38,6 +38,46 @@ When started with `hive supervisor` or when the session is named `supervisor`, i
 9. **Kick idle agents** with FULL startup messages (from kick-agents.sh) — never bare work orders.
 10. **Report status** to operator.
 
+## Beads Health Check — MANDATORY on every pass
+
+Beads is the coordination ledger. If any agent's beads DB is broken, that agent flies blind and skips work tracking. **Check ALL 5 beads DBs on every monitoring pass.**
+
+```bash
+for agent in scanner reviewer architect outreach supervisor; do
+  printf "%-12s " "$agent"
+  cd /home/dev/${agent}-beads 2>/dev/null && bd status 2>&1 | grep "Total Issues" || echo "BROKEN"
+done
+```
+
+**If any agent shows BROKEN:**
+
+1. Check if `.beads/metadata.json` exists and has a `dolt_database` field matching the dir name (`<agent>_beads`):
+   ```bash
+   cat /home/dev/<agent>-beads/.beads/metadata.json
+   ```
+   If missing, recreate from a working agent's metadata.json — change `dolt_database` to `<agent>_beads` and `project_id` to match the embedded dolt DB (check with `bd context --json` or look at the embeddeddolt subdir name).
+
+2. Check permissions — all files under `.beads/` must be owned by `dev:dev`:
+   ```bash
+   sudo chown -R dev:dev /home/dev/<agent>-beads/.beads/
+   ```
+
+3. Check if `.beads/config.yaml` exists — if missing, copy from a working agent:
+   ```bash
+   cp /home/dev/outreach-beads/.beads/config.yaml /home/dev/<agent>-beads/.beads/config.yaml
+   ```
+
+4. After fixing, verify: `cd /home/dev/<agent>-beads && bd status`
+
+5. **Kick the affected agent** with a full startup message so it re-reads beads on next pass.
+
+6. Send high-priority ntfy: `"Beads DB repaired for <agent> — was broken since <last known good time>"`
+
+**Root causes to watch for:**
+- `git rebase --abort` or `git stash drop` in the beads dir can delete tracked files
+- `sudo` operations (e.g. supervisor-kick.sh) create root-owned files agents can't read
+- An agent pulling `/tmp/hive` into the beads dir by mistake (beads repos are local-only, no remote)
+
 ## Architecture
 
 ```


### PR DESCRIPTION
## Summary
- Replace stale `bd add` → `bd create` in 4 agent CLAUDE.md files (bd 1.0.x API change)
- Add mandatory beads health check section to supervisor CLAUDE.md with repair instructions
- Documents root causes: metadata.json deletion, root-owned files, wrong git remote in beads dir

## Context
Scanner beads DB was broken (missing metadata.json, empty config.yaml) causing scanner to skip beads entirely and fly blind. Supervisor had root-owned files blocking access. Both fixed on the live system; this PR codifies the health check so supervisor catches it automatically.

## Files changed
- `examples/kubestellar/agents/architect-CLAUDE.md` — bd add → bd create
- `examples/kubestellar/agents/outreach-CLAUDE.md` — bd add → bd create
- `examples/kubestellar/agents/reviewer-CLAUDE.md` — bd add → bd create (2 instances)
- `examples/kubestellar/agents/supervisor-CLAUDE.md` — bd add → bd create + new beads health check section