### PR TITLE
fix: terminal links and send-message for all agents

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1584,7 +1584,7 @@
         </div>
         <div class="oc-detail-actions">
           <button class="btn-toggle ${isPaused ? 'paused' : isOff ? 'off' : 'running'}" onclick="toggleAgent('${a.name}', ${isPaused})">${isPaused ? '▶ resume' : isOff ? '▶ start' : '⏸ pause'}</button>
-          <a href="/api/terminal/${a.name}" target="_blank" class="terminal-link">▶ terminal</a>
+          <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link">▶ terminal</a>
           <button class="restart-btn" onclick="restartAgent('${a.name}')">↻ restart</button>
           <button class="config-gear" onclick="openConfigDialog('agent','${a.name}')" style="font-size:1rem;opacity:0.7">⚙️</button>
         </div>
@@ -1992,6 +1992,9 @@
       reviewer: 'reviewer',
       architect: 'architect',
       outreach: 'outreach',
+      strategist: 'strategist',
+      analyst: 'analyst',
+      guardian: 'guardian',
     };
     const TTYD_PORT = 7681;
 

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -697,6 +697,9 @@ const TMUX_SESSION = {
   architect: 'architect',
   outreach: 'outreach',
   supervisor: 'supervisor',
+  strategist: 'strategist',
+  analyst: 'analyst',
+  guardian: 'guardian',
 };
 
 // Control endpoints


### PR DESCRIPTION
## Summary
- Fix light mode terminal link: was `/api/terminal/:name` (404), now uses `terminalUrl()` pointing to ttyd
- Add strategist, analyst, guardian to `TMUX_SESSION` maps (server + client)
- Without this, send-message to those agents returned 400 and terminal links showed "Cannot GET"

## Test plan
- [ ] Click terminal link on any agent in light mode — should open ttyd
- [ ] Send a message to strategist/analyst/guardian — should succeed
- [ ] Send a message to outreach — should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)