### PR TITLE
fix: recognize hive bot as AI author + resilient auto-deploy

### DIFF
--- a/bin/hive-deploy.sh
+++ b/bin/hive-deploy.sh
@@ -20,6 +20,7 @@ fi
 cd "$HIVE_REPO"
 
 BEFORE=$(git rev-parse HEAD)
+git stash --quiet 2>/dev/null || true
 git pull --rebase origin main --quiet 2>/dev/null || {
   log "WARN: git pull failed, skipping deploy"
   exit 0

--- a/bin/merge-gate.sh
+++ b/bin/merge-gate.sh
@@ -120,7 +120,7 @@ checks_dir = sys.argv[1]
 eligible = []
 not_ready = []
 
-AI_AUTHORS = {os.environ.get('PROJECT_AI_AUTHOR', ''), 'copilot-swe-agent[bot]', 'github-actions[bot]', 'dependabot[bot]'} - {''}
+AI_AUTHORS = {os.environ.get('PROJECT_AI_AUTHOR', ''), 'copilot-swe-agent[bot]', 'github-actions[bot]', 'dependabot[bot]', 'app/kubestellar-hive', 'kubestellar-hive[bot]'} - {''}
 
 for f in sorted(glob.glob(os.path.join(checks_dir, '*.json'))):
     try:


### PR DESCRIPTION
## Summary
- **merge-gate.sh**: Add `app/kubestellar-hive` and `kubestellar-hive[bot]` to AI_AUTHORS — hive bot PRs weren't recognized as AI-authored for merge eligibility
- **hive-deploy.sh**: `git stash` before `git pull --rebase` so local agent edits (e.g. outreach updating awesome-lists.md) don't block auto-deploy

## Root cause
Auto-deploy was broken for 3+ days because 2 locally modified files on the server prevented `git pull --rebase`. Every 60s deploy cycle silently exited with "git pull failed, skipping deploy." This blocked all hive code updates from reaching the server.

## Test plan
- [ ] Auto-deploy pulls successfully even with dirty working tree
- [ ] Hive bot PRs appear in merge-eligible list as AI-authored