### PR TITLE
fix: remove duplicate bee emoji from spoke tab title

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -7,7 +7,7 @@
   <meta property="og:title" content="Hive Dashboard — AI Agent Orchestration for Open Source">
   <meta property="og:description" content="Real-time dashboard for a Hive AI agent swarm. Monitor agents, governor mode, issues, PRs, and contributor activity across open source projects.">
   <meta property="og:type" content="website">
-  <title>🐝 KubeStellar Hive Dashboard for KubeStellar/Console</title>
+  <title>Hive Dashboard</title>
   <style>
     :root {
       --bg: #0d1117; --surface: #161b22; --border: #30363d;
@@ -7828,7 +7828,7 @@ function burnAreaChart() {
       const el = document.getElementById("project-name");
       if (el && repoDisplay) {
         el.textContent = "for " + repoDisplay;
-        document.title = "🐝 Hive Dashboard for " + repoDisplay;
+        document.title = "Hive Dashboard for " + repoDisplay;
       }
       const ocEl = document.getElementById("oc-project-name");
       if (ocEl && repoDisplay) ocEl.textContent = repoDisplay;


### PR DESCRIPTION
Favicon already shows 🐝 — emoji in title caused double bee in browser tab.