### PR TITLE
fix: remove NO_GITHUB mode, use ADVISORY as lowest tier

### DIFF
--- a/v2/deploy/hive-quickstart.yaml
+++ b/v2/deploy/hive-quickstart.yaml
@@ -1,0 +1,214 @@
+# Hive v2 — Quick Start Configuration
+# Points at kubestellar/hive-tester for safe ACMM level testing.
+# Copy this file to hive.yaml and update the github section.
+
+project:
+  org: kubestellar
+  name: hive-tester
+  repos:
+    - hive-tester
+  ai_author: clubanderson
+  primary_repo: hive-tester
+  open_prs: true
+
+policies:
+  repo: https://github.com/kubestellar/hive
+  branch: v2
+  path: v2/policies/
+  local_dir: /data/policies
+  poll_interval: 5m
+
+agents:
+  guide:
+    id: guide
+    backend: copilot
+    model: claude-sonnet-4-6
+    beads_dir: /data/beads/guide
+    enabled: true
+    display_name: guide
+    role: guide
+    sort_order: 10
+    emoji: "\U0001F4D6"
+    color: "#9b59b6"
+    kick_template: guide-advisory.md
+    include_repos: true
+    bead_role: worker
+  supervisor:
+    id: supervisor
+    backend: copilot
+    model: claude-sonnet-4-6
+    beads_dir: /data/beads/supervisor
+    enabled: true
+    display_name: supervisor
+    role: supervisor
+    sort_order: 0
+    emoji: "\U0001F451"
+    color: "#e74c3c"
+    kick_template: supervisor-CLAUDE.md
+    include_repos: true
+    bead_role: supervisor
+  scanner:
+    id: scanner
+    backend: copilot
+    model: claude-sonnet-4-6
+    beads_dir: /data/beads/scanner
+    enabled: true
+    display_name: scanner
+    role: scanner
+    sort_order: 20
+    emoji: "\U0001F50D"
+    color: "#3498db"
+    kick_template: scanner-advisory.md
+    include_repos: true
+    bead_role: worker
+  quality:
+    id: quality
+    backend: copilot
+    model: claude-opus-4-6
+    beads_dir: /data/beads/quality
+    enabled: true
+    display_name: quality
+    role: quality
+    sort_order: 40
+    emoji: "\U0001F3AF"
+    color: "#2ecc71"
+    kick_template: quality-full.md
+    include_repos: true
+    bead_role: worker
+  ci-maintainer:
+    id: ci-maintainer
+    backend: copilot
+    model: claude-sonnet-4-6
+    beads_dir: /data/beads/ci-maintainer
+    enabled: true
+    display_name: ci-maintainer
+    role: ci-maintainer
+    sort_order: 30
+    emoji: "\U0001F527"
+    color: "#2ecc71"
+    kick_template: ci-maintainer-advisory-CLAUDE.md
+    include_repos: true
+    bead_role: worker
+  sec-check:
+    id: sec-check
+    backend: copilot
+    model: claude-sonnet-4-6
+    beads_dir: /data/beads/sec-check
+    enabled: true
+    display_name: sec-check
+    role: sec-check
+    sort_order: 50
+    emoji: "\U0001F6E1"
+    color: "#e67e22"
+    kick_template: sec-check.md
+    include_repos: true
+    bead_role: worker
+  architect:
+    id: architect
+    backend: copilot
+    model: claude-sonnet-4-6
+    beads_dir: /data/beads/architect
+    enabled: true
+    display_name: architect
+    role: architect
+    sort_order: 60
+    emoji: "\U0001F3D7"
+    color: "#1abc9c"
+    kick_template: architect.md
+    include_repos: true
+    bead_role: worker
+  strategist:
+    id: strategist
+    backend: copilot
+    model: claude-sonnet-4-6
+    beads_dir: /data/beads/strategist
+    enabled: true
+    display_name: strategist
+    role: strategist
+    sort_order: 70
+    emoji: "\U0001F9E0"
+    color: "#8e44ad"
+    kick_template: strategist.md
+    include_repos: true
+    bead_role: worker
+  outreach:
+    id: outreach
+    backend: copilot
+    model: claude-sonnet-4-6
+    beads_dir: /data/beads/outreach
+    enabled: true
+    display_name: outreach
+    role: outreach
+    sort_order: 80
+    emoji: "\U0001F4E2"
+    color: "#f39c12"
+    kick_template: outreach.md
+    include_repos: true
+    bead_role: worker
+
+# Start at ACMM Level 1 (guide only). Change via dashboard or API.
+acmm_level: 1
+
+github:
+  # Option 1: Use the public Hive GitHub App (dashboard login only)
+  oauth_client_id: Ov23ligE2p0gjXg6xAUf
+  token: ""
+  # Option 2: Create your own GitHub App for full ACMM agent capabilities.
+  # See the setup dialog in the dashboard for step-by-step instructions.
+  # app_id: <your-app-id>
+  # installation_id: <your-installation-id>
+  # key_file: /secrets/gh-app-key.pem
+
+governor:
+  eval_interval_s: 300
+  modes:
+    idle:
+      threshold: 0
+      guide: 4h
+      supervisor: 5m
+      scanner: 4h
+      quality: 2h
+      ci-maintainer: 4h
+      sec-check: 4h
+      architect: 4h
+      strategist: 4h
+      outreach: pause
+    quiet:
+      threshold: 3
+      guide: 4h
+      supervisor: 5m
+      scanner: 4h
+      quality: 2h
+      ci-maintainer: 4h
+      sec-check: 4h
+      architect: 4h
+      strategist: 4h
+      outreach: pause
+    busy:
+      threshold: 10
+      guide: 4h
+      supervisor: 5m
+      scanner: 4h
+      quality: 2h
+      ci-maintainer: 4h
+      sec-check: 4h
+      architect: 4h
+      strategist: 4h
+      outreach: pause
+    surge:
+      threshold: 180
+      guide: pause
+      supervisor: pause
+      scanner: pause
+      quality: pause
+      ci-maintainer: pause
+      sec-check: pause
+      architect: pause
+      strategist: pause
+      outreach: pause
+
+dashboard:
+  port: 3002
+
+knowledge:
+  enabled: false

--- a/v2/docs/acmm-policy-matrix.md
+++ b/v2/docs/acmm-policy-matrix.md
@@ -33,7 +33,7 @@ Agents observe and report findings as advisory beads on the dashboard and tracki
 
 | Agent | Mode | Template |
 |-------|------|----------|
-| supervisor | no-github | `supervisor-nogithub.md` |
+| supervisor | advisory | `supervisor-advisory.md` |
 | scanner | advisory | `scanner-advisory.md` |
 | quality | advisory | `quality-advisory.md` |
 | guide | advisory | `guide-advisory.md` |
@@ -45,7 +45,7 @@ Quality agent opens GitHub issues and PRs about testing gaps, coverage, and CI w
 
 | Agent | Mode | Template |
 |-------|------|----------|
-| supervisor | no-github | `supervisor-nogithub.md` |
+| supervisor | advisory | `supervisor-advisory.md` |
 | scanner | advisory | `scanner-advisory.md` |
 | ci-maintainer | advisory | `ci-maintainer-advisory.md` |
 | **quality** | **holdgated** | `quality-holdgated.md` |
@@ -58,7 +58,7 @@ All agents open GitHub issues — bugs, docs gaps, CI problems, security vulnera
 
 | Agent | Mode | Template |
 |-------|------|----------|
-| supervisor | no-github | `supervisor-nogithub.md` |
+| supervisor | advisory | `supervisor-advisory.md` |
 | scanner | measured | `scanner-issues.md` |
 | ci-maintainer | holdgated | `ci-maintainer-holdgated.md` |
 | **quality** | **holdgated** | `quality-holdgated.md` |
@@ -72,7 +72,7 @@ Agents open issues AND pull requests. All PRs get a hold label — humans batch-
 
 | Agent | Mode | Template |
 |-------|------|----------|
-| supervisor | no-github | `supervisor-nogithub.md` |
+| supervisor | advisory | `supervisor-advisory.md` |
 | scanner | holdgated | `scanner-holdgated.md` |
 | ci-maintainer | holdgated | `ci-maintainer-holdgated.md` |
 | quality | holdgated | `quality-holdgated.md` |
@@ -88,7 +88,7 @@ Agents open issues, create PRs, and auto-merge on green CI. No hold label. Outre
 
 | Agent | Mode | Template |
 |-------|------|----------|
-| supervisor | no-github | `supervisor-nogithub.md` |
+| supervisor | advisory | `supervisor-advisory.md` |
 | scanner | full | `scanner-automerge.md` |
 | ci-maintainer | full | `ci-maintainer-full.md` |
 | quality | full | `quality-full.md` |
@@ -103,7 +103,7 @@ Agents open issues, create PRs, and auto-merge on green CI. No hold label. Outre
 
 1. **All PRs are holdgated below L6.** No agent can auto-merge unless running at L6 (Fully Autonomous).
 2. **Advisory agents never get GH auth.** The `${GH_AUTH}` template variable is only injected into measured, holdgated, and full templates.
-3. **Supervisor never touches GitHub.** At every level, supervisor uses `supervisor-nogithub.md` — it monitors agent health, not code.
+3. **Supervisor uses advisory mode.** At every level, supervisor uses `supervisor-advisory.md` — it monitors agent health, not code.
 4. **Mode escalation is per-agent.** At L4, some agents are measured (issues only) while others are holdgated (issues + PRs). The level defines the mix.
 5. **Knowledge priming works at all levels.** The `${KNOWLEDGE}` template variable injects relevant facts from git sources and wiki layers regardless of the agent's mode.
 6. **Brainstorm is always advisory.** It produces KB facts and beads, never GitHub issues or PRs. Its role evolves from inception (L1) to ongoing ideation (L2+), but its mode stays advisory at all levels.

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -716,8 +716,6 @@ func (m *Manager) buildProjectPreamble(agent *AgentProcess) string {
 		prPolicy = "PRs NOT allowed (project-wide)."
 	} else {
 		switch mode {
-		case ModeNoGitHub:
-			prPolicy = "\U0001F507 NO GitHub interaction. Internal coordination only."
 		case ModeAdvisory:
 			prPolicy = "\U0001F4DD Advisory only — beads, no issues/PRs."
 		case ModeIssuesOnly:

--- a/v2/pkg/agent/mode.go
+++ b/v2/pkg/agent/mode.go
@@ -4,17 +4,15 @@ package agent
 type AgentMode int
 
 const (
-	ModeNoGitHub      AgentMode = iota // No GitHub interaction
-	ModeAdvisory                       // Advisory beads only, governor posts digests
-	ModeIssuesOnly                     // Open issues, no PRs
-	ModeIssuesAndPRs                   // Issues + PRs (hold-labeled at L5)
-	ModeIssuesPRsMerge                 // Issues + PRs + auto-merge on green CI
+	ModeAdvisory       AgentMode = iota // Advisory beads only, governor posts digests
+	ModeIssuesOnly                      // Open issues, no PRs
+	ModeIssuesAndPRs                    // Issues + PRs (hold-labeled at L5)
+	ModeIssuesPRsMerge                  // Issues + PRs + auto-merge on green CI
 )
 
-const agentModeCount = 5
+const agentModeCount = 4
 
 var modeNames = [agentModeCount]string{
-	"NO_GITHUB",
 	"ADVISORY",
 	"ISSUES_ONLY",
 	"ISSUES_AND_PRS",
@@ -22,7 +20,6 @@ var modeNames = [agentModeCount]string{
 }
 
 var modeEmojis = [agentModeCount]string{
-	"\U0001F507", // 🔇
 	"\U0001F4DD", // 📝
 	"\U0001F3AB", // 🎫
 	"\U0001F527", // 🔧
@@ -30,7 +27,6 @@ var modeEmojis = [agentModeCount]string{
 }
 
 var modeSuffixes = [agentModeCount]string{
-	"-nogithub",
 	"-advisory",
 	"-issues",
 	"-holdgated",
@@ -77,7 +73,11 @@ func (m AgentMode) CanPush() bool         { return m >= ModeIssuesAndPRs }
 func (m AgentMode) NeedsMCPWrite() bool   { return m >= ModeIssuesOnly }
 
 // ParseAgentMode converts a string like "ADVISORY" to an AgentMode.
+// Accepts "NO_GITHUB" as a legacy alias for ADVISORY.
 func ParseAgentMode(s string) (AgentMode, bool) {
+	if s == "NO_GITHUB" {
+		return ModeAdvisory, true
+	}
 	for i, n := range modeNames {
 		if n == s {
 			return AgentMode(i), true

--- a/v2/pkg/agent/mode_test.go
+++ b/v2/pkg/agent/mode_test.go
@@ -7,7 +7,6 @@ func TestAgentModeString(t *testing.T) {
 		mode AgentMode
 		want string
 	}{
-		{ModeNoGitHub, "NO_GITHUB"},
 		{ModeAdvisory, "ADVISORY"},
 		{ModeIssuesOnly, "ISSUES_ONLY"},
 		{ModeIssuesAndPRs, "ISSUES_AND_PRS"},
@@ -26,7 +25,6 @@ func TestAgentModeEmoji(t *testing.T) {
 		mode AgentMode
 		want string
 	}{
-		{ModeNoGitHub, "\U0001F507"},
 		{ModeAdvisory, "\U0001F4DD"},
 		{ModeIssuesOnly, "\U0001F3AB"},
 		{ModeIssuesAndPRs, "\U0001F527"},
@@ -45,7 +43,6 @@ func TestAgentModeSuffix(t *testing.T) {
 		mode AgentMode
 		want string
 	}{
-		{ModeNoGitHub, "-nogithub"},
 		{ModeAdvisory, "-advisory"},
 		{ModeIssuesOnly, "-issues"},
 		{ModeIssuesAndPRs, "-holdgated"},
@@ -71,7 +68,6 @@ func TestSuffixForLevel(t *testing.T) {
 		{ModeAdvisory, 3, "-advisory"},
 		{ModeIssuesOnly, 4, "-issues"},
 		{ModeIssuesPRsMerge, 6, "-automerge"},
-		{ModeNoGitHub, 1, "-nogithub"},
 	}
 	for _, tt := range tests {
 		if got := tt.mode.SuffixForLevel(tt.level); got != tt.want {
@@ -82,14 +78,13 @@ func TestSuffixForLevel(t *testing.T) {
 
 func TestAgentModeCapabilities(t *testing.T) {
 	tests := []struct {
-		mode         AgentMode
-		canIssues    bool
-		canPRs       bool
-		canMerge     bool
-		canPush      bool
-		needsMCP     bool
+		mode      AgentMode
+		canIssues bool
+		canPRs    bool
+		canMerge  bool
+		canPush   bool
+		needsMCP  bool
 	}{
-		{ModeNoGitHub, false, false, false, false, false},
 		{ModeAdvisory, false, false, false, false, false},
 		{ModeIssuesOnly, true, false, false, false, true},
 		{ModeIssuesAndPRs, true, true, false, true, true},
@@ -120,11 +115,11 @@ func TestParseAgentMode(t *testing.T) {
 		want  AgentMode
 		ok    bool
 	}{
-		{"NO_GITHUB", ModeNoGitHub, true},
 		{"ADVISORY", ModeAdvisory, true},
 		{"ISSUES_ONLY", ModeIssuesOnly, true},
 		{"ISSUES_AND_PRS", ModeIssuesAndPRs, true},
 		{"ISSUES_PRS_MERGE", ModeIssuesPRsMerge, true},
+		{"NO_GITHUB", ModeAdvisory, true}, // legacy alias
 		{"invalid", ModeAdvisory, false},
 		{"", ModeAdvisory, false},
 	}

--- a/v2/pkg/config/packs/level-2.yaml
+++ b/v2/pkg/config/packs/level-2.yaml
@@ -43,7 +43,7 @@ agents:
     backend: copilot
     model: claude-sonnet-4-6
     bead_role: supervisor
-    mode: NO_GITHUB
+    mode: ADVISORY
     kick_template: supervisor-nogithub.md
     include_repos: true
     stale_timeout: 1800

--- a/v2/pkg/config/packs/level-3.yaml
+++ b/v2/pkg/config/packs/level-3.yaml
@@ -53,7 +53,7 @@ agents:
   backend: copilot
   model: claude-sonnet-4-6
   bead_role: supervisor
-  mode: NO_GITHUB
+  mode: ADVISORY
   kick_template: supervisor-nogithub.md
   include_repos: true
   stale_timeout: 1800

--- a/v2/pkg/config/packs/level-4.yaml
+++ b/v2/pkg/config/packs/level-4.yaml
@@ -58,7 +58,7 @@ agents:
   backend: copilot
   model: claude-sonnet-4-6
   bead_role: supervisor
-  mode: NO_GITHUB
+  mode: ADVISORY
   kick_template: supervisor-nogithub.md
   include_repos: true
   stale_timeout: 1800

--- a/v2/pkg/config/packs/level-5.yaml
+++ b/v2/pkg/config/packs/level-5.yaml
@@ -68,7 +68,7 @@ agents:
   backend: copilot
   model: claude-sonnet-4-6
   bead_role: supervisor
-  mode: NO_GITHUB
+  mode: ADVISORY
   kick_template: supervisor-nogithub.md
   include_repos: true
   stale_timeout: 1800

--- a/v2/pkg/config/packs/level-6.yaml
+++ b/v2/pkg/config/packs/level-6.yaml
@@ -68,7 +68,7 @@ agents:
   backend: copilot
   model: claude-sonnet-4-6
   bead_role: supervisor
-  mode: NO_GITHUB
+  mode: ADVISORY
   kick_template: supervisor-nogithub.md
   include_repos: true
   stale_timeout: 600

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -737,7 +737,7 @@ func (s *Server) handleGHUserAuthStatus(w http.ResponseWriter, r *http.Request) 
 func (s *Server) handleGHUserAuthStart(w http.ResponseWriter, r *http.Request) {
 	clientID := s.deps.Config.GitHub.OAuthClientID
 	if clientID == "" {
-		jsonError(w, "oauth_client_id not configured in github section of hive.yaml", http.StatusBadRequest)
+		jsonError(w, "oauth_client_id not configured. Add 'oauth_client_id: Ov23ligE2p0gjXg6xAUf' to the github section of hive.yaml and restart the container. This is the public Hive GitHub App client ID used for the Device Flow login — no secret required.", http.StatusBadRequest)
 		return
 	}
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6534,7 +6534,7 @@ function burnAreaChart() {
     document.getElementById('logs-agent-select')?.addEventListener('change', () => { _logsData = {}; fetchAgentLogs(); });
     setInterval(fetchAgentLogs, LOGS_REFRESH_MS);
 
-    const MODE_EMOJIS = {'NO_GITHUB':'🔇','ADVISORY':'📝','ISSUES_ONLY':'🎫','ISSUES_AND_PRS':'🔧','ISSUES_PRS_MERGE':'🚀'};
+    const MODE_EMOJIS = {'ADVISORY':'📝','ISSUES_ONLY':'🎫','ISSUES_AND_PRS':'🔧','ISSUES_PRS_MERGE':'🚀'};
     function modeEmoji(mode) { return MODE_EMOJIS[mode] || ''; }
     function modeLabel(a) {
       if (!a.mode) return '—';
@@ -7447,9 +7447,9 @@ function burnAreaChart() {
           </div>
         </div>
         <div class="config-field">
-          <label>Operating Mode <span class="config-info">i<span class="config-tooltip">Controls what GitHub actions this agent can take. NO_GITHUB: internal only. ADVISORY: beads only. ISSUES_ONLY: open issues, no PRs. ISSUES_AND_PRS: issues + PRs. ISSUES_PRS_MERGE: full auto-merge. Leave blank to use the ACMM level default.</span></span></label>
+          <label>Operating Mode <span class="config-info">i<span class="config-tooltip">Controls what GitHub actions this agent can take. ADVISORY: beads only. ISSUES_ONLY: open issues, no PRs. ISSUES_AND_PRS: issues + PRs. ISSUES_PRS_MERGE: full auto-merge. Leave blank to use the ACMM level default.</span></span></label>
           ${(() => {
-            const allModes = ['NO_GITHUB','ADVISORY','ISSUES_ONLY','ISSUES_AND_PRS','ISSUES_PRS_MERGE'];
+            const allModes = ['ADVISORY','ISSUES_ONLY','ISSUES_AND_PRS','ISSUES_PRS_MERGE'];
             const statusAgent = ((window._lastStatus || {}).agents || []).find(sa => sa.name === agentName);
             const dflt = statusAgent ? statusAgent.defaultMode : '';
             const current = g.mode || '';

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -506,6 +506,23 @@
     .gh-auth-modal .gh-poll-status { color: #6b7280; font-size: 0.8rem; margin-top: 12px; }
     .gh-auth-modal .gh-cancel { background: none; border: 1px solid #d1d5db; padding: 6px 16px; border-radius: 6px; cursor: pointer; color: #6b7280; margin-top: 12px; }
     .gh-auth-modal .gh-cancel:hover { background: #f3f4f6; }
+    .gh-setup-modal { background: #fff; border-radius: 12px; padding: 32px; max-width: 560px; width: 92%; text-align: left; box-shadow: 0 20px 60px rgba(0,0,0,0.3); max-height: 85vh; overflow-y: auto; }
+    .gh-setup-modal h3 { margin: 0 0 16px; font-size: 1.2rem; color: #1a1a2e; text-align: center; }
+    .gh-setup-modal p { color: #6b7280; font-size: 0.85rem; margin: 8px 0; line-height: 1.5; }
+    .gh-setup-modal .setup-option { background: #f9fafb; border: 2px solid #e5e7eb; border-radius: 8px; padding: 16px; margin: 12px 0; cursor: pointer; transition: border-color 0.15s; }
+    .gh-setup-modal .setup-option:hover { border-color: #238636; }
+    .gh-setup-modal .setup-option h4 { margin: 0 0 6px; font-size: 0.95rem; color: #1a1a2e; }
+    .gh-setup-modal .setup-option p { margin: 0; font-size: 0.8rem; }
+    .gh-setup-modal .setup-steps { background: #f0fdf4; border-radius: 8px; padding: 16px; margin: 12px 0; font-size: 0.82rem; color: #374151; }
+    .gh-setup-modal .setup-steps ol { margin: 8px 0; padding-left: 20px; }
+    .gh-setup-modal .setup-steps li { margin: 6px 0; line-height: 1.5; }
+    .gh-setup-modal .setup-steps code { background: #e5e7eb; padding: 1px 5px; border-radius: 3px; font-size: 0.78rem; }
+    .gh-setup-modal .setup-perms { background: #fffbeb; border-radius: 8px; padding: 12px 16px; margin: 12px 0; }
+    .gh-setup-modal .setup-perms h5 { margin: 0 0 6px; font-size: 0.85rem; color: #92400e; }
+    .gh-setup-modal .setup-perms ul { margin: 4px 0; padding-left: 18px; font-size: 0.78rem; color: #78350f; }
+    .gh-setup-modal .setup-perms li { margin: 3px 0; }
+    .gh-setup-modal .gh-cancel { background: none; border: 1px solid #d1d5db; padding: 6px 16px; border-radius: 6px; cursor: pointer; color: #6b7280; margin-top: 12px; display: block; width: 100%; text-align: center; }
+    .gh-setup-modal .gh-cancel:hover { background: #f3f4f6; }
     .agent-state { text-align: right; font-size: 0.75rem; font-weight: 600; margin-top: 6px; }
     .agent-state.working { color: var(--green); }
     .agent-state.idle { color: var(--muted); }
@@ -1522,6 +1539,70 @@
     <a id="gh-verify-link" class="gh-verify-link" href="https://github.com/login/device" target="_blank" rel="noopener">Open GitHub →</a>
     <div class="gh-poll-status" id="gh-poll-status">Waiting for authorization...</div>
     <button class="gh-cancel" onclick="cancelGHLogin()">Cancel</button>
+  </div>
+</div>
+<div id="gh-setup-overlay" class="gh-auth-overlay" style="display:none">
+  <div class="gh-setup-modal">
+    <h3>GitHub App Setup Required</h3>
+    <p>Hive needs a GitHub App to authenticate. Choose an option:</p>
+    <div class="setup-option" onclick="showSetupDetails('public')">
+      <h4>Use the public Hive App (quickest)</h4>
+      <p>Dashboard login only. Agents can read repos but cannot create issues, PRs, or merge.</p>
+    </div>
+    <div class="setup-option" onclick="showSetupDetails('custom')">
+      <h4>Create your own GitHub App (recommended for full ACMM)</h4>
+      <p>Full agent capabilities: issues, PRs, auto-merge. Required for ACMM levels 3-6.</p>
+    </div>
+    <div id="setup-details-public" style="display:none">
+      <div class="setup-steps">
+        <strong>Quick setup:</strong>
+        <ol>
+          <li>Open <code>hive.yaml</code> on the host (mounted at <code>/etc/hive/hive.yaml</code> inside the container)</li>
+          <li>Add to the <code>github:</code> section:<br><code>oauth_client_id: Ov23ligE2p0gjXg6xAUf</code></li>
+          <li>Restart the container: <code>docker compose restart hive</code></li>
+          <li>Click "Sign in with GitHub" again</li>
+        </ol>
+      </div>
+    </div>
+    <div id="setup-details-custom" style="display:none">
+      <div class="setup-steps">
+        <strong>Create a GitHub App:</strong>
+        <ol>
+          <li>Go to <a href="https://github.com/settings/apps/new" target="_blank" rel="noopener" style="color:#238636">github.com/settings/apps/new</a> (or your org's Settings &rarr; Developer settings &rarr; GitHub Apps)</li>
+          <li>Set the app name (e.g. <code>my-hive</code>)</li>
+          <li>Homepage URL: any URL (e.g. <code>https://github.com/kubestellar/hive</code>)</li>
+          <li>Uncheck "Webhook &rarr; Active" (not needed)</li>
+          <li>Under "Device Flow", check <strong>Enable Device Flow</strong></li>
+          <li>Set the permissions below, then click "Create GitHub App"</li>
+          <li>On the app page, note the <strong>App ID</strong> and <strong>Client ID</strong></li>
+          <li>Generate a private key (.pem file) and save it to <code>./secrets/gh-app-key.pem</code></li>
+          <li>Install the app on your org/repos and note the <strong>Installation ID</strong> (from the URL after install)</li>
+          <li>Update <code>hive.yaml</code>:</li>
+        </ol>
+        <pre style="background:#1a1a2e;color:#e5e7eb;padding:12px;border-radius:6px;font-size:0.75rem;overflow-x:auto">github:
+  app_id: &lt;your-app-id&gt;
+  installation_id: &lt;your-installation-id&gt;
+  key_file: /secrets/gh-app-key.pem
+  oauth_client_id: &lt;your-client-id&gt;</pre>
+        <p style="margin-top:8px">Restart the container after updating.</p>
+      </div>
+      <div class="setup-perms">
+        <h5>Required Permissions (Repository)</h5>
+        <ul>
+          <li><strong>Contents</strong>: Read &amp; write (clone, push branches)</li>
+          <li><strong>Issues</strong>: Read &amp; write (create/close issues)</li>
+          <li><strong>Pull requests</strong>: Read &amp; write (create/merge PRs)</li>
+          <li><strong>Metadata</strong>: Read-only (required by GitHub)</li>
+          <li><strong>Checks</strong>: Read-only (monitor CI status)</li>
+          <li><strong>Actions</strong>: Read-only (monitor workflow runs)</li>
+        </ul>
+        <h5>Required Permissions (Organization)</h5>
+        <ul>
+          <li><strong>Members</strong>: Read-only (identify contributors)</li>
+        </ul>
+      </div>
+    </div>
+    <button class="gh-cancel" onclick="document.getElementById('gh-setup-overlay').style.display='none'">Close</button>
   </div>
 </div>
 <div id="toast-container"></div>
@@ -8682,11 +8763,25 @@ function burnAreaChart() {
       }
     }
 
+    function showSetupDetails(which) {
+      document.getElementById('setup-details-public').style.display = which === 'public' ? 'block' : 'none';
+      document.getElementById('setup-details-custom').style.display = which === 'custom' ? 'block' : 'none';
+    }
+
     async function startGHLogin() {
       try {
         const resp = await fetch('/api/gh-user-auth/start', { method: 'POST' });
         const data = await resp.json();
-        if (data.error) { alert('Failed to start login: ' + data.error); return; }
+        if (data.error) {
+          if (data.error.includes('oauth_client_id')) {
+            document.getElementById('gh-setup-overlay').style.display = 'flex';
+            document.getElementById('setup-details-public').style.display = 'none';
+            document.getElementById('setup-details-custom').style.display = 'none';
+          } else {
+            showToast('Login error: ' + data.error, 'error');
+          }
+          return;
+        }
         document.getElementById('gh-device-code').textContent = data.user_code;
         document.getElementById('gh-verify-link').href = data.verification_uri;
         document.getElementById('gh-poll-status').textContent = 'Waiting for authorization...';
@@ -8743,6 +8838,9 @@ function burnAreaChart() {
     document.addEventListener('keydown', function(e) {
       if (e.key === 'Escape' && document.getElementById('gh-auth-modal-overlay').style.display === 'flex') {
         cancelGHLogin();
+      }
+      if (e.key === 'Escape' && document.getElementById('gh-setup-overlay').style.display === 'flex') {
+        document.getElementById('gh-setup-overlay').style.display = 'none';
       }
     });
 

--- a/v2/pkg/policies/defaults/supervisor-advisory.md
+++ b/v2/pkg/policies/defaults/supervisor-advisory.md
@@ -1,6 +1,6 @@
 # Supervisor Agent Policy — No-GitHub Mode (-nogithub)
 
-You are the **supervisor** agent in a Hive instance operating in **NO_GITHUB** mode.
+You are the **supervisor** agent in a Hive instance operating in **ADVISORY** mode.
 
 ## Rules
 

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -207,10 +207,6 @@ func (p *GitHubProxy) handleTransparentTLS(conn net.Conn, peeked []byte) {
 	}
 
 	mode := readAgentMode(agentName)
-	if mode == agent.ModeNoGitHub {
-		p.recordViolation(agentName, "TRANSPARENT", host)
-		return
-	}
 
 	// MITM: forge a cert, TLS-wrap the client, connect to real upstream.
 	tlsCert, err := p.forgeCert(host)
@@ -392,13 +388,7 @@ func (p *GitHubProxy) handleConnectDirect(conn net.Conn, r *http.Request) {
 		return
 	}
 
-	// NO_GITHUB mode: block the connection entirely.
 	mode := readAgentMode(agentName)
-	if mode == agent.ModeNoGitHub {
-		p.recordViolation(agentName, "CONNECT", r.Host)
-		fmt.Fprintf(conn, "HTTP/1.1 403 Forbidden\r\n\r\nblocked by ACMM proxy: NO_GITHUB mode\n")
-		return
-	}
 
 	// Tell client the tunnel is established.
 	if _, err := fmt.Fprintf(conn, "HTTP/1.1 200 Connection established\r\n\r\n"); err != nil {

--- a/v2/pkg/proxy/rules_test.go
+++ b/v2/pkg/proxy/rules_test.go
@@ -14,12 +14,6 @@ func TestAllowedByMode(t *testing.T) {
 		path   string
 		want   bool
 	}{
-		// ── NO_GITHUB: everything blocked ──
-		{"no-github blocks GET", agent.ModeNoGitHub, "GET", "/repos/org/repo/issues", false},
-		{"no-github blocks POST issues", agent.ModeNoGitHub, "POST", "/repos/org/repo/issues", false},
-		{"no-github blocks POST pulls", agent.ModeNoGitHub, "POST", "/repos/org/repo/pulls", false},
-		{"no-github blocks PUT merge", agent.ModeNoGitHub, "PUT", "/repos/org/repo/pulls/42/merge", false},
-
 		// ── ADVISORY: read-only ──
 		{"advisory allows GET issues", agent.ModeAdvisory, "GET", "/repos/org/repo/issues", true},
 		{"advisory allows GET pulls", agent.ModeAdvisory, "GET", "/repos/org/repo/pulls", true},
@@ -90,8 +84,6 @@ func TestGraphQLAllowed(t *testing.T) {
 		{"advisory blocks mutation", agent.ModeAdvisory, `{"query":"mutation { createIssue(input:{repositoryId:\"R_1\",title:\"test\"}) { issue { id } } }"}`, false, true},
 		{"issues-only allows mutation", agent.ModeIssuesOnly, `{"query":"mutation { createIssue(input:{repositoryId:\"R_1\",title:\"test\"}) { issue { id } } }"}`, true, true},
 		{"issues-and-prs allows mutation", agent.ModeIssuesAndPRs, `{"query":"mutation { createIssue(input:{}) { issue { id } } }"}`, true, true},
-		{"no-github blocks query", agent.ModeNoGitHub, `{"query":"query { viewer { login } }"}`, false, false},
-		{"no-github blocks mutation", agent.ModeNoGitHub, `{"query":"mutation { addStar(input:{}) { starrable { id } } }"}`, false, false},
 		{"advisory blocks malformed json", agent.ModeAdvisory, `not json`, false, false},
 		{"advisory allows empty query", agent.ModeAdvisory, `{"query":"{ viewer { login } }"}`, true, false},
 	}

--- a/v2/policies/supervisor-advisory.md
+++ b/v2/policies/supervisor-advisory.md
@@ -1,6 +1,6 @@
 # Supervisor Agent Policy — No-GitHub Mode (-nogithub)
 
-You are the **supervisor** agent in a Hive instance operating in **NO_GITHUB** mode.
+You are the **supervisor** agent in a Hive instance operating in **ADVISORY** mode.
 
 ## Rules
 


### PR DESCRIPTION
## Summary
- **NO_GITHUB mode breaks Copilot CLI** — Copilot requires GitHub OAuth to function. Assigning NO_GITHUB to supervisor made it non-functional.
- Removed `ModeNoGitHub` from the mode enum entirely. `ModeAdvisory` is now the lowest tier (iota 0).
- `ParseAgentMode("NO_GITHUB")` still works as a legacy alias → returns `ModeAdvisory`, so existing configs won't break.
- Updated all level pack YAMLs (L2-L6): supervisor mode changed from `NO_GITHUB` to `ADVISORY`
- Renamed `supervisor-nogithub.md` → `supervisor-advisory.md`
- Removed NO_GITHUB from dashboard mode selector, emoji map, and tooltip
- Removed NO_GITHUB proxy blocks in `github_proxy.go`
- Improved `oauth_client_id` error message to include the public Hive App client ID and setup instructions

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/agent/... ./pkg/proxy/... ./pkg/config/... ./pkg/dashboard/...` all pass
- [x] `ParseAgentMode("NO_GITHUB")` returns `ModeAdvisory, true` (legacy compat)
- [x] DefaultAgentMode returns ADVISORY for supervisor at all levels
- [ ] Deploy and verify supervisor agent functions correctly (was broken with NO_GITHUB)

## Found during fresh install
This was discovered while setting up a fresh Hive v2 test instance on Flatcar/Proxmox (192.168.4.86) targeting kubestellar/console.