### PR TITLE
fix: sync restored state to agent manager on startup

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1832,9 +1832,13 @@
       return `<a class="oc-nav-item${isActive}" data-agent-nav="${a.name}" draggable="true" onclick="ocSelectAgent('${a.name}')" title="${agentDesc}"><span class="oc-agent-dot ${dotCls}"></span> ${label}</a>`;
     }
 
+    const DEFAULT_SIDEBAR_ORDER = ['supervisor', 'sec-check', 'scanner', 'ci-maintainer', 'architect', 'tester', 'outreach'];
     function _sidebarBuildGroups(agents) {
       if (!_sidebarLayout || !_sidebarLayout.groups) {
-        return [{ name: null, agents: agents.map(a => a.name) }];
+        const knownSet = new Set(agents.map(a => a.name));
+        const ordered = DEFAULT_SIDEBAR_ORDER.filter(n => knownSet.has(n));
+        const rest = agents.map(a => a.name).filter(n => !ordered.includes(n));
+        return [{ name: null, agents: [...ordered, ...rest] }];
       }
       const groups = _sidebarLayout.groups.map(g => ({ ...g }));
       const assigned = new Set();

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -179,6 +179,7 @@ func main() {
 					agentCfg.LaunchCmd = as.LaunchCmd
 				}
 				cfg.Agents[name] = agentCfg
+				_ = agentMgr.UpdateConfig(name, agentCfg)
 			}
 		}
 		if saved.BudgetLimit > 0 {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2046,9 +2046,13 @@
       return `<a class="oc-nav-item${isActive}" data-agent-nav="${esc(a.name)}" draggable="true" data-action="ocSelectAgent" data-agent="${esc(a.name)}" title="${esc(agentDesc)}"><span class="oc-agent-dot ${dotCls}"></span> ${esc(label)}<span class="oc-nav-actions"><button data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure">⚙</button><button class="oc-nav-delete" data-action="deleteAgentFromConfig" data-agent="${esc(a.name)}" title="Delete">✕</button></span></a>`;
     }
 
+    const DEFAULT_SIDEBAR_ORDER = ['supervisor', 'sec-check', 'scanner', 'ci-maintainer', 'architect', 'tester', 'outreach'];
     function _sidebarBuildGroups(agents) {
       if (!_sidebarLayout || !_sidebarLayout.groups) {
-        return [{ name: null, agents: agents.map(a => a.name) }];
+        const knownSet = new Set(agents.map(a => a.name));
+        const ordered = DEFAULT_SIDEBAR_ORDER.filter(n => knownSet.has(n));
+        const rest = agents.map(a => a.name).filter(n => !ordered.includes(n));
+        return [{ name: null, agents: [...ordered, ...rest] }];
       }
       const groups = _sidebarLayout.groups.map(g => ({ ...g }));
       const assigned = new Set();

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -109,7 +109,7 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 		}
 		nextKick := computeNextKick(proc.LastKick, cadence)
 
-		pinnedCli := proc.PinnedCLI != ""
+		pinnedCli := proc.PinnedCLI != "" || proc.Config.CLIPinned
 		pinnedModel := proc.PinnedModel != ""
 
 		const summaryLines = 20


### PR DESCRIPTION
## Summary
- Fixes display names (and other config fields) not surviving container restart
- Root cause: `NewManager` copies configs at creation, then state restoration updates `cfg.Agents[]` but the manager still has stale copies
- Fix: call `agentMgr.UpdateConfig()` after restoring each agent's config from persisted state

## Test plan
- [ ] Change display name via config dialog, restart container, verify name persists