### PR TITLE
feat: live median fix time badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # hive
 
+[![Median Fix Time](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fclubanderson%2F4ae525a9797e8f83231ac344fcb47226%2Fraw%2Fmedian-fix.json&style=for-the-badge)](https://github.com/kubestellar/console/issues)
+
 **One command starts everything. Your phone, Slack, or Discord buzzes if anything needs you.**
 
 ![hive dashboard](docs/dashboard-screenshot.png)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Median Fix Time](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fclubanderson%2F4ae525a9797e8f83231ac344fcb47226%2Fraw%2Fmedian-fix.json&style=for-the-badge)](https://github.com/kubestellar/console/issues)
 
+*How long from "issue filed" to "PR merged" — updated every 5 minutes from the last 100 fixes.*
+
 **One command starts everything. Your phone, Slack, or Discord buzzes if anything needs you.**
 
 ![hive dashboard](docs/dashboard-screenshot.png)

--- a/dashboard/api-collector.sh
+++ b/dashboard/api-collector.sh
@@ -293,3 +293,26 @@ result = {
 json.dump(result, open('$ITM_FILE','w'))
 print(f'issue-to-merge: avg={avg}m median={median}m p90={p90}m count={len(durations)}')
 " 2>&1 || echo "issue-to-merge: python computation failed"
+
+# ── Update shields.io badge gist ───────────────────────────────────────────
+BADGE_GIST_ID="${BADGE_GIST_ID:-4ae525a9797e8f83231ac344fcb47226}"
+if [ -f "$ITM_FILE" ]; then
+  badge_median=$(jq -r '.median_minutes // 0' "$ITM_FILE" 2>/dev/null || echo 0)
+  badge_count=$(jq -r '.count // 0' "$ITM_FILE" 2>/dev/null || echo 0)
+  if [ "$badge_count" -gt 0 ] 2>/dev/null; then
+    if [ "$badge_median" -le 60 ]; then
+      badge_color="brightgreen"
+    elif [ "$badge_median" -le 240 ]; then
+      badge_color="yellow"
+    else
+      badge_color="red"
+    fi
+    badge_msg="${badge_median} min"
+  else
+    badge_color="lightgrey"
+    badge_msg="no data"
+  fi
+  badge_json="{\"schemaVersion\":1,\"label\":\"median fix time\",\"message\":\"${badge_msg}\",\"color\":\"${badge_color}\"}"
+  echo "$badge_json" > "$tmpdir/median-fix.json"
+  $GH gist edit "$BADGE_GIST_ID" -f median-fix.json "$tmpdir/median-fix.json" 2>/dev/null || echo "badge gist update failed"
+fi


### PR DESCRIPTION
## Summary
- Adds a shields.io dynamic badge to README showing median issue-to-merge time in minutes
- `api-collector.sh` updates a GitHub Gist every 5 minutes with current stats
- Color bands: 🟢 ≤60min, 🟡 ≤240min, 🔴 >240min
- Falls back to "no data" (grey) if no fixes tracked, "endpoint error" if gist unreachable
- Links to console issues page when clicked

## How it works
1. `api-collector.sh` computes median fix time (already done)
2. New: writes shields.io JSON to gist via `gh gist edit`
3. README badge URL points to shields.io endpoint which reads the gist
4. Updates every ~5 min (collector cycle) + shields.io ~5 min cache = ~10 min lag

## Test plan
- [ ] After deploy, verify gist updates with real median value
- [ ] Badge renders on README with correct color
- [ ] Badge shows "no data" when ITM file is empty