### PR TITLE
feat: auto-kick brainstorm agent when inception starts

### DIFF
--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -81,6 +81,7 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 			}
 			if changed {
 				s.deps.Config.Agents[pa.Name] = existing
+				_ = s.deps.AgentMgr.UpdateConfig(pa.Name, existing)
 				updated = append(updated, pa.Name)
 			} else {
 				skipped = append(skipped, pa.Name)
@@ -117,6 +118,9 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 
 		finalCfg := s.deps.Config.Agents[pa.Name]
 		s.deps.AgentMgr.AddAgent(pa.Name, finalCfg)
+		if err := s.deps.AgentMgr.Start(s.deps.Ctx, pa.Name); err != nil {
+			s.logger.Warn("failed to start agent after pack create", "agent", pa.Name, "error", err)
+		}
 
 		created = append(created, pa.Name)
 	}

--- a/v2/pkg/dashboard/inception_handlers.go
+++ b/v2/pkg/dashboard/inception_handlers.go
@@ -30,6 +30,8 @@ func (s *Server) handleInceptionStart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.kickBrainstorm()
+
 	jsonResponse(w, map[string]interface{}{
 		"ok":    true,
 		"state": state,
@@ -55,6 +57,8 @@ func (s *Server) handleInceptionScan(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+
+	s.kickBrainstorm()
 
 	jsonResponse(w, map[string]interface{}{
 		"ok":    true,
@@ -203,6 +207,22 @@ func (s *Server) handleInceptionIdeationFacts(w http.ResponseWriter, r *http.Req
 		"ok":    true,
 		"facts": facts,
 	})
+}
+
+func (s *Server) kickBrainstorm() {
+	if s.deps.AgentMgr == nil || s.deps.Scheduler == nil {
+		return
+	}
+	go func() {
+		msg := s.deps.Scheduler.BuildAgentMessage("brainstorm", nil, s.deps.Scheduler.GetLastActionable())
+		if err := s.deps.AgentMgr.SendKick("brainstorm", msg); err != nil {
+			s.logger.Warn("failed to auto-kick brainstorm for inception", "error", err)
+			return
+		}
+		if s.deps.Governor != nil {
+			s.deps.Governor.RecordKick("brainstorm")
+		}
+	}()
 }
 
 func readJSON(r *http.Request, v interface{}) error {


### PR DESCRIPTION
Auto-kicks brainstorm when user clicks Start/Scan in inception UI, so it immediately processes the idea instead of waiting for the next cadence.