### PR TITLE
feat: make hive.yaml single source of truth for config

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -368,8 +368,19 @@ func main() {
 			if uc := userGHClient.Load(); uc != nil {
 				uc.SetRepos(cfg.Project.Repos)
 			}
-			logger.Info("config overrides restored from persisted state",
+			logger.Info("migrated config overrides from state to hive.yaml",
 				"repos", cfg.Project.Repos)
+
+			// Write merged config to hive.yaml so overrides become the base config
+			if err := cfg.Save(); err != nil {
+				logger.Error("failed to save migrated config", "error", err)
+			}
+
+			// Strip config_overrides from state and re-save
+			saved.ConfigOverrides = nil
+			if err := snapshot.SaveState(statePath, saved, logger); err != nil {
+				logger.Error("failed to re-save state after migration", "error", err)
+			}
 		}
 	}
 
@@ -645,6 +656,24 @@ func main() {
 			logger.Warn("policy watcher failed to start", "error", err)
 		}
 	}
+
+	// Watch hive.yaml for external changes and reload config when modified
+	configWatcher := config.NewWatcher(*configPath, func(newCfg *config.Config) {
+		// Preserve runtime-only fields that are not in the YAML
+		newCfg.HiveID = cfg.HiveID
+
+		// Swap the in-memory config pointer contents
+		*cfg = *newCfg
+
+		// Re-sync subsystems that cache config values
+		ghClient.SetRepos(cfg.Project.Repos)
+		if uc := userGHClient.Load(); uc != nil {
+			uc.SetRepos(cfg.Project.Repos)
+		}
+		initAgentConfigDrivenSystems(cfg)
+		refreshDashboard()
+	}, logger)
+	go configWatcher.Start(ctx)
 
 	githubProxy, err := proxy.NewGitHubProxy(logger)
 	if err != nil {
@@ -1183,8 +1212,6 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 		issueCosts = tc.IssueCosts()
 	}
 
-	configOverrides := buildConfigOverrides(cfg)
-
 	state := &snapshot.PersistedState{
 		Agents:           agents,
 		GovernorMode:     string(govState.Mode),
@@ -1200,7 +1227,6 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 		IssueCosts:       issueCosts,
 		LastEval:         govState.LastEval,
 		ACMMLevel:        cfg.ACMMLevel,
-		ConfigOverrides:  configOverrides,
 	}
 
 	if err := snapshot.SaveState(path, state, logger); err != nil {
@@ -1239,69 +1265,6 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 			}
 		}
 	}
-}
-
-func buildConfigOverrides(cfg *config.Config) *snapshot.ConfigOverrides {
-	o := &snapshot.ConfigOverrides{}
-
-	if len(cfg.Project.Repos) > 0 {
-		o.ProjectRepos = cfg.Project.Repos
-	}
-
-	evalInterval := cfg.Governor.EvalIntervalS
-	o.EvalIntervalS = &evalInterval
-
-	if len(cfg.Governor.Modes) > 0 {
-		o.Thresholds = make(map[string]int, len(cfg.Governor.Modes))
-		for name, mode := range cfg.Governor.Modes {
-			o.Thresholds[name] = mode.Threshold
-		}
-	}
-
-	if len(cfg.Governor.Sensing.GHRatePatterns) > 0 {
-		o.SensingGHRate = cfg.Governor.Sensing.GHRatePatterns
-	}
-	if len(cfg.Governor.Sensing.CLIExcludePatterns) > 0 {
-		o.SensingCLIExclude = cfg.Governor.Sensing.CLIExcludePatterns
-	}
-	if len(cfg.Governor.Sensing.LoginPatterns) > 0 {
-		o.SensingLogin = cfg.Governor.Sensing.LoginPatterns
-	}
-	ttl := cfg.Governor.Sensing.TTLSeconds
-	o.SensingTTL = &ttl
-	pullback := cfg.Governor.Sensing.PullbackSeconds
-	o.SensingPullback = &pullback
-
-	if len(cfg.Governor.Labels.Exempt) > 0 {
-		o.ExemptLabels = cfg.Governor.Labels.Exempt
-	}
-
-	if cfg.Notifications.Ntfy != nil {
-		o.NtfyServer = cfg.Notifications.Ntfy.Server
-		o.NtfyTopic = cfg.Notifications.Ntfy.Topic
-	}
-	if cfg.Notifications.Discord != nil {
-		o.DiscordWebhook = cfg.Notifications.Discord.Webhook
-	}
-
-	hcInterval := cfg.Governor.Health.HealthcheckInterval
-	o.HealthcheckInterval = &hcInterval
-	cooldown := cfg.Governor.Health.RestartCooldown
-	o.RestartCooldown = &cooldown
-	modelLock := cfg.Governor.Health.ModelLock
-	o.ModelLock = &modelLock
-
-	logSize := cfg.Governor.Logging.MaxSizeMB
-	o.LogMaxSizeMB = &logSize
-	logAge := cfg.Governor.Logging.MaxAgeDays
-	o.LogMaxAgeDays = &logAge
-	logBackups := cfg.Governor.Logging.MaxBackups
-	o.LogMaxBackups = &logBackups
-	logCompress := cfg.Governor.Logging.Compress
-	o.LogCompress = &logCompress
-	o.LogLevel = cfg.Governor.Logging.Level
-
-	return o
 }
 
 func applyConfigOverrides(cfg *config.Config, o *snapshot.ConfigOverrides) {

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -3,6 +3,7 @@ module github.com/kubestellar/hive/v2
 go 1.25.6
 
 require (
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-github/v72 v72.0.0
 	github.com/google/uuid v1.6.0
@@ -10,4 +11,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require github.com/google/go-querystring v1.1.0 // indirect
+require (
+	github.com/google/go-querystring v1.1.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
+)

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -1,3 +1,5 @@
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -9,6 +11,8 @@ github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -840,9 +841,10 @@ func (c *Config) AgentByID(id string) (AgentConfig, bool) {
 	return AgentConfig{}, false
 }
 
-// Save marshals the current config back to its source YAML file.
-// This ensures dashboard mutations (repos, thresholds, etc.) survive container restarts.
-// Uses open+truncate instead of WriteFile to work with bind-mounted files in containers.
+// Save marshals the current config back to its source YAML file atomically.
+// It writes to a temporary file in the same directory, then renames over the
+// original. This prevents partial writes if the process crashes mid-save and
+// ensures watchers see a complete file.
 func (c *Config) Save() error {
 	if c.SourcePath == "" {
 		return fmt.Errorf("config has no source path")
@@ -851,17 +853,26 @@ func (c *Config) Save() error {
 	if err != nil {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
-	f, err := os.OpenFile(c.SourcePath, os.O_WRONLY|os.O_TRUNC, 0)
+
+	dir := filepath.Dir(c.SourcePath)
+	tmp, err := os.CreateTemp(dir, ".hive-yaml-*.tmp")
 	if err != nil {
-		return fmt.Errorf("opening config %s: %w", c.SourcePath, err)
+		return fmt.Errorf("creating temp config file: %w", err)
 	}
-	_, writeErr := f.Write(data)
-	closeErr := f.Close()
-	if writeErr != nil {
-		return fmt.Errorf("writing config %s: %w", c.SourcePath, writeErr)
+	tmpPath := tmp.Name()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("writing temp config: %w", err)
 	}
-	if closeErr != nil {
-		return fmt.Errorf("closing config %s: %w", c.SourcePath, closeErr)
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("closing temp config: %w", err)
+	}
+	if err := os.Rename(tmpPath, c.SourcePath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("renaming temp config to %s: %w", c.SourcePath, err)
 	}
 	return nil
 }

--- a/v2/pkg/config/watcher.go
+++ b/v2/pkg/config/watcher.go
@@ -1,0 +1,117 @@
+package config
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// debounceDelay is the time to wait after a file change event before
+// reloading, to avoid reloading mid-write (e.g. atomic rename has
+// multiple events).
+const debounceDelay = 500 * time.Millisecond
+
+// Watcher monitors a config file for changes and calls onChange with
+// the freshly loaded Config when the file is modified.
+type Watcher struct {
+	path     string
+	onChange func(*Config)
+	logger   *slog.Logger
+
+	mu      sync.Mutex
+	timer   *time.Timer
+	stopped bool
+}
+
+// NewWatcher creates a Watcher that will reload the config at path
+// whenever the file changes on disk, then invoke onChange with the
+// new Config.
+func NewWatcher(path string, onChange func(*Config), logger *slog.Logger) *Watcher {
+	return &Watcher{
+		path:     path,
+		onChange: onChange,
+		logger:   logger,
+	}
+}
+
+// Start begins watching the config file. It blocks until ctx is
+// cancelled or a fatal watcher error occurs. Callers should run
+// this in a goroutine.
+func (w *Watcher) Start(ctx context.Context) {
+	fsw, err := fsnotify.NewWatcher()
+	if err != nil {
+		w.logger.Error("failed to create fsnotify watcher", "error", err)
+		return
+	}
+	defer fsw.Close()
+
+	if err := fsw.Add(w.path); err != nil {
+		w.logger.Error("failed to watch config file", "path", w.path, "error", err)
+		return
+	}
+
+	w.logger.Info("config file watcher started", "path", w.path)
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.cancelTimer()
+			return
+
+		case event, ok := <-fsw.Events:
+			if !ok {
+				return
+			}
+			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) == 0 {
+				continue
+			}
+			w.scheduleReload()
+
+		case err, ok := <-fsw.Errors:
+			if !ok {
+				return
+			}
+			w.logger.Warn("config watcher error", "error", err)
+		}
+	}
+}
+
+// scheduleReload debounces reload calls: it resets the timer each
+// time a new event arrives, so the reload fires only after
+// debounceDelay of quiet.
+func (w *Watcher) scheduleReload() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.stopped {
+		return
+	}
+
+	if w.timer != nil {
+		w.timer.Stop()
+	}
+	w.timer = time.AfterFunc(debounceDelay, w.reload)
+}
+
+func (w *Watcher) cancelTimer() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.stopped = true
+	if w.timer != nil {
+		w.timer.Stop()
+	}
+}
+
+func (w *Watcher) reload() {
+	cfg, err := Load(w.path)
+	if err != nil {
+		w.logger.Warn("config reload failed", "path", w.path, "error", err)
+		return
+	}
+
+	w.logger.Info("config reloaded from file", "path", w.path)
+	w.onChange(cfg)
+}

--- a/v2/pkg/config/watcher_test.go
+++ b/v2/pkg/config/watcher_test.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWatcher_ReloadsOnChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hive.yaml")
+
+	initial := minimalValidYAML("original-org", "ghp_tok")
+	if err := os.WriteFile(path, []byte(initial), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var reloadCount atomic.Int32
+	var lastOrg atomic.Value
+
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	w := NewWatcher(path, func(cfg *Config) {
+		reloadCount.Add(1)
+		lastOrg.Store(cfg.Project.Org)
+	}, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go w.Start(ctx)
+
+	// Give the watcher time to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Modify the file
+	updated := minimalValidYAML("updated-org", "ghp_tok")
+	if err := os.WriteFile(path, []byte(updated), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for debounce + reload
+	const waitForReload = 2 * time.Second
+	deadline := time.Now().Add(waitForReload)
+	for time.Now().Before(deadline) {
+		if reloadCount.Load() > 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	if reloadCount.Load() == 0 {
+		t.Fatal("expected at least one reload after file change")
+	}
+
+	org, ok := lastOrg.Load().(string)
+	if !ok || org != "updated-org" {
+		t.Errorf("expected org = %q after reload, got %q", "updated-org", org)
+	}
+}
+
+func TestWatcher_CancelStops(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hive.yaml")
+	if err := os.WriteFile(path, []byte(minimalValidYAML("o", "ghp_tok")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	w := NewWatcher(path, func(cfg *Config) {}, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		w.Start(ctx)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// OK
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not stop after context cancellation")
+	}
+}
+
+func TestWatcher_Debounce(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hive.yaml")
+	if err := os.WriteFile(path, []byte(minimalValidYAML("o", "ghp_tok")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var reloadCount atomic.Int32
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	w := NewWatcher(path, func(cfg *Config) {
+		reloadCount.Add(1)
+	}, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go w.Start(ctx)
+	time.Sleep(100 * time.Millisecond)
+
+	// Write multiple times in quick succession — should debounce to one reload
+	const rapidWrites = 5
+	for i := 0; i < rapidWrites; i++ {
+		os.WriteFile(path, []byte(minimalValidYAML("o", "ghp_tok")), 0o600)
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Wait for debounce to settle
+	time.Sleep(time.Second)
+
+	count := reloadCount.Load()
+	if count > 2 {
+		t.Errorf("expected debouncing to reduce reloads, got %d reloads for %d writes", count, rapidWrites)
+	}
+}


### PR DESCRIPTION
## Summary
- Remove the hidden `config_overrides` layer in `hive-state.json` that silently reverted user edits to `hive.yaml` on restart
- Dashboard config mutations now write directly to `hive.yaml` (atomic temp-file + rename)
- Add `fsnotify`-based file watcher that reloads config when `hive.yaml` changes on disk (500ms debounce)
- One-time startup migration: any existing `config_overrides` in state are merged into `hive.yaml` then stripped from state

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/config/ -short` passes (58 tests including 3 new watcher tests)
- [ ] Manual: edit hive.yaml while running, verify config reloads
- [ ] Manual: verify dashboard mutations persist across restart via hive.yaml
- [ ] Manual: verify old state files with config_overrides are migrated on first start