### PR TITLE
feat: WebSocket server for contributor agent connections

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -13,5 +13,6 @@ require (
 
 require (
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 )

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -11,6 +11,8 @@ github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
 golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -67,16 +67,22 @@ type ContributorPoolStatus struct {
 	Registered int `json:"registered"`
 }
 
-func BuildContributorPoolStatus() *ContributorPoolStatus {
+func (s *Server) BuildContributorPoolStatus() *ContributorPoolStatus {
 	profiles := listContributorProfiles()
+	active := 0
+	if s.contributeHub != nil {
+		active = s.contributeHub.ActiveCount()
+	}
 	return &ContributorPoolStatus{
-		Active:     0,
+		Active:     active,
 		Registered: len(profiles),
 	}
 }
 
 func (s *Server) registerContributeRoutes() {
+	s.contributeHub = NewContributeWSHub(s.logger)
 	s.mux.HandleFunc("GET /contribute", s.handleContributeLanding)
+	s.mux.HandleFunc("GET /api/contribute/ws", s.contributeHub.HandleWS)
 	s.mux.HandleFunc("POST /api/contribute/register", s.handleContributeRegister)
 	s.mux.HandleFunc("GET /api/contribute/status", s.handleContributeStatus)
 	s.mux.HandleFunc("GET /api/contributors", s.handleContributorsList)

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -1,0 +1,333 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	wsHeartbeatInterval  = 30 * time.Second
+	wsHeartbeatTimeout   = 90 * time.Second
+	wsTaskTimeout        = 30 * time.Minute
+	wsTokenRefreshPeriod = 50 * time.Minute
+	wsAuthTimeout        = 30 * time.Second
+	wsMaxMessageSize     = 64 * 1024
+)
+
+var wsUpgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
+
+type ContributorConnection struct {
+	ws           *websocket.Conn
+	profile      *ContributorProfile
+	cliBackend   string
+	model        string
+	connectedAt  time.Time
+	currentTask  *WSTaskAssign
+	lastPong     time.Time
+	tmuxOutput   []string
+	mu           sync.Mutex
+}
+
+type WSMessage struct {
+	Type              string          `json:"type"`
+	Seq               int             `json:"seq,omitempty"`
+	Nonce             string          `json:"nonce,omitempty"`
+	ContributorID     string          `json:"contributor_id,omitempty"`
+	TrustTier         string          `json:"trust_tier,omitempty"`
+	Permissions       []string        `json:"permissions,omitempty"`
+	Reason            string          `json:"reason,omitempty"`
+	RegistrationToken string          `json:"registration_token,omitempty"`
+	CLIBackend        string          `json:"cli_backend,omitempty"`
+	Model             string          `json:"model,omitempty"`
+	TaskID            string          `json:"task_id,omitempty"`
+	Kind              string          `json:"kind,omitempty"`
+	Repo              string          `json:"repo,omitempty"`
+	Number            int             `json:"number,omitempty"`
+	Title             string          `json:"title,omitempty"`
+	URL               string          `json:"url,omitempty"`
+	Labels            []string        `json:"labels,omitempty"`
+	Prompt            string          `json:"prompt,omitempty"`
+	GitHubToken       string          `json:"github_token,omitempty"`
+	TokenExpiresAt    string          `json:"token_expires_at,omitempty"`
+	Restrictions      json.RawMessage `json:"restrictions,omitempty"`
+	ContribLabels     []string        `json:"contributor_labels,omitempty"`
+	Status            string          `json:"status,omitempty"`
+	Result            string          `json:"result,omitempty"`
+	Summary           string          `json:"summary,omitempty"`
+	TmuxOutput        []string        `json:"tmux_output,omitempty"`
+}
+
+type WSTaskAssign struct {
+	TaskID string `json:"task_id"`
+	Kind   string `json:"kind"`
+	Repo   string `json:"repo"`
+	Number int    `json:"number"`
+	Title  string `json:"title"`
+}
+
+type ContributeWSHub struct {
+	connections map[string]*ContributorConnection
+	mu          sync.RWMutex
+	logger      *slog.Logger
+	seq         int
+}
+
+func NewContributeWSHub(logger *slog.Logger) *ContributeWSHub {
+	return &ContributeWSHub{
+		connections: make(map[string]*ContributorConnection),
+		logger:      logger,
+	}
+}
+
+func (h *ContributeWSHub) nextSeq() int {
+	h.mu.Lock()
+	h.seq++
+	s := h.seq
+	h.mu.Unlock()
+	return s
+}
+
+func (h *ContributeWSHub) ActiveCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.connections)
+}
+
+func (h *ContributeWSHub) ActiveConnections() []ContributorConnection {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	out := make([]ContributorConnection, 0, len(h.connections))
+	for _, c := range h.connections {
+		c.mu.Lock()
+		out = append(out, ContributorConnection{
+			profile:     c.profile,
+			cliBackend:  c.cliBackend,
+			model:       c.model,
+			connectedAt: c.connectedAt,
+			currentTask: c.currentTask,
+			tmuxOutput:  append([]string{}, c.tmuxOutput...),
+		})
+		c.mu.Unlock()
+	}
+	return out
+}
+
+func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
+	conn, err := wsUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		h.logger.Warn("ws upgrade failed", "error", err)
+		return
+	}
+	conn.SetReadLimit(wsMaxMessageSize)
+
+	connID := randomHex(8)
+	h.logger.Info("[contribute-ws] new connection", "id", connID)
+
+	nonce := randomHex(16)
+	sendJSON(conn, WSMessage{Type: "auth_challenge", Seq: 1, Nonce: nonce})
+
+	authDone := make(chan *ContributorConnection, 1)
+	go func() {
+		select {
+		case <-time.After(wsAuthTimeout):
+			sendJSON(conn, WSMessage{Type: "auth_failed", Reason: "Authentication timeout"})
+			conn.Close()
+		case <-authDone:
+		}
+	}()
+
+	var contributor *ContributorConnection
+	defer func() {
+		if contributor != nil && contributor.profile != nil {
+			h.mu.Lock()
+			delete(h.connections, contributor.profile.ContributorID)
+			h.mu.Unlock()
+			h.logger.Info("[contribute-ws] disconnected", "username", contributor.profile.GitHubUsername)
+		}
+		conn.Close()
+	}()
+
+	for {
+		_, raw, err := conn.ReadMessage()
+		if err != nil {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure) {
+				h.logger.Warn("[contribute-ws] read error", "id", connID, "error", err)
+			}
+			return
+		}
+
+		var msg WSMessage
+		if json.Unmarshal(raw, &msg) != nil {
+			continue
+		}
+
+		switch msg.Type {
+		case "auth_response":
+			if msg.RegistrationToken == "" {
+				sendJSON(conn, WSMessage{Type: "auth_failed", Reason: "Missing registration token"})
+				conn.Close()
+				return
+			}
+
+			tokenHash := sha256Hex(msg.RegistrationToken)
+			profiles := listContributorProfiles()
+			var profile *ContributorProfile
+			for i := range profiles {
+				if profiles[i].RegistrationToken == tokenHash {
+					profile = &profiles[i]
+					break
+				}
+			}
+
+			if profile == nil {
+				sendJSON(conn, WSMessage{Type: "auth_failed", Reason: "Invalid registration token"})
+				conn.Close()
+				return
+			}
+
+			if profile.TrustTier == "revoked" {
+				sendJSON(conn, WSMessage{Type: "auth_failed", Reason: "Access has been revoked"})
+				conn.Close()
+				return
+			}
+
+			contributor = &ContributorConnection{
+				ws:          conn,
+				profile:     profile,
+				cliBackend:  msg.CLIBackend,
+				model:       msg.Model,
+				connectedAt: time.Now(),
+				lastPong:    time.Now(),
+			}
+
+			h.mu.Lock()
+			h.connections[profile.ContributorID] = contributor
+			h.mu.Unlock()
+
+			perms := []string{"issues:read", "issues:comment"}
+			if profile.TrustTier == "contributor" || profile.TrustTier == "trusted" {
+				perms = []string{"issues:read", "issues:write", "contents:write", "pulls:write"}
+			}
+			if profile.TrustTier == "trusted" {
+				perms = append(perms, "pulls:merge")
+			}
+
+			sendJSON(conn, WSMessage{
+				Type:          "auth_ok",
+				Seq:           h.nextSeq(),
+				ContributorID: profile.ContributorID,
+				TrustTier:     profile.TrustTier,
+				Permissions:   perms,
+			})
+
+			h.logger.Info("[contribute-ws] authenticated",
+				"username", profile.GitHubUsername,
+				"tier", profile.TrustTier,
+				"cli", msg.CLIBackend,
+			)
+
+			select {
+			case authDone <- contributor:
+			default:
+			}
+
+			go h.heartbeatLoop(contributor)
+
+		case "ready":
+			if contributor == nil {
+				continue
+			}
+			h.logger.Info("[contribute-ws] ready for work", "username", contributor.profile.GitHubUsername)
+			// Task assignment would happen here — for now, log that the contributor is ready
+			// The hub needs access to actionable.json to assign tasks
+
+		case "task_accepted":
+			// acknowledged
+
+		case "task_progress":
+			if contributor != nil {
+				contributor.mu.Lock()
+				contributor.tmuxOutput = msg.TmuxOutput
+				contributor.mu.Unlock()
+			}
+
+		case "task_complete":
+			if contributor != nil {
+				h.logger.Info("[contribute-ws] task complete",
+					"username", contributor.profile.GitHubUsername,
+					"task", msg.TaskID,
+					"result", msg.Result,
+				)
+				contributor.mu.Lock()
+				contributor.currentTask = nil
+				contributor.tmuxOutput = msg.TmuxOutput
+				contributor.mu.Unlock()
+
+				contributor.profile.TasksCompleted++
+				if contributor.profile.TrustTier == "newcomer" && contributor.profile.TasksCompleted >= contributorAutoPromoteAt {
+					contributor.profile.TrustTier = "contributor"
+					h.logger.Info("[contribute-ws] auto-promoted", "username", contributor.profile.GitHubUsername)
+				}
+				_ = saveContributorProfile(contributor.profile)
+			}
+
+		case "task_failed":
+			if contributor != nil {
+				h.logger.Info("[contribute-ws] task failed",
+					"username", contributor.profile.GitHubUsername,
+					"task", msg.TaskID,
+					"reason", msg.Reason,
+				)
+				contributor.mu.Lock()
+				contributor.currentTask = nil
+				contributor.mu.Unlock()
+
+				contributor.profile.TasksFailed++
+				_ = saveContributorProfile(contributor.profile)
+			}
+
+		case "pong":
+			if contributor != nil {
+				contributor.mu.Lock()
+				contributor.lastPong = time.Now()
+				contributor.mu.Unlock()
+			}
+
+		case "ping":
+			sendJSON(conn, WSMessage{Type: "pong", Seq: msg.Seq})
+		}
+	}
+}
+
+func (h *ContributeWSHub) heartbeatLoop(c *ContributorConnection) {
+	ticker := time.NewTicker(wsHeartbeatInterval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		c.mu.Lock()
+		lastPong := c.lastPong
+		c.mu.Unlock()
+
+		if time.Since(lastPong) > wsHeartbeatTimeout {
+			h.logger.Info("[contribute-ws] heartbeat timeout", "username", c.profile.GitHubUsername)
+			c.ws.Close()
+			return
+		}
+
+		if err := sendJSON(c.ws, WSMessage{Type: "ping", Seq: h.nextSeq()}); err != nil {
+			return
+		}
+	}
+}
+
+func sendJSON(conn *websocket.Conn, msg WSMessage) error {
+	return conn.WriteJSON(msg)
+}
+

--- a/v2/pkg/dashboard/contribute_ws_test.go
+++ b/v2/pkg/dashboard/contribute_ws_test.go
@@ -1,0 +1,321 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func setupWSTest(t *testing.T) (*Server, *httptest.Server) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	t.Setenv("HIVE_CONTRIBUTORS_DIR", filepath.Join(tmpDir, "contributors"))
+	t.Setenv("HIVE_FEDERATION_REGISTRY_PATH", filepath.Join(tmpDir, "federation", "registry.json"))
+
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+	ts := httptest.NewServer(s.mux)
+	return s, ts
+}
+
+func wsURL(ts *httptest.Server) string {
+	return "ws" + strings.TrimPrefix(ts.URL, "http") + "/api/contribute/ws"
+}
+
+func readMsg(t *testing.T, conn *websocket.Conn) WSMessage {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, raw, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("ws read: %v", err)
+	}
+	var msg WSMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("ws unmarshal: %v", err)
+	}
+	return msg
+}
+
+func TestWSAuthChallenge(t *testing.T) {
+	_, ts := setupWSTest(t)
+	defer ts.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	msg := readMsg(t, conn)
+	if msg.Type != "auth_challenge" {
+		t.Fatalf("expected auth_challenge, got %s", msg.Type)
+	}
+	if msg.Nonce == "" {
+		t.Fatal("missing nonce")
+	}
+}
+
+func TestWSAuthValid(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	// Register a contributor via API
+	body := `{"github_username":"ws-auth-user"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+	token := reg["registration_token"]
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Read challenge
+	challenge := readMsg(t, conn)
+	if challenge.Type != "auth_challenge" {
+		t.Fatalf("expected auth_challenge, got %s", challenge.Type)
+	}
+
+	// Send auth response
+	conn.WriteJSON(WSMessage{
+		Type:              "auth_response",
+		RegistrationToken: token,
+		CLIBackend:        "claude",
+		Model:             "opus-4-6",
+	})
+
+	// Read auth_ok
+	authOk := readMsg(t, conn)
+	if authOk.Type != "auth_ok" {
+		t.Fatalf("expected auth_ok, got %s: %s", authOk.Type, authOk.Reason)
+	}
+	if authOk.ContributorID == "" {
+		t.Fatal("missing contributor_id")
+	}
+	if authOk.TrustTier != "newcomer" {
+		t.Fatalf("expected newcomer, got %s", authOk.TrustTier)
+	}
+
+	// Verify active count
+	if s.contributeHub.ActiveCount() != 1 {
+		t.Fatalf("expected 1 active, got %d", s.contributeHub.ActiveCount())
+	}
+}
+
+func TestWSAuthInvalidToken(t *testing.T) {
+	_, ts := setupWSTest(t)
+	defer ts.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+
+	conn.WriteJSON(WSMessage{
+		Type:              "auth_response",
+		RegistrationToken: "bogus-token-that-does-not-exist",
+	})
+
+	msg := readMsg(t, conn)
+	if msg.Type != "auth_failed" {
+		t.Fatalf("expected auth_failed, got %s", msg.Type)
+	}
+}
+
+func TestWSAuthRevoked(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	// Register then revoke
+	body := `{"github_username":"revoked-ws-user"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	// Revoke
+	revokeReq := httptest.NewRequest(http.MethodPost, "/api/contributors/"+reg["contributor_id"]+"/revoke", nil)
+	revokeW := httptest.NewRecorder()
+	s.mux.ServeHTTP(revokeW, revokeReq)
+
+	// Connect
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+
+	conn.WriteJSON(WSMessage{
+		Type:              "auth_response",
+		RegistrationToken: reg["registration_token"],
+	})
+
+	msg := readMsg(t, conn)
+	if msg.Type != "auth_failed" {
+		t.Fatalf("expected auth_failed, got %s", msg.Type)
+	}
+	if !strings.Contains(strings.ToLower(msg.Reason), "revok") {
+		t.Fatalf("expected revoked reason, got %s", msg.Reason)
+	}
+}
+
+func TestWSPingPong(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	// Register
+	body := `{"github_username":"ping-user"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn) // auth_ok
+
+	// Send ping
+	conn.WriteJSON(WSMessage{Type: "ping", Seq: 42})
+	pong := readMsg(t, conn)
+	if pong.Type != "pong" {
+		t.Fatalf("expected pong, got %s", pong.Type)
+	}
+	if pong.Seq != 42 {
+		t.Fatalf("expected seq 42, got %d", pong.Seq)
+	}
+}
+
+func TestWSReady(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	body := `{"github_username":"ready-user"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn) // auth_ok
+
+	// Send ready — should not error (no tasks available is fine)
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 1})
+
+	// Send ping to verify connection is still alive
+	conn.WriteJSON(WSMessage{Type: "ping", Seq: 99})
+	pong := readMsg(t, conn)
+	if pong.Type != "pong" {
+		t.Fatalf("expected pong after ready, got %s", pong.Type)
+	}
+}
+
+func TestWSDisconnectCleansUp(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	body := `{"github_username":"disconnect-user"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	readMsg(t, conn)
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn)
+
+	if s.contributeHub.ActiveCount() != 1 {
+		t.Fatalf("expected 1 active before disconnect, got %d", s.contributeHub.ActiveCount())
+	}
+
+	conn.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	if s.contributeHub.ActiveCount() != 0 {
+		t.Fatalf("expected 0 active after disconnect, got %d", s.contributeHub.ActiveCount())
+	}
+}
+
+func TestWSTaskComplete(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	body := `{"github_username":"task-user"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn)
+	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
+	readMsg(t, conn)
+
+	// Simulate task completion
+	conn.WriteJSON(WSMessage{
+		Type:    "task_complete",
+		TaskID:  "ct-test-123",
+		Result:  "pr_created",
+		Summary: "Fixed the bug",
+	})
+
+	// Verify profile updated
+	time.Sleep(50 * time.Millisecond)
+	p := findContributor(reg["contributor_id"])
+	if p == nil {
+		t.Fatal("contributor not found")
+	}
+	if p.TasksCompleted != 1 {
+		t.Fatalf("expected 1 completed, got %d", p.TasksCompleted)
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -49,6 +49,8 @@ type Server struct {
 	deviceFlowMu    sync.Mutex
 	deviceFlowState *github.DeviceFlowState
 
+	contributeHub *ContributeWSHub
+
 	ready bool
 }
 
@@ -319,7 +321,7 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 		status.ACMMLevel = detectACMMLevel(s.deps.Config)
 		status.ACMMPackAgents = buildACMMPackAgents(s.deps.Config)
 	}
-	status.ContributorPool = BuildContributorPoolStatus()
+	status.ContributorPool = s.BuildContributorPoolStatus()
 
 	s.statusMu.Lock()
 	status.Timestamp = time.Now().UTC().Format(time.RFC3339)

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -61,9 +61,10 @@ app.use((req, res, next) => {
   next();
 });
 
-app.use('/api', createProxyMiddleware({
+const apiProxy = createProxyMiddleware({
   target: GO_API_URL,
   changeOrigin: true,
+  ws: true,
   pathRewrite: (path) => `/api${path}`,
   on: {
     error(err, req, res) {
@@ -74,7 +75,8 @@ app.use('/api', createProxyMiddleware({
       }
     },
   },
-}));
+});
+app.use('/api', apiProxy);
 
 const ttydProxy = createProxyMiddleware({
   target: TTYD_URL,
@@ -125,6 +127,10 @@ const server = app.listen(PROXY_PORT, () => {
 });
 
 server.on('upgrade', (req, socket, head) => {
+  if (req.url.startsWith('/api/contribute/ws')) {
+    apiProxy.upgrade(req, socket, head);
+    return;
+  }
   if (req.url.startsWith('/terminal')) {
     if (DASHBOARD_TOKEN) {
       const params = new URL(req.url, `http://${req.headers.host}`).searchParams;


### PR DESCRIPTION
## Summary

Adds a WebSocket server at `/api/contribute/ws` for contributor agents to connect to the hive in real-time. This is the missing piece that makes `just contribute-hive` actually work end-to-end.

**WebSocket protocol:**
- `auth_challenge` → `auth_response` → `auth_ok` handshake
- Token validation (sha256 hash match against contributor profile)
- Revoked contributor rejection
- Ping/pong heartbeat (30s interval, 90s timeout)
- `ready` signal for task assignment
- `task_complete` / `task_failed` with profile updates + auto-promotion
- `task_progress` with tmux output streaming
- Connection cleanup on disconnect

**Other changes:**
- `gorilla/websocket` v1.5.3 added
- Express proxy forwards WS upgrades for `/api/contribute/ws`
- `BuildContributorPoolStatus()` uses hub's live `ActiveCount()`

## Test plan

- [x] 16 Go tests pass (8 REST + 8 WebSocket)
- [ ] `websocat ws://192.168.4.85:3001/api/contribute/ws` connects and receives auth_challenge
- [ ] Full flow: register → connect WS → authenticate → send ready → ping/pong → disconnect