### PR TITLE
fix: PST dir permissions — agent users can't write (bug #139)

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -130,7 +130,8 @@ RUN pip3 install --no-cache-dir --break-system-packages specify-cli 2>/dev/null 
 RUN git clone --depth 1 https://github.com/kubestellar/pub-sub-tmux.git /tmp/pst && \
     bash /tmp/pst/install.sh /usr/local && \
     rm -rf /tmp/pst && \
-    mkdir -p /var/run/pub-sub-tmux/logs /var/run/pub-sub-tmux/commands || \
+    mkdir -p /var/run/pub-sub-tmux/logs /var/run/pub-sub-tmux/commands && \
+    chmod 1777 /var/run/pub-sub-tmux/logs /var/run/pub-sub-tmux/commands || \
     echo "WARN: pub-sub-tmux install failed — inception will use RestartWithBootstrap fallback"
 RUN (which git && git clone -b feat/cli-agent-mode https://github.com/clubanderson/agentic-strategy-evolution /opt/nous && \
     python3 -m venv /opt/nous/venv && \

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -276,8 +276,8 @@ func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
 	// Attach pub-sub-tmux publisher if available — streams structured events
 	// from the agent's tmux output to a JSONL log for subscribers.
 	if pstPath, err := exec.LookPath("pst-publish"); err == nil {
-		_ = os.MkdirAll("/var/run/pub-sub-tmux/logs", 0o755)
-		_ = os.MkdirAll("/var/run/pub-sub-tmux/commands", 0o755)
+		_ = os.MkdirAll("/var/run/pub-sub-tmux/logs", 0o1777)
+		_ = os.MkdirAll("/var/run/pub-sub-tmux/commands", 0o1777)
 		backend := agent.Config.Backend
 		if backend == "" {
 			backend = "claude"


### PR DESCRIPTION
Logs dir was 755 root-owned. Agent users (UID 2002+) couldn't write JSONL. Changed to 1777.