### PR TITLE
fix resume endpoint: remove cadence file on unpause

### DIFF
--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -795,9 +795,11 @@ app.post('/api/resume/:agent', (req, res) => {
   }
   const pauseFlag = path.join(GOVERNOR_CADENCE_DIR, `paused_${agent}`);
   const operatorFlag = path.join(GOVERNOR_CADENCE_DIR, `operator_paused_${agent}`);
+  const cadenceFlag = path.join(GOVERNOR_CADENCE_DIR, `cadence_${agent}`);
   try {
     if (fs.existsSync(pauseFlag)) fs.unlinkSync(pauseFlag);
     if (fs.existsSync(operatorFlag)) fs.unlinkSync(operatorFlag);
+    if (fs.existsSync(cadenceFlag)) fs.unlinkSync(cadenceFlag);
   } catch (e) {
     return res.status(500).json({ error: `failed to remove pause flag: ${e.message}` });
   }


### PR DESCRIPTION
## Summary
- Pause endpoint writes `cadence_<agent>=paused` but resume only removed `paused_` and `operator_paused_` files
- This left the cadence table showing "paused" even after clicking resume
- Fix: also delete `cadence_<agent>` on resume so governor picks up the default

## Test plan
- [ ] Pause outreach from dashboard → verify cadence shows "paused"
- [ ] Resume outreach → verify cadence file is removed and table shows default interval
- [ ] Verify pause files (`paused_`, `operator_paused_`, `cadence_`) are all cleaned up