### PR TITLE
fix: prevent scroll reset when restoring saved view on reload

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1805,6 +1805,7 @@
     let _ocSelectedAgent = localStorage.getItem('hive-oc-agent') || null;
     let _ocPaneTimer = null;
     let _ocViewRestored = false;
+    let _ocSkipScrollRestore = false;
     const OC_PANE_POLL_MS = 3000;
     const OC_PANE_LINES = 2000;
 
@@ -5633,17 +5634,19 @@ function burnAreaChart() {
       if (!_ocViewRestored) {
         _ocViewRestored = true;
         if (_ocSelectedAgent) {
+          _ocSkipScrollRestore = true;
           ocSelectAgent(_ocSelectedAgent);
         } else {
           const savedSection = localStorage.getItem('hive-oc-section');
-          if (savedSection) ocNavigate(savedSection);
+          if (savedSection) { _ocSkipScrollRestore = true; ocNavigate(savedSection); }
         }
       } else if (_ocSelectedAgent) {
         ocRenderAgentDetail(); ocUpdateFocusedState(); ocStartPanePoll();
       }
       renderDebugSection();
       updateACMMBadge(data.acmmLevel || 0, data.acmmPackAgents || null);
-      window.scrollTo(0, scrollY);
+      if (!_ocSkipScrollRestore) window.scrollTo(0, scrollY);
+      _ocSkipScrollRestore = false;
     }
 
     const HEALTH_LABEL_DEFAULTS = {


### PR DESCRIPTION
## Summary
- Follow-up to #643 (persist view on reload)
- The WS handler captures `scrollY` at the start and restores it after rendering
- On first page load `scrollY` is 0, so after `ocSelectAgent` scrolled to the detail panel, the handler immediately reset scroll back to top — making the restore appear broken
- Adds a one-shot `_ocSkipScrollRestore` flag that lets the navigation scroll win on the first render

## Test plan
- [ ] Click scanner agent → reload → should scroll to and show scanner in-focus view
- [ ] Click Advisory section → reload → should scroll to Advisory Digest
- [ ] Normal WS updates should still preserve scroll position (no jitter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)