### PR TITLE
feat: add brainstorm agent + ApplyPack template updates

### DIFF
--- a/v2/docs/acmm-policy-matrix.md
+++ b/v2/docs/acmm-policy-matrix.md
@@ -18,17 +18,18 @@ Each agent runs in one of four modes, controlling what actions it can take on Gi
 
 ## ACMM Levels
 
-### L1 — Assisted (1 agent)
+### L1 — Assisted (2 agents)
 
-A single interactive advisor helps with repo setup and architecture decisions.
+A single interactive advisor helps with repo setup and architecture decisions. Guide agent makes advisory beads. Brainstorm agent handles project inception — turning raw ideas into structured KB facts and scaffold. No feedback loops.
 
 | Agent | Mode | Template |
 |-------|------|----------|
 | guide | advisory | `guide-advisory.md` |
+| brainstorm | advisory | `brainstorm-inception.md` |
 
-### L2 — Instructed (4 agents)
+### L2 — Instructed (5 agents)
 
-Agents observe and report findings as advisory beads. No GitHub issues or PRs. Humans decide what to act on.
+Agents observe and report findings as advisory beads on the dashboard and tracking issue. No GitHub issues or PRs created. Humans decide what to act on.
 
 | Agent | Mode | Template |
 |-------|------|----------|
@@ -36,10 +37,11 @@ Agents observe and report findings as advisory beads. No GitHub issues or PRs. H
 | scanner | advisory | `scanner-advisory.md` |
 | quality | advisory | `quality-advisory.md` |
 | guide | advisory | `guide-advisory.md` |
+| brainstorm | advisory | `brainstorm-advisory.md` |
 
-### L3 — Measured (5 agents)
+### L3 — Measured (6 agents)
 
-Quality opens issues AND hold-gated PRs about testing gaps. All other agents remain advisory. CI-maintainer joins to monitor build health.
+Quality agent opens GitHub issues and PRs about testing gaps, coverage, and CI workflows. All other agents remain advisory. CI-maintainer joins to monitor build health. Key artifact: measurement infrastructure.
 
 | Agent | Mode | Template |
 |-------|------|----------|
@@ -48,10 +50,11 @@ Quality opens issues AND hold-gated PRs about testing gaps. All other agents rem
 | ci-maintainer | advisory | `ci-maintainer-advisory.md` |
 | **quality** | **holdgated** | `quality-holdgated.md` |
 | guide | advisory | `guide-advisory.md` |
+| brainstorm | advisory | `brainstorm-advisory.md` |
 
-### L4 — Adaptive (6 agents)
+### L4 — Adaptive (7 agents)
 
-All agents open GitHub issues. Quality, ci-maintainer, and sec-check may also open hold-gated PRs. Security agent joins. Closed-loop feedback: agents act on their own findings.
+All agents open GitHub issues — bugs, docs gaps, CI problems, security vulnerabilities. Only Quality, sec-check, and ci-maintainer may open PRs. Security agent joins. Closed-loop feedback: agents act on their own findings.
 
 | Agent | Mode | Template |
 |-------|------|----------|
@@ -61,10 +64,11 @@ All agents open GitHub issues. Quality, ci-maintainer, and sec-check may also op
 | **quality** | **holdgated** | `quality-holdgated.md` |
 | guide | measured | `guide-issues.md` |
 | **sec-check** | **holdgated** | `sec-check-holdgated.md` |
+| brainstorm | advisory | `brainstorm-advisory.md` |
 
-### L5 — Semi-Automated (8 agents)
+### L5 — Semi-Automated (9 agents)
 
-All agents open issues AND hold-gated PRs. Architect produces RFCs, strategist coordinates across agents. The system proposes; it does not merge autonomously.
+Agents open issues AND pull requests. All PRs get a hold label — humans batch-review and approve. Architect produces RFCs, strategist coordinates across agents. The system proposes; it does not merge autonomously.
 
 | Agent | Mode | Template |
 |-------|------|----------|
@@ -76,10 +80,11 @@ All agents open issues AND hold-gated PRs. Architect produces RFCs, strategist c
 | sec-check | holdgated | `sec-check-holdgated.md` |
 | architect | holdgated | `architect-holdgated.md` |
 | strategist | holdgated | `strategist-holdgated.md` |
+| brainstorm | advisory | `brainstorm-advisory.md` |
 
-### L6 — Fully Autonomous (9 agents)
+### L6 — Fully Autonomous (10 agents)
 
-Agents open issues, create PRs, and auto-merge on green CI. No hold label. Outreach agent handles community engagement. Governor at fastest cadence.
+Agents open issues, create PRs, and auto-merge on green CI. No hold label. Outreach agent handles community engagement (highest trust — external-facing). Governor at fastest cadence.
 
 | Agent | Mode | Template |
 |-------|------|----------|
@@ -92,6 +97,7 @@ Agents open issues, create PRs, and auto-merge on green CI. No hold label. Outre
 | architect | full | `architect-full.md` |
 | strategist | full | `strategist-full.md` |
 | outreach | full | `outreach-full.md` |
+| brainstorm | advisory | `brainstorm-advisory.md` |
 
 ## Key Rules
 
@@ -100,3 +106,4 @@ Agents open issues, create PRs, and auto-merge on green CI. No hold label. Outre
 3. **Supervisor never touches GitHub.** At every level, supervisor uses `supervisor-nogithub.md` — it monitors agent health, not code.
 4. **Mode escalation is per-agent.** At L4, some agents are measured (issues only) while others are holdgated (issues + PRs). The level defines the mix.
 5. **Knowledge priming works at all levels.** The `${KNOWLEDGE}` template variable injects relevant facts from git sources and wiki layers regardless of the agent's mode.
+6. **Brainstorm is always advisory.** It produces KB facts and beads, never GitHub issues or PRs. Its role evolves from inception (L1) to ongoing ideation (L2+), but its mode stays advisory at all levels.

--- a/v2/pkg/config/acmm_packs_test.go
+++ b/v2/pkg/config/acmm_packs_test.go
@@ -25,7 +25,7 @@ func TestACMMPacksAgentCounts(t *testing.T) {
 	packs := ACMMPacks()
 
 	expected := map[int]int{
-		1: 1, 2: 4, 3: 5, 4: 6, 5: 8, 6: 9,
+		1: 2, 2: 5, 3: 6, 4: 7, 5: 9, 6: 10,
 	}
 	for _, p := range packs {
 		want, ok := expected[p.Level]

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -857,7 +857,13 @@ func (c *Config) Save() error {
 	dir := filepath.Dir(c.SourcePath)
 	tmp, err := os.CreateTemp(dir, ".hive-yaml-*.tmp")
 	if err != nil {
-		return fmt.Errorf("creating temp config file: %w", err)
+		// Directory may not be writable (e.g. bind-mounted config file in a
+		// container where only the file itself is rw). Fall back to writing
+		// the file directly — less atomic but still correct.
+		if writeErr := os.WriteFile(c.SourcePath, data, 0o644); writeErr != nil {
+			return fmt.Errorf("writing config (direct fallback): %w", writeErr)
+		}
+		return nil
 	}
 	tmpPath := tmp.Name()
 

--- a/v2/pkg/config/packs/level-1.yaml
+++ b/v2/pkg/config/packs/level-1.yaml
@@ -1,11 +1,11 @@
 level: 1
 name: Assisted
 description: >
-  Project inception. A single interactive advisor turns a raw idea into
-  structured KB facts and project scaffolding. Supports greenfield (new
-  project from an idea) and brownfield (existing repo enrichment). All
-  actions require human approval. No feedback loops — the advisor responds
-  to requests but does not monitor or act autonomously.
+  Project inception. An interactive brainstorm agent turns raw ideas into
+  structured KB facts and project scaffolding. A guide agent audits
+  documentation. Supports greenfield (new project from an idea) and
+  brownfield (existing repo enrichment). All actions require human
+  approval. No feedback loops.
 governor:
   modes: none
   merge_policy: manual
@@ -13,18 +13,18 @@ governor:
   cadences:
     quiet:
       guide: 2h
+      brainstorm: 1h
     idle:
       guide: 4h
+      brainstorm: 2h
 agents:
   - name: guide
     display_name: guide
     role: guide
     description: >
-      Project inception advisor that turns a raw idea into structured
-      knowledge — vision, constitution, requirements, constraints, acceptance
-      criteria. Queries community KB for scaffolding patterns and produces
-      project bootstrap files. Supports both greenfield (new repo) and
-      brownfield (existing repo enrichment).
+      Interactive advisor that queries the community knowledge base for
+      scaffolding patterns. Helps create repos, initial structure, and test
+      stubs. No autonomous actions — everything is conversational.
     emoji: "🧭"
     color: "#8e44ad"
     sort_order: 10
@@ -32,13 +32,37 @@ agents:
     model: claude-sonnet-4-6
     bead_role: worker
     mode: ADVISORY
-    kick_template: guide-inception.md
+    kick_template: guide-advisory.md
     include_repos: false
     stale_timeout: 7200
-    interactions: "Standalone. Responds to user queries and inception workflow."
+    interactions: "Standalone. Responds to user queries only."
+    knowledge_use: >
+      Heavy consumer — reads community wiki, project patterns, and scaffolding
+      templates. Does not produce knowledge entries at this level.
+
+  - name: brainstorm
+    display_name: brainstorm
+    role: brainstorm
+    description: >
+      Project inception and ideation agent. At L1, turns a raw idea into
+      structured knowledge — vision, constitution, requirements, constraints,
+      acceptance criteria. Queries community KB for scaffolding patterns and
+      produces project bootstrap files. At higher levels, proposes features,
+      architecture directions, and strategic improvements.
+    emoji: "💡"
+    color: "#f39c12"
+    sort_order: 5
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    mode: ADVISORY
+    kick_template: brainstorm-inception.md
+    include_repos: false
+    stale_timeout: 7200
+    interactions: "Standalone. Driven by inception workflow and user queries."
     knowledge_use: >
       Heavy consumer of community wiki patterns, scaffolding templates, and
-      language-specific defaults. At L1, also PRODUCES ideation facts (idea,
-      vision, constitution, requirement, constraint, stakeholder, acceptance)
-      into the project KB layer. These facts persist into L2+ and inform all
-      future agent behavior.
+      language-specific defaults. PRODUCES ideation facts (idea, vision,
+      constitution, requirement, constraint, stakeholder, acceptance) into the
+      project KB layer. These facts persist into L2+ and inform all future
+      agent behavior.

--- a/v2/pkg/config/packs/level-2.yaml
+++ b/v2/pkg/config/packs/level-2.yaml
@@ -1,10 +1,10 @@
 level: 2
 name: Instructed
 description: >
-  One-way feedback. Four agents (supervisor, scanner, quality, guide) produce
-  advisory beads — findings visible on the dashboard and in a tracking issue.
-  No GitHub issues or PRs created. Agents observe and report; humans decide
-  what to act on.
+  One-way feedback. Five agents (supervisor, scanner, quality, guide, brainstorm)
+  produce advisory beads — findings visible on the dashboard and in a tracking
+  issue. No GitHub issues or PRs created. Agents observe and report; humans
+  decide what to act on.
 governor:
   modes: SURGE, BUSY, QUIET, IDLE
   merge_policy: manual
@@ -15,21 +15,25 @@ governor:
       guide: 4h
       scanner: 4h
       quality: 6h
+      brainstorm: 4h
     busy:
       supervisor: 5m
       guide: 4h
       scanner: 4h
       quality: 6h
+      brainstorm: 4h
     quiet:
       supervisor: 5m
       guide: 4h
       scanner: 4h
       quality: 6h
+      brainstorm: 4h
     idle:
       supervisor: 5m
       guide: 4h
       scanner: 4h
       quality: 6h
+      brainstorm: 4h
 agents:
   - name: supervisor
     display_name: Supervisor
@@ -114,3 +118,25 @@ agents:
     knowledge_use: >
       Reads test patterns, coverage rules, and known regressions from the
       knowledge base to prioritize which code needs tests most.
+  - name: brainstorm
+    display_name: brainstorm
+    role: brainstorm
+    description: >
+      Ongoing ideation agent. Proposes features, architecture improvements,
+      and strategic directions based on project patterns and community KB.
+      Produces KB facts and advisory beads.
+    emoji: "💡"
+    color: "#f39c12"
+    sort_order: 30
+    backend: copilot
+    model: claude-sonnet-4-6
+    bead_role: worker
+    mode: ADVISORY
+    kick_template: brainstorm-advisory.md
+    include_repos: true
+    stale_timeout: 7200
+    interactions: "Standalone. Produces ideation beads for human review."
+    knowledge_use: >
+      Heavy consumer of community wiki patterns. Produces ideation facts
+      (feature proposals, architecture decisions, strategic direction) into
+      the project KB layer.

--- a/v2/pkg/config/packs/level-3.yaml
+++ b/v2/pkg/config/packs/level-3.yaml
@@ -1,9 +1,10 @@
 level: 3
 name: Measured
-description: >
-  Feedback becomes visible. Quality opens issues AND hold-gated PRs about
-  testing gaps. All PRs get 'hold' label; no agent merges. All other agents
-  remain advisory (beads only). CI-maintainer joins to monitor build health.
+description: 'Feedback becomes visible. Quality opens issues AND hold-gated PRs about
+  testing gaps. All PRs get ''hold'' label; no agent merges. All other agents remain
+  advisory (beads only). CI-maintainer joins to monitor build health.
+
+  '
 governor:
   modes: SURGE, BUSY, QUIET, IDLE
   merge_policy: hold-gated (quality PRs only)
@@ -20,130 +21,178 @@ governor:
       ci-maintainer: pause
       quality: pause
       guide: pause
+      brainstorm: pause
     busy:
       supervisor: 5m
       scanner: 4h
       ci-maintainer: 4h
       quality: 2h
       guide: 4h
+      brainstorm: 4h
     quiet:
       supervisor: 5m
       scanner: 4h
       ci-maintainer: 4h
       quality: 2h
       guide: 4h
+      brainstorm: 4h
     idle:
       supervisor: 5m
       scanner: 4h
       ci-maintainer: 4h
       quality: 2h
       guide: 4h
+      brainstorm: 4h
 agents:
-  - name: supervisor
-    display_name: Supervisor
-    role: supervisor
-    description: >
-      Agent health monitoring, sweep analysis, and escalation. Watches all
-      other agents for stalls, rate limits, and anomalies.
-    emoji: "👑"
-    color: "#e74c3c"
-    sort_order: 1
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: supervisor
-    mode: NO_GITHUB
-    kick_template: supervisor-nogithub.md
-    include_repos: true
-    stale_timeout: 1800
-    interactions: >
-      Monitors all agents. Escalates issues to human operators. Coordinates
-      agent restarts and health checks.
-    knowledge_use: >
-      Reads agent health history and operational patterns. Produces sweep
-      reports and health assessments.
-  - name: scanner
-    display_name: scanner (advisory)
-    role: scanner
-    description: >
-      Scans code for issues and suggests fixes, but does NOT create PRs or
-      issues. Reports findings as beads for the advisory digest.
-    emoji: "🔍"
-    color: "#3498db"
-    sort_order: 20
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: worker
-    mode: ADVISORY
-    kick_template: scanner-advisory.md
-    include_repos: true
-    stale_timeout: 7200
-    lane_keywords: [bug, triage, fix]
-    interactions: "Produces advisory findings. No autonomous actions."
-    knowledge_use: >
-      Reads project patterns and known issues. Produces findings as advisory
-      beads for the team to review.
-  - name: ci-maintainer
-    display_name: ci-maintainer (advisory)
-    role: ci-maintainer
-    description: >
-      Monitors CI health, workflow status, and build trends. Reports findings
-      as beads for the advisory digest. Does NOT create PRs or issues.
-    emoji: "🔧"
-    color: "#2ecc71"
-    sort_order: 30
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: worker
-    mode: ADVISORY
-    kick_template: ci-maintainer-advisory.md
-    include_repos: true
-    stale_timeout: 3600
-    lane_keywords: [ci, build, pipeline, workflow]
-    interactions: >
-      Monitors CI alongside quality. Reports CI health as advisory beads.
-    knowledge_use: >
-      Reads CI patterns and past failures. Produces CI health advisory beads.
-  - name: quality
-    display_name: quality
-    role: quality
-    description: >
-      Opens GitHub issues AND hold-gated PRs about testing — coverage gaps,
-      missing CI workflows, test infrastructure. The ONE agent at L3 with
-      GitHub write access. PRs get 'hold' label; never merges. Also
-      produces advisory beads.
-    emoji: "🧪"
-    color: "#e67e22"
-    sort_order: 25
-    backend: copilot
-    model: claude-opus-4-6
-    bead_role: worker
-    mode: ISSUES_AND_PRS
-    kick_template: quality-holdgated.md
-    include_repos: true
-    stale_timeout: 3600
-    interactions: >
-      Opens issues and hold-gated PRs about testing. Complements scanner
-      and ci-maintainer advisory findings with actionable test improvements.
-    knowledge_use: >
-      Reads test patterns, coverage rules, and known regressions from the
-      knowledge base to prioritize which code needs tests most.
-  - name: guide
-    display_name: guide (advisory)
-    role: guide
-    description: >
-      Audits project documentation and onboarding experience. Reports
-      findings as beads for the advisory digest. Does NOT create PRs or issues.
-    emoji: "🧭"
-    color: "#8e44ad"
-    sort_order: 10
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: worker
-    mode: ADVISORY
-    kick_template: guide-advisory.md
-    include_repos: true
-    stale_timeout: 3600
-    interactions: "Works alongside scanner. Reviews scanner's suggestions when asked."
-    knowledge_use: >
-      Reads community wiki and project patterns. Starts contributing review
-      insights as knowledge entries.
+- name: supervisor
+  display_name: Supervisor
+  role: supervisor
+  description: 'Agent health monitoring, sweep analysis, and escalation. Watches all
+    other agents for stalls, rate limits, and anomalies.
+
+    '
+  emoji: 👑
+  color: '#e74c3c'
+  sort_order: 1
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: supervisor
+  mode: NO_GITHUB
+  kick_template: supervisor-nogithub.md
+  include_repos: true
+  stale_timeout: 1800
+  interactions: 'Monitors all agents. Escalates issues to human operators. Coordinates
+    agent restarts and health checks.
+
+    '
+  knowledge_use: 'Reads agent health history and operational patterns. Produces sweep
+    reports and health assessments.
+
+    '
+- name: scanner
+  display_name: scanner (advisory)
+  role: scanner
+  description: 'Scans code for issues and suggests fixes, but does NOT create PRs
+    or issues. Reports findings as beads for the advisory digest.
+
+    '
+  emoji: 🔍
+  color: '#3498db'
+  sort_order: 20
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ADVISORY
+  kick_template: scanner-advisory.md
+  include_repos: true
+  stale_timeout: 7200
+  lane_keywords:
+  - bug
+  - triage
+  - fix
+  interactions: Produces advisory findings. No autonomous actions.
+  knowledge_use: 'Reads project patterns and known issues. Produces findings as advisory
+    beads for the team to review.
+
+    '
+- name: ci-maintainer
+  display_name: ci-maintainer (advisory)
+  role: ci-maintainer
+  description: 'Monitors CI health, workflow status, and build trends. Reports findings
+    as beads for the advisory digest. Does NOT create PRs or issues.
+
+    '
+  emoji: 🔧
+  color: '#2ecc71'
+  sort_order: 30
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ADVISORY
+  kick_template: ci-maintainer-advisory.md
+  include_repos: true
+  stale_timeout: 3600
+  lane_keywords:
+  - ci
+  - build
+  - pipeline
+  - workflow
+  interactions: 'Monitors CI alongside quality. Reports CI health as advisory beads.
+
+    '
+  knowledge_use: 'Reads CI patterns and past failures. Produces CI health advisory
+    beads.
+
+    '
+- name: quality
+  display_name: quality
+  role: quality
+  description: 'Opens GitHub issues AND hold-gated PRs about testing — coverage gaps,
+    missing CI workflows, test infrastructure. The ONE agent at L3 with GitHub write
+    access. PRs get ''hold'' label; never merges. Also produces advisory beads.
+
+    '
+  emoji: 🧪
+  color: '#e67e22'
+  sort_order: 25
+  backend: copilot
+  model: claude-opus-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: quality-holdgated.md
+  include_repos: true
+  stale_timeout: 3600
+  interactions: 'Opens issues and hold-gated PRs about testing. Complements scanner
+    and ci-maintainer advisory findings with actionable test improvements.
+
+    '
+  knowledge_use: 'Reads test patterns, coverage rules, and known regressions from
+    the knowledge base to prioritize which code needs tests most.
+
+    '
+- name: guide
+  display_name: guide (advisory)
+  role: guide
+  description: 'Audits project documentation and onboarding experience. Reports findings
+    as beads for the advisory digest. Does NOT create PRs or issues.
+
+    '
+  emoji: 🧭
+  color: '#8e44ad'
+  sort_order: 10
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ADVISORY
+  kick_template: guide-advisory.md
+  include_repos: true
+  stale_timeout: 3600
+  interactions: Works alongside scanner. Reviews scanner's suggestions when asked.
+  knowledge_use: 'Reads community wiki and project patterns. Starts contributing review
+    insights as knowledge entries.
+
+    '
+- name: brainstorm
+  display_name: brainstorm
+  role: brainstorm
+  description: 'Ongoing ideation agent. Proposes features, architecture improvements,
+    and strategic directions based on project patterns and community KB. Produces
+    KB facts and advisory beads.
+
+    '
+  emoji: 💡
+  color: '#f39c12'
+  sort_order: 30
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ADVISORY
+  kick_template: brainstorm-advisory.md
+  include_repos: true
+  stale_timeout: 7200
+  interactions: Standalone. Produces ideation beads for human review.
+  knowledge_use: 'Heavy consumer of community wiki patterns. Produces ideation facts
+    (feature proposals, architecture decisions, strategic direction) into the project
+    KB layer.
+
+    '

--- a/v2/pkg/config/packs/level-4.yaml
+++ b/v2/pkg/config/packs/level-4.yaml
@@ -1,10 +1,11 @@
 level: 4
 name: Adaptive
-description: >
-  Closed-loop feedback. All agents open GitHub issues — not just quality.
-  Scanner files bug reports, guide files documentation gaps, ci-maintainer
-  files workflow issues, sec-check files vulnerabilities. No PRs yet —
-  issues only. Adds security agent (+sec-check). Six agents total.
+description: 'Closed-loop feedback. All agents open GitHub issues — not just quality.
+  Scanner files bug reports, guide files documentation gaps, ci-maintainer files workflow
+  issues, sec-check files vulnerabilities. No PRs yet — issues only. Adds security
+  agent (+sec-check). Six agents total.
+
+  '
 governor:
   modes: SURGE, BUSY, QUIET, IDLE
   merge_policy: hold-gated
@@ -22,6 +23,7 @@ governor:
       quality: pause
       guide: pause
       sec-check: pause
+      brainstorm: pause
     busy:
       supervisor: 5m
       scanner: 4h
@@ -29,6 +31,7 @@ governor:
       quality: 2h
       guide: 4h
       sec-check: 4h
+      brainstorm: 4h
     quiet:
       supervisor: 5m
       scanner: 4h
@@ -36,6 +39,7 @@ governor:
       quality: 2h
       guide: 4h
       sec-check: 4h
+      brainstorm: 4h
     idle:
       supervisor: 5m
       scanner: 4h
@@ -43,136 +47,191 @@ governor:
       quality: 2h
       guide: 4h
       sec-check: 4h
+      brainstorm: 4h
 agents:
-  - name: supervisor
-    display_name: Supervisor
-    role: supervisor
-    description: >
-      Agent health monitoring, sweep analysis, and escalation. Watches all
-      other agents for stalls, rate limits, and anomalies.
-    emoji: "👑"
-    color: "#e74c3c"
-    sort_order: 1
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: supervisor
-    mode: NO_GITHUB
-    kick_template: supervisor-nogithub.md
-    include_repos: true
-    stale_timeout: 1800
-    interactions: >
-      Monitors all agents. Escalates issues to human operators. Coordinates
-      agent restarts and health checks.
-    knowledge_use: >
-      Reads agent health history and operational patterns. Produces sweep
-      reports and health assessments.
-  - name: scanner
-    display_name: scanner
-    role: scanner
-    description: >
-      Opens GitHub issues for bugs and code problems found during scans.
-      Does NOT create PRs. Reports findings as both issues and advisory beads.
-    emoji: "🔍"
-    color: "#3498db"
-    sort_order: 20
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: worker
-    mode: ISSUES_ONLY
-    kick_template: scanner-issues.md
-    include_repos: true
-    stale_timeout: 7200
-    lane_keywords: [bug, triage, fix, issue]
-    interactions: >
-      Creates issues. Produces advisory beads. No PRs.
-    knowledge_use: >
-      Reads project patterns and known issues. Produces findings as issues
-      and advisory beads.
-  - name: ci-maintainer
-    display_name: ci-maintainer
-    role: ci-maintainer
-    description: >
-      Opens GitHub issues and hold-gated PRs about CI health, workflow
-      failures, and build problems. PRs get 'hold' label; never merges.
-    emoji: "🔧"
-    color: "#2ecc71"
-    sort_order: 30
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: worker
-    mode: ISSUES_AND_PRS
-    kick_template: ci-maintainer-holdgated.md
-    include_repos: true
-    stale_timeout: 3600
-    lane_keywords: [ci, build, pipeline, workflow]
-    interactions: >
-      Creates CI-related issues. Produces advisory beads. No PRs.
-    knowledge_use: >
-      Reads CI patterns and past failures. Produces CI health issues and
-      advisory beads.
-  - name: quality
-    display_name: quality
-    role: quality
-    description: >
-      Opens GitHub issues and hold-gated PRs about testing gaps, coverage,
-      and test infrastructure. PRs get 'hold' label; never merges.
-    emoji: "🧪"
-    color: "#e67e22"
-    sort_order: 25
-    backend: copilot
-    model: claude-opus-4-6
-    bead_role: worker
-    mode: ISSUES_AND_PRS
-    kick_template: quality-holdgated.md
-    include_repos: true
-    stale_timeout: 3600
-    interactions: >
-      Creates testing-related issues. Produces advisory beads. No PRs.
-    knowledge_use: >
-      Reads test patterns, coverage rules, and known regressions to
-      prioritize which code needs tests most.
-  - name: guide
-    display_name: guide
-    role: guide
-    description: >
-      Opens GitHub issues about documentation gaps and onboarding problems.
-      Does NOT create PRs. Also produces advisory beads.
-    emoji: "🧭"
-    color: "#8e44ad"
-    sort_order: 10
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: worker
-    mode: ISSUES_ONLY
-    kick_template: guide-issues.md
-    include_repos: true
-    stale_timeout: 3600
-    interactions: >
-      Creates documentation issues. Produces advisory beads. No PRs.
-    knowledge_use: >
-      Reads community wiki and project patterns. Produces findings as
-      issues and advisory beads.
-  - name: sec-check
-    display_name: security
-    role: sec-check
-    description: >
-      Security scanning, dependency audit, and vulnerability monitoring.
-      Opens GitHub issues and hold-gated PRs for vulnerabilities and
-      security gaps. PRs get 'hold' label; never merges.
-    emoji: "🛡"
-    color: "#1abc9c"
-    sort_order: 60
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: worker
-    mode: ISSUES_AND_PRS
-    kick_template: sec-check-holdgated.md
-    include_repos: true
-    stale_timeout: 3600
-    lane_keywords: [security, cve, vulnerability, audit]
-    interactions: >
-      Creates security issues. Reports critical findings to supervisor
-      for escalation. Produces advisory beads.
-    knowledge_use: >
-      Reads vulnerability databases and past security fixes. Produces
-      security audit reports and issues.
+- name: supervisor
+  display_name: Supervisor
+  role: supervisor
+  description: 'Agent health monitoring, sweep analysis, and escalation. Watches all
+    other agents for stalls, rate limits, and anomalies.
+
+    '
+  emoji: 👑
+  color: '#e74c3c'
+  sort_order: 1
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: supervisor
+  mode: NO_GITHUB
+  kick_template: supervisor-nogithub.md
+  include_repos: true
+  stale_timeout: 1800
+  interactions: 'Monitors all agents. Escalates issues to human operators. Coordinates
+    agent restarts and health checks.
+
+    '
+  knowledge_use: 'Reads agent health history and operational patterns. Produces sweep
+    reports and health assessments.
+
+    '
+- name: scanner
+  display_name: scanner
+  role: scanner
+  description: 'Opens GitHub issues for bugs and code problems found during scans.
+    Does NOT create PRs. Reports findings as both issues and advisory beads.
+
+    '
+  emoji: 🔍
+  color: '#3498db'
+  sort_order: 20
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ISSUES_ONLY
+  kick_template: scanner-issues.md
+  include_repos: true
+  stale_timeout: 7200
+  lane_keywords:
+  - bug
+  - triage
+  - fix
+  - issue
+  interactions: 'Creates issues. Produces advisory beads. No PRs.
+
+    '
+  knowledge_use: 'Reads project patterns and known issues. Produces findings as issues
+    and advisory beads.
+
+    '
+- name: ci-maintainer
+  display_name: ci-maintainer
+  role: ci-maintainer
+  description: 'Opens GitHub issues and hold-gated PRs about CI health, workflow failures,
+    and build problems. PRs get ''hold'' label; never merges.
+
+    '
+  emoji: 🔧
+  color: '#2ecc71'
+  sort_order: 30
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: ci-maintainer-holdgated.md
+  include_repos: true
+  stale_timeout: 3600
+  lane_keywords:
+  - ci
+  - build
+  - pipeline
+  - workflow
+  interactions: 'Creates CI-related issues. Produces advisory beads. No PRs.
+
+    '
+  knowledge_use: 'Reads CI patterns and past failures. Produces CI health issues and
+    advisory beads.
+
+    '
+- name: quality
+  display_name: quality
+  role: quality
+  description: 'Opens GitHub issues and hold-gated PRs about testing gaps, coverage,
+    and test infrastructure. PRs get ''hold'' label; never merges.
+
+    '
+  emoji: 🧪
+  color: '#e67e22'
+  sort_order: 25
+  backend: copilot
+  model: claude-opus-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: quality-holdgated.md
+  include_repos: true
+  stale_timeout: 3600
+  interactions: 'Creates testing-related issues. Produces advisory beads. No PRs.
+
+    '
+  knowledge_use: 'Reads test patterns, coverage rules, and known regressions to prioritize
+    which code needs tests most.
+
+    '
+- name: guide
+  display_name: guide
+  role: guide
+  description: 'Opens GitHub issues about documentation gaps and onboarding problems.
+    Does NOT create PRs. Also produces advisory beads.
+
+    '
+  emoji: 🧭
+  color: '#8e44ad'
+  sort_order: 10
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ISSUES_ONLY
+  kick_template: guide-issues.md
+  include_repos: true
+  stale_timeout: 3600
+  interactions: 'Creates documentation issues. Produces advisory beads. No PRs.
+
+    '
+  knowledge_use: 'Reads community wiki and project patterns. Produces findings as
+    issues and advisory beads.
+
+    '
+- name: sec-check
+  display_name: security
+  role: sec-check
+  description: 'Security scanning, dependency audit, and vulnerability monitoring.
+    Opens GitHub issues and hold-gated PRs for vulnerabilities and security gaps.
+    PRs get ''hold'' label; never merges.
+
+    '
+  emoji: 🛡
+  color: '#1abc9c'
+  sort_order: 60
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: sec-check-holdgated.md
+  include_repos: true
+  stale_timeout: 3600
+  lane_keywords:
+  - security
+  - cve
+  - vulnerability
+  - audit
+  interactions: 'Creates security issues. Reports critical findings to supervisor
+    for escalation. Produces advisory beads.
+
+    '
+  knowledge_use: 'Reads vulnerability databases and past security fixes. Produces
+    security audit reports and issues.
+
+    '
+- name: brainstorm
+  display_name: brainstorm
+  role: brainstorm
+  description: 'Ongoing ideation agent. Proposes features, architecture improvements,
+    and strategic directions based on project patterns and community KB. Produces
+    KB facts and advisory beads.
+
+    '
+  emoji: 💡
+  color: '#f39c12'
+  sort_order: 30
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ADVISORY
+  kick_template: brainstorm-advisory.md
+  include_repos: true
+  stale_timeout: 7200
+  interactions: Standalone. Produces ideation beads for human review.
+  knowledge_use: 'Heavy consumer of community wiki patterns. Produces ideation facts
+    (feature proposals, architecture decisions, strategic direction) into the project
+    KB layer.
+
+    '

--- a/v2/pkg/config/packs/level-5.yaml
+++ b/v2/pkg/config/packs/level-5.yaml
@@ -1,15 +1,16 @@
 level: 5
 name: Semi-Automated
-description: >
-  Multi-loop feedback. Agents open issues AND pull requests. All agent PRs
-  get a 'hold' label automatically — humans batch-review and approve.
-  Adds architect (+architect) for RFCs and strategist (+strategist) for
-  cross-agent coordination. Eight agents total. The system proposes;
-  it does not merge autonomously.
+description: 'Multi-loop feedback. Agents open issues AND pull requests. All agent
+  PRs get a ''hold'' label automatically — humans batch-review and approve. Adds architect
+  (+architect) for RFCs and strategist (+strategist) for cross-agent coordination.
+  Eight agents total. The system proposes; it does not merge autonomously.
+
+  '
 governor:
   modes: SURGE, BUSY, QUIET, IDLE
-  merge_policy: >
-    Hold-gated — all agent PRs get 'hold' label. Human batch-approves.
+  merge_policy: 'Hold-gated — all agent PRs get ''hold'' label. Human batch-approves.
+
+    '
   eval_interval_s: 300
   thresholds:
     surge: 10
@@ -26,6 +27,7 @@ governor:
       sec-check: 4h
       architect: 4h
       strategist: 4h
+      brainstorm: pause
     busy:
       supervisor: 5m
       scanner: 4h
@@ -35,6 +37,7 @@ governor:
       sec-check: 4h
       architect: 4h
       strategist: 4h
+      brainstorm: 4h
     quiet:
       supervisor: 5m
       scanner: 4h
@@ -44,6 +47,7 @@ governor:
       sec-check: 4h
       architect: 4h
       strategist: 4h
+      brainstorm: 4h
     idle:
       supervisor: 5m
       scanner: 4h
@@ -53,169 +57,240 @@ governor:
       sec-check: 4h
       architect: 4h
       strategist: 4h
+      brainstorm: 4h
 agents:
-  - name: supervisor
-    display_name: Supervisor
-    role: supervisor
-    description: >
-      Agent health monitoring, sweep analysis, and escalation. Watches all
-      other agents for stalls, rate limits, and anomalies.
-    emoji: "👑"
-    color: "#e74c3c"
-    sort_order: 1
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: supervisor
-    mode: NO_GITHUB
-    kick_template: supervisor-nogithub.md
-    include_repos: true
-    stale_timeout: 1800
-    interactions: >
-      Monitors all agents. Escalates issues to human operators.
-    knowledge_use: >
-      Reads agent health history. Produces sweep reports.
-  - name: scanner
-    display_name: scanner
-    role: scanner
-    description: >
-      Opens issues AND hold-gated PRs. All PRs get 'hold' label
-      automatically. Human reviews in batches.
-    emoji: "🔍"
-    color: "#3498db"
-    sort_order: 20
-    backend: copilot
-    model: claude-opus-4-6
-    bead_role: worker
-    mode: ISSUES_AND_PRS
-    kick_template: scanner-holdgated.md
-    include_repos: true
-    stale_timeout: 1800
-    lane_keywords: [bug, triage, fix, issue]
-    interactions: >
-      Creates hold-gated PRs. Quality validates but does not approve.
-    knowledge_use: >
-      Full project history access. Produces fix records.
-  - name: ci-maintainer
-    display_name: ci-maintainer
-    role: ci-maintainer
-    description: >
-      Opens issues AND hold-gated PRs for CI improvements. Workflow
-      optimization and dependency updates.
-    emoji: "🔧"
-    color: "#2ecc71"
-    sort_order: 30
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: worker
-    mode: ISSUES_AND_PRS
-    kick_template: ci-maintainer-holdgated.md
-    include_repos: true
-    stale_timeout: 3600
-    lane_keywords: [ci, build, pipeline, workflow, dependency]
-    interactions: >
-      Creates CI-related issues and hold-gated PRs.
-    knowledge_use: >
-      Reads CI history. Produces workflow health reports.
-  - name: quality
-    display_name: quality
-    role: quality
-    description: >
-      Opens issues about testing AND hold-gated PRs for test improvements.
-      Reviews scanner PRs for coverage.
-    emoji: "🧪"
-    color: "#e67e22"
-    sort_order: 25
-    backend: copilot
-    model: claude-opus-4-6
-    bead_role: worker
-    mode: ISSUES_AND_PRS
-    kick_template: quality-holdgated.md
-    include_repos: true
-    stale_timeout: 3600
-    interactions: >
-      Reviews scanner PRs for coverage. Creates test PRs with hold label.
-    knowledge_use: >
-      Reads test patterns and coverage history.
-  - name: guide
-    display_name: guide
-    role: guide
-    description: >
-      Opens issues about documentation AND hold-gated PRs for doc
-      improvements. Reviews PRs on request.
-    emoji: "🧭"
-    color: "#8e44ad"
-    sort_order: 10
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: worker
-    mode: ISSUES_AND_PRS
-    kick_template: guide-holdgated.md
-    include_repos: true
-    stale_timeout: 3600
-    interactions: >
-      Creates documentation issues and hold-gated PRs.
-    knowledge_use: >
-      Reads community wiki and project patterns.
-  - name: sec-check
-    display_name: security
-    role: sec-check
-    description: >
-      Opens issues AND hold-gated PRs for security fixes. CVE tracking
-      and vulnerability monitoring.
-    emoji: "🛡"
-    color: "#1abc9c"
-    sort_order: 60
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: worker
-    mode: ISSUES_AND_PRS
-    kick_template: sec-check-holdgated.md
-    include_repos: true
-    stale_timeout: 3600
-    lane_keywords: [security, cve, vulnerability, audit]
-    interactions: >
-      Creates security issues and hold-gated PRs.
-    knowledge_use: >
-      Reads vulnerability databases and past security fixes.
-  - name: architect
-    display_name: architect
-    role: architect
-    description: >
-      Architecture agent. Produces RFCs, refactors, and new features.
-      Opens hold-gated PRs for structural changes.
-    emoji: "🏗"
-    color: "#9b59b6"
-    sort_order: 40
-    backend: copilot
-    model: claude-opus-4-6
-    bead_role: worker
-    mode: ISSUES_AND_PRS
-    kick_template: architect-holdgated.md
-    include_repos: true
-    stale_timeout: 3600
-    lane_keywords: [refactor, architecture, rfc, design, feature]
-    interactions: >
-      Receives complex issues from scanner. Produces RFCs and hold-gated PRs.
-    knowledge_use: >
-      Heavy consumer and producer of architecture decisions and patterns.
-  - name: strategist
-    display_name: strategist
-    role: strategist
-    description: >
-      Strategic planning, roadmap alignment, and cross-agent coordination.
-      Analyzes trends across all agents.
-    emoji: "🧠"
-    color: "#f39c12"
-    sort_order: 70
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: worker
-    mode: ISSUES_AND_PRS
-    kick_template: strategist-holdgated.md
-    include_repos: false
-    stale_timeout: 3600
-    lane_keywords: [strategy, roadmap, planning]
-    interactions: >
-      Reads all agent outputs. Produces strategic insights.
-    knowledge_use: >
-      Heavy consumer of all agent knowledge.
+- name: supervisor
+  display_name: Supervisor
+  role: supervisor
+  description: 'Agent health monitoring, sweep analysis, and escalation. Watches all
+    other agents for stalls, rate limits, and anomalies.
+
+    '
+  emoji: 👑
+  color: '#e74c3c'
+  sort_order: 1
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: supervisor
+  mode: NO_GITHUB
+  kick_template: supervisor-nogithub.md
+  include_repos: true
+  stale_timeout: 1800
+  interactions: 'Monitors all agents. Escalates issues to human operators.
+
+    '
+  knowledge_use: 'Reads agent health history. Produces sweep reports.
+
+    '
+- name: scanner
+  display_name: scanner
+  role: scanner
+  description: 'Opens issues AND hold-gated PRs. All PRs get ''hold'' label automatically.
+    Human reviews in batches.
+
+    '
+  emoji: 🔍
+  color: '#3498db'
+  sort_order: 20
+  backend: copilot
+  model: claude-opus-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: scanner-holdgated.md
+  include_repos: true
+  stale_timeout: 1800
+  lane_keywords:
+  - bug
+  - triage
+  - fix
+  - issue
+  interactions: 'Creates hold-gated PRs. Quality validates but does not approve.
+
+    '
+  knowledge_use: 'Full project history access. Produces fix records.
+
+    '
+- name: ci-maintainer
+  display_name: ci-maintainer
+  role: ci-maintainer
+  description: 'Opens issues AND hold-gated PRs for CI improvements. Workflow optimization
+    and dependency updates.
+
+    '
+  emoji: 🔧
+  color: '#2ecc71'
+  sort_order: 30
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: ci-maintainer-holdgated.md
+  include_repos: true
+  stale_timeout: 3600
+  lane_keywords:
+  - ci
+  - build
+  - pipeline
+  - workflow
+  - dependency
+  interactions: 'Creates CI-related issues and hold-gated PRs.
+
+    '
+  knowledge_use: 'Reads CI history. Produces workflow health reports.
+
+    '
+- name: quality
+  display_name: quality
+  role: quality
+  description: 'Opens issues about testing AND hold-gated PRs for test improvements.
+    Reviews scanner PRs for coverage.
+
+    '
+  emoji: 🧪
+  color: '#e67e22'
+  sort_order: 25
+  backend: copilot
+  model: claude-opus-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: quality-holdgated.md
+  include_repos: true
+  stale_timeout: 3600
+  interactions: 'Reviews scanner PRs for coverage. Creates test PRs with hold label.
+
+    '
+  knowledge_use: 'Reads test patterns and coverage history.
+
+    '
+- name: guide
+  display_name: guide
+  role: guide
+  description: 'Opens issues about documentation AND hold-gated PRs for doc improvements.
+    Reviews PRs on request.
+
+    '
+  emoji: 🧭
+  color: '#8e44ad'
+  sort_order: 10
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: guide-holdgated.md
+  include_repos: true
+  stale_timeout: 3600
+  interactions: 'Creates documentation issues and hold-gated PRs.
+
+    '
+  knowledge_use: 'Reads community wiki and project patterns.
+
+    '
+- name: sec-check
+  display_name: security
+  role: sec-check
+  description: 'Opens issues AND hold-gated PRs for security fixes. CVE tracking and
+    vulnerability monitoring.
+
+    '
+  emoji: 🛡
+  color: '#1abc9c'
+  sort_order: 60
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: sec-check-holdgated.md
+  include_repos: true
+  stale_timeout: 3600
+  lane_keywords:
+  - security
+  - cve
+  - vulnerability
+  - audit
+  interactions: 'Creates security issues and hold-gated PRs.
+
+    '
+  knowledge_use: 'Reads vulnerability databases and past security fixes.
+
+    '
+- name: architect
+  display_name: architect
+  role: architect
+  description: 'Architecture agent. Produces RFCs, refactors, and new features. Opens
+    hold-gated PRs for structural changes.
+
+    '
+  emoji: 🏗
+  color: '#9b59b6'
+  sort_order: 40
+  backend: copilot
+  model: claude-opus-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: architect-holdgated.md
+  include_repos: true
+  stale_timeout: 3600
+  lane_keywords:
+  - refactor
+  - architecture
+  - rfc
+  - design
+  - feature
+  interactions: 'Receives complex issues from scanner. Produces RFCs and hold-gated
+    PRs.
+
+    '
+  knowledge_use: 'Heavy consumer and producer of architecture decisions and patterns.
+
+    '
+- name: strategist
+  display_name: strategist
+  role: strategist
+  description: 'Strategic planning, roadmap alignment, and cross-agent coordination.
+    Analyzes trends across all agents.
+
+    '
+  emoji: 🧠
+  color: '#f39c12'
+  sort_order: 70
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: strategist-holdgated.md
+  include_repos: false
+  stale_timeout: 3600
+  lane_keywords:
+  - strategy
+  - roadmap
+  - planning
+  interactions: 'Reads all agent outputs. Produces strategic insights.
+
+    '
+  knowledge_use: 'Heavy consumer of all agent knowledge.
+
+    '
+- name: brainstorm
+  display_name: brainstorm
+  role: brainstorm
+  description: 'Ongoing ideation agent. Proposes features, architecture improvements,
+    and strategic directions based on project patterns and community KB. Produces
+    KB facts and advisory beads.
+
+    '
+  emoji: 💡
+  color: '#f39c12'
+  sort_order: 30
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ADVISORY
+  kick_template: brainstorm-advisory.md
+  include_repos: true
+  stale_timeout: 7200
+  interactions: Standalone. Produces ideation beads for human review.
+  knowledge_use: 'Heavy consumer of community wiki patterns. Produces ideation facts
+    (feature proposals, architecture decisions, strategic direction) into the project
+    KB layer.
+
+    '

--- a/v2/pkg/config/packs/level-6.yaml
+++ b/v2/pkg/config/packs/level-6.yaml
@@ -1,14 +1,16 @@
 level: 6
 name: Fully Autonomous
-description: >
-  Multi-loop with external orchestration. Agents open issues, create PRs,
-  and auto-merge on green CI. No hold label. Adds outreach agent (+outreach)
-  for community engagement and external-facing actions. Nine agents total.
-  Highest trust — governor at fastest cadence.
+description: 'Multi-loop with external orchestration. Agents open issues, create PRs,
+  and auto-merge on green CI. No hold label. Adds outreach agent (+outreach) for community
+  engagement and external-facing actions. Nine agents total. Highest trust — governor
+  at fastest cadence.
+
+  '
 governor:
   modes: SURGE, BUSY, QUIET, IDLE
-  merge_policy: >
-    Auto-merge on green CI. No hold label.
+  merge_policy: 'Auto-merge on green CI. No hold label.
+
+    '
   eval_interval_s: 120
   thresholds:
     surge: 10
@@ -25,6 +27,7 @@ governor:
       outreach: 30m
       sec-check: 15m
       strategist: 30m
+      brainstorm: pause
     busy:
       supervisor: 2m
       scanner: 10m
@@ -34,6 +37,7 @@ governor:
       outreach: 1h
       sec-check: 30m
       strategist: 1h
+      brainstorm: 4h
     quiet:
       supervisor: 3m
       scanner: 20m
@@ -43,6 +47,7 @@ governor:
       outreach: 2h
       sec-check: 1h
       strategist: 2h
+      brainstorm: 4h
     idle:
       supervisor: 5m
       scanner: 30m
@@ -52,188 +57,266 @@ governor:
       outreach: 4h
       sec-check: 2h
       strategist: 4h
+      brainstorm: 4h
 agents:
-  - name: supervisor
-    display_name: Supervisor
-    role: supervisor
-    description: >
-      Full autonomous oversight. Self-healing: restarts stalled agents,
-      triggers rollbacks on deploy failures.
-    emoji: "👑"
-    color: "#e74c3c"
-    sort_order: 1
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: supervisor
-    mode: NO_GITHUB
-    kick_template: supervisor-nogithub.md
-    include_repos: true
-    stale_timeout: 600
-    interactions: >
-      Full autonomous oversight of all agents. Triggers self-healing
-      actions without human intervention.
-    knowledge_use: >
-      Reads agent health history. Produces sweep reports and self-healing
-      action logs.
-  - name: scanner
-    display_name: scanner
-    role: scanner
-    description: >
-      Creates and auto-merges PRs on green CI. No hold label. Full SLA
-      enforcement with 30-minute response time.
-    emoji: "🔍"
-    color: "#3498db"
-    sort_order: 20
-    backend: copilot
-    model: claude-opus-4-6
-    bead_role: worker
-    mode: ISSUES_PRS_MERGE
-    kick_template: scanner-automerge.md
-    include_repos: true
-    stale_timeout: 900
-    lane_keywords: [bug, triage, fix, issue]
-    interactions: >
-      Creates and merges PRs autonomously.
-    knowledge_use: >
-      Full access to all project knowledge.
-  - name: ci-maintainer
-    display_name: ci-maintainer
-    role: ci-maintainer
-    description: >
-      Full CI pipeline ownership. Creates and auto-merges CI improvement PRs.
-    emoji: "🔧"
-    color: "#2ecc71"
-    sort_order: 30
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: worker
-    mode: ISSUES_AND_PRS
-    kick_template: ci-maintainer-full.md
-    include_repos: true
-    stale_timeout: 900
-    lane_keywords: [ci, build, pipeline, workflow, dependency]
-    interactions: >
-      Owns CI pipeline. Coordinates with supervisor.
-    knowledge_use: >
-      Full CI history.
-  - name: quality
-    display_name: quality
-    role: quality
-    description: >
-      Full TDD enforcement. Creates and auto-merges test PRs when coverage
-      gates pass.
-    emoji: "🧪"
-    color: "#e67e22"
-    sort_order: 25
-    backend: copilot
-    model: claude-opus-4-6
-    bead_role: worker
-    mode: ISSUES_AND_PRS
-    kick_template: quality-full.md
-    include_repos: true
-    stale_timeout: 900
-    interactions: >
-      Auto-approves PRs when coverage + CI gates pass.
-    knowledge_use: >
-      Full test history access.
-  - name: guide
-    display_name: guide
-    role: guide
-    description: >
-      Creates and auto-merges documentation PRs. Reviews PRs on request.
-    emoji: "🧭"
-    color: "#8e44ad"
-    sort_order: 10
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: worker
-    mode: ISSUES_AND_PRS
-    kick_template: guide-full.md
-    include_repos: true
-    stale_timeout: 3600
-    interactions: >
-      Creates documentation PRs autonomously.
-    knowledge_use: >
-      Reads community wiki and project patterns.
-  - name: sec-check
-    display_name: security
-    role: sec-check
-    description: >
-      Full autonomous security scanning with auto-patch for known CVEs.
-    emoji: "🛡"
-    color: "#1abc9c"
-    sort_order: 60
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: worker
-    mode: ISSUES_AND_PRS
-    kick_template: sec-check-full.md
-    include_repos: true
-    stale_timeout: 900
-    lane_keywords: [security, cve, vulnerability, audit]
-    interactions: >
-      Auto-patches known CVEs. Escalates unknowns to supervisor.
-    knowledge_use: >
-      Full security knowledge access.
-  - name: architect
-    display_name: architect
-    role: architect
-    description: >
-      Full autonomous architecture. Implements RFCs and auto-merges
-      structural changes.
-    emoji: "🏗"
-    color: "#9b59b6"
-    sort_order: 40
-    backend: copilot
-    model: claude-opus-4-6
-    bead_role: worker
-    mode: ISSUES_AND_PRS
-    kick_template: architect-full.md
-    include_repos: true
-    stale_timeout: 1800
-    lane_keywords: [refactor, architecture, rfc, design, feature]
-    interactions: >
-      Full autonomous design and implementation.
-    knowledge_use: >
-      Full architecture knowledge access.
-  - name: strategist
-    display_name: strategist
-    role: strategist
-    description: >
-      Full autonomous strategic planning with roadmap execution.
-    emoji: "🧠"
-    color: "#f39c12"
-    sort_order: 70
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: worker
-    mode: ISSUES_AND_PRS
-    kick_template: strategist-full.md
-    include_repos: false
-    stale_timeout: 1800
-    lane_keywords: [strategy, roadmap, planning]
-    interactions: >
-      Full autonomous strategic planning and priority setting.
-    knowledge_use: >
-      Full cross-agent knowledge synthesis.
-  - name: outreach
-    display_name: outreach
-    role: outreach
-    description: >
-      Full autonomous outreach. Files issues on partner projects and
-      manages community engagement. Highest trust — external-facing.
-    emoji: "🌐"
-    color: "#e67e22"
-    sort_order: 50
-    backend: copilot
-    model: claude-sonnet-4-6
-    bead_role: worker
-    mode: ISSUES_AND_PRS
-    kick_template: outreach-full.md
-    include_repos: false
-    stale_timeout: 1800
-    lane_keywords: [community, adopters, outreach, ecosystem]
-    interactions: >
-      Fully autonomous community engagement.
-    knowledge_use: >
-      Full community knowledge access.
+- name: supervisor
+  display_name: Supervisor
+  role: supervisor
+  description: 'Full autonomous oversight. Self-healing: restarts stalled agents,
+    triggers rollbacks on deploy failures.
+
+    '
+  emoji: 👑
+  color: '#e74c3c'
+  sort_order: 1
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: supervisor
+  mode: NO_GITHUB
+  kick_template: supervisor-nogithub.md
+  include_repos: true
+  stale_timeout: 600
+  interactions: 'Full autonomous oversight of all agents. Triggers self-healing actions
+    without human intervention.
+
+    '
+  knowledge_use: 'Reads agent health history. Produces sweep reports and self-healing
+    action logs.
+
+    '
+- name: scanner
+  display_name: scanner
+  role: scanner
+  description: 'Creates and auto-merges PRs on green CI. No hold label. Full SLA enforcement
+    with 30-minute response time.
+
+    '
+  emoji: 🔍
+  color: '#3498db'
+  sort_order: 20
+  backend: copilot
+  model: claude-opus-4-6
+  bead_role: worker
+  mode: ISSUES_PRS_MERGE
+  kick_template: scanner-automerge.md
+  include_repos: true
+  stale_timeout: 900
+  lane_keywords:
+  - bug
+  - triage
+  - fix
+  - issue
+  interactions: 'Creates and merges PRs autonomously.
+
+    '
+  knowledge_use: 'Full access to all project knowledge.
+
+    '
+- name: ci-maintainer
+  display_name: ci-maintainer
+  role: ci-maintainer
+  description: 'Full CI pipeline ownership. Creates and auto-merges CI improvement
+    PRs.
+
+    '
+  emoji: 🔧
+  color: '#2ecc71'
+  sort_order: 30
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: ci-maintainer-full.md
+  include_repos: true
+  stale_timeout: 900
+  lane_keywords:
+  - ci
+  - build
+  - pipeline
+  - workflow
+  - dependency
+  interactions: 'Owns CI pipeline. Coordinates with supervisor.
+
+    '
+  knowledge_use: 'Full CI history.
+
+    '
+- name: quality
+  display_name: quality
+  role: quality
+  description: 'Full TDD enforcement. Creates and auto-merges test PRs when coverage
+    gates pass.
+
+    '
+  emoji: 🧪
+  color: '#e67e22'
+  sort_order: 25
+  backend: copilot
+  model: claude-opus-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: quality-full.md
+  include_repos: true
+  stale_timeout: 900
+  interactions: 'Auto-approves PRs when coverage + CI gates pass.
+
+    '
+  knowledge_use: 'Full test history access.
+
+    '
+- name: guide
+  display_name: guide
+  role: guide
+  description: 'Creates and auto-merges documentation PRs. Reviews PRs on request.
+
+    '
+  emoji: 🧭
+  color: '#8e44ad'
+  sort_order: 10
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: guide-full.md
+  include_repos: true
+  stale_timeout: 3600
+  interactions: 'Creates documentation PRs autonomously.
+
+    '
+  knowledge_use: 'Reads community wiki and project patterns.
+
+    '
+- name: sec-check
+  display_name: security
+  role: sec-check
+  description: 'Full autonomous security scanning with auto-patch for known CVEs.
+
+    '
+  emoji: 🛡
+  color: '#1abc9c'
+  sort_order: 60
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: sec-check-full.md
+  include_repos: true
+  stale_timeout: 900
+  lane_keywords:
+  - security
+  - cve
+  - vulnerability
+  - audit
+  interactions: 'Auto-patches known CVEs. Escalates unknowns to supervisor.
+
+    '
+  knowledge_use: 'Full security knowledge access.
+
+    '
+- name: architect
+  display_name: architect
+  role: architect
+  description: 'Full autonomous architecture. Implements RFCs and auto-merges structural
+    changes.
+
+    '
+  emoji: 🏗
+  color: '#9b59b6'
+  sort_order: 40
+  backend: copilot
+  model: claude-opus-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: architect-full.md
+  include_repos: true
+  stale_timeout: 1800
+  lane_keywords:
+  - refactor
+  - architecture
+  - rfc
+  - design
+  - feature
+  interactions: 'Full autonomous design and implementation.
+
+    '
+  knowledge_use: 'Full architecture knowledge access.
+
+    '
+- name: strategist
+  display_name: strategist
+  role: strategist
+  description: 'Full autonomous strategic planning with roadmap execution.
+
+    '
+  emoji: 🧠
+  color: '#f39c12'
+  sort_order: 70
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: strategist-full.md
+  include_repos: false
+  stale_timeout: 1800
+  lane_keywords:
+  - strategy
+  - roadmap
+  - planning
+  interactions: 'Full autonomous strategic planning and priority setting.
+
+    '
+  knowledge_use: 'Full cross-agent knowledge synthesis.
+
+    '
+- name: outreach
+  display_name: outreach
+  role: outreach
+  description: 'Full autonomous outreach. Files issues on partner projects and manages
+    community engagement. Highest trust — external-facing.
+
+    '
+  emoji: 🌐
+  color: '#e67e22'
+  sort_order: 50
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ISSUES_AND_PRS
+  kick_template: outreach-full.md
+  include_repos: false
+  stale_timeout: 1800
+  lane_keywords:
+  - community
+  - adopters
+  - outreach
+  - ecosystem
+  interactions: 'Fully autonomous community engagement.
+
+    '
+  knowledge_use: 'Full community knowledge access.
+
+    '
+- name: brainstorm
+  display_name: brainstorm
+  role: brainstorm
+  description: 'Ongoing ideation agent. Proposes features, architecture improvements,
+    and strategic directions based on project patterns and community KB. Produces
+    KB facts and advisory beads.
+
+    '
+  emoji: 💡
+  color: '#f39c12'
+  sort_order: 30
+  backend: copilot
+  model: claude-sonnet-4-6
+  bead_role: worker
+  mode: ADVISORY
+  kick_template: brainstorm-advisory.md
+  include_repos: true
+  stale_timeout: 7200
+  interactions: Standalone. Produces ideation beads for human review.
+  knowledge_use: 'Heavy consumer of community wiki patterns. Produces ideation facts
+    (feature proposals, architecture decisions, strategic direction) into the project
+    KB layer.
+
+    '

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -43,6 +43,7 @@ func (s *Server) handlePacksList(w http.ResponseWriter, r *http.Request) {
 type ApplyPackResult struct {
 	Name    string   `json:"name"`
 	Created []string `json:"created"`
+	Updated []string `json:"updated"`
 	Skipped []string `json:"skipped"`
 	Paused  []string `json:"paused"`
 	Resumed []string `json:"resumed"`
@@ -66,9 +67,24 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 	var created []string
 	var skipped []string
 
+	var updated []string
 	for _, pa := range pack.Agents {
-		if _, exists := s.deps.Config.Agents[pa.Name]; exists {
-			skipped = append(skipped, pa.Name)
+		if existing, exists := s.deps.Config.Agents[pa.Name]; exists {
+			changed := false
+			if pa.KickTemplate != "" && existing.KickTemplate != pa.KickTemplate {
+				existing.KickTemplate = pa.KickTemplate
+				changed = true
+			}
+			if pa.Mode != "" && existing.Mode != pa.Mode {
+				existing.Mode = pa.Mode
+				changed = true
+			}
+			if changed {
+				s.deps.Config.Agents[pa.Name] = existing
+				updated = append(updated, pa.Name)
+			} else {
+				skipped = append(skipped, pa.Name)
+			}
 			continue
 		}
 
@@ -152,11 +168,12 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 
 	s.persistOnly()
 	go s.refreshAsync()
-	s.logger.Info("ACMM pack applied", "level", level, "name", pack.Name, "created", len(created), "skipped", len(skipped), "paused", len(paused), "resumed", len(resumed))
+	s.logger.Info("ACMM pack applied", "level", level, "name", pack.Name, "created", len(created), "updated", len(updated), "skipped", len(skipped), "paused", len(paused), "resumed", len(resumed))
 
 	return &ApplyPackResult{
 		Name:    pack.Name,
 		Created: created,
+		Updated: updated,
 		Skipped: skipped,
 		Paused:  paused,
 		Resumed: resumed,
@@ -183,6 +200,7 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 		"level":      level,
 		"name":       result.Name,
 		"created":    result.Created,
+		"updated":    result.Updated,
 		"skipped":    result.Skipped,
 		"paused":     result.Paused,
 		"resumed":    result.Resumed,

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -106,6 +106,9 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 	}
 
 	s.deps.Config.ACMMLevel = &level
+	if err := s.deps.Config.Save(); err != nil {
+		s.logger.Error("failed to save ACMM level to hive.yaml", "error", err)
+	}
 
 	if pack.Governor.EvalIntervalS > 0 {
 		s.deps.Config.Governor.EvalIntervalS = pack.Governor.EvalIntervalS
@@ -203,6 +206,9 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 
 	level := body.Level
 	s.deps.Config.ACMMLevel = &level
+	if err := s.deps.Config.Save(); err != nil {
+		s.logger.Error("failed to save ACMM level to hive.yaml", "error", err)
+	}
 
 	s.deps.AgentMgr.SyncModeFiles(level)
 	paused, resumed := s.syncAgentVisibility(level)

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5885,12 +5885,12 @@ function burnAreaChart() {
     function renderInceptionModeSelect() {
       return `
         <div style="display:flex;gap:16px;max-width:700px;margin:0 auto">
-          <div onclick="startInceptionGreenfield()" style="flex:1;background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:24px;cursor:pointer;text-align:center;transition:border-color 0.2s" onmouseover="this.style.borderColor='var(--accent)'" onmouseout="this.style.borderColor='var(--border)'">
+          <div onclick="startInceptionGreenfield()" style="flex:1;background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:24px;cursor:pointer;text-align:center;transition:border-color 0.2s" onmouseover="this.style.borderColor='var(--blue, #58a6ff)'" onmouseout="this.style.borderColor='var(--border)'">
             <div style="font-size:2rem;margin-bottom:8px">🌱</div>
             <div style="font-weight:600;margin-bottom:4px">Start from an idea</div>
             <div style="font-size:0.78rem;color:var(--muted)">New project — describe what you want to build and we'll scaffold it</div>
           </div>
-          <div onclick="startInceptionBrownfield()" style="flex:1;background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:24px;cursor:pointer;text-align:center;transition:border-color 0.2s" onmouseover="this.style.borderColor='var(--accent)'" onmouseout="this.style.borderColor='var(--border)'">
+          <div onclick="startInceptionBrownfield()" style="flex:1;background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:24px;cursor:pointer;text-align:center;transition:border-color 0.2s" onmouseover="this.style.borderColor='var(--blue, #58a6ff)'" onmouseout="this.style.borderColor='var(--border)'">
             <div style="font-size:2rem;margin-bottom:8px">🏗️</div>
             <div style="font-weight:600;margin-bottom:4px">Add to existing repo</div>
             <div style="font-size:0.78rem;color:var(--muted)">Scan an existing project and capture its principles as KB facts</div>
@@ -5905,7 +5905,7 @@ function burnAreaChart() {
           <textarea id="inception-idea" placeholder="A CLI tool that syncs Obsidian vaults to a wiki server..." style="width:100%;min-height:80px;padding:12px;border:1px solid var(--border);border-radius:8px;background:var(--card-bg);color:var(--fg);font-family:inherit;font-size:0.85rem;resize:vertical"></textarea>
           <div style="margin-top:12px;display:flex;gap:8px;justify-content:flex-end">
             <button onclick="resetInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Cancel</button>
-            <button onclick="submitInceptionIdea()" style="padding:8px 24px;border:none;border-radius:6px;background:var(--accent);color:white;cursor:pointer;font-size:0.82rem;font-weight:600">Start</button>
+            <button onclick="submitInceptionIdea()" style="padding:8px 24px;border:none;border-radius:6px;background:var(--blue, #58a6ff);color:#0d1117;cursor:pointer;font-size:0.82rem;font-weight:600">Start</button>
           </div>
         </div>`;
     }
@@ -5934,7 +5934,7 @@ function burnAreaChart() {
       });
       html += `<div style="display:flex;gap:8px;justify-content:flex-end">
         <button onclick="resetInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Reset</button>
-        <button onclick="submitInceptionAnswers()" style="padding:8px 24px;border:none;border-radius:6px;background:var(--accent);color:white;cursor:pointer;font-size:0.82rem;font-weight:600">Submit</button>
+        <button onclick="submitInceptionAnswers()" style="padding:8px 24px;border:none;border-radius:6px;background:var(--blue, #58a6ff);color:#0d1117;cursor:pointer;font-size:0.82rem;font-weight:600">Submit</button>
       </div>`;
       html += '</div>';
       return html;
@@ -5958,7 +5958,7 @@ function burnAreaChart() {
           <div style="display:flex;gap:8px;justify-content:flex-end">
             <button onclick="resetInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Start Over</button>
             <button onclick="loadInceptionScaffoldPreview()" style="padding:8px 20px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--fg);cursor:pointer;font-size:0.82rem">Preview Files</button>
-            <button onclick="approveInception()" style="padding:8px 24px;border:none;border-radius:6px;background:var(--accent);color:white;cursor:pointer;font-size:0.82rem;font-weight:600">Approve</button>
+            <button onclick="approveInception()" style="padding:8px 24px;border:none;border-radius:6px;background:var(--blue, #58a6ff);color:#0d1117;cursor:pointer;font-size:0.82rem;font-weight:600">Approve</button>
           </div>
         </div>`;
     }
@@ -5972,7 +5972,7 @@ function burnAreaChart() {
           <div style="font-size:0.85rem;color:var(--muted);margin-bottom:20px">${factCount} knowledge facts created. Your project is ready to grow.</div>
           <div style="display:flex;gap:8px;justify-content:center">
             <button onclick="resetInception()" style="padding:8px 20px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">New Inception</button>
-            <button onclick="ocNavigate('knowledge-section')" style="padding:8px 24px;border:none;border-radius:6px;background:var(--accent);color:white;cursor:pointer;font-size:0.82rem;font-weight:600">View Knowledge Base</button>
+            <button onclick="ocNavigate('knowledge-section')" style="padding:8px 24px;border:none;border-radius:6px;background:var(--blue, #58a6ff);color:#0d1117;cursor:pointer;font-size:0.82rem;font-weight:600">View Knowledge Base</button>
           </div>
         </div>`;
     }

--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -57,17 +57,19 @@ func (e *InceptionEngine) Start(rawIdea string) (*InceptionState, error) {
 
 	slug := slugify("idea-" + truncateSlug(rawIdea))
 
-	ctx := context.Background()
-	err := e.api.CreateFact(ctx, CreateFactRequest{
-		Title:      rawIdea,
-		Body:       rawIdea,
-		Type:       string(FactIdea),
-		Tags:       []string{"inception", "seed"},
-		Layer:      string(LayerProject),
-		Confidence: ideaDefaultConf,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("creating idea fact: %w", err)
+	if e.api != nil {
+		ctx := context.Background()
+		err := e.api.CreateFact(ctx, CreateFactRequest{
+			Title:      rawIdea,
+			Body:       rawIdea,
+			Type:       string(FactIdea),
+			Tags:       []string{"inception", "seed"},
+			Layer:      string(LayerProject),
+			Confidence: ideaDefaultConf,
+		})
+		if err != nil {
+			e.logger.Warn("could not persist idea fact to KB layer (knowledge may not be configured)", "error", err)
+		}
 	}
 
 	e.state = &InceptionState{
@@ -188,6 +190,12 @@ func (e *InceptionEngine) RecordFacts(ctx context.Context, facts []IdeationFact)
 			if conf > 1.0 {
 				conf = 1.0
 			}
+		}
+
+		if e.api == nil {
+			slug := slugify(string(f.Type) + "-" + truncateSlug(f.Title))
+			e.state.FactSlugs = append(e.state.FactSlugs, slug)
+			continue
 		}
 
 		err := e.api.CreateFact(ctx, CreateFactRequest{
@@ -317,6 +325,9 @@ func (e *InceptionEngine) ReadIdeaFact(ctx context.Context) (*Fact, error) {
 	if e.state == nil {
 		return nil, fmt.Errorf("no inception in progress")
 	}
+	if e.api == nil {
+		return nil, nil
+	}
 	return e.api.ReadFact(ctx, e.state.IdeaSlug)
 }
 
@@ -395,6 +406,9 @@ func (e *InceptionEngine) saveState() error {
 // --- fact helpers ---
 
 func (e *InceptionEngine) gatherFacts(ctx context.Context) []Fact {
+	if e.api == nil {
+		return nil
+	}
 	return e.api.LayerFacts(ctx, LayerProject, "")
 }
 

--- a/v2/policies/brainstorm-advisory.md
+++ b/v2/policies/brainstorm-advisory.md
@@ -1,0 +1,45 @@
+# Brainstorm Agent Policy — Advisory Mode (ACMM L2+)
+
+You are the **brainstorm** agent in a Hive instance running at ACMM Level 2 or higher.
+
+Your job is ongoing ideation — proposing features, architecture improvements, and strategic directions based on project patterns, community KB, and codebase analysis. You produce knowledge base facts and advisory beads, never GitHub issues or PRs.
+
+## Rules
+
+1. **Ideation only** — propose ideas, architecture directions, and feature concepts
+2. **DO NOT create PRs, push code, or merge anything** — brainstorm is always advisory
+3. **DO NOT create GitHub issues** — findings go to beads only
+4. **Write findings as beads** — use `bd create` for every proposal
+5. **Produce KB facts** — capture architectural decisions, patterns, and constraints as knowledge entries
+6. **Only close your own beads** — when reaping, only close beads where `actor` is `brainstorm`
+
+## What to Brainstorm
+
+- **Feature proposals** — based on gaps in the codebase, community patterns, or KB insights
+- **Architecture improvements** — refactoring opportunities, performance bottlenecks, tech debt
+- **Strategic direction** — where the project should go next, based on adoption data and usage patterns
+- **Integration opportunities** — how the project could connect with other tools or ecosystems
+- **Developer experience** — onboarding friction, tooling gaps, documentation improvements
+
+## Writing Proposals
+
+Record each proposal as a bead:
+
+```bash
+bd create --title "<proposal title>" --type advisory --priority 2 \
+  --actor brainstorm --external-ref "brainstorm/<category>"
+bd update <bead-id> --set-metadata proposal_type=<feature|architecture|strategy|integration|dx>
+bd update <bead-id> --set-metadata detail="<detailed proposal>"
+```
+
+## Reaping
+
+Before starting new work, check for stale brainstorm beads:
+
+```bash
+bd list --status=open --actor=brainstorm --json 2>/dev/null
+```
+
+Close beads that are no longer relevant. Print a single summary: `Reap: <N> open, <M> closed this cycle`
+
+${KNOWLEDGE}

--- a/v2/policies/brainstorm-inception.md
+++ b/v2/policies/brainstorm-inception.md
@@ -1,0 +1,176 @@
+# Brainstorm Agent Policy — Inception Mode (ACMM L1)
+
+You are the **brainstorm** agent in a Hive instance running at ACMM Level 1 (inception).
+
+Your job is to help a user turn a raw idea into a structured project — producing knowledge base facts, project scaffolding, and a foundation for all future agent behavior.
+
+## Mode: ${INCEPTION_MODE}
+
+## Current Phase: ${INCEPTION_PHASE}
+
+---
+
+## Phase: capture (greenfield)
+
+The user has submitted an idea:
+
+> ${INCEPTION_IDEA}
+
+Your task is to generate **3–5 targeted clarification questions** that fill the gaps the user didn't specify. Use community KB patterns (see bottom of this document) to infer smart defaults.
+
+**Do NOT ask generic questions.** If the idea mentions "Go" or "operator" or "CLI", you already know the language — ask about scope, architecture, and users instead.
+
+Required question categories:
+1. **Language/runtime** — only if not inferable from the idea
+2. **Primary users** — who will use this and how
+3. **Must-have features** — the 2-3 things it absolutely must do
+4. **Hard constraints** — what it must NOT do, or boundaries (performance, compatibility, licensing)
+5. **Success criteria** — how will you know it's working? (becomes acceptance criteria)
+
+Output each question as a bead:
+
+```bash
+bd create --title "Clarification: <question text>" --type advisory --priority 2 \
+  --actor brainstorm --external-ref "inception/${INCEPTION_SLUG}"
+bd update <bead-id> --set-metadata question_id="<category>"
+bd update <bead-id> --set-metadata default="<smart default if available>"
+bd update <bead-id> --set-metadata category="<language|users|features|constraints|testing>"
+```
+
+After creating all question beads, summarize: `Inception: <N> clarification questions generated for phase: clarify`
+
+---
+
+## Phase: capture (brownfield)
+
+The user has pointed to an existing repository:
+
+> ${INCEPTION_REPO_URL}
+
+Your task is to **scan the repository** and extract what you can determine about the project:
+
+1. Clone or navigate to the repo
+2. Read: README.md, CLAUDE.md, CONTRIBUTING.md, package.json/go.mod/pyproject.toml, .github/workflows/
+3. Detect: language, test framework, CI setup, code style, architecture patterns
+4. Identify gaps: missing docs, no CLAUDE.md, incomplete README, no test coverage config
+
+Create a bead summarizing your findings:
+
+```bash
+bd create --title "Repo scan: <repo-name>" --type advisory --priority 1 \
+  --actor brainstorm --external-ref "inception/${INCEPTION_SLUG}"
+bd update <bead-id> --set-metadata scan_language="<detected>"
+bd update <bead-id> --set-metadata scan_test_framework="<detected>"
+bd update <bead-id> --set-metadata scan_has_claude_md="<true|false>"
+bd update <bead-id> --set-metadata scan_has_contributing="<true|false>"
+bd update <bead-id> --set-metadata scan_ci_present="<true|false>"
+bd update <bead-id> --set-metadata scan_gaps="<comma-separated list>"
+```
+
+Then generate clarification questions for gaps you couldn't determine from the code.
+
+---
+
+## Phase: clarify
+
+The user has answered your clarification questions:
+
+${INCEPTION_ANSWERS}
+
+Review the answers. If any critical information is still missing, create follow-up question beads. Otherwise, proceed to the **structure** phase.
+
+---
+
+## Phase: structure
+
+Using the original idea and clarification answers, produce structured knowledge base facts. You MUST create ALL of the following:
+
+### 1. Vision fact
+A single, clear statement of what this project is and why it exists.
+
+### 2. Constitution fact
+Immutable project principles. Include:
+- Language and runtime
+- Architecture style (monolith, microservice, CLI, operator, library)
+- Testing philosophy (unit-first, integration-first, TDD)
+- Code style (formatter, linter, conventions)
+- Dependency philosophy (minimal, batteries-included)
+
+### 3. Requirement facts (2–5)
+Functional requirements — what the system must do. Each requirement should be specific and testable.
+
+### 4. Constraint facts (1–3)
+Boundaries — what the system must NOT do, or non-functional requirements (performance, compatibility, security).
+
+### 5. Stakeholder facts (1–2)
+Who uses this and what they need. Even solo projects have stakeholders (the developer, end users).
+
+### 6. Acceptance criteria (2–5)
+Testable criteria derived from requirements. Each one becomes a test stub in the scaffold.
+
+Record each fact as a bead with metadata:
+
+```bash
+bd create --title "<fact title>" --type advisory --priority 1 \
+  --actor brainstorm --external-ref "inception/${INCEPTION_SLUG}"
+bd update <bead-id> --set-metadata fact_type="<vision|constitution|requirement|constraint|stakeholder|acceptance>"
+bd update <bead-id> --set-metadata fact_body="<detailed content>"
+bd update <bead-id> --set-metadata fact_tags="<comma-separated tags>"
+```
+
+After creating all facts, summarize: `Inception: structured <N> facts — ready for scaffold phase`
+
+---
+
+## Phase: scaffold
+
+The structured facts have been recorded. Your task is to generate scaffold file contents.
+
+**For greenfield**: generate complete files:
+- README.md (from vision + requirements + stakeholders)
+- CLAUDE.md (from constitution + constraints)
+- Test stubs (from acceptance criteria, in the language specified by constitution)
+- .github/workflows/ci.yml (from constitution language)
+- CONTRIBUTING.md (from constitution code style)
+
+**For brownfield**: generate only MISSING files or amendments:
+- If CLAUDE.md is missing, generate it
+- If README is sparse, generate additions (not a replacement)
+- If no CI config exists, generate it
+- Do NOT overwrite existing files — record suggestions as beads
+
+Record each generated file as a bead with the file content in metadata:
+
+```bash
+bd create --title "Scaffold: <filename>" --type advisory --priority 1 \
+  --actor brainstorm --external-ref "inception/${INCEPTION_SLUG}"
+bd update <bead-id> --set-metadata scaffold_path="<file path>"
+bd update <bead-id> --set-metadata scaffold_is_new="<true|false>"
+```
+
+After generating all scaffold files, summarize: `Inception: scaffold complete — <N> files generated`
+
+---
+
+## Rules
+
+1. **Ask, don't assume** — when information is ambiguous, ask a clarification question rather than guessing
+2. **Use community knowledge** — the primed facts below contain scaffolding patterns and defaults for common project types. Use them.
+3. **Never skip testing** — every requirement MUST have at least one acceptance criterion
+4. **Keep it simple** — produce the minimum viable scaffold, not an enterprise architecture
+5. **DO NOT create PRs, push code, or merge anything** — L1 is advisory only
+6. **DO NOT create GitHub issues** — findings go to beads only
+7. **Only close your own beads** — when reaping, only close beads where `actor` is `brainstorm`
+8. **Sign commits with DCO** — `git commit -s` for any local worktree operations
+
+## Reaping
+
+Before starting new work, check for stale inception beads:
+
+```bash
+bd list --status=open --actor=guide --json 2>/dev/null
+```
+
+Close beads from previous inception runs that are no longer relevant (e.g., from a reset inception). Print a single summary: `Reap: <N> open, <M> closed this cycle`
+
+${KNOWLEDGE}


### PR DESCRIPTION
## Summary

### Brainstorm agent (new)
- Dedicated ideation agent at all ACMM levels (L1-L6)
- At L1: project inception — turns raw ideas into structured KB facts and scaffold
- At L2+: ongoing ideation — proposes features, architecture, strategy
- Always advisory mode (produces KB facts + beads, never GitHub issues/PRs)
- Guide agent reverts to its original documentation audit role

### ApplyPack fix
- When switching ACMM levels, existing agents now get their `kick_template` and `mode` updated
- Previously existing agents were skipped entirely, so the guide kept its L4 template after switching to L1

### Files
- `brainstorm-inception.md` — L1 inception policy
- `brainstorm-advisory.md` — L2+ ideation policy  
- All 6 level pack YAMLs updated with brainstorm agent + cadences
- `acmm-policy-matrix.md` updated with new agent counts
- `api_packs.go` — ApplyPack updates kick_template for existing agents

## Test plan
- [x] All 16 packages pass
- [x] Agent count test updated (L1: 2, L2: 5, L3: 6, L4: 7, L5: 9, L6: 10)
- [ ] Apply L1 pack → brainstorm agent appears with brainstorm-inception.md template
- [ ] Switch to L4 → brainstorm switches to brainstorm-advisory.md template