### PR TITLE
fix: scan all pack levels for on-demand agents at startup

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -790,21 +790,14 @@ func main() {
 		}
 	}
 
-	onDemandFromPack := make(map[string]bool)
-	currentLevel := inferACMMLevel(cfg)
-	if currentLevel > 0 {
-		if pack, err := config.ACMMPackByLevel(currentLevel); err == nil {
-			for _, pa := range pack.Agents {
-				if pa.OnDemand {
-					onDemandFromPack[pa.Name] = true
-				}
-			}
-		}
+	onDemandFromPack := config.OnDemandAgentsFromPacks()
+	if len(onDemandFromPack) > 0 {
+		logger.Info("on-demand agents from pack definitions", "agents", onDemandFromPack)
 	}
 	for name, ac := range cfg.EnabledAgents() {
 		isOnDemand := ac.OnDemand || onDemandFromPack[name]
 		if isOnDemand {
-			logger.Info("skipping on-demand agent at startup", "name", name, "config_on_demand", ac.OnDemand, "pack_on_demand", onDemandFromPack[name])
+			logger.Info("skipping on-demand agent at startup", "name", name)
 			continue
 		}
 		logger.Info("audit: starting agent", "name", name, "trigger", "startup")
@@ -941,9 +934,13 @@ func runEvalCycle(
 	// via the dashboard is always respected; the governor only controls kicks.
 
 	// Filter out on-demand agents — they are only triggered explicitly
+	onDemandSet := config.OnDemandAgentsFromPacks()
 	var filteredDue []string
 	for _, name := range agentsDue {
 		if ac, ok := cfg.Agents[name]; ok && ac.OnDemand {
+			continue
+		}
+		if onDemandSet[name] {
 			continue
 		}
 		filteredDue = append(filteredDue, name)

--- a/v2/pkg/config/acmm_packs.go
+++ b/v2/pkg/config/acmm_packs.go
@@ -84,6 +84,21 @@ func ACMMPacks() []ACMMPack {
 	return packs
 }
 
+// OnDemandAgentsFromPacks returns the set of agent names marked as on-demand
+// across ALL pack levels. Used to prevent auto-starting these agents regardless
+// of which level is active.
+func OnDemandAgentsFromPacks() map[string]bool {
+	result := make(map[string]bool)
+	for _, pack := range ACMMPacks() {
+		for _, a := range pack.Agents {
+			if a.OnDemand {
+				result[a.Name] = true
+			}
+		}
+	}
+	return result
+}
+
 // ACMMPackByLevel returns the pack for a specific level, or an error if not found.
 func ACMMPackByLevel(level int) (ACMMPack, error) {
 	for _, p := range ACMMPacks() {


### PR DESCRIPTION
Scans ALL pack levels for on-demand agents instead of relying on the current level (which may not be set correctly at startup). Uses shared OnDemandAgentsFromPacks() helper in both startup loop and governor eval filter.