### PR TITLE
fix: .doing summary reflows to fill card width

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -513,7 +513,7 @@
     .value.idle { color: var(--muted); }
     .value.copilot { color: var(--cyan); }
     .value.claude { color: var(--purple); }
-    .doing { font-size: 0.65rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: pre-wrap; line-height: 1.3; min-height: 5.6em; width: 100%; }
+    .doing { font-size: 0.65rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: normal; line-height: 1.3; min-height: 5.6em; width: 100%; }
     .summary-age { display: inline-block; font-size: 0.6rem; font-style: normal; border-radius: 3px; padding: 1px 5px; margin-right: 5px; vertical-align: middle; white-space: nowrap; }
     .summary-age.age-recent { background: rgba(210,153,34,0.15); color: #d29922; border: 1px solid rgba(210,153,34,0.3); }
     .summary-age.age-stale  { background: rgba(248,81,73,0.15);  color: #f85149; border: 1px solid rgba(248,81,73,0.3); }
@@ -5764,7 +5764,7 @@ function burnAreaChart() {
 
     function escPreserveNewlines(s) {
       if (typeof s !== 'string') return '';
-      return s
+      s = s
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
@@ -5773,6 +5773,8 @@ function burnAreaChart() {
         .replace(/`/g, '&#96;')
         .replace(/\r\n/g, '\n')
         .replace(/\r/g, '');
+      // Double newlines = paragraph break, single newlines = reflow (fill width)
+      return s.replace(/\n{2,}/g, '<br><br>').replace(/\n/g, ' ');
     }
 
     // ── Event delegation for actions with user-controlled data ──


### PR DESCRIPTION
## Summary
- Changes `.doing` white-space from `pre-wrap` to `normal` so text reflows to fill available width
- Single newlines (tmux line-wrapping artifacts) become spaces for natural reflow
- Double newlines are preserved as `<br><br>` paragraph breaks

## Test plan
- [ ] Verify .doing text fills the card width without ragged line breaks
- [ ] Verify paragraph breaks (double newlines) still show as visual separators