### PR TITLE
fix: enforce ACMM restrictions on git push and GitHub API access

### DIFF
--- a/bin/git-credential-hive.sh
+++ b/bin/git-credential-hive.sh
@@ -5,6 +5,23 @@
 
 set -euo pipefail
 
+# ── ACMM enforcement: block git push for advisory-only agents ──
+AGENT="${HIVE_AGENT:-}"
+ACMM="${HIVE_ACMM_LEVEL:-0}"
+
+if [ -n "$AGENT" ] && [ "$ACMM" -gt 0 ]; then
+  # L1/L2: no agent can push
+  if [ "$ACMM" -lt 3 ]; then
+    echo "⛔ git push blocked: ACMM L${ACMM} agents are advisory-only" >&2
+    exit 1
+  fi
+  # L3: only quality can push
+  if [ "$ACMM" -eq 3 ] && [ "$AGENT" != "quality" ]; then
+    echo "⛔ git push blocked: only quality agent can push at ACMM L3" >&2
+    exit 1
+  fi
+fi
+
 TOKEN_FILE="/var/run/hive-metrics/gh-app-token.cache"
 CACHE_MAX_AGE_SECONDS=3300
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -159,7 +159,7 @@ func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
 	}
 
 	cmd := exec.Command("tmux", "new-session", "-d", "-s", agent.tmuxSession, "-c", agentDir)
-	cmd.Env = append(os.Environ(), m.agentEnvVars(agent)...)
+	cmd.Env = append(m.filteredEnv(agent), m.agentEnvVars(agent)...)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("creating tmux session for %s: %w", agent.Name, err)
 	}
@@ -945,6 +945,39 @@ func normalizeModelName(model string) string {
 		return model[:idx] + "." + suffix
 	}
 	return model
+}
+
+// agentCanWrite returns true if this agent is allowed to push branches and create PRs.
+func (m *Manager) agentCanWrite(agent *AgentProcess) bool {
+	level := m.project.ACMMLevel
+	if level == 0 || level >= 4 {
+		return true
+	}
+	if level < 3 {
+		return false
+	}
+	// L3: only quality can write
+	return agent.Name == "quality"
+}
+
+// filteredEnv returns os.Environ() with write-capable tokens removed for advisory agents.
+// This prevents Copilot CLI from using COPILOT_GITHUB_TOKEN to push branches or create PRs
+// via the GitHub API, bypassing the gh wrapper.
+func (m *Manager) filteredEnv(agent *AgentProcess) []string {
+	env := os.Environ()
+	if m.agentCanWrite(agent) {
+		return env
+	}
+	filtered := make([]string, 0, len(env))
+	for _, e := range env {
+		if strings.HasPrefix(e, "COPILOT_GITHUB_TOKEN=") ||
+			strings.HasPrefix(e, "GH_TOKEN=") ||
+			strings.HasPrefix(e, "GITHUB_TOKEN=") {
+			continue
+		}
+		filtered = append(filtered, e)
+	}
+	return filtered
 }
 
 func (m *Manager) agentEnvVars(agent *AgentProcess) []string {


### PR DESCRIPTION
## Summary
- **Layer 1 — credential helper**: `git-credential-hive.sh` now checks `HIVE_AGENT` and `HIVE_ACMM_LEVEL` before issuing tokens. At L1/L2 all agents are blocked from `git push`. At L3 only `quality` can push. No token → push fails → no branch → no PR.
- **Layer 2 — token isolation**: `filteredEnv()` strips `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, and `GITHUB_TOKEN` from the tmux session environment for advisory-only agents. Copilot CLI can't use its own OAuth token to push or create PRs via the GitHub API.

## Root cause
Scanner and guide opened PRs #509, #510, #511 at ACMM L3 even though they're advisory-only. The `gh` wrapper correctly enforces L3 restrictions, but Copilot CLI creates PRs via the GitHub API directly (not `gh`), and the git credential helper issued tokens to all agents without checking identity.

## Test plan
- [ ] Deploy updated container
- [ ] Wait for governor eval cycle — scanner/guide should fail on `git push` with "⛔ git push blocked" error
- [ ] Quality agent should still push and create PRs normally
- [ ] Check `docker logs hive` for blocked credential requests