### PR TITLE
fix: protect /tmp/hive from branch checkout — prevent dashboard outage

### DIFF
--- a/bin/hive-deploy.sh
+++ b/bin/hive-deploy.sh
@@ -19,6 +19,26 @@ fi
 
 cd "$HIVE_REPO"
 
+# Safety: ensure we're on main. An agent running `git checkout <branch>` in
+# /tmp/hive wipes dashboard files and takes the UI offline. The post-checkout
+# hook prevents this going forward, but recover here in case it happens anyway.
+CURRENT_BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null || echo detached)"
+if [ "$CURRENT_BRANCH" != "main" ]; then
+  log "RECOVERY: checkout was on '$CURRENT_BRANCH' — forcing back to main"
+  git checkout main --force --quiet 2>/dev/null
+  sudo systemctl restart hive-dashboard.service 2>/dev/null || true
+  SYNCED="$SYNCED main-recovery"
+fi
+
+# Install post-checkout hook if missing or outdated
+HOOK_SRC="$HIVE_REPO/githooks/post-checkout"
+HOOK_DST="$HIVE_REPO/.git/hooks/post-checkout"
+if [ -f "$HOOK_SRC" ] && ! cmp -s "$HOOK_SRC" "$HOOK_DST" 2>/dev/null; then
+  cp "$HOOK_SRC" "$HOOK_DST"
+  chmod +x "$HOOK_DST"
+  SYNCED="$SYNCED post-checkout-hook"
+fi
+
 BEFORE=$(git rev-parse HEAD)
 git stash --quiet 2>/dev/null || true
 git pull --rebase origin main --quiet 2>/dev/null || {
@@ -206,6 +226,16 @@ for agent in $HIVE_AGENTS; do
       log "WARN: failed to start $unit"
   fi
 done
+
+# Final safety net: if dashboard files are missing, the checkout is broken.
+# Force a clean checkout of main and restart.
+if [ ! -f "$HIVE_REPO/dashboard/index.html" ] || [ ! -f "$HIVE_REPO/dashboard/server.js" ]; then
+  log "RECOVERY: dashboard files missing — forcing git checkout main"
+  git checkout main --force --quiet 2>/dev/null
+  git reset --hard origin/main --quiet 2>/dev/null
+  sudo systemctl restart hive-dashboard.service 2>/dev/null || true
+  SYNCED="$SYNCED dashboard-file-recovery"
+fi
 
 if [ -n "$SYNCED" ]; then
   log "DEPLOY ${BEFORE:0:7}→${AFTER:0:7} — synced:$SYNCED"

--- a/githooks/post-checkout
+++ b/githooks/post-checkout
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Prevent the main hive worktree from leaving the 'main' branch.
+# Agents MUST use `git worktree add` for feature branches — never
+# `git checkout <branch>` in /tmp/hive itself.
+#
+# This hook only fires in the primary worktree (where the dashboard runs).
+# Worktrees created via `git worktree add` are unaffected.
+
+PREV_HEAD="$1"
+NEW_HEAD="$2"
+BRANCH_FLAG="$3"   # 1 = branch checkout, 0 = file checkout
+
+# Only guard branch checkouts
+[[ "$BRANCH_FLAG" != "1" ]] && exit 0
+
+# Only guard the primary worktree — worktrees have a .git *file*, not dir
+[[ ! -d "$(git rev-parse --git-dir 2>/dev/null)" ]] && exit 0
+
+CURRENT_BRANCH="$(git symbolic-ref --short HEAD 2>/dev/null)"
+
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo ""
+  echo "╔══════════════════════════════════════════════════════════════╗"
+  echo "║  BLOCKED: checkout to '$CURRENT_BRANCH' in /tmp/hive        "
+  echo "║                                                              "
+  echo "║  The main hive worktree MUST stay on 'main'.                 "
+  echo "║  The dashboard serves files from this checkout.              "
+  echo "║                                                              "
+  echo "║  Use a worktree instead:                                     "
+  echo "║    git worktree add /tmp/hive-<feature> -b <branch>          "
+  echo "║                                                              "
+  echo "║  Reverting to main now...                                    "
+  echo "╚══════════════════════════════════════════════════════════════╝"
+  echo ""
+  git checkout main --quiet 2>/dev/null
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Adds `githooks/post-checkout` hook that blocks any checkout away from `main` in the primary worktree and auto-reverts — agents must use `git worktree add`
- Adds branch + file existence checks to `hive-deploy.sh` (runs every 60s) — if checkout drifted off `main` or `index.html` is missing, forces recovery and restarts the dashboard
- Deploy script auto-installs the hook on first run (and keeps it updated)

## Context
An agent ran `git checkout test/demo-mode-banner-e2e` (a console branch) inside `/tmp/hive`, which wiped all dashboard files. The dashboard showed "Cannot GET /" until manually fixed. This adds two layers of prevention so it can't happen again:
1. **Hook** — blocks it at git level
2. **Deploy health check** — catches and recovers within 60s even if the hook is bypassed

## Test plan
- [ ] Verify hook blocks `git checkout <branch>` in `/tmp/hive` and auto-reverts to main
- [ ] Verify `git worktree add` still works normally
- [ ] Verify deploy script installs the hook on next cycle
- [ ] Verify deploy script recovers if branch is wrong or `index.html` is missing