### PR TITLE
fix: auto-dismiss trust dialog after CLI restart

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -109,6 +109,10 @@ function waitForCLI() {
       if (state === 'ready') {
         console.log('CLI ready — accepting tasks');
         resolve();
+      } else if (state === 'onboarding') {
+        console.log('Auto-dismissing trust/onboarding dialog...');
+        try { execSync(`tmux send-keys -t ${TMUX_SESSION} Enter`, { timeout: 5000 }); } catch (_) {}
+        setTimeout(check, CLI_READY_POLL_MS);
       } else if (state === 'needs-login' && !loginMessageShown) {
         loginMessageShown = true;
         console.log('');


### PR DESCRIPTION
## Summary
After OOM kill + CLI restart, Claude shows the trust folder dialog. The relay's `waitForCLI` detected `onboarding` state but didn't dismiss it — the queued task prompt was lost. Now sends Enter automatically when onboarding is detected.

## Bugs Fixed
- **#139**: Trust dialog after restart eats task prompt
- **#140**: Queued task never sent after restart