### PR TITLE
feat: redesign leaderboard to match kubestellar.io style

### DIFF
--- a/dashboard/publish-snapshot-v2.sh
+++ b/dashboard/publish-snapshot-v2.sh
@@ -108,6 +108,18 @@ node "${SCRIPT_DIR}/build-snapshot.mjs" \
 
 cp "${PUBLISH_PATH}/light/index.html" "${PUBLISH_PATH}/index.html"
 
+# Capture the leaderboard page as a static snapshot.
+# The Go handler at /leaderboard serves a self-contained HTML page with
+# baked-in data; we just fetch and save it.
+echo "[${INSTANCE}] Capturing leaderboard..."
+mkdir -p "${PUBLISH_PATH}/leaderboard"
+LEADERBOARD_FETCH_TIMEOUT_S=10
+if curl -sf --max-time "$LEADERBOARD_FETCH_TIMEOUT_S" "${DASHBOARD_URL}/leaderboard" -o "${PUBLISH_PATH}/leaderboard/index.html" 2>/dev/null; then
+  echo "[${INSTANCE}] Leaderboard captured."
+else
+  echo "[${INSTANCE}] WARN: leaderboard fetch failed — skipping."
+fi
+
 # Stage first so both new and modified files are detected
 git add "${PUBLISH_PATH}/"
 if git diff --cached --quiet -- "${PUBLISH_PATH}/"; then

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -807,6 +807,28 @@ border-radius:8px;border:1px solid rgba(255,255,255,0.05);padding:24px}
   .row .reg-date{padding-left:44px}
 }
 
+/* ── Hover card ── */
+.hover-card-anchor{position:relative}
+.hover-card{display:none;position:absolute;left:0;top:100%%;margin-top:8px;z-index:50;
+width:320px;background:rgba(17,24,39,0.95);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);
+border-radius:12px;border:1px solid rgba(255,255,255,0.1);box-shadow:0 25px 50px -12px rgba(0,0,0,0.5);
+overflow:hidden;pointer-events:none}
+.hover-card-anchor:hover .hover-card{display:block}
+.hover-card .hc-header{padding:16px;border-bottom:1px solid rgba(255,255,255,0.05);display:flex;align-items:center;gap:12px}
+.hover-card .hc-header img{width:40px;height:40px;border-radius:50%%}
+.hover-card .hc-name{font-size:.875rem;font-weight:600;color:#fff}
+.hover-card .hc-meta{font-size:.75rem;color:#9ca3af;margin-top:2px}
+.hover-card .hc-meta .hc-pts{color:#facc15;font-weight:600}
+.hover-card .hc-section{padding:12px 16px;border-bottom:1px solid rgba(255,255,255,0.05)}
+.hover-card .hc-label{font-size:10px;text-transform:uppercase;letter-spacing:.05em;color:#6b7280;margin-bottom:6px}
+.hover-card .hc-stats{display:flex;gap:16px}
+.hover-card .hc-stat{text-align:center;flex:1}
+.hover-card .hc-stat-num{font-size:1.25rem;font-weight:700;font-variant-numeric:tabular-nums}
+.hover-card .hc-stat-label{font-size:.625rem;color:#6b7280;margin-top:2px;text-transform:uppercase}
+.hover-card .hc-bar-wrap{height:6px;background:rgba(255,255,255,0.05);border-radius:3px;overflow:hidden;margin-top:8px}
+.hover-card .hc-bar{height:100%%;border-radius:3px;transition:width .3s}
+.hover-card .hc-footer{padding:8px 16px;text-align:center;font-size:10px;color:#60a5fa;background:rgba(255,255,255,0.02);border-top:1px solid rgba(255,255,255,0.05)}
+
 /* ── No-results ── */
 .no-results{text-align:center;padding:40px 16px;color:#6b7280;font-size:.875rem;display:none}
 </style></head>
@@ -931,12 +953,44 @@ function renderRows() {
     if (e.completed > 0) pills += '<span class="pill pill-completed">' + e.completed + (e.completed === 1 ? ' Task' : ' Tasks') + '</span>';
     if (e.failed > 0) pills += '<span class="pill pill-failed">' + e.failed + ' Failed</span>';
 
+    var total = e.completed + e.failed;
+    var successPct = total > 0 ? Math.round((e.completed / total) * 100) : 0;
+    var barColor = successPct >= 80 ? '#4ade80' : successPct >= 50 ? '#facc15' : '#f87171';
+
+    var hoverCard = '<div class="hover-card">'
+      + '<div class="hc-header">'
+      +   '<img src="' + e.avatar + '" alt="' + e.login + '" width="40" height="40">'
+      +   '<div><div class="hc-name">' + e.login + '</div>'
+      +   '<div class="hc-meta">Rank #' + e._rank + ' &middot; <span class="hc-pts">' + e.completed.toLocaleString() + ' tasks</span></div></div>'
+      + '</div>'
+      + '<div class="hc-section">'
+      +   '<div class="hc-label">Performance</div>'
+      +   '<div class="hc-stats">'
+      +     '<div class="hc-stat"><div class="hc-stat-num" style="color:#4ade80">' + e.completed + '</div><div class="hc-stat-label">Completed</div></div>'
+      +     '<div class="hc-stat"><div class="hc-stat-num" style="color:#f87171">' + e.failed + '</div><div class="hc-stat-label">Failed</div></div>'
+      +     '<div class="hc-stat"><div class="hc-stat-num" style="color:' + barColor + '">' + successPct + '%%</div><div class="hc-stat-label">Success</div></div>'
+      +   '</div>'
+      +   '<div class="hc-bar-wrap"><div class="hc-bar" style="width:' + successPct + '%%;background:' + barColor + '"></div></div>'
+      + '</div>'
+      + '<div class="hc-section">'
+      +   '<div class="hc-label">Details</div>'
+      +   '<div style="display:flex;justify-content:space-between;align-items:center">'
+      +     '<span class="tier-badge" style="background:' + e.tierBg + ';color:' + e.tierText + ';border-color:' + e.tierBorder + '">' + e.tier + '</span>'
+      +     '<span style="font-size:.75rem;color:#6b7280">Joined ' + formatDate(e.registered) + '</span>'
+      +   '</div>'
+      + '</div>'
+      + '<div class="hc-footer">View on GitHub &rarr;</div>'
+      + '</div>';
+
     html += '<div class="row">'
       + '<div class="rank-cell">' + rankHTML(e._rank) + '</div>'
       + '<div class="contributor">'
       +   '<img src="' + e.avatar + '" alt="' + e.login + '" width="32" height="32" loading="lazy">'
-      +   '<a class="name" href="https://github.com/' + e.login + '" target="_blank" rel="noopener">' + e.login + '</a>'
-      +   '<a class="gh-icon" href="https://github.com/' + e.login + '" target="_blank" rel="noopener" title="View on GitHub">' + ghIcon() + '</a>'
+      +   '<div class="hover-card-anchor">'
+      +     '<a class="name" href="https://github.com/' + e.login + '" target="_blank" rel="noopener">' + e.login + '</a>'
+      +     '<a class="gh-icon" href="https://github.com/' + e.login + '" target="_blank" rel="noopener" title="View on GitHub">' + ghIcon() + '</a>'
+      +     hoverCard
+      +   '</div>'
       + '</div>'
       + '<div class="stats-cell"><div class="completed">' + e.completed.toLocaleString() + '</div></div>'
       + '<div style="display:flex;justify-content:center"><span class="tier-badge" style="background:' + e.tierBg + ';color:' + e.tierText + ';border-color:' + e.tierBorder + '">' + e.tier + '</span></div>'

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -578,7 +578,7 @@ func (s *Server) handleLeaderboardAPI(w http.ResponseWriter, _ *http.Request) {
 	jsonResponse(w, map[string]any{"leaderboard": buildLeaderboard()})
 }
 
-// trustTierColor maps trust tiers to badge background colours.
+// trustTierColor maps trust tiers to CSS colour values for badges.
 func trustTierColor(tier string) string {
 	switch tier {
 	case "newcomer":
@@ -596,6 +596,41 @@ func trustTierColor(tier string) string {
 	}
 }
 
+// trustTierBadgeCSS returns Tailwind-style bg/text/border CSS classes for a tier.
+func trustTierBadgeCSS(tier string) (bg, text, border string) {
+	switch tier {
+	case "newcomer":
+		return "rgba(107,114,128,0.2)", "#9ca3af", "rgba(107,114,128,0.3)"
+	case "contributor":
+		return "rgba(59,130,246,0.2)", "#60a5fa", "rgba(59,130,246,0.3)"
+	case "trusted":
+		return "rgba(34,197,94,0.2)", "#4ade80", "rgba(34,197,94,0.3)"
+	case "advisor":
+		return "rgba(168,85,247,0.2)", "#c084fc", "rgba(168,85,247,0.3)"
+	case "revoked":
+		return "rgba(239,68,68,0.2)", "#f87171", "rgba(239,68,68,0.3)"
+	default:
+		return "rgba(107,114,128,0.2)", "#9ca3af", "rgba(107,114,128,0.3)"
+	}
+}
+
+// rankDisplay returns the medal emoji for top 3, or "#N" for others.
+func rankDisplay(rank int) string {
+	const goldMedal = "\U0001F947"   // gold medal emoji
+	const silverMedal = "\U0001F948" // silver medal emoji
+	const bronzeMedal = "\U0001F949" // bronze medal emoji
+	switch rank {
+	case 1:
+		return fmt.Sprintf(`<span class="medal" title="1st place">%s</span>`, goldMedal)
+	case 2:
+		return fmt.Sprintf(`<span class="medal" title="2nd place">%s</span>`, silverMedal)
+	case 3:
+		return fmt.Sprintf(`<span class="medal" title="3rd place">%s</span>`, bronzeMedal)
+	default:
+		return fmt.Sprintf(`<span class="rank-num">#%d</span>`, rank)
+	}
+}
+
 func (s *Server) handleLeaderboardPage(w http.ResponseWriter, _ *http.Request) {
 	entries := buildLeaderboard()
 	projectName := ""
@@ -606,67 +641,337 @@ func (s *Server) handleLeaderboardPage(w http.ResponseWriter, _ *http.Request) {
 		projectName = "Hive"
 	}
 
-	var rows strings.Builder
-	for _, e := range entries {
-		rows.WriteString(fmt.Sprintf(
-			`<tr>
-<td class="rank">#%d</td>
-<td class="user"><img src="%s" width="32" height="32" alt="%s"><a href="https://github.com/%s" target="_blank" rel="noopener">%s</a></td>
-<td><span class="badge" style="background:%s">%s</span></td>
-<td class="num">%d</td>
-<td class="num">%d</td>
-<td class="date">%s</td>
-</tr>`,
-			e.Rank,
-			e.AvatarURL, e.GitHubUsername,
-			e.GitHubUsername, e.GitHubUsername,
-			trustTierColor(e.TrustTier), e.TrustTier,
-			e.TasksCompleted,
-			e.TasksFailed,
-			e.RegisteredAt,
+	// Build contributor rows as JSON for client-side search/sort
+	var entriesJSON strings.Builder
+	entriesJSON.WriteString("[")
+	for i, e := range entries {
+		if i > 0 {
+			entriesJSON.WriteString(",")
+		}
+		bg, text, border := trustTierBadgeCSS(e.TrustTier)
+		entriesJSON.WriteString(fmt.Sprintf(
+			`{"rank":%d,"login":"%s","avatar":"%s","tier":"%s","completed":%d,"failed":%d,"registered":"%s","tierBg":"%s","tierText":"%s","tierBorder":"%s"}`,
+			e.Rank, e.GitHubUsername, e.AvatarURL, e.TrustTier,
+			e.TasksCompleted, e.TasksFailed, e.RegisteredAt,
+			bg, text, border,
 		))
 	}
-
-	const avatarSize = 32 // pixels for contributor avatar thumbnails
+	entriesJSON.WriteString("]")
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprintf(w, `<!DOCTYPE html>
-<html><head><meta charset="UTF-8"><title>%s Contributor Leaderboard</title>
-<style>
-body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#0d1117;color:#e6edf3;margin:0;padding:40px;max-width:900px;margin:0 auto}
-h1{font-size:2rem;margin-bottom:8px}
-.subtitle{color:#8b949e;font-size:1.1rem;margin-bottom:32px}
-table{width:100%%;border-collapse:collapse;background:#161b22;border:1px solid #30363d;border-radius:12px;overflow:hidden}
-th{text-align:left;padding:12px 16px;color:#8b949e;font-size:.8rem;font-weight:600;border-bottom:2px solid #30363d}
-td{padding:10px 16px;border-bottom:1px solid #21262d;font-size:.9rem}
-tr:last-child td{border-bottom:none}
-tr:hover{background:#1c2128}
-.rank{font-weight:700;color:#58a6ff;width:60px}
-.user{display:flex;align-items:center;gap:10px}
-.user img{border-radius:50%%}
-.user a{color:#58a6ff;text-decoration:none}
-.user a:hover{text-decoration:underline}
-.badge{display:inline-block;padding:2px 10px;border-radius:12px;font-size:.75rem;font-weight:600;color:#fff;text-transform:capitalize}
-.num{text-align:right;font-variant-numeric:tabular-nums}
-.date{color:#8b949e;font-size:.8rem}
-.empty{text-align:center;padding:40px;color:#8b949e}
-</style></head><body>
-<h1>🏆 %s Contributor Leaderboard</h1>
-<p class="subtitle">Contributors ranked by completed tasks.</p>
-<table>
-<thead><tr><th>Rank</th><th>Contributor</th><th>Trust Tier</th><th style="text-align:right">Completed</th><th style="text-align:right">Failed</th><th>Registered</th></tr></thead>
-<tbody>%s</tbody>
-</table>
-%s
-</body></html>`,
-		projectName, projectName, rows.String(),
-		func() string {
-			if len(entries) == 0 {
-				return `<div class="empty">No contributors yet. <a href="/contribute" style="color:#58a6ff">Be the first!</a></div>`
-			}
-			return ""
-		}())
+	fmt.Fprintf(w, leaderboardHTML, projectName, projectName, len(entries), entriesJSON.String())
 }
+
+// leaderboardHTML is the full HTML template for the leaderboard page,
+// styled to match the kubestellar.io/leaderboard design.
+const leaderboardHTML = `<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>%s Contributor Leaderboard</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:#0a0a0a;color:#fff;min-height:100vh;overflow-x:hidden}
+
+/* ── Starfield background ── */
+.bg-stars{position:fixed;inset:0;z-index:0;background:#0a0a0a}
+.bg-stars::before,.bg-stars::after{content:'';position:absolute;inset:0}
+.bg-stars::before{background:radial-gradient(1px 1px at 20px 30px,rgba(255,255,255,0.3),transparent),
+radial-gradient(1px 1px at 40px 70px,rgba(255,255,255,0.2),transparent),
+radial-gradient(1px 1px at 50px 160px,rgba(255,255,255,0.3),transparent),
+radial-gradient(1px 1px at 90px 40px,rgba(255,255,255,0.15),transparent),
+radial-gradient(1px 1px at 130px 80px,rgba(255,255,255,0.25),transparent),
+radial-gradient(1px 1px at 160px 120px,rgba(255,255,255,0.2),transparent);
+background-size:200px 200px;animation:twinkle 4s ease-in-out infinite alternate}
+.bg-stars::after{background:radial-gradient(1px 1px at 180px 50px,rgba(255,255,255,0.2),transparent),
+radial-gradient(1px 1px at 60px 130px,rgba(255,255,255,0.15),transparent),
+radial-gradient(1px 1px at 100px 90px,rgba(255,255,255,0.3),transparent),
+radial-gradient(1px 1px at 140px 160px,rgba(255,255,255,0.2),transparent);
+background-size:300px 300px;animation:twinkle 6s ease-in-out infinite alternate-reverse}
+@keyframes twinkle{from{opacity:.5}to{opacity:1}}
+
+/* ── Grid overlay ── */
+.bg-grid{position:fixed;inset:0;z-index:1;
+background-image:linear-gradient(rgba(255,255,255,0.02) 1px,transparent 1px),
+linear-gradient(90deg,rgba(255,255,255,0.02) 1px,transparent 1px);
+background-size:80px 80px;pointer-events:none}
+
+.content{position:relative;z-index:10;padding-top:28px}
+
+/* ── Header ── */
+.header{text-align:center;padding:48px 16px 32px}
+@media(min-width:640px){.header{padding:96px 24px 48px}}
+.header h1{font-size:2.25rem;font-weight:700;margin-bottom:12px}
+@media(min-width:768px){.header h1{font-size:3rem}}
+@media(min-width:1024px){.header h1{font-size:3.75rem}}
+.gradient-text{background:linear-gradient(90deg,#9333ea,#3b82f6,#9333ea);
+background-size:200%% auto;-webkit-background-clip:text;-webkit-text-fill-color:transparent;
+background-clip:text;animation:gradient-shift 3s linear infinite}
+@keyframes gradient-shift{from{background-position:0%% center}to{background-position:200%% center}}
+.header .subtitle{font-size:1.125rem;color:#d1d5db;max-width:640px;margin:0 auto;line-height:1.6}
+@media(min-width:768px){.header .subtitle{font-size:1.5rem}}
+.header .meta{margin-top:12px;font-size:.875rem;color:#6b7280}
+.header .meta a{color:#9ca3af;text-decoration:none;transition:color .2s}
+.header .meta a:hover{color:#60a5fa}
+.header .contribute-link{margin-top:24px;display:inline-flex;align-items:center;gap:8px;
+padding:8px 16px;border-radius:8px;border:1px solid rgba(245,158,11,0.3);
+background:rgba(245,158,11,0.1);color:#fcd34d;font-size:.875rem;text-decoration:none;
+transition:background .2s}
+.header .contribute-link:hover{background:rgba(245,158,11,0.2)}
+
+/* ── Search ── */
+.search-wrap{max-width:448px;margin:0 auto 24px;padding:0 16px}
+.search-wrap input{width:100%%;padding:10px 16px;background:rgba(31,41,55,0.6);
+backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);
+border:1px solid rgba(255,255,255,0.1);border-radius:8px;color:#fff;font-size:.875rem;
+outline:none;transition:border-color .2s,box-shadow .2s}
+.search-wrap input::placeholder{color:#6b7280}
+.search-wrap input:focus{border-color:rgba(59,130,246,0.5);box-shadow:0 0 0 3px rgba(59,130,246,0.2)}
+
+/* ── Table wrapper ── */
+.table-section{max-width:960px;margin:0 auto;padding:0 16px 48px}
+.table-wrap{background:rgba(31,41,55,0.4);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);
+border-radius:12px;border:1px solid rgba(255,255,255,0.1);overflow:visible}
+
+/* ── Table header ── */
+.table-header{display:none;padding:12px 24px;border-bottom:1px solid rgba(255,255,255,0.05);
+font-size:.75rem;color:#6b7280;text-transform:uppercase;letter-spacing:.05em}
+@media(min-width:640px){.table-header{display:grid;grid-template-columns:60px 1fr 100px 120px 80px}}
+.table-header .sortable{cursor:pointer;transition:color .2s;user-select:none}
+.table-header .sortable:hover{color:#fff}
+.table-header .sortable.active{color:#facc15}
+
+/* ── Row ── */
+.row{display:grid;grid-template-columns:1fr;gap:8px;padding:16px;
+border-bottom:1px solid rgba(255,255,255,0.05);transition:background .15s;align-items:center}
+@media(min-width:640px){.row{grid-template-columns:60px 1fr 100px 120px 80px;gap:16px;padding:16px 24px}}
+.row:last-child{border-bottom:none}
+.row:hover{background:rgba(255,255,255,0.02)}
+
+/* ── Rank ── */
+.rank-cell{display:flex;justify-content:center}
+.medal{font-size:1.25rem}
+.rank-num{font-size:.875rem;color:#9ca3af;font-variant-numeric:tabular-nums}
+
+/* ── Contributor ── */
+.contributor{display:flex;align-items:center;gap:12px}
+.contributor img{width:32px;height:32px;border-radius:50%%;flex-shrink:0}
+.contributor .name{font-size:.875rem;font-weight:500;color:#fff;text-decoration:none;transition:color .2s}
+.contributor .name:hover{color:#60a5fa}
+.contributor .gh-icon{color:#4b5563;transition:color .2s;flex-shrink:0}
+.contributor .gh-icon:hover{color:#9ca3af}
+.contributor .gh-icon svg{width:14px;height:14px}
+
+/* ── Trust tier badge ── */
+.tier-badge{display:inline-flex;align-items:center;padding:2px 8px;border-radius:9999px;
+font-size:.75rem;font-weight:500;border:1px solid;text-transform:capitalize}
+
+/* ── Stats ── */
+.stats-cell{text-align:right;font-variant-numeric:tabular-nums}
+.stats-cell .completed{font-weight:600;font-size:.875rem;color:#4ade80}
+.stats-cell .failed{font-size:.75rem;color:#f87171;margin-top:2px}
+
+/* ── Breakdown pills ── */
+.pills{display:flex;flex-wrap:wrap;gap:6px}
+.pill{padding:2px 8px;border-radius:4px;font-size:.75rem;font-weight:500}
+.pill-completed{color:#4ade80;background:rgba(34,197,94,0.1)}
+.pill-failed{color:#f87171;background:rgba(239,68,68,0.1)}
+
+/* ── Registered date ── */
+.reg-date{font-size:.75rem;color:#6b7280;white-space:nowrap}
+
+/* ── Empty state ── */
+.empty-state{text-align:center;padding:64px 16px}
+.empty-state .icon{font-size:2.5rem;margin-bottom:16px}
+.empty-state p{color:#9ca3af}
+.empty-state a{color:#60a5fa;text-decoration:none}
+.empty-state a:hover{text-decoration:underline}
+
+/* ── Trust tiers reference ── */
+.tiers-ref{max-width:960px;margin:0 auto;padding:0 16px 64px}
+.tiers-ref .card{background:rgba(31,41,55,0.3);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);
+border-radius:8px;border:1px solid rgba(255,255,255,0.05);padding:24px}
+.tiers-ref h3{font-size:.875rem;font-weight:600;color:#9ca3af;text-transform:uppercase;letter-spacing:.05em;margin-bottom:12px}
+.tiers-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:12px}
+@media(min-width:640px){.tiers-grid{grid-template-columns:repeat(5,1fr)}}
+.tier-item{display:flex;align-items:center;gap:8px}
+.tier-item .tier-dot{width:8px;height:8px;border-radius:50%%}
+.tier-item .tier-label{font-size:.875rem;color:#9ca3af}
+.tier-item .tier-desc{font-size:.75rem;color:#6b7280}
+.tiers-ref .note{margin-top:16px;font-size:.75rem;color:#4b5563}
+
+/* ── Mobile layout ── */
+@media(max-width:639px){
+  .row .rank-cell{display:inline-flex;margin-right:8px}
+  .row .contributor{flex:1}
+  .row .stats-cell{padding-left:44px}
+  .row .pills{padding-left:44px}
+  .row .reg-date{padding-left:44px}
+}
+
+/* ── No-results ── */
+.no-results{text-align:center;padding:40px 16px;color:#6b7280;font-size:.875rem;display:none}
+</style></head>
+<body>
+<div class="bg-stars"></div>
+<div class="bg-grid"></div>
+<div class="content">
+  <!-- Header -->
+  <section class="header">
+    <h1>Contributor <span class="gradient-text">Leaderboard</span></h1>
+    <p class="subtitle">Top contributors ranked by completed tasks across %s repositories</p>
+    <p class="meta">Tracking contributions from <strong style="color:#e5e7eb">%d</strong> registered contributors</p>
+    <div style="margin-top:24px;display:flex;justify-content:center">
+      <a href="/contribute" class="contribute-link">
+        <span>&#x1F41D;</span>
+        <span><strong>Join the swarm</strong> &mdash; donate your CLI to help autonomous agents maintain repos</span>
+      </a>
+    </div>
+  </section>
+
+  <!-- Search -->
+  <div class="search-wrap">
+    <input type="text" id="search" placeholder="Search by GitHub username..." autocomplete="off">
+  </div>
+
+  <!-- Leaderboard table -->
+  <section class="table-section">
+    <div class="table-wrap">
+      <div class="table-header">
+        <div style="text-align:center">Rank</div>
+        <div>Contributor</div>
+        <div class="sortable active" style="text-align:right" id="sort-completed" onclick="toggleSort('completed')">Completed &#x25BC;</div>
+        <div style="text-align:center">Trust Tier</div>
+        <div style="text-align:right" class="sortable" id="sort-failed" onclick="toggleSort('failed')">Failed</div>
+      </div>
+      <div id="rows"></div>
+    </div>
+    <div class="no-results" id="no-results">No contributors match your search.</div>
+  </section>
+
+  <!-- Trust tiers reference -->
+  <section class="tiers-ref" id="tiers-ref">
+    <div class="card">
+      <h3>Trust Tiers</h3>
+      <div class="tiers-grid">
+        <div class="tier-item"><div class="tier-dot" style="background:#8b949e"></div><div><div class="tier-label">Newcomer</div><div class="tier-desc">Comment on issues</div></div></div>
+        <div class="tier-item"><div class="tier-dot" style="background:#60a5fa"></div><div><div class="tier-label">Contributor</div><div class="tier-desc">5+ tasks &rarr; create PRs</div></div></div>
+        <div class="tier-item"><div class="tier-dot" style="background:#4ade80"></div><div><div class="tier-label">Trusted</div><div class="tier-desc">20+ tasks &rarr; merge PRs</div></div></div>
+        <div class="tier-item"><div class="tier-dot" style="background:#c084fc"></div><div><div class="tier-label">Advisor</div><div class="tier-desc">Review agent PRs</div></div></div>
+        <div class="tier-item"><div class="tier-dot" style="background:#f87171"></div><div><div class="tier-label">Revoked</div><div class="tier-desc">Access removed</div></div></div>
+      </div>
+      <p class="note">Trust tiers determine what actions a contributor's agent can perform. Tier promotions happen automatically at task milestones or via maintainer voucher.</p>
+    </div>
+  </section>
+</div>
+
+<script>
+var ENTRIES = %s;
+var sortField = 'completed';
+var sortDir = 'desc';
+var searchQuery = '';
+
+var GOLD = '\u{1F947}';
+var SILVER = '\u{1F948}';
+var BRONZE = '\u{1F949}';
+
+function rankHTML(rank) {
+  if (rank === 1) return '<span class="medal" title="1st place">' + GOLD + '</span>';
+  if (rank === 2) return '<span class="medal" title="2nd place">' + SILVER + '</span>';
+  if (rank === 3) return '<span class="medal" title="3rd place">' + BRONZE + '</span>';
+  return '<span class="rank-num">#' + rank + '</span>';
+}
+
+function formatDate(iso) {
+  if (!iso) return '';
+  var d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString('en-US', {year:'numeric',month:'short',day:'numeric'});
+}
+
+function ghIcon() {
+  return '<svg fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>';
+}
+
+function renderRows() {
+  var filtered = ENTRIES.slice();
+  if (searchQuery) {
+    var q = searchQuery.toLowerCase();
+    filtered = filtered.filter(function(e) { return e.login.toLowerCase().indexOf(q) >= 0; });
+  }
+  var dir = sortDir === 'desc' ? 1 : -1;
+  if (sortField === 'failed') {
+    filtered.sort(function(a, b) { return dir * (b.failed - a.failed); });
+  } else {
+    filtered.sort(function(a, b) { return dir * (b.completed - a.completed); });
+  }
+  // Re-rank after sort
+  for (var i = 0; i < filtered.length; i++) filtered[i]._rank = i + 1;
+
+  var container = document.getElementById('rows');
+  var noResults = document.getElementById('no-results');
+  var tiersRef = document.getElementById('tiers-ref');
+
+  if (filtered.length === 0 && ENTRIES.length > 0) {
+    container.innerHTML = '';
+    noResults.style.display = 'block';
+    tiersRef.style.display = 'none';
+    return;
+  }
+  noResults.style.display = 'none';
+  tiersRef.style.display = filtered.length > 0 ? 'block' : 'none';
+
+  if (filtered.length === 0) {
+    container.innerHTML = '<div class="empty-state"><div class="icon">\u{1F3C6}</div><p>No contributors yet. <a href="/contribute">Be the first!</a></p></div>';
+    return;
+  }
+
+  var html = '';
+  for (var i = 0; i < filtered.length; i++) {
+    var e = filtered[i];
+    var pills = '';
+    if (e.completed > 0) pills += '<span class="pill pill-completed">' + e.completed + (e.completed === 1 ? ' Task' : ' Tasks') + '</span>';
+    if (e.failed > 0) pills += '<span class="pill pill-failed">' + e.failed + ' Failed</span>';
+
+    html += '<div class="row">'
+      + '<div class="rank-cell">' + rankHTML(e._rank) + '</div>'
+      + '<div class="contributor">'
+      +   '<img src="' + e.avatar + '" alt="' + e.login + '" width="32" height="32" loading="lazy">'
+      +   '<a class="name" href="https://github.com/' + e.login + '" target="_blank" rel="noopener">' + e.login + '</a>'
+      +   '<a class="gh-icon" href="https://github.com/' + e.login + '" target="_blank" rel="noopener" title="View on GitHub">' + ghIcon() + '</a>'
+      + '</div>'
+      + '<div class="stats-cell"><div class="completed">' + e.completed.toLocaleString() + '</div></div>'
+      + '<div style="display:flex;justify-content:center"><span class="tier-badge" style="background:' + e.tierBg + ';color:' + e.tierText + ';border-color:' + e.tierBorder + '">' + e.tier + '</span></div>'
+      + '<div class="stats-cell" style="text-align:right"><span style="color:#f87171;font-size:.875rem">' + (e.failed > 0 ? e.failed : '') + '</span></div>'
+      + '</div>';
+  }
+  container.innerHTML = html;
+
+  // Update sort header indicators
+  var sc = document.getElementById('sort-completed');
+  var sf = document.getElementById('sort-failed');
+  sc.classList.toggle('active', sortField === 'completed');
+  sf.classList.toggle('active', sortField === 'failed');
+  sc.innerHTML = 'Completed ' + (sortField === 'completed' ? (sortDir === 'desc' ? '▼' : '▲') : '');
+  sf.innerHTML = 'Failed ' + (sortField === 'failed' ? (sortDir === 'desc' ? '▼' : '▲') : '');
+}
+
+function toggleSort(field) {
+  if (sortField === field) {
+    sortDir = sortDir === 'desc' ? 'asc' : 'desc';
+  } else {
+    sortField = field;
+    sortDir = 'desc';
+  }
+  renderRows();
+}
+
+document.getElementById('search').addEventListener('input', function(e) {
+  searchQuery = e.target.value;
+  renderRows();
+});
+
+renderRows();
+</script>
+</body></html>`
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -315,6 +315,9 @@ func TestLeaderboardPageHTML(t *testing.T) {
 		"var ENTRIES":         "JavaScript entries data",
 		"toggleSort":          "sort toggle function",
 		"renderRows":          "row rendering function",
+		"hover-card":          "contributor hover card CSS",
+		"hc-header":           "hover card header",
+		"hc-bar":              "hover card success rate bar",
 	}
 	for needle, desc := range checks {
 		if !strings.Contains(body, needle) {

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -302,17 +302,24 @@ func TestLeaderboardPageHTML(t *testing.T) {
 	}
 
 	body := w.Body.String()
-	if !strings.Contains(body, "Leaderboard") {
-		t.Error("page missing 'Leaderboard' heading")
+	checks := map[string]string{
+		"gradient-text":       "animated gradient header text",
+		"Leaderboard":         "page heading",
+		"alice":               "contributor username",
+		"github.com/alice.png": "avatar URL",
+		"github.com/alice":    "GitHub profile link",
+		"search":              "search input",
+		"sort-completed":      "sortable completed column",
+		"Trust Tiers":         "trust tiers reference section",
+		"bg-stars":            "starfield background",
+		"var ENTRIES":         "JavaScript entries data",
+		"toggleSort":          "sort toggle function",
+		"renderRows":          "row rendering function",
 	}
-	if !strings.Contains(body, "alice") {
-		t.Error("page missing contributor 'alice'")
-	}
-	if !strings.Contains(body, "https://github.com/alice.png") {
-		t.Error("page missing avatar URL for alice")
-	}
-	if !strings.Contains(body, "https://github.com/alice") {
-		t.Error("page missing GitHub profile link for alice")
+	for needle, desc := range checks {
+		if !strings.Contains(body, needle) {
+			t.Errorf("page missing %s (looked for %q)", desc, needle)
+		}
 	}
 }
 
@@ -330,8 +337,9 @@ func TestLeaderboardPageEmpty(t *testing.T) {
 	}
 
 	body := w.Body.String()
-	if !strings.Contains(body, "No contributors yet") {
-		t.Error("empty page should show 'No contributors yet' message")
+	// Empty entries array should be passed to JS
+	if !strings.Contains(body, "var ENTRIES = []") {
+		t.Error("empty page should pass empty ENTRIES array")
 	}
 	if !strings.Contains(body, "/contribute") {
 		t.Error("empty page should link to /contribute")
@@ -355,6 +363,54 @@ func TestTrustTierColor(t *testing.T) {
 		if got != tc.color {
 			t.Errorf("trustTierColor(%q) = %q, want %q", tc.tier, got, tc.color)
 		}
+	}
+}
+
+func TestTrustTierBadgeCSS(t *testing.T) {
+	cases := []struct {
+		tier   string
+		wantBg string
+	}{
+		{"newcomer", "rgba(107,114,128,0.2)"},
+		{"contributor", "rgba(59,130,246,0.2)"},
+		{"trusted", "rgba(34,197,94,0.2)"},
+		{"advisor", "rgba(168,85,247,0.2)"},
+		{"revoked", "rgba(239,68,68,0.2)"},
+		{"unknown", "rgba(107,114,128,0.2)"},
+	}
+	for _, tc := range cases {
+		bg, text, border := trustTierBadgeCSS(tc.tier)
+		if bg != tc.wantBg {
+			t.Errorf("trustTierBadgeCSS(%q) bg = %q, want %q", tc.tier, bg, tc.wantBg)
+		}
+		if text == "" {
+			t.Errorf("trustTierBadgeCSS(%q) text is empty", tc.tier)
+		}
+		if border == "" {
+			t.Errorf("trustTierBadgeCSS(%q) border is empty", tc.tier)
+		}
+	}
+}
+
+func TestRankDisplay(t *testing.T) {
+	gold := rankDisplay(1)
+	if !strings.Contains(gold, "medal") || !strings.Contains(gold, "1st place") {
+		t.Errorf("rank 1 should show gold medal, got %q", gold)
+	}
+
+	silver := rankDisplay(2)
+	if !strings.Contains(silver, "medal") || !strings.Contains(silver, "2nd place") {
+		t.Errorf("rank 2 should show silver medal, got %q", silver)
+	}
+
+	bronze := rankDisplay(3)
+	if !strings.Contains(bronze, "medal") || !strings.Contains(bronze, "3rd place") {
+		t.Errorf("rank 3 should show bronze medal, got %q", bronze)
+	}
+
+	fourth := rankDisplay(4)
+	if !strings.Contains(fourth, "#4") {
+		t.Errorf("rank 4 should show #4, got %q", fourth)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Redesigns the `/leaderboard` page to match the kubestellar.io/leaderboard visual style
- Adds cosmic dark theme with animated starfield background and grid overlay
- Animated gradient header text ("Contributor **Leaderboard**")
- Client-side search filter by GitHub username
- Sortable columns (completed/failed) with click-to-toggle sort direction
- Medal emojis for top 3 contributors (gold/silver/bronze)
- Color-coded trust tier badges with translucent bg/text/border styling
- Trust tiers reference section at bottom
- Responsive grid layout (mobile-first)
- Empty and no-results states with `/contribute` CTA
- Snapshot publisher (`publish-snapshot-v2.sh`) now captures `/leaderboard` alongside the main dashboard

## Test plan
- [x] `go build ./...` passes
- [x] 7 tests pass: `go test ./pkg/dashboard/ -run "TestLeaderboard|TestTrustTier|TestRankDisplay" -v`
- [ ] CI build-and-test workflow passes