### PR TITLE
fix: dashboard scroll jumps to top on SSE refresh

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1169,7 +1169,7 @@
       renderTokens(data.tokens || {});
       renderRepos(data.repos || []);
       renderBeads(data.beads || {});
-      requestAnimationFrame(() => window.scrollTo(0, scrollY));
+      requestAnimationFrame(() => requestAnimationFrame(() => window.scrollTo(0, scrollY)));
     }
 
     function esc(s) {


### PR DESCRIPTION
## Summary
- Dashboard scrolls back to top every 5s when SSE pushes new data
- Root cause: single `requestAnimationFrame` fires before browser finishes layout after `innerHTML` updates
- Fix: double-rAF ensures scroll restore happens after paint is committed

## Test plan
- [ ] Scroll to bottom of dashboard, wait 10+ seconds, confirm position holds
- [ ] Verify data still updates (timestamp, agent status, sparklines)