### PR TITLE
dashboard: actionable issue pills on repo cards

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -479,6 +479,18 @@
     .repo-stat .label { color: var(--muted); font-size: 0.7rem; }
     .repo-stat a:hover { text-decoration: underline !important; }
     .repo-stat a:hover .label { color: var(--fg); }
+    .repo-issues { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 8px; padding-top: 6px; border-top: 1px solid var(--border); }
+    .repo-issue-pill {
+      display: inline-flex; align-items: center; gap: 3px;
+      font-size: 0.65rem; padding: 2px 6px; border-radius: 4px;
+      background: rgba(88,166,255,0.12); color: #58a6ff;
+      border: 1px solid rgba(88,166,255,0.25);
+      text-decoration: none; max-width: 100%;
+      transition: background 0.15s;
+    }
+    .repo-issue-pill:hover { background: rgba(88,166,255,0.25); text-decoration: none; }
+    .repo-issue-pill .pill-num { font-weight: 700; white-space: nowrap; }
+    .repo-issue-pill .pill-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
     /* Sparklines */
     .sparkline { display: inline-block; vertical-align: middle; margin-left: 6px; flex-shrink: 0; }
@@ -1800,13 +1812,19 @@
         const iSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.issues ?? 0), '#58a6ff');
         const pSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.prs ?? 0), '#bc8cff');
         const repoUrl = 'https://github.com/' + (r.full || r.name);
+        const MAX_PILL_TITLE_LEN = 50;
+        const pills = (r.actionableIssues || []).map(i => {
+          const title = i.title && i.title.length > MAX_PILL_TITLE_LEN ? i.title.slice(0, MAX_PILL_TITLE_LEN) + '…' : (i.title || '');
+          return `<a class="repo-issue-pill" href="${esc(i.url)}" target="_blank" rel="noopener" title="${esc(i.title || '')}"><span class="pill-num">#${i.number}</span><span class="pill-title">${esc(title)}</span></a>`;
+        }).join('');
+        const pillsHtml = pills ? `<div class="repo-issues">${pills}</div>` : '';
         return `
         <div class="repo-card">
           <div class="repo-name"><a href="${repoUrl}" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">${r.full || r.name}</a></div>
           <div class="repo-stats">
             <div class="repo-stat"><a href="${repoUrl}/issues" target="_blank" rel="noopener" style="color:inherit;text-decoration:none"><div class="spark-row"><span class="num">${r.issues >= 0 ? r.issues : '?'}</span>${iSpark}</div><div class="label">issues</div></a></div>
             <div class="repo-stat"><a href="${repoUrl}/pulls" target="_blank" rel="noopener" style="color:inherit;text-decoration:none"><div class="spark-row"><span class="num">${r.prs >= 0 ? r.prs : '?'}</span>${pSpark}</div><div class="label">PRs</div></a></div>
-          </div>
+          </div>${pillsHtml}
         </div>`;
       }).join(''));
     }

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -99,6 +99,14 @@ let summariesCache = {};
 let activityCache = {};
 let ghRateLimitsCache = { alerts: [] };
 
+const ACTIONABLE_FILE = path.join(METRICS_DIR, 'actionable.json');
+const ACTIONABLE_REFRESH_MS = 15000;
+let actionableCache = { issues: { items: [] } };
+try { actionableCache = JSON.parse(fs.readFileSync(ACTIONABLE_FILE, 'utf8')); } catch (_) {}
+setInterval(() => {
+  try { actionableCache = JSON.parse(fs.readFileSync(ACTIONABLE_FILE, 'utf8')); } catch (_) {}
+}, ACTIONABLE_REFRESH_MS);
+
 // GitHub API rate limit alerts — read from gh-rate-check.sh output every 30s
 const GH_RATE_LIMITS_FILE = '/var/run/hive-metrics/gh_rate_limits.json';
 const GH_RATE_REFRESH_MS = 30000; // 30 seconds
@@ -482,7 +490,15 @@ function fetchRepoStatus() {
   try {
     const raw = fs.readFileSync(GITHUB_CACHE_PATH, 'utf8');
     const data = JSON.parse(raw);
-    if (statusCache && data.repos) statusCache.repos = data.repos;
+    if (statusCache && data.repos) {
+      const items = (actionableCache.issues || {}).items || [];
+      for (const r of data.repos) {
+        r.actionableIssues = items
+          .filter(i => i.repo === r.full)
+          .map(i => ({ number: i.number, title: i.title, url: i.url, labels: i.labels || [] }));
+      }
+      statusCache.repos = data.repos;
+    }
   } catch (_) {}
 }
 setInterval(fetchRepoStatus, REPO_REFRESH_MS);


### PR DESCRIPTION
## Summary
- Read `actionable.json` (generated by `enumerate-actionable.sh`) and attach issue items to each repo
- Render clickable pills on repo cards showing issue number + truncated title
- Pills link directly to the GitHub issue
- Refreshes every 15s from the actionable cache

## Test plan
- [ ] Repo cards with open actionable issues show blue pills below the stats
- [ ] Pills are clickable and open the correct GitHub issue
- [ ] Repos with no actionable issues show no pills section
- [ ] Long issue titles are truncated with ellipsis