### PR TITLE
dashboard: scrollable summary, no line cap

### DIFF
--- a/dashboard/agent-activity.py
+++ b/dashboard/agent-activity.py
@@ -17,7 +17,7 @@ SUMMARY_CACHE_FILE = os.path.join(STATE_DIR, "activity-cache.json")
 
 BOOTSTRAP_BYTES = 8192
 STALE_SECONDS = 300
-SUMMARY_MAX_LINES = int(os.environ.get("SUMMARY_MAX_LINES", "40"))
+SUMMARY_MAX_LINES = int(os.environ.get("SUMMARY_MAX_LINES", "100"))
 
 AGENT_TMUX_SESSION = {
     "supervisor": "supervisor",

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -209,7 +209,7 @@
       font-size: 0.82rem; color: #374151; line-height: 1.55;
       margin-bottom: 16px; padding: 14px; background: #f9fafb;
       border-radius: 8px; border: 1px solid #e5e7eb;
-      min-height: 60px; max-height: 320px; overflow-y: auto;
+      min-height: 60px; max-height: 600px; overflow-y: auto;
       white-space: pre-wrap; word-break: break-word;
       font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
       font-size: 0.78rem;
@@ -1179,12 +1179,8 @@
       }
     }
 
-    const OC_SUMMARY_MAX_LINES = 40;
     function ocFormatSummary(raw) {
-      const escaped = esc(raw);
-      const lines = escaped.split(/\r?\n/);
-      const trimmed = lines.length > OC_SUMMARY_MAX_LINES ? lines.slice(0, OC_SUMMARY_MAX_LINES).join('\n') + '\n…' : lines.join('\n');
-      return trimmed;
+      return esc(raw);
     }
 
     function ocRenderAgentDetail() {


### PR DESCRIPTION
## Summary
- Remove JS line truncation — summary box scrolls instead of cutting at 40 lines
- Increase visible area from 320px to 600px max-height
- Raise Python accumulator from 40 to 100 lines for richer scrollback history

## Test plan
- [ ] In-focus agent summary shows all accumulated lines with scrollbar when content exceeds visible area
- [ ] Summary grows over time as agent produces new output