### PR TITLE
fix: increase bootstrap session ready delay to 2s (bug #47)

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -2076,7 +2076,7 @@ func (m *Manager) RestartWithBootstrap(ctx context.Context, name, prompt string)
 	// Wait for the new shell to initialize before sending the launch command.
 	// Without this, $(cat /tmp/.hive-bootstrap-*.txt) can fail because the
 	// shell isn't ready to process command substitution yet.
-	const sessionReadyDelay = 500 * time.Millisecond
+	const sessionReadyDelay = 2 * time.Second
 	time.Sleep(sessionReadyDelay)
 	return m.launchInTmux(ctx, agent)
 }


### PR DESCRIPTION
## Summary
- Bootstrap race: `$(cat /tmp/.hive-bootstrap-*.txt)` fails when shell isn't ready
- 500ms delay (PR #863) was insufficient — 2/4 post-deploy passes still failed
- Increased to 2s for reliable shell initialization in tmux sessions

## Test plan
- [x] Post-deploy e2e monitoring shows agent_error from bootstrap race
- [x] 2s delay gives tmux session enough time to start bash/zsh

🤖 Generated with [Claude Code](https://claude.com/claude-code)