### PR TITLE
scanner idle cadence: 30min → 15min

### DIFF
--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -27,7 +27,7 @@
 #     outreach  → every 2 hours
 #
 #   IDLE (queue ≤ IDLE_THRESHOLD):
-#     scanner   → every 30 min
+#     scanner   → every 15 min
 #     reviewer  → every 1 hour
 #     architect → every 30 min  (jam — queue is clear)
 #     outreach  → every 2 hours
@@ -83,7 +83,7 @@ IDLE_THRESHOLD_ISSUES="${IDLE_THRESHOLD_ISSUES:-2}"
 CADENCE_SCANNER_SURGE_SEC="${CADENCE_SCANNER_SURGE_SEC:-900}"     # 15 min
 CADENCE_SCANNER_BUSY_SEC="${CADENCE_SCANNER_BUSY_SEC:-900}"       # 15 min
 CADENCE_SCANNER_QUIET_SEC="${CADENCE_SCANNER_QUIET_SEC:-900}"     # 15 min
-CADENCE_SCANNER_IDLE_SEC="${CADENCE_SCANNER_IDLE_SEC:-1800}"      # 30 min
+CADENCE_SCANNER_IDLE_SEC="${CADENCE_SCANNER_IDLE_SEC:-900}"       # 15 min
 
 CADENCE_REVIEWER_SURGE_SEC="${CADENCE_REVIEWER_SURGE_SEC:-900}"    # 15 min
 CADENCE_REVIEWER_BUSY_SEC="${CADENCE_REVIEWER_BUSY_SEC:-900}"     # 15 min


### PR DESCRIPTION
## Summary
- Scanner idle cadence was 30min, meaning open PRs awaiting CI sat unattended for up to 30min
- Changed to 15min to match surge/busy/quiet modes — scanner always runs every 15min

## Test plan
- [ ] After deploy, verify `cadence_scanner` shows `15min` in idle mode
- [ ] Confirm scanner gets kicked every ~15min even with empty queue