### PR TITLE
add v2 branch container build with v2-latest tag

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -2,7 +2,7 @@ name: Container Build
 
 on:
   push:
-    branches: [main]
+    branches: [main, v2]
     paths:
       - 'bin/**'
       - 'config/**'
@@ -57,6 +57,7 @@ jobs:
           tags: |
             type=sha,prefix=
             type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=v2-latest,enable=${{ github.ref == 'refs/heads/v2' }}
             type=ref,event=pr
 
       - name: Build and push


### PR DESCRIPTION
## Summary
- Add `v2` to container-build workflow push branches
- Tag v2 branch builds as `v2-latest` (main stays `latest`)
- Enables deploying v2 containers on Flatcar/Knuckle hosts

## Test plan
- [ ] Push to v2 branch triggers container build
- [ ] Image tagged `v2-latest` appears in GHCR
- [ ] `docker pull ghcr.io/kubestellar/hive:v2-latest` works