### PR TITLE
fix: prevent dashboard scroll jump on SSE re-render

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1117,7 +1117,7 @@
 
     function renderHealth(health) {
       const el = document.getElementById('health');
-      if (!health || Object.keys(health).length === 0) { el.innerHTML = '<span style="color:var(--muted);font-size:0.8rem">Loading…</span>'; return; }
+      if (!health || Object.keys(health).length === 0) { setIfChanged(el, '<span style="color:var(--muted);font-size:0.8rem">Loading…</span>'); return; }
       const items = [
         { key: 'ci', label: 'CI Pass Rate', type: 'pct' },
         { key: 'brew', label: 'Brew Formula' },
@@ -1129,7 +1129,7 @@
         { key: 'vllm', label: 'vLLM-d Deploy' },
         { key: 'pokprod', label: 'PokProd Deploy' },
       ];
-      el.innerHTML = items.map(it => {
+      setIfChanged(el, items.map(it => {
         const v = health[it.key];
         if (it.type === 'pct') {
           const cls = v >= 90 ? 'good' : v >= 70 ? 'warn' : 'bad';
@@ -1137,7 +1137,7 @@
         }
         const dotCls = v === 1 ? 'ok' : v === 0 ? 'fail' : 'unknown';
         return `<div class="health-item"><span class="health-dot ${dotCls}"></span><span class="health-label">${it.label}</span></div>`;
-      }).join('');
+      }).join(''));
     }
 
     function formatFixTime(minutes) {
@@ -1257,7 +1257,7 @@
 
     function renderRepos(repos) {
       const el = document.getElementById('repos');
-      el.innerHTML = repos.map(r => {
+      setIfChanged(el, repos.map(r => {
         const iSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.issues ?? 0), '#58a6ff');
         const pSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.prs ?? 0), '#bc8cff');
         const repoUrl = 'https://github.com/' + (r.full || r.name);
@@ -1269,16 +1269,16 @@
             <div class="repo-stat"><a href="${repoUrl}/pulls" target="_blank" rel="noopener" style="color:inherit;text-decoration:none"><div class="spark-row"><span class="num">${r.prs >= 0 ? r.prs : '?'}</span>${pSpark}</div><div class="label">PRs</div></a></div>
           </div>
         </div>`;
-      }).join('');
+      }).join(''));
     }
 
     function renderBeads(beads) {
       const el = document.getElementById('beads');
       const wSpark = sparkSvg(getHistorySeries('beadsWorkers'), '#39d2c0');
       const sSpark = sparkSvg(getHistorySeries('beadsSupervisor'), '#d29922');
-      el.innerHTML = `
+      setIfChanged(el, `
         <div class="bead-stat"><div class="spark-row"><span class="num">${beads.workers >= 0 ? beads.workers : 0}</span>${wSpark}</div><div class="label">workers</div></div>
-        <div class="bead-stat"><div class="spark-row"><span class="num">${beads.supervisor >= 0 ? beads.supervisor : 0}</span>${sSpark}</div><div class="label">supervisor</div></div>`;
+        <div class="bead-stat"><div class="spark-row"><span class="num">${beads.supervisor >= 0 ? beads.supervisor : 0}</span>${sSpark}</div><div class="label">supervisor</div></div>`);
     }
 
     function fmtTokens(n) {
@@ -1843,7 +1843,7 @@ function burnAreaChart() {
       const activePullbacks = pullbacks.filter(p => now < (p.expiry_epoch || 0));
       if (active.length === 0 && activePullbacks.length === 0) {
         el.className = 'gh-rate-alert';
-        el.innerHTML = '';
+        setIfChanged(el, '');
         return;
       }
       el.className = 'gh-rate-alert active';
@@ -1875,7 +1875,7 @@ function burnAreaChart() {
           ⏸ Pullback (${esc(p.cli || '?')}): paused <strong>${esc(paused)}</strong> — resumes in ${remainMin}m${resetStr}
         </div>`;
       }).join('');
-      el.innerHTML = `<div class="gh-rate-alert-title">GitHub API Rate Limit (${active.length} agent${active.length > 1 ? 's' : ''})</div>${items}${pullbackHtml}`;
+      setIfChanged(el, `<div class="gh-rate-alert-title">GitHub API Rate Limit (${active.length} agent${active.length > 1 ? 's' : ''})</div>${items}${pullbackHtml}`);
     }
 
     // Guard: skip agent re-render while a dropdown is focused/open
@@ -1884,6 +1884,12 @@ function burnAreaChart() {
     document.addEventListener('focusin', (e) => { if (e.target.matches('select.backend-select')) _dropdownOpen = true; });
     document.addEventListener('focusout', (e) => { if (e.target.matches('select.backend-select')) _dropdownOpen = false; });
     document.addEventListener('change', (e) => { if (e.target.matches('select.backend-select')) _dropdownOpen = false; });
+
+    // Skip innerHTML assignment when content hasn't changed — prevents
+    // DOM reflow that causes scroll position to jump on SSE updates.
+    function setIfChanged(el, html) {
+      if (el.innerHTML !== html) el.innerHTML = html;
+    }
 
     function render(data) {
       if (!data || data.error) return;
@@ -1903,7 +1909,7 @@ function burnAreaChart() {
       renderTokens(data.tokens || {});
       renderRepos(data.repos || []);
       renderBeads(data.beads || {});
-      requestAnimationFrame(() => window.scrollTo(0, scrollY));
+      window.scrollTo(0, scrollY);
     }
 
     function esc(s) {


### PR DESCRIPTION
## Summary

Dashboard scrolls back to the repositories section every ~5s because SSE re-renders destroy and rebuild DOM elements via innerHTML, causing layout reflow that resets scroll position.

Fix:
- Add `setIfChanged(el, html)` helper that skips innerHTML when content is identical
- Apply to `renderRepos`, `renderBeads`, `renderHealth`, `renderGhRateLimits`
- Switch scroll restore from `requestAnimationFrame` (one frame late) to synchronous `scrollTo`

## Test plan
- [ ] Scroll to bottom of dashboard, wait 10+ seconds — no jump
- [ ] Verify sparklines and data still update when values change
- [ ] Verify rate limit banner still appears/disappears correctly