### PR TITLE
fix: copilot model name format + config.json perm watchdog

### DIFF
--- a/bin/agent-launch.sh
+++ b/bin/agent-launch.sh
@@ -4,11 +4,11 @@
 # Supported backends: claude, copilot (add more in the case block below)
 #
 # Usage (in .env files):
-#   AGENT_LAUNCH_CMD="agent-launch.sh --backend copilot --model claude-opus-4-6"
-#   AGENT_LAUNCH_CMD="agent-launch.sh --backend claude --model claude-opus-4-6"
+#   AGENT_LAUNCH_CMD="agent-launch.sh --backend copilot --model claude-opus-4.6"
+#   AGENT_LAUNCH_CMD="agent-launch.sh --backend claude --model claude-opus-4.6"
 #
 # Or override with env vars:
-#   AGENT_BACKEND=copilot AGENT_MODEL=claude-opus-4-6 agent-launch.sh
+#   AGENT_BACKEND=copilot AGENT_MODEL=claude-opus-4.6 agent-launch.sh
 #
 # Adding a new backend:
 #   1. Add a case block below with CMD, PERM_FLAG, MODEL_FLAG
@@ -16,6 +16,9 @@
 #   3. Update kick-agents.sh session_idle() if prompt differs
 
 set -euo pipefail
+
+# Agents share /data/home/.copilot — umask 007 ensures new files are group-rw.
+umask 007
 
 # Source hive-config.sh to make HIVE_GITHUB_TOKEN available for gh wrapper.
 # Do NOT export GH_TOKEN here — Copilot CLI uses GH_TOKEN for its own Copilot
@@ -99,4 +102,17 @@ if [[ "$BACKEND" == "copilot" ]]; then
   fi
 fi
 
-exec "${FULL_CMD[@]}"
+# Capture stderr so silent failures (e.g. invalid model name) leave a diagnostic.
+STDERR_LOG="/tmp/.hive-launch-stderr-${HIVE_AGENT:-unknown}.log"
+"${FULL_CMD[@]}" 2> >(tee "$STDERR_LOG" >&2)
+EXIT_CODE=$?
+if [[ $EXIT_CODE -ne 0 ]]; then
+  echo "HIVE: ${CMD} exited with code ${EXIT_CODE}" >&2
+  if [[ -s "$STDERR_LOG" ]]; then
+    echo "HIVE: stderr output:" >&2
+    cat "$STDERR_LOG" >&2
+  else
+    echo "HIVE: no stderr output (silent failure)" >&2
+  fi
+fi
+exit $EXIT_CODE

--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -65,6 +65,23 @@ if [ "$(id -u)" = "0" ]; then
   chown -R dev:node /data/config /data/home /home/dev/.config 2>/dev/null || true
   echo "[entrypoint] CLI config: /data/home (shared, group-writable for agent UIDs)"
 
+  # Background watchdog: copilot CLI recreates config.json with 600 perms on
+  # token refresh, locking out other agent UIDs. This loop resets ownership
+  # and permissions every 30s so all agents can read the shared token.
+  COPILOT_PERM_INTERVAL_S=30
+  (
+    while true; do
+      sleep "$COPILOT_PERM_INTERVAL_S"
+      if [[ -f /data/home/.copilot/config.json ]]; then
+        current_perms=$(stat -c '%a' /data/home/.copilot/config.json 2>/dev/null)
+        if [[ "$current_perms" != "660" ]]; then
+          chown dev:node /data/home/.copilot/config.json 2>/dev/null
+          chmod 660 /data/home/.copilot/config.json 2>/dev/null
+        fi
+      fi
+    done
+  ) &
+
   # ── Per-agent UID isolation ──────────────────────────────────────────
   # Extract agent names from config + pack YAML, create system users,
   # write UID map, and set up iptables to force all outbound :443

--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -60,6 +60,8 @@ if [ "$(id -u)" = "0" ]; then
   ln -sfn /data/config/github-copilot /data/home/.config/github-copilot
   ln -sfn /data/home/.copilot /home/dev/.copilot
   chmod -R g+rwX /data/home 2>/dev/null || true
+  # setgid on .copilot so new files inherit group node (agents share this dir)
+  chmod g+s /data/home/.copilot 2>/dev/null || true
   chown -R dev:node /data/config /data/home /home/dev/.config 2>/dev/null || true
   echo "[entrypoint] CLI config: /data/home (shared, group-writable for agent UIDs)"
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -353,23 +353,22 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 				" --disallowed-tools 'mcp__github__merge_pull_request'"
 		}
 	case "copilot":
-		copilotModel := strings.ReplaceAll(model, ".", "-")
 		switch {
 		case mode >= ModeIssuesAndPRs:
 			launchCmd = fmt.Sprintf("%s --model %s --allow-all --enable-all-github-mcp-tools",
-				binary, copilotModel)
+				binary, model)
 		case mode == ModeIssuesOnly:
 			launchCmd = fmt.Sprintf("%s --model %s --allow-all --enable-all-github-mcp-tools"+
 				" --deny-tool='github(create_pull_request)'"+
 				" --deny-tool='github(merge_pull_request)'",
-				binary, copilotModel)
+				binary, model)
 		default:
 			launchCmd = fmt.Sprintf("%s --model %s --allow-all"+
 				" --deny-tool='github(create_pull_request)'"+
 				" --deny-tool='github(create_issue)'"+
 				" --deny-tool='github(update_issue)'"+
 				" --deny-tool='github(merge_pull_request)'",
-				binary, copilotModel)
+				binary, model)
 		}
 	case "gemini":
 		launchCmd = fmt.Sprintf("%s --model %s", binary, model)

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -861,9 +861,7 @@ func (s *Server) handleAgentConfigGet(w http.ResponseWriter, r *http.Request) {
 		if cli == "claude" {
 			launchCmd = fmt.Sprintf("claude --model %s --dangerously-skip-permissions", model)
 		} else if cli == "copilot" {
-			// Copilot CLI uses dashes in model IDs (claude-opus-4-6), not dots (claude-opus-4.6)
-			cliModel := strings.ReplaceAll(model, ".", "-")
-			launchCmd = fmt.Sprintf("/usr/bin/copilot --allow-all --model %s", cliModel)
+			launchCmd = fmt.Sprintf("/usr/bin/copilot --allow-all --model %s", model)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Stop converting dots to hyphens in copilot model names — copilot CLI v1.0.55+ requires `claude-sonnet-4.6` (dot), not `claude-sonnet-4-6` (hyphen). The old format causes silent exit code 1 failures.
- Add stderr capture to `agent-launch.sh` so silent copilot failures leave a diagnostic in the tmux pane instead of just returning to a bare shell.
- Add `umask 007` to `agent-launch.sh` so copilot creates shared files as group-readable.
- Add setgid bit on `.copilot` dir so new files inherit group `node`.
- Add background watchdog (30s loop) in entrypoint to reset `config.json` perms to `dev:node 660` — copilot recreates it with `600` on token refresh, locking out other agent UIDs.

## Test plan
- [ ] Verify agents start successfully with `claude-sonnet-4.6` model name
- [ ] Verify config.json stays `660` after copilot token refresh
- [ ] Verify stderr diagnostic appears on copilot silent failures