### PR TITLE
fix: cache fallback for outreach PR counts and coverage badge

### DIFF
--- a/dashboard/agent-metrics.sh
+++ b/dashboard/agent-metrics.sh
@@ -142,8 +142,15 @@ outreach_json=$(jq -n --arg doing "$outreach_doing" --arg model "$outreach_model
 # ── Reviewer: coverage from README badge gist (authoritative source) ──
 COVERAGE_BADGE_URL="$BADGE_URL"
 coverage_target=91
-coverage_value=$(curl -sf "$COVERAGE_BADGE_URL" 2>/dev/null | jq -r '.message // "0"' | tr -d '%' || echo 0)
+coverage_value=$(curl -sf --max-time 5 "$COVERAGE_BADGE_URL" 2>/dev/null | jq -r '.message // "0"' | tr -d '%' || echo 0)
 coverage_value=${coverage_value:-0}
+# Fall back to last known value if badge fetch failed
+if [[ "$coverage_value" == "0" ]]; then
+  GITHUB_CACHE_CVG="${HIVE_METRICS_DIR:-/var/run/hive-metrics}/coverage-last.txt"
+  [[ -f "$GITHUB_CACHE_CVG" ]] && coverage_value=$(cat "$GITHUB_CACHE_CVG" 2>/dev/null || echo 0)
+elif [[ "$coverage_value" -gt 0 ]] 2>/dev/null; then
+  echo "$coverage_value" > "${HIVE_METRICS_DIR:-/var/run/hive-metrics}/coverage-last.txt" 2>/dev/null || true
+fi
 reviewer_json=$(echo "$reviewer_json" | jq --argjson cv "$coverage_value" --argjson ct "$coverage_target" '. + {coverage: $cv, coverageTarget: $ct}')
 
 # ── Outreach: read from centralized api-collector cache (no extra API calls) ──

--- a/dashboard/api-collector.sh
+++ b/dashboard/api-collector.sh
@@ -174,6 +174,16 @@ acmm=$(cat "$tmpdir/acmm" 2>/dev/null || echo 0)
 outreach_open=$(cat "$tmpdir/outreach_open" 2>/dev/null || echo 0)
 outreach_merged=$(cat "$tmpdir/outreach_merged" 2>/dev/null || echo 0)
 
+# Fall back to previous cache if search API failed (returns 0 or empty)
+if [[ "${outreach_open:-0}" == "0" ]] && [[ -f "$CACHE_FILE" ]]; then
+  cached_open=$(jq -r '.outreach.open // 0' "$CACHE_FILE" 2>/dev/null || echo 0)
+  [[ "$cached_open" -gt 0 ]] 2>/dev/null && outreach_open="$cached_open"
+fi
+if [[ "${outreach_merged:-0}" == "0" ]] && [[ -f "$CACHE_FILE" ]]; then
+  cached_merged=$(jq -r '.outreach.merged // 0' "$CACHE_FILE" 2>/dev/null || echo 0)
+  [[ "$cached_merged" -gt 0 ]] 2>/dev/null && outreach_merged="$cached_merged"
+fi
+
 now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 cat > "$CACHE_TMP" <<ENDJSON


### PR DESCRIPTION
## Summary
- When the GitHub search API fails on the remote server, outreach PR counts (open/merged) silently fall to 0. Added cache fallback in `api-collector.sh` — if the search API returns 0 but the previous cache has a non-zero value, retain it.
- When the coverage badge gist fetch fails (network/DNS on remote box), coverage shows 0%. Added a file-based last-known-good cache in `agent-metrics.sh` — writes the value when successful, reads it back when the fetch fails.

## Test plan
- [ ] Verify dashboard shows non-zero outreach PR counts after deploy
- [ ] Verify coverage shows 91% (or last known value) instead of 0%
- [ ] Confirm values update when the APIs recover