### PR TITLE
fix: persist state after every eval cycle

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -372,6 +372,7 @@ func main() {
 	}
 
 	runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, logger)
+	persistState(agentMgr, gov, cfg, statePath, logger)
 
 	for {
 		select {
@@ -381,6 +382,7 @@ func main() {
 			return
 		case <-ticker.C:
 			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, logger)
+			persistState(agentMgr, gov, cfg, statePath, logger)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- State file (`/data/hive-state.json`) was only written on clean shutdown (SIGTERM handler) and UI config changes
- If the container was killed abruptly or rebuilt via `docker compose up -d`, the state file went stale — agents reverted to paused/unpaused state from the last clean shutdown (e.g. 2 days ago)
- Now `persistState` runs after every eval cycle (~5 min), keeping agent pause state, model pins, and budget always current on disk

## Test plan
- [ ] Unpause an agent, wait for one eval cycle, then `docker compose up -d` — agent should stay unpaused
- [ ] Verify `/data/hive-state.json` updates every eval cycle
- [ ] Verify no performance impact from the extra file write

🤖 Generated with [Claude Code](https://claude.com/claude-code)