### PR TITLE
fix: config dialog cadences, model, and prompt extraction

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2101,7 +2101,7 @@ function burnAreaChart() {
     // ── Configuration Dialog ──────────────────────────────────────────
     let _configState = { type: null, agent: null, tab: null, data: {}, dirty: {} };
 
-    const AGENT_CONFIG_TABS = ['General', 'Cadences', 'Models', 'Pipeline', 'Hooks', 'Restrictions', 'Prompts'];
+    const AGENT_CONFIG_TABS = ['General', 'Cadences', 'Pipeline', 'Hooks', 'Restrictions', 'Prompts'];
     const GOVERNOR_CONFIG_TABS = ['Agents', 'Thresholds', 'Labels', 'Budget', 'Notifications', 'Health'];
     const PIPELINE_STAGES = ['resolve-beads', 'track-prs', 'stale-check', 'repo-scan', 'coverage-gate', 'prompt-compose', 'budget-check', 'api-collect', 'final-compose'];
     const RESTART_STRATEGIES = ['immediate', 'backoff', 'none'];
@@ -2166,7 +2166,6 @@ function burnAreaChart() {
       switch (tab) {
         case 'General': return renderAgentGeneral(d.general || {});
         case 'Cadences': return renderAgentCadences(d.cadences || {});
-        case 'Models': return renderAgentModels(d.models || {});
         case 'Pipeline': return renderAgentPipeline(d.pipeline || {});
         case 'Hooks': return renderAgentHooks(d.hooks || {});
         case 'Restrictions': return renderAgentRestrictions(d.restrictions || []);
@@ -2216,6 +2215,13 @@ function burnAreaChart() {
               ${RESTART_STRATEGIES.map(s => `<option value="${s}" ${g.restartStrategy === s ? 'selected' : ''}>${s}</option>`).join('')}
             </select>
           </div>
+        </div>
+        <div class="config-field">
+          <label>Model</label>
+          <select id="cfg-model" onchange="markDirty('general','model',this.value)">
+            <option value="">(from launch command)</option>
+            ${KNOWN_MODELS.map(m => `<option value="${m.value}" ${g.model === m.value ? 'selected' : ''}>${m.label}</option>`).join('')}
+          </select>
         </div>`;
     }
 
@@ -2227,20 +2233,6 @@ function burnAreaChart() {
           <div class="config-field"><label>Busy</label><input type="number" value="${c.busy || 0}" onchange="markDirty('cadences','busy',this.value)"></div>
           <div class="config-field"><label>Quiet</label><input type="number" value="${c.quiet || 0}" onchange="markDirty('cadences','quiet',this.value)"></div>
           <div class="config-field"><label>Idle</label><input type="number" value="${c.idle || 0}" onchange="markDirty('cadences','idle',this.value)"></div>
-        </div>`;
-    }
-
-    function renderAgentModels(m) {
-      const opts = (sel) => KNOWN_MODELS.map(mod =>
-        `<option value="${mod.value}" ${sel === mod.value ? 'selected' : ''}>${mod.label}</option>`
-      ).join('');
-      return `
-        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">Model assigned to this agent per governor mode.</p>
-        <div class="config-field-row4">
-          <div class="config-field"><label>Surge</label><select onchange="markDirty('models','surge',this.value)">${opts(m.surge)}</select></div>
-          <div class="config-field"><label>Busy</label><select onchange="markDirty('models','busy',this.value)">${opts(m.busy)}</select></div>
-          <div class="config-field"><label>Quiet</label><select onchange="markDirty('models','quiet',this.value)">${opts(m.quiet)}</select></div>
-          <div class="config-field"><label>Idle</label><select onchange="markDirty('models','idle',this.value)">${opts(m.idle)}</select></div>
         </div>`;
     }
 

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1149,19 +1149,22 @@ app.get('/api/config/agent/:name', (req, res) => {
     const govEnv = parseEnvFile(GOVERNOR_ENV_PATH);
     const upper = name.toUpperCase();
 
+    const launchCmd = agentEnv.AGENT_LAUNCH_CMD || '';
+    const modelMatch = launchCmd.match(/--model\s+(\S+)/);
     const general = {
-      launchCmd: agentEnv.AGENT_LAUNCH_CMD || '',
+      launchCmd,
       cliPinned: agentEnv.AGENT_CLI_PINNED === 'true' || agentEnv.AGENT_PIN_CLI === 'true',
-      cliPinValue: agentEnv.AGENT_CLI_PIN_VALUE || agentEnv.AGENT_CLI || deriveCli(agentEnv.AGENT_LAUNCH_CMD || ''),
-      staleTimeout: parseInt(agentEnv.AGENT_STALE_TIMEOUT_SEC || '1200', 10),
+      cliPinValue: agentEnv.AGENT_CLI_PIN_VALUE || agentEnv.AGENT_CLI || deriveCli(launchCmd),
+      staleTimeout: parseInt(agentEnv.AGENT_STALE_TIMEOUT_SEC || agentEnv.AGENT_STALE_MAX_SEC || '1200', 10),
       restartStrategy: agentEnv.AGENT_RESTART_STRATEGY || 'immediate',
+      model: modelMatch ? modelMatch[1] : '',
     };
 
     const cadences = {
-      surge: parseInt(govEnv[`CADENCE_${upper}_SURGE_SEC`] || '0', 10),
-      busy: parseInt(govEnv[`CADENCE_${upper}_BUSY_SEC`] || '0', 10),
-      quiet: parseInt(govEnv[`CADENCE_${upper}_QUIET_SEC`] || '0', 10),
-      idle: parseInt(govEnv[`CADENCE_${upper}_IDLE_SEC`] || '0', 10),
+      surge: parseInt(govEnv[`CADENCE_${upper}_SURGE_SEC`] || String((CADENCE_MATRIX[name] || {}).surge || 0), 10),
+      busy: parseInt(govEnv[`CADENCE_${upper}_BUSY_SEC`] || String((CADENCE_MATRIX[name] || {}).busy || 0), 10),
+      quiet: parseInt(govEnv[`CADENCE_${upper}_QUIET_SEC`] || String((CADENCE_MATRIX[name] || {}).quiet || 0), 10),
+      idle: parseInt(govEnv[`CADENCE_${upper}_IDLE_SEC`] || String((CADENCE_MATRIX[name] || {}).idle || 0), 10),
     };
 
     const models = {
@@ -1187,8 +1190,24 @@ app.get('/api/config/agent/:name', (req, res) => {
     let prompt = '';
     try {
       const kickScript = fs.readFileSync(path.join(HIVE_REPO_DIR, 'bin', 'kick-agents.sh'), 'utf8');
-      const agentSection = kickScript.match(new RegExp(`${name}\\)([\\s\\S]*?);;`, 'i'));
-      if (agentSection) prompt = agentSection[1].trim().slice(0, 2000);
+      const msgVar = `${upper}_MSG=`;
+      const msgIdx = kickScript.indexOf(msgVar);
+      if (msgIdx !== -1) {
+        const afterEq = kickScript.indexOf('"', msgIdx);
+        if (afterEq !== -1) {
+          let depth = 0;
+          let end = afterEq + 1;
+          while (end < kickScript.length) {
+            if (kickScript[end] === '\\') { end += 2; continue; }
+            if (kickScript[end] === '"' && depth === 0) break;
+            if (kickScript[end] === '$' && kickScript[end + 1] === '{') depth++;
+            if (kickScript[end] === '}' && depth > 0) depth--;
+            end++;
+          }
+          const raw = kickScript.slice(afterEq + 1, end);
+          prompt = raw.replace(/\$\{[^}]+\}/g, '(…)').slice(0, 4000);
+        }
+      }
     } catch (_) {}
 
     res.json({ general, cadences, models, pipeline, hooks, restrictions, prompt });
@@ -1201,12 +1220,19 @@ app.put('/api/config/agent/:name/general', (req, res) => {
   const { name } = req.params;
   const envFile = `${ENV_DIR}/${name}.env`;
   try {
-    const { launchCmd, cliPinned, cliPinValue, staleTimeout, restartStrategy } = req.body;
+    const { launchCmd, cliPinned, cliPinValue, staleTimeout, restartStrategy, model } = req.body;
     if (launchCmd !== undefined) writeEnvVar(envFile, 'AGENT_LAUNCH_CMD', launchCmd);
     if (cliPinned !== undefined) writeEnvVar(envFile, 'AGENT_CLI_PINNED', String(cliPinned));
     if (cliPinValue !== undefined) writeEnvVar(envFile, 'AGENT_CLI_PIN_VALUE', cliPinValue);
     if (staleTimeout !== undefined) writeEnvVar(envFile, 'AGENT_STALE_TIMEOUT_SEC', String(staleTimeout));
     if (restartStrategy !== undefined) writeEnvVar(envFile, 'AGENT_RESTART_STRATEGY', restartStrategy);
+    if (model !== undefined) {
+      const currentCmd = parseEnvFile(envFile).AGENT_LAUNCH_CMD || '';
+      const updatedCmd = currentCmd.includes('--model')
+        ? currentCmd.replace(/--model\s+\S+/, `--model ${model}`)
+        : `${currentCmd} --model ${model}`;
+      writeEnvVar(envFile, 'AGENT_LAUNCH_CMD', updatedCmd.trim());
+    }
     res.json({ ok: true });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -1290,8 +1316,27 @@ app.get('/api/config/agent/:name/prompt', (req, res) => {
   const { name } = req.params;
   try {
     const kickScript = fs.readFileSync(path.join(HIVE_REPO_DIR, 'bin', 'kick-agents.sh'), 'utf8');
-    const agentSection = kickScript.match(new RegExp(`${name}\\)([\\s\\S]*?);;`, 'i'));
-    res.json({ prompt: agentSection ? agentSection[1].trim() : '' });
+    const upper = name.toUpperCase();
+    const msgVar = `${upper}_MSG=`;
+    const msgIdx = kickScript.indexOf(msgVar);
+    let prompt = '';
+    if (msgIdx !== -1) {
+      const afterEq = kickScript.indexOf('"', msgIdx);
+      if (afterEq !== -1) {
+        let depth = 0;
+        let end = afterEq + 1;
+        while (end < kickScript.length) {
+          if (kickScript[end] === '\\') { end += 2; continue; }
+          if (kickScript[end] === '"' && depth === 0) break;
+          if (kickScript[end] === '$' && kickScript[end + 1] === '{') depth++;
+          if (kickScript[end] === '}' && depth > 0) depth--;
+          end++;
+        }
+        const raw = kickScript.slice(afterEq + 1, end);
+        prompt = raw.replace(/\$\{[^}]+\}/g, '(…)').slice(0, 4000);
+      }
+    }
+    res.json({ prompt });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }


### PR DESCRIPTION
## Summary
- **Cadences**: Fall back to `CADENCE_MATRIX` defaults instead of showing all zeros when `governor.env` doesn't have per-agent per-mode overrides
- **Models tab removed**: Single Model dropdown on General tab instead (we don't switch models per mode)
- **Prompt extraction fixed**: Parses `SCANNER_MSG=` variable content instead of matching first `scanner)...;;` case (was showing `systemctl` commands instead of the actual kick prompt)
- **Stale timeout**: Also reads `AGENT_STALE_MAX_SEC` as fallback (used by scanner/reviewer)
- **Model save**: Writing model via General tab updates `--model` flag in `AGENT_LAUNCH_CMD`

## Test plan
- [ ] Open scanner config → Cadences tab shows 900/900/900/900 (not 0/0/0/0)
- [ ] Open supervisor config → Cadences shows 300/300/300/300 (from governor.env overrides)
- [ ] No Models tab visible in agent config
- [ ] General tab has Model dropdown with current model pre-selected
- [ ] Prompts tab shows actual kick prompt text with variable placeholders as (…)
- [ ] Change model → save → verify AGENT_LAUNCH_CMD updated in env file