### PR TITLE
fix: emoji rune count, empty role rejection, log dir validation

### DIFF
--- a/v2/pkg/dashboard/validation.go
+++ b/v2/pkg/dashboard/validation.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 )
 
 // ---------- validation constants ----------
@@ -120,7 +121,7 @@ func validateAgentGeneralInput(body map[string]interface{}) error {
 	}
 	if v, ok := body["emoji"]; ok {
 		if s, ok := v.(string); ok {
-			if len(s) > maxEmojiLen {
+			if utf8.RuneCountInString(s) > maxEmojiLen {
 				return fmt.Errorf("emoji must be at most %d characters", maxEmojiLen)
 			}
 		}
@@ -133,7 +134,10 @@ func validateAgentGeneralInput(body map[string]interface{}) error {
 		}
 	}
 	if v, ok := body["role"]; ok {
-		if s, ok := v.(string); ok && s != "" {
+		if s, ok := v.(string); ok {
+			if s == "" {
+				return fmt.Errorf("role must not be empty")
+			}
 			if !knownRoles[s] {
 				return fmt.Errorf("role must be one of: %s", knownRolesList())
 			}

--- a/v2/pkg/dashboard/validation_test.go
+++ b/v2/pkg/dashboard/validation_test.go
@@ -197,6 +197,22 @@ func TestValidateAgentGeneralInput(t *testing.T) {
 			errMsg:  "emoji must be at most",
 		},
 		{
+			name:    "flag emoji accepted (multi-byte rune)",
+			body:    map[string]interface{}{"emoji": "\U0001F1FA\U0001F1F8"},
+			wantErr: false,
+		},
+		{
+			name:    "single emoji accepted",
+			body:    map[string]interface{}{"emoji": "\U0001F680"},
+			wantErr: false,
+		},
+		{
+			name:    "empty role rejected",
+			body:    map[string]interface{}{"role": ""},
+			wantErr: true,
+			errMsg:  "role must not be empty",
+		},
+		{
 			name:    "staleTimeout negative",
 			body:    map[string]interface{}{"staleTimeout": float64(-1)},
 			wantErr: true,
@@ -375,6 +391,7 @@ func TestValidateGovernorLogging(t *testing.T) {
 		{"valid", "/data/logs", 100, 30, false},
 		{"empty dir", "", 100, 30, false},
 		{"bad dir prefix", "/tmp/logs", 100, 30, true},
+		{"path traversal rejected", "/etc/passwd", 100, 30, true},
 		{"size too small", "/data/logs", 0, 30, false}, // 0 means not set
 		{"size too large", "/data/logs", 1001, 30, true},
 		{"age too large", "/data/logs", 100, 400, true},


### PR DESCRIPTION
## Summary
- **Emoji validation**: Changed `len()` to `utf8.RuneCountInString()` so multi-byte emojis like flag emoji (🇺🇸) are accepted — they are 2 runes, not 8 bytes
- **Empty role rejection**: Removed the `s != ""` guard on role validation so `role=""` is now rejected with "role must not be empty"
- **Log dir path traversal**: Confirmed existing check is correct (`/etc/passwd` is rejected by the `/data/` prefix requirement); added explicit test case for `/etc/passwd`

## Test plan
- [x] All existing validation tests pass
- [x] New test: flag emoji (🇺🇸) accepted as valid emoji
- [x] New test: single emoji (🚀) accepted as valid emoji
- [x] New test: empty role rejected
- [x] New test: `/etc/passwd` path traversal rejected in logging dir
- [x] `go build ./...` passes