### PR TITLE
fix: create .config dirs in contributor Dockerfile for goose

### DIFF
--- a/v2/Dockerfile.contributor
+++ b/v2/Dockerfile.contributor
@@ -45,7 +45,8 @@ RUN mkdir -p /opt/hive/node_modules && cd /opt/hive && npm install ws
 
 # Create non-root user
 RUN useradd -m -s /bin/bash -u 1000 dev
-RUN mkdir -p /var/run/hive-metrics && chown dev:dev /var/run/hive-metrics
+RUN mkdir -p /var/run/hive-metrics /home/dev/.config/goose /home/dev/.config/gh \
+  && chown -R dev:dev /var/run/hive-metrics /home/dev/.config
 
 # Copy agent scripts
 COPY bin/contributor-agent.sh /usr/local/bin/


### PR DESCRIPTION
Bug #145: Goose crashed with 'Permission denied' creating ~/.config/goose. Pre-create .config dirs in Dockerfile.