### PR TITLE
fix: PEM YAML escaping, provisioning hives in table, admin flicker

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -197,6 +197,39 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	seen := make(map[string]bool)
+	for _, h := range result {
+		seen[h.ID] = true
+	}
+	for hiveID, role := range user.Hives {
+		if seen[hiveID] {
+			continue
+		}
+		if strings.HasPrefix(hiveID, "hosted-") || strings.HasPrefix(hiveID, "saas-") {
+			sh := loadSaaSHive(hiveID)
+			if sh != nil {
+				entry := MyHiveEntry{
+					RegistryEntry: RegistryEntry{
+						ID:          sh.ID,
+						Name:        sh.Org + "/" + sh.PrimaryRepo,
+						Org:         sh.Org,
+						Repos:       sh.Repos,
+						PrimaryRepo: sh.PrimaryRepo,
+						ACMMLevel:   sh.ACMMLevel,
+						HiveType:    "hosted",
+					},
+					Role: role,
+				}
+				if sh.Status == "provisioning" {
+					entry.GovernorMode = "PROVISIONING"
+				} else if sh.Status == "error" {
+					entry.GovernorMode = "ERROR"
+				}
+				result = append(result, entry)
+			}
+		}
+	}
+
 	if len(user.Hives) > 0 {
 		saveSaaSUser(user)
 	}
@@ -587,15 +620,22 @@ const dashboardHTML = `<!DOCTYPE html>
     window.addEventListener('focus', function() { loadHives(); loadAdminUsers(); });
 
     var _allUsers = [];
+    var _adminLoaded = false;
     async function loadAdminUsers() {
       try {
         var resp = await fetch('/api/saas/admin/users');
-        if (resp.status === 403) return;
+        if (resp.status === 403) {
+          if (!_adminLoaded) document.getElementById('admin-section').style.display = 'none';
+          return;
+        }
+        _adminLoaded = true;
         document.getElementById('admin-section').style.display = '';
         var data = await resp.json();
         _allUsers = data.users || [];
         renderUsers(_allUsers);
-      } catch(e) {}
+      } catch(e) {
+        if (!_adminLoaded) document.getElementById('admin-section').style.display = 'none';
+      }
     }
 
     function filterUsers() {
@@ -713,7 +753,7 @@ const dashboardHTML = `<!DOCTYPE html>
   </script>
 
   <div id="create-modal" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:100;align-items:center;justify-content:center">
-    <div style="background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:32px;max-width:500px;width:90%">
+    <div style="background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:32px;max-width:640px;width:90%;max-height:90vh;overflow-y:auto">
       <h2 style="font-size:1.3rem;margin-bottom:16px;color:var(--accent)">Create Hosted Hive</h2>
       <div style="margin-bottom:12px">
         <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">GitHub Organization *</label>
@@ -772,7 +812,7 @@ const dashboardHTML = `<!DOCTYPE html>
         </div>
         <div style="margin-bottom:12px">
           <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">Private Key (PEM) *</label>
-          <textarea id="f-app-key" rows="4" placeholder="-----BEGIN RSA PRIVATE KEY-----&#10;..." style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.8rem;font-family:monospace;resize:vertical"></textarea>
+          <textarea id="f-app-key" rows="6" placeholder="-----BEGIN RSA PRIVATE KEY-----&#10;Paste or drag a .pem file here...&#10;-----END RSA PRIVATE KEY-----" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.8rem;font-family:monospace;resize:vertical" ondragover="event.preventDefault();this.style.borderColor='var(--accent)'" ondragleave="this.style.borderColor='var(--border)'" ondrop="event.preventDefault();this.style.borderColor='var(--border)';var f=event.dataTransfer.files[0];if(f){var r=new FileReader();r.onload=function(){document.getElementById('f-app-key').value=r.result};r.readAsText(f)}"></textarea>
           <div style="font-size:0.7rem;color:var(--muted);margin-top:4px">Download from your <a href="https://github.com/settings/apps" target="_blank">GitHub App settings</a> → Private keys.</div>
         </div>
       </div>

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -156,7 +156,13 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, logger *slog.Logger) err
 		"UseApp":         useApp,
 		"AppID":          req.AppID,
 		"InstallationID": req.InstallationID,
-		"AppPrivateKey":  req.AppPrivateKey,
+		"AppPrivateKey": func() string {
+			lines := strings.Split(strings.TrimSpace(req.AppPrivateKey), "\n")
+			for i := range lines {
+				lines[i] = "    " + strings.TrimSpace(lines[i])
+			}
+			return strings.Join(lines, "\n")
+		}(),
 		"CPURequest":     cpuRequest,
 		"CPULimit":       cpuLimit,
 		"MemRequest":     memRequest,
@@ -286,7 +292,7 @@ type: Opaque
 stringData:
 {{- if .UseApp}}
   gh-app-key.pem: |
-    {{.AppPrivateKey}}
+{{.AppPrivateKey}}
 {{- else}}
   github-token: {{.Token}}
 {{- end}}


### PR DESCRIPTION
## Summary
- **PEM key YAML fix** — indent each line of the private key so `-----` doesn't break YAML doc separators
- **Provisioning hives in table** — My Hives shows hosted hives with "PROVISIONING" or "ERROR" status before their first heartbeat
- **Admin table flicker** — once successfully loaded, don't hide the admin section on subsequent 403s
- **Modal wider** (640px, scrollable) for PEM key entry
- **Drag-drop PEM file** onto the textarea with visual border highlight

## Test plan
- [ ] Create hosted hive with GitHub App auth — PEM key doesn't break YAML
- [ ] Provisioning hive appears in My Hives table immediately with PROVISIONING mode
- [ ] Admin users table stays visible on 30s refresh interval
- [ ] Can drag .pem file onto the Private Key textarea