### PR TITLE
feat: add Pi (pi.dev) as supported CLI backend

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -151,8 +151,18 @@ contribute-setup backend="claude":
           exit 1
         fi
         ;;
+      pi)
+        if command -v pi &>/dev/null; then
+          echo "Pi CLI detected ($(pi --version 2>&1 | head -1))"
+          echo "  Supports: Anthropic, OpenAI, Google, Ollama, and more"
+          echo "  Set provider: --provider anthropic --model claude-sonnet-4-6"
+        else
+          echo "ERROR: Pi CLI not found. Install: curl -fsSL https://pi.dev/install.sh | sh"
+          exit 1
+        fi
+        ;;
       *)
-        echo "ERROR: Unknown backend '{{backend}}'. Supported: claude, copilot, goose, codex, bob"
+        echo "ERROR: Unknown backend '{{backend}}'. Supported: claude, copilot, goose, codex, pi, bob"
         exit 1
         ;;
     esac

--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -73,6 +73,9 @@ detect_cli() {
     codex)
       if codex --version &>/dev/null; then echo "OK"; else echo "NOT_AUTHED"; fi
       ;;
+    pi)
+      if pi --version &>/dev/null; then echo "OK"; else echo "NOT_AUTHED"; fi
+      ;;
     agy)
       if agy --version &>/dev/null; then echo "OK"; else echo "NOT_AUTHED"; fi
       ;;
@@ -186,6 +189,10 @@ GOOSECFG
     echo "Goose config: provider=${GOOSE_PROVIDER:-ollama} model=${GOOSE_MODEL:-phi4}"
     ;;
   codex)
+    ln -sf "$AGENT_MD" "${HOME}/AGENTS.md"
+    ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
+    ;;
+  pi)
     ln -sf "$AGENT_MD" "${HOME}/AGENTS.md"
     ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
     ;;

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -93,6 +93,8 @@ function getCLIState() {
       if (/bob>|>\s*$|Bob-Shell/.test(text)) return 'ready';
     } else if (BACKEND === 'codex') {
       if (/codex>|>\s*$|Codex CLI/.test(text)) return 'ready';
+    } else if (BACKEND === 'pi') {
+      if (/>\s*$|pi>|pi \d|ready/.test(text)) return 'ready';
     } else {
       if (/>\s*$|❯|\$\s*$/.test(text)) return 'ready';
     }
@@ -284,6 +286,10 @@ function checkTmuxIdle() {
       hasIdlePrompt = /codex>|>\s*$/.test(text);
       hasCompletionMarker = /completed|done|finished/i.test(text);
       isWorking = /running|executing|thinking/i.test(text);
+    } else if (BACKEND === 'pi') {
+      hasIdlePrompt = />\s*$|pi>/.test(text);
+      hasCompletionMarker = /completed|done|finished|tokens\)/i.test(text);
+      isWorking = /Reading|Writing|Bash|Editing|thinking/i.test(text);
     } else {
       hasIdlePrompt = />\s*$|\$\s*$/.test(text);
       hasCompletionMarker = /completed|done|finished/i.test(text);
@@ -312,7 +318,7 @@ function startProgressReporting() {
         `for p in /proc/[0-9]*/cmdline; do tr "\\0" " " < "$p" 2>/dev/null; done`,
         { encoding: 'utf8', timeout: 5000 }
       );
-      const cliAlive = procs.includes(BACKEND) || procs.includes('claude') || procs.includes('copilot') || procs.includes('bob') || procs.includes('codex') || procs.includes('goose');
+      const cliAlive = procs.includes(BACKEND) || procs.includes('claude') || procs.includes('copilot') || procs.includes('bob') || procs.includes('codex') || procs.includes('goose') || procs.includes('pi');
       if (!cliAlive) {
         console.error(`CLI process (${BACKEND}) died — restarting and reporting task as failed`);
         try {

--- a/config/backends.conf
+++ b/config/backends.conf
@@ -20,7 +20,7 @@
 
 # ── Supported backends ──────────────────────────────────────────────────
 # BACKEND_NAME  BINARY   PERM_FLAG                    MODEL_FLAG
-KNOWN_BACKENDS="claude copilot goose codex agy bob aider"
+KNOWN_BACKENDS="claude copilot goose codex agy bob pi aider"
 
 # ── Backend → binary mapping ────────────────────────────────────────────
 backend_binary() {
@@ -32,6 +32,7 @@ backend_binary() {
     agy)     echo "agy" ;;
     bob)     echo "bob" ;;
     goose)   echo "goose" ;;
+    pi)      echo "pi" ;;
     aider)   echo "aider" ;;
     *)       echo "$1" ;;
   esac
@@ -47,6 +48,7 @@ backend_perm_flag() {
     codex)   echo "--dangerously-bypass-approvals-and-sandbox" ;;
     agy)     echo "" ;;
     goose)   echo "" ;;
+    pi)      echo "" ;;
     aider)   echo "--yes" ;;
     *)       echo "" ;;
   esac

--- a/v2/Dockerfile.contributor
+++ b/v2/Dockerfile.contributor
@@ -32,6 +32,10 @@ RUN ARCH=$(dpkg --print-architecture) \
   && rm -rf /tmp/goose-dl \
   || echo "Goose install skipped"
 
+# Install Pi CLI (pi.dev coding agent)
+RUN curl -fsSL https://pi.dev/install.sh | sh \
+  || echo "Pi install skipped"
+
 # Install Go (needed for building/testing Go projects)
 ARG GO_VERSION=1.24.4
 RUN ARCH=$(dpkg --print-architecture) \

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -339,6 +339,7 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 <option value="copilot" data-install="" data-host-install="">GitHub Copilot</option>
 <option value="bob" data-install="" data-host-install="npm i -g bobshell">Bob</option>
 <option value="goose" data-install="" data-host-install="# Install: https://github.com/block/goose/releases\n# Configure provider: goose configure\nexport GOOSE_PROVIDER=ollama GOOSE_MODEL=phi4">Goose</option>
+<option value="pi" data-install="" data-host-install="curl -fsSL https://pi.dev/install.sh | sh">Pi</option>
 </select>
 <label style="font-size:.9rem;color:#8b949e">Mode:</label>
 <select id="mode-select" style="background:#161b22;color:#e6edf3;border:1px solid #30363d;border-radius:6px;padding:6px 12px;font-size:.9rem;cursor:pointer">

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -625,6 +625,7 @@
     .value.idle { color: var(--muted); }
     .value.copilot { color: var(--cyan); }
     .value.claude { color: var(--purple); }
+    .value.pi { color: var(--green); }
     .doing { font-size: 0.65rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: pre-wrap; line-height: 1.3; min-height: 5.6em; max-height: 30em; overflow-y: auto; width: 100%; }
     .summary-age { display: inline-block; font-size: 0.6rem; font-style: normal; border-radius: 3px; padding: 1px 5px; margin-right: 5px; vertical-align: middle; white-space: nowrap; }
     .summary-age.age-recent { background: rgba(210,153,34,0.15); color: #d29922; border: 1px solid rgba(210,153,34,0.3); }


### PR DESCRIPTION
## Summary
Add Pi coding agent (pi.dev) as a supported CLI backend for contribute-hive and spoke agent cards.

Pi supports providers: Anthropic, OpenAI, Google, Azure, Bedrock, Mistral, Groq, Cerebras, xAI, Hugging Face, Kimi, MiniMax, OpenRouter, Ollama.

## Changes
- `backends.conf`: binary + perm flag mappings
- `contributor-relay.sh`: idle detection + death detection patterns
- `contributor-agent.sh`: CLI detection + AGENTS.md symlink
- `Dockerfile.contributor`: install via `pi.dev/install.sh`
- `Justfile`: setup validation + launch
- Contribute landing page: Pi in CLI dropdown
- Dashboard: green color for Pi agent cards