### PR TITLE
fix: enforce mode files and agent visibility on ACMM level switch

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1615,6 +1615,25 @@ func normalizeModelName(model string) string {
 	return model
 }
 
+// SyncModeFiles rewrites /tmp/.hive-mode-* for all running agents to reflect the given ACMM level.
+func (m *Manager) SyncModeFiles(level int) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for name, agent := range m.agents {
+		if agent.Paused || agent.State != StateRunning {
+			continue
+		}
+		mode := DefaultAgentMode(name, level)
+		if modeStr := agent.Config.Mode; modeStr != "" {
+			if parsed, ok := ParseAgentMode(modeStr); ok {
+				mode = parsed
+			}
+		}
+		modeFile := fmt.Sprintf("/tmp/.hive-mode-%s", name)
+		_ = os.WriteFile(modeFile, []byte(mode.String()), 0o644)
+	}
+}
+
 // agentMode returns the GitHub interaction mode for a given agent at the current ACMM level.
 // If the agent has an explicit Mode in its config (hive.yaml or pack YAML), that takes precedence.
 // Otherwise, the default table by ACMM level is used.

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -203,8 +203,12 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 
 	level := body.Level
 	s.deps.Config.ACMMLevel = &level
+
+	s.deps.AgentMgr.SyncModeFiles(level)
+	paused, resumed := s.syncAgentVisibility(level)
+
 	s.persistOnly()
-	go s.refreshAsync()
+	s.refreshAsync()
 
 	pack, packErr := config.ACMMPackByLevel(level)
 	var packAgentNames []string
@@ -216,11 +220,13 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	s.logger.Info("ACMM level preview set", "level", body.Level)
+	s.logger.Info("ACMM level set", "level", body.Level, "paused", len(paused), "resumed", len(resumed))
 	jsonResponse(w, map[string]interface{}{
 		"ok":         true,
 		"level":      body.Level,
 		"packAgents": packAgentNames,
+		"paused":     paused,
+		"resumed":    resumed,
 	})
 }
 


### PR DESCRIPTION
## Summary
- `handlePackSetLevel` was a no-op for enforcement — it only updated `ACMMLevel` in config without syncing mode files or agent visibility
- Added `SyncModeFiles()` to `Manager` — rewrites `/tmp/.hive-mode-*` for all running agents when the level changes
- `handlePackSetLevel` now calls `syncAgentVisibility()` to pause/resume agents based on pack membership
- Removed `go` goroutine from `refreshAsync()` to eliminate race condition on rapid level switches

## Root Cause
The stress test (500 random level switches) found **3,040 violations** across 6 categories, all tracing to 3 root causes in `handlePackSetLevel`:
1. Mode files not updated → proxy enforces stale modes (1,333 + 837 violations)
2. `syncAgentVisibility` not called → agents stay running/paused at wrong level (356 + 185 violations)
3. `go s.refreshAsync()` race → dashboard reports stale level (324 violations)

## Test plan
- [ ] Re-run 500-iteration stress test script — expect 0 violations
- [ ] Verify supervisor stays ADVISORY at all levels (already passing)
- [ ] Verify mode files match API modes after level switch
- [ ] Verify `go test ./v2/pkg/agent/ ./v2/pkg/dashboard/` passes (verified locally)