### PR TITLE
feat: guide agent reaps stale advisory findings

### DIFF
--- a/v2/policies/guide-advisory-CLAUDE.md
+++ b/v2/policies/guide-advisory-CLAUDE.md
@@ -12,6 +12,7 @@ Your job is to audit project documentation, onboarding materials, and contributo
 4. **Write findings as beads** — use `bd create` for every documentation gap you find
 5. **Never write or fix code** — code changes are the scanner's and quality agent's job
 6. **Always sign commits** with DCO: `git commit -s` (for local worktree analysis only)
+7. **Only close your own beads** — when reaping stale findings, only close beads where `actor` is `guide`
 
 ## Writing Findings
 
@@ -50,10 +51,22 @@ bd update <bead-id> --set-metadata file="README.md"
 
 1. Read the kick message for any specific documentation tasks
 2. Clone or navigate to the target repo
-3. Audit existing documentation: README, CONTRIBUTING, architecture docs, inline docs
-4. Identify gaps: missing setup instructions, undocumented features, stale references, unclear architecture
-5. Create a bead for each finding with `bd create`
-6. Summarize your findings in your response
+3. **Reap stale findings** — re-verify your open beads and close any that are no longer valid:
+   ```bash
+   bd list --status=open --actor=guide --json
+   ```
+   For each open bead:
+   - Check the `external_ref` path — does the file/section now exist with adequate content?
+   - If the documentation gap has been resolved, close the bead:
+     ```bash
+     bd close <bead-id>
+     ```
+   - A finding is resolved when the referenced file exists AND covers the gap described in the title/detail
+   - Skip beads with no `external_ref` — verify those by re-reading the relevant project area
+4. Audit existing documentation: README, CONTRIBUTING, architecture docs, inline docs
+5. Identify gaps: missing setup instructions, undocumented features, stale references, unclear architecture
+6. Create a bead for each finding with `bd create`
+7. Summarize your findings (new and reaped) in your response
 
 ## What to Audit
 


### PR DESCRIPTION
## Summary
- Guide agent now re-verifies open beads at the start of each kick cycle
- Resolved documentation gaps are automatically closed via `bd close`
- Only closes beads owned by the guide agent (`actor == guide`)
- Keeps the advisory digest current without manual intervention

## Test plan
- [ ] Deploy updated policy to hive container
- [ ] Verify guide agent runs `bd list --status=open --actor=guide --json` on kick
- [ ] Create a test bead, resolve the referenced doc gap, confirm guide closes it on next kick
- [ ] Confirm advisory digest drops the closed finding