### PR TITLE
fix: wait for CLI ready prompt before sending kick

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -576,6 +576,26 @@ func hashLines(lines []string) uint64 {
 	return h
 }
 
+// waitForCLIReady polls the tmux pane until the CLI shows its ready prompt
+// (❯) or the timeout expires. Returns true if the CLI became ready.
+func (m *Manager) waitForCLIReady(session string) bool {
+	deadline := time.After(cliReadyTimeout)
+	ticker := time.NewTicker(cliReadyPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			return false
+		case <-ticker.C:
+			output := m.captureTmuxPane(session)
+			if strings.Contains(output, "❯") || strings.Contains(output, "help") {
+				return true
+			}
+		}
+	}
+}
+
 func (m *Manager) captureTmuxPane(session string) string {
 	cmd := exec.Command("tmux", "capture-pane", "-t", session, "-p",
 		"-S", fmt.Sprintf("-%d", tmuxCaptureLines))
@@ -730,7 +750,10 @@ func (m *Manager) SendKick(name string, message string) error {
 			m.mu.Lock()
 			return fmt.Errorf("failed to restart crashed agent %s: %w", name, err)
 		}
-		time.Sleep(cliRestartSettleDelay)
+		if !m.waitForCLIReady(agent.tmuxSession) {
+			m.mu.Lock()
+			return fmt.Errorf("agent %s CLI did not become ready after restart", name)
+		}
 		m.mu.Lock()
 		agent, ok = m.agents[name]
 		if !ok {
@@ -811,7 +834,8 @@ const (
 	chunkSize             = 400
 	chunkDelay            = 1 * time.Second
 	staleCheckDelay       = 1 * time.Second
-	cliRestartSettleDelay = 5 * time.Second
+	cliReadyPollInterval = 2 * time.Second
+	cliReadyTimeout      = 60 * time.Second
 )
 
 func (m *Manager) SeedLastKick(name string, t time.Time) {


### PR DESCRIPTION
## Summary
- Replaced fixed 5-second `cliRestartSettleDelay` with `waitForCLIReady` that polls tmux pane for the CLI's `❯` prompt
- Polls every 2s with 60s timeout — CLI needs time to start, handle trust prompt, and reach idle state
- Without this, kick text gets pasted into bare bash when CLI hasn't initialized yet, causing `bash: command not found` spam and corrupted sessions
- If CLI doesn't become ready within timeout, the kick is skipped with an error instead of corrupting the session

## Root cause
After crash restart, `SendKick` waited a fixed 5s then sent the kick. But CLI startup (especially Copilot with trust prompt) takes 10-30s. The kick text arrived at bash, not the CLI.

## Test plan
- [ ] Kill an agent's CLI — crash detection restarts it, waits for `❯`, then sends kick
- [ ] Verify no more `bash: command not found` spam in tmux sessions
- [ ] Verify terminal sessions are openable from dashboard after kicks