### PR TITLE
fix: remove [bot] filter from selectTask — was blocking all tasks

### DIFF
--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -722,17 +722,14 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 
 			title, _ := issue["title"].(string)
 			url, _ := issue["url"].(string)
-			author, _ := issue["author"].(string)
+			_, _ = issue["author"].(string)
 
 			titleLower := strings.ToLower(title)
 			if strings.Contains(titleLower, "dependency dashboard") ||
 				strings.Contains(titleLower, "renovate dashboard") ||
-				strings.Contains(titleLower, "epic:") ||
-				strings.HasSuffix(author, "[bot]") {
-				h.logger.Info("[contribute-ws] skip: filtered", "repo", repo.Full, "number", number, "title", title, "author", author)
+				strings.Contains(titleLower, "epic:") {
 				continue
 			}
-			h.logger.Info("[contribute-ws] selectTask found candidate", "repo", repo.Full, "number", number, "title", title)
 
 			ghToken := ""
 			if h.server.deps != nil && h.server.deps.GHAppAuth != nil {


### PR DESCRIPTION
## Root Cause
The `[bot]` author suffix filter excluded ALL bot-authored issues including hive-created `[quality]` issues from `kubestellar-hive[bot]`. With 48 actionable issues, 18 in cooldown, and ~20 from bots — ALL remaining were filtered out.

## Fix
Remove the blanket `[bot]` filter. Keep title-based filters (dependency dashboard, renovate dashboard, epic:).

## TODO
Make these filters configurable in the governor hub config tab — title patterns, author patterns, repo filters, label filters, tier filters. Pre-populate with sensible defaults that the hive owner can modify.