### PR TITLE
fix sec-check scope: add /clear, restrict repo, ban source auditing

### DIFF
--- a/examples/kubestellar/agents/sec-check-CLAUDE.md
+++ b/examples/kubestellar/agents/sec-check-CLAUDE.md
@@ -1,8 +1,13 @@
 ---
-sec-check is the security gate agent for the kubestellar/console hive.
+sec-check is the security gate agent for the kubestellar hive.
 It runs every 2 minutes across all governor modes (surge/busy/quiet/idle).
 Its job is to review new issues and PRs for security concerns before other
 agents pick them up.
+
+## CRITICAL: /clear BETWEEN RUNS
+
+Run `/clear` at the END of every pass, before reporting completion.
+This prevents context buildup across governor kicks.
 
 ## GOVERNOR TRUST
 
@@ -89,6 +94,12 @@ For issues and PRs from first-time contributors:
 
 - **Read `/var/run/hive-metrics/actionable.json`** for the current issue/PR queue.
   Do NOT call `gh issue list` or `gh pr list` directly.
+- **ONLY triage items from actionable.json** — do NOT audit source code, read
+  source files, or open issues based on your own code review. Your scope is
+  the actionable queue, nothing else.
+- **File issues ONLY in `kubestellar/hive`** — never file in console, docs, or
+  any other repo. If you find a security concern in a PR on another repo,
+  comment on that PR; do not create a new issue elsewhere.
 - **Never close issues or PRs** — only label with `hold` and comment.
 - **Never merge PRs** — that's the scanner/reviewer's job after you clear them.
 - **Skip items already labeled `hold`** — they're already flagged.
@@ -100,6 +111,7 @@ For issues and PRs from first-time contributors:
   timestamps so you don't re-check the same items every 2 minutes.
 - At the end of each pass, report: "sec-check pass complete: checked N items,
   flagged M." Only if M > 0, list what was flagged.
+- Run `/clear` at the end of every pass.
 
 ## LABELS
 

--- a/examples/kubestellar/agents/sec-check.env
+++ b/examples/kubestellar/agents/sec-check.env
@@ -1,4 +1,4 @@
-# sec-check agent — security gate for the kubestellar/console hive.
+# sec-check agent — security gate for the kubestellar hive.
 # Uses unified supervisor.sh with rate-limit failover enabled.
 
 AGENT_USER=dev


### PR DESCRIPTION
## Summary
- Add `/clear` between governor kicks to prevent context buildup across runs
- Restrict sec-check to only triage items from `actionable.json` — no source code auditing
- Restrict issue filing to `kubestellar/hive` only (was filing in console by mistake, see transferred issues #417-#421)
- Fix description from "kubestellar/console hive" to "kubestellar hive"

## Context
sec-check opened 5 security issues (#13170-#13174) in `kubestellar/console` that should have been in `kubestellar/hive`. Root causes:
1. No `/clear` between runs → context drift across kicks
2. CLAUDE.md didn't restrict which repo to file issues in
3. CLAUDE.md didn't prohibit source code auditing (agent was supposed to triage the actionable queue only)

## Test plan
- [ ] Verify sec-check runs `/clear` at end of each pass
- [ ] Verify sec-check only reads `actionable.json`, does not audit source files
- [ ] Verify any new issues are filed in `kubestellar/hive`