### PR TITLE
Fix agent detail card showing in classic mode

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -131,7 +131,7 @@
       border-radius: 10px; padding: 20px; margin-bottom: 16px;
       box-shadow: 0 1px 3px rgba(0,0,0,0.06);
     }
-    .oc-agent-detail.active { display: block; }
+    body.openclaw-mode .oc-agent-detail.active { display: block; }
     .oc-agent-detail.state-running { border-color: #16a34a; }
     .oc-agent-detail.state-idle { border-color: #16a34a; }
     .oc-agent-detail.state-paused { border-color: #ca8a04; }


### PR DESCRIPTION
## Summary
- Scoped `.oc-agent-detail.active` display rule to `body.openclaw-mode` only
- Fixes regression where the OpenClaw detail card was visible in classic layout, showing a duplicate architect card above the normal agent list