### PR TITLE
fix: correct brew formula name to kc-agent.rb

### DIFF
--- a/examples/kubestellar/hive-project.yaml
+++ b/examples/kubestellar/hive-project.yaml
@@ -59,7 +59,7 @@ health_checks:
     - "Performance TTFI Gate"
   brew:
     tap_repo: "kubestellar/homebrew-tap"
-    formula: "kubestellar-console.rb"
+    formula: "kc-agent.rb"
   helm:
     chart_path: "deploy/helm/kubestellar-console/Chart.yaml"
   release_workflow: "Release"


### PR DESCRIPTION
## Summary
- Fix `hive-project.yaml` brew formula reference from `kubestellar-console.rb` to `kc-agent.rb`
- The formula was renamed but config was never updated, causing `health-check.sh` to fail the brew version lookup
- This is why the reviewer health panel shows Brew as red despite the formula being up-to-date