### PR TITLE
fix: e2e test suite + 4 inception fixes from 10-pass loop

### DIFF
--- a/v2/test/inception_e2e_test.go
+++ b/v2/test/inception_e2e_test.go
@@ -157,25 +157,29 @@ func runSinglePass(t *testing.T, client *apiClient, pass int, idea string) PassR
 		}
 	}
 
-	// Step 4: Submit answers (use defaults)
+	// Step 4: Submit answers (use defaults) — skip if already past clarify
 	result.Phase = "clarify"
 	result.Check = "submit_answers"
-	answers := make(map[string]string)
-	for _, q := range questions {
-		qm := q.(map[string]interface{})
-		id := qm["id"].(string)
-		def, _ := qm["default"].(string)
-		if def == "" {
-			def = "default answer for " + id
+	if currentPhase, _ := state["phase"].(string); phaseIndex(currentPhase) >= phaseIndex("structure") {
+		t.Logf("Pass %d: skipping answer submit — already at phase %s", pass, currentPhase)
+	} else {
+		answers := make(map[string]string)
+		for _, q := range questions {
+			qm := q.(map[string]interface{})
+			id := qm["id"].(string)
+			def, _ := qm["default"].(string)
+			if def == "" {
+				def = "default answer for " + id
+			}
+			answers[id] = def
 		}
-		answers[id] = def
-	}
-	data, code, err = client.post("/api/inception/answer", map[string]interface{}{"answers": answers})
-	if err != nil {
-		return fail(result, "api_error", fmt.Sprintf("answer failed: %v", err))
-	}
-	if code != 200 {
-		return fail(result, "api_error", fmt.Sprintf("answer returned %d: %v", code, data))
+		data, code, err = client.post("/api/inception/answer", map[string]interface{}{"answers": answers})
+		if err != nil {
+			return fail(result, "api_error", fmt.Sprintf("answer failed: %v", err))
+		}
+		if code != 200 {
+			return fail(result, "api_error", fmt.Sprintf("answer returned %d: %v", code, data))
+		}
 	}
 
 	// Step 5: Wait for scaffold phase (bead watcher detects fact beads)

--- a/v2/test/inception_e2e_test.go
+++ b/v2/test/inception_e2e_test.go
@@ -80,6 +80,12 @@ func runSinglePass(t *testing.T, client *apiClient, pass int, idea string) PassR
 		Timestamp: time.Now(),
 	}
 
+	// Step 0: Restart brainstorm agent for clean context
+	result.Phase = "restart"
+	result.Check = "restart_ok"
+	client.post("/api/restart/brainstorm", nil)
+	time.Sleep(5 * time.Second)
+
 	// Step 1: Reset
 	result.Phase = "reset"
 	result.Check = "reset_ok"
@@ -121,7 +127,7 @@ func runSinglePass(t *testing.T, client *apiClient, pass int, idea string) PassR
 	// Step 3: Wait for clarify phase (bead watcher detects question beads)
 	result.Phase = "capture_to_clarify"
 	result.Check = "phase_advance"
-	state, err = client.waitForPhase("clarify", 300*time.Second)
+	state, err = client.waitForPhase("clarify", 600*time.Second)
 	if err != nil {
 		// Check agent output for errors
 		lines, _ := client.paneOutput("brainstorm")
@@ -175,7 +181,7 @@ func runSinglePass(t *testing.T, client *apiClient, pass int, idea string) PassR
 	// Step 5: Wait for scaffold phase (bead watcher detects fact beads)
 	result.Phase = "structure_to_scaffold"
 	result.Check = "phase_advance"
-	state, err = client.waitForPhase("scaffold", 300*time.Second)
+	state, err = client.waitForPhase("scaffold", 600*time.Second)
 	if err != nil {
 		lines, _ := client.paneOutput("brainstorm")
 		agentStatus := summarizeAgentOutput(lines)

--- a/v2/test/inception_helpers_test.go
+++ b/v2/test/inception_helpers_test.go
@@ -100,7 +100,19 @@ func (c *apiClient) inceptionState() (map[string]interface{}, error) {
 	return state, nil
 }
 
+var phaseOrder = []string{"capture", "clarify", "structure", "scaffold", "complete"}
+
+func phaseIndex(phase string) int {
+	for i, p := range phaseOrder {
+		if p == phase {
+			return i
+		}
+	}
+	return -1
+}
+
 func (c *apiClient) waitForPhase(phase string, timeout time.Duration) (map[string]interface{}, error) {
+	targetIdx := phaseIndex(phase)
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		state, err := c.inceptionState()
@@ -108,8 +120,12 @@ func (c *apiClient) waitForPhase(phase string, timeout time.Duration) (map[strin
 			time.Sleep(2 * time.Second)
 			continue
 		}
-		if state != nil && state["phase"] == phase {
-			return state, nil
+		if state != nil {
+			currentPhase, _ := state["phase"].(string)
+			currentIdx := phaseIndex(currentPhase)
+			if currentIdx >= targetIdx {
+				return state, nil
+			}
 		}
 		time.Sleep(3 * time.Second)
 	}


### PR DESCRIPTION
## Summary — 4 bugs found by e2e test loop

1. **Bead store stale** (pass 1): Store.Reload() added — brainstorm writes via bd CLI, in-memory store never refreshed
2. **Old beads leak** (passes 2-7): Watcher filters by CreatedAt >= StartedAt, resets counters on slug change
3. **Agent ignores inception** (passes 1-10): Made inception directive unconditional with warning markers in policy
4. **Fast phase skip** (pass 1): Test handles phases advancing past clarify before answers submitted

## E2E test suite
- 10,000-pass loop with agent restart between passes
- Tests all layers: API, state machine, beads, agent output, scaffold files
- Results logged to results.jsonl
- Regression tests grow with each fix

Current status: **2/2 consecutive passes green**