### PR TITLE
Fix in-place model switch and add avg tokens/issue metric

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -701,17 +701,29 @@ apply_model_if_changed() {
 
   # Same backend, different model — use in-place /model command (no restart needed)
   if [[ "$cur_backend" == "$gov_backend" ]]; then
-    log "MODEL IN-PLACE $agent: ${cur_model} → ${gov_model} (same backend, using /model command)"
+    local cli_model
+    cli_model=$(normalize_model_for_backend "$gov_backend" "$gov_model")
+    log "MODEL IN-PLACE $agent: ${cur_model} → ${cli_model} (same backend, using /model command)"
+    $TMUX_BIN send-keys -t "$session" Escape 2>/dev/null || true
+    sleep 0.3
+    $TMUX_BIN send-keys -t "$session" Escape 2>/dev/null || true
+    sleep 0.3
+    $TMUX_BIN send-keys -t "$session" Escape 2>/dev/null || true
+    sleep 0.3
     $TMUX_BIN send-keys -t "$session" Escape 2>/dev/null || true
     sleep 0.5
-    $TMUX_BIN send-keys -t "$session" -l "/model ${gov_model}" 2>/dev/null || true
+    $TMUX_BIN send-keys -t "$session" -l "/model ${cli_model}" 2>/dev/null || true
+    sleep 0.3
+    $TMUX_BIN send-keys -t "$session" Enter 2>/dev/null || true
+    sleep 0.3
+    $TMUX_BIN send-keys -t "$session" Enter 2>/dev/null || true
     sleep 0.3
     $TMUX_BIN send-keys -t "$session" Enter 2>/dev/null || true
     sleep 2
 
     BACKEND_MODEL[$gov_backend]="$gov_model"
     AGENT_MODEL_OVERRIDE["${agent}-${gov_backend}"]="$gov_model"
-    log "MODEL IN-PLACE $agent — sent /model ${gov_model}, no restart needed"
+    log "MODEL IN-PLACE $agent — sent /model ${cli_model}, no restart needed"
     return 0
   fi
 

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -658,6 +658,18 @@
       return m[2] === 'h' ? parseInt(m[1]) * MINUTES_PER_HOUR : parseInt(m[1]);
     }
 
+    function getAgentIssueCount(name) {
+      const m = currentAgentMetrics[name];
+      if (!m) return 0;
+      if (name === 'scanner') {
+        const pairs = m.pairs || [];
+        return pairs.filter(p => p.state === 'merged').length;
+      }
+      if (name === 'outreach') return m.outreachMerged || 0;
+      if (name === 'architect') return m.prs || m.closed || 0;
+      return 0;
+    }
+
     function agentTokenRow(name, cadence) {
       const byAgent = window._tokensByAgent || {};
       const t = byAgent[name];
@@ -669,6 +681,11 @@
       const avg = t.avgPerSession || (t.sessions > 0 ? Math.floor(total / t.sessions) : 0);
       let rows = `<div class="agent-field"><span class="label">tokens (24h)</span><span class="value" style="color:var(--cyan)">${fmtTokens(total)} <span style="color:var(--muted);font-size:0.65rem">(${t.sessions} sess)</span></span></div>`;
       rows += `<div class="agent-field"><span class="label">avg/pass</span><span class="value">${fmtTokens(avg)}</span></div>`;
+      const issueCount = getAgentIssueCount(name);
+      if (issueCount > 0) {
+        const tokensPerIssue = Math.floor(total / issueCount);
+        rows += `<div class="agent-field"><span class="label">avg/issue</span><span class="value" style="color:var(--green)">${fmtTokens(tokensPerIssue)} <span style="color:var(--muted);font-size:0.65rem">(${issueCount} today)</span></span></div>`;
+      }
       const intervalMin = parseCadenceMinutes(cadence);
       if (intervalMin > 0 && avg > 0) {
         const MINUTES_PER_HOUR = 60;


### PR DESCRIPTION
## Summary
- **Model switch fix**: In-place `/model` command now sends 4x Escape (matching full restart path), normalizes model name for the active CLI backend via `normalize_model_for_backend()`, and sends 3x Enter after the command
- **Dashboard**: Added avg tokens/issue metric to each agent card — shows `total_24h_tokens / merged_issue_count` with issue count suffix

## Test plan
- [ ] Verify in-place model switch works: governor changes model on same backend → agent switches without restart
- [ ] Verify avg tokens/issue renders on agent cards when agents have merged PRs
- [ ] Verify no avg/issue row appears when issue count is 0