### PR TITLE
fix: compute correct next-run time when governor is active

### DIFF
--- a/bin/hive.sh
+++ b/bin/hive.sh
@@ -861,7 +861,12 @@ cmd_status_json() {
   _timer_next=$(systemctl list-timers kick-governor.timer --no-pager 2>/dev/null \
        | awk 'NR==2{print $1,$2,$3,$4}')
   if [[ "$_timer_next" == -* || -z "$_timer_next" ]]; then
-    gov_next="running"
+    # Service is running — compute next 5-minute boundary from OnCalendar=*:00/5
+    local _gov_interval=300
+    local _now_epoch _next_epoch
+    _now_epoch=$(date +%s)
+    _next_epoch=$(( _now_epoch - (_now_epoch % _gov_interval) + _gov_interval ))
+    gov_next=$(TZ="$HIVE_TZ" date -d "@$_next_epoch" "+%-m/%-d %-I:%M %p %Z" 2>/dev/null || echo "")
   else
     gov_next=$(bash -c "TZ=\"$HIVE_TZ\" date -d \"$_timer_next\" \"+%-m/%-d %-I:%M %p %Z\"" 2>/dev/null || echo "")
   fi


### PR DESCRIPTION
## Summary
- When governor service is running, `systemctl list-timers` shows `-` for NEXT
- PR #237 showed "running" as a placeholder — this replaces it with the actual next 5-minute boundary computed from `OnCalendar=*:00/5`
- Dashboard always shows the correct next fire time now

## Test plan
- [ ] While governor is mid-cycle, verify dashboard shows the correct next 5-min boundary (not "running", not "12:00 AM")