### PR TITLE
fix: agent card shows red border when governor cadence is zero

### DIFF
--- a/bin/hive-config.sh
+++ b/bin/hive-config.sh
@@ -179,11 +179,13 @@ hive_log() { printf '[%s] %s\n' "$(date -Is)" "$*"; }
 hive_log_to() { local f="$1"; shift; printf '[%s] %s\n' "$(date -Is)" "$*" >> "$f"; }
 
 # Canonical pause state checks — single source of truth for all scripts.
-# An agent is paused if EITHER file exists. Operator pause survives system resume.
+# An agent is paused if ANY pause file exists. Operator pause survives system resume.
+# cadence_paused is written by governor when cadence=0 in current mode.
 hive_is_paused() {
   local agent="${1:?agent name required}"
   [[ -f "${GOVERNOR_STATE_DIR}/paused_${agent}" ]] || \
-  [[ -f "${GOVERNOR_STATE_DIR}/operator_paused_${agent}" ]]
+  [[ -f "${GOVERNOR_STATE_DIR}/operator_paused_${agent}" ]] || \
+  [[ -f "${GOVERNOR_STATE_DIR}/cadence_paused_${agent}" ]]
 }
 hive_is_operator_paused() {
   local agent="${1:?agent name required}"

--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -673,10 +673,13 @@ maybe_kick() {
   fi
 
   if [ "$cadence" -eq 0 ]; then
+    touch "$STATE_DIR/cadence_paused_${agent}"
     log "SKIP ${agent} (mode=${mode} — PAUSED)"
     audit_kick "$agent" "SKIP" "cadence-zero" "governor"
     return
   fi
+
+  rm -f "$STATE_DIR/cadence_paused_${agent}"
 
   if [ "$elapsed" -ge "$cadence" ]; then
     local next_et

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -337,7 +337,8 @@ function fetchStatus() {
           try {
             const pf = path.join(GOVERNOR_STATE_DIR, `paused_${a.name}`);
             const opf = path.join(GOVERNOR_STATE_DIR, `operator_paused_${a.name}`);
-            if (fs.existsSync(pf) || fs.existsSync(opf)) { a.paused = true; a.cadence = 'paused'; }
+            const cpf = path.join(GOVERNOR_STATE_DIR, `cadence_paused_${a.name}`);
+            if (fs.existsSync(pf) || fs.existsSync(opf) || fs.existsSync(cpf)) { a.paused = true; a.cadence = 'paused'; }
           } catch (_) {}
           // Pin state
           try {
@@ -842,6 +843,8 @@ app.post('/api/resume/:agent', (req, res) => {
     if (fs.existsSync(pauseFlag)) fs.unlinkSync(pauseFlag);
     if (fs.existsSync(operatorFlag)) fs.unlinkSync(operatorFlag);
     if (fs.existsSync(wasPausedFlag)) fs.unlinkSync(wasPausedFlag);
+    const cadencePausedFlag = path.join(GOVERNOR_CADENCE_DIR, `cadence_paused_${agent}`);
+    if (fs.existsSync(cadencePausedFlag)) fs.unlinkSync(cadencePausedFlag);
     // Write the correct cadence for the current governor mode instead of deleting.
     // Governor will overwrite on next cycle; this prevents a gap where interval shows "?".
     const cadenceForMode = lookupCadenceForAgent(agent);


### PR DESCRIPTION
## Summary

- Governor now writes `cadence_paused_<agent>` file when an agent's cadence is 0 in the current mode
- Governor removes that file when cadence becomes >0 (mode changes)
- `hive_is_paused()` in hive-config.sh checks all 3 pause files: `paused_`, `operator_paused_`, `cadence_paused_`
- Dashboard server reads `cadence_paused_` alongside existing pause files
- Dashboard resume endpoint cleans up `cadence_paused_` (operator intent wins — but governor re-creates next tick if cadence is still 0)

Fixes: architect card not showing red/paused border despite cadence=0 in surge/busy/quiet modes.