### PR TITLE
fix: card overflow + leaderboard project name

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -772,7 +772,7 @@ func (s *Server) handleLeaderboardPage(w http.ResponseWriter, _ *http.Request) {
 	entriesJSON.WriteString("]")
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprintf(w, leaderboardHTML, projectName, projectName, len(entries), entriesJSON.String())
+	fmt.Fprintf(w, leaderboardHTML, projectName, projectName, projectName, len(entries), entriesJSON.String())
 }
 
 // leaderboardHTML is the full HTML template for the leaderboard page,
@@ -951,7 +951,7 @@ overflow:hidden;pointer-events:none}
 <div class="content">
   <!-- Header -->
   <section class="header">
-    <h1>Contributor <span class="gradient-text">Leaderboard</span></h1>
+    <h1>%s Hive Contributor <span class="gradient-text">Leaderboard</span></h1>
     <p class="subtitle">Top contributors ranked by completed tasks across %s repositories</p>
     <p class="meta">Tracking contributions from <strong style="color:#e5e7eb">%d</strong> registered contributors</p>
     <div style="margin-top:24px;display:flex;justify-content:center">

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6041,11 +6041,11 @@ function burnAreaChart() {
         const tierOptions = Object.keys(TRUST_TIER_COLORS).filter(t => t !== 'revoked').map(t =>
           `<option value="${t}"${t === c.trust_tier ? ' selected' : ''}>${t}</option>`
         ).join('');
-        return `<div style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:16px">
-          <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px">
-            <span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${dotColor}" title="${dotTitle}"></span>
-            <a href="${ghLink}" target="_blank" rel="noopener" style="color:#58a6ff;text-decoration:none;font-weight:600">@${esc(c.github_username)}</a>
-            ${trustTierBadge(c.trust_tier)}
+        return `<div style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:16px;overflow:hidden">
+          <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px;min-width:0">
+            <span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${dotColor};flex-shrink:0" title="${dotTitle}"></span>
+            <a href="${ghLink}" target="_blank" rel="noopener" style="color:#58a6ff;text-decoration:none;font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0">@${esc(c.github_username)}</a>
+            <span style="flex-shrink:0">${trustTierBadge(c.trust_tier)}</span>
           </div>
           <div style="display:flex;gap:16px;margin-bottom:12px;font-size:0.8rem;color:var(--muted)">
             <span>Completed: <strong style="color:var(--fg)">${c.total_tasks_completed || 0}</strong></span>


### PR DESCRIPTION
## Summary

1. **Card overflow** — 39-char usernames overflowed card, badge overlapped text. Added text-overflow:ellipsis and flex-shrink:0.
2. **Leaderboard title** — Changed from "Contributor Leaderboard" to "Knuckle Hive Contributor Leaderboard" (project name from config).

## Test plan
- [ ] Long username card truncates with ellipsis
- [ ] Badge stays visible, no overlap
- [ ] Leaderboard title shows project name