### PR TITLE
fix: sync GitHub client repos after config overrides are restored

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -354,7 +354,12 @@ func main() {
 		}
 		if saved.ConfigOverrides != nil {
 			applyConfigOverrides(cfg, saved.ConfigOverrides)
-			logger.Info("config overrides restored from persisted state")
+			ghClient.SetRepos(cfg.Project.Repos)
+			if uc := userGHClient.Load(); uc != nil {
+				uc.SetRepos(cfg.Project.Repos)
+			}
+			logger.Info("config overrides restored from persisted state",
+				"repos", cfg.Project.Repos)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Repos added via the dashboard config dialog are persisted in `hive-state.json` and restored by `applyConfigOverrides()`, but the GitHub client was already initialized with only the YAML repos
- This meant dynamically-added repos (e.g. `testing-lab`) appeared in the dashboard but showed 0 issues / 0 PRs because the GitHub client never fetched them
- Calls `SetRepos()` on both the app client and user client after config overrides are applied

## Test plan

- [ ] Add a repo via dashboard config dialog, restart hive → repo shows correct issue/PR counts
- [ ] Verify `go build ./cmd/hive/` passes