### PR TITLE
fix: hosted hive contribute auth — accept Bearer token for CLI

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -48,6 +48,7 @@ contribute-setup backend="claude":
     HUB_HTTP=$(echo "{{hive_hub}}" | sed 's|^wss://|https://|;s|^ws://|http://|;s|/contribute$||')
     RESPONSE=$(curl -sf --max-time 15 -X POST "${HUB_HTTP}/api/contribute/register" \
       -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${GH_TOKEN}" \
       -d "{\"github_username\": \"${GH_USER}\"}" 2>/dev/null) || {
         echo "ERROR: Registration failed. Is the hub running at ${HUB_HTTP}?"
         echo "  Check: curl -sf ${HUB_HTTP}/api/contribute/status"

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -144,13 +144,71 @@ func (s *HubServer) requireAuth(next http.HandlerFunc) http.HandlerFunc {
 
 func (s *HubServer) getAuthUser(r *http.Request) string {
 	cookie, err := r.Cookie("hive_hub_user")
-	if err != nil || cookie.Value == "" {
+	if err == nil && cookie.Value != "" {
+		if loadSaaSUser(cookie.Value) != nil {
+			return cookie.Value
+		}
+	}
+
+	auth := r.Header.Get("Authorization")
+	if strings.HasPrefix(auth, "Bearer ") {
+		token := strings.TrimPrefix(auth, "Bearer ")
+		if username := s.validateGitHubToken(token); username != "" {
+			return username
+		}
+	}
+
+	return ""
+}
+
+var (
+	ghTokenCacheMu sync.RWMutex
+	ghTokenCache   = map[string]ghTokenCacheEntry{}
+)
+
+const ghTokenCacheTTL = 5 * time.Minute
+
+type ghTokenCacheEntry struct {
+	username  string
+	expiresAt time.Time
+}
+
+func (s *HubServer) validateGitHubToken(token string) string {
+	if token == "" {
 		return ""
 	}
-	if loadSaaSUser(cookie.Value) == nil {
+
+	ghTokenCacheMu.RLock()
+	if entry, ok := ghTokenCache[token]; ok && time.Now().Before(entry.expiresAt) {
+		ghTokenCacheMu.RUnlock()
+		return entry.username
+	}
+	ghTokenCacheMu.RUnlock()
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	req, err := http.NewRequest("GET", "https://api.github.com/user", nil)
+	if err != nil {
 		return ""
 	}
-	return cookie.Value
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := client.Do(req)
+	if err != nil || resp.StatusCode != 200 {
+		return ""
+	}
+	defer resp.Body.Close()
+	var user struct {
+		Login string `json:"login"`
+	}
+	if json.NewDecoder(resp.Body).Decode(&user) != nil {
+		return ""
+	}
+
+	ghTokenCacheMu.Lock()
+	ghTokenCache[token] = ghTokenCacheEntry{username: user.Login, expiresAt: time.Now().Add(ghTokenCacheTTL)}
+	ghTokenCacheMu.Unlock()
+
+	return user.Login
 }
 
 func loadSaaSUser(username string) *SaaSUser {


### PR DESCRIPTION
## Summary
- Hosted hive OAuth proxy blocks CLI registration (302 redirect to login page)
- Adds GitHub token validation to `getAuthUser` — accepts `Authorization: Bearer <gh_token>` in addition to cookies
- Contributors must be authorized users (reader/writer/owner) of the hosted hive
- Justfile sends Bearer token with registration request

## Bug Fixed
- **#133**: `just contribute-setup` against hosted hive returns "Hub returned invalid response: `<html>302 Found`"

## Test plan
- [ ] `HIVE_HUB=wss://hosted-*.hive.kubestellar.io/contribute just contribute-setup claude` succeeds
- [ ] Unauthorized GitHub users still get 403
- [ ] Cookie-based browser access still works unchanged