### PR TITLE
fix: seed governor queue state from cache on restart

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -240,6 +240,7 @@ func main() {
 		var cached github.ActionableResult
 		if err := json.Unmarshal(data, &cached); err == nil {
 			lastActionable.Store(&cached)
+			gov.SeedQueueState(cached.Issues.Count, cached.PRs.Count, cached.Hold.Total, cached.Issues.SLAViolations)
 			refreshDashboard()
 			logger.Info("restored cached actionable data", "issues", cached.Issues.Count, "prs", cached.PRs.Count, "age", time.Since(cached.GeneratedAt).Round(time.Second))
 		}

--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -386,6 +386,15 @@ func (g *Governor) SeedModeHistory(changes []ModeChange) {
 	copy(g.modeHistory, changes)
 }
 
+func (g *Governor) SeedQueueState(issues, prs, hold, slaViolations int) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.state.QueueIssues = issues
+	g.state.QueuePRs = prs
+	g.state.QueueHold = hold
+	g.state.SLAViolations = slaViolations
+}
+
 func (g *Governor) KickHistory() []KickRecord {
 	g.mu.RLock()
 	defer g.mu.RUnlock()


### PR DESCRIPTION
## Summary
- Dashboard showed 0 for actionable issues and PRs after container restart because `BuildFrontendStatus` reads counts from the governor state (which starts zeroed), not from the actionable data
- Added `SeedQueueState()` to governor and call it after restoring cached actionable data, before the first dashboard refresh
- Root cause: `refreshDashboard()` was already called after cache restore, but the governor's queue counters were never populated from the cache

## Test plan
- [ ] Restart container, verify dashboard immediately shows cached issue/PR counts
- [ ] Verify first eval cycle updates counts to fresh values
- [ ] Verify mode timeline still displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)