### PR TITLE
feat: comprehensive audit logging for full system reconstruction

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -757,6 +757,19 @@ func runEvalCycle(
 				continue
 			}
 			gov.RecordKick(msg.Agent)
+
+			// Log token state at time of kick for cost attribution
+			if tokenCollector != nil {
+				if summary := tokenCollector.Summary(); summary != nil {
+					agentTokens := summary.ByAgent[msg.Agent]
+					logger.Info("kick token snapshot",
+						"agent", msg.Agent,
+						"agent_tokens", agentTokens,
+						"total_tokens", summary.TotalTokens,
+						"total_sessions", summary.SessionCount,
+					)
+				}
+			}
 		}
 	}
 
@@ -796,6 +809,17 @@ func runEvalCycle(
 		if err != nil {
 			logger.Warn("failed to read advisory findings", "error", err)
 		} else if len(findings) > 0 {
+			// Log each new finding for the audit trail
+			for _, f := range findings {
+				logger.Info("advisory finding ingested",
+					"agent", f.Agent,
+					"severity", f.Severity,
+					"type", f.Type,
+					"title", f.Title,
+					"file", f.File,
+					"line", f.Line,
+				)
+			}
 			if persisted := advisory.PersistAsBeads(findings, beadStores); persisted > 0 {
 				logger.Info("advisory findings persisted as beads", "count", persisted)
 			}
@@ -812,6 +836,25 @@ func runEvalCycle(
 		statusPayload.AdvisoryDigest = digest
 
 		if digest.TotalCount > 0 {
+			// Log severity breakdown and contributing agents
+			bySeverity := map[string]int{"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0}
+			agentNames := make([]string, 0, len(digest.ByAgent))
+			for agentName, findings := range digest.ByAgent {
+				agentNames = append(agentNames, fmt.Sprintf("%s(%d)", agentName, len(findings)))
+				for _, f := range findings {
+					bySeverity[strings.ToLower(f.Severity)]++
+				}
+			}
+			logger.Info("advisory digest built",
+				"total_findings", digest.TotalCount,
+				"critical", bySeverity["critical"],
+				"high", bySeverity["high"],
+				"medium", bySeverity["medium"],
+				"low", bySeverity["low"],
+				"agents", strings.Join(agentNames, ", "),
+				"resolved_count", len(digest.RecentlyResolved),
+			)
+
 			md := advisory.FormatDigestMarkdown(digest)
 			if md != "" {
 				primaryRepo := cfg.Project.PrimaryRepo

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -350,7 +350,13 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	now := time.Now()
 	agent.State = StateRunning
 	agent.StartedAt = &now
-	m.logger.Info("agent launched in tmux", "name", agent.Name, "backend", backend, "session", agent.tmuxSession)
+	m.logger.Info("agent launched in tmux",
+		"name", agent.Name,
+		"backend", backend,
+		"model", model,
+		"mode", mode.String(),
+		"session", agent.tmuxSession,
+	)
 
 	agentCtx, cancel := context.WithCancel(ctx)
 	agent.cancel = cancel
@@ -599,6 +605,25 @@ func (m *Manager) buildEnvPrefix(agent *AgentProcess) string {
 	return strings.Join(vars, " ") + " "
 }
 
+// outputSignalPatterns are substrings in agent output that indicate meaningful
+// events worth logging. Each pattern maps to a short event label.
+var outputSignalPatterns = map[string]string{
+	"[HEARTBEAT]":  "heartbeat",
+	"[STATUS]":     "status",
+	"[FINDING]":    "finding",
+	"[COMPLETE]":   "task_complete",
+	"[ERROR]":      "agent_error",
+	"PASS":         "pass_marker",
+	"git commit":   "git_commit",
+	"git checkout": "git_branch",
+	"git push":     "git_push",
+	"created file": "file_created",
+	"Wrote":        "file_written",
+	"test:":        "test_activity",
+	"FAIL":         "test_failure",
+	"coverage":     "coverage_report",
+}
+
 func (m *Manager) pollTmuxOutput(name, session string, buf *RingBuffer, ctx context.Context) {
 	const pollInterval = 3 * time.Second
 	ticker := time.NewTicker(pollInterval)
@@ -627,8 +652,29 @@ func (m *Manager) pollTmuxOutput(name, session string, buf *RingBuffer, ctx cont
 			newLines := diffNewLines(prevLines, filtered)
 			for _, l := range newLines {
 				buf.Write(l)
+				m.logOutputSignals(name, l)
 			}
 			prevLines = filtered
+		}
+	}
+}
+
+// logOutputSignals checks a line of agent output for meaningful patterns
+// and emits a structured slog entry for each match.
+func (m *Manager) logOutputSignals(agent, line string) {
+	for pattern, event := range outputSignalPatterns {
+		if strings.Contains(line, pattern) {
+			preview := line
+			const maxPreviewLen = 200
+			if len(preview) > maxPreviewLen {
+				preview = preview[:maxPreviewLen] + "..."
+			}
+			m.logger.Info("agent output signal",
+				"agent", agent,
+				"event", event,
+				"content", preview,
+			)
+			return
 		}
 	}
 }
@@ -814,11 +860,30 @@ func (m *Manager) CheckAndRestartCrashedAgents(ctx context.Context) []string {
 			continue
 		}
 		if !m.tmuxSessionExists(agent.tmuxSession) {
-			m.logger.Warn("agent tmux session missing", "name", name, "session", agent.tmuxSession)
+			var uptimeSeconds float64
+			if agent.StartedAt != nil {
+				uptimeSeconds = time.Since(*agent.StartedAt).Seconds()
+			}
+			m.logger.Error("agent tmux session missing",
+				"name", name,
+				"session", agent.tmuxSession,
+				"restart_count", agent.RestartCount,
+				"uptime_seconds", int(uptimeSeconds),
+			)
 			crashed = append(crashed, name)
 			continue
 		}
 		if !m.tmuxPaneHasCLI(agent.tmuxSession) {
+			var uptimeSeconds float64
+			if agent.StartedAt != nil {
+				uptimeSeconds = time.Since(*agent.StartedAt).Seconds()
+			}
+			m.logger.Warn("agent CLI crashed (bare shell detected)",
+				"name", name,
+				"session", agent.tmuxSession,
+				"restart_count", agent.RestartCount,
+				"uptime_seconds", int(uptimeSeconds),
+			)
 			crashed = append(crashed, name)
 		}
 	}
@@ -826,10 +891,18 @@ func (m *Manager) CheckAndRestartCrashedAgents(ctx context.Context) []string {
 
 	var restarted []string
 	for _, name := range crashed {
-		m.logger.Warn("agent CLI not running, restarting", "name", name)
+		m.logger.Info("restarting crashed agent", "name", name)
 		if err := m.Restart(ctx, name); err != nil {
 			m.logger.Error("failed to restart crashed agent", "name", name, "error", err)
 		} else {
+			m.mu.RLock()
+			agent := m.agents[name]
+			m.mu.RUnlock()
+			m.logger.Info("agent recovered from crash",
+				"name", name,
+				"restart_count", agent.RestartCount,
+				"backend", agent.Config.Backend,
+			)
 			restarted = append(restarted, name)
 		}
 	}
@@ -932,7 +1005,16 @@ func (m *Manager) SendKick(name string, message string) error {
 	}
 	agent.KickHistory = append(agent.KickHistory, record)
 
-	m.logger.Info("kick sent", "name", name, "message_len", len(message))
+	kickPreview := message
+	const maxKickPreviewLen = 200
+	if len(kickPreview) > maxKickPreviewLen {
+		kickPreview = kickPreview[:maxKickPreviewLen] + "..."
+	}
+	m.logger.Info("kick sent",
+		"name", name,
+		"message_len", len(message),
+		"preview", kickPreview,
+	)
 
 	return nil
 }
@@ -1244,7 +1326,11 @@ func (m *Manager) Pause(name string) error {
 		_ = cmd.Run()
 	}
 	agent.State = StatePaused
-	m.logger.Info("agent paused", "name", name)
+	m.logger.Info("agent paused",
+		"name", name,
+		"backend", agent.Config.Backend,
+		"restart_count", agent.RestartCount,
+	)
 	return nil
 }
 

--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -138,12 +138,15 @@ func (g *Governor) Evaluate(queueIssues, queuePRs, queueHold, slaViolations int)
 	g.state.LastEval = time.Now()
 
 	newMode := g.computeMode(queueIssues)
-	if newMode != g.state.Mode {
+	modeChanged := newMode != g.state.Mode
+	if modeChanged {
 		g.logger.Info("governor mode change",
 			"from", g.state.Mode,
 			"to", newMode,
 			"issues", queueIssues,
 			"prs", queuePRs,
+			"hold", queueHold,
+			"sla_violations", slaViolations,
 		)
 		change := ModeChange{
 			Timestamp: time.Now(),
@@ -156,6 +159,23 @@ func (g *Governor) Evaluate(queueIssues, queuePRs, queueHold, slaViolations int)
 	}
 
 	g.updateCadences()
+
+	if modeChanged {
+		for agentName, cadence := range g.state.Cadences {
+			if cadence.Paused {
+				g.logger.Info("agent cadence: paused by mode",
+					"agent", agentName,
+					"mode", g.state.Mode,
+				)
+			} else if cadence.Interval > 0 {
+				g.logger.Info("agent cadence: active",
+					"agent", agentName,
+					"mode", g.state.Mode,
+					"interval", cadence.Interval.String(),
+				)
+			}
+		}
+	}
 
 	due := g.agentsDueForKick()
 

--- a/v2/pkg/knowledge/filestore.go
+++ b/v2/pkg/knowledge/filestore.go
@@ -21,12 +21,13 @@ const (
 // and exposes them as knowledge facts. It supports search, read, list, and stats
 // operations compatible with the wiki Client interface.
 type FileStore struct {
-	rootDir     string
-	name        string
-	mu          sync.RWMutex
-	pages       map[string]filePage
-	lastIndexed time.Time
-	logger      *slog.Logger
+	rootDir       string
+	name          string
+	mu            sync.RWMutex
+	pages         map[string]filePage
+	lastIndexed   time.Time
+	logger        *slog.Logger
+	prevPageCount int
 }
 
 type filePage struct {
@@ -116,11 +117,20 @@ func (s *FileStore) reindex() {
 	}
 
 	s.mu.Lock()
+	prevCount := s.prevPageCount
 	s.pages = pages
 	s.lastIndexed = time.Now()
+	s.prevPageCount = len(pages)
 	s.mu.Unlock()
 
-	s.logger.Info("vault indexed", "name", s.name, "dir", s.rootDir, "pages", len(pages))
+	if len(pages) != prevCount {
+		s.logger.Info("vault indexed",
+			"name", s.name,
+			"dir", s.rootDir,
+			"pages", len(pages),
+			"page_delta", len(pages)-prevCount,
+		)
+	}
 }
 
 func (s *FileStore) refreshIfStale() {

--- a/v2/pkg/notify/notify.go
+++ b/v2/pkg/notify/notify.go
@@ -6,18 +6,27 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
 )
 
-const httpTimeoutSeconds = 10
+const (
+	httpTimeoutSeconds      = 10
+	errorDedupeWindowSeconds = 60
+)
 
 type Notifier struct {
 	cfg    config.NotificationsConfig
 	hiveID string
 	client *http.Client
 	logger *slog.Logger
+
+	mu              sync.Mutex
+	lastNtfyErr     string
+	lastNtfyErrTime time.Time
+	ntfyErrCount    int
 }
 
 func New(cfg config.NotificationsConfig, logger *slog.Logger) *Notifier {
@@ -63,7 +72,7 @@ func (n *Notifier) sendNtfy(title, message string, priority Priority) {
 
 	req, err := http.NewRequest("POST", url, bytes.NewBufferString(message))
 	if err != nil {
-		n.logger.Warn("ntfy request creation failed", "error", err)
+		n.logNtfyError("ntfy request creation failed", err.Error())
 		return
 	}
 
@@ -72,14 +81,47 @@ func (n *Notifier) sendNtfy(title, message string, priority Priority) {
 
 	resp, err := n.client.Do(req)
 	if err != nil {
-		n.logger.Warn("ntfy send failed", "error", err)
+		n.logNtfyError("ntfy send failed", err.Error())
 		return
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		n.logger.Warn("ntfy returned error", "status", resp.StatusCode)
+		n.logNtfyError("ntfy returned error", fmt.Sprintf("status=%d", resp.StatusCode))
+		return
 	}
+
+	n.logger.Debug("ntfy sent", "title", title)
+}
+
+// logNtfyError deduplicates repeated ntfy errors within a window.
+// Logs the first occurrence immediately, then a summary when the error
+// class changes or the window expires.
+func (n *Notifier) logNtfyError(msg, errDetail string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	now := time.Now()
+	windowExpired := now.Sub(n.lastNtfyErrTime) > errorDedupeWindowSeconds*time.Second
+
+	if n.lastNtfyErr == msg && !windowExpired {
+		n.ntfyErrCount++
+		return
+	}
+
+	// Flush previous suppressed count
+	if n.ntfyErrCount > 0 {
+		n.logger.Warn("ntfy errors suppressed",
+			"message", n.lastNtfyErr,
+			"suppressed_count", n.ntfyErrCount,
+			"window_seconds", errorDedupeWindowSeconds,
+		)
+	}
+
+	n.logger.Warn(msg, "error", errDetail)
+	n.lastNtfyErr = msg
+	n.lastNtfyErrTime = now
+	n.ntfyErrCount = 0
 }
 
 func (n *Notifier) sendSlack(title, message string) {

--- a/v2/pkg/tokens/collector.go
+++ b/v2/pkg/tokens/collector.go
@@ -77,6 +77,9 @@ type Collector struct {
 	latest              *AggregateSummary
 	issueCosts          map[string]int64
 	scanInterval        time.Duration
+	prevSessionCount    int
+	prevTotalTokens     int64
+	prevByAgent         map[string]int64
 }
 
 func NewCollector(sessionsDir string, logger *slog.Logger) *Collector {
@@ -87,6 +90,7 @@ func NewCollector(sessionsDir string, logger *slog.Logger) *Collector {
 		logger:       logger,
 		issueCosts:   make(map[string]int64),
 		scanInterval: defaultScanInterval,
+		prevByAgent:  make(map[string]int64),
 	}
 	c.loadSnapshot()
 	return c
@@ -132,10 +136,6 @@ func (c *Collector) scan() {
 			c.logger.Warn("claude session scan failed", "error", err)
 		} else if claudeAgg != nil && claudeAgg.SessionCount > 0 {
 			MergeAggregates(agg, claudeAgg)
-			c.logger.Info("merged claude sessions",
-				"claude_sessions", claudeAgg.SessionCount,
-				"total_sessions", agg.SessionCount,
-			)
 		}
 	}
 
@@ -145,10 +145,35 @@ func (c *Collector) scan() {
 			c.logger.Warn("copilot session scan failed", "error", err)
 		} else if copilotAgg != nil && copilotAgg.SessionCount > 0 {
 			MergeAggregates(agg, copilotAgg)
-			c.logger.Info("merged copilot sessions",
-				"copilot_sessions", copilotAgg.SessionCount,
-				"total_sessions", agg.SessionCount,
-			)
+		}
+	}
+
+	sessionDelta := agg.SessionCount - c.prevSessionCount
+	tokenDelta := agg.TotalTokens - c.prevTotalTokens
+
+	if sessionDelta != 0 || tokenDelta != 0 {
+		attrs := []any{
+			"sessions", agg.SessionCount,
+			"session_delta", sessionDelta,
+			"total_tokens", agg.TotalTokens,
+			"token_delta", tokenDelta,
+		}
+
+		// Log per-agent token deltas for any agent whose count changed
+		for agent, tokens := range agg.ByAgent {
+			prev := c.prevByAgent[agent]
+			if tokens != prev {
+				attrs = append(attrs, "delta_"+agent, tokens-prev)
+			}
+		}
+
+		c.logger.Info("token summary updated", attrs...)
+
+		c.prevSessionCount = agg.SessionCount
+		c.prevTotalTokens = agg.TotalTokens
+		c.prevByAgent = make(map[string]int64, len(agg.ByAgent))
+		for k, v := range agg.ByAgent {
+			c.prevByAgent[k] = v
 		}
 	}
 


### PR DESCRIPTION
## Summary

- **Token collector**: Only logs when session count or token totals change (eliminates ~2,880 identical lines/day). Adds per-agent token deltas for spend attribution.
- **Ntfy notifier**: Deduplicates repeated errors within a 60s window — a single ntfy timeout no longer generates thousands of Warn lines.
- **Agent manager**: Logs meaningful patterns from agent tmux output (git commits, heartbeats, findings, test results). Enhances crash/restart logging with uptime, restart count, recovery confirmation. Includes kick message preview and mode/model in launch log.
- **Governor**: Logs per-agent cadence changes on mode transitions. Adds hold count and SLA violations to mode change log.
- **Advisory pipeline**: Logs each ingested finding individually (agent, severity, title, file:line). Logs digest severity breakdown and contributing agents.
- **Knowledge vault**: Only logs reindex at Info level when page count changes — suppresses identical lines every 60s.
- **Kick flow**: Logs token state snapshot at time of each kick for cost attribution.

Before this change, the rolling log file told you **when** the system acted but not **what agents produced** or **why decisions were made**. After this change, someone can reconstruct the full timeline: what each agent found, what the governor decided, which agents were kicked with what prompt, how tokens were spent, and what findings flowed into the advisory.

## Test plan

- [x] `go build ./cmd/hive/` — clean
- [x] `go test ./pkg/tokens/ ./pkg/notify/ ./pkg/agent/ ./pkg/governor/ ./pkg/knowledge/` — all pass
- [ ] Deploy to 4.78 or 4.85 and verify `tail -f /data/logs/hive.log` shows new structured entries
- [ ] Verify ntfy error spam is reduced (look for "ntfy errors suppressed" summary line)
- [ ] Verify "merged copilot sessions" only appears when count changes
- [ ] Verify "vault indexed" only appears when page count changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)