### PR TITLE
Wire knowledge primer into scheduler and dashboard

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/dashboard"
 	"github.com/kubestellar/hive/v2/pkg/github"
 	"github.com/kubestellar/hive/v2/pkg/governor"
+	"github.com/kubestellar/hive/v2/pkg/knowledge"
 	"github.com/kubestellar/hive/v2/pkg/notify"
 	"github.com/kubestellar/hive/v2/pkg/policies"
 	"github.com/kubestellar/hive/v2/pkg/scheduler"
@@ -86,6 +87,22 @@ func main() {
 	}
 	gov := governor.New(cfg.Governor, cfg.EnabledAgents(), logger)
 	sched := scheduler.New(cfg, logger)
+
+	if cfg.Knowledge.Enabled {
+		layers := convertKnowledgeLayers(cfg.Knowledge.Layers)
+		primerCfg := knowledge.PrimerConfig{
+			MaxFacts:      cfg.Knowledge.Primer.MaxFacts,
+			Priority:      cfg.Knowledge.Primer.Priority,
+			MergeStrategy: cfg.Knowledge.Primer.MergeStrategy,
+		}
+		primer := knowledge.NewPrimer(layers, primerCfg, logger)
+		sched.SetPrimer(primer)
+		logger.Info("knowledge primer enabled",
+			"layers", len(cfg.Knowledge.Layers),
+			"max_facts", primerCfg.MaxFacts,
+		)
+	}
+
 	notifier := notify.New(cfg.Notifications, logger)
 	agentMgr := agent.NewManager(cfg.EnabledAgents(), logger)
 
@@ -156,12 +173,22 @@ func main() {
 		))
 	}
 
+	var knowledgeAPI *knowledge.KnowledgeAPI
+	if cfg.Knowledge.Enabled {
+		layers := convertKnowledgeLayers(cfg.Knowledge.Layers)
+		knowledgeAPI = knowledge.NewKnowledgeAPI(layers, knowledge.KnowledgeConfig{
+			Enabled: cfg.Knowledge.Enabled,
+			Engine:  cfg.Knowledge.Engine,
+		}, logger)
+	}
+
 	dashSrv.RegisterAPI(&dashboard.Dependencies{
 		Config:      cfg,
 		AgentMgr:    agentMgr,
 		Governor:    gov,
 		GHClient:    ghClient,
 		Tokens:      tokenCollector,
+		Knowledge:   knowledgeAPI,
 		Logger:      logger,
 		Ctx:         ctx,
 		RefreshFunc: refreshDashboard,
@@ -295,6 +322,19 @@ func runEvalCycle(
 		ghClient,
 		ctx,
 	))
+}
+
+func convertKnowledgeLayers(cfgLayers []config.KnowledgeLayer) []knowledge.LayerConfig {
+	layers := make([]knowledge.LayerConfig, len(cfgLayers))
+	for i, l := range cfgLayers {
+		layers[i] = knowledge.LayerConfig{
+			Type:   knowledge.LayerType(l.Type),
+			Path:   l.Path,
+			URL:    l.URL,
+			Shared: l.Shared,
+		}
+	}
+	return layers
 }
 
 func persistState(agentMgr *agent.Manager, gov *governor.Governor, path string, logger *slog.Logger) {

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/knowledge"
 )
 
 func (s *Server) RegisterAPI(deps *Dependencies) {
@@ -68,6 +69,13 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/config/sidebar", s.handleSidebarGet)
 	s.mux.HandleFunc("PUT /api/config/sidebar", s.handleSidebarSet)
 	s.mux.HandleFunc("GET /api/config/backends", s.handleBackends)
+
+	s.mux.HandleFunc("GET /api/knowledge", s.handleKnowledgeList)
+	s.mux.HandleFunc("GET /api/knowledge/search", s.handleKnowledgeSearch)
+	s.mux.HandleFunc("GET /api/knowledge/health", s.handleKnowledgeHealth)
+	s.mux.HandleFunc("GET /api/knowledge/stats", s.handleKnowledgeStats)
+	s.mux.HandleFunc("GET /api/knowledge/{layer}", s.handleKnowledgeLayer)
+	s.mux.HandleFunc("GET /api/knowledge/{layer}/{slug}", s.handleKnowledgeFact)
 
 	s.mux.HandleFunc("POST /api/chat", s.handleChat)
 
@@ -806,6 +814,102 @@ func (s *Server) handleBackends(w http.ResponseWriter, r *http.Request) {
 		{"id": "gemini", "name": "Gemini", "models": []string{"gemini-2.5-pro", "gemini-2.5-flash"}},
 		{"id": "goose", "name": "Goose", "models": []string{"default"}},
 	})
+}
+
+// --- Knowledge endpoints ---
+
+func (s *Server) handleKnowledgeList(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Knowledge == nil {
+		jsonResponse(w, map[string]interface{}{"enabled": false, "facts": []interface{}{}})
+		return
+	}
+
+	typeFilter := r.URL.Query().Get("type")
+	facts := s.deps.Knowledge.SearchAll(s.deps.Ctx, "", typeFilter, 0)
+	jsonResponse(w, map[string]interface{}{
+		"enabled": true,
+		"count":   len(facts),
+		"facts":   facts,
+	})
+}
+
+func (s *Server) handleKnowledgeSearch(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Knowledge == nil {
+		jsonResponse(w, map[string]interface{}{"results": []interface{}{}})
+		return
+	}
+
+	query := r.URL.Query().Get("q")
+	if query == "" {
+		jsonError(w, "q parameter is required", http.StatusBadRequest)
+		return
+	}
+
+	typeFilter := r.URL.Query().Get("type")
+	limitStr := r.URL.Query().Get("limit")
+	limit := 0
+	if limitStr != "" {
+		limit, _ = strconv.Atoi(limitStr)
+	}
+
+	results := s.deps.Knowledge.SearchAll(s.deps.Ctx, query, typeFilter, limit)
+	jsonResponse(w, map[string]interface{}{
+		"query":   query,
+		"count":   len(results),
+		"results": results,
+	})
+}
+
+func (s *Server) handleKnowledgeHealth(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Knowledge == nil {
+		jsonResponse(w, map[string]interface{}{"enabled": false})
+		return
+	}
+	jsonResponse(w, s.deps.Knowledge.Health(s.deps.Ctx))
+}
+
+func (s *Server) handleKnowledgeStats(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Knowledge == nil {
+		jsonResponse(w, map[string]interface{}{"enabled": false})
+		return
+	}
+	jsonResponse(w, s.deps.Knowledge.Stats(s.deps.Ctx))
+}
+
+func (s *Server) handleKnowledgeLayer(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Knowledge == nil {
+		jsonResponse(w, map[string]interface{}{"enabled": false, "facts": []interface{}{}})
+		return
+	}
+
+	layer := r.PathValue("layer")
+	typeFilter := r.URL.Query().Get("type")
+
+	knowledgeLayer := knowledge.LayerType(layer)
+	facts := s.deps.Knowledge.LayerFacts(s.deps.Ctx, knowledgeLayer, typeFilter)
+	if facts == nil {
+		facts = []knowledge.Fact{}
+	}
+	jsonResponse(w, map[string]interface{}{
+		"layer": layer,
+		"count": len(facts),
+		"facts": facts,
+	})
+}
+
+func (s *Server) handleKnowledgeFact(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Knowledge == nil {
+		jsonError(w, "knowledge not enabled", http.StatusNotFound)
+		return
+	}
+
+	slug := r.PathValue("slug")
+	fact, err := s.deps.Knowledge.ReadFact(s.deps.Ctx, slug)
+	if err != nil || fact == nil {
+		jsonError(w, "fact not found", http.StatusNotFound)
+		return
+	}
+	jsonResponse(w, fact)
 }
 
 // --- Chat endpoint ---

--- a/v2/pkg/dashboard/deps.go
+++ b/v2/pkg/dashboard/deps.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/config"
 	"github.com/kubestellar/hive/v2/pkg/governor"
 	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+	"github.com/kubestellar/hive/v2/pkg/knowledge"
 	"github.com/kubestellar/hive/v2/pkg/tokens"
 )
 
@@ -17,6 +18,7 @@ type Dependencies struct {
 	Governor    *governor.Governor
 	GHClient    *ghpkg.Client
 	Tokens      *tokens.Collector
+	Knowledge   *knowledge.KnowledgeAPI
 	Nous        *NousState
 	Logger      *slog.Logger
 	Ctx         context.Context

--- a/v2/pkg/knowledge/api.go
+++ b/v2/pkg/knowledge/api.go
@@ -1,0 +1,168 @@
+package knowledge
+
+import (
+	"context"
+	"log/slog"
+)
+
+// KnowledgeAPI provides a unified interface for dashboard endpoints to query
+// across all configured wiki layers.
+type KnowledgeAPI struct {
+	layers []layerClient
+	config KnowledgeConfig
+	logger *slog.Logger
+}
+
+// NewKnowledgeAPI creates a dashboard-facing API from the full knowledge config.
+func NewKnowledgeAPI(layers []LayerConfig, config KnowledgeConfig, logger *slog.Logger) *KnowledgeAPI {
+	var clients []layerClient
+	for _, l := range layers {
+		endpoint := l.Endpoint()
+		if endpoint == "" {
+			continue
+		}
+		clients = append(clients, layerClient{
+			layerType: l.Type,
+			client:    NewClient(endpoint, logger),
+		})
+	}
+
+	return &KnowledgeAPI{
+		layers: clients,
+		config: config,
+		logger: logger,
+	}
+}
+
+// LayerStatus describes the health of a single wiki layer.
+type LayerStatus struct {
+	Type    LayerType `json:"type"`
+	URL     string    `json:"url"`
+	Healthy bool      `json:"healthy"`
+	Pages   int       `json:"pages,omitempty"`
+}
+
+// SearchAll queries all reachable layers and returns tagged results.
+func (k *KnowledgeAPI) SearchAll(ctx context.Context, query string, typeFilter string, limit int) []Fact {
+	var all []Fact
+	for _, lc := range k.layers {
+		results, err := lc.client.Search(ctx, query, typeFilter, limit)
+		if err != nil {
+			k.logger.Warn("knowledge search failed", "layer", lc.layerType, "error", err)
+			continue
+		}
+		for _, r := range results {
+			all = append(all, Fact{
+				Slug:       r.Slug,
+				Title:      r.Title,
+				Type:       FactType(r.Type),
+				Body:       r.Snippet,
+				Confidence: r.Confidence,
+				Status:     r.Status,
+				Tags:       r.Tags,
+				Layer:      lc.layerType,
+			})
+		}
+	}
+	return all
+}
+
+// LayerFacts returns facts from a specific layer.
+func (k *KnowledgeAPI) LayerFacts(ctx context.Context, layer LayerType, typeFilter string) []Fact {
+	for _, lc := range k.layers {
+		if lc.layerType != layer {
+			continue
+		}
+		results, err := lc.client.ListPages(ctx, typeFilter)
+		if err != nil {
+			k.logger.Warn("layer list failed", "layer", layer, "error", err)
+			return nil
+		}
+		facts := make([]Fact, len(results))
+		for i, r := range results {
+			facts[i] = Fact{
+				Slug:       r.Slug,
+				Title:      r.Title,
+				Type:       FactType(r.Type),
+				Body:       r.Snippet,
+				Confidence: r.Confidence,
+				Status:     r.Status,
+				Tags:       r.Tags,
+				Layer:      layer,
+			}
+		}
+		return facts
+	}
+	return nil
+}
+
+// ReadFact returns a single fact from the first layer that has it.
+func (k *KnowledgeAPI) ReadFact(ctx context.Context, slug string) (*Fact, error) {
+	for _, lc := range k.layers {
+		page, err := lc.client.ReadPage(ctx, slug)
+		if err != nil {
+			continue
+		}
+		return &Fact{
+			Slug:       page.Slug,
+			Title:      page.Title,
+			Type:       FactType(page.Type),
+			Body:       page.Body,
+			Confidence: page.Confidence,
+			Status:     page.Status,
+			Tags:       page.Tags,
+			Layer:      lc.layerType,
+		}, nil
+	}
+	return nil, nil
+}
+
+// Health checks all configured layers and returns their status.
+func (k *KnowledgeAPI) Health(ctx context.Context) []LayerStatus {
+	statuses := make([]LayerStatus, len(k.layers))
+	for i, lc := range k.layers {
+		statuses[i] = LayerStatus{
+			Type:    lc.layerType,
+			URL:     lc.client.baseURL,
+			Healthy: lc.client.Healthy(ctx),
+		}
+		if statuses[i].Healthy {
+			stats, err := lc.client.Stats(ctx)
+			if err == nil {
+				statuses[i].Pages = stats.TotalPages
+			}
+		}
+	}
+	return statuses
+}
+
+// Stats returns aggregate stats across all layers.
+func (k *KnowledgeAPI) Stats(ctx context.Context) map[string]interface{} {
+	result := map[string]interface{}{
+		"enabled":      k.config.Enabled,
+		"engine":       k.config.Engine,
+		"layers_count": len(k.layers),
+	}
+
+	layerStats := make([]map[string]interface{}, 0, len(k.layers))
+	for _, lc := range k.layers {
+		ls := map[string]interface{}{
+			"type":    lc.layerType,
+			"url":     lc.client.baseURL,
+			"healthy": false,
+		}
+		stats, err := lc.client.Stats(ctx)
+		if err == nil {
+			ls["healthy"] = true
+			ls["total_pages"] = stats.TotalPages
+			ls["by_type"] = stats.ByType
+			ls["by_status"] = stats.ByStatus
+			ls["stale"] = stats.Stale
+			ls["orphaned"] = stats.Orphaned
+		}
+		layerStats = append(layerStats, ls)
+	}
+	result["layers"] = layerStats
+
+	return result
+}

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -8,10 +9,12 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/classify"
 	"github.com/kubestellar/hive/v2/pkg/config"
 	"github.com/kubestellar/hive/v2/pkg/github"
+	"github.com/kubestellar/hive/v2/pkg/knowledge"
 )
 
 type Scheduler struct {
 	cfg    *config.Config
+	primer *knowledge.Primer
 	logger *slog.Logger
 }
 
@@ -20,6 +23,12 @@ func New(cfg *config.Config, logger *slog.Logger) *Scheduler {
 		cfg:    cfg,
 		logger: logger,
 	}
+}
+
+// SetPrimer attaches a knowledge primer to the scheduler. When set, kick
+// messages include relevant facts from the wiki layers.
+func (s *Scheduler) SetPrimer(p *knowledge.Primer) {
+	s.primer = p
 }
 
 type KickMessage struct {
@@ -126,6 +135,11 @@ func (s *Scheduler) buildScannerMessage(issues []github.Issue, actionable *githu
 		b.WriteString(fmt.Sprintf("\n⚠️ %d SLA VIOLATIONS (>30 min)\n", actionable.Issues.SLAViolations))
 	}
 
+	if knowledgeSection := s.primeKnowledge(scannerIssues); knowledgeSection != "" {
+		b.WriteString("\n")
+		b.WriteString(knowledgeSection)
+	}
+
 	b.WriteString("\n⛔ NEVER run gh issue list, gh pr list, gh search issues — the work list above is your ONLY source.\n")
 	b.WriteString("⛔ MERGE DISCIPLINE: Only merge PRs listed in MERGE-READY section. Never merge a PR you created this session.\n")
 	b.WriteString("WORKFLOW: Dispatch sub-agents for each issue (Agent tool). 4-6 agents IN PARALLEL.\n")
@@ -164,6 +178,11 @@ func (s *Scheduler) buildGenericMessage(agentName string, issues []github.Issue,
 		}
 	}
 
+	if knowledgeSection := s.primeKnowledge(agentIssues); knowledgeSection != "" {
+		b.WriteString("\n")
+		b.WriteString(knowledgeSection)
+	}
+
 	return b.String()
 }
 
@@ -175,4 +194,68 @@ func filterByLane(issues []github.Issue, lane string) []github.Issue {
 		}
 	}
 	return result
+}
+
+const maxIssuesToPrime = 5
+
+// primeKnowledge queries the wiki layers for facts relevant to the given issues
+// and returns a formatted section for injection into the kick message.
+func (s *Scheduler) primeKnowledge(issues []github.Issue) string {
+	if s.primer == nil || len(issues) == 0 {
+		return ""
+	}
+
+	limit := maxIssuesToPrime
+	if len(issues) < limit {
+		limit = len(issues)
+	}
+
+	keywords := extractKeywords(issues[:limit])
+	if len(keywords) == 0 {
+		return ""
+	}
+
+	primed := s.primer.Prime(context.Background(), nil, keywords)
+	return primed.FormatForPrompt()
+}
+
+// extractKeywords pulls searchable terms from issue labels and titles.
+func extractKeywords(issues []github.Issue) []string {
+	seen := make(map[string]bool)
+	var keywords []string
+
+	for _, issue := range issues {
+		for _, label := range issue.Labels {
+			lower := strings.ToLower(label)
+			if !seen[lower] && !isNoiseLabel(lower) {
+				keywords = append(keywords, lower)
+				seen[lower] = true
+			}
+		}
+
+		if issue.ComplexityTier != "" {
+			tier := strings.ToLower(issue.ComplexityTier)
+			if !seen[tier] {
+				keywords = append(keywords, tier)
+				seen[tier] = true
+			}
+		}
+	}
+
+	return keywords
+}
+
+var noiseLabels = map[string]bool{
+	"triage/accepted":   true,
+	"ai-fix-requested":  true,
+	"kind/bug":          true,
+	"kind/feature":      true,
+	"kind/task":         true,
+	"good first issue":  true,
+	"help wanted":       true,
+	"hold":              true,
+}
+
+func isNoiseLabel(label string) bool {
+	return noiseLabels[label]
 }

--- a/v2/pkg/scheduler/scheduler_test.go
+++ b/v2/pkg/scheduler/scheduler_test.go
@@ -1,13 +1,17 @@
 package scheduler
 
 import (
+	"encoding/json"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
 	"github.com/kubestellar/hive/v2/pkg/github"
+	"github.com/kubestellar/hive/v2/pkg/knowledge"
 )
 
 // ---------------------------------------------------------------------------
@@ -934,5 +938,224 @@ func TestBuildReposSection_BareRepoGetsPrefixed(t *testing.T) {
 	}
 	if !strings.Contains(section, "my-org/full-repo") {
 		t.Errorf("full repo should appear as-is: %q", section)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Knowledge primer wiring
+// ---------------------------------------------------------------------------
+
+func TestExtractKeywords_FromLabels(t *testing.T) {
+	issues := []github.Issue{
+		makeIssue("org/repo", 1, "Test", "", 5, []string{"typescript", "react", "kind/bug"}, false),
+	}
+	kw := extractKeywords(issues)
+	found := map[string]bool{}
+	for _, k := range kw {
+		found[k] = true
+	}
+	if !found["typescript"] {
+		t.Error("expected typescript keyword")
+	}
+	if !found["react"] {
+		t.Error("expected react keyword")
+	}
+	if found["kind/bug"] {
+		t.Error("kind/bug should be filtered as noise label")
+	}
+}
+
+func TestExtractKeywords_Dedup(t *testing.T) {
+	issues := []github.Issue{
+		makeIssue("org/repo", 1, "A", "", 5, []string{"react"}, false),
+		makeIssue("org/repo", 2, "B", "", 5, []string{"react"}, false),
+	}
+	kw := extractKeywords(issues)
+	count := 0
+	for _, k := range kw {
+		if k == "react" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 'react', got %d", count)
+	}
+}
+
+func TestExtractKeywords_IncludesTier(t *testing.T) {
+	issues := []github.Issue{
+		{Repo: "org/repo", Number: 1, ComplexityTier: "Complex"},
+	}
+	kw := extractKeywords(issues)
+	found := false
+	for _, k := range kw {
+		if k == "complex" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected 'complex' from ComplexityTier, got %v", kw)
+	}
+}
+
+func TestExtractKeywords_EmptyIssues(t *testing.T) {
+	kw := extractKeywords(nil)
+	if len(kw) != 0 {
+		t.Errorf("expected 0 keywords, got %d", len(kw))
+	}
+}
+
+func TestIsNoiseLabel(t *testing.T) {
+	if !isNoiseLabel("kind/bug") {
+		t.Error("kind/bug should be noise")
+	}
+	if !isNoiseLabel("triage/accepted") {
+		t.Error("triage/accepted should be noise")
+	}
+	if isNoiseLabel("typescript") {
+		t.Error("typescript should not be noise")
+	}
+}
+
+func TestPrimeKnowledge_NilPrimer(t *testing.T) {
+	s := newScheduler()
+	issues := []github.Issue{
+		makeIssue("org/repo", 1, "test", "", 5, []string{"react"}, false),
+	}
+	result := s.primeKnowledge(issues)
+	if result != "" {
+		t.Errorf("expected empty result with nil primer, got: %s", result)
+	}
+}
+
+func TestPrimeKnowledge_EmptyIssues(t *testing.T) {
+	s := newScheduler()
+	result := s.primeKnowledge(nil)
+	if result != "" {
+		t.Errorf("expected empty result with nil issues, got: %s", result)
+	}
+}
+
+func TestPrimeKnowledge_WithMockWiki(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := struct {
+			Total   int `json:"total"`
+			Results []struct {
+				Slug       string   `json:"slug"`
+				Title      string   `json:"title"`
+				Score      float64  `json:"score"`
+				Type       string   `json:"type"`
+				Status     string   `json:"status"`
+				Confidence float64  `json:"confidence"`
+				Tags       []string `json:"tags"`
+				Snippet    string   `json:"snippet"`
+			} `json:"results"`
+		}{
+			Total: 1,
+			Results: []struct {
+				Slug       string   `json:"slug"`
+				Title      string   `json:"title"`
+				Score      float64  `json:"score"`
+				Type       string   `json:"type"`
+				Status     string   `json:"status"`
+				Confidence float64  `json:"confidence"`
+				Tags       []string `json:"tags"`
+				Snippet    string   `json:"snippet"`
+			}{
+				{
+					Slug:       "guard-join",
+					Title:      "Guard .join() against undefined",
+					Score:      0.95,
+					Type:       "gotcha",
+					Status:     "verified",
+					Confidence: 0.95,
+					Tags:       []string{"typescript"},
+					Snippet:    "Always use (arr || []).join()",
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	layers := []knowledge.LayerConfig{
+		{Type: knowledge.LayerProject, URL: srv.URL, Shared: true},
+	}
+	primerCfg := knowledge.PrimerConfig{
+		MaxFacts: 25,
+		Priority: []string{"regression", "gotcha", "pattern"},
+	}
+	primer := knowledge.NewPrimer(layers, primerCfg, logger)
+
+	s := newScheduler()
+	s.SetPrimer(primer)
+
+	issues := []github.Issue{
+		makeIssue("org/repo", 1, "Fix hook crash", "", 5, []string{"typescript", "hooks"}, false),
+	}
+
+	result := s.primeKnowledge(issues)
+	if result == "" {
+		t.Fatal("expected non-empty knowledge section")
+	}
+	if !strings.Contains(result, "Guard .join()") {
+		t.Errorf("expected knowledge section to contain fact title, got:\n%s", result)
+	}
+	if !strings.Contains(result, "Relevant Knowledge") {
+		t.Errorf("expected knowledge section header, got:\n%s", result)
+	}
+}
+
+func TestScannerMessage_IncludesKnowledgeWhenPrimerSet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := struct {
+			Total   int `json:"total"`
+			Results []struct {
+				Slug       string   `json:"slug"`
+				Title      string   `json:"title"`
+				Score      float64  `json:"score"`
+				Type       string   `json:"type"`
+				Confidence float64  `json:"confidence"`
+				Snippet    string   `json:"snippet"`
+			} `json:"results"`
+		}{
+			Total: 1,
+			Results: []struct {
+				Slug       string   `json:"slug"`
+				Title      string   `json:"title"`
+				Score      float64  `json:"score"`
+				Type       string   `json:"type"`
+				Confidence float64  `json:"confidence"`
+				Snippet    string   `json:"snippet"`
+			}{
+				{Slug: "test-fact", Title: "Test fact", Type: "pattern", Confidence: 0.9, Snippet: "Use test factories"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	layers := []knowledge.LayerConfig{
+		{Type: knowledge.LayerProject, URL: srv.URL, Shared: true},
+	}
+	primer := knowledge.NewPrimer(layers, knowledge.PrimerConfig{MaxFacts: 25}, logger)
+
+	s := newScheduler()
+	s.SetPrimer(primer)
+
+	issues := []github.Issue{
+		makeIssue("org/repo", 1, "Fix tests", "scanner", 5, []string{"testing"}, false),
+	}
+	msg := s.buildScannerMessage(issues, emptyActionable())
+
+	if !strings.Contains(msg, "Relevant Knowledge") {
+		t.Errorf("expected Relevant Knowledge section in scanner message:\n%s", msg)
+	}
+	if !strings.Contains(msg, "Test fact") {
+		t.Errorf("expected fact title in scanner message:\n%s", msg)
 	}
 }


### PR DESCRIPTION
## Summary

- Wires the knowledge primer into the scheduler's kick preparation flow — agents now receive relevant wiki facts alongside their work orders
- Adds 6 knowledge API endpoints to the dashboard for browsing/searching wiki layers
- Initializes primer at startup from `hive.yaml` knowledge config
- Keywords extracted from issue labels and complexity tier; noise labels (kind/bug, triage/accepted, etc.) filtered out
- Graceful degradation: nil primer or unreachable wiki layers produce no knowledge section (no errors)

### Files changed

| File | What |
|------|------|
| `cmd/hive/main.go` | Primer + KnowledgeAPI init from config, layer type conversion |
| `pkg/scheduler/scheduler.go` | `SetPrimer()`, `primeKnowledge()`, `extractKeywords()`, noise label filter |
| `pkg/scheduler/scheduler_test.go` | 9 new tests for keyword extraction, priming, and integration |
| `pkg/knowledge/api.go` | `KnowledgeAPI` — unified dashboard interface (search, list, health, stats) |
| `pkg/dashboard/api.go` | 6 new `/api/knowledge/*` endpoints |
| `pkg/dashboard/deps.go` | `Knowledge *knowledge.KnowledgeAPI` field |

Part of the layered knowledge system ([design doc](https://github.com/kubestellar/hive/blob/v2/v2/docs/design/knowledge-system.md), Phase 1 wiring).

## Test plan

- [x] All scheduler tests pass (80+ existing + 9 new)
- [x] All knowledge package tests pass (23 tests)
- [x] All dashboard tests pass
- [x] Full `go build ./...` compiles clean
- [ ] CI passes (pre-existing `manager_test.go` failure is unrelated)