### PR TITLE
fix: restore hub CI build, fix contributor count, add repos column

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -223,3 +223,107 @@ jobs:
             -t ghcr.io/kubestellar/hive-contributor:v2-latest \
             -t ghcr.io/kubestellar/hive-contributor:${{ steps.meta.outputs.git_short }} \
             $(printf 'ghcr.io/kubestellar/hive-contributor@sha256:%s ' *)
+
+  build-hub:
+    strategy:
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Platform slug
+        id: slug
+        run: echo "slug=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
+        env:
+          PLATFORM: ${{ matrix.platform }}
+
+      - name: Build and push hub image by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: v2/Dockerfile.hub
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            GIT_HASH=${{ github.sha }}
+          outputs: type=image,name=ghcr.io/kubestellar/hive-hub,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=hub-${{ steps.slug.outputs.slug }}
+          cache-to: type=gha,scope=hub-${{ steps.slug.outputs.slug }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/hub-digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/hub-digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: hub-digests-${{ steps.slug.outputs.slug }}
+          path: /tmp/hub-digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-hub:
+    runs-on: ubuntu-latest
+    needs: build-hub
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/hub-digests
+          pattern: hub-digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify build commit is still HEAD of v2
+        id: head-check
+        run: |
+          CURRENT_HEAD=$(git ls-remote https://github.com/${{ github.repository }} v2 | awk '{print $1}')
+          if [ "${{ github.sha }}" != "$CURRENT_HEAD" ]; then
+            echo "Build is stale (built ${{ github.sha }} but v2 HEAD is $CURRENT_HEAD) — skipping tag"
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract git metadata
+        if: steps.head-check.outputs.stale != 'true'
+        id: meta
+        run: |
+          echo "git_short=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Create hub manifest list and push
+        if: steps.head-check.outputs.stale != 'true'
+        working-directory: /tmp/hub-digests
+        run: |
+          docker buildx imagetools create \
+            -t ghcr.io/kubestellar/hive-hub:latest \
+            -t ghcr.io/kubestellar/hive-hub:v2-latest \
+            -t ghcr.io/kubestellar/hive-hub:${{ steps.meta.outputs.git_short }} \
+            $(printf 'ghcr.io/kubestellar/hive-hub@sha256:%s ' *)

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -214,7 +214,7 @@ func (s *HubServer) handleStats(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		totalAgents += h.AgentCount
-		totalContributors += h.ContributorCount
+		totalContributors += h.ActiveContributors
 		totalIssues += h.ActionableIssues
 		totalPRs += h.ActionablePRs
 		if h.Online {

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -184,7 +184,7 @@
 
     function renderStats(hives) {
       var agents = 0, contributors = 0, online = 0;
-      hives.forEach(function(h) { agents += h.agentCount || 0; contributors += h.contributorCount || 0; if (h.online) online++; });
+      hives.forEach(function(h) { agents += h.agentCount || 0; contributors += h.activeContributors || 0; if (h.online) online++; });
       document.getElementById('hero-stats').innerHTML =
         '<span>' + online + '/' + hives.length + ' hives online</span>' +
         '<span class="dot"></span><span>' + agents + ' agents running</span>' +
@@ -199,22 +199,24 @@
         var link = h.snapshotUrl ? '<a href="' + esc(h.snapshotUrl) + '" target="_blank" class="repo-link">live</a>' : '';
         var repoPath = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : h.primaryRepo || '';
         var repoLink = repoPath ? '<a href="https://github.com/' + esc(repoPath) + '" target="_blank" class="repo-link">' + esc(h.primaryRepo) + '</a>' : '';
+        var repoCount = (h.repos || []).length;
         return '<tr>' +
           '<td>' + (i + 1) + '</td>' +
           '<td>' + dot + '<span class="hive-name">' + esc(h.name || h.id) + '</span><br><span class="hive-org">' + esc(h.org) + '</span></td>' +
           '<td>' + repoLink + '</td>' +
+          '<td>' + repoCount + '</td>' +
           '<td>' + acmmBadge(h.acmmLevel) + '</td>' +
           '<td>' + (h.agentCount || 0) + '</td>' +
           '<td>' + modeBadge(h.governorMode) + '</td>' +
           '<td>' + (h.actionableIssues || 0) + '</td>' +
           '<td>' + (h.actionablePRs || 0) + '</td>' +
-          '<td>' + (h.contributorCount || 0) + '</td>' +
+          '<td>' + (h.activeContributors || 0) + '</td>' +
           '<td>' + link + '</td>' +
           '</tr>';
       }).join('');
       document.getElementById('hive-table-container').innerHTML =
         '<table class="hive-table"><thead><tr>' +
-        '<th>#</th><th>Hive</th><th>Repo</th><th>ACMM</th><th>Agents</th><th>Mode</th><th>Issues</th><th>PRs</th><th>Contributors</th><th>Links</th>' +
+        '<th>#</th><th>Hive</th><th>Repo</th><th>Repos</th><th>ACMM</th><th>Agents</th><th>Mode</th><th>Issues</th><th>PRs</th><th>Contributors</th><th>Links</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table>';
     }
 


### PR DESCRIPTION
## Summary
- **Restore hub image CI build** — `build-hub` and `merge-hub` jobs were accidentally removed from `docker.yml`, so `ghcr.io/kubestellar/hive-hub:latest` was never getting updated. This is why all recent hub changes weren't deploying.
- **Fix contributor count** — was showing "registered" (3) instead of "active" (1). Stats bar and hive table now use `activeContributors`.
- **Add Repos column** — shows number of managed repositories per hive in the Active Hives table.

## Test plan
- [ ] After merge, CI builds and pushes `ghcr.io/kubestellar/hive-hub:latest`
- [ ] Hub restart picks up new image with all recent changes (dashboard, login/logout, get-started updates)
- [ ] Contributors column shows active count, not registered
- [ ] Repos column shows repo count per hive