### PR TITLE
fix: detail card fast-path prevents short content fallback

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2013,10 +2013,14 @@
 
       // Fast path: if the detail panel already shows this agent, update only the
       // summary text + status dot to avoid full DOM rebuild (prevents scroll jumps).
+      // Only update summary when detailSummary is available — never replace long
+      // ring buffer content with short liveSummary fallback.
       if (existingSummary && detail.dataset.agent === a.name) {
-        const newText = (a.detailSummary || a.liveSummary) ? escBlock(a.detailSummary || a.liveSummary) : '<span style="color:#9ca3af">No activity summary</span>';
-        if (existingSummary.innerHTML !== newText) {
-          existingSummary.innerHTML = newText;
+        if (a.detailSummary) {
+          const newText = escBlock(a.detailSummary);
+          if (existingSummary.innerHTML !== newText) {
+            existingSummary.innerHTML = newText;
+          }
         }
         if (_ocSummaryTailing) {
           existingSummary.scrollTop = existingSummary.scrollHeight;


### PR DESCRIPTION
## Summary
- Fast-path summary update now only fires when `detailSummary` (ring buffer) is available
- Previously, the fast-path would fall back to `liveSummary` (20 lines) when `detailSummary` was empty on a poll cycle, causing the card to flicker from long → short content
- Now if `detailSummary` is empty, the fast-path preserves whatever content is already displayed

## Test plan
- [ ] Click an agent — verify detail card shows long content and stays long
- [ ] Verify no flickering between short/long versions on repeated poll cycles
- [ ] Verify content still updates when new ring buffer data arrives