### PR TITLE
fix: unbound variable error in dynamic env var lookups

### DIFF
--- a/bin/kick-governor.sh
+++ b/bin/kick-governor.sh
@@ -366,8 +366,8 @@ get_cadence() {
   upper_agent=$(echo "$agent" | tr '[:lower:]-' '[:upper:]_')
   upper_mode=$(echo "$mode" | tr '[:lower:]' '[:upper:]')
   local var_name="CADENCE_${upper_agent}_${upper_mode}_SEC"
-  local val="${!var_name}"
-  echo "${val:-0}"
+  local val="${!var_name:-0}"
+  echo "$val"
 }
 
 # ── Model selection ──────────────────────────────────────────────────────────
@@ -382,7 +382,7 @@ get_model_selection() {
   upper_mode=$(echo "$mode" | tr '[:lower:]' '[:upper:]')
   upper_agent=$(echo "$agent" | tr '[:lower:]-' '[:upper:]_')
   local var_name="MODEL_${upper_mode}_${upper_agent}"
-  local selection="${!var_name}"
+  local selection="${!var_name:-}"
   if [[ -z "$selection" ]]; then
     selection="copilot:claude-sonnet-4-6"
   fi


### PR DESCRIPTION
## Summary
- Fixed `${!var_name}` → `${!var_name:-}` in `get_cadence()` and `get_model_selection()` to avoid `unbound variable` errors under `set -u`
- Without this fix, PR #370's dynamic lookups crash for agents that don't have `CADENCE_*` or `MODEL_*` vars defined in governor.env

## Test plan
- [ ] Governor completes without errors: `journalctl -u kick-governor --since '5 min ago' | grep -i error`
- [ ] sec-check appears in MODE= log line with correct cadence