### PR TITLE
fix: empty CLI overwrites profile + tier-based token scoping

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -86,6 +86,7 @@ func main() {
 	}()
 
 	var ghClient *github.Client
+	var appAuth *github.AppAuth
 	if cfg.GitHub.AppID != 0 {
 		keyFile := cfg.GitHub.KeyFile
 		if envKey := os.Getenv("GH_APP_KEY_FILE"); envKey != "" {
@@ -94,7 +95,8 @@ func main() {
 		if keyFile == "" {
 			keyFile = "/secrets/gh-app-key.pem"
 		}
-		appAuth, err := github.NewAppAuth(cfg.GitHub.AppID, cfg.GitHub.InstallationID, keyFile, logger)
+		var err error
+		appAuth, err = github.NewAppAuth(cfg.GitHub.AppID, cfg.GitHub.InstallationID, keyFile, logger)
 		if err != nil {
 			logger.Error("failed to init GitHub App auth", "error", err)
 			os.Exit(1)
@@ -623,6 +625,7 @@ func main() {
 		AgentMgr:         agentMgr,
 		Governor:         gov,
 		GHClient:         ghClient,
+		GHAppAuth:        appAuth,
 		Tokens:           tokenCollector,
 		Knowledge:        knowledgeAPI,
 		Inception:        inceptionEngine,

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -262,9 +263,15 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			}
 
 			profile.LastActive = time.Now().UTC().Format(time.RFC3339)
-			profile.CLIBackend = msg.CLIBackend
-			profile.Model = msg.Model
-			profile.AvatarURL = fmt.Sprintf("https://github.com/%s.png", profile.GitHubUsername)
+			if msg.CLIBackend != "" {
+				profile.CLIBackend = msg.CLIBackend
+			}
+			if msg.Model != "" {
+				profile.Model = msg.Model
+			}
+			if profile.AvatarURL == "" {
+				profile.AvatarURL = fmt.Sprintf("https://github.com/%s.png", profile.GitHubUsername)
+			}
 			if msg.Role != "" {
 				profile.PreferredRole = msg.Role
 			}
@@ -472,10 +479,22 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 			url, _ := issue["url"].(string)
 
 			ghToken := ""
-			if h.server.deps != nil && h.server.deps.GHClient != nil {
-				if tokenBytes, err := os.ReadFile("/var/run/hive-metrics/gh-app-token.cache"); err == nil {
-					ghToken = string(tokenBytes)
+			if h.server.deps != nil && h.server.deps.GHAppAuth != nil {
+				ctx := h.server.deps.Ctx
+				if ctx == nil {
+					ctx = context.Background()
 				}
+				if tok, err := h.server.deps.GHAppAuth.ScopedToken(ctx, c.profile.TrustTier); err == nil {
+					ghToken = tok
+				} else {
+					h.logger.Warn("[contribute-ws] failed to mint scoped token, falling back to cache",
+						"tier", c.profile.TrustTier, "error", err)
+					if tokenBytes, err := os.ReadFile("/var/run/hive-metrics/gh-app-token.cache"); err == nil {
+						ghToken = string(tokenBytes)
+					}
+				}
+			} else if tokenBytes, err := os.ReadFile("/var/run/hive-metrics/gh-app-token.cache"); err == nil {
+				ghToken = string(tokenBytes)
 			}
 
 			taskID := fmt.Sprintf("ct-%s-%d-%d", repo.Full, number, time.Now().Unix())

--- a/v2/pkg/dashboard/deps.go
+++ b/v2/pkg/dashboard/deps.go
@@ -24,6 +24,7 @@ type Dependencies struct {
 	AgentMgr         *agent.Manager
 	Governor         *governor.Governor
 	GHClient         *ghpkg.Client
+	GHAppAuth        *ghpkg.AppAuth
 	Tokens           *tokens.Collector
 	Knowledge        *knowledge.KnowledgeAPI
 	Inception        *knowledge.InceptionEngine

--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -126,6 +126,60 @@ func (a *AppAuth) Token(ctx context.Context) (string, error) {
 	return a.cachedToken, nil
 }
 
+// ScopedToken creates a short-lived installation token with permissions
+// scoped to a contributor's trust tier. Unlike Token(), this is NOT
+// cached — each call creates a fresh token.
+func (a *AppAuth) ScopedToken(ctx context.Context, tier string) (string, error) {
+	jwtToken, err := a.generateJWT()
+	if err != nil {
+		return "", fmt.Errorf("generating JWT: %w", err)
+	}
+
+	var perms *gh.InstallationPermissions
+	switch tier {
+	case "newcomer":
+		perms = &gh.InstallationPermissions{
+			Issues:   gh.Ptr("write"),
+			Metadata: gh.Ptr("read"),
+		}
+	case "contributor":
+		perms = &gh.InstallationPermissions{
+			Issues:       gh.Ptr("write"),
+			Contents:     gh.Ptr("write"),
+			PullRequests: gh.Ptr("write"),
+			Metadata:     gh.Ptr("read"),
+		}
+	case "trusted":
+		perms = &gh.InstallationPermissions{
+			Issues:       gh.Ptr("write"),
+			Contents:     gh.Ptr("write"),
+			PullRequests: gh.Ptr("write"),
+			Checks:       gh.Ptr("read"),
+			Metadata:     gh.Ptr("read"),
+		}
+	case "advisor":
+		perms = &gh.InstallationPermissions{
+			Issues:   gh.Ptr("read"),
+			Metadata: gh.Ptr("read"),
+		}
+	default:
+		perms = &gh.InstallationPermissions{
+			Issues:   gh.Ptr("read"),
+			Metadata: gh.Ptr("read"),
+		}
+	}
+
+	opts := &gh.InstallationTokenOptions{Permissions: perms}
+	jwtClient := gh.NewClient(nil).WithAuthToken(jwtToken)
+	installToken, _, err := jwtClient.Apps.CreateInstallationToken(ctx, a.installationID, opts)
+	if err != nil {
+		return "", fmt.Errorf("creating scoped token for tier %s: %w", tier, err)
+	}
+
+	a.logger.Info("scoped token minted", "tier", tier, "expires_at", installToken.GetExpiresAt().Format(time.RFC3339))
+	return installToken.GetToken(), nil
+}
+
 type appTransport struct {
 	auth *AppAuth
 	base http.RoundTripper


### PR DESCRIPTION
## Summary

**Bug #24**: Auth without `cli_backend` wiped profile CLI/model. Now only updates non-empty fields.

**Bug #25**: All contributors got same full-access token. Now mints scoped tokens per trust tier:
- newcomer: issues:write only
- contributor: + contents + PRs
- trusted: + checks
- advisor: issues:read only

Added `AppAuth.ScopedToken()` with per-tier `InstallationPermissions`.

## Test plan
- [x] Build passes
- [ ] Auth without cli_backend preserves existing CLI on profile
- [ ] Newcomer token can comment on issues but cannot push code
- [ ] Contributor token can create PRs