### PR TITLE
fix: persist completed tasks — prevent duplicate PRs on restart

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -70,7 +70,7 @@ const CONTAINER_NAME = process.env.HIVE_CONTAINER_NAME || 'hive-contributor';
 function getCLIState() {
   try {
     const output = execSync(
-      `tmux capture-pane -t ${TMUX_SESSION} -p -S -15 2>/dev/null`,
+      `tmux capture-pane -t ${TMUX_SESSION} -p 2>/dev/null`,
       { encoding: 'utf8', timeout: 5000 }
     );
     const text = output.toString();
@@ -215,7 +215,7 @@ function captureTmuxLines(n) {
 function checkTmuxIdle() {
   try {
     const output = execSync(
-      `tmux capture-pane -t ${TMUX_SESSION} -p -S -15 2>/dev/null`,
+      `tmux capture-pane -t ${TMUX_SESSION} -p 2>/dev/null`,
       { encoding: 'utf8', timeout: 5000 }
     );
     const text = output.toString();

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -111,12 +111,14 @@ type ContributeWSHub struct {
 const completedTaskCooldownHours = 168
 
 func NewContributeWSHub(logger *slog.Logger, server *Server) *ContributeWSHub {
-	return &ContributeWSHub{
+	hub := &ContributeWSHub{
 		connections:    make(map[string]*ContributorConnection),
 		completedTasks: make(map[string]time.Time),
-		logger:      logger,
-		server:      server,
+		logger:         logger,
+		server:         server,
 	}
+	hub.loadCompletedTasks()
+	return hub
 }
 
 const activityDebounceSecs = 60
@@ -154,11 +156,41 @@ func (h *ContributeWSHub) RecentActivity() []ActivityEntry {
 	return out
 }
 
+const completedTasksFile = "/data/contributors/completed-tasks.json"
+
+func (h *ContributeWSHub) loadCompletedTasks() {
+	h.completedMu.Lock()
+	defer h.completedMu.Unlock()
+	data, err := os.ReadFile(completedTasksFile)
+	if err != nil { return }
+	var saved map[string]string
+	if json.Unmarshal(data, &saved) != nil { return }
+	for k, v := range saved {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			if time.Since(t) < completedTaskCooldownHours*time.Hour {
+				h.completedTasks[k] = t
+			}
+		}
+	}
+	h.logger.Info("[contribute-ws] loaded completed tasks", "count", len(h.completedTasks))
+}
+
+func (h *ContributeWSHub) saveCompletedTasks() {
+	h.completedMu.Lock()
+	saved := make(map[string]string, len(h.completedTasks))
+	for k, t := range h.completedTasks { saved[k] = t.Format(time.RFC3339) }
+	h.completedMu.Unlock()
+	data, _ := json.Marshal(saved)
+	os.MkdirAll("/data/contributors", 0o755)
+	os.WriteFile(completedTasksFile, data, 0o644)
+}
+
 func (h *ContributeWSHub) markTaskCompleted(repo string, number int) {
 	key := fmt.Sprintf("%s#%d", repo, number)
 	h.completedMu.Lock()
 	h.completedTasks[key] = time.Now()
 	h.completedMu.Unlock()
+	h.saveCompletedTasks()
 }
 
 func (h *ContributeWSHub) isTaskInCooldown(repo string, number int) bool {


### PR DESCRIPTION
## Summary
**Critical fix**: The in-memory cooldown map reset on every hub restart,
causing contributors to re-work issues and create duplicate PRs.

Now persists to `/data/contributors/completed-tasks.json`:
- Written on every task completion
- Loaded on hub startup
- Tasks older than 1 week auto-pruned

Also fixes copilot working detection (esc cancel only).

## Test plan
- [ ] Hub restarts → completed tasks loaded from disk
- [ ] Previously completed issues not re-assigned
- [ ] No more duplicate PRs