### PR TITLE
fix: revert brainstorm emoji to lightbulb

### DIFF
--- a/v2/pkg/config/packs/level-1.yaml
+++ b/v2/pkg/config/packs/level-1.yaml
@@ -47,7 +47,7 @@ agents:
       acceptance criteria. Queries community KB for scaffolding patterns and
       produces project bootstrap files. At higher levels, proposes features,
       architecture directions, and strategic improvements.
-    emoji: "🧠"
+    emoji: "💡"
     color: "#f39c12"
     sort_order: 5
     backend: copilot

--- a/v2/pkg/config/packs/level-2.yaml
+++ b/v2/pkg/config/packs/level-2.yaml
@@ -121,7 +121,7 @@ agents:
       Ongoing ideation agent. Proposes features, architecture improvements,
       and strategic directions based on project patterns and community KB.
       Produces KB facts and advisory beads.
-    emoji: "🧠"
+    emoji: "💡"
     color: "#f39c12"
     sort_order: 30
     backend: copilot

--- a/v2/pkg/config/packs/level-3.yaml
+++ b/v2/pkg/config/packs/level-3.yaml
@@ -176,7 +176,7 @@ agents:
     KB facts and advisory beads.
 
     '
-  emoji: 🧠
+  emoji: 💡
   color: '#f39c12'
   sort_order: 30
   backend: copilot

--- a/v2/pkg/config/packs/level-4.yaml
+++ b/v2/pkg/config/packs/level-4.yaml
@@ -215,7 +215,7 @@ agents:
     KB facts and advisory beads.
 
     '
-  emoji: 🧠
+  emoji: 💡
   color: '#f39c12'
   sort_order: 30
   backend: copilot

--- a/v2/pkg/config/packs/level-5.yaml
+++ b/v2/pkg/config/packs/level-5.yaml
@@ -274,7 +274,7 @@ agents:
     KB facts and advisory beads.
 
     '
-  emoji: 🧠
+  emoji: 💡
   color: '#f39c12'
   sort_order: 30
   backend: copilot

--- a/v2/pkg/config/packs/level-6.yaml
+++ b/v2/pkg/config/packs/level-6.yaml
@@ -300,7 +300,7 @@ agents:
     KB facts and advisory beads.
 
     '
-  emoji: 🧠
+  emoji: 💡
   color: '#f39c12'
   sort_order: 30
   backend: copilot

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1691,7 +1691,7 @@
       <div class="oc-nav-label">Resources</div>
       <a class="oc-nav-item" data-section="repos-section" onclick="ocNavigate('repos-section')"><span class="oc-nav-emoji">📦</span><span class="oc-nav-text">Repos</span></a>
       <a class="oc-nav-item" data-section="beads-section" onclick="ocNavigate('beads-section')"><span class="oc-nav-emoji">🔮</span><span class="oc-nav-text">Beads</span></a>
-      <a class="oc-nav-item" data-section="inception-section" onclick="ocNavigate('inception-section')"><span class="oc-nav-emoji">🧠</span><span class="oc-nav-text">Inception</span></a>
+      <a class="oc-nav-item" data-section="inception-section" onclick="ocNavigate('inception-section')"><span class="oc-nav-emoji">💡</span><span class="oc-nav-text">Inception</span></a>
       <a class="oc-nav-item" data-section="knowledge-section" onclick="ocNavigate('knowledge-section')"><span class="oc-nav-emoji">📚</span><span class="oc-nav-text">Knowledge</span></a>
       <a class="oc-nav-item" data-section="nous-section" onclick="ocNavigate('nous-section')"><span class="oc-nav-emoji">🧪</span><span class="oc-nav-text">Strategy Lab</span></a>
     </div>
@@ -1765,7 +1765,7 @@
   </div>
 
   <div id="inception-section" style="margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 8px;">🧠 Project Inception</h2>
+    <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 8px;">💡 Project Inception</h2>
     <div id="inception-panel"></div>
   </div>
 
@@ -5984,7 +5984,7 @@ function burnAreaChart() {
 
     function renderInceptionProgress(phase) {
       var STAGES = [
-        { id: 'idea', label: 'Idea', icon: '🧠' },
+        { id: 'idea', label: 'Idea', icon: '💡' },
         { id: 'clarify', label: 'Clarify', icon: '🔍' },
         { id: 'structure', label: 'Structure', icon: '📐' },
         { id: 'scaffold', label: 'Scaffold', icon: '🏗️' },


### PR DESCRIPTION
## Summary
- Reverts brainstorm agent emoji from 🧠 (brain) back to 💡 (lightbulb) across all 6 level packs and the dashboard
- PR #787 incorrectly changed brainstorm to use the brain emoji, which belongs to strategist
- Strategist retains 🧠 in levels 5-6 as intended
- Dashboard inception nav, section header, and idea stage icon restored to 💡

## Files changed
- `v2/pkg/config/packs/level-{1..6}.yaml` — brainstorm emoji field
- `v2/pkg/dashboard/static/index.html` — inception nav, header, idea stage icon