### PR TITLE
fix: default ACMM level to L1 when not configured

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1138,22 +1138,12 @@ func initAgentConfigDrivenSystems(cfg *config.Config) {
 	}
 }
 
-// inferACMMLevel returns the configured ACMM level, or infers one from agent count.
+// inferACMMLevel returns the configured ACMM level, defaulting to L1 (advisory-only).
 func inferACMMLevel(cfg *config.Config) int {
 	if cfg.ACMMLevel != nil {
 		return *cfg.ACMMLevel
 	}
-	agentCount := len(cfg.Agents)
-	switch {
-	case agentCount <= 1:
-		return 1
-	case agentCount == 2:
-		return 2
-	case agentCount <= 4:
-		return 3
-	default:
-		return 4
-	}
+	return 1
 }
 
 // parseColorInt converts a hex color string like "#3498db" to an int.

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -513,7 +513,7 @@
     .value.idle { color: var(--muted); }
     .value.copilot { color: var(--cyan); }
     .value.claude { color: var(--purple); }
-    .doing { font-size: 0.65rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: normal; line-height: 1.3; min-height: 5.6em; max-height: 12em; overflow-y: auto; width: 100%; }
+    .doing { font-size: 0.65rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: pre-wrap; line-height: 1.3; min-height: 5.6em; max-height: 12em; overflow-y: auto; width: 100%; }
     .summary-age { display: inline-block; font-size: 0.6rem; font-style: normal; border-radius: 3px; padding: 1px 5px; margin-right: 5px; vertical-align: middle; white-space: nowrap; }
     .summary-age.age-recent { background: rgba(210,153,34,0.15); color: #d29922; border: 1px solid rgba(210,153,34,0.3); }
     .summary-age.age-stale  { background: rgba(248,81,73,0.15);  color: #f85149; border: 1px solid rgba(248,81,73,0.3); }
@@ -5764,7 +5764,7 @@ function burnAreaChart() {
 
     function escPreserveNewlines(s) {
       if (typeof s !== 'string') return '';
-      s = s
+      return s
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
@@ -5773,8 +5773,6 @@ function burnAreaChart() {
         .replace(/`/g, '&#96;')
         .replace(/\r\n/g, '\n')
         .replace(/\r/g, '');
-      // Double newlines = paragraph break, single newlines = reflow (fill width)
-      return s.replace(/\n{2,}/g, '<br><br>').replace(/\n/g, ' ');
     }
 
     // ── Event delegation for actions with user-controlled data ──


### PR DESCRIPTION
## Summary
- ACMM level now defaults to L1 (Idea/advisory-only) when `acmm_level` is not set in config
- Previously it was inferred from agent count, which gave L3 (CI/CD) for 4 agents — allowing issue/PR creation on repos that should be advisory-only
- Root cause of 6 unauthorized issues filed on certus (#109-#114, now closed)

## Test plan
- [ ] Deploy to certus without `acmm_level` in config — verify agents cannot create issues
- [ ] Deploy with explicit `acmm_level: 3` — verify agents CAN create issues