### PR TITLE
feat: add sec-check security gate agent

### DIFF
--- a/examples/kubestellar/hive-project.yaml
+++ b/examples/kubestellar/hive-project.yaml
@@ -32,6 +32,7 @@ agents:
     - strategist
     - analyst
     - guardian
+    - sec-check
   beads_base: "/home/dev"
   workdir: "/home/dev/kubestellar-console"
   policy_dir: "examples/kubestellar/agents"


### PR DESCRIPTION
## Summary
- Adds `sec-check` to the enabled agents list in `hive-project.yaml`
- sec-check is a security gate agent that runs every 2 minutes to:
  - Check first-time contributors for legitimacy
  - Review security implications of issues/PRs
  - Enforce UI/UX screenshot requirements
  - Apply `hold` label to flag questionable items from external contributors

## Test plan
- [ ] sec-check appears in dashboard sidebar after auto-deploy
- [ ] sec-check appears in cadence table