### PR TITLE
feat: inception feedback loop + spec-kit + UI sizing

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -107,6 +107,9 @@ RUN mkdir -p /var/run/nous/governor /var/run/nous/repo /data/nous/snapshots /opt
 RUN pip3 install --no-cache-dir --break-system-packages pyyaml 2>/dev/null || \
     pip3 install --no-cache-dir pyyaml 2>/dev/null || \
     echo "WARN: system pyyaml install failed"
+RUN pip3 install --no-cache-dir --break-system-packages specify-cli 2>/dev/null || \
+    pip3 install --no-cache-dir specify-cli 2>/dev/null || \
+    echo "WARN: spec-kit (specify-cli) install failed — inception will generate facts without it"
 RUN git clone -b feat/cli-agent-mode https://github.com/clubanderson/agentic-strategy-evolution /opt/nous && \
     python3 -m venv /opt/nous/venv && \
     /opt/nous/venv/bin/pip install --no-cache-dir -e /opt/nous 2>&1 || \

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -599,6 +599,11 @@ func main() {
 		},
 	})
 
+	if brainstormBeads, ok := beadStores["brainstorm"]; ok {
+		inceptionWatcher := dashboard.NewInceptionWatcher(brainstormBeads, inceptionEngine, sched, agentMgr, gov, logger)
+		go inceptionWatcher.Run(ctx)
+	}
+
 	if saved == nil {
 		if levelStr := os.Getenv("HIVE_LEVEL"); levelStr != "" {
 			const maxACMMLevel = 6

--- a/v2/pkg/dashboard/inception_handlers.go
+++ b/v2/pkg/dashboard/inception_handlers.go
@@ -122,6 +122,8 @@ func (s *Server) handleInceptionAnswer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.kickBrainstorm()
+
 	jsonResponse(w, map[string]interface{}{
 		"ok":    true,
 		"state": state,

--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -1,0 +1,206 @@
+package dashboard
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/agent"
+	"github.com/kubestellar/hive/v2/pkg/beads"
+	"github.com/kubestellar/hive/v2/pkg/governor"
+	"github.com/kubestellar/hive/v2/pkg/knowledge"
+	"github.com/kubestellar/hive/v2/pkg/scheduler"
+)
+
+const (
+	inceptionWatchIntervalS  = 5 * time.Second
+	inceptionBeadRefPrefix   = "inception/"
+	minQuestionsForAdvance   = 2
+	minFactsForAdvance       = 3
+)
+
+// InceptionWatcher polls brainstorm beads and bridges them into the inception
+// state machine. It detects question beads (capture → clarify) and fact beads
+// (structure → scaffold), advancing phases automatically.
+type InceptionWatcher struct {
+	beadStore *beads.Store
+	inception *knowledge.InceptionEngine
+	scheduler *scheduler.Scheduler
+	agentMgr  *agent.Manager
+	governor  *governor.Governor
+	logger    *slog.Logger
+
+	lastQuestionCount int
+	lastFactCount     int
+}
+
+// NewInceptionWatcher creates a watcher that polls the brainstorm bead store.
+func NewInceptionWatcher(
+	beadStore *beads.Store,
+	inception *knowledge.InceptionEngine,
+	sched *scheduler.Scheduler,
+	agentMgr *agent.Manager,
+	gov *governor.Governor,
+	logger *slog.Logger,
+) *InceptionWatcher {
+	return &InceptionWatcher{
+		beadStore: beadStore,
+		inception: inception,
+		scheduler: sched,
+		agentMgr:  agentMgr,
+		governor:  gov,
+		logger:    logger,
+	}
+}
+
+// Run starts the polling loop. Blocks until ctx is cancelled.
+func (w *InceptionWatcher) Run(ctx context.Context) {
+	w.logger.Info("inception watcher started")
+	ticker := time.NewTicker(inceptionWatchIntervalS)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.logger.Info("inception watcher stopped")
+			return
+		case <-ticker.C:
+			w.poll(ctx)
+		}
+	}
+}
+
+func (w *InceptionWatcher) poll(ctx context.Context) {
+	if w.inception == nil || w.beadStore == nil {
+		return
+	}
+
+	state := w.inception.GetState()
+	if state == nil {
+		w.lastQuestionCount = 0
+		w.lastFactCount = 0
+		return
+	}
+
+	inceptionBeads := w.findInceptionBeads()
+	if len(inceptionBeads) == 0 {
+		return
+	}
+
+	switch state.Phase {
+	case knowledge.PhaseCapture:
+		w.checkForQuestions(inceptionBeads)
+	case knowledge.PhaseStructure:
+		w.checkForFacts(ctx, inceptionBeads)
+	}
+}
+
+func (w *InceptionWatcher) findInceptionBeads() []*beads.Bead {
+	open := beads.StatusOpen
+	actor := "brainstorm"
+	all := w.beadStore.List(beads.ListFilter{
+		Status: &open,
+		Actor:  &actor,
+	})
+
+	var inception []*beads.Bead
+	for _, b := range all {
+		if strings.HasPrefix(b.ExternalRef, inceptionBeadRefPrefix) {
+			inception = append(inception, b)
+		}
+	}
+	return inception
+}
+
+func (w *InceptionWatcher) checkForQuestions(inceptionBeads []*beads.Bead) {
+	var questions []knowledge.Question
+	for _, b := range inceptionBeads {
+		cat := b.Metadata["category"]
+		if cat == "" {
+			continue
+		}
+		qID := b.Metadata["question_id"]
+		if qID == "" {
+			qID = cat
+		}
+
+		title := b.Title
+		title = strings.TrimPrefix(title, "Clarification: ")
+		title = strings.TrimPrefix(title, "clarification: ")
+
+		questions = append(questions, knowledge.Question{
+			ID:       qID,
+			Text:     title,
+			Default:  b.Metadata["default"],
+			Category: cat,
+		})
+	}
+
+	if len(questions) < minQuestionsForAdvance {
+		return
+	}
+	if len(questions) == w.lastQuestionCount {
+		return
+	}
+	w.lastQuestionCount = len(questions)
+
+	if err := w.inception.SetQuestions(questions); err != nil {
+		w.logger.Warn("inception watcher: failed to set questions", "error", err, "count", len(questions))
+		return
+	}
+
+	w.logger.Info("inception watcher: questions extracted, advancing to clarify",
+		"count", len(questions),
+	)
+}
+
+func (w *InceptionWatcher) checkForFacts(ctx context.Context, inceptionBeads []*beads.Bead) {
+	var facts []knowledge.IdeationFact
+	for _, b := range inceptionBeads {
+		factType := b.Metadata["fact_type"]
+		if factType == "" {
+			continue
+		}
+
+		body := b.Metadata["fact_body"]
+		if body == "" {
+			body = b.Notes
+		}
+		if body == "" {
+			body = b.Title
+		}
+
+		var tags []string
+		if t := b.Metadata["fact_tags"]; t != "" {
+			tags = strings.Split(t, ",")
+			for i := range tags {
+				tags[i] = strings.TrimSpace(tags[i])
+			}
+		}
+
+		facts = append(facts, knowledge.IdeationFact{
+			Title: b.Title,
+			Body:  body,
+			Type:  knowledge.FactType(factType),
+			Tags:  tags,
+		})
+	}
+
+	if len(facts) < minFactsForAdvance {
+		return
+	}
+	if len(facts) == w.lastFactCount {
+		return
+	}
+	w.lastFactCount = len(facts)
+
+	if err := w.inception.RecordFacts(ctx, facts); err != nil {
+		w.logger.Warn("inception watcher: failed to record facts", "error", err, "count", len(facts))
+		return
+	}
+
+	w.logger.Info("inception watcher: facts extracted, advancing to scaffold",
+		"count", len(facts),
+	)
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5931,7 +5931,7 @@ function burnAreaChart() {
             <div style="font-size:0.82rem;font-weight:600">Brainstorm agent working</div>
             <div style="font-size:0.72rem;color:var(--muted);margin-left:auto">Phase: ${phase}</div>
           </div>
-          <div id="inception-activity" style="background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:16px;font-family:'SF Mono','Cascadia Code',monospace;font-size:0.75rem;min-height:400px;max-height:600px;overflow-y:auto;white-space:pre-wrap;color:var(--muted)">Waiting for brainstorm agent...</div>
+          <div id="inception-activity" style="background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:16px;font-family:'SF Mono','Cascadia Code',monospace;font-size:0.75rem;height:calc(100vh - 280px);overflow-y:auto;white-space:pre-wrap;color:var(--muted)">Waiting for brainstorm agent...</div>
           <div style="margin-top:12px;display:flex;gap:8px;justify-content:flex-end">
             <button onclick="resetInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Cancel</button>
           </div>
@@ -5957,7 +5957,7 @@ function burnAreaChart() {
         const lines = data.lines || [];
         const el = document.getElementById('inception-activity');
         if (!el) { stopInceptionPoll(); return; }
-        const MAX_ACTIVITY_LINES = 30;
+        const MAX_ACTIVITY_LINES = 50;
         const display = lines.slice(-MAX_ACTIVITY_LINES).map(l => escapeHtml(l)).join('\n');
         el.textContent = display || 'Waiting for brainstorm agent...';
         el.scrollTop = el.scrollHeight;

--- a/v2/pkg/policies/defaults/brainstorm-advisory.md
+++ b/v2/pkg/policies/defaults/brainstorm-advisory.md
@@ -39,15 +39,31 @@ ${INCEPTION_ANSWERS}
 
 If critical info is still missing, create follow-up question beads. Otherwise produce structured facts.
 
-### If phase is `structure` — produce KB facts
+### If phase is `structure` — use spec-kit + produce KB facts
 
-Using the idea and answers, create these as beads with fact metadata:
+**Step 1: Generate spec-kit artifacts** (if `specify` is available):
+
+```bash
+if command -v specify &>/dev/null; then
+  mkdir -p /tmp/inception-specs && cd /tmp/inception-specs
+  specify init --non-interactive 2>/dev/null || true
+  specify constitution --non-interactive 2>/dev/null || true
+  specify spec --non-interactive 2>/dev/null || true
+  specify plan --non-interactive 2>/dev/null || true
+  specify tasks --non-interactive 2>/dev/null || true
+fi
+```
+
+Read the generated specs/ files (CONSTITUTION.md, SPEC.md, PLAN.md, TASKS.md) and use them to inform the KB facts below. If spec-kit is not available, generate facts directly from the idea and answers.
+
+**Step 2: Create KB fact beads** — one bead per fact, with structured metadata:
+
 - 1 **vision** fact — what this project is and why
-- 1 **constitution** fact — language, architecture, testing, code style
-- 2–5 **requirement** facts — what the system must do
-- 1–3 **constraint** facts — boundaries
+- 1 **constitution** fact — from CONSTITUTION.md or idea+answers: language, architecture, testing, code style
+- 2–5 **requirement** facts — from SPEC.md or idea: what the system must do
+- 1–3 **constraint** facts — boundaries and non-functional requirements
 - 1–2 **stakeholder** facts — who uses this
-- 2–5 **acceptance** facts — testable criteria
+- 2–5 **acceptance** facts — from PLAN.md or idea: testable criteria
 
 ```bash
 bd create --title "<fact title>" --type advisory --priority 1 \
@@ -58,7 +74,7 @@ bd update <bead-id> --set-metadata fact_body="<detailed content>"
 
 ### If phase is `scaffold` — generate bootstrap files
 
-Produce README.md, CLAUDE.md, test stubs, CI config, CONTRIBUTING.md as beads with file content in metadata.
+Produce README.md, CLAUDE.md, CONSTITUTION.md, SPEC.md, test stubs, CI config, CONTRIBUTING.md as beads with file content in metadata. If spec-kit artifacts exist in /tmp/inception-specs/specs/, include them directly.
 
 ---
 

--- a/v2/policies/brainstorm-advisory.md
+++ b/v2/policies/brainstorm-advisory.md
@@ -39,15 +39,31 @@ ${INCEPTION_ANSWERS}
 
 If critical info is still missing, create follow-up question beads. Otherwise produce structured facts.
 
-### If phase is `structure` — produce KB facts
+### If phase is `structure` — use spec-kit + produce KB facts
 
-Using the idea and answers, create these as beads with fact metadata:
+**Step 1: Generate spec-kit artifacts** (if `specify` is available):
+
+```bash
+if command -v specify &>/dev/null; then
+  mkdir -p /tmp/inception-specs && cd /tmp/inception-specs
+  specify init --non-interactive 2>/dev/null || true
+  specify constitution --non-interactive 2>/dev/null || true
+  specify spec --non-interactive 2>/dev/null || true
+  specify plan --non-interactive 2>/dev/null || true
+  specify tasks --non-interactive 2>/dev/null || true
+fi
+```
+
+Read the generated specs/ files (CONSTITUTION.md, SPEC.md, PLAN.md, TASKS.md) and use them to inform the KB facts below. If spec-kit is not available, generate facts directly from the idea and answers.
+
+**Step 2: Create KB fact beads** — one bead per fact, with structured metadata:
+
 - 1 **vision** fact — what this project is and why
-- 1 **constitution** fact — language, architecture, testing, code style
-- 2–5 **requirement** facts — what the system must do
-- 1–3 **constraint** facts — boundaries
+- 1 **constitution** fact — from CONSTITUTION.md or idea+answers: language, architecture, testing, code style
+- 2–5 **requirement** facts — from SPEC.md or idea: what the system must do
+- 1–3 **constraint** facts — boundaries and non-functional requirements
 - 1–2 **stakeholder** facts — who uses this
-- 2–5 **acceptance** facts — testable criteria
+- 2–5 **acceptance** facts — from PLAN.md or idea: testable criteria
 
 ```bash
 bd create --title "<fact title>" --type advisory --priority 1 \
@@ -58,7 +74,7 @@ bd update <bead-id> --set-metadata fact_body="<detailed content>"
 
 ### If phase is `scaffold` — generate bootstrap files
 
-Produce README.md, CLAUDE.md, test stubs, CI config, CONTRIBUTING.md as beads with file content in metadata.
+Produce README.md, CLAUDE.md, CONSTITUTION.md, SPEC.md, test stubs, CI config, CONTRIBUTING.md as beads with file content in metadata. If spec-kit artifacts exist in /tmp/inception-specs/specs/, include them directly.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the inception end-to-end flow:

- **Bead watcher**: Polls brainstorm beads every 5s, auto-advances phases when question beads (capture→clarify) or fact beads (structure→scaffold) are detected
- **Auto-kick**: Brainstorm re-kicked when user submits answers so it processes ${INCEPTION_ANSWERS}
- **Spec-kit**: Brainstorm policy uses `specify` CLI (GitHub spec-kit) for CONSTITUTION.md, SPEC.md, PLAN.md, TASKS.md generation during structure phase
- **UI**: Activity feed fills viewport height with scrollback, 50 lines shown

## Test plan
- [x] All 16 packages pass
- [ ] CDP: idea → start → watcher detects question beads → clarify form appears
- [ ] CDP: answer questions → brainstorm re-kicked → watcher detects fact beads → scaffold shown
- [ ] CDP: approve scaffold → complete