### PR TITLE
feat: wire git source FileStores into the knowledge primer

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -527,6 +527,19 @@ func main() {
 				"subpath", gsc.Subpath,
 				"layer", gsc.Layer,
 			)
+			// Register the FileStore with the scheduler's primer so agents
+			// get primed with facts from this git source during kicks.
+			if primer := sched.GetPrimer(); primer != nil {
+				for _, gs := range knowledgeAPI.GitSources() {
+					if gs.Name == gsc.Name && gs.Ready {
+						store := knowledgeAPI.GetGitSourceStore(gsc.Name)
+						if store != nil {
+							primer.AddFileStore(gsc.Name, store, knowledge.LayerType(gsc.Layer))
+						}
+						break
+					}
+				}
+			}
 		}
 	}
 

--- a/v2/pkg/knowledge/api.go
+++ b/v2/pkg/knowledge/api.go
@@ -561,6 +561,16 @@ func (k *KnowledgeAPI) ConnectGitSource(ctx context.Context, config GitSourceCon
 	return nil
 }
 
+// GetGitSourceStore returns the underlying FileStore for a git source by name.
+func (k *KnowledgeAPI) GetGitSourceStore(name string) *FileStore {
+	for _, gs := range k.gitSources {
+		if gs.Config().Name == name && gs.Ready() {
+			return gs.Store()
+		}
+	}
+	return nil
+}
+
 // DisconnectGitSource removes a git source by URL and subpath.
 func (k *KnowledgeAPI) DisconnectGitSource(url, subpath string) error {
 	found := false

--- a/v2/pkg/knowledge/primer.go
+++ b/v2/pkg/knowledge/primer.go
@@ -16,15 +16,23 @@ import (
 // Fisher-Rao geodesic distance on term-frequency embeddings. This catches
 // semantic matches that keyword search misses.
 type Primer struct {
-	layers   []layerClient
-	config   PrimerConfig
-	logger   *slog.Logger
-	embedder *EmbeddingCache
+	layers     []layerClient
+	fileStores []localStore
+	config     PrimerConfig
+	logger     *slog.Logger
+	embedder   *EmbeddingCache
 }
 
 type layerClient struct {
 	layerType LayerType
 	client    *Client
+}
+
+// localStore pairs a FileStore with the layer it belongs to.
+type localStore struct {
+	layerType LayerType
+	store     *FileStore
+	name      string
 }
 
 // NewPrimer creates a primer from the configured wiki layers. Layers that are
@@ -57,6 +65,17 @@ func NewPrimer(layers []LayerConfig, config PrimerConfig, logger *slog.Logger) *
 	}
 }
 
+// AddFileStore registers a local FileStore (from a git source or vault) so
+// the primer includes its facts alongside HTTP wiki layer results.
+func (p *Primer) AddFileStore(name string, store *FileStore, layer LayerType) {
+	p.fileStores = append(p.fileStores, localStore{
+		layerType: layer,
+		store:     store,
+		name:      name,
+	})
+	p.logger.Info("primer: added file store", "name", name, "layer", layer)
+}
+
 // Prime queries all reachable wiki layers for facts relevant to the given
 // file paths and keywords, merges with precedence, and returns a result ready
 // for prompt injection.
@@ -68,7 +87,7 @@ func (p *Primer) Prime(ctx context.Context, filePaths []string, keywords []strin
 		return &PrimedKnowledge{}
 	}
 
-	// Query each layer; collect results tagged with their layer.
+	// Query each HTTP wiki layer; collect results tagged with their layer.
 	var allFacts []Fact
 	for _, lc := range p.layers {
 		results, err := lc.client.Search(ctx, query, "", p.config.MaxFacts)
@@ -94,6 +113,15 @@ func (p *Primer) Prime(ctx context.Context, filePaths []string, keywords []strin
 		}
 	}
 
+	// Query local FileStores (git sources, vaults).
+	for _, ls := range p.fileStores {
+		facts := ls.store.Search(query, p.config.MaxFacts)
+		for i := range facts {
+			facts[i].Layer = ls.layerType
+		}
+		allFacts = append(allFacts, facts...)
+	}
+
 	merged := p.mergeWithPrecedence(allFacts)
 	reranked := p.rerankFisherRao(query, merged)
 	prioritized := p.applyPriority(reranked)
@@ -105,7 +133,8 @@ func (p *Primer) Prime(ctx context.Context, filePaths []string, keywords []strin
 	elapsed := time.Since(start).Milliseconds()
 	p.logger.Info("knowledge primed",
 		"facts", len(prioritized),
-		"layers_queried", len(p.layers),
+		"http_layers", len(p.layers),
+		"file_stores", len(p.fileStores),
 		"query_ms", elapsed,
 	)
 

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -34,6 +34,11 @@ func (s *Scheduler) SetPrimer(p *knowledge.Primer) {
 	s.primer = p
 }
 
+// GetPrimer returns the attached primer, or nil if none is set.
+func (s *Scheduler) GetPrimer() *knowledge.Primer {
+	return s.primer
+}
+
 // loadPromptTemplate searches standard paths for an agent's policy template.
 // It checks on-disk paths first, then falls back to embedded default policies.
 func (s *Scheduler) loadPromptTemplate(agentName string) string {


### PR DESCRIPTION
## Summary

Closes the gap where git sources were indexed and searchable via the API but **agents were not being primed** with their knowledge during kicks.

- `Primer.AddFileStore()` registers local FileStores for inclusion at prime time
- `Primer.Prime()` now queries both HTTP wiki layers and local FileStores
- After connecting a git source in `main.go`, its FileStore is registered with the scheduler's primer
- Logs now show `file_stores` count in the "knowledge primed" message

Without this, the dakota-skills docs were visible in the dashboard but invisible to agents.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./pkg/knowledge/` passes
- [x] `go test ./pkg/scheduler/` passes
- [ ] CI
- [ ] After deploy: verify "knowledge primed" log shows `file_stores=1` during kicks


🤖 Generated with [Claude Code](https://claude.com/claude-code)