### PR TITLE
feat: config-driven agent behavior (Phase 2 Agent UID)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/kubestellar/hive/v2/pkg/agent"
 	"github.com/kubestellar/hive/v2/pkg/beads"
+	"github.com/kubestellar/hive/v2/pkg/classify"
 	"github.com/kubestellar/hive/v2/pkg/config"
 	"github.com/kubestellar/hive/v2/pkg/dashboard"
 	"github.com/kubestellar/hive/v2/pkg/discord"
@@ -286,6 +287,8 @@ func main() {
 		beadStores[name] = store
 		logger.Info("beads store initialized", "agent", name, "count", store.Count())
 	}
+
+	initAgentConfigDrivenSystems(cfg)
 
 	tokenCollector := tokens.NewCollector(cfg.Data.MetricsDir, logger)
 	tokenCollector.SetClaudeSessionsDir(cfg.Data.ClaudeSessionsDir)
@@ -999,4 +1002,60 @@ func parseLogLevel(s string) slog.Level {
 	default:
 		return slog.LevelInfo
 	}
+}
+
+// initAgentConfigDrivenSystems wires up config-driven agent metadata to subsystems
+// that previously relied on hardcoded agent name maps (classifier, discord, token detector).
+func initAgentConfigDrivenSystems(cfg *config.Config) {
+	var lanes []classify.LaneConfig
+	var agentNames []string
+	detectKeywords := make(map[string][]string)
+	discordIdentities := make(map[string]discord.AgentIdentity)
+	discordAliases := make(map[string]string)
+
+	for name, agent := range cfg.Agents {
+		agentNames = append(agentNames, name)
+
+		if len(agent.LaneKeywords) > 0 {
+			lanes = append(lanes, classify.LaneConfig{
+				Name:     name,
+				Keywords: agent.LaneKeywords,
+			})
+		}
+		if len(agent.DetectKeywords) > 0 {
+			detectKeywords[name] = agent.DetectKeywords
+		}
+		if agent.Emoji != "" || agent.Color != "" {
+			discordIdentities[name] = discord.AgentIdentity{
+				Emoji: agent.Emoji,
+				Color: parseColorInt(agent.Color),
+			}
+		}
+		for _, alias := range agent.Aliases {
+			discordAliases[alias] = name
+		}
+	}
+
+	if len(lanes) > 0 {
+		classify.SetLanes(lanes)
+	}
+	if len(detectKeywords) > 0 {
+		tokens.SetDetectKeywords(detectKeywords)
+	}
+	tokens.SetAgentNames(agentNames)
+	discord.SetAgentIdentities(discordIdentities)
+	if len(discordAliases) > 0 {
+		discord.SetAgentAliases(discordAliases)
+	}
+}
+
+// parseColorInt converts a hex color string like "#3498db" to an int.
+func parseColorInt(color string) int {
+	color = strings.TrimPrefix(color, "#")
+	if color == "" {
+		return 0x95a5a6
+	}
+	var result int
+	fmt.Sscanf(color, "%x", &result)
+	return result
 }

--- a/v2/pkg/classify/classifier.go
+++ b/v2/pkg/classify/classifier.go
@@ -24,12 +24,22 @@ const (
 
 type Lane string
 
+// LaneConfig maps a lane name to its keywords for classification.
+type LaneConfig struct {
+	Name     string
+	Keywords []string
+}
+
+// DefaultLane is the fallback lane for issues that don't match any keywords.
+const DefaultLane = "scanner"
+
+// Backward-compatible lane constants used by tests and other packages.
 const (
-	LaneScanner   Lane = "scanner"
-	LaneCIMaintainer  Lane = "ci-maintainer"
-	LaneArchitect Lane = "architect"
-	LaneOutreach  Lane = "outreach"
-	LaneTester    Lane = "tester"
+	LaneScanner      Lane = "scanner"
+	LaneCIMaintainer Lane = "ci-maintainer"
+	LaneArchitect    Lane = "architect"
+	LaneOutreach     Lane = "outreach"
+	LaneTester       Lane = "tester"
 )
 
 type Classification struct {
@@ -44,30 +54,36 @@ var simpleKeywords = []string{
 	"tooltip", "placeholder", "aria", "alt text",
 }
 
-var architectKeywords = []string{
-	"rfc", "architecture", "refactor", "redesign", "migration",
-	"breaking change", "protocol", "api design",
+// defaultLanes is the built-in lane config used when no config-driven lanes are provided.
+var defaultLanes = []LaneConfig{
+	{Name: "architect", Keywords: []string{"rfc", "architecture", "refactor", "redesign", "migration", "breaking change", "protocol", "api design"}},
+	{Name: "ci-maintainer", Keywords: []string{"workflow-failure", "ci-failure", "nightly", "coverage", "regression", "ga4", "analytics"}},
+	{Name: "outreach", Keywords: []string{"adopters", "outreach", "community", "engagement"}},
+	{Name: "tester", Keywords: []string{"test-gap", "test-strategy", "test-coverage", "test-scaffold", "untested", "missing-tests"}},
 }
 
-var ciMaintainerKeywords = []string{
-	"workflow-failure", "ci-failure", "nightly", "coverage",
-	"regression", "ga4", "analytics",
+// configuredLanes holds the active lane configuration. Set via SetLanes().
+var configuredLanes []LaneConfig
+
+// SetLanes replaces the lane configuration used by the classifier.
+// Called at startup with lanes built from agent config LaneKeywords fields.
+func SetLanes(lanes []LaneConfig) {
+	configuredLanes = lanes
 }
 
-var outreachKeywords = []string{
-	"adopters", "outreach", "community", "engagement",
-}
-
-var testerKeywords = []string{
-	"test-gap", "test-strategy", "test-coverage", "test-scaffold",
-	"untested", "missing-tests",
+// activeLanes returns the current effective lane config.
+func activeLanes() []LaneConfig {
+	if len(configuredLanes) > 0 {
+		return configuredLanes
+	}
+	return defaultLanes
 }
 
 func Classify(issue github.Issue) Classification {
 	c := Classification{
 		Tier:  TierMedium,
 		Model: ModelSonnet,
-		Lane:  LaneScanner,
+		Lane:  Lane(DefaultLane),
 	}
 
 	titleLower := strings.ToLower(issue.Title)
@@ -82,27 +98,14 @@ func Classify(issue github.Issue) Classification {
 }
 
 func classifyLane(titleLower, labelsStr string) Lane {
-	for _, kw := range architectKeywords {
-		if strings.Contains(titleLower, kw) || strings.Contains(labelsStr, kw) {
-			return LaneArchitect
+	for _, lane := range activeLanes() {
+		for _, kw := range lane.Keywords {
+			if strings.Contains(titleLower, kw) || strings.Contains(labelsStr, kw) {
+				return Lane(lane.Name)
+			}
 		}
 	}
-	for _, kw := range ciMaintainerKeywords {
-		if strings.Contains(titleLower, kw) || strings.Contains(labelsStr, kw) {
-			return LaneCIMaintainer
-		}
-	}
-	for _, kw := range outreachKeywords {
-		if strings.Contains(titleLower, kw) || strings.Contains(labelsStr, kw) {
-			return LaneOutreach
-		}
-	}
-	for _, kw := range testerKeywords {
-		if strings.Contains(titleLower, kw) || strings.Contains(labelsStr, kw) {
-			return LaneTester
-		}
-	}
-	return LaneScanner
+	return Lane(DefaultLane)
 }
 
 func classifyTier(titleLower, labelsStr string, labels []string) Tier {

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -76,6 +76,17 @@ type PoliciesConfig struct {
 	LocalDir     string        `yaml:"local_dir"`
 }
 
+// StatsDisplayEntry defines a single metric to show in the agent's sidebar/detail view.
+type StatsDisplayEntry struct {
+	Key        string `yaml:"key" json:"key"`
+	Label      string `yaml:"label" json:"label"`
+	Source     string `yaml:"source" json:"source"`
+	Field      string `yaml:"field" json:"field"`
+	Style      string `yaml:"style" json:"style"`
+	TrendField string `yaml:"trend_field,omitempty" json:"trendField,omitempty"`
+	Target     int    `yaml:"target,omitempty" json:"target,omitempty"`
+}
+
 type AgentConfig struct {
 	ID              string `yaml:"id"`
 	Backend         string `yaml:"backend"`
@@ -89,6 +100,22 @@ type AgentConfig struct {
 	LaunchCmd       string `yaml:"launch_cmd"`
 	DisplayName     string `yaml:"display_name"`
 	Description     string `yaml:"description"`
+
+	// Phase 2: config-driven agent behavior fields
+	Role             string            `yaml:"role"`
+	SortOrder        int               `yaml:"sort_order"`
+	Emoji            string            `yaml:"emoji"`
+	Color            string            `yaml:"color"`
+	Aliases          []string          `yaml:"aliases"`
+	LaneKeywords     []string          `yaml:"lane_keywords"`
+	DetectKeywords   []string          `yaml:"detect_keywords"`
+	KickTemplate     string            `yaml:"kick_template"`
+	IncludeRepos     *bool             `yaml:"include_repos"`
+	MetricsCollector string            `yaml:"metrics_collector"`
+	BeadRole         string            `yaml:"bead_role"`
+	StatsDisplay     []StatsDisplayEntry `yaml:"stats_display"`
+	ACMMLevels       []int             `yaml:"acmm_levels"`
+
 	// clearOnKickSet tracks whether YAML explicitly set clear_on_kick to false
 	clearOnKickSet bool
 	// name is the YAML map key, set during config load
@@ -98,6 +125,34 @@ type AgentConfig struct {
 // Name returns the human-readable YAML key for this agent.
 func (a *AgentConfig) Name() string {
 	return a.name
+}
+
+// ShouldIncludeRepos returns whether the repos section should be appended to kicks.
+// Defaults to true for all agents except those with IncludeRepos explicitly set to false.
+func (a *AgentConfig) ShouldIncludeRepos() bool {
+	if a.IncludeRepos != nil {
+		return *a.IncludeRepos
+	}
+	return true
+}
+
+// GetBeadRole returns the bead role, defaulting to "worker".
+func (a *AgentConfig) GetBeadRole() string {
+	if a.BeadRole != "" {
+		return a.BeadRole
+	}
+	return "worker"
+}
+
+// GetSortOrder returns the sort order. Supervisor-role agents default to 0 (first).
+func (a *AgentConfig) GetSortOrder() int {
+	if a.SortOrder != 0 {
+		return a.SortOrder
+	}
+	if a.BeadRole == "supervisor" {
+		return 0
+	}
+	return 100
 }
 
 func (a *AgentConfig) UnmarshalYAML(value *yaml.Node) error {
@@ -437,6 +492,10 @@ func (c *Config) applyDefaults() {
 		if !agent.clearOnKickSet {
 			agent.ClearOnKick = true
 		}
+		if agent.Role == "" {
+			agent.Role = name
+		}
+		applyKnownAgentDefaults(name, &agent)
 		c.Agents[name] = agent
 	}
 
@@ -536,6 +595,100 @@ func (c *Config) applyDefaults() {
 		if c.Knowledge.Curator.AutoPromoteThreshold == 0 {
 			c.Knowledge.Curator.AutoPromoteThreshold = defaultPromoteThreshold
 		}
+	}
+}
+
+// applyKnownAgentDefaults populates metadata fields for well-known agent names
+// when those fields are not explicitly set in YAML. This bridges existing configs.
+func applyKnownAgentDefaults(name string, agent *AgentConfig) {
+	type knownAgent struct {
+		Emoji          string
+		Color          string
+		Aliases        []string
+		LaneKeywords   []string
+		DetectKeywords []string
+		BeadRole       string
+		SortOrder      int
+		IncludeRepos   bool
+	}
+
+	known := map[string]knownAgent{
+		"scanner": {
+			Emoji: "🔍", Color: "#3498db", Aliases: []string{"sc"},
+			LaneKeywords:   []string{"bug", "triage", "typo", "fix"},
+			DetectKeywords: []string{"scanner", "triage", "issue", "bug"},
+			BeadRole: "worker", SortOrder: 20, IncludeRepos: true,
+		},
+		"ci-maintainer": {
+			Emoji: "🔧", Color: "#2ecc71", Aliases: []string{"ci"},
+			LaneKeywords:   []string{"workflow-failure", "ci-failure", "nightly", "coverage", "regression", "ga4", "analytics"},
+			DetectKeywords: []string{"ci-maintainer", "review", "ci", "coverage", "ga4"},
+			BeadRole: "worker", SortOrder: 30, IncludeRepos: true,
+		},
+		"architect": {
+			Emoji: "🏗", Color: "#9b59b6", Aliases: []string{"ar"},
+			LaneKeywords:   []string{"rfc", "architecture", "refactor", "redesign", "migration", "breaking change", "protocol", "api design"},
+			DetectKeywords: []string{"architect", "rfc", "refactor"},
+			BeadRole: "worker", SortOrder: 40, IncludeRepos: true,
+		},
+		"outreach": {
+			Emoji: "🌐", Color: "#e67e22", Aliases: []string{"ou"},
+			LaneKeywords:   []string{"adopters", "outreach", "community", "engagement"},
+			DetectKeywords: []string{"outreach", "adopters", "community"},
+			BeadRole: "worker", SortOrder: 50, IncludeRepos: false,
+		},
+		"supervisor": {
+			Emoji: "👑", Color: "#e74c3c", Aliases: []string{"su"},
+			DetectKeywords: []string{"supervisor", "sweep", "monitor"},
+			BeadRole: "supervisor", SortOrder: 10, IncludeRepos: true,
+		},
+		"sec-check": {
+			Emoji: "🛡", Color: "#1abc9c", Aliases: []string{"se"},
+			DetectKeywords: []string{"security", "sec-check", "vulnerability"},
+			BeadRole: "worker", SortOrder: 60, IncludeRepos: true,
+		},
+		"tester": {
+			Emoji: "🧪", Color: "#3498db", Aliases: []string{"te"},
+			LaneKeywords:   []string{"test-gap", "test-strategy", "test-coverage", "test-scaffold", "untested", "missing-tests"},
+			DetectKeywords: []string{"tester", "test", "coverage"},
+			BeadRole: "worker", SortOrder: 35, IncludeRepos: true,
+		},
+		"strategist": {
+			Emoji: "🧠", Color: "#f39c12", Aliases: []string{"sg"},
+			DetectKeywords: []string{"strategist", "strategy"},
+			BeadRole: "worker", SortOrder: 70, IncludeRepos: true,
+		},
+	}
+
+	k, ok := known[name]
+	if !ok {
+		return
+	}
+
+	if agent.Emoji == "" {
+		agent.Emoji = k.Emoji
+	}
+	if agent.Color == "" {
+		agent.Color = k.Color
+	}
+	if len(agent.Aliases) == 0 && len(k.Aliases) > 0 {
+		agent.Aliases = k.Aliases
+	}
+	if len(agent.LaneKeywords) == 0 && len(k.LaneKeywords) > 0 {
+		agent.LaneKeywords = k.LaneKeywords
+	}
+	if len(agent.DetectKeywords) == 0 && len(k.DetectKeywords) > 0 {
+		agent.DetectKeywords = k.DetectKeywords
+	}
+	if agent.BeadRole == "" {
+		agent.BeadRole = k.BeadRole
+	}
+	if agent.SortOrder == 0 {
+		agent.SortOrder = k.SortOrder
+	}
+	if agent.IncludeRepos == nil {
+		v := k.IncludeRepos
+		agent.IncludeRepos = &v
 	}
 }
 

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -67,6 +67,11 @@ type FrontendAgent struct {
 	ID               string `json:"id"`
 	DisplayName      string `json:"displayName,omitempty"`
 	Description      string `json:"description,omitempty"`
+	Role             string `json:"role,omitempty"`
+	SortOrder        int    `json:"sortOrder"`
+	Emoji            string `json:"emoji,omitempty"`
+	Color            string `json:"color,omitempty"`
+	BeadRole         string `json:"beadRole,omitempty"`
 	Session          string `json:"session"`
 	State            string `json:"state"`
 	Busy             string `json:"busy"`

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -73,7 +73,7 @@ func BuildFrontendStatus(
 		Governor:     buildGovernor(govState, cfg),
 		Tokens:       buildTokens(tokenCollector),
 		Repos:        buildRepos(cfg, actionable),
-		Beads:        buildBeads(beadStores),
+		Beads:        BuildBeadsFromConfig(beadStores, cfg),
 		Health:       buildHealth(ghClient, ctx),
 		Budget:       buildBudget(gov, tokenCollector),
 		CadenceMatrix: buildCadenceMatrix(cfg, agentStatuses),
@@ -93,12 +93,16 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 		names = append(names, name)
 	}
 	sort.Slice(names, func(i, j int) bool {
-		// Supervisor always comes first in the sidebar.
-		if names[i] == "supervisor" {
-			return true
+		orderI := 100
+		orderJ := 100
+		if agentI, ok := cfg.Agents[names[i]]; ok {
+			orderI = agentI.GetSortOrder()
 		}
-		if names[j] == "supervisor" {
-			return false
+		if agentJ, ok := cfg.Agents[names[j]]; ok {
+			orderJ = agentJ.GetSortOrder()
+		}
+		if orderI != orderJ {
+			return orderI < orderJ
 		}
 		return names[i] < names[j]
 	})
@@ -146,11 +150,17 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 			agentID = name
 		}
 
+		agentCfg := proc.Config
 		a := FrontendAgent{
 			Name:          name,
 			ID:            agentID,
-			DisplayName:   proc.Config.DisplayName,
-			Description:   proc.Config.Description,
+			DisplayName:   agentCfg.DisplayName,
+			Description:   agentCfg.Description,
+			Role:          agentCfg.Role,
+			SortOrder:     agentCfg.GetSortOrder(),
+			Emoji:         agentCfg.Emoji,
+			Color:         agentCfg.Color,
+			BeadRole:      agentCfg.GetBeadRole(),
 			Session:       name,
 			State:         string(proc.State),
 			Busy:          busy,
@@ -177,7 +187,7 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 }
 
 // loadStatsConfig reads the per-agent stats configuration from /data/agents/{name}/stats.json.
-// Falls back to built-in defaults when the file is missing or empty.
+// Falls back to config StatsDisplay, then built-in defaults when the file is missing or empty.
 func loadStatsConfig(name string) []any {
 	statsFile := fmt.Sprintf("/data/agents/%s/stats.json", name)
 	data, err := os.ReadFile(statsFile)
@@ -192,6 +202,42 @@ func loadStatsConfig(name string) []any {
 		if json.Unmarshal(data, &stats) == nil && len(stats) > 0 {
 			return stats
 		}
+	}
+	return defaultStatsConfig(name)
+}
+
+// LoadStatsConfigWithCfg reads stats from disk, then falls back to config StatsDisplay field.
+func LoadStatsConfigWithCfg(name string, cfg *config.Config) []any {
+	statsFile := fmt.Sprintf("/data/agents/%s/stats.json", name)
+	data, err := os.ReadFile(statsFile)
+	if err == nil {
+		var wrapper struct {
+			Stats []any `json:"stats"`
+		}
+		if json.Unmarshal(data, &wrapper) == nil && len(wrapper.Stats) > 0 {
+			return wrapper.Stats
+		}
+		var stats []any
+		if json.Unmarshal(data, &stats) == nil && len(stats) > 0 {
+			return stats
+		}
+	}
+	if agentCfg, ok := cfg.Agents[name]; ok && len(agentCfg.StatsDisplay) > 0 {
+		result := make([]any, 0, len(agentCfg.StatsDisplay))
+		for _, s := range agentCfg.StatsDisplay {
+			entry := map[string]any{
+				"key": s.Key, "label": s.Label,
+				"source": s.Source, "field": s.Field, "style": s.Style,
+			}
+			if s.TrendField != "" {
+				entry["trendField"] = s.TrendField
+			}
+			if s.Target > 0 {
+				entry["target"] = s.Target
+			}
+			result = append(result, entry)
+		}
+		return result
 	}
 	return defaultStatsConfig(name)
 }
@@ -574,6 +620,24 @@ func buildBeads(stores map[string]*beads.Store) FrontendBeads {
 	for name, store := range stores {
 		count := store.Count()
 		if name == "supervisor" {
+			fb.Supervisor = count
+		} else {
+			fb.Workers += count
+		}
+	}
+	return fb
+}
+
+// BuildBeadsFromConfig uses agent config bead_role to partition bead counts.
+func BuildBeadsFromConfig(stores map[string]*beads.Store, cfg *config.Config) FrontendBeads {
+	fb := FrontendBeads{}
+	for name, store := range stores {
+		count := store.Count()
+		role := "worker"
+		if agentCfg, ok := cfg.Agents[name]; ok {
+			role = agentCfg.GetBeadRole()
+		}
+		if role == "supervisor" {
 			fb.Supervisor = count
 		} else {
 			fb.Workers += count

--- a/v2/pkg/dashboard/status_builder_test.go
+++ b/v2/pkg/dashboard/status_builder_test.go
@@ -362,8 +362,8 @@ func TestBuildAgents(t *testing.T) {
 
 	cfg := &config.Config{
 		Agents: map[string]config.AgentConfig{
-			"scanner":    {Backend: "claude", Model: "sonnet"},
-			"supervisor": {Backend: "claude", Model: "opus"},
+			"scanner":    {Backend: "claude", Model: "sonnet", SortOrder: 20},
+			"supervisor": {Backend: "claude", Model: "opus", BeadRole: "supervisor", SortOrder: 10},
 		},
 		Governor: config.GovernorConfig{
 			Modes: map[string]config.ModeConfig{

--- a/v2/pkg/discord/bot.go
+++ b/v2/pkg/discord/bot.go
@@ -26,24 +26,21 @@ const (
 	sseReconnectMax    = 60 * time.Second
 )
 
-type agentIdentity struct {
+// AgentIdentity holds the Discord display metadata for an agent.
+type AgentIdentity struct {
 	Emoji string
 	Color int
 }
 
-var agentIdentities = map[string]agentIdentity{
-	"scanner":        {Emoji: "🔍", Color: 0x3498db},
-	"ci-maintainer":  {Emoji: "🔧", Color: 0x2ecc71},
-	"architect":      {Emoji: "🏗", Color: 0x9b59b6},
-	"outreach":       {Emoji: "🌐", Color: 0xe67e22},
-	"supervisor":     {Emoji: "👑", Color: 0xe74c3c},
-	"sec-check":      {Emoji: "🛡", Color: 0x1abc9c},
-	"strategist":     {Emoji: "🧠", Color: 0xf39c12},
-	"tester":         {Emoji: "🧪", Color: 0x3498db},
-	"governor":       {Emoji: "🚦", Color: 0xf1c40f},
-	"pipeline":       {Emoji: "⚙️", Color: 0x95a5a6},
+// agentIdentities maps agent names to their Discord display identity.
+// Populated from config via SetAgentIdentities; defaults used if not called.
+var agentIdentities = map[string]AgentIdentity{
+	"governor": {Emoji: "🚦", Color: 0xf1c40f},
+	"pipeline": {Emoji: "⚙️", Color: 0x95a5a6},
 }
 
+// aliases maps shortcodes to full command/agent names.
+// Includes built-in defaults; overridable via SetAgentAliases from config.
 var aliases = map[string]string{
 	"s": "status", "st": "status",
 	"g": "governor", "gov": "governor",
@@ -52,6 +49,26 @@ var aliases = map[string]string{
 	"sc": "scanner", "ar": "architect", "ou": "outreach",
 	"su": "supervisor", "ci": "ci-maintainer", "se": "sec-check",
 	"sg": "strategist", "te": "tester",
+}
+
+// SetAgentIdentities rebuilds agentIdentities from config at startup.
+func SetAgentIdentities(identities map[string]AgentIdentity) {
+	merged := map[string]AgentIdentity{
+		"governor": {Emoji: "🚦", Color: 0xf1c40f},
+		"pipeline": {Emoji: "⚙️", Color: 0x95a5a6},
+	}
+	for k, v := range identities {
+		merged[k] = v
+	}
+	agentIdentities = merged
+}
+
+// SetAgentAliases replaces agent aliases in the aliases map with config-driven values.
+// Command aliases (status, governor, help, kick, pause, resume) are always preserved.
+func SetAgentAliases(agentAliases map[string]string) {
+	for k, v := range agentAliases {
+		aliases[k] = v
+	}
 }
 
 type CommandHandler func(ctx context.Context, args string) (string, error)
@@ -787,7 +804,7 @@ func resolveAlias(s string) string {
 	return s
 }
 
-func getIdentity(name string) agentIdentity {
+func getIdentity(name string) AgentIdentity {
 	if id, ok := agentIdentities[name]; ok {
 		return id
 	}

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -53,6 +53,25 @@ func (s *Scheduler) loadPromptTemplate(agentName string) string {
 	return ""
 }
 
+// loadNamedTemplate loads a kick template by explicit filename (from config kick_template field).
+func (s *Scheduler) loadNamedTemplate(templateName string) string {
+	paths := []string{
+		fmt.Sprintf("/data/policies/examples/kubestellar/agents/%s", templateName),
+	}
+	if s.cfg.Policies.LocalDir != "" {
+		paths = append(paths,
+			fmt.Sprintf("%s/examples/kubestellar/agents/%s", s.cfg.Policies.LocalDir, templateName),
+			fmt.Sprintf("%s/%s%s", s.cfg.Policies.LocalDir, s.cfg.Policies.Path, templateName),
+		)
+	}
+	for _, p := range paths {
+		if data, err := os.ReadFile(p); err == nil {
+			return string(data)
+		}
+	}
+	return ""
+}
+
 // substituteTemplate replaces ${VAR} placeholders in a prompt template.
 func (s *Scheduler) substituteTemplate(template string, actionable *github.ActionableResult, agentName string, issues []github.Issue) string {
 	now := time.Now().In(time.FixedZone("EDT", -4*3600))
@@ -176,7 +195,13 @@ func (s *Scheduler) BuildKickMessages(actionable *github.ActionableResult, agent
 	for _, agentName := range agentsDue {
 		msg := s.buildAgentMessage(agentName, classifiedIssues, actionable)
 		if msg != "" {
-			if agentName != "outreach" {
+			includeRepos := true
+			if agentCfg, ok := s.cfg.Agents[agentName]; ok {
+				includeRepos = agentCfg.ShouldIncludeRepos()
+			} else if agentName == "outreach" {
+				includeRepos = false
+			}
+			if includeRepos {
 				msg += "\n" + reposSection
 			}
 			messages = append(messages, KickMessage{
@@ -206,7 +231,17 @@ func (s *Scheduler) buildReposSection() string {
 const maxIssuesPerKick = 20
 
 func (s *Scheduler) buildAgentMessage(agentName string, issues []github.Issue, actionable *github.ActionableResult) string {
-	// Prefer CLAUDE.md prompt template if it exists — allows config-driven kicks
+	// 1. Config-driven: use kick_template field if set
+	if agentCfg, ok := s.cfg.Agents[agentName]; ok && agentCfg.KickTemplate != "" {
+		if template := s.loadNamedTemplate(agentCfg.KickTemplate); template != "" {
+			s.logger.Info("using config kick_template", "agent", agentName, "template", agentCfg.KickTemplate)
+			msg := fmt.Sprintf("[agent:%s] [KICK]\n\n", agentName)
+			msg += s.substituteTemplate(template, actionable, agentName, issues)
+			return msg
+		}
+	}
+
+	// 2. Convention: look for <agent>-CLAUDE.md template file
 	if template := s.loadPromptTemplate(agentName); template != "" {
 		s.logger.Info("using prompt template for kick", "agent", agentName)
 		msg := fmt.Sprintf("[agent:%s] [KICK]\n\n", agentName)
@@ -214,7 +249,7 @@ func (s *Scheduler) buildAgentMessage(agentName string, issues []github.Issue, a
 		return msg
 	}
 
-	// Fall back to hardcoded messages for agents without templates
+	// 3. Legacy hardcoded fallback (removed in Phase 4 when all agents use templates)
 	s.logger.Info("no prompt template found, using hardcoded kick", "agent", agentName)
 	switch agentName {
 	case "scanner":

--- a/v2/pkg/tokens/claude_scanner.go
+++ b/v2/pkg/tokens/claude_scanner.go
@@ -332,7 +332,7 @@ func EnhancedAgentDetector(sessionPath string, fallbackDetector func(string) str
 		// Claude projects dir structure: ~/.claude/projects/<hash-of-working-dir>/
 		// The working dir for agents is typically /data/agents/<agent-name>/
 		lower := strings.ToLower(sessionPath)
-		agents := []string{"scanner", "ci-maintainer", "architect", "outreach", "supervisor", "sec-check", "tester", "analyst"}
+		agents := ConfiguredAgentNames()
 		for _, agent := range agents {
 			if strings.Contains(lower, agent) {
 				return agent

--- a/v2/pkg/tokens/collector.go
+++ b/v2/pkg/tokens/collector.go
@@ -349,15 +349,47 @@ func (c *Collector) saveSnapshot(agg *AggregateSummary) {
 	}
 }
 
+// configuredDetectKeywords holds config-driven agent detection keywords.
+// Set via SetDetectKeywords at startup; DefaultAgentDetector falls back to built-in if empty.
+var configuredDetectKeywords map[string][]string
+
+// SetDetectKeywords sets the agent detection keyword map from config.
+func SetDetectKeywords(keywords map[string][]string) {
+	configuredDetectKeywords = keywords
+}
+
+// configuredAgentNames holds the list of known agent names for session path detection.
+var configuredAgentNames []string
+
+// SetAgentNames sets the list of known agent names from config.
+func SetAgentNames(names []string) {
+	configuredAgentNames = names
+}
+
+// ConfiguredAgentNames returns the list of configured agent names.
+// Falls back to a default list if not configured.
+func ConfiguredAgentNames() []string {
+	if len(configuredAgentNames) > 0 {
+		return configuredAgentNames
+	}
+	return []string{"scanner", "ci-maintainer", "architect", "outreach", "supervisor", "sec-check", "tester", "analyst"}
+}
+
+var defaultDetectKeywords = map[string][]string{
+	"scanner":       {"scanner", "triage", "issue", "bug"},
+	"ci-maintainer": {"ci-maintainer", "review", "ci", "coverage", "ga4"},
+	"architect":     {"architect", "rfc", "refactor"},
+	"outreach":      {"outreach", "adopters", "community"},
+	"supervisor":    {"supervisor", "sweep", "monitor"},
+	"sec-check":     {"security", "sec-check", "vulnerability"},
+}
+
 func DefaultAgentDetector(firstMsg string) string {
 	lower := strings.ToLower(firstMsg)
-	agents := map[string][]string{
-		"scanner":    {"scanner", "triage", "issue", "bug"},
-		"ci-maintainer":   {"ci-maintainer", "review", "ci", "coverage", "ga4"},
-		"architect":  {"architect", "rfc", "refactor"},
-		"outreach":   {"outreach", "adopters", "community"},
-		"supervisor": {"supervisor", "sweep", "monitor"},
-		"sec-check":  {"security", "sec-check", "vulnerability"},
+
+	agents := configuredDetectKeywords
+	if len(agents) == 0 {
+		agents = defaultDetectKeywords
 	}
 
 	for agent, keywords := range agents {


### PR DESCRIPTION
## Summary
- Adds 13 new metadata fields to `AgentConfig` (Role, SortOrder, Emoji, Color, Aliases, LaneKeywords, DetectKeywords, KickTemplate, IncludeRepos, MetricsCollector, BeadRole, StatsDisplay, ACMMLevels)
- Replaces hardcoded agent name switches in scheduler, classifier, Discord bot, token detector, and status builder with config-driven lookups
- Frontend JSON payload now includes `role`, `sortOrder`, `emoji`, `color`, `beadRole` fields for generic rendering
- `applyKnownAgentDefaults()` bridge auto-populates defaults for existing agent names — zero-config change required

## Test plan
- [x] `go build ./...` passes
- [x] All 14 test packages pass (`go test ./... -count=1`)
- [x] Existing configs work unchanged (backward compatible via defaults bridge)
- [ ] Deploy to 4.78 and verify agents appear correctly
- [ ] Add a new test agent via YAML only — verify it appears in dashboard