### PR TITLE
feat: auto-detect agent restrictions from gh wrapper and policy

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3768,18 +3768,50 @@ function burnAreaChart() {
     }
 
     function renderAgentRestrictions(restrictions) {
-      const list = restrictions.map((r, i) =>
-        `<div class="config-list-item"><span>${esc(r)}</span><button class="remove-item" onclick="removeListItem('restrictions','list',${i})">✕</button></div>`
-      ).join('');
-      return `
-        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">Commands this agent is not allowed to execute (blacklist).</p>
-        <div class="config-list">
-          ${list || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">No restrictions configured</div>'}
-          <div class="config-list-add">
+      const sourceColors = { 'gh-wrapper': '#dc2626', policy: '#7c3aed', env: '#2563eb' };
+      const sourceLabels = { 'gh-wrapper': 'gh wrapper', policy: 'CLAUDE.md', env: 'env' };
+      const isObj = restrictions.length > 0 && typeof restrictions[0] === 'object';
+      const detected = isObj ? restrictions.filter(r => r.source !== 'env') : [];
+      const manual = isObj ? restrictions.filter(r => r.source === 'env') : restrictions;
+
+      let html = '<p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">Enforced restrictions detected from gh wrapper, CLAUDE.md policy, and manual overrides.</p>';
+
+      if (detected.length > 0) {
+        const grouped = {};
+        for (const r of detected) {
+          const src = r.source || 'unknown';
+          if (!grouped[src]) grouped[src] = [];
+          grouped[src].push(r);
+        }
+        for (const [src, rules] of Object.entries(grouped)) {
+          const color = sourceColors[src] || '#6b7280';
+          const label = sourceLabels[src] || src;
+          html += `<div style="margin-bottom:12px">`;
+          html += `<div style="font-size:0.7rem;font-weight:600;color:${color};margin-bottom:4px;text-transform:uppercase">${esc(label)}</div>`;
+          for (const r of rules) {
+            html += `<div style="font-size:0.78rem;padding:6px 8px;margin-bottom:4px;background:var(--bg);border-left:3px solid ${color};border-radius:0 4px 4px 0">`;
+            html += `<code style="font-size:0.75rem">${esc(r.cmd)}</code>`;
+            if (r.reason) html += `<div style="font-size:0.7rem;color:var(--muted);margin-top:2px">${esc(r.reason)}</div>`;
+            html += '</div>';
+          }
+          html += '</div>';
+        }
+      }
+
+      html += '<div style="margin-top:14px;border-top:1px solid var(--border);padding-top:12px">';
+      html += '<div style="font-size:0.7rem;font-weight:600;color:#2563eb;margin-bottom:4px;text-transform:uppercase">Manual overrides</div>';
+      const manualList = manual.map((r, i) => {
+        const text = typeof r === 'object' ? r.cmd : r;
+        return `<div class="config-list-item"><span>${esc(text)}</span><button class="remove-item" onclick="removeListItem('restrictions','list',${i})">✕</button></div>`;
+      }).join('');
+      html += '<div class="config-list">';
+      html += manualList || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">No manual restrictions</div>';
+      html += `<div class="config-list-add">
             <input type="text" id="cfg-restriction-input" placeholder="command pattern">
             <button onclick="addListItem('restrictions','list','cfg-restriction-input')">+ Add</button>
-          </div>
-        </div>`;
+          </div>`;
+      html += '</div></div>';
+      return html;
     }
 
     function renderAgentPrompts(prompt) {

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1257,6 +1257,53 @@ function deriveCli(launchCmd) {
   return 'claude';
 }
 
+const GH_WRAPPER_PATH = '/usr/local/bin/gh';
+let _ghWrapperRestrictions = null;
+let _ghWrapperMtime = 0;
+
+function parseGhWrapperRestrictions() {
+  try {
+    const stat = fs.statSync(GH_WRAPPER_PATH);
+    if (_ghWrapperRestrictions && stat.mtimeMs === _ghWrapperMtime) return _ghWrapperRestrictions;
+    const src = fs.readFileSync(GH_WRAPPER_PATH, 'utf8');
+    const rules = [];
+    if (/BLOCKED.*gh.*issue.*list/i.test(src)) rules.push({ cmd: 'gh issue list', reason: 'Use /var/run/hive-metrics/actionable.json', source: 'gh-wrapper' });
+    if (/BLOCKED.*gh.*pr.*list/i.test(src)) rules.push({ cmd: 'gh pr list', reason: 'Use /var/run/hive-metrics/actionable.json', source: 'gh-wrapper' });
+    if (/BLOCKED.*gh.*api.*issue.*listing/i.test(src)) rules.push({ cmd: 'gh api (issue/PR listing)', reason: 'Use /var/run/hive-metrics/actionable.json', source: 'gh-wrapper' });
+    if (/BLOCKED.*gh.*search/i.test(src)) rules.push({ cmd: 'gh search', reason: 'Enumeration disabled', source: 'gh-wrapper' });
+    _ghWrapperRestrictions = rules;
+    _ghWrapperMtime = stat.mtimeMs;
+    return rules;
+  } catch (_) { return []; }
+}
+
+function parsePolicyRestrictions(agentName) {
+  const rules = [];
+  try {
+    const policyPath = `${ENV_DIR}/${agentName}-CLAUDE.md`;
+    const src = fs.readFileSync(policyPath, 'utf8');
+    const lines = src.split('\n');
+    for (const line of lines) {
+      const trimmed = line.replace(/^\*+\s*/, '').trim();
+      if (!trimmed) continue;
+      if (/^(NEVER|DO NOT|MUST NOT|SHALL NOT)\b/i.test(trimmed) || /HARD RULE/i.test(trimmed)) {
+        const MAX_RULE_LEN = 200;
+        const text = trimmed.length > MAX_RULE_LEN ? trimmed.slice(0, MAX_RULE_LEN) + '...' : trimmed;
+        rules.push({ cmd: text, reason: '', source: 'policy' });
+      }
+    }
+  } catch (_) { /* policy file may not exist */ }
+  return rules;
+}
+
+function detectRestrictions(agentName, manualList) {
+  const all = [];
+  for (const m of manualList) all.push({ cmd: m, reason: '', source: 'env' });
+  all.push(...parseGhWrapperRestrictions());
+  all.push(...parsePolicyRestrictions(agentName));
+  return all;
+}
+
 app.get('/api/config/agent/:name', (req, res) => {
   const { name } = req.params;
   if (!ENABLED_AGENTS.includes(name)) {
@@ -1307,7 +1354,8 @@ app.get('/api/config/agent/:name', (req, res) => {
       postIdle: agentEnv.POST_IDLE_HOOKS ? agentEnv.POST_IDLE_HOOKS.split(',').filter(Boolean) : [],
     };
 
-    const restrictions = agentEnv.AGENT_RESTRICTIONS ? agentEnv.AGENT_RESTRICTIONS.split(',').filter(Boolean) : [];
+    const manualRestrictions = agentEnv.AGENT_RESTRICTIONS ? agentEnv.AGENT_RESTRICTIONS.split(',').filter(Boolean) : [];
+    const restrictions = detectRestrictions(name, manualRestrictions);
 
     let prompt = '';
     try {


### PR DESCRIPTION
## Summary
- Parses `/usr/local/bin/gh` wrapper for BLOCKED commands (gh issue list, gh pr list, gh api listing)
- Parses each agent's CLAUDE.md for NEVER/DO NOT/HARD RULE directives
- Restrictions tab now shows detected rules grouped by source (gh wrapper, CLAUDE.md policy) with color-coded badges
- Manual env-based overrides remain editable in a separate section

## Test plan
- [ ] Open scanner config → Restrictions tab shows gh wrapper blocks and policy rules
- [ ] Verify gh wrapper restrictions appear for all agents (they're global)
- [ ] Verify policy restrictions are agent-specific (each agent's CLAUDE.md)