### PR TITLE
Add CI syntax check for dashboard inline JavaScript

### DIFF
--- a/.github/workflows/dashboard-lint.yml
+++ b/.github/workflows/dashboard-lint.yml
@@ -1,0 +1,43 @@
+name: Dashboard Lint
+on:
+  push:
+    paths:
+      - 'dashboard/**'
+  pull_request:
+    paths:
+      - 'dashboard/**'
+
+jobs:
+  syntax-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract and syntax-check inline JavaScript
+        run: |
+          for html_file in $(find dashboard -name '*.html'); do
+            echo "Checking $html_file..."
+            # Extract all <script> blocks (handles multiple blocks per file)
+            node -e "
+              const fs = require('fs');
+              const html = fs.readFileSync('$html_file', 'utf8');
+              const re = /<script[^>]*>([\s\S]*?)<\/script>/gi;
+              let match, idx = 0;
+              while ((match = re.exec(html)) !== null) {
+                const js = match[1].trim();
+                if (!js) continue;
+                const outFile = '/tmp/block_' + idx + '.js';
+                fs.writeFileSync(outFile, js);
+                idx++;
+              }
+              console.log('Extracted ' + idx + ' script block(s)');
+            "
+            # Syntax-check each extracted block
+            for block in /tmp/block_*.js; do
+              [ -f "$block" ] || continue
+              echo "  Parsing $(basename $block)..."
+              node --check "$block"
+            done
+            rm -f /tmp/block_*.js
+          done
+          echo "All script blocks passed syntax check."


### PR DESCRIPTION
## Summary
- Extracts `<script>` blocks from all HTML files in `dashboard/` and runs `node --check` to catch parse errors
- Triggered on push/PR to `dashboard/**`
- Would have caught the escaped backtick bug from commit 172bd64

## Test plan
- [x] Tested locally — passes on current dashboard HTML
- [x] Verified it catches the exact bug pattern (`\`` escaped backtick)