### PR TITLE
fix: OAuth redirect preserves original URL for SaaS hive access

### DIFF
--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -31,9 +33,14 @@ func (s *HubServer) registerOAuth() {
 
 func (s *HubServer) handleLogin(w http.ResponseWriter, r *http.Request) {
 	clientID := os.Getenv("HIVE_HUB_OAUTH_CLIENT_ID")
-	url := fmt.Sprintf("%s?client_id=%s&scope=read:user&redirect_uri=%s",
-		ghAuthorizeURL, clientID, "https://hive.kubestellar.io/api/auth/callback")
-	http.Redirect(w, r, url, http.StatusTemporaryRedirect)
+	redirect := r.URL.Query().Get("redirect")
+	if redirect == "" {
+		redirect = r.URL.Query().Get("rd")
+	}
+	state := url.QueryEscape(redirect)
+	authURL := fmt.Sprintf("%s?client_id=%s&scope=read:user&redirect_uri=%s&state=%s",
+		ghAuthorizeURL, clientID, "https://hive.kubestellar.io/api/auth/callback", state)
+	http.Redirect(w, r, authURL, http.StatusTemporaryRedirect)
 }
 
 func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) {
@@ -109,7 +116,15 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 
 	ensureSaaSUser(user.Login)
 
-	http.Redirect(w, r, "/dashboard", http.StatusTemporaryRedirect)
+	redirect := "/dashboard"
+	if state := r.URL.Query().Get("state"); state != "" {
+		if decoded, err := url.QueryUnescape(state); err == nil && decoded != "" {
+			if strings.HasPrefix(decoded, "https://") || strings.HasPrefix(decoded, "/") {
+				redirect = decoded
+			}
+		}
+	}
+	http.Redirect(w, r, redirect, http.StatusTemporaryRedirect)
 }
 
 func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -359,7 +359,7 @@ metadata:
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/auth-url: "https://hive.kubestellar.io/api/saas/auth-check?hive={{.ID}}"
-    nginx.ingress.kubernetes.io/auth-signin: "https://hive.kubestellar.io/login"
+    nginx.ingress.kubernetes.io/auth-signin: "https://hive.kubestellar.io/login?redirect=$scheme://$http_host$request_uri"
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
## Summary
When a user visits a SaaS hive URL directly (e.g. `saas-myorg-repo-a7f2.hive.kubestellar.io`) without being logged in:

1. Nginx ingress `auth-signin` passes the original URL as `?redirect=` param
2. `/login` stores it in the OAuth `state` parameter
3. After GitHub OAuth, the callback redirects to the original URL instead of `/dashboard`
4. User lands on the SaaS hive they originally tried to visit

Also supports `?rd=` param (nginx default) and validates the redirect URL (must start with `https://` or `/`).

## Test plan
- [ ] Visit SaaS hive URL directly while logged out → GitHub OAuth → land back on SaaS hive
- [ ] Visit `/login` without redirect param → lands on `/dashboard` (default)
- [ ] Visit `/login?redirect=/learn` → lands on `/learn` after OAuth