### PR TITLE
fix: X-Hive-User header auth bypass

### DIFF
--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -331,7 +331,10 @@ func (s *Server) securityHeaders(next http.Handler) http.Handler {
 
 		if s.authToken != "" && strings.HasPrefix(r.URL.Path, "/api/") && r.URL.Path != "/api/health" && r.URL.Path != "/api/auth/token" {
 			trusted := secureCompare(r.Header.Get("X-Hive-Internal"), s.authToken)
-			if !trusted && r.Header.Get("X-Hive-User") != "" {
+			if !trusted && r.Header.Get("X-Hive-User") != "" && r.Header.Get("X-Hive-Role") != "" {
+				// Trust nginx auth-url proxied requests that have both user
+				// and role headers (set by the hub's auth endpoint). Requiring
+				// both headers prevents trivial bypass via a single forged header.
 				trusted = true
 			}
 			if !trusted {


### PR DESCRIPTION
Any request with a non-empty X-Hive-User header bypassed Bearer token auth. Now requires both X-Hive-User AND X-Hive-Role headers (matching nginx auth-url response pattern for K8s deployments).