### PR TITLE
fix: /contribute route shadowed by SPA file server

### DIFF
--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -275,7 +275,26 @@ func (s *Server) Start() error {
 	if err != nil {
 		return fmt.Errorf("loading embedded static files: %w", err)
 	}
-	s.mux.Handle("GET /", http.FileServer(http.FS(staticContent)))
+	indexHTML, err := fs.ReadFile(staticContent, "index.html")
+	if err != nil {
+		return fmt.Errorf("reading embedded index.html: %w", err)
+	}
+	fileServer := http.FileServer(http.FS(staticContent))
+	s.mux.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.Write(indexHTML)
+			return
+		}
+		f, err := staticContent.Open(strings.TrimPrefix(r.URL.Path, "/"))
+		if err != nil {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.Write(indexHTML)
+			return
+		}
+		f.Close()
+		fileServer.ServeHTTP(w, r)
+	})
 
 	handler := s.securityHeaders(s.mux)
 


### PR DESCRIPTION
## Summary

- `/contribute` was returning the SPA `index.html` instead of the Go contribute landing page
- Root cause: `http.FileServer` registered as `GET /` was catching all paths before specific routes
- Fix: custom handler that serves static files when they exist, falls back to `index.html` for SPA routing, but lets exact routes like `GET /contribute` win via ServeMux priority

## Test plan

- [x] `TestContributeLanding` passes
- [ ] `curl http://192.168.4.85:3001/contribute` returns the contribute landing page (not the SPA)
- [ ] Dashboard SPA still works at `http://192.168.4.85:3001/`