### PR TITLE
feat: add toggleable Clear on Kick per agent

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -638,23 +638,32 @@ kick() {
   fi
 
   # Reset conversation context so agent reads kick message fresh.
-  # With 40-50 restarts/day the accumulated context is mostly stale
-  # rationalization; the kick message already contains all deterministic data.
-  log "CLEAR-CONTEXT $session — sending /clear before kick"
-  $TMUX_BIN send-keys -t "$session" -l "/clear" 2>/dev/null || true
-  sleep 1
-  $TMUX_BIN send-keys -t "$session" Enter 2>/dev/null || true
-  local CLEAR_WAIT=15
-  local _cw=0
-  while [ "$_cw" -lt "$CLEAR_WAIT" ]; do
+  # Controlled by AGENT_CLEAR_ON_KICK in the agent's env file (default: true).
+  local _clear_on_kick="true"
+  local _agent_env="/etc/hive/${agent}.env"
+  if [ -f "$_agent_env" ]; then
+    _clear_on_kick=$(grep -m1 '^AGENT_CLEAR_ON_KICK=' "$_agent_env" 2>/dev/null | cut -d= -f2 || echo "true")
+    _clear_on_kick="${_clear_on_kick:-true}"
+  fi
+  if [ "$_clear_on_kick" = "true" ]; then
+    log "CLEAR-CONTEXT $session — sending /clear before kick"
+    $TMUX_BIN send-keys -t "$session" -l "/clear" 2>/dev/null || true
     sleep 1
-    _cw=$(( _cw + 1 ))
-    if session_idle "$session"; then
-      break
+    $TMUX_BIN send-keys -t "$session" Enter 2>/dev/null || true
+    local CLEAR_WAIT=15
+    local _cw=0
+    while [ "$_cw" -lt "$CLEAR_WAIT" ]; do
+      sleep 1
+      _cw=$(( _cw + 1 ))
+      if session_idle "$session"; then
+        break
+      fi
+    done
+    if ! session_idle "$session"; then
+      log "WARN $session — /clear did not return to prompt within ${CLEAR_WAIT}s, proceeding anyway"
     fi
-  done
-  if ! session_idle "$session"; then
-    log "WARN $session — /clear did not return to prompt within ${CLEAR_WAIT}s, proceeding anyway"
+  else
+    log "SKIP-CLEAR $session — AGENT_CLEAR_ON_KICK=false"
   fi
 
   log "KICK $session (${#message} chars)"

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4339,6 +4339,10 @@ function burnAreaChart() {
           <input type="text" id="cfg-launch-cmd" value="${esc(g.launchCmd || '')}" onchange="markDirty('general','launchCmd',this.value)">
         </div>
         <div class="config-toggle">
+          <div class="config-toggle-switch ${g.clearOnKick !== false ? 'on' : ''}" id="cfg-clear-on-kick" data-action="toggleConfigSwitch" data-section="general" data-key="clearOnKick"></div>
+          <span class="config-toggle-label">Clear on Kick <span class="config-info">i<span class="config-tooltip">Send /clear before each governor kick to reset conversation context. Prevents stale context buildup across runs. On by default for all agents.</span></span></span>
+        </div>
+        <div class="config-toggle">
           <div class="config-toggle-switch ${g.cliPinned ? 'on' : ''}" id="cfg-cli-pinned" data-action="toggleConfigSwitch" data-section="general" data-key="cliPinned"></div>
           <span class="config-toggle-label">CLI Pinned</span>
         </div>

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -1575,6 +1575,7 @@ app.get('/api/config/agent/:name', (req, res) => {
       staleTimeout: parseInt(agentEnv.AGENT_STALE_TIMEOUT_SEC || agentEnv.AGENT_STALE_MAX_SEC || '1200', 10),
       restartStrategy: agentEnv.AGENT_RESTART_STRATEGY || 'immediate',
       model: modeModel || (modelMatch ? modelMatch[1] : ''),
+      clearOnKick: agentEnv.AGENT_CLEAR_ON_KICK !== 'false',
     };
 
     const cadences = {
@@ -1626,13 +1627,14 @@ app.put('/api/config/agent/:name/general', (req, res) => {
   if (!validateAgentName(name, res)) return;
   const envFile = `${ENV_DIR}/${name}.env`;
   try {
-    const { launchCmd, cliPinned, cliPinValue, staleTimeout, restartStrategy, model, displayName } = req.body;
+    const { launchCmd, cliPinned, cliPinValue, staleTimeout, restartStrategy, model, displayName, clearOnKick } = req.body;
     if (displayName !== undefined) writeEnvVar(envFile, 'AGENT_DISPLAY_NAME', displayName);
     if (launchCmd !== undefined) writeEnvVar(envFile, 'AGENT_LAUNCH_CMD', launchCmd);
     if (cliPinned !== undefined) writeEnvVar(envFile, 'AGENT_CLI_PINNED', String(cliPinned));
     if (cliPinValue !== undefined) writeEnvVar(envFile, 'AGENT_CLI_PIN_VALUE', cliPinValue);
     if (staleTimeout !== undefined) writeEnvVar(envFile, 'AGENT_STALE_TIMEOUT_SEC', String(staleTimeout));
     if (restartStrategy !== undefined) writeEnvVar(envFile, 'AGENT_RESTART_STRATEGY', restartStrategy);
+    if (clearOnKick !== undefined) writeEnvVar(envFile, 'AGENT_CLEAR_ON_KICK', String(clearOnKick));
     if (model !== undefined) {
       const currentCmd = parseEnvFile(envFile).AGENT_LAUNCH_CMD || '';
       const updatedCmd = currentCmd.includes('--model')


### PR DESCRIPTION
## Summary
- Add `AGENT_CLEAR_ON_KICK` env var per agent (default `true`) to control whether `/clear` is sent before each governor kick
- Add "Clear on Kick" toggle checkbox to the General tab (first tab) in the agent config dialog
- Kick script reads the env file fresh each cycle — no restart needed after toggling

## Context
All agents were already getting `/clear` before every kick unconditionally. This makes it configurable so the operator can disable it per agent if needed (e.g., for agents that benefit from conversational continuity).

## Test plan
- [ ] Open agent config → General tab → verify "Clear on Kick" checkbox appears and is checked by default
- [ ] Uncheck it, save → verify `AGENT_CLEAR_ON_KICK=false` in `/etc/hive/<agent>.env`
- [ ] Next governor kick for that agent should log `SKIP-CLEAR` instead of `CLEAR-CONTEXT`
- [ ] Re-check it, save → next kick sends `/clear` again