### PR TITLE
fix: auto-merge ACMM pack from config/saved state, not just env var

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -668,12 +668,22 @@ func main() {
 				}
 			}
 		}
-	} else if levelStr := os.Getenv("HIVE_LEVEL"); levelStr != "" {
+	} else {
+		// Determine the ACMM level from env var, config, or saved state
 		const maxACMMLevel = 6
-		level, err := strconv.Atoi(levelStr)
-		if err != nil || level < 1 || level > maxACMMLevel {
-			logger.Warn("invalid HIVE_LEVEL, skipping auto-apply", "value", levelStr)
-		} else {
+		level := 0
+		if levelStr := os.Getenv("HIVE_LEVEL"); levelStr != "" {
+			if parsed, err := strconv.Atoi(levelStr); err == nil && parsed >= 1 && parsed <= maxACMMLevel {
+				level = parsed
+			} else {
+				logger.Warn("invalid HIVE_LEVEL, skipping auto-apply", "value", levelStr)
+			}
+		} else if cfg.ACMMLevel != nil && *cfg.ACMMLevel >= 1 && *cfg.ACMMLevel <= maxACMMLevel {
+			level = *cfg.ACMMLevel
+		} else if saved.ACMMLevel != nil && *saved.ACMMLevel >= 1 && *saved.ACMMLevel <= maxACMMLevel {
+			level = *saved.ACMMLevel
+		}
+		if level > 0 {
 			action := "merging pack updates"
 			if saved.ACMMLevel == nil || *saved.ACMMLevel != level {
 				action = "re-applying pack (level changed)"


### PR DESCRIPTION
## Summary
- Fixes #792 which only triggered pack auto-merge when `HIVE_LEVEL` env var was set
- Now checks three sources for the ACMM level: `HIVE_LEVEL` env, `cfg.ACMMLevel` (hive.yaml), `saved.ACMMLevel` (state file)
- This is why brainstorm wasn't being created on the bluefin and knuckle hives — they store their level in config/state, not the env var

## Test plan
- [ ] Container restart creates brainstorm agent on hive-optimistic-bluefin (level 3)
- [ ] Container restart creates brainstorm agent on hive-zero-doe (level 2)
- [ ] Existing agent configs are NOT overwritten
- [ ] Audit log shows "merging pack updates" on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)