### PR TITLE
feat: add hub mode — central registry for hive fleet management

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1410,7 +1410,7 @@ func (s *Server) handleAgentConfigCadences(w http.ResponseWriter, r *http.Reques
 		s.deps.Config.Governor.Modes[modeName] = mode
 	}
 
-	if err := s.deps.Config.Save(); err != nil {
+	if err := s.saveConfig(); err != nil {
 		s.logger.Error("failed to persist config after cadence update", "agent", name, "error", err)
 	}
 	s.refreshAndPersist()


### PR DESCRIPTION
Adds HIVE_MODE=hub to run the v2 binary as a central hub instead of a spoke. Hub receives heartbeats from spoke instances, maintains a registry, and serves a dashboard with active hives table, cross-hive leaderboard, and logo ticker. Phase 1 of hive.kubestellar.io.