### PR TITLE
fix: persist repo sparkline history across page refreshes

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -573,6 +573,10 @@ func runEvalCycle(
 		gov.AttachAgentStats(agentStats)
 	}
 
+	if repoSnaps := dashboard.CollectRepoSnapshots(statusPayload); len(repoSnaps) > 0 {
+		gov.AttachRepoSnapshots(repoSnaps)
+	}
+
 	if nousState != nil {
 		var tokenSummary *tokens.AggregateSummary
 		if tokenCollector != nil {

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -212,6 +212,20 @@ func defaultStatsConfig(name string) []any {
 }
 
 // CollectAgentStats resolves current stat values for all agents, keyed by agent name then stat key.
+func CollectRepoSnapshots(payload *StatusPayload) map[string]governor.RepoSnapshot {
+	if payload == nil || len(payload.Repos) == 0 {
+		return nil
+	}
+	result := make(map[string]governor.RepoSnapshot, len(payload.Repos))
+	for _, r := range payload.Repos {
+		result[r.Name] = governor.RepoSnapshot{
+			Issues: r.Issues,
+			PRs:    r.PRs,
+		}
+	}
+	return result
+}
+
 func CollectAgentStats(payload *StatusPayload) map[string]map[string]any {
 	result := make(map[string]map[string]any)
 	for _, a := range payload.Agents {

--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -373,6 +373,16 @@ func (g *Governor) AttachAgentStats(stats map[string]map[string]any) {
 	g.evalHistory[len(g.evalHistory)-1].AgentStats = stats
 }
 
+// AttachRepoSnapshots attaches per-repo issue/PR counts to the most recent eval snapshot.
+func (g *Governor) AttachRepoSnapshots(repos map[string]RepoSnapshot) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if len(g.evalHistory) == 0 {
+		return
+	}
+	g.evalHistory[len(g.evalHistory)-1].Repos = repos
+}
+
 // SeedEvalHistory loads previously persisted eval snapshots so sparkline
 // history survives container restarts.
 func (g *Governor) SeedEvalHistory(snapshots []EvalSnapshot) {


### PR DESCRIPTION
## Summary
- `EvalSnapshot.Repos` field existed but was never populated during eval cycles
- Added `AttachRepoSnapshots()` to governor (mirrors existing `AttachAgentStats()` pattern)
- Added `CollectRepoSnapshots()` to status_builder to extract per-repo issue/PR counts from `StatusPayload`
- Wired in `main.go` eval loop so repo snapshots persist to `sparkline-history.json`
- Repo sparklines now show history across page refreshes and container restarts

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/governor/... ./pkg/dashboard/... -short -race` passes
- [ ] Deploy to 4.78, verify repo sparklines show accumulated history after multiple eval cycles
- [ ] Refresh page — sparklines should persist, not reset to flat lines