### PR TITLE
feat: auto-label issues/PRs with agent identity and hive instance ID

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -159,4 +159,77 @@ if [ "$subcmd" = "api" ]; then
   done
 fi
 
+# Auto-label issues and PRs with agent identity + hive instance ID.
+# HIVE_AGENT is set by the Go binary (e.g. "scanner").
+# HIVE_ID is the unique hive instance ID (e.g. "hive-bold-fox").
+AGENT_NAME="${HIVE_AGENT:-$AGENT_ID}"
+HIVE_INSTANCE_ID="${HIVE_ID:-}"
+
+if [[ -n "$AGENT_NAME" ]]; then
+  LABELS_CSV="agent/${AGENT_NAME}"
+  [[ -n "$HIVE_INSTANCE_ID" ]] && LABELS_CSV="${LABELS_CSV},hive/${HIVE_INSTANCE_ID}"
+
+  # Ensure labels exist on the repo (cached per-session to avoid repeated API calls).
+  LABEL_CACHE="/tmp/.hive-labels-ensured"
+  _ensure_labels() {
+    [[ -f "$LABEL_CACHE" ]] && return 0
+    local repo_flag=""
+    for arg in "${args[@]}"; do
+      case "$arg" in
+        --repo) repo_flag="next" ;;
+        --repo=*) repo_flag="${arg#--repo=}" ; break ;;
+        *) [[ "$repo_flag" = "next" ]] && repo_flag="$arg" && break ;;
+      esac
+    done
+    [[ "$repo_flag" = "next" ]] && repo_flag=""
+    local rf=""
+    [[ -n "$repo_flag" ]] && rf="--repo $repo_flag"
+    "$REAL_GH" label create "agent/${AGENT_NAME}" --description "Work by the ${AGENT_NAME} agent" --color 6f42c1 $rf 2>/dev/null || true
+    if [[ -n "$HIVE_INSTANCE_ID" ]]; then
+      "$REAL_GH" label create "hive/${HIVE_INSTANCE_ID}" --description "Hive instance ${HIVE_INSTANCE_ID}" --color 1d76db $rf 2>/dev/null || true
+    fi
+    touch "$LABEL_CACHE"
+  }
+
+  # Extract issue/PR number and repo from args (for post-action labeling).
+  _extract_item() {
+    item_num=""
+    item_repo=""
+    local skip=false
+    for arg in "${args[@]}"; do
+      if $skip; then skip=false; item_repo="$arg"; continue; fi
+      case "$arg" in
+        comment|review|"$subcmd"|"$action") continue ;;
+        --repo) skip=true; continue ;;
+        --repo=*) item_repo="${arg#--repo=}"; continue ;;
+        -*) continue ;;
+        *) [[ -z "$item_num" ]] && item_num="$arg" ;;
+      esac
+    done
+  }
+
+  case "$subcmd/$action" in
+    issue/create|pr/create)
+      _ensure_labels
+      exec "$REAL_GH" "$@" --label "$LABELS_CSV"
+      ;;
+    issue/edit|pr/edit)
+      _ensure_labels
+      exec "$REAL_GH" "$@" --add-label "$LABELS_CSV"
+      ;;
+    issue/comment|pr/comment|pr/review)
+      _ensure_labels
+      _extract_item
+      "$REAL_GH" "$@"
+      exit_code=$?
+      if [[ $exit_code -eq 0 && -n "$item_num" ]]; then
+        local_repo=""
+        [[ -n "$item_repo" ]] && local_repo="--repo $item_repo"
+        "$REAL_GH" "$subcmd" edit "$item_num" $local_repo --add-label "$LABELS_CSV" 2>/dev/null || true
+      fi
+      exit $exit_code
+      ;;
+  esac
+fi
+
 exec "$REAL_GH" "$@"

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -51,6 +51,7 @@ func main() {
 
 	// Load or generate a unique Hive ID for this instance
 	cfg.HiveID = loadOrGenerateHiveID(logger)
+	os.Setenv("HIVE_ID", cfg.HiveID)
 
 	logger.Info("hive starting",
 		"org", cfg.Project.Org,

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -537,11 +537,15 @@ func agentEnvVars(agent *AgentProcess) []string {
 	if agent.BackendOverride != "" {
 		backend = agent.BackendOverride
 	}
-	return []string{
+	vars := []string{
 		fmt.Sprintf("HIVE_AGENT=%s", agent.Name),
 		fmt.Sprintf("HIVE_BACKEND=%s", backend),
 		fmt.Sprintf("HIVE_MODEL=%s", model),
 	}
+	if hiveID := os.Getenv("HIVE_ID"); hiveID != "" {
+		vars = append(vars, fmt.Sprintf("HIVE_ID=%s", hiveID))
+	}
+	return vars
 }
 
 func (m *Manager) Pause(name string) error {


### PR DESCRIPTION
## Summary
- gh-wrapper.sh now auto-appends `agent/<name>` and `hive/<instance-id>` labels to every issue/PR that agents create, edit, comment on, or review
- Labels are auto-created on the repo if they don't exist (cached per-session to avoid repeated API calls)
- Go binary exports `HIVE_ID` env var so agent processes inherit it; agent manager passes it through to child processes

## How it works
1. `HIVE_AGENT` (set by Go binary) identifies the agent name → `agent/scanner`, `agent/tester`, etc.
2. `HIVE_ID` (set by Go binary from `/data/hive-id`) identifies the hive instance → `hive/hive-bold-fox`
3. On `issue/create` or `pr/create`: appends `--label agent/<name>,hive/<id>`
4. On `issue/edit` or `pr/edit`: appends `--add-label agent/<name>,hive/<id>`
5. On `comment` or `review`: runs the command first, then adds labels via a separate edit call
6. `_ensure_labels()` creates missing labels once per session (purple for agent, blue for hive)

## Files changed
- `bin/gh-wrapper.sh` — labeling logic + label auto-creation
- `v2/cmd/hive/main.go` — `os.Setenv("HIVE_ID", cfg.HiveID)`
- `v2/pkg/agent/manager.go` — passes `HIVE_ID` to agent env vars

## Test plan
- [ ] Deploy to hive on 192.168.4.78
- [ ] Have scanner create an issue → verify `agent/scanner` and `hive/<id>` labels appear
- [ ] Have an agent comment on a PR → verify labels are added
- [ ] Verify labels are created on repo if missing
- [ ] Verify label creation is cached (only one `gh label create` call per session)