### PR TITLE
fix: heartbeat waits for dashboard readiness before first send

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -373,6 +373,8 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 		"agents":           len(cfg.EnabledAgents()),
 		"eval_interval_s":  cfg.Governor.EvalIntervalS,
 		"primaryRepo":      primaryRepo,
+		"hub_url":          cfg.Hub.URL,
+		"hive_id":          cfg.HiveID,
 	})
 }
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -7722,6 +7722,7 @@ function burnAreaChart() {
         if (v.dirty) html += ' <span class="git-dirty">*</span>';
         if (v.behind) {
           html += ` <span class="git-behind" title="Latest: ${escapeHtml(v.latestShort || '?')}">⬆ behind</span>`;
+          html += ` <button onclick="selfUpgrade()" style="padding:1px 8px;font-size:0.6rem;background:#238636;color:#fff;border:none;border-radius:4px;cursor:pointer;margin-left:4px" title="Upgrade to latest">⟳ Upgrade</button>`;
         } else if (v.latestHash) {
           html += ' <span style="color:#22c55e" title="Up to date with remote">✓</span>';
         }
@@ -7733,6 +7734,28 @@ function burnAreaChart() {
     setInterval(fetchGitVersion, GIT_VERSION_POLL_MS);
 
     // SSE connection
+    async function selfUpgrade() {
+      try {
+        var cfgResp = await fetch('/api/config');
+        var cfg = await cfgResp.json();
+        var hubUrl = cfg.hubUrl || cfg.hub_url || '';
+        var hiveId = cfg.hiveId || cfg.hive_id || '';
+        if (!hubUrl || !hiveId) { showToast('Hub URL or Hive ID not configured', 'error'); return; }
+        showToast('Upgrading to latest...', 'info');
+        var resp = await fetch(hubUrl + '/api/saas/hives/' + encodeURIComponent(hiveId) + '/upgrade', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' }
+        });
+        if (!resp.ok) {
+          var err = await resp.json().catch(function() { return {}; });
+          showToast('Upgrade failed: ' + (err.error || resp.statusText), 'error');
+          return;
+        }
+        showToast('Upgrade started — page will auto-refresh when ready', 'success');
+      } catch (e) { showToast('Upgrade error: ' + e.message, 'error'); }
+    }
+
     var _initialVersionHash = null;
     var VERSION_CHECK_INTERVAL_MS = 60000;
     function startVersionCheck() {

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -74,6 +74,8 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 
 	logger.Info("hub heartbeat enabled", "url", hubURL, "interval", interval)
 
+	waitForReady(ctx, logger)
+
 	sendHeartbeat(ctx, hubURL, collect, logger)
 
 	ticker := time.NewTicker(interval)
@@ -86,6 +88,39 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 			return
 		case <-ticker.C:
 			sendHeartbeat(ctx, hubURL, collect, logger)
+		}
+	}
+}
+
+func waitForReady(ctx context.Context, logger *slog.Logger) {
+	const healthURL = "http://localhost:3001/api/health"
+	const pollInterval = 5 * time.Second
+	const maxWait = 3 * time.Minute
+	deadline := time.After(maxWait)
+	logger.Info("heartbeat waiting for dashboard readiness")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-deadline:
+			logger.Warn("heartbeat readiness wait timed out, starting anyway")
+			return
+		default:
+			reqCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+			req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, healthURL, nil)
+			if err == nil {
+				resp, err := http.DefaultClient.Do(req)
+				if err == nil {
+					resp.Body.Close()
+					if resp.StatusCode == 200 {
+						cancel()
+						logger.Info("dashboard ready, starting heartbeats")
+						return
+					}
+				}
+			}
+			cancel()
+			time.Sleep(pollInterval)
 		}
 	}
 }


### PR DESCRIPTION
Polls /api/health before sending first heartbeat. Prevents hub from reporting new hash before UI is live.