### PR TITLE
fix: filter ring buffer noise + eliminate detail card flicker

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -485,7 +485,9 @@ func (m *Manager) pollTmuxOutputForAgent(agent *AgentProcess, ctx context.Contex
 			if prevLines == nil {
 				if agent.OutputBuffer.Count() == 0 {
 					for _, l := range filtered {
-						agent.OutputBuffer.Write(l)
+						if !isBufferNoise(l) {
+							agent.OutputBuffer.Write(l)
+						}
 					}
 				}
 				prevLines = filtered
@@ -493,7 +495,9 @@ func (m *Manager) pollTmuxOutputForAgent(agent *AgentProcess, ctx context.Contex
 			}
 			newLines := diffNewLines(prevLines, filtered)
 			for _, l := range newLines {
-				agent.OutputBuffer.Write(l)
+				if !isBufferNoise(l) {
+					agent.OutputBuffer.Write(l)
+				}
 				m.logOutputSignals(agent.Name, l)
 			}
 			prevLines = filtered
@@ -1441,6 +1445,40 @@ func isCLIChrome(s string) bool {
 				return true
 			}
 		}
+	}
+	return false
+}
+
+func isBufferNoise(s string) bool {
+	if isCLIChrome(s) || isVisualNoise(s) {
+		return true
+	}
+	t := strings.TrimSpace(s)
+	if t == "❯" || t == "›" || t == ">" {
+		return true
+	}
+	for _, banner := range []string{"╭─╮", "╰─╯", "█ ▘▝ █", "▔▔▔▔", "Copilot v", "Check for mistakes"} {
+		if strings.Contains(t, banner) {
+			return true
+		}
+	}
+	if strings.HasPrefix(t, "● Tip:") || strings.HasPrefix(t, "└ ") || strings.HasPrefix(t, "↑/↓ to navigate") {
+		return true
+	}
+	if strings.Contains(t, "copilot-instructions.md") && strings.Contains(t, "/init") {
+		return true
+	}
+	if strings.Contains(t, "Do you trust the files in this folder") {
+		return true
+	}
+	if strings.HasPrefix(t, "› ") && (strings.Contains(t, "Yes") || strings.Contains(t, "No (Esc)")) {
+		return true
+	}
+	if strings.HasPrefix(t, "●") && strings.Contains(t, "Folder") && strings.Contains(t, "trusted") {
+		return true
+	}
+	if strings.HasPrefix(t, "✗ Model") && strings.Contains(t, "not available") {
+		return true
 	}
 	return false
 }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2011,6 +2011,25 @@
         _ocSummaryScrollTop = existingSummary.scrollTop;
       }
 
+      // Fast path: if the detail panel already shows this agent, update only the
+      // summary text + status dot to avoid full DOM rebuild (prevents scroll jumps).
+      if (existingSummary && detail.dataset.agent === a.name) {
+        const newText = (a.detailSummary || a.liveSummary) ? escBlock(a.detailSummary || a.liveSummary) : '<span style="color:#9ca3af">No activity summary</span>';
+        if (existingSummary.innerHTML !== newText) {
+          existingSummary.innerHTML = newText;
+        }
+        if (_ocSummaryTailing) {
+          existingSummary.scrollTop = existingSummary.scrollHeight;
+        }
+        const dot = detail.querySelector('.status-dot');
+        if (dot) { dot.className = 'status-dot ' + dotCls; }
+        const stateSpan = detail.querySelector('.oc-agent-detail-header > span:last-child');
+        if (stateSpan) { stateSpan.textContent = stateLabel; }
+        detail.className = 'oc-agent-detail active state-' + dotCls;
+        return;
+      }
+      detail.dataset.agent = a.name;
+
       const gov = window._lastStatus?.governor || {};
       const govMode = (gov.mode || 'unknown').toLowerCase();
       const govModeClass = 'mode-' + (['idle','quiet','busy','surge'].includes(govMode) ? govMode : 'quiet');


### PR DESCRIPTION
## Summary
- **Ring buffer noise filter**: `isBufferNoise()` strips CLI chrome (Copilot banners, separator lines, trust prompts, model warnings, tips) before writing to the ring buffer, so the detail card shows only meaningful agent output
- **Flicker fix**: When the same agent is already selected, the detail panel does a targeted update of just the summary text + status dot instead of rebuilding the entire DOM — prevents scroll position jumps and visual flickering between short/long content

## Test plan
- [ ] Verify in-focus card no longer shows Copilot banners, separator lines, or trust prompts
- [ ] Verify no flickering/jumpiness when viewing an agent's detail card
- [ ] Verify scroll position is preserved when content updates
- [ ] Verify small cards still show correct content