### PR TITLE
fix: prevent render() from overriding hash anchor scroll

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6281,9 +6281,14 @@ function burnAreaChart() {
       if (cpuSpark) cpuSpark.innerHTML = sysGaugeMiniSpark(_sysGaugeHistory.cpu, cpuColor);
     }
 
+    let _hashScrollPending = false;
     function _afterPaint(callback) {
+      _hashScrollPending = true;
       requestAnimationFrame(function() {
-        requestAnimationFrame(callback);
+        requestAnimationFrame(function() {
+          callback();
+          setTimeout(function() { _hashScrollPending = false; }, 500);
+        });
       });
     }
 
@@ -6391,9 +6396,9 @@ function burnAreaChart() {
         }
       } else if (_ocSelectedAgent) {
         ocRenderAgentDetail(); ocUpdateFocusedState(); ocStartPanePoll();
-        window.scrollTo(0, scrollY);
+        if (!_hashScrollPending) window.scrollTo(0, scrollY);
       } else {
-        window.scrollTo(0, scrollY);
+        if (!_hashScrollPending) window.scrollTo(0, scrollY);
       }
     }
 


### PR DESCRIPTION
Root cause found via CDP: render() calls window.scrollTo(0, scrollY) on every SSE update, which reset the viewport after _afterPaint scrolled to the hash target. Now suppresses scroll restoration for 500ms during hash navigation.