### PR TITLE
fix: use curl instead of wget for healthchecks

### DIFF
--- a/v2/deploy/blue-green-deploy.sh
+++ b/v2/deploy/blue-green-deploy.sh
@@ -38,7 +38,7 @@ if [ -z "$GATEWAY_RUNNING" ]; then
     log "Waiting for hive to become healthy..."
     elapsed=0
     while [ "$elapsed" -lt "$HEALTH_TIMEOUT_S" ]; do
-        if wget -q --spider "$HEALTH_URL" 2>/dev/null; then
+        if curl -sf "$HEALTH_URL" >/dev/null 2>/dev/null; then
             log "Hive is healthy. Deploy complete."
             exit 0
         fi
@@ -80,7 +80,7 @@ docker run -d \
     -v "${DATA_VOL}:/data" \
     -v "${SECRETS_DIR}:/secrets:ro" \
     $ENV_ARGS \
-    --health-cmd "wget -q --spider http://localhost:3001/api/health" \
+    --health-cmd "curl -sf http://localhost:3001/api/health" \
     --health-interval 10s \
     --health-timeout 5s \
     --health-retries 3 \

--- a/v2/docker-compose.yaml
+++ b/v2/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       hive:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3001/api/health"]
+      test: ["CMD", "curl", "-sf", "http://localhost:3001/api/health"]
       interval: 10s
       timeout: 5s
       retries: 3
@@ -40,7 +40,7 @@ services:
       - NTFY_SERVER=${NTFY_SERVER}
       - NTFY_TOPIC=${NTFY_TOPIC}
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3001/api/health"]
+      test: ["CMD", "curl", "-sf", "http://localhost:3001/api/health"]
       interval: 10s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary
- Hive container has curl but not wget — healthchecks were failing
- Switch docker-compose.yaml and blue-green-deploy.sh from wget to curl

## Test plan
- [x] Verified on 4.78 — both containers now healthy