### PR TITLE
fix: queue count badge loads on Hub tab open

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -341,6 +341,7 @@ type HubConfig struct {
 	DisabledRepos          []string            `yaml:"disabled_repos"`
 	DisabledTiers          []string            `yaml:"disabled_tiers"`
 	TierLimits             map[string]TierRate `yaml:"tier_limits"`
+	SnapshotIntervalMin    int                 `yaml:"snapshot_interval_min"`
 }
 
 type TierRate struct {

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -434,12 +434,13 @@ func (s *Server) handleSnapshotPage(w http.ResponseWriter, r *http.Request) {
 		hubURL = s.deps.Config.Hub.URL
 	}
 
-	if s.deps == nil || s.deps.Config == nil || !s.deps.Config.Hub.AutoSnapshot {
+	cfg := s.deps.Config
+	if s.deps == nil || cfg == nil || !cfg.Hub.AutoSnapshot {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		fmt.Fprintf(w, `<!DOCTYPE html><html><head><meta charset="utf-8"><meta http-equiv="refresh" content="3;url=%s"><title>Hive</title>
 <style>body{font-family:system-ui,sans-serif;background:#0a0a0a;color:#e0e0e0;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0}
 .card{text-align:center;max-width:480px;padding:40px}.bee{font-size:3rem;margin-bottom:16px}h1{color:#f59e0b;margin:0 0 8px}p{color:#8b949e;line-height:1.6}a{color:#58a6ff}</style>
-</head><body><div class="card"><div class="bee">🐝</div><h1>Hive</h1><p>AI Agent Orchestration for GitHub</p><p>Snapshot is not currently published for this hive.</p><p>Redirecting to <a href="%s">%s</a>...</p></div></body></html>`,
+</head><body><div class="card"><div class="bee">🐝</div><h1>Hive</h1><p>AI Agent Orchestration for Open Source</p><p>Snapshot is not currently published for this hive.</p><p>Redirecting to <a href="%s">%s</a>...</p></div></body></html>`,
 			hubURL, hubURL, hubURL)
 		return
 	}
@@ -450,7 +451,11 @@ func (s *Server) handleSnapshotPage(w http.ResponseWriter, r *http.Request) {
 	}
 	snapshotFile := fmt.Sprintf("/data/snapshots/snapshot-%s.html", mode)
 	info, err := os.Stat(snapshotFile)
-	staleThreshold := 15 * time.Minute
+	intervalMin := cfg.Hub.SnapshotIntervalMin
+	if intervalMin < 5 {
+		intervalMin = 15
+	}
+	staleThreshold := time.Duration(intervalMin) * time.Minute
 	needsRebuild := err != nil || time.Since(info.ModTime()) > staleThreshold
 
 	if needsRebuild {
@@ -1947,6 +1952,7 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			"snapshot_url":             cfg.Hub.SnapshotURL,
 			"is_public":               cfg.Hub.IsPublic,
 			"auto_snapshot":           cfg.Hub.AutoSnapshot,
+			"snapshot_interval_min":   cfg.Hub.SnapshotIntervalMin,
 			"contribute_allow_labels": cfg.Hub.ContributeAllowLabels,
 			"contribute_deny_labels":  cfg.Hub.ContributeDenyLabels,
 			"disabled_repos":          cfg.Hub.DisabledRepos,

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -8299,11 +8299,11 @@ function burnAreaChart() {
         <h4 style="font-size:0.8rem;color:var(--muted);margin:0 0 8px">Snapshot</h4>
         <div class="config-toggle">
           <div class="config-toggle-switch ${hub.auto_snapshot ? 'on' : ''}" onclick="toggleAutoSnapshot(this)" data-section="hub" data-key="auto_snapshot"></div>
-          <span class="config-toggle-label">Auto-publish Snapshot <span class="config-info">i<span class="config-tooltip">Publish a read-only snapshot at /snapshot. Generated immediately on enable and every 15 min. Deleted on disable.</span></span></span>
+          <span class="config-toggle-label">Auto-generate &amp; Publish Snapshot <span class="config-info">i<span class="config-tooltip">Generate a read-only snapshot at /snapshot every 15 min. When off, you can set a custom preview URL below.</span></span></span>
         </div>
         <div class="config-field">
-          <label>Snapshot URL <span class="config-info">i<span class="config-tooltip">Auto-set from Dashboard URL when enabled.</span></span></label>
-          <input type="text" id="hub-snapshot-url" value="${esc(snapUrl)}" onchange="markDirty('hub','snapshot_url',this.value)" ${hub.auto_snapshot ? '' : 'disabled style="opacity:0.5"'}>
+          <label>Snapshot / Preview URL <span class="config-info">i<span class="config-tooltip">${hub.auto_snapshot ? 'Auto-generated from Dashboard URL. Read-only while auto-publish is on.' : 'Enter a custom preview URL (e.g. your own static dashboard). Sent to hub as the Preview link.'}</span></span></label>
+          <input type="text" id="hub-snapshot-url" value="${esc(snapUrl)}" onchange="markDirty('hub','snapshot_url',this.value)" ${hub.auto_snapshot ? 'disabled style="opacity:0.5"' : ''} placeholder="${hub.auto_snapshot ? '' : 'https://your-site.com/dashboard-preview'}">
         </div>
 
         <hr style="border-color:var(--border);margin:16px 0">
@@ -8377,19 +8377,16 @@ function burnAreaChart() {
       markDirty('hub', 'auto_snapshot', isOn);
       var urlInput = document.getElementById('hub-snapshot-url');
       if (urlInput) {
-        urlInput.disabled = !isOn;
-        urlInput.style.opacity = isOn ? '1' : '0.5';
-        if (isOn && !urlInput.value) {
+        urlInput.disabled = isOn;
+        urlInput.style.opacity = isOn ? '0.5' : '1';
+        urlInput.placeholder = isOn ? '' : 'https://your-site.com/dashboard-preview';
+        if (isOn) {
           var dashUrl = (_configState.data.hub || {}).dashboard_url || '';
           if (dashUrl) {
             var snapUrl = dashUrl.replace(/\/$/, '') + '/snapshot';
             urlInput.value = snapUrl;
             markDirty('hub', 'snapshot_url', snapUrl);
           }
-        }
-        if (!isOn) {
-          urlInput.value = '';
-          markDirty('hub', 'snapshot_url', '');
         }
       }
     }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -8228,6 +8228,7 @@ function burnAreaChart() {
         body.innerHTML = renderAgentTab(tabId);
       } else {
         body.innerHTML = renderGovernorTab(tabId);
+        if (tabId === 'Hub') fetchQueueCount();
       }
     }
 
@@ -8364,12 +8365,15 @@ function burnAreaChart() {
         </div>`;
     }
 
-    (function fetchQueueCount() {
+    function fetchQueueCount() {
       fetch('/api/contribute/status').then(function(r) { return r.json(); }).then(function(d) {
         var el = document.getElementById('hub-queue-count');
         if (el) el.textContent = (d.actionable_items || 0) + ' items in queue';
-      }).catch(function() {});
-    })();
+      }).catch(function() {
+        var el = document.getElementById('hub-queue-count');
+        if (el) el.textContent = '—';
+      });
+    }
 
     function toggleAutoSnapshot(el) {
       el.classList.toggle('on');


### PR DESCRIPTION
Was running at page load before element existed. Now fetches when Hub tab renders.