### PR TITLE
fix: terminal cookie auth only on hosted, not local hives

### DIFF
--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -132,19 +132,23 @@ const ttydProxy = createProxyMiddleware({
   },
 });
 app.use('/terminal', (req, res, next) => {
-  const cookies = (req.headers.cookie || '').split(';').reduce((acc, c) => {
-    const [k, ...v] = c.trim().split('=');
-    if (k) acc[k] = v.join('=');
-    return acc;
-  }, {});
-  const user = cookies['hive_hub_user'];
-  if (!user) {
-    if (req.headers.upgrade === 'websocket') {
-      req.socket.destroy();
+  const host = req.headers.host || '';
+  const isHosted = host.endsWith('.hive.kubestellar.io');
+  if (isHosted) {
+    const cookies = (req.headers.cookie || '').split(';').reduce((acc, c) => {
+      const [k, ...v] = c.trim().split('=');
+      if (k) acc[k] = v.join('=');
+      return acc;
+    }, {});
+    const user = cookies['hive_hub_user'];
+    if (!user) {
+      if (req.headers.upgrade === 'websocket') {
+        req.socket.destroy();
+        return;
+      }
+      res.status(401).send('Terminal access requires authentication');
       return;
     }
-    res.status(401).send('Terminal access requires authentication');
-    return;
   }
   next();
 }, ttydProxy);


### PR DESCRIPTION
Local hives don't have hub cookies. Auth check now scoped to *.hive.kubestellar.io hosts only.