### PR TITLE
fix: Python injection in merge-gate and hive-config scripts

### DIFF
--- a/bin/hive-config.sh
+++ b/bin/hive-config.sh
@@ -95,7 +95,7 @@ _hive_read_array() {
     echo "${2:-}"
   else
     if command -v python3 &>/dev/null; then
-      python3 -c "import json; print(' '.join(json.loads('''$val''')))" 2>/dev/null || echo "${2:-}"
+      python3 -c "import json,sys; print(' '.join(json.loads(sys.argv[1])))" "$val" 2>/dev/null || echo "${2:-}"
     else
       echo "$val" | tr -d '[]",' | xargs
     fi
@@ -112,7 +112,7 @@ _hive_read_runtime_array() {
     _hive_read_array "$1" "${2:-}"
   else
     if command -v python3 &>/dev/null; then
-      python3 -c "import json; print(' '.join(json.loads('''$val''')))" 2>/dev/null || echo "${2:-}"
+      python3 -c "import json,sys; print(' '.join(json.loads(sys.argv[1])))" "$val" 2>/dev/null || echo "${2:-}"
     else
       echo "$val" | tr -d '[]",' | xargs
     fi

--- a/bin/merge-gate.sh
+++ b/bin/merge-gate.sh
@@ -107,7 +107,7 @@ else:
       mergeable=$(echo "$pr_info" | python3 -c "import json,sys; print(json.load(sys.stdin).get('mergeable','UNKNOWN'))" 2>/dev/null || echo "UNKNOWN")
       review=$(echo "$pr_info" | python3 -c "import json,sys; print(json.load(sys.stdin).get('reviewDecision',''))" 2>/dev/null || echo "")
 
-      echo "{\"repo\":\"$repo\",\"number\":$num,\"status\":\"$status\",\"author\":\"$author\",\"title\":$(python3 -c "import json; print(json.dumps('$title'[:100]))" 2>/dev/null || echo '""'),\"mergeable\":\"$mergeable\",\"reviewDecision\":\"$review\"}" > "$checks_tmp/${repo//\//_}_${num}.json"
+      echo "{\"repo\":\"$repo\",\"number\":$num,\"status\":\"$status\",\"author\":\"$author\",\"title\":$(python3 -c "import json,sys; print(json.dumps(sys.argv[1][:100]))" "$title" 2>/dev/null || echo '""'),\"mergeable\":\"$mergeable\",\"reviewDecision\":\"$review\"}" > "$checks_tmp/${repo//\//_}_${num}.json"
     fi
   ) &
 done


### PR DESCRIPTION
PR title from GitHub API was interpolated into Python string in merge-gate.sh. YAML array values interpolated via triple-quotes in hive-config.sh. Both now use sys.argv.