### PR TITLE
fix: prevent YAML corruption when saving governor config

### DIFF
--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1816,7 +1816,9 @@ app.put('/api/config/governor/repos', (req, res) => {
     if (!projectConfig.project) projectConfig.project = {};
     projectConfig.project.repos = list;
     const dumpYaml = yaml ? yaml.dump(projectConfig) : JSON.stringify(projectConfig, null, 2);
-    execSync(`echo ${JSON.stringify(dumpYaml)} | sudo tee ${CONFIG_PATH} > /dev/null`);
+    const tmpFile = `/tmp/hive-project-${process.pid}.yaml`;
+    fs.writeFileSync(tmpFile, dumpYaml);
+    execSync(`sudo mv ${tmpFile} ${CONFIG_PATH}`);
     res.json({ ok: true });
   } catch (err) {
     res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
- Governor config save used `echo ... | sudo tee` to write `hive-project.yaml`
- Shell `echo` interpreted `\b` (regex word boundaries) as backspace chars (0x08), corrupting the YAML
- Fix: write to temp file via `fs.writeFileSync`, then `sudo mv` into place — no shell interpretation

## Test plan
- [ ] Open governor config → Repos tab → Add a repo → Save
- [ ] Verify `/etc/hive/hive-project.yaml` has no control characters (`cat -v` shows no `^H`)
- [ ] Verify regex patterns with `\b` are preserved correctly