### PR TITLE
fix supervisor crash-loop in container, start dashboard

### DIFF
--- a/bin/container-entrypoint.sh
+++ b/bin/container-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Container entrypoint — starts dashboard + supervisor together.
+# The dashboard runs in the background; supervisor is the foreground process
+# so Docker tracks its lifecycle for health checks and restarts.
+set -euo pipefail
+
+DASHBOARD_DIR="/opt/hive/dashboard"
+DASHBOARD_LOG="/data/logs/dashboard.log"
+
+if [ -f "$DASHBOARD_DIR/server.js" ] && [ -f "$DASHBOARD_DIR/node_modules/.package-lock.json" ]; then
+  echo "[entrypoint] starting dashboard server"
+  cd "$DASHBOARD_DIR"
+  node server.js >> "$DASHBOARD_LOG" 2>&1 &
+  DASHBOARD_PID=$!
+  echo "[entrypoint] dashboard PID=$DASHBOARD_PID"
+  cd /data
+else
+  echo "[entrypoint] dashboard not available (missing server.js or node_modules)"
+fi
+
+exec /opt/hive/bin/supervisor.sh "$@"

--- a/bin/supervisor.sh
+++ b/bin/supervisor.sh
@@ -408,12 +408,12 @@ while true; do
     sync_launch_cmd_from_governor
     start_session
   else
-    handle_startup_dialogs
-    check_prompt_delivered
-    approve_prompt_if_present
-    dismiss_prompts_if_present
-    notify_if_phrase_present
-    check_rate_limit_and_failover
+    handle_startup_dialogs || true
+    check_prompt_delivered || true
+    approve_prompt_if_present || true
+    dismiss_prompts_if_present || true
+    notify_if_phrase_present || true
+    check_rate_limit_and_failover || true
   fi
   sleep "$POLL_SEC"
 done

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -78,4 +78,4 @@ EXPOSE 3001
 HEALTHCHECK --interval=60s --timeout=5s --start-period=120s --retries=3 \
   CMD find /data/logs -name "heartbeat.log" -mmin -30 | grep -q . || exit 1
 
-ENTRYPOINT ["/opt/hive/bin/supervisor.sh"]
+ENTRYPOINT ["/opt/hive/bin/container-entrypoint.sh"]


### PR DESCRIPTION
## Summary
- **supervisor.sh**: Main loop polling functions (`check_prompt_delivered`, `handle_startup_dialogs`, etc.) return non-zero when the agent CLI is slow to start or unauthenticated. With `set -e`, this kills the supervisor process, causing a Docker restart loop every 1-2 seconds. Fixed by adding `|| true` guards to all polling calls in the main loop.
- **container-entrypoint.sh**: New entrypoint script that starts the dashboard server (node `server.js` on port 3001) in the background before exec'ing into the supervisor. Previously the dashboard was only started by a separate systemd service on bare metal.
- **Dockerfile**: Updated entrypoint from `supervisor.sh` to `container-entrypoint.sh`.

## Root cause
`check_prompt_delivered` returns 1 when the prompt hasn't been delivered yet (normal during startup). Under `set -euo pipefail`, this non-zero return from a bare function call in the main loop terminates the entire script. On bare metal this was masked because the agent CLI starts fast with stored credentials. In the container, the CLI is unauthenticated on first boot, so the pane is empty when polled.

## Test plan
- [ ] Build container: `docker compose build` from v2/
- [ ] Run on Flatcar VM: container starts without crash-loop
- [ ] Dashboard accessible at http://<host>:3001
- [ ] Supervisor correctly restarts tmux sessions when agent exits