### PR TITLE
Add in-progress issue pills and restart reset button

### DIFF
--- a/dashboard/agent-metrics.sh
+++ b/dashboard/agent-metrics.sh
@@ -52,6 +52,22 @@ if command -v gh &>/dev/null; then
     ($p.body | match("(?i)(fixes|closes|resolves) #([0-9]+)"; "g") // null) as $m |
     if $m then { issue: ($m.captures[1].string | tonumber), pr: $p.pr, prTitle: $p.title, state: $p.state, created: ($p.created // null), merged: ($p.merged // null) } else empty end
   ]' 2>/dev/null || echo "[]")
+  # ── In-progress issues: mentioned in scanner tmux but no PR yet ──
+  scanner_tmux=$(tmux capture-pane -t scanner -p -S -200 2>/dev/null || echo "")
+  dispatched_issues=$(echo "$scanner_tmux" | grep -oP '#\K\d{4,5}' | sort -un)
+  pr_issues=$(echo "$scanner_pairs_json" | jq -r '.[].issue' 2>/dev/null | sort -un)
+  in_progress_issues=$(comm -23 <(echo "$dispatched_issues") <(echo "$pr_issues") 2>/dev/null | head -10)
+  scanner_inprogress_json="[]"
+  if [ -n "$in_progress_issues" ]; then
+    ip_tmp=$(mktemp -d)
+    for inum in $in_progress_issues; do
+      (gh api "repos/${REPO}/issues/${inum}" --jq '{number: .number, title: .title, state: .state}' > "$ip_tmp/$inum" 2>/dev/null || echo "{\"number\":$inum,\"title\":\"\",\"state\":\"open\"}" > "$ip_tmp/$inum") &
+    done
+    wait
+    scanner_inprogress_json=$(for inum in $in_progress_issues; do cat "$ip_tmp/$inum" 2>/dev/null; done | jq -s '[.[] | select(.state == "open")]' 2>/dev/null || echo "[]")
+    rm -rf "$ip_tmp"
+  fi
+
   # Enrich with issue titles (parallel fetch)
   if [ "$scanner_pairs_json" != "[]" ]; then
     issue_tmp=$(mktemp -d)
@@ -77,7 +93,7 @@ if command -v gh &>/dev/null; then
 fi
 
 # Build agent JSON with live summaries and model
-scanner_json=$(jq -n --arg doing "$scanner_doing" --arg model "$scanner_model" --argjson pairs "$scanner_pairs_json" '{doing: $doing, model: $model, pairs: $pairs}')
+scanner_json=$(jq -n --arg doing "$scanner_doing" --arg model "$scanner_model" --argjson pairs "$scanner_pairs_json" --argjson inProgress "$scanner_inprogress_json" '{doing: $doing, model: $model, pairs: $pairs, inProgress: $inProgress}')
 reviewer_json=$(jq -n --arg doing "$reviewer_doing" --arg model "$reviewer_model" '{doing: $doing, model: $model}')
 architect_json=$(jq -n --arg doing "$architect_doing" --arg model "$architect_model" '{doing: $doing, model: $model}')
 outreach_json=$(jq -n --arg doing "$outreach_doing" --arg model "$outreach_model" '{doing: $doing, model: $model}')

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -62,6 +62,8 @@
     .restart-warn { color: var(--yellow); }
     .restart-high { color: var(--red); }
     .restart-spark { display: inline-block; margin-left: 6px; vertical-align: middle; }
+    .restart-reset { cursor: pointer; font-size: 0.55rem; color: var(--muted); background: none; border: 1px solid var(--border); border-radius: 3px; padding: 0 4px; margin-left: 4px; vertical-align: middle; transition: all 0.2s; }
+    .restart-reset:hover { color: var(--text); border-color: var(--text); }
     .value.idle { color: var(--muted); }
     .value.copilot { color: var(--cyan); }
     .value.claude { color: var(--purple); }
@@ -285,6 +287,8 @@
     .ind-pr:hover { background: rgba(138,99,210,0.3); }
     .ind-merged { background: rgba(63,185,80,0.15); color: #3fb950; border-color: rgba(63,185,80,0.3); }
     .ind-merged:hover { background: rgba(63,185,80,0.3); }
+    .ind-wip { background: rgba(210,153,34,0.15); color: #d29922; border-color: rgba(210,153,34,0.3); }
+    .ind-wip:hover { background: rgba(210,153,34,0.3); }
     .ind-arrow { color: var(--muted); font-size: 0.7rem; }
     .ind-dots { display: flex; flex-wrap: wrap; gap: 8px; }
     .ind-dot-item { display: flex; align-items: center; gap: 3px; }
@@ -512,7 +516,7 @@
 
       if (name === 'scanner') {
         const pairs = m.pairs || [];
-        if (pairs.length === 0) return '<div class="agent-indicators"><span class="ind-empty">no active fixes</span></div>';
+        const inProgress = m.inProgress || [];
         const openPairs = pairs.filter(p => p.state !== 'merged');
         const mergedPairs = pairs.filter(p => p.state === 'merged');
         const renderPair = (p) => {
@@ -527,8 +531,16 @@
           <a class="ind-tag ${prCls}" href="https://github.com/kubestellar/console/pull/${p.pr}" target="_blank" title="${prTip}">${prIcon} #${p.pr}</a>
         </div>`;
         };
+        const renderWip = (ip) => {
+          const title = ip.title ? esc(ip.title.length > 48 ? ip.title.slice(0, 48) + '…' : ip.title) : '';
+          const label = title ? `⏳ #${ip.number} — ${title}` : `⏳ #${ip.number}`;
+          return `<div class="ind-pair">
+          <a class="ind-tag ind-wip" href="https://github.com/kubestellar/console/issues/${ip.number}" target="_blank" title="${ip.title ? esc(ip.title) : ''}">${label}</a>
+        </div>`;
+        };
         let html = '';
-        if (openPairs.length > 0) html += `<div class="agent-indicators"><span class="ind-label">In progress (${openPairs.length}):</span>${openPairs.map(renderPair).join('')}</div>`;
+        if (inProgress.length > 0) html += `<div class="agent-indicators"><span class="ind-label">Working on (${inProgress.length}):</span>${inProgress.map(renderWip).join('')}</div>`;
+        if (openPairs.length > 0) html += `<div class="agent-indicators"><span class="ind-label">PR open (${openPairs.length}):</span>${openPairs.map(renderPair).join('')}</div>`;
         if (mergedPairs.length > 0) html += `<div class="agent-indicators"><span class="ind-label">Merged today (${mergedPairs.length}):</span>${mergedPairs.map(renderPair).join('')}</div>`;
         if (!html) html = '<div class="agent-indicators"><span class="ind-empty">no active fixes</span></div>';
         return html;
@@ -715,7 +727,7 @@
           <div class="agent-field"><span class="label">last run</span><span class="value">${a.lastKick || '—'}</span></div>
           <div class="agent-field"><span class="label">next run</span><span class="value">${isPaused ? 'paused' : (a.nextKick || '—')}</span></div>
           ${agentTokenRow(a.name, a.cadence)}
-          <div class="agent-field"><span class="label">restarts</span><span class="value${(a.restarts || 0) > 5 ? ' restart-high' : (a.restarts || 0) > 0 ? ' restart-warn' : ''}">${a.restarts || 0}<span class="restart-label">24h</span><span class="restart-spark">${restartSparkSvg(a.name)}</span></span></div>
+          <div class="agent-field"><span class="label">restarts</span><span class="value${(a.restarts || 0) > 5 ? ' restart-high' : (a.restarts || 0) > 0 ? ' restart-warn' : ''}">${a.restarts || 0}<span class="restart-label">24h</span>${(a.restarts || 0) > 0 ? `<button class="restart-reset" onclick="resetRestarts('${a.name}')" title="Reset restart counter">✕</button>` : ''}<span class="restart-spark">${restartSparkSvg(a.name)}</span></span></div>
           <div class="agent-state ${isPaused ? 'paused' : a.busy}">${isPaused ? 'paused' : a.busy}</div>
           ${needsLogin ? '<div class="login-warning">⚠ NOT LOGGED IN — run /login</div>' : ''}
           ${summaryEl}${indEl}
@@ -1377,6 +1389,13 @@ function intensityGauge() {
       const data = await res.json();
       if (!data.ok) { showToast(`${action} failed: ` + (data.error || 'unknown'), 'error'); return; }
       showToast(`${agent} ${action}d`, 'success');
+    }
+
+    async function resetRestarts(agent) {
+      const res = await fetch(`/api/reset-restarts/${agent}`, { method: 'POST' });
+      const data = await res.json();
+      if (!data.ok) { showToast('Reset failed: ' + (data.error || 'unknown'), 'error'); return; }
+      showToast(`${agent} restart counter reset`, 'success');
     }
 
     async function switchCli(agent, backend) {

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -811,6 +811,25 @@ app.post('/api/unpin/:agent{/:dimension}', (req, res) => {
   }
 });
 
+// Reset restart counter for an agent
+app.post('/api/reset-restarts/:agent', (req, res) => {
+  const agent = req.params.agent;
+  const allowed = ['scanner', 'reviewer', 'architect', 'outreach', 'supervisor'];
+  if (!allowed.includes(agent)) {
+    return res.status(400).json({ error: `invalid agent: ${agent}` });
+  }
+  const restartFile = path.join(GOVERNOR_STATE_DIR, `restarts_${agent}`);
+  try {
+    if (fs.existsSync(restartFile)) {
+      const { execSync } = require('child_process');
+      execSync(`sudo truncate -s 0 ${restartFile}`);
+    }
+    res.json({ ok: true, output: `${agent} restart counter reset` });
+  } catch (e) {
+    res.status(500).json({ error: `failed to reset: ${e.message}` });
+  }
+});
+
 // Token usage
 app.get('/api/tokens', (_req, res) => {
   res.json(tokenCache || { error: 'no data yet' });


### PR DESCRIPTION
## Summary
- Scanner card now shows **Working on** pills (yellow ⏳) for issues actively being worked by sub-agents that don't have a PR yet — parsed from scanner tmux output
- Issues with open PRs show as **PR open**, merged ones as **Merged today** (unchanged)
- All agent cards now have a **✕ reset** button next to the restart counter when count > 0
- New API endpoint: `POST /api/reset-restarts/:agent` — truncates the restart tracking file

## Files changed
- `dashboard/agent-metrics.sh` — parse scanner tmux for dispatched issue numbers, fetch titles, output as `inProgress` array
- `dashboard/server.js` — add `/api/reset-restarts/:agent` endpoint
- `dashboard/public/index.html` — add `.ind-wip` style, `renderWip()` for in-progress pills, `resetRestarts()` JS function, reset button in restart row