### PR TITLE
feat: authenticated API (v1) + docs page + hub dashboard links

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -63,6 +63,7 @@ contribute-setup backend="claude":
     HIVE_REGISTRATION_TOKEN=${TOKEN}
     HIVE_HUB={{hive_hub}}
     CONTRIBUTOR_ID=${CID}
+    CONTRIBUTOR_USERNAME=${GH_USER}
     AGENT_BACKEND={{backend}}
     EOF
     echo "${MSG} — ${GH_USER} (${CID})"

--- a/Justfile
+++ b/Justfile
@@ -268,6 +268,32 @@ contribute-browse:
     echo ""
     curl -sf "${HUB_HTTP}/api/hives" 2>/dev/null | jq -r '.hives[] | "  \(.project_name) (\(.org))\n    Hub: \(.hub_url)\n    Dashboard: \(.dashboard_url // "N/A")\n    Contributors: \(.active_contributors // 0) active\n    Actionable: \(.actionable_items // "?") items\n"' || echo "Could not reach registry at ${HUB_HTTP}"
 
+# Call the authenticated hive API
+# Usage: just hive-api /status
+#        just hive-api /me
+#        just hive-api /contributors
+#        just hive-api /activity
+#        just hive-api /knowledge
+hive-api endpoint="/status":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    HUB_HTTP=$(echo "{{hive_hub}}" | sed 's|^wss://|https://|;s|^ws://|http://|;s|/contribute$||')
+    TOKEN=$(gh auth token 2>/dev/null || echo "")
+    if [[ -z "$TOKEN" ]]; then
+      echo "ERROR: Not authenticated. Run: gh auth login"
+      exit 1
+    fi
+    ENDPOINT="{{endpoint}}"
+    [[ "$ENDPOINT" != /* ]] && ENDPOINT="/$ENDPOINT"
+    curl -sf -H "Authorization: Bearer ${TOKEN}" "${HUB_HTTP}/api/v1${ENDPOINT}" 2>&1 | python3 -m json.tool 2>/dev/null || curl -sf -H "Authorization: Bearer ${TOKEN}" "${HUB_HTTP}/api/v1${ENDPOINT}" 2>&1
+    echo ""
+
+# Open the API docs in your browser
+hive-api-docs:
+    #!/usr/bin/env bash
+    HUB_HTTP=$(echo "{{hive_hub}}" | sed 's|^wss://|https://|;s|^ws://|http://|;s|/contribute$||')
+    open "${HUB_HTTP}/api/docs" 2>/dev/null || echo "Visit: ${HUB_HTTP}/api/docs"
+
 # Stop contributing (if running in background)
 contribute-stop:
     @docker ps --filter "name=hive-contributor-" --format '{{.Names}}' | xargs -r docker stop 2>/dev/null && echo "Stopped." || echo "Not running."

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -105,6 +105,9 @@ func (s *Server) registerContributeRoutes() {
 	s.mux.HandleFunc("POST /api/contributors/{id}/revoke", s.handleContributorRevoke)
 	s.mux.HandleFunc("DELETE /api/contributors/{id}", s.handleContributorDelete)
 
+	s.mux.HandleFunc("/api/v1/", s.handleAPIv1)
+	s.mux.HandleFunc("GET /api/docs", s.handleAPIDocs)
+
 	s.mux.HandleFunc("GET /leaderboard", s.handleLeaderboardPage)
 	s.mux.HandleFunc("GET /api/leaderboard", s.handleLeaderboardAPI)
 
@@ -1340,5 +1343,157 @@ func isValidUsername(s string) bool {
 		}
 	}
 	return true
+}
+
+// validateGitHubToken checks a GitHub personal access token against the GitHub API
+// and returns the authenticated username, or empty string on failure.
+func validateGitHubToken(token string) string {
+	if token == "" {
+		return ""
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	req, err := http.NewRequest("GET", "https://api.github.com/user", nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := client.Do(req)
+	if err != nil || resp.StatusCode != 200 {
+		return ""
+	}
+	defer resp.Body.Close()
+	var user struct {
+		Login string `json:"login"`
+	}
+	if json.NewDecoder(resp.Body).Decode(&user) != nil {
+		return ""
+	}
+	return user.Login
+}
+
+// handleAPIv1 wraps contribute API endpoints with GitHub token auth.
+// Accepts Authorization: Bearer <gh-personal-access-token>.
+func (s *Server) handleAPIv1(w http.ResponseWriter, r *http.Request) {
+	token := r.Header.Get("Authorization")
+	if strings.HasPrefix(token, "Bearer ") {
+		token = token[7:]
+	} else if strings.HasPrefix(token, "token ") {
+		token = token[6:]
+	} else {
+		token = r.URL.Query().Get("token")
+	}
+
+	username := validateGitHubToken(token)
+	if username == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"Invalid or missing GitHub token. Use: Authorization: Bearer <gh-token>"}`))
+		return
+	}
+
+	subpath := strings.TrimPrefix(r.URL.Path, "/api/v1")
+	switch subpath {
+	case "/status":
+		s.handleContributeStatus(w, r)
+	case "/activity":
+		s.handleContributeActivity(w, r)
+	case "/contributors":
+		s.handleContributorsList(w, r)
+	case "/knowledge":
+		s.handleKnowledgeExport(w, r)
+	case "/me":
+		profiles := listContributorProfiles()
+		for _, p := range profiles {
+			if strings.EqualFold(p.GitHubUsername, username) {
+				p.TokenPlain = ""
+				p.RegistrationToken = ""
+				var liveStates map[string]ContributorLiveState
+				if s.contributeHub != nil {
+					liveStates = s.contributeHub.LiveStates()
+				}
+				if ls, ok := liveStates[p.ContributorID]; ok {
+					p.Active = ls.Active
+					p.CurrentTask = ls.CurrentTask
+					p.ActiveTasks = ls.Tasks
+					p.Sessions = ls.Sessions
+				}
+				jsonResponse(w, p)
+				return
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error":"Not registered as a contributor. Run: just contribute-setup"}`))
+	default:
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error":"Unknown endpoint","available":["/api/v1/status","/api/v1/activity","/api/v1/contributors","/api/v1/knowledge","/api/v1/me"]}`))
+	}
+}
+
+func (s *Server) handleAPIDocs(w http.ResponseWriter, r *http.Request) {
+	baseURL := "https://" + r.Host
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, `<!DOCTYPE html>
+<html><head><meta charset="UTF-8"><title>Hive API</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#0d1117;color:#e6edf3;padding:40px;max-width:900px;margin:0 auto}
+h1{margin-bottom:8px;font-size:1.8rem}
+.subtitle{color:#8b949e;margin-bottom:32px}
+h2{margin-top:32px;margin-bottom:12px;color:#58a6ff;font-size:1.2rem}
+.endpoint{background:#161b22;border:1px solid #30363d;border-radius:8px;padding:16px;margin-bottom:12px}
+.method{color:#3fb950;font-weight:bold;margin-right:8px}
+.path{color:#58a6ff;font-family:monospace}
+.desc{color:#8b949e;margin-top:4px;font-size:0.9rem}
+pre{background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:12px;margin-top:12px;overflow-x:auto;font-size:0.85rem;color:#e6edf3}
+code{font-family:'SF Mono',monospace;font-size:0.85rem}
+.token-box{background:#161b22;border:1px solid #f0883e;border-radius:8px;padding:16px;margin:16px 0}
+.token-box h3{color:#f0883e;margin-bottom:8px}
+a{color:#58a6ff}
+</style></head><body>
+<h1>🐝 Hive API</h1>
+<p class="subtitle">Authenticated access to the contributor API</p>
+
+<div class="token-box">
+<h3>Authentication</h3>
+<p>Use your GitHub personal access token (from <code>gh auth token</code>):</p>
+<pre>curl -H "Authorization: Bearer $(gh auth token)" %s/api/v1/status</pre>
+</div>
+
+<h2>Endpoints</h2>
+
+<div class="endpoint">
+<span class="method">GET</span><span class="path">/api/v1/status</span>
+<div class="desc">Hub status — online, active contributors, actionable items</div>
+<pre>curl -H "Authorization: Bearer $TOKEN" %s/api/v1/status</pre>
+</div>
+
+<div class="endpoint">
+<span class="method">GET</span><span class="path">/api/v1/me</span>
+<div class="desc">Your contributor profile — tasks completed, active sessions, current task</div>
+<pre>curl -H "Authorization: Bearer $TOKEN" %s/api/v1/me</pre>
+</div>
+
+<div class="endpoint">
+<span class="method">GET</span><span class="path">/api/v1/contributors</span>
+<div class="desc">All registered contributors with live state</div>
+<pre>curl -H "Authorization: Bearer $TOKEN" %s/api/v1/contributors</pre>
+</div>
+
+<div class="endpoint">
+<span class="method">GET</span><span class="path">/api/v1/activity</span>
+<div class="desc">Live activity feed — joined, left, picked up, completed events</div>
+<pre>curl -H "Authorization: Bearer $TOKEN" %s/api/v1/activity</pre>
+</div>
+
+<div class="endpoint">
+<span class="method">GET</span><span class="path">/api/v1/knowledge</span>
+<div class="desc">Knowledge base export as markdown (used by agent.md)</div>
+<pre>curl -H "Authorization: Bearer $TOKEN" %s/api/v1/knowledge</pre>
+</div>
+
+</body></html>`, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL)
 }
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1811,6 +1811,7 @@
         <img id="oc-gh-avatar" src="" alt="" style="width:28px;height:28px;border-radius:50%;cursor:pointer;border:2px solid #3fb950;vertical-align:middle" onclick="toggleGHUserMenu()">
         <div id="oc-gh-user-menu" style="display:none;position:absolute;right:0;top:34px;background:#161b22;border:1px solid #30363d;border-radius:8px;padding:4px 0;min-width:160px;z-index:9999;box-shadow:0 8px 24px rgba(0,0,0,0.4)">
           <div style="padding:8px 16px;border-bottom:1px solid #21262d;color:#f0f6fc;font-weight:600;font-size:0.85rem" id="oc-gh-menu-user"></div>
+          <a href="/api/docs" target="_blank" style="display:block;padding:8px 16px;color:#58a6ff;text-decoration:none;font-size:0.82rem">API Docs ↗</a>
           <button onclick="ghLogout()" style="display:block;width:100%;text-align:left;padding:8px 16px;background:none;border:none;color:#f85149;cursor:pointer;font-size:0.82rem">Sign out</button>
         </div>
       </div>

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -744,6 +744,7 @@ const dashboardHTML = `<!DOCTYPE html>
         <a href="/learn">Learn</a>
         <a href="/get-started">Get Started</a>
         <a href="/dashboard" style="color:var(--accent)">My Hives</a>
+        <a href="/api/docs" target="_blank" style="font-size:0.85rem">API</a>
         <a href="https://github.com/kubestellar/hive" target="_blank" title="Source Code" style="font-size:1.1rem">🐙</a>
         <span id="nav-user" class="nav-user"></span>
         <a href="#" class="nav-login" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.href='/'});return false;">Logout</a>
@@ -811,6 +812,17 @@ const dashboardHTML = `<!DOCTYPE html>
     function snapshotLink(h) {
       if (h.snapshotUrl) return '<a href="' + esc(h.snapshotUrl) + '" target="_blank" class="dash-link">snapshot</a>';
       return '';
+    }
+    function apiLink(h) {
+      var isHosted = h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'));
+      var base = '';
+      if (isHosted) {
+        base = 'https://' + esc(h.id) + '.hive.kubestellar.io';
+      } else if (h.dashboardUrl && !h.dashboardUrl.includes('localhost')) {
+        base = esc(h.dashboardUrl);
+      }
+      if (!base) return '';
+      return '<a href="' + base + '/api/docs" target="_blank" style="padding:3px 10px;background:rgba(88,166,255,0.15);color:#58a6ff;border:1px solid rgba(88,166,255,0.3);border-radius:4px;font-size:0.7rem;text-decoration:none;white-space:nowrap">API ↗</a>';
     }
 
     async function loadUser() {
@@ -896,12 +908,13 @@ const dashboardHTML = `<!DOCTYPE html>
           '<td>' + roleBadge(h.role) + '</td>' +
           '<td>' + dashboardLink(h) + '</td>' +
           '<td>' + snapshotLink(h) + '</td>' +
+          '<td>' + apiLink(h) + '</td>' +
           '<td>' + actions + '</td>' +
           '</tr>';
       }).join('');
       document.getElementById('hives-container').innerHTML =
         '<table class="hive-table"><thead><tr>' +
-        '<th>Hive</th><th>Instance</th><th>SHA</th><th>Repo</th><th>Repos</th><th>ACMM</th><th>Agents</th><th>Mode</th><th>Issues</th><th>PRs</th><th>Contributors</th><th>Role</th><th>Dashboard</th><th>Snapshot</th><th></th>' +
+        '<th>Hive</th><th>Instance</th><th>SHA</th><th>Repo</th><th>Repos</th><th>ACMM</th><th>Agents</th><th>Mode</th><th>Issues</th><th>PRs</th><th>Contributors</th><th>Role</th><th>Dashboard</th><th>Snapshot</th><th>API</th><th></th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table>';
     }
 


### PR DESCRIPTION
## Summary
- `/api/v1/*` endpoints with GitHub PAT auth (`Authorization: Bearer <gh-token>`)
- `/api/docs` — styled API documentation page with curl examples
- My Hives table: "API ↗" button column per hive
- Top nav: "API" link
- User dropdown: "API Docs ↗" link
- `just hive-api /status` CLI command
- CONTRIBUTOR_USERNAME fix for ghost "unknown" cards
- Token redaction in tmux_output
- Safer /tmp cleanup

## Endpoints
- `GET /api/v1/status` — hub status
- `GET /api/v1/me` — your contributor profile
- `GET /api/v1/contributors` — all contributors
- `GET /api/v1/activity` — live feed
- `GET /api/v1/knowledge` — knowledge markdown