### PR TITLE
feat: stale finding reaper for all advisory-mode agents

### DIFF
--- a/v2/policies/ci-maintainer-advisory-CLAUDE.md
+++ b/v2/policies/ci-maintainer-advisory-CLAUDE.md
@@ -9,6 +9,7 @@ You are the **ci-maintainer** agent in a Hive instance running at ACMM Level 3 (
 3. **DO NOT create issues** — findings go to beads only
 4. **Write findings as beads** — use `bd create` for every finding
 5. **Respect hold labels** — never touch issues labeled `hold`, `on-hold`, or `do-not-merge`
+6. **Only close your own beads** — when reaping stale findings, only close beads where `actor` is `ci-maintainer`
 
 ## Writing Findings
 
@@ -47,7 +48,18 @@ bd update <bead-id> --set-metadata workflow="workflow-name"
 ## Workflow
 
 1. Read the kick message
-2. Check recent CI runs: `gh run list --repo "$HIVE_REPO" --limit 20`
-3. Identify failures, patterns, and trends
-4. Create a bead for each finding with `bd create`
-5. Summarize CI health in your response
+2. **Reap stale findings** — re-verify your open beads and close any that are no longer valid:
+   ```bash
+   bd list --status=open --actor=ci-maintainer --json
+   ```
+   For each open bead:
+   - Check the `external_ref` (workflow name or run ID) — is the CI issue still occurring?
+   - Re-run or check recent runs for that workflow to see if the problem resolved itself
+   - If the finding no longer applies, close the bead:
+     ```bash
+     bd close <bead-id>
+     ```
+3. Check recent CI runs: `gh run list --repo "$HIVE_REPO" --limit 20`
+4. Identify failures, patterns, and trends
+5. Create a bead for each finding with `bd create`
+6. Summarize CI health (new findings and reaped stale ones) in your response

--- a/v2/policies/quality-advisory-CLAUDE.md
+++ b/v2/policies/quality-advisory-CLAUDE.md
@@ -9,6 +9,7 @@ You are the **quality** agent in a Hive instance running at ACMM Level 2 (adviso
 3. **DO NOT create issues** — findings go to beads only
 4. **Write findings as beads** — use `bd create` for every finding
 5. **Record knowledge** — write test_scaffold and pattern facts to the wiki
+6. **Only close your own beads** — when reaping stale findings, only close beads where `actor` is `quality`
 
 ## Writing Findings
 
@@ -45,7 +46,17 @@ bd update <bead-id> --set-metadata file="path/to/file.go"
 ## Workflow
 
 1. Read the kick message
-2. Analyze test coverage: `go test -coverprofile=coverage.out ./...` or equivalent
-3. Identify the top coverage gaps by impact
-4. Create a bead for each finding with `bd create`
-5. Summarize what you found in your response
+2. **Reap stale findings** — re-verify your open beads and close any that are no longer valid:
+   ```bash
+   bd list --status=open --actor=quality --json
+   ```
+   For each open bead:
+   - Check the `external_ref` (file path) — has test coverage been added for this gap?
+   - If the coverage gap has been addressed, close the bead:
+     ```bash
+     bd close <bead-id>
+     ```
+3. Analyze test coverage: `go test -coverprofile=coverage.out ./...` or equivalent
+4. Identify the top coverage gaps by impact
+5. Create a bead for each finding with `bd create`
+6. Summarize what you found (new findings and reaped stale ones) in your response

--- a/v2/policies/scanner-advisory-CLAUDE.md
+++ b/v2/policies/scanner-advisory-CLAUDE.md
@@ -10,6 +10,7 @@ You are the **scanner** agent in a Hive instance running at ACMM Level 2 (adviso
 4. **Write findings as beads** — use `bd create` for every finding
 5. **Respect hold labels** — never touch issues labeled `hold`, `on-hold`, or `do-not-merge`
 6. **Always sign commits** with DCO: `git commit -s` (for local worktree analysis only)
+7. **Only close your own beads** — when reaping stale findings, only close beads where `actor` is `scanner`
 
 ## Writing Findings
 
@@ -47,7 +48,18 @@ bd update <bead-id> --set-metadata file="path/to/file.go"
 ## Workflow
 
 1. Read the kick message work list
-2. For each issue, analyze the codebase to understand root cause and complexity
-3. Create a bead for each finding with `bd create`
-4. You may create local worktrees with proposed fixes for analysis, but DO NOT push
-5. Summarize your findings in your response
+2. **Reap stale findings** — re-verify your open beads and close any that are no longer valid:
+   ```bash
+   bd list --status=open --actor=scanner --json
+   ```
+   For each open bead:
+   - Check the `external_ref` (issue number) — has the issue been closed or the bug fixed?
+   - If the finding no longer applies, close the bead:
+     ```bash
+     bd close <bead-id>
+     ```
+   - A finding is resolved when the referenced issue is closed or the underlying code has been fixed
+3. For each issue, analyze the codebase to understand root cause and complexity
+4. Create a bead for each finding with `bd create`
+5. You may create local worktrees with proposed fixes for analysis, but DO NOT push
+6. Summarize your findings (new and reaped) in your response


### PR DESCRIPTION
## Summary
- Adds stale finding reaper to scanner, ci-maintainer, and quality advisory policies
- Matches the guide agent reaper from #592
- Each agent re-verifies its open beads at the start of each kick cycle
- Resolved findings are closed via `bd close`, dropping them from the advisory digest
- Agents only close their own beads (ownership guard via `actor` field)

## Test plan
- [ ] Deploy updated policies to hive container
- [ ] Verify each agent runs `bd list --status=open --actor=<self> --json` on kick
- [ ] Confirm closed beads drop from the advisory digest