### PR TITLE
feat: split runtime config into hive-runtime.yaml

### DIFF
--- a/bin/copilot-comment-checker.sh
+++ b/bin/copilot-comment-checker.sh
@@ -14,23 +14,32 @@ LOG="/var/log/kick-agents.log"
 REAL_GH="/usr/bin/gh"
 
 PROJECT_YAML="${HIVE_PROJECT_YAML:-/etc/hive/hive-project.yaml}"
+RUNTIME_YAML="${HIVE_RUNTIME_CONFIG:-/etc/hive/hive-runtime.yaml}"
 if [ ! -f "$PROJECT_YAML" ]; then
   PROJECT_YAML="$(find "$(dirname "$(dirname "$0")")/examples" -name 'hive-project.yaml' -type f 2>/dev/null | head -1)"
 fi
 
 log() { echo "[$(date -Is)] COPILOT-CHECK $*" >> "$LOG"; }
 
-# Read config
+# Read config — repos from runtime config first, classification from project config
 CONFIG=$(python3 -c "
-import yaml, sys, json
+import yaml, sys, json, os
 with open(sys.argv[1]) as f:
-    cfg = yaml.safe_load(f)
+    cfg = yaml.safe_load(f) or {}
+runtime_path = sys.argv[2] if len(sys.argv) > 2 else ''
+repos = cfg.get('project', {}).get('repos', [])
+if runtime_path and os.path.exists(runtime_path):
+    with open(runtime_path) as f:
+        rt = yaml.safe_load(f) or {}
+    rt_repos = rt.get('project', {}).get('repos', [])
+    if rt_repos:
+        repos = rt_repos
 result = {
-    'repos': cfg.get('project', {}).get('repos', []),
+    'repos': repos,
     'copilot': cfg.get('classification', {}).get('copilot_check', {})
 }
 print(json.dumps(result))
-" "$PROJECT_YAML" 2>/dev/null || echo '{"repos":[],"copilot":{}}')
+" "$PROJECT_YAML" "$RUNTIME_YAML" 2>/dev/null || echo '{"repos":[],"copilot":{}}')
 
 REPOS=$(echo "$CONFIG" | python3 -c "import json,sys; [print(r) for r in json.load(sys.stdin)['repos']]" 2>/dev/null)
 # Copilot code review posts as "Copilot"; the fix-agent posts as "copilot-swe-agent[bot]"

--- a/bin/enumerate-actionable.sh
+++ b/bin/enumerate-actionable.sh
@@ -24,28 +24,14 @@ if ! flock -n 200; then
   exit 0
 fi
 
-# Read repos from hive-project.yaml (single source of truth)
-PROJECT_YAML="${HIVE_PROJECT_YAML:-/etc/hive/hive-project.yaml}"
-if [ ! -f "$PROJECT_YAML" ]; then
-  PROJECT_YAML="$(find "$(dirname "$(dirname "$0")")/examples" -name 'hive-project.yaml' -type f 2>/dev/null | head -1)"
-fi
-
-# Source project config for AI author and primary repo
+# Source project config (reads hive-runtime.yaml for repos, falls back to hive-project.yaml)
 # shellcheck source=hive-config.sh
 source "$(dirname "$0")/hive-config.sh" 2>/dev/null || source /usr/local/bin/hive-config.sh 2>/dev/null || true
 
-if [ -f "$PROJECT_YAML" ]; then
-  mapfile -t REPOS < <(python3 -c "
-import yaml, sys
-with open(sys.argv[1]) as f:
-    cfg = yaml.safe_load(f)
-for r in cfg.get('project', {}).get('repos', []):
-    print(r)
-" "$PROJECT_YAML" 2>/dev/null)
-fi
+IFS=' ' read -ra REPOS <<< "${PROJECT_REPOS:-}"
 
 if [ ${#REPOS[@]} -eq 0 ]; then
-  echo "ERROR: no repos found in $PROJECT_YAML" >&2
+  echo "ERROR: no repos found in config" >&2
   exit 1
 fi
 

--- a/bin/hive-config.sh
+++ b/bin/hive-config.sh
@@ -21,56 +21,62 @@ HIVE_REPO_DIR="${HIVE_REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/
 export HIVE_REPO_DIR
 
 _HIVE_CONFIG="${HIVE_PROJECT_CONFIG:-/etc/hive/hive-project.yaml}"
+_HIVE_RUNTIME="${HIVE_RUNTIME_CONFIG:-/etc/hive/hive-runtime.yaml}"
 
-_hive_yq() {
+_hive_yq_file() {
+  local file="$1" path="$2"
   if command -v yq &>/dev/null; then
-    yq -r "$1" "$_HIVE_CONFIG" 2>/dev/null
+    yq -r "$path" "$file" 2>/dev/null
   elif command -v python3 &>/dev/null; then
     python3 -c "
 import yaml, sys, json
-with open('$_HIVE_CONFIG') as f:
+with open('$file') as f:
     d = yaml.safe_load(f)
-# Navigate dotted path
-path = '''$1'''.lstrip('.')
+path = '''$path'''.lstrip('.')
 parts = []
 current = ''
 for ch in path:
     if ch == '.' and not current.endswith('\\\\'):
-        parts.append(current)
-        current = ''
+        parts.append(current); current = ''
     elif ch == '[':
-        if current:
-            parts.append(current)
+        if current: parts.append(current)
         current = ch
     elif ch == ']':
-        current += ch
-        parts.append(current)
-        current = ''
-    else:
-        current += ch
-if current:
-    parts.append(current)
+        current += ch; parts.append(current); current = ''
+    else: current += ch
+if current: parts.append(current)
 val = d
 for p in parts:
-    if p.startswith('[') and p.endswith(']'):
-        val = val[int(p[1:-1])]
-    elif isinstance(val, dict):
-        val = val.get(p)
-    else:
-        val = None
-    if val is None:
-        break
-if isinstance(val, (list, dict)):
-    print(json.dumps(val))
-elif val is None:
-    print('null')
-else:
-    print(val)
+    if p.startswith('[') and p.endswith(']'): val = val[int(p[1:-1])]
+    elif isinstance(val, dict): val = val.get(p)
+    else: val = None
+    if val is None: break
+if isinstance(val, (list, dict)): print(json.dumps(val))
+elif val is None: print('null')
+else: print(val)
 " 2>/dev/null
   else
     echo ""
   fi
 }
+
+_hive_yq() {
+  _hive_yq_file "$_HIVE_CONFIG" "$1"
+}
+
+# Read from runtime config first, fall back to project config
+_hive_runtime_yq() {
+  local val=""
+  if [[ -f "$_HIVE_RUNTIME" ]]; then
+    val=$(_hive_yq_file "$_HIVE_RUNTIME" "$1")
+  fi
+  if [[ "$val" == "null" || -z "$val" || "$val" == "[]" ]]; then
+    _hive_yq "$1"
+  else
+    echo "$val"
+  fi
+}
+
 
 _hive_read() {
   local val
@@ -96,17 +102,34 @@ _hive_read_array() {
   fi
 }
 
+# Runtime-aware array reader: checks hive-runtime.yaml first, falls back to hive-project.yaml
+_hive_read_runtime_array() {
+  local val=""
+  if [[ -f "$_HIVE_RUNTIME" ]]; then
+    val=$(_hive_yq_file "$_HIVE_RUNTIME" "$1")
+  fi
+  if [[ "$val" == "null" || -z "$val" || "$val" == "[]" ]]; then
+    _hive_read_array "$1" "${2:-}"
+  else
+    if command -v python3 &>/dev/null; then
+      python3 -c "import json; print(' '.join(json.loads('''$val''')))" 2>/dev/null || echo "${2:-}"
+    else
+      echo "$val" | tr -d '[]",' | xargs
+    fi
+  fi
+}
+
 if [[ -f "$_HIVE_CONFIG" ]]; then
   # Project
   PROJECT_NAME=$(_hive_read "project.name" "")
   PROJECT_ORG=$(_hive_read "project.org" "")
   PROJECT_PRIMARY_REPO=$(_hive_read "project.primary_repo" "")
-  PROJECT_REPOS=$(_hive_read_array "project.repos" "")
+  PROJECT_REPOS=$(_hive_read_runtime_array "project.repos" "")
   PROJECT_AI_AUTHOR=$(_hive_read "project.ai_author" "")
   PROJECT_WEBSITE=$(_hive_read "project.website" "")
 
   # Agents
-  AGENTS_ENABLED=$(_hive_read_array "agents.enabled" "supervisor scanner reviewer")
+  AGENTS_ENABLED=$(_hive_read_runtime_array "agents.enabled" "supervisor scanner reviewer")
   BEADS_BASE=$(_hive_read "agents.beads_base" "/home/dev")
   AGENTS_WORKDIR=$(_hive_read "agents.workdir" "")
 

--- a/bin/hive-deploy.sh
+++ b/bin/hive-deploy.sh
@@ -143,13 +143,43 @@ if [ -n "$DISCORD_RESTART_NEEDED" ] && [ -z "$DISCORD_CHANGED" ]; then
     log "WARN: failed to restart hive-discord (drift)"
 fi
 
-# Sync hive-project.yaml to /etc/hive if changed
+# Merge hive-project.yaml: update code-managed keys from the repo while
+# preserving runtime-managed keys (sidebar groups, repo list, enabled agents)
+# that the dashboard writes to /etc/hive/.
 HIVE_PROJECT="${HIVE_PROJECT_CONFIG_SRC:-$HIVE_REPO/examples/kubestellar/hive-project.yaml}"
 HIVE_PROJECT_INSTALLED="/etc/hive/hive-project.yaml"
-if [ -f "$HIVE_PROJECT" ] && ! cmp -s "$HIVE_PROJECT" "$HIVE_PROJECT_INSTALLED" 2>/dev/null; then
-  sudo cp "$HIVE_PROJECT" "$HIVE_PROJECT_INSTALLED" && \
-    SYNCED="$SYNCED hive-project.yaml" || \
-    log "WARN: failed to sync hive-project.yaml"
+if [ -f "$HIVE_PROJECT" ]; then
+  if [ ! -f "$HIVE_PROJECT_INSTALLED" ]; then
+    sudo mkdir -p /etc/hive
+    sudo cp "$HIVE_PROJECT" "$HIVE_PROJECT_INSTALLED" && \
+      SYNCED="$SYNCED hive-project.yaml(seed)" || \
+      log "WARN: failed to seed hive-project.yaml"
+  elif ! cmp -s "$HIVE_PROJECT" "$HIVE_PROJECT_INSTALLED" 2>/dev/null; then
+    # Merge: repo updates code-managed keys, runtime keys preserved
+    MERGED=$(python3 -c "
+import yaml, sys, copy
+RUNTIME_KEYS = {'agents.sidebar', 'agents.enabled', 'project.repos'}
+with open(sys.argv[1]) as f: repo = yaml.safe_load(f) or {}
+with open(sys.argv[2]) as f: installed = yaml.safe_load(f) or {}
+merged = copy.deepcopy(repo)
+for dotkey in RUNTIME_KEYS:
+    parts = dotkey.split('.')
+    src, dst = installed, merged
+    for p in parts[:-1]:
+        src = src.get(p, {}) if isinstance(src, dict) else {}
+        if p not in dst: dst[p] = {}
+        dst = dst[p]
+    leaf = parts[-1]
+    if leaf in src:
+        dst[leaf] = src[leaf]
+print(yaml.dump(merged, default_flow_style=False))
+" "$HIVE_PROJECT" "$HIVE_PROJECT_INSTALLED" 2>/dev/null) && {
+      MERGE_TMP="/tmp/hive-project-merge-$$.yaml"
+      echo "$MERGED" > "$MERGE_TMP"
+      sudo mv "$MERGE_TMP" "$HIVE_PROJECT_INSTALLED"
+      SYNCED="$SYNCED hive-project.yaml(merged)"
+    } || log "WARN: failed to merge hive-project.yaml"
+  fi
 fi
 
 # Sync systemd units if changed

--- a/bin/hive-deploy.sh
+++ b/bin/hive-deploy.sh
@@ -143,43 +143,15 @@ if [ -n "$DISCORD_RESTART_NEEDED" ] && [ -z "$DISCORD_CHANGED" ]; then
     log "WARN: failed to restart hive-discord (drift)"
 fi
 
-# Merge hive-project.yaml: update code-managed keys from the repo while
-# preserving runtime-managed keys (sidebar groups, repo list, enabled agents)
-# that the dashboard writes to /etc/hive/.
+# Sync hive-project.yaml (code-managed config) — safe to overwrite since
+# runtime customizations (sidebar, repos, agents) live in hive-runtime.yaml
 HIVE_PROJECT="${HIVE_PROJECT_CONFIG_SRC:-$HIVE_REPO/examples/kubestellar/hive-project.yaml}"
 HIVE_PROJECT_INSTALLED="/etc/hive/hive-project.yaml"
-if [ -f "$HIVE_PROJECT" ]; then
-  if [ ! -f "$HIVE_PROJECT_INSTALLED" ]; then
-    sudo mkdir -p /etc/hive
-    sudo cp "$HIVE_PROJECT" "$HIVE_PROJECT_INSTALLED" && \
-      SYNCED="$SYNCED hive-project.yaml(seed)" || \
-      log "WARN: failed to seed hive-project.yaml"
-  elif ! cmp -s "$HIVE_PROJECT" "$HIVE_PROJECT_INSTALLED" 2>/dev/null; then
-    # Merge: repo updates code-managed keys, runtime keys preserved
-    MERGED=$(python3 -c "
-import yaml, sys, copy
-RUNTIME_KEYS = {'agents.sidebar', 'agents.enabled', 'project.repos'}
-with open(sys.argv[1]) as f: repo = yaml.safe_load(f) or {}
-with open(sys.argv[2]) as f: installed = yaml.safe_load(f) or {}
-merged = copy.deepcopy(repo)
-for dotkey in RUNTIME_KEYS:
-    parts = dotkey.split('.')
-    src, dst = installed, merged
-    for p in parts[:-1]:
-        src = src.get(p, {}) if isinstance(src, dict) else {}
-        if p not in dst: dst[p] = {}
-        dst = dst[p]
-    leaf = parts[-1]
-    if leaf in src:
-        dst[leaf] = src[leaf]
-print(yaml.dump(merged, default_flow_style=False))
-" "$HIVE_PROJECT" "$HIVE_PROJECT_INSTALLED" 2>/dev/null) && {
-      MERGE_TMP="/tmp/hive-project-merge-$$.yaml"
-      echo "$MERGED" > "$MERGE_TMP"
-      sudo mv "$MERGE_TMP" "$HIVE_PROJECT_INSTALLED"
-      SYNCED="$SYNCED hive-project.yaml(merged)"
-    } || log "WARN: failed to merge hive-project.yaml"
-  fi
+if [ -f "$HIVE_PROJECT" ] && ! cmp -s "$HIVE_PROJECT" "$HIVE_PROJECT_INSTALLED" 2>/dev/null; then
+  sudo mkdir -p /etc/hive
+  sudo cp "$HIVE_PROJECT" "$HIVE_PROJECT_INSTALLED" && \
+    SYNCED="$SYNCED hive-project.yaml" || \
+    log "WARN: failed to sync hive-project.yaml"
 fi
 
 # Sync systemd units if changed

--- a/bin/outreach-tracker.sh
+++ b/bin/outreach-tracker.sh
@@ -14,25 +14,34 @@ LOG="/var/log/kick-agents.log"
 REAL_GH="/usr/bin/gh"
 
 PROJECT_YAML="${HIVE_PROJECT_YAML:-/etc/hive/hive-project.yaml}"
+RUNTIME_YAML="${HIVE_RUNTIME_CONFIG:-/etc/hive/hive-runtime.yaml}"
 if [ ! -f "$PROJECT_YAML" ]; then
   PROJECT_YAML="$(find "$(dirname "$(dirname "$0")")/examples" -name 'hive-project.yaml' -type f 2>/dev/null | head -1)"
 fi
 
 log() { echo "[$(date -Is)] OUTREACH-TRACK $*" >> "$LOG"; }
 
-# Read config
+# Read config — repos from runtime config first, rest from project config
 CONFIG=$(python3 -c "
-import yaml, sys, json
+import yaml, sys, json, os
 with open(sys.argv[1]) as f:
-    cfg = yaml.safe_load(f)
+    cfg = yaml.safe_load(f) or {}
+runtime_path = sys.argv[2] if len(sys.argv) > 2 else ''
+repos = cfg.get('project', {}).get('repos', [])
+if runtime_path and os.path.exists(runtime_path):
+    with open(runtime_path) as f:
+        rt = yaml.safe_load(f) or {}
+    rt_repos = rt.get('project', {}).get('repos', [])
+    if rt_repos:
+        repos = rt_repos
 result = {
     'ai_author': cfg.get('project', {}).get('ai_author', ''),
     'org': cfg.get('project', {}).get('org', ''),
-    'repos': cfg.get('project', {}).get('repos', []),
+    'repos': repos,
     'target_placements': cfg.get('outreach', {}).get('target_placements', 0),
 }
 print(json.dumps(result))
-" "$PROJECT_YAML" 2>/dev/null || echo '{}')
+" "$PROJECT_YAML" "$RUNTIME_YAML" 2>/dev/null || echo '{}')
 
 AI_AUTHOR=$(echo "$CONFIG" | python3 -c "import json,sys; print(json.load(sys.stdin).get('ai_author',''))" 2>/dev/null)
 ORG=$(echo "$CONFIG" | python3 -c "import json,sys; print(json.load(sys.stdin).get('org',''))" 2>/dev/null)

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -8,30 +8,59 @@ const yaml = (() => { try { return require('js-yaml'); } catch (_) { return null
 const app = express();
 app.use(express.json());
 
-// Load project config from hive-project.yaml
+// Load project config from hive-project.yaml (code-managed, synced from repo)
 const CONFIG_PATH = process.env.HIVE_PROJECT_CONFIG || '/etc/hive/hive-project.yaml';
-let projectConfig = {};
-try {
-  const raw = fs.readFileSync(CONFIG_PATH, 'utf8');
-  if (yaml) {
-    projectConfig = yaml.load(raw) || {};
-  } else {
-    const { execSync } = require('child_process');
-    const json = execSync(`python3 -c "import yaml,json,sys; print(json.dumps(yaml.safe_load(sys.stdin)))" < "${CONFIG_PATH}"`, { encoding: 'utf8' });
-    projectConfig = JSON.parse(json);
+// Runtime config — dashboard customizations that survive deploys
+const RUNTIME_CONFIG_PATH = process.env.HIVE_RUNTIME_CONFIG || '/etc/hive/hive-runtime.yaml';
+
+function _loadYaml(filePath) {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    if (yaml) return yaml.load(raw) || {};
+    const json = execSync(
+      `python3 -c "import yaml,json,sys; print(json.dumps(yaml.safe_load(sys.stdin)))" < "${filePath}"`,
+      { encoding: 'utf8' }
+    );
+    return JSON.parse(json);
+  } catch (_) { return {}; }
+}
+
+let projectConfig = _loadYaml(CONFIG_PATH);
+let runtimeConfig = _loadYaml(RUNTIME_CONFIG_PATH);
+
+// Migrate: if runtime file is empty but project config has runtime keys, extract them
+if (!runtimeConfig.agents && !runtimeConfig.project) {
+  const existingSidebar = (projectConfig.agents || {}).sidebar;
+  const existingEnabled = (projectConfig.agents || {}).enabled;
+  const existingRepos = (projectConfig.project || {}).repos;
+  if (existingSidebar || existingEnabled || existingRepos) {
+    runtimeConfig = {};
+    if (existingSidebar) { runtimeConfig.agents = runtimeConfig.agents || {}; runtimeConfig.agents.sidebar = existingSidebar; }
+    if (existingEnabled) { runtimeConfig.agents = runtimeConfig.agents || {}; runtimeConfig.agents.enabled = existingEnabled; }
+    if (existingRepos) { runtimeConfig.project = { repos: existingRepos }; }
+    _persistRuntime();
   }
-} catch (_) { /* no config file — use defaults */ }
+}
 
 const PROJECT_NAME = (projectConfig.project || {}).name || '';
 const PROJECT_PRIMARY_REPO = (projectConfig.project || {}).primary_repo || '';
 const PROJECT_ORG = (projectConfig.project || {}).org || '';
 const DASHBOARD_TITLE = ((projectConfig.dashboard || {}).title) || (PROJECT_NAME ? PROJECT_NAME + ' Hive' : 'Hive');
 const HIVE_REPO_DIR = process.env.HIVE_REPO_DIR || path.resolve(__dirname, '..');
-let ENABLED_AGENTS = ((projectConfig.agents || {}).enabled || ['supervisor', 'scanner', 'reviewer', 'architect', 'outreach']);
+let ENABLED_AGENTS = ((runtimeConfig.agents || {}).enabled
+  || (projectConfig.agents || {}).enabled
+  || ['supervisor', 'scanner', 'reviewer', 'architect', 'outreach']);
 let ENABLED_AGENTS_PLUS_ALL = [...ENABLED_AGENTS, 'all'];
 
 const CONFIG_REPO_SOURCE = process.env.HIVE_PROJECT_CONFIG_SRC
   || path.join(HIVE_REPO_DIR, 'examples', 'kubestellar', 'hive-project.yaml');
+
+function _persistRuntime() {
+  const dumpYaml = yaml ? yaml.dump(runtimeConfig) : JSON.stringify(runtimeConfig, null, 2);
+  const tmpFile = `/tmp/hive-runtime-${process.pid}-${Date.now()}.yaml`;
+  fs.writeFileSync(tmpFile, dumpYaml);
+  execSync(`sudo mv ${tmpFile} ${RUNTIME_CONFIG_PATH}`);
+}
 
 function persistProjectConfig() {
   const dumpYaml = yaml ? yaml.dump(projectConfig) : JSON.stringify(projectConfig, null, 2);
@@ -44,10 +73,10 @@ function persistProjectConfig() {
 }
 
 function persistEnabledAgents() {
-  if (!projectConfig.agents) projectConfig.agents = {};
-  projectConfig.agents.enabled = ENABLED_AGENTS.slice();
+  if (!runtimeConfig.agents) runtimeConfig.agents = {};
+  runtimeConfig.agents.enabled = ENABLED_AGENTS.slice();
   ENABLED_AGENTS_PLUS_ALL = [...ENABLED_AGENTS, 'all'];
-  persistProjectConfig();
+  _persistRuntime();
 }
 
 // ── Centralized backend/model config (JS equivalent of backends.conf) ──────
@@ -1698,7 +1727,7 @@ app.get('/api/config/governor', (_req, res) => {
       pullbackSeconds: parseInt(govEnv.SENSING_PULLBACK_SECONDS || '900', 10),
     };
 
-    const repos = ((projectConfig.project || {}).repos || []).slice();
+    const repos = ((runtimeConfig.project || {}).repos || (projectConfig.project || {}).repos || []).slice();
     res.json({ agents, thresholds, labels, budget, notifications, health, repos, sensing });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -1885,9 +1914,9 @@ app.delete('/api/config/governor/agents/:name', (req, res) => {
 app.put('/api/config/governor/repos', (req, res) => {
   try {
     const list = req.body.list || [];
-    if (!projectConfig.project) projectConfig.project = {};
-    projectConfig.project.repos = list;
-    persistProjectConfig();
+    if (!runtimeConfig.project) runtimeConfig.project = {};
+    runtimeConfig.project.repos = list;
+    _persistRuntime();
     res.json({ ok: true });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -1897,7 +1926,8 @@ app.put('/api/config/governor/repos', (req, res) => {
 // ── Sidebar layout (agent order + groups) ──────────────────────────────────
 app.get('/api/config/sidebar', (_req, res) => {
   try {
-    const sidebar = (projectConfig.agents || {}).sidebar || null;
+    const sidebar = (runtimeConfig.agents || {}).sidebar
+      || (projectConfig.agents || {}).sidebar || null;
     res.json({ sidebar });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -1908,9 +1938,9 @@ app.put('/api/config/sidebar', (req, res) => {
   try {
     const { groups } = req.body;
     if (!Array.isArray(groups)) return res.status(400).json({ error: 'groups must be an array' });
-    if (!projectConfig.agents) projectConfig.agents = {};
-    projectConfig.agents.sidebar = { groups };
-    persistProjectConfig();
+    if (!runtimeConfig.agents) runtimeConfig.agents = {};
+    runtimeConfig.agents.sidebar = { groups };
+    _persistRuntime();
     res.json({ ok: true });
   } catch (err) {
     res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
- Dashboard customizations (sidebar groups, repo list, enabled agents) were destroyed every 60s when deploy overwrote /etc/hive/hive-project.yaml from the repo copy
- Split into two config files: hive-project.yaml (code-managed, synced from repo) and hive-runtime.yaml (runtime-managed, never touched by deploy)
- All scripts updated to check runtime config first for runtime keys
- Auto-migration extracts existing runtime keys on first server start

## Test plan
- [ ] Add sidebar group → refresh → persists
- [ ] Add repo in governor config → persists after deploy
- [ ] Deploy fires → sidebar groups and repo list survive