### PR TITLE
fix: PST never worked — path mismatch and wrong flags (bug #126)

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -125,7 +125,8 @@ RUN pip3 install --no-cache-dir --break-system-packages specify-cli 2>/dev/null 
 # pub-sub-tmux: structured event streaming for AI agent tmux sessions
 RUN git clone --depth 1 https://github.com/kubestellar/pub-sub-tmux.git /tmp/pst && \
     bash /tmp/pst/install.sh /usr/local && \
-    rm -rf /tmp/pst || \
+    rm -rf /tmp/pst && \
+    mkdir -p /var/run/pub-sub-tmux/logs /var/run/pub-sub-tmux/commands || \
     echo "WARN: pub-sub-tmux install failed — inception will use RestartWithBootstrap fallback"
 RUN (which git && git clone -b feat/cli-agent-mode https://github.com/clubanderson/agentic-strategy-evolution /opt/nous && \
     python3 -m venv /opt/nous/venv && \

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -276,11 +276,13 @@ func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
 	// Attach pub-sub-tmux publisher if available — streams structured events
 	// from the agent's tmux output to a JSONL log for subscribers.
 	if pstPath, err := exec.LookPath("pst-publish"); err == nil {
+		_ = os.MkdirAll("/var/run/pub-sub-tmux/logs", 0o755)
+		_ = os.MkdirAll("/var/run/pub-sub-tmux/commands", 0o755)
 		backend := agent.Config.Backend
 		if backend == "" {
 			backend = "claude"
 		}
-		pipePaneCmd := fmt.Sprintf("%s --session %s --cli %s 2>/dev/null", pstPath, agent.tmuxSession, backend)
+		pipePaneCmd := fmt.Sprintf("%s --session %s --cli %s", pstPath, agent.tmuxSession, backend)
 		_ = m.tmuxCmd(agent, "pipe-pane", "-t", agent.tmuxSession, "-o", pipePaneCmd).Run()
 		m.logger.Info("pub-sub-tmux publisher attached", "agent", agent.Name, "cli", backend)
 	}

--- a/v2/pkg/dashboard/inception_handlers.go
+++ b/v2/pkg/dashboard/inception_handlers.go
@@ -490,22 +490,14 @@ func (s *Server) buildStructureKickMessage(state *knowledge.InceptionState) stri
 // writes to a named FIFO and confirms delivery via a command_received event.
 // Returns error if pst-send is not installed or the send fails.
 func pstSendKick(session, message string) error {
-	// Check if pst-send exists
 	pstPath, err := exec.LookPath("pst-send")
 	if err != nil {
 		return fmt.Errorf("pst-send not found: %w", err)
 	}
 
-	// Write message to temp file to avoid shell escaping issues
-	tmpFile := fmt.Sprintf("/tmp/.pst-kick-%s.txt", session)
-	if err := os.WriteFile(tmpFile, []byte(message), 0o644); err != nil {
-		return fmt.Errorf("write kick file: %w", err)
-	}
-
-	// pst-send reads from file and sends to the session's FIFO
 	cmd := exec.Command(pstPath,
 		"--session", "hive-"+session,
-		"--file", tmpFile,
+		"--text", message,
 		"--enter",
 	)
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -278,7 +278,7 @@ type pstEvent struct {
 	Data    map[string]string `json:"data"`
 }
 
-const pstLogDir = "/var/run/pst"
+const pstLogDir = "/var/run/pub-sub-tmux/logs"
 
 // runPSTSubscriber tails the brainstorm session's pub-sub-tmux JSONL event
 // stream and takes immediate action on relevant events. This replaces 5s


### PR DESCRIPTION
PST was installed but never connected:
1. Watcher looked in `/var/run/pst/` but PST writes to `/var/run/pub-sub-tmux/logs/`
2. `pstSendKick` used `--file` flag that doesn't exist (pst-send uses `--text`)
3. `/var/run/pub-sub-tmux/` directory never created

This is why PST has been inactive for days despite being installed in the container.