### PR TITLE
chore: deploy timer every 60s instead of 5min

### DIFF
--- a/bin/hive-deploy.sh
+++ b/bin/hive-deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # hive-deploy.sh — pull latest hive repo and sync scripts to /usr/local/bin.
-# Called by systemd timer every 5 minutes. Ensures the installed scripts
+# Called by systemd timer every 60 seconds. Ensures the installed scripts
 # always match the repo without manual SCP or copy steps.
 
 set -euo pipefail

--- a/systemd/hive-deploy.timer
+++ b/systemd/hive-deploy.timer
@@ -3,7 +3,7 @@ Description=Pull and deploy hive repo every 5 minutes
 
 [Timer]
 OnBootSec=60
-OnUnitActiveSec=300
+OnUnitActiveSec=60
 Persistent=true
 
 [Install]


### PR DESCRIPTION
## Summary

- Changes hive-deploy timer from 5-minute to 60-second cadence
- Script is a no-op when HEAD hasn't changed (instant exit after git fetch)
- Script updates propagate within ~1 minute of merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)