### PR TITLE
fix: config dialog reads CLI pin from all env var names

### DIFF
--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1151,8 +1151,8 @@ app.get('/api/config/agent/:name', (req, res) => {
 
     const general = {
       launchCmd: agentEnv.AGENT_LAUNCH_CMD || '',
-      cliPinned: agentEnv.AGENT_CLI_PINNED === 'true',
-      cliPinValue: agentEnv.AGENT_CLI_PIN_VALUE || deriveCli(agentEnv.AGENT_LAUNCH_CMD || ''),
+      cliPinned: agentEnv.AGENT_CLI_PINNED === 'true' || agentEnv.AGENT_PIN_CLI === 'true',
+      cliPinValue: agentEnv.AGENT_CLI_PIN_VALUE || agentEnv.AGENT_CLI || deriveCli(agentEnv.AGENT_LAUNCH_CMD || ''),
       staleTimeout: parseInt(agentEnv.AGENT_STALE_TIMEOUT_SEC || '1200', 10),
       restartStrategy: agentEnv.AGENT_RESTART_STRATEGY || 'immediate',
     };


### PR DESCRIPTION
## Summary
- Config API endpoint (`GET /api/config/agent/:name`) only checked `AGENT_CLI_PINNED` for pin state, but some agents use `AGENT_PIN_CLI` instead
- For CLI value, only checked `AGENT_CLI_PIN_VALUE` but agents use `AGENT_CLI` — fell back to `deriveCli()` which parses the launch command (fragile)
- The SSE data path (line 656/714) already checked both variants; the config dialog was inconsistent
- Fixes outreach/supervisor showing `cliPinned: false` and incorrect CLI values in the config dialog

## Test plan
- [ ] Open config dialog for outreach — should show CLI Pinned = ON, CLI Pin Value = copilot
- [ ] Open config dialog for architect — should show CLI Pin Value = claude
- [ ] Compare config dialog values with `cat /etc/hive/<agent>.env` on server