### PR TITLE
fix: Go button guard reset + port 3001 + installation_id parser

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -309,7 +309,7 @@ TTYD_RESPAWN_DELAY_SECS=5
 (
   trap '' HUP
   while true; do
-    ttyd -W -a -p "${TTYD_PORT}" -b /terminal -t fontSize=14 -t disableLeaveAlert=true /usr/local/bin/ttyd-tmux.sh
+    ttyd -W -a -p "${TTYD_PORT}" -t fontSize=14 -t disableLeaveAlert=true /usr/local/bin/ttyd-tmux.sh
     echo "[entrypoint] ttyd exited (rc=$?), respawning in ${TTYD_RESPAWN_DELAY_SECS}s..."
     sleep "$TTYD_RESPAWN_DELAY_SECS"
   done

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1802,6 +1802,7 @@ const dashboardHTML = `<!DOCTYPE html>
       } catch(e) {
         hiveToast('Error: ' + e.message, 'error');
       } finally {
+        _createInProgress = false;
         document.getElementById('btn-go').disabled = false;
         document.getElementById('btn-go').textContent = 'Go';
       }
@@ -1830,7 +1831,7 @@ const dashboardHTML = `<!DOCTYPE html>
           var m;
           if ((m = trimmed.match(/^\s+token:\s*(.+)/))) cfg.token = m[1].trim().replace(/^["']|["']$/g, '');
           if ((m = trimmed.match(/^\s+app_id:\s*(\d+)/))) cfg.appId = m[1];
-          if ((m = trimmed.match(/^\s+installation_id:\s*(\d+)/))) cfg.installId = m[1];
+          if ((m = trimmed.match(/^\s+installation_id:\s*(\d+)/)) && !trimmed.match(/docs_installation_id/)) cfg.installId = m[1];
         }
         if (section === 'governor') {
           var m;

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -313,7 +313,7 @@ data:
       token: "${HIVE_GITHUB_TOKEN}"
 {{- end}}
     dashboard:
-      port: 3002
+      port: 3001
     hub:
       enabled: true
       url: https://hive.kubestellar.io
@@ -494,7 +494,7 @@ spec:
           service:
             name: hive
             port:
-              number: 3002
+              number: 3001
   tls:
   - hosts:
     - {{.ID}}.hive.kubestellar.io
@@ -521,7 +521,7 @@ spec:
           service:
             name: hive
             port:
-              number: 3002
+              number: 3001
   tls:
   - hosts:
     - {{.ID}}.hive.kubestellar.io

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -121,7 +121,8 @@ app.use('/api', apiProxy);
 const ttydProxy = createProxyMiddleware({
   target: TTYD_URL,
   changeOrigin: true,
-  pathRewrite: (p) => '/terminal' + p,
+  ws: true,
+  pathRewrite: (p) => p.replace(/^\/terminal/, '') || '/',
   on: {
     error(err, req, res) {
       console.error(`[ttyd-proxy] ${req.method} ${req.url} → ${err.message}`);


### PR DESCRIPTION
Create guard stuck after failure. Ports 3001. YAML parser skips docs_installation_id.