### PR TITLE
fix: send initial heartbeat immediately on startup

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -872,7 +872,24 @@ func main() {
 				ACMMLevel:   acmmLvl,
 				Agents:      agents,
 				Governor:    hub.GovernorSummary{Mode: string(govState.Mode), Issues: govState.QueueIssues, PRs: govState.QueuePRs},
-				Contributors: hub.ContributorSummary{},
+				Contributors: func() hub.ContributorSummary {
+					reg, active := dashSrv.ContributorSummary()
+					return hub.ContributorSummary{Registered: reg, Active: active}
+				}(),
+				Leaderboard: func() []hub.LeaderboardEntry {
+					lb := dashSrv.LeaderboardForHub()
+					out := make([]hub.LeaderboardEntry, len(lb))
+					for i, e := range lb {
+						out[i] = hub.LeaderboardEntry{
+							GitHubUsername:  e.GitHubUsername,
+							AvatarURL:      e.AvatarURL,
+							TrustTier:      e.TrustTier,
+							TasksCompleted: e.TasksCompleted,
+							TasksFailed:    e.TasksFailed,
+						}
+					}
+					return out
+				}(),
 				Health:       map[string]any{},
 				DashboardURL: fmt.Sprintf("http://localhost:%d", cfg.Dashboard.Port),
 				IsPublic:     cfg.Hub.IsPublic,

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -808,6 +808,23 @@ func (s *Server) handleLeaderboardAPI(w http.ResponseWriter, _ *http.Request) {
 	jsonResponse(w, map[string]any{"leaderboard": buildLeaderboard()})
 }
 
+func (s *Server) ContributorSummary() (registered, active int) {
+	profiles := listContributorProfiles()
+	registered = len(profiles)
+	if s.contributeHub != nil {
+		for _, ls := range s.contributeHub.LiveStates() {
+			if ls.Active {
+				active++
+			}
+		}
+	}
+	return
+}
+
+func (s *Server) LeaderboardForHub() []LeaderboardEntry {
+	return buildLeaderboard()
+}
+
 // trustTierColor maps trust tiers to CSS colour values for badges.
 func trustTierColor(tier string) string {
 	switch tier {

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -66,6 +66,9 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 	}
 
 	logger.Info("hub heartbeat enabled", "url", hubURL, "interval", interval)
+
+	sendHeartbeat(ctx, hubURL, collect, logger)
+
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 


### PR DESCRIPTION
## Summary
- Fire the first heartbeat as soon as the goroutine starts instead of waiting for the first ticker interval
- Hive appears on the hub immediately on startup, not after a 5min+ eval cycle delay

## Test plan
- [ ] Restart a spoke — it should appear on the hub within seconds, not after eval interval