### PR TITLE
skip resolved SHA markers in re-check loop

### DIFF
--- a/bin/enumerate-actionable.sh
+++ b/bin/enumerate-actionable.sh
@@ -306,6 +306,8 @@ fi
 # --- Re-check previously SHA-held issues: if SHA was added, unhold them ---
 for marker_file in "${SHA_HOLD_MARKER}"_*; do
   [ -f "$marker_file" ] || continue
+  # Skip already-resolved markers — no need to re-check
+  grep -q "^resolved=" "$marker_file" 2>/dev/null && continue
   # Extract repo and number from marker filename: sha_hold_posted_org_repo_NUM
   marker_base=$(basename "$marker_file")
   num="${marker_base##*_}"


### PR DESCRIPTION
## Summary
- Re-check loop now skips markers containing `resolved=`, preventing repeated SHA-UNHOLD log entries and unnecessary API calls on every enum cycle

## Test plan
- [ ] Deploy, verify no SHA-UNHOLD entries in kick-agents.log for resolved issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)