### PR TITLE
fix: return JSON error responses from nginx during startup

### DIFF
--- a/v2/deploy/nginx.conf
+++ b/v2/deploy/nginx.conf
@@ -24,6 +24,27 @@ http {
     server {
         listen 3001;
 
+        location /api/ {
+            proxy_pass http://hive_api;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_read_timeout 86400s;
+            proxy_send_timeout 86400s;
+            proxy_hide_header Cache-Control;
+            proxy_hide_header Pragma;
+            add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+            add_header Pragma "no-cache" always;
+
+            proxy_intercept_errors on;
+            error_page 502 503 504 =503 @api_error;
+        }
+
+        location @api_error {
+            default_type application/json;
+            return 503 '{"error":"service starting up, please retry","ok":false}';
+        }
+
         location / {
             proxy_pass http://hive_api;
             proxy_http_version 1.1;


### PR DESCRIPTION
## Summary
- Adds `/api/` location block with `proxy_intercept_errors on` to intercept 502/503/504 errors from the Go backend
- Returns JSON `{"error":"service starting up, please retry","ok":false}` with 503 status instead of nginx's default HTML error pages
- Prevents API clients from breaking on unparseable HTML during the 20+ second Go binary startup window

## Test plan
- [ ] Restart the hive container and hit `/api/` endpoints during startup — verify 503 JSON response instead of HTML
- [ ] Verify normal API requests still proxy correctly once the Go binary is up
- [ ] Verify WebSocket upgrades on `/` still work (only `/api/` has error interception)