### PR TITLE
fix: agents identify themselves to proxy via userinfo URL

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1297,8 +1297,9 @@ func (m *Manager) agentEnvVars(agent *AgentProcess) []string {
 	vars = append(vars, shellEnvVar("HIVE_AGENT_MODE", mode.String()))
 	modeFile := fmt.Sprintf("/tmp/.hive-mode-%s", agent.Name)
 	_ = os.WriteFile(modeFile, []byte(mode.String()), 0o644)
-	vars = append(vars, shellEnvVar("HTTPS_PROXY", fmt.Sprintf("http://127.0.0.1:%d", proxyListenPort)))
-	vars = append(vars, shellEnvVar("HTTP_PROXY", fmt.Sprintf("http://127.0.0.1:%d", proxyListenPort)))
+	proxyURL := fmt.Sprintf("http://%s@127.0.0.1:%d", agent.Name, proxyListenPort)
+	vars = append(vars, shellEnvVar("HTTPS_PROXY", proxyURL))
+	vars = append(vars, shellEnvVar("HTTP_PROXY", proxyURL))
 	vars = append(vars, shellEnvVar("HIVE_PROXY_AGENT", agent.Name))
 	vars = append(vars, shellEnvVar("NODE_EXTRA_CA_CERTS", proxyCACertPath))
 	if sha := os.Getenv("HIVE_SHA"); sha != "" {

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -290,12 +291,25 @@ func (p *GitHubProxy) forwardPlain(w http.ResponseWriter, r *http.Request) {
 	io.Copy(w, resp.Body)
 }
 
-// extractAgentName reads the agent name from the Proxy-Authorization
-// header (format: "hive <agent-name>") or falls back to empty string.
+// extractAgentName reads the agent name from the Proxy-Authorization header.
+// Supports "hive <name>" (custom) and "Basic <b64>" (standard HTTP proxy auth
+// sent automatically when the proxy URL contains userinfo, e.g. http://quality@host:port).
 func extractAgentName(r *http.Request) string {
 	auth := r.Header.Get("Proxy-Authorization")
+	if auth == "" {
+		return ""
+	}
 	if strings.HasPrefix(auth, "hive ") {
 		return strings.TrimPrefix(auth, "hive ")
+	}
+	if strings.HasPrefix(auth, "Basic ") {
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(auth, "Basic "))
+		if err != nil {
+			return ""
+		}
+		// Format is "username:password" — agent name is the username portion.
+		user, _, _ := strings.Cut(string(decoded), ":")
+		return user
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary
- Encode agent name as userinfo in `HTTPS_PROXY`/`HTTP_PROXY` URLs (e.g. `http://quality@127.0.0.1:18443`)
- HTTP clients automatically send this as `Proxy-Authorization: Basic` on CONNECT requests
- Update `extractAgentName()` to decode Basic auth in addition to custom `hive <name>` format
- Unidentified agents (empty name) still default to ADVISORY as a safety fallback

## Problem
All agents were showing as `agent:""` in proxy logs because `gh` CLI and Copilot don't send custom `Proxy-Authorization: hive <name>` headers. The proxy couldn't look up the correct ACMM mode, so quality (ISSUES_AND_PRS) was being treated as ADVISORY and all its POST requests were blocked.

## Test plan
- [ ] `go build ./cmd/hive/` compiles
- [ ] After deploy, proxy logs show agent names instead of empty strings
- [ ] Quality agent's POST requests to issues/comments are allowed through
- [ ] ADVISORY agents' POST requests are still blocked
- [ ] Unknown/unidentified connections still default to ADVISORY (safety fallback preserved)