### PR TITLE
fix: set HOME=/data/home for per-agent UIDs

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -50,17 +50,14 @@ if [ "$(id -u)" = "0" ]; then
     chown -R dev:node /data/beads /home/dev 2>/dev/null || true
   fi
 
-  # Persist Copilot/Claude CLI auth across container restarts
+  # Shared CLI auth/cache lives in /data/home (persistent volume).
+  # Make it group-writable so all agent UIDs (node group) can use it.
+  # The manager sets HOME=/data/home for agent tmux sessions.
   mkdir -p /data/home /data/config/github-copilot /home/dev/.config
   ln -sfn /data/config/github-copilot /home/dev/.config/github-copilot
-  for shared in .copilot .claude .claude.json .cache/copilot; do
-    if [ -e "/data/home/${shared}" ]; then
-      mkdir -p "/home/dev/$(dirname "${shared}")"
-      ln -sfn "/data/home/${shared}" "/home/dev/${shared}"
-    fi
-  done
+  chmod -R g+rw /data/home 2>/dev/null || true
   chown -R dev:node /data/config /data/home /home/dev/.config 2>/dev/null || true
-  echo "[entrypoint] CLI config linked from /data/home"
+  echo "[entrypoint] CLI config: /data/home (shared, group-writable for agent UIDs)"
 
   # ── Per-agent UID isolation ──────────────────────────────────────────
   # Extract agent names from config + pack YAML, create system users,
@@ -119,16 +116,7 @@ print('\n'.join(sorted(names)))
         useradd --system -u "$AGENT_UID" -g node -m -s /bin/bash "hive-${agent_name}" 2>/dev/null || true
       fi
       mkdir -p "/home/hive-${agent_name}" "/data/agents/${agent_name}"
-      # Share CLI auth/config from /data/home so all agent UIDs can authenticate
-      mkdir -p "/home/hive-${agent_name}/.config"
-      ln -sfn /data/config/github-copilot "/home/hive-${agent_name}/.config/github-copilot"
-      for shared in .copilot .claude .claude.json .cache/copilot; do
-        if [ -e "/data/home/${shared}" ]; then
-          mkdir -p "/home/hive-${agent_name}/$(dirname "${shared}")"
-          ln -sfn "/data/home/${shared}" "/home/hive-${agent_name}/${shared}"
-        fi
-      done
-      chown -R "hive-${agent_name}:node" "/home/hive-${agent_name}" "/data/agents/${agent_name}" 2>/dev/null || true
+      chown "hive-${agent_name}:node" "/home/hive-${agent_name}" "/data/agents/${agent_name}" 2>/dev/null || true
       echo "[entrypoint] Agent user: hive-${agent_name} (UID ${AGENT_UID})"
       UID_OFFSET=$((UID_OFFSET + 1))
     done

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1547,6 +1547,10 @@ func (m *Manager) agentEnvVars(agent *AgentProcess) []string {
 	if m.copilotAuthToken != "" {
 		vars = append(vars, shellEnvVar("COPILOT_GITHUB_TOKEN", m.copilotAuthToken))
 	}
+	// Per-agent UIDs share CLI auth/cache from /data/home
+	if agent.UID > 0 {
+		vars = append(vars, shellEnvVar("HOME", "/data/home"))
+	}
 	return vars
 }
 


### PR DESCRIPTION
## Summary
- PR #639 symlinked individual CLI dirs (.copilot, .cache/copilot) but agents got EACCES trying to write to the shared cache (extracting new CLI version)
- Fix: set `HOME=/data/home` in tmux environment for agent sessions (restores pre-UID-isolation behavior) and make `/data/home` group-writable for node group
- Removes per-agent symlink complexity — agents just use /data/home directly
- Supersedes the symlink approach from #639

## Test plan
- [ ] All 5 agents authenticate and run without EACCES or login prompts
- [ ] `docker exec hive su-exec hive-supervisor env | grep HOME` shows `/data/home`
- [ ] CLI cache extraction succeeds (no permission errors)