### PR TITLE
fix: persist agent config changes across restarts

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -156,6 +156,30 @@ func main() {
 			if as.BackendOverride != "" {
 				_ = agentMgr.SetBackendOverride(name, as.BackendOverride)
 			}
+			if agentCfg, ok := cfg.Agents[name]; ok {
+				if as.DisplayName != "" {
+					agentCfg.DisplayName = as.DisplayName
+				}
+				if as.Description != "" {
+					agentCfg.Description = as.Description
+				}
+				if as.Enabled != nil {
+					agentCfg.Enabled = *as.Enabled
+				}
+				if as.ClearOnKick != nil {
+					agentCfg.ClearOnKick = *as.ClearOnKick
+				}
+				if as.StaleTimeout != nil {
+					agentCfg.StaleTimeout = *as.StaleTimeout
+				}
+				if as.RestartStrategy != "" {
+					agentCfg.RestartStrategy = as.RestartStrategy
+				}
+				if as.LaunchCmd != "" {
+					agentCfg.LaunchCmd = as.LaunchCmd
+				}
+				cfg.Agents[name] = agentCfg
+			}
 		}
 		if saved.BudgetLimit > 0 {
 			gov.SetBudgetLimit(saved.BudgetLimit)
@@ -650,7 +674,7 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 	statuses := agentMgr.AllStatuses()
 	agents := make(map[string]snapshot.AgentState, len(statuses))
 	for name, proc := range statuses {
-		agents[name] = snapshot.AgentState{
+		as := snapshot.AgentState{
 			Paused:          proc.Paused,
 			PinnedCLI:       proc.PinnedCLI,
 			PinnedModel:     proc.PinnedModel,
@@ -658,6 +682,19 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 			BackendOverride: proc.BackendOverride,
 			RestartCount:    proc.RestartCount,
 		}
+		if agentCfg, ok := cfg.Agents[name]; ok {
+			as.DisplayName = agentCfg.DisplayName
+			as.Description = agentCfg.Description
+			enabled := agentCfg.Enabled
+			as.Enabled = &enabled
+			clearOnKick := agentCfg.ClearOnKick
+			as.ClearOnKick = &clearOnKick
+			staleTimeout := agentCfg.StaleTimeout
+			as.StaleTimeout = &staleTimeout
+			as.RestartStrategy = agentCfg.RestartStrategy
+			as.LaunchCmd = agentCfg.LaunchCmd
+		}
+		agents[name] = as
 	}
 
 	cadenceOverrides := make(map[string]map[string]string)

--- a/v2/pkg/snapshot/state.go
+++ b/v2/pkg/snapshot/state.go
@@ -26,6 +26,13 @@ type AgentState struct {
 	ModelOverride   string `json:"model_override,omitempty"`
 	BackendOverride string `json:"backend_override,omitempty"`
 	RestartCount    int    `json:"restart_count"`
+	DisplayName     string `json:"display_name,omitempty"`
+	Description     string `json:"description,omitempty"`
+	Enabled         *bool  `json:"enabled,omitempty"`
+	ClearOnKick     *bool  `json:"clear_on_kick,omitempty"`
+	StaleTimeout    *int   `json:"stale_timeout,omitempty"`
+	RestartStrategy string `json:"restart_strategy,omitempty"`
+	LaunchCmd       string `json:"launch_cmd,omitempty"`
 }
 
 func SaveState(path string, state *PersistedState, logger *slog.Logger) error {


### PR DESCRIPTION
## Summary
- Dashboard config changes (display_name, description, enabled, clear_on_kick, stale_timeout, restart_strategy, launch_cmd) were only in-memory — reverted to hive.yaml defaults on restart
- Now these fields are included in `hive-state.json` and restored on startup, overriding YAML defaults
- Avoids rewriting `hive.yaml` (which would lose comments and env var references)

## Test plan
- [ ] Change agent display name via dashboard config dialog
- [ ] Rebuild container (`docker compose up -d`)
- [ ] Verify display name persists after restart
- [ ] Verify pause/resume state also persists (from PR #465)

🤖 Generated with [Claude Code](https://claude.com/claude-code)