### PR TITLE
fix: stop converting copilot model dots to hyphens

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -60,6 +60,7 @@ if [ "$(id -u)" = "0" ]; then
   ln -sfn /data/config/github-copilot /data/home/.config/github-copilot
   ln -sfn /data/home/.copilot /home/dev/.copilot
   chmod -R g+rwX /data/home 2>/dev/null || true
+  chmod g+s /data/home/.copilot 2>/dev/null || true
   chown -R dev:node /data/config /data/home /home/dev/.config 2>/dev/null || true
   echo "[entrypoint] CLI config: /data/home (shared, group-writable for agent UIDs)"
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -353,23 +353,22 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 				" --disallowed-tools 'mcp__github__merge_pull_request'"
 		}
 	case "copilot":
-		copilotModel := strings.ReplaceAll(model, ".", "-")
 		switch {
 		case mode >= ModeIssuesAndPRs:
 			launchCmd = fmt.Sprintf("%s --model %s --allow-all --enable-all-github-mcp-tools",
-				binary, copilotModel)
+				binary, model)
 		case mode == ModeIssuesOnly:
 			launchCmd = fmt.Sprintf("%s --model %s --allow-all --enable-all-github-mcp-tools"+
 				" --deny-tool='github(create_pull_request)'"+
 				" --deny-tool='github(merge_pull_request)'",
-				binary, copilotModel)
+				binary, model)
 		default:
 			launchCmd = fmt.Sprintf("%s --model %s --allow-all"+
 				" --deny-tool='github(create_pull_request)'"+
 				" --deny-tool='github(create_issue)'"+
 				" --deny-tool='github(update_issue)'"+
 				" --deny-tool='github(merge_pull_request)'",
-				binary, copilotModel)
+				binary, model)
 		}
 	case "gemini":
 		launchCmd = fmt.Sprintf("%s --model %s", binary, model)


### PR DESCRIPTION
## Summary
- Remove `strings.ReplaceAll(model, ".", "-")` in the copilot launch path — `normalizeModelName()` already converts `claude-sonnet-4-6` → `claude-sonnet-4.6`, but line 356 was undoing it
- Copilot CLI v1.0.55+ requires dot-separated model names (`claude-sonnet-4.6`) and silently exits with code 1 on hyphens
- Set setgid on `.copilot` dir so `config.json` stays group-readable when copilot rewrites it under an agent UID

## Root Cause
All agents on all three hive containers (knuckle/kubestellar/certus) were crashing on launch because:
1. `normalizeModelName()` correctly produced `claude-sonnet-4.6`
2. The copilot case immediately reversed it: `copilotModel := strings.ReplaceAll(model, ".", "-")`
3. Copilot CLI v1.0.55+ rejects `claude-sonnet-4-6` with a silent exit code 1

## Test plan
- [ ] Verify `normalizeModelName("claude-sonnet-4-6")` returns `claude-sonnet-4.6`
- [ ] Verify copilot agents launch successfully with dot-format model names
- [ ] Verify config.json remains group-readable after container restart