### PR TITLE
fix: defer anchor scroll + restore simple SHA poller

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6483,11 +6483,12 @@ function burnAreaChart() {
     }
 
     let _hashScrollPending = false;
+    var SCROLL_SETTLE_DELAY_MS = 500;
     function _afterPaint(callback) {
       _hashScrollPending = true;
       requestAnimationFrame(function() {
         requestAnimationFrame(function() {
-          callback();
+          setTimeout(callback, SCROLL_SETTLE_DELAY_MS);
           setTimeout(function() { _hashScrollPending = false; }, 500);
         });
       });

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -729,32 +729,11 @@ func fetchSHA(logger *slog.Logger) {
 	}
 	body, _ := io.ReadAll(resp.Body)
 	sha := strings.TrimSpace(string(body))
-	if len(sha) < 7 {
-		return
-	}
-	short := sha[:7]
-	latestCommitMu.Lock()
-	latestCommitSHA = short
-	latestCommitMu.Unlock()
-}
-
-var (
-	latestCommitMu  sync.RWMutex
-	latestCommitSHA string
-)
-
-func updateLatestSHAFromHeartbeat(gitHash string) {
-	if gitHash == "" {
-		return
-	}
-	latestCommitMu.RLock()
-	commitSHA := latestCommitSHA
-	latestCommitMu.RUnlock()
-
-	if gitHash == commitSHA {
+	if len(sha) >= 7 {
 		latestSHAMu.Lock()
-		latestSHACache = gitHash
+		latestSHACache = sha[:7]
 		latestSHAMu.Unlock()
+		logger.Debug("latest SHA updated", "sha", sha[:7])
 	}
 }
 

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -317,7 +317,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	s.mu.Unlock()
 
 	s.requestSave()
-	updateLatestSHAFromHeartbeat(payload.GitHash)
+
 
 	s.logger.Info("audit: hub heartbeat received",
 		"hive_id", payload.HiveID,


### PR DESCRIPTION
Scroll waits 500ms for async sections. SHA poller restored to simple commit-based approach.