### PR TITLE
feat: unfurl bot detection for all pages — OG tags without auth

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -7,7 +7,7 @@
   <meta property="og:title" content="Hive Dashboard — AI Agent Orchestration for Open Source">
   <meta property="og:description" content="Real-time dashboard for a Hive AI agent swarm. Monitor agents, governor mode, issues, PRs, and contributor activity across open source projects.">
   <meta property="og:type" content="website">
-  <title>🐝 KubeStellar Hive Dashboard for KubeStellar/Console</title>
+  <title>Hive Dashboard</title>
   <style>
     :root {
       --bg: #0d1117; --surface: #161b22; --border: #30363d;
@@ -7828,7 +7828,7 @@ function burnAreaChart() {
       const el = document.getElementById("project-name");
       if (el && repoDisplay) {
         el.textContent = "for " + repoDisplay;
-        document.title = "🐝 Hive Dashboard for " + repoDisplay;
+        document.title = "Hive Dashboard for " + repoDisplay;
       }
       const ocEl = document.getElementById("oc-project-name");
       if (ocEl && repoDisplay) ocEl.textContent = repoDisplay;

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1044,6 +1044,11 @@ func (s *HubServer) handleSaaSAuthCheck(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	if isUnfurlBot(r.Header.Get("User-Agent")) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
 	username := s.getAuthUser(r)
 	if username == "" {
 		http.Error(w, "not authenticated", http.StatusUnauthorized)
@@ -1067,7 +1072,33 @@ func (s *HubServer) handleSaaSAuthCheck(w http.ResponseWriter, r *http.Request) 
 	w.WriteHeader(http.StatusOK)
 }
 
+func isUnfurlBot(ua string) bool {
+	bots := []string{"Slackbot", "Slack-ImgProxy", "Discordbot", "Twitterbot", "facebookexternalhit", "LinkedInBot", "WhatsApp", "TelegramBot"}
+	for _, b := range bots {
+		if strings.Contains(ua, b) {
+			return true
+		}
+	}
+	return false
+}
+
+const ogFallbackHTML = `<!DOCTYPE html><html><head>
+<meta charset="utf-8">
+<meta property="og:title" content="My Hives — Hive Hub">
+<meta property="og:description" content="AI Agent Orchestration for Open Source. Manage your hive instances — monitor agents, governor mode, issues, PRs, and contributor activity.">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="Hive Hub">
+<meta property="og:url" content="https://hive.kubestellar.io/dashboard">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🍯</text></svg>">
+<title>My Hives — Hive Hub</title>
+</head><body></body></html>`
+
 func (s *HubServer) handleDashboard(w http.ResponseWriter, r *http.Request) {
+	if isUnfurlBot(r.UserAgent()) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write([]byte(ogFallbackHTML))
+		return
+	}
 	cookie, err := r.Cookie("hive_hub_user")
 	if err != nil || cookie.Value == "" {
 		http.Redirect(w, r, "/login", http.StatusTemporaryRedirect)
@@ -1136,6 +1167,10 @@ const dashboardHTML = `<!DOCTYPE html>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🍯</text></svg>">
+  <meta property="og:title" content="My Hives — Hive Hub">
+  <meta property="og:description" content="Manage your AI agent hives. View local and hosted hive instances, monitor status, upgrade, and control access.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Hive Hub">
   <!-- GA4 --><script async src="https://www.googletagmanager.com/gtag/js?id=G-4707R797K3"></script><script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments)}gtag("js",new Date());gtag("config","G-4707R797K3");</script>
   <title>My Hives — Hive Hub</title>
   <style>


### PR DESCRIPTION
Bots get OG meta HTML instead of OAuth redirect. Works for hub /dashboard and spoke via auth-check bypass.