### PR TITLE
Consolidation: consistency fixes, strict mode, configurable paths

### DIFF
--- a/bin/agent-healthcheck.sh
+++ b/bin/agent-healthcheck.sh
@@ -6,7 +6,7 @@
 # session (the supervisor will respawn it within ~10s) and push an alert.
 # After AGENT_MAX_RESPAWNS consecutive failed respawns we stop respawning and
 # send an escalation alert — manual intervention time.
-set -u
+set -euo pipefail
 
 : "${AGENT_SESSION_NAME:?AGENT_SESSION_NAME is required}"
 : "${AGENT_LOG_FILE:?AGENT_LOG_FILE is required}"

--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -3,6 +3,8 @@
 # Installed at /usr/local/bin/gh (ahead of /usr/bin/gh in PATH).
 # Agents must read from /var/run/hive-metrics/actionable.json for listings.
 
+set -euo pipefail
+
 REAL_GH="/usr/bin/gh"
 
 # Inject GitHub App token for agent gh calls when available.

--- a/bin/gh-zombie-reaper.sh
+++ b/bin/gh-zombie-reaper.sh
@@ -6,6 +6,8 @@
 # running longer than the threshold (default 120s). Legitimate gh calls
 # complete in <10s; anything older is stuck in a rate-limit retry loop.
 
+set -euo pipefail
+
 MAX_AGE_SECONDS="${GH_ZOMBIE_MAX_AGE:-120}"
 LOG="/var/log/gh-zombie-reaper.log"
 KILLED=0
@@ -19,7 +21,7 @@ while IFS= read -r line; do
     cmdline=$(ps -p "$pid" -o args= 2>/dev/null)
     kill "$pid" 2>/dev/null
     echo "$(date -Iseconds) KILLED pid=$pid age=${age_seconds}s cmd=$cmdline" >> "$LOG"
-    ((KILLED++))
+    KILLED=$((KILLED + 1))
   fi
 done < <(ps -eo pid,etimes,comm | awk '$3 == "gh" {print $1, $2}')
 

--- a/bin/hive-config.sh
+++ b/bin/hive-config.sh
@@ -17,6 +17,9 @@
 #   GH_APP_ID, GH_APP_INSTALLATION_ID, GH_APP_KEY_FILE,
 #   HIVE_GITHUB_TOKEN (auto-generated if GitHub App is configured), GH_TOKEN
 
+HIVE_REPO_DIR="${HIVE_REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/null && pwd || echo /tmp/hive)}"
+export HIVE_REPO_DIR
+
 _HIVE_CONFIG="${HIVE_PROJECT_CONFIG:-/etc/hive/hive-project.yaml}"
 
 _hive_yq() {

--- a/bin/hive-deploy.sh
+++ b/bin/hive-deploy.sh
@@ -134,7 +134,7 @@ if [ -n "$DISCORD_RESTART_NEEDED" ] && [ -z "$DISCORD_CHANGED" ]; then
 fi
 
 # Sync hive-project.yaml to /etc/hive if changed
-HIVE_PROJECT="$HIVE_REPO/examples/kubestellar/hive-project.yaml"
+HIVE_PROJECT="${HIVE_PROJECT_CONFIG_SRC:-$HIVE_REPO/examples/kubestellar/hive-project.yaml}"
 HIVE_PROJECT_INSTALLED="/etc/hive/hive-project.yaml"
 if [ -f "$HIVE_PROJECT" ] && ! cmp -s "$HIVE_PROJECT" "$HIVE_PROJECT_INSTALLED" 2>/dev/null; then
   sudo cp "$HIVE_PROJECT" "$HIVE_PROJECT_INSTALLED" && \
@@ -169,7 +169,11 @@ if systemctl is-enabled --quiet hive.service 2>/dev/null; then
   SYNCED="$SYNCED hive.service(disabled)"
 fi
 
-HIVE_AGENTS="supervisor scanner reviewer architect outreach"
+_DEPLOY_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+for _cf in "${_DEPLOY_SCRIPT_DIR}/hive-config.sh" /usr/local/bin/hive-config.sh; do
+  if [[ -f "$_cf" ]]; then source "$_cf"; break; fi
+done
+HIVE_AGENTS="${AGENTS_ENABLED:-supervisor scanner reviewer architect outreach}"
 for agent in $HIVE_AGENTS; do
   unit="hive@${agent}.service"
   envfile="/etc/hive/${agent}.env"

--- a/bin/hive.sh
+++ b/bin/hive.sh
@@ -648,7 +648,7 @@ cmd_status() {
       local at_idle_prompt=false
       # "Esc to cancel" anywhere in last 8 lines means actively working — never idle
       if ! echo "$pane" | tail -8 | LC_ALL=C.UTF-8 grep -qE 'Esc to cancel'; then
-        if echo "$pane" | tail -3 | LC_ALL=C.UTF-8 grep -qE '^❯|^ [/@] |^ / commands'; then
+        if echo "$pane" | tail -3 | LC_ALL=C.UTF-8 grep -qE '^❯|^\$ |^> |^ [/@] |^ / commands'; then
           if ! echo "$pane" | tail -3 | LC_ALL=C.UTF-8 grep -qE 'background.*/tasks|agent still running'; then
             at_idle_prompt=true
           fi
@@ -789,7 +789,7 @@ cmd_status_json() {
       # LC_ALL=C.UTF-8 required — server runs LANG=C which breaks multi-byte UTF-8 grep
       local at_idle_prompt_json=false
       if ! echo "$pane" | tail -8 | LC_ALL=C.UTF-8 grep -qE 'Esc to cancel'; then
-        if echo "$pane" | tail -3 | LC_ALL=C.UTF-8 grep -qE '^❯|^ [/@] |^ / commands'; then
+        if echo "$pane" | tail -3 | LC_ALL=C.UTF-8 grep -qE '^❯|^\$ |^> |^ [/@] |^ / commands'; then
           if ! echo "$pane" | tail -3 | LC_ALL=C.UTF-8 grep -qE 'background.*/tasks|agent still running'; then
             at_idle_prompt_json=true
           fi

--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -491,7 +491,7 @@ send_chunked() {
   if [ ${#message} -le "$MAX_CHUNK" ]; then
     $TMUX_BIN send-keys -t "$session" -l "$message"
     sleep "$CHUNK_DELAY"
-    $TMUX_BIN send-keys -t "$session" Enter
+    hive_send_enter "$session"
     return
   fi
 
@@ -503,7 +503,7 @@ send_chunked() {
     (( offset += MAX_CHUNK ))
     sleep "$CHUNK_DELAY"
   done
-  $TMUX_BIN send-keys -t "$session" Enter
+  hive_send_enter "$session"
 }
 
 kick() {

--- a/bin/supervisor.sh
+++ b/bin/supervisor.sh
@@ -5,7 +5,7 @@
 #
 # Supports optional rate-limit failover between CLI backends (set
 # AGENT_RATE_LIMIT_FAILOVER=true and AGENT_FAILOVER_CMD in env).
-set -u
+set -euo pipefail
 
 # Source shared config (provides hive_log, hive_is_paused, etc.)
 _SUP_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/bin/ttyd-tmux.sh
+++ b/bin/ttyd-tmux.sh
@@ -2,10 +2,12 @@
 # Wrapper for ttyd → tmux that disables mouse mode so the browser
 # handles text selection and clipboard (Cmd+C / Cmd+V).
 # Mouse mode is restored when the ttyd session disconnects.
+set -euo pipefail
+
 SESSION=${1:-supervisor}
 PREV_MOUSE=$(tmux show-option -t "$SESSION" -v mouse 2>/dev/null || echo "on")
-tmux set-option -t "$SESSION" mouse off 2>/dev/null
-tmux attach-session -t "$SESSION"
-EXIT_CODE=$?
-tmux set-option -t "$SESSION" mouse "$PREV_MOUSE" 2>/dev/null
+tmux set-option -t "$SESSION" mouse off 2>/dev/null || true
+EXIT_CODE=0
+tmux attach-session -t "$SESSION" || EXIT_CODE=$?
+tmux set-option -t "$SESSION" mouse "$PREV_MOUSE" 2>/dev/null || true
 exit $EXIT_CODE

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -26,6 +26,9 @@ const PROJECT_NAME = (projectConfig.project || {}).name || '';
 const PROJECT_PRIMARY_REPO = (projectConfig.project || {}).primary_repo || '';
 const PROJECT_ORG = (projectConfig.project || {}).org || '';
 const DASHBOARD_TITLE = ((projectConfig.dashboard || {}).title) || (PROJECT_NAME ? PROJECT_NAME + ' Hive' : 'Hive');
+const HIVE_REPO_DIR = process.env.HIVE_REPO_DIR || path.resolve(__dirname, '..');
+const ENABLED_AGENTS = ((projectConfig.agents || {}).enabled || ['supervisor', 'scanner', 'reviewer', 'architect', 'outreach']);
+const ENABLED_AGENTS_PLUS_ALL = [...ENABLED_AGENTS, 'all'];
 
 // ── Centralized backend/model config (JS equivalent of backends.conf) ──────
 const KNOWN_BACKENDS = ['claude', 'copilot', 'gemini', 'codex', 'amazonq', 'goose', 'aider'];
@@ -458,7 +461,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 let gitVersionCache = { hash: '?', short: '?', behind: 0, dirty: false, ts: 0 };
 const GIT_VERSION_REFRESH_MS = 300000;
 function refreshGitVersion() {
-  const hiveDir = '/tmp/hive';
+  const hiveDir = HIVE_REPO_DIR;
   execFile('git', ['-C', hiveDir, 'rev-parse', 'HEAD'], { timeout: 5000 }, (err, hash) => {
     if (err) return;
     gitVersionCache.hash = hash.trim();
@@ -596,7 +599,7 @@ const TMUX_SESSION = {
 // Control endpoints
 app.post('/api/kick/:agent', (req, res) => {
   const agent = req.params.agent;
-  const allowed = ['scanner', 'reviewer', 'architect', 'outreach', 'supervisor', 'all'];
+  const allowed = ENABLED_AGENTS_PLUS_ALL;
   if (!allowed.includes(agent)) {
     return res.status(400).json({ error: `invalid agent: ${agent}` });
   }
@@ -629,7 +632,7 @@ app.post('/api/kick/:agent', (req, res) => {
 
 app.post('/api/switch/:agent/:backend', (req, res) => {
   const { agent, backend } = req.params;
-  const allowedAgents = ['scanner', 'reviewer', 'architect', 'outreach', 'supervisor'];
+  const allowedAgents = ENABLED_AGENTS;
   const allowedBackends = ['copilot', 'claude', 'gemini', 'goose'];
   if (!allowedAgents.includes(agent)) {
     return res.status(400).json({ error: `invalid agent: ${agent}` });
@@ -668,7 +671,7 @@ app.post('/api/switch/:agent/:backend', (req, res) => {
   }
   // Keep backend state file in sync for kick-agents.sh
   try { fs.writeFileSync(`/var/run/agent-backends/${agent}`, backend); } catch (_) {}
-  execFile('/tmp/hive/bin/kick-agents.sh', [agent], { timeout: 60000 }, (err, stdout) => {
+  execFile(`${HIVE_REPO_DIR}/bin/kick-agents.sh`, [agent], { timeout: 60000 }, (err, stdout) => {
     if (err) return res.status(500).json({ error: err.message });
     res.json({ ok: true, output: `switched ${agent} backend to ${backend}` });
   });
@@ -676,7 +679,7 @@ app.post('/api/switch/:agent/:backend', (req, res) => {
 
 app.post('/api/model/:agent/:model', (req, res) => {
   const { agent, model } = req.params;
-  const allowedAgents = ['scanner', 'reviewer', 'architect', 'outreach', 'supervisor'];
+  const allowedAgents = ENABLED_AGENTS;
   if (!allowedAgents.includes(agent)) {
     return res.status(400).json({ error: `invalid agent: ${agent}` });
   }
@@ -739,7 +742,7 @@ app.post('/api/model/:agent/:model', (req, res) => {
   // Keep backend state file in sync for kick-agents.sh
   const BACKEND_STATE_DIR = '/var/run/agent-backends';
   try { fs.writeFileSync(`${BACKEND_STATE_DIR}/${agent}`, currentBackend); } catch (_) {}
-  execFile('/tmp/hive/bin/kick-agents.sh', [agent], { timeout: 60000 }, (err, stdout) => {
+  execFile(`${HIVE_REPO_DIR}/bin/kick-agents.sh`, [agent], { timeout: 60000 }, (err, stdout) => {
     if (err) return res.status(500).json({ error: err.message });
     res.json({ ok: true, output: `switched ${agent} model to ${decodedModel} (backend: ${currentBackend})` });
   });
@@ -750,7 +753,7 @@ const GOVERNOR_CADENCE_DIR = '/var/run/kick-governor';
 
 app.post('/api/pause/:agent', (req, res) => {
   const agent = req.params.agent;
-  const allowed = ['scanner', 'reviewer', 'architect', 'outreach', 'supervisor'];
+  const allowed = ENABLED_AGENTS;
   if (!allowed.includes(agent)) {
     return res.status(400).json({ error: `cannot pause ${agent}` });
   }
@@ -791,7 +794,7 @@ app.post('/api/pause/:agent', (req, res) => {
 
 app.post('/api/resume/:agent', (req, res) => {
   const agent = req.params.agent;
-  const allowed = ['scanner', 'reviewer', 'architect', 'outreach', 'supervisor'];
+  const allowed = ENABLED_AGENTS;
   if (!allowed.includes(agent)) {
     return res.status(400).json({ error: `cannot resume ${agent}` });
   }
@@ -921,7 +924,7 @@ app.post('/api/unpin/:agent{/:dimension}', (req, res) => {
 // Restart agent — kill tmux session so supervised-agent@.service respawns it
 app.post('/api/restart/:agent', (req, res) => {
   const agent = req.params.agent;
-  const allowed = ['scanner', 'reviewer', 'architect', 'outreach', 'supervisor'];
+  const allowed = ENABLED_AGENTS;
   if (!allowed.includes(agent)) {
     return res.status(400).json({ error: `invalid agent: ${agent}` });
   }
@@ -938,7 +941,7 @@ app.post('/api/restart/:agent', (req, res) => {
 // Reset restart counter for an agent
 app.post('/api/reset-restarts/:agent', (req, res) => {
   const agent = req.params.agent;
-  const allowed = ['scanner', 'reviewer', 'architect', 'outreach', 'supervisor'];
+  const allowed = ENABLED_AGENTS;
   if (!allowed.includes(agent)) {
     return res.status(400).json({ error: `invalid agent: ${agent}` });
   }

--- a/discord/lib/dashboard-bridge.js
+++ b/discord/lib/dashboard-bridge.js
@@ -7,7 +7,7 @@ const SSE_RECONNECT_BASE_MS = 5000;
 const SSE_RECONNECT_MAX_MS = 60000;
 const DASHBOARD_STALE_WARN_MS = 30000;
 const TOPIC_DEBOUNCE_MS = 5000;
-const TOPIC_AGENT_ORDER = ['scanner', 'reviewer', 'architect', 'outreach', 'supervisor'];
+const TOPIC_AGENT_ORDER_DEFAULT = ['scanner', 'reviewer', 'architect', 'outreach', 'supervisor'];
 const TOPIC_STATE_ICONS = { working: '🟢', idle: '⚪', paused: '🔴' };
 
 class DashboardBridge {
@@ -142,7 +142,10 @@ class DashboardBridge {
     const agentMap = {};
     for (const a of agents) { if (a.name) agentMap[a.name] = a; }
 
-    const parts = TOPIC_AGENT_ORDER.map(name => {
+    const agentOrder = agents.length > 0
+      ? agents.map(a => a.name).filter(Boolean)
+      : TOPIC_AGENT_ORDER_DEFAULT;
+    const parts = agentOrder.map(name => {
       const a = agentMap[name];
       if (!a) return null;
       const emoji = (AGENTS[name] || {}).emoji || '?';


### PR DESCRIPTION
## Summary

Completes the remaining items from the hive consolidation plan (tiers 2F, 2G, 3A-3E):

- **2F**: `send_chunked()` in kick-agents.sh now uses `hive_send_enter()` (3x Enter) instead of 1x Enter, matching the dashboard's custom prompt send behavior
- **2G**: Added `set -euo pipefail` to 5 scripts missing strict mode (agent-healthcheck, supervisor, gh-wrapper, gh-zombie-reaper, ttyd-tmux), with fixes for patterns that would break under strict mode
- **3A**: Replaced hardcoded `/tmp/hive` paths in dashboard/server.js with `HIVE_REPO_DIR` env var; added `HIVE_REPO_DIR` to hive-config.sh for bash scripts
- **3B**: Agent allowed-lists in server.js now read from hive-project.yaml config; hive-deploy.sh uses `AGENTS_ENABLED` from hive-config.sh; Discord dashboard-bridge.js derives agent order from SSE data
- **3C**: hive-deploy.sh project config source path is configurable via `HIVE_PROJECT_CONFIG_SRC`
- **3E**: Idle prompt detection in hive.sh broadened to match `$` and `>` prompt characters

Companion to PR #227 (shared functions, dead code removal, correctness fixes).

## Test plan

- [ ] `hive status` output unchanged for current setup
- [ ] Dashboard kick/switch/model/pause/resume endpoints accept configured agents
- [ ] `hive-deploy.sh` reads agent list from config (verify with `AGENTS_ENABLED` override)
- [ ] No scripts fail on startup with `set -euo pipefail`
- [ ] Discord topic updates from SSE agent data

🤖 Generated with [Claude Code](https://claude.com/claude-code)