### PR TITLE
fix: proxy structured logging and repo URL normalization

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -583,7 +583,7 @@ func main() {
 		}
 	}
 
-	githubProxy, err := proxy.NewGitHubProxy()
+	githubProxy, err := proxy.NewGitHubProxy(logger)
 	if err != nil {
 		logger.Error("failed to create github proxy", "error", err)
 	} else {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -7430,9 +7430,13 @@ function burnAreaChart() {
       markDirty('restrictions', 'rules', _configState.data.restrictions.agent);
     }
 
+    function normalizeRepoInput(raw) {
+      return raw.replace(/^https?:\/\/github\.com\//, '').replace(/\/+$/, '');
+    }
+
     function addListItem(section, key, inputId) {
       const input = document.getElementById(inputId);
-      const val = input.value.trim();
+      let val = input.value.trim();
       if (!val) return;
       if (section === 'hooks') {
         if (!_configState.data.hooks) _configState.data.hooks = {};
@@ -7444,6 +7448,7 @@ function burnAreaChart() {
         _configState.data.labels.push(val);
         markDirty('labels', 'labels', _configState.data.labels);
       } else if (section === 'repos') {
+        val = normalizeRepoInput(val);
         if (!_configState.data.repos) _configState.data.repos = [];
         _configState.data.repos.push(val);
         markDirty('repos', 'repos', _configState.data.repos);

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1141,13 +1141,13 @@
     }
     .config-info:hover { background: var(--blue); color: #fff; }
     .config-info .config-tooltip {
-      display: none; position: absolute; top: calc(100% + 6px); left: 50%;
-      transform: translateX(-50%); background: var(--bg); border: 1px solid var(--border);
+      display: none; position: fixed; background: var(--bg); border: 1px solid var(--border);
       border-radius: 6px; padding: 6px 10px;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
       font-size: 0.7rem; font-weight: 400; text-transform: none; letter-spacing: normal;
       color: var(--text); white-space: normal; width: 240px; z-index: 10001;
       box-shadow: 0 4px 12px rgba(0,0,0,0.4); line-height: 1.4;
+      pointer-events: none;
     }
     .config-info:hover .config-tooltip { display: block; }
 
@@ -5854,6 +5854,21 @@ function burnAreaChart() {
         .replace(/\r\n/g, '\n')
         .replace(/\r/g, '');
     }
+
+    document.addEventListener('mouseover', (e) => {
+      const info = e.target.closest('.config-info');
+      if (!info) return;
+      const tip = info.querySelector('.config-tooltip');
+      if (!tip) return;
+      const rect = info.getBoundingClientRect();
+      const tipW = 240;
+      let left = rect.left + rect.width / 2 - tipW / 2;
+      const EDGE_PAD = 8;
+      if (left < EDGE_PAD) left = EDGE_PAD;
+      if (left + tipW > window.innerWidth - EDGE_PAD) left = window.innerWidth - EDGE_PAD - tipW;
+      tip.style.top = (rect.bottom + 6) + 'px';
+      tip.style.left = left + 'px';
+    });
 
     // ── Event delegation for actions with user-controlled data ──
     // Eliminates XSS via inline onclick="func('${unsafeValue}')" injection.

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -11,7 +11,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"math/big"
 	"net"
 	"net/http"
@@ -36,13 +36,14 @@ type GitHubProxy struct {
 	listenAddr string
 	caCert     tls.Certificate
 	caX509     *x509.Certificate
+	logger     *slog.Logger
 
 	mu         sync.RWMutex
 	violations map[string]int // agent name -> blocked request count
 }
 
 // NewGitHubProxy creates a proxy with a self-signed CA for MITM.
-func NewGitHubProxy() (*GitHubProxy, error) {
+func NewGitHubProxy(logger *slog.Logger) (*GitHubProxy, error) {
 	caCert, caX509, err := generateCA()
 	if err != nil {
 		return nil, fmt.Errorf("generate CA: %w", err)
@@ -57,6 +58,7 @@ func NewGitHubProxy() (*GitHubProxy, error) {
 		listenAddr: fmt.Sprintf("127.0.0.1:%d", proxyListenPort),
 		caCert:     caCert,
 		caX509:     caX509,
+		logger:     logger,
 		violations: make(map[string]int),
 	}, nil
 }
@@ -88,7 +90,7 @@ func (p *GitHubProxy) Start() error {
 	if err != nil {
 		return fmt.Errorf("listen %s: %w", p.listenAddr, err)
 	}
-	log.Printf("[proxy] listening on %s", p.listenAddr)
+	p.logger.Info("proxy listening", "addr", p.listenAddr)
 
 	srv := &http.Server{
 		Handler:      p,
@@ -142,7 +144,7 @@ func (p *GitHubProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 
 	clientConn, _, err := hijacker.Hijack()
 	if err != nil {
-		log.Printf("[proxy] hijack error: %v", err)
+		p.logger.Error("proxy hijack error", "error", err)
 		return
 	}
 	defer clientConn.Close()
@@ -150,7 +152,7 @@ func (p *GitHubProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	// Generate a cert for the target host signed by our CA.
 	tlsCert, err := p.forgeCert(host)
 	if err != nil {
-		log.Printf("[proxy] forge cert for %s: %v", host, err)
+		p.logger.Error("proxy forge cert failed", "host", host, "error", err)
 		return
 	}
 
@@ -160,7 +162,7 @@ func (p *GitHubProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	}
 	tlsClientConn := tls.Server(clientConn, tlsConfig)
 	if err := tlsClientConn.Handshake(); err != nil {
-		log.Printf("[proxy] client TLS handshake: %v", err)
+		p.logger.Warn("proxy client TLS handshake failed", "error", err)
 		return
 	}
 	defer tlsClientConn.Close()
@@ -170,7 +172,7 @@ func (p *GitHubProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		ServerName: host,
 	})
 	if err != nil {
-		log.Printf("[proxy] upstream dial %s: %v", r.Host, err)
+		p.logger.Error("proxy upstream dial failed", "host", r.Host, "error", err)
 		return
 	}
 	defer upstreamConn.Close()
@@ -231,7 +233,7 @@ func (p *GitHubProxy) proxyHTTP(client net.Conn, upstream net.Conn, agentName st
 }
 
 func (p *GitHubProxy) recordViolation(agentName, method, path string) {
-	log.Printf("[proxy] ⛔ BLOCKED: %s → %s %s", agentName, method, path)
+	p.logger.Warn("proxy request blocked", "agent", agentName, "method", method, "path", path)
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if len(p.violations) < maxViolationLog {


### PR DESCRIPTION
## Summary
- Wire proxy log calls through `slog.Logger` instead of stdlib `log.Printf` so they are captured by lumberjack rotating log files
- Normalize repo config input to strip `https://github.com/` prefix, accepting both `org/repo` and full GitHub URLs

## Changes
- `github_proxy.go`: Replace 6 `log.Printf` calls with structured `slog.Logger` methods (Info/Warn/Error with key-value pairs)
- `main.go`: Pass `logger` to `NewGitHubProxy()` constructor
- `index.html`: Add `normalizeRepoInput()` function that strips GitHub URL prefix before storing repo entries

## Test plan
- [ ] Proxy block events appear in lumberjack log files (not just stdout)
- [ ] Enter `https://github.com/org/repo` in governor Repos config → stored as `org/repo`
- [ ] Enter `org/repo` directly → stored unchanged
- [ ] `go build ./cmd/hive/` compiles cleanly

Fixes #625