### PR TITLE
fix: sparkline race condition on page load

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2404,6 +2404,15 @@
       try {
         const r = await fetch('/api/history');
         const evalEntries = await r.json();
+        // Ensure token history is loaded before merging (fixes race on initial page load)
+        if (!window._serverTokenHistory) {
+          try {
+            const tr = await fetch('/api/trends?range=week');
+            const td = await tr.json();
+            window._serverTokenHistory = td && td.tokenHistory ? td.tokenHistory : [];
+            window._trendData = td && td.evals ? td.evals : (Array.isArray(td) ? td : []);
+          } catch { window._serverTokenHistory = []; }
+        }
         const tokenHist = window._serverTokenHistory || [];
         const MAX_MERGE_DELTA_MS = 60000;
         const matchedTokenIndices = new Set();


### PR DESCRIPTION
## Summary
- Token sparklines render flat on most page refreshes due to a race condition
- `fetchHistory()` (line 2458) fires before `/api/trends` (line 5912) completes, so `window._serverTokenHistory` is undefined when the merge happens
- Fix: `fetchHistory()` now fetches trends inline if token history isn't populated yet

## Root Cause
Two independent fetches fire on page load:
1. `fetchHistory()` at line 2458 — needs token data from trends
2. `fetch('/api/trends')` at line 5912 — provides token data but runs later in script

The trends fetch usually hasn't completed when `fetchHistory()` runs, so `tokenHist` is `[]` and no token variation data gets merged into sparklines.

## Test plan
- [x] Refresh dashboard 10+ times — sparklines should show curves every time, not flat lines
- [x] Verify burn rate charts and per-agent sparklines also populate correctly