### PR TITLE
fix: restart agents with missing tmux sessions

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -706,6 +706,8 @@ func (m *Manager) CheckAndRestartCrashedAgents(ctx context.Context) []string {
 			continue
 		}
 		if !m.tmuxSessionExists(agent.tmuxSession) {
+			m.logger.Warn("agent tmux session missing", "name", name, "session", agent.tmuxSession)
+			crashed = append(crashed, name)
 			continue
 		}
 		if !m.tmuxPaneHasCLI(agent.tmuxSession) {


### PR DESCRIPTION
## Summary
- `CheckAndRestartCrashedAgents` previously skipped agents whose tmux session was entirely gone (killed via `kill -9` or other force-kill)
- This left agents permanently dead with no automatic recovery — the governor tried to kick them but got "session not found" errors
- Now treats a missing tmux session the same as a crashed CLI, triggering `Restart()` which recreates the session and relaunches the agent

## Root Cause
Line 708-710 in `manager.go` had `if !tmuxSessionExists → continue`, which silently skipped dead agents. `Restart()` already handles session recreation via `ensureTmuxSession()`, so the fix is simply to not skip these agents.

## Test plan
- [ ] Deploy to 4.85, kill an agent's tmux session with `kill -9`
- [ ] Verify the health check detects "agent tmux session missing" in logs
- [ ] Verify the agent is automatically restarted within one health check cycle