### PR TITLE
fix: set SUID bit on gosu for non-root UID switching

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -13,7 +13,8 @@ FROM node:24-slim
 # --- Layer 1: system packages (rarely changes) ---
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git ca-certificates bash curl tmux bzip2 gosu iptables \
- && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* \
+ && chmod u+s /usr/sbin/gosu
 
 # Non-root user for agent processes (Claude Code refuses --dangerously-skip-permissions as root)
 # node:24-slim already has group 1000 (node), so reuse it


### PR DESCRIPTION
## Summary

- gosu needs the SUID bit (`chmod u+s`) to switch UIDs when called from the `dev` user (UID 1001)
- Without SUID, `gosu hive-scanner ...` fails with "operation not permitted" because the dev user has no `CAP_SETUID`
- This fixes the `exit status 1` errors preventing all agents from starting after #634

## Test plan

- [ ] `docker compose build` succeeds
- [ ] `docker exec -u dev hive gosu hive-scanner whoami` returns `hive-scanner`
- [ ] Agents launch under per-agent UIDs when kicked