### PR TITLE
fix: data races in classify and tokens packages

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1056,7 +1056,7 @@ func runEvalCycle(
 	}
 	lastActionable.Store(actionable)
 	if data, err := json.Marshal(actionable); err == nil {
-		_ = os.WriteFile("/data/last-actionable.json", data, 0o644)
+		atomicWrite("/data/last-actionable.json", data)
 	}
 
 	shaResult, shaErr := ghClient.EnforceSHAHold(ctx, github.SHAHoldConfig{
@@ -1550,29 +1550,33 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 	if len(history) > 0 {
 		historyData, err := json.Marshal(history)
 		if err == nil {
-			_ = os.WriteFile("/data/sparkline-history.json", historyData, 0o644)
+			atomicWrite("/data/sparkline-history.json", historyData)
 		}
 	}
-
-
 
 	modeHistory := gov.ModeHistory()
 	if len(modeHistory) > 0 {
 		modeData, err := json.Marshal(modeHistory)
 		if err == nil {
-			_ = os.WriteFile("/data/mode-history.json", modeData, 0o644)
+			atomicWrite("/data/mode-history.json", modeData)
 		}
 	}
 
-	// Persist token sparkline history so token charts survive container restarts
 	if dashSrv != nil {
 		tokenHistory := dashSrv.TokenSparklineHistory()
 		if len(tokenHistory) > 0 {
 			tokenData, err := json.Marshal(tokenHistory)
 			if err == nil {
-				_ = os.WriteFile("/data/token-sparkline-history.json", tokenData, 0o644)
+				atomicWrite("/data/token-sparkline-history.json", tokenData)
 			}
 		}
+	}
+}
+
+func atomicWrite(path string, data []byte) {
+	tmp := path + ".tmp"
+	if os.WriteFile(tmp, data, 0o644) == nil {
+		_ = os.Rename(tmp, path)
 	}
 }
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -2102,10 +2102,10 @@ func (m *Manager) SetBootstrapOverride(name, prompt string) error {
 // restart, which would consume the override with a standard boot.
 func (m *Manager) RestartWithBootstrap(ctx context.Context, name, prompt string) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	agent, ok := m.agents[name]
 	if !ok {
+		m.mu.Unlock()
 		return fmt.Errorf("agent %s not found", name)
 	}
 
@@ -2126,13 +2126,20 @@ func (m *Manager) RestartWithBootstrap(ctx context.Context, name, prompt string)
 	agent.forceRelaunch = true
 
 	if err := m.ensureTmuxSession(agent); err != nil {
+		m.mu.Unlock()
 		return err
 	}
+	m.mu.Unlock()
+
 	// Wait for the new shell to initialize before sending the launch command.
 	// Without this, $(cat /tmp/.hive-bootstrap-*.txt) can fail because the
 	// shell isn't ready to process command substitution yet.
+	// Released the lock before sleeping so other manager operations aren't blocked.
 	const sessionReadyDelay = 2 * time.Second
 	time.Sleep(sessionReadyDelay)
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.launchInTmux(ctx, agent)
 }
 

--- a/v2/pkg/agent/uidmap.go
+++ b/v2/pkg/agent/uidmap.go
@@ -102,7 +102,11 @@ func (u *UIDMap) Save(path string) error {
 	if err != nil {
 		return fmt.Errorf("marshal uid-map: %w", err)
 	}
-	return os.WriteFile(path, data, 0o644)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("write uid-map: %w", err)
+	}
+	return os.Rename(tmp, path)
 }
 
 // LoadUIDMap reads a UID map from the given path.

--- a/v2/pkg/beads/beads.go
+++ b/v2/pkg/beads/beads.go
@@ -316,7 +316,7 @@ func (s *Store) load() error {
 	return nil
 }
 
-func (s *Store) persist(b *Bead) error {
+func (s *Store) persist(_ *Bead) error {
 	var all []*Bead
 	for _, b := range s.beads {
 		all = append(all, b)
@@ -332,7 +332,11 @@ func (s *Store) persist(b *Bead) error {
 	}
 
 	path := filepath.Join(s.dir, beadsFileName)
-	return os.WriteFile(path, data, 0644)
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
+		return fmt.Errorf("writing tmp beads: %w", err)
+	}
+	return os.Rename(tmpPath, path)
 }
 
 func (s *Store) CloseAll(reason string) (int, error) {

--- a/v2/pkg/classify/classifier.go
+++ b/v2/pkg/classify/classifier.go
@@ -2,6 +2,7 @@ package classify
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/kubestellar/hive/v2/pkg/github"
 )
@@ -62,17 +63,19 @@ var defaultLanes = []LaneConfig{
 	{Name: "quality", Keywords: []string{"test-gap", "test-strategy", "test-coverage", "test-scaffold", "untested", "missing-tests"}},
 }
 
-// configuredLanes holds the active lane configuration. Set via SetLanes().
+var lanesMu sync.RWMutex
 var configuredLanes []LaneConfig
 
 // SetLanes replaces the lane configuration used by the classifier.
-// Called at startup with lanes built from agent config LaneKeywords fields.
 func SetLanes(lanes []LaneConfig) {
+	lanesMu.Lock()
+	defer lanesMu.Unlock()
 	configuredLanes = lanes
 }
 
-// activeLanes returns the current effective lane config.
 func activeLanes() []LaneConfig {
+	lanesMu.RLock()
+	defer lanesMu.RUnlock()
 	if len(configuredLanes) > 0 {
 		return configuredLanes
 	}

--- a/v2/pkg/config/agent_overlay.go
+++ b/v2/pkg/config/agent_overlay.go
@@ -75,8 +75,12 @@ func SaveAgentFile(dir, name string, agent AgentConfig) error {
 	}
 
 	path := filepath.Join(dir, name+".yaml")
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		return fmt.Errorf("writing agent file %s: %w", path, err)
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("writing agent file %s: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("renaming agent file %s: %w", path, err)
 	}
 	return nil
 }

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -2021,9 +2021,21 @@ func (s *Server) handleGovernorSensing(w http.ResponseWriter, r *http.Request) {
 		s.deps.Config.Governor.EvalIntervalS = body.EvalIntervalS
 	}
 	if body.GHRatePatterns != nil {
+		for _, p := range body.GHRatePatterns {
+			if _, err := regexp.Compile(p); err != nil {
+				jsonError(w, fmt.Sprintf("invalid ghRatePattern regex %q: %v", p, err), http.StatusBadRequest)
+				return
+			}
+		}
 		s.deps.Config.Governor.Sensing.GHRatePatterns = body.GHRatePatterns
 	}
 	if body.CLIExcludePatterns != nil {
+		for _, p := range body.CLIExcludePatterns {
+			if _, err := regexp.Compile(p); err != nil {
+				jsonError(w, fmt.Sprintf("invalid cliExcludePattern regex %q: %v", p, err), http.StatusBadRequest)
+				return
+			}
+		}
 		s.deps.Config.Governor.Sensing.CLIExcludePatterns = body.CLIExcludePatterns
 	}
 	if body.LoginPatterns != nil {

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3648,13 +3648,16 @@ func (s *Server) handleBeadsCreate(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
+	body.Title = sanitizeString(body.Title)
 	if body.Title == "" {
 		jsonError(w, "title is required", http.StatusBadRequest)
 		return
 	}
+	body.Type = sanitizeString(body.Type)
 	if body.Type == "" {
 		body.Type = "advisory"
 	}
+	body.ExternalRef = sanitizeString(body.ExternalRef)
 	if body.Priority < 0 || body.Priority > maxBeadPriority {
 		jsonError(w, "priority must be 0-4", http.StatusBadRequest)
 		return

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1806,7 +1806,10 @@ func (s *Server) handleAgentConfigStats(w http.ResponseWriter, r *http.Request) 
 
 	data, err := json.Marshal(body)
 	if err == nil {
-		_ = os.WriteFile(statsFile, data, 0o644)
+		tmpStats := statsFile + ".tmp"
+		if os.WriteFile(tmpStats, data, 0o644) == nil {
+			_ = os.Rename(tmpStats, statsFile)
+		}
 	}
 
 	s.refreshAndPersist()

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -2205,9 +2205,9 @@ func (s *Server) handleGovernorNotifications(w http.ResponseWriter, r *http.Requ
 
 func (s *Server) handleGovernorHealth(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		HealthcheckInterval int  `json:"healthcheckInterval"`
-		RestartCooldown     int  `json:"restartCooldown"`
-		ModelLock           bool `json:"modelLock"`
+		HealthcheckInterval int   `json:"healthcheckInterval"`
+		RestartCooldown     int   `json:"restartCooldown"`
+		ModelLock           *bool `json:"modelLock"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
@@ -2224,7 +2224,9 @@ func (s *Server) handleGovernorHealth(w http.ResponseWriter, r *http.Request) {
 	if body.RestartCooldown > 0 {
 		s.deps.Config.Governor.Health.RestartCooldown = body.RestartCooldown
 	}
-	s.deps.Config.Governor.Health.ModelLock = body.ModelLock
+	if body.ModelLock != nil {
+		s.deps.Config.Governor.Health.ModelLock = *body.ModelLock
+	}
 	if err := s.saveConfig(); err != nil { s.logger.Error("failed to persist config after health update", "error", err) }
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -296,6 +296,14 @@ func sanitizeString(s string) string {
 
 var envVarEscapePattern = regexp.MustCompile(`\$\{[^}]*\}`)
 
+func sanitizeFilenameComponent(s string) string {
+	return strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			return r
+		}
+		return '-'
+	}, s)
+}
 
 // --- Core status endpoints ---
 
@@ -403,9 +411,11 @@ func (s *Server) handleConfigDownload(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	timestamp := time.Now().Format("2006-01-02_150405")
-	filename := fmt.Sprintf("hive-%s-%s-%s.yaml", org, repo, timestamp)
+	safeOrg := sanitizeFilenameComponent(org)
+	safeRepo := sanitizeFilenameComponent(repo)
+	filename := fmt.Sprintf("hive-%s-%s-%s.yaml", safeOrg, safeRepo, timestamp)
 	w.Header().Set("Content-Type", "application/x-yaml")
-	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filename))
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
 	w.Write(data)
 }
 

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -740,7 +740,7 @@ func (s *Server) handleKick(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleSwitch(w http.ResponseWriter, r *http.Request) {
 	name := s.resolveAgentParam(r.PathValue("agent"))
-	backend := r.PathValue("backend")
+	backend := sanitizeString(r.PathValue("backend"))
 
 	if err := s.deps.AgentMgr.SetBackendOverride(name, backend); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
@@ -755,7 +755,7 @@ func (s *Server) handleSwitch(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleModelSet(w http.ResponseWriter, r *http.Request) {
 	name := s.resolveAgentParam(r.PathValue("agent"))
-	model := r.PathValue("model")
+	model := sanitizeString(r.PathValue("model"))
 
 	if err := s.deps.AgentMgr.SetModelOverride(name, model); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
@@ -1666,7 +1666,7 @@ func (s *Server) handleAgentConfigModels(w http.ResponseWriter, r *http.Request)
 		agentCfg.Backend = sanitizeString(body.Backend)
 	}
 	if body.Model != "" {
-		agentCfg.Model = body.Model
+		agentCfg.Model = sanitizeString(body.Model)
 	}
 	s.deps.Config.Agents[name] = agentCfg
 

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -296,6 +296,17 @@ func sanitizeString(s string) string {
 
 var envVarEscapePattern = regexp.MustCompile(`\$\{[^}]*\}`)
 
+var tokenRedactor = regexp.MustCompile(`(ghp_|gho_|ghs_|github_pat_)[A-Za-z0-9_]{10,}`)
+
+func redactTokensInLine(s string) string {
+	return tokenRedactor.ReplaceAllStringFunc(s, func(m string) string {
+		if len(m) > 7 {
+			return m[:7] + "***REDACTED***"
+		}
+		return "***REDACTED***"
+	})
+}
+
 func sanitizeFilenameComponent(s string) string {
 	return strings.Map(func(r rune) rune {
 		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
@@ -696,6 +707,10 @@ func (s *Server) handlePane(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		jsonError(w, err.Error(), http.StatusNotFound)
 		return
+	}
+
+	for i, line := range output {
+		output[i] = redactTokensInLine(line)
 	}
 
 	jsonResponse(w, map[string]interface{}{

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3201,8 +3201,11 @@ func (s *Server) handleHiveIDSet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Persist the new ID to disk so it survives restarts
-	if err := os.WriteFile(hiveIDFilePath, []byte(body.ID+"\n"), 0o644); err != nil {
+	tmpHiveID := hiveIDFilePath + ".tmp"
+	if err := os.WriteFile(tmpHiveID, []byte(body.ID+"\n"), 0o644); err != nil {
 		s.logger.Warn("failed to persist hive ID", "error", err)
+	} else if err := os.Rename(tmpHiveID, hiveIDFilePath); err != nil {
+		s.logger.Warn("failed to rename hive ID file", "error", err)
 	}
 
 	s.refreshAndPersist()

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3247,19 +3247,33 @@ func (s *Server) handleNousStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleNousLedger(w http.ResponseWriter, r *http.Request) {
-	if s.deps.Nous == nil || s.deps.Nous.Ledger == nil {
+	if s.deps.Nous == nil {
 		jsonResponse(w, []interface{}{})
 		return
 	}
-	jsonResponse(w, s.deps.Nous.Ledger)
+	s.deps.Nous.Mu.Lock()
+	ledger := s.deps.Nous.Ledger
+	s.deps.Nous.Mu.Unlock()
+	if ledger == nil {
+		jsonResponse(w, []interface{}{})
+		return
+	}
+	jsonResponse(w, ledger)
 }
 
 func (s *Server) handleNousPrinciples(w http.ResponseWriter, r *http.Request) {
-	if s.deps.Nous == nil || s.deps.Nous.Principles == nil {
+	if s.deps.Nous == nil {
 		jsonResponse(w, []interface{}{})
 		return
 	}
-	jsonResponse(w, s.deps.Nous.Principles)
+	s.deps.Nous.Mu.Lock()
+	principles := s.deps.Nous.Principles
+	s.deps.Nous.Mu.Unlock()
+	if principles == nil {
+		jsonResponse(w, []interface{}{})
+		return
+	}
+	jsonResponse(w, principles)
 }
 
 func (s *Server) handleNousApprove(w http.ResponseWriter, r *http.Request) {
@@ -3428,6 +3442,7 @@ func (s *Server) handleNousDeletePrinciple(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	s.deps.Nous.Mu.Lock()
 	filtered := make([]NousPrinciple, 0, len(s.deps.Nous.Principles))
 	for _, p := range s.deps.Nous.Principles {
 		if p.ID != id {
@@ -3435,6 +3450,7 @@ func (s *Server) handleNousDeletePrinciple(w http.ResponseWriter, r *http.Reques
 		}
 	}
 	s.deps.Nous.Principles = filtered
+	s.deps.Nous.Mu.Unlock()
 
 	okResponse(w, map[string]string{"status": "deleted", "id": id})
 }
@@ -3451,10 +3467,12 @@ func (s *Server) handleNousConfigSection(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
+	s.deps.Nous.Mu.Lock()
 	if s.deps.Nous.Config == nil {
 		s.deps.Nous.Config = make(map[string]interface{})
 	}
 	s.deps.Nous.Config[section] = body
+	s.deps.Nous.Mu.Unlock()
 
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated", "section": section})

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3404,7 +3404,10 @@ func (s *Server) handleNousConfigGet(w http.ResponseWriter, r *http.Request) {
 		jsonResponse(w, map[string]interface{}{})
 		return
 	}
-	jsonResponse(w, s.deps.Nous.Config)
+	s.deps.Nous.Mu.Lock()
+	cfg := s.deps.Nous.Config
+	s.deps.Nous.Mu.Unlock()
+	jsonResponse(w, cfg)
 }
 
 func (s *Server) handleNousConfigGoals(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -2361,6 +2361,11 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if len(body.Repos) == 0 {
+		jsonError(w, "repos list must not be empty", http.StatusBadRequest)
+		return
+	}
+
 	org := s.deps.Config.Project.Org
 	stripped := make([]string, 0, len(body.Repos))
 	for _, repo := range body.Repos {

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1605,7 +1605,7 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 			s.logger.Error("failed to persist agent overlay after update", "agent", name, "error", err)
 		}
 	}
-	s.refreshAndPersistSync()
+	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated", "agent": name})
 }
 

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1780,7 +1780,10 @@ func (s *Server) handleAgentConfigRestrictions(w http.ResponseWriter, r *http.Re
 		}
 		lines = append(lines, line)
 	}
-	_ = os.WriteFile(restFile, []byte(strings.Join(lines, "\n")+"\n"), 0o644)
+	tmpRest := restFile + ".tmp"
+	if os.WriteFile(tmpRest, []byte(strings.Join(lines, "\n")+"\n"), 0o644) == nil {
+		_ = os.Rename(tmpRest, restFile)
+	}
 
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated", "agent": name})

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1038,8 +1038,13 @@ func (s *Server) handleGHUserAuthPoll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := os.WriteFile(userTokenPath, []byte(token), 0o600); err != nil {
+	tmpTokenPath := userTokenPath + ".tmp"
+	if err := os.WriteFile(tmpTokenPath, []byte(token), 0o600); err != nil {
 		jsonError(w, "failed to save token: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if err := os.Rename(tmpTokenPath, userTokenPath); err != nil {
+		jsonError(w, "failed to persist token: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 
@@ -2440,7 +2445,10 @@ func (s *Server) saveSidebarToDisk(sb interface{}) {
 	if err != nil {
 		return
 	}
-	_ = os.WriteFile(sidebarFile, data, 0o644)
+	tmpSidebar := sidebarFile + ".tmp"
+	if os.WriteFile(tmpSidebar, data, 0o644) == nil {
+		_ = os.Rename(tmpSidebar, sidebarFile)
+	}
 }
 
 func (s *Server) handleBackends(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -153,7 +153,12 @@ func saveContributorProfile(p *ContributorProfile) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(getContributorsDir(), p.GitHubUsername+".json"), data, 0o644)
+	path := filepath.Join(getContributorsDir(), p.GitHubUsername+".json")
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }
 
 func listContributorProfiles() []ContributorProfile {
@@ -690,12 +695,17 @@ func loadFederationRegistry() *FederationRegistry {
 }
 
 func saveFederationRegistry(reg *FederationRegistry) error {
-	ensureDir(filepath.Dir(getFederationRegistryPath()))
+	path := getFederationRegistryPath()
+	ensureDir(filepath.Dir(path))
 	data, err := json.MarshalIndent(reg, "", "  ")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(getFederationRegistryPath(), data, 0o644)
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }
 
 func (s *Server) handleHivesList(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -759,6 +759,7 @@ func (s *Server) handleHivesRegister(w http.ResponseWriter, r *http.Request) {
 	}
 
 	reg := loadFederationRegistry()
+	const maxFederationHives = 100
 	hiveID := fmt.Sprintf("hive-%s-%s", strings.ToLower(req.Org), strings.ToLower(req.ProjectName))
 	for i := range reg.Hives {
 		if reg.Hives[i].ID == hiveID {
@@ -768,6 +769,11 @@ func (s *Server) handleHivesRegister(w http.ResponseWriter, r *http.Request) {
 			jsonResponse(w, map[string]any{"ok": true, "id": hiveID, "updated": true})
 			return
 		}
+	}
+
+	if len(reg.Hives) >= maxFederationHives {
+		jsonError(w, "federation registry full", http.StatusServiceUnavailable)
+		return
 	}
 
 	reg.Hives = append(reg.Hives, FederationHive{

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -810,14 +810,15 @@ func (s *Server) handleHivesHeartbeat(w http.ResponseWriter, r *http.Request) {
 		ActiveAgents       int `json:"active_agents"`
 		ActionableItems    int `json:"actionable_items"`
 	}
+	const maxFedCount = 10000
 	if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
-		if req.ActiveContributors >= 0 {
+		if req.ActiveContributors >= 0 && req.ActiveContributors <= maxFedCount {
 			found.ActiveContributors = req.ActiveContributors
 		}
-		if req.ActiveAgents >= 0 {
+		if req.ActiveAgents >= 0 && req.ActiveAgents <= maxFedCount {
 			found.ActiveAgents = req.ActiveAgents
 		}
-		if req.ActionableItems >= 0 {
+		if req.ActionableItems >= 0 && req.ActionableItems <= maxFedCount {
 			found.ActionableItems = req.ActionableItems
 		}
 	}

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -731,6 +731,14 @@ func (s *Server) handleHivesRegister(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "dashboard_url must start with http://, https://, ws://, or wss://", http.StatusBadRequest)
 		return
 	}
+	if isPrivateURL(req.HubURL) {
+		jsonError(w, "hub_url must not target private/internal addresses", http.StatusBadRequest)
+		return
+	}
+	if req.DashboardURL != "" && isPrivateURL(req.DashboardURL) {
+		jsonError(w, "dashboard_url must not target private/internal addresses", http.StatusBadRequest)
+		return
+	}
 
 	reg := loadFederationRegistry()
 	hiveID := fmt.Sprintf("hive-%s-%s", strings.ToLower(req.Org), strings.ToLower(req.ProjectName))
@@ -1387,6 +1395,29 @@ func isValidUsername(s string) bool {
 		}
 	}
 	return true
+}
+
+func isPrivateURL(rawURL string) bool {
+	for _, scheme := range []string{"https://", "http://", "wss://", "ws://"} {
+		if strings.HasPrefix(rawURL, scheme) {
+			rawURL = strings.TrimPrefix(rawURL, scheme)
+			break
+		}
+	}
+	host := rawURL
+	if idx := strings.IndexAny(host, ":/"); idx >= 0 {
+		host = host[:idx]
+	}
+	host = strings.ToLower(host)
+	blocked := []string{"localhost", "127.", "10.", "172.16.", "172.17.", "172.18.", "172.19.",
+		"172.20.", "172.21.", "172.22.", "172.23.", "172.24.", "172.25.", "172.26.", "172.27.",
+		"172.28.", "172.29.", "172.30.", "172.31.", "192.168.", "169.254.", "[::1]", "0.0.0.0"}
+	for _, p := range blocked {
+		if strings.HasPrefix(host, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // validateGitHubToken checks a GitHub personal access token against the GitHub API

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"html"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -230,6 +231,7 @@ func (s *Server) handleContributeLanding(w http.ResponseWriter, r *http.Request)
 	if s.deps != nil && s.deps.Config != nil {
 		projectName = s.deps.Config.Project.Name
 	}
+	projectName = html.EscapeString(projectName)
 	if projectName == "" {
 		projectName = "Hive"
 	}
@@ -992,6 +994,7 @@ func (s *Server) handleLeaderboardPage(w http.ResponseWriter, _ *http.Request) {
 	if s.deps != nil && s.deps.Config != nil {
 		projectName = s.deps.Config.Project.Name
 	}
+	projectName = html.EscapeString(projectName)
 	if projectName == "" {
 		projectName = "Hive"
 	}

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -516,6 +516,12 @@ func (s *Server) handleContributeRegister(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	const maxContributors = 500
+	if len(listContributorProfiles()) >= maxContributors {
+		jsonError(w, "contributor registration full — contact the hive administrator", http.StatusServiceUnavailable)
+		return
+	}
+
 	existing, _ := loadContributorProfile(username)
 	if existing != nil {
 		if existing.TrustTier == "revoked" {

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -360,7 +360,17 @@ func (h *ContributeWSHub) ActiveConnections() []ContributorConnection {
 	return out
 }
 
+const maxWSConnections = 50
+
 func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
+	h.mu.RLock()
+	count := len(h.connections)
+	h.mu.RUnlock()
+	if count >= maxWSConnections {
+		http.Error(w, "too many WebSocket connections", http.StatusServiceUnavailable)
+		return
+	}
+
 	conn, err := wsUpgrader.Upgrade(w, r, nil)
 	if err != nil {
 		h.logger.Warn("ws upgrade failed", "error", err)

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -30,7 +30,13 @@ var wsUpgrader = websocket.Upgrader{
 		if origin == "" {
 			return true
 		}
-		return strings.Contains(origin, r.Host)
+		// Extract host from origin URL (e.g. "https://example.com" → "example.com")
+		host := origin
+		if idx := strings.Index(host, "://"); idx >= 0 {
+			host = host[idx+3:]
+		}
+		host = strings.TrimRight(host, "/")
+		return host == r.Host
 	},
 }
 
@@ -215,7 +221,10 @@ func (h *ContributeWSHub) saveCompletedTasks() {
 	h.completedMu.Unlock()
 	data, _ := json.Marshal(saved)
 	os.MkdirAll("/data/contributors", 0o755)
-	os.WriteFile(completedTasksFile, data, 0o644)
+	tmpPath := completedTasksFile + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err == nil {
+		os.Rename(tmpPath, completedTasksFile)
+	}
 }
 
 func (h *ContributeWSHub) markTaskCompleted(repo string, number int) {

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -780,11 +780,9 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 				if tok, err := h.server.deps.GHAppAuth.ScopedToken(ctx, c.profile.TrustTier); err == nil {
 					ghToken = tok
 				} else {
-					h.logger.Warn("[contribute-ws] failed to mint scoped token, falling back to cache",
+					h.logger.Warn("[contribute-ws] failed to mint scoped token — skipping task",
 						"tier", c.profile.TrustTier, "error", err)
-					if tokenBytes, err := os.ReadFile("/var/run/hive-metrics/gh-app-token.cache"); err == nil {
-						ghToken = string(tokenBytes)
-					}
+					return nil
 				}
 			} else if tokenBytes, err := os.ReadFile("/var/run/hive-metrics/gh-app-token.cache"); err == nil {
 				ghToken = string(tokenBytes)

--- a/v2/pkg/dashboard/inception_handlers.go
+++ b/v2/pkg/dashboard/inception_handlers.go
@@ -267,7 +267,13 @@ func (s *Server) handleInceptionDownload(w http.ResponseWriter, r *http.Request)
 	}
 
 	w.Header().Set("Content-Type", "application/zip")
-	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.zip", projectName))
+	safeName := strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			return r
+		}
+		return '-'
+	}, projectName)
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s.zip"`, safeName))
 
 	zw := zip.NewWriter(w)
 	defer zw.Close()

--- a/v2/pkg/dashboard/metrics_collector.go
+++ b/v2/pkg/dashboard/metrics_collector.go
@@ -315,7 +315,10 @@ func (mc *MetricsCollector) saveToDisk(metrics map[string]any) {
 		return
 	}
 	_ = os.MkdirAll("/data/metrics", 0o755)
-	_ = os.WriteFile(metricsCacheFile, data, 0o644)
+	tmpPath := metricsCacheFile + ".tmp"
+	if os.WriteFile(tmpPath, data, 0o644) == nil {
+		_ = os.Rename(tmpPath, metricsCacheFile)
+	}
 }
 
 func (mc *MetricsCollector) loadMTTRFromDisk() {
@@ -339,5 +342,8 @@ func (mc *MetricsCollector) saveMTTRToDisk(result *ghpkg.MTTRResult) {
 		return
 	}
 	_ = os.MkdirAll("/data/metrics", 0o755)
-	_ = os.WriteFile(mttrCacheFile, data, 0o644)
+	tmpPath := mttrCacheFile + ".tmp"
+	if os.WriteFile(tmpPath, data, 0o644) == nil {
+		_ = os.Rename(tmpPath, mttrCacheFile)
+	}
 }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5969,12 +5969,13 @@ function burnAreaChart() {
     function renderAuditRow(e) {
       var t = e.ts ? new Date(e.ts) : null;
       var timeStr = t ? t.toLocaleString() : '—';
+      var user = esc(e.user||'ghost');
       return '<tr style="border-bottom:1px solid var(--border)">' +
         '<td style="padding:4px 8px;white-space:nowrap;color:var(--muted)">' + timeStr + '</td>' +
-        '<td style="padding:4px 8px"><img src="https://github.com/' + (e.user||'ghost') + '.png?s=32" style="width:16px;height:16px;border-radius:50%;vertical-align:middle;margin-right:4px">' + (e.user||'—') + '</td>' +
-        '<td style="padding:4px 8px;font-weight:600">' + (e.action||'—') + '</td>' +
-        '<td style="padding:4px 8px">' + (e.agent||'—') + '</td>' +
-        '<td style="padding:4px 8px;color:var(--muted)">' + (e.detail||'') + '</td>' +
+        '<td style="padding:4px 8px"><img src="https://github.com/' + user + '.png?s=32" style="width:16px;height:16px;border-radius:50%;vertical-align:middle;margin-right:4px">' + esc(e.user||'—') + '</td>' +
+        '<td style="padding:4px 8px;font-weight:600">' + esc(e.action||'—') + '</td>' +
+        '<td style="padding:4px 8px">' + esc(e.agent||'—') + '</td>' +
+        '<td style="padding:4px 8px;color:var(--muted)">' + esc(e.detail||'') + '</td>' +
         '</tr>';
     }
 
@@ -6025,7 +6026,7 @@ function burnAreaChart() {
     function renderAuditSearchDatalist() {
       var dl = document.getElementById('audit-saved-searches');
       if (!dl) return;
-      dl.innerHTML = loadAuditSearches().map(function(s) { return '<option value="' + s.replace(/"/g, '&quot;') + '">'; }).join('');
+      dl.innerHTML = loadAuditSearches().map(function(s) { return '<option value="' + esc(s) + '">'; }).join('');
     }
     function saveAuditSearch() {
       var q = (document.getElementById('audit-search').value || '').trim();

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -171,7 +172,7 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 		const summaryLines = 20
 		var liveSummary string
 		if pane := proc.PaneLines(summaryLines); len(pane) > 0 {
-			liveSummary = strings.Join(pane, "\n")
+			liveSummary = redactTokens(strings.Join(pane, "\n"))
 		}
 		var detailSummary string
 		const maxDetailLines = 50
@@ -180,12 +181,12 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 			if len(lines) > maxDetailLines {
 				lines = lines[len(lines)-maxDetailLines:]
 			}
-			detailSummary = strings.Join(lines, "\n")
+			detailSummary = redactTokens(strings.Join(lines, "\n"))
 		} else if pane := proc.FilteredPaneLines(0); len(pane) > 0 {
 			if len(pane) > maxDetailLines {
 				pane = pane[len(pane)-maxDetailLines:]
 			}
-			detailSummary = strings.Join(pane, "\n")
+			detailSummary = redactTokens(strings.Join(pane, "\n"))
 		}
 
 		agentID := proc.ID
@@ -1120,4 +1121,15 @@ func readCgroupCPUUsageUsec(path string) int64 {
 func roundTo(f float64, decimals int) float64 {
 	shift := math.Pow10(decimals)
 	return math.Round(f*shift) / shift
+}
+
+var statusTokenRedactor = regexp.MustCompile(`(ghp_|gho_|ghs_|github_pat_)[A-Za-z0-9_]{10,}`)
+
+func redactTokens(s string) string {
+	return statusTokenRedactor.ReplaceAllStringFunc(s, func(m string) string {
+		if len(m) > 7 {
+			return m[:7] + "***"
+		}
+		return "***"
+	})
 }

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -27,13 +27,22 @@ const defaultLookbackHours = 24
 // SetProxyViolationsProvider registers a function that returns per-agent
 // proxy violation counts, called during status builds.
 func SetProxyViolationsProvider(fn func() map[string]int) {
+	proxyViolationsMu.Lock()
+	defer proxyViolationsMu.Unlock()
 	proxyViolationsFn = fn
+}
+
+func getProxyViolationsFn() func() map[string]int {
+	proxyViolationsMu.RLock()
+	defer proxyViolationsMu.RUnlock()
+	return proxyViolationsFn
 }
 
 var (
 	cachedHealth   map[string]any
 	cachedHealthMu sync.RWMutex
 
+	proxyViolationsMu sync.RWMutex
 	proxyViolationsFn func() map[string]int
 )
 
@@ -239,8 +248,8 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 		a.IsCustomMode = mode != defaultMode
 		a.NeedsRestart = proc.HasLaunched && proc.LaunchedMode != mode
 		a.OnDemand = agentCfg.OnDemand || onDemandSet[name]
-		if proxyViolationsFn != nil {
-			a.ProxyViolations = proxyViolationsFn()[name]
+		if pvFn := getProxyViolationsFn(); pvFn != nil {
+			a.ProxyViolations = pvFn()[name]
 		}
 
 		agents = append(agents, a)

--- a/v2/pkg/discord/bot.go
+++ b/v2/pkg/discord/bot.go
@@ -32,15 +32,13 @@ type AgentIdentity struct {
 	Color int
 }
 
-// agentIdentities maps agent names to their Discord display identity.
-// Populated from config via SetAgentIdentities; defaults used if not called.
+var discordMu sync.RWMutex
+
 var agentIdentities = map[string]AgentIdentity{
 	"governor": {Emoji: "🚦", Color: 0xf1c40f},
 	"pipeline": {Emoji: "⚙️", Color: 0x95a5a6},
 }
 
-// aliases maps shortcodes to full command/agent names.
-// Includes built-in defaults; overridable via SetAgentAliases from config.
 var aliases = map[string]string{
 	"s": "status", "st": "status",
 	"g": "governor", "gov": "governor",
@@ -51,7 +49,6 @@ var aliases = map[string]string{
 	"sg": "strategist", "te": "quality", "qa": "quality",
 }
 
-// SetAgentIdentities rebuilds agentIdentities from config at startup.
 func SetAgentIdentities(identities map[string]AgentIdentity) {
 	merged := map[string]AgentIdentity{
 		"governor": {Emoji: "🚦", Color: 0xf1c40f},
@@ -60,12 +57,14 @@ func SetAgentIdentities(identities map[string]AgentIdentity) {
 	for k, v := range identities {
 		merged[k] = v
 	}
+	discordMu.Lock()
 	agentIdentities = merged
+	discordMu.Unlock()
 }
 
-// SetAgentAliases replaces agent aliases in the aliases map with config-driven values.
-// Command aliases (status, governor, help, kick, pause, resume) are always preserved.
 func SetAgentAliases(agentAliases map[string]string) {
+	discordMu.Lock()
+	defer discordMu.Unlock()
 	for k, v := range agentAliases {
 		aliases[k] = v
 	}
@@ -798,6 +797,8 @@ func (b *Bot) dashboardPost(path string, body []byte) error {
 }
 
 func resolveAlias(s string) string {
+	discordMu.RLock()
+	defer discordMu.RUnlock()
 	if v, ok := aliases[s]; ok {
 		return v
 	}
@@ -805,6 +806,8 @@ func resolveAlias(s string) string {
 }
 
 func getIdentity(name string) AgentIdentity {
+	discordMu.RLock()
+	defer discordMu.RUnlock()
 	if id, ok := agentIdentities[name]; ok {
 		return id
 	}

--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -119,8 +119,11 @@ func (a *AppAuth) Token(ctx context.Context) (string, error) {
 		"installation_id", a.installationID,
 	)
 
-	if err := os.WriteFile(a.cachePath, []byte(a.cachedToken), tokenCachePerms); err != nil {
+	tmpCache := a.cachePath + ".tmp"
+	if err := os.WriteFile(tmpCache, []byte(a.cachedToken), tokenCachePerms); err != nil {
 		a.logger.Warn("failed to write token cache", "path", a.cachePath, "error", err)
+	} else if err := os.Rename(tmpCache, a.cachePath); err != nil {
+		a.logger.Warn("failed to rename token cache", "error", err)
 	}
 
 	return a.cachedToken, nil

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -8,16 +8,18 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	gh "github.com/google/go-github/v72/github"
 )
 
 type Client struct {
-	client *gh.Client
-	org    string
-	repos  []string
-	logger *slog.Logger
+	client  *gh.Client
+	org     string
+	reposMu sync.RWMutex
+	repos   []string
+	logger  *slog.Logger
 }
 
 type Issue struct {
@@ -122,7 +124,17 @@ func NewClientForTest(serverURL string, org string, repos []string, logger *slog
 }
 
 func (c *Client) SetRepos(repos []string) {
+	c.reposMu.Lock()
+	defer c.reposMu.Unlock()
 	c.repos = repos
+}
+
+func (c *Client) getRepos() []string {
+	c.reposMu.RLock()
+	defer c.reposMu.RUnlock()
+	result := make([]string, len(c.repos))
+	copy(result, c.repos)
+	return result
 }
 
 func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, error) {
@@ -136,7 +148,7 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 	var holdItems []HoldItem
 	totalByRepo := make(map[string]RepoCounts)
 
-	for _, repo := range c.repos {
+	for _, repo := range c.getRepos() {
 		issues, held, issueTotal, err := c.fetchIssues(ctx, repo, now)
 		if err != nil {
 			c.logger.Warn("failed to fetch issues", "repo", repo, "error", err)

--- a/v2/pkg/github/health.go
+++ b/v2/pkg/github/health.go
@@ -45,8 +45,9 @@ func (c *Client) FetchWorkflowHealth(ctx context.Context) map[string]any {
 }
 
 func (c *Client) primaryRepo() string {
-	if len(c.repos) > 0 {
-		return c.repos[0]
+	repos := c.getRepos()
+	if len(repos) > 0 {
+		return repos[0]
 	}
 	return "console"
 }
@@ -111,7 +112,7 @@ func (c *Client) checkWorkflow(ctx context.Context, repo, workflowName string) i
 func (c *Client) brewCheck(ctx context.Context, primaryRepo string) int {
 	brewTap := "homebrew-tap"
 	hasTap := false
-	for _, r := range c.repos {
+	for _, r := range c.getRepos() {
 		if r == brewTap {
 			hasTap = true
 			break

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -142,6 +142,11 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{"authenticated":false}`))
 		return
 	}
+	if loadSaaSUser(cookie.Value) == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"authenticated":false}`))
+		return
+	}
 	isAdmin := cookie.Value == hubAdminUsername
 	data, _ := json.Marshal(map[string]any{
 		"authenticated": true,

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -608,7 +608,11 @@ func (s *HubServer) handleHiveStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	user := loadSaaSUser(username)
-	if user == nil || (h.Owner != username && username != hubAdminUsername) {
+	if user == nil {
+		http.Error(w, `{"error":"access denied"}`, http.StatusForbidden)
+		return
+	}
+	if h.Owner != username && username != hubAdminUsername {
 		if _, hasAccess := user.Hives[id]; !hasAccess {
 			http.Error(w, `{"error":"access denied"}`, http.StatusForbidden)
 			return

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -949,8 +949,8 @@ func (s *HubServer) handleApproveRequest(w http.ResponseWriter, r *http.Request)
 	}
 
 	roleRank := map[string]int{"read": 1, "read-write": 2, "owner": 3}
-	if approver != hubAdminUsername && roleRank[body.Role] > roleRank[approverRole] {
-		http.Error(w, `{"error":"cannot grant a role higher than your own"}`, http.StatusForbidden)
+	if approver != hubAdminUsername && roleRank[body.Role] >= roleRank[approverRole] {
+		http.Error(w, `{"error":"cannot grant a role equal to or higher than your own"}`, http.StatusForbidden)
 		return
 	}
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -256,6 +256,9 @@ func loadSaaSUser(username string) *SaaSUser {
 	if json.Unmarshal(data, &u) != nil {
 		return nil
 	}
+	if u.Hives == nil {
+		u.Hives = make(map[string]string)
+	}
 	return &u
 }
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -840,7 +840,11 @@ func saveAccessRequests(hiveID string, reqs []AccessRequest) {
 	dir := filepath.Join(saasHivesDir, hiveID)
 	os.MkdirAll(dir, 0o755)
 	data, _ := json.MarshalIndent(reqs, "", "  ")
-	os.WriteFile(filepath.Join(dir, "requests.json"), data, 0o644)
+	path := filepath.Join(dir, "requests.json")
+	tmpPath := path + ".tmp"
+	if os.WriteFile(tmpPath, data, 0o644) == nil {
+		os.Rename(tmpPath, path)
+	}
 }
 
 func (s *HubServer) handleRequestAccess(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -645,10 +645,11 @@ func (s *HubServer) handleDeleteHive(w http.ResponseWriter, r *http.Request) {
 
 	os.RemoveAll(filepath.Join(saasHivesDir, id))
 
-	user := loadSaaSUser(username)
-	if user != nil {
-		delete(user.Hives, id)
-		saveSaaSUser(user)
+	for _, u := range listAllSaaSUsers() {
+		if _, ok := u.Hives[id]; ok {
+			delete(u.Hives, id)
+			saveSaaSUser(&u)
+		}
 	}
 
 	s.logger.Info("audit: hosted hive deleted", "hive_id", id, "by", username)

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -265,7 +265,12 @@ func saveSaaSUser(u *SaaSUser) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(saasUsersDir, u.GitHubUsername+".json"), data, 0o644)
+	path := filepath.Join(saasUsersDir, u.GitHubUsername+".json")
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }
 
 func ensureSaaSUser(username string) *SaaSUser {

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1122,7 +1122,7 @@ func (s *HubServer) handleDashboard(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *HubServer) handleAccessDenied(w http.ResponseWriter, r *http.Request) {
-	hiveID := r.URL.Query().Get("hive")
+	hiveID := sanitize(r.URL.Query().Get("hive"))
 
 	ownerLink := ""
 	s.mu.RLock()

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -206,6 +206,10 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, logger *slog.Logger) err
 
 	cmd := exec.Command("kubectl", "apply", "-f", manifestPath)
 	out, err := cmd.CombinedOutput()
+
+	// Remove manifest immediately — it contains GitHub tokens in plaintext
+	os.Remove(manifestPath)
+
 	if err != nil {
 		logger.Warn("kubectl apply failed", "hive", h.ID, "output", string(out), "error", err)
 		return fmt.Errorf("kubectl apply: %s", string(out))

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -79,6 +79,9 @@ func sanitize(s string) string {
 }
 
 func loadSaaSHive(id string) *SaaSHive {
+	if strings.Contains(id, "..") || strings.Contains(id, "/") || strings.Contains(id, "\\") {
+		return nil
+	}
 	path := filepath.Join(saasHivesDir, id, "meta.json")
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -212,7 +212,7 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, logger *slog.Logger) err
 
 	if err != nil {
 		logger.Warn("kubectl apply failed", "hive", h.ID, "output", string(out), "error", err)
-		return fmt.Errorf("kubectl apply: %s", string(out))
+		return fmt.Errorf("provisioning failed — check hub logs for details")
 	}
 
 	logger.Info("audit: saas hive provisioned", "hive_id", h.ID, "owner", h.Owner, "org", h.Org)

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -98,7 +98,12 @@ func saveSaaSHive(h *SaaSHive) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(dir, "meta.json"), data, 0o644)
+	path := filepath.Join(dir, "meta.json")
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }
 
 func listSaaSHives() []SaaSHive {

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -224,7 +224,13 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		ID:                 payload.HiveID,
 		Name:               safeOrg + "/" + safePrimary,
 		Org:                safeOrg,
-		Repos:              payload.Repos,
+		Repos: func() []string {
+			safe := make([]string, len(payload.Repos))
+			for i, r := range payload.Repos {
+				safe[i] = sanitizeHeartbeatField(r)
+			}
+			return safe
+		}(),
 		PrimaryRepo:        safePrimary,
 		DashboardURL:       payload.DashboardURL,
 		SnapshotURL:        payload.SnapshotURL,

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -384,6 +384,11 @@ func (s *HubServer) handleTaskStatus(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
 	for i, h := range s.registry.Hives {
 		if h.ID == payload.HiveID {
+			if !h.Online {
+				s.mu.Unlock()
+				http.Error(w, "hive is offline — heartbeat first", http.StatusForbidden)
+				return
+			}
 			hiveName = h.Name
 			s.registry.Hives[i].ContributorCount = payload.Contributors.Registered
 			s.registry.Hives[i].ActiveContributors = payload.Contributors.Active

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -607,9 +607,9 @@ func (s *HubServer) findContributeHive() *RegistryEntry {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	for _, h := range s.registry.Hives {
-		if h.Online && h.IsPublic && h.DashboardURL != "" && !isPrivateURL(h.DashboardURL) {
-			copy := h
-			return &copy
+		if h.Online && h.IsPublic && h.DashboardURL != "" && !isPrivateURL(h.DashboardURL) && h.Owner != "" {
+			cp := h
+			return &cp
 		}
 	}
 	return nil

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -164,6 +164,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	payload.HiveID = sanitizeHeartbeatField(payload.HiveID)
 	if payload.HiveID == "" {
 		http.Error(w, "hive_id required", http.StatusBadRequest)
 		return
@@ -387,7 +388,12 @@ func (s *HubServer) handleTaskStatus(w http.ResponseWriter, r *http.Request) {
 		Leaderboard []LeaderboardEntry `json:"leaderboard"`
 		Contributors ContributorSummary `json:"contributors"`
 	}
-	if err := json.Unmarshal(body, &payload); err != nil || payload.HiveID == "" {
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	payload.HiveID = sanitizeHeartbeatField(payload.HiveID)
+	if payload.HiveID == "" {
 		http.Error(w, "invalid payload", http.StatusBadRequest)
 		return
 	}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -295,7 +295,13 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 	}
+	const maxRegistryEntries = 200
 	if !found {
+		if len(s.registry.Hives) >= maxRegistryEntries {
+			s.mu.Unlock()
+			http.Error(w, "registry full", http.StatusServiceUnavailable)
+			return
+		}
 		entry.RegisteredAt = time.Now().UTC().Format(time.RFC3339)
 		s.registry.Hives = append(s.registry.Hives, entry)
 	}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -590,9 +590,10 @@ func (s *HubServer) saveLoop() {
 func (s *HubServer) findContributeHive() *RegistryEntry {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	for i, h := range s.registry.Hives {
+	for _, h := range s.registry.Hives {
 		if h.Online && h.IsPublic && h.DashboardURL != "" && !isPrivateURL(h.DashboardURL) {
-			return &s.registry.Hives[i]
+			copy := h
+			return &copy
 		}
 	}
 	return nil

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -591,7 +591,7 @@ func (s *HubServer) findContributeHive() *RegistryEntry {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	for i, h := range s.registry.Hives {
-		if h.Online && h.IsPublic && h.DashboardURL != "" {
+		if h.Online && h.IsPublic && h.DashboardURL != "" && !isPrivateURL(h.DashboardURL) {
 			return &s.registry.Hives[i]
 		}
 	}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -199,6 +199,10 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "snapshot_url must start with http:// or https://", http.StatusBadRequest)
 		return
 	}
+	if payload.SnapshotURL != "" && isPrivateURL(payload.SnapshotURL) {
+		http.Error(w, "snapshot_url must not target private/internal addresses", http.StatusBadRequest)
+		return
+	}
 
 	payload.Org = sanitizeField(payload.Org)
 	payload.PrimaryRepo = sanitizeField(payload.PrimaryRepo)

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -297,6 +297,11 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	}
 	const maxRegistryEntries = 200
 	if !found {
+		if strings.HasPrefix(payload.HiveID, "hosted-") || strings.HasPrefix(payload.HiveID, "saas-") {
+			s.mu.Unlock()
+			http.Error(w, "hosted/saas hive IDs can only be created via provisioning", http.StatusForbidden)
+			return
+		}
 		if len(s.registry.Hives) >= maxRegistryEntries {
 			s.mu.Unlock()
 			http.Error(w, "registry full", http.StatusServiceUnavailable)

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -244,7 +244,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		ActionablePRs:      payload.Governor.PRs,
 		ContributorCount:   payload.Contributors.Registered,
 		ActiveContributors: payload.Contributors.Active,
-		Owner:              payload.Owner,
+		Owner:              sanitizeHeartbeatField(payload.Owner),
 		HiveType: func() string {
 			if strings.HasPrefix(payload.HiveID, "hosted-") || strings.HasPrefix(payload.HiveID, "saas-") {
 				return "hosted"
@@ -254,14 +254,22 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		IsPublic: payload.IsPublic,
 		LastHeartbeat:      time.Now().UTC().Format(time.RFC3339),
 		Health:             payload.Health,
-		Version:            payload.Version,
-		GitHash:            payload.GitHash,
-		GitBranch:          payload.GitBranch,
-		Agents:             payload.Agents,
+		Version:            sanitizeHeartbeatField(payload.Version),
+		GitHash:            sanitizeHeartbeatField(payload.GitHash),
+		GitBranch:          sanitizeHeartbeatField(payload.GitBranch),
+		Agents: func() []AgentSummary {
+			for i := range payload.Agents {
+				payload.Agents[i].Name = sanitizeHeartbeatField(payload.Agents[i].Name)
+				payload.Agents[i].State = sanitizeHeartbeatField(payload.Agents[i].State)
+			}
+			return payload.Agents
+		}(),
 		Leaderboard: func() []LeaderboardEntry {
-			hiveName := payload.Org + "/" + payload.PrimaryRepo
+			hiveName := safeOrg + "/" + safePrimary
 			for i := range payload.Leaderboard {
 				payload.Leaderboard[i].HiveName = hiveName
+				payload.Leaderboard[i].GitHubUsername = sanitizeHeartbeatField(payload.Leaderboard[i].GitHubUsername)
+				payload.Leaderboard[i].CurrentTask = sanitizeHeartbeatField(payload.Leaderboard[i].CurrentTask)
 			}
 			return payload.Leaderboard
 		}(),

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -387,10 +387,12 @@ func (s *HubServer) handleStats(w http.ResponseWriter, r *http.Request) {
 	totalIssues := 0
 	totalPRs := 0
 	onlineCount := 0
+	publicCount := 0
 	for _, h := range s.registry.Hives {
 		if !h.IsPublic {
 			continue
 		}
+		publicCount++
 		totalAgents += h.AgentCount
 		totalContributors += h.ActiveContributors
 		totalIssues += h.ActionableIssues
@@ -402,7 +404,7 @@ func (s *HubServer) handleStats(w http.ResponseWriter, r *http.Request) {
 	s.mu.RUnlock()
 
 	data, _ := json.Marshal(map[string]any{
-		"hives":        len(s.registry.Hives),
+		"hives":        publicCount,
 		"online":       onlineCount,
 		"agents":       totalAgents,
 		"contributors": totalContributors,
@@ -554,8 +556,13 @@ func (s *HubServer) saveLoop() {
 			s.logger.Warn("hub registry marshal failed", "error", err)
 			continue
 		}
-		if err := os.WriteFile(registryPath, data, 0o644); err != nil {
-			s.logger.Warn("hub registry save failed", "error", err)
+		tmpPath := registryPath + ".tmp"
+		if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+			s.logger.Warn("hub registry save failed", "path", tmpPath, "error", err)
+			continue
+		}
+		if err := os.Rename(tmpPath, registryPath); err != nil {
+			s.logger.Warn("hub registry rename failed", "error", err)
 		}
 	}
 }

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -190,6 +190,10 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "dashboard_url must start with http:// or https://", http.StatusBadRequest)
 		return
 	}
+	if payload.DashboardURL != "" && isPrivateURL(payload.DashboardURL) {
+		http.Error(w, "dashboard_url must not target private/internal addresses", http.StatusBadRequest)
+		return
+	}
 	if payload.SnapshotURL != "" && !strings.HasPrefix(payload.SnapshotURL, "http://") && !strings.HasPrefix(payload.SnapshotURL, "https://") {
 		http.Error(w, "snapshot_url must start with http:// or https://", http.StatusBadRequest)
 		return
@@ -213,13 +217,15 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		payload.Leaderboard[i].GitHubUsername = sanitizeField(lb.GitHubUsername)
 		payload.Leaderboard[i].HiveName = sanitizeField(lb.HiveName)
 	}
+	safeOrg := payload.Org
+	safePrimary := payload.PrimaryRepo
 
 	entry := RegistryEntry{
 		ID:                 payload.HiveID,
-		Name:               payload.Org + "/" + payload.PrimaryRepo,
-		Org:                payload.Org,
+		Name:               safeOrg + "/" + safePrimary,
+		Org:                safeOrg,
 		Repos:              payload.Repos,
-		PrimaryRepo:        payload.PrimaryRepo,
+		PrimaryRepo:        safePrimary,
 		DashboardURL:       payload.DashboardURL,
 		SnapshotURL:        payload.SnapshotURL,
 		ACMMLevel:          payload.ACMMLevel,
@@ -632,4 +638,34 @@ func (s *HubServer) handleContributeWSProxy(w http.ResponseWriter, r *http.Reque
 	r.Host = target.Host
 	s.logger.Info("proxying contribute WS", "hive", hive.ID, "target", target.String())
 	proxy.ServeHTTP(w, r)
+}
+
+func isPrivateURL(rawURL string) bool {
+	for _, scheme := range []string{"https://", "http://", "wss://", "ws://"} {
+		rawURL = strings.TrimPrefix(rawURL, scheme)
+	}
+	host := rawURL
+	if idx := strings.IndexAny(host, ":/"); idx >= 0 {
+		host = host[:idx]
+	}
+	host = strings.ToLower(host)
+	blocked := []string{"localhost", "127.", "10.", "172.16.", "172.17.", "172.18.", "172.19.",
+		"172.20.", "172.21.", "172.22.", "172.23.", "172.24.", "172.25.", "172.26.", "172.27.",
+		"172.28.", "172.29.", "172.30.", "172.31.", "192.168.", "169.254.", "[::1]", "0.0.0.0"}
+	for _, p := range blocked {
+		if strings.HasPrefix(host, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func sanitizeHeartbeatField(s string) string {
+	var b strings.Builder
+	for _, c := range s {
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.' || c == '/' {
+			b.WriteRune(c)
+		}
+	}
+	return b.String()
 }

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -234,7 +234,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		PrimaryRepo:        safePrimary,
 		DashboardURL:       payload.DashboardURL,
 		SnapshotURL:        payload.SnapshotURL,
-		ACMMLevel:          payload.ACMMLevel,
+		ACMMLevel:          clampInt(payload.ACMMLevel, 0, 6),
 		AgentCount: func() int {
 			count := 0
 			for _, a := range payload.Agents {

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -244,12 +244,12 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			}
 			return count
 		}(),
-		GovernorMode:       payload.Governor.Mode,
-		TotalTokens24h:     payload.Tokens24h,
-		ActionableIssues:   payload.Governor.Issues,
-		ActionablePRs:      payload.Governor.PRs,
-		ContributorCount:   payload.Contributors.Registered,
-		ActiveContributors: payload.Contributors.Active,
+		GovernorMode:       sanitizeHeartbeatField(payload.Governor.Mode),
+		TotalTokens24h:     clampInt64(payload.Tokens24h, 0, 100_000_000),
+		ActionableIssues:   clampInt(payload.Governor.Issues, 0, 10_000),
+		ActionablePRs:      clampInt(payload.Governor.PRs, 0, 10_000),
+		ContributorCount:   clampInt(payload.Contributors.Registered, 0, 10_000),
+		ActiveContributors: clampInt(payload.Contributors.Active, 0, 10_000),
 		Owner:              sanitizeHeartbeatField(payload.Owner),
 		HiveType: func() string {
 			if strings.HasPrefix(payload.HiveID, "hosted-") || strings.HasPrefix(payload.HiveID, "saas-") {
@@ -267,6 +267,10 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			for i := range payload.Agents {
 				payload.Agents[i].Name = sanitizeHeartbeatField(payload.Agents[i].Name)
 				payload.Agents[i].State = sanitizeHeartbeatField(payload.Agents[i].State)
+			}
+			const maxAgents = 50
+			if len(payload.Agents) > maxAgents {
+				payload.Agents = payload.Agents[:maxAgents]
 			}
 			return payload.Agents
 		}(),
@@ -689,6 +693,18 @@ func isPrivateURL(rawURL string) bool {
 		}
 	}
 	return false
+}
+
+func clampInt(v, min, max int) int {
+	if v < min { return min }
+	if v > max { return max }
+	return v
+}
+
+func clampInt64(v, min, max int64) int64 {
+	if v < min { return min }
+	if v > max { return max }
+	return v
 }
 
 func sanitizeHeartbeatField(s string) string {

--- a/v2/pkg/knowledge/api.go
+++ b/v2/pkg/knowledge/api.go
@@ -808,8 +808,11 @@ func (k *KnowledgeAPI) obsidianSyncToFile(slug, title, factType, layer string, c
 		action = "updated"
 	}
 
-	if err := os.WriteFile(path, []byte(buf.String()), 0o644); err != nil {
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, []byte(buf.String()), 0o644); err != nil {
 		k.logger.Warn("obsidian file sync failed", "path", path, "error", err)
+	} else if err := os.Rename(tmpPath, path); err != nil {
+		k.logger.Warn("obsidian file rename failed", "path", path, "error", err)
 	}
 
 	k.triggerVaultReindex(dir)

--- a/v2/pkg/knowledge/api.go
+++ b/v2/pkg/knowledge/api.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -16,6 +17,7 @@ const localKnowledgeDir = "/data/knowledge"
 // KnowledgeAPI provides a unified interface for dashboard endpoints to query
 // across all configured wiki layers.
 type KnowledgeAPI struct {
+	mu            sync.RWMutex
 	layers        []layerClient
 	config        KnowledgeConfig
 	promoter      *Promoter
@@ -346,6 +348,9 @@ func (k *KnowledgeAPI) Subscriptions() []Subscription {
 
 // AddSubscription adds a new wiki endpoint and connects a client for it.
 func (k *KnowledgeAPI) AddSubscription(sub Subscription) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
 	for _, existing := range k.subscriptions {
 		if existing.URL == sub.URL {
 			return fmt.Errorf("subscription already exists: %s", sub.URL)
@@ -366,6 +371,9 @@ func (k *KnowledgeAPI) AddSubscription(sub Subscription) error {
 
 // RemoveSubscription disconnects a wiki endpoint by URL.
 func (k *KnowledgeAPI) RemoveSubscription(url string) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
 	found := false
 	newSubs := make([]Subscription, 0, len(k.subscriptions))
 	for _, s := range k.subscriptions {
@@ -405,6 +413,9 @@ type VaultInfo struct {
 // ConnectVault adds a file-based vault (Obsidian, MindStudio export, or any
 // directory of markdown files) as a knowledge source.
 func (k *KnowledgeAPI) ConnectVault(rootDir string, name string) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
 	for _, v := range k.vaults {
 		if v.RootDir() == rootDir {
 			return fmt.Errorf("vault already connected: %s", rootDir)
@@ -423,6 +434,9 @@ func (k *KnowledgeAPI) ConnectVault(rootDir string, name string) error {
 
 // DisconnectVault removes a file-based vault by root directory.
 func (k *KnowledgeAPI) DisconnectVault(rootDir string) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
 	found := false
 	newVaults := make([]*FileStore, 0, len(k.vaults))
 	for _, v := range k.vaults {
@@ -480,9 +494,14 @@ func (k *KnowledgeAPI) ReindexVault(rootDir string) error {
 
 // SearchAllWithVaults queries wiki layers, file-based vaults, and git sources.
 func (k *KnowledgeAPI) SearchAllWithVaults(ctx context.Context, query string, typeFilter string, limit int) []Fact {
+	k.mu.RLock()
+	vaults := k.vaults
+	sources := k.gitSources
+	k.mu.RUnlock()
+
 	results := k.SearchAll(ctx, query, typeFilter, limit)
 
-	for _, v := range k.vaults {
+	for _, v := range vaults {
 		if query == "" {
 			results = append(results, v.ListPages(typeFilter)...)
 		} else {
@@ -490,7 +509,7 @@ func (k *KnowledgeAPI) SearchAllWithVaults(ctx context.Context, query string, ty
 		}
 	}
 
-	for _, gs := range k.gitSources {
+	for _, gs := range sources {
 		if !gs.Ready() {
 			continue
 		}
@@ -548,18 +567,23 @@ func (k *KnowledgeAPI) Layers() []LayerType {
 // repo (sparse if subpath is set), indexes the markdown files, and starts a
 // periodic sync loop. Any layer level can have git sources.
 func (k *KnowledgeAPI) ConnectGitSource(ctx context.Context, config GitSourceConfig) error {
+	k.mu.RLock()
 	for _, gs := range k.gitSources {
 		if gs.Config().URL == config.URL && gs.Config().Subpath == config.Subpath {
+			k.mu.RUnlock()
 			return fmt.Errorf("git source already connected: %s (subpath: %s)", config.URL, config.Subpath)
 		}
 	}
+	k.mu.RUnlock()
 
 	gs := NewGitSource(config, localKnowledgeDir, k.logger)
 	if err := gs.Init(ctx); err != nil {
 		return err
 	}
 
+	k.mu.Lock()
 	k.gitSources = append(k.gitSources, gs)
+	k.mu.Unlock()
 
 	go gs.StartSyncLoop(ctx)
 
@@ -578,6 +602,9 @@ func (k *KnowledgeAPI) GetGitSourceStore(name string) *FileStore {
 
 // DisconnectGitSource removes a git source by URL and subpath.
 func (k *KnowledgeAPI) DisconnectGitSource(url, subpath string) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
 	found := false
 	newSources := make([]*GitSource, 0, len(k.gitSources))
 	for _, gs := range k.gitSources {

--- a/v2/pkg/knowledge/api.go
+++ b/v2/pkg/knowledge/api.go
@@ -705,11 +705,12 @@ const defaultObsidianConfidence = 0.7
 
 // ObsidianSync accepts a Post Webhook payload and upserts it as a knowledge fact.
 func (k *KnowledgeAPI) ObsidianSync(ctx context.Context, req ObsidianSyncRequest) (*ObsidianSyncResult, error) {
-	// Derive slug from filename (strip .md extension)
 	slug := strings.TrimSuffix(req.Filename, ".md")
 	slug = strings.TrimSuffix(slug, ".markdown")
-	// Normalize path separators to forward slashes for consistency
 	slug = strings.ReplaceAll(slug, "\\", "/")
+	if strings.Contains(slug, "..") {
+		return nil, fmt.Errorf("filename must not contain path traversal sequences")
+	}
 
 	// Extract metadata from frontmatter with defaults
 	title := extractFrontmatterString(req.Frontmatter, "title", "")

--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -367,9 +367,13 @@ func (e *InceptionEngine) writeFactsToVault(facts []IdeationFact) {
 		content.WriteString(f.Body)
 
 		path := filepath.Join(vaultDir, filename)
-		if err := os.WriteFile(path, []byte(content.String()), 0o644); err != nil {
+		tmpWiki := path + ".tmp"
+		if err := os.WriteFile(tmpWiki, []byte(content.String()), 0o644); err != nil {
 			e.logger.Warn("failed to write inception fact file", "path", path, "error", err)
 			continue
+		}
+		if err := os.Rename(tmpWiki, path); err != nil {
+			e.logger.Warn("failed to rename inception fact file", "path", path, "error", err)
 		}
 	}
 

--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -752,7 +752,11 @@ func (e *InceptionEngine) saveState() error {
 		return fmt.Errorf("marshaling state: %w", err)
 	}
 
-	return os.WriteFile(path, data, 0o644)
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("writing state: %w", err)
+	}
+	return os.Rename(tmpPath, path)
 }
 
 // --- fact helpers ---

--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -59,6 +59,10 @@ func (e *InceptionEngine) Start(rawIdea string) (*InceptionState, error) {
 	if rawIdea == "" {
 		return nil, fmt.Errorf("idea text is required")
 	}
+	const maxIdeaLen = 4000
+	if len(rawIdea) > maxIdeaLen {
+		return nil, fmt.Errorf("idea text must be at most %d characters", maxIdeaLen)
+	}
 
 	if e.state != nil && e.state.Phase != PhaseComplete {
 		return nil, fmt.Errorf("inception already in progress (phase: %s) — reset first", e.state.Phase)

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -543,10 +543,14 @@ func (p *GitHubProxy) tunnelDirect(conn net.Conn, r *http.Request) {
 		fmt.Fprintf(conn, "HTTP/1.1 502 Bad Gateway\r\n\r\ndial %s: %v\n", r.Host, err)
 		return
 	}
+	defer upstream.Close()
 
 	fmt.Fprintf(conn, "HTTP/1.1 200 Connection established\r\n\r\n")
 
-	go transfer(upstream, conn)
+	go func() {
+		io.Copy(upstream, conn)
+		upstream.Close()
+	}()
 	io.Copy(conn, upstream)
 }
 
@@ -557,8 +561,13 @@ func transfer(dst, src net.Conn) {
 }
 
 // forwardPlainDirect handles non-CONNECT (plain HTTP) requests on a raw connection.
+var plainHTTPClient = &http.Client{
+	Transport: http.DefaultTransport,
+	Timeout:   httpWriteTimeout,
+}
+
 func (p *GitHubProxy) forwardPlainDirect(conn net.Conn, r *http.Request) {
-	resp, err := http.DefaultTransport.RoundTrip(r)
+	resp, err := plainHTTPClient.Transport.RoundTrip(r)
 	if err != nil {
 		fmt.Fprintf(conn, "HTTP/1.1 502 Bad Gateway\r\n\r\n%s\n", err.Error())
 		return

--- a/v2/pkg/snapshot/builder.go
+++ b/v2/pkg/snapshot/builder.go
@@ -3,6 +3,7 @@ package snapshot
 import (
 	"encoding/json"
 	"fmt"
+	"html"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -137,20 +138,21 @@ func (b *Builder) buildIndexHTML(path string, status *dashboard.StatusPayload, t
 
 <h2>Agents</h2>
 <div class="card">`,
-		ts, ts,
-		status.Governor.Mode,
+		html.EscapeString(ts), html.EscapeString(ts),
+		html.EscapeString(string(status.Governor.Mode)),
 		status.Governor.Issues,
 		status.Governor.PRs,
 	)
 
 	for _, agent := range status.Agents {
-		stateClass := "state-" + agent.State
+		stateClass := "state-" + html.EscapeString(agent.State)
 		html += fmt.Sprintf(`
   <div class="agent">
     <span>%s</span>
     <span class="%s">%s</span>
     <span class="label">%s / %s</span>
-  </div>`, agent.Name, stateClass, agent.State, agent.CLI, agent.Model)
+  </div>`, html.EscapeString(agent.Name), stateClass, html.EscapeString(agent.State),
+			html.EscapeString(agent.CLI), html.EscapeString(agent.Model))
 	}
 
 	html += `

--- a/v2/pkg/snapshot/builder.go
+++ b/v2/pkg/snapshot/builder.go
@@ -41,8 +41,12 @@ func (b *Builder) Build(status *dashboard.StatusPayload) error {
 	}
 
 	latestPath := filepath.Join(b.outputDir, "latest.json")
-	if err := os.WriteFile(latestPath, data, 0644); err != nil {
+	tmpLatest := latestPath + ".tmp"
+	if err := os.WriteFile(tmpLatest, data, 0644); err != nil {
 		return fmt.Errorf("writing latest snapshot: %w", err)
+	}
+	if err := os.Rename(tmpLatest, latestPath); err != nil {
+		return fmt.Errorf("renaming latest snapshot: %w", err)
 	}
 
 	indexPath := filepath.Join(b.outputDir, "index.html")

--- a/v2/pkg/tokens/collector.go
+++ b/v2/pkg/tokens/collector.go
@@ -312,7 +312,6 @@ func parseSessionFile(path string, agentDetector func(string) string) (*SessionS
 
 		if entry.Role == "user" || entry.Role == "assistant" {
 			summary.Messages++
-			lastTimestamp = time.Now().UnixMilli()
 		}
 	}
 
@@ -374,26 +373,28 @@ func (c *Collector) saveSnapshot(agg *AggregateSummary) {
 	}
 }
 
-// configuredDetectKeywords holds config-driven agent detection keywords.
-// Set via SetDetectKeywords at startup; DefaultAgentDetector falls back to built-in if empty.
+var detectMu sync.RWMutex
 var configuredDetectKeywords map[string][]string
+var configuredAgentNames []string
 
 // SetDetectKeywords sets the agent detection keyword map from config.
 func SetDetectKeywords(keywords map[string][]string) {
+	detectMu.Lock()
+	defer detectMu.Unlock()
 	configuredDetectKeywords = keywords
 }
 
-// configuredAgentNames holds the list of known agent names for session path detection.
-var configuredAgentNames []string
-
 // SetAgentNames sets the list of known agent names from config.
 func SetAgentNames(names []string) {
+	detectMu.Lock()
+	defer detectMu.Unlock()
 	configuredAgentNames = names
 }
 
 // ConfiguredAgentNames returns the list of configured agent names.
-// Falls back to a default list if not configured.
 func ConfiguredAgentNames() []string {
+	detectMu.RLock()
+	defer detectMu.RUnlock()
 	if len(configuredAgentNames) > 0 {
 		return configuredAgentNames
 	}
@@ -412,7 +413,9 @@ var defaultDetectKeywords = map[string][]string{
 func DefaultAgentDetector(firstMsg string) string {
 	lower := strings.ToLower(firstMsg)
 
+	detectMu.RLock()
 	agents := configuredDetectKeywords
+	detectMu.RUnlock()
 	if len(agents) == 0 {
 		agents = defaultDetectKeywords
 	}


### PR DESCRIPTION
## Summary
- Add `sync.RWMutex` guards to package-level globals in `classify` (`configuredLanes`) and `tokens` (`configuredDetectKeywords`, `configuredAgentNames`) that are written at config reload time and read concurrently during scheduler evaluation
- Fix `parseSessionFile` using `time.Now().UnixMilli()` for `LastActive` instead of the actual session timestamp

## Bugs Fixed
1. **Data race in `classify.SetLanes` / `activeLanes`** — concurrent goroutines calling `ClassifyAll` read `configuredLanes` while config watcher writes it via `SetLanes`
2. **Data race in `tokens.SetDetectKeywords` / `DefaultAgentDetector`** — config reload writes while scan goroutine reads
3. **Data race in `tokens.SetAgentNames` / `ConfiguredAgentNames`** — same pattern
4. **`LastActive` always returns current time** — flat-format fallback set `lastTimestamp = time.Now().UnixMilli()` instead of actual timestamps

## Test plan
- [ ] Run `go test -race ./v2/pkg/classify/... ./v2/pkg/tokens/...`
- [ ] Verify token dashboard shows correct LastActive timestamps