### PR TITLE
Chat: conversation context for follow-up questions

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3652,6 +3652,8 @@ function burnAreaChart() {
     const chatInput = document.getElementById('hiveChatInput');
     const chatSend = document.getElementById('hiveChatSend');
     let chatBusy = false;
+    const CHAT_CONTEXT_LIMIT = 6;
+    let chatContext = [];
 
     chatFab.onclick = () => {
       const isOpen = chatPanel.classList.toggle('open');
@@ -3676,19 +3678,24 @@ function burnAreaChart() {
       chatSend.disabled = true;
       chatInput.value = '';
       chatAddMsg(esc(q), 'user');
+      chatContext.push({ role: 'user', text: q });
+      if (chatContext.length > CHAT_CONTEXT_LIMIT) chatContext = chatContext.slice(-CHAT_CONTEXT_LIMIT);
       const thinking = chatAddMsg('Thinking…', 'thinking');
       try {
         const resp = await fetch('/api/chat', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ query: q }),
+          body: JSON.stringify({ query: q, history: chatContext.slice(0, -1) }),
         });
         const data = await resp.json();
         thinking.remove();
         if (data.error) {
           chatAddMsg('Error: ' + esc(data.error), 'system');
         } else {
-          let html = esc(data.answer || 'No results found.').replace(/\n/g, '<br>');
+          const answer = data.answer || 'No results found.';
+          chatContext.push({ role: 'assistant', text: answer });
+          if (chatContext.length > CHAT_CONTEXT_LIMIT) chatContext = chatContext.slice(-CHAT_CONTEXT_LIMIT);
+          let html = esc(answer).replace(/\n/g, '<br>');
           if (data.raw) {
             const rawId = 'chat-raw-' + Date.now();
             html += `<details class="chat-raw-details"><summary>Search data</summary><pre id="${rawId}">${esc(data.raw)}</pre></details>`;

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1714,11 +1714,14 @@ function formatChatResponse(query, parsed, beadResults, statusResults, dashResul
 const COPILOT_TIMEOUT_MS = 20000;
 const COPILOT_MAX_CONTEXT_CHARS = 3000;
 
+const CHAT_HISTORY_LIMIT = 6;
+
 app.post('/api/chat', async (req, res) => {
   const query = (req.body.query || '').trim();
   if (!query) return res.json({ error: 'Empty query' });
   const MAX_QUERY_LEN = 200;
   if (query.length > MAX_QUERY_LEN) return res.json({ error: 'Query too long' });
+  const history = (req.body.history || []).slice(-CHAT_HISTORY_LIMIT);
 
   try {
     const parsed = parseQuery(query);
@@ -1728,11 +1731,19 @@ app.post('/api/chat', async (req, res) => {
     const rawResponse = formatChatResponse(query, parsed, beadResults, statusResults, dashResults);
 
     const context = (rawResponse.answer || '').slice(0, COPILOT_MAX_CONTEXT_CHARS);
-    if (!context || context.startsWith('No results found')) {
+
+    const historyText = history.map(h => `${h.role === 'user' ? 'User' : 'Assistant'}: ${(h.text || '').slice(0, 300)}`).join('\n');
+    const hasHistory = historyText.length > 0;
+    const hasContext = context && !context.startsWith('No results found');
+
+    if (!hasContext && !hasHistory) {
       return res.json(rawResponse);
     }
 
-    const prompt = `You are a concise assistant for the KubeStellar Hive dashboard. Given the following search context about agents, issues, PRs, and beads, answer the user's question in 2-4 sentences. Be specific with numbers and names.\n\nContext:\n${context}\n\nUser question: ${query}`;
+    let prompt = 'You are a concise assistant for the KubeStellar Hive dashboard. Answer in 2-4 sentences. Be specific with numbers, names, and URLs when available.';
+    if (hasHistory) prompt += `\n\nConversation so far:\n${historyText}`;
+    if (hasContext) prompt += `\n\nSearch results:\n${context}`;
+    prompt += `\n\nUser: ${query}`;
 
     const aiAnswer = await new Promise((resolve) => {
       const proc = spawn('copilot', ['-p', prompt], {


### PR DESCRIPTION
## Summary
- Chat now maintains conversation history (last 6 messages)
- Follow-up questions like "give me the url for it" resolve against prior context
- Backend includes history in copilot prompt alongside search results
- Falls back gracefully when no new search results but history exists