### PR TITLE
Fix contribute-hive local mode CLI launch

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -157,31 +157,24 @@ contribute-hive mode="docker":
 
     if [[ "{{mode}}" == "local" ]]; then
       # ── Local mode: start node relay in background + launch CLI directly ──
+      HUB="${HIVE_HUB:-{{hive_hub}}}"
+      WS_URL=$(echo "$HUB" | sed 's|/contribute/*$|/api/contribute/ws|')
       echo "Starting local relay..."
+      echo "WebSocket: ${WS_URL}"
       RELAY_PID=""
       if [[ -f "v2/proxy/relay.js" ]]; then
-        node v2/proxy/relay.js &
+        HIVE_WS_URL="${WS_URL}" node v2/proxy/relay.js &
         RELAY_PID=$!
         trap "kill ${RELAY_PID} 2>/dev/null || true" EXIT
         sleep 1
       fi
-      echo "Launching ${BACKEND} CLI..."
+      echo "Launching ${BACKEND} CLI (interactive)..."
       case "${BACKEND}" in
-        claude)
-          claude --prompt "You are a Hive contributor agent. Connect to ${HIVE_HUB} and pick up tasks."
-          ;;
-        copilot)
-          gh copilot suggest "Connect to Hive hub at ${HIVE_HUB} and pick up tasks"
-          ;;
-        bob)
-          bob --prompt "You are a Hive contributor agent. Connect to ${HIVE_HUB} and pick up tasks."
-          ;;
-        gemini)
-          gemini --prompt "You are a Hive contributor agent. Connect to ${HIVE_HUB} and pick up tasks."
-          ;;
-        goose)
-          goose session start --prompt "You are a Hive contributor agent. Connect to ${HIVE_HUB} and pick up tasks."
-          ;;
+        claude)  claude --dangerously-skip-permissions ;;
+        copilot) copilot ;;
+        bob)     bob --accept-license ;;
+        gemini)  gemini --yolo ;;
+        goose)   goose --no-confirm ;;
         *)
           echo "ERROR: Unknown backend '${BACKEND}'"
           exit 1


### PR DESCRIPTION
## Summary
- Remove broken `--prompt` arguments from all CLI backend launch commands in local mode — each backend now runs with just its permission/auto-accept flag (`--dangerously-skip-permissions`, `--yolo`, `--accept-license`, `--no-confirm`)
- Fix relay WebSocket URL construction to properly transform `/contribute` to `/api/contribute/ws`
- Pass computed WebSocket URL to relay via `HIVE_WS_URL` env var

## Context
The local mode was trying to pass prompt strings to CLI backends (e.g. `claude --prompt "..."`, `gemini --prompt "..."`), which fails because these CLIs don't accept prompt arguments that way. The relay runs in the background and handles WebSocket communication with the hub; the CLI runs interactively in the foreground for the contributor.

## Test plan
- [ ] `just contribute-hive local` with `AGENT_BACKEND=claude` launches Claude Code interactively
- [ ] Relay process starts in background with correct WebSocket URL
- [ ] All 5 backends (claude, copilot, bob, gemini, goose) launch without errors