### PR TITLE
fix: gh wrapper always injects App token (15k/hr rate limit)

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -7,11 +7,20 @@ set -euo pipefail
 
 REAL_GH="/usr/bin/gh"
 
-# Inject GitHub App token for agent gh calls when available.
+# Inject GitHub App token for agent gh calls (15k/hr vs PAT's 5k/hr).
 # HIVE_GITHUB_TOKEN is set by hive-config.sh (sourced via agent-launch.sh).
-# GH_TOKEN is NOT set in the agent env (Copilot CLI uses it for its own auth),
-# so we set it here per-call so gh CLI uses the App's 15k/hr rate limit pool.
-if [[ -n "${HIVE_GITHUB_TOKEN:-}" && -z "${GH_TOKEN:-}" ]]; then
+# Always override GH_TOKEN here — agent-launch.sh unsets it to protect Copilot
+# CLI auth, but gh CLI still falls back to ~/.config/gh/hosts.yml PAT (5k limit).
+# This per-call injection ensures gh uses the App token without polluting the
+# agent's persistent env (Copilot CLI never calls this wrapper).
+#
+# Fallback: if HIVE_GITHUB_TOKEN is unset (agent launched without hive-config.sh),
+# read from the token cache file written by gh-app-token.sh.
+GH_APP_TOKEN_CACHE="/var/run/hive-metrics/gh-app-token.cache"
+if [[ -z "${HIVE_GITHUB_TOKEN:-}" && -f "$GH_APP_TOKEN_CACHE" ]]; then
+  HIVE_GITHUB_TOKEN=$(cat "$GH_APP_TOKEN_CACHE")
+fi
+if [[ -n "${HIVE_GITHUB_TOKEN:-}" ]]; then
   export GH_TOKEN="$HIVE_GITHUB_TOKEN"
 fi
 


### PR DESCRIPTION
## Summary
- gh wrapper at `/usr/local/bin/gh` was checking `if -z GH_TOKEN` before injecting the App token, but GH_TOKEN was always empty (agent-launch.sh unsets it). Real `gh` CLI fell back to `~/.config/gh/hosts.yml` PAT (5k/hr limit).
- This caused rate limit exhaustion during parallel scanner agent dispatch, stalling MTTR.
- Fix: always set GH_TOKEN from HIVE_GITHUB_TOKEN, plus fallback to reading cached app token from `/var/run/hive-metrics/gh-app-token.cache`.

## Impact
- Agents go from 5,000 req/hr (shared PAT) to 15,000 req/hr (App installation token)
- Eliminates the rate-limit wall that was blocking parallel fix-agent dispatch

## Test plan
- [ ] After auto-deploy, verify: `source /tmp/hive/bin/hive-config.sh && /usr/local/bin/gh api rate_limit --jq '.resources.core.limit'` returns 15000
- [ ] Scanner parallel dispatch no longer hits 429 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)