### PR TITLE
feat: inception live activity feed + brainstorm clear_on_kick

### DIFF
--- a/v2/pkg/config/packs/level-1.yaml
+++ b/v2/pkg/config/packs/level-1.yaml
@@ -55,6 +55,7 @@ agents:
     bead_role: worker
     mode: ADVISORY
     kick_template: brainstorm-advisory.md
+    clear_on_kick: true
     include_repos: false
     stale_timeout: 7200
     interactions: "Standalone. Driven by inception workflow and user queries."

--- a/v2/pkg/config/packs/level-2.yaml
+++ b/v2/pkg/config/packs/level-2.yaml
@@ -129,6 +129,7 @@ agents:
     bead_role: worker
     mode: ADVISORY
     kick_template: brainstorm-advisory.md
+    clear_on_kick: true
     include_repos: false
     stale_timeout: 7200
     interactions: "Standalone. Produces ideation beads for human review."

--- a/v2/pkg/config/packs/level-3.yaml
+++ b/v2/pkg/config/packs/level-3.yaml
@@ -192,3 +192,4 @@ agents:
     KB layer.
 
     '
+  clear_on_kick: true

--- a/v2/pkg/config/packs/level-4.yaml
+++ b/v2/pkg/config/packs/level-4.yaml
@@ -231,3 +231,4 @@ agents:
     KB layer.
 
     '
+  clear_on_kick: true

--- a/v2/pkg/config/packs/level-5.yaml
+++ b/v2/pkg/config/packs/level-5.yaml
@@ -290,3 +290,4 @@ agents:
     KB layer.
 
     '
+  clear_on_kick: true

--- a/v2/pkg/config/packs/level-6.yaml
+++ b/v2/pkg/config/packs/level-6.yaml
@@ -316,3 +316,4 @@ agents:
     KB layer.
 
     '
+  clear_on_kick: true

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5861,9 +5861,14 @@ function burnAreaChart() {
 
       switch (_inceptionState.phase) {
         case 'capture':
-          panel.innerHTML = _inceptionState.mode === 'greenfield'
-            ? renderInceptionCapture()
-            : renderInceptionScanProgress();
+          if (_inceptionState.idea_text) {
+            panel.innerHTML = renderInceptionWorking();
+            startInceptionPoll();
+          } else {
+            panel.innerHTML = _inceptionState.mode === 'greenfield'
+              ? renderInceptionCapture()
+              : renderInceptionScanProgress();
+          }
           break;
         case 'clarify':
           panel.innerHTML = renderInceptionClarify();
@@ -5908,6 +5913,65 @@ function burnAreaChart() {
             <button onclick="submitInceptionIdea()" style="padding:8px 24px;border:none;border-radius:6px;background:var(--blue, #58a6ff);color:#0d1117;cursor:pointer;font-size:0.82rem;font-weight:600">Start</button>
           </div>
         </div>`;
+    }
+
+    let _inceptionPollTimer = null;
+
+    function renderInceptionWorking() {
+      const idea = escapeHtml(_inceptionState.idea_text || '');
+      const phase = escapeHtml(_inceptionState.phase || 'capture');
+      return `
+        <div style="max-width:700px;margin:0 auto">
+          <div style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:16px;margin-bottom:16px">
+            <div style="font-size:0.72rem;color:var(--muted);margin-bottom:4px;text-transform:uppercase;letter-spacing:0.5px">Your Idea</div>
+            <div style="font-size:0.85rem">${idea}</div>
+          </div>
+          <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px">
+            <div style="width:8px;height:8px;border-radius:50%;background:var(--blue, #58a6ff);animation:pulse 1.5s infinite"></div>
+            <div style="font-size:0.82rem;font-weight:600">Brainstorm agent working</div>
+            <div style="font-size:0.72rem;color:var(--muted);margin-left:auto">Phase: ${phase}</div>
+          </div>
+          <div id="inception-activity" style="background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:12px;font-family:'SF Mono','Cascadia Code',monospace;font-size:0.75rem;min-height:120px;max-height:300px;overflow-y:auto;white-space:pre-wrap;color:var(--muted)">Waiting for brainstorm agent...</div>
+          <div style="margin-top:12px;display:flex;gap:8px;justify-content:flex-end">
+            <button onclick="resetInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Cancel</button>
+          </div>
+        </div>`;
+    }
+
+    function startInceptionPoll() {
+      stopInceptionPoll();
+      pollInceptionActivity();
+      const INCEPTION_POLL_INTERVAL_MS = 3000;
+      _inceptionPollTimer = setInterval(pollInceptionActivity, INCEPTION_POLL_INTERVAL_MS);
+    }
+
+    function stopInceptionPoll() {
+      if (_inceptionPollTimer) { clearInterval(_inceptionPollTimer); _inceptionPollTimer = null; }
+    }
+
+    async function pollInceptionActivity() {
+      try {
+        const r = await fetch('/api/pane/brainstorm');
+        if (!r.ok) return;
+        const data = await r.json();
+        const lines = data.lines || [];
+        const el = document.getElementById('inception-activity');
+        if (!el) { stopInceptionPoll(); return; }
+        const MAX_ACTIVITY_LINES = 15;
+        const display = lines.slice(-MAX_ACTIVITY_LINES).map(l => escapeHtml(l)).join('\n');
+        el.textContent = display || 'Waiting for brainstorm agent...';
+        el.scrollTop = el.scrollHeight;
+      } catch (e) { /* ignore poll errors */ }
+
+      try {
+        const sr = await fetch('/api/inception/state');
+        const sd = await sr.json();
+        if (sd.ok && sd.state && sd.state.phase !== _inceptionState.phase) {
+          _inceptionState = sd.state;
+          stopInceptionPoll();
+          renderInception();
+        }
+      } catch (e) { /* ignore */ }
     }
 
     function renderInceptionScanProgress() {
@@ -6077,6 +6141,7 @@ function burnAreaChart() {
     }
 
     async function resetInception() {
+      stopInceptionPoll();
       try {
         await fetch('/api/inception/reset', { method: 'POST' });
         _inceptionState = null;


### PR DESCRIPTION
## Summary

- **Live activity feed**: After clicking Start, the idea text stays visible and a live feed polls the brainstorm agent's pane output every 3s. User sees the agent working in real-time instead of a blank screen.
- **clear_on_kick**: brainstorm agent clears context on each kick so stale prior sessions don't contaminate inception processing.

## Test plan
- [ ] Type idea, click Start → idea text stays, activity feed shows brainstorm output
- [ ] Activity feed auto-scrolls, updates every 3s
- [ ] Phase transition (capture → clarify) auto-detected and UI re-renders