### PR TITLE
fix: ACMM level persists across pod restarts

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -736,19 +736,20 @@ func main() {
 			}
 		}
 	} else {
-		// Determine the ACMM level from env var, config, or saved state
+		// Config file is authoritative on restarts; HIVE_LEVEL env var is
+		// only a fallback for initial provisioning when no level is persisted.
 		const maxACMMLevel = 6
 		level := 0
-		if levelStr := os.Getenv("HIVE_LEVEL"); levelStr != "" {
+		if cfg.ACMMLevel != nil && *cfg.ACMMLevel >= 1 && *cfg.ACMMLevel <= maxACMMLevel {
+			level = *cfg.ACMMLevel
+		} else if saved.ACMMLevel != nil && *saved.ACMMLevel >= 1 && *saved.ACMMLevel <= maxACMMLevel {
+			level = *saved.ACMMLevel
+		} else if levelStr := os.Getenv("HIVE_LEVEL"); levelStr != "" {
 			if parsed, err := strconv.Atoi(levelStr); err == nil && parsed >= 1 && parsed <= maxACMMLevel {
 				level = parsed
 			} else {
 				logger.Warn("invalid HIVE_LEVEL, skipping auto-apply", "value", levelStr)
 			}
-		} else if cfg.ACMMLevel != nil && *cfg.ACMMLevel >= 1 && *cfg.ACMMLevel <= maxACMMLevel {
-			level = *cfg.ACMMLevel
-		} else if saved.ACMMLevel != nil && *saved.ACMMLevel >= 1 && *saved.ACMMLevel <= maxACMMLevel {
-			level = *saved.ACMMLevel
 		}
 		if level > 0 {
 			action := "merging pack updates"

--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -324,13 +324,7 @@ TTYD_PID=$!
 
 cleanup() {
   echo "[entrypoint] Shutting down..."
-  # Backup config before exit so it survives container recreation.
-  # The Go binary may overwrite the bind-mounted file with empty state
-  # during shutdown, so we capture it while it's still valid.
-  if [ -f "$HIVE_CONFIG_PATH" ] && [ -s "$HIVE_CONFIG_PATH" ]; then
-    cp "$HIVE_CONFIG_PATH" "$HIVE_CONFIG_BACKUP"
-    echo "[entrypoint] Config backed up on shutdown: $HIVE_CONFIG_PATH -> $HIVE_CONFIG_BACKUP"
-  fi
+  # PVC backup is managed by Save() — no shutdown backup needed
   kill "$TTYD_PID" 2>/dev/null || true
   kill "$PROXY_PID" 2>/dev/null || true
   kill "$HIVE_PID" 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Config file (`hive.yaml`) now takes priority over `HIVE_LEVEL` env var on restarts
- `HIVE_LEVEL` env var is only used as fallback for initial provisioning (when no level is persisted)
- Removed shutdown backup handler that could overwrite PVC backup with stale config

## Root cause

`HIVE_LEVEL=3` env var in the deployment spec was checked **first** on every restart, overriding the user's saved `acmm_level: 6` in config. Other config settings (repos, governor, etc.) were not affected because they have no env var override.

## Test plan

- [ ] Set ACMM to level 6 via dashboard
- [ ] Delete pod (force restart)
- [ ] Verify ACMM remains at level 6 after restart
- [ ] Repeat 5x to confirm persistence