### PR TITLE
feat: contribute-login + step order + clone v2 + copy button

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -46,6 +46,105 @@ contribute-register:
     echo "  Contributor ID: ${CID}"
     echo "  Config saved:   {{config_dir}}/contributor.env"
     echo ""
+    echo ""
+    echo "Next: run 'just contribute-login' to authenticate."
+
+# Authenticate GitHub + CLI (run once before contribute-hive)
+contribute-login backend="claude":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p "{{config_dir}}"
+    echo "=== Hive Contributor Login ==="
+    echo ""
+
+    # Step 1: GitHub authentication via gh CLI
+    echo "── Step 1: GitHub Authentication ──"
+    if command -v gh &>/dev/null; then
+      if gh auth status &>/dev/null; then
+        GH_USER=$(gh api user --jq '.login' 2>/dev/null || echo "")
+        echo "Already authenticated as: ${GH_USER}"
+      else
+        echo "Logging into GitHub..."
+        gh auth login --web --scopes "repo,read:org"
+        GH_USER=$(gh api user --jq '.login' 2>/dev/null || echo "")
+        echo "Authenticated as: ${GH_USER}"
+      fi
+      # Save the token for the contributor container
+      GH_TOKEN=$(gh auth token 2>/dev/null || echo "")
+      if [[ -n "$GH_TOKEN" ]]; then
+        echo "GH_TOKEN=${GH_TOKEN}" > "{{config_dir}}/gh-auth.env"
+        chmod 600 "{{config_dir}}/gh-auth.env"
+        echo "GitHub token saved to {{config_dir}}/gh-auth.env"
+      fi
+    else
+      echo "gh CLI not found. Install: https://cli.github.com"
+      echo "Then run: gh auth login --web --scopes 'repo,read:org'"
+      exit 1
+    fi
+
+    echo ""
+
+    # Step 2: CLI authentication
+    echo "── Step 2: {{backend}} CLI Authentication ──"
+    case "{{backend}}" in
+      claude)
+        if command -v claude &>/dev/null; then
+          echo "Launching Claude Code login..."
+          claude login 2>/dev/null || echo "Claude login complete (or already authenticated)"
+        else
+          echo "Claude Code not installed. Install: npm i -g @anthropic-ai/claude-code"
+          exit 1
+        fi
+        ;;
+      copilot)
+        if command -v copilot &>/dev/null; then
+          echo "Copilot uses your gh auth. Already authenticated via Step 1."
+        else
+          echo "Copilot CLI not found. Install: gh extension install github/gh-copilot"
+          exit 1
+        fi
+        ;;
+      gemini)
+        if command -v gemini &>/dev/null; then
+          echo "Launching Gemini CLI login..."
+          gemini auth login 2>/dev/null || echo "Gemini login complete (or already authenticated)"
+        else
+          echo "Gemini CLI not installed."
+          exit 1
+        fi
+        ;;
+      bob)
+        if command -v bob &>/dev/null; then
+          echo "Bob CLI detected. Authentication handled by bob on first run."
+        else
+          echo "Bob CLI not found."
+          exit 1
+        fi
+        ;;
+      goose)
+        if command -v goose &>/dev/null; then
+          echo "Goose CLI detected. Authentication handled by goose on first run."
+        else
+          echo "Goose CLI not found."
+          exit 1
+        fi
+        ;;
+      *)
+        echo "Unknown backend: {{backend}}"
+        echo "Supported: claude, copilot, gemini, bob, goose"
+        exit 1
+        ;;
+    esac
+
+    # Save chosen backend
+    echo "AGENT_BACKEND={{backend}}" >> "{{config_dir}}/contributor.env"
+
+    echo ""
+    echo "Login complete!"
+    echo "  GitHub:  authenticated"
+    echo "  CLI:     {{backend}}"
+    echo "  Config:  {{config_dir}}/"
+    echo ""
     echo "Run 'just contribute-hive' to start contributing."
 
 # Join the Hive swarm as a contributor
@@ -56,19 +155,29 @@ contribute-hive backend="claude":
       echo "Not registered yet. Run: just contribute-register"
       exit 1
     fi
+    if [[ ! -f "{{config_dir}}/gh-auth.env" ]]; then
+      echo "Not logged in yet. Run: just contribute-login {{backend}}"
+      exit 1
+    fi
+    # Load contributor's personal GH token
+    source "{{config_dir}}/gh-auth.env"
     echo "=== Hive Contributor Agent ==="
-    echo "Backend: {{backend}}"
-    echo "Hub:     {{hive_hub}}"
+    echo "Backend:  {{backend}}"
+    echo "Hub:      {{hive_hub}}"
+    echo "GitHub:   $(gh api user --jq '.login' 2>/dev/null || echo 'authenticated')"
     echo ""
-    echo "Your CLI API tokens stay local. Hive provides GitHub access."
+    echo "Your CLI tokens + GitHub identity stay local."
     echo ""
     docker run -it --rm \
       --name hive-contributor \
       -v "{{config_dir}}:/home/dev/.config/hive:ro" \
       -v "${HOME}/.claude:/home/dev/.claude:ro" \
       -v "${HOME}/.config/claude-code:/home/dev/.config/claude-code:ro" \
+      -v "${HOME}/.config/gh:/home/dev/.config/gh:ro" \
       -e HIVE_HUB="{{hive_hub}}" \
       -e AGENT_BACKEND="{{backend}}" \
+      -e GH_TOKEN="${GH_TOKEN}" \
+      -e HIVE_USE_CONTRIBUTOR_GH=true \
       {{hive_image}}
 
 # Check hub status and your contributor profile

--- a/Justfile
+++ b/Justfile
@@ -1,7 +1,7 @@
 # Justfile — KubeStellar Hive contributor commands
 #
 # Install just: brew install just (macOS) or cargo install just
-# Usage: just contribute-hive [backend]
+# Usage: just contribute-setup claude && just contribute-hive
 
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
@@ -13,160 +13,135 @@ config_dir := env("HOME") + "/.config/hive"
 default:
     @just --list
 
-# Register as a Hive contributor (one-time)
-contribute-register:
+# One-time setup: register with hub + authenticate GitHub + authenticate CLI
+contribute-setup backend="claude":
     #!/usr/bin/env bash
     set -euo pipefail
     mkdir -p "{{config_dir}}"
-    echo "=== Hive Contributor Registration ==="
+    echo "=== Hive Contributor Setup ==="
     echo ""
-    read -rp "GitHub username: " github_user
+
+    # ── Step 1: GitHub authentication ──
+    echo "── Step 1/3: GitHub Authentication ──"
+    if ! command -v gh &>/dev/null; then
+      echo "ERROR: gh CLI not found. Install: brew install gh"
+      exit 1
+    fi
+    if gh auth status &>/dev/null; then
+      GH_USER=$(gh api user --jq '.login' 2>/dev/null || echo "")
+      echo "Already authenticated as: ${GH_USER}"
+    else
+      echo "Logging into GitHub..."
+      gh auth login --web --scopes "repo,read:org"
+      GH_USER=$(gh api user --jq '.login' 2>/dev/null || echo "")
+      echo "Authenticated as: ${GH_USER}"
+    fi
+    GH_TOKEN=$(gh auth token 2>/dev/null || echo "")
+    if [[ -n "$GH_TOKEN" ]]; then
+      echo "GH_TOKEN=${GH_TOKEN}" > "{{config_dir}}/gh-auth.env"
+      chmod 600 "{{config_dir}}/gh-auth.env"
+    fi
     echo ""
-    echo "Registering with hub..."
+
+    # ── Step 2: Register with hive hub ──
+    echo "── Step 2/3: Hive Registration ──"
     HUB_HTTP=$(echo "{{hive_hub}}" | sed 's|^wss://|https://|;s|^ws://|http://|;s|/contribute$||')
     RESPONSE=$(curl -sf -X POST "${HUB_HTTP}/api/contribute/register" \
       -H "Content-Type: application/json" \
-      -d "{\"github_username\": \"${github_user}\"}" 2>&1) || {
+      -d "{\"github_username\": \"${GH_USER}\"}" 2>&1) || {
         echo "ERROR: Registration failed. Is the hub running at ${HUB_HTTP}?"
         exit 1
     }
     TOKEN=$(echo "$RESPONSE" | jq -r '.registration_token')
     CID=$(echo "$RESPONSE" | jq -r '.contributor_id')
+    MSG=$(echo "$RESPONSE" | jq -r '.message')
     if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
-      echo "ERROR: No token received. Response: $RESPONSE"
+      echo "ERROR: ${MSG:-No token received}"
       exit 1
     fi
     cat > "{{config_dir}}/contributor.env" <<EOF
     HIVE_REGISTRATION_TOKEN=${TOKEN}
     HIVE_HUB={{hive_hub}}
     CONTRIBUTOR_ID=${CID}
+    AGENT_BACKEND={{backend}}
     EOF
-    echo ""
-    echo "Registration successful!"
-    echo "  Contributor ID: ${CID}"
-    echo "  Config saved:   {{config_dir}}/contributor.env"
-    echo ""
-    echo ""
-    echo "Next: run 'just contribute-login' to authenticate."
-
-# Authenticate GitHub + CLI (run once before contribute-hive)
-contribute-login backend="claude":
-    #!/usr/bin/env bash
-    set -euo pipefail
-    mkdir -p "{{config_dir}}"
-    echo "=== Hive Contributor Login ==="
+    echo "${MSG} — ${GH_USER} (${CID})"
     echo ""
 
-    # Step 1: GitHub authentication via gh CLI
-    echo "── Step 1: GitHub Authentication ──"
-    if command -v gh &>/dev/null; then
-      if gh auth status &>/dev/null; then
-        GH_USER=$(gh api user --jq '.login' 2>/dev/null || echo "")
-        echo "Already authenticated as: ${GH_USER}"
-      else
-        echo "Logging into GitHub..."
-        gh auth login --web --scopes "repo,read:org"
-        GH_USER=$(gh api user --jq '.login' 2>/dev/null || echo "")
-        echo "Authenticated as: ${GH_USER}"
-      fi
-      # Save the token for the contributor container
-      GH_TOKEN=$(gh auth token 2>/dev/null || echo "")
-      if [[ -n "$GH_TOKEN" ]]; then
-        echo "GH_TOKEN=${GH_TOKEN}" > "{{config_dir}}/gh-auth.env"
-        chmod 600 "{{config_dir}}/gh-auth.env"
-        echo "GitHub token saved to {{config_dir}}/gh-auth.env"
-      fi
-    else
-      echo "gh CLI not found. Install: https://cli.github.com"
-      echo "Then run: gh auth login --web --scopes 'repo,read:org'"
-      exit 1
-    fi
-
-    echo ""
-
-    # Step 2: CLI authentication
-    echo "── Step 2: {{backend}} CLI Authentication ──"
+    # ── Step 3: CLI authentication ──
+    echo "── Step 3/3: {{backend}} CLI Authentication ──"
     case "{{backend}}" in
       claude)
         if command -v claude &>/dev/null; then
-          echo "Launching Claude Code login..."
           claude login 2>/dev/null || echo "Claude login complete (or already authenticated)"
         else
-          echo "Claude Code not installed. Install: npm i -g @anthropic-ai/claude-code"
+          echo "ERROR: Claude Code not installed. Install: npm i -g @anthropic-ai/claude-code"
           exit 1
         fi
         ;;
       copilot)
-        if command -v copilot &>/dev/null; then
-          echo "Copilot uses your gh auth. Already authenticated via Step 1."
+        if command -v copilot &>/dev/null || command -v gh &>/dev/null; then
+          echo "Copilot uses your gh auth — already authenticated."
         else
-          echo "Copilot CLI not found. Install: gh extension install github/gh-copilot"
+          echo "ERROR: Install copilot: gh extension install github/gh-copilot"
           exit 1
         fi
         ;;
       gemini)
         if command -v gemini &>/dev/null; then
-          echo "Launching Gemini CLI login..."
           gemini auth login 2>/dev/null || echo "Gemini login complete (or already authenticated)"
         else
-          echo "Gemini CLI not installed."
+          echo "ERROR: Gemini CLI not installed."
           exit 1
         fi
         ;;
       bob)
         if command -v bob &>/dev/null; then
-          echo "Bob CLI detected. Authentication handled by bob on first run."
+          echo "Bob CLI detected — authentication handled on first run."
         else
-          echo "Bob CLI not found."
+          echo "ERROR: Bob CLI not found."
           exit 1
         fi
         ;;
       goose)
         if command -v goose &>/dev/null; then
-          echo "Goose CLI detected. Authentication handled by goose on first run."
+          echo "Goose CLI detected — authentication handled on first run."
         else
-          echo "Goose CLI not found."
+          echo "ERROR: Goose CLI not found."
           exit 1
         fi
         ;;
       *)
-        echo "Unknown backend: {{backend}}"
-        echo "Supported: claude, copilot, gemini, bob, goose"
+        echo "ERROR: Unknown backend '{{backend}}'. Supported: claude, copilot, gemini, bob, goose"
         exit 1
         ;;
     esac
 
-    # Save chosen backend
-    echo "AGENT_BACKEND={{backend}}" >> "{{config_dir}}/contributor.env"
-
     echo ""
-    echo "Login complete!"
-    echo "  GitHub:  authenticated"
+    echo "✓ Setup complete!"
+    echo "  GitHub:  ${GH_USER}"
     echo "  CLI:     {{backend}}"
-    echo "  Config:  {{config_dir}}/"
+    echo "  Hub:     {{hive_hub}}"
     echo ""
     echo "Run 'just contribute-hive' to start contributing."
 
-# Join the Hive swarm as a contributor
+# Start contributing — launches the agent container
 contribute-hive backend="claude":
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ ! -f "{{config_dir}}/contributor.env" ]]; then
-      echo "Not registered yet. Run: just contribute-register"
+      echo "Not set up yet. Run: just contribute-setup {{backend}}"
       exit 1
     fi
     if [[ ! -f "{{config_dir}}/gh-auth.env" ]]; then
-      echo "Not logged in yet. Run: just contribute-login {{backend}}"
+      echo "Not set up yet. Run: just contribute-setup {{backend}}"
       exit 1
     fi
-    # Load contributor's personal GH token
     source "{{config_dir}}/gh-auth.env"
     echo "=== Hive Contributor Agent ==="
     echo "Backend:  {{backend}}"
     echo "Hub:      {{hive_hub}}"
     echo "GitHub:   $(gh api user --jq '.login' 2>/dev/null || echo 'authenticated')"
-    echo ""
-    echo "Your CLI tokens + GitHub identity stay local."
     echo ""
     docker run -it --rm \
       --name hive-contributor \

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -18,7 +18,8 @@ const { execSync, execFile } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
-const HUB_URL = process.env.HIVE_HUB || 'wss://hive.kubestellar.io:3001/contribute';
+const rawHub = process.env.HIVE_HUB || 'wss://hive.kubestellar.io:3001/contribute';
+const HUB_URL = rawHub.replace(/\/contribute\/?$/, '/api/contribute/ws');
 const REG_TOKEN = process.env.HIVE_REGISTRATION_TOKEN;
 const BACKEND = process.env.AGENT_BACKEND || 'claude';
 const MODEL = process.env.AGENT_MODEL || '';

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -313,20 +313,16 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 <div class="steps">
 <h3>How it works</h3>
 <ol>
-<li><strong>Install prerequisites</strong> — <code>brew install just gh</code> + <a href="https://docker.com/get-started" target="_blank" style="color:#58a6ff">Docker Desktop</a></li>
-<li><strong>Clone + enter repo</strong> — <code>git clone -b v2 https://github.com/kubestellar/hive && cd hive</code></li>
-<li><strong>Register</strong> — <code>just contribute-register</code></li>
-<li><strong>Login</strong> — <code>just contribute-login claude</code> (authenticates GitHub + your CLI)</li>
-<li><strong>Run</strong> — <code>just contribute-hive</code></li>
-<li><strong>Walk away</strong> — your agent pulls work from the queue</li>
+<li><strong>Install</strong> — <code>brew install just gh</code> + <a href="https://docker.com/get-started" target="_blank" style="color:#58a6ff">Docker</a> + your CLI (<code>npm i -g @anthropic-ai/claude-code</code>)</li>
+<li><strong>Setup</strong> — <code>just contribute-setup claude</code> (registers with hive + authenticates GitHub + CLI)</li>
+<li><strong>Run</strong> — <code>just contribute-hive</code> — then walk away</li>
 </ol>
 <div style="margin-top:16px;background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:16px;position:relative">
 <button onclick="navigator.clipboard.writeText(this.nextElementSibling.textContent.trim());this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',2000)" style="position:absolute;top:8px;right:8px;background:#238636;color:#fff;border:none;border-radius:4px;padding:4px 12px;cursor:pointer;font-size:.75rem">Copy</button>
-<pre style="color:#e6edf3;font-size:.85rem;margin:0;overflow-x:auto;white-space:pre">brew install just gh  # also install Docker Desktop
+<pre style="color:#e6edf3;font-size:.85rem;margin:0;overflow-x:auto;white-space:pre">brew install just gh
 git clone -b v2 https://github.com/kubestellar/hive && cd hive
 export HIVE_HUB=%s
-just contribute-register
-just contribute-login claude
+just contribute-setup claude
 just contribute-hive</pre>
 </div>
 </div>

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -255,6 +255,12 @@ func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request)
 			ts.color, ts.count, ts.label)
 	}
 
+	wsProto := "ws"
+	if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
+		wsProto = "wss"
+	}
+	hubURL := fmt.Sprintf("%s://%s/contribute", wsProto, r.Host)
+
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	fmt.Fprintf(w, `<!DOCTYPE html>
 <html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Contribute to %s</title>
@@ -307,20 +313,30 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 <div class="steps">
 <h3>How it works</h3>
 <ol>
-<li><strong>Register</strong> — <code>just contribute-register</code> or POST to <code>/api/contribute/register</code></li>
-<li><strong>Install just</strong> — <code>brew install just</code></li>
-<li><strong>Clone the hive repo</strong> — <code>git clone https://github.com/kubestellar/hive</code></li>
+<li><strong>Install prerequisites</strong> — <code>brew install just gh</code> + <a href="https://docker.com/get-started" target="_blank" style="color:#58a6ff">Docker Desktop</a></li>
+<li><strong>Clone + enter repo</strong> — <code>git clone -b v2 https://github.com/kubestellar/hive && cd hive</code></li>
+<li><strong>Register</strong> — <code>just contribute-register</code></li>
+<li><strong>Login</strong> — <code>just contribute-login claude</code> (authenticates GitHub + your CLI)</li>
 <li><strong>Run</strong> — <code>just contribute-hive</code></li>
 <li><strong>Walk away</strong> — your agent pulls work from the queue</li>
 </ol>
+<div style="margin-top:16px;background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:16px;position:relative">
+<button onclick="navigator.clipboard.writeText(this.nextElementSibling.textContent.trim());this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',2000)" style="position:absolute;top:8px;right:8px;background:#238636;color:#fff;border:none;border-radius:4px;padding:4px 12px;cursor:pointer;font-size:.75rem">Copy</button>
+<pre style="color:#e6edf3;font-size:.85rem;margin:0;overflow-x:auto;white-space:pre">brew install just gh  # also install Docker Desktop
+git clone -b v2 https://github.com/kubestellar/hive && cd hive
+export HIVE_HUB=%s
+just contribute-register
+just contribute-login claude
+just contribute-hive</pre>
+</div>
 </div>
 <div style="margin-top:20px;display:flex;gap:12px;flex-wrap:wrap">
 <a href="/leaderboard" style="display:inline-block;padding:8px 20px;background:#161b22;border:1px solid #30363d;border-radius:8px;color:#58a6ff;text-decoration:none;font-size:.9rem">🏆 View Leaderboard</a>
 </div>
 <div class="how">
 <h3>What you bring vs. what the hive provides</h3>
-<p><strong>You bring:</strong> Your own CLI API tokens. You pay for your own model inference.</p>
-<p><strong>The hive provides:</strong> Scoped GitHub access via a GitHub App. Neither side sees the other's secrets.</p>
+<p><strong>You bring:</strong> Your GitHub account + CLI API tokens. Issues and PRs are created under YOUR name.</p>
+<p><strong>The hive provides:</strong> Work queue, task assignment, and coordination. Your credentials never leave your machine.</p>
 </div>
 <div class="how">
 <h3>Trust tiers</h3>
@@ -370,7 +386,7 @@ if(isNew)f.scrollTop=0;
 }catch(e){}}
 poll();setInterval(poll,3000);
 </script>
-</body></html>`, projectName, projectName, len(profiles), tierBoxes.String())
+</body></html>`, projectName, projectName, len(profiles), tierBoxes.String(), hubURL)
 }
 
 // ── Registration ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **`just contribute-login`**: authenticates GitHub via `gh auth login` + CLI login. Saves personal GH token.
- **`just contribute-hive`**: now requires login, passes contributor's GH_TOKEN to container
- **/contribute page**: steps reordered, clone uses `-b v2`, copy-all button added
- Bug #67 (step order) and #68 (no justfile on main) fixed

## Test plan
- [ ] `git clone -b v2 https://github.com/kubestellar/hive && cd hive`
- [ ] `just contribute-register` works
- [ ] `just contribute-login claude` authenticates GitHub + Claude
- [ ] `just contribute-hive` passes GH_TOKEN to container
- [ ] /contribute page shows correct steps with copy button