### PR TITLE
fix: use sudo for /etc/hive config sync

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -687,7 +687,7 @@ STATUSEOF
 # After git pull updates the repo copy, sync it so new pipeline stages take effect.
 _REPO_PROJECT_YAML=$(find /tmp/hive/examples -name 'hive-project.yaml' -type f 2>/dev/null | head -1)
 if [ -n "$_REPO_PROJECT_YAML" ] && [ -f "$_REPO_PROJECT_YAML" ]; then
-  cp "$_REPO_PROJECT_YAML" /etc/hive/hive-project.yaml 2>/dev/null || true
+  sudo cp "$_REPO_PROJECT_YAML" /etc/hive/hive-project.yaml 2>/dev/null || true
 fi
 
 # --- Pre-kick pipeline: enumerators → classifiers → gates → monitors ---


### PR DESCRIPTION
## Summary

Follow-up to #205. The config sync was failing silently because `/etc/hive/hive-project.yaml` is owned by root and `kick-agents.sh` runs as `dev`. The `cp` needs `sudo`.

Without this, the conflict-sweeper stage (PR #204) never activates — the pipeline keeps reading the stale config.

## Test plan

- [ ] Verify `/etc/hive/hive-project.yaml` updates after next kick cycle
- [ ] Verify `CONFLICT-SWEEP` appears in kick-agents.log