### PR TITLE
perf: remove token sessions from status response (70% size reduction)

### DIFF
--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -605,20 +605,8 @@ func buildTokens(collector *tokens.Collector) FrontendTokens {
 		ft.ByModel[modelName] = bucket
 	}
 
-	// Build individual session list for Active Sessions
-	for _, sess := range summary.Sessions {
-		fs := FrontendSession{
-			ID:       sess.SessionID,
-			Agent:    sess.Agent,
-			Model:    sess.Model,
-			Total:    sess.TotalTokens,
-			Messages: sess.Messages,
-		}
-		if sess.LastActive > 0 {
-			fs.LastActive = time.UnixMilli(sess.LastActive).UTC().Format(time.RFC3339)
-		}
-		ft.Sessions = append(ft.Sessions, fs)
-	}
+	// Individual sessions are omitted from the status payload to reduce size
+	// (~70% savings). Use GET /api/tokens for the full session list.
 
 	return ft
 }

--- a/v2/pkg/dashboard/status_builder_test.go
+++ b/v2/pkg/dashboard/status_builder_test.go
@@ -688,8 +688,8 @@ func TestBuildTokens_WithSessionData(t *testing.T) {
 	if ft.Totals.Input <= 0 {
 		t.Errorf("expected positive total input, got %d", ft.Totals.Input)
 	}
-	if len(ft.Sessions) != 1 {
-		t.Errorf("sessions len = %d, want 1", len(ft.Sessions))
+	if len(ft.Sessions) != 0 {
+		t.Errorf("sessions len = %d, want 0 (sessions excluded from status payload)", len(ft.Sessions))
 	}
 	if ft.Totals.Sessions != 1 {
 		t.Errorf("totals.sessions = %d, want 1", ft.Totals.Sessions)


### PR DESCRIPTION
## Summary
- Remove the `tokens.sessions` array from the `/api/status` response, reducing payload size from ~158KB to ~47KB (~70% reduction)
- Individual session data remains available via the dedicated `GET /api/tokens` endpoint
- At 5-second polling intervals, this saves ~13KB/s of bandwidth per connected dashboard client

## Details
The `tokens.sessions` array contained 600+ individual copilot CLI sessions with per-session token counts. This data is only needed by the Active Sessions view, which can fetch it on demand from `/api/tokens`. The status response retains all aggregate token data (`totals`, `byAgent`, `byModel`).

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/dashboard/...` passes
- [ ] Verify dashboard loads correctly with slimmed status payload
- [ ] Verify Active Sessions view still works via `/api/tokens`