### PR TITLE
fix: persist display names, default sidebar order, CLI pinned alignment

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1832,9 +1832,13 @@
       return `<a class="oc-nav-item${isActive}" data-agent-nav="${a.name}" draggable="true" onclick="ocSelectAgent('${a.name}')" title="${agentDesc}"><span class="oc-agent-dot ${dotCls}"></span> ${label}</a>`;
     }
 
+    const DEFAULT_SIDEBAR_ORDER = ['supervisor', 'sec-check', 'scanner', 'ci-maintainer', 'architect', 'tester', 'outreach'];
     function _sidebarBuildGroups(agents) {
       if (!_sidebarLayout || !_sidebarLayout.groups) {
-        return [{ name: null, agents: agents.map(a => a.name) }];
+        const knownSet = new Set(agents.map(a => a.name));
+        const ordered = DEFAULT_SIDEBAR_ORDER.filter(n => knownSet.has(n));
+        const rest = agents.map(a => a.name).filter(n => !ordered.includes(n));
+        return [{ name: null, agents: [...ordered, ...rest] }];
       }
       const groups = _sidebarLayout.groups.map(g => ({ ...g }));
       const assigned = new Set();

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2046,9 +2046,13 @@
       return `<a class="oc-nav-item${isActive}" data-agent-nav="${esc(a.name)}" draggable="true" data-action="ocSelectAgent" data-agent="${esc(a.name)}" title="${esc(agentDesc)}"><span class="oc-agent-dot ${dotCls}"></span> ${esc(label)}<span class="oc-nav-actions"><button data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure">⚙</button><button class="oc-nav-delete" data-action="deleteAgentFromConfig" data-agent="${esc(a.name)}" title="Delete">✕</button></span></a>`;
     }
 
+    const DEFAULT_SIDEBAR_ORDER = ['supervisor', 'sec-check', 'scanner', 'ci-maintainer', 'architect', 'tester', 'outreach'];
     function _sidebarBuildGroups(agents) {
       if (!_sidebarLayout || !_sidebarLayout.groups) {
-        return [{ name: null, agents: agents.map(a => a.name) }];
+        const knownSet = new Set(agents.map(a => a.name));
+        const ordered = DEFAULT_SIDEBAR_ORDER.filter(n => knownSet.has(n));
+        const rest = agents.map(a => a.name).filter(n => !ordered.includes(n));
+        return [{ name: null, agents: [...ordered, ...rest] }];
       }
       const groups = _sidebarLayout.groups.map(g => ({ ...g }));
       const assigned = new Set();

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -109,7 +109,7 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 		}
 		nextKick := computeNextKick(proc.LastKick, cadence)
 
-		pinnedCli := proc.PinnedCLI != ""
+		pinnedCli := proc.PinnedCLI != "" || proc.Config.CLIPinned
 		pinnedModel := proc.PinnedModel != ""
 
 		const summaryLines = 20


### PR DESCRIPTION
## Summary
- **Display name persistence**: User-changed display names are now saved to `/data/hive-state.json` and restored on container restart. Previously they were lost on rebuild.
- **Default sidebar order**: Sets default agent order to supervisor, sec-check, scanner, ci-maintainer, architect, tester, outreach (persisted and overridable via sidebar.json).
- **CLI Pinned sidebar fix**: The sidebar now reflects the config-level `cli_pinned` flag in addition to runtime pins. Previously, an agent marked `cli_pinned: true` in config showed as unpinned in the sidebar cadence view even though the config dialog showed it correctly.

## Changes
- `v2/pkg/snapshot/state.go`: Added `DisplayName` field to `AgentState`
- `v2/cmd/hive/main.go`: Persist and restore display names via state file
- `v2/pkg/dashboard/status_builder.go`: Include `proc.Config.CLIPinned` in sidebar pinned state
- `v2/pkg/dashboard/static/index.html`: Default sidebar order constant + ordering logic
- `dashboard/index.html`: Same sidebar order fix for bare-metal dashboard

## Test plan
- [ ] Rebuild container on 4.78, change an agent's display name, rebuild again — name should persist
- [ ] Verify sidebar shows agents in correct default order on fresh install
- [ ] Verify CLI Pinned toggle in config dialog matches the pin icon in sidebar cadence view