### PR TITLE
feat: Discord channel topic shows agent status at a glance

### DIFF
--- a/discord/bot.js
+++ b/discord/bot.js
@@ -67,7 +67,18 @@ function sendEmbed(embed, target) {
   drainQueue();
 }
 
-const bridge = new DashboardBridge(config, sendMessage, sendEmbed);
+async function setTopic(topic) {
+  try {
+    const channel = await client.channels.fetch(config.channelPrimary);
+    if (channel && channel.setTopic) {
+      await channel.setTopic(topic);
+    }
+  } catch (err) {
+    console.error('Topic update error:', err.message);
+  }
+}
+
+const bridge = new DashboardBridge(config, sendMessage, sendEmbed, setTopic);
 const watcher = new PipelineWatcher(config, sendMessage, sendEmbed);
 
 let statusInterval = null;

--- a/discord/lib/dashboard-bridge.js
+++ b/discord/lib/dashboard-bridge.js
@@ -1,16 +1,24 @@
 const http = require('http');
 const { agentMessage } = require('./formatter');
 
+const { AGENTS } = require('./agent-identities');
+
 const SSE_RECONNECT_BASE_MS = 5000;
 const SSE_RECONNECT_MAX_MS = 60000;
 const DASHBOARD_STALE_WARN_MS = 30000;
+const TOPIC_DEBOUNCE_MS = 5000;
+const TOPIC_AGENT_ORDER = ['scanner', 'reviewer', 'architect', 'outreach', 'supervisor'];
+const TOPIC_STATE_ICONS = { working: '🟢', idle: '⚪', paused: '🔴' };
 
 class DashboardBridge {
-  constructor(config, sendMessage, sendEmbed) {
+  constructor(config, sendMessage, sendEmbed, setTopic) {
     this.config = config;
     this.sendMessage = sendMessage;
     this.sendEmbed = sendEmbed;
+    this.setTopic = setTopic || (() => {});
     this.lastState = null;
+    this.lastTopic = '';
+    this.topicTimer = null;
     this.reconnectDelay = SSE_RECONNECT_BASE_MS;
     this.staleTimer = null;
     this.firstEvent = true;
@@ -91,6 +99,7 @@ class DashboardBridge {
 
     this._diffAgents(data);
     this._diffGovernor(data);
+    this._updateTopic(data);
     this.lastState = data;
   }
 
@@ -126,6 +135,29 @@ class DashboardBridge {
         this.sendMessage(agentMessage(name, `\n\`\`\`\n${lines}\n\`\`\``));
       }
     }
+  }
+
+  _updateTopic(data) {
+    const agents = Array.isArray(data.agents) ? data.agents : [];
+    const agentMap = {};
+    for (const a of agents) { if (a.name) agentMap[a.name] = a; }
+
+    const parts = TOPIC_AGENT_ORDER.map(name => {
+      const a = agentMap[name];
+      if (!a) return null;
+      const emoji = (AGENTS[name] || {}).emoji || '?';
+      const state = a.cadence === 'paused' ? 'paused' : (a.busy || 'idle');
+      const icon = TOPIC_STATE_ICONS[state] || TOPIC_STATE_ICONS.idle;
+      return `${emoji}${icon}`;
+    }).filter(Boolean);
+
+    const gov = data.governor || {};
+    const topic = `${parts.join(' ')} · ${gov.mode || '?'} · ${gov.issues || 0}i ${gov.prs || 0}pr`;
+
+    if (topic === this.lastTopic) return;
+    this.lastTopic = topic;
+    clearTimeout(this.topicTimer);
+    this.topicTimer = setTimeout(() => this.setTopic(topic), TOPIC_DEBOUNCE_MS);
   }
 
   _diffGovernor(data) {


### PR DESCRIPTION
## Summary
- Auto-update Discord channel topic with agent status indicators on every state change
- Format: `🔍🟢 ✅⚪ 🏗🔴 🌐🟢 👑⚪ · idle · 1i 2pr`
- 🟢 working, ⚪ idle, 🔴 paused — per agent icon
- Includes governor mode and queue depth
- 5s debounce to avoid Discord rate limits

## Requires
- Bot needs `Manage Channels` permission in Discord server settings

## Test plan
- [ ] Deploy restarts Discord bot
- [ ] Channel topic updates within seconds of agent state change
- [ ] Topic reflects correct states for all 5 agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)