### PR TITLE
fix: add STOP CHECK guard to prevent template bead creation

### DIFF
--- a/v2/policies/ci-maintainer-advisory.md
+++ b/v2/policies/ci-maintainer-advisory.md
@@ -13,37 +13,28 @@ You are the **ci-maintainer** agent in a Hive instance running at ACMM Level 3 (
 
 ## Writing Findings
 
-After analyzing CI health, record each finding as a bead:
+After analyzing CI health, record each finding as a bead using `bd create`. **NEVER execute an example command literally** — always substitute real values for every placeholder.
 
-```bash
-bd create --title "Short description of the CI finding" \
-  --type advisory \
-  --priority 2 \
-  --actor ci-maintainer \
-  --external-ref "workflow-name or run-id"
-```
+**Required fields** — every `bd create` MUST have all of these filled with real data:
+- `--title` — a specific, descriptive title (NEVER placeholder text like "Short description")
+- `--type advisory`
+- `--priority` — 0 (critical), 1 (high), 2 (medium), 3 (low)
+- `--actor ci-maintainer`
+- `--external-ref` — the actual workflow name or run ID
 
-### Priority levels
-- **0** (critical) — CI completely broken, builds not running
-- **1** (high) — persistent test failure, coverage drop, security workflow broken
-- **2** (medium) — flaky test, slow build, workflow optimization opportunity
-- **3** (low) — minor improvement, nice-to-have optimization
+**STOP CHECK before every `bd create`**: if your title contains placeholder text, DO NOT run the command.
+
+Priority levels: 0 (critical — CI broken), 1 (high — persistent failure/coverage drop), 2 (medium — flaky test/slow build), 3 (low — minor optimization)
 
 Then add detail metadata:
 
 ```bash
-bd update <bead-id> --set-metadata finding_type=ci-health
-bd update <bead-id> --set-metadata detail="Detailed explanation of the CI finding"
-bd update <bead-id> --set-metadata workflow="workflow-name"
+bd update <bead-id> --set-metadata finding_type=<type>
+bd update <bead-id> --set-metadata detail="<real explanation>"
+bd update <bead-id> --set-metadata workflow="<real-workflow-name>"
 ```
 
-### Finding types (for `finding_type` metadata)
-- `ci-failure` — workflow failing consistently
-- `flaky-test` — test that passes/fails intermittently
-- `slow-build` — build time regression
-- `coverage-drop` — coverage decreased from previous baseline
-- `dependency-update` — outdated or vulnerable dependency
-- `workflow-gap` — missing CI workflow that should exist
+Finding types: `ci-failure`, `flaky-test`, `slow-build`, `coverage-drop`, `dependency-update`, `workflow-gap`
 
 ## Workflow
 

--- a/v2/policies/guide-advisory.md
+++ b/v2/policies/guide-advisory.md
@@ -16,36 +16,28 @@ Your job is to audit project documentation, onboarding materials, and contributo
 
 ## Writing Findings
 
-After auditing the project's documentation, record each gap as a bead:
+After auditing the project's documentation, record each gap as a bead using `bd create`. **NEVER execute an example command literally** — always substitute real values for every placeholder.
+
+**Required fields** — every `bd create` MUST have all of these filled with real data:
+- `--title` — a specific, descriptive title (NEVER placeholder text like "Short description")
+- `--type advisory`
+- `--priority` — 0 (critical), 1 (high), 2 (medium), 3 (low)
+- `--actor guide`
+- `--external-ref` — the actual file path or section reference
+
+**STOP CHECK before every `bd create`**: if your title contains placeholder text, DO NOT run the command.
+
+Priority levels: 0 (critical — no README/build instructions), 1 (high — missing setup/stale arch docs), 2 (medium — missing contributor guide/incomplete examples), 3 (low — typos/style)
+
+Then add detail metadata:
 
 ```bash
-bd create --title "Short description of the documentation gap" \
-  --type advisory \
-  --priority 2 \
-  --actor guide \
-  --external-ref "path/to/file-or-section"
+bd update <bead-id> --set-metadata finding_type=<type>
+bd update <bead-id> --set-metadata detail="<real explanation>"
+bd update <bead-id> --set-metadata file="<real-file-path>"
 ```
 
-### Priority levels
-- **0** (critical) — no README, no build instructions, project completely unapproachable
-- **1** (high) — missing setup/install docs, undocumented breaking changes, stale architecture docs
-- **2** (medium) — missing contributor guide, undocumented API surface, incomplete examples
-- **3** (low) — minor doc improvements, typos, formatting, style inconsistencies
-
-Then add detail metadata to the bead:
-
-```bash
-bd update <bead-id> --set-metadata finding_type=docs
-bd update <bead-id> --set-metadata detail="Detailed explanation of the gap and suggested content"
-bd update <bead-id> --set-metadata file="README.md"
-```
-
-### Finding types (for `finding_type` metadata)
-- `docs` — missing or incomplete documentation
-- `onboarding` — gap in getting-started or setup flow
-- `architecture` — missing or stale architecture documentation
-- `api` — undocumented public interfaces, config options, or environment variables
-- `contributing` — missing or incomplete contributor workflow docs
+Finding types: `docs`, `onboarding`, `architecture`, `api`, `contributing`
 
 ## Workflow
 

--- a/v2/policies/quality-advisory.md
+++ b/v2/policies/quality-advisory.md
@@ -13,35 +13,28 @@ You are the **quality** agent in a Hive instance running at ACMM Level 2 (adviso
 
 ## Writing Findings
 
-After analyzing the codebase, record each finding as a bead:
+After analyzing the codebase, record each finding as a bead using `bd create`. **NEVER execute an example command literally** — always substitute real values for every placeholder.
+
+**Required fields** — every `bd create` MUST have all of these filled with real data:
+- `--title` — a specific, descriptive title (NEVER placeholder text like "Short description")
+- `--type advisory`
+- `--priority` — 0 (critical), 1 (high), 2 (medium), 3 (low)
+- `--actor quality`
+- `--external-ref` — the actual file path being analyzed
+
+**STOP CHECK before every `bd create`**: if your title contains placeholder text, DO NOT run the command.
+
+Priority levels: 0 (critical — untested auth/data mutation), 1 (high — major business logic gap), 2 (medium — significant gap), 3 (low — nice-to-have)
+
+Then add detail metadata:
 
 ```bash
-bd create --title "Short description of the coverage gap" \
-  --type advisory \
-  --priority 2 \
-  --actor quality \
-  --external-ref "path/to/untested/file.go"
+bd update <bead-id> --set-metadata finding_type=<type>
+bd update <bead-id> --set-metadata detail="<real explanation>"
+bd update <bead-id> --set-metadata file="<real-file-path>"
 ```
 
-### Priority levels
-- **0** (critical) — critical untested code path (auth, data mutation, error handling)
-- **1** (high) — major gap in business logic coverage
-- **2** (medium) — significant gap worth addressing
-- **3** (low) — minor gap, nice-to-have test
-
-Then add detail metadata to the bead:
-
-```bash
-bd update <bead-id> --set-metadata finding_type=coverage-gap
-bd update <bead-id> --set-metadata detail="Detailed explanation of what needs testing"
-bd update <bead-id> --set-metadata file="path/to/file.go"
-```
-
-### Finding types (for `finding_type` metadata)
-- `coverage-gap` — untested function or branch
-- `missing-fixture` — no test infrastructure for a module
-- `regression-risk` — code changed recently with no test update
-- `test-quality` — existing test is weak (no assertions, flaky, etc.)
+Finding types: `coverage-gap`, `missing-fixture`, `regression-risk`, `test-quality`
 
 ## Workflow
 

--- a/v2/policies/scanner-advisory.md
+++ b/v2/policies/scanner-advisory.md
@@ -14,36 +14,25 @@ You are the **scanner** agent in a Hive instance running at ACMM Level 2 (adviso
 
 ## Writing Findings
 
-After analyzing each issue, record your finding as a bead:
+After analyzing each issue, record your finding as a bead using `bd create`. **NEVER execute an example command literally** — always substitute real values for every placeholder.
+
+**Required fields** — every `bd create` MUST have all of these filled with real data:
+- `--title` — a specific, descriptive title (NEVER "Short description", NEVER "#NNNN", NEVER template text)
+- `--type advisory`
+- `--priority` — 0 (critical/security), 1 (high/bug), 2 (medium/quality), 3 (low/style)
+- `--actor scanner`
+- `--external-ref "gh-<REAL-ISSUE-NUMBER>"` — the actual GitHub issue number, not a placeholder
+
+**STOP CHECK before every `bd create`**: if your title contains "NNNN", "short title", "Short description", or any placeholder text, DO NOT run the command. Replace with real values first.
+
+Then add detail metadata:
 
 ```bash
-bd create --title "Short description of the finding" \
-  --type advisory \
-  --priority 1 \
-  --actor scanner \
-  --external-ref "gh-<issue-number>"
+bd update <bead-id> --set-metadata finding_type=<type>
+bd update <bead-id> --set-metadata detail="<real explanation>"
 ```
 
-### Priority levels
-- **0** (critical) — security vulnerability, data loss risk
-- **1** (high) — functional bug, broken feature, architectural issue
-- **2** (medium) — code quality issue, missing validation, doc gap
-- **3** (low) — style, minor improvement, nice-to-have
-
-Then add detail metadata to the bead:
-
-```bash
-bd update <bead-id> --set-metadata finding_type=bug
-bd update <bead-id> --set-metadata detail="Detailed explanation of the finding"
-bd update <bead-id> --set-metadata file="path/to/file.go"
-```
-
-### Finding types (for `finding_type` metadata)
-- `bug` — functional defect
-- `security` — security vulnerability
-- `architecture` — design or structural issue
-- `performance` — performance problem
-- `docs` — documentation gap or error
+Finding types: `bug`, `security`, `architecture`, `performance`, `docs`
 
 ## Workflow
 


### PR DESCRIPTION
## Summary
- Scanner was creating garbage beads with literal placeholder text (`Fixing #NNNN: <short title>`) — 18 total since May 21, 7 open
- Replaced `bd create` example code blocks in all 4 advisory policies with explicit STOP CHECK guards
- Agents must verify titles contain real data before every `bd create` execution
- Cleaned up 7 open garbage beads manually

## Test plan
- [x] Policies are markdown-only, no code changes
- [ ] Monitor next scanner kick to verify no more garbage beads