### PR TITLE
fix: upgrade only shows when Docker image is actually ready

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -722,12 +722,55 @@ func fetchSHA(logger *slog.Logger) {
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	sha := strings.TrimSpace(string(body))
-	if len(sha) >= 7 {
-		latestSHAMu.Lock()
-		latestSHACache = sha[:7]
-		latestSHAMu.Unlock()
-		logger.Debug("latest SHA updated", "sha", sha[:7])
+	if len(sha) < 7 {
+		return
 	}
+	short := sha[:7]
+
+	if !isImageAvailable(short, logger) {
+		logger.Debug("latest SHA skipped — Docker image not ready", "sha", short)
+		return
+	}
+
+	latestSHAMu.Lock()
+	latestSHACache = short
+	latestSHAMu.Unlock()
+	logger.Debug("latest SHA updated", "sha", short)
+}
+
+func isImageAvailable(shortSHA string, logger *slog.Logger) bool {
+	client := &http.Client{Timeout: 10 * time.Second}
+	checkURL := "https://api.github.com/repos/kubestellar/hive/commits/" + shortSHA + "/check-runs"
+	req, err := http.NewRequest("GET", checkURL, nil)
+	if err != nil {
+		return true
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return true
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return true
+	}
+	var result struct {
+		CheckRuns []struct {
+			Name       string `json:"name"`
+			Status     string `json:"status"`
+			Conclusion string `json:"conclusion"`
+		} `json:"check_runs"`
+	}
+	json.NewDecoder(resp.Body).Decode(&result)
+	for _, cr := range result.CheckRuns {
+		if cr.Name == "docker" || cr.Name == "merge-hub" {
+			if cr.Status == "completed" && cr.Conclusion == "success" {
+				return true
+			}
+			return false
+		}
+	}
+	return false
 }
 
 func (s *HubServer) handleLatestSHA(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/snapshot/builder.go
+++ b/v2/pkg/snapshot/builder.go
@@ -97,7 +97,7 @@ func (b *Builder) Cleanup(maxAge time.Duration) error {
 }
 
 func (b *Builder) buildIndexHTML(path string, status *dashboard.StatusPayload, ts string) error {
-	html := fmt.Sprintf(`<!DOCTYPE html>
+	page := fmt.Sprintf(`<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
@@ -146,7 +146,7 @@ func (b *Builder) buildIndexHTML(path string, status *dashboard.StatusPayload, t
 
 	for _, agent := range status.Agents {
 		stateClass := "state-" + html.EscapeString(agent.State)
-		html += fmt.Sprintf(`
+		page += fmt.Sprintf(`
   <div class="agent">
     <span>%s</span>
     <span class="%s">%s</span>
@@ -155,7 +155,7 @@ func (b *Builder) buildIndexHTML(path string, status *dashboard.StatusPayload, t
 			html.EscapeString(agent.CLI), html.EscapeString(agent.Model))
 	}
 
-	html += `
+	page += `
 </div>
 
 <h2>Raw Status</h2>
@@ -168,5 +168,5 @@ func (b *Builder) buildIndexHTML(path string, status *dashboard.StatusPayload, t
 </body>
 </html>`
 
-	return os.WriteFile(path, []byte(html), 0644)
+	return os.WriteFile(path, []byte(page), 0644)
 }


### PR DESCRIPTION
SHA poller checks GitHub check-runs for 'docker' job success before updating latest_sha. Prevents premature 'behind' indicator and upgrade button.