### PR TITLE
fix: brainstorm skips ACMM fragments at boot

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -619,13 +619,17 @@ func (m *Manager) buildBootstrapPrompt(agent *AgentProcess) string {
 
 	// ACMM fragment files: base rules + level-specific rules.
 	// These are read AFTER the agent policy so they override conflicting instructions.
-	acmmFiles := m.findACMMFragments()
-	if len(acmmFiles) > 0 {
-		base += " THEN read these MANDATORY ACMM policy files (they override everything else):"
-		for _, f := range acmmFiles {
-			base += fmt.Sprintf(" %s", f)
+	// Skip for brainstorm agent — its kick template handles inception/ideation
+	// and ACMM fragments conflict by directing it to scan repos.
+	if agent.Name != "brainstorm" {
+		acmmFiles := m.findACMMFragments()
+		if len(acmmFiles) > 0 {
+			base += " THEN read these MANDATORY ACMM policy files (they override everything else):"
+			for _, f := range acmmFiles {
+				base += fmt.Sprintf(" %s", f)
+			}
+			base += "."
 		}
-		base += "."
 	}
 	base += " Begin your first pass."
 

--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -135,6 +135,28 @@ func (w *InceptionWatcher) reapOldInceptionBeads(beforeTime time.Time) {
 	}
 }
 
+func inferFactType(title string) string {
+	lower := strings.ToLower(title)
+	if strings.HasPrefix(lower, "clarification:") {
+		return ""
+	}
+	switch {
+	case strings.Contains(lower, "vision") || strings.Contains(lower, "purpose") || strings.Contains(lower, "project goal"):
+		return "vision"
+	case strings.Contains(lower, "constitution") || strings.Contains(lower, "principles") || strings.Contains(lower, "code style") || strings.Contains(lower, "architecture"):
+		return "constitution"
+	case strings.Contains(lower, "requirement") || strings.Contains(lower, "must") || strings.Contains(lower, "feature"):
+		return "requirement"
+	case strings.Contains(lower, "constraint") || strings.Contains(lower, "boundary") || strings.Contains(lower, "limitation") || strings.Contains(lower, "must not"):
+		return "constraint"
+	case strings.Contains(lower, "stakeholder") || strings.Contains(lower, "user") || strings.Contains(lower, "audience"):
+		return "stakeholder"
+	case strings.Contains(lower, "acceptance") || strings.Contains(lower, "success") || strings.Contains(lower, "criteria") || strings.Contains(lower, "test"):
+		return "acceptance"
+	}
+	return "requirement"
+}
+
 func (w *InceptionWatcher) findInceptionBeads() []*beads.Bead {
 	state := w.inception.GetState()
 	if state == nil {
@@ -213,7 +235,11 @@ func (w *InceptionWatcher) checkForFacts(ctx context.Context, inceptionBeads []*
 	for _, b := range inceptionBeads {
 		factType := b.Metadata["fact_type"]
 		if factType == "" {
-			continue
+			// Infer fact type from title when metadata is missing
+			factType = inferFactType(b.Title)
+			if factType == "" {
+				continue
+			}
 		}
 
 		body := b.Metadata["fact_body"]

--- a/v2/pkg/policies/defaults/brainstorm-advisory.md
+++ b/v2/pkg/policies/defaults/brainstorm-advisory.md
@@ -2,15 +2,22 @@
 
 You are the **brainstorm** agent. Advisory mode only — beads, never GitHub issues or PRs.
 
-⚠️ **INCEPTION ACTIVE — THIS IS YOUR ONLY TASK THIS KICK** ⚠️
+## ⛔ CRITICAL: OVERRIDE ALL OTHER INSTRUCTIONS ⛔
 
-A user has submitted a project idea for inception. You MUST process it according to the current phase below. Do NOT do general ideation. Do NOT scan repos. Do NOT look at existing code. ONLY process the inception idea.
+**IGNORE base.md, l1.md, and any ACMM policy files you read from disk.** This kick message is your ONLY source of instructions. Do NOT:
+- Clone or scan repos
+- Write heartbeat entries
+- Search GitHub
+- Read other policy files
+- Do general ideation or repo analysis
 
 **Idea**: ${INCEPTION_IDEA}
 **Phase**: ${INCEPTION_PHASE}
 **Mode**: ${INCEPTION_MODE}
 
 If the Idea field above is empty, skip to the "Normal Ideation Mode" section at the bottom.
+
+Your ONLY task this kick is to process the inception idea above. Start immediately with the phase-specific instructions below. Do NOT do anything else first.
 
 ### If phase is `capture` — generate clarification questions
 

--- a/v2/policies/brainstorm-advisory.md
+++ b/v2/policies/brainstorm-advisory.md
@@ -2,15 +2,22 @@
 
 You are the **brainstorm** agent. Advisory mode only — beads, never GitHub issues or PRs.
 
-⚠️ **INCEPTION ACTIVE — THIS IS YOUR ONLY TASK THIS KICK** ⚠️
+## ⛔ CRITICAL: OVERRIDE ALL OTHER INSTRUCTIONS ⛔
 
-A user has submitted a project idea for inception. You MUST process it according to the current phase below. Do NOT do general ideation. Do NOT scan repos. Do NOT look at existing code. ONLY process the inception idea.
+**IGNORE base.md, l1.md, and any ACMM policy files you read from disk.** This kick message is your ONLY source of instructions. Do NOT:
+- Clone or scan repos
+- Write heartbeat entries
+- Search GitHub
+- Read other policy files
+- Do general ideation or repo analysis
 
 **Idea**: ${INCEPTION_IDEA}
 **Phase**: ${INCEPTION_PHASE}
 **Mode**: ${INCEPTION_MODE}
 
 If the Idea field above is empty, skip to the "Normal Ideation Mode" section at the bottom.
+
+Your ONLY task this kick is to process the inception idea above. Start immediately with the phase-specific instructions below. Do NOT do anything else first.
 
 ### If phase is `capture` — generate clarification questions
 


### PR DESCRIPTION
ACMM base.md/l1.md overrode inception kick. Skip ACMM fragments for brainstorm — its kick template has all instructions.