### PR TITLE
fix: restore dashboard overrides and fix agent shell

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -269,14 +269,13 @@ func main() {
 			if as.PinnedModel != "" {
 				_ = agentMgr.PinModel(name, as.PinnedModel)
 			}
-			// Model/backend overrides are intentionally NOT restored from
-			// persisted state — YAML is authoritative on restart. Overrides
-			// set via the dashboard API are session-only.
 			if as.ModelOverride != "" {
-				logger.Info("ignoring persisted model override (YAML is authoritative)", "agent", name, "override", as.ModelOverride)
+				agentMgr.SetModelOverride(name, as.ModelOverride)
+				logger.Info("model override restored", "agent", name, "model", as.ModelOverride)
 			}
 			if as.BackendOverride != "" {
-				logger.Info("ignoring persisted backend override (YAML is authoritative)", "agent", name, "override", as.BackendOverride)
+				agentMgr.SetBackendOverride(name, as.BackendOverride)
+				logger.Info("backend override restored", "agent", name, "backend", as.BackendOverride)
 			}
 			if as.RestartCount > 0 {
 				agentMgr.SeedRestartCount(name, as.RestartCount)
@@ -320,10 +319,21 @@ func main() {
 		if len(saved.BudgetIgnored) > 0 {
 			gov.SetBudgetIgnored(saved.BudgetIgnored)
 		}
-		// Cadence overrides are intentionally NOT restored — YAML is
-		// authoritative on restart. Dashboard cadence tweaks are session-only.
 		if len(saved.CadenceOverrides) > 0 {
-			logger.Info("ignoring persisted cadence overrides (YAML is authoritative)", "modes", len(saved.CadenceOverrides))
+			for modeName, agentCadences := range saved.CadenceOverrides {
+				mode, ok := cfg.Governor.Modes[modeName]
+				if !ok {
+					continue
+				}
+				if mode.Cadences == nil {
+					mode.Cadences = make(map[string]string)
+				}
+				for agentName, cadence := range agentCadences {
+					mode.Cadences[agentName] = cadence
+				}
+				cfg.Governor.Modes[modeName] = mode
+			}
+			logger.Info("cadence overrides restored", "modes", len(saved.CadenceOverrides))
 		}
 		if saved.GovernorMode != "" {
 			gov.SetMode(governor.Mode(saved.GovernorMode))

--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -110,7 +110,7 @@ print('\n'.join(sorted(names)))
       [ -z "$agent_name" ] && continue
       AGENT_UID=$((HIVE_UID_BASE + UID_OFFSET))
       if ! id "hive-${agent_name}" >/dev/null 2>&1; then
-        useradd --system -u "$AGENT_UID" -g node -M -s /usr/sbin/nologin "hive-${agent_name}" 2>/dev/null || true
+        useradd --system -u "$AGENT_UID" -g node -M -s /bin/bash "hive-${agent_name}" 2>/dev/null || true
       fi
       mkdir -p "/data/agents/${agent_name}"
       chown "hive-${agent_name}:node" "/data/agents/${agent_name}" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Two fixes for per-agent UID isolation:

### 1. Agent users created with nologin shell
Agent users were created with `/usr/sbin/nologin` which causes tmux sessions to exit immediately — nologin is the default shell so tmux starts it, it exits, killing the session before the agent CLI can launch. Agents appeared to start (logs showed "tmux session created" and "agent launched") but sessions died within seconds. Governor kicks then failed with "tmux session not found".

**Fix**: Create agent users with `/bin/bash` instead of `/usr/sbin/nologin`.

### 2. Dashboard overrides not restored on restart
Dashboard-set cadence overrides, model overrides, and backend overrides were saved to `hive-state.json` but explicitly ignored on restore (comments said "YAML is authoritative"). Any dashboard config changes were lost on container restart.

**Fix**: Restore all three override types from persisted state, matching the behavior of other persisted fields (paused state, budget, kick history).

## Test plan
- [ ] Agents stay alive in tmux sessions after container start
- [ ] Governor kicks succeed (no "tmux session not found" errors)
- [ ] Change a cadence via dashboard → restart → verify it persists
- [ ] Logs show "cadence overrides restored" on startup