### PR TITLE
fix: add homebrew-tap to project repos config

### DIFF
--- a/examples/kubestellar/hive-project.yaml
+++ b/examples/kubestellar/hive-project.yaml
@@ -13,6 +13,7 @@ project:
     - kubestellar/docs
     - kubestellar/console-marketplace
     - kubestellar/kubestellar-mcp
+    - kubestellar/homebrew-tap
   ai_author: "clubanderson"
   website: "console.kubestellar.io"
   hive_repo: "kubestellar/hive"


### PR DESCRIPTION
## Summary
- `kubestellar/homebrew-tap` was only in `hive-runtime.yaml` on the server, not in `hive-project.yaml`
- `hive-project.yaml` is the user's config and source of truth — it should reflect all 6 monitored repos
- Now matches what the dashboard shows and what agents receive in their kick messages

## Test plan
- [ ] Verify `hive-project.yaml` has all 6 repos
- [ ] Verify deploy syncs the updated config to `/etc/hive/hive-project.yaml`