### PR TITLE
fix: sync all agent bead DBs to central ledger

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -872,4 +872,20 @@ case "$TARGET" in
 esac
 
 bd dolt push 2>&1 | tee -a "$LOG" || log "WARN: bd dolt push failed (non-fatal)"
+
+# Merge all agent JSONL exports into central ledger for dashboard/supervisor visibility
+CENTRAL_ISSUES="/tmp/hive/.beads/issues.jsonl"
+CENTRAL_INTERACTIONS="/tmp/hive/.beads/interactions.jsonl"
+{
+  for agent_dir in /home/dev/{scanner,reviewer,architect,outreach,supervisor}-beads; do
+    [ -f "$agent_dir/.beads/issues.jsonl" ] && cat "$agent_dir/.beads/issues.jsonl"
+  done
+} > "${CENTRAL_ISSUES}.tmp" 2>/dev/null && mv "${CENTRAL_ISSUES}.tmp" "$CENTRAL_ISSUES" || true
+{
+  for agent_dir in /home/dev/{scanner,reviewer,architect,outreach,supervisor}-beads; do
+    [ -f "$agent_dir/.beads/interactions.jsonl" ] && cat "$agent_dir/.beads/interactions.jsonl"
+  done
+} > "${CENTRAL_INTERACTIONS}.tmp" 2>/dev/null && mv "${CENTRAL_INTERACTIONS}.tmp" "$CENTRAL_INTERACTIONS" || true
+log "Central ledger synced ($(wc -l < "$CENTRAL_ISSUES" 2>/dev/null || echo 0) issues)"
+
 log "DONE"


### PR DESCRIPTION
## Summary
- All agents write beads to local DBs (`~/scanner-beads/`, `~/reviewer-beads/`, etc.) but only scanner's were visible in the central `/tmp/hive/.beads/issues.jsonl`
- Reviewer had 70 beads, architect 121, outreach 8 — all invisible to dashboard and supervisor sweeps
- Adds a post-kick step that concatenates all agents' JSONL exports into the central ledger
- Also set `beads.role=maintainer` on all agent DBs to fix `bd list --json` warning that broke JSON parsing

## Test plan
- [ ] Run `kick-agents.sh all` on dev server
- [ ] Verify `/tmp/hive/.beads/issues.jsonl` contains beads from all agents (not just scanner)
- [ ] Verify supervisor sweep sees cross-agent bead counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)