### PR TITLE
fix: governor config repo add/remove buttons not working

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4445,6 +4445,10 @@ function burnAreaChart() {
         if (!_configState.data.labels) _configState.data.labels = [];
         _configState.data.labels.push(val);
         markDirty('labels', 'list', _configState.data.labels);
+      } else if (section === 'repos') {
+        if (!_configState.data.repos) _configState.data.repos = [];
+        _configState.data.repos.push(val);
+        markDirty('repos', 'list', _configState.data.repos);
       }
       input.value = '';
       renderConfigTab(_configState.tab);
@@ -4457,6 +4461,9 @@ function burnAreaChart() {
       } else if (section === 'labels') {
         _configState.data.labels.splice(index, 1);
         markDirty('labels', 'list', _configState.data.labels);
+      } else if (section === 'repos') {
+        _configState.data.repos.splice(index, 1);
+        markDirty('repos', 'list', _configState.data.repos);
       }
       renderConfigTab(_configState.tab);
     }


### PR DESCRIPTION
## Summary
- The `addListItem` and `removeListItem` functions in the governor config dialog only handled `hooks` and `labels` sections
- The `repos` section fell through silently — clicking + Add or ✕ remove on the Repos tab did nothing
- Added the missing `repos` case to both functions, wiring them to `_configState.data.repos` with proper `markDirty` calls

## Test plan
- [ ] Open governor config → Repos tab
- [ ] Type a repo name and click + Add — should appear in the list
- [ ] Click ✕ on a repo — should be removed from the list
- [ ] Click Save — should persist via PUT /api/config/governor/repos