### PR TITLE
fix: redact tokens from tmux_output + safer /tmp cleanup

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -220,13 +220,19 @@ function shellQuote(s) {
   return "'" + s.replace(/'/g, "'\\''") + "'";
 }
 
+function redactTokens(text) {
+  return text.replace(/gho_[A-Za-z0-9]{36}/g, 'gho_***REDACTED***')
+    .replace(/ghp_[A-Za-z0-9]{36}/g, 'ghp_***REDACTED***')
+    .replace(/ghs_[A-Za-z0-9]{36}/g, 'ghs_***REDACTED***');
+}
+
 function captureTmuxLines(n) {
   try {
     const output = execSync(
       `tmux capture-pane -t ${TMUX_SESSION} -p -S -${n} 2>/dev/null`,
       { encoding: 'utf8', timeout: 5000 }
     );
-    return output.trim().split('\n').slice(-n);
+    return output.trim().split('\n').slice(-n).map(l => redactTokens(l));
   } catch (_) {
     return [];
   }

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -170,7 +170,7 @@ function checkContextUsage() {
 function tmuxSendKeys(text) {
   try {
     try {
-      execSync(`find /tmp -maxdepth 1 -user dev -not -name contributor-task.json -not -name '.hive-*' -not -name 'claude-*' -not -name 'tmux-*' -mmin +30 -exec rm -rf {} + 2>/dev/null`, { timeout: 5000 });
+      execSync(`find /tmp -maxdepth 1 -type d -user dev -not -name 'tmux-*' -not -name 'claude-*' -not -name 'node-*' -not -name '.' -mmin +60 -exec rm -rf {} + 2>/dev/null; find /tmp -maxdepth 1 -type f -user dev -name '*.out' -o -name '*.html' -mmin +60 -exec rm -f {} + 2>/dev/null`, { timeout: 5000 });
     } catch (_) {}
     const ctxPct = checkContextUsage();
     const RESET_EVERY_N = 3;


### PR DESCRIPTION
## Summary
- **#96 SECURITY**: Copilot embeds GH_TOKEN in git push URLs visible
  in tmux output. The relay sends this to the hub in progress messages.
  Now redacts gho_/ghp_/ghs_ tokens before sending.
- **#95**: Safer /tmp cleanup preserves node cache, 60min threshold

## Test plan
- [ ] Token not visible in hub's tmux_output field
- [x] /tmp cleanup preserves tmux-*, node-*, claude-*