### PR TITLE
fix: auto-deploy agent CLAUDE.md policies to /etc/hive/

### DIFF
--- a/bin/hive-deploy.sh
+++ b/bin/hive-deploy.sh
@@ -174,6 +174,20 @@ if [ -f "$HIVE_PROJECT" ] && ! cmp -s "$HIVE_PROJECT" "$HIVE_PROJECT_INSTALLED" 
     log "WARN: failed to sync hive-project.yaml"
 fi
 
+# Sync agent CLAUDE.md policies from repo to /etc/hive/
+AGENTS_SRC=$(find "$HIVE_REPO" -path '*/examples/*/agents' -type d 2>/dev/null | head -1)
+if [ -n "$AGENTS_SRC" ]; then
+  for policy in "$AGENTS_SRC"/*-CLAUDE.md; do
+    [ -f "$policy" ] || continue
+    policyname=$(basename "$policy")
+    dst="/etc/hive/$policyname"
+    if [ -f "$dst" ] && cmp -s "$policy" "$dst"; then
+      continue
+    fi
+    sudo cp "$policy" "$dst" && SYNCED="$SYNCED $policyname" || true
+  done
+fi
+
 # Sync systemd units if changed
 for unit in "$HIVE_REPO"/systemd/*.service "$HIVE_REPO"/systemd/*.timer; do
   [ -f "$unit" ] || continue


### PR DESCRIPTION
## Summary
- Deploy script synced scripts (`bin/`) and `hive-project.yaml` but never agent CLAUDE.md policies
- This caused `/etc/hive/<agent>-CLAUDE.md` to go stale — agents reading from `/etc/hive/` got outdated instructions
- Root cause of sec-check not checking comments for screenshots despite PR #429 being merged
- Now syncs all `*-CLAUDE.md` files from `examples/*/agents/` to `/etc/hive/` on every deploy cycle

## Test plan
- [ ] Verify deploy copies updated CLAUDE.md files to `/etc/hive/`
- [ ] Verify unchanged policies are skipped (cmp -s check)
- [ ] Verify sec-check uses the new screenshot-comments policy on next kick