### PR TITLE
Clickable repo cards + fix vanishing intensity gauge

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -1239,21 +1239,25 @@ function intensityGauge() {
     { key: 'tokenMessages',   w: 1 },
   ];
 
-  let weightedRecent = 0, weightedTrail = 0, totalWeight = 0;
+  let weightedRecent = 0, totalWeight = 0;
   for (const m of metrics) {
     const recent = sliceRate(recentStart, len, m.key);
     const trail  = sliceRate(0, len, m.key);
-    if (trail > 0) {
-      weightedRecent += (recent / trail) * m.w;
-      totalWeight += m.w;
+    const absTrail = Math.abs(trail);
+    const MIN_RATE = 0.001;
+    if (absTrail > MIN_RATE) {
+      weightedRecent += (recent / absTrail) * m.w;
+    } else {
+      weightedRecent += 0;
     }
+    totalWeight += m.w;
   }
 
   if (totalWeight === 0) return '';
-  const ratio = weightedRecent / totalWeight;
+  const ratio = Math.max(0, weightedRecent / totalWeight);
 
-  // Clamp ratio to [0.2, 2.0] for display
-  const GAUGE_MIN = 0.2;
+  // Clamp ratio to [0, 2.0] for display
+  const GAUGE_MIN = 0;
   const GAUGE_MAX = 2.0;
   const clamped = Math.max(GAUGE_MIN, Math.min(GAUGE_MAX, ratio));
 
@@ -1272,7 +1276,8 @@ function intensityGauge() {
 
   // Label
   let label;
-  if (ratio < 0.7) label = 'cooling';
+  if (ratio < 0.1) label = 'idle';
+  else if (ratio < 0.7) label = 'cooling';
   else if (ratio < 0.9) label = 'easing';
   else if (ratio < 1.1) label = 'steady';
   else if (ratio < 1.4) label = 'ramping';

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -174,9 +174,12 @@
       border-radius: 6px; padding: 12px; overflow: hidden;
     }
     .repo-name { font-size: 0.85rem; font-weight: 600; margin-bottom: 6px; }
+    .repo-name a:hover { text-decoration: underline !important; }
     .repo-stats { display: flex; gap: 16px; font-size: 0.8rem; }
     .repo-stat .num { font-weight: 700; font-size: 1rem; }
     .repo-stat .label { color: var(--muted); font-size: 0.7rem; }
+    .repo-stat a:hover { text-decoration: underline !important; }
+    .repo-stat a:hover .label { color: var(--fg); }
 
     /* Sparklines */
     .sparkline { display: inline-block; vertical-align: middle; margin-left: 6px; flex-shrink: 0; }
@@ -977,12 +980,13 @@
       el.innerHTML = repos.map(r => {
         const iSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.issues ?? 0), '#58a6ff');
         const pSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.prs ?? 0), '#bc8cff');
+        const repoUrl = \`https://github.com/\${r.full || r.name}\`;
         return `
         <div class="repo-card">
-          <div class="repo-name">${r.full || r.name}</div>
+          <div class="repo-name"><a href="${repoUrl}" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">${r.full || r.name}</a></div>
           <div class="repo-stats">
-            <div class="repo-stat"><div class="spark-row"><span class="num">${r.issues >= 0 ? r.issues : '?'}</span>${iSpark}</div><div class="label">issues</div></div>
-            <div class="repo-stat"><div class="spark-row"><span class="num">${r.prs >= 0 ? r.prs : '?'}</span>${pSpark}</div><div class="label">PRs</div></div>
+            <div class="repo-stat"><a href="${repoUrl}/issues" target="_blank" rel="noopener" style="color:inherit;text-decoration:none"><div class="spark-row"><span class="num">${r.issues >= 0 ? r.issues : '?'}</span>${iSpark}</div><div class="label">issues</div></a></div>
+            <div class="repo-stat"><a href="${repoUrl}/pulls" target="_blank" rel="noopener" style="color:inherit;text-decoration:none"><div class="spark-row"><span class="num">${r.prs >= 0 ? r.prs : '?'}</span>${pSpark}</div><div class="label">PRs</div></a></div>
           </div>
         </div>`;
       }).join('');


### PR DESCRIPTION
## Summary
- **Clickable repo cards**: Repo name links to GitHub repo root, issue count links to /issues, PR count links to /pulls — all open in new tabs with hover underline
- **Intensity gauge fix**: Gauge vanished when token usage was flat/declining (sessions expiring from 24h window). Trail rates were zero/negative, so all metrics were skipped and `totalWeight === 0` returned empty string. Now uses absolute trail rate and always contributes to weight, showing "idle" at far-left instead of disappearing.

## Test plan
- [x] Deployed to dev server
- [ ] Click repo name → opens `github.com/org/repo` in new tab
- [ ] Click issue count → opens `/issues` in new tab
- [ ] Click PR count → opens `/pulls` in new tab
- [ ] Intensity gauge visible even when agents are idle