### PR TITLE
fix: inception-specific prompts for structure phase (bugs #121-122)

### DIFF
--- a/v2/pkg/dashboard/inception_handlers.go
+++ b/v2/pkg/dashboard/inception_handlers.go
@@ -423,12 +423,11 @@ func (s *Server) kickBrainstorm() {
 	}()
 }
 
-// sendKickBrainstorm sends the inception prompt to a RUNNING brainstorm agent
-// via SendKick (no restart). Used for the structure-phase kick after answers
-// are submitted — the agent is already running from the capture kick and
-// restarting it would kill its context and revert the phase.
+// sendKickBrainstorm sends an inception-specific prompt to the RUNNING
+// brainstorm agent via SendKick (no restart). Includes the user's Q&A
+// so the agent knows to extract facts and create fact beads.
 func (s *Server) sendKickBrainstorm() {
-	if s.deps.AgentMgr == nil || s.deps.Scheduler == nil {
+	if s.deps.AgentMgr == nil || s.deps.Inception == nil {
 		return
 	}
 	go func() {
@@ -438,7 +437,12 @@ func (s *Server) sendKickBrainstorm() {
 			}
 		}()
 
-		msg := s.deps.Scheduler.BuildAgentMessage("brainstorm", nil, s.deps.Scheduler.GetLastActionable())
+		state := s.deps.Inception.GetState()
+		if state == nil {
+			return
+		}
+
+		msg := s.buildStructureKickMessage(state)
 		if err := s.deps.AgentMgr.SendKick("brainstorm", msg); err != nil {
 			s.logger.Warn("sendKick for structure phase failed, trying pst-send", "error", err)
 			if err2 := pstSendKick("brainstorm", msg); err2 != nil {
@@ -450,6 +454,24 @@ func (s *Server) sendKickBrainstorm() {
 			s.deps.Governor.RecordKick("brainstorm")
 		}
 	}()
+}
+
+func (s *Server) buildStructureKickMessage(state *knowledge.InceptionState) string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("INCEPTION TASK: Structure phase for idea: %q\n", state.IdeaText))
+	sb.WriteString("The user has answered your clarification questions. Extract structured facts from these answers.\n\n")
+	for _, q := range state.Questions {
+		ans := state.Answers[q.ID]
+		if ans != "" {
+			sb.WriteString(fmt.Sprintf("Q: %s\nA: %s\n\n", q.Text, ans))
+		}
+	}
+	sb.WriteString("Create fact beads using `bd create` with:\n")
+	sb.WriteString("  - external_ref starting with 'inception/'\n")
+	sb.WriteString("  - meta field 'fact_type' set to one of: requirement, constraint, decision, assumption, dependency, goal\n")
+	sb.WriteString("  - meta field 'fact_body' with the extracted fact detail\n")
+	sb.WriteString("Create at least 3 fact beads from these answers.")
+	return sb.String()
 }
 
 // pstSendKick sends the inception prompt via pub-sub-tmux's pst-send command.

--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -429,7 +429,9 @@ func (w *InceptionWatcher) retryKickIfStale(state *knowledge.InceptionState) {
 			isReaping = true
 		}
 		if strings.Contains(lower, "inception") || strings.Contains(lower, "clarif") ||
-			strings.Contains(lower, "bd create") || strings.Contains(l, "Clarification:") {
+			strings.Contains(lower, "bd create") || strings.Contains(l, "Clarification:") ||
+			strings.Contains(lower, "fact") || strings.Contains(lower, "structur") ||
+			strings.Contains(lower, "extract") || strings.Contains(lower, "requirement") {
 			hasInceptionWork = true
 		}
 	}
@@ -441,11 +443,11 @@ func (w *InceptionWatcher) retryKickIfStale(state *knowledge.InceptionState) {
 		return
 	}
 
-	// Agent is reaping or idle — re-kick with inception prompt
+	// Agent is reaping or idle — re-kick with inception-specific prompt
 	w.kickRetryCount++
 	w.lastKickRetry = time.Now()
 
-	msg := w.scheduler.BuildAgentMessage("brainstorm", nil, w.scheduler.GetLastActionable())
+	msg := w.buildInceptionKickMessage(state)
 	if err := w.agentMgr.SendKick("brainstorm", msg); err != nil {
 		w.logger.Warn("inception retry kick failed",
 			"attempt", w.kickRetryCount,
@@ -456,6 +458,38 @@ func (w *InceptionWatcher) retryKickIfStale(state *knowledge.InceptionState) {
 			"attempt", w.kickRetryCount,
 			"isReaping", isReaping,
 		)
+	}
+}
+
+func (w *InceptionWatcher) buildInceptionKickMessage(state *knowledge.InceptionState) string {
+	switch state.Phase {
+	case knowledge.PhaseCapture:
+		return fmt.Sprintf(
+			"INCEPTION TASK: You are in the capture phase for idea: %q\n"+
+				"Generate at least %d clarification questions using `bd create`.\n"+
+				"Each question bead must have external_ref starting with 'inception/'.\n"+
+				"DO NOT close any beads with inception/ prefix.\n"+
+				"DO NOT run spec-kit during capture phase.",
+			state.IdeaText, minQuestionsForAdvance,
+		)
+	case knowledge.PhaseStructure:
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("INCEPTION TASK: Structure phase for idea: %q\n", state.IdeaText))
+		sb.WriteString("The user has answered your clarification questions. Extract structured facts from these answers.\n\n")
+		for _, q := range state.Questions {
+			ans := state.Answers[q.ID]
+			if ans != "" {
+				sb.WriteString(fmt.Sprintf("Q: %s\nA: %s\n\n", q.Text, ans))
+			}
+		}
+		sb.WriteString("Create fact beads using `bd create` with:\n")
+		sb.WriteString("  - external_ref starting with 'inception/'\n")
+		sb.WriteString("  - meta field 'fact_type' set to one of: requirement, constraint, decision, assumption, dependency, goal\n")
+		sb.WriteString("  - meta field 'fact_body' with the extracted fact detail\n")
+		sb.WriteString("Create at least 3 fact beads from these answers.")
+		return sb.String()
+	default:
+		return w.scheduler.BuildAgentMessage("brainstorm", nil, w.scheduler.GetLastActionable())
 	}
 }
 


### PR DESCRIPTION
Structure kicks sent generic governor messages instead of inception prompts. Agent had no idea it needed to extract facts.