### PR TITLE
feat: force flag on inception start resets stale state (bug #132)

### DIFF
--- a/v2/pkg/dashboard/inception_handlers.go
+++ b/v2/pkg/dashboard/inception_handlers.go
@@ -24,11 +24,19 @@ func (s *Server) handleInceptionStart(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		Idea string `json:"idea"`
+		Idea  string `json:"idea"`
+		Force bool   `json:"force,omitempty"`
 	}
 	if err := readJSON(r, &req); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
+	}
+
+	if req.Force {
+		_ = s.deps.Inception.Reset()
+		if s.deps.AgentMgr != nil {
+			_ = s.deps.AgentMgr.Pause("brainstorm", "inception-force-reset", "forced reset before new inception")
+		}
 	}
 
 	state, err := s.deps.Inception.Start(req.Idea)


### PR DESCRIPTION
Adds force:true to POST /api/inception/start. Resets any existing inception before starting, preventing 400s from stale state after container restarts.