### PR TITLE
feat: snapshot URL in hub config, fix repo links

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -899,6 +899,7 @@ func main() {
 				}(),
 				Health:       map[string]any{},
 				DashboardURL: fmt.Sprintf("http://localhost:%d", cfg.Dashboard.Port),
+				SnapshotURL:  cfg.Hub.SnapshotURL,
 				IsPublic:     cfg.Hub.IsPublic,
 				Version:      "2.0.0",
 				GitHash:      gitShort,

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -327,9 +327,10 @@ type DiscordConfig struct {
 }
 
 type HubConfig struct {
-	Enabled  bool   `yaml:"enabled"`
-	URL      string `yaml:"url"`
-	IsPublic bool   `yaml:"is_public"`
+	Enabled     bool   `yaml:"enabled"`
+	URL         string `yaml:"url"`
+	IsPublic    bool   `yaml:"is_public"`
+	SnapshotURL string `yaml:"snapshot_url"`
 }
 
 type DashboardConfig struct {

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1732,9 +1732,10 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			"level":      cfg.Governor.Logging.Level,
 		},
 		"hub": map[string]interface{}{
-			"enabled":  cfg.Hub.Enabled,
-			"url":      cfg.Hub.URL,
-			"isPublic": cfg.Hub.IsPublic,
+			"enabled":     cfg.Hub.Enabled,
+			"url":         cfg.Hub.URL,
+			"isPublic":    cfg.Hub.IsPublic,
+			"snapshotUrl": cfg.Hub.SnapshotURL,
 		},
 	})
 }
@@ -2047,9 +2048,10 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		Enabled  bool   `json:"enabled"`
-		URL      string `json:"url"`
-		IsPublic bool   `json:"isPublic"`
+		Enabled     bool   `json:"enabled"`
+		URL         string `json:"url"`
+		IsPublic    bool   `json:"isPublic"`
+		SnapshotURL string `json:"snapshotUrl"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
@@ -2058,6 +2060,7 @@ func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 	s.deps.Config.Hub.Enabled = body.Enabled
 	s.deps.Config.Hub.URL = body.URL
 	s.deps.Config.Hub.IsPublic = body.IsPublic
+	s.deps.Config.Hub.SnapshotURL = body.SnapshotURL
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})
 }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -8141,6 +8141,7 @@ function burnAreaChart() {
       const enabled = h.enabled || false;
       const url = h.url || 'https://hive.kubestellar.io';
       const isPublic = h.isPublic !== false;
+      const snapshotUrl = h.snapshotUrl || '';
       return `
         <div class="config-field">
           <label>Register on Hive Hub <span class="config-info">i<span class="config-tooltip">Register this hive instance on the central hub at hive.kubestellar.io. When enabled, the hive pushes status heartbeats to the hub every eval cycle.</span></span></label>
@@ -8163,6 +8164,10 @@ function burnAreaChart() {
               Public (visible on hub)
             </label>
           </div>
+        </div>
+        <div class="config-field">
+          <label>Public Snapshot URL <span class="config-info">i<span class="config-tooltip">The public URL where this hive's dashboard snapshot is hosted (e.g. https://kubestellar.io/live/hive/bluefin). Shown as the "live" link on the hub. Leave empty if no snapshot is published.</span></span></label>
+          <input type="text" id="cfg-hub-snapshot" value="${esc(snapshotUrl)}" placeholder="https://kubestellar.io/live/hive/..." onchange="markDirty('hub','snapshotUrl',this.value)">
         </div>
         <div style="font-size:0.7rem;color:var(--muted);margin-top:8px;padding:8px;background:var(--surface);border-radius:6px;border:1px solid var(--border)">
           When enabled, this hive sends a heartbeat to the hub every eval cycle with: hive ID, ACMM level, agent states, governor mode, and contributor stats.

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -51,6 +51,7 @@ type HeartbeatPayload struct {
 	Leaderboard  []LeaderboardEntry `json:"leaderboard"`
 	Health       map[string]any     `json:"health"`
 	DashboardURL string             `json:"dashboard_url"`
+	SnapshotURL  string             `json:"snapshot_url"`
 	IsPublic     bool               `json:"is_public"`
 	Version      string             `json:"version"`
 	GitHash      string             `json:"git_hash"`

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -117,6 +117,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		Repos:              payload.Repos,
 		PrimaryRepo:        payload.PrimaryRepo,
 		DashboardURL:       payload.DashboardURL,
+		SnapshotURL:        payload.SnapshotURL,
 		ACMMLevel:          payload.ACMMLevel,
 		AgentCount:         len(payload.Agents),
 		GovernorMode:       payload.Governor.Mode,

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -194,9 +194,9 @@
       if (!pub.length) { document.getElementById('hive-table-container').innerHTML = '<div class="loading">No public hives registered yet</div>'; return; }
       var rows = pub.map(function(h, i) {
         var dot = '<span class="online-dot ' + (h.online ? 'on' : 'off') + '"></span>';
-        var link = h.snapshotUrl ? '<a href="' + esc(h.snapshotUrl) + '" target="_blank" class="repo-link">snapshot</a>' : '';
-        var dash = h.dashboardUrl ? ' <a href="' + esc(h.dashboardUrl) + '" target="_blank" class="repo-link">live</a>' : '';
-        var repoLink = h.primaryRepo ? '<a href="https://github.com/' + esc(h.primaryRepo) + '" target="_blank" class="repo-link">' + esc(h.primaryRepo) + '</a>' : '';
+        var link = h.snapshotUrl ? '<a href="' + esc(h.snapshotUrl) + '" target="_blank" class="repo-link">live</a>' : '';
+        var repoPath = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : h.primaryRepo || '';
+        var repoLink = repoPath ? '<a href="https://github.com/' + esc(repoPath) + '" target="_blank" class="repo-link">' + esc(h.primaryRepo) + '</a>' : '';
         return '<tr>' +
           '<td>' + (i + 1) + '</td>' +
           '<td>' + dot + '<span class="hive-name">' + esc(h.name || h.id) + '</span><br><span class="hive-org">' + esc(h.org) + '</span></td>' +
@@ -207,7 +207,7 @@
           '<td>' + (h.actionableIssues || 0) + '</td>' +
           '<td>' + (h.actionablePRs || 0) + '</td>' +
           '<td>' + (h.contributorCount || 0) + '</td>' +
-          '<td>' + link + dash + '</td>' +
+          '<td>' + link + '</td>' +
           '</tr>';
       }).join('');
       document.getElementById('hive-table-container').innerHTML =


### PR DESCRIPTION
## Summary
- Add **Public Snapshot URL** field to the Hub tab in governor config
- Hub dashboard only shows "live" link when a snapshot URL is configured
- Fix repo links to use `org/repo` path (was just `repo`, producing broken GitHub URLs)
- Remove broken "live" link that pointed to `localhost` dashboard URL

## Test plan
- [ ] Governor config → Hub tab shows new Snapshot URL field
- [ ] Hub dashboard: repo column links to correct GitHub URL (`github.com/org/repo`)
- [ ] Hub dashboard: LINKS column shows "live" only for hives with snapshotUrl
- [ ] Hub dashboard: hives without snapshotUrl show empty LINKS column