### PR TITLE
fix: skip bot issues in task assignment + /leaderboard link

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -309,6 +309,9 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 <li><strong>Walk away</strong> — your agent pulls work from the queue</li>
 </ol>
 </div>
+<div style="margin-top:20px;display:flex;gap:12px;flex-wrap:wrap">
+<a href="/leaderboard" style="display:inline-block;padding:8px 20px;background:#161b22;border:1px solid #30363d;border-radius:8px;color:#58a6ff;text-decoration:none;font-size:.9rem">🏆 View Leaderboard</a>
+</div>
 <div class="how">
 <h3>What you bring vs. what the hive provides</h3>
 <p><strong>You bring:</strong> Your own CLI API tokens. You pay for your own model inference.</p>

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -477,6 +478,15 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 
 			title, _ := issue["title"].(string)
 			url, _ := issue["url"].(string)
+			author, _ := issue["author"].(string)
+
+			titleLower := strings.ToLower(title)
+			if strings.Contains(titleLower, "dependency dashboard") ||
+				strings.Contains(titleLower, "renovate dashboard") ||
+				strings.Contains(titleLower, "epic:") ||
+				strings.HasSuffix(author, "[bot]") {
+				continue
+			}
 
 			ghToken := ""
 			if h.server.deps != nil && h.server.deps.GHAppAuth != nil {


### PR DESCRIPTION
## Summary

**Bug #33**: Task assignment was giving contributors "Dependency Dashboard" and bot-managed issues. Now skips:
- Titles with "Dependency Dashboard" or "Renovate Dashboard"
- Epic-prefixed issues
- Issues authored by bots (`[bot]` suffix)

**Bug #32**: /contribute page had no link to /leaderboard. Added a "View Leaderboard" button.