### PR TITLE
fix: advisory JSONL capture + .doing scrollback

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -100,11 +100,41 @@ ADVISORY_ISSUE="${HIVE_ADVISORY_ISSUE:-}"
 
 if [ "$ACMM_LEVEL" -gt 0 ] && [ "$ACMM_LEVEL" -lt 3 ]; then
   if [ "$subcmd" = "issue" ] && [ "$action" = "create" ]; then
+    # Extract --title and --body from args to save as advisory finding
+    _adv_title="" _adv_body="" _next_is_title=false _next_is_body=false
+    for arg in "${args[@]}"; do
+      if $_next_is_title; then _adv_title="$arg"; _next_is_title=false; continue; fi
+      if $_next_is_body;  then _adv_body="$arg";  _next_is_body=false;  continue; fi
+      case "$arg" in
+        --title)   _next_is_title=true ;;
+        --title=*) _adv_title="${arg#--title=}" ;;
+        --body)    _next_is_body=true ;;
+        --body=*)  _adv_body="${arg#--body=}" ;;
+        -t)        _next_is_title=true ;;
+        -b)        _next_is_body=true ;;
+      esac
+    done
+    # Write advisory finding to JSONL for governor digest
+    ADVISORY_DIR="/data/advisory"
+    mkdir -p "$ADVISORY_DIR"
+    AGENT_NAME="${HIVE_AGENT:-unknown}"
+    python3 -c "
+import json, datetime, sys
+f = {
+    'agent': '${AGENT_NAME}',
+    'timestamp': datetime.datetime.utcnow().isoformat() + 'Z',
+    'type': 'issue',
+    'severity': 'medium',
+    'title': sys.argv[1],
+    'detail': sys.argv[2][:500] if len(sys.argv[2]) > 500 else sys.argv[2]
+}
+with open('${ADVISORY_DIR}/${AGENT_NAME}.jsonl', 'a') as fh:
+    fh.write(json.dumps(f) + '\n')
+" "${_adv_title:-untitled}" "${_adv_body:-}" 2>/dev/null || true
     echo "⛔ BLOCKED: gh issue create is not allowed at ACMM L${ACMM_LEVEL}." >&2
-    echo "L1/L2 agents are advisory-only." >&2
+    echo "L1/L2 agents are advisory-only. Finding saved to advisory digest." >&2
     if [ -n "$ADVISORY_ISSUE" ]; then
-      echo "Post findings as a comment on the advisory issue instead:" >&2
-      echo "  gh issue comment ${ADVISORY_ISSUE} --body 'your findings here'" >&2
+      echo "Finding will appear in advisory issue #${ADVISORY_ISSUE} at next governor cycle." >&2
     fi
     exit 1
   fi

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -513,7 +513,7 @@
     .value.idle { color: var(--muted); }
     .value.copilot { color: var(--cyan); }
     .value.claude { color: var(--purple); }
-    .doing { font-size: 0.65rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: normal; line-height: 1.3; min-height: 5.6em; width: 100%; }
+    .doing { font-size: 0.65rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: normal; line-height: 1.3; min-height: 5.6em; max-height: 12em; overflow-y: auto; width: 100%; }
     .summary-age { display: inline-block; font-size: 0.6rem; font-style: normal; border-radius: 3px; padding: 1px 5px; margin-right: 5px; vertical-align: middle; white-space: nowrap; }
     .summary-age.age-recent { background: rgba(210,153,34,0.15); color: #d29922; border: 1px solid rgba(210,153,34,0.3); }
     .summary-age.age-stale  { background: rgba(248,81,73,0.15);  color: #f85149; border: 1px solid rgba(248,81,73,0.3); }


### PR DESCRIPTION
## Summary
- gh-wrapper now captures blocked `gh issue create` attempts as advisory findings in `/data/advisory/<agent>.jsonl`
- Governor digest cycle picks up these findings and posts them to the advisory issue + dashboard
- `.doing` card gets `max-height: 12em` with `overflow-y: auto` for scrollable content

## Test plan
- [ ] Block an issue create at L2 and verify `/data/advisory/<agent>.jsonl` has the entry
- [ ] Verify governor picks up the finding and posts to advisory issue
- [ ] Verify .doing card scrolls when content exceeds 12em height