### PR TITLE
fix: ensure GitHub App key is readable by dev user in entrypoint

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -13,6 +13,11 @@ if [ "$(id -u)" = "0" ]; then
   chown dev:node /etc/hive/hive.yaml 2>/dev/null || true
   mkdir -p /var/run/hive-metrics && chown dev:node /var/run/hive-metrics 2>/dev/null || true
 
+  # Fix permissions on bind-mounted secret files (host may own them as
+  # a different UID with mode 600, making them unreadable by dev/UID 1001)
+  chown dev:node /secrets/*.pem 2>/dev/null || true
+  chmod 644 /secrets/*.pem 2>/dev/null || true
+
   # Copy read-only mounted secrets so dev user can read them
   if [ -f /etc/hive/gh-app-key.pem ]; then
     cp /etc/hive/gh-app-key.pem /var/run/hive-metrics/gh-app-key.pem


### PR DESCRIPTION
## Summary
- Adds `chown dev:node` and `chmod 644` for `/secrets/*.pem` files in the root phase of `entrypoint.sh`
- Fixes the case where the host file at `/secrets/gh-app-key.pem` is `chmod 600` owned by a different UID, making it unreadable by the container's dev user (UID 1001)

## Test plan
- [ ] Deploy with a bind-mounted `/secrets/gh-app-key.pem` owned by root:root mode 600 on the host
- [ ] Verify the container's dev user can read the key file after entrypoint runs