### PR TITLE
dashboard: 20-line agent summaries and fix dot colors

### DIFF
--- a/dashboard/agent-activity.py
+++ b/dashboard/agent-activity.py
@@ -2,8 +2,9 @@
 """Extract live activity summaries from Claude Code JSONL session files.
 
 Tails active session files efficiently using byte offset tracking.
-Produces human-readable 1-5 line summaries via template-based extraction.
+Produces human-readable summaries via template-based extraction.
 Called by server.js every 5s, outputs JSON to stdout.
+Set SUMMARY_MAX_LINES env var to control output length (default 20).
 """
 
 import json, os, sys, glob, re, time, subprocess
@@ -16,6 +17,7 @@ SUMMARY_CACHE_FILE = os.path.join(STATE_DIR, "activity-cache.json")
 
 BOOTSTRAP_BYTES = 8192
 STALE_SECONDS = 300
+SUMMARY_MAX_LINES = int(os.environ.get("SUMMARY_MAX_LINES", "20"))
 
 AGENT_TMUX_SESSION = {
     "supervisor": "supervisor",
@@ -263,7 +265,7 @@ def summarize_entries(entries):
         msg = entry.get("message", {})
         for content in msg.get("content", []):
             ct = content.get("type")
-            if ct == "tool_use" and len(tools) < 5:
+            if ct == "tool_use" and len(tools) < SUMMARY_MAX_LINES:
                 desc = describe_tool(content)
                 if desc and desc not in tools:
                     tools.append(desc)
@@ -276,19 +278,19 @@ def summarize_entries(entries):
     if last_text and last_text not in lines:
         lines.append(last_text)
     for t in tools[1:]:
-        if len(lines) >= 5:
+        if len(lines) >= SUMMARY_MAX_LINES:
             break
         if t not in lines:
             lines.append(t)
 
-    return "\n".join(lines[:5])
+    return "\n".join(lines[:SUMMARY_MAX_LINES])
 
 
 def scrape_tmux(session):
     """Extract meaningful output lines from a tmux pane."""
     try:
         raw = subprocess.check_output(
-            ["tmux", "capture-pane", "-t", session, "-p", "-S", "-50"],
+            ["tmux", "capture-pane", "-t", session, "-p", "-S", "-100"],
             timeout=5, text=True, stderr=subprocess.DEVNULL
         )
     except (subprocess.SubprocessError, OSError):
@@ -322,7 +324,7 @@ def scrape_tmux(session):
     for l in lines:
         if l not in unique:
             unique.append(l)
-    result = unique[-5:] if unique else []
+    result = unique[-SUMMARY_MAX_LINES:] if unique else []
     return ("\n".join(result), is_working) if result else None
 
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -194,6 +194,7 @@
     .oc-agent-dot.running { background: #16a34a; }
     .oc-agent-dot.idle { background: #9ca3af; }
     .oc-agent-dot.paused { background: #dc2626; }
+    .oc-agent-dot.stopped { background: #dc2626; }
     .oc-agent-dot.off { background: #d1d5db; }
 
     /* Agent detail summary — monospace, respect newlines */
@@ -1152,7 +1153,7 @@
       }
     }
 
-    const OC_SUMMARY_MAX_LINES = 15;
+    const OC_SUMMARY_MAX_LINES = 20;
     function ocFormatSummary(raw) {
       const escaped = esc(raw);
       const lines = escaped.split(/\r?\n/);
@@ -1170,9 +1171,9 @@
 
       const isOff = a.offByCadence === true;
       const isPaused = a.paused === true && !isOff;
-      const isWorking = a.busy === 'working';
-      const dotCls = isWorking ? 'running' : isPaused ? 'paused' : isOff ? 'idle' : 'idle';
-      const stateLabel = isWorking ? 'working' : isPaused ? 'paused' : isOff ? 'off' : 'idle';
+      const isStopped = a.state === 'stopped';
+      const dotCls = isPaused ? 'paused' : isOff ? 'off' : isStopped ? 'stopped' : 'running';
+      const stateLabel = a.busy === 'working' ? 'working' : isPaused ? 'paused' : isOff ? 'off' : isStopped ? 'stopped' : 'idle';
 
       const kickId = `oc-kick-${a.name}`;
       const prevInput = document.getElementById(kickId);
@@ -1230,7 +1231,8 @@
       const html = agents.map(a => {
         const isOff = a.offByCadence === true;
         const isPaused = a.paused === true && !isOff;
-        const dotCls = a.busy === 'working' ? 'running' : isPaused ? 'paused' : isOff ? 'off' : 'idle';
+        const isStopped = a.state === 'stopped';
+        const dotCls = isPaused ? 'paused' : isOff ? 'off' : isStopped ? 'stopped' : 'running';
         const isActive = _ocSelectedAgent === a.name ? ' active' : '';
         return `<a class="oc-nav-item${isActive}" data-agent-nav="${a.name}" onclick="ocSelectAgent('${a.name}')"><span class="oc-agent-dot ${dotCls}"></span> ${a.name}</a>`;
       }).join('');


### PR DESCRIPTION
## Summary
- **agent-activity.py**: Add `SUMMARY_MAX_LINES` env var (default 20, was hardcoded 5) — controls how many lines of agent output appear in liveSummary
- **agent-activity.py**: Increase tmux capture depth from 50 to 100 lines for richer output
- **Dot colors**: Sidebar and detail panel dots now match classic card logic — green for all running agents (not just "working"), red for paused/stopped, grey for off. Previously idle-but-running agents showed grey.
- **Dashboard JS**: Bump display cap from 15 to 20 lines

## Test plan
- [ ] After deploy, verify agent summaries show up to 20 lines (may take 1-2 refresh cycles for cache to rebuild)
- [ ] Verify supervisor shows GREEN dot in sidebar and detail panel (was grey)
- [ ] Verify scanner shows GREEN dot when working
- [ ] Verify paused agents (reviewer, outreach) show RED dot
- [ ] Override with `SUMMARY_MAX_LINES=10` in env to verify configurability

🤖 Generated with [Claude Code](https://claude.com/claude-code)