### PR TITLE
fix: add 120s timeout to snapshot service

### DIFF
--- a/systemd/hive-snapshot.service
+++ b/systemd/hive-snapshot.service
@@ -10,5 +10,6 @@ Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 Environment=HIVE_DASHBOARD_URL=http://localhost:3001
 Environment=DOCS_REPO_DIR=/tmp/kubestellar-docs-snapshot
 ExecStart=/tmp/hive/dashboard/publish-snapshot.sh
+TimeoutStartSec=120
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
## Summary
- Adds `TimeoutStartSec=120` to `hive-snapshot.service` systemd unit
- Prevents snapshot publisher from hanging indefinitely when Watchtower recreates the container mid-exec

## Root cause
When Watchtower pulls a new image and recreates the hive container, any in-flight `docker exec` loses its namespace and hangs with an OCI runtime error. The systemd oneshot service has no timeout by default, so it blocks the timer from firing new runs. The 21:15 UTC run on 4.85 hung for 3.5 hours, blocking all snapshot updates.

## Fix
`TimeoutStartSec=120` tells systemd to kill the process after 2 minutes. The script normally completes in 10-30 seconds. The next 5-minute timer cycle retries cleanly against the new container.

Also applied `timeout 120` to the live wrapper script on 4.85.