### PR TITLE
fix: add OpenAPI/Redoc routes to v2 proxy and sidebar

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1764,6 +1764,7 @@
       <a class="oc-nav-item" data-section="knowledge-section" onclick="ocNavigate('knowledge-section')"><span class="oc-nav-emoji">📚</span><span class="oc-nav-text">Knowledge</span></a>
       <a class="oc-nav-item" data-section="contributors-section" onclick="ocNavigate('contributors-section')"><span class="oc-nav-emoji">👥</span><span class="oc-nav-text">Contributors</span><span id="contributors-sidebar-badge" style="display:none;margin-left:auto;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:700;background:#238636;color:#fff"></span></a>
       <a class="oc-nav-item" data-section="nous-section" onclick="ocNavigate('nous-section')"><span class="oc-nav-emoji">🧪</span><span class="oc-nav-text">Strategy Lab</span></a>
+      <a class="oc-nav-item" href="/api-docs" target="_blank"><span class="oc-nav-emoji">📘</span><span class="oc-nav-text">API Spec (Redoc)</span></a>
     </div>
     <div class="system-gauges" id="system-gauges">
       <div class="sys-gauge-row" id="sys-gauge-disk" title="Disk usage">

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -84,6 +84,32 @@ const apiProxy = createProxyMiddleware({
     },
   },
 });
+// OpenAPI spec — serve from dashboard dir (bypasses Go API proxy)
+const DASHBOARD_DIR = process.env.HIVE_DASHBOARD_DIR || path.join(__dirname, '..', 'dashboard');
+app.get('/api/openapi.json', (_req, res) => {
+  const specPath = path.join(DASHBOARD_DIR, 'openapi.json');
+  try {
+    res.type('json').send(fs.readFileSync(specPath, 'utf8'));
+  } catch {
+    res.status(404).json({ error: 'OpenAPI spec not found' });
+  }
+});
+
+// Redoc API documentation (read-only)
+app.get('/api-docs', (_req, res) => {
+  res.type('html').send(`<!DOCTYPE html>
+<html><head>
+  <title>Hive API Reference</title>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+  <style>body { margin: 0; padding: 0; }</style>
+</head><body>
+  <redoc spec-url="/api/openapi.json"></redoc>
+  <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
+</body></html>`);
+});
+
 app.use('/api', apiProxy);
 
 const ttydProxy = createProxyMiddleware({


### PR DESCRIPTION
## Summary
PR #924 added OpenAPI/Redoc to the v1 dashboard files, but the v2 Docker deployment uses different files:
- `v2/proxy/server.js` (not `dashboard/server.js`)
- `v2/pkg/dashboard/static/index.html` (not `dashboard/index.html`)

This adds:
- `/api/openapi.json` and `/api-docs` routes to the v2 proxy (before the Go API proxy)
- "API Spec (Redoc)" link to the v2 sidebar Resources section

## Test plan
- [ ] Verify `/api-docs` renders Redoc on the live Bluefin dashboard
- [ ] Verify sidebar shows the new link under Resources