### PR TITLE
Fix: tighten rate-limit detection to avoid false positives

### DIFF
--- a/bin/gh-rate-check.sh
+++ b/bin/gh-rate-check.sh
@@ -43,8 +43,9 @@ get_agent_cli() {
   echo "${cli:-unknown}"
 }
 
-# GitHub API rate limit patterns
-GH_RATE_PATTERNS='API rate limit exceeded|secondary rate limit|rate limit|403.*rate|You have exceeded|retry-after|gh: Resource not accessible'
+# GitHub API rate limit patterns — must match actual error messages, not casual mentions
+# Removed bare "rate limit" which false-positives on code output like "good rate limiting"
+GH_RATE_PATTERNS='API rate limit exceeded|secondary rate limit|403.*rate limit|You have exceeded a secondary rate|retry-after:[[:space:]]*[0-9]|gh: Resource not accessible|abuse detection mechanism'
 
 # Claude/Copilot CLI patterns to EXCLUDE
 CLI_EXCLUDE_PATTERNS="You.re out of extra usage|out of extra usage|extra usage.*resets|resets [0-9]+(:[0-9]+)?[aApP][mM]"

--- a/bin/gh-rate-check.sh
+++ b/bin/gh-rate-check.sh
@@ -19,8 +19,8 @@ GOVERNOR_FLAG_DIR="/var/run/kick-governor"
 NTFY_SERVER="${NTFY_SERVER:-https://ntfy.sh}"
 NTFY_TOPIC="${NTFY_TOPIC:-hive}"
 TMUX_BIN="${TMUX_BIN:-tmux}"
-TTL_SECONDS=900   # 15 minutes — cleared sooner if API shows recovery
-PULLBACK_SECONDS=900  # 15 minutes
+DEFAULT_TTL_SECONDS=900
+DEFAULT_PULLBACK_SECONDS=900
 
 mkdir -p "$PULLBACK_STATE_DIR"
 
@@ -43,12 +43,22 @@ get_agent_cli() {
   echo "${cli:-unknown}"
 }
 
-# GitHub API rate limit patterns — must match actual error messages, not casual mentions
-# Removed bare "rate limit" which false-positives on code output like "good rate limiting"
-GH_RATE_PATTERNS='API rate limit exceeded|secondary rate limit|403.*rate limit|You have exceeded a secondary rate|retry-after:[[:space:]]*[0-9]|gh: Resource not accessible|abuse detection mechanism'
+# Sensing patterns — read from governor.env if available, else use defaults
+GOVERNOR_ENV="${GOVERNOR_ENV:-/etc/hive/governor.env}"
+_load_env_pattern() {
+  local var="$1" default="$2"
+  local val
+  val=$(grep -s "^${var}=" "$GOVERNOR_ENV" 2>/dev/null | cut -d= -f2- | sed "s/^['\"]//;s/['\"]$//" || true)
+  echo "${val:-$default}"
+}
 
-# Claude/Copilot CLI patterns to EXCLUDE
-CLI_EXCLUDE_PATTERNS="You.re out of extra usage|out of extra usage|extra usage.*resets|resets [0-9]+(:[0-9]+)?[aApP][mM]"
+DEFAULT_GH_RATE_PATTERNS='API rate limit exceeded|secondary rate limit|403.*rate limit|You have exceeded a secondary rate|retry-after:[[:space:]]*[0-9]|gh: Resource not accessible|abuse detection mechanism'
+DEFAULT_CLI_EXCLUDE_PATTERNS='You.re out of extra usage|out of extra usage|extra usage.*resets|resets [0-9]+(:[0-9]+)?[aApP][mM]'
+
+GH_RATE_PATTERNS=$(_load_env_pattern SENSING_GH_RATE_PATTERNS "$DEFAULT_GH_RATE_PATTERNS")
+CLI_EXCLUDE_PATTERNS=$(_load_env_pattern SENSING_CLI_EXCLUDE_PATTERNS "$DEFAULT_CLI_EXCLUDE_PATTERNS")
+TTL_SECONDS=$(_load_env_pattern SENSING_TTL_SECONDS "$DEFAULT_TTL_SECONDS")
+PULLBACK_SECONDS=$(_load_env_pattern SENSING_PULLBACK_SECONDS "$DEFAULT_PULLBACK_SECONDS")
 
 now_epoch=$(date +%s)
 now_iso=$(date -Is)

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3755,7 +3755,7 @@ function burnAreaChart() {
     let _configState = { type: null, agent: null, tab: null, data: {}, dirty: {} };
 
     const AGENT_CONFIG_TABS = ['General', 'Cadences', 'Pipeline', 'Hooks', 'Restrictions', 'Stats', 'Prompts'];
-    const GOVERNOR_CONFIG_TABS = ['Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health'];
+    const GOVERNOR_CONFIG_TABS = ['Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing'];
     const PIPELINE_STAGES = ['resolve-beads', 'track-prs', 'stale-check', 'repo-scan', 'coverage-gate', 'prompt-compose', 'budget-check', 'api-collect', 'final-compose'];
     const RESTART_STRATEGIES = ['immediate', 'backoff', 'none'];
 
@@ -3841,6 +3841,7 @@ function burnAreaChart() {
         case 'Budget': return renderGovBudget(d.budget || {});
         case 'Notifications': return renderGovNotifications(d.notifications || {});
         case 'Health': return renderGovHealth(d.health || {});
+        case 'Sensing': return renderGovSensing(d.sensing || {});
         default: return '';
       }
     }
@@ -4321,6 +4322,60 @@ function burnAreaChart() {
           <div class="config-toggle-switch ${h.modelLock ? 'on' : ''}" onclick="toggleConfigSwitch(this,'health','modelLock')"></div>
           <span class="config-toggle-label">Model Lock (prevent automatic model changes)</span>
         </div>`;
+    }
+
+    function renderGovSensing(s) {
+      const ghPatterns = (s.ghRatePatterns || []).map((p, i) =>
+        `<div class="config-list-item"><code style="font-size:0.7rem">${esc(p)}</code><button class="remove-item" onclick="removeSensingItem('ghRatePatterns',${i})">✕</button></div>`
+      ).join('');
+      const cliPatterns = (s.cliExcludePatterns || []).map((p, i) =>
+        `<div class="config-list-item"><code style="font-size:0.7rem">${esc(p)}</code><button class="remove-item" onclick="removeSensingItem('cliExcludePatterns',${i})">✕</button></div>`
+      ).join('');
+      return `
+        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">Patterns scanned in agent tmux panes to detect rate limits and CLI usage caps.</p>
+        <div style="margin-bottom:18px">
+          <label style="font-weight:600;font-size:0.78rem;display:block;margin-bottom:6px">GitHub API Rate Limit Patterns <span style="font-weight:400;color:var(--muted)">(regex, matched against pane output)</span></label>
+          <div class="config-list">
+            ${ghPatterns || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">No patterns configured</div>'}
+            <div class="config-list-add">
+              <input type="text" id="cfg-sensing-gh-input" placeholder="e.g. 403.*rate limit" style="font-family:monospace;font-size:0.75rem">
+              <button onclick="addSensingItem('ghRatePatterns','cfg-sensing-gh-input')">+ Add</button>
+            </div>
+          </div>
+        </div>
+        <div style="margin-bottom:18px">
+          <label style="font-weight:600;font-size:0.78rem;display:block;margin-bottom:6px">CLI Exclude Patterns <span style="font-weight:400;color:var(--muted)">(lines matching these are ignored before rate-limit check)</span></label>
+          <div class="config-list">
+            ${cliPatterns || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">No exclude patterns</div>'}
+            <div class="config-list-add">
+              <input type="text" id="cfg-sensing-cli-input" placeholder="e.g. out of extra usage" style="font-family:monospace;font-size:0.75rem">
+              <button onclick="addSensingItem('cliExcludePatterns','cfg-sensing-cli-input')">+ Add</button>
+            </div>
+          </div>
+        </div>
+        <div class="config-field-row">
+          <div class="config-field"><label>Alert TTL (sec)</label><input type="number" value="${s.ttlSeconds || 900}" onchange="markDirty('sensing','ttlSeconds',Number(this.value))"></div>
+          <div class="config-field"><label>Pullback Duration (sec)</label><input type="number" value="${s.pullbackSeconds || 900}" onchange="markDirty('sensing','pullbackSeconds',Number(this.value))"></div>
+        </div>`;
+    }
+
+    function addSensingItem(key, inputId) {
+      const input = document.getElementById(inputId);
+      const val = input.value.trim();
+      if (!val) return;
+      if (!_configState.data.sensing) _configState.data.sensing = {};
+      if (!_configState.data.sensing[key]) _configState.data.sensing[key] = [];
+      _configState.data.sensing[key].push(val);
+      markDirty('sensing', key, _configState.data.sensing[key]);
+      input.value = '';
+      renderConfigTab(_configState.tab);
+    }
+
+    function removeSensingItem(key, index) {
+      if (!_configState.data.sensing || !_configState.data.sensing[key]) return;
+      _configState.data.sensing[key].splice(index, 1);
+      markDirty('sensing', key, _configState.data.sensing[key]);
+      renderConfigTab(_configState.tab);
     }
 
     // ── Config Interaction Helpers ──

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1669,8 +1669,30 @@ app.get('/api/config/governor', (_req, res) => {
       modelLock: govEnv.MODEL_LOCK === 'true',
     };
 
+    const DEFAULT_GH_RATE_PATTERNS = 'API rate limit exceeded|secondary rate limit|403.*rate limit|You have exceeded a secondary rate|retry-after:[[:space:]]*[0-9]|gh: Resource not accessible|abuse detection mechanism';
+    const DEFAULT_CLI_EXCLUDE_PATTERNS = 'You.re out of extra usage|out of extra usage|extra usage.*resets|resets [0-9]+(:[0-9]+)?[aApP][mM]';
+    const sensing = {
+      ghRatePatterns: (govEnv.SENSING_GH_RATE_PATTERNS || DEFAULT_GH_RATE_PATTERNS).split('|').filter(Boolean),
+      cliExcludePatterns: (govEnv.SENSING_CLI_EXCLUDE_PATTERNS || DEFAULT_CLI_EXCLUDE_PATTERNS).split('|').filter(Boolean),
+      ttlSeconds: parseInt(govEnv.SENSING_TTL_SECONDS || '900', 10),
+      pullbackSeconds: parseInt(govEnv.SENSING_PULLBACK_SECONDS || '900', 10),
+    };
+
     const repos = ((projectConfig.project || {}).repos || []).slice();
-    res.json({ agents, thresholds, labels, budget, notifications, health, repos });
+    res.json({ agents, thresholds, labels, budget, notifications, health, repos, sensing });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.put('/api/config/governor/sensing', (req, res) => {
+  try {
+    const { ghRatePatterns, cliExcludePatterns, ttlSeconds, pullbackSeconds } = req.body;
+    if (ghRatePatterns !== undefined) writeEnvVar(GOVERNOR_ENV_PATH, 'SENSING_GH_RATE_PATTERNS', ghRatePatterns.join('|'));
+    if (cliExcludePatterns !== undefined) writeEnvVar(GOVERNOR_ENV_PATH, 'SENSING_CLI_EXCLUDE_PATTERNS', cliExcludePatterns.join('|'));
+    if (ttlSeconds !== undefined) writeEnvVar(GOVERNOR_ENV_PATH, 'SENSING_TTL_SECONDS', String(ttlSeconds));
+    if (pullbackSeconds !== undefined) writeEnvVar(GOVERNOR_ENV_PATH, 'SENSING_PULLBACK_SECONDS', String(pullbackSeconds));
+    res.json({ ok: true });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }


### PR DESCRIPTION
## Summary
- Remove bare `rate limit` pattern from `gh-rate-check.sh` which matched casual code mentions (e.g., "good rate limiting" in architect output)
- Tighten all patterns to match actual GitHub API error messages only
- Adds `abuse detection mechanism` pattern for GitHub's secondary limit response

## Context
Architect was implementing rate-limiting code and the detector pattern-matched on "good rate limiting" in the tmux pane output, triggering a false alert + scanner pullback.