### PR TITLE
fix: export GH_TOKEN for SHA recheck xargs subshells

### DIFF
--- a/bin/enumerate-actionable.sh
+++ b/bin/enumerate-actionable.sh
@@ -324,6 +324,11 @@ for marker_file in "${SHA_HOLD_MARKER}"_*; do
 done > "$sha_recheck_tmp"
 
 SHA_RECHECK_PARALLELISM=8
+GH_APP_TOKEN_CACHE="/var/run/hive-metrics/gh-app-token.cache"
+if [ -f "$GH_APP_TOKEN_CACHE" ]; then
+  export GH_TOKEN
+  GH_TOKEN=$(cat "$GH_APP_TOKEN_CACHE")
+fi
 if [ -s "$sha_recheck_tmp" ]; then
   cat "$sha_recheck_tmp" | xargs -P "$SHA_RECHECK_PARALLELISM" -I {} bash -c '
     entry="$1"


### PR DESCRIPTION
## Summary
- PR #398 (May 10) parallelized the SHA re-check loop using `xargs -P` with `/usr/bin/gh` (bypassing the wrapper)
- But `/usr/bin/gh` needs `GH_TOKEN` for auth, and the xargs subshells don't inherit it
- Every GraphQL call fails silently (401 → `2>/dev/null` → `skip` fallback)
- **SHA-UNHOLD has been broken since May 10** — external contributor issues that provide a SHA in comments are never unholded

## Fix
Export `GH_TOKEN` from the app token cache before the xargs call so subshells inherit it.

## Impact
~40+ unresolved SHA hold markers will be rechecked on the next enumerate cycle. Issues where the reporter provided a SHA will have `hold` removed and `kind/bug` restored.

## Test plan
- [ ] Verify auto-deploy syncs to 4.56
- [ ] Check `grep SHA-UNHOLD /var/log/kick-agents.log` shows new entries after next kick cycle
- [ ] Verify issue #14391 on console has `hold` removed

Fixes kubestellar/console#14391