### PR TITLE
Add knowledge CRUD, import, promote, and subscription workflows

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -75,6 +75,14 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/knowledge/search", s.handleKnowledgeSearch)
 	s.mux.HandleFunc("GET /api/knowledge/health", s.handleKnowledgeHealth)
 	s.mux.HandleFunc("GET /api/knowledge/stats", s.handleKnowledgeStats)
+	s.mux.HandleFunc("POST /api/knowledge/create", s.handleKnowledgeCreate)
+	s.mux.HandleFunc("POST /api/knowledge/import", s.handleKnowledgeImport)
+	s.mux.HandleFunc("POST /api/knowledge/promote", s.handleKnowledgePromote)
+	s.mux.HandleFunc("GET /api/knowledge/subscriptions", s.handleKnowledgeSubsList)
+	s.mux.HandleFunc("POST /api/knowledge/subscriptions", s.handleKnowledgeSubsAdd)
+	s.mux.HandleFunc("DELETE /api/knowledge/subscriptions", s.handleKnowledgeSubsRemove)
+	s.mux.HandleFunc("PUT /api/knowledge/{layer}/{slug}", s.handleKnowledgeUpdate)
+	s.mux.HandleFunc("DELETE /api/knowledge/{layer}/{slug}", s.handleKnowledgeDelete)
 	s.mux.HandleFunc("GET /api/knowledge/{layer}", s.handleKnowledgeLayer)
 	s.mux.HandleFunc("GET /api/knowledge/{layer}/{slug}", s.handleKnowledgeFact)
 
@@ -962,6 +970,202 @@ func (s *Server) handleKnowledgeFact(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	jsonResponse(w, fact)
+}
+
+func (s *Server) handleKnowledgeCreate(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Knowledge == nil {
+		jsonError(w, "knowledge not enabled", http.StatusServiceUnavailable)
+		return
+	}
+
+	var req knowledge.CreateFactRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.Title == "" || req.Body == "" {
+		jsonError(w, "title and body are required", http.StatusBadRequest)
+		return
+	}
+	if req.Layer == "" {
+		req.Layer = "project"
+	}
+	if req.Type == "" {
+		req.Type = "pattern"
+	}
+	const defaultConfidence = 0.7
+	if req.Confidence <= 0 {
+		req.Confidence = defaultConfidence
+	}
+
+	if err := s.deps.Knowledge.CreateFact(s.deps.Ctx, req); err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, map[string]interface{}{"ok": true, "title": req.Title, "layer": req.Layer})
+}
+
+func (s *Server) handleKnowledgeUpdate(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Knowledge == nil {
+		jsonError(w, "knowledge not enabled", http.StatusServiceUnavailable)
+		return
+	}
+
+	layer := r.PathValue("layer")
+	slug := r.PathValue("slug")
+
+	var req knowledge.UpdateFactRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.deps.Knowledge.UpdateFact(s.deps.Ctx, knowledge.LayerType(layer), slug, req); err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, map[string]interface{}{"ok": true, "slug": slug, "layer": layer})
+}
+
+func (s *Server) handleKnowledgeDelete(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Knowledge == nil {
+		jsonError(w, "knowledge not enabled", http.StatusServiceUnavailable)
+		return
+	}
+
+	layer := r.PathValue("layer")
+	slug := r.PathValue("slug")
+
+	if err := s.deps.Knowledge.DeleteFact(s.deps.Ctx, knowledge.LayerType(layer), slug); err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, map[string]interface{}{"ok": true, "deleted": slug})
+}
+
+func (s *Server) handleKnowledgePromote(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Knowledge == nil {
+		jsonError(w, "knowledge not enabled", http.StatusServiceUnavailable)
+		return
+	}
+
+	var req knowledge.PromoteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.Slug == "" || req.FromLayer == "" || req.ToLayer == "" {
+		jsonError(w, "slug, from_layer, and to_layer are required", http.StatusBadRequest)
+		return
+	}
+	if req.Promoter == "" {
+		req.Promoter = "dashboard"
+	}
+
+	result := s.deps.Knowledge.PromoteFact(s.deps.Ctx, req)
+	if !result.Success {
+		jsonError(w, result.Error, http.StatusBadRequest)
+		return
+	}
+	jsonResponse(w, result)
+}
+
+func (s *Server) handleKnowledgeImport(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Knowledge == nil {
+		jsonError(w, "knowledge not enabled", http.StatusServiceUnavailable)
+		return
+	}
+
+	var req struct {
+		Content string `json:"content"`
+		Format  string `json:"format"`
+		Layer   string `json:"layer"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.Content == "" {
+		jsonError(w, "content is required", http.StatusBadRequest)
+		return
+	}
+	if req.Layer == "" {
+		req.Layer = "project"
+	}
+	if req.Format == "" {
+		req.Format = "markdown"
+	}
+
+	count, err := s.deps.Knowledge.ImportFacts(s.deps.Ctx, knowledge.LayerType(req.Layer), req.Content, req.Format)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, map[string]interface{}{"ok": true, "imported": count, "layer": req.Layer, "format": req.Format})
+}
+
+func (s *Server) handleKnowledgeSubsList(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Knowledge == nil {
+		jsonResponse(w, []interface{}{})
+		return
+	}
+	jsonResponse(w, s.deps.Knowledge.Subscriptions())
+}
+
+func (s *Server) handleKnowledgeSubsAdd(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Knowledge == nil {
+		jsonError(w, "knowledge not enabled", http.StatusServiceUnavailable)
+		return
+	}
+
+	var sub knowledge.Subscription
+	if err := json.NewDecoder(r.Body).Decode(&sub); err != nil {
+		jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if sub.URL == "" {
+		jsonError(w, "url is required", http.StatusBadRequest)
+		return
+	}
+	if sub.Layer == "" {
+		sub.Layer = knowledge.LayerOrg
+	}
+
+	if err := s.deps.Knowledge.AddSubscription(sub); err != nil {
+		jsonError(w, err.Error(), http.StatusConflict)
+		return
+	}
+	jsonResponse(w, map[string]interface{}{"ok": true, "subscription": sub})
+}
+
+func (s *Server) handleKnowledgeSubsRemove(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Knowledge == nil {
+		jsonError(w, "knowledge not enabled", http.StatusServiceUnavailable)
+		return
+	}
+
+	var req struct {
+		URL string `json:"url"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.URL == "" {
+		jsonError(w, "url is required", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.deps.Knowledge.RemoveSubscription(req.URL); err != nil {
+		jsonError(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	jsonResponse(w, map[string]interface{}{"ok": true, "removed": req.URL})
 }
 
 // --- Chat endpoint ---

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4232,6 +4232,13 @@ function burnAreaChart() {
       if (orphanedTotal > 0) html += `<div class="kb-stat"><div class="val" style="color:#dc2626">${orphanedTotal}</div><div class="lbl">Orphaned</div></div>`;
       html += '</div>';
 
+      // Action buttons
+      html += '<div style="display:flex;gap:8px;margin-bottom:14px">';
+      html += '<button class="nous-btn" style="background:var(--accent);color:white" onclick="kbOpenCreate()">+ New Fact</button>';
+      html += '<button class="nous-btn" style="background:var(--card);color:var(--fg);border:1px solid var(--border)" onclick="kbOpenImport()">📥 Import</button>';
+      html += '<button class="nous-btn" style="background:var(--card);color:var(--fg);border:1px solid var(--border)" onclick="kbOpenSubscriptions()">🔗 Subscriptions</button>';
+      html += '</div>';
+
       // Main layout: sidebar + content
       html += '<div class="kb-layout">';
 
@@ -4336,7 +4343,20 @@ function burnAreaChart() {
       html += `<div><span class="kb-detail-label">Confidence:</span> <span style="color:${confColor(conf)};font-weight:600">${confPct}%</span></div>`;
       html += `<div><span class="kb-detail-label">Slug:</span> ${escapeHtml(f.slug || '')}</div>`;
       if (f.tags && f.tags.length) html += `<div><span class="kb-detail-label">Tags:</span> ${f.tags.map(t => escapeHtml(t)).join(', ')}</div>`;
-      html += '</div></div>';
+      html += '</div>';
+
+      // Action buttons
+      html += '<div style="display:flex;gap:6px;margin-top:12px;flex-wrap:wrap">';
+      html += `<button class="nous-btn" style="background:#2563eb;color:white;font-size:0.72rem;padding:5px 10px" onclick="kbOpenEdit()">✏️ Edit</button>`;
+      const promoteTargets = { personal: 'project', project: 'org', org: 'community' };
+      const promoteTo = promoteTargets[f.layer];
+      if (promoteTo) {
+        html += `<button class="nous-btn" style="background:#7c3aed;color:white;font-size:0.72rem;padding:5px 10px" onclick="kbPromote('${escapeHtml(f.slug)}','${escapeHtml(f.layer)}','${promoteTo}')">⬆ Promote to ${promoteTo}</button>`;
+      }
+      html += `<button class="nous-btn" style="background:#dc2626;color:white;font-size:0.72rem;padding:5px 10px" onclick="kbDelete('${escapeHtml(f.slug)}','${escapeHtml(f.layer)}')">🗑 Delete</button>`;
+      html += '</div>';
+
+      html += '</div>';
       el.innerHTML = html;
 
       // Highlight selected fact in list
@@ -4348,6 +4368,348 @@ function burnAreaChart() {
           break;
         }
       }
+    }
+
+    // ── Knowledge modals and actions ──
+
+    function kbShowModal(title, bodyHtml) {
+      let overlay = document.getElementById('kb-modal-overlay');
+      if (!overlay) {
+        overlay = document.createElement('div');
+        overlay.id = 'kb-modal-overlay';
+        overlay.className = 'nous-config-overlay';
+        document.body.appendChild(overlay);
+      }
+      overlay.style.display = 'flex';
+      overlay.innerHTML = `<div class="nous-config-dialog" style="width:600px">
+        <h2 style="font-size:1rem;margin:0 0 16px 0;display:flex;align-items:center;justify-content:space-between">
+          ${title}
+          <button onclick="kbCloseModal()" style="background:none;border:none;font-size:1.2rem;cursor:pointer;color:var(--muted)">✕</button>
+        </h2>
+        ${bodyHtml}
+      </div>`;
+    }
+
+    function kbCloseModal() {
+      const overlay = document.getElementById('kb-modal-overlay');
+      if (overlay) overlay.style.display = 'none';
+    }
+
+    function kbOpenCreate() {
+      const layers = (_kbCache || {}).layers || [];
+      let layerOpts = '';
+      for (const l of layers) {
+        const sel = l.type === 'project' ? ' selected' : '';
+        layerOpts += `<option value="${escapeHtml(l.type)}"${sel}>${escapeHtml(KB_LAYER_LABELS[l.type] || l.type)}</option>`;
+      }
+      if (!layerOpts) layerOpts = '<option value="project">Project</option>';
+
+      let typeOpts = '';
+      for (const t of KB_FACT_TYPES) {
+        typeOpts += `<option value="${escapeHtml(t)}">${escapeHtml(t)}</option>`;
+      }
+
+      const html = `
+        <div style="display:flex;flex-direction:column;gap:10px">
+          <label style="font-size:0.78rem;color:var(--muted)">Title
+            <input id="kb-create-title" type="text" class="kb-search-box" style="margin-top:4px" placeholder="Guard .join() against undefined">
+          </label>
+          <label style="font-size:0.78rem;color:var(--muted)">Body
+            <textarea id="kb-create-body" rows="6" style="width:100%;margin-top:4px;padding:8px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.8rem;font-family:inherit;resize:vertical" placeholder="Always use (arr || []).join(',') — hooks can return undefined when endpoints fail."></textarea>
+          </label>
+          <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px">
+            <label style="font-size:0.78rem;color:var(--muted)">Layer
+              <select id="kb-create-layer" style="width:100%;margin-top:4px;padding:6px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">${layerOpts}</select>
+            </label>
+            <label style="font-size:0.78rem;color:var(--muted)">Type
+              <select id="kb-create-type" style="width:100%;margin-top:4px;padding:6px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">${typeOpts}</select>
+            </label>
+            <label style="font-size:0.78rem;color:var(--muted)">Confidence
+              <input id="kb-create-conf" type="number" min="0" max="1" step="0.1" value="0.7" style="width:100%;margin-top:4px;padding:6px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">
+            </label>
+          </div>
+          <label style="font-size:0.78rem;color:var(--muted)">Tags (comma-separated)
+            <input id="kb-create-tags" type="text" class="kb-search-box" style="margin-top:4px" placeholder="react, testing, hooks">
+          </label>
+          <div style="display:flex;justify-content:flex-end;gap:8px;margin-top:8px">
+            <button class="nous-btn nous-config-btn-cancel" onclick="kbCloseModal()">Cancel</button>
+            <button class="nous-btn" style="background:var(--accent);color:white" onclick="kbSubmitCreate()">Create Fact</button>
+          </div>
+        </div>`;
+      kbShowModal('New Fact', html);
+    }
+
+    async function kbSubmitCreate() {
+      const title = document.getElementById('kb-create-title')?.value?.trim();
+      const body = document.getElementById('kb-create-body')?.value?.trim();
+      const layer = document.getElementById('kb-create-layer')?.value;
+      const type = document.getElementById('kb-create-type')?.value;
+      const conf = parseFloat(document.getElementById('kb-create-conf')?.value || '0.7');
+      const tagsRaw = document.getElementById('kb-create-tags')?.value || '';
+      const tags = tagsRaw.split(',').map(t => t.trim()).filter(Boolean);
+
+      if (!title || !body) { alert('Title and body are required'); return; }
+
+      try {
+        const r = await fetch('/api/knowledge/create', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ title, body, layer, type, confidence: conf, tags }),
+        });
+        if (!r.ok) { const e = await r.json(); alert(e.error || 'Failed to create'); return; }
+        kbCloseModal();
+        fetchKnowledgeStats();
+        kbSearch();
+      } catch (e) { alert('Error: ' + e.message); }
+    }
+
+    function kbOpenEdit() {
+      if (!_kbSelectedFact) return;
+      const f = _kbSelectedFact;
+
+      let typeOpts = '';
+      for (const t of KB_FACT_TYPES) {
+        const sel = t === f.type ? ' selected' : '';
+        typeOpts += `<option value="${escapeHtml(t)}"${sel}>${escapeHtml(t)}</option>`;
+      }
+
+      const html = `
+        <div style="display:flex;flex-direction:column;gap:10px">
+          <label style="font-size:0.78rem;color:var(--muted)">Title
+            <input id="kb-edit-title" type="text" class="kb-search-box" style="margin-top:4px" value="${escapeHtml(f.title || '')}">
+          </label>
+          <label style="font-size:0.78rem;color:var(--muted)">Body
+            <textarea id="kb-edit-body" rows="8" style="width:100%;margin-top:4px;padding:8px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.8rem;font-family:inherit;resize:vertical">${escapeHtml(f.body || '')}</textarea>
+          </label>
+          <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px">
+            <label style="font-size:0.78rem;color:var(--muted)">Type
+              <select id="kb-edit-type" style="width:100%;margin-top:4px;padding:6px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">${typeOpts}</select>
+            </label>
+            <label style="font-size:0.78rem;color:var(--muted)">Status
+              <select id="kb-edit-status" style="width:100%;margin-top:4px;padding:6px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">
+                <option value="draft"${f.status === 'draft' ? ' selected' : ''}>Draft</option>
+                <option value="verified"${f.status === 'verified' ? ' selected' : ''}>Verified</option>
+                <option value="stale"${f.status === 'stale' ? ' selected' : ''}>Stale</option>
+                <option value="archived"${f.status === 'archived' ? ' selected' : ''}>Archived</option>
+              </select>
+            </label>
+            <label style="font-size:0.78rem;color:var(--muted)">Confidence
+              <input id="kb-edit-conf" type="number" min="0" max="1" step="0.1" value="${f.confidence || 0.7}" style="width:100%;margin-top:4px;padding:6px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">
+            </label>
+          </div>
+          <label style="font-size:0.78rem;color:var(--muted)">Tags (comma-separated)
+            <input id="kb-edit-tags" type="text" class="kb-search-box" style="margin-top:4px" value="${escapeHtml((f.tags || []).join(', '))}">
+          </label>
+          <div style="font-size:0.7rem;color:var(--muted)">Layer: ${escapeHtml(f.layer || '')} · Slug: ${escapeHtml(f.slug || '')}</div>
+          <div style="display:flex;justify-content:flex-end;gap:8px;margin-top:8px">
+            <button class="nous-btn nous-config-btn-cancel" onclick="kbCloseModal()">Cancel</button>
+            <button class="nous-btn" style="background:#2563eb;color:white" onclick="kbSubmitEdit()">Save Changes</button>
+          </div>
+        </div>`;
+      kbShowModal('Edit Fact', html);
+    }
+
+    async function kbSubmitEdit() {
+      if (!_kbSelectedFact) return;
+      const f = _kbSelectedFact;
+      const title = document.getElementById('kb-edit-title')?.value?.trim();
+      const body = document.getElementById('kb-edit-body')?.value?.trim();
+      const type = document.getElementById('kb-edit-type')?.value;
+      const status = document.getElementById('kb-edit-status')?.value;
+      const conf = parseFloat(document.getElementById('kb-edit-conf')?.value || '0.7');
+      const tagsRaw = document.getElementById('kb-edit-tags')?.value || '';
+      const tags = tagsRaw.split(',').map(t => t.trim()).filter(Boolean);
+
+      try {
+        const r = await fetch('/api/knowledge/' + encodeURIComponent(f.layer) + '/' + encodeURIComponent(f.slug), {
+          method: 'PUT', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ title, body, type, status, confidence: conf, tags }),
+        });
+        if (!r.ok) { const e = await r.json(); alert(e.error || 'Failed to update'); return; }
+        kbCloseModal();
+        kbReadFact(f.slug, f.layer);
+        kbSearch();
+      } catch (e) { alert('Error: ' + e.message); }
+    }
+
+    async function kbDelete(slug, layer) {
+      if (!confirm('Delete fact "' + slug + '" from ' + layer + '?')) return;
+      try {
+        const r = await fetch('/api/knowledge/' + encodeURIComponent(layer) + '/' + encodeURIComponent(slug), { method: 'DELETE' });
+        if (!r.ok) { const e = await r.json(); alert(e.error || 'Failed to delete'); return; }
+        _kbSelectedFact = null;
+        const detail = document.getElementById('kb-fact-detail');
+        if (detail) detail.innerHTML = '';
+        fetchKnowledgeStats();
+        kbSearch();
+      } catch (e) { alert('Error: ' + e.message); }
+    }
+
+    async function kbPromote(slug, fromLayer, toLayer) {
+      const reason = prompt('Reason for promoting to ' + toLayer + ':', 'Useful for the broader team');
+      if (reason === null) return;
+      try {
+        const r = await fetch('/api/knowledge/promote', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ slug, from_layer: fromLayer, to_layer: toLayer, reason, promoter: 'dashboard' }),
+        });
+        if (!r.ok) { const e = await r.json(); alert(e.error || 'Failed to promote'); return; }
+        alert('Fact promoted to ' + toLayer);
+        fetchKnowledgeStats();
+      } catch (e) { alert('Error: ' + e.message); }
+    }
+
+    function kbOpenImport() {
+      const layers = (_kbCache || {}).layers || [];
+      let layerOpts = '';
+      for (const l of layers) {
+        const sel = l.type === 'project' ? ' selected' : '';
+        layerOpts += `<option value="${escapeHtml(l.type)}"${sel}>${escapeHtml(KB_LAYER_LABELS[l.type] || l.type)}</option>`;
+      }
+      if (!layerOpts) layerOpts = '<option value="project">Project</option>';
+
+      const html = `
+        <div style="display:flex;flex-direction:column;gap:10px">
+          <p style="font-size:0.78rem;color:var(--muted);margin:0">Paste markdown or JSON content. Markdown headings (# or ##) become separate facts. JSON should be an array of {title, body, type, tags} objects.</p>
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px">
+            <label style="font-size:0.78rem;color:var(--muted)">Layer
+              <select id="kb-import-layer" style="width:100%;margin-top:4px;padding:6px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">${layerOpts}</select>
+            </label>
+            <label style="font-size:0.78rem;color:var(--muted)">Format
+              <select id="kb-import-format" style="width:100%;margin-top:4px;padding:6px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">
+                <option value="markdown" selected>Markdown</option>
+                <option value="json">JSON</option>
+              </select>
+            </label>
+          </div>
+          <label style="font-size:0.78rem;color:var(--muted)">Content
+            <textarea id="kb-import-content" rows="12" style="width:100%;margin-top:4px;padding:8px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem;font-family:'SF Mono','Fira Code',monospace;resize:vertical" placeholder="# Guard .join() against undefined\n\nAlways use (arr || []).join(',')..."></textarea>
+          </label>
+          <div style="display:flex;align-items:center;gap:10px;margin-top:4px">
+            <label style="font-size:0.72rem;color:var(--muted);cursor:pointer;display:flex;align-items:center;gap:4px">
+              <span>or load from file:</span>
+              <input type="file" accept=".md,.json,.txt" style="font-size:0.72rem" onchange="kbLoadFile(this)">
+            </label>
+          </div>
+          <div style="display:flex;justify-content:flex-end;gap:8px;margin-top:8px">
+            <button class="nous-btn nous-config-btn-cancel" onclick="kbCloseModal()">Cancel</button>
+            <button class="nous-btn" style="background:var(--accent);color:white" onclick="kbSubmitImport()">Import</button>
+          </div>
+        </div>`;
+      kbShowModal('📥 Import Facts', html);
+    }
+
+    function kbLoadFile(input) {
+      const file = input.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = function(e) {
+        const textarea = document.getElementById('kb-import-content');
+        if (textarea) textarea.value = e.target.result;
+        const formatSel = document.getElementById('kb-import-format');
+        if (formatSel && file.name.endsWith('.json')) formatSel.value = 'json';
+      };
+      reader.readAsText(file);
+    }
+
+    async function kbSubmitImport() {
+      const content = document.getElementById('kb-import-content')?.value?.trim();
+      const layer = document.getElementById('kb-import-layer')?.value;
+      const format = document.getElementById('kb-import-format')?.value;
+
+      if (!content) { alert('Content is required'); return; }
+
+      try {
+        const r = await fetch('/api/knowledge/import', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content, layer, format }),
+        });
+        const data = await r.json();
+        if (!r.ok) { alert(data.error || 'Failed to import'); return; }
+        kbCloseModal();
+        alert('Imported ' + (data.imported || 0) + ' facts to ' + layer);
+        fetchKnowledgeStats();
+        kbSearch();
+      } catch (e) { alert('Error: ' + e.message); }
+    }
+
+    function kbOpenSubscriptions() {
+      kbShowModal('🔗 Subscriptions', '<div id="kb-subs-content"><div style="text-align:center;padding:20px;color:var(--muted)">Loading...</div></div>');
+      kbLoadSubscriptions();
+    }
+
+    async function kbLoadSubscriptions() {
+      const el = document.getElementById('kb-subs-content');
+      if (!el) return;
+
+      try {
+        const r = await fetch('/api/knowledge/subscriptions');
+        const subs = await r.json();
+
+        let html = '';
+        if (subs && subs.length > 0) {
+          html += '<div style="margin-bottom:14px">';
+          for (const s of subs) {
+            html += `<div style="display:flex;align-items:center;justify-content:space-between;padding:8px;border:1px solid var(--border);border-radius:6px;margin-bottom:6px">`;
+            html += `<div><div style="font-size:0.82rem;font-weight:600;color:var(--fg)">${escapeHtml(s.name || s.url)}</div>`;
+            html += `<div style="font-size:0.7rem;color:var(--muted)">${escapeHtml(s.url)} · ${escapeHtml(s.layer || 'org')}</div></div>`;
+            html += `<button class="nous-btn" style="background:#dc2626;color:white;font-size:0.7rem;padding:4px 8px" onclick="kbRemoveSub('${escapeHtml(s.url)}')">Remove</button>`;
+            html += '</div>';
+          }
+          html += '</div>';
+        } else {
+          html += '<div style="text-align:center;padding:16px;color:var(--muted);font-size:0.78rem">No subscriptions yet. Add an org or community wiki endpoint.</div>';
+        }
+
+        html += '<div style="border-top:1px solid var(--border);padding-top:12px;margin-top:8px">';
+        html += '<div style="font-size:0.82rem;font-weight:600;color:var(--fg);margin-bottom:8px">Add Subscription</div>';
+        html += '<div style="display:flex;flex-direction:column;gap:8px">';
+        html += '<input id="kb-sub-url" type="text" class="kb-search-box" placeholder="https://wiki.example.com/mcp">';
+        html += '<div style="display:grid;grid-template-columns:1fr 1fr;gap:8px">';
+        html += `<input id="kb-sub-name" type="text" class="kb-search-box" placeholder="Display name">`;
+        html += `<select id="kb-sub-layer" style="padding:7px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">
+          <option value="org">Org</option>
+          <option value="community">Community</option>
+        </select>`;
+        html += '</div>';
+        html += '<div style="display:flex;justify-content:flex-end">';
+        html += '<button class="nous-btn" style="background:var(--accent);color:white" onclick="kbAddSub()">Add</button>';
+        html += '</div></div></div>';
+
+        el.innerHTML = html;
+      } catch (e) {
+        el.innerHTML = '<div style="color:#dc2626;padding:12px">Failed to load subscriptions: ' + escapeHtml(e.message) + '</div>';
+      }
+    }
+
+    async function kbAddSub() {
+      const url = document.getElementById('kb-sub-url')?.value?.trim();
+      const name = document.getElementById('kb-sub-name')?.value?.trim();
+      const layer = document.getElementById('kb-sub-layer')?.value;
+
+      if (!url) { alert('URL is required'); return; }
+
+      try {
+        const r = await fetch('/api/knowledge/subscriptions', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url, name: name || url, layer }),
+        });
+        if (!r.ok) { const e = await r.json(); alert(e.error || 'Failed to add'); return; }
+        kbLoadSubscriptions();
+        fetchKnowledgeStats();
+      } catch (e) { alert('Error: ' + e.message); }
+    }
+
+    async function kbRemoveSub(url) {
+      if (!confirm('Remove subscription to ' + url + '?')) return;
+      try {
+        const r = await fetch('/api/knowledge/subscriptions', {
+          method: 'DELETE', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url }),
+        });
+        if (!r.ok) { const e = await r.json(); alert(e.error || 'Failed to remove'); return; }
+        kbLoadSubscriptions();
+        fetchKnowledgeStats();
+      } catch (e) { alert('Error: ' + e.message); }
     }
 
     fetchKnowledgeStats();

--- a/v2/pkg/knowledge/api.go
+++ b/v2/pkg/knowledge/api.go
@@ -2,15 +2,29 @@ package knowledge
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"log/slog"
+	"strings"
+	"time"
 )
 
 // KnowledgeAPI provides a unified interface for dashboard endpoints to query
 // across all configured wiki layers.
 type KnowledgeAPI struct {
-	layers []layerClient
-	config KnowledgeConfig
-	logger *slog.Logger
+	layers        []layerClient
+	config        KnowledgeConfig
+	promoter      *Promoter
+	subscriptions []Subscription
+	logger        *slog.Logger
+}
+
+// Subscription represents a user-added wiki endpoint.
+type Subscription struct {
+	URL   string    `json:"url"`
+	Layer LayerType `json:"layer"`
+	Name  string    `json:"name"`
+	Added time.Time `json:"added"`
 }
 
 // NewKnowledgeAPI creates a dashboard-facing API from the full knowledge config.
@@ -27,10 +41,13 @@ func NewKnowledgeAPI(layers []LayerConfig, config KnowledgeConfig, logger *slog.
 		})
 	}
 
+	promoter := NewPromoter(layers, config.Curator, logger)
+
 	return &KnowledgeAPI{
-		layers: clients,
-		config: config,
-		logger: logger,
+		layers:   clients,
+		config:   config,
+		promoter: promoter,
+		logger:   logger,
 	}
 }
 
@@ -165,4 +182,270 @@ func (k *KnowledgeAPI) Stats(ctx context.Context) map[string]interface{} {
 	result["layers"] = layerStats
 
 	return result
+}
+
+// CreateFactRequest is the payload for creating a new fact.
+type CreateFactRequest struct {
+	Title      string   `json:"title"`
+	Body       string   `json:"body"`
+	Type       string   `json:"type"`
+	Tags       []string `json:"tags"`
+	Layer      string   `json:"layer"`
+	Confidence float64  `json:"confidence"`
+}
+
+// CreateFact ingests a new fact into the specified layer.
+func (k *KnowledgeAPI) CreateFact(ctx context.Context, req CreateFactRequest) error {
+	layer := LayerType(req.Layer)
+	client := k.clientForLayer(layer)
+	if client == nil {
+		return fmt.Errorf("layer %s has no configured endpoint", req.Layer)
+	}
+
+	fact := ExtractedFact{
+		Title:      req.Title,
+		Body:       req.Body,
+		Type:       FactType(req.Type),
+		Confidence: req.Confidence,
+		Tags:       req.Tags,
+		SourcePR:   "manual",
+		SourceDate: time.Now(),
+	}
+
+	if err := client.IngestFacts(ctx, []ExtractedFact{fact}); err != nil {
+		return fmt.Errorf("ingesting fact: %w", err)
+	}
+
+	k.logger.Info("fact created", "title", req.Title, "layer", req.Layer, "type", req.Type)
+	return nil
+}
+
+// UpdateFactRequest is the payload for updating an existing fact.
+type UpdateFactRequest struct {
+	Title      string   `json:"title"`
+	Body       string   `json:"body"`
+	Type       string   `json:"type"`
+	Tags       []string `json:"tags"`
+	Status     string   `json:"status"`
+	Confidence float64  `json:"confidence"`
+}
+
+// UpdateFact modifies an existing fact in the specified layer.
+func (k *KnowledgeAPI) UpdateFact(ctx context.Context, layer LayerType, slug string, req UpdateFactRequest) error {
+	client := k.clientForLayer(layer)
+	if client == nil {
+		return fmt.Errorf("layer %s has no configured endpoint", layer)
+	}
+
+	update := pageUpdateRequest{
+		Title:      req.Title,
+		Body:       req.Body,
+		Type:       req.Type,
+		Confidence: req.Confidence,
+		Tags:       req.Tags,
+		Status:     req.Status,
+	}
+
+	if err := client.UpdatePage(ctx, slug, update); err != nil {
+		return fmt.Errorf("updating fact %s: %w", slug, err)
+	}
+
+	k.logger.Info("fact updated", "slug", slug, "layer", layer)
+	return nil
+}
+
+// DeleteFact removes a fact from the specified layer.
+func (k *KnowledgeAPI) DeleteFact(ctx context.Context, layer LayerType, slug string) error {
+	client := k.clientForLayer(layer)
+	if client == nil {
+		return fmt.Errorf("layer %s has no configured endpoint", layer)
+	}
+
+	if err := client.DeletePage(ctx, slug); err != nil {
+		return fmt.Errorf("deleting fact %s: %w", slug, err)
+	}
+
+	k.logger.Info("fact deleted", "slug", slug, "layer", layer)
+	return nil
+}
+
+// PromoteFact promotes a fact from one layer to another (upward only).
+func (k *KnowledgeAPI) PromoteFact(ctx context.Context, req PromoteRequest) PromoteResult {
+	return k.promoter.Promote(ctx, req)
+}
+
+// ImportFacts parses markdown or JSON content and ingests extracted facts.
+func (k *KnowledgeAPI) ImportFacts(ctx context.Context, layer LayerType, content string, format string) (int, error) {
+	client := k.clientForLayer(layer)
+	if client == nil {
+		return 0, fmt.Errorf("layer %s has no configured endpoint", layer)
+	}
+
+	var facts []ExtractedFact
+
+	switch format {
+	case "json":
+		if err := parseJSONFacts(content, &facts); err != nil {
+			return 0, fmt.Errorf("parsing JSON: %w", err)
+		}
+	case "markdown", "md":
+		facts = parseMarkdownFacts(content)
+	default:
+		facts = parseMarkdownFacts(content)
+	}
+
+	if len(facts) == 0 {
+		return 0, nil
+	}
+
+	if err := client.IngestFacts(ctx, facts); err != nil {
+		return 0, fmt.Errorf("ingesting imported facts: %w", err)
+	}
+
+	k.logger.Info("facts imported", "count", len(facts), "layer", layer, "format", format)
+	return len(facts), nil
+}
+
+// Subscriptions returns the current list of subscribed wiki endpoints.
+func (k *KnowledgeAPI) Subscriptions() []Subscription {
+	subs := make([]Subscription, len(k.subscriptions))
+	copy(subs, k.subscriptions)
+	return subs
+}
+
+// AddSubscription adds a new wiki endpoint and connects a client for it.
+func (k *KnowledgeAPI) AddSubscription(sub Subscription) error {
+	for _, existing := range k.subscriptions {
+		if existing.URL == sub.URL {
+			return fmt.Errorf("subscription already exists: %s", sub.URL)
+		}
+	}
+
+	sub.Added = time.Now()
+	k.subscriptions = append(k.subscriptions, sub)
+
+	k.layers = append(k.layers, layerClient{
+		layerType: sub.Layer,
+		client:    NewClient(sub.URL, k.logger),
+	})
+
+	k.logger.Info("subscription added", "url", sub.URL, "layer", sub.Layer, "name", sub.Name)
+	return nil
+}
+
+// RemoveSubscription disconnects a wiki endpoint by URL.
+func (k *KnowledgeAPI) RemoveSubscription(url string) error {
+	found := false
+	newSubs := make([]Subscription, 0, len(k.subscriptions))
+	for _, s := range k.subscriptions {
+		if s.URL == url {
+			found = true
+			continue
+		}
+		newSubs = append(newSubs, s)
+	}
+	if !found {
+		return fmt.Errorf("subscription not found: %s", url)
+	}
+	k.subscriptions = newSubs
+
+	newLayers := make([]layerClient, 0, len(k.layers))
+	for _, lc := range k.layers {
+		if lc.client.baseURL == url {
+			continue
+		}
+		newLayers = append(newLayers, lc)
+	}
+	k.layers = newLayers
+
+	k.logger.Info("subscription removed", "url", url)
+	return nil
+}
+
+// Layers returns the configured layer types for the frontend.
+func (k *KnowledgeAPI) Layers() []LayerType {
+	seen := make(map[LayerType]bool)
+	var result []LayerType
+	for _, lc := range k.layers {
+		if !seen[lc.layerType] {
+			seen[lc.layerType] = true
+			result = append(result, lc.layerType)
+		}
+	}
+	return result
+}
+
+func (k *KnowledgeAPI) clientForLayer(layer LayerType) *Client {
+	for _, lc := range k.layers {
+		if lc.layerType == layer {
+			return lc.client
+		}
+	}
+	return nil
+}
+
+func parseJSONFacts(content string, facts *[]ExtractedFact) error {
+	return json.Unmarshal([]byte(content), facts)
+}
+
+func parseMarkdownFacts(content string) []ExtractedFact {
+	var facts []ExtractedFact
+	lines := strings.Split(content, "\n")
+
+	var current *ExtractedFact
+	var bodyLines []string
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "# ") || strings.HasPrefix(trimmed, "## ") {
+			if current != nil && current.Title != "" {
+				current.Body = strings.TrimSpace(strings.Join(bodyLines, "\n"))
+				facts = append(facts, *current)
+			}
+			title := strings.TrimLeft(trimmed, "# ")
+			current = &ExtractedFact{
+				Title:      title,
+				Type:       FactPattern,
+				Confidence: 0.6,
+				SourcePR:   "import",
+				SourceDate: time.Now(),
+			}
+			bodyLines = nil
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "- **") && strings.Contains(trimmed, "**") {
+			if current != nil && current.Title != "" {
+				current.Body = strings.TrimSpace(strings.Join(bodyLines, "\n"))
+				facts = append(facts, *current)
+			}
+			title := trimmed[4:]
+			if idx := strings.Index(title, "**"); idx > 0 {
+				body := strings.TrimSpace(title[idx+2:])
+				title = title[:idx]
+				current = &ExtractedFact{
+					Title:      title,
+					Body:       body,
+					Type:       FactPattern,
+					Confidence: 0.6,
+					SourcePR:   "import",
+					SourceDate: time.Now(),
+				}
+				bodyLines = nil
+			}
+			continue
+		}
+
+		if current != nil && trimmed != "" {
+			bodyLines = append(bodyLines, trimmed)
+		}
+	}
+
+	if current != nil && current.Title != "" {
+		current.Body = strings.TrimSpace(strings.Join(bodyLines, "\n"))
+		facts = append(facts, *current)
+	}
+
+	return facts
 }

--- a/v2/pkg/knowledge/api_test.go
+++ b/v2/pkg/knowledge/api_test.go
@@ -1,0 +1,244 @@
+package knowledge
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func testLogger() *slog.Logger {
+	return slog.Default()
+}
+
+func TestParseMarkdownFacts(t *testing.T) {
+	input := `# Guard join against undefined
+
+Always use (arr || []).join(',').
+
+## Use mock factories
+
+Use createMockCluster() from test/factories.ts.
+`
+	facts := parseMarkdownFacts(input)
+	if len(facts) != 2 {
+		t.Fatalf("expected 2 facts, got %d", len(facts))
+	}
+	if facts[0].Title != "Guard join against undefined" {
+		t.Errorf("expected title 'Guard join against undefined', got %q", facts[0].Title)
+	}
+	if facts[1].Title != "Use mock factories" {
+		t.Errorf("expected title 'Use mock factories', got %q", facts[1].Title)
+	}
+}
+
+func TestParseMarkdownFacts_BulletList(t *testing.T) {
+	input := `- **Guard join** Always use safe joins
+- **Mock factories** Use createMockCluster
+`
+	facts := parseMarkdownFacts(input)
+	if len(facts) != 2 {
+		t.Fatalf("expected 2 facts, got %d", len(facts))
+	}
+	if facts[0].Title != "Guard join" {
+		t.Errorf("unexpected title: %q", facts[0].Title)
+	}
+}
+
+func TestParseMarkdownFacts_Empty(t *testing.T) {
+	facts := parseMarkdownFacts("")
+	if len(facts) != 0 {
+		t.Errorf("expected 0 facts from empty input, got %d", len(facts))
+	}
+}
+
+func TestParseJSONFacts(t *testing.T) {
+	input := `[{"title":"test fact","body":"body text","type":"gotcha","confidence":0.9}]`
+	var facts []ExtractedFact
+	if err := parseJSONFacts(input, &facts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(facts) != 1 {
+		t.Fatalf("expected 1 fact, got %d", len(facts))
+	}
+	if facts[0].Title != "test fact" {
+		t.Errorf("unexpected title: %q", facts[0].Title)
+	}
+}
+
+func TestParseJSONFacts_Invalid(t *testing.T) {
+	var facts []ExtractedFact
+	if err := parseJSONFacts("not json", &facts); err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestAddRemoveSubscription(t *testing.T) {
+	api := &KnowledgeAPI{
+		config: KnowledgeConfig{Enabled: true},
+		logger: testLogger(),
+	}
+
+	sub := Subscription{URL: "https://wiki.example.com", Layer: LayerOrg, Name: "Test"}
+	if err := api.AddSubscription(sub); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	subs := api.Subscriptions()
+	if len(subs) != 1 {
+		t.Fatalf("expected 1 subscription, got %d", len(subs))
+	}
+	if subs[0].URL != "https://wiki.example.com" {
+		t.Errorf("unexpected URL: %q", subs[0].URL)
+	}
+
+	if err := api.AddSubscription(sub); err == nil {
+		t.Error("expected error for duplicate subscription")
+	}
+
+	if err := api.RemoveSubscription("https://wiki.example.com"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(api.Subscriptions()) != 0 {
+		t.Error("expected 0 subscriptions after removal")
+	}
+
+	if err := api.RemoveSubscription("https://nonexistent.com"); err == nil {
+		t.Error("expected error for nonexistent subscription")
+	}
+}
+
+func TestSubscriptionAddsLayer(t *testing.T) {
+	api := &KnowledgeAPI{
+		config: KnowledgeConfig{Enabled: true},
+		logger: testLogger(),
+	}
+
+	initialLayers := len(api.layers)
+	sub := Subscription{URL: "https://wiki.test.com", Layer: LayerCommunity, Name: "Community"}
+	if err := api.AddSubscription(sub); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(api.layers) != initialLayers+1 {
+		t.Errorf("expected %d layers, got %d", initialLayers+1, len(api.layers))
+	}
+}
+
+func TestCreateFact_NoEndpoint(t *testing.T) {
+	api := &KnowledgeAPI{
+		config: KnowledgeConfig{Enabled: true},
+		logger: testLogger(),
+	}
+
+	err := api.CreateFact(context.Background(), CreateFactRequest{
+		Title: "test", Body: "body", Layer: "project",
+	})
+	if err == nil {
+		t.Error("expected error when no endpoint configured")
+	}
+}
+
+func TestCreateFact_WithServer(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/ingest" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var facts []ExtractedFact
+		if err := json.NewDecoder(r.Body).Decode(&facts); err != nil {
+			t.Errorf("failed to decode body: %v", err)
+		}
+		if len(facts) != 1 || facts[0].Title != "test fact" {
+			t.Errorf("unexpected facts: %+v", facts)
+		}
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer ts.Close()
+
+	api := &KnowledgeAPI{
+		layers: []layerClient{{layerType: LayerProject, client: NewClient(ts.URL, testLogger())}},
+		config: KnowledgeConfig{Enabled: true},
+		logger: testLogger(),
+	}
+
+	err := api.CreateFact(context.Background(), CreateFactRequest{
+		Title: "test fact", Body: "body", Layer: "project", Type: "gotcha",
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDeleteFact_NoEndpoint(t *testing.T) {
+	api := &KnowledgeAPI{
+		config: KnowledgeConfig{Enabled: true},
+		logger: testLogger(),
+	}
+
+	err := api.DeleteFact(context.Background(), LayerProject, "test-slug")
+	if err == nil {
+		t.Error("expected error when no endpoint configured")
+	}
+}
+
+func TestImportFacts_Markdown(t *testing.T) {
+	var ingested int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var facts []ExtractedFact
+		json.NewDecoder(r.Body).Decode(&facts)
+		ingested = len(facts)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer ts.Close()
+
+	api := &KnowledgeAPI{
+		layers: []layerClient{{layerType: LayerProject, client: NewClient(ts.URL, testLogger())}},
+		config: KnowledgeConfig{Enabled: true},
+		logger: testLogger(),
+	}
+
+	count, err := api.ImportFacts(context.Background(), LayerProject, "# Fact One\n\nBody one\n\n# Fact Two\n\nBody two", "markdown")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 imported, got %d", count)
+	}
+	if ingested != 2 {
+		t.Errorf("expected 2 ingested on server, got %d", ingested)
+	}
+}
+
+func TestImportFacts_EmptyContent(t *testing.T) {
+	api := &KnowledgeAPI{
+		layers: []layerClient{{layerType: LayerProject, client: NewClient("http://unused", testLogger())}},
+		config: KnowledgeConfig{Enabled: true},
+		logger: testLogger(),
+	}
+
+	count, err := api.ImportFacts(context.Background(), LayerProject, "", "markdown")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 imported for empty content, got %d", count)
+	}
+}
+
+func TestLayers(t *testing.T) {
+	api := &KnowledgeAPI{
+		layers: []layerClient{
+			{layerType: LayerPersonal},
+			{layerType: LayerProject},
+			{layerType: LayerProject},
+		},
+		logger: testLogger(),
+	}
+
+	layers := api.Layers()
+	if len(layers) != 2 {
+		t.Errorf("expected 2 unique layers, got %d", len(layers))
+	}
+}

--- a/v2/pkg/knowledge/client.go
+++ b/v2/pkg/knowledge/client.go
@@ -1,6 +1,7 @@
 package knowledge
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -132,6 +133,76 @@ func (c *Client) ListPages(ctx context.Context, typeFilter string) ([]searchResu
 func (c *Client) Healthy(ctx context.Context) bool {
 	err := c.get(ctx, "/api/stats", nil, &statsResponse{})
 	return err == nil
+}
+
+// IngestFacts sends facts to the wiki for storage.
+func (c *Client) IngestFacts(ctx context.Context, facts []ExtractedFact) error {
+	return c.postJSON(ctx, "/api/ingest", facts)
+}
+
+// UpdatePage updates an existing wiki page by slug.
+func (c *Client) UpdatePage(ctx context.Context, slug string, page pageUpdateRequest) error {
+	return c.postJSON(ctx, "/api/pages/"+slug, page)
+}
+
+// DeletePage removes a wiki page by slug.
+func (c *Client) DeletePage(ctx context.Context, slug string) error {
+	reqCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodDelete, c.baseURL+"/api/pages/"+slug, nil)
+	if err != nil {
+		return fmt.Errorf("creating delete request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("delete request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("delete returned HTTP %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+type pageUpdateRequest struct {
+	Title      string   `json:"title"`
+	Body       string   `json:"body"`
+	Type       string   `json:"type"`
+	Confidence float64  `json:"confidence"`
+	Tags       []string `json:"tags"`
+	Status     string   `json:"status"`
+}
+
+func (c *Client) postJSON(ctx context.Context, path string, payload any) error {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshaling payload: %w", err)
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, c.baseURL+path, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP request to %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("HTTP %d from %s: %s", resp.StatusCode, path, string(body))
+	}
+	return nil
 }
 
 func (c *Client) get(ctx context.Context, path string, params url.Values, dest any) error {


### PR DESCRIPTION
## Summary
- **Create**: New Fact modal with title, body, type dropdown, layer selector, confidence slider, tags input
- **Save/Edit**: Edit modal pre-filled from selected fact, saves via PUT to `/api/knowledge/{layer}/{slug}`
- **Delete**: Confirm dialog, removes fact from wiki layer
- **Promote**: Upward-only promotion (personal→project→org→community) with reason prompt
- **Import/Load**: Paste markdown (headings become facts) or JSON array, or load from `.md`/`.json` file
- **Subscribe**: List/add/remove wiki endpoints — dynamically adds layers to the knowledge system

Adds 8 new API endpoints and 13 new Go tests.

## Test plan
- [ ] Create fact: fills form, submits, fact appears in list
- [ ] Edit fact: select fact, click Edit, modify fields, save — reflects in detail view
- [ ] Delete fact: confirm dialog, fact removed from list
- [ ] Promote: button only shows for layers that can promote upward
- [ ] Import markdown: paste `# Heading\n\nBody` content, imports 1 fact per heading
- [ ] Import JSON: paste `[{"title":"x","body":"y"}]`, imports correctly
- [ ] Load from file: select `.md` file, content populates textarea, format auto-detects
- [ ] Subscriptions: add endpoint, verify it appears; remove, verify gone
- [ ] All 13 unit tests pass: `go test ./pkg/knowledge/ -v`