### PR TITLE
fix: config tooltip inherits uppercase from label

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1145,7 +1145,7 @@
       transform: translateX(-50%); background: var(--bg); border: 1px solid var(--border);
       border-radius: 6px; padding: 6px 10px;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-      font-size: 0.8125rem; font-weight: 400;
+      font-size: 0.7rem; font-weight: 400; text-transform: none; letter-spacing: normal;
       color: var(--text); white-space: normal; width: 240px; z-index: 10001;
       box-shadow: 0 4px 12px rgba(0,0,0,0.4); line-height: 1.4;
     }


### PR DESCRIPTION
## Summary
- Tooltips inside config dialog labels were inheriting `text-transform: uppercase` and `letter-spacing: 0.5px` from the parent label, making them appear large and shouty
- Reset both properties on `.config-tooltip` and reduced font-size from 0.8125rem to 0.7rem

## Test plan
- [ ] Hover over any info icon in config dialog → tooltip text is normal case, readable size