### PR TITLE
fix: filter cadence matrix by ACMM pack, hide Tokens at L2

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3025,9 +3025,11 @@
     function renderCadenceMatrix(matrix, currentMode, modes) {
       if (!matrix || !matrix.length) return '';
       const agents = window._lastAgents || [];
+      const packAgentNames = (window._lastStatus && window._lastStatus.acmmPackAgents) || null;
+      const packSet = packAgentNames ? new Set(packAgentNames) : null;
       const { sorted: sortedAgents } = _sortAgentsBySidebar(agents);
       const sidebarOrder = sortedAgents.map(a => a.name);
-      const matrixNames = matrix.map(r => r.agent);
+      const matrixNames = matrix.map(r => r.agent).filter(n => !packSet || packSet.has(n));
       const agentOrder = sidebarOrder.filter(n => matrixNames.includes(n));
       for (const n of matrixNames) { if (!agentOrder.includes(n)) agentOrder.push(n); }
       const rows = agentOrder.map(aname => {
@@ -6415,6 +6417,7 @@ function burnAreaChart() {
         }
         sidebarItems.forEach(item => {
           const section = item.getAttribute('data-section') || '';
+          if (section === 'token-panel' && level < ACMM_TOKENS_MIN_LEVEL) hide(item);
           if (section === 'repos-section' && level < ACMM_REPOS_MIN_LEVEL) hide(item);
           if (section === 'beads-section' && level < ACMM_BEADS_MIN_LEVEL) hide(item);
           if (section === 'nous-section' && level < ACMM_NOUS_MIN_LEVEL) hide(item);


### PR DESCRIPTION
## Summary
- Cadence matrix now only shows agents in the current ACMM pack (filters out non-pack agents like reviewer at L2)
- Hides Tokens sidebar nav item when below `ACMM_TOKENS_MIN_LEVEL` (L3) — previously only the panel was hidden but the nav link remained visible

## Test plan
- [ ] At L2: cadence matrix shows only pack agents (guide, scanner, supervisor, quality) — no reviewer
- [ ] At L2: Tokens link hidden in sidebar Control section
- [ ] At L3+: all agents and Tokens visible as before