### PR TITLE
feat: role enforcement for SaaS hives + 30s task status push

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -916,6 +916,28 @@ func main() {
 				GitHash:      gitShort,
 			}
 		}, time.Duration(cfg.Governor.EvalIntervalS)*time.Second, logger)
+
+		go hub.StartTaskStatusPush(ctx, hubURL, func() *hub.TaskStatusPayload {
+			reg, active := dashSrv.ContributorSummary()
+			lb := dashSrv.LeaderboardForHub()
+			out := make([]hub.LeaderboardEntry, len(lb))
+			for i, e := range lb {
+				out[i] = hub.LeaderboardEntry{
+					GitHubUsername:  e.GitHubUsername,
+					AvatarURL:      e.AvatarURL,
+					TrustTier:      e.TrustTier,
+					TasksCompleted: e.TasksCompleted,
+					TasksFailed:    e.TasksFailed,
+					Active:         e.Active,
+					CurrentTask:    e.CurrentTask,
+				}
+			}
+			return &hub.TaskStatusPayload{
+				HiveID:       cfg.HiveID,
+				Leaderboard:  out,
+				Contributors: hub.ContributorSummary{Registered: reg, Active: active},
+			}
+		}, logger)
 	}
 
 	logger.Info("entering governor loop", "interval_seconds", cfg.Governor.EvalIntervalS)

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -33,6 +33,8 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/widget", s.handleWidget)
 	s.mux.HandleFunc("GET /api/pane/{agent}", s.handlePane)
 
+	s.mux.HandleFunc("GET /api/role", s.handleRole)
+
 	s.mux.HandleFunc("POST /api/kick/{agent}", s.handleKick)
 	s.mux.HandleFunc("POST /api/switch/{agent}/{backend}", s.handleSwitch)
 	s.mux.HandleFunc("POST /api/model/{agent}/{model}", s.handleModelSet)
@@ -276,6 +278,15 @@ func sanitizeString(s string) string {
 }
 
 // --- Core status endpoints ---
+
+func (s *Server) handleRole(w http.ResponseWriter, r *http.Request) {
+	role := r.Header.Get("X-Hive-Role")
+	user := r.Header.Get("X-Hive-User")
+	if role == "" {
+		role = "owner"
+	}
+	jsonResponse(w, map[string]string{"role": role, "user": user})
+}
 
 func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 	resp := map[string]interface{}{

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -291,7 +291,7 @@ func (s *Server) Start() error {
 	}
 	s.mux.Handle("GET /", http.FileServer(http.FS(staticContent)))
 
-	handler := s.securityHeaders(s.mux)
+	handler := s.roleEnforcement(s.securityHeaders(s.mux))
 
 	addr := fmt.Sprintf(":%d", s.port)
 	s.logger.Info("dashboard starting", "addr", addr)
@@ -327,7 +327,26 @@ func (s *Server) securityHeaders(next http.Handler) http.Handler {
 }
 
 func (s *Server) Handler() http.Handler {
-	return s.securityHeaders(s.mux)
+	return s.roleEnforcement(s.securityHeaders(s.mux))
+}
+
+func (s *Server) roleEnforcement(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		role := r.Header.Get("X-Hive-Role")
+		if role == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		w.Header().Set("X-Hive-Role", role)
+		w.Header().Set("X-Hive-User", r.Header.Get("X-Hive-User"))
+		if role == "read" && r.Method != http.MethodGet && r.Method != http.MethodHead && r.Method != http.MethodOptions {
+			if !strings.HasPrefix(r.URL.Path, "/api/contribute") && r.URL.Path != "/api/gh-user-auth/status" {
+				http.Error(w, `{"error":"read-only access"}`, http.StatusForbidden)
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 func (s *Server) UpdateStatus(status *StatusPayload) {

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -122,3 +122,51 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 		logger.Warn("hub heartbeat rejected", "status", resp.StatusCode)
 	}
 }
+
+const taskPushInterval = 30 * time.Second
+
+type TaskStatusPayload struct {
+	HiveID       string             `json:"hive_id"`
+	Leaderboard  []LeaderboardEntry `json:"leaderboard"`
+	Contributors ContributorSummary `json:"contributors"`
+}
+
+type TaskStatusCollector func() *TaskStatusPayload
+
+func StartTaskStatusPush(ctx context.Context, hubURL string, collect TaskStatusCollector, logger *slog.Logger) {
+	if hubURL == "" {
+		return
+	}
+
+	logger.Info("hub task status push enabled", "url", hubURL, "interval", taskPushInterval)
+	ticker := time.NewTicker(taskPushInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			payload := collect()
+			if payload == nil {
+				continue
+			}
+			body, err := json.Marshal(payload)
+			if err != nil {
+				continue
+			}
+			reqCtx, cancel := context.WithTimeout(ctx, heartbeatTimeout)
+			req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, hubURL+"/api/task-status", bytes.NewReader(body))
+			if err != nil {
+				cancel()
+				continue
+			}
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			cancel()
+			if err == nil {
+				resp.Body.Close()
+			}
+		}
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -347,11 +347,14 @@ func (s *HubServer) handleSaaSAuthCheck(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	if _, ok := user.Hives[hiveID]; !ok {
+	role, ok := user.Hives[hiveID]
+	if !ok {
 		http.Error(w, "no access to this hive", http.StatusForbidden)
 		return
 	}
 
+	w.Header().Set("X-Hive-User", username)
+	w.Header().Set("X-Hive-Role", role)
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -393,6 +393,7 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/auth-url: "https://hive.kubestellar.io/api/saas/auth-check?hive={{.ID}}"
     nginx.ingress.kubernetes.io/auth-signin: "https://hive.kubestellar.io/login?redirect=$scheme://$http_host$request_uri"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Hive-User, X-Hive-Role"
 spec:
   ingressClassName: nginx
   rules:

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -75,6 +75,7 @@ func NewHubServer(port int, logger *slog.Logger) *HubServer {
 	s.loadRegistry()
 
 	s.mux.HandleFunc("POST /api/heartbeat", s.handleHeartbeat)
+	s.mux.HandleFunc("POST /api/task-status", s.handleTaskStatus)
 	s.mux.HandleFunc("GET /api/registry", s.handleRegistry)
 	s.mux.HandleFunc("GET /api/hub/leaderboard", s.handleLeaderboard)
 	s.mux.HandleFunc("GET /api/hub/stats", s.handleStats)
@@ -208,6 +209,42 @@ func (s *HubServer) handleLeaderboard(w http.ResponseWriter, r *http.Request) {
 	data, _ := json.Marshal(map[string]any{"leaderboard": merged})
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(data)
+}
+
+func (s *HubServer) handleTaskStatus(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxPayloadBytes))
+	if err != nil {
+		http.Error(w, "read error", http.StatusBadRequest)
+		return
+	}
+	var payload struct {
+		HiveID      string           `json:"hive_id"`
+		Leaderboard []LeaderboardEntry `json:"leaderboard"`
+		Contributors ContributorSummary `json:"contributors"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil || payload.HiveID == "" {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+
+	hiveName := ""
+	s.mu.Lock()
+	for i, h := range s.registry.Hives {
+		if h.ID == payload.HiveID {
+			hiveName = h.Name
+			s.registry.Hives[i].ContributorCount = payload.Contributors.Registered
+			s.registry.Hives[i].ActiveContributors = payload.Contributors.Active
+			for j := range payload.Leaderboard {
+				payload.Leaderboard[j].HiveName = hiveName
+			}
+			s.registry.Hives[i].Leaderboard = payload.Leaderboard
+			break
+		}
+	}
+	s.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write([]byte(`{"ok":true}`))
 }
 
 func (s *HubServer) handleStats(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

### Role enforcement (read-only = snapshot view)
- Hub `auth-check` returns `X-Hive-User` and `X-Hive-Role` headers
- Ingress `auth-response-headers` passes them to the spoke backend
- Spoke middleware blocks all POST/PUT/DELETE for `read` role users (403)
- `GET /api/role` lets the frontend detect the current role for UI adjustments
- Local hives (no header) default to `owner` — no change in behavior

### Task status push (30s freshness)
- New `POST /api/task-status` endpoint on hub — lightweight leaderboard/contributor update
- Spokes push every 30s (separate from the 5-min heartbeat)
- Hub updates registry in-memory only (task data is ephemeral)
- Current task appears in hub leaderboard within 30s instead of waiting for full heartbeat

## Test plan
- [ ] SaaS hive with `read` role → can view dashboard, cannot change config/restart agents
- [ ] SaaS hive with `read-write` or `owner` → full access
- [ ] Local hive → unchanged behavior (owner access)
- [ ] `GET /api/role` returns `{role: "owner"}` for local, actual role for SaaS
- [ ] Hub leaderboard shows current task within 30s of assignment
- [ ] Task clears from leaderboard within 30s of completion