### PR TITLE
feat: add author and age to issue/PR pill hover

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2268,13 +2268,17 @@
         const MAX_PILL_TITLE_LEN = 50;
         const issuePills = (r.actionableIssues || []).map(i => {
           const title = i.title && i.title.length > MAX_PILL_TITLE_LEN ? i.title.slice(0, MAX_PILL_TITLE_LEN) + '…' : (i.title || '');
-          return `<a class="repo-issue-pill" href="${esc(i.url)}" target="_blank" rel="noopener" title="${esc(i.title || '')}"><span class="pill-num">#${i.number}</span><span class="pill-title">${esc(title)}</span></a>`;
+          const age = pillAge(i.created_at);
+          const tip = (i.title || '') + (i.author ? ' — @' + i.author : '') + (age ? ' (' + age + ')' : '');
+          return `<a class="repo-issue-pill" href="${esc(i.url)}" target="_blank" rel="noopener" title="${esc(tip)}"><span class="pill-num">#${i.number}</span><span class="pill-title">${esc(title)}</span></a>`;
         }).join('');
         const prPills = (r.openPrs || []).map(p => {
           const title = p.title && p.title.length > MAX_PILL_TITLE_LEN ? p.title.slice(0, MAX_PILL_TITLE_LEN) + '…' : (p.title || '');
           const mergeIcon = p.mergeable ? '<span class="pill-merge-icon">✓</span>' : '';
           const mergeClass = p.mergeable ? ' mergeable' : '';
-          return `<a class="repo-pr-pill${mergeClass}" href="${esc(p.url)}" target="_blank" rel="noopener" title="${esc(p.title || '')}${p.mergeable ? ' (merge eligible)' : ''}"><span class="pill-num">#${p.number}</span><span class="pill-title">${esc(title)}</span>${mergeIcon}</a>`;
+          const prAge = pillAge(p.created_at);
+          const prTip = (p.title || '') + (p.author ? ' — @' + p.author : '') + (prAge ? ' (' + prAge + ')' : '') + (p.mergeable ? ' (merge eligible)' : '');
+          return `<a class="repo-pr-pill${mergeClass}" href="${esc(p.url)}" target="_blank" rel="noopener" title="${esc(prTip)}"><span class="pill-num">#${p.number}</span><span class="pill-title">${esc(title)}</span>${mergeIcon}</a>`;
         }).join('');
         const allPills = issuePills + prPills;
         const pillsHtml = allPills ? `<div class="repo-issues">${allPills}</div>` : '';
@@ -2307,6 +2311,17 @@
       if (b >= 0.1) return b.toFixed(2) + 'B';
       if (b >= 0.01) return b.toFixed(3) + 'B';
       return b.toFixed(3) + 'B';
+    }
+    function pillAge(createdAt) {
+      if (!createdAt) return '';
+      const MS_PER_MIN = 60000;
+      const MS_PER_HOUR = 3600000;
+      const MS_PER_DAY = 86400000;
+      const ms = Date.now() - new Date(createdAt).getTime();
+      if (ms < 0 || isNaN(ms)) return '';
+      if (ms < MS_PER_HOUR) return Math.floor(ms / MS_PER_MIN) + 'm ago';
+      if (ms < MS_PER_DAY) return Math.floor(ms / MS_PER_HOUR) + 'h ago';
+      return Math.floor(ms / MS_PER_DAY) + 'd ago';
     }
 
     let budgetIgnored = false;

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -534,12 +534,12 @@ function enrichReposWithActionable() {
   for (const r of statusCache.repos) {
     r.actionableIssues = issues
       .filter(i => i.repo === r.full)
-      .map(i => ({ number: i.number, title: i.title, url: i.url, labels: i.labels || [] }));
+      .map(i => ({ number: i.number, title: i.title, url: i.url, labels: i.labels || [], author: i.author || '', created_at: i.created_at || '' }));
     r.openPrs = prs
       .filter(p => p.repo === r.full)
       .map(p => ({
         number: p.number, title: p.title, url: p.url,
-        labels: p.labels || [], author: p.author || '',
+        labels: p.labels || [], author: p.author || '', created_at: p.created_at || '',
         mergeable: eligibleNums.has(`${r.full}#${p.number}`),
       }));
   }


### PR DESCRIPTION
## Summary

- Issue and PR pills in the Repositories section now show `@author` and relative age (e.g. "3h ago") in the hover tooltip
- Server passes `author` and `created_at` through for both issues and PRs from actionable.json
- Hover format: `Title — @author (2d ago)`

## Test plan

- [ ] Hover over an issue pill → verify author and age appear in tooltip
- [ ] Hover over a PR pill → verify author, age, and merge eligibility appear
- [ ] Verify pills without author data still show title only