### PR TITLE
feat: add contributor leaderboard page and API

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -89,6 +90,9 @@ func (s *Server) registerContributeRoutes() {
 	s.mux.HandleFunc("GET /api/contributors/{id}", s.handleContributorGet)
 	s.mux.HandleFunc("PUT /api/contributors/{id}/trust", s.handleContributorTrust)
 	s.mux.HandleFunc("POST /api/contributors/{id}/revoke", s.handleContributorRevoke)
+
+	s.mux.HandleFunc("GET /leaderboard", s.handleLeaderboardPage)
+	s.mux.HandleFunc("GET /api/leaderboard", s.handleLeaderboardAPI)
 
 	s.mux.HandleFunc("GET /api/hives", s.handleHivesList)
 	s.mux.HandleFunc("POST /api/hives/register", s.handleHivesRegister)
@@ -514,6 +518,136 @@ func (s *Server) handleHivesOnboard(w http.ResponseWriter, r *http.Request) {
 			"5. Register: POST /api/hives/register",
 		},
 	})
+}
+
+// ── Leaderboard ───────────────────────────────────────────────────────────
+
+// LeaderboardEntry is the JSON shape returned by the leaderboard API.
+type LeaderboardEntry struct {
+	Rank           int    `json:"rank"`
+	GitHubUsername string `json:"github_username"`
+	AvatarURL      string `json:"avatar_url"`
+	TrustTier      string `json:"trust_tier"`
+	TasksCompleted int    `json:"tasks_completed"`
+	TasksFailed    int    `json:"tasks_failed"`
+	RegisteredAt   string `json:"registered_at"`
+}
+
+// buildLeaderboard loads all contributor profiles, sorts by tasks completed
+// descending, and returns ranked entries with secrets stripped.
+func buildLeaderboard() []LeaderboardEntry {
+	profiles := listContributorProfiles()
+	sort.Slice(profiles, func(i, j int) bool {
+		return profiles[i].TasksCompleted > profiles[j].TasksCompleted
+	})
+
+	entries := make([]LeaderboardEntry, 0, len(profiles))
+	for i, p := range profiles {
+		entries = append(entries, LeaderboardEntry{
+			Rank:           i + 1,
+			GitHubUsername: p.GitHubUsername,
+			AvatarURL:      fmt.Sprintf("https://github.com/%s.png", p.GitHubUsername),
+			TrustTier:      p.TrustTier,
+			TasksCompleted: p.TasksCompleted,
+			TasksFailed:    p.TasksFailed,
+			RegisteredAt:   p.RegisteredAt,
+		})
+	}
+	return entries
+}
+
+func (s *Server) handleLeaderboardAPI(w http.ResponseWriter, _ *http.Request) {
+	jsonResponse(w, map[string]any{"leaderboard": buildLeaderboard()})
+}
+
+// trustTierColor maps trust tiers to badge background colours.
+func trustTierColor(tier string) string {
+	switch tier {
+	case "newcomer":
+		return "#8b949e"
+	case "contributor":
+		return "#3fb950"
+	case "trusted":
+		return "#d29922"
+	case "advisor":
+		return "#a371f7"
+	case "revoked":
+		return "#f85149"
+	default:
+		return "#8b949e"
+	}
+}
+
+func (s *Server) handleLeaderboardPage(w http.ResponseWriter, _ *http.Request) {
+	entries := buildLeaderboard()
+	projectName := ""
+	if s.deps != nil && s.deps.Config != nil {
+		projectName = s.deps.Config.Project.Name
+	}
+	if projectName == "" {
+		projectName = "Hive"
+	}
+
+	var rows strings.Builder
+	for _, e := range entries {
+		rows.WriteString(fmt.Sprintf(
+			`<tr>
+<td class="rank">#%d</td>
+<td class="user"><img src="%s" width="32" height="32" alt="%s"><a href="https://github.com/%s" target="_blank" rel="noopener">%s</a></td>
+<td><span class="badge" style="background:%s">%s</span></td>
+<td class="num">%d</td>
+<td class="num">%d</td>
+<td class="date">%s</td>
+</tr>`,
+			e.Rank,
+			e.AvatarURL, e.GitHubUsername,
+			e.GitHubUsername, e.GitHubUsername,
+			trustTierColor(e.TrustTier), e.TrustTier,
+			e.TasksCompleted,
+			e.TasksFailed,
+			e.RegisteredAt,
+		))
+	}
+
+	const avatarSize = 32 // pixels for contributor avatar thumbnails
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, `<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><title>%s Contributor Leaderboard</title>
+<style>
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#0d1117;color:#e6edf3;margin:0;padding:40px;max-width:900px;margin:0 auto}
+h1{font-size:2rem;margin-bottom:8px}
+.subtitle{color:#8b949e;font-size:1.1rem;margin-bottom:32px}
+table{width:100%%;border-collapse:collapse;background:#161b22;border:1px solid #30363d;border-radius:12px;overflow:hidden}
+th{text-align:left;padding:12px 16px;color:#8b949e;font-size:.8rem;font-weight:600;border-bottom:2px solid #30363d}
+td{padding:10px 16px;border-bottom:1px solid #21262d;font-size:.9rem}
+tr:last-child td{border-bottom:none}
+tr:hover{background:#1c2128}
+.rank{font-weight:700;color:#58a6ff;width:60px}
+.user{display:flex;align-items:center;gap:10px}
+.user img{border-radius:50%%}
+.user a{color:#58a6ff;text-decoration:none}
+.user a:hover{text-decoration:underline}
+.badge{display:inline-block;padding:2px 10px;border-radius:12px;font-size:.75rem;font-weight:600;color:#fff;text-transform:capitalize}
+.num{text-align:right;font-variant-numeric:tabular-nums}
+.date{color:#8b949e;font-size:.8rem}
+.empty{text-align:center;padding:40px;color:#8b949e}
+</style></head><body>
+<h1>🏆 %s Contributor Leaderboard</h1>
+<p class="subtitle">Contributors ranked by completed tasks.</p>
+<table>
+<thead><tr><th>Rank</th><th>Contributor</th><th>Trust Tier</th><th style="text-align:right">Completed</th><th style="text-align:right">Failed</th><th>Registered</th></tr></thead>
+<tbody>%s</tbody>
+</table>
+%s
+</body></html>`,
+		projectName, projectName, rows.String(),
+		func() string {
+			if len(entries) == 0 {
+				return `<div class="empty">No contributors yet. <a href="/contribute" style="color:#58a6ff">Be the first!</a></div>`
+			}
+			return ""
+		}())
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -193,6 +193,171 @@ func TestHivesRegisterMissingFields(t *testing.T) {
 	}
 }
 
+// ── Leaderboard tests ─────────────────────────────────────────────────────
+
+func seedContributor(t *testing.T, username string, completed, failed int) {
+	t.Helper()
+	p := &ContributorProfile{
+		GitHubUsername: username,
+		ContributorID:  "c-" + username,
+		TrustTier:      "contributor",
+		TasksCompleted: completed,
+		TasksFailed:    failed,
+		RegisteredAt:   "2025-01-01T00:00:00Z",
+	}
+	if err := saveContributorProfile(p); err != nil {
+		t.Fatalf("seedContributor(%s): %v", username, err)
+	}
+}
+
+func TestLeaderboardAPIEmpty(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/leaderboard", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Leaderboard []LeaderboardEntry `json:"leaderboard"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(resp.Leaderboard) != 0 {
+		t.Errorf("expected empty leaderboard, got %d entries", len(resp.Leaderboard))
+	}
+}
+
+func TestLeaderboardAPISorted(t *testing.T) {
+	setupContributeEnv(t)
+
+	seedContributor(t, "alice", 10, 2)
+	seedContributor(t, "bob", 25, 1)
+	seedContributor(t, "carol", 5, 0)
+
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/leaderboard", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Leaderboard []LeaderboardEntry `json:"leaderboard"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if len(resp.Leaderboard) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(resp.Leaderboard))
+	}
+
+	// Verify sort order: bob (25) > alice (10) > carol (5)
+	expectedOrder := []string{"bob", "alice", "carol"}
+	for i, name := range expectedOrder {
+		if resp.Leaderboard[i].GitHubUsername != name {
+			t.Errorf("rank %d: expected %s, got %s", i+1, name, resp.Leaderboard[i].GitHubUsername)
+		}
+		if resp.Leaderboard[i].Rank != i+1 {
+			t.Errorf("rank %d: expected rank=%d, got rank=%d", i+1, i+1, resp.Leaderboard[i].Rank)
+		}
+	}
+
+	// Verify avatar URL format
+	if resp.Leaderboard[0].AvatarURL != "https://github.com/bob.png" {
+		t.Errorf("unexpected avatar URL: %s", resp.Leaderboard[0].AvatarURL)
+	}
+}
+
+func TestLeaderboardPageHTML(t *testing.T) {
+	setupContributeEnv(t)
+
+	seedContributor(t, "alice", 10, 2)
+
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/leaderboard", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	contentType := w.Header().Get("Content-Type")
+	if !strings.Contains(contentType, "text/html") {
+		t.Errorf("expected text/html content-type, got %s", contentType)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "Leaderboard") {
+		t.Error("page missing 'Leaderboard' heading")
+	}
+	if !strings.Contains(body, "alice") {
+		t.Error("page missing contributor 'alice'")
+	}
+	if !strings.Contains(body, "https://github.com/alice.png") {
+		t.Error("page missing avatar URL for alice")
+	}
+	if !strings.Contains(body, "https://github.com/alice") {
+		t.Error("page missing GitHub profile link for alice")
+	}
+}
+
+func TestLeaderboardPageEmpty(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	req := httptest.NewRequest(http.MethodGet, "/leaderboard", nil)
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	if !strings.Contains(body, "No contributors yet") {
+		t.Error("empty page should show 'No contributors yet' message")
+	}
+	if !strings.Contains(body, "/contribute") {
+		t.Error("empty page should link to /contribute")
+	}
+}
+
+func TestTrustTierColor(t *testing.T) {
+	cases := []struct {
+		tier  string
+		color string
+	}{
+		{"newcomer", "#8b949e"},
+		{"contributor", "#3fb950"},
+		{"trusted", "#d29922"},
+		{"advisor", "#a371f7"},
+		{"revoked", "#f85149"},
+		{"unknown", "#8b949e"},
+	}
+	for _, tc := range cases {
+		got := trustTierColor(tc.tier)
+		if got != tc.color {
+			t.Errorf("trustTierColor(%q) = %q, want %q", tc.tier, got, tc.color)
+		}
+	}
+}
+
 func TestIsValidUsername(t *testing.T) {
 	cases := []struct {
 		input string

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -119,6 +119,13 @@ const contributeProxy = createProxyMiddleware({
 app.get('/contribute', contributeProxy);
 app.get('/contribute/', contributeProxy);
 
+const leaderboardProxy = createProxyMiddleware({
+  target: GO_API_URL,
+  changeOrigin: true,
+});
+app.get('/leaderboard', leaderboardProxy);
+app.get('/leaderboard/', leaderboardProxy);
+
 app.get('/', serveIndex);
 app.get('/{*splat}', serveIndex);
 


### PR DESCRIPTION
## Summary
- Adds `GET /leaderboard` HTML page showing a ranked table of contributors sorted by tasks completed, with GitHub avatars, profile links, color-coded trust tier badges, task stats, and registration dates
- Adds `GET /api/leaderboard` JSON endpoint returning the same sorted data
- Adds proxy route in `v2/proxy/server.js` for `/leaderboard` (same pattern as `/contribute`)
- Includes 6 Go tests covering both endpoints (empty state, sorted order, HTML content, trust tier colors)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/dashboard/ -run TestLeaderboard -v` — all 4 leaderboard tests pass
- [x] `go test ./pkg/dashboard/ -run TestTrustTierColor -v` — passes
- [ ] CI build-and-test workflow passes