### PR TITLE
fix: local mode uses tmux + relay, goose idle detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ examples/kubestellar/agents/agent.env
 
 # Beads ledger — runtime state, not source code
 .beads/
+node_modules/

--- a/Justfile
+++ b/Justfile
@@ -190,8 +190,10 @@ contribute-hive backend="" mode="docker":
       echo "Not set up yet. Run: just contribute-setup <cli>"
       exit 1
     fi
+    set -a
     source "{{config_dir}}/gh-auth.env"
     source "{{config_dir}}/contributor.env"
+    set +a
     # Handle "just contribute-hive local" (backward compat)
     _BACKEND="{{backend}}"
     _MODE="{{mode}}"
@@ -204,6 +206,7 @@ contribute-hive backend="" mode="docker":
     else
       BACKEND="${AGENT_BACKEND:-claude}"
     fi
+    export AGENT_BACKEND="$BACKEND"
     echo "=== Hive Contributor Agent ==="
     echo "Backend:  ${BACKEND}"
     echo "Hub:      {{hive_hub}}"
@@ -211,30 +214,62 @@ contribute-hive backend="" mode="docker":
     echo ""
 
     if [[ "$_MODE" == "local" ]]; then
-      # ── Local mode: start node relay in background + launch CLI directly ──
-      HUB="${HIVE_HUB:-{{hive_hub}}}"
-      WS_URL=$(echo "$HUB" | sed 's|/contribute/*$|/api/contribute/ws|')
-      echo "Starting local relay..."
-      echo "WebSocket: ${WS_URL}"
-      RELAY_PID=""
-      if [[ -f "v2/proxy/relay.js" ]]; then
-        HIVE_WS_URL="${WS_URL}" node v2/proxy/relay.js &
-        RELAY_PID=$!
-        trap "kill ${RELAY_PID} 2>/dev/null || true" EXIT
-        sleep 1
+      # ── Local mode: tmux session + relay (same as container, but on host) ──
+      TMUX_SESSION="hive-contributor"
+      SCRIPT_DIR="$(pwd)/bin"
+      RELAY="${SCRIPT_DIR}/contributor-relay.sh"
+
+      if [[ ! -f "$RELAY" ]]; then
+        echo "ERROR: Run from the hive repo root (need bin/contributor-relay.sh)"
+        exit 1
       fi
-      echo "Launching ${BACKEND} CLI (interactive)..."
-      case "${BACKEND}" in
-        claude)  claude --dangerously-skip-permissions ;;
-        copilot) copilot --allow-all ;;
-        bob)     bob --accept-license --approval-mode yolo --prompt-interactive "ready" ;;
-        goose)   goose session ;;
-        codex)   codex --dangerously-bypass-approvals-and-sandbox ;;
-        *)
-          echo "ERROR: Unknown backend '${BACKEND}'"
-          exit 1
-          ;;
-      esac
+
+      # Ensure ws module is available
+      if ! node -e "require('ws')" 2>/dev/null; then
+        echo "Installing ws module..."
+        npm install ws 2>/dev/null || { echo "ERROR: npm install ws failed"; exit 1; }
+      fi
+
+      # Get CLI binary and permission flags from backends.conf
+      source "${SCRIPT_DIR}/../config/backends.conf" 2>/dev/null || true
+      CMD=$(backend_binary "$BACKEND" 2>/dev/null || echo "$BACKEND")
+      PERM_FLAG=$(backend_perm_flag "$BACKEND" 2>/dev/null || echo "")
+
+      if ! command -v "$CMD" &>/dev/null; then
+        echo "ERROR: ${BACKEND} CLI not found. Install it first."
+        exit 1
+      fi
+
+      # Create tmux session with the CLI
+      tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
+      tmux new-session -d -s "$TMUX_SESSION" -x 200 -y 50
+      tmux send-keys -t "$TMUX_SESSION" "$CMD $PERM_FLAG" Enter
+
+      # Start the relay
+      export HIVE_AGENT_SESSION="$TMUX_SESSION"
+      export HIVE_CONTRIBUTOR_MODE=true
+      export HIVE_CONTRIBUTOR_CLI="$BACKEND"
+      export NODE_PATH="${NODE_PATH:-$(pwd)/node_modules}"
+      echo "Starting relay + ${BACKEND} in tmux session '${TMUX_SESSION}'..."
+
+      cleanup() {
+        echo "Shutting down..."
+        kill "$RELAY_PID" 2>/dev/null || true
+        tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
+        exit 0
+      }
+      trap cleanup SIGTERM SIGINT EXIT
+
+      node "$RELAY" &
+      RELAY_PID=$!
+      echo ""
+      echo "✓ Contributor running in local mode."
+      echo "  CLI:    $CMD (tmux session: $TMUX_SESSION)"
+      echo "  Relay:  PID $RELAY_PID"
+      echo "  Attach: tmux attach -t $TMUX_SESSION"
+      echo ""
+      echo "Relay logs:"
+      wait "$RELAY_PID"
     else
       # ── Docker mode: stop existing, start fresh ──
       if [[ "${HIVE_SKIP_PULL:-}" != "true" ]]; then

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -24,7 +24,9 @@ const REG_TOKEN = process.env.HIVE_REGISTRATION_TOKEN;
 const BACKEND = process.env.AGENT_BACKEND || 'claude';
 const MODEL = process.env.AGENT_MODEL || '';
 const TMUX_SESSION = process.env.HIVE_AGENT_SESSION || 'contributor';
-const GH_TOKEN_CACHE = '/var/run/hive-metrics/gh-app-token.cache';
+const GH_TOKEN_CACHE = fs.existsSync('/var/run/hive-metrics')
+  ? '/var/run/hive-metrics/gh-app-token.cache'
+  : '/tmp/hive-gh-token.cache';
 const TASK_FILE = '/tmp/contributor-task.json';
 
 const TMUX_TAIL_LINES = 15;
@@ -86,7 +88,7 @@ function getCLIState() {
       if (/not authenticated|login required/i.test(text)) return 'needs-login';
       if (/>\s*$|❯/.test(text)) return 'ready';
     } else if (BACKEND === 'goose') {
-      if (/>\s*$|goose>|G\s*>/.test(text)) return 'ready';
+      if (/goose is ready|> Enter to send|>\s*$|goose>|G\s*>/.test(text)) return 'ready';
     } else if (BACKEND === 'bob') {
       if (/bob>|>\s*$|Bob-Shell/.test(text)) return 'ready';
     } else if (BACKEND === 'codex') {
@@ -271,9 +273,9 @@ function checkTmuxIdle() {
       hasCompletionMarker = /completed|Done|finished/i.test(text);
       isWorking = /Thinking|Running|Searching/i.test(text);
     } else if (BACKEND === 'goose') {
-      hasIdlePrompt = />\s*$|goose>|G\s*>/.test(text);
+      hasIdlePrompt = /goose is ready|> Enter to send|>\s*$|goose>|G\s*>/.test(text);
       hasCompletionMarker = true;
-      isWorking = /working|running|executing/i.test(text);
+      isWorking = /working|running|executing|calling/i.test(text);
     } else if (BACKEND === 'bob') {
       hasIdlePrompt = /bob>|>\s*$/.test(text);
       hasCompletionMarker = /completed|done|finished|✓/i.test(text);


### PR DESCRIPTION
## Summary
- Local mode now uses tmux + relay (same architecture as container mode)
- Goose idle detection patterns fixed: matches 'goose is ready' and '> Enter to send'
- AGENT_BACKEND properly exported so relay uses correct backend
- GH_TOKEN_CACHE falls back to /tmp on host (no /var/run/hive-metrics)
- All contributor.env vars exported with `set -a`

## Bugs Fixed
- **#146**: GH token cache path crash on host
- **#147**: Relay used wrong backend (claude instead of goose) from contributor.env

## Verified
- Goose + ollama + llama3.2:3b working in local mode against hosted hive
- Task assigned, prompt sent, goose processing with 32s inference time