### PR TITLE
fix: rename SaaS to Hosted across entire site

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -203,7 +203,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 
 	saasCount := 0
 	for _, h := range result {
-		if strings.HasPrefix(h.ID, "saas-") {
+		if strings.HasPrefix(h.ID, "hosted-") || strings.HasPrefix(h.ID, "saas-") {
 			saasCount++
 		}
 	}
@@ -231,7 +231,7 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if user.SaaSQuota == 0 {
-		http.Error(w, `{"error":"no SaaS quota — contact the hub admin to request access"}`, http.StatusForbidden)
+		http.Error(w, `{"error":"no hosted hive quota — contact the hub admin to request access"}`, http.StatusForbidden)
 		return
 	}
 
@@ -258,7 +258,7 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(listSaaSHives()) >= maxSaaSHivesTotal {
-		http.Error(w, `{"error":"SaaS capacity reached — try again later"}`, http.StatusServiceUnavailable)
+		http.Error(w, `{"error":"hosted capacity reached — try again later"}`, http.StatusServiceUnavailable)
 		return
 	}
 
@@ -302,7 +302,7 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 			h.Status = "error"
 			h.Error = err.Error()
 			saveSaaSHive(h)
-			s.logger.Warn("saas hive provision failed", "hive_id", hiveID, "error", err)
+			s.logger.Warn("hosted hive provision failed", "hive_id", hiveID, "error", err)
 			return
 		}
 		h.Status = "provisioning"
@@ -523,7 +523,7 @@ const dashboardHTML = `<!DOCTYPE html>
         var addBtn = document.getElementById('btn-add-hive');
         if (addBtn) {
           addBtn.disabled = !canCreate;
-          addBtn.title = canCreate ? '' : 'No SaaS quota — contact hub admin';
+          addBtn.title = canCreate ? '' : 'No hosted quota — contact hub admin';
         }
         renderHives(data.hives || []);
       } catch(e) {
@@ -536,7 +536,7 @@ const dashboardHTML = `<!DOCTYPE html>
         document.getElementById('hives-container').innerHTML =
           '<div class="empty-state">' +
           '<p style="font-size:1.2rem;margin-bottom:8px">No hives yet</p>' +
-          '<p>Log in to a local hive dashboard to see it here, or create a SaaS hive.</p>' +
+          '<p>Log in to a local hive dashboard to see it here, or create a hosted hive.</p>' +
           '</div>';
         return;
       }
@@ -546,10 +546,10 @@ const dashboardHTML = `<!DOCTYPE html>
         var rp = repoPath(h);
         var repoLink = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" class="repo-link">' + esc(h.primaryRepo) + '</a>' : '';
         var repoCount = (h.repos || []).length;
-        var isLocal = !h.id || !h.id.startsWith('saas-');
+        var isLocal = !h.id || !h.id.startsWith('hosted-') || h.id.startsWith('saas-');
         var canConvert = isLocal && h.role === 'owner' && (_userQuota < 0 || _userQuota > _userUsed);
         var convertBtn = canConvert ?
-          '<button onclick="openConvert(this)" data-org="' + esc(h.org) + '" data-repos="' + esc((h.repos||[]).join(', ')) + '" data-primary="' + esc(h.primaryRepo) + '" data-level="' + (h.acmmLevel||1) + '" data-name="' + esc(h.name||'') + '" style="padding:3px 10px;background:var(--accent);color:#000;border:none;border-radius:4px;cursor:pointer;font-size:0.7rem;white-space:nowrap">Convert to SaaS</button>' : '';
+          '<button onclick="openConvert(this)" data-org="' + esc(h.org) + '" data-repos="' + esc((h.repos||[]).join(', ')) + '" data-primary="' + esc(h.primaryRepo) + '" data-level="' + (h.acmmLevel||1) + '" data-name="' + esc(h.name||'') + '" style="padding:3px 10px;background:var(--accent);color:#000;border:none;border-radius:4px;cursor:pointer;font-size:0.7rem;white-space:nowrap">Convert to Hosted</button>' : '';
         return '<tr>' +
           '<td>' + (i + 1) + '</td>' +
           '<td>' + dot + '<span class="hive-name">' + esc(h.name || h.id) + '</span><br><span class="hive-org">' + esc(h.org) + '</span></td>' +
@@ -621,7 +621,7 @@ const dashboardHTML = `<!DOCTYPE html>
           hiveRows += '<table style="width:100%;border-collapse:collapse"><thead><tr style="color:var(--muted);font-size:0.7rem"><th style="text-align:left;padding:4px 8px">Hive ID</th><th>Role</th><th>Type</th><th>Link</th></tr></thead><tbody>';
           hiveIds.forEach(function(hid) {
             var role = hivesObj[hid];
-            var isSaas = hid.startsWith('saas-');
+            var isSaas = hid.startsWith('hosted-') || h.id.startsWith('saas-');
             var link = isSaas ? '<a href="https://' + esc(hid) + '.hive.kubestellar.io" target="_blank" class="dash-link">' + esc(hid) + '.hive.kubestellar.io</a>' : '<span style="color:var(--muted)">local</span>';
             var typeBadge = isSaas ? '<span style="color:#60a5fa">hosted</span>' : '<span style="color:#9ca3af">local</span>';
             hiveRows += '<tr><td style="padding:4px 8px">' + esc(hid) + '</td><td style="text-align:center">' + esc(role) + '</td><td style="text-align:center">' + typeBadge + '</td><td>' + link + '</td></tr>';

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -64,7 +64,7 @@ func generateHiveID(org, repo string) string {
 	for i := range suffix {
 		suffix[i] = chars[rand.Intn(len(chars))]
 	}
-	return fmt.Sprintf("saas-%s-%s-%s", sanitize(org), sanitize(short), string(suffix))
+	return fmt.Sprintf("hosted-%s-%s-%s", sanitize(org), sanitize(short), string(suffix))
 }
 
 func sanitize(s string) string {
@@ -147,7 +147,7 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, logger *slog.Logger) err
 
 	data := map[string]any{
 		"ID":             h.ID,
-		"Namespace":      "hive-saas-" + h.ID,
+		"Namespace":      "hive-hosted-" + h.ID,
 		"Org":            h.Org,
 		"Repos":          reposYAML,
 		"PrimaryRepo":    h.PrimaryRepo,
@@ -210,7 +210,7 @@ func StartProvisionWatcher(logger *slog.Logger, mu *sync.RWMutex) {
 				continue
 			}
 
-			ns := "hive-saas-" + h.ID
+			ns := "hive-hosted-" + h.ID
 			cmd := exec.Command("kubectl", "get", "deployment", "hive", "-n", ns, "-o", "jsonpath={.status.availableReplicas}")
 			out, err := cmd.Output()
 			if err != nil {

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -133,7 +133,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		ActiveContributors: payload.Contributors.Active,
 		Owner:              payload.Owner,
 		HiveType: func() string {
-			if strings.HasPrefix(payload.HiveID, "saas-") {
+			if strings.HasPrefix(payload.HiveID, "hosted-") || strings.HasPrefix(payload.HiveID, "saas-") {
 				return "hosted"
 			}
 			return "local"

--- a/v2/pkg/hub/static/get-started.html
+++ b/v2/pkg/hub/static/get-started.html
@@ -94,14 +94,14 @@ open http://localhost:3001</code></pre>
 HIVE_HUB_URL=https://hive.kubestellar.io</code></pre>
     <p>Your hive will appear in the Active Hives table within 5 minutes. Set <code>HIVE_PUBLIC=false</code> to keep it private.</p>
 
-    <h2>Option 2: SaaS <span class="badge badge-ready">Ready</span></h2>
+    <h2>Option 2: Hosted <span class="badge badge-ready">Ready</span></h2>
     <p>Run a hosted hive instance on our infrastructure. Login with GitHub to get started.</p>
     <div class="card">
       <h3>How it works</h3>
       <ol>
         <li><a href="/login"><strong>Login with GitHub</strong></a> at hive.kubestellar.io</li>
-        <li>View your local hives and manage SaaS instances from your <a href="/dashboard">dashboard</a></li>
-        <li>Click "Add SaaS Hive" to provision a new instance</li>
+        <li>View your local hives and manage hosted instances from your <a href="/dashboard">dashboard</a></li>
+        <li>Click "Add Hosted Hive" to provision a new instance</li>
         <li>Invite contributors to run agents (you don't need your own compute)</li>
         <li>Manage access: read-only, read-write, or owner per user</li>
       </ol>

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -221,7 +221,7 @@
         var repoLink = repoPath ? '<a href="https://github.com/' + esc(repoPath) + '" target="_blank" class="repo-link">' + esc(h.primaryRepo) + '</a>' : '';
         var repoCount = (h.repos || []).length;
         var htype = (h.hiveType || 'local') === 'hosted'
-          ? '<span style="display:inline-block;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:rgba(59,130,246,0.15);color:#60a5fa;border:1px solid rgba(59,130,246,0.3)" title="Hosted on hive.kubestellar.io SaaS">hosted</span>'
+          ? '<span style="display:inline-block;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:rgba(59,130,246,0.15);color:#60a5fa;border:1px solid rgba(59,130,246,0.3)" title="Hosted on hive.kubestellar.io">hosted</span>'
           : '<span style="display:inline-block;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:rgba(107,114,128,0.15);color:#9ca3af;border:1px solid rgba(107,114,128,0.3)" title="Self-hosted by the owner">local</span>';
         return '<tr>' +
           '<td>' + (i + 1) + '</td>' +


### PR DESCRIPTION
## Summary
- All user-facing "SaaS" text replaced with "Hosted"
- New hive IDs: `hosted-` prefix (subdomains: `hosted-myorg-repo.hive.kubestellar.io`)
- K8s namespaces: `hive-hosted-` prefix
- Backward compatible: existing `saas-` prefixed hives still recognized
- Buttons: "Add Hosted Hive", "Convert to Hosted", "Create Hosted Hive"
- Get Started: "Option 2: Hosted"

## Test plan
- [ ] No user-facing "SaaS" text visible anywhere on the site
- [ ] New hosted hives get `hosted-` prefix IDs
- [ ] Existing `saas-` hives still work (backward compat)