### PR TITLE
fix: contribute page Docker/local mode + HTTP copy fallback

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -132,35 +132,75 @@ contribute-setup backend="claude":
     echo ""
     echo "Run 'just contribute-hive' to start contributing."
 
-# Start contributing — launches the agent container
-contribute-hive backend="claude":
+# Start contributing — Docker (default) or local mode
+# Usage: just contribute-hive        (Docker, reads CLI from contributor.env)
+#        just contribute-hive local   (native, starts relay + CLI directly)
+contribute-hive mode="docker":
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ ! -f "{{config_dir}}/contributor.env" ]]; then
-      echo "Not set up yet. Run: just contribute-setup {{backend}}"
+      echo "Not set up yet. Run: just contribute-setup <cli>"
       exit 1
     fi
     if [[ ! -f "{{config_dir}}/gh-auth.env" ]]; then
-      echo "Not set up yet. Run: just contribute-setup {{backend}}"
+      echo "Not set up yet. Run: just contribute-setup <cli>"
       exit 1
     fi
     source "{{config_dir}}/gh-auth.env"
+    source "{{config_dir}}/contributor.env"
+    BACKEND="${AGENT_BACKEND:-claude}"
     echo "=== Hive Contributor Agent ==="
-    echo "Backend:  {{backend}}"
+    echo "Backend:  ${BACKEND}"
     echo "Hub:      {{hive_hub}}"
     echo "GitHub:   $(gh api user --jq '.login' 2>/dev/null || echo 'authenticated')"
     echo ""
-    docker run -it --rm \
-      --name hive-contributor \
-      -v "{{config_dir}}:/home/dev/.config/hive:ro" \
-      -v "${HOME}/.claude:/home/dev/.claude:ro" \
-      -v "${HOME}/.config/claude-code:/home/dev/.config/claude-code:ro" \
-      -v "${HOME}/.config/gh:/home/dev/.config/gh:ro" \
-      -e HIVE_HUB="{{hive_hub}}" \
-      -e AGENT_BACKEND="{{backend}}" \
-      -e GH_TOKEN="${GH_TOKEN}" \
-      -e HIVE_USE_CONTRIBUTOR_GH=true \
-      {{hive_image}}
+
+    if [[ "{{mode}}" == "local" ]]; then
+      # ── Local mode: start node relay in background + launch CLI directly ──
+      echo "Starting local relay..."
+      RELAY_PID=""
+      if [[ -f "v2/proxy/relay.js" ]]; then
+        node v2/proxy/relay.js &
+        RELAY_PID=$!
+        trap "kill ${RELAY_PID} 2>/dev/null || true" EXIT
+        sleep 1
+      fi
+      echo "Launching ${BACKEND} CLI..."
+      case "${BACKEND}" in
+        claude)
+          claude --prompt "You are a Hive contributor agent. Connect to ${HIVE_HUB} and pick up tasks."
+          ;;
+        copilot)
+          gh copilot suggest "Connect to Hive hub at ${HIVE_HUB} and pick up tasks"
+          ;;
+        bob)
+          bob --prompt "You are a Hive contributor agent. Connect to ${HIVE_HUB} and pick up tasks."
+          ;;
+        gemini)
+          gemini --prompt "You are a Hive contributor agent. Connect to ${HIVE_HUB} and pick up tasks."
+          ;;
+        goose)
+          goose session start --prompt "You are a Hive contributor agent. Connect to ${HIVE_HUB} and pick up tasks."
+          ;;
+        *)
+          echo "ERROR: Unknown backend '${BACKEND}'"
+          exit 1
+          ;;
+      esac
+    else
+      # ── Docker mode: read saved AGENT_BACKEND from contributor.env ──
+      docker run -it --rm \
+        --name hive-contributor \
+        -v "{{config_dir}}:/home/dev/.config/hive:ro" \
+        -v "${HOME}/.claude:/home/dev/.claude:ro" \
+        -v "${HOME}/.config/claude-code:/home/dev/.config/claude-code:ro" \
+        -v "${HOME}/.config/gh:/home/dev/.config/gh:ro" \
+        -e HIVE_HUB="{{hive_hub}}" \
+        -e AGENT_BACKEND="${BACKEND}" \
+        -e GH_TOKEN="${GH_TOKEN}" \
+        -e HIVE_USE_CONTRIBUTOR_GH=true \
+        {{hive_image}}
+    fi
 
 # Check hub status and your contributor profile
 contribute-status:

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -356,9 +356,12 @@ cmds.textContent=tpl.replace('CLI',cli);
 }
 sel.addEventListener('change',update);
 document.getElementById('copy-btn').addEventListener('click',function(){
-navigator.clipboard.writeText(cmds.textContent.trim()).then(function(){
-var b=document.getElementById('copy-btn');b.textContent='Copied!';setTimeout(function(){b.textContent='Copy'},2000);
-});
+var text=cmds.textContent.trim();
+var ok=false;
+try{var ta=document.createElement('textarea');ta.value=text;ta.style.position='fixed';ta.style.left='-9999px';document.body.appendChild(ta);ta.select();ok=document.execCommand('copy');document.body.removeChild(ta)}catch(e){}
+if(!ok&&navigator.clipboard){navigator.clipboard.writeText(text).then(function(){done()});return}
+function done(){var b=document.getElementById('copy-btn');b.textContent='Copied!';setTimeout(function(){b.textContent='Copy'},2000)}
+if(ok)done();
 });
 })();
 </script>


### PR DESCRIPTION
## Summary
- **Justfile**: `contribute-hive` now supports Docker (default) and local mode (`just contribute-hive local`)
  - Docker mode reads `AGENT_BACKEND` from `contributor.env` (not hardcoded), passes `GH_TOKEN`, mounts `~/.config/gh`
  - Local mode starts node relay in background + launches CLI directly (claude/copilot/bob/gemini/goose with respective flags)
- **api_contribute.go**: Copy button uses `document.execCommand('copy')` as primary (works on HTTP) with `navigator.clipboard` as fallback
- **proxy/server.js**: Already had `X-Forwarded-Host` header — no change needed

## Test plan
- [ ] `just contribute-hive` runs Docker container with saved backend from contributor.env
- [ ] `just contribute-hive local` starts relay + launches CLI natively
- [ ] Copy button works on HTTP (non-HTTPS) pages via execCommand fallback
- [ ] Copy button still works on HTTPS via navigator.clipboard