### PR TITLE
fix: populate OnDemand field in agent status JSON

### DIFF
--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -225,6 +225,7 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 		a.DefaultMode = defaultMode.String()
 		a.IsCustomMode = mode != defaultMode
 		a.NeedsRestart = proc.HasLaunched && proc.LaunchedMode != mode
+		a.OnDemand = agentCfg.OnDemand
 		if proxyViolationsFn != nil {
 			a.ProxyViolations = proxyViolationsFn()[name]
 		}


### PR DESCRIPTION
Status builder wasn't setting OnDemand from agent config, so brainstorm showed 'paused' instead of 'on demand' in the governor cadence matrix. One-line fix.