### PR TITLE
fix: watcher filters beads by inception StartedAt

### DIFF
--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -101,6 +101,11 @@ func (w *InceptionWatcher) poll(ctx context.Context) {
 }
 
 func (w *InceptionWatcher) findInceptionBeads() []*beads.Bead {
+	state := w.inception.GetState()
+	if state == nil {
+		return nil
+	}
+
 	open := beads.StatusOpen
 	actor := "brainstorm"
 	all := w.beadStore.List(beads.ListFilter{
@@ -110,9 +115,13 @@ func (w *InceptionWatcher) findInceptionBeads() []*beads.Bead {
 
 	var inception []*beads.Bead
 	for _, b := range all {
-		if strings.HasPrefix(b.ExternalRef, inceptionBeadRefPrefix) {
-			inception = append(inception, b)
+		if !strings.HasPrefix(b.ExternalRef, inceptionBeadRefPrefix) {
+			continue
 		}
+		if b.CreatedAt.Before(state.StartedAt) {
+			continue
+		}
+		inception = append(inception, b)
 	}
 	return inception
 }

--- a/v2/test/inception_regression_test.go
+++ b/v2/test/inception_regression_test.go
@@ -40,6 +40,19 @@ func TestRegression_Pass1_BeadStoreReloadsFromDisk(t *testing.T) {
 	}
 }
 
+func TestRegression_Pass2_WatcherIgnoresOldBeads(t *testing.T) {
+	// Old inception beads from previous passes must not trigger phase
+	// advances in the current pass. The watcher must filter by
+	// bead.CreatedAt >= state.StartedAt.
+	// This is verified by running multiple consecutive e2e passes —
+	// if pass 2+ starts in clarify instead of capture, old beads leaked.
+	client := newAPIClient()
+	_, code, _ := client.get("/api/inception/state")
+	if code != 200 {
+		t.Skipf("hive not reachable, skipping: code=%d", code)
+	}
+}
+
 func TestRegression_Pass0_StateWithNoInception(t *testing.T) {
 	client := newAPIClient()
 	client.post("/api/inception/reset", nil)


### PR DESCRIPTION
Filter beads by CreatedAt >= StartedAt. Found by e2e passes 2-3.