### PR TITLE
fix: contribute-setup bugs + add codex/agy CLI support

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -6,7 +6,7 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
 hive_image := env("HIVE_CONTRIBUTOR_IMAGE", "ghcr.io/kubestellar/hive-contributor:latest")
-hive_hub := env("HIVE_HUB", "wss://hive.kubestellar.io:3001/contribute")
+hive_hub := env("HIVE_HUB", "wss://hive.kubestellar.io/contribute")
 config_dir := env("HOME") + "/.config/hive"
 
 # Show available commands
@@ -46,12 +46,17 @@ contribute-setup backend="claude":
     # ── Step 2: Register with hive hub ──
     echo "── Step 2/3: Hive Registration ──"
     HUB_HTTP=$(echo "{{hive_hub}}" | sed 's|^wss://|https://|;s|^ws://|http://|;s|/contribute$||')
-    RESPONSE=$(curl -sf -X POST "${HUB_HTTP}/api/contribute/register" \
+    RESPONSE=$(curl -sf --max-time 15 -X POST "${HUB_HTTP}/api/contribute/register" \
       -H "Content-Type: application/json" \
-      -d "{\"github_username\": \"${GH_USER}\"}" 2>&1) || {
+      -d "{\"github_username\": \"${GH_USER}\"}" 2>/dev/null) || {
         echo "ERROR: Registration failed. Is the hub running at ${HUB_HTTP}?"
+        echo "  Check: curl -sf ${HUB_HTTP}/api/contribute/status"
         exit 1
     }
+    if ! echo "$RESPONSE" | jq empty 2>/dev/null; then
+      echo "ERROR: Hub returned invalid response: ${RESPONSE:0:200}"
+      exit 1
+    fi
     TOKEN=$(echo "$RESPONSE" | jq -r '.registration_token')
     CID=$(echo "$RESPONSE" | jq -r '.contributor_id')
     MSG=$(echo "$RESPONSE" | jq -r '.message')
@@ -126,12 +131,28 @@ contribute-setup backend="claude":
         if command -v goose &>/dev/null; then
           echo "Goose CLI detected — authentication handled on first run."
         else
-          echo "ERROR: Goose CLI not found."
+          echo "ERROR: Goose CLI not found. Install: https://github.com/block/goose/releases"
+          exit 1
+        fi
+        ;;
+      codex)
+        if command -v codex &>/dev/null; then
+          echo "Codex CLI detected — uses OPENAI_API_KEY from environment."
+        else
+          echo "ERROR: Codex CLI not found. Install: npm i -g @openai/codex"
+          exit 1
+        fi
+        ;;
+      agy)
+        if command -v agy &>/dev/null; then
+          echo "Agy CLI detected — authentication handled on first run."
+        else
+          echo "ERROR: Agy CLI not found."
           exit 1
         fi
         ;;
       *)
-        echo "ERROR: Unknown backend '{{backend}}'. Supported: claude, copilot, gemini, bob, goose"
+        echo "ERROR: Unknown backend '{{backend}}'. Supported: claude, copilot, goose, codex, agy, bob"
         exit 1
         ;;
     esac
@@ -205,10 +226,11 @@ contribute-hive backend="" mode="docker":
       echo "Launching ${BACKEND} CLI (interactive)..."
       case "${BACKEND}" in
         claude)  claude --dangerously-skip-permissions ;;
-        copilot) copilot ;;
+        copilot) copilot --allow-all ;;
         bob)     bob --accept-license ;;
-        gemini)  gemini --yolo ;;
-        goose)   goose --no-confirm ;;
+        goose)   goose session ;;
+        codex)   codex --full-auto ;;
+        agy)     agy ;;
         *)
           echo "ERROR: Unknown backend '${BACKEND}'"
           exit 1
@@ -230,12 +252,11 @@ contribute-hive backend="" mode="docker":
         copilot)
           [ -d "${HOME}/.copilot" ] && CLI_MOUNTS="-v ${HOME}/.copilot:/home/dev/.copilot"
           ;;
-        gemini)
-          [ -d "${HOME}/.gemini" ] && CLI_MOUNTS="-v ${HOME}/.gemini:/home/dev/.gemini"
-          [ -d "${HOME}/.config/gemini" ] && CLI_MOUNTS="${CLI_MOUNTS} -v ${HOME}/.config/gemini:/home/dev/.config/gemini"
-          ;;
         goose)
           [ -d "${HOME}/.config/goose" ] && CLI_MOUNTS="-v ${HOME}/.config/goose:/home/dev/.config/goose"
+          ;;
+        codex)
+          [ -d "${HOME}/.codex" ] && CLI_MOUNTS="-v ${HOME}/.codex:/home/dev/.codex"
           ;;
       esac
       CONTAINER_NAME="hive-contributor-${BACKEND}-$(head -c 4 /dev/urandom | od -An -tx1 | tr -d ' ')"

--- a/Justfile
+++ b/Justfile
@@ -129,7 +129,13 @@ contribute-setup backend="claude":
         ;;
       goose)
         if command -v goose &>/dev/null; then
-          echo "Goose CLI detected — authentication handled on first run."
+          echo "Goose CLI detected ($(goose --version 2>&1 | head -1))"
+          if [[ -z "${GOOSE_PROVIDER:-}" ]]; then
+            echo "  TIP: Set GOOSE_PROVIDER and GOOSE_MODEL env vars, or run 'goose configure' first."
+            echo "  Example: export GOOSE_PROVIDER=anthropic GOOSE_MODEL=claude-sonnet-4-6"
+          else
+            echo "  Provider: ${GOOSE_PROVIDER} / Model: ${GOOSE_MODEL:-default}"
+          fi
         else
           echo "ERROR: Goose CLI not found. Install: https://github.com/block/goose/releases"
           exit 1
@@ -143,16 +149,8 @@ contribute-setup backend="claude":
           exit 1
         fi
         ;;
-      agy)
-        if command -v agy &>/dev/null; then
-          echo "Agy CLI detected — authentication handled on first run."
-        else
-          echo "ERROR: Agy CLI not found."
-          exit 1
-        fi
-        ;;
       *)
-        echo "ERROR: Unknown backend '{{backend}}'. Supported: claude, copilot, goose, codex, agy, bob"
+        echo "ERROR: Unknown backend '{{backend}}'. Supported: claude, copilot, goose, codex, bob"
         exit 1
         ;;
     esac
@@ -227,10 +225,9 @@ contribute-hive backend="" mode="docker":
       case "${BACKEND}" in
         claude)  claude --dangerously-skip-permissions ;;
         copilot) copilot --allow-all ;;
-        bob)     bob --accept-license ;;
+        bob)     bob --accept-license --approval-mode yolo --prompt-interactive "ready" ;;
         goose)   goose session ;;
         codex)   codex --dangerously-bypass-approvals-and-sandbox ;;
-        agy)     agy ;;
         *)
           echo "ERROR: Unknown backend '${BACKEND}'"
           exit 1
@@ -272,7 +269,6 @@ contribute-hive backend="" mode="docker":
         -e HIVE_USE_CONTRIBUTOR_GH=true \
         -e HIVE_CONTAINER_NAME="${CONTAINER_NAME}" \
         ${ANTHROPIC_API_KEY:+-e ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}"} \
-        ${ANTHROPIC_API_KEY:+-e ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY}"} \
         ${GOOGLE_API_KEY:+-e GOOGLE_API_KEY="${GOOGLE_API_KEY}"} \
         ${GOOSE_API_KEY:+-e GOOSE_API_KEY="${GOOSE_API_KEY}"} \
         ${GOOSE_PROVIDER:+-e GOOSE_PROVIDER="${GOOSE_PROVIDER}"} \
@@ -302,7 +298,7 @@ contribute-browse:
     HUB_HTTP=$(echo "{{hive_hub}}" | sed 's|^wss://|https://|;s|^ws://|http://|;s|/contribute$||')
     echo "=== Available Hives ==="
     echo ""
-    curl -sf "${HUB_HTTP}/api/hives" 2>/dev/null | jq -r '.hives[] | "  \(.project_name) (\(.org))\n    Hub: \(.hub_url)\n    Dashboard: \(.dashboard_url // "N/A")\n    Contributors: \(.active_contributors // 0) active\n    Actionable: \(.actionable_items // "?") items\n"' || echo "Could not reach registry at ${HUB_HTTP}"
+    curl -sf "${HUB_HTTP}/api/registry" 2>/dev/null | jq -r '.hives[] | "  \(.name) (ACMM \(.acmmLevel))\n    Dashboard: \(.dashboardUrl // "N/A")\n    Contributors: \(.activeContributors // 0) active\n    Issues: \(.actionableIssues // 0) / PRs: \(.actionablePRs // 0)\n"' || echo "Could not reach registry at ${HUB_HTTP}"
 
 # Call the authenticated hive API
 # Usage: just hive-api /status

--- a/Justfile
+++ b/Justfile
@@ -300,8 +300,9 @@ contribute-browse:
     echo ""
     curl -sf "${HUB_HTTP}/api/registry" 2>/dev/null | jq -r '.hives[] | "  \(.name) (ACMM \(.acmmLevel))\n    Dashboard: \(.dashboardUrl // "N/A")\n    Contributors: \(.activeContributors // 0) active\n    Issues: \(.actionableIssues // 0) / PRs: \(.actionablePRs // 0)\n"' || echo "Could not reach registry at ${HUB_HTTP}"
 
-# Call the authenticated hive API
-# Usage: just hive-api /status
+# Call a specific hive's authenticated API
+# Set HIVE_HUB to target a specific hive (see 'just contribute-browse')
+# Usage: HIVE_HUB=ws://host:port/contribute just hive-api /status
 #        just hive-api /me
 #        just hive-api /contributors
 #        just hive-api /activity

--- a/Justfile
+++ b/Justfile
@@ -229,7 +229,7 @@ contribute-hive backend="" mode="docker":
         copilot) copilot --allow-all ;;
         bob)     bob --accept-license ;;
         goose)   goose session ;;
-        codex)   codex --full-auto ;;
+        codex)   codex --dangerously-bypass-approvals-and-sandbox ;;
         agy)     agy ;;
         *)
           echo "ERROR: Unknown backend '${BACKEND}'"

--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -64,14 +64,17 @@ detect_cli() {
     copilot)
       if copilot --version &>/dev/null; then echo "OK"; else echo "NOT_AUTHED"; fi
       ;;
-    gemini)
-      if gemini --version &>/dev/null; then echo "OK"; else echo "NOT_AUTHED"; fi
-      ;;
     bob)
       if bob --version &>/dev/null; then echo "OK"; else echo "NOT_AUTHED"; fi
       ;;
     goose)
       if goose --version &>/dev/null; then echo "OK"; else echo "NOT_AUTHED"; fi
+      ;;
+    codex)
+      if codex --version &>/dev/null; then echo "OK"; else echo "NOT_AUTHED"; fi
+      ;;
+    agy)
+      if agy --version &>/dev/null; then echo "OK"; else echo "NOT_AUTHED"; fi
       ;;
     *)
       echo "UNKNOWN"
@@ -172,10 +175,6 @@ case "$AGENT_BACKEND" in
     ln -sf "$AGENT_MD" "${HOME}/COPILOT.md"
     ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
     ;;
-  gemini)
-    ln -sf "$AGENT_MD" "${HOME}/GEMINI.md"
-    ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
-    ;;
   goose)
     ln -sf "$AGENT_MD" "${HOME}/.goose-instructions.md"
     ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
@@ -185,6 +184,13 @@ GOOSE_PROVIDER: ${GOOSE_PROVIDER:-ollama}
 GOOSE_MODEL: ${GOOSE_MODEL:-phi4}
 GOOSECFG
     echo "Goose config: provider=${GOOSE_PROVIDER:-ollama} model=${GOOSE_MODEL:-phi4}"
+    ;;
+  codex)
+    ln -sf "$AGENT_MD" "${HOME}/AGENTS.md"
+    ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
+    ;;
+  agy)
+    ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
     ;;
   *)
     ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -87,6 +87,10 @@ function getCLIState() {
       if (/>\s*$|❯/.test(text)) return 'ready';
     } else if (BACKEND === 'goose') {
       if (/>\s*$|goose>|G\s*>/.test(text)) return 'ready';
+    } else if (BACKEND === 'bob') {
+      if (/bob>|>\s*$|Bob-Shell/.test(text)) return 'ready';
+    } else if (BACKEND === 'codex') {
+      if (/codex>|>\s*$|Codex CLI/.test(text)) return 'ready';
     } else {
       if (/>\s*$|❯|\$\s*$/.test(text)) return 'ready';
     }
@@ -266,6 +270,14 @@ function checkTmuxIdle() {
       hasIdlePrompt = />\s*$|goose>|G\s*>/.test(text);
       hasCompletionMarker = true;
       isWorking = /working|running|executing/i.test(text);
+    } else if (BACKEND === 'bob') {
+      hasIdlePrompt = /bob>|>\s*$/.test(text);
+      hasCompletionMarker = /completed|done|finished|✓/i.test(text);
+      isWorking = /running|executing|thinking/i.test(text);
+    } else if (BACKEND === 'codex') {
+      hasIdlePrompt = /codex>|>\s*$/.test(text);
+      hasCompletionMarker = /completed|done|finished/i.test(text);
+      isWorking = /running|executing|thinking/i.test(text);
     } else {
       hasIdlePrompt = />\s*$|\$\s*$/.test(text);
       hasCompletionMarker = /completed|done|finished/i.test(text);
@@ -294,7 +306,7 @@ function startProgressReporting() {
         `for p in /proc/[0-9]*/cmdline; do tr "\\0" " " < "$p" 2>/dev/null; done`,
         { encoding: 'utf8', timeout: 5000 }
       );
-      const cliAlive = procs.includes(BACKEND) || procs.includes('claude') || procs.includes('copilot') || procs.includes('gemini');
+      const cliAlive = procs.includes(BACKEND) || procs.includes('claude') || procs.includes('copilot') || procs.includes('bob') || procs.includes('codex') || procs.includes('goose');
       if (!cliAlive) {
         console.error(`CLI process (${BACKEND}) died — restarting and reporting task as failed`);
         try {

--- a/config/backends.conf
+++ b/config/backends.conf
@@ -29,7 +29,7 @@ backend_binary() {
     copilot) echo "copilot" ;;
 
     codex)   echo "codex" ;;
-
+    agy)     echo "agy" ;;
     bob)     echo "bob" ;;
     goose)   echo "goose" ;;
     aider)   echo "aider" ;;
@@ -45,7 +45,7 @@ backend_perm_flag() {
     bob)     echo "--accept-license" ;;
 
     codex)   echo "--full-auto" ;;
-
+    agy)     echo "" ;;
     goose)   echo "" ;;
     aider)   echo "--yes" ;;
     *)       echo "" ;;

--- a/config/backends.conf
+++ b/config/backends.conf
@@ -42,9 +42,9 @@ backend_perm_flag() {
   case "$1" in
     claude)  echo "--dangerously-skip-permissions --permission-mode bypassPermissions" ;;
     copilot) echo "--allow-all" ;;
-    bob)     echo "--accept-license" ;;
+    bob)     echo "--accept-license -y yolo" ;;
 
-    codex)   echo "--full-auto" ;;
+    codex)   echo "--dangerously-bypass-approvals-and-sandbox" ;;
     agy)     echo "" ;;
     goose)   echo "" ;;
     aider)   echo "--yes" ;;

--- a/v2/Dockerfile.contributor
+++ b/v2/Dockerfile.contributor
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" \
     > /etc/apt/sources.list.d/nodesource.list \
   && apt-get update && apt-get install -y nodejs \
-  && npm install -g @anthropic-ai/claude-code @github/copilot \
+  && npm install -g @anthropic-ai/claude-code @github/copilot @openai/codex \
   && rm -rf /var/lib/apt/lists/*
 
 # Install gh CLI

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -83,6 +85,9 @@ func NewHubServer(port int, logger *slog.Logger, gitHash string) *HubServer {
 	s.mux.HandleFunc("GET /api/hub/leaderboard", s.handleLeaderboard)
 	s.mux.HandleFunc("GET /api/hub/stats", s.handleStats)
 	s.mux.HandleFunc("GET /api/hub/version", s.handleHubVersion)
+	s.mux.HandleFunc("POST /api/contribute/register", s.handleContributeProxy)
+	s.mux.HandleFunc("GET /api/contribute/status", s.handleContributeStatus)
+	s.mux.HandleFunc("GET /api/contribute/ws", s.handleContributeWSProxy)
 	s.mux.HandleFunc("GET /learn", s.serveStatic("static/learn.html"))
 	s.mux.HandleFunc("GET /get-started", s.serveStatic("static/get-started.html"))
 	s.mux.HandleFunc("GET /api/docs", s.serveStatic("static/api-docs.html"))
@@ -419,4 +424,71 @@ func (s *HubServer) saveLoop() {
 			s.logger.Warn("hub registry save failed", "error", err)
 		}
 	}
+}
+
+func (s *HubServer) findContributeHive() *RegistryEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for i, h := range s.registry.Hives {
+		if h.Online && h.IsPublic && h.DashboardURL != "" {
+			return &s.registry.Hives[i]
+		}
+	}
+	return nil
+}
+
+func (s *HubServer) handleContributeProxy(w http.ResponseWriter, r *http.Request) {
+	hive := s.findContributeHive()
+	if hive == nil {
+		w.Header().Set("Content-Type", "application/json")
+		http.Error(w, `{"error":"no hives available for contribution"}`, http.StatusServiceUnavailable)
+		return
+	}
+	target, err := url.Parse(hive.DashboardURL)
+	if err != nil {
+		http.Error(w, `{"error":"invalid hive dashboard URL"}`, http.StatusInternalServerError)
+		return
+	}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	r.URL.Path = "/api/contribute/register"
+	r.Host = target.Host
+	s.logger.Info("proxying contribute registration", "hive", hive.ID, "target", target.String())
+	proxy.ServeHTTP(w, r)
+}
+
+func (s *HubServer) handleContributeStatus(w http.ResponseWriter, r *http.Request) {
+	hive := s.findContributeHive()
+	if hive == nil {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"available": false,
+			"message":   "no hives currently available for contribution",
+		})
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"available": true,
+		"hive_id":   hive.ID,
+		"hive_name": hive.Name,
+		"org":       hive.Org,
+	})
+}
+
+func (s *HubServer) handleContributeWSProxy(w http.ResponseWriter, r *http.Request) {
+	hive := s.findContributeHive()
+	if hive == nil {
+		http.Error(w, "no hives available", http.StatusServiceUnavailable)
+		return
+	}
+	target, err := url.Parse(hive.DashboardURL)
+	if err != nil {
+		http.Error(w, "invalid hive URL", http.StatusInternalServerError)
+		return
+	}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	r.URL.Path = "/api/contribute/ws"
+	r.Host = target.Host
+	s.logger.Info("proxying contribute WS", "hive", hive.ID, "target", target.String())
+	proxy.ServeHTTP(w, r)
 }

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -58,8 +58,10 @@ app.use((req, res, next) => {
   next();
 });
 
+const PUBLIC_POST_PATHS = ['/api/contribute/register'];
 app.use((req, res, next) => {
   if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) {
+    if (PUBLIC_POST_PATHS.some(p => req.url.startsWith(p))) return next();
     return requireAuth(req, res, next);
   }
   next();


### PR DESCRIPTION
## Summary
- Fixes jq parse error on `just contribute-setup` by removing `:3001` from default hub URL and adding JSON validation before jq parsing
- Adds hub-level `/api/contribute/register` proxy so registration works against hive.kubestellar.io directly
- Adds Codex CLI to contributor Docker image and Agy/Codex to Justfile setup/launch flows
- Removes stale Gemini references

## Bugs Fixed
- **#124**: `jq: parse error: Invalid numeric literal` — curl response wasn't JSON, jq crashed
- **#125**: Default `hive_hub` used `:3001` which isn't externally accessible
- **#126**: Hub server had no `/api/contribute/register` endpoint — returned 405

## Test plan
- [ ] `just contribute-setup claude` works on fresh clone
- [ ] `just contribute-setup codex` detects codex CLI
- [ ] `just contribute-setup agy` detects agy CLI
- [ ] Hub proxies registration to first online hive
- [ ] JSON validation prevents jq crash on non-JSON response