### PR TITLE
Fix ACMM Paper link and add blog links to sidebar

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1503,11 +1503,14 @@
       <li><strong style="color:#c9d1d9;">Supervisor</strong> &mdash; monitors all agents, detects stalls, reports status</li>
     </ul>
     <ul class="sidebar-links">
-      <li><a href="https://arxiv.org/abs/2504.07459" target="_blank" rel="noopener">&#128196; ACMM Paper</a></li>
+      <li><a href="https://arxiv.org/abs/2604.09388" target="_blank" rel="noopener">&#128196; ACMM Paper</a></li>
       <li><a href="https://console.kubestellar.io" target="_blank" rel="noopener">&#128421; Console Live Demo</a></li>
       <li><a href="https://github.com/kubestellar/hive" target="_blank" rel="noopener">&#128230; Source Code</a></li>
       <li><a href="https://kubestellar.io/en/acmm-leaderboard" target="_blank" rel="noopener">&#128202; ACMM Leaderboard</a></li>
       <li><a href="https://kubestellar.io/en/leaderboard" target="_blank" rel="noopener">&#127942; Contributor Leaderboard</a></li>
+      <li><a href="https://kubestellar.medium.com/plaque-the-silent-killer-of-ai-agent-reliability-f5c5318c4e9c" target="_blank" rel="noopener">&#128221; Blog: Plaque — Silent Killer</a></li>
+      <li><a href="https://kubestellar.medium.com/intentional-amnesia-why-i-wipe-my-ai-agents-memories-every-15-minutes-1c27e9dcbf0a" target="_blank" rel="noopener">&#128221; Blog: Intentional Amnesia</a></li>
+      <li><a href="https://medium.com/p/b9381a7e9773" target="_blank" rel="noopener">&#128221; Blog: ACMM Framework</a></li>
     </ul>
   </aside>
 


### PR DESCRIPTION
## Summary
- Update ACMM Paper arxiv link from `2504.07459` to `2604.09388`
- Add three blog post links to sidebar: Plaque — Silent Killer, Intentional Amnesia, ACMM Framework

## Test plan
- [ ] Verify ACMM Paper link opens correct arxiv page
- [ ] Verify all three blog links open correctly
- [ ] Check sidebar renders properly with additional links