### PR TITLE
feat: static/dynamic config split with config.env

### DIFF
--- a/bin/copilot-comment-checker.sh
+++ b/bin/copilot-comment-checker.sh
@@ -14,32 +14,33 @@ LOG="/var/log/kick-agents.log"
 REAL_GH="/usr/bin/gh"
 
 PROJECT_YAML="${HIVE_PROJECT_YAML:-/etc/hive/hive-project.yaml}"
-RUNTIME_YAML="${HIVE_RUNTIME_CONFIG:-/etc/hive/hive-runtime.yaml}"
+CONFIG_ENV="${HIVE_CONFIG_ENV:-/etc/hive/config.env}"
 if [ ! -f "$PROJECT_YAML" ]; then
   PROJECT_YAML="$(find "$(dirname "$(dirname "$0")")/examples" -name 'hive-project.yaml' -type f 2>/dev/null | head -1)"
 fi
 
 log() { echo "[$(date -Is)] COPILOT-CHECK $*" >> "$LOG"; }
 
-# Read config — repos from runtime config first, classification from project config
+# Read config — config.env overrides yaml defaults
 CONFIG=$(python3 -c "
 import yaml, sys, json, os
 with open(sys.argv[1]) as f:
     cfg = yaml.safe_load(f) or {}
-runtime_path = sys.argv[2] if len(sys.argv) > 2 else ''
 repos = cfg.get('project', {}).get('repos', [])
-if runtime_path and os.path.exists(runtime_path):
-    with open(runtime_path) as f:
-        rt = yaml.safe_load(f) or {}
-    rt_repos = rt.get('project', {}).get('repos', [])
-    if rt_repos:
-        repos = rt_repos
+env_path = sys.argv[2] if len(sys.argv) > 2 else ''
+if env_path and os.path.exists(env_path):
+    for line in open(env_path):
+        line = line.strip()
+        if line.startswith('#') or '=' not in line: continue
+        k, v = line.split('=', 1)
+        if k == 'PROJECT_REPOS' and v.strip():
+            repos = v.strip().split()
 result = {
     'repos': repos,
     'copilot': cfg.get('classification', {}).get('copilot_check', {})
 }
 print(json.dumps(result))
-" "$PROJECT_YAML" "$RUNTIME_YAML" 2>/dev/null || echo '{"repos":[],"copilot":{}}')
+" "$PROJECT_YAML" "$CONFIG_ENV" 2>/dev/null || echo '{"repos":[],"copilot":{}}')
 
 REPOS=$(echo "$CONFIG" | python3 -c "import json,sys; [print(r) for r in json.load(sys.stdin)['repos']]" 2>/dev/null)
 # Copilot code review posts as "Copilot"; the fix-agent posts as "copilot-swe-agent[bot]"

--- a/bin/enumerate-actionable.sh
+++ b/bin/enumerate-actionable.sh
@@ -24,7 +24,7 @@ if ! flock -n 200; then
   exit 0
 fi
 
-# Source project config (reads hive-runtime.yaml for repos, falls back to hive-project.yaml)
+# Source project config (yaml defaults + config.env overrides)
 # shellcheck source=hive-config.sh
 source "$(dirname "$0")/hive-config.sh" 2>/dev/null || source /usr/local/bin/hive-config.sh 2>/dev/null || true
 

--- a/bin/hive-config.sh
+++ b/bin/hive-config.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # hive-config.sh — Shared config reader for all hive scripts.
-# Sources project-specific values from hive-project.yaml.
+#
+# Precedence (lowest → highest):
+#   1. hive-project.yaml  (static defaults from repo)
+#   2. /etc/hive/config.env  (dynamic overrides, dashboard reads/writes this)
+#   3. Explicit env vars set before sourcing this file
 #
 # Usage: source /usr/local/bin/hive-config.sh
 #        (or source this file from the repo at bin/hive-config.sh)
@@ -21,7 +25,7 @@ HIVE_REPO_DIR="${HIVE_REPO_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/
 export HIVE_REPO_DIR
 
 _HIVE_CONFIG="${HIVE_PROJECT_CONFIG:-/etc/hive/hive-project.yaml}"
-_HIVE_RUNTIME="${HIVE_RUNTIME_CONFIG:-/etc/hive/hive-runtime.yaml}"
+_HIVE_CONFIG_ENV="${HIVE_CONFIG_ENV:-/etc/hive/config.env}"
 
 _hive_yq_file() {
   local file="$1" path="$2"
@@ -64,20 +68,6 @@ _hive_yq() {
   _hive_yq_file "$_HIVE_CONFIG" "$1"
 }
 
-# Read from runtime config first, fall back to project config
-_hive_runtime_yq() {
-  local val=""
-  if [[ -f "$_HIVE_RUNTIME" ]]; then
-    val=$(_hive_yq_file "$_HIVE_RUNTIME" "$1")
-  fi
-  if [[ "$val" == "null" || -z "$val" || "$val" == "[]" ]]; then
-    _hive_yq "$1"
-  else
-    echo "$val"
-  fi
-}
-
-
 _hive_read() {
   local val
   val=$(_hive_yq "$1")
@@ -102,34 +92,17 @@ _hive_read_array() {
   fi
 }
 
-# Runtime-aware array reader: checks hive-runtime.yaml first, falls back to hive-project.yaml
-_hive_read_runtime_array() {
-  local val=""
-  if [[ -f "$_HIVE_RUNTIME" ]]; then
-    val=$(_hive_yq_file "$_HIVE_RUNTIME" "$1")
-  fi
-  if [[ "$val" == "null" || -z "$val" || "$val" == "[]" ]]; then
-    _hive_read_array "$1" "${2:-}"
-  else
-    if command -v python3 &>/dev/null; then
-      python3 -c "import json; print(' '.join(json.loads('''$val''')))" 2>/dev/null || echo "${2:-}"
-    else
-      echo "$val" | tr -d '[]",' | xargs
-    fi
-  fi
-}
-
 if [[ -f "$_HIVE_CONFIG" ]]; then
   # Project
   PROJECT_NAME=$(_hive_read "project.name" "")
   PROJECT_ORG=$(_hive_read "project.org" "")
   PROJECT_PRIMARY_REPO=$(_hive_read "project.primary_repo" "")
-  PROJECT_REPOS=$(_hive_read_runtime_array "project.repos" "")
+  PROJECT_REPOS=$(_hive_read_array "project.repos" "")
   PROJECT_AI_AUTHOR=$(_hive_read "project.ai_author" "")
   PROJECT_WEBSITE=$(_hive_read "project.website" "")
 
   # Agents
-  AGENTS_ENABLED=$(_hive_read_runtime_array "agents.enabled" "supervisor scanner reviewer")
+  AGENTS_ENABLED=$(_hive_read_array "agents.enabled" "supervisor scanner reviewer")
   BEADS_BASE=$(_hive_read "agents.beads_base" "/home/dev")
   AGENTS_WORKDIR=$(_hive_read "agents.workdir" "")
 
@@ -188,6 +161,16 @@ if [[ -f "$_HIVE_CONFIG" ]]; then
   HIVE_CONFIG_LOADED=true
 else
   HIVE_CONFIG_LOADED=false
+fi
+
+# ── config.env overrides ──────────────────────────────────────────
+# Flat key=value file for dynamic overrides. Dashboard reads/writes this.
+# Values here win over hive-project.yaml defaults.
+if [[ -f "$_HIVE_CONFIG_ENV" ]]; then
+  set -a
+  # shellcheck source=/etc/hive/config.env
+  source "$_HIVE_CONFIG_ENV"
+  set +a
 fi
 
 # ─── Shared utility functions ─────────────────────────────────────────────

--- a/bin/hive-deploy.sh
+++ b/bin/hive-deploy.sh
@@ -163,8 +163,8 @@ if [ -n "$DISCORD_RESTART_NEEDED" ] && [ -z "$DISCORD_CHANGED" ]; then
     log "WARN: failed to restart hive-discord (drift)"
 fi
 
-# Sync hive-project.yaml (code-managed config) — safe to overwrite since
-# runtime customizations (sidebar, repos, agents) live in hive-runtime.yaml
+# Sync hive-project.yaml (code-managed static defaults) — safe to overwrite since
+# dynamic overrides live in /etc/hive/config.env
 HIVE_PROJECT="${HIVE_PROJECT_CONFIG_SRC:-$HIVE_REPO/examples/kubestellar/hive-project.yaml}"
 HIVE_PROJECT_INSTALLED="/etc/hive/hive-project.yaml"
 if [ -f "$HIVE_PROJECT" ] && ! cmp -s "$HIVE_PROJECT" "$HIVE_PROJECT_INSTALLED" 2>/dev/null; then
@@ -172,6 +172,14 @@ if [ -f "$HIVE_PROJECT" ] && ! cmp -s "$HIVE_PROJECT" "$HIVE_PROJECT_INSTALLED" 
   sudo cp "$HIVE_PROJECT" "$HIVE_PROJECT_INSTALLED" && \
     SYNCED="$SYNCED hive-project.yaml" || \
     log "WARN: failed to sync hive-project.yaml"
+fi
+
+# Seed config.env from example if it doesn't exist yet (never overwrite user config)
+EXAMPLE_CONFIG_ENV=$(find "$HIVE_REPO/examples" -name 'example-config.env' -type f 2>/dev/null | head -1)
+if [ -n "$EXAMPLE_CONFIG_ENV" ] && [ ! -f /etc/hive/config.env ]; then
+  sudo cp "$EXAMPLE_CONFIG_ENV" /etc/hive/config.env && \
+    SYNCED="$SYNCED config.env(seed)" || \
+    log "WARN: failed to seed config.env"
 fi
 
 # Sync agent CLAUDE.md policies from repo to /etc/hive/

--- a/bin/outreach-tracker.sh
+++ b/bin/outreach-tracker.sh
@@ -14,34 +14,35 @@ LOG="/var/log/kick-agents.log"
 REAL_GH="/usr/bin/gh"
 
 PROJECT_YAML="${HIVE_PROJECT_YAML:-/etc/hive/hive-project.yaml}"
-RUNTIME_YAML="${HIVE_RUNTIME_CONFIG:-/etc/hive/hive-runtime.yaml}"
+CONFIG_ENV="${HIVE_CONFIG_ENV:-/etc/hive/config.env}"
 if [ ! -f "$PROJECT_YAML" ]; then
   PROJECT_YAML="$(find "$(dirname "$(dirname "$0")")/examples" -name 'hive-project.yaml' -type f 2>/dev/null | head -1)"
 fi
 
 log() { echo "[$(date -Is)] OUTREACH-TRACK $*" >> "$LOG"; }
 
-# Read config — repos from runtime config first, rest from project config
+# Read config — config.env overrides yaml defaults
 CONFIG=$(python3 -c "
 import yaml, sys, json, os
 with open(sys.argv[1]) as f:
     cfg = yaml.safe_load(f) or {}
-runtime_path = sys.argv[2] if len(sys.argv) > 2 else ''
 repos = cfg.get('project', {}).get('repos', [])
-if runtime_path and os.path.exists(runtime_path):
-    with open(runtime_path) as f:
-        rt = yaml.safe_load(f) or {}
-    rt_repos = rt.get('project', {}).get('repos', [])
-    if rt_repos:
-        repos = rt_repos
+env_path = sys.argv[2] if len(sys.argv) > 2 else ''
+if env_path and os.path.exists(env_path):
+    for line in open(env_path):
+        line = line.strip()
+        if line.startswith('#') or '=' not in line: continue
+        k, v = line.split('=', 1)
+        if k == 'PROJECT_REPOS' and v.strip():
+            repos = v.strip().split()
 result = {
-    'ai_author': cfg.get('project', {}).get('ai_author', ''),
-    'org': cfg.get('project', {}).get('org', ''),
+    'ai_author': os.environ.get('PROJECT_AI_AUTHOR', cfg.get('project', {}).get('ai_author', '')),
+    'org': os.environ.get('PROJECT_ORG', cfg.get('project', {}).get('org', '')),
     'repos': repos,
     'target_placements': cfg.get('outreach', {}).get('target_placements', 0),
 }
 print(json.dumps(result))
-" "$PROJECT_YAML" "$RUNTIME_YAML" 2>/dev/null || echo '{}')
+" "$PROJECT_YAML" "$CONFIG_ENV" 2>/dev/null || echo '{}')
 
 AI_AUTHOR=$(echo "$CONFIG" | python3 -c "import json,sys; print(json.load(sys.stdin).get('ai_author',''))" 2>/dev/null)
 ORG=$(echo "$CONFIG" | python3 -c "import json,sys; print(json.load(sys.stdin).get('org',''))" 2>/dev/null)

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -61,8 +61,9 @@ app.use((_req, res, next) => {
 
 // Load project config from hive-project.yaml (code-managed, synced from repo)
 const CONFIG_PATH = process.env.HIVE_PROJECT_CONFIG || '/etc/hive/hive-project.yaml';
-// Runtime config — dashboard customizations that survive deploys
-const RUNTIME_CONFIG_PATH = process.env.HIVE_RUNTIME_CONFIG || '/etc/hive/hive-runtime.yaml';
+// Dynamic config — operator overrides that survive deploys (flat key=value)
+const CONFIG_ENV_PATH = process.env.HIVE_CONFIG_ENV || '/etc/hive/config.env';
+const SIDEBAR_JSON_PATH = process.env.HIVE_SIDEBAR_CONFIG || '/etc/hive/sidebar.json';
 
 function _loadYaml(filePath) {
   try {
@@ -77,20 +78,24 @@ function _loadYaml(filePath) {
 }
 
 let projectConfig = _loadYaml(CONFIG_PATH);
-let runtimeConfig = _loadYaml(RUNTIME_CONFIG_PATH);
+const configEnv = parseEnvFile(CONFIG_ENV_PATH);
 
-// Migrate: if runtime file is empty but project config has runtime keys, extract them
-if (!runtimeConfig.agents && !runtimeConfig.project) {
-  const existingSidebar = (projectConfig.agents || {}).sidebar;
-  const existingEnabled = (projectConfig.agents || {}).enabled;
-  const existingRepos = (projectConfig.project || {}).repos;
-  if (existingSidebar || existingEnabled || existingRepos) {
-    runtimeConfig = {};
-    if (existingSidebar) { runtimeConfig.agents = runtimeConfig.agents || {}; runtimeConfig.agents.sidebar = existingSidebar; }
-    if (existingEnabled) { runtimeConfig.agents = runtimeConfig.agents || {}; runtimeConfig.agents.enabled = existingEnabled; }
-    if (existingRepos) { runtimeConfig.project = { repos: existingRepos }; }
-    _persistRuntime();
+// Migrate: if hive-runtime.yaml exists but config.env does not, extract dynamic values
+const LEGACY_RUNTIME_PATH = process.env.HIVE_RUNTIME_CONFIG || '/etc/hive/hive-runtime.yaml';
+if (fs.existsSync(LEGACY_RUNTIME_PATH) && !fs.existsSync(CONFIG_ENV_PATH)) {
+  const legacyRuntime = _loadYaml(LEGACY_RUNTIME_PATH);
+  const legacyEnabled = (legacyRuntime.agents || {}).enabled;
+  const legacyRepos = (legacyRuntime.project || {}).repos;
+  const legacySidebar = (legacyRuntime.agents || {}).sidebar;
+  if (legacyEnabled) writeEnvVar(CONFIG_ENV_PATH, 'AGENTS_ENABLED', legacyEnabled.join(' '));
+  if (legacyRepos) writeEnvVar(CONFIG_ENV_PATH, 'PROJECT_REPOS', legacyRepos.join(' '));
+  if (legacySidebar) {
+    const tmpSb = `/tmp/hive-sidebar-${process.pid}-${Date.now()}.json`;
+    fs.writeFileSync(tmpSb, JSON.stringify(legacySidebar, null, 2));
+    execSync(`sudo mv ${shellQuote(tmpSb)} ${shellQuote(SIDEBAR_JSON_PATH)}`);
   }
+  // Rename legacy file so migration doesn't re-run
+  try { execSync(`sudo mv ${shellQuote(LEGACY_RUNTIME_PATH)} ${shellQuote(LEGACY_RUNTIME_PATH + '.migrated')}`); } catch (_) {}
 }
 
 const PROJECT_NAME = (projectConfig.project || {}).name || '';
@@ -98,20 +103,14 @@ const PROJECT_PRIMARY_REPO = (projectConfig.project || {}).primary_repo || '';
 const PROJECT_ORG = (projectConfig.project || {}).org || '';
 const DASHBOARD_TITLE = ((projectConfig.dashboard || {}).title) || (PROJECT_NAME ? PROJECT_NAME + ' Hive' : 'Hive');
 const HIVE_REPO_DIR = process.env.HIVE_REPO_DIR || path.resolve(__dirname, '..');
-let ENABLED_AGENTS = ((runtimeConfig.agents || {}).enabled
-  || (projectConfig.agents || {}).enabled
-  || ['supervisor', 'scanner', 'reviewer', 'architect', 'outreach']);
+let ENABLED_AGENTS = configEnv.AGENTS_ENABLED
+  ? configEnv.AGENTS_ENABLED.split(/\s+/).filter(Boolean)
+  : ((projectConfig.agents || {}).enabled
+    || ['supervisor', 'scanner', 'reviewer', 'architect', 'outreach']);
 let ENABLED_AGENTS_PLUS_ALL = [...ENABLED_AGENTS, 'all'];
 
 const CONFIG_REPO_SOURCE = process.env.HIVE_PROJECT_CONFIG_SRC
   || path.join(HIVE_REPO_DIR, 'examples', 'kubestellar', 'hive-project.yaml');
-
-function _persistRuntime() {
-  const dumpYaml = yaml ? yaml.dump(runtimeConfig) : JSON.stringify(runtimeConfig, null, 2);
-  const tmpFile = `/tmp/hive-runtime-${process.pid}-${Date.now()}.yaml`;
-  fs.writeFileSync(tmpFile, dumpYaml);
-  execSync(`sudo mv ${shellQuote(tmpFile)} ${shellQuote(RUNTIME_CONFIG_PATH)}`);
-}
 
 function persistProjectConfig() {
   const dumpYaml = yaml ? yaml.dump(projectConfig) : JSON.stringify(projectConfig, null, 2);
@@ -124,10 +123,8 @@ function persistProjectConfig() {
 }
 
 function persistEnabledAgents() {
-  if (!runtimeConfig.agents) runtimeConfig.agents = {};
-  runtimeConfig.agents.enabled = ENABLED_AGENTS.slice();
+  writeEnvVar(CONFIG_ENV_PATH, 'AGENTS_ENABLED', ENABLED_AGENTS.join(' '));
   ENABLED_AGENTS_PLUS_ALL = [...ENABLED_AGENTS, 'all'];
-  _persistRuntime();
 }
 
 // ── Centralized backend/model config (JS equivalent of backends.conf) ──────
@@ -1833,7 +1830,10 @@ app.get('/api/config/governor', (_req, res) => {
       pullbackSeconds: parseInt(govEnv.SENSING_PULLBACK_SECONDS || '900', 10),
     };
 
-    const repos = ((runtimeConfig.project || {}).repos || (projectConfig.project || {}).repos || []).slice();
+    const freshEnv = parseEnvFile(CONFIG_ENV_PATH);
+    const repos = freshEnv.PROJECT_REPOS
+      ? freshEnv.PROJECT_REPOS.split(/\s+/).filter(Boolean)
+      : ((projectConfig.project || {}).repos || []).slice();
     res.json({ agents, thresholds, labels, budget, notifications, health, repos, sensing });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -2020,9 +2020,7 @@ app.delete('/api/config/governor/agents/:name', (req, res) => {
 app.put('/api/config/governor/repos', (req, res) => {
   try {
     const list = req.body.list || [];
-    if (!runtimeConfig.project) runtimeConfig.project = {};
-    runtimeConfig.project.repos = list;
-    _persistRuntime();
+    writeEnvVar(CONFIG_ENV_PATH, 'PROJECT_REPOS', list.join(' '));
     res.json({ ok: true });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -2032,8 +2030,11 @@ app.put('/api/config/governor/repos', (req, res) => {
 // ── Sidebar layout (agent order + groups) ──────────────────────────────────
 app.get('/api/config/sidebar', (_req, res) => {
   try {
-    const sidebar = (runtimeConfig.agents || {}).sidebar
-      || (projectConfig.agents || {}).sidebar || null;
+    let sidebar = null;
+    if (fs.existsSync(SIDEBAR_JSON_PATH)) {
+      try { sidebar = JSON.parse(fs.readFileSync(SIDEBAR_JSON_PATH, 'utf8')); } catch (_) {}
+    }
+    if (!sidebar) sidebar = (projectConfig.agents || {}).sidebar || null;
     res.json({ sidebar });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -2044,9 +2045,9 @@ app.put('/api/config/sidebar', (req, res) => {
   try {
     const { groups } = req.body;
     if (!Array.isArray(groups)) return res.status(400).json({ error: 'groups must be an array' });
-    if (!runtimeConfig.agents) runtimeConfig.agents = {};
-    runtimeConfig.agents.sidebar = { groups };
-    _persistRuntime();
+    const tmpSb = `/tmp/hive-sidebar-${process.pid}-${Date.now()}.json`;
+    fs.writeFileSync(tmpSb, JSON.stringify({ groups }, null, 2));
+    execSync(`sudo mv ${shellQuote(tmpSb)} ${shellQuote(SIDEBAR_JSON_PATH)}`);
     res.json({ ok: true });
   } catch (err) {
     res.status(500).json({ error: err.message });

--- a/examples/kubestellar/example-config.env
+++ b/examples/kubestellar/example-config.env
@@ -1,0 +1,66 @@
+# example-config.env — Dynamic config overrides for hive.
+#
+# Copy this file to /etc/hive/config.env on the hive server.
+# Values here override defaults from hive-project.yaml.
+# The dashboard reads and writes this file for runtime changes.
+#
+# Precedence (lowest → highest):
+#   1. hive-project.yaml (static defaults, from repo)
+#   2. /etc/hive/config.env (this file — dynamic overrides)
+#   3. Explicit env vars set before sourcing hive-config.sh
+#
+# Lines starting with # are ignored. Uncomment and edit to override.
+
+# ── Project ────────────────────────────────────────────────────────
+# Space-separated list of repos this hive manages.
+# Agents will ONLY interact with repos listed here.
+#PROJECT_REPOS=kubestellar/console kubestellar/console-kb kubestellar/docs kubestellar/console-marketplace kubestellar/kubestellar-mcp kubestellar/homebrew-tap
+
+#PROJECT_ORG=kubestellar
+#PROJECT_NAME=KubeStellar Console
+#PROJECT_PRIMARY_REPO=kubestellar/console
+#PROJECT_AI_AUTHOR=clubanderson
+#PROJECT_WEBSITE=console.kubestellar.io
+
+# ── Agents ─────────────────────────────────────────────────────────
+# Space-separated list of enabled agents.
+#AGENTS_ENABLED=supervisor scanner reviewer architect outreach strategist analyst guardian sec-check
+
+#BEADS_BASE=/home/dev
+#AGENTS_WORKDIR=/home/dev/kubestellar-console
+
+# ── Dashboard ──────────────────────────────────────────────────────
+#DASHBOARD_PORT=3001
+#DASHBOARD_TITLE=KubeStellar Console Hive
+
+# ── GitHub App ─────────────────────────────────────────────────────
+# Secrets — set here or as env vars, never in hive-project.yaml.
+#GH_APP_ID=3568013
+#GH_APP_INSTALLATION_ID=128685788
+#GH_APP_KEY_FILE=/etc/hive/gh-app-key.pem
+
+# ── Outreach ───────────────────────────────────────────────────────
+#OUTREACH_ENABLED=true
+#OUTREACH_TARGET_PLACEMENTS=200
+#OUTREACH_DESCRIPTION=KubeStellar Console — Multi-cluster Kubernetes dashboard with AI-powered operations
+
+# ── GA4 / Analytics ────────────────────────────────────────────────
+#OUTREACH_GA4_PROPERTY_ID=525401563
+#OUTREACH_GA4_KEY_PATH=/home/dev/.config/gcloud-keys/ga4-reader-key.json
+#OUTREACH_COVERAGE_BADGE_URL=https://gist.githubusercontent.com/clubanderson/b9a9ae8469f1897a22d5a40629bc1e82/raw/coverage-badge.json
+
+# ── Notifications ──────────────────────────────────────────────────
+#NTFY_TOPIC=hive
+#NTFY_SERVER=https://ntfy.sh
+#DISCORD_WEBHOOK=
+#SLACK_WEBHOOK=
+
+# ── Token Budget ───────────────────────────────────────────────────
+#TOKEN_BUDGET_WEEKLY=200000000
+#TOKEN_BUDGET_SAFETY_PCT=85
+
+# ── Timezone ───────────────────────────────────────────────────────
+#HIVE_TZ=America/New_York
+
+# ── Misc ───────────────────────────────────────────────────────────
+#HIVE_ENTER_COUNT=3


### PR DESCRIPTION
## Summary
Replaces `hive-runtime.yaml` with a flat `config.env` file for dynamic operator overrides.

**Pattern**: static defaults in repo (`hive-project.yaml`) + dynamic overrides on disk (`/etc/hive/config.env`). Same pattern as systemd drop-ins, Docker Compose overrides, kustomize patches.

**Precedence** (lowest → highest):
1. `hive-project.yaml` — static defaults from repo
2. `/etc/hive/config.env` — dynamic overrides, dashboard reads/writes
3. Explicit env vars set before sourcing hive-config.sh

### Changes
- **New file**: `examples/kubestellar/example-config.env` — template with all overridable keys + comments
- **`hive-config.sh`**: loads yaml defaults, then sources `config.env` (values win). Removed `_hive_runtime_yq` and `_hive_read_runtime_array` functions.
- **`dashboard/server.js`**: reads/writes `config.env` instead of `hive-runtime.yaml` for repos and enabled agents. Sidebar moves to `/etc/hive/sidebar.json`.
- **Migration**: on first run, auto-extracts `hive-runtime.yaml` → `config.env` + `sidebar.json`, renames legacy file to `.migrated`
- **Deploy**: seeds `config.env` from `example-config.env` if not present (never overwrites user config)
- **Scripts**: `outreach-tracker.sh` and `copilot-comment-checker.sh` read `config.env` instead of runtime yaml

### What stays separate
- Per-agent `.env` files (`/etc/hive/<agent>.env`) — agent-specific settings
- `governor.env` — cadences, models, thresholds
- `hive-project.yaml` — structural config (pipeline stages, classification rules, health checks)

## Test plan
- [ ] Verify `hive-config.sh` loads yaml defaults, then overrides from `config.env`
- [ ] Verify dashboard reads/writes repos and agents to `config.env`
- [ ] Verify sidebar reads/writes to `sidebar.json`
- [ ] Verify migration from `hive-runtime.yaml` works on first run
- [ ] Verify deploy seeds `config.env` only if not present
- [ ] Verify no remaining references to `hive-runtime.yaml` (except migration code)