### PR TITLE
feat: contribute-hive Go API for v2 dashboard

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -22,6 +22,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.deps = deps
 	s.loadSidebarFromDisk()
 	s.restoreGHUserSession()
+	s.registerContributeRoutes()
 
 	s.mux.HandleFunc("GET /api/version", s.handleVersion)
 	s.mux.HandleFunc("GET /api/config", s.handleConfig)

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -1,0 +1,523 @@
+package dashboard
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultContributorsDir     = "/data/contributors"
+	contributorAutoPromoteAt   = 5
+	contributorTrustedAt       = 20
+	defaultFederationRegistry  = "/data/federation/registry.json"
+)
+
+func getContributorsDir() string {
+	if v := os.Getenv("HIVE_CONTRIBUTORS_DIR"); v != "" {
+		return v
+	}
+	return defaultContributorsDir
+}
+
+func getFederationRegistryPath() string {
+	if v := os.Getenv("HIVE_FEDERATION_REGISTRY_PATH"); v != "" {
+		return v
+	}
+	return defaultFederationRegistry
+}
+
+type ContributorProfile struct {
+	GitHubUsername      string                `json:"github_username"`
+	ContributorID      string                `json:"contributor_id"`
+	RegistrationToken  string                `json:"registration_token"`
+	TokenPlain         string                `json:"registration_token_plain,omitempty"`
+	TrustTier          string                `json:"trust_tier"`
+	RegisteredAt       string                `json:"registered_at"`
+	TasksCompleted     int                   `json:"total_tasks_completed"`
+	TasksFailed        int                   `json:"total_tasks_failed"`
+	RateLimits         ContributorRateLimits `json:"rate_limits"`
+	Active             bool                  `json:"active,omitempty"`
+}
+
+type ContributorRateLimits struct {
+	MaxConcurrent  int `json:"max_concurrent_tasks"`
+	MaxPerHour     int `json:"max_tasks_per_hour"`
+	MaxPerDay      int `json:"max_tasks_per_day"`
+}
+
+type ContributorPool struct {
+	Active     int                     `json:"active"`
+	Registered int                     `json:"registered"`
+	mu         sync.RWMutex
+}
+
+var contributorPool = &ContributorPool{}
+
+type ContributorPoolStatus struct {
+	Active     int `json:"active"`
+	Registered int `json:"registered"`
+}
+
+func BuildContributorPoolStatus() *ContributorPoolStatus {
+	profiles := listContributorProfiles()
+	return &ContributorPoolStatus{
+		Active:     0,
+		Registered: len(profiles),
+	}
+}
+
+func (s *Server) registerContributeRoutes() {
+	s.mux.HandleFunc("GET /contribute", s.handleContributeLanding)
+	s.mux.HandleFunc("POST /api/contribute/register", s.handleContributeRegister)
+	s.mux.HandleFunc("GET /api/contribute/status", s.handleContributeStatus)
+	s.mux.HandleFunc("GET /api/contributors", s.handleContributorsList)
+	s.mux.HandleFunc("GET /api/contributors/{id}", s.handleContributorGet)
+	s.mux.HandleFunc("PUT /api/contributors/{id}/trust", s.handleContributorTrust)
+	s.mux.HandleFunc("POST /api/contributors/{id}/revoke", s.handleContributorRevoke)
+
+	s.mux.HandleFunc("GET /api/hives", s.handleHivesList)
+	s.mux.HandleFunc("POST /api/hives/register", s.handleHivesRegister)
+	s.mux.HandleFunc("POST /api/hives/{id}/heartbeat", s.handleHivesHeartbeat)
+	s.mux.HandleFunc("DELETE /api/hives/{id}", s.handleHivesDelete)
+	s.mux.HandleFunc("POST /api/hives/onboard", s.handleHivesOnboard)
+}
+
+func randomHex(n int) string {
+	b := make([]byte, n)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+func sha256Hex(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
+}
+
+func ensureDir(dir string) {
+	_ = os.MkdirAll(dir, 0o755)
+}
+
+func loadContributorProfile(username string) (*ContributorProfile, error) {
+	data, err := os.ReadFile(filepath.Join(getContributorsDir(), username+".json"))
+	if err != nil {
+		return nil, err
+	}
+	var p ContributorProfile
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+func saveContributorProfile(p *ContributorProfile) error {
+	ensureDir(getContributorsDir())
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(getContributorsDir(), p.GitHubUsername+".json"), data, 0o644)
+}
+
+func listContributorProfiles() []ContributorProfile {
+	ensureDir(getContributorsDir())
+	entries, err := os.ReadDir(getContributorsDir())
+	if err != nil {
+		return nil
+	}
+	var profiles []ContributorProfile
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(getContributorsDir(), e.Name()))
+		if err != nil {
+			continue
+		}
+		var p ContributorProfile
+		if json.Unmarshal(data, &p) == nil {
+			profiles = append(profiles, p)
+		}
+	}
+	return profiles
+}
+
+func createContributorProfile(username string) (*ContributorProfile, string) {
+	cid := "c-" + randomHex(6)
+	token := randomHex(32)
+	p := &ContributorProfile{
+		GitHubUsername:     username,
+		ContributorID:     cid,
+		RegistrationToken: sha256Hex(token),
+		TokenPlain:        token,
+		TrustTier:         "newcomer",
+		RegisteredAt:      time.Now().UTC().Format(time.RFC3339),
+		RateLimits: ContributorRateLimits{
+			MaxConcurrent: 1,
+			MaxPerHour:    3,
+			MaxPerDay:     10,
+		},
+	}
+	_ = saveContributorProfile(p)
+	return p, token
+}
+
+func findContributor(id string) *ContributorProfile {
+	profiles := listContributorProfiles()
+	for i := range profiles {
+		if profiles[i].ContributorID == id || profiles[i].GitHubUsername == id {
+			return &profiles[i]
+		}
+	}
+	return nil
+}
+
+// ── Landing page ───────────────────────────────────────────────────────────
+
+func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request) {
+	profiles := listContributorProfiles()
+	projectName := ""
+	if s.deps != nil && s.deps.Config != nil {
+		projectName = s.deps.Config.Project.Name
+	}
+	if projectName == "" {
+		projectName = "Hive"
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, `<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><title>Contribute to %s</title>
+<style>
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#0d1117;color:#e6edf3;margin:0;padding:40px;max-width:720px;margin:0 auto}
+h1{font-size:2rem;margin-bottom:8px}
+.subtitle{color:#8b949e;font-size:1.1rem;margin-bottom:32px}
+.stat-row{display:flex;gap:16px;margin-bottom:32px}
+.stat{background:#161b22;border:1px solid #30363d;border-radius:12px;padding:16px 20px;flex:1;text-align:center}
+.stat-num{font-size:1.8rem;font-weight:700;color:#58a6ff}
+.stat-label{font-size:.8rem;color:#8b949e;margin-top:4px}
+.steps{background:#161b22;border:1px solid #30363d;border-radius:12px;padding:24px;margin-top:24px}
+.steps h3{margin-top:0;color:#58a6ff}
+.steps ol{padding-left:20px;line-height:2}
+code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
+.how{margin-top:32px}
+.how h3{color:#e6edf3}
+.how p{color:#8b949e;line-height:1.6}
+.tier-table{width:100%%;border-collapse:collapse;margin-top:16px}
+.tier-table th,.tier-table td{padding:8px 12px;text-align:left;border-bottom:1px solid #30363d;font-size:.85rem}
+.tier-table th{color:#8b949e;font-weight:600}
+</style></head><body>
+<h1>🐝 Contribute to %s</h1>
+<p class="subtitle">Donate your CLI + API tokens to help this project's AI agent swarm.</p>
+<div class="stat-row">
+<div class="stat"><div class="stat-num">%d</div><div class="stat-label">Registered Contributors</div></div>
+</div>
+<div class="steps">
+<h3>How it works</h3>
+<ol>
+<li><strong>Register</strong> — <code>just contribute-register</code> or POST to <code>/api/contribute/register</code></li>
+<li><strong>Install just</strong> — <code>brew install just</code></li>
+<li><strong>Clone the hive repo</strong> — <code>git clone https://github.com/kubestellar/hive</code></li>
+<li><strong>Run</strong> — <code>just contribute-hive</code></li>
+<li><strong>Walk away</strong> — your agent pulls work from the queue</li>
+</ol>
+</div>
+<div class="how">
+<h3>What you bring vs. what the hive provides</h3>
+<p><strong>You bring:</strong> Your own CLI API tokens. You pay for your own model inference.</p>
+<p><strong>The hive provides:</strong> Scoped GitHub access via a GitHub App. Neither side sees the other's secrets.</p>
+</div>
+<div class="how">
+<h3>Trust tiers</h3>
+<table class="tier-table">
+<tr><th>Tier</th><th>Unlocked at</th><th>Can do</th></tr>
+<tr><td>Newcomer</td><td>Registration</td><td>Comment on issues</td></tr>
+<tr><td>Contributor</td><td>5 completed tasks</td><td>Create PRs, push code</td></tr>
+<tr><td>Trusted</td><td>20 tasks + maintainer voucher</td><td>Merge PRs</td></tr>
+<tr><td>Advisor</td><td>Registration</td><td>Review agent PRs</td></tr>
+</table>
+</div>
+</body></html>`, projectName, projectName, len(profiles))
+}
+
+// ── Registration ───────────────────────────────────────────────────────────
+
+func (s *Server) handleContributeRegister(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		GitHubUsername string `json:"github_username"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+	username := strings.TrimSpace(req.GitHubUsername)
+	if username == "" || !isValidUsername(username) {
+		jsonError(w, "Invalid github_username", http.StatusBadRequest)
+		return
+	}
+
+	existing, _ := loadContributorProfile(username)
+	if existing != nil {
+		jsonResponse(w, map[string]string{
+			"contributor_id":     existing.ContributorID,
+			"registration_token": existing.TokenPlain,
+			"message":            "Already registered",
+		})
+		return
+	}
+
+	profile, token := createContributorProfile(username)
+	s.logger.Info("contributor registered", "username", username, "id", profile.ContributorID)
+
+	jsonResponse(w, map[string]string{
+		"contributor_id":     profile.ContributorID,
+		"registration_token": token,
+		"message":            "Registered successfully",
+	})
+}
+
+func (s *Server) handleContributeStatus(w http.ResponseWriter, r *http.Request) {
+	profiles := listContributorProfiles()
+	jsonResponse(w, map[string]any{
+		"hub":                  "online",
+		"active_contributors": 0,
+		"total_registered":    len(profiles),
+		"actionable_items":    0,
+	})
+}
+
+// ── Contributor management ─────────────────────────────────────────────────
+
+func (s *Server) handleContributorsList(w http.ResponseWriter, r *http.Request) {
+	profiles := listContributorProfiles()
+	for i := range profiles {
+		profiles[i].TokenPlain = ""
+		profiles[i].RegistrationToken = ""
+	}
+	jsonResponse(w, map[string]any{"contributors": profiles})
+}
+
+func (s *Server) handleContributorGet(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	p := findContributor(id)
+	if p == nil {
+		jsonError(w, "Contributor not found", http.StatusNotFound)
+		return
+	}
+	p.TokenPlain = ""
+	p.RegistrationToken = ""
+	jsonResponse(w, p)
+}
+
+func (s *Server) handleContributorTrust(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	p := findContributor(id)
+	if p == nil {
+		jsonError(w, "Contributor not found", http.StatusNotFound)
+		return
+	}
+	var req struct {
+		Tier string `json:"tier"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+	validTiers := map[string]bool{"newcomer": true, "contributor": true, "trusted": true, "advisor": true, "revoked": true}
+	if !validTiers[req.Tier] {
+		jsonError(w, "Invalid tier", http.StatusBadRequest)
+		return
+	}
+	p.TrustTier = req.Tier
+	if err := saveContributorProfile(p); err != nil {
+		jsonError(w, "Failed to save", http.StatusInternalServerError)
+		return
+	}
+	s.logger.Info("contributor tier changed", "username", p.GitHubUsername, "tier", req.Tier)
+	jsonResponse(w, map[string]any{"ok": true, "trust_tier": req.Tier})
+}
+
+func (s *Server) handleContributorRevoke(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	p := findContributor(id)
+	if p == nil {
+		jsonError(w, "Contributor not found", http.StatusNotFound)
+		return
+	}
+	p.TrustTier = "revoked"
+	_ = saveContributorProfile(p)
+	s.logger.Info("contributor revoked", "username", p.GitHubUsername)
+	jsonResponse(w, map[string]any{"ok": true})
+}
+
+// ── Federation registry ────────────────────────────────────────────────────
+
+
+type FederationRegistry struct {
+	Hives []FederationHive `json:"hives"`
+}
+
+type FederationHive struct {
+	ID                 string `json:"id"`
+	ProjectName        string `json:"project_name"`
+	Org                string `json:"org"`
+	HubURL             string `json:"hub_url"`
+	DashboardURL       string `json:"dashboard_url,omitempty"`
+	ActiveContributors int    `json:"active_contributors"`
+	ActiveAgents       int    `json:"active_agents"`
+	ActionableItems    int    `json:"actionable_items"`
+	RegisteredAt       string `json:"registered_at"`
+	LastHeartbeat      string `json:"last_heartbeat,omitempty"`
+}
+
+func loadFederationRegistry() *FederationRegistry {
+	data, err := os.ReadFile(getFederationRegistryPath())
+	if err != nil {
+		return &FederationRegistry{}
+	}
+	var reg FederationRegistry
+	if json.Unmarshal(data, &reg) != nil {
+		return &FederationRegistry{}
+	}
+	return &reg
+}
+
+func saveFederationRegistry(reg *FederationRegistry) error {
+	ensureDir(filepath.Dir(getFederationRegistryPath()))
+	data, err := json.MarshalIndent(reg, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(getFederationRegistryPath(), data, 0o644)
+}
+
+func (s *Server) handleHivesList(w http.ResponseWriter, r *http.Request) {
+	reg := loadFederationRegistry()
+	jsonResponse(w, reg)
+}
+
+func (s *Server) handleHivesRegister(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ProjectName  string `json:"project_name"`
+		Org          string `json:"org"`
+		HubURL       string `json:"hub_url"`
+		DashboardURL string `json:"dashboard_url"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+	if req.ProjectName == "" || req.Org == "" || req.HubURL == "" {
+		jsonError(w, "project_name, org, and hub_url are required", http.StatusBadRequest)
+		return
+	}
+
+	reg := loadFederationRegistry()
+	hiveID := fmt.Sprintf("hive-%s-%s", strings.ToLower(req.Org), strings.ToLower(req.ProjectName))
+	for i := range reg.Hives {
+		if reg.Hives[i].ID == hiveID {
+			reg.Hives[i].HubURL = req.HubURL
+			reg.Hives[i].DashboardURL = req.DashboardURL
+			_ = saveFederationRegistry(reg)
+			jsonResponse(w, map[string]any{"ok": true, "id": hiveID})
+			return
+		}
+	}
+
+	reg.Hives = append(reg.Hives, FederationHive{
+		ID:           hiveID,
+		ProjectName:  req.ProjectName,
+		Org:          req.Org,
+		HubURL:       req.HubURL,
+		DashboardURL: req.DashboardURL,
+		RegisteredAt: time.Now().UTC().Format(time.RFC3339),
+	})
+	_ = saveFederationRegistry(reg)
+	s.logger.Info("hive registered", "id", hiveID)
+	jsonResponse(w, map[string]any{"ok": true, "id": hiveID})
+}
+
+func (s *Server) handleHivesHeartbeat(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	reg := loadFederationRegistry()
+	var found *FederationHive
+	for i := range reg.Hives {
+		if reg.Hives[i].ID == id {
+			found = &reg.Hives[i]
+			break
+		}
+	}
+	if found == nil {
+		jsonError(w, "Hive not found", http.StatusNotFound)
+		return
+	}
+
+	var req struct {
+		ActiveContributors int `json:"active_contributors"`
+		ActiveAgents       int `json:"active_agents"`
+		ActionableItems    int `json:"actionable_items"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+		found.ActiveContributors = req.ActiveContributors
+		found.ActiveAgents = req.ActiveAgents
+		found.ActionableItems = req.ActionableItems
+	}
+	found.LastHeartbeat = time.Now().UTC().Format(time.RFC3339)
+	_ = saveFederationRegistry(reg)
+	jsonResponse(w, map[string]any{"ok": true})
+}
+
+func (s *Server) handleHivesDelete(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	reg := loadFederationRegistry()
+	for i := range reg.Hives {
+		if reg.Hives[i].ID == id {
+			reg.Hives = append(reg.Hives[:i], reg.Hives[i+1:]...)
+			_ = saveFederationRegistry(reg)
+			jsonResponse(w, map[string]any{"ok": true})
+			return
+		}
+	}
+	jsonError(w, "Hive not found", http.StatusNotFound)
+}
+
+func (s *Server) handleHivesOnboard(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ProjectName string   `json:"project_name"`
+		Org         string   `json:"org"`
+		Repos       []string `json:"repos"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.ProjectName == "" || req.Org == "" || len(req.Repos) == 0 {
+		jsonError(w, "project_name, org, and repos[] are required", http.StatusBadRequest)
+		return
+	}
+
+	jsonResponse(w, map[string]any{
+		"next_steps": []string{
+			"1. Install the Hive GitHub App on your org",
+			"2. Note the App ID and Installation ID",
+			"3. Save the private key as /etc/hive/gh-app-key.pem",
+			"4. Deploy with: docker compose up -d",
+			"5. Register: POST /api/hives/register",
+		},
+	})
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+func isValidUsername(s string) bool {
+	for _, c := range s {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_') {
+			return false
+		}
+	}
+	return len(s) > 0
+}
+

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -1,0 +1,213 @@
+package dashboard
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+)
+
+func setupContributeEnv(t *testing.T) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	t.Setenv("HIVE_CONTRIBUTORS_DIR", filepath.Join(tmpDir, "contributors"))
+	t.Setenv("HIVE_FEDERATION_REGISTRY_PATH", filepath.Join(tmpDir, "federation", "registry.json"))
+}
+
+func TestContributeRegister(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	body := `{"github_username":"testuser123"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if resp["contributor_id"] == "" {
+		t.Error("missing contributor_id")
+	}
+	if resp["registration_token"] == "" {
+		t.Error("missing registration_token")
+	}
+	if resp["message"] != "Registered successfully" {
+		t.Errorf("unexpected message: %s", resp["message"])
+	}
+
+}
+
+func TestContributeRegisterInvalidUsername(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	body := `{"github_username":"bad user!"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestContributeRegisterEmpty(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	body := `{"github_username":""}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestContributeStatus(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/contribute/status", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if resp["hub"] != "online" {
+		t.Errorf("expected hub=online, got %v", resp["hub"])
+	}
+}
+
+func TestContributeLanding(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/contribute", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte("Contribute to")) {
+		t.Error("landing page missing expected content")
+	}
+}
+
+func TestContributorNotFound(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/contributors/nonexistent", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHivesRegisterAndList(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	// Register
+	body := `{"project_name":"test-proj","org":"test-org","hub_url":"wss://test:3001/contribute"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/hives/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("register: expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// List
+	req2 := httptest.NewRequest(http.MethodGet, "/api/hives", nil)
+	w2 := httptest.NewRecorder()
+	s.mux.ServeHTTP(w2, req2)
+
+	if w2.Code != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d", w2.Code)
+	}
+
+	var reg FederationRegistry
+	if err := json.Unmarshal(w2.Body.Bytes(), &reg); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	found := false
+	for _, h := range reg.Hives {
+		if h.ProjectName == "test-proj" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("registered hive not found in list")
+	}
+
+}
+
+func TestHivesRegisterMissingFields(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	body := `{"project_name":"x"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/hives/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestIsValidUsername(t *testing.T) {
+	cases := []struct {
+		input string
+		want  bool
+	}{
+		{"testuser", true},
+		{"test-user", true},
+		{"test_user123", true},
+		{"bad user!", false},
+		{"", false},
+		{"user@name", false},
+	}
+	for _, tc := range cases {
+		got := isValidUsername(tc.input)
+		if got != tc.want {
+			t.Errorf("isValidUsername(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -67,9 +67,10 @@ type StatusPayload struct {
 	AgentMetrics  map[string]any      `json:"agentMetrics"`
 	Hold          FrontendHold        `json:"hold"`
 	IssueToMerge  map[string]any      `json:"issueToMerge"`
-	ACMMLevel      int                 `json:"acmmLevel"`
-	ACMMPackAgents []string            `json:"acmmPackAgents"`
-	AdvisoryDigest any                 `json:"advisoryDigest,omitempty"`
+	ACMMLevel        int                 `json:"acmmLevel"`
+	ACMMPackAgents   []string            `json:"acmmPackAgents"`
+	AdvisoryDigest   any                 `json:"advisoryDigest,omitempty"`
+	ContributorPool  *ContributorPoolStatus `json:"contributorPool,omitempty"`
 }
 
 type FrontendAgent struct {
@@ -317,6 +318,8 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 		status.ACMMLevel = detectACMMLevel(s.deps.Config)
 		status.ACMMPackAgents = buildACMMPackAgents(s.deps.Config)
 	}
+	status.ContributorPool = BuildContributorPoolStatus()
+
 	s.statusMu.Lock()
 	status.Timestamp = time.Now().UTC().Format(time.RFC3339)
 	s.status = status


### PR DESCRIPTION
## Summary

Implements the contribute-hive REST API endpoints in Go for the v2 dashboard server. This is the Go-native version of the contribute-hive feature — the previous Node.js implementation (#811) landed on v2's `dashboard/server.js` which is not used by the v2 Go binary.

**Endpoints added:**
- `GET /contribute` — contributor landing page
- `POST /api/contribute/register` — register with GitHub username
- `GET /api/contribute/status` — hub status
- `GET /api/contributors` — list contributors
- `GET /api/contributors/{id}` — get by ID/username
- `PUT /api/contributors/{id}/trust` — change trust tier
- `POST /api/contributors/{id}/revoke` — revoke access
- `GET /api/hives` — federation registry
- `POST /api/hives/register` — register a hive
- `POST /api/hives/{id}/heartbeat` — update stats
- `DELETE /api/hives/{id}` — remove a hive
- `POST /api/hives/onboard` — onboarding instructions

**Other changes:**
- `ContributorPoolStatus` added to `StatusPayload` for SSE broadcast
- Routes registered via `registerContributeRoutes()` in `RegisterAPI()`
- Paths configurable via `HIVE_CONTRIBUTORS_DIR` / `HIVE_FEDERATION_REGISTRY_PATH` env vars

## Test plan

- [x] 8 Go tests pass (registration, validation, status, landing, federation, username validation)
- [ ] Watchtower picks up new image, `/contribute` loads on 4.85
- [ ] Register a contributor, verify profile persists to `/data/contributors/`
- [ ] Contributors panel appears in dashboard sidebar