### PR TITLE
fix: upgrade contributor container to Node.js 24 for Copilot

### DIFF
--- a/v2/Dockerfile.contributor
+++ b/v2/Dockerfile.contributor
@@ -1,6 +1,6 @@
 FROM debian:bookworm-slim
 
-ARG NODE_MAJOR=22
+ARG NODE_MAJOR=24
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash curl git jq tmux python3 ca-certificates gnupg openssh-client \


### PR DESCRIPTION
Bug #144: Copilot CLI requires Node.js v24+, container had v22. Copilot crashed with SIGKILL on startup.