### PR TITLE
test: github coverage over 90% threshold (74.9% → 91.0%)

### DIFF
--- a/v2/pkg/github/advisory_test.go
+++ b/v2/pkg/github/advisory_test.go
@@ -1,0 +1,315 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+func TestFindAdvisoryIssue_FoundByLabel(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/testorg/testrepo/issues" {
+			q := r.URL.Query()
+			if q.Get("labels") == advisoryLabelName {
+				issues := []*gh.Issue{
+					{Number: gh.Ptr(42), Title: gh.Ptr(advisoryTitle)},
+				}
+				json.NewEncoder(w).Encode(issues)
+				return
+			}
+		}
+		json.NewEncoder(w).Encode([]*gh.Issue{})
+	}))
+
+	num, err := c.findAdvisoryIssue(context.Background(), "testorg", "testrepo")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if num != 42 {
+		t.Errorf("issue number = %d, want 42", num)
+	}
+}
+
+func TestFindAdvisoryIssue_FoundByTitleFallback(t *testing.T) {
+	callCount := 0
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			json.NewEncoder(w).Encode([]*gh.Issue{})
+			return
+		}
+		issues := []*gh.Issue{
+			{Number: gh.Ptr(99), Title: gh.Ptr(advisoryTitle)},
+		}
+		json.NewEncoder(w).Encode(issues)
+	}))
+
+	num, err := c.findAdvisoryIssue(context.Background(), "testorg", "testrepo")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if num != 99 {
+		t.Errorf("issue number = %d, want 99", num)
+	}
+}
+
+func TestFindAdvisoryIssue_NotFound(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]*gh.Issue{})
+	}))
+
+	num, err := c.findAdvisoryIssue(context.Background(), "testorg", "testrepo")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if num != 0 {
+		t.Errorf("issue number = %d, want 0", num)
+	}
+}
+
+func TestFindDigestComment_Found(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		comments := []*gh.IssueComment{
+			{ID: gh.Ptr(int64(100)), Body: gh.Ptr("some other comment")},
+			{ID: gh.Ptr(int64(200)), Body: gh.Ptr(advisoryDigestPrefix + "\n\nDigest content here")},
+		}
+		json.NewEncoder(w).Encode(comments)
+	}))
+
+	id, err := c.findDigestComment(context.Background(), "testorg", "testrepo", 42)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if id != 200 {
+		t.Errorf("comment ID = %d, want 200", id)
+	}
+}
+
+func TestFindDigestComment_NotFound(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		comments := []*gh.IssueComment{
+			{ID: gh.Ptr(int64(100)), Body: gh.Ptr("just a regular comment")},
+		}
+		json.NewEncoder(w).Encode(comments)
+	}))
+
+	id, err := c.findDigestComment(context.Background(), "testorg", "testrepo", 42)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if id != 0 {
+		t.Errorf("comment ID = %d, want 0", id)
+	}
+}
+
+func TestFindDigestComment_Error(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	_, err := c.findDigestComment(context.Background(), "testorg", "testrepo", 42)
+	if err == nil {
+		t.Error("expected error")
+	}
+}
+
+func TestEnsureAdvisoryIssue_ExistingIssue(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/testorg/testrepo/issues" && r.Method == "GET" {
+			issues := []*gh.Issue{
+				{Number: gh.Ptr(42), Title: gh.Ptr(advisoryTitle)},
+			}
+			json.NewEncoder(w).Encode(issues)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	num, err := c.EnsureAdvisoryIssue(context.Background(), "testrepo")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if num != 42 {
+		t.Errorf("issue number = %d, want 42", num)
+	}
+}
+
+func TestEnsureAdvisoryIssue_CreatesNew(t *testing.T) {
+	var labelCreated, issueCreated bool
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/testorg/testrepo/issues" && r.Method == "GET" {
+			json.NewEncoder(w).Encode([]*gh.Issue{})
+			return
+		}
+		if r.URL.Path == "/repos/testorg/testrepo/labels" && r.Method == "POST" {
+			labelCreated = true
+			json.NewEncoder(w).Encode(gh.Label{Name: gh.Ptr(advisoryLabelName)})
+			return
+		}
+		if r.URL.Path == "/repos/testorg/testrepo/issues" && r.Method == "POST" {
+			issueCreated = true
+			json.NewEncoder(w).Encode(gh.Issue{Number: gh.Ptr(77)})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	num, err := c.EnsureAdvisoryIssue(context.Background(), "testrepo")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if num != 77 {
+		t.Errorf("issue number = %d, want 77", num)
+	}
+	if !labelCreated {
+		t.Error("label should be created")
+	}
+	if !issueCreated {
+		t.Error("issue should be created")
+	}
+}
+
+func TestEnsureAdvisoryIssue_WithOrgSlash(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/otherorg/otherrepo/issues" && r.Method == "GET" {
+			issues := []*gh.Issue{
+				{Number: gh.Ptr(10), Title: gh.Ptr(advisoryTitle)},
+			}
+			json.NewEncoder(w).Encode(issues)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	num, err := c.EnsureAdvisoryIssue(context.Background(), "otherorg/otherrepo")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if num != 10 {
+		t.Errorf("issue number = %d, want 10", num)
+	}
+}
+
+func TestPostAdvisoryDigest_CreateNew(t *testing.T) {
+	var commentCreated bool
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/testorg/testrepo/issues/42/comments" && r.Method == "GET" {
+			json.NewEncoder(w).Encode([]*gh.IssueComment{})
+			return
+		}
+		if r.URL.Path == "/repos/testorg/testrepo/issues/42/comments" && r.Method == "POST" {
+			commentCreated = true
+			json.NewEncoder(w).Encode(gh.IssueComment{ID: gh.Ptr(int64(1))})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	err := c.PostAdvisoryDigest(context.Background(), "testrepo", 42, advisoryDigestPrefix+"\n\nNew digest")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !commentCreated {
+		t.Error("new comment should be created")
+	}
+}
+
+func TestPostAdvisoryDigest_UpdateExisting(t *testing.T) {
+	var commentEdited bool
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/testorg/testrepo/issues/42/comments" && r.Method == "GET" {
+			comments := []*gh.IssueComment{
+				{ID: gh.Ptr(int64(200)), Body: gh.Ptr(advisoryDigestPrefix + "\n\nOld digest")},
+			}
+			json.NewEncoder(w).Encode(comments)
+			return
+		}
+		if r.URL.Path == "/repos/testorg/testrepo/issues/comments/200" && r.Method == "PATCH" {
+			commentEdited = true
+			json.NewEncoder(w).Encode(gh.IssueComment{ID: gh.Ptr(int64(200))})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	err := c.PostAdvisoryDigest(context.Background(), "testrepo", 42, advisoryDigestPrefix+"\n\nUpdated digest")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !commentEdited {
+		t.Error("existing comment should be edited")
+	}
+}
+
+func TestPostAdvisoryDigest_CreateError(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			json.NewEncoder(w).Encode([]*gh.IssueComment{})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	err := c.PostAdvisoryDigest(context.Background(), "testrepo", 42, "digest")
+	if err == nil {
+		t.Error("expected error on create failure")
+	}
+}
+
+func TestDeviceFlowStartWithMockServer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(DeviceFlowState{
+			DeviceCode:      "ABCD-1234",
+			UserCode:        "EFGH-5678",
+			VerificationURI: "https://github.com/login/device",
+			ExpiresIn:       900,
+			Interval:        5,
+		})
+	}))
+	defer srv.Close()
+
+	origClient := deviceFlowClient
+	deviceFlowClient = srv.Client()
+	defer func() { deviceFlowClient = origClient }()
+
+	t.Log("DeviceFlow mock server test - URLs are const, cannot redirect fully")
+}
+
+func TestDeviceFlowPollResponse(t *testing.T) {
+	var pr pollResponse
+	pr.AccessToken = "gho_test123"
+	pr.TokenType = "bearer"
+	if pr.AccessToken == "" {
+		t.Error("token should be set")
+	}
+}
+
+func TestDeviceFlowStateFields(t *testing.T) {
+	state := DeviceFlowState{
+		DeviceCode:      "code",
+		UserCode:        "user",
+		VerificationURI: "https://example.com",
+		ExpiresIn:       900,
+		Interval:        0,
+	}
+	if state.DeviceCode != "code" {
+		t.Error("DeviceCode not set")
+	}
+	if state.Interval != 0 {
+		t.Error("Interval should be 0")
+	}
+}
+
+func TestGitHubUserFields(t *testing.T) {
+	user := GitHubUser{
+		Login:     "testuser",
+		AvatarURL: "https://example.com/avatar.png",
+	}
+	if user.Login != "testuser" {
+		t.Error("Login not set")
+	}
+}

--- a/v2/pkg/github/deviceflow_test.go
+++ b/v2/pkg/github/deviceflow_test.go
@@ -1,0 +1,189 @@
+package github
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type mockTransport struct {
+	handler func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m.handler(req)
+}
+
+func withMockDeviceFlow(handler func(req *http.Request) (*http.Response, error), fn func()) {
+	orig := deviceFlowClient
+	deviceFlowClient = &http.Client{Transport: &mockTransport{handler: handler}}
+	defer func() { deviceFlowClient = orig }()
+	fn()
+}
+
+func jsonBodyResponse(statusCode int, body any) *http.Response {
+	data, _ := json.Marshal(body)
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(string(data))),
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+}
+
+func TestStartDeviceFlowSuccess(t *testing.T) {
+	withMockDeviceFlow(func(req *http.Request) (*http.Response, error) {
+		resp := DeviceFlowState{
+			DeviceCode:      "ABCD-1234",
+			UserCode:        "EFGH-5678",
+			VerificationURI: "https://github.com/login/device",
+			ExpiresIn:       900,
+			Interval:        5,
+		}
+		return jsonBodyResponse(200, resp), nil
+	}, func() {
+		state, err := StartDeviceFlow("test-client-id")
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if state.DeviceCode != "ABCD-1234" {
+			t.Errorf("DeviceCode = %q", state.DeviceCode)
+		}
+		if state.UserCode != "EFGH-5678" {
+			t.Errorf("UserCode = %q", state.UserCode)
+		}
+		if state.Interval != 5 {
+			t.Errorf("Interval = %d", state.Interval)
+		}
+	})
+}
+
+func TestStartDeviceFlowDefaultInterval(t *testing.T) {
+	withMockDeviceFlow(func(req *http.Request) (*http.Response, error) {
+		resp := DeviceFlowState{
+			DeviceCode: "code",
+			UserCode:   "user",
+			Interval:   0,
+		}
+		return jsonBodyResponse(200, resp), nil
+	}, func() {
+		state, err := StartDeviceFlow("test-client-id")
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if state.Interval != 5 {
+			t.Errorf("zero interval should default to 5, got %d", state.Interval)
+		}
+	})
+}
+
+func TestStartDeviceFlowServerError(t *testing.T) {
+	withMockDeviceFlow(func(req *http.Request) (*http.Response, error) {
+		return jsonBodyResponse(500, map[string]string{"error": "server error"}), nil
+	}, func() {
+		_, err := StartDeviceFlow("test-client-id")
+		if err == nil {
+			t.Error("expected error on 500")
+		}
+	})
+}
+
+func TestPollDeviceFlowComplete(t *testing.T) {
+	withMockDeviceFlow(func(req *http.Request) (*http.Response, error) {
+		return jsonBodyResponse(200, pollResponse{
+			AccessToken: "gho_test_token_12345",
+			TokenType:   "bearer",
+			Scope:       "repo",
+		}), nil
+	}, func() {
+		token, status, err := PollDeviceFlow("client-id", "device-code")
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if token != "gho_test_token_12345" {
+			t.Errorf("token = %q", token)
+		}
+		if status != "complete" {
+			t.Errorf("status = %q", status)
+		}
+	})
+}
+
+func TestPollDeviceFlowPending(t *testing.T) {
+	withMockDeviceFlow(func(req *http.Request) (*http.Response, error) {
+		return jsonBodyResponse(200, pollResponse{
+			Error:     "authorization_pending",
+			ErrorDesc: "waiting for user",
+		}), nil
+	}, func() {
+		token, status, err := PollDeviceFlow("client-id", "device-code")
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if token != "" {
+			t.Error("pending should return empty token")
+		}
+		if status != "authorization_pending" {
+			t.Errorf("status = %q", status)
+		}
+	})
+}
+
+func TestPollDeviceFlowSlowDown(t *testing.T) {
+	withMockDeviceFlow(func(req *http.Request) (*http.Response, error) {
+		return jsonBodyResponse(200, pollResponse{
+			Error: "slow_down",
+		}), nil
+	}, func() {
+		_, status, err := PollDeviceFlow("client-id", "device-code")
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if status != "slow_down" {
+			t.Errorf("status = %q", status)
+		}
+	})
+}
+
+func TestPollDeviceFlowError(t *testing.T) {
+	withMockDeviceFlow(func(req *http.Request) (*http.Response, error) {
+		return jsonBodyResponse(200, pollResponse{
+			Error:     "access_denied",
+			ErrorDesc: "user denied",
+		}), nil
+	}, func() {
+		_, _, err := PollDeviceFlow("client-id", "device-code")
+		if err == nil {
+			t.Error("expected error on access_denied")
+		}
+	})
+}
+
+func TestValidateTokenSuccess(t *testing.T) {
+	withMockDeviceFlow(func(req *http.Request) (*http.Response, error) {
+		return jsonBodyResponse(200, GitHubUser{
+			Login:     "testuser",
+			AvatarURL: "https://example.com/avatar.png",
+		}), nil
+	}, func() {
+		user, err := ValidateToken("gho_valid_token")
+		if err != nil {
+			t.Fatalf("error: %v", err)
+		}
+		if user.Login != "testuser" {
+			t.Errorf("login = %q", user.Login)
+		}
+	})
+}
+
+func TestValidateTokenInvalid(t *testing.T) {
+	withMockDeviceFlow(func(req *http.Request) (*http.Response, error) {
+		return jsonBodyResponse(401, map[string]string{"message": "Bad credentials"}), nil
+	}, func() {
+		_, err := ValidateToken("invalid-token")
+		if err == nil {
+			t.Error("expected error on 401")
+		}
+	})
+}

--- a/v2/pkg/github/github_coverage_test.go
+++ b/v2/pkg/github/github_coverage_test.go
@@ -1,0 +1,346 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+func testClient(handler http.Handler) *Client {
+	srv := httptest.NewServer(handler)
+	logger := slog.Default()
+	c := NewClientForTest(srv.URL, "testorg", []string{"testrepo"}, logger)
+	return c
+}
+
+func TestHoldAddsLabelAndComment(t *testing.T) {
+	var labelAdded, commentPosted bool
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/repos/org/repo/issues/42/labels":
+			labelAdded = true
+			json.NewEncoder(w).Encode([]gh.Label{{Name: gh.Ptr("hold")}})
+		case r.Method == "POST" && r.URL.Path == "/repos/org/repo/issues/42/comments":
+			commentPosted = true
+			json.NewEncoder(w).Encode(gh.IssueComment{ID: gh.Ptr(int64(1))})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	c.hold(context.Background(), "org", "repo", 42)
+	if !labelAdded {
+		t.Error("hold should add 'hold' label")
+	}
+	if !commentPosted {
+		t.Error("hold should post SHA hold comment")
+	}
+}
+
+func TestHoldErrorHandling(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	c.hold(context.Background(), "org", "repo", 42)
+}
+
+func TestUnholdRemovesLabel(t *testing.T) {
+	var labelRemoved bool
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "DELETE" && r.URL.Path == "/repos/org/repo/issues/42/labels/hold" {
+			labelRemoved = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	c.unhold(context.Background(), "org", "repo", 42)
+	if !labelRemoved {
+		t.Error("unhold should remove 'hold' label")
+	}
+}
+
+func TestUnholdErrorHandling(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	c.unhold(context.Background(), "org", "repo", 42)
+}
+
+func TestCheckCommentsForSHAFound(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		comments := []*gh.IssueComment{
+			{Body: gh.Ptr("no sha here")},
+			{Body: gh.Ptr("fix at abc1234 worked")},
+		}
+		json.NewEncoder(w).Encode(comments)
+	}))
+
+	found := c.checkCommentsForSHA(context.Background(), "org", "repo", 1, "")
+	if !found {
+		t.Error("should find SHA in comments")
+	}
+}
+
+func TestCheckCommentsForSHANotFound(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		comments := []*gh.IssueComment{
+			{Body: gh.Ptr("no sha here")},
+			{Body: gh.Ptr("just a regular comment")},
+		}
+		json.NewEncoder(w).Encode(comments)
+	}))
+
+	found := c.checkCommentsForSHA(context.Background(), "org", "repo", 1, "")
+	if found {
+		t.Error("should not find SHA in comments")
+	}
+}
+
+func TestCheckCommentsForSHAError(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	found := c.checkCommentsForSHA(context.Background(), "org", "repo", 1, "")
+	if found {
+		t.Error("should return false on error")
+	}
+}
+
+func TestEnforceSHAHold(t *testing.T) {
+	var holdCalled bool
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/testorg/testrepo/issues" && r.Method == "GET" {
+			issues := []*gh.Issue{
+				{
+					Number: gh.Ptr(10),
+					Title:  gh.Ptr("Bug with SHA"),
+					Body:   gh.Ptr("Error at deadbeef1234567"),
+					Labels: []*gh.Label{{Name: gh.Ptr("kind/bug")}},
+					User:   &gh.User{Login: gh.Ptr("external-user")},
+				},
+				{
+					Number: gh.Ptr(11),
+					Title:  gh.Ptr("Bug no SHA"),
+					Body:   gh.Ptr("Something broke"),
+					Labels: []*gh.Label{{Name: gh.Ptr("kind/bug")}},
+					User:   &gh.User{Login: gh.Ptr("external-user")},
+				},
+			}
+			json.NewEncoder(w).Encode(issues)
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == "/repos/testorg/testrepo/issues/11/comments" {
+			json.NewEncoder(w).Encode([]*gh.IssueComment{})
+			return
+		}
+		if r.Method == "POST" && r.URL.Path == "/repos/testorg/testrepo/issues/11/labels" {
+			holdCalled = true
+			json.NewEncoder(w).Encode([]gh.Label{})
+			return
+		}
+		if r.Method == "POST" && r.URL.Path == "/repos/testorg/testrepo/issues/11/comments" {
+			json.NewEncoder(w).Encode(gh.IssueComment{ID: gh.Ptr(int64(1))})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "[]")
+	}))
+
+	result, err := c.EnforceSHAHold(context.Background(), SHAHoldConfig{
+		PrimaryRepo:     "testrepo",
+		AIAuthor:        "bot",
+		InternalAuthors: []string{"bot"},
+	})
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !holdCalled {
+		t.Error("expected hold on issue #11 (no SHA)")
+	}
+	if result.Held != 1 {
+		t.Errorf("held = %d, want 1", result.Held)
+	}
+}
+
+func TestGetFileContentSuccess(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/testorg/testrepo/contents/README.md" {
+			resp := gh.RepositoryContent{
+				Content:  gh.Ptr("SGVsbG8gV29ybGQ="),
+				Encoding: gh.Ptr("base64"),
+			}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	content, err := c.GetFileContent(context.Background(), "testorg", "testrepo", "README.md")
+	if err != nil {
+		t.Fatalf("GetFileContent error: %v", err)
+	}
+	if content != "Hello World" {
+		t.Errorf("content = %q, want 'Hello World'", content)
+	}
+}
+
+func TestGetFileContentNotFound(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	_, err := c.GetFileContent(context.Background(), "testorg", "testrepo", "missing.md")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestIsExemptCoverage(t *testing.T) {
+	tests := []struct {
+		labels []string
+		want   bool
+	}{
+		{[]string{"bug", "help wanted"}, false},
+		{[]string{"LFX-mentorship"}, true},
+		{[]string{"do-not-merge/hold"}, true},
+		{[]string{"bug", "LFX", "urgent"}, true},
+		{nil, false},
+	}
+	for _, tt := range tests {
+		got := isExempt(tt.labels)
+		if got != tt.want {
+			t.Errorf("isExempt(%v) = %v, want %v", tt.labels, got, tt.want)
+		}
+	}
+}
+
+func TestIsTrackerCoverage(t *testing.T) {
+	tests := []struct {
+		title  string
+		labels []string
+		want   bool
+	}{
+		{"[Tracker] Release 1.0", nil, true},
+		{"Regular bug report", nil, false},
+		{"Regular issue", []string{"meta-tracker"}, true},
+		{"Regular issue", []string{"bug"}, false},
+		{"Regular issue", nil, false},
+	}
+	for _, tt := range tests {
+		got := isTracker(tt.title, tt.labels)
+		if got != tt.want {
+			t.Errorf("isTracker(%q, %v) = %v, want %v", tt.title, tt.labels, got, tt.want)
+		}
+	}
+}
+
+func TestExtractLabelsWithNil(t *testing.T) {
+	labels := []*gh.Label{
+		{Name: gh.Ptr("bug")},
+		{Name: gh.Ptr("enhancement")},
+	}
+	got := extractLabels(labels)
+	if len(got) != 2 || got[0] != "bug" || got[1] != "enhancement" {
+		t.Errorf("extractLabels = %v", got)
+	}
+}
+
+func TestExtractAssigneesWithNil(t *testing.T) {
+	users := []*gh.User{
+		{Login: gh.Ptr("alice")},
+		{Login: gh.Ptr("bob")},
+		nil,
+	}
+	got := extractAssignees(users)
+	if len(got) != 2 || got[0] != "alice" || got[1] != "bob" {
+		t.Errorf("extractAssignees = %v", got)
+	}
+}
+
+func TestExtractLabelsEmpty(t *testing.T) {
+	got := extractLabels(nil)
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %v", got)
+	}
+}
+
+func TestExtractAssigneesEmpty(t *testing.T) {
+	got := extractAssignees(nil)
+	if len(got) != 0 {
+		t.Errorf("expected empty, got %v", got)
+	}
+}
+
+func TestLatestCommitHashMock(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/testorg/testrepo/git/ref/heads/main" {
+			ref := gh.Reference{
+				Object: &gh.GitObject{SHA: gh.Ptr("abc1234567890")},
+			}
+			json.NewEncoder(w).Encode(ref)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	sha, err := c.LatestCommitHash(context.Background(), "testorg", "testrepo", "main")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if sha != "abc1234567890" {
+		t.Errorf("sha = %q", sha)
+	}
+}
+
+func TestRateLimitsMock(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/rate_limit" {
+			resp := struct {
+				Resources gh.RateLimits `json:"resources"`
+			}{
+				Resources: gh.RateLimits{
+					Core: &gh.Rate{Limit: 5000, Remaining: 4999},
+				},
+			}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	limits, err := c.RateLimits(context.Background())
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if limits == nil {
+		t.Fatal("expected rate limits")
+	}
+}
+
+func TestSearchPRCountMock(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/search/issues" {
+			result := gh.IssuesSearchResult{Total: gh.Ptr(42)}
+			json.NewEncoder(w).Encode(result)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	count, err := c.SearchPRCount(context.Background(), "testuser", "testorg", "merged")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if count != 42 {
+		t.Errorf("count = %d, want 42", count)
+	}
+}

--- a/v2/pkg/github/github_extra2_test.go
+++ b/v2/pkg/github/github_extra2_test.go
@@ -1,0 +1,292 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+func TestPostAdvisoryDigestEditError(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			comments := []*gh.IssueComment{
+				{ID: gh.Ptr(int64(200)), Body: gh.Ptr(advisoryDigestPrefix + "\nOld")},
+			}
+			json.NewEncoder(w).Encode(comments)
+			return
+		}
+		if r.Method == "PATCH" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	err := c.PostAdvisoryDigest(context.Background(), "testrepo", 42, "new digest")
+	if err == nil {
+		t.Error("expected error on edit failure")
+	}
+}
+
+func TestEnsureAdvisoryIssueLabelAlreadyExists(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/testorg/testrepo/issues" && r.Method == "GET" {
+			json.NewEncoder(w).Encode([]*gh.Issue{})
+			return
+		}
+		if r.URL.Path == "/repos/testorg/testrepo/labels" && r.Method == "POST" {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			w.Write([]byte(`{"message":"Validation Failed","errors":[{"code":"already_exists"}]}`))
+			return
+		}
+		if r.URL.Path == "/repos/testorg/testrepo/issues" && r.Method == "POST" {
+			json.NewEncoder(w).Encode(gh.Issue{Number: gh.Ptr(55)})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]"))
+	}))
+
+	num, err := c.EnsureAdvisoryIssue(context.Background(), "testrepo")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if num != 55 {
+		t.Errorf("issue number = %d, want 55", num)
+	}
+}
+
+func TestEnsureAdvisoryIssueCreateError(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			json.NewEncoder(w).Encode([]*gh.Issue{})
+			return
+		}
+		if r.URL.Path == "/repos/testorg/testrepo/labels" {
+			json.NewEncoder(w).Encode(gh.Label{})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	_, err := c.EnsureAdvisoryIssue(context.Background(), "testrepo")
+	if err == nil {
+		t.Error("expected error on issue create failure")
+	}
+}
+
+func TestEnforceSHAHoldAlreadyHeld(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/testorg/testrepo/issues" && r.Method == "GET" {
+			issues := []*gh.Issue{
+				{
+					Number: gh.Ptr(10),
+					Title:  gh.Ptr("Bug already held"),
+					Body:   gh.Ptr("No sha"),
+					Labels: []*gh.Label{
+						{Name: gh.Ptr("kind/bug")},
+						{Name: gh.Ptr("hold")},
+					},
+					User: &gh.User{Login: gh.Ptr("external-user")},
+				},
+			}
+			json.NewEncoder(w).Encode(issues)
+			return
+		}
+		if r.Method == "GET" && r.URL.Path == "/repos/testorg/testrepo/issues/10/comments" {
+			json.NewEncoder(w).Encode([]*gh.IssueComment{})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]"))
+	}))
+
+	result, err := c.EnforceSHAHold(context.Background(), SHAHoldConfig{
+		PrimaryRepo: "testrepo",
+		AIAuthor:    "bot",
+	})
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if result.Skipped != 1 {
+		t.Errorf("already held should be skipped, got held=%d skipped=%d", result.Held, result.Skipped)
+	}
+}
+
+func TestEnforceSHAHoldUnholdOnSHA(t *testing.T) {
+	var unholdCalled bool
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/testorg/testrepo/issues" && r.Method == "GET" {
+			issues := []*gh.Issue{
+				{
+					Number: gh.Ptr(10),
+					Title:  gh.Ptr("Bug with SHA"),
+					Body:   gh.Ptr("Fix at abc1234567"),
+					Labels: []*gh.Label{
+						{Name: gh.Ptr("kind/bug")},
+						{Name: gh.Ptr("hold")},
+					},
+					User: &gh.User{Login: gh.Ptr("external-user")},
+				},
+			}
+			json.NewEncoder(w).Encode(issues)
+			return
+		}
+		if r.Method == "DELETE" && r.URL.Path == "/repos/testorg/testrepo/issues/10/labels/hold" {
+			unholdCalled = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]"))
+	}))
+
+	result, err := c.EnforceSHAHold(context.Background(), SHAHoldConfig{
+		PrimaryRepo: "testrepo",
+		AIAuthor:    "bot",
+	})
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if !unholdCalled {
+		t.Error("should unhold issue with SHA + hold label")
+	}
+	if result.Unheld != 1 {
+		t.Errorf("unheld = %d, want 1", result.Unheld)
+	}
+}
+
+func TestEnforceSHAHoldSkipsInternalAuthor(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/testorg/testrepo/issues" && r.Method == "GET" {
+			issues := []*gh.Issue{
+				{
+					Number: gh.Ptr(10),
+					Body:   gh.Ptr("no sha"),
+					Labels: []*gh.Label{{Name: gh.Ptr("kind/bug")}},
+					User:   &gh.User{Login: gh.Ptr("ai-bot")},
+				},
+			}
+			json.NewEncoder(w).Encode(issues)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]"))
+	}))
+
+	result, _ := c.EnforceSHAHold(context.Background(), SHAHoldConfig{
+		PrimaryRepo:     "testrepo",
+		AIAuthor:        "ai-bot",
+		InternalAuthors: []string{"ai-bot"},
+	})
+	if result.Skipped != 1 {
+		t.Errorf("internal author should be skipped, got %d", result.Skipped)
+	}
+}
+
+func TestEnforceSHAHoldListError(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	_, err := c.EnforceSHAHold(context.Background(), SHAHoldConfig{
+		PrimaryRepo: "testrepo",
+	})
+	if err == nil {
+		t.Error("should error on list failure")
+	}
+}
+
+func TestEnforceSHAHoldSkipsPR(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/testorg/testrepo/issues" && r.Method == "GET" {
+			issues := []*gh.Issue{
+				{
+					Number:           gh.Ptr(10),
+					Body:             gh.Ptr("no sha"),
+					Labels:           []*gh.Label{{Name: gh.Ptr("kind/bug")}},
+					User:             &gh.User{Login: gh.Ptr("user")},
+					PullRequestLinks: &gh.PullRequestLinks{URL: gh.Ptr("https://github.com/...")},
+				},
+			}
+			json.NewEncoder(w).Encode(issues)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]"))
+	}))
+
+	result, err := c.EnforceSHAHold(context.Background(), SHAHoldConfig{
+		PrimaryRepo: "testrepo",
+	})
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if result.Held != 0 {
+		t.Error("PRs should be skipped")
+	}
+}
+
+func TestGetContributorCountMock(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/testorg/testrepo/contributors" {
+			contribs := []*gh.Contributor{
+				{Login: gh.Ptr("user1")},
+				{Login: gh.Ptr("user2")},
+			}
+			json.NewEncoder(w).Encode(contribs)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	count, err := c.GetContributorCount(context.Background(), "testorg", "testrepo")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("count = %d, want 2", count)
+	}
+}
+
+func TestGetRepoMock(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/repos/testorg/testrepo" {
+			json.NewEncoder(w).Encode(gh.Repository{
+				FullName:    gh.Ptr("testorg/testrepo"),
+				Description: gh.Ptr("A test repo"),
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	repo, _, err := c.GetRepo(context.Background(), "testorg", "testrepo")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if repo.GetFullName() != "testorg/testrepo" {
+		t.Errorf("name = %q", repo.GetFullName())
+	}
+}
+
+func TestSearchOutreachPRCountOpen(t *testing.T) {
+	c := testClient(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/search/issues" {
+			json.NewEncoder(w).Encode(gh.IssuesSearchResult{Total: gh.Ptr(7)})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	count, err := c.SearchOutreachPRCount(context.Background(), "user", "org", "project", "open")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if count != 7 {
+		t.Errorf("count = %d, want 7", count)
+	}
+}


### PR DESCRIPTION
## Summary
- GitHub package: 74.9% → 91.0% coverage (+16.1%) — **crosses 90% threshold** ✓
- **14th package over 90%**
- Supersedes #1240, #1245, #1263

### New: DeviceFlow tests (mock HTTP transport)
- **StartDeviceFlow**: success, default interval (0→5), server error (500)
- **PollDeviceFlow**: complete (returns token), authorization_pending, slow_down, access_denied (error)
- **ValidateToken**: success (returns user), invalid (401 error)

Uses `mockTransport` to intercept `deviceFlowClient` requests to hardcoded GitHub URLs.

### From prior PRs
- Advisory (EnsureAdvisoryIssue, PostAdvisoryDigest, findDigestComment)
- Client (hold/unhold, checkCommentsForSHA, EnforceSHAHold, GetFileContent, etc.)

## Coverage table (14/17 at 90%+)
| Package | Coverage |
|---------|----------|
| governor | 94.9% |
| snapshot | 93.2% |
| tokens | 93.9% |
| classify | 91.8% |
| discord | 91.2% |
| **github** | **91.0%** ← NEW |
| advisory | 90.9% |
| policies | 90.8% |
| config | 90.7% |
| notify | 90.5% |
| beads | 90.1% |
| scheduler | 90.1% |

## Test plan
- [x] `go test ./v2/pkg/github/ -cover` passes (91.0%)
- [x] All 17/17 packages still pass