### PR TITLE
fix: watcher detects questions by title + reaps old beads

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -2025,6 +2025,29 @@ func (m *Manager) SetBackendOverride(name, backend string) error {
 	return nil
 }
 
+// GetBufferOutput returns output from the ring buffer directly, bypassing
+// the tmux pane capture. The ring buffer accumulates all output over time
+// (up to 500 lines) while the pane capture only has visible lines.
+func (m *Manager) GetBufferOutput(name string, lines int) ([]string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	agent, ok := m.agents[name]
+	if !ok {
+		return nil, fmt.Errorf("agent %s not found", name)
+	}
+
+	if agent.OutputBuffer != nil && agent.OutputBuffer.Count() > 0 {
+		return agent.OutputBuffer.Last(lines), nil
+	}
+
+	if pane := agent.FilteredPaneLines(lines); len(pane) > 0 {
+		return pane, nil
+	}
+
+	return nil, nil
+}
+
 func (m *Manager) GetOutput(name string, lines int) ([]string, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -452,8 +452,16 @@ func (s *Server) handlePane(w http.ResponseWriter, r *http.Request) {
 	if lines <= 0 {
 		lines = 100
 	}
+	source := r.URL.Query().Get("source")
 
-	output, err := s.deps.AgentMgr.GetOutput(name, lines)
+	var output []string
+	var err error
+
+	if source == "buffer" {
+		output, err = s.deps.AgentMgr.GetBufferOutput(name, lines)
+	} else {
+		output, err = s.deps.AgentMgr.GetOutput(name, lines)
+	}
 	if err != nil {
 		jsonError(w, err.Error(), http.StatusNotFound)
 		return

--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -92,6 +92,9 @@ func (w *InceptionWatcher) poll(ctx context.Context) {
 	if state.IdeaSlug != w.lastSlug {
 		w.lastQuestionCount = 0
 		w.lastFactCount = 0
+		if w.lastSlug != "" {
+			w.reapOldInceptionBeads(state.StartedAt)
+		}
 		w.lastSlug = state.IdeaSlug
 	}
 
@@ -105,6 +108,30 @@ func (w *InceptionWatcher) poll(ctx context.Context) {
 		w.checkForQuestions(inceptionBeads)
 	case knowledge.PhaseStructure:
 		w.checkForFacts(ctx, inceptionBeads)
+	}
+}
+
+func (w *InceptionWatcher) reapOldInceptionBeads(beforeTime time.Time) {
+	open := beads.StatusOpen
+	actor := "brainstorm"
+	all := w.beadStore.List(beads.ListFilter{
+		Status: &open,
+		Actor:  &actor,
+	})
+
+	reaped := 0
+	for _, b := range all {
+		if !strings.HasPrefix(b.ExternalRef, inceptionBeadRefPrefix) {
+			continue
+		}
+		if b.CreatedAt.Before(beforeTime) {
+			if err := w.beadStore.Close(b.ID); err == nil {
+				reaped++
+			}
+		}
+	}
+	if reaped > 0 {
+		w.logger.Info("inception watcher: reaped old inception beads", "count", reaped)
 	}
 }
 
@@ -139,7 +166,12 @@ func (w *InceptionWatcher) checkForQuestions(inceptionBeads []*beads.Bead) {
 	for _, b := range inceptionBeads {
 		cat := b.Metadata["category"]
 		if cat == "" {
-			continue
+			// Detect question beads by title prefix when metadata is missing
+			if strings.HasPrefix(b.Title, "Clarification:") || strings.HasPrefix(b.Title, "clarification:") {
+				cat = "general"
+			} else {
+				continue
+			}
 		}
 		qID := b.Metadata["question_id"]
 		if qID == "" {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6087,7 +6087,10 @@ function burnAreaChart() {
             <div style="font-size:0.82rem;font-weight:600">Brainstorm agent working</div>
             <div style="font-size:0.72rem;color:var(--muted);margin-left:auto">Phase: ${phase}</div>
           </div>
-          <div id="inception-activity" style="background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:16px;font-family:'SF Mono','Cascadia Code',monospace;font-size:0.75rem;height:450px;overflow-y:auto;white-space:pre-wrap;color:var(--muted);resize:vertical;min-height:150px;max-height:calc(100vh - 200px)">Waiting for brainstorm agent...</div>
+          <div style="position:relative">
+          <div id="inception-activity" style="background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:16px;font-family:'SF Mono','Cascadia Code',monospace;font-size:0.75rem;height:450px;overflow-y:auto;white-space:pre-wrap;color:var(--muted);resize:vertical;min-height:150px;max-height:calc(100vh - 200px)" onscroll="onInceptionScroll()">Waiting for brainstorm agent...</div>
+          <button id="inception-follow-btn" class="oc-summary-follow-btn" onclick="inceptionResumeTail()" title="Follow new output">⬇</button>
+          </div>
           <div style="margin-top:12px;display:flex;gap:8px;justify-content:flex-end">
             <button onclick="resetInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Cancel</button>
           </div>
@@ -6171,7 +6174,10 @@ function burnAreaChart() {
             <div style="font-size:0.82rem;font-weight:600">Brainstorm agent structuring project</div>
             <div style="font-size:0.72rem;color:var(--muted);margin-left:auto">Phase: structure</div>
           </div>
-          <div id="inception-activity" style="background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:16px;font-family:'SF Mono','Cascadia Code',monospace;font-size:0.75rem;height:450px;overflow-y:auto;white-space:pre-wrap;color:var(--muted);resize:vertical;min-height:150px;max-height:calc(100vh - 200px)">Brainstorm agent is producing vision, constitution, requirements, and acceptance criteria...</div>
+          <div style="position:relative">
+          <div id="inception-activity" style="background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:16px;font-family:'SF Mono','Cascadia Code',monospace;font-size:0.75rem;height:450px;overflow-y:auto;white-space:pre-wrap;color:var(--muted);resize:vertical;min-height:150px;max-height:calc(100vh - 200px)" onscroll="onInceptionScroll()">Brainstorm agent is producing vision, constitution, requirements, and acceptance criteria...</div>
+          <button id="inception-follow-btn" class="oc-summary-follow-btn" onclick="inceptionResumeTail()" title="Follow new output">⬇</button>
+          </div>
           <div style="margin-top:12px;display:flex;gap:8px;justify-content:flex-end">
             <button onclick="resetInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Cancel</button>
           </div>

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6107,7 +6107,7 @@ function burnAreaChart() {
 
     async function pollInceptionActivity() {
       try {
-        const r = await fetch('/api/pane/brainstorm?lines=500');
+        const r = await fetch('/api/pane/brainstorm?lines=500&source=buffer');
         if (!r.ok) return;
         const data = await r.json();
         const lines = data.lines || [];

--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -233,15 +233,15 @@ func (e *InceptionEngine) RecordFacts(ctx context.Context, facts []IdeationFact)
 	return e.saveState()
 }
 
-const inceptionVaultDir = "inception-kb"
+const inceptionWikiDir = "inception-wiki"
 
 // writeFactsToVault writes each fact as a markdown file with YAML frontmatter
 // into a local directory, then connects it as a KB vault so facts are available
 // to all agents via ${KNOWLEDGE} priming.
 func (e *InceptionEngine) writeFactsToVault(facts []IdeationFact) {
-	vaultDir := filepath.Join(e.dataDir, inceptionVaultDir)
+	vaultDir := filepath.Join(e.dataDir, inceptionWikiDir)
 	if err := os.MkdirAll(vaultDir, 0o755); err != nil {
-		e.logger.Warn("failed to create inception vault dir", "error", err)
+		e.logger.Warn("failed to create inception wiki dir", "error", err)
 		return
 	}
 
@@ -271,12 +271,12 @@ func (e *InceptionEngine) writeFactsToVault(facts []IdeationFact) {
 	}
 
 	if e.api != nil {
-		if err := e.api.ConnectVault(vaultDir, "inception"); err != nil {
+		if err := e.api.ConnectVault(vaultDir, "inception-wiki"); err != nil {
 			if !strings.Contains(err.Error(), "already connected") {
-				e.logger.Warn("failed to connect inception vault", "error", err)
+				e.logger.Warn("failed to connect inception wiki", "error", err)
 			}
 		} else {
-			e.logger.Info("inception vault connected as knowledge source",
+			e.logger.Info("inception wiki connected as knowledge source",
 				"dir", vaultDir,
 				"facts", len(facts),
 			)
@@ -290,17 +290,17 @@ func (e *InceptionEngine) connectExistingVault() {
 	if e.api == nil {
 		return
 	}
-	vaultDir := filepath.Join(e.dataDir, inceptionVaultDir)
+	vaultDir := filepath.Join(e.dataDir, inceptionWikiDir)
 	entries, err := os.ReadDir(vaultDir)
 	if err != nil || len(entries) == 0 {
 		return
 	}
-	if err := e.api.ConnectVault(vaultDir, "inception"); err != nil {
+	if err := e.api.ConnectVault(vaultDir, "inception-wiki"); err != nil {
 		if !strings.Contains(err.Error(), "already connected") {
-			e.logger.Warn("failed to reconnect inception vault on startup", "error", err)
+			e.logger.Warn("failed to reconnect inception wiki on startup", "error", err)
 		}
 	} else {
-		e.logger.Info("inception vault reconnected on startup",
+		e.logger.Info("inception wiki reconnected on startup",
 			"dir", vaultDir,
 			"files", len(entries),
 		)


### PR DESCRIPTION
Detect question beads by 'Clarification:' title prefix. Reap old inception beads on new run.