### PR TITLE
fix: prevent masked secrets from overwriting real values in container dashboard

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1411,14 +1411,19 @@ func (s *Server) handleGovernorNotifications(w http.ResponseWriter, r *http.Requ
 		jsonError(w, "invalid body", http.StatusBadRequest)
 		return
 	}
-	if body.NtfyServer != "" || body.NtfyTopic != "" {
+	isMasked := func(v string) bool { return strings.HasPrefix(v, "•") }
+	if (body.NtfyServer != "" && !isMasked(body.NtfyServer)) || (body.NtfyTopic != "" && !isMasked(body.NtfyTopic)) {
 		if s.deps.Config.Notifications.Ntfy == nil {
 			s.deps.Config.Notifications.Ntfy = &config.NtfyConfig{}
 		}
-		s.deps.Config.Notifications.Ntfy.Server = body.NtfyServer
-		s.deps.Config.Notifications.Ntfy.Topic = body.NtfyTopic
+		if body.NtfyServer != "" && !isMasked(body.NtfyServer) {
+			s.deps.Config.Notifications.Ntfy.Server = body.NtfyServer
+		}
+		if body.NtfyTopic != "" && !isMasked(body.NtfyTopic) {
+			s.deps.Config.Notifications.Ntfy.Topic = body.NtfyTopic
+		}
 	}
-	if body.DiscordWebhook != "" {
+	if body.DiscordWebhook != "" && !isMasked(body.DiscordWebhook) {
 		if s.deps.Config.Notifications.Discord == nil {
 			s.deps.Config.Notifications.Discord = &config.DiscordConfig{}
 		}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6396,18 +6396,20 @@ function burnAreaChart() {
     }
 
     function renderGovNotifications(n) {
+      const ntfyHint = n.hasNtfy ? '(configured — enter new value to change)' : '';
+      const discordHint = n.hasDiscord ? '(configured — enter new value to change)' : '';
       return `
         <div class="config-field">
-          <label>Ntfy Server <span class="config-info">i<span class="config-tooltip">URL of the ntfy.sh server for push notifications. The governor sends alerts for mode changes, budget warnings, agent crashes, and rate limits. Leave empty to disable ntfy notifications. Default: https://ntfy.sh</span></span></label>
-          <input type="text" value="${esc(n.ntfyServer || '')}" onchange="markDirty('notifications','ntfyServer',this.value)">
+          <label>Ntfy Server ${ntfyHint} <span class="config-info">i<span class="config-tooltip">URL of the ntfy.sh server for push notifications. The governor sends alerts for mode changes, budget warnings, agent crashes, and rate limits. Leave empty to disable ntfy notifications. Default: https://ntfy.sh</span></span></label>
+          <input type="text" value="" onchange="markDirty('notifications','ntfyServer',this.value)" placeholder="${esc(n.ntfyServer || 'https://ntfy.sh')}">
         </div>
         <div class="config-field">
           <label>Ntfy Topic <span class="config-info">i<span class="config-tooltip">Topic name on the ntfy server. Subscribe to this topic in the ntfy app or web UI to receive governor notifications on your phone or desktop.</span></span></label>
-          <input type="text" value="${esc(n.ntfyTopic || '')}" onchange="markDirty('notifications','ntfyTopic',this.value)">
+          <input type="text" value="" onchange="markDirty('notifications','ntfyTopic',this.value)" placeholder="${esc(n.ntfyTopic || 'my-topic')}">
         </div>
         <div class="config-field">
-          <label>Discord Webhook <span class="config-info">i<span class="config-tooltip">Discord webhook URL for posting governor notifications to a channel. Create a webhook in your Discord server settings under Integrations. Leave empty to disable Discord notifications.</span></span></label>
-          <input type="text" value="${esc(n.discordWebhook || '')}" onchange="markDirty('notifications','discordWebhook',this.value)" placeholder="https://discord.com/api/webhooks/...">
+          <label>Discord Webhook ${discordHint} <span class="config-info">i<span class="config-tooltip">Discord webhook URL for posting governor notifications to a channel. Create a webhook in your Discord server settings under Integrations. Leave empty to disable Discord notifications.</span></span></label>
+          <input type="text" value="" onchange="markDirty('notifications','discordWebhook',this.value)" placeholder="${esc(n.discordWebhook || 'https://discord.com/api/webhooks/...')}">
         </div>`;
     }
 


### PR DESCRIPTION
## Summary
Same fix as #461 but applied to the **container source files** that the Dockerfile actually copies:
- `v2/pkg/dashboard/static/index.html` — notification inputs render empty with masked values as placeholders
- `v2/pkg/dashboard/api.go` — Go backend rejects masked values (`strings.HasPrefix(v, "•")`)

PR #461 fixed `dashboard/index.html` and `dashboard/server.js` (bare-metal paths), but the container builds from `v2/proxy/` and `v2/pkg/dashboard/static/`.

## Test plan
- [ ] `docker compose build && docker compose up -d` on 4.78
- [ ] Open Governor config → Notifications → verify empty inputs with placeholder hints
- [ ] Save without changing → verify secrets preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)