### PR TITLE
fix: governor writes 'on demand' for resumed cadence-zero agents

### DIFF
--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -737,7 +737,11 @@ for _agent in scanner reviewer architect outreach supervisor; do
   fi
   _secs=$(get_cadence "$_agent" "$mode")
   if [ "$_secs" -eq 0 ]; then
-    echo "paused"
+    if [[ -f "$STATE_DIR/operator_resumed_${_agent}" ]]; then
+      echo "on demand"
+    else
+      echo "paused"
+    fi
   else
     secs_to_label "$_secs"
   fi > "$STATE_DIR/cadence_${_agent}"


### PR DESCRIPTION
## Summary
- When an operator resumes a cadence-zero agent, governor was overwriting cadence file with "paused" every tick
- Now checks for `operator_resumed_<agent>` flag and writes "on demand" instead
- Fixes interval/next-run showing "paused" on a resumed agent card

## Test plan
- [ ] Resume cadence-zero agent → interval shows "on demand", not "paused"
- [ ] Wait for governor tick → cadence file still says "on demand"
- [ ] Pause again → cadence reverts to "paused"