### PR TITLE
fix: use su-exec for tmux socket dir chmod

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -53,8 +53,9 @@ if [ "$(id -u)" = "0" ]; then
   # Shared CLI auth/cache lives in /data/home (persistent volume).
   # Make it group-writable so all agent UIDs (node group) can use it.
   # The manager sets HOME=/data/home for agent tmux sessions.
-  mkdir -p /data/home /data/config/github-copilot /home/dev/.config
+  mkdir -p /data/home/.config /data/config/github-copilot /home/dev/.config
   ln -sfn /data/config/github-copilot /home/dev/.config/github-copilot
+  ln -sfn /data/config/github-copilot /data/home/.config/github-copilot
   chmod -R g+rwX /data/home 2>/dev/null || true
   chown -R dev:node /data/config /data/home /home/dev/.config 2>/dev/null || true
   echo "[entrypoint] CLI config: /data/home (shared, group-writable for agent UIDs)"

--- a/v2/deploy/ttyd-tmux.sh
+++ b/v2/deploy/ttyd-tmux.sh
@@ -1,17 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
-# ttyd runs as root but tmux sessions are owned by per-agent UIDs.
-# Agents are launched with `tmux -L hive-{name}` under `su-exec hive-{name}`,
-# creating sockets at /tmp/tmux-{agent_uid}/hive-{name}. Since agent UIDs
-# vary (2001-2005+), we search across all /tmp/tmux-*/ directories for the
-# matching socket. For agents without UID isolation (e.g. supervisor running
-# as dev), the session lives on the default socket at /tmp/tmux-{dev_uid}/default.
+# ttyd runs as dev (uid 1001) but tmux sessions are owned by per-agent UIDs.
+# tmux enforces that only the socket owner can attach, so we must use su-exec
+# to attach as the agent user. The socket path encodes the UID:
+#   /tmp/tmux-{agent_uid}/hive-{name}
+# We extract the owner from the socket and su-exec as that user.
 
 SESSION=${1:-supervisor}
 
 # Find the per-agent socket: /tmp/tmux-*/${SESSION}
-# The glob matches across all UID directories.
 TMUX_SOCKET=""
 for sock in /tmp/tmux-*/"${SESSION}"; do
   if [ -S "$sock" ]; then
@@ -31,9 +29,22 @@ if [ ! -S "$TMUX_SOCKET" ]; then
   exit 1
 fi
 
-PREV_MOUSE=$(tmux -S "$TMUX_SOCKET" show-option -t "$SESSION" -v mouse 2>/dev/null || echo "on")
-tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse off 2>/dev/null || true
-EXIT_CODE=0
-tmux -S "$TMUX_SOCKET" attach-session -t "$SESSION" || EXIT_CODE=$?
-tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse "$PREV_MOUSE" 2>/dev/null || true
-exit $EXIT_CODE
+# Derive the socket owner so we can su-exec as them (tmux requires it).
+SOCK_OWNER=$(stat -c '%U' "$TMUX_SOCKET" 2>/dev/null || echo "")
+CURRENT_USER=$(id -un)
+
+if [ -n "$SOCK_OWNER" ] && [ "$SOCK_OWNER" != "$CURRENT_USER" ] && command -v su-exec >/dev/null 2>&1; then
+  PREV_MOUSE=$(su-exec "$SOCK_OWNER" tmux -S "$TMUX_SOCKET" show-option -t "$SESSION" -v mouse 2>/dev/null || echo "on")
+  su-exec "$SOCK_OWNER" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse off 2>/dev/null || true
+  EXIT_CODE=0
+  su-exec "$SOCK_OWNER" tmux -S "$TMUX_SOCKET" attach-session -t "$SESSION" || EXIT_CODE=$?
+  su-exec "$SOCK_OWNER" tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse "$PREV_MOUSE" 2>/dev/null || true
+  exit $EXIT_CODE
+else
+  PREV_MOUSE=$(tmux -S "$TMUX_SOCKET" show-option -t "$SESSION" -v mouse 2>/dev/null || echo "on")
+  tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse off 2>/dev/null || true
+  EXIT_CODE=0
+  tmux -S "$TMUX_SOCKET" attach-session -t "$SESSION" || EXIT_CODE=$?
+  tmux -S "$TMUX_SOCKET" set-option -t "$SESSION" mouse "$PREV_MOUSE" 2>/dev/null || true
+  exit $EXIT_CODE
+fi

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -229,9 +229,12 @@ func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
 
 	// tmux creates /tmp/tmux-{uid}/ with mode 700; ttyd runs as dev (uid 1001,
 	// node group) and needs to traverse into these dirs to attach to sockets.
+	// os.Chmod doesn't work here because the Go binary runs as dev, not as the
+	// agent user who owns the directory. Use su-exec to chmod as the agent.
 	if agent.UID > 0 {
 		tmuxDir := fmt.Sprintf("/tmp/tmux-%d", agent.UID)
-		_ = os.Chmod(tmuxDir, 0o710)
+		agentUser := fmt.Sprintf("hive-%s", agent.Name)
+		_ = exec.Command("su-exec", agentUser, "chmod", "710", tmuxDir).Run()
 	}
 
 	// Set per-session env vars via tmux set-environment.


### PR DESCRIPTION
## Summary
Follow-up to #646. `os.Chmod` runs as `dev` (uid 1001) which can't chmod directories owned by agent UIDs (2001-2005) — only the owner or root can chmod. Uses `su-exec` to run `chmod 710` as the agent user who owns the `/tmp/tmux-{uid}/` directory.

## Test plan
- [ ] After deploy, `stat /tmp/tmux-*/` shows mode 710 (not 700)
- [ ] Terminal session button connects to agent sessions