### PR TITLE
fix: PhaseChangedAt uses *time.Time for proper omitempty (bug #48)

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -221,7 +221,8 @@ func (e *InceptionEngine) SubmitAnswers(answers map[string]string) (*InceptionSt
 	e.state.Answers = answers
 	if e.state.Phase == PhaseClarify {
 		e.state.Phase = PhaseStructure
-		e.state.PhaseChangedAt = time.Now()
+		now := time.Now()
+		e.state.PhaseChangedAt = &now
 	}
 
 	if err := e.saveState(); err != nil {

--- a/v2/pkg/knowledge/types.go
+++ b/v2/pkg/knowledge/types.go
@@ -231,7 +231,7 @@ type InceptionState struct {
 	Answers        map[string]string `json:"answers"`
 	FactSlugs      []string          `json:"fact_slugs"`
 	StartedAt      time.Time         `json:"started_at"`
-	PhaseChangedAt time.Time         `json:"phase_changed_at,omitempty"`
+	PhaseChangedAt *time.Time        `json:"phase_changed_at,omitempty"`
 	WikiName       string            `json:"wiki_name,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
- `time.Time` zero value (`0001-01-01T00:00:00Z`) is not omitted by Go's `encoding/json` with `omitempty`
- Changed `PhaseChangedAt` to `*time.Time` pointer so `nil` is properly omitted from JSON
- Fixes inception state API returning confusing zero date in capture phase

## Test plan
- [x] Verified on live instance: capture phase state no longer includes `phase_changed_at`
- [x] Structure phase sets `PhaseChangedAt` with valid timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)