### PR TITLE
fix: shell-quote env var values in tmux launch commands

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -476,6 +476,14 @@ func (m *Manager) readCoveragePreamble() string {
 	return fmt.Sprintf("[COVERAGE] Current: %d%% | Target: %d%%.", cov, target)
 }
 
+// shellEnvVar formats KEY='value' with single-quoting so values containing
+// spaces, parentheses, or other shell metacharacters are safe in inline env
+// var assignments sent to tmux via send-keys.
+func shellEnvVar(key, value string) string {
+	quoted := strings.ReplaceAll(value, "'", "'\"'\"'")
+	return fmt.Sprintf("%s='%s'", key, quoted)
+}
+
 func (m *Manager) buildEnvPrefix(agent *AgentProcess) string {
 	vars := m.agentEnvVars(agent)
 	if len(vars) == 0 {
@@ -843,20 +851,20 @@ func (m *Manager) agentEnvVars(agent *AgentProcess) []string {
 		displayName = agent.Name
 	}
 	vars := []string{
-		fmt.Sprintf("HIVE_AGENT=%s", agent.Name),
-		fmt.Sprintf("HIVE_AGENT_DISPLAY_NAME=%s", displayName),
-		fmt.Sprintf("HIVE_BACKEND=%s", backend),
-		fmt.Sprintf("HIVE_MODEL=%s", model),
+		shellEnvVar("HIVE_AGENT", agent.Name),
+		shellEnvVar("HIVE_AGENT_DISPLAY_NAME", displayName),
+		shellEnvVar("HIVE_BACKEND", backend),
+		shellEnvVar("HIVE_MODEL", model),
 	}
 	if hiveID := os.Getenv("HIVE_ID"); hiveID != "" {
-		vars = append(vars, fmt.Sprintf("HIVE_ID=%s", hiveID))
+		vars = append(vars, shellEnvVar("HIVE_ID", hiveID))
 	}
 	vars = append(vars, fmt.Sprintf("HIVE_ACMM_LEVEL=%d", m.project.ACMMLevel))
 	if sha := os.Getenv("HIVE_SHA"); sha != "" {
-		vars = append(vars, fmt.Sprintf("HIVE_SHA=%s", sha))
+		vars = append(vars, shellEnvVar("HIVE_SHA", sha))
 	}
 	if advisory := os.Getenv("HIVE_ADVISORY_ISSUE"); advisory != "" {
-		vars = append(vars, fmt.Sprintf("HIVE_ADVISORY_ISSUE=%s", advisory))
+		vars = append(vars, shellEnvVar("HIVE_ADVISORY_ISSUE", advisory))
 	}
 	return vars
 }

--- a/v2/pkg/agent/manager_coverage_test.go
+++ b/v2/pkg/agent/manager_coverage_test.go
@@ -159,7 +159,7 @@ func TestAgentEnvVars_WithHiveID(t *testing.T) {
 
 	foundHiveID := false
 	for _, v := range vars {
-		if v == "HIVE_ID=test-hive-123" {
+		if v == "HIVE_ID='test-hive-123'" {
 			foundHiveID = true
 		}
 	}
@@ -185,10 +185,10 @@ func TestAgentEnvVars_WithOverrides(t *testing.T) {
 	foundModel := false
 	foundBackend := false
 	for _, v := range vars {
-		if v == "HIVE_MODEL=opus" {
+		if v == "HIVE_MODEL='opus'" {
 			foundModel = true
 		}
-		if v == "HIVE_BACKEND=gemini" {
+		if v == "HIVE_BACKEND='gemini'" {
 			foundBackend = true
 		}
 	}

--- a/v2/pkg/agent/manager_test.go
+++ b/v2/pkg/agent/manager_test.go
@@ -297,9 +297,9 @@ func TestAgentEnvVars_ContainsRequiredKeys(t *testing.T) {
 	vars := testEnvVars(ap)
 
 	want := map[string]string{
-		"HIVE_AGENT":   "test-agent",
-		"HIVE_BACKEND": "claude",
-		"HIVE_MODEL":   "claude-3-5-sonnet",
+		"HIVE_AGENT":   "'test-agent'",
+		"HIVE_BACKEND": "'claude'",
+		"HIVE_MODEL":   "'claude-3-5-sonnet'",
 	}
 
 	for _, v := range vars {
@@ -344,12 +344,12 @@ func TestAgentEnvVars_EmptyModelAllowed(t *testing.T) {
 
 	found := false
 	for _, v := range vars {
-		if v == "HIVE_MODEL=" {
+		if v == "HIVE_MODEL=''" {
 			found = true
 		}
 	}
 	if !found {
-		t.Error("expected HIVE_MODEL= (empty) to be present when model is unset")
+		t.Error("expected HIVE_MODEL='' (empty) to be present when model is unset")
 	}
 }
 
@@ -666,12 +666,12 @@ func TestStart_EnvIncludesHiveVars(t *testing.T) {
 
 	found := false
 	for _, v := range combined {
-		if v == "HIVE_AGENT=env-test" {
+		if v == "HIVE_AGENT='env-test'" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Error("HIVE_AGENT=env-test not found in combined env")
+		t.Error("HIVE_AGENT='env-test' not found in combined env")
 	}
 }


### PR DESCRIPTION
## Summary
- `agentEnvVars()` constructs inline env var assignments like `HIVE_AGENT_DISPLAY_NAME=guide (advisory)` that are sent to tmux via `send-keys`
- When the display name contains parentheses (added by ACMM advisory mode), bash interprets `(` as a subshell and throws `syntax error near unexpected token '('`
- This breaks **all agents** — none can start when ACMM advisory mode appends `(advisory)` to display names
- Fix: single-quote all env var values so metacharacters are treated as literals

## Test plan
- [ ] Deploy updated image to hive server
- [ ] Verify agents with `(advisory)` display names launch successfully
- [ ] Verify agents without special chars in display names still work