### PR TITLE
fix: manual kicks now prime knowledge from cached actionable

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -816,6 +816,7 @@ func runEvalCycle(
 	// in this mode" — it does NOT force-pause the agent. Manual pause/resume
 	// via the dashboard is always respected; the governor only controls kicks.
 
+	sched.SetLastActionable(actionable)
 	if len(agentsDue) > 0 {
 		messages := sched.BuildKickMessages(actionable, agentsDue)
 		for _, msg := range messages {

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -471,7 +471,7 @@ func (s *Server) handleKick(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if msg == "" && s.deps.Scheduler != nil {
-		msg = s.deps.Scheduler.BuildAgentMessage(name, nil, nil)
+		msg = s.deps.Scheduler.BuildAgentMessage(name, nil, s.deps.Scheduler.GetLastActionable())
 	}
 
 	if err := s.deps.AgentMgr.SendKick(name, msg); err != nil {

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -16,9 +16,10 @@ import (
 )
 
 type Scheduler struct {
-	cfg    *config.Config
-	primer *knowledge.Primer
-	logger *slog.Logger
+	cfg            *config.Config
+	primer         *knowledge.Primer
+	lastActionable *github.ActionableResult
+	logger         *slog.Logger
 }
 
 func New(cfg *config.Config, logger *slog.Logger) *Scheduler {
@@ -37,6 +38,17 @@ func (s *Scheduler) SetPrimer(p *knowledge.Primer) {
 // GetPrimer returns the attached primer, or nil if none is set.
 func (s *Scheduler) GetPrimer() *knowledge.Primer {
 	return s.primer
+}
+
+// SetLastActionable caches the latest actionable result so manual kicks
+// (via the dashboard API) can prime knowledge from the same issue set.
+func (s *Scheduler) SetLastActionable(a *github.ActionableResult) {
+	s.lastActionable = a
+}
+
+// GetLastActionable returns the most recently cached actionable result.
+func (s *Scheduler) GetLastActionable() *github.ActionableResult {
+	return s.lastActionable
 }
 
 // loadPromptTemplate searches standard paths for an agent's policy template.


### PR DESCRIPTION
## Summary

Manual kicks via the dashboard button or API were not priming agents with knowledge because `BuildAgentMessage` was called with `nil` actionable data, causing `primeKnowledge` to exit early.

Now the scheduler caches the last actionable result from each governor eval cycle, and manual kicks use that cached data for knowledge priming.

## Test plan

- [x] `go build ./...` clean
- [x] Tests pass
- [ ] CI
- [ ] After deploy: manual scanner kick shows `"knowledge primed"` in logs with `facts > 0`


🤖 Generated with [Claude Code](https://claude.com/claude-code)