### PR TITLE
feat: ACMM enforcement in gh-wrapper + agent identity

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -84,6 +84,33 @@ if { [ "$subcmd" = "issue" ] || [ "$subcmd" = "pr" ]; } && [ "$action" = "list" 
   exit 1
 fi
 
+# ── ACMM level enforcement ──
+# At L1/L2: block issue create, pr create, pr merge.
+# Exception: commenting on the advisory issue is always allowed.
+ACMM_LEVEL="${HIVE_ACMM_LEVEL:-0}"
+ADVISORY_ISSUE="${HIVE_ADVISORY_ISSUE:-}"
+
+if [ "$ACMM_LEVEL" -gt 0 ] && [ "$ACMM_LEVEL" -lt 3 ]; then
+  if [ "$subcmd" = "issue" ] && [ "$action" = "create" ]; then
+    echo "⛔ BLOCKED: gh issue create is not allowed at ACMM L${ACMM_LEVEL}." >&2
+    echo "L1/L2 agents are advisory-only. Findings go to the advisory issue or dashboard." >&2
+    exit 1
+  fi
+  if [ "$subcmd" = "pr" ] && { [ "$action" = "create" ] || [ "$action" = "merge" ]; }; then
+    echo "⛔ BLOCKED: gh pr ${action} is not allowed at ACMM L${ACMM_LEVEL}." >&2
+    echo "L1/L2 agents are advisory-only. No PRs allowed." >&2
+    exit 1
+  fi
+fi
+# At L3: block pr merge (issues and PRs allowed, merging is manual)
+if [ "$ACMM_LEVEL" -eq 3 ]; then
+  if [ "$subcmd" = "pr" ] && [ "$action" = "merge" ]; then
+    echo "⛔ BLOCKED: gh pr merge is not allowed at ACMM L3." >&2
+    echo "L3 agents can create PRs but merging requires human approval." >&2
+    exit 1
+  fi
+fi
+
 # Enforce merge gate — only PRs in merge-eligible.json can be merged
 MERGE_ELIGIBLE_FILE="/var/run/hive-metrics/merge-eligible.json"
 if [ "$subcmd" = "pr" ] && [ "$action" = "merge" ]; then
@@ -164,6 +191,47 @@ fi
 # HIVE_ID is the unique hive instance ID (e.g. "hive-bold-fox").
 AGENT_NAME="${HIVE_AGENT:-$AGENT_ID}"
 HIVE_INSTANCE_ID="${HIVE_ID:-}"
+HIVE_SHA="${HIVE_SHA:-$(git rev-parse --short HEAD 2>/dev/null || echo 'unknown')}"
+
+# Build identity footer for injection into issue/comment bodies.
+_identity_footer() {
+  local parts="---\n🐝 **Hive Agent**:"
+  [[ -n "$AGENT_NAME" ]] && parts="${parts} \`${AGENT_NAME}\`"
+  [[ -n "$HIVE_INSTANCE_ID" ]] && parts="${parts} | **Instance:** \`${HIVE_INSTANCE_ID}\`"
+  parts="${parts} | **SHA:** \`${HIVE_SHA}\`"
+  echo -e "$parts"
+}
+
+# Inject identity footer into --body argument if present, otherwise append --body.
+_inject_identity() {
+  local footer
+  footer="$(_identity_footer)"
+  local new_args=()
+  local body_found=false
+  local i=0
+  while [ $i -lt ${#args[@]} ]; do
+    if [ "${args[$i]}" = "--body" ] && [ $((i+1)) -lt ${#args[@]} ]; then
+      new_args+=("--body")
+      new_args+=("${args[$((i+1))]}
+${footer}")
+      body_found=true
+      i=$((i+2))
+    elif [[ "${args[$i]}" == --body=* ]]; then
+      local body_val="${args[$i]#--body=}"
+      new_args+=("--body=${body_val}
+${footer}")
+      body_found=true
+      i=$((i+1))
+    else
+      new_args+=("${args[$i]}")
+      i=$((i+1))
+    fi
+  done
+  if ! $body_found; then
+    new_args+=("--body" "${footer}")
+  fi
+  args=("${new_args[@]}")
+}
 
 if [[ -n "$AGENT_NAME" ]]; then
   LABELS_CSV="agent/${AGENT_NAME}"
@@ -211,7 +279,8 @@ if [[ -n "$AGENT_NAME" ]]; then
   case "$subcmd/$action" in
     issue/create|pr/create)
       _ensure_labels
-      exec "$REAL_GH" "$@" --label "$LABELS_CSV"
+      _inject_identity
+      exec "$REAL_GH" "${args[@]}" --label "$LABELS_CSV"
       ;;
     issue/edit|pr/edit)
       _ensure_labels
@@ -229,8 +298,9 @@ if [[ -n "$AGENT_NAME" ]]; then
       ;;
     issue/comment|pr/comment|pr/review)
       _ensure_labels
+      _inject_identity
       _extract_item
-      "$REAL_GH" "$@"
+      "$REAL_GH" "${args[@]}"
       exit_code=$?
       if [[ $exit_code -eq 0 && -n "$item_num" ]]; then
         local_repo=""

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -156,7 +156,7 @@ func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
 	}
 
 	cmd := exec.Command("tmux", "new-session", "-d", "-s", agent.tmuxSession, "-c", agentDir)
-	cmd.Env = append(os.Environ(), agentEnvVars(agent)...)
+	cmd.Env = append(os.Environ(), m.agentEnvVars(agent)...)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("creating tmux session for %s: %w", agent.Name, err)
 	}
@@ -403,7 +403,7 @@ func (m *Manager) readCoveragePreamble() string {
 }
 
 func (m *Manager) buildEnvPrefix(agent *AgentProcess) string {
-	vars := agentEnvVars(agent)
+	vars := m.agentEnvVars(agent)
 	if len(vars) == 0 {
 		return ""
 	}
@@ -755,7 +755,7 @@ func normalizeModelName(model string) string {
 	return model
 }
 
-func agentEnvVars(agent *AgentProcess) []string {
+func (m *Manager) agentEnvVars(agent *AgentProcess) []string {
 	model := agent.Config.Model
 	if agent.ModelOverride != "" {
 		model = agent.ModelOverride
@@ -771,6 +771,13 @@ func agentEnvVars(agent *AgentProcess) []string {
 	}
 	if hiveID := os.Getenv("HIVE_ID"); hiveID != "" {
 		vars = append(vars, fmt.Sprintf("HIVE_ID=%s", hiveID))
+	}
+	vars = append(vars, fmt.Sprintf("HIVE_ACMM_LEVEL=%d", m.project.ACMMLevel))
+	if sha := os.Getenv("HIVE_SHA"); sha != "" {
+		vars = append(vars, fmt.Sprintf("HIVE_SHA=%s", sha))
+	}
+	if advisory := os.Getenv("HIVE_ADVISORY_ISSUE"); advisory != "" {
+		vars = append(vars, fmt.Sprintf("HIVE_ADVISORY_ISSUE=%s", advisory))
 	}
 	return vars
 }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3025,9 +3025,11 @@
     function renderCadenceMatrix(matrix, currentMode, modes) {
       if (!matrix || !matrix.length) return '';
       const agents = window._lastAgents || [];
+      const packAgentNames = (window._lastStatus && window._lastStatus.acmmPackAgents) || null;
+      const packSet = packAgentNames ? new Set(packAgentNames) : null;
       const { sorted: sortedAgents } = _sortAgentsBySidebar(agents);
       const sidebarOrder = sortedAgents.map(a => a.name);
-      const matrixNames = matrix.map(r => r.agent);
+      const matrixNames = matrix.map(r => r.agent).filter(n => !packSet || packSet.has(n));
       const agentOrder = sidebarOrder.filter(n => matrixNames.includes(n));
       for (const n of matrixNames) { if (!agentOrder.includes(n)) agentOrder.push(n); }
       const rows = agentOrder.map(aname => {
@@ -6415,6 +6417,7 @@ function burnAreaChart() {
         }
         sidebarItems.forEach(item => {
           const section = item.getAttribute('data-section') || '';
+          if (section === 'token-panel' && level < ACMM_TOKENS_MIN_LEVEL) hide(item);
           if (section === 'repos-section' && level < ACMM_REPOS_MIN_LEVEL) hide(item);
           if (section === 'beads-section' && level < ACMM_BEADS_MIN_LEVEL) hide(item);
           if (section === 'nous-section' && level < ACMM_NOUS_MIN_LEVEL) hide(item);


### PR DESCRIPTION
## Summary
- **gh-wrapper ACMM enforcement**: Blocks `gh issue create` and `gh pr create` at L1/L2 (advisory-only levels). Blocks `gh pr merge` at L3 (human approval required). Advisory issue comments always allowed.
- **Agent identity injection**: Every issue body and comment gets a footer with agent name, hive instance ID, and commit SHA
- **Env vars**: Go binary now passes `HIVE_ACMM_LEVEL`, `HIVE_SHA`, `HIVE_ADVISORY_ISSUE` to agent tmux sessions

## Test plan
- [ ] At L2: agent running `gh issue create` gets blocked with clear message
- [ ] At L2: agent running `gh issue comment` succeeds (advisory issue)
- [ ] At L3: `gh issue create` and `gh pr create` succeed; `gh pr merge` blocked
- [ ] At L4+: all commands succeed
- [ ] Issue bodies include agent identity footer
- [ ] Comments include agent identity footer