### PR TITLE
fix: remove connection eviction — causes infinite reconnect loop

### DIFF
--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -505,13 +505,6 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 			}
 
 			h.mu.Lock()
-			for oldID, oldConn := range h.connections {
-				if oldConn.profile != nil && oldConn.profile.GitHubUsername == profile.GitHubUsername && oldID != connID {
-					h.logger.Info("[contribute-ws] evicting stale session", "username", profile.GitHubUsername, "old_conn", oldID)
-					oldConn.ws.Close()
-					delete(h.connections, oldID)
-				}
-			}
 			h.connections[connID] = contributor
 			h.mu.Unlock()
 


### PR DESCRIPTION
Eviction on auth triggers defer→disconnect→reconnect→evict→loop. Stale connections are already filtered via heartbeat timeout in LiveStates.