### PR TITLE
feat: static snapshot builder for read-only dashboard

### DIFF
--- a/dashboard/build-snapshot.mjs
+++ b/dashboard/build-snapshot.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// Build a static HTML snapshot of the hive dashboard.
+// Reads index.html, fetches live data from the dashboard API,
+// and produces a self-contained static HTML file.
+
+import { readFileSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FETCH_TIMEOUT_MS = 10_000;
+
+const dashboardUrl = process.argv[2] || process.env.HIVE_DASHBOARD_URL || 'http://localhost:3001';
+const outputFile = process.argv[3] || 'snapshot.html';
+
+async function fetchJson(endpoint, fallback = '{}') {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    const res = await fetch(`${dashboardUrl}${endpoint}`, { signal: controller.signal });
+    clearTimeout(timer);
+    return await res.text();
+  } catch {
+    return fallback;
+  }
+}
+
+async function main() {
+  console.log(`Fetching data from ${dashboardUrl}...`);
+
+  const [statusRaw, historyRaw, trendsRaw, timelineRaw, configRaw, versionRaw] = await Promise.all([
+    fetchJson('/api/status'),
+    fetchJson('/api/history', '[]'),
+    fetchJson('/api/trends?range=week', '[]'),
+    fetchJson('/api/timeline', '[]'),
+    fetchJson('/api/config'),
+    fetchJson('/api/version'),
+  ]);
+
+  // Validate status
+  try { JSON.parse(statusRaw); } catch {
+    console.error(`ERROR: Invalid JSON from ${dashboardUrl}/api/status`);
+    process.exit(1);
+  }
+
+  const config = JSON.parse(configRaw || '{}');
+  const projectName = config.projectName || 'Hive';
+  const snapshotTs = new Date().toISOString();
+
+  console.log(`Building snapshot for ${projectName} (${snapshotTs})...`);
+
+  const sourceHtml = readFileSync(join(__dirname, 'index.html'), 'utf-8');
+
+  // Split at key boundaries
+  const styleEnd = sourceHtml.indexOf('</style>');
+  const bodyStart = sourceHtml.indexOf('<body>');
+  const scriptStart = sourceHtml.indexOf('<script>');
+  const scriptEnd = sourceHtml.lastIndexOf('</script>');
+
+  const headAndStyles = sourceHtml.slice(0, styleEnd);
+  const bodyContent = sourceHtml.slice(bodyStart + 6, scriptStart);
+  const originalScript = sourceHtml.slice(scriptStart + 8, scriptEnd);
+
+  // Extract only the render functions from the original script (skip initialization code)
+  const connectIdx = originalScript.indexOf('function connect()');
+  const renderFunctions = originalScript.slice(0, connectIdx);
+
+  const staticCss = `
+    /* Static snapshot overrides */
+    .connection { display: none !important; }
+    .agent-actions { display: none !important; }
+    .kick-row { display: none !important; }
+    .widget-dl { display: none !important; }
+    .snapshot-banner {
+      background: linear-gradient(135deg, #1a1f2e 0%, #161b22 100%);
+      border: 1px solid #30363d; border-radius: 8px;
+      padding: 12px 20px; margin-bottom: 16px;
+      display: flex; align-items: center; gap: 12px;
+      font-size: 0.8rem; color: #8b949e;
+    }
+    .snapshot-banner .snap-icon { font-size: 1.2rem; }
+    .snapshot-banner .snap-label { color: #58a6ff; font-weight: 600; }
+    .snapshot-banner .snap-time { color: #e6edf3; }
+  `;
+
+  const banner = `
+  <div class="snapshot-banner">
+    <span class="snap-icon">📸</span>
+    <span><span class="snap-label">Read-only snapshot</span> &mdash; captured <span class="snap-time" id="snap-time"></span></span>
+  </div>`;
+
+  const initScript = `
+    // ── Static snapshot initialization ──
+    historyData = ${historyRaw};
+    window._trendData = ${trendsRaw};
+    window._timelineData = ${timelineRaw};
+
+    // Set project name — match the live dashboard's pattern
+    const _cfg = ${configRaw};
+    const _projEl = document.getElementById('project-name');
+    if (_projEl && _cfg.primaryRepo) {
+      _projEl.textContent = 'for ' + _cfg.primaryRepo;
+      document.title = '\\u{1F41D} Hive Dashboard for ' + _cfg.primaryRepo + ' (Snapshot)';
+    }
+    if (_cfg.primaryRepo) window._primaryRepo = _cfg.primaryRepo;
+    if (_cfg.repo) window._hiveRepo = _cfg.repo;
+
+    // Render baked status
+    render(${statusRaw});
+
+    // Git version
+    const _v = ${versionRaw};
+    const _gv = document.getElementById('git-version');
+    if (_gv && _v.short) {
+      let _html = '<span style="color:inherit">' + _v.short + '</span>';
+      if (_v.dirty) _html += ' <span class="git-dirty">*</span>';
+      if (_v.behind > 0) _html += ' <span class="git-behind">' + _v.behind + ' behind</span>';
+      _gv.innerHTML = _html;
+    }
+
+    // Format snapshot timestamp
+    const _snapTs = '${snapshotTs}';
+    const _snapEl = document.getElementById('snap-time');
+    if (_snapEl) {
+      const d = new Date(_snapTs);
+      _snapEl.textContent = d.toLocaleDateString([], {month:'short',day:'numeric',year:'numeric'}) +
+        ' ' + d.toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true});
+    }
+
+    // Disable interactive functions
+    function kick() {}
+    function switchCli() {}
+    function switchModel() {}
+  `;
+
+  const output = [
+    headAndStyles,
+    staticCss,
+    '\n  </style>\n</head>\n<body>',
+    banner,
+    bodyContent,
+    '  <script>',
+    renderFunctions,
+    initScript,
+    '  </script>\n</body>\n</html>',
+  ].join('\n');
+
+  writeFileSync(outputFile, output);
+  const size = Buffer.byteLength(output);
+  console.log(`Snapshot written to ${outputFile} (${size} bytes)`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/dashboard/build-snapshot.sh
+++ b/dashboard/build-snapshot.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Build a static HTML snapshot of the hive dashboard.
+# Fetches current state from the live dashboard API and bakes it into
+# a self-contained HTML file that renders identically but without SSE.
+#
+# Usage: ./build-snapshot.sh [DASHBOARD_URL] [OUTPUT_FILE]
+#   DASHBOARD_URL  defaults to http://localhost:3001
+#   OUTPUT_FILE    defaults to ./snapshot.html
+
+set -euo pipefail
+
+DASHBOARD_URL="${1:-${HIVE_DASHBOARD_URL:-http://localhost:3001}}"
+OUTPUT_FILE="${2:-snapshot.html}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+node "${SCRIPT_DIR}/build-snapshot.mjs" "$DASHBOARD_URL" "$OUTPUT_FILE"

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>🐝 Hive Dashboard</title>
+  <title>🐝 KubeStellar Hive Dashboard for KubeStellar/Console</title>
   <style>
     :root {
       --bg: #0d1117; --surface: #161b22; --border: #30363d;
@@ -46,6 +46,16 @@
     .agent-state { text-align: right; font-size: 0.75rem; font-weight: 600; margin-top: 6px; }
     .agent-state.working { color: var(--green); }
     .agent-state.idle { color: var(--muted); }
+    .agent-state.paused { color: #f85149; }
+    .status-badge { display: inline-block; font-size: 0.65rem; font-weight: 700; padding: 2px 6px; border-radius: 4px; margin-left: 6px; text-transform: uppercase; letter-spacing: 0.5px; }
+    .status-badge.blocked { background: rgba(248,81,73,0.2); color: #f85149; border: 1px solid rgba(248,81,73,0.4); }
+    .status-badge.needs-context { background: rgba(210,153,34,0.2); color: #d2992a; border: 1px solid rgba(210,153,34,0.4); }
+    .status-badge.done-concerns { background: rgba(227,139,44,0.2); color: #e38b2c; border: 1px solid rgba(227,139,44,0.4); }
+    .status-badge.done { background: rgba(63,185,80,0.15); color: #3fb950; border: 1px solid rgba(63,185,80,0.3); }
+    .agent-card.status-blocked { border-color: #f85149 !important; }
+    .agent-card.status-needs-context { border-color: #d2992a !important; }
+    @keyframes pulse-amber { 0%,100% { border-color: rgba(210,153,34,0.3); } 50% { border-color: rgba(210,153,34,0.8); } }
+    .agent-card.status-stale { animation: pulse-amber 2s ease-in-out infinite; }
     .agent-name { font-size: 1.1rem; font-weight: 700; margin-bottom: 8px; }
     .agent-name .dot {
       display: inline-block; width: 8px; height: 8px;
@@ -61,6 +71,8 @@
     .restart-warn { color: var(--yellow); }
     .restart-high { color: var(--red); }
     .restart-spark { display: inline-block; margin-left: 6px; vertical-align: middle; }
+    .restart-reset { cursor: pointer; font-size: 0.55rem; color: var(--muted); background: none; border: 1px solid var(--border); border-radius: 3px; padding: 0 4px; margin-left: 4px; vertical-align: middle; transition: all 0.2s; }
+    .restart-reset:hover { color: var(--text); border-color: var(--text); }
     .value.idle { color: var(--muted); }
     .value.copilot { color: var(--cyan); }
     .value.claude { color: var(--purple); }
@@ -77,6 +89,13 @@
     }
     .kick-prompt:focus { border-color: var(--accent); }
     .kick-prompt::placeholder { color: var(--muted); }
+    .btn-toggle { cursor: pointer; font-size: 0.7rem; padding: 3px 8px; border-radius: 4px; border: 1px solid var(--border); background: var(--surface); color: var(--muted); transition: all 0.2s; }
+    .btn-toggle:hover { border-color: var(--accent); color: var(--text); }
+    .btn-toggle.paused { background: rgba(248,81,73,0.15); border-color: #f85149; color: #f85149; }
+    .btn-toggle.running { background: rgba(63,185,80,0.15); border-color: #3fb950; color: #3fb950; }
+    .agent-card.paused { border-color: #f85149; opacity: 0.7; }
+    .agent-card.paused .agent-state { color: #f85149; }
+    .pause-badge { display: inline-block; font-size: 0.6rem; background: rgba(248,81,73,0.15); color: #f85149; border: 1px solid rgba(248,81,73,0.3); border-radius: 3px; padding: 1px 5px; margin-left: 4px; vertical-align: middle; }
 
     /* Health status panel */
     .health { margin-bottom: 24px; }
@@ -110,6 +129,13 @@
       text-decoration: none; transition: all 0.2s; display: inline-block;
     }
     .terminal-link:hover { background: var(--cyan); color: var(--bg); }
+    .restart-btn {
+      font-size: 0.7rem; padding: 3px 8px; border-radius: 4px;
+      border: 1px solid var(--yellow); background: transparent;
+      color: var(--yellow); cursor: pointer; font-family: inherit;
+      transition: all 0.2s; display: inline-block;
+    }
+    .restart-btn:hover { background: var(--yellow); color: var(--bg); }
     .backend-select {
       appearance: none; -webkit-appearance: none;
       background: var(--surface); color: var(--muted);
@@ -124,6 +150,10 @@
     .governor {
       background: var(--surface); border: 1px solid var(--border);
       border-radius: 8px; padding: 16px; margin-bottom: 24px;
+    }
+    @media (max-width: 480px) {
+      .governor { padding: 10px; }
+      .pause-badge { font-size: 0.55rem; padding: 0px 3px; margin-left: 2px; }
     }
     .governor.dead { border-color: var(--red); }
     .governor.active { border-color: var(--green); }
@@ -144,9 +174,12 @@
       border-radius: 6px; padding: 12px; overflow: hidden;
     }
     .repo-name { font-size: 0.85rem; font-weight: 600; margin-bottom: 6px; }
+    .repo-name a:hover { text-decoration: underline !important; }
     .repo-stats { display: flex; gap: 16px; font-size: 0.8rem; }
     .repo-stat .num { font-weight: 700; font-size: 1rem; }
     .repo-stat .label { color: var(--muted); font-size: 0.7rem; }
+    .repo-stat a:hover { text-decoration: underline !important; }
+    .repo-stat a:hover .label { color: var(--fg); }
 
     /* Sparklines */
     .sparkline { display: inline-block; vertical-align: middle; margin-left: 6px; flex-shrink: 0; }
@@ -189,6 +222,14 @@
       animation: breathe-green 4s ease-in-out infinite;
     }
 
+    /* Green pulsing dot for active agents in cadence matrix */
+    @keyframes green-pulse { 0%,100% { opacity: 1; box-shadow: 0 0 4px var(--green); } 50% { opacity: 0.3; box-shadow: none; } }
+    .active-dot {
+      display: inline-block; width: 6px; height: 6px; border-radius: 50%;
+      background: var(--green); margin-right: 6px; vertical-align: middle;
+      animation: green-pulse 6s ease-in-out infinite;
+    }
+
     /* Temperature gauge */
     .temp-gauge { margin: 12px 0 8px; }
     .temp-gauge-label { font-size: 0.7rem; color: var(--muted); margin-bottom: 4px; display: flex; justify-content: space-between; }
@@ -220,17 +261,21 @@
       text-shadow: 0 1px 4px rgba(0,0,0,0.8);
     }
     .temp-gauge-labels {
-      display: flex; justify-content: space-between; margin-top: 4px;
+      position: relative; margin-top: 4px; height: 1em;
       font-size: 0.6rem; color: var(--muted);
     }
-    .temp-gauge-labels span { text-align: center; }
+    .temp-gauge-labels span { position: absolute; transform: translateX(-50%); text-align: center; }
+    .temp-gauge-labels .lbl-idle  { left: 3.5%; }
+    .temp-gauge-labels .lbl-quiet { left: 20%; }
+    .temp-gauge-labels .lbl-busy  { left: 50%; }
+    .temp-gauge-labels .lbl-surge { left: 83.5%; }
     .tl-idle { color: #238636; }
     .tl-quiet { color: #1f6feb; }
     .tl-busy { color: #d29922; }
     .tl-surge { color: #f85149; }
 
     /* Governor cadence matrix table */
-    .gov-matrix { margin-top: 14px; width: 100%; border-collapse: collapse; font-size: 0.72rem; }
+    .gov-matrix { margin-top: 14px; width: 100%; border-collapse: collapse; font-size: 0.72rem; table-layout: fixed; }
     .gov-matrix th { color: var(--muted); font-weight: 600; padding: 3px 8px; text-align: center; border-bottom: 1px solid var(--border); }
     .gov-matrix th.mode-active { border-radius: 4px 4px 0 0; padding: 4px 10px; font-weight: 700; }
     .gov-matrix th.mode-idle  { color: #238636; }
@@ -243,14 +288,24 @@
     .gov-matrix th.mode-active.mode-surge { background: rgba(248,81,73,0.15); }
     .gov-matrix td { padding: 3px 8px; text-align: center; color: var(--muted); border-bottom: 1px solid rgba(48,54,61,0.5); }
     .gov-matrix td:first-child { text-align: left; color: var(--text); font-weight: 600; min-width: 72px; }
+    @media (max-width: 480px) {
+      .gov-matrix { font-size: 0.65rem; }
+      .gov-matrix th { padding: 2px 4px; }
+      .gov-matrix th.mode-active { padding: 3px 6px; }
+      .gov-matrix td { padding: 2px 4px; }
+      .gov-matrix td:first-child { min-width: 56px; }
+    }
     .gov-matrix td.col-active { font-weight: 700; color: var(--text); }
     .gov-matrix td.col-active.mode-idle  { background: rgba(35,134,54,0.08); color: #3fb950; }
     .gov-matrix td.col-active.mode-quiet { background: rgba(31,111,235,0.08); color: #58a6ff; }
     .gov-matrix td.col-active.mode-busy  { background: rgba(210,153,34,0.08); color: #d29922; }
     .gov-matrix td.col-active.mode-surge { background: rgba(248,81,73,0.08); color: #f85149; }
     .gov-matrix td.paused { color: #484f58; font-style: italic; }
-    @keyframes cadence-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.3; } }
-    .gov-matrix td.col-active.agent-working { animation: cadence-pulse 2.5s ease-in-out infinite; }
+    .gov-matrix .agent-dot {
+      display: inline-block; width: 6px; height: 6px; border-radius: 50%;
+      background: var(--green); margin-right: 4px; vertical-align: middle;
+      animation: green-pulse 6s ease-in-out infinite;
+    }
 
     /* Timeline strip */
     .gov-timeline { margin-top: 10px; }
@@ -281,6 +336,8 @@
     .ind-pr:hover { background: rgba(138,99,210,0.3); }
     .ind-merged { background: rgba(63,185,80,0.15); color: #3fb950; border-color: rgba(63,185,80,0.3); }
     .ind-merged:hover { background: rgba(63,185,80,0.3); }
+    .ind-wip { background: rgba(210,153,34,0.15); color: #d29922; border-color: rgba(210,153,34,0.3); }
+    .ind-wip:hover { background: rgba(210,153,34,0.3); }
     .ind-arrow { color: var(--muted); font-size: 0.7rem; }
     .ind-dots { display: flex; flex-wrap: wrap; gap: 8px; }
     .ind-dot-item { display: flex; align-items: center; gap: 3px; }
@@ -332,6 +389,16 @@
     .token-session-row .smsgs { color: var(--muted); min-width: 50px; }
     .token-session-row .sproj { color: var(--muted); font-size: 0.65rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
+    /* Token burn rate chart */
+    .burn-chart-wrap { margin: 8px 0 12px; }
+    .burn-chart-title { font-size: 0.7rem; color: var(--muted); margin-bottom: 4px; }
+    .burn-context { display: flex; justify-content: space-between; margin-top: 6px; font-size: 0.7rem; font-family: monospace; }
+    .burn-context .bc-stat { display: flex; flex-direction: column; align-items: center; }
+    .burn-context .bc-val { font-weight: 700; font-size: 0.85rem; }
+    .burn-context .bc-label { color: var(--muted); font-size: 0.6rem; }
+    .burn-area-wrap { margin: 4px 0 12px; }
+    .burn-area-title { font-size: 0.7rem; color: var(--muted); margin-bottom: 4px; }
+
     /* Cadence advisor */
     .advisor-section { margin: 12px 0; padding: 12px; background: rgba(88,166,255,0.05); border: 1px solid rgba(88,166,255,0.15); border-radius: 6px; }
     .advisor-title { font-size: 0.85rem; font-weight: 700; margin-bottom: 6px; }
@@ -357,8 +424,11 @@
     .budget-bar-fill.danger { background: var(--red); }
 
     /* Model chip on agent cards */
+    .pin-toggle { cursor: pointer; background: none; border: none; font-size: 0.7rem; padding: 0 2px; opacity: 0.6; transition: opacity 0.2s; }
+    .pin-toggle:hover { opacity: 1; }
     .model-chip { display: inline-flex; align-items: center; gap: 4px; font-size: 0.65rem; padding: 2px 6px; border-radius: 4px; }
     .model-chip.free { background: rgba(63,185,80,0.12); color: var(--green); }
+    .model-chip.paid { background: rgba(210,153,34,0.12); color: var(--yellow); }
     .model-chip.haiku { background: rgba(88,166,255,0.12); color: var(--blue); }
     .model-chip.sonnet { background: rgba(210,153,34,0.12); color: var(--yellow); }
     .model-chip.opus { background: rgba(248,81,73,0.12); color: var(--red); }
@@ -374,6 +444,13 @@
     .health-ci.bad { color: #f85149; }
 
     /* GitHub API rate limit alert bar */
+    .gh-auth-alert {
+      display: none; position: fixed; top: 0; left: 0; right: 0; z-index: 10000;
+      background: #8b1a1a; border-bottom: 2px solid #f85149; color: #e6edf3;
+      padding: 10px 20px; font-size: 0.85rem; text-align: center;
+    }
+    .gh-auth-alert.active { display: block; }
+    .gh-auth-alert a { color: #79c0ff; text-decoration: underline; }
     .gh-rate-alert {
       background: rgba(210,153,34,0.15); border: 1px solid rgba(210,153,34,0.4);
       border-radius: 8px; padding: 10px 16px; margin-bottom: 16px;
@@ -397,16 +474,27 @@
       color: var(--text); opacity: 0.85; overflow: hidden;
       text-overflow: ellipsis; white-space: nowrap; flex: 1;
     }
+    #toast-container { position: fixed; top: 16px; right: 16px; z-index: 9999; display: flex; flex-direction: column; gap: 8px; pointer-events: none; }
+    .toast { pointer-events: auto; padding: 10px 16px; border-radius: 6px; font-size: 0.78rem; color: #e6edf3; box-shadow: 0 4px 12px rgba(0,0,0,0.4); animation: toast-in 0.25s ease-out; max-width: 360px; }
+    .toast.success { background: #1a7f37; border: 1px solid #238636; }
+    .toast.error { background: #8b1a1a; border: 1px solid #f85149; }
+    .toast.info { background: #1a3a5c; border: 1px solid #1f6feb; }
+    .toast-spinner { display: inline-block; width: 12px; height: 12px; border: 2px solid rgba(255,255,255,0.3); border-top-color: #fff; border-radius: 50%; animation: spin 0.8s linear infinite; margin-right: 8px; vertical-align: middle; }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    @keyframes toast-in { from { opacity: 0; transform: translateX(40px); } to { opacity: 1; transform: translateX(0); } }
+    @keyframes toast-out { from { opacity: 1; } to { opacity: 0; transform: translateY(-10px); } }
   </style>
 </head>
 <body>
+<div id="toast-container"></div>
+<div class="gh-auth-alert" id="gh-auth-alert">GitHub CLI authentication failed (401). Agents cannot use <code>gh</code> commands. Run <code>gh auth login</code> on the dev server to fix.</div>
   <div class="gh-rate-alert" id="gh-rate-alert"></div>
 
   <div class="connection live" id="conn">
     <span class="dot-live">●</span> live
   </div>
 
-  <h1><span class="bee">🐝</span> <span id="project-name">Hive</span> Dashboard <span class="timestamp" id="ts"></span>
+  <h1><span class="bee">🐝</span> KubeStellar Hive Dashboard&nbsp;<span id="project-name">for KubeStellar/Console</span> <span class="timestamp" id="ts"></span>
     <span class="git-version" id="git-version"></span>
     <a href="/api/widget" class="widget-dl" title="Download Übersicht widget">⬇ Widget</a>
   </h1>
@@ -455,21 +543,6 @@
         `</svg></span>`;
     }
 
-    function dailyAggregate(rawData, key) {
-      if (!rawData || rawData.length === 0) return [];
-      const MS_PER_DAY = 86400000;
-      const buckets = {};
-      for (const s of rawData) {
-        const dayKey = Math.floor((s.t || 0) / MS_PER_DAY);
-        const keys = key.split('.');
-        let v = s;
-        for (const k of keys) v = v?.[k];
-        buckets[dayKey] = v ?? 0;
-      }
-      const sortedDays = Object.keys(buckets).sort((a, b) => a - b);
-      return sortedDays.map(d => buckets[d]);
-    }
-
     function getHistorySeries(key) {
       return historyData.map(s => {
         const keys = key.split('.');
@@ -505,6 +578,25 @@
     }
 
     let currentAgentMetrics = {};
+    // Per-issue token cost data — keyed by issue number (string)
+    let issueCosts = {};
+
+    async function fetchIssueCosts() {
+      try {
+        const r = await fetch('/api/issue-costs');
+        const data = await r.json();
+        issueCosts = {};
+        for (const entry of (data || [])) {
+          if (entry.issue && entry.issue !== 'unknown') {
+            issueCosts[String(entry.issue)] = entry;
+          }
+        }
+      } catch (_) { /* non-fatal — cost display is optional */ }
+    }
+    // Fetch on load, then every 60s (matches token-collector cadence)
+    fetchIssueCosts();
+    const ISSUE_COSTS_REFRESH_MS = 60000;
+    setInterval(fetchIssueCosts, ISSUE_COSTS_REFRESH_MS);
 
     function agentIndicators(name) {
       const m = currentAgentMetrics[name];
@@ -512,7 +604,7 @@
 
       if (name === 'scanner') {
         const pairs = m.pairs || [];
-        if (pairs.length === 0) return '<div class="agent-indicators"><span class="ind-empty">no active fixes</span></div>';
+        const inProgress = m.inProgress || [];
         const openPairs = pairs.filter(p => p.state !== 'merged');
         const mergedPairs = pairs.filter(p => p.state === 'merged');
         const renderPair = (p) => {
@@ -521,14 +613,35 @@
           const prIcon = p.state === 'merged' ? '✓' : '⎇';
           const prCls = p.state === 'merged' ? 'ind-pr ind-merged' : 'ind-pr';
           const prTip = p.prTitle ? esc(p.prTitle) : '';
+          // Show token cost annotation for merged issues when data is available
+          let costHtml = '';
+          if (p.state === 'merged') {
+            const cost = issueCosts[String(p.issue)];
+            if (cost) {
+              const tokVal = cost.tokens_exact != null ? cost.tokens_exact : cost.tokens_estimated;
+              if (tokVal > 0) {
+                const isExact = cost.tokens_exact != null;
+                const costTip = isExact ? 'exact token count (from session metadata)' : 'estimated (total ÷ issues)';
+                costHtml = ` <span class="ind-cost" title="${costTip}" style="color:var(--muted);font-size:0.65rem">${isExact ? '' : '~'}${fmtTokens(tokVal)} tok</span>`;
+              }
+            }
+          }
           return `<div class="ind-pair">
-          <a class="ind-tag ind-issue" href="https://github.com/${window._primaryRepo || 'kubestellar/console'}/issues/${p.issue}" target="_blank" title="${issueTip}">${issueLabel}</a>
+          <a class="ind-tag ind-issue" href="https://github.com/kubestellar/console/issues/${p.issue}" target="_blank" title="${issueTip}">${issueLabel}</a>
           <span class="ind-arrow">→</span>
-          <a class="ind-tag ${prCls}" href="https://github.com/${window._primaryRepo || 'kubestellar/console'}/pull/${p.pr}" target="_blank" title="${prTip}">${prIcon} #${p.pr}</a>
+          <a class="ind-tag ${prCls}" href="https://github.com/kubestellar/console/pull/${p.pr}" target="_blank" title="${prTip}">${prIcon} #${p.pr}</a>${costHtml}
+        </div>`;
+        };
+        const renderWip = (ip) => {
+          const title = ip.title ? esc(ip.title.length > 48 ? ip.title.slice(0, 48) + '…' : ip.title) : '';
+          const label = title ? `⏳ #${ip.number} — ${title}` : `⏳ #${ip.number}`;
+          return `<div class="ind-pair">
+          <a class="ind-tag ind-wip" href="https://github.com/kubestellar/console/issues/${ip.number}" target="_blank" title="${ip.title ? esc(ip.title) : ''}">${label}</a>
         </div>`;
         };
         let html = '';
-        if (openPairs.length > 0) html += `<div class="agent-indicators"><span class="ind-label">In progress (${openPairs.length}):</span>${openPairs.map(renderPair).join('')}</div>`;
+        if (inProgress.length > 0) html += `<div class="agent-indicators"><span class="ind-label">Working on (${inProgress.length}):</span>${inProgress.map(renderWip).join('')}</div>`;
+        if (openPairs.length > 0) html += `<div class="agent-indicators"><span class="ind-label">PR open (${openPairs.length}):</span>${openPairs.map(renderPair).join('')}</div>`;
         if (mergedPairs.length > 0) html += `<div class="agent-indicators"><span class="ind-label">Merged today (${mergedPairs.length}):</span>${mergedPairs.map(renderPair).join('')}</div>`;
         if (!html) html = '<div class="agent-indicators"><span class="ind-empty">no active fixes</span></div>';
         return html;
@@ -593,11 +706,11 @@
         const contribs = m.contributors || 0;
         const adopters = m.adopters || 0;
         const acmm = m.acmm || 0;
-        const awOpen = m.outreachOpen || m.awesomeOpen || 0;
-        const awMerged = m.outreachMerged || m.awesomeMerged || 0;
-        const starSpark = sparkSvg(dailyAggregate(window._trendData || [], 'stars'), '#e3b341');
-        const awOpenSpark = sparkSvg(dailyAggregate(window._trendData || [], 'awesomeOpen'), '#58a6ff');
-        const awMergedSpark = sparkSvg(dailyAggregate(window._trendData || [], 'awesomeMerged'), '#3fb950');
+        const orOpen = m.outreachOpen || 0;
+        const orMerged = m.outreachMerged || 0;
+        const starSpark = sparkSvg((window._trendData || []).map(s => s.stars || 0), '#e3b341');
+        const orOpenSpark = sparkSvg((window._trendData || []).map(s => s.outreachOpen || 0), '#58a6ff');
+        const orMergedSpark = sparkSvg((window._trendData || []).map(s => s.outreachMerged || 0), '#3fb950');
         return `<div class="agent-indicators">
           <div class="ind-group"><span class="ind-group-label">GROWTH</span><div class="ind-dots">
             <span class="ind-dot-item"><span class="ind-num">⭐ ${stars}</span><span class="ind-dlabel">stars ${starSpark}</span></span>
@@ -608,14 +721,14 @@
             <span class="ind-dot-item"><span class="ind-num">${adopters}</span><span class="ind-dlabel">adopters</span></span>
             <span class="ind-dot-item"><span class="ind-num">${acmm}</span><span class="ind-dlabel">ACMM badges</span></span>
           </div></div>
-          <div class="ind-group"><span class="ind-group-label">AWESOME LISTS</span><div class="ind-dots">
-            <span class="ind-dot-item"><span class="ind-num">${awOpen}</span><span class="ind-dlabel">open ${awOpenSpark}</span></span>
-            <span class="ind-dot-item"><span class="ind-num">${awMerged}</span><span class="ind-dlabel">merged ${awMergedSpark}</span></span>
+          <div class="ind-group"><span class="ind-group-label">OUTREACH PRs</span><div class="ind-dots">
+            <span class="ind-dot-item"><span class="ind-num">${orOpen}</span><span class="ind-dlabel">open ${orOpenSpark}</span></span>
+            <span class="ind-dot-item"><span class="ind-num">${orMerged}</span><span class="ind-dlabel">merged ${orMergedSpark}</span></span>
           </div></div>
         </div>`;
       }
 
-      if (name === 'feature' || name === 'architect') {
+      if (name === 'architect') {
         const prs = m.prs || 0;
         const closed = m.closed || 0;
         return `<div class="agent-indicators">
@@ -637,6 +750,18 @@
       return m[2] === 'h' ? parseInt(m[1]) * MINUTES_PER_HOUR : parseInt(m[1]);
     }
 
+    function getAgentIssueCount(name) {
+      const m = currentAgentMetrics[name];
+      if (!m) return 0;
+      if (name === 'scanner') {
+        const pairs = m.pairs || [];
+        return pairs.filter(p => p.state === 'merged').length;
+      }
+      if (name === 'outreach') return m.outreachMerged || 0;
+      if (name === 'architect') return m.prs || m.closed || 0;
+      return 0;
+    }
+
     function agentTokenRow(name, cadence) {
       const byAgent = window._tokensByAgent || {};
       const t = byAgent[name];
@@ -648,6 +773,11 @@
       const avg = t.avgPerSession || (t.sessions > 0 ? Math.floor(total / t.sessions) : 0);
       let rows = `<div class="agent-field"><span class="label">tokens (24h)</span><span class="value" style="color:var(--cyan)">${fmtTokens(total)} <span style="color:var(--muted);font-size:0.65rem">(${t.sessions} sess)</span></span></div>`;
       rows += `<div class="agent-field"><span class="label">avg/pass</span><span class="value">${fmtTokens(avg)}</span></div>`;
+      const issueCount = getAgentIssueCount(name);
+      if (issueCount > 0) {
+        const tokensPerIssue = Math.floor(total / issueCount);
+        rows += `<div class="agent-field"><span class="label">avg/issue</span><span class="value" style="color:var(--green)">${fmtTokens(tokensPerIssue)} <span style="color:var(--muted);font-size:0.65rem">(${issueCount} today)</span></span></div>`;
+      }
       const intervalMin = parseCadenceMinutes(cadence);
       if (intervalMin > 0 && avg > 0) {
         const MINUTES_PER_HOUR = 60;
@@ -664,7 +794,7 @@
       supervisor: 'supervisor',
       scanner: 'scanner',
       reviewer: 'reviewer',
-      architect: 'feature',
+      architect: 'architect',
       outreach: 'outreach',
     };
     const TTYD_PORT = 7681;
@@ -685,8 +815,18 @@
       });
       const cards = agents.map(a => {
         const needsLogin = a.needsLogin === true;
-        const cls = needsLogin ? 'needs-login' : (a.state === 'stopped' ? 'stopped' : a.busy);
+        const isPaused = a.paused === true;
+        const isStopped = a.state === 'stopped' && !isPaused;
+        const STALE_MS = 1200000; // 20 minutes
+        const isStale = a.summaryUpdated && !isPaused && a.busy === 'working' && (Date.now() - new Date(a.summaryUpdated).getTime()) > STALE_MS;
+        let statusCls = '';
+        if (a.structuredStatus === 'BLOCKED') statusCls = 'status-blocked';
+        else if (a.structuredStatus === 'NEEDS_CONTEXT') statusCls = 'status-needs-context';
+        else if (isStale) statusCls = 'status-stale';
+        const cls = needsLogin ? 'needs-login' : isPaused ? 'paused' : isStopped ? 'stopped' : `${a.busy} ${statusCls}`.trim();
         const dotCls = a.state === 'stopped' ? 'stopped' : 'running';
+        const canToggle = a.name !== 'supervisor';
+        const toggleBtn = canToggle ? `<button class="btn-toggle ${isPaused ? 'paused' : 'running'}" onclick="toggleAgent('${a.name}', ${isPaused})">${isPaused ? '▶ resume' : '⏸ pause'}</button>` : '';
         // liveSummary is pushed via SSE every 5s — no separate fetch needed
         let summaryEl = '';
         if (a.liveSummary) {
@@ -705,35 +845,35 @@
         const indEl = agentIndicators(a.name);
         return `<div class="agent-card ${cls}">
           <span class="working-indicator"></span>
-          <div class="agent-name"><span class="dot ${dotCls}"></span>${a.name} <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a></div>
-          <div class="agent-field"><span class="label">cli</span><span class="value ${a.cli}">${a.cli}</span></div>
-          <div class="agent-field"><span class="label">model</span><span class="value">${a.model || ''} ${a.govBackend ? modelChip(a.govBackend, a.govModel, a.govReason) : ''}</span></div>
-          <div class="agent-field"><span class="label">interval</span><span class="value">${a.cadence}</span></div>
+          <div class="agent-name"><span class="dot ${dotCls}"></span>${a.name} ${toggleBtn} <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <button class="restart-btn" onclick="restartAgent('${a.name}')" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button></div>
+          <div class="agent-field"><span class="label">cli</span><span class="value">${cliChip(a.cli, a.pinnedBoth || a.pinnedCli, a.name)}${(a.pinnedBoth || a.pinnedCli) ? '' : ` <button class="pin-toggle" onclick="togglePin('${a.name}', 'cli', false)" title="Pin CLI — lock current backend">📌</button>`}</span></div>
+          <div class="agent-field"><span class="label">model</span><span class="value">${modelChip(a.model, a.govReason, a.pinnedBoth || a.pinnedModel, a.name)}${(a.pinnedBoth || a.pinnedModel) ? '' : ` <button class="pin-toggle" onclick="togglePin('${a.name}', 'model', false)" title="Pin model — lock current model">📌</button>`}</span></div>
+          <div class="agent-field"><span class="label">interval</span><span class="value">${isPaused ? 'paused' : a.cadence}</span></div>
           <div class="agent-field"><span class="label">last run</span><span class="value">${a.lastKick || '—'}</span></div>
-          <div class="agent-field"><span class="label">next run</span><span class="value">${a.nextKick || '—'}</span></div>
+          <div class="agent-field"><span class="label">next run</span><span class="value">${isPaused ? 'paused' : (a.nextKick || '—')}</span></div>
           ${agentTokenRow(a.name, a.cadence)}
-          <div class="agent-field"><span class="label">restarts</span><span class="value${(a.restarts || 0) > 5 ? ' restart-high' : (a.restarts || 0) > 0 ? ' restart-warn' : ''}">${a.restarts || 0}<span class="restart-label">24h</span><span class="restart-spark">${restartSparkSvg(a.name)}</span></span></div>
-          <div class="agent-state ${a.busy}">${a.busy}</div>
+          <div class="agent-field"><span class="label">restarts</span><span class="value${(a.restarts || 0) > 5 ? ' restart-high' : (a.restarts || 0) > 0 ? ' restart-warn' : ''}">${a.restarts || 0}<span class="restart-label">24h</span>${(a.restarts || 0) > 0 ? `<button class="restart-reset" onclick="resetRestarts('${a.name}')" title="Reset restart counter">✕</button>` : ''}<span class="restart-spark">${restartSparkSvg(a.name)}</span></span></div>
+          <div class="agent-state ${isPaused ? 'paused' : a.busy}">${isPaused ? 'paused' : a.busy}${(() => {
+            if (a.structuredStatus === 'BLOCKED') return '<span class="status-badge blocked" title="' + esc(a.statusEvidence) + '">blocked</span>';
+            if (a.structuredStatus === 'NEEDS_CONTEXT') return '<span class="status-badge needs-context" title="' + esc(a.statusEvidence) + '">needs context</span>';
+            if (a.structuredStatus === 'DONE_WITH_CONCERNS') return '<span class="status-badge done-concerns" title="' + esc(a.statusEvidence) + '">concerns</span>';
+            if (a.structuredStatus === 'DONE') return '<span class="status-badge done">done</span>';
+            if (isStale) return '<span class="status-badge needs-context">stale</span>';
+            return '';
+          })()}</div>
           ${needsLogin ? '<div class="login-warning">⚠ NOT LOGGED IN — run /login</div>' : ''}
           ${summaryEl}${indEl}
           <div class="agent-actions">
-            <input type="text" class="kick-prompt" id="kick-prompt-${a.name}" placeholder="custom prompt (optional)" />
-            <button class="btn" onclick="kick('${a.name}')">kick</button>
+            <input type="text" class="kick-prompt" id="kick-prompt-${a.name}" placeholder="custom prompt (optional)" onkeydown="if(event.key==='Enter'){kick('${a.name}')}" />
+            <button class="btn" onclick="kick('${a.name}')" title="Send custom prompt to agent">send</button>
+            <button class="btn" onclick="document.getElementById('kick-prompt-${a.name}').value='';kick('${a.name}')">kick</button>
             <select class="btn backend-select" onchange="switchCli('${a.name}', this.value); this.selectedIndex=0">
               <option value="" disabled selected>cli ▾</option>
-              <option value="copilot" ${a.cli === 'copilot' ? 'disabled' : ''}>copilot</option>
-              <option value="claude" ${a.cli === 'claude' ? 'disabled' : ''}>claude</option>
-              <option value="gemini" ${a.cli === 'gemini' ? 'disabled' : ''}>gemini</option>
-              <option value="goose" ${a.cli === 'goose' ? 'disabled' : ''}>goose</option>
+              ${KNOWN_BACKENDS.map(b => `<option value="${b}" ${a.cli === b ? 'disabled' : ''}>${b}</option>`).join('')}
             </select>
             <select class="btn backend-select" onchange="switchModel('${a.name}', this.value); this.selectedIndex=0">
               <option value="" disabled selected>model ▾</option>
-              <option value="claude-opus-4-6">Opus 4.6</option>
-              <option value="claude-sonnet-4-6">Sonnet 4.6</option>
-              <option value="claude-sonnet-4-5">Sonnet 4.5</option>
-              <option value="claude-haiku-4-5">Haiku 4.5</option>
-              <option value="gpt-5.4">GPT-5.4</option>
-              <option value="gpt-5.2">GPT-5.2</option>
+              ${KNOWN_MODELS.map(m => `<option value="${m.value}">${m.label}</option>`).join('')}
             </select>
           </div>
         </div>`;
@@ -776,18 +916,8 @@
     }
 
     function formatFixTime(minutes) {
-      if (!minutes || minutes <= 0) return '--';
-      const MINUTES_PER_HOUR = 60;
-      const MINUTES_PER_DAY = 1440;
-      if (minutes >= MINUTES_PER_DAY) {
-        const days = Math.floor(minutes / MINUTES_PER_DAY);
-        const hrs = Math.floor((minutes % MINUTES_PER_DAY) / MINUTES_PER_HOUR);
-        return `${days}d ${hrs}h`;
-      }
-      const h = Math.floor(minutes / MINUTES_PER_HOUR);
-      const m = minutes % MINUTES_PER_HOUR;
-      if (h === 0) return `${m}m`;
-      return `${h}h ${m}m`;
+      if (!minutes || minutes <= 0) return '—';
+      return `${minutes}m`;
     }
 
     function renderGovernor(gov, cadenceMatrix, data) {
@@ -797,24 +927,13 @@
       const issuesSpark = sparkSvg(getHistorySeries('govIssues'), '#58a6ff');
       const prsSpark = sparkSvg(getHistorySeries('govPrs'), '#bc8cff');
       const totalSpark = sparkSvg(getHistorySeries('govTotal'), '#3fb950');
-      const total = (gov.issues || 0) + (gov.prs || 0);
+      const issueCount = gov.issues || 0;
       const currentMode = gov.mode || 'idle';
       const modes = ['idle', 'quiet', 'busy', 'surge'];
 
-      // Issue-to-merge time metric
-      const itm = data.issueToMerge || {};
-      const itmAvg = itm.avg_minutes || 0;
-      const itmMedian = itm.median_minutes || 0;
-      const itmCount = itm.count || 0;
-      const itmHistory = itm.history || [];
-      const itmSparkData = itmHistory.map(h => h.avg || 0);
-      const FIX_TIME_SPARK_COLOR = '#d29922'; // yellow
-      const itmSpark = sparkSvg(itmSparkData, FIX_TIME_SPARK_COLOR);
-      const itmTitle = itmCount > 0 ? `median: ${formatFixTime(itmMedian)} | p90: ${formatFixTime(itm.p90_minutes)} | fastest: ${formatFixTime(itm.fastest_minutes)} | slowest: ${formatFixTime(itm.slowest_minutes)} | ${itmCount} fixes` : 'no data yet';
-
-      // Gauge bar — thresholds: idle≤2, quiet≤10, busy≤20, surge>20
+      // Gauge bar — thresholds driven by issue count only (PRs don't affect mode)
       const maxQ = 30;
-      const pct = Math.min(total / maxQ * 100, 100);
+      const pct = Math.min(issueCount / maxQ * 100, 100);
       const modeColors = { idle: '#238636', quiet: '#58a6ff', busy: '#d29922', surge: '#f85149' };
       const modeColor = modeColors[gov.mode] || '#8b949e';
 
@@ -822,32 +941,40 @@
       const tlData = window._timelineData || [];
       const tlModes = tlData.map(s => s.mode || 'unknown');
       const ticks = tlModes.map(m => `<div class="tick tick-${m}"></div>`).join('');
-      const firstTime = tlData.length > 0 ? new Date(tlData[0].t).toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true}) : '';
+      const firstTime = tlData.length > 0 ? new Date(tlData[0].t).toLocaleDateString([], {month:'numeric',day:'numeric'}) + ' ' + new Date(tlData[0].t).toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true}) : '';
       const lastTime = tlData.length > 0 ? new Date(tlData[tlData.length-1].t).toLocaleDateString([], {month:'numeric',day:'numeric'}) + ' ' + new Date(tlData[tlData.length-1].t).toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true}) : '';
+
+      const itm = data.issueToMerge || {};
+      const itmAvg = itm.avg_minutes || 0;
+      const itmMedian = itm.median_minutes || 0;
+      const itmCount = itm.count || 0;
+      const FIX_TIME_SPARK_COLOR = '#d2a8ff';
+      const itmHistory = (itm.history || []).map(h => h.median || h.avg);
+      const itmSpark = sparkSvg(itmHistory, FIX_TIME_SPARK_COLOR);
+      const itmTitle = itmCount > 0 ? `MTTR (Mean Time to Resolution) — median: ${formatFixTime(itmMedian)} | avg: ${formatFixTime(itmAvg)} | p90: ${formatFixTime(itm.p90_minutes)} | fastest: ${formatFixTime(itm.fastest_minutes)} | slowest: ${formatFixTime(itm.slowest_minutes)} | ${itmCount} fixes in last 30d` : 'MTTR — no data yet';
 
       el.innerHTML = `
         <div class="gov-title">Governor</div>
         <div class="gov-grid">
           <div class="gov-stat"><div class="label">timer</div><div class="val ${cls}">${gov.active ? '● active' : '⚠ DEAD'}</div></div>
           <div class="gov-stat"><div class="label">mode</div><div class="val" style="color:${modeColor}">${gov.mode}</div></div>
-          <div class="gov-stat"><div class="label">actionable</div><div class="spark-row"><span class="val">${total}</span>${totalSpark}</div></div>
-          <div class="gov-stat"><div class="label">issues</div><div class="spark-row"><span class="val">${gov.issues}</span>${issuesSpark}</div></div>
+          <div class="gov-stat"><div class="label">actionable issues</div><div class="spark-row"><span class="val">${issueCount}</span>${issuesSpark}</div></div>
           <div class="gov-stat"><div class="label">PRs</div><div class="spark-row"><span class="val">${gov.prs}</span>${prsSpark}</div></div>
-          <div class="gov-stat" title="${itmTitle}"><div class="label">avg fix time</div><div class="spark-row"><span class="val" style="color:${FIX_TIME_SPARK_COLOR}">${formatFixTime(itmAvg)}</span>${itmSpark}</div></div>
+          <div class="gov-stat" title="${itmTitle}"><div class="label">MTTR</div><div class="spark-row"><span class="val" style="color:${FIX_TIME_SPARK_COLOR}">${formatFixTime(itmMedian)}</span>${itmSpark}</div></div>
           <div class="gov-stat"><div class="label">next run</div><div class="val">${gov.nextKick || '—'}</div></div>
         </div>
         <div class="temp-gauge">
-          <div class="temp-gauge-label"><span>Queue: ${total}</span><span>max ${maxQ}</span></div>
+          <div class="temp-gauge-label"><span>Issues: ${issueCount}</span><span>max ${maxQ}</span></div>
           <div class="temp-gauge-track">
             <div class="temp-gauge-glow" style="width:100%"></div>
             <div class="temp-gauge-ticks"><span>0</span><span>2</span><span>10</span><span>20</span><span>${maxQ}</span></div>
-            <div class="temp-gauge-needle" style="left:${pct}%" data-val="${total}"></div>
+            <div class="temp-gauge-needle" style="left:${pct}%" data-val="${issueCount}"></div>
           </div>
           <div class="temp-gauge-labels">
-            <span class="tl-idle">idle</span>
-            <span class="tl-quiet">quiet</span>
-            <span class="tl-busy">busy</span>
-            <span class="tl-surge">surge</span>
+            <span class="tl-idle lbl-idle">idle</span>
+            <span class="tl-quiet lbl-quiet">quiet</span>
+            <span class="tl-busy lbl-busy">busy</span>
+            <span class="tl-surge lbl-surge">surge</span>
           </div>
         </div>
         <div class="gov-timeline">
@@ -873,16 +1000,24 @@
         if (!row) return '';
         const agentData = agents.find(a => a.name === aname);
         const isWorking = agentData && agentData.busy === 'working';
+        const agentPaused = agentData && agentData.paused === true;
         const cells = modes.map(m => {
           const val = row[m] || '?';
           const isActive = m === currentMode;
           const isPaused = val === 'paused';
-          const colCls = isActive ? `col-active mode-${m}${isWorking ? ' agent-working' : ''}` : '';
-          const pausedCls = isPaused ? ' paused' : '';
-          return `<td class="${colCls}${pausedCls}">${isPaused ? '—' : val}</td>`;
+          const showPaused = isPaused || agentPaused;
+          const colCls = isActive ? `col-active mode-${m}` : '';
+          const pausedCls = showPaused ? ' paused' : '';
+          const dot = (isActive && isWorking && !agentPaused) ? '<span class="active-dot"></span>' : '';
+          return `<td class="${colCls}${pausedCls}">${dot}${showPaused ? '<span class="pause-badge">paused</span>' : val}</td>`;
         }).join('');
-        const mChip = agentData && agentData.govBackend ? modelChip(agentData.govBackend, agentData.govModel, agentData.govReason) : '';
-        return `<tr><td>${aname}</td>${cells}<td>${mChip}</td></tr>`;
+        const nameDot = isWorking ? '<span class="agent-dot"></span>' : '';
+        const pauseBadge = agentPaused ? '<span class="pause-badge">paused</span>' : '';
+        const cliPinned = agentData && (agentData.pinnedBoth || agentData.pinnedCli);
+        const modelPinned = agentData && (agentData.pinnedBoth || agentData.pinnedModel);
+        const cChip = agentData && agentData.cli ? cliChip(agentData.cli, cliPinned, aname) : '?';
+        const mChip = agentData && agentData.model ? modelChip(agentData.model, agentData.govReason, modelPinned, aname) : '';
+        return `<tr><td>${nameDot}${aname}${pauseBadge}</td>${cells}<td>${cChip}</td><td>${mChip}</td></tr>`;
       }).join('');
       const headers = modes.map(m => {
         const isActive = m === currentMode;
@@ -890,7 +1025,7 @@
         return `<th class="${cls}">${m}${isActive ? ' ◀' : ''}</th>`;
       }).join('');
       return `<table class="gov-matrix">
-        <thead><tr><th></th>${headers}<th>model</th></tr></thead>
+        <thead><tr><th></th>${headers}<th>cli</th><th>model</th></tr></thead>
         <tbody>${rows}</tbody>
       </table>`;
     }
@@ -900,12 +1035,13 @@
       el.innerHTML = repos.map(r => {
         const iSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.issues ?? 0), '#58a6ff');
         const pSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.prs ?? 0), '#bc8cff');
+        const repoUrl = 'https://github.com/' + (r.full || r.name);
         return `
         <div class="repo-card">
-          <div class="repo-name">${r.full || r.name}</div>
+          <div class="repo-name"><a href="${repoUrl}" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">${r.full || r.name}</a></div>
           <div class="repo-stats">
-            <div class="repo-stat"><div class="spark-row"><span class="num">${r.issues >= 0 ? r.issues : '?'}</span>${iSpark}</div><div class="label">issues</div></div>
-            <div class="repo-stat"><div class="spark-row"><span class="num">${r.prs >= 0 ? r.prs : '?'}</span>${pSpark}</div><div class="label">PRs</div></div>
+            <div class="repo-stat"><a href="${repoUrl}/issues" target="_blank" rel="noopener" style="color:inherit;text-decoration:none"><div class="spark-row"><span class="num">${r.issues >= 0 ? r.issues : '?'}</span>${iSpark}</div><div class="label">issues</div></a></div>
+            <div class="repo-stat"><a href="${repoUrl}/pulls" target="_blank" rel="noopener" style="color:inherit;text-decoration:none"><div class="spark-row"><span class="num">${r.prs >= 0 ? r.prs : '?'}</span>${pSpark}</div><div class="label">PRs</div></a></div>
           </div>
         </div>`;
       }).join('');
@@ -921,10 +1057,23 @@
     }
 
     function fmtTokens(n) {
-      if (n >= 1e9) return (n / 1e9).toFixed(1) + 'B';
-      if (n >= 1e6) return (n / 1e6).toFixed(1) + 'M';
-      if (n >= 1e3) return (n / 1e3).toFixed(1) + 'K';
-      return String(n);
+      if (n === 0) return '0';
+      const b = n / 1e9;
+      if (b >= 100) return b.toFixed(0) + 'B';
+      if (b >= 10) return b.toFixed(1) + 'B';
+      if (b >= 1) return b.toFixed(2) + 'B';
+      if (b >= 0.1) return b.toFixed(2) + 'B';
+      if (b >= 0.01) return b.toFixed(3) + 'B';
+      return b.toFixed(3) + 'B';
+    }
+
+    let budgetIgnored = false;
+    fetch('/api/budget-ignore').then(r => r.json()).then(d => { budgetIgnored = d.ignored; }).catch(() => {});
+
+    function toggleBudgetIgnore() {
+      budgetIgnored = !budgetIgnored;
+      fetch('/api/budget-ignore', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ ignored: budgetIgnored }) })
+        .then(r => r.json()).then(d => { budgetIgnored = d.ignored; renderAll(); });
     }
 
     function renderBudgetBar(budget) {
@@ -939,11 +1088,12 @@
       const hoursLeft = budget.HOURS_REMAINING || 0;
       const HOURS_PER_DAY = 24;
       const dailyRate = burnRate * HOURS_PER_DAY;
-      const usedFillCls = pctUsed < PCT_SAFE ? 'safe' : pctUsed < PCT_WARN ? 'warning' : 'danger';
-      const projFillCls = projPct < PCT_SAFE ? 'safe' : projPct < PCT_WARN ? 'warning' : 'danger';
+      const usedFillCls = budgetIgnored ? 'safe' : pctUsed < PCT_SAFE ? 'safe' : pctUsed < PCT_WARN ? 'warning' : 'danger';
 
       let govAction = '';
-      if (projPct > PCT_WARN) {
+      if (budgetIgnored) {
+        govAction = '<span style="color:var(--muted)">Budget enforcement disabled by operator</span>';
+      } else if (projPct > PCT_WARN) {
         govAction = '<span style="color:var(--red)">Governor downgrading models to stay within budget</span>';
       } else if (projPct > PCT_SAFE) {
         govAction = '<span style="color:var(--yellow)">Governor may downgrade non-priority agents if burn increases</span>';
@@ -951,9 +1101,13 @@
         govAction = '<span style="color:var(--green)">Budget healthy — governor using preferred models</span>';
       }
 
+      const ignoreCheck = `<label style="font-size:0.68rem;color:var(--muted);cursor:pointer;margin-left:12px">
+        <input type="checkbox" ${budgetIgnored ? 'checked' : ''} onchange="toggleBudgetIgnore()" style="cursor:pointer;vertical-align:middle"> ignore budget
+      </label>`;
+
       return `<div class="budget-bar">
         <div class="budget-bar-label">
-          <span>Used: ${fmtTokens(used)} / ${fmtTokens(weekly)} (${pctUsed}%)</span>
+          <span>Used: ${fmtTokens(used)} / ${fmtTokens(weekly)} (${pctUsed}%)${ignoreCheck}</span>
           <span>${hoursLeft}h until reset</span>
         </div>
         <div class="budget-bar-track"><div class="budget-bar-fill ${usedFillCls}" style="width:${Math.min(pctUsed, 100)}%"></div></div>
@@ -965,19 +1119,56 @@
       </div>`;
     }
 
-    function modelChip(backend, model, reason) {
+    // ── Centralized backend/model config (mirrors backends.conf) ──────────
+    const KNOWN_BACKENDS = ['claude', 'copilot', 'gemini', 'codex', 'amazonq', 'goose', 'aider'];
+    const FREE_BACKENDS = ['copilot', 'goose'];
+    const KNOWN_MODELS = [
+      { value: 'claude-opus-4-6', label: 'Opus 4.6' },
+      { value: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
+      { value: 'claude-sonnet-4-5', label: 'Sonnet 4.5' },
+      { value: 'claude-haiku-4-5', label: 'Haiku 4.5' },
+      { value: 'gpt-5.4', label: 'GPT-5.4' },
+      { value: 'gpt-5.2', label: 'GPT-5.2' },
+    ];
+
+    function _modelTier(model) {
+      const m = (model || '').toLowerCase();
+      if (m.includes('haiku')) return 'haiku';
+      if (m.includes('opus')) return 'opus';
+      if (m.includes('sonnet')) return 'sonnet';
+      if (m.startsWith('gpt-')) return 'gpt';
+      if (m.startsWith('gemini-')) return 'gemini';
+      return 'unknown';
+    }
+
+    function cliChip(cli, pinned, agent) {
+      if (!cli || cli === '?') return '?';
+      const tier = FREE_BACKENDS.includes(cli) ? 'free' : 'paid';
+      const pin = pinned ? ' \u{1F4CC}' : '';
+      const pinTitle = pinned ? ' (pinned — click to unpin)' : '';
+      const click = pinned && agent ? ` onclick="togglePin('${agent}', 'cli', true)" style="cursor:pointer"` : '';
+      return `<span class="model-chip ${tier}" title="cli: ${cli}${pinTitle}"${click}>${cli}${pin}</span>`;
+    }
+
+    function backendChip(backend) {
       if (!backend || backend === 'unknown') return '';
-      const isFree = backend === 'copilot' || backend === 'goose';
-      let tier = 'sonnet';
-      if (isFree) tier = 'free';
-      else if (model && model.includes('haiku')) tier = 'haiku';
-      else if (model && model.includes('opus')) tier = 'opus';
-      const shortModel = model ? model.replace(/^claude-/, '').replace(/-\d+-\d+$/, m => m.replace(/-/g, '.').slice(0, 4)) : '?';
-      const label = isFree ? `${backend}` : shortModel;
+      const tier = FREE_BACKENDS.includes(backend) ? 'free' : 'paid';
+      return ` <span class="model-chip ${tier}" title="billing: ${backend}">${backend}</span>`;
+    }
+
+    function modelChip(model, reason, pinned, agent) {
+      if (!model || model === '?' || model === 'unknown') return '?';
+      const normalized = model.toLowerCase().replace(/\s+/g, '-');
+      const shortModel = normalized.replace(/^claude-/, '').replace(/-(\d[\d-]*\d)$/, (_, v) => '-' + v.replace(/-/g, '.'));
+      const tier = _modelTier(normalized);
+      const chipCls = tier === 'unknown' ? 'sonnet' : tier;
       const isBudgetOverride = reason && (reason.includes('budget_downgrade') || reason.includes('budget_critical'));
       const overrideIcon = isBudgetOverride ? ' ⬇' : '';
       const overrideTitle = isBudgetOverride ? ` (${reason})` : '';
-      return `<span class="model-chip ${tier}" title="${backend}:${model}${overrideTitle}">${label}${overrideIcon}</span>`;
+      const pin = pinned ? ' \u{1F4CC}' : '';
+      const pinTitle = pinned ? ' (pinned — click to unpin)' : '';
+      const click = pinned && agent ? ` onclick="togglePin('${agent}', 'model', true)" style="cursor:pointer"` : '';
+      return `<span class="model-chip ${chipCls}" title="${model}${overrideTitle}${pinTitle}"${click}>${shortModel}${overrideIcon}${pin}</span>`;
     }
 
     function buildCadenceAdvisor(byAgent) {
@@ -1022,12 +1213,12 @@
       const architect = rows.find(r => r.name === 'architect');
       if (architect) {
         if (architect.isPaused) {
-          tips.push(`<b>architect</b> is paused — no feature work happening. Consider enabling at 1h cadence.`);
+          tips.push(`<b>architect</b> is paused — no architect work happening. Consider enabling at 1h cadence.`);
         } else if (architect.weeklyBurn > 0) {
           const architectPct = Math.round((architect.weeklyBurn / totalWeeklyBurn) * 100);
           if (architectPct < 15 && architect.cadenceMin > 15) {
             const HALVE_CADENCE = 2;
-            tips.push(`<b>architect</b> is only ${architectPct}% of burn. Could increase to ${Math.max(15, Math.floor(architect.cadenceMin / HALVE_CADENCE))}m for more feature work.`);
+            tips.push(`<b>architect</b> is only ${architectPct}% of burn. Could increase to ${Math.max(15, Math.floor(architect.cadenceMin / HALVE_CADENCE))}m for more architect work.`);
           }
         }
       }
@@ -1092,6 +1283,200 @@
       </div>`;
     }
 
+// Intensity gauge: compares recent vs trailing token rate
+// Returns SVG string for a half-circle speedometer
+function computeHourlyBurnRates() {
+  const MIN_POINTS = 6;
+  if (historyData.length < MIN_POINTS) return null;
+
+  // Collect points where tokenTotal actually changed (skip stale repeats)
+  const changePoints = [];
+  let lastVal = -1;
+  for (const s of historyData) {
+    const v = s.tokenTotal || 0;
+    if (v !== lastVal) {
+      changePoints.push({ t: s.t, v });
+      lastVal = v;
+    }
+  }
+  if (changePoints.length < 3) return null;
+
+  // Compute rate between consecutive change points
+  const rawRates = [];
+  for (let i = 1; i < changePoints.length; i++) {
+    const dt = (changePoints[i].t - changePoints[i - 1].t) / 1000;
+    if (dt <= 0) continue;
+    const delta = changePoints[i].v - changePoints[i - 1].v;
+    if (delta <= 0) continue;
+    rawRates.push({ t: changePoints[i].t, rate: (delta / dt) * 3600 });
+  }
+  if (rawRates.length < 3) return null;
+
+  // Cap outliers at p95 to remove collector-reset spikes
+  const sorted = rawRates.map(r => r.rate).sort((a, b) => a - b);
+  const P95_IDX = Math.floor(sorted.length * 0.95);
+  const cap = sorted[Math.min(P95_IDX, sorted.length - 1)] * 1.5;
+  for (const r of rawRates) { if (r.rate > cap) r.rate = cap; }
+
+  // Bucket into 5-minute windows
+  const BUCKET_MS = 300000;
+  const rates = [];
+  let i = 0;
+  while (i < rawRates.length) {
+    const bucketEnd = rawRates[i].t + BUCKET_MS;
+    let sum = 0, count = 0;
+    const bt = rawRates[i].t;
+    while (i < rawRates.length && rawRates[i].t < bucketEnd) {
+      sum += rawRates[i].rate;
+      count++;
+      i++;
+    }
+    if (count > 0) rates.push({ t: bt, rate: sum / count });
+  }
+  return rates.length >= 3 ? rates : null;
+}
+
+function intensityGauge() {
+  const rates = computeHourlyBurnRates();
+  if (!rates) return '';
+
+  const rateVals = rates.map(r => r.rate);
+  const now = rateVals[rateVals.length - 1];
+  const peak = Math.max(...rateVals);
+  const low = Math.min(...rateVals);
+  const avg = rateVals.reduce((a, b) => a + b, 0) / rateVals.length;
+
+  let color;
+  if (peak === 0) color = '#8b949e';
+  else if (now / peak > 0.8) color = '#f85149';
+  else if (now / peak > 0.5) color = '#d29922';
+  else if (now / peak > 0.2) color = '#3fb950';
+  else color = '#58a6ff';
+
+  let label;
+  if (peak === 0) label = 'idle';
+  else if (now / peak > 0.8) label = 'surging';
+  else if (now / peak > 0.5) label = 'ramping';
+  else if (now / peak > 0.2) label = 'steady';
+  else label = 'cooling';
+
+  const W = 240, H = 50, PAD = 2;
+  const range = peak - low || 1;
+  const pts = rateVals.map((v, i) => {
+    const x = PAD + (i / (rateVals.length - 1)) * (W - PAD * 2);
+    const y = PAD + (1 - (v - low) / range) * (H - PAD * 2);
+    return [x.toFixed(1), y.toFixed(1)];
+  });
+
+  const yAvg = (PAD + (1 - (avg - low) / range) * (H - PAD * 2)).toFixed(1);
+  const yPeak = (PAD + (1 - (peak - low) / range) * (H - PAD * 2)).toFixed(1);
+  const yLow = (PAD + (1 - (low - low) / range) * (H - PAD * 2)).toFixed(1);
+  const lastPt = pts[pts.length - 1];
+
+  const polyline = pts.map(p => p.join(',')).join(' ');
+
+  const tStart = new Date(rates[0].t).toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true}).toLowerCase();
+  const tEnd = new Date(rates[rates.length - 1].t).toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true}).toLowerCase();
+
+  const dotLeftPct = (parseFloat(lastPt[0]) / W * 100).toFixed(1);
+  const dotTopPct = (parseFloat(lastPt[1]) / H * 100).toFixed(1);
+
+  return `<div class="burn-chart-wrap">
+    <div class="burn-chart-title">burn rate (tok/hr)</div>
+    <div style="position:relative">
+      <svg viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" style="width:100%;height:${H}px;display:block">
+        <line x1="${PAD}" y1="${yPeak}" x2="${W - PAD}" y2="${yPeak}" stroke="#f85149" stroke-width="0.5" stroke-dasharray="3,3" opacity="0.5" vector-effect="non-scaling-stroke"/>
+        <line x1="${PAD}" y1="${yAvg}" x2="${W - PAD}" y2="${yAvg}" stroke="#d29922" stroke-width="0.5" stroke-dasharray="3,3" opacity="0.5" vector-effect="non-scaling-stroke"/>
+        <line x1="${PAD}" y1="${yLow}" x2="${W - PAD}" y2="${yLow}" stroke="#58a6ff" stroke-width="0.5" stroke-dasharray="3,3" opacity="0.5" vector-effect="non-scaling-stroke"/>
+        <polyline points="${polyline}" fill="none" stroke="${color}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke"/>
+      </svg>
+      <div style="position:absolute;left:${dotLeftPct}%;top:${dotTopPct}%;width:6px;height:6px;border-radius:50%;background:${color};border:1px solid #0d1117;transform:translate(-50%,-50%)"></div>
+    </div>
+    <div style="display:flex;justify-content:space-between;font-size:0.6rem;color:var(--muted);margin-top:1px;font-family:monospace">
+      <span>${tStart}</span><span>${tEnd}</span>
+    </div>
+    <div class="burn-context">
+      <div class="bc-stat"><span class="bc-val" style="color:#58a6ff">${fmtTokens(low)}</span><span class="bc-label">low/hr</span></div>
+      <div class="bc-stat"><span class="bc-val" style="color:#d29922">${fmtTokens(avg)}</span><span class="bc-label">avg/hr</span></div>
+      <div class="bc-stat"><span class="bc-val" style="color:#f85149">${fmtTokens(peak)}</span><span class="bc-label">peak/hr</span></div>
+      <div class="bc-stat"><span class="bc-val" style="color:${color}">${fmtTokens(now)}</span><span class="bc-label">current/hr</span></div>
+    </div>
+    <div style="color:${color};font-size:11px;font-family:monospace;margin-top:2px">${label}</div>
+  </div>`;
+}
+
+function burnAreaChart() {
+  const rates = computeHourlyBurnRates();
+  if (!rates || rates.length < 4) return '';
+
+  const rateVals = rates.map(r => r.rate);
+  const BUCKET_COUNT = 8;
+  const bucketSize = Math.max(1, Math.floor(rateVals.length / BUCKET_COUNT));
+  const buckets = [];
+  for (let i = 0; i < rateVals.length; i += bucketSize) {
+    const slice = rateVals.slice(i, i + bucketSize).sort((a, b) => a - b);
+    if (slice.length === 0) continue;
+    const p25Idx = Math.floor(slice.length * 0.25);
+    const p75Idx = Math.min(Math.floor(slice.length * 0.75), slice.length - 1);
+    const median = slice[Math.floor(slice.length * 0.5)];
+    buckets.push({ p25: slice[p25Idx], p75: slice[p75Idx], median, t: rates[Math.min(i, rates.length - 1)].t });
+  }
+
+  if (buckets.length < 2) return '';
+
+  const allVals = rateVals;
+  const peak = Math.max(...allVals);
+  const low = Math.min(...allVals);
+  const range = peak - low || 1;
+
+  const W = 400, H = 60, PAD = 2;
+  const xStep = (W - PAD * 2) / (buckets.length - 1);
+
+  const bandTop = buckets.map((b, i) => {
+    const x = PAD + i * xStep;
+    const y = PAD + (1 - (b.p75 - low) / range) * (H - PAD * 2);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+  const bandBot = buckets.map((b, i) => {
+    const x = PAD + i * xStep;
+    const y = PAD + (1 - (b.p25 - low) / range) * (H - PAD * 2);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  }).reverse();
+
+  const medianPts = buckets.map((b, i) => {
+    const x = PAD + i * xStep;
+    const y = PAD + (1 - (b.median - low) / range) * (H - PAD * 2);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+
+  const nowPts = rateVals.map((v, i) => {
+    const x = PAD + (i / (rateVals.length - 1)) * (W - PAD * 2);
+    const y = PAD + (1 - (v - low) / range) * (H - PAD * 2);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  });
+  const lastNow = nowPts[nowPts.length - 1];
+  const nowVal = rateVals[rateVals.length - 1];
+  const aboveBand = nowVal > buckets[buckets.length - 1].p75;
+  const belowBand = nowVal < buckets[buckets.length - 1].p25;
+  const dotColor = aboveBand ? '#f85149' : belowBand ? '#58a6ff' : '#3fb950';
+
+  const areaDotLeftPct = (parseFloat(lastNow.split(',')[0]) / W * 100).toFixed(1);
+  const areaDotTopPct = (parseFloat(lastNow.split(',')[1]) / H * 100).toFixed(1);
+
+  return `<div class="burn-area-wrap">
+    <div class="burn-area-title" style="text-align:left">burn rate distribution · <span style="color:rgba(57,210,192,0.6)">p25–p75 band</span> · <span style="color:#39d2c0">actual</span></div>
+    <div style="position:relative">
+      <svg viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" style="width:100%;height:${H}px;display:block">
+        <polygon points="${bandTop.join(' ')} ${bandBot.join(' ')}" fill="rgba(57,210,192,0.12)" stroke="none"/>
+        <polyline points="${medianPts.join(' ')}" fill="none" stroke="rgba(57,210,192,0.3)" stroke-width="1" stroke-dasharray="2,2" vector-effect="non-scaling-stroke"/>
+        <polyline points="${nowPts.join(' ')}" fill="none" stroke="#39d2c0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke"/>
+      </svg>
+      <div style="position:absolute;left:${areaDotLeftPct}%;top:${areaDotTopPct}%;width:6px;height:6px;border-radius:50%;background:${dotColor};border:1px solid #0d1117;transform:translate(-50%,-50%)"></div>
+    </div>
+  </div>`;
+}
+
+
     function renderTokens(tokens) {
       const el = document.getElementById('token-panel');
 
@@ -1100,7 +1485,8 @@
         return;
       }
 
-      const sessionsOpen = el.querySelector('.token-sessions')?.open || false;
+      const sessionsEl = el.querySelector('.token-sessions');
+      const sessionsOpen = sessionsEl ? sessionsEl.open : true;
 
       const t = tokens.totals;
       const totalTokens = t.input + t.output + t.cacheRead;
@@ -1119,24 +1505,53 @@
         </div>`;
       }).join('');
 
-      const sessionRows = sessions.map(s => {
-        const age = s.lastActive ? new Date(s.lastActive).toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true}) : '';
-        const agentName = s.agent && s.agent !== 'unknown' ? s.agent : '';
-        const agentCls = agentName ? `a-${agentName}` : 'a-unknown';
-        return `<div class="token-session-row">
-          <span class="sid">${esc(s.id)}</span>
-          <span class="sagent ${agentCls}">${agentName || '—'}</span>
-          <span class="smodel">${esc(s.model)}</span>
-          <span class="stokens">${fmtTokens(s.total)}</span>
-          <span class="smsgs">${s.messages} msgs</span>
-          <span class="sproj">${esc(s.project)} · ${age}</span>
+      const HIVE_AGENTS = new Set(['scanner', 'reviewer', 'architect', 'outreach', 'supervisor']);
+      const agentSessions = sessions.filter(s => HIVE_AGENTS.has(s.agent));
+      const grouped = {};
+      for (const s of agentSessions) {
+        if (!grouped[s.agent]) grouped[s.agent] = [];
+        grouped[s.agent].push(s);
+      }
+      const AGENT_ORDER = ['supervisor', 'scanner', 'reviewer', 'architect', 'outreach'];
+      const sortedGroups = AGENT_ORDER.filter(a => grouped[a]).map(a => [a, grouped[a]]);
+      const sessionRows = sortedGroups.map(([agent, grp]) => {
+        const agentCls = `a-${agent}`;
+        const rows = grp.map(s => {
+          const age = s.lastActive ? new Date(s.lastActive).toLocaleTimeString([], {hour:'numeric',minute:'2-digit',hour12:true}) : '';
+          const act = s.activity || [];
+          const MINI_W = 60, MINI_H = 14;
+          let miniSpark = '';
+          if (act.length >= 2) {
+            const mx = Math.max(...act, 1);
+            const pts = act.map((v, i) => `${(i / (act.length - 1)) * MINI_W},${MINI_H - (v / mx) * (MINI_H - 2) - 1}`).join(' ');
+            const aClrs = { scanner: '#58a6ff', reviewer: '#3fb950', architect: '#bc8cff', outreach: '#39d2c0', supervisor: '#d29922' };
+            const clr = aClrs[s.agent] || '#8b949e';
+            miniSpark = `<span class="sparkline" style="margin-left:4px"><svg width="${MINI_W}" height="${MINI_H}" viewBox="0 0 ${MINI_W} ${MINI_H}"><polyline points="${pts}" fill="none" stroke="${clr}" stroke-width="1.2" opacity="0.7"/></svg></span>`;
+          }
+          return `<div class="token-session-row" style="padding-left:12px">
+            <span class="sid">${esc(s.id)}</span>
+            <span class="smodel">${esc(s.model)}</span>
+            <span class="stokens" ${s.estimated ? 'title="estimated from avg tokens/msg"' : ''}>${s.total > 0 ? (s.estimated ? '~' : '') + fmtTokens(s.total) : '—'}</span>
+            <span class="smsgs">${s.messages} msgs</span>${miniSpark}
+            <span class="sproj">${age}</span>
+          </div>`;
+        }).join('');
+        const totalMsgs = grp.reduce((a, s) => a + s.messages, 0);
+        const totalTokens = grp.reduce((a, s) => a + s.total, 0);
+        const hasEstimates = grp.some(s => s.estimated && s.total > 0);
+        return `<div style="margin-bottom:6px">
+          <div style="display:flex;align-items:center;gap:8px;margin-bottom:2px">
+            <span class="sagent ${agentCls}" style="font-weight:700">${agent}</span>
+            <span style="color:var(--muted);font-size:0.65rem">${grp.length} session${grp.length > 1 ? 's' : ''} · ${totalMsgs} msgs${totalTokens > 0 ? ' · ' + (hasEstimates ? '~' : '') + fmtTokens(totalTokens) : ''}</span>
+          </div>
+          ${rows}
         </div>`;
       }).join('');
 
       const advisorHtml = buildCadenceAdvisor(tokens.byAgent || {});
 
       const totalSpark = sparkSvg(getHistorySeries('tokenTotal'), '#39d2c0');
-      const agentNames = ['scanner', 'reviewer', 'architect', 'outreach', 'supervisor'];
+      const agentNames = ['supervisor', 'scanner', 'reviewer', 'architect', 'outreach'];
       const agentColors = { scanner: '#58a6ff', reviewer: '#3fb950', architect: '#bc8cff', outreach: '#39d2c0', supervisor: '#d29922' };
       const agentSparkRows = agentNames.map(name => {
         const ba = tokens.byAgent || {};
@@ -1148,6 +1563,10 @@
 
       el.innerHTML = `<div class="token-panel">
         <div class="token-title">Token Usage <span class="lookback">${tokens.lookbackHours || 24}h window · ${t.sessions} sessions</span></div>
+        <div style="display:flex;gap:16px;margin-bottom:24px;padding-bottom:16px;border-bottom:1px solid var(--border)">
+          <div style="flex:1;min-width:0">${intensityGauge()}</div>
+          <div style="flex:1;min-width:0">${burnAreaChart()}</div>
+        </div>
         <div class="token-grid">
           <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--cyan)">${fmtTokens(totalTokens)}</span>${totalSpark}</div><div class="tlabel">total tokens</div></div>
           <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--blue)">${fmtTokens(t.input)}</span>${sparkSvg(getHistorySeries('tokenInput'), '#58a6ff')}</div><div class="tlabel">input</div></div>
@@ -1159,42 +1578,83 @@
         ${agentSparkRows ? `<div class="token-grid" style="margin-top:4px">${agentSparkRows}</div>` : ''}
         ${advisorHtml}
         <div class="token-models">${modelChips}</div>
-        ${sessions.length > 0 ? `<details class="token-sessions"${sessionsOpen ? ' open' : ''}><summary>Active Sessions (${sessions.length})</summary>${sessionRows}</details>` : ''}
+        ${agentSessions.length > 0 ? `<details class="token-sessions"${sessionsOpen ? ' open' : ''}><summary>Active Sessions (${agentSessions.length})</summary>${sessionRows}</details>` : ''}
       </div>`;
     }
+
+    // GitHub auth health — sticky banner when 401
+    const GH_AUTH_POLL_MS = 30000;
+    async function checkGhAuth() {
+      try {
+        const res = await fetch('/api/gh-auth');
+        const data = await res.json();
+        const el = document.getElementById('gh-auth-alert');
+        if (data.ok) {
+          el.className = 'gh-auth-alert';
+        } else {
+          el.className = 'gh-auth-alert active';
+        }
+      } catch (_) { /* dashboard unreachable — different problem */ }
+    }
+    checkGhAuth();
+    setInterval(checkGhAuth, GH_AUTH_POLL_MS);
 
     function renderGhRateLimits(ghRateLimits) {
       const el = document.getElementById('gh-rate-alert');
       const alerts = (ghRateLimits && ghRateLimits.alerts) || [];
-      // Filter out expired alerts client-side
+      const pullbacks = (ghRateLimits && ghRateLimits.pullbacks) || [];
       const now = Math.floor(Date.now() / 1000);
-      const GH_RATE_DEFAULT_TTL = 900;
+      const GH_RATE_DEFAULT_TTL = 3600;
+      const SECONDS_PER_MINUTE = 60;
+      const MINUTES_PER_HOUR = 60;
       const active = alerts.filter(a => {
+        if (a.api_reset_epoch && a.api_reset_epoch > 0) return now < a.api_reset_epoch;
         const ttl = a.ttl_seconds || GH_RATE_DEFAULT_TTL;
         return now - (a.detected_epoch || 0) < ttl;
       });
-      if (active.length === 0) {
+      const activePullbacks = pullbacks.filter(p => now < (p.expiry_epoch || 0));
+      if (active.length === 0 && activePullbacks.length === 0) {
         el.className = 'gh-rate-alert';
         el.innerHTML = '';
         return;
       }
       el.className = 'gh-rate-alert active';
-      const SECONDS_PER_MINUTE = 60;
-      const MINUTES_PER_HOUR = 60;
       const items = active.map(a => {
         const ageSec = now - (a.detected_epoch || now);
         let ageStr;
         if (ageSec < SECONDS_PER_MINUTE) ageStr = ageSec + 's ago';
         else if (ageSec < SECONDS_PER_MINUTE * MINUTES_PER_HOUR) ageStr = Math.floor(ageSec / SECONDS_PER_MINUTE) + 'm ago';
         else ageStr = Math.floor(ageSec / (SECONDS_PER_MINUTE * MINUTES_PER_HOUR)) + 'h ago';
+        const cliTag = a.cli ? ` <span style="opacity:0.6;font-size:0.65rem">(${esc(a.cli)})</span>` : '';
         return `<div class="gh-rate-alert-item">
-          <span class="gh-rate-alert-agent">${esc(a.agent)}</span>
+          <span class="gh-rate-alert-agent">${esc(a.agent)}${cliTag}</span>
           <span class="gh-rate-alert-age">${ageStr}</span>
           <span class="gh-rate-alert-msg">${esc(a.message || 'GitHub API rate limited')}</span>
         </div>`;
       }).join('');
-      el.innerHTML = `<div class="gh-rate-alert-title">GitHub API Rate Limit (${active.length} agent${active.length > 1 ? 's' : ''})</div>${items}`;
+      const pullbackHtml = activePullbacks.map(p => {
+        const remainSec = (p.expiry_epoch || 0) - now;
+        const remainMin = Math.max(0, Math.ceil(remainSec / SECONDS_PER_MINUTE));
+        const paused = (p.paused_agents || []).join(', ') || 'none';
+        let resetStr = '';
+        if (p.api_reset_epoch && p.api_reset_epoch > now) {
+          const resetDate = new Date(p.api_reset_epoch * 1000);
+          resetStr = ` · API quota resets ${resetDate.toLocaleTimeString([], {hour:'numeric',minute:'2-digit'})}`;
+        } else if (p.api_reset_epoch && p.api_reset_epoch <= now) {
+          resetStr = ' · API quota restored';
+        }
+        return `<div style="font-size:0.72rem;color:#d29922;margin-top:6px;padding-top:6px;border-top:1px solid rgba(210,153,34,0.25)">
+          ⏸ Pullback (${esc(p.cli || '?')}): paused <strong>${esc(paused)}</strong> — resumes in ${remainMin}m${resetStr}
+        </div>`;
+      }).join('');
+      el.innerHTML = `<div class="gh-rate-alert-title">GitHub API Rate Limit (${active.length} agent${active.length > 1 ? 's' : ''})</div>${items}${pullbackHtml}`;
     }
+
+    // Guard: skip agent re-render while a dropdown is focused/open
+    let _dropdownOpen = false;
+    document.addEventListener('focusin', (e) => { if (e.target.matches('select.backend-select')) _dropdownOpen = true; });
+    document.addEventListener('focusout', (e) => { if (e.target.matches('select.backend-select')) _dropdownOpen = false; });
+    document.addEventListener('change', (e) => { if (e.target.matches('select.backend-select')) _dropdownOpen = false; });
 
     function render(data) {
       if (!data || data.error) return;
@@ -1206,12 +1666,15 @@
       window._lastAgents = data.agents || [];
       window._lastBudget = data.budget || {};
       renderGhRateLimits(data.ghRateLimits || {});
-      renderAgents(data.agents || []);
-      renderGovernor(data.governor || {}, data.cadenceMatrix || [], data);
+      if (!_dropdownOpen) {
+        applyPinOverrides(data.agents || []);
+        renderAgents(data.agents || []);
+        renderGovernor(data.governor || {}, data.cadenceMatrix || [], data);
+      }
       renderTokens(data.tokens || {});
       renderRepos(data.repos || []);
       renderBeads(data.beads || {});
-      requestAnimationFrame(() => requestAnimationFrame(() => window.scrollTo(0, scrollY)));
+      requestAnimationFrame(() => window.scrollTo(0, scrollY));
     }
 
     function esc(s) {
@@ -1220,31 +1683,122 @@
       return d.innerHTML;
     }
 
+    const TOAST_DURATION_MS = 3000;
+    const TOAST_PROGRESS_MAX_MS = 60000;
+    function showToast(msg, type = 'info', persistent = false) {
+      const container = document.getElementById('toast-container');
+      const el = document.createElement('div');
+      el.className = `toast ${type}`;
+      el.textContent = msg;
+      container.appendChild(el);
+      if (persistent) {
+        const spinner = document.createElement('span');
+        spinner.className = 'toast-spinner';
+        el.prepend(spinner);
+        el._persistent = true;
+        setTimeout(() => { if (el.parentNode) dismissToast(el); }, TOAST_PROGRESS_MAX_MS);
+        return el;
+      }
+      setTimeout(() => dismissToast(el), TOAST_DURATION_MS);
+      return el;
+    }
+    function dismissToast(el, newMsg, newType) {
+      if (!el || !el.parentNode) return;
+      if (newMsg) {
+        el.textContent = newMsg;
+        el.className = `toast ${newType || 'success'}`;
+        setTimeout(() => { el.style.animation = 'toast-out 0.3s ease-in forwards'; setTimeout(() => el.remove(), 300); }, TOAST_DURATION_MS);
+      } else {
+        el.style.animation = 'toast-out 0.3s ease-in forwards';
+        setTimeout(() => el.remove(), 300);
+      }
+    }
+
     async function kick(agent) {
       const input = document.getElementById(`kick-prompt-${agent}`);
       const prompt = input ? input.value.trim() : '';
+
       const opts = { method: 'POST', headers: { 'Content-Type': 'application/json' } };
       if (prompt) opts.body = JSON.stringify({ prompt });
       const res = await fetch(`/api/kick/${agent}`, opts);
       const data = await res.json();
-      if (!data.ok) { alert('Kick failed: ' + (data.error || 'unknown')); return; }
+      if (!data.ok) { showToast('Kick failed: ' + (data.error || 'unknown'), 'error'); return; }
+      showToast(`Kicked ${agent}`, 'success');
       if (input) input.value = '';
+    }
+
+    async function toggleAgent(agent, currentlyPaused) {
+      const action = currentlyPaused ? 'resume' : 'pause';
+      const label = currentlyPaused ? 'Resuming' : 'Pausing';
+      const toast = showToast(`${label} ${agent}...`, 'info', true);
+      const res = await fetch(`/api/${action}/${agent}`, { method: 'POST' });
+      const data = await res.json();
+      if (!data.ok) { dismissToast(toast, `${action} failed: ${data.error || 'unknown'}`, 'error'); return; }
+      dismissToast(toast, `${agent} ${action}d`, 'success');
+    }
+
+    async function restartAgent(agent) {
+      if (!confirm(`Restart ${agent}? This will kill the current session and start fresh.`)) return;
+      const toast = showToast(`Restarting ${agent}...`, 'info', true);
+      const res = await fetch(`/api/restart/${agent}`, { method: 'POST' });
+      const data = await res.json();
+      if (!data.ok) { dismissToast(toast, `Restart failed: ${data.error || 'unknown'}`, 'error'); return; }
+      dismissToast(toast, `${agent} restarted — supervisor will respawn`, 'success');
+    }
+
+    async function resetRestarts(agent) {
+      const toast = showToast(`Resetting ${agent} restart counter...`, 'info', true);
+      const res = await fetch(`/api/reset-restarts/${agent}`, { method: 'POST' });
+      const data = await res.json();
+      if (!data.ok) { dismissToast(toast, `Reset failed: ${data.error || 'unknown'}`, 'error'); return; }
+      dismissToast(toast, `${agent} restart counter reset`, 'success');
     }
 
     async function switchCli(agent, backend) {
       if (!backend) return;
-      if (!confirm(`Switch ${agent} to ${backend}?`)) return;
+      const toast = showToast(`Switching ${agent} → ${backend}...`, 'info', true);
       const res = await fetch(`/api/switch/${agent}/${backend}`, { method: 'POST' });
       const data = await res.json();
-      if (!data.ok) alert('Switch failed: ' + (data.error || 'unknown'));
+      if (!data.ok) { dismissToast(toast, `Switch failed: ${data.error || 'unknown'}`, 'error'); return; }
+      dismissToast(toast, `${agent} CLI → ${backend}`, 'success');
     }
 
     async function switchModel(agent, model) {
       if (!model) return;
-      if (!confirm(`Switch ${agent} model to ${model}?`)) return;
+      const toast = showToast(`Switching ${agent} model → ${model}...`, 'info', true);
       const res = await fetch(`/api/model/${agent}/${encodeURIComponent(model)}`, { method: 'POST' });
       const data = await res.json();
-      if (!data.ok) alert('Model switch failed: ' + (data.error || 'unknown'));
+      if (!data.ok) { dismissToast(toast, `Model switch failed: ${data.error || 'unknown'}`, 'error'); return; }
+      dismissToast(toast, `${agent} model → ${model}`, 'success');
+    }
+
+    const PIN_OVERRIDE_TTL_MS = 8000;
+    const _pinOverrides = {};
+    async function togglePin(agent, dimension, currentlyPinned) {
+      const action = currentlyPinned ? 'unpin' : 'pin';
+      const res = await fetch(`/api/${action}/${agent}/${dimension}`, { method: 'POST' });
+      const data = await res.json();
+      if (!data.ok) { showToast(`${action} failed: ` + (data.error || 'unknown'), 'error'); return; }
+      showToast(`${agent} ${dimension} ${action}ned`, 'success');
+      const nowPinned = !currentlyPinned;
+      const key = `${agent}:${dimension}`;
+      _pinOverrides[key] = { value: nowPinned, expires: Date.now() + PIN_OVERRIDE_TTL_MS };
+      const agents = window._lastAgents || [];
+      applyPinOverrides(agents);
+      renderAgents(agents);
+    }
+    function applyPinOverrides(agents) {
+      const now = Date.now();
+      for (const key of Object.keys(_pinOverrides)) {
+        if (_pinOverrides[key].expires < now) { delete _pinOverrides[key]; continue; }
+        const [agent, dimension] = key.split(':');
+        const a = (agents || []).find(x => x.name === agent);
+        if (!a) continue;
+        const v = _pinOverrides[key].value;
+        if (dimension === 'cli') { a.pinnedCli = v; if (!v && a.pinnedBoth) { a.pinnedBoth = false; a.pinnedModel = true; } }
+        else if (dimension === 'model') { a.pinnedModel = v; if (!v && a.pinnedBoth) { a.pinnedBoth = false; a.pinnedCli = true; } }
+        else { a.pinnedBoth = v; a.pinnedCli = v; a.pinnedModel = v; }
+      }
     }
 
     // Git version indicator
@@ -1254,7 +1808,7 @@
         const res = await fetch('/api/version');
         const v = await res.json();
         const el = document.getElementById('git-version');
-        let html = `<a href="https://github.com/${window._hiveRepo || 'kubestellar/hive'}/commit/${v.hash}" target="_blank" style="color:inherit;text-decoration:none" title="${v.hash}">${v.short}</a>`;
+        let html = `<a href="https://github.com/kubestellar/hive/commit/${v.hash}" target="_blank" style="color:inherit;text-decoration:none" title="${v.hash}">${v.short}</a>`;
         if (v.dirty) html += ' <span class="git-dirty">*</span>';
         if (v.behind > 0) html += ` <span class="git-behind">${v.behind} behind</span>`;
         el.innerHTML = html;
@@ -1325,11 +1879,11 @@
     }
 
     // Set project name and repo from API
-    fetch('/api/config').then(r => r.json()).then(cfg => {
-      const el = document.getElementById('project-name');
-      if (el && cfg.projectName) {
-        el.textContent = cfg.projectName + ' Hive';
-        document.title = '🐝 ' + cfg.projectName + ' Hive Dashboard';
+    fetch("/api/config").then(r => r.json()).then(cfg => {
+      const el = document.getElementById("project-name");
+      if (el && cfg.primaryRepo) {
+        el.textContent = "for " + cfg.primaryRepo;
+        document.title = "🐝 Hive Dashboard for " + cfg.primaryRepo;
       }
       if (cfg.primaryRepo) window._primaryRepo = cfg.primaryRepo;
     }).catch(() => {});

--- a/dashboard/publish-snapshot.sh
+++ b/dashboard/publish-snapshot.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Build a dashboard snapshot and push it to the docs repo.
+# Designed to run as a cron job on the hive server.
+#
+# Usage: ./publish-snapshot.sh
+# Env vars:
+#   HIVE_DASHBOARD_URL  — dashboard URL (default: http://localhost:3001)
+#   DOCS_REPO_DIR       — local clone of kubestellar/docs (default: /tmp/kubestellar-docs-snapshot)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DASHBOARD_URL="${HIVE_DASHBOARD_URL:-http://localhost:3001}"
+DOCS_REPO="${DOCS_REPO_DIR:-/tmp/kubestellar-docs-snapshot}"
+DOCS_REMOTE="https://github.com/kubestellar/docs.git"
+OUTPUT_DIR="${DOCS_REPO}/public/live/hive"
+BRANCH="main"
+
+# Ensure docs repo clone exists
+if [ ! -d "$DOCS_REPO/.git" ]; then
+  git clone --depth 1 --single-branch -b "$BRANCH" "$DOCS_REMOTE" "$DOCS_REPO"
+fi
+
+cd "$DOCS_REPO"
+git fetch origin "$BRANCH"
+git reset --hard "origin/$BRANCH"
+
+# Build snapshot
+mkdir -p "$OUTPUT_DIR"
+node "${SCRIPT_DIR}/build-snapshot.mjs" "$DASHBOARD_URL" "${OUTPUT_DIR}/index.html"
+
+# Check if anything changed
+if git diff --quiet -- public/live/hive/; then
+  echo "No changes to snapshot — skipping commit."
+  exit 0
+fi
+
+# Commit and push
+git add public/live/hive/index.html
+git commit -s -m "chore: update hive dashboard snapshot $(date -u '+%Y-%m-%d %H:%M UTC')"
+git push origin "$BRANCH"
+echo "Snapshot published."


### PR DESCRIPTION
## Summary
- Adds `build-snapshot.sh` / `build-snapshot.mjs` — fetches live data from dashboard API and produces a self-contained static HTML file
- Adds `publish-snapshot.sh` — builds snapshot and pushes to kubestellar/docs for hosting at kubestellar.io/live/hive
- Syncs `index.html` with the deployed version (MTTR, burn rate distribution, ignore budget, title format)

The snapshot renders identically to the live dashboard but with SSE disabled and interactive controls (kick, switch CLI/model) hidden. A "Read-only snapshot" banner shows the capture timestamp.

## Test plan
- [ ] `bash build-snapshot.sh http://localhost:3001 /tmp/test.html` produces a valid HTML file
- [ ] Opening the file in a browser shows the full dashboard with all sections
- [ ] No JavaScript errors in console
- [ ] Interactive buttons are hidden