### PR TITLE
fix: double-org repo paths + PEM key permissions for non-root

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -87,6 +87,9 @@ func main() {
 	var ghClient *github.Client
 	if cfg.GitHub.AppID != 0 {
 		keyFile := cfg.GitHub.KeyFile
+		if envKey := os.Getenv("GH_APP_KEY_FILE"); envKey != "" {
+			keyFile = envKey
+		}
 		if keyFile == "" {
 			keyFile = "/secrets/gh-app-key.pem"
 		}

--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -12,6 +12,14 @@ if [ "$(id -u)" = "0" ]; then
   chown -R dev:node /data /home/dev 2>/dev/null || true
   mkdir -p /var/run/hive-metrics && chown dev:node /var/run/hive-metrics 2>/dev/null || true
 
+  # Copy read-only mounted secrets so dev user can read them
+  if [ -f /etc/hive/gh-app-key.pem ]; then
+    cp /etc/hive/gh-app-key.pem /var/run/hive-metrics/gh-app-key.pem
+    chown dev:node /var/run/hive-metrics/gh-app-key.pem
+    chmod 400 /var/run/hive-metrics/gh-app-key.pem
+    export GH_APP_KEY_FILE=/var/run/hive-metrics/gh-app-key.pem
+  fi
+
   # Seed data files from image into /data if they don't already exist
   if [ -d /opt/hive/seed-data ]; then
     echo "[entrypoint] Seeding data files..."
@@ -72,6 +80,12 @@ git config --global --replace-all "credential.https://github.com.helper" "/usr/l
 # Generate initial GitHub App token if credentials are available
 if [ -x /usr/local/bin/hive-config.sh ]; then
   . /usr/local/bin/hive-config.sh 2>/dev/null || true
+fi
+# Use the dev-readable copy if the configured key file isn't readable
+if [ -n "${GH_APP_KEY_FILE:-}" ] && [ ! -r "$GH_APP_KEY_FILE" ]; then
+  if [ -r /var/run/hive-metrics/gh-app-key.pem ]; then
+    export GH_APP_KEY_FILE=/var/run/hive-metrics/gh-app-key.pem
+  fi
 fi
 if [ -n "${GH_APP_ID:-}" ] && [ -n "${GH_APP_INSTALLATION_ID:-}" ]; then
   echo "[entrypoint] Generating GitHub App token..."

--- a/v2/pkg/github/advisory.go
+++ b/v2/pkg/github/advisory.go
@@ -20,6 +20,10 @@ const (
 // Returns the issue number.
 func (c *Client) EnsureAdvisoryIssue(ctx context.Context, repo string) (int, error) {
 	owner := c.org
+	if parts := strings.SplitN(repo, "/", 2); len(parts) == 2 {
+		owner = parts[0]
+		repo = parts[1]
+	}
 
 	num, err := c.findAdvisoryIssue(ctx, owner, repo)
 	if err != nil {
@@ -65,8 +69,8 @@ func (c *Client) EnsureAdvisoryIssue(ctx context.Context, repo string) (int, err
 
 // PostAdvisoryDigest posts a digest comment on the advisory issue.
 func (c *Client) PostAdvisoryDigest(ctx context.Context, repo string, issueNum int, digest string) error {
-	owner := c.org
-	_, _, err := c.client.Issues.CreateComment(ctx, owner, repo, issueNum, &gh.IssueComment{
+	owner, repoName := c.splitRepo(repo)
+	_, _, err := c.client.Issues.CreateComment(ctx, owner, repoName, issueNum, &gh.IssueComment{
 		Body: gh.Ptr(digest),
 	})
 	if err != nil {

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -193,15 +193,25 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 	return result, nil
 }
 
+// splitRepo handles repo names that may include org prefix (e.g. "org/repo").
+// When repo contains "/", the prefix is used as owner; otherwise c.org is used.
+func (c *Client) splitRepo(repo string) (owner, repoName string) {
+	if parts := strings.SplitN(repo, "/", 2); len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return c.org, repo
+}
+
 func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (actionable []Issue, held []HoldItem, totalIssues int, err error) {
+	owner, repoName := c.splitRepo(repo)
 	opts := &gh.IssueListByRepoOptions{
 		State:       "open",
 		ListOptions: gh.ListOptions{PerPage: 100},
 	}
 
-	issues, _, err := c.client.Issues.ListByRepo(ctx, c.org, repo, opts)
+	issues, _, err := c.client.Issues.ListByRepo(ctx, owner, repoName, opts)
 	if err != nil {
-		return nil, nil, 0, fmt.Errorf("listing issues for %s/%s: %w", c.org, repo, err)
+		return nil, nil, 0, fmt.Errorf("listing issues for %s/%s: %w", owner, repoName, err)
 	}
 
 	for _, issue := range issues {
@@ -246,14 +256,15 @@ func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (a
 }
 
 func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRequest, held []HoldItem, totalPRs int, err error) {
+	owner, repoName := c.splitRepo(repo)
 	opts := &gh.PullRequestListOptions{
 		State:       "open",
 		ListOptions: gh.ListOptions{PerPage: 100},
 	}
 
-	prs, _, err := c.client.PullRequests.List(ctx, c.org, repo, opts)
+	prs, _, err := c.client.PullRequests.List(ctx, owner, repoName, opts)
 	if err != nil {
-		return nil, nil, 0, fmt.Errorf("listing PRs for %s/%s: %w", c.org, repo, err)
+		return nil, nil, 0, fmt.Errorf("listing PRs for %s/%s: %w", owner, repoName, err)
 	}
 
 	for _, pr := range prs {
@@ -511,8 +522,7 @@ type SHAHoldResult struct {
 
 func (c *Client) EnforceSHAHold(ctx context.Context, cfg SHAHoldConfig) (*SHAHoldResult, error) {
 	result := &SHAHoldResult{}
-	owner := c.org
-	repo := cfg.PrimaryRepo
+	owner, repo := c.splitRepo(cfg.PrimaryRepo)
 
 	opts := &gh.IssueListByRepoOptions{
 		State:       "open",

--- a/v2/pkg/github/mttr.go
+++ b/v2/pkg/github/mttr.go
@@ -47,7 +47,7 @@ var fixesPattern = regexp.MustCompile(`(?i)(?:fixes|closes|resolves)\s+#(\d+)`)
 // "Fixes #N" references, looks up each issue's creation time, and computes
 // issue-to-merge duration statistics.
 func (c *Client) ComputeMTTR(ctx context.Context, primaryRepo string) (*MTTRResult, error) {
-	owner := c.org
+	owner, repo := c.splitRepo(primaryRepo)
 
 	// List recently merged PRs
 	opts := &gh.PullRequestListOptions{
@@ -57,9 +57,9 @@ func (c *Client) ComputeMTTR(ctx context.Context, primaryRepo string) (*MTTRResu
 		ListOptions: gh.ListOptions{PerPage: mttrMergedPRLimit},
 	}
 
-	prs, _, err := c.client.PullRequests.List(ctx, owner, primaryRepo, opts)
+	prs, _, err := c.client.PullRequests.List(ctx, owner, repo, opts)
 	if err != nil {
-		return nil, fmt.Errorf("listing merged PRs for %s/%s: %w", owner, primaryRepo, err)
+		return nil, fmt.Errorf("listing merged PRs for %s/%s: %w", owner, repo, err)
 	}
 
 	// Extract issue references from merged PRs
@@ -103,7 +103,7 @@ func (c *Client) ComputeMTTR(ctx context.Context, primaryRepo string) (*MTTRResu
 	// Fetch creation times for referenced issues
 	createdAt := make(map[int]time.Time)
 	for num := range issueNums {
-		issue, _, err := c.client.Issues.Get(ctx, owner, primaryRepo, num)
+		issue, _, err := c.client.Issues.Get(ctx, owner, repo, num)
 		if err != nil {
 			c.logger.Warn("failed to fetch issue for MTTR", "issue", num, "error", err)
 			continue


### PR DESCRIPTION
## Summary

### Double-org fix
When `primary_repo` is set to `projectbluefin/knuckle` (with org prefix), GitHub API calls were double-prefixing the org, producing 404 errors like `repos/projectbluefin/projectbluefin/knuckle`.

Added `splitRepo()` helper to the GitHub client that handles both `repo` and `org/repo` formats. Applied to:
- `fetchIssues` / `fetchPRs` (governor eval cycle)
- `EnsureAdvisoryIssue` / `PostAdvisoryDigest` (L2 advisory)
- `EnforceSHAHold` (SHA hold enforcement)
- `ComputeMTTR` (mean time to resolve)

### PEM key permissions
After dropping to non-root `dev` user via gosu, the bind-mounted PEM key at `/etc/hive/gh-app-key.pem` is unreadable (root-owned, `:ro` mount). The entrypoint now:
1. Copies the key to `/var/run/hive-metrics/` during root phase
2. Sets ownership to `dev:node`
3. Falls back to the readable copy when the configured path fails `-r` check
4. The Go binary now also supports `GH_APP_KEY_FILE` env var as override

## Test plan
- [ ] Container starts without crash loop
- [ ] GitHub App auth succeeds (no "permission denied" on key file)
- [ ] No more double-org 404s in logs
- [ ] Advisory issue operations succeed
- [ ] MTTR and SHA hold work