### PR TITLE
feat: notify test coverage 81.0% → 88.9%

### DIFF
--- a/v2/pkg/notify/notify_extra_test.go
+++ b/v2/pkg/notify/notify_extra_test.go
@@ -1,0 +1,76 @@
+package notify
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+func TestLogNtfyErrorDedupe(t *testing.T) {
+	n := &Notifier{
+		logger: slog.Default(),
+		client: &http.Client{},
+	}
+
+	n.logNtfyError("first error", "details1")
+	n.logNtfyError("first error", "details1")
+	n.logNtfyError("first error", "details1")
+
+	if n.ntfyErrCount != 2 {
+		t.Errorf("suppressed count = %d, want 2", n.ntfyErrCount)
+	}
+
+	n.logNtfyError("different error", "details2")
+	if n.ntfyErrCount != 0 {
+		t.Errorf("count after flush = %d, want 0", n.ntfyErrCount)
+	}
+}
+
+func TestSendSlackSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := &Notifier{
+		cfg:    config.NotificationsConfig{Slack: &config.SlackConfig{Webhook: srv.URL}},
+		logger: slog.Default(),
+		client: srv.Client(),
+	}
+	n.sendSlack("test title", "test message")
+}
+
+func TestSendDiscordWebhookSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	n := &Notifier{
+		cfg:    config.NotificationsConfig{Discord: &config.DiscordConfig{Webhook: srv.URL}},
+		logger: slog.Default(),
+		client: srv.Client(),
+	}
+	n.sendDiscordWebhook("test title", "test message")
+}
+
+func TestSendSlackInvalidScheme(t *testing.T) {
+	n := &Notifier{
+		cfg:    config.NotificationsConfig{Slack: &config.SlackConfig{Webhook: "ftp://invalid"}},
+		logger: slog.Default(),
+		client: &http.Client{},
+	}
+	n.sendSlack("test", "test")
+}
+
+func TestSendDiscordInvalidScheme(t *testing.T) {
+	n := &Notifier{
+		cfg:    config.NotificationsConfig{Discord: &config.DiscordConfig{Webhook: "ftp://invalid"}},
+		logger: slog.Default(),
+		client: &http.Client{},
+	}
+	n.sendDiscordWebhook("test", "test")
+}


### PR DESCRIPTION
Tests for logNtfyError dedup, Slack/Discord success paths, invalid schemes.