### PR TITLE
feat: ${KNOWLEDGE} template variable for knowledge priming

### DIFF
--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -119,6 +119,9 @@ func (s *Scheduler) substituteTemplate(template string, actionable *github.Actio
 		displayName = ac.DisplayName
 	}
 
+	agentIssues := filterByLane(issues, agentName)
+	knowledgeSection := s.primeKnowledge(agentIssues)
+
 	replacer := strings.NewReplacer(
 		"${AGENT_NAME}", agentName,
 		"${AGENT_DISPLAY_NAME}", displayName,
@@ -142,6 +145,7 @@ func (s *Scheduler) substituteTemplate(template string, actionable *github.Actio
 		"${AGENT_LIST}", agentList,
 		"${AGENT_ROLES}", agentRoles,
 		"${ENABLED_AGENTS}", agentList,
+		"${KNOWLEDGE}", knowledgeSection,
 	)
 	return replacer.Replace(template)
 }

--- a/v2/policies/architect-full.md
+++ b/v2/policies/architect-full.md
@@ -76,3 +76,5 @@ Priority: 0 (critical structural risk), 1 (high coupling/broken abstraction), 2 
 6. For problems with a clear refactor, create a worktree and open a PR
 7. Create a bead for each finding
 8. Summarize architectural health in your response
+
+${KNOWLEDGE}

--- a/v2/policies/architect-holdgated.md
+++ b/v2/policies/architect-holdgated.md
@@ -75,3 +75,5 @@ Priority: 0 (critical structural risk), 1 (high coupling/broken abstraction), 2 
 6. For problems with a clear refactor, create a worktree and open a hold-gated PR
 7. Create a bead for each finding
 8. Summarize architectural health in your response
+
+${KNOWLEDGE}

--- a/v2/policies/ci-maintainer-advisory.md
+++ b/v2/policies/ci-maintainer-advisory.md
@@ -59,3 +59,5 @@ Finding types: `ci-failure`, `flaky-test`, `slow-build`, `coverage-drop`, `depen
 4. Identify failures, patterns, and trends
 5. Create a bead for each finding with `bd create`
 6. Summarize CI health (new findings and reaped stale ones) — keep it concise, no raw tables
+
+${KNOWLEDGE}

--- a/v2/policies/ci-maintainer-full.md
+++ b/v2/policies/ci-maintainer-full.md
@@ -58,3 +58,5 @@ Priority: 0 (CI broken/blocking), 1 (persistent failure/coverage drop), 2 (flaky
 6. For problems with a clear fix, create a worktree and open a PR
 7. Create a bead for each finding
 8. Summarize CI health in your response
+
+${KNOWLEDGE}

--- a/v2/policies/ci-maintainer-holdgated.md
+++ b/v2/policies/ci-maintainer-holdgated.md
@@ -70,3 +70,5 @@ Priority: 0 (CI broken/blocking), 1 (persistent failure/coverage drop), 2 (flaky
 6. For problems with a clear fix, create a worktree and open a hold-gated PR
 7. Create a bead for each finding
 8. Summarize CI health in your response
+
+${KNOWLEDGE}

--- a/v2/policies/ci-maintainer.md
+++ b/v2/policies/ci-maintainer.md
@@ -8,3 +8,5 @@ You are the **ci-maintainer** agent in a Hive instance. Your job is post-merge h
 2. **Review open PRs** for code quality, error handling, test coverage
 3. **Never merge PRs** — only review and comment
 4. **Report findings** clearly with file paths and line numbers
+
+${KNOWLEDGE}

--- a/v2/policies/guide-advisory.md
+++ b/v2/policies/guide-advisory.md
@@ -71,3 +71,5 @@ Finding types: `docs`, `onboarding`, `architecture`, `api`, `contributing`
 - **Architecture** — component overview, data flow, key abstractions
 - **Contributing** — workflow, code style, PR expectations, CI requirements
 - **API surface** — public interfaces, configuration options, environment variables
+
+${KNOWLEDGE}

--- a/v2/policies/guide-full.md
+++ b/v2/policies/guide-full.md
@@ -56,3 +56,5 @@ bd create --title "<specific documentation gap title>" \
 5. For gaps with a clear fix, create a worktree and open a PR
 6. Create a bead for each finding
 7. Summarize findings in your response
+
+${KNOWLEDGE}

--- a/v2/policies/guide-holdgated.md
+++ b/v2/policies/guide-holdgated.md
@@ -57,3 +57,5 @@ bd create --title "<specific documentation gap title>" \
 5. For gaps with a clear fix, create a worktree and open a hold-gated PR
 6. Create a bead for each finding
 7. Summarize findings in your response
+
+${KNOWLEDGE}

--- a/v2/policies/guide-issues.md
+++ b/v2/policies/guide-issues.md
@@ -60,3 +60,5 @@ Priority: 0 (no README/build instructions), 1 (missing setup/stale arch docs), 2
 5. Create a GitHub issue for each significant gap
 6. Create a bead for each finding
 7. Summarize findings in your response
+
+${KNOWLEDGE}

--- a/v2/policies/guide.md
+++ b/v2/policies/guide.md
@@ -28,3 +28,5 @@ You are the **guide** agent in a Hive instance. Your job is to improve project d
 - **Architecture** — component overview, data flow, key abstractions
 - **Contributing** — workflow, code style, PR expectations, CI requirements
 - **API surface** — public interfaces, configuration options, environment variables
+
+${KNOWLEDGE}

--- a/v2/policies/quality-advisory.md
+++ b/v2/policies/quality-advisory.md
@@ -58,3 +58,5 @@ Finding types: `coverage-gap`, `missing-fixture`, `regression-risk`, `test-quali
 4. Identify the top coverage gaps by impact
 5. Create a bead for each finding with `bd create`
 6. Summarize what you found (new findings and reaped stale ones) — keep it concise, no raw tables
+
+${KNOWLEDGE}

--- a/v2/policies/quality-full.md
+++ b/v2/policies/quality-full.md
@@ -71,3 +71,5 @@ Priority: 0 (critical untested path), 1 (major logic gap), 2 (significant gap), 
 5. For high-priority findings, open a GitHub issue
 6. For findings with a clear fix, open a PR with the test code
 7. Summarize findings in your response
+
+${KNOWLEDGE}

--- a/v2/policies/quality-holdgated.md
+++ b/v2/policies/quality-holdgated.md
@@ -71,3 +71,5 @@ Priority: 0 (critical untested path), 1 (major logic gap), 2 (significant gap), 
 5. For high-priority findings, open a GitHub issue
 6. For findings with a clear fix, open a hold-gated PR with the test code
 7. Summarize findings in your response
+
+${KNOWLEDGE}

--- a/v2/policies/quality-measured.md
+++ b/v2/policies/quality-measured.md
@@ -114,3 +114,5 @@ bd update <bead-id> --set-metadata file="path/to/file.go"
 5. For high-priority findings, open a GitHub issue
 6. For findings with a clear fix, also open a hold-gated PR with the test code
 7. Summarize what you found in your response
+
+${KNOWLEDGE}

--- a/v2/policies/quality.md
+++ b/v2/policies/quality.md
@@ -10,3 +10,5 @@ You are the **quality** agent in a Hive instance. Your job is to strategically b
 4. **Record knowledge** — write test_scaffold and pattern facts to the wiki
 5. **Max 3 concurrent test PRs** per kick
 6. **Adapt by maturity level** — suggest at L1-2, gate at L3, TDD at L4
+
+${KNOWLEDGE}

--- a/v2/policies/scanner-advisory.md
+++ b/v2/policies/scanner-advisory.md
@@ -57,3 +57,5 @@ Finding types: `bug`, `security`, `architecture`, `performance`, `docs`
 4. Create a bead for each finding with `bd create`
 5. You may create local worktrees with proposed fixes for analysis, but DO NOT push
 6. Summarize your findings (new and reaped) in your response — keep it concise, no raw tables
+
+${KNOWLEDGE}

--- a/v2/policies/scanner-automerge.md
+++ b/v2/policies/scanner-automerge.md
@@ -61,3 +61,5 @@ bd create --title "<specific finding title>" \
 5. Create a PR for each fix; poll CI; merge when green
 6. Create a bead for each finding
 7. Summarize completed work including merged PRs
+
+${KNOWLEDGE}

--- a/v2/policies/scanner-full.md
+++ b/v2/policies/scanner-full.md
@@ -53,3 +53,5 @@ bd create --title "<specific finding title>" \
 5. For findings with a clear fix, create a worktree, implement, and open a PR
 6. Create a bead for each finding
 7. Summarize completed work
+
+${KNOWLEDGE}

--- a/v2/policies/scanner-holdgated.md
+++ b/v2/policies/scanner-holdgated.md
@@ -54,3 +54,5 @@ bd create --title "<specific finding title>" \
 5. For findings with a clear fix, create a worktree, implement, and open a hold-gated PR
 6. Create a bead for each finding
 7. Summarize completed work
+
+${KNOWLEDGE}

--- a/v2/policies/scanner-issues.md
+++ b/v2/policies/scanner-issues.md
@@ -60,3 +60,5 @@ Priority: 0 (critical/security), 1 (high/bug), 2 (medium/quality), 3 (low/style)
 4. Create a GitHub issue for each confirmed finding
 5. Create a bead linking to the GitHub issue
 6. Summarize findings in your response
+
+${KNOWLEDGE}

--- a/v2/policies/scanner.md
+++ b/v2/policies/scanner.md
@@ -19,3 +19,5 @@ You are the **scanner** agent in a Hive instance. Your job is to triage and fix 
 3. Dispatch sub-agents in parallel (4-6 at a time)
 4. Monitor sub-agent results
 5. Report summary of completed work
+
+${KNOWLEDGE}

--- a/v2/policies/sec-check-full.md
+++ b/v2/policies/sec-check-full.md
@@ -75,3 +75,5 @@ Priority: 0 (critical/RCE/secret-exposed), 1 (high/auth-bypass), 2 (medium/info-
 6. For findings with a clear safe fix, create a worktree and open a PR
 7. Create a bead for each finding
 8. Summarize security posture in your response
+
+${KNOWLEDGE}

--- a/v2/policies/sec-check-holdgated.md
+++ b/v2/policies/sec-check-holdgated.md
@@ -74,3 +74,5 @@ Priority: 0 (critical/RCE/secret-exposed), 1 (high/auth-bypass), 2 (medium/info-
 6. For findings with a clear safe fix, create a worktree and open a hold-gated PR
 7. Create a bead for each finding
 8. Summarize security posture in your response
+
+${KNOWLEDGE}

--- a/v2/policies/strategist-full.md
+++ b/v2/policies/strategist-full.md
@@ -77,3 +77,5 @@ Priority: 0 (critical adoption blocker), 1 (high-impact opportunity), 2 (medium 
 6. For findings that need a planning document, create a worktree and open a PR
 7. Create a bead for each finding
 8. Summarize strategic health in your response
+
+${KNOWLEDGE}

--- a/v2/policies/strategist-holdgated.md
+++ b/v2/policies/strategist-holdgated.md
@@ -76,3 +76,5 @@ Priority: 0 (critical adoption blocker), 1 (high-impact opportunity), 2 (medium 
 6. For findings that need a planning document, create a worktree and open a hold-gated PR
 7. Create a bead for each finding
 8. Summarize strategic health in your response
+
+${KNOWLEDGE}


### PR DESCRIPTION
## Summary

Template-based kicks never called `primeKnowledge` — the function only existed in the hardcoded fallback builders. Since all knuckle agents use templates, knowledge was never injected.

- Added `${KNOWLEDGE}` to the template replacer in `substituteTemplate`
- Added `${KNOWLEDGE}` to all 26 agent policy templates
- Supervisor/outreach excluded (they don't work on issues)

## Test plan

- [x] Build clean, tests pass
- [ ] After deploy: kick scanner → logs show "knowledge primer: searching" and "injecting facts"
- [ ] Scanner tmux pane shows "# Relevant Knowledge" section in kick message


🤖 Generated with [Claude Code](https://claude.com/claude-code)