### PR TITLE
Add no-build HARD GATE to all 5 agent CLAUDE.md files

### DIFF
--- a/examples/kubestellar/agents/architect-CLAUDE.md
+++ b/examples/kubestellar/agents/architect-CLAUDE.md
@@ -93,7 +93,7 @@ When the supervisor sends you a planning request:
 
 **Autonomous workflow:**
 1. **Open an issue first** — title format `🏗 Architect: <slug>`, label `architect-plan`. Describe what you plan to change and why.
-2. Create a worktree branch, make the changes. Do NOT run npm run build, npm run lint, or tsc locally — CI handles that.
+2. Create a worktree branch, make the changes. ⛔ HARD GATE: Do NOT run `npm run build`, `npm run lint`, `tsc`, `tsc --noEmit`, `vitest`, or any local validation — not in your session, not in dispatched agents. Push and let CI validate.
 3. Open a PR referencing the issue (`Fixes #N`).
 4. Monitor CI with `unset GITHUB_TOKEN && gh pr checks <N> --repo kubestellar/console --watch`. Wait for build/lint to pass (ignore Playwright and `tide` — bypass with `--admin`).
 5. Merge your own PR: `unset GITHUB_TOKEN && gh pr merge <N> --repo kubestellar/console --admin --squash`.

--- a/examples/kubestellar/agents/outreach-CLAUDE.md
+++ b/examples/kubestellar/agents/outreach-CLAUDE.md
@@ -41,6 +41,10 @@ NEVER claim a task is complete without FRESH evidence in THIS message:
 | "ACMM outreach is blocked" | Check if the HARD STOP is still active. If lifted, start Mission A immediately. |
 | "Review feedback is too vague" | Re-read the comment. Match the repo's format exactly. When in doubt, ask in a PR comment. |
 
+## ⛔ NO LOCAL BUILD — HARD GATE
+
+NEVER run `npm run build`, `npm run lint`, `tsc`, `tsc --noEmit`, `vitest`, or any local validation command. Not in your session, not in dispatched agents. Push and let CI validate.
+
 ## Operator-Directed Work
 
 When the supervisor's kick message includes a specific issue number, PR number, or repo reference, work on it **regardless of whether it relates to awesome lists**. Operator-directed work takes priority over standing missions. Complete it first, then resume autonomous outreach.

--- a/examples/kubestellar/agents/reviewer-CLAUDE.md
+++ b/examples/kubestellar/agents/reviewer-CLAUDE.md
@@ -76,7 +76,7 @@ unset GITHUB_TOKEN && gh api "repos/kubestellar/console/pulls/<NUMBER>/comments"
 ## SPEED RULES — Non-Negotiable
 
 1. **5-MINUTE DIAGNOSIS CAP.** You have 5 minutes from identifying a RED indicator to opening a fix PR. If you cannot diagnose root cause in 5 minutes, open a best-effort fix PR anyway.
-2. **NO LOCAL BUILD, NO LOCAL TEST, NO LOCAL LINT.** NEVER run `npm run build`, `npm run lint`, `npm test`, `npm run test:coverage`, or `vitest` locally. Push your fix, let CI validate.
+2. **⛔ NO LOCAL BUILD, NO LOCAL TEST, NO LOCAL LINT — HARD GATE.** NEVER run `npm run build`, `npm run lint`, `npm test`, `npm run test:coverage`, `tsc`, `tsc --noEmit`, or `vitest` locally — not in your session, not in dispatched fix agents. Push your fix, let CI validate. Every dispatch prompt you write MUST include this prohibition.
 3. **ONE WORKTREE PER FIX.** For each RED indicator, create a separate worktree: `git worktree add /tmp/console-fix-<name> -b fix/<name>`. Never reuse another agent's branch.
 4. **PARALLEL FIXES.** Use the Agent tool to dispatch background fix agents for each RED indicator simultaneously.
 5. **SHIP, THEN ITERATE.** Your first PR does not need to be perfect. Push the fix, open the PR, let CI run.

--- a/examples/kubestellar/agents/scanner-CLAUDE.md
+++ b/examples/kubestellar/agents/scanner-CLAUDE.md
@@ -20,7 +20,15 @@ Abbreviate freely: DB, auth, config, req, res, fn, impl, PR, CI, ns. Use arrows 
 
 **Scanner self-scans the issue queue every kick.** On each kick, pull main, scan for open issues, dispatch fix agents, merge green PRs. No waiting for specific issue numbers from the supervisor — the kick IS your trigger to scan autonomously.
 
-**NO LOCAL BUILD, NO LOCAL LINT.** NEVER run `npm run build`, `npm run lint`, `tsc`, or `tsc --noEmit` locally — not in your session, and not in dispatched fix agents. Push the fix, open the PR, let CI validate. This rule is non-negotiable.
+## ⛔ NO LOCAL BUILD — HARD GATE (applies to YOU and ALL dispatched fix agents)
+
+NEVER run `npm run build`, `npm run lint`, `tsc`, `tsc --noEmit`, `vitest`, `npm test`, or `npm run test:coverage` locally. Not in your session, not in dispatched fix agents, not "just to check". Push the fix, open the PR, let CI validate.
+
+**If you see a build/lint/test process running in a dispatched agent, that agent has violated this rule.** Kill it, fix the dispatch prompt, and redispatch.
+
+This is the single most common agent failure mode. Fix agents that run `npm run build` burn 3-5 minutes, hit rate limits, and block on node_modules issues that don't exist in CI. Every dispatch prompt you write MUST include this prohibition verbatim:
+
+> ⛔ HARD GATE: Do NOT run npm run build, npm run lint, tsc, vitest, or any local validation. Push and let CI validate. Violating this wastes tokens and time.
 
 **What happens every time you get a [KICK] message:**
 
@@ -128,7 +136,8 @@ This ensures every dispatched agent has a trackable bead. If scanner crashes mid
 ```
 Fix kubestellar/console#NNNN. Worktree /tmp/kubestellar-console-NNNN-slug.
 Read the issue body, produce a focused fix, commit -s, push, open PR with
-Fixes #NNNN. Return PR number. Do NOT run npm run build or tsc locally — CI handles lint and build.
+Fixes #NNNN. Return PR number.
+⛔ HARD GATE: Do NOT run npm run build, npm run lint, tsc, vitest, or any local validation. Push and let CI validate. Violating this wastes tokens and time.
 ```
 
 ## LEAN MODE (default scan behavior)
@@ -170,7 +179,7 @@ Agent(subagent_type="general-purpose",
       description="Fix #NNNN <short title>",
       prompt="Fix kubestellar/console#NNNN. Worktree /tmp/kubestellar-console-NNNN-slug. 
               Find the bug, fix it, commit -s, push, open PR with Fixes #NNNN. Return PR number.
-              Do NOT run npm run build or tsc locally — CI handles lint and build.",
+              ⛔ HARD GATE: Do NOT run npm run build, npm run lint, tsc, vitest, or any local validation. Push and let CI validate. Violating this wastes tokens and time.",
       run_in_background=true)
 ```
 
@@ -542,7 +551,7 @@ The SLA is an OBLIGATION, not an aspiration. Missing it is worse than shipping a
 2. Each dispatched agent:
    - Creates its own worktree: `/tmp/kubestellar-console-<bug-num>-<slug>`
    - Reads the issue body, produces a focused fix
-   - Does NOT run npm run build or tsc locally — CI handles that
+   - ⛔ Does NOT run npm run build, npm run lint, tsc, vitest, or any local validation — CI handles that
    - Commits with `-s` (DCO sign-off, per CLAUDE.md)
    - Opens PR with `Fixes #NNN` in body
    - Returns PR number to scanner

--- a/examples/kubestellar/agents/supervisor-CLAUDE.md
+++ b/examples/kubestellar/agents/supervisor-CLAUDE.md
@@ -18,6 +18,7 @@ These are non-negotiable. Violating any of these is a supervisor failure.
 6. **NEVER forget beads.** You read your beads at startup. Agents read theirs via the BEADS_RESTORE instructions you send. If an agent isn't reading/writing beads, that's YOUR failure — you sent an incomplete work order.
 7. **NEVER ignore agent questions.** Monitor all 4 panes. If an agent is stuck or asking a question, answer it immediately via tmux send-keys.
 8. **NEVER use 24-hour clock.** Every timestamp you output MUST be 12-hour with AM/PM. Use `TZ=America/New_York date '+%Y-%m-%d %I:%M %p %Z'`. Correct: `1:17 PM EDT`. Wrong: `13:17 EDT`. If you find yourself writing an hour > 12, stop and fix it.
+9. **⛔ NEVER run local builds.** NEVER run `npm run build`, `npm run lint`, `tsc`, `vitest`, or any local validation — not in your session, not in dispatched agents. Every dispatch prompt you write MUST include this prohibition. Push and let CI validate.
 
 ## Verification — HARD GATE
 
@@ -294,7 +295,7 @@ Agent(subagent_type="general-purpose",
       prompt="Fix kubestellar/console#NNNN. Worktree /tmp/kubestellar-console-NNNN-slug.
               Read the issue, fix it, git commit -s, push, open PR with Fixes #NNNN.
               unset GITHUB_TOKEN before all gh commands.
-              Do NOT run npm run build or tsc locally — CI handles that.
+              ⛔ HARD GATE: Do NOT run npm run build, npm run lint, tsc, vitest, or any local validation. Push and let CI validate. Violating this wastes tokens and time.
               Return the PR number.",
       run_in_background=true)
 ```


### PR DESCRIPTION
## Summary

- Escalate soft "Do NOT run npm run build" to ⛔ HARD GATE language in all 5 agents
- Scanner: new dedicated section with detection/kill/redispatch instructions + all 3 dispatch templates strengthened
- Reviewer: existing rule upgraded to HARD GATE, covers dispatched agents
- Architect: autonomous workflow step strengthened
- Outreach: new HARD GATE section added (had no build rule at all)
- Supervisor: added rule #9 to NEVER DO list + dispatch template strengthened

## Why

Fix agents were running `npm run build` locally despite existing soft prohibitions in scanner's dispatch templates. This wastes 3-5 minutes per cycle, hits rate limits, and blocks on node_modules issues that don't exist in CI. The rule needs to be loud, consistent, and present in every agent — not just scanner.

## Test plan

- [ ] Verify agents on next kick pick up the new rules
- [ ] Monitor for any `npm run build` processes on dev server after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)