### PR TITLE
fix: flock enumerate-actionable to prevent race condition

### DIFF
--- a/bin/enumerate-actionable.sh
+++ b/bin/enumerate-actionable.sh
@@ -16,6 +16,13 @@ set -euo pipefail
 OUTPUT_FILE="/var/run/hive-metrics/actionable.json"
 TMP_FILE="${OUTPUT_FILE}.tmp"
 LOG="/var/log/kick-agents.log"
+LOCK_FILE="/var/run/hive-metrics/enumerate-actionable.lock"
+
+exec 200>"$LOCK_FILE"
+if ! flock -n 200; then
+  echo "[$(date -Is)] ENUM SKIP — another instance is running" >> "$LOG"
+  exit 0
+fi
 
 # Read repos from hive-project.yaml (single source of truth)
 PROJECT_YAML="${HIVE_PROJECT_YAML:-/etc/hive/hive-project.yaml}"


### PR DESCRIPTION
## Summary
- Two concurrent `kick-agents.sh` invocations (scanner + supervisor kicked close together) both call `enumerate-actionable.sh`
- The second run can overwrite `actionable.json` with partial data, dropping non-console repos from the actionable count
- Dashboard showed `actionable issues: 16` (console only) instead of ~19 (console + docs + console-kb)
- Fix: `flock` ensures only one instance runs at a time

## Test plan
- [ ] After deploy, actionable count includes issues from all 5 repos
- [ ] Concurrent kicks don't produce partial counts