### PR TITLE
feat: dual-token for cross-org snapshot publishing

### DIFF
--- a/dashboard/publish-snapshot-v2.sh
+++ b/dashboard/publish-snapshot-v2.sh
@@ -48,15 +48,19 @@ DOCS_REPO_SLUG="kubestellar/docs"
 PUBLISH_PATH="public/live/hive/${INSTANCE}"
 BASE_PATH="/live/hive/${INSTANCE}"
 
-GH_APP_TOKEN_FILE="/var/run/hive-metrics/gh-app-token.cache"
-if [ -f "$GH_APP_TOKEN_FILE" ]; then
-  GH_APP_TOKEN=$(cat "$GH_APP_TOKEN_FILE")
-  DOCS_REMOTE="https://x-access-token:${GH_APP_TOKEN}@github.com/${DOCS_REPO_SLUG}.git"
-  export GH_TOKEN="$GH_APP_TOKEN"
+DOCS_TOKEN_FILE="/var/run/hive-metrics/gh-app-token-docs.cache"
+FALLBACK_TOKEN_FILE="/var/run/hive-metrics/gh-app-token.cache"
+if [ -f "$DOCS_TOKEN_FILE" ]; then
+  GH_APP_TOKEN=$(cat "$DOCS_TOKEN_FILE")
+elif [ -f "$FALLBACK_TOKEN_FILE" ]; then
+  echo "WARN: docs token not found, falling back to default token"
+  GH_APP_TOKEN=$(cat "$FALLBACK_TOKEN_FILE")
 else
-  echo "ERROR: no GitHub App token at $GH_APP_TOKEN_FILE"
+  echo "ERROR: no GitHub App token at $DOCS_TOKEN_FILE or $FALLBACK_TOKEN_FILE"
   exit 1
 fi
+DOCS_REMOTE="https://x-access-token:${GH_APP_TOKEN}@github.com/${DOCS_REPO_SLUG}.git"
+export GH_TOKEN="$GH_APP_TOKEN"
 
 echo "[${INSTANCE}] Snapshot from ${DASHBOARD_URL} → ${BASE_PATH}"
 

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -100,6 +100,37 @@ func main() {
 		}
 		logger.Info("using GitHub App authentication", "app_id", cfg.GitHub.AppID)
 		ghClient = github.NewClientFromApp(appAuth, cfg.Project.Org, cfg.Project.Repos, logger)
+
+		if cfg.GitHub.DocsInstallationID != 0 {
+			docsAuth, err := github.NewAppAuthWithCache(
+				cfg.GitHub.AppID, cfg.GitHub.DocsInstallationID,
+				keyFile, github.DocsTokenCachePath, logger,
+			)
+			if err != nil {
+				logger.Warn("failed to init docs org token", "error", err)
+			} else {
+				if _, err := docsAuth.Token(ctx); err != nil {
+					logger.Warn("failed to generate initial docs org token", "error", err)
+				} else {
+					logger.Info("docs org token cached", "installation_id", cfg.GitHub.DocsInstallationID)
+				}
+				go func() {
+					const docsTokenRefreshInterval = 45 * time.Minute
+					ticker := time.NewTicker(docsTokenRefreshInterval)
+					defer ticker.Stop()
+					for {
+						select {
+						case <-ctx.Done():
+							return
+						case <-ticker.C:
+							if _, err := docsAuth.Token(ctx); err != nil {
+								logger.Warn("docs token refresh failed", "error", err)
+							}
+						}
+					}
+				}()
+			}
+		}
 	} else {
 		ghToken := cfg.GitHub.Token
 		if ghToken == "" {

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -269,11 +269,12 @@ func (m *ModeConfig) UnmarshalYAML(value *yaml.Node) error {
 }
 
 type GitHubConfig struct {
-	AppID          int64  `yaml:"app_id"`
-	InstallationID int64  `yaml:"installation_id"`
-	KeyFile        string `yaml:"key_file"`
-	Token          string `yaml:"token"`
-	OAuthClientID  string `yaml:"oauth_client_id"`
+	AppID                int64  `yaml:"app_id"`
+	InstallationID       int64  `yaml:"installation_id"`
+	DocsInstallationID   int64  `yaml:"docs_installation_id"`
+	KeyFile              string `yaml:"key_file"`
+	Token                string `yaml:"token"`
+	OAuthClientID        string `yaml:"oauth_client_id"`
 }
 
 type NotificationsConfig struct {

--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -19,7 +19,8 @@ import (
 const (
 	jwtExpiry          = 10 * time.Minute
 	tokenRefreshBuffer = 5 * time.Minute
-	tokenCachePath     = "/var/run/hive-metrics/gh-app-token.cache"
+	TokenCachePath     = "/var/run/hive-metrics/gh-app-token.cache"
+	DocsTokenCachePath = "/var/run/hive-metrics/gh-app-token-docs.cache"
 	tokenCachePerms    = 0o640
 )
 
@@ -28,6 +29,7 @@ type AppAuth struct {
 	installationID int64
 	key            *rsa.PrivateKey
 	logger         *slog.Logger
+	cachePath      string
 
 	mu          sync.RWMutex
 	cachedToken string
@@ -35,6 +37,10 @@ type AppAuth struct {
 }
 
 func NewAppAuth(appID, installationID int64, keyFile string, logger *slog.Logger) (*AppAuth, error) {
+	return NewAppAuthWithCache(appID, installationID, keyFile, TokenCachePath, logger)
+}
+
+func NewAppAuthWithCache(appID, installationID int64, keyFile, cachePath string, logger *slog.Logger) (*AppAuth, error) {
 	keyData, err := os.ReadFile(keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("reading app key %s: %w", keyFile, err)
@@ -63,6 +69,7 @@ func NewAppAuth(appID, installationID int64, keyFile string, logger *slog.Logger
 		installationID: installationID,
 		key:            key,
 		logger:         logger,
+		cachePath:      cachePath,
 	}, nil
 }
 
@@ -112,8 +119,8 @@ func (a *AppAuth) Token(ctx context.Context) (string, error) {
 		"installation_id", a.installationID,
 	)
 
-	if err := os.WriteFile(tokenCachePath, []byte(a.cachedToken), tokenCachePerms); err != nil {
-		a.logger.Warn("failed to write token cache", "path", tokenCachePath, "error", err)
+	if err := os.WriteFile(a.cachePath, []byte(a.cachedToken), tokenCachePerms); err != nil {
+		a.logger.Warn("failed to write token cache", "path", a.cachePath, "error", err)
 	}
 
 	return a.cachedToken, nil


### PR DESCRIPTION
## Summary

- Adds `docs_installation_id` field to `github:` config in hive.yaml
- When set, the Go binary generates a second GitHub App installation token scoped to the kubestellar org, cached at `/var/run/hive-metrics/gh-app-token-docs.cache`
- `publish-snapshot-v2.sh` reads from the docs-specific token file, falling back to the default token
- Token auto-refreshes every 45 minutes via a background goroutine
- Fixes snapshot publishing from 4.85 (projectbluefin org) which was failing with 403 because the main token is scoped to projectbluefin, not kubestellar

## How to use

Add to hive.yaml on 4.85:
```yaml
github:
  app_id: 3568013
  installation_id: 135058248        # projectbluefin org (agents)
  docs_installation_id: 128685788   # kubestellar org (snapshot publishing)
  key_file: /etc/hive/gh-app-key.pem
```

## Test plan

- [ ] Deploy to 4.85, verify `gh-app-token-docs.cache` is created
- [ ] Trigger snapshot: `systemctl start hive-snapshot-bluefin.service`
- [ ] Verify `git push` to kubestellar/docs succeeds
- [ ] Verify agents still use the projectbluefin token for issues/PRs