### PR TITLE
fix: serialize agent restart operations to prevent race condition

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -649,6 +649,11 @@ func (s *Server) handleUnpin(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleRestart(w http.ResponseWriter, r *http.Request) {
 	name := s.resolveAgentParam(r.PathValue("agent"))
 
+	// Serialize restart operations to prevent concurrent pause/resume cycles
+	// from interfering through shared state (tmux server, config writes).
+	s.restartMu.Lock()
+	defer s.restartMu.Unlock()
+
 	if err := s.deps.AgentMgr.Restart(s.deps.Ctx, name); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -38,6 +38,7 @@ type Server struct {
 	hooksMu        sync.RWMutex
 	knowledgeMu    sync.Mutex
 	levelMu        sync.Mutex
+	restartMu      sync.Mutex // serializes concurrent agent restart operations
 
 	tokenHistoryMu    sync.RWMutex
 	tokenHistory      []TokenSparklineEntry


### PR DESCRIPTION
## Summary
- Adds `restartMu` mutex to the dashboard `Server` struct to serialize concurrent `POST /api/restart/{agent}` calls
- Prevents race condition where concurrent restart operations for different agents interfere through shared state (tmux server, config writes), leaving all agents paused with 0 restarts instead of running with 1 restart
- Follows the same pattern as the existing `levelMu` mutex used for pack level switches

## Test plan
- [ ] Trigger concurrent restarts for 3+ agents via the dashboard and verify each ends up running with restart count = 1
- [ ] Verify single-agent restart still works normally
- [ ] Verify no deadlock when rapid restart clicks occur