### PR TITLE
feat: agent ID field + dual-key resolution (UID Phase 1)

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -39,6 +39,7 @@ const (
 
 type AgentProcess struct {
 	Name            string
+	ID              string
 	Config          config.AgentConfig
 	State           ProcessState
 	PID             int
@@ -57,10 +58,11 @@ type AgentProcess struct {
 }
 
 type Manager struct {
-	agents  map[string]*AgentProcess
-	mu      sync.RWMutex
-	logger  *slog.Logger
-	workDir string
+	agents    map[string]*AgentProcess
+	idToName  map[string]string
+	mu        sync.RWMutex
+	logger    *slog.Logger
+	workDir   string
 }
 
 func NewManager(agents map[string]config.AgentConfig, logger *slog.Logger) *Manager {
@@ -70,22 +72,42 @@ func NewManager(agents map[string]config.AgentConfig, logger *slog.Logger) *Mana
 	}
 
 	m := &Manager{
-		agents:  make(map[string]*AgentProcess),
-		logger:  logger,
-		workDir: workDir,
+		agents:   make(map[string]*AgentProcess),
+		idToName: make(map[string]string),
+		logger:   logger,
+		workDir:  workDir,
 	}
 
 	for name, cfg := range agents {
+		agentID := cfg.ID
+		if agentID == "" {
+			agentID = name
+		}
 		m.agents[name] = &AgentProcess{
 			Name:         name,
+			ID:           agentID,
 			Config:       cfg,
 			State:        StateStopped,
 			OutputBuffer: NewRingBuffer(outputBufferCapacity),
 			tmuxSession:  "hive-" + name,
 		}
+		m.idToName[agentID] = name
 	}
 
 	return m
+}
+
+// ResolveAgent returns the YAML key (name) for a given name or ID.
+// If the input matches neither, it returns the input unchanged (callers
+// will get a "not found" error from the specific method).
+func (m *Manager) ResolveAgent(nameOrID string) string {
+	if _, ok := m.agents[nameOrID]; ok {
+		return nameOrID
+	}
+	if name, ok := m.idToName[nameOrID]; ok {
+		return name
+	}
+	return nameOrID
 }
 
 func (m *Manager) Start(ctx context.Context, name string) error {
@@ -409,14 +431,20 @@ func (m *Manager) AddAgent(name string, cfg config.AgentConfig) {
 		return
 	}
 
+	agentID := cfg.ID
+	if agentID == "" {
+		agentID = name
+	}
 	m.agents[name] = &AgentProcess{
 		Name:         name,
+		ID:           agentID,
 		Config:       cfg,
 		State:        StateStopped,
 		OutputBuffer: NewRingBuffer(outputBufferCapacity),
 		tmuxSession:  "hive-" + name,
 	}
-	m.logger.Info("agent added", "name", name)
+	m.idToName[agentID] = name
+	m.logger.Info("agent added", "name", name, "id", agentID)
 }
 
 // UpdateConfig updates the stored config for a running agent process so that
@@ -448,8 +476,9 @@ func (m *Manager) RemoveAgent(name string) {
 		agent.cancel()
 	}
 
+	delete(m.idToName, agent.ID)
 	delete(m.agents, name)
-	m.logger.Info("agent removed", "name", name)
+	m.logger.Info("agent removed", "name", name, "id", agent.ID)
 }
 
 func (m *Manager) SendKick(name string, message string) error {
@@ -593,6 +622,7 @@ func (a *AgentProcess) snapshot() AgentProcess {
 	copy(history, a.KickHistory)
 	return AgentProcess{
 		Name:            a.Name,
+		ID:              a.ID,
 		Config:          a.Config,
 		State:           a.State,
 		PID:             a.PID,

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -77,6 +77,7 @@ type PoliciesConfig struct {
 }
 
 type AgentConfig struct {
+	ID              string `yaml:"id"`
 	Backend         string `yaml:"backend"`
 	Model           string `yaml:"model"`
 	BeadsDir        string `yaml:"beads_dir"`
@@ -90,6 +91,13 @@ type AgentConfig struct {
 	Description     string `yaml:"description"`
 	// clearOnKickSet tracks whether YAML explicitly set clear_on_kick to false
 	clearOnKickSet bool
+	// name is the YAML map key, set during config load
+	name string
+}
+
+// Name returns the human-readable YAML key for this agent.
+func (a *AgentConfig) Name() string {
+	return a.name
 }
 
 func (a *AgentConfig) UnmarshalYAML(value *yaml.Node) error {
@@ -416,6 +424,10 @@ func (c *Config) applyDefaults() {
 		c.Data.CopilotSessionsDir = "/data/home/.copilot/session-state"
 	}
 	for name, agent := range c.Agents {
+		agent.name = name
+		if agent.ID == "" {
+			agent.ID = name
+		}
 		if agent.BeadsDir == "" {
 			agent.BeadsDir = fmt.Sprintf("/data/beads/%s", name)
 		}
@@ -557,4 +569,28 @@ func (c *Config) EnabledAgents() map[string]AgentConfig {
 		}
 	}
 	return result
+}
+
+// ResolveAgent finds an agent by name or ID and returns its YAML key (name).
+// Returns the key and true if found, empty string and false otherwise.
+func (c *Config) ResolveAgent(nameOrID string) (string, bool) {
+	if _, ok := c.Agents[nameOrID]; ok {
+		return nameOrID, true
+	}
+	for name, agent := range c.Agents {
+		if agent.ID == nameOrID {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+// AgentByID returns the agent config with the given ID.
+func (c *Config) AgentByID(id string) (AgentConfig, bool) {
+	for _, agent := range c.Agents {
+		if agent.ID == id {
+			return agent, true
+		}
+	}
+	return AgentConfig{}, false
 }

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -155,6 +155,15 @@ func okResponse(w http.ResponseWriter, extra map[string]string) {
 	jsonResponse(w, result)
 }
 
+// resolveAgentParam resolves an agent path parameter (name or ID) to the
+// canonical YAML key (name). Returns the resolved name.
+func (s *Server) resolveAgentParam(nameOrID string) string {
+	if s.deps != nil && s.deps.AgentMgr != nil {
+		return s.deps.AgentMgr.ResolveAgent(nameOrID)
+	}
+	return nameOrID
+}
+
 func (s *Server) refreshAfterMutation() {
 	if s.deps != nil && s.deps.RefreshFunc != nil {
 		go s.deps.RefreshFunc()
@@ -375,7 +384,7 @@ func (s *Server) handleWidget(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handlePane(w http.ResponseWriter, r *http.Request) {
-	name := r.PathValue("agent")
+	name := s.resolveAgentParam(r.PathValue("agent"))
 	lines, _ := strconv.Atoi(r.URL.Query().Get("lines"))
 	if lines <= 0 {
 		lines = 100
@@ -397,7 +406,7 @@ func (s *Server) handlePane(w http.ResponseWriter, r *http.Request) {
 // --- Agent control endpoints ---
 
 func (s *Server) handleKick(w http.ResponseWriter, r *http.Request) {
-	name := r.PathValue("agent")
+	name := s.resolveAgentParam(r.PathValue("agent"))
 	var body struct {
 		Message string `json:"message"`
 	}
@@ -417,7 +426,7 @@ func (s *Server) handleKick(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleSwitch(w http.ResponseWriter, r *http.Request) {
-	name := r.PathValue("agent")
+	name := s.resolveAgentParam(r.PathValue("agent"))
 	backend := r.PathValue("backend")
 
 	if err := s.deps.AgentMgr.SetBackendOverride(name, backend); err != nil {
@@ -430,7 +439,7 @@ func (s *Server) handleSwitch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleModelSet(w http.ResponseWriter, r *http.Request) {
-	name := r.PathValue("agent")
+	name := s.resolveAgentParam(r.PathValue("agent"))
 	model := r.PathValue("model")
 
 	if err := s.deps.AgentMgr.SetModelOverride(name, model); err != nil {
@@ -443,7 +452,7 @@ func (s *Server) handleModelSet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handlePause(w http.ResponseWriter, r *http.Request) {
-	name := r.PathValue("agent")
+	name := s.resolveAgentParam(r.PathValue("agent"))
 
 	if err := s.deps.AgentMgr.Pause(name); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
@@ -455,7 +464,7 @@ func (s *Server) handlePause(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleResume(w http.ResponseWriter, r *http.Request) {
-	name := r.PathValue("agent")
+	name := s.resolveAgentParam(r.PathValue("agent"))
 
 	if err := s.deps.AgentMgr.Resume(s.deps.Ctx, name); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
@@ -467,7 +476,7 @@ func (s *Server) handleResume(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handlePin(w http.ResponseWriter, r *http.Request) {
-	name := r.PathValue("agent")
+	name := s.resolveAgentParam(r.PathValue("agent"))
 	dimension := r.PathValue("dimension")
 
 	var body struct {
@@ -516,7 +525,7 @@ func (s *Server) handlePin(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleUnpin(w http.ResponseWriter, r *http.Request) {
-	name := r.PathValue("agent")
+	name := s.resolveAgentParam(r.PathValue("agent"))
 	dimension := r.PathValue("dimension")
 
 	var err error
@@ -540,7 +549,7 @@ func (s *Server) handleUnpin(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleRestart(w http.ResponseWriter, r *http.Request) {
-	name := r.PathValue("agent")
+	name := s.resolveAgentParam(r.PathValue("agent"))
 
 	if err := s.deps.AgentMgr.Restart(s.deps.Ctx, name); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
@@ -552,7 +561,7 @@ func (s *Server) handleRestart(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleResetRestarts(w http.ResponseWriter, r *http.Request) {
-	name := r.PathValue("agent")
+	name := s.resolveAgentParam(r.PathValue("agent"))
 
 	if err := s.deps.AgentMgr.ResetRestartCount(name); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -64,6 +64,7 @@ type StatusPayload struct {
 
 type FrontendAgent struct {
 	Name             string `json:"name"`
+	ID               string `json:"id"`
 	DisplayName      string `json:"displayName,omitempty"`
 	Description      string `json:"description,omitempty"`
 	Session          string `json:"session"`

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -141,8 +141,14 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 			liveSummary = strings.Join(lines, "\n")
 		}
 
+		agentID := proc.ID
+		if agentID == "" {
+			agentID = name
+		}
+
 		a := FrontendAgent{
 			Name:          name,
+			ID:            agentID,
 			DisplayName:   proc.Config.DisplayName,
 			Description:   proc.Config.Description,
 			Session:       name,


### PR DESCRIPTION
## Summary

- Adds a stable `id` field to `AgentConfig` so agents can be identified by either name (YAML key) or ID
- All 10 API handlers resolve agent params via name or ID transparently
- `FrontendAgent` JSON now includes `id` field for frontend consumption
- Manager maintains `idToName` reverse map for O(1) lookups
- ID defaults to the YAML key name when not explicitly set — fully backward compatible

This is Phase 1 of the [Agent UID Architecture plan](https://github.com/kubestellar/hive/blob/v2/v2/docs/design/knowledge-system.md) to make Hive a generic orchestration system. Future phases will move hardcoded agent behavior into config fields (Phase 2), make the frontend fully generic (Phase 3), and clean up legacy references (Phase 4).

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./... -count=1` — all 14 packages pass
- [ ] Deploy to 4.78 — verify agents appear with correct ID in JSON payload
- [ ] Verify API accepts both name and ID for all agent endpoints