### PR TITLE
fix: contributor badge counts unique users, audit section visible

### DIFF
--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -219,6 +219,18 @@ func (h *ContributeWSHub) nextSeq() int {
 func (h *ContributeWSHub) ActiveCount() int {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
+	seen := make(map[string]bool)
+	for _, c := range h.connections {
+		if c.profile != nil && c.profile.GitHubUsername != "" {
+			seen[c.profile.GitHubUsername] = true
+		}
+	}
+	return len(seen)
+}
+
+func (h *ContributeWSHub) ActiveSessionCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
 	return len(h.connections)
 }
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -434,6 +434,7 @@
     body.light-mode.oc-agent-focused #nous-section,
     body.light-mode.oc-agent-focused #knowledge-section,
     body.light-mode.oc-agent-focused #contributors-section,
+    body.light-mode.oc-agent-focused #audit-section,
     body.light-mode.oc-agent-focused #leaderboard-section { display: none; }
     body.light-mode.oc-strategy-focused #nous-section { display: block; }
     body.light-mode.oc-agent-focused .agent-card.oc-hidden { display: none; }
@@ -1853,7 +1854,7 @@
     <div class="beads" id="beads"></div>
   </div>
 
-  <div id="audit-section" style="display:none; margin-top: 16px; margin-bottom: 24px;">
+  <div id="audit-section" style="margin-top: 16px; margin-bottom: 24px;">
     <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 8px;">📋 Audit Log</h2>
     <div id="audit-panel" style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:12px;max-height:500px;overflow-y:auto">
       <div class="loading">Loading audit log...</div>


### PR DESCRIPTION
- ActiveCount() counts unique GitHub usernames not WS connections (1 user with 2 sessions = 1, not 2)
- Audit section removed display:none so it's reachable via sidebar navigation