### PR TITLE
feat: Hub tab save handler — persist to PVC

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -327,12 +327,16 @@ type DiscordConfig struct {
 }
 
 type HubConfig struct {
-	Enabled      bool   `yaml:"enabled"`
-	URL          string `yaml:"url"`
-	IsPublic     bool   `yaml:"is_public"`
-	SnapshotURL  string `yaml:"snapshot_url"`
-	DashboardURL string `yaml:"dashboard_url"`
-	AutoSnapshot bool   `yaml:"auto_snapshot"`
+	Enabled                bool     `yaml:"enabled"`
+	URL                    string   `yaml:"url"`
+	IsPublic               bool     `yaml:"is_public"`
+	SnapshotURL            string   `yaml:"snapshot_url"`
+	DashboardURL           string   `yaml:"dashboard_url"`
+	AutoSnapshot           bool     `yaml:"auto_snapshot"`
+	ContributeAllowLabels  []string `yaml:"contribute_allow_labels"`
+	ContributeDenyLabels   []string `yaml:"contribute_deny_labels"`
+	DisabledRepos          []string `yaml:"disabled_repos"`
+	DisabledTiers          []string `yaml:"disabled_tiers"`
 }
 
 type DashboardConfig struct {

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1870,12 +1870,16 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			"level":      cfg.Governor.Logging.Level,
 		},
 		"hub": map[string]interface{}{
-			"enabled":       cfg.Hub.Enabled,
-			"url":           cfg.Hub.URL,
-			"dashboard_url": cfg.Hub.DashboardURL,
-			"snapshot_url":  cfg.Hub.SnapshotURL,
-			"is_public":     cfg.Hub.IsPublic,
-			"auto_snapshot": cfg.Hub.AutoSnapshot,
+			"enabled":                  cfg.Hub.Enabled,
+			"url":                      cfg.Hub.URL,
+			"dashboard_url":            cfg.Hub.DashboardURL,
+			"snapshot_url":             cfg.Hub.SnapshotURL,
+			"is_public":               cfg.Hub.IsPublic,
+			"auto_snapshot":           cfg.Hub.AutoSnapshot,
+			"contribute_allow_labels": cfg.Hub.ContributeAllowLabels,
+			"contribute_deny_labels":  cfg.Hub.ContributeDenyLabels,
+			"disabled_repos":          cfg.Hub.DisabledRepos,
+			"disabled_tiers":          cfg.Hub.DisabledTiers,
 		},
 	})
 }

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -81,6 +81,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("PUT /api/config/governor/notifications", s.handleGovernorNotifications)
 	s.mux.HandleFunc("PUT /api/config/governor/health", s.handleGovernorHealth)
 	s.mux.HandleFunc("PUT /api/config/governor/logging", s.handleGovernorLogging)
+	s.mux.HandleFunc("PUT /api/config/governor/hub", s.handleGovernorHub)
 	s.mux.HandleFunc("POST /api/config/governor/agents", s.handleGovernorAddAgent)
 	s.mux.HandleFunc("DELETE /api/config/governor/agents/{name}", s.handleGovernorRemoveAgent)
 	s.mux.HandleFunc("PUT /api/config/governor/repos", s.handleGovernorRepos)
@@ -2144,6 +2145,56 @@ func (s *Server) handleGovernorLogging(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if err := s.saveConfig(); err != nil { s.logger.Error("failed to persist config after logging update", "error", err) }
+	s.refreshAndPersist()
+	okResponse(w, map[string]string{"status": "updated"})
+}
+
+func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Enabled              *bool    `json:"enabled"`
+		URL                  string   `json:"url"`
+		DashboardURL         string   `json:"dashboard_url"`
+		SnapshotURL          string   `json:"snapshot_url"`
+		IsPublic             *bool    `json:"is_public"`
+		AutoSnapshot         *bool    `json:"auto_snapshot"`
+		ContributeAllowLabels []string `json:"contribute_allow_labels"`
+		ContributeDenyLabels  []string `json:"contribute_deny_labels"`
+		DisabledRepos         []string `json:"disabled_repos"`
+		DisabledTiers         []string `json:"disabled_tiers"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	cfg := s.deps.Config
+	if body.Enabled != nil {
+		cfg.Hub.Enabled = *body.Enabled
+	}
+	if body.URL != "" {
+		cfg.Hub.URL = body.URL
+	}
+	if body.DashboardURL != "" {
+		cfg.Hub.DashboardURL = body.DashboardURL
+	}
+	cfg.Hub.SnapshotURL = body.SnapshotURL
+	if body.IsPublic != nil {
+		cfg.Hub.IsPublic = *body.IsPublic
+	}
+	if body.AutoSnapshot != nil {
+		cfg.Hub.AutoSnapshot = *body.AutoSnapshot
+	}
+	if body.ContributeAllowLabels != nil {
+		cfg.Hub.ContributeAllowLabels = body.ContributeAllowLabels
+	}
+	if body.ContributeDenyLabels != nil {
+		cfg.Hub.ContributeDenyLabels = body.ContributeDenyLabels
+	}
+	if body.DisabledRepos != nil {
+		cfg.Hub.DisabledRepos = body.DisabledRepos
+	}
+	if body.DisabledTiers != nil {
+		cfg.Hub.DisabledTiers = body.DisabledTiers
+	}
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})
 }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -8261,32 +8261,146 @@ function burnAreaChart() {
     }
 
     function renderGovHub(hub) {
+      const dashUrl = hub.dashboard_url || '';
+      const snapUrl = hub.snapshot_url || (hub.auto_snapshot && dashUrl ? dashUrl.replace(/\/$/, '') + '/snapshot' : '');
+      const repos = (_configState.data.repos || []).map(function(r) {
+        const name = r.split('/').pop();
+        const enabled = !(hub.disabled_repos || []).includes(name);
+        return {name: name, full: r, enabled: enabled};
+      });
+      const tiers = ['newcomer', 'contributor', 'trusted', 'advisor'];
+      const allowLabels = (hub.contribute_allow_labels || []);
+      const denyLabels = (hub.contribute_deny_labels || []);
       return `
         <div class="config-toggle">
           <div class="config-toggle-switch ${hub.enabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="hub" data-key="enabled"></div>
           <span class="config-toggle-label">Hub Enabled <span class="config-info">i<span class="config-tooltip">Register this hive with the central hub at hive.kubestellar.io so it appears in the public registry.</span></span></span>
         </div>
         <div class="config-field">
-          <label>Hub URL <span class="config-info">i<span class="config-tooltip">URL of the Hive Hub (e.g. https://hive.kubestellar.io). Heartbeats and task status are sent here.</span></span></label>
+          <label>Hub URL <span class="config-info">i<span class="config-tooltip">URL of the Hive Hub. Heartbeats and task status are sent here.</span></span></label>
           <input type="text" value="${esc(hub.url || '')}" onchange="markDirty('hub','url',this.value)">
         </div>
         <div class="config-field">
-          <label>Dashboard URL <span class="config-info">i<span class="config-tooltip">Public URL of this hive's dashboard. Shown in the hub registry as the dashboard link.</span></span></label>
-          <input type="text" value="${esc(hub.dashboard_url || '')}" onchange="markDirty('hub','dashboard_url',this.value)">
+          <label>Dashboard URL <span class="config-info">i<span class="config-tooltip">Public URL of this hive's dashboard.</span></span></label>
+          <input type="text" value="${esc(dashUrl)}" onchange="markDirty('hub','dashboard_url',this.value)">
         </div>
         <div class="config-toggle">
           <div class="config-toggle-switch ${hub.is_public ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="hub" data-key="is_public"></div>
-          <span class="config-toggle-label">Public <span class="config-info">i<span class="config-tooltip">Show this hive on the public hub registry. When off, the hive is hidden from the main page.</span></span></span>
+          <span class="config-toggle-label">Public <span class="config-info">i<span class="config-tooltip">Show this hive on the public hub registry.</span></span></span>
         </div>
+
         <hr style="border-color:var(--border);margin:16px 0">
+        <h4 style="font-size:0.8rem;color:var(--muted);margin:0 0 8px">Snapshot</h4>
         <div class="config-toggle">
-          <div class="config-toggle-switch ${hub.auto_snapshot ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="hub" data-key="auto_snapshot"></div>
-          <span class="config-toggle-label">Auto-publish Snapshot <span class="config-info">i<span class="config-tooltip">Publish a read-only snapshot every 15 minutes at /snapshot. Anyone with the link can view dashboard state without auth. Off by default.</span></span></span>
+          <div class="config-toggle-switch ${hub.auto_snapshot ? 'on' : ''}" onclick="toggleAutoSnapshot(this)" data-section="hub" data-key="auto_snapshot"></div>
+          <span class="config-toggle-label">Auto-publish Snapshot <span class="config-info">i<span class="config-tooltip">Publish a read-only snapshot at /snapshot. Generated immediately on enable and every 15 min. Deleted on disable.</span></span></span>
         </div>
         <div class="config-field">
-          <label>Snapshot URL <span class="config-info">i<span class="config-tooltip">Public URL to the read-only snapshot. Auto-set when auto-publish is enabled.</span></span></label>
-          <input type="text" value="${esc(hub.snapshot_url || '')}" onchange="markDirty('hub','snapshot_url',this.value)">
+          <label>Snapshot URL <span class="config-info">i<span class="config-tooltip">Auto-set from Dashboard URL when enabled.</span></span></label>
+          <input type="text" id="hub-snapshot-url" value="${esc(snapUrl)}" onchange="markDirty('hub','snapshot_url',this.value)" ${hub.auto_snapshot ? '' : 'disabled style="opacity:0.5"'}>
+        </div>
+
+        <hr style="border-color:var(--border);margin:16px 0">
+        <h4 style="font-size:0.8rem;color:var(--muted);margin:0 0 8px">Contribute Work Queue</h4>
+
+        <div class="config-field">
+          <label>Allow Labels <span class="config-info">i<span class="config-tooltip">Only issues with these labels will be queued for contributors. Leave empty to allow all.</span></span></label>
+          <div id="hub-allow-labels" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">${allowLabels.map(function(l) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(34,197,94,0.15);color:#4ade80;border:1px solid rgba(34,197,94,0.3)">' + esc(l) + ' <span onclick="removeHubLabel(\'allow\',' + "'" + esc(l) + "'" + ')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('')}</div>
+          <div style="display:flex;gap:4px"><input type="text" id="hub-allow-label-input" placeholder="e.g. good-first-issue, help-wanted" style="flex:1" onkeydown="if(event.key==='Enter'){addHubLabel('allow');event.preventDefault()}"><button onclick="addHubLabel('allow')" style="padding:4px 12px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer;font-size:0.75rem">Add</button></div>
+        </div>
+
+        <div class="config-field">
+          <label>Deny Labels <span class="config-info">i<span class="config-tooltip">Issues with these labels will never be queued for contributors.</span></span></label>
+          <div id="hub-deny-labels" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">${denyLabels.map(function(l) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(248,81,73,0.15);color:#f85149;border:1px solid rgba(248,81,73,0.3)">' + esc(l) + ' <span onclick="removeHubLabel(\'deny\',' + "'" + esc(l) + "'" + ')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('')}</div>
+          <div style="display:flex;gap:4px"><input type="text" id="hub-deny-label-input" placeholder="e.g. hold, wontfix, duplicate" style="flex:1" onkeydown="if(event.key==='Enter'){addHubLabel('deny');event.preventDefault()}"><button onclick="addHubLabel('deny')" style="padding:4px 12px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer;font-size:0.75rem">Add</button></div>
+        </div>
+
+        <div class="config-field">
+          <label>Repos for Contribute <span class="config-info">i<span class="config-tooltip">Toggle which repos serve work to contributors. New repos default to on.</span></span></label>
+          <div style="display:flex;flex-direction:column;gap:4px">${repos.map(function(r) {
+            return '<div class="config-toggle" style="padding:2px 0"><div class="config-toggle-switch ' + (r.enabled ? 'on' : '') + '" onclick="toggleContribRepo(this,\'' + esc(r.name) + '\')"></div><span style="font-size:0.78rem">' + esc(r.full) + '</span></div>';
+          }).join('')}</div>
+        </div>
+
+        <div class="config-field">
+          <label>Tier Access <span class="config-info">i<span class="config-tooltip">Restrict which tiers can pick up work. All tiers enabled by default.</span></span></label>
+          <div style="display:flex;flex-direction:column;gap:4px">${tiers.map(function(t) {
+            const enabled = !(hub.disabled_tiers || []).includes(t);
+            return '<div class="config-toggle" style="padding:2px 0"><div class="config-toggle-switch ' + (enabled ? 'on' : '') + '" onclick="toggleContribTier(this,\'' + t + '\')"></div><span style="font-size:0.78rem">' + t + '</span></div>';
+          }).join('')}</div>
         </div>`;
+    }
+
+    function toggleAutoSnapshot(el) {
+      el.classList.toggle('on');
+      var isOn = el.classList.contains('on');
+      markDirty('hub', 'auto_snapshot', isOn);
+      var urlInput = document.getElementById('hub-snapshot-url');
+      if (urlInput) {
+        urlInput.disabled = !isOn;
+        urlInput.style.opacity = isOn ? '1' : '0.5';
+        if (isOn && !urlInput.value) {
+          var dashUrl = (_configState.data.hub || {}).dashboard_url || '';
+          if (dashUrl) {
+            var snapUrl = dashUrl.replace(/\/$/, '') + '/snapshot';
+            urlInput.value = snapUrl;
+            markDirty('hub', 'snapshot_url', snapUrl);
+          }
+        }
+        if (!isOn) {
+          urlInput.value = '';
+          markDirty('hub', 'snapshot_url', '');
+        }
+      }
+    }
+
+    function addHubLabel(type) {
+      var input = document.getElementById('hub-' + type + '-label-input');
+      var val = (input.value || '').trim();
+      if (!val) return;
+      var key = type === 'allow' ? 'contribute_allow_labels' : 'contribute_deny_labels';
+      if (!_configState.data.hub) _configState.data.hub = {};
+      if (!_configState.data.hub[key]) _configState.data.hub[key] = [];
+      if (_configState.data.hub[key].indexOf(val) === -1) {
+        _configState.data.hub[key].push(val);
+        markDirty('hub', key, _configState.data.hub[key]);
+      }
+      input.value = '';
+      renderConfigTab('Hub');
+    }
+
+    function removeHubLabel(type, label) {
+      var key = type === 'allow' ? 'contribute_allow_labels' : 'contribute_deny_labels';
+      if (!_configState.data.hub || !_configState.data.hub[key]) return;
+      _configState.data.hub[key] = _configState.data.hub[key].filter(function(l) { return l !== label; });
+      markDirty('hub', key, _configState.data.hub[key]);
+      renderConfigTab('Hub');
+    }
+
+    function toggleContribRepo(el, repoName) {
+      el.classList.toggle('on');
+      if (!_configState.data.hub) _configState.data.hub = {};
+      var disabled = _configState.data.hub.disabled_repos || [];
+      if (el.classList.contains('on')) {
+        disabled = disabled.filter(function(r) { return r !== repoName; });
+      } else {
+        if (disabled.indexOf(repoName) === -1) disabled.push(repoName);
+      }
+      _configState.data.hub.disabled_repos = disabled;
+      markDirty('hub', 'disabled_repos', disabled);
+    }
+
+    function toggleContribTier(el, tier) {
+      el.classList.toggle('on');
+      if (!_configState.data.hub) _configState.data.hub = {};
+      var disabled = _configState.data.hub.disabled_tiers || [];
+      if (el.classList.contains('on')) {
+        disabled = disabled.filter(function(t) { return t !== tier; });
+      } else {
+        if (disabled.indexOf(tier) === -1) disabled.push(tier);
+      }
+      _configState.data.hub.disabled_tiers = disabled;
+      markDirty('hub', 'disabled_tiers', disabled);
     }
 
     // ── Agent Tab Renderers ──


### PR DESCRIPTION
PUT /api/config/governor/hub handler. Saves all hub settings including contribute work queue controls.