### PR TITLE
feat: per-agent restriction files with dashboard CRUD

### DIFF
--- a/bin/agent-launch.sh
+++ b/bin/agent-launch.sh
@@ -30,6 +30,10 @@ elif [[ -f /usr/local/bin/hive-config.sh ]]; then
 fi
 unset GH_TOKEN
 
+# Export agent identity so the gh wrapper can load per-agent restrictions.
+# AGENT_SESSION_NAME is set by the supervisor from the agent's .env file.
+export HIVE_AGENT_ID="${AGENT_SESSION_NAME:-unknown}"
+
 # Source the centralized backend/model config
 BACKENDS_CONF="${SCRIPT_DIR}/../config/backends.conf"
 if [[ -f "$BACKENDS_CONF" ]]; then

--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -1,26 +1,65 @@
 #!/bin/bash
-# gh wrapper — enforces agent safety rules and injects App token.
+# gh wrapper — enforces per-agent + global restrictions and injects App token.
 # Installed at /usr/local/bin/gh (ahead of /usr/bin/gh in PATH).
-# Agents must read from /var/run/hive-metrics/actionable.json for listings.
+#
+# Per-agent restrictions live at /etc/hive/restrictions/<agent-id>.json.
+# The wrapper reads HIVE_AGENT_ID to find the right file.
+#
+# Restriction file format:
+#   { "rules": [
+#       { "pattern": "gh issue list*", "reason": "Use actionable.json", "enabled": true },
+#       { "pattern": "gh api repos/*/issues*", "reason": "Enumeration disabled", "enabled": true }
+#   ]}
+#
+# Pattern matching: the full command ("gh issue list --repo foo") is checked
+# against each pattern using bash glob matching. Patterns support * wildcards.
 
 set -euo pipefail
 
 REAL_GH="/usr/bin/gh"
+RESTRICTIONS_DIR="/etc/hive/restrictions"
 
 # Inject GitHub App token for agent gh calls (15k/hr vs PAT's 5k/hr).
-# Always read from the cache file written by gh-app-token.sh — this is
-# refreshed every 55 minutes and is always fresh, unlike HIVE_GITHUB_TOKEN
-# which is set at session launch and can go stale after token expiry (1hr).
-# This per-call injection ensures gh uses the App token without polluting the
-# agent's persistent env (Copilot CLI never calls this wrapper).
 GH_APP_TOKEN_CACHE="/var/run/hive-metrics/gh-app-token.cache"
 if [[ -f "$GH_APP_TOKEN_CACHE" ]]; then
   export GH_TOKEN="$(cat "$GH_APP_TOKEN_CACHE")"
 elif [[ -n "${HIVE_GITHUB_TOKEN:-}" ]]; then
-  # Fallback: session env var if cache file is missing
   export GH_TOKEN="$HIVE_GITHUB_TOKEN"
 fi
 
+# Build the full command string for pattern matching
+FULL_CMD="gh $*"
+
+# Check per-agent restrictions
+AGENT_ID="${HIVE_AGENT_ID:-}"
+if [[ -n "$AGENT_ID" ]]; then
+  RESTRICTION_FILE="${RESTRICTIONS_DIR}/${AGENT_ID}.json"
+  if [[ -f "$RESTRICTION_FILE" ]]; then
+    while IFS='|' read -r pattern reason; do
+      [[ -z "$pattern" ]] && continue
+      # Use bash extglob for pattern matching
+      # shellcheck disable=SC2254
+      case "$FULL_CMD" in
+        $pattern)
+          echo "⛔ BLOCKED: ${reason:-command not allowed for ${AGENT_ID}}" >&2
+          exit 1
+          ;;
+      esac
+    done < <(python3 -c "
+import json, sys
+try:
+    with open('${RESTRICTION_FILE}') as f:
+        data = json.load(f)
+    for r in data.get('rules', []):
+        if r.get('enabled', True):
+            print(r.get('pattern','') + '|' + r.get('reason',''))
+except Exception:
+    pass
+" 2>/dev/null)
+  fi
+fi
+
+# Global defaults — always enforced for all agents regardless of restriction file
 args=("$@")
 subcmd=""
 action=""
@@ -38,14 +77,14 @@ for arg in "${args[@]}"; do
   esac
 done
 
-# Block gh issue list and gh pr list
+# Block gh issue list and gh pr list (global)
 if { [ "$subcmd" = "issue" ] || [ "$subcmd" = "pr" ]; } && [ "$action" = "list" ]; then
   echo "⛔ BLOCKED: gh $subcmd list is disabled for agents." >&2
   echo "Read /var/run/hive-metrics/actionable.json instead." >&2
   exit 1
 fi
 
-# Block gh api calls that list issues or pulls (enumeration endpoints)
+# Block gh api calls that list issues or pulls (global)
 if [ "$subcmd" = "api" ]; then
   for arg in "${args[@]}"; do
     case "$arg" in

--- a/config/restrictions/README.md
+++ b/config/restrictions/README.md
@@ -1,0 +1,40 @@
+# Per-Agent Restrictions
+
+Each agent gets a `<agent-id>.json` file in `/etc/hive/restrictions/`.
+The agent ID is the env file stem (e.g., `scanner`, `reviewer`), not
+the display name — renaming an agent in the dashboard doesn't lose its
+restrictions.
+
+## File format
+
+```json
+{
+  "rules": [
+    {
+      "pattern": "gh issue list*",
+      "reason": "Use actionable.json instead",
+      "enabled": true
+    }
+  ]
+}
+```
+
+## Pattern matching
+
+The gh wrapper (`bin/gh-wrapper.sh`) matches the full command string
+(e.g., `gh issue list --repo kubestellar/console`) against each pattern
+using bash glob matching. Patterns support `*` wildcards.
+
+## How it works
+
+1. Agent launches via `agent-launch.sh`, which exports `HIVE_AGENT_ID`
+2. When the agent runs `gh`, the wrapper at `/usr/local/bin/gh` reads
+   `HIVE_AGENT_ID` and loads `/etc/hive/restrictions/<id>.json`
+3. Each enabled rule's pattern is matched against the command
+4. Global rules (hardcoded in the wrapper) apply to all agents regardless
+
+## Management
+
+Restrictions are managed via the dashboard's Restrictions tab in each
+agent's config dialog. Changes are written to the JSON file and take
+effect on the next `gh` invocation (no agent restart needed).

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3629,7 +3629,7 @@ function burnAreaChart() {
         case 'Cadences': return renderAgentCadences(d.cadences || {});
         case 'Pipeline': return renderAgentPipeline(d.pipeline || {});
         case 'Hooks': return renderAgentHooks(d.hooks || {});
-        case 'Restrictions': return renderAgentRestrictions(d.restrictions || []);
+        case 'Restrictions': return renderAgentRestrictions(d.restrictions || {});
         case 'Prompts': return renderAgentPrompts(d.prompt || '');
         default: return '';
       }
@@ -3768,49 +3768,49 @@ function burnAreaChart() {
     }
 
     function renderAgentRestrictions(restrictions) {
-      const sourceColors = { 'gh-wrapper': '#dc2626', policy: '#7c3aed', env: '#2563eb' };
-      const sourceLabels = { 'gh-wrapper': 'gh wrapper', policy: 'CLAUDE.md', env: 'env' };
-      const isObj = restrictions.length > 0 && typeof restrictions[0] === 'object';
-      const detected = isObj ? restrictions.filter(r => r.source !== 'env') : [];
-      const manual = isObj ? restrictions.filter(r => r.source === 'env') : restrictions;
+      const agentRules = (restrictions.agent || []);
+      const globalRules = (restrictions.global || []);
+      const policyRules = (restrictions.policy || []);
 
-      let html = '<p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">Enforced restrictions detected from gh wrapper, CLAUDE.md policy, and manual overrides.</p>';
-
-      if (detected.length > 0) {
-        const grouped = {};
-        for (const r of detected) {
-          const src = r.source || 'unknown';
-          if (!grouped[src]) grouped[src] = [];
-          grouped[src].push(r);
+      function renderSection(title, color, rules, opts) {
+        const editable = opts && opts.editable;
+        const icon = opts && opts.icon || '';
+        let h = `<div style="margin-bottom:16px">`;
+        h += `<div style="font-size:0.72rem;font-weight:600;color:${color};margin-bottom:6px;text-transform:uppercase;display:flex;align-items:center;gap:4px">${icon} ${esc(title)}</div>`;
+        if (rules.length === 0 && !editable) {
+          h += `<div style="font-size:0.75rem;color:var(--muted);padding:4px 0">None</div>`;
         }
-        for (const [src, rules] of Object.entries(grouped)) {
-          const color = sourceColors[src] || '#6b7280';
-          const label = sourceLabels[src] || src;
-          html += `<div style="margin-bottom:12px">`;
-          html += `<div style="font-size:0.7rem;font-weight:600;color:${color};margin-bottom:4px;text-transform:uppercase">${esc(label)}</div>`;
-          for (const r of rules) {
-            html += `<div style="font-size:0.78rem;padding:6px 8px;margin-bottom:4px;background:var(--bg);border-left:3px solid ${color};border-radius:0 4px 4px 0">`;
-            html += `<code style="font-size:0.75rem">${esc(r.cmd)}</code>`;
-            if (r.reason) html += `<div style="font-size:0.7rem;color:var(--muted);margin-top:2px">${esc(r.reason)}</div>`;
-            html += '</div>';
+        for (let i = 0; i < rules.length; i++) {
+          const r = rules[i];
+          h += `<div style="font-size:0.78rem;padding:6px 8px;margin-bottom:4px;background:var(--bg);border-left:3px solid ${color};border-radius:0 4px 4px 0;display:flex;align-items:start;gap:8px">`;
+          h += `<div style="flex:1">`;
+          h += `<code style="font-size:0.75rem">${esc(r.pattern || '')}</code>`;
+          if (r.reason) h += `<div style="font-size:0.7rem;color:var(--muted);margin-top:2px">${esc(r.reason)}</div>`;
+          h += '</div>';
+          if (editable) {
+            h += `<label style="font-size:0.7rem;display:flex;align-items:center;gap:4px;cursor:pointer;white-space:nowrap">`;
+            h += `<input type="checkbox" ${r.enabled !== false ? 'checked' : ''} onchange="toggleRestriction(${i}, this.checked)"> on</label>`;
+            h += `<button style="background:none;border:none;color:#dc2626;cursor:pointer;font-size:1rem;padding:0 4px" onclick="removeRestriction(${i})">✕</button>`;
           }
-          html += '</div>';
+          h += '</div>';
         }
+        if (editable) {
+          h += `<div style="display:flex;gap:6px;margin-top:6px">`;
+          h += `<input type="text" id="cfg-restriction-pattern" placeholder="glob pattern, e.g. gh issue list*" style="flex:2;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg)">`;
+          h += `<input type="text" id="cfg-restriction-reason" placeholder="reason (optional)" style="flex:1;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg)">`;
+          h += `<button onclick="addRestriction()" style="padding:6px 12px;border:1px solid var(--border);border-radius:4px;background:var(--card);color:var(--fg);cursor:pointer;font-size:0.78rem;white-space:nowrap">+ Add</button>`;
+          h += '</div>';
+        }
+        h += '</div>';
+        return h;
       }
 
-      html += '<div style="margin-top:14px;border-top:1px solid var(--border);padding-top:12px">';
-      html += '<div style="font-size:0.7rem;font-weight:600;color:#2563eb;margin-bottom:4px;text-transform:uppercase">Manual overrides</div>';
-      const manualList = manual.map((r, i) => {
-        const text = typeof r === 'object' ? r.cmd : r;
-        return `<div class="config-list-item"><span>${esc(text)}</span><button class="remove-item" onclick="removeListItem('restrictions','list',${i})">✕</button></div>`;
-      }).join('');
-      html += '<div class="config-list">';
-      html += manualList || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">No manual restrictions</div>';
-      html += `<div class="config-list-add">
-            <input type="text" id="cfg-restriction-input" placeholder="command pattern">
-            <button onclick="addListItem('restrictions','list','cfg-restriction-input')">+ Add</button>
-          </div>`;
-      html += '</div></div>';
+      let html = '<p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">Per-agent command restrictions enforced by the gh wrapper. Agent rules are editable; global and policy rules are read-only.</p>';
+      html += renderSection('Agent restrictions', '#2563eb', agentRules, { editable: true, icon: '🔧' });
+      html += '<div style="border-top:1px solid var(--border);padding-top:12px">';
+      html += renderSection('Global (all agents)', '#dc2626', globalRules, { icon: '🌐' });
+      html += renderSection('Policy (CLAUDE.md)', '#7c3aed', policyRules, { icon: '📋' });
+      html += '</div>';
       return html;
     }
 
@@ -4042,15 +4042,38 @@ function burnAreaChart() {
       }
     }
 
+    function addRestriction() {
+      const patternEl = document.getElementById('cfg-restriction-pattern');
+      const reasonEl = document.getElementById('cfg-restriction-reason');
+      const pattern = (patternEl ? patternEl.value.trim() : '');
+      const reason = (reasonEl ? reasonEl.value.trim() : '');
+      if (!pattern) return;
+      if (!_configState.data.restrictions) _configState.data.restrictions = { agent: [], global: [], policy: [] };
+      _configState.data.restrictions.agent.push({ pattern, reason, enabled: true });
+      markDirty('restrictions', 'rules', _configState.data.restrictions.agent);
+      if (patternEl) patternEl.value = '';
+      if (reasonEl) reasonEl.value = '';
+      renderConfigTab(_configState.tab);
+    }
+
+    function removeRestriction(index) {
+      if (!_configState.data.restrictions || !_configState.data.restrictions.agent) return;
+      _configState.data.restrictions.agent.splice(index, 1);
+      markDirty('restrictions', 'rules', _configState.data.restrictions.agent);
+      renderConfigTab(_configState.tab);
+    }
+
+    function toggleRestriction(index, enabled) {
+      if (!_configState.data.restrictions || !_configState.data.restrictions.agent) return;
+      _configState.data.restrictions.agent[index].enabled = enabled;
+      markDirty('restrictions', 'rules', _configState.data.restrictions.agent);
+    }
+
     function addListItem(section, key, inputId) {
       const input = document.getElementById(inputId);
       const val = input.value.trim();
       if (!val) return;
-      if (section === 'restrictions') {
-        if (!_configState.data.restrictions) _configState.data.restrictions = [];
-        _configState.data.restrictions.push(val);
-        markDirty('restrictions', 'list', _configState.data.restrictions);
-      } else if (section === 'hooks') {
+      if (section === 'hooks') {
         if (!_configState.data.hooks) _configState.data.hooks = {};
         if (!_configState.data.hooks[key]) _configState.data.hooks[key] = [];
         _configState.data.hooks[key].push(val);
@@ -4065,10 +4088,7 @@ function burnAreaChart() {
     }
 
     function removeListItem(section, key, index) {
-      if (section === 'restrictions') {
-        _configState.data.restrictions.splice(index, 1);
-        markDirty('restrictions', 'list', _configState.data.restrictions);
-      } else if (section === 'hooks') {
+      if (section === 'hooks') {
         _configState.data.hooks[key].splice(index, 1);
         markDirty('hooks', key, _configState.data.hooks[key]);
       } else if (section === 'labels') {

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1258,6 +1258,7 @@ function deriveCli(launchCmd) {
 }
 
 const GH_WRAPPER_PATH = '/usr/local/bin/gh';
+const RESTRICTIONS_DIR = '/etc/hive/restrictions';
 let _ghWrapperRestrictions = null;
 let _ghWrapperMtime = 0;
 
@@ -1267,10 +1268,10 @@ function parseGhWrapperRestrictions() {
     if (_ghWrapperRestrictions && stat.mtimeMs === _ghWrapperMtime) return _ghWrapperRestrictions;
     const src = fs.readFileSync(GH_WRAPPER_PATH, 'utf8');
     const rules = [];
-    if (/BLOCKED.*gh.*issue.*list/i.test(src)) rules.push({ cmd: 'gh issue list', reason: 'Use /var/run/hive-metrics/actionable.json', source: 'gh-wrapper' });
-    if (/BLOCKED.*gh.*pr.*list/i.test(src)) rules.push({ cmd: 'gh pr list', reason: 'Use /var/run/hive-metrics/actionable.json', source: 'gh-wrapper' });
-    if (/BLOCKED.*gh.*api.*issue.*listing/i.test(src)) rules.push({ cmd: 'gh api (issue/PR listing)', reason: 'Use /var/run/hive-metrics/actionable.json', source: 'gh-wrapper' });
-    if (/BLOCKED.*gh.*search/i.test(src)) rules.push({ cmd: 'gh search', reason: 'Enumeration disabled', source: 'gh-wrapper' });
+    if (/BLOCKED.*gh.*issue.*list/i.test(src)) rules.push({ pattern: 'gh issue list*', reason: 'Use /var/run/hive-metrics/actionable.json', source: 'global' });
+    if (/BLOCKED.*gh.*pr.*list/i.test(src)) rules.push({ pattern: 'gh pr list*', reason: 'Use /var/run/hive-metrics/actionable.json', source: 'global' });
+    if (/BLOCKED.*gh.*api.*issue.*listing/i.test(src)) rules.push({ pattern: 'gh api repos/*/issues*', reason: 'Use /var/run/hive-metrics/actionable.json', source: 'global' });
+    if (/BLOCKED.*gh.*search/i.test(src)) rules.push({ pattern: 'gh search*', reason: 'Enumeration disabled', source: 'global' });
     _ghWrapperRestrictions = rules;
     _ghWrapperMtime = stat.mtimeMs;
     return rules;
@@ -1289,19 +1290,34 @@ function parsePolicyRestrictions(agentName) {
       if (/^(NEVER|DO NOT|MUST NOT|SHALL NOT)\b/i.test(trimmed) || /HARD RULE/i.test(trimmed)) {
         const MAX_RULE_LEN = 200;
         const text = trimmed.length > MAX_RULE_LEN ? trimmed.slice(0, MAX_RULE_LEN) + '...' : trimmed;
-        rules.push({ cmd: text, reason: '', source: 'policy' });
+        rules.push({ pattern: text, reason: '', source: 'policy' });
       }
     }
   } catch (_) { /* policy file may not exist */ }
   return rules;
 }
 
-function detectRestrictions(agentName, manualList) {
-  const all = [];
-  for (const m of manualList) all.push({ cmd: m, reason: '', source: 'env' });
-  all.push(...parseGhWrapperRestrictions());
-  all.push(...parsePolicyRestrictions(agentName));
-  return all;
+function readAgentRestrictions(agentId) {
+  try {
+    const filePath = path.join(RESTRICTIONS_DIR, `${agentId}.json`);
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch (_) { return { rules: [] }; }
+}
+
+function writeAgentRestrictions(agentId, data) {
+  if (!fs.existsSync(RESTRICTIONS_DIR)) {
+    execSync(`sudo mkdir -p ${shellQuote(RESTRICTIONS_DIR)} && sudo chown dev:dev ${shellQuote(RESTRICTIONS_DIR)}`);
+  }
+  const filePath = path.join(RESTRICTIONS_DIR, `${agentId}.json`);
+  fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + '\n');
+}
+
+function getAgentRestrictions(agentName) {
+  const agentFile = readAgentRestrictions(agentName);
+  const agentRules = (agentFile.rules || []).map((r) => ({ ...r, source: 'agent' }));
+  const globalRules = parseGhWrapperRestrictions();
+  const policyRules = parsePolicyRestrictions(agentName);
+  return { agent: agentRules, global: globalRules, policy: policyRules };
 }
 
 app.get('/api/config/agent/:name', (req, res) => {
@@ -1354,8 +1370,7 @@ app.get('/api/config/agent/:name', (req, res) => {
       postIdle: agentEnv.POST_IDLE_HOOKS ? agentEnv.POST_IDLE_HOOKS.split(',').filter(Boolean) : [],
     };
 
-    const manualRestrictions = agentEnv.AGENT_RESTRICTIONS ? agentEnv.AGENT_RESTRICTIONS.split(',').filter(Boolean) : [];
-    const restrictions = detectRestrictions(name, manualRestrictions);
+    const restrictions = getAgentRestrictions(name);
 
     let prompt = '';
     try {
@@ -1464,10 +1479,9 @@ app.put('/api/config/agent/:name/hooks', (req, res) => {
 app.put('/api/config/agent/:name/restrictions', (req, res) => {
   const { name } = req.params;
   if (!validateAgentName(name, res)) return;
-  const envFile = `${ENV_DIR}/${name}.env`;
   try {
-    const list = req.body.list || [];
-    writeEnvVar(envFile, 'AGENT_RESTRICTIONS', list.join(','));
+    const rules = req.body.rules || [];
+    writeAgentRestrictions(name, { rules });
     res.json({ ok: true });
   } catch (err) {
     res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary

- Replaces flat restriction detection with persistent per-agent JSON files at `/etc/hive/restrictions/<agent-id>.json`
- gh wrapper reads `HIVE_AGENT_ID` (exported by `agent-launch.sh`) to load the right restriction file per agent
- Dashboard Restrictions tab now shows 3 sections: editable agent rules, read-only global rules (gh wrapper), read-only policy rules (CLAUDE.md)
- Agent ID is the env file stem (e.g., `scanner`), so restrictions survive display name changes
- No agent restart needed — restrictions take effect on next `gh` invocation

## Files changed

| File | Change |
|---|---|
| `bin/agent-launch.sh` | Export `HIVE_AGENT_ID` from `AGENT_SESSION_NAME` |
| `bin/gh-wrapper.sh` | Read per-agent restriction file, match patterns via bash glob |
| `dashboard/server.js` | `readAgentRestrictions()`, `writeAgentRestrictions()`, `getAgentRestrictions()`, PUT endpoint |
| `dashboard/index.html` | Rewritten Restrictions tab with 3 sections, add/remove/toggle functions |
| `config/restrictions/README.md` | Documentation for the per-agent restriction system |

## Test plan

- [ ] Open scanner config → Restrictions tab → verify global rules visible (gh issue list, gh pr list)
- [ ] Add a custom restriction pattern → Save → verify `/etc/hive/restrictions/scanner.json` created
- [ ] Toggle restriction off → Save → verify `enabled: false` in JSON
- [ ] SSH to server, run `HIVE_AGENT_ID=scanner gh issue list` → verify blocked
- [ ] Disable the rule → rerun → verify allowed (falls through to global block)