### PR TITLE
feat: contribute-hive — community agent contribution system

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -9,7 +9,9 @@ on:
       - 'dashboard/**'
       - 'discord/**'
       - 'v2/Dockerfile'
+      - 'v2/Dockerfile.contributor'
       - 'v2/compose.yaml'
+      - 'v2/compose-contributor.yaml'
       - '.github/workflows/container-build.yml'
   pull_request:
     paths:
@@ -18,7 +20,9 @@ on:
       - 'dashboard/**'
       - 'discord/**'
       - 'v2/Dockerfile'
+      - 'v2/Dockerfile.contributor'
       - 'v2/compose.yaml'
+      - 'v2/compose-contributor.yaml'
   workflow_dispatch:
 
 env:
@@ -71,3 +75,44 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  build-contributor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (contributor)
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-contributor
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=pr
+
+      - name: Build and push contributor image
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0
+        with:
+          context: .
+          file: v2/Dockerfile.contributor
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha,scope=contributor
+          cache-to: type=gha,mode=max,scope=contributor

--- a/Justfile
+++ b/Justfile
@@ -85,6 +85,15 @@ contribute-status:
       curl -sf "${HUB_HTTP}/api/contributors/${CONTRIBUTOR_ID}" 2>/dev/null | jq . || echo "Could not fetch profile"
     fi
 
+# Browse available Hive projects to contribute to
+contribute-browse:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    HUB_HTTP=$(echo "{{hive_hub}}" | sed 's|^wss://|https://|;s|^ws://|http://|;s|/contribute$||')
+    echo "=== Available Hives ==="
+    echo ""
+    curl -sf "${HUB_HTTP}/api/hives" 2>/dev/null | jq -r '.hives[] | "  \(.project_name) (\(.org))\n    Hub: \(.hub_url)\n    Dashboard: \(.dashboard_url // "N/A")\n    Contributors: \(.active_contributors // 0) active\n    Actionable: \(.actionable_items // "?") items\n"' || echo "Could not reach registry at ${HUB_HTTP}"
+
 # Stop contributing (if running in background)
 contribute-stop:
     @docker stop hive-contributor 2>/dev/null && echo "Stopped." || echo "Not running."

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,90 @@
+# Justfile — KubeStellar Hive contributor commands
+#
+# Install just: brew install just (macOS) or cargo install just
+# Usage: just contribute-hive [backend]
+
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
+hive_image := env("HIVE_CONTRIBUTOR_IMAGE", "ghcr.io/kubestellar/hive-contributor:latest")
+hive_hub := env("HIVE_HUB", "wss://hive.kubestellar.io:3001/contribute")
+config_dir := env("HOME") + "/.config/hive"
+
+# Show available commands
+default:
+    @just --list
+
+# Register as a Hive contributor (one-time)
+contribute-register:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p "{{config_dir}}"
+    echo "=== Hive Contributor Registration ==="
+    echo ""
+    read -rp "GitHub username: " github_user
+    echo ""
+    echo "Registering with hub..."
+    HUB_HTTP=$(echo "{{hive_hub}}" | sed 's|^wss://|https://|;s|^ws://|http://|;s|/contribute$||')
+    RESPONSE=$(curl -sf -X POST "${HUB_HTTP}/api/contribute/register" \
+      -H "Content-Type: application/json" \
+      -d "{\"github_username\": \"${github_user}\"}" 2>&1) || {
+        echo "ERROR: Registration failed. Is the hub running at ${HUB_HTTP}?"
+        exit 1
+    }
+    TOKEN=$(echo "$RESPONSE" | jq -r '.registration_token')
+    CID=$(echo "$RESPONSE" | jq -r '.contributor_id')
+    if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
+      echo "ERROR: No token received. Response: $RESPONSE"
+      exit 1
+    fi
+    cat > "{{config_dir}}/contributor.env" <<EOF
+    HIVE_REGISTRATION_TOKEN=${TOKEN}
+    HIVE_HUB={{hive_hub}}
+    CONTRIBUTOR_ID=${CID}
+    EOF
+    echo ""
+    echo "Registration successful!"
+    echo "  Contributor ID: ${CID}"
+    echo "  Config saved:   {{config_dir}}/contributor.env"
+    echo ""
+    echo "Run 'just contribute-hive' to start contributing."
+
+# Join the Hive swarm as a contributor
+contribute-hive backend="claude":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ ! -f "{{config_dir}}/contributor.env" ]]; then
+      echo "Not registered yet. Run: just contribute-register"
+      exit 1
+    fi
+    echo "=== Hive Contributor Agent ==="
+    echo "Backend: {{backend}}"
+    echo "Hub:     {{hive_hub}}"
+    echo ""
+    echo "Your CLI API tokens stay local. Hive provides GitHub access."
+    echo ""
+    docker run -it --rm \
+      --name hive-contributor \
+      -v "{{config_dir}}:/home/dev/.config/hive:ro" \
+      -v "${HOME}/.claude:/home/dev/.claude:ro" \
+      -v "${HOME}/.config/claude-code:/home/dev/.config/claude-code:ro" \
+      -e HIVE_HUB="{{hive_hub}}" \
+      -e AGENT_BACKEND="{{backend}}" \
+      {{hive_image}}
+
+# Check hub status and your contributor profile
+contribute-status:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    HUB_HTTP=$(echo "{{hive_hub}}" | sed 's|^wss://|https://|;s|^ws://|http://|;s|/contribute$||')
+    echo "=== Hub Status ==="
+    curl -sf "${HUB_HTTP}/api/contribute/status" 2>/dev/null | jq . || echo "Hub unreachable at ${HUB_HTTP}"
+    if [[ -f "{{config_dir}}/contributor.env" ]]; then
+      source "{{config_dir}}/contributor.env"
+      echo ""
+      echo "=== Your Profile ==="
+      curl -sf "${HUB_HTTP}/api/contributors/${CONTRIBUTOR_ID}" 2>/dev/null | jq . || echo "Could not fetch profile"
+    fi
+
+# Stop contributing (if running in background)
+contribute-stop:
+    @docker stop hive-contributor 2>/dev/null && echo "Stopped." || echo "Not running."

--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -29,6 +29,10 @@ export HIVE_REGISTRATION_TOKEN="${HIVE_REGISTRATION_TOKEN:?Not registered — ru
 export AGENT_BACKEND="${AGENT_BACKEND:-claude}"
 export HIVE_AGENT_SESSION="$TMUX_SESSION"
 export HIVE_AGENT_ID="contributor"
+export HIVE_CONTRIBUTOR_MODE="true"
+export HIVE_CONTRIBUTOR_CLI="$AGENT_BACKEND"
+# Username is extracted from contributor.env (set during registration)
+export HIVE_CONTRIBUTOR_USERNAME="${CONTRIBUTOR_USERNAME:-unknown}"
 
 # Source backends.conf for binary detection
 BACKENDS_CONF="${SCRIPT_DIR}/../config/backends.conf"

--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# contributor-agent.sh — Entrypoint for the contributor container.
+#
+# 1. Detects which CLI backend is authenticated
+# 2. Starts the contributor-relay (WebSocket client) in the background
+# 3. Launches the CLI agent in a tmux session
+# 4. The relay feeds tasks into the tmux session and reports results
+#
+# Environment (from ~/.config/hive/contributor.env):
+#   HIVE_HUB                — WebSocket URL
+#   HIVE_REGISTRATION_TOKEN — contributor's token
+#   AGENT_BACKEND           — preferred CLI backend
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG_DIR="${HOME}/.config/hive"
+CONFIG_FILE="${CONFIG_DIR}/contributor.env"
+TMUX_SESSION="contributor"
+
+# Load contributor config
+if [[ -f "$CONFIG_FILE" ]]; then
+  # shellcheck source=/dev/null
+  source "$CONFIG_FILE"
+fi
+
+export HIVE_HUB="${HIVE_HUB:-wss://hive.kubestellar.io:3001/contribute}"
+export HIVE_REGISTRATION_TOKEN="${HIVE_REGISTRATION_TOKEN:?Not registered — run 'just contribute-register' first}"
+export AGENT_BACKEND="${AGENT_BACKEND:-claude}"
+export HIVE_AGENT_SESSION="$TMUX_SESSION"
+export HIVE_AGENT_ID="contributor"
+
+# Source backends.conf for binary detection
+BACKENDS_CONF="${SCRIPT_DIR}/../config/backends.conf"
+if [[ -f "$BACKENDS_CONF" ]]; then
+  source "$BACKENDS_CONF"
+elif [[ -f /usr/local/etc/hive/backends.conf ]]; then
+  source /usr/local/etc/hive/backends.conf
+fi
+
+# Detect CLI authentication
+detect_cli() {
+  local backend="$1"
+  local cmd
+  cmd=$(backend_binary "$backend" 2>/dev/null || echo "$backend")
+
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "NOT_INSTALLED"
+    return
+  fi
+
+  case "$backend" in
+    claude)
+      if claude --version &>/dev/null; then echo "OK"; else echo "NOT_AUTHED"; fi
+      ;;
+    copilot)
+      if copilot --version &>/dev/null; then echo "OK"; else echo "NOT_AUTHED"; fi
+      ;;
+    gemini)
+      if gemini --version &>/dev/null; then echo "OK"; else echo "NOT_AUTHED"; fi
+      ;;
+    bob)
+      if bob --version &>/dev/null; then echo "OK"; else echo "NOT_AUTHED"; fi
+      ;;
+    goose)
+      if goose --version &>/dev/null; then echo "OK"; else echo "NOT_AUTHED"; fi
+      ;;
+    *)
+      echo "UNKNOWN"
+      ;;
+  esac
+}
+
+echo "=== Hive Contributor Agent ==="
+echo "Hub:     $HIVE_HUB"
+echo "Backend: $AGENT_BACKEND"
+echo ""
+
+# Check CLI readiness
+STATUS=$(detect_cli "$AGENT_BACKEND")
+case "$STATUS" in
+  NOT_INSTALLED)
+    echo "ERROR: $AGENT_BACKEND CLI not found."
+    echo "Install it and try again."
+    exit 1
+    ;;
+  NOT_AUTHED)
+    echo "WARNING: $AGENT_BACKEND CLI may not be authenticated."
+    echo "You may need to log in. The agent will start and prompt if needed."
+    ;;
+  OK)
+    echo "$AGENT_BACKEND CLI detected and ready."
+    ;;
+esac
+
+# Ensure metrics directory exists for gh-wrapper token injection
+mkdir -p /var/run/hive-metrics 2>/dev/null || true
+
+# Create tmux session for the agent
+tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
+tmux new-session -d -s "$TMUX_SESSION" -x 200 -y 50
+
+# Start the relay in the background
+echo "Starting relay connection to hub..."
+node "${SCRIPT_DIR}/contributor-relay.sh" &
+RELAY_PID=$!
+
+# Launch the CLI in the tmux session
+CMD=$(backend_binary "$AGENT_BACKEND")
+PERM_FLAG=$(backend_perm_flag "$AGENT_BACKEND")
+MODEL_FLAG=""
+if [[ -n "${AGENT_MODEL:-}" ]]; then
+  case "$AGENT_BACKEND" in
+    amazonq|goose) ;;
+    *) MODEL_FLAG="--model $AGENT_MODEL" ;;
+  esac
+fi
+
+tmux send-keys -t "$TMUX_SESSION" "$CMD $PERM_FLAG $MODEL_FLAG" Enter
+
+echo ""
+echo "Contributor agent is running."
+echo "  CLI:   $CMD"
+echo "  Relay: PID $RELAY_PID"
+echo "  Tmux:  tmux attach -t $TMUX_SESSION"
+echo ""
+echo "Press Ctrl-C to stop contributing."
+
+# Keep running until interrupted
+cleanup() {
+  echo "Shutting down..."
+  kill "$RELAY_PID" 2>/dev/null || true
+  tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
+  exit 0
+}
+trap cleanup SIGTERM SIGINT
+
+wait "$RELAY_PID"

--- a/bin/contributor-dispatcher.sh
+++ b/bin/contributor-dispatcher.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# contributor-dispatcher.sh — Pipeline stage: report contributor assignment state.
+#
+# Reads /var/run/hive-metrics/contributors.json (written by dashboard server.js)
+# and outputs a summary for the governor and dashboard to consume.
+#
+# This script is read-only — it does NOT assign tasks. Task assignment happens
+# in real-time via the WebSocket server in dashboard/server.js. This script
+# only reports the current state for observability.
+#
+# Output: /var/run/hive-metrics/contributor-assignments.json
+#
+# Called by: run-pipeline.sh (post-classifier stage)
+
+set -euo pipefail
+
+METRICS_DIR="${HIVE_METRICS_DIR:-/var/run/hive-metrics}"
+CONTRIBUTORS_FILE="$METRICS_DIR/contributors.json"
+OUTPUT_FILE="$METRICS_DIR/contributor-assignments.json"
+
+if [[ ! -f "$CONTRIBUTORS_FILE" ]]; then
+  echo '{"active":0,"assigned":0,"idle":0,"assignments":[],"updated_at":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}' > "$OUTPUT_FILE"
+  exit 0
+fi
+
+python3 -c "
+import json, sys
+from datetime import datetime
+
+try:
+    with open('$CONTRIBUTORS_FILE') as f:
+        data = json.load(f)
+except Exception:
+    data = {'active': []}
+
+active = data.get('active', [])
+assigned = [c for c in active if c.get('current_task')]
+idle = [c for c in active if not c.get('current_task')]
+
+assignments = []
+for c in assigned:
+    task = c.get('current_task', {})
+    assignments.append({
+        'contributor_id': c.get('contributor_id', ''),
+        'github_username': c.get('github_username', ''),
+        'cli_backend': c.get('cli_backend', ''),
+        'trust_tier': c.get('trust_tier', ''),
+        'task_id': task.get('task_id', ''),
+        'kind': task.get('kind', ''),
+        'repo': task.get('repo', ''),
+        'number': task.get('number', 0),
+    })
+
+result = {
+    'active': len(active),
+    'assigned': len(assigned),
+    'idle': len(idle),
+    'assignments': assignments,
+    'updated_at': datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+}
+
+print(json.dumps(result, indent=2))
+" > "$OUTPUT_FILE"

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+// contributor-relay.sh — WebSocket client that connects a contributor agent to the Hive hub.
+//
+// Handles: authentication, task receipt, GitHub token injection, result reporting,
+// heartbeat, and reconnection with exponential backoff.
+//
+// Environment:
+//   HIVE_HUB              — WebSocket URL (wss://host:port/contribute)
+//   HIVE_REGISTRATION_TOKEN — contributor's registration token
+//   AGENT_BACKEND          — CLI backend name (claude, copilot, gemini, etc.)
+//   AGENT_MODEL            — model override (optional)
+//   HIVE_AGENT_SESSION     — tmux session name for the agent (default: contributor)
+
+'use strict';
+
+const WebSocket = require('ws');
+const { execSync, execFile } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const HUB_URL = process.env.HIVE_HUB || 'wss://hive.kubestellar.io:3001/contribute';
+const REG_TOKEN = process.env.HIVE_REGISTRATION_TOKEN;
+const BACKEND = process.env.AGENT_BACKEND || 'claude';
+const MODEL = process.env.AGENT_MODEL || '';
+const TMUX_SESSION = process.env.HIVE_AGENT_SESSION || 'contributor';
+const GH_TOKEN_CACHE = '/var/run/hive-metrics/gh-app-token.cache';
+const TASK_FILE = '/tmp/contributor-task.json';
+
+const TMUX_TAIL_LINES = 15;
+const HEARTBEAT_INTERVAL_MS = 30000;
+const HEARTBEAT_TIMEOUT_MS = 90000;
+const PROGRESS_REPORT_INTERVAL_MS = 120000;
+const MAX_RECONNECT_DELAY_MS = 60000;
+const BASE_RECONNECT_DELAY_MS = 1000;
+const TOKEN_REFRESH_MARGIN_MS = 300000;
+
+if (!REG_TOKEN) {
+  console.error('FATAL: HIVE_REGISTRATION_TOKEN not set. Run `just contribute-register` first.');
+  process.exit(1);
+}
+
+let ws = null;
+let seq = 0;
+let reconnectDelay = BASE_RECONNECT_DELAY_MS;
+let heartbeatInterval = null;
+let lastPong = Date.now();
+let currentTask = null;
+let progressInterval = null;
+let tokenExpiresAt = null;
+
+function nextSeq() { return ++seq; }
+
+function send(msg) {
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify(msg));
+  }
+}
+
+function injectGhToken(token) {
+  const dir = path.dirname(GH_TOKEN_CACHE);
+  try { fs.mkdirSync(dir, { recursive: true }); } catch (_) {}
+  fs.writeFileSync(GH_TOKEN_CACHE, token, { mode: 0o600 });
+}
+
+function tmuxSendKeys(text) {
+  try {
+    execSync(`tmux send-keys -t ${TMUX_SESSION} C-u`, { timeout: 5000 });
+    execSync(`tmux send-keys -t ${TMUX_SESSION} -l ${shellQuote(text)}`, { timeout: 5000 });
+    execSync(`tmux send-keys -t ${TMUX_SESSION} Enter`, { timeout: 5000 });
+  } catch (e) {
+    console.error('tmux send-keys failed:', e.message);
+  }
+}
+
+function shellQuote(s) {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+function captureTmuxLines(n) {
+  try {
+    const output = execSync(
+      `tmux capture-pane -t ${TMUX_SESSION} -p -S -${n} 2>/dev/null`,
+      { encoding: 'utf8', timeout: 5000 }
+    );
+    return output.trim().split('\n').slice(-n);
+  } catch (_) {
+    return [];
+  }
+}
+
+function checkTmuxIdle() {
+  try {
+    const output = execSync(
+      `tmux capture-pane -t ${TMUX_SESSION} -p -S -5 2>/dev/null`,
+      { encoding: 'utf8', timeout: 5000 }
+    );
+    const lines = output.trim().split('\n');
+    const lastLine = lines[lines.length - 1] || '';
+    const idlePatterns = [/\$\s*$/, />\s*$/, /\?\s*$/, /claude.*>\s*$/i];
+    return idlePatterns.some(p => p.test(lastLine));
+  } catch (_) {
+    return false;
+  }
+}
+
+function startProgressReporting() {
+  if (progressInterval) clearInterval(progressInterval);
+  progressInterval = setInterval(() => {
+    if (!currentTask) return;
+    const idle = checkTmuxIdle();
+    const tmuxLines = captureTmuxLines(TMUX_TAIL_LINES);
+    if (idle) {
+      send({ type: 'task_complete', seq: nextSeq(), task_id: currentTask.task_id, result: 'completed', summary: 'Agent returned to idle', tmux_output: tmuxLines });
+      currentTask = null;
+      clearInterval(progressInterval);
+      progressInterval = null;
+      send({ type: 'ready', seq: nextSeq() });
+    } else {
+      send({ type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, status: 'working', tmux_output: tmuxLines });
+    }
+  }, PROGRESS_REPORT_INTERVAL_MS);
+}
+
+function handleMessage(data) {
+  let msg;
+  try { msg = JSON.parse(data); } catch (_) { return; }
+
+  switch (msg.type) {
+    case 'auth_challenge':
+      send({
+        type: 'auth_response',
+        seq: nextSeq(),
+        registration_token: REG_TOKEN,
+        cli_backend: BACKEND,
+        model: MODEL,
+      });
+      break;
+
+    case 'auth_ok':
+      console.log(`Authenticated as ${msg.contributor_id} (tier: ${msg.trust_tier})`);
+      reconnectDelay = BASE_RECONNECT_DELAY_MS;
+      send({ type: 'ready', seq: nextSeq() });
+      break;
+
+    case 'auth_failed':
+      console.error(`Authentication failed: ${msg.reason}`);
+      process.exit(1);
+      break;
+
+    case 'task_assign':
+      currentTask = msg;
+      console.log(`Task assigned: ${msg.kind} ${msg.repo}#${msg.number} — ${msg.title}`);
+      if (msg.github_token) {
+        injectGhToken(msg.github_token);
+        tokenExpiresAt = msg.token_expires_at ? new Date(msg.token_expires_at).getTime() : null;
+      }
+      fs.writeFileSync(TASK_FILE, JSON.stringify(msg, null, 2));
+      send({ type: 'task_accepted', seq: nextSeq(), task_id: msg.task_id });
+      tmuxSendKeys(msg.prompt || `Work on ${msg.kind} ${msg.repo}#${msg.number}: ${msg.title}`);
+      startProgressReporting();
+      break;
+
+    case 'token_refresh':
+      if (msg.github_token) {
+        injectGhToken(msg.github_token);
+        tokenExpiresAt = msg.token_expires_at ? new Date(msg.token_expires_at).getTime() : null;
+        console.log('GitHub token refreshed');
+      }
+      break;
+
+    case 'task_revoke':
+      console.log(`Task revoked: ${msg.task_id} — ${msg.reason}`);
+      currentTask = null;
+      if (progressInterval) { clearInterval(progressInterval); progressInterval = null; }
+      send({ type: 'ready', seq: nextSeq() });
+      break;
+
+    case 'ping':
+      send({ type: 'pong', seq: msg.seq });
+      break;
+
+    case 'pong':
+      lastPong = Date.now();
+      break;
+
+    default:
+      console.log('Unknown message type:', msg.type);
+  }
+}
+
+function connect() {
+  console.log(`Connecting to ${HUB_URL}...`);
+  ws = new WebSocket(HUB_URL);
+
+  ws.on('open', () => {
+    console.log('Connected to hub');
+    lastPong = Date.now();
+
+    heartbeatInterval = setInterval(() => {
+      if (Date.now() - lastPong > HEARTBEAT_TIMEOUT_MS) {
+        console.error('Heartbeat timeout — reconnecting');
+        ws.terminate();
+        return;
+      }
+      send({ type: 'ping', seq: nextSeq() });
+    }, HEARTBEAT_INTERVAL_MS);
+  });
+
+  ws.on('message', (data) => handleMessage(data.toString()));
+
+  ws.on('close', () => {
+    console.log(`Connection closed. Reconnecting in ${reconnectDelay}ms...`);
+    cleanup();
+    setTimeout(connect, reconnectDelay);
+    reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY_MS);
+  });
+
+  ws.on('error', (err) => {
+    console.error('WebSocket error:', err.message);
+  });
+}
+
+function cleanup() {
+  if (heartbeatInterval) { clearInterval(heartbeatInterval); heartbeatInterval = null; }
+  if (progressInterval) { clearInterval(progressInterval); progressInterval = null; }
+  currentTask = null;
+}
+
+process.on('SIGTERM', () => { cleanup(); process.exit(0); });
+process.on('SIGINT', () => { cleanup(); process.exit(0); });
+
+connect();

--- a/bin/federation-heartbeat.sh
+++ b/bin/federation-heartbeat.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# federation-heartbeat.sh — Periodically sends this hive's live stats
+# to the federation registry so contributors can see which hives need help.
+#
+# Called by: cron or systemd timer (every 5 minutes)
+#
+# Environment:
+#   HIVE_FEDERATION_REGISTRY — URL of the registry hub (default: https://hive.kubestellar.io)
+#   HIVE_FEDERATION_ID       — this hive's ID in the registry
+#
+# Reads from:
+#   /var/run/hive-metrics/contributors.json — active contributor count
+#   /var/run/hive-metrics/actionable.json   — actionable items count
+
+set -euo pipefail
+
+REGISTRY_URL="${HIVE_FEDERATION_REGISTRY:-https://hive.kubestellar.io}"
+HIVE_ID="${HIVE_FEDERATION_ID:-}"
+METRICS_DIR="${HIVE_METRICS_DIR:-/var/run/hive-metrics}"
+
+if [[ -z "$HIVE_ID" ]]; then
+  echo "HIVE_FEDERATION_ID not set — skipping heartbeat" >&2
+  exit 0
+fi
+
+ACTIVE_CONTRIBUTORS=0
+if [[ -f "$METRICS_DIR/contributors.json" ]]; then
+  ACTIVE_CONTRIBUTORS=$(python3 -c "
+import json
+try:
+    with open('$METRICS_DIR/contributors.json') as f:
+        d = json.load(f)
+    print(len(d.get('active', [])))
+except: print(0)
+" 2>/dev/null)
+fi
+
+ACTIONABLE_ITEMS=0
+if [[ -f "$METRICS_DIR/actionable.json" ]]; then
+  ACTIONABLE_ITEMS=$(python3 -c "
+import json
+try:
+    with open('$METRICS_DIR/actionable.json') as f:
+        d = json.load(f)
+    print(len(d.get('issues', {}).get('items', [])))
+except: print(0)
+" 2>/dev/null)
+fi
+
+# Count enabled agents from config
+ACTIVE_AGENTS=0
+if [[ -f /etc/hive/config.env ]]; then
+  AGENTS_LINE=$(grep '^AGENTS_ENABLED=' /etc/hive/config.env 2>/dev/null || true)
+  if [[ -n "$AGENTS_LINE" ]]; then
+    ACTIVE_AGENTS=$(echo "${AGENTS_LINE#*=}" | wc -w)
+  fi
+fi
+
+curl -sf -X POST "${REGISTRY_URL}/api/hives/${HIVE_ID}/heartbeat" \
+  -H "Content-Type: application/json" \
+  -d "{\"active_contributors\":${ACTIVE_CONTRIBUTORS},\"active_agents\":${ACTIVE_AGENTS},\"actionable_items\":${ACTIONABLE_ITEMS}}" \
+  >/dev/null 2>&1 || echo "Heartbeat failed — registry may be unreachable" >&2

--- a/bin/gh-app-token.sh
+++ b/bin/gh-app-token.sh
@@ -59,6 +59,65 @@ mkdir -p "$(dirname "$CACHE_FILE")"
 echo -n "$TOKEN" > "$CACHE_FILE"
 chmod 600 "$CACHE_FILE"
 
+if [ "${1:-}" = "--scoped" ]; then
+  # Mint a scoped installation token for a contributor.
+  # Usage: gh-app-token.sh --scoped <tier> [repo1,repo2,...]
+  TIER="${2:?Usage: gh-app-token.sh --scoped <tier> [repos]}"
+  REPOS="${3:-}"
+
+  case "$TIER" in
+    newcomer)
+      PERMISSIONS='{"issues":"write","metadata":"read"}'
+      ;;
+    contributor)
+      PERMISSIONS='{"issues":"write","contents":"write","pull_requests":"write","metadata":"read"}'
+      ;;
+    trusted)
+      PERMISSIONS='{"issues":"write","contents":"write","pull_requests":"write","metadata":"read","checks":"read"}'
+      ;;
+    advisor)
+      PERMISSIONS='{"issues":"read","metadata":"read"}'
+      ;;
+    *)
+      echo "ERROR: unknown tier: $TIER (valid: newcomer, contributor, trusted, advisor)" >&2
+      exit 1
+      ;;
+  esac
+
+  SCOPED_BODY="{\"permissions\":${PERMISSIONS}}"
+  if [ -n "$REPOS" ]; then
+    REPO_ARRAY=$(echo "$REPOS" | tr ',' '\n' | sed 's/.*/"&"/' | paste -sd ',' -)
+    SCOPED_BODY="{\"permissions\":${PERMISSIONS},\"repositories\":[${REPO_ARRAY}]}"
+  fi
+
+  # Generate fresh JWT for scoped token (don't use cached full-access token)
+  SCOPED_NOW=$(date +%s)
+  SCOPED_IAT=$((SCOPED_NOW - 60))
+  SCOPED_EXP=$((SCOPED_NOW + 540))
+  SCOPED_HEADER=$(echo -n '{"alg":"RS256","typ":"JWT"}' | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
+  SCOPED_PAYLOAD=$(echo -n "{\"iat\":${SCOPED_IAT},\"exp\":${SCOPED_EXP},\"iss\":\"${APP_ID}\"}" | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
+  SCOPED_SIG=$(echo -n "${SCOPED_HEADER}.${SCOPED_PAYLOAD}" | openssl dgst -sha256 -sign "$PRIVATE_KEY_FILE" | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
+  SCOPED_JWT="${SCOPED_HEADER}.${SCOPED_PAYLOAD}.${SCOPED_SIG}"
+
+  SCOPED_RESPONSE=$(curl -s -X POST \
+    -H "Authorization: Bearer ${SCOPED_JWT}" \
+    -H "Accept: application/vnd.github+json" \
+    -d "$SCOPED_BODY" \
+    "https://api.github.com/app/installations/${INSTALLATION_ID}/access_tokens")
+
+  SCOPED_TOKEN=$(echo "$SCOPED_RESPONSE" | jq -r '.token // empty')
+  SCOPED_EXPIRES=$(echo "$SCOPED_RESPONSE" | jq -r '.expires_at // empty')
+
+  if [ -z "$SCOPED_TOKEN" ]; then
+    echo "ERROR: Failed to mint scoped token for tier=$TIER" >&2
+    echo "$SCOPED_RESPONSE" >&2
+    exit 1
+  fi
+
+  echo "{\"token\":\"${SCOPED_TOKEN}\",\"expires_at\":\"${SCOPED_EXPIRES}\"}"
+  exit 0
+fi
+
 if [ "${1:-}" = "--export" ]; then
   echo "export GH_TOKEN=$TOKEN"
 else

--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -27,6 +27,16 @@ elif [[ -n "${HIVE_GITHUB_TOKEN:-}" ]]; then
   export GH_TOKEN="$HIVE_GITHUB_TOKEN"
 fi
 
+# Contributor mode — extra restrictions for remote contributor agents
+if [[ "${HIVE_CONTRIBUTOR_MODE:-}" == "true" ]]; then
+  case "$*" in
+    *"auth "*)
+      echo "⛔ BLOCKED: gh auth is disabled for contributor agents." >&2
+      exit 1
+      ;;
+  esac
+fi
+
 # Log gh calls involving label manipulation or issues 15056/15061/15062
 if [[ "$*" == *"hold"* ]] || [[ "$*" == *"label"* ]] || [[ "$*" == *"/labels"* ]] || [[ "$*" == *"15056"* ]] || [[ "$*" == *"15061"* ]] || [[ "$*" == *"15062"* ]] || [[ "$*" == *"issue"*"edit"* ]]; then
   echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] GH-TRACE: gh $* | PID=$$ PPID=$PPID AGENT=${HIVE_AGENT_ID:-${HIVE_AGENT:-unknown}} | caller=$(ps -o args= -p $PPID 2>/dev/null | head -c200)" >> /tmp/hold-trace.log 2>/dev/null || true
@@ -191,6 +201,13 @@ fi
 if [[ -n "$AGENT_NAME" ]]; then
   LABELS_CSV="agent/${AGENT_NAME}"
   [[ -n "$HIVE_INSTANCE_ID" ]] && LABELS_CSV="${LABELS_CSV},hive/${HIVE_INSTANCE_ID}"
+  # Contributor labels — added when running in contributor mode
+  if [[ "${HIVE_CONTRIBUTOR_MODE:-}" == "true" ]]; then
+    CONTRIBUTOR_USER="${HIVE_CONTRIBUTOR_USERNAME:-}"
+    CONTRIBUTOR_CLI="${HIVE_CONTRIBUTOR_CLI:-}"
+    [[ -n "$CONTRIBUTOR_USER" ]] && LABELS_CSV="${LABELS_CSV},contributor/${CONTRIBUTOR_USER}"
+    [[ -n "$CONTRIBUTOR_CLI" ]] && LABELS_CSV="${LABELS_CSV},cli/${CONTRIBUTOR_CLI}"
+  fi
 
   # Ensure labels exist on the repo (cached per-session to avoid repeated API calls).
   LABEL_CACHE="/tmp/.hive-labels-ensured"

--- a/config/contributor.env.example
+++ b/config/contributor.env.example
@@ -1,0 +1,12 @@
+# Contributor agent configuration
+# Created by `just contribute-register`
+# This file is read by the contributor container on startup.
+
+# Registration token (obtained from hub during registration)
+HIVE_REGISTRATION_TOKEN=
+
+# Hub WebSocket URL
+HIVE_HUB=wss://hive.kubestellar.io:3001/contribute
+
+# Preferred CLI backend (claude, copilot, gemini, goose, bob)
+AGENT_BACKEND=claude

--- a/config/restrictions/contributor-default.json
+++ b/config/restrictions/contributor-default.json
@@ -1,0 +1,11 @@
+{
+  "rules": [
+    { "pattern": "gh api *", "reason": "Direct API calls disabled for contributors", "enabled": true },
+    { "pattern": "gh auth *", "reason": "Auth management disabled for contributors", "enabled": true },
+    { "pattern": "gh issue list*", "reason": "Use assigned tasks from the hive hub", "enabled": true },
+    { "pattern": "gh pr list*", "reason": "Use assigned tasks from the hive hub", "enabled": true },
+    { "pattern": "gh search *", "reason": "Enumeration disabled for contributors", "enabled": true },
+    { "pattern": "gh repo delete*", "reason": "Destructive operations disabled for contributors", "enabled": true },
+    { "pattern": "gh repo edit*", "reason": "Repo settings changes disabled for contributors", "enabled": true }
+  ]
+}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -368,6 +368,7 @@
     body.light-mode.oc-agent-focused .token-usage,
     body.light-mode.oc-agent-focused .repos,
     body.light-mode.oc-agent-focused #beads-section,
+    body.light-mode.oc-agent-focused #contributors-section,
     body.light-mode.oc-agent-focused #nous-section { display: none; }
     body.light-mode.oc-strategy-focused #nous-section { display: block; }
     body.light-mode.oc-agent-focused .agent-card.oc-hidden { display: none; }
@@ -1475,6 +1476,11 @@
     <div class="beads" id="beads"></div>
   </div>
 
+  <div id="contributors-section" style="margin-top: 16px; margin-bottom: 24px;">
+    <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 8px;">👥 Contributors</h2>
+    <div id="contributors-panel" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 12px;"></div>
+  </div>
+
   <div id="nous-section" style="margin-top: 16px; margin-bottom: 24px;">
     <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 8px;">🧪 Strategy Lab <span id="nous-mode-badge" style="font-size:0.75rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span> <button onclick="openNousConfig()" style="background:none;border:none;cursor:pointer;font-size:1rem;color:var(--muted);margin-left:6px;padding:2px" title="Strategy Lab Configuration">⚙️</button></h2>
     <div id="nous-panel"></div>
@@ -2169,6 +2175,7 @@
         }
       }
 
+      html += `<a class="oc-nav-item" data-section="contributors-section" onclick="ocNavigate('contributors-section')">👥 Contributors <span id="contributor-count-badge" style="font-size:0.7rem;background:var(--green);color:var(--bg);padding:1px 6px;border-radius:9999px;margin-left:4px;display:none"></span></a>`;
       html += `<a class="oc-nav-item" data-section="nous-section" onclick="ocNavigate('nous-section')">🧪 Strategy Lab</a>`;
       html += `<div id="nous-sidebar-config" style="padding:2px 8px 6px 24px;font-size:0.65rem;color:var(--muted);line-height:1.5;display:none">`;
       html += `<div><span id="nous-sb-scope" style="font-weight:600"></span> · <span id="nous-sb-mode"></span></div>`;
@@ -3397,6 +3404,113 @@ function burnAreaChart() {
       if (el.innerHTML !== html) el.innerHTML = html;
     }
 
+    // ── Contributors rendering ───────────────────────────────────────────
+    const CONTRIBUTOR_POLL_MS = 10000;
+    let _contributorCache = null;
+
+    async function fetchContributors() {
+      try {
+        const res = await fetch('/api/contributors');
+        _contributorCache = await res.json();
+        renderContributors();
+      } catch (_) {}
+    }
+
+    function renderContributors() {
+      const panel = document.getElementById('contributors-panel');
+      const badge = document.getElementById('contributor-count-badge');
+      if (!panel || !_contributorCache) return;
+
+      const contributors = _contributorCache.contributors || [];
+      const active = contributors.filter(c => c.active);
+
+      if (badge) {
+        if (active.length > 0) {
+          badge.textContent = active.length;
+          badge.style.display = 'inline';
+        } else {
+          badge.style.display = 'none';
+        }
+      }
+
+      if (contributors.length === 0) {
+        setIfChanged(panel, `<div style="color:var(--muted);font-size:0.85rem;padding:12px;border:1px dashed var(--border);border-radius:8px">No contributors registered yet. Projects can invite contributors who run <code style="background:var(--surface);padding:2px 6px;border-radius:4px">just contribute-hive</code> to donate their CLI tokens to this hive.</div>`);
+        return;
+      }
+
+      let html = '';
+      for (const c of contributors) {
+        const isActive = c.active;
+        const dotColor = isActive ? 'var(--green)' : 'var(--muted)';
+        const tierColors = { newcomer: 'var(--yellow)', contributor: 'var(--blue)', trusted: 'var(--green)', advisor: 'var(--purple)', revoked: 'var(--red)' };
+        const tierColor = tierColors[c.trust_tier] || 'var(--muted)';
+        const taskHtml = c.active && c.currentTask
+          ? `<div style="margin-top:6px;font-size:0.75rem;color:var(--text);background:rgba(255,255,255,0.05);padding:6px 8px;border-radius:4px">Working on: <a href="https://github.com/${esc(c.currentTask.repo)}/issues/${c.currentTask.number}" target="_blank" style="color:var(--blue)">${esc(c.currentTask.repo)}#${c.currentTask.number}</a></div>`
+          : '';
+        const tmuxHtml = c.lastTmuxOutput && c.lastTmuxOutput.length
+          ? `<details style="margin-top:6px"><summary style="font-size:0.7rem;color:var(--muted);cursor:pointer">tmux output</summary><pre style="font-size:0.65rem;color:var(--muted);max-height:120px;overflow-y:auto;margin-top:4px;padding:6px;background:rgba(0,0,0,0.3);border-radius:4px">${esc(c.lastTmuxOutput.join('\n'))}</pre></details>`
+          : '';
+
+        html += `<div style="background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:12px">
+          <div style="display:flex;align-items:center;gap:8px">
+            <span style="width:8px;height:8px;border-radius:50%;background:${dotColor};flex-shrink:0"></span>
+            <a href="https://github.com/${esc(c.github_username)}" target="_blank" style="color:var(--text);font-weight:600;text-decoration:none;font-size:0.9rem">${esc(c.github_username)}</a>
+            <span style="font-size:0.7rem;padding:1px 8px;border-radius:9999px;border:1px solid ${tierColor};color:${tierColor}">${esc(c.trust_tier)}</span>
+            <span style="margin-left:auto;font-size:0.7rem;color:var(--muted)">${c.total_tasks_completed || 0} done / ${c.total_tasks_failed || 0} failed</span>
+          </div>
+          <div style="margin-top:6px;font-size:0.75rem;color:var(--muted)">
+            Registered: ${c.registered_at ? new Date(c.registered_at).toLocaleDateString() : '?'}
+            ${isActive ? '' : ' · <span style="color:var(--muted)">offline</span>'}
+          </div>
+          ${taskHtml}${tmuxHtml}
+          <div style="margin-top:8px;display:flex;gap:6px">
+            <select onchange="changeContributorTier('${esc(c.contributor_id || c.github_username)}', this.value)" style="font-size:0.7rem;padding:2px 6px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;cursor:pointer">
+              ${['newcomer','contributor','trusted','advisor','revoked'].map(t => `<option value="${t}"${t === c.trust_tier ? ' selected' : ''}>${t}</option>`).join('')}
+            </select>
+            ${c.trust_tier !== 'revoked' ? `<button onclick="revokeContributor('${esc(c.contributor_id || c.github_username)}')" style="font-size:0.7rem;padding:2px 8px;background:var(--red);color:white;border:none;border-radius:4px;cursor:pointer">Revoke</button>` : ''}
+          </div>
+        </div>`;
+      }
+      setIfChanged(panel, html);
+    }
+
+    async function changeContributorTier(id, tier) {
+      try {
+        const res = await fetch(`/api/contributors/${id}/trust`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tier }),
+        });
+        if (res.ok) fetchContributors();
+      } catch (_) {}
+    }
+
+    async function revokeContributor(id) {
+      if (!confirm('Revoke this contributor? Their WebSocket will be disconnected and GitHub token invalidated.')) return;
+      try {
+        const res = await fetch(`/api/contributors/${id}/revoke`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        });
+        if (res.ok) fetchContributors();
+      } catch (_) {}
+    }
+
+    function updateContributorBadge(pool) {
+      const badge = document.getElementById('contributor-count-badge');
+      if (!badge) return;
+      const active = pool.active || 0;
+      if (active > 0) {
+        badge.textContent = active;
+        badge.style.display = 'inline';
+      } else {
+        badge.style.display = 'none';
+      }
+    }
+
+    fetchContributors();
+    setInterval(fetchContributors, CONTRIBUTOR_POLL_MS);
+
     // ── Strategy Lab (Nous) rendering ──────────────────────────────────────
     let _nousCache = null;
     const NOUS_POLL_MS = 30000;
@@ -4118,6 +4232,7 @@ function burnAreaChart() {
       renderTokens(data.tokens || {});
       renderRepos(data.repos || []);
       renderBeads(data.beads || {});
+      updateContributorBadge(data.contributorPool || {});
       ocUpdateSidebarAgents();
       if (_ocSelectedAgent) { ocRenderAgentDetail(); ocUpdateFocusedState(); }
       renderDebugSection();

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test 'test/**/*.test.js'"
   },
   "keywords": [],
   "author": "",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "ws": "^8.18.0"
   }
 }

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -3021,6 +3021,148 @@ app.get('/api/contribute/status', (_req, res) => {
   });
 });
 
+// ── Hive Federation: Project onboarding & discovery ─────────────────────────
+const HIVE_REGISTRY_DIR = '/etc/hive/federation';
+const HIVE_REGISTRY_FILE = path.join(HIVE_REGISTRY_DIR, 'registry.json');
+
+function loadHiveRegistry() {
+  try { return JSON.parse(fs.readFileSync(HIVE_REGISTRY_FILE, 'utf8')); }
+  catch (_) { return { hives: [] }; }
+}
+
+function saveHiveRegistry(data) {
+  try {
+    if (!fs.existsSync(HIVE_REGISTRY_DIR)) {
+      execSync(`sudo mkdir -p ${shellQuote(HIVE_REGISTRY_DIR)} && sudo chown dev:dev ${shellQuote(HIVE_REGISTRY_DIR)}`);
+    }
+    fs.writeFileSync(HIVE_REGISTRY_FILE, JSON.stringify(data, null, 2));
+  } catch (e) { console.error('Failed to save registry:', e.message); }
+}
+
+app.get('/api/hives', (_req, res) => {
+  const registry = loadHiveRegistry();
+  const thisHive = {
+    id: `hive-${(projectConfig.project || {}).name || 'unknown'}`,
+    project_name: PROJECT_NAME,
+    org: PROJECT_ORG,
+    primary_repo: PROJECT_PRIMARY_REPO,
+    hub_url: `wss://${process.env.HIVE_PUBLIC_HOST || 'localhost'}:${PORT}/contribute`,
+    dashboard_url: `https://${process.env.HIVE_PUBLIC_HOST || 'localhost'}:${PORT}`,
+    active_contributors: contributorConnections.size,
+    active_agents: ENABLED_AGENTS.length,
+    actionable_items: ((actionableCache.issues || {}).items || []).length,
+    registered_at: (projectConfig.project || {}).registered_at || null,
+  };
+  const hives = [thisHive, ...(registry.hives || [])];
+  res.json({ hives });
+});
+
+app.post('/api/hives/register', (req, res) => {
+  const { project_name, org, repos, hub_url, dashboard_url, contact_email } = req.body;
+  if (!project_name || !org || !hub_url) {
+    return res.status(400).json({ error: 'project_name, org, and hub_url are required' });
+  }
+  const registry = loadHiveRegistry();
+  const existing = (registry.hives || []).find(h => h.org === org && h.project_name === project_name);
+  if (existing) {
+    Object.assign(existing, { repos, hub_url, dashboard_url, contact_email, updated_at: new Date().toISOString() });
+  } else {
+    const hiveId = `hive-${org}-${project_name}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+    registry.hives = registry.hives || [];
+    registry.hives.push({
+      id: hiveId,
+      project_name,
+      org,
+      repos: repos || [],
+      hub_url,
+      dashboard_url: dashboard_url || '',
+      contact_email: contact_email || '',
+      registered_at: new Date().toISOString(),
+      active_contributors: 0,
+      active_agents: 0,
+    });
+  }
+  saveHiveRegistry(registry);
+  res.json({ ok: true, message: `Hive registered for ${org}/${project_name}` });
+});
+
+app.delete('/api/hives/:id', (req, res) => {
+  const registry = loadHiveRegistry();
+  const idx = (registry.hives || []).findIndex(h => h.id === req.params.id);
+  if (idx === -1) return res.status(404).json({ error: 'Hive not found' });
+  registry.hives.splice(idx, 1);
+  saveHiveRegistry(registry);
+  res.json({ ok: true });
+});
+
+// Project onboarding — generate a starter hive-project.yaml
+app.post('/api/hives/onboard', (req, res) => {
+  const { project_name, org, repos, github_app_id, github_app_installation_id } = req.body;
+  if (!project_name || !org || !repos || !repos.length) {
+    return res.status(400).json({ error: 'project_name, org, and repos[] are required' });
+  }
+  const config = {
+    project: {
+      name: project_name,
+      org,
+      primary_repo: repos[0],
+      repos,
+    },
+    agents: {
+      enabled: ['scanner', 'supervisor'],
+    },
+    dashboard: {
+      title: `${project_name} Hive`,
+      port: 3001,
+    },
+    github_app: {
+      app_id: github_app_id || 'YOUR_APP_ID',
+      installation_id: github_app_installation_id || 'YOUR_INSTALLATION_ID',
+    },
+  };
+
+  const yamlContent = yaml
+    ? yaml.dump(config, { lineWidth: 120 })
+    : JSON.stringify(config, null, 2);
+
+  const dockerCompose = `# Docker Compose for ${project_name} Hive
+# 1. Save this as compose.yaml
+# 2. Create /etc/hive/hive-project.yaml with the config below
+# 3. Place your GitHub App private key at /etc/hive/gh-app-key.pem
+# 4. Run: docker compose up -d
+
+services:
+  hive:
+    image: ghcr.io/kubestellar/hive:latest
+    container_name: ${project_name.toLowerCase().replace(/[^a-z0-9]/g, '-')}-hive
+    restart: unless-stopped
+    ports:
+      - "3001:3001"
+    volumes:
+      - hive-data:/data
+      - /etc/hive:/etc/hive:ro
+    environment:
+      - HIVE_PUBLIC_HOST=your-server.example.com
+
+volumes:
+  hive-data:
+`;
+
+  res.json({
+    hive_project_yaml: yamlContent,
+    docker_compose_yaml: dockerCompose,
+    next_steps: [
+      '1. Install the Hive GitHub App on your org: https://github.com/apps/kubestellar-hive-bot',
+      '2. Note the App ID and Installation ID from the app settings',
+      '3. Save the private key as /etc/hive/gh-app-key.pem on your server',
+      '4. Save the hive-project.yaml as /etc/hive/hive-project.yaml',
+      '5. Save the docker-compose.yaml and run: docker compose up -d',
+      '6. Register your hive: curl -X POST https://hive.kubestellar.io/api/hives/register -d \'{"project_name":"...", "org":"...", "hub_url":"wss://your-server:3001/contribute"}\'',
+      '7. Contributors can now find your hive at https://hive.kubestellar.io and run: just contribute-hive',
+    ],
+  });
+});
+
 // WebSocket server for contributor agents
 const server = app.listen(PORT, () => {
   console.log(`🐝 Hive Dashboard running at http://localhost:${PORT}`);

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -2912,8 +2912,13 @@ function persistContributorMetrics() {
 trackedInterval(persistContributorMetrics, REFRESH_MS);
 
 function selectTaskForContributor(profile) {
-  const items = (actionableCache.issues || {}).items || [];
   const tier = profile.trust_tier;
+
+  if (tier === 'advisor') {
+    return selectAdvisorTask(profile);
+  }
+
+  const items = (actionableCache.issues || {}).items || [];
 
   for (const item of items) {
     if (item.assigned_to) continue;
@@ -2931,6 +2936,31 @@ function selectTaskForContributor(profile) {
       url: item.url,
       labels: item.labels || [],
       prompt: `You are a Hive contributor agent. Work on issue ${item.repo}#${item.number}: "${item.title}". Read the issue, understand the requirements, and implement a fix. Create a PR when done. Use conventional commits. Add label "contributor/${profile.github_username}" to any PRs you create.`,
+    };
+  }
+  return null;
+}
+
+function selectAdvisorTask(profile) {
+  const prs = (actionableCache.prs || {}).items || [];
+
+  for (const pr of prs) {
+    if (pr.assigned_to) continue;
+    const labels = (pr.labels || []).map(l => (typeof l === 'string' ? l : l.name || '').toLowerCase());
+    if (labels.some(l => l.includes('hold') || l.includes('do-not-merge'))) continue;
+    const hasAgentLabel = labels.some(l => l.startsWith('agent/'));
+    if (!hasAgentLabel) continue;
+
+    pr.assigned_to = { type: 'advisor', id: profile.contributor_id, assigned_at: new Date().toISOString() };
+    return {
+      task_id: `adv-${pr.repo}-${pr.number}-${Date.now()}`,
+      kind: 'advisor_review',
+      repo: pr.repo,
+      number: pr.number,
+      title: pr.title,
+      url: pr.url,
+      labels: pr.labels || [],
+      prompt: `Review PR ${pr.repo}#${pr.number}: "${pr.title}". This was created by a Hive agent. Run: gh pr diff ${pr.number} --repo ${pr.repo} to see the changes. Check for correctness, test coverage, and code style. Post your review with: gh pr review ${pr.number} --repo ${pr.repo} --approve (or --request-changes --body "reason")`,
     };
   }
   return null;

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -573,6 +573,19 @@ function fetchStatus() {
         statusCache.issueToMerge = issueToMergeCache;
         // GitHub API rate limit alerts
         statusCache.ghRateLimits = ghRateLimitsCache;
+        // Contributor pool metrics
+        statusCache.contributorPool = {
+          active: contributorConnections.size,
+          registered: listContributors().length,
+          connections: Array.from(contributorConnections.values()).map(c => ({
+            github_username: c.profile.github_username,
+            trust_tier: c.profile.trust_tier,
+            cli_backend: c.cliBackend,
+            model: c.model,
+            current_task: c.currentTask ? { kind: c.currentTask.kind, repo: c.currentTask.repo, number: c.currentTask.number } : null,
+          })),
+        };
+
         // Activity from JSONL tailing + tmux scraping — no stale status file fallback
         statusCache.summaries = summariesCache;
         for (const a of (statusCache.agents || [])) {
@@ -643,6 +656,10 @@ function fetchStatus() {
         snap.tokenCacheRead = tt.cacheRead || 0;
         snap.tokenCacheCreate = tt.cacheCreate || 0;
         snap.tokenMessages = tt.messages || 0;
+        // Contributor pool
+        snap.contributorActive = contributorConnections.size;
+        snap.contributorAssigned = Array.from(contributorConnections.values()).filter(c => c.currentTask).length;
+
         // Per-model token data
         snap.tokenModels = {};
         const bm = tc.byModel || {};

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -3011,22 +3011,19 @@ app.post('/api/contributors/:id/revoke', (req, res) => {
   res.json({ ok: true });
 });
 
-// Registration endpoint (simplified — real implementation would use GitHub OAuth)
-app.post('/api/contribute/register', (req, res) => {
-  const { github_username } = req.body;
-  if (!github_username || !/^[a-zA-Z0-9_-]+$/.test(github_username)) {
-    return res.status(400).json({ error: 'Invalid github_username' });
-  }
-  const existing = loadContributor(github_username);
-  if (existing) {
-    return res.json({ contributor_id: existing.contributor_id, registration_token: existing.registration_token_plain, message: 'Already registered' });
-  }
+// GitHub OAuth registration flow — uses the Hive GitHub App as OAuth provider
+const CONTRIBUTOR_OAUTH_CLIENT_ID = process.env.HIVE_CONTRIBUTOR_OAUTH_CLIENT_ID
+  || (projectConfig.github_app || {}).oauth_client_id || '';
+const CONTRIBUTOR_OAUTH_CLIENT_SECRET = process.env.HIVE_CONTRIBUTOR_OAUTH_CLIENT_SECRET
+  || (projectConfig.github_app || {}).oauth_client_secret || '';
+const CONTRIBUTOR_OAUTH_STATES = new Map();
+const CONTRIBUTOR_OAUTH_STATE_TTL_MS = 600000;
 
+function createContributorProfile(githubUsername) {
   const contributorId = `c-${crypto.randomBytes(6).toString('hex')}`;
   const registrationToken = crypto.randomBytes(32).toString('hex');
-
   const profile = {
-    github_username,
+    github_username: githubUsername,
     contributor_id: contributorId,
     registration_token: crypto.createHash('sha256').update(registrationToken).digest('hex'),
     registration_token_plain: registrationToken,
@@ -3037,8 +3034,207 @@ app.post('/api/contribute/register', (req, res) => {
     rate_limits: { max_concurrent_tasks: 1, max_tasks_per_hour: 3, max_tasks_per_day: 10 },
   };
   saveContributor(profile);
+  return { profile, registrationToken };
+}
 
-  res.json({ contributor_id: contributorId, registration_token: registrationToken, message: 'Registered successfully' });
+// Contributor landing page
+app.get('/contribute', (_req, res) => {
+  const hubUrl = `${req.protocol === 'https' ? 'wss' : 'ws'}://${_req.get('host')}/contribute`;
+  const activeCount = contributorConnections.size;
+  const registered = listContributors().length;
+  const actionable = ((actionableCache.issues || {}).items || []).length;
+  res.send(`<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><title>Contribute to ${DASHBOARD_TITLE}</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #e6edf3; margin: 0; padding: 40px; max-width: 720px; margin: 0 auto; }
+  h1 { font-size: 2rem; margin-bottom: 8px; }
+  .subtitle { color: #8b949e; font-size: 1.1rem; margin-bottom: 32px; }
+  .stat-row { display: flex; gap: 16px; margin-bottom: 32px; }
+  .stat { background: #161b22; border: 1px solid #30363d; border-radius: 12px; padding: 16px 20px; flex: 1; text-align: center; }
+  .stat-num { font-size: 1.8rem; font-weight: 700; color: #58a6ff; }
+  .stat-label { font-size: 0.8rem; color: #8b949e; margin-top: 4px; }
+  .cta { display: inline-block; background: #238636; color: white; padding: 12px 24px; border-radius: 8px; text-decoration: none; font-size: 1rem; font-weight: 600; margin-top: 8px; }
+  .cta:hover { background: #2ea043; }
+  .steps { background: #161b22; border: 1px solid #30363d; border-radius: 12px; padding: 24px; margin-top: 24px; }
+  .steps h3 { margin-top: 0; color: #58a6ff; }
+  .steps ol { padding-left: 20px; line-height: 2; }
+  code { background: #0d1117; padding: 2px 8px; border-radius: 4px; font-size: 0.9rem; }
+  .how { margin-top: 32px; }
+  .how h3 { color: #e6edf3; }
+  .how p { color: #8b949e; line-height: 1.6; }
+  .tier-table { width: 100%; border-collapse: collapse; margin-top: 16px; }
+  .tier-table th, .tier-table td { padding: 8px 12px; text-align: left; border-bottom: 1px solid #30363d; font-size: 0.85rem; }
+  .tier-table th { color: #8b949e; font-weight: 600; }
+</style></head><body>
+  <h1>🐝 Contribute to ${esc(DASHBOARD_TITLE)}</h1>
+  <p class="subtitle">Donate your CLI + API tokens to help this project's AI agent swarm.</p>
+
+  <div class="stat-row">
+    <div class="stat"><div class="stat-num">${activeCount}</div><div class="stat-label">Active Contributors</div></div>
+    <div class="stat"><div class="stat-num">${registered}</div><div class="stat-label">Registered</div></div>
+    <div class="stat"><div class="stat-num">${actionable}</div><div class="stat-label">Items Needing Work</div></div>
+  </div>
+
+  <a href="/contribute/register" class="cta">Register with GitHub</a>
+
+  <div class="steps">
+    <h3>How it works</h3>
+    <ol>
+      <li><strong>Register</strong> — click the button above to authenticate with GitHub</li>
+      <li><strong>Install just</strong> — <code>brew install just</code> (macOS) or <code>cargo install just</code></li>
+      <li><strong>Clone the hive repo</strong> — <code>git clone https://github.com/kubestellar/hive</code></li>
+      <li><strong>Run</strong> — <code>just contribute-hive</code> (defaults to Claude Code, or <code>just contribute-hive gemini</code>)</li>
+      <li><strong>Log into your CLI</strong> — the container prompts you if needed</li>
+      <li><strong>Walk away</strong> — your agent pulls work from the queue automatically</li>
+    </ol>
+  </div>
+
+  <div class="how">
+    <h3>What you bring vs. what the hive provides</h3>
+    <p><strong>You bring:</strong> Your own CLI API tokens (Claude, Gemini, Copilot, Goose, Bob). You pay for your own model inference.</p>
+    <p><strong>The hive provides:</strong> Scoped GitHub access via a GitHub App. Your agent can create PRs and comment on issues without you sharing any GitHub credentials.</p>
+    <p>Neither side sees the other's secrets.</p>
+  </div>
+
+  <div class="how">
+    <h3>Trust tiers</h3>
+    <table class="tier-table">
+      <tr><th>Tier</th><th>Unlocked at</th><th>Can do</th></tr>
+      <tr><td>Newcomer</td><td>Registration</td><td>Comment on issues</td></tr>
+      <tr><td>Contributor</td><td>5 completed tasks</td><td>Create PRs, push code</td></tr>
+      <tr><td>Trusted</td><td>20 tasks + maintainer voucher</td><td>Merge PRs</td></tr>
+      <tr><td>Advisor</td><td>Registration (no API tokens needed)</td><td>Review agent PRs</td></tr>
+    </table>
+  </div>
+</body></html>`);
+});
+
+function esc(s) { return String(s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+
+// Step 1: Redirect to GitHub OAuth
+app.get('/contribute/register', (_req, res) => {
+  if (!CONTRIBUTOR_OAUTH_CLIENT_ID) {
+    return res.send(`<html><body style="font-family:monospace;background:#0d1117;color:#e6edf3;padding:40px">
+      <h2>Hive Contributor Registration</h2>
+      <p>GitHub OAuth is not configured on this hub.</p>
+      <p>Use the API endpoint instead:</p>
+      <pre style="background:#161b22;padding:16px;border-radius:8px">curl -X POST ${_req.protocol}://${_req.get('host')}/api/contribute/register \\
+  -H "Content-Type: application/json" \\
+  -d '{"github_username": "your-github-username"}'</pre>
+      <p>Or run: <code>just contribute-register</code></p>
+    </body></html>`);
+  }
+  const state = crypto.randomBytes(16).toString('hex');
+  CONTRIBUTOR_OAUTH_STATES.set(state, { created: Date.now() });
+  const redirectUri = `${_req.protocol}://${_req.get('host')}/contribute/callback`;
+  const authUrl = `https://github.com/login/oauth/authorize?client_id=${CONTRIBUTOR_OAUTH_CLIENT_ID}&redirect_uri=${encodeURIComponent(redirectUri)}&state=${state}&scope=read:user`;
+  res.redirect(authUrl);
+});
+
+// Step 2: OAuth callback
+app.get('/contribute/callback', async (req, res) => {
+  const { code, state } = req.query;
+  if (!code || !state) return res.status(400).send('Missing code or state');
+
+  const stored = CONTRIBUTOR_OAUTH_STATES.get(state);
+  if (!stored || Date.now() - stored.created > CONTRIBUTOR_OAUTH_STATE_TTL_MS) {
+    CONTRIBUTOR_OAUTH_STATES.delete(state);
+    return res.status(400).send('Invalid or expired state');
+  }
+  CONTRIBUTOR_OAUTH_STATES.delete(state);
+
+  try {
+    const https = require('https');
+    const tokenBody = JSON.stringify({
+      client_id: CONTRIBUTOR_OAUTH_CLIENT_ID,
+      client_secret: CONTRIBUTOR_OAUTH_CLIENT_SECRET,
+      code,
+      state,
+    });
+    const tokenResponse = await new Promise((resolve, reject) => {
+      const tokenReq = https.request({
+        hostname: 'github.com', path: '/login/oauth/access_token', method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'Content-Length': Buffer.byteLength(tokenBody) },
+      }, (tokenRes) => {
+        let data = '';
+        tokenRes.on('data', (d) => { data += d; });
+        tokenRes.on('end', () => { try { resolve(JSON.parse(data)); } catch (e) { reject(e); } });
+      });
+      tokenReq.on('error', reject);
+      tokenReq.write(tokenBody);
+      tokenReq.end();
+    });
+
+    if (!tokenResponse.access_token) {
+      return res.status(400).send(`OAuth failed: ${tokenResponse.error_description || tokenResponse.error || 'unknown'}`);
+    }
+
+    const userResponse = await new Promise((resolve, reject) => {
+      const userReq = https.request({
+        hostname: 'api.github.com', path: '/user', method: 'GET',
+        headers: { 'Authorization': `Bearer ${tokenResponse.access_token}`, 'User-Agent': 'Hive-Contributor-Registration', 'Accept': 'application/json' },
+      }, (userRes) => {
+        let data = '';
+        userRes.on('data', (d) => { data += d; });
+        userRes.on('end', () => { try { resolve(JSON.parse(data)); } catch (e) { reject(e); } });
+      });
+      userReq.on('error', reject);
+      userReq.end();
+    });
+
+    const githubUsername = userResponse.login;
+    if (!githubUsername) return res.status(400).send('Could not determine GitHub username');
+
+    const existing = loadContributor(githubUsername);
+    let regToken;
+    if (existing) {
+      regToken = existing.registration_token_plain;
+    } else {
+      const result = createContributorProfile(githubUsername);
+      regToken = result.registrationToken;
+    }
+
+    res.send(`<html><body style="font-family:monospace;background:#0d1117;color:#e6edf3;padding:40px">
+      <h2>Welcome to the Hive, @${githubUsername}!</h2>
+      <p>Your registration token (save this — it won't be shown again):</p>
+      <pre style="background:#161b22;padding:16px;border-radius:8px;user-select:all;cursor:pointer" onclick="navigator.clipboard.writeText(this.textContent)">${regToken}</pre>
+      <p style="color:#8b949e;font-size:0.85rem">Click the token to copy it.</p>
+      <h3 style="margin-top:24px">Next steps:</h3>
+      <pre style="background:#161b22;padding:16px;border-radius:8px"># Save your token
+mkdir -p ~/.config/hive
+cat > ~/.config/hive/contributor.env &lt;&lt;EOF
+HIVE_REGISTRATION_TOKEN=${regToken}
+HIVE_HUB=${req.protocol === 'https' ? 'wss' : 'ws'}://${req.get('host')}/contribute
+EOF
+
+# Start contributing
+just contribute-hive</pre>
+    </body></html>`);
+  } catch (err) {
+    res.status(500).send(`Registration error: ${err.message}`);
+  }
+});
+
+// Cleanup expired OAuth states every 5 minutes
+trackedInterval(() => {
+  const now = Date.now();
+  for (const [state, data] of CONTRIBUTOR_OAUTH_STATES) {
+    if (now - data.created > CONTRIBUTOR_OAUTH_STATE_TTL_MS) CONTRIBUTOR_OAUTH_STATES.delete(state);
+  }
+}, 300000);
+
+// Direct API registration (fallback for headless/CLI use)
+app.post('/api/contribute/register', (req, res) => {
+  const { github_username } = req.body;
+  if (!github_username || !/^[a-zA-Z0-9_-]+$/.test(github_username)) {
+    return res.status(400).json({ error: 'Invalid github_username' });
+  }
+  const existing = loadContributor(github_username);
+  if (existing) {
+    return res.json({ contributor_id: existing.contributor_id, registration_token: existing.registration_token_plain, message: 'Already registered' });
+  }
+  const { profile, registrationToken } = createContributorProfile(github_username);
+  res.json({ contributor_id: profile.contributor_id, registration_token: registrationToken, message: 'Registered successfully' });
 });
 
 // Contribute status
@@ -3121,6 +3317,20 @@ app.delete('/api/hives/:id', (req, res) => {
   const idx = (registry.hives || []).findIndex(h => h.id === req.params.id);
   if (idx === -1) return res.status(404).json({ error: 'Hive not found' });
   registry.hives.splice(idx, 1);
+  saveHiveRegistry(registry);
+  res.json({ ok: true });
+});
+
+// Heartbeat — remote hives ping with live stats
+app.post('/api/hives/:id/heartbeat', (req, res) => {
+  const registry = loadHiveRegistry();
+  const hive = (registry.hives || []).find(h => h.id === req.params.id);
+  if (!hive) return res.status(404).json({ error: 'Hive not found' });
+  const { active_contributors, active_agents, actionable_items } = req.body;
+  if (active_contributors !== undefined) hive.active_contributors = active_contributors;
+  if (active_agents !== undefined) hive.active_agents = active_agents;
+  if (actionable_items !== undefined) hive.actionable_items = actionable_items;
+  hive.last_heartbeat = new Date().toISOString();
   saveHiveRegistry(registry);
   res.json({ ok: true });
 });

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -3,6 +3,7 @@ const { execFile, execSync, spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
+const { WebSocketServer } = require('ws');
 
 const yaml = (() => { try { return require('js-yaml'); } catch (_) { return null; } })();
 
@@ -2820,6 +2821,391 @@ function shutdown(signal) {
 process.on('SIGTERM', () => shutdown('SIGTERM'));
 process.on('SIGINT', () => shutdown('SIGINT'));
 
-app.listen(PORT, () => {
+// ── Contribute-Hive: Remote contributor management ─────────────────────────
+const CONTRIBUTORS_DIR = '/etc/hive/contributors';
+const CONTRIBUTORS_METRICS_FILE = path.join(METRICS_DIR, 'contributors.json');
+const CONTRIBUTOR_RESTRICTIONS_FILE = path.join(RESTRICTIONS_DIR, 'contributor-default.json');
+const TOKEN_MINT_SCRIPT = path.join(HIVE_REPO_DIR, 'bin', 'gh-app-token.sh');
+const CONTRIBUTOR_HEARTBEAT_MS = 30000;
+const CONTRIBUTOR_HEARTBEAT_TIMEOUT_MS = 90000;
+const CONTRIBUTOR_TASK_TIMEOUT_MS = 1800000;
+const CONTRIBUTOR_TOKEN_REFRESH_MS = 3000000;
+const CONTRIBUTOR_AUTO_PROMOTE_THRESHOLD = 5;
+const CONTRIBUTOR_TRUSTED_THRESHOLD = 20;
+
+const contributorConnections = new Map();
+let contributorSeq = 0;
+
+function loadContributor(githubUsername) {
+  try {
+    const file = path.join(CONTRIBUTORS_DIR, `${githubUsername}.json`);
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (_) { return null; }
+}
+
+function saveContributor(profile) {
+  try {
+    if (!fs.existsSync(CONTRIBUTORS_DIR)) {
+      execSync(`sudo mkdir -p ${shellQuote(CONTRIBUTORS_DIR)} && sudo chown dev:dev ${shellQuote(CONTRIBUTORS_DIR)}`);
+    }
+    const file = path.join(CONTRIBUTORS_DIR, `${profile.github_username}.json`);
+    fs.writeFileSync(file, JSON.stringify(profile, null, 2));
+  } catch (e) { console.error('Failed to save contributor:', e.message); }
+}
+
+function listContributors() {
+  try {
+    if (!fs.existsSync(CONTRIBUTORS_DIR)) return [];
+    return fs.readdirSync(CONTRIBUTORS_DIR)
+      .filter(f => f.endsWith('.json'))
+      .map(f => { try { return JSON.parse(fs.readFileSync(path.join(CONTRIBUTORS_DIR, f), 'utf8')); } catch (_) { return null; } })
+      .filter(Boolean);
+  } catch (_) { return []; }
+}
+
+function mintScopedToken(tier) {
+  try {
+    const result = execSync(`${TOKEN_MINT_SCRIPT} --scoped ${tier}`, { encoding: 'utf8', timeout: 30000 });
+    return JSON.parse(result.trim());
+  } catch (e) {
+    console.error('Failed to mint scoped token:', e.message);
+    return null;
+  }
+}
+
+function persistContributorMetrics() {
+  const active = [];
+  for (const [id, conn] of contributorConnections) {
+    active.push({
+      contributor_id: id,
+      github_username: conn.profile.github_username,
+      trust_tier: conn.profile.trust_tier,
+      cli_backend: conn.cliBackend || 'unknown',
+      model: conn.model || '',
+      current_task: conn.currentTask ? { task_id: conn.currentTask.task_id, kind: conn.currentTask.kind, repo: conn.currentTask.repo, number: conn.currentTask.number } : null,
+      connected_at: conn.connectedAt,
+      last_tmux_output: conn.lastTmuxOutput || [],
+    });
+  }
+  try {
+    fs.writeFileSync(CONTRIBUTORS_METRICS_FILE, JSON.stringify({ active, updated_at: new Date().toISOString() }, null, 2));
+  } catch (_) {}
+}
+
+trackedInterval(persistContributorMetrics, REFRESH_MS);
+
+function selectTaskForContributor(profile) {
+  const items = (actionableCache.issues || {}).items || [];
+  const tier = profile.trust_tier;
+
+  for (const item of items) {
+    if (item.assigned_to) continue;
+    const labels = (item.labels || []).map(l => (typeof l === 'string' ? l : l.name || '').toLowerCase());
+    if (labels.some(l => l.includes('architecture') || l.includes('epic'))) continue;
+    if (tier === 'newcomer' && !labels.some(l => l.includes('good first issue') || l.includes('simple'))) continue;
+
+    item.assigned_to = { type: 'contributor', id: profile.contributor_id, assigned_at: new Date().toISOString() };
+    return {
+      task_id: `ct-${item.repo}-${item.number}-${Date.now()}`,
+      kind: 'issue',
+      repo: item.repo,
+      number: item.number,
+      title: item.title,
+      url: item.url,
+      labels: item.labels || [],
+      prompt: `You are a Hive contributor agent. Work on issue ${item.repo}#${item.number}: "${item.title}". Read the issue, understand the requirements, and implement a fix. Create a PR when done. Use conventional commits. Add label "contributor/${profile.github_username}" to any PRs you create.`,
+    };
+  }
+  return null;
+}
+
+// REST API for contributor management
+app.get('/api/contributors', (_req, res) => {
+  const profiles = listContributors();
+  const active = [];
+  for (const [id, conn] of contributorConnections) {
+    active.push(id);
+  }
+  res.json({ contributors: profiles.map(p => ({ ...p, active: active.includes(p.contributor_id) })) });
+});
+
+app.get('/api/contributors/:id', (req, res) => {
+  const profiles = listContributors();
+  const profile = profiles.find(p => p.contributor_id === req.params.id || p.github_username === req.params.id);
+  if (!profile) return res.status(404).json({ error: 'Contributor not found' });
+  const conn = contributorConnections.get(profile.contributor_id);
+  res.json({ ...profile, active: !!conn, currentTask: conn ? conn.currentTask : null, lastTmuxOutput: conn ? conn.lastTmuxOutput : [] });
+});
+
+app.put('/api/contributors/:id/trust', (req, res) => {
+  const profiles = listContributors();
+  const profile = profiles.find(p => p.contributor_id === req.params.id || p.github_username === req.params.id);
+  if (!profile) return res.status(404).json({ error: 'Contributor not found' });
+  const { tier } = req.body;
+  const validTiers = ['newcomer', 'contributor', 'trusted', 'advisor', 'revoked'];
+  if (!validTiers.includes(tier)) return res.status(400).json({ error: 'Invalid tier' });
+  profile.trust_tier = tier;
+  saveContributor(profile);
+  res.json({ ok: true, trust_tier: tier });
+});
+
+app.post('/api/contributors/:id/revoke', (req, res) => {
+  const profiles = listContributors();
+  const profile = profiles.find(p => p.contributor_id === req.params.id || p.github_username === req.params.id);
+  if (!profile) return res.status(404).json({ error: 'Contributor not found' });
+  profile.trust_tier = 'revoked';
+  saveContributor(profile);
+  const conn = contributorConnections.get(profile.contributor_id);
+  if (conn && conn.ws) {
+    conn.ws.send(JSON.stringify({ type: 'auth_failed', reason: 'Access revoked by administrator' }));
+    conn.ws.close();
+    contributorConnections.delete(profile.contributor_id);
+  }
+  res.json({ ok: true });
+});
+
+// Registration endpoint (simplified — real implementation would use GitHub OAuth)
+app.post('/api/contribute/register', (req, res) => {
+  const { github_username } = req.body;
+  if (!github_username || !/^[a-zA-Z0-9_-]+$/.test(github_username)) {
+    return res.status(400).json({ error: 'Invalid github_username' });
+  }
+  const existing = loadContributor(github_username);
+  if (existing) {
+    return res.json({ contributor_id: existing.contributor_id, registration_token: existing.registration_token_plain, message: 'Already registered' });
+  }
+
+  const contributorId = `c-${crypto.randomBytes(6).toString('hex')}`;
+  const registrationToken = crypto.randomBytes(32).toString('hex');
+
+  const profile = {
+    github_username,
+    contributor_id: contributorId,
+    registration_token: crypto.createHash('sha256').update(registrationToken).digest('hex'),
+    registration_token_plain: registrationToken,
+    trust_tier: 'newcomer',
+    registered_at: new Date().toISOString(),
+    total_tasks_completed: 0,
+    total_tasks_failed: 0,
+    rate_limits: { max_concurrent_tasks: 1, max_tasks_per_hour: 3, max_tasks_per_day: 10 },
+  };
+  saveContributor(profile);
+
+  res.json({ contributor_id: contributorId, registration_token: registrationToken, message: 'Registered successfully' });
+});
+
+// Contribute status
+app.get('/api/contribute/status', (_req, res) => {
+  res.json({
+    hub: 'online',
+    active_contributors: contributorConnections.size,
+    total_registered: listContributors().length,
+    actionable_items: ((actionableCache.issues || {}).items || []).length,
+  });
+});
+
+// WebSocket server for contributor agents
+const server = app.listen(PORT, () => {
   console.log(`🐝 Hive Dashboard running at http://localhost:${PORT}`);
+});
+
+const wss = new WebSocketServer({ server, path: '/contribute' });
+
+wss.on('connection', (ws) => {
+  let contributorProfile = null;
+  let connState = null;
+  const connId = `ws-${++contributorSeq}`;
+
+  console.log(`[contribute] New connection ${connId}`);
+
+  const nonce = crypto.randomBytes(16).toString('hex');
+  ws.send(JSON.stringify({ type: 'auth_challenge', seq: 1, nonce }));
+
+  const authTimeout = setTimeout(() => {
+    if (!contributorProfile) {
+      ws.send(JSON.stringify({ type: 'auth_failed', reason: 'Authentication timeout' }));
+      ws.close();
+    }
+  }, 30000);
+
+  let pingInterval = null;
+  let lastPong = Date.now();
+  let tokenRefreshInterval = null;
+  let taskTimeout = null;
+
+  ws.on('message', (data) => {
+    let msg;
+    try { msg = JSON.parse(data.toString()); } catch (_) { return; }
+
+    switch (msg.type) {
+      case 'auth_response': {
+        clearTimeout(authTimeout);
+        const token = msg.registration_token;
+        if (!token) {
+          ws.send(JSON.stringify({ type: 'auth_failed', reason: 'Missing registration token' }));
+          ws.close();
+          return;
+        }
+        const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+        const profiles = listContributors();
+        contributorProfile = profiles.find(p => p.registration_token === tokenHash);
+        if (!contributorProfile) {
+          ws.send(JSON.stringify({ type: 'auth_failed', reason: 'Invalid registration token' }));
+          ws.close();
+          return;
+        }
+        if (contributorProfile.trust_tier === 'revoked') {
+          ws.send(JSON.stringify({ type: 'auth_failed', reason: 'Access has been revoked' }));
+          ws.close();
+          return;
+        }
+
+        connState = {
+          ws,
+          profile: contributorProfile,
+          cliBackend: msg.cli_backend || 'unknown',
+          model: msg.model || '',
+          connectedAt: new Date().toISOString(),
+          currentTask: null,
+          lastTmuxOutput: [],
+        };
+        contributorConnections.set(contributorProfile.contributor_id, connState);
+
+        ws.send(JSON.stringify({
+          type: 'auth_ok',
+          seq: 2,
+          contributor_id: contributorProfile.contributor_id,
+          trust_tier: contributorProfile.trust_tier,
+          permissions: contributorProfile.trust_tier === 'newcomer' ? ['issues:read', 'issues:comment'] : ['issues:read', 'issues:write', 'contents:write', 'pulls:write'],
+        }));
+
+        console.log(`[contribute] Authenticated: ${contributorProfile.github_username} (${contributorProfile.trust_tier}) via ${msg.cli_backend}`);
+
+        pingInterval = setInterval(() => {
+          if (Date.now() - lastPong > CONTRIBUTOR_HEARTBEAT_TIMEOUT_MS) {
+            console.log(`[contribute] Heartbeat timeout for ${contributorProfile.github_username}`);
+            ws.terminate();
+            return;
+          }
+          ws.send(JSON.stringify({ type: 'ping', seq: ++contributorSeq }));
+        }, CONTRIBUTOR_HEARTBEAT_MS);
+        break;
+      }
+
+      case 'ready': {
+        if (!contributorProfile || !connState) return;
+        const task = selectTaskForContributor(contributorProfile);
+        if (!task) {
+          console.log(`[contribute] No tasks available for ${contributorProfile.github_username}`);
+          return;
+        }
+        const tokenData = mintScopedToken(contributorProfile.trust_tier);
+        if (!tokenData) {
+          console.log(`[contribute] Failed to mint token for ${contributorProfile.github_username}`);
+          return;
+        }
+
+        let restrictions = { rules: [] };
+        try { restrictions = JSON.parse(fs.readFileSync(CONTRIBUTOR_RESTRICTIONS_FILE, 'utf8')); } catch (_) {}
+
+        connState.currentTask = task;
+        ws.send(JSON.stringify({
+          type: 'task_assign',
+          seq: ++contributorSeq,
+          ...task,
+          github_token: tokenData.token,
+          token_expires_at: tokenData.expires_at,
+          restrictions,
+          contributor_labels: [`contributor/${contributorProfile.github_username}`, `cli/${connState.cliBackend}`],
+        }));
+
+        console.log(`[contribute] Assigned ${task.kind} ${task.repo}#${task.number} to ${contributorProfile.github_username}`);
+
+        if (tokenRefreshInterval) clearInterval(tokenRefreshInterval);
+        tokenRefreshInterval = setInterval(() => {
+          const refreshed = mintScopedToken(contributorProfile.trust_tier);
+          if (refreshed) {
+            ws.send(JSON.stringify({ type: 'token_refresh', seq: ++contributorSeq, task_id: task.task_id, github_token: refreshed.token, token_expires_at: refreshed.expires_at }));
+          }
+        }, CONTRIBUTOR_TOKEN_REFRESH_MS);
+
+        if (taskTimeout) clearTimeout(taskTimeout);
+        taskTimeout = setTimeout(() => {
+          if (connState && connState.currentTask && connState.currentTask.task_id === task.task_id) {
+            ws.send(JSON.stringify({ type: 'task_revoke', seq: ++contributorSeq, task_id: task.task_id, reason: 'timeout' }));
+            connState.currentTask = null;
+            console.log(`[contribute] Task timeout for ${contributorProfile.github_username}: ${task.task_id}`);
+          }
+        }, CONTRIBUTOR_TASK_TIMEOUT_MS);
+        break;
+      }
+
+      case 'task_accepted':
+        break;
+
+      case 'task_progress': {
+        if (connState) {
+          connState.lastTmuxOutput = msg.tmux_output || [];
+        }
+        break;
+      }
+
+      case 'task_complete': {
+        if (!contributorProfile || !connState) return;
+        console.log(`[contribute] Task complete by ${contributorProfile.github_username}: ${msg.task_id} — ${msg.result}`);
+        if (connState) {
+          connState.currentTask = null;
+          connState.lastTmuxOutput = msg.tmux_output || [];
+        }
+        if (tokenRefreshInterval) { clearInterval(tokenRefreshInterval); tokenRefreshInterval = null; }
+        if (taskTimeout) { clearTimeout(taskTimeout); taskTimeout = null; }
+
+        contributorProfile.total_tasks_completed = (contributorProfile.total_tasks_completed || 0) + 1;
+        if (contributorProfile.trust_tier === 'newcomer' && contributorProfile.total_tasks_completed >= CONTRIBUTOR_AUTO_PROMOTE_THRESHOLD) {
+          contributorProfile.trust_tier = 'contributor';
+          console.log(`[contribute] Auto-promoted ${contributorProfile.github_username} to contributor`);
+        }
+        if (contributorProfile.trust_tier === 'contributor' && contributorProfile.total_tasks_completed >= CONTRIBUTOR_TRUSTED_THRESHOLD) {
+          console.log(`[contribute] ${contributorProfile.github_username} eligible for trusted tier (needs maintainer voucher)`);
+        }
+        saveContributor(contributorProfile);
+        break;
+      }
+
+      case 'task_failed': {
+        if (!contributorProfile || !connState) return;
+        console.log(`[contribute] Task failed by ${contributorProfile.github_username}: ${msg.task_id} — ${msg.reason}`);
+        if (connState) connState.currentTask = null;
+        if (tokenRefreshInterval) { clearInterval(tokenRefreshInterval); tokenRefreshInterval = null; }
+        if (taskTimeout) { clearTimeout(taskTimeout); taskTimeout = null; }
+        contributorProfile.total_tasks_failed = (contributorProfile.total_tasks_failed || 0) + 1;
+        saveContributor(contributorProfile);
+        break;
+      }
+
+      case 'pong':
+        lastPong = Date.now();
+        break;
+
+      case 'ping':
+        ws.send(JSON.stringify({ type: 'pong', seq: msg.seq }));
+        break;
+    }
+  });
+
+  ws.on('close', () => {
+    clearTimeout(authTimeout);
+    if (pingInterval) clearInterval(pingInterval);
+    if (tokenRefreshInterval) clearInterval(tokenRefreshInterval);
+    if (taskTimeout) clearTimeout(taskTimeout);
+    if (contributorProfile) {
+      contributorConnections.delete(contributorProfile.contributor_id);
+      console.log(`[contribute] Disconnected: ${contributorProfile.github_username}`);
+    }
+    persistContributorMetrics();
+  });
+
+  ws.on('error', (err) => {
+    console.error(`[contribute] WebSocket error for ${connId}:`, err.message);
+  });
 });

--- a/dashboard/test/contribute.test.js
+++ b/dashboard/test/contribute.test.js
@@ -1,0 +1,502 @@
+'use strict';
+
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('http');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const WebSocket = require('ws');
+
+const TEST_PORT = 13001 + Math.floor(Math.random() * 1000);
+const TEST_CONTRIBUTORS_DIR = path.join(os.tmpdir(), `hive-test-contributors-${Date.now()}`);
+const TEST_METRICS_DIR = path.join(os.tmpdir(), `hive-test-metrics-${Date.now()}`);
+const TEST_FEDERATION_DIR = path.join(os.tmpdir(), `hive-test-federation-${Date.now()}`);
+const TEST_RESTRICTIONS_DIR = path.join(os.tmpdir(), `hive-test-restrictions-${Date.now()}`);
+
+function httpRequest(method, urlPath, body) {
+  return new Promise((resolve, reject) => {
+    const opts = { hostname: '127.0.0.1', port: TEST_PORT, path: urlPath, method, headers: {} };
+    if (body) {
+      const data = JSON.stringify(body);
+      opts.headers['Content-Type'] = 'application/json';
+      opts.headers['Content-Length'] = Buffer.byteLength(data);
+    }
+    const req = http.request(opts, (res) => {
+      let chunks = '';
+      res.on('data', (d) => { chunks += d; });
+      res.on('end', () => {
+        try { resolve({ status: res.statusCode, body: JSON.parse(chunks) }); }
+        catch (_) { resolve({ status: res.statusCode, body: chunks }); }
+      });
+    });
+    req.on('error', reject);
+    if (body) req.write(JSON.stringify(body));
+    req.end();
+  });
+}
+
+function wsConnectAndRecvFirst(urlPath) {
+  return new Promise((resolve, reject) => {
+    const TIMEOUT_MS = 5000;
+    const ws = new WebSocket(`ws://127.0.0.1:${TEST_PORT}${urlPath}`);
+    const timer = setTimeout(() => { ws.terminate(); reject(new Error('ws timeout')); }, TIMEOUT_MS);
+    ws.once('message', (data) => {
+      clearTimeout(timer);
+      resolve({ ws, firstMessage: JSON.parse(data.toString()) });
+    });
+    ws.on('error', (err) => { clearTimeout(timer); reject(err); });
+  });
+}
+
+function wsRecv(ws, timeout) {
+  const RECV_TIMEOUT_MS = timeout || 5000;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('ws recv timeout')), RECV_TIMEOUT_MS);
+    ws.once('message', (data) => {
+      clearTimeout(timer);
+      resolve(JSON.parse(data.toString()));
+    });
+  });
+}
+
+// ── Minimal server setup for testing ───────────────────────────────────────
+// We can't import server.js directly (it starts listening and reads /etc/hive).
+// Instead, we test the contributor module functions in isolation and run a
+// lightweight Express app that mirrors the contribute endpoints.
+
+const express = require('express');
+const { WebSocketServer } = require('ws');
+
+let app, server, wss;
+
+function createTestServer() {
+  app = express();
+  app.use(express.json());
+
+  const contributorConnections = new Map();
+  let contributorSeq = 0;
+
+  function loadContributor(username) {
+    try {
+      return JSON.parse(fs.readFileSync(path.join(TEST_CONTRIBUTORS_DIR, `${username}.json`), 'utf8'));
+    } catch (_) { return null; }
+  }
+
+  function saveContributor(profile) {
+    fs.writeFileSync(
+      path.join(TEST_CONTRIBUTORS_DIR, `${profile.github_username}.json`),
+      JSON.stringify(profile, null, 2)
+    );
+  }
+
+  function listContributors() {
+    try {
+      return fs.readdirSync(TEST_CONTRIBUTORS_DIR)
+        .filter(f => f.endsWith('.json'))
+        .map(f => { try { return JSON.parse(fs.readFileSync(path.join(TEST_CONTRIBUTORS_DIR, f), 'utf8')); } catch (_) { return null; } })
+        .filter(Boolean);
+    } catch (_) { return []; }
+  }
+
+  // Registration
+  app.post('/api/contribute/register', (req, res) => {
+    const { github_username } = req.body;
+    if (!github_username || !/^[a-zA-Z0-9_-]+$/.test(github_username)) {
+      return res.status(400).json({ error: 'Invalid github_username' });
+    }
+    const existing = loadContributor(github_username);
+    if (existing) {
+      return res.json({ contributor_id: existing.contributor_id, registration_token: existing.registration_token_plain, message: 'Already registered' });
+    }
+    const contributorId = `c-${crypto.randomBytes(6).toString('hex')}`;
+    const registrationToken = crypto.randomBytes(32).toString('hex');
+    const profile = {
+      github_username,
+      contributor_id: contributorId,
+      registration_token: crypto.createHash('sha256').update(registrationToken).digest('hex'),
+      registration_token_plain: registrationToken,
+      trust_tier: 'newcomer',
+      registered_at: new Date().toISOString(),
+      total_tasks_completed: 0,
+      total_tasks_failed: 0,
+      rate_limits: { max_concurrent_tasks: 1, max_tasks_per_hour: 3, max_tasks_per_day: 10 },
+    };
+    saveContributor(profile);
+    res.json({ contributor_id: contributorId, registration_token: registrationToken, message: 'Registered successfully' });
+  });
+
+  // Status
+  app.get('/api/contribute/status', (_req, res) => {
+    res.json({
+      hub: 'online',
+      active_contributors: contributorConnections.size,
+      total_registered: listContributors().length,
+      actionable_items: 0,
+    });
+  });
+
+  // List contributors
+  app.get('/api/contributors', (_req, res) => {
+    const profiles = listContributors();
+    const activeIds = [...contributorConnections.keys()];
+    res.json({ contributors: profiles.map(p => ({ ...p, active: activeIds.includes(p.contributor_id) })) });
+  });
+
+  // Get single contributor
+  app.get('/api/contributors/:id', (req, res) => {
+    const profiles = listContributors();
+    const profile = profiles.find(p => p.contributor_id === req.params.id || p.github_username === req.params.id);
+    if (!profile) return res.status(404).json({ error: 'Contributor not found' });
+    res.json(profile);
+  });
+
+  // Trust tier change
+  app.put('/api/contributors/:id/trust', (req, res) => {
+    const profiles = listContributors();
+    const profile = profiles.find(p => p.contributor_id === req.params.id || p.github_username === req.params.id);
+    if (!profile) return res.status(404).json({ error: 'Contributor not found' });
+    const { tier } = req.body;
+    const validTiers = ['newcomer', 'contributor', 'trusted', 'advisor', 'revoked'];
+    if (!validTiers.includes(tier)) return res.status(400).json({ error: 'Invalid tier' });
+    profile.trust_tier = tier;
+    saveContributor(profile);
+    res.json({ ok: true, trust_tier: tier });
+  });
+
+  // Revoke
+  app.post('/api/contributors/:id/revoke', (req, res) => {
+    const profiles = listContributors();
+    const profile = profiles.find(p => p.contributor_id === req.params.id || p.github_username === req.params.id);
+    if (!profile) return res.status(404).json({ error: 'Contributor not found' });
+    profile.trust_tier = 'revoked';
+    saveContributor(profile);
+    const conn = contributorConnections.get(profile.contributor_id);
+    if (conn && conn.ws) {
+      conn.ws.send(JSON.stringify({ type: 'auth_failed', reason: 'Access revoked' }));
+      conn.ws.close();
+      contributorConnections.delete(profile.contributor_id);
+    }
+    res.json({ ok: true });
+  });
+
+  // Federation
+  const registryFile = path.join(TEST_FEDERATION_DIR, 'registry.json');
+  function loadRegistry() { try { return JSON.parse(fs.readFileSync(registryFile, 'utf8')); } catch (_) { return { hives: [] }; } }
+  function saveRegistry(d) { fs.writeFileSync(registryFile, JSON.stringify(d)); }
+
+  app.get('/api/hives', (_req, res) => {
+    res.json(loadRegistry());
+  });
+
+  app.post('/api/hives/register', (req, res) => {
+    const { project_name, org, hub_url } = req.body;
+    if (!project_name || !org || !hub_url) return res.status(400).json({ error: 'Missing fields' });
+    const registry = loadRegistry();
+    const hiveId = `hive-${org}-${project_name}`.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+    registry.hives = registry.hives || [];
+    registry.hives.push({ id: hiveId, project_name, org, hub_url, registered_at: new Date().toISOString() });
+    saveRegistry(registry);
+    res.json({ ok: true });
+  });
+
+  app.post('/api/hives/:id/heartbeat', (req, res) => {
+    const registry = loadRegistry();
+    const hive = (registry.hives || []).find(h => h.id === req.params.id);
+    if (!hive) return res.status(404).json({ error: 'Hive not found' });
+    hive.last_heartbeat = new Date().toISOString();
+    hive.active_contributors = req.body.active_contributors || 0;
+    saveRegistry(registry);
+    res.json({ ok: true });
+  });
+
+  app.delete('/api/hives/:id', (req, res) => {
+    const registry = loadRegistry();
+    const idx = (registry.hives || []).findIndex(h => h.id === req.params.id);
+    if (idx === -1) return res.status(404).json({ error: 'Not found' });
+    registry.hives.splice(idx, 1);
+    saveRegistry(registry);
+    res.json({ ok: true });
+  });
+
+  server = app.listen(TEST_PORT);
+
+  // WebSocket server
+  wss = new WebSocketServer({ server, path: '/contribute' });
+  wss.on('connection', (ws) => {
+    const nonce = crypto.randomBytes(16).toString('hex');
+    ws.send(JSON.stringify({ type: 'auth_challenge', seq: 1, nonce }));
+
+    ws.on('message', (data) => {
+      let msg;
+      try { msg = JSON.parse(data.toString()); } catch (_) { return; }
+
+      if (msg.type === 'auth_response') {
+        const token = msg.registration_token;
+        if (!token) {
+          ws.send(JSON.stringify({ type: 'auth_failed', reason: 'Missing token' }));
+          ws.close();
+          return;
+        }
+        const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+        const profiles = listContributors();
+        const profile = profiles.find(p => p.registration_token === tokenHash);
+        if (!profile) {
+          ws.send(JSON.stringify({ type: 'auth_failed', reason: 'Invalid token' }));
+          ws.close();
+          return;
+        }
+        if (profile.trust_tier === 'revoked') {
+          ws.send(JSON.stringify({ type: 'auth_failed', reason: 'Revoked' }));
+          ws.close();
+          return;
+        }
+        contributorConnections.set(profile.contributor_id, { ws, profile });
+        ws.send(JSON.stringify({ type: 'auth_ok', seq: 2, contributor_id: profile.contributor_id, trust_tier: profile.trust_tier }));
+      }
+
+      if (msg.type === 'pong') { /* heartbeat ack */ }
+      if (msg.type === 'ping') { ws.send(JSON.stringify({ type: 'pong', seq: msg.seq })); }
+    });
+
+    ws.on('close', () => {
+      for (const [id, conn] of contributorConnections) {
+        if (conn.ws === ws) { contributorConnections.delete(id); break; }
+      }
+    });
+  });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('contribute-hive', () => {
+  before(async () => {
+    fs.mkdirSync(TEST_CONTRIBUTORS_DIR, { recursive: true });
+    fs.mkdirSync(TEST_METRICS_DIR, { recursive: true });
+    fs.mkdirSync(TEST_FEDERATION_DIR, { recursive: true });
+    fs.mkdirSync(TEST_RESTRICTIONS_DIR, { recursive: true });
+    createTestServer();
+    await new Promise((resolve) => { server.on('listening', resolve); });
+  });
+
+  after(() => {
+    if (wss) wss.close();
+    if (server) server.close();
+    fs.rmSync(TEST_CONTRIBUTORS_DIR, { recursive: true, force: true });
+    fs.rmSync(TEST_METRICS_DIR, { recursive: true, force: true });
+    fs.rmSync(TEST_FEDERATION_DIR, { recursive: true, force: true });
+    fs.rmSync(TEST_RESTRICTIONS_DIR, { recursive: true, force: true });
+  });
+
+  describe('registration', () => {
+    it('registers a new contributor', async () => {
+      const res = await httpRequest('POST', '/api/contribute/register', { github_username: 'testuser1' });
+      assert.equal(res.status, 200);
+      assert.equal(res.body.message, 'Registered successfully');
+      assert.ok(res.body.contributor_id.startsWith('c-'));
+      assert.ok(res.body.registration_token.length > 0);
+    });
+
+    it('returns existing profile on re-registration', async () => {
+      const res1 = await httpRequest('POST', '/api/contribute/register', { github_username: 'testuser-dupe' });
+      const res2 = await httpRequest('POST', '/api/contribute/register', { github_username: 'testuser-dupe' });
+      assert.equal(res2.status, 200);
+      assert.equal(res2.body.message, 'Already registered');
+      assert.equal(res2.body.contributor_id, res1.body.contributor_id);
+    });
+
+    it('rejects invalid username', async () => {
+      const res = await httpRequest('POST', '/api/contribute/register', { github_username: 'bad user!' });
+      assert.equal(res.status, 400);
+    });
+
+    it('rejects empty username', async () => {
+      const res = await httpRequest('POST', '/api/contribute/register', { github_username: '' });
+      assert.equal(res.status, 400);
+    });
+  });
+
+  describe('contributor management', () => {
+    let contributorId;
+    let regToken;
+
+    before(async () => {
+      const res = await httpRequest('POST', '/api/contribute/register', { github_username: 'managed-user' });
+      contributorId = res.body.contributor_id;
+      regToken = res.body.registration_token;
+    });
+
+    it('lists contributors', async () => {
+      const res = await httpRequest('GET', '/api/contributors');
+      assert.equal(res.status, 200);
+      assert.ok(Array.isArray(res.body.contributors));
+      assert.ok(res.body.contributors.some(c => c.github_username === 'managed-user'));
+    });
+
+    it('gets a single contributor by ID', async () => {
+      const res = await httpRequest('GET', `/api/contributors/${contributorId}`);
+      assert.equal(res.status, 200);
+      assert.equal(res.body.github_username, 'managed-user');
+      assert.equal(res.body.trust_tier, 'newcomer');
+    });
+
+    it('gets a contributor by username', async () => {
+      const res = await httpRequest('GET', '/api/contributors/managed-user');
+      assert.equal(res.status, 200);
+      assert.equal(res.body.contributor_id, contributorId);
+    });
+
+    it('returns 404 for unknown contributor', async () => {
+      const res = await httpRequest('GET', '/api/contributors/nonexistent');
+      assert.equal(res.status, 404);
+    });
+
+    it('changes trust tier', async () => {
+      const res = await httpRequest('PUT', `/api/contributors/${contributorId}/trust`, { tier: 'contributor' });
+      assert.equal(res.status, 200);
+      assert.equal(res.body.trust_tier, 'contributor');
+
+      const check = await httpRequest('GET', `/api/contributors/${contributorId}`);
+      assert.equal(check.body.trust_tier, 'contributor');
+    });
+
+    it('rejects invalid trust tier', async () => {
+      const res = await httpRequest('PUT', `/api/contributors/${contributorId}/trust`, { tier: 'superadmin' });
+      assert.equal(res.status, 400);
+    });
+
+    it('revokes a contributor', async () => {
+      const regRes = await httpRequest('POST', '/api/contribute/register', { github_username: 'revoke-target' });
+      const res = await httpRequest('POST', `/api/contributors/${regRes.body.contributor_id}/revoke`);
+      assert.equal(res.status, 200);
+
+      const check = await httpRequest('GET', `/api/contributors/${regRes.body.contributor_id}`);
+      assert.equal(check.body.trust_tier, 'revoked');
+    });
+  });
+
+  describe('hub status', () => {
+    it('returns hub status', async () => {
+      const res = await httpRequest('GET', '/api/contribute/status');
+      assert.equal(res.status, 200);
+      assert.equal(res.body.hub, 'online');
+      assert.equal(typeof res.body.active_contributors, 'number');
+      assert.equal(typeof res.body.total_registered, 'number');
+    });
+  });
+
+  describe('WebSocket authentication', () => {
+    let regToken;
+
+    before(async () => {
+      const res = await httpRequest('POST', '/api/contribute/register', { github_username: 'ws-test-user' });
+      regToken = res.body.registration_token;
+    });
+
+    it('sends auth_challenge on connect', async () => {
+      const { ws, firstMessage } = await wsConnectAndRecvFirst('/contribute');
+      assert.equal(firstMessage.type, 'auth_challenge');
+      assert.ok(firstMessage.nonce);
+      ws.close();
+    });
+
+    it('authenticates with valid token', async () => {
+      const { ws, firstMessage } = await wsConnectAndRecvFirst('/contribute');
+      assert.equal(firstMessage.type, 'auth_challenge');
+
+      ws.send(JSON.stringify({ type: 'auth_response', registration_token: regToken, cli_backend: 'claude', model: 'opus-4-6' }));
+      const authOk = await wsRecv(ws);
+      assert.equal(authOk.type, 'auth_ok');
+      assert.ok(authOk.contributor_id);
+      assert.equal(authOk.trust_tier, 'newcomer');
+      ws.close();
+    });
+
+    it('rejects invalid token', async () => {
+      const { ws } = await wsConnectAndRecvFirst('/contribute');
+      ws.send(JSON.stringify({ type: 'auth_response', registration_token: 'bogus-token' }));
+      const msg = await wsRecv(ws);
+      assert.equal(msg.type, 'auth_failed');
+      assert.match(msg.reason, /Invalid/i);
+    });
+
+    it('rejects revoked contributor', async () => {
+      const reg = await httpRequest('POST', '/api/contribute/register', { github_username: 'revoked-ws-user2' });
+      await httpRequest('POST', `/api/contributors/${reg.body.contributor_id}/revoke`);
+
+      const { ws } = await wsConnectAndRecvFirst('/contribute');
+      ws.send(JSON.stringify({ type: 'auth_response', registration_token: reg.body.registration_token }));
+      const msg = await wsRecv(ws);
+      assert.equal(msg.type, 'auth_failed');
+      assert.match(msg.reason, /[Rr]evok/);
+    });
+
+    it('responds to ping with pong', async () => {
+      const { ws } = await wsConnectAndRecvFirst('/contribute');
+      ws.send(JSON.stringify({ type: 'auth_response', registration_token: regToken, cli_backend: 'claude' }));
+      await wsRecv(ws);
+
+      ws.send(JSON.stringify({ type: 'ping', seq: 42 }));
+      const pong = await wsRecv(ws);
+      assert.equal(pong.type, 'pong');
+      assert.equal(pong.seq, 42);
+      ws.close();
+    });
+  });
+
+  describe('federation registry', () => {
+    it('starts with empty hive list', async () => {
+      const res = await httpRequest('GET', '/api/hives');
+      assert.equal(res.status, 200);
+      assert.ok(Array.isArray(res.body.hives));
+    });
+
+    it('registers a hive', async () => {
+      const res = await httpRequest('POST', '/api/hives/register', {
+        project_name: 'test-project', org: 'test-org', hub_url: 'wss://test:3001/contribute',
+      });
+      assert.equal(res.status, 200);
+      assert.equal(res.body.ok, true);
+    });
+
+    it('lists registered hives', async () => {
+      const res = await httpRequest('GET', '/api/hives');
+      assert.ok(res.body.hives.some(h => h.project_name === 'test-project'));
+    });
+
+    it('rejects registration with missing fields', async () => {
+      const res = await httpRequest('POST', '/api/hives/register', { project_name: 'x' });
+      assert.equal(res.status, 400);
+    });
+
+    it('receives heartbeat', async () => {
+      const list = await httpRequest('GET', '/api/hives');
+      const hive = list.body.hives.find(h => h.project_name === 'test-project');
+      assert.ok(hive);
+
+      const res = await httpRequest('POST', `/api/hives/${hive.id}/heartbeat`, { active_contributors: 5 });
+      assert.equal(res.status, 200);
+
+      const updated = await httpRequest('GET', '/api/hives');
+      const refreshed = updated.body.hives.find(h => h.id === hive.id);
+      assert.equal(refreshed.active_contributors, 5);
+      assert.ok(refreshed.last_heartbeat);
+    });
+
+    it('returns 404 for heartbeat to unknown hive', async () => {
+      const res = await httpRequest('POST', '/api/hives/hive-nonexistent/heartbeat', { active_contributors: 1 });
+      assert.equal(res.status, 404);
+    });
+
+    it('deletes a hive', async () => {
+      const list = await httpRequest('GET', '/api/hives');
+      const hive = list.body.hives.find(h => h.project_name === 'test-project');
+      const res = await httpRequest('DELETE', `/api/hives/${hive.id}`);
+      assert.equal(res.status, 200);
+
+      const after = await httpRequest('GET', '/api/hives');
+      assert.ok(!after.body.hives.some(h => h.project_name === 'test-project'));
+    });
+  });
+});

--- a/docs/federation-design.md
+++ b/docs/federation-design.md
@@ -1,0 +1,167 @@
+# Hive Federation: Multi-Project Agent Swarm Network
+
+## Overview
+
+Hive Federation allows any open source project to run their own Hive instance
+and join a network where contributors can discover and join any participating
+project's swarm. A contributor runs `just contribute-browse` to find projects
+that need help, then `just contribute-hive` pointed at that project's hub.
+
+## How a New Project Signs Up
+
+### 1. Install the Hive GitHub App
+
+The project maintainer installs the shared [Hive GitHub App](https://github.com/apps/kubestellar-hive-bot) on their GitHub org/repos. This gives their Hive instance the ability to mint scoped installation tokens for contributors.
+
+### 2. Generate Starter Config
+
+```bash
+curl -X POST https://hive.kubestellar.io/api/hives/onboard \
+  -H "Content-Type: application/json" \
+  -d '{
+    "project_name": "drasi",
+    "org": "drasi-project",
+    "repos": ["drasi-project/drasi-platform", "drasi-project/drasi-docs"],
+    "github_app_id": "123456",
+    "github_app_installation_id": "789012"
+  }'
+```
+
+Returns:
+- `hive-project.yaml` — project config with repos, agents, dashboard settings
+- `docker-compose.yaml` — ready to deploy
+- Step-by-step instructions
+
+### 3. Deploy Their Hive
+
+```bash
+# On their server/VM
+mkdir -p /etc/hive
+# Save hive-project.yaml to /etc/hive/
+# Save GitHub App private key to /etc/hive/gh-app-key.pem
+docker compose up -d
+```
+
+The Hive starts with `scanner` and `supervisor` agents by default.
+The project can enable more agents as their needs grow.
+
+### 4. Register with the Federation
+
+```bash
+curl -X POST https://hive.kubestellar.io/api/hives/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "project_name": "drasi",
+    "org": "drasi-project",
+    "hub_url": "wss://drasi-hive.example.com:3001/contribute",
+    "dashboard_url": "https://drasi-hive.example.com:3001",
+    "contact_email": "maintainer@drasi.io"
+  }'
+```
+
+Now the project appears in `just contribute-browse` and on the
+federation directory at `https://hive.kubestellar.io/api/hives`.
+
+## Contributor Flow
+
+```
+$ just contribute-browse
+
+=== Available Hives ===
+
+  KubeStellar Console (kubestellar)
+    Hub: wss://hive.kubestellar.io:3001/contribute
+    Dashboard: https://hive.kubestellar.io:3001
+    Contributors: 12 active
+    Actionable: 8 items
+
+  Drasi (drasi-project)
+    Hub: wss://drasi-hive.example.com:3001/contribute
+    Dashboard: https://drasi-hive.example.com:3001
+    Contributors: 3 active
+    Actionable: 15 items
+
+  Keptn (keptn)
+    Hub: wss://keptn-hive.cncf.io:3001/contribute
+    Dashboard: https://keptn-hive.cncf.io:3001
+    Contributors: 0 active
+    Actionable: 23 items
+```
+
+The contributor can then target a specific hive:
+
+```bash
+HIVE_HUB=wss://drasi-hive.example.com:3001/contribute just contribute-hive
+```
+
+Or register with multiple hives and switch between them.
+
+## Federation Architecture
+
+```
+┌──────────────────────────┐
+│  Federation Registry     │  hive.kubestellar.io
+│  GET /api/hives          │  (the KubeStellar hive doubles as registry)
+│  POST /api/hives/register│
+└──────────┬───────────────┘
+           │ lists
+    ┌──────┴──────┬──────────────┐
+    ▼             ▼              ▼
+┌─────────┐ ┌─────────┐  ┌─────────┐
+│ KS Hive │ │ Drasi   │  │ Keptn   │
+│ Hub     │ │ Hive Hub│  │ Hive Hub│
+│ :3001   │ │ :3001   │  │ :3001   │
+└────┬────┘ └────┬────┘  └────┬────┘
+     │           │            │
+  Contributors connect directly to each hub
+```
+
+Each hive is fully independent:
+- Own GitHub App credentials
+- Own agent fleet
+- Own work queue
+- Own contributor registry
+- Own trust tiers
+
+The federation registry is just a directory — it doesn't proxy traffic or
+manage credentials across hives. Each hub handles its own WebSocket
+connections and token minting.
+
+## What Each Hive Gets
+
+- **Dashboard** at port 3001 with agent status, queue, sparklines
+- **Agent fleet** (scanner, supervisor, + whatever they enable)
+- **Contributor WebSocket** at `/contribute`
+- **Scoped GitHub tokens** via the shared Hive GitHub App
+- **Governor** that adapts agent cadence to queue depth
+- **Nous Strategy Lab** for automated experimentation (optional)
+
+## Future: Cross-Hive Contributor Reputation
+
+A contributor who builds trust in one hive could have that reputation
+portable to other hives. A signed attestation from Hive A saying
+"this contributor completed 20 tasks with 0 revocations" could be
+presented to Hive B to skip the newcomer tier.
+
+This is out of scope for the initial implementation but the
+per-hive contributor profile (`/etc/hive/contributors/<user>.json`)
+already tracks the data needed to issue such attestations.
+
+## Implementation Status
+
+### Done (in PR #798)
+- `GET /api/hives` — list registered hives
+- `POST /api/hives/register` — register a remote hive
+- `DELETE /api/hives/:id` — remove a hive
+- `POST /api/hives/onboard` — generate starter config
+- `just contribute-browse` — discover available hives
+- Federation registry storage at `/etc/hive/federation/registry.json`
+
+### TODO
+- [ ] Heartbeat: registered hives periodically ping the registry with
+      their current active contributor count and actionable items
+- [ ] Web UI: add a "Join a Hive" page at `/contribute` with project
+      cards showing description, star count, contributor needs
+- [ ] GitHub App installation guide with screenshots
+- [ ] Cross-hive reputation attestations
+- [ ] Rate limiting on registration endpoint

--- a/v2/Dockerfile.contributor
+++ b/v2/Dockerfile.contributor
@@ -40,6 +40,7 @@ RUN chmod +x /usr/local/bin/contributor-agent.sh /usr/local/bin/contributor-rela
     /usr/local/bin/agent-launch.sh /usr/local/bin/gh
 
 ENV NODE_PATH=/opt/hive/node_modules
+ENV HIVE_CONTRIBUTOR_MODE=true
 USER dev
 WORKDIR /home/dev
 

--- a/v2/Dockerfile.contributor
+++ b/v2/Dockerfile.contributor
@@ -1,0 +1,46 @@
+FROM debian:bookworm-slim
+
+ARG NODE_MAJOR=22
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash curl git jq tmux python3 ca-certificates gnupg openssh-client \
+  && mkdir -p /etc/apt/keyrings \
+  && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+    | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
+    > /etc/apt/sources.list.d/nodesource.list \
+  && apt-get update && apt-get install -y nodejs \
+  && npm install -g @anthropic-ai/claude-code \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install gh CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    > /etc/apt/sources.list.d/github-cli.list \
+  && apt-get update && apt-get install -y gh && rm -rf /var/lib/apt/lists/*
+
+# Install ws for contributor-relay
+RUN mkdir -p /opt/hive/node_modules && cd /opt/hive && npm install ws
+
+# Create non-root user
+RUN useradd -m -s /bin/bash -u 1000 dev
+RUN mkdir -p /var/run/hive-metrics && chown dev:dev /var/run/hive-metrics
+
+# Copy agent scripts
+COPY bin/contributor-agent.sh /usr/local/bin/
+COPY bin/contributor-relay.sh /usr/local/bin/
+COPY bin/agent-launch.sh /usr/local/bin/
+COPY bin/gh-wrapper.sh /usr/local/bin/gh
+COPY bin/hive-config.sh /usr/local/bin/
+COPY config/backends.conf /usr/local/etc/hive/
+COPY config/restrictions/contributor-default.json /etc/hive/restrictions/
+
+RUN chmod +x /usr/local/bin/contributor-agent.sh /usr/local/bin/contributor-relay.sh \
+    /usr/local/bin/agent-launch.sh /usr/local/bin/gh
+
+ENV NODE_PATH=/opt/hive/node_modules
+USER dev
+WORKDIR /home/dev
+
+ENTRYPOINT ["/usr/local/bin/contributor-agent.sh"]

--- a/v2/compose-contributor.yaml
+++ b/v2/compose-contributor.yaml
@@ -1,0 +1,17 @@
+services:
+  contributor:
+    build:
+      context: ..
+      dockerfile: v2/Dockerfile.contributor
+    container_name: hive-contributor
+    restart: "no"
+    stdin_open: true
+    tty: true
+    volumes:
+      - ${HOME}/.config/hive:/home/dev/.config/hive:ro
+      - ${HOME}/.claude:/home/dev/.claude:ro
+      - ${HOME}/.config/claude-code:/home/dev/.config/claude-code:ro
+    environment:
+      - HIVE_HUB=${HIVE_HUB:-wss://hive.kubestellar.io:3001/contribute}
+      - AGENT_BACKEND=${AGENT_BACKEND:-claude}
+      - AGENT_MODEL=${AGENT_MODEL:-}


### PR DESCRIPTION
## Summary

- **Contribute-hive**: Community members donate their own CLI + API tokens to the Hive swarm via `just contribute-hive`. Contributors bring model inference tokens; the hub provides scoped GitHub App access tokens. Neither side sees the other's credentials.
- **Trust tiers**: newcomer → contributor (auto at 5 tasks) → trusted (maintainer voucher). Each tier scopes GitHub token permissions (issues-only → code push → merge).
- **Federation registry**: Projects sign up to run their own Hive instance. Contributors browse available hives and join any project. `/api/hives` lists participating projects; `/api/hives/onboard` generates starter configs.
- **Contributor labeling**: All PRs/issues created by contributors are stamped with `contributor/<github-user>` and `cli/<backend>` labels for traceability.
- **Live visibility**: Hub streams last 15 lines of contributor tmux output in progress messages. Dashboard shows active contributors, their CLI/model, current task, and task history.

## New Files

| File | Purpose |
|------|---------|
| `Justfile` | `contribute-register`, `contribute-hive`, `contribute-browse`, `contribute-status`, `contribute-stop` |
| `bin/contributor-agent.sh` | Container entrypoint: CLI detection, tmux session, relay startup |
| `bin/contributor-relay.sh` | WebSocket client: auth, task receipt, GH token injection, tmux streaming |
| `bin/contributor-dispatcher.sh` | Pipeline stage: contributor assignment reporting |
| `v2/Dockerfile.contributor` | Slim contributor container (no supervisor/governor/dashboard) |
| `v2/compose-contributor.yaml` | Docker Compose for contributor mode |
| `config/restrictions/contributor-default.json` | Default gh restrictions for contributors |
| `config/contributor.env.example` | Config template |

## Modified Files

| File | Change |
|------|--------|
| `bin/gh-app-token.sh` | `--scoped <tier>` flag for per-tier token minting |
| `bin/gh-wrapper.sh` | Contributor mode restrictions + contributor/cli labels |
| `dashboard/server.js` | `/contribute` WebSocket, `/api/contributors/*`, `/api/hives/*` endpoints |
| `dashboard/package.json` | Added `ws` dependency |

## Test plan

- [ ] Register a contributor via `POST /api/contribute/register`
- [ ] Connect contributor relay to WebSocket and verify auth handshake
- [ ] Verify scoped token minting with `gh-app-token.sh --scoped newcomer`
- [ ] Verify contributor labels appear on created PRs/issues
- [ ] Verify trust tier auto-promotion after 5 completed tasks
- [ ] Verify revocation disconnects WebSocket and invalidates token
- [ ] Verify `just contribute-browse` lists registered hives
- [ ] Verify `POST /api/hives/onboard` generates valid config
- [ ] Build contributor container: `docker build -f v2/Dockerfile.contributor .`