### PR TITLE
fix: handle repos with org prefix in dynamic repo list

### DIFF
--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -806,8 +806,12 @@ fi
 # Build dynamic repo list for all kick messages — agents must ONLY interact with these repos
 _REPOS_INLINE=""
 for _r in ${PROJECT_REPOS}; do
-  _REPOS_INLINE="${_REPOS_INLINE}  ${PROJECT_ORG}/${_r}
-"
+  case "$_r" in
+    */*) _REPOS_INLINE="${_REPOS_INLINE}  ${_r}
+" ;;
+    *)   _REPOS_INLINE="${_REPOS_INLINE}  ${PROJECT_ORG}/${_r}
+" ;;
+  esac
 done
 _HIVE_REPO="${PROJECT_HIVE_REPO:-${PROJECT_ORG}/hive}"
 _REPOS_INLINE="${_REPOS_INLINE}  ${_HIVE_REPO} (issues only — file hive-related issues here)


### PR DESCRIPTION
## Summary
- `PROJECT_REPOS` on production contains full `org/repo` paths (e.g. `kubestellar/console`)
- PR #430 prepended `PROJECT_ORG/` unconditionally, producing `kubestellar/kubestellar/console`
- Now checks for `/` in repo name before prepending org prefix

## Test plan
- [ ] Verify repos with org prefix (`kubestellar/console`) render as-is
- [ ] Verify bare repo names (`console`) get `PROJECT_ORG/` prepended