### PR TITLE
fix: add sudo, procps, /var/run/hive to container image

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -12,8 +12,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       git \
       jq \
       openssh-client \
+      procps \
       python3 \
       python3-pip \
+      sudo \
       tmux \
     && rm -rf /var/lib/apt/lists/*
 
@@ -46,8 +48,9 @@ RUN groupadd -g 1000 dev && useradd -m -u 1000 -g dev -s /bin/bash dev
 #   /data/logs/          — heartbeat + supervisor logs
 #   /data/agents/        — per-agent beads, state, scratch
 #   /data/repos/         — cloned working repos
-RUN mkdir -p /opt/hive /etc/hive /data/logs /data/agents /data/repos \
-    && chown -R dev:dev /data
+RUN mkdir -p /opt/hive /etc/hive /data/logs /data/agents /data/repos /var/run/hive \
+    && chown -R dev:dev /data /var/run/hive \
+    && echo "dev ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/dev
 
 COPY bin/        /opt/hive/bin/
 COPY config/     /opt/hive/config/


### PR DESCRIPTION
## Summary
- Add `sudo` and `procps` packages to Dockerfile — supervisor.sh needs both
- Create `/var/run/hive` lock directory at build time
- Add passwordless sudo for `dev` user (supervisor.sh uses `sudo mkdir` for lock dir)

Without these, the container crash-loops with:
```
/opt/hive/bin/supervisor.sh: line 377: sudo: command not found
/opt/hive/bin/supervisor.sh: line 379: /var/run/hive/supervisor-hive.lock: No such file or directory
```

## Test plan
- [ ] `docker build` succeeds
- [ ] Container starts without crash-loop
- [ ] `supervisor.sh` creates lock file and proceeds to tmux session setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)