### PR TITLE
fix: increase hosted hive resources — 4Gi mem, 2 CPU, 10Gi PVC

### DIFF
--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -22,11 +22,11 @@ const (
 	maxSaaSHivesTotal     = 5
 	provisionPollInterval = 30 * time.Second
 	provisionTimeout      = 5 * time.Minute
-	cpuRequest            = "200m"
-	cpuLimit              = "500m"
-	memRequest            = "256Mi"
-	memLimit              = "512Mi"
-	pvcSize               = "1Gi"
+	cpuRequest            = "500m"
+	cpuLimit              = "2000m"
+	memRequest            = "1Gi"
+	memLimit              = "4Gi"
+	pvcSize               = "10Gi"
 )
 
 type SaaSHive struct {


### PR DESCRIPTION
512Mi caused OOM kills on Copilot arm64. Multiple agents need room.