### PR TITLE
fix: check pack definition for on-demand flag at startup

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -790,11 +790,20 @@ func main() {
 		}
 	}
 
+	onDemandFromPack := make(map[string]bool)
+	if acmmLevel > 0 {
+		if pack, err := config.ACMMPackByLevel(acmmLevel); err == nil {
+			for _, pa := range pack.Agents {
+				if pa.OnDemand {
+					onDemandFromPack[pa.Name] = true
+				}
+			}
+		}
+	}
 	for name, ac := range cfg.EnabledAgents() {
-		// On-demand agents (e.g. brainstorm) should not auto-start on
-		// container restart; they are triggered explicitly by workflows.
-		if ac.OnDemand {
-			logger.Info("skipping on-demand agent at startup", "name", name)
+		isOnDemand := ac.OnDemand || onDemandFromPack[name]
+		if isOnDemand {
+			logger.Info("skipping on-demand agent at startup", "name", name, "config_on_demand", ac.OnDemand, "pack_on_demand", onDemandFromPack[name])
 			continue
 		}
 		logger.Info("audit: starting agent", "name", name, "trigger", "startup")


### PR DESCRIPTION
On-demand agents (brainstorm) kept auto-starting on container restart because the loaded agent config didn't have on_demand=true. Now also checks the embedded pack definition as a fallback. Logs both sources for diagnostics.