### PR TITLE
fix: faster inception retry timing (bug #133)

### DIFF
--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -273,8 +273,8 @@ func (w *InceptionWatcher) checkForQuestions(inceptionBeads []*beads.Bead) {
 
 const (
 	outputParseLineCount   = 100
-	kickRetryDelayS        = 30 * time.Second
-	kickRetryGracePeriodS  = 30 * time.Second
+	kickRetryDelayS        = 20 * time.Second
+	kickRetryGracePeriodS  = 15 * time.Second
 	maxKickRetries         = 5
 )
 


### PR DESCRIPTION
Grace 30→15s, delay 30→20s. All 5 retries now fit within 120s capture timeout.