### PR TITLE
fix: remove duplicate org from main page hive table

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1584,7 +1584,7 @@ const dashboardHTML = `<!DOCTYPE html>
         } else { versionCell = '<span style="color:var(--muted)">—</span>'; }
         return '<tr>' +
           '<td style="position:relative;width:30px;text-align:center"><span onclick="toggleHiveMenu(\'' + menuId + '\')" style="cursor:pointer;font-size:1.1rem;color:var(--muted);user-select:none">⋮</span><div id="' + menuId + '" style="display:none;position:absolute;left:0;top:28px;background:var(--surface);border:1px solid var(--border);border-radius:8px;min-width:180px;z-index:100;box-shadow:0 8px 24px rgba(0,0,0,0.4)">' + menuItems.join('') + '</div></td>' +
-          '<td>' + dot + '<span class="hive-name">' + esc(h.name || h.id) + '</span><br><span class="hive-org">' + esc(h.org) + '</span> ' + roleBadge(h.role) + '</td>' +
+          '<td style="text-align:left">' + dot + '<span class="hive-name">' + esc(h.name || h.id) + '</span><br>' + roleBadge(h.role) + '</td>' +
           '<td>' + typeBadge + '</td>' +
           '<td style="font-size:0.7rem;white-space:nowrap">' + versionCell + '</td>' +
           '<td>' + repoLink + '</td>' +

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -261,7 +261,7 @@
           : '<span style="display:inline-block;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:rgba(107,114,128,0.15);color:#9ca3af;border:1px solid rgba(107,114,128,0.3)" title="Self-hosted by the owner">local</span>';
         return '<tr>' +
           
-          '<td style="display:flex;align-items:center;gap:10px"><img src="https://github.com/' + esc(h.org) + '.png" style="width:36px;height:36px;border-radius:6px;flex-shrink:0" onerror="this.style.display=\'none\'">' + dot + '<div><span class="hive-name">' + esc(h.name || h.id) + '</span><br><span class="hive-org">' + esc(h.org) + '</span></div></td>' +
+          '<td style="display:flex;align-items:center;gap:10px"><img src="https://github.com/' + esc(h.org) + '.png" style="width:36px;height:36px;border-radius:6px;flex-shrink:0" onerror="this.style.display=\'none\'">' + dot + '<div><span class="hive-name">' + esc(h.name || h.id) + '</span></div></td>' +
           '<td>' + htype + '</td>' +
           '<td>' + repoLink + '</td>' +
           '<td>' + repoCount + '</td>' +


### PR DESCRIPTION
Same fix as dashboard — name shows org/repo, no need for org line.