### PR TITLE
fix: terminate old WS before reconnect — prevents ghost sessions

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -485,6 +485,8 @@ function handleMessage(data) {
 }
 
 function connect() {
+  cleanup();
+  if (ws) { try { ws.terminate(); } catch (_) {} }
   console.log(`Connecting to ${HUB_URL}...`);
   ws = new WebSocket(HUB_URL);
 


### PR DESCRIPTION
Root cause of persistent ghost testsuite#409: relay reconnect created a second WS without killing the first. Both authenticated, creating 2 sessions on the hub.