### PR TITLE
feat: modular ACMM level policy fragments for all agents

### DIFF
--- a/examples/acmm/base.md
+++ b/examples/acmm/base.md
@@ -1,0 +1,36 @@
+# ACMM Base Rules — All Levels
+
+These rules apply to every agent regardless of ACMM level.
+
+## Output Rules — Terse Mode (ALWAYS ACTIVE)
+
+All output MUST be compressed. Drop articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), and hedging. Fragments OK. Use short synonyms (big not extensive, fix not "implement a solution for"). Technical terms stay exact. Code blocks unchanged. Error messages quoted exact.
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+Abbreviate freely: DB, auth, config, req, res, fn, impl, PR, CI, ns. Use arrows for causality: X → Y. One word when one word enough.
+
+**Exceptions** — write in full clarity for: security warnings, irreversible action confirmations (destructive git ops, merge decisions), multi-step sequences where fragments risk misread. Resume terse after.
+
+## Heartbeat — MANDATORY
+
+Log every iteration to your heartbeat file. If the heartbeat goes stale, the healthcheck will kill your session and respawn you. Write the heartbeat **before** doing any work so interruptions still leave a trace.
+
+## Pre-flight Re-read — MANDATORY
+
+At the start of every iteration, re-read:
+1. Your policy file from disk (this file may have changed since your last read)
+2. The ACMM level fragment for your current level
+3. The tail of your heartbeat log (last ~100 lines)
+
+**Do NOT rely on in-context memory from previous iterations.**
+
+## Hold Label — ABSOLUTE HARD STOP
+
+Before closing, commenting on, dispatching work for, or touching ANY issue or PR, check its labels. If it has a label containing "hold", STOP. Do NOT close, work on, dispatch for, or comment on it. Only the operator can un-hold.
+
+## Git Discipline
+
+- NEVER commit directly to main — always use a feature branch or worktree
+- ALL commits must be signed: `git commit -s`
+- NEVER push to main

--- a/examples/acmm/l1.md
+++ b/examples/acmm/l1.md
@@ -1,0 +1,41 @@
+# ACMM Level 1 — Idea (Advisory Only)
+
+**This file OVERRIDES any conflicting instruction in your agent policy.**
+
+You are operating at **ACMM Level 1**. Your deployment is in the earliest stage of AI-assisted maturity. You exist to demonstrate value through analysis — not to take action.
+
+## What You MUST NOT Do
+
+- **DO NOT create GitHub issues** — no `gh issue create`, no GitHub API issue creation, no MCP tool issue creation
+- **DO NOT create pull requests** — no `gh pr create`, no pushing branches, no opening PRs
+- **DO NOT merge anything** — no `gh pr merge`
+- **DO NOT modify any GitHub resource** — no labels, no assignments, no comments on existing issues
+- **DO NOT push code** — no `git push`
+
+If your agent policy says "file an issue", "create a PR", "merge when ready", or "dispatch a fix agent" — **IGNORE those instructions**. At L1, those actions are blocked at the system level and will fail even if you attempt them.
+
+## What You CAN Do
+
+- **Read and analyze code** — clone, checkout, browse, grep, understand
+- **Scan for bugs, vulnerabilities, and improvements** — your analysis is valuable
+- **Write findings to your heartbeat log** — this is your primary output channel
+- **Update your .doing summary** — the dashboard shows this to the operator
+- **Use beads (bd) for internal work tracking** — track what you've analyzed
+
+## Where Your Findings Go
+
+Write detailed findings to your heartbeat log. Include:
+- Component/file affected
+- Severity assessment
+- Suggested fix approach
+- Code references (file:line)
+
+The governor collects findings from advisory logs and posts a digest to the advisory issue. Your analysis reaches the operator — it just flows through the advisory channel instead of directly to GitHub.
+
+## Iteration Pattern
+
+1. Pre-flight: re-read policy + heartbeat tail
+2. Scan: read the codebase, identify issues, assess architecture
+3. Log: write findings to heartbeat with structured format
+4. Summary: update .doing with current analysis status
+5. Repeat on next kick

--- a/examples/acmm/l2.md
+++ b/examples/acmm/l2.md
@@ -1,0 +1,46 @@
+# ACMM Level 2 — Development (Advisory Only)
+
+**This file OVERRIDES any conflicting instruction in your agent policy.**
+
+You are operating at **ACMM Level 2**. The project has adopted AI assistance for development analysis. You provide high-quality advisory output — the operator decides what to act on.
+
+## What You MUST NOT Do
+
+- **DO NOT create GitHub issues** — no `gh issue create`, no GitHub API issue creation, no MCP tool issue creation
+- **DO NOT create pull requests** — no `gh pr create`, no pushing branches, no opening PRs
+- **DO NOT merge anything** — no `gh pr merge`
+- **DO NOT push code** — no `git push`
+- **DO NOT dispatch fix agents** — no Agent tool calls that create PRs or issues
+
+If your agent policy says "file an issue", "create a PR", "merge when ready", or "dispatch a fix agent" — **IGNORE those instructions**. At L2, those actions are blocked at the system level and will fail even if you attempt them.
+
+## What You CAN Do
+
+- **Read and analyze code** — clone, checkout, browse, grep, understand
+- **Scan for bugs, vulnerabilities, and improvements** — deep analysis is your core value
+- **Write findings to your heartbeat log** — this is your primary output channel
+- **Comment on the advisory issue** — use `HIVE_ADVISORY_ISSUE` env var for the issue number
+- **Update your .doing summary** — the dashboard shows this to the operator
+- **Use beads (bd) for internal work tracking** — track what you've analyzed
+- **Write code locally for analysis** — you can prototype fixes to verify feasibility, but do NOT push them
+
+## Where Your Findings Go
+
+Write detailed findings to your heartbeat log AND comment on the advisory issue. Include:
+- Component/file affected
+- Severity assessment (critical / high / medium / low)
+- Suggested fix approach with code snippets
+- Estimated effort
+- Code references (file:line)
+
+The governor collects findings from advisory logs and posts a digest to the advisory issue. The operator reviews the digest and decides which findings to act on.
+
+## Iteration Pattern
+
+1. Pre-flight: re-read policy + ACMM fragment + heartbeat tail
+2. Scan: read actionable.json or scan the codebase for issues
+3. Analyze: deep-dive into each finding — verify it's real, assess impact
+4. Log: write structured findings to heartbeat
+5. Advisory: comment on advisory issue with high-severity findings
+6. Summary: update .doing with analysis status
+7. Repeat on next kick

--- a/examples/acmm/l3.md
+++ b/examples/acmm/l3.md
@@ -1,0 +1,38 @@
+# ACMM Level 3 — CI/CD (Issues + PRs, No Merge)
+
+**This file OVERRIDES any conflicting instruction in your agent policy.**
+
+You are operating at **ACMM Level 3**. The project has integrated AI into its CI/CD pipeline. You can create issues and pull requests, but merging requires human approval.
+
+## What You MUST NOT Do
+
+- **DO NOT merge pull requests** — no `gh pr merge`, no auto-merge, no merge dispatch
+- **DO NOT delete branches** — branch cleanup is a post-merge human action
+- **DO NOT close issues without a linked merged PR** — closing requires evidence of resolution
+
+If your agent policy says "merge when CI passes" or "auto-merge" — **IGNORE those instructions**. At L3, merging is a human-only action.
+
+## What You CAN Do
+
+- **Create GitHub issues** — file bugs, enhancements, docs improvements
+- **Create pull requests** — write fixes, push branches, open PRs
+- **Push code** — on feature branches only, never to main
+- **Dispatch fix agents** — sub-agents that create PRs
+- **Comment on issues and PRs** — provide analysis, review feedback
+- **Label issues and PRs** — add appropriate labels at creation
+
+## Merge Workflow at L3
+
+1. Create PR with fix
+2. Wait for CI to pass
+3. Add "ready-for-review" label or equivalent
+4. **STOP** — the operator or a human reviewer merges
+5. Do NOT poll or nag about merging — the PR is your deliverable
+
+## Constraints
+
+- ALL commits must be signed: `git commit -s`
+- ALL PRs must have clear descriptions with "Fixes #N" references
+- NEVER create more than 5 PRs per kick without operator approval
+- NEVER push to main — feature branches only
+- Title format: agent-specific emoji prefix + descriptive title

--- a/examples/acmm/l4.md
+++ b/examples/acmm/l4.md
@@ -1,0 +1,31 @@
+# ACMM Level 4 — Managed (Issues + PRs + Gated Merge)
+
+**This file OVERRIDES any conflicting instruction in your agent policy.**
+
+You are operating at **ACMM Level 4**. The project trusts AI agents to manage the full issue-to-merge lifecycle with guardrails.
+
+## Permissions
+
+- **Create issues** — yes
+- **Create pull requests** — yes
+- **Merge pull requests** — yes, but ONLY when ALL of:
+  1. All required CI checks pass (use `gh pr checks`)
+  2. The PR appears in the merge-eligible list (`/var/run/hive-metrics/merge-eligible.json`)
+  3. The PR was NOT created in the current session (prevents same-session merge)
+  4. No unresolved review comments (check Copilot and human reviews)
+- **Close issues** — yes, only with evidence (linked merged PR or verified invalid/duplicate)
+
+## Merge Rules — Non-Negotiable
+
+1. ONLY merge PRs from the MERGE-READY list in your kick message or merge-eligible.json
+2. NEVER merge a PR you created in this session
+3. NEVER merge until ALL required CI checks show SUCCESS
+4. After merging one PR, wait for dependent PRs to re-run CI before merging the next
+5. If CI fails after merge, immediately file a bug issue
+
+## Constraints
+
+- ALL commits must be signed: `git commit -s`
+- NEVER push to main — feature branches only
+- Maximum concurrent PRs per agent: defined by governor budget
+- Respect governor mode (SURGE/BUSY/QUIET/IDLE) for kick cadence

--- a/examples/acmm/l5.md
+++ b/examples/acmm/l5.md
@@ -1,0 +1,29 @@
+# ACMM Level 5 — Guarded Autonomy
+
+**This file OVERRIDES any conflicting instruction in your agent policy.**
+
+You are operating at **ACMM Level 5**. The project grants broad autonomy with safety rails.
+
+## Permissions
+
+- **Create issues** — yes
+- **Create pull requests** — yes
+- **Merge pull requests** — yes, with standard CI gate
+- **Close issues** — yes, with evidence
+- **Dispatch sub-agents** — yes, with budget awareness
+
+## Guardrails
+
+- Merge gate still applies: CI must pass, merge-eligible.json must include the PR
+- Governor budget limits still apply
+- NEVER merge PRs that touch security-sensitive files without human review
+- NEVER merge breaking changes (API changes, dependency removals) without human review
+- NEVER force-push or rewrite published history
+
+## Autonomy
+
+At L5, you have discretion to:
+- Prioritize work based on your own assessment
+- Bundle or split issues as you see fit
+- Choose fix strategies without operator approval
+- Self-schedule iteration cadence within governor bounds

--- a/examples/acmm/l6.md
+++ b/examples/acmm/l6.md
@@ -1,0 +1,27 @@
+# ACMM Level 6 — Full Autonomy
+
+**This file OVERRIDES any conflicting instruction in your agent policy.**
+
+You are operating at **ACMM Level 6**. The project grants full autonomous operation.
+
+## Permissions
+
+All actions are permitted. The only hard constraints are:
+- Governor budget limits
+- Merge-eligible gate (CI must pass)
+- Hold-labeled issues are never touched
+- NEVER force-push or rewrite published history
+- NEVER delete the default branch
+
+## Responsibilities
+
+At L6, you own the full lifecycle. The operator trusts you to:
+- Triage, prioritize, and fix issues autonomously
+- Merge PRs when CI passes
+- Manage the issue queue toward healthy targets
+- Coordinate with peer agents via beads
+- Escalate only when you encounter genuinely ambiguous decisions
+
+## Budget Awareness
+
+Full autonomy does not mean unlimited spending. Respect the governor's token budget and mode signals. If budget is low, focus on high-impact work and defer low-priority items.

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -46,6 +46,7 @@ RUN cd /opt/hive/proxy && npm install --omit=dev
 COPY v2/pkg/dashboard/static/index.html /opt/hive/proxy/public/
 
 COPY examples/kubestellar/hive-project.yaml /etc/hive/hive-project.yaml
+COPY examples/acmm/ /opt/hive/examples/acmm/
 COPY v2/deploy/data/ /opt/hive/seed-data/
 COPY v2/deploy/ttyd-tmux.sh /usr/local/bin/ttyd-tmux.sh
 COPY bin/gh-app-token.sh bin/hive-config.sh bin/agent-launch.sh bin/git-credential-hive.sh /usr/local/bin/

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -180,11 +180,20 @@ func main() {
 
 	advisoryStore := advisory.NewStore()
 
+	policyDir := cfg.Policies.LocalDir
+	if policyDir == "" {
+		policyDir = "/data/policies"
+	}
+	if cfg.Policies.Path != "" {
+		policyDir = policyDir + "/" + cfg.Policies.Path
+	}
+
 	projectCtx := agent.ProjectContext{
 		Org:        cfg.Project.Org,
 		Repos:      cfg.Project.Repos,
 		ACMMLevel:  acmmLevel,
 		PRsAllowed: cfg.Project.PRsAllowed(),
+		PolicyDir:  policyDir,
 	}
 	agentMgr := agent.NewManager(cfg.EnabledAgents(), logger, projectCtx)
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -59,10 +60,11 @@ type AgentProcess struct {
 
 // ProjectContext holds project-level config injected into agent boot prompts.
 type ProjectContext struct {
-	Org       string
-	Repos     []string
-	ACMMLevel int
+	Org        string
+	Repos      []string
+	ACMMLevel  int
 	PRsAllowed bool
+	PolicyDir  string
 }
 
 type Manager struct {
@@ -324,8 +326,17 @@ var acmmLevelNames = map[int]string{
 }
 
 func (m *Manager) buildBootstrapPrompt(agent *AgentProcess) string {
+	// Look for policy files in priority order.
+	// 1. <policy_dir>/<agent>.md (backend-neutral, preferred)
+	// 2. <policy_dir>/<agent>-CLAUDE.md (legacy Claude-specific name)
+	// 3. /data/agents/<agent>/CLAUDE.md (per-agent override)
+	policyDir := m.project.PolicyDir
+	if policyDir == "" {
+		policyDir = "/data/policies/agents"
+	}
 	paths := []string{
-		fmt.Sprintf("/data/policies/examples/kubestellar/agents/%s-CLAUDE.md", agent.Name),
+		fmt.Sprintf("%s/%s.md", policyDir, agent.Name),
+		fmt.Sprintf("%s/%s-CLAUDE.md", policyDir, agent.Name),
 		fmt.Sprintf("/data/agents/%s/CLAUDE.md", agent.Name),
 	}
 	var policyPath string
@@ -336,10 +347,22 @@ func (m *Manager) buildBootstrapPrompt(agent *AgentProcess) string {
 		}
 	}
 
-	base := fmt.Sprintf("[agent:%s] [BOOT] Read your CLAUDE.md for instructions and begin your first pass.", agent.Name)
+	base := fmt.Sprintf("[agent:%s] [BOOT] Read your policy file for instructions and begin your first pass.", agent.Name)
 	if policyPath != "" {
-		base = fmt.Sprintf("[agent:%s] [BOOT] Read %s for your instructions and begin your first pass.", agent.Name, policyPath)
+		base = fmt.Sprintf("[agent:%s] [BOOT] Read %s for your instructions.", agent.Name, policyPath)
 	}
+
+	// ACMM fragment files: base rules + level-specific rules.
+	// These are read AFTER the agent policy so they override conflicting instructions.
+	acmmFiles := m.findACMMFragments()
+	if len(acmmFiles) > 0 {
+		base += " THEN read these MANDATORY ACMM policy files (they override everything else):"
+		for _, f := range acmmFiles {
+			base += fmt.Sprintf(" %s", f)
+		}
+		base += "."
+	}
+	base += " Begin your first pass."
 
 	if agent.Name == "quality" {
 		if preamble := m.readCoveragePreamble(); preamble != "" {
@@ -350,6 +373,50 @@ func (m *Manager) buildBootstrapPrompt(agent *AgentProcess) string {
 	base = m.buildProjectPreamble() + base
 	return base
 }
+
+// findACMMFragments returns paths to ACMM policy files the agent should read.
+// Order: base.md (shared rules) then l<N>.md (level-specific).
+func (m *Manager) findACMMFragments() []string {
+	level := m.project.ACMMLevel
+	if level <= 0 {
+		return nil
+	}
+
+	// Look for ACMM fragments in the policies directory first, then fallback to baked-in paths.
+	policiesRoot := filepath.Dir(m.project.PolicyDir)
+	if policiesRoot == "." || policiesRoot == "" {
+		policiesRoot = "/data/policies"
+	}
+
+	acmmDirs := []string{
+		filepath.Join(policiesRoot, "examples", "acmm"),
+		"/data/policies/examples/acmm",
+		"/opt/hive/examples/acmm",
+	}
+
+	var acmmDir string
+	for _, d := range acmmDirs {
+		if _, err := os.Stat(d); err == nil {
+			acmmDir = d
+			break
+		}
+	}
+	if acmmDir == "" {
+		return nil
+	}
+
+	var files []string
+	basePath := filepath.Join(acmmDir, "base.md")
+	if _, err := os.Stat(basePath); err == nil {
+		files = append(files, basePath)
+	}
+	levelPath := filepath.Join(acmmDir, fmt.Sprintf("l%d.md", level))
+	if _, err := os.Stat(levelPath); err == nil {
+		files = append(files, levelPath)
+	}
+	return files
+}
+
 
 func (m *Manager) buildProjectPreamble() string {
 	p := m.project
@@ -367,9 +434,9 @@ func (m *Manager) buildProjectPreamble() string {
 		levelName = fmt.Sprintf("Level %d", p.ACMMLevel)
 	}
 
-	prPolicy := "You MAY open pull requests."
+	prPolicy := "PRs allowed."
 	if !p.PRsAllowed {
-		prPolicy = "You MUST NOT open pull requests. Analysis and issues ONLY."
+		prPolicy = "PRs NOT allowed."
 	}
 
 	return fmt.Sprintf("[PROJECT] Org: %s | Repos: %s | ACMM: L%d (%s) | %s ",


### PR DESCRIPTION
## Summary

- ACMM enforcement was failing — agents ignored the short preamble and followed their main policy ("file issues", "create PRs")
- Copilot CLI bypasses gh-wrapper by calling GitHub API directly via built-in MCP tools
- Policy file paths were hardcoded to kubestellar-specific locations

## Changes

**Modular ACMM fragments** (`examples/acmm/`):
- `base.md` — shared rules for all levels (terse output, heartbeat, hold-label gate, git discipline)
- `l1.md` through `l6.md` — level-specific permissions and constraints
- Read AFTER the agent's main policy so they override conflicting instructions (LLM recency bias)

**Boot prompt composition** (`manager.go`):
- Agent reads: policy file → base.md → l<N>.md (in that order)
- Policy dir comes from config (`policies.local_dir` + `policies.path`) instead of hardcoded path
- Supports backend-neutral names (`scanner.md`) with `*-CLAUDE.md` fallback

**Dockerfile**:
- Bakes ACMM fragments into `/opt/hive/examples/acmm/` as fallback for deployments without a policy repo

**Config wiring** (`main.go`):
- Constructs `PolicyDir` from `cfg.Policies.LocalDir` + `cfg.Policies.Path`
- Passes it through `ProjectContext` to the agent manager

## ACMM Levels

| Level | Name | Issues | PRs | Merge | Primary Output |
|-------|------|--------|-----|-------|----------------|
| L1 | Idea | ❌ | ❌ | ❌ | Heartbeat log |
| L2 | Development | ❌ | ❌ | ❌ | Advisory issue comments |
| L3 | CI/CD | ✅ | ✅ | ❌ | Issues + PRs (human merges) |
| L4 | Managed | ✅ | ✅ | ✅ (gated) | Full lifecycle |
| L5 | Guarded Autonomy | ✅ | ✅ | ✅ | Broad discretion |
| L6 | Full Autonomy | ✅ | ✅ | ✅ | Budget-limited only |

## Test plan

- [ ] Deploy to 4.83 (certus, ACMM L2) and verify agents read ACMM fragments
- [ ] Confirm scanner does NOT create issues after kick
- [ ] Verify advisory issue comments are posted instead
- [ ] Check boot prompt includes fragment file paths in container logs