### PR TITLE
test: hub comprehensive coverage (12.2% → 35.8%)

### DIFF
--- a/v2/pkg/hub/hub_coverage_test.go
+++ b/v2/pkg/hub/hub_coverage_test.go
@@ -1,0 +1,762 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSanitizeField(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"hello", "hello"},
+		{"  spaced  ", "spaced"},
+		{"<script>alert(1)</script>", "&lt;script&gt;alert(1)&lt;/script&gt;"},
+		{strings.Repeat("a", 300), strings.Repeat("a", 200)},
+		{"", ""},
+		{"normal text", "normal text"},
+		{"a&b", "a&amp;b"},
+	}
+	for _, tt := range tests {
+		got := sanitizeField(tt.input)
+		if got != tt.want {
+			t.Errorf("sanitizeField(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestIsValidName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"valid-name", true},
+		{"my.repo_123", true},
+		{"UPPER", true},
+		{"", false},
+		{"has spaces", false},
+		{"<script>", false},
+		{strings.Repeat("a", 100), true},
+		{strings.Repeat("a", 101), false},
+		{"with/slash", false},
+		{"valid_name-123.test", true},
+	}
+	for _, tt := range tests {
+		got := isValidName(tt.input)
+		if got != tt.want {
+			t.Errorf("isValidName(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestSanitizeHeartbeatField(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"hello-world", "hello-world"},
+		{"org/repo", "org/repo"},
+		{"has spaces!", "hasspaces"},
+		{"<script>bad</script>", "scriptbad/script"},
+		{"v1.2.3", "v1.2.3"},
+		{"abc_def.ghi-123/foo", "abc_def.ghi-123/foo"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := sanitizeHeartbeatField(tt.input)
+		if got != tt.want {
+			t.Errorf("sanitizeHeartbeatField(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestClampInt(t *testing.T) {
+	tests := []struct {
+		v, min, max, want int
+	}{
+		{5, 0, 10, 5},
+		{-1, 0, 10, 0},
+		{15, 0, 10, 10},
+		{0, 0, 0, 0},
+		{3, 3, 3, 3},
+	}
+	for _, tt := range tests {
+		got := clampInt(tt.v, tt.min, tt.max)
+		if got != tt.want {
+			t.Errorf("clampInt(%d, %d, %d) = %d, want %d", tt.v, tt.min, tt.max, got, tt.want)
+		}
+	}
+}
+
+func TestClampInt64(t *testing.T) {
+	tests := []struct {
+		v, min, max, want int64
+	}{
+		{5, 0, 10, 5},
+		{-1, 0, 10, 0},
+		{15, 0, 10, 10},
+		{100_000_000, 0, 100_000_000, 100_000_000},
+		{200_000_000, 0, 100_000_000, 100_000_000},
+	}
+	for _, tt := range tests {
+		got := clampInt64(tt.v, tt.min, tt.max)
+		if got != tt.want {
+			t.Errorf("clampInt64(%d, %d, %d) = %d, want %d", tt.v, tt.min, tt.max, got, tt.want)
+		}
+	}
+}
+
+func newTestServer() *HubServer {
+	srv := NewHubServer(0, slog.Default(), "testhash")
+	srv.hubSecret = ""
+	return srv
+}
+
+func TestHandleHeartbeatValidPayload(t *testing.T) {
+	srv := newTestServer()
+	srv.hubSecret = "test-secret"
+
+	payload := HeartbeatPayload{
+		HiveID:      "test-hive-1",
+		Org:         "testorg",
+		Repos:       []string{"repo1", "repo2"},
+		PrimaryRepo: "repo1",
+		ACMMLevel:   3,
+		DashboardURL: "https://example.com",
+		IsPublic:    true,
+		Agents: []AgentSummary{
+			{Name: "scanner", State: "running"},
+			{Name: "quality", State: "paused"},
+		},
+		Leaderboard: []LeaderboardEntry{
+			{GitHubUsername: "user1", TasksCompleted: 5},
+		},
+		Governor: GovernorSummary{Mode: "active", Issues: 3, PRs: 2},
+	}
+
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer test-secret")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("heartbeat status = %d, want 200, body: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["ok"] != true {
+		t.Error("expected ok=true")
+	}
+
+	srv.mu.RLock()
+	defer srv.mu.RUnlock()
+	if len(srv.registry.Hives) != 1 {
+		t.Fatalf("expected 1 hive, got %d", len(srv.registry.Hives))
+	}
+	h := srv.registry.Hives[0]
+	if h.ID != "test-hive-1" {
+		t.Errorf("hive ID = %q", h.ID)
+	}
+	if h.ACMMLevel != 3 {
+		t.Errorf("ACMM level = %d, want 3", h.ACMMLevel)
+	}
+	if h.AgentCount != 1 {
+		t.Errorf("agent count = %d, want 1 (only running)", h.AgentCount)
+	}
+	if !h.Online {
+		t.Error("hive should be online")
+	}
+}
+
+func TestHandleHeartbeatEmptyHiveID(t *testing.T) {
+	srv := newTestServer()
+	payload := HeartbeatPayload{HiveID: ""}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleHeartbeatInvalidName(t *testing.T) {
+	srv := newTestServer()
+	// After sanitizeHeartbeatField, only alphanumeric, dash, underscore, dot, slash remain.
+	// To trigger isValidName failure, send all-special chars that get stripped to empty.
+	payload := HeartbeatPayload{HiveID: "!!!@@@"}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleHeartbeatInvalidOrg(t *testing.T) {
+	srv := newTestServer()
+	payload := HeartbeatPayload{HiveID: "valid-id", Org: "bad org!"}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleHeartbeatInvalidDashboardURL(t *testing.T) {
+	srv := newTestServer()
+	payload := HeartbeatPayload{HiveID: "valid-id", DashboardURL: "ftp://bad"}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleHeartbeatInvalidSnapshotURL(t *testing.T) {
+	srv := newTestServer()
+	payload := HeartbeatPayload{HiveID: "valid-id", SnapshotURL: "ftp://bad"}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleHeartbeatInvalidRepoName(t *testing.T) {
+	srv := newTestServer()
+	payload := HeartbeatPayload{HiveID: "valid-id", Repos: []string{"good", "bad repo!"}}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleHeartbeatInvalidAgentName(t *testing.T) {
+	srv := newTestServer()
+	payload := HeartbeatPayload{
+		HiveID: "valid-id",
+		Agents: []AgentSummary{{Name: "bad agent!", State: "running"}},
+	}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleHeartbeatInvalidLeaderboardUsername(t *testing.T) {
+	srv := newTestServer()
+	payload := HeartbeatPayload{
+		HiveID:      "valid-id",
+		Leaderboard: []LeaderboardEntry{{GitHubUsername: "bad user!"}},
+	}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleHeartbeatUpdateExisting(t *testing.T) {
+	srv := newTestServer()
+
+	p1 := HeartbeatPayload{HiveID: "hive-1", Org: "org", PrimaryRepo: "repo", ACMMLevel: 1, IsPublic: true}
+	body1, _ := json.Marshal(p1)
+	req1 := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body1)))
+	req1.Header.Set("Content-Type", "application/json")
+	w1 := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w1, req1)
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first heartbeat failed: %d", w1.Code)
+	}
+
+	p2 := HeartbeatPayload{HiveID: "hive-1", Org: "org", PrimaryRepo: "repo", ACMMLevel: 5, IsPublic: true}
+	body2, _ := json.Marshal(p2)
+	req2 := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body2)))
+	req2.Header.Set("Content-Type", "application/json")
+	w2 := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("second heartbeat failed: %d", w2.Code)
+	}
+
+	srv.mu.RLock()
+	defer srv.mu.RUnlock()
+	if len(srv.registry.Hives) != 1 {
+		t.Fatalf("expected 1 hive after update, got %d", len(srv.registry.Hives))
+	}
+	if srv.registry.Hives[0].ACMMLevel != 5 {
+		t.Errorf("ACMM level not updated, got %d", srv.registry.Hives[0].ACMMLevel)
+	}
+}
+
+func TestHandleHeartbeatACMMClamp(t *testing.T) {
+	srv := newTestServer()
+
+	payload := HeartbeatPayload{HiveID: "clamp-test", Org: "org", PrimaryRepo: "repo", ACMMLevel: 99}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+
+	srv.mu.RLock()
+	defer srv.mu.RUnlock()
+	if srv.registry.Hives[0].ACMMLevel != 6 {
+		t.Errorf("ACMM should be clamped to 6, got %d", srv.registry.Hives[0].ACMMLevel)
+	}
+}
+
+func TestHandleHeartbeatHostedPrefix(t *testing.T) {
+	srv := newTestServer()
+
+	payload := HeartbeatPayload{HiveID: "hosted-test-abc", Org: "org", PrimaryRepo: "repo"}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("hosted- prefix without provisioning should be 403, got %d", w.Code)
+	}
+}
+
+func TestMarkStaleHives(t *testing.T) {
+	srv := newTestServer()
+	now := time.Now().UTC()
+
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{
+		{ID: "fresh", LastHeartbeat: now.Format(time.RFC3339), Online: true},
+		{ID: "stale", LastHeartbeat: now.Add(-6 * time.Minute).Format(time.RFC3339), Online: true},
+		{ID: "ancient", LastHeartbeat: now.Add(-25 * time.Hour).Format(time.RFC3339), Online: true},
+		{ID: "no-heartbeat", LastHeartbeat: "", Online: true},
+		{ID: "bad-time", LastHeartbeat: "not-a-time", Online: true},
+	}
+	srv.markStaleHives()
+	srv.mu.Unlock()
+
+	srv.mu.RLock()
+	defer srv.mu.RUnlock()
+
+	hiveMap := map[string]*RegistryEntry{}
+	for i := range srv.registry.Hives {
+		hiveMap[srv.registry.Hives[i].ID] = &srv.registry.Hives[i]
+	}
+
+	if _, ok := hiveMap["ancient"]; ok {
+		t.Error("ancient hive (>24h) should be removed")
+	}
+	if h, ok := hiveMap["fresh"]; !ok || !h.Online {
+		t.Error("fresh hive should be online")
+	}
+	if h, ok := hiveMap["stale"]; !ok || h.Online {
+		t.Error("stale hive (>5min) should be offline")
+	}
+	if h, ok := hiveMap["no-heartbeat"]; !ok || h.Online {
+		t.Error("no-heartbeat hive should be offline")
+	}
+	if h, ok := hiveMap["bad-time"]; !ok || h.Online {
+		t.Error("bad-time hive should be offline")
+	}
+}
+
+func TestMergeLeaderboards(t *testing.T) {
+	srv := newTestServer()
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{
+		{
+			ID: "h1", IsPublic: true,
+			Leaderboard: []LeaderboardEntry{
+				{GitHubUsername: "user1", TasksCompleted: 3, TasksFailed: 1, Active: true, CurrentTask: "fix bug", HiveName: "h1"},
+				{GitHubUsername: "user2", TasksCompleted: 5},
+			},
+		},
+		{
+			ID: "h2", IsPublic: true,
+			Leaderboard: []LeaderboardEntry{
+				{GitHubUsername: "user1", TasksCompleted: 2, TasksFailed: 0},
+				{GitHubUsername: "user3", TasksCompleted: 0, TasksFailed: 0},
+			},
+		},
+		{
+			ID: "h3", IsPublic: false,
+			Leaderboard: []LeaderboardEntry{
+				{GitHubUsername: "private-user", TasksCompleted: 10},
+			},
+		},
+	}
+	merged := srv.mergeLeaderboards()
+	srv.mu.Unlock()
+
+	userMap := map[string]LeaderboardEntry{}
+	for _, e := range merged {
+		userMap[e.GitHubUsername] = e
+	}
+
+	if _, ok := userMap["private-user"]; ok {
+		t.Error("private hive users should not be in leaderboard")
+	}
+	if _, ok := userMap["user3"]; ok {
+		t.Error("user3 (0 tasks, inactive) should be excluded")
+	}
+	if u1, ok := userMap["user1"]; !ok {
+		t.Error("user1 should be present")
+	} else {
+		if u1.TasksCompleted != 5 {
+			t.Errorf("user1 completed = %d, want 5 (3+2)", u1.TasksCompleted)
+		}
+		if u1.TasksFailed != 1 {
+			t.Errorf("user1 failed = %d, want 1", u1.TasksFailed)
+		}
+		if !u1.Active {
+			t.Error("user1 should be active")
+		}
+	}
+}
+
+func TestHandleRegistryFiltersPrivate(t *testing.T) {
+	srv := newTestServer()
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{
+		{ID: "pub", IsPublic: true, Online: true, LastHeartbeat: time.Now().UTC().Format(time.RFC3339)},
+		{ID: "priv", IsPublic: false, Online: true, LastHeartbeat: time.Now().UTC().Format(time.RFC3339)},
+	}
+	srv.mu.Unlock()
+
+	req := httptest.NewRequest("GET", "/api/registry", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	var reg Registry
+	json.Unmarshal(w.Body.Bytes(), &reg)
+	for _, h := range reg.Hives {
+		if h.ID == "priv" {
+			t.Error("private hive should not appear in registry")
+		}
+	}
+}
+
+func TestHandleRegistryDedupsHostedVsLocal(t *testing.T) {
+	srv := newTestServer()
+	now := time.Now().UTC()
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{
+		{ID: "hosted-abc", Name: "org/repo", IsPublic: true, HiveType: "hosted", Online: true, LastHeartbeat: now.Format(time.RFC3339)},
+		{ID: "local-abc", Name: "org/repo", IsPublic: true, HiveType: "local", Online: false, LastHeartbeat: now.Add(-10 * time.Minute).Format(time.RFC3339)},
+	}
+	srv.mu.Unlock()
+
+	req := httptest.NewRequest("GET", "/api/registry", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	var reg Registry
+	json.Unmarshal(w.Body.Bytes(), &reg)
+	if len(reg.Hives) != 1 {
+		t.Errorf("expected 1 hive (hosted wins over offline local), got %d", len(reg.Hives))
+	}
+	if len(reg.Hives) > 0 && reg.Hives[0].ID != "hosted-abc" {
+		t.Errorf("expected hosted hive to win, got %s", reg.Hives[0].ID)
+	}
+}
+
+func TestHandleStatsAggregation(t *testing.T) {
+	srv := newTestServer()
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{
+		{ID: "h1", IsPublic: true, Online: true, AgentCount: 3, ActiveContributors: 2, ActionableIssues: 5, ActionablePRs: 1, LastHeartbeat: time.Now().UTC().Format(time.RFC3339)},
+		{ID: "h2", IsPublic: true, Online: false, AgentCount: 2, ActiveContributors: 1, ActionableIssues: 3, ActionablePRs: 2, LastHeartbeat: time.Now().UTC().Add(-10 * time.Minute).Format(time.RFC3339)},
+		{ID: "h3", IsPublic: false, AgentCount: 10, LastHeartbeat: time.Now().UTC().Format(time.RFC3339)},
+	}
+	srv.mu.Unlock()
+
+	req := httptest.NewRequest("GET", "/api/hub/stats", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	var stats map[string]any
+	json.Unmarshal(w.Body.Bytes(), &stats)
+	if stats["hives"].(float64) != 2 {
+		t.Errorf("hives = %v, want 2 (public only)", stats["hives"])
+	}
+	if stats["agents"].(float64) != 5 {
+		t.Errorf("agents = %v, want 5 (3+2)", stats["agents"])
+	}
+}
+
+func TestHandleRegistryDeleteNotAdmin(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest("DELETE", "/api/hub/registry/some-id", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", w.Code)
+	}
+}
+
+func TestHandleRegistryDeleteAdmin(t *testing.T) {
+	srv := newTestServer()
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{
+		{ID: "to-delete", IsPublic: true},
+		{ID: "keep", IsPublic: true},
+	}
+	srv.mu.Unlock()
+
+	req := httptest.NewRequest("DELETE", "/api/hub/registry/to-delete", nil)
+	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: hubAdminUsername})
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["removed"] != true {
+		t.Error("expected removed=true")
+	}
+
+	srv.mu.RLock()
+	defer srv.mu.RUnlock()
+	if len(srv.registry.Hives) != 1 {
+		t.Errorf("expected 1 hive remaining, got %d", len(srv.registry.Hives))
+	}
+}
+
+func TestHandleRegistryDeleteNotFound(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest("DELETE", "/api/hub/registry/nonexistent", nil)
+	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: hubAdminUsername})
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["removed"] != false {
+		t.Error("expected removed=false for nonexistent")
+	}
+}
+
+func TestHandleHubVersionAdmin(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest("GET", "/api/hub/version", nil)
+	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: hubAdminUsername})
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if _, ok := resp["hub_secret"]; !ok {
+		t.Error("admin should see hub_secret in version response")
+	}
+}
+
+func TestHandleHubVersionNonAdmin(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest("GET", "/api/hub/version", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if _, ok := resp["hub_secret"]; ok {
+		t.Error("non-admin should NOT see hub_secret in version response")
+	}
+}
+
+func TestHandleTaskStatusNoAuth(t *testing.T) {
+	srv := newTestServer()
+	srv.hubSecret = "secret"
+	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestHandleTaskStatusBadPayload(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleTaskStatusEmptyHiveID(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader(`{"hive_id":""}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleTaskStatusOfflineHive(t *testing.T) {
+	srv := newTestServer()
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{
+		{ID: "offline-hive", Online: false},
+	}
+	srv.mu.Unlock()
+
+	body := `{"hive_id":"offline-hive","leaderboard":[]}`
+	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for offline hive", w.Code)
+	}
+}
+
+func TestHandleTaskStatusUpdatesContributors(t *testing.T) {
+	srv := newTestServer()
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{
+		{ID: "active-hive", Online: true, Name: "org/repo"},
+	}
+	srv.mu.Unlock()
+
+	body := `{"hive_id":"active-hive","contributors":{"active":5,"registered":10},"leaderboard":[{"github_username":"user1","tasks_completed":3}]}`
+	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+
+	srv.mu.RLock()
+	defer srv.mu.RUnlock()
+	h := srv.registry.Hives[0]
+	if h.ContributorCount != 10 {
+		t.Errorf("contributors registered = %d, want 10", h.ContributorCount)
+	}
+	if h.ActiveContributors != 5 {
+		t.Errorf("contributors active = %d, want 5", h.ActiveContributors)
+	}
+}
+
+func TestFindContributeHive(t *testing.T) {
+	srv := newTestServer()
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{
+		{ID: "offline", Online: false, IsPublic: true, DashboardURL: "https://example.com", Owner: "user"},
+		{ID: "private", Online: true, IsPublic: false, DashboardURL: "https://example.com", Owner: "user"},
+		{ID: "no-url", Online: true, IsPublic: true, DashboardURL: "", Owner: "user"},
+		{ID: "private-url", Online: true, IsPublic: true, DashboardURL: "http://192.168.1.1", Owner: "user"},
+		{ID: "no-owner", Online: true, IsPublic: true, DashboardURL: "https://example.com", Owner: ""},
+		{ID: "good", Online: true, IsPublic: true, DashboardURL: "https://good.example.com", Owner: "user"},
+	}
+	srv.mu.Unlock()
+
+	h := srv.findContributeHive()
+	if h == nil {
+		t.Fatal("expected to find a contribute hive")
+	}
+	if h.ID != "good" {
+		t.Errorf("expected 'good' hive, got %q", h.ID)
+	}
+}
+
+func TestFindContributeHiveNone(t *testing.T) {
+	srv := newTestServer()
+	h := srv.findContributeHive()
+	if h != nil {
+		t.Error("expected nil when no hives available")
+	}
+}
+
+func TestHandleContributeStatusNoHive(t *testing.T) {
+	srv := newTestServer()
+	req := httptest.NewRequest("GET", "/api/contribute/status", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["available"] != false {
+		t.Error("expected available=false when no hives")
+	}
+}
+
+func TestHandleContributeStatusWithHive(t *testing.T) {
+	srv := newTestServer()
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{
+		{ID: "pub-hive", Online: true, IsPublic: true, DashboardURL: "https://example.com", Owner: "user", Name: "org/repo", Org: "org"},
+	}
+	srv.mu.Unlock()
+
+	req := httptest.NewRequest("GET", "/api/contribute/status", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["available"] != true {
+		t.Error("expected available=true")
+	}
+	if resp["hive_id"] != "pub-hive" {
+		t.Errorf("hive_id = %v", resp["hive_id"])
+	}
+}
+
+func TestRequestSaveNonBlocking(t *testing.T) {
+	srv := newTestServer()
+	srv.requestSave()
+	srv.requestSave()
+	srv.requestSave()
+}
+
+func TestShutdownNilServer(t *testing.T) {
+	srv := newTestServer()
+	srv.httpServer = nil
+	if err := srv.Shutdown(time.Second); err != nil {
+		t.Errorf("Shutdown with nil httpServer should return nil, got %v", err)
+	}
+}

--- a/v2/pkg/hub/hub_routes_test.go
+++ b/v2/pkg/hub/hub_routes_test.go
@@ -1,0 +1,334 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandleLatestSHA(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/api/saas/latest-sha", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if _, ok := resp["sha"]; !ok {
+		t.Error("response should contain 'sha' key")
+	}
+}
+
+func TestHandleSaaSAuthCheckMissingHive(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/api/saas/auth-check", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("missing hive param should return 400, got %d", w.Code)
+	}
+}
+
+func TestHandleSaaSAuthCheckUnfurlBot(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test-hive", nil)
+	req.Header.Set("User-Agent", "Slackbot-LinkExpanding 1.0")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("unfurl bot should get 200, got %d", w.Code)
+	}
+}
+
+func TestHandleSaaSAuthCheckNoAuth(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test-hive", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("no auth should return 401, got %d", w.Code)
+	}
+}
+
+func TestHandleDashboardNoAuth(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/dashboard", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusTemporaryRedirect {
+		t.Errorf("no cookie should redirect, got %d", w.Code)
+	}
+	loc := w.Header().Get("Location")
+	if loc != "/login" {
+		t.Errorf("redirect to %q, want /login", loc)
+	}
+}
+
+func TestHandleDashboardUnfurlBot(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/dashboard", nil)
+	req.Header.Set("User-Agent", "Twitterbot/1.0")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("unfurl bot should get 200, got %d", w.Code)
+	}
+	if !strings.Contains(w.Header().Get("Content-Type"), "text/html") {
+		t.Error("should return HTML")
+	}
+}
+
+func TestHandleDashboardWithCookie(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/dashboard", nil)
+	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "testuser"})
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("with cookie should get 200, got %d", w.Code)
+	}
+}
+
+func TestRequireAuthRejectsNoCSRF(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "text/plain")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("CSRF fail should return 403, got %d", w.Code)
+	}
+}
+
+func TestRequireAuthRejectsNoAuth(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("no auth should return 401, got %d", w.Code)
+	}
+}
+
+func TestRequireAdminRejectsNonAdmin(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/api/saas/admin/users", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("non-admin should return 403, got %d", w.Code)
+	}
+}
+
+func TestRequireAdminRejectsWrongUser(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/api/saas/admin/users", nil)
+	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "not-admin"})
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("wrong user should return 403, got %d", w.Code)
+	}
+}
+
+func TestHandleMyHivesNoAuth(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/api/saas/my-hives", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("my-hives without auth should return 401, got %d", w.Code)
+	}
+}
+
+func TestHandleHiveStatusNoAuth(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/api/saas/hives/test-id/status", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status without auth should return 401, got %d", w.Code)
+	}
+}
+
+func TestHandleDeleteHiveNoAuth(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("DELETE", "/api/saas/hives/test-id", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden && w.Code != http.StatusUnauthorized {
+		t.Errorf("delete without auth should return 401 or 403, got %d", w.Code)
+	}
+}
+
+func TestHandleUpgradeHiveNoAuth(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("POST", "/api/saas/hives/test-id/upgrade", nil)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("upgrade without auth should return 401, got %d", w.Code)
+	}
+}
+
+func TestHandleProxyHiveConfigNoAuth(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/api/saas/hive-config/test-id", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("proxy config without auth should return 401, got %d", w.Code)
+	}
+}
+
+func TestHandleAccessListNoAuth(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/api/saas/hives/test-id/access", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("access list without auth should return 401, got %d", w.Code)
+	}
+}
+
+func TestHandleRequestAccessNoAuth(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("POST", "/api/saas/hives/test-id/request-access", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("request-access without auth should return 401, got %d", w.Code)
+	}
+}
+
+func TestHandleUserTokenNoAuth(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("POST", "/api/saas/user-token", strings.NewReader("{}"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("user-token without auth should return 401, got %d", w.Code)
+	}
+}
+
+func TestGetAuthUserNoCookieNoHeader(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	got := srv.getAuthUser(req)
+	if got != "" {
+		t.Errorf("no auth should return empty, got %q", got)
+	}
+}
+
+func TestGetAuthUserInvalidCookie(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "nonexistent-user-xyz"})
+	got := srv.getAuthUser(req)
+	if got != "" {
+		t.Errorf("invalid cookie user should return empty, got %q", got)
+	}
+}
+
+func TestGetAuthUserInvalidBearer(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer invalid-token-xyz")
+	got := srv.getAuthUser(req)
+	if got != "" {
+		t.Errorf("invalid bearer should return empty, got %q", got)
+	}
+}
+
+func TestIsTrustedOriginEdgeCases(t *testing.T) {
+	tests := []struct {
+		origin string
+		want   bool
+	}{
+		{"http://localhost:3000", true},
+		{"http://127.0.0.1:8080", true},
+		{"https://sub.hive.kubestellar.io", true},
+		{"https://hive.kubestellar.io", true},
+		{"https://evil-hive.kubestellar.io", false},
+		{"https://hive.kubestellar.io.evil.com", false},
+		{"ftp://hive.kubestellar.io", true},
+	}
+	for _, tt := range tests {
+		got := isTrustedOrigin(tt.origin)
+		if got != tt.want {
+			t.Errorf("isTrustedOrigin(%q) = %v, want %v", tt.origin, got, tt.want)
+		}
+	}
+}

--- a/v2/pkg/hub/hub_saas_test.go
+++ b/v2/pkg/hub/hub_saas_test.go
@@ -1,0 +1,304 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSanitizeProvision(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Hello-World", "hello-world"},
+		{"My Org!", "myorg"},
+		{"test_repo", "testrepo"},
+		{"UPPER", "upper"},
+		{"abc-123", "abc-123"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := sanitize(tt.input)
+		if got != tt.want {
+			t.Errorf("sanitize(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestGenerateHiveID(t *testing.T) {
+	id := generateHiveID("MyOrg", "my-repo")
+	if !strings.HasPrefix(id, "hosted-myorg-my-repo-") {
+		t.Errorf("id = %q, expected prefix 'hosted-myorg-my-repo-'", id)
+	}
+	if len(id) < 20 {
+		t.Errorf("id too short: %q", id)
+	}
+}
+
+func TestGenerateHiveIDLongRepo(t *testing.T) {
+	id := generateHiveID("org", "very-long-repository-name-here")
+	if !strings.HasPrefix(id, "hosted-org-very-long-re") {
+		t.Errorf("id = %q, expected truncated repo", id)
+	}
+}
+
+func TestGenerateHiveIDUnique(t *testing.T) {
+	id1 := generateHiveID("org", "repo")
+	id2 := generateHiveID("org", "repo")
+	if id1 == id2 {
+		t.Error("IDs should be unique (random suffix)")
+	}
+}
+
+func TestLoadSaaSHivePathTraversal(t *testing.T) {
+	if loadSaaSHive("../../etc/passwd") != nil {
+		t.Error("path traversal should return nil")
+	}
+	if loadSaaSHive("foo/bar") != nil {
+		t.Error("slash in ID should return nil")
+	}
+	if loadSaaSHive("foo\\bar") != nil {
+		t.Error("backslash in ID should return nil")
+	}
+}
+
+func TestLoadSaaSHiveNonexistent(t *testing.T) {
+	if loadSaaSHive("nonexistent-hive-xyz-999") != nil {
+		t.Error("nonexistent hive should return nil")
+	}
+}
+
+func TestHandleContributeProxyNoHive(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("POST", "/api/contribute/register", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+}
+
+func TestHandleContributeWSProxyNoHive(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/api/contribute/ws", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+}
+
+func TestHandleHeartbeatWithAuth(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = "my-secret"
+
+	payload := HeartbeatPayload{
+		HiveID:      "auth-test",
+		Org:         "org",
+		PrimaryRepo: "repo",
+		ACMMLevel:   2,
+		IsPublic:    true,
+	}
+	body, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer my-secret")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("authenticated heartbeat status = %d, want 200", w.Code)
+	}
+}
+
+func TestHandleHeartbeatWrongSecret(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = "correct-secret"
+
+	payload := HeartbeatPayload{HiveID: "test"}
+	body, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer wrong-secret")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("wrong secret status = %d, want 401", w.Code)
+	}
+}
+
+func TestHandleHeartbeatMaxAgents(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	agents := make([]AgentSummary, 60)
+	for i := range agents {
+		agents[i] = AgentSummary{Name: "agent" + string(rune('a'+i%26)), State: "running"}
+	}
+
+	payload := HeartbeatPayload{
+		HiveID:      "max-agents",
+		Org:         "org",
+		PrimaryRepo: "repo",
+		Agents:      agents,
+	}
+	body, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+
+	srv.mu.RLock()
+	defer srv.mu.RUnlock()
+	if len(srv.registry.Hives[0].Agents) > 50 {
+		t.Errorf("agents should be capped at 50, got %d", len(srv.registry.Hives[0].Agents))
+	}
+}
+
+func TestHandleTaskStatusWithAuth(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = "secret"
+
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{
+		{ID: "test-hive", Online: true, Name: "org/repo"},
+	}
+	srv.mu.Unlock()
+
+	body := `{"hive_id":"test-hive","leaderboard":[],"contributors":{"active":3,"registered":5}}`
+	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer secret")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+}
+
+func TestHandleStatsEmpty(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/api/hub/stats", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	var stats map[string]any
+	json.Unmarshal(w.Body.Bytes(), &stats)
+	if stats["hives"].(float64) != 0 {
+		t.Errorf("empty registry should have 0 hives")
+	}
+}
+
+func TestMergeLeaderboardsEmpty(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	merged := srv.mergeLeaderboards()
+	if len(merged) != 0 {
+		t.Errorf("empty registry should have 0 leaderboard entries, got %d", len(merged))
+	}
+}
+
+func TestMergeLeaderboardsSkipsEmptyUsername(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{
+		{
+			ID: "h1", IsPublic: true,
+			Leaderboard: []LeaderboardEntry{
+				{GitHubUsername: "", TasksCompleted: 5},
+				{GitHubUsername: "valid-user", TasksCompleted: 3},
+			},
+		},
+	}
+	merged := srv.mergeLeaderboards()
+	srv.mu.Unlock()
+
+	for _, e := range merged {
+		if e.GitHubUsername == "" {
+			t.Error("empty username should be skipped")
+		}
+	}
+}
+
+func TestHandleLeaderboardEmpty(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/api/hub/leaderboard", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d", w.Code)
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	lb, ok := resp["leaderboard"].([]any)
+	if !ok {
+		t.Fatal("leaderboard should be an array")
+	}
+	if len(lb) != 0 {
+		t.Errorf("empty registry leaderboard should be empty, got %d", len(lb))
+	}
+}
+
+func TestMarkStaleHivesKeepsRecent(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+	now := time.Now().UTC()
+
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{
+		{ID: "recent", LastHeartbeat: now.Format(time.RFC3339), Online: false},
+	}
+	srv.markStaleHives()
+	srv.mu.Unlock()
+
+	srv.mu.RLock()
+	defer srv.mu.RUnlock()
+	if len(srv.registry.Hives) != 1 {
+		t.Error("recent hive should be kept")
+	}
+	if !srv.registry.Hives[0].Online {
+		t.Error("recent hive should be marked online")
+	}
+}
+
+func TestServeStaticNotFound(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	handler := srv.serveStatic("static/nonexistent.html")
+	req := httptest.NewRequest("GET", "/nonexistent", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}

--- a/v2/pkg/hub/hub_static_test.go
+++ b/v2/pkg/hub/hub_static_test.go
@@ -1,0 +1,307 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestServeStaticIndex(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	if !strings.Contains(w.Header().Get("Content-Type"), "text/html") {
+		t.Error("should return HTML")
+	}
+	if w.Body.Len() == 0 {
+		t.Error("body should not be empty")
+	}
+}
+
+func TestServeStaticLearn(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/learn", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+}
+
+func TestServeStaticGetStarted(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/get-started", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+}
+
+func TestServeStaticAPIDocs(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	req := httptest.NewRequest("GET", "/api/docs", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+}
+
+func TestHandleHeartbeatMultipleHives(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	for i := 0; i < 5; i++ {
+		payload := HeartbeatPayload{
+			HiveID:      "hive-" + string(rune('a'+i)),
+			Org:         "org",
+			PrimaryRepo: "repo",
+			ACMMLevel:   i + 1,
+			IsPublic:    true,
+		}
+		body, _ := json.Marshal(payload)
+		req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body)))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		srv.mux.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("heartbeat %d failed: %d", i, w.Code)
+		}
+	}
+
+	srv.mu.RLock()
+	count := len(srv.registry.Hives)
+	srv.mu.RUnlock()
+	if count != 5 {
+		t.Errorf("expected 5 hives, got %d", count)
+	}
+}
+
+func TestHandleHeartbeatPreservesRegisteredAt(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	p1 := HeartbeatPayload{HiveID: "persist-test", Org: "org", PrimaryRepo: "repo"}
+	body1, _ := json.Marshal(p1)
+	req1 := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body1)))
+	req1.Header.Set("Content-Type", "application/json")
+	srv.mux.ServeHTTP(httptest.NewRecorder(), req1)
+
+	srv.mu.RLock()
+	registeredAt := srv.registry.Hives[0].RegisteredAt
+	srv.mu.RUnlock()
+
+	time.Sleep(10 * time.Millisecond)
+
+	body2, _ := json.Marshal(p1)
+	req2 := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body2)))
+	req2.Header.Set("Content-Type", "application/json")
+	srv.mux.ServeHTTP(httptest.NewRecorder(), req2)
+
+	srv.mu.RLock()
+	newRegisteredAt := srv.registry.Hives[0].RegisteredAt
+	srv.mu.RUnlock()
+
+	if registeredAt != newRegisteredAt {
+		t.Error("RegisteredAt should be preserved across updates")
+	}
+}
+
+func TestHandleHeartbeatPreservesSnapshotURL(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	p1 := HeartbeatPayload{
+		HiveID:      "snap-test",
+		Org:         "org",
+		PrimaryRepo: "repo",
+		SnapshotURL: "https://example.com/snapshot",
+	}
+	body1, _ := json.Marshal(p1)
+	req1 := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body1)))
+	req1.Header.Set("Content-Type", "application/json")
+	srv.mux.ServeHTTP(httptest.NewRecorder(), req1)
+
+	p2 := HeartbeatPayload{HiveID: "snap-test", Org: "org", PrimaryRepo: "repo"}
+	body2, _ := json.Marshal(p2)
+	req2 := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body2)))
+	req2.Header.Set("Content-Type", "application/json")
+	srv.mux.ServeHTTP(httptest.NewRecorder(), req2)
+
+	srv.mu.RLock()
+	snapURL := srv.registry.Hives[0].SnapshotURL
+	srv.mu.RUnlock()
+
+	if snapURL != "https://example.com/snapshot" {
+		t.Errorf("SnapshotURL should be preserved, got %q", snapURL)
+	}
+}
+
+func TestHandleHeartbeatHiveType(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	payload := HeartbeatPayload{HiveID: "local-test", Org: "org", PrimaryRepo: "repo"}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	srv.mux.ServeHTTP(httptest.NewRecorder(), req)
+
+	srv.mu.RLock()
+	hiveType := srv.registry.Hives[0].HiveType
+	srv.mu.RUnlock()
+
+	if hiveType != "local" {
+		t.Errorf("non-hosted ID should be 'local', got %q", hiveType)
+	}
+}
+
+func TestHandleHeartbeatSaaSPrefix(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	payload := HeartbeatPayload{HiveID: "saas-test-xyz", Org: "org", PrimaryRepo: "repo"}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("saas- prefix without provisioning should be 403, got %d", w.Code)
+	}
+}
+
+func TestHandleTaskStatusUnknownHive(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	body := `{"hive_id":"unknown-hive","leaderboard":[]}`
+	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Logf("unknown hive task-status: %d (expected OK or error)", w.Code)
+	}
+}
+
+func TestHandleRegistryWithMixedHives(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{
+		{ID: "pub-online", IsPublic: true, Online: true, HiveType: "local", LastHeartbeat: now},
+		{ID: "pub-offline", IsPublic: true, Online: false, HiveType: "local", LastHeartbeat: now},
+		{ID: "private", IsPublic: false, Online: true, LastHeartbeat: now},
+	}
+	srv.mu.Unlock()
+
+	req := httptest.NewRequest("GET", "/api/registry", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	var reg Registry
+	json.Unmarshal(w.Body.Bytes(), &reg)
+
+	for _, h := range reg.Hives {
+		if h.ID == "private" {
+			t.Error("private hive should be filtered")
+		}
+	}
+}
+
+func TestMergeLeaderboardsActiveOverrides(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{
+		{
+			ID: "h1", IsPublic: true,
+			Leaderboard: []LeaderboardEntry{
+				{GitHubUsername: "user1", TasksCompleted: 5, Active: false, HiveName: "h1"},
+			},
+		},
+		{
+			ID: "h2", IsPublic: true,
+			Leaderboard: []LeaderboardEntry{
+				{GitHubUsername: "user1", TasksCompleted: 3, Active: true, CurrentTask: "fixing bug", HiveName: "h2"},
+			},
+		},
+	}
+	merged := srv.mergeLeaderboards()
+	srv.mu.Unlock()
+
+	if len(merged) != 1 {
+		t.Fatalf("expected 1 merged entry, got %d", len(merged))
+	}
+	if merged[0].TasksCompleted != 8 {
+		t.Errorf("completed = %d, want 8", merged[0].TasksCompleted)
+	}
+	if !merged[0].Active {
+		t.Error("should be active (from h2)")
+	}
+	if merged[0].CurrentTask != "fixing bug" {
+		t.Errorf("current task = %q", merged[0].CurrentTask)
+	}
+	if merged[0].HiveName != "h2" {
+		t.Errorf("hive name = %q, want h2 (active hive)", merged[0].HiveName)
+	}
+}
+
+func TestHandleLeaderboardSorted(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test")
+	srv.hubSecret = ""
+
+	srv.mu.Lock()
+	srv.registry.Hives = []RegistryEntry{
+		{
+			ID: "h1", IsPublic: true,
+			Leaderboard: []LeaderboardEntry{
+				{GitHubUsername: "low", TasksCompleted: 1},
+				{GitHubUsername: "high", TasksCompleted: 10},
+				{GitHubUsername: "mid", TasksCompleted: 5},
+			},
+		},
+	}
+	srv.mu.Unlock()
+
+	req := httptest.NewRequest("GET", "/api/hub/leaderboard", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	lb, ok := resp["leaderboard"].([]any)
+	if !ok {
+		t.Fatal("leaderboard should be array")
+	}
+	if len(lb) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(lb))
+	}
+}


### PR DESCRIPTION
## Summary
- Hub package: 12.2% → 35.8% coverage (+23.6%)
- Supersedes #1238, #1246, #1258

### New tests (this round)
- **Static serving**: index.html, learn, get-started, api-docs all return 200
- **Heartbeat edge cases**: multiple hives, RegisteredAt preserved, SnapshotURL preserved, HiveType detection, saas- prefix rejection
- **Leaderboard merging**: active overrides inactive, task count accumulation, current task from active hive
- **Registry filtering**: mixed public/private/online/offline
- **Task status**: unknown hive

### From prior PRs
- sanitize, generateHiveID, loadSaaSHive path traversal
- Heartbeat validation (auth, invalid fields, ACMM clamp, max agents)
- Registry dedup, delete, stats, contribute proxy/WS/status
- SaaS routes: auth rejection, admin rejection, CSRF
- Dashboard redirect, unfurl bot OG, getAuthUser

## Test plan
- [x] `go test ./v2/pkg/hub/ -cover` passes (35.8%)
- [x] All 17/17 packages still pass