### PR TITLE
fix: disable clearOnKick for supervisor to reduce token waste

### DIFF
--- a/v2/deploy/hive-quickstart.yaml
+++ b/v2/deploy/hive-quickstart.yaml
@@ -63,6 +63,7 @@ agents:
     color: "#e74c3c"
     kick_template: supervisor-CLAUDE.md
     include_repos: true
+    clear_on_kick: false
     bead_role: supervisor
   scanner:
     id: scanner

--- a/v2/pkg/config/packs/level-2.yaml
+++ b/v2/pkg/config/packs/level-2.yaml
@@ -46,6 +46,7 @@ agents:
     mode: ADVISORY
     kick_template: supervisor-nogithub.md
     include_repos: true
+    clear_on_kick: false
     stale_timeout: 1800
     interactions: >
       Monitors all agents. Escalates issues to human operators. Coordinates

--- a/v2/pkg/config/packs/level-3.yaml
+++ b/v2/pkg/config/packs/level-3.yaml
@@ -56,6 +56,7 @@ agents:
   mode: ADVISORY
   kick_template: supervisor-nogithub.md
   include_repos: true
+  clear_on_kick: false
   stale_timeout: 1800
   interactions: 'Monitors all agents. Escalates issues to human operators. Coordinates
     agent restarts and health checks.

--- a/v2/pkg/config/packs/level-4.yaml
+++ b/v2/pkg/config/packs/level-4.yaml
@@ -61,6 +61,7 @@ agents:
   mode: ADVISORY
   kick_template: supervisor-nogithub.md
   include_repos: true
+  clear_on_kick: false
   stale_timeout: 1800
   interactions: 'Monitors all agents. Escalates issues to human operators. Coordinates
     agent restarts and health checks.

--- a/v2/pkg/config/packs/level-5.yaml
+++ b/v2/pkg/config/packs/level-5.yaml
@@ -71,6 +71,7 @@ agents:
   mode: ADVISORY
   kick_template: supervisor-nogithub.md
   include_repos: true
+  clear_on_kick: false
   stale_timeout: 1800
   interactions: 'Monitors all agents. Escalates issues to human operators.
 

--- a/v2/pkg/config/packs/level-6.yaml
+++ b/v2/pkg/config/packs/level-6.yaml
@@ -71,6 +71,7 @@ agents:
   mode: ADVISORY
   kick_template: supervisor-nogithub.md
   include_repos: true
+  clear_on_kick: false
   stale_timeout: 600
   interactions: 'Full autonomous oversight of all agents. Triggers self-healing actions
     without human intervention.


### PR DESCRIPTION
## Summary
- Set `clear_on_kick: false` for the supervisor agent in `hive-quickstart.yaml` and all level packs (2-6)
- Supervisor was defaulting to `clearOnKick=true`, causing it to rebuild its full 549-line template context every 5-minute kick cycle
- This wasted ~57M tokens (30% of total) and accumulated 121 stale CLI sessions
- With `clear_on_kick: false`, supervisor persists context across kicks and maintains awareness of agent health, bead status, and monitoring state
- Other agents (brainstorm) with longer cadences keep `clearOnKick=true`

## Files changed
- `v2/deploy/hive-quickstart.yaml` — added `clear_on_kick: false` to supervisor
- `v2/pkg/config/packs/level-{2,3,4,5,6}.yaml` — added `clear_on_kick: false` to supervisor (level-1 has no supervisor)