### PR TITLE
fix: show clear message instead of (…) placeholders in prompt tab

### DIFF
--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1195,27 +1195,7 @@ app.get('/api/config/agent/:name', (req, res) => {
       const promptFile = path.join(METRICS_DIR, `last_prompt_${name}`);
       prompt = fs.readFileSync(promptFile, 'utf8');
     } catch (_) {
-      try {
-        const kickScript = fs.readFileSync(path.join(HIVE_REPO_DIR, 'bin', 'kick-agents.sh'), 'utf8');
-        const msgVar = `${upper}_MSG=`;
-        const msgIdx = kickScript.indexOf(msgVar);
-        if (msgIdx !== -1) {
-          const afterEq = kickScript.indexOf('"', msgIdx);
-          if (afterEq !== -1) {
-            let depth = 0;
-            let end = afterEq + 1;
-            while (end < kickScript.length) {
-              if (kickScript[end] === '\\') { end += 2; continue; }
-              if (kickScript[end] === '"' && depth === 0) break;
-              if (kickScript[end] === '$' && kickScript[end + 1] === '{') depth++;
-              if (kickScript[end] === '}' && depth > 0) depth--;
-              end++;
-            }
-            const raw = kickScript.slice(afterEq + 1, end);
-            prompt = raw.replace(/\$\{[^}]+\}/g, '(…)');
-          }
-        }
-      } catch (_) {}
+      prompt = `(awaiting next kick — the full expanded prompt will appear here after the governor kicks ${name})`;
     }
 
     res.json({ general, cadences, models, pipeline, hooks, restrictions, prompt });


### PR DESCRIPTION
## Summary
- When no expanded prompt file exists yet (agent hasn't been kicked since the fix deployed), show a clear "awaiting next kick" message instead of the template with `(…)` placeholders
- Removes the template parser fallback that was producing confusing output

## Test plan
- [ ] Open config dialog for a paused agent → should show "awaiting next kick" message
- [ ] Open config dialog for scanner after next kick → should show full expanded prompt