### PR TITLE
fix: close WS on heartbeat ping failure — kills ghost connections

### DIFF
--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -699,6 +699,8 @@ func (h *ContributeWSHub) heartbeatLoop(c *ContributorConnection) {
 		}
 
 		if err := sendJSON(c.ws, WSMessage{Type: "ping", Seq: h.nextSeq()}); err != nil {
+			h.logger.Info("[contribute-ws] heartbeat ping failed, closing", "username", c.profile.GitHubUsername)
+			c.ws.Close()
 			return
 		}
 	}


### PR DESCRIPTION
Ghost connections persisted because heartbeatLoop exited on ping failure without closing the WS. Connection stayed in map with stale task data.