### PR TITLE
fix: supervisor ADVISORY at ACMM L3+, NO_GITHUB at L1-2

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1175,14 +1175,16 @@ func (m *Manager) agentMode(agent *AgentProcess) AgentMode {
 // DefaultAgentMode returns the default mode for a given agent name and ACMM level,
 // ignoring any hive.yaml override. Used by the dashboard to show "(default)" indicators.
 func DefaultAgentMode(agentName string, level int) AgentMode {
-	if agentName == "supervisor" {
-		return ModeNoGitHub
-	}
-
 	switch level {
 	case 1:
+		if agentName == "supervisor" {
+			return ModeNoGitHub
+		}
 		return ModeAdvisory
 	case 2:
+		if agentName == "supervisor" {
+			return ModeNoGitHub
+		}
 		return ModeAdvisory
 	case 3:
 		if agentName == "quality" {
@@ -1199,8 +1201,14 @@ func DefaultAgentMode(agentName string, level int) AgentMode {
 			return ModeAdvisory
 		}
 	case 5:
+		if agentName == "supervisor" {
+			return ModeAdvisory
+		}
 		return ModeIssuesAndPRs
 	case 6:
+		if agentName == "supervisor" {
+			return ModeAdvisory
+		}
 		if agentName == "scanner" {
 			return ModeIssuesPRsMerge
 		}

--- a/v2/pkg/agent/mode_test.go
+++ b/v2/pkg/agent/mode_test.go
@@ -153,23 +153,23 @@ func TestDefaultAgentMode(t *testing.T) {
 		{"quality", 2, ModeAdvisory},
 		{"guide", 2, ModeAdvisory},
 
-		// L3: quality ISSUES_AND_PRS, others advisory, supervisor NO_GITHUB
-		{"supervisor", 3, ModeNoGitHub},
+		// L3: quality ISSUES_AND_PRS, all others (including supervisor) advisory
+		{"supervisor", 3, ModeAdvisory},
 		{"scanner", 3, ModeAdvisory},
 		{"quality", 3, ModeIssuesAndPRs},
 		{"guide", 3, ModeAdvisory},
 		{"ci-maintainer", 3, ModeAdvisory},
 
 		// L4: quality/sec-check/ci-maintainer ISSUES_AND_PRS, scanner/guide ISSUES_ONLY
-		{"supervisor", 4, ModeNoGitHub},
+		{"supervisor", 4, ModeAdvisory},
 		{"scanner", 4, ModeIssuesOnly},
 		{"quality", 4, ModeIssuesAndPRs},
 		{"guide", 4, ModeIssuesOnly},
 		{"ci-maintainer", 4, ModeIssuesAndPRs},
 		{"sec-check", 4, ModeIssuesAndPRs},
 
-		// L5: all ISSUES_AND_PRS, supervisor NO_GITHUB
-		{"supervisor", 5, ModeNoGitHub},
+		// L5: all ISSUES_AND_PRS, supervisor advisory
+		{"supervisor", 5, ModeAdvisory},
 		{"scanner", 5, ModeIssuesAndPRs},
 		{"quality", 5, ModeIssuesAndPRs},
 		{"guide", 5, ModeIssuesAndPRs},
@@ -178,8 +178,8 @@ func TestDefaultAgentMode(t *testing.T) {
 		{"architect", 5, ModeIssuesAndPRs},
 		{"strategist", 5, ModeIssuesAndPRs},
 
-		// L6: scanner ISSUES_PRS_MERGE, others ISSUES_AND_PRS, supervisor NO_GITHUB
-		{"supervisor", 6, ModeNoGitHub},
+		// L6: scanner ISSUES_PRS_MERGE, others ISSUES_AND_PRS, supervisor advisory
+		{"supervisor", 6, ModeAdvisory},
 		{"scanner", 6, ModeIssuesPRsMerge},
 		{"quality", 6, ModeIssuesAndPRs},
 		{"guide", 6, ModeIssuesAndPRs},
@@ -189,9 +189,9 @@ func TestDefaultAgentMode(t *testing.T) {
 		{"strategist", 6, ModeIssuesAndPRs},
 		{"outreach", 6, ModeIssuesAndPRs},
 
-		// Supervisor is always NO_GITHUB regardless of level
+		// Supervisor: NO_GITHUB at L1-2, ADVISORY at L3+
 		{"supervisor", 1, ModeNoGitHub},
-		{"supervisor", 6, ModeNoGitHub},
+		{"supervisor", 6, ModeAdvisory},
 
 		// Unknown level defaults to advisory
 		{"scanner", 0, ModeAdvisory},


### PR DESCRIPTION
## Summary
- Supervisor was hardcoded to `NO_GITHUB` at all ACMM levels
- At L3+, this prevented the Copilot CLI from authenticating (it needs GitHub API access to start)
- Now: `NO_GITHUB` at L1-2, `ADVISORY` at L3+ (read-only GitHub access, no writes)

## Changes
- `manager.go`: Remove blanket `supervisor → NO_GITHUB` override; handle per-level instead
- `mode_test.go`: Update all supervisor test expectations

## Test plan
- [ ] `go test ./pkg/agent/...` passes
- [ ] Supervisor starts successfully at L3 without login prompt
- [ ] Supervisor can read GitHub (GET requests allowed) but cannot create issues/PRs (POST blocked)