### PR TITLE
fix: sync hive-config.sh to /usr/local/bin on each kick

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -682,12 +682,17 @@ STATUSEOF
 # Policy hash compression: if CLAUDE.md (and skill files) are unchanged since
 # the last kick, we tell the agent to skip re-reading to save tokens.
 
-# --- Sync project config from repo to deployed location ---
-# /etc/hive/hive-project.yaml is the live config read by run-pipeline.sh.
-# After git pull updates the repo copy, sync it so new pipeline stages take effect.
+# --- Sync repo files to deployed locations ---
+# Scripts source hive-config.sh from $SCRIPT_DIR and /usr/local/bin/.
+# Pipeline reads hive-project.yaml from /etc/hive/.
+# Both must stay in sync with the repo after git pull.
 _REPO_PROJECT_YAML=$(find /tmp/hive/examples -name 'hive-project.yaml' -type f 2>/dev/null | head -1)
 if [ -n "$_REPO_PROJECT_YAML" ] && [ -f "$_REPO_PROJECT_YAML" ]; then
   sudo cp "$_REPO_PROJECT_YAML" /etc/hive/hive-project.yaml 2>/dev/null || true
+fi
+if [ -f "/tmp/hive/bin/hive-config.sh" ]; then
+  sudo cp /tmp/hive/bin/hive-config.sh /usr/local/bin/hive-config.sh 2>/dev/null || true
+  source /usr/local/bin/hive-config.sh 2>/dev/null || true
 fi
 
 # --- Pre-kick pipeline: enumerators → classifiers → gates → monitors ---


### PR DESCRIPTION
## Summary

Follow-up to #209. `kick-agents.sh` sources `hive-config.sh` from `/usr/local/bin/` which is a stale copy without the `export` statements from #209. Pipeline subprocesses inherit unexported vars, so `PROJECT_AI_AUTHOR` is invisible to merge-gate and conflict-sweeper python code.

Fix: add `hive-config.sh` to the config sync step (alongside `hive-project.yaml`) and re-source it so exports take effect immediately.

## Test plan

- [ ] Verify merge-gate shows eligible count > 0 after next kick
- [ ] Verify conflict-sweeper processes CONFLICTING PRs