### PR TITLE
fix: ApplyPack auto-starts new agents and syncs config for updated ones

### DIFF
--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -81,6 +81,7 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 			}
 			if changed {
 				s.deps.Config.Agents[pa.Name] = existing
+				_ = s.deps.AgentMgr.UpdateConfig(pa.Name, existing)
 				updated = append(updated, pa.Name)
 			} else {
 				skipped = append(skipped, pa.Name)
@@ -117,6 +118,9 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 
 		finalCfg := s.deps.Config.Agents[pa.Name]
 		s.deps.AgentMgr.AddAgent(pa.Name, finalCfg)
+		if err := s.deps.AgentMgr.Start(s.deps.Ctx, pa.Name); err != nil {
+			s.logger.Warn("failed to start agent after pack create", "agent", pa.Name, "error", err)
+		}
 
 		created = append(created, pa.Name)
 	}


### PR DESCRIPTION
## Summary

- New agents created by ApplyPack now get their tmux session spawned immediately via `Start()`, instead of waiting for the governor's next kick cycle
- Updated agents (template/mode changes) get their config synced to the agent manager via `UpdateConfig()`
- Fixes: "no tmux session found for brainstorm" after applying L1 pack

## Test plan
- [x] Build + tests pass
- [ ] Apply L1 pack → brainstorm tmux session created automatically