### PR TITLE
fix: spoke self-upgrade proxied server-side — no CORS

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3,6 +3,7 @@ package dashboard
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -29,6 +30,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/config", s.handleConfig)
 	s.mux.HandleFunc("GET /api/config/download", s.handleConfigDownload)
 	s.mux.HandleFunc("GET /api/audit", s.handleAuditLog)
+	s.mux.HandleFunc("POST /api/self-upgrade", s.handleSelfUpgrade)
 	s.mux.HandleFunc("GET /api/snapshot", s.handleSnapshotAPI)
 	s.mux.HandleFunc("GET /snapshot", s.handleSnapshotPage)
 	s.mux.HandleFunc("GET /api/history", s.handleHistory)
@@ -430,6 +432,52 @@ func (s *Server) handleConfigDownload(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/x-yaml")
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
 	w.Write(data)
+}
+
+func (s *Server) handleSelfUpgrade(w http.ResponseWriter, r *http.Request) {
+	role := r.Header.Get("X-Hive-Role")
+	if role == "" {
+		role = "owner"
+	}
+	if role != "owner" {
+		jsonError(w, "owner access required", http.StatusForbidden)
+		return
+	}
+	if s.deps == nil || s.deps.Config == nil {
+		jsonError(w, "config not loaded", http.StatusInternalServerError)
+		return
+	}
+	hubURL := s.deps.Config.Hub.URL
+	hiveID := s.deps.Config.HiveID
+	if hubURL == "" || hiveID == "" {
+		jsonError(w, "hub URL or hive ID not configured", http.StatusBadRequest)
+		return
+	}
+	upgradeURL := hubURL + "/api/saas/hives/" + hiveID + "/upgrade"
+
+	cookie, _ := r.Cookie("hive_hub_user")
+	client := &http.Client{Timeout: 30 * time.Second}
+	req, err := http.NewRequest("POST", upgradeURL, nil)
+	if err != nil {
+		jsonError(w, "failed to create request", http.StatusInternalServerError)
+		return
+	}
+	if cookie != nil {
+		req.AddCookie(cookie)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Origin", "https://hive.kubestellar.io")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		jsonError(w, "hub unreachable: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
+	w.Write(body)
 }
 
 func (s *Server) handleSnapshotAPI(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -7753,17 +7753,8 @@ function burnAreaChart() {
     // SSE connection
     async function selfUpgrade() {
       try {
-        var cfgResp = await fetch('/api/config');
-        var cfg = await cfgResp.json();
-        var hubUrl = cfg.hubUrl || cfg.hub_url || '';
-        var hiveId = cfg.hiveId || cfg.hive_id || '';
-        if (!hubUrl || !hiveId) { showToast('Hub URL or Hive ID not configured', 'error'); return; }
         showToast('Upgrading to latest...', 'info');
-        var resp = await fetch(hubUrl + '/api/saas/hives/' + encodeURIComponent(hiveId) + '/upgrade', {
-          method: 'POST',
-          credentials: 'include',
-          headers: { 'Content-Type': 'application/json' }
-        });
+        var resp = await fetch('/api/self-upgrade', { method: 'POST' });
         if (!resp.ok) {
           var err = await resp.json().catch(function() { return {}; });
           showToast('Upgrade failed: ' + (err.error || resp.statusText), 'error');

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6483,11 +6483,12 @@ function burnAreaChart() {
     }
 
     let _hashScrollPending = false;
+    var SCROLL_SETTLE_DELAY_MS = 500;
     function _afterPaint(callback) {
       _hashScrollPending = true;
       requestAnimationFrame(function() {
         requestAnimationFrame(function() {
-          callback();
+          setTimeout(callback, SCROLL_SETTLE_DELAY_MS);
           setTimeout(function() { _hashScrollPending = false; }, 500);
         });
       });

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -7739,7 +7739,7 @@ function burnAreaChart() {
         if (v.dirty) html += ' <span class="git-dirty">*</span>';
         if (v.behind) {
           html += ` <span class="git-behind" title="Latest: ${escapeHtml(v.latestShort || '?')}">⬆ behind</span>`;
-          html += ` <button onclick="selfUpgrade()" style="padding:1px 8px;font-size:0.6rem;background:#238636;color:#fff;border:none;border-radius:4px;cursor:pointer;margin-left:4px" title="Upgrade to latest">⟳ Upgrade</button>`;
+          html += ` <button onclick="selfUpgrade()" style="padding:3px 10px;font-size:0.7rem;background:#238636;color:#fff;border:none;border-radius:4px;cursor:pointer;margin-left:6px;white-space:nowrap" title="Upgrade to latest">⟳ Upgrade</button>`;
         } else if (v.latestHash) {
           html += ' <span style="color:#22c55e" title="Up to date with remote">✓</span>';
         }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1537,13 +1537,17 @@ const dashboardHTML = `<!DOCTYPE html>
 
     async function upgradeHive(id) {
       if (!await hiveConfirm('Upgrade ' + id + ' to latest?')) return;
+      var btns = document.querySelectorAll('button[onclick*="upgradeHive"]');
+      btns.forEach(function(b) { b.disabled = true; b.textContent = '⟳ Upgrading...'; b.style.opacity = '0.6'; });
       try {
+        hiveToast('Upgrading ' + id + '...', 'info');
         var resp = await fetch('/api/saas/hives/' + encodeURIComponent(id) + '/upgrade', {method: 'POST'});
         var data = await resp.json();
         if (!resp.ok) { hiveToast(data.error || 'Upgrade failed', 'error'); return; }
         hiveToast('Upgrade started for ' + id, 'success');
         loadHives();
       } catch(e) { hiveToast('Error: ' + e.message, 'error'); }
+      finally { btns.forEach(function(b) { b.disabled = false; b.textContent = '⟳'; b.style.opacity = '1'; }); }
     }
 
     async function init() {
@@ -1652,12 +1656,17 @@ const dashboardHTML = `<!DOCTYPE html>
 
     async function deleteHive(id) {
       if (!await hiveConfirm('Delete ' + id + '? This removes all data.')) return;
+      var btns = document.querySelectorAll('button[onclick*="deleteHive"]');
+      btns.forEach(function(b) { b.disabled = true; b.textContent = 'Deleting...'; b.style.opacity = '0.6'; });
       try {
         gtag('event','hive_deleted',{hive_id:id});
+        hiveToast('Deleting ' + id + '...', 'info');
         var resp = await fetch('/api/saas/hives/' + encodeURIComponent(id), {method: 'DELETE'});
         if (!resp.ok) { var d = await resp.json(); hiveToast(d.error || 'Delete failed', 'error'); return; }
+        hiveToast('Deleted ' + id, 'success');
         loadHives();
       } catch(e) { hiveToast('Error: ' + e.message, 'error'); }
+      finally { btns.forEach(function(b) { b.disabled = false; b.textContent = 'Delete'; b.style.opacity = '1'; }); }
     }
 
     async function openConvert(btn) {

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -729,32 +729,11 @@ func fetchSHA(logger *slog.Logger) {
 	}
 	body, _ := io.ReadAll(resp.Body)
 	sha := strings.TrimSpace(string(body))
-	if len(sha) < 7 {
-		return
-	}
-	short := sha[:7]
-	latestCommitMu.Lock()
-	latestCommitSHA = short
-	latestCommitMu.Unlock()
-}
-
-var (
-	latestCommitMu  sync.RWMutex
-	latestCommitSHA string
-)
-
-func updateLatestSHAFromHeartbeat(gitHash string) {
-	if gitHash == "" {
-		return
-	}
-	latestCommitMu.RLock()
-	commitSHA := latestCommitSHA
-	latestCommitMu.RUnlock()
-
-	if gitHash == commitSHA {
+	if len(sha) >= 7 {
 		latestSHAMu.Lock()
-		latestSHACache = gitHash
+		latestSHACache = sha[:7]
 		latestSHAMu.Unlock()
+		logger.Debug("latest SHA updated", "sha", sha[:7])
 	}
 }
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -107,6 +107,7 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("GET /api/saas/hives/{id}/status", s.requireAuth(s.handleHiveStatus))
 	s.mux.HandleFunc("DELETE /api/saas/hives/{id}", s.requireAuth(s.handleDeleteHive))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/upgrade", s.requireAuth(s.handleUpgradeHive))
+	s.mux.HandleFunc("OPTIONS /api/saas/hives/{id}/upgrade", s.handleUpgradeHive)
 	s.mux.HandleFunc("GET /api/saas/latest-sha", s.handleLatestSHA)
 	s.mux.HandleFunc("GET /api/saas/auth-check", s.handleSaaSAuthCheck)
 	s.mux.HandleFunc("POST /api/saas/user-token", s.requireAuth(s.handleUserToken))
@@ -669,6 +670,17 @@ func (s *HubServer) handleDeleteHive(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
+	origin := r.Header.Get("Origin")
+	if strings.HasSuffix(origin, ".hive.kubestellar.io") || origin == "https://hive.kubestellar.io" {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	}
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
 	id := r.PathValue("id")
 	username := s.getAuthUser(r)
 	h := loadSaaSHive(id)
@@ -1507,7 +1519,7 @@ const dashboardHTML = `<!DOCTYPE html>
             var branch = '<span style="display:inline-block;padding:1px 6px;border-radius:9999px;font-size:0.6rem;background:rgba(59,130,246,0.15);color:#60a5fa;border:1px solid rgba(59,130,246,0.3);margin-right:4px">' + esc(branchName) + '</span>';
             var isCurrent = _latestSHA && sha === _latestSHA;
             var status = isCurrent ? '<span style="color:var(--green);margin-left:3px" title="latest">✓</span>' : '<span style="color:var(--red);margin-left:3px" title="behind latest ' + esc(_latestSHA) + '">↑</span>';
-            var upgradeIcon = (!isCurrent && isHosted && h.role === 'owner') ? ' <button onclick="upgradeHive(\'' + esc(h.id) + '\')" title="Upgrade to latest" style="padding:1px 5px;background:var(--green);color:#fff;border:none;border-radius:3px;cursor:pointer;font-size:0.6rem;margin-left:3px">⟳</button>' : '';
+            var upgradeIcon = (!isCurrent && isHosted && h.role === 'owner') ? ' <button onclick="upgradeHive(\'' + esc(h.id) + '\')" title="Upgrade to latest" style="padding:3px 10px;background:var(--green);color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.7rem;margin-left:6px;white-space:nowrap">⟳ Upgrade</button>' : '';
             return branch + '<span style="font-family:monospace;color:var(--muted)">' + esc(sha) + '</span>' + status + upgradeIcon;
           })() + '</td>' +
           '<td>' + repoLink + '</td>' +

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -107,7 +107,6 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("GET /api/saas/hives/{id}/status", s.requireAuth(s.handleHiveStatus))
 	s.mux.HandleFunc("DELETE /api/saas/hives/{id}", s.requireAuth(s.handleDeleteHive))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/upgrade", s.requireAuth(s.handleUpgradeHive))
-	s.mux.HandleFunc("OPTIONS /api/saas/hives/{id}/upgrade", s.handleUpgradeHive)
 	s.mux.HandleFunc("GET /api/saas/latest-sha", s.handleLatestSHA)
 	s.mux.HandleFunc("GET /api/saas/auth-check", s.handleSaaSAuthCheck)
 	s.mux.HandleFunc("POST /api/saas/user-token", s.requireAuth(s.handleUserToken))
@@ -670,17 +669,6 @@ func (s *HubServer) handleDeleteHive(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
-	origin := r.Header.Get("Origin")
-	if strings.HasSuffix(origin, ".hive.kubestellar.io") || origin == "https://hive.kubestellar.io" {
-		w.Header().Set("Access-Control-Allow-Origin", origin)
-		w.Header().Set("Access-Control-Allow-Credentials", "true")
-		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-	}
-	if r.Method == "OPTIONS" {
-		w.WriteHeader(http.StatusNoContent)
-		return
-	}
 	id := r.PathValue("id")
 	username := s.getAuthUser(r)
 	h := loadSaaSHive(id)

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -317,7 +317,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	s.mu.Unlock()
 
 	s.requestSave()
-	updateLatestSHAFromHeartbeat(payload.GitHash)
+
 
 	s.logger.Info("audit: hub heartbeat received",
 		"hive_id", payload.HiveID,


### PR DESCRIPTION
Spoke calls /api/self-upgrade (same-origin), Go backend proxies to hub. Removes CORS/OPTIONS. Owner-only.