### PR TITLE
fix: restore simple SHA poller — fixes missing ✓ indicator

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -729,32 +729,11 @@ func fetchSHA(logger *slog.Logger) {
 	}
 	body, _ := io.ReadAll(resp.Body)
 	sha := strings.TrimSpace(string(body))
-	if len(sha) < 7 {
-		return
-	}
-	short := sha[:7]
-	latestCommitMu.Lock()
-	latestCommitSHA = short
-	latestCommitMu.Unlock()
-}
-
-var (
-	latestCommitMu  sync.RWMutex
-	latestCommitSHA string
-)
-
-func updateLatestSHAFromHeartbeat(gitHash string) {
-	if gitHash == "" {
-		return
-	}
-	latestCommitMu.RLock()
-	commitSHA := latestCommitSHA
-	latestCommitMu.RUnlock()
-
-	if gitHash == commitSHA {
+	if len(sha) >= 7 {
 		latestSHAMu.Lock()
-		latestSHACache = gitHash
+		latestSHACache = sha[:7]
 		latestSHAMu.Unlock()
+		logger.Debug("latest SHA updated", "sha", sha[:7])
 	}
 }
 

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -317,7 +317,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	s.mu.Unlock()
 
 	s.requestSave()
-	updateLatestSHAFromHeartbeat(payload.GitHash)
+
 
 	s.logger.Info("audit: hub heartbeat received",
 		"hive_id", payload.HiveID,


### PR DESCRIPTION
Heartbeat-verified approach broke because target kept moving. Reverted to simple commit-based latest_sha.