### PR TITLE
fix: harden dashboard security and observability

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -2648,9 +2648,10 @@ func (s *Server) handleAuthToken(w http.ResponseWriter, r *http.Request) {
 		token = os.Getenv("HIVE_DASHBOARD_TOKEN")
 	}
 	if token == "" {
-		token = "(not set)"
+		okResponse(w, map[string]string{"token": "(not set)", "configured": "false"})
+		return
 	}
-	okResponse(w, map[string]string{"token": token})
+	okResponse(w, map[string]string{"token": maskSecret(token), "configured": "true"})
 }
 
 func (s *Server) handleBeadsReset(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/api_coverage2_test.go
+++ b/v2/pkg/dashboard/api_coverage2_test.go
@@ -119,6 +119,9 @@ func TestHandleAuthToken_NotSet(t *testing.T) {
 	if body["token"] != "(not set)" {
 		t.Errorf("token = %q, want (not set)", body["token"])
 	}
+	if body["configured"] != "false" {
+		t.Errorf("configured = %q, want false", body["configured"])
+	}
 }
 
 func TestHandleAuthToken_FromEnv(t *testing.T) {
@@ -131,8 +134,11 @@ func TestHandleAuthToken_FromEnv(t *testing.T) {
 	}
 	var body map[string]string
 	json.Unmarshal(rec.Body.Bytes(), &body)
-	if body["token"] != "secret-token-abc" {
-		t.Errorf("token = %q, want secret-token-abc", body["token"])
+	if body["token"] != "••••••••••••-abc" {
+		t.Errorf("token = %q, want masked value", body["token"])
+	}
+	if body["configured"] != "true" {
+		t.Errorf("configured = %q, want true", body["configured"])
 	}
 }
 
@@ -143,8 +149,11 @@ func TestHandleAuthToken_FromServer(t *testing.T) {
 	rec := doGet(s, "/api/auth/token")
 	var body map[string]string
 	json.Unmarshal(rec.Body.Bytes(), &body)
-	if body["token"] != "server-token-xyz" {
-		t.Errorf("token = %q, want server-token-xyz", body["token"])
+	if body["token"] != "••••••••••••-xyz" {
+		t.Errorf("token = %q, want masked value", body["token"])
+	}
+	if body["configured"] != "true" {
+		t.Errorf("configured = %q, want true", body["configured"])
 	}
 }
 

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -427,7 +427,7 @@ func (s *Server) broadcastFrame(frame string) {
 		select {
 		case ch <- raw:
 		default:
-			// Client too slow — drop the event
+			s.logger.Warn("SSE client too slow, dropping event")
 		}
 	}
 }

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -104,6 +104,17 @@ const server = app.listen(PROXY_PORT, () => {
 
 server.on('upgrade', (req, socket, head) => {
   if (req.url.startsWith('/terminal')) {
+    if (DASHBOARD_TOKEN) {
+      const params = new URL(req.url, `http://${req.headers.host}`).searchParams;
+      const token = params.get('token') || '';
+      const supplied = Buffer.from(token);
+      const expected = Buffer.from(DASHBOARD_TOKEN);
+      if (supplied.length !== expected.length || !crypto.timingSafeEqual(supplied, expected)) {
+        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+    }
     ttydProxy.upgrade(req, socket, head);
   }
 });


### PR DESCRIPTION
## Summary
- Mask auth token in `/api/auth-token` response instead of exposing plaintext
- Add WebSocket auth check for terminal proxy upgrade requests (prevents unauthenticated terminal access)
- Log SSE client drops instead of silently discarding events

## Test plan
- [ ] Verify `/api/auth-token` returns masked token (e.g., `abc...xyz`)
- [ ] Verify terminal WebSocket requires `?token=` param when `HIVE_DASHBOARD_TOKEN` is set
- [ ] Verify SSE slow-client drops produce warning logs