### PR TITLE
fix: bypass OAuth proxy for /api/contribute on hosted hives

### DIFF
--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -457,4 +457,35 @@ spec:
   - hosts:
     - {{.ID}}.hive.kubestellar.io
     secretName: hive-tls
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hive-contribute
+  namespace: {{.Namespace}}
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header X-Hive-Internal "{{.DashboardToken}}";
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: {{.ID}}.hive.kubestellar.io
+    http:
+      paths:
+      - path: /api/contribute
+        pathType: Prefix
+        backend:
+          service:
+            name: hive
+            port:
+              number: 3002
+  tls:
+  - hosts:
+    - {{.ID}}.hive.kubestellar.io
+    secretName: hive-tls
 `

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -467,10 +467,6 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_set_header X-Hive-Internal "{{.DashboardToken}}";
-      proxy_set_header Upgrade $http_upgrade;
-      proxy_set_header Connection "upgrade";
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
## Summary
- Adds second Ingress for `/api/contribute/*` on hosted hives that skips OAuth `auth-url`
- WebSocket + registration now work from CLI/Docker without browser cookies
- Go backend handles auth internally (registration token for WS, username validation for register)
- Already applied live to `hosted-projectbluefin-knuckle-gjvq` — this PR updates the provision template for future hives

## Bug Fixed
- **#134**: WebSocket gets 302 from OAuth proxy — contributor relay can't connect
- **#135**: Dashboard shows registered but 0 active because WS never connects

## Test plan
- [x] `kubectl apply` second ingress on live hosted hive
- [x] `/api/contribute/status` returns JSON (no 302)
- [x] `/api/contribute/register` works without Bearer token
- [ ] `just contribute-hive` connects WebSocket successfully