### PR TITLE
feat: self-deploying timer for hive script updates

### DIFF
--- a/bin/hive-deploy.sh
+++ b/bin/hive-deploy.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# hive-deploy.sh — pull latest hive repo and sync scripts to /usr/local/bin.
+# Called by systemd timer every 5 minutes. Ensures the installed scripts
+# always match the repo without manual SCP or copy steps.
+
+set -euo pipefail
+
+HIVE_REPO="${HIVE_REPO_DIR:-/tmp/hive}"
+INSTALL_DIR="/usr/local/bin"
+LOG="/var/log/hive-deploy.log"
+TIMESTAMP="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+log() { echo "[$TIMESTAMP] $*" >> "$LOG" 2>/dev/null || true; }
+
+if [ ! -d "$HIVE_REPO/.git" ]; then
+  log "ERROR: $HIVE_REPO is not a git repo"
+  exit 1
+fi
+
+cd "$HIVE_REPO"
+
+BEFORE=$(git rev-parse HEAD)
+git pull --rebase origin main --quiet 2>/dev/null || {
+  log "WARN: git pull failed, skipping deploy"
+  exit 0
+}
+AFTER=$(git rev-parse HEAD)
+
+if [ "$BEFORE" = "$AFTER" ]; then
+  exit 0
+fi
+
+CHANGED_FILES=$(git diff --name-only "$BEFORE" "$AFTER")
+SCRIPTS_CHANGED=$(echo "$CHANGED_FILES" | grep '^bin/' || true)
+
+if [ -z "$SCRIPTS_CHANGED" ]; then
+  log "PULL $BEFORE→$AFTER — no bin/ changes, skipping sync"
+  exit 0
+fi
+
+SYNCED=""
+for script in $SCRIPTS_CHANGED; do
+  filename=$(basename "$script")
+  src="$HIVE_REPO/$script"
+  dst="$INSTALL_DIR/$filename"
+  if [ -f "$src" ] && [ -f "$dst" ]; then
+    cp "$src" "$dst"
+    chmod +x "$dst"
+    SYNCED="$SYNCED $filename"
+  fi
+done
+
+if [ -n "$SYNCED" ]; then
+  log "DEPLOY $BEFORE→$AFTER — synced:$SYNCED"
+fi

--- a/systemd/hive-deploy.service
+++ b/systemd/hive-deploy.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Pull latest hive repo and sync scripts to /usr/local/bin
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=dev
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ExecStart=/usr/local/bin/hive-deploy.sh
+StandardOutput=journal
+StandardError=journal

--- a/systemd/hive-deploy.timer
+++ b/systemd/hive-deploy.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Pull and deploy hive repo every 5 minutes
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=300
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

- Adds `hive-deploy.sh` — a script that pulls the hive repo and syncs changed `bin/` scripts to `/usr/local/bin/` automatically
- Adds systemd timer that runs every 5 minutes
- Eliminates manual SCP/copy after merging PRs — the system self-sustains
- Only syncs scripts that already exist at the destination (safe)
- Logs only when changes are actually deployed

## Setup (one-time on dev server)

```bash
sudo cp /tmp/hive/bin/hive-deploy.sh /usr/local/bin/hive-deploy.sh
sudo cp /tmp/hive/systemd/hive-deploy.service /etc/systemd/system/
sudo cp /tmp/hive/systemd/hive-deploy.timer /etc/systemd/system/
sudo systemctl daemon-reload
sudo systemctl enable --now hive-deploy.timer
```

## Test plan

- [ ] Merge a trivial change to `bin/kick-agents.sh`, wait 5 min, verify `/usr/local/bin/kick-agents.sh` updated automatically
- [ ] Verify no-op when HEAD hasn't changed (no log entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)