### PR TITLE
fix: reload beads from disk on startup to restore advisory digest

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -438,6 +438,36 @@ func main() {
 		logger.Info("beads store initialized", "agent", name, "count", store.Count())
 	}
 
+	// Scan /data/beads/ for agent directories that have beads.json files on
+	// disk but are not covered by the enabled-agent loop above. This handles
+	// agents that were disabled between restarts or added by a previous ACMM
+	// pack that is no longer active.
+	const beadsRootDir = "/data/beads"
+	if entries, err := os.ReadDir(beadsRootDir); err == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			name := entry.Name()
+			if _, exists := beadStores[name]; exists {
+				continue // already loaded from config
+			}
+			agentBeadsDir := filepath.Join(beadsRootDir, name)
+			beadsFile := filepath.Join(agentBeadsDir, "beads.json")
+			if _, statErr := os.Stat(beadsFile); statErr != nil {
+				continue // no beads.json in this directory
+			}
+			store, err := beads.NewStore(agentBeadsDir)
+			if err != nil {
+				logger.Warn("failed to load orphan beads store", "agent", name, "error", err)
+				continue
+			}
+			store.SetHiveID(cfg.HiveID)
+			beadStores[name] = store
+			logger.Info("orphan beads store loaded from disk", "agent", name, "count", store.Count())
+		}
+	}
+
 	initAgentConfigDrivenSystems(cfg)
 
 	tokenCollector := tokens.NewCollector(cfg.Data.MetricsDir, logger)
@@ -1024,6 +1054,15 @@ func runEvalCycle(
 			if persisted := advisory.PersistAsBeads(findings, beadStores); persisted > 0 {
 				logger.Info("advisory findings persisted as beads", "count", persisted)
 			}
+		}
+	}
+
+	// Reload bead stores from disk before building the digest. Agents write
+	// beads via the bd CLI which persists directly to disk, so the in-memory
+	// stores can become stale between eval cycles.
+	for name, store := range beadStores {
+		if err := store.Reload(); err != nil {
+			logger.Warn("failed to reload beads from disk", "agent", name, "error", err)
 		}
 	}
 

--- a/v2/pkg/beads/beads_test.go
+++ b/v2/pkg/beads/beads_test.go
@@ -647,3 +647,46 @@ func TestNewStore_ReadError(t *testing.T) {
 		t.Error("expected error when beads.json is a directory")
 	}
 }
+
+// TestReload_PicksUpExternalWrites simulates the bug where agents write beads
+// to disk via the bd CLI but the in-memory store in the hive process is stale.
+// Reload must re-read the file and reflect the new beads.
+func TestReload_PicksUpExternalWrites(t *testing.T) {
+	dir := t.TempDir()
+
+	// Store 1: the "hive process" store — starts empty
+	s1, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore (hive): %v", err)
+	}
+	if s1.Count() != 0 {
+		t.Fatalf("initial count: got %d, want 0", s1.Count())
+	}
+
+	// Store 2: simulates the bd CLI writing beads to the same directory
+	s2, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore (bd): %v", err)
+	}
+	if _, err := s2.Create("external finding", TypeAdvisory, PriorityHigh, "scanner", ""); err != nil {
+		t.Fatalf("Create via bd CLI: %v", err)
+	}
+
+	// Before Reload, s1 is stale
+	if s1.Count() != 0 {
+		t.Fatalf("s1 should still be 0 before Reload, got %d", s1.Count())
+	}
+
+	// After Reload, s1 picks up the external write
+	if err := s1.Reload(); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if s1.Count() != 1 {
+		t.Fatalf("after Reload: got %d, want 1", s1.Count())
+	}
+
+	beads := s1.List(ListFilter{})
+	if beads[0].Title != "external finding" {
+		t.Errorf("Title: got %q, want %q", beads[0].Title, "external finding")
+	}
+}


### PR DESCRIPTION
## Summary
- Fix bead persistence bug where the API returned 0 beads and advisory digest showed 0 findings after container restart despite 6,431 lines of bead data existing on disk
- Scan `/data/beads/` for orphan agent directories (agents not in current config) and load their `beads.json` files into the bead store
- Call `Reload()` on all bead stores before building the advisory digest in each eval cycle, so beads written by agents via the `bd` CLI are reflected in the dashboard
- Add test verifying that `Reload()` picks up external writes to disk

## Root cause
Two issues combined:
1. Bead stores were only created for `cfg.EnabledAgents()`, missing beads for agents from a previous ACMM pack level or disabled agents
2. The in-memory bead stores were never refreshed during eval cycles — agents write via the `bd` CLI directly to disk, but the hive process never called `Reload()`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/beads/...` passes (including new `TestReload_PicksUpExternalWrites`)
- [ ] Deploy and verify advisory digest shows findings after container restart