### PR TITLE
Agent efficiency: verification gates, model tiering, status protocol

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -699,7 +699,24 @@ apply_model_if_changed() {
     return 0
   fi
 
-  log "MODEL SWITCH $agent: ${cur_backend}:${cur_model} → ${gov_backend}:${gov_model} (agent idle, restarting)"
+  # Same backend, different model — use in-place /model command (no restart needed)
+  if [[ "$cur_backend" == "$gov_backend" ]]; then
+    log "MODEL IN-PLACE $agent: ${cur_model} → ${gov_model} (same backend, using /model command)"
+    $TMUX_BIN send-keys -t "$session" Escape 2>/dev/null || true
+    sleep 0.5
+    $TMUX_BIN send-keys -t "$session" -l "/model ${gov_model}" 2>/dev/null || true
+    sleep 0.3
+    $TMUX_BIN send-keys -t "$session" Enter 2>/dev/null || true
+    sleep 2
+
+    BACKEND_MODEL[$gov_backend]="$gov_model"
+    AGENT_MODEL_OVERRIDE["${agent}-${gov_backend}"]="$gov_model"
+    log "MODEL IN-PLACE $agent — sent /model ${gov_model}, no restart needed"
+    return 0
+  fi
+
+  # Different backend — full restart required
+  log "MODEL SWITCH $agent: ${cur_backend}:${cur_model} → ${gov_backend}:${gov_model} (backend change, restarting)"
   record_restart "$session"
 
   capture_handoff_state "$session" "$agent"

--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -579,6 +579,10 @@ optimize_model_assignment() {
     prev_backend=$(grep '^BACKEND=' "$STATE_DIR/model_${agent}" 2>/dev/null | cut -d= -f2 || true)
     prev_model=$(grep '^MODEL=' "$STATE_DIR/model_${agent}" 2>/dev/null | cut -d= -f2 || true)
 
+    if [[ "$prev_backend" == "$backend" && "$prev_model" == "$model" ]]; then
+      continue
+    fi
+
     cat > "$STATE_DIR/model_${agent}" <<MODELEOF
 BACKEND=$backend
 MODEL=$model
@@ -589,7 +593,7 @@ PREV_MODEL=${prev_model:-}
 UPDATED=$(date -Iseconds)
 MODELEOF
 
-    if [[ -n "$prev_backend" && ("$prev_backend" != "$backend" || "$prev_model" != "$model") ]]; then
+    if [[ -n "$prev_backend" ]]; then
       log "MODEL CHANGE ${agent}: ${prev_backend}:${prev_model} -> ${backend}:${model}"
     fi
   done
@@ -729,6 +733,50 @@ for _fa in scanner reviewer supervisor architect outreach; do
       log "STUCK ${_fa} — buffer frozen (${#_after2} chars), flagging for restart"
       touch "$STATE_DIR/needs_restart_${_fa}"
     fi
+  fi
+done
+
+# ── Stale-status escalation ─────────────────────────────────────────────────
+# Check each agent's status file. If UPDATED is >20 min stale and STATUS is
+# not DONE/DONE_WITH_CONCERNS, flag as stuck.
+STALE_THRESHOLD_SEC=1200  # 20 minutes
+STUCK_COUNT_FILE="$STATE_DIR/stuck_counts"
+touch "$STUCK_COUNT_FILE" 2>/dev/null || true
+
+for _sa in scanner reviewer architect outreach supervisor; do
+  [[ -f "$STATE_DIR/paused_${_sa}" ]] && continue
+  _status_file="$HOME/.hive/${_sa}_status.txt"
+  [[ ! -f "$_status_file" ]] && continue
+
+  _sa_status=$(grep '^STATUS=' "$_status_file" 2>/dev/null | cut -d= -f2 || true)
+  _sa_updated=$(grep '^UPDATED=' "$_status_file" 2>/dev/null | cut -d= -f2 || true)
+
+  [[ -z "$_sa_updated" ]] && continue
+  [[ "$_sa_status" == "DONE" || "$_sa_status" == "DONE_WITH_CONCERNS" ]] && continue
+
+  _sa_epoch=$(date -d "$_sa_updated" +%s 2>/dev/null || echo 0)
+  _now_epoch=$(date +%s)
+  _sa_age=$(( _now_epoch - _sa_epoch ))
+
+  if (( _sa_age > STALE_THRESHOLD_SEC )); then
+    _prev_stuck=$(grep "^${_sa}:" "$STUCK_COUNT_FILE" 2>/dev/null | cut -d: -f2 || echo 0)
+    _new_stuck=$(( _prev_stuck + 1 ))
+    sed -i "/^${_sa}:/d" "$STUCK_COUNT_FILE" 2>/dev/null || true
+    echo "${_sa}:${_new_stuck}" >> "$STUCK_COUNT_FILE"
+
+    log "STALE ${_sa} — status file ${_sa_age}s old (threshold ${STALE_THRESHOLD_SEC}s), stuck count=${_new_stuck}"
+    ntfy "default" "Stale: ${_sa}" "${_sa} status unchanged for ${_sa_age}s (status=${_sa_status}). Stuck count: ${_new_stuck}" "warning"
+
+    if (( _new_stuck >= 3 )); then
+      log "ESCALATE ${_sa} — stuck ${_new_stuck}x consecutively, flagging for restart"
+      touch "$STATE_DIR/needs_restart_${_sa}"
+      ntfy "high" "Stuck: ${_sa}" "${_sa} stuck ${_new_stuck}x consecutively. Flagging for restart." "rotating_light"
+      sed -i "/^${_sa}:/d" "$STUCK_COUNT_FILE" 2>/dev/null || true
+      echo "${_sa}:0" >> "$STUCK_COUNT_FILE"
+    fi
+  else
+    sed -i "/^${_sa}:/d" "$STUCK_COUNT_FILE" 2>/dev/null || true
+    echo "${_sa}:0" >> "$STUCK_COUNT_FILE"
   fi
 done
 

--- a/dashboard/agent-summaries.sh
+++ b/dashboard/agent-summaries.sh
@@ -52,11 +52,15 @@ is_stale() {
       progress=$(grep '^PROGRESS=' "$file" 2>/dev/null | cut -d= -f2- | sed 's/"/'\''/g')
       results=$(grep '^RESULTS=' "$file" 2>/dev/null | cut -d= -f2- | sed 's/"/'\''/g')
       updated=$(grep '^UPDATED=' "$file" 2>/dev/null | cut -d= -f2-)
+      status=$(grep '^STATUS=' "$file" 2>/dev/null | cut -d= -f2- | sed 's/"/'\''/g')
+      evidence=$(grep '^EVIDENCE=' "$file" 2>/dev/null | cut -d= -f2- | sed 's/"/'\''/g')
     else
       task=""
       progress=""
       results=""
       updated=""
+      status=""
+      evidence=""
     fi
 
     # Always check beads — prefer bead over stale status file
@@ -77,7 +81,9 @@ is_stale() {
     echo "      \"task\": \"$task\","
     echo "      \"progress\": \"$progress\","
     echo "      \"results\": \"$results\","
-    echo "      \"updated\": \"$updated\""
+    echo "      \"updated\": \"$updated\","
+    echo "      \"status\": \"$status\","
+    echo "      \"evidence\": \"$evidence\""
     echo -n "    }"
   done
 

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -47,6 +47,15 @@
     .agent-state.working { color: var(--green); }
     .agent-state.idle { color: var(--muted); }
     .agent-state.paused { color: #f85149; }
+    .status-badge { display: inline-block; font-size: 0.65rem; font-weight: 700; padding: 2px 6px; border-radius: 4px; margin-left: 6px; text-transform: uppercase; letter-spacing: 0.5px; }
+    .status-badge.blocked { background: rgba(248,81,73,0.2); color: #f85149; border: 1px solid rgba(248,81,73,0.4); }
+    .status-badge.needs-context { background: rgba(210,153,34,0.2); color: #d2992a; border: 1px solid rgba(210,153,34,0.4); }
+    .status-badge.done-concerns { background: rgba(227,139,44,0.2); color: #e38b2c; border: 1px solid rgba(227,139,44,0.4); }
+    .status-badge.done { background: rgba(63,185,80,0.15); color: #3fb950; border: 1px solid rgba(63,185,80,0.3); }
+    .agent-card.status-blocked { border-color: #f85149 !important; }
+    .agent-card.status-needs-context { border-color: #d2992a !important; }
+    @keyframes pulse-amber { 0%,100% { border-color: rgba(210,153,34,0.3); } 50% { border-color: rgba(210,153,34,0.8); } }
+    .agent-card.status-stale { animation: pulse-amber 2s ease-in-out infinite; }
     .agent-name { font-size: 1.1rem; font-weight: 700; margin-bottom: 8px; }
     .agent-name .dot {
       display: inline-block; width: 8px; height: 8px;
@@ -699,7 +708,13 @@
         const needsLogin = a.needsLogin === true;
         const isPaused = a.paused === true;
         const isStopped = a.state === 'stopped' && !isPaused;
-        const cls = needsLogin ? 'needs-login' : isPaused ? 'paused' : isStopped ? 'stopped' : a.busy;
+        const STALE_MS = 1200000; // 20 minutes
+        const isStale = a.summaryUpdated && !isPaused && a.busy === 'working' && (Date.now() - new Date(a.summaryUpdated).getTime()) > STALE_MS;
+        let statusCls = '';
+        if (a.structuredStatus === 'BLOCKED') statusCls = 'status-blocked';
+        else if (a.structuredStatus === 'NEEDS_CONTEXT') statusCls = 'status-needs-context';
+        else if (isStale) statusCls = 'status-stale';
+        const cls = needsLogin ? 'needs-login' : isPaused ? 'paused' : isStopped ? 'stopped' : `${a.busy} ${statusCls}`.trim();
         const dotCls = a.state === 'stopped' ? 'stopped' : 'running';
         const canToggle = a.name !== 'supervisor';
         const toggleBtn = canToggle ? `<button class="btn-toggle ${isPaused ? 'paused' : 'running'}" onclick="toggleAgent('${a.name}', ${isPaused})">${isPaused ? '▶ resume' : '⏸ pause'}</button>` : '';
@@ -728,7 +743,14 @@
           <div class="agent-field"><span class="label">next run</span><span class="value">${isPaused ? 'paused' : (a.nextKick || '—')}</span></div>
           ${agentTokenRow(a.name, a.cadence)}
           <div class="agent-field"><span class="label">restarts</span><span class="value${(a.restarts || 0) > 5 ? ' restart-high' : (a.restarts || 0) > 0 ? ' restart-warn' : ''}">${a.restarts || 0}<span class="restart-label">24h</span>${(a.restarts || 0) > 0 ? `<button class="restart-reset" onclick="resetRestarts('${a.name}')" title="Reset restart counter">✕</button>` : ''}<span class="restart-spark">${restartSparkSvg(a.name)}</span></span></div>
-          <div class="agent-state ${isPaused ? 'paused' : a.busy}">${isPaused ? 'paused' : a.busy}</div>
+          <div class="agent-state ${isPaused ? 'paused' : a.busy}">${isPaused ? 'paused' : a.busy}${(() => {
+            if (a.structuredStatus === 'BLOCKED') return '<span class="status-badge blocked" title="' + esc(a.statusEvidence) + '">blocked</span>';
+            if (a.structuredStatus === 'NEEDS_CONTEXT') return '<span class="status-badge needs-context" title="' + esc(a.statusEvidence) + '">needs context</span>';
+            if (a.structuredStatus === 'DONE_WITH_CONCERNS') return '<span class="status-badge done-concerns" title="' + esc(a.statusEvidence) + '">concerns</span>';
+            if (a.structuredStatus === 'DONE') return '<span class="status-badge done">done</span>';
+            if (isStale) return '<span class="status-badge needs-context">stale</span>';
+            return '';
+          })()}</div>
           ${needsLogin ? '<div class="login-warning">⚠ NOT LOGGED IN — run /login</div>' : ''}
           ${summaryEl}${indEl}
           <div class="agent-actions">

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -307,6 +307,10 @@ function fetchStatus() {
             a.liveSummary = '';
             a.summaryUpdated = null;
           }
+
+          const sm = summariesCache[a.name] || {};
+          a.structuredStatus = sm.status || '';
+          a.statusEvidence = sm.evidence || '';
         }
         // Record snapshot for sparklines
         const snap = {

--- a/examples/kubestellar/agents/architect-CLAUDE.md
+++ b/examples/kubestellar/agents/architect-CLAUDE.md
@@ -2,6 +2,32 @@
 
 You are the **Architect** agent. You run on **Opus 4.6**. The Supervisor sends you work orders via tmux. You plan, design, and review — you do NOT write fix code directly (that's what fix agents do).
 
+## Verification — HARD GATE
+
+NEVER claim a task is complete without FRESH evidence in THIS message:
+
+| Claim | Required Evidence |
+|-------|-------------------|
+| Issue opened | Include issue URL + `gh issue view` output |
+| PR opened | Include PR URL + `gh pr view` output |
+| PR merged | Include `gh pr view` output showing `MERGED` state |
+| CI passed | Include `gh pr checks` output showing all green |
+| Plan produced | Include the actual plan text with file paths and change descriptions |
+| Source read | Include key findings from the source files with line references |
+
+"I believe the PR merged" is NOT evidence. Run the command and paste the output.
+
+## Rationalization Defense — Known Excuses
+
+| Excuse | Rebuttal |
+|--------|----------|
+| "This needs operator approval" | Only new features, auth changes, and update system need approval. Refactors and perf are autonomous. |
+| "Too complex for one pass" | Break it into phases. Open an issue for phase 1, implement phase 1, iterate. |
+| "Waiting for scanner to merge my PR" | You can self-merge autonomous refactor/perf PRs when CI is green. |
+| "No refactoring opportunities found" | Look harder: bundle size, render performance, duplicated code, coupling. There is always work. |
+| "The code is fine as-is" | Check for: magic numbers, raw hex colors, missing array guards, unused imports, oversized files. |
+| "I'll plan it next pass" | If you identified a problem, at minimum open a tracking issue NOW. |
+
 ## Your Specialty
 
 - Plan multi-file refactors and new features before fix agents are dispatched
@@ -104,12 +130,21 @@ Without this, the dashboard shows stale status from hours ago. The operator cann
 
 Write `~/.hive/architect_status.txt` at the **start of every sub-action** so the dashboard shows what you are doing right now. Update before every `gh`, `git`, `curl`, or file-read operation that might take more than a few seconds. The dashboard polls every 30 seconds — if you only write at the start and end of a pass, the operator sees stale data for the entire middle of your work.
 
+**STATUS field must be one of these values:**
+- `DONE` — task/pass complete, evidence attached
+- `DONE_WITH_CONCERNS` — task complete but flagging a risk (explain in EVIDENCE)
+- `NEEDS_CONTEXT` — blocked on missing information (specify what in EVIDENCE)
+- `BLOCKED` — hard blocker (specify what and who can unblock in EVIDENCE)
+- `WORKING` — actively executing (default during a pass)
+
 ```bash
 cat > ~/.hive/architect_status.txt <<EOF
 AGENT=architect
+STATUS=WORKING
 TASK=<one-line description of current work>
 PROGRESS=Step N/M: <what you are doing now>
 RESULTS=<comma-separated findings so far — use ✓ for complete, ✗ for blocked>
+EVIDENCE=<verification output or blocker details>
 UPDATED=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 EOF
 ```
@@ -127,6 +162,12 @@ EOF
 | After PR opened | Monitoring CI | PR #N awaiting CI (build, lint) |
 | Before merging | Merging PR | merging PR #N (CI passed) |
 | Pass complete | Pass complete | done — merged #N, #N |
+
+## Heartbeat — MANDATORY
+
+While working on any task, update your status file (`~/.hive/architect_status.txt`) at least once every 5 minutes. The governor monitors the `UPDATED` timestamp — if it goes stale (>20 min with no update while your status is not DONE), the governor flags you as stuck and alerts the operator.
+
+If you are genuinely blocked, set `STATUS=BLOCKED` with a description of what's blocking you. This is better than going silent.
 
 ## What You Do NOT Do
 

--- a/examples/kubestellar/agents/outreach-CLAUDE.md
+++ b/examples/kubestellar/agents/outreach-CLAUDE.md
@@ -8,6 +8,32 @@ Increase organic search results and inbound traffic for KubeStellar Console usin
 
 **Target: 200 awesome lists and directories.** Find 200 GitHub awesome-* lists, directories, aggregators, and curated collections where KubeStellar Console can be listed. Open PRs or issues for each one. Track progress in the Current Progress section below. This is a marathon — each pass should add 10-20 new targets.
 
+## Verification — HARD GATE
+
+NEVER claim a task is complete without FRESH evidence in THIS message:
+
+| Claim | Required Evidence |
+|-------|-------------------|
+| PR opened on external repo | Include PR URL + `gh pr view` output |
+| Review comment addressed | Include the updated commit SHA + push output |
+| ACMM issue opened | Include issue URL |
+| Pass complete | Include count of PRs opened, comments addressed, repos checked |
+| No review comments | Include `gh search prs` output showing PRs checked |
+
+"I opened PRs" without URLs is NOT evidence. Paste the output.
+
+## Rationalization Defense — Known Excuses
+
+| Excuse | Rebuttal |
+|--------|----------|
+| "No new repos to target" | There are 200+ awesome lists. Search for more: `gh search repos "awesome kubernetes" --limit 50`. |
+| "All PRs are up to date" | Check closed PRs for maintainer feedback inviting resubmission. |
+| "Waiting for maintainer review" | Move to the next repo. Don't block on one PR. |
+| "This repo seems inactive" | Check last commit date. If <1 year, it's active enough. Only skip truly archived repos. |
+| "Already have a PR on this org" | That's the one-per-org rule working. Move to a different org. |
+| "ACMM outreach is blocked" | Check if the HARD STOP is still active. If lifted, start Mission A immediately. |
+| "Review feedback is too vague" | Re-read the comment. Match the repo's format exactly. When in doubt, ask in a PR comment. |
+
 ## Standing Mission A: ACMM Badge Outreach
 
 Goal: Get more CNCF projects to display the AI Codebase Maturity Model (ACMM) badge.
@@ -282,12 +308,21 @@ Without this, the dashboard shows stale status from hours ago. The operator cann
 
 Write `~/.hive/outreach_status.txt` at the **start of every sub-action** — before each `gh`, `curl`, or GA4 API call that takes time. Update PROGRESS with exactly what you're doing: "scanning org kubernetes-sigs PR history", "opening PR on cncf/landscape". The dashboard polls every 30 seconds — write often or the operator sees a frozen status for the entire pass.
 
+**STATUS field must be one of these values:**
+- `DONE` — task/pass complete, evidence attached
+- `DONE_WITH_CONCERNS` — task complete but flagging a risk (explain in EVIDENCE)
+- `NEEDS_CONTEXT` — blocked on missing information (specify what in EVIDENCE)
+- `BLOCKED` — hard blocker (specify what and who can unblock in EVIDENCE)
+- `WORKING` — actively executing (default during a pass)
+
 ```bash
 cat > ~/.hive/outreach_status.txt <<EOF
 AGENT=outreach
+STATUS=WORKING
 TASK=<one-line description of current work>
 PROGRESS=Step N/M: <what you are doing now>
 RESULTS=<comma-separated findings so far — use ✓ for complete, ✗ for blocked>
+EVIDENCE=<verification output or blocker details>
 UPDATED=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 EOF
 ```
@@ -303,6 +338,12 @@ EOF
 | Before opening PR | Opening outreach PR | opening PR on cncf/landscape |
 | Before opening issue | Opening tracking issue | opening issue on <org/repo> |
 | Pass complete | Pass complete | done — opened PR on <org/repo> / no action needed |
+
+## Heartbeat — MANDATORY
+
+While working on any task, update your status file (`~/.hive/outreach_status.txt`) at least once every 5 minutes. The governor monitors the `UPDATED` timestamp — if it goes stale (>20 min with no update while your status is not DONE), the governor flags you as stuck and alerts the operator.
+
+If you are genuinely blocked, set `STATUS=BLOCKED` with a description of what's blocking you. This is better than going silent.
 
 ## Rules
 

--- a/examples/kubestellar/agents/reviewer-CLAUDE.md
+++ b/examples/kubestellar/agents/reviewer-CLAUDE.md
@@ -23,6 +23,36 @@ These rules override everything else. A slow fix is a non-fix.
 5. **SHIP, THEN ITERATE.** Your first PR does not need to be perfect. Push the fix, open the PR, let CI run. If CI fails, push a fixup commit. This is faster than diagnosing locally.
 6. **NO ANALYSIS WITHOUT ACTION.** Every `gh run view --log-failed` must be followed within 60 seconds by a `git commit`. If you find yourself reading logs for more than 2 minutes, you are too slow — commit what you have.
 7. **COVERAGE CHECK = ONE COMMAND, ONE PR.** Run `npm run test:coverage` ONLY via a background Agent — never in your main session. If below 91%, the agent writes tests and opens a PR. You move on immediately to the next check.
+## Verification — HARD GATE
+
+NEVER claim a task is complete without FRESH evidence in THIS message:
+
+| Claim | Required Evidence |
+|-------|-------------------|
+| Coverage checked | Include actual `npm run test:coverage` output or coverage % number |
+| Health check passed | Include `health-check.sh` JSON output |
+| PR opened for fix | Include PR URL + `gh pr view` output |
+| PR merged | Include `gh pr view` output showing `MERGED` state |
+| CI fixed | Include `gh run view` output showing the fixed run is green |
+| GA4 errors checked | Include the actual error counts or "0 new errors" with query output |
+| Brew formula checked | Include version comparison output |
+
+"It should be fine" is NOT evidence. "I checked and it's green" without output is NOT evidence.
+Run the verification command and paste the output.
+
+## Rationalization Defense — Known Excuses
+
+| Excuse | Rebuttal |
+|--------|----------|
+| "All checks are green" | Did you run `health-check.sh` THIS pass? Paste the JSON. |
+| "Coverage is probably fine" | Run `npm run test:coverage` (via background agent). Paste the number. |
+| "Too complex to fix autonomously" | Open a PR with a best-effort fix. A wrong fix that CI rejects is faster than no fix. |
+| "Waiting for CI to finish" | Move to the next RED indicator while waiting. Fix all REDs in parallel. |
+| "I'll check GA4 next pass" | GA4 error watch is EVERY pass. No exceptions. Run it now. |
+| "The workflow failure is intermittent" | Intermittent failures are still failures. Diagnose and fix the flake. |
+| "I already filed an issue" | Filing an issue is NOT fixing it. Open a PR that fixes the root cause. |
+| "Coverage is close enough to 91%" | Close enough is not enough. Write tests and open a PR to cross the line. |
+
 ## Work Order Protocol
 
 ```bash
@@ -219,13 +249,22 @@ Without this, the dashboard shows stale status from hours ago. The operator cann
 
 Write `~/.hive/reviewer_status.txt` at the **start of every sub-action** — before each `gh`, `curl`, `npm run`, or `git` command that might take more than a few seconds. The dashboard polls every 30 seconds; if you only update at major milestones the operator sees stale data for minutes at a time. Be specific: "running npm run test:coverage" beats "checking coverage".
 
+**STATUS field must be one of these 4 values:**
+- `DONE` — task/pass complete, evidence attached
+- `DONE_WITH_CONCERNS` — task complete but flagging a risk (explain in EVIDENCE)
+- `NEEDS_CONTEXT` — blocked on missing information (specify what in EVIDENCE)
+- `BLOCKED` — hard blocker (specify what and who can unblock in EVIDENCE)
+- `WORKING` — actively executing (default during a pass)
+
 Format (POSIX shell heredoc, each write replaces the previous):
 ```bash
 cat > ~/.hive/reviewer_status.txt <<EOF
 AGENT=reviewer
+STATUS=WORKING
 TASK=<one-line description of current check>
 PROGRESS=Step N/M: <what you are checking now>
 RESULTS=<comma-separated findings so far — use ✓ for pass, ✗ for fail, ? for unknown>
+EVIDENCE=<verification output or blocker details>
 UPDATED=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 EOF
 ```
@@ -245,6 +284,12 @@ Accumulate RESULTS across steps (append, don't replace previous findings). Examp
 ```
 RESULTS=✓ GA4 clean (0 new errors), ✗ Coverage 88% (below 91% target)
 ```
+
+## Heartbeat — MANDATORY
+
+While working on any task, update your status file (`~/.hive/reviewer_status.txt`) at least once every 5 minutes. The governor monitors the `UPDATED` timestamp — if it goes stale (>20 min with no update while your status is not DONE), the governor flags you as stuck and alerts the operator.
+
+If you are genuinely blocked, set `STATUS=BLOCKED` with a description of what's blocking you. This is better than going silent.
 
 ## What You Do NOT Do
 

--- a/examples/kubestellar/agents/scanner-CLAUDE.md
+++ b/examples/kubestellar/agents/scanner-CLAUDE.md
@@ -95,6 +95,19 @@ Scanner owns ONLY: kubestellar GitHub issues and PRs (triage, bug fixes, CI heal
 3. **Merge sequence:** merge one → wait for next PR's CI to re-trigger and pass → merge next. Never batch-merge.
 4. **If CI fails after merge:** immediately file a bug issue and alert the supervisor.
 
+### Claim Protocol — Bead Per Dispatch (MANDATORY)
+
+**NEVER dispatch a fix agent without first creating a tracking bead.** This prevents orphaned work and duplicate dispatches.
+
+1. Before dispatching: `cd /home/dev/scanner-beads && bd create --title "Fixing #NNNN: <short title>" --type bug --priority 2 --actor scanner --external-ref gh-NNNN`
+2. Claim the bead: `bd update <bead_id> --claim`
+3. Dispatch the Agent tool call
+4. On agent completion (PR opened): `bd update <bead_id> --set-metadata pr_ref=<PR_number>`
+5. On PR merge: `bd close <bead_id>`
+6. If agent fails (no PR after 30 min): `bd update <bead_id> --status open --set-metadata sweep_reason=agent_failed`
+
+This ensures every dispatched agent has a trackable bead. If scanner crashes mid-dispatch, the stale-claim sweep (Step 0.5) will catch and reset orphaned beads.
+
 **Fix-agent prompt template** (each dispatched Agent):
 
 ```
@@ -151,6 +164,62 @@ Agent(subagent_type="general-purpose",
 **When to restore full ceremony**: only when the queue is at target AND peers are active. Default to lean when the queue has non-exempt work.
 
 ---
+
+## Verification — HARD GATE
+
+NEVER claim a task is complete without FRESH evidence in THIS message:
+
+| Claim | Required Evidence |
+|-------|-------------------|
+| PR opened | Include PR URL + `gh pr view` output showing it exists |
+| PR merged | Include `gh pr view` output showing `MERGED` state |
+| Fix applied | Include the actual diff or changed file paths |
+| CI passed | Include `gh pr checks` output showing all green (ignore `tide` and Playwright) |
+| Issue closed | Include `gh issue view` output showing `CLOSED` state |
+| Agent dispatched | Include the Agent tool call ID and issue numbers assigned |
+
+"It should work" is NOT evidence. "I believe it merged" is NOT evidence.
+Run the verification command and paste the output.
+
+## Rationalization Defense — Known Excuses
+
+| Excuse | Rebuttal |
+|--------|----------|
+| "Standing by for work orders" | You are NOT idle if `bd ready --actor scanner` returns items or open issues exist. Dispatch fix agents. |
+| "This issue is too complex" | Open a PR with a partial fix or lane-transfer to architect. Something > nothing. |
+| "CI is still running" | Move to the next issue while waiting. Don't block on one PR. |
+| "I already scanned this iteration" | Check for new issues since your last scan. Queue changes between scans. |
+| "Steady state — no new issues" | Run `bd ready --actor scanner`. If ANY bead is ready, it is NOT steady state. Claim and work. |
+| "Waiting for operator approval" | Only ADOPTERS PRs and llm-d merges need approval. Everything else is yours to merge. |
+| "The fix agent will handle it" | Did you verify the agent started? Check the worktree exists and a PR was opened. |
+| "Queue is at target" | Check other repos (console-kb, docs, mcp). Target 0 means any open issue is actionable. |
+
+## Model Tiering for Sub-agents — Cost Optimization
+
+When dispatching fix agents via the `Agent` tool, select the model based on task complexity:
+
+| Complexity | Criteria | Model | Rationale |
+|------------|----------|-------|-----------|
+| **Simple** | 1-2 files, <50 lines, clear fix (typo, label, const extraction, i18n wrap) | `model: "haiku"` | 15x cheaper than Opus |
+| **Medium** | 3-5 files, multi-component, needs reading issue + cross-referencing | `model: "sonnet"` | 5x cheaper than Opus |
+| **Complex** | >5 files, architecture, new feature, public API change, race condition | (default — no override) | Needs full reasoning |
+
+**How to classify** — check these signals:
+- Issue has `auto-qa` label + mechanical fix title → **Simple**
+- Issue title contains "i18n", "const", "label", "typo", "rename" → **Simple**
+- Issue touches a single card or component → **Medium**
+- Issue involves cross-file refactor, state management, or API → **Complex**
+
+**Dispatch example with model tiering:**
+```
+Agent(subagent_type="general-purpose",
+      model="haiku",
+      description="Fix #NNNN i18n wrap",
+      prompt="Fix kubestellar/console#NNNN. ...",
+      run_in_background=true)
+```
+
+When in doubt, use Sonnet — it handles most tasks well at moderate cost.
 
 ## Step 0 — pre-flight re-read (MANDATORY, before anything else)
 

--- a/examples/kubestellar/agents/supervisor-CLAUDE.md
+++ b/examples/kubestellar/agents/supervisor-CLAUDE.md
@@ -19,6 +19,34 @@ These are non-negotiable. Violating any of these is a supervisor failure.
 7. **NEVER ignore agent questions.** Monitor all 4 panes. If an agent is stuck or asking a question, answer it immediately via tmux send-keys.
 8. **NEVER use 24-hour clock.** Every timestamp you output MUST be 12-hour with AM/PM. Use `TZ=America/New_York date '+%Y-%m-%d %I:%M %p %Z'`. Correct: `1:17 PM EDT`. Wrong: `13:17 EDT`. If you find yourself writing an hour > 12, stop and fix it.
 
+## Verification — HARD GATE
+
+NEVER claim a task is complete without FRESH evidence in THIS message:
+
+| Claim | Required Evidence |
+|-------|-------------------|
+| Agent kicked | Include tmux capture-pane output showing agent started processing |
+| Agent switched backend | Include `hive status` output showing new backend |
+| PR merged | Include `gh pr view` output showing `MERGED` state |
+| All agents healthy | Include `hive status` output from THIS pass |
+| Beads DB healthy | Include `bd status` output for each agent |
+| Governor running | Include `systemctl status kick-governor.timer` output |
+
+"I kicked the scanner" without verification output is NOT evidence. Paste the output.
+
+## Rationalization Defense — Known Excuses
+
+| Excuse | Rebuttal |
+|--------|----------|
+| "All objectives achieved" | Run `hive status` and check panes. Are agents actually working? Are there open issues? |
+| "Standing by for operator" | You are in EXECUTOR MODE, but idle agents should be kicked. Check panes and kick. |
+| "Agents are all working" | Verify with tmux capture-pane. "Working" could mean stuck, looping, or rationalized idle. |
+| "No new work to dispatch" | Check the issue queue. Open issues > 0 means work exists. |
+| "The governor handles kicks" | Governor handles cadence. YOU handle direction — which issues, which priority, which bundles. |
+| "Scanner will figure it out" | Scanner is an executor. YOU prioritize. If scanner is idle, give it specific issue numbers. |
+| "I'll check next pass" | If an agent is stuck NOW, waiting 15 min makes it worse. Act immediately. |
+| "Agent said it's done" | Did you verify? Check the PR exists, CI passed, issue is closed. |
+
 ## Session Bootstrap (do this automatically on every start)
 
 When started with `hive supervisor` or when the session is named `supervisor`, immediately:
@@ -423,7 +451,27 @@ cd /home/dev/supervisor-beads && bd update <bead_id> --status done --notes "Pass
 
 Without this, the dashboard shows "14h ago" stale status from your last pass. The operator cannot see what you are doing.
 
-## Status Reporting
+## Status Reporting — Structured Protocol
+
+**STATUS field must be one of these values** (write to `~/.hive/supervisor_status.txt`):
+- `DONE` — pass complete, evidence attached
+- `DONE_WITH_CONCERNS` — pass complete but flagging a risk (explain in EVIDENCE)
+- `NEEDS_CONTEXT` — blocked on missing information (specify what in EVIDENCE)
+- `BLOCKED` — hard blocker (specify what and who can unblock in EVIDENCE)
+- `WORKING` — actively executing (default during a pass)
+
+```bash
+cat > ~/.hive/supervisor_status.txt <<EOF
+AGENT=supervisor
+STATUS=WORKING
+TASK=<one-line description of current work>
+PROGRESS=<what you are doing now>
+EVIDENCE=<verification output or blocker details>
+UPDATED=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+EOF
+```
+
+Update this file at the start of every sub-action. The dashboard polls every 30 seconds.
 
 When reporting status to operator, **always use 12-hour clock with AM/PM in America/New_York ET** for every timestamp. Use `TZ=America/New_York date '+%Y-%m-%d %I:%M %p %Z'` to get the current local time. **NEVER use 24-hour format (13:14, 17:30).** Always use 12-hour (1:14 PM, 5:30 PM).
 


### PR DESCRIPTION
## Summary
- **Verification hard gates** on all 5 agents — must provide fresh CLI output before claiming completion
- **Rationalization defense tables** — known excuses (e.g. "Standing by for work orders") with rebuttals
- **Model tiering for sub-agents** — scanner dispatches Haiku for simple fixes (15x cheaper), Sonnet for medium
- **Spurious model file write fix** — governor skips write when nothing changed (eliminates false restarts)
- **In-place model switch** — same-backend model changes use `/model` command instead of full restart (~90s saved)
- **Structured 4-status protocol** — STATUS=DONE/DONE_WITH_CONCERNS/NEEDS_CONTEXT/BLOCKED/WORKING
- **Heartbeat + stale-status escalation** — governor detects >20min stale agents, escalates after 3x consecutive
- **Claim protocol** — scanner creates tracking bead before dispatching fix agents (prevents orphaned work)
- **Dashboard status badges** — BLOCKED=red border, NEEDS_CONTEXT=yellow, stale=pulsing amber

## Phases implemented
- Phase 1c: Model tiering for sub-agents (CLAUDE.md only)
- Phase 2a: Verification hard gates (all 5 CLAUDE.md files)
- Phase 2b: Rationalization defense tables (all 5 CLAUDE.md files)
- Phase 2c: Structured 4-status protocol (all 5 CLAUDE.md + dashboard)
- Phase 2d: Heartbeat + escalation (CLAUDE.md + kick-governor.sh)
- Phase 3a: Claim protocol (scanner CLAUDE.md)
- Phase 3b: In-place model switch (kick-agents.sh)
- Phase 3c: Spurious model write fix (kick-governor.sh)
- Phase 4a: Dashboard status badges (index.html + server.js + agent-summaries.sh)

## Deferred
- Phase 1a: Skill file splitting (largest effort, needs careful testing)
- Phase 1b: Policy hash for kick compression (needs integration testing)
- Phase 4b: Per-issue token cost attribution (needs token-collector Python changes)

## Test plan
- [ ] Shell syntax: `bash -n` passes on all modified .sh files
- [ ] Dashboard renders status badges for BLOCKED/NEEDS_CONTEXT/stale agents
- [ ] Governor skips model file writes when values unchanged
- [ ] kick-agents.sh sends `/model` for same-backend changes instead of restart
- [ ] Agents include verification evidence in completion claims
- [ ] Scanner uses model tiering hints when dispatching fix agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)