### PR TITLE
fix: Hub tab renders + auto-snapshot toggle + snapshot endpoints

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -332,6 +332,7 @@ type HubConfig struct {
 	IsPublic     bool   `yaml:"is_public"`
 	SnapshotURL  string `yaml:"snapshot_url"`
 	DashboardURL string `yaml:"dashboard_url"`
+	AutoSnapshot bool   `yaml:"auto_snapshot"`
 }
 
 type DashboardConfig struct {

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -28,6 +28,8 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/config", s.handleConfig)
 	s.mux.HandleFunc("GET /api/config/download", s.handleConfigDownload)
 	s.mux.HandleFunc("GET /api/audit", s.handleAuditLog)
+	s.mux.HandleFunc("GET /api/snapshot", s.handleSnapshotAPI)
+	s.mux.HandleFunc("GET /snapshot", s.handleSnapshotPage)
 	s.mux.HandleFunc("GET /api/history", s.handleHistory)
 	s.mux.HandleFunc("GET /api/trends", s.handleTrends)
 	s.mux.HandleFunc("GET /api/timeline", s.handleTimeline)
@@ -403,6 +405,40 @@ func (s *Server) handleConfigDownload(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/x-yaml")
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filename))
 	w.Write(data)
+}
+
+func (s *Server) handleSnapshotAPI(w http.ResponseWriter, r *http.Request) {
+	if s.deps != nil && s.deps.Config != nil && !s.deps.Config.Hub.AutoSnapshot {
+		http.Error(w, "snapshots not enabled", http.StatusNotFound)
+		return
+	}
+	s.statusMu.RLock()
+	status := s.status
+	s.statusMu.RUnlock()
+	if status == nil {
+		http.Error(w, "no data yet", http.StatusServiceUnavailable)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=60")
+	json.NewEncoder(w).Encode(status)
+}
+
+func (s *Server) handleSnapshotPage(w http.ResponseWriter, r *http.Request) {
+	if s.deps != nil && s.deps.Config != nil && !s.deps.Config.Hub.AutoSnapshot {
+		http.Error(w, "snapshots not enabled", http.StatusNotFound)
+		return
+	}
+	data, err := staticFS.ReadFile("static/index.html")
+	if err != nil {
+		http.Error(w, "dashboard not found", http.StatusInternalServerError)
+		return
+	}
+	html := strings.Replace(string(data), "</head>",
+		`<script>window.HIVE_SNAPSHOT_MODE=true;</script></head>`, 1)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "public, max-age=60")
+	w.Write([]byte(html))
 }
 
 func (s *Server) handleHistory(w http.ResponseWriter, r *http.Request) {
@@ -1839,6 +1875,7 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			"dashboard_url": cfg.Hub.DashboardURL,
 			"snapshot_url":  cfg.Hub.SnapshotURL,
 			"is_public":     cfg.Hub.IsPublic,
+			"auto_snapshot": cfg.Hub.AutoSnapshot,
 		},
 	})
 }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -8261,13 +8261,32 @@ function burnAreaChart() {
     }
 
     function renderGovHub(hub) {
-      return `<div class="config-section">
-        ${configField('Hub Enabled', 'checkbox', hub.enabled, 'hub.enabled', 'Register this hive with the central hub')}
-        ${configField('Hub URL', 'text', hub.url || '', 'hub.url', 'URL of the Hive Hub (e.g. https://hive.kubestellar.io)')}
-        ${configField('Dashboard URL', 'text', hub.dashboard_url || '', 'hub.dashboard_url', 'Public URL of this hive dashboard')}
-        ${configField('Snapshot URL', 'text', hub.snapshot_url || '', 'hub.snapshot_url', 'URL to a published snapshot of this hive')}
-        ${configField('Public', 'checkbox', hub.is_public, 'hub.is_public', 'Show this hive on the public hub registry')}
-      </div>`;
+      return `
+        <div class="config-toggle">
+          <div class="config-toggle-switch ${hub.enabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="hub" data-key="enabled"></div>
+          <span class="config-toggle-label">Hub Enabled <span class="config-info">i<span class="config-tooltip">Register this hive with the central hub at hive.kubestellar.io so it appears in the public registry.</span></span></span>
+        </div>
+        <div class="config-field">
+          <label>Hub URL <span class="config-info">i<span class="config-tooltip">URL of the Hive Hub (e.g. https://hive.kubestellar.io). Heartbeats and task status are sent here.</span></span></label>
+          <input type="text" value="${esc(hub.url || '')}" onchange="markDirty('hub','url',this.value)">
+        </div>
+        <div class="config-field">
+          <label>Dashboard URL <span class="config-info">i<span class="config-tooltip">Public URL of this hive's dashboard. Shown in the hub registry as the dashboard link.</span></span></label>
+          <input type="text" value="${esc(hub.dashboard_url || '')}" onchange="markDirty('hub','dashboard_url',this.value)">
+        </div>
+        <div class="config-toggle">
+          <div class="config-toggle-switch ${hub.is_public ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="hub" data-key="is_public"></div>
+          <span class="config-toggle-label">Public <span class="config-info">i<span class="config-tooltip">Show this hive on the public hub registry. When off, the hive is hidden from the main page.</span></span></span>
+        </div>
+        <hr style="border-color:var(--border);margin:16px 0">
+        <div class="config-toggle">
+          <div class="config-toggle-switch ${hub.auto_snapshot ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="hub" data-key="auto_snapshot"></div>
+          <span class="config-toggle-label">Auto-publish Snapshot <span class="config-info">i<span class="config-tooltip">Publish a read-only snapshot every 15 minutes at /snapshot. Anyone with the link can view dashboard state without auth. Off by default.</span></span></span>
+        </div>
+        <div class="config-field">
+          <label>Snapshot URL <span class="config-info">i<span class="config-tooltip">Public URL to the read-only snapshot. Auto-set when auto-publish is enabled.</span></span></label>
+          <input type="text" value="${esc(hub.snapshot_url || '')}" onchange="markDirty('hub','snapshot_url',this.value)">
+        </div>`;
     }
 
     // ── Agent Tab Renderers ──


### PR DESCRIPTION
Hub tab was blank — used nonexistent configField(). Now uses native config-field/config-toggle. Added auto_snapshot config, GET /api/snapshot (public JSON), GET /snapshot (read-only page).