### PR TITLE
dashboard: rows for Governor, columns for focused agent

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -234,9 +234,12 @@
     body.openclaw-mode .agent-card.paused { border-color: #ca8a04; opacity: 0.8; }
     body.openclaw-mode .agent-card.off { border-color: #d1d5db; opacity: 0.7; }
 
-    /* OpenClaw agents grid — always single column (rows) */
+    /* OpenClaw agents grid — rows for Governor/Overview, columns when agent is focused */
     body.openclaw-mode .agents {
       grid-template-columns: 1fr; gap: 14px;
+    }
+    body.openclaw-mode.oc-agent-focused .agents {
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     }
 
     /* OpenClaw surface panels */


### PR DESCRIPTION
## Summary
- Governor/Overview: agent cards in single-column rows (unchanged)
- Agent focused: non-hidden agent cards below display in multi-column grid (`auto-fit, minmax(280px, 1fr)`)
- Uses existing `oc-agent-focused` body class to switch layouts

## Test plan
- [ ] Click Governor — agents display as stacked rows
- [ ] Click an agent — other agents below display in columns
- [ ] Click Overview — agents return to row layout