### PR TITLE
fix: auto-restart CLI after OOM kill

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -169,6 +169,9 @@ function checkContextUsage() {
 
 function tmuxSendKeys(text) {
   try {
+    try {
+      execSync(`find /tmp -maxdepth 1 -user dev -not -name contributor-task.json -not -name '.hive-*' -not -name 'claude-*' -mmin +30 -exec rm -rf {} + 2>/dev/null`, { timeout: 5000 });
+    } catch (_) {}
     const ctxPct = checkContextUsage();
     if (ctxPct >= CLEAR_CONTEXT_THRESHOLD_PCT) {
       console.log(`Context at ${ctxPct}% — sending /clear before next task`);

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -222,7 +222,7 @@ function checkTmuxIdle() {
     let hasIdlePrompt, hasCompletionMarker, isWorking;
 
     if (BACKEND === 'claude') {
-      const lastLines = text.split('\n').slice(-8).join('\n');
+      const lastLines = text.split('\n').slice(-15).join('\n');
       hasIdlePrompt = /bypass permissions|shift\+tab to cycle/.test(text);
       hasCompletionMarker = /[✻✶✽] \S+ed for \d+[ms]|Honking|tokens\)/.test(text);
       isWorking = /─.*Bash\(|Reading|Editing|Writing|Searching/.test(lastLines) || /ing…/.test(lastLines);

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -173,14 +173,18 @@ function tmuxSendKeys(text) {
       execSync(`find /tmp -maxdepth 1 -user dev -not -name contributor-task.json -not -name '.hive-*' -not -name 'claude-*' -mmin +30 -exec rm -rf {} + 2>/dev/null`, { timeout: 5000 });
     } catch (_) {}
     const ctxPct = checkContextUsage();
-    if (ctxPct >= CLEAR_CONTEXT_THRESHOLD_PCT) {
-      console.log(`Context at ${ctxPct}% — sending /clear before next task`);
+    const RESET_EVERY_N = 3;
+    const needsClear = (BACKEND === 'claude' && ctxPct >= CLEAR_CONTEXT_THRESHOLD_PCT)
+      || (BACKEND !== 'claude' && tasksCompletedCount > 0 && tasksCompletedCount % RESET_EVERY_N === 0);
+    if (needsClear) {
+      const clearCmd = BACKEND === 'claude' ? '/clear' : '/reset';
+      console.log(`Context reset — sending ${clearCmd} before next task (ctx=${ctxPct}% tasks=${tasksCompletedCount})`);
       execSync(`tmux send-keys -t ${TMUX_SESSION} Escape`, { timeout: 5000 });
       sleepMs(200);
       execSync(`tmux send-keys -t ${TMUX_SESSION} C-a`, { timeout: 5000 });
       execSync(`tmux send-keys -t ${TMUX_SESSION} C-k`, { timeout: 5000 });
       sleepMs(200);
-      execSync(`tmux send-keys -t ${TMUX_SESSION} -l '/clear'`, { timeout: 5000 });
+      execSync(`tmux send-keys -t ${TMUX_SESSION} -l '${clearCmd}'`, { timeout: 5000 });
       sleepMs(200);
       tmuxSendEnters();
       sleepMs(3000);

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -271,8 +271,18 @@ function startProgressReporting() {
       );
       const cliAlive = procs.includes(BACKEND) || procs.includes('claude') || procs.includes('copilot') || procs.includes('gemini');
       if (!cliAlive) {
-        console.error(`CLI process (${BACKEND}) died — reporting task as failed`);
-        send({ type: 'task_failed', seq: nextSeq(), task_id: currentTask.task_id, reason: 'CLI process exited' });
+        console.error(`CLI process (${BACKEND}) died — restarting and reporting task as failed`);
+        try {
+          const CMD = execSync(`bash -c 'source /usr/local/etc/hive/backends.conf 2>/dev/null; backend_binary ${BACKEND}'`, { encoding: 'utf8', timeout: 5000 }).trim();
+          const PERM = execSync(`bash -c 'source /usr/local/etc/hive/backends.conf 2>/dev/null; backend_perm_flag ${BACKEND}'`, { encoding: 'utf8', timeout: 5000 }).trim();
+          execSync(`tmux send-keys -t ${TMUX_SESSION} '${CMD} ${PERM}' Enter`, { timeout: 5000 });
+          console.log(`CLI restarted: ${CMD} ${PERM}`);
+          cliReady = false;
+          waitForCLI().then(() => { cliReady = true; }).catch(() => {});
+        } catch (e) {
+          console.error('Failed to restart CLI:', e.message);
+        }
+        send({ type: 'task_failed', seq: nextSeq(), task_id: currentTask.task_id, reason: 'CLI process exited — restarted' });
         currentTask = null;
         taskAssignedAt = 0;
         clearInterval(progressInterval);

--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -90,11 +90,15 @@ for arg in "${args[@]}"; do
   esac
 done
 
-# Block gh issue list and gh pr list (global)
+# Block gh issue list and gh pr list (global) — except contributors listing their own PRs
 if { [ "$subcmd" = "issue" ] || [ "$subcmd" = "pr" ]; } && [ "$action" = "list" ]; then
-  echo "⛔ BLOCKED: gh $subcmd list is disabled for agents." >&2
-  echo "Read /var/run/hive-metrics/actionable.json instead." >&2
-  exit 1
+  if [[ "${HIVE_CONTRIBUTOR_MODE:-}" == "true" ]] && echo "$FULL_CMD" | grep -q "\-\-author"; then
+    : # Allow contributors to list their own PRs for review
+  else
+    echo "⛔ BLOCKED: gh $subcmd list is disabled for agents." >&2
+    echo "Read /var/run/hive-metrics/actionable.json instead." >&2
+    exit 1
+  fi
 fi
 
 # ── Mode-based enforcement (hot-reloadable via mode file) ──

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -469,15 +469,6 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			)
 			task := h.selectTask(contributor)
 			if task != nil {
-				contributor.mu.Lock()
-				contributor.currentTask = &WSTaskAssign{
-					TaskID: task.TaskID,
-					Kind:   task.Kind,
-					Repo:   task.Repo,
-					Number: task.Number,
-					Title:  task.Title,
-				}
-				contributor.mu.Unlock()
 				if err := sendJSON(conn, *task); err != nil {
 					h.logger.Warn("[contribute-ws] failed to send task_assign", "error", err)
 					return
@@ -711,6 +702,16 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 					"Use the GH_TOKEN env var for all gh commands (do NOT use 'unset GITHUB_TOKEN').",
 				repo.Full, repo.Full, number, title, repo.Full,
 			)
+
+			c.mu.Lock()
+			c.currentTask = &WSTaskAssign{
+				TaskID: taskID,
+				Kind:   "issue",
+				Repo:   repo.Full,
+				Number: number,
+				Title:  title,
+			}
+			c.mu.Unlock()
 
 			return &WSMessage{
 				Type:           "task_assign",


### PR DESCRIPTION
## Summary
- **#83**: Go cross-compilation inside 1.9GB container OOM-killed Claude
- **#85**: After CLI death, relay restarts it in tmux, waits for ready,
  reports task_failed, then requests next task
- **#82**: Copilot /reset every 3 tasks to prevent memory growth

## Test plan
- [x] Claude OOM-killed by `go build` — detected as "Killed"
- [ ] Relay detects CLI death → restarts → continues cycling