### PR TITLE
feat: persist dashboard view across page reload

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1804,6 +1804,7 @@
     const OC_TOPBAR_HEIGHT = 64;
     let _ocSelectedAgent = localStorage.getItem('hive-oc-agent') || null;
     let _ocPaneTimer = null;
+    let _ocViewRestored = false;
     const OC_PANE_POLL_MS = 3000;
     const OC_PANE_LINES = 2000;
 
@@ -1833,17 +1834,20 @@
       } catch {}
     }
 
-    function ocNavigate(section) {
+    function ocNavigate(section, skipScroll) {
       _ocSelectedAgent = null;
       localStorage.setItem('hive-oc-agent', '');
+      localStorage.setItem('hive-oc-section', section);
       ocStopPanePoll();
       const detail = document.getElementById('oc-agent-detail');
       if (detail) { detail.classList.remove('active'); detail.innerHTML = ''; }
       ocUpdateFocusedState();
-      const el = document.getElementById(section);
-      if (el) {
-        const y = el.getBoundingClientRect().top + window.scrollY - OC_TOPBAR_HEIGHT;
-        window.scrollTo({ top: y, behavior: 'smooth' });
+      if (!skipScroll) {
+        const el = document.getElementById(section);
+        if (el) {
+          const y = el.getBoundingClientRect().top + window.scrollY - OC_TOPBAR_HEIGHT;
+          window.scrollTo({ top: y, behavior: 'smooth' });
+        }
       }
       document.querySelectorAll('.oc-nav-item').forEach(i => i.classList.remove('active'));
       const active = document.querySelector(`.oc-nav-item[data-section="${section}"]`);
@@ -1876,6 +1880,7 @@
     function ocSelectAgent(name) {
       _ocSelectedAgent = name;
       localStorage.setItem('hive-oc-agent', name || '');
+      localStorage.setItem('hive-oc-section', '');
       document.querySelectorAll('.oc-nav-item').forEach(i => i.classList.remove('active'));
       const active = document.querySelector(`.oc-nav-item[data-agent-nav="${name}"]`);
       if (active) active.classList.add('active');
@@ -5625,7 +5630,17 @@ function burnAreaChart() {
       renderRepos(data.repos || []);
       renderBeads(data.beads || {});
       ocUpdateSidebarAgents();
-      if (_ocSelectedAgent) { ocRenderAgentDetail(); ocUpdateFocusedState(); ocStartPanePoll(); }
+      if (!_ocViewRestored) {
+        _ocViewRestored = true;
+        if (_ocSelectedAgent) {
+          ocSelectAgent(_ocSelectedAgent);
+        } else {
+          const savedSection = localStorage.getItem('hive-oc-section');
+          if (savedSection) ocNavigate(savedSection);
+        }
+      } else if (_ocSelectedAgent) {
+        ocRenderAgentDetail(); ocUpdateFocusedState(); ocStartPanePoll();
+      }
       renderDebugSection();
       updateACMMBadge(data.acmmLevel || 0, data.acmmPackAgents || null);
       window.scrollTo(0, scrollY);


### PR DESCRIPTION
## Summary
- Save current view (selected agent or sidebar section) to localStorage
- On page reload, restore the last active view after first WS data render
- Agent selection already persisted via `hive-oc-agent`; now section navigation (Governor, Advisory, Tokens, etc.) also persists via `hive-oc-section`
- Uses a one-shot `_ocViewRestored` flag to restore only on first render

## Test plan
- [ ] Click on an agent (e.g. scanner) → reload page → should return to scanner in-focus view
- [ ] Click on a section (e.g. Advisory) → reload page → should return to Advisory section with correct nav highlight
- [ ] Click Governor (default) → reload → should stay on Governor
- [ ] Normal navigation between agents/sections should work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)