### PR TITLE
fix: bust Docker cache for nginx and proxy layers too

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -78,6 +78,12 @@ RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} && npm cache
 # --- Application layers ---
 ENV HOME=/home/dev
 
+# Cache-buster: re-declare in the final stage so ALL COPY layers below
+# (proxy/, deploy/, dashboard/, bin/) are invalidated on every commit.
+# Without this, only the Go binary (from the builder stage) gets rebuilt
+# while nginx config, Node.js proxy, and script changes stay stale.
+ARG GIT_HASH=unknown
+
 COPY --from=builder /hive /usr/local/bin/hive
 COPY --from=builder /bd /usr/local/bin/bd
 


### PR DESCRIPTION
## Summary

`ARG GIT_HASH` was only declared in the builder stage, so it only invalidated the Go binary build. The final stage COPY layers for `proxy/`, `deploy/`, `dashboard/`, and `bin/` remained cached, preventing merged changes from deploying:

- #884 (gzip compression)
- #885 (cache-control headers)
- #895 (JSON error responses)

Re-declares `ARG GIT_HASH=unknown` in the final stage before the application COPY layers so all of them are invalidated when the commit hash changes.

## Test plan

- [x] `docker build --check` passes (no warnings)
- [ ] After merge, verify next deploy picks up nginx/proxy changes