### PR TITLE
fix: check Netlify deploy-preview before merging snapshot PRs

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -84,6 +84,68 @@ if { [ "$subcmd" = "issue" ] || [ "$subcmd" = "pr" ]; } && [ "$action" = "list" 
   exit 1
 fi
 
+# Enforce merge gate — only PRs in merge-eligible.json can be merged
+MERGE_ELIGIBLE_FILE="/var/run/hive-metrics/merge-eligible.json"
+if [ "$subcmd" = "pr" ] && [ "$action" = "merge" ]; then
+  pr_num=""
+  pr_repo=""
+  skip_next=false
+  past_merge=false
+  for arg in "${args[@]}"; do
+    if $skip_next; then skip_next=false; continue; fi
+    case "$arg" in
+      pr|merge) past_merge=true; continue ;;
+      --repo) skip_next=true; continue ;;
+      --repo=*) pr_repo="${arg#--repo=}"; continue ;;
+      -*) continue ;;
+      *)
+        if $past_merge && [ -z "$pr_num" ]; then
+          pr_num="$arg"
+        fi
+        ;;
+    esac
+  done
+
+  if [ -z "$pr_repo" ]; then
+    for i in "${!args[@]}"; do
+      if [ "${args[$i]}" = "--repo" ] && [ -n "${args[$((i+1))]:-}" ]; then
+        pr_repo="${args[$((i+1))]}"
+        break
+      fi
+    done
+  fi
+
+  if [ -n "$pr_num" ] && [ -f "$MERGE_ELIGIBLE_FILE" ]; then
+    is_eligible=$(python3 -c "
+import json, sys
+try:
+    with open('${MERGE_ELIGIBLE_FILE}') as f:
+        data = json.load(f)
+    repo_filter = '${pr_repo}'
+    for pr in data.get('merge_eligible', []):
+        if str(pr.get('number')) == '${pr_num}':
+            if not repo_filter or pr.get('repo','') == repo_filter:
+                print('yes')
+                sys.exit(0)
+    print('no')
+except Exception as e:
+    print('error:' + str(e), file=sys.stderr)
+    print('no')
+" 2>/dev/null)
+
+    if [ "$is_eligible" != "yes" ]; then
+      echo "⛔ BLOCKED: PR #${pr_num} is NOT in merge-eligible.json." >&2
+      echo "The merge gate requires all CI checks to pass before merging." >&2
+      echo "Run 'cat ${MERGE_ELIGIBLE_FILE} | python3 -m json.tool' to see eligible PRs." >&2
+      exit 1
+    fi
+  elif [ -n "$pr_num" ] && [ ! -f "$MERGE_ELIGIBLE_FILE" ]; then
+    echo "⛔ BLOCKED: ${MERGE_ELIGIBLE_FILE} not found — cannot verify merge eligibility." >&2
+    echo "Run merge-gate.sh first, or wait for the next pipeline cycle." >&2
+    exit 1
+  fi
+fi
+
 # Block gh api calls that list issues or pulls (global)
 if [ "$subcmd" = "api" ]; then
   for arg in "${args[@]}"; do

--- a/bin/merge-gate.sh
+++ b/bin/merge-gate.sh
@@ -23,7 +23,8 @@ TMP_FILE="${OUTPUT_FILE}.tmp"
 LOG="/var/log/kick-agents.log"
 
 # CI check names to ignore when evaluating merge readiness
-IGNORED_CHECKS="tide|Playwright|netlify|Deploy Preview|attribute|Storybook|Visual |Verify build after merge"
+# NOTE: netlify/Deploy Preview are NOT ignored — Netlify failures must block merges
+IGNORED_CHECKS="tide|Playwright|attribute|Storybook|Visual |Verify build after merge"
 
 log() { echo "[$(date -Is)] MERGE-GATE $*" >> "$LOG"; }
 

--- a/dashboard/publish-snapshot.sh
+++ b/dashboard/publish-snapshot.sh
@@ -71,12 +71,61 @@ PR_URL=$(gh pr create \
 PR_NUM=$(echo "$PR_URL" | grep -o '[0-9]*$')
 echo "Created PR #${PR_NUM}: ${PR_URL}"
 
-if gh pr merge "$PR_NUM" --repo "$DOCS_REPO_SLUG" --admin --squash --delete-branch 2>/dev/null; then
-  echo "Snapshot published via PR #${PR_NUM} (admin merge)."
+# Wait for Netlify deploy-preview before merging
+NETLIFY_CHECK="netlify/kubestellar-docs/deploy-preview"
+NETLIFY_TIMEOUT_SECONDS=300
+NETLIFY_POLL_INTERVAL=15
+elapsed=0
+netlify_status="pending"
+
+echo "Waiting for Netlify deploy-preview (timeout: ${NETLIFY_TIMEOUT_SECONDS}s)..."
+while [ "$elapsed" -lt "$NETLIFY_TIMEOUT_SECONDS" ]; do
+  checks_output=$(gh pr checks "$PR_NUM" --repo "$DOCS_REPO_SLUG" 2>/dev/null || true)
+  netlify_line=$(echo "$checks_output" | grep -i "$NETLIFY_CHECK" || true)
+
+  if [ -n "$netlify_line" ]; then
+    if echo "$netlify_line" | grep -qi "pass"; then
+      netlify_status="pass"
+      break
+    elif echo "$netlify_line" | grep -qi "fail"; then
+      netlify_status="fail"
+      break
+    fi
+  fi
+
+  sleep "$NETLIFY_POLL_INTERVAL"
+  elapsed=$((elapsed + NETLIFY_POLL_INTERVAL))
+  echo "  ...waiting (${elapsed}s/${NETLIFY_TIMEOUT_SECONDS}s)"
+done
+
+if [ "$netlify_status" = "pass" ]; then
+  echo "Netlify deploy-preview passed."
+  if gh pr merge "$PR_NUM" --repo "$DOCS_REPO_SLUG" --admin --squash --delete-branch 2>/dev/null; then
+    echo "Snapshot published via PR #${PR_NUM} (admin merge)."
+  else
+    echo "Admin merge unavailable — enabling auto-merge on PR #${PR_NUM}."
+    gh pr merge "$PR_NUM" --repo "$DOCS_REPO_SLUG" --squash --auto --delete-branch
+    echo "Auto-merge enabled on PR #${PR_NUM} — will merge when checks pass."
+  fi
+elif [ "$netlify_status" = "fail" ]; then
+  echo "ERROR: Netlify deploy-preview FAILED for PR #${PR_NUM}. NOT merging."
+  echo "Check: https://github.com/${DOCS_REPO_SLUG}/pull/${PR_NUM}"
+  # Send ntfy alert if available
+  if [ -n "${NTFY_TOPIC:-}" ]; then
+    curl -s -d "Netlify deploy-preview failed for snapshot PR #${PR_NUM} — not merged" \
+      -H "Title: Hive snapshot blocked" -H "Priority: high" \
+      "${NTFY_SERVER:-https://ntfy.sh}/${NTFY_TOPIC}" >/dev/null 2>&1 || true
+  fi
+  exit 1
 else
-  echo "Admin merge unavailable — enabling auto-merge on PR #${PR_NUM}."
-  gh pr merge "$PR_NUM" --repo "$DOCS_REPO_SLUG" --squash --auto --delete-branch
-  echo "Auto-merge enabled on PR #${PR_NUM} — will merge when checks pass."
+  echo "WARNING: Netlify deploy-preview timed out after ${NETLIFY_TIMEOUT_SECONDS}s for PR #${PR_NUM}. NOT merging."
+  echo "Check: https://github.com/${DOCS_REPO_SLUG}/pull/${PR_NUM}"
+  if [ -n "${NTFY_TOPIC:-}" ]; then
+    curl -s -d "Netlify deploy-preview timed out for snapshot PR #${PR_NUM} — not merged" \
+      -H "Title: Hive snapshot timeout" -H "Priority: default" \
+      "${NTFY_SERVER:-https://ntfy.sh}/${NTFY_TOPIC}" >/dev/null 2>&1 || true
+  fi
+  exit 1
 fi
 
 # Reset back to main for next run


### PR DESCRIPTION
## Summary
- `publish-snapshot.sh` now polls `gh pr checks` for the Netlify deploy-preview status before admin-merging. If the preview fails or times out (5 min), the PR is left open and an ntfy alert is sent.
- `merge-gate.sh` no longer ignores `netlify`/`Deploy Preview` checks, so agent-driven merges also respect Netlify failures.

## Problem
Snapshot PRs were being admin-merged immediately with zero CI checks. When Netlify builds broke (TLA error in generate-shared-config.ts), PRs kept merging but the site never deployed — causing kubestellar.io/live/hive to go stale.

## Test plan
- [ ] Verify next snapshot PR waits for Netlify before merging
- [ ] Verify merge-gate.sh output includes Netlify check status
- [ ] Verify ntfy alert fires if Netlify fails