### PR TITLE
fix: consolidate pause checks across all components

### DIFF
--- a/bin/gh-rate-check.sh
+++ b/bin/gh-rate-check.sh
@@ -183,7 +183,7 @@ print(json.dumps(alerts))
       # Skip scanner — it's the one that found the limit, let it finish its cycle
       [ "$other_agent" = "$agent" ] && continue
 
-      if [ -f "$GOVERNOR_FLAG_DIR/paused_${other_agent}" ]; then
+      if [ -f "$GOVERNOR_FLAG_DIR/paused_${other_agent}" ] || [ -f "$GOVERNOR_FLAG_DIR/operator_paused_${other_agent}" ]; then
         already_paused+=("$other_agent")
       else
         touch "$GOVERNOR_FLAG_DIR/paused_${other_agent}"

--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -61,6 +61,10 @@ AGENTS_DIR="${AGENTS_DIR:-${SCRIPT_DIR}/../agents}"
 
 GOVERNOR_FLAG_DIR="/var/run/kick-governor"
 
+_is_agent_paused() {
+  [[ -f "$GOVERNOR_FLAG_DIR/paused_${1}" ]] || [[ -f "$GOVERNOR_FLAG_DIR/operator_paused_${1}" ]]
+}
+
 # Agent handoff state — captures last N lines of work context when switching backends
 HANDOFF_DIR="/tmp/agent-handoff"
 mkdir -p "$HANDOFF_DIR" 2>/dev/null || true
@@ -508,7 +512,7 @@ kick() {
   local agent="$3"
 
   # Respect pause state — if agent is paused, skip the kick entirely
-  if [[ -f "$GOVERNOR_FLAG_DIR/paused_${agent}" ]]; then
+  if _is_agent_paused "$agent"; then
     log "SKIP $session — agent is paused"
     return
   fi
@@ -932,7 +936,7 @@ apply_model_if_changed() {
   local agent="$1" session="$2"
 
   # Skip model changes for paused agents
-  if [[ -f "$GOVERNOR_FLAG_DIR/paused_${agent}" ]]; then
+  if _is_agent_paused "$agent"; then
     return 0
   fi
 

--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -150,6 +150,9 @@ RATE_LIMIT_COOLDOWN="${RATE_LIMIT_COOLDOWN:-1800}"  # 30 min
 
 # ── Paths ───────────────────────────────────────────────────────────────────
 STATE_DIR="/var/run/kick-governor"
+_is_agent_paused() {
+  [[ -f "$STATE_DIR/paused_${1}" ]] || [[ -f "$STATE_DIR/operator_paused_${1}" ]]
+}
 LOG_FILE="/var/log/kick-governor.log"
 KICK_SCRIPT="${KICK_SCRIPT:-/usr/local/bin/kick-agents.sh}"
 GH_BIN="${GH_BIN:-gh}"
@@ -521,7 +524,7 @@ optimize_model_assignment() {
 
   for agent in "${agents[@]}"; do
     # Skip paused agents — don't write model files that trigger restarts
-    if [[ -f "$STATE_DIR/paused_${agent}" ]]; then
+    if _is_agent_paused "$agent"; then
       log "  PAUSED: $agent — skipping model assignment"
       continue
     fi
@@ -636,7 +639,7 @@ maybe_kick() {
   elapsed=$(seconds_since_last_kick "$agent")
 
   # Dashboard pause flag — survives governor ticks
-  if [[ -f "$STATE_DIR/paused_${agent}" ]]; then
+  if _is_agent_paused "$agent"; then
     # Track that this agent is paused so we can detect unpause next tick
     touch "$STATE_DIR/was_paused_${agent}"
     log "SKIP ${agent} (mode=${mode} — DASHBOARD PAUSED)"
@@ -700,7 +703,7 @@ echo "$busy_pct"  > "$STATE_DIR/busyness_pct"
 
 # Write per-agent cadences for hive status to read
 for _agent in scanner reviewer architect outreach supervisor; do
-  if [[ -f "$STATE_DIR/paused_${_agent}" ]]; then
+  if _is_agent_paused "$_agent"; then
     echo "paused" > "$STATE_DIR/cadence_${_agent}"
     continue
   fi
@@ -738,7 +741,7 @@ done)"
 # If C-c + C-u fails (buffer completely stuck), flag agent for restart.
 BUFFER_STUCK_HEARTBEAT_THRESHOLD=1200  # 20 minutes — skip buffer-stuck flag if status file is fresher
 for _fa in scanner reviewer supervisor architect outreach; do
-  [[ -f "$STATE_DIR/paused_${_fa}" ]] && continue
+  _is_agent_paused "$_fa" && continue
   tmux has-session -t "$_fa" 2>/dev/null || continue
   _pane_text=$(tmux capture-pane -t "$_fa" -p 2>/dev/null || true)
   _prompt_line=$(echo "$_pane_text" | grep "❯" | tail -1)
@@ -781,7 +784,7 @@ STUCK_COUNT_FILE="$STATE_DIR/stuck_counts"
 touch "$STUCK_COUNT_FILE" 2>/dev/null || true
 
 for _sa in scanner reviewer architect outreach supervisor; do
-  [[ -f "$STATE_DIR/paused_${_sa}" ]] && continue
+  _is_agent_paused "$_sa" && continue
   _status_file="$HOME/.hive/${_sa}_status.txt"
   [[ ! -f "$_status_file" ]] && continue
 

--- a/bin/supervisor.sh
+++ b/bin/supervisor.sh
@@ -111,7 +111,7 @@ apply_tmux_styling() {
 PROMPT_DELIVERED=""
 
 is_paused() {
-  [[ -f "$GOVERNOR_STATE_DIR/paused_${SESSION}" ]]
+  [[ -f "$GOVERNOR_STATE_DIR/paused_${SESSION}" ]] || [[ -f "$GOVERNOR_STATE_DIR/operator_paused_${SESSION}" ]]
 }
 
 write_paused_launcher() {

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -328,7 +328,8 @@ function fetchStatus() {
           } catch (_) {}
           try {
             const pf = path.join(GOVERNOR_STATE_DIR, `paused_${a.name}`);
-            if (fs.existsSync(pf)) { a.paused = true; a.cadence = 'paused'; }
+            const opf = path.join(GOVERNOR_STATE_DIR, `operator_paused_${a.name}`);
+            if (fs.existsSync(pf) || fs.existsSync(opf)) { a.paused = true; a.cadence = 'paused'; }
           } catch (_) {}
           // Pin state
           try {
@@ -1013,7 +1014,8 @@ app.get('/api/model-advisor', (_req, res) => {
 
     try {
       const pf = path.join(GOVERNOR_STATE_DIR, `paused_${agent}`);
-      if (fs.existsSync(pf)) entry.paused = true;
+      const opf = path.join(GOVERNOR_STATE_DIR, `operator_paused_${agent}`);
+      if (fs.existsSync(pf) || fs.existsSync(opf)) entry.paused = true;
     } catch (_) {}
 
     result.agents.push(entry);


### PR DESCRIPTION
## Summary
- All 10 pause check locations across 5 files now check both `paused_<agent>` AND `operator_paused_<agent>` files
- Adds `_is_agent_paused()` helper to kick-agents.sh and kick-governor.sh
- Fixes dashboard server.js to show red border/badge when operator_paused_ exists
- Fixes gh-rate-check.sh to recognize operator-paused agents during pullback

**Root cause:** Dashboard pause API correctly creates both files, but agents paused by other paths (manual file creation, cadence-only write) had only one file. All check locations only looked for `paused_`, so the governor/kick-agents would kick paused agents and the dashboard wouldn't show pause visuals.

## Files changed
- `bin/kick-agents.sh` — 2 check sites → `_is_agent_paused()`
- `bin/kick-governor.sh` — 5 check sites → `_is_agent_paused()`
- `bin/supervisor.sh` — `is_paused()` now checks both files
- `bin/gh-rate-check.sh` — pullback already-paused detection
- `dashboard/server.js` — 2 status endpoints check both files

## Test plan
- [ ] Pause agent via dashboard → both `paused_` and `operator_paused_` created, red border shown
- [ ] Create only `operator_paused_<agent>` → agent skipped by governor, shown as paused in dashboard
- [ ] Resume via dashboard → both files removed, agent kicks normally
- [ ] Rate-limit pullback with operator-paused agent → agent stays in `already_paused`, not resumed on expiry

🤖 Generated with [Claude Code](https://claude.com/claude-code)