### PR TITLE
fix: show median fix time instead of avg on dashboard

### DIFF
--- a/dashboard/api-collector.sh
+++ b/dashboard/api-collector.sh
@@ -280,8 +280,9 @@ cutoff = time.time()*1000 - $ITM_BACKFILL_DAYS*86400000
 history = []
 for t in sorted(bucketed.keys()):
     if t < cutoff: continue
-    vals = bucketed[t]
-    history.append({'t': t, 'avg': round(sum(vals)/len(vals))})
+    vals = sorted(bucketed[t])
+    bucket_median = vals[len(vals)//2]
+    history.append({'t': t, 'avg': round(sum(vals)/len(vals)), 'median': bucket_median})
 
 result = {
     'avg_minutes': avg, 'median_minutes': median, 'p90_minutes': p90,

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -948,9 +948,9 @@
       const itmMedian = itm.median_minutes || 0;
       const itmCount = itm.count || 0;
       const FIX_TIME_SPARK_COLOR = '#d2a8ff';
-      const itmHistory = (itm.history || []).map(h => h.avg);
+      const itmHistory = (itm.history || []).map(h => h.median || h.avg);
       const itmSpark = sparkSvg(itmHistory, FIX_TIME_SPARK_COLOR);
-      const itmTitle = itmCount > 0 ? `median: ${formatFixTime(itmMedian)} | p90: ${formatFixTime(itm.p90_minutes)} | fastest: ${formatFixTime(itm.fastest_minutes)} | slowest: ${formatFixTime(itm.slowest_minutes)} | ${itmCount} fixes` : 'no data yet';
+      const itmTitle = itmCount > 0 ? `avg: ${formatFixTime(itmAvg)} | p90: ${formatFixTime(itm.p90_minutes)} | fastest: ${formatFixTime(itm.fastest_minutes)} | slowest: ${formatFixTime(itm.slowest_minutes)} | ${itmCount} fixes` : 'no data yet';
 
       el.innerHTML = `
         <div class="gov-title">Governor</div>
@@ -959,7 +959,7 @@
           <div class="gov-stat"><div class="label">mode</div><div class="val" style="color:${modeColor}">${gov.mode}</div></div>
           <div class="gov-stat"><div class="label">actionable issues</div><div class="spark-row"><span class="val">${issueCount}</span>${issuesSpark}</div></div>
           <div class="gov-stat"><div class="label">PRs</div><div class="spark-row"><span class="val">${gov.prs}</span>${prsSpark}</div></div>
-          <div class="gov-stat" title="${itmTitle}"><div class="label">avg fix time</div><div class="spark-row"><span class="val" style="color:${FIX_TIME_SPARK_COLOR}">${formatFixTime(itmAvg)}</span>${itmSpark}</div></div>
+          <div class="gov-stat" title="${itmTitle}"><div class="label">median fix time</div><div class="spark-row"><span class="val" style="color:${FIX_TIME_SPARK_COLOR}">${formatFixTime(itmMedian)}</span>${itmSpark}</div></div>
           <div class="gov-stat"><div class="label">next run</div><div class="val">${gov.nextKick || '—'}</div></div>
         </div>
         <div class="temp-gauge">


### PR DESCRIPTION
## Summary
- Display median fix time instead of avg (avg skewed by long-tail outliers)
- Sparkline history buckets now emit median alongside avg
- Tooltip still shows avg, p90, fastest, slowest for full context

## Test plan
- [ ] Dashboard Governor shows "median fix time" with realistic value (~2h vs ~2.4d)
- [ ] Hover tooltip shows avg, p90, fastest, slowest