### PR TITLE
fix: nil guards + entrypoint group name crash

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -81,7 +81,7 @@ VOLUME ["/data", "/secrets"]
 COPY v2/deploy/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-RUN chown -R dev:dev /data /home/dev 2>/dev/null || true
+RUN chown -R dev:node /data /home/dev 2>/dev/null || true
 
 ENTRYPOINT ["entrypoint.sh"]
 CMD ["--config", "/etc/hive/hive.yaml"]

--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -9,14 +9,14 @@ export HIVE_STATIC_DIR="${HIVE_STATIC_DIR:-/opt/hive/proxy/public}"
 # ── Root-only setup (runs once, then re-execs as dev) ──────────────────
 if [ "$(id -u)" = "0" ]; then
   # Fix ownership of mounted volumes (may be root-owned from host bind mounts)
-  chown -R dev:dev /data /home/dev 2>/dev/null || true
-  mkdir -p /var/run/hive-metrics && chown dev:dev /var/run/hive-metrics
+  chown -R dev:node /data /home/dev 2>/dev/null || true
+  mkdir -p /var/run/hive-metrics && chown dev:node /var/run/hive-metrics 2>/dev/null || true
 
   # Seed data files from image into /data if they don't already exist
   if [ -d /opt/hive/seed-data ]; then
     echo "[entrypoint] Seeding data files..."
     cp -rn /opt/hive/seed-data/* /data/ 2>/dev/null || true
-    chown -R dev:dev /data 2>/dev/null || true
+    chown -R dev:node /data 2>/dev/null || true
   fi
 
   # Create beads symlinks: /home/dev/<agent>-beads -> /data/beads/<agent>
@@ -39,7 +39,7 @@ if [ "$(id -u)" = "0" ]; then
         echo "[entrypoint] Beads symlink: /home/dev/${agent}-beads -> /data/beads/${agent}"
       fi
     done
-    chown -R dev:dev /data/beads /home/dev 2>/dev/null || true
+    chown -R dev:node /data/beads /home/dev 2>/dev/null || true
   fi
 
   # Drop to non-root user for all runtime processes.

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -678,6 +678,10 @@ func (s *Server) handleGHAuth(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGHRateLimits(w http.ResponseWriter, r *http.Request) {
+	if s.deps.GHClient == nil {
+		jsonError(w, "GitHub client not configured", http.StatusServiceUnavailable)
+		return
+	}
 	limits, err := s.deps.GHClient.RateLimits(s.deps.Ctx)
 	if err != nil {
 		jsonError(w, err.Error(), http.StatusInternalServerError)
@@ -2400,7 +2404,7 @@ func (s *Server) handleNousStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleNousLedger(w http.ResponseWriter, r *http.Request) {
-	if s.deps.Nous == nil {
+	if s.deps.Nous == nil || s.deps.Nous.Ledger == nil {
 		jsonResponse(w, []interface{}{})
 		return
 	}
@@ -2408,7 +2412,7 @@ func (s *Server) handleNousLedger(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleNousPrinciples(w http.ResponseWriter, r *http.Request) {
-	if s.deps.Nous == nil {
+	if s.deps.Nous == nil || s.deps.Nous.Principles == nil {
 		jsonResponse(w, []interface{}{})
 		return
 	}


### PR DESCRIPTION
## Summary
- **CRITICAL**: Fix `dev:dev` → `dev:node` in all chown commands (Dockerfile + entrypoint.sh). The `dev` user was created with `-g node`, so no `dev` group exists. This crashed the container on startup.
- Add `|| true` to the bare `chown` on the metrics dir (only chown without error suppression)
- Add nil check for `GHClient` in `handleGHRateLimits` to prevent panic when GitHub is not configured
- Add nil checks for `Nous.Ledger` and `Nous.Principles` to prevent panic during early initialization

## Test plan
- [ ] Container starts without chown errors
- [ ] Entrypoint drops to dev user via gosu
- [ ] `/api/gh-rate-limits` returns 503 when GHClient is nil
- [ ] `/api/nous/ledger` and `/api/nous/principles` return `[]` when sub-objects are nil