### PR TITLE
fix: auto-question timeout 90s→60s (bug #135)

### DIFF
--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -24,7 +24,7 @@ const (
 	minQuestionsForAdvance   = 5
 	minFactsForAdvance       = 3
 	autoFactFallbackTimeout      = 60 * time.Second
-	autoQuestionFallbackTimeout  = 90 * time.Second
+	autoQuestionFallbackTimeout  = 60 * time.Second
 )
 
 // InceptionWatcher polls brainstorm beads and bridges them into the inception


### PR DESCRIPTION
Matches auto-fact timeout. Gives more time for post-fallback lifecycle.