### PR TITLE
feat: test CRUD signaling with soft merge block

### DIFF
--- a/bin/merge-gate.sh
+++ b/bin/merge-gate.sh
@@ -107,7 +107,39 @@ else:
       mergeable=$(echo "$pr_info" | python3 -c "import json,sys; print(json.load(sys.stdin).get('mergeable','UNKNOWN'))" 2>/dev/null || echo "UNKNOWN")
       review=$(echo "$pr_info" | python3 -c "import json,sys; print(json.load(sys.stdin).get('reviewDecision',''))" 2>/dev/null || echo "")
 
-      echo "{\"repo\":\"$repo\",\"number\":$num,\"status\":\"$status\",\"author\":\"$author\",\"title\":$(python3 -c "import json; print(json.dumps('$title'[:100]))" 2>/dev/null || echo '""'),\"mergeable\":\"$mergeable\",\"reviewDecision\":\"$review\"}" > "$checks_tmp/${repo//\//_}_${num}.json"
+      # --- Test CRUD detection ---
+      pr_files=$(gh api "repos/${repo}/pulls/${num}/files" --jq '.[].filename' 2>/dev/null || echo "")
+
+      test_status=$(echo "$pr_files" | python3 -c "
+import sys, os.path
+
+TEST_PATTERN_SUFFIXES = ('.test.', '.spec.', '_test.')
+TEST_DIR_PATTERNS = ('__tests__/', '/tests/', '/test/')
+CODE_EXTENSIONS = {'.ts', '.tsx', '.js', '.jsx', '.go', '.py', '.rs', '.java'}
+
+files = [l.strip() for l in sys.stdin if l.strip()]
+
+def is_test_file(f):
+    fl = f.lower()
+    return any(p in fl for p in TEST_PATTERN_SUFFIXES) or any(p in fl for p in TEST_DIR_PATTERNS)
+
+def is_code_file(f):
+    _, ext = os.path.splitext(f)
+    return ext.lower() in CODE_EXTENSIONS and not is_test_file(f)
+
+has_test = any(is_test_file(f) for f in files)
+code_files = [f for f in files if is_code_file(f)]
+test_exempt = len(code_files) == 0
+
+if has_test:
+    print('included')
+elif test_exempt:
+    print('exempt')
+else:
+    print('missing')
+" 2>/dev/null || echo "unknown")
+
+      echo "{\"repo\":\"$repo\",\"number\":$num,\"status\":\"$status\",\"author\":\"$author\",\"title\":$(python3 -c "import json; print(json.dumps('$title'[:100]))" 2>/dev/null || echo '""'),\"mergeable\":\"$mergeable\",\"reviewDecision\":\"$review\",\"test_status\":\"$test_status\"}" > "$checks_tmp/${repo//\//_}_${num}.json"
     fi
   ) &
 done
@@ -140,8 +172,10 @@ for f in sorted(glob.glob(os.path.join(checks_dir, '*.json'))):
     pr['ci_pass'] = ci_pass
     pr['approved'] = approved
 
-    # Eligible: CI green + mergeable + (AI-authored OR community-approved)
-    if ci_pass and mergeable and (is_ai or approved):
+    test_missing = pr.get('test_status') == 'missing'
+
+    # Eligible: CI green + mergeable + (AI-authored OR community-approved) + has tests
+    if ci_pass and mergeable and (is_ai or approved) and not test_missing:
         eligible.append(pr)
     else:
         reasons = []
@@ -151,6 +185,8 @@ for f in sorted(glob.glob(os.path.join(checks_dir, '*.json'))):
             reasons.append(f\"mergeable={pr.get('mergeable','?')}\")
         if not is_ai and not approved:
             reasons.append(f\"author={pr.get('author','?')} (not AI, not approved)\")
+        if test_missing:
+            reasons.append('missing_test')
         pr['block_reasons'] = reasons
         not_ready.append(pr)
 

--- a/examples/kubestellar/agents/reviewer-CLAUDE.md
+++ b/examples/kubestellar/agents/reviewer-CLAUDE.md
@@ -83,6 +83,38 @@ unset GITHUB_TOKEN && gh api "repos/${PROJECT_PRIMARY_REPO}/pulls/<NUMBER>/comme
 - Bundle findings from multiple PRs into a single follow-up PR when they touch the same files
 - Title format: `🐛 Address Copilot review findings from PRs #NNNN, #MMMM`
 
+## Test Coverage Check — EVERY PASS (after Copilot review)
+
+For each merged PR from Step 1 above, check whether it includes a regression test. Read `test_status` from `/var/run/hive-metrics/merge-eligible.json` (the merge-gate annotates every PR).
+
+**Workflow:**
+
+```bash
+# Read test_status for a merged PR from the last merge-gate run
+cat /var/run/hive-metrics/merge-eligible.json | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for pr in d.get('merge_eligible', []) + d.get('not_ready', []):
+    if pr.get('number') == int(sys.argv[1]):
+        print(pr.get('test_status', 'unknown'))
+        break
+" <PR_NUMBER>
+```
+
+**Actions by test_status:**
+
+1. **`included`** — Test was added/modified in the PR. Update bead: `bd update <bead_id> --set-metadata test_status=included`. No further action.
+2. **`exempt`** — PR only changed config/docs/infra (no .ts/.tsx/.go/.py). Update bead: `bd update <bead_id> --set-metadata test_status=exempt`. No further action.
+3. **`existing_untouched`** — A companion test file exists but was NOT modified by the PR. **Read the companion test file AND the PR diff.** Judge whether existing test cases exercise the fixed code path:
+   - If covered → `bd update <bead_id> --set-metadata test_status=covered_by_existing`. No issue.
+   - If NOT covered → File issue: "Add test case to [test file] for fix in PR #N (Fixes #X)". Label: `kind/test`, `auto-qa`, `test-gap`. Update bead: `bd update <bead_id> --set-metadata test_status=test_gap test_debt_issue=<issue_number>`
+4. **`missing`** — No test file exists and PR changed source code. This PR was either merged via `--admin` bypass or before the soft block was deployed. File issue: "Add regression test for PR #N (Fixes #X)". Label: `kind/test`, `auto-qa`, `test-debt`. Update bead: `bd update <bead_id> --set-metadata test_status=missing test_debt_issue=<issue_number>`
+
+**Rules:**
+- Do NOT skip this step — it runs alongside the Copilot review, same PR iteration
+- Do NOT file duplicate test-debt issues — check if one already exists for the PR before filing
+- For `existing_untouched`: actually read the test file contents and the diff. A companion test that only tests unrelated functions does NOT count as covering the fix.
+
 ## SPEED RULES — Non-Negotiable
 
 1. **5-MINUTE DIAGNOSIS CAP.** You have 5 minutes from identifying a RED indicator to opening a fix PR. If you cannot diagnose root cause in 5 minutes, open a best-effort fix PR anyway.

--- a/examples/kubestellar/agents/scanner-CLAUDE.md
+++ b/examples/kubestellar/agents/scanner-CLAUDE.md
@@ -186,7 +186,7 @@ When a PR has failing Netlify checks (`netlify/kubestellar-docs/deploy-preview`,
 1. Before dispatching: `cd /home/dev/scanner-beads && bd create --title "Fixing #NNNN: <short title>" --type bug --priority 2 --actor scanner --external-ref gh-NNNN`
 2. Claim the bead: `bd update <bead_id> --claim`
 3. Dispatch the Agent tool call
-4. On agent completion (PR opened): `bd update <bead_id> --set-metadata pr_ref=<PR_number>`
+4. On agent completion (PR opened): `bd update <bead_id> --set-metadata pr_ref=<PR_number> test_status=pending`
 5. On PR merge: `bd close <bead_id>`
 6. If agent fails (no PR after 30 min): `bd update <bead_id> --status open --set-metadata sweep_reason=agent_failed`
 
@@ -198,6 +198,7 @@ This ensures every dispatched agent has a trackable bead. If scanner crashes mid
 Fix ${PROJECT_PRIMARY_REPO}#NNNN. Worktree /tmp/<repo-name>-NNNN-slug.
 Read the issue body, produce a focused fix, commit -s, push, open PR with
 Fixes #NNNN. Return PR number.
+⚠ REGRESSION TEST REQUIRED: Include a regression test that reproduces the bug and verifies the fix, following existing *.test.ts / *.spec.ts conventions. PRs that change source code without a test will NOT be auto-merged. If the fix is config/docs/infra only (no .ts/.tsx/.go/.py code changed), note "test-exempt" in the PR body.
 ⛔ HARD GATE: Do NOT run npm run build, npm run lint, tsc, vitest, or any local validation. Push and let CI validate. Violating this wastes tokens and time.
 ```
 
@@ -248,6 +249,7 @@ Agent(subagent_type="general-purpose",
       prompt="Fix ORG/REPO#NNNN. Clone/worktree at /tmp/REPO-NNNN-slug.
               Find the bug, fix it, commit -s, push, open PR with Fixes ORG/REPO#NNNN. Return PR number.
               PR title MUST start with 🔍. Add label `scanner` to the PR.
+              ⚠ REGRESSION TEST REQUIRED: Include a regression test (*.test.ts / *.spec.ts) that reproduces the bug and verifies the fix. PRs without tests will NOT be auto-merged. If config/docs/infra only, note 'test-exempt' in the PR body.
               ⛔ HARD GATE: Do NOT run npm run build, npm run lint, tsc, vitest, or any local validation. Push and let CI validate. Violating this wastes tokens and time.",
       run_in_background=true)
 ```


### PR DESCRIPTION
## Summary
- **merge-gate.sh**: Detects test file changes in PRs via GitHub API file list. Annotates each PR with `test_status` (included/exempt/missing). PRs with `test_status=missing` are routed to `not_ready` (soft block — `--admin` still works).
- **scanner-CLAUDE.md**: Fix-agent dispatch prompts now require a regression test. Bead gets `test_status=pending` at dispatch.
- **reviewer-CLAUDE.md**: Post-merge sweep checks `test_status`. For `existing_untouched` companion tests, reviewer reads test+diff to judge coverage. Files `test-debt` or `test-gap` issues when tests are missing or insufficient.

## Test plan
- [ ] Run merge-gate.sh against a PR with test files → `test_status=included`, lands in `merge_eligible`
- [ ] Run against a PR with code but no tests → `test_status=missing`, lands in `not_ready`
- [ ] Run against a config-only PR → `test_status=exempt`, lands in `merge_eligible`
- [ ] Verify existing merge flow unaffected for PRs that include tests
- [ ] Watch one scanner dispatch — verify fix agent attempts to include a test
- [ ] Watch one reviewer pass — verify it reads `test_status` and acts accordingly