### PR TITLE
fix: prevent brainstorm from auto-starting on level switch and container restart

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -779,7 +779,13 @@ func main() {
 		}
 	}
 
-	for name := range cfg.EnabledAgents() {
+	for name, ac := range cfg.EnabledAgents() {
+		// On-demand agents (e.g. brainstorm) should not auto-start on
+		// container restart; they are triggered explicitly by workflows.
+		if ac.OnDemand {
+			logger.Info("skipping on-demand agent at startup", "name", name)
+			continue
+		}
 		if err := agentMgr.Start(ctx, name); err != nil {
 			logger.Warn("failed to start agent", "name", name, "error", err)
 		}

--- a/v2/pkg/config/acmm_packs.go
+++ b/v2/pkg/config/acmm_packs.go
@@ -41,6 +41,7 @@ type PackAgent struct {
 	Hidden       bool     `json:"hidden,omitempty" yaml:"hidden"`
 	StaleTimeout int      `json:"staleTimeout,omitempty" yaml:"stale_timeout,omitempty"`
 	Mode         string   `json:"mode,omitempty" yaml:"mode,omitempty"`
+	OnDemand     bool     `json:"onDemand,omitempty" yaml:"on_demand,omitempty"`
 }
 
 // PackGovernor describes the governor configuration recommended for a level.

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -140,6 +140,7 @@ type AgentConfig struct {
 	StatsDisplay     []StatsDisplayEntry `yaml:"stats_display" json:"stats_display,omitempty"`
 	ACMMLevels       []int             `yaml:"acmm_levels" json:"acmm_levels,omitempty"`
 	Mode             string            `yaml:"mode" json:"mode,omitempty"`
+	OnDemand         bool              `yaml:"on_demand" json:"on_demand,omitempty"`
 
 	// Managed is true for agents loaded from the overlay directory (not base config).
 	Managed bool `yaml:"-" json:"managed"`

--- a/v2/pkg/config/packs/level-1.yaml
+++ b/v2/pkg/config/packs/level-1.yaml
@@ -56,6 +56,7 @@ agents:
     mode: ADVISORY
     kick_template: brainstorm-advisory.md
     clear_on_kick: true
+    on_demand: true
     include_repos: false
     stale_timeout: 7200
     interactions: "Standalone. Driven by inception workflow and user queries."

--- a/v2/pkg/config/packs/level-2.yaml
+++ b/v2/pkg/config/packs/level-2.yaml
@@ -130,6 +130,7 @@ agents:
     mode: ADVISORY
     kick_template: brainstorm-advisory.md
     clear_on_kick: true
+    on_demand: true
     include_repos: false
     stale_timeout: 7200
     interactions: "Standalone. Produces ideation beads for human review."

--- a/v2/pkg/config/packs/level-3.yaml
+++ b/v2/pkg/config/packs/level-3.yaml
@@ -184,6 +184,7 @@ agents:
   bead_role: worker
   mode: ADVISORY
   kick_template: brainstorm-advisory.md
+  on_demand: true
   include_repos: false
   stale_timeout: 7200
   interactions: Standalone. Produces ideation beads for human review.

--- a/v2/pkg/config/packs/level-4.yaml
+++ b/v2/pkg/config/packs/level-4.yaml
@@ -223,6 +223,7 @@ agents:
   bead_role: worker
   mode: ADVISORY
   kick_template: brainstorm-advisory.md
+  on_demand: true
   include_repos: false
   stale_timeout: 7200
   interactions: Standalone. Produces ideation beads for human review.

--- a/v2/pkg/config/packs/level-5.yaml
+++ b/v2/pkg/config/packs/level-5.yaml
@@ -282,6 +282,7 @@ agents:
   bead_role: worker
   mode: ADVISORY
   kick_template: brainstorm-advisory.md
+  on_demand: true
   include_repos: false
   stale_timeout: 7200
   interactions: Standalone. Produces ideation beads for human review.

--- a/v2/pkg/config/packs/level-6.yaml
+++ b/v2/pkg/config/packs/level-6.yaml
@@ -308,6 +308,7 @@ agents:
   bead_role: worker
   mode: ADVISORY
   kick_template: brainstorm-advisory.md
+  on_demand: true
   include_repos: false
   stale_timeout: 7200
   interactions: Standalone. Produces ideation beads for human review.

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -105,6 +105,7 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 			IncludeRepos: &includeRepos,
 			LaneKeywords: pa.LaneKeywords,
 			Mode:         pa.Mode,
+			OnDemand:     pa.OnDemand,
 			Managed:      true,
 		}
 
@@ -118,8 +119,11 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 
 		finalCfg := s.deps.Config.Agents[pa.Name]
 		s.deps.AgentMgr.AddAgent(pa.Name, finalCfg)
-		if err := s.deps.AgentMgr.Start(s.deps.Ctx, pa.Name); err != nil {
-			s.logger.Warn("failed to start agent after pack create", "agent", pa.Name, "error", err)
+		// On-demand agents are only triggered explicitly (e.g. by inception).
+		if !pa.OnDemand {
+			if err := s.deps.AgentMgr.Start(s.deps.Ctx, pa.Name); err != nil {
+				s.logger.Warn("failed to start agent after pack create", "agent", pa.Name, "error", err)
+			}
 		}
 
 		created = append(created, pa.Name)
@@ -266,14 +270,23 @@ func (s *Server) syncAgentVisibility(level int) (paused, resumed []string) {
 	}
 
 	packAgents := make(map[string]bool, len(pack.Agents))
+	onDemandAgents := make(map[string]bool, len(pack.Agents))
 	for _, a := range pack.Agents {
 		if !a.Hidden {
 			packAgents[a.Name] = true
+		}
+		if a.OnDemand {
+			onDemandAgents[a.Name] = true
 		}
 	}
 
 	for name := range s.deps.Config.Agents {
 		if packAgents[name] {
+			// On-demand agents (e.g. brainstorm) should never auto-resume;
+			// they are triggered explicitly by workflows like inception.
+			if onDemandAgents[name] {
+				continue
+			}
 			if s.deps.AgentMgr.IsPaused(name) {
 				if err := s.deps.AgentMgr.Resume(s.deps.Ctx, name, "acmm-pack", fmt.Sprintf("agent included in pack level %d", level)); err == nil {
 					resumed = append(resumed, name)


### PR DESCRIPTION
## Summary
- Adds `on_demand` field to `PackAgent` and `AgentConfig` structs
- Sets `on_demand: true` on brainstorm agent in all 6 level pack YAMLs
- `syncAgentVisibility` now skips resuming on-demand agents during level switch
- `ApplyPack` skips starting on-demand agents when creating them from a pack
- Main startup loop skips on-demand agents on container restart

## Problem
Two bugs:
1. Switching ACMM levels via `PUT /api/packs/level` called `syncAgentVisibility` which resumed brainstorm because it was in the pack's agent list — but brainstorm has no cadence and should only run when explicitly triggered by inception
2. Container restart started all enabled agents including brainstorm, which has no cadence and should never auto-start

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/agent/... ./pkg/dashboard/... ./pkg/config/...` passes
- [ ] Verify brainstorm shows in sidebar at all levels but does not auto-start
- [ ] Verify switching levels does not resume brainstorm
- [ ] Verify container restart does not start brainstorm
- [ ] Verify inception workflow can still explicitly trigger brainstorm