### PR TITLE
fix: deduplicate repeated blocks in agent detail summary

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1519,7 +1519,7 @@ func filterPaneOutput(lines []string, n int) []string {
 		}
 	}
 	lines = cleaned
-	lines = deduplicateBlocks(lines)
+	lines = DeduplicateBlocks(lines)
 	if n > 0 && len(lines) > n {
 		lines = lines[len(lines)-n:]
 	}
@@ -1528,9 +1528,9 @@ func filterPaneOutput(lines []string, n int) []string {
 	return out
 }
 
-// deduplicateBlocks removes repeated blocks from pane output.
+// DeduplicateBlocks removes repeated blocks from pane output.
 // It finds the longest suffix that also appears earlier and removes the earlier copy.
-func deduplicateBlocks(lines []string) []string {
+func DeduplicateBlocks(lines []string) []string {
 	if len(lines) < 4 {
 		return lines
 	}
@@ -1556,7 +1556,7 @@ func deduplicateBlocks(lines []string) []string {
 				result := make([]string, 0, len(lines)-blockSize)
 				result = append(result, lines[:start]...)
 				result = append(result, lines[start+blockSize:]...)
-				return deduplicateBlocks(result)
+				return DeduplicateBlocks(result)
 			}
 		}
 	}

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -160,7 +160,8 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 		}
 		var detailSummary string
 		if buf := proc.OutputBuffer; buf != nil && buf.Count() > 0 {
-			detailSummary = strings.Join(buf.Last(buf.Count()), "\n")
+			lines := agent.DeduplicateBlocks(buf.Last(buf.Count()))
+			detailSummary = strings.Join(lines, "\n")
 		} else if pane := proc.FilteredPaneLines(0); len(pane) > 0 {
 			detailSummary = strings.Join(pane, "\n")
 		}


### PR DESCRIPTION
## Summary

- When `diffNewLines` fails overlap detection (spinner characters change between tmux captures), the entire pane gets written to the output buffer as "new" lines, duplicating content already in the buffer
- The detail summary (expanded agent card) dumps the raw buffer via `buf.Last(buf.Count())` without deduplication, showing the same output block 3+ times
- Fix: apply `DeduplicateBlocks` to the output buffer lines when building `detailSummary` in status_builder
- The `liveSummary` path already runs dedupe via `FilteredPaneLines` → `filterPaneOutput` → `deduplicateBlocks`, so it was unaffected

**Root cause**: `findOverlap` compares lines exactly. Copilot spinner characters (`◐`, `●`, `◎`, `◉`) change between 3-second tmux capture ticks, causing the overlap detection to fail. When it fails, `diffNewLines` returns the entire current pane as "new" lines, writing them all to the ring buffer — even though most were already there from the previous capture.

## Test plan

- [ ] Verify expanded agent cards no longer show duplicated output blocks
- [ ] Verify scanner and ci-maintainer cards on knuckle show clean output
- [ ] Verify liveSummary (collapsed cards) still works correctly
- [ ] Verify detailSummary still shows full output when there are no duplicates