### PR TITLE
feat: add role-based contributor mode

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -41,6 +41,7 @@ type ContributorProfile struct {
 	RegistrationToken  string                `json:"registration_token"`
 	TokenPlain         string                `json:"registration_token_plain,omitempty"`
 	TrustTier          string                `json:"trust_tier"`
+	PreferredRole      string                `json:"preferred_role,omitempty"`
 	RegisteredAt       string                `json:"registered_at"`
 	TasksCompleted     int                   `json:"total_tasks_completed"`
 	TasksFailed        int                   `json:"total_tasks_failed"`
@@ -63,19 +64,23 @@ type ContributorPool struct {
 var contributorPool = &ContributorPool{}
 
 type ContributorPoolStatus struct {
-	Active     int `json:"active"`
-	Registered int `json:"registered"`
+	Active     int            `json:"active"`
+	Registered int            `json:"registered"`
+	ByRole     map[string]int `json:"by_role,omitempty"`
 }
 
 func (s *Server) BuildContributorPoolStatus() *ContributorPoolStatus {
 	profiles := listContributorProfiles()
 	active := 0
+	var byRole map[string]int
 	if s.contributeHub != nil {
 		active = s.contributeHub.ActiveCount()
+		byRole = s.contributeHub.RoleBreakdown()
 	}
 	return &ContributorPoolStatus{
 		Active:     active,
 		Registered: len(profiles),
+		ByRole:     byRole,
 	}
 }
 

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -28,6 +28,7 @@ type ContributorConnection struct {
 	profile      *ContributorProfile
 	cliBackend   string
 	model        string
+	role         string // empty = task-driven mode, "scanner"/"reviewer"/etc. = role mode
 	connectedAt  time.Time
 	currentTask  *WSTaskAssign
 	lastPong     time.Time
@@ -57,6 +58,7 @@ type WSMessage struct {
 	GitHubToken       string          `json:"github_token,omitempty"`
 	TokenExpiresAt    string          `json:"token_expires_at,omitempty"`
 	Restrictions      json.RawMessage `json:"restrictions,omitempty"`
+	Role              string          `json:"role,omitempty"`
 	ContribLabels     []string        `json:"contributor_labels,omitempty"`
 	Status            string          `json:"status,omitempty"`
 	Result            string          `json:"result,omitempty"`
@@ -100,6 +102,24 @@ func (h *ContributeWSHub) ActiveCount() int {
 	return len(h.connections)
 }
 
+// RoleBreakdown returns a count of active connections grouped by role.
+// Connections without a role (task-driven mode) are counted under "task-driven".
+func (h *ContributeWSHub) RoleBreakdown() map[string]int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	breakdown := make(map[string]int)
+	for _, c := range h.connections {
+		c.mu.Lock()
+		role := c.role
+		c.mu.Unlock()
+		if role == "" {
+			role = "task-driven"
+		}
+		breakdown[role]++
+	}
+	return breakdown
+}
+
 func (h *ContributeWSHub) ActiveConnections() []ContributorConnection {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
@@ -110,6 +130,7 @@ func (h *ContributeWSHub) ActiveConnections() []ContributorConnection {
 			profile:     c.profile,
 			cliBackend:  c.cliBackend,
 			model:       c.model,
+			role:        c.role,
 			connectedAt: c.connectedAt,
 			currentTask: c.currentTask,
 			tmuxOutput:  append([]string{}, c.tmuxOutput...),
@@ -203,6 +224,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				profile:     profile,
 				cliBackend:  msg.CLIBackend,
 				model:       msg.Model,
+				role:        msg.Role,
 				connectedAt: time.Now(),
 				lastPong:    time.Now(),
 			}
@@ -225,12 +247,14 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				ContributorID: profile.ContributorID,
 				TrustTier:     profile.TrustTier,
 				Permissions:   perms,
+				Role:          msg.Role,
 			})
 
 			h.logger.Info("[contribute-ws] authenticated",
 				"username", profile.GitHubUsername,
 				"tier", profile.TrustTier,
 				"cli", msg.CLIBackend,
+				"role", msg.Role,
 			)
 
 			select {
@@ -244,9 +268,19 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			if contributor == nil {
 				continue
 			}
-			h.logger.Info("[contribute-ws] ready for work", "username", contributor.profile.GitHubUsername)
-			// Task assignment would happen here — for now, log that the contributor is ready
-			// The hub needs access to actionable.json to assign tasks
+			if contributor.role != "" {
+				h.logger.Info("[contribute-ws] role-based contributor ready",
+					"username", contributor.profile.GitHubUsername,
+					"role", contributor.role,
+				)
+				// Role-based contributors act as remote instances of an agent role
+				// (e.g., scanner, reviewer). The hive operator can pause the local
+				// agent for that role to save tokens while this contributor covers it.
+			} else {
+				h.logger.Info("[contribute-ws] ready for work", "username", contributor.profile.GitHubUsername)
+				// Task assignment would happen here — for now, log that the contributor is ready
+				// The hub needs access to actionable.json to assign tasks
+			}
 
 		case "task_accepted":
 			// acknowledged

--- a/v2/pkg/dashboard/contribute_ws_test.go
+++ b/v2/pkg/dashboard/contribute_ws_test.go
@@ -319,3 +319,216 @@ func TestWSTaskComplete(t *testing.T) {
 		t.Fatalf("expected 1 completed, got %d", p.TasksCompleted)
 	}
 }
+
+func TestWSAuthWithRole(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	// Register a contributor
+	body := `{"github_username":"role-auth-user"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+	token := reg["registration_token"]
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+
+	// Send auth response with role
+	conn.WriteJSON(WSMessage{
+		Type:              "auth_response",
+		RegistrationToken: token,
+		CLIBackend:        "claude",
+		Model:             "opus-4-6",
+		Role:              "scanner",
+	})
+
+	authOk := readMsg(t, conn)
+	if authOk.Type != "auth_ok" {
+		t.Fatalf("expected auth_ok, got %s: %s", authOk.Type, authOk.Reason)
+	}
+	if authOk.Role != "scanner" {
+		t.Fatalf("expected role 'scanner' in auth_ok, got %q", authOk.Role)
+	}
+
+	// Verify the connection has the role stored
+	conns := s.contributeHub.ActiveConnections()
+	if len(conns) != 1 {
+		t.Fatalf("expected 1 active connection, got %d", len(conns))
+	}
+	if conns[0].role != "scanner" {
+		t.Fatalf("expected connection role 'scanner', got %q", conns[0].role)
+	}
+}
+
+func TestWSAuthWithoutRole(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	body := `{"github_username":"norole-user"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+
+	conn.WriteJSON(WSMessage{
+		Type:              "auth_response",
+		RegistrationToken: reg["registration_token"],
+		CLIBackend:        "claude",
+		Model:             "opus-4-6",
+	})
+
+	authOk := readMsg(t, conn)
+	if authOk.Type != "auth_ok" {
+		t.Fatalf("expected auth_ok, got %s", authOk.Type)
+	}
+	if authOk.Role != "" {
+		t.Fatalf("expected empty role for task-driven mode, got %q", authOk.Role)
+	}
+}
+
+func TestWSRoleBreakdown(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	// Register three contributors
+	usernames := []string{"role-breakdown-1", "role-breakdown-2", "role-breakdown-3"}
+	tokens := make([]string, len(usernames))
+	for i, u := range usernames {
+		body := `{"github_username":"` + u + `"}`
+		req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		s.mux.ServeHTTP(w, req)
+		var reg map[string]string
+		json.Unmarshal(w.Body.Bytes(), &reg)
+		tokens[i] = reg["registration_token"]
+	}
+
+	// Connect: user1 as scanner, user2 as reviewer, user3 as task-driven (no role)
+	roles := []string{"scanner", "reviewer", ""}
+	conns := make([]*websocket.Conn, len(usernames))
+	for i, tok := range tokens {
+		c, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+		if err != nil {
+			t.Fatalf("dial %d: %v", i, err)
+		}
+		defer c.Close()
+		conns[i] = c
+
+		readMsg(t, c) // challenge
+		msg := WSMessage{
+			Type:              "auth_response",
+			RegistrationToken: tok,
+			CLIBackend:        "claude",
+			Model:             "opus-4-6",
+		}
+		if roles[i] != "" {
+			msg.Role = roles[i]
+		}
+		c.WriteJSON(msg)
+		readMsg(t, c) // auth_ok
+	}
+
+	// Check role breakdown
+	breakdown := s.contributeHub.RoleBreakdown()
+	if breakdown["scanner"] != 1 {
+		t.Fatalf("expected 1 scanner, got %d", breakdown["scanner"])
+	}
+	if breakdown["reviewer"] != 1 {
+		t.Fatalf("expected 1 reviewer, got %d", breakdown["reviewer"])
+	}
+	if breakdown["task-driven"] != 1 {
+		t.Fatalf("expected 1 task-driven, got %d", breakdown["task-driven"])
+	}
+
+	// Check pool status includes role breakdown
+	poolStatus := s.BuildContributorPoolStatus()
+	if poolStatus.Active != 3 {
+		t.Fatalf("expected 3 active, got %d", poolStatus.Active)
+	}
+	if poolStatus.ByRole == nil {
+		t.Fatal("expected non-nil ByRole in pool status")
+	}
+	if poolStatus.ByRole["scanner"] != 1 {
+		t.Fatalf("pool status: expected 1 scanner, got %d", poolStatus.ByRole["scanner"])
+	}
+}
+
+func TestWSRoleBasedReady(t *testing.T) {
+	s, ts := setupWSTest(t)
+	defer ts.Close()
+
+	body := `{"github_username":"role-ready-user"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	var reg map[string]string
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(ts), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	readMsg(t, conn) // challenge
+	conn.WriteJSON(WSMessage{
+		Type:              "auth_response",
+		RegistrationToken: reg["registration_token"],
+		CLIBackend:        "claude",
+		Model:             "opus-4-6",
+		Role:              "ci-maintainer",
+	})
+	readMsg(t, conn) // auth_ok
+
+	// Send ready — role-based contributors should not get task assignments
+	conn.WriteJSON(WSMessage{Type: "ready", Seq: 1})
+
+	// Verify connection is still alive
+	conn.WriteJSON(WSMessage{Type: "ping", Seq: 99})
+	pong := readMsg(t, conn)
+	if pong.Type != "pong" {
+		t.Fatalf("expected pong after role-based ready, got %s", pong.Type)
+	}
+}
+
+func TestContributorProfilePreferredRole(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HIVE_CONTRIBUTORS_DIR", tmpDir)
+
+	profile, _ := createContributorProfile("role-pref-user")
+	profile.PreferredRole = "scanner"
+	if err := saveContributorProfile(profile); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loaded, err := loadContributorProfile("role-pref-user")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded.PreferredRole != "scanner" {
+		t.Fatalf("expected preferred_role 'scanner', got %q", loaded.PreferredRole)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds optional `role` field to the contributor WebSocket auth flow, enabling contributors to run as a specific agent role (scanner, reviewer, ci-maintainer, etc.) instead of receiving individual task assignments
- When a contributor connects with a role, the hive operator can pause the local agent for that role to save tokens — the contributor's agent covers the same work using their own API keys
- Adds `ByRole` breakdown to `ContributorPoolStatus` so the SSE dashboard data shows how many scanners, reviewers, etc. are connected
- Adds `PreferredRole` field to `ContributorProfile` for persistence

## Test plan

- [x] `TestWSAuthWithRole` — role is stored on connection and echoed in auth_ok
- [x] `TestWSAuthWithoutRole` — task-driven mode (no role) still works unchanged
- [x] `TestWSRoleBreakdown` — multiple contributors with different roles produce correct breakdown
- [x] `TestWSRoleBasedReady` — role-based contributors handle `ready` without task assignment
- [x] `TestContributorProfilePreferredRole` — preferred role persists through save/load cycle
- [x] All existing tests pass unchanged