### PR TITLE
fix: show 'running' instead of bogus midnight when governor is active

### DIFF
--- a/bin/hive.sh
+++ b/bin/hive.sh
@@ -857,9 +857,14 @@ cmd_status_json() {
   gov_active=$(systemctl is-active kick-governor.timer 2>/dev/null || echo "inactive")
   gov_qi=$(  cat /var/run/kick-governor/queue_issues 2>/dev/null || echo "0")
   gov_qp=$(  cat /var/run/kick-governor/queue_prs    2>/dev/null || echo "0")
-  gov_next=$(systemctl list-timers kick-governor.timer --no-pager 2>/dev/null \
-       | awk 'NR==2{print $1,$2,$3,$4}' \
-       | xargs -I{} bash -c "TZ=\"$HIVE_TZ\" date -d \"{}\" \"+%-m/%-d %-I:%M %p %Z\"" 2>/dev/null || echo "")
+  local _timer_next
+  _timer_next=$(systemctl list-timers kick-governor.timer --no-pager 2>/dev/null \
+       | awk 'NR==2{print $1,$2,$3,$4}')
+  if [[ "$_timer_next" == -* || -z "$_timer_next" ]]; then
+    gov_next="running"
+  else
+    gov_next=$(bash -c "TZ=\"$HIVE_TZ\" date -d \"$_timer_next\" \"+%-m/%-d %-I:%M %p %Z\"" 2>/dev/null || echo "")
+  fi
 
   # Repos — read from centralized api-collector cache
   local GITHUB_CACHE="${HIVE_METRICS_DIR:-/var/run/hive-metrics}/github-cache.json"


### PR DESCRIPTION
## Summary
- When `kick-governor.service` is actively executing, `systemctl list-timers` shows `-` for NEXT
- The awk/date pipeline parsed this as a bare date, producing "12:00 AM" on the dashboard
- Now shows "running" instead, so the operator knows the governor is mid-cycle

## Test plan
- [ ] Start governor manually, check dashboard shows "running" for next run
- [ ] After governor completes, verify normal next-fire time reappears