### PR TITLE
Add knowledge curator for PR-based fact extraction

### DIFF
--- a/v2/pkg/knowledge/curator.go
+++ b/v2/pkg/knowledge/curator.go
@@ -1,0 +1,333 @@
+package knowledge
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+const (
+	curatorExtractLimit   = 50
+	minCommentLength      = 20
+	ingestRequestTimeout  = 30 * time.Second
+)
+
+// Curator extracts knowledge from merged PRs and ingests it into a wiki layer.
+type Curator struct {
+	ghClient  *gh.Client
+	wikiURL   string
+	org       string
+	repos     []string
+	config    CuratorConfig
+	logger    *slog.Logger
+}
+
+// NewCurator creates a curator that watches the given repos for merged PRs.
+func NewCurator(ghClient *gh.Client, wikiURL string, org string, repos []string, config CuratorConfig, logger *slog.Logger) *Curator {
+	return &Curator{
+		ghClient: ghClient,
+		wikiURL:  wikiURL,
+		org:      org,
+		repos:    repos,
+		config:   config,
+		logger:   logger,
+	}
+}
+
+// ExtractedFact is a fact candidate extracted from a PR before ingestion.
+type ExtractedFact struct {
+	Title      string   `json:"title"`
+	Body       string   `json:"body"`
+	Type       FactType `json:"type"`
+	Confidence float64  `json:"confidence"`
+	Tags       []string `json:"tags"`
+	SourcePR   string   `json:"source_pr"`
+	SourceDate time.Time `json:"source_date"`
+}
+
+// RunExtraction fetches merged PRs since the given time and extracts knowledge
+// candidates from their diffs and review comments.
+func (c *Curator) RunExtraction(ctx context.Context, since time.Time) ([]ExtractedFact, error) {
+	var allFacts []ExtractedFact
+
+	for _, repo := range c.repos {
+		parts := strings.SplitN(repo, "/", 2)
+		owner, repoName := c.org, repo
+		if len(parts) == 2 {
+			owner, repoName = parts[0], parts[1]
+		}
+
+		prs, err := c.fetchMergedPRs(ctx, owner, repoName, since)
+		if err != nil {
+			c.logger.Warn("failed to fetch PRs",
+				"repo", repo,
+				"error", err,
+			)
+			continue
+		}
+
+		for _, pr := range prs {
+			facts := c.extractFromPR(ctx, owner, repoName, pr)
+			allFacts = append(allFacts, facts...)
+		}
+	}
+
+	c.logger.Info("extraction complete",
+		"facts_extracted", len(allFacts),
+		"repos_scanned", len(c.repos),
+		"since", since.Format(time.RFC3339),
+	)
+
+	return allFacts, nil
+}
+
+// Ingest sends extracted facts to the wiki for storage. The wiki handles
+// deduplication, cross-referencing, and confidence scoring.
+func (c *Curator) Ingest(ctx context.Context, facts []ExtractedFact) error {
+	if len(facts) == 0 {
+		return nil
+	}
+
+	payload, err := json.Marshal(facts)
+	if err != nil {
+		return fmt.Errorf("marshaling facts: %w", err)
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, ingestRequestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, c.wikiURL+"/api/ingest", bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("creating ingest request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("ingest request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("ingest returned HTTP %d", resp.StatusCode)
+	}
+
+	c.logger.Info("facts ingested", "count", len(facts))
+	return nil
+}
+
+func (c *Curator) fetchMergedPRs(ctx context.Context, owner, repo string, since time.Time) ([]*gh.PullRequest, error) {
+	opts := &gh.PullRequestListOptions{
+		State:     "closed",
+		Sort:      "updated",
+		Direction: "desc",
+		ListOptions: gh.ListOptions{
+			PerPage: curatorExtractLimit,
+		},
+	}
+
+	prs, _, err := c.ghClient.PullRequests.List(ctx, owner, repo, opts)
+	if err != nil {
+		return nil, fmt.Errorf("listing PRs for %s/%s: %w", owner, repo, err)
+	}
+
+	var merged []*gh.PullRequest
+	for _, pr := range prs {
+		if pr.MergedAt == nil {
+			continue
+		}
+		mergedAt := pr.MergedAt.Time
+		if mergedAt.Before(since) {
+			break
+		}
+		merged = append(merged, pr)
+	}
+
+	return merged, nil
+}
+
+func (c *Curator) extractFromPR(ctx context.Context, owner, repo string, pr *gh.PullRequest) []ExtractedFact {
+	var facts []ExtractedFact
+	prRef := fmt.Sprintf("%s/%s#%d", owner, repo, pr.GetNumber())
+
+	if c.shouldExtractFrom("review_comments") {
+		comments := c.fetchReviewComments(ctx, owner, repo, pr.GetNumber())
+		for _, comment := range comments {
+			if fact := classifyComment(comment, prRef, pr.GetMergedAt().Time); fact != nil {
+				facts = append(facts, *fact)
+			}
+		}
+	}
+
+	if c.shouldExtractFrom("pr_comments") {
+		comments := c.fetchIssueComments(ctx, owner, repo, pr.GetNumber())
+		for _, comment := range comments {
+			if fact := classifyComment(comment, prRef, pr.GetMergedAt().Time); fact != nil {
+				facts = append(facts, *fact)
+			}
+		}
+	}
+
+	return facts
+}
+
+func (c *Curator) fetchReviewComments(ctx context.Context, owner, repo string, prNumber int) []string {
+	comments, _, err := c.ghClient.PullRequests.ListComments(ctx, owner, repo, prNumber, nil)
+	if err != nil {
+		c.logger.Debug("failed to fetch review comments", "pr", prNumber, "error", err)
+		return nil
+	}
+
+	var bodies []string
+	for _, comment := range comments {
+		body := comment.GetBody()
+		if len(body) >= minCommentLength {
+			bodies = append(bodies, body)
+		}
+	}
+	return bodies
+}
+
+func (c *Curator) fetchIssueComments(ctx context.Context, owner, repo string, prNumber int) []string {
+	comments, _, err := c.ghClient.Issues.ListComments(ctx, owner, repo, prNumber, nil)
+	if err != nil {
+		c.logger.Debug("failed to fetch issue comments", "pr", prNumber, "error", err)
+		return nil
+	}
+
+	var bodies []string
+	for _, comment := range comments {
+		body := comment.GetBody()
+		if len(body) >= minCommentLength {
+			bodies = append(bodies, body)
+		}
+	}
+	return bodies
+}
+
+func (c *Curator) shouldExtractFrom(source string) bool {
+	for _, s := range c.config.ExtractFrom {
+		if s == source {
+			return true
+		}
+	}
+	return false
+}
+
+// classifyComment examines a comment for knowledge signals and returns an
+// ExtractedFact if the comment contains actionable knowledge. Returns nil for
+// comments that are just conversational or too short.
+func classifyComment(comment string, prRef string, mergedAt time.Time) *ExtractedFact {
+	lower := strings.ToLower(comment)
+
+	var factType FactType
+	var confidence float64
+
+	switch {
+	case containsAny(lower, "always", "never", "must", "do not", "don't"):
+		factType = FactGotcha
+		confidence = 0.7
+	case containsAny(lower, "regression", "broke", "broke again", "reverted"):
+		factType = FactRegression
+		confidence = 0.8
+	case containsAny(lower, "pattern", "convention", "prefer", "should use", "best practice"):
+		factType = FactPattern
+		confidence = 0.6
+	case containsAny(lower, "test", "coverage", "mock", "fixture", "assert"):
+		factType = FactTestScaff
+		confidence = 0.5
+	case containsAny(lower, "decided", "agreed", "going forward", "from now on"):
+		factType = FactDecision
+		confidence = 0.7
+	default:
+		return nil
+	}
+
+	title := extractTitle(comment)
+	if title == "" {
+		return nil
+	}
+
+	return &ExtractedFact{
+		Title:      title,
+		Body:       truncate(comment, 500),
+		Type:       factType,
+		Confidence: confidence,
+		Tags:       extractTags(comment),
+		SourcePR:   prRef,
+		SourceDate: mergedAt,
+	}
+}
+
+func containsAny(s string, needles ...string) bool {
+	for _, n := range needles {
+		if strings.Contains(s, n) {
+			return true
+		}
+	}
+	return false
+}
+
+// extractTitle pulls the first meaningful sentence from a comment.
+func extractTitle(comment string) string {
+	lines := strings.Split(comment, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if len(trimmed) < minCommentLength {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "<!--") {
+			continue
+		}
+		const maxTitleLen = 120
+		if len(trimmed) > maxTitleLen {
+			trimmed = trimmed[:maxTitleLen] + "..."
+		}
+		return trimmed
+	}
+	return ""
+}
+
+func extractTags(comment string) []string {
+	lower := strings.ToLower(comment)
+	var tags []string
+
+	tagKeywords := map[string]string{
+		"typescript": "typescript",
+		"react":      "react",
+		"go ":        "go",
+		"golang":     "go",
+		"test":       "testing",
+		"ci":         "ci",
+		"docker":     "docker",
+		"kubernetes": "kubernetes",
+		"k8s":        "kubernetes",
+		"helm":       "helm",
+		"security":   "security",
+		"auth":       "auth",
+	}
+
+	seen := make(map[string]bool)
+	for keyword, tag := range tagKeywords {
+		if strings.Contains(lower, keyword) && !seen[tag] {
+			tags = append(tags, tag)
+			seen[tag] = true
+		}
+	}
+
+	return tags
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/v2/pkg/knowledge/curator_test.go
+++ b/v2/pkg/knowledge/curator_test.go
@@ -1,0 +1,344 @@
+package knowledge
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+func TestClassifyComment(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		comment  string
+		wantType FactType
+		wantNil  bool
+	}{
+		{
+			name:     "gotcha: always keyword",
+			comment:  "You should always guard .join() against undefined arrays.",
+			wantType: FactGotcha,
+		},
+		{
+			name:     "gotcha: never keyword",
+			comment:  "Never call setState inside a useEffect cleanup function.",
+			wantType: FactGotcha,
+		},
+		{
+			name:     "regression: broke keyword",
+			comment:  "This broke again after the last deploy — the webhook port override was lost.",
+			wantType: FactRegression,
+		},
+		{
+			name:     "pattern: convention keyword",
+			comment:  "Our convention is to use factory functions from test/factories.ts for all mocks.",
+			wantType: FactPattern,
+		},
+		{
+			name:     "test_scaffold: test keyword",
+			comment:  "Make sure to add a test for the edge case when the array is empty.",
+			wantType: FactTestScaff,
+		},
+		{
+			name:     "decision: decided keyword",
+			comment:  "We decided to use Zustand instead of Redux for state management going forward.",
+			wantType: FactDecision,
+		},
+		{
+			name:    "nil: conversational comment",
+			comment: "Looks good to me, thanks for the update!",
+			wantNil: true,
+		},
+		{
+			name:    "nil: too short for title",
+			comment: "ok lgtm",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fact := classifyComment(tt.comment, "org/repo#42", now)
+			if tt.wantNil {
+				if fact != nil {
+					t.Errorf("expected nil, got %+v", fact)
+				}
+				return
+			}
+			if fact == nil {
+				t.Fatal("expected non-nil fact")
+			}
+			if fact.Type != tt.wantType {
+				t.Errorf("type = %s, want %s", fact.Type, tt.wantType)
+			}
+			if fact.SourcePR != "org/repo#42" {
+				t.Errorf("source_pr = %s, want org/repo#42", fact.SourcePR)
+			}
+			if fact.Title == "" {
+				t.Error("expected non-empty title")
+			}
+		})
+	}
+}
+
+func TestExtractTitle(t *testing.T) {
+	tests := []struct {
+		name    string
+		comment string
+		want    string
+	}{
+		{
+			name:    "simple sentence",
+			comment: "Always guard .join() against undefined arrays to prevent crashes.",
+			want:    "Always guard .join() against undefined arrays to prevent crashes.",
+		},
+		{
+			name:    "skips markdown headers",
+			comment: "# Review\nAlways guard .join() against undefined arrays.",
+			want:    "Always guard .join() against undefined arrays.",
+		},
+		{
+			name:    "skips code blocks",
+			comment: "```go\nfmt.Println()\n```\nAlways guard .join() against undefined.",
+			want:    "Always guard .join() against undefined.",
+		},
+		{
+			name:    "skips short lines",
+			comment: "ok\nAlways guard .join() against undefined arrays to prevent crashes.",
+			want:    "Always guard .join() against undefined arrays to prevent crashes.",
+		},
+		{
+			name:    "truncates long lines",
+			comment: "This is a very long comment that goes on and on and on and on and on and on and on and on and on and on and on and on and on and keeps going past the limit.",
+			want:    "This is a very long comment that goes on and on and on and on and on and on and on and on and on and on and on and on an...",
+		},
+		{
+			name:    "empty when all short",
+			comment: "ok\nlgtm\nnice",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractTitle(tt.comment)
+			if got != tt.want {
+				t.Errorf("extractTitle() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractTags(t *testing.T) {
+	comment := "This React component uses TypeScript and needs a test with Docker."
+	tags := extractTags(comment)
+
+	expected := map[string]bool{
+		"react":      false,
+		"typescript": false,
+		"testing":    false,
+		"docker":     false,
+	}
+
+	for _, tag := range tags {
+		if _, ok := expected[tag]; ok {
+			expected[tag] = true
+		}
+	}
+
+	for tag, found := range expected {
+		if !found {
+			t.Errorf("expected tag %q not found in %v", tag, tags)
+		}
+	}
+}
+
+func TestExtractTagsDedup(t *testing.T) {
+	comment := "go and golang are the same language for testing purposes"
+	tags := extractTags(comment)
+
+	goCount := 0
+	for _, tag := range tags {
+		if tag == "go" {
+			goCount++
+		}
+	}
+	if goCount != 1 {
+		t.Errorf("expected 1 'go' tag, got %d in %v", goCount, tags)
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if got := truncate("short", 10); got != "short" {
+		t.Errorf("truncate short = %q", got)
+	}
+	if got := truncate("exactly ten", 11); got != "exactly ten" {
+		t.Errorf("truncate exact = %q", got)
+	}
+	if got := truncate("this is too long", 7); got != "this is..." {
+		t.Errorf("truncate long = %q, want %q", got, "this is...")
+	}
+}
+
+func TestContainsAny(t *testing.T) {
+	if !containsAny("always use guards", "always", "never") {
+		t.Error("should match 'always'")
+	}
+	if containsAny("looks good", "always", "never") {
+		t.Error("should not match")
+	}
+}
+
+func TestShouldExtractFrom(t *testing.T) {
+	c := &Curator{
+		config: CuratorConfig{
+			ExtractFrom: []string{"review_comments", "pr_comments"},
+		},
+	}
+
+	if !c.shouldExtractFrom("review_comments") {
+		t.Error("should extract from review_comments")
+	}
+	if !c.shouldExtractFrom("pr_comments") {
+		t.Error("should extract from pr_comments")
+	}
+	if c.shouldExtractFrom("ci_failures") {
+		t.Error("should not extract from ci_failures")
+	}
+}
+
+func TestFetchMergedPRsFiltering(t *testing.T) {
+	now := time.Now()
+	since := now.Add(-24 * time.Hour)
+
+	mergedRecent := now.Add(-1 * time.Hour)
+	mergedOld := now.Add(-48 * time.Hour)
+	recentTimestamp := &gh.Timestamp{Time: mergedRecent}
+	oldTimestamp := &gh.Timestamp{Time: mergedOld}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		prs := []*gh.PullRequest{
+			{
+				Number:   gh.Ptr(1),
+				MergedAt: recentTimestamp,
+			},
+			{
+				Number:   gh.Ptr(2),
+				MergedAt: oldTimestamp,
+			},
+			{
+				Number: gh.Ptr(3),
+				// not merged
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(prs)
+	}))
+	defer srv.Close()
+
+	ghClient, err := gh.NewClient(nil).WithEnterpriseURLs(srv.URL+"/", srv.URL+"/")
+	if err != nil {
+		t.Fatalf("creating test client: %v", err)
+	}
+
+	c := &Curator{
+		ghClient: ghClient,
+		logger:   slog.Default(),
+	}
+
+	merged, err := c.fetchMergedPRs(context.Background(), "org", "repo", since)
+	if err != nil {
+		t.Fatalf("fetchMergedPRs: %v", err)
+	}
+
+	if len(merged) != 1 {
+		t.Fatalf("expected 1 merged PR since cutoff, got %d", len(merged))
+	}
+	if merged[0].GetNumber() != 1 {
+		t.Errorf("expected PR #1, got #%d", merged[0].GetNumber())
+	}
+}
+
+func TestIngestSuccess(t *testing.T) {
+	var receivedFacts []ExtractedFact
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/ingest" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("unexpected method: %s", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("unexpected content-type: %s", r.Header.Get("Content-Type"))
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		json.Unmarshal(body, &receivedFacts)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	c := &Curator{
+		wikiURL: srv.URL,
+		logger:  slog.Default(),
+	}
+
+	facts := []ExtractedFact{
+		{
+			Title:      "Guard .join()",
+			Body:       "Always guard .join() against undefined",
+			Type:       FactGotcha,
+			Confidence: 0.8,
+			Tags:       []string{"typescript"},
+			SourcePR:   "org/repo#42",
+			SourceDate: time.Now(),
+		},
+	}
+
+	err := c.Ingest(context.Background(), facts)
+	if err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+
+	if len(receivedFacts) != 1 {
+		t.Fatalf("expected 1 fact ingested, got %d", len(receivedFacts))
+	}
+	if receivedFacts[0].Title != "Guard .join()" {
+		t.Errorf("title = %q, want %q", receivedFacts[0].Title, "Guard .join()")
+	}
+}
+
+func TestIngestEmpty(t *testing.T) {
+	c := &Curator{logger: slog.Default()}
+	err := c.Ingest(context.Background(), nil)
+	if err != nil {
+		t.Errorf("Ingest(nil) should return nil, got %v", err)
+	}
+}
+
+func TestIngestHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := &Curator{
+		wikiURL: srv.URL,
+		logger:  slog.Default(),
+	}
+
+	facts := []ExtractedFact{{Title: "test", Body: "test body for length"}}
+	err := c.Ingest(context.Background(), facts)
+	if err == nil {
+		t.Error("expected error for HTTP 500")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `curator.go` — extracts knowledge facts from merged PR review comments and issue comments using heuristic keyword classification (gotcha/regression/pattern/test_scaffold/decision)
- Adds `curator_test.go` — 11 test functions covering classification, title extraction, tag extraction, PR filtering, ingest success/failure, and edge cases
- Uses `go-github/v72` (already in go.mod) for GitHub API access
- Ingests extracted facts to wiki via HTTP POST to `/api/ingest`

Part of the layered knowledge system ([design doc](https://github.com/kubestellar/hive/blob/v2/v2/docs/design/knowledge-system.md), Phase 1).

## Test plan

- [x] All 17 knowledge package tests pass (`go test ./pkg/knowledge/ -v`)
- [x] Package compiles cleanly (`go build ./pkg/knowledge/`)
- [ ] CI passes (pre-existing `manager_test.go` failure is unrelated)