### PR TITLE
fix: sanitize HTML tags from config string inputs (XSS prevention)

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -250,6 +251,14 @@ func (s *Server) refreshAsync() {
 func decodeBody(r *http.Request, v interface{}) error {
 	defer r.Body.Close()
 	return json.NewDecoder(r.Body).Decode(v)
+}
+
+// htmlTagPattern matches HTML/XML tags for sanitization.
+var htmlTagPattern = regexp.MustCompile(`<[^>]*>`)
+
+// sanitizeString strips HTML tags from user input to prevent stored XSS.
+func sanitizeString(s string) string {
+	return strings.TrimSpace(htmlTagPattern.ReplaceAllString(s, ""))
 }
 
 // --- Core status endpoints ---
@@ -1229,17 +1238,17 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 	}
 	if v, ok := body["displayName"]; ok {
 		if s, ok := v.(string); ok {
-			agentCfg.DisplayName = s
+			agentCfg.DisplayName = sanitizeString(s)
 		}
 	}
 	if v, ok := body["description"]; ok {
 		if s, ok := v.(string); ok {
-			agentCfg.Description = s
+			agentCfg.Description = sanitizeString(s)
 		}
 	}
 	if v, ok := body["launchCmd"]; ok {
 		if s, ok := v.(string); ok {
-			agentCfg.LaunchCmd = s
+			agentCfg.LaunchCmd = sanitizeString(s)
 		}
 	}
 	if v, ok := body["staleTimeout"]; ok {
@@ -1249,7 +1258,7 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 	}
 	if v, ok := body["restartStrategy"]; ok {
 		if s, ok := v.(string); ok {
-			agentCfg.RestartStrategy = s
+			agentCfg.RestartStrategy = sanitizeString(s)
 		}
 	}
 	if v, ok := body["cliPinned"]; ok {
@@ -1259,12 +1268,12 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 	}
 	if v, ok := body["emoji"]; ok {
 		if s, ok := v.(string); ok {
-			agentCfg.Emoji = s
+			agentCfg.Emoji = sanitizeString(s)
 		}
 	}
 	if v, ok := body["color"]; ok {
 		if s, ok := v.(string); ok {
-			agentCfg.Color = s
+			agentCfg.Color = sanitizeString(s)
 		}
 	}
 	if v, ok := body["sortOrder"]; ok {
@@ -1274,22 +1283,22 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 	}
 	if v, ok := body["beadRole"]; ok {
 		if s, ok := v.(string); ok {
-			agentCfg.BeadRole = s
+			agentCfg.BeadRole = sanitizeString(s)
 		}
 	}
 	if v, ok := body["role"]; ok {
 		if s, ok := v.(string); ok {
-			agentCfg.Role = s
+			agentCfg.Role = sanitizeString(s)
 		}
 	}
 	if v, ok := body["kickTemplate"]; ok {
 		if s, ok := v.(string); ok {
-			agentCfg.KickTemplate = s
+			agentCfg.KickTemplate = sanitizeString(s)
 		}
 	}
 	if v, ok := body["mode"]; ok {
 		if s, ok := v.(string); ok {
-			agentCfg.Mode = s
+			agentCfg.Mode = sanitizeString(s)
 		}
 	}
 	if v, ok := body["includeRepos"]; ok {
@@ -1302,7 +1311,7 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 			kw := make([]string, 0, len(arr))
 			for _, item := range arr {
 				if s, ok := item.(string); ok {
-					kw = append(kw, s)
+					kw = append(kw, sanitizeString(s))
 				}
 			}
 			agentCfg.LaneKeywords = kw
@@ -1313,7 +1322,7 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 			kw := make([]string, 0, len(arr))
 			for _, item := range arr {
 				if s, ok := item.(string); ok {
-					kw = append(kw, s)
+					kw = append(kw, sanitizeString(s))
 				}
 			}
 			agentCfg.DetectKeywords = kw
@@ -1863,6 +1872,15 @@ func (s *Server) handleGovernorAddAgent(w http.ResponseWriter, r *http.Request) 
 		Model   string `json:"model"`
 	}
 	if err := decodeBody(r, &body); err != nil || body.Name == "" {
+		jsonError(w, "name is required", http.StatusBadRequest)
+		return
+	}
+
+	body.Name = sanitizeString(body.Name)
+	body.Backend = sanitizeString(body.Backend)
+	body.Model = sanitizeString(body.Model)
+
+	if body.Name == "" {
 		jsonError(w, "name is required", http.StatusBadRequest)
 		return
 	}

--- a/v2/pkg/dashboard/api_test.go
+++ b/v2/pkg/dashboard/api_test.go
@@ -1261,3 +1261,60 @@ func TestFormatCadenceDuration(t *testing.T) {
 		}
 	}
 }
+
+func TestSanitizeString(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain text unchanged",
+			input: "my-agent",
+			want:  "my-agent",
+		},
+		{
+			name:  "script tag stripped",
+			input: `<script>alert(1)</script>`,
+			want:  "alert(1)",
+		},
+		{
+			name:  "nested tags stripped",
+			input: `<b><i>bold italic</i></b>`,
+			want:  "bold italic",
+		},
+		{
+			name:  "img tag with onerror stripped",
+			input: `<img src=x onerror=alert(1)>`,
+			want:  "",
+		},
+		{
+			name:  "mixed content",
+			input: `Agent <script>steal()</script> Name`,
+			want:  "Agent steal() Name",
+		},
+		{
+			name:  "whitespace trimmed",
+			input: "  hello  ",
+			want:  "hello",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "self-closing tag stripped",
+			input: `test<br/>value`,
+			want:  "testvalue",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeString(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeString(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `sanitizeString()` helper that strips HTML tags from user input using a compiled regexp
- Applied to all string fields in the general config handler: displayName, description, launchCmd, emoji, color, restartStrategy, beadRole, role, kickTemplate, mode, laneKeywords, detectKeywords
- Applied to governor agent add endpoint: name, backend, model
- Prevents stored XSS where `<script>alert(1)</script>` would be stored raw and could execute if rendered unsafely

## Test plan
- [x] Added `TestSanitizeString` with 8 cases covering script tags, nested tags, img/onerror, mixed content, self-closing tags, whitespace, empty string
- [x] `go build ./...` passes
- [x] `go test ./pkg/dashboard/ -run TestSanitizeString` passes