### PR TITLE
feat: advisory issue for L1/L2 agent findings

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -93,7 +93,11 @@ ADVISORY_ISSUE="${HIVE_ADVISORY_ISSUE:-}"
 if [ "$ACMM_LEVEL" -gt 0 ] && [ "$ACMM_LEVEL" -lt 3 ]; then
   if [ "$subcmd" = "issue" ] && [ "$action" = "create" ]; then
     echo "⛔ BLOCKED: gh issue create is not allowed at ACMM L${ACMM_LEVEL}." >&2
-    echo "L1/L2 agents are advisory-only. Findings go to the advisory issue or dashboard." >&2
+    echo "L1/L2 agents are advisory-only." >&2
+    if [ -n "$ADVISORY_ISSUE" ]; then
+      echo "Post findings as a comment on the advisory issue instead:" >&2
+      echo "  gh issue comment ${ADVISORY_ISSUE} --body 'your findings here'" >&2
+    fi
     exit 1
   fi
   if [ "$subcmd" = "pr" ] && { [ "$action" = "create" ] || [ "$action" = "merge" ]; }; then

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -156,6 +156,27 @@ func main() {
 	notifier := notify.New(cfg.Notifications, logger)
 	notifier.SetHiveID(cfg.HiveID)
 	acmmLevel := inferACMMLevel(cfg)
+
+	// At L1/L2 (advisory-only), create or find the pinned advisory issue per repo.
+	// Agents can comment on this issue but cannot create new issues.
+	advisoryIssues := map[string]int{}
+	if acmmLevel > 0 && acmmLevel < 3 {
+		primaryRepo := cfg.Project.PrimaryRepo
+		if primaryRepo == "" && len(cfg.Project.Repos) > 0 {
+			primaryRepo = cfg.Project.Repos[0]
+		}
+		if primaryRepo != "" {
+			num, err := ghClient.EnsureAdvisoryIssue(ctx, primaryRepo)
+			if err != nil {
+				logger.Error("failed to ensure advisory issue", "repo", primaryRepo, "error", err)
+			} else {
+				advisoryIssues[primaryRepo] = num
+				os.Setenv("HIVE_ADVISORY_ISSUE", fmt.Sprintf("%d", num))
+				logger.Info("advisory issue ready", "repo", primaryRepo, "number", num)
+			}
+		}
+	}
+
 	projectCtx := agent.ProjectContext{
 		Org:        cfg.Project.Org,
 		Repos:      cfg.Project.Repos,

--- a/v2/pkg/github/advisory.go
+++ b/v2/pkg/github/advisory.go
@@ -1,0 +1,90 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+const (
+	advisoryTitle     = "🐝 Hive Advisory Report"
+	advisoryLabelName = "hive/advisory"
+	advisoryLabelDesc = "Pinned advisory report from Hive agents"
+	advisoryLabelClr  = "0e8a16"
+)
+
+// EnsureAdvisoryIssue finds or creates the pinned advisory issue for a repo.
+// Returns the issue number.
+func (c *Client) EnsureAdvisoryIssue(ctx context.Context, repo string) (int, error) {
+	owner := c.org
+
+	num, err := c.findAdvisoryIssue(ctx, owner, repo)
+	if err != nil {
+		return 0, fmt.Errorf("searching for advisory issue: %w", err)
+	}
+	if num > 0 {
+		c.logger.Info("found existing advisory issue", slog.String("repo", repo), slog.Int("number", num))
+		return num, nil
+	}
+
+	c.logger.Info("creating advisory issue", slog.String("repo", repo))
+
+	_, _, labelErr := c.client.Issues.CreateLabel(ctx, owner, repo, &gh.Label{
+		Name:        gh.Ptr(advisoryLabelName),
+		Description: gh.Ptr(advisoryLabelDesc),
+		Color:       gh.Ptr(advisoryLabelClr),
+	})
+	if labelErr != nil && !strings.Contains(labelErr.Error(), "already_exists") {
+		c.logger.Warn("could not create advisory label", slog.String("error", labelErr.Error()))
+	}
+
+	body := "This issue collects advisory findings from Hive agents.\n\n" +
+		"At ACMM L1/L2, agents are advisory-only — they cannot create issues or PRs. " +
+		"Instead, the governor posts periodic digest comments here summarizing what agents found.\n\n" +
+		"**Do not close this issue.** It is a living document."
+
+	issue, _, err := c.client.Issues.Create(ctx, owner, repo, &gh.IssueRequest{
+		Title:  gh.Ptr(advisoryTitle),
+		Body:   gh.Ptr(body),
+		Labels: &[]string{advisoryLabelName},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("creating advisory issue: %w", err)
+	}
+
+	c.logger.Info("created advisory issue — pin it manually for visibility", slog.String("repo", repo), slog.Int("number", issue.GetNumber()))
+	return issue.GetNumber(), nil
+}
+
+// PostAdvisoryDigest posts a digest comment on the advisory issue.
+func (c *Client) PostAdvisoryDigest(ctx context.Context, repo string, issueNum int, digest string) error {
+	owner := c.org
+	_, _, err := c.client.Issues.CreateComment(ctx, owner, repo, issueNum, &gh.IssueComment{
+		Body: gh.Ptr(digest),
+	})
+	if err != nil {
+		return fmt.Errorf("posting advisory digest to %s#%d: %w", repo, issueNum, err)
+	}
+	return nil
+}
+
+func (c *Client) findAdvisoryIssue(ctx context.Context, owner, repo string) (int, error) {
+	opts := &gh.IssueListByRepoOptions{
+		State:  "open",
+		Labels: []string{advisoryLabelName},
+		ListOptions: gh.ListOptions{PerPage: 5},
+	}
+	issues, _, err := c.client.Issues.ListByRepo(ctx, owner, repo, opts)
+	if err != nil {
+		return 0, err
+	}
+	for _, issue := range issues {
+		if issue.GetTitle() == advisoryTitle {
+			return issue.GetNumber(), nil
+		}
+	}
+	return 0, nil
+}


### PR DESCRIPTION
## Summary
- Governor creates (or finds) a pinned advisory issue per repo at ACMM L1/L2
- Advisory issue labeled `hive/advisory`, stays open as a living document
- `HIVE_ADVISORY_ISSUE` env var passed to agent tmux sessions
- gh-wrapper blocks `gh issue create` at L1/L2 and directs agents to comment on the advisory issue instead
- New `EnsureAdvisoryIssue` and `PostAdvisoryDigest` methods on GitHub client

## Test plan
- [ ] Start hive at L2 — verify advisory issue created on primary repo
- [ ] Restart hive at L2 — verify existing advisory issue found (not duplicated)
- [ ] Agent tries `gh issue create` — verify blocked with advisory issue redirect message
- [ ] Agent tries `gh issue comment <advisory#>` — verify allowed
- [ ] Check HIVE_ADVISORY_ISSUE env var is set in agent tmux sessions