### PR TITLE
feat: fast 10s agent-status SSE ticker

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -457,6 +457,13 @@ func main() {
 	ticker := time.NewTicker(time.Duration(cfg.Governor.EvalIntervalS) * time.Second)
 	defer ticker.Stop()
 
+	var agentTicker *time.Ticker
+	if cfg.Dashboard.AgentPollIntervalS > 0 {
+		agentTicker = time.NewTicker(time.Duration(cfg.Dashboard.AgentPollIntervalS) * time.Second)
+		defer agentTicker.Stop()
+		logger.Info("fast agent status enabled", "interval_seconds", cfg.Dashboard.AgentPollIntervalS)
+	}
+
 	const cliStartupDelay = 10 * time.Second
 	logger.Info("waiting for CLI startup before first eval", "delay", cliStartupDelay)
 	select {
@@ -469,6 +476,13 @@ func main() {
 	persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
 	dashSrv.MarkReady()
 
+	agentTickCh := func() <-chan time.Time {
+		if agentTicker != nil {
+			return agentTicker.C
+		}
+		return nil
+	}()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -478,6 +492,11 @@ func main() {
 		case <-ticker.C:
 			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, logger)
 			persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
+		case <-agentTickCh:
+			govState := gov.GetState()
+			agentStatuses := agentMgr.AllStatuses()
+			payload := dashboard.BuildAgentOnlyStatus(govState, agentStatuses, cfg)
+			dashSrv.BroadcastAgentStatus(payload)
 		}
 	}
 }

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -221,9 +221,10 @@ type DiscordConfig struct {
 }
 
 type DashboardConfig struct {
-	Port        int    `yaml:"port"`
-	SnapshotDir string `yaml:"snapshot_dir"`
-	AuthToken   string `yaml:"auth_token"`
+	Port               int    `yaml:"port"`
+	SnapshotDir        string `yaml:"snapshot_dir"`
+	AuthToken          string `yaml:"auth_token"`
+	AgentPollIntervalS int    `yaml:"agent_poll_interval_s"`
 }
 
 type DataConfig struct {
@@ -370,6 +371,7 @@ func expandEnvVars(s string) string {
 
 const (
 	defaultDashboardPort          = 3002
+	defaultAgentPollIntervalS     = 10
 	defaultEvalIntervalS          = 300
 	defaultPollIntervalMins       = 5
 	defaultKnowledgeMaxFacts      = 25
@@ -391,6 +393,9 @@ const (
 func (c *Config) applyDefaults() {
 	if c.Dashboard.Port == 0 {
 		c.Dashboard.Port = defaultDashboardPort
+	}
+	if c.Dashboard.AgentPollIntervalS == 0 {
+		c.Dashboard.AgentPollIntervalS = defaultAgentPollIntervalS
 	}
 	if c.Governor.EvalIntervalS == 0 {
 		c.Governor.EvalIntervalS = defaultEvalIntervalS

--- a/v2/pkg/dashboard/api_coverage_test.go
+++ b/v2/pkg/dashboard/api_coverage_test.go
@@ -1176,11 +1176,11 @@ func TestBroadcast(t *testing.T) {
 	s.sseClients[ch] = struct{}{}
 	s.sseMu.Unlock()
 
-	s.broadcast([]byte(`{"test":true}`))
+	s.broadcastFrame("data: {\"test\":true}\n\n")
 
 	data := <-ch
-	if string(data) != `{"test":true}` {
-		t.Errorf("broadcast data = %q", string(data))
+	if string(data) != "data: {\"test\":true}\n\n" {
+		t.Errorf("broadcastFrame data = %q", string(data))
 	}
 
 	s.sseMu.Lock()

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -16,6 +16,8 @@ import (
 //go:embed static
 var staticFS embed.FS
 
+const agentSkipAfterFullBroadcastS = 5 * time.Second
+
 type Server struct {
 	port       int
 	authToken  string
@@ -35,8 +37,9 @@ type Server struct {
 	hooksMu        sync.RWMutex
 	knowledgeMu    sync.Mutex
 
-	tokenHistoryMu sync.RWMutex
-	tokenHistory   []TokenSparklineEntry
+	tokenHistoryMu    sync.RWMutex
+	tokenHistory      []TokenSparklineEntry
+	lastFullBroadcast time.Time
 
 	ready bool
 }
@@ -285,6 +288,7 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 	s.statusMu.Lock()
 	status.Timestamp = time.Now().UTC().Format(time.RFC3339)
 	s.status = status
+	s.lastFullBroadcast = time.Now()
 	s.statusMu.Unlock()
 
 	s.AppendTokenSparkline(status)
@@ -295,7 +299,27 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 		return
 	}
 
-	s.broadcast(data)
+	s.broadcastFrame(fmt.Sprintf("data: %s\n\n", data))
+}
+
+// BroadcastAgentStatus sends a lightweight agent-only SSE event on a fast
+// cadence. Skipped if a full status was broadcast within the last 5 seconds
+// to avoid redundant renders on the frontend.
+func (s *Server) BroadcastAgentStatus(payload *AgentStatusPayload) {
+	s.statusMu.RLock()
+	recentFull := time.Since(s.lastFullBroadcast) < agentSkipAfterFullBroadcastS
+	s.statusMu.RUnlock()
+	if recentFull {
+		return
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		s.logger.Warn("failed to marshal agent status for SSE", "error", err)
+		return
+	}
+
+	s.broadcastFrame(fmt.Sprintf("event: agent-status\ndata: %s\n\n", data))
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
@@ -368,8 +392,8 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 
 	for {
 		select {
-		case data := <-ch:
-			fmt.Fprintf(w, "data: %s\n\n", data)
+		case frame := <-ch:
+			_, _ = w.Write(frame)
 			flusher.Flush()
 		case <-r.Context().Done():
 			return
@@ -377,13 +401,14 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) broadcast(data []byte) {
+func (s *Server) broadcastFrame(frame string) {
+	raw := []byte(frame)
 	s.sseMu.Lock()
 	defer s.sseMu.Unlock()
 
 	for ch := range s.sseClients {
 		select {
-		case ch <- data:
+		case ch <- raw:
 		default:
 			// Client too slow — drop the event
 		}

--- a/v2/pkg/dashboard/server_test.go
+++ b/v2/pkg/dashboard/server_test.go
@@ -263,10 +263,12 @@ func TestUpdateStatus_BroadcastsToClients(t *testing.T) {
 	s.UpdateStatus(minimalPayload())
 
 	select {
-	case data := <-ch:
+	case frame := <-ch:
+		raw := strings.TrimPrefix(string(frame), "data: ")
+		raw = strings.TrimSpace(raw)
 		var payload StatusPayload
-		if err := json.Unmarshal(data, &payload); err != nil {
-			t.Fatalf("unmarshal error: %v", err)
+		if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+			t.Fatalf("unmarshal error: %v (frame=%q)", err, string(frame))
 		}
 		if payload.Governor.Mode != "IDLE" {
 			t.Errorf("unexpected mode in broadcast: %q", payload.Governor.Mode)
@@ -519,12 +521,13 @@ func TestBroadcast_MultipleClients(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s.broadcast(data)
+	frame := fmt.Sprintf("data: %s\n\n", data)
+	s.broadcastFrame(frame)
 
 	for i, ch := range channels {
 		select {
 		case got := <-ch:
-			if string(got) != string(data) {
+			if string(got) != frame {
 				t.Errorf("client %d: unexpected payload", i)
 			}
 		case <-time.After(time.Second):
@@ -547,11 +550,12 @@ func TestBroadcast_DropsEventForSlowClient(t *testing.T) {
 	s.sseMu.Unlock()
 
 	data, _ := json.Marshal(minimalPayload())
-	s.broadcast(data)
+	frame := fmt.Sprintf("data: %s\n\n", data)
+	s.broadcastFrame(frame)
 
 	select {
 	case got := <-fast:
-		if string(got) != string(data) {
+		if string(got) != frame {
 			t.Error("fast client: unexpected payload")
 		}
 	case <-time.After(time.Second):
@@ -570,7 +574,7 @@ func TestBroadcast_DropsEventForSlowClient(t *testing.T) {
 func TestBroadcast_NoClients(t *testing.T) {
 	s := newTestServer()
 	data, _ := json.Marshal(minimalPayload())
-	s.broadcast(data)
+	s.broadcastFrame(fmt.Sprintf("data: %s\n\n", data))
 }
 
 func TestConcurrency_UpdateAndReadStatus(t *testing.T) {
@@ -613,7 +617,7 @@ func TestConcurrency_BroadcastWithClientChurn(t *testing.T) {
 			s.sseClients[ch] = struct{}{}
 			s.sseMu.Unlock()
 
-			s.broadcast(data)
+			s.broadcastFrame(fmt.Sprintf("data: %s\n\n", data))
 
 			s.sseMu.Lock()
 			delete(s.sseClients, ch)

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5921,6 +5921,27 @@ function burnAreaChart() {
         }
       };
 
+      source.addEventListener('agent-status', (e) => {
+        try {
+          const payload = JSON.parse(e.data);
+          window._lastAgents = payload.agents || [];
+          if (window._lastStatus) {
+            window._lastStatus.agents = payload.agents || [];
+          }
+          ocUpdateSidebarAgents();
+          if (_ocSelectedAgent) {
+            ocRenderAgentDetail();
+          }
+          const lastData = window._lastStatus || {};
+          if (lastData.agents) {
+            applyPinOverrides(lastData.agents);
+            renderAgents(lastData.agents);
+          }
+        } catch (err) {
+          console.error('SSE agent-status parse error:', err);
+        }
+      });
+
       source.onerror = () => {
         conn.className = 'connection';
         conn.innerHTML = '<span class="dot-dead">●</span> reconnecting...';

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -25,6 +25,28 @@ var (
 	cachedHealthMu sync.RWMutex
 )
 
+// AgentStatusPayload is a lightweight payload containing only agent metadata,
+// broadcast on a fast cadence (every ~10s) independent of the full eval cycle.
+type AgentStatusPayload struct {
+	Timestamp string          `json:"timestamp"`
+	Agents    []FrontendAgent `json:"agents"`
+	GovMode   string          `json:"govMode"`
+}
+
+// BuildAgentOnlyStatus builds a lightweight agent-only status from in-memory
+// data. No GitHub API calls, no metrics collection — just agent state.
+func BuildAgentOnlyStatus(
+	govState governor.State,
+	agentStatuses map[string]*agent.AgentProcess,
+	cfg *config.Config,
+) *AgentStatusPayload {
+	return &AgentStatusPayload{
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Agents:    buildAgents(agentStatuses, cfg, govState),
+		GovMode:   strings.ToLower(string(govState.Mode)),
+	}
+}
+
 func BuildFrontendStatus(
 	govState governor.State,
 	actionable *github.ActionableResult,


### PR DESCRIPTION
## Summary

- Adds a lightweight 10s ticker that broadcasts **only agent metadata** via named SSE events (`event: agent-status`), decoupled from the expensive 5-min governor eval cycle
- Agent detail panels now populate within ~10s of opening instead of waiting up to 5 minutes
- Full eval cycle continues unchanged for GitHub/governor data
- Configurable via `agent_poll_interval_s` in dashboard config (default 10, 0 = disabled)
- 5s skip guard prevents double-render flicker when both tickers fire close together

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./... -count=1` — all 14 packages pass
- [ ] Deploy to 4.78 via blue-green, verify agent detail panel populates within ~10s
- [ ] Check browser DevTools for `agent-status` SSE events arriving every 10s
- [ ] Verify full status SSE events still arrive on eval cycle
- [ ] Verify no flicker when both events fire close together