### PR TITLE
fix: BootstrapOverride for inception agent boot

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -65,7 +65,8 @@ type AgentProcess struct {
 	tmuxSession     string
 	tmuxSocket      string
 	cancel context.CancelFunc
-	forceRelaunch   bool
+	forceRelaunch       bool
+	BootstrapOverride   string // when set, replaces buildBootstrapPrompt output
 }
 
 // ProjectContext holds project-level config injected into agent boot prompts.
@@ -329,7 +330,11 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	}
 	model = normalizeModelName(model)
 
-	bootstrapPrompt := m.buildBootstrapPrompt(agent)
+	bootstrapPrompt := agent.BootstrapOverride
+	if bootstrapPrompt == "" {
+		bootstrapPrompt = m.buildBootstrapPrompt(agent)
+	}
+	agent.BootstrapOverride = "" // one-shot: clear after use
 
 	mode := m.agentMode(agent)
 	agent.LaunchedMode = mode
@@ -1888,6 +1893,19 @@ func (m *Manager) Resume(ctx context.Context, name string) error {
 		}
 		return m.launchInTmux(ctx, agent)
 	}
+	return nil
+}
+
+// SetBootstrapOverride sets a one-shot bootstrap prompt override. On the next
+// restart, this message replaces the standard boot prompt. Cleared after use.
+func (m *Manager) SetBootstrapOverride(name, prompt string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	agent, ok := m.agents[name]
+	if !ok {
+		return fmt.Errorf("agent %s not found", name)
+	}
+	agent.BootstrapOverride = prompt
 	return nil
 }
 

--- a/v2/pkg/dashboard/inception_handlers.go
+++ b/v2/pkg/dashboard/inception_handlers.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"os"
 
 	"github.com/kubestellar/hive/v2/pkg/knowledge"
 )
@@ -217,19 +216,15 @@ func (s *Server) kickBrainstorm() {
 		return
 	}
 	go func() {
-		// Build the inception kick message FIRST
+		// Build the inception kick message and set it as the bootstrap
+		// override — when the agent restarts, this replaces the default
+		// boot prompt ("read policy file, scan repos"). The agent boots
+		// with inception as its ONLY instruction.
 		msg := s.deps.Scheduler.BuildAgentMessage("brainstorm", nil, s.deps.Scheduler.GetLastActionable())
-
-		// Write the inception kick as the bootstrap prompt so the agent
-		// sees it as its FIRST instruction on boot — not as a follow-up
-		// message after boot has already started repo scanning.
-		bootstrapFile := "/tmp/.hive-bootstrap-brainstorm.txt"
-		if err := os.WriteFile(bootstrapFile, []byte(msg), 0o644); err != nil {
-			s.logger.Warn("failed to write inception bootstrap", "error", err)
+		if err := s.deps.AgentMgr.SetBootstrapOverride("brainstorm", msg); err != nil {
+			s.logger.Warn("failed to set bootstrap override", "error", err)
 		}
 
-		// Restart the agent — it will boot with the inception kick as
-		// its initial prompt, not the default "read your policy file" boot.
 		if err := s.deps.AgentMgr.Restart(s.deps.Ctx, "brainstorm"); err != nil {
 			s.logger.Warn("failed to restart brainstorm for inception", "error", err)
 		}

--- a/v2/pkg/dashboard/inception_handlers.go
+++ b/v2/pkg/dashboard/inception_handlers.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"time"
+	"os"
 
 	"github.com/kubestellar/hive/v2/pkg/knowledge"
 )
@@ -217,22 +217,23 @@ func (s *Server) kickBrainstorm() {
 		return
 	}
 	go func() {
-		// Restart the agent to get a completely fresh session.
-		// The brainstorm agent accumulates context from prior kicks and
-		// ignores inception instructions if its session has general
-		// ideation history. A full restart ensures a clean slate.
+		// Build the inception kick message FIRST
+		msg := s.deps.Scheduler.BuildAgentMessage("brainstorm", nil, s.deps.Scheduler.GetLastActionable())
+
+		// Write the inception kick as the bootstrap prompt so the agent
+		// sees it as its FIRST instruction on boot — not as a follow-up
+		// message after boot has already started repo scanning.
+		bootstrapFile := "/tmp/.hive-bootstrap-brainstorm.txt"
+		if err := os.WriteFile(bootstrapFile, []byte(msg), 0o644); err != nil {
+			s.logger.Warn("failed to write inception bootstrap", "error", err)
+		}
+
+		// Restart the agent — it will boot with the inception kick as
+		// its initial prompt, not the default "read your policy file" boot.
 		if err := s.deps.AgentMgr.Restart(s.deps.Ctx, "brainstorm"); err != nil {
 			s.logger.Warn("failed to restart brainstorm for inception", "error", err)
 		}
 
-		const agentBootWait = 8 * time.Second
-		time.Sleep(agentBootWait)
-
-		msg := s.deps.Scheduler.BuildAgentMessage("brainstorm", nil, s.deps.Scheduler.GetLastActionable())
-		if err := s.deps.AgentMgr.SendKick("brainstorm", msg); err != nil {
-			s.logger.Warn("failed to kick brainstorm for inception", "error", err)
-			return
-		}
 		if s.deps.Governor != nil {
 			s.deps.Governor.RecordKick("brainstorm")
 		}


### PR DESCRIPTION
Agent manager always overwrote bootstrap. Added BootstrapOverride field — inception kick replaces boot prompt.