### PR TITLE
fix: guard grep in buffer-clear loop against set -e crash

### DIFF
--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -742,7 +742,7 @@ for _fa in scanner reviewer supervisor architect outreach; do
   _is_agent_paused "$_fa" && continue
   tmux has-session -t "$_fa" 2>/dev/null || continue
   _pane_text=$(tmux capture-pane -t "$_fa" -p 2>/dev/null || true)
-  _prompt_line=$(echo "$_pane_text" | grep "❯" | tail -1)
+  _prompt_line=$(echo "$_pane_text" | grep "❯" | tail -1 || true)
   _after=$(echo "$_prompt_line" | sed 's/.*❯[[:space:]]*//')
   if [ -n "$_after" ] && [ ${#_after} -gt 2 ]; then
     log "CLEAR ${_fa} — discarding ${#_after} chars of stale input (C-c + C-u)"


### PR DESCRIPTION
## Summary
- Guard `grep "❯"` in the buffer-clear loop (line 745 of `kick-governor.sh`) with `|| true` to prevent `set -euo pipefail` from killing the entire governor script when no prompt character is found in a tmux pane.

## Root cause
When an agent's tmux pane has no `❯` prompt character (e.g., during active output or after a session state change), `grep` returns exit code 1. Under `set -euo pipefail`, this terminates the governor script silently — no error log, no GOVERNOR DONE marker. All agent kicks stop until the next 5-minute systemd timer fires... which crashes again at the same point.

## Impact
Governor kick loop was silently dying after the buffer-clear phase, preventing all agents from receiving kicks. The scanner accumulated 28+ unprocessed issues over ~2 hours while the governor appeared healthy (model assignment phase still logged normally).

## Test plan
- [ ] Deploy to remote, verify governor log shows `KICK`/`SKIP` lines and `GOVERNOR DONE` after buffer-clear phase
- [ ] Confirm scanner receives kicks and processes the accumulated issue queue