### PR TITLE
tag v2 container builds as v2-latest instead of latest

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/kubestellar/hive:latest
+            ghcr.io/kubestellar/hive:v2-latest
             ghcr.io/kubestellar/hive:${{ steps.meta.outputs.git_short }}
           build-args: |
             GIT_HASH=${{ steps.meta.outputs.git_hash }}


### PR DESCRIPTION
## Summary
- Stop v2 branch builds from overwriting main's `:latest` tag
- v2 builds now produce `:v2-latest` and `:<short-sha>` tags
- Flatcar/Knuckle hosts can pin to `v2-latest` for stable v2 deployments

## Test plan
- [ ] Push to v2 triggers build with `v2-latest` tag
- [ ] `docker pull ghcr.io/kubestellar/hive:v2-latest` works
- [ ] Main branch `:latest` tag unaffected