### PR TITLE
fix: show standalone merged PRs as pills without issue references

### DIFF
--- a/dashboard/agent-metrics.sh
+++ b/dashboard/agent-metrics.sh
@@ -56,6 +56,9 @@ if command -v $GH &>/dev/null; then
     ($p.body | match("(?i)(fixes|closes|resolves) #([0-9]+)"; "g") // null) as $m |
     if $m then { issue: ($m.captures[1].string | tonumber), pr: $p.pr, prTitle: $p.title, state: $p.state, created: ($p.created // null), merged: ($p.merged // null) } else empty end
   ]' 2>/dev/null || echo "[]")
+  # ── Standalone merged PRs: merged recently but no Fixes/Closes reference ──
+  paired_pr_nums=$(echo "$scanner_pairs_json" | jq -r '.[].pr' 2>/dev/null | sort -un)
+  scanner_standalone_merged=$(echo "$merged_prs" | jq --argjson paired "$(echo "$paired_pr_nums" | jq -Rn '[inputs | select(length>0) | tonumber]')" '[.[] | select(([.pr] - $paired) | length > 0) | {pr: .pr, prTitle: .title, state: .state, merged: .merged}]' 2>/dev/null || echo "[]")
   # ── In-progress issues: mentioned in scanner tmux but no PR yet ──
   scanner_tmux=$(tmux capture-pane -t scanner -p -S -200 2>/dev/null || echo "")
   dispatched_issues=$(echo "$scanner_tmux" | grep -oP '#\K\d{4,5}' | sort -un)
@@ -134,7 +137,7 @@ if command -v $GH &>/dev/null; then
 fi
 
 # Build agent JSON with live summaries and model
-scanner_json=$(jq -n --arg doing "$scanner_doing" --arg model "$scanner_model" --argjson pairs "$scanner_pairs_json" --argjson inProgress "$scanner_inprogress_json" '{doing: $doing, model: $model, pairs: $pairs, inProgress: $inProgress}')
+scanner_json=$(jq -n --arg doing "$scanner_doing" --arg model "$scanner_model" --argjson pairs "$scanner_pairs_json" --argjson inProgress "$scanner_inprogress_json" --argjson mergedPrs "$scanner_standalone_merged" '{doing: $doing, model: $model, pairs: $pairs, inProgress: $inProgress, mergedPrs: $mergedPrs}')
 reviewer_json=$(jq -n --arg doing "$reviewer_doing" --arg model "$reviewer_model" '{doing: $doing, model: $model}')
 architect_json=$(jq -n --arg doing "$architect_doing" --arg model "$architect_model" '{doing: $doing, model: $model}')
 outreach_json=$(jq -n --arg doing "$outreach_doing" --arg model "$outreach_model" '{doing: $doing, model: $model}')

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -855,10 +855,19 @@
           <a class="ind-tag ind-wip" href="https://github.com/kubestellar/console/issues/${ip.number}" target="_blank" title="${ip.title ? esc(ip.title) : ''}">${label}</a>
         </div>`;
         };
+        const standaloneMerged = m.mergedPrs || [];
+        const renderStandalonePr = (p) => {
+          const title = p.prTitle ? esc(p.prTitle.length > 55 ? p.prTitle.slice(0, 55) + '…' : p.prTitle) : '';
+          const tip = p.prTitle ? esc(p.prTitle) : '';
+          return `<div class="ind-pair">
+          <a class="ind-tag ind-pr ind-merged" href="https://github.com/kubestellar/console/pull/${p.pr}" target="_blank" title="${tip}">✓ #${p.pr} — ${title}</a>
+        </div>`;
+        };
+        const allMergedCount = mergedPairs.length + standaloneMerged.length;
         let html = '';
         if (inProgress.length > 0) html += `<div class="agent-indicators"><span class="ind-label">Working on (${inProgress.length}):</span>${inProgress.map(renderWip).join('')}</div>`;
         if (openPairs.length > 0) html += `<div class="agent-indicators"><span class="ind-label">PR open (${openPairs.length}):</span>${openPairs.map(renderPair).join('')}</div>`;
-        if (mergedPairs.length > 0) html += `<div class="agent-indicators"><span class="ind-label">Merged today (${mergedPairs.length}):</span>${mergedPairs.map(renderPair).join('')}</div>`;
+        if (allMergedCount > 0) html += `<div class="agent-indicators"><span class="ind-label">Merged today (${allMergedCount}):</span>${mergedPairs.map(renderPair).join('')}${standaloneMerged.map(renderStandalonePr).join('')}</div>`;
         if (!html) html = '<div class="agent-indicators"><span class="ind-empty">no active fixes</span></div>';
         return html;
       }
@@ -971,7 +980,7 @@
       if (!m) return 0;
       if (name === 'scanner') {
         const pairs = m.pairs || [];
-        return pairs.filter(p => p.state === 'merged').length;
+        return pairs.filter(p => p.state === 'merged').length + (m.mergedPrs || []).length;
       }
       if (name === 'outreach') return m.outreachMerged || 0;
       if (name === 'architect') return m.prs || m.closed || 0;


### PR DESCRIPTION
## Summary
- Merged PRs that don't use `Fixes`/`Closes`/`Resolves` keywords (infra, CI, config PRs) now appear as standalone pills in the "Merged today" section
- `agent-metrics.sh`: extracts merged PRs not already in issue→PR pairs into a new `mergedPrs` field
- `index.html`: renders standalone merged PRs with the same merged styling, combined count with paired merges

## Context
Infrastructure PRs (hold-issue-guard, case-conflict check, cron fixes) were invisible because they had no issue link. The "Merged today" section was empty even though 3 PRs merged in the last 24h.

## Test plan
- [ ] Dashboard shows standalone merged PRs in "Merged today" section
- [ ] PRs with issue references still show as issue→PR pairs (not duplicated)
- [ ] Count includes both paired and standalone merges