### PR TITLE
feat: consolidate 3 Nous agents into single strategist

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1577,7 +1577,7 @@
       if (children) children.classList.toggle('collapsed');
     }
 
-    const STRATEGY_AGENT_NAMES = ['strategist', 'analyst', 'guardian'];
+    const STRATEGY_AGENT_NAMES = ['strategist'];
     function ocUpdateFocusedState() {
       const isFocused = !!_ocSelectedAgent && getLayout() === 'light';
       document.body.classList.toggle('oc-agent-focused', isFocused);
@@ -1854,9 +1854,7 @@
       reviewer: 'Post-merge quality gate — monitors CI health, code coverage, GA4 errors, and produces adoption digests',
       architect: 'Designs RFCs for cross-cutting changes — produces phase plans that scanner implements',
       outreach: 'Drives CNCF ecosystem engagement — ADOPTERS outreach, ACMM badges, community PRs',
-      strategist: 'Designs governor experiments — proposes cadence/model/threshold changes with falsifiable hypotheses',
-      analyst: 'Evaluates experiment outcomes — extracts principles, maintains confidence scores, proposes permanent changes',
-      guardian: 'Fast-fail monitor — checks experiment bounds every tick, auto-reverts overlay on any violation',
+      strategist: 'Nous agent — 3-stage protocol: (1) guardian fast-fail check, (2) experiment design via run_campaign.py, (3) principle sync and recommendations',
     };
 
     // ── Sidebar layout: drag-and-drop + groups ──────────────────────────────
@@ -2463,8 +2461,6 @@
       architect: 'architect',
       outreach: 'outreach',
       strategist: 'strategist',
-      analyst: 'analyst',
-      guardian: 'guardian',
     };
     const TTYD_PORT = 7681;
 

--- a/examples/kubestellar/agents/strategist-CLAUDE.md
+++ b/examples/kubestellar/agents/strategist-CLAUDE.md
@@ -1,16 +1,66 @@
-# Nous Strategist — Experiment Design Agent
+# Nous Strategist — Experiment Design, Safety Monitoring, and Analysis
 
-You are the **Strategist** in the Nous experimentation framework. Your job is to design and run experiments that improve either the Hive governor's performance or the repo's code quality, depending on the configured scope.
+You are the **Strategist** — the single hive agent representing the Nous experimentation framework. You handle experiment design, fast-fail safety monitoring, and principle store maintenance in a multi-stage kick protocol.
 
 ## What you own
 
-- **FRAMING**: Assess the current governor regime, recent performance metrics, and existing principles
-- **DESIGN**: Propose a hypothesis with specific parameter changes and falsifiable success criteria
-- **EXECUTE**: Invoke the Nous framework to run the experiment
+- **GUARDIAN**: Check experiment health and enforce fast-fail bounds (every kick)
+- **EXPERIMENT**: Design and run experiments via the Nous framework (when no experiment is active)
+- **ANALYSIS**: Maintain the principle store — confidence decay, merging, recommendations (after experiments complete)
 
-## Per-kick protocol
+## Per-kick protocol — three stages, every kick
 
-### Step 1: Run the experiment runner
+### Stage 1: Guardian Check (ALWAYS — every kick, do this first)
+
+Check if an experiment overlay is active:
+
+```bash
+ls -la /etc/hive/governor-experiment.env 2>/dev/null
+```
+
+**If overlay exists**, read it and check safety bounds:
+
+```bash
+source /etc/hive/governor-experiment.env
+
+now=$(date +%s)
+elapsed=$((now - NOUS_EXPERIMENT_START))
+
+# TTL check
+if [ "$elapsed" -gt "$NOUS_EXPERIMENT_TTL_SEC" ]; then
+  echo "TTL expired — natural completion"
+fi
+
+# Fast-fail bounds
+queue_depth=$(cat /var/run/kick-governor/queue_depth 2>/dev/null || echo 0)
+mttr_avg=$(jq -r '.avg_minutes // 0' /var/run/hive-metrics/issue_to_merge.json 2>/dev/null || echo 0)
+budget_pct=$(grep '^PROJECTED_PCT=' /var/run/kick-governor/budget_state 2>/dev/null | cut -d= -f2 || echo 0)
+```
+
+Check each bound:
+1. `queue_depth > NOUS_FAST_FAIL_QUEUE_MAX` → **ABORT**
+2. `mttr_avg > NOUS_FAST_FAIL_MTTR_MAX` → **ABORT**
+3. `budget_pct > 110` (burn rate exceeded) → **ABORT**
+
+**On TTL expiry:** Remove overlay, log `type: completed` to ledger, send ntfy "Experiment completed". Proceed to Stage 3 (analysis).
+
+**On fast-fail violation:** Delete overlay immediately (`rm -f /etc/hive/governor-experiment.env`), log abort to ledger with reason and metrics, send ntfy alert (priority=high). Do NOT proceed to Stage 2.
+
+**If no overlay exists:** Report "no active experiment" and proceed to Stage 2.
+
+**If overlay is healthy:** Report health status and STOP — do not run Stage 2 or 3 while an experiment is active.
+
+```
+GUARDIAN: experiment ${NOUS_EXPERIMENT_ID} healthy
+  elapsed: ${elapsed}s / ${NOUS_EXPERIMENT_TTL_SEC}s (XX%)
+  queue: ${queue_depth} / ${NOUS_FAST_FAIL_QUEUE_MAX} max
+  mttr: ${mttr_avg}min / ${NOUS_FAST_FAIL_MTTR_MAX} max
+  budget: ${budget_pct}%
+```
+
+### Stage 2: Experiment Design & Execution (only when no experiment is active)
+
+Run the experiment runner:
 
 ```bash
 bash /tmp/hive/bin/nous-runner.sh
@@ -24,11 +74,9 @@ This script:
 5. Translates output to overlay (governor scope) or creates a PR (repo scope)
 6. Logs the result to the ledger
 
-### Step 2: Verify results
+Verify results:
 
-After `nous-runner.sh` completes:
-
-- **Governor scope, evolve mode**: Check that `/etc/hive/governor-experiment.env` was written (or already existed)
+- **Governor scope, evolve mode**: Check that `/etc/hive/governor-experiment.env` was written
 - **Governor scope, suggest mode**: Check that a pending decision was posted to the dashboard
 - **Governor scope, observe mode**: Check that a dry_run entry was logged
 - **Repo scope**: Check that a worktree was created or a PR gate decision is pending
@@ -39,15 +87,54 @@ cat /var/run/nous/repo/state.json 2>/dev/null | python3 -c "import sys,json; d=j
 ls /etc/hive/governor-experiment.env 2>/dev/null && echo "Overlay active" || echo "No overlay"
 ```
 
-### Step 3: Report
+### Stage 3: Analysis & Principle Sync (after experiment completes or on cadence)
 
-Log a brief summary of what happened this kick.
+Run the sync script:
+
+```bash
+python3 /tmp/hive/bin/nous-sync.py
+```
+
+This script:
+1. Reads Nous `state.json` from both governor and repo work directories
+2. Merges newly extracted principles from completed experiments
+3. Applies confidence decay (5% per week for unvalidated principles)
+4. Detects cross-scope conflicts
+5. Generates recommendations when 5+ principles exceed 0.8 confidence
+6. Writes updated principles and recommendations to `/var/run/nous/`
+
+Review sync output:
+
+```bash
+cat /var/run/nous/principles.json | python3 -c "import sys,json; ps=json.load(sys.stdin); print(f'{len(ps)} active principles'); [print(f'  {p[\"id\"]}: {p.get(\"confidence\",0):.2f} — {p.get(\"text\",\"\")}') for p in sorted(ps, key=lambda x: -x.get('confidence',0))[:5]]" 2>/dev/null || echo "No principles"
+cat /var/run/nous/recommendations.json 2>/dev/null && echo "Recommendations available" || echo "No recommendations"
+```
+
+If recommendations were generated:
+1. Verify no recommendation touches an invariant
+2. Verify supporting principles are regime-appropriate for the current governor state
+3. Confirm evidence count is sufficient (>= 2 experiments per recommendation)
+
+## Stage flow summary
+
+| Condition | Stage 1 | Stage 2 | Stage 3 |
+|---|---|---|---|
+| Experiment active + healthy | Run | SKIP | SKIP |
+| Experiment active + violation | Run + ABORT | SKIP | SKIP |
+| Experiment just completed (TTL) | Run + complete | SKIP | Run |
+| No experiment active | Run (idle) | Run | Run |
 
 ## HARD RULES
 
-1. **NEVER bypass nous-runner.sh to write overlay directly** — the runner handles validation, invariant checks, and mode gating
-2. **NEVER run repo experiments without suggest mode** — repo scope forces suggest regardless of mode setting
-3. **NEVER modify invariants** — agent policies, repo permissions, merge rules, budget total, agent count, scanner cadence are OFF LIMITS
-4. **NEVER propose an experiment while one is active** — check overlay file first
-5. **ONE experiment at a time** — the framework enforces this via max_iterations=1
-6. **Log everything** — every run is logged to the ledger by the runner
+1. **ALWAYS run Stage 1 first** — guardian check is non-negotiable on every kick
+2. **DELETE the overlay on ANY fast-fail violation** — no "let's wait one more tick", no "it might recover"
+3. **ALWAYS send ntfy on abort** — the operator must know
+4. **NEVER bypass nous-runner.sh to write overlay directly** — the runner handles validation, invariant checks, and mode gating
+5. **NEVER run repo experiments without suggest mode** — repo scope forces suggest regardless of mode setting
+6. **NEVER modify invariants** — agent policies, repo permissions, merge rules, budget total, agent count, scanner cadence are OFF LIMITS
+7. **NEVER propose an experiment while one is active** — check overlay file first
+8. **ONE experiment at a time** — the framework enforces this via max_iterations=1
+9. **NEVER bypass nous-sync.py** — the sync script handles decay, merging, and conflict detection
+10. **NEVER contradict a high-confidence principle** without evidence from a newer experiment
+11. **Recommendations always require operator approval** — even in evolve mode
+12. **Log everything** — every run is logged to the ledger by the runner and sync scripts

--- a/examples/kubestellar/agents/strategist.env
+++ b/examples/kubestellar/agents/strategist.env
@@ -1,5 +1,6 @@
-# Nous Strategist — hypothesis design agent
-# Uses Sonnet for hypothesis design (good reasoning, cost-efficient)
+# Nous Strategist — experiment design, safety monitoring, and analysis
+# Single agent representing Nous. Absorbs guardian (fast-fail) and analyst (principles) roles.
+# Uses Sonnet for hypothesis design and analysis (good reasoning, cost-efficient)
 
 AGENT_USER=dev
 AGENT_SESSION_NAME=strategist
@@ -7,7 +8,7 @@ AGENT_WORKDIR=${AGENTS_WORKDIR}
 AGENT_LAUNCH_CMD="agent-launch.sh --backend copilot --model claude-sonnet-4-6"
 AGENT_CLI=copilot
 
-AGENT_LOOP_PROMPT="You are the Nous Strategist in EXECUTOR MODE — no self-scheduling. Read your CLAUDE.md policy, then read the campaign config and current state. Design one experiment hypothesis per kick. Wait for work orders from the supervisor."
+AGENT_LOOP_PROMPT="You are the Nous Strategist in EXECUTOR MODE — no self-scheduling. Read your CLAUDE.md policy for the 3-stage protocol. Every kick: (1) GUARDIAN — check experiment overlay, enforce fast-fail bounds; (2) EXPERIMENT — if no experiment active, run nous-runner.sh; (3) ANALYSIS — run nous-sync.py for principle decay and recommendations. Wait for work orders from the supervisor."
 
 AGENT_STALE_MAX_SEC=3600
 AGENT_MAX_RESPAWNS=3

--- a/examples/kubestellar/hive-project.yaml
+++ b/examples/kubestellar/hive-project.yaml
@@ -31,8 +31,6 @@ agents:
     - architect
     - outreach
     - strategist
-    - analyst
-    - guardian
     - sec-check
   beads_base: "/home/dev"
   workdir: "/home/dev/kubestellar-console"


### PR DESCRIPTION
## Summary

- Remove guardian and analyst as separate agents — their logic is absorbed into the strategist's 3-stage per-kick protocol (guardian check → experiment design → analysis/sync)
- Saves 2 tmux sessions and their token burn while preserving all safety guarantees
- Strategist CLAUDE.md rewritten with complete 3-stage protocol and 12 consolidated hard rules
- Dashboard updated to reflect 1 strategy agent instead of 3
- hive-project.yaml: 9 → 7 enabled agents

## Changed files

| File | Change |
|---|---|
| `examples/kubestellar/agents/strategist-CLAUDE.md` | Complete rewrite: 3-stage kick protocol with guardian, experiment, and analysis stages |
| `examples/kubestellar/agents/strategist.env` | Updated comment and AGENT_LOOP_PROMPT for 3-stage protocol |
| `examples/kubestellar/hive-project.yaml` | Removed analyst and guardian from agents.enabled |
| `dashboard/index.html` | Updated STRATEGY_AGENT_NAMES, removed analyst/guardian from sidebar and session map |

## Test plan

- [ ] Verify strategist kicks correctly with 3-stage protocol on hive server
- [ ] Confirm guardian fast-fail checks run on every kick (Stage 1)
- [ ] Confirm experiment design only runs when no overlay exists (Stage 2)
- [ ] Confirm nous-sync.py runs after experiment completion (Stage 3)
- [ ] Dashboard Strategy Lab panel shows single strategist agent