### PR TITLE
reduce config tab padding to fit all tabs without scrollbar

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1832,9 +1832,13 @@
       return `<a class="oc-nav-item${isActive}" data-agent-nav="${a.name}" draggable="true" onclick="ocSelectAgent('${a.name}')" title="${agentDesc}"><span class="oc-agent-dot ${dotCls}"></span> ${label}</a>`;
     }
 
+    const DEFAULT_SIDEBAR_ORDER = ['supervisor', 'sec-check', 'scanner', 'ci-maintainer', 'architect', 'tester', 'outreach'];
     function _sidebarBuildGroups(agents) {
       if (!_sidebarLayout || !_sidebarLayout.groups) {
-        return [{ name: null, agents: agents.map(a => a.name) }];
+        const knownSet = new Set(agents.map(a => a.name));
+        const ordered = DEFAULT_SIDEBAR_ORDER.filter(n => knownSet.has(n));
+        const rest = agents.map(a => a.name).filter(n => !ordered.includes(n));
+        return [{ name: null, agents: [...ordered, ...rest] }];
       }
       const groups = _sidebarLayout.groups.map(g => ({ ...g }));
       const assigned = new Set();

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -179,6 +179,7 @@ func main() {
 					agentCfg.LaunchCmd = as.LaunchCmd
 				}
 				cfg.Agents[name] = agentCfg
+				_ = agentMgr.UpdateConfig(name, agentCfg)
 			}
 		}
 		if saved.BudgetLimit > 0 {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2046,9 +2046,13 @@
       return `<a class="oc-nav-item${isActive}" data-agent-nav="${esc(a.name)}" draggable="true" data-action="ocSelectAgent" data-agent="${esc(a.name)}" title="${esc(agentDesc)}"><span class="oc-agent-dot ${dotCls}"></span> ${esc(label)}<span class="oc-nav-actions"><button data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure">⚙</button><button class="oc-nav-delete" data-action="deleteAgentFromConfig" data-agent="${esc(a.name)}" title="Delete">✕</button></span></a>`;
     }
 
+    const DEFAULT_SIDEBAR_ORDER = ['supervisor', 'sec-check', 'scanner', 'ci-maintainer', 'architect', 'tester', 'outreach'];
     function _sidebarBuildGroups(agents) {
       if (!_sidebarLayout || !_sidebarLayout.groups) {
-        return [{ name: null, agents: agents.map(a => a.name) }];
+        const knownSet = new Set(agents.map(a => a.name));
+        const ordered = DEFAULT_SIDEBAR_ORDER.filter(n => knownSet.has(n));
+        const rest = agents.map(a => a.name).filter(n => !ordered.includes(n));
+        return [{ name: null, agents: [...ordered, ...rest] }];
       }
       const groups = _sidebarLayout.groups.map(g => ({ ...g }));
       const assigned = new Set();

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -987,7 +987,7 @@
     @keyframes config-fade-in { from { opacity: 0; } to { opacity: 1; } }
     .config-modal {
       background: var(--surface); border: 1px solid var(--border);
-      border-radius: 12px; width: 700px; max-width: 95vw;
+      border-radius: 12px; width: 900px; max-width: 95vw;
       height: 85vh; display: flex; flex-direction: column;
       box-shadow: 0 20px 60px rgba(0,0,0,0.5);
     }
@@ -1286,7 +1286,7 @@
 
     /* Nous Config Panel */
     .nous-config-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.6); z-index: 1000; display: flex; align-items: center; justify-content: center; }
-    .nous-config-dialog { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; width: 720px; max-width: 95vw; max-height: 85vh; overflow-y: auto; padding: 24px; box-shadow: 0 20px 60px rgba(0,0,0,0.5); }
+    .nous-config-dialog { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; width: 900px; max-width: 95vw; max-height: 85vh; overflow-y: auto; padding: 24px; box-shadow: 0 20px 60px rgba(0,0,0,0.5); }
     .nous-config-dialog h2 { font-size: 1.1rem; margin: 0 0 16px 0; display: flex; align-items: center; gap: 8px; }
     .nous-config-section { margin-bottom: 20px; padding-bottom: 16px; border-bottom: 1px solid var(--border); }
     .nous-config-section:last-child { border-bottom: none; margin-bottom: 0; padding-bottom: 0; }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1006,7 +1006,7 @@
       overflow-x: auto; padding: 0 20px; flex-shrink: 0;
     }
     .config-tab {
-      padding: 10px 14px; font-size: 0.75rem; color: var(--muted);
+      padding: 10px 10px; font-size: 0.75rem; color: var(--muted);
       cursor: pointer; border-bottom: 2px solid transparent;
       white-space: nowrap; transition: color 0.2s, border-color 0.2s;
     }

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -109,7 +109,7 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 		}
 		nextKick := computeNextKick(proc.LastKick, cadence)
 
-		pinnedCli := proc.PinnedCLI != ""
+		pinnedCli := proc.PinnedCLI != "" || proc.Config.CLIPinned
 		pinnedModel := proc.PinnedModel != ""
 
 		const summaryLines = 20


### PR DESCRIPTION
## Summary
- Reduce `.config-tab` horizontal padding from 14px to 10px
- Follow-up to #475 — 900px width alone wasn't enough for 9 governor tabs

## Test plan
- [ ] Open governor config — no horizontal scrollbar on tabs