### PR TITLE
fix: advisory issue posting works at all ACMM levels

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -208,10 +208,10 @@ func main() {
 	notifier.SetHiveID(cfg.HiveID)
 	acmmLevel := inferACMMLevel(cfg)
 
-	// At L1/L2 (advisory-only), create or find the pinned advisory issue per repo.
-	// Agents can comment on this issue but cannot create new issues.
+	// Find or create the pinned advisory issue. Any level can have advisory
+	// agents whose findings should be posted to this issue.
 	advisoryIssues := map[string]int{}
-	if acmmLevel > 0 && acmmLevel < 3 {
+	if acmmLevel > 0 {
 		primaryRepo := cfg.Project.PrimaryRepo
 		if primaryRepo == "" && len(cfg.Project.Repos) > 0 {
 			primaryRepo = cfg.Project.Repos[0]

--- a/v2/pkg/github/advisory.go
+++ b/v2/pkg/github/advisory.go
@@ -116,7 +116,7 @@ func (c *Client) findDigestComment(ctx context.Context, owner, repo string, issu
 
 func (c *Client) findAdvisoryIssue(ctx context.Context, owner, repo string) (int, error) {
 	opts := &gh.IssueListByRepoOptions{
-		State:  "open",
+		State:  "all",
 		Labels: []string{advisoryLabelName},
 		ListOptions: gh.ListOptions{PerPage: 5},
 	}


### PR DESCRIPTION
## Summary
- Removed `acmmLevel < 3` gate from advisory issue setup — any level with advisory agents now posts digests to the tracking issue
- Changed `findAdvisoryIssue` to search `state: "all"` instead of `"open"` so closed advisory issues (like #114 on knuckle) are still found and used
- At L3, scanner/guide/ci-maintainer are advisory agents whose findings should appear both on the dashboard and in the repo's advisory issue

## Test plan
- [ ] Restart container at level 3 — logs should show "advisory issue ready" with issue number
- [ ] Wait for eval cycle with advisory digest — comment should appear on the advisory issue
- [ ] Verify dashboard advisor section still works