### PR TITLE
fix: auto-attach tmux so user sees CLI session + auth check

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -94,14 +94,15 @@ contribute-setup backend="claude":
           echo "ERROR: Claude Code not installed. Install: npm i -g @anthropic-ai/claude-code"
           exit 1
         fi
-        if [[ -d "${HOME}/.claude" ]] || [[ -d "${HOME}/.config/claude-code" ]]; then
-          echo "Claude Code authenticated (credentials found)"
+        if claude -p "reply with OK" --max-turns 1 2>/dev/null | grep -qi "ok"; then
+          echo "Claude Code authenticated and working."
         else
-          echo "Claude Code needs authentication. Opening Claude Code..."
-          echo "Type /login then exit when done (Ctrl+C or type /exit)."
           echo ""
-          claude -p "/login"
-          echo "Claude Code authentication complete."
+          echo "Claude Code needs authentication."
+          echo "Run:  claude"
+          echo "Then type /login and follow the prompts."
+          echo "Once logged in, exit Claude (Ctrl+C) and re-run this setup."
+          exit 1
         fi
         ;;
       copilot)

--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -248,13 +248,10 @@ AUTO_DISMISS_INTERVAL=3
 ) &
 
 echo ""
-CONTAINER_NAME="${HIVE_CONTAINER_NAME:-hive-contributor}"
-echo "Contributor agent is running."
-echo "  CLI:   $CMD"
-echo "  Relay: PID $RELAY_PID"
-echo "  Tmux:  docker exec -it $CONTAINER_NAME tmux attach -t $TMUX_SESSION"
+echo "Contributor agent is running. Attaching to CLI session..."
+echo "  Press Ctrl-B then D to detach (relay keeps running)."
+echo "  Press Ctrl-C to stop contributing."
 echo ""
-echo "Press Ctrl-C to stop contributing."
 
 # Keep running until interrupted
 cleanup() {
@@ -265,4 +262,6 @@ cleanup() {
 }
 trap cleanup SIGTERM SIGINT
 
-wait "$RELAY_PID"
+# Wait for CLI to start, then attach so the user sees the session
+sleep 2
+tmux attach -t "$TMUX_SESSION" 2>/dev/null || wait "$RELAY_PID"


### PR DESCRIPTION
## Summary
- Container now auto-attaches to the tmux session so the user sees the CLI directly (including login prompts)
- `contribute-setup claude` runs a real auth check (`claude -p "reply with OK"`) instead of just checking if `~/.claude` exists

## Test plan
- [ ] `just contribute-hive` shows the Claude CLI session directly
- [ ] If Claude needs login, user sees the prompt immediately
- [ ] Ctrl-B D detaches from tmux (relay keeps running)
- [ ] Ctrl-C stops contributing