### PR TITLE
fix: serialize level switch requests to prevent race condition

### DIFF
--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -211,6 +211,9 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.levelMu.Lock()
+	defer s.levelMu.Unlock()
+
 	result, err := s.ApplyPack(level)
 	if err != nil {
 		jsonError(w, err.Error(), http.StatusInternalServerError)
@@ -244,6 +247,9 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "level must be 1-6", http.StatusBadRequest)
 		return
 	}
+
+	s.levelMu.Lock()
+	defer s.levelMu.Unlock()
 
 	level := body.Level
 	s.deps.Config.ACMMLevel = &level

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -37,6 +37,7 @@ type Server struct {
 	pipelineMu     sync.RWMutex
 	hooksMu        sync.RWMutex
 	knowledgeMu    sync.Mutex
+	levelMu        sync.Mutex
 
 	tokenHistoryMu    sync.RWMutex
 	tokenHistory      []TokenSparklineEntry


### PR DESCRIPTION
## Summary
- Adds `levelMu sync.Mutex` to the dashboard `Server` struct to serialize concurrent level-switch and pack-apply operations
- Locks the mutex in `handlePackSetLevel` and `handlePackApply` after parameter validation, preventing interleaved `syncAgentVisibility`, `SyncModeFiles`, and `config.Save` calls from corrupting ACMM state
- Fixes a race where 10 concurrent L1 requests land on L4, or simultaneous L1+L6 requests land on neither

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/dashboard/...` passes
- [ ] Manual test: send 10 concurrent `PUT /api/packs/level` requests with `{"level":1}` and verify state ends at L1
- [ ] Manual test: send simultaneous L1 and L6 requests and verify one wins cleanly