### PR TITLE
revert: restore pre-wrap for .doing, keep scrollback

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -513,7 +513,7 @@
     .value.idle { color: var(--muted); }
     .value.copilot { color: var(--cyan); }
     .value.claude { color: var(--purple); }
-    .doing { font-size: 0.65rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: normal; line-height: 1.3; min-height: 5.6em; max-height: 12em; overflow-y: auto; width: 100%; }
+    .doing { font-size: 0.65rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: pre-wrap; line-height: 1.3; min-height: 5.6em; max-height: 12em; overflow-y: auto; width: 100%; }
     .summary-age { display: inline-block; font-size: 0.6rem; font-style: normal; border-radius: 3px; padding: 1px 5px; margin-right: 5px; vertical-align: middle; white-space: nowrap; }
     .summary-age.age-recent { background: rgba(210,153,34,0.15); color: #d29922; border: 1px solid rgba(210,153,34,0.3); }
     .summary-age.age-stale  { background: rgba(248,81,73,0.15);  color: #f85149; border: 1px solid rgba(248,81,73,0.3); }
@@ -5764,7 +5764,7 @@ function burnAreaChart() {
 
     function escPreserveNewlines(s) {
       if (typeof s !== 'string') return '';
-      s = s
+      return s
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
@@ -5773,8 +5773,6 @@ function burnAreaChart() {
         .replace(/`/g, '&#96;')
         .replace(/\r\n/g, '\n')
         .replace(/\r/g, '');
-      // Double newlines = paragraph break, single newlines = reflow (fill width)
-      return s.replace(/\n{2,}/g, '<br><br>').replace(/\n/g, ' ');
     }
 
     // ── Event delegation for actions with user-controlled data ──


### PR DESCRIPTION
## Summary
- Reverts `white-space: normal` back to `pre-wrap` — original line breaks are preserved
- Reverts newline collapsing in `escPreserveNewlines` — no more joining single newlines into spaces
- Keeps `max-height: 12em` + `overflow-y: auto` for scrollback

User preference: respect the original line breaks from tmux output.