### PR TITLE
fix: sync mode files after agent resume, not before

### DIFF
--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -169,6 +169,7 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 	}
 
 	paused, resumed := s.syncAgentVisibility(level)
+	s.deps.AgentMgr.SyncModeFiles(level)
 
 	s.persistOnly()
 	go s.refreshAsync()
@@ -232,8 +233,8 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 		s.logger.Error("failed to save ACMM level to hive.yaml", "error", err)
 	}
 
-	s.deps.AgentMgr.SyncModeFiles(level)
 	paused, resumed := s.syncAgentVisibility(level)
+	s.deps.AgentMgr.SyncModeFiles(level)
 
 	s.persistOnly()
 	s.refreshAsync()


### PR DESCRIPTION
## Summary
`SyncModeFiles` was called before `syncAgentVisibility` in the level-change handler. This meant resumed agents kept their stale mode files from the previous ACMM level.

Example: switching from L1 (guide only) to L6 (all 9 agents) — architect, outreach, sec-check, strategist would resume but keep `ADVISORY` mode files instead of getting `ISSUES_AND_PRS`.

## Fix
- Move `SyncModeFiles(level)` after `syncAgentVisibility(level)` so mode files are written after agents are resumed
- Add `SyncModeFiles(level)` to the full pack apply handler (`handleApplyPack`) which was missing it entirely

## Found by
Automated ACMM test harness running 5000 random level switches on a fresh Flatcar VM (192.168.4.86).

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/dashboard/...` passes
- [ ] L1→L6 transition: all 9 agents get correct modes after deploy