### PR TITLE
fix: health dot clipped by overflow:hidden

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4931,7 +4931,8 @@ function burnAreaChart() {
         const isGitSource = l.type && l.type.startsWith('git_source:');
         const repoUrl = isGitSource && l.url ? (l.subpath ? l.url + '/tree/' + 'main/' + l.subpath : l.url) : '';
         html += `<button class="kb-layer-btn${active}" onclick="kbSelectLayer('${escapeHtml(l.type)}')">`;
-        html += `<span class="kb-layer-label">${icon} ${escapeHtml(label)} <span class="kb-health-indicator" style="background:${dotColor}"></span></span>`;
+        html += `<span class="kb-layer-label">${icon} ${escapeHtml(label)}</span>`;
+        html += `<span class="kb-health-indicator" style="background:${dotColor}"></span>`;
         if (isGitSource && repoUrl) {
           html += `<a href="${escapeHtml(repoUrl)}" target="_blank" rel="noopener" onclick="event.stopPropagation()" style="color:var(--accent);text-decoration:none;font-size:0.82rem;flex-shrink:0" title="Open source repo in new tab">↗</a>`;
         }


### PR DESCRIPTION
Move health indicator out of label span to be a direct flex child. Pill now: [label] [dot] [↗] [count]

🤖 Generated with [Claude Code](https://claude.com/claude-code)