### PR TITLE
fix: ghost @unknown contributor from completed-tasks.json

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -171,7 +171,7 @@ func listContributorProfiles() []ContributorProfile {
 			continue
 		}
 		var p ContributorProfile
-		if json.Unmarshal(data, &p) == nil {
+		if json.Unmarshal(data, &p) == nil && p.GitHubUsername != "" && p.ContributorID != "" {
 			profiles = append(profiles, p)
 		}
 	}


### PR DESCRIPTION
## Summary
`completed-tasks.json` in the contributors directory unmarshals as a `ContributorProfile` with all empty fields, creating a ghost "@unknown" entry. Fix: skip entries without `GitHubUsername` and `ContributorID`.

## Bug Fixed
- **#137**: Ghost "@unknown" contributor visible on dashboard, can't be revoked or removed