### PR TITLE
fix: use GitHub App token for snapshot push

### DIFF
--- a/dashboard/publish-snapshot.sh
+++ b/dashboard/publish-snapshot.sh
@@ -12,9 +12,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 DASHBOARD_URL="${HIVE_DASHBOARD_URL:-http://localhost:3001}"
 DOCS_REPO="${DOCS_REPO_DIR:-/tmp/kubestellar-docs-snapshot}"
-DOCS_REMOTE="https://github.com/kubestellar/docs.git"
 OUTPUT_DIR="${DOCS_REPO}/public/live/hive"
 BRANCH="main"
+
+GH_APP_TOKEN_FILE="/var/run/hive-metrics/gh-app-token.cache"
+if [ -f "$GH_APP_TOKEN_FILE" ]; then
+  GH_APP_TOKEN=$(cat "$GH_APP_TOKEN_FILE")
+  DOCS_REMOTE="https://x-access-token:${GH_APP_TOKEN}@github.com/kubestellar/docs.git"
+else
+  DOCS_REMOTE="https://github.com/kubestellar/docs.git"
+fi
 
 # Ensure docs repo clone exists
 if [ ! -d "$DOCS_REPO/.git" ]; then
@@ -22,6 +29,7 @@ if [ ! -d "$DOCS_REPO/.git" ]; then
 fi
 
 cd "$DOCS_REPO"
+git remote set-url origin "$DOCS_REMOTE"
 git fetch origin "$BRANCH"
 git reset --hard "origin/$BRANCH"
 


### PR DESCRIPTION
## Summary
- `publish-snapshot.sh` has been failing every 15 minutes since ~May 3 because `git push` uses HTTPS without authentication
- The `/live/hive` page on kubestellar.io is 24+ hours stale as a result
- Now reads the cached GitHub App token from `/var/run/hive-metrics/gh-app-token.cache` and sets it on the origin remote before fetch/push

## Root cause
GitHub dropped password auth for HTTPS git operations. The systemd service environment doesn't inherit the `GH_TOKEN` from the dev user's shell, so raw `git push origin main` fails with `Authentication failed`.

## Fix
- Read `x-access-token` from the cached GitHub App token file (same token `ghx()` uses)
- `git remote set-url origin` with the token-embedded URL before fetch and push
- Falls back to unauthenticated URL if the token file doesn't exist