### PR TITLE
fix: detect untracked files in snapshot change check

### DIFF
--- a/dashboard/publish-snapshot.sh
+++ b/dashboard/publish-snapshot.sh
@@ -68,11 +68,14 @@ cat > public/live/hive/api-docs/index.html <<REDOC_EOF
 REDOC_EOF
 echo "Redoc API docs written to public/live/hive/api-docs/index.html"
 
-# Check if anything changed
-if git diff --quiet -- public/live/hive/; then
+# Check if anything changed (tracked or untracked)
+git add public/live/hive/
+if git diff --cached --quiet -- public/live/hive/; then
   echo "No changes to snapshot — skipping."
+  git reset HEAD -- public/live/hive/ >/dev/null 2>&1
   exit 0
 fi
+git reset HEAD -- public/live/hive/ >/dev/null 2>&1
 
 TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M UTC')
 SNAPSHOT_BRANCH="chore/hive-snapshot-$(date -u '+%Y%m%d-%H%M%S')"


### PR DESCRIPTION
## Summary
- The v1 `publish-snapshot.sh` used `git diff --quiet` which only detects modified **tracked** files
- New directories (like `api-docs/` from PR #924) are untracked and silently skipped
- Fix: stage first, check `--cached`, unstage — matches the v2 script's existing pattern

This is why `kubestellar.io/live/hive/api-docs` didn't appear after the last snapshot cycle.

## Test plan
- [ ] Next snapshot cycle should include `public/live/hive/api-docs/index.html`