### PR TITLE
fix: dashboard UI — Strategy Lab flash, agent dedup, restart reset, scrollback

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -513,7 +513,7 @@ func (m *Manager) pollTmuxOutput(name, session string, buf *RingBuffer, ctx cont
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 
-	var lastHash uint64
+	var prevLines []string
 	for {
 		select {
 		case <-ctx.Done():
@@ -533,28 +533,46 @@ func (m *Manager) pollTmuxOutput(name, session string, buf *RingBuffer, ctx cont
 			if len(filtered) == 0 {
 				continue
 			}
-			h := hashLines(filtered)
-			if h == lastHash {
-				continue
+			newLines := diffNewLines(prevLines, filtered)
+			for _, l := range newLines {
+				buf.Write(l)
 			}
-			lastHash = h
-			buf.ReplaceAll(filtered)
+			prevLines = filtered
 		}
 	}
 }
 
-func hashLines(lines []string) uint64 {
-	var h uint64 = 14695981039346656037
-	for _, l := range lines {
-		for i := 0; i < len(l); i++ {
-			h ^= uint64(l[i])
-			h *= 1099511628211
-		}
-		h ^= uint64('\n')
-		h *= 1099511628211
+func diffNewLines(prev, curr []string) []string {
+	if len(prev) == 0 {
+		return curr
 	}
-	return h
+	overlap := findOverlap(prev, curr)
+	if overlap >= 0 && overlap < len(curr) {
+		return curr[overlap:]
+	}
+	return curr
 }
+
+func findOverlap(prev, curr []string) int {
+	maxTail := len(prev)
+	if maxTail > len(curr) {
+		maxTail = len(curr)
+	}
+	for tail := maxTail; tail > 0; tail-- {
+		match := true
+		for i := range tail {
+			if prev[len(prev)-tail+i] != curr[i] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return tail
+		}
+	}
+	return -1
+}
+
 
 // waitForCLIReady polls the tmux pane until the CLI shows its ready prompt
 // or the timeout expires. Returns true if the CLI became ready.
@@ -1148,25 +1166,11 @@ func (m *Manager) GetOutput(name string, lines int) ([]string, error) {
 		return nil, fmt.Errorf("agent %s not found", name)
 	}
 
-	if m.tmuxSessionExists(agent.tmuxSession) {
-		output := m.captureTmuxPane(agent.tmuxSession)
-		if output != "" {
-			allLines := strings.Split(output, "\n")
-			for len(allLines) > 0 && strings.TrimSpace(allLines[len(allLines)-1]) == "" {
-				allLines = allLines[:len(allLines)-1]
-			}
-			if len(allLines) > lines {
-				allLines = allLines[len(allLines)-lines:]
-			}
-			return allLines, nil
-		}
+	if agent.OutputBuffer != nil {
+		return agent.OutputBuffer.Last(lines), nil
 	}
 
-	if agent.OutputBuffer == nil {
-		return nil, nil
-	}
-
-	return agent.OutputBuffer.Last(lines), nil
+	return nil, nil
 }
 
 func (m *Manager) IsPaused(name string) bool {

--- a/v2/pkg/agent/ringbuffer.go
+++ b/v2/pkg/agent/ringbuffer.go
@@ -51,24 +51,6 @@ func (r *RingBuffer) Last(n int) []string {
 	return result
 }
 
-func (r *RingBuffer) ReplaceAll(lines []string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	n := len(lines)
-	if n > r.cap {
-		lines = lines[n-r.cap:]
-		n = r.cap
-	}
-	for i := range r.cap {
-		r.items[i] = ""
-	}
-	for i, l := range lines {
-		r.items[i] = l
-	}
-	r.head = n % r.cap
-	r.count = n
-}
 
 func (r *RingBuffer) Count() int {
 	r.mu.RLock()

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1653,7 +1653,7 @@
     <div class="beads" id="beads"></div>
   </div>
 
-  <div id="nous-section" style="margin-top: 16px; margin-bottom: 24px;">
+  <div id="nous-section" style="display:none; margin-top: 16px; margin-bottom: 24px;">
     <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 8px;">🧪 Strategy Lab <span id="nous-mode-badge" style="font-size:0.75rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span> <button onclick="openNousConfig()" style="background:none;border:none;cursor:pointer;font-size:1rem;color:var(--muted);margin-left:6px;padding:2px" title="Strategy Lab Configuration">⚙️</button></h2>
     <div id="nous-panel"></div>
     <div id="nous-config-overlay" class="nous-config-overlay" style="display:none"></div>
@@ -2060,7 +2060,7 @@
           <div class="oc-detail-field"><div class="label" title="When the governor last kicked (started a work pass for) this agent.">Last Run</div><div class="value">${esc(a.lastKick || '—')}</div></div>
           <div class="oc-detail-field"><div class="label" title="When the governor will next kick this agent based on its cadence interval.">Next Run</div><div class="value">${isPaused ? 'paused' : isOff ? 'off' : esc(a.nextKick || '—')}</div></div>
           <div class="oc-detail-field"><div class="label" title="Total tokens consumed by this agent in the last 24 hours across all sessions.">Tokens (24h)</div><div class="value">${_tokTotal > 0 ? fmtTokens(_tokTotal) : (_tok.sessions > 0 ? _tok.sessions + ' sess' : '—')}</div></div>
-          <div class="oc-detail-field"><div class="label" title="Number of times this agent has been restarted in the last 24 hours. High counts may indicate instability.">Restarts</div><div class="value">${a.restarts ?? 0}</div></div>
+          <div class="oc-detail-field"><div class="label" title="Number of times this agent has been restarted in the last 24 hours. High counts may indicate instability.">Restarts</div><div class="value">${a.restarts ?? 0}${(a.restarts || 0) > 0 ? ` <button class="restart-reset" data-action="resetRestarts" data-agent="${esc(a.name)}" title="Reset the restart counter to zero — does not affect the agent">✕</button>` : ''}</div></div>
           <div class="oc-detail-field"><div class="label" title="Average tokens consumed per work pass (kick session). Lower is more efficient.">Avg/Pass</div><div class="value">${_tokAvg > 0 ? fmtTokens(_tokAvg) : '—'}</div></div>
           <div class="oc-detail-field"><div class="label" title="Number of separate CLI sessions this agent has had in the last 24 hours.">Sessions</div><div class="value">${_tok.sessions ?? '—'}</div></div>
           <div class="oc-detail-field"><div class="label" title="Total number of messages (prompts + responses) across all sessions in the last 24 hours.">Messages</div><div class="value">${_tok.messages ?? '—'}</div></div>
@@ -6167,6 +6167,7 @@ function burnAreaChart() {
             applyPinOverrides(lastData.agents);
             renderAgents(lastData.agents);
           }
+          ocUpdateFocusedState();
           const _lvl = (lastData.acmmLevel != null) ? lastData.acmmLevel : 0;
           const _pa = lastData.acmmPackAgents || null;
           applyACMMVisibility(_lvl, _pa);


### PR DESCRIPTION
## Summary
- **Strategy Lab flash**: Section starts hidden (`display:none`) and is only shown by `applyACMMVisibility` when level >= 4. Previously it was visible by default, causing a flash at lower levels before the first SSE event hid it.
- **Focused agent in bottom cards**: `renderAgents` rebuilds all card HTML (wiping `oc-hidden` classes), but `ocUpdateFocusedState` was not called afterward. The focused agent's card would briefly reappear in the bottom row until the next render cycle.
- **Missing restart reset button**: The in-focus agent detail card showed the restart count but had no reset button (the bottom cards had one). Added the same reset button to the detail card.
- **Scrollback loss**: `pollTmuxOutput` called `ReplaceAll` every 3s, wiping the ring buffer and replacing it with only the currently visible pane content. Changed to incremental append — only new lines are added to the buffer, preserving scrollback history. `GetOutput` now serves from the accumulated ring buffer instead of a live tmux pane capture.

## Test plan
- [ ] Load dashboard at ACMM level 3 — Strategy Lab should not flash
- [ ] Select an agent — it should disappear from bottom cards immediately, not flash
- [ ] Selected agent detail card should show restart reset button when count > 0
- [ ] Open terminal view for an agent — scrollback should persist beyond visible pane