### PR TITLE
Inject coverage pct into tester bootstrap prompt

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -217,6 +217,16 @@ if [[ -n "$AGENT_NAME" ]]; then
       _ensure_labels
       exec "$REAL_GH" "$@" --add-label "$LABELS_CSV"
       ;;
+    pr/merge)
+      _ensure_labels
+      _extract_item
+      if [[ -n "$item_num" ]]; then
+        local_repo=""
+        [[ -n "$item_repo" ]] && local_repo="--repo $item_repo"
+        "$REAL_GH" pr edit "$item_num" $local_repo --add-label "$LABELS_CSV" 2>/dev/null || true
+      fi
+      exec "$REAL_GH" "$@"
+      ;;
     issue/comment|pr/comment|pr/review)
       _ensure_labels
       _extract_item

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -253,12 +254,52 @@ func (m *Manager) buildBootstrapPrompt(agent *AgentProcess) string {
 		fmt.Sprintf("/data/policies/examples/kubestellar/agents/%s-CLAUDE.md", agent.Name),
 		fmt.Sprintf("/data/agents/%s/CLAUDE.md", agent.Name),
 	}
+	var policyPath string
 	for _, p := range paths {
 		if _, err := os.Stat(p); err == nil {
-			return fmt.Sprintf("[agent:%s] [BOOT] Read %s for your instructions and begin your first pass.", agent.Name, p)
+			policyPath = p
+			break
 		}
 	}
-	return fmt.Sprintf("[agent:%s] [BOOT] Read your CLAUDE.md for instructions and begin your first pass.", agent.Name)
+
+	base := fmt.Sprintf("[agent:%s] [BOOT] Read your CLAUDE.md for instructions and begin your first pass.", agent.Name)
+	if policyPath != "" {
+		base = fmt.Sprintf("[agent:%s] [BOOT] Read %s for your instructions and begin your first pass.", agent.Name, policyPath)
+	}
+
+	if agent.Name == "tester" {
+		if preamble := m.readCoveragePreamble(); preamble != "" {
+			base = preamble + " " + base
+		}
+	}
+
+	return base
+}
+
+const metricsCachePath = "/data/metrics/agent-metrics-cache.json"
+
+func (m *Manager) readCoveragePreamble() string {
+	data, err := os.ReadFile(metricsCachePath)
+	if err != nil {
+		return ""
+	}
+	var metrics map[string]map[string]json.Number
+	if err := json.Unmarshal(data, &metrics); err != nil {
+		return ""
+	}
+	ci, ok := metrics["ci-maintainer"]
+	if !ok {
+		return ""
+	}
+	cov, err := ci["coverage"].Int64()
+	if err != nil {
+		return ""
+	}
+	target, err := ci["coverageTarget"].Int64()
+	if err != nil {
+		target = 91
+	}
+	return fmt.Sprintf("[COVERAGE] Current: %d%% | Target: %d%%.", cov, target)
 }
 
 func (m *Manager) buildEnvPrefix(agent *AgentProcess) string {


### PR DESCRIPTION
## Summary
- Reads current coverage % and target from `/data/metrics/agent-metrics-cache.json` (written by ci-maintainer)
- Prepends `[COVERAGE] Current: 90% | Target: 91%.` to the tester agent's bootstrap prompt
- No scan needed — uses the latest cached value from ci-maintainer

## Test plan
- [ ] Deploy via blue-green on 4.78
- [ ] Check `/tmp/.hive-bootstrap-tester.txt` contains coverage preamble
- [ ] Verify tester agent sees coverage data on startup