### PR TITLE
feat: vertically resizable OpenClaw summary

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -210,7 +210,8 @@
       color: #374151; line-height: 1.5;
       padding: 14px; background: #f9fafb;
       border-radius: 8px; border: 1px solid #e5e7eb;
-      min-height: 60px; max-height: 600px; overflow-y: auto;
+      min-height: 60px; max-height: none; overflow-y: auto;
+      resize: vertical;
       font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
       font-size: 0.78rem;
     }


### PR DESCRIPTION
## Summary
- Remove 600px max-height cap on summary box
- Add `resize: vertical` so user can drag the bottom edge to resize
- Summary expands to show all content by default

## Test plan
- [ ] Drag bottom-right corner of summary box to resize vertically
- [ ] Summary shows all content without scrolling by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)