### PR TITLE
fix: sparkline delta normalization for cumulative token values

### DIFF
--- a/v2/pkg/dashboard/api_coverage_test.go
+++ b/v2/pkg/dashboard/api_coverage_test.go
@@ -1017,6 +1017,7 @@ func TestSecurityHeaders_HealthNoAuth(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	s := NewServerWithAuth(0, "secret", logger)
 	s.UpdateStatus(&StatusPayload{Agents: []FrontendAgent{{Name: "scanner"}}})
+	s.MarkReady()
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)

--- a/v2/pkg/dashboard/server_test.go
+++ b/v2/pkg/dashboard/server_test.go
@@ -83,6 +83,7 @@ func TestNewServer_DefaultFields(t *testing.T) {
 func TestHandleHealth_StatusCode(t *testing.T) {
 	s := newTestServer()
 	s.UpdateStatus(minimalPayload())
+	s.MarkReady()
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
 	s.handleHealth(rec, req)
@@ -107,6 +108,7 @@ func TestHandleHealth_ContentType(t *testing.T) {
 func TestHandleHealth_Body(t *testing.T) {
 	s := newTestServer()
 	s.UpdateStatus(minimalPayload())
+	s.MarkReady()
 	rec := httptest.NewRecorder()
 	s.handleHealth(rec, httptest.NewRequest(http.MethodGet, "/api/health", nil))
 
@@ -700,6 +702,7 @@ func TestStart_ServesEndpoints(t *testing.T) {
 	port := freePort(t)
 	s := NewServer(port, slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
 	s.UpdateStatus(minimalPayload())
+	s.MarkReady()
 
 	errCh := make(chan error, 1)
 	go func() {
@@ -837,6 +840,7 @@ func TestAuthMiddleware_HealthBypassesAuth(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 	s := NewServerWithAuth(0, "secret-token-123", logger)
 	s.UpdateStatus(minimalPayload())
+	s.MarkReady()
 	handler := s.Handler()
 	ts := httptest.NewServer(handler)
 	defer ts.Close()

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2370,10 +2370,11 @@
         else if (lastNonZero > 0) { values[i] = lastNonZero; }
       }
       const max = Math.max(...values);
-      const range = max || 1;
+      const min = Math.min(...values);
+      const range = (max - min) || max || 1;
       const pts = values.map((v, i) => {
         const x = (i / (values.length - 1)) * SPARK_W;
-        const y = SPARK_H - (v / range) * (SPARK_H - 2) - 1;
+        const y = SPARK_H - ((v - min) / range) * (SPARK_H - 2) - 1;
         return `${x.toFixed(1)},${y.toFixed(1)}`;
       });
       return `<span class="sparkline"><svg width="${SPARK_W}" height="${SPARK_H}" viewBox="0 0 ${SPARK_W} ${SPARK_H}">` +
@@ -3461,7 +3462,9 @@ function burnAreaChart() {
           let miniSpark = '';
           if (act.length >= 2) {
             const mx = Math.max(...act, 1);
-            const pts = act.map((v, i) => `${(i / (act.length - 1)) * MINI_W},${MINI_H - (v / mx) * (MINI_H - 2) - 1}`).join(' ');
+            const mn = Math.min(...act);
+            const rng = (mx - mn) || mx || 1;
+            const pts = act.map((v, i) => `${(i / (act.length - 1)) * MINI_W},${MINI_H - ((v - mn) / rng) * (MINI_H - 2) - 1}`).join(' ');
             const aClrs = { scanner: '#58a6ff', 'ci-maintainer': '#3fb950', architect: '#bc8cff', outreach: '#39d2c0', supervisor: '#d29922' };
             const clr = aClrs[s.agent] || '#8b949e';
             miniSpark = `<span class="sparkline" style="margin-left:4px"><svg width="${MINI_W}" height="${MINI_H}" viewBox="0 0 ${MINI_W} ${MINI_H}"><polyline points="${pts}" fill="none" stroke="${clr}" stroke-width="1.2" opacity="0.7"/></svg></span>`;


### PR DESCRIPTION
## Summary
- Sparklines for token usage appeared flat because rendering normalized against absolute max value
- For cumulative counters (245M→265M), the ~8% variation was invisible at chart scale
- Now normalizes by `(max - min)` so sparklines show the trend/delta regardless of absolute magnitude
- Applied to both main sparkline helper and mini session sparklines

## Test plan
- [ ] Deploy to 4.78 and verify token usage sparklines show visible trends
- [ ] Verify eval history sparklines (issues/PRs) still render correctly
- [ ] Verify session activity mini sparklines still render correctly