### PR TITLE
feat: inject live coverage metrics into tester kick

### DIFF
--- a/bin/fetch-coverage.sh
+++ b/bin/fetch-coverage.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# fetch-coverage.sh — pulls coverage metrics from the coverage-hourly workflow
+# (Coverage Suite) on ${PROJECT_ORG}/${PROJECT_PRIMARY_REPO} and writes a JSON
+# summary to /var/run/hive-metrics/coverage.json for the tester kick message.
+#
+# Data sources:
+#   1. merge-coverage job logs → total lines/statements/branches/functions %
+#   2. coverage-summary.json artifact (if available) → per-file breakdown
+#
+# Called by kick-agents.sh before the tester kick. Caches for 10 min to avoid
+# hammering the GitHub API on rapid kicks.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Source project config for org/repo
+if [[ -f "${SCRIPT_DIR}/hive-config.sh" ]]; then
+  source "${SCRIPT_DIR}/hive-config.sh"
+elif [[ -f /usr/local/bin/hive-config.sh ]]; then
+  source /usr/local/bin/hive-config.sh
+fi
+
+COVERAGE_REPO="${PROJECT_ORG}/${PROJECT_PRIMARY_REPO}"
+COVERAGE_WORKFLOW="coverage-hourly.yml"
+OUTPUT_FILE="/var/run/hive-metrics/coverage.json"
+CACHE_MAX_AGE_SEC=600
+COVERAGE_THRESHOLD=91
+
+GH_CMD="gh"
+TOKEN_CACHE="/var/run/hive-metrics/gh-app-token.cache"
+if [[ -f "$TOKEN_CACHE" ]]; then
+  GH_CMD="GH_TOKEN=$(cat "$TOKEN_CACHE") gh"
+fi
+
+mkdir -p /var/run/hive-metrics 2>/dev/null || true
+
+# Skip if cache is fresh
+if [[ -f "$OUTPUT_FILE" ]]; then
+  file_age=$(( $(date +%s) - $(stat -c %Y "$OUTPUT_FILE" 2>/dev/null || stat -f %m "$OUTPUT_FILE" 2>/dev/null || echo 0) ))
+  if [[ "$file_age" -lt "$CACHE_MAX_AGE_SEC" ]]; then
+    exit 0
+  fi
+fi
+
+# Find the latest coverage-hourly run that produced a merge-coverage job
+run_json=$(eval "$GH_CMD" run list --repo "$COVERAGE_REPO" --workflow="$COVERAGE_WORKFLOW" \
+  --limit 5 --json databaseId,conclusion,createdAt 2>/dev/null || echo "[]")
+
+if [[ "$run_json" == "[]" ]]; then
+  echo '{"error":"no coverage runs found","lines":0,"statements":0,"branches":0,"functions":0}' > "$OUTPUT_FILE"
+  exit 0
+fi
+
+# Try each run until we find one with a merge-coverage job that has coverage data
+for run_id in $(echo "$run_json" | python3 -c "import sys,json; [print(r['databaseId']) for r in json.load(sys.stdin)]" 2>/dev/null); do
+  # Get the merge-coverage job ID
+  merge_job_id=$(eval "$GH_CMD" api "repos/${COVERAGE_REPO}/actions/runs/${run_id}/jobs" \
+    --jq '.jobs[] | select(.name == "merge-coverage") | .id' 2>/dev/null || echo "")
+
+  [[ -z "$merge_job_id" ]] && continue
+
+  # Pull the job logs and extract the coverage summary table
+  logs=$(eval "$GH_CMD" api "repos/${COVERAGE_REPO}/actions/jobs/${merge_job_id}/logs" 2>/dev/null || echo "")
+  [[ -z "$logs" ]] && continue
+
+  # Extract "## Coverage Summary" output lines (not script definition — no ANSI codes)
+  lines_pct=$(echo "$logs" | grep -E '^\d{4}-.*\| Lines \|' | grep -v '\[36;1m' | tail -1 | grep -oE '[0-9]+\.[0-9]+' || echo "")
+  stmts_pct=$(echo "$logs" | grep -E '^\d{4}-.*\| Statements \|' | grep -v '\[36;1m' | tail -1 | grep -oE '[0-9]+\.[0-9]+' || echo "")
+  branch_pct=$(echo "$logs" | grep -E '^\d{4}-.*\| Branches \|' | grep -v '\[36;1m' | tail -1 | grep -oE '[0-9]+\.[0-9]+' || echo "")
+  funcs_pct=$(echo "$logs" | grep -E '^\d{4}-.*\| Functions \|' | grep -v '\[36;1m' | tail -1 | grep -oE '[0-9]+\.[0-9]+' || echo "")
+
+  [[ -z "$lines_pct" ]] && continue
+
+  # Extract the per-file coverage table from the Vitest text reporter output.
+  # Lines look like: "  src/foo/bar.ts  |  45.23 |  30.00 |  50.00 |  42.85 | ..."
+  # We want files with lines coverage < threshold.
+  low_files=$(echo "$logs" | grep -v '\[36;1m' | \
+    grep -E '^\d{4}-.*\|.*\|.*\|.*\|.*\|' | \
+    grep -v 'File\|---\|All files' | \
+    python3 -c "
+import sys
+THRESHOLD = $COVERAGE_THRESHOLD
+results = []
+for line in sys.stdin:
+    # Strip timestamp prefix
+    parts = line.split('|')
+    if len(parts) < 5:
+        continue
+    # parts[0] has timestamp + file path, parts[1]=stmts, parts[2]=branch, parts[3]=funcs, parts[4]=lines
+    try:
+        file_part = parts[0].strip()
+        # Extract just the file path (after the timestamp)
+        file_name = file_part.split('Z ')[-1].strip() if 'Z ' in file_part else file_part
+        stmts = float(parts[1].strip())
+        branch = float(parts[2].strip())
+        funcs = float(parts[3].strip())
+        lines = float(parts[4].strip())
+        if lines < THRESHOLD:
+            results.append({'file': file_name, 'lines': lines, 'statements': stmts, 'branches': branch, 'functions': funcs})
+    except (ValueError, IndexError):
+        continue
+# Sort by lines coverage ascending (worst first), take top 20
+results.sort(key=lambda x: x['lines'])
+import json
+print(json.dumps(results[:20]))
+" 2>/dev/null || echo "[]")
+
+  # Extract the run's created_at timestamp
+  run_ts=$(echo "$run_json" | python3 -c "
+import sys, json
+runs = json.load(sys.stdin)
+for r in runs:
+    if r['databaseId'] == $run_id:
+        print(r['createdAt'])
+        break
+" 2>/dev/null || echo "unknown")
+
+  # Count failing test shards
+  failing_shards=$(eval "$GH_CMD" api "repos/${COVERAGE_REPO}/actions/runs/${run_id}/jobs" \
+    --jq '[.jobs[] | select(.name | startswith("test-shard")) | select(.conclusion == "failure")] | length' 2>/dev/null || echo "0")
+
+  # Write the output
+  python3 -c "
+import json
+data = {
+    'lines': ${lines_pct:-0},
+    'statements': ${stmts_pct:-0},
+    'branches': ${branch_pct:-0},
+    'functions': ${funcs_pct:-0},
+    'threshold': $COVERAGE_THRESHOLD,
+    'run_id': $run_id,
+    'run_ts': '$run_ts',
+    'failing_shards': $failing_shards,
+    'low_coverage_files': json.loads('''$low_files'''),
+    'fetched_at': '$(date -u +%Y-%m-%dT%H:%M:%S+00:00)'
+}
+print(json.dumps(data, indent=2))
+" > "$OUTPUT_FILE" 2>/dev/null
+
+  exit 0
+done
+
+# All runs failed to produce coverage data
+echo '{"error":"no coverage data in recent runs","lines":0,"statements":0,"branches":0,"functions":0}' > "$OUTPUT_FILE"

--- a/bin/kick-agents.sh
+++ b/bin/kick-agents.sh
@@ -744,6 +744,7 @@ done
 /tmp/hive/bin/enumerate-actionable.sh 2>/dev/null || log "WARN: enumerate-actionable.sh failed (non-fatal)"
 /tmp/hive/bin/merge-gate.sh 2>/dev/null || log "WARN: merge-gate.sh failed (non-fatal)"
 /tmp/hive/bin/copilot-comment-checker.sh 2>/dev/null || log "WARN: copilot-comment-checker.sh failed (non-fatal)"
+/tmp/hive/bin/fetch-coverage.sh 2>/dev/null || log "WARN: fetch-coverage.sh failed (non-fatal)"
 
 # Build inline work list for scanner kick message (agents must NOT list issues/PRs themselves)
 _ENUM_FILE="/var/run/hive-metrics/actionable.json"
@@ -1125,6 +1126,78 @@ apply_model_if_changed() {
 }
 
 _now_et=$(TZ=America/New_York date '+%Y-%m-%d %I:%M %p %Z')
+
+# ── Tester coverage data ──────────────────────────────────────────────
+# Reads /var/run/hive-metrics/coverage.json (written by fetch-coverage.sh)
+# and builds a structured preamble for the tester kick message.
+_COVERAGE_FILE="/var/run/hive-metrics/coverage.json"
+_TESTER_COVERAGE_PREAMBLE=""
+if [ -f "$_COVERAGE_FILE" ]; then
+  _TESTER_COVERAGE_PREAMBLE=$(python3 -c "
+import json, sys
+try:
+    d = json.load(open('$_COVERAGE_FILE'))
+except Exception:
+    sys.exit(0)
+
+if d.get('error'):
+    print(f'COVERAGE: unavailable ({d[\"error\"]})')
+    sys.exit(0)
+
+lines = d.get('lines', 0)
+stmts = d.get('statements', 0)
+branches = d.get('branches', 0)
+funcs = d.get('functions', 0)
+threshold = d.get('threshold', 91)
+run_ts = d.get('run_ts', 'unknown')
+failing = d.get('failing_shards', 0)
+
+out = []
+out.append(f'COVERAGE STATUS (from {run_ts}):')
+out.append(f'  Lines: {lines}% | Statements: {stmts}% | Branches: {branches}% | Functions: {funcs}%')
+out.append(f'  Threshold: {threshold}%')
+
+gaps = []
+if lines < threshold:
+    gaps.append(f'Lines ({threshold - lines:.1f}% gap)')
+if stmts < threshold:
+    gaps.append(f'Statements ({threshold - stmts:.1f}% gap)')
+if branches < threshold:
+    gaps.append(f'Branches ({threshold - branches:.1f}% gap)')
+if funcs < threshold:
+    gaps.append(f'Functions ({threshold - funcs:.1f}% gap)')
+
+if gaps:
+    out.append(f'  ⚠ BELOW THRESHOLD: {', '.join(gaps)}')
+else:
+    out.append(f'  ✅ All metrics at or above {threshold}%')
+
+if failing > 0:
+    out.append(f'  ⚠ {failing} test shard(s) failing in latest run — investigate and fix')
+
+low = d.get('low_coverage_files', [])
+if low:
+    out.append(f'LOWEST COVERAGE FILES (below {threshold}%):')
+    for f in low[:15]:
+        out.append(f'  {f[\"file\"]}: L={f[\"lines\"]}% S={f[\"statements\"]}% B={f[\"branches\"]}% F={f[\"functions\"]}%')
+    if len(low) > 15:
+        out.append(f'  ... and {len(low) - 15} more')
+
+print('\n'.join(out))
+" 2>/dev/null || echo "COVERAGE: data unavailable (parse error)")
+fi
+
+if policy_changed "tester"; then
+  _TESTER_POLICY_INSTR="Read your CLAUDE.md."
+else
+  _TESTER_POLICY_INSTR="Policy unchanged since last kick — skip CLAUDE.md re-read, continue with standing instructions."
+fi
+TESTER_MSG="[agent:tester] [KICK] git pull /tmp/hive. ${_TESTER_POLICY_INSTR}
+${_GH_AUTH_INSTR}
+${_REPOS_SECTION}
+${_TESTER_COVERAGE_PREAMBLE}
+PRIORITIES: 1) Fix any failing test shards first (these block coverage reporting). 2) Write tests for the lowest-coverage files listed above — target files furthest below threshold. 3) Focus on branches coverage (typically the weakest metric). Max 3 PRs per kick. Each PR must include coverage delta estimate. NEVER run vitest, npm test, npm run build, tsc, or any test/build locally — CI validates. Beads: ~/tester-beads"
+
 if policy_changed "supervisor"; then
   _SUPERVISOR_POLICY_INSTR="Read your CLAUDE.md."
 else
@@ -1150,6 +1223,9 @@ case "$TARGET" in
     ;;
   supervisor)
     apply_model_if_changed "supervisor" "supervisor" && kick "supervisor" "$SUPERVISOR_MSG" "supervisor"
+    ;;
+  tester)
+    apply_model_if_changed "tester" "tester" && kick "tester" "$TESTER_MSG" "tester"
     ;;
   sec-check)
     SEC_CHECK_MSG="[agent:sec-check] [KICK] git pull /tmp/hive. Read your CLAUDE.md. Time: ${_now_et}.


### PR DESCRIPTION
## Summary
- Add `bin/fetch-coverage.sh` — fetches coverage data from the Coverage Suite (`coverage-hourly.yml`) workflow's `merge-coverage` job logs and caches as `/var/run/hive-metrics/coverage.json` (10-min TTL)
- Add dedicated `tester` kick case in `kick-agents.sh` that injects: lines/statements/branches/functions percentages, gap-to-threshold analysis, failing shard count, and the 15 lowest-covered files
- Previously the tester agent fell through to the generic `*` handler and had zero visibility into actual coverage numbers — it was working blind

## What the tester now sees on each kick
```
COVERAGE STATUS (from 2026-05-16T01:41:17Z):
  Lines: 90.57% | Statements: 89.23% | Branches: 79.81% | Functions: 88.67%
  Threshold: 91%
  ⚠ BELOW THRESHOLD: Statements (1.8% gap), Branches (11.2% gap), Functions (2.3% gap)
  ⚠ 2 test shard(s) failing in latest run — investigate and fix
LOWEST COVERAGE FILES (below 91%):
  src/foo/bar.ts: L=45% S=40% B=30% F=50%
  ...
```

## Test plan
- [ ] Deploy to 4.78, kick tester agent, verify kick message contains coverage data
- [ ] Verify `fetch-coverage.sh` creates `/var/run/hive-metrics/coverage.json`
- [ ] Verify 10-min cache — second run within 10 min should be a no-op
- [ ] Verify fallback when no coverage runs exist (error JSON written)