### PR TITLE
🐛 fix: ignore Netlify checks in merge gate readiness

### DIFF
--- a/bin/merge-gate.sh
+++ b/bin/merge-gate.sh
@@ -23,8 +23,8 @@ TMP_FILE="${OUTPUT_FILE}.tmp"
 LOG="/var/log/kick-agents.log"
 
 # CI check names to ignore when evaluating merge readiness
-# NOTE: netlify/Deploy Preview are NOT ignored — Netlify failures must block merges
-IGNORED_CHECKS="tide|Playwright|attribute|Storybook|Visual |Verify build after merge"
+# Netlify/deploy-preview checks publish docs previews and must not block merge readiness.
+IGNORED_CHECKS="tide|Playwright|netlify/|deploy-preview|Header rules|Pages changed|Redirect rules|attribute|Storybook|Visual |Verify build after merge"
 
 log() { echo "[$(date -Is)] MERGE-GATE $*" >> "$LOG"; }
 


### PR DESCRIPTION
## Summary
- align `IGNORED_CHECKS` with the merge-gate header policy from `bin/merge-gate.sh`
- ignore Netlify deploy-preview, Header rules, Pages changed, and Redirect rules checks when computing merge readiness

Fixes #509.

## Validation
- `bash -n bin/merge-gate.sh` passed
- focused local parser sample passed:
  - Netlify/Header rules/Pages changed/Redirect rules failures were filtered and the remaining passing check produced `pass`
  - adding a non-ignored `unit-tests` failure produced `fail`
- `git diff --check HEAD~1 HEAD` passed
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact` found no leaks

Not run: ShellCheck is not installed in this local environment. I also did not run a live end-to-end merge-gate pass against `/var/run/hive-metrics/actionable.json`.