### PR TITLE
fix: unify tooltip font and size across dashboard

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1084,7 +1084,9 @@
     .config-info .config-tooltip {
       display: none; position: absolute; top: calc(100% + 6px); left: 50%;
       transform: translateX(-50%); background: var(--bg); border: 1px solid var(--border);
-      border-radius: 6px; padding: 8px 10px; font-size: 0.7rem; font-weight: 400;
+      border-radius: 6px; padding: 6px 10px;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      font-size: 0.8125rem; font-weight: 400;
       color: var(--text); white-space: normal; width: 240px; z-index: 10001;
       box-shadow: 0 4px 12px rgba(0,0,0,0.4); line-height: 1.4;
     }
@@ -1429,6 +1431,37 @@
       body.has-info-sidebar { margin-right: 0; }
       body.has-info-sidebar #oc-topbar { right: 0; }
     }
+
+    /* ── Unified tooltip styling for native title attributes ── */
+    [data-tip] { position: relative; }
+    [data-tip]::after {
+      content: attr(data-tip);
+      display: none;
+      position: absolute;
+      bottom: calc(100% + 6px);
+      left: 50%;
+      transform: translateX(-50%);
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 6px 10px;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      font-size: 0.8125rem;
+      font-weight: 400;
+      color: var(--text);
+      white-space: normal;
+      max-width: 280px;
+      min-width: 120px;
+      width: max-content;
+      z-index: 10002;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+      line-height: 1.4;
+      pointer-events: none;
+      text-align: left;
+    }
+    [data-tip]:hover::after { display: block; }
+    /* Flip tooltip below when near top of viewport — JS adds this class */
+    [data-tip].tip-below::after { bottom: auto; top: calc(100% + 6px); }
   </style>
 </head>
 <body>
@@ -1440,6 +1473,28 @@
   if(m==='light'){document.body.classList.add('light-mode','has-info-sidebar')}
   document.body.style.opacity='0';
   document.body.style.transition='opacity 0.15s ease-in';
+})();
+
+/* ── Unified tooltip: swap title→data-tip on hover to suppress native tooltip ── */
+(function(){
+  var VIEWPORT_FLIP_PX = 80; /* flip tooltip below if element is within 80px of viewport top */
+  document.addEventListener('mouseover', function(e){
+    var el = e.target.closest('[title]');
+    if (!el || !el.getAttribute('title')) return;
+    el.setAttribute('data-tip', el.getAttribute('title'));
+    el.removeAttribute('title');
+    /* flip below if near top of viewport */
+    var r = el.getBoundingClientRect();
+    if (r.top < VIEWPORT_FLIP_PX) el.classList.add('tip-below');
+    else el.classList.remove('tip-below');
+  });
+  document.addEventListener('mouseout', function(e){
+    var el = e.target.closest('[data-tip]');
+    if (!el) return;
+    el.setAttribute('title', el.getAttribute('data-tip'));
+    el.removeAttribute('data-tip');
+    el.classList.remove('tip-below');
+  });
 })();
 </script>
 <div id="toast-container"></div>


### PR DESCRIPTION
## Summary
- Unified all tooltip text to use the same font family and size (0.8125rem / 13px)
- Updated `.config-tooltip` CSS to match the unified style
- Added `[data-tip]` CSS pseudo-element tooltip system for consistent styled rendering
- Delegated JS handler converts native `title` attributes to `data-tip` on hover, covering all 50+ dynamically rendered tooltips without modifying templates

## Test plan
- [ ] Hover over info icons in config dialog — verify consistent font/size
- [ ] Hover over agent cards, sparklines, status badges — verify same styling
- [ ] Check viewport edge behavior — tooltips near top should flip below