### PR TITLE
fix: rewrite generic kick prompt to avoid Copilot rejection

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -1135,9 +1135,7 @@ case "$TARGET" in
     else
       _GENERIC_POLICY_INSTR="Policy unchanged — continue with standing instructions."
     fi
-    _GENERIC_MSG="You are the ${TARGET} agent. This is a scheduled governor kick at ${_now_et}. ${_GENERIC_POLICY_INSTR}
-Pull latest changes: cd /tmp/hive && git pull
-Then run your next pass as described in your CLAUDE.md."
+    _GENERIC_MSG="[agent:${TARGET}] [KICK] git pull /tmp/hive. ${_GENERIC_POLICY_INSTR} Run your next pass as described in your CLAUDE.md. Kick time: ${_now_et}."
     apply_model_if_changed "$TARGET" "$TARGET" && kick "$TARGET" "$_GENERIC_MSG" "$TARGET"
     ;;
 esac


### PR DESCRIPTION
## Summary
- Generic kick message for new agents (like sec-check) used "You are the X agent. This is a scheduled governor kick" framing
- Copilot CLI interprets this as prompt injection / social engineering and refuses to follow the instructions
- Rewrite to match the scanner's proven format: `[agent:name] [KICK] git pull /tmp/hive. Run your pass per CLAUDE.md.`
- This is direct and task-oriented, avoiding the role-play framing that triggers Copilot's safety layer

## Test plan
- [ ] Kick sec-check after deploy — should accept the prompt and run its pass
- [ ] Restarts should drop significantly (was 23 restarts from repeated rejections)
- [ ] Other agents unaffected (scanner/reviewer/etc. have their own specific messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)