### PR TITLE
fix: obsidian sync path traversal, dashboard and app client timeouts

### DIFF
--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -302,9 +302,17 @@ func (s *Server) Start() error {
 
 	handler := s.roleEnforcement(s.securityHeaders(s.mux))
 
+	const dashboardReadTimeout = 30 * time.Second
+	const dashboardIdleTimeout = 120 * time.Second
 	addr := fmt.Sprintf(":%d", s.port)
 	s.logger.Info("dashboard starting", "addr", addr)
-	return http.ListenAndServe(addr, handler)
+	srv := &http.Server{
+		Addr:        addr,
+		Handler:     handler,
+		ReadTimeout: dashboardReadTimeout,
+		IdleTimeout: dashboardIdleTimeout,
+	}
+	return srv.ListenAndServe()
 }
 
 func (s *Server) securityHeaders(next http.Handler) http.Handler {

--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -205,7 +205,8 @@ func NewClientFromApp(auth *AppAuth, org string, repos []string, logger *slog.Lo
 		auth: auth,
 		base: http.DefaultTransport,
 	}
-	httpClient := &http.Client{Transport: transport}
+	const appClientTimeout = 30 * time.Second
+	httpClient := &http.Client{Transport: transport, Timeout: appClientTimeout}
 	client := gh.NewClient(httpClient)
 
 	return &Client{

--- a/v2/pkg/knowledge/api.go
+++ b/v2/pkg/knowledge/api.go
@@ -721,6 +721,10 @@ func (k *KnowledgeAPI) ObsidianSync(ctx context.Context, req ObsidianSyncRequest
 	tags := extractFrontmatterStringSlice(req.Frontmatter, "tags")
 	factType := extractFrontmatterString(req.Frontmatter, "type", "pattern")
 	layer := extractFrontmatterString(req.Frontmatter, "layer", "project")
+	layer = filepath.Base(layer)
+	if layer == "" || layer == "." || layer == ".." {
+		layer = "project"
+	}
 	confidence := extractFrontmatterFloat(req.Frontmatter, "confidence", defaultObsidianConfidence)
 
 	layerType := LayerType(layer)


### PR DESCRIPTION
Sanitizes layer parameter from Obsidian frontmatter to prevent directory traversal. Adds read/idle timeouts to dashboard HTTP server. Adds 30s timeout to GitHub App HTTP client.