### PR TITLE
fix: skip agent card DOM rebuild when content unchanged

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2893,15 +2893,17 @@
           </div>
         </div>`;
       });
-      el.innerHTML = cards.join('');
-      // Restore saved input values and focus
-      for (const [id, val] of Object.entries(savedInputs)) {
-        const inp = document.getElementById(id);
-        if (inp) inp.value = val;
-      }
-      if (focusedId) {
-        const prev = document.getElementById(focusedId);
-        if (prev) prev.focus();
+      const html = cards.join('');
+      if (el.innerHTML !== html) {
+        el.innerHTML = html;
+        for (const [id, val] of Object.entries(savedInputs)) {
+          const inp = document.getElementById(id);
+          if (inp) inp.value = val;
+        }
+        if (focusedId) {
+          const prev = document.getElementById(focusedId);
+          if (prev) prev.focus();
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- `renderAgents()` was unconditionally replacing `#agents` innerHTML every SSE cycle (~5s), causing visual reflow/bounce even when agent data hadn't changed
- Root cause confirmed via CDP MutationObserver — DOM was being torn down and rebuilt identically every cycle
- Guards innerHTML assignment with content equality check; input save/restore only runs when DOM actually changes
- `setIfChanged`-style pattern already used elsewhere in the dashboard

## Test plan
- [ ] Open dashboard with agents running — verify no visual bounce/jump on agent cards
- [ ] Open dashboard with stopped agents — verify cards remain stable
- [ ] Verify custom prompt inputs retain values across SSE cycles
- [ ] Verify focus is preserved when editing a prompt input