### PR TITLE
fix: dynamic agent lists in scrapers + auto-create beads on add

### DIFF
--- a/dashboard/agent-activity.py
+++ b/dashboard/agent-activity.py
@@ -19,13 +19,30 @@ BOOTSTRAP_BYTES = 8192
 STALE_SECONDS = 300
 SUMMARY_MAX_LINES = int(os.environ.get("SUMMARY_MAX_LINES", "100"))
 
-AGENT_TMUX_SESSION = {
-    "supervisor": "supervisor",
-    "scanner": "scanner",
-    "reviewer": "reviewer",
-    "architect": "architect",
-    "outreach": "outreach",
-}
+def _load_enabled_agents():
+    """Build agent→tmux-session map from AGENTS_ENABLED or hive-config.sh."""
+    agents_str = os.environ.get("AGENTS_ENABLED", "")
+    if not agents_str:
+        try:
+            out = subprocess.check_output(
+                ["bash", "-c", "source /usr/local/bin/hive-config.sh 2>/dev/null && echo $AGENTS_ENABLED"],
+                timeout=5, text=True
+            ).strip()
+            if out:
+                agents_str = out
+        except Exception:
+            pass
+    if agents_str:
+        return {a: a for a in agents_str.split()}
+    return {
+        "supervisor": "supervisor",
+        "scanner": "scanner",
+        "reviewer": "reviewer",
+        "architect": "architect",
+        "outreach": "outreach",
+    }
+
+AGENT_TMUX_SESSION = _load_enabled_agents()
 
 PANE_NOISE = re.compile(
     r"^[─━═].*[─━═]$|^❯|^\s*$|^ / commands|^ @ files|^  dev@|^  ⏵|"
@@ -53,6 +70,7 @@ AGENT_PATTERNS = [
     ("reviewer",   ["[agent:reviewer]", "reviewer-beads"]),
     ("outreach",   ["[agent:outreach]", "outreach-beads"]),
     ("scanner",    ["[agent:scanner]", "scanner-beads"]),
+    ("sec-check",  ["[agent:sec-check]", "sec-check-beads", "security gate", "security gatekeeper"]),
 ]
 
 BASH_PATTERNS = [

--- a/dashboard/agent-summaries.sh
+++ b/dashboard/agent-summaries.sh
@@ -11,13 +11,14 @@ mkdir -p ~/.hive
 
 STALE_THRESHOLD_SEC=1800  # 30 min
 
-# Map agent name → beads directory
+# Map agent name → beads directory (dynamic from AGENTS_ENABLED)
+if [ -f /usr/local/bin/hive-config.sh ]; then
+  source /usr/local/bin/hive-config.sh 2>/dev/null
+fi
 declare -A BEADS_DIR
-BEADS_DIR[supervisor]="/home/dev/supervisor-beads"
-BEADS_DIR[scanner]="/home/dev/scanner-beads"
-BEADS_DIR[reviewer]="/home/dev/reviewer-beads"
-BEADS_DIR[architect]="/home/dev/architect-beads"
-BEADS_DIR[outreach]="/home/dev/outreach-beads"
+for _sa in ${AGENTS_ENABLED:-supervisor scanner reviewer architect outreach}; do
+  BEADS_DIR[$_sa]="/home/dev/${_sa}-beads"
+done
 
 # Read top in-progress bead title for an agent (returns empty if none)
 bead_in_progress() {
@@ -45,7 +46,7 @@ is_stale() {
   echo '  "summaries": {'
 
   first=1
-  for agent in supervisor scanner reviewer architect outreach; do
+  for agent in ${AGENTS_ENABLED:-supervisor scanner reviewer architect outreach}; do
     file=~/.hive/${agent}_status.txt
     if [ -f "$file" ]; then
       task=$(grep '^TASK=' "$file" 2>/dev/null | cut -d= -f2- | sed 's/"/'\''/g')

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1812,6 +1812,14 @@ app.post('/api/config/governor/agents', (req, res) => {
       ENABLED_AGENTS.push(name);
       persistEnabledAgents();
     }
+    // Create beads directory for the new agent
+    const beadsDir = path.join(process.env.HOME || '/home/dev', `${name}-beads`);
+    if (!fs.existsSync(beadsDir)) {
+      try {
+        fs.mkdirSync(beadsDir, { recursive: true });
+        execSync(`cd ${shellQuote(beadsDir)} && bd init 2>/dev/null`, { timeout: 5000 });
+      } catch (_) {}
+    }
     res.json({ ok: true });
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/dashboard/token-collector.sh
+++ b/dashboard/token-collector.sh
@@ -69,6 +69,8 @@ AGENT_PATTERNS = [
                     "you are the kubestellar outreach"]),
     ("scanner",    ["[agent:scanner]", "scanner-beads", "you are the scanner",
                     "you are the kubestellar scanner"]),
+    ("sec-check",  ["[agent:sec-check]", "sec-check-beads", "you are sec-check",
+                    "security gate", "security gatekeeper"]),
 ]
 
 PROJECT_DIR_AGENTS = {


### PR DESCRIPTION
## Summary
- Activity, summary, and token scrapers now use `$AGENTS_ENABLED` instead of hardcoded agent lists
- New agents get a beads directory (`mkdir` + `bd init`) automatically when added via the UI
- Fixes sec-check card showing "No activity summary" and empty TOKENS/MESSAGES/SESSIONS fields

## Test plan
- [ ] sec-check card shows activity summary after next dashboard refresh
- [ ] Token tracking picks up sec-check sessions
- [ ] Adding a new agent via UI creates `<name>-beads/` directory