### PR TITLE
fix: per-agent UID directory permissions for CLI auth and ttyd

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -55,7 +55,7 @@ if [ "$(id -u)" = "0" ]; then
   # The manager sets HOME=/data/home for agent tmux sessions.
   mkdir -p /data/home /data/config/github-copilot /home/dev/.config
   ln -sfn /data/config/github-copilot /home/dev/.config/github-copilot
-  chmod -R g+rw /data/home 2>/dev/null || true
+  chmod -R g+rwX /data/home 2>/dev/null || true
   chown -R dev:node /data/config /data/home /home/dev/.config 2>/dev/null || true
   echo "[entrypoint] CLI config: /data/home (shared, group-writable for agent UIDs)"
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -227,6 +227,13 @@ func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
 		return fmt.Errorf("creating tmux session for %s: %w", agent.Name, err)
 	}
 
+	// tmux creates /tmp/tmux-{uid}/ with mode 700; ttyd runs as dev (uid 1001,
+	// node group) and needs to traverse into these dirs to attach to sockets.
+	if agent.UID > 0 {
+		tmuxDir := fmt.Sprintf("/tmp/tmux-%d", agent.UID)
+		_ = os.Chmod(tmuxDir, 0o710)
+	}
+
 	// Set per-session env vars via tmux set-environment.
 	for _, envVar := range m.agentEnvVars(agent) {
 		parts := strings.SplitN(envVar, "=", 2)


### PR DESCRIPTION
## Summary
- **entrypoint.sh**: `chmod -R g+rw` → `chmod -R g+rwX` on `/data/home` — adds execute bit to directories so per-agent UIDs can traverse into `.copilot/` and `.claude/` subdirectories. Without the `x` bit, Copilot CLI silently exits with code 1 (can't read `session-store.db`).
- **manager.go**: `chmod 710` on `/tmp/tmux-{uid}/` after tmux session creation — ttyd runs as dev (uid 1001, node group) and needs group-execute to traverse into per-agent tmux socket directories for the terminal session button.

## Root Cause
`chmod -R g+rw` adds group read+write but NOT execute. Directories require the execute bit for traversal — without it, group members get "Permission denied" even though they can see the directory listing. Capital `X` only adds execute to directories (not files), which is the correct behavior.

## Test plan
- [ ] After deploy, verify terminal session button connects to agent sessions
- [ ] Verify Copilot CLI starts successfully (no silent exit code 1)
- [ ] `ls -la /data/home/.copilot/` from agent session shows accessible files
- [ ] `stat /tmp/tmux-*/` shows mode 710 (drwx--x---)