### PR TITLE
Integrate Nous (Agentic Strategy Evolution) into Hive

### DIFF
--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -53,6 +53,13 @@ if [[ -f /etc/hive/governor.env ]]; then
   # shellcheck disable=SC1091
   . /etc/hive/governor.env
 fi
+
+# ── Nous experiment overlay (loosely coupled — file may not exist) ──────────
+if [[ -f /etc/hive/governor-experiment.env ]]; then
+  # shellcheck disable=SC1091
+  . /etc/hive/governor-experiment.env
+  log "NOUS: experiment overlay active (${NOUS_EXPERIMENT_ID:-unknown})"
+fi
 # Load from project config if available and HIVE_REPOS not already set
 if [[ -z "${HIVE_REPOS:-}" ]]; then
   if [[ -f /usr/local/bin/hive-config.sh ]]; then
@@ -104,6 +111,22 @@ CADENCE_OUTREACH_SURGE_SEC="${CADENCE_OUTREACH_SURGE_SEC:-0}"       # PAUSED
 CADENCE_OUTREACH_BUSY_SEC="${CADENCE_OUTREACH_BUSY_SEC:-0}"         # PAUSED
 CADENCE_OUTREACH_QUIET_SEC="${CADENCE_OUTREACH_QUIET_SEC:-0}"       # PAUSED
 CADENCE_OUTREACH_IDLE_SEC="${CADENCE_OUTREACH_IDLE_SEC:-7200}"      # 2 hours
+
+# Nous agents — strategy experimentation fleet (Phase 3)
+CADENCE_STRATEGIST_SURGE_SEC="${CADENCE_STRATEGIST_SURGE_SEC:-0}"      # PAUSED during surge
+CADENCE_STRATEGIST_BUSY_SEC="${CADENCE_STRATEGIST_BUSY_SEC:-28800}"    # 8h — less experimentation when busy
+CADENCE_STRATEGIST_QUIET_SEC="${CADENCE_STRATEGIST_QUIET_SEC:-14400}"  # 4h
+CADENCE_STRATEGIST_IDLE_SEC="${CADENCE_STRATEGIST_IDLE_SEC:-14400}"    # 4h
+
+CADENCE_ANALYST_SURGE_SEC="${CADENCE_ANALYST_SURGE_SEC:-14400}"        # 4h — still analyzes past experiments
+CADENCE_ANALYST_BUSY_SEC="${CADENCE_ANALYST_BUSY_SEC:-14400}"          # 4h
+CADENCE_ANALYST_QUIET_SEC="${CADENCE_ANALYST_QUIET_SEC:-14400}"        # 4h
+CADENCE_ANALYST_IDLE_SEC="${CADENCE_ANALYST_IDLE_SEC:-14400}"          # 4h
+
+CADENCE_GUARDIAN_SURGE_SEC="${CADENCE_GUARDIAN_SURGE_SEC:-900}"         # 15min — must monitor active experiments
+CADENCE_GUARDIAN_BUSY_SEC="${CADENCE_GUARDIAN_BUSY_SEC:-900}"           # 15min
+CADENCE_GUARDIAN_QUIET_SEC="${CADENCE_GUARDIAN_QUIET_SEC:-900}"         # 15min
+CADENCE_GUARDIAN_IDLE_SEC="${CADENCE_GUARDIAN_IDLE_SEC:-900}"           # 15min
 
 # ── Token budget ────────────────────────────────────────────────────────────
 TOKEN_BUDGET_WEEKLY="${TOKEN_BUDGET_WEEKLY:-200000000}"  # ~200M billable tokens ≈ 100% weekly limit
@@ -374,6 +397,27 @@ get_cadence() {
         busy)  echo "$CADENCE_SUPERVISOR_BUSY_SEC"  ;;
         quiet) echo "$CADENCE_SUPERVISOR_QUIET_SEC" ;;
         idle)  echo "$CADENCE_SUPERVISOR_IDLE_SEC"  ;;
+      esac ;;
+    strategist)
+      case "$mode" in
+        surge) echo "$CADENCE_STRATEGIST_SURGE_SEC" ;;
+        busy)  echo "$CADENCE_STRATEGIST_BUSY_SEC"  ;;
+        quiet) echo "$CADENCE_STRATEGIST_QUIET_SEC" ;;
+        idle)  echo "$CADENCE_STRATEGIST_IDLE_SEC"  ;;
+      esac ;;
+    analyst)
+      case "$mode" in
+        surge) echo "$CADENCE_ANALYST_SURGE_SEC" ;;
+        busy)  echo "$CADENCE_ANALYST_BUSY_SEC"  ;;
+        quiet) echo "$CADENCE_ANALYST_QUIET_SEC" ;;
+        idle)  echo "$CADENCE_ANALYST_IDLE_SEC"  ;;
+      esac ;;
+    guardian)
+      case "$mode" in
+        surge) echo "$CADENCE_GUARDIAN_SURGE_SEC" ;;
+        busy)  echo "$CADENCE_GUARDIAN_BUSY_SEC"  ;;
+        quiet) echo "$CADENCE_GUARDIAN_QUIET_SEC" ;;
+        idle)  echo "$CADENCE_GUARDIAN_IDLE_SEC"  ;;
       esac ;;
     *)
   esac
@@ -764,7 +808,7 @@ echo "$mode"      > "$STATE_DIR/mode"
 echo "$busy_pct"  > "$STATE_DIR/busyness_pct"
 
 # Write per-agent cadences for hive status to read
-for _agent in scanner reviewer architect outreach supervisor; do
+for _agent in scanner reviewer architect outreach supervisor strategist analyst guardian; do
   if _is_agent_paused "$_agent"; then
     echo "paused" > "$STATE_DIR/cadence_${_agent}"
     continue
@@ -797,16 +841,43 @@ log "MODE=${mode} queue=${queue_depth} scanner=$(secs_to_label "$(get_cadence sc
 
 # Log model assignments
 budget_pct=$(grep '^PROJECTED_PCT=' "$STATE_DIR/budget_state" 2>/dev/null | cut -d= -f2 || echo "?")
-log "BUDGET projected=${budget_pct}% models: $(for _a in scanner reviewer architect outreach supervisor; do
+log "BUDGET projected=${budget_pct}% models: $(for _a in scanner reviewer architect outreach supervisor strategist analyst guardian; do
   _b=$(grep '^BACKEND=' "$STATE_DIR/model_${_a}" 2>/dev/null | cut -d= -f2 || echo "?")
   _m=$(grep '^MODEL=' "$STATE_DIR/model_${_a}" 2>/dev/null | cut -d= -f2 || echo "?")
   printf '%s=%s:%s ' "$_a" "$_b" "$_m"
 done)"
 
+# ── Nous: state snapshot + outcome tracking (loosely coupled) ──────────────
+NOUS_SNAPSHOTS_DIR="${NOUS_SNAPSHOTS_DIR:-/var/run/nous/snapshots}"
+if mkdir -p "$NOUS_SNAPSHOTS_DIR" 2>/dev/null; then
+  _snap_ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  _snap_epoch=$(date +%s)
+  _snap_tokens_hourly=0
+  [[ -f /var/run/hive-metrics/tokens.json ]] && \
+    _snap_tokens_hourly=$(jq -r '.hourly.billableTokens // 0' /var/run/hive-metrics/tokens.json 2>/dev/null || echo 0)
+  _snap_mttr=0
+  [[ -f /var/run/hive-metrics/issue_to_merge.json ]] && \
+    _snap_mttr=$(jq -r '.avg_minutes // 0' /var/run/hive-metrics/issue_to_merge.json 2>/dev/null || echo 0)
+
+  cat > "${NOUS_SNAPSHOTS_DIR}/${_snap_epoch}.json" <<SNAP_EOF
+{"ts":"${_snap_ts}","mode":"${mode}","queue_depth":${queue_depth},"budget_pct":"${budget_pct}","tokens_hourly":${_snap_tokens_hourly},"mttr_avg":${_snap_mttr}}
+SNAP_EOF
+
+  # Prune snapshots older than 7 days
+  find "$NOUS_SNAPSHOTS_DIR" -name '*.json' -mtime +7 -delete 2>/dev/null || true
+  log "NOUS: snapshot written (queue=${queue_depth} mode=${mode})"
+fi
+
+# Outcome tracker — correlate kicks with results
+OUTCOME_TRACKER="${OUTCOME_TRACKER:-$(dirname "$0")/kick-outcome-tracker.sh}"
+if [[ -x "$OUTCOME_TRACKER" ]]; then
+  "$OUTCOME_TRACKER" 2>&1 | while IFS= read -r _ot_line; do log "  $_ot_line"; done || true
+fi
+
 # Clear stuck input on every tick — C-c + C-u to discard, not Enter to execute.
 # If C-c + C-u fails (buffer completely stuck), flag agent for restart.
 BUFFER_STUCK_HEARTBEAT_THRESHOLD=1200  # 20 minutes — skip buffer-stuck flag if status file is fresher
-for _fa in scanner reviewer supervisor architect outreach; do
+for _fa in scanner reviewer supervisor architect outreach strategist analyst guardian; do
   _is_agent_paused "$_fa" && continue
   tmux has-session -t "$_fa" 2>/dev/null || continue
   _pane_text=$(tmux capture-pane -t "$_fa" -p 2>/dev/null || true)
@@ -849,7 +920,7 @@ DEFAULT_STALE_THRESHOLD_SEC=1200  # 20 minutes — overridden by per-agent AGENT
 STUCK_COUNT_FILE="$STATE_DIR/stuck_counts"
 touch "$STUCK_COUNT_FILE" 2>/dev/null || true
 
-for _sa in scanner reviewer architect outreach supervisor; do
+for _sa in scanner reviewer architect outreach supervisor strategist analyst guardian; do
   _is_agent_paused "$_sa" && continue
   _status_file="$HOME/.hive/${_sa}_status.txt"
   [[ ! -f "$_status_file" ]] && continue
@@ -898,5 +969,8 @@ maybe_kick reviewer   "$mode"
 maybe_kick architect  "$mode"
 maybe_kick outreach   "$mode"
 maybe_kick supervisor "$mode"
+maybe_kick strategist "$mode"
+maybe_kick analyst    "$mode"
+maybe_kick guardian   "$mode"
 
 log "GOVERNOR DONE"

--- a/bin/kick-outcome-tracker.sh
+++ b/bin/kick-outcome-tracker.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Correlate governor kicks with queue/MTTR/token outcomes.
+# Called at end of each governor tick. Writes outcome records to kick-outcomes.jsonl
+# after a cooldown period so we can measure the effect of each kick.
+set -euo pipefail
+
+METRICS_DIR="${NOUS_METRICS_DIR:-/var/run/hive-metrics}"
+OUTCOMES_FILE="${METRICS_DIR}/kick-outcomes.jsonl"
+AUDIT_LOG="${KICK_AUDIT_LOG:-/var/log/kick-audit.jsonl}"
+STATE_DIR="${GOVERNOR_STATE_DIR:-/var/run/kick-governor}"
+SNAPSHOTS_DIR="${NOUS_SNAPSHOTS_DIR:-/var/run/nous/snapshots}"
+PENDING_DIR="${METRICS_DIR}/pending-outcomes"
+
+# How many ticks to wait before measuring outcome (2 ticks ≈ 30min)
+COOLDOWN_TICKS=2
+TICK_INTERVAL_SEC=900
+
+mkdir -p "$METRICS_DIR" "$PENDING_DIR" "$SNAPSHOTS_DIR"
+
+log() { echo "[outcome-tracker] $(date '+%Y-%m-%d %H:%M:%S') $*"; }
+
+# ── Record current state as a pending outcome seed ──────────────────────────
+record_pending() {
+  local ts now_epoch queue_depth tokens_hourly mttr_avg mode
+  ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  now_epoch=$(date +%s)
+
+  queue_depth=$(cat "$STATE_DIR/queue_depth" 2>/dev/null || echo 0)
+  mode=$(cat "$STATE_DIR/mode" 2>/dev/null || echo "unknown")
+
+  # Token burn from collector
+  tokens_hourly=0
+  if [[ -f "${METRICS_DIR}/tokens.json" ]]; then
+    tokens_hourly=$(jq -r '.hourly.billableTokens // 0' "${METRICS_DIR}/tokens.json" 2>/dev/null || echo 0)
+  fi
+
+  # MTTR from issue-to-merge tracker
+  mttr_avg=0
+  if [[ -f "${METRICS_DIR}/issue_to_merge.json" ]]; then
+    mttr_avg=$(jq -r '.avg_minutes // 0' "${METRICS_DIR}/issue_to_merge.json" 2>/dev/null || echo 0)
+  fi
+
+  # Find kicks from this tick in audit log (last 5 minutes of entries)
+  local kicks_this_tick=0
+  local kicked_agents=""
+  if [[ -f "$AUDIT_LOG" ]]; then
+    local cutoff=$((now_epoch - TICK_INTERVAL_SEC))
+    while IFS= read -r line; do
+      local entry_ts entry_action entry_agent
+      entry_action=$(echo "$line" | jq -r '.action // empty' 2>/dev/null || true)
+      if [[ "$entry_action" == "KICK" ]]; then
+        kicks_this_tick=$((kicks_this_tick + 1))
+        entry_agent=$(echo "$line" | jq -r '.agent // empty' 2>/dev/null || true)
+        kicked_agents="${kicked_agents:+$kicked_agents,}$entry_agent"
+      fi
+    done < <(tail -50 "$AUDIT_LOG" 2>/dev/null || true)
+  fi
+
+  # Only record if there were actual kicks this tick
+  if [[ $kicks_this_tick -eq 0 ]]; then
+    log "No kicks this tick — skipping outcome seed"
+    return
+  fi
+
+  local seed_file="${PENDING_DIR}/${now_epoch}.json"
+  cat > "$seed_file" <<EOF
+{
+  "ts": "${ts}",
+  "epoch": ${now_epoch},
+  "mode": "${mode}",
+  "queue_at_kick": ${queue_depth},
+  "tokens_hourly_at_kick": ${tokens_hourly},
+  "mttr_at_kick": ${mttr_avg},
+  "kicks": ${kicks_this_tick},
+  "kicked_agents": "${kicked_agents}",
+  "measure_after_epoch": $((now_epoch + COOLDOWN_TICKS * TICK_INTERVAL_SEC))
+}
+EOF
+  log "Recorded pending outcome seed: ${kicks_this_tick} kicks [${kicked_agents}] queue=${queue_depth}"
+}
+
+# ── Resolve matured pending outcomes ────────────────────────────────────────
+resolve_pending() {
+  local now_epoch
+  now_epoch=$(date +%s)
+
+  for seed_file in "$PENDING_DIR"/*.json; do
+    [[ -f "$seed_file" ]] || continue
+
+    local measure_after
+    measure_after=$(jq -r '.measure_after_epoch' "$seed_file" 2>/dev/null || echo 999999999999)
+
+    if [[ $now_epoch -lt $measure_after ]]; then
+      continue
+    fi
+
+    # Measure current state
+    local queue_after tokens_after mttr_after
+    queue_after=$(cat "$STATE_DIR/queue_depth" 2>/dev/null || echo 0)
+    tokens_after=0
+    if [[ -f "${METRICS_DIR}/tokens.json" ]]; then
+      tokens_after=$(jq -r '.hourly.billableTokens // 0' "${METRICS_DIR}/tokens.json" 2>/dev/null || echo 0)
+    fi
+    mttr_after=0
+    if [[ -f "${METRICS_DIR}/issue_to_merge.json" ]]; then
+      mttr_after=$(jq -r '.avg_minutes // 0' "${METRICS_DIR}/issue_to_merge.json" 2>/dev/null || echo 0)
+    fi
+
+    # Compute deltas
+    local queue_at tokens_at seed_epoch
+    queue_at=$(jq -r '.queue_at_kick' "$seed_file")
+    tokens_at=$(jq -r '.tokens_hourly_at_kick' "$seed_file")
+    seed_epoch=$(jq -r '.epoch' "$seed_file")
+    local elapsed=$((now_epoch - seed_epoch))
+    local delta_queue=$((queue_after - queue_at))
+    local tokens_burned=$((tokens_after > 0 ? tokens_after : 1))
+
+    # Cost-effectiveness: negative delta_queue is good (queue shrank)
+    # effectiveness = -delta_queue / tokens_burned (higher = better)
+    local effectiveness
+    effectiveness=$(awk "BEGIN { printf \"%.6f\", ${delta_queue} * -1.0 / ${tokens_burned} }")
+
+    # Build outcome record
+    local outcome
+    outcome=$(jq -c \
+      --argjson queue_after "$queue_after" \
+      --argjson tokens_after "$tokens_after" \
+      --argjson mttr_after "$mttr_after" \
+      --argjson delta_queue "$delta_queue" \
+      --argjson elapsed "$elapsed" \
+      --arg effectiveness "$effectiveness" \
+      '. + {
+        queue_after: $queue_after,
+        tokens_hourly_after: $tokens_after,
+        mttr_after: $mttr_after,
+        delta_queue: $delta_queue,
+        elapsed_sec: $elapsed,
+        effectiveness: ($effectiveness | tonumber)
+      }' "$seed_file")
+
+    echo "$outcome" >> "$OUTCOMES_FILE"
+    rm -f "$seed_file"
+    log "Resolved outcome: delta_queue=${delta_queue} effectiveness=${effectiveness} elapsed=${elapsed}s"
+  done
+}
+
+# ── Main ────────────────────────────────────────────────────────────────────
+record_pending
+resolve_pending

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1160,6 +1160,42 @@
     @media (max-width: 500px) {
       .hive-chat-panel { width: calc(100vw - 32px); right: 16px; bottom: 72px; }
     }
+
+    /* Strategy Lab (Nous) */
+    .nous-card { background: var(--card); border: 1px solid var(--border); border-radius: 10px; padding: 14px 16px; margin-bottom: 12px; }
+    .nous-card h3 { font-size: 0.85rem; margin: 0 0 8px 0; color: var(--fg); }
+    .nous-mode-toggle { display: flex; gap: 0; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; margin-bottom: 14px; }
+    .nous-mode-btn { flex: 1; padding: 8px 12px; text-align: center; font-size: 0.78rem; cursor: pointer; border: none; background: var(--card); color: var(--muted); transition: all 0.2s; }
+    .nous-mode-btn:not(:last-child) { border-right: 1px solid var(--border); }
+    .nous-mode-btn.active-observe { background: #2563eb; color: white; }
+    .nous-mode-btn.active-suggest { background: #d97706; color: white; }
+    .nous-mode-btn.active-evolve { background: #16a34a; color: white; }
+    .nous-mode-btn:hover:not([class*="active-"]) { background: #f3f4f6; }
+    .nous-progress { height: 6px; background: var(--border); border-radius: 3px; overflow: hidden; margin: 8px 0; }
+    .nous-progress-fill { height: 100%; border-radius: 3px; transition: width 0.5s; }
+    .nous-stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 10px; }
+    .nous-stat { text-align: center; }
+    .nous-stat .val { font-size: 1.3rem; font-weight: 700; color: var(--fg); }
+    .nous-stat .lbl { font-size: 0.7rem; color: var(--muted); }
+    .nous-principle { display: flex; align-items: center; gap: 10px; padding: 8px 0; border-bottom: 1px solid var(--border); }
+    .nous-principle:last-child { border-bottom: none; }
+    .nous-confidence-bar { width: 60px; height: 6px; background: var(--border); border-radius: 3px; flex-shrink: 0; }
+    .nous-confidence-fill { height: 100%; border-radius: 3px; background: #16a34a; }
+    .nous-principle-text { font-size: 0.78rem; color: var(--fg); flex: 1; }
+    .nous-principle-score { font-size: 0.7rem; color: var(--muted); width: 35px; text-align: right; flex-shrink: 0; }
+    .nous-timeline { display: flex; gap: 3px; align-items: flex-end; height: 40px; margin-top: 8px; }
+    .nous-timeline-bar { flex: 1; min-width: 4px; border-radius: 2px 2px 0 0; cursor: default; }
+    .nous-pending-card { background: #fffbeb; border: 1px solid #f59e0b; border-radius: 8px; padding: 12px; margin-bottom: 10px; }
+    .nous-pending-card h4 { margin: 0 0 6px 0; font-size: 0.82rem; color: #92400e; }
+    .nous-pending-params { font-size: 0.75rem; margin: 6px 0; }
+    .nous-pending-params td { padding: 2px 8px; }
+    .nous-btn { padding: 6px 14px; border: none; border-radius: 6px; font-size: 0.78rem; cursor: pointer; font-weight: 600; }
+    .nous-btn-approve { background: #16a34a; color: white; }
+    .nous-btn-reject { background: #dc2626; color: white; margin-left: 8px; }
+    .nous-btn-abort { background: #dc2626; color: white; }
+    .nous-btn:hover { opacity: 0.85; }
+    .nous-experiment-live { background: #f0fdf4; border: 1px solid #16a34a; border-radius: 8px; padding: 12px; margin-bottom: 10px; }
+    .nous-experiment-live h4 { margin: 0 0 6px 0; font-size: 0.82rem; color: #166534; }
   </style>
 </head>
 <body>
@@ -1225,6 +1261,7 @@
       <div class="oc-nav-label">Resources</div>
       <a class="oc-nav-item" data-section="repos-section" onclick="ocNavigate('repos-section')">📦 Repos</a>
       <a class="oc-nav-item" data-section="beads-section" onclick="ocNavigate('beads-section')">🔮 Beads</a>
+      <a class="oc-nav-item" data-section="nous-section" onclick="ocNavigate('nous-section')">🧪 Strategy Lab</a>
     </div>
     <div class="oc-nav-group" style="margin-top:auto">
       <div class="oc-nav-label">Settings</div>
@@ -1270,6 +1307,11 @@
   <div id="beads-section" style="margin-top: 16px; margin-bottom: 24px;">
     <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 8px;">Beads</h2>
     <div class="beads" id="beads"></div>
+  </div>
+
+  <div id="nous-section" style="margin-top: 16px; margin-bottom: 24px;">
+    <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 8px;">🧪 Strategy Lab <span id="nous-mode-badge" style="font-size:0.75rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span></h2>
+    <div id="nous-panel"></div>
   </div>
 
   <div id="oc-gov-strip-outer" class="oc-gov-strip"></div>
@@ -2818,6 +2860,228 @@ function burnAreaChart() {
     function setIfChanged(el, html) {
       if (el.innerHTML !== html) el.innerHTML = html;
     }
+
+    // ── Strategy Lab (Nous) rendering ──────────────────────────────────────
+    let _nousCache = null;
+    const NOUS_POLL_MS = 30000;
+    const NOUS_CONFIDENCE_THRESHOLD = 0.8;
+    const NOUS_PRINCIPLE_HIGH_CONFIDENCE = 5;
+
+    async function fetchNousStatus() {
+      try {
+        const [statusRes, ledgerRes, principlesRes] = await Promise.all([
+          fetch('/api/nous/status'), fetch('/api/nous/ledger'), fetch('/api/nous/principles'),
+        ]);
+        _nousCache = {
+          status: await statusRes.json(),
+          ledger: await ledgerRes.json(),
+          principles: await principlesRes.json(),
+        };
+        renderNous();
+      } catch (_) { /* nous endpoints may not exist yet */ }
+    }
+
+    function renderNous() {
+      const panel = document.getElementById('nous-panel');
+      const badge = document.getElementById('nous-mode-badge');
+      if (!panel || !_nousCache) return;
+      const s = _nousCache.status || {};
+      const ledger = _nousCache.ledger || [];
+      const principles = _nousCache.principles || [];
+      const mode = s.mode || 'observe';
+
+      const modeColors = { observe: '#2563eb', suggest: '#d97706', evolve: '#16a34a' };
+      const modeLabels = { observe: 'Observing', suggest: 'Suggesting', evolve: 'Evolving' };
+      if (badge) {
+        badge.textContent = modeLabels[mode] || mode;
+        badge.style.background = modeColors[mode] || '#6b7280';
+        badge.style.color = 'white';
+      }
+
+      let html = '';
+
+      // Mode toggle
+      html += '<div class="nous-mode-toggle">';
+      for (const m of ['observe', 'suggest', 'evolve']) {
+        const active = m === mode ? ` active-${m}` : '';
+        const titles = {
+          observe: 'Data collection only — governor unchanged',
+          suggest: 'Experiments require your approval',
+          evolve: 'Fully autonomous experimentation',
+        };
+        html += `<button class="nous-mode-btn${active}" title="${titles[m]}" onclick="nousSetMode('${m}')">${m.charAt(0).toUpperCase() + m.slice(1)}</button>`;
+      }
+      html += '</div>';
+
+      // Stats row
+      const snapPct = s.snapshotTarget ? Math.min(Math.round((s.snapshotCount / s.snapshotTarget) * 100), 100) : 0;
+      html += '<div class="nous-stat-grid">';
+      html += `<div class="nous-stat"><div class="val">${s.snapshotCount || 0}</div><div class="lbl">Snapshots (${snapPct}% of baseline)</div></div>`;
+      html += `<div class="nous-stat"><div class="val">${s.principleCount || 0}</div><div class="lbl">Principles</div></div>`;
+      html += `<div class="nous-stat"><div class="val">${ledger.length}</div><div class="lbl">Experiments</div></div>`;
+      html += '</div>';
+
+      // Data collection progress (observe mode emphasis)
+      if (mode === 'observe') {
+        html += '<div class="nous-card" style="margin-top:12px">';
+        html += '<h3>Data Collection</h3>';
+        html += `<div class="nous-progress"><div class="nous-progress-fill" style="width:${snapPct}%;background:#2563eb"></div></div>`;
+        html += `<div style="font-size:0.72rem;color:var(--muted)">${s.snapshotCount || 0} / ${s.snapshotTarget || 672} snapshots — ${snapPct >= 75 ? 'Ready to upgrade to Suggest' : 'Collecting baseline data'}</div>`;
+
+        // Show dry_run proposals
+        const dryRuns = ledger.filter(e => e.type === 'dry_run').slice(-5);
+        if (dryRuns.length > 0) {
+          html += '<h3 style="margin-top:12px">Would Have Tested</h3>';
+          for (const dr of dryRuns) {
+            html += `<div style="font-size:0.75rem;color:var(--muted);padding:4px 0;border-bottom:1px solid var(--border)">`;
+            html += `<strong>${dr.id || '?'}</strong>: ${dr.hypothesis || 'no description'}`;
+            html += '</div>';
+          }
+        }
+        html += '</div>';
+      }
+
+      // Active experiment card
+      if (s.activeExperiment) {
+        const exp = s.activeExperiment;
+        html += '<div class="nous-experiment-live">';
+        html += `<h4>Active Experiment: ${exp.id}</h4>`;
+        html += `<div class="nous-progress"><div class="nous-progress-fill" style="width:${exp.progressPct}%;background:#16a34a"></div></div>`;
+        html += `<div style="font-size:0.72rem;color:var(--muted)">${exp.progressPct}% complete — ${Math.round((exp.ttlSec - exp.elapsed) / 60)}min remaining</div>`;
+        html += '<div style="display:flex;gap:16px;margin-top:8px;font-size:0.75rem">';
+        html += `<span>Queue limit: ${exp.fastFail.queueMax}</span>`;
+        html += `<span>MTTR limit: ${exp.fastFail.mttrMax}min</span>`;
+        html += '</div>';
+        html += `<button class="nous-btn nous-btn-abort" style="margin-top:10px" onclick="nousAbort()">Abort Experiment</button>`;
+        html += '</div>';
+      }
+
+      // Pending experiment (suggest mode)
+      if (s.pending && mode === 'suggest') {
+        const p = s.pending;
+        html += '<div class="nous-pending-card">';
+        html += `<h4>Pending Proposal: ${p.id || 'experiment'}</h4>`;
+        html += `<div style="font-size:0.78rem;margin-bottom:8px">${p.hypothesis || 'No hypothesis description'}</div>`;
+        if (p.params) {
+          html += '<table class="nous-pending-params"><tbody>';
+          for (const [k, v] of Object.entries(p.params)) {
+            html += `<tr><td style="color:var(--muted)">${k}</td><td><strong>${v}</strong></td></tr>`;
+          }
+          html += '</tbody></table>';
+        }
+        if (p.predicted) {
+          html += `<div style="font-size:0.72rem;color:#92400e">Predicted: ${JSON.stringify(p.predicted)}</div>`;
+        }
+        html += '<div style="margin-top:10px">';
+        html += '<button class="nous-btn nous-btn-approve" onclick="nousApprove()">Apply</button>';
+        html += '<button class="nous-btn nous-btn-reject" onclick="nousReject()">Reject</button>';
+        html += '</div></div>';
+      }
+
+      // Principles
+      if (principles.length > 0) {
+        html += '<div class="nous-card" style="margin-top:12px">';
+        html += '<h3>Principles</h3>';
+        const sorted = [...principles].sort((a, b) => (b.confidence || 0) - (a.confidence || 0));
+        for (const p of sorted) {
+          const conf = Math.round((p.confidence || 0) * 100);
+          const barColor = conf >= 80 ? '#16a34a' : conf >= 50 ? '#d97706' : '#dc2626';
+          html += '<div class="nous-principle">';
+          html += `<div class="nous-confidence-bar"><div class="nous-confidence-fill" style="width:${conf}%;background:${barColor}"></div></div>`;
+          html += `<div class="nous-principle-text">${p.text || p.id}</div>`;
+          html += `<div class="nous-principle-score">${conf}%</div>`;
+          html += '</div>';
+        }
+        html += '</div>';
+      }
+
+      // Experiment timeline
+      if (ledger.length > 0) {
+        html += '<div class="nous-card" style="margin-top:12px">';
+        html += '<h3>Experiment History</h3>';
+        html += '<div class="nous-timeline">';
+        const TIMELINE_MAX_BARS = 30;
+        const recent = ledger.slice(-TIMELINE_MAX_BARS);
+        for (const entry of recent) {
+          const colors = { dry_run: '#94a3b8', active: '#2563eb', completed: '#16a34a', aborted: '#dc2626', analysis: '#7c3aed', shadow_analysis: '#a78bfa' };
+          const color = colors[entry.type] || '#94a3b8';
+          const outcome = entry.outcome || entry.type;
+          html += `<div class="nous-timeline-bar" style="height:${20 + Math.random() * 20}px;background:${color}" title="${entry.id || '?'}: ${outcome}"></div>`;
+        }
+        html += '</div>';
+        html += '<div style="font-size:0.65rem;color:var(--muted);margin-top:4px;display:flex;gap:12px">';
+        html += '<span><span style="color:#94a3b8">■</span> dry run</span>';
+        html += '<span><span style="color:#2563eb">■</span> active</span>';
+        html += '<span><span style="color:#16a34a">■</span> completed</span>';
+        html += '<span><span style="color:#dc2626">■</span> aborted</span>';
+        html += '<span><span style="color:#7c3aed">■</span> analysis</span>';
+        html += '</div></div>';
+      }
+
+      // Recommendations badge
+      if (s.hasRecommendations && s.recommendations) {
+        const recs = s.recommendations.recommendations || [];
+        html += '<div class="nous-card" style="margin-top:12px;border-color:#7c3aed">';
+        html += `<h3 style="color:#7c3aed">Pending Recommendations (${recs.length})</h3>`;
+        for (const r of recs) {
+          html += `<div style="font-size:0.78rem;padding:4px 0;border-bottom:1px solid var(--border)">`;
+          html += `<strong>${r.var}</strong>: ${r.current || '?'} → <strong>${r.proposed}</strong>`;
+          html += `<div style="font-size:0.7rem;color:var(--muted)">${r.rationale} (${Math.round((r.confidence || 0) * 100)}% confidence)</div>`;
+          html += '</div>';
+        }
+        html += '</div>';
+      }
+
+      setIfChanged(panel, html);
+    }
+
+    async function nousSetMode(mode) {
+      const current = (_nousCache && _nousCache.status && _nousCache.status.mode) || 'observe';
+      const modeOrder = { observe: 0, suggest: 1, evolve: 2 };
+      let force = false;
+      if (modeOrder[mode] < modeOrder[current]) {
+        if (!confirm(`Switch from ${current} to ${mode}? This will stop any active experiment.`)) return;
+        force = true;
+      }
+      try {
+        await fetch('/api/nous/mode', {
+          method: 'PUT', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ mode, force }),
+        });
+        fetchNousStatus();
+      } catch (e) { showToast('Failed to change mode: ' + e.message, 'error'); }
+    }
+
+    async function nousApprove() {
+      try {
+        const r = await fetch('/api/nous/approve', { method: 'POST' });
+        const j = await r.json();
+        if (j.ok) { showToast('Experiment approved and started', 'success'); fetchNousStatus(); }
+        else showToast(j.error || 'Approve failed', 'error');
+      } catch (e) { showToast('Approve failed: ' + e.message, 'error'); }
+    }
+
+    async function nousReject() {
+      if (!confirm('Reject this experiment proposal?')) return;
+      try {
+        await fetch('/api/nous/abort', { method: 'POST' });
+        showToast('Proposal rejected', 'success');
+        fetchNousStatus();
+      } catch (e) { showToast('Reject failed: ' + e.message, 'error'); }
+    }
+
+    async function nousAbort() {
+      if (!confirm('Abort the active experiment? This will revert governor to default behavior.')) return;
+      try {
+        const r = await fetch('/api/nous/abort', { method: 'POST' });
+        const j = await r.json();
+        if (j.ok) { showToast('Experiment aborted: ' + j.aborted, 'success'); fetchNousStatus(); }
+        else showToast(j.error || 'Abort failed', 'error');
+      } catch (e) { showToast('Abort failed: ' + e.message, 'error'); }
+    }
+
+    fetchNousStatus();
+    setInterval(fetchNousStatus, NOUS_POLL_MS);
 
     function render(data) {
       if (!data || data.error) return;

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1809,6 +1809,201 @@ app.post('/api/chat', async (req, res) => {
   }
 });
 
+// ── Nous (Strategy Lab) API endpoints ──────────────────────────────────────
+const NOUS_CAMPAIGN_PATH = process.env.NOUS_CAMPAIGN_PATH || '/etc/hive/nous-campaign.yaml';
+const NOUS_OVERLAY_PATH = '/etc/hive/governor-experiment.env';
+const NOUS_STATE_DIR = '/var/run/nous';
+const NOUS_LEDGER_PATH = path.join(NOUS_STATE_DIR, 'ledger.jsonl');
+const NOUS_PRINCIPLES_PATH = path.join(NOUS_STATE_DIR, 'principles.json');
+const NOUS_PENDING_PATH = path.join(NOUS_STATE_DIR, 'pending-experiment.json');
+const NOUS_RECOMMENDATIONS_PATH = path.join(NOUS_STATE_DIR, 'recommendations.json');
+const NOUS_SNAPSHOTS_DIR = path.join(NOUS_STATE_DIR, 'snapshots');
+
+function readNousCampaign() {
+  try {
+    const raw = fs.readFileSync(NOUS_CAMPAIGN_PATH, 'utf8');
+    if (yaml) return yaml.load(raw) || {};
+    return {};
+  } catch (_) { return {}; }
+}
+
+function readJsonFile(p) {
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch (_) { return null; }
+}
+
+function readJsonlFile(p, limit) {
+  try {
+    const lines = fs.readFileSync(p, 'utf8').trim().split('\n').filter(Boolean);
+    const MAX_LEDGER_LINES = limit || 100;
+    const recent = lines.slice(-MAX_LEDGER_LINES);
+    return recent.map((l) => { try { return JSON.parse(l); } catch (_) { return null; } }).filter(Boolean);
+  } catch (_) { return []; }
+}
+
+// GET /api/nous/status — current mode, active experiment, pending proposal
+app.get('/api/nous/status', (_req, res) => {
+  const campaign = readNousCampaign();
+  const mode = (campaign.campaign && campaign.campaign.mode) || 'observe';
+
+  let activeExperiment = null;
+  if (fs.existsSync(NOUS_OVERLAY_PATH)) {
+    try {
+      const overlay = parseEnvFile(NOUS_OVERLAY_PATH);
+      const startEpoch = parseInt(overlay.NOUS_EXPERIMENT_START || '0', 10);
+      const ttlSec = parseInt(overlay.NOUS_EXPERIMENT_TTL_SEC || '14400', 10);
+      const nowEpoch = Math.floor(Date.now() / 1000);
+      const PERCENT_DIVISOR = 100;
+      activeExperiment = {
+        id: overlay.NOUS_EXPERIMENT_ID || 'unknown',
+        start: startEpoch,
+        ttlSec,
+        elapsed: nowEpoch - startEpoch,
+        progressPct: Math.min(Math.round(((nowEpoch - startEpoch) / ttlSec) * PERCENT_DIVISOR), PERCENT_DIVISOR),
+        fastFail: {
+          queueMax: parseInt(overlay.NOUS_FAST_FAIL_QUEUE_MAX || '30', 10),
+          mttrMax: parseInt(overlay.NOUS_FAST_FAIL_MTTR_MAX || '180', 10),
+        },
+      };
+    } catch (_) { /* overlay parse failed */ }
+  }
+
+  const pending = readJsonFile(NOUS_PENDING_PATH);
+  const principles = readJsonFile(NOUS_PRINCIPLES_PATH) || [];
+  const recommendations = readJsonFile(NOUS_RECOMMENDATIONS_PATH);
+
+  const SNAPSHOT_COUNT_TARGET = 672;
+  let snapshotCount = 0;
+  try {
+    if (fs.existsSync(NOUS_SNAPSHOTS_DIR)) {
+      snapshotCount = fs.readdirSync(NOUS_SNAPSHOTS_DIR).filter((f) => f.endsWith('.json')).length;
+    }
+  } catch (_) { /* ignore */ }
+
+  res.json({
+    mode,
+    campaign: campaign.campaign || {},
+    activeExperiment,
+    pending,
+    principleCount: Array.isArray(principles) ? principles.length : 0,
+    snapshotCount,
+    snapshotTarget: SNAPSHOT_COUNT_TARGET,
+    hasRecommendations: !!recommendations,
+    recommendations,
+  });
+});
+
+// GET /api/nous/ledger — experiment history
+app.get('/api/nous/ledger', (_req, res) => {
+  const LEDGER_LIMIT = 200;
+  res.json(readJsonlFile(NOUS_LEDGER_PATH, LEDGER_LIMIT));
+});
+
+// GET /api/nous/principles — accumulated knowledge
+app.get('/api/nous/principles', (_req, res) => {
+  res.json(readJsonFile(NOUS_PRINCIPLES_PATH) || []);
+});
+
+// POST /api/nous/approve — approve pending experiment (suggest mode only)
+app.post('/api/nous/approve', (_req, res) => {
+  const campaign = readNousCampaign();
+  const mode = (campaign.campaign && campaign.campaign.mode) || 'observe';
+  if (mode !== 'suggest') {
+    return res.status(400).json({ error: `Approve only available in suggest mode (current: ${mode})` });
+  }
+  const pending = readJsonFile(NOUS_PENDING_PATH);
+  if (!pending) {
+    return res.status(404).json({ error: 'No pending experiment to approve' });
+  }
+
+  try {
+    const overlayLines = [
+      '# Nous experiment overlay — approved from dashboard',
+      `NOUS_EXPERIMENT_ID=${pending.id || 'exp-approved'}`,
+      `NOUS_EXPERIMENT_START=${Math.floor(Date.now() / 1000)}`,
+      `NOUS_EXPERIMENT_TTL_SEC=${(pending.duration_hours || 4) * 3600}`,
+      `NOUS_FAST_FAIL_QUEUE_MAX=${(pending.fast_fail && pending.fast_fail.queue_max) || 30}`,
+      `NOUS_FAST_FAIL_MTTR_MAX=${(pending.fast_fail && pending.fast_fail.mttr_max) || 180}`,
+    ];
+    if (pending.params) {
+      for (const [k, v] of Object.entries(pending.params)) {
+        overlayLines.push(`${k}=${v}`);
+      }
+    }
+    fs.writeFileSync(NOUS_OVERLAY_PATH, overlayLines.join('\n') + '\n');
+
+    const ledgerEntry = JSON.stringify({
+      ...pending, type: 'active', approved_at: new Date().toISOString(),
+    });
+    fs.appendFileSync(NOUS_LEDGER_PATH, ledgerEntry + '\n');
+
+    fs.unlinkSync(NOUS_PENDING_PATH);
+    res.json({ ok: true, experimentId: pending.id });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /api/nous/abort — emergency stop
+app.post('/api/nous/abort', (_req, res) => {
+  try {
+    let experimentId = 'unknown';
+    if (fs.existsSync(NOUS_OVERLAY_PATH)) {
+      const overlay = parseEnvFile(NOUS_OVERLAY_PATH);
+      experimentId = overlay.NOUS_EXPERIMENT_ID || 'unknown';
+      fs.unlinkSync(NOUS_OVERLAY_PATH);
+    }
+
+    const abortEntry = JSON.stringify({
+      id: `abort-${Date.now()}`, ts: new Date().toISOString(),
+      type: 'aborted', experiment_id: experimentId,
+      reason: 'operator_abort',
+    });
+    try { fs.appendFileSync(NOUS_LEDGER_PATH, abortEntry + '\n'); } catch (_) { /* ignore */ }
+
+    res.json({ ok: true, aborted: experimentId });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// PUT /api/nous/mode — change campaign mode
+app.put('/api/nous/mode', (req, res) => {
+  const { mode, force } = req.body;
+  const VALID_MODES = ['observe', 'suggest', 'evolve'];
+  if (!VALID_MODES.includes(mode)) {
+    return res.status(400).json({ error: `Invalid mode: ${mode}. Must be one of: ${VALID_MODES.join(', ')}` });
+  }
+
+  const campaign = readNousCampaign();
+  const currentMode = (campaign.campaign && campaign.campaign.mode) || 'observe';
+  const modeOrder = { observe: 0, suggest: 1, evolve: 2 };
+
+  if (!force && modeOrder[mode] < modeOrder[currentMode]) {
+    return res.status(400).json({
+      error: `Backward transition ${currentMode} → ${mode} requires force: true`,
+      currentMode,
+    });
+  }
+
+  try {
+    if (!campaign.campaign) campaign.campaign = {};
+    campaign.campaign.mode = mode;
+    if (yaml) {
+      fs.writeFileSync(NOUS_CAMPAIGN_PATH, yaml.dump(campaign, { lineWidth: 120 }));
+    } else {
+      return res.status(500).json({ error: 'js-yaml not available — cannot write campaign yaml' });
+    }
+
+    if (force && fs.existsSync(NOUS_OVERLAY_PATH)) {
+      fs.unlinkSync(NOUS_OVERLAY_PATH);
+    }
+
+    res.json({ ok: true, mode, previousMode: currentMode });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 app.listen(PORT, () => {
   console.log(`🐝 Hive Dashboard running at http://localhost:${PORT}`);
 });

--- a/examples/kubestellar/agents/analyst-CLAUDE.md
+++ b/examples/kubestellar/agents/analyst-CLAUDE.md
@@ -1,0 +1,124 @@
+# Nous Analyst — Experiment Evaluation Agent
+
+You are the **Analyst** in the Nous experimentation framework. Your job is to evaluate completed experiments, extract principles (what works and what doesn't), and maintain the principle store that guides future experiments.
+
+## What you own
+
+- **ANALYSIS**: Compare baseline vs experiment metrics after an experiment completes
+- **EXTRACTION**: Turn experiment results into principles with confidence scores
+- **RECOMMENDATIONS**: When enough high-confidence principles accumulate, propose permanent governor changes
+
+## Per-kick protocol
+
+### Step 1: Read current state
+
+```bash
+cat /etc/hive/nous-campaign.yaml
+cat /var/run/nous/principles.json 2>/dev/null || echo '[]'
+cat /var/run/nous/ledger.jsonl 2>/dev/null | tail -20
+ls /etc/hive/governor-experiment.env 2>/dev/null
+ls -t /var/run/nous/snapshots/ | head -40
+```
+
+### Step 2: Check for completed experiments
+
+An experiment is "completed" when:
+- The overlay file was removed by the guardian (TTL expired or fast-fail), OR
+- The ledger shows an `active` experiment whose `NOUS_EXPERIMENT_START + NOUS_EXPERIMENT_TTL_SEC` is in the past
+
+Check the ledger for the most recent `active` entry that has no corresponding `completed` or `aborted` entry.
+
+### Step 3: Analyze (if experiment completed)
+
+Compare snapshots from the baseline window vs the experiment window:
+
+1. Collect all snapshots from the baseline period (4h before experiment start)
+2. Collect all snapshots from the experiment period (experiment start to end)
+3. Require at least 16 snapshots in each window (one per governor tick)
+4. Compare:
+   - **Queue depth**: avg, min, max, trend
+   - **MTTR**: avg change
+   - **Token burn**: total and hourly rate
+   - **Effectiveness**: from kick-outcomes.jsonl records during each window
+
+**Statistical significance**: Require >10% delta AND consistent direction (>75% of experiment ticks better than baseline avg) to call a result positive or negative. Otherwise: inconclusive.
+
+### Step 4: Extract principle
+
+Based on analysis, write or update a principle in `/var/run/nous/principles.json`:
+
+```json
+{
+  "id": "P001",
+  "text": "Sonnet handles scanner work as well as Opus in quiet mode at 3x lower cost",
+  "confidence": 0.82,
+  "regime": "quiet",
+  "controllable": "MODEL_QUIET_SCANNER",
+  "effect_size": {"mttr_delta_pct": -2, "cost_delta_pct": -67},
+  "evidence": ["exp-2026-05-06-sonnet-scanner-quiet"],
+  "created": "2026-05-06T14:00:00Z",
+  "last_validated": "2026-05-06T14:00:00Z"
+}
+```
+
+**Confidence scoring**:
+- Positive result with >20% delta: 0.8 base
+- Positive result with 10-20% delta: 0.6 base
+- Negative result: record as negative principle at 0.7 confidence
+- Inconclusive: 0.3, mark for retry
+- Multiple confirming experiments: confidence += 0.1 per confirmation (cap at 0.95)
+
+### Step 5: Apply confidence decay
+
+On EVERY kick, decay all existing principles:
+- Reduce confidence by 5% per week since `last_validated`
+- If confidence drops below 0.2, archive the principle (move to `archived` array)
+- If a new experiment confirms an existing principle, reset `last_validated` to now
+
+### Step 6: Shadow analysis (observe mode)
+
+In `observe` mode, there are no real experiments to analyze. Instead:
+- Read `dry_run` entries from the ledger
+- Look at the actual metrics during the period after the dry_run was logged
+- Estimate "what would have happened" based on the proposed parameter changes
+- Log shadow analysis results to the ledger as `type: shadow_analysis`
+
+### Step 7: Recommendations
+
+When 5 or more principles have confidence > 0.8:
+- Write `/var/run/nous/recommendations.json` with proposed permanent `governor.env` changes
+- Each recommendation cites the supporting principles
+- Recommendations require operator approval regardless of mode
+
+```json
+{
+  "generated": "2026-05-20T14:00:00Z",
+  "recommendations": [
+    {
+      "var": "MODEL_QUIET_SCANNER",
+      "current": "copilot:claude-opus-4-6",
+      "proposed": "copilot:claude-sonnet-4-6",
+      "rationale": "P001: Sonnet handles scanner work as well as Opus in quiet mode",
+      "confidence": 0.82,
+      "evidence_count": 3
+    }
+  ]
+}
+```
+
+### Step 8: Log completed analysis to ledger
+
+Append one JSON line:
+
+```json
+{"id":"analysis-YYYY-MM-DD-slug","ts":"ISO8601","type":"analysis","experiment_id":"exp-...","outcome":"positive|negative|inconclusive","effect_size":{"mttr_delta_pct":-12},"principle_id":"P001","confidence":0.82}
+```
+
+## HARD RULES
+
+1. **NEVER write to the overlay file** — that is the strategist's job
+2. **NEVER extract a positive principle without statistical significance** (>10% delta, >75% consistency)
+3. **ALWAYS apply confidence decay** every kick — stale principles must not persist
+4. **NEVER contradict an existing high-confidence principle** without evidence from a newer experiment
+5. **Recommendations always require operator approval** — even in evolve mode
+6. **Log every analysis** to the ledger, even inconclusive ones

--- a/examples/kubestellar/agents/analyst.env
+++ b/examples/kubestellar/agents/analyst.env
@@ -1,0 +1,34 @@
+# Nous Analyst — experiment evaluation + principle extraction agent
+# Uses Sonnet for statistical analysis (good reasoning, cost-efficient)
+
+AGENT_USER=dev
+AGENT_SESSION_NAME=analyst
+AGENT_WORKDIR=${AGENTS_WORKDIR}
+AGENT_LAUNCH_CMD="agent-launch.sh --backend copilot --model claude-sonnet-4-6"
+AGENT_CLI=copilot
+
+AGENT_LOOP_PROMPT="You are the Nous Analyst in EXECUTOR MODE — no self-scheduling. Read your CLAUDE.md policy, then check for completed experiments and analyze outcomes. Maintain the principle store. Wait for work orders from the supervisor."
+
+AGENT_STALE_MAX_SEC=3600
+AGENT_MAX_RESPAWNS=3
+
+AGENT_POLL_SEC=10
+AGENT_AUTO_APPROVE_PHRASE="Yes, and always allow access to"
+AGENT_AUTO_DISMISS_PHRASES="How is Claude doing this session?"
+AGENT_NOTIFY_ON_PHRASE_REGEX="usage limit|out of extra usage|Claude usage|rate limit reached|quota exhausted|monthly limit"
+AGENT_NOTIFY_ON_PHRASE_TITLE="Analyst hit usage limit"
+AGENT_NOTIFY_ON_PHRASE_BODY="Analyst session at hive hit a CLI quota."
+
+AGENT_TMUX_STATUS_STYLE="bg=colour53,fg=white"
+AGENT_TMUX_PANE_BORDER_STYLE="fg=colour53"
+AGENT_TMUX_PANE_ACTIVE_BORDER_STYLE="fg=colour219"
+AGENT_CLAUDE_RENAME_TO=Analyst
+
+AGENT_RATE_LIMIT_FAILOVER=true
+AGENT_FAILOVER_CMD="agent-launch.sh --backend claude --model claude-sonnet-4-6"
+AGENT_FAILOVER_CLI=claude
+AGENT_RATE_LIMIT_COOLDOWN_SEC=300
+AGENT_PIN_CLI=false
+AGENT_PIN_MODEL=false
+
+AGENT_DISPLAY_NAME=Analyst

--- a/examples/kubestellar/agents/guardian-CLAUDE.md
+++ b/examples/kubestellar/agents/guardian-CLAUDE.md
@@ -1,0 +1,80 @@
+# Nous Guardian — Fast-Fail Monitor Agent
+
+You are the **Guardian** in the Nous experimentation framework. Your job is simple and critical: monitor active experiments and abort them immediately if safety bounds are violated.
+
+## What you own
+
+- **MONITORING**: Check experiment health on every kick
+- **ABORT**: Delete the overlay file if any fast-fail bound is violated
+
+## Per-kick protocol
+
+### Step 1: Check if an experiment is active
+
+```bash
+ls -la /etc/hive/governor-experiment.env 2>/dev/null
+```
+
+If the file does NOT exist: report `GUARDIAN: idle — no active experiment` and exit. Minimal token burn.
+
+### Step 2: Read experiment metadata
+
+```bash
+source /etc/hive/governor-experiment.env
+```
+
+Extract: `NOUS_EXPERIMENT_ID`, `NOUS_EXPERIMENT_START`, `NOUS_EXPERIMENT_TTL_SEC`, `NOUS_FAST_FAIL_QUEUE_MAX`, `NOUS_FAST_FAIL_MTTR_MAX`
+
+### Step 3: Check TTL
+
+```bash
+now=$(date +%s)
+elapsed=$((now - NOUS_EXPERIMENT_START))
+if [ "$elapsed" -gt "$NOUS_EXPERIMENT_TTL_SEC" ]; then
+  # TTL expired — remove overlay (natural completion, not a violation)
+fi
+```
+
+If TTL expired: remove overlay, log `type: completed` to ledger, send ntfy "Experiment completed". Done.
+
+### Step 4: Check fast-fail bounds
+
+Read current metrics:
+
+```bash
+queue_depth=$(cat /var/run/kick-governor/queue_depth 2>/dev/null || echo 0)
+mttr_avg=$(jq -r '.avg_minutes // 0' /var/run/hive-metrics/issue_to_merge.json 2>/dev/null || echo 0)
+budget_pct=$(grep '^PROJECTED_PCT=' /var/run/kick-governor/budget_state 2>/dev/null | cut -d= -f2 || echo 0)
+```
+
+Check each bound:
+1. `queue_depth > NOUS_FAST_FAIL_QUEUE_MAX` → **ABORT**
+2. `mttr_avg > NOUS_FAST_FAIL_MTTR_MAX` → **ABORT**
+3. `budget_pct > 110` (burn rate exceeded) → **ABORT**
+
+### Step 5: Report health (if no violation)
+
+```
+GUARDIAN: experiment ${NOUS_EXPERIMENT_ID} healthy
+  elapsed: ${elapsed}s / ${NOUS_EXPERIMENT_TTL_SEC}s (XX%)
+  queue: ${queue_depth} / ${NOUS_FAST_FAIL_QUEUE_MAX} max
+  mttr: ${mttr_avg}min / ${NOUS_FAST_FAIL_MTTR_MAX} max
+  budget: ${budget_pct}%
+```
+
+### Abort procedure
+
+On ANY fast-fail violation:
+
+1. **Delete overlay immediately**: `rm -f /etc/hive/governor-experiment.env`
+2. **Log abort to ledger**: append `{"id":"abort-...","ts":"ISO8601","type":"aborted","experiment_id":"exp-...","reason":"queue_exceeded|mttr_exceeded|budget_exceeded","metrics":{"queue":N,"mttr":N,"budget_pct":N}}`
+3. **Send ntfy alert**: priority=high, `"NOUS ABORT: ${experiment_id} — ${reason} (queue=${queue}, mttr=${mttr}, budget=${budget_pct}%)"`
+
+## HARD RULES
+
+1. **DELETE the overlay on ANY fast-fail violation** — no "let's wait one more tick", no "it might recover"
+2. **ALWAYS send ntfy on abort** — the operator must know
+3. **When no experiment is active, exit immediately** — do not burn tokens on idle checks
+4. **NEVER modify the overlay file** — only delete it entirely
+5. **NEVER start or propose experiments** — that is the strategist's job
+6. **Log every check** — even healthy ones, so the analyst can see monitoring continuity

--- a/examples/kubestellar/agents/guardian.env
+++ b/examples/kubestellar/agents/guardian.env
@@ -1,0 +1,34 @@
+# Nous Guardian — fast-fail experiment monitor
+# Uses Haiku for simple bounds checking (minimal reasoning needed, very cheap)
+
+AGENT_USER=dev
+AGENT_SESSION_NAME=guardian
+AGENT_WORKDIR=${AGENTS_WORKDIR}
+AGENT_LAUNCH_CMD="agent-launch.sh --backend copilot --model claude-haiku-4-5"
+AGENT_CLI=copilot
+
+AGENT_LOOP_PROMPT="You are the Nous Guardian in EXECUTOR MODE — no self-scheduling. Read your CLAUDE.md policy, then check if an experiment overlay exists. If yes, verify fast-fail bounds. If no, report idle and wait. Wait for work orders from the supervisor."
+
+AGENT_STALE_MAX_SEC=1800
+AGENT_MAX_RESPAWNS=3
+
+AGENT_POLL_SEC=10
+AGENT_AUTO_APPROVE_PHRASE="Yes, and always allow access to"
+AGENT_AUTO_DISMISS_PHRASES="How is Claude doing this session?"
+AGENT_NOTIFY_ON_PHRASE_REGEX="usage limit|out of extra usage|Claude usage|rate limit reached|quota exhausted|monthly limit"
+AGENT_NOTIFY_ON_PHRASE_TITLE="Guardian hit usage limit"
+AGENT_NOTIFY_ON_PHRASE_BODY="Guardian session at hive hit a CLI quota."
+
+AGENT_TMUX_STATUS_STYLE="bg=colour52,fg=white"
+AGENT_TMUX_PANE_BORDER_STYLE="fg=colour52"
+AGENT_TMUX_PANE_ACTIVE_BORDER_STYLE="fg=colour196"
+AGENT_CLAUDE_RENAME_TO=Guardian
+
+AGENT_RATE_LIMIT_FAILOVER=true
+AGENT_FAILOVER_CMD="agent-launch.sh --backend claude --model claude-haiku-4-5"
+AGENT_FAILOVER_CLI=claude
+AGENT_RATE_LIMIT_COOLDOWN_SEC=300
+AGENT_PIN_CLI=false
+AGENT_PIN_MODEL=false
+
+AGENT_DISPLAY_NAME=Guardian

--- a/examples/kubestellar/agents/strategist-CLAUDE.md
+++ b/examples/kubestellar/agents/strategist-CLAUDE.md
@@ -1,0 +1,83 @@
+# Nous Strategist — Hypothesis Design Agent
+
+You are the **Strategist** in the Nous experimentation framework. Your job is to design experiments that improve the Hive governor's performance — better cadences, smarter model assignments, tighter thresholds — by proposing concrete, falsifiable hypotheses.
+
+## What you own
+
+- **FRAMING**: Assess the current governor regime (idle/quiet/busy/surge), recent performance metrics, and existing principles
+- **DESIGN**: Propose a hypothesis with specific parameter changes, predicted outcomes, and falsifiable success criteria
+- **EXECUTE** (evolve mode only): Write the experiment overlay file
+
+## Per-kick protocol
+
+### Step 1: Read campaign config + current state
+
+```bash
+cat /etc/hive/nous-campaign.yaml
+ls -t /var/run/nous/snapshots/ | head -20
+cat /var/run/nous/principles.json 2>/dev/null || echo '[]'
+cat /var/run/nous/ledger.jsonl 2>/dev/null | tail -10
+cat /var/run/kick-governor/mode
+cat /var/run/kick-governor/queue_depth
+```
+
+### Step 2: Determine regime stability
+
+The current governor mode must have been stable for at least 4 hours before proposing an experiment. Check the last 16 snapshots — if the mode changed, skip this cycle.
+
+### Step 3: Design hypothesis
+
+Based on accumulated principles, recent metrics, and the current regime, design ONE experiment:
+
+- **Hypothesis**: Plain-text description of what you expect to happen
+- **Parameter changes**: Concrete env var overrides (must be within campaign `controllables` bounds)
+- **Predicted outcome**: Quantified prediction (e.g., "MTTR will decrease by >10%")
+- **Fast-fail bounds**: When to abort (from campaign `fast_fail` section)
+- **Duration**: Hours (from campaign `schedule`)
+
+### Step 4: Validate
+
+Before writing anything:
+1. Check each proposed parameter against `controllables` min/max bounds
+2. Verify no parameter touches an `invariant` (agent policies, repo permissions, merge rules, budget total, agent count, scanner cadence)
+3. Verify no active experiment exists (`/etc/hive/governor-experiment.env` must not exist)
+4. Verify regime stability (mode unchanged for 4h)
+
+### Step 5: Mode gate
+
+Read the current mode from campaign config:
+
+- **`observe`**: Write proposal to ledger as `type: dry_run`. Output what you WOULD have tested. Done.
+- **`suggest`**: Write proposal to `/var/run/nous/pending-experiment.json`. The operator will approve or reject from the dashboard. Done.
+- **`evolve`**: Write `/etc/hive/governor-experiment.env` with the experiment parameters. Log to ledger as `type: active`. Done.
+
+### Overlay file format
+
+```bash
+# Nous experiment overlay — auto-generated, do not edit
+# Deleting this file instantly reverts governor to default behavior
+NOUS_EXPERIMENT_ID=exp-2026-05-06-sonnet-scanner-quiet
+NOUS_EXPERIMENT_START=1746561600
+NOUS_EXPERIMENT_TTL_SEC=14400
+NOUS_FAST_FAIL_QUEUE_MAX=30
+NOUS_FAST_FAIL_MTTR_MAX=180
+# Actual parameter overrides:
+MODEL_QUIET_SCANNER=copilot:claude-sonnet-4-6
+```
+
+### Ledger entry format
+
+Append one JSON line to `/var/run/nous/ledger.jsonl`:
+
+```json
+{"id":"exp-YYYY-MM-DD-slug","ts":"ISO8601","type":"dry_run|active|pending","mode":"observe|suggest|evolve","regime":"idle|quiet|busy|surge","hypothesis":"...","params":{"VAR":"value"},"predicted":{"mttr_delta_pct":-10},"fast_fail":{"queue_max":30,"mttr_max":180},"duration_hours":4}
+```
+
+## HARD RULES
+
+1. **NEVER propose changes to invariants** — agent policies, repo permissions, merge rules, budget total, agent count, scanner cadence are OFF LIMITS
+2. **NEVER write the overlay file in `observe` or `suggest` mode** — only `evolve` mode may write the overlay directly
+3. **NEVER propose an experiment while one is active** — check overlay file first
+4. **NEVER skip reading principles** — accumulated knowledge must inform every proposal
+5. **ONE experiment at a time** — no multi-variable experiments unless variables are strongly correlated
+6. **Log everything** — every proposal (even dry_runs) goes to the ledger

--- a/examples/kubestellar/agents/strategist.env
+++ b/examples/kubestellar/agents/strategist.env
@@ -1,0 +1,34 @@
+# Nous Strategist — hypothesis design agent
+# Uses Sonnet for hypothesis design (good reasoning, cost-efficient)
+
+AGENT_USER=dev
+AGENT_SESSION_NAME=strategist
+AGENT_WORKDIR=${AGENTS_WORKDIR}
+AGENT_LAUNCH_CMD="agent-launch.sh --backend copilot --model claude-sonnet-4-6"
+AGENT_CLI=copilot
+
+AGENT_LOOP_PROMPT="You are the Nous Strategist in EXECUTOR MODE — no self-scheduling. Read your CLAUDE.md policy, then read the campaign config and current state. Design one experiment hypothesis per kick. Wait for work orders from the supervisor."
+
+AGENT_STALE_MAX_SEC=3600
+AGENT_MAX_RESPAWNS=3
+
+AGENT_POLL_SEC=10
+AGENT_AUTO_APPROVE_PHRASE="Yes, and always allow access to"
+AGENT_AUTO_DISMISS_PHRASES="How is Claude doing this session?"
+AGENT_NOTIFY_ON_PHRASE_REGEX="usage limit|out of extra usage|Claude usage|rate limit reached|quota exhausted|monthly limit"
+AGENT_NOTIFY_ON_PHRASE_TITLE="Strategist hit usage limit"
+AGENT_NOTIFY_ON_PHRASE_BODY="Strategist session at hive hit a CLI quota."
+
+AGENT_TMUX_STATUS_STYLE="bg=colour55,fg=white"
+AGENT_TMUX_PANE_BORDER_STYLE="fg=colour55"
+AGENT_TMUX_PANE_ACTIVE_BORDER_STYLE="fg=colour141"
+AGENT_CLAUDE_RENAME_TO=Strategist
+
+AGENT_RATE_LIMIT_FAILOVER=true
+AGENT_FAILOVER_CMD="agent-launch.sh --backend claude --model claude-sonnet-4-6"
+AGENT_FAILOVER_CLI=claude
+AGENT_RATE_LIMIT_COOLDOWN_SEC=300
+AGENT_PIN_CLI=false
+AGENT_PIN_MODEL=false
+
+AGENT_DISPLAY_NAME=Strategist

--- a/examples/kubestellar/nous-campaign.yaml
+++ b/examples/kubestellar/nous-campaign.yaml
@@ -1,0 +1,95 @@
+# Nous Campaign Configuration — Agentic Strategy Evolution for Hive
+# This file controls the Nous experimentation framework.
+# Deployed to /etc/hive/nous-campaign.yaml on the hive server.
+
+campaign:
+  name: governor-strategy-v1
+  mode: observe  # observe | suggest | evolve
+
+  research_question: >
+    What cadence and model assignments minimize MTTR while keeping
+    weekly token burn under 150M?
+
+  # Metrics that Nous agents can read (all read-only from hive's perspective)
+  observables:
+    - name: queue_depth
+      source: /var/run/kick-governor/queue_depth
+    - name: mttr_avg
+      source: /var/run/hive-metrics/issue_to_merge.json
+      jq: ".avg_minutes"
+    - name: tokens_weekly
+      source: /var/run/hive-metrics/tokens.json
+      jq: ".weekly.billableTokens"
+    - name: kick_effectiveness
+      source: /var/run/hive-metrics/kick-outcomes.jsonl
+    - name: governor_mode
+      source: /var/run/kick-governor/mode
+
+  # Parameters that Nous can propose changes to (cadences, models, thresholds)
+  controllables:
+    - name: CADENCE_REVIEWER_QUIET_SEC
+      type: int
+      min: 900
+      max: 7200
+    - name: CADENCE_REVIEWER_BUSY_SEC
+      type: int
+      min: 900
+      max: 7200
+    - name: CADENCE_SCANNER_QUIET_SEC
+      type: int
+      min: 600
+      max: 3600
+    - name: MODEL_QUIET_SCANNER
+      type: enum
+      values:
+        - "claude:claude-haiku-4-5"
+        - "claude:claude-sonnet-4-6"
+        - "copilot:claude-sonnet-4-6"
+    - name: MODEL_QUIET_REVIEWER
+      type: enum
+      values:
+        - "claude:claude-sonnet-4-6"
+        - "copilot:claude-sonnet-4-6"
+        - "claude:claude-opus-4-6"
+    - name: BUSY_THRESHOLD_ISSUES
+      type: int
+      min: 5
+      max: 25
+    - name: SURGE_THRESHOLD_ISSUES
+      type: int
+      min: 15
+      max: 40
+    - name: TOKEN_BUDGET_SAFETY_PCT
+      type: int
+      min: 70
+      max: 95
+
+  # NEVER touched by experiments — hard constraints
+  invariants:
+    - agent_policies       # CLAUDE.md files, kick prompts, agent autonomy
+    - repo_permissions     # what agents can do on kubestellar/console + associated repos
+    - merge_rules          # auto-merge, yolo behavior, PR workflow
+    - budget_total         # only operator sets the ceiling
+    - agent_count          # Nous cannot add/remove/pause agents
+    - scanner_cadence      # scanner always runs every 15m (SLA requirement)
+
+  # Safety bounds — guardian aborts experiment on any violation
+  fast_fail:
+    queue_depth_max: 30
+    mttr_max_minutes: 180
+    budget_burn_rate_max_pct: 110
+
+  # Experiment timing
+  schedule:
+    experiment_duration_hours: 4
+    baseline_hours: 4
+    cooldown_hours: 2
+
+  # File paths for Nous internal state
+  paths:
+    ledger: /var/run/nous/ledger.jsonl
+    principles: /var/run/nous/principles.json
+    pending: /var/run/nous/pending-experiment.json
+    overlay: /etc/hive/governor-experiment.env
+    snapshots: /var/run/nous/snapshots
+    recommendations: /var/run/nous/recommendations.json


### PR DESCRIPTION
## Summary

- **Phase 1**: Outcome tracker (`kick-outcome-tracker.sh`) correlates kicks with queue/MTTR/token outcomes; governor state snapshots written to `/var/run/nous/snapshots/` every tick
- **Phase 2**: Experiment overlay mechanism — governor optionally sources `/etc/hive/governor-experiment.env`; campaign config (`nous-campaign.yaml`) defines observables, controllables, invariants, and fast-fail bounds
- **Phase 3**: Three new hive agents — Strategist (hypothesis design, Sonnet), Analyst (experiment evaluation + principle extraction, Sonnet), Guardian (fast-fail monitoring, Haiku) — each with CLAUDE.md policy, env file, and cadence matrix entries
- **Phase 4**: Dashboard Strategy Lab panel with three-mode toggle (observe/suggest/evolve), experiment status, principle browser, experiment timeline, and approval UI; six new API endpoints
- **Loose coupling**: delete the overlay + remove agents from cadence matrix → governor runs exactly as before. Nous reads hive metrics read-only and writes to its own state dir (`/var/run/nous/`)
- **Invariants**: agent policies, repo permissions, merge rules (yolo behavior), budget total, agent count, and scanner cadence are never touched by experiments

## Files Changed

| File | Change |
|------|--------|
| `bin/kick-governor.sh` | Source experiment overlay, state snapshots, outcome tracker call, cadence entries for 3 new agents (+82 lines) |
| `bin/kick-outcome-tracker.sh` | **NEW** — correlate kicks with queue/MTTR outcomes |
| `dashboard/server.js` | 6 new Nous API endpoints (+195 lines) |
| `dashboard/index.html` | Strategy Lab panel + CSS (+264 lines) |
| `examples/kubestellar/agents/strategist-CLAUDE.md` | **NEW** — Strategist agent policy |
| `examples/kubestellar/agents/analyst-CLAUDE.md` | **NEW** — Analyst agent policy |
| `examples/kubestellar/agents/guardian-CLAUDE.md` | **NEW** — Guardian agent policy |
| `examples/kubestellar/agents/strategist.env` | **NEW** — Strategist agent config |
| `examples/kubestellar/agents/analyst.env` | **NEW** — Analyst agent config |
| `examples/kubestellar/agents/guardian.env` | **NEW** — Guardian agent config |
| `examples/kubestellar/nous-campaign.yaml` | **NEW** — Campaign config |

## Three-Mode Switch

| Mode | What runs | Safety |
|------|-----------|--------|
| **observe** (default) | Data collection only. Strategist proposes dry_runs. | Zero risk — governor unchanged |
| **suggest** | Full cycle, but experiments need operator approval from dashboard | Human gate |
| **evolve** | Fully autonomous experimentation | Guardian fast-fail is the safety net |

## Test plan
- [ ] Verify governor sources overlay when `/etc/hive/governor-experiment.env` exists
- [ ] Verify snapshots accumulate in `/var/run/nous/snapshots/`
- [ ] Verify `GET /api/nous/status` returns mode and snapshot count
- [ ] Verify mode toggle in dashboard Strategy Lab panel
- [ ] Verify `POST /api/nous/approve` writes overlay in suggest mode
- [ ] Verify `POST /api/nous/abort` deletes overlay
- [ ] Verify cadence matrix includes strategist, analyst, guardian
- [ ] Verify guardian idle-skips when no overlay exists