### PR TITLE
fix: soft pause keeps agent alive, resume kicks immediately

### DIFF
--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -803,10 +803,9 @@ app.post('/api/pause/:agent', (req, res) => {
   } catch (e) {
     return res.status(500).json({ error: `failed to write pause flag: ${e.message}` });
   }
-  // Send 4x Esc to cancel any pending work, C-c + C-u to clear prompt, then /rename, then stop
+  // Soft pause: cancel current work but keep the agent session alive
   const PAUSE_ESC_TO_CLEAR_MS = 2000;
-  const PAUSE_CLEAR_TO_RENAME_MS = 1000;
-  const PAUSE_RENAME_TO_STOP_MS = 3000;
+  const PAUSE_CLEAR_TO_MSG_MS = 1000;
   try {
     execSync(`tmux send-keys -t ${agent} Escape Escape Escape Escape`, { timeout: 5000 });
   } catch (_) { /* session may not exist */ }
@@ -817,15 +816,10 @@ app.post('/api/pause/:agent', (req, res) => {
     } catch (_) { /* ignore */ }
     setTimeout(() => {
       try {
-        execSync(`tmux send-keys -t ${agent} '/rename ${agent}-paused' Enter`, { timeout: 5000 });
+        execSync(`tmux send-keys -t ${agent} 'agent is paused' Enter`, { timeout: 5000 });
       } catch (_) { /* ignore */ }
-      setTimeout(() => {
-        execFile('/usr/local/bin/hive', ['stop', agent], { timeout: 30000 }, (err) => {
-          if (err) console.error(`pause stop error for ${agent}:`, err.message);
-          res.json({ ok: true, output: `${agent} paused` });
-        });
-      }, PAUSE_RENAME_TO_STOP_MS);
-    }, PAUSE_CLEAR_TO_RENAME_MS);
+      res.json({ ok: true, output: `${agent} paused` });
+    }, PAUSE_CLEAR_TO_MSG_MS);
   }, PAUSE_ESC_TO_CLEAR_MS);
 });
 
@@ -845,25 +839,19 @@ app.post('/api/resume/:agent', (req, res) => {
     if (fs.existsSync(wasPausedFlag)) fs.unlinkSync(wasPausedFlag);
     const cadencePausedFlag = path.join(GOVERNOR_CADENCE_DIR, `cadence_paused_${agent}`);
     if (fs.existsSync(cadencePausedFlag)) fs.unlinkSync(cadencePausedFlag);
-    // Write the correct cadence for the current governor mode instead of deleting.
-    // Governor will overwrite on next cycle; this prevents a gap where interval shows "?".
     const cadenceForMode = lookupCadenceForAgent(agent);
     fs.writeFileSync(cadenceFlag, cadenceForMode);
   } catch (e) {
     return res.status(500).json({ error: `failed to remove pause flag: ${e.message}` });
   }
-  // Start the systemd service first (hive stop killed it), then kick after CLI is ready
-  // supervisor.sh handles /rename via AGENT_CLAUDE_RENAME_TO on startup
-  const RESUME_KICK_DELAY_MS = 20000;
-  execFile('sudo', ['systemctl', 'start', `hive@${agent}`], { timeout: 30000 }, (startErr) => {
-    if (startErr) return res.status(500).json({ error: `failed to start ${agent}: ${startErr.message}` });
-    setTimeout(() => {
-      execFile('/usr/local/bin/kick-agents.sh', [agent], { timeout: 30000 }, (kickErr) => {
-        if (kickErr) console.error(`resume kick error for ${agent}:`, kickErr.message);
-      });
-    }, RESUME_KICK_DELAY_MS);
-    res.json({ ok: true, output: `${agent} resumed` });
-  });
+  // Agent session is still alive (soft pause didn't kill it) — kick immediately
+  const RESUME_KICK_DELAY_MS = 2000;
+  setTimeout(() => {
+    execFile('/usr/local/bin/kick-agents.sh', [agent], { timeout: 30000 }, (kickErr) => {
+      if (kickErr) console.error(`resume kick error for ${agent}:`, kickErr.message);
+    });
+  }, RESUME_KICK_DELAY_MS);
+  res.json({ ok: true, output: `${agent} resumed` });
 });
 
 // Pin / Unpin — supports granular pinning (cli, model, or both)


### PR DESCRIPTION
## Summary

- **Pause**: sends Esc×4 + Ctrl-C + Ctrl-U + types "agent is paused" as visible status. Agent session stays alive (no `hive stop`).
- **Resume**: clears pause flags, kicks agent after 2s delay. No service restart needed since session is still running. kick-agents.sh sends `/clear` before the kick, which clears the "agent is paused" text.
- Reduces pause→resume cycle from ~30s (stop + start + 20s kick delay) to ~5s.