### PR TITLE
fix: use isTrustedOrigin for upgrade CORS validation

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -684,7 +684,7 @@ func (s *HubServer) handleDeleteHive(w http.ResponseWriter, r *http.Request) {
 
 func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
 	origin := r.Header.Get("Origin")
-	if strings.HasSuffix(origin, ".hive.kubestellar.io") || origin == "https://hive.kubestellar.io" {
+	if isTrustedOrigin(origin) {
 		w.Header().Set("Access-Control-Allow-Origin", origin)
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")


### PR DESCRIPTION
PR #1164 used raw strings.HasSuffix for CORS origin check. Should use isTrustedOrigin (from PR #1155) which properly parses URLs.