### PR TITLE
feat: audit logging for agent state changes with trigger/reason tracking

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -261,7 +261,18 @@ func main() {
 				continue
 			}
 			if as.Paused {
-				_ = agentMgr.Pause(name)
+				reason := as.PausedReason
+				if reason == "" {
+					reason = "persisted pause state"
+				}
+				trigger := as.PausedTrigger
+				if trigger == "" {
+					trigger = "state-restore"
+				}
+				_ = agentMgr.Pause(name, trigger, reason)
+				if as.PausedAt != nil {
+					agentMgr.SeedPauseState(name, *as.PausedAt, trigger, reason)
+				}
 			}
 			if as.PinnedCLI != "" {
 				_ = agentMgr.PinCLI(name, as.PinnedCLI)
@@ -1073,7 +1084,7 @@ func scanForLoginRequired(
 				)
 
 				// Pause the agent instead of restarting
-				if pauseErr := agentMgr.Pause(name); pauseErr != nil {
+				if pauseErr := agentMgr.Pause(name, "login-detector", "login required detected"); pauseErr != nil {
 					logger.Warn("failed to pause agent after login detection",
 						"agent", name, "error", pauseErr)
 				}
@@ -1175,6 +1186,12 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 			BackendOverride: proc.BackendOverride,
 			RestartCount:    proc.RestartCount,
 			LastKick:        proc.LastKick,
+			PausedReason:    proc.PausedReason,
+			PausedTrigger:   proc.PausedTrigger,
+		}
+		if !proc.PausedAt.IsZero() {
+			t := proc.PausedAt
+			as.PausedAt = &t
 		}
 		if len(proc.KickHistory) > 0 {
 			as.KickHistory = make([]snapshot.AgentKickEntry, len(proc.KickHistory))

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -51,6 +51,9 @@ type AgentProcess struct {
 	StartedAt       *time.Time
 	LastKick        *time.Time
 	Paused          bool
+	PausedAt        time.Time
+	PausedReason    string
+	PausedTrigger   string
 	PinnedCLI       string
 	PinnedModel     string
 	ModelOverride   string
@@ -1856,7 +1859,7 @@ func (m *Manager) agentEnvPairs(agent *AgentProcess) []agentEnvPair {
 	return vars
 }
 
-func (m *Manager) Pause(name string) error {
+func (m *Manager) Pause(name, trigger, reason string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -1866,19 +1869,34 @@ func (m *Manager) Pause(name string) error {
 	}
 
 	agent.Paused = true
+	agent.PausedAt = time.Now()
+	agent.PausedReason = reason
+	agent.PausedTrigger = trigger
 	if agent.State == StateRunning {
 		m.tmuxSendKeysForAgent(agent, "C-c", "")
 	}
 	agent.State = StatePaused
-	m.logger.Info("agent paused",
+	m.logger.Info("audit: agent paused",
 		"name", name,
+		"trigger", trigger,
+		"reason", reason,
 		"backend", agent.Config.Backend,
 		"restart_count", agent.RestartCount,
 	)
 	return nil
 }
 
-func (m *Manager) Resume(ctx context.Context, name string) error {
+func (m *Manager) SeedPauseState(name string, pausedAt time.Time, trigger, reason string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if agent, ok := m.agents[name]; ok {
+		agent.PausedAt = pausedAt
+		agent.PausedTrigger = trigger
+		agent.PausedReason = reason
+	}
+}
+
+func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -1887,7 +1905,19 @@ func (m *Manager) Resume(ctx context.Context, name string) error {
 		return fmt.Errorf("agent %s not found", name)
 	}
 
+	prevTrigger := agent.PausedTrigger
+	prevReason := agent.PausedReason
 	agent.Paused = false
+	agent.PausedAt = time.Time{}
+	agent.PausedReason = ""
+	agent.PausedTrigger = ""
+	m.logger.Info("audit: agent resumed",
+		"name", name,
+		"trigger", trigger,
+		"reason", reason,
+		"prev_trigger", prevTrigger,
+		"prev_reason", prevReason,
+	)
 	if agent.State == StatePaused {
 		agent.forceRelaunch = true
 		if err := m.ensureTmuxSession(agent); err != nil {

--- a/v2/pkg/agent/manager_coverage_test.go
+++ b/v2/pkg/agent/manager_coverage_test.go
@@ -315,7 +315,7 @@ func TestResume_NotPaused(t *testing.T) {
 	}, discardLogger(), ProjectContext{})
 
 	// Agent is in Stopped state (not paused), Resume should be no-op
-	err := m.Resume(nil, "scanner")
+	err := m.Resume(nil, "scanner", "test", "test resume")
 	if err != nil {
 		t.Fatalf("Resume: %v", err)
 	}
@@ -323,7 +323,7 @@ func TestResume_NotPaused(t *testing.T) {
 
 func TestResume_NotFound(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
-	err := m.Resume(nil, "nonexistent")
+	err := m.Resume(nil, "nonexistent", "test", "test resume")
 	if err == nil {
 		t.Error("expected error")
 	}
@@ -494,7 +494,7 @@ func TestSendKick_NotRunning(t *testing.T) {
 
 func TestPause_NotFound(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
-	err := m.Pause("nonexistent")
+	err := m.Pause("nonexistent", "test", "test pause")
 	if err == nil {
 		t.Error("expected error")
 	}
@@ -509,7 +509,7 @@ func TestPause_AlreadyPaused(t *testing.T) {
 	m.agents["scanner"].Paused = true
 	m.mu.Unlock()
 
-	err := m.Pause("scanner")
+	err := m.Pause("scanner", "test", "test pause")
 	if err != nil {
 		t.Fatalf("Pause should succeed even if already paused: %v", err)
 	}

--- a/v2/pkg/agent/manager_extra_test.go
+++ b/v2/pkg/agent/manager_extra_test.go
@@ -166,7 +166,7 @@ func TestIsPaused(t *testing.T) {
 		t.Error("scanner should not be paused initially")
 	}
 
-	m.Pause("scanner")
+	m.Pause("scanner", "test", "test pause")
 	if !m.IsPaused("scanner") {
 		t.Error("scanner should be paused")
 	}

--- a/v2/pkg/agent/manager_test.go
+++ b/v2/pkg/agent/manager_test.go
@@ -434,7 +434,7 @@ func TestCopilotToken_NotInEnvPrefix(t *testing.T) {
 
 func TestPause_UnknownAgentReturnsError(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
-	err := m.Pause("ghost")
+	err := m.Pause("ghost", "test", "test pause")
 	if err == nil {
 		t.Fatal("expected error pausing unknown agent, got nil")
 	}
@@ -446,7 +446,7 @@ func TestPause_SetsPausedFlag(t *testing.T) {
 	}
 	m := NewManager(cfgs, discardLogger(), ProjectContext{})
 
-	if err := m.Pause("worker"); err != nil {
+	if err := m.Pause("worker", "test", "test pause"); err != nil {
 		t.Fatalf("Pause() error: %v", err)
 	}
 
@@ -463,8 +463,8 @@ func TestResume_ClearsPausedFlag(t *testing.T) {
 	}
 	m := NewManager(cfgs, discardLogger(), ProjectContext{})
 
-	_ = m.Pause("worker")
-	if err := m.Resume(context.Background(), "worker"); err != nil {
+	_ = m.Pause("worker", "test", "test pause")
+	if err := m.Resume(context.Background(), "worker", "test", "test resume"); err != nil {
 		t.Fatalf("Resume() error: %v", err)
 	}
 

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -499,6 +499,7 @@ func (s *Server) handleKick(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.deps.Governor.RecordKick(name)
+	s.deps.Logger.Info("audit: agent kicked", "agent", name, "trigger", "dashboard-api")
 	s.refreshAfterMutation()
 	okResponse(w, map[string]string{"status": "kicked", "agent": name})
 }
@@ -512,6 +513,7 @@ func (s *Server) handleSwitch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.deps.Logger.Info("audit: backend switched", "agent", name, "backend", backend, "trigger", "dashboard-api")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "switched", "agent": name, "backend": backend})
 }
@@ -525,6 +527,7 @@ func (s *Server) handleModelSet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.deps.Logger.Info("audit: model set", "agent", name, "model", model, "trigger", "dashboard-api")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "model_set", "agent": name, "model": model})
 }
@@ -532,7 +535,7 @@ func (s *Server) handleModelSet(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handlePause(w http.ResponseWriter, r *http.Request) {
 	name := s.resolveAgentParam(r.PathValue("agent"))
 
-	if err := s.deps.AgentMgr.Pause(name); err != nil {
+	if err := s.deps.AgentMgr.Pause(name, "dashboard-api", "manual pause"); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -544,7 +547,7 @@ func (s *Server) handlePause(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleResume(w http.ResponseWriter, r *http.Request) {
 	name := s.resolveAgentParam(r.PathValue("agent"))
 
-	if err := s.deps.AgentMgr.Resume(s.deps.Ctx, name); err != nil {
+	if err := s.deps.AgentMgr.Resume(s.deps.Ctx, name, "dashboard-api", "manual resume"); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -598,6 +601,7 @@ func (s *Server) handlePin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.deps.Logger.Info("audit: agent pinned", "agent", name, "dimension", dimension, "value", body.Value, "trigger", "dashboard-api")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "pinned", "agent": name, "dimension": dimension, "value": body.Value})
 }
@@ -622,6 +626,7 @@ func (s *Server) handleUnpin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.deps.Logger.Info("audit: agent unpinned", "agent", name, "dimension", dimension, "trigger", "dashboard-api")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "unpinned", "agent": name, "dimension": dimension})
 }
@@ -634,6 +639,7 @@ func (s *Server) handleRestart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.deps.Logger.Info("audit: agent restarted", "agent", name, "trigger", "dashboard-api")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "restarted", "agent": name})
 }
@@ -646,6 +652,7 @@ func (s *Server) handleResetRestarts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.deps.Logger.Info("audit: restart count reset", "agent", name, "trigger", "dashboard-api")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "reset", "agent": name})
 }

--- a/v2/pkg/dashboard/api_coverage_test.go
+++ b/v2/pkg/dashboard/api_coverage_test.go
@@ -3703,7 +3703,7 @@ func TestHandleGovernorHealth_PartialUpdate(t *testing.T) {
 func TestHandleWidget_PausedAgent(t *testing.T) {
 	s, deps := apiServer(t)
 	// Pause the scanner agent so it has State="paused"
-	_ = deps.AgentMgr.Pause("scanner")
+	_ = deps.AgentMgr.Pause("scanner", "test", "test pause")
 	deps.Governor.Evaluate(5, 1, 0, 0)
 	rec := doGet(s, "/api/widget")
 	if rec.Code != http.StatusOK {

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -274,13 +274,13 @@ func (s *Server) syncAgentVisibility(level int) (paused, resumed []string) {
 	for name := range s.deps.Config.Agents {
 		if packAgents[name] {
 			if s.deps.AgentMgr.IsPaused(name) {
-				if err := s.deps.AgentMgr.Resume(s.deps.Ctx, name); err == nil {
+				if err := s.deps.AgentMgr.Resume(s.deps.Ctx, name, "acmm-pack", fmt.Sprintf("agent included in pack level %d", level)); err == nil {
 					resumed = append(resumed, name)
 				}
 			}
 		} else {
 			if !s.deps.AgentMgr.IsPaused(name) {
-				if err := s.deps.AgentMgr.Pause(name); err == nil {
+				if err := s.deps.AgentMgr.Pause(name, "acmm-pack", fmt.Sprintf("agent not in pack level %d", level)); err == nil {
 					paused = append(paused, name)
 				}
 			}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -87,6 +87,9 @@ type FrontendAgent struct {
 	State            string `json:"state"`
 	Busy             string `json:"busy"`
 	Paused           bool   `json:"paused"`
+	PausedAt         string `json:"pausedAt,omitempty"`
+	PausedReason     string `json:"pausedReason,omitempty"`
+	PausedTrigger    string `json:"pausedTrigger,omitempty"`
 	OffByCadence     bool   `json:"offByCadence"`
 	NeedsLogin       bool   `json:"needsLogin"`
 	CLI              string `json:"cli"`

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -187,6 +187,9 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 			State:         string(proc.State),
 			Busy:          busy,
 			Paused:        proc.Paused,
+			PausedAt:      formatOptionalTime(proc.PausedAt),
+			PausedReason:  proc.PausedReason,
+			PausedTrigger: proc.PausedTrigger,
 			CLI:           cli,
 			Model:         model,
 			Cadence:       cadence,
@@ -926,4 +929,11 @@ func buildACMMPackAgents(cfg *config.Config) []string {
 		}
 	}
 	return names
+}
+
+func formatOptionalTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format(time.RFC3339)
 }

--- a/v2/pkg/snapshot/state.go
+++ b/v2/pkg/snapshot/state.go
@@ -54,6 +54,9 @@ type ConfigOverrides struct {
 
 type AgentState struct {
 	Paused          bool             `json:"paused"`
+	PausedAt        *time.Time       `json:"paused_at,omitempty"`
+	PausedReason    string           `json:"paused_reason,omitempty"`
+	PausedTrigger   string           `json:"paused_trigger,omitempty"`
 	PinnedCLI       string           `json:"pinned_cli,omitempty"`
 	PinnedModel     string           `json:"pinned_model,omitempty"`
 	ModelOverride   string           `json:"model_override,omitempty"`


### PR DESCRIPTION
## Summary
- Adds `trigger` and `reason` parameters to `Pause()` and `Resume()` so every agent state change records who initiated it and why
- All 4 callers of Pause updated: state-restore, login-detector, acmm-pack, dashboard-api
- Dashboard API mutation handlers emit structured audit entries via existing slog + lumberjack logger
- Pause metadata (`PausedAt`, `PausedReason`, `PausedTrigger`) exposed in status JSON and persisted in snapshot state

## Motivation
When agents were found paused on the bluefin hive instance, there was no record of who paused them, when, or why. The existing `Pause()` method logged only the agent name and backend — no trigger source or reason.

## Test plan
- [ ] Verify `hive.log` contains audit entries with trigger/reason when pausing via dashboard
- [ ] Verify pause metadata appears in `/api/status` JSON response
- [ ] Verify pause state (with reason/trigger) survives container restart
- [ ] Verify ACMM pack level change logs correct trigger ("acmm-pack")
- [ ] Verify login detection logs correct trigger ("login-detector")

Fixes #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)