### PR TITLE
feat: Discord bot for agent interaction and pipeline notifications

### DIFF
--- a/bin/agent-pause.sh
+++ b/bin/agent-pause.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# agent-pause.sh — Centralized pause/unpause logic for hive agents.
+# Source this file to use the functions, or run directly:
+#   agent-pause.sh pause <agent> [--operator]
+#   agent-pause.sh resume <agent>
+#   agent-pause.sh status <agent>
+#   agent-pause.sh list
+#
+# All pause state lives in PAUSE_DIR (default: /var/run/kick-governor).
+# Two file types:
+#   paused_<agent>          — agent is paused (checked by governor, kick-agents, dashboard)
+#   operator_paused_<agent> — operator explicitly paused (survives rate-limit pullback resume)
+#
+# Rules:
+#   - Operator pause creates BOTH files
+#   - System pause (rate-limit pullback) creates only paused_<agent>
+#   - Resume removes paused_<agent> ONLY IF operator_paused_<agent> does NOT exist
+#   - Operator resume (--force) removes both files
+#   - Any component can check is_paused / is_operator_paused
+
+PAUSE_DIR="${PAUSE_DIR:-/var/run/kick-governor}"
+VALID_AGENTS="scanner reviewer architect outreach supervisor"
+
+_agent_valid() {
+  echo "$VALID_AGENTS" | grep -qw "$1"
+}
+
+agent_pause() {
+  local agent="$1"
+  local operator="${2:-false}"
+  _agent_valid "$agent" || { echo "invalid agent: $agent" >&2; return 1; }
+
+  echo "$(date -Iseconds)" > "$PAUSE_DIR/paused_${agent}"
+  if [[ "$operator" == "--operator" || "$operator" == "true" ]]; then
+    echo "$(date -Iseconds)" > "$PAUSE_DIR/operator_paused_${agent}"
+  fi
+}
+
+agent_resume() {
+  local agent="$1"
+  local force="${2:-false}"
+  _agent_valid "$agent" || { echo "invalid agent: $agent" >&2; return 1; }
+
+  if [[ "$force" == "--force" || "$force" == "true" ]]; then
+    rm -f "$PAUSE_DIR/paused_${agent}"
+    rm -f "$PAUSE_DIR/operator_paused_${agent}"
+    return 0
+  fi
+
+  if [[ -f "$PAUSE_DIR/operator_paused_${agent}" ]]; then
+    echo "SKIP: $agent is operator-paused (use --force to override)" >&2
+    return 1
+  fi
+
+  rm -f "$PAUSE_DIR/paused_${agent}"
+}
+
+is_paused() {
+  [[ -f "$PAUSE_DIR/paused_${1}" ]]
+}
+
+is_operator_paused() {
+  [[ -f "$PAUSE_DIR/operator_paused_${1}" ]]
+}
+
+agent_pause_status() {
+  local agent="$1"
+  _agent_valid "$agent" || { echo "invalid agent: $agent" >&2; return 1; }
+
+  if is_operator_paused "$agent"; then
+    echo "operator-paused"
+  elif is_paused "$agent"; then
+    echo "system-paused"
+  else
+    echo "active"
+  fi
+}
+
+agent_pause_list() {
+  for agent in $VALID_AGENTS; do
+    echo "$agent: $(agent_pause_status "$agent")"
+  done
+}
+
+# Direct invocation
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  cmd="${1:-list}"
+  case "$cmd" in
+    pause)
+      [[ -z "$2" ]] && { echo "usage: $0 pause <agent> [--operator]" >&2; exit 1; }
+      agent_pause "$2" "${3:---operator}"
+      echo "$(agent_pause_status "$2"): $2"
+      ;;
+    resume)
+      [[ -z "$2" ]] && { echo "usage: $0 resume <agent> [--force]" >&2; exit 1; }
+      agent_resume "$2" "$3"
+      echo "$(agent_pause_status "$2"): $2"
+      ;;
+    status)
+      [[ -z "$2" ]] && { echo "usage: $0 status <agent>" >&2; exit 1; }
+      agent_pause_status "$2"
+      ;;
+    list)
+      agent_pause_list
+      ;;
+    *)
+      echo "usage: $0 {pause|resume|status|list} [agent] [--operator|--force]" >&2
+      exit 1
+      ;;
+  esac
+fi

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -605,12 +605,9 @@ app.post('/api/kick/:agent', (req, res) => {
     if (!session) {
       return res.status(400).json({ error: `no tmux session for ${agent}` });
     }
-    execFile('tmux', ['send-keys', '-t', session, '-l', `OPERATOR DIRECTIVE: ${extraPrompt}`], { timeout: 10000 }, (err) => {
+    execFile('tmux', ['send-keys', '-t', session, '-l', `OPERATOR DIRECTIVE: ${extraPrompt}\n`], { timeout: 10000 }, (err) => {
       if (err) return res.status(500).json({ error: err.message });
-      execFile('tmux', ['send-keys', '-t', session, 'Enter'], { timeout: 5000 }, (err2) => {
-        if (err2) return res.status(500).json({ error: err2.message });
-        res.json({ ok: true, output: `Sent custom prompt to ${agent}` });
-      });
+      res.json({ ok: true, output: `Sent custom prompt to ${agent}` });
     });
   } else {
     execFile('/usr/local/bin/hive', ['kick', agent], { timeout: 30000 }, (err, stdout) => {

--- a/discord/.gitignore
+++ b/discord/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/discord/bot.js
+++ b/discord/bot.js
@@ -1,0 +1,116 @@
+const { Client, GatewayIntentBits, Events } = require('discord.js');
+const { loadConfig } = require('./lib/config');
+const { DashboardBridge } = require('./lib/dashboard-bridge');
+const { PipelineWatcher } = require('./lib/pipeline-watcher');
+const { CommandRouter } = require('./lib/command-router');
+const { agentNames } = require('./lib/agent-identities');
+
+const MSG_QUEUE_INTERVAL_MS = 1200;
+
+const config = loadConfig();
+
+if (!config.botToken) {
+  console.error('DISCORD_BOT_TOKEN not set');
+  process.exit(1);
+}
+if (!config.channelPrimary) {
+  console.error('DISCORD_CHANNEL_PRIMARY not set');
+  process.exit(1);
+}
+
+const client = new Client({
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.MessageContent,
+  ],
+});
+
+const router = new CommandRouter(config);
+
+const messageQueue = [];
+let draining = false;
+
+function drainQueue() {
+  if (draining) return;
+  draining = true;
+  const interval = setInterval(async () => {
+    if (messageQueue.length === 0) {
+      clearInterval(interval);
+      draining = false;
+      return;
+    }
+    const item = messageQueue.shift();
+    try {
+      const channelId = item.target === 'alerts' ? config.channelAlerts : config.channelPrimary;
+      const channel = await client.channels.fetch(channelId);
+      if (!channel) return;
+      if (item.embed) {
+        await channel.send({ embeds: [item.embed] });
+      } else {
+        await channel.send(item.text);
+      }
+    } catch (err) {
+      console.error('Discord send error:', err.message);
+    }
+  }, MSG_QUEUE_INTERVAL_MS);
+}
+
+function sendMessage(text, target) {
+  messageQueue.push({ text, target: target || 'primary' });
+  drainQueue();
+}
+
+function sendEmbed(embed, target) {
+  messageQueue.push({ embed, target: target || 'primary' });
+  drainQueue();
+}
+
+const bridge = new DashboardBridge(config, sendMessage, sendEmbed);
+const watcher = new PipelineWatcher(config, sendMessage, sendEmbed);
+
+client.once(Events.ClientReady, (c) => {
+  console.log(`Hive bot logged in as ${c.user.tag}`);
+  bridge.start();
+  watcher.start();
+  sendMessage('⚙️ **[pipeline]** Hive Discord bot online');
+});
+
+client.on(Events.MessageCreate, async (message) => {
+  if (message.author.bot) return;
+
+  let content = '';
+
+  if (message.mentions.has(client.user)) {
+    content = message.content.replace(/<@!?\d+>/g, '').trim();
+  } else if (message.content.startsWith(config.commandPrefix)) {
+    content = message.content.slice(config.commandPrefix.length).trim();
+  } else {
+    return;
+  }
+
+  if (!content) {
+    await message.reply(await router.handle('help', message.author.tag));
+    return;
+  }
+
+  const response = await router.handle(content, message.author.tag);
+  await message.reply(response);
+});
+
+process.on('SIGTERM', () => {
+  console.log('SIGTERM received, shutting down');
+  bridge.stop();
+  watcher.stop();
+  client.destroy();
+  process.exit(0);
+});
+
+process.on('SIGINT', () => {
+  bridge.stop();
+  watcher.stop();
+  client.destroy();
+  process.exit(0);
+});
+
+client.login(config.botToken);

--- a/discord/lib/agent-identities.js
+++ b/discord/lib/agent-identities.js
@@ -1,0 +1,24 @@
+const AGENTS = {
+  scanner:    { emoji: '\u{1F50D}', label: 'scanner',    color: 0x3498db },
+  reviewer:   { emoji: '✅',    label: 'reviewer',   color: 0x2ecc71 },
+  architect:  { emoji: '\u{1F3D7}', label: 'architect',  color: 0x9b59b6 },
+  outreach:   { emoji: '\u{1F310}', label: 'outreach',   color: 0xe67e22 },
+  supervisor: { emoji: '\u{1F451}', label: 'supervisor', color: 0xe74c3c },
+  governor:   { emoji: '\u{1F6A6}', label: 'governor',   color: 0xf1c40f },
+  pipeline:   { emoji: '⚙️', label: 'pipeline',   color: 0x95a5a6 },
+};
+
+function agentPrefix(name) {
+  const a = AGENTS[name] || AGENTS.pipeline;
+  return `${a.emoji} **[${a.label}]**`;
+}
+
+function agentColor(name) {
+  return (AGENTS[name] || AGENTS.pipeline).color;
+}
+
+function agentNames() {
+  return Object.keys(AGENTS).filter(n => n !== 'pipeline' && n !== 'governor');
+}
+
+module.exports = { AGENTS, agentPrefix, agentColor, agentNames };

--- a/discord/lib/command-router.js
+++ b/discord/lib/command-router.js
@@ -107,13 +107,14 @@ class CommandRouter {
   _help() {
     return [
       '**Hive Discord Bot Commands**',
-      '`status` — show system status',
-      '`governor` — show governor mode and thresholds',
-      '`scanner <prompt>` — send prompt to scanner',
-      '`reviewer <prompt>` — send prompt to reviewer',
-      '`kick <agent> [prompt]` — kick an agent with optional prompt',
-      '`pause <agent>` — pause an agent',
-      '`resume <agent>` — resume an agent',
+      '`!status` — show system status',
+      '`!governor` — show governor mode and thresholds',
+      '`!scanner <prompt>` — send prompt to scanner',
+      '`!reviewer <prompt>` — send prompt to reviewer',
+      '`!kick <agent> [prompt]` — kick an agent with optional prompt',
+      '`!pause <agent>` — pause an agent',
+      '`!resume <agent>` — resume an agent',
+      '`!help` — show this message',
       '',
       `Valid agents: ${this.validAgents.join(', ')}`,
     ].join('\n');

--- a/discord/lib/command-router.js
+++ b/discord/lib/command-router.js
@@ -11,14 +11,26 @@ class CommandRouter {
 
   async handle(content, authorTag) {
     const parts = content.trim().split(/\s+/);
-    const cmd = (parts[0] || '').toLowerCase();
+    let cmd = (parts[0] || '').toLowerCase();
+
+    const ALIASES = {
+      s: 'status', st: 'status',
+      g: 'governor', gov: 'governor',
+      h: 'help', '?': 'help',
+      k: 'kick',
+      p: 'pause',
+      r: 'resume',
+      sc: 'scanner', rv: 'reviewer', ar: 'architect', ou: 'outreach', su: 'supervisor',
+    };
+    cmd = ALIASES[cmd] || cmd;
 
     if (cmd === 'status') return this._status();
     if (cmd === 'governor') return this._governor();
     if (cmd === 'help') return this._help();
 
     if (this.validAgents.includes(cmd)) {
-      const action = (parts[1] || '').toLowerCase();
+      let action = (parts[1] || '').toLowerCase();
+      action = ALIASES[action] || action;
       const rest = parts.slice(2).join(' ');
 
       if (action === 'kick' || (!action && !rest)) {
@@ -31,7 +43,8 @@ class CommandRouter {
     }
 
     if (['kick', 'pause', 'resume'].includes(cmd)) {
-      const agent = (parts[1] || '').toLowerCase();
+      let agent = (parts[1] || '').toLowerCase();
+      agent = ALIASES[agent] || agent;
       if (!this.validAgents.includes(agent)) {
         return commandResponse(false, `Unknown agent: ${agent}. Valid: ${this.validAgents.join(', ')}`);
       }
@@ -79,7 +92,7 @@ class CommandRouter {
     for (const agent of agents) {
       const name = agent.name || '?';
       const busy = agent.busy || agent.state || 'unknown';
-      const cadence = agent.cadence || '';
+      const cadence = agent.cadence || agent.nextKick || 'active';
       const doing = agent.doing ? ` — ${agent.doing.slice(0, 80)}` : '';
       lines.push(`  ${agentPrefix(name)} ${busy} (${cadence})${doing}`);
     }

--- a/discord/lib/command-router.js
+++ b/discord/lib/command-router.js
@@ -1,0 +1,158 @@
+const http = require('http');
+const https = require('https');
+const { agentNames, agentPrefix } = require('./agent-identities');
+const { commandResponse } = require('./formatter');
+
+class CommandRouter {
+  constructor(config) {
+    this.config = config;
+    this.validAgents = agentNames();
+  }
+
+  async handle(content, authorTag) {
+    const parts = content.trim().split(/\s+/);
+    const cmd = (parts[0] || '').toLowerCase();
+
+    if (cmd === 'status') return this._status();
+    if (cmd === 'governor') return this._governor();
+    if (cmd === 'help') return this._help();
+
+    if (this.validAgents.includes(cmd)) {
+      const action = (parts[1] || '').toLowerCase();
+      const rest = parts.slice(2).join(' ');
+
+      if (action === 'kick' || (!action && !rest)) {
+        return this._kick(cmd, rest);
+      }
+      if (action === 'pause') return this._pause(cmd);
+      if (action === 'resume') return this._resume(cmd);
+
+      return this._kick(cmd, parts.slice(1).join(' '));
+    }
+
+    if (['kick', 'pause', 'resume'].includes(cmd)) {
+      const agent = (parts[1] || '').toLowerCase();
+      if (!this.validAgents.includes(agent)) {
+        return commandResponse(false, `Unknown agent: ${agent}. Valid: ${this.validAgents.join(', ')}`);
+      }
+      if (cmd === 'kick') return this._kick(agent, parts.slice(2).join(' '));
+      if (cmd === 'pause') return this._pause(agent);
+      if (cmd === 'resume') return this._resume(agent);
+    }
+
+    return commandResponse(false, `Unknown command. Try \`help\` for usage.`);
+  }
+
+  async _kick(agent, prompt) {
+    const body = prompt ? JSON.stringify({ prompt }) : '{}';
+    const res = await this._dashboardPost(`/api/kick/${agent}`, body);
+    if (res.ok) {
+      return commandResponse(true, prompt
+        ? `Sent to ${agent}: "${prompt}"`
+        : `Kicked ${agent}`);
+    }
+    return commandResponse(false, `Failed to kick ${agent}: ${res.error || 'unknown error'}`);
+  }
+
+  async _pause(agent) {
+    const res = await this._dashboardPost(`/api/pause/${agent}`);
+    if (res.ok) return commandResponse(true, `Paused ${agent}`);
+    return commandResponse(false, `Failed to pause ${agent}: ${res.error || 'unknown error'}`);
+  }
+
+  async _resume(agent) {
+    const res = await this._dashboardPost(`/api/resume/${agent}`);
+    if (res.ok) return commandResponse(true, `Resumed ${agent}`);
+    return commandResponse(false, `Failed to resume ${agent}: ${res.error || 'unknown error'}`);
+  }
+
+  async _status() {
+    const data = await this._dashboardGet('/api/status');
+    if (!data) return commandResponse(false, 'Could not reach dashboard');
+
+    const lines = [];
+    const gov = data.governor || {};
+    lines.push(`**Governor:** ${gov.mode || 'unknown'} (issues: ${gov.issues || 0}, PRs: ${gov.prs || 0})`);
+    lines.push(`**CI Pass Rate:** ${data.ciPassRate || '?'}%`);
+
+    const agents = Array.isArray(data.agents) ? data.agents : [];
+    for (const agent of agents) {
+      const name = agent.name || '?';
+      const busy = agent.busy || agent.state || 'unknown';
+      const cadence = agent.cadence || '';
+      const doing = agent.doing ? ` — ${agent.doing.slice(0, 80)}` : '';
+      lines.push(`  ${agentPrefix(name)} ${busy} (${cadence})${doing}`);
+    }
+
+    const DISCORD_MSG_LIMIT = 1900;
+    const result = lines.join('\n');
+    return result.length > DISCORD_MSG_LIMIT ? result.slice(0, DISCORD_MSG_LIMIT) + '…' : result;
+  }
+
+  async _governor() {
+    const data = await this._dashboardGet('/api/status');
+    if (!data) return commandResponse(false, 'Could not reach dashboard');
+    const gov = data.governor || {};
+    const lines = [];
+    lines.push(`**Mode:** ${gov.mode || 'unknown'}`);
+    lines.push(`**Queue:** ${gov.issues || 0} issues, ${gov.prs || 0} PRs`);
+    lines.push(`**Next Kick:** ${gov.nextKick || 'unknown'}`);
+    if (data.budget) {
+      const b = data.budget;
+      lines.push(`**Budget:** $${b.BUDGET_USED || '?'} / $${b.BUDGET_WEEKLY || '?'} (${b.BUDGET_PCT_USED || '?'}% used)`);
+    }
+    return lines.join('\n') || 'No governor data available';
+  }
+
+  _help() {
+    return [
+      '**Hive Discord Bot Commands**',
+      '`status` — show system status',
+      '`governor` — show governor mode and thresholds',
+      '`scanner <prompt>` — send prompt to scanner',
+      '`reviewer <prompt>` — send prompt to reviewer',
+      '`kick <agent> [prompt]` — kick an agent with optional prompt',
+      '`pause <agent>` — pause an agent',
+      '`resume <agent>` — resume an agent',
+      '',
+      `Valid agents: ${this.validAgents.join(', ')}`,
+    ].join('\n');
+  }
+
+  _dashboardPost(path, body) {
+    return new Promise((resolve) => {
+      const url = new URL(path, this.config.dashboardUrl);
+      const options = {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        timeout: 10000,
+      };
+      const req = http.request(url, options, (res) => {
+        let data = '';
+        res.on('data', c => data += c);
+        res.on('end', () => {
+          try { resolve(JSON.parse(data)); } catch (_) { resolve({ ok: false, error: data }); }
+        });
+      });
+      req.on('error', (e) => resolve({ ok: false, error: e.message }));
+      req.on('timeout', () => { req.destroy(); resolve({ ok: false, error: 'timeout' }); });
+      if (body) req.write(body);
+      req.end();
+    });
+  }
+
+  _dashboardGet(path) {
+    return new Promise((resolve) => {
+      const url = new URL(path, this.config.dashboardUrl);
+      http.get(url, { timeout: 10000 }, (res) => {
+        let data = '';
+        res.on('data', c => data += c);
+        res.on('end', () => {
+          try { resolve(JSON.parse(data)); } catch (_) { resolve(null); }
+        });
+      }).on('error', () => resolve(null));
+    });
+  }
+}
+
+module.exports = { CommandRouter };

--- a/discord/lib/config.js
+++ b/discord/lib/config.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const yaml = require('js-yaml');
+
+const HIVE_CONFIG_PATH = process.env.HIVE_PROJECT_CONFIG || '/etc/hive/hive-project.yaml';
+
+function loadConfig() {
+  const config = {
+    botToken: process.env.DISCORD_BOT_TOKEN || '',
+    channelPrimary: process.env.DISCORD_CHANNEL_PRIMARY || '',
+    channelAlerts: process.env.DISCORD_CHANNEL_ALERTS || '',
+    dashboardUrl: process.env.HIVE_DASHBOARD_URL || 'http://localhost:3001',
+    metricsDir: process.env.HIVE_METRICS_DIR || '/var/run/hive-metrics',
+    postPipelineResults: true,
+    postAgentTransitions: true,
+    postGovernorModeChanges: true,
+    commandPrefix: '!',
+  };
+
+  try {
+    const raw = fs.readFileSync(HIVE_CONFIG_PATH, 'utf8');
+    const doc = yaml.load(raw);
+    if (doc && doc.discord) {
+      const d = doc.discord;
+      if (d.channels) {
+        config.channelPrimary = config.channelPrimary || d.channels.primary || '';
+        config.channelAlerts = config.channelAlerts || d.channels.alerts || '';
+      }
+      if (d.command_prefix) config.commandPrefix = d.command_prefix;
+      if (d.post_pipeline_results === false) config.postPipelineResults = false;
+      if (d.post_agent_transitions === false) config.postAgentTransitions = false;
+      if (d.post_governor_mode_changes === false) config.postGovernorModeChanges = false;
+    }
+    if (doc && doc.dashboard) {
+      config.dashboardPort = doc.dashboard.port || '3001';
+      config.dashboardUrl = process.env.HIVE_DASHBOARD_URL || `http://localhost:${config.dashboardPort}`;
+    }
+  } catch (_) {
+    // config file missing is fine — env vars are primary
+  }
+
+  if (!config.channelAlerts) config.channelAlerts = config.channelPrimary;
+  return config;
+}
+
+module.exports = { loadConfig };

--- a/discord/lib/dashboard-bridge.js
+++ b/discord/lib/dashboard-bridge.js
@@ -110,12 +110,20 @@ class DashboardBridge {
       if (old.busy !== agent.busy) {
         const doing = agent.doing ? ` — ${agent.doing.slice(0, 100)}` : '';
         if (agent.busy === 'idle' && old.busy === 'working') {
-          this.sendMessage(agentMessage(name, `Completed${doing}`));
+          const summary = (agent.liveSummary || '').split('\n').slice(0, 3).join('\n').slice(0, 300);
+          this.sendMessage(agentMessage(name, `Completed${doing}${summary ? '\n```\n' + summary + '\n```' : ''}`));
         } else if (agent.busy === 'working' && old.busy === 'idle') {
           this.sendMessage(agentMessage(name, `Working${doing}`));
         } else if (agent.cadence === 'paused' && old.cadence !== 'paused') {
           this.sendMessage(agentMessage(name, 'Paused'));
         }
+      }
+
+      const oldSummary = (old.liveSummary || '').trim();
+      const newSummary = (agent.liveSummary || '').trim();
+      if (newSummary && newSummary !== oldSummary) {
+        const lines = newSummary.split('\n').slice(0, 4).join('\n').slice(0, 400);
+        this.sendMessage(agentMessage(name, `\n\`\`\`\n${lines}\n\`\`\``));
       }
     }
   }

--- a/discord/lib/dashboard-bridge.js
+++ b/discord/lib/dashboard-bridge.js
@@ -1,0 +1,142 @@
+const http = require('http');
+const { agentMessage } = require('./formatter');
+
+const SSE_RECONNECT_BASE_MS = 5000;
+const SSE_RECONNECT_MAX_MS = 60000;
+const DASHBOARD_STALE_WARN_MS = 30000;
+
+class DashboardBridge {
+  constructor(config, sendMessage, sendEmbed) {
+    this.config = config;
+    this.sendMessage = sendMessage;
+    this.sendEmbed = sendEmbed;
+    this.lastState = null;
+    this.reconnectDelay = SSE_RECONNECT_BASE_MS;
+    this.staleTimer = null;
+    this.firstEvent = true;
+  }
+
+  start() {
+    this._connect();
+  }
+
+  stop() {
+    if (this.req) {
+      this.req.destroy();
+      this.req = null;
+    }
+    clearTimeout(this.staleTimer);
+  }
+
+  _connect() {
+    const url = new URL('/api/events', this.config.dashboardUrl);
+    const req = http.get(url, (res) => {
+      if (res.statusCode !== 200) {
+        res.resume();
+        this._scheduleReconnect();
+        return;
+      }
+
+      this.reconnectDelay = SSE_RECONNECT_BASE_MS;
+      this._resetStaleTimer();
+      let buffer = '';
+
+      res.on('data', (chunk) => {
+        buffer += chunk.toString();
+        const lines = buffer.split('\n\n');
+        buffer = lines.pop();
+        for (const block of lines) {
+          const dataLine = block.split('\n').find(l => l.startsWith('data:'));
+          if (dataLine) {
+            try {
+              const data = JSON.parse(dataLine.slice(5).trim());
+              this._onEvent(data);
+              this._resetStaleTimer();
+            } catch (_) { /* ignore parse errors */ }
+          }
+        }
+      });
+
+      res.on('end', () => this._scheduleReconnect());
+      res.on('error', () => this._scheduleReconnect());
+    });
+
+    req.on('error', () => this._scheduleReconnect());
+    this.req = req;
+  }
+
+  _scheduleReconnect() {
+    setTimeout(() => this._connect(), this.reconnectDelay);
+    this.reconnectDelay = Math.min(this.reconnectDelay * 2, SSE_RECONNECT_MAX_MS);
+  }
+
+  _resetStaleTimer() {
+    clearTimeout(this.staleTimer);
+    this.staleTimer = setTimeout(() => {
+      this.sendMessage(agentMessage('pipeline', '⚠️ Dashboard SSE connection lost — commands may not route'), 'alerts');
+    }, DASHBOARD_STALE_WARN_MS);
+  }
+
+  _onEvent(data) {
+    if (this.firstEvent) {
+      this.lastState = data;
+      this.firstEvent = false;
+      return;
+    }
+
+    if (!this.lastState) {
+      this.lastState = data;
+      return;
+    }
+
+    this._diffAgents(data);
+    this._diffGovernor(data);
+    this.lastState = data;
+  }
+
+  _diffAgents(data) {
+    if (!this.config.postAgentTransitions) return;
+    const agents = Array.isArray(data.agents) ? data.agents : [];
+    const prevAgents = Array.isArray(this.lastState.agents) ? this.lastState.agents : [];
+    const prevMap = {};
+    for (const a of prevAgents) { if (a.name) prevMap[a.name] = a; }
+
+    for (const agent of agents) {
+      const name = agent.name;
+      if (!name) continue;
+      const old = prevMap[name];
+      if (!old) continue;
+
+      if (old.busy !== agent.busy) {
+        const doing = agent.doing ? ` — ${agent.doing.slice(0, 100)}` : '';
+        if (agent.busy === 'idle' && old.busy === 'working') {
+          this.sendMessage(agentMessage(name, `Completed${doing}`));
+        } else if (agent.busy === 'working' && old.busy === 'idle') {
+          this.sendMessage(agentMessage(name, `Working${doing}`));
+        } else if (agent.cadence === 'paused' && old.cadence !== 'paused') {
+          this.sendMessage(agentMessage(name, 'Paused'));
+        }
+      }
+    }
+  }
+
+  _diffGovernor(data) {
+    if (!this.config.postGovernorModeChanges) return;
+    const gov = data.governor || {};
+    const prevGov = this.lastState.governor || {};
+    const govMode = gov.mode || '';
+    const prevMode = prevGov.mode || '';
+
+    if (govMode && prevMode && govMode !== prevMode) {
+      const { governorEmbed } = require('./formatter');
+      const queueDepth = (gov.issues || 0) + (gov.prs || 0);
+      const agentStates = {};
+      for (const agent of (Array.isArray(data.agents) ? data.agents : [])) {
+        if (agent.name) agentStates[agent.name] = agent.busy || agent.state || 'unknown';
+      }
+      this.sendEmbed(governorEmbed(`${prevMode} → ${govMode}`, queueDepth, agentStates), 'alerts');
+    }
+  }
+}
+
+module.exports = { DashboardBridge };

--- a/discord/lib/formatter.js
+++ b/discord/lib/formatter.js
@@ -1,0 +1,76 @@
+const { EmbedBuilder } = require('discord.js');
+const { agentPrefix, agentColor } = require('./agent-identities');
+
+function agentMessage(agentName, text) {
+  return `${agentPrefix(agentName)} ${text}`;
+}
+
+function governorEmbed(transition, queueDepth, agentStates) {
+  const embed = new EmbedBuilder()
+    .setTitle('Governor Mode Change')
+    .setColor(agentColor('governor'))
+    .addFields({ name: 'Transition', value: transition, inline: true })
+    .addFields({ name: 'Queue Depth', value: String(queueDepth), inline: true })
+    .setTimestamp();
+
+  if (agentStates) {
+    const lines = Object.entries(agentStates)
+      .map(([name, state]) => `${agentPrefix(name)} ${state}`)
+      .join('\n');
+    embed.addFields({ name: 'Agent States', value: lines || 'unknown' });
+  }
+  return embed;
+}
+
+function mergeGateEmbed(eligible, notReady) {
+  const embed = new EmbedBuilder()
+    .setTitle('Merge Gate Results')
+    .setColor(eligible.length > 0 ? 0x2ecc71 : 0x95a5a6)
+    .setTimestamp();
+
+  if (eligible.length > 0) {
+    const lines = eligible.map(p => `#${p.number} — ${p.title}`).join('\n');
+    embed.setDescription(`**${eligible.length}** PR(s) eligible for merge`);
+    embed.addFields({ name: 'Eligible', value: lines.slice(0, 1024) });
+  } else {
+    embed.setDescription('No PRs eligible for merge');
+  }
+
+  if (notReady.length > 0) {
+    const lines = notReady.map(p => {
+      const reasons = (p.block_reasons || []).join(', ');
+      return `#${p.number} — ${reasons}`;
+    }).join('\n');
+    embed.addFields({ name: `Not Ready (${notReady.length})`, value: lines.slice(0, 1024) });
+  }
+  return embed;
+}
+
+function conflictSweepEmbed(data) {
+  const embed = new EmbedBuilder()
+    .setTitle('Conflict Sweep')
+    .setColor(agentColor('pipeline'))
+    .setTimestamp();
+
+  const rebased = data.rebased || [];
+  const closed = data.closed || [];
+
+  if (rebased.length === 0 && closed.length === 0) {
+    embed.setDescription('No conflicting PRs found');
+  } else {
+    if (rebased.length > 0) {
+      embed.addFields({ name: `Rebased (${rebased.length})`, value: rebased.map(p => `#${p}`).join(', ') });
+    }
+    if (closed.length > 0) {
+      embed.addFields({ name: `Closed (${closed.length})`, value: closed.map(p => `#${p}`).join(', ') });
+    }
+  }
+  return embed;
+}
+
+function commandResponse(success, text) {
+  const icon = success ? '✅' : '❌';
+  return `${icon} ${text}`;
+}
+
+module.exports = { agentMessage, governorEmbed, mergeGateEmbed, conflictSweepEmbed, commandResponse };

--- a/discord/lib/pipeline-watcher.js
+++ b/discord/lib/pipeline-watcher.js
@@ -1,0 +1,112 @@
+const fs = require('fs');
+const path = require('path');
+const { mergeGateEmbed, conflictSweepEmbed, agentMessage } = require('./formatter');
+
+const DEBOUNCE_MS = 10000;
+const POLL_INTERVAL_MS = 30000;
+
+class PipelineWatcher {
+  constructor(config, sendMessage, sendEmbed) {
+    this.config = config;
+    this.sendMessage = sendMessage;
+    this.sendEmbed = sendEmbed;
+    this.metricsDir = config.metricsDir;
+    this.lastMergeGate = null;
+    this.lastConflictSweep = null;
+    this.lastQueueCount = null;
+    this.debounceTimers = {};
+    this.watchers = [];
+    this.pollTimer = null;
+  }
+
+  start() {
+    this._watchFile('merge-eligible.json', () => this._onMergeGate());
+    this._watchFile('conflict-sweep.json', () => this._onConflictSweep());
+    this._watchFile('actionable.json', () => this._onQueueChange());
+
+    this.pollTimer = setInterval(() => {
+      this._onMergeGate();
+      this._onConflictSweep();
+      this._onQueueChange();
+    }, POLL_INTERVAL_MS);
+  }
+
+  stop() {
+    for (const w of this.watchers) w.close();
+    this.watchers = [];
+    clearInterval(this.pollTimer);
+    for (const t of Object.values(this.debounceTimers)) clearTimeout(t);
+  }
+
+  _watchFile(filename, handler) {
+    const filePath = path.join(this.metricsDir, filename);
+    try {
+      const watcher = fs.watch(filePath, () => {
+        clearTimeout(this.debounceTimers[filename]);
+        this.debounceTimers[filename] = setTimeout(handler, DEBOUNCE_MS);
+      });
+      this.watchers.push(watcher);
+    } catch (_) {
+      // file may not exist yet — poll will catch it
+    }
+  }
+
+  _readJson(filename) {
+    try {
+      const raw = fs.readFileSync(path.join(this.metricsDir, filename), 'utf8');
+      return JSON.parse(raw);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  _onMergeGate() {
+    if (!this.config.postPipelineResults) return;
+    const data = this._readJson('merge-eligible.json');
+    if (!data) return;
+
+    const ts = data.generated_at || '';
+    if (ts === this.lastMergeGate) return;
+    this.lastMergeGate = ts;
+
+    const eligible = data.merge_eligible || [];
+    const notReady = data.not_ready || [];
+    if (eligible.length > 0 || notReady.length > 0) {
+      this.sendEmbed(mergeGateEmbed(eligible, notReady));
+    }
+  }
+
+  _onConflictSweep() {
+    if (!this.config.postPipelineResults) return;
+    const data = this._readJson('conflict-sweep.json');
+    if (!data) return;
+
+    const ts = data.generated_at || '';
+    if (ts === this.lastConflictSweep) return;
+    this.lastConflictSweep = ts;
+
+    const rebased = data.rebased || [];
+    const closed = data.closed || [];
+    if (rebased.length > 0 || closed.length > 0) {
+      this.sendEmbed(conflictSweepEmbed(data));
+    }
+  }
+
+  _onQueueChange() {
+    const data = this._readJson('actionable.json');
+    if (!data) return;
+
+    const issues = (data.issues && data.issues.items) ? data.issues.items.length : 0;
+    const prs = (data.prs && data.prs.items) ? data.prs.items.length : 0;
+    const total = issues + prs;
+
+    if (this.lastQueueCount !== null && total !== this.lastQueueCount) {
+      const delta = total - this.lastQueueCount;
+      const direction = delta > 0 ? `+${delta} new` : `${Math.abs(delta)} resolved`;
+      this.sendMessage(agentMessage('pipeline', `Queue: ${total} items (${issues} issues, ${prs} PRs) — ${direction}`));
+    }
+    this.lastQueueCount = total;
+  }
+}
+
+module.exports = { PipelineWatcher };

--- a/discord/package-lock.json
+++ b/discord/package-lock.json
@@ -1,0 +1,343 @@
+{
+  "name": "hive-discord",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hive-discord",
+      "version": "1.0.0",
+      "dependencies": {
+        "discord.js": "^14.16.0",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.14.1.tgz",
+      "integrity": "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
+      "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.5",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.40",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "6.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@sapphire/snowflake": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+      "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.38.47",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.47.tgz",
+      "integrity": "sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA==",
+      "license": "MIT",
+      "workspaces": [
+        "scripts/actions/documentation"
+      ]
+    },
+    "node_modules/discord.js": {
+      "version": "14.26.4",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.26.4.tgz",
+      "integrity": "sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@discordjs/builders": "^1.14.1",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.1",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.40",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.13.0",
+        "tslib": "^2.6.3",
+        "undici": "6.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "license": "MIT"
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
+      "license": "MIT"
+    },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/undici": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/discord/package.json
+++ b/discord/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "hive-discord",
+  "version": "1.0.0",
+  "description": "Discord bot for Hive pipeline agent interaction",
+  "main": "bot.js",
+  "scripts": {
+    "start": "node bot.js"
+  },
+  "dependencies": {
+    "discord.js": "^14.16.0",
+    "js-yaml": "^4.1.0"
+  }
+}

--- a/examples/kubestellar/hive-project.yaml
+++ b/examples/kubestellar/hive-project.yaml
@@ -235,6 +235,17 @@ governor:
     - changes-requested
     - waiting-on-author
 
+discord:
+  enabled: true
+  bot_token_env: "DISCORD_BOT_TOKEN"
+  channels:
+    primary: ""    # set via DISCORD_CHANNEL_PRIMARY env var
+    alerts: ""     # set via DISCORD_CHANNEL_ALERTS env var (falls back to primary)
+  post_pipeline_results: true
+  post_agent_transitions: true
+  post_governor_mode_changes: true
+  command_prefix: "!"
+
 dashboard:
   title: "KubeStellar Console Hive"
   port: 3001

--- a/systemd/hive-discord.service
+++ b/systemd/hive-discord.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Hive Discord Bot
+After=network-online.target hive.service
+Wants=network-online.target
+Requires=hive.service
+
+[Service]
+Type=simple
+User=dev
+Group=dev
+WorkingDirectory=/tmp/hive/discord
+EnvironmentFile=/etc/hive/discord.env
+EnvironmentFile=-/etc/hive/supervisor.env
+Environment=NODE_ENV=production
+ExecStart=/usr/bin/node bot.js
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=hive-discord
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Two-way Discord bot for hive pipeline: agents post status updates, operator sends commands
- Interactive commands: `!status`, `!kick <agent>`, `!pause/resume <agent>`, `!governor`, `!help`
- Pipeline watchers post merge-gate results, conflict sweep, queue changes, governor mode transitions
- Standalone Node.js service with systemd unit (`hive-discord.service`)
- Config via `/etc/hive/discord.env` (bot token, channel IDs)
- Also fixes tmux send-keys race condition in dashboard custom prompt dispatch (single `\n` instead of separate Enter command)

## Files
- `discord/` — bot source (bot.js + lib/)
- `systemd/hive-discord.service` — systemd unit
- `examples/kubestellar/hive-project.yaml` — discord config section
- `dashboard/server.js` — send-keys fix

## Test plan
- [x] Bot logs in and posts online message
- [x] `!status` returns formatted agent states and governor mode
- [ ] `!kick scanner` routes command to scanner tmux session
- [ ] Governor mode change triggers Discord embed
- [ ] Merge-gate results posted on pipeline run