### PR TITLE
fix: revert ttyd base path + ws:true for WebSocket proxy

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -309,7 +309,7 @@ TTYD_RESPAWN_DELAY_SECS=5
 (
   trap '' HUP
   while true; do
-    ttyd -W -a -p "${TTYD_PORT}" -b /terminal -t fontSize=14 -t disableLeaveAlert=true /usr/local/bin/ttyd-tmux.sh
+    ttyd -W -a -p "${TTYD_PORT}" -t fontSize=14 -t disableLeaveAlert=true /usr/local/bin/ttyd-tmux.sh
     echo "[entrypoint] ttyd exited (rc=$?), respawning in ${TTYD_RESPAWN_DELAY_SECS}s..."
     sleep "$TTYD_RESPAWN_DELAY_SECS"
   done

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -121,7 +121,8 @@ app.use('/api', apiProxy);
 const ttydProxy = createProxyMiddleware({
   target: TTYD_URL,
   changeOrigin: true,
-  pathRewrite: (p) => '/terminal' + p,
+  ws: true,
+  pathRewrite: (p) => p.replace(/^\/terminal/, '') || '/',
   on: {
     error(err, req, res) {
       console.error(`[ttyd-proxy] ${req.method} ${req.url} → ${err.message}`);


### PR DESCRIPTION
ttyd -b broke WS. Reverted. Proxy now strips /terminal and passes ws:true for WebSocket upgrades.