### PR TITLE
fix: hive selector shows only user's hives, requireAuth accepts Bearer

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -18,19 +18,29 @@ contribute-setup backend="claude":
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ "{{hive_hub}}" == "wss://hive.kubestellar.io/contribute" ]]; then
-      echo "HIVE_HUB not set — fetching available hives..."
+      echo "HIVE_HUB not set — looking up your hives..."
       echo ""
-      HIVES_JSON=$(curl -sf "https://hive.kubestellar.io/api/registry" 2>/dev/null) || {
-        echo "ERROR: Could not reach hive.kubestellar.io"
-        echo "Set HIVE_HUB manually: export HIVE_HUB=wss://<hive>/contribute"
-        exit 1
-      }
-      HIVE_LIST=$(echo "$HIVES_JSON" | jq -r '.hives[] | select(.online==true) | "\(.id)|\(.name)"' 2>/dev/null)
+      _TOKEN=$(gh auth token 2>/dev/null || echo "")
+      HIVE_LIST=""
+      if [[ -n "$_TOKEN" ]]; then
+        MY_HIVES=$(curl -sf -H "Authorization: Bearer ${_TOKEN}" "https://hive.kubestellar.io/api/saas/my-hives" 2>/dev/null || echo "")
+        if [[ -n "$MY_HIVES" ]]; then
+          HIVE_LIST=$(echo "$MY_HIVES" | jq -r '.[] | "\(.id)|\(.name // .project_name)"' 2>/dev/null)
+        fi
+      fi
+      if [[ -z "$HIVE_LIST" ]]; then
+        HIVES_JSON=$(curl -sf "https://hive.kubestellar.io/api/registry" 2>/dev/null) || {
+          echo "ERROR: Could not reach hive.kubestellar.io"
+          echo "Set HIVE_HUB manually: export HIVE_HUB=wss://<hive>/contribute"
+          exit 1
+        }
+        HIVE_LIST=$(echo "$HIVES_JSON" | jq -r '.hives[] | select(.online==true) | "\(.id)|\(.name)"' 2>/dev/null)
+      fi
       if [[ -z "$HIVE_LIST" ]]; then
         echo "No hives available. Check https://hive.kubestellar.io"
         exit 1
       fi
-      echo "Available hives:"
+      echo "Your hives:"
       echo ""
       i=1
       declare -a HIVE_IDS
@@ -49,9 +59,13 @@ contribute-setup backend="claude":
       if [[ "$SELECTED" == hosted-* ]]; then
         export HIVE_HUB="wss://${SELECTED}.hive.kubestellar.io/contribute"
       else
-        DASH_URL=$(echo "$HIVES_JSON" | jq -r --arg id "$SELECTED" '.hives[] | select(.id==$id) | .dashboardUrl' 2>/dev/null)
-        DASH_URL=$(echo "$DASH_URL" | sed 's|^http://|ws://|;s|^https://|wss://|')
-        export HIVE_HUB="${DASH_URL}/contribute"
+        DASH_URL=$(echo "$HIVES_JSON" | jq -r --arg id "$SELECTED" '.hives[] | select(.id==$id) | .dashboardUrl' 2>/dev/null || echo "")
+        if [[ -n "$DASH_URL" ]]; then
+          DASH_URL=$(echo "$DASH_URL" | sed 's|^http://|ws://|;s|^https://|wss://|')
+          export HIVE_HUB="${DASH_URL}/contribute"
+        else
+          export HIVE_HUB="wss://${SELECTED}.hive.kubestellar.io/contribute"
+        fi
       fi
       echo ""
       echo "Selected: ${HIVE_HUB}"

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -130,14 +130,18 @@ func (s *HubServer) requireAuth(next http.HandlerFunc) http.HandlerFunc {
 			w.Write([]byte(`{"error":"CSRF check failed"}`))
 			return
 		}
-		cookie, err := r.Cookie("hive_hub_user")
-		if err != nil || cookie.Value == "" {
+		username := s.getAuthUser(r)
+		if username == "" {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
 			w.Write([]byte(`{"error":"not authenticated"}`))
 			return
 		}
-		user := loadSaaSUser(cookie.Value)
+		user := loadSaaSUser(username)
+		if user == nil {
+			ensureSaaSUser(username)
+			user = loadSaaSUser(username)
+		}
 		if user == nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)


### PR DESCRIPTION
Shows 'Your hives' from /api/saas/my-hives (user-specific) instead of full public registry. Also fixes requireAuth to accept Bearer tokens so CLI tools can call authenticated hub endpoints.