### PR TITLE
fix: constant-time auth token comparison to prevent timing attacks

### DIFF
--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -461,7 +461,7 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			profiles := listContributorProfiles()
 			var profile *ContributorProfile
 			for i := range profiles {
-				if profiles[i].RegistrationToken == tokenHash {
+				if secureCompare(profiles[i].RegistrationToken, tokenHash) {
 					profile = &profiles[i]
 					break
 				}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"crypto/subtle"
 	"embed"
 	"encoding/json"
 	"fmt"
@@ -16,6 +17,10 @@ import (
 
 //go:embed static
 var staticFS embed.FS
+
+func secureCompare(a, b string) bool {
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
 
 const agentSkipAfterFullBroadcastS = 5 * time.Second
 const maxSSEClients = 100
@@ -325,7 +330,7 @@ func (s *Server) securityHeaders(next http.Handler) http.Handler {
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 
 		if s.authToken != "" && strings.HasPrefix(r.URL.Path, "/api/") && r.URL.Path != "/api/health" && r.URL.Path != "/api/auth/token" {
-			trusted := r.Header.Get("X-Hive-Internal") == s.authToken
+			trusted := secureCompare(r.Header.Get("X-Hive-Internal"), s.authToken)
 			if !trusted && r.Header.Get("X-Hive-User") != "" {
 				trusted = true
 			}
@@ -335,7 +340,7 @@ func (s *Server) securityHeaders(next http.Handler) http.Handler {
 					token = r.URL.Query().Get("token")
 				}
 				expected := "Bearer " + s.authToken
-				if token != expected && token != s.authToken {
+				if !secureCompare(token, expected) && !secureCompare(token, s.authToken) {
 					http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
 					return
 				}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -3,6 +3,7 @@ package hub
 import (
 	"context"
 	cryptoRand "crypto/rand"
+	"crypto/subtle"
 	"embed"
 	"encoding/json"
 	"fmt"
@@ -77,6 +78,10 @@ func sanitizeField(s string) string {
 
 func isValidName(s string) bool {
 	return safeNamePattern.MatchString(s) && len(s) <= 100
+}
+
+func secureCompareHub(a, b string) bool {
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }
 
 type HubServer struct {
@@ -172,7 +177,7 @@ func (s *HubServer) Shutdown(timeout time.Duration) error {
 func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	if s.hubSecret != "" {
 		auth := r.Header.Get("Authorization")
-		if !strings.HasPrefix(auth, "Bearer ") || strings.TrimPrefix(auth, "Bearer ") != s.hubSecret {
+		if !strings.HasPrefix(auth, "Bearer ") || !secureCompareHub(strings.TrimPrefix(auth, "Bearer "), s.hubSecret) {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
@@ -395,7 +400,7 @@ func (s *HubServer) handleLeaderboard(w http.ResponseWriter, r *http.Request) {
 func (s *HubServer) handleTaskStatus(w http.ResponseWriter, r *http.Request) {
 	if s.hubSecret != "" {
 		auth := r.Header.Get("Authorization")
-		if !strings.HasPrefix(auth, "Bearer ") || strings.TrimPrefix(auth, "Bearer ") != s.hubSecret {
+		if !strings.HasPrefix(auth, "Bearer ") || !secureCompareHub(strings.TrimPrefix(auth, "Bearer "), s.hubSecret) {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}


### PR DESCRIPTION
Replaces string == with subtle.ConstantTimeCompare for all auth token checks: dashboard Bearer/X-Hive-Internal, hub heartbeat/task-status hubSecret, and contribute WebSocket registration token hash. String equality leaks token bytes through response timing.