### PR TITLE
Fix spacing bounce in active summary and raise Strategy Lab to L4+

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1761,6 +1761,7 @@
         const d = await r.json();
         const el = document.getElementById('oc-summary-scroll');
         if (!el || !d.lines) return;
+        while (d.lines.length > 0 && d.lines[d.lines.length - 1].trim() === '') d.lines.pop();
         const txt = d.lines.join('\n');
         if (el.textContent === txt) return;
         const wasAtBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
@@ -5684,6 +5685,7 @@ function burnAreaChart() {
         lines = _logsData[selected] || ['(no output)'];
       }
 
+      while (lines.length > 0 && lines[lines.length - 1].trim() === '') lines.pop();
       output.textContent = lines.join('\n').replace(/\x1b\[[0-9;]*m/g, '');
       if (follow && follow.checked) {
         output.scrollTop = output.scrollHeight;
@@ -6384,7 +6386,7 @@ function burnAreaChart() {
       const ACMM_TOKENS_MIN_LEVEL = 3;
       const ACMM_BEADS_MIN_LEVEL = 3;
       const ACMM_REPOS_MIN_LEVEL = 2;
-      const ACMM_NOUS_MIN_LEVEL = 2;
+      const ACMM_NOUS_MIN_LEVEL = 4;
       const ACMM_DEBUG_MIN_LEVEL = 3;
       const ACMM_LOGS_MIN_LEVEL = 3;
 


### PR DESCRIPTION
## Summary
- Trim trailing blank lines from tmux pane capture before rendering — the capture sometimes includes an extra blank line, causing the active summary display to bounce between single and double spacing on each poll cycle
- Raise Strategy Lab (Nous) minimum ACMM level from L2 to L4 (Managed) — experimentation features don't belong at the analysis-only development level

## Test plan
- [ ] Deploy to 4.83 (L2) and verify active summary stays single-spaced
- [ ] Verify Strategy Lab section is hidden on L2 dashboard
- [ ] Deploy to 4.78 (L4+) and verify Strategy Lab still appears