### PR TITLE
fix: hub server graceful shutdown and slowloris protection

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -1862,12 +1863,16 @@ func runHub(logger *slog.Logger) {
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		sig := <-sigCh
-		logger.Info("hub received signal, shutting down", "signal", sig)
-		os.Exit(0)
+		logger.Info("hub received signal, shutting down gracefully", "signal", sig)
+		const shutdownTimeout = 10 * time.Second
+		if err := hubSrv.Shutdown(shutdownTimeout); err != nil {
+			logger.Error("hub graceful shutdown failed", "error", err)
+		}
 	}()
 
-	if err := hubSrv.Start(port); err != nil {
+	if err := hubSrv.Start(port); err != nil && err != http.ErrServerClosed {
 		logger.Error("hub server failed", "error", err)
 		os.Exit(1)
 	}
+	logger.Info("hub server stopped")
 }

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"context"
 	cryptoRand "crypto/rand"
 	"embed"
 	"encoding/json"
@@ -86,6 +87,7 @@ type HubServer struct {
 	saveCh     chan struct{}
 	hubGitHash string
 	hubSecret  string
+	httpServer *http.Server
 }
 
 func NewHubServer(port int, logger *slog.Logger, gitHash string) *HubServer {
@@ -139,10 +141,32 @@ func NewHubServer(port int, logger *slog.Logger, gitHash string) *HubServer {
 	return s
 }
 
+const (
+	hubReadTimeout  = 30 * time.Second
+	hubWriteTimeout = 60 * time.Second
+	hubIdleTimeout  = 120 * time.Second
+)
+
 func (s *HubServer) Start(port int) error {
 	addr := fmt.Sprintf(":%d", port)
 	s.logger.Info("hub server starting", "addr", addr)
-	return http.ListenAndServe(addr, s.mux)
+	s.httpServer = &http.Server{
+		Addr:         addr,
+		Handler:      s.mux,
+		ReadTimeout:  hubReadTimeout,
+		WriteTimeout: hubWriteTimeout,
+		IdleTimeout:  hubIdleTimeout,
+	}
+	return s.httpServer.ListenAndServe()
+}
+
+func (s *HubServer) Shutdown(timeout time.Duration) error {
+	if s.httpServer == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return s.httpServer.Shutdown(ctx)
 }
 
 func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Replaces http.ListenAndServe with http.Server for proper timeouts (Read 30s, Write 60s, Idle 120s) and graceful shutdown. Signal handler now drains in-flight requests instead of os.Exit(0).