### PR TITLE
fix: handle multiple Copilot trust prompts on launch

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -307,7 +307,8 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 func (m *Manager) watchForTrustPrompt(session string, ctx context.Context) {
 	const (
 		trustPollInterval = 2 * time.Second
-		trustMaxWait      = 60 * time.Second
+		trustMaxWait      = 120 * time.Second
+		trustCooldown     = 3 * time.Second
 	)
 	deadline := time.After(trustMaxWait)
 	ticker := time.NewTicker(trustPollInterval)
@@ -327,7 +328,7 @@ func (m *Manager) watchForTrustPrompt(session string, ctx context.Context) {
 				time.Sleep(enterDelay)
 				_ = exec.Command("tmux", "send-keys", "-t", session, "Enter").Run()
 				m.logger.Info("auto-answered folder trust prompt", "session", session)
-				return
+				time.Sleep(trustCooldown)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- The trust prompt watcher exited after answering one prompt, but Copilot can show multiple (e.g. agent dir + beads symlink dir)
- Supervisor was getting stuck on the second trust prompt and crash-looping (3 restarts observed)
- Keep the watcher alive for the full 120s timeout with a 3s cooldown between answers

## Test plan
- [x] Build passes
- [x] Manually verified supervisor unstuck after answering second trust prompt
- [ ] Verify on next container restart that supervisor launches without crash-loop