### PR TITLE
fix: preserve newlines in focused agent detail summary

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1682,7 +1682,7 @@
         </div>
         <div class="oc-detail-indicators">${agentIndicators(a.name)}</div>
         <div class="oc-detail-summary-wrap">
-          <div class="oc-detail-summary" id="oc-summary-scroll">${a.liveSummary ? esc(a.liveSummary) : '<span style="color:#9ca3af">No activity summary</span>'}</div>
+          <div class="oc-detail-summary" id="oc-summary-scroll">${a.liveSummary ? escBlock(a.liveSummary) : '<span style="color:#9ca3af">No activity summary</span>'}</div>
           <button class="oc-summary-follow-btn" id="oc-summary-follow" title="Follow new output" onclick="ocSummaryResumeTail()">⬇</button>
         </div>
         <div class="oc-chat-prompt">


### PR DESCRIPTION
## Summary
- In-focus agent card summary used `esc()` which strips `\n` → spaces, causing run-on text
- Switch to `escBlock()` which converts `\n` → `<br>`, preserving line breaks
- The card row view was already fixed in PR #379; this fixes the detail/expanded view

## Test plan
- [ ] Click on sec-check (or any agent with multi-line summary) — text should show line breaks
- [ ] Card row view still shows line breaks (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)