### PR TITLE
fix: serve index.html at hub root path

### DIFF
--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -77,6 +77,7 @@ func NewHubServer(port int, logger *slog.Logger) *HubServer {
 	s.mux.HandleFunc("GET /api/hub/stats", s.handleStats)
 	s.mux.HandleFunc("GET /learn", s.serveStatic("static/learn.html"))
 	s.mux.HandleFunc("GET /get-started", s.serveStatic("static/get-started.html"))
+	s.mux.HandleFunc("GET /{$}", s.serveStatic("static/index.html"))
 	s.mux.Handle("GET /", http.FileServerFS(staticFS))
 
 	s.registerOAuth()


### PR DESCRIPTION
## Summary
- Root path `/` was showing a directory listing instead of the hub dashboard
- Add explicit `GET /{$}` route to serve `static/index.html` at root

## Test plan
- [ ] Visit `https://hive.kubestellar.io/` — should show the hub dashboard, not a directory listing
- [ ] `/learn`, `/get-started`, `/login` still work
- [ ] `/api/registry`, `/api/heartbeat` endpoints unaffected