### PR TITLE
security: validate task_id on complete/fail + block reserved usernames

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -1165,8 +1165,17 @@ renderRows();
 
 const maxUsernameLength = 39 // GitHub max username length
 
+var reservedUsernames = map[string]bool{
+	"null": true, "undefined": true, "true": true, "false": true,
+	"admin": true, "root": true, "system": true, "hive": true,
+	"api": true, "contribute": true, "leaderboard": true,
+}
+
 func isValidUsername(s string) bool {
 	if len(s) == 0 || len(s) > maxUsernameLength {
+		return false
+	}
+	if reservedUsernames[strings.ToLower(s)] {
 		return false
 	}
 	for _, c := range s {

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -368,38 +368,54 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 
 		case "task_complete":
 			if contributor != nil {
-				h.logger.Info("[contribute-ws] task complete",
-					"username", contributor.profile.GitHubUsername,
-					"task", msg.TaskID,
-					"result", msg.Result,
-				)
 				contributor.mu.Lock()
+				hasTask := contributor.currentTask != nil && contributor.currentTask.TaskID == msg.TaskID
 				contributor.currentTask = nil
 				contributor.tmuxOutput = msg.TmuxOutput
 				contributor.mu.Unlock()
 
-				contributor.profile.TasksCompleted++
-				contributor.profile.LastActive = time.Now().UTC().Format(time.RFC3339)
-				if contributor.profile.TrustTier == "newcomer" && contributor.profile.TasksCompleted >= contributorAutoPromoteAt {
-					contributor.profile.TrustTier = "contributor"
-					h.logger.Info("[contribute-ws] auto-promoted", "username", contributor.profile.GitHubUsername)
+				if hasTask {
+					h.logger.Info("[contribute-ws] task complete",
+						"username", contributor.profile.GitHubUsername,
+						"task", msg.TaskID,
+						"result", msg.Result,
+					)
+					contributor.profile.TasksCompleted++
+					contributor.profile.LastActive = time.Now().UTC().Format(time.RFC3339)
+					if contributor.profile.TrustTier == "newcomer" && contributor.profile.TasksCompleted >= contributorAutoPromoteAt {
+						contributor.profile.TrustTier = "contributor"
+						h.logger.Info("[contribute-ws] auto-promoted", "username", contributor.profile.GitHubUsername)
+					}
+					_ = saveContributorProfile(contributor.profile)
+				} else {
+					h.logger.Warn("[contribute-ws] task_complete for unassigned task ignored",
+						"username", contributor.profile.GitHubUsername,
+						"task", msg.TaskID,
+					)
 				}
-				_ = saveContributorProfile(contributor.profile)
 			}
 
 		case "task_failed":
 			if contributor != nil {
-				h.logger.Info("[contribute-ws] task failed",
-					"username", contributor.profile.GitHubUsername,
-					"task", msg.TaskID,
-					"reason", msg.Reason,
-				)
 				contributor.mu.Lock()
+				hasTask := contributor.currentTask != nil && contributor.currentTask.TaskID == msg.TaskID
 				contributor.currentTask = nil
 				contributor.mu.Unlock()
 
-				contributor.profile.TasksFailed++
-				_ = saveContributorProfile(contributor.profile)
+				if hasTask {
+					h.logger.Info("[contribute-ws] task failed",
+						"username", contributor.profile.GitHubUsername,
+						"task", msg.TaskID,
+						"reason", msg.Reason,
+					)
+					contributor.profile.TasksFailed++
+					_ = saveContributorProfile(contributor.profile)
+				} else {
+					h.logger.Warn("[contribute-ws] task_failed for unassigned task ignored",
+						"username", contributor.profile.GitHubUsername,
+						"task", msg.TaskID,
+					)
+				}
 			}
 
 		case "pong":

--- a/v2/pkg/dashboard/contribute_ws_test.go
+++ b/v2/pkg/dashboard/contribute_ws_test.go
@@ -279,7 +279,7 @@ func TestWSDisconnectCleansUp(t *testing.T) {
 	}
 }
 
-func TestWSTaskComplete(t *testing.T) {
+func TestWSTaskCompleteUnassigned(t *testing.T) {
 	s, ts := setupWSTest(t)
 	defer ts.Close()
 
@@ -301,22 +301,21 @@ func TestWSTaskComplete(t *testing.T) {
 	conn.WriteJSON(WSMessage{Type: "auth_response", RegistrationToken: reg["registration_token"], CLIBackend: "claude"})
 	readMsg(t, conn)
 
-	// Simulate task completion
+	// Send task_complete for a task that was never assigned — should be ignored
 	conn.WriteJSON(WSMessage{
 		Type:    "task_complete",
-		TaskID:  "ct-test-123",
+		TaskID:  "FAKE-NEVER-ASSIGNED",
 		Result:  "pr_created",
-		Summary: "Fixed the bug",
+		Summary: "Fake completion",
 	})
 
-	// Verify profile updated
 	time.Sleep(50 * time.Millisecond)
 	p := findContributor(reg["contributor_id"])
 	if p == nil {
 		t.Fatal("contributor not found")
 	}
-	if p.TasksCompleted != 1 {
-		t.Fatalf("expected 1 completed, got %d", p.TasksCompleted)
+	if p.TasksCompleted != 0 {
+		t.Fatalf("expected 0 completed (unassigned task ignored), got %d", p.TasksCompleted)
 	}
 }
 


### PR DESCRIPTION
## Summary

**SECURITY FIX**: Contributors could inflate stats by spamming fake task_complete messages. Auto-promotion to trusted tier (merge permissions) was possible without doing any real work.

Fix: task_complete/task_failed now validate the task_id matches the currently assigned task. Unmatched IDs are logged as warnings and ignored.

**Also**: Reserved usernames blocked (null, undefined, admin, root, etc.)

## Test plan
- [x] Build passes, existing tests pass
- [ ] Fake task_complete no longer increments count
- [ ] "null" username rejected
- [ ] "admin" username rejected