### PR TITLE
fix: dashboard URL from config, token instructions

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -904,7 +904,12 @@ func main() {
 					return ""
 				}(),
 				Health:       map[string]any{},
-				DashboardURL: fmt.Sprintf("http://localhost:%d", cfg.Dashboard.Port),
+				DashboardURL: func() string {
+					if cfg.Hub.DashboardURL != "" {
+						return cfg.Hub.DashboardURL
+					}
+					return fmt.Sprintf("http://localhost:%d", cfg.Dashboard.Port)
+				}(),
 				SnapshotURL:  cfg.Hub.SnapshotURL,
 				IsPublic:     cfg.Hub.IsPublic,
 				Version:      "2.0.0",

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -327,10 +327,11 @@ type DiscordConfig struct {
 }
 
 type HubConfig struct {
-	Enabled     bool   `yaml:"enabled"`
-	URL         string `yaml:"url"`
-	IsPublic    bool   `yaml:"is_public"`
-	SnapshotURL string `yaml:"snapshot_url"`
+	Enabled      bool   `yaml:"enabled"`
+	URL          string `yaml:"url"`
+	IsPublic     bool   `yaml:"is_public"`
+	SnapshotURL  string `yaml:"snapshot_url"`
+	DashboardURL string `yaml:"dashboard_url"`
 }
 
 type DashboardConfig struct {

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -683,8 +683,14 @@ const dashboardHTML = `<!DOCTYPE html>
         </div>
       </div>
       <div style="margin-bottom:20px">
-        <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">GitHub Token * <span style="font-size:0.7rem">(ghp_... or github_pat_...)</span></label>
+        <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">GitHub Personal Access Token *</label>
         <input id="f-token" type="password" placeholder="ghp_xxxxxxxxxxxx" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
+        <div style="font-size:0.7rem;color:var(--muted);margin-top:6px;line-height:1.5">
+          Create a <a href="https://github.com/settings/tokens?type=beta" target="_blank">Fine-grained PAT</a> with these permissions on your repos:<br>
+          <strong>Required:</strong> Contents (read/write), Issues (read/write), Pull requests (read/write), Metadata (read)<br>
+          <strong>Optional:</strong> Actions (read), Commit statuses (read)<br>
+          Classic tokens (<code>ghp_</code>) also work with <code>repo</code> scope.
+        </div>
       </div>
       <div style="display:flex;gap:12px;justify-content:flex-end">
         <button onclick="document.getElementById('create-modal').style.display='none'" style="padding:8px 20px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--muted);cursor:pointer">Cancel</button>

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -114,29 +114,13 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dashURL := payload.DashboardURL
-	if strings.Contains(dashURL, "localhost") || strings.Contains(dashURL, "127.0.0.1") {
-		remoteIP := r.RemoteAddr
-		if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
-			remoteIP = strings.TrimSpace(strings.Split(fwd, ",")[0])
-		}
-		if idx := strings.LastIndex(remoteIP, ":"); idx > 0 && !strings.Contains(remoteIP[idx:], "]") {
-			remoteIP = remoteIP[:idx]
-		}
-		port := "3001"
-		if idx := strings.LastIndex(dashURL, ":"); idx > 0 {
-			port = strings.TrimRight(dashURL[idx+1:], "/")
-		}
-		dashURL = "http://" + remoteIP + ":" + port
-	}
-
 	entry := RegistryEntry{
 		ID:                 payload.HiveID,
 		Name:               payload.Org + "/" + payload.PrimaryRepo,
 		Org:                payload.Org,
 		Repos:              payload.Repos,
 		PrimaryRepo:        payload.PrimaryRepo,
-		DashboardURL:       dashURL,
+		DashboardURL:       payload.DashboardURL,
 		SnapshotURL:        payload.SnapshotURL,
 		ACMMLevel:          payload.ACMMLevel,
 		AgentCount:         len(payload.Agents),


### PR DESCRIPTION
## Summary
- **Revert heartbeat IP extraction** — was giving OCI LB internal IP (10.0.20.95), not the spoke's real IP
- **Add `dashboard_url` to hub config** — spokes set their real URL (e.g. `http://192.168.4.85:3001`)
- **Token instructions** — modal now explains: fine-grained PAT permissions (Contents, Issues, PRs read/write) or classic `repo` scope
- Set `dashboard_url` on all 4 spokes in their hive.yaml files

## Test plan
- [ ] My Hives Dashboard column shows `192.168.4.85:3001` etc. (after next heartbeat)
- [ ] Token field in create modal shows permission instructions
- [ ] Link to GitHub PAT settings page works