### PR TITLE
fix: source hive-config.sh in agent-launch.sh for GH_TOKEN

### DIFF
--- a/bin/agent-launch.sh
+++ b/bin/agent-launch.sh
@@ -17,8 +17,16 @@
 
 set -euo pipefail
 
-# Source the centralized backend/model config
+# Source hive-config.sh to inherit GH_TOKEN from GitHub App (if configured)
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HIVE_CONFIG="${SCRIPT_DIR}/hive-config.sh"
+if [[ -f "$HIVE_CONFIG" ]]; then
+  source "$HIVE_CONFIG"
+elif [[ -f /usr/local/bin/hive-config.sh ]]; then
+  source /usr/local/bin/hive-config.sh
+fi
+
+# Source the centralized backend/model config
 BACKENDS_CONF="${SCRIPT_DIR}/../config/backends.conf"
 if [[ -f "$BACKENDS_CONF" ]]; then
   # shellcheck source=../config/backends.conf


### PR DESCRIPTION
## Summary
- `agent-launch.sh` now sources `hive-config.sh` before launching the backend CLI
- This ensures agents inherit `GH_TOKEN` from the GitHub App integration (PR #213)
- Without this, agents fall back to the operator's personal 5k/hr rate limit pool

## Context
The dashboard showed 3 agents (architect, reviewer, outreach) hitting rate limits because their Copilot sessions weren't picking up the GitHub App token. Only scripts that explicitly source `hive-config.sh` get `GH_TOKEN` — agent-launch.sh wasn't doing that.

## Test plan
- [ ] After deploy, restart an agent session and verify `echo $GH_TOKEN` inside the session shows a `ghs_*` token
- [ ] Confirm `gh api rate_limit` inside agent sessions shows the 15k pool