### PR TITLE
Send /clear before each kick to reset agent context

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -574,6 +574,26 @@ kick() {
     sleep 1
   fi
 
+  # Reset conversation context so agent reads kick message fresh.
+  # With 40-50 restarts/day the accumulated context is mostly stale
+  # rationalization; the kick message already contains all deterministic data.
+  log "CLEAR-CONTEXT $session — sending /clear before kick"
+  $TMUX_BIN send-keys -t "$session" -l "/clear" 2>/dev/null || true
+  sleep 1
+  $TMUX_BIN send-keys -t "$session" Enter 2>/dev/null || true
+  local CLEAR_WAIT=15
+  local _cw=0
+  while [ "$_cw" -lt "$CLEAR_WAIT" ]; do
+    sleep 1
+    _cw=$(( _cw + 1 ))
+    if session_idle "$session"; then
+      break
+    fi
+  done
+  if ! session_idle "$session"; then
+    log "WARN $session — /clear did not return to prompt within ${CLEAR_WAIT}s, proceeding anyway"
+  fi
+
   log "KICK $session (${#message} chars)"
   send_chunked "$session" "$message"
   # Verify Enter was delivered — retry then restart if buffer is stuck


### PR DESCRIPTION
## Summary
- Sends `/clear` to the agent CLI before every kick message
- Waits up to 15s for the prompt to return before proceeding
- Eliminates stale context accumulation that causes agents to drift from pipeline-computed decisions
- The kick message already inlines all deterministic data (tiers, clusters, lanes, outreach stats), so agents don't need conversation history

## Rationale
Scanner restarts ~50 times/day. The "context" it accumulates between kicks is mostly rationalization about why it skipped or deferred issues — exactly the drift the pipeline infrastructure was built to prevent. Fresh context on each kick means the agent reads and follows the inlined data.

## Test plan
- [ ] Kick scanner — verify `/clear` appears in log before kick message
- [ ] Verify agent returns to prompt after `/clear` within 15s
- [ ] Verify kick message is delivered and agent starts working
- [ ] Monitor one full cycle — confirm agents follow pipeline classifications without drift