### PR TITLE
feat: estimate tokens for active Copilot sessions

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -1483,17 +1483,18 @@ function burnAreaChart() {
           return `<div class="token-session-row" style="padding-left:12px">
             <span class="sid">${esc(s.id)}</span>
             <span class="smodel">${esc(s.model)}</span>
-            <span class="stokens">${s.total > 0 ? fmtTokens(s.total) : '—'}</span>
+            <span class="stokens" ${s.estimated ? 'title="estimated from avg tokens/msg"' : ''}>${s.total > 0 ? (s.estimated ? '~' : '') + fmtTokens(s.total) : '—'}</span>
             <span class="smsgs">${s.messages} msgs</span>${miniSpark}
             <span class="sproj">${age}</span>
           </div>`;
         }).join('');
         const totalMsgs = grp.reduce((a, s) => a + s.messages, 0);
         const totalTokens = grp.reduce((a, s) => a + s.total, 0);
+        const hasEstimates = grp.some(s => s.estimated && s.total > 0);
         return `<div style="margin-bottom:6px">
           <div style="display:flex;align-items:center;gap:8px;margin-bottom:2px">
             <span class="sagent ${agentCls}" style="font-weight:700">${agent}</span>
-            <span style="color:var(--muted);font-size:0.65rem">${grp.length} session${grp.length > 1 ? 's' : ''} · ${totalMsgs} msgs${totalTokens > 0 ? ' · ' + fmtTokens(totalTokens) : ''}</span>
+            <span style="color:var(--muted);font-size:0.65rem">${grp.length} session${grp.length > 1 ? 's' : ''} · ${totalMsgs} msgs${totalTokens > 0 ? ' · ' + (hasEstimates ? '~' : '') + fmtTokens(totalTokens) : ''}</span>
           </div>
           ${rows}
         </div>`;

--- a/dashboard/token-collector.sh
+++ b/dashboard/token-collector.sh
@@ -380,6 +380,7 @@ if os.path.isdir(copilot_dir):
             continue
 
         cli = "copilot"
+        has_shutdown = cp_inp > 0 or cp_out > 0 or cp_cache_read > 0
         cp_total = cp_inp + cp_out + cp_cache_read
 
         BUCKET_MINUTES = 10
@@ -415,6 +416,7 @@ if os.path.isdir(copilot_dir):
             "messages": cp_msg_count,
             "toolCalls": cp_tool_count,
             "total": cp_total,
+            "estimated": not has_shutdown,
             "project": "copilot-session",
             "started": cp_first_ts,
             "lastActive": cp_last_ts,
@@ -461,6 +463,32 @@ if os.path.isdir(copilot_dir):
             hourly_by_agent[cp_agent]["output"] += cp_out
             hourly_by_agent[cp_agent]["cacheRead"] += cp_cache_read
             hourly_by_agent[cp_agent]["sessions"] += 1
+
+# Estimate tokens for active Copilot sessions (no session.shutdown yet)
+# Uses avg tokens-per-message from completed sessions of the same model
+model_token_stats = defaultdict(lambda: {"tokens": 0, "msgs": 0})
+for s in sessions:
+    if s.get("cli") == "copilot" and not s.get("estimated") and s["total"] > 0:
+        model_token_stats[s["model"]]["tokens"] += s["total"]
+        model_token_stats[s["model"]]["msgs"] += s["messages"]
+
+global_copilot_tokens = sum(v["tokens"] for v in model_token_stats.values())
+global_copilot_msgs = sum(v["msgs"] for v in model_token_stats.values())
+global_avg = global_copilot_tokens / global_copilot_msgs if global_copilot_msgs > 0 else 0
+
+for s in sessions:
+    if not s.get("estimated") or s["total"] > 0:
+        continue
+    m = s["model"]
+    ms = model_token_stats[m]
+    avg_per_msg = ms["tokens"] / ms["msgs"] if ms["msgs"] > 0 else global_avg
+    if avg_per_msg <= 0:
+        continue
+    est = int(avg_per_msg * s["messages"])
+    s["total"] = est
+    s["input"] = int(est * 0.6)
+    s["output"] = int(est * 0.05)
+    s["cacheRead"] = int(est * 0.35)
 
 # Sort sessions by most recent first
 sessions.sort(key=lambda s: s.get("mtime", 0), reverse=True)


### PR DESCRIPTION
## Summary
- Active Copilot sessions show 0 tokens because usage data only appears in `session.shutdown` events
- Adds estimation using avg tokens-per-message from completed sessions of the same model
- Estimated values shown with `~` prefix in session list and group summary
- API response includes `"estimated": true` flag for these sessions

## Test plan
- [ ] Verify active Copilot sessions now show `~0.XXB` instead of `—`
- [ ] Verify completed sessions still show exact values (no `~` prefix)
- [ ] Verify group summary shows `~` when any session in the group is estimated

🤖 Generated with [Claude Code](https://claude.com/claude-code)