### PR TITLE
fix: synchronous status refresh after config update

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1339,7 +1339,7 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 		s.logger.Warn("failed to sync agent config to process", "agent", name, "error", err)
 	}
 
-	s.refreshAndPersist()
+	s.refreshAndPersistSync()
 	okResponse(w, map[string]string{"status": "updated", "agent": name})
 }
 


### PR DESCRIPTION
## Summary
- Fix stale displayName in `GET /api/status` after updating agent config via `PUT /api/config/agent/{name}/general`
- Root cause: `refreshAndPersist()` fires the status cache rebuild asynchronously, so a subsequent GET can race and return stale data
- Fix: switch to `refreshAndPersistSync()` in the general config handler so the status cache is fully rebuilt before the HTTP response is sent

## Test plan
- [ ] Update an agent's displayName via PUT, immediately GET /api/status, verify the new displayName appears
- [ ] Verify no regression in other config update endpoints