### PR TITLE
scanner: explicitly list all repos in kick message

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -616,7 +616,7 @@ if policy_changed "scanner"; then
 else
   _SCANNER_POLICY_INSTR="Policy unchanged since last kick — skip CLAUDE.md re-read, continue with standing instructions."
 fi
-SCANNER_MSG="[agent:scanner] [KICK] git pull /tmp/hive. ${_SCANNER_POLICY_INSTR} AUTONOMOUS SCAN: query open issues (oldest-first), dispatch fix agents for 4-6 oldest, merge green PRs. Do NOT stand by — if issues exist, work them. 'Not actionable' and 'not a code fix' are NOT valid reasons to skip an open issue — dispatch a fix agent with a best-effort PR. Deferred beads older than 1 pass MUST be retried. NEVER run vitest, npm test, npm run build, tsc, or any test/build locally — dispatch fix agents instead, they read CI logs. Beads: ~/scanner-beads"
+SCANNER_MSG="[agent:scanner] [KICK] git pull /tmp/hive. ${_SCANNER_POLICY_INSTR} AUTONOMOUS SCAN ALL REPOS: kubestellar/console, kubestellar/docs, kubestellar/console-kb, kubestellar/kubestellar-mcp, kubestellar/console-marketplace. Query open issues AND open PRs on EVERY repo (oldest-first), dispatch fix agents for 4-6 oldest across ALL repos, merge green PRs. Do NOT stand by — if issues exist on ANY repo, work them. 'Not actionable' and 'not a code fix' are NOT valid reasons to skip an open issue — dispatch a fix agent with a best-effort PR. Deferred beads older than 1 pass MUST be retried. NEVER run vitest, npm test, npm run build, tsc, or any test/build locally — dispatch fix agents instead, they read CI logs. Beads: ~/scanner-beads"
 
 # Build live health preamble for reviewer — tells it exactly what's red RIGHT NOW
 _rh_json=$(/tmp/hive/dashboard/health-check.sh 2>/dev/null || echo '{}')


### PR DESCRIPTION
## Summary
- Scanner was only working on kubestellar/console issues despite CLAUDE.md having multi-repo scan policy for all 5 repos
- Root cause: kick message said "query open issues" without specifying which repos — compacted context defaulted to console-only
- Fix: kick message now explicitly lists all 5 repos (console, docs, console-kb, kubestellar-mcp, console-marketplace)

## Test plan
- [ ] After merge + deploy, verify scanner's next kick iteration scans docs (#1546, #1545) and console-kb PRs
- [ ] Check scanner tmux output shows multi-repo `gh issue list` queries