### PR TITLE
Add restart button for each agent on the dashboard

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -129,6 +129,13 @@
       text-decoration: none; transition: all 0.2s; display: inline-block;
     }
     .terminal-link:hover { background: var(--cyan); color: var(--bg); }
+    .restart-btn {
+      font-size: 0.7rem; padding: 3px 8px; border-radius: 4px;
+      border: 1px solid var(--yellow); background: transparent;
+      color: var(--yellow); cursor: pointer; font-family: inherit;
+      transition: all 0.2s; display: inline-block;
+    }
+    .restart-btn:hover { background: var(--yellow); color: var(--bg); }
     .backend-select {
       appearance: none; -webkit-appearance: none;
       background: var(--surface); color: var(--muted);
@@ -763,7 +770,7 @@
         }
         const indEl = agentIndicators(a.name);
         return `<div class="agent-card ${cls}">
-          <div class="agent-name"><span class="dot ${dotCls}"></span>${a.name} ${toggleBtn} <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a></div>
+          <div class="agent-name"><span class="dot ${dotCls}"></span>${a.name} ${toggleBtn} <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <button class="restart-btn" onclick="restartAgent('${a.name}')" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button></div>
           <div class="agent-field"><span class="label">cli</span><span class="value">${cliChip(a.cli, a.pinnedBoth || a.pinnedCli, a.name)}${(a.pinnedBoth || a.pinnedCli) ? '' : ` <button class="pin-toggle" onclick="togglePin('${a.name}', 'cli', false)" title="Pin CLI — lock current backend">📌</button>`}</span></div>
           <div class="agent-field"><span class="label">model</span><span class="value">${modelChip(a.model, a.govReason, a.pinnedBoth || a.pinnedModel, a.name)}${(a.pinnedBoth || a.pinnedModel) ? '' : ` <button class="pin-toggle" onclick="togglePin('${a.name}', 'model', false)" title="Pin model — lock current model">📌</button>`}</span></div>
           <div class="agent-field"><span class="label">interval</span><span class="value">${isPaused ? 'paused' : a.cadence}</span></div>
@@ -1439,6 +1446,15 @@ function intensityGauge() {
       const data = await res.json();
       if (!data.ok) { showToast(`${action} failed: ` + (data.error || 'unknown'), 'error'); return; }
       showToast(`${agent} ${action}d`, 'success');
+    }
+
+    async function restartAgent(agent) {
+      if (!confirm(`Restart ${agent}? This will kill the current session and start fresh.`)) return;
+      showToast(`Restarting ${agent}...`, 'info');
+      const res = await fetch(`/api/restart/${agent}`, { method: 'POST' });
+      const data = await res.json();
+      if (!data.ok) { showToast('Restart failed: ' + (data.error || 'unknown'), 'error'); return; }
+      showToast(`${agent} restarted — supervisor will respawn`, 'success');
     }
 
     async function resetRestarts(agent) {

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -815,6 +815,23 @@ app.post('/api/unpin/:agent{/:dimension}', (req, res) => {
   }
 });
 
+// Restart agent — kill tmux session so supervised-agent@.service respawns it
+app.post('/api/restart/:agent', (req, res) => {
+  const agent = req.params.agent;
+  const allowed = ['scanner', 'reviewer', 'architect', 'outreach', 'supervisor'];
+  if (!allowed.includes(agent)) {
+    return res.status(400).json({ error: `invalid agent: ${agent}` });
+  }
+  const session = TMUX_SESSION[agent];
+  if (!session) {
+    return res.status(400).json({ error: `no tmux session mapped for ${agent}` });
+  }
+  execFile('tmux', ['kill-session', '-t', session], { timeout: 10000 }, (err) => {
+    if (err) return res.status(500).json({ error: `tmux kill-session failed: ${err.message}` });
+    res.json({ ok: true, output: `${agent} session killed — supervisor will respawn` });
+  });
+});
+
 // Reset restart counter for an agent
 app.post('/api/reset-restarts/:agent', (req, res) => {
   const agent = req.params.agent;


### PR DESCRIPTION
## Summary
- Adds a **restart/respawn button** (↻ restart) next to the existing pause and terminal buttons on each agent card
- Clicking shows a confirmation dialog: "Restart scanner? This will kill the current session and start fresh."
- Calls `POST /api/restart/:agent` which runs `tmux kill-session -t <session>` — the `supervised-agent@.service` detects the session died and respawns with fresh context

## Changes
- `dashboard/public/index.html`: New `.restart-btn` CSS class (yellow, matching terminal-link style), restart button in agent card header, `restartAgent()` JS function with `confirm()` dialog
- `dashboard/server.js`: New `/api/restart/:agent` endpoint that validates the agent name, maps to tmux session via `TMUX_SESSION`, and kills it

## Test plan
- [ ] Click restart on a running agent — confirm dialog appears
- [ ] Cancel the dialog — nothing happens
- [ ] Confirm — agent session is killed and supervisor respawns it
- [ ] Try restart on supervisor — should work (supervisor is in the allowed list)
- [ ] Verify button styling is consistent with pause/terminal buttons