### PR TITLE
Fix ttyd copy/paste — disable tmux mouse for browser sessions

### DIFF
--- a/bin/ttyd-tmux.sh
+++ b/bin/ttyd-tmux.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Wrapper for ttyd → tmux that disables mouse mode so the browser
+# handles text selection and clipboard (Cmd+C / Cmd+V).
+# Mouse mode is restored when the ttyd session disconnects.
+SESSION=${1:-supervisor}
+PREV_MOUSE=$(tmux show-option -t "$SESSION" -v mouse 2>/dev/null || echo "on")
+tmux set-option -t "$SESSION" mouse off 2>/dev/null
+tmux attach-session -t "$SESSION"
+EXIT_CODE=$?
+tmux set-option -t "$SESSION" mouse "$PREV_MOUSE" 2>/dev/null
+exit $EXIT_CODE

--- a/systemd/ttyd-hive.service
+++ b/systemd/ttyd-hive.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=ttyd web terminal for hive agent sessions
+After=network.target
+
+[Service]
+Type=simple
+User=dev
+ExecStart=/usr/bin/ttyd -W -a -p 7681 -t fontSize=14 -t disableLeaveAlert=true /usr/local/bin/ttyd-tmux.sh
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Added `bin/ttyd-tmux.sh` wrapper that disables tmux mouse mode while ttyd is attached, restoring it on disconnect
- Browser now handles text selection and clipboard (Cmd+C/V work)
- SSH users keep mouse mode (restored after ttyd disconnects)
- Added `systemd/ttyd-hive.service` with `fontSize=14` and `disableLeaveAlert=true` client options

## Root cause
tmux `mouse on` (global setting) captures all mouse events before the browser sees them. Text selection goes into tmux's paste buffer instead of the system clipboard, and right-click shows tmux's menu overlapping the browser's context menu.

## Test plan
- [x] Deployed to dev server and verified mouse toggle logic works
- [x] Verified ttyd service restarts with new flags
- [ ] Manual test: open ttyd terminal, select text, Cmd+C → paste elsewhere
- [ ] Manual test: Cmd+V pastes from system clipboard into terminal
- [ ] Verify single-line URLs are clickable (WebLinksAddon built into ttyd 1.7.4)

**Note:** Multi-line URLs (long OAuth/GitHub URLs wrapping across rows) cannot be made clickable — this is an xterm.js architectural limitation. The proper fix requires OSC 8 hyperlink support upstream (Claude Code issue #23804). With this PR, users can manually select and copy multi-line URLs.