### PR TITLE
fix: allow OAuth device-flow through MITM proxy

### DIFF
--- a/v2/pkg/proxy/rules.go
+++ b/v2/pkg/proxy/rules.go
@@ -31,6 +31,11 @@ func IsGitHubHost(host string) bool {
 // Order matters: more-specific patterns must come before less-specific ones
 // for the same method, because evaluation is first-match-wins.
 var rules = []ProxyRule{
+	// ── OAuth / device-flow login — all modes ──
+	// Copilot CLI /login needs these to authenticate via GitHub device flow.
+	{regexp.MustCompile(`^/login/device/code$`), "POST", agent.ModeAdvisory},
+	{regexp.MustCompile(`^/login/oauth/access_token$`), "POST", agent.ModeAdvisory},
+
 	// ── Merge — ISSUES_PRS_MERGE only ──
 	// Must come before the generic pulls PATCH/PUT rules.
 	{regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls/\d+/merge$`), "PUT", agent.ModeIssuesPRsMerge},


### PR DESCRIPTION
## Summary
Copilot CLI `/login` POSTs to `/login/device/code` and `/login/oauth/access_token` on `github.com`. The MITM proxy had no rules for these paths, so they were denied by default — causing `TypeError: fetch failed` and `ECONNRESET` errors during login.

Adds two rules at `ModeAdvisory` (lowest) so all agents can authenticate without needing to `unset HTTPS_PROXY`.

## Test plan
- [ ] From a terminal session, run `/login` in Copilot — should get device code without fetch errors
- [ ] Complete the OAuth flow — auth persists in `/data/config/github-copilot/`
- [ ] Agents restart without needing re-login