### PR TITLE
fix: proxy /contribute to Go backend

### DIFF
--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -275,26 +275,7 @@ func (s *Server) Start() error {
 	if err != nil {
 		return fmt.Errorf("loading embedded static files: %w", err)
 	}
-	indexHTML, err := fs.ReadFile(staticContent, "index.html")
-	if err != nil {
-		return fmt.Errorf("reading embedded index.html: %w", err)
-	}
-	fileServer := http.FileServer(http.FS(staticContent))
-	s.mux.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/" {
-			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			w.Write(indexHTML)
-			return
-		}
-		f, err := staticContent.Open(strings.TrimPrefix(r.URL.Path, "/"))
-		if err != nil {
-			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			w.Write(indexHTML)
-			return
-		}
-		f.Close()
-		fileServer.ServeHTTP(w, r)
-	})
+	s.mux.Handle("GET /", http.FileServer(http.FS(staticContent)))
 
 	handler := s.securityHeaders(s.mux)
 

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -110,6 +110,11 @@ function serveIndex(_req, res) {
   }
 }
 
+app.use('/contribute', createProxyMiddleware({
+  target: GO_API_URL,
+  changeOrigin: true,
+}));
+
 app.get('/', serveIndex);
 app.get('/{*splat}', serveIndex);
 


### PR DESCRIPTION
## Summary

`/contribute` was returning the SPA `index.html` because the Express proxy's `/{*splat}` catch-all served `serveIndex` for all non-API paths. Only `/api/*` was proxied to Go.

Fix: add `/contribute` as a proxied route to the Go API before the SPA catch-all.

## Test plan

- [ ] `curl http://192.168.4.85:3001/contribute` returns "Contribute to" landing page
- [ ] `curl http://192.168.4.85:3001/` still returns the SPA dashboard