### PR TITLE
feat: hosted/local type badge in Active Hives table

### DIFF
--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 )
@@ -44,6 +45,7 @@ type RegistryEntry struct {
 	ContributorCount   int            `json:"contributorCount"`
 	ActiveContributors int            `json:"activeContributors"`
 	Owner              string         `json:"owner,omitempty"`
+	HiveType           string         `json:"hiveType,omitempty"`
 	IsPublic           bool           `json:"isPublic"`
 	RegisteredAt       string         `json:"registeredAt"`
 	LastHeartbeat      string         `json:"lastHeartbeat"`
@@ -129,7 +131,13 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		ContributorCount:   payload.Contributors.Registered,
 		ActiveContributors: payload.Contributors.Active,
 		Owner:              payload.Owner,
-		IsPublic:           payload.IsPublic,
+		HiveType: func() string {
+			if strings.HasPrefix(payload.HiveID, "saas-") {
+				return "hosted"
+			}
+			return "local"
+		}(),
+		IsPublic: payload.IsPublic,
 		LastHeartbeat:      time.Now().UTC().Format(time.RFC3339),
 		Health:             payload.Health,
 		Version:            payload.Version,

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -208,9 +208,13 @@
         var repoPath = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : h.primaryRepo || '';
         var repoLink = repoPath ? '<a href="https://github.com/' + esc(repoPath) + '" target="_blank" class="repo-link">' + esc(h.primaryRepo) + '</a>' : '';
         var repoCount = (h.repos || []).length;
+        var htype = (h.hiveType || 'local') === 'hosted'
+          ? '<span style="display:inline-block;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:rgba(59,130,246,0.15);color:#60a5fa;border:1px solid rgba(59,130,246,0.3)" title="Hosted on hive.kubestellar.io SaaS">hosted</span>'
+          : '<span style="display:inline-block;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:rgba(107,114,128,0.15);color:#9ca3af;border:1px solid rgba(107,114,128,0.3)" title="Self-hosted by the owner">local</span>';
         return '<tr>' +
           '<td>' + (i + 1) + '</td>' +
           '<td>' + dot + '<span class="hive-name">' + esc(h.name || h.id) + '</span><br><span class="hive-org">' + esc(h.org) + '</span></td>' +
+          '<td>' + htype + '</td>' +
           '<td>' + repoLink + '</td>' +
           '<td>' + repoCount + '</td>' +
           '<td>' + acmmBadge(h.acmmLevel) + '</td>' +
@@ -224,7 +228,7 @@
       }).join('');
       document.getElementById('hive-table-container').innerHTML =
         '<table class="hive-table"><thead><tr>' +
-        '<th>#</th><th>Hive</th><th>Repo</th><th>Repos</th><th>ACMM</th><th>Agents</th><th>Mode</th><th>Issues</th><th>PRs</th><th>Contributors</th><th>Links</th>' +
+        '<th>#</th><th>Hive</th><th>Type</th><th>Repo</th><th>Repos</th><th>ACMM</th><th>Agents</th><th>Mode</th><th>Issues</th><th>PRs</th><th>Contributors</th><th>Links</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table>';
     }
 


### PR DESCRIPTION
## Summary
- Add **Type** column to Active Hives table showing `local` (gray) or `hosted` (blue) badge
- SaaS-provisioned hives (ID starts with `saas-`) automatically tagged as "hosted"
- All heartbeat-registered hives default to "local"
- Hover tooltip explains: "Self-hosted by the owner" vs "Hosted on hive.kubestellar.io SaaS"

## Test plan
- [ ] All current hives show gray "local" badge
- [ ] Future SaaS hives with `saas-` prefix will show blue "hosted" badge