### PR TITLE
feat: central logging with rolling files and config UI

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -6,14 +6,18 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"gopkg.in/natefinch/lumberjack.v2"
 
 	"github.com/kubestellar/hive/v2/pkg/agent"
 	"github.com/kubestellar/hive/v2/pkg/beads"
@@ -48,6 +52,12 @@ func main() {
 		logger.Error("failed to load config", "error", err)
 		os.Exit(1)
 	}
+
+	// Reconfigure logger with rolling file output
+	logger = setupLogger(cfg.Governor.Logging.Dir, cfg.Governor.Logging.MaxSizeMB,
+		cfg.Governor.Logging.MaxAgeDays, cfg.Governor.Logging.MaxBackups,
+		cfg.Governor.Logging.Compress, cfg.Governor.Logging.Level)
+	slog.SetDefault(logger)
 
 	// Load or generate a unique Hive ID for this instance
 	cfg.HiveID = loadOrGenerateHiveID(logger)
@@ -923,5 +933,38 @@ func confidenceToFloat(s string) float64 {
 		return 0.4
 	default:
 		return 0.5
+	}
+}
+
+const logFilename = "hive.log"
+
+func setupLogger(dir string, maxSizeMB, maxAgeDays, maxBackups int, compress bool, level string) *slog.Logger {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		slog.Warn("failed to create log directory, falling back to stdout only", "dir", dir, "error", err)
+		return slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: parseLogLevel(level)}))
+	}
+
+	lj := &lumberjack.Logger{
+		Filename:   filepath.Join(dir, logFilename),
+		MaxSize:    maxSizeMB,
+		MaxAge:     maxAgeDays,
+		MaxBackups: maxBackups,
+		Compress:   compress,
+	}
+
+	tee := io.MultiWriter(os.Stdout, lj)
+	return slog.New(slog.NewJSONHandler(tee, &slog.HandlerOptions{Level: parseLogLevel(level)}))
+}
+
+func parseLogLevel(s string) slog.Level {
+	switch strings.ToLower(s) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
 	}
 }

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-github/v72 v72.0.0
 	github.com/google/uuid v1.6.0
+	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -12,5 +12,7 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
+gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -113,6 +113,16 @@ type GovernorConfig struct {
 	Sensing       SensingConfig         `yaml:"sensing"`
 	Health        HealthConfig          `yaml:"health"`
 	Budget        BudgetConfig          `yaml:"budget"`
+	Logging       LoggingConfig         `yaml:"logging"`
+}
+
+type LoggingConfig struct {
+	Dir        string `yaml:"dir"`
+	MaxSizeMB  int    `yaml:"max_size_mb"`
+	MaxAgeDays int    `yaml:"max_age_days"`
+	MaxBackups int    `yaml:"max_backups"`
+	Compress   bool   `yaml:"compress"`
+	Level      string `yaml:"level"`
 }
 
 type LabelsConfig struct {
@@ -371,6 +381,10 @@ const (
 	defaultRestartCooldownS       = 60
 	defaultBudgetPeriodDays       = 7
 	defaultBudgetCriticalPct      = 90
+	defaultLogMaxSizeMB           = 50
+	defaultLogMaxAgeDays          = 7
+	defaultLogMaxBackups          = 10
+	defaultLogLevel               = "info"
 )
 
 func (c *Config) applyDefaults() {
@@ -465,6 +479,24 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Governor.Budget.CriticalPct == 0 {
 		c.Governor.Budget.CriticalPct = defaultBudgetCriticalPct
+	}
+	if c.Governor.Logging.Dir == "" {
+		c.Governor.Logging.Dir = c.Data.LogsDir
+	}
+	if c.Governor.Logging.MaxSizeMB == 0 {
+		c.Governor.Logging.MaxSizeMB = defaultLogMaxSizeMB
+	}
+	if c.Governor.Logging.MaxAgeDays == 0 {
+		c.Governor.Logging.MaxAgeDays = defaultLogMaxAgeDays
+	}
+	if c.Governor.Logging.MaxBackups == 0 {
+		c.Governor.Logging.MaxBackups = defaultLogMaxBackups
+	}
+	if !c.Governor.Logging.Compress {
+		c.Governor.Logging.Compress = true
+	}
+	if c.Governor.Logging.Level == "" {
+		c.Governor.Logging.Level = defaultLogLevel
 	}
 
 	if c.Knowledge.Enabled {

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -65,6 +65,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("PUT /api/config/governor/budget", s.handleGovernorBudget)
 	s.mux.HandleFunc("PUT /api/config/governor/notifications", s.handleGovernorNotifications)
 	s.mux.HandleFunc("PUT /api/config/governor/health", s.handleGovernorHealth)
+	s.mux.HandleFunc("PUT /api/config/governor/logging", s.handleGovernorLogging)
 	s.mux.HandleFunc("POST /api/config/governor/agents", s.handleGovernorAddAgent)
 	s.mux.HandleFunc("DELETE /api/config/governor/agents/{name}", s.handleGovernorRemoveAgent)
 	s.mux.HandleFunc("PUT /api/config/governor/repos", s.handleGovernorRepos)
@@ -1323,6 +1324,14 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			"ttlSeconds":         cfg.Governor.Sensing.TTLSeconds,
 			"pullbackSeconds":    cfg.Governor.Sensing.PullbackSeconds,
 		},
+		"logging": map[string]interface{}{
+			"dir":        cfg.Governor.Logging.Dir,
+			"maxSizeMB":  cfg.Governor.Logging.MaxSizeMB,
+			"maxAgeDays": cfg.Governor.Logging.MaxAgeDays,
+			"maxBackups": cfg.Governor.Logging.MaxBackups,
+			"compress":   cfg.Governor.Logging.Compress,
+			"level":      cfg.Governor.Logging.Level,
+		},
 	})
 }
 
@@ -1469,6 +1478,37 @@ func (s *Server) handleGovernorHealth(w http.ResponseWriter, r *http.Request) {
 		s.deps.Config.Governor.Health.RestartCooldown = body.RestartCooldown
 	}
 	s.deps.Config.Governor.Health.ModelLock = body.ModelLock
+	s.refreshAndPersist()
+	okResponse(w, map[string]string{"status": "updated"})
+}
+
+func (s *Server) handleGovernorLogging(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		MaxSizeMB  int    `json:"maxSizeMB"`
+		MaxAgeDays int    `json:"maxAgeDays"`
+		MaxBackups int    `json:"maxBackups"`
+		Compress   *bool  `json:"compress"`
+		Level      string `json:"level"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	if body.MaxSizeMB > 0 {
+		s.deps.Config.Governor.Logging.MaxSizeMB = body.MaxSizeMB
+	}
+	if body.MaxAgeDays > 0 {
+		s.deps.Config.Governor.Logging.MaxAgeDays = body.MaxAgeDays
+	}
+	if body.MaxBackups > 0 {
+		s.deps.Config.Governor.Logging.MaxBackups = body.MaxBackups
+	}
+	if body.Compress != nil {
+		s.deps.Config.Governor.Logging.Compress = *body.Compress
+	}
+	if body.Level != "" {
+		s.deps.Config.Governor.Logging.Level = body.Level
+	}
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})
 }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5906,7 +5906,7 @@ function burnAreaChart() {
     let _configState = { type: null, agent: null, tab: null, data: {}, dirty: {} };
 
     const AGENT_CONFIG_TABS = ['General', 'Cadences', 'Pipeline', 'Hooks', 'Restrictions', 'Stats', 'Prompt Template', 'Last Prompt'];
-    const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing'];
+    const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging'];
     const PIPELINE_STAGES = ['resolve-beads', 'track-prs', 'stale-check', 'repo-scan', 'coverage-gate', 'prompt-compose', 'budget-check', 'api-collect', 'final-compose'];
     const PIPELINE_STAGE_TIPS = {
       'resolve-beads': 'Fetch and inject knowledge beads (facts, patterns, gotchas) relevant to the agent\'s current task context.',
@@ -6012,6 +6012,7 @@ function burnAreaChart() {
         case 'Notifications': return renderGovNotifications(d.notifications || {});
         case 'Health': return renderGovHealth(d.health || {});
         case 'Sensing': return renderGovSensing(d.sensing || {});
+        case 'Logging': return renderGovLogging(d.logging || {});
         default: return '';
       }
     }
@@ -6625,6 +6626,31 @@ function burnAreaChart() {
         <div class="config-field-row">
           <div class="config-field"><label>Alert TTL (sec) <span class="config-info">i<span class="config-tooltip">How long a rate-limit alert stays active before auto-clearing. Default is 900 seconds (15 minutes). After this time, the agent is considered safe to kick again.</span></span></label><input type="number" value="${s.ttlSeconds || 900}" onchange="markDirty('sensing','ttlSeconds',Number(this.value))"></div>
           <div class="config-field"><label>Pullback Duration (sec) <span class="config-info">i<span class="config-tooltip">How long to pause an agent after detecting a rate limit. During pullback, the governor skips kicks for this agent. Default is 900 seconds (15 minutes).</span></span></label><input type="number" value="${s.pullbackSeconds || 900}" onchange="markDirty('sensing','pullbackSeconds',Number(this.value))"></div>
+        </div>`;
+    }
+
+    function renderGovLogging(l) {
+      const levels = ['debug', 'info', 'warn', 'error'];
+      return `
+        <div class="config-field">
+          <label>Log Directory <span class="config-info">i<span class="config-tooltip">Directory where rolling log files are written. Stored on the persistent /data volume so logs survive container restarts. Read-only at runtime — change in hive.yaml and restart.</span></span></label>
+          <input type="text" value="${esc(l.dir || '/data/logs')}" disabled style="opacity:0.6">
+        </div>
+        <div class="config-field-row">
+          <div class="config-field"><label>Max File Size (MB) <span class="config-info">i<span class="config-tooltip">Maximum size of a single log file before rotation. When reached, the current file is rotated and a new one starts. Default 50 MB.</span></span></label><input type="number" value="${l.maxSizeMB || 50}" onchange="markDirty('logging','maxSizeMB',Number(this.value))"></div>
+          <div class="config-field"><label>Retention (days) <span class="config-info">i<span class="config-tooltip">How many days to keep rotated log files. Files older than this are automatically deleted by lumberjack. Default 7 days.</span></span></label><input type="number" value="${l.maxAgeDays || 7}" onchange="markDirty('logging','maxAgeDays',Number(this.value))"></div>
+        </div>
+        <div class="config-field-row">
+          <div class="config-field"><label>Max Backups <span class="config-info">i<span class="config-tooltip">Maximum number of rotated log files to keep. Works alongside retention days — whichever limit is hit first triggers cleanup. Default 10 files.</span></span></label><input type="number" value="${l.maxBackups || 10}" onchange="markDirty('logging','maxBackups',Number(this.value))"></div>
+          <div class="config-field"><label>Log Level <span class="config-info">i<span class="config-tooltip">Minimum severity level for log output. DEBUG includes all messages. INFO is the default operational level. WARN and ERROR reduce noise. Takes effect on next container restart.</span></span></label>
+            <select onchange="markDirty('logging','level',this.value)">
+              ${levels.map(lv => '<option value="' + lv + '" ' + ((l.level||'info')===lv?'selected':'') + '>' + lv.toUpperCase() + '</option>').join('')}
+            </select>
+          </div>
+        </div>
+        <div class="config-toggle">
+          <div class="config-toggle-switch ${l.compress !== false ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="logging" data-key="compress"></div>
+          <span class="config-toggle-label">Compress Rotated Files <span class="config-info">i<span class="config-tooltip">Gzip-compress rotated log files to save disk space. Typically reduces log file size by ~90%. Enabled by default.</span></span></span>
         </div>`;
     }
 


### PR DESCRIPTION
## Summary
- Adds `lumberjack`-based rolling log files that tee all slog output to both stdout and `/data/logs/hive.log`
- New **Logging** tab in the governor config dialog with controls for max file size, retention days, max backups, log level, and compression
- New `PUT /api/config/governor/logging` endpoint follows existing config handler pattern
- Defaults: 50MB max file size, 7-day retention, 10 max backups, gzip compression, INFO level
- Log directory is read-only at runtime (set in hive.yaml); all other settings are configurable via the dashboard

## Test plan
- [ ] Build succeeds: `cd v2 && go build ./cmd/hive/`
- [ ] Deploy to 4.78, verify `/data/logs/hive.log` is created with JSON structured logs
- [ ] Open governor config dialog → Logging tab renders with all fields
- [ ] Change retention to 14 days → save → reopen → value persisted
- [ ] Container restart preserves log files on /data volume