### PR TITLE
fix: poll for element readiness before hash scroll

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6281,6 +6281,26 @@ function burnAreaChart() {
       if (cpuSpark) cpuSpark.innerHTML = sysGaugeMiniSpark(_sysGaugeHistory.cpu, cpuColor);
     }
 
+    const SCROLL_READY_POLL_MS = 50;
+    const SCROLL_READY_MAX_MS = 3000;
+    function _scrollWhenReady(elementId, callback) {
+      var elapsed = 0;
+      function check() {
+        var el = document.getElementById(elementId);
+        if (el && el.offsetHeight > 0) {
+          callback(el);
+          return;
+        }
+        elapsed += SCROLL_READY_POLL_MS;
+        if (elapsed < SCROLL_READY_MAX_MS) {
+          setTimeout(check, SCROLL_READY_POLL_MS);
+        } else if (el) {
+          callback(el);
+        }
+      }
+      requestAnimationFrame(check);
+    }
+
     function render(data) {
       if (!data || data.error || data.status === 'initializing') return;
       if (document.body.style.opacity === '0') document.body.style.opacity = '1';
@@ -6369,22 +6389,15 @@ function burnAreaChart() {
         if (_ocSelectedAgent) {
           const restoreName = _ocSelectedAgent;
           ocRenderAgentDetail(); ocUpdateFocusedState(); ocStartPanePoll();
-          requestAnimationFrame(() => {
-            setTimeout(() => {
-              const detail = document.getElementById('oc-agent-detail');
-              if (detail) {
-                detail.classList.add('active');
-                const y = detail.getBoundingClientRect().top + window.scrollY - OC_TOPBAR_HEIGHT;
-                window.scrollTo({ top: y, behavior: 'instant' });
-              }
-            }, 100);
+          _scrollWhenReady('oc-agent-detail', function(el) {
+            el.classList.add('active');
+            const y = el.getBoundingClientRect().top + window.scrollY - OC_TOPBAR_HEIGHT;
+            window.scrollTo({ top: y, behavior: 'instant' });
           });
         } else {
           const savedSection = _ocSectionFromHash();
           if (savedSection) {
-            requestAnimationFrame(() => {
-              setTimeout(() => { ocNavigate(savedSection); }, 100);
-            });
+            _scrollWhenReady(savedSection, function() { ocNavigate(savedSection); });
           }
         }
       } else if (_ocSelectedAgent) {


### PR DESCRIPTION
Replaces fixed 100ms delay with polling (50ms intervals, 3s max) until the target element has non-zero height. Fixes flaky blank screen on refresh with hash anchors.