### PR TITLE
feat: enable gzip compression for API responses in nginx

### DIFF
--- a/v2/deploy/nginx.conf
+++ b/v2/deploy/nginx.conf
@@ -14,6 +14,13 @@ http {
         '' close;
     }
 
+    # Compress JSON API responses (70-90% reduction)
+    gzip on;
+    gzip_types application/json text/plain text/event-stream;
+    gzip_min_length 1000;
+    gzip_comp_level 6;
+    gzip_vary on;
+
     server {
         listen 3001;
 


### PR DESCRIPTION
## Summary
- Add gzip compression directives to nginx gateway config
- Compresses JSON API responses by 70-90% (e.g., /api/status from ~470KB to ~50-80KB)
- At 5s polling interval, reduces bandwidth from ~5.6MB/min to ~0.6-1MB/min

## Changes
- `v2/deploy/nginx.conf`: Added `gzip on`, `gzip_types`, `gzip_min_length 1000`, `gzip_comp_level 6`, `gzip_vary on` in the http block

## Test plan
- [ ] Deploy updated nginx config
- [ ] Verify `Content-Encoding: gzip` header on `/api/status` responses
- [ ] Confirm response size reduction with `curl --compressed`