### PR TITLE
feat: complete ACMM L2 pack + auto-apply + audit fixes

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -717,6 +717,10 @@ func runEvalCycle(
 		if err != nil {
 			logger.Warn("failed to read advisory findings", "error", err)
 		} else if len(findings) > 0 {
+			if persisted := advisory.PersistAsBeads(findings, beadStores); persisted > 0 {
+				logger.Info("advisory findings persisted as beads", "count", persisted)
+			}
+
 			digest := advisory.BuildDigest(findings, string(govState.Mode))
 			advisoryStore.SetLatestDigest(digest)
 			dashSrv.SetAdvisoryDigest(digest)

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -12,6 +12,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -199,8 +200,9 @@ func main() {
 
 	const statePath = "/data/hive-state.json"
 	var savedIssueCosts map[string]int64
-	if saved, err := snapshot.LoadState(statePath, logger); err != nil {
-		logger.Warn("failed to load persisted state", "error", err)
+	saved, stateErr := snapshot.LoadState(statePath, logger)
+	if stateErr != nil {
+		logger.Warn("failed to load persisted state", "error", stateErr)
 	} else if saved != nil {
 		savedIssueCosts = saved.IssueCosts
 		for name, as := range saved.Agents {
@@ -459,6 +461,33 @@ func main() {
 			initAgentConfigDrivenSystems(cfg)
 		},
 	})
+
+	if saved == nil {
+		if levelStr := os.Getenv("HIVE_LEVEL"); levelStr != "" {
+			const maxACMMLevel = 6
+			level, err := strconv.Atoi(levelStr)
+			if err != nil || level < 1 || level > maxACMMLevel {
+				logger.Warn("invalid HIVE_LEVEL, skipping auto-apply", "value", levelStr)
+			} else {
+				logger.Info("first start detected, auto-applying ACMM pack", "level", level)
+				result, err := dashSrv.ApplyPack(level)
+				if err != nil {
+					logger.Error("failed to auto-apply ACMM pack", "level", level, "error", err)
+				} else {
+					logger.Info("ACMM pack auto-applied",
+						"level", level,
+						"name", result.Name,
+						"created", result.Created,
+						"skipped", result.Skipped,
+						"paused", result.Paused,
+						"resumed", result.Resumed,
+					)
+				}
+			}
+		}
+	} else if os.Getenv("HIVE_LEVEL") != "" {
+		logger.Info("existing state found, skipping ACMM auto-apply")
+	}
 
 	if cfg.Policies.Repo != "" {
 		localDir := cfg.Policies.LocalDir

--- a/v2/deploy/docker-compose.architect.yaml
+++ b/v2/deploy/docker-compose.architect.yaml
@@ -8,7 +8,7 @@ services:
     ports:
       - "3001:3001"
     volumes:
-      - ./architect-only.yaml:/etc/hive/hive.yaml:ro
+      - ./architect-only.yaml:/etc/hive/hive.yaml
       - hive-data:/data
     environment:
       - HIVE_GITHUB_TOKEN=${HIVE_GITHUB_TOKEN}

--- a/v2/deploy/docker-compose.architect.yaml
+++ b/v2/deploy/docker-compose.architect.yaml
@@ -14,6 +14,8 @@ services:
       - HIVE_GITHUB_TOKEN=${HIVE_GITHUB_TOKEN}
       - HIVE_DASHBOARD_TOKEN=${HIVE_DASHBOARD_TOKEN}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - HIVE_LEVEL=${HIVE_LEVEL:-}
+      - HIVE_REPO=${HIVE_REPO:-}
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:3001/api/health"]
       interval: 30s

--- a/v2/docker-compose.yaml
+++ b/v2/docker-compose.yaml
@@ -39,6 +39,8 @@ services:
       - HIVE_DASHBOARD_TOKEN=${HIVE_DASHBOARD_TOKEN}
       - NTFY_SERVER=${NTFY_SERVER}
       - NTFY_TOPIC=${NTFY_TOPIC}
+      - HIVE_LEVEL=${HIVE_LEVEL:-}
+      - HIVE_REPO=${HIVE_REPO:-}
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:3001/api/health"]
       interval: 10s

--- a/v2/docker-compose.yaml
+++ b/v2/docker-compose.yaml
@@ -31,7 +31,7 @@ services:
       - "3001"
       - "7681"
     volumes:
-      - ./hive.yaml:/etc/hive/hive.yaml:ro
+      - ./hive.yaml:/etc/hive/hive.yaml
       - hive-data:/data
       - ./secrets:/secrets:ro
     environment:

--- a/v2/pkg/advisory/advisory.go
+++ b/v2/pkg/advisory/advisory.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/beads"
 )
 
 const advisoryDir = "/data/advisory"
@@ -120,53 +122,65 @@ func BuildDigest(findings []Finding, mode string) *Digest {
 }
 
 // FormatDigestMarkdown formats a digest as markdown for posting to GitHub.
+// Findings are grouped by severity (high→low) with a summary table, then
+// listed with their source agent — this gives repo owners a quick "what matters"
+// view without reading per-agent sections.
 func FormatDigestMarkdown(d *Digest) string {
 	if d.TotalCount == 0 {
 		return ""
 	}
 
+	var all []Finding
+	for _, findings := range d.ByAgent {
+		all = append(all, findings...)
+	}
+
+	bySeverity := map[string][]Finding{}
+	for _, f := range all {
+		sev := f.Severity
+		if sev == "" {
+			sev = "info"
+		}
+		bySeverity[sev] = append(bySeverity[sev], f)
+	}
+
+	sevOrder := []string{"critical", "high", "medium", "low", "info"}
+
 	var b strings.Builder
 	b.WriteString(fmt.Sprintf("## 🐝 Advisory Digest — %s\n\n", d.GeneratedAt.Format("2006-01-02 15:04 MST")))
 	b.WriteString(fmt.Sprintf("**Mode:** %s | **Findings:** %d\n\n", d.Mode, d.TotalCount))
 
-	agents := make([]string, 0, len(d.ByAgent))
-	for a := range d.ByAgent {
-		agents = append(agents, a)
-	}
-	sort.Strings(agents)
-
-	for _, agent := range agents {
-		findings := d.ByAgent[agent]
-		b.WriteString(fmt.Sprintf("### %s (%d)\n\n", agent, len(findings)))
-
-		bySeverity := map[string][]Finding{}
-		for _, f := range findings {
-			sev := f.Severity
-			if sev == "" {
-				sev = "info"
-			}
-			bySeverity[sev] = append(bySeverity[sev], f)
+	b.WriteString("| Severity | Count |\n|----------|-------|\n")
+	for _, sev := range sevOrder {
+		items := bySeverity[sev]
+		if len(items) == 0 {
+			continue
 		}
+		b.WriteString(fmt.Sprintf("| %s %s | %d |\n", severityIcon(sev), sev, len(items)))
+	}
+	b.WriteString("\n")
 
-		sevOrder := []string{"critical", "high", "medium", "low", "info"}
-		for _, sev := range sevOrder {
-			items, ok := bySeverity[sev]
-			if !ok {
-				continue
+	for _, sev := range sevOrder {
+		items, ok := bySeverity[sev]
+		if !ok {
+			continue
+		}
+		sort.Slice(items, func(i, j int) bool {
+			return items[i].Agent < items[j].Agent
+		})
+		icon := severityIcon(sev)
+		b.WriteString(fmt.Sprintf("### %s %s (%d)\n\n", icon, strings.ToUpper(sev), len(items)))
+		for _, f := range items {
+			loc := ""
+			if f.File != "" {
+				loc = fmt.Sprintf(" `%s`", f.File)
+				if f.Line > 0 {
+					loc = fmt.Sprintf(" `%s:%d`", f.File, f.Line)
+				}
 			}
-			icon := severityIcon(sev)
-			for _, f := range items {
-				loc := ""
-				if f.File != "" {
-					loc = fmt.Sprintf(" `%s`", f.File)
-					if f.Line > 0 {
-						loc = fmt.Sprintf(" `%s:%d`", f.File, f.Line)
-					}
-				}
-				b.WriteString(fmt.Sprintf("- %s **[%s]** %s%s\n", icon, f.Type, f.Title, loc))
-				if f.Detail != "" {
-					b.WriteString(fmt.Sprintf("  > %s\n", f.Detail))
-				}
+			b.WriteString(fmt.Sprintf("- **[%s]** %s%s _%s_\n", f.Type, f.Title, loc, f.Agent))
+			if f.Detail != "" {
+				b.WriteString(fmt.Sprintf("  > %s\n", f.Detail))
 			}
 		}
 		b.WriteString("\n")
@@ -186,6 +200,73 @@ func (s *Store) LatestDigest() *Digest {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.latestDigest
+}
+
+// severityToPriority maps advisory severity strings to bead priority values.
+func severityToPriority(sev string) beads.Priority {
+	switch sev {
+	case "critical":
+		return beads.PriorityCritical
+	case "high":
+		return beads.PriorityHigh
+	case "medium":
+		return beads.PriorityMedium
+	case "low":
+		return beads.PriorityLow
+	default:
+		return beads.PriorityMinor
+	}
+}
+
+// PersistAsBeads stores advisory findings as beads in the given bead stores,
+// keyed by agent name. Findings are deduplicated by title — if a bead with the
+// same title already exists for an agent, it is skipped.
+func PersistAsBeads(findings []Finding, stores map[string]*beads.Store) (created int) {
+	for _, f := range findings {
+		store, ok := stores[f.Agent]
+		if !ok {
+			continue
+		}
+
+		existing := store.List(beads.ListFilter{})
+		dup := false
+		for _, b := range existing {
+			if b.Title == f.Title && b.Type == beads.TypeAdvisory {
+				dup = true
+				break
+			}
+		}
+		if dup {
+			continue
+		}
+
+		ref := ""
+		if f.File != "" {
+			ref = f.File
+			if f.Line > 0 {
+				ref = fmt.Sprintf("%s:%d", f.File, f.Line)
+			}
+		}
+
+		meta := map[string]string{
+			"severity":       f.Severity,
+			"finding_type":   f.Type,
+			"advisory_agent": f.Agent,
+		}
+		if f.Detail != "" {
+			meta["detail"] = f.Detail
+		}
+
+		b, err := store.Create(f.Title, beads.TypeAdvisory, severityToPriority(f.Severity), f.Agent, ref)
+		if err != nil {
+			continue
+		}
+		for k, v := range meta {
+			_ = store.SetMetadata(b.ID, k, v)
+		}
+		created++
+	}
+	return created
 }
 
 func severityIcon(sev string) string {

--- a/v2/pkg/beads/beads.go
+++ b/v2/pkg/beads/beads.go
@@ -31,6 +31,7 @@ const (
 	TypeEpic     BeadType = "epic"
 	TypeChore    BeadType = "chore"
 	TypeDecision BeadType = "decision"
+	TypeAdvisory BeadType = "advisory"
 )
 
 type Priority int

--- a/v2/pkg/config/acmm_packs.go
+++ b/v2/pkg/config/acmm_packs.go
@@ -39,13 +39,16 @@ type PackAgent struct {
 	Interactions string   `json:"interactions" yaml:"interactions"`
 	KnowledgeUse string   `json:"knowledgeUse" yaml:"knowledge_use"`
 	Hidden       bool     `json:"hidden,omitempty" yaml:"hidden"`
+	StaleTimeout int      `json:"staleTimeout,omitempty" yaml:"stale_timeout,omitempty"`
 }
 
 // PackGovernor describes the governor configuration recommended for a level.
 type PackGovernor struct {
-	Modes       string                       `json:"modes" yaml:"modes"`
-	MergePolicy string                       `json:"mergePolicy" yaml:"merge_policy"`
-	Cadences    map[string]map[string]string `json:"cadences,omitempty" yaml:"cadences,omitempty"`
+	Modes         string                       `json:"modes" yaml:"modes"`
+	MergePolicy   string                       `json:"mergePolicy" yaml:"merge_policy"`
+	EvalIntervalS int                          `json:"evalIntervalS,omitempty" yaml:"eval_interval_s,omitempty"`
+	Cadences      map[string]map[string]string `json:"cadences,omitempty" yaml:"cadences,omitempty"`
+	Thresholds    map[string]int               `json:"thresholds,omitempty" yaml:"thresholds,omitempty"`
 }
 
 // ACMMPacks returns the built-in ACMM level pack definitions loaded from

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -497,6 +497,12 @@ const (
 )
 
 func (c *Config) applyDefaults() {
+	if c.Project.PrimaryRepo != "" && c.Project.Org != "" {
+		prefix := c.Project.Org + "/"
+		if strings.HasPrefix(c.Project.PrimaryRepo, prefix) {
+			c.Project.PrimaryRepo = strings.TrimPrefix(c.Project.PrimaryRepo, prefix)
+		}
+	}
 	if c.Dashboard.Port == 0 {
 		c.Dashboard.Port = defaultDashboardPort
 	}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -346,6 +346,7 @@ func LoadWithOverrides(path, envPath string) (*Config, error) {
 		}
 	}
 
+	cfg.applyBootstrapEnv()
 	cfg.applyDefaults()
 
 	// Merge per-agent overlay files from the agents directory.
@@ -451,6 +452,17 @@ func (c *Config) applyConfigEnv(path string) error {
 	}
 
 	return nil
+}
+
+func (c *Config) applyBootstrapEnv() {
+	if repo := os.Getenv("HIVE_REPO"); repo != "" {
+		parts := strings.SplitN(repo, "/", 2)
+		if len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+			c.Project.Org = parts[0]
+			c.Project.Repos = []string{parts[1]}
+			c.Project.PrimaryRepo = parts[1]
+		}
+	}
 }
 
 func expandEnvVars(s string) string {

--- a/v2/pkg/config/packs/level-1.yaml
+++ b/v2/pkg/config/packs/level-1.yaml
@@ -7,6 +7,12 @@ description: >
 governor:
   modes: none
   merge_policy: manual
+  eval_interval_s: 600
+  cadences:
+    quiet:
+      guide: 2h
+    idle:
+      guide: 4h
 agents:
   - name: guide
     display_name: guide
@@ -23,6 +29,7 @@ agents:
     bead_role: worker
     kick_template: guide-CLAUDE.md
     include_repos: false
+    stale_timeout: 7200
     interactions: "Standalone. Responds to user queries only."
     knowledge_use: >
       Heavy consumer — reads community wiki, project patterns, and scaffolding

--- a/v2/pkg/config/packs/level-2.yaml
+++ b/v2/pkg/config/packs/level-2.yaml
@@ -11,14 +11,14 @@ governor:
   cadences:
     quiet:
       supervisor: 5m
-      guide: 1h
-      scanner: 2h
-      quality: 2h
+      guide: 4h
+      scanner: 4h
+      quality: 6h
     idle:
       supervisor: 5m
-      guide: 2h
-      scanner: 2h
-      quality: 2h
+      guide: 8h
+      scanner: 6h
+      quality: 8h
 agents:
   - name: supervisor
     display_name: Supervisor
@@ -81,18 +81,18 @@ agents:
       Reads project patterns and known issues. Produces findings as knowledge
       entries for the team to review.
   - name: quality
-    display_name: quality
+    display_name: quality (advisory)
     role: quality
     description: >
-      Generates test cases for existing code. Focuses on coverage gaps and
-      edge cases. All tests require human review before merging.
+      Analyzes test coverage gaps and suggests test strategies. At L2, reports
+      findings to the advisory issue — does NOT create PRs or push code.
     emoji: "🧪"
     color: "#e67e22"
     sort_order: 25
     backend: copilot
     model: claude-sonnet-4-6
     bead_role: worker
-    kick_template: quality-CLAUDE.md
+    kick_template: quality-advisory-CLAUDE.md
     include_repos: true
     stale_timeout: 7200
     interactions: "Complements scanner findings with targeted tests. Guide reviews test quality."

--- a/v2/pkg/config/packs/level-2.yaml
+++ b/v2/pkg/config/packs/level-2.yaml
@@ -7,6 +7,7 @@ description: >
 governor:
   modes: none
   merge_policy: manual
+  eval_interval_s: 600
   cadences:
     quiet:
       supervisor: 5m
@@ -33,6 +34,7 @@ agents:
     bead_role: supervisor
     kick_template: supervisor-CLAUDE.md
     include_repos: true
+    stale_timeout: 1800
     interactions: >
       Monitors all agents. Escalates issues to human operators. Coordinates
       agent restarts and health checks.
@@ -53,6 +55,7 @@ agents:
     bead_role: worker
     kick_template: guide-CLAUDE.md
     include_repos: false
+    stale_timeout: 3600
     interactions: "Works alongside scanner. Reviews scanner's suggestions when asked."
     knowledge_use: >
       Reads community wiki and project patterns. Starts contributing review
@@ -71,6 +74,7 @@ agents:
     bead_role: worker
     kick_template: scanner-advisory-CLAUDE.md
     include_repos: true
+    stale_timeout: 7200
     lane_keywords: [bug, triage, fix]
     interactions: "Produces findings that guide can review. No autonomous actions."
     knowledge_use: >
@@ -90,6 +94,7 @@ agents:
     bead_role: worker
     kick_template: quality-CLAUDE.md
     include_repos: true
+    stale_timeout: 7200
     interactions: "Complements scanner findings with targeted tests. Guide reviews test quality."
     knowledge_use: >
       Reads test patterns, coverage rules, and known regressions from the

--- a/v2/pkg/config/packs/level-3.yaml
+++ b/v2/pkg/config/packs/level-3.yaml
@@ -7,6 +7,25 @@ description: >
 governor:
   modes: QUIET, IDLE
   merge_policy: CI must pass (merge-gate.sh)
+  eval_interval_s: 300
+  thresholds:
+    quiet: 3
+    idle: 0
+  cadences:
+    quiet:
+      supervisor: 5m
+      scanner: 30m
+      ci-maintainer: 30m
+      architect: 1h
+      quality: 1h
+      guide: 1h
+    idle:
+      supervisor: 5m
+      scanner: 1h
+      ci-maintainer: 1h
+      architect: 2h
+      quality: 2h
+      guide: 2h
 agents:
   - name: supervisor
     display_name: Supervisor
@@ -22,6 +41,7 @@ agents:
     bead_role: supervisor
     kick_template: supervisor-CLAUDE.md
     include_repos: true
+    stale_timeout: 1800
     interactions: >
       Monitors all agents. Escalates issues to human operators. Coordinates
       agent restarts and health checks.
@@ -42,6 +62,7 @@ agents:
     bead_role: worker
     kick_template: scanner-CLAUDE.md
     include_repos: true
+    stale_timeout: 3600
     lane_keywords: [bug, triage, fix, issue]
     interactions: >
       Creates PRs that ci-maintainer monitors. Transfers complex issues to
@@ -63,6 +84,7 @@ agents:
     bead_role: worker
     kick_template: ci-maintainer-CLAUDE.md
     include_repos: true
+    stale_timeout: 3600
     lane_keywords: [ci, build, pipeline, workflow]
     interactions: >
       Watches scanner's PRs for CI failures. Coordinates with architect on
@@ -84,6 +106,7 @@ agents:
     bead_role: worker
     kick_template: architect-CLAUDE.md
     include_repos: true
+    stale_timeout: 7200
     lane_keywords: [refactor, architecture, rfc, design]
     interactions: >
       Receives complex issues from scanner. Produces RFCs that other agents
@@ -105,6 +128,7 @@ agents:
     bead_role: worker
     kick_template: quality-CLAUDE.md
     include_repos: true
+    stale_timeout: 3600
     lane_keywords: [test, coverage, quality, regression]
     interactions: >
       Uses scanner findings to generate targeted tests. CI-maintainer validates

--- a/v2/pkg/config/packs/level-4.yaml
+++ b/v2/pkg/config/packs/level-4.yaml
@@ -7,6 +7,49 @@ description: >
 governor:
   modes: SURGE, BUSY, QUIET, IDLE
   merge_policy: CI + coverage gate (90%+)
+  eval_interval_s: 300
+  thresholds:
+    surge: 10
+    busy: 5
+    quiet: 2
+    idle: 0
+  cadences:
+    surge:
+      supervisor: 2m
+      scanner: 10m
+      ci-maintainer: 10m
+      quality: 15m
+      architect: 30m
+      outreach: 1h
+      sec-check: 30m
+      strategist: 1h
+    busy:
+      supervisor: 3m
+      scanner: 15m
+      ci-maintainer: 15m
+      quality: 30m
+      architect: 1h
+      outreach: 2h
+      sec-check: 1h
+      strategist: 2h
+    quiet:
+      supervisor: 5m
+      scanner: 30m
+      ci-maintainer: 30m
+      quality: 1h
+      architect: 2h
+      outreach: 4h
+      sec-check: 2h
+      strategist: 4h
+    idle:
+      supervisor: 5m
+      scanner: 1h
+      ci-maintainer: 1h
+      quality: 2h
+      architect: 4h
+      outreach: 8h
+      sec-check: 4h
+      strategist: 8h
 agents:
   - name: supervisor
     display_name: supervisor
@@ -22,6 +65,7 @@ agents:
     bead_role: supervisor
     kick_template: supervisor-CLAUDE.md
     include_repos: true
+    stale_timeout: 900
     interactions: >
       Monitors all agents. Escalates issues to human operators. Coordinates
       agent restarts and health checks.
@@ -42,6 +86,7 @@ agents:
     bead_role: worker
     kick_template: scanner-CLAUDE.md
     include_repos: true
+    stale_timeout: 1800
     lane_keywords: [bug, triage, fix, issue]
     interactions: >
       Creates PRs that quality validates. Transfers complex issues to architect.
@@ -63,6 +108,7 @@ agents:
     bead_role: worker
     kick_template: ci-maintainer-CLAUDE.md
     include_repos: true
+    stale_timeout: 1800
     lane_keywords: [ci, build, pipeline, workflow, dependency]
     interactions: >
       Coordinates with quality on coverage gates. Reports pipeline health
@@ -84,6 +130,7 @@ agents:
     bead_role: worker
     kick_template: quality-CLAUDE.md
     include_repos: true
+    stale_timeout: 1800
     lane_keywords: [test, coverage, tdd, quality]
     interactions: >
       Reviews scanner PRs for test coverage. Coordinates with ci-maintainer
@@ -105,6 +152,7 @@ agents:
     bead_role: worker
     kick_template: architect-CLAUDE.md
     include_repos: true
+    stale_timeout: 3600
     lane_keywords: [refactor, architecture, rfc, design, feature]
     interactions: >
       Receives complex issues from scanner. Produces RFCs that all agents
@@ -126,6 +174,7 @@ agents:
     bead_role: worker
     kick_template: outreach-CLAUDE.md
     include_repos: false
+    stale_timeout: 3600
     lane_keywords: [community, adopters, outreach, ecosystem]
     interactions: >
       Independent agent. Reports adoption metrics to supervisor.
@@ -146,6 +195,7 @@ agents:
     bead_role: worker
     kick_template: sec-check-CLAUDE.md
     include_repos: true
+    stale_timeout: 1800
     lane_keywords: [security, cve, vulnerability, audit]
     interactions: >
       Reports critical findings to supervisor for escalation. Coordinates
@@ -167,6 +217,7 @@ agents:
     bead_role: worker
     kick_template: strategist-CLAUDE.md
     include_repos: false
+    stale_timeout: 3600
     lane_keywords: [strategy, roadmap, planning]
     interactions: >
       Reads all agent outputs. Produces strategic insights and priority

--- a/v2/pkg/config/packs/level-5.yaml
+++ b/v2/pkg/config/packs/level-5.yaml
@@ -10,6 +10,49 @@ governor:
   merge_policy: >
     Hold-gated — all agent PRs get 'hold' label. Human batch-approves.
     merge-gate.sh blocks agent merges. batch-approve.sh for human review.
+  eval_interval_s: 300
+  thresholds:
+    surge: 10
+    busy: 5
+    quiet: 2
+    idle: 0
+  cadences:
+    surge:
+      supervisor: 2m
+      scanner: 10m
+      ci-maintainer: 10m
+      quality: 15m
+      architect: 30m
+      outreach: 1h
+      sec-check: 30m
+      strategist: 1h
+    busy:
+      supervisor: 3m
+      scanner: 15m
+      ci-maintainer: 15m
+      quality: 30m
+      architect: 1h
+      outreach: 2h
+      sec-check: 1h
+      strategist: 2h
+    quiet:
+      supervisor: 5m
+      scanner: 30m
+      ci-maintainer: 30m
+      quality: 1h
+      architect: 2h
+      outreach: 4h
+      sec-check: 2h
+      strategist: 4h
+    idle:
+      supervisor: 5m
+      scanner: 1h
+      ci-maintainer: 1h
+      quality: 2h
+      architect: 4h
+      outreach: 8h
+      sec-check: 4h
+      strategist: 8h
 agents:
   - name: supervisor
     display_name: supervisor
@@ -24,6 +67,7 @@ agents:
     bead_role: supervisor
     kick_template: supervisor-CLAUDE.md
     include_repos: true
+    stale_timeout: 900
     interactions: >
       Monitors all agents. Escalates issues to human operators.
     knowledge_use: >
@@ -42,6 +86,7 @@ agents:
     bead_role: worker
     kick_template: scanner-guarded-CLAUDE.md
     include_repos: true
+    stale_timeout: 1800
     lane_keywords: [bug, triage, fix, issue]
     interactions: >
       Creates hold-gated PRs. Tester validates but does not approve.
@@ -60,6 +105,7 @@ agents:
     bead_role: worker
     kick_template: ci-maintainer-CLAUDE.md
     include_repos: true
+    stale_timeout: 1800
     lane_keywords: [ci, build, pipeline, workflow, dependency]
     interactions: >
       Same as L4.
@@ -78,6 +124,7 @@ agents:
     bead_role: worker
     kick_template: quality-CLAUDE.md
     include_repos: true
+    stale_timeout: 1800
     lane_keywords: [test, coverage, tdd, quality]
     interactions: >
       Reviews PRs for coverage. Adds /lgtm but does NOT /approve.
@@ -96,6 +143,7 @@ agents:
     bead_role: worker
     kick_template: architect-CLAUDE.md
     include_repos: true
+    stale_timeout: 3600
     lane_keywords: [refactor, architecture, rfc, design, feature]
     interactions: >
       Same as L4.
@@ -115,6 +163,7 @@ agents:
     bead_role: worker
     kick_template: outreach-guarded-CLAUDE.md
     include_repos: false
+    stale_timeout: 3600
     lane_keywords: [community, adopters, outreach, ecosystem]
     interactions: >
       Drafts outreach actions for human review before execution.
@@ -134,6 +183,7 @@ agents:
     bead_role: worker
     kick_template: sec-check-CLAUDE.md
     include_repos: true
+    stale_timeout: 1800
     lane_keywords: [security, cve, vulnerability, audit]
     interactions: >
       Same as L4 plus immediate escalation for critical CVEs.
@@ -152,6 +202,7 @@ agents:
     bead_role: worker
     kick_template: strategist-CLAUDE.md
     include_repos: false
+    stale_timeout: 3600
     lane_keywords: [strategy, roadmap, planning]
     interactions: >
       Same as L4.

--- a/v2/pkg/config/packs/level-6.yaml
+++ b/v2/pkg/config/packs/level-6.yaml
@@ -9,6 +9,49 @@ governor:
   merge_policy: >
     Auto-merge on green CI. No hold label. auto-deploy.sh active.
     rollback.sh for self-healing on deploy failure.
+  eval_interval_s: 120
+  thresholds:
+    surge: 10
+    busy: 5
+    quiet: 2
+    idle: 0
+  cadences:
+    surge:
+      supervisor: 1m
+      scanner: 5m
+      ci-maintainer: 5m
+      quality: 10m
+      architect: 15m
+      outreach: 30m
+      sec-check: 15m
+      strategist: 30m
+    busy:
+      supervisor: 2m
+      scanner: 10m
+      ci-maintainer: 10m
+      quality: 15m
+      architect: 30m
+      outreach: 1h
+      sec-check: 30m
+      strategist: 1h
+    quiet:
+      supervisor: 3m
+      scanner: 20m
+      ci-maintainer: 20m
+      quality: 30m
+      architect: 1h
+      outreach: 2h
+      sec-check: 1h
+      strategist: 2h
+    idle:
+      supervisor: 5m
+      scanner: 30m
+      ci-maintainer: 30m
+      quality: 1h
+      architect: 2h
+      outreach: 4h
+      sec-check: 2h
+      strategist: 4h
 agents:
   - name: supervisor
     display_name: supervisor
@@ -24,6 +67,7 @@ agents:
     bead_role: supervisor
     kick_template: supervisor-CLAUDE.md
     include_repos: true
+    stale_timeout: 600
     interactions: >
       Full autonomous oversight of all agents. Triggers rollbacks and
       self-healing actions without human intervention.
@@ -44,6 +88,7 @@ agents:
     bead_role: worker
     kick_template: scanner-CLAUDE.md
     include_repos: true
+    stale_timeout: 900
     lane_keywords: [bug, triage, fix, issue]
     interactions: >
       Creates and merges PRs autonomously. Tester validates before merge.
@@ -62,6 +107,7 @@ agents:
     bead_role: worker
     kick_template: ci-maintainer-CLAUDE.md
     include_repos: true
+    stale_timeout: 900
     lane_keywords: [ci, build, pipeline, workflow, dependency, deploy]
     interactions: >
       Owns deploy pipeline. Coordinates rollbacks with supervisor.
@@ -80,6 +126,7 @@ agents:
     bead_role: worker
     kick_template: quality-CLAUDE.md
     include_repos: true
+    stale_timeout: 900
     lane_keywords: [test, coverage, tdd, quality]
     interactions: >
       Auto-approves PRs when coverage + CI gates pass.
@@ -99,6 +146,7 @@ agents:
     bead_role: worker
     kick_template: architect-CLAUDE.md
     include_repos: true
+    stale_timeout: 1800
     lane_keywords: [refactor, architecture, rfc, design, feature]
     interactions: >
       Full autonomous design and implementation.
@@ -118,6 +166,7 @@ agents:
     bead_role: worker
     kick_template: outreach-CLAUDE.md
     include_repos: false
+    stale_timeout: 1800
     lane_keywords: [community, adopters, outreach, ecosystem]
     interactions: >
       Fully autonomous community engagement.
@@ -136,6 +185,7 @@ agents:
     bead_role: worker
     kick_template: sec-check-CLAUDE.md
     include_repos: true
+    stale_timeout: 900
     lane_keywords: [security, cve, vulnerability, audit]
     interactions: >
       Auto-patches known CVEs. Escalates unknowns to supervisor.
@@ -154,6 +204,7 @@ agents:
     bead_role: worker
     kick_template: strategist-CLAUDE.md
     include_repos: false
+    stale_timeout: 1800
     lane_keywords: [strategy, roadmap, planning]
     interactions: >
       Full autonomous strategic planning and priority setting.

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -259,7 +259,10 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 	cfg := s.deps.Config
 	primaryRepo := cfg.Project.PrimaryRepo
 	if primaryRepo == "" && len(cfg.Project.Repos) > 0 {
-		primaryRepo = cfg.Project.Org + "/" + cfg.Project.Repos[0]
+		primaryRepo = cfg.Project.Repos[0]
+	}
+	if primaryRepo != "" && cfg.Project.Org != "" && !strings.Contains(primaryRepo, "/") {
+		primaryRepo = cfg.Project.Org + "/" + primaryRepo
 	}
 	jsonResponse(w, map[string]interface{}{
 		"org":              cfg.Project.Org,

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -102,7 +102,11 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 
 	s.deps.Config.ACMMLevel = &level
 
-	if len(pack.Governor.Cadences) > 0 {
+	if pack.Governor.EvalIntervalS > 0 {
+		s.deps.Config.Governor.EvalIntervalS = pack.Governor.EvalIntervalS
+	}
+
+	if len(pack.Governor.Cadences) > 0 || len(pack.Governor.Thresholds) > 0 {
 		if s.deps.Config.Governor.Modes == nil {
 			s.deps.Config.Governor.Modes = make(map[string]config.ModeConfig)
 		}
@@ -115,6 +119,20 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 				mode.Cadences[agent] = interval
 			}
 			s.deps.Config.Governor.Modes[modeName] = mode
+		}
+		for modeName, threshold := range pack.Governor.Thresholds {
+			mode := s.deps.Config.Governor.Modes[modeName]
+			mode.Threshold = threshold
+			s.deps.Config.Governor.Modes[modeName] = mode
+		}
+	}
+
+	for _, pa := range pack.Agents {
+		if pa.StaleTimeout > 0 {
+			if ac, ok := s.deps.Config.Agents[pa.Name]; ok {
+				ac.StaleTimeout = pa.StaleTimeout
+				s.deps.Config.Agents[pa.Name] = ac
+			}
 		}
 	}
 

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -38,24 +39,28 @@ func (s *Server) handlePacksList(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, result)
 }
 
-func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
-	levelStr := r.PathValue("level")
-	level, err := strconv.Atoi(levelStr)
-	if err != nil {
-		jsonError(w, "invalid level: "+levelStr, http.StatusBadRequest)
-		return
-	}
+// ApplyPackResult holds the outcome of applying an ACMM pack.
+type ApplyPackResult struct {
+	Name    string   `json:"name"`
+	Created []string `json:"created"`
+	Skipped []string `json:"skipped"`
+	Paused  []string `json:"paused"`
+	Resumed []string `json:"resumed"`
+}
 
+// ApplyPack applies the ACMM pack for the given level. It creates agents,
+// sets governor config (eval interval, cadences, thresholds, stale timeouts),
+// syncs agent visibility, and persists state. Callable from both the HTTP
+// handler and the startup bootstrap path.
+func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 	pack, err := config.ACMMPackByLevel(level)
 	if err != nil {
-		jsonError(w, err.Error(), http.StatusNotFound)
-		return
+		return nil, err
 	}
 
 	agentsDir := s.deps.Config.Data.AgentsDir
 	if agentsDir == "" {
-		jsonError(w, "agents_dir not configured", http.StatusInternalServerError)
-		return
+		return nil, fmt.Errorf("agents_dir not configured")
 	}
 
 	var created []string
@@ -87,8 +92,7 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 
 		if err := config.SaveAgentFile(agentsDir, pa.Name, agentCfg); err != nil {
 			s.logger.Error("failed to save agent from pack", "agent", pa.Name, "error", err)
-			jsonError(w, "failed to save agent "+pa.Name+": "+err.Error(), http.StatusInternalServerError)
-			return
+			return nil, fmt.Errorf("failed to save agent %s: %w", pa.Name, err)
 		}
 
 		s.deps.Config.Agents[pa.Name] = agentCfg
@@ -146,23 +150,38 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 	go s.refreshAsync()
 	s.logger.Info("ACMM pack applied", "level", level, "name", pack.Name, "created", len(created), "skipped", len(skipped), "paused", len(paused), "resumed", len(resumed))
 
-	var packAgentNames []string
-	for _, a := range pack.Agents {
-		if !a.Hidden {
-			packAgentNames = append(packAgentNames, a.Name)
-		}
+	return &ApplyPackResult{
+		Name:    pack.Name,
+		Created: created,
+		Skipped: skipped,
+		Paused:  paused,
+		Resumed: resumed,
+	}, nil
+}
+
+func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
+	levelStr := r.PathValue("level")
+	level, err := strconv.Atoi(levelStr)
+	if err != nil {
+		jsonError(w, "invalid level: "+levelStr, http.StatusBadRequest)
+		return
+	}
+
+	result, err := s.ApplyPack(level)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	jsonResponse(w, map[string]interface{}{
 		"ok":         true,
 		"status":     "applied",
 		"level":      level,
-		"name":       pack.Name,
-		"created":    created,
-		"skipped":    skipped,
-		"paused":     paused,
-		"resumed":    resumed,
-		"packAgents": packAgentNames,
+		"name":       result.Name,
+		"created":    result.Created,
+		"skipped":    result.Skipped,
+		"paused":     result.Paused,
+		"resumed":    result.Resumed,
 	})
 }
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6136,14 +6136,17 @@ function burnAreaChart() {
 
     // Set project name and repo from API
     fetch("/api/config").then(r => r.json()).then(cfg => {
+      const repoDisplay = cfg.org && cfg.primaryRepo && !cfg.primaryRepo.includes('/')
+        ? cfg.org + '/' + cfg.primaryRepo
+        : (cfg.primaryRepo || '');
       const el = document.getElementById("project-name");
-      if (el && cfg.primaryRepo) {
-        el.textContent = "for " + cfg.primaryRepo;
-        document.title = "🐝 Hive Dashboard for " + cfg.primaryRepo;
+      if (el && repoDisplay) {
+        el.textContent = "for " + repoDisplay;
+        document.title = "🐝 Hive Dashboard for " + repoDisplay;
       }
       const ocEl = document.getElementById("oc-project-name");
-      if (ocEl && cfg.primaryRepo) ocEl.textContent = cfg.primaryRepo;
-      if (cfg.primaryRepo) window._primaryRepo = cfg.primaryRepo;
+      if (ocEl && repoDisplay) ocEl.textContent = repoDisplay;
+      if (repoDisplay) window._primaryRepo = repoDisplay;
     }).catch(() => {});
 
     // Initial fetch then SSE

--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -19,6 +19,8 @@ import (
 const (
 	jwtExpiry          = 10 * time.Minute
 	tokenRefreshBuffer = 5 * time.Minute
+	tokenCachePath     = "/var/run/hive-metrics/gh-app-token.cache"
+	tokenCachePerms    = 0o640
 )
 
 type AppAuth struct {
@@ -109,6 +111,10 @@ func (a *AppAuth) Token(ctx context.Context) (string, error) {
 		"expires_at", a.tokenExpiry.Format(time.RFC3339),
 		"installation_id", a.installationID,
 	)
+
+	if err := os.WriteFile(tokenCachePath, []byte(a.cachedToken), tokenCachePerms); err != nil {
+		a.logger.Warn("failed to write token cache", "path", tokenCachePath, "error", err)
+	}
 
 	return a.cachedToken, nil
 }

--- a/v2/policies/quality-advisory-CLAUDE.md
+++ b/v2/policies/quality-advisory-CLAUDE.md
@@ -1,0 +1,38 @@
+# Quality Agent Policy — Advisory Mode (ACMM L2)
+
+You are the **quality** agent in a Hive instance running at ACMM Level 2 (advisory only).
+
+## Rules
+
+1. **Analyze coverage gaps** — identify untested modules by impact
+2. **DO NOT create PRs, push code, or merge anything** — L2 is advisory only
+3. **DO NOT create issues** — post findings to the advisory issue only
+4. **Write findings to the advisory file** — append JSONL lines to `/data/advisory/quality.jsonl`
+5. **Record knowledge** — write test_scaffold and pattern facts to the wiki
+
+## Advisory Output
+
+After analyzing the codebase, write your findings as JSONL to `/data/advisory/quality.jsonl`. Each line must be a JSON object:
+
+```json
+{"agent":"quality","timestamp":"2026-01-01T00:00:00Z","type":"coverage-gap","severity":"medium","title":"Short title","detail":"Details here","file":"path/to/file.go","line":42}
+```
+
+### Severity levels
+- **high** — critical untested code path (auth, data mutation, error handling)
+- **medium** — significant gap in business logic coverage
+- **low** — minor gap, nice-to-have test
+
+### Finding types
+- `coverage-gap` — untested function or branch
+- `missing-fixture` — no test infrastructure for a module
+- `regression-risk` — code changed recently with no test update
+- `test-quality` — existing test is weak (no assertions, flaky, etc.)
+
+## Workflow
+
+1. Read the kick message
+2. Analyze test coverage: `go test -coverprofile=coverage.out ./...` or equivalent
+3. Identify the top coverage gaps by impact
+4. Write findings to `/data/advisory/quality.jsonl`
+5. Summarize what you found in your response

--- a/v2/policies/scanner-advisory-CLAUDE.md
+++ b/v2/policies/scanner-advisory-CLAUDE.md
@@ -1,0 +1,41 @@
+# Scanner Agent Policy — Advisory Mode (ACMM L2)
+
+You are the **scanner** agent in a Hive instance running at ACMM Level 2 (advisory only).
+
+## Rules
+
+1. **ONLY work items from the kick message** — never run `gh issue list` or `gh pr list`
+2. **DO NOT create PRs, push code, or merge anything** — L2 is advisory only
+3. **DO NOT create issues** — post findings to the advisory issue only
+4. **Write findings to the advisory file** — append JSONL lines to `/data/advisory/scanner.jsonl`
+5. **Respect hold labels** — never touch issues labeled `hold`, `on-hold`, or `do-not-merge`
+6. **Always sign commits** with DCO: `git commit -s` (for local worktree analysis only)
+
+## Advisory Output
+
+After analyzing each issue, write your findings as JSONL to `/data/advisory/scanner.jsonl`. Each line must be a JSON object:
+
+```json
+{"agent":"scanner","timestamp":"2026-01-01T00:00:00Z","type":"bug","severity":"high","title":"Short title","detail":"Details here","file":"path/to/file.go","line":42}
+```
+
+### Severity levels
+- **critical** — security vulnerability, data loss risk
+- **high** — functional bug, broken feature, architectural issue
+- **medium** — code quality issue, missing validation, doc gap
+- **low** — style, minor improvement, nice-to-have
+
+### Finding types
+- `bug` — functional defect
+- `security` — security vulnerability
+- `architecture` — design or structural issue
+- `performance` — performance problem
+- `docs` — documentation gap or error
+
+## Workflow
+
+1. Read the kick message work list
+2. For each issue, analyze the codebase to understand root cause and complexity
+3. Write findings to `/data/advisory/scanner.jsonl`
+4. You may create local worktrees with proposed fixes for analysis, but DO NOT push
+5. Summarize your findings in your response


### PR DESCRIPTION
## Summary

- **Complete ACMM pack defaults** for all 6 levels — cadences, thresholds, eval intervals, stale timeouts now embedded in each pack YAML so every level is self-contained
- **Auto-apply on container start** — pass `HIVE_LEVEL=2` and `HIVE_REPO=org/repo` as env vars, container bootstraps with zero dashboard clicks (first start only; restarts use persisted state)
- **Advisory findings persisted as beads** — new `TypeAdvisory` bead type; governor writes JSONL findings into agent bead stores, deduplicated by title, surviving restarts and rebuilds
- **Severity-first digest format** — advisory digest now groups by severity (CRITICAL→LOW) with summary table instead of per-agent sections
- **Quality advisory template** — quality agent now posts findings to the advisory issue at L2 (was missing entirely)
- **Slower L2 cadences** — scanner 4h/6h, guide 4h/8h, quality 6h/8h to avoid overwhelming external repo owners
- **Fix double-org bug** — strip org prefix from `PrimaryRepo` when it matches `Project.Org`, fixing `org/org/repo` 404s in all GitHub API calls
- **Fix GitHub App token staleness** — write refreshed token to cache file so agent CLI reads current token
- **Show org/repo in dashboard header** — display `projectbluefin/knuckle` instead of just `knuckle`
- **Remove `:ro` from hive.yaml mount** — allow hive binary to write config changes back

## L2 Compliance Audit Results (4.85 / projectbluefin/knuckle)

- **PASS**: No PRs created, no code pushed, no merges — advisory-only confirmed
- **PASS**: Scanner and guide posted high-quality advisory reports to issue #93
- **Fixed**: Double-org bug causing 404s on every eval cycle
- **Fixed**: Quality never posted to advisory issue (missing template)
- **Config drift noted**: Governor mode-switching active when L2 prescribes `modes: none`

## Test plan

- [ ] `cd v2 && go build ./...` — clean build
- [ ] `cd v2 && go test ./pkg/config/... ./pkg/advisory/... ./pkg/beads/...` — tests pass
- [ ] Fresh start: delete state, set `HIVE_LEVEL=2 HIVE_REPO=org/repo`, verify 4 agents created
- [ ] Restart: verify "skipping auto-apply" log, agents loaded from state
- [ ] Verify advisory digest shows severity-first format
- [ ] Verify quality findings appear in advisory issue
- [ ] Deploy to 4.85 and confirm no more double-org 404s