### PR TITLE
fix: add hashchange listener for anchor navigation

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -9509,6 +9509,11 @@ function burnAreaChart() {
     checkGHAuth();
     setInterval(checkGHAuth, GH_AUTH_CHECK_INTERVAL_MS);
 
+    window.addEventListener('hashchange', function() {
+      var section = _ocSectionFromHash();
+      if (section) ocNavigate(section);
+    });
+
     connect();
     setTimeout(fetchAgentLogs, 2000);
   </script>


### PR DESCRIPTION
Hash-only URL changes didn't scroll because no reload occurs. Adds window hashchange listener that calls ocNavigate for the target section.