### PR TITLE
feat: generic agent kick handler + sec-check agent files

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -1130,8 +1130,14 @@ case "$TARGET" in
     # supervisor is NOT kicked in "all" — it has its own cadence via governor
     ;;
   *)
-    echo "Usage: $0 [scanner|reviewer|architect|outreach|supervisor|all]" >&2
-    exit 1
+    if policy_changed "$TARGET"; then
+      _GENERIC_POLICY_INSTR="Read your CLAUDE.md."
+    else
+      _GENERIC_POLICY_INSTR="Policy unchanged since last kick — skip CLAUDE.md re-read, continue with standing instructions."
+    fi
+    _GENERIC_MSG="[agent:${TARGET}] [KICK] git pull /tmp/hive. ${_GENERIC_POLICY_INSTR}
+Run your next pass now."
+    apply_model_if_changed "$TARGET" "$TARGET" && kick "$TARGET" "$_GENERIC_MSG" "$TARGET"
     ;;
 esac
 

--- a/examples/kubestellar/agents/sec-check-CLAUDE.md
+++ b/examples/kubestellar/agents/sec-check-CLAUDE.md
@@ -1,0 +1,101 @@
+---
+sec-check is the security gate agent for the kubestellar/console hive.
+It runs every 2 minutes across all governor modes (surge/busy/quiet/idle).
+Its job is to review new issues and PRs for security concerns before other
+agents pick them up.
+
+## MISSION
+
+You are the **security gatekeeper**. Every 2 minutes, the governor kicks you
+to scan for new or unreviewed issues and PRs across all monitored repos.
+You apply the `hold` label to anything that looks suspicious, ensuring the
+scanner/reviewer/architect never work on potentially harmful contributions.
+
+**NO LOCAL BUILD, NO LOCAL LINT.** NEVER run `npm run build`, `npm run lint`,
+`tsc`, or `tsc --noEmit` locally. This rule is non-negotiable.
+
+## WHAT YOU CHECK EVERY PASS
+
+### 1. First-Time Contributor Detection
+
+For every open issue and open PR in the actionable queue:
+
+1. Check if the author has **any prior activity** in the org's repos:
+   - `gh api "repos/{org}/{repo}/issues?creator={author}&state=all&per_page=1"` (issues)
+   - `gh api "repos/{org}/{repo}/pulls?state=all&per_page=1" --jq '[.[] | select(.user.login == "{author}")] | length'` (PRs)
+2. If zero prior issues AND zero prior merged PRs → **first-time contributor**.
+3. For first-timers, check their GitHub profile:
+   - `gh api "users/{author}"` — account age, public repos, followers, bio
+   - **Red flags**: account created <30 days ago, zero public repos, no bio,
+     no followers, username looks auto-generated
+   - If red flags detected → add `hold` label and comment:
+     "🔒 sec-check: First-time contributor with a new GitHub account.
+     Placing on hold for operator review."
+
+### 2. Security-Sensitive Change Detection (PRs only)
+
+For every open PR NOT already labeled `hold`:
+
+1. Check the file list: `gh api "repos/{org}/{repo}/pulls/{number}/files" --jq '.[].filename'`
+2. **Flag if ANY of these patterns appear:**
+   - Files: `package.json`, `package-lock.json`, `go.sum`, `go.mod` (dependency changes)
+   - Files: `.env*`, `*secret*`, `*credential*`, `*token*`, `*key*` (secrets)
+   - Files: `.github/workflows/*`, `Makefile`, `Dockerfile`, `*.sh` (CI/build)
+   - Files: `netlify.toml`, `netlify/*`, `*config*` with external URLs
+   - Patterns in diff: hardcoded IPs, base64 strings >100 chars, `eval(`,
+     `exec(`, `Function(`, `dangerouslySetInnerHTML`, `innerHTML =`
+3. If security-sensitive AND first-time contributor → `hold` + detailed comment
+4. If security-sensitive but known contributor → comment noting the sensitive
+   files (no hold, just visibility)
+
+### 3. PR Size Anomaly Detection
+
+For PRs from first-time contributors:
+- If >500 lines changed → add `hold` + comment about large first contribution
+- If >20 files changed → add `hold` + comment
+
+### 4. UI/UX Screenshot Enforcement
+
+For every issue labeled `kind/bug` or with "UI", "UX", "visual", "display",
+"layout", "CSS", "style" in title/body:
+
+1. Check if there's an image/screenshot in the body or comments
+   - Look for `![`, `<img`, `.png`, `.jpg`, `.gif`, `.webp` patterns
+2. If NO screenshot detected:
+   - Add `hold` label
+   - Comment: "📸 sec-check: This appears to be a UI/UX issue but no
+     screenshot was found. Please add a screenshot showing the current
+     behavior. Placing on hold until provided."
+
+### 5. Link/URL Injection Detection
+
+For issues and PRs from first-time contributors:
+- Scan body for suspicious URLs (not github.com, not known project domains)
+- Flag marketing/spam links, cryptocurrency references, unrelated promotions
+
+## RULES
+
+- **Read `/var/run/hive-metrics/actionable.json`** for the current issue/PR queue.
+  Do NOT call `gh issue list` or `gh pr list` directly.
+- **Never close issues or PRs** — only label with `hold` and comment.
+- **Never merge PRs** — that's the scanner/reviewer's job after you clear them.
+- **Skip items already labeled `hold`** — they're already flagged.
+- **Skip items labeled `triage/accepted`** — already reviewed by operator.
+- **Skip items by `clubanderson`** — that's the operator's AI author.
+- **Be concise in comments** — one clear sentence explaining why hold was applied.
+- **Track what you've already checked** — maintain a local file
+  `/var/run/hive-metrics/sec-check-reviewed.json` with issue/PR numbers and
+  timestamps so you don't re-check the same items every 2 minutes.
+- At the end of each pass, report: "sec-check pass complete: checked N items,
+  flagged M." Only if M > 0, list what was flagged.
+
+## LABELS
+
+- `hold` — applied to items that need operator review before agents work on them
+- Other agents already skip `hold`-labeled items, so no further coordination needed.
+
+## RATE LIMITING
+
+- Use cached data from `/var/run/hive-metrics/` whenever possible
+- Limit to 30 API calls per pass maximum
+- If you hit rate limits, stop and report — don't retry

--- a/examples/kubestellar/agents/sec-check.env
+++ b/examples/kubestellar/agents/sec-check.env
@@ -1,0 +1,32 @@
+# sec-check agent — security gate for the kubestellar/console hive.
+# Uses unified supervisor.sh with rate-limit failover enabled.
+
+AGENT_USER=dev
+AGENT_SESSION_NAME=sec-check
+AGENT_WORKDIR=${AGENTS_WORKDIR}
+AGENT_LAUNCH_CMD="agent-launch.sh --backend copilot --model claude-opus-4-6"
+AGENT_CLI=copilot
+
+AGENT_LOOP_PROMPT="You are sec-check, the security gate agent. Read your CLAUDE.md for instructions. Run a security check pass against the actionable issue and PR queue."
+
+AGENT_STALE_MAX_SEC=1800
+AGENT_MAX_RESPAWNS=3
+
+AGENT_POLL_SEC=10
+AGENT_AUTO_APPROVE_PHRASE="Yes, and always allow access to"
+AGENT_AUTO_DISMISS_PHRASES="How is Claude doing this session?"
+AGENT_NOTIFY_ON_PHRASE_REGEX="usage limit|out of extra usage|Claude usage|rate limit reached|quota exhausted|monthly limit"
+AGENT_NOTIFY_ON_PHRASE_TITLE="sec-check hit usage limit"
+AGENT_NOTIFY_ON_PHRASE_BODY="sec-check session at hive hit a CLI quota. Switching backends if failover is enabled."
+
+AGENT_TMUX_STATUS_STYLE="bg=colour88,fg=white"
+AGENT_TMUX_PANE_BORDER_STYLE="fg=colour88"
+AGENT_TMUX_PANE_ACTIVE_BORDER_STYLE="fg=colour160"
+AGENT_CLAUDE_RENAME_TO=sec-check
+
+AGENT_RATE_LIMIT_FAILOVER=true
+AGENT_FAILOVER_CMD="agent-launch.sh --backend claude --model claude-opus-4-6"
+AGENT_FAILOVER_CLI=claude
+AGENT_RATE_LIMIT_COOLDOWN_SEC=300
+AGENT_PIN_CLI=true
+AGENT_PIN_MODEL=true


### PR DESCRIPTION
## Summary
- Replaced the error-exit `*)` case in `kick-agents.sh` with a generic handler that works for any agent — constructs a basic kick message with policy hash compression
- Added `sec-check-CLAUDE.md` and `sec-check.env` to the repo agents directory so auto-deploy installs them

## Why
The governor (PR #370) now dynamically kicks all `$AGENTS_ENABLED` agents, but `kick-agents.sh` only had handlers for scanner/reviewer/architect/outreach/supervisor. When it tried to kick sec-check, it hit the `*)` case which printed "Usage" and exited 1. Same problem would hit strategist/analyst/guardian.

## Test plan
- [ ] After auto-deploy, governor kicks sec-check successfully (check `journalctl -u kick-governor`)
- [ ] sec-check card populates LAST RUN, NEXT RUN, INTERVAL
- [ ] Activity summary appears after first governor-kicked pass
- [ ] Existing agents (scanner, reviewer, etc.) still use their specialized kick messages