### PR TITLE
fix: allow Redoc CDN and Google Fonts in CSP

### DIFF
--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -39,8 +39,8 @@ function requireAuth(req, res, next) {
 app.use((req, res, next) => {
   res.setHeader('Content-Security-Policy', [
     "default-src 'self'",
-    "script-src 'self' 'unsafe-inline'",
-    "style-src 'self' 'unsafe-inline'",
+    "script-src 'self' 'unsafe-inline' https://cdn.redoc.ly",
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: https:",
     "font-src 'self' https:",
     "connect-src 'self' https: ws: wss:",


### PR DESCRIPTION
## Summary
The Content-Security-Policy in the v2 proxy blocks external scripts and stylesheets. This causes the `/api-docs` Redoc page to render blank (title shows but no content).

Adds `https://cdn.redoc.ly` to `script-src` and `https://fonts.googleapis.com` to `style-src`.

## Test plan
- [ ] Verify `/api-docs` renders the full Redoc UI on the live dashboard