### PR TITLE
feat: show hive name and current task in hub leaderboard

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -893,6 +893,8 @@ func main() {
 							TrustTier:      e.TrustTier,
 							TasksCompleted: e.TasksCompleted,
 							TasksFailed:    e.TasksFailed,
+							Active:         e.Active,
+							CurrentTask:    e.CurrentTask,
 						}
 					}
 					return out

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -773,6 +773,8 @@ type LeaderboardEntry struct {
 	TasksCompleted int    `json:"tasks_completed"`
 	TasksFailed    int    `json:"tasks_failed"`
 	RegisteredAt   string `json:"registered_at"`
+	Active         bool   `json:"active,omitempty"`
+	CurrentTask    string `json:"current_task,omitempty"`
 }
 
 // buildLeaderboard loads all contributor profiles, sorts by tasks completed
@@ -822,7 +824,26 @@ func (s *Server) ContributorSummary() (registered, active int) {
 }
 
 func (s *Server) LeaderboardForHub() []LeaderboardEntry {
-	return buildLeaderboard()
+	entries := buildLeaderboard()
+	if s.contributeHub != nil {
+		liveStates := s.contributeHub.LiveStates()
+		profiles := listContributorProfiles()
+		liveByUsername := make(map[string]ContributorLiveState)
+		for _, p := range profiles {
+			if ls, ok := liveStates[p.ContributorID]; ok {
+				liveByUsername[p.GitHubUsername] = ls
+			}
+		}
+		for i := range entries {
+			if ls, ok := liveByUsername[entries[i].GitHubUsername]; ok {
+				entries[i].Active = ls.Active
+				if ls.CurrentTask != nil {
+					entries[i].CurrentTask = ls.CurrentTask.Title
+				}
+			}
+		}
+	}
+	return entries
 }
 
 // trustTierColor maps trust tiers to CSS colour values for badges.

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -36,6 +36,9 @@ type LeaderboardEntry struct {
 	TrustTier      string `json:"trust_tier"`
 	TasksCompleted int    `json:"tasks_completed"`
 	TasksFailed    int    `json:"tasks_failed"`
+	Active         bool   `json:"active"`
+	CurrentTask    string `json:"current_task,omitempty"`
+	HiveName       string `json:"hive_name,omitempty"`
 }
 
 type HeartbeatPayload struct {

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -132,8 +132,14 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		Version:            payload.Version,
 		GitHash:            payload.GitHash,
 		Agents:             payload.Agents,
-		Leaderboard:        payload.Leaderboard,
-		Online:             true,
+		Leaderboard: func() []LeaderboardEntry {
+			hiveName := payload.Org + "/" + payload.PrimaryRepo
+			for i := range payload.Leaderboard {
+				payload.Leaderboard[i].HiveName = hiveName
+			}
+			return payload.Leaderboard
+		}(),
+		Online: true,
 	}
 
 	s.mu.Lock()

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -221,17 +221,21 @@
       entries.sort(function(a, b) { return (b.tasks_completed || 0) - (a.tasks_completed || 0); });
       var rows = entries.map(function(e, i) {
         var avatar = e.avatar_url ? '<img src="' + esc(e.avatar_url) + '" width="24" height="24" style="border-radius:50%;vertical-align:middle;margin-right:6px">' : '';
+        var activeDot = e.active ? '<span class="online-dot on" style="margin-right:4px"></span>' : '';
+        var taskText = e.current_task ? '<span style="color:var(--green);font-size:0.75rem">' + esc(e.current_task) + '</span>' : '<span style="color:var(--muted);font-size:0.75rem">—</span>';
         return '<tr>' +
           '<td>' + (i + 1) + '</td>' +
-          '<td>' + avatar + '<a href="https://github.com/' + esc(e.github_username) + '" target="_blank">' + esc(e.github_username) + '</a></td>' +
+          '<td>' + activeDot + avatar + '<a href="https://github.com/' + esc(e.github_username) + '" target="_blank">' + esc(e.github_username) + '</a></td>' +
+          '<td style="font-size:0.8rem;color:var(--muted)">' + esc(e.hive_name || '') + '</td>' +
           '<td>' + (e.tasks_completed || 0) + '</td>' +
           '<td>' + (e.tasks_failed || 0) + '</td>' +
           '<td><span class="acmm-badge acmm-2">' + esc(e.trust_tier || 'newcomer') + '</span></td>' +
+          '<td>' + taskText + '</td>' +
           '</tr>';
       }).join('');
       document.getElementById('leaderboard-container').innerHTML =
         '<table class="hive-table"><thead><tr>' +
-        '<th>#</th><th>Contributor</th><th>Completed</th><th>Failed</th><th>Tier</th>' +
+        '<th>#</th><th>Contributor</th><th>Hive</th><th>Completed</th><th>Failed</th><th>Tier</th><th>Current Task</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table>';
     }
 


### PR DESCRIPTION
## Summary
- Add **Hive** column showing which hive each contributor belongs to
- Add **Current Task** column showing the task title for active contributors
- Active contributors get a green dot next to their avatar
- Hub server tags leaderboard entries with the hive name from heartbeat data

## Test plan
- [ ] Hub leaderboard shows Hive column with `org/repo` name
- [ ] Active contributors show green dot and current task title
- [ ] Inactive contributors show `—` in current task column