### PR TITLE
feat: copy existing agent when adding new agents

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4004,6 +4004,10 @@ function burnAreaChart() {
         <ul class="config-agent-list">${list}</ul>
         <div class="config-list-add" style="margin-top:12px">
           <input type="text" id="cfg-new-agent" placeholder="agent name">
+          <select id="cfg-copy-from" style="margin-left:6px;font-size:0.75rem;background:var(--surface);color:var(--text);border:1px solid var(--border);border-radius:4px;padding:4px 6px">
+            <option value="">blank</option>
+            ${agents.map(a => '<option value="' + a + '">copy ' + a + '</option>').join('')}
+          </select>
           <button onclick="addAgent()">+ Add Agent</button>
         </div>`;
     }
@@ -4278,12 +4282,15 @@ function burnAreaChart() {
         showToast(`Agent "${name}" already exists`, 'error');
         return;
       }
+      const copySelect = document.getElementById('cfg-copy-from');
+      const copyFrom = copySelect ? copySelect.value : '';
+      const payload = copyFrom ? { name, copyFrom } : { name };
       fetch('/api/config/governor/agents', {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name })
+        body: JSON.stringify(payload)
       }).then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
         .then(() => {
-          showToast(`Agent "${name}" added`, 'success');
+          showToast(copyFrom ? `Agent "${name}" created from ${copyFrom}` : `Agent "${name}" added`, 'success');
           if (!_configState.data.agents) _configState.data.agents = [];
           _configState.data.agents.push(name);
           input.value = '';

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1632,18 +1632,37 @@ app.put('/api/config/governor/health', (req, res) => {
 });
 
 app.post('/api/config/governor/agents', (req, res) => {
-  const { name } = req.body;
+  const { name, copyFrom } = req.body;
   if (!name || !/^[a-z][a-z0-9-]*$/.test(name)) {
     return res.status(400).json({ error: 'Invalid agent name (lowercase alphanumeric + hyphens)' });
   }
   try {
     const envFile = `${ENV_DIR}/${name}.env`;
-    if (!fs.existsSync(envFile)) {
-      const initContent = `# ${name} agent config\nAGENT_LAUNCH_CMD=agent-launch.sh\nAGENT_CLI_PINNED=false\n`;
-      const tmp = `/tmp/hive-env-${process.pid}-${Date.now()}`;
-      fs.writeFileSync(tmp, initContent, { mode: 0o644 });
-      execSync(`sudo mv ${shellQuote(tmp)} ${shellQuote(envFile)}`);
+    if (fs.existsSync(envFile)) {
+      return res.json({ ok: true });
     }
+    const tmp = `/tmp/hive-env-${process.pid}-${Date.now()}`;
+    if (copyFrom && VALID_AGENT_NAME.test(copyFrom)) {
+      const srcEnv = `${ENV_DIR}/${copyFrom}.env`;
+      if (fs.existsSync(srcEnv)) {
+        let content = fs.readFileSync(srcEnv, 'utf8');
+        content = content.replace(/^#.*\n?/, `# ${name} agent config (copied from ${copyFrom})\n`);
+        content = content.replace(/AGENT_DISPLAY_NAME=.*/g, `AGENT_DISPLAY_NAME=${name}`);
+        content = content.replace(/AGENT_SESSION_NAME=.*/g, `AGENT_SESSION_NAME=${name}`);
+        fs.writeFileSync(tmp, content, { mode: 0o644 });
+      } else {
+        fs.writeFileSync(tmp, `# ${name} agent config\nAGENT_LAUNCH_CMD=agent-launch.sh\nAGENT_CLI_PINNED=false\n`, { mode: 0o644 });
+      }
+      const srcPolicy = `${ENV_DIR}/${copyFrom}-CLAUDE.md`;
+      if (fs.existsSync(srcPolicy)) {
+        const policyTmp = `/tmp/hive-policy-${process.pid}-${Date.now()}`;
+        fs.writeFileSync(policyTmp, fs.readFileSync(srcPolicy, 'utf8'), { mode: 0o644 });
+        execSync(`sudo mv ${shellQuote(policyTmp)} ${shellQuote(`${ENV_DIR}/${name}-CLAUDE.md`)}`);
+      }
+    } else {
+      fs.writeFileSync(tmp, `# ${name} agent config\nAGENT_LAUNCH_CMD=agent-launch.sh\nAGENT_CLI_PINNED=false\n`, { mode: 0o644 });
+    }
+    execSync(`sudo mv ${shellQuote(tmp)} ${shellQuote(envFile)}`);
     res.json({ ok: true });
   } catch (err) {
     res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary

- Add Agent form now has a "copy from" dropdown listing all existing agents
- Selecting an agent copies its `.env` (with name/session updated) and `CLAUDE.md` policy to the new agent
- Default "blank" option creates a minimal config as before
- Server validates `copyFrom` and falls back gracefully if source doesn't exist

## Test plan

- [ ] Open Governor config → Agents tab → verify dropdown shows existing agents
- [ ] Create agent with "copy scanner" → verify new `.env` has scanner's settings with updated name
- [ ] Verify new agent's CLAUDE.md matches source
- [ ] Create agent with "blank" → verify minimal config created