### PR TITLE
fix: user must answer questions before structure advances

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -331,10 +331,12 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	model = normalizeModelName(model)
 
 	bootstrapPrompt := agent.BootstrapOverride
-	if bootstrapPrompt == "" {
+	if bootstrapPrompt != "" {
+		m.logger.Info("using bootstrap override", "agent", agent.Name, "len", len(bootstrapPrompt))
+		agent.BootstrapOverride = ""
+	} else {
 		bootstrapPrompt = m.buildBootstrapPrompt(agent)
 	}
-	agent.BootstrapOverride = "" // one-shot: clear after use
 
 	mode := m.agentMode(agent)
 	agent.LaunchedMode = mode

--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -107,7 +107,19 @@ func (w *InceptionWatcher) poll(ctx context.Context) {
 	case knowledge.PhaseCapture:
 		w.checkForQuestions(inceptionBeads)
 	case knowledge.PhaseStructure:
-		w.checkForFacts(ctx, inceptionBeads)
+		// Only check for facts created AFTER the user submitted answers
+		// (PhaseChangedAt). Fact beads from the initial kick predate the
+		// structure phase and should not auto-advance — the user must be
+		// in the loop via the clarify form first.
+		if !state.PhaseChangedAt.IsZero() {
+			var postAnswerBeads []*beads.Bead
+			for _, b := range inceptionBeads {
+				if !b.CreatedAt.Before(state.PhaseChangedAt) {
+					postAnswerBeads = append(postAnswerBeads, b)
+				}
+			}
+			w.checkForFacts(ctx, postAnswerBeads)
+		}
 	}
 }
 

--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -166,6 +166,7 @@ func (e *InceptionEngine) SubmitAnswers(answers map[string]string) (*InceptionSt
 	e.state.Answers = answers
 	if e.state.Phase == PhaseClarify {
 		e.state.Phase = PhaseStructure
+		e.state.PhaseChangedAt = time.Now()
 	}
 
 	if err := e.saveState(); err != nil {

--- a/v2/pkg/knowledge/types.go
+++ b/v2/pkg/knowledge/types.go
@@ -222,15 +222,16 @@ type Question struct {
 
 // InceptionState tracks the progress of a Level 1 ideation workflow.
 type InceptionState struct {
-	Phase     InceptionPhase    `json:"phase"`
-	Mode      InceptionMode     `json:"mode"`
-	IdeaText  string            `json:"idea_text"`
-	IdeaSlug  string            `json:"idea_slug"`
-	RepoURL   string            `json:"repo_url,omitempty"`
-	Questions []Question        `json:"questions,omitempty"`
-	Answers   map[string]string `json:"answers,omitempty"`
-	FactSlugs []string          `json:"fact_slugs,omitempty"`
-	StartedAt time.Time         `json:"started_at"`
+	Phase          InceptionPhase    `json:"phase"`
+	Mode           InceptionMode     `json:"mode"`
+	IdeaText       string            `json:"idea_text"`
+	IdeaSlug       string            `json:"idea_slug"`
+	RepoURL        string            `json:"repo_url,omitempty"`
+	Questions      []Question        `json:"questions,omitempty"`
+	Answers        map[string]string `json:"answers,omitempty"`
+	FactSlugs      []string          `json:"fact_slugs,omitempty"`
+	StartedAt      time.Time         `json:"started_at"`
+	PhaseChangedAt time.Time         `json:"phase_changed_at"`
 }
 
 // ScaffoldFile is a single generated file in the scaffold output.

--- a/v2/test/inception_e2e_test.go
+++ b/v2/test/inception_e2e_test.go
@@ -127,7 +127,7 @@ func runSinglePass(t *testing.T, client *apiClient, pass int, idea string) PassR
 	// Step 3: Wait for clarify phase (bead watcher detects question beads)
 	result.Phase = "capture_to_clarify"
 	result.Check = "phase_advance"
-	state, err = client.waitForPhase("clarify", 600*time.Second)
+	state, err = client.waitForPhase("clarify", 900*time.Second)
 	if err != nil {
 		// Check agent output for errors
 		lines, _ := client.paneOutput("brainstorm")
@@ -185,7 +185,7 @@ func runSinglePass(t *testing.T, client *apiClient, pass int, idea string) PassR
 	// Step 5: Wait for scaffold phase (bead watcher detects fact beads)
 	result.Phase = "structure_to_scaffold"
 	result.Check = "phase_advance"
-	state, err = client.waitForPhase("scaffold", 600*time.Second)
+	state, err = client.waitForPhase("scaffold", 900*time.Second)
 	if err != nil {
 		lines, _ := client.paneOutput("brainstorm")
 		agentStatus := summarizeAgentOutput(lines)

--- a/v2/test/inception_e2e_test.go
+++ b/v2/test/inception_e2e_test.go
@@ -157,12 +157,12 @@ func runSinglePass(t *testing.T, client *apiClient, pass int, idea string) PassR
 		}
 	}
 
-	// Step 4: Submit answers (use defaults) — skip if already past clarify
+	// Step 4: Submit answers (use defaults) — always submit, even if phase
+	// already advanced past clarify. The API accepts late answers and sets
+	// PhaseChangedAt which the watcher needs to detect post-answer fact beads.
 	result.Phase = "clarify"
 	result.Check = "submit_answers"
-	if currentPhase, _ := state["phase"].(string); phaseIndex(currentPhase) >= phaseIndex("structure") {
-		t.Logf("Pass %d: skipping answer submit — already at phase %s", pass, currentPhase)
-	} else {
+	{
 		answers := make(map[string]string)
 		for _, q := range questions {
 			qm := q.(map[string]interface{})


### PR DESCRIPTION
Watcher only counts fact beads created after user submits answers (PhaseChangedAt). Keeps user in the clarify loop.