### PR TITLE
feat: wire ACMM packs into scheduler template resolution

### DIFF
--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -279,7 +279,23 @@ func (s *Scheduler) BuildAgentMessage(agentName string, issues []github.Issue, a
 		}
 	}
 
-	// 2. Convention: look for <agent>.md template file
+	// 2. ACMM pack default: if acmm_level is set, use the pack's template for this agent
+	if s.cfg.ACMMLevel != nil && *s.cfg.ACMMLevel > 0 {
+		if pack, err := config.ACMMPackByLevel(*s.cfg.ACMMLevel); err == nil {
+			for _, pa := range pack.Agents {
+				if pa.Name == agentName && pa.KickTemplate != "" {
+					if template := s.loadNamedTemplate(pa.KickTemplate); template != "" {
+						s.logger.Info("using ACMM pack template", "agent", agentName, "level", *s.cfg.ACMMLevel, "template", pa.KickTemplate)
+						msg := fmt.Sprintf("[agent:%s] [KICK]\n\n", agentName)
+						msg += s.substituteTemplate(template, actionable, agentName, issues)
+						return msg
+					}
+				}
+			}
+		}
+	}
+
+	// 3. Convention: look for <agent>.md template file
 	if template := s.loadPromptTemplate(agentName); template != "" {
 		s.logger.Info("using prompt template for kick", "agent", agentName)
 		msg := fmt.Sprintf("[agent:%s] [KICK]\n\n", agentName)


### PR DESCRIPTION
## Summary

The scheduler now reads `acmm_level` from config and uses the pack's `kick_template` for each agent as the default. No more manual `kick_template` overrides needed — set `acmm_level: 3` and every agent gets the right policy automatically.

Resolution chain: config override → **ACMM pack default (NEW)** → convention → hardcoded

## Impact

- Setting `acmm_level: 3` gives quality `quality-holdgated.md`, scanner `scanner-advisory.md`, etc.
- Setting `acmm_level: 4` gives quality/ci-maint/sec-check holdgated, scanner/guide issues-only, etc.
- Explicit `kick_template` in hive.yaml still overrides everything (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)