### PR TITLE
Add contributor filters and tier breakdown stats

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -209,6 +209,43 @@ func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request)
 		projectName = "Hive"
 	}
 
+	// Count profiles by trust tier and active status
+	activeCount := 0
+	if s.contributeHub != nil {
+		activeCount = s.contributeHub.ActiveCount()
+	}
+	tierCounts := map[string]int{
+		"newcomer":    0,
+		"contributor": 0,
+		"trusted":     0,
+		"advisor":     0,
+		"revoked":     0,
+	}
+	for _, p := range profiles {
+		tierCounts[p.TrustTier]++
+	}
+
+	// Build tier stat boxes HTML
+	type tierStat struct {
+		label string
+		color string
+		count int
+	}
+	tierStats := []tierStat{
+		{"Active", "#3fb950", activeCount},
+		{"Newcomer", "#d29922", tierCounts["newcomer"]},
+		{"Contributor", "#58a6ff", tierCounts["contributor"]},
+		{"Trusted", "#3fb950", tierCounts["trusted"]},
+		{"Advisor", "#bc8cff", tierCounts["advisor"]},
+		{"Revoked", "#f85149", tierCounts["revoked"]},
+	}
+	var tierBoxes strings.Builder
+	for _, ts := range tierStats {
+		fmt.Fprintf(&tierBoxes,
+			`<div class="stat" style="flex:0 1 auto;min-width:80px"><div class="stat-num" style="color:%s;font-size:1.4rem">%d</div><div class="stat-label">%s</div></div>`,
+			ts.color, ts.count, ts.label)
+	}
+
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	fmt.Fprintf(w, `<!DOCTYPE html>
 <html><head><meta charset="UTF-8"><title>Contribute to %s</title>
@@ -220,10 +257,13 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;backgrou
 .sidebar{flex:1;min-width:280px;max-width:380px;background:#161b22;border-left:1px solid #30363d;display:flex;flex-direction:column}
 h1{font-size:2rem;margin-bottom:8px}
 .subtitle{color:#8b949e;font-size:1.1rem;margin-bottom:32px}
-.stat-row{display:flex;gap:16px;margin-bottom:32px}
-.stat{background:#161b22;border:1px solid #30363d;border-radius:12px;padding:16px 20px;flex:1;text-align:center}
+.stat-row{display:flex;flex-wrap:wrap;gap:10px;margin-bottom:16px;align-items:stretch}
+.stat{background:#161b22;border:1px solid #30363d;border-radius:12px;padding:12px 16px;flex:1;text-align:center;min-width:80px}
 .stat-num{font-size:1.8rem;font-weight:700;color:#58a6ff}
-.stat-label{font-size:.8rem;color:#8b949e;margin-top:4px}
+.stat-label{font-size:.75rem;color:#8b949e;margin-top:4px;text-transform:capitalize}
+.stat-total{background:#161b22;border:1px solid #30363d;border-radius:12px;padding:12px 20px;text-align:center;display:flex;align-items:center;gap:8px;justify-content:center}
+.stat-total .stat-num{font-size:1.6rem;color:#58a6ff}
+.stat-total .stat-label{font-size:.75rem;color:#8b949e;margin-top:0}
 .steps{background:#161b22;border:1px solid #30363d;border-radius:12px;padding:24px;margin-top:24px}
 .steps h3{margin-top:0;color:#58a6ff}
 .steps ol{padding-left:20px;line-height:2}
@@ -254,9 +294,9 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 <h1>🐝 Contribute to %s</h1>
 <p class="subtitle">Donate your CLI + API tokens to help this project's AI agent swarm.</p>
 <div class="stat-row">
-<div class="stat"><div class="stat-num" id="stat-registered">%d</div><div class="stat-label">Registered</div></div>
-<div class="stat"><div class="stat-num" id="stat-active" style="color:#3fb950">0</div><div class="stat-label">Active Now</div></div>
+%s
 </div>
+<div class="stat-total"><div class="stat-num">%d</div><div class="stat-label">Total Contributors</div></div>
 <div class="steps">
 <h3>How it works</h3>
 <ol>
@@ -300,8 +340,6 @@ async function poll(){try{
 const[statusRes,actRes]=await Promise.all([fetch('/api/contribute/status'),fetch('/api/contribute/activity')]);
 const status=await statusRes.json();
 const act=await actRes.json();
-document.getElementById('stat-registered').textContent=status.total_registered||0;
-document.getElementById('stat-active').textContent=status.active_contributors||0;
 document.getElementById('feed-count').textContent=(act.activity||[]).length+' events';
 const f=document.getElementById('activity-feed');
 if(!act.activity||!act.activity.length){f.innerHTML='<div class="feed-empty">No activity yet — be the first to contribute!</div>';return}
@@ -322,7 +360,7 @@ if(isNew)f.scrollTop=0;
 }catch(e){}}
 poll();setInterval(poll,3000);
 </script>
-</body></html>`, projectName, projectName, len(profiles))
+</body></html>`, projectName, projectName, tierBoxes.String(), len(profiles))
 }
 
 // ── Registration ───────────────────────────────────────────────────────────

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1791,6 +1791,7 @@
 
   <div id="contributors-section" style="margin-top: 16px; margin-bottom: 24px;">
     <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 8px;">👥 Contributors <span id="contributors-status-badge" style="font-size:0.7rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span></h2>
+    <div id="contributors-filters" style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:12px"></div>
     <div id="contributors-panel"></div>
   </div>
 
@@ -5875,12 +5876,83 @@ function burnAreaChart() {
       return `<span style="display:inline-block;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;border:1px solid ${color};color:${color}">${esc(tier || 'unknown')}</span>`;
     }
 
+    // Active contributor filter set — empty means "all"
+    let _contributorFilters = new Set();
+    // Cache the last fetched contributor list for re-rendering on filter change
+    let _cachedContributors = [];
+
+    const CONTRIBUTOR_FILTER_ALL = 'all';
+    const CONTRIBUTOR_FILTER_ACTIVE = 'active';
+    const CONTRIBUTOR_FILTER_TIERS = ['newcomer', 'contributor', 'trusted', 'advisor', 'revoked'];
+
+    function contributorFilterColor(filter) {
+      if (filter === CONTRIBUTOR_FILTER_ACTIVE) return '#3fb950';
+      return TRUST_TIER_COLORS[filter] || '#8b949e';
+    }
+
+    function renderContributorFilters(contributors) {
+      const bar = document.getElementById('contributors-filters');
+      if (!bar) return;
+      // Count per category
+      const activeCount = (contributors || []).filter(c => c.active).length;
+      const tierCounts = {};
+      for (const t of CONTRIBUTOR_FILTER_TIERS) tierCounts[t] = 0;
+      for (const c of (contributors || [])) {
+        if (tierCounts.hasOwnProperty(c.trust_tier)) tierCounts[c.trust_tier]++;
+      }
+      const totalCount = (contributors || []).length;
+
+      const isAllActive = _contributorFilters.size === 0;
+
+      function pill(key, label, count) {
+        const active = key === CONTRIBUTOR_FILTER_ALL ? isAllActive : _contributorFilters.has(key);
+        const color = key === CONTRIBUTOR_FILTER_ALL ? '#58a6ff' : contributorFilterColor(key);
+        const bg = active ? color : 'transparent';
+        const fg = active ? '#0d1117' : color;
+        const border = color;
+        return `<button onclick="toggleContributorFilter('${key}')" style="display:inline-flex;align-items:center;gap:4px;padding:4px 12px;border-radius:9999px;font-size:0.72rem;font-weight:600;cursor:pointer;border:1px solid ${border};background:${bg};color:${fg};transition:all 0.15s">${esc(label)} <span style="opacity:0.8">${count}</span></button>`;
+      }
+
+      let html = pill(CONTRIBUTOR_FILTER_ALL, 'All', totalCount);
+      html += pill(CONTRIBUTOR_FILTER_ACTIVE, 'Active', activeCount);
+      for (const t of CONTRIBUTOR_FILTER_TIERS) {
+        html += pill(t, t.charAt(0).toUpperCase() + t.slice(1), tierCounts[t]);
+      }
+      setIfChanged(bar, html);
+    }
+
+    // Exposed globally for onclick
+    window.toggleContributorFilter = function(key) {
+      if (key === CONTRIBUTOR_FILTER_ALL) {
+        _contributorFilters.clear();
+      } else {
+        if (_contributorFilters.has(key)) {
+          _contributorFilters.delete(key);
+        } else {
+          _contributorFilters.add(key);
+        }
+      }
+      renderContributorFilters(_cachedContributors);
+      renderContributors(_cachedContributors);
+    };
+
+    function matchesContributorFilter(c) {
+      if (_contributorFilters.size === 0) return true;
+      for (const f of _contributorFilters) {
+        if (f === CONTRIBUTOR_FILTER_ACTIVE && c.active) return true;
+        if (f === c.trust_tier) return true;
+      }
+      return false;
+    }
+
     async function fetchContributors() {
       try {
         const res = await fetch('/api/contributors');
         if (!res.ok) return;
         const data = await res.json();
-        renderContributors(data.contributors || []);
+        _cachedContributors = data.contributors || [];
+        renderContributorFilters(_cachedContributors);
+        renderContributors(_cachedContributors);
       } catch (e) { /* silently retry on next poll */ }
     }
 
@@ -5891,7 +5963,12 @@ function burnAreaChart() {
         setIfChanged(panel, '<div style="color:var(--muted);padding:24px;text-align:center;background:var(--card-bg);border:1px solid var(--border);border-radius:8px">No contributors registered yet.</div>');
         return;
       }
-      const cards = contributors.map(c => {
+      const filtered = contributors.filter(matchesContributorFilter);
+      if (!filtered.length) {
+        setIfChanged(panel, '<div style="color:var(--muted);padding:24px;text-align:center;background:var(--card-bg);border:1px solid var(--border);border-radius:8px">No contributors match the selected filters.</div>');
+        return;
+      }
+      const cards = filtered.map(c => {
         const dotColor = c.active ? '#3fb950' : '#8b949e';
         const dotTitle = c.active ? 'Online' : 'Offline';
         const ghLink = `https://github.com/${esc(c.github_username)}`;


### PR DESCRIPTION
## Summary
- Adds toggleable filter pill buttons (All, Active, Newcomer, Contributor, Trusted, Advisor, Revoked) above the contributor card grid in the dashboard. Filters are client-side with multi-select support and per-category counts.
- Updates the `/contribute` landing page to show a per-tier stat breakdown with color-coded boxes instead of a single "Registered" number.

## Test plan
- [ ] Open the dashboard and navigate to the Contributors section -- verify filter pills appear above the card grid with correct counts
- [ ] Click individual tier filters and verify only matching contributors are shown
- [ ] Click multiple filters and verify OR logic (shows contributors matching any selected filter)
- [ ] Click "All" to reset filters
- [ ] Visit `/contribute` and verify the stat row shows Active, Newcomer, Contributor, Trusted, Advisor, Revoked boxes with a Total at the end
- [ ] Verify `go build ./...` passes