### PR TITLE
fix: add logout and login/logout nav toggle

### DIFF
--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -25,6 +25,7 @@ func (s *HubServer) registerOAuth() {
 	s.mux.HandleFunc("GET /login", s.handleLogin)
 	s.mux.HandleFunc("GET /api/auth/callback", s.handleOAuthCallback)
 	s.mux.HandleFunc("GET /api/auth/user", s.handleAuthUser)
+	s.mux.HandleFunc("POST /api/auth/logout", s.handleLogout)
 	s.logger.Info("hub OAuth enabled", "client_id", clientID)
 }
 
@@ -125,4 +126,17 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 	})
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(data)
+}
+
+func (s *HubServer) handleLogout(w http.ResponseWriter, r *http.Request) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     "hive_hub_user",
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+	http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -193,6 +193,7 @@ const dashboardHTML = `<!DOCTYPE html>
         <a href="/learn">Learn</a>
         <a href="/get-started">Get Started</a>
         <div class="nav-user" id="nav-user"></div>
+        <a href="#" style="color:var(--muted);font-size:0.8rem;padding:4px 12px;border:1px solid var(--border);border-radius:6px" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.href='/'});return false;">Logout</a>
       </div>
     </div>
   </nav>

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -102,8 +102,9 @@
         <a href="#leaderboard">Leaderboard</a>
         <a href="/learn">Learn</a>
         <a href="/get-started">Get Started</a>
-        <a href="/dashboard" class="nav-login" id="nav-dashboard" style="display:none">My Hives</a>
+        <a href="/dashboard" id="nav-dashboard" style="display:none">My Hives</a>
         <a href="/login" class="nav-login" id="nav-login">Login</a>
+        <a href="#" class="nav-login" id="nav-logout" style="display:none" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.reload()});return false;">Logout</a>
       </div>
     </div>
   </nav>
@@ -260,6 +261,7 @@
     fetch('/api/auth/user').then(function(r){return r.json()}).then(function(d){
       if(d.authenticated){
         document.getElementById('nav-login').style.display='none';
+        document.getElementById('nav-logout').style.display='';
         var el=document.getElementById('nav-dashboard');
         el.style.display='';
         el.innerHTML='<img src="'+esc(d.avatar_url)+'" style="width:22px;height:22px;border-radius:50%;vertical-align:middle;margin-right:4px">My Hives';


### PR DESCRIPTION
## Summary
- Add `POST /api/auth/logout` endpoint that clears the session cookie
- Main page: show avatar + "My Hives" link when logged in, replace Login with Logout
- Dashboard page: add Logout link in nav bar

## Test plan
- [ ] Logged out: see "Login" button, no "My Hives" or "Logout"
- [ ] Click Login → GitHub OAuth → redirected to dashboard
- [ ] Main page now shows avatar + "My Hives" and "Logout" (no "Login")
- [ ] Click Logout → cookie cleared → back to logged-out state