### PR TITLE
Fix black screen: extra brace in applyACMMVisibility

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6427,7 +6427,6 @@ function burnAreaChart() {
             if (name && !packSet.has(name)) hide(card);
           });
         }
-      }
     }
 
     function switchConfigTab(tabId) {


### PR DESCRIPTION
## Summary
- The L0 removal in #532 left an extra closing brace from the old `else` block
- This caused a JS parse error ("Unexpected end of input") preventing any rendering
- Dashboard showed black screen (body.style.opacity stuck at '0')

## Test plan
- [ ] Dashboard renders on both 4.78 and 4.83
- [ ] ACMM badge visible and correct
- [ ] Agent cards render properly