### PR TITLE
fix: add drift check so stale installed scripts get synced

### DIFF
--- a/bin/hive-deploy.sh
+++ b/bin/hive-deploy.sh
@@ -26,30 +26,35 @@ git pull --rebase origin main --quiet 2>/dev/null || {
 }
 AFTER=$(git rev-parse HEAD)
 
-if [ "$BEFORE" = "$AFTER" ]; then
-  exit 0
-fi
-
-CHANGED_FILES=$(git diff --name-only "$BEFORE" "$AFTER")
-SCRIPTS_CHANGED=$(echo "$CHANGED_FILES" | grep '^bin/' || true)
-
-if [ -z "$SCRIPTS_CHANGED" ]; then
-  log "PULL $BEFORE→$AFTER — no bin/ changes, skipping sync"
-  exit 0
-fi
-
 SYNCED=""
-for script in $SCRIPTS_CHANGED; do
-  filename=$(basename "$script")
-  src="$HIVE_REPO/$script"
+
+if [ "$BEFORE" != "$AFTER" ]; then
+  CHANGED_FILES=$(git diff --name-only "$BEFORE" "$AFTER")
+  SCRIPTS_CHANGED=$(echo "$CHANGED_FILES" | grep '^bin/' || true)
+  for script in $SCRIPTS_CHANGED; do
+    filename=$(basename "$script")
+    src="$HIVE_REPO/$script"
+    dst="$INSTALL_DIR/$filename"
+    if [ -f "$src" ] && [ -f "$dst" ]; then
+      cp "$src" "$dst"
+      chmod +x "$dst"
+      SYNCED="$SYNCED $filename"
+    fi
+  done
+fi
+
+# Drift check: even if HEAD unchanged, installed files may be stale
+for src in "$HIVE_REPO"/bin/*.sh; do
+  filename=$(basename "$src")
   dst="$INSTALL_DIR/$filename"
-  if [ -f "$src" ] && [ -f "$dst" ]; then
+  [ -f "$dst" ] || continue
+  if ! cmp -s "$src" "$dst"; then
     cp "$src" "$dst"
     chmod +x "$dst"
-    SYNCED="$SYNCED $filename"
+    SYNCED="$SYNCED $filename(drift)"
   fi
 done
 
 if [ -n "$SYNCED" ]; then
-  log "DEPLOY $BEFORE→$AFTER — synced:$SYNCED"
+  log "DEPLOY ${BEFORE:0:7}→${AFTER:0:7} — synced:$SYNCED"
 fi


### PR DESCRIPTION
## Summary

- Deploy script only synced on new git commits — stale files from before the timer was set up would never get fixed
- Now every 60s run also compares each `bin/*.sh` in the repo against `/usr/local/bin/` and syncs any that differ
- This fixes the bug where `kick-governor.sh` was stale and ignoring the budget-ignore flag

## Test plan

- [x] Manually synced kick-governor.sh — governor now respects budget_ignore flag
- [ ] After deploy, intentionally corrupt an installed script, wait 60s, verify it's restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)