### PR TITLE
fix: add --cache 300s to search API calls and error logging

### DIFF
--- a/dashboard/api-collector.sh
+++ b/dashboard/api-collector.sh
@@ -111,8 +111,9 @@ else
 fi
 
 # ── Fetch outreach PR counts ──
-($GH api "search/issues?q=author:${AI_AUTHOR}+type:pr+is:open+${PROJECT}+in:title+-org:${PROJECT_ORG}" --jq '.total_count' > "$tmpdir/outreach_open" 2>/dev/null || echo 0 > "$tmpdir/outreach_open") &
-($GH api "search/issues?q=author:${AI_AUTHOR}+type:pr+is:merged+${PROJECT}+in:title+-org:${PROJECT_ORG}" --jq '.total_count' > "$tmpdir/outreach_merged" 2>/dev/null || echo 0 > "$tmpdir/outreach_merged") &
+# Use --cache to avoid secondary rate limits on search API
+(result=$($GH api --cache 300s "search/issues?q=author:${AI_AUTHOR}+type:pr+is:open+${PROJECT}+in:title+-org:${PROJECT_ORG}" --jq '.total_count' 2>"$tmpdir/outreach_open_err") && echo "$result" > "$tmpdir/outreach_open" || { echo 0 > "$tmpdir/outreach_open"; cat "$tmpdir/outreach_open_err" >> "$CACHE_DIR/api-collector.log" 2>/dev/null; }) &
+(result=$($GH api --cache 300s "search/issues?q=author:${AI_AUTHOR}+type:pr+is:merged+${PROJECT}+in:title+-org:${PROJECT_ORG}" --jq '.total_count' 2>"$tmpdir/outreach_merged_err") && echo "$result" > "$tmpdir/outreach_merged" || { echo 0 > "$tmpdir/outreach_merged"; cat "$tmpdir/outreach_merged_err" >> "$CACHE_DIR/api-collector.log" 2>/dev/null; }) &
 
 wait
 


### PR DESCRIPTION
## Summary
- GitHub search API has tighter rate limits (30 req/min) than REST API. The outreach PR count queries were silently failing due to secondary rate limits on the remote server.
- Added `--cache 300s` to both search API calls so `gh` reuses cached responses within 5 minutes.
- Added stderr capture to `api-collector.log` for debugging when search calls fail.

This complements PR #232's cache fallback — #232 prevents the cache from being overwritten with 0, this PR prevents the search API from being rate-limited in the first place.

## Test plan
- [ ] After deploy, check `api-collector.log` on remote for any error messages
- [ ] Verify outreach PR counts show 257/103 (or current values) instead of 0