### PR TITLE
fix: ACMM enforcement, advisory issue fallback, display name identity

### DIFF
--- a/bin/agent-launch.sh
+++ b/bin/agent-launch.sh
@@ -34,6 +34,13 @@ unset GH_TOKEN
 # AGENT_SESSION_NAME is set by the supervisor from the agent's .env file.
 export HIVE_AGENT_ID="${AGENT_SESSION_NAME:-unknown}"
 
+# Re-export HIVE_ env vars so child processes (gh, etc.) inherit them.
+# These are set as inline prefixes by the Go binary (e.g. HIVE_ACMM_LEVEL=2 agent-launch.sh ...)
+# and need to be exported for gh-wrapper ACMM enforcement to work.
+for var in HIVE_AGENT HIVE_AGENT_DISPLAY_NAME HIVE_ACMM_LEVEL HIVE_ID HIVE_SHA HIVE_ADVISORY_ISSUE HIVE_GITHUB_TOKEN; do
+  [[ -n "${!var:-}" ]] && export "$var"
+done
+
 # Source the centralized backend/model config
 BACKENDS_CONF="${SCRIPT_DIR}/../config/backends.conf"
 if [[ -f "$BACKENDS_CONF" ]]; then

--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -194,13 +194,14 @@ fi
 # HIVE_AGENT is set by the Go binary (e.g. "scanner").
 # HIVE_ID is the unique hive instance ID (e.g. "hive-bold-fox").
 AGENT_NAME="${HIVE_AGENT:-$AGENT_ID}"
+AGENT_DISPLAY_NAME="${HIVE_AGENT_DISPLAY_NAME:-$AGENT_NAME}"
 HIVE_INSTANCE_ID="${HIVE_ID:-}"
 HIVE_SHA="${HIVE_SHA:-$(git rev-parse --short HEAD 2>/dev/null || echo 'unknown')}"
 
 # Build identity footer for injection into issue/comment bodies.
 _identity_footer() {
   local parts="---\n🐝 **Hive Agent**:"
-  [[ -n "$AGENT_NAME" ]] && parts="${parts} \`${AGENT_NAME}\`"
+  [[ -n "$AGENT_DISPLAY_NAME" ]] && parts="${parts} \`${AGENT_DISPLAY_NAME}\`"
   [[ -n "$HIVE_INSTANCE_ID" ]] && parts="${parts} | **Instance:** \`${HIVE_INSTANCE_ID}\`"
   parts="${parts} | **SHA:** \`${HIVE_SHA}\`"
   echo -e "$parts"
@@ -238,7 +239,7 @@ ${footer}")
 }
 
 if [[ -n "$AGENT_NAME" ]]; then
-  LABELS_CSV="agent/${AGENT_NAME}"
+  LABELS_CSV="agent/${AGENT_DISPLAY_NAME}"
   [[ -n "$HIVE_INSTANCE_ID" ]] && LABELS_CSV="${LABELS_CSV},hive/${HIVE_INSTANCE_ID}"
 
   # Ensure labels exist on the repo (cached per-session to avoid repeated API calls).
@@ -256,7 +257,7 @@ if [[ -n "$AGENT_NAME" ]]; then
     [[ "$repo_flag" = "next" ]] && repo_flag=""
     local rf=""
     [[ -n "$repo_flag" ]] && rf="--repo $repo_flag"
-    "$REAL_GH" label create "agent/${AGENT_NAME}" --description "Work by the ${AGENT_NAME} agent" --color 6f42c1 $rf 2>/dev/null || true
+    "$REAL_GH" label create "agent/${AGENT_DISPLAY_NAME}" --description "Work by the ${AGENT_DISPLAY_NAME} agent" --color 6f42c1 $rf 2>/dev/null || true
     if [[ -n "$HIVE_INSTANCE_ID" ]]; then
       "$REAL_GH" label create "hive/${HIVE_INSTANCE_ID}" --description "Hive instance ${HIVE_INSTANCE_ID}" --color 1d76db $rf 2>/dev/null || true
     fi

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -19,6 +19,7 @@ import (
 
 	"gopkg.in/natefinch/lumberjack.v2"
 
+	"github.com/kubestellar/hive/v2/pkg/advisory"
 	"github.com/kubestellar/hive/v2/pkg/agent"
 	"github.com/kubestellar/hive/v2/pkg/beads"
 	"github.com/kubestellar/hive/v2/pkg/classify"
@@ -176,6 +177,8 @@ func main() {
 			}
 		}
 	}
+
+	advisoryStore := advisory.NewStore()
 
 	projectCtx := agent.ProjectContext{
 		Org:        cfg.Project.Org,
@@ -510,7 +513,7 @@ func main() {
 		return
 	}
 
-	runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, logger)
+	runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, logger)
 	persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
 	dashSrv.MarkReady()
 
@@ -528,7 +531,7 @@ func main() {
 			persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
 			return
 		case <-ticker.C:
-			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, logger)
+			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, logger)
 			persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
 		case <-agentTickCh:
 			govState := gov.GetState()
@@ -553,6 +556,8 @@ func runEvalCycle(
 	metricsCollector *dashboard.MetricsCollector,
 	nousState *dashboard.NousState,
 	lastActionable *atomic.Pointer[github.ActionableResult],
+	advisoryStore *advisory.Store,
+	advisoryIssues map[string]int,
 	logger *slog.Logger,
 ) {
 	actionable, err := ghClient.EnumerateActionable(ctx)
@@ -639,6 +644,9 @@ func runEvalCycle(
 		ctx,
 		metricsCollector,
 	)
+	if d := dashSrv.GetAdvisoryDigest(); d != nil {
+		statusPayload.AdvisoryDigest = d
+	}
 	dashSrv.UpdateStatus(statusPayload)
 
 	if agentStats := dashboard.CollectAgentStats(statusPayload); len(agentStats) > 0 {
@@ -656,6 +664,33 @@ func runEvalCycle(
 		}
 		if err := nousState.RecordSnapshot(govState, actionable, agentsDue, agentStatuses, tokenSummary); err != nil {
 			logger.Warn("failed to record nous snapshot", "error", err)
+		}
+	}
+
+	// Advisory digest: read new agent findings and post to advisory issue.
+	if advisoryStore != nil {
+		findings, err := advisoryStore.ReadNewFindings()
+		if err != nil {
+			logger.Warn("failed to read advisory findings", "error", err)
+		} else if len(findings) > 0 {
+			digest := advisory.BuildDigest(findings, string(govState.Mode))
+			advisoryStore.SetLatestDigest(digest)
+			dashSrv.SetAdvisoryDigest(digest)
+
+			md := advisory.FormatDigestMarkdown(digest)
+			if md != "" {
+				primaryRepo := cfg.Project.PrimaryRepo
+				if primaryRepo == "" && len(cfg.Project.Repos) > 0 {
+					primaryRepo = cfg.Project.Repos[0]
+				}
+				if issueNum, ok := advisoryIssues[primaryRepo]; ok && issueNum > 0 {
+					if err := ghClient.PostAdvisoryDigest(ctx, primaryRepo, issueNum, md); err != nil {
+						logger.Warn("failed to post advisory digest", "repo", primaryRepo, "issue", issueNum, "error", err)
+					} else {
+						logger.Info("posted advisory digest", "repo", primaryRepo, "issue", issueNum, "findings", len(findings))
+					}
+				}
+			}
 		}
 	}
 }

--- a/v2/pkg/advisory/advisory.go
+++ b/v2/pkg/advisory/advisory.go
@@ -1,0 +1,204 @@
+package advisory
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const advisoryDir = "/data/advisory"
+
+// Finding represents a single advisory finding from an agent.
+type Finding struct {
+	Agent     string    `json:"agent"`
+	Timestamp time.Time `json:"timestamp"`
+	Type      string    `json:"type"`
+	Severity  string    `json:"severity"`
+	Title     string    `json:"title"`
+	Detail    string    `json:"detail,omitempty"`
+	File      string    `json:"file,omitempty"`
+	Line      int       `json:"line,omitempty"`
+}
+
+// Digest is a consolidated summary of findings across agents.
+type Digest struct {
+	GeneratedAt time.Time            `json:"generated_at"`
+	Mode        string               `json:"mode"`
+	ByAgent     map[string][]Finding `json:"by_agent"`
+	TotalCount  int                  `json:"total_count"`
+}
+
+// Store manages advisory findings on disk.
+type Store struct {
+	dir          string
+	mu           sync.Mutex
+	lastReadPos  map[string]int64
+	latestDigest *Digest
+}
+
+func NewStore() *Store {
+	_ = os.MkdirAll(advisoryDir, 0o755)
+	return &Store{
+		dir:         advisoryDir,
+		lastReadPos: make(map[string]int64),
+	}
+}
+
+// ReadNewFindings reads all findings written since the last read for each agent.
+func (s *Store) ReadNewFindings() ([]Finding, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading advisory dir: %w", err)
+	}
+
+	var all []Finding
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		agentName := strings.TrimSuffix(e.Name(), ".jsonl")
+		path := filepath.Join(s.dir, e.Name())
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+
+		lastPos := s.lastReadPos[agentName]
+		if int64(len(data)) <= lastPos {
+			continue
+		}
+
+		newData := string(data[lastPos:])
+		s.lastReadPos[agentName] = int64(len(data))
+
+		for _, line := range strings.Split(newData, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			var f Finding
+			if err := json.Unmarshal([]byte(line), &f); err != nil {
+				continue
+			}
+			if f.Agent == "" {
+				f.Agent = agentName
+			}
+			all = append(all, f)
+		}
+	}
+
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].Timestamp.Before(all[j].Timestamp)
+	})
+	return all, nil
+}
+
+// BuildDigest creates a digest from the given findings.
+func BuildDigest(findings []Finding, mode string) *Digest {
+	byAgent := make(map[string][]Finding)
+	for _, f := range findings {
+		byAgent[f.Agent] = append(byAgent[f.Agent], f)
+	}
+	return &Digest{
+		GeneratedAt: time.Now(),
+		Mode:        mode,
+		ByAgent:     byAgent,
+		TotalCount:  len(findings),
+	}
+}
+
+// FormatDigestMarkdown formats a digest as markdown for posting to GitHub.
+func FormatDigestMarkdown(d *Digest) string {
+	if d.TotalCount == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("## 🐝 Advisory Digest — %s\n\n", d.GeneratedAt.Format("2006-01-02 15:04 MST")))
+	b.WriteString(fmt.Sprintf("**Mode:** %s | **Findings:** %d\n\n", d.Mode, d.TotalCount))
+
+	agents := make([]string, 0, len(d.ByAgent))
+	for a := range d.ByAgent {
+		agents = append(agents, a)
+	}
+	sort.Strings(agents)
+
+	for _, agent := range agents {
+		findings := d.ByAgent[agent]
+		b.WriteString(fmt.Sprintf("### %s (%d)\n\n", agent, len(findings)))
+
+		bySeverity := map[string][]Finding{}
+		for _, f := range findings {
+			sev := f.Severity
+			if sev == "" {
+				sev = "info"
+			}
+			bySeverity[sev] = append(bySeverity[sev], f)
+		}
+
+		sevOrder := []string{"critical", "high", "medium", "low", "info"}
+		for _, sev := range sevOrder {
+			items, ok := bySeverity[sev]
+			if !ok {
+				continue
+			}
+			icon := severityIcon(sev)
+			for _, f := range items {
+				loc := ""
+				if f.File != "" {
+					loc = fmt.Sprintf(" `%s`", f.File)
+					if f.Line > 0 {
+						loc = fmt.Sprintf(" `%s:%d`", f.File, f.Line)
+					}
+				}
+				b.WriteString(fmt.Sprintf("- %s **[%s]** %s%s\n", icon, f.Type, f.Title, loc))
+				if f.Detail != "" {
+					b.WriteString(fmt.Sprintf("  > %s\n", f.Detail))
+				}
+			}
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// SetLatestDigest stores the most recent digest for dashboard access.
+func (s *Store) SetLatestDigest(d *Digest) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.latestDigest = d
+}
+
+// LatestDigest returns the most recent digest.
+func (s *Store) LatestDigest() *Digest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.latestDigest
+}
+
+func severityIcon(sev string) string {
+	switch sev {
+	case "critical":
+		return "🔴"
+	case "high":
+		return "🟠"
+	case "medium":
+		return "🟡"
+	case "low":
+		return "🔵"
+	default:
+		return "⚪"
+	}
+}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -764,8 +764,13 @@ func (m *Manager) agentEnvVars(agent *AgentProcess) []string {
 	if agent.BackendOverride != "" {
 		backend = agent.BackendOverride
 	}
+	displayName := agent.Config.DisplayName
+	if displayName == "" {
+		displayName = agent.Name
+	}
 	vars := []string{
 		fmt.Sprintf("HIVE_AGENT=%s", agent.Name),
+		fmt.Sprintf("HIVE_AGENT_DISPLAY_NAME=%s", displayName),
 		fmt.Sprintf("HIVE_BACKEND=%s", backend),
 		fmt.Sprintf("HIVE_MODEL=%s", model),
 	}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -41,6 +41,9 @@ type Server struct {
 	tokenHistory      []TokenSparklineEntry
 	lastFullBroadcast time.Time
 
+	advisoryMu     sync.RWMutex
+	advisoryDigest any
+
 	ready bool
 }
 
@@ -62,6 +65,7 @@ type StatusPayload struct {
 	IssueToMerge  map[string]any      `json:"issueToMerge"`
 	ACMMLevel      int                 `json:"acmmLevel"`
 	ACMMPackAgents []string            `json:"acmmPackAgents"`
+	AdvisoryDigest any                 `json:"advisoryDigest,omitempty"`
 }
 
 type FrontendAgent struct {
@@ -478,4 +482,18 @@ func (s *Server) SeedTokenSparklineHistory(entries []TokenSparklineEntry) {
 		entries = entries[len(entries)-tokenSparklineMaxEntries:]
 	}
 	s.tokenHistory = entries
+}
+
+// SetAdvisoryDigest stores the latest advisory digest for SSE broadcast.
+func (s *Server) SetAdvisoryDigest(digest any) {
+	s.advisoryMu.Lock()
+	defer s.advisoryMu.Unlock()
+	s.advisoryDigest = digest
+}
+
+// GetAdvisoryDigest returns the latest advisory digest.
+func (s *Server) GetAdvisoryDigest() any {
+	s.advisoryMu.RLock()
+	defer s.advisoryMu.RUnlock()
+	return s.advisoryDigest
 }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1541,6 +1541,7 @@
     <div class="oc-nav-group">
       <div class="oc-nav-label">Control</div>
       <a class="oc-nav-item active" data-section="governor" onclick="ocNavigate('governor')">📊 Governor</a>
+      <a class="oc-nav-item" data-section="advisory-section" onclick="ocNavigate('advisory-section')">📋 Advisory</a>
       <a class="oc-nav-item" data-section="token-panel" onclick="ocNavigate('token-panel')">🪙 Tokens</a>
     </div>
     <div class="oc-nav-group">
@@ -1595,6 +1596,11 @@
   </h1>
 
   <div class="governor" id="governor"></div>
+
+  <div id="advisory-section" style="margin-top: 16px; margin-bottom: 24px; display: none;">
+    <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 8px;">📋 Advisory Digest</h2>
+    <div id="advisory-digest" style="background: var(--card-bg); border: 1px solid var(--border); border-radius: 8px; padding: 16px;"></div>
+  </div>
 
   <div class="token-usage" id="token-panel" style="margin-bottom: 24px;"></div>
 
@@ -2138,6 +2144,7 @@
       if (lastData.governor) {
         renderGovernor(lastData.governor, lastData.cadenceMatrix || [], lastData);
       }
+      renderAdvisoryDigest(lastData.advisoryDigest || null);
       renderDebugSection();
       const _lvl2 = (lastData.acmmLevel != null) ? lastData.acmmLevel : 0;
       applyACMMVisibility(_lvl2, lastData.acmmPackAgents || null);
@@ -3069,6 +3076,35 @@
         <thead><tr><th></th>${headers}<th>cli</th><th>model</th></tr></thead>
         <tbody>${rows}</tbody>
       </table>`;
+    }
+
+    function renderAdvisoryDigest(digest) {
+      const el = document.getElementById('advisory-digest');
+      if (!el) return;
+      if (!digest || !digest.total_count) {
+        setIfChanged(el, '<div style="color:var(--muted);font-size:0.82rem;text-align:center;padding:20px">No advisory findings yet. Agents will post findings here as they analyze the codebase.</div>');
+        return;
+      }
+      const sevIcon = s => ({ critical: '🔴', high: '🟠', medium: '🟡', low: '🔵' }[s] || '⚪');
+      const agents = Object.keys(digest.by_agent || {}).sort();
+      let html = `<div style="font-size:0.78rem;color:var(--muted);margin-bottom:12px">
+        <strong>Mode:</strong> ${escapeHtml(digest.mode)} | <strong>Findings:</strong> ${digest.total_count} | <strong>Updated:</strong> ${new Date(digest.generated_at).toLocaleString()}
+      </div>`;
+      for (const agent of agents) {
+        const findings = digest.by_agent[agent] || [];
+        html += `<div style="margin-bottom:12px">
+          <div style="font-weight:600;font-size:0.85rem;margin-bottom:6px;color:var(--text)">${escapeHtml(agent)} <span style="color:var(--muted);font-weight:400">(${findings.length})</span></div>
+          <div style="display:flex;flex-direction:column;gap:4px">`;
+        for (const f of findings) {
+          const loc = f.file ? ` <code style="font-size:0.72rem;color:var(--muted)">${escapeHtml(f.file)}${f.line ? ':' + f.line : ''}</code>` : '';
+          html += `<div style="font-size:0.8rem;padding:6px 10px;background:var(--bg);border-radius:4px;border-left:3px solid ${f.severity === 'critical' ? '#dc2626' : f.severity === 'high' ? '#ea580c' : f.severity === 'medium' ? '#ca8a04' : '#6b7280'}">
+            ${sevIcon(f.severity)} <strong>[${escapeHtml(f.type || 'finding')}]</strong> ${escapeHtml(f.title)}${loc}
+            ${f.detail ? `<div style="margin-top:4px;color:var(--muted);font-size:0.75rem">${escapeHtml(f.detail)}</div>` : ''}
+          </div>`;
+        }
+        html += '</div></div>';
+      }
+      setIfChanged(el, html);
     }
 
     function renderRepos(repos) {
@@ -5521,6 +5557,7 @@ function burnAreaChart() {
         renderGovernor(data.governor || {}, data.cadenceMatrix || [], data);
       }
       renderTokens(data.tokens || {});
+      renderAdvisoryDigest(data.advisoryDigest || null);
       renderRepos(data.repos || []);
       renderBeads(data.beads || {});
       ocUpdateSidebarAgents();
@@ -6372,6 +6409,7 @@ function burnAreaChart() {
       const show = (el, d) => { if (el) el.style.display = d || ''; };
 
       const governor = document.getElementById('governor');
+      const advisorySection = document.getElementById('advisory-section');
       const tokenPanel = document.getElementById('token-panel');
       const reposSection = document.getElementById('repos-section');
       const beadsSection = document.getElementById('beads-section');
@@ -6387,6 +6425,7 @@ function burnAreaChart() {
       const agentDetail = document.getElementById('oc-agent-detail');
 
       const ACMM_GOVERNOR_MIN_LEVEL = 2;
+      const ACMM_ADVISORY_MIN_LEVEL = 2;
       const ACMM_TOKENS_MIN_LEVEL = 3;
       const ACMM_BEADS_MIN_LEVEL = 2;
       const ACMM_REPOS_MIN_LEVEL = 2;
@@ -6401,6 +6440,7 @@ function burnAreaChart() {
         sidebarItems.forEach(item => show(item, ''));
 
         level >= ACMM_GOVERNOR_MIN_LEVEL ? show(governor, '') : hide(governor);
+        level >= ACMM_ADVISORY_MIN_LEVEL ? show(advisorySection, '') : hide(advisorySection);
         level >= ACMM_TOKENS_MIN_LEVEL ? show(tokenPanel, '') : hide(tokenPanel);
         level >= ACMM_BEADS_MIN_LEVEL ? show(beadsSection, '') : hide(beadsSection);
         level >= ACMM_REPOS_MIN_LEVEL ? show(reposSection, '') : hide(reposSection);
@@ -6417,6 +6457,7 @@ function burnAreaChart() {
         }
         sidebarItems.forEach(item => {
           const section = item.getAttribute('data-section') || '';
+          if (section === 'advisory-section' && level < ACMM_ADVISORY_MIN_LEVEL) hide(item);
           if (section === 'token-panel' && level < ACMM_TOKENS_MIN_LEVEL) hide(item);
           if (section === 'repos-section' && level < ACMM_REPOS_MIN_LEVEL) hide(item);
           if (section === 'beads-section' && level < ACMM_BEADS_MIN_LEVEL) hide(item);

--- a/v2/pkg/github/advisory.go
+++ b/v2/pkg/github/advisory.go
@@ -37,8 +37,9 @@ func (c *Client) EnsureAdvisoryIssue(ctx context.Context, repo string) (int, err
 		Description: gh.Ptr(advisoryLabelDesc),
 		Color:       gh.Ptr(advisoryLabelClr),
 	})
-	if labelErr != nil && !strings.Contains(labelErr.Error(), "already_exists") {
-		c.logger.Warn("could not create advisory label", slog.String("error", labelErr.Error()))
+	labelExists := labelErr == nil || strings.Contains(labelErr.Error(), "already_exists")
+	if !labelExists {
+		c.logger.Warn("could not create advisory label, issue will be created without it", slog.String("error", labelErr.Error()))
 	}
 
 	body := "This issue collects advisory findings from Hive agents.\n\n" +
@@ -46,11 +47,14 @@ func (c *Client) EnsureAdvisoryIssue(ctx context.Context, repo string) (int, err
 		"Instead, the governor posts periodic digest comments here summarizing what agents found.\n\n" +
 		"**Do not close this issue.** It is a living document."
 
-	issue, _, err := c.client.Issues.Create(ctx, owner, repo, &gh.IssueRequest{
-		Title:  gh.Ptr(advisoryTitle),
-		Body:   gh.Ptr(body),
-		Labels: &[]string{advisoryLabelName},
-	})
+	req := &gh.IssueRequest{
+		Title: gh.Ptr(advisoryTitle),
+		Body:  gh.Ptr(body),
+	}
+	if labelExists {
+		req.Labels = &[]string{advisoryLabelName}
+	}
+	issue, _, err := c.client.Issues.Create(ctx, owner, repo, req)
 	if err != nil {
 		return 0, fmt.Errorf("creating advisory issue: %w", err)
 	}
@@ -78,6 +82,21 @@ func (c *Client) findAdvisoryIssue(ctx context.Context, owner, repo string) (int
 		ListOptions: gh.ListOptions{PerPage: 5},
 	}
 	issues, _, err := c.client.Issues.ListByRepo(ctx, owner, repo, opts)
+	if err == nil {
+		for _, issue := range issues {
+			if issue.GetTitle() == advisoryTitle {
+				return issue.GetNumber(), nil
+			}
+		}
+	}
+
+	// Fallback: search by title if label-based search failed or found nothing
+	// (label may not exist if we don't have permission to create it)
+	titleOpts := &gh.IssueListByRepoOptions{
+		State:       "open",
+		ListOptions: gh.ListOptions{PerPage: 20},
+	}
+	issues, _, err = c.client.Issues.ListByRepo(ctx, owner, repo, titleOpts)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## Summary
- **agent-launch.sh**: Re-export HIVE_* env vars so child processes (gh-wrapper) inherit ACMM level, agent identity, and advisory issue number. Without this, agents bypassed L2 enforcement and created issues.
- **advisory.go**: Create advisory issue without label when label creation fails (403 on repos where token lacks label permissions). Also fallback to title-based search.
- **gh-wrapper.sh**: Use `HIVE_AGENT_DISPLAY_NAME` for identity footer and labels instead of internal agent name (fixes "tester" showing instead of "quality").
- **manager.go**: Pass `HIVE_AGENT_DISPLAY_NAME` env var to agents from config.

## Test plan
- [ ] Deploy to 4.83 (certus) and verify agents cannot create issues at L2
- [ ] Verify advisory issue is created on certus repo
- [ ] Verify identity footer shows display name (e.g. "quality" not "tester")
- [ ] Verify agent cards show correctly on dashboard