### PR TITLE
fix: prevent credential helper stacking in entrypoint

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -49,8 +49,8 @@ mkdir -p /data/vaults/hive-wiki
 # Configure git identity and credential helper for GitHub App token
 git config --global user.name "kubestellar-hive"
 git config --global user.email "hive-bot@kubestellar.io"
-git config --global credential.helper ""
-git config --global "credential.https://github.com.helper" "/usr/local/bin/git-credential-hive.sh"
+git config --global --replace-all credential.helper ""
+git config --global --replace-all "credential.https://github.com.helper" "/usr/local/bin/git-credential-hive.sh"
 
 # Generate initial GitHub App token if credentials are available
 if [ -x /usr/local/bin/hive-config.sh ]; then


### PR DESCRIPTION
## Summary
- Use `--replace-all` for git credential helper config in `entrypoint.sh`
- Prevents duplicate credential helper entries from stacking across container restarts
- Without this fix, restarted containers hit "cannot overwrite multiple values" error when git operations attempt to use the credential helper

## Root Cause
`git config --global credential.helper ""` appends a new entry each restart instead of replacing. After multiple restarts, git refuses to operate because the key has multiple conflicting values.

## Test plan
- [x] Verified fix resolves the issue on running container (4.78)
- [ ] Rebuild image and deploy — credential helper should work after multiple container restarts