### PR TITLE
Improve gauge tick number visibility

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -641,9 +641,9 @@
     }
     .temp-gauge-ticks {
       position: absolute; top: 0; left: 0; right: 0; bottom: 0;
-      font-size: 0.55rem; color: rgba(255,255,255,0.6); pointer-events: none;
+      font-size: 0.55rem; color: #fff; font-weight: 600; pointer-events: none;
     }
-    .temp-gauge-ticks span { position: absolute; top: 50%; transform: translate(-50%, -50%); }
+    .temp-gauge-ticks span { position: absolute; top: 50%; transform: translate(-50%, -50%); text-shadow: 0 1px 3px rgba(0,0,0,0.6); }
     .temp-gauge-needle {
       position: absolute; top: -4px; width: 4px; height: 32px;
       background: #fff; border-radius: 2px;


### PR DESCRIPTION
## Summary
- Tick numbers were faint white (`rgba(255,255,255,0.6)`) and disappeared on lighter zones
- Make them bold white with dark text-shadow for contrast on all colors

## Test plan
- [ ] Verify 0, 5, 16, 30, 40 are clearly visible on the gauge

🤖 Generated with [Claude Code](https://claude.com/claude-code)