### PR TITLE
fix: task assignment type assertion for []any items

### DIFF
--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -446,8 +446,14 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 			continue
 		}
 		for _, raw := range repo.ActionableIssues {
-			issue, ok := raw.(map[string]any)
-			if !ok {
+			// ActionableIssues contains ghpkg.Issue structs stored as any.
+			// Marshal/unmarshal to get a map we can read fields from.
+			b, err := json.Marshal(raw)
+			if err != nil {
+				continue
+			}
+			var issue map[string]any
+			if json.Unmarshal(b, &issue) != nil {
 				continue
 			}
 


### PR DESCRIPTION
## Summary

Task assignment silently returned no tasks because `ActionableIssues` contains `ghpkg.Issue` structs stored as `[]any`. The type assertion `raw.(map[string]any)` always failed.

Fix: marshal/unmarshal each item to convert the struct to a map.

**This is the blocking bug for the e2e proof** — without this fix, `ready` never gets a `task_assign` response.