### PR TITLE
fix: Claude idle detection for auto task cycling

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -219,6 +219,7 @@ jobs:
         working-directory: /tmp/contrib-digests
         run: |
           docker buildx imagetools create \
+            -t ghcr.io/kubestellar/hive-contributor:latest \
             -t ghcr.io/kubestellar/hive-contributor:v2-latest \
             -t ghcr.io/kubestellar/hive-contributor:${{ steps.meta.outputs.git_short }} \
             $(printf 'ghcr.io/kubestellar/hive-contributor@sha256:%s ' *)

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -143,7 +143,10 @@ function tmuxSendEnters() {
 
 function tmuxSendKeys(text) {
   try {
-    execSync(`tmux send-keys -t ${TMUX_SESSION} C-u`, { timeout: 5000 });
+    execSync(`tmux send-keys -t ${TMUX_SESSION} Escape`, { timeout: 5000 });
+    sleepMs(200);
+    execSync(`tmux send-keys -t ${TMUX_SESSION} C-a`, { timeout: 5000 });
+    execSync(`tmux send-keys -t ${TMUX_SESSION} C-k`, { timeout: 5000 });
     sleepMs(200);
     execSync(`tmux send-keys -t ${TMUX_SESSION} -l ${shellQuote(text)}`, { timeout: 10000 });
     sleepMs(300);
@@ -173,13 +176,14 @@ function captureTmuxLines(n) {
 function checkTmuxIdle() {
   try {
     const output = execSync(
-      `tmux capture-pane -t ${TMUX_SESSION} -p -S -5 2>/dev/null`,
+      `tmux capture-pane -t ${TMUX_SESSION} -p -S -15 2>/dev/null`,
       { encoding: 'utf8', timeout: 5000 }
     );
-    const lines = output.trim().split('\n');
-    const lastLine = lines[lines.length - 1] || '';
-    const idlePatterns = [/\$\s*$/, />\s*$/, /\?\s*$/, /claude.*>\s*$/i];
-    return idlePatterns.some(p => p.test(lastLine));
+    const text = output.toString();
+    const hasIdlePrompt = /bypass permissions|shift\+tab to cycle/.test(text);
+    const hasCompletionMarker = /Brewed for|Honking|Crunched for|Worked for|tokens\)/.test(text);
+    const isWorking = /─.*Bash\(|Reading|Editing|Writing|Searching/.test(text);
+    return hasIdlePrompt && hasCompletionMarker && !isWorking;
   } catch (_) {
     return false;
   }

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -103,12 +103,17 @@ type ContributeWSHub struct {
 	seq         int
 	activityMu  sync.RWMutex
 	activity    []ActivityEntry
-	server      *Server
+	server         *Server
+	completedTasks map[string]time.Time
+	completedMu    sync.Mutex
 }
+
+const completedTaskCooldownHours = 4
 
 func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 	return &ContributeWSHub{
-		connections: make(map[string]*ContributorConnection),
+		connections:    make(map[string]*ContributorConnection),
+		completedTasks: make(map[string]time.Time),
 		logger:      logger,
 		server:      server,
 	}
@@ -137,6 +142,28 @@ func (h *ContributeWSHub) RecentActivity() []ActivityEntry {
 	out := make([]ActivityEntry, len(h.activity))
 	copy(out, h.activity)
 	return out
+}
+
+func (h *ContributeWSHub) markTaskCompleted(repo string, number int) {
+	key := fmt.Sprintf("%s#%d", repo, number)
+	h.completedMu.Lock()
+	h.completedTasks[key] = time.Now()
+	h.completedMu.Unlock()
+}
+
+func (h *ContributeWSHub) isTaskInCooldown(repo string, number int) bool {
+	key := fmt.Sprintf("%s#%d", repo, number)
+	h.completedMu.Lock()
+	defer h.completedMu.Unlock()
+	t, ok := h.completedTasks[key]
+	if !ok {
+		return false
+	}
+	if time.Since(t) > completedTaskCooldownHours*time.Hour {
+		delete(h.completedTasks, key)
+		return false
+	}
+	return true
 }
 
 func (h *ContributeWSHub) nextSeq() int {
@@ -438,12 +465,16 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			if contributor != nil {
 				contributor.mu.Lock()
 				hasTask := contributor.currentTask != nil && contributor.currentTask.TaskID == msg.TaskID
+				completedTask := contributor.currentTask
 				contributor.currentTask = nil
 				contributor.tmuxOutput = msg.TmuxOutput
 				contributor.mu.Unlock()
 
 				if hasTask {
-				h.addActivity(contributor.profile.GitHubUsername, "completed", contributor.role, contributor.cliBackend, contributor.model, msg.TaskID)
+					if completedTask != nil {
+						h.markTaskCompleted(completedTask.Repo, completedTask.Number)
+					}
+					h.addActivity(contributor.profile.GitHubUsername, "completed", contributor.role, contributor.cliBackend, contributor.model, msg.TaskID)
 					h.logger.Info("[contribute-ws] task complete",
 						"username", contributor.profile.GitHubUsername,
 						"task", msg.TaskID,
@@ -563,6 +594,9 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				number = n
 			}
 			if number == 0 {
+				continue
+			}
+			if h.isTaskInCooldown(repo.Full, number) {
 				continue
 			}
 


### PR DESCRIPTION
## Summary
- Fix `checkTmuxIdle()` to detect Claude Code's actual idle state
  (status bar + completion markers) instead of looking for bare `>` prompt
- When idle detected: sends task_complete → ready → hub assigns next task
- Contributor container auto-cycles through tasks without manual intervention

## Test plan
- [ ] After Claude finishes a task ("Brewed for Xm"), relay detects idle
- [ ] Hub receives task_complete, activity shows "completed"
- [ ] Hub assigns next task, relay injects it into Claude