### PR TITLE
fix: handle cgroup memory.max=max and fix CPU percentage calculation

### DIFF
--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -1009,13 +1010,20 @@ func collectSystemResources() *SystemResources {
 	// --- Memory (cgroup v2) ---
 	memCurrent := readCgroupInt64(cgroupMemCurrent)
 	memMax := readCgroupInt64(cgroupMemMax)
-	if memCurrent > 0 && memMax > 0 && memMax < maxCgroupMemBytes {
+	// When no memory limit is set (Docker without --memory), memory.max contains
+	// "max" which readCgroupInt64 returns as -1. Fall back to host total memory.
+	if memMax <= 0 || memMax >= maxCgroupMemBytes {
+		memMax = readProcMemTotalBytes()
+	}
+	if memCurrent > 0 && memMax > 0 {
 		res.MemUsedMB = roundTo(float64(memCurrent)/bytesPerMB, 0)
 		res.MemTotalMB = roundTo(float64(memMax)/bytesPerMB, 0)
 		res.MemPct = roundTo(float64(memCurrent)/float64(memMax)*pctMultiplierSysRes, 1)
 	}
 
 	// --- CPU (cgroup v2, sampled) ---
+	// usage_usec accumulates total CPU time across all cores. To get a 0-100%
+	// value we divide by (wall-clock time * number of CPUs).
 	usec1 := readCgroupCPUUsageUsec(cgroupCPUStat)
 	if usec1 >= 0 {
 		time.Sleep(cpuSampleDelayMs * time.Millisecond)
@@ -1023,8 +1031,11 @@ func collectSystemResources() *SystemResources {
 		if usec2 > usec1 {
 			deltaUsec := float64(usec2 - usec1)
 			deltaSec := float64(cpuSampleDelayMs) / 1000.0
-			// usage_usec tracks total CPU time; divide by wall-clock to get fraction
-			cpuFraction := deltaUsec / (deltaSec * microsecondsPerSec)
+			numCPUs := float64(runtime.NumCPU())
+			if numCPUs < 1 {
+				numCPUs = 1
+			}
+			cpuFraction := deltaUsec / (deltaSec * microsecondsPerSec * numCPUs)
 			res.CpuPct = roundTo(cpuFraction*pctMultiplierSysRes, 1)
 		}
 	}
@@ -1048,6 +1059,33 @@ func readCgroupInt64(path string) int64 {
 		return -1
 	}
 	return v
+}
+
+// procMeminfo is the path to the host memory info file.
+const procMeminfo = "/proc/meminfo"
+
+// kbToBytes converts kB (as reported by /proc/meminfo) to bytes.
+const kbToBytes = 1024
+
+// readProcMemTotalBytes reads MemTotal from /proc/meminfo and returns
+// the value in bytes. Returns -1 on error.
+func readProcMemTotalBytes() int64 {
+	data, err := os.ReadFile(procMeminfo)
+	if err != nil {
+		return -1
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "MemTotal:") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				kb, err := strconv.ParseInt(fields[1], 10, 64)
+				if err == nil {
+					return kb * kbToBytes
+				}
+			}
+		}
+	}
+	return -1
 }
 
 // readCgroupCPUUsageUsec parses usage_usec from a cgroup v2 cpu.stat file.

--- a/v2/pkg/dashboard/status_builder_test.go
+++ b/v2/pkg/dashboard/status_builder_test.go
@@ -879,3 +879,46 @@ func TestComputeNextKick_ValidCadenceNoLastKick(t *testing.T) {
 		t.Error("expected non-empty result for valid cadence without last kick")
 	}
 }
+
+func TestReadCgroupInt64_MaxReturnsNegOne(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/memory.max"
+	os.WriteFile(path, []byte("max\n"), 0o644)
+	result := readCgroupInt64(path)
+	if result != -1 {
+		t.Errorf("readCgroupInt64('max') = %d, want -1", result)
+	}
+}
+
+func TestReadCgroupInt64_ValidNumber(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/memory.max"
+	os.WriteFile(path, []byte("1073741824\n"), 0o644)
+	result := readCgroupInt64(path)
+	if result != 1073741824 {
+		t.Errorf("readCgroupInt64 = %d, want 1073741824", result)
+	}
+}
+
+func TestReadProcMemTotalBytes_ValidFile(t *testing.T) {
+	// We can't easily mock procMeminfo path, but we can verify the function
+	// returns a reasonable value on Linux or -1 on other platforms.
+	result := readProcMemTotalBytes()
+	// On macOS (test environment) this will be -1 since /proc/meminfo doesn't exist.
+	// On Linux it should be > 0.
+	if result == 0 {
+		t.Error("readProcMemTotalBytes should never return 0 (either >0 or -1)")
+	}
+}
+
+func TestCollectSystemResources_DoesNotPanic(t *testing.T) {
+	// Ensure collectSystemResources doesn't panic on any platform.
+	res := collectSystemResources()
+	if res == nil {
+		t.Fatal("expected non-nil SystemResources")
+	}
+	// CPU percentage should be in [0, 100] range (not 354%)
+	if res.CpuPct < 0 || res.CpuPct > 100 {
+		t.Errorf("CpuPct = %.1f, want [0, 100]", res.CpuPct)
+	}
+}


### PR DESCRIPTION
## Summary
- **Memory gauge showed 0/0 MB**: cgroup v2 `memory.max` returns the literal string `"max"` when no memory limit is set (default Docker without `--memory`). `readCgroupInt64` returned -1 for `"max"`, causing the gauge to skip rendering entirely. Now falls back to `/proc/meminfo` `MemTotal` for the host's total memory.
- **CPU gauge showed 354%**: `usage_usec` accumulates total CPU time across all cores, but the calculation divided only by wall-clock time. Now divides by `(wall-clock * runtime.NumCPU())` to produce a 0-100% value.

## Test plan
- [x] Added test for `readCgroupInt64` returning -1 for `"max"` string
- [x] Added test for `readCgroupInt64` parsing valid numbers
- [x] Added test for `readProcMemTotalBytes` returning valid value or -1
- [x] Added test for `collectSystemResources` not panicking and CPU staying in [0, 100]
- [x] `go build ./...` passes
- [x] `go test ./pkg/dashboard/...` passes

Fixes #852