### PR TITLE
feat: hub registration config in governor settings

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -842,10 +842,18 @@ func main() {
 		}
 	}
 
-	// Start hub heartbeat push if configured
-	hubURL := os.Getenv("HIVE_HUB_URL")
-	if hubURL != "" {
+	// Start hub heartbeat push if configured (env var or config)
+	hubURL := cfg.Hub.URL
+	if envHub := os.Getenv("HIVE_HUB_URL"); envHub != "" {
+		hubURL = envHub
+		cfg.Hub.Enabled = true
+		cfg.Hub.URL = envHub
+	}
+	if cfg.Hub.Enabled && hubURL != "" {
 		go hub.StartHeartbeat(ctx, hubURL, func() *hub.HeartbeatPayload {
+			if !cfg.Hub.Enabled {
+				return nil
+			}
 			statuses := agentMgr.AllStatuses()
 			govState := gov.GetState()
 			agents := make([]hub.AgentSummary, 0, len(statuses))
@@ -867,7 +875,7 @@ func main() {
 				Contributors: hub.ContributorSummary{},
 				Health:       map[string]any{},
 				DashboardURL: fmt.Sprintf("http://localhost:%d", cfg.Dashboard.Port),
-				IsPublic:     true,
+				IsPublic:     cfg.Hub.IsPublic,
 				Version:      "2.0.0",
 				GitHash:      gitShort,
 			}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Dashboard     DashboardConfig              `yaml:"dashboard"`
 	Data          DataConfig                   `yaml:"data"`
 	Knowledge     KnowledgeConfig              `yaml:"knowledge"`
+	Hub           HubConfig                    `yaml:"hub"`
 	HiveID        string                       `yaml:"hive_id"`
 	ACMMLevel     *int                         `yaml:"acmm_level,omitempty" json:"acmm_level"`
 
@@ -325,6 +326,12 @@ type DiscordConfig struct {
 	ChannelID string `yaml:"channel_id"`
 }
 
+type HubConfig struct {
+	Enabled  bool   `yaml:"enabled"`
+	URL      string `yaml:"url"`
+	IsPublic bool   `yaml:"is_public"`
+}
+
 type DashboardConfig struct {
 	Port               int    `yaml:"port"`
 	SnapshotDir        string `yaml:"snapshot_dir"`
@@ -570,6 +577,10 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Data.AgentsDir == "" {
 		c.Data.AgentsDir = "/data/agent-configs"
+	}
+	if c.Hub.URL == "" {
+		c.Hub.URL = "https://hive.kubestellar.io"
+		c.Hub.IsPublic = true
 	}
 	for name, agent := range c.Agents {
 		agent.name = name

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -79,6 +79,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("POST /api/config/governor/agents", s.handleGovernorAddAgent)
 	s.mux.HandleFunc("DELETE /api/config/governor/agents/{name}", s.handleGovernorRemoveAgent)
 	s.mux.HandleFunc("PUT /api/config/governor/repos", s.handleGovernorRepos)
+	s.mux.HandleFunc("PUT /api/config/governor/hub", s.handleGovernorHub)
 
 	s.mux.HandleFunc("GET /api/agents", s.handleAgentsList)
 	s.mux.HandleFunc("POST /api/agents", s.handleAgentCreate)
@@ -1730,6 +1731,11 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			"compress":   cfg.Governor.Logging.Compress,
 			"level":      cfg.Governor.Logging.Level,
 		},
+		"hub": map[string]interface{}{
+			"enabled":  cfg.Hub.Enabled,
+			"url":      cfg.Hub.URL,
+			"isPublic": cfg.Hub.IsPublic,
+		},
 	})
 }
 
@@ -2035,6 +2041,23 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 	if s.deps.EnumerateFunc != nil {
 		go s.deps.EnumerateFunc()
 	}
+	s.refreshAndPersist()
+	okResponse(w, map[string]string{"status": "updated"})
+}
+
+func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Enabled  bool   `json:"enabled"`
+		URL      string `json:"url"`
+		IsPublic bool   `json:"isPublic"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	s.deps.Config.Hub.Enabled = body.Enabled
+	s.deps.Config.Hub.URL = body.URL
+	s.deps.Config.Hub.IsPublic = body.IsPublic
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})
 }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -7739,7 +7739,7 @@ function burnAreaChart() {
 
     const AGENT_CONFIG_TABS = ['General', 'Cadences', 'Pipeline', 'Hooks', 'Restrictions', 'Stats', 'Prompt Template', 'Last Prompt'];
     const AGENT_CREATE_TABS = ['General', 'Cadences'];
-    const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging'];
+    const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Hub'];
     const PIPELINE_STAGES = ['resolve-beads', 'track-prs', 'stale-check', 'repo-scan', 'coverage-gate', 'prompt-compose', 'budget-check', 'api-collect', 'final-compose'];
     const PIPELINE_STAGE_TIPS = {
       'resolve-beads': 'Fetch and inject knowledge beads (facts, patterns, gotchas) relevant to the agent\'s current task context.',
@@ -8132,8 +8132,42 @@ function burnAreaChart() {
         case 'Health': return renderGovHealth(d.health || {});
         case 'Sensing': return renderGovSensing(d.sensing || {});
         case 'Logging': return renderGovLogging(d.logging || {});
+        case 'Hub': return renderGovHub(d.hub || {});
         default: return '';
       }
+    }
+
+    function renderGovHub(h) {
+      const enabled = h.enabled || false;
+      const url = h.url || 'https://hive.kubestellar.io';
+      const isPublic = h.isPublic !== false;
+      return `
+        <div class="config-field">
+          <label>Register on Hive Hub <span class="config-info">i<span class="config-tooltip">Register this hive instance on the central hub at hive.kubestellar.io. When enabled, the hive pushes status heartbeats to the hub every eval cycle.</span></span></label>
+          <div style="display:flex;align-items:center;gap:10px;margin-top:4px">
+            <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:0.8rem">
+              <input type="checkbox" id="cfg-hub-enabled" ${enabled ? 'checked' : ''} onchange="markDirty('hub','enabled',this.checked)">
+              Enabled
+            </label>
+          </div>
+        </div>
+        <div class="config-field">
+          <label>Hub URL <span class="config-info">i<span class="config-tooltip">The URL of the Hive Hub server to register with. Default: https://hive.kubestellar.io</span></span></label>
+          <input type="text" id="cfg-hub-url" value="${esc(url)}" placeholder="https://hive.kubestellar.io" onchange="markDirty('hub','url',this.value)">
+        </div>
+        <div class="config-field">
+          <label>Visibility <span class="config-info">i<span class="config-tooltip">Public hives appear in the hub's Active Hives table and contribute to the cross-hive leaderboard. Private hives are registered but hidden from the public listing.</span></span></label>
+          <div style="display:flex;align-items:center;gap:10px;margin-top:4px">
+            <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:0.8rem">
+              <input type="checkbox" id="cfg-hub-public" ${isPublic ? 'checked' : ''} onchange="markDirty('hub','isPublic',this.checked)">
+              Public (visible on hub)
+            </label>
+          </div>
+        </div>
+        <div style="font-size:0.7rem;color:var(--muted);margin-top:8px;padding:8px;background:var(--surface);border-radius:6px;border:1px solid var(--border)">
+          When enabled, this hive sends a heartbeat to the hub every eval cycle with: hive ID, ACMM level, agent states, governor mode, and contributor stats.
+          ${enabled ? '<div style="color:var(--green);margin-top:4px">✓ Heartbeat active — pushing to ' + esc(url) + '</div>' : '<div style="color:var(--muted);margin-top:4px">Heartbeat disabled — not registered on any hub</div>'}
+        </div>`;
     }
 
     // ── Agent Tab Renderers ──

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -169,7 +169,13 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 func (s *HubServer) handleRegistry(w http.ResponseWriter, r *http.Request) {
 	s.mu.RLock()
 	s.markStaleHives()
-	data, _ := json.Marshal(s.registry)
+	filtered := Registry{UpdatedAt: s.registry.UpdatedAt}
+	for _, h := range s.registry.Hives {
+		if h.IsPublic {
+			filtered.Hives = append(filtered.Hives, h)
+		}
+	}
+	data, _ := json.Marshal(filtered)
 	s.mu.RUnlock()
 
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary
- Add **Hub** tab to governor config dialog with: enabled checkbox, hub URL field, public/private visibility toggle
- Spokes read hub config from YAML (`hub:` section) and env var (`HIVE_HUB_URL` for backward compat)
- Hub server filters private hives from the public `/api/registry` response
- Default: disabled, URL `https://hive.kubestellar.io`, public visibility

## Test plan
- [ ] Open governor config → Hub tab renders with checkbox, URL, and visibility toggle
- [ ] Enable hub registration → save → heartbeat starts pushing to hub
- [ ] Set visibility to private → hive disappears from hub's Active Hives table
- [ ] `HIVE_HUB_URL` env var still works (backward compat)