### PR TITLE
feat: add default cadence tables to ACMM packs

### DIFF
--- a/v2/pkg/config/acmm_packs.go
+++ b/v2/pkg/config/acmm_packs.go
@@ -43,8 +43,9 @@ type PackAgent struct {
 
 // PackGovernor describes the governor configuration recommended for a level.
 type PackGovernor struct {
-	Modes       string `json:"modes" yaml:"modes"`
-	MergePolicy string `json:"mergePolicy" yaml:"merge_policy"`
+	Modes       string                       `json:"modes" yaml:"modes"`
+	MergePolicy string                       `json:"mergePolicy" yaml:"merge_policy"`
+	Cadences    map[string]map[string]string `json:"cadences,omitempty" yaml:"cadences,omitempty"`
 }
 
 // ACMMPacks returns the built-in ACMM level pack definitions loaded from

--- a/v2/pkg/config/packs/level-2.yaml
+++ b/v2/pkg/config/packs/level-2.yaml
@@ -7,6 +7,17 @@ description: >
 governor:
   modes: none
   merge_policy: manual
+  cadences:
+    quiet:
+      supervisor: 5m
+      guide: 1h
+      scanner: 2h
+      quality: 2h
+    idle:
+      supervisor: 5m
+      guide: 2h
+      scanner: 2h
+      quality: 2h
 agents:
   - name: supervisor
     display_name: Supervisor

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -102,6 +102,22 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 
 	s.deps.Config.ACMMLevel = &level
 
+	if len(pack.Governor.Cadences) > 0 {
+		if s.deps.Config.Governor.Modes == nil {
+			s.deps.Config.Governor.Modes = make(map[string]config.ModeConfig)
+		}
+		for modeName, agentCadences := range pack.Governor.Cadences {
+			mode := s.deps.Config.Governor.Modes[modeName]
+			if mode.Cadences == nil {
+				mode.Cadences = make(map[string]string)
+			}
+			for agent, interval := range agentCadences {
+				mode.Cadences[agent] = interval
+			}
+			s.deps.Config.Governor.Modes[modeName] = mode
+		}
+	}
+
 	if len(created) > 0 {
 		s.reInitSubsystems()
 	}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1655,11 +1655,12 @@
     <h4 style="font-size:0.82rem;color:#f0f6fc;margin:14px 0 6px 0;">Agents</h4>
     <ul style="list-style:none;padding:0;margin:0 0 14px 0;font-size:0.78rem;color:#8b949e;line-height:1.6;">
       <li><strong style="color:#c9d1d9;">Scanner</strong> &mdash; triages issues, dispatches fixes, merges PRs</li>
+      <li><strong style="color:#c9d1d9;">Guide</strong> &mdash; architecture analysis, code walkthroughs, advisory reviews</li>
       <li><strong style="color:#c9d1d9;">CI-Maintainer</strong> &mdash; CI health, workflow fixes, GA4 monitoring</li>
       <li><strong style="color:#c9d1d9;">Architect</strong> &mdash; cross-cutting RFCs, refactors, new features</li>
       <li><strong style="color:#c9d1d9;">Outreach</strong> &mdash; ADOPTERS outreach, community engagement</li>
       <li><strong style="color:#c9d1d9;">Sec-Check</strong> &mdash; security gate on PRs, contributor vetting</li>
-      <li><strong style="color:#c9d1d9;">Tester</strong> &mdash; test coverage, integration tests, quality gates</li>
+      <li><strong style="color:#c9d1d9;">Quality</strong> &mdash; test coverage, integration tests, quality gates</li>
       <li><strong style="color:#c9d1d9;">Strategist</strong> &mdash; experiment design, A/B testing, strategy lab</li>
       <li><strong style="color:#c9d1d9;">Supervisor</strong> &mdash; monitors all agents, detects stalls, reports status</li>
     </ul>


### PR DESCRIPTION
## Summary
- Add `cadences` field to `PackGovernor` (mode → agent → interval map)
- L2 pack now ships with default cadences: scanner/quality at 2h, guide at 1h, supervisor at 5m
- Cadences are applied to governor config when a pack is activated via `POST /api/packs/{level}/apply`
- User's hive.yaml can override any pack cadence

At L2 (advisory-only), the scanner checks a near-empty queue — 2h intervals save tokens without losing responsiveness.

## Test plan
- [ ] `go build ./...` passes
- [ ] Apply L2 pack via API — verify governor modes get cadence entries
- [ ] Override scanner cadence in hive.yaml — verify user config wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)