### PR TITLE
fix: set BD_DIR env var so bd writes to configured beads_dir

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1773,6 +1773,13 @@ func (m *Manager) agentEnvPairs(agent *AgentProcess) []agentEnvPair {
 	if m.copilotAuthToken != "" {
 		vars = append(vars, agentEnvPair{"COPILOT_GITHUB_TOKEN", m.copilotAuthToken, true})
 	}
+	// BD_DIR tells the `bd` CLI where to read/write beads. Without this,
+	// bd falls back to cwd (/data/agents/<name>) instead of the configured
+	// beads_dir (/data/beads/<name>), causing a path mismatch with the
+	// dashboard and advisory digest.
+	if agent.Config.BeadsDir != "" {
+		vars = append(vars, agentEnvPair{"BD_DIR", agent.Config.BeadsDir, false})
+	}
 	if agent.UID > 0 {
 		vars = append(vars, agentEnvPair{"HOME", "/data/home", false})
 	}

--- a/v2/pkg/agent/manager_test.go
+++ b/v2/pkg/agent/manager_test.go
@@ -347,6 +347,53 @@ func TestAgentEnvPairs_EmptyModelAllowed(t *testing.T) {
 	}
 }
 
+func TestAgentEnvPairs_BDDirFromBeadsDir(t *testing.T) {
+	ap := &AgentProcess{
+		Name: "scanner",
+		Config: config.AgentConfig{
+			Backend:  "claude",
+			Model:    "claude-sonnet-4-6",
+			BeadsDir: "/data/beads/scanner",
+		},
+	}
+
+	pairs := testEnvPairs(ap)
+
+	found := false
+	for _, p := range pairs {
+		if p.Key == "BD_DIR" {
+			found = true
+			if p.Value != "/data/beads/scanner" {
+				t.Errorf("BD_DIR = %q, want %q", p.Value, "/data/beads/scanner")
+			}
+		}
+	}
+	if !found {
+		t.Error("BD_DIR should be present when BeadsDir is configured")
+	}
+
+	// Count should be baseEnvVarCount + 1 for BD_DIR
+	const expectedWithBDDir = baseEnvVarCount + 1
+	if len(pairs) != expectedWithBDDir {
+		t.Errorf("testEnvPairs() returned %d vars, want %d (base + BD_DIR)", len(pairs), expectedWithBDDir)
+	}
+}
+
+func TestAgentEnvPairs_NoBDDirWhenEmpty(t *testing.T) {
+	ap := &AgentProcess{
+		Name:   "worker",
+		Config: config.AgentConfig{Backend: "claude", Model: "sonnet"},
+	}
+
+	pairs := testEnvPairs(ap)
+
+	for _, p := range pairs {
+		if p.Key == "BD_DIR" {
+			t.Error("BD_DIR should not be present when BeadsDir is empty")
+		}
+	}
+}
+
 func TestCopilotToken_NotInEnvPrefix(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"worker": {Backend: "copilot", Model: "sonnet"},


### PR DESCRIPTION
## Summary
- The `bd` CLI resolves its storage path via `BD_DIR` env var, but the agent manager never set it
- Agents run with cwd `/data/agents/<name>`, so bd wrote beads there instead of the configured `beads_dir` (`/data/beads/<name>`)
- The dashboard and advisory digest read from `beads_dir`, causing beads to be invisible
- Fix: inject `BD_DIR=<BeadsDir>` into each agent's tmux environment in `agentEnvPairs()`
- Added tests verifying BD_DIR is present when BeadsDir is configured and absent when empty

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 16 packages)
- [x] New tests: `TestAgentEnvPairs_BDDirFromBeadsDir` and `TestAgentEnvPairs_NoBDDirWhenEmpty`