### PR TITLE
fix: set agent passwd home to /data/home for CLI auth

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -113,10 +113,10 @@ print('\n'.join(sorted(names)))
       [ -z "$agent_name" ] && continue
       AGENT_UID=$((HIVE_UID_BASE + UID_OFFSET))
       if ! id "hive-${agent_name}" >/dev/null 2>&1; then
-        useradd --system -u "$AGENT_UID" -g node -m -s /bin/bash "hive-${agent_name}" 2>/dev/null || true
+        useradd --system -u "$AGENT_UID" -g node -d /data/home -M -s /bin/bash "hive-${agent_name}" 2>/dev/null || true
       fi
-      mkdir -p "/home/hive-${agent_name}" "/data/agents/${agent_name}"
-      chown "hive-${agent_name}:node" "/home/hive-${agent_name}" "/data/agents/${agent_name}" 2>/dev/null || true
+      mkdir -p "/data/agents/${agent_name}"
+      chown "hive-${agent_name}:node" "/data/agents/${agent_name}" 2>/dev/null || true
       echo "[entrypoint] Agent user: hive-${agent_name} (UID ${AGENT_UID})"
       UID_OFFSET=$((UID_OFFSET + 1))
     done


### PR DESCRIPTION
## Summary
- Copilot CLI resolves home dir from `/etc/passwd` during early Node.js SEA bootstrap, before shell `HOME` env var takes effect
- Agent users had `/home/hive-*` as their passwd home, causing EACCES when the CLI tried to extract its package cache there
- PR #641 set `HOME=/data/home` via tmux env but that only affects new tmux windows, not the initial shell
- Fix: `useradd -d /data/home -M` sets passwd home to `/data/home` (the shared persistent volume) so the CLI finds auth and cache at the right path from the start
- Also makes `/data/home` group-writable for the `node` group so all agent UIDs can write to the shared cache

## Test plan
- [ ] `grep hive-scanner /etc/passwd` shows `/data/home` as home dir
- [ ] All 5 agents launch without EACCES or login prompt errors
- [ ] CLI package extraction succeeds into `/data/home/.cache/copilot/`
- [ ] Agent terminal sessions show active Copilot CLI (not bare shell prompts)