### PR TITLE
add guide agent archetype with emoji

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -692,6 +692,12 @@ func applyKnownAgentDefaults(name string, agent *AgentConfig) {
 			DetectKeywords: []string{"strategist", "strategy"},
 			BeadRole: "worker", SortOrder: 70, IncludeRepos: true,
 		},
+		"guide": {
+			Emoji: "📖", Color: "#8e44ad", Aliases: []string{"gu"},
+			LaneKeywords:   []string{"docs", "documentation", "readme", "guide", "tutorial", "onboarding"},
+			DetectKeywords: []string{"guide", "docs", "documentation"},
+			BeadRole: "worker", SortOrder: 45, IncludeRepos: true,
+		},
 	}
 
 	k, ok := known[name]


### PR DESCRIPTION
## Summary
- Add `guide` to the known-agent defaults map in `config.go`
- Emoji: 📖, color: #8e44ad, lane keywords: docs/documentation/guide/tutorial/onboarding
- Fixes the missing emoji in the sidebar for guide agents (visible on knuckle deployment)

## Test plan
- [ ] Deploy updated v2 container to 4.85
- [ ] Verify guide shows 📖 emoji in sidebar