### PR TITLE
Use venv for Nous framework on Debian

### DIFF
--- a/bin/nous-install.sh
+++ b/bin/nous-install.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 NOUS_DIR="${NOUS_DIR:-/opt/nous}"
+NOUS_VENV="${NOUS_DIR}/venv"
 NOUS_RUN_DIR="${NOUS_RUN_DIR:-/var/run/nous}"
 NOUS_REPO="https://github.com/AI-native-Systems-Research/agentic-strategy-evolution"
 
@@ -14,10 +15,20 @@ else
 fi
 
 cd "$NOUS_DIR"
-pip3 install -e . 2>&1
+
+if [ ! -d "$NOUS_VENV" ]; then
+  echo "Creating virtual environment at $NOUS_VENV"
+  python3 -m venv "$NOUS_VENV"
+fi
+
+echo "Installing Nous into venv"
+"$NOUS_VENV/bin/pip" install -e . 2>&1
 
 mkdir -p "$NOUS_RUN_DIR"/{governor,repo,snapshots}
 chown -R dev:dev "$NOUS_RUN_DIR" "$NOUS_DIR"
 
 echo "Verifying installation…"
-python3 -c "from run_campaign import run_campaign; print('Nous framework installed OK')"
+"$NOUS_VENV/bin/python3" -c "from run_campaign import run_campaign; print('Nous framework installed OK')"
+
+echo ""
+echo "Use $NOUS_VENV/bin/python3 to run Nous scripts"

--- a/bin/nous-runner.sh
+++ b/bin/nous-runner.sh
@@ -4,6 +4,7 @@
 set -euo pipefail
 
 NOUS_DIR="${NOUS_DIR:-/opt/nous}"
+NOUS_PYTHON="${NOUS_DIR}/venv/bin/python3"
 NOUS_RUN_DIR="${NOUS_RUN_DIR:-/var/run/nous}"
 CAMPAIGN_PATH="${NOUS_CAMPAIGN_PATH:-/etc/hive/nous-campaign.yaml}"
 HIVE_METRICS_DIR="${HIVE_METRICS_DIR:-/var/run/hive-metrics}"
@@ -150,7 +151,7 @@ echo "[nous-runner] invoking run_campaign.py (auto_approve=$AUTO_APPROVE, timeou
 NOUS_HIVE_MODE="$EFFECTIVE_MODE" \
 NOUS_HIVE_SCOPE="$EFFECTIVE_SCOPE" \
 NOUS_GATE_SCRIPT="$GATE_SCRIPT" \
-python3 "$NOUS_DIR/run_campaign.py" \
+"$NOUS_PYTHON" "$NOUS_DIR/run_campaign.py" \
   --campaign "$CAMPAIGN_CONFIG" \
   --work-dir "$WORK_DIR" \
   --max-iterations 1 \


### PR DESCRIPTION
## Summary
- Debian's externally-managed-environment blocks system-wide `pip install`
- Create a venv at `/opt/nous/venv` for Nous dependencies
- Use `$NOUS_PYTHON` (venv python) for `run_campaign.py` invocation in `nous-runner.sh`

## Test plan
- [ ] Run `sudo bash /tmp/hive/bin/nous-install.sh` on server
- [ ] Verify `from run_campaign import run_campaign` succeeds with venv python

🤖 Generated with [Claude Code](https://claude.com/claude-code)