### PR TITLE
fix: use proportional font for OpenClaw summary

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -207,13 +207,13 @@
     /* Agent detail summary — monospace, respect newlines */
     .oc-detail-summary-wrap { position: relative; margin-bottom: 16px; }
     .oc-detail-summary {
-      font-size: 0.82rem; color: #374151; line-height: 1.55;
+      color: #374151; line-height: 1.55;
       padding: 14px; background: #f9fafb;
       border-radius: 8px; border: 1px solid #e5e7eb;
       min-height: 60px; max-height: 600px; overflow-y: auto;
       white-space: pre-wrap; word-break: break-word;
-      font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
-      font-size: 0.78rem;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      font-size: 0.82rem;
     }
     .oc-summary-follow-btn {
       position: absolute; bottom: 10px; right: 10px;


### PR DESCRIPTION
## Summary
- Monospace font (`SF Mono`) made summary text look like it only filled half the panel — each character is fixed width, so ~80 char lines only span ~50% of the viewport
- Switched to system sans-serif (`-apple-system`) which uses proportional widths, filling the summary area naturally
- Bumped font size from 0.78rem to 0.82rem for consistency

## Test plan
- [ ] Open scanner in OpenClaw — summary text should fill the width naturally
- [ ] ASCII tables will lose column alignment but text content is much more readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)