### PR TITLE
fix: handle ignored errors across 9 packages

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1830,7 +1830,9 @@ func (m *Manager) SyncModeFiles(level int) {
 			}
 		}
 		modeFile := fmt.Sprintf("/tmp/.hive-mode-%s", name)
-		_ = os.WriteFile(modeFile, []byte(mode.String()), 0o644)
+		if err := os.WriteFile(modeFile, []byte(mode.String()), 0o644); err != nil {
+			m.logger.Warn("SyncModeFiles: write failed", "file", modeFile, "error", err)
+		}
 	}
 }
 
@@ -1977,7 +1979,9 @@ func (m *Manager) agentEnvPairs(agent *AgentProcess) []agentEnvPair {
 	mode := m.agentMode(agent)
 	vars = append(vars, agentEnvPair{"HIVE_AGENT_MODE", mode.String(), false})
 	modeFile := fmt.Sprintf("/tmp/.hive-mode-%s", agent.Name)
-	_ = os.WriteFile(modeFile, []byte(mode.String()), 0o644)
+	if err := os.WriteFile(modeFile, []byte(mode.String()), 0o644); err != nil {
+		m.logger.Warn("agentBootstrapEnv: mode file write failed", "file", modeFile, "error", err)
+	}
 	proxyURL := fmt.Sprintf("http://%s@127.0.0.1:%d", agent.Name, proxyListenPort)
 	vars = append(vars, agentEnvPair{"HTTPS_PROXY", proxyURL, false})
 	vars = append(vars, agentEnvPair{"HTTP_PROXY", proxyURL, false})

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -547,9 +547,16 @@ func (s *Server) handleHistory(w http.ResponseWriter, r *http.Request) {
 	if err == nil {
 		var seed []json.RawMessage
 		if json.Unmarshal(seedData, &seed) == nil && len(seed) > 0 {
-			liveData, _ := json.Marshal(history)
+			liveData, err := json.Marshal(history)
+			if err != nil {
+				jsonResponse(w, history)
+				return
+			}
 			var liveEntries []json.RawMessage
-			_ = json.Unmarshal(liveData, &liveEntries)
+			if json.Unmarshal(liveData, &liveEntries) != nil {
+				jsonResponse(w, history)
+				return
+			}
 			combined := append(seed, liveEntries...)
 			jsonResponse(w, combined)
 			return
@@ -1783,8 +1790,10 @@ func (s *Server) handleAgentConfigRestrictions(w http.ResponseWriter, r *http.Re
 		lines = append(lines, line)
 	}
 	tmpRest := restFile + ".tmp"
-	if os.WriteFile(tmpRest, []byte(strings.Join(lines, "\n")+"\n"), 0o644) == nil {
-		_ = os.Rename(tmpRest, restFile)
+	if err := os.WriteFile(tmpRest, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		s.logger.Warn("rest file write failed", "error", err)
+	} else if err := os.Rename(tmpRest, restFile); err != nil {
+		s.logger.Warn("rest file rename failed", "error", err)
 	}
 
 	s.refreshAndPersist()
@@ -1812,8 +1821,10 @@ func (s *Server) handleAgentConfigStats(w http.ResponseWriter, r *http.Request) 
 	data, err := json.Marshal(body)
 	if err == nil {
 		tmpStats := statsFile + ".tmp"
-		if os.WriteFile(tmpStats, data, 0o644) == nil {
-			_ = os.Rename(tmpStats, statsFile)
+		if err := os.WriteFile(tmpStats, data, 0o644); err != nil {
+			s.logger.Warn("stats file write failed", "error", err)
+		} else if err := os.Rename(tmpStats, statsFile); err != nil {
+			s.logger.Warn("stats file rename failed", "error", err)
 		}
 	}
 

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -156,7 +156,14 @@ func (h *ContributeWSHub) saveActivity() {
 		return
 	}
 	os.MkdirAll("/data/contributors", 0o755)
-	os.WriteFile(activityFilePath, data, 0o644)
+	tmpPath := activityFilePath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		h.logger.Warn("[contribute-ws] activity write failed", "error", err)
+		return
+	}
+	if err := os.Rename(tmpPath, activityFilePath); err != nil {
+		h.logger.Warn("[contribute-ws] activity rename failed", "error", err)
+	}
 }
 
 const activityDebounceSecs = 60
@@ -219,11 +226,19 @@ func (h *ContributeWSHub) saveCompletedTasks() {
 	saved := make(map[string]string, len(h.completedTasks))
 	for k, t := range h.completedTasks { saved[k] = t.Format(time.RFC3339) }
 	h.completedMu.Unlock()
-	data, _ := json.Marshal(saved)
+	data, err := json.Marshal(saved)
+	if err != nil {
+		h.logger.Warn("[contribute-ws] completed tasks marshal failed", "error", err)
+		return
+	}
 	os.MkdirAll("/data/contributors", 0o755)
 	tmpPath := completedTasksFile + ".tmp"
-	if err := os.WriteFile(tmpPath, data, 0o644); err == nil {
-		os.Rename(tmpPath, completedTasksFile)
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		h.logger.Warn("[contribute-ws] completed tasks write failed", "error", err)
+		return
+	}
+	if err := os.Rename(tmpPath, completedTasksFile); err != nil {
+		h.logger.Warn("[contribute-ws] completed tasks rename failed", "error", err)
 	}
 }
 

--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -42,6 +42,7 @@ type InceptionWatcher struct {
 	lastSlug          string
 	lastKickRetry     time.Time
 	kickRetryCount    int
+	ctx               context.Context
 }
 
 // NewInceptionWatcher creates a watcher that polls the brainstorm bead store.
@@ -65,6 +66,7 @@ func NewInceptionWatcher(
 
 // Run starts the polling loop and event subscriber. Blocks until ctx is cancelled.
 func (w *InceptionWatcher) Run(ctx context.Context) {
+	w.ctx = ctx
 	w.logger.Info("inception watcher started")
 	ticker := time.NewTicker(inceptionWatchIntervalS)
 	defer ticker.Stop()
@@ -402,7 +404,7 @@ func (w *InceptionWatcher) handlePSTEvent(event pstEvent) {
 	case "tool_call_completed":
 		// bd create/update completed — trigger immediate poll to check for new beads
 		if state.Phase == knowledge.PhaseCapture || state.Phase == knowledge.PhaseStructure {
-			go w.poll(context.Background())
+			go w.poll(w.ctx)
 		}
 
 	case "raw_output":
@@ -417,7 +419,7 @@ func (w *InceptionWatcher) handlePSTEvent(event pstEvent) {
 			if strings.Contains(line, "│") {
 				for kw := range categoryKeywords {
 					if strings.Contains(lower, kw) {
-						go w.poll(context.Background())
+						go w.poll(w.ctx)
 						return
 					}
 				}
@@ -426,7 +428,7 @@ func (w *InceptionWatcher) handlePSTEvent(event pstEvent) {
 			// Detect fact bead creation in real-time
 			if strings.Contains(lower, "bd create") || strings.Contains(lower, "bd update") ||
 				strings.Contains(lower, "fact_type") || strings.Contains(lower, "fact_body") {
-				go w.poll(context.Background())
+				go w.poll(w.ctx)
 				return
 			}
 		}

--- a/v2/pkg/discord/bot.go
+++ b/v2/pkg/discord/bot.go
@@ -352,7 +352,11 @@ func (b *Bot) cmdAgentAction(action, args string) (string, error) {
 func (b *Bot) dashboardKick(agent, prompt string) (string, error) {
 	var body []byte
 	if prompt != "" {
-		body, _ = json.Marshal(map[string]string{"prompt": prompt})
+		var err error
+		body, err = json.Marshal(map[string]string{"prompt": prompt})
+		if err != nil {
+			return fmt.Sprintf("❌ Failed to marshal kick payload: %s", err), nil
+		}
 	}
 	err := b.dashboardPost(fmt.Sprintf("/api/kick/%s", agent), body)
 	if err != nil {
@@ -571,7 +575,10 @@ func (b *Bot) updateTopic(snap *statusSnapshot) {
 }
 
 func (b *Bot) setChannelTopic(topic string) error {
-	payload, _ := json.Marshal(map[string]string{"topic": topic})
+	payload, err := json.Marshal(map[string]string{"topic": topic})
+	if err != nil {
+		return fmt.Errorf("marshal topic payload: %w", err)
+	}
 	url := fmt.Sprintf("%s/channels/%s", discordAPIBase, b.channelID)
 
 	req, err := http.NewRequest(http.MethodPatch, url, bytes.NewReader(payload))

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -148,12 +148,16 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	isAdmin := cookie.Value == hubAdminUsername
-	data, _ := json.Marshal(map[string]any{
+	data, err := json.Marshal(map[string]any{
 		"authenticated": true,
 		"login":         cookie.Value,
 		"avatar_url":    fmt.Sprintf("https://github.com/%s.png", cookie.Value),
 		"hub_admin":     isAdmin,
 	})
+	if err != nil {
+		http.Error(w, `{"error":"internal"}`, http.StatusInternalServerError)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(data)
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -44,7 +44,9 @@ func loadOrCreateHMACKey() ([]byte, error) {
 	if _, err := io.ReadFull(rand.Reader, key); err != nil {
 		return nil, err
 	}
-	os.WriteFile(hmacKeyPath, key, 0o600)
+	if err := os.WriteFile(hmacKeyPath, key, 0o600); err != nil {
+		return nil, fmt.Errorf("write HMAC key: %w", err)
+	}
 	return key, nil
 }
 
@@ -281,7 +283,9 @@ func ensureSaaSUser(username string) *SaaSUser {
 	u := loadSaaSUser(username)
 	if u != nil {
 		u.LastLogin = now
-		saveSaaSUser(u)
+		if err := saveSaaSUser(u); err != nil {
+			slog.Warn("ensureSaaSUser: save failed", "user", username, "error", err)
+		}
 		return u
 	}
 	quota := 0
@@ -871,11 +875,19 @@ func loadAccessRequests(hiveID string) []AccessRequest {
 func saveAccessRequests(hiveID string, reqs []AccessRequest) {
 	dir := filepath.Join(saasHivesDir, hiveID)
 	os.MkdirAll(dir, 0o755)
-	data, _ := json.MarshalIndent(reqs, "", "  ")
+	data, err := json.MarshalIndent(reqs, "", "  ")
+	if err != nil {
+		slog.Warn("saveAccessRequests: marshal failed", "hiveID", hiveID, "error", err)
+		return
+	}
 	path := filepath.Join(dir, "requests.json")
 	tmpPath := path + ".tmp"
-	if os.WriteFile(tmpPath, data, 0o644) == nil {
-		os.Rename(tmpPath, path)
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		slog.Warn("saveAccessRequests: write failed", "error", err)
+		return
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		slog.Warn("saveAccessRequests: rename failed", "error", err)
 	}
 }
 

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -101,7 +101,9 @@ func NewHubServer(port int, logger *slog.Logger, gitHash string) *HubServer {
 		cryptoRand.Read(b)
 		secret = fmt.Sprintf("%x", b)
 		os.MkdirAll("/data/saas", 0o755)
-		os.WriteFile("/data/saas/hub-secret.key", []byte(secret), 0o600)
+		if err := os.WriteFile("/data/saas/hub-secret.key", []byte(secret), 0o600); err != nil {
+			logger.Error("failed to write hub secret", "error", err)
+		}
 		logger.Info("generated hub secret", "path", "/data/saas/hub-secret.key")
 	}
 	s := &HubServer{

--- a/v2/pkg/notify/notify.go
+++ b/v2/pkg/notify/notify.go
@@ -133,7 +133,11 @@ func (n *Notifier) sendSlack(title, message string) {
 		"text": fmt.Sprintf("*%s*\n%s", title, message),
 	}
 
-	body, _ := json.Marshal(payload)
+	body, err := json.Marshal(payload)
+	if err != nil {
+		n.logger.Warn("slack payload marshal failed", "error", err)
+		return
+	}
 	resp, err := n.client.Post(n.cfg.Slack.Webhook, "application/json", bytes.NewReader(body))
 	if err != nil {
 		n.logger.Warn("slack send failed", "error", err)
@@ -150,7 +154,11 @@ func (n *Notifier) sendDiscordWebhook(title, message string) {
 		"content": fmt.Sprintf("**%s**\n%s", title, message),
 	}
 
-	body, _ := json.Marshal(payload)
+	body, err := json.Marshal(payload)
+	if err != nil {
+		n.logger.Warn("discord payload marshal failed", "error", err)
+		return
+	}
 	resp, err := n.client.Post(n.cfg.Discord.Webhook, "application/json", bytes.NewReader(body))
 	if err != nil {
 		n.logger.Warn("discord webhook send failed", "error", err)


### PR DESCRIPTION
## Summary
- **notify**: check json.Marshal errors for Slack/Discord webhook payloads
- **discord**: check json.Marshal for kick payload and topic update
- **contribute_ws**: atomic write for activity file, check marshal/rename errors for completed tasks
- **api**: propagate sparkline marshal/unmarshal errors, log rest/stats file write failures
- **inception_watcher**: use parent context instead of context.Background() to fix goroutine leak on shutdown
- **agent/manager**: log mode file write failures instead of silently discarding
- **hub/server**: log hub secret write failure
- **hub/saas**: propagate HMAC key write error, log ensureSaaSUser save failure, check access requests marshal/write/rename errors
- **hub/oauth**: return 500 on handleCheckAuth marshal failure instead of writing nil body

9 files, 91 insertions, 26 deletions — all silent error suppression or missing error propagation.

## Test plan
- [ ] Verify Slack/Discord notifications still send correctly
- [ ] Verify activity/completed-tasks files persist across restarts
- [ ] Verify ACMM mode sweeps still pass (mode files written correctly)
- [ ] Verify hub login/auth flow works
- [ ] Verify inception watcher goroutines shut down cleanly on stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)