### PR TITLE
Fix gauge tick positioning

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -641,9 +641,9 @@
     }
     .temp-gauge-ticks {
       position: absolute; top: 0; left: 0; right: 0; bottom: 0;
-      display: flex; align-items: center;
-      padding: 0 4px; font-size: 0.55rem; color: rgba(255,255,255,0.6); pointer-events: none;
+      font-size: 0.55rem; color: rgba(255,255,255,0.6); pointer-events: none;
     }
+    .temp-gauge-ticks span { position: absolute; top: 50%; transform: translate(-50%, -50%); }
     .temp-gauge-needle {
       position: absolute; top: -4px; width: 4px; height: 32px;
       background: #fff; border-radius: 2px;
@@ -1553,7 +1553,7 @@
           <div class="oc-gov-gauge">
             <div class="temp-gauge-track" style="background:linear-gradient(to right, #238636 0%, #238636 ${OC_THRESH_QUIET/OC_GAUGE_MAX*100}%, #1f6feb ${OC_THRESH_QUIET/OC_GAUGE_MAX*100}%, #1f6feb ${OC_THRESH_BUSY/OC_GAUGE_MAX*100}%, #d29922 ${OC_THRESH_BUSY/OC_GAUGE_MAX*100}%, #d29922 ${OC_THRESH_SURGE/OC_GAUGE_MAX*100}%, #f85149 ${OC_THRESH_SURGE/OC_GAUGE_MAX*100}%, #f85149 100%)">
               <div class="temp-gauge-glow" style="width:100%"></div>
-              <div class="temp-gauge-ticks"><span style="position:absolute;left:0">0</span><span style="position:absolute;left:${OC_THRESH_QUIET/OC_GAUGE_MAX*100}%;transform:translateX(-50%)">${OC_THRESH_QUIET}</span><span style="position:absolute;left:${OC_THRESH_BUSY/OC_GAUGE_MAX*100}%;transform:translateX(-50%)">${OC_THRESH_BUSY}</span><span style="position:absolute;left:${OC_THRESH_SURGE/OC_GAUGE_MAX*100}%;transform:translateX(-50%)">${OC_THRESH_SURGE}</span><span style="position:absolute;right:0">${OC_GAUGE_MAX}</span></div>
+              <div class="temp-gauge-ticks"><span style="left:2%;transform:translate(0,-50%)">0</span><span style="left:${OC_THRESH_QUIET/OC_GAUGE_MAX*100}%">${OC_THRESH_QUIET}</span><span style="left:${OC_THRESH_BUSY/OC_GAUGE_MAX*100}%">${OC_THRESH_BUSY}</span><span style="left:${OC_THRESH_SURGE/OC_GAUGE_MAX*100}%">${OC_THRESH_SURGE}</span><span style="left:98%;transform:translate(-100%,-50%)">${OC_GAUGE_MAX}</span></div>
               <div class="temp-gauge-needle" style="left:${gaugePct}%" data-val="${govActionable}"></div>
             </div>
             <div class="temp-gauge-labels">


### PR DESCRIPTION
## Summary
- Tick numbers were stacking on the left because flex layout ignored absolute positioning
- Remove `display: flex` from `.temp-gauge-ticks`, add per-span absolute positioning CSS
- Each tick's `left%` now matches the gradient color stop percentages

## Test plan
- [ ] Verify tick numbers (0, 5, 16, 30, 40) align with gauge color zone boundaries
- [ ] Verify numbers don't overlap or clip at edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)