### PR TITLE
fix: parallelize agent resume to reduce level switch time

### DIFF
--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"sync"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
 )
@@ -304,6 +305,8 @@ func (s *Server) syncAgentVisibility(level int) (paused, resumed []string) {
 		}
 	}
 
+	// Collect agents to resume and agents to pause.
+	var toResume []string
 	for name := range s.deps.Config.Agents {
 		if packAgents[name] {
 			// On-demand agents (e.g. brainstorm) should never auto-resume;
@@ -312,11 +315,10 @@ func (s *Server) syncAgentVisibility(level int) (paused, resumed []string) {
 				continue
 			}
 			if s.deps.AgentMgr.IsPaused(name) {
-				if err := s.deps.AgentMgr.Resume(s.deps.Ctx, name, "acmm-pack", fmt.Sprintf("agent included in pack level %d", level)); err == nil {
-					resumed = append(resumed, name)
-				}
+				toResume = append(toResume, name)
 			}
 		} else {
+			// Pause sequentially — it's fast and order can matter.
 			if !s.deps.AgentMgr.IsPaused(name) {
 				if err := s.deps.AgentMgr.Pause(name, "acmm-pack", fmt.Sprintf("agent not in pack level %d", level)); err == nil {
 					paused = append(paused, name)
@@ -324,6 +326,26 @@ func (s *Server) syncAgentVisibility(level int) (paused, resumed []string) {
 			}
 		}
 	}
+
+	// Resume agents in parallel — each Resume() call takes ~2s,
+	// so sequential resume of N agents blocks the API for N*2s.
+	var (
+		wg sync.WaitGroup
+		mu sync.Mutex
+	)
+	for _, name := range toResume {
+		wg.Add(1)
+		go func(agentName string) {
+			defer wg.Done()
+			if err := s.deps.AgentMgr.Resume(s.deps.Ctx, agentName, "acmm-pack", fmt.Sprintf("agent included in pack level %d", level)); err == nil {
+				mu.Lock()
+				resumed = append(resumed, agentName)
+				mu.Unlock()
+			}
+		}(name)
+	}
+	wg.Wait()
+
 	return paused, resumed
 }
 


### PR DESCRIPTION
## Summary
- Parallelizes agent Resume() calls in `syncAgentVisibility` using goroutines + sync.WaitGroup
- Each Resume() takes ~2s, so resuming 8 agents sequentially blocked the API for 16-20s during level switches (e.g. L1 to L6)
- Now all resumes run concurrently, reducing the total time to ~2s regardless of agent count
- Pause operations remain sequential (they're fast and order can matter)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/dashboard/...` passes
- [ ] Manual test: switch from L1 to L6 and verify all agents resume within ~2-3s