### PR TITLE
feat: SaaS hive provisioning with create modal and kubectl apply

### DIFF
--- a/v2/Dockerfile.hub
+++ b/v2/Dockerfile.hub
@@ -9,7 +9,10 @@ RUN GIT_HASH=$(git -C /repo rev-parse HEAD 2>/dev/null || echo "unknown") && \
     CGO_ENABLED=0 go build -ldflags "-X main.gitHash=${GIT_HASH} -X main.gitShort=${GIT_SHORT}" -o /hive ./cmd/hive
 
 FROM alpine:3.21
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates curl && \
+    ARCH=$(uname -m | sed 's/aarch64/arm64/' | sed 's/x86_64/amd64/') && \
+    curl -sLo /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl" && \
+    chmod +x /usr/local/bin/kubectl
 COPY --from=builder /hive /usr/local/bin/hive
 RUN chmod +x /usr/local/bin/hive
 RUN mkdir -p /data /etc/hive

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -21,6 +21,11 @@ type SaaSUser struct {
 func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("GET /dashboard", s.handleDashboard)
 	s.mux.HandleFunc("GET /api/saas/my-hives", s.requireAuth(s.handleMyHives))
+	s.mux.HandleFunc("POST /api/saas/hives", s.requireAuth(s.handleCreateHive))
+	s.mux.HandleFunc("GET /api/saas/hives/{id}/status", s.requireAuth(s.handleHiveStatus))
+	s.mux.HandleFunc("GET /api/saas/auth-check", s.handleSaaSAuthCheck)
+
+	go StartProvisionWatcher(s.logger, &s.mu)
 }
 
 func (s *HubServer) requireAuth(next http.HandlerFunc) http.HandlerFunc {
@@ -121,6 +126,128 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]any{"hives": result})
 }
 
+func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
+	username := s.getAuthUser(r)
+	if username == "" {
+		http.Error(w, `{"error":"not authenticated"}`, http.StatusUnauthorized)
+		return
+	}
+
+	var req CreateHiveRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
+		return
+	}
+
+	if req.Org == "" || req.Repos == "" || req.GitHubToken == "" {
+		http.Error(w, `{"error":"org, repos, and github_token are required"}`, http.StatusBadRequest)
+		return
+	}
+
+	if countUserHives(username) >= maxHivesPerUser {
+		http.Error(w, fmt.Sprintf(`{"error":"max %d hives per user"}`, maxHivesPerUser), http.StatusBadRequest)
+		return
+	}
+
+	if len(listSaaSHives()) >= maxSaaSHivesTotal {
+		http.Error(w, `{"error":"SaaS capacity reached — try again later"}`, http.StatusServiceUnavailable)
+		return
+	}
+
+	repos := strings.Split(req.Repos, ",")
+	for i := range repos {
+		repos[i] = strings.TrimSpace(repos[i])
+	}
+	primaryRepo := req.PrimaryRepo
+	if primaryRepo == "" && len(repos) > 0 {
+		primaryRepo = repos[0]
+	}
+	acmm := req.ACMMLevel
+	if acmm < 1 || acmm > 6 {
+		acmm = 1
+	}
+
+	hiveID := generateHiveID(req.Org, primaryRepo)
+	h := &SaaSHive{
+		ID:          hiveID,
+		Owner:       username,
+		ProjectName: req.ProjectName,
+		Org:         req.Org,
+		Repos:       repos,
+		PrimaryRepo: primaryRepo,
+		ACMMLevel:   acmm,
+		Status:      "provisioning",
+		CreatedAt:   time.Now().UTC().Format(time.RFC3339),
+		Subdomain:   hiveID + ".hive.kubestellar.io",
+	}
+
+	if err := saveSaaSHive(h); err != nil {
+		http.Error(w, `{"error":"failed to save hive metadata"}`, http.StatusInternalServerError)
+		return
+	}
+
+	user := ensureSaaSUser(username)
+	user.Hives[hiveID] = "owner"
+	saveSaaSUser(user)
+
+	go func() {
+		if err := provisionHive(h, req.GitHubToken, s.logger); err != nil {
+			h.Status = "error"
+			h.Error = err.Error()
+			saveSaaSHive(h)
+			s.logger.Warn("saas hive provision failed", "hive_id", hiveID, "error", err)
+			return
+		}
+		h.Status = "provisioning"
+		saveSaaSHive(h)
+	}()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"id":        hiveID,
+		"status":    "provisioning",
+		"subdomain": h.Subdomain,
+	})
+}
+
+func (s *HubServer) handleHiveStatus(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	h := loadSaaSHive(id)
+	if h == nil {
+		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(h)
+}
+
+func (s *HubServer) handleSaaSAuthCheck(w http.ResponseWriter, r *http.Request) {
+	hiveID := r.URL.Query().Get("hive")
+	if hiveID == "" {
+		http.Error(w, "missing hive param", http.StatusBadRequest)
+		return
+	}
+
+	username := s.getAuthUser(r)
+	if username == "" {
+		http.Error(w, "not authenticated", http.StatusUnauthorized)
+		return
+	}
+
+	user := loadSaaSUser(username)
+	if user == nil {
+		http.Error(w, "no access", http.StatusForbidden)
+		return
+	}
+
+	if _, ok := user.Hives[hiveID]; !ok {
+		http.Error(w, "no access to this hive", http.StatusForbidden)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
 func (s *HubServer) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	cookie, err := r.Cookie("hive_hub_user")
 	if err != nil || cookie.Value == "" {
@@ -146,10 +273,12 @@ const dashboardHTML = `<!DOCTYPE html>
     .nav { position: fixed; top: 0; width: 100%; z-index: 50; background: rgba(10,10,15,0.85); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); }
     .nav-inner { max-width: 1200px; margin: 0 auto; padding: 12px 24px; display: flex; align-items: center; justify-content: space-between; }
     .nav-brand { display: flex; align-items: center; gap: 8px; font-weight: 700; font-size: 1.1rem; color: var(--text); text-decoration: none; }
-    .nav-links { display: flex; align-items: center; gap: 20px; font-size: 0.85rem; }
-    .nav-links a { color: var(--muted); }
+    .nav-links { display: flex; align-items: center; gap: 20px; font-size: 0.85rem; flex-wrap: nowrap; }
+    .nav-links a { color: var(--muted); white-space: nowrap; }
     .nav-links a:hover { color: var(--text); text-decoration: none; }
-    .nav-user { display: flex; align-items: center; gap: 8px; }
+    .nav-login { padding: 6px 14px; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; color: var(--muted); font-size: 0.8rem; }
+    .nav-login:hover { border-color: var(--accent); color: var(--text); }
+    .nav-user { display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
     .nav-avatar { width: 28px; height: 28px; border-radius: 50%; }
     .content { max-width: 1200px; margin: 0 auto; padding: 80px 24px 48px; }
     h1 { font-size: 2rem; font-weight: 800; margin-bottom: 8px; background: linear-gradient(135deg, #f59e0b, #fbbf24); -webkit-background-clip: text; -webkit-text-fill-color: transparent; }
@@ -192,7 +321,8 @@ const dashboardHTML = `<!DOCTYPE html>
         <a href="/learn">Learn</a>
         <a href="/get-started">Get Started</a>
         <a href="/dashboard" style="color:var(--accent)">My Hives</a>
-        <span id="nav-user"></span>
+        <a href="https://github.com/kubestellar/hive" target="_blank" title="Source Code" style="font-size:1.1rem">🐙</a>
+        <span id="nav-user" class="nav-user"></span>
         <a href="#" class="nav-login" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.href='/'});return false;">Logout</a>
       </div>
     </div>
@@ -204,7 +334,7 @@ const dashboardHTML = `<!DOCTYPE html>
         <h1>My Hives</h1>
         <p class="subtitle">Hive instances you own or have access to</p>
       </div>
-      <button class="btn-primary" id="btn-add-hive" disabled title="Coming soon">+ Add SaaS Hive</button>
+      <button class="btn-primary" id="btn-add-hive" onclick="document.getElementById('create-modal').style.display='flex'">+ Add SaaS Hive</button>
     </div>
 
     <div id="hives-container"><div class="loading">Loading your hives...</div></div>
@@ -289,6 +419,7 @@ const dashboardHTML = `<!DOCTYPE html>
           '<td>' + modeBadge(h.governorMode) + '</td>' +
           '<td>' + (h.actionableIssues || 0) + '</td>' +
           '<td>' + (h.actionablePRs || 0) + '</td>' +
+          '<td>' + (h.activeContributors || 0) + '</td>' +
           '<td>' + roleBadge(h.role) + '</td>' +
           '<td>' + dashboardLink(h) + '</td>' +
           '<td>' + snapshotLink(h) + '</td>' +
@@ -296,13 +427,92 @@ const dashboardHTML = `<!DOCTYPE html>
       }).join('');
       document.getElementById('hives-container').innerHTML =
         '<table class="hive-table"><thead><tr>' +
-        '<th>#</th><th>Hive</th><th>Repo</th><th>Repos</th><th>ACMM</th><th>Agents</th><th>Mode</th><th>Issues</th><th>PRs</th><th>Role</th><th>Dashboard</th><th>Snapshot</th>' +
+        '<th>#</th><th>Hive</th><th>Repo</th><th>Repos</th><th>ACMM</th><th>Agents</th><th>Mode</th><th>Issues</th><th>PRs</th><th>Contributors</th><th>Role</th><th>Dashboard</th><th>Snapshot</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table>';
     }
 
     loadUser();
     loadHives();
     setInterval(loadHives, 60000);
+
+    async function createHive() {
+      var org = document.getElementById('f-org').value.trim();
+      var repos = document.getElementById('f-repos').value.trim();
+      var primary = document.getElementById('f-primary').value.trim();
+      var name = document.getElementById('f-name').value.trim();
+      var level = parseInt(document.getElementById('f-level').value) || 1;
+      var token = document.getElementById('f-token').value.trim();
+
+      if (!org || !repos || !token) { alert('Org, repos, and GitHub token are required'); return; }
+
+      document.getElementById('btn-go').disabled = true;
+      document.getElementById('btn-go').textContent = 'Provisioning...';
+
+      try {
+        var resp = await fetch('/api/saas/hives', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({org: org, repos: repos, primary_repo: primary || repos.split(',')[0].trim(), project_name: name, acmm_level: level, github_token: token})
+        });
+        var data = await resp.json();
+        if (!resp.ok) { alert(data.error || 'Failed to create hive'); return; }
+
+        document.getElementById('create-modal').style.display = 'none';
+        document.getElementById('btn-go').disabled = false;
+        document.getElementById('btn-go').textContent = 'Go';
+
+        alert('Hive ' + data.id + ' is provisioning! It will appear in your dashboard shortly.');
+        loadHives();
+      } catch(e) {
+        alert('Error: ' + e.message);
+      } finally {
+        document.getElementById('btn-go').disabled = false;
+        document.getElementById('btn-go').textContent = 'Go';
+      }
+    }
   </script>
+
+  <div id="create-modal" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:100;align-items:center;justify-content:center">
+    <div style="background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:32px;max-width:500px;width:90%">
+      <h2 style="font-size:1.3rem;margin-bottom:16px;color:var(--accent)">Create SaaS Hive</h2>
+      <div style="margin-bottom:12px">
+        <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">GitHub Organization *</label>
+        <input id="f-org" type="text" placeholder="my-org" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
+      </div>
+      <div style="margin-bottom:12px">
+        <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">Repositories * <span style="font-size:0.7rem">(comma-separated)</span></label>
+        <input id="f-repos" type="text" placeholder="repo1, repo2" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
+      </div>
+      <div style="margin-bottom:12px">
+        <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">Primary Repository</label>
+        <input id="f-primary" type="text" placeholder="defaults to first repo" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
+      </div>
+      <div style="margin-bottom:12px">
+        <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">Project Name</label>
+        <input id="f-name" type="text" placeholder="defaults to org/repo" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
+      </div>
+      <div style="display:flex;gap:12px;margin-bottom:12px">
+        <div style="flex:1">
+          <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">ACMM Level</label>
+          <select id="f-level" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
+            <option value="1">L1 — Idea</option>
+            <option value="2">L2 — Measured</option>
+            <option value="3" selected>L3 — CI/CD</option>
+            <option value="4">L4 — Auto PR</option>
+            <option value="5">L5 — Self-Governing</option>
+            <option value="6">L6 — Fully Autonomous</option>
+          </select>
+        </div>
+      </div>
+      <div style="margin-bottom:20px">
+        <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">GitHub Token * <span style="font-size:0.7rem">(ghp_... or github_pat_...)</span></label>
+        <input id="f-token" type="password" placeholder="ghp_xxxxxxxxxxxx" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
+      </div>
+      <div style="display:flex;gap:12px;justify-content:flex-end">
+        <button onclick="document.getElementById('create-modal').style.display='none'" style="padding:8px 20px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--muted);cursor:pointer">Cancel</button>
+        <button id="btn-go" onclick="createHive()" class="btn-primary">Go</button>
+      </div>
+    </div>
+  </div>
 </body>
 </html>`

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1,0 +1,380 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math/rand"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"text/template"
+	"time"
+)
+
+const (
+	saasHivesDir          = "/data/saas/hives"
+	maxHivesPerUser       = 3
+	maxSaaSHivesTotal     = 5
+	provisionPollInterval = 30 * time.Second
+	provisionTimeout      = 5 * time.Minute
+	cpuRequest            = "200m"
+	cpuLimit              = "500m"
+	memRequest            = "256Mi"
+	memLimit              = "512Mi"
+	pvcSize               = "1Gi"
+)
+
+type SaaSHive struct {
+	ID          string `json:"id"`
+	Owner       string `json:"owner"`
+	ProjectName string `json:"project_name"`
+	Org         string `json:"org"`
+	Repos       []string `json:"repos"`
+	PrimaryRepo string `json:"primary_repo"`
+	ACMMLevel   int    `json:"acmm_level"`
+	Status      string `json:"status"`
+	CreatedAt   string `json:"created_at"`
+	Subdomain   string `json:"subdomain"`
+	Error       string `json:"error,omitempty"`
+}
+
+type CreateHiveRequest struct {
+	Org         string `json:"org"`
+	Repos       string `json:"repos"`
+	PrimaryRepo string `json:"primary_repo"`
+	ProjectName string `json:"project_name"`
+	ACMMLevel   int    `json:"acmm_level"`
+	GitHubToken string `json:"github_token"`
+}
+
+func generateHiveID(org, repo string) string {
+	short := repo
+	if len(short) > 12 {
+		short = short[:12]
+	}
+	chars := "abcdefghijklmnopqrstuvwxyz0123456789"
+	suffix := make([]byte, 4)
+	for i := range suffix {
+		suffix[i] = chars[rand.Intn(len(chars))]
+	}
+	return fmt.Sprintf("saas-%s-%s-%s", sanitize(org), sanitize(short), string(suffix))
+}
+
+func sanitize(s string) string {
+	s = strings.ToLower(s)
+	var b strings.Builder
+	for _, c := range s {
+		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' {
+			b.WriteRune(c)
+		}
+	}
+	return b.String()
+}
+
+func loadSaaSHive(id string) *SaaSHive {
+	path := filepath.Join(saasHivesDir, id, "meta.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var h SaaSHive
+	if json.Unmarshal(data, &h) != nil {
+		return nil
+	}
+	return &h
+}
+
+func saveSaaSHive(h *SaaSHive) error {
+	dir := filepath.Join(saasHivesDir, h.ID)
+	os.MkdirAll(dir, 0o755)
+	data, err := json.MarshalIndent(h, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "meta.json"), data, 0o644)
+}
+
+func listSaaSHives() []SaaSHive {
+	entries, err := os.ReadDir(saasHivesDir)
+	if err != nil {
+		return nil
+	}
+	var hives []SaaSHive
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		h := loadSaaSHive(e.Name())
+		if h != nil {
+			hives = append(hives, *h)
+		}
+	}
+	return hives
+}
+
+func countUserHives(username string) int {
+	count := 0
+	for _, h := range listSaaSHives() {
+		if h.Owner == username {
+			count++
+		}
+	}
+	return count
+}
+
+func provisionHive(h *SaaSHive, token string, logger *slog.Logger) error {
+	dir := filepath.Join(saasHivesDir, h.ID, "manifests")
+	os.MkdirAll(dir, 0o755)
+
+	repos := h.Repos
+	reposYAML := "[]"
+	if len(repos) > 0 {
+		parts := make([]string, len(repos))
+		for i, r := range repos {
+			parts[i] = fmt.Sprintf("      - %s", r)
+		}
+		reposYAML = "\n" + strings.Join(parts, "\n")
+	}
+
+	data := map[string]any{
+		"ID":          h.ID,
+		"Namespace":   "hive-saas-" + h.ID,
+		"Org":         h.Org,
+		"Repos":       reposYAML,
+		"PrimaryRepo": h.PrimaryRepo,
+		"ACMMLevel":   h.ACMMLevel,
+		"Token":       token,
+		"CPURequest":  cpuRequest,
+		"CPULimit":    cpuLimit,
+		"MemRequest":  memRequest,
+		"MemLimit":    memLimit,
+		"PVCSize":     pvcSize,
+	}
+
+	tmpl, err := template.New("manifests").Parse(k8sManifestTemplate)
+	if err != nil {
+		return fmt.Errorf("template parse: %w", err)
+	}
+
+	manifestPath := filepath.Join(dir, "all.yaml")
+	f, err := os.Create(manifestPath)
+	if err != nil {
+		return fmt.Errorf("create manifest: %w", err)
+	}
+	if err := tmpl.Execute(f, data); err != nil {
+		f.Close()
+		return fmt.Errorf("template exec: %w", err)
+	}
+	f.Close()
+
+	cmd := exec.Command("kubectl", "apply", "-f", manifestPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		logger.Warn("kubectl apply failed", "hive", h.ID, "output", string(out), "error", err)
+		return fmt.Errorf("kubectl apply: %s", string(out))
+	}
+
+	logger.Info("audit: saas hive provisioned", "hive_id", h.ID, "owner", h.Owner, "org", h.Org)
+	return nil
+}
+
+func StartProvisionWatcher(logger *slog.Logger, mu *sync.RWMutex) {
+	ticker := time.NewTicker(provisionPollInterval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		hives := listSaaSHives()
+		for _, h := range hives {
+			if h.Status != "provisioning" {
+				continue
+			}
+			created, _ := time.Parse(time.RFC3339, h.CreatedAt)
+			if time.Since(created) > provisionTimeout {
+				h.Status = "error"
+				h.Error = "provisioning timed out"
+				saveSaaSHive(&h)
+				logger.Warn("saas hive provision timeout", "hive_id", h.ID)
+				continue
+			}
+
+			ns := "hive-saas-" + h.ID
+			cmd := exec.Command("kubectl", "get", "deployment", "hive", "-n", ns, "-o", "jsonpath={.status.availableReplicas}")
+			out, err := cmd.Output()
+			if err != nil {
+				continue
+			}
+			if strings.TrimSpace(string(out)) == "1" {
+				h.Status = "running"
+				saveSaaSHive(&h)
+				logger.Info("audit: saas hive running", "hive_id", h.ID)
+			}
+		}
+	}
+}
+
+const k8sManifestTemplate = `apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{.Namespace}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hive-config
+  namespace: {{.Namespace}}
+data:
+  hive.yaml: |
+    project:
+      org: {{.Org}}
+      repos: {{.Repos}}
+      primary_repo: {{.PrimaryRepo}}
+    agents:
+      guide:
+        backend: copilot
+        model: claude-sonnet-4-6
+        enabled: true
+      scanner:
+        backend: copilot
+        model: claude-sonnet-4-6
+        enabled: true
+    governor:
+      eval_interval_s: 300
+      modes:
+        idle:
+          threshold: 0
+          guide: 4h
+          scanner: 4h
+        busy:
+          threshold: 10
+          guide: 2h
+          scanner: 2h
+    github:
+      token: "${HIVE_GITHUB_TOKEN}"
+    dashboard:
+      port: 3002
+    hub:
+      enabled: true
+      url: https://hive.kubestellar.io
+      is_public: true
+    acmm_level: {{.ACMMLevel}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hive-secrets
+  namespace: {{.Namespace}}
+type: Opaque
+stringData:
+  github-token: {{.Token}}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hive-data
+  namespace: {{.Namespace}}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{.PVCSize}}
+  storageClassName: oci-bv
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hive
+  namespace: {{.Namespace}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hive
+      hive-id: {{.ID}}
+  template:
+    metadata:
+      labels:
+        app: hive
+        hive-id: {{.ID}}
+    spec:
+      containers:
+      - name: hive
+        image: ghcr.io/kubestellar/hive:v2-latest
+        imagePullPolicy: Always
+        env:
+        - name: HIVE_GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: hive-secrets
+              key: github-token
+        - name: HIVE_LEVEL
+          value: "{{.ACMMLevel}}"
+        - name: HIVE_HUB_URL
+          value: https://hive.kubestellar.io
+        ports:
+        - containerPort: 3002
+        resources:
+          requests:
+            cpu: {{.CPURequest}}
+            memory: {{.MemRequest}}
+          limits:
+            cpu: {{.CPULimit}}
+            memory: {{.MemLimit}}
+        volumeMounts:
+        - name: config
+          mountPath: /etc/hive
+        - name: data
+          mountPath: /data
+      volumes:
+      - name: config
+        configMap:
+          name: hive-config
+      - name: data
+        persistentVolumeClaim:
+          claimName: hive-data
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hive
+  namespace: {{.Namespace}}
+spec:
+  selector:
+    app: hive
+    hive-id: {{.ID}}
+  ports:
+  - name: http
+    port: 3002
+    targetPort: 3002
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hive
+  namespace: {{.Namespace}}
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/auth-url: "https://hive.kubestellar.io/api/saas/auth-check?hive={{.ID}}"
+    nginx.ingress.kubernetes.io/auth-signin: "https://hive.kubestellar.io/login"
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: {{.ID}}.hive.kubestellar.io
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: hive
+            port:
+              number: 3002
+  tls:
+  - hosts:
+    - {{.ID}}.hive.kubestellar.io
+    secretName: hive-tls
+`

--- a/v2/pkg/hub/static/get-started.html
+++ b/v2/pkg/hub/static/get-started.html
@@ -42,6 +42,7 @@
         <a href="/learn">Learn</a>
         <a href="/get-started">Get Started</a>
         <a href="/dashboard" id="nav-dashboard" style="display:none">My Hives</a>
+        <a href="https://github.com/kubestellar/hive" target="_blank" title="Source Code" style="font-size:1.1rem">🐙</a>
         <span id="nav-user" style="display:none"></span>
         <a href="/login" class="nav-login" id="nav-login">Login</a>
         <a href="#" class="nav-login" id="nav-logout" style="display:none" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.href='/'});return false;">Logout</a>

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -102,6 +102,7 @@
         <a href="/learn">Learn</a>
         <a href="/get-started">Get Started</a>
         <a href="/dashboard" id="nav-dashboard" style="display:none">My Hives</a>
+        <a href="https://github.com/kubestellar/hive" target="_blank" title="Source Code" style="font-size:1.1rem">🐙</a>
         <span id="nav-user" style="display:none"></span>
         <a href="/login" class="nav-login" id="nav-login">Login</a>
         <a href="#" class="nav-login" id="nav-logout" style="display:none" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.reload()});return false;">Logout</a>

--- a/v2/pkg/hub/static/learn.html
+++ b/v2/pkg/hub/static/learn.html
@@ -38,6 +38,7 @@
         <a href="/learn">Learn</a>
         <a href="/get-started">Get Started</a>
         <a href="/dashboard" id="nav-dashboard" style="display:none">My Hives</a>
+        <a href="https://github.com/kubestellar/hive" target="_blank" title="Source Code" style="font-size:1.1rem">🐙</a>
         <span id="nav-user" style="display:none"></span>
         <a href="/login" class="nav-login" id="nav-login">Login</a>
         <a href="#" class="nav-login" id="nav-logout" style="display:none" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.href='/'});return false;">Logout</a>


### PR DESCRIPTION
## Summary
**Step 2 of the SaaS plan — full provisioning pipeline:**

- **Create SaaS Hive modal** — form with org, repos, primary repo, ACMM level, GitHub token
- **`POST /api/saas/hives`** — validates input, generates K8s manifests, applies via `kubectl apply`
- **K8s resources per hive:** namespace, configmap (hive.yaml), secret (token), PVC (1Gi), deployment, service, ingress
- **Ingress auth** — `auth-url` annotation proxies through `GET /api/saas/auth-check` on the hub
- **Status watcher** — background goroutine polls deployment status every 30s
- **Dockerfile.hub** — adds `kubectl` binary for provisioning
- **Contributors column** added to My Hives dashboard table
- **GitHub 🐙 link** added to all nav bars (links to kubestellar/hive)
- **Nav fix** — dashboard nav no longer wraps username below links
- **Limits**: max 3 hives/user, 5 total (cluster capacity)

### Remaining before SaaS hives work end-to-end:
- [ ] RBAC — ServiceAccount needs ClusterRole for namespace/deployment/etc creation
- [ ] Wildcard TLS — `*.hive.kubestellar.io` cert via Netlify DNS01 challenge

## Test plan
- [ ] Click "Add SaaS Hive" → modal opens with form
- [ ] Fill org/repos/token → click Go → hive provisioned
- [ ] `kubectl get all -n hive-saas-{id}` shows resources
- [ ] Dashboard shows new hive with "provisioning" then "running" status
- [ ] Contributors column visible in My Hives table
- [ ] GitHub link visible in all nav bars