### PR TITLE
fix: generic kick tells agents to read /etc/hive/<agent>-CLAUDE.md

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -1135,7 +1135,13 @@ case "$TARGET" in
     else
       _GENERIC_POLICY_INSTR="Policy unchanged — continue with standing instructions."
     fi
-    _GENERIC_MSG="[agent:${TARGET}] [KICK] git pull /tmp/hive. ${_GENERIC_POLICY_INSTR} Run your next pass as described in your CLAUDE.md. Kick time: ${_now_et}."
+    _AGENT_CLAUDE="/etc/hive/${TARGET}-CLAUDE.md"
+    if [[ -f "$_AGENT_CLAUDE" ]]; then
+      _GENERIC_INSTR="Read ${_AGENT_CLAUDE} for your instructions and run your next pass."
+    else
+      _GENERIC_INSTR="Run your next pass as described in your CLAUDE.md."
+    fi
+    _GENERIC_MSG="[agent:${TARGET}] [KICK] git pull /tmp/hive. ${_GENERIC_POLICY_INSTR} ${_GENERIC_INSTR} Kick time: ${_now_et}."
     apply_model_if_changed "$TARGET" "$TARGET" && kick "$TARGET" "$_GENERIC_MSG" "$TARGET"
     ;;
 esac


### PR DESCRIPTION
## Summary
- Generic kick message now checks for `/etc/hive/<agent>-CLAUDE.md` at kick time
- If found, explicitly tells the agent to `Read /etc/hive/<agent>-CLAUDE.md for your instructions`
- Falls back to the old generic instruction for agents without a dedicated CLAUDE.md
- Fixes sec-check (and any future agents with `/etc/hive/` instructions) not finding their policy

## Context
sec-check agent was restarting 42 times because it couldn't find its instructions — the generic kick said "Run your next pass as described in your CLAUDE.md" which resolved to the console project's CLAUDE.md, not `/etc/hive/sec-check-CLAUDE.md`.