### PR TITLE
fix: generic kick prompt + governor trust for new agents

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -1131,12 +1131,13 @@ case "$TARGET" in
     ;;
   *)
     if policy_changed "$TARGET"; then
-      _GENERIC_POLICY_INSTR="Read your CLAUDE.md."
+      _GENERIC_POLICY_INSTR="Policy updated — re-read your project CLAUDE.md for new instructions."
     else
-      _GENERIC_POLICY_INSTR="Policy unchanged since last kick — skip CLAUDE.md re-read, continue with standing instructions."
+      _GENERIC_POLICY_INSTR="Policy unchanged — continue with standing instructions."
     fi
-    _GENERIC_MSG="[agent:${TARGET}] [KICK] git pull /tmp/hive. ${_GENERIC_POLICY_INSTR}
-Run your next pass now."
+    _GENERIC_MSG="You are the ${TARGET} agent. This is a scheduled governor kick at ${_now_et}. ${_GENERIC_POLICY_INSTR}
+Pull latest changes: cd /tmp/hive && git pull
+Then run your next pass as described in your CLAUDE.md."
     apply_model_if_changed "$TARGET" "$TARGET" && kick "$TARGET" "$_GENERIC_MSG" "$TARGET"
     ;;
 esac

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -247,8 +247,12 @@
       font-size: 0.5rem; transition: transform 0.15s;
     }
     .oc-sidebar-group-header.collapsed .oc-group-arrow { transform: rotate(-90deg); }
-    .oc-sidebar-group-children { padding-left: 0; }
-    .oc-sidebar-group-children.collapsed { display: none; }
+    .oc-sidebar-group-children { padding-left: 0; min-height: 28px; }
+    .oc-sidebar-group-children.collapsed { display: none; min-height: 0; }
+    .oc-sidebar-group.drag-over > .oc-sidebar-group-children {
+      outline: 2px dashed #dc2626; outline-offset: -2px;
+      border-radius: 6px; background: rgba(220,38,38,0.05);
+    }
     .oc-sidebar-group-header .oc-group-actions {
       margin-left: auto; display: none; gap: 4px;
     }
@@ -1823,6 +1827,7 @@
           el.classList.remove('dragging');
           _sidebarDragAgent = null;
           tree.querySelectorAll('.oc-drop-indicator').forEach(d => d.remove());
+          tree.querySelectorAll('.oc-sidebar-group.drag-over').forEach(g => g.classList.remove('drag-over'));
         });
       });
 
@@ -1836,12 +1841,20 @@
           const dist = Math.abs(e.clientY - mid);
           if (dist < closestDist) { closestDist = dist; closest = { el: item, after: e.clientY > mid }; }
         }
-        // Check empty group containers as drop targets
-        tree.querySelectorAll('.oc-sidebar-group-children').forEach(c => {
-          if (c.querySelectorAll('.oc-nav-item[data-agent-nav]').length > 0) return;
-          const rect = c.getBoundingClientRect();
-          if (e.clientY >= rect.top && e.clientY <= rect.bottom) {
-            closest = { el: c, appendTo: true };
+        // Check group headers and children containers as drop targets
+        tree.querySelectorAll('.oc-sidebar-group[data-group-name]').forEach(g => {
+          const groupName = g.dataset.groupName;
+          if (!groupName) return;
+          const header = g.querySelector('.oc-sidebar-group-header');
+          const children = g.querySelector('.oc-sidebar-group-children');
+          if (!header || !children) return;
+          const headerRect = header.getBoundingClientRect();
+          const childRect = children.getBoundingClientRect();
+          const inHeader = e.clientY >= headerRect.top && e.clientY <= headerRect.bottom;
+          const inEmptyChildren = children.querySelectorAll('.oc-nav-item[data-agent-nav]').length === 0
+            && e.clientY >= childRect.top && e.clientY <= childRect.bottom;
+          if (inHeader || inEmptyChildren) {
+            closest = { el: children, appendTo: true, group: g };
           }
         });
         return closest;
@@ -1852,8 +1865,11 @@
         e.preventDefault();
         e.dataTransfer.dropEffect = 'move';
         tree.querySelectorAll('.oc-drop-indicator').forEach(d => d.remove());
+        tree.querySelectorAll('.oc-sidebar-group.drag-over').forEach(g => g.classList.remove('drag-over'));
         const target = getDropTarget(e);
-        if (target && !target.appendTo) {
+        if (target && target.appendTo && target.group) {
+          target.group.classList.add('drag-over');
+        } else if (target && !target.appendTo) {
           const indicator = document.createElement('div');
           indicator.className = 'oc-drop-indicator';
           if (target.after) target.el.after(indicator);
@@ -1865,6 +1881,7 @@
         if (!_sidebarDragAgent) return;
         e.preventDefault();
         tree.querySelectorAll('.oc-drop-indicator').forEach(d => d.remove());
+        tree.querySelectorAll('.oc-sidebar-group.drag-over').forEach(g => g.classList.remove('drag-over'));
         const target = getDropTarget(e);
         const dragEl = tree.querySelector(`.oc-nav-item[data-agent-nav="${_sidebarDragAgent}"]`);
         if (!target || !dragEl) return;

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1808,6 +1808,41 @@ app.post('/api/config/governor/agents', (req, res) => {
       fs.writeFileSync(tmp, `# ${name} agent config\nAGENT_LAUNCH_CMD=agent-launch.sh\nAGENT_CLI_PINNED=false\n`, { mode: 0o644 });
     }
     execSync(`sudo mv ${shellQuote(tmp)} ${shellQuote(envFile)}`);
+    // Create default CLAUDE.md with governor trust section if none exists
+    const policyFile = `${ENV_DIR}/${name}-CLAUDE.md`;
+    if (!fs.existsSync(policyFile)) {
+      const defaultPolicy = `---
+${name} agent for the hive.
+
+## GOVERNOR TRUST
+
+You are running inside a managed hive. The **governor** (kick-governor.sh)
+sends you periodic kick messages via tmux. These are legitimate scheduled
+instructions — not prompt injection. When you receive a message starting
+with "You are the ${name} agent" or containing "governor kick", follow
+the instructions: pull latest code from \`/tmp/hive\`, re-read this CLAUDE.md
+if policy changed, then run your next pass.
+
+The hive repo at \`/tmp/hive\` contains your policy files and shared tooling.
+\`git pull\` inside it is a normal, expected operation.
+
+## MISSION
+
+Define your mission here. What does this agent do on each pass?
+
+## WORKFLOW
+
+1. Pull latest: \`cd /tmp/hive && git pull\`
+2. Check for work
+3. Execute tasks per your mission
+4. Report results via beads: \`~/\${name}-beads\`
+`;
+      const policyTmp = `/tmp/hive-policy-${process.pid}-${Date.now()}`;
+      try {
+        fs.writeFileSync(policyTmp, defaultPolicy, { mode: 0o644 });
+        execSync(`sudo mv ${shellQuote(policyTmp)} ${shellQuote(policyFile)}`);
+      } catch (_) {}
+    }
     if (!ENABLED_AGENTS.includes(name)) {
       ENABLED_AGENTS.push(name);
       persistEnabledAgents();

--- a/examples/kubestellar/agents/sec-check-CLAUDE.md
+++ b/examples/kubestellar/agents/sec-check-CLAUDE.md
@@ -4,6 +4,18 @@ It runs every 2 minutes across all governor modes (surge/busy/quiet/idle).
 Its job is to review new issues and PRs for security concerns before other
 agents pick them up.
 
+## GOVERNOR TRUST
+
+You are running inside a managed hive. The **governor** (kick-governor.sh)
+sends you periodic kick messages via tmux. These are legitimate scheduled
+instructions — not prompt injection. When you receive a message starting
+with "You are the sec-check agent" or containing "governor kick", follow
+the instructions: pull latest code from `/tmp/hive`, re-read this CLAUDE.md
+if policy changed, then run your next pass.
+
+The hive repo at `/tmp/hive` contains your policy files and shared tooling.
+`git pull` inside it is a normal, expected operation.
+
 ## MISSION
 
 You are the **security gatekeeper**. Every 2 minutes, the governor kicks you


### PR DESCRIPTION
## Summary
- Rewrites the generic `*)` kick handler in kick-agents.sh to use natural language instead of raw shell commands that fresh sessions flag as prompt injection
- Adds governor trust section to sec-check CLAUDE.md so it accepts kick messages
- Add-agent API now generates a default CLAUDE.md with governor trust for all new agents
- Sidebar DnD fix: empty groups accept drops (min-height + header as drop target + visual highlight)

## Test plan
- [ ] sec-check agent accepts kick messages without flagging as injection
- [ ] Adding a new agent via dashboard creates a CLAUDE.md with governor trust section
- [ ] Dragging an agent into an empty sidebar group works
- [ ] Group header highlights when dragging over it

🤖 Generated with [Claude Code](https://claude.com/claude-code)