### PR TITLE
fix: use current ACMM level for on-demand check at startup

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -791,8 +791,9 @@ func main() {
 	}
 
 	onDemandFromPack := make(map[string]bool)
-	if acmmLevel > 0 {
-		if pack, err := config.ACMMPackByLevel(acmmLevel); err == nil {
+	currentLevel := inferACMMLevel(cfg)
+	if currentLevel > 0 {
+		if pack, err := config.ACMMPackByLevel(currentLevel); err == nil {
 			for _, pa := range pack.Agents {
 				if pa.OnDemand {
 					onDemandFromPack[pa.Name] = true


### PR DESCRIPTION
Fixes brainstorm auto-starting on restart. The on-demand pack lookup used a stale acmmLevel from before state restore. Now re-infers the level from cfg right before the startup loop.