### PR TITLE
fix: add agent dialog error and toast z-index behind modals

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -882,7 +882,7 @@
       color: var(--text); opacity: 0.85; overflow: hidden;
       text-overflow: ellipsis; white-space: nowrap; flex: 1;
     }
-    #toast-container { position: fixed; top: 16px; right: 16px; z-index: 9999; display: flex; flex-direction: column; gap: 8px; pointer-events: none; }
+    #toast-container { position: fixed; top: 16px; right: 16px; z-index: 10001; display: flex; flex-direction: column; gap: 8px; pointer-events: none; }
     .toast { pointer-events: auto; padding: 10px 16px; border-radius: 6px; font-size: 0.78rem; color: #e6edf3; box-shadow: 0 4px 12px rgba(0,0,0,0.4); animation: toast-in 0.25s ease-out; max-width: 360px; }
     .toast.success { background: #1a7f37; border: 1px solid #238636; }
     .toast.error { background: #8b1a1a; border: 1px solid #f85149; }
@@ -3741,6 +3741,9 @@ function burnAreaChart() {
     const RESTART_STRATEGIES = ['immediate', 'backoff', 'none'];
 
     function openConfigDialog(type, agentName) {
+      if (type === 'agent' && !agentName) {
+        type = 'governor';
+      }
       _configModalOpen = true;
       _configState = { type, agent: agentName || null, tab: null, data: {}, dirty: {} };
       document.getElementById('config-overlay').classList.remove('hidden');


### PR DESCRIPTION
## Summary

- Fix "+ add agent" sidebar link causing "failed to load config" (was opening agent config with no name → 404)
- Now redirects to governor config which shows the Agents tab with the add agent form
- Fix toast z-index (was 9999, behind overlay at 10000) → now 10001 so toasts render above modals

## Test plan

- [ ] Click "+ add agent" in sidebar → governor config opens on Agents tab, no error
- [ ] Trigger an error while modal is open → toast visible above the modal overlay