### PR TITLE
fix: tighten advisor/newcomer token permissions

### DIFF
--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -138,9 +138,9 @@ func (a *AppAuth) ScopedToken(ctx context.Context, tier string) (string, error) 
 	var perms *gh.InstallationPermissions
 	switch tier {
 	case "newcomer":
+		// Newcomers can comment on issues but not access code
 		perms = &gh.InstallationPermissions{
-			Issues:   gh.Ptr("write"),
-			Metadata: gh.Ptr("read"),
+			Issues: gh.Ptr("write"),
 		}
 	case "contributor":
 		perms = &gh.InstallationPermissions{
@@ -158,13 +158,14 @@ func (a *AppAuth) ScopedToken(ctx context.Context, tier string) (string, error) 
 			Metadata:     gh.Ptr("read"),
 		}
 	case "advisor":
+		// Advisors review agent PRs — they only need to read, not write.
+		// Don't request issues permission at all to prevent creation.
 		perms = &gh.InstallationPermissions{
-			Issues:   gh.Ptr("read"),
-			Metadata: gh.Ptr("read"),
+			Metadata:     gh.Ptr("read"),
+			PullRequests: gh.Ptr("read"),
 		}
 	default:
 		perms = &gh.InstallationPermissions{
-			Issues:   gh.Ptr("read"),
 			Metadata: gh.Ptr("read"),
 		}
 	}


### PR DESCRIPTION
## Summary

GitHub App scoped tokens with `issues:read` still allow issue creation (HTTP 201).
`metadata:read` grants content access.

**Advisor**: removed issues permission, added pull_requests:read (review-only)
**Newcomer**: removed metadata:read (was leaking content access)
**Default**: metadata:read only

## Test plan
- [ ] Advisor token: cannot create issues (should get 403/404)
- [ ] Newcomer token: cannot read contents (should get 403)
- [ ] Contributor token: still works as before