### PR TITLE
fix: don't export GH_TOKEN to agent CLI process

### DIFF
--- a/bin/agent-launch.sh
+++ b/bin/agent-launch.sh
@@ -17,7 +17,10 @@
 
 set -euo pipefail
 
-# Source hive-config.sh to inherit GH_TOKEN from GitHub App (if configured)
+# Source hive-config.sh to make HIVE_GITHUB_TOKEN available for gh wrapper.
+# Do NOT export GH_TOKEN here — Copilot CLI uses GH_TOKEN for its own Copilot
+# API auth, which rejects GitHub App server-to-server tokens. The gh wrapper
+# (/usr/local/bin/gh) injects HIVE_GITHUB_TOKEN on a per-call basis instead.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 HIVE_CONFIG="${SCRIPT_DIR}/hive-config.sh"
 if [[ -f "$HIVE_CONFIG" ]]; then
@@ -25,6 +28,7 @@ if [[ -f "$HIVE_CONFIG" ]]; then
 elif [[ -f /usr/local/bin/hive-config.sh ]]; then
   source /usr/local/bin/hive-config.sh
 fi
+unset GH_TOKEN
 
 # Source the centralized backend/model config
 BACKENDS_CONF="${SCRIPT_DIR}/../config/backends.conf"

--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# gh wrapper — enforces agent safety rules and injects App token.
+# Installed at /usr/local/bin/gh (ahead of /usr/bin/gh in PATH).
+# Agents must read from /var/run/hive-metrics/actionable.json for listings.
+
+REAL_GH="/usr/bin/gh"
+
+# Inject GitHub App token for agent gh calls when available.
+# HIVE_GITHUB_TOKEN is set by hive-config.sh (sourced via agent-launch.sh).
+# GH_TOKEN is NOT set in the agent env (Copilot CLI uses it for its own auth),
+# so we set it here per-call so gh CLI uses the App's 15k/hr rate limit pool.
+if [[ -n "${HIVE_GITHUB_TOKEN:-}" && -z "${GH_TOKEN:-}" ]]; then
+  export GH_TOKEN="$HIVE_GITHUB_TOKEN"
+fi
+
+args=("$@")
+subcmd=""
+action=""
+for arg in "${args[@]}"; do
+  case "$arg" in
+    -*) continue ;;
+    *)
+      if [ -z "$subcmd" ]; then
+        subcmd="$arg"
+      elif [ -z "$action" ]; then
+        action="$arg"
+        break
+      fi
+      ;;
+  esac
+done
+
+# Block gh issue list and gh pr list
+if { [ "$subcmd" = "issue" ] || [ "$subcmd" = "pr" ]; } && [ "$action" = "list" ]; then
+  echo "⛔ BLOCKED: gh $subcmd list is disabled for agents." >&2
+  echo "Read /var/run/hive-metrics/actionable.json instead." >&2
+  exit 1
+fi
+
+# Block gh api calls that list issues or pulls (enumeration endpoints)
+if [ "$subcmd" = "api" ]; then
+  for arg in "${args[@]}"; do
+    case "$arg" in
+      repos/*/issues\?*|repos/*/issues|repos/*/pulls\?*|repos/*/pulls)
+        echo "⛔ BLOCKED: gh api issue/PR listing is disabled for agents." >&2
+        echo "Read /var/run/hive-metrics/actionable.json instead." >&2
+        exit 1
+        ;;
+    esac
+  done
+fi
+
+exec "$REAL_GH" "$@"

--- a/bin/hive-deploy.sh
+++ b/bin/hive-deploy.sh
@@ -57,6 +57,15 @@ for src in "$HIVE_REPO"/bin/*.sh; do
   fi
 done
 
+# gh-wrapper.sh is installed as /usr/local/bin/gh (ahead of /usr/bin/gh in PATH)
+GH_WRAPPER="$HIVE_REPO/bin/gh-wrapper.sh"
+GH_INSTALLED="$INSTALL_DIR/gh"
+if [ -f "$GH_WRAPPER" ] && ! cmp -s "$GH_WRAPPER" "$GH_INSTALLED"; then
+  sudo cp "$GH_WRAPPER" "$GH_INSTALLED"
+  sudo chmod +x "$GH_INSTALLED"
+  SYNCED="$SYNCED gh-wrapper→gh"
+fi
+
 # Restart dashboard if any dashboard/ files changed during pull
 if [ -n "$DASHBOARD_CHANGED" ]; then
   sudo systemctl restart hive-dashboard.service 2>/dev/null && \


### PR DESCRIPTION
## Summary
- Copilot CLI uses `GH_TOKEN` for its own Copilot API auth, which rejects GitHub App tokens (HTTP 400: "Server-To-Server Tokens are not supported")
- `agent-launch.sh` now unsets `GH_TOKEN` before `exec`'ing the CLI, keeping `HIVE_GITHUB_TOKEN` in the env
- New `bin/gh-wrapper.sh` (installed as `/usr/local/bin/gh`) injects `HIVE_GITHUB_TOKEN` as `GH_TOKEN` per-call, so agent `gh` commands use the App's 15k/hr pool
- `hive-deploy.sh` updated to auto-install `gh-wrapper.sh` as `/usr/local/bin/gh`

## Context
PR #214 added `hive-config.sh` sourcing to `agent-launch.sh`, which exported `GH_TOKEN` into the agent's env. This broke Copilot CLI startup — it tried to use the App token for its own auth and got 400 errors.

## Test plan
- [ ] After deploy, verify agents start without "Server-To-Server Token" errors
- [ ] Verify `gh api rate_limit` inside agent sessions shows the 15k App pool
- [ ] Verify Copilot CLI auth works (no 400 errors in pane output)