### PR TITLE
fix: preserve advisory digest across dashboard refreshes

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -439,7 +439,7 @@ func main() {
 		actionable := lastActionable.Load()
 		govState := gov.GetState()
 		agentStatuses := agentMgr.AllStatuses()
-		dashSrv.UpdateStatus(dashboard.BuildFrontendStatus(
+		payload := dashboard.BuildFrontendStatus(
 			govState,
 			actionable,
 			agentStatuses,
@@ -450,7 +450,11 @@ func main() {
 			ghClient,
 			ctx,
 			metricsCollector,
-		))
+		)
+		if d := dashSrv.GetAdvisoryDigest(); d != nil {
+			payload.AdvisoryDigest = d
+		}
+		dashSrv.UpdateStatus(payload)
 	}
 
 	const cachedActionablePath = "/data/last-actionable.json"


### PR DESCRIPTION
## Summary

- `refreshDashboard()` creates a fresh `StatusPayload` via `BuildFrontendStatus` which doesn't include `AdvisoryDigest`
- When called by config watcher, cached actionable restore, or API handlers, it overwrites `s.status` with a nil advisory digest — erasing the digest built during eval cycles
- Fix: restore the latest advisory digest from the dashboard server before broadcasting the status update

**Root cause**: `refreshDashboard` (3 call sites) calls `BuildFrontendStatus` → `UpdateStatus`, which replaces `s.status`. The advisory digest is only set in `runEvalCycle` (line 937). Between eval cycles, any `refreshDashboard` call wipes the digest. The `/api/status` endpoint returns `s.status`, so clients see no advisory data.

**Impact**: Advisory digest panel is empty on all dashboards (L2 and L3) despite the digest being built correctly and posted to GitHub.

## Test plan

- [ ] Verify `advisoryDigest` appears in `/api/status` response after deploy
- [ ] Verify dashboard advisory panel renders findings on certus (L2) and knuckle (L3)
- [ ] Verify config changes via dashboard don't wipe advisory digest
- [ ] Verify advisory digest survives fast agent status polling ticks