### PR TITLE
fix: stop old hive.service before starting per-agent units

### DIFF
--- a/bin/hive-deploy.sh
+++ b/bin/hive-deploy.sh
@@ -222,9 +222,14 @@ fi
 # Migrate from monolithic hive.service to per-agent hive@<name>.service.
 # The old hive.service only watchdogged the supervisor; per-agent units
 # give each agent its own watchdog with Restart=always.
-# Don't stop the old service mid-run (its tmux sessions are independent),
-# just disable it so it won't start on next boot.
-if systemctl is-enabled --quiet hive.service 2>/dev/null; then
+# Migrate from monolithic hive.service to per-agent hive@<name>.service.
+# The old service holds an flock that blocks new per-agent supervisors, so
+# we must stop it (tmux sessions are independent and survive the stop).
+if systemctl is-active --quiet hive.service 2>/dev/null; then
+  sudo systemctl stop hive.service 2>/dev/null || true
+  sudo systemctl disable hive.service 2>/dev/null || true
+  SYNCED="$SYNCED hive.service(stopped+disabled)"
+elif systemctl is-enabled --quiet hive.service 2>/dev/null; then
   sudo systemctl disable hive.service 2>/dev/null || true
   SYNCED="$SYNCED hive.service(disabled)"
 fi


### PR DESCRIPTION
## Summary
- The migration from monolithic `hive.service` to per-agent `hive@<name>.service` only **disabled** the old service but didn't **stop** it
- The running supervisor held an `flock` that blocked new per-agent supervisors from starting, causing a restart loop (33,870 restarts over ~3 hours)
- Fix: stop the old service first so the flock is released and per-agent supervisors can adopt existing tmux sessions cleanly

## Root cause
An agent re-cloned `/tmp/hive` at ~22:48 UTC, which unblocked the deploy script (previously failing on `git pull`). The deploy ran the migration logic for the first time, but couldn't complete it because the old service still held the lock.

## Test plan
- [x] Manually verified the fix on 192.168.4.56 — stopped old service, started hive@supervisor, confirmed it adopted existing tmux sessions
- [ ] Next deploy cycle on 4.56 should be a no-op (old service already stopped)