### PR TITLE
fix: proxy WS broken — removeHeader causes write-after-end

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -8319,7 +8319,7 @@ function burnAreaChart() {
     }
 
     function renderGovHub(hub) {
-      const dashUrl = hub.dashboard_url || '';
+      const dashUrl = hub.dashboard_url || window.location.origin || '';
       const snapUrl = hub.snapshot_url || (hub.auto_snapshot && dashUrl ? dashUrl.replace(/\/$/, '') + '/snapshot' : '');
       const repos = (_configState.data.repos || []).map(function(r) {
         const name = r.split('/').pop();
@@ -8438,7 +8438,7 @@ function burnAreaChart() {
         urlInput.style.opacity = isOn ? '0.5' : '1';
         urlInput.placeholder = isOn ? '' : 'https://your-site.com/dashboard-preview';
         if (isOn) {
-          var dashUrl = (_configState.data.hub || {}).dashboard_url || '';
+          var dashUrl = (_configState.data.hub || {}).dashboard_url || window.location.origin || '';
           if (dashUrl) {
             var snapUrl = dashUrl.replace(/\/$/, '') + '/snapshot';
             urlInput.value = snapUrl;

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -74,12 +74,15 @@ const apiProxy = createProxyMiddleware({
   pathRewrite: (path) => `/api${path}`,
   on: {
     proxyReq(proxyReq) {
-      proxyReq.removeHeader('X-Hive-Internal');
-      proxyReq.removeHeader('X-Hive-User');
-      proxyReq.removeHeader('X-Hive-Role');
-      if (DASHBOARD_TOKEN) {
-        proxyReq.setHeader('X-Hive-Internal', DASHBOARD_TOKEN);
-      }
+      try {
+        proxyReq.removeHeader('X-Hive-User');
+        proxyReq.removeHeader('X-Hive-Role');
+        if (DASHBOARD_TOKEN) {
+          proxyReq.setHeader('X-Hive-Internal', DASHBOARD_TOKEN);
+        } else {
+          proxyReq.removeHeader('X-Hive-Internal');
+        }
+      } catch (_) {}
     },
     error(err, req, res) {
       console.error(`[proxy] ${req.method} ${req.url} → ${err.message}`);
@@ -177,9 +180,11 @@ const contributeProxy = createProxyMiddleware({
   changeOrigin: true,
   on: {
     proxyReq(proxyReq, req) {
-      proxyReq.removeHeader('X-Hive-Internal');
-      proxyReq.removeHeader('X-Hive-User');
-      proxyReq.removeHeader('X-Hive-Role');
+      try {
+        proxyReq.removeHeader('X-Hive-Internal');
+        proxyReq.removeHeader('X-Hive-User');
+        proxyReq.removeHeader('X-Hive-Role');
+      } catch (_) {}
       proxyReq.setHeader('X-Forwarded-Host', req.headers.host || '');
     },
   },


### PR DESCRIPTION
PR #1163's removeHeader() calls crash during WS upgrade, breaking contribute WS and terminal WS. Wrapped in try/catch.