### PR TITLE
fix: require minimum 5 clarification questions for inception

### DIFF
--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -16,7 +16,7 @@ import (
 const (
 	inceptionWatchIntervalS  = 5 * time.Second
 	inceptionBeadRefPrefix   = "inception/"
-	minQuestionsForAdvance   = 2
+	minQuestionsForAdvance   = 5
 	minFactsForAdvance       = 3
 )
 

--- a/v2/pkg/policies/defaults/brainstorm-advisory.md
+++ b/v2/pkg/policies/defaults/brainstorm-advisory.md
@@ -21,14 +21,16 @@ Your ONLY task this kick is to process the inception idea above. Start immediate
 
 ### If phase is `capture` — generate clarification questions
 
-The user submitted the idea above. Generate 3–5 targeted clarification questions to fill gaps. Use community KB patterns (below) to infer smart defaults.
+The user submitted the idea above. You MUST generate exactly 5–7 targeted clarification questions to fill gaps. Use community KB patterns (below) to infer smart defaults. The inception engine will NOT advance until at least 5 questions are recorded — do not stop early.
 
-Required categories:
+Required categories (create ALL of these):
 1. **Language/runtime** — only if not inferable from the idea
 2. **Primary users** — who will use this and how
 3. **Must-have features** — the 2–3 things it absolutely must do
 4. **Hard constraints** — what it must NOT do, or boundaries
 5. **Success criteria** — how will you know it's working?
+6. **Deployment** — how and where will this run (container, CLI, serverless, etc.)
+7. **Data/storage** — what data does it manage and how is it persisted
 
 Record each question as a bead:
 

--- a/v2/test/inception_e2e_test.go
+++ b/v2/test/inception_e2e_test.go
@@ -196,7 +196,7 @@ func runSinglePass(t *testing.T, client *apiClient, pass int, idea string) PassR
 	// Verify questions
 	result.Check = "questions_populated"
 	questions, _ := state["questions"].([]interface{})
-	const minExpectedQuestions = 1
+	const minExpectedQuestions = 5
 	if len(questions) < minExpectedQuestions {
 		return fail(result, "assertion", fmt.Sprintf("expected >=%d questions, got %d", minExpectedQuestions, len(questions)))
 	}


### PR DESCRIPTION
## Summary
- Watcher threshold: `minQuestionsForAdvance` changed from 2 to 5
- Brainstorm policy now demands 5-7 questions across 7 required categories
  (added deployment and data/storage categories)
- E2E test threshold updated to match (5)
- Policy explicitly tells agent inception will NOT advance until 5 questions recorded

## Test plan
- [ ] Hammer capture→clarify transition to verify 5+ questions consistently
- [x] Watcher threshold enforced in code
- [x] Policy instructs agent to create all 7 categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)