### PR TITLE
feat: proxy GraphQL body inspection — queries vs mutations

### DIFF
--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -193,8 +193,38 @@ func (p *GitHubProxy) proxyHTTP(client net.Conn, upstream net.Conn, agentName st
 			return // client closed or error
 		}
 
-		if !AllowedByMode(mode, req.Method, req.URL.Path) {
-			p.recordViolation(agentName, req.Method, req.URL.Path)
+		blocked := false
+		blockReason := ""
+
+		if req.Method == "POST" && IsGraphQLPath(req.URL.Path) {
+			body, readErr := io.ReadAll(io.LimitReader(req.Body, graphQLBodyLimit))
+			if req.Body != nil {
+				req.Body.Close()
+			}
+			if readErr != nil {
+				return
+			}
+			allowed, isMutation := GraphQLAllowed(mode, body)
+			if !allowed {
+				blocked = true
+				if isMutation {
+					blockReason = "graphql mutation"
+				} else {
+					blockReason = "graphql"
+				}
+			}
+			req.Body = io.NopCloser(strings.NewReader(string(body)))
+			req.ContentLength = int64(len(body))
+		} else if !AllowedByMode(mode, req.Method, req.URL.Path) {
+			blocked = true
+		}
+
+		if blocked {
+			detail := req.URL.Path
+			if blockReason != "" {
+				detail = blockReason
+			}
+			p.recordViolation(agentName, req.Method, detail)
 
 			resp := &http.Response{
 				StatusCode: http.StatusForbidden,
@@ -202,7 +232,7 @@ func (p *GitHubProxy) proxyHTTP(client net.Conn, upstream net.Conn, agentName st
 				ProtoMajor: 1,
 				ProtoMinor: 1,
 				Header:     make(http.Header),
-				Body:       io.NopCloser(strings.NewReader(fmt.Sprintf("⛔ ACMM proxy: %s (%s) blocked %s %s\n", agentName, mode, req.Method, req.URL.Path))),
+				Body:       io.NopCloser(strings.NewReader(fmt.Sprintf("⛔ ACMM proxy: %s (%s) blocked %s %s\n", agentName, mode, req.Method, detail))),
 			}
 			resp.Header.Set("Content-Type", "text/plain")
 			resp.Header.Set("X-Hive-Proxy-Blocked", "true")

--- a/v2/pkg/proxy/rules.go
+++ b/v2/pkg/proxy/rules.go
@@ -1,7 +1,9 @@
 package proxy
 
 import (
+	"encoding/json"
 	"regexp"
+	"strings"
 
 	"github.com/kubestellar/hive/v2/pkg/agent"
 )
@@ -67,4 +69,38 @@ func AllowedByMode(mode agent.AgentMode, method, path string) bool {
 		}
 	}
 	return false
+}
+
+// IsGraphQLPath returns true if the path is the GitHub GraphQL endpoint.
+func IsGraphQLPath(path string) bool {
+	return path == "/graphql"
+}
+
+const graphQLBodyLimit = 64 * 1024
+
+type graphQLRequest struct {
+	Query string `json:"query"`
+}
+
+// GraphQLAllowed inspects a GraphQL request body and returns whether the
+// operation is allowed for the given mode. Queries (reads) are allowed at
+// ADVISORY and above. Mutations (writes) require ISSUES_ONLY and above.
+// Returns (allowed, isMutation). Body must be the raw JSON request body.
+func GraphQLAllowed(mode agent.AgentMode, body []byte) (bool, bool) {
+	if mode < agent.ModeAdvisory {
+		return false, false
+	}
+
+	var req graphQLRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return false, false
+	}
+
+	query := strings.TrimSpace(req.Query)
+	isMutation := strings.HasPrefix(query, "mutation")
+
+	if isMutation {
+		return mode >= agent.ModeIssuesOnly, true
+	}
+	return true, false
 }

--- a/v2/pkg/proxy/rules_test.go
+++ b/v2/pkg/proxy/rules_test.go
@@ -78,6 +78,37 @@ func TestAllowedByMode(t *testing.T) {
 	}
 }
 
+func TestGraphQLAllowed(t *testing.T) {
+	tests := []struct {
+		name       string
+		mode       agent.AgentMode
+		body       string
+		wantAllow  bool
+		wantMutate bool
+	}{
+		{"advisory allows query", agent.ModeAdvisory, `{"query":"query { repository(owner:\"org\",name:\"repo\") { issues { totalCount } } }"}`, true, false},
+		{"advisory blocks mutation", agent.ModeAdvisory, `{"query":"mutation { createIssue(input:{repositoryId:\"R_1\",title:\"test\"}) { issue { id } } }"}`, false, true},
+		{"issues-only allows mutation", agent.ModeIssuesOnly, `{"query":"mutation { createIssue(input:{repositoryId:\"R_1\",title:\"test\"}) { issue { id } } }"}`, true, true},
+		{"issues-and-prs allows mutation", agent.ModeIssuesAndPRs, `{"query":"mutation { createIssue(input:{}) { issue { id } } }"}`, true, true},
+		{"no-github blocks query", agent.ModeNoGitHub, `{"query":"query { viewer { login } }"}`, false, false},
+		{"no-github blocks mutation", agent.ModeNoGitHub, `{"query":"mutation { addStar(input:{}) { starrable { id } } }"}`, false, false},
+		{"advisory blocks malformed json", agent.ModeAdvisory, `not json`, false, false},
+		{"advisory allows empty query", agent.ModeAdvisory, `{"query":"{ viewer { login } }"}`, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			allowed, isMutation := GraphQLAllowed(tt.mode, []byte(tt.body))
+			if allowed != tt.wantAllow {
+				t.Errorf("GraphQLAllowed(%v) allowed = %v, want %v", tt.mode, allowed, tt.wantAllow)
+			}
+			if isMutation != tt.wantMutate {
+				t.Errorf("GraphQLAllowed(%v) isMutation = %v, want %v", tt.mode, isMutation, tt.wantMutate)
+			}
+		})
+	}
+}
+
 func TestIsGitHubHost(t *testing.T) {
 	tests := []struct {
 		host string


### PR DESCRIPTION
## Summary
- Proxy now inspects `POST /graphql` request bodies to distinguish queries from mutations
- GraphQL **queries** (reads) are allowed at ADVISORY and above
- GraphQL **mutations** (writes) require ISSUES_ONLY or higher
- Prevents advisory agents from bypassing REST API rules via raw GraphQL mutations

## Problem
`gh` CLI uses `POST /graphql` for all operations including reads (`gh run list`, `gh issue list`). Previously the proxy blocked all `POST /graphql` since it wasn't in the rules table, which meant advisory agents couldn't use `gh` CLI at all. Simply allowing all `POST /graphql` at ADVISORY would let agents craft GraphQL mutations to create issues/PRs, bypassing the REST rules.

## Changes
- `rules.go`: Add `GraphQLAllowed()` function that parses JSON body, checks if query starts with `mutation`
- `github_proxy.go`: In `proxyHTTP()`, intercept `POST /graphql`, read body, call `GraphQLAllowed()`, reconstruct body for forwarding if allowed
- `rules_test.go`: 8 test cases covering query/mutation at each mode level

## Test plan
- [ ] `go test ./pkg/proxy/...` passes
- [ ] Advisory agents can run `gh run list`, `gh issue list` (GraphQL queries)
- [ ] Advisory agents are blocked from `gh api graphql -f query='mutation {...}'`
- [ ] ISSUES_ONLY+ agents can run GraphQL mutations
- [ ] NO_GITHUB agents are blocked from all GraphQL