### PR TITLE
fix: real dashboard URL, mode gauge, org avatar, ACMM nowrap

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -385,7 +385,7 @@ const dashboardHTML = `<!DOCTYPE html>
     .role-owner { background: rgba(245,158,11,0.15); color: #fbbf24; border: 1px solid rgba(245,158,11,0.3); }
     .role-read { background: rgba(59,130,246,0.15); color: #60a5fa; border: 1px solid rgba(59,130,246,0.3); }
     .role-read-write { background: rgba(34,197,94,0.15); color: #4ade80; border: 1px solid rgba(34,197,94,0.3); }
-    .acmm-badge { display: inline-block; padding: 4px 12px; border-radius: 9999px; font-size: 0.7rem; font-weight: 700; }
+    .acmm-badge { display: inline-block; padding: 4px 12px; border-radius: 9999px; font-size: 0.7rem; font-weight: 700; white-space: nowrap; cursor: help; }
     .acmm-1 { background: rgba(59,130,246,0.15); color: #60a5fa; border: 1px solid rgba(59,130,246,0.3); }
     .acmm-2 { background: rgba(168,85,247,0.15); color: #c084fc; border: 1px solid rgba(168,85,247,0.3); }
     .acmm-3 { background: rgba(34,197,94,0.15); color: #4ade80; border: 1px solid rgba(34,197,94,0.3); }
@@ -443,17 +443,26 @@ const dashboardHTML = `<!DOCTYPE html>
     var ACMM_LABELS = {1:'L1 Idea',2:'L2 Measured',3:'L3 CI/CD',4:'L4 Auto PR',5:'L5 Self-Governing',6:'L6 Fully Autonomous'};
     function acmmBadge(level) {
       var l = level || 0;
-      return '<span class="acmm-badge acmm-' + l + '">' + (ACMM_LABELS[l] || 'L' + l) + '</span>';
+      var tips = {1:'L1 Idea — Advisory only.',2:'L2 Measured — Can open issues.',3:'L3 CI/CD — Hold-gated PRs.',4:'L4 Auto PR — Merge on green CI.',5:'L5 Self-Governing — Full autonomy.',6:'L6 Fully Autonomous — Multi-loop.'};
+      return '<span class="acmm-badge acmm-' + l + '" title="' + esc(tips[l] || '') + '">' + (ACMM_LABELS[l] || 'L' + l) + '</span>';
     }
     function roleBadge(role) {
       var cls = role === 'owner' ? 'role-owner' : role === 'read-write' ? 'role-read-write' : 'role-read';
       return '<span class="role-badge ' + cls + '">' + esc(role) + '</span>';
     }
     function modeBadge(mode) {
-      var m = (mode || '').toUpperCase();
-      var colors = {IDLE:'#6b7280',QUIET:'#3b82f6',BUSY:'#f59e0b',SURGE:'#ef4444'};
+      var m = (mode || 'idle').toUpperCase();
+      var levels = {IDLE:0, QUIET:1, BUSY:2, SURGE:3};
+      var colors = {IDLE:'#6b7280', QUIET:'#3b82f6', BUSY:'#f59e0b', SURGE:'#ef4444'};
+      var fill = levels[m] !== undefined ? levels[m] : 0;
       var c = colors[m] || '#6b7280';
-      return '<span style="color:' + c + ';font-weight:600">' + m + '</span>';
+      var bars = '';
+      for (var i = 0; i < 4; i++) {
+        var h = 6 + i * 4;
+        var bc = i <= fill ? c : '#1e1e2e';
+        bars += '<rect x="' + (i * 6) + '" y="' + (20 - h) + '" width="4" height="' + h + '" rx="1" fill="' + bc + '"/>';
+      }
+      return '<span title="' + m + '" style="display:inline-flex;align-items:center;gap:4px"><svg width="24" height="20" viewBox="0 0 24 20">' + bars + '</svg><span style="font-size:0.7rem;color:' + c + ';font-weight:600">' + m + '</span></span>';
     }
     function dashboardLink(h) {
       if (h.dashboardUrl && !h.dashboardUrl.includes('localhost'))

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -114,13 +114,29 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	dashURL := payload.DashboardURL
+	if strings.Contains(dashURL, "localhost") || strings.Contains(dashURL, "127.0.0.1") {
+		remoteIP := r.RemoteAddr
+		if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
+			remoteIP = strings.TrimSpace(strings.Split(fwd, ",")[0])
+		}
+		if idx := strings.LastIndex(remoteIP, ":"); idx > 0 && !strings.Contains(remoteIP[idx:], "]") {
+			remoteIP = remoteIP[:idx]
+		}
+		port := "3001"
+		if idx := strings.LastIndex(dashURL, ":"); idx > 0 {
+			port = strings.TrimRight(dashURL[idx+1:], "/")
+		}
+		dashURL = "http://" + remoteIP + ":" + port
+	}
+
 	entry := RegistryEntry{
 		ID:                 payload.HiveID,
 		Name:               payload.Org + "/" + payload.PrimaryRepo,
 		Org:                payload.Org,
 		Repos:              payload.Repos,
 		PrimaryRepo:        payload.PrimaryRepo,
-		DashboardURL:       payload.DashboardURL,
+		DashboardURL:       dashURL,
 		SnapshotURL:        payload.SnapshotURL,
 		ACMMLevel:          payload.ACMMLevel,
 		AgentCount:         len(payload.Agents),

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -159,7 +159,18 @@
     }
 
     function modeBadge(mode) {
-      return '<span class="mode-badge mode-' + (mode || 'idle') + '">' + esc(mode || 'idle') + '</span>';
+      var m = (mode || 'idle').toUpperCase();
+      var levels = {IDLE:0, QUIET:1, BUSY:2, SURGE:3};
+      var colors = {IDLE:'#6b7280', QUIET:'#3b82f6', BUSY:'#f59e0b', SURGE:'#ef4444'};
+      var fill = levels[m] !== undefined ? levels[m] : 0;
+      var c = colors[m] || '#6b7280';
+      var bars = '';
+      for (var i = 0; i < 4; i++) {
+        var h = 6 + i * 4;
+        var bc = i <= fill ? c : '#1e1e2e';
+        bars += '<rect x="' + (i * 6) + '" y="' + (20 - h) + '" width="4" height="' + h + '" rx="1" fill="' + bc + '"/>';
+      }
+      return '<span title="' + m + '" style="display:inline-flex;align-items:center;gap:4px"><svg width="24" height="20" viewBox="0 0 24 20">' + bars + '</svg><span style="font-size:0.7rem;color:' + c + ';font-weight:600">' + m + '</span></span>';
     }
 
     function sparkSvg(values, color) {
@@ -214,7 +225,7 @@
           : '<span style="display:inline-block;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:rgba(107,114,128,0.15);color:#9ca3af;border:1px solid rgba(107,114,128,0.3)" title="Self-hosted by the owner">local</span>';
         return '<tr>' +
           '<td>' + (i + 1) + '</td>' +
-          '<td>' + dot + '<span class="hive-name">' + esc(h.name || h.id) + '</span><br><span class="hive-org">' + esc(h.org) + '</span></td>' +
+          '<td style="display:flex;align-items:center;gap:10px"><img src="https://github.com/' + esc(h.org) + '.png" style="width:36px;height:36px;border-radius:6px;flex-shrink:0" onerror="this.style.display=\'none\'">' + dot + '<div><span class="hive-name">' + esc(h.name || h.id) + '</span><br><span class="hive-org">' + esc(h.org) + '</span></div></td>' +
           '<td>' + htype + '</td>' +
           '<td>' + repoLink + '</td>' +
           '<td>' + repoCount + '</td>' +


### PR DESCRIPTION
## Summary
- **Dashboard URL**: Hub extracts real IP from heartbeat request when spoke sends localhost URL. My Hives now shows clickable `192.168.x.x:3001` links.
- **Mode gauge**: SVG bar chart — 4 bars that fill based on mode (IDLE=1, QUIET=2, BUSY=3, SURGE=4) with color coding
- **Org avatar**: GitHub org avatar shown next to hive name at full row height in Active Hives
- **ACMM nowrap**: Dashboard table pills no longer wrap, with hover tooltips

## Test plan
- [ ] Active Hives shows org avatar next to each hive name
- [ ] Mode column shows bar gauge instead of text
- [ ] My Hives dashboard shows real IP:port in Dashboard column
- [ ] ACMM pills don't wrap in dashboard table