### PR TITLE
test: verify config API escapes control characters in descriptions

### DIFF
--- a/v2/pkg/dashboard/api_test.go
+++ b/v2/pkg/dashboard/api_test.go
@@ -527,6 +527,103 @@ func TestHandleAgentConfigGet_NotFound(t *testing.T) {
 	}
 }
 
+// TestHandleAgentConfigGet_MultilineDescription verifies that agents whose
+// description contains literal newlines, tabs, and other control characters
+// (as produced by YAML block scalars) still produce valid JSON in the config
+// API response. Python's json.loads(strict=True) rejects unescaped control
+// characters, so the JSON must contain \n / \t / \uXXXX escapes rather than
+// raw bytes.
+func TestHandleAgentConfigGet_MultilineDescription(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	s := NewServer(0, logger)
+
+	multilineDesc := "Creates and auto-merges documentation PRs.\n" +
+		"Reviews PRs on request.\n" +
+		"\tIndented line with tab.\n" +
+		"Line with carriage return.\r\n" +
+		"Final line."
+
+	cfg := &config.Config{
+		Project: config.ProjectConfig{Org: "myorg", Repos: []string{"repo1"}, AIAuthor: "bot"},
+		GitHub:  config.GitHubConfig{Token: "tok"},
+		Agents: map[string]config.AgentConfig{
+			"scanner": {
+				Backend:     "claude",
+				Model:       "sonnet",
+				Enabled:     true,
+				Description: multilineDesc,
+			},
+		},
+		Governor: config.GovernorConfig{
+			EvalIntervalS: 300,
+			Modes: map[string]config.ModeConfig{
+				"busy": {Threshold: 10, Cadences: map[string]string{"scanner": "5m"}},
+			},
+		},
+	}
+
+	gov := governor.New(cfg.Governor, cfg.Agents, logger)
+	mgr := agent.NewManager(cfg.Agents, logger, agent.ProjectContext{})
+
+	s.RegisterAPI(&Dependencies{
+		Config:      cfg,
+		AgentMgr:    mgr,
+		Governor:    gov,
+		Logger:      logger,
+		Ctx:         context.Background(),
+		RefreshFunc: func() {},
+		PersistFunc: func() {},
+	})
+
+	rec := doGet(s, "/api/config/agent/scanner")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	// The response body must be valid JSON — json.Decoder must not reject it.
+	rawBody := rec.Body.Bytes()
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(rawBody, &parsed); err != nil {
+		t.Fatalf("response is not valid JSON: %v\nbody: %s", err, rawBody)
+	}
+
+	// Verify the description survived round-trip intact.
+	general, ok := parsed["general"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected general section in response")
+	}
+	gotDesc, ok := general["description"].(string)
+	if !ok {
+		t.Fatal("expected description to be a string")
+	}
+	if gotDesc != multilineDesc {
+		t.Errorf("description mismatch:\n  got:  %q\n  want: %q", gotDesc, multilineDesc)
+	}
+
+	// Additionally, verify no raw control characters (U+0000–U+001F) are
+	// present in the JSON bytes except as part of valid escape sequences.
+	// This catches the exact bug Python's json.loads(strict=True) rejects.
+	inString := false
+	escaped := false
+	for i, b := range rawBody {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if b == '\\' && inString {
+			escaped = true
+			continue
+		}
+		if b == '"' {
+			inString = !inString
+			continue
+		}
+		if inString && b < 0x20 {
+			t.Errorf("raw control character 0x%02x at byte offset %d inside JSON string", b, i)
+		}
+	}
+}
+
 func TestHandleAgentConfigGeneral(t *testing.T) {
 	s, _ := apiServer(t)
 	enabled := true


### PR DESCRIPTION
## Summary

- Adds regression test `TestHandleAgentConfigGet_MultilineDescription` that verifies the `/api/config/agent/{name}` endpoint produces valid JSON when agent descriptions contain literal newlines, tabs, and carriage returns (as produced by YAML `|` and `>` block scalars)
- Test confirms both `json.Unmarshal` succeeds AND no raw control characters (U+0000-U+001F) appear inside JSON string values
- Investigation confirmed the existing `jsonResponse` helper already uses `json.NewEncoder.Encode` which properly escapes all control characters — this test guards against future regressions

## Context

YAML block scalars produce Go strings with literal control characters. If the JSON serialization path were ever changed (e.g. to `fmt.Sprintf` or string concatenation), the resulting JSON would contain unescaped control characters that Python's `json.loads(strict=True)` rejects with "Invalid control character".

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/dashboard/...` passes (all existing + new test)
- [x] New test covers newlines, tabs, carriage returns in description field
- [x] New test performs byte-level scan for raw control chars in JSON output