### PR TITLE
fix: bump snapshot Netlify timeout from 300s to 600s

### DIFF
--- a/dashboard/publish-snapshot.sh
+++ b/dashboard/publish-snapshot.sh
@@ -94,7 +94,7 @@ echo "Created PR #${PR_NUM}: ${PR_URL}"
 
 # Wait for Netlify deploy-preview before merging
 NETLIFY_CHECK="netlify/kubestellar-docs/deploy-preview"
-NETLIFY_TIMEOUT_SECONDS=300
+NETLIFY_TIMEOUT_SECONDS=600
 NETLIFY_POLL_INTERVAL=15
 elapsed=0
 netlify_status="pending"


### PR DESCRIPTION
## Summary
- Netlify docs builds take ~7 minutes. The 300s timeout causes snapshot PRs to be abandoned unmerged every run on the 4.56 publisher.
- Bumps `NETLIFY_TIMEOUT_SECONDS` from 300 to 600 in `publish-snapshot.sh`.

## Test plan
- [ ] Verify next snapshot publish on 4.56 waits long enough for Netlify and merges successfully