### PR TITLE
Rename tester agent to quality everywhere

### DIFF
--- a/v2/deploy/hive.yaml
+++ b/v2/deploy/hive.yaml
@@ -84,17 +84,17 @@ agents:
     restart_strategy: immediate
     launch_cmd: "/usr/bin/copilot --allow-all --model claude-opus-4.6"
     display_name: sec-check
-  tester:
+  quality:
     enabled: true
     backend: copilot
     model: claude-sonnet-4-6
-    beads_dir: /data/beads/tester
+    beads_dir: /data/beads/quality
     clear_on_kick: true
     cli_pinned: true
     stale_timeout: 2400
     restart_strategy: immediate
     launch_cmd: "agent-launch.sh --backend copilot --model claude-sonnet-4-6"
-    display_name: tester
+    display_name: quality
   strategist:
     enabled: true
     backend: copilot
@@ -117,7 +117,7 @@ governor:
       architect: pause
       outreach: pause
       sec-check: 2m
-      tester: pause
+      quality: pause
       strategist: pause
     busy:
       threshold: 16
@@ -127,7 +127,7 @@ governor:
       architect: pause
       outreach: pause
       sec-check: 2m
-      tester: 2h
+      quality: 2h
       strategist: pause
     quiet:
       threshold: 5
@@ -137,7 +137,7 @@ governor:
       architect: pause
       outreach: pause
       sec-check: 2m
-      tester: 45m
+      quality: 45m
       strategist: pause
     idle:
       threshold: 0
@@ -147,7 +147,7 @@ governor:
       architect: 2h
       outreach: 2h
       sec-check: 2m
-      tester: 30m
+      quality: 30m
       strategist: pause
   labels:
     exempt:

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -341,7 +341,7 @@ func (m *Manager) buildBootstrapPrompt(agent *AgentProcess) string {
 		base = fmt.Sprintf("[agent:%s] [BOOT] Read %s for your instructions and begin your first pass.", agent.Name, policyPath)
 	}
 
-	if agent.Name == "tester" {
+	if agent.Name == "quality" {
 		if preamble := m.readCoveragePreamble(); preamble != "" {
 			base = preamble + " " + base
 		}

--- a/v2/pkg/classify/classifier.go
+++ b/v2/pkg/classify/classifier.go
@@ -39,7 +39,7 @@ const (
 	LaneCIMaintainer Lane = "ci-maintainer"
 	LaneArchitect    Lane = "architect"
 	LaneOutreach     Lane = "outreach"
-	LaneTester       Lane = "tester"
+	LaneQuality      Lane = "quality"
 )
 
 type Classification struct {
@@ -59,7 +59,7 @@ var defaultLanes = []LaneConfig{
 	{Name: "architect", Keywords: []string{"rfc", "architecture", "refactor", "redesign", "migration", "breaking change", "protocol", "api design"}},
 	{Name: "ci-maintainer", Keywords: []string{"workflow-failure", "ci-failure", "nightly", "coverage", "regression", "ga4", "analytics"}},
 	{Name: "outreach", Keywords: []string{"adopters", "outreach", "community", "engagement"}},
-	{Name: "tester", Keywords: []string{"test-gap", "test-strategy", "test-coverage", "test-scaffold", "untested", "missing-tests"}},
+	{Name: "quality", Keywords: []string{"test-gap", "test-strategy", "test-coverage", "test-scaffold", "untested", "missing-tests"}},
 }
 
 // configuredLanes holds the active lane configuration. Set via SetLanes().

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -681,10 +681,10 @@ func applyKnownAgentDefaults(name string, agent *AgentConfig) {
 			DetectKeywords: []string{"security", "sec-check", "vulnerability"},
 			BeadRole: "worker", SortOrder: 60, IncludeRepos: true,
 		},
-		"tester": {
-			Emoji: "🧪", Color: "#3498db", Aliases: []string{"te"},
+		"quality": {
+			Emoji: "🧪", Color: "#3498db", Aliases: []string{"te", "qa"},
 			LaneKeywords:   []string{"test-gap", "test-strategy", "test-coverage", "test-scaffold", "untested", "missing-tests"},
-			DetectKeywords: []string{"tester", "test", "coverage"},
+			DetectKeywords: []string{"quality", "tester", "test", "coverage"},
 			BeadRole: "worker", SortOrder: 35, IncludeRepos: true,
 		},
 		"strategist": {

--- a/v2/pkg/config/packs/level-1.yaml
+++ b/v2/pkg/config/packs/level-1.yaml
@@ -9,7 +9,7 @@ governor:
   merge_policy: manual
 agents:
   - name: guide
-    display_name: Guide
+    display_name: guide
     role: guide
     description: >
       Interactive advisor that queries the community knowledge base for

--- a/v2/pkg/config/packs/level-2.yaml
+++ b/v2/pkg/config/packs/level-2.yaml
@@ -45,9 +45,9 @@ agents:
     knowledge_use: >
       Reads project patterns and known issues. Produces findings as knowledge
       entries for the team to review.
-  - name: tester
+  - name: quality
     display_name: Quality
-    role: tester
+    role: quality
     description: >
       Generates test cases for existing code. Focuses on coverage gaps and
       edge cases. All tests require human review before merging.
@@ -57,7 +57,7 @@ agents:
     backend: copilot
     model: claude-sonnet-4-6
     bead_role: worker
-    kick_template: tester-CLAUDE.md
+    kick_template: quality-CLAUDE.md
     include_repos: true
     interactions: "Complements scanner findings with targeted tests. Guide reviews test quality."
     knowledge_use: >

--- a/v2/pkg/config/packs/level-2.yaml
+++ b/v2/pkg/config/packs/level-2.yaml
@@ -9,7 +9,7 @@ governor:
   merge_policy: manual
 agents:
   - name: guide
-    display_name: Guide
+    display_name: guide
     role: guide
     description: >
       Enhanced advisor that reviews PRs on request, flags code without tests,
@@ -27,7 +27,7 @@ agents:
       Reads community wiki and project patterns. Starts contributing review
       insights as knowledge entries.
   - name: scanner
-    display_name: Scanner (Advisory)
+    display_name: scanner (advisory)
     role: scanner
     description: >
       Scans code for issues and suggests fixes, but does NOT create PRs or
@@ -46,7 +46,7 @@ agents:
       Reads project patterns and known issues. Produces findings as knowledge
       entries for the team to review.
   - name: quality
-    display_name: Quality
+    display_name: quality
     role: quality
     description: >
       Generates test cases for existing code. Focuses on coverage gaps and

--- a/v2/pkg/config/packs/level-3.yaml
+++ b/v2/pkg/config/packs/level-3.yaml
@@ -71,9 +71,9 @@ agents:
     knowledge_use: >
       Heavy consumer of architecture decisions and patterns. Produces RFCs
       and design records.
-  - name: tester
+  - name: quality
     display_name: Quality
-    role: tester
+    role: quality
     description: >
       Full TDD enforcement. Coverage ratcheting. Generates integration tests,
       quality gates, and regression suites. Works with scanner findings.
@@ -83,7 +83,7 @@ agents:
     backend: copilot
     model: claude-opus-4-6
     bead_role: worker
-    kick_template: tester-CLAUDE.md
+    kick_template: quality-CLAUDE.md
     include_repos: true
     lane_keywords: [test, coverage, quality, regression]
     interactions: >

--- a/v2/pkg/config/packs/level-3.yaml
+++ b/v2/pkg/config/packs/level-3.yaml
@@ -9,7 +9,7 @@ governor:
   merge_policy: CI must pass (merge-gate.sh)
 agents:
   - name: scanner
-    display_name: Scanner
+    display_name: scanner
     role: scanner
     description: >
       Triages issues, creates fix PRs for simple bugs, and opens issues when
@@ -30,7 +30,7 @@ agents:
       Reads known patterns, past fixes, and regression history. Produces fix
       records and triage decisions.
   - name: ci-maintainer
-    display_name: CI Maintainer
+    display_name: ci-maintainer
     role: ci-maintainer
     description: >
       Monitors CI health, nightly tests, and coverage trends. Post-merge state
@@ -51,7 +51,7 @@ agents:
       Reads CI patterns and past failures. Produces CI health reports and
       workflow optimization insights.
   - name: architect
-    display_name: Architect
+    display_name: architect
     role: architect
     description: >
       RFCs for cross-cutting changes. Activated when scanner transfers complex
@@ -72,7 +72,7 @@ agents:
       Heavy consumer of architecture decisions and patterns. Produces RFCs
       and design records.
   - name: quality
-    display_name: Quality
+    display_name: quality
     role: quality
     description: >
       Full TDD enforcement. Coverage ratcheting. Generates integration tests,
@@ -93,7 +93,7 @@ agents:
       Reads test patterns, coverage rules, regressions. Produces test coverage
       reports and quality gate records.
   - name: guide
-    display_name: Guide
+    display_name: guide
     role: guide
     description: >
       Enhanced advisor that reviews PRs on request, flags code without tests,

--- a/v2/pkg/config/packs/level-4.yaml
+++ b/v2/pkg/config/packs/level-4.yaml
@@ -44,7 +44,7 @@ agents:
     include_repos: true
     lane_keywords: [bug, triage, fix, issue]
     interactions: >
-      Creates PRs that tester validates. Transfers complex issues to architect.
+      Creates PRs that quality validates. Transfers complex issues to architect.
       Reports to supervisor.
     knowledge_use: >
       Reads full project history, known regressions, and fix patterns. Produces
@@ -65,14 +65,14 @@ agents:
     include_repos: true
     lane_keywords: [ci, build, pipeline, workflow, dependency]
     interactions: >
-      Coordinates with tester on coverage gates. Reports pipeline health
+      Coordinates with quality on coverage gates. Reports pipeline health
       to supervisor.
     knowledge_use: >
       Reads CI history and optimization patterns. Produces workflow health
       reports.
-  - name: tester
+  - name: quality
     display_name: Tester
-    role: tester
+    role: quality
     description: >
       Full TDD enforcement with coverage ratcheting. Generates tests for new
       code and validates scanner PRs.
@@ -82,7 +82,7 @@ agents:
     backend: copilot
     model: claude-sonnet-4-6
     bead_role: worker
-    kick_template: tester-CLAUDE.md
+    kick_template: quality-CLAUDE.md
     include_repos: true
     lane_keywords: [test, coverage, tdd, quality]
     interactions: >

--- a/v2/pkg/config/packs/level-4.yaml
+++ b/v2/pkg/config/packs/level-4.yaml
@@ -9,7 +9,7 @@ governor:
   merge_policy: CI + coverage gate (90%+)
 agents:
   - name: supervisor
-    display_name: Supervisor
+    display_name: supervisor
     role: supervisor
     description: >
       Agent health monitoring, sweep analysis, and escalation. Watches all
@@ -29,7 +29,7 @@ agents:
       Reads agent health history and operational patterns. Produces sweep
       reports and health assessments.
   - name: scanner
-    display_name: Scanner
+    display_name: scanner
     role: scanner
     description: >
       Full triage and fix capability. Parallel dispatch with 30-minute SLA
@@ -50,7 +50,7 @@ agents:
       Reads full project history, known regressions, and fix patterns. Produces
       fix records and triage decisions.
   - name: ci-maintainer
-    display_name: CI Maintainer
+    display_name: ci-maintainer
     role: ci-maintainer
     description: >
       Full CI pipeline ownership. Nightly E2E monitoring. Dependency updates
@@ -71,7 +71,7 @@ agents:
       Reads CI history and optimization patterns. Produces workflow health
       reports.
   - name: quality
-    display_name: Tester
+    display_name: quality
     role: quality
     description: >
       Full TDD enforcement with coverage ratcheting. Generates tests for new
@@ -92,7 +92,7 @@ agents:
       Reads test patterns and coverage history. Produces coverage reports
       and test strategy insights.
   - name: architect
-    display_name: Architect
+    display_name: architect
     role: architect
     description: >
       Active architecture agent. RFCs, refactors, and new features. Proactively
@@ -113,7 +113,7 @@ agents:
       Heavy consumer and producer of architecture decisions, patterns, and
       design records.
   - name: outreach
-    display_name: Outreach
+    display_name: outreach
     role: outreach
     description: >
       Community engagement, ADOPTERS tracking, and ecosystem missions.
@@ -133,7 +133,7 @@ agents:
       Reads community patterns and adoption history. Produces outreach
       reports and engagement insights.
   - name: sec-check
-    display_name: Security
+    display_name: security
     role: sec-check
     description: >
       Security scanning, dependency audit, and vulnerability monitoring.
@@ -154,7 +154,7 @@ agents:
       Reads vulnerability databases and past security fixes. Produces
       security audit reports.
   - name: strategist
-    display_name: Strategist
+    display_name: strategist
     role: strategist
     description: >
       Strategic planning, roadmap alignment, and cross-agent coordination.
@@ -175,7 +175,7 @@ agents:
       Heavy consumer of all agent knowledge. Produces strategic summaries
       and priority recommendations.
   - name: guide
-    display_name: Guide
+    display_name: guide
     role: guide
     description: >
       Enhanced advisor that reviews PRs on request, flags code without tests,

--- a/v2/pkg/config/packs/level-5.yaml
+++ b/v2/pkg/config/packs/level-5.yaml
@@ -12,7 +12,7 @@ governor:
     merge-gate.sh blocks agent merges. batch-approve.sh for human review.
 agents:
   - name: supervisor
-    display_name: Supervisor
+    display_name: supervisor
     role: supervisor
     description: >
       Agent health monitoring and sweep analysis. Same as L4.
@@ -29,7 +29,7 @@ agents:
     knowledge_use: >
       Reads agent health history. Produces sweep reports.
   - name: scanner
-    display_name: Scanner
+    display_name: scanner
     role: scanner
     description: >
       Opens issues and PRs but does NOT merge. All PRs get 'hold' label
@@ -48,7 +48,7 @@ agents:
     knowledge_use: >
       Same as L4. Full project history access.
   - name: ci-maintainer
-    display_name: CI Maintainer
+    display_name: ci-maintainer
     role: ci-maintainer
     description: >
       Same as L4. CI changes are low-risk and don't need hold gating.
@@ -66,7 +66,7 @@ agents:
     knowledge_use: >
       Same as L4.
   - name: quality
-    display_name: Tester
+    display_name: quality
     role: quality
     description: >
       Same as L4. Tests and validates but does not approve merges.
@@ -84,7 +84,7 @@ agents:
     knowledge_use: >
       Same as L4.
   - name: architect
-    display_name: Architect
+    display_name: architect
     role: architect
     description: >
       Same as L4. RFCs are advisory by nature and don't need hold gating.
@@ -102,7 +102,7 @@ agents:
     knowledge_use: >
       Same as L4.
   - name: outreach
-    display_name: Outreach
+    display_name: outreach
     role: outreach
     description: >
       Proposes outreach but does NOT file external issues/PRs without
@@ -121,7 +121,7 @@ agents:
     knowledge_use: >
       Same as L4.
   - name: sec-check
-    display_name: Security
+    display_name: security
     role: sec-check
     description: >
       Enhanced security scanning with CVE monitoring. Critical findings
@@ -140,7 +140,7 @@ agents:
     knowledge_use: >
       Same as L4.
   - name: strategist
-    display_name: Strategist
+    display_name: strategist
     role: strategist
     description: >
       Same as L4.
@@ -158,7 +158,7 @@ agents:
     knowledge_use: >
       Same as L4.
   - name: guide
-    display_name: Guide
+    display_name: guide
     role: guide
     description: >
       Enhanced advisor that reviews PRs on request, flags code without tests,

--- a/v2/pkg/config/packs/level-5.yaml
+++ b/v2/pkg/config/packs/level-5.yaml
@@ -65,9 +65,9 @@ agents:
       Same as L4.
     knowledge_use: >
       Same as L4.
-  - name: tester
+  - name: quality
     display_name: Tester
-    role: tester
+    role: quality
     description: >
       Same as L4. Tests and validates but does not approve merges.
     emoji: "🧪"
@@ -76,7 +76,7 @@ agents:
     backend: copilot
     model: claude-sonnet-4-6
     bead_role: worker
-    kick_template: tester-CLAUDE.md
+    kick_template: quality-CLAUDE.md
     include_repos: true
     lane_keywords: [test, coverage, tdd, quality]
     interactions: >

--- a/v2/pkg/config/packs/level-6.yaml
+++ b/v2/pkg/config/packs/level-6.yaml
@@ -67,9 +67,9 @@ agents:
       Owns deploy pipeline. Coordinates rollbacks with supervisor.
     knowledge_use: >
       Full CI history. Produces deploy reports and rollback records.
-  - name: tester
+  - name: quality
     display_name: Tester
-    role: tester
+    role: quality
     description: >
       Full TDD with auto-approve when coverage gates pass.
     emoji: "🧪"
@@ -78,7 +78,7 @@ agents:
     backend: copilot
     model: claude-sonnet-4-6
     bead_role: worker
-    kick_template: tester-CLAUDE.md
+    kick_template: quality-CLAUDE.md
     include_repos: true
     lane_keywords: [test, coverage, tdd, quality]
     interactions: >

--- a/v2/pkg/config/packs/level-6.yaml
+++ b/v2/pkg/config/packs/level-6.yaml
@@ -11,7 +11,7 @@ governor:
     rollback.sh for self-healing on deploy failure.
 agents:
   - name: supervisor
-    display_name: Supervisor
+    display_name: supervisor
     role: supervisor
     description: >
       Full autonomous oversight. Self-healing: restarts stalled agents,
@@ -31,7 +31,7 @@ agents:
       Reads agent health history. Produces sweep reports and self-healing
       action logs.
   - name: scanner
-    display_name: Scanner
+    display_name: scanner
     role: scanner
     description: >
       Merges PRs when CI passes. No hold. Full SLA enforcement with
@@ -50,7 +50,7 @@ agents:
     knowledge_use: >
       Full access to all project knowledge.
   - name: ci-maintainer
-    display_name: CI Maintainer
+    display_name: ci-maintainer
     role: ci-maintainer
     description: >
       Full CI pipeline ownership with auto-deploy integration.
@@ -68,7 +68,7 @@ agents:
     knowledge_use: >
       Full CI history. Produces deploy reports and rollback records.
   - name: quality
-    display_name: Tester
+    display_name: quality
     role: quality
     description: >
       Full TDD with auto-approve when coverage gates pass.
@@ -86,7 +86,7 @@ agents:
     knowledge_use: >
       Full test history access.
   - name: architect
-    display_name: Architect
+    display_name: architect
     role: architect
     description: >
       Full autonomous architecture. Implements RFCs without waiting for
@@ -105,7 +105,7 @@ agents:
     knowledge_use: >
       Full architecture knowledge access.
   - name: outreach
-    display_name: Outreach
+    display_name: outreach
     role: outreach
     description: >
       Full autonomous outreach. Files issues on partner projects and
@@ -124,7 +124,7 @@ agents:
     knowledge_use: >
       Full community knowledge access.
   - name: sec-check
-    display_name: Security
+    display_name: security
     role: sec-check
     description: >
       Full autonomous security scanning with auto-patch for known CVEs.
@@ -142,7 +142,7 @@ agents:
     knowledge_use: >
       Full security knowledge access.
   - name: strategist
-    display_name: Strategist
+    display_name: strategist
     role: strategist
     description: >
       Full autonomous strategic planning with roadmap execution.
@@ -160,7 +160,7 @@ agents:
     knowledge_use: >
       Full cross-agent knowledge synthesis.
   - name: guide
-    display_name: Guide
+    display_name: guide
     role: guide
     description: >
       Enhanced advisor that reviews PRs on request, flags code without tests,

--- a/v2/pkg/discord/bot.go
+++ b/v2/pkg/discord/bot.go
@@ -48,7 +48,7 @@ var aliases = map[string]string{
 	"k": "kick", "p": "pause", "r": "resume",
 	"sc": "scanner", "ar": "architect", "ou": "outreach",
 	"su": "supervisor", "ci": "ci-maintainer", "se": "sec-check",
-	"sg": "strategist", "te": "tester",
+	"sg": "strategist", "te": "quality", "qa": "quality",
 }
 
 // SetAgentIdentities rebuilds agentIdentities from config at startup.

--- a/v2/pkg/discord/bot_coverage_test.go
+++ b/v2/pkg/discord/bot_coverage_test.go
@@ -60,7 +60,7 @@ func TestResolveAlias_KnownAliases(t *testing.T) {
 		{"ci", "ci-maintainer"},
 		{"se", "sec-check"},
 		{"sg", "strategist"},
-		{"te", "tester"},
+		{"te", "quality"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
@@ -84,7 +84,7 @@ func TestResolveAlias_NotAnAlias(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestGetIdentity_KnownAgents(t *testing.T) {
-	known := []string{"scanner", "ci-maintainer", "architect", "outreach", "supervisor", "sec-check", "strategist", "tester", "governor", "pipeline"}
+	known := []string{"scanner", "ci-maintainer", "architect", "outreach", "supervisor", "sec-check", "strategist", "quality", "governor", "pipeline"}
 	for _, name := range known {
 		id := getIdentity(name)
 		if id.Emoji == "" {

--- a/v2/pkg/policies/defaults/quality-CLAUDE.md
+++ b/v2/pkg/policies/defaults/quality-CLAUDE.md
@@ -1,6 +1,6 @@
-# Tester Agent Policy (Default Template)
+# Quality Agent Policy (Default Template)
 
-You are the **tester** agent in a Hive instance. Your job is to strategically build test coverage from its current level toward the target (91%+).
+You are the **quality** agent in a Hive instance. Your job is to strategically build test coverage from its current level toward the target (91%+).
 
 ## Rules
 

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -258,7 +258,7 @@ func (s *Scheduler) buildAgentMessage(agentName string, issues []github.Issue, a
 		return s.buildCIMaintainerMessage(actionable)
 	case "supervisor":
 		return s.buildSupervisorMessage(actionable)
-	case "tester":
+	case "quality":
 		return s.buildTesterMessage(issues, actionable)
 	case "architect":
 		return s.buildArchitectMessage(issues, actionable)
@@ -415,7 +415,7 @@ func (s *Scheduler) buildTesterMessage(issues []github.Issue, actionable *github
 
 	b.WriteString(fmt.Sprintf("COVERAGE TARGET: %.0f%%\n", defaultCoverageTargetPct))
 
-	testerIssues := filterByLane(issues, "tester")
+	testerIssues := filterByLane(issues, "quality")
 	if len(testerIssues) > 0 {
 		b.WriteString(fmt.Sprintf("\nTEST-RELATED ISSUES (%d):\n", len(testerIssues)))
 		shown := 0

--- a/v2/pkg/scheduler/scheduler_coverage_test.go
+++ b/v2/pkg/scheduler/scheduler_coverage_test.go
@@ -371,7 +371,7 @@ func TestBuildTesterMessage_NoIssues(t *testing.T) {
 func TestBuildTesterMessage_WithIssues(t *testing.T) {
 	s := newScheduler()
 	issues := []github.Issue{
-		{Repo: "r", Number: 1, Title: "test gap", Lane: "tester", Labels: []string{"test"}},
+		{Repo: "r", Number: 1, Title: "test gap", Lane: "quality", Labels: []string{"test"}},
 	}
 	actionable := &github.ActionableResult{
 		Issues: github.IssueResult{Count: 1, Items: issues},
@@ -386,7 +386,7 @@ func TestBuildTesterMessage_TruncatesTitle(t *testing.T) {
 	s := newScheduler()
 	longTitle := strings.Repeat("z", 80)
 	issues := []github.Issue{
-		{Repo: "r", Number: 1, Title: longTitle, Lane: "tester", Labels: []string{}},
+		{Repo: "r", Number: 1, Title: longTitle, Lane: "quality", Labels: []string{}},
 	}
 	actionable := &github.ActionableResult{
 		Issues: github.IssueResult{Count: 1, Items: issues},

--- a/v2/pkg/scheduler/scheduler_extra_test.go
+++ b/v2/pkg/scheduler/scheduler_extra_test.go
@@ -22,7 +22,7 @@ func extraActionable() *github.ActionableResult {
 			Items: []github.Issue{
 				{Repo: "repo1", Number: 1, Title: "bug fix", Labels: []string{"kind/bug"}, Lane: "scanner", AgeMinutes: 120, ComplexityTier: "simple", ModelRec: "haiku"},
 				{Repo: "repo1", Number: 2, Title: "refactor needed", Labels: []string{"kind/task"}, Lane: "architect", AgeMinutes: 60},
-				{Repo: "repo1", Number: 3, Title: "test coverage gap", Labels: []string{"kind/task"}, Lane: "tester", AgeMinutes: 45},
+				{Repo: "repo1", Number: 3, Title: "test coverage gap", Labels: []string{"kind/task"}, Lane: "quality", AgeMinutes: 45},
 			},
 		},
 		PRs: github.PRResult{
@@ -83,7 +83,7 @@ func TestBuildKickMessages_Supervisor_Extra(t *testing.T) {
 func TestBuildKickMessages_Tester(t *testing.T) {
 	s := newScheduler()
 	actionable := extraActionable()
-	msgs := s.BuildKickMessages(actionable, []string{"tester"})
+	msgs := s.BuildKickMessages(actionable, []string{"quality"})
 	if len(msgs) != 1 {
 		t.Fatalf("expected 1 message, got %d", len(msgs))
 	}
@@ -149,7 +149,7 @@ func TestFilterByLane_Extra(t *testing.T) {
 		{Number: 1, Lane: "scanner"},
 		{Number: 2, Lane: "architect"},
 		{Number: 3, Lane: ""}, // empty lane matches all
-		{Number: 4, Lane: "tester"},
+		{Number: 4, Lane: "quality"},
 	}
 
 	result := filterByLane(issues, "scanner")

--- a/v2/pkg/tokens/collector.go
+++ b/v2/pkg/tokens/collector.go
@@ -372,7 +372,7 @@ func ConfiguredAgentNames() []string {
 	if len(configuredAgentNames) > 0 {
 		return configuredAgentNames
 	}
-	return []string{"scanner", "ci-maintainer", "architect", "outreach", "supervisor", "sec-check", "tester", "analyst"}
+	return []string{"scanner", "ci-maintainer", "architect", "outreach", "supervisor", "sec-check", "quality", "analyst"}
 }
 
 var defaultDetectKeywords = map[string][]string{

--- a/v2/pkg/tokens/tokens_coverage_test.go
+++ b/v2/pkg/tokens/tokens_coverage_test.go
@@ -283,7 +283,7 @@ func TestEnhancedAgentDetector_NoMatch(t *testing.T) {
 }
 
 func TestEnhancedAgentDetector_AllAgents(t *testing.T) {
-	agents := []string{"scanner", "ci-maintainer", "architect", "outreach", "supervisor", "sec-check", "tester", "analyst"}
+	agents := []string{"scanner", "ci-maintainer", "architect", "outreach", "supervisor", "sec-check", "quality", "analyst"}
 	for _, agent := range agents {
 		detect := EnhancedAgentDetector("/path/to/"+agent+"/dir", nil)
 		result := detect("anything")

--- a/v2/policies/quality-CLAUDE.md
+++ b/v2/policies/quality-CLAUDE.md
@@ -1,6 +1,6 @@
-# Tester Agent Policy (Default Template)
+# Quality Agent Policy (Default Template)
 
-You are the **tester** agent in a Hive instance. Your job is to strategically build test coverage from its current level toward the target (91%+).
+You are the **quality** agent in a Hive instance. Your job is to strategically build test coverage from its current level toward the target (91%+).
 
 ## Rules
 


### PR DESCRIPTION
## Summary
- Renames the `tester` agent to `quality` across all code, configs, pack definitions, policies, tests, and deploy configs
- Policy files renamed: `tester-CLAUDE.md` → `quality-CLAUDE.md`
- All 5 ACMM level packs updated (L2-L6)
- Governor cadence tables updated
- Go source: classifier lane, scheduler, manager coverage preamble, token collector, discord bot aliases
- Deploy config: agent key, beads dir, display name, governor references
- All test files updated
- Keeps "tester" as a detection keyword for backward compatibility

## Context
User requested the agent be called "quality" everywhere, not just in display_name. The display_name was already "Quality" in most packs, but the internal name was still "tester".

## Test plan
- [ ] Verify Go compilation passes
- [ ] Verify all tests pass with renamed agent
- [ ] Confirm dashboard shows "quality" agent after deploy