### PR TITLE
fix: normalize pane overlap detection to prevent detail summary duplication

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -870,10 +870,24 @@ func diffNewLines(prev, curr []string) []string {
 		return curr
 	}
 	overlap := findOverlap(prev, curr)
-	if overlap >= 0 && overlap < len(curr) {
+	if overlap >= 0 {
 		return curr[overlap:]
 	}
 	return curr
+}
+
+var spinnerReplacer = strings.NewReplacer(
+	"◐", "○", "◑", "○", "◒", "○", "◓", "○",
+	"◎", "○", "◉", "○", "●", "○",
+)
+
+var creditsRe = regexp.MustCompile(`AI Credits: [\d.]+`)
+
+func normalizeLine(s string) string {
+	s = strings.TrimRight(s, " \t")
+	s = spinnerReplacer.Replace(s)
+	s = creditsRe.ReplaceAllString(s, "AI Credits: _")
+	return s
 }
 
 func findOverlap(prev, curr []string) int {
@@ -884,7 +898,7 @@ func findOverlap(prev, curr []string) int {
 	for tail := maxTail; tail > 0; tail-- {
 		match := true
 		for i := range tail {
-			if prev[len(prev)-tail+i] != curr[i] {
+			if normalizeLine(prev[len(prev)-tail+i]) != normalizeLine(curr[i]) {
 				match = false
 				break
 			}
@@ -1546,7 +1560,7 @@ func DeduplicateBlocks(lines []string) []string {
 			}
 			match := true
 			for j := 0; j < blockSize; j++ {
-				if strings.TrimSpace(lines[start+j]) != strings.TrimSpace(candidate[j]) {
+				if normalizeLine(lines[start+j]) != normalizeLine(candidate[j]) {
 					match = false
 					break
 				}

--- a/v2/pkg/agent/manager_extra_test.go
+++ b/v2/pkg/agent/manager_extra_test.go
@@ -235,3 +235,88 @@ func TestSetModelOverride_Pinned(t *testing.T) {
 		t.Error("expected error when model is pinned")
 	}
 }
+
+func TestNormalizeLine(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{"identical", "hello world", "hello world", true},
+		{"spinner change", "◐ Reading files", "◎ Reading files", true},
+		{"credits change", "AI Credits: 42.3", "AI Credits: 99.1", true},
+		{"trailing space", "hello   ", "hello", true},
+		{"different content", "line A", "line B", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeLine(tt.a) == normalizeLine(tt.b)
+			if got != tt.want {
+				t.Errorf("normalizeLine(%q) == normalizeLine(%q) = %v, want %v",
+					tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindOverlap_SpinnerTolerant(t *testing.T) {
+	prev := []string{
+		"● Read CLAUDE.md",
+		"● Read base.md",
+		"/data/agents/scanner                                          AI Credits: 4.02",
+		"◐ Analyzing coverage                                        Claude Sonnet 4.6",
+	}
+	curr := []string{
+		"● Read CLAUDE.md",
+		"● Read base.md",
+		"/data/agents/scanner                                          AI Credits: 4.05",
+		"◎ Analyzing coverage                                        Claude Sonnet 4.6",
+	}
+	overlap := findOverlap(prev, curr)
+	if overlap != 4 {
+		t.Errorf("findOverlap with spinner/credits change = %d, want 4", overlap)
+	}
+}
+
+func TestFindOverlap_ExactMatch(t *testing.T) {
+	prev := []string{"a", "b", "c"}
+	curr := []string{"b", "c", "d"}
+	overlap := findOverlap(prev, curr)
+	if overlap != 2 {
+		t.Errorf("findOverlap exact = %d, want 2", overlap)
+	}
+}
+
+func TestDiffNewLines_SpinnerChange(t *testing.T) {
+	prev := []string{
+		"static line 1",
+		"static line 2",
+		"◐ Working                                                      AI Credits: 10",
+	}
+	curr := []string{
+		"static line 1",
+		"static line 2",
+		"◎ Working                                                      AI Credits: 11",
+	}
+	newLines := diffNewLines(prev, curr)
+	if len(newLines) != 0 {
+		t.Errorf("diffNewLines should return 0 new lines when only spinner/credits changed, got %d: %v",
+			len(newLines), newLines)
+	}
+}
+
+func TestDeduplicateBlocks_NearDuplicates(t *testing.T) {
+	lines := []string{
+		"● Read base.md",
+		"/data/agents/scanner                                          AI Credits: 4.02",
+		"◐ Analyzing",
+		"● Read base.md",
+		"/data/agents/scanner                                          AI Credits: 4.05",
+		"◎ Analyzing",
+	}
+	result := DeduplicateBlocks(lines)
+	if len(result) > 3 {
+		t.Errorf("DeduplicateBlocks should remove near-duplicate block, got %d lines: %v",
+			len(result), result)
+	}
+}


### PR DESCRIPTION
## Summary
- `findOverlap` used exact string comparison on tmux pane captures. Copilot CLI status bar lines change every tick (spinner chars cycle, `AI Credits: X` updates), breaking overlap detection and causing the entire 2000-line pane to be written to the output buffer as "new" content
- `diffNewLines` had an off-by-one: when `overlap == len(curr)` (entire pane unchanged), it returned the full content instead of empty — so even when nothing changed, all lines were re-buffered
- Both bugs compound: every 3-second capture tick dumps duplicate content into the 500-line ring buffer, producing the repeated blocks visible in expanded agent cards on the dashboard

## Fix
- Add `normalizeLine()` that collapses spinner chars to a single form, replaces volatile `AI Credits: X` values with a placeholder, and trims trailing whitespace
- Use `normalizeLine()` in both `findOverlap` (prevents buffer duplication at source) and `DeduplicateBlocks` (catches any remaining near-duplicates at display time)
- Fix `diffNewLines` boundary check: `overlap >= 0` instead of `overlap >= 0 && overlap < len(curr)`

## Test plan
- [x] `TestNormalizeLine` — spinner, credits, whitespace, exact match, different content
- [x] `TestFindOverlap_SpinnerTolerant` — overlap found despite spinner/credits changes
- [x] `TestFindOverlap_ExactMatch` — existing behavior preserved
- [x] `TestDiffNewLines_SpinnerChange` — returns empty when only status bar changed
- [x] `TestDeduplicateBlocks_NearDuplicates` — removes near-duplicate blocks
- [x] Full test suite passes
- [ ] Deploy via Watchtower, verify expanded agent cards show clean output