### PR TITLE
fix: deduplicate summary output and gate Nous sidebar by ACMM level

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -650,6 +650,19 @@ func (m *Manager) pollTmuxOutput(name, session string, buf *RingBuffer, ctx cont
 			if len(filtered) == 0 {
 				continue
 			}
+			if prevLines == nil {
+				// First capture after (re)start — seed prevLines so subsequent
+				// diffs work. Only write to the buffer if it's empty (fresh
+				// start); skip if it already has content (restart) to avoid
+				// duplicating the scrollback.
+				if buf.Count() == 0 {
+					for _, l := range filtered {
+						buf.Write(l)
+					}
+				}
+				prevLines = filtered
+				continue
+			}
 			newLines := diffNewLines(prevLines, filtered)
 			for _, l := range newLines {
 				buf.Write(l)

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3888,13 +3888,15 @@ function burnAreaChart() {
         badge.style.color = 'white';
       }
 
-      // Update sidebar config
+      // Update sidebar config — only show at ACMM L4+
+      const NOUS_SIDEBAR_MIN_LEVEL = 4;
+      const currentACMM = window._lastStatus ? (window._lastStatus.acmmLevel || 0) : 0;
       const sbConfig = document.getElementById('nous-sidebar-config');
       const sbScope = document.getElementById('nous-sb-scope');
       const sbMode = document.getElementById('nous-sb-mode');
       const sbPhase = document.getElementById('nous-sb-phase');
       if (sbConfig) {
-        sbConfig.style.display = '';
+        sbConfig.style.display = currentACMM >= NOUS_SIDEBAR_MIN_LEVEL ? '' : 'none';
         if (sbScope) sbScope.textContent = scope;
         if (sbMode) { sbMode.textContent = mode; sbMode.style.color = modeColors[mode] || 'var(--muted)'; }
         if (sbPhase) {
@@ -6567,6 +6569,8 @@ function burnAreaChart() {
         level >= ACMM_BEADS_MIN_LEVEL ? show(beadsSection, '') : hide(beadsSection);
         level >= ACMM_REPOS_MIN_LEVEL ? show(reposSection, '') : hide(reposSection);
         level >= ACMM_NOUS_MIN_LEVEL ? show(nousSection, '') : hide(nousSection);
+        const nousSidebarCfg = document.getElementById('nous-sidebar-config');
+        level >= ACMM_NOUS_MIN_LEVEL ? show(nousSidebarCfg, '') : hide(nousSidebarCfg);
         level >= ACMM_DEBUG_MIN_LEVEL ? show(debugSection, '') : hide(debugSection);
         level >= ACMM_LOGS_MIN_LEVEL ? show(logsSection, '') : hide(logsSection);
 

--- a/v2/policies/ci-maintainer-advisory.md
+++ b/v2/policies/ci-maintainer-advisory.md
@@ -41,8 +41,13 @@ Finding types: `ci-failure`, `flaky-test`, `slow-build`, `coverage-drop`, `depen
 1. Read the kick message
 2. **Reap stale findings** — re-verify your open beads and close any that are no longer valid:
    ```bash
-   bd list --status=open --actor=ci-maintainer --json
+   bd list --status=open --actor=ci-maintainer --json 2>/dev/null
    ```
+   **IMPORTANT: Do NOT print or display the full bead table.** The table output floods the dashboard activity log with repetitive content every cycle. Instead:
+   - Read the JSON output silently
+   - Only mention beads you are actually closing or that need attention
+   - At the end, print a single summary line: `Reap: <N> open, <M> closed this cycle`
+
    For each open bead:
    - Check the `external_ref` (workflow name or run ID) — is the CI issue still occurring?
    - Re-run or check recent runs for that workflow to see if the problem resolved itself
@@ -53,4 +58,4 @@ Finding types: `ci-failure`, `flaky-test`, `slow-build`, `coverage-drop`, `depen
 3. Check recent CI runs: `gh run list --repo "$HIVE_REPO" --limit 20`
 4. Identify failures, patterns, and trends
 5. Create a bead for each finding with `bd create`
-6. Summarize CI health (new findings and reaped stale ones) in your response
+6. Summarize CI health (new findings and reaped stale ones) — keep it concise, no raw tables

--- a/v2/policies/guide-advisory.md
+++ b/v2/policies/guide-advisory.md
@@ -45,8 +45,13 @@ Finding types: `docs`, `onboarding`, `architecture`, `api`, `contributing`
 2. Clone or navigate to the target repo
 3. **Reap stale findings** — re-verify your open beads and close any that are no longer valid:
    ```bash
-   bd list --status=open --actor=guide --json
+   bd list --status=open --actor=guide --json 2>/dev/null
    ```
+   **IMPORTANT: Do NOT print or display the full bead table.** The table output floods the dashboard activity log with repetitive content every cycle. Instead:
+   - Read the JSON output silently
+   - Only mention beads you are actually closing or that need attention
+   - At the end, print a single summary line: `Reap: <N> open, <M> closed this cycle`
+
    For each open bead:
    - Check the `external_ref` path — does the file/section now exist with adequate content?
    - If the documentation gap has been resolved, close the bead:

--- a/v2/policies/quality-advisory.md
+++ b/v2/policies/quality-advisory.md
@@ -41,8 +41,13 @@ Finding types: `coverage-gap`, `missing-fixture`, `regression-risk`, `test-quali
 1. Read the kick message
 2. **Reap stale findings** — re-verify your open beads and close any that are no longer valid:
    ```bash
-   bd list --status=open --actor=quality --json
+   bd list --status=open --actor=quality --json 2>/dev/null
    ```
+   **IMPORTANT: Do NOT print or display the full bead table.** The table output floods the dashboard activity log with repetitive content every cycle. Instead:
+   - Read the JSON output silently
+   - Only mention beads you are actually closing or that need attention
+   - At the end, print a single summary line: `Reap: <N> open, <M> closed this cycle`
+
    For each open bead:
    - Check the `external_ref` (file path) — has test coverage been added for this gap?
    - If the coverage gap has been addressed, close the bead:
@@ -52,4 +57,4 @@ Finding types: `coverage-gap`, `missing-fixture`, `regression-risk`, `test-quali
 3. Analyze test coverage: `go test -coverprofile=coverage.out ./...` or equivalent
 4. Identify the top coverage gaps by impact
 5. Create a bead for each finding with `bd create`
-6. Summarize what you found (new findings and reaped stale ones) in your response
+6. Summarize what you found (new findings and reaped stale ones) — keep it concise, no raw tables

--- a/v2/policies/scanner-advisory.md
+++ b/v2/policies/scanner-advisory.md
@@ -39,8 +39,13 @@ Finding types: `bug`, `security`, `architecture`, `performance`, `docs`
 1. Read the kick message work list
 2. **Reap stale findings** — re-verify your open beads and close any that are no longer valid:
    ```bash
-   bd list --status=open --actor=scanner --json
+   bd list --status=open --actor=scanner --json 2>/dev/null
    ```
+   **IMPORTANT: Do NOT print or display the full bead table.** The table output floods the dashboard activity log with repetitive content every cycle. Instead:
+   - Read the JSON output silently
+   - Only mention beads you are actually closing or that need attention
+   - At the end, print a single summary line: `Reap: <N> open, <M> closed this cycle`
+
    For each open bead:
    - Check the `external_ref` (issue number) — has the issue been closed or the bug fixed?
    - If the finding no longer applies, close the bead:
@@ -51,4 +56,4 @@ Finding types: `bug`, `security`, `architecture`, `performance`, `docs`
 3. For each issue, analyze the codebase to understand root cause and complexity
 4. Create a bead for each finding with `bd create`
 5. You may create local worktrees with proposed fixes for analysis, but DO NOT push
-6. Summarize your findings (new and reaped) in your response
+6. Summarize your findings (new and reaped) in your response — keep it concise, no raw tables


### PR DESCRIPTION
## Summary

- **Ring buffer dedup**: Each agent restart spawns a new tmux poller goroutine that re-dumps the entire scrollback into the ring buffer, causing the dashboard in-focus summary to show the same content block repeated 20+ times. Fix: on first capture after (re)start, seed `prevLines` without writing to buffer (unless buffer is empty on fresh start).
- **Nous sidebar ACMM gate**: The `#nous-sidebar-config` element was unconditionally shown by WebSocket updates regardless of ACMM level. Strategy/Nous requires L4 but the sidebar config appeared at L3, flickering on each status poll. Fix: gate visibility on ACMM >= 4 in both the WebSocket handler and `applyACMMVisibility`.
- **Policy: suppress bd list table**: All 4 advisory agent policies updated to suppress verbose `bd list` table dumps that flood the activity log.

## Test plan

- [ ] Open dashboard at L3 — verify Nous sidebar config no longer appears below agent cards
- [ ] Click into an agent with restarts — verify summary shows content once, not duplicated
- [ ] Restart an agent — verify new poller doesn't re-dump scrollback
- [ ] Fresh container start — verify summary populates on first capture (empty buffer path)