### PR TITLE
fix: show GH API auth identity on diagnostics card

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -3737,6 +3737,12 @@ function burnAreaChart() {
       const ghCoreLimit = ghRate.core?.limit || 5000;
       const ghCorePct = ghCoreLimit > 0 ? Math.round((ghCoreUsed / ghCoreLimit) * 100) : 0;
       const ghResetAt = ghRate.core?.reset ? new Date(ghRate.core.reset * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '—';
+      const ghIdentity = ghRate.identity || {};
+      const ghIdentityLabel = ghIdentity.label || 'unknown';
+      const ghIdentityType = ghIdentity.type || 'unknown';
+      const ghIdentityBadge = ghIdentityType === 'app'
+        ? `<span style="display:inline-block;font-size:0.6rem;background:#dbeafe;color:#1d4ed8;padding:1px 6px;border-radius:4px;font-weight:500">App</span>`
+        : `<span style="display:inline-block;font-size:0.6rem;background:#fef3c7;color:#92400e;padding:1px 6px;border-radius:4px;font-weight:500">Personal</span>`;
 
       const totals = tokens.totals || {};
       const tokenInput = (totals.input || 0).toLocaleString();
@@ -3752,6 +3758,7 @@ function burnAreaChart() {
         <div style="${cardStyle}"><div style="${labelStyle}">Agent States</div>${agentRows || '<div style="color:var(--muted);font-size:0.8rem">No agents</div>'}</div>
         <div style="${cardStyle}">
           <div style="${labelStyle}">GitHub API</div>
+          <div style="${rowStyle}"><span>Identity</span><span>${ghIdentityBadge} ${esc(ghIdentityLabel)}</span></div>
           <div style="${rowStyle}"><span>Core API</span><span style="font-weight:600">${ghCoreUsed} / ${ghCoreLimit} (${ghCorePct}%)</span></div>
           <div style="${rowStyle}"><span>Resets at</span><span>${ghResetAt}</span></div>
           <div style="margin-top:6px;height:6px;background:#e5e7eb;border-radius:3px;overflow:hidden">

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -187,6 +187,25 @@ setInterval(fetchGhRateLimits, GH_RATE_REFRESH_MS);
 const GH_AUTH_CHECK_MS = 60000;
 let ghAuthOk = true;
 let ghAuthLastChecked = null;
+let ghAuthIdentity = null;
+
+// Detect GH auth identity at startup — App vs personal account
+(function detectGhIdentity() {
+  const appId = process.env.GH_APP_ID
+    || ((projectConfig.github_app || {}).app_id)
+    || '';
+  if (appId) {
+    ghAuthIdentity = { type: 'app', label: `GitHub App (${appId})` };
+    return;
+  }
+  execFile('bash', ['-c', "gh api user --jq '.login' 2>/dev/null || echo ''"], { timeout: 10000 }, (_err, stdout) => {
+    const login = (stdout || '').trim();
+    ghAuthIdentity = login
+      ? { type: 'personal', label: login }
+      : { type: 'unknown', label: 'unknown' };
+  });
+})();
+
 function checkGhAuth() {
   execFile('bash', ['-c', 'gh api rate_limit --jq \'{ limit: .rate.limit, used: .rate.used, remaining: .rate.remaining, reset: .rate.reset }\' 2>&1'], { timeout: 15000 }, (err, stdout, stderr) => {
     const output = (stdout || '') + (stderr || '');
@@ -203,6 +222,9 @@ function checkGhAuth() {
         remaining: parsed.remaining || 0,
         reset: parsed.reset || 0,
       };
+    }
+    if (ghAuthIdentity) {
+      ghRateLimitsCache.identity = ghAuthIdentity;
     }
     if (was && !ghAuthOk) console.error('gh auth DOWN:', output.trim());
     if (!was && ghAuthOk) console.log('gh auth recovered (limit=' + limit + ')');


### PR DESCRIPTION
## Summary
- Server detects whether GH auth uses a GitHub App token or personal account at startup
- Identity (app ID or username) is included in the rate limit data sent to the dashboard
- Diagnostics GitHub API card shows an "Identity" row with a colored badge: blue "App" or yellow "Personal"

## Test plan
- [ ] GitHub API card shows identity row with badge and username/app-id
- [ ] If using GitHub App: blue "App" badge with app ID
- [ ] If using personal token: yellow "Personal" badge with GitHub username
- [ ] Rate limit data still shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)