### PR TITLE
feat: container image + Flatcar deployment

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -1,0 +1,72 @@
+name: Container Build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'bin/**'
+      - 'config/**'
+      - 'dashboard/**'
+      - 'discord/**'
+      - 'v2/Dockerfile'
+      - 'v2/compose.yaml'
+      - '.github/workflows/container-build.yml'
+  pull_request:
+    paths:
+      - 'bin/**'
+      - 'config/**'
+      - 'dashboard/**'
+      - 'discord/**'
+      - 'v2/Dockerfile'
+      - 'v2/compose.yaml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: kubestellar/hive
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=pr
+
+      - name: Build and push
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        with:
+          context: .
+          file: v2/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -1,0 +1,78 @@
+FROM debian:bookworm-slim AS base
+
+ARG TARGETARCH
+
+# Runtime dependencies: tmux for session management, gh for GitHub API,
+# jq/curl for scripting, node for dashboard, git for repo ops, python3
+# for token-usage and nous scripts, openssh-client for git+ssh.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bash \
+      ca-certificates \
+      curl \
+      git \
+      jq \
+      openssh-client \
+      python3 \
+      python3-pip \
+      tmux \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 22 LTS (dashboard + GA4 scripts)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=${TARGETARCH} signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Claude Code CLI (default AI backend)
+RUN npm install -g @anthropic-ai/claude-code
+
+# Non-root user for agent processes
+RUN groupadd -g 1000 dev && useradd -m -u 1000 -g dev -s /bin/bash dev
+
+# Directory layout:
+#   /opt/hive/bin/       — hive scripts (from repo)
+#   /opt/hive/config/    — default config templates
+#   /opt/hive/dashboard/ — dashboard static + server
+#   /opt/hive/discord/   — discord bot
+#   /etc/hive/           — runtime config (mounted from host)
+#   /data/               — persistent variable data (mounted volume)
+#   /data/logs/          — heartbeat + supervisor logs
+#   /data/agents/        — per-agent beads, state, scratch
+#   /data/repos/         — cloned working repos
+RUN mkdir -p /opt/hive /etc/hive /data/logs /data/agents /data/repos \
+    && chown -R dev:dev /data
+
+COPY bin/        /opt/hive/bin/
+COPY config/     /opt/hive/config/
+COPY dashboard/  /opt/hive/dashboard/
+COPY discord/    /opt/hive/discord/
+
+# Symlink scripts into PATH
+RUN for f in /opt/hive/bin/*.sh; do \
+      ln -sf "$f" "/usr/local/bin/$(basename "$f")"; \
+    done
+
+# Dashboard dependencies
+RUN cd /opt/hive/dashboard && [ -f package.json ] && npm ci --omit=dev || true
+
+# hive CLI entrypoint
+RUN ln -sf /opt/hive/bin/hive.sh /usr/local/bin/hive
+
+WORKDIR /data
+USER dev
+
+# Dashboard port
+EXPOSE 3001
+
+# Health check: supervisor writes heartbeat; stale = unhealthy
+HEALTHCHECK --interval=60s --timeout=5s --start-period=120s --retries=3 \
+  CMD find /data/logs -name "heartbeat.log" -mmin -30 | grep -q . || exit 1
+
+ENTRYPOINT ["/opt/hive/bin/supervisor.sh"]

--- a/v2/README.md
+++ b/v2/README.md
@@ -1,0 +1,91 @@
+# Hive v2 — Container Deployment
+
+Run hive as a container on any Docker/Podman host (Flatcar, Ubuntu, etc.).
+
+## Quick Start
+
+```bash
+# Pull the image
+docker pull ghcr.io/kubestellar/hive:latest
+
+# Create config directory
+mkdir -p /etc/hive
+cp config/agent.env.example /etc/hive/agent.env
+cp config/hive-project.yaml.example /etc/hive/hive-project.yaml
+# Edit both files with your values
+
+# Run
+docker run -d \
+  --name hive \
+  --env-file /etc/hive/agent.env \
+  -v /etc/hive:/etc/hive:ro \
+  -v /data:/data \
+  -p 3001:3001 \
+  --tty \
+  ghcr.io/kubestellar/hive:latest
+```
+
+## With Docker Compose
+
+```bash
+cd v2
+cp ../config/agent.env.example .env
+# Edit .env with your values
+docker compose up -d
+```
+
+## Mount Points
+
+| Path | Purpose | Mode |
+|------|---------|------|
+| `/etc/hive/` | Config: `agent.env`, `hive-project.yaml`, policies | Read-only |
+| `/data/` | Variable data: logs, beads, repos, agent state | Read-write |
+| `/data/logs/` | Heartbeat + supervisor logs | Read-write |
+| `/data/repos/` | Cloned working repositories | Read-write |
+| `/data/agents/` | Per-agent beads and scratch | Read-write |
+| `/home/dev/.ssh/` | SSH keys for git+ssh (optional) | Read-only |
+
+## Flatcar on Proxmox (via Knuckle)
+
+1. Download the [Knuckle ISO](https://github.com/castrojo/knuckle/releases) (amd64 or arm64)
+2. Create a Proxmox VM: upload ISO, boot, walk through the 9-step wizard
+   - Select the **Docker** sysext when prompted
+3. After install, SSH into the Flatcar host
+4. Copy `v2/deploy/flatcar/hive.bu` and edit `/etc/hive/agent.env` with your secrets
+5. The Butane config includes a systemd unit that auto-pulls and runs the container
+
+```bash
+# On the Flatcar host — the systemd unit handles everything:
+sudo systemctl enable --now hive.service
+
+# Check status
+sudo systemctl status hive
+docker logs -f hive
+
+# Attach to the agent tmux session inside the container
+docker exec -it hive tmux attach -t hive
+
+# Dashboard
+curl http://localhost:3001
+```
+
+## Environment Variables
+
+See `config/agent.env.example` for the full list. Key variables:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `AGENT_LAUNCH_CMD` | Yes | CLI command to start the AI agent |
+| `AGENT_LOOP_PROMPT` | Yes | Startup prompt (executor or cron mode) |
+| `ANTHROPIC_API_KEY` | Yes | Claude API key |
+| `HIVE_GITHUB_TOKEN` | Yes | GitHub PAT or App token |
+| `AGENT_SESSION_NAME` | No | tmux session name (default: `hive`) |
+| `DISCORD_WEBHOOK` | No | Discord notification webhook |
+| `NTFY_TOPIC` | No | ntfy.sh push notification topic |
+| `DASHBOARD_PORT` | No | Dashboard port (default: `3001`) |
+
+## Building Locally
+
+```bash
+docker build -t hive:local -f v2/Dockerfile .
+```

--- a/v2/compose.yaml
+++ b/v2/compose.yaml
@@ -1,0 +1,43 @@
+# Hive v2 — container deployment
+#
+# Usage:
+#   cp config/agent.env.example .env    # edit with your values
+#   docker compose up -d
+#
+# Mount points:
+#   /etc/hive/  — project config (hive-project.yaml, agent.env, policies)
+#   /data/      — persistent state (logs, beads, repos, agent scratch)
+
+services:
+  hive:
+    build:
+      context: ..
+      dockerfile: v2/Dockerfile
+    image: ghcr.io/kubestellar/hive:latest
+    container_name: hive
+    restart: unless-stopped
+    hostname: ${HIVE_HOSTNAME:-hive}
+    env_file:
+      - .env
+    environment:
+      - AGENT_USER=dev
+      - AGENT_WORKDIR=/data/repos
+      - AGENT_LOG_FILE=/data/logs/heartbeat.log
+      - AGENT_SESSION_NAME=${AGENT_SESSION_NAME:-hive}
+    volumes:
+      # Config — read-only from host
+      - ${HIVE_CONFIG_DIR:-./config}:/etc/hive:ro
+      # Persistent data — survives container restarts
+      - hive-data:/data
+      # SSH keys — for git+ssh access to repos (optional)
+      - ${SSH_KEY_DIR:-~/.ssh}:/home/dev/.ssh:ro
+    ports:
+      # Dashboard
+      - "${DASHBOARD_PORT:-3001}:3001"
+    # Keep tmux happy inside container
+    tty: true
+    stdin_open: true
+
+volumes:
+  hive-data:
+    driver: local

--- a/v2/deploy/flatcar/hive.bu
+++ b/v2/deploy/flatcar/hive.bu
@@ -1,0 +1,125 @@
+# Butane config for Hive on Flatcar Container Linux
+#
+# Provision via Knuckle:
+#   1. Boot the Knuckle ISO on a Proxmox VM
+#   2. Walk through the wizard (select Docker sysext)
+#   3. After install, copy this file and run:
+#        butane --strict hive.bu -o hive.ign
+#        # Or apply post-install via Ignition merge
+#
+# Or use as a post-install systemd drop-in — copy hive.service
+# to the Flatcar host after Knuckle provisioning.
+
+variant: flatcar
+version: 1.1.0
+
+storage:
+  directories:
+    - path: /etc/hive
+      mode: 0755
+    - path: /data
+      mode: 0755
+      user:
+        id: 1000
+      group:
+        id: 1000
+    - path: /data/logs
+      mode: 0755
+      user:
+        id: 1000
+      group:
+        id: 1000
+    - path: /data/repos
+      mode: 0755
+      user:
+        id: 1000
+      group:
+        id: 1000
+
+  files:
+    # Hive environment — EDIT before deploying
+    - path: /etc/hive/agent.env
+      mode: 0600
+      contents:
+        inline: |
+          # Required
+          AGENT_USER=dev
+          AGENT_WORKDIR=/data/repos
+          AGENT_LOG_FILE=/data/logs/heartbeat.log
+          AGENT_SESSION_NAME=hive
+          AGENT_LAUNCH_CMD="/usr/bin/claude --dangerously-skip-permissions --model claude-opus-4-6"
+          AGENT_READY_MARKER="bypass permissions on"
+          AGENT_LOOP_PROMPT="You are in EXECUTOR MODE. Read your policy file, then wait for work orders."
+
+          # Secrets — set these before starting
+          # ANTHROPIC_API_KEY=
+          # HIVE_GITHUB_TOKEN=
+
+          # Optional
+          # DISCORD_WEBHOOK=
+          # NTFY_TOPIC=
+          # AGENT_POLL_SEC=10
+          # AGENT_STALE_MAX_SEC=1800
+          # AGENT_MAX_RESPAWNS=3
+
+systemd:
+  units:
+    - name: hive.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Hive agent container
+        After=network-online.target docker.service
+        Wants=network-online.target
+        Requires=docker.service
+
+        [Service]
+        Type=simple
+        Restart=always
+        RestartSec=10
+        TimeoutStartSec=300
+
+        ExecStartPre=-/usr/bin/docker pull ghcr.io/kubestellar/hive:latest
+        ExecStartPre=-/usr/bin/docker rm -f hive
+
+        ExecStart=/usr/bin/docker run \
+          --name hive \
+          --hostname %H \
+          --env-file /etc/hive/agent.env \
+          -v /etc/hive:/etc/hive:ro \
+          -v /data:/data \
+          -p 3001:3001 \
+          --tty \
+          ghcr.io/kubestellar/hive:latest
+
+        ExecStop=/usr/bin/docker stop -t 30 hive
+        ExecStopPost=-/usr/bin/docker rm -f hive
+
+        [Install]
+        WantedBy=multi-user.target
+
+    # Auto-update: pull latest image daily at 4 AM UTC
+    - name: hive-update.service
+      enabled: false
+      contents: |
+        [Unit]
+        Description=Pull latest hive container image
+
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/bin/docker pull ghcr.io/kubestellar/hive:latest
+        ExecStartPost=/usr/bin/systemctl restart hive.service
+
+    - name: hive-update.timer
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Daily hive container update check
+
+        [Timer]
+        OnCalendar=*-*-* 04:00:00 UTC
+        RandomizedDelaySec=900
+        Persistent=true
+
+        [Install]
+        WantedBy=timers.target


### PR DESCRIPTION
## Summary
- **Dockerfile** (`v2/Dockerfile`): debian-slim based container with tmux, claude CLI, gh, node, python3, and all hive scripts. Multi-arch (amd64/arm64). Runs `supervisor.sh` as entrypoint.
- **Compose** (`v2/compose.yaml`): docker compose config with config mount (`/etc/hive:ro`) and data volume (`/data`).
- **Flatcar Butane** (`v2/deploy/flatcar/hive.bu`): systemd unit that auto-pulls and runs the container on Flatcar Linux (provisioned via Knuckle on Proxmox). Includes daily auto-update timer.
- **CI workflow** (`.github/workflows/container-build.yml`): builds and pushes to `ghcr.io/kubestellar/hive` on main push. PR builds verify without pushing.

### Mount points
| Path | Purpose | Mode |
|------|---------|------|
| `/etc/hive/` | `agent.env`, `hive-project.yaml`, policies | Read-only |
| `/data/` | Logs, beads, repos, agent state | Read-write |

No existing files are modified — this is purely additive.

## Test plan
- [ ] `docker build -t hive:local -f v2/Dockerfile .` succeeds
- [ ] Container starts with `supervisor.sh` and tmux session is accessible via `docker exec`
- [ ] Dashboard accessible on port 3001
- [ ] Heartbeat log written to `/data/logs/heartbeat.log`
- [ ] CI workflow triggers on PR and builds without push

🤖 Generated with [Claude Code](https://claude.com/claude-code)