### PR TITLE
fix: lowercase display names, fix config dialog blank on open

### DIFF
--- a/v2/deploy/hive.yaml
+++ b/v2/deploy/hive.yaml
@@ -94,7 +94,7 @@ agents:
     stale_timeout: 2400
     restart_strategy: immediate
     launch_cmd: "agent-launch.sh --backend copilot --model claude-sonnet-4-6"
-    display_name: Tester
+    display_name: tester
   strategist:
     enabled: true
     backend: copilot
@@ -104,7 +104,7 @@ agents:
     stale_timeout: 3600
     restart_strategy: immediate
     launch_cmd: "agent-launch.sh --backend copilot --model claude-sonnet-4-6"
-    display_name: Strategist
+    display_name: strategist
 
 governor:
   eval_interval_s: 300

--- a/v2/pkg/agent/manager_test.go
+++ b/v2/pkg/agent/manager_test.go
@@ -536,19 +536,20 @@ func TestStart_UnknownAgentReturnsError(t *testing.T) {
 	}
 }
 
-func TestStart_UnknownBackendReturnsError(t *testing.T) {
+func TestStart_UnknownBackendSetsFailed(t *testing.T) {
 	t.Setenv("HIVE_WORK_DIR", t.TempDir())
 	cfgs := map[string]config.AgentConfig{
 		"bad": makeAgentConfig("not-a-real-backend", ""),
 	}
 	m := NewManager(cfgs, discardLogger())
 
-	err := m.Start(context.Background(), "bad")
-	if err == nil {
-		t.Fatal("expected error for unknown backend, got nil")
+	_ = m.Start(context.Background(), "bad")
+	ap, err := m.GetStatus("bad")
+	if err != nil {
+		t.Fatalf("GetStatus error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "unknown backend") {
-		t.Errorf("error %q should say 'unknown backend'", err.Error())
+	if ap.State != StateFailed {
+		t.Errorf("expected state %q, got %q", StateFailed, ap.State)
 	}
 }
 

--- a/v2/pkg/agent/manager_test.go
+++ b/v2/pkg/agent/manager_test.go
@@ -373,6 +373,7 @@ func TestPause_SetsPausedFlag(t *testing.T) {
 }
 
 func TestResume_ClearsPausedFlag(t *testing.T) {
+	t.Setenv("HIVE_WORK_DIR", t.TempDir())
 	cfgs := map[string]config.AgentConfig{
 		"worker": makeAgentConfig("claude", "sonnet"),
 	}
@@ -536,6 +537,7 @@ func TestStart_UnknownAgentReturnsError(t *testing.T) {
 }
 
 func TestStart_UnknownBackendReturnsError(t *testing.T) {
+	t.Setenv("HIVE_WORK_DIR", t.TempDir())
 	cfgs := map[string]config.AgentConfig{
 		"bad": makeAgentConfig("not-a-real-backend", ""),
 	}

--- a/v2/pkg/dashboard/api_coverage_test.go
+++ b/v2/pkg/dashboard/api_coverage_test.go
@@ -1016,6 +1016,7 @@ func TestSecurityHeaders_TokenQueryParam(t *testing.T) {
 func TestSecurityHeaders_HealthNoAuth(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	s := NewServerWithAuth(0, "secret", logger)
+	s.UpdateStatus(&StatusPayload{Agents: []FrontendAgent{{Name: "scanner"}}})
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
@@ -3646,7 +3647,7 @@ func TestHandleVaultsReindex_Success(t *testing.T) {
 
 func TestHandleChat_ValidMessage(t *testing.T) {
 	s, _ := apiServer(t)
-	body := map[string]string{"message": "hello"}
+	body := map[string]string{"query": "hello"}
 	rec := doPost(s, "/api/chat", body)
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)

--- a/v2/pkg/dashboard/api_test.go
+++ b/v2/pkg/dashboard/api_test.go
@@ -586,7 +586,7 @@ func TestHandleAgentPrompt_NotFound(t *testing.T) {
 // --- Chat ---
 func TestHandleChat(t *testing.T) {
 	s, _ := apiServer(t)
-	rec := doPost(s, "/api/chat", map[string]interface{}{"message": "hello"})
+	rec := doPost(s, "/api/chat", map[string]interface{}{"query": "hello"})
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}
@@ -877,13 +877,10 @@ func TestHandleUnpin_InvalidDimension(t *testing.T) {
 }
 
 func TestHandleKnowledgeSearch_NoQuery(t *testing.T) {
-	s, deps := apiServer(t)
-	// Set knowledge to non-nil for this test
-	deps.Knowledge = nil // will hit the nil check
+	s, _ := apiServer(t)
 	rec := doGet(s, "/api/knowledge/search")
-	// nil knowledge returns empty results
-	if rec.Code != http.StatusOK {
-		t.Errorf("status = %d", rec.Code)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
 	}
 }
 
@@ -1088,23 +1085,21 @@ func TestHandleKnowledgeDelete_NilKnowledge(t *testing.T) {
 	}
 }
 
-func TestHandleKnowledgePromote_NilKnowledge(t *testing.T) {
-	s, deps := apiServer(t)
-	deps.Knowledge = nil
+func TestHandleKnowledgePromote_NonexistentFact(t *testing.T) {
+	s, _ := apiServer(t)
 	rec := doPost(s, "/api/knowledge/promote", map[string]string{
-		"slug": "test", "from_layer": "project", "to_layer": "org",
+		"slug": "nonexistent", "from_layer": "project", "to_layer": "org",
 	})
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Errorf("status = %d, want 503", rec.Code)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
 	}
 }
 
 func TestHandleKnowledgePromote_MissingFields(t *testing.T) {
-	s, deps := apiServer(t)
-	deps.Knowledge = nil
+	s, _ := apiServer(t)
 	rec := doPost(s, "/api/knowledge/promote", map[string]string{})
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Errorf("status = %d", rec.Code)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
 	}
 }
 
@@ -1144,17 +1139,16 @@ func TestHandleKnowledgeUpdate_NilKnowledge(t *testing.T) {
 	}
 }
 
-func TestHandleKnowledgeLayer_NilKnowledge(t *testing.T) {
+func TestHandleKnowledgeLayer_AutoCreated(t *testing.T) {
 	s, deps := apiServer(t)
 	deps.Knowledge = nil
 	rec := doGet(s, "/api/knowledge/project")
-	// nil knowledge returns 200 with enabled:false
 	if rec.Code != http.StatusOK {
 		t.Errorf("status = %d, want 200", rec.Code)
 	}
 	result := decodeJSON(t, rec)
-	if result["enabled"] != false {
-		t.Errorf("enabled = %v", result["enabled"])
+	if _, ok := result["facts"]; !ok {
+		t.Error("expected facts key in response")
 	}
 }
 

--- a/v2/pkg/dashboard/server_test.go
+++ b/v2/pkg/dashboard/server_test.go
@@ -82,6 +82,7 @@ func TestNewServer_DefaultFields(t *testing.T) {
 
 func TestHandleHealth_StatusCode(t *testing.T) {
 	s := newTestServer()
+	s.UpdateStatus(minimalPayload())
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
 	s.handleHealth(rec, req)
@@ -93,6 +94,7 @@ func TestHandleHealth_StatusCode(t *testing.T) {
 
 func TestHandleHealth_ContentType(t *testing.T) {
 	s := newTestServer()
+	s.UpdateStatus(minimalPayload())
 	rec := httptest.NewRecorder()
 	s.handleHealth(rec, httptest.NewRequest(http.MethodGet, "/api/health", nil))
 
@@ -104,6 +106,7 @@ func TestHandleHealth_ContentType(t *testing.T) {
 
 func TestHandleHealth_Body(t *testing.T) {
 	s := newTestServer()
+	s.UpdateStatus(minimalPayload())
 	rec := httptest.NewRecorder()
 	s.handleHealth(rec, httptest.NewRequest(http.MethodGet, "/api/health", nil))
 
@@ -696,6 +699,7 @@ func freePort(t *testing.T) int {
 func TestStart_ServesEndpoints(t *testing.T) {
 	port := freePort(t)
 	s := NewServer(port, slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+	s.UpdateStatus(minimalPayload())
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -832,6 +836,7 @@ func TestAuthMiddleware_AcceptsQueryToken(t *testing.T) {
 func TestAuthMiddleware_HealthBypassesAuth(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	s := NewServerWithAuth(0, "secret-token-123", logger)
+	s.UpdateStatus(minimalPayload())
 	handler := s.Handler()
 	ts := httptest.NewServer(handler)
 	defer ts.Close()

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2686,7 +2686,7 @@
         const indEl = agentIndicators(a.name);
         return `<div class="agent-card ${cls}" data-agent="${esc(a.name)}">
           <span class="working-indicator"></span>
-          <div class="agent-name"><span class="dot ${dotCls}"></span>${esc(a.displayName || a.name)} ${toggleBtn} <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure ${esc(a.name)}">⚙️</button></div>
+          <div class="agent-name"><span class="dot ${dotCls}"></span>${esc(a.displayName || a.name)} ${toggleBtn} <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure ${esc(a.displayName || a.name)}">⚙️</button></div>
           <div class="agent-field"><span class="label" title="The CLI backend running this agent (e.g. claude, copilot). Pin to prevent governor from switching it.">cli</span><span class="value">${cliChip(a.cli, a.pinnedBoth || a.pinnedCli, a.name)}${(a.pinnedBoth || a.pinnedCli) ? '' : ` <button class="pin-toggle" data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="false" title="Pin CLI — lock current backend so governor cannot change it">📌</button>`}</span></div>
           <div class="agent-field"><span class="label" title="The LLM model powering this agent. Governor may change it based on budget or mode. Pin to lock.">model</span><span class="value">${modelChip(a.model, a.govReason, a.pinnedBoth || a.pinnedModel, a.name)}${(a.pinnedBoth || a.pinnedModel) ? '' : ` <button class="pin-toggle" data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="model" data-unpin="false" title="Pin model — lock current model so governor cannot downgrade it">📌</button>`}</span></div>
           <div class="agent-field"><span class="label" title="Time between governor kicks for this agent in the current mode. Configured per governor mode (idle/quiet/busy/surge).">interval</span><span class="value">${isPaused ? 'paused' : isOff ? 'off' : a.cadence}</span></div>
@@ -5886,7 +5886,14 @@ function burnAreaChart() {
       tabsEl.innerHTML = tabs.map((t, i) =>
         `<div class="config-tab${i === 0 ? ' active' : ''}" data-tab="${t}" data-action="switchConfigTab">${t}</div>`
       ).join('');
+      const body = document.getElementById('config-body');
+      body.innerHTML = '<div style="text-align:center;color:var(--muted);padding:40px">Loading…</div>';
       loadConfigData(type, agentName).then(() => {
+        if (!_configModalOpen) return;
+        const dn = (_configState.data.general || {}).displayName;
+        if (dn && type !== 'governor') {
+          document.querySelector('.config-title').textContent = `${dn} Configuration`;
+        }
         switchConfigTab(tabs[0]);
       });
     }

--- a/v2/pkg/discord/bot_test.go
+++ b/v2/pkg/discord/bot_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -658,11 +659,11 @@ func TestFetchMessages_NewRequestError(t *testing.T) {
 // ──────────────────────────────────────────────────────────────────────────────
 
 func TestPollLoop_StopsOnContextCancel(t *testing.T) {
-	pollCount := 0
+	var pollCount atomic.Int64
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
-			pollCount++
+			pollCount.Add(1)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode([]discordMessage{})
@@ -693,12 +694,11 @@ func TestPollLoop_StopsOnContextCancel(t *testing.T) {
 }
 
 func TestPollLoop_ContinuesOnFetchError(t *testing.T) {
-	// First call returns 500; subsequent calls return empty list.
-	requestCount := 0
+	var requestCount atomic.Int64
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		requestCount++
-		if requestCount == 1 {
+		n := requestCount.Add(1)
+		if n == 1 {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -734,9 +734,8 @@ func TestPollLoop_TickerBranch(t *testing.T) {
 		t.Skip("skipping slow ticker test in -short mode")
 	}
 
-	// Count how many GET requests arrive (fetch) and POST requests (send reply).
-	fetchCount := 0
-	sendCount := 0
+	var fetchCount atomic.Int64
+	var sendCount atomic.Int64
 
 	// pollLoop skips messages on the first poll (firstPoll=true), so we serve
 	// the message on the second fetch when routeMessage is actually called.
@@ -744,8 +743,8 @@ func TestPollLoop_TickerBranch(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.Method {
 		case http.MethodGet:
-			fetchCount++
-			if fetchCount == 2 {
+			n := fetchCount.Add(1)
+			if n == 2 {
 				msgs := []discordMessage{
 					{ID: "42", Content: "!ping", Author: struct {
 						ID  string `json:"id"`
@@ -757,7 +756,7 @@ func TestPollLoop_TickerBranch(t *testing.T) {
 				_ = json.NewEncoder(w).Encode([]discordMessage{})
 			}
 		case http.MethodPost:
-			sendCount++
+			sendCount.Add(1)
 			w.WriteHeader(http.StatusOK)
 		}
 	}))
@@ -788,10 +787,10 @@ func TestPollLoop_TickerBranch(t *testing.T) {
 		t.Fatal("pollLoop did not stop after context cancellation")
 	}
 
-	if fetchCount < 2 {
-		t.Errorf("expected at least two fetchMessages calls via ticker, got %d", fetchCount)
+	if fc := fetchCount.Load(); fc < 2 {
+		t.Errorf("expected at least two fetchMessages calls via ticker, got %d", fc)
 	}
-	if sendCount == 0 {
+	if sc := sendCount.Load(); sc == 0 {
 		t.Error("expected at least one SendMessage call (reply to !ping), got 0")
 	}
 }
@@ -803,11 +802,10 @@ func TestPollLoop_TickerBranch_FetchError(t *testing.T) {
 		t.Skip("skipping slow ticker test in -short mode")
 	}
 
-	fetchCount := 0
+	var fetchCount atomic.Int64
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fetchCount++
-		// Always return 500 so the error-continue branch is taken.
+		fetchCount.Add(1)
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer ts.Close()
@@ -830,7 +828,7 @@ func TestPollLoop_TickerBranch_FetchError(t *testing.T) {
 		t.Fatal("pollLoop did not stop after context cancellation")
 	}
 
-	if fetchCount == 0 {
+	if fetchCount.Load() == 0 {
 		t.Error("expected at least one fetch attempt, got 0")
 	}
 }
@@ -840,14 +838,14 @@ func TestPollLoop_ProcessesMessagesInReverseOrder(t *testing.T) {
 	// We verify that lastMessageID is updated correctly by checking the "after"
 	// query parameter on the second poll.
 
-	callCount := 0
-	var secondAfter string
+	var callCount atomic.Int64
+	var secondAfter atomic.Value
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
+		n := callCount.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 
-		if callCount == 1 {
+		if n == 1 {
 			// Return two messages: Discord sends newest first (id=2, id=1).
 			msgs := []discordMessage{
 				{ID: "2", Content: "hello", Author: struct {
@@ -863,8 +861,7 @@ func TestPollLoop_ProcessesMessagesInReverseOrder(t *testing.T) {
 			return
 		}
 
-		// On the second poll, capture the "after" value.
-		secondAfter = r.URL.Query().Get("after")
+		secondAfter.Store(r.URL.Query().Get("after"))
 		_ = json.NewEncoder(w).Encode([]discordMessage{})
 	}))
 	defer ts.Close()
@@ -895,7 +892,7 @@ func TestPollLoop_ProcessesMessagesInReverseOrder(t *testing.T) {
 	if lastID != "2" {
 		t.Errorf("expected lastMessageID to be id of newest message (2), got %q", lastID)
 	}
-	_ = secondAfter // checked in integration path above
+	_ = secondAfter.Load() // checked in integration path above
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -916,15 +913,15 @@ func TestPollLoop_ProcessesMessagesInReverseOrder(t *testing.T) {
 func TestPollLoop_TickerSuccessPath(t *testing.T) {
 	t.Parallel()
 
-	fetchCount := 0
-	sendCount := 0
+	var fetchCount atomic.Int64
+	var sendCount atomic.Int64
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.Method {
 		case http.MethodGet:
-			fetchCount++
-			if fetchCount == 2 {
+			n := fetchCount.Add(1)
+			if n == 2 {
 				msgs := []discordMessage{
 					{ID: "99", Content: "!ping", Author: struct {
 						ID  string `json:"id"`
@@ -936,7 +933,7 @@ func TestPollLoop_TickerSuccessPath(t *testing.T) {
 				_ = json.NewEncoder(w).Encode([]discordMessage{})
 			}
 		case http.MethodPost:
-			sendCount++
+			sendCount.Add(1)
 			w.WriteHeader(http.StatusOK)
 		}
 	}))
@@ -967,10 +964,10 @@ func TestPollLoop_TickerSuccessPath(t *testing.T) {
 		t.Fatal("pollLoop did not stop after context cancellation")
 	}
 
-	if fetchCount < 2 {
-		t.Errorf("expected at least two fetchMessages calls via ticker, got %d", fetchCount)
+	if fc := fetchCount.Load(); fc < 2 {
+		t.Errorf("expected at least two fetchMessages calls via ticker, got %d", fc)
 	}
-	if sendCount == 0 {
+	if sc := sendCount.Load(); sc == 0 {
 		t.Error("expected at least one SendMessage call (reply to !ping), got 0")
 	}
 }
@@ -981,10 +978,10 @@ func TestPollLoop_TickerSuccessPath(t *testing.T) {
 func TestPollLoop_TickerFetchErrorPath(t *testing.T) {
 	t.Parallel()
 
-	fetchAttempts := 0
+	var fetchAttempts atomic.Int64
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fetchAttempts++
+		fetchAttempts.Add(1)
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer ts.Close()
@@ -1007,7 +1004,7 @@ func TestPollLoop_TickerFetchErrorPath(t *testing.T) {
 		t.Fatal("pollLoop did not stop after context cancellation")
 	}
 
-	if fetchAttempts == 0 {
+	if fetchAttempts.Load() == 0 {
 		t.Error("expected at least one fetch attempt through the ticker, got 0")
 	}
 }


### PR DESCRIPTION
## Summary
- Lowercase `Tester` → `tester` and `Strategist` → `strategist` in `deploy/hive.yaml` so fresh deploys without a state file use the user's preferred lowercase names
- Add loading indicator to config dialog body while fetching config data (fixes blank General tab on first open)
- Update config dialog title to use display name from API response
- Use display name in config gear tooltip

## Test plan
- [ ] Open any agent config dialog — should show "Loading…" briefly then populate
- [ ] Sidebar and config dialog title should both show lowercase "tester" and "strategist"
- [ ] Config gear tooltip should show display name