### PR TITLE
feat: GitHub App auth, logo scroll fix, admin users fix

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -229,8 +229,14 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Org == "" || req.Repos == "" || req.GitHubToken == "" {
-		http.Error(w, `{"error":"org, repos, and github_token are required"}`, http.StatusBadRequest)
+	if req.Org == "" || req.Repos == "" {
+		http.Error(w, `{"error":"org and repos are required"}`, http.StatusBadRequest)
+		return
+	}
+	hasToken := req.GitHubToken != ""
+	hasApp := req.AuthMethod == "app" && req.AppID != "" && req.InstallationID != "" && req.AppPrivateKey != ""
+	if !hasToken && !hasApp {
+		http.Error(w, `{"error":"provide either a GitHub token or GitHub App credentials"}`, http.StatusBadRequest)
 		return
 	}
 
@@ -280,7 +286,7 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 	saveSaaSUser(user)
 
 	go func() {
-		if err := provisionHive(h, req.GitHubToken, s.logger); err != nil {
+		if err := provisionHive(h, &req, s.logger); err != nil {
 			h.Status = "error"
 			h.Error = err.Error()
 			saveSaaSHive(h)
@@ -537,9 +543,14 @@ const dashboardHTML = `<!DOCTYPE html>
         '</tr></thead><tbody>' + rows + '</tbody></table>';
     }
 
-    loadUser();
-    loadHives();
+    async function init() {
+      await loadUser();
+      loadHives();
+      loadAdminUsers();
+    }
+    init();
     setInterval(loadHives, 60000);
+    setInterval(loadAdminUsers, 60000);
 
     var _allUsers = [];
     async function loadAdminUsers() {
@@ -611,26 +622,34 @@ const dashboardHTML = `<!DOCTYPE html>
       } catch(e) { alert('Error: ' + e.message); }
     }
 
-    loadAdminUsers();
-
     async function createHive() {
       var org = document.getElementById('f-org').value.trim();
       var repos = document.getElementById('f-repos').value.trim();
       var primary = document.getElementById('f-primary').value.trim();
       var name = document.getElementById('f-name').value.trim();
       var level = parseInt(document.getElementById('f-level').value) || 1;
+      var method = document.querySelector('input[name="auth-method"]:checked').value;
       var token = document.getElementById('f-token').value.trim();
+      var appId = (document.getElementById('f-app-id') || {}).value || '';
+      var installId = (document.getElementById('f-install-id') || {}).value || '';
+      var appKey = (document.getElementById('f-app-key') || {}).value || '';
 
-      if (!org || !repos || !token) { alert('Org, repos, and GitHub token are required'); return; }
+      if (!org || !repos) { alert('Org and repos are required'); return; }
+      if (method === 'pat' && !token) { alert('GitHub token is required'); return; }
+      if (method === 'app' && (!appId || !installId || !appKey)) { alert('App ID, Installation ID, and Private Key are required'); return; }
 
       document.getElementById('btn-go').disabled = true;
       document.getElementById('btn-go').textContent = 'Provisioning...';
 
       try {
+        var body = {org: org, repos: repos, primary_repo: primary || repos.split(',')[0].trim(), project_name: name, acmm_level: level, auth_method: method};
+        if (method === 'pat') body.github_token = token;
+        else { body.app_id = appId.trim(); body.installation_id = installId.trim(); body.app_private_key = appKey.trim(); }
+
         var resp = await fetch('/api/saas/hives', {
           method: 'POST',
           headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({org: org, repos: repos, primary_repo: primary || repos.split(',')[0].trim(), project_name: name, acmm_level: level, github_token: token})
+          body: JSON.stringify(body)
         });
         var data = await resp.json();
         if (!resp.ok) { alert(data.error || 'Failed to create hive'); return; }
@@ -682,14 +701,36 @@ const dashboardHTML = `<!DOCTYPE html>
           </select>
         </div>
       </div>
-      <div style="margin-bottom:20px">
-        <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">GitHub Personal Access Token *</label>
-        <input id="f-token" type="password" placeholder="ghp_xxxxxxxxxxxx" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
-        <div style="font-size:0.7rem;color:var(--muted);margin-top:6px;line-height:1.5">
-          Create a <a href="https://github.com/settings/tokens?type=beta" target="_blank">Fine-grained PAT</a> with these permissions on your repos:<br>
-          <strong>Required:</strong> Contents (read/write), Issues (read/write), Pull requests (read/write), Metadata (read)<br>
-          <strong>Optional:</strong> Actions (read), Commit statuses (read)<br>
-          Classic tokens (<code>ghp_</code>) also work with <code>repo</code> scope.
+      <div style="margin-bottom:12px">
+        <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">Authentication Method</label>
+        <div style="display:flex;gap:12px;margin-top:4px">
+          <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:0.8rem"><input type="radio" name="auth-method" value="pat" checked onchange="document.getElementById('auth-pat').style.display='';document.getElementById('auth-app').style.display='none'"> Personal Access Token</label>
+          <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:0.8rem"><input type="radio" name="auth-method" value="app" onchange="document.getElementById('auth-pat').style.display='none';document.getElementById('auth-app').style.display=''"> GitHub App</label>
+        </div>
+      </div>
+      <div id="auth-pat">
+        <div style="margin-bottom:12px">
+          <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">GitHub Token *</label>
+          <input id="f-token" type="password" placeholder="ghp_xxxxxxxxxxxx" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
+          <div style="font-size:0.7rem;color:var(--muted);margin-top:6px;line-height:1.5">
+            Create a <a href="https://github.com/settings/tokens?type=beta" target="_blank">Fine-grained PAT</a>: Contents, Issues, Pull requests (read/write), Metadata (read).<br>
+            Classic tokens (<code>ghp_</code>) work with <code>repo</code> scope.
+          </div>
+        </div>
+      </div>
+      <div id="auth-app" style="display:none">
+        <div style="margin-bottom:12px">
+          <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">App ID *</label>
+          <input id="f-app-id" type="text" placeholder="123456" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
+        </div>
+        <div style="margin-bottom:12px">
+          <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">Installation ID *</label>
+          <input id="f-install-id" type="text" placeholder="78901234" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem">
+        </div>
+        <div style="margin-bottom:12px">
+          <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">Private Key (PEM) *</label>
+          <textarea id="f-app-key" rows="4" placeholder="-----BEGIN RSA PRIVATE KEY-----&#10;..." style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.8rem;font-family:monospace;resize:vertical"></textarea>
+          <div style="font-size:0.7rem;color:var(--muted);margin-top:4px">Download from your <a href="https://github.com/settings/apps" target="_blank">GitHub App settings</a> → Private keys.</div>
         </div>
       </div>
       <div style="display:flex;gap:12px;justify-content:flex-end">

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -42,12 +42,16 @@ type SaaSHive struct {
 }
 
 type CreateHiveRequest struct {
-	Org         string `json:"org"`
-	Repos       string `json:"repos"`
-	PrimaryRepo string `json:"primary_repo"`
-	ProjectName string `json:"project_name"`
-	ACMMLevel   int    `json:"acmm_level"`
-	GitHubToken string `json:"github_token"`
+	Org            string `json:"org"`
+	Repos          string `json:"repos"`
+	PrimaryRepo    string `json:"primary_repo"`
+	ProjectName    string `json:"project_name"`
+	ACMMLevel      int    `json:"acmm_level"`
+	GitHubToken    string `json:"github_token"`
+	AuthMethod     string `json:"auth_method"`
+	AppID          string `json:"app_id"`
+	InstallationID string `json:"installation_id"`
+	AppPrivateKey  string `json:"app_private_key"`
 }
 
 func generateHiveID(org, repo string) string {
@@ -125,7 +129,7 @@ func countUserHives(username string) int {
 	return count
 }
 
-func provisionHive(h *SaaSHive, token string, logger *slog.Logger) error {
+func provisionHive(h *SaaSHive, req *CreateHiveRequest, logger *slog.Logger) error {
 	dir := filepath.Join(saasHivesDir, h.ID, "manifests")
 	os.MkdirAll(dir, 0o755)
 
@@ -139,19 +143,25 @@ func provisionHive(h *SaaSHive, token string, logger *slog.Logger) error {
 		reposYAML = "\n" + strings.Join(parts, "\n")
 	}
 
+	useApp := req.AuthMethod == "app" && req.AppID != "" && req.InstallationID != "" && req.AppPrivateKey != ""
+
 	data := map[string]any{
-		"ID":          h.ID,
-		"Namespace":   "hive-saas-" + h.ID,
-		"Org":         h.Org,
-		"Repos":       reposYAML,
-		"PrimaryRepo": h.PrimaryRepo,
-		"ACMMLevel":   h.ACMMLevel,
-		"Token":       token,
-		"CPURequest":  cpuRequest,
-		"CPULimit":    cpuLimit,
-		"MemRequest":  memRequest,
-		"MemLimit":    memLimit,
-		"PVCSize":     pvcSize,
+		"ID":             h.ID,
+		"Namespace":      "hive-saas-" + h.ID,
+		"Org":            h.Org,
+		"Repos":          reposYAML,
+		"PrimaryRepo":    h.PrimaryRepo,
+		"ACMMLevel":      h.ACMMLevel,
+		"Token":          req.GitHubToken,
+		"UseApp":         useApp,
+		"AppID":          req.AppID,
+		"InstallationID": req.InstallationID,
+		"AppPrivateKey":  req.AppPrivateKey,
+		"CPURequest":     cpuRequest,
+		"CPULimit":       cpuLimit,
+		"MemRequest":     memRequest,
+		"MemLimit":       memLimit,
+		"PVCSize":        pvcSize,
 	}
 
 	tmpl, err := template.New("manifests").Parse(k8sManifestTemplate)
@@ -252,7 +262,13 @@ data:
           guide: 2h
           scanner: 2h
     github:
+{{- if .UseApp}}
+      app_id: {{.AppID}}
+      installation_id: {{.InstallationID}}
+      key_file: /secrets/gh-app-key.pem
+{{- else}}
       token: "${HIVE_GITHUB_TOKEN}"
+{{- end}}
     dashboard:
       port: 3002
     hub:
@@ -268,7 +284,12 @@ metadata:
   namespace: {{.Namespace}}
 type: Opaque
 stringData:
+{{- if .UseApp}}
+  gh-app-key.pem: |
+    {{.AppPrivateKey}}
+{{- else}}
   github-token: {{.Token}}
+{{- end}}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -305,11 +326,13 @@ spec:
         image: ghcr.io/kubestellar/hive:v2-latest
         imagePullPolicy: Always
         env:
+{{- if not .UseApp}}
         - name: HIVE_GITHUB_TOKEN
           valueFrom:
             secretKeyRef:
               name: hive-secrets
               key: github-token
+{{- end}}
         - name: HIVE_LEVEL
           value: "{{.ACMMLevel}}"
         - name: HIVE_HUB_URL
@@ -328,6 +351,11 @@ spec:
           mountPath: /etc/hive
         - name: data
           mountPath: /data
+{{- if .UseApp}}
+        - name: secrets
+          mountPath: /secrets
+          readOnly: true
+{{- end}}
       volumes:
       - name: config
         configMap:
@@ -335,6 +363,11 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: hive-data
+{{- if .UseApp}}
+      - name: secrets
+        secret:
+          secretName: hive-secrets
+{{- end}}
 ---
 apiVersion: v1
 kind: Service

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -275,7 +275,10 @@
       });
       if (!orgs.length) return;
       var imgs = orgs.map(function(o) { return '<img src="https://github.com/' + esc(o) + '.png" alt="' + esc(o) + '" title="' + esc(o) + '">'; });
-      var track = imgs.join('') + imgs.join('');
+      var set = imgs.join('');
+      var repeats = Math.max(6, Math.ceil(20 / orgs.length));
+      var track = '';
+      for (var r = 0; r < repeats; r++) track += set;
       document.getElementById('ticker').innerHTML = '<div class="ticker-track">' + track + '</div>';
     }
 


### PR DESCRIPTION
## Summary
- **GitHub App support** in create SaaS hive modal — PAT/App radio toggle with fields for App ID, Installation ID, and PEM private key
- **K8s manifests** support both auth methods: PAT via env var, App via secret volume mount at `/secrets/gh-app-key.pem`
- **Logo ticker** — repeats images enough times to fill viewport for smooth infinite scroll
- **Admin users table** — sequential init (loadUser → loadHives → loadAdminUsers) fixes race condition where table appeared empty after login redirect
- **Token instructions** — detailed permissions for fine-grained and classic PATs

## Remaining items (separate PRs)
- Role enforcement (read-only = snapshot view) — spoke-side change
- Keel auto-deploy — needs GHCR credentials, not a code change
- Current task in leaderboard — spoke-side task status push

## Test plan
- [ ] Create modal shows PAT/App radio toggle
- [ ] Selecting "GitHub App" shows App ID, Installation ID, PEM fields
- [ ] Selecting "Personal Access Token" shows token field with instructions
- [ ] Logo ticker scrolls smoothly with 4 orgs
- [ ] Admin users table shows users immediately after login (no empty table)