### PR TITLE
feat: scanner pre-merge Copilot comment addressing

### DIFF
--- a/examples/kubestellar/agents/reviewer-CLAUDE.md
+++ b/examples/kubestellar/agents/reviewer-CLAUDE.md
@@ -46,7 +46,9 @@ Abbreviate freely: DB, auth, config, req, res, fn, impl, PR, CI, ns. Use arrows 
 
 ## Copilot Review Follow-up — EVERY PASS
 
-Copilot reviews every PR we open. Those comments often flag real issues. **Every pass**, scan recently merged PRs for unaddressed Copilot comments and act on them.
+Copilot reviews every PR we open. Those comments often flag real issues. The scanner addresses Copilot comments **pre-merge** (one attempt per PR), but some may slip through. **Every pass**, scan recently merged PRs for any remaining unaddressed Copilot comments.
+
+**IMPORTANT**: Before filing a follow-up issue from a Copilot comment, **verify the flagged code still exists in the current main branch**. Copilot comments reference specific lines in the PR diff — if a subsequent PR already fixed the issue, do NOT file a duplicate. `grep` for the flagged pattern in the repo before acting.
 
 **Workflow:**
 

--- a/examples/kubestellar/agents/scanner-CLAUDE.md
+++ b/examples/kubestellar/agents/scanner-CLAUDE.md
@@ -129,9 +129,28 @@ Scanner owns ONLY: ${PROJECT_ORG} GitHub issues and PRs (triage, bug fixes, CI h
 1. **ONLY merge PRs that appear in the MERGE-READY section of your kick message.** The deterministic pipeline pre-validates which PRs are safe to merge. If no MERGE-READY section exists in your kick, merge NOTHING.
 2. **NEVER merge a PR you created in this session.** Your PRs must pass CI and appear in a future kick's MERGE-READY list before being eligible.
 3. **NEVER merge a PR until ALL required CI checks show SUCCESS.** Run `gh pr checks <number> --repo <repo>` and verify every line says `pass` before merging. If any check is `pending` or `fail`, WAIT. **The only exception is `tide`** — Prow's merge queue stays pending without `lgtm`/`approved` labels. If `tide` is the only non-passing check, treat CI as green.
-4. **NEVER merge multiple PRs in rapid succession.** After merging one PR, wait for the next PR's CI to re-run against the updated base branch. PRs that were green before a merge may conflict after.
-5. **Merge sequence:** merge one → wait for next PR's CI to re-trigger and pass → merge next. Never batch-merge.
-6. **If CI fails after merge:** immediately file a bug issue and alert the supervisor.
+4. **CHECK COPILOT COMMENTS BEFORE MERGING.** After CI passes but before running `gh pr merge`, fetch Copilot review comments:
+   ```bash
+   unset GITHUB_TOKEN && gh api "repos/${REPO}/pulls/${PR_NUM}/comments" \
+     --jq '[.[] | select(.user.login == "Copilot")] | length'
+   ```
+   - If **0 comments**: proceed to merge.
+   - If **>0 comments**: dispatch a fix agent to address them on the same branch:
+     ```
+     Agent(subagent_type="general-purpose",
+           description="Address Copilot comments on PR #NNNN",
+           prompt="PR ${REPO}#NNNN has Copilot review comments that need addressing.
+                   Clone/worktree, checkout the PR branch, read the Copilot comments via
+                   gh api repos/${REPO}/pulls/NNNN/comments --jq '[.[] | select(.user.login == \"Copilot\")] | .[] | {body, path, line}',
+                   fix each finding, commit -s, push to the same branch. Return 'done' when complete.
+                   ⛔ HARD GATE: Do NOT run npm run build, npm run lint, tsc, vitest locally.",
+           run_in_background=true)
+     ```
+   - After the fix agent pushes, CI re-runs. On the NEXT kick, if CI is green and no new Copilot comments, merge.
+   - **Do NOT loop**: if Copilot comments persist after one fix attempt, merge anyway and let the reviewer handle post-merge. One attempt is enough.
+5. **NEVER merge multiple PRs in rapid succession.** After merging one PR, wait for the next PR's CI to re-run against the updated base branch. PRs that were green before a merge may conflict after.
+6. **Merge sequence:** merge one → wait for next PR's CI to re-trigger and pass → merge next. Never batch-merge.
+7. **If CI fails after merge:** immediately file a bug issue and alert the supervisor.
 
 ### Claim Protocol — Bead Per Dispatch (MANDATORY)
 


### PR DESCRIPTION
## Summary
- **Scanner**: New merge rule — after CI passes, fetch Copilot review comments. If any exist, dispatch a fix agent to address them on the same branch before merging. One attempt max; if comments persist after fix, merge anyway (reviewer catches post-merge).
- **Reviewer**: Added verification rule — `grep` current main before filing Copilot follow-up issues. Prevents stale duplicates from comments on code already fixed by subsequent PRs.

## Why
Scanner was auto-merging PRs with unaddressed Copilot comments. Reviewer then filed follow-up issues post-merge, some for code that was already fixed. This created a queue spike of 13 issues in one reviewer pass, many stale. Pre-merge addressing fixes both problems.

## Test plan
- [ ] Scanner encounters a PR with Copilot comments → dispatches fix agent on same branch
- [ ] Fix agent pushes → CI re-runs → scanner merges on next kick if green
- [ ] PR with no Copilot comments → merges immediately (no change in behavior)
- [ ] Reviewer verifies code exists in main before filing follow-up issues