### PR TITLE
fix: ttyd-tmux.sh finds per-agent tmux sockets across UIDs

### DIFF
--- a/v2/deploy/ttyd-tmux.sh
+++ b/v2/deploy/ttyd-tmux.sh
@@ -1,13 +1,36 @@
 #!/bin/bash
 set -euo pipefail
 
-# ttyd runs as root but tmux sessions are owned by dev (uid 1001).
-# TMUX_TMPDIR doesn't work here because tmux appends tmux-$UID/ to it,
-# producing the wrong path. Use -S with the exact socket path instead.
-DEV_UID=$(id -u dev 2>/dev/null || echo "1001")
-TMUX_SOCKET="/tmp/tmux-${DEV_UID}/default"
+# ttyd runs as root but tmux sessions are owned by per-agent UIDs.
+# Agents are launched with `tmux -L hive-{name}` under `su-exec hive-{name}`,
+# creating sockets at /tmp/tmux-{agent_uid}/hive-{name}. Since agent UIDs
+# vary (2001-2005+), we search across all /tmp/tmux-*/ directories for the
+# matching socket. For agents without UID isolation (e.g. supervisor running
+# as dev), the session lives on the default socket at /tmp/tmux-{dev_uid}/default.
 
 SESSION=${1:-supervisor}
+
+# Find the per-agent socket: /tmp/tmux-*/${SESSION}
+# The glob matches across all UID directories.
+TMUX_SOCKET=""
+for sock in /tmp/tmux-*/"${SESSION}"; do
+  if [ -S "$sock" ]; then
+    TMUX_SOCKET="$sock"
+    break
+  fi
+done
+
+# Fallback: session may be on the default tmux server (no UID isolation).
+if [ -z "$TMUX_SOCKET" ]; then
+  DEV_UID=$(id -u dev 2>/dev/null || echo "1001")
+  TMUX_SOCKET="/tmp/tmux-${DEV_UID}/default"
+fi
+
+if [ ! -S "$TMUX_SOCKET" ]; then
+  echo "error: no tmux socket found for session '${SESSION}'" >&2
+  exit 1
+fi
+
 PREV_MOUSE=$(tmux -S "$TMUX_SOCKET" show-option -t "$SESSION" -v mouse 2>/dev/null || echo "on")
 tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse off 2>/dev/null || true
 EXIT_CODE=0


### PR DESCRIPTION
## Summary
- Agents now use per-agent tmux sockets (`tmux -L hive-{name}`) under separate UIDs (2001-2005+), placing sockets at `/tmp/tmux-{uid}/hive-{name}`
- The old script hardcoded `/tmp/tmux-{dev_uid}/default`, so ttyd could never find any agent sessions — the terminal button in the dashboard was broken
- Now searches `/tmp/tmux-*/{SESSION}` to locate the correct socket regardless of owning UID, with fallback to the dev user's default socket for non-isolated agents

## Test plan
- [ ] Start hive with UID-isolated agents, click terminal button for each agent in the dashboard — should attach to the correct tmux session
- [ ] Verify supervisor (no UID isolation) still works via the default socket fallback
- [ ] Verify error message when no socket exists for a given session name