### PR TITLE
fix: vault disconnect path traversal and subscription SSRF

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -2905,6 +2905,14 @@ func (s *Server) handleKnowledgeSubsAdd(w http.ResponseWriter, r *http.Request) 
 		jsonError(w, "url is required", http.StatusBadRequest)
 		return
 	}
+	if !strings.HasPrefix(sub.URL, "https://") && !strings.HasPrefix(sub.URL, "http://") {
+		jsonError(w, "url must use http or https scheme", http.StatusBadRequest)
+		return
+	}
+	if isPrivateURL(sub.URL) {
+		jsonError(w, "subscription url must not point to private/internal addresses", http.StatusBadRequest)
+		return
+	}
 	if sub.Layer == "" {
 		sub.Layer = knowledge.LayerOrg
 	}
@@ -3007,6 +3015,14 @@ func (s *Server) handleVaultsDisconnect(w http.ResponseWriter, r *http.Request) 
 		jsonError(w, "path is required", http.StatusBadRequest)
 		return
 	}
+	if strings.Contains(req.Path, "..") {
+		jsonError(w, "vault path must not contain '..'", http.StatusBadRequest)
+		return
+	}
+	if !filepath.IsAbs(req.Path) {
+		jsonError(w, "vault path must be absolute", http.StatusBadRequest)
+		return
+	}
 
 	if err := s.deps.Knowledge.DisconnectVault(req.Path); err != nil {
 		jsonError(w, err.Error(), http.StatusNotFound)
@@ -3034,6 +3050,10 @@ func (s *Server) handleVaultsReindex(w http.ResponseWriter, r *http.Request) {
 	}
 	if strings.Contains(req.Path, "..") {
 		jsonError(w, "path must not contain '..'", http.StatusBadRequest)
+		return
+	}
+	if !filepath.IsAbs(req.Path) {
+		jsonError(w, "path must be absolute", http.StatusBadRequest)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- **Vault disconnect path traversal**: `handleVaultsDisconnect` was missing the `..` and `IsAbs` validation that `handleVaultsConnect` already had
- **Subscription SSRF**: `handleKnowledgeSubsAdd` accepted any URL without scheme or private IP validation — could be used to probe internal services (localhost, AWS metadata, etc.)
- **Vault reindex missing IsAbs**: Had `..` check but not absolute path requirement

## Test plan
- [ ] Verify vault connect/disconnect/reindex still work with valid paths
- [ ] Verify subscription add rejects `http://localhost`, `http://169.254.169.254`
- [ ] Verify vault disconnect rejects `../../etc/passwd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)