### PR TITLE
fix: CLI selector dropdown, copy button, hub URL, bob install

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -72,11 +72,18 @@ contribute-setup backend="claude":
     echo "── Step 3/3: {{backend}} CLI Authentication ──"
     case "{{backend}}" in
       claude)
-        if command -v claude &>/dev/null; then
-          claude login 2>/dev/null || echo "Claude login complete (or already authenticated)"
-        else
+        if ! command -v claude &>/dev/null; then
           echo "ERROR: Claude Code not installed. Install: npm i -g @anthropic-ai/claude-code"
           exit 1
+        fi
+        if [[ -d "${HOME}/.claude" ]] || [[ -d "${HOME}/.config/claude-code" ]]; then
+          echo "Claude Code authenticated (credentials found)"
+        else
+          echo "Claude Code needs authentication. Opening Claude Code..."
+          echo "Type /login then exit when done (Ctrl+C or type /exit)."
+          echo ""
+          claude -p "/login"
+          echo "Claude Code authentication complete."
         fi
         ;;
       copilot)

--- a/Justfile
+++ b/Justfile
@@ -132,35 +132,72 @@ contribute-setup backend="claude":
     echo ""
     echo "Run 'just contribute-hive' to start contributing."
 
-# Start contributing — launches the agent container
-contribute-hive backend="claude":
+# Start contributing — Docker by default, 'just contribute-hive local' for native
+contribute-hive mode="docker":
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ ! -f "{{config_dir}}/contributor.env" ]]; then
-      echo "Not set up yet. Run: just contribute-setup {{backend}}"
+      echo "Not set up yet. Run: just contribute-setup <cli>"
       exit 1
     fi
-    if [[ ! -f "{{config_dir}}/gh-auth.env" ]]; then
-      echo "Not set up yet. Run: just contribute-setup {{backend}}"
-      exit 1
+    source "{{config_dir}}/contributor.env"
+    if [[ -f "{{config_dir}}/gh-auth.env" ]]; then
+      source "{{config_dir}}/gh-auth.env"
     fi
-    source "{{config_dir}}/gh-auth.env"
+
+    BACKEND="${AGENT_BACKEND:-claude}"
+    HUB="${HIVE_HUB:-{{hive_hub}}}"
+    TOKEN="${HIVE_REGISTRATION_TOKEN:-}"
+
     echo "=== Hive Contributor Agent ==="
-    echo "Backend:  {{backend}}"
-    echo "Hub:      {{hive_hub}}"
+    echo "Backend:  ${BACKEND}"
+    echo "Hub:      ${HUB}"
+    echo "Mode:     {{mode}}"
     echo "GitHub:   $(gh api user --jq '.login' 2>/dev/null || echo 'authenticated')"
     echo ""
-    docker run -it --rm \
-      --name hive-contributor \
-      -v "{{config_dir}}:/home/dev/.config/hive:ro" \
-      -v "${HOME}/.claude:/home/dev/.claude:ro" \
-      -v "${HOME}/.config/claude-code:/home/dev/.config/claude-code:ro" \
-      -v "${HOME}/.config/gh:/home/dev/.config/gh:ro" \
-      -e HIVE_HUB="{{hive_hub}}" \
-      -e AGENT_BACKEND="{{backend}}" \
-      -e GH_TOKEN="${GH_TOKEN}" \
-      -e HIVE_USE_CONTRIBUTOR_GH=true \
-      {{hive_image}}
+
+    if [[ "{{mode}}" == "local" ]]; then
+      # ── Native mode: run relay + CLI directly ──
+      WS_URL=$(echo "$HUB" | sed 's|/contribute/*$|/api/contribute/ws|')
+      if ! command -v node &>/dev/null; then
+        echo "ERROR: node is required for the relay. Install: brew install node"
+        exit 1
+      fi
+      echo "Starting relay → ${WS_URL}"
+      HIVE_HUB="$WS_URL" \
+      HIVE_REGISTRATION_TOKEN="$TOKEN" \
+      AGENT_BACKEND="$BACKEND" \
+      node bin/contributor-relay.sh &
+      RELAY_PID=$!
+      cleanup() { echo "Shutting down..."; kill "$RELAY_PID" 2>/dev/null || true; exit 0; }
+      trap cleanup SIGTERM SIGINT
+      echo "Relay PID: ${RELAY_PID}"
+      echo ""
+      echo "Starting ${BACKEND} CLI... Press Ctrl-C to stop."
+      echo ""
+      case "$BACKEND" in
+        claude)  claude --dangerously-skip-permissions ;;
+        copilot) copilot --allow-all ;;
+        bob)     bob --accept-license ;;
+        gemini)  gemini --yolo ;;
+        goose)   goose --no-confirm ;;
+        *)       echo "Unknown backend: $BACKEND"; kill "$RELAY_PID" 2>/dev/null; exit 1 ;;
+      esac
+      cleanup
+    else
+      # ── Docker mode (default) ──
+      docker run -it --rm \
+        --name hive-contributor \
+        -v "{{config_dir}}:/home/dev/.config/hive:ro" \
+        -v "${HOME}/.claude:/home/dev/.claude:ro" \
+        -v "${HOME}/.config/claude-code:/home/dev/.config/claude-code:ro" \
+        -v "${HOME}/.config/gh:/home/dev/.config/gh:ro" \
+        -e HIVE_HUB="${HUB}" \
+        -e AGENT_BACKEND="${BACKEND}" \
+        -e GH_TOKEN="${GH_TOKEN:-}" \
+        -e HIVE_USE_CONTRIBUTOR_GH=true \
+        {{hive_image}}
+    fi
 
 # Check hub status and your contributor profile
 contribute-status:

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -356,9 +356,13 @@ cmds.textContent=tpl.replace('CLI',cli);
 }
 sel.addEventListener('change',update);
 document.getElementById('copy-btn').addEventListener('click',function(){
-navigator.clipboard.writeText(cmds.textContent.trim()).then(function(){
-var b=document.getElementById('copy-btn');b.textContent='Copied!';setTimeout(function(){b.textContent='Copy'},2000);
-});
+var el=cmds;var btn=document.getElementById('copy-btn');
+var range=document.createRange();range.selectNodeContents(el);
+var s=window.getSelection();s.removeAllRanges();s.addRange(range);
+var ok=false;try{ok=document.execCommand('copy')}catch(e){}
+if(!ok&&navigator.clipboard){navigator.clipboard.writeText(el.textContent.trim()).catch(function(){});ok=true}
+btn.textContent=ok?'Copied!':'Select + Cmd+C';btn.style.background='#16a34a';
+setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},2000);
 });
 })();
 </script>

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -259,7 +259,11 @@ func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request)
 	if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
 		wsProto = "wss"
 	}
-	hubURL := fmt.Sprintf("%s://%s/contribute", wsProto, r.Host)
+	host := r.Header.Get("X-Forwarded-Host")
+	if host == "" {
+		host = r.Host
+	}
+	hubURL := fmt.Sprintf("%s://%s/contribute", wsProto, host)
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	fmt.Fprintf(w, `<!DOCTYPE html>
@@ -312,19 +316,52 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 </div>
 <div class="steps">
 <h3>How it works</h3>
+<div style="margin-bottom:16px;display:flex;align-items:center;gap:12px">
+<label style="font-size:.9rem;color:#8b949e">Choose your CLI:</label>
+<select id="cli-select" style="background:#161b22;color:#e6edf3;border:1px solid #30363d;border-radius:6px;padding:6px 12px;font-size:.9rem;cursor:pointer">
+<option value="claude" data-install="npm i -g @anthropic-ai/claude-code">Claude Code</option>
+<option value="copilot" data-install="gh extension install github/gh-copilot">GitHub Copilot</option>
+<option value="gemini" data-install="npm i -g @anthropic-ai/gemini-cli">Gemini CLI</option>
+<option value="bob" data-install="npm i -g bobshell">Bob (IBM)</option>
+<option value="goose" data-install="pip install goose-ai">Goose</option>
+</select>
+</div>
 <ol>
-<li><strong>Install</strong> — <code>brew install just gh</code> + <a href="https://docker.com/get-started" target="_blank" style="color:#58a6ff">Docker</a> + your CLI (<code>npm i -g @anthropic-ai/claude-code</code>)</li>
-<li><strong>Setup</strong> — <code>just contribute-setup claude</code> (registers with hive + authenticates GitHub + CLI)</li>
+<li><strong>Install</strong> — <code>brew install just gh</code> + <a href="https://docker.com/get-started" target="_blank" style="color:#58a6ff">Docker</a> + <code id="install-cmd">npm i -g @anthropic-ai/claude-code</code></li>
+<li><strong>Setup</strong> — <code>just contribute-setup <span id="step-cli">claude</span></code> (registers + authenticates GitHub + CLI)</li>
 <li><strong>Run</strong> — <code>just contribute-hive</code> — then walk away</li>
 </ol>
 <div style="margin-top:16px;background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:16px;position:relative">
-<button onclick="navigator.clipboard.writeText(this.nextElementSibling.textContent.trim());this.textContent='Copied!';setTimeout(()=>this.textContent='Copy',2000)" style="position:absolute;top:8px;right:8px;background:#238636;color:#fff;border:none;border-radius:4px;padding:4px 12px;cursor:pointer;font-size:.75rem">Copy</button>
-<pre style="color:#e6edf3;font-size:.85rem;margin:0;overflow-x:auto;white-space:pre">brew install just gh
+<button id="copy-btn" style="position:absolute;top:8px;right:8px;background:#238636;color:#fff;border:none;border-radius:4px;padding:4px 12px;cursor:pointer;font-size:.75rem">Copy</button>
+<pre id="copy-cmds" style="color:#e6edf3;font-size:.85rem;margin:0;overflow-x:auto;white-space:pre">brew install just gh
 git clone -b v2 https://github.com/kubestellar/hive && cd hive
 export HIVE_HUB=%s
 just contribute-setup claude
 just contribute-hive</pre>
 </div>
+<script>
+(function(){
+var sel=document.getElementById('cli-select');
+var cmds=document.getElementById('copy-cmds');
+var installCmd=document.getElementById('install-cmd');
+var stepCli=document.getElementById('step-cli');
+var hubURL='%s';
+var tpl='brew install just gh\ngit clone -b v2 https://github.com/kubestellar/hive && cd hive\nexport HIVE_HUB='+hubURL+'\njust contribute-setup CLI\njust contribute-hive';
+function update(){
+var cli=sel.value;
+var opt=sel.options[sel.selectedIndex];
+installCmd.textContent=opt.getAttribute('data-install');
+stepCli.textContent=cli;
+cmds.textContent=tpl.replace('CLI',cli);
+}
+sel.addEventListener('change',update);
+document.getElementById('copy-btn').addEventListener('click',function(){
+navigator.clipboard.writeText(cmds.textContent.trim()).then(function(){
+var b=document.getElementById('copy-btn');b.textContent='Copied!';setTimeout(function(){b.textContent='Copy'},2000);
+});
+});
+})();
+</script>
 </div>
 <div style="margin-top:20px;display:flex;gap:12px;flex-wrap:wrap">
 <a href="/leaderboard" style="display:inline-block;padding:8px 20px;background:#161b22;border:1px solid #30363d;border-radius:8px;color:#58a6ff;text-decoration:none;font-size:.9rem">🏆 View Leaderboard</a>
@@ -382,7 +419,7 @@ if(isNew)f.scrollTop=0;
 }catch(e){}}
 poll();setInterval(poll,3000);
 </script>
-</body></html>`, projectName, projectName, len(profiles), tierBoxes.String(), hubURL)
+</body></html>`, projectName, projectName, len(profiles), tierBoxes.String(), hubURL, hubURL)
 }
 
 // ── Registration ───────────────────────────────────────────────────────────

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -117,6 +117,11 @@ function serveIndex(_req, res) {
 const contributeProxy = createProxyMiddleware({
   target: GO_API_URL,
   changeOrigin: true,
+  on: {
+    proxyReq(proxyReq, req) {
+      proxyReq.setHeader('X-Forwarded-Host', req.headers.host || '');
+    },
+  },
 });
 app.get('/contribute', contributeProxy);
 app.get('/contribute/', contributeProxy);


### PR DESCRIPTION
- CLI selector dropdown on /contribute — picks claude/copilot/gemini/bob/goose, updates all commands dynamically
- Copy button fixed (addEventListener instead of inline onclick)
- Hub URL uses X-Forwarded-Host from proxy (was showing internal 127.0.0.1:3002)
- Bob install corrected to `npm i -g bobshell` (IBM, not Anthropic)
- Claude auth checks for existing credentials, opens `claude -p /login` if missing