### PR TITLE
fix: profile race conditions + missing body size limits

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -457,6 +457,7 @@ func (s *Server) handleContributorGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleContributorTrust(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	id := r.PathValue("id")
 	p := findContributor(id)
 	if p == nil {
@@ -560,6 +561,7 @@ func (s *Server) handleHivesList(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleHivesRegister(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	var req struct {
 		ProjectName  string `json:"project_name"`
 		Org          string `json:"org"`
@@ -601,6 +603,7 @@ func (s *Server) handleHivesRegister(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleHivesHeartbeat(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	id := r.PathValue("id")
 	reg := loadFederationRegistry()
 	var found *FederationHive
@@ -651,6 +654,7 @@ func (s *Server) handleHivesDelete(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleHivesOnboard(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	var req struct {
 		ProjectName string   `json:"project_name"`
 		Org         string   `json:"org"`

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -401,12 +401,14 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 						"task", msg.TaskID,
 						"result", msg.Result,
 					)
+					contributor.mu.Lock()
 					contributor.profile.TasksCompleted++
 					contributor.profile.LastActive = time.Now().UTC().Format(time.RFC3339)
 					if contributor.profile.TrustTier == "newcomer" && contributor.profile.TasksCompleted >= contributorAutoPromoteAt {
 						contributor.profile.TrustTier = "contributor"
 						h.logger.Info("[contribute-ws] auto-promoted", "username", contributor.profile.GitHubUsername)
 					}
+					contributor.mu.Unlock()
 					_ = saveContributorProfile(contributor.profile)
 				} else {
 					h.logger.Warn("[contribute-ws] task_complete for unassigned task ignored",
@@ -429,7 +431,9 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 						"task", msg.TaskID,
 						"reason", msg.Reason,
 					)
+					contributor.mu.Lock()
 					contributor.profile.TasksFailed++
+					contributor.mu.Unlock()
 					_ = saveContributorProfile(contributor.profile)
 				} else {
 					h.logger.Warn("[contribute-ws] task_failed for unassigned task ignored",


### PR DESCRIPTION
## Summary

Found via static code analysis:

**4 race conditions**: `TasksCompleted++`, `TasksFailed++`, `TrustTier` read/write, and `LastActive` were modified outside the mutex. Now wrapped in `contributor.mu.Lock/Unlock`.

**4 missing body limits**: `handleContributorTrust`, `handleHivesRegister`, `handleHivesHeartbeat`, `handleHivesOnboard` had no `MaxBytesReader`. Multi-GB POST could OOM. Now all use 4KB limit.

## Test plan
- [x] All existing tests pass
- [x] `go build` clean