### PR TITLE
fix: nil-guard actionable in substituteTemplate

### DIFF
--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -83,6 +83,9 @@ func (s *Scheduler) loadNamedTemplate(templateName string) string {
 
 // substituteTemplate replaces ${VAR} placeholders in a prompt template.
 func (s *Scheduler) substituteTemplate(template string, actionable *github.ActionableResult, agentName string, issues []github.Issue) string {
+	if actionable == nil {
+		actionable = &github.ActionableResult{}
+	}
 	now := time.Now().In(time.FixedZone("EDT", -4*3600))
 
 	issueList := s.formatIssueList(filterByLane(issues, agentName))


### PR DESCRIPTION
## Summary
- Manual kick passes `nil` for `actionable` to `BuildAgentMessage`, which panics in `formatPRList` when dereferencing `actionable.PRs.Items`
- Fix: default to empty `ActionableResult` at the top of `substituteTemplate`
- One-line nil guard, no behavior change for scheduled kicks (actionable is always non-nil there)

## Test plan
- [ ] `go test ./pkg/scheduler/` passes
- [ ] Manual kick via dashboard no longer panics
- [ ] Scheduled kicks unchanged