### PR TITLE
persist all critical state across container restarts

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -147,9 +147,11 @@ func main() {
 	agentMgr := agent.NewManager(cfg.EnabledAgents(), logger)
 
 	const statePath = "/data/hive-state.json"
+	var savedIssueCosts map[string]int64
 	if saved, err := snapshot.LoadState(statePath, logger); err != nil {
 		logger.Warn("failed to load persisted state", "error", err)
 	} else if saved != nil {
+		savedIssueCosts = saved.IssueCosts
 		for name, as := range saved.Agents {
 			if as.Paused {
 				_ = agentMgr.Pause(name)
@@ -165,6 +167,16 @@ func main() {
 			}
 			if as.BackendOverride != "" {
 				_ = agentMgr.SetBackendOverride(name, as.BackendOverride)
+			}
+			if as.LastKick != nil {
+				agentMgr.SeedLastKick(name, *as.LastKick)
+			}
+			if len(as.KickHistory) > 0 {
+				records := make([]agent.KickRecord, len(as.KickHistory))
+				for i, ke := range as.KickHistory {
+					records[i] = agent.KickRecord{Timestamp: ke.Timestamp, Agent: ke.Agent, Snippet: ke.Snippet}
+				}
+				agentMgr.SeedKickHistory(name, records)
 			}
 			if agentCfg, ok := cfg.Agents[name]; ok {
 				if as.DisplayName != "" {
@@ -211,6 +223,29 @@ func main() {
 			}
 			cfg.Governor.Modes[modeName] = mode
 		}
+		if saved.GovernorMode != "" {
+			gov.SetMode(governor.Mode(saved.GovernorMode))
+			logger.Info("governor mode restored", "mode", saved.GovernorMode)
+		}
+		if len(saved.LastKicks) > 0 {
+			gov.SeedLastKicks(saved.LastKicks)
+			logger.Info("governor last kicks restored", "agents", len(saved.LastKicks))
+		}
+		if saved.BudgetSpend > 0 || !saved.BudgetResetAt.IsZero() || len(saved.BudgetByAgent) > 0 {
+			gov.SeedBudget(saved.BudgetSpend, saved.BudgetByAgent, saved.BudgetByModel, saved.BudgetResetAt)
+			logger.Info("budget state restored", "spend", saved.BudgetSpend, "reset_at", saved.BudgetResetAt)
+		}
+		if len(saved.KickHistory) > 0 {
+			records := make([]governor.KickRecord, len(saved.KickHistory))
+			for i, ke := range saved.KickHistory {
+				records[i] = governor.KickRecord{Timestamp: ke.Timestamp, Agent: ke.Agent}
+			}
+			gov.SeedKickHistory(records)
+			logger.Info("kick history restored", "entries", len(records))
+		}
+		if !saved.LastEval.IsZero() {
+			gov.SeedLastEval(saved.LastEval)
+		}
 	}
 
 	if gov.GetBudget().WeeklyLimit == 0 && cfg.Governor.Budget.TotalTokens > 0 {
@@ -242,6 +277,10 @@ func main() {
 	tokenCollector := tokens.NewCollector(cfg.Data.MetricsDir, logger)
 	tokenCollector.SetClaudeSessionsDir(cfg.Data.ClaudeSessionsDir)
 	tokenCollector.SetCopilotSessionsDir(cfg.Data.CopilotSessionsDir)
+	if len(savedIssueCosts) > 0 {
+		tokenCollector.SeedIssueCosts(savedIssueCosts)
+		logger.Info("issue costs restored", "entries", len(savedIssueCosts))
+	}
 	tokenStop := make(chan struct{})
 	go tokenCollector.Start(tokenStop)
 	defer close(tokenStop)
@@ -349,7 +388,7 @@ func main() {
 		Ctx:              ctx,
 		RefreshFunc:      refreshDashboard,
 		PersistFunc: func() {
-			persistState(agentMgr, gov, cfg, statePath, logger, dashSrv)
+			persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
 		},
 	})
 
@@ -413,17 +452,17 @@ func main() {
 	}
 
 	runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, logger)
-	persistState(agentMgr, gov, cfg, statePath, logger, dashSrv)
+	persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
 
 	for {
 		select {
 		case <-ctx.Done():
 			logger.Info("shutting down, persisting state")
-			persistState(agentMgr, gov, cfg, statePath, logger, dashSrv)
+			persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
 			return
 		case <-ticker.C:
 			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, logger)
-			persistState(agentMgr, gov, cfg, statePath, logger, dashSrv)
+			persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
 		}
 	}
 }
@@ -680,7 +719,7 @@ func randomName() string {
 	return adj + "-" + noun
 }
 
-func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.Config, path string, logger *slog.Logger, dashSrv *dashboard.Server) {
+func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.Config, tc *tokens.Collector, path string, logger *slog.Logger, dashSrv *dashboard.Server) {
 	statuses := agentMgr.AllStatuses()
 	agents := make(map[string]snapshot.AgentState, len(statuses))
 	for name, proc := range statuses {
@@ -691,6 +730,17 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 			ModelOverride:   proc.ModelOverride,
 			BackendOverride: proc.BackendOverride,
 			RestartCount:    proc.RestartCount,
+			LastKick:        proc.LastKick,
+		}
+		if len(proc.KickHistory) > 0 {
+			as.KickHistory = make([]snapshot.AgentKickEntry, len(proc.KickHistory))
+			for i, kr := range proc.KickHistory {
+				as.KickHistory[i] = snapshot.AgentKickEntry{
+					Timestamp: kr.Timestamp,
+					Agent:     kr.Agent,
+					Snippet:   kr.Snippet,
+				}
+			}
 		}
 		if agentCfg, ok := cfg.Agents[name]; ok {
 			as.DisplayName = agentCfg.DisplayName
@@ -718,12 +768,33 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 	}
 
 	budget := gov.GetBudget()
+	govState := gov.GetState()
+
+	govKickHistory := gov.KickHistory()
+	kickEntries := make([]snapshot.GovKickEntry, len(govKickHistory))
+	for i, kr := range govKickHistory {
+		kickEntries[i] = snapshot.GovKickEntry{Timestamp: kr.Timestamp, Agent: kr.Agent}
+	}
+
+	var issueCosts map[string]int64
+	if tc != nil {
+		issueCosts = tc.IssueCosts()
+	}
+
 	state := &snapshot.PersistedState{
 		Agents:           agents,
-		GovernorMode:     string(gov.GetState().Mode),
+		GovernorMode:     string(govState.Mode),
 		BudgetLimit:      budget.WeeklyLimit,
 		BudgetIgnored:    budget.IgnoredAgents,
 		CadenceOverrides: cadenceOverrides,
+		LastKicks:        govState.LastKick,
+		BudgetSpend:      budget.CurrentSpend,
+		BudgetResetAt:    budget.ResetAt,
+		BudgetByAgent:    budget.ByAgent,
+		BudgetByModel:    budget.ByModel,
+		KickHistory:      kickEntries,
+		IssueCosts:       issueCosts,
+		LastEval:         govState.LastEval,
 	}
 
 	if err := snapshot.SaveState(path, state, logger); err != nil {

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -438,6 +438,26 @@ const (
 	staleCheckDelay       = 1 * time.Second
 )
 
+func (m *Manager) SeedLastKick(name string, t time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if agent, ok := m.agents[name]; ok {
+		agent.LastKick = &t
+	}
+}
+
+func (m *Manager) SeedKickHistory(name string, records []KickRecord) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if agent, ok := m.agents[name]; ok {
+		if len(records) > kickHistoryCapacity {
+			records = records[len(records)-kickHistoryCapacity:]
+		}
+		agent.KickHistory = make([]KickRecord, len(records))
+		copy(agent.KickHistory, records)
+	}
+}
+
 func (m *Manager) GetStatus(name string) (*AgentProcess, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -395,6 +395,49 @@ func (g *Governor) SeedQueueState(issues, prs, hold, slaViolations int) {
 	g.state.SLAViolations = slaViolations
 }
 
+func (g *Governor) SeedLastKicks(kicks map[string]time.Time) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for k, v := range kicks {
+		g.state.LastKick[k] = v
+	}
+}
+
+func (g *Governor) SeedKickHistory(records []KickRecord) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if len(records) > kickHistoryCapacity {
+		records = records[len(records)-kickHistoryCapacity:]
+	}
+	g.kickHistory = make([]KickRecord, len(records), kickHistoryCapacity)
+	copy(g.kickHistory, records)
+}
+
+func (g *Governor) SeedBudget(spend int64, byAgent map[string]int64, byModel map[string]int64, resetAt time.Time) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.budget.CurrentSpend = spend
+	for k, v := range byAgent {
+		g.budget.ByAgent[k] = v
+	}
+	for k, v := range byModel {
+		g.budget.ByModel[k] = v
+	}
+	g.budget.ResetAt = resetAt
+}
+
+func (g *Governor) SetMode(m Mode) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.state.Mode = m
+}
+
+func (g *Governor) SeedLastEval(t time.Time) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.state.LastEval = t
+}
+
 func (g *Governor) KickHistory() []KickRecord {
 	g.mu.RLock()
 	defer g.mu.RUnlock()

--- a/v2/pkg/snapshot/state.go
+++ b/v2/pkg/snapshot/state.go
@@ -17,22 +17,43 @@ type PersistedState struct {
 	BudgetLimit      int64                            `json:"budget_limit"`
 	BudgetIgnored    []string                         `json:"budget_ignored"`
 	CadenceOverrides map[string]map[string]string     `json:"cadence_overrides,omitempty"`
+	LastKicks        map[string]time.Time             `json:"last_kicks,omitempty"`
+	BudgetSpend      int64                            `json:"budget_spend,omitempty"`
+	BudgetResetAt    time.Time                        `json:"budget_reset_at,omitempty"`
+	BudgetByAgent    map[string]int64                 `json:"budget_by_agent,omitempty"`
+	BudgetByModel    map[string]int64                 `json:"budget_by_model,omitempty"`
+	KickHistory      []GovKickEntry                   `json:"kick_history,omitempty"`
+	IssueCosts       map[string]int64                 `json:"issue_costs,omitempty"`
+	LastEval         time.Time                        `json:"last_eval,omitempty"`
 }
 
 type AgentState struct {
-	Paused          bool   `json:"paused"`
-	PinnedCLI       string `json:"pinned_cli,omitempty"`
-	PinnedModel     string `json:"pinned_model,omitempty"`
-	ModelOverride   string `json:"model_override,omitempty"`
-	BackendOverride string `json:"backend_override,omitempty"`
-	RestartCount    int    `json:"restart_count"`
-	DisplayName     string `json:"display_name,omitempty"`
-	Description     string `json:"description,omitempty"`
-	Enabled         *bool  `json:"enabled,omitempty"`
-	ClearOnKick     *bool  `json:"clear_on_kick,omitempty"`
-	StaleTimeout    *int   `json:"stale_timeout,omitempty"`
-	RestartStrategy string `json:"restart_strategy,omitempty"`
-	LaunchCmd       string `json:"launch_cmd,omitempty"`
+	Paused          bool             `json:"paused"`
+	PinnedCLI       string           `json:"pinned_cli,omitempty"`
+	PinnedModel     string           `json:"pinned_model,omitempty"`
+	ModelOverride   string           `json:"model_override,omitempty"`
+	BackendOverride string           `json:"backend_override,omitempty"`
+	RestartCount    int              `json:"restart_count"`
+	DisplayName     string           `json:"display_name,omitempty"`
+	Description     string           `json:"description,omitempty"`
+	Enabled         *bool            `json:"enabled,omitempty"`
+	ClearOnKick     *bool            `json:"clear_on_kick,omitempty"`
+	StaleTimeout    *int             `json:"stale_timeout,omitempty"`
+	RestartStrategy string           `json:"restart_strategy,omitempty"`
+	LaunchCmd       string           `json:"launch_cmd,omitempty"`
+	LastKick        *time.Time       `json:"last_kick,omitempty"`
+	KickHistory     []AgentKickEntry `json:"kick_history,omitempty"`
+}
+
+type GovKickEntry struct {
+	Timestamp time.Time `json:"timestamp"`
+	Agent     string    `json:"agent"`
+}
+
+type AgentKickEntry struct {
+	Timestamp time.Time `json:"timestamp"`
+	Agent     string    `json:"agent"`
+	Snippet   string    `json:"snippet"`
 }
 
 func SaveState(path string, state *PersistedState, logger *slog.Logger) error {

--- a/v2/pkg/tokens/collector.go
+++ b/v2/pkg/tokens/collector.go
@@ -165,6 +165,14 @@ func (c *Collector) Summary() *AggregateSummary {
 	return c.latest
 }
 
+func (c *Collector) SeedIssueCosts(costs map[string]int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for k, v := range costs {
+		c.issueCosts[k] = v
+	}
+}
+
 func (c *Collector) IssueCosts() map[string]int64 {
 	c.mu.RLock()
 	defer c.mu.RUnlock()


### PR DESCRIPTION
## Summary
- Persist 11 previously lost state items to `hive-state.json` so they survive container rebuilds
- **Critical fix**: Governor `LastKick` per agent now persisted — prevents all agents from being immediately kicked on restart (root cause of architect being kicked more often than its 2h cadence)
- Governor mode now restored on startup (was saved but never loaded back)
- Full budget state preserved: CurrentSpend, ResetAt, ByAgent, ByModel
- Per-agent LastKick timestamps and KickHistory (last 50 per agent)
- Governor-level KickHistory (last 500 entries) for audit trail
- Token collector issueCosts for per-issue cost attribution
- Governor LastEval timestamp for observability

Items 12-13 (cadences, output buffer) intentionally not persisted — cadences recompute on first eval cycle, output buffer is too large and repopulated from tmux polling.

## Files changed
- `pkg/snapshot/state.go` — expanded PersistedState and AgentState structs with new fields
- `pkg/governor/governor.go` — added SeedLastKicks, SeedKickHistory, SeedBudget, SetMode, SeedLastEval
- `pkg/agent/manager.go` — added SeedLastKick, SeedKickHistory
- `pkg/tokens/collector.go` — added SeedIssueCosts
- `cmd/hive/main.go` — updated persistState() and restore block

## Test plan
- [ ] Build passes
- [ ] Deploy to 4.78, verify `/data/hive-state.json` contains new fields
- [ ] Trigger container rebuild, verify budget bar retains values
- [ ] Verify governor mode stays correct (not IDLE) after restart
- [ ] Verify agents are NOT immediately kicked after restart
- [ ] Verify architect respects 2h cadence across restarts