### PR TITLE
fix: persist ACMM level to hive.yaml on change

### DIFF
--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -106,6 +106,9 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 	}
 
 	s.deps.Config.ACMMLevel = &level
+	if err := s.deps.Config.Save(); err != nil {
+		s.logger.Error("failed to save ACMM level to hive.yaml", "error", err)
+	}
 
 	if pack.Governor.EvalIntervalS > 0 {
 		s.deps.Config.Governor.EvalIntervalS = pack.Governor.EvalIntervalS
@@ -203,6 +206,9 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 
 	level := body.Level
 	s.deps.Config.ACMMLevel = &level
+	if err := s.deps.Config.Save(); err != nil {
+		s.logger.Error("failed to save ACMM level to hive.yaml", "error", err)
+	}
 
 	s.deps.AgentMgr.SyncModeFiles(level)
 	paused, resumed := s.syncAgentVisibility(level)


### PR DESCRIPTION
## Summary

- When user changes ACMM level via dashboard, now writes to `hive.yaml` via `cfg.Save()` 
- Previously only saved to in-memory state file — on container restart, level defaulted back because `hive.yaml` had no `acmm_level` field
- Fixes the "level resets to L1/L4 on restart" bug

## Test plan
- [x] Build + tests pass
- [ ] Set level to L1 via dashboard, restart container, verify level stays at L1