### PR TITLE
fix: active count, last_active tracking, live activity feed

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -46,6 +46,7 @@ type ContributorProfile struct {
 	RegisteredAt       string                `json:"registered_at"`
 	TasksCompleted     int                   `json:"total_tasks_completed"`
 	TasksFailed        int                   `json:"total_tasks_failed"`
+	LastActive         string                `json:"last_active,omitempty"`
 	RateLimits         ContributorRateLimits `json:"rate_limits"`
 	Active             bool                  `json:"active,omitempty"`
 }
@@ -91,6 +92,7 @@ func (s *Server) registerContributeRoutes() {
 	s.mux.HandleFunc("GET /api/contribute/ws", s.contributeHub.HandleWS)
 	s.mux.HandleFunc("POST /api/contribute/register", s.handleContributeRegister)
 	s.mux.HandleFunc("GET /api/contribute/status", s.handleContributeStatus)
+	s.mux.HandleFunc("GET /api/contribute/activity", s.handleContributeActivity)
 	s.mux.HandleFunc("GET /api/contributors", s.handleContributorsList)
 	s.mux.HandleFunc("GET /api/contributors/{id}", s.handleContributorGet)
 	s.mux.HandleFunc("PUT /api/contributors/{id}/trust", s.handleContributorTrust)
@@ -259,6 +261,15 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 <tr><td>Advisor</td><td>Registration</td><td>Review agent PRs</td></tr>
 </table>
 </div>
+<div class="how">
+<h3>Live Activity</h3>
+<div id="activity-feed" style="background:#161b22;border:1px solid #30363d;border-radius:12px;padding:16px;min-height:60px;max-height:200px;overflow-y:auto;font-size:.85rem">
+<span style="color:#8b949e">Watching for contributors...</span>
+</div>
+</div>
+<script>
+async function pollActivity(){try{const r=await fetch('/api/contribute/activity');const d=await r.json();const f=document.getElementById('activity-feed');if(!d.activity||!d.activity.length){f.innerHTML='<span style="color:#8b949e">No activity yet</span>';return}f.innerHTML=d.activity.slice().reverse().map(e=>{const t=new Date(e.timestamp).toLocaleTimeString([],{hour:'numeric',minute:'2-digit'});const icon=e.action==='joined'?'🟢':'🔴';const role=e.role?' as <b>'+e.role+'</b>':'';const cli=e.cli?' ('+e.cli+')':'';return '<div style="padding:4px 0;border-bottom:1px solid #21262d">'+icon+' <b>'+e.username+'</b> '+e.action+role+cli+' <span style="color:#8b949e;float:right">'+t+'</span></div>'}).join('')}catch(e){}}pollActivity();setInterval(pollActivity,5000);
+</script>
 </body></html>`, projectName, projectName, len(profiles))
 }
 
@@ -307,12 +318,24 @@ func (s *Server) handleContributeRegister(w http.ResponseWriter, r *http.Request
 
 func (s *Server) handleContributeStatus(w http.ResponseWriter, r *http.Request) {
 	profiles := listContributorProfiles()
+	active := 0
+	if s.contributeHub != nil {
+		active = s.contributeHub.ActiveCount()
+	}
 	jsonResponse(w, map[string]any{
 		"hub":                  "online",
-		"active_contributors": 0,
+		"active_contributors": active,
 		"total_registered":    len(profiles),
 		"actionable_items":    0,
 	})
+}
+
+func (s *Server) handleContributeActivity(w http.ResponseWriter, r *http.Request) {
+	if s.contributeHub == nil {
+		jsonResponse(w, map[string]any{"activity": []any{}})
+		return
+	}
+	jsonResponse(w, map[string]any{"activity": s.contributeHub.RecentActivity()})
 }
 
 // ── Contributor management ─────────────────────────────────────────────────

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -74,11 +74,23 @@ type WSTaskAssign struct {
 	Title  string `json:"title"`
 }
 
+const maxActivityEntries = 50
+
+type ActivityEntry struct {
+	Timestamp string `json:"timestamp"`
+	Username  string `json:"username"`
+	Action    string `json:"action"`
+	Role      string `json:"role,omitempty"`
+	CLI       string `json:"cli,omitempty"`
+}
+
 type ContributeWSHub struct {
 	connections map[string]*ContributorConnection
 	mu          sync.RWMutex
 	logger      *slog.Logger
 	seq         int
+	activityMu  sync.RWMutex
+	activity    []ActivityEntry
 }
 
 func NewContributeWSHub(logger *slog.Logger) *ContributeWSHub {
@@ -86,6 +98,29 @@ func NewContributeWSHub(logger *slog.Logger) *ContributeWSHub {
 		connections: make(map[string]*ContributorConnection),
 		logger:      logger,
 	}
+}
+
+func (h *ContributeWSHub) addActivity(username, action, role, cli string) {
+	h.activityMu.Lock()
+	defer h.activityMu.Unlock()
+	h.activity = append(h.activity, ActivityEntry{
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Username:  username,
+		Action:    action,
+		Role:      role,
+		CLI:       cli,
+	})
+	if len(h.activity) > maxActivityEntries {
+		h.activity = h.activity[len(h.activity)-maxActivityEntries:]
+	}
+}
+
+func (h *ContributeWSHub) RecentActivity() []ActivityEntry {
+	h.activityMu.RLock()
+	defer h.activityMu.RUnlock()
+	out := make([]ActivityEntry, len(h.activity))
+	copy(out, h.activity)
+	return out
 }
 
 func (h *ContributeWSHub) nextSeq() int {
@@ -171,6 +206,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			delete(h.connections, contributor.profile.ContributorID)
 			h.mu.Unlock()
 			h.logger.Info("[contribute-ws] disconnected", "username", contributor.profile.GitHubUsername)
+			h.addActivity(contributor.profile.GitHubUsername, "left", contributor.role, contributor.cliBackend)
 		}
 		conn.Close()
 	}()
@@ -219,6 +255,9 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
+			profile.LastActive = time.Now().UTC().Format(time.RFC3339)
+			_ = saveContributorProfile(profile)
+
 			contributor = &ContributorConnection{
 				ws:          conn,
 				profile:     profile,
@@ -256,6 +295,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				"cli", msg.CLIBackend,
 				"role", msg.Role,
 			)
+			h.addActivity(profile.GitHubUsername, "joined", msg.Role, msg.CLIBackend)
 
 			select {
 			case authDone <- contributor:
@@ -305,6 +345,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				contributor.mu.Unlock()
 
 				contributor.profile.TasksCompleted++
+				contributor.profile.LastActive = time.Now().UTC().Format(time.RFC3339)
 				if contributor.profile.TrustTier == "newcomer" && contributor.profile.TasksCompleted >= contributorAutoPromoteAt {
 					contributor.profile.TrustTier = "contributor"
 					h.logger.Info("[contribute-ws] auto-promoted", "username", contributor.profile.GitHubUsername)


### PR DESCRIPTION
## Summary

Found via live testing:

1. **active_contributors hardcoded to 0** — now reads from hub.ActiveCount()
2. **No last_active tracking** — stale registrations indistinguishable from active. Added last_active timestamp updated on WS connect + task complete
3. **No visibility into who's online** — added live activity feed to /contribute page showing join/leave events with username, role, CLI (polls /api/contribute/activity every 5s)

## Test plan
- [x] All existing tests pass
- [ ] Connect via WS, verify active_contributors increments
- [ ] /contribute page shows "joined" event in real-time