### PR TITLE
fix: use sudo for /usr/local/bin copies in deploy

### DIFF
--- a/bin/hive-deploy.sh
+++ b/bin/hive-deploy.sh
@@ -37,8 +37,8 @@ if [ "$BEFORE" != "$AFTER" ]; then
     src="$HIVE_REPO/$script"
     dst="$INSTALL_DIR/$filename"
     if [ -f "$src" ] && [ -f "$dst" ]; then
-      cp "$src" "$dst"
-      chmod +x "$dst"
+      sudo cp "$src" "$dst"
+      sudo chmod +x "$dst"
       SYNCED="$SYNCED $filename"
     fi
   done
@@ -51,8 +51,8 @@ for src in "$HIVE_REPO"/bin/*.sh; do
   dst="$INSTALL_DIR/$filename"
   [ -f "$dst" ] || continue
   if ! cmp -s "$src" "$dst"; then
-    cp "$src" "$dst"
-    chmod +x "$dst"
+    sudo cp "$src" "$dst"
+    sudo chmod +x "$dst"
     SYNCED="$SYNCED $filename(drift)"
   fi
 done


### PR DESCRIPTION
## Summary
- Deploy service runs as `User=dev` but all files in `/usr/local/bin/` are owned by root
- Plain `cp` fails with permission denied, crashing the deploy loop every 60s
- This blocks ALL script syncs and dashboard restarts
- Added `sudo` to both the git-diff copy block and the drift check copy

## Test plan
- [ ] Deploy service stops failing in journalctl
- [ ] Dashboard drift-restart triggers on next cycle