### PR TITLE
feat: multi-backend contributor support (copilot, gemini, goose)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -196,12 +196,28 @@ contribute-hive mode="docker":
         docker pull {{hive_image}} 2>/dev/null || echo "Pull failed — using local image"
         echo ""
       fi
+      # Mount CLI-specific config directories
+      CLI_MOUNTS=""
+      case "${BACKEND}" in
+        claude)
+          CLI_MOUNTS="-v ${HOME}/.claude:/home/dev/.claude -v ${HOME}/.config/claude-code:/home/dev/.config/claude-code"
+          ;;
+        copilot)
+          [ -d "${HOME}/.copilot" ] && CLI_MOUNTS="-v ${HOME}/.copilot:/home/dev/.copilot"
+          ;;
+        gemini)
+          [ -d "${HOME}/.gemini" ] && CLI_MOUNTS="-v ${HOME}/.gemini:/home/dev/.gemini"
+          [ -d "${HOME}/.config/gemini" ] && CLI_MOUNTS="${CLI_MOUNTS} -v ${HOME}/.config/gemini:/home/dev/.config/gemini"
+          ;;
+        goose)
+          [ -d "${HOME}/.config/goose" ] && CLI_MOUNTS="-v ${HOME}/.config/goose:/home/dev/.config/goose"
+          ;;
+      esac
       docker run -it --rm \
         --name hive-contributor \
         --network host \
         -v "{{config_dir}}:/home/dev/.config/hive:ro" \
-        -v "${HOME}/.claude:/home/dev/.claude" \
-        -v "${HOME}/.config/claude-code:/home/dev/.config/claude-code" \
+        ${CLI_MOUNTS} \
         -v "${HOME}/.config/gh:/home/dev/.config/gh:ro" \
         -e HIVE_HUB="{{hive_hub}}" \
         -e AGENT_BACKEND="${BACKEND}" \
@@ -209,6 +225,8 @@ contribute-hive mode="docker":
         -e HIVE_USE_CONTRIBUTOR_GH=true \
         -e HIVE_CONTAINER_NAME=hive-contributor \
         ${ANTHROPIC_API_KEY:+-e ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}"} \
+        ${GOOGLE_API_KEY:+-e GOOGLE_API_KEY="${GOOGLE_API_KEY}"} \
+        ${GOOSE_API_KEY:+-e GOOSE_API_KEY="${GOOSE_API_KEY}"} \
         {{hive_image}}
     fi
 

--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -157,8 +157,24 @@ KNOWLEDGE_REFRESH_SECS=600
   done
 ) &
 
-# Make agent.md visible as CLAUDE.md in the working directory
-ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
+# Make agent.md visible to each CLI backend
+case "$AGENT_BACKEND" in
+  claude)
+    ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
+    ;;
+  copilot)
+    mkdir -p "${HOME}/.copilot"
+    ln -sf "$AGENT_MD" "${HOME}/COPILOT.md"
+    ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
+    ;;
+  gemini)
+    ln -sf "$AGENT_MD" "${HOME}/GEMINI.md"
+    ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
+    ;;
+  *)
+    ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
+    ;;
+esac
 
 # Create tmux session for the agent
 tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -290,7 +290,7 @@ function handleMessage(data) {
       } else {
         console.log(`Reconnected while working on ${currentTask.repo}#${currentTask.number} — resuming`);
         send({ type: 'task_accepted', seq: nextSeq(), task_id: currentTask.task_id });
-        send({ type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, status: 'working' });
+        send({ type: 'task_progress', seq: nextSeq(), task_id: currentTask.task_id, kind: currentTask.kind, repo: currentTask.repo, number: currentTask.number, title: currentTask.title, status: 'working' });
         startProgressReporting();
       }
       break;

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -74,9 +74,19 @@ function getCLIState() {
       { encoding: 'utf8', timeout: 5000 }
     );
     const text = output.toString();
-    if (/Not logged in|Please run \/login/.test(text)) return 'needs-login';
-    if (/bypass permissions|Welcome back|Try "how does|medium.*effort|@gmail\.com|@.*\.com.*Organization/.test(text)) return 'ready';
-    if (/Choose the text style|trust this folder/.test(text)) return 'onboarding';
+    if (BACKEND === 'claude') {
+      if (/Not logged in|Please run \/login/.test(text)) return 'needs-login';
+      if (/bypass permissions|Welcome back|Try "how does|medium.*effort|@gmail\.com|@.*\.com.*Organization/.test(text)) return 'ready';
+      if (/Choose the text style|trust this folder/.test(text)) return 'onboarding';
+    } else if (BACKEND === 'copilot') {
+      if (/copilot login|gh auth login/.test(text)) return 'needs-login';
+      if (/autopilot|allow-all|>\s*$|❯/.test(text)) return 'ready';
+    } else if (BACKEND === 'gemini') {
+      if (/not authenticated|login required/i.test(text)) return 'needs-login';
+      if (/>\s*$|❯/.test(text)) return 'ready';
+    } else {
+      if (/>\s*$|❯|\$\s*$/.test(text)) return 'ready';
+    }
     return 'starting';
   } catch (_) {
     return 'starting';
@@ -208,9 +218,25 @@ function checkTmuxIdle() {
       { encoding: 'utf8', timeout: 5000 }
     );
     const text = output.toString();
-    const hasIdlePrompt = /bypass permissions|shift\+tab to cycle/.test(text);
-    const hasCompletionMarker = /[✻✶✽] \S+ed for \d+[ms]|Honking|tokens\)/.test(text);
-    const isWorking = /─.*Bash\(|Reading|Editing|Writing|Searching|ing…/.test(text);
+    let hasIdlePrompt, hasCompletionMarker, isWorking;
+
+    if (BACKEND === 'claude') {
+      hasIdlePrompt = /bypass permissions|shift\+tab to cycle/.test(text);
+      hasCompletionMarker = /[✻✶✽] \S+ed for \d+[ms]|Honking|tokens\)/.test(text);
+      isWorking = /─.*Bash\(|Reading|Editing|Writing|Searching|ing…/.test(text);
+    } else if (BACKEND === 'copilot') {
+      hasIdlePrompt = />\s*$|❯\s*$|autopilot/.test(text);
+      hasCompletionMarker = /completed|Done!|finished|Total tokens/i.test(text);
+      isWorking = /Running|Executing|Thinking|searching/i.test(text);
+    } else if (BACKEND === 'gemini') {
+      hasIdlePrompt = />\s*$|❯\s*$/.test(text);
+      hasCompletionMarker = /completed|Done|finished/i.test(text);
+      isWorking = /Thinking|Running|Searching/i.test(text);
+    } else {
+      hasIdlePrompt = />\s*$|\$\s*$/.test(text);
+      hasCompletionMarker = /completed|done|finished/i.test(text);
+      isWorking = false;
+    }
     return hasIdlePrompt && hasCompletionMarker && !isWorking;
   } catch (_) {
     return false;

--- a/v2/Dockerfile.contributor
+++ b/v2/Dockerfile.contributor
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
     > /etc/apt/sources.list.d/nodesource.list \
   && apt-get update && apt-get install -y nodejs \
-  && npm install -g @anthropic-ai/claude-code \
+  && npm install -g @anthropic-ai/claude-code @google/gemini-cli \
   && rm -rf /var/lib/apt/lists/*
 
 # Install gh CLI
@@ -19,6 +19,9 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
   && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
     > /etc/apt/sources.list.d/github-cli.list \
   && apt-get update && apt-get install -y gh && rm -rf /var/lib/apt/lists/*
+
+# Install Copilot CLI (via gh extension)
+RUN gh extension install github/gh-copilot 2>/dev/null || true
 
 # Install Go (needed for building/testing Go projects)
 ARG GO_VERSION=1.24.4

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -469,7 +469,13 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				contributor.mu.Lock()
 				contributor.tmuxOutput = msg.TmuxOutput
 				if contributor.currentTask == nil && msg.TaskID != "" {
-					contributor.currentTask = &WSTaskAssign{TaskID: msg.TaskID}
+					contributor.currentTask = &WSTaskAssign{
+						TaskID: msg.TaskID,
+						Kind:   msg.Kind,
+						Repo:   msg.Repo,
+						Number: msg.Number,
+						Title:  msg.Title,
+					}
 				}
 				contributor.mu.Unlock()
 			}


### PR DESCRIPTION
## Summary
Adds support for multiple CLI backends in the contributor container:

- **Copilot CLI**: installed via `gh extension install github/gh-copilot`, uses `--allow-all`
- **Gemini CLI**: installed via `npm install -g @google/gemini-cli`
- **Goose/Bob**: stubs in backends.conf, will be added later

Changes:
- Dockerfile installs all three CLIs
- Relay: backend-aware idle detection and CLI ready state
- Agent: backend-specific config mounts and knowledge symlinks
- Justfile: per-backend volume mounts and API key pass-through

Usage: `just contribute-setup copilot && just contribute-hive`

## Test plan
- [ ] `just contribute-setup claude && just contribute-hive` — existing flow works
- [ ] `just contribute-setup copilot && just contribute-hive` — copilot starts and receives tasks
- [ ] `just contribute-setup gemini && just contribute-hive` — gemini starts and receives tasks