### PR TITLE
Inject project context into agent boot prompts

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -155,7 +155,14 @@ func main() {
 
 	notifier := notify.New(cfg.Notifications, logger)
 	notifier.SetHiveID(cfg.HiveID)
-	agentMgr := agent.NewManager(cfg.EnabledAgents(), logger)
+	acmmLevel := inferACMMLevel(cfg)
+	projectCtx := agent.ProjectContext{
+		Org:        cfg.Project.Org,
+		Repos:      cfg.Project.Repos,
+		ACMMLevel:  acmmLevel,
+		PRsAllowed: cfg.Project.PRsAllowed(),
+	}
+	agentMgr := agent.NewManager(cfg.EnabledAgents(), logger, projectCtx)
 
 	const statePath = "/data/hive-state.json"
 	var savedIssueCosts map[string]int64
@@ -1068,6 +1075,24 @@ func initAgentConfigDrivenSystems(cfg *config.Config) {
 	discord.SetAgentIdentities(discordIdentities)
 	if len(discordAliases) > 0 {
 		discord.SetAgentAliases(discordAliases)
+	}
+}
+
+// inferACMMLevel returns the configured ACMM level, or infers one from agent count.
+func inferACMMLevel(cfg *config.Config) int {
+	if cfg.ACMMLevel != nil {
+		return *cfg.ACMMLevel
+	}
+	agentCount := len(cfg.Agents)
+	switch {
+	case agentCount <= 1:
+		return 1
+	case agentCount == 2:
+		return 2
+	case agentCount <= 4:
+		return 3
+	default:
+		return 4
 	}
 }
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -57,15 +57,24 @@ type AgentProcess struct {
 	cancel          context.CancelFunc
 }
 
+// ProjectContext holds project-level config injected into agent boot prompts.
+type ProjectContext struct {
+	Org       string
+	Repos     []string
+	ACMMLevel int
+	PRsAllowed bool
+}
+
 type Manager struct {
 	agents    map[string]*AgentProcess
 	idToName  map[string]string
 	mu        sync.RWMutex
 	logger    *slog.Logger
 	workDir   string
+	project   ProjectContext
 }
 
-func NewManager(agents map[string]config.AgentConfig, logger *slog.Logger) *Manager {
+func NewManager(agents map[string]config.AgentConfig, logger *slog.Logger, project ProjectContext) *Manager {
 	workDir := os.Getenv("HIVE_WORK_DIR")
 	if workDir == "" {
 		workDir = "/data/agents"
@@ -76,6 +85,7 @@ func NewManager(agents map[string]config.AgentConfig, logger *slog.Logger) *Mana
 		idToName: make(map[string]string),
 		logger:   logger,
 		workDir:  workDir,
+		project:  project,
 	}
 
 	for name, cfg := range agents {
@@ -303,6 +313,16 @@ func (m *Manager) watchForTrustPrompt(session string, ctx context.Context) {
 	}
 }
 
+// acmmLevelNames maps ACMM level numbers to human-readable names.
+var acmmLevelNames = map[int]string{
+	1: "Idea",
+	2: "Development",
+	3: "CI/CD",
+	4: "Managed",
+	5: "Guarded Autonomy",
+	6: "Full Autonomy",
+}
+
 func (m *Manager) buildBootstrapPrompt(agent *AgentProcess) string {
 	paths := []string{
 		fmt.Sprintf("/data/policies/examples/kubestellar/agents/%s-CLAUDE.md", agent.Name),
@@ -327,7 +347,33 @@ func (m *Manager) buildBootstrapPrompt(agent *AgentProcess) string {
 		}
 	}
 
+	base = m.buildProjectPreamble() + base
 	return base
+}
+
+func (m *Manager) buildProjectPreamble() string {
+	p := m.project
+	if p.Org == "" || len(p.Repos) == 0 {
+		return ""
+	}
+
+	repos := make([]string, len(p.Repos))
+	for i, r := range p.Repos {
+		repos[i] = fmt.Sprintf("%s/%s", p.Org, r)
+	}
+
+	levelName := acmmLevelNames[p.ACMMLevel]
+	if levelName == "" {
+		levelName = fmt.Sprintf("Level %d", p.ACMMLevel)
+	}
+
+	prPolicy := "You MAY open pull requests."
+	if !p.PRsAllowed {
+		prPolicy = "You MUST NOT open pull requests. Analysis and issues ONLY."
+	}
+
+	return fmt.Sprintf("[PROJECT] Org: %s | Repos: %s | ACMM: L%d (%s) | %s ",
+		p.Org, strings.Join(repos, ", "), p.ACMMLevel, levelName, prPolicy)
 }
 
 const metricsCachePath = "/data/metrics/agent-metrics-cache.json"

--- a/v2/pkg/agent/manager_coverage_test.go
+++ b/v2/pkg/agent/manager_coverage_test.go
@@ -15,7 +15,7 @@ import (
 func TestUpdateConfig_Success(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude", Model: "sonnet"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	newCfg := config.AgentConfig{Backend: "gemini", Model: "pro", Enabled: true}
 	err := m.UpdateConfig("scanner", newCfg)
@@ -33,7 +33,7 @@ func TestUpdateConfig_Success(t *testing.T) {
 }
 
 func TestUpdateConfig_NotFound(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	err := m.UpdateConfig("nonexistent", config.AgentConfig{})
 	if err == nil {
 		t.Error("expected error for nonexistent agent")
@@ -47,7 +47,7 @@ func TestUpdateConfig_NotFound(t *testing.T) {
 func TestSeedLastKick_SetsTime(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	now := time.Now()
 	m.SeedLastKick("scanner", now)
@@ -62,7 +62,7 @@ func TestSeedLastKick_SetsTime(t *testing.T) {
 }
 
 func TestSeedLastKick_NotFound(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	// Should not panic for nonexistent agent
 	m.SeedLastKick("nonexistent", time.Now())
 }
@@ -74,7 +74,7 @@ func TestSeedLastKick_NotFound(t *testing.T) {
 func TestSeedKickHistory_SetsRecords(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	records := []KickRecord{
 		{Timestamp: time.Now().Add(-2 * time.Hour), Agent: "scanner", Snippet: "first kick"},
@@ -96,7 +96,7 @@ func TestSeedKickHistory_SetsRecords(t *testing.T) {
 func TestSeedKickHistory_TruncatesToCapacity(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	// Create more records than capacity
 	records := make([]KickRecord, kickHistoryCapacity+10)
@@ -117,7 +117,7 @@ func TestSeedKickHistory_TruncatesToCapacity(t *testing.T) {
 }
 
 func TestSeedKickHistory_NotFound(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	// Should not panic for nonexistent agent
 	m.SeedKickHistory("nonexistent", []KickRecord{})
 }
@@ -129,7 +129,7 @@ func TestSeedKickHistory_NotFound(t *testing.T) {
 func TestPinModel_SetsModelOverride(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude", Model: "sonnet"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	_ = m.PinModel("scanner", "opus")
 
@@ -201,7 +201,7 @@ func TestAgentEnvVars_WithOverrides(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestRestart_NotFound(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	err := m.Restart(nil, "nonexistent")
 	if err == nil {
 		t.Error("expected error for nonexistent agent")
@@ -215,7 +215,7 @@ func TestRestart_NotFound(t *testing.T) {
 func TestStop_RunningAgentCallsCancel(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	cancelled := false
 	m.mu.Lock()
@@ -245,7 +245,7 @@ func TestStop_RunningAgentCallsCancel(t *testing.T) {
 func TestStart_AlreadyRunning(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	m.mu.Lock()
 	m.agents["scanner"].State = StateRunning
@@ -268,7 +268,7 @@ func TestStart_PausedAgentStaysPaused(t *testing.T) {
 	t.Setenv("HIVE_WORK_DIR", t.TempDir())
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	m.mu.Lock()
 	m.agents["scanner"].Paused = true
@@ -286,7 +286,7 @@ func TestStart_PausedAgentStaysPaused(t *testing.T) {
 func TestGetOutput_NilBuffer(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	m.mu.Lock()
 	m.agents["scanner"].OutputBuffer = nil
@@ -308,7 +308,7 @@ func TestGetOutput_NilBuffer(t *testing.T) {
 func TestResume_NotPaused(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	// Agent is in Stopped state (not paused), Resume should be no-op
 	err := m.Resume(nil, "scanner")
@@ -318,7 +318,7 @@ func TestResume_NotPaused(t *testing.T) {
 }
 
 func TestResume_NotFound(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	err := m.Resume(nil, "nonexistent")
 	if err == nil {
 		t.Error("expected error")
@@ -330,7 +330,7 @@ func TestResume_NotFound(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestPinCLI_NotFound(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	err := m.PinCLI("nonexistent", "v1")
 	if err == nil {
 		t.Error("expected error")
@@ -338,7 +338,7 @@ func TestPinCLI_NotFound(t *testing.T) {
 }
 
 func TestPinModel_NotFound(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	err := m.PinModel("nonexistent", "opus")
 	if err == nil {
 		t.Error("expected error")
@@ -350,7 +350,7 @@ func TestPinModel_NotFound(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestSetModelOverride_NotFound(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	err := m.SetModelOverride("nonexistent", "opus")
 	if err == nil {
 		t.Error("expected error")
@@ -358,7 +358,7 @@ func TestSetModelOverride_NotFound(t *testing.T) {
 }
 
 func TestSetBackendOverride_NotFound(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	err := m.SetBackendOverride("nonexistent", "gemini")
 	if err == nil {
 		t.Error("expected error")
@@ -375,7 +375,7 @@ func TestNewManager_CustomWorkDir(t *testing.T) {
 
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	if m.workDir != dir {
 		t.Errorf("workDir = %q, want %q", m.workDir, dir)
@@ -384,7 +384,7 @@ func TestNewManager_CustomWorkDir(t *testing.T) {
 
 func TestNewManager_DefaultWorkDir(t *testing.T) {
 	os.Unsetenv("HIVE_WORK_DIR")
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	if m.workDir != "/data/agents" {
 		t.Errorf("workDir = %q, want /data/agents", m.workDir)
 	}
@@ -397,7 +397,7 @@ func TestNewManager_DefaultWorkDir(t *testing.T) {
 func TestSnapshot_CopiesKickHistory(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	now := time.Now()
 	m.SeedKickHistory("scanner", []KickRecord{
@@ -425,7 +425,7 @@ func TestSnapshot_CopiesKickHistory(t *testing.T) {
 func TestSeedRestartCount(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	m.SeedRestartCount("scanner", 5)
 
@@ -436,7 +436,7 @@ func TestSeedRestartCount(t *testing.T) {
 }
 
 func TestSeedRestartCount_NotFound(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	// Should not panic for nonexistent agent
 	m.SeedRestartCount("nonexistent", 3)
 }
@@ -448,7 +448,7 @@ func TestSeedRestartCount_NotFound(t *testing.T) {
 func TestRemoveAgent_WithCancel(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	cancelled := false
 	m.mu.Lock()
@@ -466,7 +466,7 @@ func TestRemoveAgent_WithCancel(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestSendKick_NotFound(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	err := m.SendKick("nonexistent", "go")
 	if err == nil {
 		t.Error("expected error for nonexistent agent")
@@ -476,7 +476,7 @@ func TestSendKick_NotFound(t *testing.T) {
 func TestSendKick_NotRunning(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	err := m.SendKick("scanner", "scan issues")
 	if err == nil {
@@ -489,7 +489,7 @@ func TestSendKick_NotRunning(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestPause_NotFound(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	err := m.Pause("nonexistent")
 	if err == nil {
 		t.Error("expected error")
@@ -499,7 +499,7 @@ func TestPause_NotFound(t *testing.T) {
 func TestPause_AlreadyPaused(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	m.mu.Lock()
 	m.agents["scanner"].Paused = true
@@ -520,7 +520,7 @@ func TestPause_AlreadyPaused(t *testing.T) {
 func TestBuildBootstrapPrompt_NoFile(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	m.mu.RLock()
 	agent := m.agents["scanner"]
@@ -538,7 +538,7 @@ func TestBuildBootstrapPrompt_NoFile(t *testing.T) {
 func TestBuildBootstrapPrompt_WithFile(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	// Create a CLAUDE.md file in the expected path
 	tmpDir := t.TempDir()

--- a/v2/pkg/agent/manager_extra_test.go
+++ b/v2/pkg/agent/manager_extra_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestAddAgent(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	m.AddAgent("new-agent", config.AgentConfig{Backend: "claude", Model: "sonnet"})
 
 	status, err := m.GetStatus("new-agent")
@@ -25,7 +25,7 @@ func TestAddAgent(t *testing.T) {
 func TestAddAgent_Duplicate(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	// Should not overwrite
 	m.AddAgent("scanner", config.AgentConfig{Backend: "gemini"})
@@ -38,7 +38,7 @@ func TestAddAgent_Duplicate(t *testing.T) {
 func TestRemoveAgent(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	m.RemoveAgent("scanner")
 	_, err := m.GetStatus("scanner")
@@ -48,7 +48,7 @@ func TestRemoveAgent(t *testing.T) {
 }
 
 func TestRemoveAgent_NotFound(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	// Should not panic
 	m.RemoveAgent("nonexistent")
 }
@@ -56,7 +56,7 @@ func TestRemoveAgent_NotFound(t *testing.T) {
 func TestResetRestartCount(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	m.mu.Lock()
 	m.agents["scanner"].RestartCount = 5
@@ -73,7 +73,7 @@ func TestResetRestartCount(t *testing.T) {
 }
 
 func TestResetRestartCount_NotFound(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	err := m.ResetRestartCount("nonexistent")
 	if err == nil {
 		t.Error("expected error")
@@ -83,7 +83,7 @@ func TestResetRestartCount_NotFound(t *testing.T) {
 func TestUnpinCLI(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	m.PinCLI("scanner", "claude-v2")
 	err := m.UnpinCLI("scanner")
@@ -97,7 +97,7 @@ func TestUnpinCLI(t *testing.T) {
 }
 
 func TestUnpinCLI_NotFound(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	err := m.UnpinCLI("nonexistent")
 	if err == nil {
 		t.Error("expected error")
@@ -107,7 +107,7 @@ func TestUnpinCLI_NotFound(t *testing.T) {
 func TestUnpinModel(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	m.PinModel("scanner", "opus")
 	err := m.UnpinModel("scanner")
@@ -121,7 +121,7 @@ func TestUnpinModel(t *testing.T) {
 }
 
 func TestUnpinModel_NotFound(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	err := m.UnpinModel("nonexistent")
 	if err == nil {
 		t.Error("expected error")
@@ -129,7 +129,7 @@ func TestUnpinModel_NotFound(t *testing.T) {
 }
 
 func TestGetOutput_NotFound(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	_, err := m.GetOutput("nonexistent", 10)
 	if err == nil {
 		t.Error("expected error")
@@ -139,7 +139,7 @@ func TestGetOutput_NotFound(t *testing.T) {
 func TestGetOutput_WithBuffer(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	// Write some output to the buffer
 	m.mu.Lock()
@@ -160,7 +160,7 @@ func TestGetOutput_WithBuffer(t *testing.T) {
 func TestIsPaused(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	if m.IsPaused("scanner") {
 		t.Error("scanner should not be paused initially")
@@ -173,7 +173,7 @@ func TestIsPaused(t *testing.T) {
 }
 
 func TestIsPaused_NotFound(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	if m.IsPaused("nonexistent") {
 		t.Error("nonexistent agent should return false")
 	}
@@ -182,7 +182,7 @@ func TestIsPaused_NotFound(t *testing.T) {
 func TestTmuxSession(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	session := m.TmuxSession("scanner")
 	if session != "hive-scanner" {
@@ -191,7 +191,7 @@ func TestTmuxSession(t *testing.T) {
 }
 
 func TestTmuxSession_NotFound(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	session := m.TmuxSession("nonexistent")
 	if session != "" {
 		t.Errorf("session = %q, want empty", session)
@@ -201,7 +201,7 @@ func TestTmuxSession_NotFound(t *testing.T) {
 func TestBuildEnvPrefix(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude", Model: "sonnet"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	m.mu.RLock()
 	agent := m.agents["scanner"]
@@ -214,7 +214,7 @@ func TestBuildEnvPrefix(t *testing.T) {
 }
 
 func TestBuildEnvPrefix_EmptyVars(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 
 	agent := &AgentProcess{Name: "test"}
 	prefix := m.buildEnvPrefix(agent)
@@ -227,7 +227,7 @@ func TestBuildEnvPrefix_EmptyVars(t *testing.T) {
 func TestSetModelOverride_Pinned(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude", Model: "sonnet"},
-	}, discardLogger())
+	}, discardLogger(), ProjectContext{})
 
 	m.PinModel("scanner", "opus")
 	err := m.SetModelOverride("scanner", "haiku")

--- a/v2/pkg/agent/manager_test.go
+++ b/v2/pkg/agent/manager_test.go
@@ -84,7 +84,7 @@ func TestNewManager_InitializesAgentsAsStopped(t *testing.T) {
 		"worker":  makeAgentConfig("gemini", "gemini-pro"),
 	}
 
-	m := NewManager(cfgs, discardLogger())
+	m := NewManager(cfgs, discardLogger(), ProjectContext{})
 
 	if len(m.agents) != 2 {
 		t.Fatalf("expected 2 agents, got %d", len(m.agents))
@@ -107,7 +107,7 @@ func TestNewManager_InitializesAgentsAsStopped(t *testing.T) {
 }
 
 func TestNewManager_EmptyAgentMap(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	if len(m.agents) != 0 {
 		t.Fatalf("expected 0 agents, got %d", len(m.agents))
 	}
@@ -117,7 +117,7 @@ func TestNewManager_ConfigPreserved(t *testing.T) {
 	cfg := makeAgentConfig("gemini", "gemini-ultra")
 	cfg.BeadsDir = "/tmp/beads"
 
-	m := NewManager(map[string]config.AgentConfig{"agent1": cfg}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{"agent1": cfg}, discardLogger(), ProjectContext{})
 
 	ap := m.agents["agent1"]
 	if ap.Config.Backend != "gemini" {
@@ -140,7 +140,7 @@ func TestGetStatus_ReturnsCorrectAgent(t *testing.T) {
 		"alpha": makeAgentConfig("claude", "opus"),
 		"beta":  makeAgentConfig("gemini", "pro"),
 	}
-	m := NewManager(cfgs, discardLogger())
+	m := NewManager(cfgs, discardLogger(), ProjectContext{})
 
 	ap, err := m.GetStatus("alpha")
 	if err != nil {
@@ -155,7 +155,7 @@ func TestGetStatus_ReturnsCorrectAgent(t *testing.T) {
 }
 
 func TestGetStatus_UnknownAgentReturnsError(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 
 	_, err := m.GetStatus("nonexistent")
 	if err == nil {
@@ -168,7 +168,7 @@ func TestGetStatus_UnknownAgentReturnsError(t *testing.T) {
 
 func TestGetStatus_ReturnsConsistentSnapshots(t *testing.T) {
 	cfgs := map[string]config.AgentConfig{"a": makeAgentConfig("claude", "haiku")}
-	m := NewManager(cfgs, discardLogger())
+	m := NewManager(cfgs, discardLogger(), ProjectContext{})
 
 	ap1, _ := m.GetStatus("a")
 	ap2, _ := m.GetStatus("a")
@@ -188,7 +188,7 @@ func TestAllStatuses_ReturnsAllAgents(t *testing.T) {
 		"y": makeAgentConfig("gemini", "pro"),
 		"z": makeAgentConfig("goose", ""),
 	}
-	m := NewManager(cfgs, discardLogger())
+	m := NewManager(cfgs, discardLogger(), ProjectContext{})
 
 	all := m.AllStatuses()
 
@@ -204,7 +204,7 @@ func TestAllStatuses_ReturnsAllAgents(t *testing.T) {
 
 func TestAllStatuses_ReturnsCopy(t *testing.T) {
 	cfgs := map[string]config.AgentConfig{"a": makeAgentConfig("claude", "sonnet")}
-	m := NewManager(cfgs, discardLogger())
+	m := NewManager(cfgs, discardLogger(), ProjectContext{})
 
 	all := m.AllStatuses()
 	delete(all, "a")
@@ -216,7 +216,7 @@ func TestAllStatuses_ReturnsCopy(t *testing.T) {
 }
 
 func TestAllStatuses_EmptyManager(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	all := m.AllStatuses()
 	if len(all) != 0 {
 		t.Errorf("expected empty map, got %d entries", len(all))
@@ -349,7 +349,7 @@ func TestAgentEnvVars_EmptyModelAllowed(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestPause_UnknownAgentReturnsError(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	err := m.Pause("ghost")
 	if err == nil {
 		t.Fatal("expected error pausing unknown agent, got nil")
@@ -360,7 +360,7 @@ func TestPause_SetsPausedFlag(t *testing.T) {
 	cfgs := map[string]config.AgentConfig{
 		"worker": makeAgentConfig("claude", "sonnet"),
 	}
-	m := NewManager(cfgs, discardLogger())
+	m := NewManager(cfgs, discardLogger(), ProjectContext{})
 
 	if err := m.Pause("worker"); err != nil {
 		t.Fatalf("Pause() error: %v", err)
@@ -377,7 +377,7 @@ func TestResume_ClearsPausedFlag(t *testing.T) {
 	cfgs := map[string]config.AgentConfig{
 		"worker": makeAgentConfig("claude", "sonnet"),
 	}
-	m := NewManager(cfgs, discardLogger())
+	m := NewManager(cfgs, discardLogger(), ProjectContext{})
 
 	_ = m.Pause("worker")
 	if err := m.Resume(context.Background(), "worker"); err != nil {
@@ -398,7 +398,7 @@ func TestPinCLI_SetsValue(t *testing.T) {
 	cfgs := map[string]config.AgentConfig{
 		"worker": makeAgentConfig("claude", "sonnet"),
 	}
-	m := NewManager(cfgs, discardLogger())
+	m := NewManager(cfgs, discardLogger(), ProjectContext{})
 
 	if err := m.PinCLI("worker", "1.2.3"); err != nil {
 		t.Fatalf("PinCLI() error: %v", err)
@@ -414,7 +414,7 @@ func TestPinModel_SetsValue(t *testing.T) {
 	cfgs := map[string]config.AgentConfig{
 		"worker": makeAgentConfig("claude", "sonnet"),
 	}
-	m := NewManager(cfgs, discardLogger())
+	m := NewManager(cfgs, discardLogger(), ProjectContext{})
 
 	if err := m.PinModel("worker", "opus"); err != nil {
 		t.Fatalf("PinModel() error: %v", err)
@@ -434,7 +434,7 @@ func TestSetModelOverride(t *testing.T) {
 	cfgs := map[string]config.AgentConfig{
 		"worker": makeAgentConfig("claude", "sonnet"),
 	}
-	m := NewManager(cfgs, discardLogger())
+	m := NewManager(cfgs, discardLogger(), ProjectContext{})
 
 	if err := m.SetModelOverride("worker", "opus"); err != nil {
 		t.Fatalf("SetModelOverride() error: %v", err)
@@ -450,7 +450,7 @@ func TestSetBackendOverride(t *testing.T) {
 	cfgs := map[string]config.AgentConfig{
 		"worker": makeAgentConfig("claude", "sonnet"),
 	}
-	m := NewManager(cfgs, discardLogger())
+	m := NewManager(cfgs, discardLogger(), ProjectContext{})
 
 	if err := m.SetBackendOverride("worker", "gemini"); err != nil {
 		t.Fatalf("SetBackendOverride() error: %v", err)
@@ -467,7 +467,7 @@ func TestSetBackendOverride(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestSendKick_UnknownAgentReturnsError(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	err := m.SendKick("nobody", "hello")
 	if err == nil {
 		t.Fatal("expected error for unknown agent, got nil")
@@ -481,7 +481,7 @@ func TestSendKick_NonRunningAgentReturnsError(t *testing.T) {
 	cfgs := map[string]config.AgentConfig{
 		"idle": makeAgentConfig("claude", "haiku"),
 	}
-	m := NewManager(cfgs, discardLogger())
+	m := NewManager(cfgs, discardLogger(), ProjectContext{})
 
 	err := m.SendKick("idle", "wake up")
 	if err == nil {
@@ -497,7 +497,7 @@ func TestSendKick_NonRunningAgentReturnsError(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestStop_UnknownAgentReturnsError(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 	err := m.Stop("ghost")
 	if err == nil {
 		t.Fatal("expected error stopping unknown agent, got nil")
@@ -508,7 +508,7 @@ func TestStop_NonRunningAgentIsNoOp(t *testing.T) {
 	cfgs := map[string]config.AgentConfig{
 		"idle": makeAgentConfig("claude", "haiku"),
 	}
-	m := NewManager(cfgs, discardLogger())
+	m := NewManager(cfgs, discardLogger(), ProjectContext{})
 
 	if err := m.Stop("idle"); err != nil {
 		t.Fatalf("Stop() on non-running agent returned error: %v", err)
@@ -525,7 +525,7 @@ func TestStop_NonRunningAgentIsNoOp(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestStart_UnknownAgentReturnsError(t *testing.T) {
-	m := NewManager(map[string]config.AgentConfig{}, discardLogger())
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
 
 	err := m.Start(context.Background(), "ghost")
 	if err == nil {
@@ -541,7 +541,7 @@ func TestStart_UnknownBackendSetsFailed(t *testing.T) {
 	cfgs := map[string]config.AgentConfig{
 		"bad": makeAgentConfig("not-a-real-backend", ""),
 	}
-	m := NewManager(cfgs, discardLogger())
+	m := NewManager(cfgs, discardLogger(), ProjectContext{})
 
 	_ = m.Start(context.Background(), "bad")
 	ap, err := m.GetStatus("bad")
@@ -562,7 +562,7 @@ func TestConcurrentGetStatus_NoPanic(t *testing.T) {
 		"a": makeAgentConfig("claude", "haiku"),
 		"b": makeAgentConfig("gemini", "pro"),
 	}
-	m := NewManager(cfgs, discardLogger())
+	m := NewManager(cfgs, discardLogger(), ProjectContext{})
 
 	done := make(chan struct{})
 	for i := 0; i < 10; i++ {

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -67,6 +67,15 @@ type ProjectConfig struct {
 	Repos       []string `yaml:"repos"`
 	AIAuthor    string   `yaml:"ai_author"`
 	PrimaryRepo string   `yaml:"primary_repo"`
+	OpenPRs     *bool    `yaml:"open_prs,omitempty"`
+}
+
+// PRsAllowed returns whether agents may open pull requests. Defaults to true.
+func (p *ProjectConfig) PRsAllowed() bool {
+	if p.OpenPRs != nil {
+		return *p.OpenPRs
+	}
+	return true
 }
 
 type PoliciesConfig struct {
@@ -418,6 +427,10 @@ func (c *Config) applyConfigEnv(path string) error {
 	}
 	if v, ok := env["PROJECT_PRIMARY_REPO"]; ok {
 		c.Project.PrimaryRepo = v
+	}
+	if v, ok := env["PROJECT_OPEN_PRS"]; ok {
+		b := v == "true" || v == "1" || v == "yes"
+		c.Project.OpenPRs = &b
 	}
 	if v, ok := env["AGENTS_ENABLED"]; ok {
 		for _, name := range strings.Fields(v) {

--- a/v2/pkg/dashboard/api_coverage_test.go
+++ b/v2/pkg/dashboard/api_coverage_test.go
@@ -95,7 +95,7 @@ func apiServerWithKnowledge(t *testing.T) (*Server, *Dependencies, *httptest.Ser
 	}
 
 	gov := governor.New(cfg.Governor, cfg.Agents, logger)
-	mgr := agent.NewManager(cfg.Agents, logger)
+	mgr := agent.NewManager(cfg.Agents, logger, agent.ProjectContext{})
 
 	layers := []knowledge.LayerConfig{
 		{Type: knowledge.LayerProject, URL: wiki.URL},
@@ -2986,7 +2986,7 @@ func TestHandleAgentConfigGet_CopilotBackend(t *testing.T) {
 		},
 	}
 	gov := governor.New(cfg.Governor, cfg.Agents, logger)
-	mgr := agent.NewManager(cfg.Agents, logger)
+	mgr := agent.NewManager(cfg.Agents, logger, agent.ProjectContext{})
 	deps := &Dependencies{
 		Config:   cfg,
 		AgentMgr: mgr,
@@ -3027,7 +3027,7 @@ func TestHandleAgentConfigGet_CustomLaunchCmd(t *testing.T) {
 		},
 	}
 	gov := governor.New(cfg.Governor, cfg.Agents, logger)
-	mgr := agent.NewManager(cfg.Agents, logger)
+	mgr := agent.NewManager(cfg.Agents, logger, agent.ProjectContext{})
 	deps := &Dependencies{
 		Config:   cfg,
 		AgentMgr: mgr,
@@ -3068,7 +3068,7 @@ func TestHandleAgentConfigGet_DisplayNameAndPauseCadence(t *testing.T) {
 		},
 	}
 	gov := governor.New(cfg.Governor, cfg.Agents, logger)
-	mgr := agent.NewManager(cfg.Agents, logger)
+	mgr := agent.NewManager(cfg.Agents, logger, agent.ProjectContext{})
 	deps := &Dependencies{
 		Config:   cfg,
 		AgentMgr: mgr,
@@ -3222,7 +3222,7 @@ func TestHandleAgentConfigGet_OffCadence(t *testing.T) {
 		},
 	}
 	gov := governor.New(cfg.Governor, cfg.Agents, logger)
-	mgr := agent.NewManager(cfg.Agents, logger)
+	mgr := agent.NewManager(cfg.Agents, logger, agent.ProjectContext{})
 	deps := &Dependencies{
 		Config:   cfg,
 		AgentMgr: mgr,

--- a/v2/pkg/dashboard/api_test.go
+++ b/v2/pkg/dashboard/api_test.go
@@ -43,7 +43,7 @@ func testDeps(t *testing.T) *Dependencies {
 	}
 
 	gov := governor.New(cfg.Governor, cfg.Agents, logger)
-	mgr := agent.NewManager(cfg.Agents, logger)
+	mgr := agent.NewManager(cfg.Agents, logger, agent.ProjectContext{})
 
 	var refreshCalled atomic.Bool
 	var persistCalled atomic.Bool


### PR DESCRIPTION
## Summary
- Agents now receive a `[PROJECT]` preamble in their boot prompt with org, repos, ACMM level, and PR policy — all sourced from the hive config file
- Adds `open_prs` field to `ProjectConfig` so deployments can disable PR creation (e.g. ACMM L2 external contributor mode)
- No more need for hardcoded per-deployment CLAUDE.md files to tell agents which repo to work on

Example boot prompt on the certus instance:
```
[PROJECT] Org: AI-native-Systems-Research | Repos: AI-native-Systems-Research/ai-native-storage-certus | ACMM: L2 (Development) | You MUST NOT open pull requests. Analysis and issues ONLY. [agent:scanner] [BOOT] Read your CLAUDE.md for instructions and begin your first pass.
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/agent/ ./pkg/config/ ./pkg/dashboard/` all pass
- [ ] Deploy to 4.83 (certus) and verify agents receive project context in boot prompt
- [ ] Verify scanner operates on ai-native-storage-certus, not kubestellar/console