### PR TITLE
fix: zero restart count in statusCache on reset

### DIFF
--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1002,6 +1002,10 @@ app.post('/api/reset-restarts/:agent', (req, res) => {
       const { execSync } = require('child_process');
       execSync(`sudo truncate -s 0 ${restartFile}`);
     }
+    if (statusCache && statusCache.agents) {
+      const entry = statusCache.agents.find(a => a.name === agent);
+      if (entry) entry.restarts = 0;
+    }
     res.json({ ok: true, output: `${agent} restart counter reset` });
   } catch (e) {
     res.status(500).json({ error: `failed to reset: ${e.message}` });


### PR DESCRIPTION
## Summary
- After resetting an agent's restart counter, immediately zero the in-memory `statusCache` entry
- Prevents SSE from broadcasting the stale pre-reset value during the ~5s window before the next `fetchStatus()` cycle
- Eliminates the brief flicker where the old count reappears after clicking the reset button

## Test plan
- [ ] Reset restart count on an agent — verify count goes to 0 and stays at 0 (no flicker)