### PR TITLE
fix: replace gosu with su-exec for UID isolation

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -12,9 +12,17 @@ FROM node:24-slim
 
 # --- Layer 1: system packages (rarely changes) ---
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git ca-certificates bash curl tmux bzip2 gosu iptables \
- && rm -rf /var/lib/apt/lists/* \
- && chmod u+s /usr/sbin/gosu
+    git ca-certificates bash curl tmux bzip2 gosu iptables gcc libc6-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# su-exec: lightweight setuid exec for UID switching from non-root.
+# gosu rejects SUID mode, so we use su-exec (which is designed for it)
+# for the manager's dev→agent UID switches.
+RUN curl -sL -o /tmp/su-exec.c https://raw.githubusercontent.com/ncopa/su-exec/master/su-exec.c \
+ && gcc -Wall -o /usr/local/bin/su-exec /tmp/su-exec.c \
+ && chmod u+s /usr/local/bin/su-exec \
+ && rm /tmp/su-exec.c \
+ && apt-get purge -y gcc libc6-dev && apt-get autoremove -y
 
 # Non-root user for agent processes (Claude Code refuses --dangerously-skip-permissions as root)
 # node:24-slim already has group 1000 (node), so reuse it

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -193,15 +193,13 @@ func (m *Manager) tmuxBaseArgs(agent *AgentProcess) []string {
 	return []string{"tmux"}
 }
 
-// tmuxCmd builds an exec.Cmd for tmux with agent-specific socket args + the given subcommand args.
-// When UID isolation is active, wraps in gosu so the dev user can access the agent's tmux socket.
 func (m *Manager) tmuxCmd(agent *AgentProcess, args ...string) *exec.Cmd {
 	base := m.tmuxBaseArgs(agent)
 	tmuxArgs := append(base[1:], args...)
 	if agent.UID > 0 {
 		agentUser := fmt.Sprintf("hive-%s", agent.Name)
-		gosuArgs := append([]string{agentUser, base[0]}, tmuxArgs...)
-		return exec.Command("gosu", gosuArgs...)
+		suExecArgs := append([]string{agentUser, base[0]}, tmuxArgs...)
+		return exec.Command("su-exec", suExecArgs...)
 	}
 	return exec.Command(base[0], tmuxArgs...)
 }
@@ -216,15 +214,12 @@ func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
 		return fmt.Errorf("creating agent work dir %s: %w", agentDir, err)
 	}
 
-	// When UID isolation is active, launch the tmux session under the agent's UID
-	// using gosu (SUID root, works from non-root). This creates an isolated tmux
-	// server per agent.
 	var cmd *exec.Cmd
 	if agent.UID > 0 {
 		agentUser := fmt.Sprintf("hive-%s", agent.Name)
-		gosuArgs := []string{"gosu", agentUser}
+		suExecArgs := []string{"su-exec", agentUser}
 		tmuxArgs := append(m.tmuxBaseArgs(agent), "new-session", "-d", "-s", agent.tmuxSession, "-c", agentDir)
-		cmd = exec.Command(gosuArgs[0], append(gosuArgs[1:], tmuxArgs...)...)
+		cmd = exec.Command(suExecArgs[0], append(suExecArgs[1:], tmuxArgs...)...)
 	} else {
 		cmd = exec.Command("tmux", "new-session", "-d", "-s", agent.tmuxSession, "-c", agentDir)
 	}


### PR DESCRIPTION
## Summary
- gosu refuses to run when installed with the SUID bit set (it detects this and exits with an error), causing the container to crash-loop after PR #635
- Replace gosu with `su-exec` for the manager's dev→agent UID switches — su-exec is designed for SUID operation
- Build su-exec from source in Dockerfile (single C file), set SUID on it
- Entrypoint keeps using gosu (no SUID needed — it's called from root)
- Remove gcc/libc6-dev after building to keep image size down

## Test plan
- [ ] Container starts without crash-looping
- [ ] `docker exec hive su-exec hive-scanner whoami` returns `hive-scanner`
- [ ] Agents launch under per-agent UIDs
- [ ] iptables rules still active

Fixes the crash-loop introduced by PR #635's `chmod u+s /usr/sbin/gosu`.