### PR TITLE
fix: default dashboard port to 3002

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -400,7 +400,7 @@ func main() {
 	}
 
 	// Go binary serves the internal API without auth — the Node.js proxy
-	// on port 3001 handles public-facing authentication.
+	// on port 3002 handles public-facing authentication.
 	dashSrv := dashboard.NewServer(cfg.Dashboard.Port, logger)
 
 	// Seed token sparkline history now that the dashboard server exists

--- a/v2/deploy/architect-only.yaml
+++ b/v2/deploy/architect-only.yaml
@@ -53,7 +53,7 @@ notifications:
     topic: hive-architect
 
 dashboard:
-  port: 3001
+  port: 3002
   snapshot_dir: /data/snapshots
   auth_token: ${HIVE_DASHBOARD_TOKEN}
 

--- a/v2/deploy/docker-compose.architect.yaml
+++ b/v2/deploy/docker-compose.architect.yaml
@@ -6,7 +6,7 @@ services:
     container_name: hive-architect
     restart: unless-stopped
     ports:
-      - "3001:3001"
+      - "3002:3002"
     volumes:
       - ./architect-only.yaml:/etc/hive/hive.yaml
       - hive-data:/data
@@ -17,7 +17,7 @@ services:
       - HIVE_LEVEL=${HIVE_LEVEL:-}
       - HIVE_REPO=${HIVE_REPO:-}
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3001/api/health"]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3002/api/health"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/v2/deploy/hive.yaml
+++ b/v2/deploy/hive.yaml
@@ -216,7 +216,7 @@ knowledge:
       git_sync: true
 
 dashboard:
-  port: 3001
+  port: 3002
   snapshot_dir: /data/snapshots
   auth_token: ${HIVE_DASHBOARD_TOKEN}
 

--- a/v2/deploy/k8s/deployment.yaml
+++ b/v2/deploy/k8s/deployment.yaml
@@ -27,7 +27,7 @@ spec:
             - "/etc/hive/hive.yaml"
           ports:
             - name: dashboard
-              containerPort: 3001
+              containerPort: 3002
               protocol: TCP
             - name: api
               containerPort: 3002

--- a/v2/deploy/k8s/service.yaml
+++ b/v2/deploy/k8s/service.yaml
@@ -11,7 +11,7 @@ spec:
     app.kubernetes.io/name: hive
   ports:
     - name: dashboard
-      port: 3001
+      port: 3002
       targetPort: dashboard
       protocol: TCP
     - name: api

--- a/v2/deploy/nginx.conf
+++ b/v2/deploy/nginx.conf
@@ -6,7 +6,7 @@ events {
 
 http {
     upstream hive_api {
-        server hive:3001;
+        server hive:3002;
     }
 
     map $http_upgrade $connection_upgrade {

--- a/v2/docker-compose.yaml
+++ b/v2/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
     cap_add:
       - NET_ADMIN
     expose:
-      - "3001"
+      - "3002"
       - "7681"
     volumes:
       - ./hive.yaml:/etc/hive/hive.yaml
@@ -44,7 +44,7 @@ services:
       - HIVE_LEVEL=${HIVE_LEVEL:-}
       - HIVE_REPO=${HIVE_REPO:-}
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:3001/api/health"]
+      test: ["CMD", "curl", "-sf", "http://localhost:3002/api/health"]
       interval: 10s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary

- Updated all deploy configs and manifests to use port 3002 for the Go dashboard binary, resolving the conflict with the Node.js proxy on port 3001
- Changed: `deploy/hive.yaml`, `deploy/architect-only.yaml`, `deploy/docker-compose.architect.yaml`, `deploy/k8s/deployment.yaml`, `deploy/k8s/service.yaml`, `deploy/nginx.conf` (upstream), `docker-compose.yaml` (hive service expose/healthcheck), `cmd/hive/main.go` (comment)
- The nginx gateway continues to listen on port 3001 as the public-facing proxy, forwarding to the Go binary on 3002

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/config/... ./pkg/dashboard/...` passes
- [ ] Verify docker-compose stack starts with no port conflict