### PR TITLE
feat: resizable sidebar + fix mode emoji visibility

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -51,11 +51,20 @@
     body.light-mode .gh-rate-alert { border-radius: 8px; }
 
     /* Light sidebar */
+    :root { --sidebar-w: 232px; }
     .oc-sidebar {
-      position: fixed; top: 0; left: 0; bottom: 0; width: 232px;
+      position: fixed; top: 0; left: 0; bottom: 0; width: var(--sidebar-w);
       background: #ffffff; border-right: 1px solid #e9ecef;
       display: flex; flex-direction: column; padding: 0;
       z-index: 100; overflow-y: auto;
+    }
+    .oc-sidebar-resize {
+      position: fixed; top: 0; bottom: 0; width: 5px;
+      left: calc(var(--sidebar-w) - 2px);
+      cursor: col-resize; z-index: 101;
+    }
+    .oc-sidebar-resize:hover, .oc-sidebar-resize.dragging {
+      background: rgba(220,38,38,0.25);
     }
     .oc-sidebar-logo {
       display: flex; align-items: center; gap: 10px;
@@ -75,12 +84,15 @@
       content: ''; flex: 1; height: 1px; background: #e5e7eb;
     }
     .oc-nav-item {
-      display: flex; align-items: center; gap: 10px;
-      padding: 10px 20px; font-size: 0.88rem; color: #4b5563;
+      display: flex; align-items: center; gap: 6px;
+      padding: 10px 12px; font-size: 0.88rem; color: #4b5563;
       cursor: pointer; text-decoration: none; border-radius: 8px;
       transition: background 0.15s, color 0.15s;
-      margin: 2px 10px;
+      margin: 2px 10px; overflow: hidden;
     }
+    .oc-nav-emoji { display: inline-flex; width: 20px; font-size: 1rem; flex-shrink: 0; justify-content: center; }
+    .oc-nav-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0; }
+    .oc-nav-mode { flex-shrink: 0; font-size: 0.9rem; margin-left: 2px; }
     .oc-nav-item:hover { background: #f5f5f7; color: #374151; }
     .oc-nav-item.active {
       background: #fef2f2; color: #dc2626; font-weight: 600;
@@ -99,7 +111,7 @@
 
     /* Light top bar */
     .oc-topbar {
-      position: fixed; top: 0; left: 232px; right: 0; height: 48px;
+      position: fixed; top: 0; left: var(--sidebar-w); right: 0; height: 48px;
       background: #ffffff; border-bottom: 1px solid #e5e7eb;
       display: flex; align-items: center; justify-content: space-between;
       padding: 0 20px; z-index: 99;
@@ -127,7 +139,7 @@
 
     /* Light main content area */
     body.light-mode {
-      padding: 64px 20px 24px 252px; margin: 0;
+      padding: 64px 20px 24px calc(var(--sidebar-w) + 20px); margin: 0;
       max-width: 100vw; overflow-x: hidden; box-sizing: border-box;
     }
     body.light-mode > .gh-rate-alert { margin-left: 0; }
@@ -1332,6 +1344,7 @@
   <div class="gh-rate-alert" id="gh-rate-alert"></div>
 
   <!-- Light sidebar (hidden by default) -->
+  <div class="oc-sidebar-resize" id="ocSidebarResize"></div>
   <nav id="oc-sidebar" class="oc-sidebar" style="display:none">
     <div class="oc-sidebar-logo">
       <span class="oc-logo-icon">🐝</span>
@@ -1829,7 +1842,9 @@
       const isActive = _ocSelectedAgent === a.name ? ' active' : '';
       const agentDesc = AGENT_DESCRIPTIONS[a.name] || '';
       const label = a.displayName || a.name;
-      return `<a class="oc-nav-item${isActive}" data-agent-nav="${a.name}" draggable="true" onclick="ocSelectAgent('${a.name}')" title="${agentDesc}"><span class="oc-agent-dot ${dotCls}"></span> ${label}</a>`;
+      const emojiHtml = a.emoji ? `<span class="oc-nav-emoji">${a.emoji}</span>` : '';
+      const modeHtml = a.modeEmoji ? `<span class="oc-nav-mode" title="${esc(a.mode || '')}">${a.modeEmoji}</span>` : '';
+      return `<a class="oc-nav-item${isActive}" data-agent-nav="${a.name}" draggable="true" onclick="ocSelectAgent('${a.name}')" title="${agentDesc}"><span class="oc-agent-dot ${dotCls}"></span>${emojiHtml}<span class="oc-nav-text">${esc(label)}</span>${modeHtml}</a>`;
     }
 
     const DEFAULT_SIDEBAR_ORDER = ['supervisor', 'sec-check', 'scanner', 'ci-maintainer', 'architect', 'quality', 'outreach'];
@@ -5108,6 +5123,42 @@ function burnAreaChart() {
       handle.addEventListener('pointerup', () => {
         if (startH) localStorage.setItem(CHAT_HEIGHT_KEY, chatPanel.offsetHeight);
         startH = 0;
+      });
+    })();
+
+    // Sidebar resize handle — drag right edge to resize sidebar width
+    (function initSidebarResize() {
+      const SIDEBAR_WIDTH_KEY = 'hive-sidebar-width';
+      const SIDEBAR_MIN_W = 180;
+      const SIDEBAR_MAX_W = 400;
+      const SIDEBAR_DEFAULT_W = 232;
+      const saved = parseInt(localStorage.getItem(SIDEBAR_WIDTH_KEY), 10);
+      if (saved >= SIDEBAR_MIN_W && saved <= SIDEBAR_MAX_W) {
+        document.documentElement.style.setProperty('--sidebar-w', saved + 'px');
+      }
+      const handle = document.getElementById('ocSidebarResize');
+      if (!handle) return;
+      let startX = 0, startW = 0;
+      handle.addEventListener('pointerdown', (e) => {
+        startX = e.clientX;
+        const cur = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--sidebar-w'), 10) || SIDEBAR_DEFAULT_W;
+        startW = cur;
+        handle.setPointerCapture(e.pointerId);
+        handle.classList.add('dragging');
+        e.preventDefault();
+      });
+      handle.addEventListener('pointermove', (e) => {
+        if (!startW) return;
+        const newW = Math.max(SIDEBAR_MIN_W, Math.min(SIDEBAR_MAX_W, startW + (e.clientX - startX)));
+        document.documentElement.style.setProperty('--sidebar-w', newW + 'px');
+      });
+      handle.addEventListener('pointerup', () => {
+        if (startW) {
+          const cur = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--sidebar-w'), 10) || SIDEBAR_DEFAULT_W;
+          localStorage.setItem(SIDEBAR_WIDTH_KEY, cur);
+        }
+        startW = 0;
+        handle.classList.remove('dragging');
       });
     })();
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -51,11 +51,20 @@
     body.light-mode .gh-rate-alert { border-radius: 8px; }
 
     /* Light sidebar */
+    :root { --sidebar-w: 232px; }
     .oc-sidebar {
-      position: fixed; top: 0; left: 0; bottom: 0; width: 232px;
+      position: fixed; top: 0; left: 0; bottom: 0; width: var(--sidebar-w);
       background: #ffffff; border-right: 1px solid #e9ecef;
       display: flex; flex-direction: column; padding: 0;
       z-index: 100; overflow-y: auto;
+    }
+    .oc-sidebar-resize {
+      position: fixed; top: 0; bottom: 0; width: 5px;
+      left: calc(var(--sidebar-w) - 2px);
+      cursor: col-resize; z-index: 101;
+    }
+    .oc-sidebar-resize:hover, .oc-sidebar-resize.dragging {
+      background: rgba(220,38,38,0.25);
     }
     .oc-sidebar-logo {
       display: flex; align-items: center; gap: 10px;
@@ -84,6 +93,7 @@
     }
     .oc-nav-emoji { display: inline-flex; width: 18px; font-size: 0.9rem; flex-shrink: 0; justify-content: center; }
     .oc-nav-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0; }
+    .oc-nav-mode { flex-shrink: 0; font-size: 0.9rem; margin-left: 2px; }
     .oc-nav-item:hover { background: #f5f5f7; color: #374151; }
     .oc-nav-item .oc-nav-actions {
       display: none; position: absolute; right: 4px; top: 50%;
@@ -115,7 +125,7 @@
 
     /* Light top bar */
     .oc-topbar {
-      position: fixed; top: 0; left: 232px; right: 0; height: 48px;
+      position: fixed; top: 0; left: var(--sidebar-w); right: 0; height: 48px;
       background: #ffffff; border-bottom: 1px solid #e5e7eb;
       display: flex; align-items: center; justify-content: space-between;
       padding: 0 20px; z-index: 99;
@@ -143,7 +153,7 @@
 
     /* Light main content area */
     body.light-mode {
-      padding: 64px 20px 24px 252px; margin: 0;
+      padding: 64px 20px 24px calc(var(--sidebar-w) + 20px); margin: 0;
       max-width: 100vw; overflow-x: hidden; box-sizing: border-box;
     }
     body.light-mode > .gh-rate-alert { margin-left: 0; }
@@ -1564,6 +1574,7 @@
   <div class="gh-rate-alert" id="gh-rate-alert"></div>
 
   <!-- Light sidebar (hidden by default) -->
+  <div class="oc-sidebar-resize" id="ocSidebarResize"></div>
   <nav id="oc-sidebar" class="oc-sidebar" style="display:none">
     <div class="oc-sidebar-logo">
       <span class="oc-logo-icon">🐝</span>
@@ -2205,9 +2216,9 @@
       const isActive = _ocSelectedAgent === a.name ? ' active' : '';
       const agentDesc = a.description || AGENT_DESCRIPTIONS[a.name] || '';
       const label = a.displayName || a.name;
-      const emojiPrefix = a.emoji ? a.emoji + ' ' : '';
-      const modeBadge = a.mode ? ` <span class="mode-badge" title="${esc(a.mode)}">${modeEmoji(a.mode)}</span>` : '';
-      return `<a class="oc-nav-item${isActive}" data-agent-nav="${esc(a.name)}" draggable="true" data-action="ocSelectAgent" data-agent="${esc(a.name)}" title="${esc(agentDesc)}"><span class="oc-agent-dot ${dotCls}"></span>${emojiPrefix ? `<span class="oc-nav-emoji">${emojiPrefix.trim()}</span>` : ''}<span class="oc-nav-text">${esc(label)}${modeBadge}</span><span class="oc-nav-actions"><button data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure">⚙</button><button class="oc-nav-delete" data-action="deleteAgentFromConfig" data-agent="${esc(a.name)}" title="Delete">✕</button></span></a>`;
+      const emojiHtml = a.emoji ? `<span class="oc-nav-emoji">${a.emoji}</span>` : '';
+      const modeHtml = (a.modeEmoji || a.mode) ? `<span class="oc-nav-mode" title="${esc(a.mode || '')}">${a.modeEmoji || modeEmoji(a.mode)}</span>` : '';
+      return `<a class="oc-nav-item${isActive}" data-agent-nav="${esc(a.name)}" draggable="true" data-action="ocSelectAgent" data-agent="${esc(a.name)}" title="${esc(agentDesc)}"><span class="oc-agent-dot ${dotCls}"></span>${emojiHtml}<span class="oc-nav-text">${esc(label)}</span>${modeHtml}<span class="oc-nav-actions"><button data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" title="Configure">⚙</button><button class="oc-nav-delete" data-action="deleteAgentFromConfig" data-agent="${esc(a.name)}" title="Delete">✕</button></span></a>`;
     }
 
     function _sidebarBuildGroups(agents) {
@@ -7734,6 +7745,42 @@ function burnAreaChart() {
       handle.addEventListener('pointerup', () => {
         if (startH) localStorage.setItem(CHAT_HEIGHT_KEY, chatPanel.offsetHeight);
         startH = 0;
+      });
+    })();
+
+    // Sidebar resize handle — drag right edge to resize sidebar width
+    (function initSidebarResize() {
+      const SIDEBAR_WIDTH_KEY = 'hive-sidebar-width';
+      const SIDEBAR_MIN_W = 180;
+      const SIDEBAR_MAX_W = 400;
+      const SIDEBAR_DEFAULT_W = 232;
+      const saved = parseInt(localStorage.getItem(SIDEBAR_WIDTH_KEY), 10);
+      if (saved >= SIDEBAR_MIN_W && saved <= SIDEBAR_MAX_W) {
+        document.documentElement.style.setProperty('--sidebar-w', saved + 'px');
+      }
+      const handle = document.getElementById('ocSidebarResize');
+      if (!handle) return;
+      let startX = 0, startW = 0;
+      handle.addEventListener('pointerdown', (e) => {
+        startX = e.clientX;
+        const cur = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--sidebar-w'), 10) || SIDEBAR_DEFAULT_W;
+        startW = cur;
+        handle.setPointerCapture(e.pointerId);
+        handle.classList.add('dragging');
+        e.preventDefault();
+      });
+      handle.addEventListener('pointermove', (e) => {
+        if (!startW) return;
+        const newW = Math.max(SIDEBAR_MIN_W, Math.min(SIDEBAR_MAX_W, startW + (e.clientX - startX)));
+        document.documentElement.style.setProperty('--sidebar-w', newW + 'px');
+      });
+      handle.addEventListener('pointerup', () => {
+        if (startW) {
+          const cur = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--sidebar-w'), 10) || SIDEBAR_DEFAULT_W;
+          localStorage.setItem(SIDEBAR_WIDTH_KEY, cur);
+        }
+        startW = 0;
+        handle.classList.remove('dragging');
       });
     })();
 


### PR DESCRIPTION
## Summary
- **Resizable sidebar**: drag the right edge to resize between 180–400px, persisted to localStorage
- **Mode emoji fix**: mode emoji is now a separate `flex-shrink:0` element outside the truncatable name text — fixes ci-maintainer and other long-named agents having their mode emoji clipped

Applied to both `dashboard/index.html` (Docker deploy) and `v2/pkg/dashboard/static/index.html` (embedded Go binary).

## Test plan
- [ ] Drag sidebar right edge — width resizes smoothly between 180–400px
- [ ] Refresh page — sidebar width persists
- [ ] ci-maintainer mode emoji visible even with long agent name
- [ ] All agent emojis and mode badges render correctly
- [ ] Mobile breakpoint (<768px) still hides sidebar