### PR TITLE
fix: create home directories for per-agent users

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -110,10 +110,10 @@ print('\n'.join(sorted(names)))
       [ -z "$agent_name" ] && continue
       AGENT_UID=$((HIVE_UID_BASE + UID_OFFSET))
       if ! id "hive-${agent_name}" >/dev/null 2>&1; then
-        useradd --system -u "$AGENT_UID" -g node -M -s /bin/bash "hive-${agent_name}" 2>/dev/null || true
+        useradd --system -u "$AGENT_UID" -g node -m -s /bin/bash "hive-${agent_name}" 2>/dev/null || true
       fi
-      mkdir -p "/data/agents/${agent_name}"
-      chown "hive-${agent_name}:node" "/data/agents/${agent_name}" 2>/dev/null || true
+      mkdir -p "/home/hive-${agent_name}" "/data/agents/${agent_name}"
+      chown "hive-${agent_name}:node" "/home/hive-${agent_name}" "/data/agents/${agent_name}" 2>/dev/null || true
       echo "[entrypoint] Agent user: hive-${agent_name} (UID ${AGENT_UID})"
       UID_OFFSET=$((UID_OFFSET + 1))
     done


### PR DESCRIPTION
## Summary
- Copilot CLI fails with `EACCES: permission denied, mkdir '/home/hive-supervisor'` because agent users have no home directory
- The `useradd -M` flag skipped home dir creation; switched to `-m` and added explicit `mkdir/chown` for restarts where the user already exists

## Test plan
- [ ] `docker exec hive ls -la /home/hive-supervisor` shows directory owned by hive-supervisor
- [ ] Agent CLI launches without EACCES errors
- [ ] Governor kicks succeed