### PR TITLE
feat: readiness gate — block traffic until first eval completes

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -453,6 +453,7 @@ func main() {
 
 	runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, logger)
 	persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
+	dashSrv.MarkReady()
 
 	for {
 		select {

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -37,6 +37,8 @@ type Server struct {
 
 	tokenHistoryMu sync.RWMutex
 	tokenHistory   []TokenSparklineEntry
+
+	ready bool
 }
 
 // StatusPayload matches the JSON contract the dashboard frontend render() expects.
@@ -298,7 +300,7 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	s.statusMu.RLock()
-	ready := s.status != nil
+	ready := s.status != nil && s.ready
 	s.statusMu.RUnlock()
 
 	w.Header().Set("Content-Type", "application/json")
@@ -308,6 +310,13 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (s *Server) MarkReady() {
+	s.statusMu.Lock()
+	s.ready = true
+	s.statusMu.Unlock()
+	s.logger.Info("dashboard marked ready")
 }
 
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Add `ready` flag to dashboard server, set after first governor eval cycle
- Health endpoint returns 503 until `MarkReady()` is called
- Nginx gateway won't route traffic to a container still initializing
- Users see nothing until the dashboard is fully populated

## Test plan
- [ ] Container healthcheck stays unhealthy during startup (~10-15s)
- [ ] Gateway doesn't start until hive is healthy
- [ ] Dashboard loads fully on first visit after deploy