### PR TITLE
fix: resilient Dockerfile git steps — unblocks container builds

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -123,13 +123,14 @@ RUN pip3 install --no-cache-dir --break-system-packages specify-cli 2>/dev/null 
     pip3 install --no-cache-dir specify-cli 2>/dev/null || \
     echo "WARN: spec-kit (specify-cli) install failed — inception will generate facts without it"
 # pub-sub-tmux: structured event streaming for AI agent tmux sessions
-RUN git clone https://github.com/kubestellar/pub-sub-tmux.git /tmp/pub-sub-tmux && \
+RUN (which git && git clone https://github.com/kubestellar/pub-sub-tmux.git /tmp/pub-sub-tmux && \
     cd /tmp/pub-sub-tmux && make install PREFIX=/usr/local && \
-    rm -rf /tmp/pub-sub-tmux
-RUN git clone -b feat/cli-agent-mode https://github.com/clubanderson/agentic-strategy-evolution /opt/nous && \
+    rm -rf /tmp/pub-sub-tmux) || \
+    echo "WARN: pub-sub-tmux install failed — skipping"
+RUN (which git && git clone -b feat/cli-agent-mode https://github.com/clubanderson/agentic-strategy-evolution /opt/nous && \
     python3 -m venv /opt/nous/venv && \
-    /opt/nous/venv/bin/pip install --no-cache-dir -e /opt/nous 2>&1 || \
-    echo "WARN: Nous pip install failed — run_campaign.py may not work"
+    /opt/nous/venv/bin/pip install --no-cache-dir -e /opt/nous 2>&1) || \
+    echo "WARN: Nous install failed — run_campaign.py may not work"
 
 EXPOSE 3001 3002 7681
 VOLUME ["/data", "/secrets"]


### PR DESCRIPTION
pub-sub-tmux and nous git clone steps gracefully fallback if git unavailable. Unblocks hub + spoke container image builds.