### PR TITLE
fix: pause/resume rename + scanner hold-label hard gate

### DIFF
--- a/bin/supervisor.sh
+++ b/bin/supervisor.sh
@@ -165,7 +165,7 @@ check_prompt_delivered() {
   if echo "$pane" | grep -qE '◐|◑|◒|◓|● Read CLAUDE|● Environment loaded.*custom instructions'; then
     PROMPT_DELIVERED="yes"
     log "prompt delivered and agent is working"
-    if [ "$CLI" = "claude" ] && [ -n "$CLAUDE_RENAME_TO" ]; then
+    if [ -n "$CLAUDE_RENAME_TO" ]; then
       sleep 5
       log "sending /rename $CLAUDE_RENAME_TO"
       tmux send-keys -t "$SESSION" -l "/rename $CLAUDE_RENAME_TO"

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { execFile, spawn } = require('child_process');
+const { execFile, execSync, spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
@@ -692,10 +692,30 @@ app.post('/api/pause/:agent', (req, res) => {
   } catch (e) {
     return res.status(500).json({ error: `failed to write pause flag: ${e.message}` });
   }
-  execFile('/usr/local/bin/hive', ['stop', agent], { timeout: 30000 }, (err) => {
-    if (err) console.error(`pause stop error for ${agent}:`, err.message);
-    res.json({ ok: true, output: `${agent} paused` });
-  });
+  // Send 4x Esc to cancel any pending work, C-c + C-u to clear prompt, then /rename, then stop
+  const PAUSE_ESC_TO_CLEAR_MS = 2000;
+  const PAUSE_CLEAR_TO_RENAME_MS = 1000;
+  const PAUSE_RENAME_TO_STOP_MS = 3000;
+  try {
+    execSync(`tmux send-keys -t ${agent} Escape Escape Escape Escape`, { timeout: 5000 });
+  } catch (_) { /* session may not exist */ }
+  setTimeout(() => {
+    try {
+      execSync(`tmux send-keys -t ${agent} C-c`, { timeout: 5000 });
+      execSync(`tmux send-keys -t ${agent} C-u`, { timeout: 5000 });
+    } catch (_) { /* ignore */ }
+    setTimeout(() => {
+      try {
+        execSync(`tmux send-keys -t ${agent} '/rename ${agent}-paused' Enter`, { timeout: 5000 });
+      } catch (_) { /* ignore */ }
+      setTimeout(() => {
+        execFile('/usr/local/bin/hive', ['stop', agent], { timeout: 30000 }, (err) => {
+          if (err) console.error(`pause stop error for ${agent}:`, err.message);
+          res.json({ ok: true, output: `${agent} paused` });
+        });
+      }, PAUSE_RENAME_TO_STOP_MS);
+    }, PAUSE_CLEAR_TO_RENAME_MS);
+  }, PAUSE_ESC_TO_CLEAR_MS);
 });
 
 app.post('/api/resume/:agent', (req, res) => {
@@ -710,8 +730,16 @@ app.post('/api/resume/:agent', (req, res) => {
   } catch (e) {
     return res.status(500).json({ error: `failed to remove pause flag: ${e.message}` });
   }
-  execFile('/usr/local/bin/hive', ['kick', agent], { timeout: 30000 }, (err, stdout) => {
-    if (err) return res.status(500).json({ error: err.message });
+  // Start the systemd service first (hive stop killed it), then kick after CLI is ready
+  // supervisor.sh handles /rename via AGENT_CLAUDE_RENAME_TO on startup
+  const RESUME_KICK_DELAY_MS = 20000;
+  execFile('sudo', ['systemctl', 'start', `supervised-agent@${agent}`], { timeout: 30000 }, (startErr) => {
+    if (startErr) return res.status(500).json({ error: `failed to start ${agent}: ${startErr.message}` });
+    setTimeout(() => {
+      execFile('/usr/local/bin/kick-agents.sh', [agent], { timeout: 30000 }, (kickErr) => {
+        if (kickErr) console.error(`resume kick error for ${agent}:`, kickErr.message);
+      });
+    }, RESUME_KICK_DELAY_MS);
     res.json({ ok: true, output: `${agent} resumed` });
   });
 });

--- a/examples/kubestellar/agents/scanner-CLAUDE.md
+++ b/examples/kubestellar/agents/scanner-CLAUDE.md
@@ -1,4 +1,16 @@
 ---
+
+## ⛔ HOLD LABEL — ABSOLUTE HARD STOP (CHECK BEFORE EVERY ACTION)
+
+**Before closing, commenting on, dispatching work for, or touching ANY issue or PR in ANY way, you MUST first check its labels.** If it has a label containing "hold" (e.g., `hold`, `on-hold`, `hold/review`), STOP IMMEDIATELY. Do NOT close it, do NOT work on it, do NOT dispatch fix agents for it, do NOT comment on it. This applies to ALL code paths — triage, stale-issue cleanup, housekeeping, bead closure, everything. Only the operator can close or un-hold these issues. Violations of this rule have caused incidents and required manual reopening. This gate overrides ALL other logic including stale-issue auto-close, bundle-fix dispatch, and housekeeping sweeps.
+
+**Quick check before any `gh issue close`:**
+```bash
+gh issue view <number> --repo kubestellar/console --json labels --jq '.labels[].name' | grep -qi hold && echo "HOLD — DO NOT TOUCH" || echo "OK to proceed"
+```
+
+---
+
 The scanner runs on claude-dev (192.168.4.56) in the `scanner` tmux session. The supervisor (dispatcher on the Mac) sends work orders directly. No cron, no self-scheduling. The scanner's project memory dir is a symlink into this one, so policy edits propagate via Syncthing.
 
 ## Output Rules — Terse Mode (ALWAYS ACTIVE)
@@ -312,6 +324,7 @@ When scanner has capacity remaining in an iteration and there are unPR'd issues 
 ### Concrete levers to move toward the target
 
 1. **Stale-reporter auto-nudge + close** for `triage/needs-information` labeled issues (soft tempo — 4-day silence is acceptable before any action):
+   - ⛔ **FIRST: check for `hold` label** — if the issue has ANY label containing "hold", SKIP IT ENTIRELY. Do not nudge, do not close, do not comment.
    - **Day 4** (last maintainer comment is 4+ days old, no reporter reply): post a reminder comment: `@<reporter> any update on the questions above? If we don't hear back in a few days we'll close this, and you can reopen once you have more details.`
    - **Day 7** (still no reporter reply 3 days after the reminder): close with `--reason "not planned"` and comment `Closing for lack of reporter response. Feel free to reopen with the requested details.` — do NOT strip labels on close (keeps searchability). Post the reminder once per issue; if the issue has been nudged before, do NOT re-nudge, proceed to close when day 7 passes.
 2. **Bundle-fix small related bugs** before dispatching fix agents (already the pattern for arcade bug clusters — keep doing it; a single PR closes 3+ beads).


### PR DESCRIPTION
## Summary
- **supervisor.sh**: Remove `CLI=="claude"` check so `/rename` fires for all CLI backends (copilot, gemini, etc.) — outreach runs on copilot and rename was silently skipped
- **dashboard server.js**: Fix pause to clear queued prompt text (C-c + C-u) before `/rename`; fix resume to `systemctl start` + `kick-agents.sh` since `hive stop` kills the service
- **scanner CLAUDE.md**: Add absolute hold-label hard stop at the very top of the file (scanner closed hold-labeled LFX issues #4189/#4190 three times despite existing hold rule buried at step 3)

## Test plan
- [x] 10x pause/resume cycle on outreach: 10/10 resume renames, 8/10 pause renames (2 timing races, cosmetic only)
- [ ] Monitor hold-labeled issues (#4189, #4190, #4196, #10354) remain open through next 3 scanner kicks