### PR TITLE
fix: PR review unblocked + isWorking 15-line window + PR label retry

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -222,7 +222,7 @@ function checkTmuxIdle() {
     let hasIdlePrompt, hasCompletionMarker, isWorking;
 
     if (BACKEND === 'claude') {
-      const lastLines = text.split('\n').slice(-8).join('\n');
+      const lastLines = text.split('\n').slice(-15).join('\n');
       hasIdlePrompt = /bypass permissions|shift\+tab to cycle/.test(text);
       hasCompletionMarker = /[✻✶✽] \S+ed for \d+[ms]|Honking|tokens\)/.test(text);
       isWorking = /─.*Bash\(|Reading|Editing|Writing|Searching/.test(lastLines) || /ing…/.test(lastLines);

--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -90,11 +90,15 @@ for arg in "${args[@]}"; do
   esac
 done
 
-# Block gh issue list and gh pr list (global)
+# Block gh issue list and gh pr list (global) — except contributors listing their own PRs
 if { [ "$subcmd" = "issue" ] || [ "$subcmd" = "pr" ]; } && [ "$action" = "list" ]; then
-  echo "⛔ BLOCKED: gh $subcmd list is disabled for agents." >&2
-  echo "Read /var/run/hive-metrics/actionable.json instead." >&2
-  exit 1
+  if [[ "${HIVE_CONTRIBUTOR_MODE:-}" == "true" ]] && echo "$FULL_CMD" | grep -q "\-\-author"; then
+    : # Allow contributors to list their own PRs for review
+  else
+    echo "⛔ BLOCKED: gh $subcmd list is disabled for agents." >&2
+    echo "Read /var/run/hive-metrics/actionable.json instead." >&2
+    exit 1
+  fi
 fi
 
 # ── Mode-based enforcement (hot-reloadable via mode file) ──


### PR DESCRIPTION
## Summary
- **#60**: gh pr create retries without --label on failure (cross-repo)
- **#62**: isWorking checks last 15 lines (separator bars push indicators out of 8)
- **#64**: Allow `gh pr list --author @me` in contributor mode for PR review cycle
  (was globally blocked)

## Test plan
- [x] PR review cycle fired at 5th task completion
- [x] Context cleared before review
- [ ] `gh pr list --author @me` works in contributor mode
- [ ] PR creation succeeds on repos without hive labels