### PR TITLE
fix: make dashboard and main page fully dynamic

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -572,12 +572,16 @@ const dashboardHTML = `<!DOCTYPE html>
 
     async function init() {
       await loadUser();
-      loadHives();
+      await loadHives();
       loadAdminUsers();
     }
     init();
-    setInterval(loadHives, 60000);
-    setInterval(loadAdminUsers, 60000);
+    setInterval(loadHives, 30000);
+    setInterval(loadAdminUsers, 30000);
+    document.addEventListener('visibilitychange', function() {
+      if (!document.hidden) { loadHives(); loadAdminUsers(); }
+    });
+    window.addEventListener('focus', function() { loadHives(); loadAdminUsers(); });
 
     var _allUsers = [];
     async function loadAdminUsers() {

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -284,8 +284,12 @@
 
     loadRegistry();
     loadLeaderboard();
-    setInterval(loadRegistry, 60000);
-    setInterval(loadLeaderboard, 60000);
+    setInterval(loadRegistry, 30000);
+    setInterval(loadLeaderboard, 30000);
+    document.addEventListener('visibilitychange', function() {
+      if (!document.hidden) { loadRegistry(); loadLeaderboard(); }
+    });
+    window.addEventListener('focus', function() { loadRegistry(); loadLeaderboard(); });
 
     fetch('/api/auth/user').then(function(r){return r.json()}).then(function(d){
       if(d.authenticated){


### PR DESCRIPTION
## Summary
- **Reload on tab focus** — both `/` and `/dashboard` reload all data when the browser tab becomes visible or gains focus
- **30s refresh interval** — reduced from 60s for more responsive updates
- **Sequential init** — dashboard awaits `loadHives` before `loadAdminUsers`
- No more stale data when switching tabs or navigating back

## Test plan
- [ ] Open /dashboard → switch to another tab → switch back → data refreshes immediately
- [ ] Open / → switch tab → switch back → hive table and leaderboard refresh
- [ ] New hive heartbeat appears within 30s without manual refresh
- [ ] Admin users table appears reliably after login redirect