### PR TITLE
feat: wire git sources into startup and dashboard API

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -495,6 +495,41 @@ func main() {
 			}
 		}
 	}
+
+	// Auto-connect configured git sources (remote repos indexed as knowledge)
+	for _, gsc := range cfg.Knowledge.GitSources {
+		if knowledgeAPI == nil {
+			// Knowledge not enabled but git sources configured — auto-enable
+			knowledgeAPI = knowledge.NewKnowledgeAPI(nil, knowledge.KnowledgeConfig{
+				Enabled: true,
+				Engine:  "file",
+			}, logger)
+			logger.Info("auto-enabled knowledge API for git sources")
+		}
+		gsConfig := knowledge.GitSourceConfig{
+			Name:    gsc.Name,
+			URL:     gsc.URL,
+			Branch:  gsc.Branch,
+			Subpath: gsc.Subpath,
+			Layer:   knowledge.LayerType(gsc.Layer),
+		}
+		if err := knowledgeAPI.ConnectGitSource(ctx, gsConfig); err != nil {
+			logger.Warn("failed to connect git source",
+				"name", gsc.Name,
+				"url", gsc.URL,
+				"subpath", gsc.Subpath,
+				"error", err,
+			)
+		} else {
+			logger.Info("git source connected",
+				"name", gsc.Name,
+				"url", gsc.URL,
+				"subpath", gsc.Subpath,
+				"layer", gsc.Layer,
+			)
+		}
+	}
+
 	go gitSyncer.Start(ctx)
 
 	os.MkdirAll(nousSnapshotDir, 0o755)

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -109,6 +109,9 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("DELETE /api/knowledge/vaults", s.handleVaultsDisconnect)
 	s.mux.HandleFunc("POST /api/knowledge/vaults/reindex", s.handleVaultsReindex)
 	s.mux.HandleFunc("GET /api/knowledge/vaults/{name}/facts", s.handleVaultFacts)
+	s.mux.HandleFunc("GET /api/knowledge/git-sources", s.handleGitSourcesList)
+	s.mux.HandleFunc("POST /api/knowledge/git-sources", s.handleGitSourcesConnect)
+	s.mux.HandleFunc("DELETE /api/knowledge/git-sources", s.handleGitSourcesDisconnect)
 	s.mux.HandleFunc("POST /api/knowledge/obsidian/sync", s.handleObsidianSync)
 
 	s.mux.HandleFunc("GET /api/hive-id", s.handleHiveIDGet)
@@ -2021,6 +2024,7 @@ func (s *Server) handleKnowledgeStats(w http.ResponseWriter, r *http.Request) {
 	}
 	stats := s.deps.Knowledge.Stats(s.deps.Ctx)
 	stats["vaults"] = s.deps.Knowledge.Vaults()
+	stats["git_sources"] = s.deps.Knowledge.GitSources()
 	jsonResponse(w, stats)
 }
 
@@ -2384,6 +2388,81 @@ func (s *Server) handleVaultFacts(w http.ResponseWriter, r *http.Request) {
 		facts = []knowledge.Fact{}
 	}
 	jsonResponse(w, facts)
+}
+
+// --- Git source endpoints ---
+
+func (s *Server) handleGitSourcesList(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Knowledge == nil {
+		jsonResponse(w, []interface{}{})
+		return
+	}
+	jsonResponse(w, s.deps.Knowledge.GitSources())
+}
+
+func (s *Server) handleGitSourcesConnect(w http.ResponseWriter, r *http.Request) {
+	if !s.ensureKnowledge() {
+		jsonError(w, "knowledge not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	var req struct {
+		Name    string `json:"name"`
+		URL     string `json:"url"`
+		Branch  string `json:"branch"`
+		Subpath string `json:"subpath"`
+		Layer   string `json:"layer"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.URL == "" || req.Name == "" {
+		jsonError(w, "name and url are required", http.StatusBadRequest)
+		return
+	}
+	if req.Layer == "" {
+		req.Layer = "project"
+	}
+
+	gsConfig := knowledge.GitSourceConfig{
+		Name:    req.Name,
+		URL:     req.URL,
+		Branch:  req.Branch,
+		Subpath: req.Subpath,
+		Layer:   knowledge.LayerType(req.Layer),
+	}
+	if err := s.deps.Knowledge.ConnectGitSource(s.deps.Ctx, gsConfig); err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, map[string]interface{}{"ok": true, "name": req.Name, "url": req.URL})
+}
+
+func (s *Server) handleGitSourcesDisconnect(w http.ResponseWriter, r *http.Request) {
+	if s.deps.Knowledge == nil {
+		jsonError(w, "knowledge not enabled", http.StatusServiceUnavailable)
+		return
+	}
+
+	var req struct {
+		URL     string `json:"url"`
+		Subpath string `json:"subpath"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.URL == "" {
+		jsonError(w, "url is required", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.deps.Knowledge.DisconnectGitSource(req.URL, req.Subpath); err != nil {
+		jsonError(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	jsonResponse(w, map[string]interface{}{"ok": true, "removed": req.URL})
 }
 
 // --- Obsidian sync endpoint ---


### PR DESCRIPTION
## Summary

- Wires `git_sources` from `hive.yaml` into the startup path in `main.go` — repos are cloned, indexed, and sync loops started automatically
- Auto-enables knowledge API if `git_sources` are configured even without `knowledge.enabled: true`
- Adds 3 new dashboard API endpoints for runtime git source management
- Includes `git_sources` in `/api/knowledge/stats` response

Follow-up to #649 (Fisher-Rao metric + git source data structures). This PR adds the plumbing so the feature actually runs.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/knowledge/` passes
- [x] `go test ./pkg/dashboard/ -short` passes
- [ ] CI build
- [ ] Deploy to knuckle and verify dakota-skills indexed via `/api/knowledge/stats`


🤖 Generated with [Claude Code](https://claude.com/claude-code)