### PR TITLE
feat: auto-merge ACMM pack updates on startup

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -667,18 +667,21 @@ func main() {
 		level, err := strconv.Atoi(levelStr)
 		if err != nil || level < 1 || level > maxACMMLevel {
 			logger.Warn("invalid HIVE_LEVEL, skipping auto-apply", "value", levelStr)
-		} else if saved.ACMMLevel != nil && *saved.ACMMLevel == level {
-			logger.Info("ACMM level unchanged from saved state, skipping auto-apply", "level", level)
 		} else {
-			logger.Info("ACMM level changed, re-applying pack", "level", level, "saved_level", saved.ACMMLevel)
+			action := "merging pack updates"
+			if saved.ACMMLevel == nil || *saved.ACMMLevel != level {
+				action = "re-applying pack (level changed)"
+			}
+			logger.Info("audit: "+action, "level", level, "saved_level", saved.ACMMLevel, "trigger", "startup")
 			result, err := dashSrv.ApplyPack(level)
 			if err != nil {
-				logger.Error("failed to re-apply ACMM pack", "level", level, "error", err)
+				logger.Error("failed to apply ACMM pack", "level", level, "error", err)
 			} else {
-				logger.Info("ACMM pack re-applied",
+				logger.Info("ACMM pack applied on startup",
 					"level", level,
 					"name", result.Name,
 					"created", result.Created,
+					"updated", result.Updated,
 					"skipped", result.Skipped,
 					"paused", result.Paused,
 					"resumed", result.Resumed,


### PR DESCRIPTION
## Summary
- Runs `ApplyPack` on every startup, not just when the ACMM level changes
- This ensures new agents added to a pack definition (e.g. brainstorm in level 3) get auto-created after image updates
- Existing agent configs are preserved — `ApplyPack` already skips agents that exist, only creating missing ones
- Mode and kickTemplate are merged from the pack if changed

## Problem
When watchtower pulls a new hive image that adds an agent to a pack (e.g. brainstorm added to level 3), the agent was never created because the startup code skipped `ApplyPack` when the level was unchanged. Users had to manually re-apply the pack from the dashboard.

## Test plan
- [ ] Container restart with same ACMM level creates any missing pack agents
- [ ] Existing agent configs (cadences, models, pins) are NOT overwritten
- [ ] New agents start and join the eval loop
- [ ] Audit log shows "merging pack updates" on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)