### PR TITLE
fix: allow heartbeat from provisioned hosted hives

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1546,7 +1546,7 @@ const dashboardHTML = `<!DOCTYPE html>
         var contributeCell = contributeUrl ? '<a href="' + contributeUrl + '" target="_blank" style="padding:2px 8px;background:rgba(34,197,94,0.15);color:#4ade80;border:1px solid rgba(34,197,94,0.3);border-radius:4px;font-size:0.65rem;white-space:nowrap;text-decoration:none">Contribute</a>' : '';
         var actions = '';
         if (canConvert) {
-          actions = '<button onclick="openConvert(this)" data-hive-id="' + esc(h.id) + '" data-org="' + esc(h.org) + '" data-repos="' + esc((h.repos||[]).join(', ')) + '" data-primary="' + esc(h.primaryRepo) + '" data-level="' + (h.acmmLevel||1) + '" data-name="' + esc(h.name||'') + '" style="padding:3px 10px;background:var(--accent);color:#000;border:none;border-radius:4px;cursor:pointer;font-size:0.7rem;white-space:nowrap">Convert to Hosted</button>';
+          actions = '<button onclick="openConvert(this)" data-hive-id="' + esc(h.id) + '" data-dash-url="' + esc(h.dashboardUrl||'') + '" data-org="' + esc(h.org) + '" data-repos="' + esc((h.repos||[]).join(', ')) + '" data-primary="' + esc(h.primaryRepo) + '" data-level="' + (h.acmmLevel||1) + '" data-name="' + esc(h.name||'') + '" style="padding:3px 10px;background:var(--accent);color:#000;border:none;border-radius:4px;cursor:pointer;font-size:0.7rem;white-space:nowrap">Convert to Hosted</button>';
         } else if (isHosted && (h.role === 'owner' || h.role === 'read-write')) {
           actions = '<button onclick="openAccessModal(\'' + esc(h.id) + '\')" style="padding:3px 10px;background:var(--blue);color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.7rem;white-space:nowrap;margin-right:4px">Access</button>';
           if (h.role === 'owner') {
@@ -1726,28 +1726,21 @@ const dashboardHTML = `<!DOCTYPE html>
       finally { btns.forEach(function(b) { b.disabled = false; b.textContent = 'Delete'; b.style.opacity = '1'; }); }
     }
 
-    async function openConvert(btn) {
+    function openConvert(btn) {
       document.getElementById('f-org').value = btn.dataset.org || '';
       document.getElementById('f-repos').value = btn.dataset.repos || '';
       document.getElementById('f-primary').value = btn.dataset.primary || '';
       document.getElementById('f-name').value = btn.dataset.name || '';
       document.getElementById('f-level').value = btn.dataset.level || '1';
       document.getElementById('create-modal').style.display = 'flex';
-      var hiveId = btn.dataset.hiveId || '';
-      if (hiveId) {
-        try {
-          var resp = await fetch('/api/saas/hive-config/' + encodeURIComponent(hiveId));
-          if (resp.ok) {
-            var text = await resp.text();
-            var cfg = parseHiveYaml(text);
-            applyYamlConfig(cfg);
-            hiveToast('Config loaded from local hive', 'success');
-          } else {
-            hiveToast('Could not fetch config from hive — drop your hive.yaml above to fill in GitHub App credentials', 'info');
-          }
-        } catch(e) {
-          hiveToast('Could not reach local hive — drop your hive.yaml above to fill in GitHub App credentials', 'info');
-        }
+      var dashUrl = (btn.dataset.dashUrl || '').replace(/\/$/, '');
+      var dlLink = document.getElementById('yaml-download-link');
+      var dlHref = document.getElementById('yaml-download-href');
+      if (dashUrl && dlLink && dlHref) {
+        dlHref.href = dashUrl + '/api/config/download';
+        dlLink.style.display = '';
+      } else if (dlLink) {
+        dlLink.style.display = 'none';
       }
     }
 
@@ -1870,7 +1863,8 @@ const dashboardHTML = `<!DOCTYPE html>
         ondrop="event.preventDefault();this.style.borderColor='var(--border)';var f=event.dataTransfer.files[0];if(f)readYamlFile(f)"
         onclick="document.getElementById('yaml-upload').click()">
         <div style="font-size:0.82rem;color:var(--muted)">Drop a <code>hive.yaml</code> here or <span style="color:var(--accent);text-decoration:underline">browse</span></div>
-        <div style="font-size:0.7rem;color:var(--muted);margin-top:4px">Auto-fills all fields from your config</div>
+        <div style="font-size:0.7rem;color:var(--muted);margin-top:4px">Auto-fills all fields including GitHub App credentials</div>
+        <div id="yaml-download-link" style="display:none;font-size:0.7rem;margin-top:6px"><a id="yaml-download-href" href="#" target="_blank" style="color:var(--accent)" onclick="event.stopPropagation()">⬇ Download hive.yaml from your local hive</a></div>
         <input type="file" id="yaml-upload" accept=".yaml,.yml" style="display:none" onchange="if(this.files[0])readYamlFile(this.files[0])">
       </div>
       <div style="margin-bottom:12px">

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -449,6 +449,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 					entry.ProvError = sh.Error
 				}
 				result = append(result, entry)
+				seen[sh.ID] = true
 			}
 		}
 	}
@@ -1744,7 +1745,12 @@ const dashboardHTML = `<!DOCTYPE html>
       }
     }
 
+    var _createInProgress = false;
     async function createHive() {
+      if (_createInProgress) return;
+      _createInProgress = true;
+      document.getElementById('btn-go').disabled = true;
+      document.getElementById('btn-go').textContent = 'Provisioning...';
       var org = document.getElementById('f-org').value.trim();
       var repos = document.getElementById('f-repos').value.trim();
       var primary = document.getElementById('f-primary').value.trim();
@@ -1757,12 +1763,9 @@ const dashboardHTML = `<!DOCTYPE html>
       var appKey = (document.getElementById('f-app-key') || {}).value || '';
 
       gtag('event','hive_create_started',{org:org,primary_repo:primary,acmm_level:level});
-      if (!org || !repos) { hiveToast('Org and repos are required', 'error'); return; }
-      if (method === 'pat' && !token) { hiveToast('GitHub token is required', 'error'); return; }
-      if (method === 'app' && (!appId || !installId || !appKey)) { hiveToast('App ID, Installation ID, and Private Key are required', 'error'); return; }
-
-      document.getElementById('btn-go').disabled = true;
-      document.getElementById('btn-go').textContent = 'Provisioning...';
+      if (!org || !repos) { hiveToast('Org and repos are required', 'error'); _createInProgress = false; document.getElementById('btn-go').disabled = false; document.getElementById('btn-go').textContent = 'Go'; return; }
+      if (method === 'pat' && !token) { hiveToast('GitHub token is required', 'error'); _createInProgress = false; document.getElementById('btn-go').disabled = false; document.getElementById('btn-go').textContent = 'Go'; return; }
+      if (method === 'app' && (!appId || !installId || !appKey)) { hiveToast('App ID, Installation ID, and Private Key are required', 'error'); _createInProgress = false; document.getElementById('btn-go').disabled = false; document.getElementById('btn-go').textContent = 'Go'; return; }
 
       try {
         var body = {org: org, repos: repos, primary_repo: primary || repos.split(',')[0].trim(), project_name: name, acmm_level: level, auth_method: method};

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -447,14 +447,7 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-prod
     nginx.ingress.kubernetes.io/auth-url: "https://hive.kubestellar.io/api/saas/auth-check?hive={{.ID}}"
     nginx.ingress.kubernetes.io/auth-signin: "https://hive.kubestellar.io/login?redirect=$scheme://$http_host$request_uri"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Hive-User, X-Hive-Role"
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      proxy_set_header X-Hive-Internal "{{.DashboardToken}}";
-    nginx.ingress.kubernetes.io/server-snippet: |
-      error_page 403 = @denied;
-      location @denied {
-        return 302 https://hive.kubestellar.io/access-denied?hive={{.ID}}&redirect=$scheme://$http_host$request_uri;
-      }
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Hive-User,X-Hive-Role"
 spec:
   ingressClassName: nginx
   rules:

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -192,6 +192,15 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, logger *slog.Logger) err
 			}
 			return hex.EncodeToString(b)
 		}(),
+		"HubSecret": func() string {
+			if s := os.Getenv("HIVE_HUB_SECRET"); s != "" {
+				return s
+			}
+			if data, err := os.ReadFile("/data/saas/hub-secret.key"); err == nil {
+				return strings.TrimSpace(string(data))
+			}
+			return ""
+		}(),
 	}
 
 	tmpl, err := template.New("manifests").Parse(k8sManifestTemplate)
@@ -391,6 +400,8 @@ spec:
           value: "{{.ACMMLevel}}"
         - name: HIVE_HUB_URL
           value: https://hive.kubestellar.io
+        - name: HIVE_HUB_SECRET
+          value: "{{.HubSecret}}"
         ports:
         - containerPort: 3002
         resources:

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -330,9 +330,11 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	const maxRegistryEntries = 200
 	if !found {
 		if strings.HasPrefix(payload.HiveID, "hosted-") || strings.HasPrefix(payload.HiveID, "saas-") {
-			s.mu.Unlock()
-			http.Error(w, "hosted/saas hive IDs can only be created via provisioning", http.StatusForbidden)
-			return
+			if loadSaaSHive(payload.HiveID) == nil {
+				s.mu.Unlock()
+				http.Error(w, "hosted/saas hive IDs can only be created via provisioning", http.StatusForbidden)
+				return
+			}
 		}
 		if len(s.registry.Hives) >= maxRegistryEntries {
 			s.mu.Unlock()


### PR DESCRIPTION
First heartbeat from hosted hives was blocked. Now checks SaaS metadata exists before rejecting.