### PR TITLE
feat: per-agent UID isolation for mandatory proxy enforcement

### DIFF
--- a/bin/git-credential-hive.sh
+++ b/bin/git-credential-hive.sh
@@ -5,8 +5,36 @@
 
 set -euo pipefail
 
+# ── UID-based identity verification (defense-in-depth) ──
+# When running under a per-agent UID (>= 2001), derive the agent name from
+# the UID map instead of trusting the HIVE_AGENT env var (which the agent
+# could unset or spoof).
+UID_MAP_FILE="/var/run/hive/uid-map.json"
+CURRENT_UID=$(id -u)
+AGENT_UID_BASE=2001
+
+if [ "$CURRENT_UID" -ge "$AGENT_UID_BASE" ] && [ -f "$UID_MAP_FILE" ]; then
+  UID_AGENT=$(python3 -c "
+import json, sys
+with open('$UID_MAP_FILE') as f:
+    m = json.load(f)
+for name, uid in m.get('agents', {}).items():
+    if uid == $CURRENT_UID:
+        print(name)
+        sys.exit(0)
+sys.exit(1)
+" 2>/dev/null) || true
+  if [ -n "$UID_AGENT" ]; then
+    AGENT="$UID_AGENT"
+  else
+    echo "⛔ git push blocked: unknown agent UID ${CURRENT_UID}" >&2
+    exit 1
+  fi
+else
+  AGENT="${HIVE_AGENT:-}"
+fi
+
 # ── Mode-based enforcement: block git push for agents without push capability ──
-AGENT="${HIVE_AGENT:-}"
 
 # Read mode from file first (hot-reloadable), fallback to env var
 MODE_FILE="/tmp/.hive-mode-${AGENT}"

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -12,7 +12,7 @@ FROM node:24-slim
 
 # --- Layer 1: system packages (rarely changes) ---
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git ca-certificates bash curl tmux bzip2 gosu \
+    git ca-certificates bash curl tmux bzip2 gosu iptables \
  && rm -rf /var/lib/apt/lists/*
 
 # Non-root user for agent processes (Claude Code refuses --dangerously-skip-permissions as root)

--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -56,6 +56,114 @@ if [ "$(id -u)" = "0" ]; then
   chown -R dev:node /data/config /home/dev/.config 2>/dev/null || true
   echo "[entrypoint] Copilot config: ~/.config/github-copilot -> /data/config/github-copilot"
 
+  # ── Per-agent UID isolation ──────────────────────────────────────────
+  # Extract agent names from config + pack YAML, create system users,
+  # write UID map, and set up iptables to force all outbound :443
+  # through the MITM proxy (so agents can't bypass it via unset HTTPS_PROXY).
+  HIVE_CONFIG="${HIVE_CONFIG:-/etc/hive/hive.yaml}"
+  HIVE_UID_BASE=2001
+  PROXY_UID=1001
+
+  # Collect agent names from hive.yaml (map keys) and pack YAML (list items)
+  AGENT_NAMES=""
+  if [ -f "$HIVE_CONFIG" ]; then
+    AGENT_NAMES=$(python3 -c "
+import yaml, sys, os
+names = set()
+with open('$HIVE_CONFIG') as f:
+    cfg = yaml.safe_load(f) or {}
+agents = cfg.get('agents', {})
+if isinstance(agents, dict):
+    names.update(agents.keys())
+elif isinstance(agents, list):
+    for a in agents:
+        if isinstance(a, dict) and 'name' in a:
+            names.add(a['name'])
+# Also check pack YAML if HIVE_LEVEL is set
+level = os.environ.get('HIVE_LEVEL', '')
+if level:
+    import glob
+    for p in glob.glob('/opt/hive/packs/level-*.yaml') + glob.glob('/data/packs/level-*.yaml'):
+        try:
+            with open(p) as pf:
+                pack = yaml.safe_load(pf) or {}
+            pack_agents = pack.get('agents', [])
+            if isinstance(pack_agents, list):
+                for a in pack_agents:
+                    if isinstance(a, dict) and 'name' in a:
+                        names.add(a['name'])
+            elif isinstance(pack_agents, dict):
+                names.update(pack_agents.keys())
+        except Exception:
+            pass
+print('\n'.join(sorted(names)))
+" 2>/dev/null) || true
+  fi
+
+  if [ -n "$AGENT_NAMES" ]; then
+    echo "[entrypoint] Creating per-agent users for UID isolation..."
+    mkdir -p /var/run/hive
+    UID_OFFSET=0
+    UID_JSON='{"agents":{'
+    FIRST=true
+    echo "$AGENT_NAMES" | while read -r agent_name; do
+      [ -z "$agent_name" ] && continue
+      AGENT_UID=$((HIVE_UID_BASE + UID_OFFSET))
+      if ! id "hive-${agent_name}" >/dev/null 2>&1; then
+        useradd --system -u "$AGENT_UID" -g node -M -s /usr/sbin/nologin "hive-${agent_name}" 2>/dev/null || true
+      fi
+      mkdir -p "/data/agents/${agent_name}"
+      chown "hive-${agent_name}:node" "/data/agents/${agent_name}" 2>/dev/null || true
+      echo "[entrypoint] Agent user: hive-${agent_name} (UID ${AGENT_UID})"
+      UID_OFFSET=$((UID_OFFSET + 1))
+    done
+
+    # Write uid-map.json using python for proper JSON
+    python3 -c "
+import json, os
+names = '''$AGENT_NAMES'''.strip().split('\n')
+names = [n for n in names if n]
+agents = {}
+for i, name in enumerate(sorted(names)):
+    agents[name] = $HIVE_UID_BASE + i
+uid_map = {
+    'agents': agents,
+    'proxy_uid': $PROXY_UID,
+    'base_uid': $HIVE_UID_BASE,
+    'iptables_active': False
+}
+os.makedirs('/var/run/hive', exist_ok=True)
+with open('/var/run/hive/uid-map.json', 'w') as f:
+    json.dump(uid_map, f, indent=2)
+print('[entrypoint] UID map written to /var/run/hive/uid-map.json')
+" 2>/dev/null || echo "[entrypoint] WARN: Failed to write UID map"
+
+    # Set up iptables: redirect all outbound :443 to the MITM proxy port,
+    # except traffic from the proxy itself (UID 1001 / dev user).
+    PROXY_PORT=18443
+    if command -v iptables >/dev/null 2>&1; then
+      if iptables -t nat -N HIVE_PROXY 2>/dev/null; then
+        iptables -t nat -A HIVE_PROXY -m owner --uid-owner "$PROXY_UID" -j RETURN
+        iptables -t nat -A HIVE_PROXY -p tcp --dport 443 -j REDIRECT --to-ports "$PROXY_PORT"
+        iptables -t nat -A OUTPUT -j HIVE_PROXY
+        echo "[entrypoint] iptables: outbound :443 -> :${PROXY_PORT} (proxy UID ${PROXY_UID} exempt)"
+        # Update uid-map to record iptables active
+        python3 -c "
+import json
+with open('/var/run/hive/uid-map.json') as f:
+    m = json.load(f)
+m['iptables_active'] = True
+with open('/var/run/hive/uid-map.json', 'w') as f:
+    json.dump(m, f, indent=2)
+" 2>/dev/null || true
+      else
+        echo "[entrypoint] WARN: iptables chain creation failed (need NET_ADMIN capability)"
+      fi
+    else
+      echo "[entrypoint] WARN: iptables not found, proxy enforcement is advisory-only"
+    fi
+  fi
+
   # Drop to non-root user for all runtime processes.
   # Claude Code refuses --dangerously-skip-permissions as root.
   if command -v gosu >/dev/null 2>&1; then

--- a/v2/docker-compose.yaml
+++ b/v2/docker-compose.yaml
@@ -27,6 +27,8 @@ services:
         GIT_SHORT: ${GIT_SHORT:-unknown}
     container_name: hive
     restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
     expose:
       - "3001"
       - "7681"

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -47,6 +47,7 @@ type AgentProcess struct {
 	Config          config.AgentConfig
 	State           ProcessState
 	PID             int
+	UID             int
 	StartedAt       *time.Time
 	LastKick        *time.Time
 	Paused          bool
@@ -59,6 +60,7 @@ type AgentProcess struct {
 	KickHistory     []KickRecord
 	LaunchedMode    AgentMode
 	tmuxSession     string
+	tmuxSocket      string
 	cancel          context.CancelFunc
 	forceRelaunch   bool
 }
@@ -80,6 +82,7 @@ type Manager struct {
 	workDir          string
 	project          ProjectContext
 	copilotAuthToken string
+	uidMap           *UIDMap
 }
 
 func NewManager(agents map[string]config.AgentConfig, logger *slog.Logger, project ProjectContext) *Manager {
@@ -93,6 +96,14 @@ func NewManager(agents map[string]config.AgentConfig, logger *slog.Logger, proje
 	// completions; write access is gated by --enable-all-github-mcp-tools flag.
 	copilotToken := os.Getenv("COPILOT_GITHUB_TOKEN")
 
+	var uidMap *UIDMap
+	if loaded, err := LoadUIDMap(UIDMapPath); err == nil {
+		uidMap = loaded
+		logger.Info("UID map loaded", "agents", len(uidMap.Agents), "iptables", uidMap.IptablesActive)
+	} else {
+		logger.Info("no UID map found, agents will share dev UID", "path", UIDMapPath)
+	}
+
 	m := &Manager{
 		agents:           make(map[string]*AgentProcess),
 		idToName:         make(map[string]string),
@@ -100,6 +111,7 @@ func NewManager(agents map[string]config.AgentConfig, logger *slog.Logger, proje
 		workDir:          workDir,
 		project:          project,
 		copilotAuthToken: copilotToken,
+		uidMap:           uidMap,
 	}
 
 	for name, cfg := range agents {
@@ -107,13 +119,23 @@ func NewManager(agents map[string]config.AgentConfig, logger *slog.Logger, proje
 		if agentID == "" {
 			agentID = name
 		}
+		agentUID := 0
+		tmuxSocket := ""
+		if uidMap != nil {
+			agentUID = uidMap.LookupByName(name)
+			if agentUID > 0 {
+				tmuxSocket = "hive-" + name
+			}
+		}
 		m.agents[name] = &AgentProcess{
 			Name:         name,
 			ID:           agentID,
 			Config:       cfg,
 			State:        StateStopped,
+			UID:          agentUID,
 			OutputBuffer: NewRingBuffer(outputBufferCapacity),
 			tmuxSession:  "hive-" + name,
+			tmuxSocket:   tmuxSocket,
 		}
 		m.idToName[agentID] = name
 	}
@@ -161,8 +183,24 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 	return m.launchInTmux(ctx, agent)
 }
 
+// tmuxBaseArgs returns the base tmux command args for an agent. When the agent
+// has a per-agent tmux socket (UID isolation), it returns ["tmux", "-L", socketName].
+// Otherwise it returns ["tmux"] for the shared tmux server.
+func (m *Manager) tmuxBaseArgs(agent *AgentProcess) []string {
+	if agent.tmuxSocket != "" {
+		return []string{"tmux", "-L", agent.tmuxSocket}
+	}
+	return []string{"tmux"}
+}
+
+// tmuxCmd builds an exec.Cmd for tmux with agent-specific socket args + the given subcommand args.
+func (m *Manager) tmuxCmd(agent *AgentProcess, args ...string) *exec.Cmd {
+	base := m.tmuxBaseArgs(agent)
+	return exec.Command(base[0], append(base[1:], args...)...)
+}
+
 func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
-	if m.tmuxSessionExists(agent.tmuxSession) {
+	if m.tmuxSessionExistsForAgent(agent) {
 		return nil
 	}
 
@@ -171,35 +209,47 @@ func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
 		return fmt.Errorf("creating agent work dir %s: %w", agentDir, err)
 	}
 
-	cmd := exec.Command("tmux", "new-session", "-d", "-s", agent.tmuxSession, "-c", agentDir)
+	// When UID isolation is active, launch the tmux session under the agent's UID
+	// using setpriv. This creates an isolated tmux server per agent.
+	var cmd *exec.Cmd
+	if agent.UID > 0 {
+		setprivArgs := []string{
+			"setpriv", "--reuid", fmt.Sprintf("%d", agent.UID),
+			"--regid", "1000", "--init-groups", "--",
+		}
+		tmuxArgs := append(m.tmuxBaseArgs(agent), "new-session", "-d", "-s", agent.tmuxSession, "-c", agentDir)
+		cmd = exec.Command(setprivArgs[0], append(setprivArgs[1:], tmuxArgs...)...)
+	} else {
+		cmd = exec.Command("tmux", "new-session", "-d", "-s", agent.tmuxSession, "-c", agentDir)
+	}
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("creating tmux session for %s: %w", agent.Name, err)
 	}
 
-	// Set per-session env vars via tmux set-environment. cmd.Env on tmux
-	// new-session only affects the tmux client process, not the shell spawned
-	// inside the session — all sessions share the tmux server's environment.
+	// Set per-session env vars via tmux set-environment.
 	for _, envVar := range m.agentEnvVars(agent) {
 		parts := strings.SplitN(envVar, "=", 2)
 		if len(parts) == 2 {
-			_ = exec.Command("tmux", "set-environment", "-t", agent.tmuxSession, parts[0], parts[1]).Run()
+			_ = m.tmuxCmd(agent, "set-environment", "-t", agent.tmuxSession, parts[0], parts[1]).Run()
 		}
 	}
-	// Strip gh/git tokens from advisory agent sessions (they use gh-wrapper
-	// and credential helper enforcement). COPILOT_GITHUB_TOKEN is kept for
-	// all agents — AI auth needs it; write access is gated by the
-	// --enable-all-github-mcp-tools flag (only passed for quality).
+	// Strip gh/git tokens from advisory agent sessions.
 	if !m.agentMode(agent).CanPush() {
-		_ = exec.Command("tmux", "set-environment", "-t", agent.tmuxSession, "-u", "GH_TOKEN").Run()
-		_ = exec.Command("tmux", "set-environment", "-t", agent.tmuxSession, "-u", "GITHUB_TOKEN").Run()
+		_ = m.tmuxCmd(agent, "set-environment", "-t", agent.tmuxSession, "-u", "GH_TOKEN").Run()
+		_ = m.tmuxCmd(agent, "set-environment", "-t", agent.tmuxSession, "-u", "GITHUB_TOKEN").Run()
 	}
 
-	m.logger.Info("tmux session created", "name", agent.Name, "session", agent.tmuxSession)
+	m.logger.Info("tmux session created", "name", agent.Name, "session", agent.tmuxSession, "uid", agent.UID, "socket", agent.tmuxSocket)
 	return nil
 }
 
 func (m *Manager) tmuxSessionExists(session string) bool {
 	cmd := exec.Command("tmux", "has-session", "-t", session)
+	return cmd.Run() == nil
+}
+
+func (m *Manager) tmuxSessionExistsForAgent(agent *AgentProcess) bool {
+	cmd := m.tmuxCmd(agent, "has-session", "-t", agent.tmuxSession)
 	return cmd.Run() == nil
 }
 
@@ -222,6 +272,20 @@ var cliPaneMarkers = []string{
 // the visible pane content for known CLI UI markers.
 func (m *Manager) tmuxPaneHasCLI(session string) bool {
 	output := m.captureTmuxPane(session)
+	if output == "" {
+		return false
+	}
+	for _, marker := range cliPaneMarkers {
+		if strings.Contains(output, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// tmuxPaneHasCLIForAgent checks for CLI markers using the agent's tmux socket.
+func (m *Manager) tmuxPaneHasCLIForAgent(agent *AgentProcess) bool {
+	output := m.captureTmuxPaneForAgent(agent)
 	if output == "" {
 		return false
 	}
@@ -324,7 +388,7 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		}
 	}
 
-	if !agent.forceRelaunch && m.tmuxPaneHasCLI(agent.tmuxSession) {
+	if !agent.forceRelaunch && m.tmuxPaneHasCLIForAgent(agent) {
 		m.logger.Info("CLI already running in tmux pane, skipping launch", "name", agent.Name, "session", agent.tmuxSession)
 		now := time.Now()
 		agent.State = StateRunning
@@ -332,10 +396,10 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 
 		agentCtx, cancel := context.WithCancel(ctx)
 		agent.cancel = cancel
-		go m.pollTmuxOutput(agent.Name, agent.tmuxSession, agent.OutputBuffer, agentCtx)
+		go m.pollTmuxOutputForAgent(agent, agentCtx)
 
 		if backend == "copilot" {
-			go m.watchForTrustPrompt(agent.tmuxSession, agentCtx)
+			go m.watchForTrustPromptForAgent(agent, agentCtx)
 		}
 		return nil
 	}
@@ -344,9 +408,9 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	envCmd := m.buildEnvPrefix(agent)
 	fullCmd := envCmd + launchCmd
 
-	m.tmuxSendLiteral(agent.tmuxSession, fullCmd)
+	m.tmuxSendLiteralForAgent(agent, fullCmd)
 	time.Sleep(textToEnterDelay)
-	m.tmuxSendEnters(agent.tmuxSession)
+	m.tmuxSendEntersForAgent(agent)
 
 	now := time.Now()
 	agent.State = StateRunning
@@ -361,13 +425,81 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 
 	agentCtx, cancel := context.WithCancel(ctx)
 	agent.cancel = cancel
-	go m.pollTmuxOutput(agent.Name, agent.tmuxSession, agent.OutputBuffer, agentCtx)
+	go m.pollTmuxOutputForAgent(agent, agentCtx)
 
 	if backend == "copilot" {
-		go m.watchForTrustPrompt(agent.tmuxSession, agentCtx)
+		go m.watchForTrustPromptForAgent(agent, agentCtx)
 	}
 
 	return nil
+}
+
+// pollTmuxOutputForAgent is pollTmuxOutput using the agent's tmux socket.
+func (m *Manager) pollTmuxOutputForAgent(agent *AgentProcess, ctx context.Context) {
+	const pollInterval = 3 * time.Second
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	var prevLines []string
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			output := m.captureTmuxPaneForAgent(agent)
+			if output == "" {
+				continue
+			}
+			var filtered []string
+			for _, line := range strings.Split(output, "\n") {
+				trimmed := strings.TrimRight(line, " \t")
+				if trimmed != "" {
+					filtered = append(filtered, trimmed)
+				}
+			}
+			if len(filtered) == 0 {
+				continue
+			}
+			newLines := diffNewLines(prevLines, filtered)
+			for _, l := range newLines {
+				agent.OutputBuffer.Write(l)
+				m.logOutputSignals(agent.Name, l)
+			}
+			prevLines = filtered
+		}
+	}
+}
+
+// watchForTrustPromptForAgent monitors a tmux session for Copilot's "Confirm folder trust"
+// prompt using the agent's tmux socket.
+func (m *Manager) watchForTrustPromptForAgent(agent *AgentProcess, ctx context.Context) {
+	const (
+		trustPollInterval = 2 * time.Second
+		trustMaxWait      = 120 * time.Second
+		trustCooldown     = 3 * time.Second
+	)
+	deadline := time.After(trustMaxWait)
+	ticker := time.NewTicker(trustPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-deadline:
+			return
+		case <-ticker.C:
+			output := m.captureTmuxPaneForAgent(agent)
+			if strings.Contains(output, "Confirm folder trust") || strings.Contains(output, "Do you trust the files") {
+				time.Sleep(paneCaptureSleep)
+				m.tmuxSendKeysForAgent(agent, "2")
+				time.Sleep(enterDelay)
+				m.tmuxSendKeysForAgent(agent, "Enter")
+				m.logger.Info("auto-answered folder trust prompt", "agent", agent.Name)
+				time.Sleep(trustCooldown)
+			}
+		}
+	}
 }
 
 // watchForTrustPrompt monitors a tmux session for Copilot's "Confirm folder trust"
@@ -731,6 +863,45 @@ func (m *Manager) waitForCLIReady(session string) bool {
 	}
 }
 
+// waitForCLIReadyForAgent polls the agent's tmux pane (using its socket)
+// until the CLI shows its ready prompt or the timeout expires.
+func (m *Manager) waitForCLIReadyForAgent(agent *AgentProcess) bool {
+	deadline := time.After(cliReadyTimeout)
+	ticker := time.NewTicker(cliReadyPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			return false
+		case <-ticker.C:
+			if m.tmuxPaneHasCLIForAgent(agent) {
+				return true
+			}
+		}
+	}
+}
+
+// waitForInputPromptForAgent polls until the CLI shows its input prompt (❯)
+// using the agent's tmux socket.
+func (m *Manager) waitForInputPromptForAgent(agent *AgentProcess) bool {
+	deadline := time.After(inputPromptTimeout)
+	ticker := time.NewTicker(inputPromptPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			return false
+		case <-ticker.C:
+			output := m.captureTmuxPaneForAgent(agent)
+			if strings.Contains(output, "❯") {
+				return true
+			}
+		}
+	}
+}
+
 // waitForInputPrompt polls until the CLI shows its input prompt (❯),
 // indicating it is ready to accept a kick. This is stricter than
 // waitForCLIReady which matches any CLI marker (including trust prompts).
@@ -762,6 +933,17 @@ func (m *Manager) captureTmuxPane(session string) string {
 	return string(out)
 }
 
+// captureTmuxPaneForAgent captures pane content using the agent's tmux socket.
+func (m *Manager) captureTmuxPaneForAgent(agent *AgentProcess) string {
+	cmd := m.tmuxCmd(agent, "capture-pane", "-t", agent.tmuxSession, "-p",
+		"-S", fmt.Sprintf("-%d", tmuxCaptureLines))
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}
+
 func (m *Manager) Stop(name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -779,8 +961,7 @@ func (m *Manager) Stop(name string) error {
 		agent.cancel()
 	}
 
-	cmd := exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "C-c", "")
-	_ = cmd.Run()
+	m.tmuxSendKeysForAgent(agent, "C-c", "")
 
 	agent.State = StateStopped
 	m.logger.Info("agent stopped", "name", name)
@@ -800,16 +981,27 @@ func (m *Manager) AddAgent(name string, cfg config.AgentConfig) {
 	if agentID == "" {
 		agentID = name
 	}
+	agentUID := 0
+	tmuxSocket := ""
+	if m.uidMap != nil {
+		agentUID = m.uidMap.AllocateUID(name)
+		if agentUID > 0 {
+			tmuxSocket = "hive-" + name
+		}
+		_ = m.uidMap.Save(UIDMapPath)
+	}
 	m.agents[name] = &AgentProcess{
 		Name:         name,
 		ID:           agentID,
 		Config:       cfg,
 		State:        StateStopped,
+		UID:          agentUID,
 		OutputBuffer: NewRingBuffer(outputBufferCapacity),
 		tmuxSession:  "hive-" + name,
+		tmuxSocket:   tmuxSocket,
 	}
 	m.idToName[agentID] = name
-	m.logger.Info("agent added", "name", name, "id", agentID)
+	m.logger.Info("agent added", "name", name, "id", agentID, "uid", agentUID)
 }
 
 // UpdateConfig updates the stored config for a running agent process so that
@@ -860,7 +1052,7 @@ func (m *Manager) CheckAndRestartCrashedAgents(ctx context.Context) []string {
 		if agent.Paused {
 			continue
 		}
-		if !m.tmuxSessionExists(agent.tmuxSession) {
+		if !m.tmuxSessionExistsForAgent(agent) {
 			var uptimeSeconds float64
 			if agent.StartedAt != nil {
 				uptimeSeconds = time.Since(*agent.StartedAt).Seconds()
@@ -874,7 +1066,7 @@ func (m *Manager) CheckAndRestartCrashedAgents(ctx context.Context) []string {
 			crashed = append(crashed, name)
 			continue
 		}
-		if !m.tmuxPaneHasCLI(agent.tmuxSession) {
+		if !m.tmuxPaneHasCLIForAgent(agent) {
 			var uptimeSeconds float64
 			if agent.StartedAt != nil {
 				uptimeSeconds = time.Since(*agent.StartedAt).Seconds()
@@ -923,19 +1115,19 @@ func (m *Manager) SendKick(name string, message string) error {
 		return fmt.Errorf("agent %s not running", name)
 	}
 
-	if !m.tmuxSessionExists(agent.tmuxSession) {
+	if !m.tmuxSessionExistsForAgent(agent) {
 		return fmt.Errorf("tmux session %s not found", agent.tmuxSession)
 	}
 
 	// Detect crashed CLI and restart before sending kick
-	if !m.tmuxPaneHasCLI(agent.tmuxSession) {
+	if !m.tmuxPaneHasCLIForAgent(agent) {
 		m.logger.Warn("agent CLI crashed, restarting before kick", "name", name)
 		m.mu.Unlock()
 		if err := m.Restart(context.Background(), name); err != nil {
 			m.mu.Lock()
 			return fmt.Errorf("failed to restart crashed agent %s: %w", name, err)
 		}
-		if !m.waitForCLIReady(agent.tmuxSession) {
+		if !m.waitForCLIReadyForAgent(agent) {
 			m.mu.Lock()
 			return fmt.Errorf("agent %s CLI did not become ready after restart", name)
 		}
@@ -949,9 +1141,8 @@ func (m *Manager) SendKick(name string, message string) error {
 	// Wait for the input prompt (❯) before sending — the CLI may be
 	// showing a trust prompt or still initializing even though
 	// tmuxPaneHasCLI matched a broad marker like "Copilot".
-	session := agent.tmuxSession
 	m.mu.Unlock()
-	if !m.waitForInputPrompt(session) {
+	if !m.waitForInputPromptForAgent(agent) {
 		m.mu.Lock()
 		return fmt.Errorf("agent %s CLI did not reach input prompt", name)
 	}
@@ -962,35 +1153,35 @@ func (m *Manager) SendKick(name string, message string) error {
 	}
 
 	// Clear stale input before kick (Ctrl+C then Ctrl+U)
-	_ = exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "C-c").Run()
+	m.tmuxSendKeysForAgent(agent, "C-c")
 	time.Sleep(staleCheckDelay)
-	_ = exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "C-u").Run()
+	m.tmuxSendKeysForAgent(agent, "C-u")
 	time.Sleep(staleCheckDelay)
 
 	if agent.Config.ClearOnKick {
-		m.tmuxSendLiteral(agent.tmuxSession, "/clear")
+		m.tmuxSendLiteralForAgent(agent, "/clear")
 		time.Sleep(textToEnterDelay)
-		m.tmuxSendEnters(agent.tmuxSession)
+		m.tmuxSendEntersForAgent(agent)
 		time.Sleep(clearBeforeKickDelay)
 	}
 
 	// Send message in chunks (old hive pattern: 400 char max per chunk)
 	if len(message) <= chunkSize {
-		m.tmuxSendLiteral(agent.tmuxSession, message)
+		m.tmuxSendLiteralForAgent(agent, message)
 	} else {
 		for offset := 0; offset < len(message); offset += chunkSize {
 			end := offset + chunkSize
 			if end > len(message) {
 				end = len(message)
 			}
-			m.tmuxSendLiteral(agent.tmuxSession, message[offset:end])
+			m.tmuxSendLiteralForAgent(agent, message[offset:end])
 			time.Sleep(chunkDelay)
 		}
 	}
 
 	// Text and Enter must always be separate calls with a delay between
 	time.Sleep(textToEnterDelay)
-	m.tmuxSendEnters(agent.tmuxSession)
+	m.tmuxSendEntersForAgent(agent)
 
 	now := time.Now()
 	agent.LastKick = &now
@@ -1025,6 +1216,11 @@ func (m *Manager) tmuxSendLiteral(session, text string) {
 	_ = exec.Command("tmux", "send-keys", "-t", session, "-l", text).Run()
 }
 
+// tmuxSendLiteralForAgent sends text using the agent's tmux socket.
+func (m *Manager) tmuxSendLiteralForAgent(agent *AgentProcess, text string) {
+	_ = m.tmuxCmd(agent, "send-keys", "-t", agent.tmuxSession, "-l", text).Run()
+}
+
 // tmuxSendEnters sends multiple Enter presses with delays between each (old hive: 3x, 300ms apart).
 func (m *Manager) tmuxSendEnters(session string) {
 	for i := 0; i < enterCount; i++ {
@@ -1033,6 +1229,22 @@ func (m *Manager) tmuxSendEnters(session string) {
 			time.Sleep(enterDelay)
 		}
 	}
+}
+
+// tmuxSendEntersForAgent sends Enter presses using the agent's tmux socket.
+func (m *Manager) tmuxSendEntersForAgent(agent *AgentProcess) {
+	for i := 0; i < enterCount; i++ {
+		_ = m.tmuxCmd(agent, "send-keys", "-t", agent.tmuxSession, "Enter").Run()
+		if i < enterCount-1 {
+			time.Sleep(enterDelay)
+		}
+	}
+}
+
+// tmuxSendKeysForAgent sends key sequences (C-c, C-u, etc.) using the agent's tmux socket.
+func (m *Manager) tmuxSendKeysForAgent(agent *AgentProcess, keys ...string) {
+	args := append([]string{"send-keys", "-t", agent.tmuxSession}, keys...)
+	_ = m.tmuxCmd(agent, args...).Run()
 }
 
 const (
@@ -1102,6 +1314,7 @@ func (a *AgentProcess) snapshot() AgentProcess {
 		Config:          a.Config,
 		State:           a.State,
 		PID:             a.PID,
+		UID:             a.UID,
 		StartedAt:       a.StartedAt,
 		LastKick:        a.LastKick,
 		Paused:          a.Paused,
@@ -1112,6 +1325,7 @@ func (a *AgentProcess) snapshot() AgentProcess {
 		RestartCount:    a.RestartCount,
 		KickHistory:     history,
 		tmuxSession:     a.tmuxSession,
+		tmuxSocket:      a.tmuxSocket,
 		OutputBuffer:    a.OutputBuffer,
 	}
 }
@@ -1333,8 +1547,7 @@ func (m *Manager) Pause(name string) error {
 
 	agent.Paused = true
 	if agent.State == StateRunning {
-		cmd := exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "C-c", "")
-		_ = cmd.Run()
+		m.tmuxSendKeysForAgent(agent, "C-c", "")
 	}
 	agent.State = StatePaused
 	m.logger.Info("agent paused",
@@ -1375,15 +1588,13 @@ func (m *Manager) Restart(ctx context.Context, name string) error {
 	}
 
 	if agent.State == StateRunning {
-		cmd := exec.Command("tmux", "send-keys", "-t", agent.tmuxSession, "C-c", "")
-		_ = cmd.Run()
+		m.tmuxSendKeysForAgent(agent, "C-c", "")
 		if agent.cancel != nil {
 			agent.cancel()
 		}
 	}
 
-	killCmd := exec.Command("tmux", "kill-session", "-t", agent.tmuxSession)
-	_ = killCmd.Run()
+	_ = m.tmuxCmd(agent, "kill-session", "-t", agent.tmuxSession).Run()
 
 	agent.RestartCount++
 	agent.forceRelaunch = true

--- a/v2/pkg/agent/uidmap.go
+++ b/v2/pkg/agent/uidmap.go
@@ -1,0 +1,122 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+)
+
+const (
+	UIDMapPath = "/var/run/hive/uid-map.json"
+	baseAgentUID = 2001
+	proxyUserUID = 1001
+)
+
+type UIDMap struct {
+	Agents         map[string]int `json:"agents"`
+	ProxyUID       int            `json:"proxy_uid"`
+	BaseUID        int            `json:"base_uid"`
+	IptablesActive bool           `json:"iptables_active"`
+
+	mu sync.RWMutex
+}
+
+func NewUIDMap() *UIDMap {
+	return &UIDMap{
+		Agents:   make(map[string]int),
+		ProxyUID: proxyUserUID,
+		BaseUID:  baseAgentUID,
+	}
+}
+
+// AllocateUIDs assigns UIDs to agent names in alphabetical order,
+// starting from BaseUID. Existing allocations are preserved.
+func (u *UIDMap) AllocateUIDs(names []string) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	sorted := make([]string, len(names))
+	copy(sorted, names)
+	sort.Strings(sorted)
+
+	for i, name := range sorted {
+		if _, exists := u.Agents[name]; !exists {
+			u.Agents[name] = u.BaseUID + i
+		}
+	}
+}
+
+// AllocateUID assigns a UID to a single agent, using the next available
+// UID above all existing allocations. For runtime agent additions.
+func (u *UIDMap) AllocateUID(name string) int {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	if uid, exists := u.Agents[name]; exists {
+		return uid
+	}
+
+	maxUID := u.BaseUID - 1
+	for _, uid := range u.Agents {
+		if uid > maxUID {
+			maxUID = uid
+		}
+	}
+	uid := maxUID + 1
+	u.Agents[name] = uid
+	return uid
+}
+
+// LookupByUID returns the agent name for a given UID, or empty string if not found.
+func (u *UIDMap) LookupByUID(uid int) string {
+	u.mu.RLock()
+	defer u.mu.RUnlock()
+
+	for name, agentUID := range u.Agents {
+		if agentUID == uid {
+			return name
+		}
+	}
+	return ""
+}
+
+// LookupByName returns the UID for a given agent name, or 0 if not found.
+func (u *UIDMap) LookupByName(name string) int {
+	u.mu.RLock()
+	defer u.mu.RUnlock()
+	return u.Agents[name]
+}
+
+// Save writes the UID map to the given path as JSON.
+func (u *UIDMap) Save(path string) error {
+	u.mu.RLock()
+	defer u.mu.RUnlock()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create uid-map dir: %w", err)
+	}
+	data, err := json.MarshalIndent(u, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal uid-map: %w", err)
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// LoadUIDMap reads a UID map from the given path.
+func LoadUIDMap(path string) (*UIDMap, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read uid-map: %w", err)
+	}
+	u := &UIDMap{}
+	if err := json.Unmarshal(data, u); err != nil {
+		return nil, fmt.Errorf("unmarshal uid-map: %w", err)
+	}
+	if u.Agents == nil {
+		u.Agents = make(map[string]int)
+	}
+	return u, nil
+}

--- a/v2/pkg/agent/uidmap_test.go
+++ b/v2/pkg/agent/uidmap_test.go
@@ -1,0 +1,137 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAllocateUIDs_Alphabetical(t *testing.T) {
+	u := NewUIDMap()
+	u.AllocateUIDs([]string{"quality", "scanner", "ci-maintainer", "guide", "supervisor"})
+
+	expected := map[string]int{
+		"ci-maintainer": 2001,
+		"guide":         2002,
+		"quality":       2003,
+		"scanner":       2004,
+		"supervisor":    2005,
+	}
+	for name, want := range expected {
+		got := u.Agents[name]
+		if got != want {
+			t.Errorf("agent %s: got UID %d, want %d", name, got, want)
+		}
+	}
+}
+
+func TestAllocateUIDs_Idempotent(t *testing.T) {
+	u := NewUIDMap()
+	u.AllocateUIDs([]string{"scanner", "quality"})
+	first := u.Agents["quality"]
+	u.AllocateUIDs([]string{"scanner", "quality"})
+	second := u.Agents["quality"]
+	if first != second {
+		t.Errorf("not idempotent: first=%d, second=%d", first, second)
+	}
+}
+
+func TestAllocateUID_Dynamic(t *testing.T) {
+	u := NewUIDMap()
+	u.AllocateUIDs([]string{"quality", "scanner"})
+	maxBefore := 0
+	for _, uid := range u.Agents {
+		if uid > maxBefore {
+			maxBefore = uid
+		}
+	}
+
+	uid := u.AllocateUID("newcomer")
+	if uid != maxBefore+1 {
+		t.Errorf("dynamic UID: got %d, want %d", uid, maxBefore+1)
+	}
+
+	uid2 := u.AllocateUID("newcomer")
+	if uid2 != uid {
+		t.Errorf("duplicate allocation: got %d, want %d", uid2, uid)
+	}
+}
+
+func TestLookupByUID(t *testing.T) {
+	u := NewUIDMap()
+	u.AllocateUIDs([]string{"quality", "scanner"})
+
+	name := u.LookupByUID(u.Agents["quality"])
+	if name != "quality" {
+		t.Errorf("lookup by UID: got %q, want %q", name, "quality")
+	}
+
+	name = u.LookupByUID(99999)
+	if name != "" {
+		t.Errorf("lookup unknown UID: got %q, want empty", name)
+	}
+}
+
+func TestLookupByName(t *testing.T) {
+	u := NewUIDMap()
+	u.AllocateUIDs([]string{"guide"})
+
+	uid := u.LookupByName("guide")
+	if uid != baseAgentUID {
+		t.Errorf("lookup by name: got %d, want %d", uid, baseAgentUID)
+	}
+
+	uid = u.LookupByName("nonexistent")
+	if uid != 0 {
+		t.Errorf("lookup unknown name: got %d, want 0", uid)
+	}
+}
+
+func TestSaveAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "subdir", "uid-map.json")
+
+	u := NewUIDMap()
+	u.AllocateUIDs([]string{"quality", "scanner"})
+	u.IptablesActive = true
+
+	if err := u.Save(path); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loaded, err := LoadUIDMap(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if loaded.ProxyUID != u.ProxyUID {
+		t.Errorf("ProxyUID: got %d, want %d", loaded.ProxyUID, u.ProxyUID)
+	}
+	if !loaded.IptablesActive {
+		t.Error("IptablesActive should be true")
+	}
+	for name, want := range u.Agents {
+		got := loaded.Agents[name]
+		if got != want {
+			t.Errorf("loaded agent %s: got %d, want %d", name, got, want)
+		}
+	}
+}
+
+func TestLoadUIDMap_NotFound(t *testing.T) {
+	_, err := LoadUIDMap("/nonexistent/uid-map.json")
+	if err == nil {
+		t.Error("expected error for nonexistent file")
+	}
+}
+
+func TestLoadUIDMap_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.json")
+	os.WriteFile(path, []byte("not json"), 0o644)
+
+	_, err := LoadUIDMap(path)
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -38,6 +38,7 @@ type GitHubProxy struct {
 	caCert     tls.Certificate
 	caX509     *x509.Certificate
 	logger     *slog.Logger
+	uidMap     *agent.UIDMap
 
 	mu         sync.RWMutex
 	violations map[string]int // agent name -> blocked request count
@@ -55,11 +56,18 @@ func NewGitHubProxy(logger *slog.Logger) (*GitHubProxy, error) {
 		return nil, fmt.Errorf("write CA cert to %s: %w", CACertPath, err)
 	}
 
+	var uidMap *agent.UIDMap
+	if loaded, loadErr := agent.LoadUIDMap(agent.UIDMapPath); loadErr == nil {
+		uidMap = loaded
+		logger.Info("proxy loaded UID map", "agents", len(uidMap.Agents), "iptables", uidMap.IptablesActive)
+	}
+
 	return &GitHubProxy{
 		listenAddr: fmt.Sprintf("127.0.0.1:%d", proxyListenPort),
 		caCert:     caCert,
 		caX509:     caX509,
 		logger:     logger,
+		uidMap:     uidMap,
 		violations: make(map[string]int),
 	}, nil
 }
@@ -86,6 +94,8 @@ func (p *GitHubProxy) AgentViolations(agentName string) int {
 }
 
 // Start begins listening. Blocks until the listener is closed.
+// Handles both explicit HTTP CONNECT proxy requests and transparent
+// iptables-redirected TLS connections (detected by TLS ClientHello).
 func (p *GitHubProxy) Start() error {
 	ln, err := net.Listen("tcp", p.listenAddr)
 	if err != nil {
@@ -93,13 +103,254 @@ func (p *GitHubProxy) Start() error {
 	}
 	p.logger.Info("proxy listening", "addr", p.listenAddr)
 
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			return fmt.Errorf("accept: %w", err)
+		}
+		go p.handleConn(conn)
+	}
+}
+
+// handleConn peeks at the first byte to distinguish HTTP CONNECT requests
+// (explicit proxy) from raw TLS ClientHello (iptables-redirected traffic).
+func (p *GitHubProxy) handleConn(conn net.Conn) {
+	defer conn.Close()
+
+	peeked := make([]byte, 1)
+	conn.SetReadDeadline(time.Now().Add(transparentProxyTimeout))
+	n, err := conn.Read(peeked)
+	conn.SetReadDeadline(time.Time{})
+	if err != nil || n == 0 {
+		return
+	}
+
+	// TLS ClientHello starts with byte 0x16 (ContentType handshake).
+	// HTTP methods start with ASCII letters (C for CONNECT, G for GET, etc.).
+	const tlsHandshakeContentType = 0x16
+	if peeked[0] == tlsHandshakeContentType {
+		p.handleTransparentTLS(conn, peeked)
+		return
+	}
+
+	// Re-wrap the peeked byte and handle as HTTP.
+	prefixed := &prefixConn{Conn: conn, prefix: peeked[:n]}
 	srv := &http.Server{
 		Handler:      p,
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 60 * time.Second,
+		ReadTimeout:  httpReadTimeout,
+		WriteTimeout: httpWriteTimeout,
 	}
-	return srv.Serve(ln)
+	srv.Serve(&singleConnListener{conn: prefixed})
 }
+
+const (
+	transparentProxyTimeout = 5 * time.Second
+	httpReadTimeout         = 30 * time.Second
+	httpWriteTimeout        = 60 * time.Second
+)
+
+// handleTransparentTLS handles iptables-redirected connections. The agent
+// tried to connect to github.com:443 but iptables sent it here instead.
+// We extract the SNI hostname from the TLS ClientHello, then MITM the connection.
+func (p *GitHubProxy) handleTransparentTLS(conn net.Conn, peeked []byte) {
+	// Read enough of the ClientHello to extract SNI.
+	buf := make([]byte, tlsClientHelloMaxSize)
+	copy(buf, peeked)
+	conn.SetReadDeadline(time.Now().Add(transparentProxyTimeout))
+	n, err := conn.Read(buf[len(peeked):])
+	conn.SetReadDeadline(time.Time{})
+	if err != nil {
+		return
+	}
+	fullBuf := buf[:len(peeked)+n]
+
+	host := extractSNI(fullBuf)
+	if host == "" {
+		host = "github.com"
+	}
+
+	// Identify agent by UID from /proc/net/tcp
+	agentName := ""
+	if p.uidMap != nil && p.uidMap.IptablesActive {
+		_, portStr, splitErr := net.SplitHostPort(conn.RemoteAddr().String())
+		if splitErr == nil {
+			port := 0
+			for _, c := range portStr {
+				port = port*10 + int(c-'0')
+			}
+			uid, lookupErr := LookupUIDByLocalPort(port)
+			if lookupErr == nil {
+				agentName = p.uidMap.LookupByUID(uid)
+			}
+		}
+	}
+
+	if !IsGitHubHost(host) {
+		// Non-GitHub: tunnel directly to the intended host.
+		upstream, err := net.DialTimeout("tcp", host+":443", transparentProxyTimeout)
+		if err != nil {
+			return
+		}
+		defer upstream.Close()
+		upstream.Write(fullBuf)
+		go io.Copy(upstream, conn)
+		io.Copy(conn, upstream)
+		return
+	}
+
+	mode := readAgentMode(agentName)
+	if mode == agent.ModeNoGitHub {
+		p.recordViolation(agentName, "TRANSPARENT", host)
+		return
+	}
+
+	// MITM: forge a cert, TLS-wrap the client, connect to real upstream.
+	tlsCert, err := p.forgeCert(host)
+	if err != nil {
+		p.logger.Error("transparent proxy forge cert failed", "host", host, "error", err)
+		return
+	}
+
+	tlsConfig := &tls.Config{Certificates: []tls.Certificate{tlsCert}}
+	prefixed := &prefixConn{Conn: conn, prefix: fullBuf}
+	tlsClientConn := tls.Server(prefixed, tlsConfig)
+	if err := tlsClientConn.Handshake(); err != nil {
+		p.logger.Warn("transparent proxy TLS handshake failed", "error", err)
+		return
+	}
+	defer tlsClientConn.Close()
+
+	upstreamConn, err := tls.Dial("tcp", host+":443", &tls.Config{ServerName: host})
+	if err != nil {
+		p.logger.Error("transparent proxy upstream dial failed", "host", host, "error", err)
+		return
+	}
+	defer upstreamConn.Close()
+
+	p.proxyHTTP(tlsClientConn, upstreamConn, agentName, mode)
+}
+
+const tlsClientHelloMaxSize = 4096
+
+// extractSNI reads the SNI hostname from a TLS ClientHello message.
+func extractSNI(data []byte) string {
+	if len(data) < 5 {
+		return ""
+	}
+	// TLS record: type(1) + version(2) + length(2) + handshake
+	recordLen := int(data[3])<<8 | int(data[4])
+	if len(data) < 5+recordLen {
+		// Partial read — use what we have
+		recordLen = len(data) - 5
+	}
+	handshake := data[5 : 5+recordLen]
+	if len(handshake) < 4 {
+		return ""
+	}
+	// Handshake: type(1) + length(3) + ClientHello
+	hsLen := int(handshake[1])<<16 | int(handshake[2])<<8 | int(handshake[3])
+	if len(handshake) < 4+hsLen {
+		hsLen = len(handshake) - 4
+	}
+	ch := handshake[4 : 4+hsLen]
+	if len(ch) < 34 {
+		return ""
+	}
+	// Skip: version(2) + random(32)
+	pos := 34
+	// Session ID
+	if pos >= len(ch) {
+		return ""
+	}
+	sessLen := int(ch[pos])
+	pos += 1 + sessLen
+	// Cipher suites
+	if pos+2 > len(ch) {
+		return ""
+	}
+	csLen := int(ch[pos])<<8 | int(ch[pos+1])
+	pos += 2 + csLen
+	// Compression methods
+	if pos >= len(ch) {
+		return ""
+	}
+	cmLen := int(ch[pos])
+	pos += 1 + cmLen
+	// Extensions
+	if pos+2 > len(ch) {
+		return ""
+	}
+	extLen := int(ch[pos])<<8 | int(ch[pos+1])
+	pos += 2
+	extEnd := pos + extLen
+	if extEnd > len(ch) {
+		extEnd = len(ch)
+	}
+	for pos+4 <= extEnd {
+		extType := int(ch[pos])<<8 | int(ch[pos+1])
+		eLen := int(ch[pos+2])<<8 | int(ch[pos+3])
+		pos += 4
+		if pos+eLen > extEnd {
+			break
+		}
+		if extType == 0 { // SNI extension
+			sniData := ch[pos : pos+eLen]
+			if len(sniData) < 2 {
+				break
+			}
+			sniListLen := int(sniData[0])<<8 | int(sniData[1])
+			_ = sniListLen
+			sniPos := 2
+			for sniPos+3 <= len(sniData) {
+				nameType := sniData[sniPos]
+				nameLen := int(sniData[sniPos+1])<<8 | int(sniData[sniPos+2])
+				sniPos += 3
+				if sniPos+nameLen > len(sniData) {
+					break
+				}
+				if nameType == 0 { // host_name
+					return string(sniData[sniPos : sniPos+nameLen])
+				}
+				sniPos += nameLen
+			}
+		}
+		pos += eLen
+	}
+	return ""
+}
+
+// prefixConn wraps a net.Conn and prepends already-read bytes to the stream.
+type prefixConn struct {
+	net.Conn
+	prefix []byte
+	offset int
+}
+
+func (c *prefixConn) Read(b []byte) (int, error) {
+	if c.offset < len(c.prefix) {
+		n := copy(b, c.prefix[c.offset:])
+		c.offset += n
+		return n, nil
+	}
+	return c.Conn.Read(b)
+}
+
+// singleConnListener wraps a single connection as a net.Listener for http.Server.Serve.
+type singleConnListener struct {
+	conn net.Conn
+	done bool
+}
+
+func (l *singleConnListener) Accept() (net.Conn, error) {
+	if l.done {
+		return nil, io.EOF
+	}
+	l.done = true
+	return l.conn, nil
+}
+
+func (l *singleConnListener) Close() error   { return nil }
+func (l *singleConnListener) Addr() net.Addr { return l.conn.LocalAddr() }
 
 // ServeHTTP handles both CONNECT (for HTTPS MITM) and plain HTTP requests.
 func (p *GitHubProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -111,13 +362,46 @@ func (p *GitHubProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	p.forwardPlain(w, r)
 }
 
+// identifyAgent determines the agent name for a request. It prefers UID-based
+// identification (unforgeable) when iptables is active, falling back to
+// Proxy-Authorization headers for non-iptables deployments.
+func (p *GitHubProxy) identifyAgent(r *http.Request) string {
+	if p.uidMap != nil && p.uidMap.IptablesActive {
+		if name := p.identifyAgentByUID(r.RemoteAddr); name != "" {
+			return name
+		}
+	}
+	return extractAgentName(r)
+}
+
+// identifyAgentByUID reads /proc/net/tcp to find the UID of the process
+// that owns the socket connected to the proxy, then looks up the agent name.
+func (p *GitHubProxy) identifyAgentByUID(remoteAddr string) string {
+	_, portStr, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return ""
+	}
+	port := 0
+	for _, c := range portStr {
+		if c < '0' || c > '9' {
+			return ""
+		}
+		port = port*10 + int(c-'0')
+	}
+	uid, err := LookupUIDByLocalPort(port)
+	if err != nil {
+		return ""
+	}
+	return p.uidMap.LookupByUID(uid)
+}
+
 func (p *GitHubProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 	host, _, err := net.SplitHostPort(r.Host)
 	if err != nil {
 		host = r.Host
 	}
 
-	agentName := extractAgentName(r)
+	agentName := p.identifyAgent(r)
 
 	// Non-GitHub hosts: tunnel without inspection.
 	if !IsGitHubHost(host) {

--- a/v2/pkg/proxy/procnet.go
+++ b/v2/pkg/proxy/procnet.go
@@ -1,0 +1,71 @@
+package proxy
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const procNetTCPPath = "/proc/net/tcp"
+
+// LookupUIDByLocalPort reads /proc/net/tcp and returns the UID of the
+// process owning the socket bound to the given local port. Returns -1
+// if no match is found.
+//
+// Each line in /proc/net/tcp (after the header) has this layout:
+//
+//	sl  local_address rem_address   st tx_queue:rx_queue ... uid ...
+//	0:  0100007F:4803 0100007F:0050 01 00000000:00000000 ... 1001 ...
+//
+// local_address is hex IP:port. UID is field index 7 (0-based).
+func LookupUIDByLocalPort(port int) (int, error) {
+	return lookupUIDByLocalPortFrom(procNetTCPPath, port)
+}
+
+func lookupUIDByLocalPortFrom(path string, port int) (int, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return -1, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	hexPort := fmt.Sprintf("%04X", port)
+	scanner := bufio.NewScanner(f)
+
+	// Skip header line.
+	if !scanner.Scan() {
+		return -1, fmt.Errorf("empty %s", path)
+	}
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 8 {
+			continue
+		}
+
+		// fields[1] is "hex_ip:hex_port"
+		localAddr := fields[1]
+		colonIdx := strings.LastIndex(localAddr, ":")
+		if colonIdx < 0 {
+			continue
+		}
+		localPort := localAddr[colonIdx+1:]
+		if !strings.EqualFold(localPort, hexPort) {
+			continue
+		}
+
+		uid, err := strconv.Atoi(fields[7])
+		if err != nil {
+			continue
+		}
+		return uid, nil
+	}
+
+	return -1, fmt.Errorf("no socket found for local port %d", port)
+}

--- a/v2/pkg/proxy/procnet_test.go
+++ b/v2/pkg/proxy/procnet_test.go
@@ -1,0 +1,73 @@
+package proxy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Sample /proc/net/tcp content (simplified but structurally correct).
+// Fields: sl local_address rem_address st tx_queue:rx_queue tr:tm->when retrnsmt uid timeout inode
+const sampleProcNetTCP = `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 0100007F:4803 0100007F:0050 01 00000000:00000000 00:00000000 00000000  1001        0 12345 1 0000000000000000 100 0 0 10 0
+   1: 0100007F:C350 0100007F:4803 01 00000000:00000000 00:00000000 00000000  2001        0 12346 1 0000000000000000 100 0 0 10 0
+   2: 0100007F:C351 0100007F:4803 01 00000000:00000000 00:00000000 00000000  2002        0 12347 1 0000000000000000 100 0 0 10 0
+   3: 00000000:0BBB 00000000:0000 0A 00000000:00000000 00:00000000 00000000  2003        0 12348 1 0000000000000000 100 0 0 10 0
+`
+
+func TestLookupUIDByLocalPort(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tcp")
+	if err := os.WriteFile(path, []byte(sampleProcNetTCP), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		port    int
+		wantUID int
+		wantErr bool
+	}{
+		{name: "proxy port 0x4803=18435", port: 0x4803, wantUID: 1001},
+		{name: "agent on port 0xC350=50000", port: 0xC350, wantUID: 2001},
+		{name: "agent on port 0xC351=50001", port: 0xC351, wantUID: 2002},
+		{name: "listening socket 0x0BBB=3003", port: 0x0BBB, wantUID: 2003},
+		{name: "unknown port", port: 9999, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uid, err := lookupUIDByLocalPortFrom(path, tt.port)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got uid=%d", uid)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if uid != tt.wantUID {
+				t.Errorf("got uid=%d, want %d", uid, tt.wantUID)
+			}
+		})
+	}
+}
+
+func TestLookupUID_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tcp")
+	os.WriteFile(path, []byte(""), 0o644)
+
+	_, err := lookupUIDByLocalPortFrom(path, 80)
+	if err == nil {
+		t.Error("expected error for empty file")
+	}
+}
+
+func TestLookupUID_MissingFile(t *testing.T) {
+	_, err := lookupUIDByLocalPortFrom("/nonexistent/tcp", 80)
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}


### PR DESCRIPTION
## Summary

- Each agent runs under its own dynamically-allocated Linux UID (base 2001 + alphabetical offset)
- iptables NAT REDIRECT forces all outbound :443 through the MITM proxy — agents can't bypass via `unset HTTPS_PROXY`
- Proxy identifies agents by unforgeable source UID (`/proc/net/tcp` lookup) instead of spoofable HTTP headers
- Credential helper verifies agent identity via UID when running under agent UIDs (>= 2001)
- Graceful fallback: without NET_ADMIN capability, everything works as before (header-based auth)

## Changes

| File | What |
|------|------|
| `v2/pkg/agent/uidmap.go` | UID map: allocate, lookup, save/load |
| `v2/pkg/agent/uidmap_test.go` | 8 unit tests for UID map |
| `v2/pkg/proxy/procnet.go` | `/proc/net/tcp` parser for UID-by-port lookup |
| `v2/pkg/proxy/procnet_test.go` | 5 unit tests for procnet parser |
| `v2/deploy/entrypoint.sh` | Create per-agent users, write UID map, set up iptables |
| `v2/docker-compose.yaml` | Add `cap_add: NET_ADMIN` |
| `v2/Dockerfile` | Add `iptables` package |
| `v2/pkg/agent/manager.go` | Launch agents under per-agent UIDs via `setpriv`, isolated tmux sockets |
| `v2/pkg/proxy/github_proxy.go` | UID-based agent identification, transparent TLS proxy for iptables-redirected connections |
| `bin/git-credential-hive.sh` | UID verification — derive agent name from UID map, not env var |

## Design

- **No hardcoded UIDs** — derived at runtime from config YAML (alphabetical sort for determinism)
- **Three enforcement layers**: (1) iptables forces traffic through proxy, (2) proxy identifies by UID, (3) credential helper verifies UID
- **Per-agent tmux sockets** (`tmux -L hive-{name}`) isolate tmux namespaces
- **Transparent TLS handling**: iptables REDIRECT delivers raw TLS (not HTTP CONNECT); proxy detects TLS ClientHello via first-byte peek, extracts SNI for routing

## Test plan

- [ ] `go test ./v2/pkg/agent/ ./v2/pkg/proxy/` — unit tests pass
- [ ] `docker compose build` — image builds with iptables package
- [ ] Start with `NET_ADMIN` → verify `/var/run/hive/uid-map.json` has correct mappings
- [ ] `ps -eo uid,pid,cmd | grep claude` — each agent runs under its own UID
- [ ] `iptables -t nat -L HIVE_PROXY -n` — redirect rules in place
- [ ] Agent runs `unset HTTPS_PROXY && curl https://api.github.com` → still goes through proxy
- [ ] Start WITHOUT `NET_ADMIN` → falls back gracefully to header-based auth