### PR TITLE
Add Copilot review follow-up workflow to reviewer

### DIFF
--- a/examples/kubestellar/agents/reviewer-CLAUDE.md
+++ b/examples/kubestellar/agents/reviewer-CLAUDE.md
@@ -10,6 +10,37 @@ You are the **Quality Gate** agent. You autonomously find and fix CI, nightly, d
 - Do NOT finish a pass with red indicators you haven't addressed
 - Post review comments on PRs per supervisor's analysis
 - File follow-up issues when you identify regressions
+- **Scan merged PRs for unaddressed Copilot review comments every pass** — open follow-up PRs or issues
+
+## Copilot Review Follow-up — EVERY PASS
+
+Copilot reviews every PR we open. Those comments often flag real issues (error handling, race conditions, missing validation). **Every pass**, scan recently merged PRs for unaddressed Copilot comments and act on them.
+
+**Workflow:**
+
+```bash
+# 1. Get PRs merged in the last 24h by clubanderson
+unset GITHUB_TOKEN && gh pr list --repo kubestellar/console --state merged \
+  --author clubanderson --limit 30 \
+  --json number,title,mergedAt --jq '.[] | "\(.number) \(.title)"'
+
+# 2. For each merged PR, check for Copilot review comments
+unset GITHUB_TOKEN && gh api "repos/kubestellar/console/pulls/<NUMBER>/comments" \
+  --jq '[.[] | select(.user.login == "Copilot")] | .[] | {body: .body[:200], path: .path, line: .line}'
+
+# 3. For each PR with unaddressed Copilot comments:
+#    - If the fix is small (1-2 files): open a follow-up PR titled
+#      "🐛 Address Copilot review findings from PR #NNNN"
+#    - If the fix is complex or cross-cutting: open a follow-up issue titled
+#      "Address Copilot review: <summary> (from PR #NNNN)"
+```
+
+**Rules:**
+- Do NOT skip this step even if all health indicators are green
+- Do NOT dismiss Copilot comments as "style nits" — evaluate each one for real impact
+- Bundle findings from multiple PRs into a single follow-up PR when they touch the same files
+- Title format: `🐛 Address Copilot review findings from PRs #NNNN, #MMMM`
+- Reference specific Copilot comments in the PR body so reviewers can trace the fix
 
 
 ## SPEED RULES — Non-Negotiable
@@ -52,6 +83,8 @@ Run the verification command and paste the output.
 | "The workflow failure is intermittent" | Intermittent failures are still failures. Diagnose and fix the flake. |
 | "I already filed an issue" | Filing an issue is NOT fixing it. Open a PR that fixes the root cause. |
 | "Coverage is close enough to 91%" | Close enough is not enough. Write tests and open a PR to cross the line. |
+| "Copilot comments are just style nits" | Evaluate each one. Copilot flags real issues — error handling, races, missing validation. Open a follow-up PR. |
+| "I'll address Copilot comments next pass" | No. Scan merged PRs for Copilot comments THIS pass. Unaddressed comments accumulate and become tech debt. |
 
 ## Work Order Protocol
 


### PR DESCRIPTION
## Summary
- Reviewer was not scanning merged PRs for Copilot review comments — 17 of today's 20 merged PRs had 58 total Copilot comments with zero follow-up PRs or issues
- Adds a concrete "Copilot Review Follow-up — EVERY PASS" workflow: scan merged PRs, check for Copilot comments via API, open follow-up PRs or issues
- Adds 2 rationalization defense entries to prevent skipping this duty
- Adds bullet point to job description

## Test plan
- [ ] Verify reviewer scans for Copilot comments on next pass after kick
- [ ] Verify follow-up PRs are created with correct title format