### PR TITLE
fix: summary lines stretch to fill agent card width

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -64,7 +64,7 @@
     .value.idle { color: var(--muted); }
     .value.copilot { color: var(--cyan); }
     .value.claude { color: var(--purple); }
-    .doing { font-size: 0.75rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: pre-line; line-height: 1.5; min-height: 5.6em; }
+    .doing { font-size: 0.75rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: normal; line-height: 1.5; min-height: 5.6em; width: 100%; }
     .summary-age { display: inline-block; font-size: 0.6rem; font-style: normal; border-radius: 3px; padding: 1px 5px; margin-right: 5px; vertical-align: middle; white-space: nowrap; }
     .summary-age.age-recent { background: rgba(210,153,34,0.15); color: #d29922; border: 1px solid rgba(210,153,34,0.3); }
     .summary-age.age-stale  { background: rgba(248,81,73,0.15);  color: #f85149; border: 1px solid rgba(248,81,73,0.3); }


### PR DESCRIPTION
## Summary
- Changed `.doing` CSS from `white-space: pre-line` to `white-space: normal` so agent summary text reflows to fill the full card width as the card resizes
- Added `width: 100%` for explicit stretch
- `pre-line` was preserving embedded newlines in the SSE summary data, causing text to wrap at ~80 chars even when the card was wider

## Test plan
- [ ] Verify summary text fills the full card width on the dashboard
- [ ] Check that text still wraps correctly on narrow viewports