### PR TITLE
fix: read bead detail metadata for fact body

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -605,8 +605,19 @@ func main() {
 
 	// Brainstorm is on-demand only — start paused so it doesn't run
 	// general ideation on boot. Inception's RestartWithBootstrap unpauses it.
-	if err := agentMgr.Pause("brainstorm", "startup", "on-demand only — waits for inception"); err != nil {
-		logger.Debug("brainstorm pause on startup", "error", err)
+	// Exception: if inception is active (state loaded from disk), kick brainstorm
+	// to resume the interrupted inception flow.
+	if state := inceptionEngine.GetState(); state != nil && state.Phase != knowledge.PhaseComplete {
+		msg := sched.BuildAgentMessage("brainstorm", nil, nil)
+		if err := agentMgr.RestartWithBootstrap(ctx, "brainstorm", msg); err != nil {
+			logger.Warn("failed to resume brainstorm for active inception", "error", err)
+		} else {
+			logger.Info("brainstorm resumed for active inception", "phase", state.Phase)
+		}
+	} else {
+		if err := agentMgr.Pause("brainstorm", "startup", "on-demand only — waits for inception"); err != nil {
+			logger.Debug("brainstorm pause on startup", "error", err)
+		}
 	}
 
 	dashSrv.RegisterAPI(&dashboard.Dependencies{

--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -256,6 +256,9 @@ func (w *InceptionWatcher) checkForFacts(ctx context.Context, inceptionBeads []*
 
 		body := b.Metadata["fact_body"]
 		if body == "" {
+			body = b.Metadata["detail"]
+		}
+		if body == "" {
 			body = b.Notes
 		}
 		if body == "" {

--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -273,7 +273,14 @@ func (e *InceptionEngine) writeFactsToVault(facts []IdeationFact) {
 
 	if e.api != nil {
 		if err := e.api.ConnectVault(vaultDir, "inception-wiki"); err != nil {
-			if !strings.Contains(err.Error(), "already connected") {
+			if strings.Contains(err.Error(), "already connected") {
+				// Vault exists — reindex to pick up new files
+				if err := e.api.ReindexVault(vaultDir); err != nil {
+					e.logger.Warn("failed to reindex inception wiki", "error", err)
+				} else {
+					e.logger.Info("inception wiki reindexed", "dir", vaultDir, "facts", len(facts))
+				}
+			} else {
 				e.logger.Warn("failed to connect inception wiki", "error", err)
 			}
 		} else {


### PR DESCRIPTION
Watcher missed metadata[detail]. Scaffold content was title-only.