### PR TITLE
fix: persist dashboard config dialog changes across restarts

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -352,6 +352,10 @@ func main() {
 			cfg.ACMMLevel = saved.ACMMLevel
 			logger.Info("ACMM level restored", "level", *saved.ACMMLevel)
 		}
+		if saved.ConfigOverrides != nil {
+			applyConfigOverrides(cfg, saved.ConfigOverrides)
+			logger.Info("config overrides restored from persisted state")
+		}
 	}
 
 	if gov.GetBudget().WeeklyLimit == 0 && cfg.Governor.Budget.TotalTokens > 0 {
@@ -1115,6 +1119,8 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 		issueCosts = tc.IssueCosts()
 	}
 
+	configOverrides := buildConfigOverrides(cfg)
+
 	state := &snapshot.PersistedState{
 		Agents:           agents,
 		GovernorMode:     string(govState.Mode),
@@ -1130,6 +1136,7 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 		IssueCosts:       issueCosts,
 		LastEval:         govState.LastEval,
 		ACMMLevel:        cfg.ACMMLevel,
+		ConfigOverrides:  configOverrides,
 	}
 
 	if err := snapshot.SaveState(path, state, logger); err != nil {
@@ -1163,6 +1170,145 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 				_ = os.WriteFile("/data/token-sparkline-history.json", tokenData, 0o644)
 			}
 		}
+	}
+}
+
+func buildConfigOverrides(cfg *config.Config) *snapshot.ConfigOverrides {
+	o := &snapshot.ConfigOverrides{}
+
+	if len(cfg.Project.Repos) > 0 {
+		o.ProjectRepos = cfg.Project.Repos
+	}
+
+	evalInterval := cfg.Governor.EvalIntervalS
+	o.EvalIntervalS = &evalInterval
+
+	if len(cfg.Governor.Modes) > 0 {
+		o.Thresholds = make(map[string]int, len(cfg.Governor.Modes))
+		for name, mode := range cfg.Governor.Modes {
+			o.Thresholds[name] = mode.Threshold
+		}
+	}
+
+	if len(cfg.Governor.Sensing.GHRatePatterns) > 0 {
+		o.SensingGHRate = cfg.Governor.Sensing.GHRatePatterns
+	}
+	if len(cfg.Governor.Sensing.CLIExcludePatterns) > 0 {
+		o.SensingCLIExclude = cfg.Governor.Sensing.CLIExcludePatterns
+	}
+	if len(cfg.Governor.Sensing.LoginPatterns) > 0 {
+		o.SensingLogin = cfg.Governor.Sensing.LoginPatterns
+	}
+	ttl := cfg.Governor.Sensing.TTLSeconds
+	o.SensingTTL = &ttl
+	pullback := cfg.Governor.Sensing.PullbackSeconds
+	o.SensingPullback = &pullback
+
+	if len(cfg.Governor.Labels.Exempt) > 0 {
+		o.ExemptLabels = cfg.Governor.Labels.Exempt
+	}
+
+	if cfg.Notifications.Ntfy != nil {
+		o.NtfyServer = cfg.Notifications.Ntfy.Server
+		o.NtfyTopic = cfg.Notifications.Ntfy.Topic
+	}
+	if cfg.Notifications.Discord != nil {
+		o.DiscordWebhook = cfg.Notifications.Discord.Webhook
+	}
+
+	hcInterval := cfg.Governor.Health.HealthcheckInterval
+	o.HealthcheckInterval = &hcInterval
+	cooldown := cfg.Governor.Health.RestartCooldown
+	o.RestartCooldown = &cooldown
+	modelLock := cfg.Governor.Health.ModelLock
+	o.ModelLock = &modelLock
+
+	logSize := cfg.Governor.Logging.MaxSizeMB
+	o.LogMaxSizeMB = &logSize
+	logAge := cfg.Governor.Logging.MaxAgeDays
+	o.LogMaxAgeDays = &logAge
+	logBackups := cfg.Governor.Logging.MaxBackups
+	o.LogMaxBackups = &logBackups
+	logCompress := cfg.Governor.Logging.Compress
+	o.LogCompress = &logCompress
+	o.LogLevel = cfg.Governor.Logging.Level
+
+	return o
+}
+
+func applyConfigOverrides(cfg *config.Config, o *snapshot.ConfigOverrides) {
+	if len(o.ProjectRepos) > 0 {
+		cfg.Project.Repos = o.ProjectRepos
+	}
+	if o.EvalIntervalS != nil {
+		cfg.Governor.EvalIntervalS = *o.EvalIntervalS
+	}
+	if len(o.Thresholds) > 0 {
+		for name, threshold := range o.Thresholds {
+			if mode, ok := cfg.Governor.Modes[name]; ok {
+				mode.Threshold = threshold
+				cfg.Governor.Modes[name] = mode
+			}
+		}
+	}
+	if len(o.SensingGHRate) > 0 {
+		cfg.Governor.Sensing.GHRatePatterns = o.SensingGHRate
+	}
+	if len(o.SensingCLIExclude) > 0 {
+		cfg.Governor.Sensing.CLIExcludePatterns = o.SensingCLIExclude
+	}
+	if len(o.SensingLogin) > 0 {
+		cfg.Governor.Sensing.LoginPatterns = o.SensingLogin
+	}
+	if o.SensingTTL != nil {
+		cfg.Governor.Sensing.TTLSeconds = *o.SensingTTL
+	}
+	if o.SensingPullback != nil {
+		cfg.Governor.Sensing.PullbackSeconds = *o.SensingPullback
+	}
+	if len(o.ExemptLabels) > 0 {
+		cfg.Governor.Labels.Exempt = o.ExemptLabels
+	}
+	if o.NtfyServer != "" || o.NtfyTopic != "" {
+		if cfg.Notifications.Ntfy == nil {
+			cfg.Notifications.Ntfy = &config.NtfyConfig{}
+		}
+		if o.NtfyServer != "" {
+			cfg.Notifications.Ntfy.Server = o.NtfyServer
+		}
+		if o.NtfyTopic != "" {
+			cfg.Notifications.Ntfy.Topic = o.NtfyTopic
+		}
+	}
+	if o.DiscordWebhook != "" {
+		if cfg.Notifications.Discord == nil {
+			cfg.Notifications.Discord = &config.DiscordConfig{}
+		}
+		cfg.Notifications.Discord.Webhook = o.DiscordWebhook
+	}
+	if o.HealthcheckInterval != nil {
+		cfg.Governor.Health.HealthcheckInterval = *o.HealthcheckInterval
+	}
+	if o.RestartCooldown != nil {
+		cfg.Governor.Health.RestartCooldown = *o.RestartCooldown
+	}
+	if o.ModelLock != nil {
+		cfg.Governor.Health.ModelLock = *o.ModelLock
+	}
+	if o.LogMaxSizeMB != nil {
+		cfg.Governor.Logging.MaxSizeMB = *o.LogMaxSizeMB
+	}
+	if o.LogMaxAgeDays != nil {
+		cfg.Governor.Logging.MaxAgeDays = *o.LogMaxAgeDays
+	}
+	if o.LogMaxBackups != nil {
+		cfg.Governor.Logging.MaxBackups = *o.LogMaxBackups
+	}
+	if o.LogCompress != nil {
+		cfg.Governor.Logging.Compress = *o.LogCompress
+	}
+	if o.LogLevel != "" {
+		cfg.Governor.Logging.Level = o.LogLevel
 	}
 }
 

--- a/v2/pkg/snapshot/state.go
+++ b/v2/pkg/snapshot/state.go
@@ -26,6 +26,30 @@ type PersistedState struct {
 	IssueCosts       map[string]int64                 `json:"issue_costs,omitempty"`
 	LastEval         time.Time                        `json:"last_eval,omitempty"`
 	ACMMLevel        *int                             `json:"acmm_level,omitempty"`
+	ConfigOverrides  *ConfigOverrides                 `json:"config_overrides,omitempty"`
+}
+
+type ConfigOverrides struct {
+	ProjectRepos        []string       `json:"project_repos,omitempty"`
+	EvalIntervalS       *int           `json:"eval_interval_s,omitempty"`
+	Thresholds          map[string]int `json:"thresholds,omitempty"`
+	SensingGHRate       []string       `json:"sensing_gh_rate,omitempty"`
+	SensingCLIExclude   []string       `json:"sensing_cli_exclude,omitempty"`
+	SensingLogin        []string       `json:"sensing_login,omitempty"`
+	SensingTTL          *int           `json:"sensing_ttl,omitempty"`
+	SensingPullback     *int           `json:"sensing_pullback,omitempty"`
+	ExemptLabels        []string       `json:"exempt_labels,omitempty"`
+	NtfyServer          string         `json:"ntfy_server,omitempty"`
+	NtfyTopic           string         `json:"ntfy_topic,omitempty"`
+	DiscordWebhook      string         `json:"discord_webhook,omitempty"`
+	HealthcheckInterval *int           `json:"healthcheck_interval,omitempty"`
+	RestartCooldown     *int           `json:"restart_cooldown,omitempty"`
+	ModelLock           *bool          `json:"model_lock,omitempty"`
+	LogMaxSizeMB        *int           `json:"log_max_size_mb,omitempty"`
+	LogMaxAgeDays       *int           `json:"log_max_age_days,omitempty"`
+	LogMaxBackups       *int           `json:"log_max_backups,omitempty"`
+	LogCompress         *bool          `json:"log_compress,omitempty"`
+	LogLevel            string         `json:"log_level,omitempty"`
 }
 
 type AgentState struct {


### PR DESCRIPTION
## Summary
- Dashboard config dialog changes (repos, thresholds, sensing, labels, notifications, health, logging) were lost on container restart because `persistState()` only saved runtime state
- Added `ConfigOverrides` struct to `PersistedState` that captures all config fields modifiable via dashboard dialogs
- On save, `buildConfigOverrides()` snapshots the current config; on startup, `applyConfigOverrides()` merges saved overrides on top of the base YAML config
- Follows the same overlay pattern as agent configs — YAML is the base, dashboard mutations take precedence

## Test plan
- [ ] Start hive, add repos via governor config dialog
- [ ] Verify `/data/hive-state.json` contains the `config_overrides` field with the repos
- [ ] Restart the container
- [ ] Verify repos are still present in dashboard
- [ ] Repeat for thresholds, sensing, labels, notifications, health, logging
- [ ] `go test ./pkg/snapshot/ ./pkg/config/` — passes