### PR TITLE
🐛 fix: check release freshness by published date

### DIFF
--- a/dashboard/health-check.sh
+++ b/dashboard/health-check.sh
@@ -19,6 +19,7 @@ fi
 
 # Load project config
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+source "$(cd "$(dirname "$0")" && pwd)/health-lib.sh"
 if [ -f /usr/local/bin/hive-config.sh ]; then
   source /usr/local/bin/hive-config.sh
 elif [ -f "$SCRIPT_DIR/bin/hive-config.sh" ]; then
@@ -91,13 +92,13 @@ else
 fi
 
 # ── Release freshness — nightly (24h) and weekly (7d) ────────────────────────
-# Check GitHub Releases: nightly = prerelease with -nightly tag in last 24h,
-# weekly/stable = non-prerelease release in last 7 days.
+# Check GitHub Releases by published_at, not created_at. GitHub's release list
+# ordering can surface older prerelease tags first when created_at differs from
+# publish time, which causes false stale-release alarms.
 ONE_DAY_AGO=$(date -u -v-1d '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '1 day ago' '+%Y-%m-%dT%H:%M:%SZ')
 SEVEN_DAYS_AGO=$(date -u -v-7d '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')
-releases=$(gh api "repos/${REPO}/releases?per_page=20" --jq '[.[] | {tag_name, prerelease, draft, created_at}]' 2>/dev/null || echo "[]")
-nightly_rel_ok=$(echo "$releases" | jq -r "[.[] | select(.prerelease == true and .draft == false and (.created_at > \"${ONE_DAY_AGO}\") and (.tag_name | test(\"nightly\")))] | if length > 0 then 1 else 0 end")
-weekly_rel_ok=$(echo "$releases" | jq -r "[.[] | select(.prerelease == false and .draft == false and (.created_at > \"${SEVEN_DAYS_AGO}\") and (.tag_name | test(\"nightly\") | not))] | if length > 0 then 1 else 0 end")
+releases=$(gh api "repos/${REPO}/releases?per_page=100" --jq '[.[] | {tag_name, prerelease, draft, published_at}]' 2>/dev/null || echo "[]")
+read -r nightly_rel_ok weekly_rel_ok <<< "$(release_freshness_from_json "$releases" "$ONE_DAY_AGO" "$SEVEN_DAYS_AGO")"
 
 # ── Weekly workflow ──────────────────────────────────────────────────────────
 # Check for a "Weekly" type workflow from config, or fall back to hardcoded

--- a/dashboard/health-lib.sh
+++ b/dashboard/health-lib.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+release_freshness_from_json() {
+  local releases="$1"
+  local one_day_ago="$2"
+  local seven_days_ago="$3"
+
+  echo "$releases" | jq -r --arg one_day_ago "$one_day_ago" --arg seven_days_ago "$seven_days_ago" '
+    def release_time: (.published_at // "");
+    def fresh_nightly:
+      [
+        .[]
+        | select(.prerelease == true)
+        | select(.draft == false)
+        | select(.tag_name | test("nightly"))
+      ]
+      | sort_by(release_time)
+      | reverse
+      | .[0]?
+      | if . == null then 0 elif release_time > $one_day_ago then 1 else 0 end;
+    def fresh_weekly:
+      [
+        .[]
+        | select(.prerelease == false)
+        | select(.draft == false)
+        | select((.tag_name | test("nightly")) | not)
+      ]
+      | sort_by(release_time)
+      | reverse
+      | .[0]?
+      | if . == null then 0 elif release_time > $seven_days_ago then 1 else 0 end;
+    "\(fresh_nightly) \(fresh_weekly)"
+  '
+}

--- a/tests/health-release-freshness-test.sh
+++ b/tests/health-release-freshness-test.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+source "$ROOT_DIR/dashboard/health-lib.sh"
+
+cutoff_day="2026-05-29T12:00:00Z"
+cutoff_week="2026-05-23T12:00:00Z"
+
+releases='[
+  {
+    "tag_name": "v0.3.24-nightly.20260503",
+    "prerelease": true,
+    "draft": false,
+    "published_at": "2026-05-03T06:30:33Z"
+  },
+  {
+    "tag_name": "v0.3.29-nightly.20260530",
+    "prerelease": true,
+    "draft": false,
+    "published_at": "2026-05-30T06:30:33Z"
+  },
+  {
+    "tag_name": "v0.3.28",
+    "prerelease": false,
+    "draft": false,
+    "published_at": "2026-05-28T06:30:33Z"
+  }
+]'
+
+result="$(release_freshness_from_json "$releases" "$cutoff_day" "$cutoff_week")"
+if [[ "$result" != "1 1" ]]; then
+  echo "expected fresh nightly and weekly releases, got: $result" >&2
+  exit 1
+fi
+
+stale_releases='[
+  {
+    "tag_name": "v0.3.24-nightly.20260503",
+    "prerelease": true,
+    "draft": false,
+    "published_at": "2026-05-03T06:30:33Z"
+  },
+  {
+    "tag_name": "v0.3.20",
+    "prerelease": false,
+    "draft": false,
+    "published_at": "2026-05-01T06:30:33Z"
+  }
+]'
+
+result="$(release_freshness_from_json "$stale_releases" "$cutoff_day" "$cutoff_week")"
+if [[ "$result" != "0 0" ]]; then
+  echo "expected stale nightly and weekly releases, got: $result" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Release freshness checks now use GitHub release `published_at` timestamps instead of `created_at`, so older prerelease tags no longer cause fresh nightly releases to be reported as stale.

This also checks up to 100 releases and moves the nightly/stable freshness selection into a small shell helper so the edge case can be covered with fixture data.

Fixes kubestellar/hive#681.

## Verification

```bash
bash -n dashboard/health-check.sh dashboard/health-lib.sh tests/health-release-freshness-test.sh
bash tests/health-release-freshness-test.sh
env -u HIVE_GITHUB_TOKEN bash dashboard/health-check.sh
```

The no-token fallback still returns the existing fallback JSON shape.
