### PR TITLE
feat: systemd timer for dashboard snapshot publishing

### DIFF
--- a/bin/hive-deploy.sh
+++ b/bin/hive-deploy.sh
@@ -165,6 +165,12 @@ if echo "$SYNCED" | grep -q '\.service\|\.timer'; then
   sudo systemctl daemon-reload 2>/dev/null || true
 fi
 
+# Ensure snapshot timer is enabled
+if [ -f /etc/systemd/system/hive-snapshot.timer ] && ! systemctl is-enabled --quiet hive-snapshot.timer 2>/dev/null; then
+  sudo systemctl enable --now hive-snapshot.timer 2>/dev/null && \
+    SYNCED="$SYNCED hive-snapshot.timer(enabled)" || true
+fi
+
 # Ensure per-agent watchdog services are enabled and running.
 # Each agent gets its own hive@<name>.service backed by supervisor.sh,
 # which monitors the tmux session and restarts if it dies.

--- a/systemd/hive-snapshot.service
+++ b/systemd/hive-snapshot.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Build and publish hive dashboard snapshot to kubestellar.io/live/hive
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=dev
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+Environment=HIVE_DASHBOARD_URL=http://localhost:3001
+Environment=DOCS_REPO_DIR=/tmp/kubestellar-docs-snapshot
+ExecStart=/tmp/hive/dashboard/publish-snapshot.sh
+StandardOutput=journal
+StandardError=journal

--- a/systemd/hive-snapshot.timer
+++ b/systemd/hive-snapshot.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Publish hive dashboard snapshot every 15 minutes
+
+[Timer]
+OnCalendar=*:00/15
+AccuracySec=30s
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- Adds `hive-snapshot.service` + `hive-snapshot.timer` to run `publish-snapshot.sh` every 15 minutes
- Deploy script auto-enables the timer on first sync
- Keeps https://kubestellar.io/live/hive current — was last updated 7+ hours ago because no recurring mechanism existed

## Files
- `systemd/hive-snapshot.service` — oneshot service calling `publish-snapshot.sh`
- `systemd/hive-snapshot.timer` — fires every 15 min (`OnCalendar=*:00/15`)
- `bin/hive-deploy.sh` — enables timer if not already active

## Test plan
- [ ] After deploy, verify `systemctl list-timers hive-snapshot.timer` shows active timer
- [ ] Wait for first fire, verify new commit on `kubestellar/docs` updating `public/live/hive/index.html`
- [ ] Verify https://kubestellar.io/live/hive shows fresh data