### PR TITLE
feat: move go test from PR CI to 15-min scheduled workflow

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -31,9 +31,6 @@ jobs:
       - name: Vet
         run: go vet ./...
 
-      - name: Test
-        run: go test ./pkg/... -short -race -count=1
-
   create-issue-on-failure:
     if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/v2'
     runs-on: ubuntu-latest

--- a/.github/workflows/v2-tests.yml
+++ b/.github/workflows/v2-tests.yml
@@ -1,0 +1,69 @@
+name: v2 Tests
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: v2
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache-dependency-path: v2/go.sum
+
+      - name: Test
+        run: go test ./pkg/... -short -race -count=1
+
+  create-issue-on-failure:
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Create issue for test failure
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const sha = context.sha.substring(0, 7);
+            const title = `[Tests] v2 test failure on ${sha}`;
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'ci-failure',
+              per_page: 10,
+            });
+            const dup = existing.data.find(i => i.title.startsWith('[Tests] v2 test failure'));
+            if (dup) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: dup.number,
+                body: `Another failure on \`${sha}\`: ${runUrl}`,
+              });
+              return;
+            }
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body: `## Test Failure\n\n- **Commit:** \`${context.sha}\`\n- **Run:** ${runUrl}\n- **Branch:** v2\n\nScheduled test run failed. See the [workflow run](${runUrl}) for details.`,
+              labels: ['ci-failure', 'kind/bug'],
+            });


### PR DESCRIPTION
Removes go test from PR CI (keeps build+vet). Creates v2-tests.yml that runs every 15 min with issue auto-creation on failure.