### PR TITLE
fix: show rate limit warning banner when GitHub API quota is low

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4079,7 +4079,22 @@ function burnAreaChart() {
       const el = document.getElementById('gh-rate-alert');
       const alerts = (ghRateLimits && ghRateLimits.alerts) || [];
       const pullbacks = (ghRateLimits && ghRateLimits.pullbacks) || [];
+      const core = (ghRateLimits && ghRateLimits.core) || {};
       const now = Math.floor(Date.now() / 1000);
+
+      const RATE_LIMIT_WARN_THRESHOLD = 100;
+      if (core.remaining !== undefined && core.remaining <= RATE_LIMIT_WARN_THRESHOLD && core.reset) {
+        const resetDate = new Date(core.reset);
+        const resetStr = resetDate.toLocaleTimeString([], {hour:'numeric',minute:'2-digit'});
+        const coreAlert = {
+          agent: 'github-api',
+          message: 'Core API: ' + core.remaining + '/' + (core.limit || '?') + ' remaining — resets ' + resetStr,
+          detected_epoch: now,
+          api_reset_epoch: Math.floor(resetDate.getTime() / 1000),
+        };
+        const hasCoreAlert = alerts.some(a => a.agent === 'github-api');
+        if (!hasCoreAlert) alerts.unshift(coreAlert);
+      }
       const GH_RATE_DEFAULT_TTL = 3600;
       const SECONDS_PER_MINUTE = 60;
       const MINUTES_PER_HOUR = 60;


### PR DESCRIPTION
## Summary
When the GitHub core API remaining quota drops below 100, a yellow warning banner appears in the dashboard showing the current remaining count and the reset time.

Previously, rate-limited repos showed 0 issues/0 PRs with no explanation — users had no idea why data was missing or when it would recover.

## Test plan
- [ ] Trigger rate limit by rapid API calls
- [ ] Verify yellow banner appears with remaining count and reset time
- [ ] Verify banner disappears after rate limit resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)