### PR TITLE
feat: add ignore-budget toggle to dashboard

### DIFF
--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -106,6 +106,7 @@ TOKEN_BUDGET_WEEKLY="${TOKEN_BUDGET_WEEKLY:-200000000}"  # ~200M billable tokens
 TOKEN_BUDGET_SAFETY_PCT="${TOKEN_BUDGET_SAFETY_PCT:-85}"
 TOKEN_BUDGET_RESET_DAY="${TOKEN_BUDGET_RESET_DAY:-4}"  # 4=Friday (Claude resets Fri 7PM)
 TOKEN_COLLECTOR_JSON="/var/run/hive-metrics/tokens.json"
+BUDGET_IGNORE_FLAG="/var/run/hive-metrics/budget_ignore"
 
 # ── Cost weights (relative to Haiku=1) ──────────────────────────────────────
 COST_WEIGHT_OPUS="${COST_WEIGHT_OPUS:-15}"
@@ -461,7 +462,9 @@ optimize_model_assignment() {
     override_reasons[$agent]=""
   done
 
-  if (( projected_pct > TOKEN_BUDGET_SAFETY_PCT )); then
+  if [[ -f "$BUDGET_IGNORE_FLAG" ]]; then
+    log "BUDGET: ignored (operator override active)"
+  elif (( projected_pct > TOKEN_BUDGET_SAFETY_PCT )); then
     log "BUDGET PRESSURE: projected ${projected_pct}% > safety ${TOKEN_BUDGET_SAFETY_PCT}%"
 
     for agent in outreach architect supervisor; do

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -1033,6 +1033,15 @@
       return b.toFixed(3) + 'B';
     }
 
+    let budgetIgnored = false;
+    fetch('/api/budget-ignore').then(r => r.json()).then(d => { budgetIgnored = d.ignored; }).catch(() => {});
+
+    function toggleBudgetIgnore() {
+      budgetIgnored = !budgetIgnored;
+      fetch('/api/budget-ignore', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ignored: budgetIgnored }) })
+        .then(r => r.json()).then(d => { budgetIgnored = d.ignored; renderAll(); });
+    }
+
     function renderBudgetBar(budget) {
       if (!budget || !budget.BUDGET_WEEKLY) return '';
       const PCT_SAFE = 50;
@@ -1045,11 +1054,12 @@
       const hoursLeft = budget.HOURS_REMAINING || 0;
       const HOURS_PER_DAY = 24;
       const dailyRate = burnRate * HOURS_PER_DAY;
-      const usedFillCls = pctUsed < PCT_SAFE ? 'safe' : pctUsed < PCT_WARN ? 'warning' : 'danger';
-      const projFillCls = projPct < PCT_SAFE ? 'safe' : projPct < PCT_WARN ? 'warning' : 'danger';
+      const usedFillCls = budgetIgnored ? 'safe' : pctUsed < PCT_SAFE ? 'safe' : pctUsed < PCT_WARN ? 'warning' : 'danger';
 
       let govAction = '';
-      if (projPct > PCT_WARN) {
+      if (budgetIgnored) {
+        govAction = '<span style="color:var(--muted)">Budget enforcement disabled by operator</span>';
+      } else if (projPct > PCT_WARN) {
         govAction = '<span style="color:var(--red)">Governor downgrading models to stay within budget</span>';
       } else if (projPct > PCT_SAFE) {
         govAction = '<span style="color:var(--yellow)">Governor may downgrade non-priority agents if burn increases</span>';
@@ -1057,9 +1067,13 @@
         govAction = '<span style="color:var(--green)">Budget healthy — governor using preferred models</span>';
       }
 
+      const ignoreCheck = `<label style="font-size:0.68rem;color:var(--muted);cursor:pointer;margin-left:12px">
+        <input type="checkbox" ${budgetIgnored ? 'checked' : ''} onchange="toggleBudgetIgnore()" style="cursor:pointer;vertical-align:middle"> ignore budget
+      </label>`;
+
       return `<div class="budget-bar">
         <div class="budget-bar-label">
-          <span>Used: ${fmtTokens(used)} / ${fmtTokens(weekly)} (${pctUsed}%)</span>
+          <span>Used: ${fmtTokens(used)} / ${fmtTokens(weekly)} (${pctUsed}%)${ignoreCheck}</span>
           <span>${hoursLeft}h until reset</span>
         </div>
         <div class="budget-bar-track"><div class="budget-bar-fill ${usedFillCls}" style="width:${Math.min(pctUsed, 100)}%"></div></div>

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -459,6 +459,20 @@ app.get('/api/config', (_req, res) => res.json({
   dashboardTitle: DASHBOARD_TITLE,
 }));
 
+const BUDGET_IGNORE_FLAG = path.join(METRICS_DIR, 'budget_ignore');
+app.get('/api/budget-ignore', (_req, res) => {
+  res.json({ ignored: fs.existsSync(BUDGET_IGNORE_FLAG) });
+});
+app.post('/api/budget-ignore', (req, res) => {
+  const { ignored } = req.body || {};
+  if (ignored) {
+    try { fs.writeFileSync(BUDGET_IGNORE_FLAG, new Date().toISOString()); } catch (_) {}
+  } else {
+    try { fs.unlinkSync(BUDGET_IGNORE_FLAG); } catch (_) {}
+  }
+  res.json({ ignored: fs.existsSync(BUDGET_IGNORE_FLAG) });
+});
+
 // JSON API
 app.get('/api/status', async (_req, res) => {
   const data = statusCache || await fetchStatus();


### PR DESCRIPTION
## Summary
- Governor was downgrading models because Copilot tokens (free) inflated usage past 200M weekly budget
- Adds checkbox in budget bar to disable budget enforcement
- Writes `/var/run/hive-metrics/budget_ignore` flag that governor checks before applying model downgrades
- Persists across page reloads via server-side flag file

## Test plan
- [ ] Check the "ignore budget" checkbox
- [ ] Verify governor stops showing "downgrading models" message
- [ ] Verify governor log shows "BUDGET: ignored (operator override active)"
- [ ] Uncheck → verify budget enforcement resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)