### PR TITLE
feat: per-agent systemd watchdogs with auto-migration

### DIFF
--- a/bin/hive-deploy.sh
+++ b/bin/hive-deploy.sh
@@ -156,6 +156,35 @@ if echo "$SYNCED" | grep -q '\.service\|\.timer'; then
   sudo systemctl daemon-reload 2>/dev/null || true
 fi
 
+# Ensure per-agent watchdog services are enabled and running.
+# Each agent gets its own hive@<name>.service backed by agent-supervisor.sh,
+# which monitors the tmux session and restarts if it dies.
+# Migrate from monolithic hive.service to per-agent hive@<name>.service.
+# The old hive.service only watchdogged the supervisor; per-agent units
+# give each agent its own watchdog with Restart=always.
+# Don't stop the old service mid-run (its tmux sessions are independent),
+# just disable it so it won't start on next boot.
+if systemctl is-enabled --quiet hive.service 2>/dev/null; then
+  sudo systemctl disable hive.service 2>/dev/null || true
+  SYNCED="$SYNCED hive.service(disabled)"
+fi
+
+HIVE_AGENTS="supervisor scanner reviewer architect outreach"
+for agent in $HIVE_AGENTS; do
+  unit="hive@${agent}.service"
+  envfile="/etc/hive/${agent}.env"
+  [ -f "$envfile" ] || continue
+  if ! systemctl is-enabled --quiet "$unit" 2>/dev/null; then
+    sudo systemctl enable "$unit" 2>/dev/null && \
+      SYNCED="$SYNCED ${unit}(enabled)" || true
+  fi
+  if ! systemctl is-active --quiet "$unit" 2>/dev/null; then
+    sudo systemctl start "$unit" 2>/dev/null && \
+      SYNCED="$SYNCED ${unit}(started)" || \
+      log "WARN: failed to start $unit"
+  fi
+done
+
 if [ -n "$SYNCED" ]; then
   log "DEPLOY ${BEFORE:0:7}→${AFTER:0:7} — synced:$SYNCED"
 fi

--- a/bin/supervisor.sh
+++ b/bin/supervisor.sh
@@ -364,7 +364,11 @@ agent_alive() {
 trap 'log "supervisor exiting"; exit 0' TERM INT
 
 log "supervisor started (session=$SESSION, cli=$CLI, poll=${POLL_SEC}s, failover=$RATE_LIMIT_FAILOVER)"
-start_session
+if session_alive && agent_alive; then
+  log "existing session $SESSION is healthy; adopting without restart"
+else
+  start_session
+fi
 while true; do
   if ! session_alive; then
     log "session $SESSION gone; restarting"

--- a/systemd/hive.service
+++ b/systemd/hive.service
@@ -5,11 +5,11 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=__AGENT_USER__
-Group=__AGENT_USER__
+User=dev
+Group=dev
 EnvironmentFile=/etc/hive/supervisor.env
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ExecStart=/usr/local/bin/agent-supervisor.sh
+ExecStart=/usr/local/bin/supervisor.sh
 Restart=always
 RestartSec=5
 StandardOutput=journal

--- a/systemd/hive@.service
+++ b/systemd/hive@.service
@@ -5,13 +5,13 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=__AGENT_USER__
-Group=__AGENT_USER__
+User=dev
+Group=dev
 # Per-instance env file; default to /etc/hive/<instance>.env.
 # %i is the instance name from hive@<name>.service.
 EnvironmentFile=/etc/hive/%i.env
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ExecStart=/usr/local/bin/agent-supervisor.sh
+ExecStart=/usr/local/bin/supervisor.sh
 Restart=always
 RestartSec=5
 StandardOutput=journal


### PR DESCRIPTION
## Summary
- Fix `hive@.service` template: replace `__AGENT_USER__` placeholder with `dev`, point ExecStart to `supervisor.sh`
- `supervisor.sh`: adopt existing healthy tmux sessions on startup instead of kill+recreate
- `hive-deploy.sh`: auto-enable and start `hive@<agent>.service` for all 5 agents; disable old monolithic `hive.service`

## Problem
Only the supervisor agent had a systemd watchdog (`hive.service`). When architect/outreach tmux sessions died, nothing restarted them — they stayed dead indefinitely. The `hive@.service` template existed but was never enabled, and had a `__AGENT_USER__` placeholder that would fail on start.

## Test plan
- [ ] Deploy triggers `hive-deploy.sh` which enables+starts `hive@{supervisor,scanner,reviewer,architect,outreach}`
- [ ] Architect and outreach tmux sessions are recreated
- [ ] Existing scanner/reviewer/supervisor sessions are adopted (not restarted)
- [ ] Old `hive.service` disabled from auto-start

🤖 Generated with [Claude Code](https://claude.com/claude-code)