### PR TITLE
feat: track auto-fact fallback count in inception state

### DIFF
--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -819,6 +819,8 @@ func (w *InceptionWatcher) autoGenerateFacts(ctx context.Context, state *knowled
 		return
 	}
 
+	w.inception.IncrementAutoFactCount(len(facts))
+
 	w.logger.Info("inception watcher: auto-generated facts from Q&A (agent timeout fallback)",
 		"count", len(facts),
 		"timeout", autoFactFallbackTimeout,

--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -673,6 +673,15 @@ func (e *InceptionEngine) SetWikiName(name string) {
 	}
 }
 
+func (e *InceptionEngine) IncrementAutoFactCount(count int) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.state != nil {
+		e.state.AutoFactCount += count
+		_ = e.saveState()
+	}
+}
+
 // HasWikiFiles returns true if the inception wiki has any files from a previous run.
 func (e *InceptionEngine) HasWikiFiles() bool {
 	wikiDir := filepath.Join(e.dataDir, inceptionWikiDir)

--- a/v2/pkg/knowledge/types.go
+++ b/v2/pkg/knowledge/types.go
@@ -233,6 +233,7 @@ type InceptionState struct {
 	StartedAt      time.Time         `json:"started_at"`
 	PhaseChangedAt *time.Time        `json:"phase_changed_at,omitempty"`
 	WikiName       string            `json:"wiki_name,omitempty"`
+	AutoFactCount  int               `json:"auto_fact_count,omitempty"`
 }
 
 // ScaffoldFile is a single generated file in the scaffold output.


### PR DESCRIPTION
Adds auto_fact_count to inception state API. Shows how often the 60s fallback fires vs agent-produced facts.