### PR TITLE
fix: escape repo names and model names in dashboard innerHTML

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3050,8 +3050,8 @@
         const mergedPairs = pairs.filter(p => p.state === 'merged');
         const _org = (window._primaryRepo || 'kubestellar/console').split('/')[0];
         const _defaultRepo = (window._primaryRepo || 'kubestellar/console').split('/')[1];
-        const _ghUrl = (p, type) => `https://github.com/${_org}/${p.repo || _defaultRepo}/${type}/${type === 'issues' ? p.issue : p.pr}`;
-        const _repoTag = (p) => (p.repo && p.repo !== _defaultRepo) ? `<span style="color:var(--muted);font-size:0.65rem">${p.repo}/</span>` : '';
+        const _ghUrl = (p, type) => `https://github.com/${encodeURIComponent(_org)}/${encodeURIComponent(p.repo || _defaultRepo)}/${type}/${type === 'issues' ? p.issue : p.pr}`;
+        const _repoTag = (p) => (p.repo && p.repo !== _defaultRepo) ? `<span style="color:var(--muted);font-size:0.65rem">${esc(p.repo)}/</span>` : '';
         const renderPair = (p) => {
           const issueLabel = p.issueTitle ? `⊙ #${p.issue} — ${esc(p.issueTitle.length > 48 ? p.issueTitle.slice(0, 48) + '…' : p.issueTitle)}` : `⊙ #${p.issue}`;
           const issueTip = p.issueTitle ? esc(p.issueTitle) : '';
@@ -3484,10 +3484,10 @@
         const pillsHtml = allPills ? `<div class="repo-issues">${allPills}</div>` : '';
         return `
         <div class="repo-card">
-          <div class="repo-name"><a href="${repoUrl}" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">${r.full || r.name}</a></div>
+          <div class="repo-name"><a href="${esc(repoUrl)}" target="_blank" rel="noopener" style="color:inherit;text-decoration:none">${esc(r.full || r.name)}</a></div>
           <div class="repo-stats">
-            <div class="repo-stat"><a href="${repoUrl}/issues" target="_blank" rel="noopener" style="color:inherit;text-decoration:none"><div class="spark-row"><span class="num">${r.issues >= 0 ? r.issues : '?'}</span>${iSpark}</div><div class="label">issues</div></a></div>
-            <div class="repo-stat"><a href="${repoUrl}/pulls" target="_blank" rel="noopener" style="color:inherit;text-decoration:none"><div class="spark-row"><span class="num">${r.prs >= 0 ? r.prs : '?'}</span>${pSpark}</div><div class="label">PRs</div></a></div>
+            <div class="repo-stat"><a href="${esc(repoUrl)}/issues" target="_blank" rel="noopener" style="color:inherit;text-decoration:none"><div class="spark-row"><span class="num">${r.issues >= 0 ? r.issues : '?'}</span>${iSpark}</div><div class="label">issues</div></a></div>
+            <div class="repo-stat"><a href="${esc(repoUrl)}/pulls" target="_blank" rel="noopener" style="color:inherit;text-decoration:none"><div class="spark-row"><span class="num">${r.prs >= 0 ? r.prs : '?'}</span>${pSpark}</div><div class="label">PRs</div></a></div>
           </div>${pillsHtml}
         </div>`;
       }).join(''));
@@ -3628,7 +3628,7 @@
       const pin = pinned ? ' \u{1F4CC}' : '';
       const pinTitle = pinned ? ' (pinned — click to unpin)' : '';
       const click = pinned && agent ? ` data-action="togglePin" data-agent="${esc(agent)}" data-pin-type="model" data-unpin="true" style="cursor:pointer"` : '';
-      return `<span class="model-chip ${chipCls}" title="${model}${overrideTitle}${pinTitle}"${click}>${shortModel}${overrideIcon}${pin}</span>`;
+      return `<span class="model-chip ${chipCls}" title="${esc(model)}${esc(overrideTitle)}${pinTitle}"${click}>${esc(shortModel)}${overrideIcon}${pin}</span>`;
     }
 
     function buildCadenceAdvisor(byAgent) {


### PR DESCRIPTION
Fixes XSS in repo card rendering (_repoTag, repo-card href/text) and model chip title attribute. Repo names from the config API were rendered as raw HTML; model names could break out of title attribute with double quotes.