### PR TITLE
feat: knowledge system with llm-wiki integration

### DIFF
--- a/v2/hive.yaml.example
+++ b/v2/hive.yaml.example
@@ -118,6 +118,42 @@ dashboard:
   snapshot_dir: /data/snapshots
   auth_token: ${HIVE_DASHBOARD_TOKEN}     # Optional — omit to allow unauthenticated access
 
+# Knowledge — 4-layer wiki system powered by llm-wiki (geronimo-iia/llm-wiki)
+# Facts are primed into agent kicks automatically — agents never query the wiki.
+# Personal layer stays on your machine; project layer lives in the repo.
+knowledge:
+  enabled: false                             # Set to true to activate knowledge priming
+  engine: llm-wiki
+  layers:
+    - type: personal
+      path: ~/.hive/wiki                     # Private, local-only, highest precedence
+      shared: false
+    - type: project
+      path: .hive/wiki                       # Same visibility as the repo
+      shared: true
+    # - type: org
+    #   url: https://wiki.your-org.dev/mcp   # Team-scoped, hosted llm-wiki instance
+    #   shared: true
+    # - type: community
+    #   url: https://wiki.hive.dev/mcp       # Public, read-only
+    #   shared: true
+  curator:
+    schedule: daily                           # How often to extract facts from merged PRs
+    extract_from:
+      - pr_comments
+      - ci_failures
+      - review_comments
+    auto_promote_threshold: 0.9              # Confidence to auto-promote project→org
+  primer:
+    max_facts: 25                            # Max facts injected per agent kick
+    priority:                                # Fact types, highest priority first
+      - regression
+      - gotcha
+      - test_scaffold
+      - pattern
+      - decision
+    merge_strategy: precedence               # personal > project > org > community
+
 # Data directories — all persistent state
 data:
   metrics_dir: /data/metrics

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -20,6 +20,34 @@ type Config struct {
 	Notifications NotificationsConfig          `yaml:"notifications"`
 	Dashboard     DashboardConfig              `yaml:"dashboard"`
 	Data          DataConfig                   `yaml:"data"`
+	Knowledge     KnowledgeConfig              `yaml:"knowledge"`
+}
+
+type KnowledgeConfig struct {
+	Enabled bool                `yaml:"enabled"`
+	Engine  string              `yaml:"engine"`
+	Layers  []KnowledgeLayer    `yaml:"layers"`
+	Curator KnowledgeCurator    `yaml:"curator"`
+	Primer  KnowledgePrimer     `yaml:"primer"`
+}
+
+type KnowledgeLayer struct {
+	Type   string `yaml:"type"`
+	Path   string `yaml:"path,omitempty"`
+	URL    string `yaml:"url,omitempty"`
+	Shared bool   `yaml:"shared"`
+}
+
+type KnowledgeCurator struct {
+	Schedule             string   `yaml:"schedule"`
+	ExtractFrom          []string `yaml:"extract_from"`
+	AutoPromoteThreshold float64  `yaml:"auto_promote_threshold"`
+}
+
+type KnowledgePrimer struct {
+	MaxFacts      int      `yaml:"max_facts"`
+	Priority      []string `yaml:"priority"`
+	MergeStrategy string   `yaml:"merge_strategy"`
 }
 
 type ProjectConfig struct {
@@ -265,9 +293,13 @@ func expandEnvVars(s string) string {
 }
 
 const (
-	defaultDashboardPort    = 3002
-	defaultEvalIntervalS    = 300
-	defaultPollIntervalMins = 5
+	defaultDashboardPort       = 3002
+	defaultEvalIntervalS       = 300
+	defaultPollIntervalMins    = 5
+	defaultKnowledgeMaxFacts   = 25
+	defaultKnowledgeEngine     = "llm-wiki"
+	defaultCuratorSchedule     = "daily"
+	defaultPromoteThreshold    = 0.9
 )
 
 func (c *Config) applyDefaults() {
@@ -294,6 +326,27 @@ func (c *Config) applyDefaults() {
 			agent.Enabled = true
 		}
 		c.Agents[name] = agent
+	}
+
+	if c.Knowledge.Enabled {
+		if c.Knowledge.Engine == "" {
+			c.Knowledge.Engine = defaultKnowledgeEngine
+		}
+		if c.Knowledge.Primer.MaxFacts == 0 {
+			c.Knowledge.Primer.MaxFacts = defaultKnowledgeMaxFacts
+		}
+		if c.Knowledge.Primer.MergeStrategy == "" {
+			c.Knowledge.Primer.MergeStrategy = "precedence"
+		}
+		if len(c.Knowledge.Primer.Priority) == 0 {
+			c.Knowledge.Primer.Priority = []string{"regression", "gotcha", "test_scaffold", "pattern", "decision"}
+		}
+		if c.Knowledge.Curator.Schedule == "" {
+			c.Knowledge.Curator.Schedule = defaultCuratorSchedule
+		}
+		if c.Knowledge.Curator.AutoPromoteThreshold == 0 {
+			c.Knowledge.Curator.AutoPromoteThreshold = defaultPromoteThreshold
+		}
 	}
 }
 

--- a/v2/pkg/knowledge/client.go
+++ b/v2/pkg/knowledge/client.go
@@ -1,0 +1,165 @@
+package knowledge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	defaultTimeout    = 10 * time.Second
+	searchResultLimit = 50
+)
+
+// Client talks to a single llm-wiki HTTP instance.
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+	logger     *slog.Logger
+}
+
+// NewClient creates a wiki client for the given HTTP endpoint.
+func NewClient(baseURL string, logger *slog.Logger) *Client {
+	return &Client{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout: defaultTimeout,
+		},
+		logger: logger,
+	}
+}
+
+// searchResponse matches llm-wiki's wiki_search MCP tool output.
+type searchResponse struct {
+	Results []searchResult `json:"results"`
+	Total   int            `json:"total"`
+}
+
+type searchResult struct {
+	Slug       string   `json:"slug"`
+	Title      string   `json:"title"`
+	Score      float64  `json:"score"`
+	Type       string   `json:"type"`
+	Status     string   `json:"status"`
+	Confidence float64  `json:"confidence"`
+	Tags       []string `json:"tags"`
+	Snippet    string   `json:"snippet"`
+}
+
+// pageResponse matches llm-wiki's wiki_content_read output.
+type pageResponse struct {
+	Slug       string   `json:"slug"`
+	Title      string   `json:"title"`
+	Body       string   `json:"body"`
+	Type       string   `json:"type"`
+	Status     string   `json:"status"`
+	Confidence float64  `json:"confidence"`
+	Tags       []string `json:"tags"`
+	Sources    []string `json:"sources"`
+	Backlinks  []string `json:"backlinks"`
+}
+
+// statsResponse matches llm-wiki's wiki_stats output.
+type statsResponse struct {
+	TotalPages int            `json:"total_pages"`
+	ByType     map[string]int `json:"by_type"`
+	ByStatus   map[string]int `json:"by_status"`
+	Stale      int            `json:"stale"`
+	Orphaned   int            `json:"orphaned"`
+}
+
+// Search queries the wiki with BM25 ranked search.
+func (c *Client) Search(ctx context.Context, query string, typeFilter string, limit int) ([]searchResult, error) {
+	if limit <= 0 {
+		limit = searchResultLimit
+	}
+
+	params := url.Values{
+		"q":     {query},
+		"limit": {fmt.Sprintf("%d", limit)},
+	}
+	if typeFilter != "" {
+		params.Set("type", typeFilter)
+	}
+
+	var resp searchResponse
+	if err := c.get(ctx, "/api/search", params, &resp); err != nil {
+		return nil, fmt.Errorf("wiki search: %w", err)
+	}
+
+	return resp.Results, nil
+}
+
+// ReadPage fetches a single wiki page by slug.
+func (c *Client) ReadPage(ctx context.Context, slug string) (*pageResponse, error) {
+	var resp pageResponse
+	if err := c.get(ctx, "/api/pages/"+slug, nil, &resp); err != nil {
+		return nil, fmt.Errorf("wiki read %s: %w", slug, err)
+	}
+	return &resp, nil
+}
+
+// Stats returns aggregate wiki health statistics.
+func (c *Client) Stats(ctx context.Context) (*statsResponse, error) {
+	var resp statsResponse
+	if err := c.get(ctx, "/api/stats", nil, &resp); err != nil {
+		return nil, fmt.Errorf("wiki stats: %w", err)
+	}
+	return &resp, nil
+}
+
+// ListPages returns all pages, optionally filtered by type.
+func (c *Client) ListPages(ctx context.Context, typeFilter string) ([]searchResult, error) {
+	params := url.Values{}
+	if typeFilter != "" {
+		params.Set("type", typeFilter)
+	}
+
+	var resp searchResponse
+	if err := c.get(ctx, "/api/pages", params, &resp); err != nil {
+		return nil, fmt.Errorf("wiki list: %w", err)
+	}
+
+	return resp.Results, nil
+}
+
+// Healthy returns true if the wiki endpoint is reachable.
+func (c *Client) Healthy(ctx context.Context) bool {
+	err := c.get(ctx, "/api/stats", nil, &statsResponse{})
+	return err == nil
+}
+
+func (c *Client) get(ctx context.Context, path string, params url.Values, dest any) error {
+	u := c.baseURL + path
+	if len(params) > 0 {
+		u += "?" + params.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP request to %s: %w", u, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("HTTP %d from %s: %s", resp.StatusCode, path, string(body))
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(dest); err != nil {
+		return fmt.Errorf("decoding response from %s: %w", path, err)
+	}
+
+	return nil
+}

--- a/v2/pkg/knowledge/primer.go
+++ b/v2/pkg/knowledge/primer.go
@@ -1,0 +1,176 @@
+package knowledge
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Primer queries wiki layers and merges results with precedence for injection
+// into agent kick prompts. It runs during kick preparation — agents never talk
+// to the wiki directly.
+type Primer struct {
+	layers []layerClient
+	config PrimerConfig
+	logger *slog.Logger
+}
+
+type layerClient struct {
+	layerType LayerType
+	client    *Client
+}
+
+// NewPrimer creates a primer from the configured wiki layers. Layers that are
+// unreachable at construction time are skipped with a warning — the primer
+// degrades gracefully.
+func NewPrimer(layers []LayerConfig, config PrimerConfig, logger *slog.Logger) *Primer {
+	var clients []layerClient
+	for _, l := range layers {
+		endpoint := l.Endpoint()
+		if endpoint == "" {
+			logger.Debug("skipping local-only layer (no HTTP endpoint)", "type", l.Type)
+			continue
+		}
+		c := NewClient(endpoint, logger)
+		clients = append(clients, layerClient{
+			layerType: l.Type,
+			client:    c,
+		})
+	}
+
+	if config.MaxFacts <= 0 {
+		config.MaxFacts = 25
+	}
+
+	return &Primer{
+		layers: clients,
+		config: config,
+		logger: logger,
+	}
+}
+
+// Prime queries all reachable wiki layers for facts relevant to the given
+// file paths and keywords, merges with precedence, and returns a result ready
+// for prompt injection.
+func (p *Primer) Prime(ctx context.Context, filePaths []string, keywords []string) *PrimedKnowledge {
+	start := time.Now()
+
+	query := buildQuery(filePaths, keywords)
+	if query == "" {
+		return &PrimedKnowledge{}
+	}
+
+	// Query each layer; collect results tagged with their layer.
+	var allFacts []Fact
+	for _, lc := range p.layers {
+		results, err := lc.client.Search(ctx, query, "", p.config.MaxFacts)
+		if err != nil {
+			p.logger.Warn("wiki layer unreachable, skipping",
+				"layer", lc.layerType,
+				"error", err,
+			)
+			continue
+		}
+
+		for _, r := range results {
+			allFacts = append(allFacts, Fact{
+				Slug:       r.Slug,
+				Title:      r.Title,
+				Type:       FactType(r.Type),
+				Body:       r.Snippet,
+				Confidence: r.Confidence,
+				Status:     r.Status,
+				Tags:       r.Tags,
+				Layer:      lc.layerType,
+			})
+		}
+	}
+
+	merged := p.mergeWithPrecedence(allFacts)
+	prioritized := p.applyPriority(merged)
+
+	if len(prioritized) > p.config.MaxFacts {
+		prioritized = prioritized[:p.config.MaxFacts]
+	}
+
+	elapsed := time.Since(start).Milliseconds()
+	p.logger.Info("knowledge primed",
+		"facts", len(prioritized),
+		"layers_queried", len(p.layers),
+		"query_ms", elapsed,
+	)
+
+	return &PrimedKnowledge{
+		Facts:     prioritized,
+		QueryTime: elapsed,
+	}
+}
+
+// mergeWithPrecedence deduplicates facts by slug, keeping the version from the
+// highest-precedence layer (personal > project > org > community).
+func (p *Primer) mergeWithPrecedence(facts []Fact) []Fact {
+	seen := make(map[string]Fact)
+	for _, f := range facts {
+		existing, exists := seen[f.Slug]
+		if !exists || f.Layer.Precedence() < existing.Layer.Precedence() {
+			seen[f.Slug] = f
+		}
+	}
+
+	result := make([]Fact, 0, len(seen))
+	for _, f := range seen {
+		result = append(result, f)
+	}
+	return result
+}
+
+// applyPriority sorts facts by configured type priority, then by confidence.
+func (p *Primer) applyPriority(facts []Fact) []Fact {
+	priorityMap := make(map[string]int)
+	for i, typ := range p.config.Priority {
+		priorityMap[typ] = i
+	}
+	defaultPriority := len(p.config.Priority)
+
+	sort.Slice(facts, func(i, j int) bool {
+		pi := defaultPriority
+		pj := defaultPriority
+		if idx, ok := priorityMap[string(facts[i].Type)]; ok {
+			pi = idx
+		}
+		if idx, ok := priorityMap[string(facts[j].Type)]; ok {
+			pj = idx
+		}
+		if pi != pj {
+			return pi < pj
+		}
+		return facts[i].Confidence > facts[j].Confidence
+	})
+
+	return facts
+}
+
+// buildQuery constructs a search string from file paths and keywords.
+func buildQuery(filePaths []string, keywords []string) string {
+	var parts []string
+
+	for _, fp := range filePaths {
+		segments := strings.Split(fp, "/")
+		if len(segments) > 0 {
+			filename := segments[len(segments)-1]
+			name := strings.TrimSuffix(filename, ".go")
+			name = strings.TrimSuffix(name, ".ts")
+			name = strings.TrimSuffix(name, ".tsx")
+			name = strings.TrimSuffix(name, ".js")
+			if name != "" && name != "index" {
+				parts = append(parts, name)
+			}
+		}
+	}
+
+	parts = append(parts, keywords...)
+
+	return strings.Join(parts, " ")
+}

--- a/v2/pkg/knowledge/primer_test.go
+++ b/v2/pkg/knowledge/primer_test.go
@@ -1,0 +1,215 @@
+package knowledge
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBuildQuery(t *testing.T) {
+	tests := []struct {
+		name      string
+		filePaths []string
+		keywords  []string
+		want      string
+	}{
+		{
+			name:      "empty",
+			filePaths: nil,
+			keywords:  nil,
+			want:      "",
+		},
+		{
+			name:      "keywords only",
+			filePaths: nil,
+			keywords:  []string{"auth", "jwt"},
+			want:      "auth jwt",
+		},
+		{
+			name:      "file paths only",
+			filePaths: []string{"src/hooks/useSearchIndex.ts", "src/components/CardWrapper.tsx"},
+			keywords:  nil,
+			want:      "useSearchIndex CardWrapper",
+		},
+		{
+			name:      "mixed",
+			filePaths: []string{"pkg/dashboard/server.go"},
+			keywords:  []string{"dashboard", "SSE"},
+			want:      "server dashboard SSE",
+		},
+		{
+			name:      "index files skipped",
+			filePaths: []string{"src/index.ts"},
+			keywords:  []string{"setup"},
+			want:      "setup",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildQuery(tt.filePaths, tt.keywords)
+			if got != tt.want {
+				t.Errorf("buildQuery() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeWithPrecedence(t *testing.T) {
+	p := &Primer{config: PrimerConfig{MaxFacts: 25}}
+
+	facts := []Fact{
+		{Slug: "dco-signing", Title: "DCO", Layer: LayerCommunity, Confidence: 0.8},
+		{Slug: "dco-signing", Title: "DCO (org override)", Layer: LayerOrg, Confidence: 0.95},
+		{Slug: "guard-join", Title: "Guard .join()", Layer: LayerProject, Confidence: 0.9},
+		{Slug: "guard-join", Title: "Guard .join() (personal)", Layer: LayerPersonal, Confidence: 1.0},
+		{Slug: "envtest", Title: "envtest timeout", Layer: LayerCommunity, Confidence: 0.7},
+	}
+
+	merged := p.mergeWithPrecedence(facts)
+
+	if len(merged) != 3 {
+		t.Fatalf("expected 3 merged facts, got %d", len(merged))
+	}
+
+	bySlug := map[string]Fact{}
+	for _, f := range merged {
+		bySlug[f.Slug] = f
+	}
+
+	if f, ok := bySlug["dco-signing"]; !ok || f.Layer != LayerOrg {
+		t.Errorf("dco-signing should come from org layer, got %v", f.Layer)
+	}
+	if f, ok := bySlug["guard-join"]; !ok || f.Layer != LayerPersonal {
+		t.Errorf("guard-join should come from personal layer, got %v", f.Layer)
+	}
+	if f, ok := bySlug["envtest"]; !ok || f.Layer != LayerCommunity {
+		t.Errorf("envtest should come from community layer, got %v", f.Layer)
+	}
+}
+
+func TestApplyPriority(t *testing.T) {
+	p := &Primer{
+		config: PrimerConfig{
+			Priority: []string{"regression", "gotcha", "pattern", "decision"},
+		},
+	}
+
+	facts := []Fact{
+		{Slug: "a", Type: FactDecision, Confidence: 1.0},
+		{Slug: "b", Type: FactGotcha, Confidence: 0.8},
+		{Slug: "c", Type: FactRegression, Confidence: 0.9},
+		{Slug: "d", Type: FactPattern, Confidence: 0.95},
+	}
+
+	sorted := p.applyPriority(facts)
+
+	expectedOrder := []string{"c", "b", "d", "a"}
+	for i, slug := range expectedOrder {
+		if sorted[i].Slug != slug {
+			t.Errorf("position %d: expected %s, got %s", i, slug, sorted[i].Slug)
+		}
+	}
+}
+
+func TestPrimeWithMockWiki(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := searchResponse{
+			Total: 2,
+			Results: []searchResult{
+				{
+					Slug:       "guard-join",
+					Title:      "Guard .join() against undefined",
+					Score:      0.95,
+					Type:       "gotcha",
+					Status:     "verified",
+					Confidence: 0.95,
+					Tags:       []string{"typescript", "hooks"},
+					Snippet:    "Always use (arr || []).join()",
+				},
+				{
+					Slug:       "isDemoData-wiring",
+					Title:      "isDemoData wiring is mandatory",
+					Score:      0.88,
+					Type:       "pattern",
+					Status:     "verified",
+					Confidence: 0.92,
+					Tags:       []string{"react", "cards"},
+					Snippet:    "Every card using useCached* hooks MUST destructure isDemoData",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	logger := slog.Default()
+	layers := []LayerConfig{
+		{Type: LayerProject, URL: srv.URL, Shared: true},
+	}
+	config := PrimerConfig{
+		MaxFacts: 25,
+		Priority: []string{"regression", "gotcha", "pattern"},
+	}
+
+	primer := NewPrimer(layers, config, logger)
+	result := primer.Prime(context.Background(), []string{"src/hooks/useSearchIndex.ts"}, []string{"hooks"})
+
+	if len(result.Facts) != 2 {
+		t.Fatalf("expected 2 facts, got %d", len(result.Facts))
+	}
+
+	if result.Facts[0].Type != FactGotcha {
+		t.Errorf("expected gotcha first (higher priority), got %s", result.Facts[0].Type)
+	}
+	if result.Facts[1].Type != FactPattern {
+		t.Errorf("expected pattern second, got %s", result.Facts[1].Type)
+	}
+
+	prompt := result.FormatForPrompt()
+	if prompt == "" {
+		t.Error("FormatForPrompt returned empty string")
+	}
+	if !contains(prompt, "Guard .join()") {
+		t.Error("prompt should contain fact title")
+	}
+}
+
+func TestPrimeGracefulDegradation(t *testing.T) {
+	logger := slog.Default()
+	layers := []LayerConfig{
+		{Type: LayerOrg, URL: "http://127.0.0.1:1", Shared: true},
+	}
+	config := PrimerConfig{MaxFacts: 25}
+
+	primer := NewPrimer(layers, config, logger)
+	result := primer.Prime(context.Background(), nil, []string{"test"})
+
+	if len(result.Facts) != 0 {
+		t.Errorf("expected 0 facts when wiki unreachable, got %d", len(result.Facts))
+	}
+}
+
+func TestFormatForPromptEmpty(t *testing.T) {
+	pk := &PrimedKnowledge{}
+	if pk.FormatForPrompt() != "" {
+		t.Error("empty knowledge should produce empty prompt")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstr(s, substr))
+}
+
+func containsSubstr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/v2/pkg/knowledge/types.go
+++ b/v2/pkg/knowledge/types.go
@@ -1,0 +1,165 @@
+package knowledge
+
+import "time"
+
+// LayerType identifies the scope and privacy of a knowledge wiki layer.
+type LayerType string
+
+const (
+	LayerPersonal  LayerType = "personal"
+	LayerProject   LayerType = "project"
+	LayerOrg       LayerType = "org"
+	LayerCommunity LayerType = "community"
+)
+
+// Precedence returns the merge priority (lower = higher priority).
+// Personal overrides everything; community is the fallback.
+func (l LayerType) Precedence() int {
+	switch l {
+	case LayerPersonal:
+		return 1
+	case LayerProject:
+		return 2
+	case LayerOrg:
+		return 3
+	case LayerCommunity:
+		return 4
+	default:
+		return 99
+	}
+}
+
+// LayerConfig describes a single wiki layer in hive.yaml.
+type LayerConfig struct {
+	Type   LayerType `yaml:"type"   json:"type"`
+	Path   string    `yaml:"path"   json:"path,omitempty"`
+	URL    string    `yaml:"url"    json:"url,omitempty"`
+	Shared bool      `yaml:"shared" json:"shared"`
+}
+
+// Endpoint returns the HTTP URL for this layer. Local layers use path-based
+// access; remote layers use their configured URL.
+func (l LayerConfig) Endpoint() string {
+	if l.URL != "" {
+		return l.URL
+	}
+	return ""
+}
+
+// KnowledgeConfig is the top-level knowledge section of hive.yaml.
+type KnowledgeConfig struct {
+	Enabled bool            `yaml:"enabled" json:"enabled"`
+	Engine  string          `yaml:"engine"  json:"engine"`
+	Layers  []LayerConfig   `yaml:"layers"  json:"layers"`
+	Curator CuratorConfig   `yaml:"curator" json:"curator"`
+	Primer  PrimerConfig    `yaml:"primer"  json:"primer"`
+}
+
+// CuratorConfig controls automated knowledge extraction from merged PRs.
+type CuratorConfig struct {
+	Schedule              string   `yaml:"schedule"                json:"schedule"`
+	ExtractFrom           []string `yaml:"extract_from"            json:"extract_from"`
+	AutoPromoteThreshold  float64  `yaml:"auto_promote_threshold"  json:"auto_promote_threshold"`
+}
+
+// PrimerConfig controls how facts are selected and injected into agent kicks.
+type PrimerConfig struct {
+	MaxFacts      int      `yaml:"max_facts"       json:"max_facts"`
+	Priority      []string `yaml:"priority"        json:"priority"`
+	MergeStrategy string   `yaml:"merge_strategy"  json:"merge_strategy"`
+}
+
+// FactType categorizes knowledge entries.
+type FactType string
+
+const (
+	FactPattern    FactType = "pattern"
+	FactGotcha     FactType = "gotcha"
+	FactDecision   FactType = "decision"
+	FactRegression FactType = "regression"
+	FactTestScaff  FactType = "test_scaffold"
+	FactIntegration FactType = "integration"
+	FactCoverage   FactType = "coverage_rule"
+)
+
+// Fact is a single knowledge entry returned by the wiki.
+type Fact struct {
+	Slug       string    `json:"slug"`
+	Title      string    `json:"title"`
+	Type       FactType  `json:"type"`
+	Body       string    `json:"body"`
+	Confidence float64   `json:"confidence"`
+	Status     string    `json:"status"`
+	Tags       []string  `json:"tags"`
+	Layer      LayerType `json:"layer"`
+	Sources    []Source  `json:"sources,omitempty"`
+	Related    []string  `json:"related,omitempty"`
+	UsageCount int       `json:"usage_count"`
+	LastUsed   time.Time `json:"last_used,omitempty"`
+}
+
+// Source tracks where a fact was extracted from.
+type Source struct {
+	PR      string    `json:"pr,omitempty"`
+	Comment string    `json:"comment,omitempty"`
+	Author  string    `json:"author,omitempty"`
+	Date    time.Time `json:"date"`
+}
+
+// PrimedKnowledge is the result of priming — ready to inject into an agent kick.
+type PrimedKnowledge struct {
+	Facts     []Fact `json:"facts"`
+	QueryTime int64  `json:"query_time_ms"`
+}
+
+// FormatForPrompt renders primed facts as markdown for injection into an agent's
+// kick prompt. This runs once during kick preparation; the agent never queries
+// the wiki directly.
+func (pk *PrimedKnowledge) FormatForPrompt() string {
+	if len(pk.Facts) == 0 {
+		return ""
+	}
+
+	var b []byte
+	b = append(b, "# Relevant Knowledge\n\n"...)
+
+	typeSections := map[string][]Fact{}
+	typeOrder := []string{}
+	for _, f := range pk.Facts {
+		key := string(f.Type)
+		if _, exists := typeSections[key]; !exists {
+			typeOrder = append(typeOrder, key)
+		}
+		typeSections[key] = append(typeSections[key], f)
+	}
+
+	for _, typ := range typeOrder {
+		facts := typeSections[typ]
+		b = append(b, "## "+typ+"\n\n"...)
+		for _, f := range facts {
+			b = append(b, "- **"+f.Title+"**"...)
+			if f.Confidence < 1.0 {
+				b = append(b, " (confidence: "...)
+				b = append(b, formatConfidence(f.Confidence)...)
+				b = append(b, ")"...)
+			}
+			b = append(b, "\n  "...)
+			b = append(b, f.Body...)
+			b = append(b, "\n\n"...)
+		}
+	}
+
+	return string(b)
+}
+
+func formatConfidence(c float64) string {
+	pct := int(c * 100)
+	switch {
+	case pct >= 90:
+		return "high"
+	case pct >= 70:
+		return "medium"
+	default:
+		return "low"
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `v2/pkg/knowledge/` package — the foundation for the 4-layer wiki knowledge system
- Implements llm-wiki HTTP client, selective primer with layer precedence, and prompt formatter
- Extends `v2/pkg/config/` with `KnowledgeConfig` (layers, curator, primer settings with defaults)
- Updates `hive.yaml.example` with full knowledge section documentation

## Architecture

Facts are primed during kick preparation and injected into the agent's prompt — agents never talk to the wiki directly. After `/clear`, the agent gets fresh context with exactly the knowledge it needs.

```
Governor evaluates → Primer queries wiki by file paths/keywords → Facts injected into kick prompt
```

4 layers with precedence (personal > project > org > community):
- **Personal** (`~/.hive/wiki/`) — private, local-only, never shared
- **Project** (`.hive/wiki/`) — same visibility as the repo
- **Org** — team-scoped hosted instance
- **Community** — public, read-only

## Files

| File | Purpose |
|------|---------|
| `pkg/knowledge/types.go` | Fact, Layer, Config types, `FormatForPrompt()` |
| `pkg/knowledge/client.go` | llm-wiki HTTP client (search, read, stats, list, health) |
| `pkg/knowledge/primer.go` | Selective priming with layer merge and priority sorting |
| `pkg/knowledge/primer_test.go` | 6 tests: query building, precedence, priority, mock wiki, graceful degradation |
| `pkg/config/config.go` | `KnowledgeConfig` added to Config struct with defaults |
| `hive.yaml.example` | Knowledge section with all 4 layers documented |

## Test plan

- [x] `go test ./pkg/knowledge/...` — 6 tests pass
- [x] `go test ./pkg/config/...` — 37 tests pass (no regressions)
- [ ] Integration test with live llm-wiki instance (Phase 2)

## Next steps

- `pkg/knowledge/curator.go` — extract facts from merged PRs
- `pkg/knowledge/promote.go` — fact promotion between layers  
- `pkg/knowledge/maturity.go` — ACMM test maturity detection
- Dashboard Knowledge tab (API endpoints + frontend)
- Wire primer into scheduler kick flow