### PR TITLE
fix: SHA recheck xargs placeholder clash with Python dict literals

### DIFF
--- a/bin/enumerate-actionable.sh
+++ b/bin/enumerate-actionable.sh
@@ -330,7 +330,7 @@ if [ -f "$GH_APP_TOKEN_CACHE" ]; then
   GH_TOKEN=$(cat "$GH_APP_TOKEN_CACHE")
 fi
 if [ -s "$sha_recheck_tmp" ]; then
-  cat "$sha_recheck_tmp" | xargs -P "$SHA_RECHECK_PARALLELISM" -I {} bash -c '
+  cat "$sha_recheck_tmp" | xargs -P "$SHA_RECHECK_PARALLELISM" -I ENTRY bash -c '
     entry="$1"
     repo="${entry%%:*}"
     rest="${entry#*:}"
@@ -368,7 +368,7 @@ SHA_RE = re.compile(r\"[0-9a-f]{7,40}\\b\")
 print(\"has_sha\" if SHA_RE.search(reporter_text) else \"no_sha\")
 " 2>/dev/null || echo "skip")
     echo "${repo}:${num}:${marker_file}:${state}"
-  ' _ {} >> "$sha_recheck_results"
+  ' _ ENTRY >> "$sha_recheck_results"
 fi
 
 while IFS=: read -r repo num marker_file state; do


### PR DESCRIPTION
## Summary
- `xargs -I {}` replaces ALL `{}` occurrences in the command string, including inside Python dict literals like `d.get("data",{})`. This caused every SHA recheck to fail with a Python SyntaxError, silently producing `skip` for all 53 unresolved marker files.
- Fix: switch from `-I {}` to `-I ENTRY` so Python `{}` syntax is preserved.

## Root cause
PR #523 added the SHA recheck loop using `xargs -P 8 -I {} bash -c '...' _ {}`. The bash -c string contains an inline Python script with `d.get("data",{}).get("repository",{}).get("issue")`. The `-I {}` flag caused xargs to substitute the input line into every `{}`, turning valid Python into:
```
d.get("data",kubestellar/console:11283:...).get("repository",kubestellar/console:11283:...)
```
This produced a `SyntaxError`, caught by `|| echo "skip"`, so every issue was silently skipped.

## Test plan
- [x] Verified broken: `xargs -I {} ... d.get("data",{})` → SyntaxError → `skip`
- [x] Verified fixed: `xargs -I ENTRY ... d.get("data",{})` → `closed` (correct)
- [x] Tested with all 53 unresolved markers — first entry returns correct state

🤖 Generated with [Claude Code](https://claude.com/claude-code)