### PR TITLE
fix: next-run text display + deploy sync for hive CLI

### DIFF
--- a/bin/hive-deploy.sh
+++ b/bin/hive-deploy.sh
@@ -59,6 +59,15 @@ for src in "$HIVE_REPO"/bin/*.sh; do
   fi
 done
 
+# hive.sh is installed as /usr/local/bin/hive (no .sh extension)
+HIVE_CLI="$HIVE_REPO/bin/hive.sh"
+HIVE_INSTALLED="$INSTALL_DIR/hive"
+if [ -f "$HIVE_CLI" ] && ! cmp -s "$HIVE_CLI" "$HIVE_INSTALLED"; then
+  sudo cp "$HIVE_CLI" "$HIVE_INSTALLED"
+  sudo chmod +x "$HIVE_INSTALLED"
+  SYNCED="$SYNCED hive.sh→hive"
+fi
+
 # gh-wrapper.sh is installed as /usr/local/bin/gh (ahead of /usr/bin/gh in PATH)
 GH_WRAPPER="$HIVE_REPO/bin/gh-wrapper.sh"
 GH_INSTALLED="$INSTALL_DIR/gh"

--- a/bin/hive.sh
+++ b/bin/hive.sh
@@ -692,10 +692,17 @@ cmd_status() {
   else
     gov_label="${RED}⚠ DEAD${RST}"
   fi
-  local next
-  next=$(systemctl list-timers kick-governor.timer --no-pager 2>/dev/null \
-       | awk 'NR==2{print $1,$2,$3,$4}' \
-       | xargs -I{} bash -c "TZ=\"$HIVE_TZ\" date -d \"{}\" \"+%-I:%M %p %Z\"" 2>/dev/null || echo "—")
+  local next _txt_timer
+  _txt_timer=$(systemctl list-timers kick-governor.timer --no-pager 2>/dev/null \
+       | awk 'NR==2{print $1,$2,$3,$4}')
+  if [[ "$_txt_timer" == -* || -z "$_txt_timer" ]]; then
+    local _gi=300 _tn _te
+    _tn=$(date +%s)
+    _te=$(( _tn - (_tn % _gi) + _gi ))
+    next=$(TZ="$HIVE_TZ" date -d "@$_te" "+%-I:%M %p %Z" 2>/dev/null || echo "—")
+  else
+    next=$(bash -c "TZ=\"$HIVE_TZ\" date -d \"$_txt_timer\" \"+%-I:%M %p %Z\"" 2>/dev/null || echo "—")
+  fi
   echo -e "  Governor:  ${BLD}$mode${RST} [${gov_label}]  actionable: ${queue}  |  next kick: ${CYN}$next${RST}"
 
   # Per-repo issue + PR counts with trend markers


### PR DESCRIPTION
## Summary
- Fix the text-display path (`hive status`) which had the same `list-timers` bug — showed "12:00 AM" when governor service is active
- Add `hive.sh → /usr/local/bin/hive` sync to `hive-deploy.sh` — the deploy script only synced `*.sh` → `*.sh`, but the dashboard calls `/usr/local/bin/hive` (no extension), so it was stale since Apr 29

## Root cause of dashboard still showing 12:00 AM
PR #238 fixed `bin/hive.sh` but `hive-deploy.sh` never copied it to `/usr/local/bin/hive`. The dashboard server calls `/usr/local/bin/hive status --json` (line 292 of server.js), which was the Apr 29 version without the fix.

## Test plan
- [ ] After deploy, verify `/usr/local/bin/hive` matches `/tmp/hive/bin/hive.sh`
- [ ] While governor is mid-cycle, confirm dashboard shows correct next 5-min boundary