### PR TITLE
fix: use pack definition as fallback for onDemand in status API

### DIFF
--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -99,6 +99,7 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 	currentMode := strings.ToLower(string(govState.Mode))
 
 	packAllowed := acmmPackAllowedSet(cfg)
+	onDemandSet := config.OnDemandAgentsFromPacks()
 
 	names := make([]string, 0, len(statuses))
 	for name := range statuses {
@@ -225,7 +226,7 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 		a.DefaultMode = defaultMode.String()
 		a.IsCustomMode = mode != defaultMode
 		a.NeedsRestart = proc.HasLaunched && proc.LaunchedMode != mode
-		a.OnDemand = agentCfg.OnDemand
+		a.OnDemand = agentCfg.OnDemand || onDemandSet[name]
 		if proxyViolationsFn != nil {
 			a.ProxyViolations = proxyViolationsFn()[name]
 		}


### PR DESCRIPTION
Agent config from YAML overlay doesn't preserve on_demand=true. Now checks OnDemandAgentsFromPacks() as fallback so brainstorm shows 'on demand' instead of 'paused' in the dashboard.