### PR TITLE
fix: consistent nav bar + ACMM pill tooltips

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -189,11 +189,11 @@ const dashboardHTML = `<!DOCTYPE html>
       <a href="/" class="nav-brand"><span>🐝</span> Hive Hub</a>
       <div class="nav-links">
         <a href="/">Hives</a>
-        <a href="/dashboard" style="color:var(--accent)">My Hives</a>
         <a href="/learn">Learn</a>
         <a href="/get-started">Get Started</a>
-        <div class="nav-user" id="nav-user"></div>
-        <a href="#" style="color:var(--muted);font-size:0.8rem;padding:4px 12px;border:1px solid var(--border);border-radius:6px" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.href='/'});return false;">Logout</a>
+        <a href="/dashboard" style="color:var(--accent)">My Hives</a>
+        <span id="nav-user"></span>
+        <a href="#" class="nav-login" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.href='/'});return false;">Logout</a>
       </div>
     </div>
   </nav>

--- a/v2/pkg/hub/static/get-started.html
+++ b/v2/pkg/hub/static/get-started.html
@@ -10,9 +10,11 @@
     .nav { position: fixed; top: 0; width: 100%; z-index: 50; background: rgba(10,10,15,0.85); backdrop-filter: blur(12px); border-bottom: 1px solid #1e1e2e; }
     .nav-inner { max-width: 900px; margin: 0 auto; padding: 12px 24px; display: flex; align-items: center; justify-content: space-between; }
     .nav-brand { display: flex; align-items: center; gap: 8px; font-weight: 700; font-size: 1.1rem; color: #e6edf3; text-decoration: none; }
-    .nav-links { display: flex; gap: 20px; font-size: 0.85rem; }
+    .nav-links { display: flex; align-items: center; gap: 20px; font-size: 0.85rem; }
     .nav-links a { color: #8b949e; text-decoration: none; }
     .nav-links a:hover { color: #e6edf3; }
+    .nav-login { padding: 6px 14px; background: #12121a; border: 1px solid #1e1e2e; border-radius: 8px; color: #8b949e; font-size: 0.8rem; }
+    .nav-login:hover { border-color: #f59e0b; color: #e6edf3; }
     .content { max-width: 900px; margin: 0 auto; padding: 80px 24px 48px; }
     h1 { font-size: 2.5rem; font-weight: 800; margin-bottom: 24px; background: linear-gradient(135deg, #f59e0b, #fbbf24); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
     h2 { font-size: 1.4rem; font-weight: 700; margin: 32px 0 12px; color: #e6edf3; }
@@ -39,6 +41,10 @@
         <a href="/">Hives</a>
         <a href="/learn">Learn</a>
         <a href="/get-started">Get Started</a>
+        <a href="/dashboard" id="nav-dashboard" style="display:none">My Hives</a>
+        <span id="nav-user" style="display:none"></span>
+        <a href="/login" class="nav-login" id="nav-login">Login</a>
+        <a href="#" class="nav-login" id="nav-logout" style="display:none" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.href='/'});return false;">Logout</a>
       </div>
     </div>
   </nav>
@@ -112,5 +118,17 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID
 # Your CLI runs agents locally, tasks are assigned by the hive</code></pre>
     <p>Contributors earn trust tiers (newcomer → contributor → trusted → advisor) based on completed tasks. See the <a href="/#leaderboard">leaderboard</a>.</p>
   </div>
+  <script>
+    function esc(s){var d=document.createElement('div');d.textContent=s;return d.innerHTML;}
+    fetch('/api/auth/user').then(function(r){return r.json()}).then(function(d){
+      if(d.authenticated){
+        document.getElementById('nav-login').style.display='none';
+        document.getElementById('nav-logout').style.display='';
+        document.getElementById('nav-dashboard').style.display='';
+        var u=document.getElementById('nav-user');u.style.display='';
+        u.innerHTML='<img src="'+esc(d.avatar_url)+'" style="width:24px;height:24px;border-radius:50%;vertical-align:middle"> <span style="font-size:0.85rem">'+esc(d.login)+'</span>';
+      }
+    }).catch(function(){});
+  </script>
 </body>
 </html>

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -50,7 +50,7 @@
     .hive-table tr:hover td { background: rgba(245,158,11,0.04); }
     .hive-name { font-weight: 600; color: var(--text); }
     .hive-org { color: var(--muted); font-size: 0.75rem; }
-    .acmm-badge { display: inline-block; padding: 2px 10px; border-radius: 9999px; font-size: 0.7rem; font-weight: 700; }
+    .acmm-badge { display: inline-block; padding: 2px 10px; border-radius: 9999px; font-size: 0.7rem; font-weight: 700; white-space: nowrap; cursor: help; }
     .acmm-1 { background: rgba(59,130,246,0.15); color: #60a5fa; border: 1px solid rgba(59,130,246,0.3); }
     .acmm-2 { background: rgba(6,182,212,0.15); color: #22d3ee; border: 1px solid rgba(6,182,212,0.3); }
     .acmm-3 { background: rgba(16,185,129,0.15); color: #34d399; border: 1px solid rgba(16,185,129,0.3); }
@@ -96,13 +96,13 @@
 <body>
   <nav class="nav">
     <div class="nav-inner">
-      <div class="nav-brand"><span>🐝</span> Hive Hub</div>
+      <a href="/" class="nav-brand"><span>🐝</span> Hive Hub</a>
       <div class="nav-links">
-        <a href="#hives">Hives</a>
-        <a href="#leaderboard">Leaderboard</a>
+        <a href="/">Hives</a>
         <a href="/learn">Learn</a>
         <a href="/get-started">Get Started</a>
         <a href="/dashboard" id="nav-dashboard" style="display:none">My Hives</a>
+        <span id="nav-user" style="display:none"></span>
         <a href="/login" class="nav-login" id="nav-login">Login</a>
         <a href="#" class="nav-login" id="nav-logout" style="display:none" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.reload()});return false;">Logout</a>
       </div>
@@ -145,8 +145,16 @@
     function esc(s) { var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
 
     function acmmBadge(level) {
-      var names = {1:'Idea',2:'Measured',3:'CI/CD',4:'Autonomous PR',5:'Self-Governing',6:'Fully Autonomous'};
-      return '<span class="acmm-badge acmm-' + level + '">L' + level + ' ' + esc(names[level] || '') + '</span>';
+      var names = {1:'Idea',2:'Measured',3:'CI/CD',4:'Auto PR',5:'Self-Governing',6:'Fully Autonomous'};
+      var tips = {
+        1:'L1 Idea — Advisory only. Agents suggest but take no action.',
+        2:'L2 Measured — Agents can open issues to track findings.',
+        3:'L3 CI/CD — Agents open hold-gated PRs. CI must pass before merge.',
+        4:'L4 Auto PR — Agents open and merge PRs on green CI.',
+        5:'L5 Self-Governing — Full autonomy with budget controls.',
+        6:'L6 Fully Autonomous — Multi-loop orchestration, self-healing.'
+      };
+      return '<span class="acmm-badge acmm-' + level + '" title="' + esc(tips[level] || '') + '">L' + level + ' ' + esc(names[level] || '') + '</span>';
     }
 
     function modeBadge(mode) {
@@ -264,9 +272,10 @@
       if(d.authenticated){
         document.getElementById('nav-login').style.display='none';
         document.getElementById('nav-logout').style.display='';
-        var el=document.getElementById('nav-dashboard');
-        el.style.display='';
-        el.innerHTML='<img src="'+esc(d.avatar_url)+'" style="width:22px;height:22px;border-radius:50%;vertical-align:middle;margin-right:4px">My Hives';
+        document.getElementById('nav-dashboard').style.display='';
+        var u=document.getElementById('nav-user');
+        u.style.display='';
+        u.innerHTML='<img src="'+esc(d.avatar_url)+'" style="width:24px;height:24px;border-radius:50%;vertical-align:middle">'+' <span style="font-size:0.85rem">'+esc(d.login)+'</span>';
       }
     }).catch(function(){});
   </script>

--- a/v2/pkg/hub/static/learn.html
+++ b/v2/pkg/hub/static/learn.html
@@ -10,9 +10,11 @@
     .nav { position: fixed; top: 0; width: 100%; z-index: 50; background: rgba(10,10,15,0.85); backdrop-filter: blur(12px); border-bottom: 1px solid #1e1e2e; }
     .nav-inner { max-width: 900px; margin: 0 auto; padding: 12px 24px; display: flex; align-items: center; justify-content: space-between; }
     .nav-brand { display: flex; align-items: center; gap: 8px; font-weight: 700; font-size: 1.1rem; color: #e6edf3; text-decoration: none; }
-    .nav-links { display: flex; gap: 20px; font-size: 0.85rem; }
+    .nav-links { display: flex; align-items: center; gap: 20px; font-size: 0.85rem; }
     .nav-links a { color: #8b949e; text-decoration: none; }
     .nav-links a:hover { color: #e6edf3; }
+    .nav-login { padding: 6px 14px; background: #12121a; border: 1px solid #1e1e2e; border-radius: 8px; color: #8b949e; font-size: 0.8rem; }
+    .nav-login:hover { border-color: #f59e0b; color: #e6edf3; }
     .content { max-width: 900px; margin: 0 auto; padding: 80px 24px 48px; }
     h1 { font-size: 2.5rem; font-weight: 800; margin-bottom: 24px; background: linear-gradient(135deg, #f59e0b, #fbbf24); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
     h2 { font-size: 1.4rem; font-weight: 700; margin: 32px 0 12px; color: #e6edf3; }
@@ -35,6 +37,10 @@
         <a href="/">Hives</a>
         <a href="/learn">Learn</a>
         <a href="/get-started">Get Started</a>
+        <a href="/dashboard" id="nav-dashboard" style="display:none">My Hives</a>
+        <span id="nav-user" style="display:none"></span>
+        <a href="/login" class="nav-login" id="nav-login">Login</a>
+        <a href="#" class="nav-login" id="nav-logout" style="display:none" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.href='/'});return false;">Logout</a>
       </div>
     </div>
   </nav>
@@ -85,5 +91,17 @@
       <li><a href="https://kubestellar.io/en/acmm-leaderboard" target="_blank">ACMM Leaderboard</a></li>
     </ul>
   </div>
+  <script>
+    function esc(s){var d=document.createElement('div');d.textContent=s;return d.innerHTML;}
+    fetch('/api/auth/user').then(function(r){return r.json()}).then(function(d){
+      if(d.authenticated){
+        document.getElementById('nav-login').style.display='none';
+        document.getElementById('nav-logout').style.display='';
+        document.getElementById('nav-dashboard').style.display='';
+        var u=document.getElementById('nav-user');u.style.display='';
+        u.innerHTML='<img src="'+esc(d.avatar_url)+'" style="width:24px;height:24px;border-radius:50%;vertical-align:middle"> <span style="font-size:0.85rem">'+esc(d.login)+'</span>';
+      }
+    }).catch(function(){});
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- **Consistent nav bar** across all 4 hub pages (index, dashboard, learn, get-started)
  - All pages show: 🐝 Hive Hub | Hives | Learn | Get Started | My Hives | avatar username | Logout
  - Login/Logout toggle works on learn and get-started pages (was missing)
- **ACMM pill improvements**
  - `white-space: nowrap` prevents pill text from wrapping
  - Hover tooltip explains what each ACMM level means
  - Shortened "Autonomous PR" to "Auto PR" for better fit

## Test plan
- [ ] All 4 pages show identical nav bar when logged in
- [ ] All 4 pages show Login button when logged out
- [ ] ACMM pills don't wrap text
- [ ] Hovering ACMM pill shows educational tooltip