### PR TITLE
dashboard: fix issue pills + 40-line in-focus summary

### DIFF
--- a/dashboard/agent-activity.py
+++ b/dashboard/agent-activity.py
@@ -17,7 +17,7 @@ SUMMARY_CACHE_FILE = os.path.join(STATE_DIR, "activity-cache.json")
 
 BOOTSTRAP_BYTES = 8192
 STALE_SECONDS = 300
-SUMMARY_MAX_LINES = int(os.environ.get("SUMMARY_MAX_LINES", "20"))
+SUMMARY_MAX_LINES = int(os.environ.get("SUMMARY_MAX_LINES", "40"))
 
 AGENT_TMUX_SESSION = {
     "supervisor": "supervisor",

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1179,7 +1179,7 @@
       }
     }
 
-    const OC_SUMMARY_MAX_LINES = 20;
+    const OC_SUMMARY_MAX_LINES = 40;
     function ocFormatSummary(raw) {
       const escaped = esc(raw);
       const lines = escaped.split(/\r?\n/);

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -404,6 +404,7 @@ function fetchStatus() {
           a.structuredStatus = sm.status || '';
           a.statusEvidence = sm.evidence || '';
         }
+        enrichReposWithActionable();
         // Record snapshot for sparklines
         const snap = {
           t: lastFetch,
@@ -486,18 +487,22 @@ fetchStatus();
 // Repo data — read from centralized api-collector cache (no additional GH API calls)
 const REPO_REFRESH_MS = 60000;
 const GITHUB_CACHE_PATH = path.join(process.env.HIVE_METRICS_DIR || '/var/run/hive-metrics', 'github-cache.json');
+function enrichReposWithActionable() {
+  if (!statusCache || !statusCache.repos) return;
+  const items = (actionableCache.issues || {}).items || [];
+  for (const r of statusCache.repos) {
+    r.actionableIssues = items
+      .filter(i => i.repo === r.full)
+      .map(i => ({ number: i.number, title: i.title, url: i.url, labels: i.labels || [] }));
+  }
+}
 function fetchRepoStatus() {
   try {
     const raw = fs.readFileSync(GITHUB_CACHE_PATH, 'utf8');
     const data = JSON.parse(raw);
     if (statusCache && data.repos) {
-      const items = (actionableCache.issues || {}).items || [];
-      for (const r of data.repos) {
-        r.actionableIssues = items
-          .filter(i => i.repo === r.full)
-          .map(i => ({ number: i.number, title: i.title, url: i.url, labels: i.labels || [] }));
-      }
       statusCache.repos = data.repos;
+      enrichReposWithActionable();
     }
   } catch (_) {}
 }


### PR DESCRIPTION
## Summary
- Fix: actionable issue pills disappeared every 5s because fetchStatus overwrote enriched repos. Now `enrichReposWithActionable()` runs after every status fetch.
- Raise in-focus summary display from 20 to 40 lines (Python default + JS cap)

## Test plan
- [ ] Repo cards consistently show issue pills (not flickering on/off)
- [ ] In-focus agent summary shows up to 40 lines