### PR TITLE
fix: actionable count drops non-console repos

### DIFF
--- a/bin/enumerate-actionable.sh
+++ b/bin/enumerate-actionable.sh
@@ -143,7 +143,7 @@ while pos < len(raw):
     try:
         obj, end = decoder.raw_decode(raw, pos)
         arrays.extend(obj if isinstance(obj, list) else [obj])
-        pos += end
+        pos = end
     except json.JSONDecodeError:
         break
 
@@ -186,7 +186,7 @@ while pos < len(raw):
     try:
         obj, end = decoder.raw_decode(raw, pos)
         arrays.extend(obj if isinstance(obj, list) else [obj])
-        pos += end
+        pos = end
     except json.JSONDecodeError:
         break
 


### PR DESCRIPTION
## Summary
- Root cause found: `json.JSONDecoder.raw_decode(raw, pos)` returns `(obj, end)` where `end` is an **absolute** index, not relative
- Code had `pos += end` (double-counting) instead of `pos = end`
- After parsing console's large JSON array, `pos` overshoots past the remaining repos (docs, console-kb, etc.)
- Same bug in both the issue filter and PR filter parsers
- This is why actionable showed 10-16 (console only) instead of ~19 (all repos)

## Test plan
- [ ] After deploy, actionable count includes docs and console-kb issues
- [ ] `ENUM DONE` log line shows correct total across all 5 repos