### PR TITLE
fix: fall back to actionable issues for knowledge priming

### DIFF
--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -120,6 +120,9 @@ func (s *Scheduler) substituteTemplate(template string, actionable *github.Actio
 	}
 
 	agentIssues := filterByLane(issues, agentName)
+	if len(agentIssues) == 0 && actionable != nil && len(actionable.Issues.Items) > 0 {
+		agentIssues = actionable.Issues.Items
+	}
 	knowledgeSection := s.primeKnowledge(agentIssues)
 
 	replacer := strings.NewReplacer(


### PR DESCRIPTION
Template kicks from the dashboard API pass nil for classified issues — only the governor has those. When nil, fall back to `actionable.Issues.Items` so the primer has issue titles to extract keywords from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)