### PR TITLE
fix: silence ollama output in contribute-hive

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -236,11 +236,15 @@ contribute-hive backend="" mode="docker":
 
       # Start ollama silently if needed for goose
       if [[ "$BACKEND" == "goose" && "${GOOSE_PROVIDER:-}" == "ollama" ]]; then
+        # Kill any existing ollama that might spam logs to this terminal
+        pkill -f "ollama serve" 2>/dev/null || true
+        sleep 1
+        echo "Starting ollama (silent)..."
+        OLLAMA_FLASH_ATTENTION=1 nohup ollama serve > /dev/null 2>&1 &
+        disown
+        sleep 2
         if ! curl -sf http://localhost:11434/api/tags > /dev/null 2>&1; then
-          echo "Starting ollama..."
-          ollama serve > /dev/null 2>&1 &
-          OLLAMA_PID=$!
-          sleep 2
+          echo "WARNING: ollama failed to start. Install: https://ollama.com/download"
         fi
       fi
 


### PR DESCRIPTION
Kills existing ollama and restarts with nohup+disown so logs don't spam the relay terminal.