### PR TITLE
add send button for custom agent prompts

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -862,8 +862,9 @@
           ${needsLogin ? '<div class="login-warning">⚠ NOT LOGGED IN — run /login</div>' : ''}
           ${summaryEl}${indEl}
           <div class="agent-actions">
-            <input type="text" class="kick-prompt" id="kick-prompt-${a.name}" placeholder="custom prompt (optional)" />
-            <button class="btn" onclick="kick('${a.name}')">kick</button>
+            <input type="text" class="kick-prompt" id="kick-prompt-${a.name}" placeholder="custom prompt (optional)" onkeydown="if(event.key==='Enter'){kick('${a.name}')}" />
+            <button class="btn" onclick="kick('${a.name}')" title="Send custom prompt to agent">send</button>
+            <button class="btn" onclick="document.getElementById('kick-prompt-${a.name}').value='';kick('${a.name}')">kick</button>
             <select class="btn backend-select" onchange="switchCli('${a.name}', this.value); this.selectedIndex=0">
               <option value="" disabled selected>cli ▾</option>
               ${KNOWN_BACKENDS.map(b => `<option value="${b}" ${a.cli === b ? 'disabled' : ''}>${b}</option>`).join('')}


### PR DESCRIPTION
## Summary
- Adds a **send** button next to the custom prompt input that delivers the typed prompt to the agent
- Existing **kick** button now clears the prompt field first, sending the default cadence kick
- **Enter key** in the prompt field triggers send

## Test plan
- [ ] Type a custom prompt, click send — verify agent receives it
- [ ] Click kick with empty prompt — verify default kick fires
- [ ] Type a prompt, press Enter — verify it sends
- [ ] Click kick with text in field — verify text is cleared and default kick fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)