### PR TITLE
feat: add gh-zombie-reaper to prevent rate-limit retry storms

### DIFF
--- a/bin/gh-zombie-reaper.sh
+++ b/bin/gh-zombie-reaper.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# gh-zombie-reaper.sh — Kill gh API processes older than MAX_AGE_SECONDS
+# Prevents rate-limit retry storms from accumulating zombie processes.
+#
+# Runs via cron every 2 minutes. Kills any gh process that has been
+# running longer than the threshold (default 120s). Legitimate gh calls
+# complete in <10s; anything older is stuck in a rate-limit retry loop.
+
+MAX_AGE_SECONDS="${GH_ZOMBIE_MAX_AGE:-120}"
+LOG="/var/log/gh-zombie-reaper.log"
+KILLED=0
+
+# Use etimes (elapsed seconds) for accurate age calculation
+while IFS= read -r line; do
+  pid=$(echo "$line" | awk '{print $1}')
+  age_seconds=$(echo "$line" | awk '{print $2}')
+
+  if [ "$age_seconds" -gt "$MAX_AGE_SECONDS" ] 2>/dev/null; then
+    cmdline=$(ps -p "$pid" -o args= 2>/dev/null)
+    kill "$pid" 2>/dev/null
+    echo "$(date -Iseconds) KILLED pid=$pid age=${age_seconds}s cmd=$cmdline" >> "$LOG"
+    ((KILLED++))
+  fi
+done < <(ps -eo pid,etimes,comm | awk '$3 == "gh" {print $1, $2}')
+
+if [ "$KILLED" -gt 0 ]; then
+  echo "$(date -Iseconds) Reaped $KILLED zombie gh processes" >> "$LOG"
+fi

--- a/systemd/gh-zombie-reaper.service
+++ b/systemd/gh-zombie-reaper.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Kill stale gh CLI processes stuck in rate-limit retry loops
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/gh-zombie-reaper.sh

--- a/systemd/gh-zombie-reaper.timer
+++ b/systemd/gh-zombie-reaper.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Reap zombie gh processes every 2 minutes
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=120
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

- Adds `bin/gh-zombie-reaper.sh` — kills any `gh` process running >120s
- Adds systemd timer to run it every 2 minutes
- Prevents exponential zombie pileup when `gh` CLI hits GitHub rate limits

## Root Cause

The dashboard's `api-collector.sh` spawns `gh api search/issues` calls every 5 minutes. When rate-limited, `gh` retries with backoff but never exits. New spawns accumulate while old ones retry → observed 27 zombies burning 1000+ requests in 12 minutes after a rate reset.

## Already deployed

Script is already live on 192.168.4.56 (via cron for now). This PR adds it to the repo so `hive-deploy.sh` keeps it in sync and new installs get it via the systemd timer.

## Test plan

- [x] Deployed manually on prod server
- [x] Killed 27 zombies on first run
- [x] Rate limit recovered from 0 → 2976 immediately after
- [ ] Verify systemd timer fires correctly after merge + deploy