### PR TITLE
fix: snapshot countdown layout shift on mobile

### DIFF
--- a/dashboard/build-snapshot.mjs
+++ b/dashboard/build-snapshot.mjs
@@ -159,7 +159,7 @@ async function main() {
     .snapshot-banner .snap-icon { font-size: 1.2rem; }
     .snapshot-banner .snap-label { ${bannerLabelColor} font-weight: 600; }
     .snapshot-banner .snap-time { ${bannerTimeColor} }
-    .snapshot-banner .snap-refresh { ${bannerRefreshColor} margin-left: auto; font-size: 0.75rem; }
+    .snapshot-banner .snap-refresh { ${bannerRefreshColor} margin-left: auto; font-size: 0.75rem; font-variant-numeric: tabular-nums; min-width: 10ch; text-align: right; white-space: nowrap; }
     .snapshot-banner .snap-links { margin-left: 12px; font-size: 0.75rem; }
     .snapshot-banner .snap-links a { ${bannerLabelColor} text-decoration: none; margin: 0 6px; }
     .snapshot-banner .snap-links a:hover { text-decoration: underline; }


### PR DESCRIPTION
## Summary

- The "refreshes in" countdown in the snapshot banner changes text width as seconds tick down (e.g. "14m 59s" → "9s"), causing the flex banner to reflow on narrow mobile viewports
- Fix: `font-variant-numeric: tabular-nums` for fixed-width digits, `min-width: 10ch` to reserve space, `white-space: nowrap` to prevent wrapping

## Test plan

- [ ] Open snapshot page on mobile viewport
- [ ] Verify countdown text no longer causes vertical layout shift as seconds change