### PR TITLE
feat: git credential helper for GitHub App token auth

### DIFF
--- a/bin/git-credential-hive.sh
+++ b/bin/git-credential-hive.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# git-credential-hive.sh — Git credential helper that uses the GitHub App token.
+# Reads from the cached token file, refreshing if stale (>55 min old).
+# Install: git config --global credential.https://github.com.helper /usr/local/bin/git-credential-hive.sh
+
+set -euo pipefail
+
+TOKEN_FILE="/var/run/hive-metrics/gh-app-token.cache"
+CACHE_MAX_AGE_SECONDS=3300
+
+refresh_token() {
+  if [ -x /usr/local/bin/gh-app-token.sh ]; then
+    /usr/local/bin/gh-app-token.sh >/dev/null 2>&1 || true
+  fi
+}
+
+if [ ! -f "$TOKEN_FILE" ]; then
+  refresh_token
+fi
+
+if [ -f "$TOKEN_FILE" ]; then
+  cache_age=$(( $(date +%s) - $(stat -c %Y "$TOKEN_FILE" 2>/dev/null || echo 0) ))
+  if [ "$cache_age" -gt "$CACHE_MAX_AGE_SECONDS" ]; then
+    refresh_token
+  fi
+fi
+
+TOKEN=$(cat "$TOKEN_FILE" 2>/dev/null || true)
+if [ -z "$TOKEN" ]; then
+  exit 1
+fi
+
+case "${1:-}" in
+  get)
+    echo "protocol=https"
+    echo "host=github.com"
+    echo "username=x-access-token"
+    echo "password=$TOKEN"
+    ;;
+esac

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -48,10 +48,11 @@ COPY v2/pkg/dashboard/static/index.html /opt/hive/proxy/public/
 COPY examples/kubestellar/hive-project.yaml /etc/hive/hive-project.yaml
 COPY v2/deploy/data/ /opt/hive/seed-data/
 COPY v2/deploy/ttyd-tmux.sh /usr/local/bin/ttyd-tmux.sh
-COPY bin/gh-app-token.sh bin/hive-config.sh bin/agent-launch.sh /usr/local/bin/
+COPY bin/gh-app-token.sh bin/hive-config.sh bin/agent-launch.sh bin/git-credential-hive.sh /usr/local/bin/
 COPY bin/gh-wrapper.sh /usr/local/bin/gh
 RUN chmod +x /usr/local/bin/ttyd-tmux.sh /usr/local/bin/gh-app-token.sh \
-    /usr/local/bin/hive-config.sh /usr/local/bin/agent-launch.sh /usr/local/bin/gh
+    /usr/local/bin/hive-config.sh /usr/local/bin/agent-launch.sh /usr/local/bin/gh \
+    /usr/local/bin/git-credential-hive.sh
 
 # --- Nous framework (strategist experiment engine) ---
 RUN (apt-get update && apt-get install -y --no-install-recommends \

--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -46,6 +46,24 @@ if [ -n "${HIVE_WIKI_GIT_URL:-}" ] && [ ! -d /data/vaults/hive-wiki/.git ]; then
 fi
 mkdir -p /data/vaults/hive-wiki
 
+# Configure git identity and credential helper for GitHub App token
+git config --global user.name "kubestellar-hive"
+git config --global user.email "hive-bot@kubestellar.io"
+git config --global credential.helper ""
+git config --global "credential.https://github.com.helper" "/usr/local/bin/git-credential-hive.sh"
+
+# Generate initial GitHub App token if credentials are available
+if [ -x /usr/local/bin/hive-config.sh ]; then
+  . /usr/local/bin/hive-config.sh 2>/dev/null || true
+fi
+if [ -n "${GH_APP_ID:-}" ] && [ -n "${GH_APP_INSTALLATION_ID:-}" ]; then
+  echo "[entrypoint] Generating GitHub App token..."
+  /usr/local/bin/gh-app-token.sh >/dev/null 2>&1 && \
+    echo "[entrypoint] Token cached at /var/run/hive-metrics/gh-app-token.cache" || \
+    echo "[entrypoint] WARN: GitHub App token generation failed"
+  export HIVE_GITHUB_TOKEN="$(cat /var/run/hive-metrics/gh-app-token.cache 2>/dev/null || true)"
+fi
+
 echo "[entrypoint] Starting Go binary on :${HIVE_API_PORT}"
 hive "$@" &
 HIVE_PID=$!


### PR DESCRIPTION
## Summary
- New `bin/git-credential-hive.sh` — git credential helper that reads the cached GitHub App token
- Entrypoint now sources `hive-config.sh` on startup to generate an initial token and configure git
- All agents can now `git push` without manual token setup

## Problem
Agents (especially tester) couldn't push branches or create PRs because `git push` had no credentials. The `gh` wrapper handled `gh` CLI auth via the app token, but `git` operations had no credential helper configured.

## How it works
1. `entrypoint.sh` sources `hive-config.sh` → reads GitHub App config from `hive-project.yaml` → generates initial token
2. `git config --global credential.https://github.com.helper /usr/local/bin/git-credential-hive.sh`
3. On `git push`, git calls the helper which reads `/var/run/hive-metrics/gh-app-token.cache`, refreshing if >55 min old

## Test plan
- [ ] Deploy to 192.168.4.78
- [ ] Verify tester agent can `git push` a branch
- [ ] Verify `git credential fill` returns a valid token inside the container
- [ ] Verify token auto-refreshes after expiry