### PR TITLE
fix: increase staleTimeout to exceed agent cadence intervals

### DIFF
--- a/v2/deploy/hive-quickstart.yaml
+++ b/v2/deploy/hive-quickstart.yaml
@@ -49,6 +49,7 @@ agents:
     kick_template: guide-advisory.md
     include_repos: true
     bead_role: worker
+    stale_timeout: 28800  # 8h — must exceed longest cadence (4h)
   supervisor:
     id: supervisor
     backend: copilot
@@ -77,6 +78,7 @@ agents:
     kick_template: scanner-advisory.md
     include_repos: true
     bead_role: worker
+    stale_timeout: 28800  # 8h — must exceed longest cadence (4h)
   quality:
     id: quality
     backend: copilot
@@ -91,6 +93,7 @@ agents:
     kick_template: quality-full.md
     include_repos: true
     bead_role: worker
+    stale_timeout: 14400  # 4h — must exceed longest cadence (2h)
   ci-maintainer:
     id: ci-maintainer
     backend: copilot

--- a/v2/pkg/config/packs/level-1.yaml
+++ b/v2/pkg/config/packs/level-1.yaml
@@ -32,7 +32,7 @@ agents:
     mode: ADVISORY
     kick_template: guide-advisory.md
     include_repos: false
-    stale_timeout: 7200
+    stale_timeout: 28800  # 8h — must exceed longest cadence (4h idle)
     interactions: "Standalone. Responds to user queries only."
     knowledge_use: >
       Heavy consumer — reads community wiki, project patterns, and scaffolding

--- a/v2/pkg/config/packs/level-2.yaml
+++ b/v2/pkg/config/packs/level-2.yaml
@@ -68,7 +68,7 @@ agents:
     mode: ADVISORY
     kick_template: guide-advisory.md
     include_repos: true
-    stale_timeout: 3600
+    stale_timeout: 28800  # 8h — must exceed longest cadence (4h)
     interactions: "Works alongside scanner. Reviews scanner's suggestions when asked."
     knowledge_use: >
       Reads community wiki and project patterns. Starts contributing review
@@ -88,7 +88,7 @@ agents:
     mode: ADVISORY
     kick_template: scanner-advisory.md
     include_repos: true
-    stale_timeout: 7200
+    stale_timeout: 28800  # 8h — must exceed longest cadence (4h)
     lane_keywords: [bug, triage, fix]
     interactions: "Produces findings that guide can review. No autonomous actions."
     knowledge_use: >
@@ -109,7 +109,7 @@ agents:
     mode: ADVISORY
     kick_template: quality-advisory.md
     include_repos: true
-    stale_timeout: 7200
+    stale_timeout: 43200  # 12h — must exceed longest cadence (6h)
     interactions: "Complements scanner findings with targeted tests. Guide reviews test quality."
     knowledge_use: >
       Reads test patterns, coverage rules, and known regressions from the

--- a/v2/pkg/config/packs/level-3.yaml
+++ b/v2/pkg/config/packs/level-3.yaml
@@ -81,7 +81,7 @@ agents:
   mode: ADVISORY
   kick_template: scanner-advisory.md
   include_repos: true
-  stale_timeout: 7200
+  stale_timeout: 28800  # 8h — must exceed longest cadence (4h)
   lane_keywords:
   - bug
   - triage
@@ -107,7 +107,7 @@ agents:
   mode: ADVISORY
   kick_template: ci-maintainer-advisory.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800  # 8h — must exceed longest cadence (4h)
   lane_keywords:
   - ci
   - build
@@ -137,7 +137,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: quality-holdgated.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 14400  # 4h — must exceed longest cadence (2h)
   interactions: 'Opens issues and hold-gated PRs about testing. Complements scanner
     and ci-maintainer advisory findings with actionable test improvements.
 
@@ -162,7 +162,7 @@ agents:
   mode: ADVISORY
   kick_template: guide-advisory.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800  # 8h — must exceed longest cadence (4h)
   interactions: Works alongside scanner. Reviews scanner's suggestions when asked.
   knowledge_use: 'Reads community wiki and project patterns. Starts contributing review
     insights as knowledge entries.

--- a/v2/pkg/config/packs/level-4.yaml
+++ b/v2/pkg/config/packs/level-4.yaml
@@ -86,7 +86,7 @@ agents:
   mode: ISSUES_ONLY
   kick_template: scanner-issues.md
   include_repos: true
-  stale_timeout: 7200
+  stale_timeout: 28800  # 8h — must exceed longest cadence (4h)
   lane_keywords:
   - bug
   - triage
@@ -115,7 +115,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: ci-maintainer-holdgated.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800  # 8h — must exceed longest cadence (4h)
   lane_keywords:
   - ci
   - build
@@ -144,7 +144,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: quality-holdgated.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 14400  # 4h — must exceed longest cadence (2h)
   interactions: 'Creates testing-related issues. Produces advisory beads. No PRs.
 
     '
@@ -168,7 +168,7 @@ agents:
   mode: ISSUES_ONLY
   kick_template: guide-issues.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800  # 8h — must exceed longest cadence (4h)
   interactions: 'Creates documentation issues. Produces advisory beads. No PRs.
 
     '
@@ -193,7 +193,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: sec-check-holdgated.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800  # 8h — must exceed longest cadence (4h)
   lane_keywords:
   - security
   - cve

--- a/v2/pkg/config/packs/level-5.yaml
+++ b/v2/pkg/config/packs/level-5.yaml
@@ -94,7 +94,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: scanner-holdgated.md
   include_repos: true
-  stale_timeout: 1800
+  stale_timeout: 28800  # 8h — must exceed longest cadence (4h)
   lane_keywords:
   - bug
   - triage
@@ -122,7 +122,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: ci-maintainer-holdgated.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800  # 8h — must exceed longest cadence (4h)
   lane_keywords:
   - ci
   - build
@@ -151,7 +151,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: quality-holdgated.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 14400  # 4h — must exceed longest cadence (2h)
   interactions: 'Reviews scanner PRs for coverage. Creates test PRs with hold label.
 
     '
@@ -174,7 +174,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: guide-holdgated.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800  # 8h — must exceed longest cadence (4h)
   interactions: 'Creates documentation issues and hold-gated PRs.
 
     '
@@ -197,7 +197,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: sec-check-holdgated.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800  # 8h — must exceed longest cadence (4h)
   lane_keywords:
   - security
   - cve
@@ -225,7 +225,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: architect-holdgated.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800  # 8h — must exceed longest cadence (4h)
   lane_keywords:
   - refactor
   - architecture
@@ -255,7 +255,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: strategist-holdgated.md
   include_repos: false
-  stale_timeout: 3600
+  stale_timeout: 28800  # 8h — must exceed longest cadence (4h)
   lane_keywords:
   - strategy
   - roadmap

--- a/v2/pkg/config/packs/level-6.yaml
+++ b/v2/pkg/config/packs/level-6.yaml
@@ -96,7 +96,7 @@ agents:
   mode: ISSUES_PRS_MERGE
   kick_template: scanner-automerge.md
   include_repos: true
-  stale_timeout: 900
+  stale_timeout: 3600  # 1h — must exceed longest cadence (30m idle)
   lane_keywords:
   - bug
   - triage
@@ -124,7 +124,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: ci-maintainer-full.md
   include_repos: true
-  stale_timeout: 900
+  stale_timeout: 3600  # 1h — must exceed longest cadence (30m idle)
   lane_keywords:
   - ci
   - build
@@ -153,7 +153,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: quality-full.md
   include_repos: true
-  stale_timeout: 900
+  stale_timeout: 7200  # 2h — must exceed longest cadence (1h idle)
   interactions: 'Auto-approves PRs when coverage + CI gates pass.
 
     '
@@ -197,7 +197,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: sec-check-full.md
   include_repos: true
-  stale_timeout: 900
+  stale_timeout: 14400  # 4h — must exceed longest cadence (2h idle)
   lane_keywords:
   - security
   - cve
@@ -225,7 +225,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: architect-full.md
   include_repos: true
-  stale_timeout: 1800
+  stale_timeout: 14400  # 4h — must exceed longest cadence (2h idle)
   lane_keywords:
   - refactor
   - architecture
@@ -253,7 +253,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: strategist-full.md
   include_repos: false
-  stale_timeout: 1800
+  stale_timeout: 28800  # 8h — must exceed longest cadence (4h idle)
   lane_keywords:
   - strategy
   - roadmap
@@ -280,7 +280,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: outreach-full.md
   include_repos: false
-  stale_timeout: 1800
+  stale_timeout: 28800  # 8h — must exceed longest cadence (4h idle)
   lane_keywords:
   - community
   - adopters

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -941,8 +941,9 @@ func (s *Server) handleAgentConfigGet(w http.ResponseWriter, r *http.Request) {
 		displayName = ""
 	}
 
-	// Stale timeout from config, default to 1200
-	const defaultStaleTimeoutS = 1200
+	// Stale timeout from config, default to 28800 (8 hours).
+	// Must exceed the longest cadence interval to avoid false stale flags.
+	const defaultStaleTimeoutS = 28800
 	staleTimeout := agentCfg.StaleTimeout
 	if staleTimeout == 0 {
 		staleTimeout = defaultStaleTimeoutS


### PR DESCRIPTION
## Summary
- Agents with `staleTimeout` shorter than their kick cadence were falsely flagged as stale between every kick cycle
- Fixed 3 agents called out in the bug report (guide, scanner, quality) plus all other agents across all 6 level packs that had the same problem
- Updated the Go default from 1200s (20min) to 28800s (8h) for agents without an explicit `stale_timeout` in config
- Added explicit `stale_timeout` values to guide, scanner, and quality in `hive-quickstart.yaml`

## Rule applied
`stale_timeout >= 2x longest cadence` for each agent across all governor modes (excluding pause).

## Files changed
- `v2/deploy/hive-quickstart.yaml` — added stale_timeout for guide (28800), scanner (28800), quality (14400)
- `v2/pkg/config/packs/level-{1..6}.yaml` — fixed all stale_timeout values that were shorter than cadence
- `v2/pkg/dashboard/api.go` — raised `defaultStaleTimeoutS` from 1200 to 28800