### PR TITLE
fix: CONNECT proxy ECONNRESET — write 200 on hijacked conn

### DIFF
--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -424,15 +424,20 @@ func (p *GitHubProxy) handleConnect(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Tell client the tunnel is established.
-	w.WriteHeader(http.StatusOK)
-
 	clientConn, _, err := hijacker.Hijack()
 	if err != nil {
 		p.logger.Error("proxy hijack error", "error", err)
 		return
 	}
 	defer clientConn.Close()
+
+	// Tell client the tunnel is established — must be written directly
+	// on the hijacked connection, not via ResponseWriter (which may not
+	// flush before hijack).
+	if _, err := fmt.Fprintf(clientConn, "HTTP/1.1 200 Connection established\r\n\r\n"); err != nil {
+		p.logger.Error("proxy CONNECT response write failed", "error", err)
+		return
+	}
 
 	// Generate a cert for the target host signed by our CA.
 	tlsCert, err := p.forgeCert(host)
@@ -570,13 +575,13 @@ func (p *GitHubProxy) tunnel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
-
 	clientConn, _, err := hijacker.Hijack()
 	if err != nil {
 		upstream.Close()
 		return
 	}
+
+	fmt.Fprintf(clientConn, "HTTP/1.1 200 Connection established\r\n\r\n")
 
 	go transfer(upstream, clientConn)
 	go transfer(clientConn, upstream)

--- a/v2/pkg/proxy/rules.go
+++ b/v2/pkg/proxy/rules.go
@@ -31,6 +31,11 @@ func IsGitHubHost(host string) bool {
 // Order matters: more-specific patterns must come before less-specific ones
 // for the same method, because evaluation is first-match-wins.
 var rules = []ProxyRule{
+	// ── OAuth / device-flow login — all modes ──
+	// Copilot CLI /login needs these to authenticate via GitHub device flow.
+	{regexp.MustCompile(`^/login/device/code$`), "POST", agent.ModeAdvisory},
+	{regexp.MustCompile(`^/login/oauth/access_token$`), "POST", agent.ModeAdvisory},
+
 	// ── Merge — ISSUES_PRS_MERGE only ──
 	// Must come before the generic pulls PATCH/PUT rules.
 	{regexp.MustCompile(`^/repos/[^/]+/[^/]+/pulls/\d+/merge$`), "PUT", agent.ModeIssuesPRsMerge},


### PR DESCRIPTION
## Summary
- Fix ECONNRESET on all HTTPS CONNECT requests through the MITM proxy
- Root cause: `ResponseWriter.WriteHeader(200)` buffers the response internally; when `Hijack()` is called immediately after, the 200 bytes never reach the client — the client sees raw TLS handshake data instead and resets
- Fix: hijack first, then write `HTTP/1.1 200 Connection established\r\n\r\n` directly on the raw connection
- Applied to both `handleConnect` (GitHub MITM path) and `tunnel` (non-GitHub passthrough path)

This fixes Copilot `/login` failing with "TypeError: fetch failed" (ECONNRESET) when the proxy is active. The OAuth device-flow rules from #648 were correct but never reached — connections died at the CONNECT level before any HTTP request was parsed.

## Test plan
- [ ] Container deploys via Watchtower
- [ ] `curl -v -x http://127.0.0.1:18443 https://api.github.com/` returns a valid response (not ECONNRESET)
- [ ] Copilot `/login` completes successfully through the proxy
- [ ] Auth tokens persist at `/data/config/github-copilot/` for all agents