### PR TITLE
fix: increase stale_timeout to exceed cadence intervals

### DIFF
--- a/v2/pkg/config/packs/level-2.yaml
+++ b/v2/pkg/config/packs/level-2.yaml
@@ -46,7 +46,7 @@ agents:
     mode: ADVISORY
     kick_template: supervisor-nogithub.md
     include_repos: true
-    stale_timeout: 1800
+    stale_timeout: 28800
     interactions: >
       Monitors all agents. Escalates issues to human operators. Coordinates
       agent restarts and health checks.
@@ -68,7 +68,7 @@ agents:
     mode: ADVISORY
     kick_template: guide-advisory.md
     include_repos: true
-    stale_timeout: 3600
+    stale_timeout: 28800
     interactions: "Works alongside scanner. Reviews scanner's suggestions when asked."
     knowledge_use: >
       Reads community wiki and project patterns. Starts contributing review

--- a/v2/pkg/config/packs/level-3.yaml
+++ b/v2/pkg/config/packs/level-3.yaml
@@ -56,7 +56,7 @@ agents:
   mode: ADVISORY
   kick_template: supervisor-nogithub.md
   include_repos: true
-  stale_timeout: 1800
+  stale_timeout: 28800
   interactions: 'Monitors all agents. Escalates issues to human operators. Coordinates
     agent restarts and health checks.
 
@@ -107,7 +107,7 @@ agents:
   mode: ADVISORY
   kick_template: ci-maintainer-advisory.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800
   lane_keywords:
   - ci
   - build
@@ -137,7 +137,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: quality-holdgated.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800
   interactions: 'Opens issues and hold-gated PRs about testing. Complements scanner
     and ci-maintainer advisory findings with actionable test improvements.
 
@@ -162,7 +162,7 @@ agents:
   mode: ADVISORY
   kick_template: guide-advisory.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800
   interactions: Works alongside scanner. Reviews scanner's suggestions when asked.
   knowledge_use: 'Reads community wiki and project patterns. Starts contributing review
     insights as knowledge entries.

--- a/v2/pkg/config/packs/level-4.yaml
+++ b/v2/pkg/config/packs/level-4.yaml
@@ -61,7 +61,7 @@ agents:
   mode: ADVISORY
   kick_template: supervisor-nogithub.md
   include_repos: true
-  stale_timeout: 1800
+  stale_timeout: 28800
   interactions: 'Monitors all agents. Escalates issues to human operators. Coordinates
     agent restarts and health checks.
 
@@ -115,7 +115,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: ci-maintainer-holdgated.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800
   lane_keywords:
   - ci
   - build
@@ -144,7 +144,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: quality-holdgated.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800
   interactions: 'Creates testing-related issues. Produces advisory beads. No PRs.
 
     '
@@ -168,7 +168,7 @@ agents:
   mode: ISSUES_ONLY
   kick_template: guide-issues.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800
   interactions: 'Creates documentation issues. Produces advisory beads. No PRs.
 
     '
@@ -193,7 +193,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: sec-check-holdgated.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800
   lane_keywords:
   - security
   - cve

--- a/v2/pkg/config/packs/level-5.yaml
+++ b/v2/pkg/config/packs/level-5.yaml
@@ -71,7 +71,7 @@ agents:
   mode: ADVISORY
   kick_template: supervisor-nogithub.md
   include_repos: true
-  stale_timeout: 1800
+  stale_timeout: 28800
   interactions: 'Monitors all agents. Escalates issues to human operators.
 
     '
@@ -94,7 +94,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: scanner-holdgated.md
   include_repos: true
-  stale_timeout: 1800
+  stale_timeout: 28800
   lane_keywords:
   - bug
   - triage
@@ -122,7 +122,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: ci-maintainer-holdgated.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800
   lane_keywords:
   - ci
   - build
@@ -151,7 +151,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: quality-holdgated.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800
   interactions: 'Reviews scanner PRs for coverage. Creates test PRs with hold label.
 
     '
@@ -174,7 +174,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: guide-holdgated.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800
   interactions: 'Creates documentation issues and hold-gated PRs.
 
     '
@@ -197,7 +197,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: sec-check-holdgated.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800
   lane_keywords:
   - security
   - cve
@@ -225,7 +225,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: architect-holdgated.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800
   lane_keywords:
   - refactor
   - architecture
@@ -255,7 +255,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: strategist-holdgated.md
   include_repos: false
-  stale_timeout: 3600
+  stale_timeout: 28800
   lane_keywords:
   - strategy
   - roadmap

--- a/v2/pkg/config/packs/level-6.yaml
+++ b/v2/pkg/config/packs/level-6.yaml
@@ -175,7 +175,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: guide-full.md
   include_repos: true
-  stale_timeout: 3600
+  stale_timeout: 28800
   interactions: 'Creates documentation PRs autonomously.
 
     '
@@ -225,7 +225,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: architect-full.md
   include_repos: true
-  stale_timeout: 1800
+  stale_timeout: 28800
   lane_keywords:
   - refactor
   - architecture
@@ -253,7 +253,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: strategist-full.md
   include_repos: false
-  stale_timeout: 1800
+  stale_timeout: 28800
   lane_keywords:
   - strategy
   - roadmap
@@ -280,7 +280,7 @@ agents:
   mode: ISSUES_AND_PRS
   kick_template: outreach-full.md
   include_repos: false
-  stale_timeout: 1800
+  stale_timeout: 28800
   lane_keywords:
   - community
   - adopters


### PR DESCRIPTION
stale_timeout was shorter than cadence for guide/scanner/quality, causing false stale detection every kick cycle.