### PR TITLE
wire copilot-comment-checker.sh into pre-kick pipeline

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -691,6 +691,7 @@ STATUSEOF
 # configured, and a stale actionable.json causes agents to miss new issues.
 /tmp/hive/bin/enumerate-actionable.sh 2>/dev/null || log "WARN: enumerate-actionable.sh failed (non-fatal)"
 /tmp/hive/bin/merge-gate.sh 2>/dev/null || log "WARN: merge-gate.sh failed (non-fatal)"
+/tmp/hive/bin/copilot-comment-checker.sh 2>/dev/null || log "WARN: copilot-comment-checker.sh failed (non-fatal)"
 
 # Build inline work list for scanner kick message (agents must NOT list issues/PRs themselves)
 _ENUM_FILE="/var/run/hive-metrics/actionable.json"


### PR DESCRIPTION
## Summary
- `copilot-comment-checker.sh` existed but was never invoked — the output file (`copilot-comments.json`) was always missing
- Reviewer's kick message references this file for unaddressed Copilot review comments on merged PRs, but it was always empty
- Fix: call it in the pre-kick pipeline alongside `enumerate-actionable.sh` and `merge-gate.sh`

## Test plan
- [ ] After deploy, check `/var/run/hive-metrics/copilot-comments.json` exists after a kick cycle
- [ ] Verify reviewer kick message includes Copilot comment data
- [ ] Confirm non-fatal on failure (||  log WARN pattern)