### PR TITLE
fix: use hive GitHub App token in all scripts

### DIFF
--- a/dashboard/agent-metrics.sh
+++ b/dashboard/agent-metrics.sh
@@ -3,7 +3,17 @@
 
 set +e
 unset GITHUB_TOKEN
-[ -n "$HIVE_GITHUB_TOKEN" ] && export GH_TOKEN="$HIVE_GITHUB_TOKEN"
+
+# Use hive GitHub App token — never fall back to personal gh auth
+GH_APP_TOKEN_CACHE="/var/run/hive-metrics/gh-app-token.cache"
+if [[ -f "$GH_APP_TOKEN_CACHE" ]]; then
+  export GH_TOKEN="$(cat "$GH_APP_TOKEN_CACHE")"
+elif [[ -n "${HIVE_GITHUB_TOKEN:-}" ]]; then
+  export GH_TOKEN="$HIVE_GITHUB_TOKEN"
+else
+  echo '{"error":"no hive app token available"}' >&2
+  exit 0
+fi
 
 # Load project config
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"

--- a/dashboard/api-collector.sh
+++ b/dashboard/api-collector.sh
@@ -33,10 +33,17 @@ PROJECT="${PROJECT_NAME:-KubeStellar}"
 # (designed for agents) which would break this infrastructure script.
 GH=/usr/bin/gh
 
-# Auth: use HIVE_GITHUB_TOKEN if set
-if [ -n "${HIVE_GITHUB_TOKEN:-}" ]; then
-  unset GITHUB_TOKEN 2>/dev/null || true
+# Auth: use hive GitHub App token — never fall back to personal gh auth
+unset GITHUB_TOKEN 2>/dev/null || true
+GH_APP_TOKEN_CACHE="/var/run/hive-metrics/gh-app-token.cache"
+if [[ -f "$GH_APP_TOKEN_CACHE" ]]; then
+  export GH_TOKEN="$(cat "$GH_APP_TOKEN_CACHE")"
+elif [[ -n "${HIVE_GITHUB_TOKEN:-}" ]]; then
   export GH_TOKEN="$HIVE_GITHUB_TOKEN"
+else
+  echo '{"error":"no hive app token available","repos":[]}' > "$CACHE_FILE"
+  echo "ERROR: no hive app token — cannot collect GitHub data" >&2
+  exit 0
 fi
 
 tmpdir=$(mktemp -d)

--- a/dashboard/health-check.sh
+++ b/dashboard/health-check.sh
@@ -4,7 +4,18 @@
 # Falls back to hardcoded kubestellar defaults if no config file exists.
 set +e
 unset GITHUB_TOKEN
-[ -n "$HIVE_GITHUB_TOKEN" ] && export GH_TOKEN="$HIVE_GITHUB_TOKEN"
+
+# Use hive GitHub App token — never fall back to personal gh auth
+GH_APP_TOKEN_CACHE="/var/run/hive-metrics/gh-app-token.cache"
+if [[ -f "$GH_APP_TOKEN_CACHE" ]]; then
+  export GH_TOKEN="$(cat "$GH_APP_TOKEN_CACHE")"
+elif [[ -n "${HIVE_GITHUB_TOKEN:-}" ]]; then
+  export GH_TOKEN="$HIVE_GITHUB_TOKEN"
+else
+  echo '{"error":"no hive app token available"}' >&2
+  echo '{"ci":0,"brew":-1,"helm":-1,"nightlyRel":-1,"weeklyRel":-1,"weekly":-1,"hourly":-1}'
+  exit 0
+fi
 
 # Load project config
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
@@ -29,7 +40,7 @@ ci=$(gh run list --repo "$REPO" --status completed --limit 10 --json conclusion 
 # ── Brew formula freshness ───────────────────────────────────────────────────
 if [ -n "$BREW_TAP" ] && [ -n "$BREW_FORMULA" ]; then
   formula_ver=$(gh api "repos/${BREW_TAP}/contents/Formula/${BREW_FORMULA}" \
-    --jq '.content' 2>/dev/null | base64 -d 2>/dev/null | grep -oP 'version "\K[^"]+' | sed 's/^v//' || echo "?")
+    --jq '.content' 2>/dev/null | base64 -d 2>/dev/null | grep 'version "' | sed 's/.*version "//;s/".*//' | sed 's/^v//' || echo "?")
   latest_rel=$(gh api "repos/${REPO}/releases/latest" --jq '.tag_name' 2>/dev/null | sed 's/^v//' || echo "?")
   brew_ok=$( [ "$formula_ver" = "$latest_rel" ] && echo 1 || echo 0 )
 else
@@ -126,7 +137,7 @@ hourly_ok=$hourly_worst
 deploy_json=""
 if [ -n "$CI_WF" ]; then
   deploy_run_id=$(gh run list --repo "$REPO" --workflow "$CI_WF" \
-    --event push --branch main --limit 1 \
+    --event push --branch main --status completed --limit 1 \
     --json databaseId --jq '.[0].databaseId' 2>/dev/null || echo "")
 
   if [ -n "$deploy_run_id" ]; then

--- a/examples/kubestellar/worker.sh
+++ b/examples/kubestellar/worker.sh
@@ -5,6 +5,18 @@
 # The Copilot skill reads the DB and does actual fixes.
 set -euo pipefail
 
+# Use hive GitHub App token — never fall back to personal gh auth
+unset GITHUB_TOKEN 2>/dev/null || true
+GH_APP_TOKEN_CACHE="/var/run/hive-metrics/gh-app-token.cache"
+if [[ -f "$GH_APP_TOKEN_CACHE" ]]; then
+  export GH_TOKEN="$(cat "$GH_APP_TOKEN_CACHE")"
+elif [[ -n "${HIVE_GITHUB_TOKEN:-}" ]]; then
+  export GH_TOKEN="$HIVE_GITHUB_TOKEN"
+else
+  echo "ERROR: no hive app token available" >&2
+  exit 1
+fi
+
 DIR="$HOME/.kubestellar-fix-loop"
 DB="$DIR/state.db"
 LOCKFILE="$DIR/cycle.lock"
@@ -84,12 +96,12 @@ NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 for repo in $REPOS; do
   # Fetch issues
-  ISSUES=$(unset GITHUB_TOKEN && gh issue list --repo "kubestellar/$repo" --state open --limit 200 \
+  ISSUES=$(gh issue list --repo "kubestellar/$repo" --state open --limit 200 \
     --json number,title,author,createdAt 2>/dev/null || echo "[]")
   IC=$(echo "$ISSUES" | jq 'length' 2>/dev/null || echo 0)
 
   # Fetch PRs
-  PRS=$(unset GITHUB_TOKEN && gh pr list --repo "kubestellar/$repo" --state open --limit 100 \
+  PRS=$(gh pr list --repo "kubestellar/$repo" --state open --limit 100 \
     --json number,title,author,createdAt 2>/dev/null || echo "[]")
   PC=$(echo "$PRS" | jq 'length' 2>/dev/null || echo 0)
 


### PR DESCRIPTION
## Summary
- Replace personal `gh auth` fallbacks with the hive GitHub App token cache (`/var/run/hive-metrics/gh-app-token.cache`) in all 4 scripts that make GitHub API calls
- Scripts now fail gracefully (dashboard scripts output error JSON) or hard (worker exits 1) if no app token is available
- Fixes `grep -oP` (Linux-only Perl regex) with portable `grep + sed` in brew formula check
- Deploy run query now filters `--status completed` to avoid picking up in-progress runs
- Worker removes `unset GITHUB_TOKEN &&` from subshell `gh` calls (redundant after top-level auth block)

## Files changed
- `dashboard/health-check.sh` — app token auth, portable grep, deploy --status completed
- `dashboard/agent-metrics.sh` — app token auth
- `dashboard/api-collector.sh` — app token auth + error cache write
- `examples/kubestellar/worker.sh` — app token auth + removed subshell unset

## Test plan
- [x] Tested without any token: graceful JSON error output
- [x] Tested with HIVE_GITHUB_TOKEN: all indicators return correct values
- [x] Verified grep portability fix works on macOS (no -oP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)