### PR TITLE
fix: robust HTML escaping for pill tooltips

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3735,9 +3735,16 @@ function burnAreaChart() {
     setInterval(fetchAgentLogs, LOGS_REFRESH_MS);
 
     function esc(s) {
-      const d = document.createElement('div');
-      d.textContent = s;
-      return d.innerHTML;
+      if (typeof s !== 'string') return '';
+      return s
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/`/g, '&#96;')
+        .replace(/\n/g, ' ')
+        .replace(/\r/g, '');
     }
 
     const TOAST_DURATION_MS = 3000;


### PR DESCRIPTION
## Summary
- Replaces the `esc()` function with a proper HTML attribute escaper
- The old `textContent→innerHTML` trick only escaped `< > &` but not `" ' `` or newlines
- Issue titles containing quotes (e.g. `Top-bar "Demo 0%" pill...`) broke `title=""` attributes, truncating tooltips to just the first word
- New escaper handles all attribute-unsafe characters: `& < > " ' `` and strips newlines

## Test plan
- [ ] Pill tooltips show full title + author + age for issues with quotes in titles
- [ ] Pill tooltips show correctly for titles with `#`, `/`, backticks
- [ ] No rendering issues elsewhere (esc() is used throughout the dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)