### PR TITLE
Rename median fix time to MTTR, add badge gist update

### DIFF
--- a/dashboard/api-collector.sh
+++ b/dashboard/api-collector.sh
@@ -294,25 +294,21 @@ json.dump(result, open('$ITM_FILE','w'))
 print(f'issue-to-merge: avg={avg}m median={median}m p90={p90}m count={len(durations)}')
 " 2>&1 || echo "issue-to-merge: python computation failed"
 
-# ── Update shields.io badge gist ───────────────────────────────────────────
+# ── Update MTTR badge gist ─────────────────────────────────────────────────
 BADGE_GIST_ID="${BADGE_GIST_ID:-4ae525a9797e8f83231ac344fcb47226}"
 if [ -f "$ITM_FILE" ]; then
   badge_median=$(jq -r '.median_minutes // 0' "$ITM_FILE" 2>/dev/null || echo 0)
   badge_count=$(jq -r '.count // 0' "$ITM_FILE" 2>/dev/null || echo 0)
   if [ "$badge_count" -gt 0 ] 2>/dev/null; then
-    if [ "$badge_median" -le 60 ]; then
-      badge_color="brightgreen"
-    elif [ "$badge_median" -le 240 ]; then
-      badge_color="yellow"
-    else
-      badge_color="red"
-    fi
+    if [ "$badge_median" -le 60 ]; then badge_color="brightgreen"
+    elif [ "$badge_median" -le 240 ]; then badge_color="yellow"
+    else badge_color="red"; fi
     badge_msg="${badge_median} min"
   else
     badge_color="lightgrey"
     badge_msg="no data"
   fi
-  badge_json="{\"schemaVersion\":1,\"label\":\"median fix time\",\"message\":\"${badge_msg}\",\"color\":\"${badge_color}\"}"
+  badge_json="{\"schemaVersion\":1,\"label\":\"MTTR\",\"message\":\"${badge_msg}\",\"color\":\"${badge_color}\"}"
   echo "$badge_json" > "$tmpdir/median-fix.json"
   $GH gist edit "$BADGE_GIST_ID" -f median-fix.json "$tmpdir/median-fix.json" 2>/dev/null || echo "badge gist update failed"
 fi

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -950,7 +950,7 @@
       const FIX_TIME_SPARK_COLOR = '#d2a8ff';
       const itmHistory = (itm.history || []).map(h => h.median || h.avg);
       const itmSpark = sparkSvg(itmHistory, FIX_TIME_SPARK_COLOR);
-      const itmTitle = itmCount > 0 ? `avg: ${formatFixTime(itmAvg)} | p90: ${formatFixTime(itm.p90_minutes)} | fastest: ${formatFixTime(itm.fastest_minutes)} | slowest: ${formatFixTime(itm.slowest_minutes)} | ${itmCount} fixes` : 'no data yet';
+      const itmTitle = itmCount > 0 ? `MTTR (Mean Time to Resolution) — median: ${formatFixTime(itmMedian)} | avg: ${formatFixTime(itmAvg)} | p90: ${formatFixTime(itm.p90_minutes)} | fastest: ${formatFixTime(itm.fastest_minutes)} | slowest: ${formatFixTime(itm.slowest_minutes)} | ${itmCount} fixes in last 30d` : 'MTTR — no data yet';
 
       el.innerHTML = `
         <div class="gov-title">Governor</div>
@@ -959,7 +959,7 @@
           <div class="gov-stat"><div class="label">mode</div><div class="val" style="color:${modeColor}">${gov.mode}</div></div>
           <div class="gov-stat"><div class="label">actionable issues</div><div class="spark-row"><span class="val">${issueCount}</span>${issuesSpark}</div></div>
           <div class="gov-stat"><div class="label">PRs</div><div class="spark-row"><span class="val">${gov.prs}</span>${prsSpark}</div></div>
-          <div class="gov-stat" title="${itmTitle}"><div class="label">median fix time</div><div class="spark-row"><span class="val" style="color:${FIX_TIME_SPARK_COLOR}">${formatFixTime(itmMedian)}</span>${itmSpark}</div></div>
+          <div class="gov-stat" title="${itmTitle}"><div class="label">MTTR</div><div class="spark-row"><span class="val" style="color:${FIX_TIME_SPARK_COLOR}">${formatFixTime(itmMedian)}</span>${itmSpark}</div></div>
           <div class="gov-stat"><div class="label">next run</div><div class="val">${gov.nextKick || '—'}</div></div>
         </div>
         <div class="temp-gauge">


### PR DESCRIPTION
## Summary
- Dashboard label changed from "median fix time" to "MTTR"
- Hover text shows full breakdown: MTTR (Mean Time to Resolution) — median, avg, p90, fastest, slowest, fix count
- api-collector.sh now updates the shields.io badge gist every 5 minutes with current median and color band
- Badge color bands: green ≤60min, yellow ≤240min, red >240min

## Test plan
- [ ] Dashboard shows "MTTR" label with hover tooltip
- [ ] Badge gist gets updated after next api-collector run