### PR TITLE
feat: model selector, Other CLI, tier rate limits in hub tab

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -338,8 +338,15 @@ type HubConfig struct {
 	ContributeDenyLabels   []string `yaml:"contribute_deny_labels"`
 	ContributeDenyTitles   []string `yaml:"contribute_deny_titles"`
 	ContributeDenyAuthors  []string `yaml:"contribute_deny_authors"`
-	DisabledRepos          []string `yaml:"disabled_repos"`
-	DisabledTiers          []string `yaml:"disabled_tiers"`
+	DisabledRepos          []string            `yaml:"disabled_repos"`
+	DisabledTiers          []string            `yaml:"disabled_tiers"`
+	TierLimits             map[string]TierRate `yaml:"tier_limits"`
+}
+
+type TierRate struct {
+	MaxPerHour    int `yaml:"max_per_hour" json:"max_per_hour"`
+	MaxPerDay     int `yaml:"max_per_day" json:"max_per_day"`
+	MaxConcurrent int `yaml:"max_concurrent" json:"max_concurrent"`
 }
 
 type DashboardConfig struct {
@@ -626,6 +633,15 @@ func (c *Config) applyDefaults() {
 			"renovate[bot]",
 			"dependabot[bot]",
 			"mergeraptor[bot]",
+		}
+	}
+
+	if len(c.Hub.TierLimits) == 0 {
+		c.Hub.TierLimits = map[string]TierRate{
+			"newcomer":    {MaxPerHour: 3, MaxPerDay: 10, MaxConcurrent: 1},
+			"contributor": {MaxPerHour: 10, MaxPerDay: 50, MaxConcurrent: 2},
+			"trusted":     {MaxPerHour: 30, MaxPerDay: 200, MaxConcurrent: 5},
+			"advisor":     {MaxPerHour: 0, MaxPerDay: 0, MaxConcurrent: 0},
 		}
 	}
 

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -335,17 +335,22 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 <div style="margin-bottom:16px;display:flex;align-items:center;gap:12px;flex-wrap:wrap">
 <label style="font-size:.9rem;color:#8b949e">Choose your CLI:</label>
 <select id="cli-select" style="background:#161b22;color:#e6edf3;border:1px solid #30363d;border-radius:6px;padding:6px 12px;font-size:.9rem;cursor:pointer">
-<option value="claude" data-install="npm i -g @anthropic-ai/claude-code" data-host-install="npm i -g @anthropic-ai/claude-code">Claude Code</option>
-<option value="copilot" data-install="" data-host-install="">GitHub Copilot</option>
-<option value="bob" data-install="" data-host-install="npm i -g bobshell">Bob</option>
-<option value="goose" data-install="" data-host-install="# Install Goose: https://github.com/block/goose/releases\n# Install Ollama: https://ollama.com/download\nollama pull llama3.2:3b\nexport GOOSE_PROVIDER=ollama GOOSE_MODEL=llama3.2:3b">Goose</option>
-<option value="pi" data-install="" data-host-install="curl -fsSL https://pi.dev/install.sh | sh">Pi</option>
+<option value="claude" data-install="npm i -g @anthropic-ai/claude-code" data-host-install="npm i -g @anthropic-ai/claude-code" data-model-flag="--model" data-default-model="">Claude Code</option>
+<option value="copilot" data-install="" data-host-install="" data-model-flag="--model" data-default-model="">GitHub Copilot</option>
+<option value="pi" data-install="" data-host-install="curl -fsSL https://pi.dev/install.sh | sh" data-model-flag="--model" data-default-model="">Pi</option>
+<option value="goose" data-install="" data-host-install="# Install Goose: https://github.com/block/goose/releases\n# Install Ollama: https://ollama.com/download\nollama pull llama3.2:3b\nexport GOOSE_PROVIDER=ollama GOOSE_MODEL=llama3.2:3b" data-model-flag="" data-default-model="">Goose</option>
+<option value="bob" data-install="" data-host-install="npm i -g bobshell" data-model-flag="" data-default-model="">Bob</option>
+<option value="other" data-install="" data-host-install="# Install your CLI tool" data-model-flag="" data-default-model="">Other (host only)</option>
 </select>
 <label style="font-size:.9rem;color:#8b949e">Mode:</label>
 <select id="mode-select" style="background:#161b22;color:#e6edf3;border:1px solid #30363d;border-radius:6px;padding:6px 12px;font-size:.9rem;cursor:pointer">
 <option value="containerized">Containerized (recommended)</option>
 <option value="host">Host (non-containerized)</option>
 </select>
+</div>
+<div id="model-row" style="margin-bottom:12px;display:none;align-items:center;gap:8px">
+<label style="font-size:.9rem;color:#8b949e">Model (optional):</label>
+<input id="model-input" type="text" placeholder="e.g. claude-sonnet-4-6, gpt-4o" style="background:#161b22;color:#e6edf3;border:1px solid #30363d;border-radius:6px;padding:6px 12px;font-size:.85rem;flex:1;max-width:300px" oninput="updateCmds()">
 </div>
 <p style="color:#8b949e;margin-bottom:8px">Copy and paste these commands to get started:</p>
 <div style="margin-top:16px;background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:16px;position:relative">
@@ -364,21 +369,34 @@ var cmds=document.getElementById('copy-cmds');
 var hubURL='%s';
 var containerTpl='brew install just gh\ngit clone -b v2 https://github.com/kubestellar/hive && cd hive\nexport HIVE_HUB='+hubURL+'\njust contribute-setup CLI\njust contribute-hive';
 var hostTpl='brew install just gh\nINSTALL\ngit clone -b v2 https://github.com/kubestellar/hive && cd hive\nexport HIVE_HUB='+hubURL+'\njust contribute-setup CLI\njust contribute-hive CLI local';
+var modelRow=document.getElementById('model-row');
+var modelInput=document.getElementById('model-input');
+function updateCmds(){update();}
 function update(){
 var cli=sel.value;
 var opt=sel.options[sel.selectedIndex];
 var mode=modeSel.value;
+var modelFlag=opt.getAttribute('data-model-flag')||'';
+var model=(modelInput.value||'').trim();
+if(cli==='other')mode='host';
+if(mode==='containerized'&&cli==='other'){modeSel.value='host';mode='host';}
+modelRow.style.display=(modelFlag||cli==='goose')?'flex':'none';
+var modelLine='';
+if(model){
+if(cli==='goose'){modelLine='\nexport GOOSE_MODEL='+model;}
+else if(modelFlag){modelLine='\nexport AGENT_MODEL='+model;}
+}
 var tpl,install;
 if(mode==='host'){
 tpl=hostTpl;
 install=opt.getAttribute('data-host-install');
 if(!install)install='# '+cli+' uses your existing gh auth';
-cmds.textContent=tpl.replace('INSTALL',install.replace(/\\n/g,'\n')).replace(/CLI/g,cli);
+cmds.textContent=tpl.replace('INSTALL',install.replace(/\\n/g,'\n')).replace(/CLI/g,cli)+modelLine;
 }else{
-cmds.textContent=containerTpl.replace(/CLI/g,cli);
+cmds.textContent=containerTpl.replace(/CLI/g,cli)+modelLine;
 }
 }
-sel.addEventListener('change',update);
+sel.addEventListener('change',function(){modelInput.value='';update();});
 modeSel.addEventListener('change',update);
 document.getElementById('copy-btn').addEventListener('click',function(){
 var el=document.getElementById('copy-cmds');
@@ -398,6 +416,7 @@ setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},200
 })();
 </script>
 </div>
+<p style="color:#6e7681;font-size:.78rem;margin-top:8px">Don't see your CLI? <a href="https://github.com/kubestellar/hive/issues/new?title=CLI+request:+&labels=contribute,enhancement" target="_blank" style="color:#58a6ff">Open an issue</a> and we'll add support for it.</p>
 <div style="margin-top:20px;display:flex;gap:12px;flex-wrap:wrap">
 <a href="/leaderboard" style="display:inline-block;padding:8px 20px;background:#161b22;border:1px solid #30363d;border-radius:8px;color:#58a6ff;text-decoration:none;font-size:.9rem">🏆 View Leaderboard</a>
 </div>

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -8346,10 +8346,18 @@ function burnAreaChart() {
         </div>
 
         <div class="config-field">
-          <label>Tier Access <span class="config-info">i<span class="config-tooltip">Restrict which tiers can pick up work. All tiers enabled by default.</span></span></label>
-          <div style="display:flex;flex-direction:column;gap:4px">${tiers.map(function(t) {
+          <label>Tier Access &amp; Rate Limits <span class="config-info">i<span class="config-tooltip">Toggle tiers on/off and set tasks/hour, tasks/day, max concurrent per tier. 0 = unlimited.</span></span></label>
+          <div style="display:flex;flex-direction:column;gap:6px">${tiers.map(function(t) {
             const enabled = !(hub.disabled_tiers || []).includes(t);
-            return '<div class="config-toggle" style="padding:2px 0"><div class="config-toggle-switch ' + (enabled ? 'on' : '') + '" onclick="toggleContribTier(this,\'' + t + '\')"></div><span style="font-size:0.78rem">' + t + '</span></div>';
+            const limits = (hub.tier_limits || {})[t] || {};
+            const mph = limits.max_per_hour != null ? limits.max_per_hour : '';
+            const mpd = limits.max_per_day != null ? limits.max_per_day : '';
+            const mc = limits.max_concurrent != null ? limits.max_concurrent : '';
+            return '<div style="display:flex;align-items:center;gap:8px;padding:2px 0"><div class="config-toggle-switch ' + (enabled ? 'on' : '') + '" onclick="toggleContribTier(this,\'' + t + '\')" style="flex-shrink:0"></div><span style="font-size:0.78rem;width:80px">' + t + '</span>' +
+              '<input type="number" min="0" placeholder="/hr" value="' + mph + '" style="width:50px;padding:2px 4px;font-size:0.72rem;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--text)" onchange="setTierLimit(\'' + t + '\',\'max_per_hour\',+this.value)">' +
+              '<input type="number" min="0" placeholder="/day" value="' + mpd + '" style="width:50px;padding:2px 4px;font-size:0.72rem;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--text)" onchange="setTierLimit(\'' + t + '\',\'max_per_day\',+this.value)">' +
+              '<input type="number" min="0" placeholder="max" value="' + mc + '" style="width:50px;padding:2px 4px;font-size:0.72rem;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--text)" onchange="setTierLimit(\'' + t + '\',\'max_concurrent\',+this.value)">' +
+              '<span style="font-size:0.65rem;color:var(--muted)">/hr · /day · max</span></div>';
           }).join('')}</div>
         </div>`;
     }
@@ -8419,6 +8427,14 @@ function burnAreaChart() {
       _configState.data.hub[key] = _configState.data.hub[key].filter(function(v) { return v !== val; });
       markDirty('hub', key, _configState.data.hub[key]);
       renderConfigTab('Hub');
+    }
+
+    function setTierLimit(tier, key, val) {
+      if (!_configState.data.hub) _configState.data.hub = {};
+      if (!_configState.data.hub.tier_limits) _configState.data.hub.tier_limits = {};
+      if (!_configState.data.hub.tier_limits[tier]) _configState.data.hub.tier_limits[tier] = {};
+      _configState.data.hub.tier_limits[tier][key] = val;
+      markDirty('hub', 'tier_limits', _configState.data.hub.tier_limits);
     }
 
     function toggleContribRepo(el, repoName) {


### PR DESCRIPTION
## Contribute Page
- Model input field (shown for CLIs with --model support)
- "Other (host only)" option for any terminal CLI
- "Don't see your CLI? Open an issue" link
- Model passed as AGENT_MODEL or GOOSE_MODEL env var

## Hub Config Tab
- Per-tier rate limits: tasks/hr, tasks/day, max concurrent
- Editable inline inputs next to each tier toggle
- Defaults pre-populated (newcomer: 3/hr, contributor: 10/hr, etc.)
- TierRate struct in config with YAML persistence