### PR TITLE
Config dialog: agent name field + budget fallback

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3153,7 +3153,7 @@ function burnAreaChart() {
       _configModalOpen = true;
       _configState = { type, agent: agentName || null, tab: null, data: {}, dirty: {} };
       document.getElementById('config-overlay').classList.remove('hidden');
-      const title = type === 'governor' ? 'Governor Configuration' : `${agentName} Configuration`;
+      const title = type === 'governor' ? 'Governor Configuration' : `${agentName || 'New Agent'} Configuration`;
       document.querySelector('.config-title').textContent = title;
       const tabs = type === 'governor' ? GOVERNOR_CONFIG_TABS : AGENT_CONFIG_TABS;
       const tabsEl = document.getElementById('config-tabs');
@@ -3233,7 +3233,12 @@ function burnAreaChart() {
 
     // ── Agent Tab Renderers ──
     function renderAgentGeneral(g) {
+      const agentName = _configState.agent || '';
       return `
+        <div class="config-field">
+          <label>Agent Name</label>
+          <input type="text" id="cfg-agent-name" value="${esc(agentName)}" placeholder="e.g. scanner, reviewer, outreach" onchange="updateConfigAgentName(this.value)">
+        </div>
         <div class="config-field">
           <label>Launch Command</label>
           <input type="text" id="cfg-launch-cmd" value="${esc(g.launchCmd || '')}" onchange="markDirty('general','launchCmd',this.value)">
@@ -3267,6 +3272,13 @@ function burnAreaChart() {
             ${KNOWN_MODELS.map(m => `<option value="${m.value}" ${_modelsEqual(g.model, m.value) ? 'selected' : ''}>${m.label}</option>`).join('')}
           </select>
         </div>`;
+    }
+
+    function updateConfigAgentName(name) {
+      _configState.agent = name;
+      const titleEl = document.querySelector('.config-title');
+      if (titleEl) titleEl.textContent = `${name || 'New Agent'} Configuration`;
+      markDirty('general', 'name', name);
     }
 
     const SECONDS_PER_MIN = 60;

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1435,8 +1435,21 @@ app.get('/api/config/governor', (_req, res) => {
     const rawLabels = govEnv.GOVERNOR_EXEMPT_LABELS || govEnv.EXEMPT_LABELS || DEFAULT_EXEMPT_LABELS;
     const labels = rawLabels.split(/[|,]/).filter(Boolean);
 
+    // Fall back to runtime budget_state if env var not set
+    let runtimeBudgetTokens = 0;
+    try {
+      const budgetFile = path.join(GOVERNOR_STATE_DIR, 'budget_state');
+      if (fs.existsSync(budgetFile)) {
+        const blines = fs.readFileSync(budgetFile, 'utf8').trim().split('\n');
+        for (const l of blines) {
+          const [k, v] = l.split('=');
+          if (k === 'TOTAL' && v) runtimeBudgetTokens = Number(v);
+        }
+      }
+    } catch (_) {}
+    const envTokens = parseInt(govEnv.BUDGET_TOTAL_TOKENS || '0', 10);
     const budget = {
-      totalTokens: parseInt(govEnv.BUDGET_TOTAL_TOKENS || '0', 10),
+      totalTokens: envTokens || runtimeBudgetTokens,
       periodDays: parseInt(govEnv.BUDGET_PERIOD_DAYS || '7', 10),
       criticalPct: parseInt(govEnv.BUDGET_CRITICAL_PCT || '90', 10),
     };


### PR DESCRIPTION
## Summary
- Agent name is now an editable text input at the top of the General tab
- Fixes "undefined Configuration" title when opening config for a new agent
- Dialog title updates live as user types agent name
- Budget Total Tokens now falls back to runtime `budget_state` file when `BUDGET_TOTAL_TOKENS` env var is unset (was showing 0)

## Fixes
- Config dialog title showed "undefined Configuration" for new agents
- Budget showed 0 even though runtime had 200M configured