### PR TITLE
test: proxy coverage boost (15.8% → 34.1%)

### DIFF
--- a/v2/pkg/proxy/proxy_coverage_test.go
+++ b/v2/pkg/proxy/proxy_coverage_test.go
@@ -1,0 +1,336 @@
+package proxy
+
+import (
+	"encoding/base64"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/agent"
+)
+
+func TestAllowedByModeOAuthDeviceFlow(t *testing.T) {
+	if !AllowedByMode(agent.ModeAdvisory, "POST", "/login/device/code") {
+		t.Error("ADVISORY should allow POST /login/device/code")
+	}
+	if !AllowedByMode(agent.ModeAdvisory, "POST", "/login/oauth/access_token") {
+		t.Error("ADVISORY should allow POST /login/oauth/access_token")
+	}
+}
+
+func TestAllowedByModeMerge(t *testing.T) {
+	if AllowedByMode(agent.ModeIssuesAndPRs, "PUT", "/repos/org/repo/pulls/123/merge") {
+		t.Error("ISSUES_AND_PRS should NOT allow merge")
+	}
+	if !AllowedByMode(agent.ModeIssuesPRsMerge, "PUT", "/repos/org/repo/pulls/123/merge") {
+		t.Error("ISSUES_PRS_MERGE should allow merge")
+	}
+}
+
+func TestAllowedByModePROperations(t *testing.T) {
+	if AllowedByMode(agent.ModeIssuesOnly, "POST", "/repos/org/repo/pulls") {
+		t.Error("ISSUES_ONLY should NOT allow creating PRs")
+	}
+	if !AllowedByMode(agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/pulls") {
+		t.Error("ISSUES_AND_PRS should allow creating PRs")
+	}
+	if !AllowedByMode(agent.ModeIssuesAndPRs, "PATCH", "/repos/org/repo/pulls/42") {
+		t.Error("ISSUES_AND_PRS should allow patching PRs")
+	}
+	if !AllowedByMode(agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/pulls/42/reviews") {
+		t.Error("ISSUES_AND_PRS should allow posting reviews")
+	}
+}
+
+func TestAllowedByModeGitOperations(t *testing.T) {
+	if !AllowedByMode(agent.ModeAdvisory, "POST", "/org/repo.git/git-upload-pack") {
+		t.Error("ADVISORY should allow git fetch (upload-pack)")
+	}
+	if AllowedByMode(agent.ModeAdvisory, "POST", "/org/repo.git/git-receive-pack") {
+		t.Error("ADVISORY should NOT allow git push (receive-pack)")
+	}
+	if !AllowedByMode(agent.ModeIssuesAndPRs, "POST", "/org/repo.git/git-receive-pack") {
+		t.Error("ISSUES_AND_PRS should allow git push")
+	}
+	if !AllowedByMode(agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/git/refs") {
+		t.Error("ISSUES_AND_PRS should allow creating refs")
+	}
+	if !AllowedByMode(agent.ModeIssuesAndPRs, "POST", "/repos/org/repo/git/commits") {
+		t.Error("ISSUES_AND_PRS should allow creating commits")
+	}
+	if !AllowedByMode(agent.ModeIssuesAndPRs, "DELETE", "/repos/org/repo/git/refs/heads/branch") {
+		t.Error("ISSUES_AND_PRS should allow deleting refs")
+	}
+}
+
+func TestAllowedByModeIssueOperations(t *testing.T) {
+	if AllowedByMode(agent.ModeAdvisory, "POST", "/repos/org/repo/issues") {
+		t.Error("ADVISORY should NOT allow creating issues")
+	}
+	if !AllowedByMode(agent.ModeIssuesOnly, "POST", "/repos/org/repo/issues") {
+		t.Error("ISSUES_ONLY should allow creating issues")
+	}
+	if !AllowedByMode(agent.ModeIssuesOnly, "PATCH", "/repos/org/repo/issues/42") {
+		t.Error("ISSUES_ONLY should allow patching issues")
+	}
+	if !AllowedByMode(agent.ModeIssuesOnly, "POST", "/repos/org/repo/issues/42/comments") {
+		t.Error("ISSUES_ONLY should allow commenting on issues")
+	}
+	if !AllowedByMode(agent.ModeIssuesOnly, "POST", "/repos/org/repo/issues/42/labels") {
+		t.Error("ISSUES_ONLY should allow adding labels")
+	}
+}
+
+func TestAllowedByModeReadOperations(t *testing.T) {
+	if !AllowedByMode(agent.ModeAdvisory, "GET", "/repos/org/repo") {
+		t.Error("ADVISORY should allow GET")
+	}
+	if !AllowedByMode(agent.ModeAdvisory, "HEAD", "/repos/org/repo") {
+		t.Error("ADVISORY should allow HEAD")
+	}
+	if !AllowedByMode(agent.ModeAdvisory, "OPTIONS", "/repos/org/repo") {
+		t.Error("ADVISORY should allow OPTIONS")
+	}
+}
+
+func TestAllowedByModeUnknownMethod(t *testing.T) {
+	if AllowedByMode(agent.ModeIssuesPRsMerge, "TRACE", "/repos/org/repo") {
+		t.Error("unknown method TRACE should be denied")
+	}
+}
+
+func TestGraphQLAllowedQuery(t *testing.T) {
+	body := []byte(`{"query":"{ viewer { login } }"}`)
+	allowed, isMutation := GraphQLAllowed(agent.ModeAdvisory, body)
+	if !allowed {
+		t.Error("ADVISORY should allow GraphQL queries")
+	}
+	if isMutation {
+		t.Error("query should not be flagged as mutation")
+	}
+}
+
+func TestGraphQLAllowedMutation(t *testing.T) {
+	body := []byte(`{"query":"mutation { addStar(input: {starrableId: \"abc\"}) { starrable { id } } }"}`)
+	allowed, isMutation := GraphQLAllowed(agent.ModeAdvisory, body)
+	if allowed {
+		t.Error("ADVISORY should NOT allow GraphQL mutations")
+	}
+	if !isMutation {
+		t.Error("should be flagged as mutation")
+	}
+
+	allowed2, _ := GraphQLAllowed(agent.ModeIssuesOnly, body)
+	if !allowed2 {
+		t.Error("ISSUES_ONLY should allow GraphQL mutations")
+	}
+}
+
+func TestGraphQLAllowedBelowAdvisory(t *testing.T) {
+	body := []byte(`{"query":"{ viewer { login } }"}`)
+	allowed, _ := GraphQLAllowed(agent.AgentMode(-1), body)
+	if allowed {
+		t.Error("mode below ADVISORY should deny everything")
+	}
+}
+
+func TestGraphQLAllowedInvalidJSON(t *testing.T) {
+	allowed, _ := GraphQLAllowed(agent.ModeAdvisory, []byte("not json"))
+	if allowed {
+		t.Error("invalid JSON should be denied")
+	}
+}
+
+func TestGraphQLAllowedMultilineMutation(t *testing.T) {
+	body := []byte(`{"query":"\nmutation {\n  addComment(input: {}) { id }\n}"}`)
+	allowed, isMutation := GraphQLAllowed(agent.ModeAdvisory, body)
+	if allowed {
+		t.Error("multiline mutation should be denied for ADVISORY")
+	}
+	if !isMutation {
+		t.Error("multiline mutation should be detected")
+	}
+}
+
+func TestExtractSNIEmpty(t *testing.T) {
+	if sni := extractSNI(nil); sni != "" {
+		t.Errorf("nil data should return empty, got %q", sni)
+	}
+	if sni := extractSNI([]byte{1, 2, 3}); sni != "" {
+		t.Errorf("too-short data should return empty, got %q", sni)
+	}
+}
+
+func TestExtractSNIPartialData(t *testing.T) {
+	data := make([]byte, 10)
+	data[0] = 0x16
+	data[3] = 0
+	data[4] = 4
+	sni := extractSNI(data)
+	if sni != "" {
+		t.Errorf("partial ClientHello should return empty, got %q", sni)
+	}
+}
+
+func TestExtractAgentNameFromHeader(t *testing.T) {
+	tests := []struct {
+		name     string
+		authHdr  string
+		wantName string
+	}{
+		{"basic auth with agent name", "Basic " + base64.StdEncoding.EncodeToString([]byte("scanner:token")), "scanner"},
+		{"no auth header", "", ""},
+		{"bearer token", "Bearer ghp_abc123", ""},
+		{"basic with empty user", "Basic " + base64.StdEncoding.EncodeToString([]byte(":token")), ""},
+		{"invalid base64", "Basic not-valid-base64!!!", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", "https://api.github.com/repos", nil)
+			if tt.authHdr != "" {
+				req.Header.Set("Proxy-Authorization", tt.authHdr)
+			}
+			got := extractAgentName(req)
+			if got != tt.wantName {
+				t.Errorf("extractAgentName() = %q, want %q", got, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestReadAgentMode(t *testing.T) {
+	tmpDir := t.TempDir()
+	origPrefix := modeFilePrefix
+	defer func() {
+		// restore if needed - but since it's a const, just test via actual file
+	}()
+
+	modeFile := filepath.Join(tmpDir, "mode-test-agent")
+	os.WriteFile(modeFile, []byte("ISSUES_AND_PRS\n"), 0644)
+
+	got := readAgentMode("nonexistent-agent-xyz")
+	if got != agent.ModeAdvisory {
+		t.Errorf("missing mode file should default to ADVISORY, got %v", got)
+	}
+	_ = origPrefix
+}
+
+func TestLookupUIDByLocalPortFrom(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "tcp")
+	content := `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 0100007F:1F91 0100007F:0050 01 00000000:00000000 00:00000000 00000000  1001        0 12345
+   1: 0100007F:4E21 0100007F:0050 01 00000000:00000000 00:00000000 00000000  1002        0 12346
+`
+	os.WriteFile(tmpFile, []byte(content), 0644)
+
+	uid, err := lookupUIDByLocalPortFrom(tmpFile, 8081)
+	if err != nil {
+		t.Fatalf("lookup port 8081 failed: %v", err)
+	}
+	if uid != 1001 {
+		t.Errorf("uid = %d, want 1001", uid)
+	}
+
+	uid2, err := lookupUIDByLocalPortFrom(tmpFile, 20001)
+	if err != nil {
+		t.Fatalf("lookup port 20001 failed: %v", err)
+	}
+	if uid2 != 1002 {
+		t.Errorf("uid = %d, want 1002", uid2)
+	}
+
+	_, err = lookupUIDByLocalPortFrom(tmpFile, 9999)
+	if err == nil {
+		t.Error("expected error for non-existent port")
+	}
+}
+
+func TestLookupUIDByLocalPortFromEmpty(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "tcp")
+	os.WriteFile(tmpFile, []byte(""), 0644)
+
+	_, err := lookupUIDByLocalPortFrom(tmpFile, 8080)
+	if err == nil {
+		t.Error("expected error for empty file")
+	}
+}
+
+func TestLookupUIDByLocalPortFromMissing(t *testing.T) {
+	_, err := lookupUIDByLocalPortFrom("/nonexistent/path/tcp", 8080)
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestLookupUIDByLocalPortFromMalformed(t *testing.T) {
+	tmpFile := filepath.Join(t.TempDir(), "tcp")
+	content := `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid
+   0: baddata
+   1: short 0100007F:0050
+`
+	os.WriteFile(tmpFile, []byte(content), 0644)
+
+	_, err := lookupUIDByLocalPortFrom(tmpFile, 8080)
+	if err == nil {
+		t.Error("expected error for malformed data")
+	}
+}
+
+func TestPrefixConnRead(t *testing.T) {
+	prefix := []byte("hello")
+	pc := &prefixConn{prefix: prefix}
+	buf := make([]byte, 3)
+	n, err := pc.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 3 || string(buf[:n]) != "hel" {
+		t.Errorf("first read = %q, want 'hel'", buf[:n])
+	}
+	n, err = pc.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 || string(buf[:n]) != "lo" {
+		t.Errorf("second read = %q, want 'lo'", buf[:n])
+	}
+}
+
+func TestIsGitHubHostComplete(t *testing.T) {
+	positives := []string{"api.github.com", "github.com"}
+	negatives := []string{"gitlab.com", "bitbucket.org", "github.io", "", "api.github.com.evil.com"}
+
+	for _, h := range positives {
+		if !IsGitHubHost(h) {
+			t.Errorf("IsGitHubHost(%q) = false, want true", h)
+		}
+	}
+	for _, h := range negatives {
+		if IsGitHubHost(h) {
+			t.Errorf("IsGitHubHost(%q) = true, want false", h)
+		}
+	}
+}
+
+func TestAllowedByModeEscalation(t *testing.T) {
+	path := "/repos/org/repo/pulls"
+	method := "POST"
+
+	modes := []agent.AgentMode{
+		agent.ModeAdvisory,
+		agent.ModeIssuesOnly,
+		agent.ModeIssuesAndPRs,
+		agent.ModeIssuesPRsMerge,
+	}
+
+	for i, mode := range modes {
+		allowed := AllowedByMode(mode, method, path)
+		if i < 2 && allowed {
+			t.Errorf("mode %v should NOT allow %s %s", mode, method, path)
+		}
+		if i >= 2 && !allowed {
+			t.Errorf("mode %v should allow %s %s", mode, method, path)
+		}
+	}
+}

--- a/v2/pkg/proxy/proxy_tls_test.go
+++ b/v2/pkg/proxy/proxy_tls_test.go
@@ -1,0 +1,247 @@
+package proxy
+
+import (
+	"crypto/x509"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/agent"
+)
+
+func TestGenerateCA(t *testing.T) {
+	tlsCert, x509Cert, err := generateCA()
+	if err != nil {
+		t.Fatalf("generateCA error: %v", err)
+	}
+	if x509Cert == nil {
+		t.Fatal("x509Cert should not be nil")
+	}
+	if !x509Cert.IsCA {
+		t.Error("certificate should be a CA")
+	}
+	if x509Cert.Subject.CommonName != "Hive ACMM Proxy CA" {
+		t.Errorf("CN = %q", x509Cert.Subject.CommonName)
+	}
+	if tlsCert.PrivateKey == nil {
+		t.Error("private key should not be nil")
+	}
+}
+
+func TestForgeCert(t *testing.T) {
+	caCert, caX509, err := generateCA()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &GitHubProxy{
+		caCert:    caCert,
+		caX509:    caX509,
+		logger:    slog.Default(),
+		certCache: make(map[string]cachedCert),
+	}
+
+	cert, err := p.forgeCert("api.github.com")
+	if err != nil {
+		t.Fatalf("forgeCert error: %v", err)
+	}
+	if cert.PrivateKey == nil {
+		t.Error("forged cert should have private key")
+	}
+
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatalf("parse forged cert: %v", err)
+	}
+	if leaf.Subject.CommonName != "api.github.com" {
+		t.Errorf("CN = %q, want 'api.github.com'", leaf.Subject.CommonName)
+	}
+	if len(leaf.DNSNames) == 0 || leaf.DNSNames[0] != "api.github.com" {
+		t.Error("SAN should include api.github.com")
+	}
+}
+
+func TestForgeCertCached(t *testing.T) {
+	caCert, caX509, err := generateCA()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &GitHubProxy{
+		caCert:    caCert,
+		caX509:    caX509,
+		logger:    slog.Default(),
+		certCache: make(map[string]cachedCert),
+	}
+
+	cert1, _ := p.forgeCert("github.com")
+	cert2, _ := p.forgeCert("github.com")
+
+	if len(cert1.Certificate) == 0 || len(cert2.Certificate) == 0 {
+		t.Fatal("certs should not be empty")
+	}
+
+	leaf1, _ := x509.ParseCertificate(cert1.Certificate[0])
+	leaf2, _ := x509.ParseCertificate(cert2.Certificate[0])
+	if leaf1.SerialNumber.Cmp(leaf2.SerialNumber) != 0 {
+		t.Error("second call should return cached cert with same serial")
+	}
+}
+
+func TestForgeCertDifferentHosts(t *testing.T) {
+	caCert, caX509, err := generateCA()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p := &GitHubProxy{
+		caCert:    caCert,
+		caX509:    caX509,
+		logger:    slog.Default(),
+		certCache: make(map[string]cachedCert),
+	}
+
+	cert1, _ := p.forgeCert("api.github.com")
+	cert2, _ := p.forgeCert("github.com")
+
+	leaf1, _ := x509.ParseCertificate(cert1.Certificate[0])
+	leaf2, _ := x509.ParseCertificate(cert2.Certificate[0])
+	if leaf1.Subject.CommonName == leaf2.Subject.CommonName {
+		t.Error("different hosts should get different certs")
+	}
+}
+
+func TestReadAgentModeFromFile(t *testing.T) {
+	dir := t.TempDir()
+	origPrefix := modeFilePrefix
+	_ = origPrefix
+
+	modePath := filepath.Join(dir, "mode-test-agent")
+	os.WriteFile(modePath, []byte("ISSUES_AND_PRS\n"), 0644)
+
+	got := readAgentMode("")
+	if got != agent.ModeAdvisory {
+		t.Errorf("empty agent name should return ADVISORY, got %v", got)
+	}
+}
+
+func TestReadAgentModeMissing(t *testing.T) {
+	got := readAgentMode("nonexistent-agent-xyz-999")
+	if got != agent.ModeAdvisory {
+		t.Errorf("missing mode file should return ADVISORY, got %v", got)
+	}
+}
+
+func TestListenAddr(t *testing.T) {
+	p := &GitHubProxy{listenAddr: "127.0.0.1:18443"}
+	if p.ListenAddr() != "127.0.0.1:18443" {
+		t.Errorf("ListenAddr() = %q", p.ListenAddr())
+	}
+}
+
+func TestViolationsEmpty(t *testing.T) {
+	p := &GitHubProxy{violations: make(map[string]int)}
+	v := p.Violations()
+	if len(v) != 0 {
+		t.Error("should be empty")
+	}
+}
+
+func TestAgentViolationsZero(t *testing.T) {
+	p := &GitHubProxy{violations: make(map[string]int)}
+	if p.AgentViolations("scanner") != 0 {
+		t.Error("unknown agent should have 0 violations")
+	}
+}
+
+func TestRecordViolationIncrement(t *testing.T) {
+	p := &GitHubProxy{
+		violations: make(map[string]int),
+		logger:     slog.Default(),
+	}
+	p.recordViolation("scanner", "POST", "/repos/org/repo/pulls")
+	p.recordViolation("scanner", "POST", "/repos/org/repo/pulls")
+	p.recordViolation("quality", "PUT", "/repos/org/repo/pulls/1/merge")
+
+	if p.AgentViolations("scanner") != 2 {
+		t.Errorf("scanner violations = %d, want 2", p.AgentViolations("scanner"))
+	}
+	if p.AgentViolations("quality") != 1 {
+		t.Errorf("quality violations = %d, want 1", p.AgentViolations("quality"))
+	}
+
+	snap := p.Violations()
+	if snap["scanner"] != 2 {
+		t.Error("snapshot should reflect violations")
+	}
+}
+
+func TestNewBufferedConn(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	r := newBufferedConn(client)
+	if r == nil {
+		t.Error("should return non-nil reader")
+	}
+}
+
+func TestNewBufferedReader(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	r := newBufferedReader(client)
+	if r == nil {
+		t.Error("should return non-nil reader")
+	}
+}
+
+func TestIdentifyAgentFromReqNoUIDMap(t *testing.T) {
+	// identifyAgentFromReq needs *http.Request — tested via extractAgentName
+	// in proxy_coverage_test.go. This just verifies the struct can be created.
+	p := &GitHubProxy{
+		uidMap:     nil,
+		violations: make(map[string]int),
+		logger:     slog.Default(),
+	}
+	if p.ListenAddr() != "" {
+		t.Error("empty listenAddr should be empty")
+	}
+}
+
+func TestIdentifyAgentByUIDInvalidPort(t *testing.T) {
+	uidMap := &agent.UIDMap{IptablesActive: true}
+	p := &GitHubProxy{
+		uidMap:     uidMap,
+		violations: make(map[string]int),
+		logger:     slog.Default(),
+	}
+
+	got := p.identifyAgentByUID("127.0.0.1:abc")
+	if got != "" {
+		t.Errorf("invalid port should return empty, got %q", got)
+	}
+
+	got2 := p.identifyAgentByUID("invalid-no-colon")
+	if got2 != "" {
+		t.Errorf("no port should return empty, got %q", got2)
+	}
+}
+
+func TestIdentifyAgentByUIDOverflow(t *testing.T) {
+	uidMap := &agent.UIDMap{IptablesActive: true}
+	p := &GitHubProxy{
+		uidMap:     uidMap,
+		violations: make(map[string]int),
+		logger:     slog.Default(),
+	}
+
+	got := p.identifyAgentByUID("127.0.0.1:99999999")
+	if got != "" {
+		t.Errorf("overflow port should return empty, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Proxy package: 15.8% → 34.1% coverage (+18.3%)
- Supersedes proxy portion of #1238

### New TLS/cert tests
- **generateCA**: creates valid CA cert with correct CN, IsCA flag, private key
- **forgeCert**: generates host cert signed by CA, validates CN/SAN, tests cache hit on second call, different hosts get different certs
- **readAgentMode**: empty name → ADVISORY, missing file → ADVISORY
- **identifyAgentByUID**: invalid port string, no colon in addr, port overflow

### Utility tests
- ListenAddr, Violations (empty), AgentViolations (zero), recordViolation (increment + snapshot)
- newBufferedConn, newBufferedReader
- All AllowedByMode operation types, GraphQL mutation detection, extractSNI, extractAgentName, lookupUIDByLocalPortFrom, prefixConn, IsGitHubHost

## Test plan
- [x] `go test ./v2/pkg/proxy/ -cover` passes (34.1%)
- [x] All 17/17 packages still pass