### PR TITLE
fix: brainstorm agent is on-demand only, no cadence

### DIFF
--- a/v2/pkg/config/packs/level-1.yaml
+++ b/v2/pkg/config/packs/level-1.yaml
@@ -13,10 +13,8 @@ governor:
   cadences:
     quiet:
       guide: 2h
-      brainstorm: 1h
     idle:
       guide: 4h
-      brainstorm: 2h
 agents:
   - name: guide
     display_name: guide

--- a/v2/pkg/config/packs/level-2.yaml
+++ b/v2/pkg/config/packs/level-2.yaml
@@ -15,25 +15,21 @@ governor:
       guide: 4h
       scanner: 4h
       quality: 6h
-      brainstorm: 4h
     busy:
       supervisor: 5m
       guide: 4h
       scanner: 4h
       quality: 6h
-      brainstorm: 4h
     quiet:
       supervisor: 5m
       guide: 4h
       scanner: 4h
       quality: 6h
-      brainstorm: 4h
     idle:
       supervisor: 5m
       guide: 4h
       scanner: 4h
       quality: 6h
-      brainstorm: 4h
 agents:
   - name: supervisor
     display_name: Supervisor

--- a/v2/pkg/config/packs/level-3.yaml
+++ b/v2/pkg/config/packs/level-3.yaml
@@ -21,28 +21,24 @@ governor:
       ci-maintainer: pause
       quality: pause
       guide: pause
-      brainstorm: pause
     busy:
       supervisor: 5m
       scanner: 4h
       ci-maintainer: 4h
       quality: 2h
       guide: 4h
-      brainstorm: 4h
     quiet:
       supervisor: 5m
       scanner: 4h
       ci-maintainer: 4h
       quality: 2h
       guide: 4h
-      brainstorm: 4h
     idle:
       supervisor: 5m
       scanner: 4h
       ci-maintainer: 4h
       quality: 2h
       guide: 4h
-      brainstorm: 4h
 agents:
 - name: supervisor
   display_name: Supervisor

--- a/v2/pkg/config/packs/level-4.yaml
+++ b/v2/pkg/config/packs/level-4.yaml
@@ -23,7 +23,6 @@ governor:
       quality: pause
       guide: pause
       sec-check: pause
-      brainstorm: pause
     busy:
       supervisor: 5m
       scanner: 4h
@@ -31,7 +30,6 @@ governor:
       quality: 2h
       guide: 4h
       sec-check: 4h
-      brainstorm: 4h
     quiet:
       supervisor: 5m
       scanner: 4h
@@ -39,7 +37,6 @@ governor:
       quality: 2h
       guide: 4h
       sec-check: 4h
-      brainstorm: 4h
     idle:
       supervisor: 5m
       scanner: 4h
@@ -47,7 +44,6 @@ governor:
       quality: 2h
       guide: 4h
       sec-check: 4h
-      brainstorm: 4h
 agents:
 - name: supervisor
   display_name: Supervisor

--- a/v2/pkg/config/packs/level-5.yaml
+++ b/v2/pkg/config/packs/level-5.yaml
@@ -27,7 +27,6 @@ governor:
       sec-check: 4h
       architect: 4h
       strategist: 4h
-      brainstorm: pause
     busy:
       supervisor: 5m
       scanner: 4h
@@ -37,7 +36,6 @@ governor:
       sec-check: 4h
       architect: 4h
       strategist: 4h
-      brainstorm: 4h
     quiet:
       supervisor: 5m
       scanner: 4h
@@ -47,7 +45,6 @@ governor:
       sec-check: 4h
       architect: 4h
       strategist: 4h
-      brainstorm: 4h
     idle:
       supervisor: 5m
       scanner: 4h
@@ -57,7 +54,6 @@ governor:
       sec-check: 4h
       architect: 4h
       strategist: 4h
-      brainstorm: 4h
 agents:
 - name: supervisor
   display_name: Supervisor

--- a/v2/pkg/config/packs/level-6.yaml
+++ b/v2/pkg/config/packs/level-6.yaml
@@ -27,7 +27,6 @@ governor:
       outreach: 30m
       sec-check: 15m
       strategist: 30m
-      brainstorm: pause
     busy:
       supervisor: 2m
       scanner: 10m
@@ -37,7 +36,6 @@ governor:
       outreach: 1h
       sec-check: 30m
       strategist: 1h
-      brainstorm: 4h
     quiet:
       supervisor: 3m
       scanner: 20m
@@ -47,7 +45,6 @@ governor:
       outreach: 2h
       sec-check: 1h
       strategist: 2h
-      brainstorm: 4h
     idle:
       supervisor: 5m
       scanner: 30m
@@ -57,7 +54,6 @@ governor:
       outreach: 4h
       sec-check: 2h
       strategist: 4h
-      brainstorm: 4h
 agents:
 - name: supervisor
   display_name: Supervisor


### PR DESCRIPTION
Remove brainstorm from all governor cadences. It only runs when explicitly kicked (inception Start button or manual dashboard kick), never on a timer.