### PR TITLE
fix: blue-green deploy rename approach + sync refresh

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -453,6 +453,7 @@ func main() {
 
 	runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, logger)
 	persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
+	dashSrv.MarkReady()
 
 	for {
 		select {

--- a/v2/deploy/blue-green-deploy.sh
+++ b/v2/deploy/blue-green-deploy.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Blue-green deploy for Hive v2.
 # Builds the new image, starts it alongside the old container,
-# waits for the healthcheck to pass, then swaps traffic via nginx reload.
+# waits for the healthcheck to pass, then swaps by renaming containers.
+# Nginx resolves "hive" via Docker DNS — no config file changes needed.
 #
 # Usage: ./blue-green-deploy.sh [--skip-build]
 
@@ -28,8 +29,6 @@ if [ "$SKIP_BUILD" = false ]; then
 fi
 
 # ── 2. Determine active slot ────────────────────────────────────────
-# The active container is whichever one nginx currently points at.
-# On first run (no gateway), we just do a normal start.
 GATEWAY_RUNNING=$(docker ps -q -f name=hive-gateway 2>/dev/null || true)
 
 if [ -z "$GATEWAY_RUNNING" ]; then
@@ -51,31 +50,27 @@ if [ -z "$GATEWAY_RUNNING" ]; then
 fi
 
 # ── 3. Start new container alongside old one ────────────────────────
-# We use docker run directly to avoid compose tearing down the old one.
 log "Starting new container as hive-next..."
 
-# Get the image name compose would use
 IMAGE=$(docker compose config --images | grep hive | head -1)
 
-# Collect env vars from compose
 ENV_ARGS=""
 for var in HIVE_GITHUB_TOKEN HIVE_DASHBOARD_TOKEN NTFY_SERVER NTFY_TOPIC; do
     val="${!var:-}"
     ENV_ARGS="$ENV_ARGS -e $var=$val"
 done
 
-# Get the data volume name
 DATA_VOL=$(docker inspect hive --format '{{range .Mounts}}{{if eq .Destination "/data"}}{{.Name}}{{end}}{{end}}' 2>/dev/null || echo "v2_hive-data")
-
-# Get the hive.yaml and secrets paths from the running container
 HIVE_YAML=$(docker inspect hive --format '{{range .Mounts}}{{if eq .Destination "/etc/hive/hive.yaml"}}{{.Source}}{{end}}{{end}}' 2>/dev/null)
 SECRETS_DIR=$(docker inspect hive --format '{{range .Mounts}}{{if eq .Destination "/secrets"}}{{.Source}}{{end}}{{end}}' 2>/dev/null)
 
 docker rm -f hive-next 2>/dev/null || true
 
+NETWORK=$(docker inspect hive-gateway --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}}{{end}}' | head -1)
+
 docker run -d \
     --name hive-next \
-    --network "$(docker inspect hive-gateway --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}}{{end}}' | head -1)" \
+    --network "$NETWORK" \
     -v "${HIVE_YAML}:/etc/hive/hive.yaml:ro" \
     -v "${DATA_VOL}:/data" \
     -v "${SECRETS_DIR}:/secrets:ro" \
@@ -114,21 +109,9 @@ if [ "$elapsed" -ge "$HEALTH_TIMEOUT_S" ]; then
     exit 1
 fi
 
-# ── 5. Swap traffic: point nginx at hive-next ───────────────────────
-log "Swapping traffic to hive-next..."
-
-# Update nginx upstream to point at hive-next
-NGINX_CONF="/tmp/nginx-swap.conf"
-sed 's/server hive:/server hive-next:/g' deploy/nginx.conf > "$NGINX_CONF"
-docker cp "$NGINX_CONF" hive-gateway:/etc/nginx/nginx.conf
-rm -f "$NGINX_CONF"
-
-# Reload nginx (zero-downtime)
-docker exec hive-gateway nginx -s reload
-log "Traffic switched to hive-next."
-
-# ── 6. Stop old container, rename new one ────────────────────────────
-sleep 2
+# ── 5. Swap: stop old, rename new, reload nginx ─────────────────────
+# Nginx upstream points at "hive" by name. Docker DNS resolves container
+# names, so after rename + reload, traffic goes to the new container.
 log "Stopping old hive container..."
 docker stop hive 2>/dev/null || true
 docker rm hive 2>/dev/null || true
@@ -136,8 +119,18 @@ docker rm hive 2>/dev/null || true
 log "Renaming hive-next → hive..."
 docker rename hive-next hive
 
-# Restore nginx config to use "hive" name
-docker cp deploy/nginx.conf hive-gateway:/etc/nginx/nginx.conf
+# Reload nginx so it re-resolves "hive" via Docker DNS
 docker exec hive-gateway nginx -s reload
 
-log "Deploy complete. New version is live."
+log "Waiting for gateway to confirm new backend..."
+elapsed=0
+while [ "$elapsed" -lt 60 ]; do
+    if curl -sf "$HEALTH_URL" >/dev/null 2>/dev/null; then
+        log "Deploy complete. New version is live."
+        exit 0
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+done
+
+log "WARN: Gateway health check didn't pass within 60s, but swap completed."

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -156,7 +156,7 @@ func okResponse(w http.ResponseWriter, extra map[string]string) {
 
 func (s *Server) refreshAfterMutation() {
 	if s.deps != nil && s.deps.RefreshFunc != nil {
-		go s.deps.RefreshFunc()
+		s.deps.RefreshFunc()
 	}
 }
 

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -37,6 +37,8 @@ type Server struct {
 
 	tokenHistoryMu sync.RWMutex
 	tokenHistory   []TokenSparklineEntry
+
+	ready bool
 }
 
 // StatusPayload matches the JSON contract the dashboard frontend render() expects.
@@ -298,7 +300,7 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	s.statusMu.RLock()
-	ready := s.status != nil
+	ready := s.status != nil && s.ready
 	s.statusMu.RUnlock()
 
 	w.Header().Set("Content-Type", "application/json")
@@ -308,6 +310,13 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (s *Server) MarkReady() {
+	s.statusMu.Lock()
+	s.ready = true
+	s.statusMu.Unlock()
+	s.logger.Info("dashboard marked ready")
 }
 
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Deploy script: use container rename + nginx reload instead of config file swap (bind-mount is read-only)
- Config refresh: synchronous so display name changes appear immediately
- Readiness gate: health endpoint returns 503 until first governor eval

## Test plan
- [ ] Run 25 consecutive blue-green deploys without failure