### PR TITLE
fix: persist Copilot CLI auth across container restarts

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -50,6 +50,12 @@ if [ "$(id -u)" = "0" ]; then
     chown -R dev:node /data/beads /home/dev 2>/dev/null || true
   fi
 
+  # Persist Copilot CLI auth across container restarts
+  mkdir -p /data/config/github-copilot /home/dev/.config
+  ln -sfn /data/config/github-copilot /home/dev/.config/github-copilot
+  chown -R dev:node /data/config /home/dev/.config 2>/dev/null || true
+  echo "[entrypoint] Copilot config: ~/.config/github-copilot -> /data/config/github-copilot"
+
   # Drop to non-root user for all runtime processes.
   # Claude Code refuses --dangerously-skip-permissions as root.
   if command -v gosu >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- Symlinks `~/.config/github-copilot` → `/data/config/github-copilot` in entrypoint.sh
- After one `/login`, auth token (`hosts.json`) survives all future container restarts
- Follows existing beads symlink pattern (lines 30-50 of entrypoint.sh)

## Problem

Every container restart (policy repo conflicts, manual restart, image update) kills all agent auth. User must manually `/login` each time. This happened 3+ times in one session.

## Test plan

- [ ] Deploy updated image
- [ ] `/login` once inside any agent
- [ ] Verify `hosts.json` on persistent volume: `docker exec hive ls /data/config/github-copilot/`
- [ ] Restart container — agents should start authenticated