### PR TITLE
feat: task assignment from actionable queue + profile CLI/model/avatar

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -43,6 +43,9 @@ type ContributorProfile struct {
 	TokenPlain         string                `json:"registration_token_plain,omitempty"`
 	TrustTier          string                `json:"trust_tier"`
 	PreferredRole      string                `json:"preferred_role,omitempty"`
+	CLIBackend         string                `json:"cli_backend,omitempty"`
+	Model              string                `json:"model,omitempty"`
+	AvatarURL          string                `json:"avatar_url,omitempty"`
 	RegisteredAt       string                `json:"registered_at"`
 	TasksCompleted     int                   `json:"total_tasks_completed"`
 	TasksFailed        int                   `json:"total_tasks_failed"`
@@ -87,7 +90,7 @@ func (s *Server) BuildContributorPoolStatus() *ContributorPoolStatus {
 }
 
 func (s *Server) registerContributeRoutes() {
-	s.contributeHub = NewContributeWSHub(s.logger)
+	s.contributeHub = NewContributeWSHub(s.logger, s)
 	s.mux.HandleFunc("GET /contribute", s.handleContributeLanding)
 	s.mux.HandleFunc("GET /api/contribute/ws", s.contributeHub.HandleWS)
 	s.mux.HandleFunc("POST /api/contribute/register", s.handleContributeRegister)

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -2,8 +2,10 @@ package dashboard
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -92,12 +94,14 @@ type ContributeWSHub struct {
 	seq         int
 	activityMu  sync.RWMutex
 	activity    []ActivityEntry
+	server      *Server
 }
 
-func NewContributeWSHub(logger *slog.Logger) *ContributeWSHub {
+func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 	return &ContributeWSHub{
 		connections: make(map[string]*ContributorConnection),
 		logger:      logger,
+		server:      server,
 	}
 }
 
@@ -258,6 +262,12 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			}
 
 			profile.LastActive = time.Now().UTC().Format(time.RFC3339)
+			profile.CLIBackend = msg.CLIBackend
+			profile.Model = msg.Model
+			profile.AvatarURL = fmt.Sprintf("https://github.com/%s.png", profile.GitHubUsername)
+			if msg.Role != "" {
+				profile.PreferredRole = msg.Role
+			}
 			_ = saveContributorProfile(profile)
 
 			contributor = &ContributorConnection{
@@ -310,18 +320,32 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			if contributor == nil {
 				continue
 			}
-			if contributor.role != "" {
-				h.logger.Info("[contribute-ws] role-based contributor ready",
+			h.logger.Info("[contribute-ws] ready for work",
+				"username", contributor.profile.GitHubUsername,
+				"role", contributor.role,
+			)
+			task := h.selectTask(contributor)
+			if task != nil {
+				contributor.mu.Lock()
+				contributor.currentTask = &WSTaskAssign{
+					TaskID: task.TaskID,
+					Kind:   task.Kind,
+					Repo:   task.Repo,
+					Number: task.Number,
+					Title:  task.Title,
+				}
+				contributor.mu.Unlock()
+				sendJSON(conn, *task)
+				h.logger.Info("[contribute-ws] task assigned",
 					"username", contributor.profile.GitHubUsername,
-					"role", contributor.role,
+					"task", task.TaskID,
+					"repo", task.Repo,
+					"number", task.Number,
 				)
-				// Role-based contributors act as remote instances of an agent role
-				// (e.g., scanner, reviewer). The hive operator can pause the local
-				// agent for that role to save tokens while this contributor covers it.
 			} else {
-				h.logger.Info("[contribute-ws] ready for work", "username", contributor.profile.GitHubUsername)
-				// Task assignment would happen here — for now, log that the contributor is ready
-				// The hub needs access to actionable.json to assign tasks
+				h.logger.Info("[contribute-ws] no tasks available",
+					"username", contributor.profile.GitHubUsername,
+				)
 			}
 
 		case "task_accepted":
@@ -402,6 +426,79 @@ func (h *ContributeWSHub) heartbeatLoop(c *ContributorConnection) {
 			return
 		}
 	}
+}
+
+func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
+	if h.server == nil {
+		return nil
+	}
+
+	h.server.statusMu.RLock()
+	status := h.server.status
+	h.server.statusMu.RUnlock()
+
+	if status == nil {
+		return nil
+	}
+
+	for _, repo := range status.Repos {
+		if len(repo.ActionableIssues) == 0 {
+			continue
+		}
+		for _, raw := range repo.ActionableIssues {
+			issue, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			number := 0
+			switch n := issue["number"].(type) {
+			case float64:
+				number = int(n)
+			case int:
+				number = n
+			}
+			if number == 0 {
+				continue
+			}
+
+			title, _ := issue["title"].(string)
+			url, _ := issue["url"].(string)
+
+			ghToken := ""
+			if h.server.deps != nil && h.server.deps.GHClient != nil {
+				if tokenBytes, err := os.ReadFile("/var/run/hive-metrics/gh-app-token.cache"); err == nil {
+					ghToken = string(tokenBytes)
+				}
+			}
+
+			taskID := fmt.Sprintf("ct-%s-%d-%d", repo.Full, number, time.Now().Unix())
+
+			prompt := fmt.Sprintf(
+				"You are a contributor to the %s hive. Work on issue %s#%d: \"%s\". "+
+					"Read the issue, understand what's needed, and take action. "+
+					"Use the provided GitHub token for all gh commands.",
+				repo.Full, repo.Full, number, title,
+			)
+
+			return &WSMessage{
+				Type:           "task_assign",
+				Seq:            h.nextSeq(),
+				TaskID:         taskID,
+				Kind:           "issue",
+				Repo:           repo.Full,
+				Number:         number,
+				Title:          title,
+				URL:            url,
+				GitHubToken:    ghToken,
+				TokenExpiresAt: time.Now().Add(55 * time.Minute).UTC().Format(time.RFC3339),
+				Prompt:         prompt,
+				ContribLabels:  []string{"contributor/" + c.profile.GitHubUsername},
+			}
+		}
+	}
+
+	return nil
 }
 
 func sendJSON(conn *websocket.Conn, msg WSMessage) error {


### PR DESCRIPTION
## Summary

**Task assignment**: When a contributor sends 'ready', the hub now selects the first actionable issue from the cached status and sends task_assign with:
- Issue details (repo, number, title, URL)
- GitHub App installation token (from cache)
- Prompt for the contributor's CLI agent
- Contributor labels

**Profile enrichment**: CLI backend, model, avatar URL, and preferred role now saved to contributor profile on WebSocket auth. Visible in /api/contributors.

## Test plan
- [ ] Connect as clubanderson, send ready, receive task_assign with real issue
- [ ] Use the GitHub token from task_assign to create an issue on a knuckle repo
- [ ] Verify issue created with contributor label