### PR TITLE
fix: bake dashboard snapshot scripts into Docker image

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -48,6 +48,9 @@ RUN cd /opt/hive/proxy && npm install --omit=dev
 
 COPY v2/pkg/dashboard/static/index.html /opt/hive/proxy/public/
 
+COPY dashboard/ /opt/hive/dashboard/
+RUN chmod +x /opt/hive/dashboard/publish-snapshot*.sh
+
 COPY examples/kubestellar/hive-project.yaml /etc/hive/hive-project.yaml
 COPY examples/acmm/ /opt/hive/examples/acmm/
 COPY examples/agents/ /opt/hive/examples/agents/


### PR DESCRIPTION
## Summary
- `publish-snapshot-v2.sh` and `build-snapshot.mjs` live on the `v2` branch but the container's policy sync pulls from `main`, so they were never synced automatically
- Manual copies into the container were lost on every container restart
- This bakes the entire `dashboard/` directory into `/opt/hive/dashboard/` in the Docker image

## Test plan
- [ ] After merge + CI build, pull new image and verify `/opt/hive/dashboard/publish-snapshot-v2.sh` exists
- [ ] Update systemd wrapper to use `/opt/hive/dashboard/` path
- [ ] Verify timer-triggered snapshot publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)