### PR TITLE
Use green border for active agents

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -38,7 +38,7 @@
       border-radius: 8px; padding: 16px; transition: border-color 0.3s;
       position: relative;
     }
-    .agent-card.working { border-color: var(--yellow); }
+    .agent-card.working { border-color: var(--green); }
     .agent-card.idle { border-color: var(--border); }
     .agent-card.stopped { border-color: var(--red); }
     .agent-card.needs-login { border-color: #ef4444; }
@@ -56,7 +56,7 @@
     .agent-field { display: flex; justify-content: space-between; font-size: 0.8rem; padding: 2px 0; }
     .agent-field .label { color: var(--muted); }
     .agent-field .value { text-align: right; }
-    .value.working { color: var(--yellow); }
+    .value.working { color: var(--green); }
     .restart-label { font-size: 0.6rem; color: var(--muted); margin-left: 3px; }
     .restart-warn { color: var(--yellow); }
     .restart-high { color: var(--red); }

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -38,7 +38,7 @@
       border-radius: 8px; padding: 16px; transition: border-color 0.3s;
       position: relative;
     }
-    .agent-card.working { border-color: var(--yellow); }
+    .agent-card.working { border-color: var(--green); }
     .agent-card.idle { border-color: var(--border); }
     .agent-card.stopped { border-color: var(--red); }
     .agent-card.needs-login { border-color: #ef4444; }
@@ -66,7 +66,7 @@
     .agent-field { display: flex; justify-content: space-between; font-size: 0.8rem; padding: 2px 0; }
     .agent-field .label { color: var(--muted); }
     .agent-field .value { text-align: right; }
-    .value.working { color: var(--yellow); }
+    .value.working { color: var(--green); }
     .restart-label { font-size: 0.6rem; color: var(--muted); margin-left: 3px; }
     .restart-warn { color: var(--yellow); }
     .restart-high { color: var(--red); }


### PR DESCRIPTION
## Summary
- Active/working agent cards now use green (`var(--green)`) border and value text instead of yellow
- Yellow is reserved for warning states (git dirty, needs-context, budget warnings)
- Both `dashboard/index.html` and `dashboard/public/index.html` updated

## Test plan
- [ ] Load dashboard with at least one active agent — verify green border
- [ ] Verify idle agents still have default border
- [ ] Verify stopped agents still have red border