### PR TITLE
feat: rewrite setup scripts for Docker-based deployment

### DIFF
--- a/bin/hive-prereq-check.sh
+++ b/bin/hive-prereq-check.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
-# hive-prereq-check.sh — Validate that a host has all prerequisites for Hive v2.
+# hive-prereq-check.sh — Validate prerequisites for Hive v2 (Docker-based deployment).
 #
 # Usage: ./hive-prereq-check.sh [--fix]
-#   --fix   Attempt to install missing prerequisites automatically
+#   --fix   Attempt to install/fix missing prerequisites automatically
+#
+# This checks the HOST (LXC container), not the Docker container.
+# The Docker image contains its own toolchain (Go, Node, Claude, Copilot, tmux, etc.)
 #
 # Exit codes:
 #   0  All prerequisites met
@@ -32,7 +35,10 @@ try_fix() {
   return 1
 }
 
-# ── OS ──────────────────────────────────────────────────────────────
+HIVE_DIR="${HIVE_DIR:-/opt/hive}"
+ENV_FILE="${HIVE_DIR}/.env"
+
+# ── OS & Hardware ──────────────────────────────────────────────────
 echo "OS & Environment"
 
 if [[ -f /etc/os-release ]]; then
@@ -54,250 +60,171 @@ else
 fi
 
 MEM_MB=$(free -m 2>/dev/null | awk '/^Mem:/ {print $2}' || echo 0)
-if [[ "$MEM_MB" -ge 8000 ]]; then
-  pass "RAM: ${MEM_MB}MB (minimum 8GB)"
-elif [[ "$MEM_MB" -ge 4000 ]]; then
-  warn "RAM: ${MEM_MB}MB (8GB+ recommended, 4GB minimum)"
+if [[ "$MEM_MB" -ge 4000 ]]; then
+  pass "RAM: ${MEM_MB}MB (minimum 4GB)"
 else
   fail "RAM: ${MEM_MB}MB (need at least 4GB)"
 fi
 
 DISK_AVAIL_KB=$(df / 2>/dev/null | awk 'NR==2 {print $4}' || echo 0)
 DISK_AVAIL_GB=$((DISK_AVAIL_KB / 1048576))
-if [[ "$DISK_AVAIL_GB" -ge 20 ]]; then
-  pass "Disk available: ${DISK_AVAIL_GB}GB (minimum 20GB)"
-elif [[ "$DISK_AVAIL_GB" -ge 10 ]]; then
-  warn "Disk available: ${DISK_AVAIL_GB}GB (20GB+ recommended)"
+if [[ "$DISK_AVAIL_GB" -ge 10 ]]; then
+  pass "Disk available: ${DISK_AVAIL_GB}GB (minimum 10GB)"
 else
   fail "Disk available: ${DISK_AVAIL_GB}GB (need at least 10GB)"
 fi
 
-# ── Users ───────────────────────────────────────────────────────────
+# ── LXC / AppArmor ────────────────────────────────────────────────
 echo ""
-echo "Users"
+echo "LXC Configuration"
 
-if id dev &>/dev/null; then
-  pass "User 'dev' exists"
+APPARMOR=$(cat /proc/self/attr/apparmor/current 2>/dev/null || cat /proc/self/attr/current 2>/dev/null || echo "unknown")
+if [[ "$APPARMOR" == "unconfined" ]]; then
+  pass "AppArmor: unconfined (required for Docker-in-LXC)"
 else
-  fail "User 'dev' does not exist"
-  try_fix "useradd -m -s /bin/bash dev" && pass "User 'dev' created"
+  fail "AppArmor: ${APPARMOR} — must be 'unconfined'"
+  echo "    Fix on Proxmox host: add 'lxc.apparmor.profile: unconfined' and 'lxc.cap.drop:' to /etc/pve/lxc/<CTID>.conf, then restart LXC"
 fi
 
-# ── Core Tools ──────────────────────────────────────────────────────
+# ── Docker ─────────────────────────────────────────────────────────
 echo ""
-echo "Core Tools"
-
-check_cmd() {
-  local name="$1" cmd="${2:-$1}" min_ver="${3:-}" install_cmd="${4:-}"
-  if command -v "$cmd" &>/dev/null; then
-    local ver
-    ver=$("$cmd" --version 2>/dev/null | head -1 || echo "installed")
-    pass "$name: $ver"
-  else
-    fail "$name: not found"
-    [[ -n "$install_cmd" ]] && try_fix "$install_cmd" && pass "$name: installed"
-  fi
-}
-
-check_cmd "git" "git" "" "apt-get install -y git"
-check_cmd "tmux" "tmux" "" "apt-get install -y tmux"
-check_cmd "jq" "jq" "" "apt-get install -y jq"
-check_cmd "curl" "curl" "" "apt-get install -y curl"
-check_cmd "gh" "gh" "" "apt-get install -y gh"
-check_cmd "ripgrep" "rg" "" "apt-get install -y ripgrep"
-check_cmd "htop" "htop" "" "apt-get install -y htop"
-check_cmd "sqlite3" "sqlite3" "" "apt-get install -y sqlite3"
-check_cmd "bc" "bc" "" "apt-get install -y bc"
-
-# ── Node.js ─────────────────────────────────────────────────────────
-echo ""
-echo "Node.js"
-
-if command -v node &>/dev/null; then
-  NODE_VER=$(node --version 2>/dev/null)
-  NODE_MAJOR="${NODE_VER#v}"
-  NODE_MAJOR="${NODE_MAJOR%%.*}"
-  if [[ "$NODE_MAJOR" -ge 22 ]]; then
-    pass "Node.js: $NODE_VER"
-  else
-    warn "Node.js: $NODE_VER (v22+ recommended)"
-  fi
-else
-  fail "Node.js: not installed"
-  try_fix "curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && apt-get install -y nodejs" \
-    && pass "Node.js: installed"
-fi
-
-if command -v npm &>/dev/null; then
-  pass "npm: $(npm --version 2>/dev/null)"
-else
-  fail "npm: not found (should come with Node.js)"
-fi
-
-# ── Claude Code CLI ─────────────────────────────────────────────────
-echo ""
-echo "AI Agent CLIs"
-
-if command -v claude &>/dev/null; then
-  pass "Claude Code: $(claude --version 2>/dev/null | head -1)"
-else
-  fail "Claude Code: not installed"
-  try_fix "npm install -g @anthropic-ai/claude-code" && pass "Claude Code: installed"
-fi
-
-if command -v copilot &>/dev/null; then
-  pass "GitHub Copilot CLI: $(copilot --version 2>/dev/null | head -1)"
-else
-  warn "GitHub Copilot CLI: not installed (optional failover backend)"
-fi
-
-# ── Python ──────────────────────────────────────────────────────────
-echo ""
-echo "Python"
-
-if command -v python3 &>/dev/null; then
-  pass "Python3: $(python3 --version 2>/dev/null)"
-else
-  fail "Python3: not installed"
-  try_fix "apt-get install -y python3 python3-venv" && pass "Python3: installed"
-fi
-
-# ── Go ──────────────────────────────────────────────────────────────
-echo ""
-echo "Go (optional — needed for Go-based projects)"
-
-if command -v go &>/dev/null; then
-  pass "Go: $(go version 2>/dev/null)"
-else
-  warn "Go: not installed (install if targeting Go projects)"
-fi
-
-# ── Docker ──────────────────────────────────────────────────────────
-echo ""
-echo "Docker (optional)"
+echo "Docker"
 
 if command -v docker &>/dev/null; then
-  pass "Docker: $(docker --version 2>/dev/null)"
+  pass "Docker: $(docker --version 2>/dev/null | head -1)"
 else
-  warn "Docker: not installed (optional, for container-based workflows)"
+  fail "Docker: not installed"
+  try_fix "apt-get update -qq && apt-get install -y -qq ca-certificates curl gnupg && install -m 0755 -d /etc/apt/keyrings && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc && chmod a+r /etc/apt/keyrings/docker.asc && echo \"deb [arch=\$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \$(. /etc/os-release && echo \\\$VERSION_CODENAME) stable\" > /etc/apt/sources.list.d/docker.list && apt-get update -qq && apt-get install -y -qq docker-ce docker-ce-cli containerd.io docker-compose-plugin" \
+    && pass "Docker: installed"
 fi
 
-# ── Build Tools ─────────────────────────────────────────────────────
+if docker compose version &>/dev/null 2>&1; then
+  pass "Docker Compose: $(docker compose version --short 2>/dev/null)"
+else
+  fail "Docker Compose plugin: not installed"
+  try_fix "apt-get install -y -qq docker-compose-plugin" && pass "Docker Compose: installed"
+fi
+
+if docker info &>/dev/null 2>&1; then
+  pass "Docker daemon: running"
+else
+  fail "Docker daemon: not running"
+  try_fix "systemctl start docker" && pass "Docker daemon: started"
+fi
+
+# Smoke test: can Docker actually run containers?
+if docker run --rm alpine echo ok &>/dev/null 2>&1; then
+  pass "Docker run: works (AppArmor/nesting OK)"
+else
+  fail "Docker run: FAILED — likely AppArmor issue in LXC config"
+fi
+
+# ── Host Tools (minimal — most tooling is inside the container) ────
 echo ""
-echo "Build Tools"
+echo "Host Tools"
 
-check_cmd "make" "make" "" "apt-get install -y make"
-check_cmd "gcc" "gcc" "" "apt-get install -y build-essential"
-
-# ── Rust (needed for ai-native-storage-certus) ──────────────────────
-echo ""
-echo "Rust (needed for Rust-based projects)"
-
-if command -v rustc &>/dev/null; then
-  pass "Rust: $(rustc --version 2>/dev/null)"
-else
-  warn "Rust: not installed (needed for Rust projects like certus)"
-fi
-
-if command -v cargo &>/dev/null; then
-  pass "Cargo: $(cargo --version 2>/dev/null)"
-else
-  warn "Cargo: not installed"
-fi
-
-# ── Hive Infrastructure ────────────────────────────────────────────
-echo ""
-echo "Hive Infrastructure"
-
-if [[ -d /etc/hive ]]; then
-  pass "/etc/hive directory exists"
-else
-  fail "/etc/hive directory does not exist"
-  try_fix "mkdir -p /etc/hive" && pass "/etc/hive created"
-fi
-
-if [[ -d /var/run/hive ]]; then
-  pass "/var/run/hive directory exists"
-else
-  fail "/var/run/hive directory does not exist"
-  try_fix "mkdir -p /var/run/hive && chown dev:dev /var/run/hive" && pass "/var/run/hive created"
-fi
-
-if [[ -d /var/run/hive-metrics ]]; then
-  pass "/var/run/hive-metrics directory exists"
-else
-  fail "/var/run/hive-metrics directory does not exist"
-  try_fix "mkdir -p /var/run/hive-metrics && chown dev:dev /var/run/hive-metrics" \
-    && pass "/var/run/hive-metrics created"
-fi
-
-for script in supervisor.sh agent-launch.sh hive-config.sh kick-agents.sh; do
-  if [[ -x "/usr/local/bin/$script" ]]; then
-    pass "$script installed"
+for cmd in git curl jq; do
+  if command -v "$cmd" &>/dev/null; then
+    pass "$cmd: installed"
   else
-    fail "$script not found in /usr/local/bin/"
+    fail "$cmd: not found"
+    try_fix "apt-get install -y -qq $cmd" && pass "$cmd: installed"
   fi
 done
 
-if [[ -f /usr/local/etc/hive/backends.conf ]]; then
-  pass "backends.conf exists"
+# ── Hive Repo ──────────────────────────────────────────────────────
+echo ""
+echo "Hive Repository"
+
+if [[ -d "${HIVE_DIR}/.git" ]]; then
+  HIVE_BRANCH=$(cd "$HIVE_DIR" && git branch --show-current 2>/dev/null || echo "unknown")
+  pass "Hive repo: ${HIVE_DIR} (branch: ${HIVE_BRANCH})"
 else
-  fail "backends.conf not found at /usr/local/etc/hive/backends.conf"
+  fail "Hive repo: not found at ${HIVE_DIR}"
+  try_fix "git clone --branch v2 --single-branch https://github.com/kubestellar/hive.git ${HIVE_DIR}" \
+    && pass "Hive repo: cloned"
 fi
 
-# ── Systemd Units ───────────────────────────────────────────────────
+# ── Docker Image ───────────────────────────────────────────────────
 echo ""
-echo "Systemd Units"
+echo "Docker Image"
 
-for unit in hive.service hive@.service; do
-  if [[ -f "/etc/systemd/system/$unit" ]]; then
-    pass "$unit installed"
+if docker images --format '{{.Repository}}:{{.Tag}}' 2>/dev/null | grep -qE '(v2-hive|deploy-hive)'; then
+  IMG=$(docker images --format '{{.Repository}}:{{.Tag}} ({{.Size}})' 2>/dev/null | grep -E '(v2-hive|deploy-hive)' | head -1)
+  pass "Hive image: ${IMG}"
+else
+  fail "Hive image: not built"
+  if [[ -d "${HIVE_DIR}" ]]; then
+    try_fix "cd ${HIVE_DIR} && docker compose -f v2/docker-compose.yaml build" \
+      && pass "Hive image: built"
+  fi
+fi
+
+# ── Environment File ──────────────────────────────────────────────
+echo ""
+echo "Configuration"
+
+if [[ -f "$ENV_FILE" ]]; then
+  pass ".env file: ${ENV_FILE}"
+  GH_TOKEN=$(grep -E '^HIVE_GITHUB_TOKEN=' "$ENV_FILE" 2>/dev/null | cut -d= -f2- || true)
+  if [[ -n "$GH_TOKEN" ]]; then
+    pass "HIVE_GITHUB_TOKEN: set (${#GH_TOKEN} chars)"
   else
-    fail "$unit not found"
+    fail "HIVE_GITHUB_TOKEN: empty (required — Go binary refuses to start without it)"
+  fi
+  DASH_TOKEN=$(grep -E '^HIVE_DASHBOARD_TOKEN=' "$ENV_FILE" 2>/dev/null | cut -d= -f2- || true)
+  if [[ -n "$DASH_TOKEN" ]]; then
+    pass "HIVE_DASHBOARD_TOKEN: set"
+  else
+    warn "HIVE_DASHBOARD_TOKEN: empty (dashboard API unprotected)"
+  fi
+else
+  fail ".env file: not found at ${ENV_FILE}"
+fi
+
+# Check for a hive.yaml project config
+HIVE_YAML_COUNT=0
+for yaml in "${HIVE_DIR}"/v2/deploy/hive*.yaml; do
+  if [[ -f "$yaml" ]] && grep -q "^project:" "$yaml" 2>/dev/null; then
+    pass "Hive config: $(basename "$yaml")"
+    HIVE_YAML_COUNT=$((HIVE_YAML_COUNT + 1))
   fi
 done
+if [[ "$HIVE_YAML_COUNT" -eq 0 ]]; then
+  fail "No hive.yaml config found in ${HIVE_DIR}/v2/deploy/"
+fi
 
-# ── Git Configuration ──────────────────────────────────────────────
+# ── Running Container ─────────────────────────────────────────────
 echo ""
-echo "Git Configuration"
+echo "Running State"
 
-GIT_NAME=$(sudo -u dev git config --global user.name 2>/dev/null || echo "")
-GIT_EMAIL=$(sudo -u dev git config --global user.email 2>/dev/null || echo "")
-if [[ -n "$GIT_NAME" ]]; then
-  pass "git user.name: $GIT_NAME"
+HIVE_CONTAINER=$(docker ps --filter "name=hive" --format '{{.Names}} (up {{.RunningFor}})' 2>/dev/null | head -1)
+if [[ -n "$HIVE_CONTAINER" ]]; then
+  pass "Container: ${HIVE_CONTAINER}"
+  if curl -sf http://localhost:3001/api/health &>/dev/null; then
+    pass "Dashboard: healthy (port 3001)"
+  else
+    warn "Dashboard: not responding on port 3001 (may still be starting)"
+  fi
+  if curl -sf http://localhost:7681 &>/dev/null; then
+    pass "ttyd terminal: available (port 7681)"
+  else
+    warn "ttyd terminal: not responding on port 7681"
+  fi
 else
-  fail "git user.name not set for user 'dev'"
-fi
-if [[ -n "$GIT_EMAIL" ]]; then
-  pass "git user.email: $GIT_EMAIL"
-else
-  fail "git user.email not set for user 'dev'"
+  warn "Container: not running"
 fi
 
-# ── GitHub Auth ─────────────────────────────────────────────────────
+# ── SSH ────────────────────────────────────────────────────────────
 echo ""
-echo "GitHub Authentication"
+echo "SSH Access"
 
-if sudo -u dev gh auth status &>/dev/null 2>&1; then
-  pass "gh CLI authenticated"
+if grep -q "^PermitRootLogin yes" /etc/ssh/sshd_config 2>/dev/null; then
+  pass "SSH root login: enabled"
 else
-  warn "gh CLI not authenticated (run: gh auth login)"
-fi
-
-if [[ -f /etc/hive/gh-app-key.pem ]]; then
-  pass "GitHub App key exists"
-else
-  warn "GitHub App key not found at /etc/hive/gh-app-key.pem (needed for App-based auth)"
-fi
-
-# ── Notifications ───────────────────────────────────────────────────
-echo ""
-echo "Notifications (optional)"
-
-if command -v ntfy &>/dev/null || [[ -f /usr/local/bin/ntfy ]]; then
-  pass "ntfy: installed"
-else
-  warn "ntfy: not installed (optional push notifications)"
+  warn "SSH root login: disabled (enable for remote management)"
+  try_fix 'sed -i "s/^#*PermitRootLogin.*/PermitRootLogin yes/" /etc/ssh/sshd_config && sed -i "s/^#*PasswordAuthentication.*/PasswordAuthentication yes/" /etc/ssh/sshd_config && systemctl restart sshd' \
+    && pass "SSH root login: enabled"
 fi
 
 # ── Summary ─────────────────────────────────────────────────────────
@@ -313,7 +240,7 @@ if [[ "$FAIL" -eq 0 ]]; then
 else
   echo "  Status: NOT READY — fix $FAIL issue(s) above"
   if ! $FIX_MODE; then
-    echo "  Tip: re-run with --fix to auto-install missing packages"
+    echo "  Tip: re-run with --fix to auto-install missing items"
   fi
   exit 1
 fi

--- a/bin/hive-setup.sh
+++ b/bin/hive-setup.sh
@@ -1,50 +1,72 @@
 #!/bin/bash
-# hive-setup.sh — Bootstrap a fresh Ubuntu 24.04 LXC into a Hive v2 instance.
+# hive-setup.sh — Bootstrap a fresh Ubuntu 24.04 LXC into a Hive v2 instance (Docker-based).
+#
+# This is the all-in-one setup script. It does everything bootstrap-lxc.sh does,
+# plus generates a project-specific hive.yaml and .env file.
 #
 # Usage:
-#   curl -fsSL <raw-url>/hive-setup.sh | bash
+#   curl -fsSL <raw-url>/hive-setup.sh | bash -s -- --repo org/repo
 #   # or
-#   ./hive-setup.sh [--level 2] [--repo org/repo] [--agents "scanner reviewer"]
+#   ./hive-setup.sh [--level 2] [--repo org/repo] [--gh-token ghp_xxx]
 #
 # Options:
-#   --level N          ACMM maturity level (default: 2 = analysis only, no PRs)
-#   --repo org/repo    Target repository (default: interactive prompt)
-#   --agents "list"    Space-separated agent list (default: per-level defaults)
-#   --git-name "name"  Git user.name for the dev user
-#   --git-email "email" Git user.email for the dev user
-#   --skip-auth        Skip interactive gh auth login (do it later)
-#   --dry-run          Print what would be done without executing
+#   --level N           ACMM maturity level (default: 2 = analysis only, no PRs)
+#   --repo org/repo     Target repository (required)
+#   --agents "list"     Space-separated agent list (default: per-level defaults)
+#   --gh-token TOKEN    GitHub PAT for API access (required)
+#   --dashboard-token T Dashboard auth token (default: auto-generated)
+#   --anthropic-key KEY Anthropic API key for Claude Code (optional)
+#   --compose FILE      Compose file name (default: docker-compose.yaml)
+#   --skip-build        Skip Docker image build (use pre-built image)
+#   --dry-run           Print what would be done without executing
 #
 # ACMM Levels and default agents:
 #   L1: (local tooling only — no hive needed)
 #   L2: supervisor scanner reviewer (analysis + issue filing, NO PRs)
 #   L3: supervisor scanner reviewer architect (opens PRs)
 #   L4: supervisor scanner reviewer architect outreach sec-check (full autonomy)
-#   L5+: supervisor scanner reviewer architect outreach sec-check strategist analyst guardian
+#   L5+: supervisor scanner reviewer architect outreach sec-check strategist tester
 
 set -euo pipefail
 
 ACMM_LEVEL=2
 TARGET_REPO=""
 AGENTS=""
-GIT_NAME=""
-GIT_EMAIL=""
-SKIP_AUTH=false
+GH_TOKEN=""
+DASHBOARD_TOKEN=""
+ANTHROPIC_KEY=""
+COMPOSE_FILE="docker-compose.yaml"
+SKIP_BUILD=false
 DRY_RUN=false
 HIVE_REPO_URL="https://github.com/kubestellar/hive.git"
+HIVE_DIR=/opt/hive
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --level)     ACMM_LEVEL="$2"; shift 2 ;;
-    --repo)      TARGET_REPO="$2"; shift 2 ;;
-    --agents)    AGENTS="$2"; shift 2 ;;
-    --git-name)  GIT_NAME="$2"; shift 2 ;;
-    --git-email) GIT_EMAIL="$2"; shift 2 ;;
-    --skip-auth) SKIP_AUTH=true; shift ;;
-    --dry-run)   DRY_RUN=true; shift ;;
-    *)           echo "Unknown option: $1"; exit 1 ;;
+    --level)           ACMM_LEVEL="$2"; shift 2 ;;
+    --repo)            TARGET_REPO="$2"; shift 2 ;;
+    --agents)          AGENTS="$2"; shift 2 ;;
+    --gh-token)        GH_TOKEN="$2"; shift 2 ;;
+    --dashboard-token) DASHBOARD_TOKEN="$2"; shift 2 ;;
+    --anthropic-key)   ANTHROPIC_KEY="$2"; shift 2 ;;
+    --compose)         COMPOSE_FILE="$2"; shift 2 ;;
+    --skip-build)      SKIP_BUILD=true; shift ;;
+    --dry-run)         DRY_RUN=true; shift ;;
+    *)                 echo "Unknown option: $1"; exit 1 ;;
   esac
 done
+
+# Validate required args
+if [[ -z "$TARGET_REPO" ]]; then
+  echo "ERROR: --repo org/repo is required"
+  echo "Usage: $0 --repo org/repo --gh-token ghp_xxx [--level 2]"
+  exit 1
+fi
+
+if [[ -z "$GH_TOKEN" ]]; then
+  echo "ERROR: --gh-token is required (GitHub PAT with repo read access)"
+  exit 1
+fi
 
 # Default agents by ACMM level
 if [[ -z "$AGENTS" ]]; then
@@ -53,9 +75,17 @@ if [[ -z "$AGENTS" ]]; then
     2) AGENTS="supervisor scanner reviewer" ;;
     3) AGENTS="supervisor scanner reviewer architect" ;;
     4) AGENTS="supervisor scanner reviewer architect outreach sec-check" ;;
-    *) AGENTS="supervisor scanner reviewer architect outreach sec-check strategist analyst guardian" ;;
+    *) AGENTS="supervisor scanner reviewer architect outreach sec-check strategist tester" ;;
   esac
 fi
+
+# Auto-generate dashboard token if not provided
+if [[ -z "$DASHBOARD_TOKEN" ]]; then
+  DASHBOARD_TOKEN=$(openssl rand -hex 16 2>/dev/null || echo "hive-$(date +%s)")
+fi
+
+TARGET_ORG="${TARGET_REPO%%/*}"
+TARGET_REPO_NAME="${TARGET_REPO##*/}"
 
 log() { echo "[hive-setup] $*"; }
 run() {
@@ -66,371 +96,249 @@ run() {
   fi
 }
 
-log "Hive v2 Setup — ACMM Level $ACMM_LEVEL"
-log "Target repo: ${TARGET_REPO:-<will prompt>}"
-log "Agents: $AGENTS"
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+log "Hive v2 Setup (Docker-based)"
+log "  Target:  ${TARGET_REPO}"
+log "  Level:   L${ACMM_LEVEL}"
+log "  Agents:  ${AGENTS}"
+log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 
-# ── Prompt for missing values ───────────────────────────────────────
+# Fix locale (common LXC issue)
+export DEBIAN_FRONTEND=noninteractive
+locale-gen en_US.UTF-8 2>/dev/null || true
+export LANG=en_US.UTF-8
 
-if [[ -z "$TARGET_REPO" ]]; then
-  read -rp "Target repository (org/repo): " TARGET_REPO
-fi
-
-if [[ -z "$GIT_NAME" ]]; then
-  read -rp "Git user.name for commits: " GIT_NAME
-fi
-
-if [[ -z "$GIT_EMAIL" ]]; then
-  read -rp "Git user.email for commits: " GIT_EMAIL
-fi
-
-TARGET_ORG="${TARGET_REPO%%/*}"
-TARGET_REPO_NAME="${TARGET_REPO##*/}"
-
-log "Configuration:"
-log "  Repo: $TARGET_REPO"
-log "  Org: $TARGET_ORG"
-log "  Level: L$ACMM_LEVEL"
-log "  Agents: $AGENTS"
-log "  Git: $GIT_NAME <$GIT_EMAIL>"
-echo ""
-
-# ── Phase 1: System Packages ───────────────────────────────────────
-
-log "Phase 1: Installing system packages..."
-
+# ── Phase 1: System packages ──────────────────────────────────────
+log "Phase 1/8: Installing system packages..."
 run "apt-get update -qq"
+run "apt-get install -y -qq ca-certificates curl gnupg lsb-release git jq"
 
-PACKAGES=(
-  # Core
-  git tmux jq curl wget bc sqlite3 htop ripgrep
-  # Build tools
-  build-essential make gcc g++
-  # Python
-  python3 python3-venv python3-pip
-  # Misc
-  unzip fzf tree
-)
+# ── Phase 2: Docker Engine ───────────────────────────────────────
+log "Phase 2/8: Installing Docker..."
 
-run "apt-get install -y -qq ${PACKAGES[*]}"
-
-# ── Phase 2: Node.js 22 (via NodeSource) ───────────────────────────
-
-log "Phase 2: Installing Node.js 22..."
-
-if ! command -v node &>/dev/null || [[ "$(node --version | cut -d. -f1 | tr -d v)" -lt 22 ]]; then
-  run "curl -fsSL https://deb.nodesource.com/setup_22.x | bash -"
-  run "apt-get install -y -qq nodejs"
-fi
-
-log "  Node.js: $(node --version 2>/dev/null || echo 'pending')"
-log "  npm: $(npm --version 2>/dev/null || echo 'pending')"
-
-# ── Phase 3: GitHub CLI ────────────────────────────────────────────
-
-log "Phase 3: Installing GitHub CLI..."
-
-if ! command -v gh &>/dev/null; then
-  run "curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-    | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg"
-  run "echo 'deb [arch=\$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main' \
-    | tee /etc/apt/sources.list.d/github-cli.list > /dev/null"
-  run "apt-get update -qq && apt-get install -y -qq gh"
-fi
-
-log "  gh: $(gh --version 2>/dev/null | head -1 || echo 'pending')"
-
-# ── Phase 4: Claude Code CLI ──────────────────────────────────────
-
-log "Phase 4: Installing Claude Code CLI..."
-
-if ! command -v claude &>/dev/null; then
-  run "npm install -g @anthropic-ai/claude-code"
-fi
-
-log "  Claude: $(claude --version 2>/dev/null | head -1 || echo 'pending')"
-
-# ── Phase 5: Create dev user ──────────────────────────────────────
-
-log "Phase 5: Setting up 'dev' user..."
-
-if ! id dev &>/dev/null; then
-  run "useradd -m -s /bin/bash dev"
-fi
-
-run "sudo -u dev git config --global user.name '$GIT_NAME'"
-run "sudo -u dev git config --global user.email '$GIT_EMAIL'"
-
-# ── Phase 6: Clone Hive repo ─────────────────────────────────────
-
-log "Phase 6: Cloning Hive repo..."
-
-HIVE_DIR="/tmp/hive"
-if [[ ! -d "$HIVE_DIR/.git" ]]; then
-  run "git clone '$HIVE_REPO_URL' '$HIVE_DIR'"
+if ! command -v docker &>/dev/null; then
+  run "install -m 0755 -d /etc/apt/keyrings"
+  run "curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc"
+  run "chmod a+r /etc/apt/keyrings/docker.asc"
+  run 'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo $VERSION_CODENAME) stable" > /etc/apt/sources.list.d/docker.list'
+  run "apt-get update -qq"
+  run "apt-get install -y -qq docker-ce docker-ce-cli containerd.io docker-compose-plugin"
 else
-  run "git -C '$HIVE_DIR' pull --rebase origin main"
+  log "  Docker already installed: $(docker --version)"
 fi
 
-# ── Phase 7: Install Hive scripts ────────────────────────────────
+# ── Phase 3: Clone hive repo ─────────────────────────────────────
+log "Phase 3/8: Cloning hive repo..."
 
-log "Phase 7: Installing Hive scripts to /usr/local/bin/..."
-
-HIVE_SCRIPTS=(
-  supervisor.sh agent-launch.sh hive-config.sh kick-agents.sh
-  agent-healthcheck.sh enumerate-actionable.sh merge-gate.sh
-  gh-app-token.sh gh-rate-check.sh gh-zombie-reaper.sh
-  notify.sh hive.sh hive-deploy.sh kick-governor.sh
-  supervisor-kick.sh ttyd-tmux.sh conflict-sweeper.sh
-  run-pipeline.sh issue-classifier.sh pr-cluster-detector.sh
-  architecture-detector.sh copilot-comment-checker.sh
-  outreach-tracker.sh ga4-anomaly-detector.sh
-  kick-outcome-tracker.sh fetch-coverage.sh
-  hive-prereq-check.sh
-)
-
-for script in "${HIVE_SCRIPTS[@]}"; do
-  if [[ -f "$HIVE_DIR/bin/$script" ]]; then
-    run "cp '$HIVE_DIR/bin/$script' '/usr/local/bin/$script'"
-    run "chmod +x '/usr/local/bin/$script'"
-  fi
-done
-
-# Install backends.conf
-run "mkdir -p /usr/local/etc/hive"
-if [[ -f "$HIVE_DIR/config/backends.conf" ]]; then
-  run "cp '$HIVE_DIR/config/backends.conf' /usr/local/etc/hive/backends.conf"
+if [[ -d "${HIVE_DIR}/.git" ]]; then
+  log "  Repo exists, pulling latest..."
+  run "cd ${HIVE_DIR} && git pull --rebase origin v2"
+else
+  run "git clone --branch v2 --single-branch ${HIVE_REPO_URL} ${HIVE_DIR}"
 fi
 
-# Install gh wrapper (interposes on gh to enforce per-agent restrictions)
-if [[ -f "$HIVE_DIR/bin/gh-wrapper.sh" ]]; then
-  run "cp /usr/bin/gh /usr/bin/gh-real 2>/dev/null || true"
-  run "cp '$HIVE_DIR/bin/gh-wrapper.sh' /usr/local/bin/gh"
-  run "chmod +x /usr/local/bin/gh"
+# ── Phase 4: Build Docker image ──────────────────────────────────
+if ! $SKIP_BUILD; then
+  log "Phase 4/8: Building Docker image (this takes 2-5 minutes)..."
+  run "cd ${HIVE_DIR} && docker compose -f v2/docker-compose.yaml build"
+else
+  log "Phase 4/8: Skipping build (--skip-build)"
 fi
 
-# ── Phase 8: Create directories ──────────────────────────────────
+# ── Phase 5: Generate hive.yaml ──────────────────────────────────
+log "Phase 5/8: Generating project config..."
 
-log "Phase 8: Creating Hive directories..."
-
-run "mkdir -p /etc/hive"
-run "mkdir -p /var/run/hive && chown dev:dev /var/run/hive"
-run "mkdir -p /var/run/hive-metrics && chown dev:dev /var/run/hive-metrics"
-run "mkdir -p /home/dev/.local/state/hive && chown -R dev:dev /home/dev/.local"
-
-# ── Phase 9: Clone target repo ───────────────────────────────────
-
-log "Phase 9: Cloning target repo for dev user..."
-
-TARGET_DIR="/home/dev/${TARGET_REPO_NAME}"
-if [[ ! -d "$TARGET_DIR" ]]; then
-  run "sudo -u dev git clone 'https://github.com/${TARGET_REPO}.git' '$TARGET_DIR'"
-fi
-
-# Create agent workdirs (beads directories)
-for agent in $AGENTS; do
-  run "sudo -u dev mkdir -p '/home/dev/${agent}-beads'"
-done
-
-# ── Phase 10: Generate hive-project.yaml ─────────────────────────
-
-log "Phase 10: Generating hive-project.yaml..."
-
-# Determine PR permissions based on ACMM level
 PR_ENABLED=false
 [[ "$ACMM_LEVEL" -ge 3 ]] && PR_ENABLED=true
 
-cat > /etc/hive/hive-project.yaml << PROJEOF
-# hive-project.yaml — Auto-generated by hive-setup.sh
-# Target: ${TARGET_REPO} | ACMM Level: L${ACMM_LEVEL}
+HIVE_YAML="${HIVE_DIR}/v2/deploy/hive-${TARGET_REPO_NAME}.yaml"
+
+# Build agents YAML block
+AGENTS_YAML=""
+for agent in $AGENTS; do
+  case "$agent" in
+    supervisor) MODEL="claude-sonnet-4-6"; STALE=3600 ;;
+    scanner)    MODEL="claude-opus-4.6";   STALE=1800 ;;
+    reviewer)   MODEL="claude-sonnet-4-6"; STALE=2400 ;;
+    architect)  MODEL="claude-opus-4.6";   STALE=9000 ;;
+    *)          MODEL="claude-sonnet-4-6"; STALE=2400 ;;
+  esac
+  AGENTS_YAML="${AGENTS_YAML}
+  ${agent}:
+    enabled: true
+    backend: copilot
+    model: ${MODEL}
+    beads_dir: /data/beads/${agent}
+    clear_on_kick: true
+    cli_pinned: true
+    stale_timeout: ${STALE}
+    restart_strategy: immediate
+    launch_cmd: \"agent-launch.sh --backend copilot --model ${MODEL}\"
+    display_name: ${agent}"
+done
+
+cat > "$HIVE_YAML" << YAMLEOF
+# Hive v2 config for ${TARGET_REPO} (ACMM Level ${ACMM_LEVEL})
+# Auto-generated by hive-setup.sh on $(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 project:
-  name: "${TARGET_REPO_NAME}"
-  org: "${TARGET_ORG}"
-  primary_repo: "${TARGET_REPO}"
+  org: ${TARGET_ORG}
+  name: ${TARGET_REPO_NAME}
   repos:
-    - ${TARGET_REPO}
-  ai_author: "${GIT_NAME}"
-  website: ""
-  hive_repo: "kubestellar/hive"
-
-agents:
-  enabled:
-$(for a in $AGENTS; do echo "    - $a"; done)
-  beads_base: "/home/dev"
-  workdir: "${TARGET_DIR}"
-  policy_dir: "agents"
-
-permissions:
-  open_issues: true
-  open_prs: ${PR_ENABLED}
-  merge_prs: false
+    - ${TARGET_REPO_NAME}
+  ai_author: clubanderson
+  primary_repo: ${TARGET_REPO_NAME}
   acmm_level: ${ACMM_LEVEL}
+  open_prs: ${PR_ENABLED}
+
+policies:
+  repo: https://github.com/kubestellar/hive
+  path: examples/${TARGET_REPO_NAME}/agents/
+  local_dir: /data/policies
+  poll_interval: 5m
+
+agents:${AGENTS_YAML}
+
+governor:
+  eval_interval_s: 300
+  modes:
+    busy:
+      threshold: 10
+$(for a in $AGENTS; do echo "      ${a}: 15m"; done)
+    quiet:
+      threshold: 3
+$(for a in $AGENTS; do echo "      ${a}: 30m"; done)
+    idle:
+      threshold: 0
+$(for a in $AGENTS; do echo "      ${a}: 1h"; done)
+  labels:
+    exempt:
+      - hold
+      - do-not-merge
+  sensing:
+    gh_rate_patterns:
+      - "API rate limit exceeded"
+      - "secondary rate limit"
+    cli_exclude_patterns:
+      - "out of extra usage"
+    ttl_seconds: 900
+    pullback_seconds: 900
+  health:
+    healthcheck_interval: 300
+    restart_cooldown: 60
+    model_lock: false
+
+github:
+  token: \${HIVE_GITHUB_TOKEN}
+
+notifications:
+  ntfy:
+    server: \${NTFY_SERVER}
+    topic: \${NTFY_TOPIC}
 
 dashboard:
-  title: "${TARGET_REPO_NAME} Hive"
   port: 3001
-PROJEOF
+  snapshot_dir: /data/snapshots
+  auth_token: \${HIVE_DASHBOARD_TOKEN}
 
-# ── Phase 11: Generate hive-runtime.yaml ─────────────────────────
+data:
+  metrics_dir: /data/metrics
+  logs_dir: /data/logs
+  claude_sessions_dir: /data/home/.claude/projects
+YAMLEOF
 
-log "Phase 11: Generating hive-runtime.yaml..."
+log "  Config: ${HIVE_YAML}"
 
-cat > /etc/hive/hive-runtime.yaml << RTEOF
-agents:
-  enabled:
-$(for a in $AGENTS; do echo "    - $a"; done)
-  sidebar:
-    groups:
-      - name: null
-        agents:
-          - supervisor
-      - name: autonomy
-        agents:
-$(for a in $AGENTS; do [[ "$a" != "supervisor" ]] && echo "          - $a"; done)
-project:
-  repos:
-    - ${TARGET_REPO}
-RTEOF
+# ── Phase 6: Generate docker-compose override ────────────────────
+log "Phase 6/8: Generating docker-compose file..."
 
-# ── Phase 12: Generate agent .env files ──────────────────────────
+COMPOSE_OUT="${HIVE_DIR}/v2/deploy/docker-compose.${TARGET_REPO_NAME}.yaml"
 
-log "Phase 12: Generating agent .env files..."
+cat > "$COMPOSE_OUT" << COMPEOF
+services:
+  hive:
+    build:
+      context: ../..
+      dockerfile: v2/Dockerfile
+    container_name: hive-${TARGET_REPO_NAME}
+    restart: unless-stopped
+    ports:
+      - "3001:3001"
+      - "7681:7681"
+    volumes:
+      - ./hive-${TARGET_REPO_NAME}.yaml:/etc/hive/hive.yaml:ro
+      - hive-data:/data
+      - ./secrets:/secrets:ro
+    environment:
+      - HIVE_GITHUB_TOKEN=\${HIVE_GITHUB_TOKEN}
+      - HIVE_DASHBOARD_TOKEN=\${HIVE_DASHBOARD_TOKEN}
+      - ANTHROPIC_API_KEY=\${ANTHROPIC_API_KEY}
+      - NTFY_SERVER=\${NTFY_SERVER}
+      - NTFY_TOPIC=\${NTFY_TOPIC}
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:3001/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 120s
 
-# L2 prompt suffix — analysis only, no PRs
-L2_SUFFIX="You are operating at ACMM Level 2 (analysis only). You may open issues but MUST NOT open pull requests, push code, or modify any files in the repository. Your role is to study, analyze, and report."
+volumes:
+  hive-data:
+COMPEOF
 
-for agent in $AGENTS; do
-  ENVFILE="/etc/hive/${agent}.env"
+log "  Compose: ${COMPOSE_OUT}"
 
-  # Agent-specific defaults
-  case "$agent" in
-    supervisor)
-      WORKDIR="/home/dev/hive-supervisor"
-      MODEL="claude-sonnet-4-6"
-      PROMPT="You are the Hive Supervisor for ${TARGET_REPO}. STEP 0: pull latest hive repo: git -C /tmp/hive pull --rebase origin main. STEP 1: re-read your policy file. STEP 2: hive status. STEP 3: check all agent panes. STEP 4: kick idle agents. STEP 5: report status. ${L2_SUFFIX}"
-      STYLE="bg=colour196,fg=white"
-      ;;
-    scanner)
-      WORKDIR="$TARGET_DIR"
-      MODEL="claude-sonnet-4-6"
-      PROMPT="You are the Scanner agent for ${TARGET_REPO}. Study the codebase, identify bugs, test gaps, security issues, and code quality problems. File issues for significant findings. ${L2_SUFFIX}"
-      STYLE="bg=colour33,fg=white"
-      ;;
-    reviewer)
-      WORKDIR="$TARGET_DIR"
-      MODEL="claude-sonnet-4-6"
-      PROMPT="You are the Reviewer agent for ${TARGET_REPO}. Review recent PRs and commits for quality, correctness, and potential regressions. File issues for problems found. ${L2_SUFFIX}"
-      STYLE="bg=colour28,fg=white"
-      ;;
-    architect)
-      WORKDIR="$TARGET_DIR"
-      MODEL="claude-sonnet-4-6"
-      PROMPT="You are the Architect agent for ${TARGET_REPO}. Analyze architecture, identify refactoring opportunities, and propose structural improvements via issues. ${L2_SUFFIX}"
-      STYLE="bg=colour93,fg=white"
-      ;;
-    outreach)
-      WORKDIR="$TARGET_DIR"
-      MODEL="claude-sonnet-4-6"
-      PROMPT="You are the Outreach agent for ${TARGET_REPO}. Study the ecosystem, identify adoption opportunities, and track community activity. ${L2_SUFFIX}"
-      STYLE="bg=colour208,fg=white"
-      ;;
-    sec-check)
-      WORKDIR="$TARGET_DIR"
-      MODEL="claude-sonnet-4-6"
-      PROMPT="You are the Security agent for ${TARGET_REPO}. Audit dependencies, scan for vulnerabilities, check for hardcoded secrets, and review security practices. File issues for findings. ${L2_SUFFIX}"
-      STYLE="bg=colour160,fg=white"
-      ;;
-    *)
-      WORKDIR="$TARGET_DIR"
-      MODEL="claude-sonnet-4-6"
-      PROMPT="You are the ${agent} agent for ${TARGET_REPO}. ${L2_SUFFIX}"
-      STYLE="bg=colour240,fg=white"
-      ;;
-  esac
+# ── Phase 7: Create .env ─────────────────────────────────────────
+log "Phase 7/8: Writing .env file..."
 
-  cat > "$ENVFILE" << ENVEOF
-# ${agent}.env — Hive agent config (auto-generated)
-AGENT_USER=dev
-AGENT_SESSION_NAME=${agent}
-AGENT_WORKDIR=${WORKDIR}
-AGENT_LAUNCH_CMD="agent-launch.sh --backend claude --model ${MODEL}"
-AGENT_CLI=claude
-
-AGENT_POLL_SEC=10
-AGENT_LOOP_PROMPT="${PROMPT}"
-
-AGENT_LOG_FILE=/home/dev/.local/state/hive/${agent}-heartbeat.log
-AGENT_STALE_MAX_SEC=3600
-AGENT_MAX_RESPAWNS=3
-
-AGENT_TMUX_STATUS_STYLE="${STYLE}"
-AGENT_CLAUDE_RENAME_TO=${agent^}
-
-AGENT_RATE_LIMIT_FAILOVER=false
+ENV_FILE="${HIVE_DIR}/.env"
+cat > "$ENV_FILE" << ENVEOF
+HIVE_GITHUB_TOKEN=${GH_TOKEN}
+HIVE_DASHBOARD_TOKEN=${DASHBOARD_TOKEN}
+ANTHROPIC_API_KEY=${ANTHROPIC_KEY}
+NTFY_SERVER=
+NTFY_TOPIC=hive-${TARGET_REPO_NAME}
 ENVEOF
-done
 
-# Create supervisor workdir
-run "sudo -u dev mkdir -p /home/dev/hive-supervisor"
-run "sudo -u dev git -C /home/dev/hive-supervisor init 2>/dev/null || true"
+log "  .env: ${ENV_FILE}"
 
-# ── Phase 13: Install systemd units ──────────────────────────────
+# ── Phase 8: Start container ────────────────────────────────────
+log "Phase 8/8: Starting hive container..."
 
-log "Phase 13: Installing systemd units..."
+run "cd ${HIVE_DIR}/v2/deploy && docker compose -f docker-compose.${TARGET_REPO_NAME}.yaml --env-file ${ENV_FILE} up -d"
 
-for unit in hive.service hive@.service; do
-  if [[ -f "$HIVE_DIR/systemd/$unit" ]]; then
-    run "cp '$HIVE_DIR/systemd/$unit' '/etc/systemd/system/$unit'"
+# Wait for health
+log "  Waiting for dashboard..."
+HEALTH_OK=false
+for i in $(seq 1 15); do
+  if curl -sf http://localhost:3001/api/health &>/dev/null; then
+    HEALTH_OK=true
+    break
   fi
+  sleep 2
 done
-
-run "systemctl daemon-reload"
-
-# Enable agent services
-for agent in $AGENTS; do
-  run "systemctl enable 'hive@${agent}.service' 2>/dev/null || true"
-done
-
-# ── Phase 14: GitHub Auth ────────────────────────────────────────
-
-log "Phase 14: GitHub authentication..."
-
-if ! $SKIP_AUTH; then
-  echo ""
-  echo "  GitHub authentication is needed for the 'dev' user."
-  echo "  The gh CLI will prompt you to log in."
-  echo ""
-  run "sudo -u dev gh auth login" || warn "gh auth skipped — run manually: sudo -u dev gh auth login"
-fi
-
-# ── Phase 15: Run prereq check ───────────────────────────────────
-
-log "Phase 15: Running prereq check..."
-echo ""
-run "bash /usr/local/bin/hive-prereq-check.sh" || true
-
-# ── Done ─────────────────────────────────────────────────────────
 
 echo ""
 log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-log "Hive v2 setup complete!"
-log ""
-log "  Target repo:  ${TARGET_REPO}"
-log "  ACMM Level:   L${ACMM_LEVEL}"
-log "  Agents:       ${AGENTS}"
-log "  Config:       /etc/hive/"
-log "  Repo clone:   ${TARGET_DIR}"
-log ""
-log "Next steps:"
-log "  1. Authenticate Claude Code:  sudo -u dev claude auth login"
-log "  2. Copy agent CLAUDE.md files to /etc/hive/ (or use defaults)"
-log "  3. Start agents:  systemctl start hive@supervisor"
-log "  4. Attach to session:  tmux attach -t supervisor"
+if $HEALTH_OK; then
+  LXC_IP=$(ip -4 addr show eth0 2>/dev/null | grep -oP '(?<=inet )\d+\.\d+\.\d+\.\d+' || hostname -I | awk '{print $1}')
+  log "Hive v2 is running!"
+  log ""
+  log "  Dashboard:  http://${LXC_IP}:3001"
+  log "  Terminal:   http://${LXC_IP}:7681"
+  log "  Container:  docker logs -f hive-${TARGET_REPO_NAME}"
+  log ""
+  log "  Target:     ${TARGET_REPO}"
+  log "  Level:      L${ACMM_LEVEL}"
+  log "  Agents:     ${AGENTS}"
+else
+  log "Container started but dashboard not yet healthy."
+  log "Check logs: docker logs hive-${TARGET_REPO_NAME}"
+fi
 log ""
 if [[ "$ACMM_LEVEL" -le 2 ]]; then
-  log "  NOTE: L${ACMM_LEVEL} mode — agents will analyze and file issues"
+  log "  NOTE: L${ACMM_LEVEL} mode — agents analyze and file issues"
   log "  but will NOT open PRs or modify code."
 fi
 log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/v2/deploy/bootstrap-lxc.sh
+++ b/v2/deploy/bootstrap-lxc.sh
@@ -1,24 +1,43 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Bootstrap script for hive-v2 architect LXC on Proxmox
-# Run this INSIDE the LXC after creation.
+# bootstrap-lxc.sh — Bootstrap a Proxmox LXC for Hive v2 (Docker-based).
+#
+# Run this INSIDE the LXC after creation with create-lxc.sh.
+#
+# What it does:
+#   1. Installs Docker Engine + Compose plugin
+#   2. Clones the hive repo (v2 branch)
+#   3. Builds the hive Docker image
+#   4. Creates a template .env file for tokens
 #
 # Prerequisites:
-#   - Ubuntu 24.04 LXC created on Proxmox
-#   - Network configured (DHCP)
-#   - This script copied into the LXC
+#   - Ubuntu 24.04 LXC created with create-lxc.sh
+#   - LXC config includes: lxc.apparmor.profile: unconfined
+#     (create-lxc.sh does this automatically)
+#   - curl installed (create-lxc.sh instructions include this)
 #
 # Usage:
-#   bash bootstrap-lxc.sh
+#   apt-get update -qq && apt-get install -y -qq curl
+#   curl -fsSL https://raw.githubusercontent.com/kubestellar/hive/v2/v2/deploy/bootstrap-lxc.sh | bash
+#
+# After bootstrap, edit /opt/hive/.env and run:
+#   cd /opt/hive/v2/deploy && docker compose -f docker-compose.yaml --env-file /opt/hive/.env up -d
 
 HIVE_DIR=/opt/hive
 ENV_FILE="${HIVE_DIR}/.env"
 
-echo "=== Installing Docker ==="
-apt-get update -qq
-apt-get install -y -qq ca-certificates curl gnupg lsb-release git
+# Fix locale warnings (common in LXC containers)
+export DEBIAN_FRONTEND=noninteractive
+locale-gen en_US.UTF-8 2>/dev/null || true
+export LANG=en_US.UTF-8
+export LC_ALL=en_US.UTF-8
 
+echo "=== Phase 1: System packages ==="
+apt-get update -qq
+apt-get install -y -qq ca-certificates curl gnupg lsb-release git jq
+
+echo "=== Phase 2: Docker Engine ==="
 install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
 chmod a+r /etc/apt/keyrings/docker.asc
@@ -30,42 +49,65 @@ echo \
 apt-get update -qq
 apt-get install -y -qq docker-ce docker-ce-cli containerd.io docker-compose-plugin
 
-echo "=== Cloning hive repo ==="
-git clone --branch v2 --single-branch https://github.com/kubestellar/hive.git "${HIVE_DIR}"
+echo "=== Phase 3: Clone hive repo ==="
+if [ -d "${HIVE_DIR}/.git" ]; then
+  echo "Hive repo already exists at ${HIVE_DIR}, pulling latest..."
+  cd "${HIVE_DIR}" && git pull --rebase origin v2
+else
+  git clone --branch v2 --single-branch https://github.com/kubestellar/hive.git "${HIVE_DIR}"
+fi
 
-echo "=== Creating .env file ==="
+echo "=== Phase 4: Build Docker image ==="
+cd "${HIVE_DIR}"
+docker compose -f v2/docker-compose.yaml build
+
+echo "=== Phase 5: Create .env template ==="
 if [ ! -f "${ENV_FILE}" ]; then
   cat > "${ENV_FILE}" <<'ENVEOF'
-# Fill in these values before running docker compose up
+# Hive v2 environment — fill in before running docker compose up
+#
+# HIVE_GITHUB_TOKEN: GitHub PAT or App token with repo access
+#   - For public repos: fine-grained PAT with "Public Repositories (read-only)"
+#   - For org repos: classic PAT with repo scope, or use GitHub App auth
 HIVE_GITHUB_TOKEN=
+
+# HIVE_DASHBOARD_TOKEN: protects the dashboard API (generate: openssl rand -hex 32)
 HIVE_DASHBOARD_TOKEN=
+
+# ANTHROPIC_API_KEY: for Claude Code CLI inside container (optional if using Copilot backend)
 ANTHROPIC_API_KEY=
+
+# NTFY_SERVER: self-hosted ntfy URL for push notifications (optional)
+NTFY_SERVER=
+
+# NTFY_TOPIC: notification topic name (e.g., hive-myproject)
+NTFY_TOPIC=
 ENVEOF
   echo ">>> EDIT ${ENV_FILE} with your tokens before starting <<<"
 else
   echo ".env already exists, skipping"
 fi
 
-echo "=== Building Docker image ==="
-cd "${HIVE_DIR}"
-docker compose -f v2/deploy/docker-compose.architect.yaml build
-
 echo ""
-echo "=== Setup complete ==="
+echo "============================================="
+echo "  Hive v2 bootstrap complete"
+echo "============================================="
 echo ""
 echo "Next steps:"
-echo "  1. Edit ${ENV_FILE} with your tokens:"
-echo "     - HIVE_GITHUB_TOKEN  (same as 4.56 hive server)"
-echo "     - HIVE_DASHBOARD_TOKEN  (generate with: openssl rand -hex 32)"
-echo "     - ANTHROPIC_API_KEY  (for Claude Code CLI inside container)"
 echo ""
-echo "  2. Start hive:"
-echo "     cd ${HIVE_DIR} && docker compose --env-file .env -f v2/deploy/docker-compose.architect.yaml up -d"
+echo "  1. Edit ${ENV_FILE} with your tokens"
 echo ""
-echo "  3. Check logs:"
-echo "     docker logs -f hive-architect"
+echo "  2. (Optional) Create a project-specific hive.yaml:"
+echo "     cp ${HIVE_DIR}/v2/deploy/hive.yaml ${HIVE_DIR}/v2/deploy/hive-myproject.yaml"
+echo "     # Edit org, repos, agents, governor thresholds"
 echo ""
-echo "  4. Dashboard: http://<this-lxc-ip>:3001"
+echo "  3. Start hive:"
+echo "     cd ${HIVE_DIR}/v2/deploy"
+echo "     docker compose -f docker-compose.yaml --env-file ${ENV_FILE} up -d"
 echo ""
-echo "  5. Pause architect on 4.56:"
-echo "     ssh dev@192.168.4.56 'touch /etc/hive/pause_architect'"
+echo "  4. Check health:"
+echo "     curl -sf http://localhost:3001/api/health"
+echo "     docker logs -f hive"
+echo ""
+echo "  5. Dashboard: http://<this-lxc-ip>:3001"
+echo ""

--- a/v2/deploy/create-lxc.sh
+++ b/v2/deploy/create-lxc.sh
@@ -1,20 +1,39 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Run this on the Proxmox host (192.168.6.144) to create the LXC.
-# Usage: bash create-lxc.sh
+# create-lxc.sh — Create a Proxmox LXC container for Hive v2 (Docker-based).
+#
+# Run this on the Proxmox host.
+# Usage:
+#   bash create-lxc.sh [--ctid 111] [--hostname hive-certus] [--password maver1ck]
 #
 # Or from your Mac:
-#   ssh root@192.168.6.144 'bash -s' < create-lxc.sh
+#   sshpass -p <pw> ssh root@<proxmox-ip> 'bash -s' < create-lxc.sh
+#
+# After creation, run bootstrap-lxc.sh inside the container:
+#   pct exec <CTID> -- bash -c 'curl -fsSL https://raw.githubusercontent.com/kubestellar/hive/v2/v2/deploy/bootstrap-lxc.sh | bash'
 
-CTID=110
-HOSTNAME="hive-v2"
+CTID="${CTID:-111}"
+HOSTNAME="${LXC_HOSTNAME:-hive}"
+PASSWORD="${LXC_PASSWORD:-changeme}"
 TEMPLATE="local:vztmpl/ubuntu-24.04-standard_24.04-2_amd64.tar.zst"
 STORAGE="local-lvm"
 DISK_SIZE=16
 RAM_MB=4096
 SWAP_MB=512
 CORES=4
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ctid)     CTID="$2"; shift 2 ;;
+    --hostname) HOSTNAME="$2"; shift 2 ;;
+    --password) PASSWORD="$2"; shift 2 ;;
+    --disk)     DISK_SIZE="$2"; shift 2 ;;
+    --memory)   RAM_MB="$2"; shift 2 ;;
+    --cores)    CORES="$2"; shift 2 ;;
+    *)          echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
 
 # Check if template exists, download if not
 if ! pveam list local | grep -q "ubuntu-24.04-standard"; then
@@ -25,7 +44,7 @@ fi
 
 # Check if CTID is in use
 if pct status "${CTID}" &>/dev/null; then
-  echo "ERROR: CTID ${CTID} already exists. Pick a different ID."
+  echo "ERROR: CTID ${CTID} already exists. Pick a different ID or destroy first."
   exit 1
 fi
 
@@ -40,21 +59,38 @@ pct create "${CTID}" "${TEMPLATE}" \
   --net0 "name=eth0,bridge=vmbr0,ip=dhcp" \
   --features "nesting=1,keyctl=1" \
   --unprivileged 0 \
-  --start 1 \
-  --password "changeme"
+  --start 0 \
+  --password "${PASSWORD}"
 
-echo "=== Waiting for LXC to boot ==="
+# Docker-in-LXC requires AppArmor unconfined + no cap drop
+echo "=== Configuring LXC for Docker compatibility ==="
+cat >> "/etc/pve/lxc/${CTID}.conf" <<'EOF'
+lxc.apparmor.profile: unconfined
+lxc.cap.drop:
+EOF
+
+echo "=== Starting LXC ==="
+pct start "${CTID}"
 sleep 5
 
+echo "=== Enabling SSH with root password auth ==="
+pct exec "${CTID}" -- bash -c '
+  sed -i "s/^#*PermitRootLogin.*/PermitRootLogin yes/" /etc/ssh/sshd_config
+  sed -i "s/^#*PasswordAuthentication.*/PasswordAuthentication yes/" /etc/ssh/sshd_config
+  systemctl restart sshd
+'
+
 echo "=== LXC IP address ==="
-pct exec "${CTID}" -- ip -4 addr show eth0 | grep inet || echo "(DHCP may still be pending — check in a few seconds)"
+LXC_IP=$(pct exec "${CTID}" -- ip -4 addr show eth0 | grep -oP '(?<=inet )\d+\.\d+\.\d+\.\d+' || echo "unknown")
+echo "  IP: ${LXC_IP}"
 
 echo ""
-echo "=== LXC ${CTID} created ==="
+echo "=== LXC ${CTID} (${HOSTNAME}) created ==="
 echo ""
-echo "Next: copy and run the bootstrap script inside the LXC:"
-echo "  pct exec ${CTID} -- bash -c 'curl -fsSL https://raw.githubusercontent.com/kubestellar/hive/v2/v2/deploy/bootstrap-lxc.sh | bash'"
+echo "SSH:  ssh root@${LXC_IP}  (password: ${PASSWORD})"
 echo ""
-echo "Or manually:"
-echo "  pct enter ${CTID}"
-echo "  # then run bootstrap-lxc.sh"
+echo "Next: run the bootstrap script inside the LXC:"
+echo "  pct exec ${CTID} -- bash -c 'apt-get update -qq && apt-get install -y -qq curl && curl -fsSL https://raw.githubusercontent.com/kubestellar/hive/v2/v2/deploy/bootstrap-lxc.sh | bash'"
+echo ""
+echo "Or via SSH:"
+echo "  sshpass -p ${PASSWORD} ssh root@${LXC_IP} 'apt-get update -qq && apt-get install -y -qq curl && curl -fsSL https://raw.githubusercontent.com/kubestellar/hive/v2/v2/deploy/bootstrap-lxc.sh | bash'"


### PR DESCRIPTION
## Summary
- Rewrites all deployment scripts from bare-metal/systemd to Docker Compose
- `create-lxc.sh` now adds AppArmor unconfined config (required for Docker-in-LXC), enables SSH, accepts CLI flags
- `bootstrap-lxc.sh` installs Docker + Compose, clones repo, builds image, creates .env template
- `hive-setup.sh` is the all-in-one script: bootstrap + project-specific hive.yaml + docker-compose + .env generation
- `hive-prereq-check.sh` validates Docker-based deployment instead of bare-metal checks

## Test plan
- [x] Created fresh Proxmox LXC (CT 111) with `create-lxc.sh` pattern
- [x] Ran `bootstrap-lxc.sh` — Docker installed, image built
- [x] Generated certus-specific hive.yaml and docker-compose override
- [x] Container running and healthy at http://192.168.4.83:3001
- [x] `hive-prereq-check.sh` passes 23/23 checks on live container
- [x] ttyd terminal accessible on port 7681