### PR TITLE
fix: gh auth health check compatible with App tokens

### DIFF
--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -123,13 +123,14 @@ const GH_AUTH_CHECK_MS = 60000;
 let ghAuthOk = true;
 let ghAuthLastChecked = null;
 function checkGhAuth() {
-  execFile('bash', ['-c', 'unset GITHUB_TOKEN && gh api user --jq .login 2>&1'], { timeout: 15000 }, (err, stdout, stderr) => {
+  execFile('bash', ['-c', 'gh api rate_limit --jq .rate.limit 2>&1'], { timeout: 15000 }, (err, stdout, stderr) => {
     const output = (stdout || '') + (stderr || '');
     const was = ghAuthOk;
-    ghAuthOk = !err && !output.includes('401') && !output.includes('auth') && stdout.trim().length > 0;
+    const limit = parseInt(stdout.trim(), 10);
+    ghAuthOk = !err && limit > 0;
     ghAuthLastChecked = new Date().toISOString();
     if (was && !ghAuthOk) console.error('gh auth DOWN:', output.trim());
-    if (!was && ghAuthOk) console.log('gh auth recovered');
+    if (!was && ghAuthOk) console.log('gh auth recovered (limit=' + limit + ')');
   });
 }
 checkGhAuth();


### PR DESCRIPTION
## Summary
- Health check used `gh api user` which returns 403 for GitHub App installation tokens (not a user endpoint)
- Switched to `gh api rate_limit --jq .rate.limit` which works for both PATs and App tokens
- Removed `unset GITHUB_TOKEN` — check now uses the same auth path as agents (App token via gh wrapper)
- Fixes the false-positive red "GitHub CLI authentication failed (401)" banner

## Test plan
- [ ] Banner disappears within 60s of deploy
- [ ] `gh api rate_limit` returns valid limit on dev box