### PR TITLE
fix: explicit app.get routes for /contribute proxy

### DIFF
--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -110,10 +110,12 @@ function serveIndex(_req, res) {
   }
 }
 
-app.use('/contribute', createProxyMiddleware({
+const contributeProxy = createProxyMiddleware({
   target: GO_API_URL,
   changeOrigin: true,
-}));
+});
+app.get('/contribute', contributeProxy);
+app.get('/contribute/', contributeProxy);
 
 app.get('/', serveIndex);
 app.get('/{*splat}', serveIndex);


### PR DESCRIPTION
## Summary

Previous fix used `app.use('/contribute')` which didn't match before the `/{*splat}` catch-all. 

Fix: `app.get('/contribute')` and `app.get('/contribute/')` with a shared proxy instance, placed before the catch-all. Express matches specific `get()` routes before splat.

## Test plan

- [ ] `curl http://192.168.4.85:3001/contribute` returns "Contribute to" landing page
- [ ] `curl http://192.168.4.85:3001/contribute/` also works
- [ ] `curl http://192.168.4.85:3001/` still returns the SPA