### PR TITLE
fix: remove ws:true — root cause of WS FIN error

### DIFF
--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -70,7 +70,6 @@ app.use((req, res, next) => {
 const apiProxy = createProxyMiddleware({
   target: GO_API_URL,
   changeOrigin: true,
-  ws: true,
   pathRewrite: (path) => `/api${path}`,
   on: {
     proxyReq(proxyReq, req) {
@@ -123,7 +122,6 @@ app.use('/api', apiProxy);
 const ttydProxy = createProxyMiddleware({
   target: TTYD_URL,
   changeOrigin: true,
-  ws: true,
   pathRewrite: (p) => p.replace(/^\/terminal/, '') || '/',
   on: {
     error(err, req, res) {

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -213,6 +213,11 @@ const server = app.listen(PROXY_PORT, () => {
 });
 
 server.on('upgrade', (req, socket, head) => {
+  if (req.url.startsWith('/api/contribute/ws')) {
+    req.url = req.url.replace(/^\/api/, '');
+    apiProxy.upgrade(req, socket, head);
+    return;
+  }
   if (req.url.startsWith('/terminal')) {
     const host = req.headers.host || '';
     const isHosted = host.endsWith('.hive.kubestellar.io');
@@ -226,23 +231,7 @@ server.on('upgrade', (req, socket, head) => {
         socket.destroy();
         return;
       }
-    }
-    req.url = req.url.replace(/^\/terminal/, '') || '/';
-    ttydProxy.upgrade(req, socket, head);
-  }
-});
-
-server.on('upgrade', (req, socket, head) => {
-  if (req.url.startsWith('/api/contribute/ws')) {
-    // Strip the /api prefix so pathRewrite produces /api/contribute/ws
-    // (not /api/api/contribute/ws). Express middleware strips the mount
-    // path for HTTP requests, but the upgrade handler receives the full URL.
-    req.url = req.url.replace(/^\/api/, '');
-    apiProxy.upgrade(req, socket, head);
-    return;
-  }
-  if (req.url.startsWith('/terminal')) {
-    if (DASHBOARD_TOKEN) {
+    } else if (DASHBOARD_TOKEN) {
       const params = new URL(req.url, `http://${req.headers.host}`).searchParams;
       const token = params.get('token') || '';
       const supplied = Buffer.from(token);


### PR DESCRIPTION
ws:true on apiProxy and ttydProxy made http-proxy-middleware auto-register upgrade handlers that competed with our manual server.on('upgrade'). ttydProxy was proxying contribute WS requests to ttyd, returning garbage frames.