### PR TITLE
fix: /contribute layout fills viewport, activity shows CLI + model

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -215,9 +215,9 @@ func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request)
 <style>
 *{margin:0;padding:0;box-sizing:border-box}
 body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#0d1117;color:#e6edf3;margin:0;min-height:100vh}
-.page{display:flex;min-height:100vh}
-.main{flex:2;padding:40px;max-width:800px}
-.sidebar{flex:1;min-width:280px;max-width:380px;background:#161b22;border-left:1px solid #30363d;display:flex;flex-direction:column}
+.page{display:flex;min-height:100vh;width:100%%}
+.main{flex:2;padding:40px;overflow-y:auto}
+.sidebar{flex:1;background:#161b22;border-left:1px solid #30363d;display:flex;flex-direction:column;position:sticky;top:0;height:100vh;overflow-y:auto}
 h1{font-size:2rem;margin-bottom:8px}
 .subtitle{color:#8b949e;font-size:1.1rem;margin-bottom:32px}
 .stat-row{display:flex;gap:16px;margin-bottom:32px}
@@ -313,10 +313,10 @@ const t=new Date(e.timestamp).toLocaleTimeString([],{hour:'numeric',minute:'2-di
 const icon=e.action==='joined'?'🟢':'🔴';
 const verb=e.action==='joined'?'entered the hive':'left the hive';
 const role=e.role?' as <span class="feed-role">'+e.role+'</span>':'';
-const cli=e.cli?' <span class="feed-cli">via '+e.cli+'</span>':'';
+const cliModel=e.cli?(e.model?' <span class="feed-cli">via '+e.cli+' CLI with '+e.model+'</span>':' <span class="feed-cli">via '+e.cli+' CLI</span>'):'';
 return '<div class="feed-entry"'+(i===0&&isNew?' style="background:rgba(63,185,80,.08)"':'')+'>'+
 '<span class="feed-time">'+t+'</span>'+
-icon+' <b>'+e.username+'</b> '+verb+role+cli+'</div>'
+icon+' <b>'+e.username+'</b> '+verb+role+cliModel+'</div>'
 }).join('');
 if(isNew)f.scrollTop=0;
 }catch(e){}}

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -82,6 +82,7 @@ type ActivityEntry struct {
 	Action    string `json:"action"`
 	Role      string `json:"role,omitempty"`
 	CLI       string `json:"cli,omitempty"`
+	Model     string `json:"model,omitempty"`
 }
 
 type ContributeWSHub struct {
@@ -100,7 +101,7 @@ func NewContributeWSHub(logger *slog.Logger) *ContributeWSHub {
 	}
 }
 
-func (h *ContributeWSHub) addActivity(username, action, role, cli string) {
+func (h *ContributeWSHub) addActivity(username, action, role, cli, model string) {
 	h.activityMu.Lock()
 	defer h.activityMu.Unlock()
 	h.activity = append(h.activity, ActivityEntry{
@@ -109,6 +110,7 @@ func (h *ContributeWSHub) addActivity(username, action, role, cli string) {
 		Action:    action,
 		Role:      role,
 		CLI:       cli,
+		Model:     model,
 	})
 	if len(h.activity) > maxActivityEntries {
 		h.activity = h.activity[len(h.activity)-maxActivityEntries:]
@@ -206,7 +208,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			delete(h.connections, contributor.profile.ContributorID)
 			h.mu.Unlock()
 			h.logger.Info("[contribute-ws] disconnected", "username", contributor.profile.GitHubUsername)
-			h.addActivity(contributor.profile.GitHubUsername, "left", contributor.role, contributor.cliBackend)
+			h.addActivity(contributor.profile.GitHubUsername, "left", contributor.role, contributor.cliBackend, contributor.model)
 		}
 		conn.Close()
 	}()
@@ -295,7 +297,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				"cli", msg.CLIBackend,
 				"role", msg.Role,
 			)
-			h.addActivity(profile.GitHubUsername, "joined", msg.Role, msg.CLIBackend)
+			h.addActivity(profile.GitHubUsername, "joined", msg.Role, msg.CLIBackend, msg.Model)
 
 			select {
 			case authDone <- contributor:


### PR DESCRIPTION
## Summary

1. **Layout fix** — main column had `max-width:800px` causing empty space right of the activity sidebar. Removed cap, sidebar is now sticky full-height with proper 2/3 + 1/3 split.
2. **Model in activity** — entries now show "via claude CLI with opus-4-6" instead of just "via claude".

## Test plan
- [ ] /contribute page fills full viewport width
- [ ] Activity sidebar stretches full height
- [ ] Activity entries show CLI + model