### PR TITLE
fix: agent disappears immediately after delete

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4869,6 +4869,8 @@ function burnAreaChart() {
         .then(() => {
           showToast(`Agent "${name}" deleted`, 'success');
           closeConfigDialog();
+          // Remove from cached agents so cards disappear immediately
+          window._lastAgents = (window._lastAgents || []).filter(a => a.name !== name);
           // Remove from sidebar layout
           if (_sidebarLayout && _sidebarLayout.groups) {
             for (const g of _sidebarLayout.groups) {
@@ -4877,6 +4879,7 @@ function burnAreaChart() {
             _saveSidebarLayout(_sidebarLayout.groups);
           }
           ocUpdateSidebarAgents();
+          renderAgents(window._lastAgents);
         })
         .catch(err => showToast(`Failed: ${err.message}`, 'error'));
     }


### PR DESCRIPTION
## Summary
- After deleting an agent via config dialog, remove it from `window._lastAgents` and re-render agent cards
- Previously required a page refresh for the deleted agent to disappear from the main view

## Test plan
- [ ] Delete an agent via config dialog → agent card and sidebar entry disappear immediately
- [ ] No page refresh needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)