### PR TITLE
Add breathing green indicator for active agents

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -174,6 +174,21 @@
     @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.6; } }
     .agent-card.working .agent-name { animation: pulse 2s ease-in-out infinite; }
 
+    /* Breathing green indicator for working agent cards — top right */
+    @keyframes breathe-green {
+      0%,100% { opacity: 1; box-shadow: 0 0 6px 2px rgba(63,185,80,0.5); }
+      50% { opacity: 0.25; box-shadow: 0 0 2px 0px rgba(63,185,80,0.1); }
+    }
+    .working-indicator {
+      position: absolute; top: 12px; right: 12px;
+      width: 8px; height: 8px; border-radius: 50%;
+      background: var(--green); display: none;
+    }
+    .agent-card.working .working-indicator {
+      display: block;
+      animation: breathe-green 4s ease-in-out infinite;
+    }
+
     /* Temperature gauge */
     .temp-gauge { margin: 12px 0 8px; }
     .temp-gauge-label { font-size: 0.7rem; color: var(--muted); margin-bottom: 4px; display: flex; justify-content: space-between; }
@@ -674,6 +689,7 @@
         }
         const indEl = agentIndicators(a.name);
         return `<div class="agent-card ${cls}">
+          <span class="working-indicator"></span>
           <div class="agent-name"><span class="dot ${dotCls}"></span>${a.name} <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a></div>
           <div class="agent-field"><span class="label">cli</span><span class="value ${a.cli}">${a.cli}</span></div>
           <div class="agent-field"><span class="label">model</span><span class="value">${a.model || ''} ${a.govBackend ? modelChip(a.govBackend, a.govModel, a.govReason) : ''}</span></div>

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -207,6 +207,21 @@
     @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.6; } }
     .agent-card.working .agent-name { animation: pulse 2s ease-in-out infinite; }
 
+    /* Breathing green indicator for working agent cards — top right */
+    @keyframes breathe-green {
+      0%,100% { opacity: 1; box-shadow: 0 0 6px 2px rgba(63,185,80,0.5); }
+      50% { opacity: 0.25; box-shadow: 0 0 2px 0px rgba(63,185,80,0.1); }
+    }
+    .working-indicator {
+      position: absolute; top: 12px; right: 12px;
+      width: 8px; height: 8px; border-radius: 50%;
+      background: var(--green); display: none;
+    }
+    .agent-card.working .working-indicator {
+      display: block;
+      animation: breathe-green 4s ease-in-out infinite;
+    }
+
     /* Green pulsing dot for active agents in cadence matrix */
     @keyframes green-pulse { 0%,100% { opacity: 1; box-shadow: 0 0 4px var(--green); } 50% { opacity: 0.3; box-shadow: none; } }
     .active-dot {
@@ -827,6 +842,7 @@
         }
         const indEl = agentIndicators(a.name);
         return `<div class="agent-card ${cls}">
+          <span class="working-indicator"></span>
           <div class="agent-name"><span class="dot ${dotCls}"></span>${a.name} ${toggleBtn} <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <button class="restart-btn" onclick="restartAgent('${a.name}')" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button></div>
           <div class="agent-field"><span class="label">cli</span><span class="value">${cliChip(a.cli, a.pinnedBoth || a.pinnedCli, a.name)}${(a.pinnedBoth || a.pinnedCli) ? '' : ` <button class="pin-toggle" onclick="togglePin('${a.name}', 'cli', false)" title="Pin CLI — lock current backend">📌</button>`}</span></div>
           <div class="agent-field"><span class="label">model</span><span class="value">${modelChip(a.model, a.govReason, a.pinnedBoth || a.pinnedModel, a.name)}${(a.pinnedBoth || a.pinnedModel) ? '' : ` <button class="pin-toggle" onclick="togglePin('${a.name}', 'model', false)" title="Pin model — lock current model">📌</button>`}</span></div>


### PR DESCRIPTION
## Summary
- Adds a slow-pulsing green dot in the top-right corner of agent cards when the agent is working
- 4-second breathing cycle with subtle glow effect
- Hidden when agent is idle, stopped, or paused
- Both `dashboard/index.html` and `dashboard/public/index.html` updated

## Test plan
- [ ] Load dashboard with a working agent — verify green dot appears top-right and pulses slowly
- [ ] Verify dot is hidden on idle/stopped/paused agents