### PR TITLE
feat: add optional Watchtower service for auto-updates

### DIFF
--- a/v2/docker-compose.yaml
+++ b/v2/docker-compose.yaml
@@ -43,12 +43,27 @@ services:
       - NTFY_TOPIC=${NTFY_TOPIC}
       - HIVE_LEVEL=${HIVE_LEVEL:-}
       - HIVE_REPO=${HIVE_REPO:-}
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:3002/api/health"]
       interval: 10s
       timeout: 5s
       retries: 3
       start_period: 120s
+
+  watchtower:
+    image: containrrr/watchtower
+    container_name: hive-watchtower
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - WATCHTOWER_CLEANUP=true
+      - WATCHTOWER_POLL_INTERVAL=60
+      - WATCHTOWER_LABEL_ENABLE=true
+    profiles:
+      - auto-update
 
 volumes:
   hive-data:


### PR DESCRIPTION
## Summary
- Adds Watchtower as an optional service in `v2/docker-compose.yaml` for automatic container image updates from GHCR
- Uses `profiles: [auto-update]` so it only runs when explicitly opted in: `docker compose --profile auto-update up -d`
- Adds `com.centurylinklabs.watchtower.enable=true` label to the hive service so Watchtower only watches that container
- Polls every 60s and cleans up old images automatically