### PR TITLE
fix: dashboard knowledge search returns no results for git sources

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4643,7 +4643,7 @@ function burnAreaChart() {
         const r = await fetch(url);
         if (!r.ok) { _kbFacts = []; renderKnowledgeFacts(); return; }
         const data = await r.json();
-        _kbFacts = Array.isArray(data) ? data : (data.facts || []);
+        _kbFacts = Array.isArray(data) ? data : (data.results || data.facts || []);
         _kbSelectedFact = null;
         renderKnowledgeFacts();
       } catch (e) { _kbFacts = []; renderKnowledgeFacts(); }


### PR DESCRIPTION
## Summary
- The `/api/knowledge/search` endpoint returns results in a `results` array, but the frontend `kbSearch()` function only destructured `data.facts` (the shape used by the list endpoint `/api/knowledge`).
- Added `data.results` as a fallback before `data.facts` so search responses are parsed correctly.

## Root cause
Line 4646 in `index.html`:
```js
// Before (broken for search):
_kbFacts = Array.isArray(data) ? data : (data.facts || []);

// After (handles both list and search response shapes):
_kbFacts = Array.isArray(data) ? data : (data.results || data.facts || []);
```

The backend was already calling `SearchAllWithVaults` (which includes git vault sources). The bug was purely a frontend response-shape mismatch.

## Test plan
- `curl -s "http://<host>:3001/api/knowledge/search?q=rust&limit=5"` continues to return results
- Searching "rust" in the Knowledge Base UI now displays matching facts from git sources