### PR TITLE
fix: git credential helper for fork+PR contributor workflow

### DIFF
--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -105,15 +105,32 @@ mkdir -p /var/run/hive-metrics 2>/dev/null || true
 CRED_HELPER="${HOME}/.git-credential-hive"
 cat > "$CRED_HELPER" <<CRED
 #!/bin/sh
-echo "protocol=https"
-echo "host=github.com"
-echo "username=x-access-token"
-echo "password=${GH_TOKEN}"
+# Git credential helper protocol: only respond to "get" requests
+case "\$1" in
+  get)
+    echo "protocol=https"
+    echo "host=github.com"
+    echo "username=x-access-token"
+    echo "password=${GH_TOKEN}"
+    ;;
+esac
 CRED
 chmod +x "$CRED_HELPER"
 git config --global credential.helper "$CRED_HELPER"
 git config --global user.email "${HIVE_CONTRIBUTOR_USERNAME:-contributor}@users.noreply.github.com"
 git config --global user.name "${HIVE_CONTRIBUTOR_USERNAME:-Hive Contributor}"
+
+# Disable Claude auto-updates inside container (no npm write permission)
+if [[ "$AGENT_BACKEND" == "claude" ]] && [[ -f "${HOME}/.claude.json" ]]; then
+  python3 -c "
+import json
+p = '${HOME}/.claude.json'
+with open(p) as f: d = json.load(f)
+d['autoUpdates'] = False
+d['installMethod'] = 'npm'
+with open(p, 'w') as f: json.dump(d, f, indent=2)
+" 2>/dev/null || true
+fi
 
 # Create tmux session for the agent
 tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true

--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -100,6 +100,20 @@ esac
 # Ensure metrics directory exists for gh-wrapper token injection
 mkdir -p /var/run/hive-metrics 2>/dev/null || true
 
+# Configure git credentials so push works (fork + PR model).
+# GH_TOKEN is the contributor's personal token — enough to fork and push.
+cat > /usr/local/bin/git-credential-hive <<CRED
+#!/bin/sh
+echo "protocol=https"
+echo "host=github.com"
+echo "username=x-access-token"
+echo "password=${GH_TOKEN}"
+CRED
+chmod +x /usr/local/bin/git-credential-hive
+git config --global credential.helper hive
+git config --global user.email "${HIVE_CONTRIBUTOR_USERNAME:-contributor}@users.noreply.github.com"
+git config --global user.name "${HIVE_CONTRIBUTOR_USERNAME:-Hive Contributor}"
+
 # Create tmux session for the agent
 tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
 tmux new-session -d -s "$TMUX_SESSION" -x 200 -y 50

--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -102,15 +102,16 @@ mkdir -p /var/run/hive-metrics 2>/dev/null || true
 
 # Configure git credentials so push works (fork + PR model).
 # GH_TOKEN is the contributor's personal token — enough to fork and push.
-cat > /usr/local/bin/git-credential-hive <<CRED
+CRED_HELPER="${HOME}/.git-credential-hive"
+cat > "$CRED_HELPER" <<CRED
 #!/bin/sh
 echo "protocol=https"
 echo "host=github.com"
 echo "username=x-access-token"
 echo "password=${GH_TOKEN}"
 CRED
-chmod +x /usr/local/bin/git-credential-hive
-git config --global credential.helper hive
+chmod +x "$CRED_HELPER"
+git config --global credential.helper "$CRED_HELPER"
 git config --global user.email "${HIVE_CONTRIBUTOR_USERNAME:-contributor}@users.noreply.github.com"
 git config --global user.name "${HIVE_CONTRIBUTOR_USERNAME:-Hive Contributor}"
 

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -232,7 +232,11 @@ function handleMessage(data) {
     case 'auth_ok':
       console.log(`Authenticated as ${msg.contributor_id} (tier: ${msg.trust_tier})`);
       reconnectDelay = BASE_RECONNECT_DELAY_MS;
-      send({ type: 'ready', seq: nextSeq() });
+      if (!currentTask) {
+        send({ type: 'ready', seq: nextSeq() });
+      } else {
+        console.log(`Reconnected while working on ${currentTask.repo}#${currentTask.number} — not requesting new task`);
+      }
       break;
 
     case 'auth_failed':

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -182,8 +182,9 @@ function checkTmuxIdle() {
     const text = output.toString();
     const hasIdlePrompt = /bypass permissions|shift\+tab to cycle/.test(text);
     const hasCompletionMarker = /Brewed for|Honking|Crunched for|Worked for|tokens\)/.test(text);
-    const isWorking = /─.*Bash\(|Reading|Editing|Writing|Searching/.test(text);
-    return hasIdlePrompt && hasCompletionMarker && !isWorking;
+    const isWorking = /─.*Bash\(|Reading|Editing|Writing|Searching|ing…/.test(text);
+    const hasErrors = /Error:|BLOCKED:|fatal:|failed|Interrupted/.test(text);
+    return hasIdlePrompt && hasCompletionMarker && !isWorking && !hasErrors;
   } catch (_) {
     return false;
   }

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -181,7 +181,7 @@ function checkTmuxIdle() {
     );
     const text = output.toString();
     const hasIdlePrompt = /bypass permissions|shift\+tab to cycle/.test(text);
-    const hasCompletionMarker = /Brewed for|Honking|Crunched for|Worked for|tokens\)/.test(text);
+    const hasCompletionMarker = /[A-Z][a-z]+ed for \d+[ms]|Honking|tokens\)/.test(text);
     const isWorking = /─.*Bash\(|Reading|Editing|Writing|Searching|ing…/.test(text);
     const hasErrors = /Error:|BLOCKED:|fatal:|failed|Interrupted/.test(text);
     return hasIdlePrompt && hasCompletionMarker && !isWorking && !hasErrors;

--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -20,11 +20,14 @@ REAL_GH="/usr/bin/gh"
 RESTRICTIONS_DIR="/etc/hive/restrictions"
 
 # Inject GitHub App token for agent gh calls (15k/hr vs PAT's 5k/hr).
+# Contributors keep their personal token — they fork+PR with their own identity.
 GH_APP_TOKEN_CACHE="/var/run/hive-metrics/gh-app-token.cache"
-if [[ -f "$GH_APP_TOKEN_CACHE" ]]; then
-  export GH_TOKEN="$(cat "$GH_APP_TOKEN_CACHE")"
-elif [[ -n "${HIVE_GITHUB_TOKEN:-}" ]]; then
-  export GH_TOKEN="$HIVE_GITHUB_TOKEN"
+if [[ "${HIVE_CONTRIBUTOR_MODE:-}" != "true" ]]; then
+  if [[ -f "$GH_APP_TOKEN_CACHE" ]]; then
+    export GH_TOKEN="$(cat "$GH_APP_TOKEN_CACHE")"
+  elif [[ -n "${HIVE_GITHUB_TOKEN:-}" ]]; then
+    export GH_TOKEN="$HIVE_GITHUB_TOKEN"
+  fi
 fi
 
 # Contributor mode — extra restrictions for remote contributor agents

--- a/v2/Dockerfile.contributor
+++ b/v2/Dockerfile.contributor
@@ -20,6 +20,14 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     > /etc/apt/sources.list.d/github-cli.list \
   && apt-get update && apt-get install -y gh && rm -rf /var/lib/apt/lists/*
 
+# Install Go (needed for building/testing Go projects)
+ARG GO_VERSION=1.24.4
+RUN ARCH=$(dpkg --print-architecture) \
+  && curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" \
+    | tar -C /usr/local -xzf - \
+  && ln -s /usr/local/go/bin/go /usr/local/bin/go \
+  && ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+
 # Install ws for contributor-relay
 RUN mkdir -p /opt/hive/node_modules && cd /opt/hive && npm install ws
 

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -119,9 +119,19 @@ func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
 	}
 }
 
+const activityDebounceSecs = 60
+
 func (h *ContributeWSHub) addActivity(username, action, role, cli, model, task string) {
 	h.activityMu.Lock()
 	defer h.activityMu.Unlock()
+	if len(h.activity) > 0 && (action == "joined" || action == "left") {
+		last := h.activity[len(h.activity)-1]
+		if last.Username == username && last.Action == action {
+			if t, err := time.Parse(time.RFC3339, last.Timestamp); err == nil && time.Since(t) < activityDebounceSecs*time.Second {
+				return
+			}
+		}
+	}
 	h.activity = append(h.activity, ActivityEntry{
 		Timestamp: time.Now().UTC().Format(time.RFC3339),
 		Username:  username,


### PR DESCRIPTION
## Summary
- Add git-credential-hive helper using contributor's personal GH_TOKEN
- Contributors can now fork, push, and open PRs (standard open-source model)
- Error-aware idle detection (won't mark complete if errors visible)

## Test plan
- [ ] `git push` works to contributor's fork
- [ ] `gh repo fork` + `gh pr create` work with personal token
- [ ] Errors (BLOCKED, fatal) prevent false task completion