### PR TITLE
feat: add Cache-Control no-store headers to API responses

### DIFF
--- a/v2/deploy/nginx.conf
+++ b/v2/deploy/nginx.conf
@@ -26,6 +26,10 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_read_timeout 86400s;
             proxy_send_timeout 86400s;
+            proxy_hide_header Cache-Control;
+            proxy_hide_header Pragma;
+            add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+            add_header Pragma "no-cache" always;
         }
     }
 }

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -51,6 +51,8 @@ app.use((req, res, next) => {
   res.setHeader('X-Content-Type-Options', 'nosniff');
   res.setHeader('X-Frame-Options', 'DENY');
   res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+  res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
+  res.setHeader('Pragma', 'no-cache');
   next();
 });
 


### PR DESCRIPTION
## Summary
- Add `Cache-Control: no-store, no-cache, must-revalidate` and `Pragma: no-cache` headers to all API responses
- Prevents browsers and proxies from caching sensitive data (agent config, tokens, prompts)
- Applied in two layers for defense in depth:
  - **Node.js proxy** (`v2/proxy/server.js`): added to existing security headers middleware (applies to all routes)
  - **nginx** (`v2/deploy/nginx.conf`): added to `/api` location block with `proxy_hide_header` to avoid duplicates

## Test plan
- [ ] Verify `curl -I` against any API endpoint returns `Cache-Control: no-store, no-cache, must-revalidate` and `Pragma: no-cache`
- [ ] Verify dashboard still loads and functions normally
- [ ] Verify WebSocket connections (contribute, terminal) are unaffected