### PR TITLE
fix: enforce holdgated PRs across all ACMM levels below L6

### DIFF
--- a/v2/pkg/config/packs/level-3.yaml
+++ b/v2/pkg/config/packs/level-3.yaml
@@ -1,10 +1,9 @@
 level: 3
 name: Measured
 description: >
-  Feedback becomes visible. The quality agent opens issues AND hold-gated PRs
-  about testing — coverage gaps, missing CI workflows, test infrastructure.
-  Quality PRs get a 'hold' label; no agent merges. All other agents remain
-  in advisory mode. CI-maintainer joins to monitor build health.
+  Feedback becomes visible. Quality opens issues AND hold-gated PRs about
+  testing gaps. All PRs get 'hold' label; no agent merges. All other agents
+  remain advisory (beads only). CI-maintainer joins to monitor build health.
 governor:
   modes: SURGE, BUSY, QUIET, IDLE
   merge_policy: hold-gated (quality PRs only)
@@ -119,7 +118,7 @@ agents:
     model: claude-opus-4-6
     bead_role: worker
     mode: ISSUES_AND_PRS
-    kick_template: quality-full.md
+    kick_template: quality-holdgated.md
     include_repos: true
     stale_timeout: 3600
     interactions: >

--- a/v2/pkg/config/packs/level-4.yaml
+++ b/v2/pkg/config/packs/level-4.yaml
@@ -7,7 +7,7 @@ description: >
   issues only. Adds security agent (+sec-check). Six agents total.
 governor:
   modes: SURGE, BUSY, QUIET, IDLE
-  merge_policy: manual
+  merge_policy: hold-gated
   eval_interval_s: 300
   thresholds:
     surge: 10
@@ -92,8 +92,8 @@ agents:
     display_name: ci-maintainer
     role: ci-maintainer
     description: >
-      Opens GitHub issues about CI health, workflow failures, and build
-      problems. Does NOT create PRs. Also produces advisory beads.
+      Opens GitHub issues and hold-gated PRs about CI health, workflow
+      failures, and build problems. PRs get 'hold' label; never merges.
     emoji: "🔧"
     color: "#2ecc71"
     sort_order: 30
@@ -101,7 +101,7 @@ agents:
     model: claude-sonnet-4-6
     bead_role: worker
     mode: ISSUES_AND_PRS
-    kick_template: ci-maintainer-full.md
+    kick_template: ci-maintainer-holdgated.md
     include_repos: true
     stale_timeout: 3600
     lane_keywords: [ci, build, pipeline, workflow]
@@ -114,8 +114,8 @@ agents:
     display_name: quality
     role: quality
     description: >
-      Opens GitHub issues about testing gaps, coverage, and test infrastructure.
-      Does NOT create PRs. Also produces advisory beads.
+      Opens GitHub issues and hold-gated PRs about testing gaps, coverage,
+      and test infrastructure. PRs get 'hold' label; never merges.
     emoji: "🧪"
     color: "#e67e22"
     sort_order: 25
@@ -123,7 +123,7 @@ agents:
     model: claude-opus-4-6
     bead_role: worker
     mode: ISSUES_AND_PRS
-    kick_template: quality-full.md
+    kick_template: quality-holdgated.md
     include_repos: true
     stale_timeout: 3600
     interactions: >
@@ -157,8 +157,8 @@ agents:
     role: sec-check
     description: >
       Security scanning, dependency audit, and vulnerability monitoring.
-      Opens GitHub issues for vulnerabilities and security gaps. Does NOT
-      create PRs.
+      Opens GitHub issues and hold-gated PRs for vulnerabilities and
+      security gaps. PRs get 'hold' label; never merges.
     emoji: "🛡"
     color: "#1abc9c"
     sort_order: 60
@@ -166,7 +166,7 @@ agents:
     model: claude-sonnet-4-6
     bead_role: worker
     mode: ISSUES_AND_PRS
-    kick_template: sec-check-full.md
+    kick_template: sec-check-holdgated.md
     include_repos: true
     stale_timeout: 3600
     lane_keywords: [security, cve, vulnerability, audit]

--- a/v2/policies/quality-measured.md
+++ b/v2/policies/quality-measured.md
@@ -8,11 +8,11 @@ ${GH_AUTH}
 
 1. **Analyze coverage gaps** — identify untested modules by impact
 2. **Open GitHub issues for testing recommendations** — coverage gaps, missing CI workflows, test infrastructure, coverage reporting
-3. **Open hold-gated PRs for test improvements** — write the tests, create a PR, label it `hold`. NEVER merge or attempt to merge. NEVER remove the `hold` label.
+3. **DO NOT create PRs** — measured mode is issues + beads only. PRs require hold-gated mode (L4+).
 4. **Write findings as beads** — use `bd create` for every finding (feeds advisory digest)
 5. **Record knowledge** — write test_scaffold and pattern facts to the wiki
 6. **Respect hold labels** — never touch issues labeled `hold`, `on-hold`, or `do-not-merge`
-7. **You are the ONLY agent with GitHub write access at L3** — all other agents are advisory-only
+7. **You are the ONLY agent with GitHub issue access at L3** — all other agents are advisory-only
 
 ## Opening Issues
 
@@ -45,45 +45,9 @@ Specific steps to address the gap.
 - **coverage-reporting** — tracking issue for coverage trends, coverage badge, regression alerts
 - **regression-risk** — code changed recently with no test update
 
-## Opening Hold-Gated PRs
-
-When you have a concrete test improvement (new tests, test fixtures, CI workflow), create a PR:
-
-1. Create a feature branch: `git checkout -b quality/test-<short-slug>`
-2. Write the test code or CI workflow changes
-3. Commit with DCO sign-off: `git commit -s -m "[quality] <description>"`
-4. Push: `git push origin quality/test-<short-slug>`
-5. Open a PR with `hold` label — **NEVER merge**:
-
-```bash
-gh pr create --repo "$HIVE_REPO" \
-  --title "[quality] <short description of test improvement>" \
-  --body "## Test Improvement
-
-<what this PR adds/changes>
-
-## Related Issue
-Fixes #<issue-number> (if applicable)
-
----
-*Filed by quality agent (ACMM L3 — measured mode). Hold-gated: human review required.*" \
-  --label "quality,testing,hold"
-```
-
-### What quality can PR
-- New unit tests for uncovered functions
-- Test fixtures and helpers
-- CI workflow improvements (coverage gates, nightly test suites)
-- Coverage reporting configuration
-
-### What quality must NEVER do
-- Merge any PR (even its own)
-- Remove the `hold` label from any PR
-- Create PRs for non-testing changes (no production code, no refactors, no features)
-
 ## Writing Beads
 
-Also record each finding as a bead for the advisory digest:
+Record each finding as a bead for the advisory digest:
 
 ```bash
 bd create --title "Short description of the coverage gap" \
@@ -114,7 +78,12 @@ bd update <bead-id> --set-metadata file="path/to/file.go"
 3. Identify the top coverage gaps by impact
 4. Create a bead for each finding with `bd create`
 5. For high-priority findings, open a GitHub issue
-6. For findings with a clear fix, also open a hold-gated PR with the test code
-7. Summarize what you found in your response
+6. Summarize what you found in your response
+
+## What NOT To Do
+
+- Do NOT create pull requests — measured mode is issues + beads only
+- Do NOT merge anything
+- Do NOT spend time debugging TLS certs or proxy config — use the auth recipe above
 
 ${KNOWLEDGE}


### PR DESCRIPTION
## Summary

Clean 4-tier policy model enforced across all ACMM levels:
- **advisory**: beads only
- **measured**: beads + issues  
- **holdgated**: beads + issues + PRs with `hold` label
- **full**: beads + issues + PRs + auto-merge (L6 only)

All PRs are holdgated unless L6. No agent can auto-merge below L6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)