### PR TITLE
fix: format MTTR in human-readable time units

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -2604,7 +2604,25 @@
 
     function formatFixTime(minutes) {
       if (!minutes || minutes <= 0) return '—';
-      return `${minutes}m`;
+      const MINS_PER_HOUR = 60;
+      const MINS_PER_DAY = 1440;
+      const MINS_PER_WEEK = 10080;
+      if (minutes >= MINS_PER_WEEK) {
+        const weeks = Math.floor(minutes / MINS_PER_WEEK);
+        const remainDays = Math.floor((minutes % MINS_PER_WEEK) / MINS_PER_DAY);
+        return remainDays > 0 ? `${weeks}.${remainDays}w` : `${weeks}w`;
+      }
+      if (minutes >= MINS_PER_DAY) {
+        const days = Math.floor(minutes / MINS_PER_DAY);
+        const remainHrs = Math.floor((minutes % MINS_PER_DAY) / MINS_PER_HOUR);
+        return remainHrs > 0 ? `${days}.${remainHrs}d` : `${days}d`;
+      }
+      if (minutes >= MINS_PER_HOUR) {
+        const hrs = Math.floor(minutes / MINS_PER_HOUR);
+        const remainMins = Math.round(minutes % MINS_PER_HOUR);
+        return remainMins > 0 ? `${hrs}.${remainMins}h` : `${hrs}h`;
+      }
+      return `${Math.round(minutes)}m`;
     }
 
     function renderGovernor(gov, cadenceMatrix, data) {


### PR DESCRIPTION
## Summary
- MTTR was showing raw minutes (e.g. `737m`) which is hard to read at a glance
- Now shows tiered units: `45m` → `11.46h` → `1.12d` → `1.2w`
  - Below 60m: minutes (`45m`)
  - 60m–24h: hours.minutes (`11.46h` = 11 hours 46 minutes)
  - 24h–7d: days.hours (`1.12d` = 1 day 12 hours)
  - 7d+: weeks.days (`1.2w` = 1 week 2 days)

## Test plan
- [ ] Verify on live dashboard after deploy pulls the change