### PR TITLE
fix: bust Docker cache on every commit to prevent stale binaries

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,6 +54,8 @@ jobs:
           context: .
           file: v2/Dockerfile
           platforms: ${{ matrix.platform }}
+          build-args: |
+            GIT_HASH=${{ github.sha }}
           outputs: type=image,name=ghcr.io/kubestellar/hive,push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ steps.slug.outputs.slug }}
           cache-to: type=gha,scope=${{ steps.slug.outputs.slug }},mode=max

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -1,6 +1,11 @@
 FROM golang:1.25-alpine AS builder
 RUN apk add --no-cache git
 WORKDIR /src
+
+# Cache-buster: this ARG changes on every commit, invalidating all layers
+# below it so Docker never reuses a stale Go binary from a previous build.
+ARG GIT_HASH=unknown
+
 COPY .git /repo/.git
 COPY v2/ .
 RUN GIT_HASH=$(git -C /repo rev-parse HEAD 2>/dev/null || echo "unknown") && \


### PR DESCRIPTION
## Summary
- Adds a `GIT_HASH` build arg before the `COPY`/`RUN` layers in the builder stage of `v2/Dockerfile`
- Passes `github.sha` as the build arg from `.github/workflows/docker.yml`
- Every commit produces a unique ARG value that invalidates the Docker layer cache from that point forward, ensuring the Go binary is always rebuilt with the correct source

## Problem
The GHA Docker build cache (`type=gha`) reuses cached layers when file content hasn't changed. When only CI YAML or non-`v2/` files change (e.g., from other merged PRs), the `COPY` and `RUN` layers that build the Go binary are served from cache, producing an image with a stale `hive` binary.

## Test plan
- [ ] Verify Docker CI builds pass on this PR
- [ ] Confirm future builds after merging non-Go PRs produce fresh binaries