### PR TITLE
fix: outreach PR counts showing 0 in live dashboard

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -593,8 +593,8 @@
         const contribs = m.contributors || 0;
         const adopters = m.adopters || 0;
         const acmm = m.acmm || 0;
-        const awOpen = m.awesomeOpen || 0;
-        const awMerged = m.awesomeMerged || 0;
+        const awOpen = m.outreachOpen || m.awesomeOpen || 0;
+        const awMerged = m.outreachMerged || m.awesomeMerged || 0;
         const starSpark = sparkSvg(dailyAggregate(window._trendData || [], 'stars'), '#e3b341');
         const awOpenSpark = sparkSvg(dailyAggregate(window._trendData || [], 'awesomeOpen'), '#58a6ff');
         const awMergedSpark = sparkSvg(dailyAggregate(window._trendData || [], 'awesomeMerged'), '#3fb950');


### PR DESCRIPTION
## Summary
- The live dashboard was reading `m.awesomeOpen`/`m.awesomeMerged` from the SSE agent metrics, but the raw agent-metrics output uses `outreachOpen`/`outreachMerged`.
- PR #230 fixed the server.js sparkline/persistent history mapping but missed the HTML live render path — `statusCache.agentMetrics` passes the raw object directly to the client.
- Fix: read `m.outreachOpen || m.awesomeOpen` so it works with both live SSE data (raw field names) and sparkline snapshot keys (mapped names).

## Test plan
- [ ] Verify OUTREACH PRS row shows non-zero values in Safari after hard refresh