### PR TITLE
fix: prevent config.Save from overwriting hive.yaml with empty config

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -6,6 +6,18 @@ export HIVE_API_PORT="${HIVE_API_PORT:-3002}"
 export HIVE_PROXY_PORT="${HIVE_PROXY_PORT:-3001}"
 export HIVE_STATIC_DIR="${HIVE_STATIC_DIR:-/opt/hive/proxy/public}"
 
+# ── Config file sanity check ──────────────────────────────────────────
+# After `docker compose down -v`, the bind-mounted hive.yaml may exist
+# but be empty (0 bytes). Detect this early and exit with a clear message
+# instead of letting the Go binary crash-loop with "project.org is required".
+HIVE_CONFIG_PATH="${HIVE_CONFIG:-/etc/hive/hive.yaml}"
+if [ -f "$HIVE_CONFIG_PATH" ] && [ ! -s "$HIVE_CONFIG_PATH" ]; then
+  echo "[entrypoint] ERROR: $HIVE_CONFIG_PATH exists but is empty (0 bytes)."
+  echo "[entrypoint] This usually happens after 'docker compose down -v' wipes the data volume."
+  echo "[entrypoint] Restore your hive.yaml from backup or version control and restart."
+  exit 1
+fi
+
 # ── Root-only setup (runs once, then re-execs as dev) ──────────────────
 if [ "$(id -u)" = "0" ]; then
   # Fix ownership of mounted volumes (may be root-owned from host bind mounts)

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bufio"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -841,13 +842,37 @@ func (c *Config) AgentByID(id string) (AgentConfig, bool) {
 	return AgentConfig{}, false
 }
 
+// validateSaveGuard checks that essential fields are present before allowing
+// a config write. This prevents docker compose down -v (or similar) from
+// causing Save() to overwrite hive.yaml with an empty/minimal config that
+// would crash-loop on next startup.
+func (c *Config) validateSaveGuard() error {
+	if c.Project.Org == "" {
+		log.Printf("WARNING: config.Save() blocked — project.org is empty, would corrupt hive.yaml")
+		return fmt.Errorf("project.org is empty")
+	}
+	if len(c.Agents) == 0 {
+		log.Printf("WARNING: config.Save() blocked — no agents configured, would corrupt hive.yaml")
+		return fmt.Errorf("no agents configured")
+	}
+	return nil
+}
+
 // Save marshals the current config back to its source YAML file atomically.
 // It writes to a temporary file in the same directory, then renames over the
 // original. This prevents partial writes if the process crashes mid-save and
 // ensures watchers see a complete file.
+//
+// As a safety measure, Save refuses to write if essential fields are missing
+// (project.org, at least one agent). This prevents an empty or minimal config
+// from overwriting the bind-mounted hive.yaml — a scenario that causes
+// crash-loops on the next startup ("project.org is required").
 func (c *Config) Save() error {
 	if c.SourcePath == "" {
 		return fmt.Errorf("config has no source path")
+	}
+	if err := c.validateSaveGuard(); err != nil {
+		return fmt.Errorf("refusing to save invalid config: %w", err)
 	}
 	data, err := yaml.Marshal(c)
 	if err != nil {

--- a/v2/pkg/config/config_test.go
+++ b/v2/pkg/config/config_test.go
@@ -966,3 +966,70 @@ github:
 		t.Errorf("SourcePath = %q, want %q", cfg2.SourcePath, path)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Save — guard against empty/invalid config
+// ---------------------------------------------------------------------------
+
+func TestSave_BlocksEmptyOrg(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hive.yaml")
+	os.WriteFile(path, []byte("placeholder"), 0o600)
+
+	cfg := &Config{
+		SourcePath: path,
+		Project:    ProjectConfig{Org: ""}, // missing org
+		Agents:     map[string]AgentConfig{"w": {Backend: "claude"}},
+	}
+	err := cfg.Save()
+	if err == nil {
+		t.Fatal("Save() should have returned an error for empty project.org")
+	}
+
+	// Verify the file was NOT overwritten.
+	data, _ := os.ReadFile(path)
+	if string(data) != "placeholder" {
+		t.Errorf("Save() overwrote file despite empty org; got %q", string(data))
+	}
+}
+
+func TestSave_BlocksNoAgents(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hive.yaml")
+	os.WriteFile(path, []byte("placeholder"), 0o600)
+
+	cfg := &Config{
+		SourcePath: path,
+		Project:    ProjectConfig{Org: "my-org", Repos: []string{"r"}},
+		Agents:     map[string]AgentConfig{}, // no agents
+	}
+	err := cfg.Save()
+	if err == nil {
+		t.Fatal("Save() should have returned an error for empty agents")
+	}
+
+	data, _ := os.ReadFile(path)
+	if string(data) != "placeholder" {
+		t.Errorf("Save() overwrote file despite no agents; got %q", string(data))
+	}
+}
+
+func TestSave_AllowsValidConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hive.yaml")
+	os.WriteFile(path, []byte("old"), 0o600)
+
+	cfg := &Config{
+		SourcePath: path,
+		Project:    ProjectConfig{Org: "my-org", Repos: []string{"r"}},
+		Agents:     map[string]AgentConfig{"w": {Backend: "claude"}},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save() should succeed for valid config: %v", err)
+	}
+
+	data, _ := os.ReadFile(path)
+	if string(data) == "old" {
+		t.Error("Save() did not write the new config")
+	}
+}


### PR DESCRIPTION
## Summary

- **config.Save() guard**: Added `validateSaveGuard()` that checks essential fields (`project.org`, at least one agent) before writing. If the config is empty/invalid, Save() logs a warning and returns an error without touching the file. This prevents `docker compose down -v` from causing the bind-mounted hive.yaml to be overwritten with an empty config.
- **entrypoint.sh check**: Added an early check — if `/etc/hive/hive.yaml` exists but is 0 bytes, the entrypoint exits immediately with a clear error message telling the user to restore their config.
- **Tests**: Added `TestSave_BlocksEmptyOrg`, `TestSave_BlocksNoAgents`, and `TestSave_AllowsValidConfig`.

## Problem

When `docker compose down -v` wipes the data volume, the Go binary's `config.Save()` could write an empty/minimal config to the bind-mounted `hive.yaml`, causing crash-loops on next startup ("project.org is required").

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/config/...` passes (all existing + 3 new tests)