### PR TITLE
fix: add SHA hold enforcement for external contributor issues

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -530,6 +530,20 @@ func runEvalCycle(
 		_ = os.WriteFile("/data/last-actionable.json", data, 0o644)
 	}
 
+	shaResult, shaErr := ghClient.EnforceSHAHold(ctx, github.SHAHoldConfig{
+		PrimaryRepo: cfg.Project.PrimaryRepo,
+		AIAuthor:    cfg.Project.AIAuthor,
+	})
+	if shaErr != nil {
+		logger.Warn("SHA hold enforcement failed", "error", shaErr)
+	} else {
+		logger.Info("SHA hold enforcement complete",
+			"held", shaResult.Held,
+			"unheld", shaResult.Unheld,
+			"skipped", shaResult.Skipped,
+		)
+	}
+
 	agentsDue := gov.Evaluate(
 		actionable.Issues.Count,
 		actionable.PRs.Count,

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/url"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -486,3 +487,121 @@ func (c *Client) SearchOutreachPRCount(ctx context.Context, author, org, project
 }
 
 const perPage = 100
+
+var shaPattern = regexp.MustCompile(`[0-9a-f]{7,40}\b`)
+
+const shaHoldComment = "Thanks for filing this issue! To help us reproduce and investigate, " +
+	"could you please include the **commit SHA** of the build you're running?\n\n" +
+	"You can find it by running:\n```\ngit rev-parse --short HEAD\n```\n\n" +
+	"Or check the bottom of the console UI for the version string.\n\n" +
+	"_This issue will be on hold until a SHA is provided. " +
+	"Simply add a comment with the SHA and the hold will be automatically removed._"
+
+type SHAHoldConfig struct {
+	PrimaryRepo     string
+	AIAuthor        string
+	InternalAuthors []string
+}
+
+type SHAHoldResult struct {
+	Held    int `json:"held"`
+	Unheld  int `json:"unheld"`
+	Skipped int `json:"skipped"`
+}
+
+func (c *Client) EnforceSHAHold(ctx context.Context, cfg SHAHoldConfig) (*SHAHoldResult, error) {
+	result := &SHAHoldResult{}
+	owner := c.org
+	repo := cfg.PrimaryRepo
+
+	opts := &gh.IssueListByRepoOptions{
+		State:       "open",
+		Labels:      []string{"kind/bug"},
+		ListOptions: gh.ListOptions{PerPage: 100},
+	}
+
+	issues, _, err := c.client.Issues.ListByRepo(ctx, owner, repo, opts)
+	if err != nil {
+		return nil, fmt.Errorf("listing kind/bug issues for %s/%s: %w", owner, repo, err)
+	}
+
+	for _, issue := range issues {
+		if issue.IsPullRequest() {
+			continue
+		}
+
+		author := issue.GetUser().GetLogin()
+		if author == cfg.AIAuthor || isInternalAuthor(author, cfg.InternalAuthors) {
+			result.Skipped++
+			continue
+		}
+
+		labels := extractLabels(issue.Labels)
+		held := isHeld(labels)
+		hasSHA := shaPattern.MatchString(issue.GetBody())
+
+		if !hasSHA {
+			hasSHA = c.checkCommentsForSHA(ctx, owner, repo, issue.GetNumber(), author)
+		}
+
+		if hasSHA && held {
+			c.unhold(ctx, owner, repo, issue.GetNumber())
+			result.Unheld++
+			c.logger.Info("SHA-UNHOLD", "repo", repo, "issue", issue.GetNumber(), "author", author)
+		} else if !hasSHA && !held {
+			c.hold(ctx, owner, repo, issue.GetNumber())
+			result.Held++
+			c.logger.Info("SHA-HOLD", "repo", repo, "issue", issue.GetNumber(), "author", author)
+		} else {
+			result.Skipped++
+		}
+	}
+
+	return result, nil
+}
+
+func (c *Client) checkCommentsForSHA(ctx context.Context, owner, repo string, number int, reporter string) bool {
+	opts := &gh.IssueListCommentsOptions{
+		ListOptions: gh.ListOptions{PerPage: 100},
+	}
+	comments, _, err := c.client.Issues.ListComments(ctx, owner, repo, number, opts)
+	if err != nil {
+		c.logger.Warn("failed to list comments for SHA check", "repo", repo, "issue", number, "error", err)
+		return false
+	}
+	for _, comment := range comments {
+		if comment.GetUser().GetLogin() == reporter && shaPattern.MatchString(comment.GetBody()) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Client) hold(ctx context.Context, owner, repo string, number int) {
+	_, _, err := c.client.Issues.AddLabelsToIssue(ctx, owner, repo, number, []string{"hold"})
+	if err != nil {
+		c.logger.Warn("failed to add hold label", "repo", repo, "issue", number, "error", err)
+	}
+
+	comment := &gh.IssueComment{Body: gh.Ptr(shaHoldComment)}
+	_, _, err = c.client.Issues.CreateComment(ctx, owner, repo, number, comment)
+	if err != nil {
+		c.logger.Warn("failed to post SHA hold comment", "repo", repo, "issue", number, "error", err)
+	}
+}
+
+func (c *Client) unhold(ctx context.Context, owner, repo string, number int) {
+	_, err := c.client.Issues.RemoveLabelForIssue(ctx, owner, repo, number, "hold")
+	if err != nil {
+		c.logger.Warn("failed to remove hold label", "repo", repo, "issue", number, "error", err)
+	}
+}
+
+func isInternalAuthor(author string, internalAuthors []string) bool {
+	for _, ia := range internalAuthors {
+		if strings.EqualFold(author, ia) {
+			return true
+		}
+	}
+	return false
+}

--- a/v2/pkg/github/client_test.go
+++ b/v2/pkg/github/client_test.go
@@ -719,6 +719,288 @@ func TestEnumerateActionable_NoSLAViolationsWhenAllFresh(t *testing.T) {
 	}
 }
 
+// --------------------------------------------------------------------------
+// SHA Hold Enforcement Tests
+// --------------------------------------------------------------------------
+
+type wireComment struct {
+	User wireUser `json:"user"`
+	Body string   `json:"body"`
+}
+
+func buildSHAHoldMux(t *testing.T, org, repo string, issues []wireIssue, commentsByIssue map[int][]wireComment) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(mustMarshal(t, issues))
+		}
+	})
+
+	for num, comments := range commentsByIssue {
+		n := num
+		c := comments
+		mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/%d/comments", org, repo, n), func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "GET" {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(mustMarshal(t, c))
+				return
+			}
+			if r.Method == "POST" {
+				w.WriteHeader(http.StatusCreated)
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`{"id":1}`))
+			}
+		})
+	}
+
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == "POST" {
+			w.WriteHeader(http.StatusCreated)
+			w.Write([]byte(`{"id":1}`))
+			return
+		}
+		w.Write([]byte(`{}`))
+	})
+
+	return mux
+}
+
+func TestEnforceSHAHold_UnholdWhenSHAInComment(t *testing.T) {
+	org, repo := "testorg", "console"
+	issues := []wireIssue{
+		{
+			Number:    14391,
+			Title:     "Bug: something broken",
+			User:      wireUser{"external-user"},
+			Labels:    []wireLabel{{Name: "kind/bug"}, {Name: "hold"}},
+			CreatedAt: hoursAgo(2),
+		},
+	}
+	comments := map[int][]wireComment{
+		14391: {
+			{User: wireUser{"external-user"}, Body: "Here is the SHA: abc1234def"},
+		},
+	}
+
+	var removedLabel string
+	mux := buildSHAHoldMux(t, org, repo, issues, comments)
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/14391/labels/hold", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "DELETE" {
+			removedLabel = "hold"
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`[]`))
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	result, err := c.EnforceSHAHold(context.Background(), SHAHoldConfig{
+		PrimaryRepo: repo,
+		AIAuthor:    "hive-bot",
+	})
+	if err != nil {
+		t.Fatalf("EnforceSHAHold: %v", err)
+	}
+
+	if result.Unheld != 1 {
+		t.Errorf("Unheld = %d, want 1", result.Unheld)
+	}
+	if result.Held != 0 {
+		t.Errorf("Held = %d, want 0", result.Held)
+	}
+	if removedLabel != "hold" {
+		t.Errorf("hold label was not removed (DELETE not called)")
+	}
+}
+
+func TestEnforceSHAHold_HoldWhenNoSHA(t *testing.T) {
+	org, repo := "testorg", "console"
+	issues := []wireIssue{
+		{
+			Number:    100,
+			Title:     "Bug: crash on startup",
+			User:      wireUser{"external-user"},
+			Labels:    []wireLabel{{Name: "kind/bug"}},
+			CreatedAt: hoursAgo(1),
+		},
+	}
+
+	var addedLabels []string
+	var commentPosted bool
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mustMarshal(t, issues))
+	})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/100/labels", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			addedLabels = append(addedLabels, "hold")
+			w.WriteHeader(http.StatusOK)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`[{"name":"hold"}]`))
+		}
+	})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues/100/comments", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			commentPosted = true
+			w.WriteHeader(http.StatusCreated)
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"id":1}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[]`))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	result, err := c.EnforceSHAHold(context.Background(), SHAHoldConfig{
+		PrimaryRepo: repo,
+		AIAuthor:    "hive-bot",
+	})
+	if err != nil {
+		t.Fatalf("EnforceSHAHold: %v", err)
+	}
+
+	if result.Held != 1 {
+		t.Errorf("Held = %d, want 1", result.Held)
+	}
+	if len(addedLabels) == 0 {
+		t.Error("hold label was not added")
+	}
+	if !commentPosted {
+		t.Error("SHA hold comment was not posted")
+	}
+}
+
+func TestEnforceSHAHold_SkipsInternalAuthors(t *testing.T) {
+	org, repo := "testorg", "console"
+	issues := []wireIssue{
+		{
+			Number:    200,
+			Title:     "Bug from AI",
+			User:      wireUser{"hive-bot"},
+			Labels:    []wireLabel{{Name: "kind/bug"}},
+			CreatedAt: hoursAgo(1),
+		},
+		{
+			Number:    201,
+			Title:     "Bug from maintainer",
+			User:      wireUser{"clubanderson"},
+			Labels:    []wireLabel{{Name: "kind/bug"}},
+			CreatedAt: hoursAgo(1),
+		},
+	}
+
+	mux := buildSHAHoldMux(t, org, repo, issues, nil)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	result, err := c.EnforceSHAHold(context.Background(), SHAHoldConfig{
+		PrimaryRepo:     repo,
+		AIAuthor:        "hive-bot",
+		InternalAuthors: []string{"clubanderson"},
+	})
+	if err != nil {
+		t.Fatalf("EnforceSHAHold: %v", err)
+	}
+
+	if result.Skipped != 2 {
+		t.Errorf("Skipped = %d, want 2 (AI + internal)", result.Skipped)
+	}
+	if result.Held != 0 {
+		t.Errorf("Held = %d, want 0", result.Held)
+	}
+}
+
+func TestEnforceSHAHold_AlreadyHeldNoSHA_Skips(t *testing.T) {
+	org, repo := "testorg", "console"
+	issues := []wireIssue{
+		{
+			Number:    300,
+			Title:     "Bug already held, no SHA yet",
+			User:      wireUser{"external-user"},
+			Labels:    []wireLabel{{Name: "kind/bug"}, {Name: "hold"}},
+			CreatedAt: hoursAgo(1),
+		},
+	}
+	comments := map[int][]wireComment{
+		300: {{User: wireUser{"external-user"}, Body: "still working on getting the SHA"}},
+	}
+
+	mux := buildSHAHoldMux(t, org, repo, issues, comments)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	result, err := c.EnforceSHAHold(context.Background(), SHAHoldConfig{
+		PrimaryRepo: repo,
+		AIAuthor:    "hive-bot",
+	})
+	if err != nil {
+		t.Fatalf("EnforceSHAHold: %v", err)
+	}
+	if result.Skipped != 1 {
+		t.Errorf("Skipped = %d, want 1 (already held, no SHA → no-op)", result.Skipped)
+	}
+	if result.Held != 0 {
+		t.Errorf("Held = %d, want 0", result.Held)
+	}
+	if result.Unheld != 0 {
+		t.Errorf("Unheld = %d, want 0", result.Unheld)
+	}
+}
+
+func TestSHAPattern(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"abc1234", true},
+		{"abc1234def5678901234567890123456789012", true},
+		{"Running on commit abc1234 on main", true},
+		{"SHA: deadbeef", true},
+		{"no sha here", false},
+		{"ABCDEF1", false},
+		{"12345", false},
+		{"1234567", true},
+	}
+	for _, tt := range tests {
+		got := shaPattern.MatchString(tt.input)
+		if got != tt.want {
+			t.Errorf("shaPattern.MatchString(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestIsInternalAuthor(t *testing.T) {
+	internal := []string{"alice", "Bob"}
+	if !isInternalAuthor("alice", internal) {
+		t.Error("alice should be internal")
+	}
+	if !isInternalAuthor("ALICE", internal) {
+		t.Error("ALICE should match alice (case-insensitive)")
+	}
+	if !isInternalAuthor("bob", internal) {
+		t.Error("bob should match Bob")
+	}
+	if isInternalAuthor("charlie", internal) {
+		t.Error("charlie should not be internal")
+	}
+	if isInternalAuthor("alice", nil) {
+		t.Error("nil list should not match")
+	}
+}
+
 func init() {
 	_ = rfc3339Ago // suppress unused-constant warning
 }


### PR DESCRIPTION
## Summary
- Adds `EnforceSHAHold()` method to the v2 Go GitHub client that checks `kind/bug` issues from external contributors for commit SHAs in body or comments
- When an external user files a `kind/bug` issue without a SHA, the issue gets a `hold` label and a comment asking for the SHA
- When the reporter later adds a comment containing a SHA (`[0-9a-f]{7,40}`), the hold is automatically removed
- Called each eval cycle after `EnumerateActionable()` in `runEvalCycle`
- Ports the SHA hold/unhold logic from main branch `enumerate-actionable.sh` to the v2 binary

Fixes kubestellar/console#14391

## Test plan
- [x] 6 new unit tests covering: unhold-when-SHA-in-comment, hold-when-no-SHA, skip-internal-authors, already-held-no-SHA no-op, SHA regex pattern, isInternalAuthor helper
- [x] `go test ./pkg/github/` — all pass
- [x] `go build ./cmd/hive/` — clean build