### PR TITLE
fix: detail card scrollback + fill height

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -462,24 +462,7 @@ func (m *Manager) pollTmuxOutputForAgent(agent *AgentProcess, ctx context.Contex
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			// Visible-only capture for dashboard .doing display
-			visible := m.captureVisiblePaneForAgent(agent)
-			if visible != "" {
-				var visFiltered []string
-				for _, line := range strings.Split(visible, "\n") {
-					trimmed := strings.TrimRight(line, " \t")
-					if trimmed != "" {
-						visFiltered = append(visFiltered, trimmed)
-					}
-				}
-				if len(visFiltered) > 0 {
-					agent.paneMu.Lock()
-					agent.lastPaneCapture = visFiltered
-					agent.paneMu.Unlock()
-				}
-			}
-
-			// Scrollback capture for ring buffer diff and output signal detection
+			// Scrollback capture for dashboard display + ring buffer diff
 			output := m.captureTmuxPaneForAgent(agent)
 			if output == "" {
 				continue
@@ -494,6 +477,11 @@ func (m *Manager) pollTmuxOutputForAgent(agent *AgentProcess, ctx context.Contex
 			if len(filtered) == 0 {
 				continue
 			}
+
+			agent.paneMu.Lock()
+			agent.lastPaneCapture = filtered
+			agent.paneMu.Unlock()
+
 			if prevLines == nil {
 				if agent.OutputBuffer.Count() == 0 {
 					for _, l := range filtered {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -308,7 +308,7 @@
       color: var(--cyan); line-height: 1.3;
       padding: 14px; background: #f9fafb;
       border-radius: 8px; border: 1px solid #e5e7eb;
-      height: calc(1.3em * 20 + 28px); max-height: none; overflow-y: auto;
+      min-height: calc(1.3em * 20 + 28px); max-height: 70vh; overflow-y: auto;
       resize: vertical;
       font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
       font-size: 0.65rem;

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -159,7 +159,9 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 			liveSummary = strings.Join(pane, "\n")
 		}
 		var detailSummary string
-		if pane := proc.FilteredPaneLines(0); len(pane) > 0 {
+		if buf := proc.OutputBuffer; buf != nil && buf.Count() > 0 {
+			detailSummary = strings.Join(buf.Last(buf.Count()), "\n")
+		} else if pane := proc.FilteredPaneLines(0); len(pane) > 0 {
 			detailSummary = strings.Join(pane, "\n")
 		}
 


### PR DESCRIPTION
## Summary
- **Detail card** now reads from the 500-line ring buffer (`OutputBuffer`) instead of the point-in-time pane capture, so lines accumulate over time and users can scroll back through agent history
- **Small cards** now get scrollback content (2000 lines) instead of visible-only capture (~24 lines), providing more content
- **CSS**: detail summary uses `min-height` + `max-height: 70vh` instead of fixed height, filling available vertical space while remaining scrollable

## Test plan
- [ ] Verify in-focus agent card fills vertical space and shows accumulated output
- [ ] Verify scrollback works in the detail card (scroll up to see older content)
- [ ] Verify small agent cards still show ~20 lines of recent output