### PR TITLE
fix: data race, HTML injection, unbounded growth, silent failures

### DIFF
--- a/v2/pkg/beads/beads.go
+++ b/v2/pkg/beads/beads.go
@@ -105,6 +105,8 @@ func (b *Bead) Meta(key string) string {
 	return ""
 }
 
+const maxBeadCount = 5000
+
 type Store struct {
 	dir    string
 	hiveID string
@@ -163,7 +165,29 @@ func (s *Store) Create(title string, beadType BeadType, priority Priority, actor
 	}
 
 	s.beads[b.ID] = b
+	s.evictOldClosed()
 	return b, s.persist(b)
+}
+
+func (s *Store) evictOldClosed() {
+	if len(s.beads) <= maxBeadCount {
+		return
+	}
+	var closedIDs []string
+	for id, b := range s.beads {
+		if b.Status == StatusClosed || b.Status == StatusDone {
+			closedIDs = append(closedIDs, id)
+		}
+	}
+	sort.Slice(closedIDs, func(i, j int) bool {
+		return s.beads[closedIDs[i]].UpdatedAt.Before(s.beads[closedIDs[j]].UpdatedAt.Time)
+	})
+	for _, id := range closedIDs {
+		if len(s.beads) <= maxBeadCount {
+			break
+		}
+		delete(s.beads, id)
+	}
 }
 
 func (s *Store) Update(id string, fn func(b *Bead)) error {

--- a/v2/pkg/config/watcher.go
+++ b/v2/pkg/config/watcher.go
@@ -74,6 +74,7 @@ func (w *Watcher) Start(ctx context.Context) {
 
 		case event, ok := <-fsw.Events:
 			if !ok {
+				w.logger.Warn("config watcher: events channel closed")
 				return
 			}
 			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Rename) == 0 {
@@ -83,6 +84,7 @@ func (w *Watcher) Start(ctx context.Context) {
 
 		case err, ok := <-fsw.Errors:
 			if !ok {
+				w.logger.Warn("config watcher: errors channel closed")
 				return
 			}
 			w.logger.Warn("config watcher error", "error", err)

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -706,14 +706,21 @@ func BuildBeadsFromConfig(stores map[string]*beads.Store, cfg *config.Config) Fr
 	return fb
 }
 
+func copyHealthMap(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
 func buildHealth(ghClient *github.Client, ctx context.Context) map[string]any {
 	if ghClient == nil || ctx == nil {
 		cachedHealthMu.RLock()
+		defer cachedHealthMu.RUnlock()
 		if cachedHealth != nil {
-			defer cachedHealthMu.RUnlock()
-			return cachedHealth
+			return copyHealthMap(cachedHealth)
 		}
-		cachedHealthMu.RUnlock()
 		return map[string]any{"ci": 100}
 	}
 
@@ -723,7 +730,7 @@ func buildHealth(ghClient *github.Client, ctx context.Context) map[string]any {
 	cachedHealth = health
 	cachedHealthMu.Unlock()
 
-	return health
+	return copyHealthMap(health)
 }
 
 func buildBudget(gov *governor.Governor, tokenCollector *tokens.Collector) FrontendBudget {

--- a/v2/pkg/snapshot/builder.go
+++ b/v2/pkg/snapshot/builder.go
@@ -7,10 +7,13 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
 	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/dashboard"
 )
+
+var safeClassRe = regexp.MustCompile(`[^a-zA-Z0-9-]`)
 
 type Builder struct {
 	outputDir string
@@ -84,7 +87,10 @@ func (b *Builder) Cleanup(maxAge time.Duration) error {
 		}
 
 		if info.ModTime().Before(cutoff) {
-			os.Remove(filepath.Join(b.outputDir, name))
+			if err := os.Remove(filepath.Join(b.outputDir, name)); err != nil {
+				b.logger.Warn("snapshot cleanup: remove failed", "file", name, "error", err)
+				continue
+			}
 			removed++
 		}
 	}
@@ -145,7 +151,7 @@ func (b *Builder) buildIndexHTML(path string, status *dashboard.StatusPayload, t
 	)
 
 	for _, agent := range status.Agents {
-		stateClass := "state-" + html.EscapeString(agent.State)
+		stateClass := "state-" + safeClassRe.ReplaceAllString(agent.State, "")
 		page += fmt.Sprintf(`
   <div class="agent">
     <span>%s</span>


### PR DESCRIPTION
## Summary
- **cachedHealth data race**: `buildHealth()` returned a direct pointer to the shared `cachedHealth` map — callers could read it while another goroutine was writing. Now returns a copy.
- **Snapshot HTML injection**: `agent.State` was used in a CSS class attribute via `html.EscapeString()` which doesn't prevent attribute breakout with quotes. Now sanitized with regex to strip non-alphanumeric chars.
- **Snapshot cleanup errors**: `os.Remove()` failures were silently ignored and counted as successful — now logged with file name and error.
- **Config watcher silent death**: fsnotify channel closures caused silent return — now logged so watcher failures are visible.
- **Unbounded bead storage**: Bead map grew without limit. Added `maxBeadCount` (5000) with LRU eviction of closed/done beads on Create.

## Test plan
- [ ] Verify ACMM sweep still passes
- [ ] Verify beads create/close lifecycle works
- [ ] Verify snapshot HTML renders correctly
- [ ] Verify config watcher still detects changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)