### PR TITLE
feat: token burn rate visualizations + gauge fixes

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -246,10 +246,14 @@
       text-shadow: 0 1px 4px rgba(0,0,0,0.8);
     }
     .temp-gauge-labels {
-      display: flex; justify-content: space-between; margin-top: 4px;
+      position: relative; margin-top: 4px; height: 1em;
       font-size: 0.6rem; color: var(--muted);
     }
-    .temp-gauge-labels span { text-align: center; }
+    .temp-gauge-labels span { position: absolute; transform: translateX(-50%); text-align: center; }
+    .temp-gauge-labels .lbl-idle  { left: 3.5%; }
+    .temp-gauge-labels .lbl-quiet { left: 20%; }
+    .temp-gauge-labels .lbl-busy  { left: 50%; }
+    .temp-gauge-labels .lbl-surge { left: 83.5%; }
     .tl-idle { color: #238636; }
     .tl-quiet { color: #1f6feb; }
     .tl-busy { color: #d29922; }
@@ -370,6 +374,16 @@
     .token-session-row .smsgs { color: var(--muted); min-width: 50px; }
     .token-session-row .sproj { color: var(--muted); font-size: 0.65rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
+    /* Token burn rate chart */
+    .burn-chart-wrap { margin: 8px 0 12px; }
+    .burn-chart-title { font-size: 0.7rem; color: var(--muted); margin-bottom: 4px; }
+    .burn-context { display: flex; gap: 16px; margin-top: 6px; font-size: 0.7rem; font-family: monospace; }
+    .burn-context .bc-stat { display: flex; flex-direction: column; align-items: center; }
+    .burn-context .bc-val { font-weight: 700; font-size: 0.85rem; }
+    .burn-context .bc-label { color: var(--muted); font-size: 0.6rem; }
+    .burn-area-wrap { margin: 4px 0 12px; }
+    .burn-area-title { font-size: 0.7rem; color: var(--muted); margin-bottom: 4px; }
+
     /* Cadence advisor */
     .advisor-section { margin: 12px 0; padding: 12px; background: rgba(88,166,255,0.05); border: 1px solid rgba(88,166,255,0.15); border-radius: 6px; }
     .advisor-title { font-size: 0.85rem; font-weight: 700; margin-bottom: 6px; }
@@ -415,6 +429,13 @@
     .health-ci.bad { color: #f85149; }
 
     /* GitHub API rate limit alert bar */
+    .gh-auth-alert {
+      display: none; position: fixed; top: 0; left: 0; right: 0; z-index: 10000;
+      background: #8b1a1a; border-bottom: 2px solid #f85149; color: #e6edf3;
+      padding: 10px 20px; font-size: 0.85rem; text-align: center;
+    }
+    .gh-auth-alert.active { display: block; }
+    .gh-auth-alert a { color: #79c0ff; text-decoration: underline; }
     .gh-rate-alert {
       background: rgba(210,153,34,0.15); border: 1px solid rgba(210,153,34,0.4);
       border-radius: 8px; padding: 10px 16px; margin-bottom: 16px;
@@ -449,6 +470,7 @@
 </head>
 <body>
 <div id="toast-container"></div>
+<div class="gh-auth-alert" id="gh-auth-alert">GitHub CLI authentication failed (401). Agents cannot use <code>gh</code> commands. Run <code>gh auth login</code> on the dev server to fix.</div>
   <div class="gh-rate-alert" id="gh-rate-alert"></div>
 
   <div class="connection live" id="conn">
@@ -881,13 +903,13 @@
       const issuesSpark = sparkSvg(getHistorySeries('govIssues'), '#58a6ff');
       const prsSpark = sparkSvg(getHistorySeries('govPrs'), '#bc8cff');
       const totalSpark = sparkSvg(getHistorySeries('govTotal'), '#3fb950');
-      const total = (gov.issues || 0) + (gov.prs || 0);
+      const issueCount = gov.issues || 0;
       const currentMode = gov.mode || 'idle';
       const modes = ['idle', 'quiet', 'busy', 'surge'];
 
-      // Gauge bar — thresholds: idle≤2, quiet≤10, busy≤20, surge>20
+      // Gauge bar — thresholds driven by issue count only (PRs don't affect mode)
       const maxQ = 30;
-      const pct = Math.min(total / maxQ * 100, 100);
+      const pct = Math.min(issueCount / maxQ * 100, 100);
       const modeColors = { idle: '#238636', quiet: '#58a6ff', busy: '#d29922', surge: '#f85149' };
       const modeColor = modeColors[gov.mode] || '#8b949e';
 
@@ -903,23 +925,22 @@
         <div class="gov-grid">
           <div class="gov-stat"><div class="label">timer</div><div class="val ${cls}">${gov.active ? '● active' : '⚠ DEAD'}</div></div>
           <div class="gov-stat"><div class="label">mode</div><div class="val" style="color:${modeColor}">${gov.mode}</div></div>
-          <div class="gov-stat"><div class="label">actionable</div><div class="spark-row"><span class="val">${total}</span>${totalSpark}</div></div>
-          <div class="gov-stat"><div class="label">issues</div><div class="spark-row"><span class="val">${gov.issues}</span>${issuesSpark}</div></div>
+          <div class="gov-stat"><div class="label">actionable</div><div class="spark-row"><span class="val">${issueCount}</span>${issuesSpark}</div></div>
           <div class="gov-stat"><div class="label">PRs</div><div class="spark-row"><span class="val">${gov.prs}</span>${prsSpark}</div></div>
           <div class="gov-stat"><div class="label">next run</div><div class="val">${gov.nextKick || '—'}</div></div>
         </div>
         <div class="temp-gauge">
-          <div class="temp-gauge-label"><span>Queue: ${total}</span><span>max ${maxQ}</span></div>
+          <div class="temp-gauge-label"><span>Issues: ${issueCount}</span><span>max ${maxQ}</span></div>
           <div class="temp-gauge-track">
             <div class="temp-gauge-glow" style="width:100%"></div>
             <div class="temp-gauge-ticks"><span>0</span><span>2</span><span>10</span><span>20</span><span>${maxQ}</span></div>
-            <div class="temp-gauge-needle" style="left:${pct}%" data-val="${total}"></div>
+            <div class="temp-gauge-needle" style="left:${pct}%" data-val="${issueCount}"></div>
           </div>
           <div class="temp-gauge-labels">
-            <span class="tl-idle">idle</span>
-            <span class="tl-quiet">quiet</span>
-            <span class="tl-busy">busy</span>
-            <span class="tl-surge">surge</span>
+            <span class="tl-idle lbl-idle">idle</span>
+            <span class="tl-quiet lbl-quiet">quiet</span>
+            <span class="tl-busy lbl-busy">busy</span>
+            <span class="tl-surge lbl-surge">surge</span>
           </div>
         </div>
         <div class="gov-timeline">
@@ -1212,111 +1233,157 @@
 
 // Intensity gauge: compares recent vs trailing token rate
 // Returns SVG string for a half-circle speedometer
-function intensityGauge() {
+function computeHourlyBurnRates() {
   const MIN_POINTS = 6;
-  if (historyData.length < MIN_POINTS) return '';
-
-  const len = historyData.length;
-  const RECENT_FRACTION = 0.25;
-  const recentStart = Math.floor(len * (1 - RECENT_FRACTION));
-
-  // Compute rate (delta per second) for a slice of historyData
-  function sliceRate(start, end, key) {
-    const first = historyData[start];
-    const last = historyData[end - 1];
-    const dt = (last.t - first.t) / 1000;
-    if (dt <= 0) return 0;
-    return ((last[key] || 0) - (first[key] || 0)) / dt;
-  }
-
-  // Metrics with weights: total tokens & output weighted 2x
-  const metrics = [
-    { key: 'tokenTotal',      w: 3 },
-    { key: 'tokenOutput',     w: 2 },
-    { key: 'tokenInput',      w: 1 },
-    { key: 'tokenCacheRead',  w: 0.5 },
-    { key: 'tokenCacheCreate',w: 0.5 },
-    { key: 'tokenMessages',   w: 1 },
-  ];
-
-  let weightedRecent = 0, totalWeight = 0;
-  for (const m of metrics) {
-    const recent = sliceRate(recentStart, len, m.key);
-    const trail  = sliceRate(0, len, m.key);
-    const absTrail = Math.abs(trail);
-    const MIN_RATE = 0.001;
-    if (absTrail > MIN_RATE) {
-      weightedRecent += (recent / absTrail) * m.w;
-    } else {
-      weightedRecent += 0;
+  if (historyData.length < MIN_POINTS) return null;
+  const BUCKET_MS = 300000;
+  const rates = [];
+  let i = 0;
+  while (i < historyData.length) {
+    const bucketStart = historyData[i].t;
+    const bucketEnd = bucketStart + BUCKET_MS;
+    let j = i;
+    while (j < historyData.length && historyData[j].t < bucketEnd) j++;
+    if (j > i && j < historyData.length) {
+      const dt = (historyData[j - 1].t - historyData[i].t) / 1000;
+      if (dt > 0) {
+        const delta = (historyData[j - 1].tokenTotal || 0) - (historyData[i].tokenTotal || 0);
+        rates.push({ t: bucketStart, rate: Math.max(0, (delta / dt) * 3600) });
+      }
     }
-    totalWeight += m.w;
+    i = j || i + 1;
+  }
+  return rates.length >= 3 ? rates : null;
+}
+
+function intensityGauge() {
+  const rates = computeHourlyBurnRates();
+  if (!rates) return '';
+
+  const rateVals = rates.map(r => r.rate);
+  const now = rateVals[rateVals.length - 1];
+  const peak = Math.max(...rateVals);
+  const low = Math.min(...rateVals);
+  const avg = rateVals.reduce((a, b) => a + b, 0) / rateVals.length;
+
+  let color;
+  if (peak === 0) color = '#8b949e';
+  else if (now / peak > 0.8) color = '#f85149';
+  else if (now / peak > 0.5) color = '#d29922';
+  else if (now / peak > 0.2) color = '#3fb950';
+  else color = '#58a6ff';
+
+  let label;
+  if (peak === 0) label = 'idle';
+  else if (now / peak > 0.8) label = 'surging';
+  else if (now / peak > 0.5) label = 'ramping';
+  else if (now / peak > 0.2) label = 'steady';
+  else label = 'cooling';
+
+  const W = 240, H = 50, PAD = 2;
+  const range = peak - low || 1;
+  const pts = rateVals.map((v, i) => {
+    const x = PAD + (i / (rateVals.length - 1)) * (W - PAD * 2);
+    const y = PAD + (1 - (v - low) / range) * (H - PAD * 2);
+    return [x.toFixed(1), y.toFixed(1)];
+  });
+
+  const yAvg = (PAD + (1 - (avg - low) / range) * (H - PAD * 2)).toFixed(1);
+  const yPeak = (PAD + (1 - (peak - low) / range) * (H - PAD * 2)).toFixed(1);
+  const yLow = (PAD + (1 - (low - low) / range) * (H - PAD * 2)).toFixed(1);
+  const lastPt = pts[pts.length - 1];
+
+  const polyline = pts.map(p => p.join(',')).join(' ');
+
+  return `<div style="display:flex;flex-direction:column;align-items:center;gap:2px;min-width:260px">
+    <div class="burn-chart-title">burn rate (tok/hr)</div>
+    <svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
+      <line x1="${PAD}" y1="${yPeak}" x2="${W - PAD}" y2="${yPeak}" stroke="#f85149" stroke-width="0.5" stroke-dasharray="3,3" opacity="0.5"/>
+      <line x1="${PAD}" y1="${yAvg}" x2="${W - PAD}" y2="${yAvg}" stroke="#d29922" stroke-width="0.5" stroke-dasharray="3,3" opacity="0.5"/>
+      <line x1="${PAD}" y1="${yLow}" x2="${W - PAD}" y2="${yLow}" stroke="#58a6ff" stroke-width="0.5" stroke-dasharray="3,3" opacity="0.5"/>
+      <text x="${W - PAD}" y="${yPeak}" dy="-2" text-anchor="end" fill="#f85149" font-size="7" opacity="0.7">peak</text>
+      <text x="${W - PAD}" y="${yAvg}" dy="-2" text-anchor="end" fill="#d29922" font-size="7" opacity="0.7">avg</text>
+      <text x="${W - PAD}" y="${yLow}" dy="8" text-anchor="end" fill="#58a6ff" font-size="7" opacity="0.7">low</text>
+      <polyline points="${polyline}" fill="none" stroke="${color}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      <circle cx="${lastPt[0]}" cy="${lastPt[1]}" r="3" fill="${color}" stroke="#0d1117" stroke-width="1"/>
+    </svg>
+    <div class="burn-context">
+      <div class="bc-stat"><span class="bc-val" style="color:#f85149">${fmtTokens(peak)}</span><span class="bc-label">peak/hr</span></div>
+      <div class="bc-stat"><span class="bc-val" style="color:#d29922">${fmtTokens(avg)}</span><span class="bc-label">avg/hr</span></div>
+      <div class="bc-stat"><span class="bc-val" style="color:${color}">${fmtTokens(now)}</span><span class="bc-label">now/hr</span></div>
+      <div class="bc-stat"><span class="bc-val" style="color:#58a6ff">${fmtTokens(low)}</span><span class="bc-label">low/hr</span></div>
+    </div>
+    <div style="color:${color};font-size:11px;font-family:monospace;margin-top:2px">${label}</div>
+  </div>`;
+}
+
+function burnAreaChart() {
+  const rates = computeHourlyBurnRates();
+  if (!rates || rates.length < 4) return '';
+
+  const rateVals = rates.map(r => r.rate);
+  const BUCKET_COUNT = 8;
+  const bucketSize = Math.max(1, Math.floor(rateVals.length / BUCKET_COUNT));
+  const buckets = [];
+  for (let i = 0; i < rateVals.length; i += bucketSize) {
+    const slice = rateVals.slice(i, i + bucketSize).sort((a, b) => a - b);
+    if (slice.length === 0) continue;
+    const p25Idx = Math.floor(slice.length * 0.25);
+    const p75Idx = Math.min(Math.floor(slice.length * 0.75), slice.length - 1);
+    const median = slice[Math.floor(slice.length * 0.5)];
+    buckets.push({ p25: slice[p25Idx], p75: slice[p75Idx], median, t: rates[Math.min(i, rates.length - 1)].t });
   }
 
-  if (totalWeight === 0) return '';
-  const ratio = Math.max(0, weightedRecent / totalWeight);
+  if (buckets.length < 2) return '';
 
-  // Clamp ratio to [0, 2.0] for display
-  const GAUGE_MIN = 0;
-  const GAUGE_MAX = 2.0;
-  const clamped = Math.max(GAUGE_MIN, Math.min(GAUGE_MAX, ratio));
+  const allVals = rateVals;
+  const peak = Math.max(...allVals);
+  const low = Math.min(...allVals);
+  const range = peak - low || 1;
 
-  // Map to angle: 0.2 = -90deg (left), 1.0 = 0deg (center), 2.0 = +90deg (right)
-  const HALF_PI = Math.PI;
-  const normalized = (clamped - GAUGE_MIN) / (GAUGE_MAX - GAUGE_MIN);
-  const angle = -HALF_PI / 2 + normalized * HALF_PI;
+  const W = 400, H = 60, PAD = 2;
+  const xStep = (W - PAD * 2) / (buckets.length - 1);
 
-  // Color: blue (decel) -> green (steady) -> orange -> red (accel)
-  let color;
-  if (ratio < 0.7) color = '#58a6ff';
-  else if (ratio < 0.9) color = '#3fb950';
-  else if (ratio < 1.1) color = '#3fb950';
-  else if (ratio < 1.4) color = '#d29922';
-  else color = '#f85149';
+  const bandTop = buckets.map((b, i) => {
+    const x = PAD + i * xStep;
+    const y = PAD + (1 - (b.p75 - low) / range) * (H - PAD * 2);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+  const bandBot = buckets.map((b, i) => {
+    const x = PAD + i * xStep;
+    const y = PAD + (1 - (b.p25 - low) / range) * (H - PAD * 2);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  }).reverse();
 
-  // Label
-  let label;
-  if (ratio < 0.1) label = 'idle';
-  else if (ratio < 0.7) label = 'cooling';
-  else if (ratio < 0.9) label = 'easing';
-  else if (ratio < 1.1) label = 'steady';
-  else if (ratio < 1.4) label = 'ramping';
-  else label = 'surging';
+  const medianPts = buckets.map((b, i) => {
+    const x = PAD + i * xStep;
+    const y = PAD + (1 - (b.median - low) / range) * (H - PAD * 2);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
 
-  const ratioText = ratio.toFixed(1) + 'x';
+  const nowPts = rateVals.map((v, i) => {
+    const x = PAD + (i / (rateVals.length - 1)) * (W - PAD * 2);
+    const y = PAD + (1 - (v - low) / range) * (H - PAD * 2);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+  const lastNow = nowPts[nowPts.length - 1];
+  const nowVal = rateVals[rateVals.length - 1];
+  const aboveBand = nowVal > buckets[buckets.length - 1].p75;
+  const belowBand = nowVal < buckets[buckets.length - 1].p25;
+  const dotColor = aboveBand ? '#f85149' : belowBand ? '#58a6ff' : '#3fb950';
 
-  // SVG half-circle gauge
-  const W = 120, H = 75;
-  const cx = W / 2, cy = H - 8;
-  const r = 42;
-  const needleLen = 36;
-  const nx = cx + needleLen * Math.cos(angle - Math.PI / 2);
-  const ny = cy + needleLen * Math.sin(angle - Math.PI / 2);
+  const firstTime = new Date(rates[0].t).toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true});
+  const lastTime = new Date(rates[rates.length - 1].t).toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true});
 
-  // Arc segments for background
-  const arcPath = (startAngle, endAngle, radius) => {
-    const x1 = cx + radius * Math.cos(startAngle);
-    const y1 = cy + radius * Math.sin(startAngle);
-    const x2 = cx + radius * Math.cos(endAngle);
-    const y2 = cy + radius * Math.sin(endAngle);
-    const large = endAngle - startAngle > Math.PI ? 1 : 0;
-    return `M${x1},${y1} A${radius},${radius} 0 ${large} 1 ${x2},${y2}`;
-  };
-
-  return `<div class="intensity-gauge" style="text-align:center;margin:0 8px">
-    <svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
-      <!-- background arc -->
-      <path d="${arcPath(-Math.PI, -Math.PI * 0.67, r)}" fill="none" stroke="#58a6ff" stroke-width="6" opacity="0.3"/>
-      <path d="${arcPath(-Math.PI * 0.67, -Math.PI * 0.33, r)}" fill="none" stroke="#3fb950" stroke-width="6" opacity="0.3"/>
-      <path d="${arcPath(-Math.PI * 0.33, -Math.PI * 0.05, r)}" fill="none" stroke="#d29922" stroke-width="6" opacity="0.3"/>
-      <path d="${arcPath(-Math.PI * 0.05, 0, r)}" fill="none" stroke="#f85149" stroke-width="6" opacity="0.3"/>
-      <!-- needle -->
-      <line x1="${cx}" y1="${cy}" x2="${nx}" y2="${ny}" stroke="${color}" stroke-width="2.5" stroke-linecap="round"/>
-      <circle cx="${cx}" cy="${cy}" r="4" fill="${color}"/>
-      <!-- ratio text -->
-      <text x="${cx}" y="${cy - 14}" text-anchor="middle" fill="${color}" font-size="14" font-weight="bold" font-family="monospace">${ratioText}</text>
+  return `<div class="burn-area-wrap">
+    <div class="burn-area-title">burn rate distribution · <span style="color:rgba(57,210,192,0.6)">p25–p75 band</span> · <span style="color:#39d2c0">actual</span></div>
+    <svg width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" style="width:100%;height:${H}px">
+      <polygon points="${bandTop.join(' ')} ${bandBot.join(' ')}" fill="rgba(57,210,192,0.12)" stroke="none"/>
+      <polyline points="${medianPts.join(' ')}" fill="none" stroke="rgba(57,210,192,0.3)" stroke-width="1" stroke-dasharray="2,2"/>
+      <polyline points="${nowPts.join(' ')}" fill="none" stroke="#39d2c0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+      <circle cx="${lastNow.split(',')[0]}" cy="${lastNow.split(',')[1]}" r="3" fill="${dotColor}" stroke="#0d1117" stroke-width="1"/>
     </svg>
-    <div style="color:${color};font-size:11px;margin-top:-4px;font-family:monospace">${label}</div>
+    <div style="display:flex;justify-content:space-between;font-size:0.6rem;color:var(--muted)">${firstTime}<span>${lastTime}</span></div>
   </div>`;
 }
 
@@ -1386,11 +1453,29 @@ function intensityGauge() {
           <div class="token-stat"><div class="spark-row"><span class="tval">${t.messages}</span>${sparkSvg(getHistorySeries('tokenMessages'), '#8b949e')}</div><div class="tlabel">messages</div></div>
         </div>
         ${agentSparkRows ? `<div class="token-grid" style="margin-top:4px">${agentSparkRows}</div>` : ''}
+        ${burnAreaChart()}
         ${advisorHtml}
         <div class="token-models">${modelChips}</div>
         ${sessions.length > 0 ? `<details class="token-sessions"${sessionsOpen ? ' open' : ''}><summary>Active Sessions (${sessions.length})</summary>${sessionRows}</details>` : ''}
       </div>`;
     }
+
+    // GitHub auth health — sticky banner when 401
+    const GH_AUTH_POLL_MS = 30000;
+    async function checkGhAuth() {
+      try {
+        const res = await fetch('/api/gh-auth');
+        const data = await res.json();
+        const el = document.getElementById('gh-auth-alert');
+        if (data.ok) {
+          el.className = 'gh-auth-alert';
+        } else {
+          el.className = 'gh-auth-alert active';
+        }
+      } catch (_) { /* dashboard unreachable — different problem */ }
+    }
+    checkGhAuth();
+    setInterval(checkGhAuth, GH_AUTH_POLL_MS);
 
     function renderGhRateLimits(ghRateLimits) {
       const el = document.getElementById('gh-rate-alert');

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -97,6 +97,23 @@ function fetchGhRateLimits() {
 fetchGhRateLimits();
 setInterval(fetchGhRateLimits, GH_RATE_REFRESH_MS);
 
+// GitHub auth health — check every 60s, expose sticky alert when 401
+const GH_AUTH_CHECK_MS = 60000;
+let ghAuthOk = true;
+let ghAuthLastChecked = null;
+function checkGhAuth() {
+  execFile('bash', ['-c', 'unset GITHUB_TOKEN && gh api user --jq .login 2>&1'], { timeout: 15000 }, (err, stdout, stderr) => {
+    const output = (stdout || '') + (stderr || '');
+    const was = ghAuthOk;
+    ghAuthOk = !err && !output.includes('401') && !output.includes('auth') && stdout.trim().length > 0;
+    ghAuthLastChecked = new Date().toISOString();
+    if (was && !ghAuthOk) console.error('gh auth DOWN:', output.trim());
+    if (!was && ghAuthOk) console.log('gh auth recovered');
+  });
+}
+checkGhAuth();
+setInterval(checkGhAuth, GH_AUTH_CHECK_MS);
+
 // Fetch CI pass rate + binary health checks every 60s
 function fetchHealthChecks() {
   execFile(path.join(__dirname, 'health-check.sh'), [], { timeout: 30000 }, (err, stdout) => {
@@ -954,6 +971,11 @@ app.get('/api/model-advisor', (_req, res) => {
     result.agents.push(entry);
   }
   res.json(result);
+});
+
+// GitHub auth health
+app.get('/api/gh-auth', (_req, res) => {
+  res.json({ ok: ghAuthOk, lastChecked: ghAuthLastChecked });
 });
 
 // GitHub API rate limit alerts


### PR DESCRIPTION
## Summary
- Replace half-circle intensity gauge with burn rate sparkline (tok/hr) showing high/low/avg reference lines + peak/avg/now/low context numbers
- Add burn rate distribution area chart with p25–p75 percentile band and actual rate overlay — current position shown as colored dot (red=above band, green=in band, blue=below)
- Fix governor gauge to use issue count only (PRs don't drive mode thresholds), matching the governor script's `determine_mode()` logic
- Center idle/quiet/busy/surge labels under their respective colored gauge segments
- Add GitHub CLI auth health check endpoint + sticky red banner on 401

## Test plan
- [ ] Verify burn rate sparkline shows peak/avg/now/low reference lines
- [ ] Verify area chart shows p25-p75 band with actual rate line
- [ ] Verify governor gauge needle tracks issue count, not issues+PRs
- [ ] Verify mode labels are centered under gauge segments
- [ ] Verify 401 banner appears when gh auth fails, auto-dismisses on recovery