### PR TITLE
fix: deploy restarts dashboard on file drift

### DIFF
--- a/bin/hive-deploy.sh
+++ b/bin/hive-deploy.sh
@@ -57,11 +57,33 @@ for src in "$HIVE_REPO"/bin/*.sh; do
   fi
 done
 
-# Restart dashboard if any dashboard/ files changed
+# Restart dashboard if any dashboard/ files changed during pull
 if [ -n "$DASHBOARD_CHANGED" ]; then
   sudo systemctl restart hive-dashboard.service 2>/dev/null && \
     SYNCED="$SYNCED dashboard(restart)" || \
     log "WARN: failed to restart hive-dashboard"
+fi
+
+# Dashboard drift check: restart if running process is older than dashboard files
+DASH_RESTART_NEEDED=""
+if systemctl is-active --quiet hive-dashboard.service 2>/dev/null; then
+  DASH_PID=$(systemctl show hive-dashboard.service --property=MainPID --value 2>/dev/null)
+  if [ -n "$DASH_PID" ] && [ "$DASH_PID" != "0" ]; then
+    DASH_START=$(stat -c %Y "/proc/$DASH_PID" 2>/dev/null || echo 0)
+    for df in "$HIVE_REPO"/dashboard/*.js "$HIVE_REPO"/dashboard/*.html; do
+      [ -f "$df" ] || continue
+      FILE_MTIME=$(stat -c %Y "$df" 2>/dev/null || echo 0)
+      if [ "$FILE_MTIME" -gt "$DASH_START" ]; then
+        DASH_RESTART_NEEDED="yes"
+        break
+      fi
+    done
+  fi
+fi
+if [ -n "$DASH_RESTART_NEEDED" ] && [ -z "$DASHBOARD_CHANGED" ]; then
+  sudo systemctl restart hive-dashboard.service 2>/dev/null && \
+    SYNCED="$SYNCED dashboard(drift-restart)" || \
+    log "WARN: failed to restart hive-dashboard (drift)"
 fi
 
 if [ -n "$SYNCED" ]; then


### PR DESCRIPTION
## Summary
- Dashboard restart only triggered when `git pull` moved HEAD and changed `dashboard/` files
- If HEAD was already current (manual pull, reset, or prior deploy cycle), the dashboard never restarted — running stale code indefinitely
- Adds a drift check: compares the running dashboard process start time against dashboard file mtimes, restarts if files are newer

## Test plan
- [ ] Merge, wait 60s for deploy cycle, verify dashboard shows updated code
- [ ] Manually touch a dashboard file, verify deploy restarts within 60s