### PR TITLE
fix: WebSocket 404 on /api/contribute/ws

### DIFF
--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -128,6 +128,10 @@ const server = app.listen(PROXY_PORT, () => {
 
 server.on('upgrade', (req, socket, head) => {
   if (req.url.startsWith('/api/contribute/ws')) {
+    // Strip the /api prefix so pathRewrite produces /api/contribute/ws
+    // (not /api/api/contribute/ws). Express middleware strips the mount
+    // path for HTTP requests, but the upgrade handler receives the full URL.
+    req.url = req.url.replace(/^\/api/, '');
     apiProxy.upgrade(req, socket, head);
     return;
   }


### PR DESCRIPTION
## Summary
- Fix WebSocket upgrade proxy producing double `/api` prefix (`/api/api/contribute/ws`) causing 404 on the Go server
- The Express `server.on('upgrade')` handler receives the full URL `/api/contribute/ws`, but unlike Express middleware routing, it does not strip the mount path — so `pathRewrite: (path) => /api${path}` produces `/api/api/contribute/ws`
- Strip the `/api` prefix from `req.url` before forwarding to `apiProxy.upgrade()` so the Go server receives the correct path `/api/contribute/ws`

## Test plan
- [ ] Deploy to 192.168.4.85:3001
- [ ] Verify `websocat ws://192.168.4.85:3001/api/contribute/ws` connects (no 404)
- [ ] Verify existing HTTP API routes still work