### PR TITLE
Match in-focus card summary font to columnar cards

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -230,30 +230,30 @@
       height: calc(1.5em * 20 + 28px); max-height: none; overflow-y: auto;
       resize: vertical;
       font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
-      font-size: 0.78rem;
+      font-size: 0.65rem;
     }
     .sum-tool {
       display: flex; align-items: center; gap: 6px;
       padding: 6px 10px; margin: 6px 0 2px; border-radius: 6px;
       background: #eef2ff; border-left: 3px solid #6366f1;
-      font-weight: 600; font-size: 0.78rem; color: #4338ca;
+      font-weight: 600; font-size: 0.65rem; color: #4338ca;
     }
     .sum-tool .sum-tool-type {
-      font-size: 0.6rem; text-transform: uppercase; font-weight: 700;
+      font-size: 0.5rem; text-transform: uppercase; font-weight: 700;
       background: #6366f1; color: #fff; padding: 1px 5px; border-radius: 3px;
     }
     .sum-cmd {
       font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
-      font-size: 0.72rem; color: #475569; padding: 4px 10px 4px 14px;
+      font-size: 0.6rem; color: #475569; padding: 4px 10px 4px 14px;
       border-left: 2px solid #cbd5e1; margin: 0; line-height: 1.4;
       word-break: break-all;
     }
     .sum-tree {
-      font-size: 0.7rem; color: #9ca3af; padding: 1px 10px 1px 20px;
+      font-size: 0.58rem; color: #9ca3af; padding: 1px 10px 1px 20px;
       font-style: italic;
     }
     .sum-text {
-      padding: 3px 0; font-size: 0.82rem; color: #374151; line-height: 1.5;
+      padding: 3px 0; font-size: 0.65rem; color: #374151; line-height: 1.4;
     }
     .sum-table-wrap {
       overflow-x: auto; margin: 4px 0;
@@ -440,7 +440,7 @@
     .value.idle { color: var(--muted); }
     .value.copilot { color: var(--cyan); }
     .value.claude { color: var(--purple); }
-    .doing { font-size: 0.45rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: pre-wrap; line-height: 1.3; min-height: 5.6em; width: 100%; }
+    .doing { font-size: 0.65rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: pre-wrap; line-height: 1.3; min-height: 5.6em; width: 100%; }
     .summary-age { display: inline-block; font-size: 0.6rem; font-style: normal; border-radius: 3px; padding: 1px 5px; margin-right: 5px; vertical-align: middle; white-space: nowrap; }
     .summary-age.age-recent { background: rgba(210,153,34,0.15); color: #d29922; border: 1px solid rgba(210,153,34,0.3); }
     .summary-age.age-stale  { background: rgba(248,81,73,0.15);  color: #f85149; border: 1px solid rgba(248,81,73,0.3); }


### PR DESCRIPTION
Revert columnar .doing to 0.65rem, reduce in-focus detail summary and sub-elements to match.