### PR TITLE
fix: re-kick brainstorm with inception bootstrap after crash (bug #96)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -912,6 +912,24 @@ func main() {
 			return
 		case <-ticker.C:
 			restarted := agentMgr.CheckAndRestartCrashedAgents(ctx)
+			// If brainstorm crashed during inception, re-kick with the inception
+			// bootstrap instead of the standard kick. Without this, the agent
+			// restarts idle and the inception flow stalls.
+			for _, name := range restarted {
+				if name == "brainstorm" && inceptionEngine != nil {
+					if state := inceptionEngine.GetState(); state != nil && state.Phase != knowledge.PhaseComplete {
+						msg := sched.BuildAgentMessage("brainstorm", nil, sched.GetLastActionable())
+						if err := agentMgr.RestartWithBootstrap(ctx, "brainstorm", msg); err != nil {
+							logger.Warn("inception re-kick after crash failed", "error", err)
+						} else {
+							logger.Info("brainstorm re-kicked with inception bootstrap after crash",
+								"phase", state.Phase,
+							)
+							gov.RecordKick("brainstorm")
+						}
+					}
+				}
+			}
 			runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, &userGHClient, restarted, logger)
 			persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
 		case <-agentTickCh:


### PR DESCRIPTION
## Summary
Root cause of ~30% timeout rate in capture→clarify transition:

When brainstorm's CLI crashes during inception (credits exhausted, API error),
`CheckAndRestartCrashedAgents` restarts the tmux session but the eval cycle
filters brainstorm from the kick list (on-demand agent). The agent sits idle
at a bare shell — no inception prompt, no standard kick, the flow stalls.

Fix: after crash restart, check if brainstorm is in the crashed list AND
inception is active (not complete). If so, `RestartWithBootstrap` with the
inception prompt to resume the flow.

## Test plan
- [x] Hammer test: 16/23 (70%) without fix — timeouts from crash-no-rekick
- [ ] Hammer test after deploy: expect >90% pass rate
- [x] Verified via live monitoring: agent output showed repeated restarts
  losing inception context

🤖 Generated with [Claude Code](https://claude.com/claude-code)