### PR TITLE
dashboard: fix OpenClaw content overflow clipping repos/beads

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -118,8 +118,11 @@
     /* OpenClaw main content area */
     body.openclaw-mode {
       padding: 64px 20px 24px 220px; margin: 0;
+      max-width: 100vw; overflow-x: hidden; box-sizing: border-box;
     }
     body.openclaw-mode > .gh-rate-alert { margin-left: 0; }
+    body.openclaw-mode .repo-grid { grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); }
+    body.openclaw-mode .beads { flex-wrap: wrap; }
 
     /* OpenClaw agent detail panel (shown when agent selected in sidebar) */
     .oc-agent-detail {


### PR DESCRIPTION
## Summary
- Fix repos and beads being clipped/overflowing past the right edge in OpenClaw mode
- Add `max-width: 100vw` + `overflow-x: hidden` + `box-sizing: border-box` to body
- Constrain repo grid to smaller minmax (200px) to fit sidebar-offset content area
- Allow beads to wrap

## Test plan
- [ ] Verify repos section fits within viewport (no horizontal overflow)
- [ ] Verify beads section wraps properly
- [ ] Check at various viewport widths