### PR TITLE
fix: always pause brainstorm on startup, remove inception auto-resume

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -603,21 +603,10 @@ func main() {
 	inceptionEngine := knowledge.NewInceptionEngine("/data", knowledgeAPI, logger)
 	sched.SetInception(inceptionEngine)
 
-	// Brainstorm is on-demand only — start paused so it doesn't run
-	// general ideation on boot. Inception's RestartWithBootstrap unpauses it.
-	// Exception: if inception is active (state loaded from disk), kick brainstorm
-	// to resume the interrupted inception flow.
-	if state := inceptionEngine.GetState(); state != nil && state.Phase != knowledge.PhaseComplete {
-		msg := sched.BuildAgentMessage("brainstorm", nil, nil)
-		if err := agentMgr.RestartWithBootstrap(ctx, "brainstorm", msg); err != nil {
-			logger.Warn("failed to resume brainstorm for active inception", "error", err)
-		} else {
-			logger.Info("brainstorm resumed for active inception", "phase", state.Phase)
-		}
-	} else {
-		if err := agentMgr.Pause("brainstorm", "startup", "on-demand only — waits for inception"); err != nil {
-			logger.Debug("brainstorm pause on startup", "error", err)
-		}
+	// Brainstorm is on-demand only — always start paused. The inception
+	// watcher will resume it when needed via RestartWithBootstrap.
+	if err := agentMgr.Pause("brainstorm", "startup", "on-demand agent — triggered by inception only"); err != nil {
+		logger.Debug("brainstorm pause on startup", "error", err)
 	}
 
 	dashSrv.RegisterAPI(&dashboard.Dependencies{


### PR DESCRIPTION
Root cause found: stale inception state on disk triggered RestartWithBootstrap for brainstorm on every container restart. Now always pauses brainstorm — inception watcher resumes it when needed.