### PR TITLE
fix: allow blob: worker-src in CSP for Redoc

### DIFF
--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -41,6 +41,7 @@ app.use((req, res, next) => {
     "default-src 'self'",
     "script-src 'self' 'unsafe-inline' https://cdn.redoc.ly",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "worker-src blob:",
     "img-src 'self' data: https:",
     "font-src 'self' https:",
     "connect-src 'self' https: ws: wss:",


### PR DESCRIPTION
Redoc uses a Web Worker via blob: URL. CSP blocks it without `worker-src blob:`.