### PR TITLE
fix: persist token sparkline history + config dialog loading fix

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -118,6 +118,15 @@ func main() {
 		}
 	}
 
+	// Restore token sparkline history from disk so token charts survive container restarts
+	const tokenSparklinePath = "/data/token-sparkline-history.json"
+	var pendingTokenSeed []dashboard.TokenSparklineEntry
+	if tokenSparkData, err := os.ReadFile(tokenSparklinePath); err == nil {
+		if err := json.Unmarshal(tokenSparkData, &pendingTokenSeed); err == nil && len(pendingTokenSeed) > 0 {
+			logger.Info("token sparkline history loaded", "entries", len(pendingTokenSeed))
+		}
+	}
+
 	if cfg.Knowledge.Enabled {
 		layers := convertKnowledgeLayers(cfg.Knowledge.Layers)
 		primerCfg := knowledge.PrimerConfig{
@@ -211,6 +220,12 @@ func main() {
 	// Go binary serves the internal API without auth — the Node.js proxy
 	// on port 3001 handles public-facing authentication.
 	dashSrv := dashboard.NewServer(cfg.Dashboard.Port, logger)
+
+	// Seed token sparkline history now that the dashboard server exists
+	if len(pendingTokenSeed) > 0 {
+		dashSrv.SeedTokenSparklineHistory(pendingTokenSeed)
+		logger.Info("token sparkline history restored", "entries", len(pendingTokenSeed))
+	}
 
 	beadStores := make(map[string]*beads.Store)
 	for name, agentCfg := range cfg.EnabledAgents() {
@@ -334,7 +349,7 @@ func main() {
 		Ctx:              ctx,
 		RefreshFunc:      refreshDashboard,
 		PersistFunc: func() {
-			persistState(agentMgr, gov, cfg, statePath, logger)
+			persistState(agentMgr, gov, cfg, statePath, logger, dashSrv)
 		},
 	})
 
@@ -398,17 +413,17 @@ func main() {
 	}
 
 	runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, logger)
-	persistState(agentMgr, gov, cfg, statePath, logger)
+	persistState(agentMgr, gov, cfg, statePath, logger, dashSrv)
 
 	for {
 		select {
 		case <-ctx.Done():
 			logger.Info("shutting down, persisting state")
-			persistState(agentMgr, gov, cfg, statePath, logger)
+			persistState(agentMgr, gov, cfg, statePath, logger, dashSrv)
 			return
 		case <-ticker.C:
 			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, logger)
-			persistState(agentMgr, gov, cfg, statePath, logger)
+			persistState(agentMgr, gov, cfg, statePath, logger, dashSrv)
 		}
 	}
 }
@@ -665,7 +680,7 @@ func randomName() string {
 	return adj + "-" + noun
 }
 
-func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.Config, path string, logger *slog.Logger) {
+func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.Config, path string, logger *slog.Logger, dashSrv *dashboard.Server) {
 	statuses := agentMgr.AllStatuses()
 	agents := make(map[string]snapshot.AgentState, len(statuses))
 	for name, proc := range statuses {
@@ -730,6 +745,17 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 		modeData, err := json.Marshal(modeHistory)
 		if err == nil {
 			_ = os.WriteFile("/data/mode-history.json", modeData, 0o644)
+		}
+	}
+
+	// Persist token sparkline history so token charts survive container restarts
+	if dashSrv != nil {
+		tokenHistory := dashSrv.TokenSparklineHistory()
+		if len(tokenHistory) > 0 {
+			tokenData, err := json.Marshal(tokenHistory)
+			if err == nil {
+				_ = os.WriteFile("/data/token-sparkline-history.json", tokenData, 0o644)
+			}
 		}
 	}
 }

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -276,7 +276,20 @@ func (s *Server) handleTrends(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	jsonResponse(w, filtered)
+	// Include token sparkline history within the requested time range
+	allTokenHistory := s.TokenSparklineHistory()
+	tokenFiltered := make([]TokenSparklineEntry, 0)
+	cutoffMs := cutoff.UnixMilli()
+	for _, entry := range allTokenHistory {
+		if entry.Timestamp > cutoffMs {
+			tokenFiltered = append(tokenFiltered, entry)
+		}
+	}
+
+	jsonResponse(w, map[string]interface{}{
+		"evals":        filtered,
+		"tokenHistory": tokenFiltered,
+	})
 }
 
 func (s *Server) handleTimeline(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -34,6 +34,9 @@ type Server struct {
 	pipelineMu     sync.RWMutex
 	hooksMu        sync.RWMutex
 	knowledgeMu    sync.Mutex
+
+	tokenHistoryMu sync.RWMutex
+	tokenHistory   []TokenSparklineEntry
 }
 
 // StatusPayload matches the JSON contract the dashboard frontend render() expects.
@@ -182,6 +185,22 @@ type FrontendHold struct {
 	Items  []any `json:"items"`
 }
 
+// TokenSparklineEntry is a single timestamped snapshot of token metrics,
+// persisted to disk so sparklines survive container restarts.
+type TokenSparklineEntry struct {
+	Timestamp    int64                       `json:"t"`
+	Input        int64                       `json:"tokenInput"`
+	Output       int64                       `json:"tokenOutput"`
+	CacheRead    int64                       `json:"tokenCacheRead"`
+	CacheCreate  int64                       `json:"tokenCacheCreate"`
+	Messages     int                         `json:"tokenMessages"`
+	ByAgent      map[string]int64            `json:"tokens,omitempty"`
+	ByModel      map[string]int64            `json:"tokenModels,omitempty"`
+}
+
+// tokenSparklineMaxEntries caps the on-disk history to ~24h at 5-min intervals.
+const tokenSparklineMaxEntries = 288
+
 const sseRetryMs = 3000
 
 func NewServer(port int, logger *slog.Logger) *Server {
@@ -265,6 +284,8 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 	status.Timestamp = time.Now().UTC().Format(time.RFC3339)
 	s.status = status
 	s.statusMu.Unlock()
+
+	s.AppendTokenSparkline(status)
 
 	data, err := json.Marshal(status)
 	if err != nil {
@@ -358,4 +379,56 @@ func (s *Server) broadcast(data []byte) {
 			// Client too slow — drop the event
 		}
 	}
+}
+
+// AppendTokenSparkline extracts token metrics from the current status and
+// appends a timestamped entry to the in-memory token sparkline history.
+func (s *Server) AppendTokenSparkline(status *StatusPayload) {
+	if status == nil {
+		return
+	}
+
+	entry := TokenSparklineEntry{
+		Timestamp:   time.Now().UnixMilli(),
+		Input:       status.Tokens.Totals.Input,
+		Output:      status.Tokens.Totals.Output,
+		CacheRead:   status.Tokens.Totals.CacheRead,
+		CacheCreate: status.Tokens.Totals.CacheCreate,
+		Messages:    status.Tokens.Totals.Messages,
+		ByAgent:     make(map[string]int64),
+		ByModel:     make(map[string]int64),
+	}
+
+	for name, bucket := range status.Tokens.ByAgent {
+		entry.ByAgent[name] = bucket.Input + bucket.Output + bucket.CacheRead
+	}
+	for name, bucket := range status.Tokens.ByModel {
+		entry.ByModel[name] = bucket.Input + bucket.Output + bucket.CacheRead
+	}
+
+	s.tokenHistoryMu.Lock()
+	s.tokenHistory = append(s.tokenHistory, entry)
+	if len(s.tokenHistory) > tokenSparklineMaxEntries {
+		s.tokenHistory = s.tokenHistory[len(s.tokenHistory)-tokenSparklineMaxEntries:]
+	}
+	s.tokenHistoryMu.Unlock()
+}
+
+// TokenSparklineHistory returns a copy of the current token sparkline history.
+func (s *Server) TokenSparklineHistory() []TokenSparklineEntry {
+	s.tokenHistoryMu.RLock()
+	defer s.tokenHistoryMu.RUnlock()
+	out := make([]TokenSparklineEntry, len(s.tokenHistory))
+	copy(out, s.tokenHistory)
+	return out
+}
+
+// SeedTokenSparklineHistory restores persisted token history on startup.
+func (s *Server) SeedTokenSparklineHistory(entries []TokenSparklineEntry) {
+	s.tokenHistoryMu.Lock()
+	defer s.tokenHistoryMu.Unlock()
+	if len(entries) > tokenSparklineMaxEntries {
+		entries = entries[len(entries)-tokenSparklineMaxEntries:]
+	}
+	s.tokenHistory = entries
 }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5930,7 +5930,7 @@ function burnAreaChart() {
       ).join('');
       const body = document.getElementById('config-body');
       body.innerHTML = '<div style="text-align:center;color:var(--muted);padding:40px">Loading…</div>';
-      loadConfigData(type, agentName).then(() => {
+      loadConfigData(type, agentName).finally(() => {
         if (!_configModalOpen) return;
         const dn = (_configState.data.general || {}).displayName;
         if (dn && type !== 'governor') {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2395,12 +2395,43 @@
     async function fetchHistory() {
       try {
         const r = await fetch('/api/history');
-        historyData = await r.json();
+        const evalEntries = await r.json();
+        // Merge server-side token sparkline history into eval entries by timestamp.
+        // Eval entries have governor fields; token entries have token fields.
+        // Match by closest timestamp so sparklines show both on page load.
+        const tokenHist = window._serverTokenHistory || [];
+        if (tokenHist.length > 0) {
+          for (const entry of (evalEntries || [])) {
+            const entryT = entry.t || 0;
+            // Find the token snapshot closest in time to this eval entry
+            let best = null;
+            let bestDelta = Infinity;
+            const MAX_MERGE_DELTA_MS = 60000; // 60s — only merge if within 1 minute
+            for (const th of tokenHist) {
+              const delta = Math.abs((th.t || 0) - entryT);
+              if (delta < bestDelta) {
+                bestDelta = delta;
+                best = th;
+              }
+            }
+            if (best && bestDelta < MAX_MERGE_DELTA_MS) {
+              entry.tokenInput = best.tokenInput || 0;
+              entry.tokenOutput = best.tokenOutput || 0;
+              entry.tokenCacheRead = best.tokenCacheRead || 0;
+              entry.tokenCacheCreate = best.tokenCacheCreate || 0;
+              entry.tokenMessages = best.tokenMessages || 0;
+              if (best.tokens) entry.tokens = best.tokens;
+              if (best.tokenModels) entry.tokenModels = best.tokenModels;
+            }
+          }
+        }
+        historyData = evalEntries || [];
       } catch (e) { /* ignore */ }
     }
     // Fetch history on load, then every 30s
     fetchHistory();
-    setInterval(fetchHistory, 30000);
+    const HISTORY_REFRESH_MS = 30000;
+    setInterval(fetchHistory, HISTORY_REFRESH_MS);
 
     function formatAge(sec) {
       if (sec < 0) return '—';
@@ -5843,11 +5874,18 @@ function burnAreaChart() {
     fetch('/api/status').then(r => r.json()).then(render).catch(console.error);
     // Fetch persistent trends for sparklines (day/week)
     window._trendData = [];
-    fetch('/api/trends?range=week').then(r => r.json()).then(d => { window._trendData = d; }).catch(() => {});
+    function applyTrends(d) {
+      // Trends API returns {evals: [...], tokenHistory: [...]}
+      const evals = d && d.evals ? d.evals : (Array.isArray(d) ? d : []);
+      window._trendData = evals;
+      // Cache token history from server for merging into historyData
+      window._serverTokenHistory = d && d.tokenHistory ? d.tokenHistory : [];
+    }
+    fetch('/api/trends?range=week').then(r => r.json()).then(applyTrends).catch(() => {});
     // Refresh trends every 15 min
     const TREND_REFRESH_MS = 900000;
     setInterval(() => {
-      fetch('/api/trends?range=week').then(r => r.json()).then(d => { window._trendData = d; }).catch(() => {});
+      fetch('/api/trends?range=week').then(r => r.json()).then(applyTrends).catch(() => {});
     }, TREND_REFRESH_MS);
     // Fetch 24h timeline for governor mode strip
     window._timelineData = [];


### PR DESCRIPTION
## Summary
- **Token sparkline persistence**: Server-side storage of token usage time-series data so sparklines survive container restarts
- **Config dialog fix**: General tab no longer gets stuck on "Loading..." 

## Token Sparkline Persistence

Previously, token usage sparklines (total tokens, input, output, cache read, cache create, messages, per-agent) only stored history in browser localStorage — lost on container restart. Governor sparklines persisted via `/data/sparkline-history.json` but token metrics had no equivalent.

**Changes:**
- `server.go`: New `TokenSparklineEntry` struct + ring buffer (288 entries = 24h at 5-min intervals). `AppendTokenSparkline()` called on every status update. `SeedTokenSparklineHistory()` restores from disk on startup.
- `api.go`: `/api/trends` now returns `{evals: [...], tokenHistory: [...]}` instead of just an array
- `main.go`: Reads/writes `/data/token-sparkline-history.json` alongside existing governor history persistence
- `index.html`: Dashboard fetches token history on load and merges into `historyData` before SSE starts appending

## Config Dialog Fix

Changed `loadConfigData().then()` to `.finally()` so `switchConfigTab` always fires, even if the promise rejects silently.

## Test plan
- [ ] Restart container → verify token sparklines show historical data on page load
- [ ] Open agent config dialog → General tab should load immediately (not stuck on Loading...)
- [ ] Verify governor sparklines still work (no regression)
- [ ] Check `/api/trends?range=week` returns both `evals` and `tokenHistory` fields