### PR TITLE
fix: username allows dots, max length 39, hive update indicator

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -432,7 +432,7 @@ func (s *Server) handleHivesRegister(w http.ResponseWriter, r *http.Request) {
 			reg.Hives[i].HubURL = req.HubURL
 			reg.Hives[i].DashboardURL = req.DashboardURL
 			_ = saveFederationRegistry(reg)
-			jsonResponse(w, map[string]any{"ok": true, "id": hiveID})
+			jsonResponse(w, map[string]any{"ok": true, "id": hiveID, "updated": true})
 			return
 		}
 	}
@@ -518,12 +518,17 @@ func (s *Server) handleHivesOnboard(w http.ResponseWriter, r *http.Request) {
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
+const maxUsernameLength = 39 // GitHub max username length
+
 func isValidUsername(s string) bool {
+	if len(s) == 0 || len(s) > maxUsernameLength {
+		return false
+	}
 	for _, c := range s {
-		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_') {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.') {
 			return false
 		}
 	}
-	return len(s) > 0
+	return true
 }
 

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -200,9 +201,15 @@ func TestIsValidUsername(t *testing.T) {
 		{"testuser", true},
 		{"test-user", true},
 		{"test_user123", true},
+		{"j.doe", true},
+		{"user.name.with.dots", true},
 		{"bad user!", false},
 		{"", false},
 		{"user@name", false},
+		{"<script>alert(1)</script>", false},
+		{"../../../etc/passwd", false},
+		{strings.Repeat("a", 39), true},
+		{strings.Repeat("a", 40), false},
 	}
 	for _, tc := range cases {
 		got := isValidUsername(tc.input)


### PR DESCRIPTION
## Summary

Found via live testing on 4.85:

1. **Username with dots rejected** — GitHub allows dots (e.g., `j.doe`). Fixed `isValidUsername` to allow `.`
2. **No username length limit** — Could create absurdly long filenames. Capped at 39 (GitHub's max)
3. **Hive re-register silent** — Now returns `{updated: true}` when updating an existing hive

6 new test cases for validation edge cases (path traversal, XSS, dots, length).

## Test plan

- [x] All 22 tests pass (16 existing + 6 new validation cases)