### PR TITLE
fix(deploy): npm install for Discord bot before restart

### DIFF
--- a/bin/hive-deploy.sh
+++ b/bin/hive-deploy.sh
@@ -97,6 +97,13 @@ if [ -n "$DASH_RESTART_NEEDED" ] && [ -z "$DASHBOARD_CHANGED" ]; then
     log "WARN: failed to restart hive-dashboard (drift)"
 fi
 
+# Install Discord bot dependencies if package.json changed or node_modules missing
+if [ -n "$DISCORD_CHANGED" ] || [ ! -d "$HIVE_REPO/discord/node_modules" ]; then
+  (cd "$HIVE_REPO/discord" && npm install --production 2>/dev/null) && \
+    SYNCED="$SYNCED discord(npm-install)" || \
+    log "WARN: failed to npm install in discord/"
+fi
+
 # Restart Discord bot if any discord/ files changed during pull
 if [ -n "$DISCORD_CHANGED" ]; then
   sudo systemctl restart hive-discord.service 2>/dev/null && \


### PR DESCRIPTION
## Summary
- Run `npm install --production` in `discord/` when files change or `node_modules` is missing
- Prevents bot crash-loop after fresh `git pull` (node_modules are gitignored)

## Test plan
- [ ] Delete `discord/node_modules` → next deploy tick reinstalls and restarts bot
- [ ] Merge discord/ change → npm install runs before service restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)