### PR TITLE
fix: always run enumerator on every kick cycle

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -668,11 +668,10 @@ kick() {
 # Each stage writes its output to /var/run/hive-metrics/*.json.
 # Agents receive pre-computed data in their kick messages — never query GitHub directly.
 /tmp/hive/bin/run-pipeline.sh 2>/dev/null || log "WARN: run-pipeline.sh failed (non-fatal, falling back to direct calls)"
-# Fallback: if pipeline runner failed, try the critical scripts directly
-if [ ! -f "/var/run/hive-metrics/actionable.json" ]; then
-  /tmp/hive/bin/enumerate-actionable.sh 2>/dev/null || log "WARN: enumerate-actionable.sh failed (non-fatal)"
-  /tmp/hive/bin/merge-gate.sh 2>/dev/null || log "WARN: merge-gate.sh failed (non-fatal)"
-fi
+# Always refresh the enumerator and merge gate — the pipeline may have 0 stages
+# configured, and a stale actionable.json causes agents to miss new issues.
+/tmp/hive/bin/enumerate-actionable.sh 2>/dev/null || log "WARN: enumerate-actionable.sh failed (non-fatal)"
+/tmp/hive/bin/merge-gate.sh 2>/dev/null || log "WARN: merge-gate.sh failed (non-fatal)"
 
 # Build inline work list for scanner kick message (agents must NOT list issues/PRs themselves)
 _ENUM_FILE="/var/run/hive-metrics/actionable.json"


### PR DESCRIPTION
## Summary
- `run-pipeline.sh` returns exit 0 with "0/0 stages OK" when no pipeline stages are configured in `hive-project.yaml`
- The fallback only ran `enumerate-actionable.sh` when `actionable.json` was missing entirely — but it existed (just stale from hours ago)
- Result: agents worked from a stale issue list and missed 3 Firefox Playwright bugs (#10992-10994) for 4+ hours

**Fix:** Always run `enumerate-actionable.sh` and `merge-gate.sh` on every kick cycle, regardless of pipeline status.

## Test plan
- [x] Deployed to dev server
- [x] Next scanner kick will refresh actionable.json and pick up the Firefox bugs
- [ ] Verify scanner dispatches fixes for #10992-10994 after next kick

🤖 Generated with [Claude Code](https://claude.com/claude-code)