### PR TITLE
feat: agent CRUD API with persistent overlay files

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -406,6 +406,9 @@ func main() {
 		PersistFunc: func() {
 			persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
 		},
+		ReInitFunc: func() {
+			initAgentConfigDrivenSystems(cfg)
+		},
 	})
 
 	if cfg.Policies.Repo != "" {

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -260,6 +260,10 @@ func main() {
 		if !saved.LastEval.IsZero() {
 			gov.SeedLastEval(saved.LastEval)
 		}
+		if saved.ACMMLevel != nil {
+			cfg.ACMMLevel = saved.ACMMLevel
+			logger.Info("ACMM level restored", "level", *saved.ACMMLevel)
+		}
 	}
 
 	if gov.GetBudget().WeeklyLimit == 0 && cfg.Governor.Budget.TotalTokens > 0 {
@@ -844,6 +848,7 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 		KickHistory:      kickEntries,
 		IssueCosts:       issueCosts,
 		LastEval:         govState.LastEval,
+		ACMMLevel:        cfg.ACMMLevel,
 	}
 
 	if err := snapshot.SaveState(path, state, logger); err != nil {

--- a/v2/deploy/blue-green-deploy.sh
+++ b/v2/deploy/blue-green-deploy.sh
@@ -97,28 +97,30 @@ docker run -d \
     --health-cmd "curl -sf http://localhost:3001/api/health" \
     --health-interval 10s \
     --health-timeout 5s \
-    --health-retries 3 \
-    --health-start-period 120s \
+    --health-retries 5 \
+    --health-start-period 180s \
     "$IMAGE"
 
 # ── 4. Wait for hive-next to become healthy ─────────────────────────
+# Probe the endpoint directly via docker exec instead of waiting for
+# Docker's health status (which delays behind health-start-period).
 log "Waiting for hive-next to become healthy..."
 elapsed=0
 while [ "$elapsed" -lt "$HEALTH_TIMEOUT_S" ]; do
-    HEALTH=$(docker inspect hive-next --format '{{.State.Health.Status}}' 2>/dev/null || echo "unknown")
-    if [ "$HEALTH" = "healthy" ]; then
+    if docker exec hive-next curl -sf http://localhost:3001/api/health >/dev/null 2>&1; then
         log "hive-next is healthy!"
         break
     fi
-    if [ "$HEALTH" = "unhealthy" ]; then
-        log "ERROR: hive-next is unhealthy. Aborting deploy."
+    RUNNING=$(docker inspect hive-next --format '{{.State.Running}}' 2>/dev/null || echo "false")
+    if [ "$RUNNING" != "true" ]; then
+        log "ERROR: hive-next stopped unexpectedly."
         docker logs hive-next --tail 20
         docker rm -f hive-next 2>/dev/null || true
         exit 1
     fi
     sleep "$HEALTH_INTERVAL_S"
     elapsed=$((elapsed + HEALTH_INTERVAL_S))
-    log "Waiting... (${elapsed}s / ${HEALTH_TIMEOUT_S}s) status=${HEALTH}"
+    log "Waiting... (${elapsed}s / ${HEALTH_TIMEOUT_S}s)"
 done
 
 if [ "$elapsed" -ge "$HEALTH_TIMEOUT_S" ]; then

--- a/v2/pkg/config/acmm_packs.go
+++ b/v2/pkg/config/acmm_packs.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"embed"
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed packs/*.yaml
+var packsFS embed.FS
+
+// ACMMPack defines a curated set of agents for a given ACMM maturity level.
+type ACMMPack struct {
+	Level       int          `json:"level" yaml:"level"`
+	Name        string       `json:"name" yaml:"name"`
+	Description string       `json:"description" yaml:"description"`
+	Agents      []PackAgent  `json:"agents" yaml:"agents"`
+	Governor    PackGovernor `json:"governor" yaml:"governor"`
+}
+
+// PackAgent describes an agent within an ACMM pack.
+type PackAgent struct {
+	Name         string   `json:"name" yaml:"name"`
+	DisplayName  string   `json:"displayName" yaml:"display_name"`
+	Role         string   `json:"role" yaml:"role"`
+	Description  string   `json:"description" yaml:"description"`
+	Emoji        string   `json:"emoji" yaml:"emoji"`
+	Color        string   `json:"color" yaml:"color"`
+	SortOrder    int      `json:"sortOrder" yaml:"sort_order"`
+	Backend      string   `json:"backend" yaml:"backend"`
+	Model        string   `json:"model" yaml:"model"`
+	BeadRole     string   `json:"beadRole" yaml:"bead_role"`
+	KickTemplate string   `json:"kickTemplate" yaml:"kick_template"`
+	IncludeRepos bool     `json:"includeRepos" yaml:"include_repos"`
+	LaneKeywords []string `json:"laneKeywords" yaml:"lane_keywords"`
+	Interactions string   `json:"interactions" yaml:"interactions"`
+	KnowledgeUse string   `json:"knowledgeUse" yaml:"knowledge_use"`
+}
+
+// PackGovernor describes the governor configuration recommended for a level.
+type PackGovernor struct {
+	Modes       string `json:"modes" yaml:"modes"`
+	MergePolicy string `json:"mergePolicy" yaml:"merge_policy"`
+}
+
+// ACMMPacks returns the built-in ACMM level pack definitions loaded from
+// embedded YAML files. These files live in v2/packs/ and can be forked,
+// tweaked, or contributed by the community.
+func ACMMPacks() []ACMMPack {
+	entries, err := packsFS.ReadDir("packs")
+	if err != nil {
+		return nil
+	}
+
+	var packs []ACMMPack
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".yaml" {
+			continue
+		}
+		data, err := packsFS.ReadFile("packs/" + entry.Name())
+		if err != nil {
+			continue
+		}
+		var pack ACMMPack
+		if err := yaml.Unmarshal(data, &pack); err != nil {
+			continue
+		}
+		packs = append(packs, pack)
+	}
+
+	sort.Slice(packs, func(i, j int) bool {
+		return packs[i].Level < packs[j].Level
+	})
+	return packs
+}
+
+// ACMMPackByLevel returns the pack for a specific level, or an error if not found.
+func ACMMPackByLevel(level int) (ACMMPack, error) {
+	for _, p := range ACMMPacks() {
+		if p.Level == level {
+			return p, nil
+		}
+	}
+	return ACMMPack{}, fmt.Errorf("ACMM pack level %d not found", level)
+}

--- a/v2/pkg/config/acmm_packs.go
+++ b/v2/pkg/config/acmm_packs.go
@@ -38,6 +38,7 @@ type PackAgent struct {
 	LaneKeywords []string `json:"laneKeywords" yaml:"lane_keywords"`
 	Interactions string   `json:"interactions" yaml:"interactions"`
 	KnowledgeUse string   `json:"knowledgeUse" yaml:"knowledge_use"`
+	Hidden       bool     `json:"hidden,omitempty" yaml:"hidden"`
 }
 
 // PackGovernor describes the governor configuration recommended for a level.

--- a/v2/pkg/config/acmm_packs_test.go
+++ b/v2/pkg/config/acmm_packs_test.go
@@ -1,0 +1,86 @@
+package config
+
+import "testing"
+
+func TestACMMPacksLoad(t *testing.T) {
+	packs := ACMMPacks()
+	if len(packs) != 7 {
+		t.Fatalf("expected 7 packs (L0-L6), got %d", len(packs))
+	}
+
+	for i, p := range packs {
+		if p.Level != i {
+			t.Errorf("pack %d: level = %d, want %d", i, p.Level, i)
+		}
+		if p.Name == "" {
+			t.Errorf("pack %d: name is empty", i)
+		}
+		if p.Description == "" {
+			t.Errorf("pack %d: description is empty", i)
+		}
+	}
+}
+
+func TestACMMPacksAgentCounts(t *testing.T) {
+	packs := ACMMPacks()
+
+	expected := map[int]int{
+		0: 0, 1: 1, 2: 2, 3: 3, 4: 8, 5: 8, 6: 8,
+	}
+	for _, p := range packs {
+		want, ok := expected[p.Level]
+		if !ok {
+			continue
+		}
+		if len(p.Agents) != want {
+			t.Errorf("L%d (%s): expected %d agents, got %d", p.Level, p.Name, want, len(p.Agents))
+		}
+	}
+}
+
+func TestACMMPacksAgentsHaveRequiredFields(t *testing.T) {
+	packs := ACMMPacks()
+	for _, p := range packs {
+		for _, a := range p.Agents {
+			if a.Name == "" {
+				t.Errorf("L%d: agent missing name", p.Level)
+			}
+			if a.Emoji == "" {
+				t.Errorf("L%d %s: missing emoji", p.Level, a.Name)
+			}
+			if a.Color == "" {
+				t.Errorf("L%d %s: missing color", p.Level, a.Name)
+			}
+			if a.SortOrder == 0 {
+				t.Errorf("L%d %s: sort_order is 0", p.Level, a.Name)
+			}
+			if a.Description == "" {
+				t.Errorf("L%d %s: missing description", p.Level, a.Name)
+			}
+		}
+	}
+}
+
+func TestACMMPackByLevel(t *testing.T) {
+	p, err := ACMMPackByLevel(4)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Name != "Full Automation" {
+		t.Errorf("L4 name = %q, want 'Full Automation'", p.Name)
+	}
+
+	_, err = ACMMPackByLevel(99)
+	if err == nil {
+		t.Error("expected error for non-existent level 99")
+	}
+}
+
+func TestACMMPacksAreSorted(t *testing.T) {
+	packs := ACMMPacks()
+	for i := 1; i < len(packs); i++ {
+		if packs[i].Level <= packs[i-1].Level {
+			t.Errorf("packs not sorted: L%d before L%d", packs[i-1].Level, packs[i].Level)
+		}
+	}
+}

--- a/v2/pkg/config/agent_overlay.go
+++ b/v2/pkg/config/agent_overlay.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// LoadAgentOverrides reads all .yaml files from dir and returns them as a map
+// of agent name → AgentConfig. Each file should contain a single agent config
+// with the filename (minus extension) used as the agent name.
+func LoadAgentOverrides(dir string) (map[string]AgentConfig, error) {
+	if dir == "" {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading agent overlay dir %s: %w", dir, err)
+	}
+
+	agents := make(map[string]AgentConfig)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+		name := strings.TrimSuffix(entry.Name(), ".yaml")
+		path := filepath.Join(dir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading agent file %s: %w", path, err)
+		}
+
+		var agent AgentConfig
+		if err := yaml.Unmarshal(data, &agent); err != nil {
+			return nil, fmt.Errorf("parsing agent file %s: %w", path, err)
+		}
+		agent.Managed = true
+		agents[name] = agent
+	}
+	return agents, nil
+}
+
+// MergeAgentOverrides merges overlay agents into the config's agent map.
+// Overlay agents override base config agents with the same name.
+func (c *Config) MergeAgentOverrides(overlays map[string]AgentConfig) {
+	if c.Agents == nil {
+		c.Agents = make(map[string]AgentConfig)
+	}
+	for name, agent := range overlays {
+		agent.Managed = true
+		c.Agents[name] = agent
+	}
+}
+
+// SaveAgentFile writes a single agent config to dir/<name>.yaml.
+func SaveAgentFile(dir, name string, agent AgentConfig) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating agent overlay dir: %w", err)
+	}
+
+	// Don't persist internal-only fields
+	agent.Managed = false
+	agent.name = ""
+	agent.clearOnKickSet = false
+
+	data, err := yaml.Marshal(&agent)
+	if err != nil {
+		return fmt.Errorf("marshaling agent %s: %w", name, err)
+	}
+
+	path := filepath.Join(dir, name+".yaml")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("writing agent file %s: %w", path, err)
+	}
+	return nil
+}
+
+// RemoveAgentFile deletes dir/<name>.yaml.
+func RemoveAgentFile(dir, name string) error {
+	path := filepath.Join(dir, name+".yaml")
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing agent file %s: %w", path, err)
+	}
+	return nil
+}
+
+// ApplyAgentDefaults runs the same defaulting logic as applyDefaults for a
+// single agent entry. Call this after adding an agent at runtime.
+func (c *Config) ApplyAgentDefaults(name string) {
+	agent, ok := c.Agents[name]
+	if !ok {
+		return
+	}
+	agent.name = name
+	if agent.ID == "" {
+		agent.ID = name
+	}
+	if agent.BeadsDir == "" {
+		agent.BeadsDir = fmt.Sprintf("/data/beads/%s", name)
+	}
+	if !agent.Enabled {
+		agent.Enabled = true
+	}
+	if !agent.clearOnKickSet {
+		agent.ClearOnKick = true
+	}
+	if agent.Role == "" {
+		agent.Role = name
+	}
+	applyKnownAgentDefaults(name, &agent)
+	c.Agents[name] = agent
+}

--- a/v2/pkg/config/agent_overlay_test.go
+++ b/v2/pkg/config/agent_overlay_test.go
@@ -1,0 +1,201 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadAgentOverrides_Empty(t *testing.T) {
+	dir := t.TempDir()
+	agents, err := LoadAgentOverrides(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(agents) != 0 {
+		t.Errorf("expected 0 agents, got %d", len(agents))
+	}
+}
+
+func TestLoadAgentOverrides_NonExistent(t *testing.T) {
+	agents, err := LoadAgentOverrides("/nonexistent/path")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agents != nil {
+		t.Errorf("expected nil, got %v", agents)
+	}
+}
+
+func TestLoadAgentOverrides_EmptyPath(t *testing.T) {
+	agents, err := LoadAgentOverrides("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agents != nil {
+		t.Errorf("expected nil, got %v", agents)
+	}
+}
+
+func TestSaveAndLoadAgentFile(t *testing.T) {
+	dir := t.TempDir()
+
+	includeRepos := true
+	agent := AgentConfig{
+		Backend:      "copilot",
+		Model:        "claude-sonnet-4-6",
+		Enabled:      true,
+		DisplayName:  "Docs Writer",
+		Description:  "Writes docs",
+		SortOrder:    45,
+		Emoji:        "📝",
+		Color:        "#e91e63",
+		BeadRole:     "worker",
+		LaneKeywords: []string{"docs", "readme"},
+		IncludeRepos: &includeRepos,
+	}
+
+	if err := SaveAgentFile(dir, "docs-writer", agent); err != nil {
+		t.Fatalf("save failed: %v", err)
+	}
+
+	path := filepath.Join(dir, "docs-writer.yaml")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Fatalf("file not created at %s", path)
+	}
+
+	agents, err := LoadAgentOverrides(dir)
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if len(agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(agents))
+	}
+
+	loaded, ok := agents["docs-writer"]
+	if !ok {
+		t.Fatal("docs-writer not found in loaded agents")
+	}
+	if loaded.DisplayName != "Docs Writer" {
+		t.Errorf("display_name = %q, want %q", loaded.DisplayName, "Docs Writer")
+	}
+	if loaded.SortOrder != 45 {
+		t.Errorf("sort_order = %d, want 45", loaded.SortOrder)
+	}
+	if loaded.Emoji != "📝" {
+		t.Errorf("emoji = %q, want 📝", loaded.Emoji)
+	}
+	if loaded.Color != "#e91e63" {
+		t.Errorf("color = %q, want #e91e63", loaded.Color)
+	}
+	if !loaded.Managed {
+		t.Error("loaded agent should have Managed=true")
+	}
+}
+
+func TestRemoveAgentFile(t *testing.T) {
+	dir := t.TempDir()
+
+	agent := AgentConfig{Backend: "copilot", Enabled: true}
+	if err := SaveAgentFile(dir, "test-agent", agent); err != nil {
+		t.Fatalf("save failed: %v", err)
+	}
+
+	if err := RemoveAgentFile(dir, "test-agent"); err != nil {
+		t.Fatalf("remove failed: %v", err)
+	}
+
+	path := filepath.Join(dir, "test-agent.yaml")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("file should have been deleted at %s", path)
+	}
+}
+
+func TestRemoveAgentFile_NonExistent(t *testing.T) {
+	dir := t.TempDir()
+	if err := RemoveAgentFile(dir, "no-such-agent"); err != nil {
+		t.Errorf("removing non-existent file should not error, got: %v", err)
+	}
+}
+
+func TestMergeAgentOverrides(t *testing.T) {
+	cfg := &Config{
+		Agents: map[string]AgentConfig{
+			"scanner": {Backend: "claude", Enabled: true},
+		},
+	}
+
+	overlays := map[string]AgentConfig{
+		"docs-writer": {Backend: "copilot", Enabled: true, Managed: true},
+	}
+	cfg.MergeAgentOverrides(overlays)
+
+	if len(cfg.Agents) != 2 {
+		t.Fatalf("expected 2 agents, got %d", len(cfg.Agents))
+	}
+	if !cfg.Agents["docs-writer"].Managed {
+		t.Error("overlay agent should have Managed=true")
+	}
+	if cfg.Agents["scanner"].Managed {
+		t.Error("base agent should have Managed=false")
+	}
+}
+
+func TestMergeAgentOverrides_OverrideExisting(t *testing.T) {
+	cfg := &Config{
+		Agents: map[string]AgentConfig{
+			"scanner": {Backend: "claude", Model: "opus", Enabled: true},
+		},
+	}
+
+	overlays := map[string]AgentConfig{
+		"scanner": {Backend: "copilot", Model: "sonnet", Enabled: true, Managed: true},
+	}
+	cfg.MergeAgentOverrides(overlays)
+
+	if cfg.Agents["scanner"].Backend != "copilot" {
+		t.Errorf("overlay should override base: backend = %q, want copilot", cfg.Agents["scanner"].Backend)
+	}
+}
+
+func TestApplyAgentDefaults(t *testing.T) {
+	cfg := &Config{
+		Agents: map[string]AgentConfig{
+			"my-agent": {Backend: "copilot", Enabled: true},
+		},
+	}
+	cfg.ApplyAgentDefaults("my-agent")
+
+	agent := cfg.Agents["my-agent"]
+	if agent.ID != "my-agent" {
+		t.Errorf("ID = %q, want my-agent", agent.ID)
+	}
+	if agent.Name() != "my-agent" {
+		t.Errorf("Name() = %q, want my-agent", agent.Name())
+	}
+	if agent.Role != "my-agent" {
+		t.Errorf("Role = %q, want my-agent", agent.Role)
+	}
+	if agent.BeadsDir != "/data/beads/my-agent" {
+		t.Errorf("BeadsDir = %q, want /data/beads/my-agent", agent.BeadsDir)
+	}
+}
+
+func TestLoadSkipsNonYAML(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(dir, "subdir.yaml"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	agents, err := LoadAgentOverrides(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(agents) != 0 {
+		t.Errorf("expected 0 agents, got %d", len(agents))
+	}
+}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -88,33 +88,33 @@ type StatsDisplayEntry struct {
 }
 
 type AgentConfig struct {
-	ID              string `yaml:"id"`
-	Backend         string `yaml:"backend"`
-	Model           string `yaml:"model"`
-	BeadsDir        string `yaml:"beads_dir"`
-	Enabled         bool   `yaml:"enabled"`
+	ID              string `yaml:"id" json:"id,omitempty"`
+	Backend         string `yaml:"backend" json:"backend,omitempty"`
+	Model           string `yaml:"model" json:"model,omitempty"`
+	BeadsDir        string `yaml:"beads_dir" json:"beads_dir,omitempty"`
+	Enabled         bool   `yaml:"enabled" json:"enabled,omitempty"`
 	ClearOnKick     bool   `yaml:"clear_on_kick"`
 	CLIPinned       bool   `yaml:"cli_pinned"`
 	StaleTimeout    int    `yaml:"stale_timeout"`
 	RestartStrategy string `yaml:"restart_strategy"`
 	LaunchCmd       string `yaml:"launch_cmd"`
-	DisplayName     string `yaml:"display_name"`
-	Description     string `yaml:"description"`
+	DisplayName     string `yaml:"display_name" json:"display_name,omitempty"`
+	Description     string `yaml:"description" json:"description,omitempty"`
 
 	// Phase 2: config-driven agent behavior fields
-	Role             string            `yaml:"role"`
-	SortOrder        int               `yaml:"sort_order"`
-	Emoji            string            `yaml:"emoji"`
-	Color            string            `yaml:"color"`
-	Aliases          []string          `yaml:"aliases"`
-	LaneKeywords     []string          `yaml:"lane_keywords"`
-	DetectKeywords   []string          `yaml:"detect_keywords"`
-	KickTemplate     string            `yaml:"kick_template"`
-	IncludeRepos     *bool             `yaml:"include_repos"`
-	MetricsCollector string            `yaml:"metrics_collector"`
-	BeadRole         string            `yaml:"bead_role"`
-	StatsDisplay     []StatsDisplayEntry `yaml:"stats_display"`
-	ACMMLevels       []int             `yaml:"acmm_levels"`
+	Role             string            `yaml:"role" json:"role,omitempty"`
+	SortOrder        int               `yaml:"sort_order" json:"sort_order,omitempty"`
+	Emoji            string            `yaml:"emoji" json:"emoji,omitempty"`
+	Color            string            `yaml:"color" json:"color,omitempty"`
+	Aliases          []string          `yaml:"aliases" json:"aliases,omitempty"`
+	LaneKeywords     []string          `yaml:"lane_keywords" json:"lane_keywords,omitempty"`
+	DetectKeywords   []string          `yaml:"detect_keywords" json:"detect_keywords,omitempty"`
+	KickTemplate     string            `yaml:"kick_template" json:"kick_template,omitempty"`
+	IncludeRepos     *bool             `yaml:"include_repos" json:"include_repos,omitempty"`
+	MetricsCollector string            `yaml:"metrics_collector" json:"metrics_collector,omitempty"`
+	BeadRole         string            `yaml:"bead_role" json:"bead_role,omitempty"`
+	StatsDisplay     []StatsDisplayEntry `yaml:"stats_display" json:"stats_display,omitempty"`
+	ACMMLevels       []int             `yaml:"acmm_levels" json:"acmm_levels,omitempty"`
 
 	// Managed is true for agents loaded from the overlay directory (not base config).
 	Managed bool `yaml:"-" json:"managed"`

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -94,11 +94,11 @@ type AgentConfig struct {
 	Model           string `yaml:"model" json:"model,omitempty"`
 	BeadsDir        string `yaml:"beads_dir" json:"beads_dir,omitempty"`
 	Enabled         bool   `yaml:"enabled" json:"enabled,omitempty"`
-	ClearOnKick     bool   `yaml:"clear_on_kick"`
-	CLIPinned       bool   `yaml:"cli_pinned"`
-	StaleTimeout    int    `yaml:"stale_timeout"`
-	RestartStrategy string `yaml:"restart_strategy"`
-	LaunchCmd       string `yaml:"launch_cmd"`
+	ClearOnKick     bool   `yaml:"clear_on_kick" json:"clear_on_kick"`
+	CLIPinned       bool   `yaml:"cli_pinned" json:"cli_pinned,omitempty"`
+	StaleTimeout    int    `yaml:"stale_timeout" json:"stale_timeout,omitempty"`
+	RestartStrategy string `yaml:"restart_strategy" json:"restart_strategy,omitempty"`
+	LaunchCmd       string `yaml:"launch_cmd" json:"launch_cmd,omitempty"`
 	DisplayName     string `yaml:"display_name" json:"display_name,omitempty"`
 	Description     string `yaml:"description" json:"description,omitempty"`
 

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -22,7 +22,7 @@ type Config struct {
 	Data          DataConfig                   `yaml:"data"`
 	Knowledge     KnowledgeConfig              `yaml:"knowledge"`
 	HiveID        string                       `yaml:"hive_id"`
-	ACMMLevel     int                          `yaml:"acmm_level" json:"acmm_level,omitempty"`
+	ACMMLevel     *int                         `yaml:"acmm_level,omitempty" json:"acmm_level"`
 }
 
 type KnowledgeConfig struct {

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -116,6 +116,9 @@ type AgentConfig struct {
 	StatsDisplay     []StatsDisplayEntry `yaml:"stats_display"`
 	ACMMLevels       []int             `yaml:"acmm_levels"`
 
+	// Managed is true for agents loaded from the overlay directory (not base config).
+	Managed bool `yaml:"-" json:"managed"`
+
 	// clearOnKickSet tracks whether YAML explicitly set clear_on_kick to false
 	clearOnKickSet bool
 	// name is the YAML map key, set during config load
@@ -295,6 +298,7 @@ type DataConfig struct {
 	LogsDir             string `yaml:"logs_dir"`
 	ClaudeSessionsDir   string `yaml:"claude_sessions_dir"`
 	CopilotSessionsDir  string `yaml:"copilot_sessions_dir"`
+	AgentsDir           string `yaml:"agents_dir"`
 }
 
 var envVarPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
@@ -333,6 +337,19 @@ func LoadWithOverrides(path, envPath string) (*Config, error) {
 	}
 
 	cfg.applyDefaults()
+
+	// Merge per-agent overlay files from the agents directory.
+	if cfg.Data.AgentsDir != "" {
+		overlays, err := LoadAgentOverrides(cfg.Data.AgentsDir)
+		if err != nil {
+			return nil, fmt.Errorf("loading agent overlays: %w", err)
+		}
+		cfg.MergeAgentOverrides(overlays)
+		// Re-apply defaults for overlay agents.
+		for name := range overlays {
+			cfg.ApplyAgentDefaults(name)
+		}
+	}
 
 	if err := cfg.validate(); err != nil {
 		return nil, fmt.Errorf("validating config: %w", err)
@@ -477,6 +494,9 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Data.CopilotSessionsDir == "" {
 		c.Data.CopilotSessionsDir = "/data/home/.copilot/session-state"
+	}
+	if c.Data.AgentsDir == "" {
+		c.Data.AgentsDir = "/data/agents"
 	}
 	for name, agent := range c.Agents {
 		agent.name = name

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -496,7 +496,7 @@ func (c *Config) applyDefaults() {
 		c.Data.CopilotSessionsDir = "/data/home/.copilot/session-state"
 	}
 	if c.Data.AgentsDir == "" {
-		c.Data.AgentsDir = "/data/agents"
+		c.Data.AgentsDir = "/data/agent-configs"
 	}
 	for name, agent := range c.Agents {
 		agent.name = name

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Data          DataConfig                   `yaml:"data"`
 	Knowledge     KnowledgeConfig              `yaml:"knowledge"`
 	HiveID        string                       `yaml:"hive_id"`
+	ACMMLevel     int                          `yaml:"acmm_level" json:"acmm_level,omitempty"`
 }
 
 type KnowledgeConfig struct {

--- a/v2/pkg/config/packs/level-0.yaml
+++ b/v2/pkg/config/packs/level-0.yaml
@@ -1,0 +1,9 @@
+level: 0
+name: Unaware
+description: >
+  No AI tooling. Manual everything. This is your baseline for comparison
+  as you adopt higher levels of AI-assisted development.
+governor:
+  modes: none
+  merge_policy: manual
+agents: []

--- a/v2/pkg/config/packs/level-1.yaml
+++ b/v2/pkg/config/packs/level-1.yaml
@@ -1,0 +1,29 @@
+level: 1
+name: Idea
+description: >
+  Project conception and scaffolding. A single interactive advisor helps with
+  repo setup, test stubs, and early architecture decisions. All actions require
+  human approval. The knowledge base is your primary asset at this level.
+governor:
+  modes: none
+  merge_policy: manual
+agents:
+  - name: guide
+    display_name: Guide
+    role: guide
+    description: >
+      Interactive advisor that queries the community knowledge base for
+      scaffolding patterns. Helps create repos, initial structure, and test
+      stubs. No autonomous actions — everything is conversational.
+    emoji: "🧭"
+    color: "#8e44ad"
+    sort_order: 10
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    kick_template: guide-CLAUDE.md
+    include_repos: false
+    interactions: "Standalone. Responds to user queries only."
+    knowledge_use: >
+      Heavy consumer — reads community wiki, project patterns, and scaffolding
+      templates. Does not produce knowledge entries at this level.

--- a/v2/pkg/config/packs/level-2.yaml
+++ b/v2/pkg/config/packs/level-2.yaml
@@ -1,0 +1,47 @@
+level: 2
+name: Development
+description: >
+  Code exists, PRs are manual, knowledge is accumulating. An enhanced advisor
+  reviews PRs on request. An advisory scanner suggests fixes but does not
+  create PRs or issues. Agents start building your knowledge base.
+governor:
+  modes: none
+  merge_policy: manual
+agents:
+  - name: guide
+    display_name: Guide
+    role: guide
+    description: >
+      Enhanced advisor that reviews PRs on request, flags code without tests,
+      and suggests patterns from the knowledge base.
+    emoji: "🧭"
+    color: "#8e44ad"
+    sort_order: 10
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    kick_template: guide-CLAUDE.md
+    include_repos: false
+    interactions: "Works alongside scanner. Reviews scanner's suggestions when asked."
+    knowledge_use: >
+      Reads community wiki and project patterns. Starts contributing review
+      insights as knowledge entries.
+  - name: scanner
+    display_name: Scanner (Advisory)
+    role: scanner
+    description: >
+      Scans code for issues and suggests fixes, but does NOT create PRs or
+      issues. Reports findings to the user for manual action.
+    emoji: "🔍"
+    color: "#3498db"
+    sort_order: 20
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    kick_template: scanner-advisory-CLAUDE.md
+    include_repos: true
+    lane_keywords: [bug, triage, fix]
+    interactions: "Produces findings that guide can review. No autonomous actions."
+    knowledge_use: >
+      Reads project patterns and known issues. Produces findings as knowledge
+      entries for the team to review.

--- a/v2/pkg/config/packs/level-2.yaml
+++ b/v2/pkg/config/packs/level-2.yaml
@@ -45,3 +45,21 @@ agents:
     knowledge_use: >
       Reads project patterns and known issues. Produces findings as knowledge
       entries for the team to review.
+  - name: tester
+    display_name: Quality
+    role: tester
+    description: >
+      Generates test cases for existing code. Focuses on coverage gaps and
+      edge cases. All tests require human review before merging.
+    emoji: "🧪"
+    color: "#e67e22"
+    sort_order: 25
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    kick_template: tester-CLAUDE.md
+    include_repos: true
+    interactions: "Complements scanner findings with targeted tests. Guide reviews test quality."
+    knowledge_use: >
+      Reads test patterns, coverage rules, and known regressions from the
+      knowledge base to prioritize which code needs tests most.

--- a/v2/pkg/config/packs/level-3.yaml
+++ b/v2/pkg/config/packs/level-3.yaml
@@ -92,3 +92,18 @@ agents:
     knowledge_use: >
       Reads test patterns, coverage rules, regressions. Produces test coverage
       reports and quality gate records.
+  - name: guide
+    display_name: Guide
+    role: guide
+    description: >
+      Enhanced advisor that reviews PRs on request, flags code without tests,
+      and suggests patterns from the knowledge base.
+    emoji: "🧭"
+    color: "#8e44ad"
+    sort_order: 5
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    kick_template: guide-CLAUDE.md
+    include_repos: false
+    hidden: true

--- a/v2/pkg/config/packs/level-3.yaml
+++ b/v2/pkg/config/packs/level-3.yaml
@@ -1,0 +1,73 @@
+level: 3
+name: CI/CD
+description: >
+  Automated builds, coverage gates, and active scanning. Agents create PRs
+  and issues. All merges require CI pass. Governor runs in QUIET/IDLE modes.
+  Coverage gate at 70%+ with ratcheting.
+governor:
+  modes: QUIET, IDLE
+  merge_policy: CI must pass (merge-gate.sh)
+agents:
+  - name: scanner
+    display_name: Scanner
+    role: scanner
+    description: >
+      Triages issues, creates fix PRs for simple bugs, and opens issues when
+      coverage drops. Active, not just advisory.
+    emoji: "🔍"
+    color: "#3498db"
+    sort_order: 20
+    backend: copilot
+    model: claude-opus-4-6
+    bead_role: worker
+    kick_template: scanner-CLAUDE.md
+    include_repos: true
+    lane_keywords: [bug, triage, fix, issue]
+    interactions: >
+      Creates PRs that ci-maintainer monitors. Transfers complex issues to
+      architect via lane routing.
+    knowledge_use: >
+      Reads known patterns, past fixes, and regression history. Produces fix
+      records and triage decisions.
+  - name: ci-maintainer
+    display_name: CI Maintainer
+    role: ci-maintainer
+    description: >
+      Monitors CI health, nightly tests, and coverage trends. Post-merge state
+      checks ensure nothing regresses.
+    emoji: "🔧"
+    color: "#2ecc71"
+    sort_order: 30
+    backend: copilot
+    model: claude-opus-4-6
+    bead_role: worker
+    kick_template: ci-maintainer-CLAUDE.md
+    include_repos: true
+    lane_keywords: [ci, build, pipeline, workflow]
+    interactions: >
+      Watches scanner's PRs for CI failures. Coordinates with architect on
+      workflow changes.
+    knowledge_use: >
+      Reads CI patterns and past failures. Produces CI health reports and
+      workflow optimization insights.
+  - name: architect
+    display_name: Architect
+    role: architect
+    description: >
+      RFCs for cross-cutting changes. Activated when scanner transfers complex
+      issues via lane routing. Opportunistic — not always active.
+    emoji: "🏗"
+    color: "#9b59b6"
+    sort_order: 40
+    backend: copilot
+    model: claude-opus-4-6
+    bead_role: worker
+    kick_template: architect-CLAUDE.md
+    include_repos: true
+    lane_keywords: [refactor, architecture, rfc, design]
+    interactions: >
+      Receives complex issues from scanner. Produces RFCs that other agents
+      can reference.
+    knowledge_use: >
+      Heavy consumer of architecture decisions and patterns. Produces RFCs
+      and design records.

--- a/v2/pkg/config/packs/level-3.yaml
+++ b/v2/pkg/config/packs/level-3.yaml
@@ -71,3 +71,24 @@ agents:
     knowledge_use: >
       Heavy consumer of architecture decisions and patterns. Produces RFCs
       and design records.
+  - name: tester
+    display_name: Quality
+    role: tester
+    description: >
+      Full TDD enforcement. Coverage ratcheting. Generates integration tests,
+      quality gates, and regression suites. Works with scanner findings.
+    emoji: "🧪"
+    color: "#e67e22"
+    sort_order: 25
+    backend: copilot
+    model: claude-opus-4-6
+    bead_role: worker
+    kick_template: tester-CLAUDE.md
+    include_repos: true
+    lane_keywords: [test, coverage, quality, regression]
+    interactions: >
+      Uses scanner findings to generate targeted tests. CI-maintainer validates
+      test results in the pipeline.
+    knowledge_use: >
+      Reads test patterns, coverage rules, regressions. Produces test coverage
+      reports and quality gate records.

--- a/v2/pkg/config/packs/level-4.yaml
+++ b/v2/pkg/config/packs/level-4.yaml
@@ -1,0 +1,176 @@
+level: 4
+name: Full Automation
+description: >
+  24/7 agents with dynamic scaling, full TDD enforcement, and community
+  outreach. Governor active in all modes (SURGE/BUSY/QUIET/IDLE). Coverage
+  gate at 90%+ with ratcheting. This is the standard production level.
+governor:
+  modes: SURGE, BUSY, QUIET, IDLE
+  merge_policy: CI + coverage gate (90%+)
+agents:
+  - name: supervisor
+    display_name: Supervisor
+    role: supervisor
+    description: >
+      Agent health monitoring, sweep analysis, and escalation. Watches all
+      other agents for stalls, rate limits, and anomalies.
+    emoji: "👑"
+    color: "#e74c3c"
+    sort_order: 10
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: supervisor
+    kick_template: supervisor-CLAUDE.md
+    include_repos: true
+    interactions: >
+      Monitors all agents. Escalates issues to human operators. Coordinates
+      agent restarts and health checks.
+    knowledge_use: >
+      Reads agent health history and operational patterns. Produces sweep
+      reports and health assessments.
+  - name: scanner
+    display_name: Scanner
+    role: scanner
+    description: >
+      Full triage and fix capability. Parallel dispatch with 30-minute SLA
+      on issue response.
+    emoji: "🔍"
+    color: "#3498db"
+    sort_order: 20
+    backend: copilot
+    model: claude-opus-4-6
+    bead_role: worker
+    kick_template: scanner-CLAUDE.md
+    include_repos: true
+    lane_keywords: [bug, triage, fix, issue]
+    interactions: >
+      Creates PRs that tester validates. Transfers complex issues to architect.
+      Reports to supervisor.
+    knowledge_use: >
+      Reads full project history, known regressions, and fix patterns. Produces
+      fix records and triage decisions.
+  - name: ci-maintainer
+    display_name: CI Maintainer
+    role: ci-maintainer
+    description: >
+      Full CI pipeline ownership. Nightly E2E monitoring. Dependency updates
+      and workflow optimization.
+    emoji: "🔧"
+    color: "#2ecc71"
+    sort_order: 30
+    backend: copilot
+    model: claude-opus-4-6
+    bead_role: worker
+    kick_template: ci-maintainer-CLAUDE.md
+    include_repos: true
+    lane_keywords: [ci, build, pipeline, workflow, dependency]
+    interactions: >
+      Coordinates with tester on coverage gates. Reports pipeline health
+      to supervisor.
+    knowledge_use: >
+      Reads CI history and optimization patterns. Produces workflow health
+      reports.
+  - name: tester
+    display_name: Tester
+    role: tester
+    description: >
+      Full TDD enforcement with coverage ratcheting. Generates tests for new
+      code and validates scanner PRs.
+    emoji: "🧪"
+    color: "#3498db"
+    sort_order: 35
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    kick_template: tester-CLAUDE.md
+    include_repos: true
+    lane_keywords: [test, coverage, tdd, quality]
+    interactions: >
+      Reviews scanner PRs for test coverage. Coordinates with ci-maintainer
+      on test infrastructure.
+    knowledge_use: >
+      Reads test patterns and coverage history. Produces coverage reports
+      and test strategy insights.
+  - name: architect
+    display_name: Architect
+    role: architect
+    description: >
+      Active architecture agent. RFCs, refactors, and new features. Proactively
+      identifies improvement areas.
+    emoji: "🏗"
+    color: "#9b59b6"
+    sort_order: 40
+    backend: copilot
+    model: claude-opus-4-6
+    bead_role: worker
+    kick_template: architect-CLAUDE.md
+    include_repos: true
+    lane_keywords: [refactor, architecture, rfc, design, feature]
+    interactions: >
+      Receives complex issues from scanner. Produces RFCs that all agents
+      reference.
+    knowledge_use: >
+      Heavy consumer and producer of architecture decisions, patterns, and
+      design records.
+  - name: outreach
+    display_name: Outreach
+    role: outreach
+    description: >
+      Community engagement, ADOPTERS tracking, and ecosystem missions.
+      Monitors adoption metrics and files issues on partner projects.
+    emoji: "🌐"
+    color: "#e67e22"
+    sort_order: 50
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    kick_template: outreach-CLAUDE.md
+    include_repos: false
+    lane_keywords: [community, adopters, outreach, ecosystem]
+    interactions: >
+      Independent agent. Reports adoption metrics to supervisor.
+    knowledge_use: >
+      Reads community patterns and adoption history. Produces outreach
+      reports and engagement insights.
+  - name: sec-check
+    display_name: Security
+    role: sec-check
+    description: >
+      Security scanning, dependency audit, and vulnerability monitoring.
+      CVE tracking and security gate enforcement.
+    emoji: "🛡"
+    color: "#1abc9c"
+    sort_order: 60
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    kick_template: sec-check-CLAUDE.md
+    include_repos: true
+    lane_keywords: [security, cve, vulnerability, audit]
+    interactions: >
+      Reports critical findings to supervisor for escalation. Coordinates
+      with ci-maintainer on security gates.
+    knowledge_use: >
+      Reads vulnerability databases and past security fixes. Produces
+      security audit reports.
+  - name: strategist
+    display_name: Strategist
+    role: strategist
+    description: >
+      Strategic planning, roadmap alignment, and cross-agent coordination.
+      Analyzes trends across all agents.
+    emoji: "🧠"
+    color: "#f39c12"
+    sort_order: 70
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    kick_template: strategist-CLAUDE.md
+    include_repos: false
+    lane_keywords: [strategy, roadmap, planning]
+    interactions: >
+      Reads all agent outputs. Produces strategic insights and priority
+      recommendations.
+    knowledge_use: >
+      Heavy consumer of all agent knowledge. Produces strategic summaries
+      and priority recommendations.

--- a/v2/pkg/config/packs/level-4.yaml
+++ b/v2/pkg/config/packs/level-4.yaml
@@ -174,3 +174,18 @@ agents:
     knowledge_use: >
       Heavy consumer of all agent knowledge. Produces strategic summaries
       and priority recommendations.
+  - name: guide
+    display_name: Guide
+    role: guide
+    description: >
+      Enhanced advisor that reviews PRs on request, flags code without tests,
+      and suggests patterns from the knowledge base.
+    emoji: "🧭"
+    color: "#8e44ad"
+    sort_order: 5
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    kick_template: guide-CLAUDE.md
+    include_repos: false
+    hidden: true

--- a/v2/pkg/config/packs/level-5.yaml
+++ b/v2/pkg/config/packs/level-5.yaml
@@ -1,0 +1,159 @@
+level: 5
+name: Guarded Autonomy
+description: >
+  Same agents as Level 4 but with hold-gated merges. All agent-created PRs
+  get a 'hold' label automatically. Humans batch-review and approve. Ideal
+  for regulated industries, compliance requirements, or teams building trust
+  in their AI pipeline.
+governor:
+  modes: SURGE, BUSY, QUIET, IDLE
+  merge_policy: >
+    Hold-gated — all agent PRs get 'hold' label. Human batch-approves.
+    merge-gate.sh blocks agent merges. batch-approve.sh for human review.
+agents:
+  - name: supervisor
+    display_name: Supervisor
+    role: supervisor
+    description: >
+      Agent health monitoring and sweep analysis. Same as L4.
+    emoji: "👑"
+    color: "#e74c3c"
+    sort_order: 10
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: supervisor
+    kick_template: supervisor-CLAUDE.md
+    include_repos: true
+    interactions: >
+      Monitors all agents. Escalates issues to human operators.
+    knowledge_use: >
+      Reads agent health history. Produces sweep reports.
+  - name: scanner
+    display_name: Scanner
+    role: scanner
+    description: >
+      Opens issues and PRs but does NOT merge. All PRs get 'hold' label
+      automatically. Human reviews in batches.
+    emoji: "🔍"
+    color: "#3498db"
+    sort_order: 20
+    backend: copilot
+    model: claude-opus-4-6
+    bead_role: worker
+    kick_template: scanner-guarded-CLAUDE.md
+    include_repos: true
+    lane_keywords: [bug, triage, fix, issue]
+    interactions: >
+      Creates hold-gated PRs. Tester validates but does not approve.
+    knowledge_use: >
+      Same as L4. Full project history access.
+  - name: ci-maintainer
+    display_name: CI Maintainer
+    role: ci-maintainer
+    description: >
+      Same as L4. CI changes are low-risk and don't need hold gating.
+    emoji: "🔧"
+    color: "#2ecc71"
+    sort_order: 30
+    backend: copilot
+    model: claude-opus-4-6
+    bead_role: worker
+    kick_template: ci-maintainer-CLAUDE.md
+    include_repos: true
+    lane_keywords: [ci, build, pipeline, workflow, dependency]
+    interactions: >
+      Same as L4.
+    knowledge_use: >
+      Same as L4.
+  - name: tester
+    display_name: Tester
+    role: tester
+    description: >
+      Same as L4. Tests and validates but does not approve merges.
+    emoji: "🧪"
+    color: "#3498db"
+    sort_order: 35
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    kick_template: tester-CLAUDE.md
+    include_repos: true
+    lane_keywords: [test, coverage, tdd, quality]
+    interactions: >
+      Reviews PRs for coverage. Adds /lgtm but does NOT /approve.
+    knowledge_use: >
+      Same as L4.
+  - name: architect
+    display_name: Architect
+    role: architect
+    description: >
+      Same as L4. RFCs are advisory by nature and don't need hold gating.
+    emoji: "🏗"
+    color: "#9b59b6"
+    sort_order: 40
+    backend: copilot
+    model: claude-opus-4-6
+    bead_role: worker
+    kick_template: architect-CLAUDE.md
+    include_repos: true
+    lane_keywords: [refactor, architecture, rfc, design, feature]
+    interactions: >
+      Same as L4.
+    knowledge_use: >
+      Same as L4.
+  - name: outreach
+    display_name: Outreach
+    role: outreach
+    description: >
+      Proposes outreach but does NOT file external issues/PRs without
+      human approval.
+    emoji: "🌐"
+    color: "#e67e22"
+    sort_order: 50
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    kick_template: outreach-guarded-CLAUDE.md
+    include_repos: false
+    lane_keywords: [community, adopters, outreach, ecosystem]
+    interactions: >
+      Drafts outreach actions for human review before execution.
+    knowledge_use: >
+      Same as L4.
+  - name: sec-check
+    display_name: Security
+    role: sec-check
+    description: >
+      Enhanced security scanning with CVE monitoring. Critical findings
+      escalate to supervisor immediately.
+    emoji: "🛡"
+    color: "#1abc9c"
+    sort_order: 60
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    kick_template: sec-check-CLAUDE.md
+    include_repos: true
+    lane_keywords: [security, cve, vulnerability, audit]
+    interactions: >
+      Same as L4 plus immediate escalation for critical CVEs.
+    knowledge_use: >
+      Same as L4.
+  - name: strategist
+    display_name: Strategist
+    role: strategist
+    description: >
+      Same as L4.
+    emoji: "🧠"
+    color: "#f39c12"
+    sort_order: 70
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    kick_template: strategist-CLAUDE.md
+    include_repos: false
+    lane_keywords: [strategy, roadmap, planning]
+    interactions: >
+      Same as L4.
+    knowledge_use: >
+      Same as L4.

--- a/v2/pkg/config/packs/level-5.yaml
+++ b/v2/pkg/config/packs/level-5.yaml
@@ -157,3 +157,18 @@ agents:
       Same as L4.
     knowledge_use: >
       Same as L4.
+  - name: guide
+    display_name: Guide
+    role: guide
+    description: >
+      Enhanced advisor that reviews PRs on request, flags code without tests,
+      and suggests patterns from the knowledge base.
+    emoji: "🧭"
+    color: "#8e44ad"
+    sort_order: 5
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    kick_template: guide-CLAUDE.md
+    include_repos: false
+    hidden: true

--- a/v2/pkg/config/packs/level-6.yaml
+++ b/v2/pkg/config/packs/level-6.yaml
@@ -1,0 +1,161 @@
+level: 6
+name: Full Autonomy
+description: >
+  Agents open AND merge PRs. Self-healing on deploy failures. Minimal human
+  oversight — monitoring shifts from pre-merge approval to post-merge
+  dashboards and alerts. Auto-deploy with rollback on failure.
+governor:
+  modes: SURGE, BUSY, QUIET, IDLE
+  merge_policy: >
+    Auto-merge on green CI. No hold label. auto-deploy.sh active.
+    rollback.sh for self-healing on deploy failure.
+agents:
+  - name: supervisor
+    display_name: Supervisor
+    role: supervisor
+    description: >
+      Full autonomous oversight. Self-healing: restarts stalled agents,
+      triggers rollbacks on deploy failures.
+    emoji: "👑"
+    color: "#e74c3c"
+    sort_order: 10
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: supervisor
+    kick_template: supervisor-CLAUDE.md
+    include_repos: true
+    interactions: >
+      Full autonomous oversight of all agents. Triggers rollbacks and
+      self-healing actions without human intervention.
+    knowledge_use: >
+      Reads agent health history. Produces sweep reports and self-healing
+      action logs.
+  - name: scanner
+    display_name: Scanner
+    role: scanner
+    description: >
+      Merges PRs when CI passes. No hold. Full SLA enforcement with
+      30-minute response time.
+    emoji: "🔍"
+    color: "#3498db"
+    sort_order: 20
+    backend: copilot
+    model: claude-opus-4-6
+    bead_role: worker
+    kick_template: scanner-CLAUDE.md
+    include_repos: true
+    lane_keywords: [bug, triage, fix, issue]
+    interactions: >
+      Creates and merges PRs autonomously. Tester validates before merge.
+    knowledge_use: >
+      Full access to all project knowledge.
+  - name: ci-maintainer
+    display_name: CI Maintainer
+    role: ci-maintainer
+    description: >
+      Full CI pipeline ownership with auto-deploy integration.
+    emoji: "🔧"
+    color: "#2ecc71"
+    sort_order: 30
+    backend: copilot
+    model: claude-opus-4-6
+    bead_role: worker
+    kick_template: ci-maintainer-CLAUDE.md
+    include_repos: true
+    lane_keywords: [ci, build, pipeline, workflow, dependency, deploy]
+    interactions: >
+      Owns deploy pipeline. Coordinates rollbacks with supervisor.
+    knowledge_use: >
+      Full CI history. Produces deploy reports and rollback records.
+  - name: tester
+    display_name: Tester
+    role: tester
+    description: >
+      Full TDD with auto-approve when coverage gates pass.
+    emoji: "🧪"
+    color: "#3498db"
+    sort_order: 35
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    kick_template: tester-CLAUDE.md
+    include_repos: true
+    lane_keywords: [test, coverage, tdd, quality]
+    interactions: >
+      Auto-approves PRs when coverage + CI gates pass.
+    knowledge_use: >
+      Full test history access.
+  - name: architect
+    display_name: Architect
+    role: architect
+    description: >
+      Full autonomous architecture. Implements RFCs without waiting for
+      human approval.
+    emoji: "🏗"
+    color: "#9b59b6"
+    sort_order: 40
+    backend: copilot
+    model: claude-opus-4-6
+    bead_role: worker
+    kick_template: architect-CLAUDE.md
+    include_repos: true
+    lane_keywords: [refactor, architecture, rfc, design, feature]
+    interactions: >
+      Full autonomous design and implementation.
+    knowledge_use: >
+      Full architecture knowledge access.
+  - name: outreach
+    display_name: Outreach
+    role: outreach
+    description: >
+      Full autonomous outreach. Files issues on partner projects and
+      manages community engagement.
+    emoji: "🌐"
+    color: "#e67e22"
+    sort_order: 50
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    kick_template: outreach-CLAUDE.md
+    include_repos: false
+    lane_keywords: [community, adopters, outreach, ecosystem]
+    interactions: >
+      Fully autonomous community engagement.
+    knowledge_use: >
+      Full community knowledge access.
+  - name: sec-check
+    display_name: Security
+    role: sec-check
+    description: >
+      Full autonomous security scanning with auto-patch for known CVEs.
+    emoji: "🛡"
+    color: "#1abc9c"
+    sort_order: 60
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    kick_template: sec-check-CLAUDE.md
+    include_repos: true
+    lane_keywords: [security, cve, vulnerability, audit]
+    interactions: >
+      Auto-patches known CVEs. Escalates unknowns to supervisor.
+    knowledge_use: >
+      Full security knowledge access.
+  - name: strategist
+    display_name: Strategist
+    role: strategist
+    description: >
+      Full autonomous strategic planning with roadmap execution.
+    emoji: "🧠"
+    color: "#f39c12"
+    sort_order: 70
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    kick_template: strategist-CLAUDE.md
+    include_repos: false
+    lane_keywords: [strategy, roadmap, planning]
+    interactions: >
+      Full autonomous strategic planning and priority setting.
+    knowledge_use: >
+      Full cross-agent knowledge synthesis.

--- a/v2/pkg/config/packs/level-6.yaml
+++ b/v2/pkg/config/packs/level-6.yaml
@@ -159,3 +159,18 @@ agents:
       Full autonomous strategic planning and priority setting.
     knowledge_use: >
       Full cross-agent knowledge synthesis.
+  - name: guide
+    display_name: Guide
+    role: guide
+    description: >
+      Enhanced advisor that reviews PRs on request, flags code without tests,
+      and suggests patterns from the knowledge base.
+    emoji: "🧭"
+    color: "#8e44ad"
+    sort_order: 5
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    kick_template: guide-CLAUDE.md
+    include_repos: false
+    hidden: true

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -70,6 +70,10 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("DELETE /api/config/governor/agents/{name}", s.handleGovernorRemoveAgent)
 	s.mux.HandleFunc("PUT /api/config/governor/repos", s.handleGovernorRepos)
 
+	s.mux.HandleFunc("GET /api/agents", s.handleAgentsList)
+	s.mux.HandleFunc("POST /api/agents", s.handleAgentCreate)
+	s.mux.HandleFunc("DELETE /api/agents/{name}", s.handleAgentDelete)
+
 	s.mux.HandleFunc("GET /api/config/sidebar", s.handleSidebarGet)
 	s.mux.HandleFunc("PUT /api/config/sidebar", s.handleSidebarSet)
 	s.mux.HandleFunc("GET /api/config/backends", s.handleBackends)

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -770,6 +770,11 @@ func (s *Server) handleAgentConfigGet(w http.ResponseWriter, r *http.Request) {
 	pipeline := s.getAgentPipeline(name)
 	hooks := s.getAgentHooks(name)
 
+	includeRepos := true
+	if agentCfg.IncludeRepos != nil {
+		includeRepos = *agentCfg.IncludeRepos
+	}
+
 	jsonResponse(w, map[string]interface{}{
 		"general": map[string]interface{}{
 			"launchCmd":       launchCmd,
@@ -781,6 +786,16 @@ func (s *Server) handleAgentConfigGet(w http.ResponseWriter, r *http.Request) {
 			"restartStrategy": restartStrategy,
 			"model":           model,
 			"clearOnKick":     agentCfg.ClearOnKick,
+			"emoji":           agentCfg.Emoji,
+			"color":           agentCfg.Color,
+			"sortOrder":       agentCfg.SortOrder,
+			"beadRole":        agentCfg.BeadRole,
+			"role":            agentCfg.Role,
+			"kickTemplate":    agentCfg.KickTemplate,
+			"includeRepos":    includeRepos,
+			"laneKeywords":    agentCfg.LaneKeywords,
+			"detectKeywords":  agentCfg.DetectKeywords,
+			"aliases":         agentCfg.Aliases,
 		},
 		"cadences": cadences,
 		"models":   models,
@@ -1028,6 +1043,74 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 	if v, ok := body["cliPinned"]; ok {
 		if b, ok := v.(bool); ok {
 			agentCfg.CLIPinned = b
+		}
+	}
+	if v, ok := body["emoji"]; ok {
+		if s, ok := v.(string); ok {
+			agentCfg.Emoji = s
+		}
+	}
+	if v, ok := body["color"]; ok {
+		if s, ok := v.(string); ok {
+			agentCfg.Color = s
+		}
+	}
+	if v, ok := body["sortOrder"]; ok {
+		if f, ok := v.(float64); ok {
+			agentCfg.SortOrder = int(f)
+		}
+	}
+	if v, ok := body["beadRole"]; ok {
+		if s, ok := v.(string); ok {
+			agentCfg.BeadRole = s
+		}
+	}
+	if v, ok := body["role"]; ok {
+		if s, ok := v.(string); ok {
+			agentCfg.Role = s
+		}
+	}
+	if v, ok := body["kickTemplate"]; ok {
+		if s, ok := v.(string); ok {
+			agentCfg.KickTemplate = s
+		}
+	}
+	if v, ok := body["includeRepos"]; ok {
+		if b, ok := v.(bool); ok {
+			agentCfg.IncludeRepos = &b
+		}
+	}
+	if v, ok := body["laneKeywords"]; ok {
+		if arr, ok := v.([]interface{}); ok {
+			kw := make([]string, 0, len(arr))
+			for _, item := range arr {
+				if s, ok := item.(string); ok {
+					kw = append(kw, s)
+				}
+			}
+			agentCfg.LaneKeywords = kw
+		}
+	}
+	if v, ok := body["detectKeywords"]; ok {
+		if arr, ok := v.([]interface{}); ok {
+			kw := make([]string, 0, len(arr))
+			for _, item := range arr {
+				if s, ok := item.(string); ok {
+					kw = append(kw, s)
+				}
+			}
+			agentCfg.DetectKeywords = kw
+		}
+	}
+	if v, ok := body["aliases"]; ok {
+		if arr, ok := v.([]interface{}); ok {
+			a := make([]string, 0, len(arr))
+			for _, item := range arr {
+				if s, ok := item.(string); ok {
+					a = append(a, s)
+				}
+			}
+			agentCfg.Aliases = a
 		}
 	}
 	s.deps.Config.Agents[name] = agentCfg

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -189,6 +189,15 @@ func (s *Server) refreshAndPersist() {
 	s.persistAfterMutation()
 }
 
+func (s *Server) refreshAndPersistSync() {
+	if s.deps != nil && s.deps.RefreshFunc != nil {
+		s.deps.RefreshFunc()
+	}
+	if s.deps != nil && s.deps.PersistFunc != nil {
+		s.deps.PersistFunc()
+	}
+}
+
 func decodeBody(r *http.Request, v interface{}) error {
 	defer r.Body.Close()
 	return json.NewDecoder(r.Body).Decode(v)

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -74,6 +74,9 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("POST /api/agents", s.handleAgentCreate)
 	s.mux.HandleFunc("DELETE /api/agents/{name}", s.handleAgentDelete)
 
+	s.mux.HandleFunc("GET /api/packs", s.handlePacksList)
+	s.mux.HandleFunc("POST /api/packs/{level}/apply", s.handlePackApply)
+
 	s.mux.HandleFunc("GET /api/config/sidebar", s.handleSidebarGet)
 	s.mux.HandleFunc("PUT /api/config/sidebar", s.handleSidebarSet)
 	s.mux.HandleFunc("GET /api/config/backends", s.handleBackends)

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -198,6 +198,18 @@ func (s *Server) refreshAndPersistSync() {
 	}
 }
 
+func (s *Server) persistOnly() {
+	if s.deps != nil && s.deps.PersistFunc != nil {
+		s.deps.PersistFunc()
+	}
+}
+
+func (s *Server) refreshAsync() {
+	if s.deps != nil && s.deps.RefreshFunc != nil {
+		s.deps.RefreshFunc()
+	}
+}
+
 func decodeBody(r *http.Request, v interface{}) error {
 	defer r.Body.Close()
 	return json.NewDecoder(r.Body).Decode(v)

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -76,6 +76,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 
 	s.mux.HandleFunc("GET /api/packs", s.handlePacksList)
 	s.mux.HandleFunc("POST /api/packs/{level}/apply", s.handlePackApply)
+	s.mux.HandleFunc("PUT /api/packs/level", s.handlePackSetLevel)
 
 	s.mux.HandleFunc("GET /api/config/sidebar", s.handleSidebarGet)
 	s.mux.HandleFunc("PUT /api/config/sidebar", s.handleSidebarSet)

--- a/v2/pkg/dashboard/api_agents.go
+++ b/v2/pkg/dashboard/api_agents.go
@@ -1,0 +1,120 @@
+package dashboard
+
+import (
+	"net/http"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+type agentListEntry struct {
+	Name        string `json:"name"`
+	ID          string `json:"id"`
+	DisplayName string `json:"displayName,omitempty"`
+	Enabled     bool   `json:"enabled"`
+	Managed     bool   `json:"managed"`
+	Backend     string `json:"backend"`
+	Model       string `json:"model"`
+}
+
+func (s *Server) handleAgentsList(w http.ResponseWriter, r *http.Request) {
+	agents := make([]agentListEntry, 0, len(s.deps.Config.Agents))
+	for name, cfg := range s.deps.Config.Agents {
+		displayName := cfg.DisplayName
+		if displayName == "" {
+			displayName = name
+		}
+		agents = append(agents, agentListEntry{
+			Name:        name,
+			ID:          cfg.ID,
+			DisplayName: displayName,
+			Enabled:     cfg.Enabled,
+			Managed:     cfg.Managed,
+			Backend:     cfg.Backend,
+			Model:       cfg.Model,
+		})
+	}
+	jsonResponse(w, agents)
+}
+
+func (s *Server) handleAgentCreate(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Name        string              `json:"name"`
+		Agent       config.AgentConfig  `json:"agent"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if body.Name == "" {
+		jsonError(w, "name is required", http.StatusBadRequest)
+		return
+	}
+
+	if _, exists := s.deps.Config.Agents[body.Name]; exists {
+		jsonError(w, "agent already exists", http.StatusConflict)
+		return
+	}
+
+	agentsDir := s.deps.Config.Data.AgentsDir
+	if agentsDir == "" {
+		jsonError(w, "agents_dir not configured", http.StatusInternalServerError)
+		return
+	}
+
+	body.Agent.Managed = true
+	if err := config.SaveAgentFile(agentsDir, body.Name, body.Agent); err != nil {
+		s.logger.Error("failed to save agent file", "agent", body.Name, "error", err)
+		jsonError(w, "failed to save agent: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	s.deps.Config.Agents[body.Name] = body.Agent
+	s.deps.Config.ApplyAgentDefaults(body.Name)
+
+	finalCfg := s.deps.Config.Agents[body.Name]
+	s.deps.AgentMgr.AddAgent(body.Name, finalCfg)
+
+	s.reInitSubsystems()
+	s.refreshAndPersist()
+
+	s.logger.Info("agent created via API", "name", body.Name, "id", finalCfg.ID)
+	okResponse(w, map[string]string{"status": "created", "agent": body.Name, "id": finalCfg.ID})
+}
+
+func (s *Server) handleAgentDelete(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	agentCfg, ok := s.deps.Config.Agents[name]
+	if !ok {
+		jsonError(w, "agent not found", http.StatusNotFound)
+		return
+	}
+
+	if !agentCfg.Managed {
+		jsonError(w, "cannot delete base config agent — only managed (CRUD-created) agents can be deleted", http.StatusForbidden)
+		return
+	}
+
+	agentsDir := s.deps.Config.Data.AgentsDir
+	if agentsDir != "" {
+		if err := config.RemoveAgentFile(agentsDir, name); err != nil {
+			s.logger.Error("failed to remove agent file", "agent", name, "error", err)
+			jsonError(w, "failed to remove agent file: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	s.deps.AgentMgr.RemoveAgent(name)
+	delete(s.deps.Config.Agents, name)
+
+	s.reInitSubsystems()
+	s.refreshAndPersist()
+
+	s.logger.Info("agent deleted via API", "name", name)
+	okResponse(w, map[string]string{"status": "deleted", "agent": name})
+}
+
+func (s *Server) reInitSubsystems() {
+	if s.deps != nil && s.deps.ReInitFunc != nil {
+		s.deps.ReInitFunc()
+	}
+}

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -108,7 +108,8 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 
 	paused, resumed := s.syncAgentVisibility(level)
 
-	s.refreshAndPersistSync()
+	s.persistOnly()
+	go s.refreshAsync()
 	s.logger.Info("ACMM pack applied", "level", level, "name", pack.Name, "created", len(created), "skipped", len(skipped), "paused", len(paused), "resumed", len(resumed))
 
 	var packAgentNames []string
@@ -146,7 +147,8 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 
 	level := body.Level
 	s.deps.Config.ACMMLevel = &level
-	s.refreshAndPersistSync()
+	s.persistOnly()
+	go s.refreshAsync()
 
 	pack, packErr := config.ACMMPackByLevel(level)
 	var packAgentNames []string

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"encoding/json"
 	"net/http"
 	"strconv"
 
@@ -114,6 +115,31 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 		"name":    pack.Name,
 		"created": created,
 		"skipped": skipped,
+	})
+}
+
+func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Level int `json:"level"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		jsonError(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	const maxACMMLevel = 6
+	if body.Level < 0 || body.Level > maxACMMLevel {
+		jsonError(w, "level must be 0-6", http.StatusBadRequest)
+		return
+	}
+
+	s.deps.Config.ACMMLevel = &body.Level
+	s.refreshAndPersist()
+
+	s.logger.Info("ACMM level set explicitly", "level", body.Level)
+	jsonResponse(w, map[string]interface{}{
+		"ok":    true,
+		"level": body.Level,
 	})
 }
 

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -135,6 +135,7 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 
 	level := body.Level
 	s.deps.Config.ACMMLevel = &level
+	s.refreshAfterMutation()
 
 	s.logger.Info("ACMM level set explicitly", "level", body.Level)
 	jsonResponse(w, map[string]interface{}{

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -105,8 +105,11 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 	if len(created) > 0 {
 		s.reInitSubsystems()
 	}
+
+	paused, resumed := s.syncAgentVisibility(level)
+
 	s.refreshAndPersistSync()
-	s.logger.Info("ACMM pack applied", "level", level, "name", pack.Name, "created", len(created), "skipped", len(skipped))
+	s.logger.Info("ACMM pack applied", "level", level, "name", pack.Name, "created", len(created), "skipped", len(skipped), "paused", len(paused), "resumed", len(resumed))
 
 	jsonResponse(w, map[string]interface{}{
 		"ok":      true,
@@ -115,6 +118,8 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 		"name":    pack.Name,
 		"created": created,
 		"skipped": skipped,
+		"paused":  paused,
+		"resumed": resumed,
 	})
 }
 
@@ -135,17 +140,12 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 
 	level := body.Level
 	s.deps.Config.ACMMLevel = &level
-
-	paused, resumed := s.syncAgentVisibility(level)
-
 	s.refreshAndPersistSync()
 
-	s.logger.Info("ACMM level set explicitly", "level", body.Level, "paused", len(paused), "resumed", len(resumed))
+	s.logger.Info("ACMM level preview set", "level", body.Level)
 	jsonResponse(w, map[string]interface{}{
-		"ok":      true,
-		"level":   body.Level,
-		"paused":  paused,
-		"resumed": resumed,
+		"ok":    true,
+		"level": body.Level,
 	})
 }
 

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -133,8 +133,8 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.deps.Config.ACMMLevel = &body.Level
-	s.refreshAndPersist()
+	level := body.Level
+	s.deps.Config.ACMMLevel = &level
 
 	s.logger.Info("ACMM level set explicitly", "level", body.Level)
 	jsonResponse(w, map[string]interface{}{

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -105,7 +105,7 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 	if len(created) > 0 {
 		s.reInitSubsystems()
 	}
-	s.refreshAndPersist()
+	s.refreshAndPersistSync()
 	s.logger.Info("ACMM pack applied", "level", level, "name", pack.Name, "created", len(created), "skipped", len(skipped))
 
 	jsonResponse(w, map[string]interface{}{
@@ -135,7 +135,7 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 
 	level := body.Level
 	s.deps.Config.ACMMLevel = &level
-	s.refreshAndPersist()
+	s.refreshAndPersistSync()
 
 	s.logger.Info("ACMM level set explicitly", "level", body.Level)
 	jsonResponse(w, map[string]interface{}{

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -114,7 +114,9 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 
 	var packAgentNames []string
 	for _, a := range pack.Agents {
-		packAgentNames = append(packAgentNames, a.Name)
+		if !a.Hidden {
+			packAgentNames = append(packAgentNames, a.Name)
+		}
 	}
 
 	jsonResponse(w, map[string]interface{}{
@@ -154,7 +156,9 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 	var packAgentNames []string
 	if packErr == nil {
 		for _, a := range pack.Agents {
-			packAgentNames = append(packAgentNames, a.Name)
+			if !a.Hidden {
+				packAgentNames = append(packAgentNames, a.Name)
+			}
 		}
 	}
 
@@ -174,7 +178,9 @@ func (s *Server) syncAgentVisibility(level int) (paused, resumed []string) {
 
 	packAgents := make(map[string]bool, len(pack.Agents))
 	for _, a := range pack.Agents {
-		packAgents[a.Name] = true
+		if !a.Hidden {
+			packAgents[a.Name] = true
+		}
 	}
 
 	for name := range s.deps.Config.Agents {

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -1,0 +1,140 @@
+package dashboard
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+func (s *Server) handlePacksList(w http.ResponseWriter, r *http.Request) {
+	packs := config.ACMMPacks()
+
+	currentLevel := s.detectCurrentLevel()
+
+	type packSummary struct {
+		Level       int                `json:"level"`
+		Name        string             `json:"name"`
+		Description string             `json:"description"`
+		AgentCount  int                `json:"agentCount"`
+		Governor    config.PackGovernor `json:"governor"`
+		Current     bool               `json:"current"`
+		Agents      []config.PackAgent  `json:"agents"`
+	}
+
+	result := make([]packSummary, 0, len(packs))
+	for _, p := range packs {
+		result = append(result, packSummary{
+			Level:       p.Level,
+			Name:        p.Name,
+			Description: p.Description,
+			AgentCount:  len(p.Agents),
+			Governor:    p.Governor,
+			Current:     p.Level == currentLevel,
+			Agents:      p.Agents,
+		})
+	}
+	jsonResponse(w, result)
+}
+
+func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
+	levelStr := r.PathValue("level")
+	level, err := strconv.Atoi(levelStr)
+	if err != nil {
+		jsonError(w, "invalid level: "+levelStr, http.StatusBadRequest)
+		return
+	}
+
+	pack, err := config.ACMMPackByLevel(level)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	agentsDir := s.deps.Config.Data.AgentsDir
+	if agentsDir == "" {
+		jsonError(w, "agents_dir not configured", http.StatusInternalServerError)
+		return
+	}
+
+	var created []string
+	var skipped []string
+
+	for _, pa := range pack.Agents {
+		if _, exists := s.deps.Config.Agents[pa.Name]; exists {
+			skipped = append(skipped, pa.Name)
+			continue
+		}
+
+		includeRepos := pa.IncludeRepos
+		agentCfg := config.AgentConfig{
+			Backend:      pa.Backend,
+			Model:        pa.Model,
+			Enabled:      true,
+			DisplayName:  pa.DisplayName,
+			Description:  pa.Description,
+			Role:         pa.Role,
+			SortOrder:    pa.SortOrder,
+			Emoji:        pa.Emoji,
+			Color:        pa.Color,
+			BeadRole:     pa.BeadRole,
+			KickTemplate: pa.KickTemplate,
+			IncludeRepos: &includeRepos,
+			LaneKeywords: pa.LaneKeywords,
+			Managed:      true,
+		}
+
+		if err := config.SaveAgentFile(agentsDir, pa.Name, agentCfg); err != nil {
+			s.logger.Error("failed to save agent from pack", "agent", pa.Name, "error", err)
+			jsonError(w, "failed to save agent "+pa.Name+": "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		s.deps.Config.Agents[pa.Name] = agentCfg
+		s.deps.Config.ApplyAgentDefaults(pa.Name)
+
+		finalCfg := s.deps.Config.Agents[pa.Name]
+		s.deps.AgentMgr.AddAgent(pa.Name, finalCfg)
+
+		created = append(created, pa.Name)
+	}
+
+	if len(created) > 0 {
+		s.reInitSubsystems()
+		s.refreshAndPersist()
+	}
+
+	s.deps.Config.ACMMLevel = level
+	s.logger.Info("ACMM pack applied", "level", level, "name", pack.Name, "created", len(created), "skipped", len(skipped))
+
+	jsonResponse(w, map[string]interface{}{
+		"ok":      true,
+		"status":  "applied",
+		"level":   level,
+		"name":    pack.Name,
+		"created": created,
+		"skipped": skipped,
+	})
+}
+
+// detectCurrentLevel infers the current ACMM level from the configured level
+// or by matching the agent set against known pack definitions.
+func (s *Server) detectCurrentLevel() int {
+	if s.deps.Config.ACMMLevel > 0 {
+		return s.deps.Config.ACMMLevel
+	}
+
+	agentCount := len(s.deps.Config.Agents)
+	switch {
+	case agentCount == 0:
+		return 0
+	case agentCount == 1:
+		return 1
+	case agentCount == 2:
+		return 2
+	case agentCount <= 4:
+		return 3
+	default:
+		return 4
+	}
+}

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -104,7 +104,7 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 		s.refreshAndPersist()
 	}
 
-	s.deps.Config.ACMMLevel = level
+	s.deps.Config.ACMMLevel = &level
 	s.logger.Info("ACMM pack applied", "level", level, "name", pack.Name, "created", len(created), "skipped", len(skipped))
 
 	jsonResponse(w, map[string]interface{}{
@@ -117,14 +117,16 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// detectCurrentLevel infers the current ACMM level from the configured level
-// or by matching the agent set against known pack definitions.
 func (s *Server) detectCurrentLevel() int {
-	if s.deps.Config.ACMMLevel > 0 {
-		return s.deps.Config.ACMMLevel
+	return detectACMMLevel(s.deps.Config)
+}
+
+func detectACMMLevel(cfg *config.Config) int {
+	if cfg.ACMMLevel != nil {
+		return *cfg.ACMMLevel
 	}
 
-	agentCount := len(s.deps.Config.Agents)
+	agentCount := len(cfg.Agents)
 	switch {
 	case agentCount == 0:
 		return 0

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -100,12 +100,12 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 		created = append(created, pa.Name)
 	}
 
+	s.deps.Config.ACMMLevel = &level
+
 	if len(created) > 0 {
 		s.reInitSubsystems()
-		s.refreshAndPersist()
 	}
-
-	s.deps.Config.ACMMLevel = &level
+	s.refreshAndPersist()
 	s.logger.Info("ACMM pack applied", "level", level, "name", pack.Name, "created", len(created), "skipped", len(skipped))
 
 	jsonResponse(w, map[string]interface{}{
@@ -135,7 +135,7 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 
 	level := body.Level
 	s.deps.Config.ACMMLevel = &level
-	s.refreshAfterMutation()
+	s.refreshAndPersist()
 
 	s.logger.Info("ACMM level set explicitly", "level", body.Level)
 	jsonResponse(w, map[string]interface{}{

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -135,13 +135,47 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 
 	level := body.Level
 	s.deps.Config.ACMMLevel = &level
+
+	paused, resumed := s.syncAgentVisibility(level)
+
 	s.refreshAndPersistSync()
 
-	s.logger.Info("ACMM level set explicitly", "level", body.Level)
+	s.logger.Info("ACMM level set explicitly", "level", body.Level, "paused", len(paused), "resumed", len(resumed))
 	jsonResponse(w, map[string]interface{}{
-		"ok":    true,
-		"level": body.Level,
+		"ok":      true,
+		"level":   body.Level,
+		"paused":  paused,
+		"resumed": resumed,
 	})
+}
+
+func (s *Server) syncAgentVisibility(level int) (paused, resumed []string) {
+	pack, err := config.ACMMPackByLevel(level)
+	if err != nil {
+		return nil, nil
+	}
+
+	packAgents := make(map[string]bool, len(pack.Agents))
+	for _, a := range pack.Agents {
+		packAgents[a.Name] = true
+	}
+
+	for name := range s.deps.Config.Agents {
+		if packAgents[name] {
+			if s.deps.AgentMgr.IsPaused(name) {
+				if err := s.deps.AgentMgr.Resume(s.deps.Ctx, name); err == nil {
+					resumed = append(resumed, name)
+				}
+			}
+		} else {
+			if !s.deps.AgentMgr.IsPaused(name) {
+				if err := s.deps.AgentMgr.Pause(name); err == nil {
+					paused = append(paused, name)
+				}
+			}
+		}
+	}
+	return paused, resumed
 }
 
 func (s *Server) detectCurrentLevel() int {

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -111,15 +111,21 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 	s.refreshAndPersistSync()
 	s.logger.Info("ACMM pack applied", "level", level, "name", pack.Name, "created", len(created), "skipped", len(skipped), "paused", len(paused), "resumed", len(resumed))
 
+	var packAgentNames []string
+	for _, a := range pack.Agents {
+		packAgentNames = append(packAgentNames, a.Name)
+	}
+
 	jsonResponse(w, map[string]interface{}{
-		"ok":      true,
-		"status":  "applied",
-		"level":   level,
-		"name":    pack.Name,
-		"created": created,
-		"skipped": skipped,
-		"paused":  paused,
-		"resumed": resumed,
+		"ok":         true,
+		"status":     "applied",
+		"level":      level,
+		"name":       pack.Name,
+		"created":    created,
+		"skipped":    skipped,
+		"paused":     paused,
+		"resumed":    resumed,
+		"packAgents": packAgentNames,
 	})
 }
 
@@ -142,10 +148,19 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 	s.deps.Config.ACMMLevel = &level
 	s.refreshAndPersistSync()
 
+	pack, packErr := config.ACMMPackByLevel(level)
+	var packAgentNames []string
+	if packErr == nil {
+		for _, a := range pack.Agents {
+			packAgentNames = append(packAgentNames, a.Name)
+		}
+	}
+
 	s.logger.Info("ACMM level preview set", "level", body.Level)
 	jsonResponse(w, map[string]interface{}{
-		"ok":    true,
-		"level": body.Level,
+		"ok":         true,
+		"level":      body.Level,
+		"packAgents": packAgentNames,
 	})
 }
 

--- a/v2/pkg/dashboard/deps.go
+++ b/v2/pkg/dashboard/deps.go
@@ -30,6 +30,7 @@ type Dependencies struct {
 	Ctx              context.Context
 	RefreshFunc      func()
 	PersistFunc      func()
+	ReInitFunc       func()
 }
 
 type NousState struct {

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -61,7 +61,7 @@ type StatusPayload struct {
 	Hold          FrontendHold        `json:"hold"`
 	IssueToMerge  map[string]any      `json:"issueToMerge"`
 	ACMMLevel      int                 `json:"acmmLevel"`
-	ACMMPackAgents []string            `json:"acmmPackAgents,omitempty"`
+	ACMMPackAgents []string            `json:"acmmPackAgents"`
 }
 
 type FrontendAgent struct {

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -60,7 +60,8 @@ type StatusPayload struct {
 	AgentMetrics  map[string]any      `json:"agentMetrics"`
 	Hold          FrontendHold        `json:"hold"`
 	IssueToMerge  map[string]any      `json:"issueToMerge"`
-	ACMMLevel     int                 `json:"acmmLevel"`
+	ACMMLevel      int                 `json:"acmmLevel"`
+	ACMMPackAgents []string            `json:"acmmPackAgents,omitempty"`
 }
 
 type FrontendAgent struct {

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -294,6 +294,10 @@ func (s *Server) Handler() http.Handler {
 }
 
 func (s *Server) UpdateStatus(status *StatusPayload) {
+	if s.deps != nil && s.deps.Config != nil {
+		status.ACMMLevel = detectACMMLevel(s.deps.Config)
+		status.ACMMPackAgents = buildACMMPackAgents(s.deps.Config)
+	}
 	s.statusMu.Lock()
 	status.Timestamp = time.Now().UTC().Format(time.RFC3339)
 	s.status = status

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -60,6 +60,7 @@ type StatusPayload struct {
 	AgentMetrics  map[string]any      `json:"agentMetrics"`
 	Hold          FrontendHold        `json:"hold"`
 	IssueToMerge  map[string]any      `json:"issueToMerge"`
+	ACMMLevel     int                 `json:"acmmLevel"`
 }
 
 type FrontendAgent struct {

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -72,6 +72,7 @@ type FrontendAgent struct {
 	Emoji            string `json:"emoji,omitempty"`
 	Color            string `json:"color,omitempty"`
 	BeadRole         string `json:"beadRole,omitempty"`
+	Managed          bool   `json:"managed,omitempty"`
 	Session          string `json:"session"`
 	State            string `json:"state"`
 	Busy             string `json:"busy"`

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1475,66 +1475,7 @@
     </div>
   </div>
 </div>
-<div id="add-agent-overlay" class="config-overlay hidden">
-  <div class="config-modal" style="max-width:520px">
-    <div class="config-header">
-      <h2 class="config-title">Add Agent</h2>
-      <button class="config-close" onclick="closeAddAgentDialog()">&times;</button>
-    </div>
-    <div class="config-body" style="padding:16px 24px">
-      <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px">
-        <div style="grid-column:1/-1">
-          <label style="font-size:0.75rem;font-weight:600;color:var(--muted)">Name <span style="color:#dc2626">*</span></label>
-          <input type="text" id="add-agent-name" placeholder="e.g. docs-writer" style="width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:6px;font-size:0.85rem;background:var(--bg);color:var(--fg);box-sizing:border-box" />
-          <div style="font-size:0.65rem;color:var(--muted);margin-top:2px">Lowercase, hyphens allowed. Used as the agent ID.</div>
-        </div>
-        <div style="grid-column:1/-1">
-          <label style="font-size:0.75rem;font-weight:600;color:var(--muted)">Display Name</label>
-          <input type="text" id="add-agent-display" placeholder="e.g. Docs Writer" style="width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:6px;font-size:0.85rem;background:var(--bg);color:var(--fg);box-sizing:border-box" />
-        </div>
-        <div>
-          <label style="font-size:0.75rem;font-weight:600;color:var(--muted)">Backend</label>
-          <select id="add-agent-backend" style="width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:6px;font-size:0.85rem;background:var(--bg);color:var(--fg)">
-            <option value="copilot">copilot</option>
-            <option value="claude">claude</option>
-          </select>
-        </div>
-        <div>
-          <label style="font-size:0.75rem;font-weight:600;color:var(--muted)">Model</label>
-          <input type="text" id="add-agent-model" placeholder="claude-sonnet-4-6" value="claude-sonnet-4-6" style="width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:6px;font-size:0.85rem;background:var(--bg);color:var(--fg);box-sizing:border-box" />
-        </div>
-        <div>
-          <label style="font-size:0.75rem;font-weight:600;color:var(--muted)">Emoji</label>
-          <input type="text" id="add-agent-emoji" placeholder="🤖" value="🤖" style="width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:6px;font-size:0.85rem;background:var(--bg);color:var(--fg);box-sizing:border-box" />
-        </div>
-        <div>
-          <label style="font-size:0.75rem;font-weight:600;color:var(--muted)">Color</label>
-          <input type="color" id="add-agent-color" value="#3498db" style="width:100%;height:38px;border:1px solid var(--border);border-radius:6px;background:var(--bg);cursor:pointer" />
-        </div>
-        <div>
-          <label style="font-size:0.75rem;font-weight:600;color:var(--muted)">Sort Order</label>
-          <input type="number" id="add-agent-sort" placeholder="50" value="50" style="width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:6px;font-size:0.85rem;background:var(--bg);color:var(--fg);box-sizing:border-box" />
-          <div style="font-size:0.65rem;color:var(--muted);margin-top:2px">Lower = higher in sidebar</div>
-        </div>
-        <div>
-          <label style="font-size:0.75rem;font-weight:600;color:var(--muted)">Bead Role</label>
-          <select id="add-agent-bead-role" style="width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:6px;font-size:0.85rem;background:var(--bg);color:var(--fg)">
-            <option value="worker">worker</option>
-            <option value="supervisor">supervisor</option>
-          </select>
-        </div>
-        <div style="grid-column:1/-1">
-          <label style="font-size:0.75rem;font-weight:600;color:var(--muted)">Description</label>
-          <input type="text" id="add-agent-desc" placeholder="What this agent does" style="width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:6px;font-size:0.85rem;background:var(--bg);color:var(--fg);box-sizing:border-box" />
-        </div>
-      </div>
-      <div id="add-agent-error" style="color:#dc2626;font-size:0.8rem;margin-top:12px;display:none"></div>
-    </div>
-    <div class="config-footer">
-      <button class="btn config-cancel" onclick="closeAddAgentDialog()">Cancel</button>
-      <button class="btn config-save" onclick="submitAddAgent()">Create Agent</button>
-    </div>
-  </div>
+<!-- Add Agent dialog removed — create mode now uses the config dialog -->
 </div>
 <div id="acmm-overlay" class="config-overlay hidden">
   <div class="config-modal" style="max-width:800px;max-height:85vh">
@@ -2173,7 +2114,8 @@
       const isActive = _ocSelectedAgent === a.name ? ' active' : '';
       const agentDesc = a.description || AGENT_DESCRIPTIONS[a.name] || '';
       const label = a.displayName || a.name;
-      return `<a class="oc-nav-item${isActive}" data-agent-nav="${esc(a.name)}" draggable="true" data-action="ocSelectAgent" data-agent="${esc(a.name)}" title="${esc(agentDesc)}"><span class="oc-agent-dot ${dotCls}"></span> ${esc(label)}<span class="oc-nav-actions"><button data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure">⚙</button><button class="oc-nav-delete" data-action="deleteAgentFromConfig" data-agent="${esc(a.name)}" title="Delete">✕</button></span></a>`;
+      const emojiPrefix = a.emoji ? a.emoji + ' ' : '';
+      return `<a class="oc-nav-item${isActive}" data-agent-nav="${esc(a.name)}" draggable="true" data-action="ocSelectAgent" data-agent="${esc(a.name)}" title="${esc(agentDesc)}"><span class="oc-agent-dot ${dotCls}"></span> ${emojiPrefix}${esc(label)}<span class="oc-nav-actions"><button data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure">⚙</button><button class="oc-nav-delete" data-action="deleteAgentFromConfig" data-agent="${esc(a.name)}" title="Delete">✕</button></span></a>`;
     }
 
     function _sidebarBuildGroups(agents) {
@@ -2880,7 +2822,7 @@
         const indEl = agentIndicators(a.name);
         return `<div class="agent-card ${cls}" data-agent="${esc(a.name)}">
           <span class="working-indicator"></span>
-          <div class="agent-name"><span class="dot ${dotCls}"></span>${esc(a.displayName || a.name)} ${toggleBtn} <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure ${esc(a.displayName || a.name)}">⚙️</button></div>
+          <div class="agent-name"><span class="dot ${dotCls}"></span>${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)} ${toggleBtn} <a href="${terminalUrl(a.name)}" target="_blank" class="terminal-link" title="Open tmux session">▶ terminal</a> <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill tmux session — supervisor will respawn with fresh context">↻ restart</button> <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure ${esc(a.displayName || a.name)}">⚙️</button></div>
           <div class="agent-field"><span class="label" title="The CLI backend running this agent (e.g. claude, copilot). Pin to prevent governor from switching it.">cli</span><span class="value">${cliChip(a.cli, a.pinnedBoth || a.pinnedCli, a.name)}${(a.pinnedBoth || a.pinnedCli) ? '' : ` <button class="pin-toggle" data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="false" title="Pin CLI — lock current backend so governor cannot change it">📌</button>`}</span></div>
           <div class="agent-field"><span class="label" title="The LLM model powering this agent. Governor may change it based on budget or mode. Pin to lock.">model</span><span class="value">${modelChip(a.model, a.govReason, a.pinnedBoth || a.pinnedModel, a.name)}${(a.pinnedBoth || a.pinnedModel) ? '' : ` <button class="pin-toggle" data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="model" data-unpin="false" title="Pin model — lock current model so governor cannot downgrade it">📌</button>`}</span></div>
           <div class="agent-field"><span class="label" title="Time between governor kicks for this agent in the current mode. Configured per governor mode (idle/quiet/busy/surge).">interval</span><span class="value">${isPaused ? 'paused' : isOff ? 'off' : a.cadence}</span></div>
@@ -6088,6 +6030,7 @@ function burnAreaChart() {
     let _configState = { type: null, agent: null, tab: null, data: {}, dirty: {} };
 
     const AGENT_CONFIG_TABS = ['General', 'Cadences', 'Pipeline', 'Hooks', 'Restrictions', 'Stats', 'Prompt Template', 'Last Prompt'];
+    const AGENT_CREATE_TABS = ['General', 'Cadences'];
     const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging'];
     const PIPELINE_STAGES = ['resolve-beads', 'track-prs', 'stale-check', 'repo-scan', 'coverage-gate', 'prompt-compose', 'budget-check', 'api-collect', 'final-compose'];
     const PIPELINE_STAGE_TIPS = {
@@ -6104,29 +6047,33 @@ function burnAreaChart() {
     const RESTART_STRATEGIES = ['immediate', 'backoff', 'none'];
 
     function openConfigDialog(type, agentName) {
-      if (type === 'agent' && !agentName) {
-        openAddAgentDialog();
-        return;
-      }
+      const isCreate = type === 'agent' && !agentName;
       _configModalOpen = true;
-      _configState = { type, agent: agentName || null, tab: null, data: {}, dirty: {} };
+      _configState = { type, agent: agentName || null, tab: null, data: {}, dirty: {}, isCreate };
       document.getElementById('config-overlay').classList.remove('hidden');
-      const title = type === 'governor' ? 'Governor Configuration' : `${agentName || 'New Agent'} Configuration`;
+      const title = type === 'governor' ? 'Governor Configuration' : isCreate ? 'Create Agent' : `${agentName || 'Agent'} Configuration`;
       document.querySelector('.config-title').textContent = title;
-      const tabs = type === 'governor' ? GOVERNOR_CONFIG_TABS : AGENT_CONFIG_TABS;
+      const tabs = type === 'governor' ? GOVERNOR_CONFIG_TABS : (isCreate ? AGENT_CREATE_TABS : AGENT_CONFIG_TABS);
       const tabsEl = document.getElementById('config-tabs');
       tabsEl.innerHTML = tabs.map((t, i) =>
         `<div class="config-tab${i === 0 ? ' active' : ''}" data-tab="${t}" data-action="switchConfigTab">${t}</div>`
       ).join('');
-      switchConfigTab(tabs[0]);
-      loadConfigData(type, agentName).finally(() => {
-        if (!_configModalOpen) return;
-        const dn = (_configState.data.general || {}).displayName;
-        if (dn && type !== 'governor') {
-          document.querySelector('.config-title').textContent = `${dn} Configuration`;
-        }
-        switchConfigTab(_configState.tab || tabs[0]);
-      });
+      const saveBtn = document.querySelector('.config-save');
+      if (saveBtn) saveBtn.textContent = isCreate ? 'Create Agent' : 'Save';
+      if (isCreate) {
+        _configState.data = { general: { clearOnKick: true, restartStrategy: 'immediate', staleTimeout: 1200 }, cadences: {} };
+        switchConfigTab(tabs[0]);
+      } else {
+        switchConfigTab(tabs[0]);
+        loadConfigData(type, agentName).finally(() => {
+          if (!_configModalOpen) return;
+          const dn = (_configState.data.general || {}).displayName;
+          if (dn && type !== 'governor') {
+            document.querySelector('.config-title').textContent = `${dn} Configuration`;
+          }
+          switchConfigTab(_configState.tab || tabs[0]);
+        });
+      }
     }
 
     function closeConfigDialog() {
@@ -6137,70 +6084,11 @@ function burnAreaChart() {
 
     document.addEventListener('keydown', (e) => {
       if (e.key === 'Escape' && _configModalOpen) closeConfigDialog();
-      if (e.key === 'Escape' && _addAgentOpen) closeAddAgentDialog();
       if (e.key === 'Escape' && _acmmOpen) closeACMMDialog();
     });
 
-    let _addAgentOpen = false;
     function openAddAgentDialog() {
-      _addAgentOpen = true;
-      document.getElementById('add-agent-overlay').classList.remove('hidden');
-      document.getElementById('add-agent-name').value = '';
-      document.getElementById('add-agent-display').value = '';
-      document.getElementById('add-agent-model').value = 'claude-sonnet-4-6';
-      document.getElementById('add-agent-emoji').value = '🤖';
-      document.getElementById('add-agent-color').value = '#3498db';
-      document.getElementById('add-agent-sort').value = '50';
-      document.getElementById('add-agent-desc').value = '';
-      document.getElementById('add-agent-error').style.display = 'none';
-      setTimeout(() => document.getElementById('add-agent-name').focus(), 100);
-    }
-
-    function closeAddAgentDialog() {
-      _addAgentOpen = false;
-      document.getElementById('add-agent-overlay').classList.add('hidden');
-    }
-
-    async function submitAddAgent() {
-      const name = (document.getElementById('add-agent-name').value || '').trim().toLowerCase().replace(/\s+/g, '-');
-      const errEl = document.getElementById('add-agent-error');
-      if (!name) {
-        errEl.textContent = 'Name is required';
-        errEl.style.display = 'block';
-        return;
-      }
-      if (!/^[a-z0-9][a-z0-9-]*$/.test(name)) {
-        errEl.textContent = 'Name must be lowercase letters, numbers, and hyphens';
-        errEl.style.display = 'block';
-        return;
-      }
-      const body = {
-        name,
-        agent: {
-          backend: document.getElementById('add-agent-backend').value,
-          model: document.getElementById('add-agent-model').value,
-          enabled: true,
-          display_name: document.getElementById('add-agent-display').value || '',
-          description: document.getElementById('add-agent-desc').value || '',
-          emoji: document.getElementById('add-agent-emoji').value || '🤖',
-          color: document.getElementById('add-agent-color').value || '#3498db',
-          sort_order: parseInt(document.getElementById('add-agent-sort').value, 10) || 50,
-          bead_role: document.getElementById('add-agent-bead-role').value || 'worker',
-        }
-      };
-      try {
-        const res = await fetch('/api/agents', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
-        const data = await res.json();
-        if (!res.ok) {
-          errEl.textContent = data.error || 'Failed to create agent';
-          errEl.style.display = 'block';
-          return;
-        }
-        closeAddAgentDialog();
-      } catch (err) {
-        errEl.textContent = 'Network error: ' + err.message;
-        errEl.style.display = 'block';
-      }
+      openConfigDialog('agent', null);
     }
 
     // ── ACMM Level Selector ──
@@ -6380,14 +6268,57 @@ function burnAreaChart() {
     // ── Agent Tab Renderers ──
     function renderAgentGeneral(g) {
       const agentName = _configState.agent || '';
-      return `
+      const isCreate = _configState.isCreate === true;
+      let html = '';
+      if (isCreate) {
+        html += `
+        <div class="config-field">
+          <label>Name <span style="color:#dc2626">*</span> <span class="config-info">i<span class="config-tooltip">The agent's internal name used as its ID, config file name, and tmux session. Lowercase, hyphens allowed.</span></span></label>
+          <input type="text" id="cfg-create-name" value="" placeholder="e.g. docs-writer, sec-scanner" onchange="markDirty('_create','name',this.value)">
+          <div style="font-size:0.65rem;color:var(--muted);margin-top:2px">Lowercase, hyphens allowed. Used as the agent ID.</div>
+        </div>`;
+      }
+      html += `
         <div class="config-field">
           <label>Display Name <span class="config-info">i<span class="config-tooltip">The friendly name shown on the agent card and sidebar. Does not affect the agent's internal ID or tmux session name.</span></span></label>
-          <input type="text" id="cfg-agent-name" value="${esc(g.displayName || agentName)}" placeholder="e.g. Scanner, Code Reviewer" onchange="updateConfigAgentName(this.value);markDirty('general','displayName',this.value)">
+          <input type="text" id="cfg-agent-name" value="${esc(g.displayName || (isCreate ? '' : agentName))}" placeholder="e.g. Scanner, Code Reviewer" onchange="updateConfigAgentName(this.value);markDirty('general','displayName',this.value)">
         </div>
         <div class="config-field">
           <label>Description <span class="config-info">i<span class="config-tooltip">A short description of what this agent is responsible for. Shown as hover text on the sidebar agent list. Helps operators and collaborators understand each agent's role at a glance.</span></span></label>
-          <textarea id="cfg-agent-desc" rows="2" style="width:100%;resize:vertical;font-size:0.75rem" placeholder="e.g. Triages GitHub issues and dispatches fix agents" onchange="markDirty('general','description',this.value)">${esc(g.description || AGENT_DESCRIPTIONS[agentName] || '')}</textarea>
+          <textarea id="cfg-agent-desc" rows="2" style="width:100%;resize:vertical;font-size:0.75rem" placeholder="e.g. Triages GitHub issues and dispatches fix agents" onchange="markDirty('general','description',this.value)">${esc(g.description || (isCreate ? '' : AGENT_DESCRIPTIONS[agentName]) || '')}</textarea>
+        </div>
+        <div class="config-field-row">
+          <div class="config-field">
+            <label>Emoji <span class="config-info">i<span class="config-tooltip">Emoji shown next to the agent name in the sidebar and agent cards.</span></span></label>
+            <input type="text" id="cfg-agent-emoji" value="${esc(g.emoji || '')}" placeholder="🤖" onchange="markDirty('general','emoji',this.value)">
+          </div>
+          <div class="config-field">
+            <label>Color <span class="config-info">i<span class="config-tooltip">Agent color used in the dashboard for visual distinction.</span></span></label>
+            <input type="color" id="cfg-agent-color" value="${esc(g.color || '#3498db')}" style="height:34px" onchange="markDirty('general','color',this.value)">
+          </div>
+        </div>
+        <div class="config-field-row">
+          <div class="config-field">
+            <label>Sort Order <span class="config-info">i<span class="config-tooltip">Controls position in sidebar and agent grid. Lower numbers appear first.</span></span></label>
+            <input type="number" id="cfg-agent-sort" value="${g.sortOrder || 50}" onchange="markDirty('general','sortOrder',parseInt(this.value,10))">
+          </div>
+          <div class="config-field">
+            <label>Bead Role <span class="config-info">i<span class="config-tooltip">Worker agents do tasks. Supervisor monitors other agents.</span></span></label>
+            <select id="cfg-agent-bead-role" onchange="markDirty('general','beadRole',this.value)">
+              <option value="worker" ${(g.beadRole || 'worker') === 'worker' ? 'selected' : ''}>worker</option>
+              <option value="supervisor" ${g.beadRole === 'supervisor' ? 'selected' : ''}>supervisor</option>
+            </select>
+          </div>
+        </div>
+        <div class="config-field-row">
+          <div class="config-field">
+            <label>Role <span class="config-info">i<span class="config-tooltip">Semantic role for behavioral dispatch (e.g. scanner, reviewer, architect). Used by lane routing and kick templates.</span></span></label>
+            <input type="text" id="cfg-agent-role" value="${esc(g.role || '')}" placeholder="e.g. scanner, reviewer" onchange="markDirty('general','role',this.value)">
+          </div>
+          <div class="config-field">
+            <label>Kick Template <span class="config-info">i<span class="config-tooltip">Prompt template file used when the governor kicks this agent. Located in the prompts directory.</span></span></label>
+            <input type="text" id="cfg-agent-kick-tpl" value="${esc(g.kickTemplate || '')}" placeholder="e.g. scanner-CLAUDE.md" onchange="markDirty('general','kickTemplate',this.value)">
+          </div>
         </div>
         <div class="config-field">
           <label>Launch Command <span class="config-info">i<span class="config-tooltip">The shell command used to start this agent's CLI process. Typically uses agent-launch.sh with a --backend flag. Changing the CLI Pin Value will auto-update the binary path here.</span></span></label>
@@ -6396,6 +6327,10 @@ function burnAreaChart() {
         <div class="config-toggle">
           <div class="config-toggle-switch ${g.clearOnKick !== false ? 'on' : ''}" id="cfg-clear-on-kick" data-action="toggleConfigSwitch" data-section="general" data-key="clearOnKick"></div>
           <span class="config-toggle-label">Clear on Kick <span class="config-info">i<span class="config-tooltip">Send /clear before each governor kick to reset conversation context. Prevents stale context buildup across runs. On by default for all agents.</span></span></span>
+        </div>
+        <div class="config-toggle">
+          <div class="config-toggle-switch ${g.includeRepos !== false ? 'on' : ''}" id="cfg-include-repos" data-action="toggleConfigSwitch" data-section="general" data-key="includeRepos"></div>
+          <span class="config-toggle-label">Include Repos in Kicks <span class="config-info">i<span class="config-tooltip">Append monitored repo information to the kick prompt. Disable for agents that don't need repo context (e.g. outreach).</span></span></span>
         </div>
         <div class="config-toggle">
           <div class="config-toggle-switch ${g.cliPinned ? 'on' : ''}" id="cfg-cli-pinned" data-action="toggleConfigSwitch" data-section="general" data-key="cliPinned"></div>
@@ -6426,11 +6361,23 @@ function burnAreaChart() {
             ${KNOWN_MODELS.map(m => `<option value="${m.value}" ${_modelsEqual(g.model, m.value) ? 'selected' : ''}>${m.label}</option>`).join('')}
           </select>
         </div>
-        <div style="margin-top:24px;padding-top:16px;border-top:1px solid #fecaca">
+        <div class="config-field">
+          <label>Lane Keywords <span class="config-info">i<span class="config-tooltip">Comma-separated keywords for issue classification routing. Issues matching these keywords are routed to this agent.</span></span></label>
+          <input type="text" id="cfg-agent-lane-kw" value="${esc((g.laneKeywords || []).join(', '))}" placeholder="e.g. bug, triage, security" onchange="markDirty('general','laneKeywords',this.value.split(',').map(s=>s.trim()).filter(Boolean))">
+        </div>
+        <div class="config-field">
+          <label>Detect Keywords <span class="config-info">i<span class="config-tooltip">Comma-separated keywords for token session detection. Used to identify which agent produced a given session.</span></span></label>
+          <input type="text" id="cfg-agent-detect-kw" value="${esc((g.detectKeywords || []).join(', '))}" placeholder="e.g. scanner, triage, issue" onchange="markDirty('general','detectKeywords',this.value.split(',').map(s=>s.trim()).filter(Boolean))">
+        </div>
+        <div class="config-field">
+          <label>Aliases <span class="config-info">i<span class="config-tooltip">Comma-separated short aliases for Discord commands.</span></span></label>
+          <input type="text" id="cfg-agent-aliases" value="${esc((g.aliases || []).join(', '))}" placeholder="e.g. sc, scan" onchange="markDirty('general','aliases',this.value.split(',').map(s=>s.trim()).filter(Boolean))">
+        </div>
+        ${isCreate ? '' : `<div style="margin-top:24px;padding-top:16px;border-top:1px solid #fecaca">
           <label style="color:#b91c1c;font-weight:600;font-size:0.75rem;margin-bottom:8px;display:block">Danger Zone</label>
           <button data-action="deleteAgentFromConfig" data-agent="${esc(agentName)}" style="background:#dc2626;color:#fff;border:none;padding:6px 16px;border-radius:6px;font-size:0.75rem;cursor:pointer;font-weight:600" title="Permanently remove this agent from the hive. Deletes its config file, env file, and sidebar entry. Cannot be undone.">Delete Agent</button>
           <span style="color:#9ca3af;font-size:0.65rem;margin-left:8px">Removes agent config, env file, and sidebar entry</span>
-        </div>`;
+        </div>`}`;
     }
 
     function updateConfigAgentName(name) {
@@ -7184,6 +7131,62 @@ function burnAreaChart() {
 
     async function saveConfig() {
       const dirty = _configState.dirty;
+
+      if (_configState.isCreate) {
+        const createData = dirty._create || {};
+        const generalData = dirty.general || {};
+        const cadenceData = dirty.cadences || {};
+        const name = (createData.name || '').trim().toLowerCase().replace(/\s+/g, '-');
+        if (!name) {
+          showToast('Agent name is required', 'error');
+          return;
+        }
+        if (!/^[a-z0-9][a-z0-9-]*$/.test(name)) {
+          showToast('Name must be lowercase letters, numbers, and hyphens', 'error');
+          return;
+        }
+        const agent = {
+          backend: generalData.cliPinValue || 'copilot',
+          model: generalData.model || '',
+          enabled: true,
+          display_name: generalData.displayName || '',
+          description: generalData.description || '',
+          emoji: generalData.emoji || '',
+          color: generalData.color || '#3498db',
+          sort_order: generalData.sortOrder || 50,
+          bead_role: generalData.beadRole || 'worker',
+          role: generalData.role || '',
+          kick_template: generalData.kickTemplate || '',
+          launch_cmd: generalData.launchCmd || '',
+          restart_strategy: generalData.restartStrategy || 'immediate',
+          stale_timeout: generalData.staleTimeout || 0,
+          clear_on_kick: generalData.clearOnKick !== false,
+          include_repos: generalData.includeRepos !== false,
+          lane_keywords: generalData.laneKeywords || [],
+          detect_keywords: generalData.detectKeywords || [],
+          aliases: generalData.aliases || [],
+        };
+        try {
+          const res = await fetch('/api/agents', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name, agent })
+          });
+          const data = await res.json();
+          if (!res.ok) {
+            showToast(data.error || 'Failed to create agent', 'error');
+            return;
+          }
+          showToast(`Agent "${name}" created`, 'success');
+          _configState.dirty = {};
+          closeConfigDialog();
+          fetch('/api/status').then(r => r.json()).then(render).catch(() => {});
+        } catch (err) {
+          showToast('Network error: ' + err.message, 'error');
+        }
+        return;
+      }
+
       if (Object.keys(dirty).length === 0) {
         showToast('No changes to save', 'info');
         return;
@@ -7192,7 +7195,6 @@ function burnAreaChart() {
       let success = true;
       for (const [section, values] of Object.entries(dirty)) {
         try {
-          // Governor "General" tab stores hive-id via its own endpoint
           if (_configState.type === 'governor' && section === 'general' && values.hiveId !== undefined) {
             const idRes = await fetch('/api/hive-id', {
               method: 'PUT',

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6404,6 +6404,7 @@ function burnAreaChart() {
           <button data-action="deleteAgentFromConfig" data-agent="${esc(agentName)}" style="background:#dc2626;color:#fff;border:none;padding:6px 16px;border-radius:6px;font-size:0.75rem;cursor:pointer;font-weight:600" title="Permanently remove this agent from the hive. Deletes its config file, env file, and sidebar entry. Cannot be undone.">Delete Agent</button>
           <span style="color:#9ca3af;font-size:0.65rem;margin-left:8px">Removes agent config, env file, and sidebar entry</span>
         </div>`}`;
+      return html;
     }
 
     function updateConfigAgentName(name) {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1475,6 +1475,67 @@
     </div>
   </div>
 </div>
+<div id="add-agent-overlay" class="config-overlay hidden">
+  <div class="config-modal" style="max-width:520px">
+    <div class="config-header">
+      <h2 class="config-title">Add Agent</h2>
+      <button class="config-close" onclick="closeAddAgentDialog()">&times;</button>
+    </div>
+    <div class="config-body" style="padding:16px 24px">
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px">
+        <div style="grid-column:1/-1">
+          <label style="font-size:0.75rem;font-weight:600;color:var(--muted)">Name <span style="color:#dc2626">*</span></label>
+          <input type="text" id="add-agent-name" placeholder="e.g. docs-writer" style="width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:6px;font-size:0.85rem;background:var(--bg);color:var(--fg);box-sizing:border-box" />
+          <div style="font-size:0.65rem;color:var(--muted);margin-top:2px">Lowercase, hyphens allowed. Used as the agent ID.</div>
+        </div>
+        <div style="grid-column:1/-1">
+          <label style="font-size:0.75rem;font-weight:600;color:var(--muted)">Display Name</label>
+          <input type="text" id="add-agent-display" placeholder="e.g. Docs Writer" style="width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:6px;font-size:0.85rem;background:var(--bg);color:var(--fg);box-sizing:border-box" />
+        </div>
+        <div>
+          <label style="font-size:0.75rem;font-weight:600;color:var(--muted)">Backend</label>
+          <select id="add-agent-backend" style="width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:6px;font-size:0.85rem;background:var(--bg);color:var(--fg)">
+            <option value="copilot">copilot</option>
+            <option value="claude">claude</option>
+          </select>
+        </div>
+        <div>
+          <label style="font-size:0.75rem;font-weight:600;color:var(--muted)">Model</label>
+          <input type="text" id="add-agent-model" placeholder="claude-sonnet-4-6" value="claude-sonnet-4-6" style="width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:6px;font-size:0.85rem;background:var(--bg);color:var(--fg);box-sizing:border-box" />
+        </div>
+        <div>
+          <label style="font-size:0.75rem;font-weight:600;color:var(--muted)">Emoji</label>
+          <input type="text" id="add-agent-emoji" placeholder="🤖" value="🤖" style="width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:6px;font-size:0.85rem;background:var(--bg);color:var(--fg);box-sizing:border-box" />
+        </div>
+        <div>
+          <label style="font-size:0.75rem;font-weight:600;color:var(--muted)">Color</label>
+          <input type="color" id="add-agent-color" value="#3498db" style="width:100%;height:38px;border:1px solid var(--border);border-radius:6px;background:var(--bg);cursor:pointer" />
+        </div>
+        <div>
+          <label style="font-size:0.75rem;font-weight:600;color:var(--muted)">Sort Order</label>
+          <input type="number" id="add-agent-sort" placeholder="50" value="50" style="width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:6px;font-size:0.85rem;background:var(--bg);color:var(--fg);box-sizing:border-box" />
+          <div style="font-size:0.65rem;color:var(--muted);margin-top:2px">Lower = higher in sidebar</div>
+        </div>
+        <div>
+          <label style="font-size:0.75rem;font-weight:600;color:var(--muted)">Bead Role</label>
+          <select id="add-agent-bead-role" style="width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:6px;font-size:0.85rem;background:var(--bg);color:var(--fg)">
+            <option value="worker">worker</option>
+            <option value="supervisor">supervisor</option>
+          </select>
+        </div>
+        <div style="grid-column:1/-1">
+          <label style="font-size:0.75rem;font-weight:600;color:var(--muted)">Description</label>
+          <input type="text" id="add-agent-desc" placeholder="What this agent does" style="width:100%;padding:8px 10px;border:1px solid var(--border);border-radius:6px;font-size:0.85rem;background:var(--bg);color:var(--fg);box-sizing:border-box" />
+        </div>
+      </div>
+      <div id="add-agent-error" style="color:#dc2626;font-size:0.8rem;margin-top:12px;display:none"></div>
+    </div>
+    <div class="config-footer">
+      <button class="btn config-cancel" onclick="closeAddAgentDialog()">Cancel</button>
+      <button class="btn config-save" onclick="submitAddAgent()">Create Agent</button>
+    </div>
+  </div>
+</div>
 <div class="gh-auth-alert" id="gh-auth-alert">GitHub API authentication failed. Check GitHub App key or token configuration.</div>
   <div class="gh-rate-alert" id="gh-rate-alert"></div>
 
@@ -2365,7 +2426,7 @@
       html += `<div><span id="nous-sb-scope" style="font-weight:600"></span> · <span id="nous-sb-mode"></span></div>`;
       html += `<div id="nous-sb-phase" style="opacity:0.8"></div></div>`;
       html += `<div style="display:flex;gap:4px;margin:4px 10px">`;
-      html += `<a class="oc-nav-item" style="color:#6b7280;font-style:italic;flex:1" onclick="openConfigDialog('agent')">+ agent</a>`;
+      html += `<a class="oc-nav-item" style="color:#6b7280;font-style:italic;flex:1" onclick="openAddAgentDialog()">+ agent</a>`;
       html += `<a class="oc-nav-item" style="color:#6b7280;font-style:italic;flex:1" onclick="ocAddSidebarGroup()">+ group</a>`;
       html += `</div>`;
 
@@ -6023,7 +6084,8 @@ function burnAreaChart() {
 
     function openConfigDialog(type, agentName) {
       if (type === 'agent' && !agentName) {
-        type = 'governor';
+        openAddAgentDialog();
+        return;
       }
       _configModalOpen = true;
       _configState = { type, agent: agentName || null, tab: null, data: {}, dirty: {} };
@@ -6054,7 +6116,70 @@ function burnAreaChart() {
 
     document.addEventListener('keydown', (e) => {
       if (e.key === 'Escape' && _configModalOpen) closeConfigDialog();
+      if (e.key === 'Escape' && _addAgentOpen) closeAddAgentDialog();
     });
+
+    let _addAgentOpen = false;
+    function openAddAgentDialog() {
+      _addAgentOpen = true;
+      document.getElementById('add-agent-overlay').classList.remove('hidden');
+      document.getElementById('add-agent-name').value = '';
+      document.getElementById('add-agent-display').value = '';
+      document.getElementById('add-agent-model').value = 'claude-sonnet-4-6';
+      document.getElementById('add-agent-emoji').value = '🤖';
+      document.getElementById('add-agent-color').value = '#3498db';
+      document.getElementById('add-agent-sort').value = '50';
+      document.getElementById('add-agent-desc').value = '';
+      document.getElementById('add-agent-error').style.display = 'none';
+      setTimeout(() => document.getElementById('add-agent-name').focus(), 100);
+    }
+
+    function closeAddAgentDialog() {
+      _addAgentOpen = false;
+      document.getElementById('add-agent-overlay').classList.add('hidden');
+    }
+
+    async function submitAddAgent() {
+      const name = (document.getElementById('add-agent-name').value || '').trim().toLowerCase().replace(/\s+/g, '-');
+      const errEl = document.getElementById('add-agent-error');
+      if (!name) {
+        errEl.textContent = 'Name is required';
+        errEl.style.display = 'block';
+        return;
+      }
+      if (!/^[a-z0-9][a-z0-9-]*$/.test(name)) {
+        errEl.textContent = 'Name must be lowercase letters, numbers, and hyphens';
+        errEl.style.display = 'block';
+        return;
+      }
+      const body = {
+        name,
+        agent: {
+          backend: document.getElementById('add-agent-backend').value,
+          model: document.getElementById('add-agent-model').value,
+          enabled: true,
+          display_name: document.getElementById('add-agent-display').value || '',
+          description: document.getElementById('add-agent-desc').value || '',
+          emoji: document.getElementById('add-agent-emoji').value || '🤖',
+          color: document.getElementById('add-agent-color').value || '#3498db',
+          sort_order: parseInt(document.getElementById('add-agent-sort').value, 10) || 50,
+          bead_role: document.getElementById('add-agent-bead-role').value || 'worker',
+        }
+      };
+      try {
+        const res = await fetch('/api/agents', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+        const data = await res.json();
+        if (!res.ok) {
+          errEl.textContent = data.error || 'Failed to create agent';
+          errEl.style.display = 'block';
+          return;
+        }
+        closeAddAgentDialog();
+      } catch (err) {
+        errEl.textContent = 'Network error: ' + err.message;
+        errEl.style.display = 'block';
+      }
+    }
 
     function switchConfigTab(tabId) {
       _configState.tab = tabId;

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3043,7 +3043,8 @@
         const modelPinned = agentData && (agentData.pinnedBoth || agentData.pinnedModel);
         const cChip = agentData && agentData.cli ? cliChip(agentData.cli, cliPinned, aname) : '?';
         const mChip = agentData && agentData.model ? modelChip(agentData.model, agentData.govReason, modelPinned, aname) : '';
-        return `<tr><td>${nameDot}${aname}${pauseBadge}</td>${cells}<td>${cChip}</td><td>${mChip}</td></tr>`;
+        const displayLabel = (agentData && agentData.displayName) || aname;
+        return `<tr><td>${nameDot}${displayLabel}${pauseBadge}</td>${cells}<td>${cChip}</td><td>${mChip}</td></tr>`;
       }).join('');
       const headers = modes.map(m => {
         const isActive = m === currentMode;

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6282,6 +6282,14 @@ function burnAreaChart() {
       const agentCards = document.getElementById('agents');
       const agentDetail = document.getElementById('oc-agent-detail');
 
+      const ACMM_GOVERNOR_MIN_LEVEL = 3;
+      const ACMM_TOKENS_MIN_LEVEL = 3;
+      const ACMM_BEADS_MIN_LEVEL = 3;
+      const ACMM_REPOS_MIN_LEVEL = 2;
+      const ACMM_NOUS_MIN_LEVEL = 2;
+      const ACMM_DEBUG_MIN_LEVEL = 3;
+      const ACMM_LOGS_MIN_LEVEL = 3;
+
       if (isL0) {
         show(welcome, 'block');
         hide(governor);
@@ -6307,18 +6315,33 @@ function burnAreaChart() {
         });
       } else {
         hide(welcome);
-        show(governor, '');
-        show(tokenPanel, '');
-        show(reposSection, '');
-        show(beadsSection, '');
-        show(nousSection, '');
-        show(debugSection, '');
-        show(logsSection, '');
-        show(infoSidebar, '');
         show(agentCards, '');
         show(agentDetail, '');
+        show(infoSidebar, '');
         sidebarGroups.forEach(g => show(g, ''));
         sidebarItems.forEach(item => show(item, ''));
+
+        level >= ACMM_GOVERNOR_MIN_LEVEL ? show(governor, '') : hide(governor);
+        level >= ACMM_TOKENS_MIN_LEVEL ? show(tokenPanel, '') : hide(tokenPanel);
+        level >= ACMM_BEADS_MIN_LEVEL ? show(beadsSection, '') : hide(beadsSection);
+        level >= ACMM_REPOS_MIN_LEVEL ? show(reposSection, '') : hide(reposSection);
+        level >= ACMM_NOUS_MIN_LEVEL ? show(nousSection, '') : hide(nousSection);
+        level >= ACMM_DEBUG_MIN_LEVEL ? show(debugSection, '') : hide(debugSection);
+        level >= ACMM_LOGS_MIN_LEVEL ? show(logsSection, '') : hide(logsSection);
+
+        if (level < ACMM_GOVERNOR_MIN_LEVEL) {
+          sidebarGroups.forEach(g => {
+            const label = g.querySelector('.oc-nav-label, .oc-tree-toggle');
+            const text = label ? label.textContent.trim() : '';
+            if (text === 'Control') hide(g);
+          });
+        }
+        sidebarItems.forEach(item => {
+          const section = item.getAttribute('data-section') || '';
+          if (section === 'repos-section' && level < ACMM_REPOS_MIN_LEVEL) hide(item);
+          if (section === 'beads-section' && level < ACMM_BEADS_MIN_LEVEL) hide(item);
+          if (section === 'nous-section' && level < ACMM_NOUS_MIN_LEVEL) hide(item);
+        });
       }
     }
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6218,6 +6218,7 @@ function burnAreaChart() {
         showToast(`Level ${level} applied: ${created} created, ${skipped} skipped`, 'success');
         _acmmPacks = null;
         closeACMMDialog();
+        fetch('/api/status').then(r => r.json()).then(render).catch(() => {});
       } catch (err) {
         errEl.textContent = 'Network error: ' + err.message;
         errEl.style.display = 'block';
@@ -6243,6 +6244,7 @@ function burnAreaChart() {
         showToast(`ACMM level set to L${level} (${name})`, 'success');
         _acmmPacks = null;
         closeACMMDialog();
+        fetch('/api/status').then(r => r.json()).then(render).catch(() => {});
       } catch (err) {
         errEl.textContent = 'Network error: ' + err.message;
         errEl.style.display = 'block';

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5455,7 +5455,7 @@ function burnAreaChart() {
       if (hiveIdBadge) hiveIdBadge.textContent = hiveId;
       const ocHiveId = document.getElementById('oc-hive-id');
       if (ocHiveId) ocHiveId.textContent = hiveId;
-      updateACMMBadge(data.acmmLevel || 0);
+      updateACMMBadge(data.acmmLevel || 0, data.acmmPackAgents || null);
       // Update Light health badge with hover detail
       const ocHealth = document.getElementById('oc-health');
       if (ocHealth) {
@@ -6251,17 +6251,17 @@ function burnAreaChart() {
       }
     }
 
-    function updateACMMBadge(level) {
+    function updateACMMBadge(level, packAgents) {
       const levelNames = ['L0 Unaware', 'L1 Idea', 'L2 Dev', 'L3 CI/CD', 'L4 Auto', 'L5 Guarded', 'L6 Full Auto'];
       const text = levelNames[level] || 'L' + level;
       const badge = document.getElementById('acmm-badge');
       if (badge) badge.textContent = 'ACMM ' + text;
       const sbBadge = document.getElementById('acmm-sidebar-badge');
       if (sbBadge) sbBadge.textContent = 'ACMM ' + text;
-      applyACMMVisibility(level);
+      applyACMMVisibility(level, packAgents);
     }
 
-    function applyACMMVisibility(level) {
+    function applyACMMVisibility(level, packAgents) {
       const isL0 = level === 0;
       const hide = el => { if (el) el.style.display = 'none'; };
       const show = (el, d) => { if (el) el.style.display = d || ''; };
@@ -6342,6 +6342,18 @@ function burnAreaChart() {
           if (section === 'beads-section' && level < ACMM_BEADS_MIN_LEVEL) hide(item);
           if (section === 'nous-section' && level < ACMM_NOUS_MIN_LEVEL) hide(item);
         });
+
+        if (packAgents && packAgents.length > 0) {
+          const packSet = new Set(packAgents);
+          document.querySelectorAll('[data-agent-nav]').forEach(navItem => {
+            const name = navItem.getAttribute('data-agent-nav');
+            if (name && !packSet.has(name)) hide(navItem);
+          });
+          document.querySelectorAll('.agent-card[data-agent]').forEach(card => {
+            const name = card.getAttribute('data-agent');
+            if (name && !packSet.has(name)) hide(card);
+          });
+        }
       }
     }
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5455,7 +5455,6 @@ function burnAreaChart() {
       if (hiveIdBadge) hiveIdBadge.textContent = hiveId;
       const ocHiveId = document.getElementById('oc-hive-id');
       if (ocHiveId) ocHiveId.textContent = hiveId;
-      updateACMMBadge(data.acmmLevel || 0, data.acmmPackAgents || null);
       // Update Light health badge with hover detail
       const ocHealth = document.getElementById('oc-health');
       if (ocHealth) {
@@ -5505,6 +5504,7 @@ function burnAreaChart() {
       ocUpdateSidebarAgents();
       if (_ocSelectedAgent) { ocRenderAgentDetail(); ocUpdateFocusedState(); ocStartPanePoll(); }
       renderDebugSection();
+      updateACMMBadge(data.acmmLevel || 0, data.acmmPackAgents || null);
       window.scrollTo(0, scrollY);
     }
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6295,7 +6295,11 @@ function burnAreaChart() {
         showToast(`Level ${level} applied: ${created} created, ${skipped} skipped`, 'success');
         _acmmPacks = null;
         closeACMMDialog();
-        fetch('/api/status').then(r => r.json()).then(render).catch(() => {});
+        if (window._lastStatus) {
+          window._lastStatus.acmmLevel = level;
+          window._lastStatus.acmmPackAgents = data.packAgents || [];
+          render(window._lastStatus);
+        }
       } catch (err) {
         errEl.textContent = 'Network error: ' + err.message;
         errEl.style.display = 'block';
@@ -6321,7 +6325,11 @@ function burnAreaChart() {
         showToast(`ACMM level set to L${level} (${name})`, 'success');
         _acmmPacks = null;
         closeACMMDialog();
-        fetch('/api/status').then(r => r.json()).then(render).catch(() => {});
+        if (window._lastStatus) {
+          window._lastStatus.acmmLevel = level;
+          window._lastStatus.acmmPackAgents = data.packAgents || [];
+          render(window._lastStatus);
+        }
       } catch (err) {
         errEl.textContent = 'Network error: ' + err.message;
         errEl.style.display = 'block';

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1589,6 +1589,34 @@
     <div id="knowledge-panel"></div>
   </div>
 
+  <div id="acmm-welcome" style="display:none; text-align:center; padding:60px 40px; max-width:720px; margin:40px auto;">
+    <div style="font-size:3rem; margin-bottom:16px;">📚</div>
+    <h2 style="font-size:1.5rem; font-weight:700; margin-bottom:12px; color:var(--text);">Welcome to Hive</h2>
+    <p style="font-size:0.95rem; color:var(--muted); line-height:1.6; margin-bottom:24px;">
+      You're at <strong>ACMM Level 0 — Unaware</strong>. This is your starting point before introducing any AI agents.
+      Begin by building your project's knowledge base so that when you're ready, your agents will have the context they need.
+    </p>
+    <div style="background:var(--surface); border:1px solid var(--border); border-radius:12px; padding:28px; text-align:left; margin-bottom:24px;">
+      <h3 style="font-size:1rem; font-weight:600; margin-bottom:12px;">Get started with the Knowledge Base</h3>
+      <p style="font-size:0.85rem; color:var(--muted); line-height:1.6; margin-bottom:16px;">
+        The <strong>llm-wiki</strong> is how your future agents will understand your project — architecture decisions,
+        coding patterns, known gotchas, team conventions. Start capturing knowledge now so it's ready when you level up.
+      </p>
+      <ol style="font-size:0.85rem; color:var(--text); line-height:1.8; padding-left:20px; margin-bottom:16px;">
+        <li>Open the <strong>Knowledge</strong> section in the sidebar</li>
+        <li>Connect your Obsidian vault or Git-based wiki</li>
+        <li>Add notes about your project's architecture, patterns, and decisions</li>
+        <li>When you're ready, move to <strong>L1 Idea</strong> to add your first interactive advisor</li>
+      </ol>
+      <button onclick="ocNavigate('knowledge-section')" style="padding:10px 24px; background:linear-gradient(135deg,#3498db,#2ecc71); color:#fff; border:none; border-radius:8px; font-size:0.88rem; font-weight:600; cursor:pointer;">
+        Open Knowledge Base
+      </button>
+    </div>
+    <p style="font-size:0.78rem; color:var(--muted);">
+      Click the <strong>ACMM badge</strong> above to explore higher maturity levels and add agents when you're ready.
+    </p>
+  </div>
+
   <div id="debug-section" style="margin-top: 16px; margin-bottom: 24px;">
     <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 12px;">🔍 System Diagnostics</h2>
     <div id="debug-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 12px;"></div>
@@ -6228,6 +6256,51 @@ function burnAreaChart() {
       if (badge) badge.textContent = 'ACMM ' + text;
       const sbBadge = document.getElementById('acmm-sidebar-badge');
       if (sbBadge) sbBadge.textContent = 'ACMM ' + text;
+      applyACMMVisibility(level);
+    }
+
+    function applyACMMVisibility(level) {
+      const isL0 = level === 0;
+      const hide = el => { if (el) el.style.display = 'none'; };
+      const show = (el, d) => { if (el) el.style.display = d || ''; };
+
+      const welcome = document.getElementById('acmm-welcome');
+      const governor = document.getElementById('governor');
+      const tokenPanel = document.getElementById('token-panel');
+      const reposSection = document.getElementById('repos-section');
+      const beadsSection = document.getElementById('beads-section');
+      const nousSection = document.getElementById('nous-section');
+      const debugSection = document.getElementById('debug-section');
+      const logsSection = document.getElementById('logs-section');
+
+      const sidebarControl = document.querySelector('.oc-nav-group .oc-nav-label');
+      const sidebarGroups = document.querySelectorAll('.oc-nav-group');
+
+      if (isL0) {
+        show(welcome, 'block');
+        hide(governor);
+        hide(tokenPanel);
+        hide(reposSection);
+        hide(beadsSection);
+        hide(nousSection);
+        hide(debugSection);
+        hide(logsSection);
+        sidebarGroups.forEach(g => {
+          const label = g.querySelector('.oc-nav-label, .oc-tree-toggle');
+          const text = label ? label.textContent.trim() : '';
+          if (text === 'Control' || text.includes('Agent')) hide(g);
+        });
+      } else {
+        hide(welcome);
+        show(governor, '');
+        show(tokenPanel, '');
+        show(reposSection, '');
+        show(beadsSection, '');
+        show(nousSection, '');
+        show(debugSection, '');
+        show(logsSection, '');
+        sidebarGroups.forEach(g => show(g, ''));
+      }
     }
 
     function switchConfigTab(tabId) {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6185,8 +6185,7 @@ function burnAreaChart() {
             <div style="text-align:right;min-width:80px">
               <div style="font-size:0.7rem;color:var(--muted)">${p.agentCount} agent${p.agentCount !== 1 ? 's' : ''}</div>
               ${!isCurrent && p.level > 0 ? '<button onclick="applyACMMPack(' + p.level + ')" style="margin-top:4px;padding:6px 14px;background:' + color + ';color:#fff;border:none;border-radius:6px;font-size:0.75rem;font-weight:600;cursor:pointer">Apply</button>' : ''}
-              ${!isCurrent && p.level > 0 ? '<button onclick="setACMMLevel(' + p.level + ')" style="margin-top:4px;padding:5px 10px;background:transparent;color:' + color + ';border:1px solid ' + color + ';border-radius:6px;font-size:0.68rem;font-weight:600;cursor:pointer" title="Set level without creating agents">Set Level</button>' : ''}
-              ${p.level === 0 ? '<div style="font-size:0.65rem;color:var(--muted);margin-top:4px">Baseline</div>' : ''}
+              ${!isCurrent ? '<button onclick="setACMMLevel(' + p.level + ')" style="margin-top:4px;padding:5px 10px;background:transparent;color:' + color + ';border:1px solid ' + color + ';border-radius:6px;font-size:0.68rem;font-weight:600;cursor:pointer" title="Set level without creating agents">Set Level</button>' : ''}
             </div>
           </div>
           ${p.governor ? '<div style="font-size:0.7rem;color:var(--muted);margin-bottom:6px"><span style="font-weight:600">Governor:</span> ' + esc(p.governor.modes || 'none') + ' · <span style="font-weight:600">Merge:</span> ' + esc(p.governor.mergePolicy || 'manual') + '</div>' : ''}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2131,6 +2131,8 @@
         renderGovernor(lastData.governor, lastData.cadenceMatrix || [], lastData);
       }
       renderDebugSection();
+      const _lvl2 = (lastData.acmmLevel != null) ? lastData.acmmLevel : 0;
+      applyACMMVisibility(_lvl2, lastData.acmmPackAgents || null);
     }
 
     function _sidebarRenderAgent(a) {
@@ -6005,6 +6007,9 @@ function burnAreaChart() {
             applyPinOverrides(lastData.agents);
             renderAgents(lastData.agents);
           }
+          const _lvl = (lastData.acmmLevel != null) ? lastData.acmmLevel : 0;
+          const _pa = lastData.acmmPackAgents || null;
+          applyACMMVisibility(_lvl, _pa);
         } catch (err) {
           console.error('SSE agent-status parse error:', err);
         }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -991,24 +991,29 @@
       animation: config-fade-in 0.15s ease-out;
     }
     .hive-dialog {
-      background: var(--surface); border: 1px solid var(--border);
+      background: #1a1a2e; border: 1px solid #2d2d3d;
       border-radius: 10px; width: 460px; max-width: 92vw;
       box-shadow: 0 16px 48px rgba(0,0,0,0.5);
       padding: 24px;
     }
-    .hive-dialog-title { font-size: 1rem; font-weight: 600; color: var(--text); margin-bottom: 12px; }
-    .hive-dialog-body { font-size: 0.9rem; color: var(--text-secondary); line-height: 1.5; white-space: pre-wrap; margin-bottom: 20px; }
+    body.light-mode .hive-dialog { background: #fff; border-color: #e0e0e0; }
+    .hive-dialog-title { font-size: 1rem; font-weight: 600; color: #c9d1d9; margin-bottom: 12px; }
+    body.light-mode .hive-dialog-title { color: #1a1a2e; }
+    .hive-dialog-body { font-size: 0.9rem; color: #8b949e; line-height: 1.5; white-space: pre-wrap; margin-bottom: 20px; }
+    body.light-mode .hive-dialog-body { color: #555; }
     .hive-dialog-buttons { display: flex; gap: 10px; justify-content: flex-end; }
     .hive-dialog-btn {
       padding: 8px 20px; border-radius: 6px; border: 1px solid var(--border);
       font-size: 0.85rem; font-weight: 500; cursor: pointer;
       transition: background 0.15s, border-color 0.15s;
     }
-    .hive-dialog-btn:hover { border-color: var(--accent); }
-    .hive-dialog-btn.primary { background: var(--accent); color: #fff; border-color: var(--accent); }
-    .hive-dialog-btn.primary:hover { opacity: 0.9; }
-    .hive-dialog-btn.cancel { background: transparent; color: var(--text-secondary); }
-    .hive-dialog-btn.cancel:hover { background: var(--surface-hover, rgba(255,255,255,0.05)); }
+    .hive-dialog-btn:hover { border-color: #58a6ff; }
+    .hive-dialog-btn.primary { background: #58a6ff; color: #fff; border-color: #58a6ff; }
+    .hive-dialog-btn.primary:hover { background: #4a90e0; }
+    .hive-dialog-btn.cancel { background: #2d2d3d; color: #8b949e; border-color: #3d3d4d; }
+    .hive-dialog-btn.cancel:hover { background: #3d3d4d; }
+    body.light-mode .hive-dialog-btn.cancel { background: #f0f0f0; color: #555; border-color: #ddd; }
+    body.light-mode .hive-dialog-btn.cancel:hover { background: #e0e0e0; }
     .config-modal {
       background: var(--surface); border: 1px solid var(--border);
       border-radius: 12px; width: 900px; max-width: 95vw;

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6185,7 +6185,7 @@ function burnAreaChart() {
             <div style="text-align:right;min-width:80px">
               <div style="font-size:0.7rem;color:var(--muted)">${p.agentCount} agent${p.agentCount !== 1 ? 's' : ''}</div>
               ${!isCurrent && p.level > 0 ? '<button onclick="applyACMMPack(' + p.level + ')" style="margin-top:4px;padding:6px 14px;background:' + color + ';color:#fff;border:none;border-radius:6px;font-size:0.75rem;font-weight:600;cursor:pointer">Apply</button>' : ''}
-              ${!isCurrent ? '<button onclick="setACMMLevel(' + p.level + ')" style="margin-top:4px;padding:5px 10px;background:transparent;color:' + color + ';border:1px solid ' + color + ';border-radius:6px;font-size:0.68rem;font-weight:600;cursor:pointer" title="Set level without creating agents">Set Level</button>' : ''}
+              ${!isCurrent ? '<button onclick="setACMMLevel(' + p.level + ')" style="margin-top:4px;padding:5px 10px;background:transparent;color:' + color + ';border:1px solid ' + color + ';border-radius:6px;font-size:0.68rem;font-weight:600;cursor:pointer" title="Preview this level — changes the display without affecting running agents">Preview</button>' : ''}
             </div>
           </div>
           ${p.governor ? '<div style="font-size:0.7rem;color:var(--muted);margin-bottom:6px"><span style="font-weight:600">Governor:</span> ' + esc(p.governor.modes || 'none') + ' · <span style="font-weight:600">Merge:</span> ' + esc(p.governor.mergePolicy || 'manual') + '</div>' : ''}
@@ -6203,7 +6203,7 @@ function burnAreaChart() {
       const pack = (_acmmPacks || []).find(p => p.level === level);
       if (!pack) return;
 
-      if (!confirm(`Apply ACMM Level ${level} (${pack.name})?\n\nThis will create ${pack.agentCount} agent(s). Existing agents with the same name will be skipped.`)) return;
+      if (!confirm(`Apply ACMM Level ${level} (${pack.name})?\n\nThis will:\n• Create ${pack.agentCount} agent(s) (existing agents with the same name are skipped)\n• Pause agents not in this level's pack\n• Resume agents that are in this level's pack`)) return;
 
       try {
         const res = await fetch(`/api/packs/${level}/apply`, { method: 'POST' });
@@ -6231,7 +6231,7 @@ function burnAreaChart() {
 
       const levelNames = ['Unaware', 'Idea', 'Development', 'CI/CD', 'Full Automation', 'Guarded Autonomy', 'Full Autonomy'];
       const name = levelNames[level] || 'Level ' + level;
-      if (!confirm(`Set ACMM level to L${level} (${name})?\n\nThis only changes the displayed level — no agents will be created or removed.`)) return;
+      if (!confirm(`Preview ACMM Level ${level} (${name})?\n\nThis changes the dashboard display to show what this level looks like. Running agents are not affected — use Apply to create agents and change their state.`)) return;
 
       try {
         const res = await fetch('/api/packs/level', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ level }) });

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -984,6 +984,31 @@
     }
     .config-overlay.hidden { display: none; }
     @keyframes config-fade-in { from { opacity: 0; } to { opacity: 1; } }
+    .hive-dialog-overlay {
+      position: fixed; inset: 0; z-index: 20000;
+      background: rgba(0,0,0,0.6); backdrop-filter: blur(2px);
+      display: flex; align-items: center; justify-content: center;
+      animation: config-fade-in 0.15s ease-out;
+    }
+    .hive-dialog {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 10px; width: 460px; max-width: 92vw;
+      box-shadow: 0 16px 48px rgba(0,0,0,0.5);
+      padding: 24px;
+    }
+    .hive-dialog-title { font-size: 1rem; font-weight: 600; color: var(--text); margin-bottom: 12px; }
+    .hive-dialog-body { font-size: 0.9rem; color: var(--text-secondary); line-height: 1.5; white-space: pre-wrap; margin-bottom: 20px; }
+    .hive-dialog-buttons { display: flex; gap: 10px; justify-content: flex-end; }
+    .hive-dialog-btn {
+      padding: 8px 20px; border-radius: 6px; border: 1px solid var(--border);
+      font-size: 0.85rem; font-weight: 500; cursor: pointer;
+      transition: background 0.15s, border-color 0.15s;
+    }
+    .hive-dialog-btn:hover { border-color: var(--accent); }
+    .hive-dialog-btn.primary { background: var(--accent); color: #fff; border-color: var(--accent); }
+    .hive-dialog-btn.primary:hover { opacity: 0.9; }
+    .hive-dialog-btn.cancel { background: transparent; color: var(--text-secondary); }
+    .hive-dialog-btn.cancel:hover { background: var(--surface-hover, rgba(255,255,255,0.05)); }
     .config-modal {
       background: var(--surface); border: 1px solid var(--border);
       border-radius: 12px; width: 900px; max-width: 95vw;
@@ -4026,7 +4051,7 @@ function burnAreaChart() {
       const modeOrder = { observe: 0, suggest: 1, evolve: 2 };
       let force = false;
       if (modeOrder[mode] < modeOrder[current]) {
-        if (!confirm(`Switch from ${current} to ${mode}? This will stop any active experiment.`)) return;
+        if (!(await hiveConfirm(`Switch from ${current} to ${mode}? This will stop any active experiment.`))) return;
         force = true;
       }
       try {
@@ -4059,7 +4084,7 @@ function burnAreaChart() {
     }
 
     async function nousReject() {
-      if (!confirm('Reject this experiment proposal?')) return;
+      if (!(await hiveConfirm('Reject this experiment proposal?'))) return;
       try {
         await fetch('/api/nous/abort', { method: 'POST' });
         showToast('Proposal rejected', 'success');
@@ -4068,7 +4093,7 @@ function burnAreaChart() {
     }
 
     async function nousAbort() {
-      if (!confirm('Abort the active experiment? This will revert governor to default behavior.')) return;
+      if (!(await hiveConfirm('Abort the active experiment? This will revert governor to default behavior.'))) return;
       try {
         const r = await fetch('/api/nous/abort', { method: 'POST' });
         const j = await r.json();
@@ -4288,7 +4313,7 @@ function burnAreaChart() {
     }
 
     async function deleteNousPrinciple(id) {
-      if (!confirm('Invalidate this principle? It will be removed from the store.')) return;
+      if (!(await hiveConfirm('Invalidate this principle? It will be removed from the store.'))) return;
       try {
         const r = await fetch('/api/nous/principles/' + encodeURIComponent(id), { method: 'DELETE' });
         const j = await r.json();
@@ -4703,17 +4728,17 @@ function burnAreaChart() {
     async function kbSetupConnectVault() {
       const path = document.getElementById('kb-setup-vault-path')?.value?.trim();
       const name = document.getElementById('kb-setup-vault-name')?.value?.trim();
-      if (!path) { alert('Path is required'); return; }
+      if (!path) { await hiveAlert('Path is required'); return; }
 
       try {
         const r = await fetch('/api/knowledge/vaults', {
           method: 'POST', headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ path, name: name || '' }),
         });
-        if (!r.ok) { const e = await r.json(); alert(e.error || 'Failed to connect vault'); return; }
+        if (!r.ok) { const e = await r.json(); await hiveAlert(e.error || 'Failed to connect vault'); return; }
         _kbSetupView = 'none';
         await fetchKnowledgeStats();
-      } catch (e) { alert('Error: ' + e.message); }
+      } catch (e) { await hiveAlert('Error: ' + e.message); }
     }
 
     function renderKnowledge() {
@@ -4989,18 +5014,18 @@ function burnAreaChart() {
       const tagsRaw = document.getElementById('kb-create-tags')?.value || '';
       const tags = tagsRaw.split(',').map(t => t.trim()).filter(Boolean);
 
-      if (!title || !body) { alert('Title and body are required'); return; }
+      if (!title || !body) { await hiveAlert('Title and body are required'); return; }
 
       try {
         const r = await fetch('/api/knowledge/create', {
           method: 'POST', headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ title, body, layer, type, confidence: conf, tags }),
         });
-        if (!r.ok) { const e = await r.json(); alert(e.error || 'Failed to create'); return; }
+        if (!r.ok) { const e = await r.json(); await hiveAlert(e.error || 'Failed to create'); return; }
         kbCloseModal();
         fetchKnowledgeStats();
         kbSearch();
-      } catch (e) { alert('Error: ' + e.message); }
+      } catch (e) { await hiveAlert('Error: ' + e.message); }
     }
 
     function kbOpenEdit() {
@@ -5065,24 +5090,24 @@ function burnAreaChart() {
           method: 'PUT', headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ title, body, type, status, confidence: conf, tags }),
         });
-        if (!r.ok) { const e = await r.json(); alert(e.error || 'Failed to update'); return; }
+        if (!r.ok) { const e = await r.json(); await hiveAlert(e.error || 'Failed to update'); return; }
         kbCloseModal();
         kbReadFact(f.slug, f.layer);
         kbSearch();
-      } catch (e) { alert('Error: ' + e.message); }
+      } catch (e) { await hiveAlert('Error: ' + e.message); }
     }
 
     async function kbDelete(slug, layer) {
-      if (!confirm('Delete fact "' + slug + '" from ' + layer + '?')) return;
+      if (!(await hiveConfirm('Delete fact "' + slug + '" from ' + layer + '?'))) return;
       try {
         const r = await fetch('/api/knowledge/' + encodeURIComponent(layer) + '/' + encodeURIComponent(slug), { method: 'DELETE' });
-        if (!r.ok) { const e = await r.json(); alert(e.error || 'Failed to delete'); return; }
+        if (!r.ok) { const e = await r.json(); await hiveAlert(e.error || 'Failed to delete'); return; }
         _kbSelectedFact = null;
         const detail = document.getElementById('kb-fact-detail');
         if (detail) detail.innerHTML = '';
         fetchKnowledgeStats();
         kbSearch();
-      } catch (e) { alert('Error: ' + e.message); }
+      } catch (e) { await hiveAlert('Error: ' + e.message); }
     }
 
     async function kbPromote(slug, fromLayer, toLayer) {
@@ -5093,10 +5118,10 @@ function burnAreaChart() {
           method: 'POST', headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ slug, from_layer: fromLayer, to_layer: toLayer, reason, promoter: 'dashboard' }),
         });
-        if (!r.ok) { const e = await r.json(); alert(e.error || 'Failed to promote'); return; }
-        alert('Fact promoted to ' + toLayer);
+        if (!r.ok) { const e = await r.json(); await hiveAlert(e.error || 'Failed to promote'); return; }
+        await hiveAlert('Fact promoted to ' + toLayer);
         fetchKnowledgeStats();
-      } catch (e) { alert('Error: ' + e.message); }
+      } catch (e) { await hiveAlert('Error: ' + e.message); }
     }
 
     function kbOpenImport() {
@@ -5157,7 +5182,7 @@ function burnAreaChart() {
       const layer = document.getElementById('kb-import-layer')?.value;
       const format = document.getElementById('kb-import-format')?.value;
 
-      if (!content) { alert('Content is required'); return; }
+      if (!content) { await hiveAlert('Content is required'); return; }
 
       try {
         const r = await fetch('/api/knowledge/import', {
@@ -5165,12 +5190,12 @@ function burnAreaChart() {
           body: JSON.stringify({ content, layer, format }),
         });
         const data = await r.json();
-        if (!r.ok) { alert(data.error || 'Failed to import'); return; }
+        if (!r.ok) { await hiveAlert(data.error || 'Failed to import'); return; }
         kbCloseModal();
-        alert('Imported ' + (data.imported || 0) + ' facts to ' + layer);
+        await hiveAlert('Imported ' + (data.imported || 0) + ' facts to ' + layer);
         fetchKnowledgeStats();
         kbSearch();
-      } catch (e) { alert('Error: ' + e.message); }
+      } catch (e) { await hiveAlert('Error: ' + e.message); }
     }
 
     function kbOpenSubscriptions() {
@@ -5227,30 +5252,30 @@ function burnAreaChart() {
       const name = document.getElementById('kb-sub-name')?.value?.trim();
       const layer = document.getElementById('kb-sub-layer')?.value;
 
-      if (!url) { alert('URL is required'); return; }
+      if (!url) { await hiveAlert('URL is required'); return; }
 
       try {
         const r = await fetch('/api/knowledge/subscriptions', {
           method: 'POST', headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ url, name: name || url, layer }),
         });
-        if (!r.ok) { const e = await r.json(); alert(e.error || 'Failed to add'); return; }
+        if (!r.ok) { const e = await r.json(); await hiveAlert(e.error || 'Failed to add'); return; }
         kbLoadSubscriptions();
         fetchKnowledgeStats();
-      } catch (e) { alert('Error: ' + e.message); }
+      } catch (e) { await hiveAlert('Error: ' + e.message); }
     }
 
     async function kbRemoveSub(url) {
-      if (!confirm('Remove subscription to ' + url + '?')) return;
+      if (!(await hiveConfirm('Remove subscription to ' + url + '?'))) return;
       try {
         const r = await fetch('/api/knowledge/subscriptions', {
           method: 'DELETE', headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ url }),
         });
-        if (!r.ok) { const e = await r.json(); alert(e.error || 'Failed to remove'); return; }
+        if (!r.ok) { const e = await r.json(); await hiveAlert(e.error || 'Failed to remove'); return; }
         kbLoadSubscriptions();
         fetchKnowledgeStats();
-      } catch (e) { alert('Error: ' + e.message); }
+      } catch (e) { await hiveAlert('Error: ' + e.message); }
     }
 
 
@@ -5385,30 +5410,30 @@ function burnAreaChart() {
     async function kbConnectVault() {
       const path = document.getElementById('kb-vault-path')?.value?.trim();
       const name = document.getElementById('kb-vault-name')?.value?.trim();
-      if (!path) { alert('Path is required'); return; }
+      if (!path) { await hiveAlert('Path is required'); return; }
 
       try {
         const r = await fetch('/api/knowledge/vaults', {
           method: 'POST', headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ path, name: name || '' }),
         });
-        if (!r.ok) { const e = await r.json(); alert(e.error || 'Failed to connect vault'); return; }
+        if (!r.ok) { const e = await r.json(); await hiveAlert(e.error || 'Failed to connect vault'); return; }
         kbLoadVaults();
         fetchKnowledgeStats();
-      } catch (e) { alert('Error: ' + e.message); }
+      } catch (e) { await hiveAlert('Error: ' + e.message); }
     }
 
     async function kbDisconnectVault(path) {
-      if (!confirm('Disconnect vault at ' + path + '?')) return;
+      if (!(await hiveConfirm('Disconnect vault at ' + path + '?'))) return;
       try {
         const r = await fetch('/api/knowledge/vaults', {
           method: 'DELETE', headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ path }),
         });
-        if (!r.ok) { const e = await r.json(); alert(e.error || 'Failed to disconnect'); return; }
+        if (!r.ok) { const e = await r.json(); await hiveAlert(e.error || 'Failed to disconnect'); return; }
         kbLoadVaults();
         fetchKnowledgeStats();
-      } catch (e) { alert('Error: ' + e.message); }
+      } catch (e) { await hiveAlert('Error: ' + e.message); }
     }
 
     async function kbReindexVault(path) {
@@ -5417,10 +5442,10 @@ function burnAreaChart() {
           method: 'POST', headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ path }),
         });
-        if (!r.ok) { const e = await r.json(); alert(e.error || 'Failed to reindex'); return; }
+        if (!r.ok) { const e = await r.json(); await hiveAlert(e.error || 'Failed to reindex'); return; }
         kbLoadVaults();
         fetchKnowledgeStats();
-      } catch (e) { alert('Error: ' + e.message); }
+      } catch (e) { await hiveAlert('Error: ' + e.message); }
     }
 
     async function kbSearchVault(name) {
@@ -5766,6 +5791,45 @@ function burnAreaChart() {
 
     const TOAST_DURATION_MS = 3000;
     const TOAST_PROGRESS_MAX_MS = 60000;
+    function hiveConfirm(message, title) {
+      return new Promise(resolve => {
+        const overlay = document.createElement('div');
+        overlay.className = 'hive-dialog-overlay';
+        const parts = message.split('\n\n');
+        const heading = title || parts.length > 1 ? (title || parts[0]) : 'Confirm';
+        const body = title ? message : (parts.length > 1 ? parts.slice(1).join('\n\n') : message);
+        overlay.innerHTML = `<div class="hive-dialog">
+          <div class="hive-dialog-title">${heading.replace(/</g,'&lt;')}</div>
+          <div class="hive-dialog-body">${body.replace(/</g,'&lt;')}</div>
+          <div class="hive-dialog-buttons">
+            <button class="hive-dialog-btn cancel">Cancel</button>
+            <button class="hive-dialog-btn primary">OK</button>
+          </div></div>`;
+        document.body.appendChild(overlay);
+        const close = (val) => { overlay.remove(); resolve(val); };
+        overlay.querySelector('.cancel').onclick = () => close(false);
+        overlay.querySelector('.primary').onclick = () => close(true);
+        overlay.onclick = (e) => { if (e.target === overlay) close(false); };
+        overlay.querySelector('.primary').focus();
+      });
+    }
+    function hiveAlert(message, title) {
+      return new Promise(resolve => {
+        const overlay = document.createElement('div');
+        overlay.className = 'hive-dialog-overlay';
+        overlay.innerHTML = `<div class="hive-dialog">
+          <div class="hive-dialog-title">${(title || 'Notice').replace(/</g,'&lt;')}</div>
+          <div class="hive-dialog-body">${String(message).replace(/</g,'&lt;')}</div>
+          <div class="hive-dialog-buttons">
+            <button class="hive-dialog-btn primary">OK</button>
+          </div></div>`;
+        document.body.appendChild(overlay);
+        const close = () => { overlay.remove(); resolve(); };
+        overlay.querySelector('.primary').onclick = close;
+        overlay.onclick = (e) => { if (e.target === overlay) close(); };
+        overlay.querySelector('.primary').focus();
+      });
+    }
     function showToast(msg, type = 'info', persistent = false) {
       const container = document.getElementById('toast-container');
       const el = document.createElement('div');
@@ -5847,7 +5911,7 @@ function burnAreaChart() {
     }
 
     async function restartAgent(agent) {
-      if (!confirm(`Restart ${agent}? This will kill the current session and start fresh.`)) return;
+      if (!(await hiveConfirm(`Restart ${agent}? This will kill the current session and start fresh.`))) return;
       const toast = showToast(`Restarting ${agent}...`, 'info', true);
       const res = await fetch(`/api/restart/${agent}`, { method: 'POST' });
       const data = await res.json();
@@ -6211,7 +6275,7 @@ function burnAreaChart() {
       const pack = (_acmmPacks || []).find(p => p.level === level);
       if (!pack) return;
 
-      if (!confirm(`Apply ACMM Level ${level} (${pack.name})?\n\nThis will:\n• Create ${pack.agentCount} agent(s) (existing agents with the same name are skipped)\n• Pause agents not in this level's pack\n• Resume agents that are in this level's pack`)) return;
+      if (!(await hiveConfirm(`Apply ACMM Level ${level} (${pack.name})?\n\nThis will:\n• Create ${pack.agentCount} agent(s) (existing agents with the same name are skipped)\n• Pause agents not in this level's pack\n• Resume agents that are in this level's pack`))) return;
 
       try {
         const res = await fetch(`/api/packs/${level}/apply`, { method: 'POST' });
@@ -6239,7 +6303,7 @@ function burnAreaChart() {
 
       const levelNames = ['Unaware', 'Idea', 'Development', 'CI/CD', 'Full Automation', 'Guarded Autonomy', 'Full Autonomy'];
       const name = levelNames[level] || 'Level ' + level;
-      if (!confirm(`Preview ACMM Level ${level} (${name})?\n\nThis changes the dashboard display to show what this level looks like. Running agents are not affected — use Apply to create agents and change their state.`)) return;
+      if (!(await hiveConfirm(`Preview ACMM Level ${level} (${name})?\n\nThis changes the dashboard display to show what this level looks like. Running agents are not affected — use Apply to create agents and change their state.`))) return;
 
       try {
         const res = await fetch('/api/packs/level', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ level }) });
@@ -7257,8 +7321,8 @@ function burnAreaChart() {
         .catch(err => showToast(`Failed: ${err.message}`, 'error'));
     }
 
-    function deleteAgentFromConfig(name) {
-      if (!confirm(`Delete agent "${name}"?\n\nThis will remove its env file, governor config, and sidebar entry. The tmux session (if running) will NOT be killed.`)) return;
+    async function deleteAgentFromConfig(name) {
+      if (!(await hiveConfirm(`Delete agent "${name}"?\n\nThis will remove its env file, governor config, and sidebar entry. The tmux session (if running) will NOT be killed.`))) return;
       fetch(`/api/config/governor/agents/${name}`, { method: 'DELETE' })
         .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
         .then(() => {
@@ -7279,8 +7343,8 @@ function burnAreaChart() {
         .catch(err => showToast(`Failed: ${err.message}`, 'error'));
     }
 
-    function removeAgent(name) {
-      if (!confirm(`Remove agent "${name}"? This will delete its configuration.`)) return;
+    async function removeAgent(name) {
+      if (!(await hiveConfirm(`Remove agent "${name}"? This will delete its configuration.`))) return;
       fetch(`/api/config/governor/agents/${name}`, { method: 'DELETE' })
         .then(r => { if (!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
         .then(() => {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6274,8 +6274,12 @@ function burnAreaChart() {
       const debugSection = document.getElementById('debug-section');
       const logsSection = document.getElementById('logs-section');
 
-      const sidebarControl = document.querySelector('.oc-nav-group .oc-nav-label');
       const sidebarGroups = document.querySelectorAll('.oc-nav-group');
+      const sidebarItems = document.querySelectorAll('.oc-nav-item');
+
+      const infoSidebar = document.getElementById('hive-info-sidebar');
+      const agentCards = document.getElementById('agents');
+      const agentDetail = document.getElementById('oc-agent-detail');
 
       if (isL0) {
         show(welcome, 'block');
@@ -6286,10 +6290,19 @@ function burnAreaChart() {
         hide(nousSection);
         hide(debugSection);
         hide(logsSection);
+        hide(infoSidebar);
+        hide(agentCards);
+        hide(agentDetail);
         sidebarGroups.forEach(g => {
           const label = g.querySelector('.oc-nav-label, .oc-tree-toggle');
           const text = label ? label.textContent.trim() : '';
           if (text === 'Control' || text.includes('Agent')) hide(g);
+        });
+        sidebarItems.forEach(item => {
+          const section = item.getAttribute('data-section') || '';
+          if (section === 'repos-section' || section === 'beads-section' || section === 'nous-section') {
+            hide(item);
+          }
         });
       } else {
         hide(welcome);
@@ -6300,7 +6313,11 @@ function burnAreaChart() {
         show(nousSection, '');
         show(debugSection, '');
         show(logsSection, '');
+        show(infoSidebar, '');
+        show(agentCards, '');
+        show(agentDetail, '');
         sidebarGroups.forEach(g => show(g, ''));
+        sidebarItems.forEach(item => show(item, ''));
       }
     }
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1536,6 +1536,22 @@
     </div>
   </div>
 </div>
+<div id="acmm-overlay" class="config-overlay hidden">
+  <div class="config-modal" style="max-width:800px;max-height:85vh">
+    <div class="config-header">
+      <h2 class="config-title">ACMM Maturity Level</h2>
+      <button class="config-close" onclick="closeACMMDialog()">&times;</button>
+    </div>
+    <div class="config-body" style="padding:16px 24px;overflow-y:auto;max-height:calc(85vh - 120px)">
+      <p style="font-size:0.82rem;color:var(--muted);margin:0 0 16px">
+        Select your AI-native Continuous Maturity Model (ACMM) level. Each level provides a curated set of agents
+        with increasing autonomy. Agents are additive — higher levels build on lower ones.
+      </p>
+      <div id="acmm-packs-list" style="display:flex;flex-direction:column;gap:12px"></div>
+      <div id="acmm-apply-error" style="color:#dc2626;font-size:0.8rem;margin-top:12px;display:none"></div>
+    </div>
+  </div>
+</div>
 <div class="gh-auth-alert" id="gh-auth-alert">GitHub API authentication failed. Check GitHub App key or token configuration.</div>
   <div class="gh-rate-alert" id="gh-rate-alert"></div>
 
@@ -1547,6 +1563,9 @@
         <div class="oc-logo-title">HIVE</div>
         <div class="oc-logo-sub">GATEWAY DASHBOARD</div>
       </div>
+    </div>
+    <div style="padding:4px 16px 8px;text-align:center">
+      <span id="acmm-sidebar-badge" title="ACMM Maturity Level — click to change" style="cursor:pointer;display:inline-block;padding:4px 12px;border-radius:12px;font-size:0.7rem;font-weight:700;background:linear-gradient(135deg,#3498db,#2ecc71);color:#fff;letter-spacing:0.5px" onclick="openACMMDialog()"></span>
     </div>
     <div class="oc-nav-group">
       <div class="oc-nav-label">Control</div>
@@ -1599,6 +1618,7 @@
   <h1><span class="bee">🐝</span> KubeStellar Hive Dashboard&nbsp;<span id="project-name">for KubeStellar/Console</span> <span class="timestamp" id="ts"></span>
     <span class="git-version" id="git-version"></span>
     <span class="git-version" id="hive-id-badge" title="Hive Instance ID" style="cursor:pointer;border:1px solid var(--border);padding:2px 8px;border-radius:4px" onclick="openConfigDialog('governor')"></span>
+    <span class="git-version" id="acmm-badge" title="ACMM Maturity Level — click to change" style="cursor:pointer;border:1px solid var(--border);padding:2px 8px;border-radius:4px;background:linear-gradient(135deg,#3498db,#2ecc71);color:#fff;font-weight:600" onclick="openACMMDialog()"></span>
     <button class="layout-toggle" id="layout-toggle" onclick="toggleLayout()" title="Switch between Light layout (sidebar + detail panel) and Classic layout (dark theme grid). Your preference is saved in the browser.">☰ Classic</button>
     <a href="/api/widget" class="widget-dl" title="Download Übersicht widget">⬇ Widget</a>
   </h1>
@@ -5464,6 +5484,7 @@ function burnAreaChart() {
       if (hiveIdBadge) hiveIdBadge.textContent = hiveId;
       const ocHiveId = document.getElementById('oc-hive-id');
       if (ocHiveId) ocHiveId.textContent = hiveId;
+      updateACMMBadge(data.acmmLevel || 0);
       // Update Light health badge with hover detail
       const ocHealth = document.getElementById('oc-health');
       if (ocHealth) {
@@ -6117,6 +6138,7 @@ function burnAreaChart() {
     document.addEventListener('keydown', (e) => {
       if (e.key === 'Escape' && _configModalOpen) closeConfigDialog();
       if (e.key === 'Escape' && _addAgentOpen) closeAddAgentDialog();
+      if (e.key === 'Escape' && _acmmOpen) closeACMMDialog();
     });
 
     let _addAgentOpen = false;
@@ -6179,6 +6201,119 @@ function burnAreaChart() {
         errEl.textContent = 'Network error: ' + err.message;
         errEl.style.display = 'block';
       }
+    }
+
+    // ── ACMM Level Selector ──
+    let _acmmOpen = false;
+    let _acmmPacks = null;
+
+    async function openACMMDialog() {
+      _acmmOpen = true;
+      document.getElementById('acmm-overlay').classList.remove('hidden');
+      document.getElementById('acmm-apply-error').style.display = 'none';
+
+      if (!_acmmPacks) {
+        try {
+          const res = await fetch('/api/packs');
+          _acmmPacks = await res.json();
+        } catch (err) {
+          document.getElementById('acmm-packs-list').innerHTML = '<div style="color:var(--muted)">Failed to load packs</div>';
+          return;
+        }
+      }
+      renderACMMPacks();
+    }
+
+    function closeACMMDialog() {
+      _acmmOpen = false;
+      document.getElementById('acmm-overlay').classList.add('hidden');
+    }
+
+    function renderACMMPacks() {
+      const container = document.getElementById('acmm-packs-list');
+      const currentLevel = window._lastStatus ? (window._lastStatus.acmmLevel || 0) : 0;
+
+      const levelColors = ['#95a5a6', '#8e44ad', '#2980b9', '#27ae60', '#e67e22', '#e74c3c', '#c0392b'];
+
+      container.innerHTML = (_acmmPacks || []).map(p => {
+        const isCurrent = p.current || p.level === currentLevel;
+        const color = levelColors[p.level] || '#3498db';
+        const agentList = (p.agents || []).map(a =>
+          `<div style="display:flex;align-items:center;gap:6px;padding:3px 0;font-size:0.75rem">
+            <span style="font-size:1rem">${esc(a.emoji || '🤖')}</span>
+            <span style="font-weight:600;color:${esc(a.color || '#999')}">${esc(a.displayName || a.name)}</span>
+            <span style="color:var(--muted);flex:1">${esc(a.description || '').substring(0, 80)}${(a.description || '').length > 80 ? '…' : ''}</span>
+          </div>`
+        ).join('');
+
+        const knowledgeNotes = (p.agents || []).filter(a => a.knowledgeUse).map(a =>
+          `<div style="font-size:0.7rem;color:var(--muted);padding:2px 0">
+            <span style="font-weight:600">${esc(a.emoji || '')} ${esc(a.displayName || a.name)}</span>: ${esc(a.knowledgeUse || '').substring(0, 120)}${(a.knowledgeUse || '').length > 120 ? '…' : ''}
+          </div>`
+        ).join('');
+
+        const interactionNotes = (p.agents || []).filter(a => a.interactions).map(a =>
+          `<div style="font-size:0.7rem;color:var(--muted);padding:2px 0">
+            <span style="font-weight:600">${esc(a.emoji || '')} ${esc(a.displayName || a.name)}</span>: ${esc(a.interactions || '')}
+          </div>`
+        ).join('');
+
+        return `<div style="border:2px solid ${isCurrent ? color : 'var(--border)'};border-radius:10px;padding:16px;${isCurrent ? 'background:var(--surface);box-shadow:0 0 12px ' + color + '40' : ''}">
+          <div style="display:flex;align-items:center;gap:10px;margin-bottom:8px">
+            <span style="font-size:1.5rem;font-weight:800;color:${color};min-width:32px">L${p.level}</span>
+            <div style="flex:1">
+              <div style="font-weight:700;font-size:0.9rem">${esc(p.name)} ${isCurrent ? '<span style="font-size:0.7rem;background:' + color + ';color:#fff;padding:2px 8px;border-radius:8px;margin-left:6px">CURRENT</span>' : ''}</div>
+              <div style="font-size:0.78rem;color:var(--muted);margin-top:2px">${esc(p.description || '')}</div>
+            </div>
+            <div style="text-align:right;min-width:80px">
+              <div style="font-size:0.7rem;color:var(--muted)">${p.agentCount} agent${p.agentCount !== 1 ? 's' : ''}</div>
+              ${!isCurrent && p.level > 0 ? '<button onclick="applyACMMPack(' + p.level + ')" style="margin-top:4px;padding:6px 14px;background:' + color + ';color:#fff;border:none;border-radius:6px;font-size:0.75rem;font-weight:600;cursor:pointer">Apply</button>' : ''}
+              ${p.level === 0 ? '<div style="font-size:0.65rem;color:var(--muted);margin-top:4px">Baseline</div>' : ''}
+            </div>
+          </div>
+          ${p.governor ? '<div style="font-size:0.7rem;color:var(--muted);margin-bottom:6px"><span style="font-weight:600">Governor:</span> ' + esc(p.governor.modes || 'none') + ' · <span style="font-weight:600">Merge:</span> ' + esc(p.governor.mergePolicy || 'manual') + '</div>' : ''}
+          ${agentList ? '<details style="margin-top:6px"><summary style="font-size:0.75rem;font-weight:600;cursor:pointer;color:var(--fg)">Agents (' + p.agentCount + ')</summary><div style="margin-top:6px;padding-left:4px">' + agentList + '</div></details>' : ''}
+          ${interactionNotes ? '<details style="margin-top:4px"><summary style="font-size:0.72rem;font-weight:600;cursor:pointer;color:var(--muted)">Agent Interactions</summary><div style="margin-top:4px;padding-left:4px">' + interactionNotes + '</div></details>' : ''}
+          ${knowledgeNotes ? '<details style="margin-top:4px"><summary style="font-size:0.72rem;font-weight:600;cursor:pointer;color:var(--muted)">Knowledge Base Usage</summary><div style="margin-top:4px;padding-left:4px">' + knowledgeNotes + '</div></details>' : ''}
+        </div>`;
+      }).join('');
+    }
+
+    async function applyACMMPack(level) {
+      const errEl = document.getElementById('acmm-apply-error');
+      errEl.style.display = 'none';
+
+      const pack = (_acmmPacks || []).find(p => p.level === level);
+      if (!pack) return;
+
+      if (!confirm(`Apply ACMM Level ${level} (${pack.name})?\n\nThis will create ${pack.agentCount} agent(s). Existing agents with the same name will be skipped.`)) return;
+
+      try {
+        const res = await fetch(`/api/packs/${level}/apply`, { method: 'POST' });
+        const data = await res.json();
+        if (!res.ok) {
+          errEl.textContent = data.error || 'Failed to apply pack';
+          errEl.style.display = 'block';
+          return;
+        }
+        const created = (data.created || []).length;
+        const skipped = (data.skipped || []).length;
+        showToast(`Level ${level} applied: ${created} created, ${skipped} skipped`, 'success');
+        _acmmPacks = null;
+        closeACMMDialog();
+      } catch (err) {
+        errEl.textContent = 'Network error: ' + err.message;
+        errEl.style.display = 'block';
+      }
+    }
+
+    function updateACMMBadge(level) {
+      const levelNames = ['L0 Unaware', 'L1 Idea', 'L2 Dev', 'L3 CI/CD', 'L4 Auto', 'L5 Guarded', 'L6 Full Auto'];
+      const text = levelNames[level] || 'L' + level;
+      const badge = document.getElementById('acmm-badge');
+      if (badge) badge.textContent = 'ACMM ' + text;
+      const sbBadge = document.getElementById('acmm-sidebar-badge');
+      if (sbBadge) sbBadge.textContent = 'ACMM ' + text;
     }
 
     function switchConfigTab(tabId) {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6343,7 +6343,7 @@ function burnAreaChart() {
           if (section === 'nous-section' && level < ACMM_NOUS_MIN_LEVEL) hide(item);
         });
 
-        if (packAgents && packAgents.length > 0) {
+        if (Array.isArray(packAgents)) {
           const packSet = new Set(packAgents);
           document.querySelectorAll('[data-agent-nav]').forEach(navItem => {
             const name = navItem.getAttribute('data-agent-nav');

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5482,6 +5482,14 @@ function burnAreaChart() {
       window._tokensByAgent = (data.tokens || {}).byAgent || {};
       window._lastAgents = data.agents || [];
       window._lastStatus = data;
+      if (window._acmmOverride) {
+        if (data.acmmLevel === window._acmmOverride.level) {
+          window._acmmOverride = null;
+        } else {
+          window._lastStatus.acmmLevel = window._acmmOverride.level;
+          window._lastStatus.acmmPackAgents = window._acmmOverride.packAgents;
+        }
+      }
       window._lastBudget = data.budget || {};
       if (data.agents) injectAgentStyles(data.agents);
       // Display the Hive ID in header badges
@@ -6320,6 +6328,7 @@ function burnAreaChart() {
         const created = (data.created || []).length;
         const skipped = (data.skipped || []).length;
         closeACMMDialog();
+        window._acmmOverride = { level: level, packAgents: data.packAgents || [] };
         if (window._lastStatus) {
           window._lastStatus.acmmLevel = level;
           window._lastStatus.acmmPackAgents = data.packAgents || [];
@@ -6353,6 +6362,7 @@ function burnAreaChart() {
           return;
         }
         closeACMMDialog();
+        window._acmmOverride = { level: level, packAgents: data.packAgents || [] };
         if (window._lastStatus) {
           window._lastStatus.acmmLevel = level;
           window._lastStatus.acmmPackAgents = data.packAgents || [];

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1654,11 +1654,14 @@
       <li><strong style="color:#c9d1d9;">Supervisor</strong> &mdash; monitors all agents, detects stalls, reports status</li>
     </ul>
     <ul class="sidebar-links">
-      <li><a href="https://arxiv.org/abs/2504.07459" target="_blank" rel="noopener">&#128196; ACMM Paper</a></li>
+      <li><a href="https://arxiv.org/abs/2604.09388" target="_blank" rel="noopener">&#128196; ACMM Paper</a></li>
       <li><a href="https://console.kubestellar.io" target="_blank" rel="noopener">&#128421; Console Live Demo</a></li>
       <li><a href="https://github.com/kubestellar/hive" target="_blank" rel="noopener">&#128230; Source Code</a></li>
       <li><a href="https://kubestellar.io/en/acmm-leaderboard" target="_blank" rel="noopener">&#128202; ACMM Leaderboard</a></li>
       <li><a href="https://kubestellar.io/en/leaderboard" target="_blank" rel="noopener">&#127942; Contributor Leaderboard</a></li>
+      <li><a href="https://kubestellar.medium.com/plaque-the-silent-killer-of-ai-agent-reliability-f5c5318c4e9c" target="_blank" rel="noopener">&#128221; Blog: Plaque — Silent Killer</a></li>
+      <li><a href="https://kubestellar.medium.com/intentional-amnesia-why-i-wipe-my-ai-agents-memories-every-15-minutes-1c27e9dcbf0a" target="_blank" rel="noopener">&#128221; Blog: Intentional Amnesia</a></li>
+      <li><a href="https://medium.com/p/b9381a7e9773" target="_blank" rel="noopener">&#128221; Blog: ACMM Framework</a></li>
     </ul>
   </aside>
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6223,6 +6223,31 @@ function burnAreaChart() {
       document.getElementById('acmm-overlay').classList.add('hidden');
     }
 
+    function showACMMLoading(message) {
+      let el = document.getElementById('acmm-loading-overlay');
+      if (!el) {
+        el = document.createElement('div');
+        el.id = 'acmm-loading-overlay';
+        el.style.cssText = 'position:absolute;inset:0;z-index:100;background:rgba(0,0,0,0.7);display:flex;align-items:center;justify-content:center;border-radius:12px';
+        const inner = document.createElement('div');
+        inner.style.cssText = 'text-align:center;color:#fff';
+        inner.innerHTML = '<div style="font-size:2rem;margin-bottom:12px;animation:spin 1s linear infinite">&#9881;</div><div id="acmm-loading-text" style="font-size:0.9rem;font-weight:600"></div>';
+        el.appendChild(inner);
+        const style = document.createElement('style');
+        style.textContent = '@keyframes spin{to{transform:rotate(360deg)}}';
+        el.appendChild(style);
+        document.querySelector('#acmm-overlay .config-modal').style.position = 'relative';
+        document.querySelector('#acmm-overlay .config-modal').appendChild(el);
+      }
+      document.getElementById('acmm-loading-text').textContent = message || 'Switching level…';
+      el.style.display = 'flex';
+    }
+
+    function hideACMMLoading() {
+      const el = document.getElementById('acmm-loading-overlay');
+      if (el) el.style.display = 'none';
+    }
+
     function renderACMMPacks() {
       const container = document.getElementById('acmm-packs-list');
       const currentLevel = window._lastStatus ? (window._lastStatus.acmmLevel || 0) : 0;
@@ -6230,7 +6255,7 @@ function burnAreaChart() {
       const levelColors = ['#95a5a6', '#8e44ad', '#2980b9', '#27ae60', '#e67e22', '#e74c3c', '#c0392b'];
 
       container.innerHTML = (_acmmPacks || []).map(p => {
-        const isCurrent = p.current || p.level === currentLevel;
+        const isCurrent = p.level === currentLevel;
         const color = levelColors[p.level] || '#3498db';
         const agentList = (p.agents || []).map(a =>
           `<div style="display:flex;align-items:center;gap:6px;padding:3px 0;font-size:0.75rem">
@@ -6282,9 +6307,11 @@ function burnAreaChart() {
 
       if (!(await hiveConfirm(`Apply ACMM Level ${level} (${pack.name})?\n\nThis will:\n• Create ${pack.agentCount} agent(s) (existing agents with the same name are skipped)\n• Pause agents not in this level's pack\n• Resume agents that are in this level's pack`))) return;
 
+      showACMMLoading('Applying Level ' + level + '…');
       try {
         const res = await fetch(`/api/packs/${level}/apply`, { method: 'POST' });
         const data = await res.json();
+        hideACMMLoading();
         if (!res.ok) {
           errEl.textContent = data.error || 'Failed to apply pack';
           errEl.style.display = 'block';
@@ -6292,15 +6319,16 @@ function burnAreaChart() {
         }
         const created = (data.created || []).length;
         const skipped = (data.skipped || []).length;
-        showToast(`Level ${level} applied: ${created} created, ${skipped} skipped`, 'success');
-        _acmmPacks = null;
         closeACMMDialog();
         if (window._lastStatus) {
           window._lastStatus.acmmLevel = level;
           window._lastStatus.acmmPackAgents = data.packAgents || [];
           render(window._lastStatus);
         }
+        showToast(`Level ${level} applied: ${created} created, ${skipped} skipped`, 'success');
+        _acmmPacks = null;
       } catch (err) {
+        hideACMMLoading();
         errEl.textContent = 'Network error: ' + err.message;
         errEl.style.display = 'block';
       }
@@ -6314,23 +6342,26 @@ function burnAreaChart() {
       const name = levelNames[level] || 'Level ' + level;
       if (!(await hiveConfirm(`Preview ACMM Level ${level} (${name})?\n\nThis changes the dashboard display to show what this level looks like. Running agents are not affected — use Apply to create agents and change their state.`))) return;
 
+      showACMMLoading('Switching to Level ' + level + '…');
       try {
         const res = await fetch('/api/packs/level', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ level }) });
         const data = await res.json();
+        hideACMMLoading();
         if (!res.ok) {
           errEl.textContent = data.error || 'Failed to set level';
           errEl.style.display = 'block';
           return;
         }
-        showToast(`ACMM level set to L${level} (${name})`, 'success');
-        _acmmPacks = null;
         closeACMMDialog();
         if (window._lastStatus) {
           window._lastStatus.acmmLevel = level;
           window._lastStatus.acmmPackAgents = data.packAgents || [];
           render(window._lastStatus);
         }
+        showToast(`ACMM level set to L${level} (${name})`, 'success');
+        _acmmPacks = null;
       } catch (err) {
+        hideACMMLoading();
         errEl.textContent = 'Network error: ' + err.message;
         errEl.style.display = 'block';
       }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6156,6 +6156,7 @@ function burnAreaChart() {
             <div style="text-align:right;min-width:80px">
               <div style="font-size:0.7rem;color:var(--muted)">${p.agentCount} agent${p.agentCount !== 1 ? 's' : ''}</div>
               ${!isCurrent && p.level > 0 ? '<button onclick="applyACMMPack(' + p.level + ')" style="margin-top:4px;padding:6px 14px;background:' + color + ';color:#fff;border:none;border-radius:6px;font-size:0.75rem;font-weight:600;cursor:pointer">Apply</button>' : ''}
+              ${!isCurrent && p.level > 0 ? '<button onclick="setACMMLevel(' + p.level + ')" style="margin-top:4px;padding:5px 10px;background:transparent;color:' + color + ';border:1px solid ' + color + ';border-radius:6px;font-size:0.68rem;font-weight:600;cursor:pointer" title="Set level without creating agents">Set Level</button>' : ''}
               ${p.level === 0 ? '<div style="font-size:0.65rem;color:var(--muted);margin-top:4px">Baseline</div>' : ''}
             </div>
           </div>
@@ -6187,6 +6188,31 @@ function burnAreaChart() {
         const created = (data.created || []).length;
         const skipped = (data.skipped || []).length;
         showToast(`Level ${level} applied: ${created} created, ${skipped} skipped`, 'success');
+        _acmmPacks = null;
+        closeACMMDialog();
+      } catch (err) {
+        errEl.textContent = 'Network error: ' + err.message;
+        errEl.style.display = 'block';
+      }
+    }
+
+    async function setACMMLevel(level) {
+      const errEl = document.getElementById('acmm-apply-error');
+      errEl.style.display = 'none';
+
+      const levelNames = ['Unaware', 'Idea', 'Development', 'CI/CD', 'Full Automation', 'Guarded Autonomy', 'Full Autonomy'];
+      const name = levelNames[level] || 'Level ' + level;
+      if (!confirm(`Set ACMM level to L${level} (${name})?\n\nThis only changes the displayed level — no agents will be created or removed.`)) return;
+
+      try {
+        const res = await fetch('/api/packs/level', { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ level }) });
+        const data = await res.json();
+        if (!res.ok) {
+          errEl.textContent = data.error || 'Failed to set level';
+          errEl.style.display = 'block';
+          return;
+        }
+        showToast(`ACMM level set to L${level} (${name})`, 'success');
         _acmmPacks = null;
         closeACMMDialog();
       } catch (err) {

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -81,7 +81,8 @@ func BuildFrontendStatus(
 		AgentMetrics: agentMetrics,
 		Hold:         buildHold(actionable),
 		IssueToMerge: issueToMerge,
-		ACMMLevel:    detectACMMLevel(cfg),
+		ACMMLevel:      detectACMMLevel(cfg),
+		ACMMPackAgents: buildACMMPackAgents(cfg),
 	}
 	return payload
 }
@@ -851,4 +852,17 @@ func buildIssueToMerge(mc *MetricsCollector) map[string]any {
 		"updated_at":      mttr.UpdatedAt,
 		"history":         history,
 	}
+}
+
+func buildACMMPackAgents(cfg *config.Config) []string {
+	level := detectACMMLevel(cfg)
+	pack, err := config.ACMMPackByLevel(level)
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(pack.Agents))
+	for _, a := range pack.Agents {
+		names = append(names, a.Name)
+	}
+	return names
 }

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -81,7 +81,7 @@ func BuildFrontendStatus(
 		AgentMetrics: agentMetrics,
 		Hold:         buildHold(actionable),
 		IssueToMerge: issueToMerge,
-		ACMMLevel:    cfg.ACMMLevel,
+		ACMMLevel:    detectACMMLevel(cfg),
 	}
 	return payload
 }

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -81,6 +81,7 @@ func BuildFrontendStatus(
 		AgentMetrics: agentMetrics,
 		Hold:         buildHold(actionable),
 		IssueToMerge: issueToMerge,
+		ACMMLevel:    cfg.ACMMLevel,
 	}
 	return payload
 }

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -161,6 +161,7 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 			Emoji:         agentCfg.Emoji,
 			Color:         agentCfg.Color,
 			BeadRole:      agentCfg.GetBeadRole(),
+			Managed:       agentCfg.Managed,
 			Session:       name,
 			State:         string(proc.State),
 			Busy:          busy,

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -862,7 +862,9 @@ func buildACMMPackAgents(cfg *config.Config) []string {
 	}
 	names := make([]string, 0, len(pack.Agents))
 	for _, a := range pack.Agents {
-		names = append(names, a.Name)
+		if !a.Hidden {
+			names = append(names, a.Name)
+		}
 	}
 	return names
 }

--- a/v2/pkg/snapshot/state.go
+++ b/v2/pkg/snapshot/state.go
@@ -25,6 +25,7 @@ type PersistedState struct {
 	KickHistory      []GovKickEntry                   `json:"kick_history,omitempty"`
 	IssueCosts       map[string]int64                 `json:"issue_costs,omitempty"`
 	LastEval         time.Time                        `json:"last_eval,omitempty"`
+	ACMMLevel        *int                             `json:"acmm_level,omitempty"`
 }
 
 type AgentState struct {


### PR DESCRIPTION
## Summary
- Adds `POST /api/agents`, `DELETE /api/agents/{name}`, `GET /api/agents` endpoints
- CRUD-managed agents are saved as individual YAML files in `/data/agents/<name>.yaml` (persistent Docker volume)
- At startup, overlay files are merged with base `hive.yaml` — agents survive container rebuilds without touching the repo config
- Base config agents cannot be deleted via API (safety guard)
- Adding/removing an agent hot-reloads subsystems (classifier lanes, Discord identities, token detection) without restart

## How it works
1. `POST /api/agents` with `{"name": "docs-writer", "agent": {...}}` → writes `/data/agents/docs-writer.yaml`, adds to manager, re-wires subsystems
2. On next container start, `LoadWithOverrides` reads `hive.yaml` then merges all `/data/agents/*.yaml` files
3. `DELETE /api/agents/docs-writer` → removes the YAML file, stops the tmux session, removes from manager
4. `AgentConfig.Managed` field distinguishes overlay agents from base config agents in the dashboard

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -count=1` — all 16 packages pass
- [x] New tests: `TestSaveAndLoadAgentFile`, `TestRemoveAgentFile`, `TestMergeAgentOverrides`, `TestApplyAgentDefaults`, `TestLoadSkipsNonYAML`
- [ ] Deploy to 4.78 and test `curl -X POST /api/agents` to add a docs-writer agent
- [ ] Verify agent appears in dashboard with correct color/emoji/sortOrder
- [ ] Rebuild container — verify CRUD agent survives
- [ ] `curl -X DELETE /api/agents/docs-writer` — verify removal
- [ ] Verify base config agent (scanner) cannot be deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)