### PR TITLE
fix: deterministic status heartbeat — stop agent restart loop

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -265,6 +265,16 @@ restart_stuck_agent() {
     kill -9 "$pane_pid" 2>/dev/null || true
     sleep 2
   fi
+  # Reset status file so governor doesn't immediately re-flag as stale
+  local status_file="$HOME/.hive/${agent}_status.txt"
+  cat > "$status_file" <<STATUSEOF
+AGENT=$agent
+STATUS=INITIALIZING
+TASK=Restarting after stuck detection
+PROGRESS=Process killed, supervisor relaunching
+RESULTS=
+UPDATED=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
+STATUSEOF
   # supervisor.sh detects the killed process and relaunches automatically
   # (reading the governor model file for the correct backend:model).
   # Just wait for it to come back.
@@ -628,6 +638,15 @@ kick() {
 
   log "KICK $session (${#message} chars)"
   send_chunked "$session" "$message"
+  # Deterministic status heartbeat — refresh timestamp on every kick
+  cat > "$HOME/.hive/${agent}_status.txt" <<STATUSEOF
+AGENT=$agent
+STATUS=WORKING
+TASK=Processing kick
+PROGRESS=Kick delivered, agent working
+RESULTS=
+UPDATED=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
+STATUSEOF
   # Verify Enter was delivered — retry then restart if buffer is stuck
   sleep 3
   local _vline _vtext


### PR DESCRIPTION
## Summary
- Agents (especially scanner) restart every ~20min in a loop because the status file `UPDATED` timestamp is only written by the LLM agent, which doesn't reliably do it
- Governor sees stale timestamp → stuck counter → restart → but nobody resets the file → repeat
- **Fix 1**: `restart_stuck_agent()` now resets status file immediately after kill (stops the loop)
- **Fix 2**: `kick()` now refreshes status file on every successful kick (prevents future staleness)
- Governor only escalates when agent hasn't been kicked AND hasn't self-reported — a genuine stuck condition

## Test plan
- [ ] Deploy, watch scanner for 30 min — zero spurious restarts
- [ ] `cat ~/.hive/scanner_status.txt` — UPDATED within last kick cycle
- [ ] `grep 'ESCALATE\|STALE' /var/log/kick-governor.log | tail -5` — no new entries