### PR TITLE
test: knowledge coverage boost (53.1% → 83.3%)

### DIFF
--- a/v2/pkg/knowledge/inception_helpers_test.go
+++ b/v2/pkg/knowledge/inception_helpers_test.go
@@ -1,0 +1,244 @@
+package knowledge
+
+import (
+	"log/slog"
+	"testing"
+)
+
+func TestSlugify(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Hello World", "hello-world"},
+		{"my_project_name", "my-project-name"},
+		{"Already-Slug", "already-slug"},
+		{"Special!@#Chars", "specialchars"},
+		{"  spaces  ", "spaces"},
+		{"double--dash", "double-dash"},
+		{"", ""},
+		{"UPPER CASE", "upper-case"},
+	}
+	for _, tt := range tests {
+		got := slugify(tt.input)
+		if got != tt.want {
+			t.Errorf("slugify(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestTruncateSlug(t *testing.T) {
+	short := "short"
+	if truncateSlug(short) != short {
+		t.Errorf("short string should not be truncated")
+	}
+
+	long := "a-very-long-project-name-that-exceeds-sixty-characters-in-total-length-and-more"
+	got := truncateSlug(long)
+	if len(got) != 60 {
+		t.Errorf("expected truncated to 60, got %d", len(got))
+	}
+}
+
+func TestRepoBaseName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://github.com/org/myrepo.git", "myrepo"},
+		{"https://github.com/org/myrepo", "myrepo"},
+		{"git@github.com:org/repo.git", "repo"},
+		{"repo", "repo"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := repoBaseName(tt.input)
+		if got != tt.want {
+			t.Errorf("repoBaseName(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestPyPackageName(t *testing.T) {
+	if pyPackageName("my-project") != "my_project" {
+		t.Error("should replace dashes with underscores")
+	}
+	if pyPackageName("no_dashes") != "no_dashes" {
+		t.Error("no dashes should be unchanged")
+	}
+}
+
+func TestToPascalCase(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"hello world", "HelloWorld"},
+		{"my project", "MyProject"},
+		{"single", "Single"},
+		{"UPPER case", "UPPERCase"},
+		{"with-special!chars", "Withspecialchars"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := toPascalCase(tt.input)
+		if got != tt.want {
+			t.Errorf("toPascalCase(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestToSnakeCase(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Hello World", "hello_world"},
+		{"MY PROJECT", "my_project"},
+		{"single", "single"},
+		{"with-special!chars", "withspecialchars"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := toSnakeCase(tt.input)
+		if got != tt.want {
+			t.Errorf("toSnakeCase(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestInferLanguage(t *testing.T) {
+	tests := []struct {
+		body string
+		want string
+	}{
+		{"A TypeScript web app using React", "typescript"},
+		{"Python API with FastAPI", "python"},
+		{"Rust service using tokio and axum", "rust"},
+		{"Java Spring Boot application", "java"},
+		{"Bash shell scripts with Makefile", "shell"},
+		{"A Go microservice", "go"},
+		{"", "go"},
+	}
+	for _, tt := range tests {
+		fact := &Fact{Body: tt.body}
+		got := inferLanguage(fact)
+		if got != tt.want {
+			t.Errorf("inferLanguage(%q) = %q, want %q", tt.body, got, tt.want)
+		}
+	}
+}
+
+func TestInferLanguageNil(t *testing.T) {
+	if inferLanguage(nil) != "go" {
+		t.Error("nil constitution should default to go")
+	}
+}
+
+func TestInferTestPath(t *testing.T) {
+	goFact := &Fact{Body: "A Go project"}
+	if inferTestPath(goFact) != "main_test.go" {
+		t.Errorf("go test path = %q", inferTestPath(goFact))
+	}
+
+	tsFact := &Fact{Body: "TypeScript React app"}
+	if inferTestPath(tsFact) != "src/__tests__/acceptance.test.ts" {
+		t.Errorf("ts test path = %q", inferTestPath(tsFact))
+	}
+
+	pyFact := &Fact{Body: "Python FastAPI service"}
+	if inferTestPath(pyFact) != "tests/test_acceptance.py" {
+		t.Errorf("python test path = %q", inferTestPath(pyFact))
+	}
+}
+
+func TestFindFactByType(t *testing.T) {
+	facts := []Fact{
+		{Type: FactPattern, Title: "Pattern A"},
+		{Type: FactVision, Title: "Vision"},
+		{Type: FactDecision, Title: "Decision A"},
+	}
+
+	got := findFactByType(facts, FactVision)
+	if got == nil || got.Title != "Vision" {
+		t.Error("should find vision fact")
+	}
+
+	missing := findFactByType(facts, FactConstraint)
+	if missing != nil {
+		t.Error("should return nil for missing type")
+	}
+}
+
+func TestFilterFactsByType(t *testing.T) {
+	facts := []Fact{
+		{Type: FactRequirement, Title: "Req 1"},
+		{Type: FactPattern, Title: "Pattern"},
+		{Type: FactRequirement, Title: "Req 2"},
+	}
+
+	got := filterFactsByType(facts, FactRequirement)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 requirements, got %d", len(got))
+	}
+	if got[0].Title != "Req 1" || got[1].Title != "Req 2" {
+		t.Error("wrong requirements returned")
+	}
+
+	empty := filterFactsByType(facts, FactConstraint)
+	if len(empty) != 0 {
+		t.Error("should return empty for missing type")
+	}
+}
+
+func TestDefaultConfidence(t *testing.T) {
+	tests := []struct {
+		ft   FactType
+		want float64
+	}{
+		{FactIdea, 0.3},
+		{FactVision, 0.6},
+		{FactPattern, 0.5},
+	}
+	for _, tt := range tests {
+		got := defaultConfidence(tt.ft)
+		if got != tt.want {
+			t.Errorf("defaultConfidence(%q) = %f, want %f", tt.ft, got, tt.want)
+		}
+	}
+}
+
+func TestFileStoreSetName(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := NewFileStore(dir, "test", slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.SetName("test-vault")
+	if fs.Name() != "test-vault" {
+		t.Errorf("Name() = %q, want 'test-vault'", fs.Name())
+	}
+}
+
+func TestFileStoreRecordAndAccessCount(t *testing.T) {
+	dir := t.TempDir()
+	fs, err := NewFileStore(dir, "test", slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if fs.AccessCount("fact-1") != 0 {
+		t.Error("initial access count should be 0")
+	}
+
+	fs.RecordAccess("fact-1")
+	fs.RecordAccess("fact-1")
+	fs.RecordAccess("fact-2")
+
+	if fs.AccessCount("fact-1") != 2 {
+		t.Errorf("fact-1 access count = %d, want 2", fs.AccessCount("fact-1"))
+	}
+	if fs.AccessCount("fact-2") != 1 {
+		t.Errorf("fact-2 access count = %d, want 1", fs.AccessCount("fact-2"))
+	}
+}

--- a/v2/pkg/knowledge/inception_record_test.go
+++ b/v2/pkg/knowledge/inception_record_test.go
@@ -1,0 +1,334 @@
+package knowledge
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRecordFactsSuccess(t *testing.T) {
+	e := newTestEngine(t)
+	e.Start("my project idea")
+
+	e.mu.Lock()
+	e.state.Phase = PhaseStructure
+	e.mu.Unlock()
+
+	e.SetQuestions([]Question{{ID: "lang", Text: "What language?"}})
+
+	e.mu.Lock()
+	e.state.Phase = PhaseClarify
+	e.mu.Unlock()
+	e.SubmitAnswers(map[string]string{"lang": "Go"})
+
+	facts := []IdeationFact{
+		{Title: "Project Vision", Body: "Build a CLI tool", Type: FactVision},
+		{Title: "Main Requirement", Body: "Must be fast", Type: FactRequirement},
+	}
+
+	err := e.RecordFacts(context.Background(), facts)
+	if err != nil {
+		t.Fatalf("RecordFacts error: %v", err)
+	}
+
+	state := e.GetState()
+	if state.Phase != PhaseScaffold {
+		t.Errorf("phase = %q, want scaffold", state.Phase)
+	}
+	if len(state.FactSlugs) < 2 {
+		t.Errorf("fact slugs = %d, want at least 2", len(state.FactSlugs))
+	}
+}
+
+func TestRecordFactsNoState(t *testing.T) {
+	e := newTestEngine(t)
+	err := e.RecordFacts(context.Background(), []IdeationFact{
+		{Title: "Test", Body: "Body", Type: FactVision},
+	})
+	if err == nil {
+		t.Error("should error with no active inception")
+	}
+}
+
+func TestRecordFactsEmpty(t *testing.T) {
+	e := newTestEngine(t)
+	e.Start("idea")
+	err := e.RecordFacts(context.Background(), nil)
+	if err == nil {
+		t.Error("should error with empty facts")
+	}
+}
+
+func TestRecordFactsInvalidType(t *testing.T) {
+	e := newTestEngine(t)
+	e.Start("idea")
+	err := e.RecordFacts(context.Background(), []IdeationFact{
+		{Title: "Test", Body: "Body", Type: FactPattern},
+	})
+	if err == nil {
+		t.Error("non-ideation type should error")
+	}
+}
+
+func TestRecordFactsMissingTitle(t *testing.T) {
+	e := newTestEngine(t)
+	e.Start("idea")
+	err := e.RecordFacts(context.Background(), []IdeationFact{
+		{Title: "", Body: "Body", Type: FactVision},
+	})
+	if err == nil {
+		t.Error("empty title should error")
+	}
+}
+
+func TestRecordFactsMissingBody(t *testing.T) {
+	e := newTestEngine(t)
+	e.Start("idea")
+	err := e.RecordFacts(context.Background(), []IdeationFact{
+		{Title: "Test", Body: "", Type: FactVision},
+	})
+	if err == nil {
+		t.Error("empty body should error")
+	}
+}
+
+func TestRecordFactsBrownfieldBoost(t *testing.T) {
+	e := newTestEngine(t)
+	e.StartBrownfield("https://github.com/org/repo")
+
+	e.mu.Lock()
+	e.state.Phase = PhaseStructure
+	e.mu.Unlock()
+
+	facts := []IdeationFact{
+		{Title: "Vision", Body: "Existing project", Type: FactVision},
+	}
+	err := e.RecordFacts(context.Background(), facts)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+}
+
+func TestGatherFactsPublicEmpty(t *testing.T) {
+	e := newTestEngine(t)
+	facts := e.GatherFactsPublic(context.Background())
+	if len(facts) != 0 {
+		t.Errorf("no wiki dir should return empty, got %d", len(facts))
+	}
+}
+
+func TestGatherFactsPublicFromFiles(t *testing.T) {
+	e := newTestEngine(t)
+	wikiDir := filepath.Join(e.dataDir, inceptionWikiDir)
+	os.MkdirAll(wikiDir, 0755)
+
+	fact1 := `---
+title: Project Vision
+type: vision
+confidence: 0.8
+---
+Build an awesome CLI tool.`
+
+	fact2 := `---
+title: Main Requirement
+type: requirement
+confidence: 0.7
+---
+Must be fast and reliable.`
+
+	os.WriteFile(filepath.Join(wikiDir, "vision-project.md"), []byte(fact1), 0644)
+	os.WriteFile(filepath.Join(wikiDir, "req-main.md"), []byte(fact2), 0644)
+	os.WriteFile(filepath.Join(wikiDir, "not-a-fact.txt"), []byte("ignore"), 0644)
+	os.Mkdir(filepath.Join(wikiDir, "subdir"), 0755)
+
+	facts := e.GatherFactsPublic(context.Background())
+	if len(facts) != 2 {
+		t.Fatalf("expected 2 facts, got %d", len(facts))
+	}
+
+	visionFound := false
+	for _, f := range facts {
+		if f.Type == FactVision {
+			visionFound = true
+			if f.Title != "Project Vision" {
+				t.Errorf("vision title = %q", f.Title)
+			}
+			if f.Confidence != 0.8 {
+				t.Errorf("vision confidence = %f", f.Confidence)
+			}
+		}
+	}
+	if !visionFound {
+		t.Error("vision fact should be found")
+	}
+}
+
+func TestProduceScaffoldNoState(t *testing.T) {
+	e := newTestEngine(t)
+	_, err := e.ProduceScaffold(context.Background())
+	if err == nil {
+		t.Error("should error with no active inception")
+	}
+}
+
+func TestProduceScaffoldGreenfield(t *testing.T) {
+	e := newTestEngine(t)
+	e.Start("build a Go CLI tool for task management")
+
+	wikiDir := filepath.Join(e.dataDir, inceptionWikiDir)
+	os.MkdirAll(wikiDir, 0755)
+
+	visionFact := `---
+title: Task Manager
+type: vision
+confidence: 0.8
+---
+A CLI tool for managing tasks efficiently.`
+
+	constFact := `---
+title: Go Architecture
+type: constitution
+confidence: 0.7
+---
+Go microservice with cobra CLI framework.`
+
+	os.WriteFile(filepath.Join(wikiDir, "vision-task.md"), []byte(visionFact), 0644)
+	os.WriteFile(filepath.Join(wikiDir, "const-arch.md"), []byte(constFact), 0644)
+
+	e.mu.Lock()
+	e.state.Phase = PhaseScaffold
+	e.mu.Unlock()
+
+	result, err := e.ProduceScaffold(context.Background())
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("result should not be nil")
+	}
+	if len(result.Files) == 0 {
+		t.Error("should produce at least one file")
+	}
+
+	hasReadme := false
+	for _, f := range result.Files {
+		if f.Path == "README.md" {
+			hasReadme = true
+		}
+	}
+	if !hasReadme {
+		t.Error("scaffold should include README.md")
+	}
+}
+
+func TestClearWikiVault(t *testing.T) {
+	e := newTestEngine(t)
+	wikiDir := filepath.Join(e.dataDir, inceptionWikiDir)
+	os.MkdirAll(wikiDir, 0755)
+	os.WriteFile(filepath.Join(wikiDir, "fact.md"), []byte("test"), 0644)
+	os.WriteFile(filepath.Join(wikiDir, "other.txt"), []byte("keep"), 0644)
+
+	e.clearWikiVault()
+
+	entries, _ := os.ReadDir(wikiDir)
+	for _, entry := range entries {
+		if entry.Name() == "fact.md" {
+			t.Error("clearWikiVault should remove .md files")
+		}
+	}
+}
+
+func TestWriteFactsToVault(t *testing.T) {
+	e := newTestEngine(t)
+	facts := []IdeationFact{
+		{Title: "Vision", Body: "Build something", Type: FactVision},
+		{Title: "Requirement", Body: "Must be fast", Type: FactRequirement},
+	}
+
+	e.writeFactsToVault(facts)
+
+	wikiDir := filepath.Join(e.dataDir, inceptionWikiDir)
+	entries, err := os.ReadDir(wikiDir)
+	if err != nil {
+		t.Fatalf("wiki dir should exist: %v", err)
+	}
+
+	mdCount := 0
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) == ".md" {
+			mdCount++
+		}
+	}
+	if mdCount != 2 {
+		t.Errorf("expected 2 .md files, got %d", mdCount)
+	}
+}
+
+func TestBuildK8sConfigMap(t *testing.T) {
+	got := buildK8sConfigMap("myproject")
+	if got == "" {
+		t.Error("should produce output")
+	}
+}
+
+func TestBuildK8sSecret(t *testing.T) {
+	got := buildK8sSecret("myproject")
+	if got == "" {
+		t.Error("should produce output")
+	}
+}
+
+func TestBuildK8sBaseKustomization(t *testing.T) {
+	got := buildK8sBaseKustomization("myproject")
+	if got == "" {
+		t.Error("should produce output")
+	}
+}
+
+func TestBuildK8sOverlayKustomization(t *testing.T) {
+	got := buildK8sOverlayKustomization("myproject", "dev")
+	if got == "" {
+		t.Error("should produce output")
+	}
+}
+
+func TestBuildNightlyCI(t *testing.T) {
+	got := buildNightlyCI("go")
+	if got == "" {
+		t.Error("should produce output")
+	}
+}
+
+func TestBuildMakefile(t *testing.T) {
+	got := buildMakefile("go", "myproject")
+	if got == "" {
+		t.Error("should produce output")
+	}
+}
+
+func TestBuildI18nFile(t *testing.T) {
+	got := buildI18nFile("en", "myproject")
+	if got == "" {
+		t.Error("should produce output")
+	}
+}
+
+func TestBuildI18nIndex(t *testing.T) {
+	got := buildI18nIndex()
+	if got == "" {
+		t.Error("should produce output")
+	}
+}
+
+func TestNewInceptionEngineWithDir(t *testing.T) {
+	dir := t.TempDir()
+	e := NewInceptionEngine(dir, nil, slog.Default())
+	if e == nil {
+		t.Fatal("engine should not be nil")
+	}
+	if e.GetState() != nil {
+		t.Error("fresh engine should have nil state")
+	}
+}

--- a/v2/pkg/knowledge/inception_scaffold_test.go
+++ b/v2/pkg/knowledge/inception_scaffold_test.go
@@ -1,0 +1,451 @@
+package knowledge
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildReadme(t *testing.T) {
+	vision := &Fact{Title: "MyProject", Body: "A cool tool"}
+	constitution := &Fact{Body: "Go microservice"}
+	reqs := []Fact{{Title: "Req 1", Body: "Must be fast"}}
+	constraints := []Fact{{Title: "Constraint 1", Body: "No external deps"}}
+	stakeholders := []Fact{{Title: "Team A", Body: "Backend devs"}}
+
+	got := buildReadme("build a tool", vision, constitution, reqs, constraints, stakeholders)
+	if !strings.Contains(got, "MyProject") {
+		t.Error("should contain project name")
+	}
+	if !strings.Contains(got, "Must be fast") {
+		t.Error("should contain requirement")
+	}
+	if !strings.Contains(got, "No external deps") {
+		t.Error("should contain constraint")
+	}
+}
+
+func TestBuildReadmeMinimal(t *testing.T) {
+	got := buildReadme("simple idea", nil, nil, nil, nil, nil)
+	if got == "" {
+		t.Error("should produce output even with nil facts")
+	}
+	if !strings.Contains(got, "Project") {
+		t.Error("should have default title")
+	}
+}
+
+func TestBuildClaudeMD(t *testing.T) {
+	constitution := &Fact{Body: "Go microservice with REST API"}
+	constraints := []Fact{{Body: "Must use stdlib only"}}
+
+	got := buildClaudeMD(constitution, constraints)
+	if !strings.Contains(got, "Guidelines") {
+		t.Error("should contain Guidelines header")
+	}
+	if !strings.Contains(got, "Go microservice") {
+		t.Error("should contain constitution body")
+	}
+}
+
+func TestBuildClaudeMDNil(t *testing.T) {
+	got := buildClaudeMD(nil, nil)
+	if got == "" {
+		t.Error("should produce output with nil inputs")
+	}
+}
+
+func TestBuildContributing(t *testing.T) {
+	constitution := &Fact{Body: "TypeScript React application"}
+	got := buildContributing(constitution)
+	if !strings.Contains(got, "Contributing") {
+		t.Error("should contain Contributing header")
+	}
+}
+
+func TestBuildContributingNil(t *testing.T) {
+	got := buildContributing(nil)
+	if got == "" {
+		t.Error("should produce output with nil constitution")
+	}
+}
+
+func TestBuildTestStubsGo(t *testing.T) {
+	acceptance := []Fact{{Title: "Test 1", Body: "It works"}}
+	constitution := &Fact{Body: "Go project"}
+	got := buildTestStubs(acceptance, constitution)
+	if !strings.Contains(got, "Test") {
+		t.Error("should contain test content")
+	}
+}
+
+func TestBuildGoTestStubs(t *testing.T) {
+	acceptance := []Fact{
+		{Title: "Login works", Body: "User can log in"},
+		{Title: "Logout works", Body: "User can log out"},
+	}
+	got := buildGoTestStubs(acceptance)
+	if !strings.Contains(got, "func Test") {
+		t.Error("should contain Go test functions")
+	}
+}
+
+func TestBuildTSTestStubs(t *testing.T) {
+	acceptance := []Fact{{Title: "Button clicks", Body: "Button responds"}}
+	got := buildTSTestStubs(acceptance)
+	if !strings.Contains(got, "describe") || !strings.Contains(got, "it.todo") {
+		t.Error("should contain TS test structure")
+	}
+}
+
+func TestBuildPythonTestStubs(t *testing.T) {
+	acceptance := []Fact{{Title: "API responds", Body: "Returns 200"}}
+	got := buildPythonTestStubs(acceptance)
+	if !strings.Contains(got, "def test_") {
+		t.Error("should contain Python test functions")
+	}
+}
+
+func TestBuildRustTestStubs(t *testing.T) {
+	acceptance := []Fact{{Title: "Compiles", Body: "No errors"}}
+	got := buildRustTestStubs(acceptance)
+	if !strings.Contains(got, "#[test]") {
+		t.Error("should contain Rust test attribute")
+	}
+}
+
+func TestBuildJavaTestStubs(t *testing.T) {
+	acceptance := []Fact{{Title: "Starts up", Body: "No crash"}}
+	got := buildJavaTestStubs(acceptance)
+	if !strings.Contains(got, "@Test") {
+		t.Error("should contain Java @Test annotation")
+	}
+}
+
+func TestBuildShellTestStubs(t *testing.T) {
+	acceptance := []Fact{{Title: "Script runs", Body: "Exits 0"}}
+	got := buildShellTestStubs(acceptance)
+	if got == "" {
+		t.Error("should produce output")
+	}
+}
+
+func TestBuildShellMain(t *testing.T) {
+	vision := &Fact{Body: "A CLI tool for automation"}
+	got := buildShellMain("mytool", vision)
+	if !strings.Contains(got, "#!/") {
+		t.Error("should contain shebang")
+	}
+	if !strings.Contains(got, "mytool") {
+		t.Error("should contain tool name")
+	}
+}
+
+func TestBuildCIConfigGo(t *testing.T) {
+	constitution := &Fact{Body: "Go project"}
+	got := buildCIConfig(constitution)
+	if !strings.Contains(got, "go") {
+		t.Error("Go CI should reference go")
+	}
+}
+
+func TestBuildCIConfigTS(t *testing.T) {
+	constitution := &Fact{Body: "TypeScript project"}
+	got := buildCIConfig(constitution)
+	if !strings.Contains(got, "npm") || !strings.Contains(got, "node") {
+		t.Error("TS CI should reference npm/node")
+	}
+}
+
+func TestBuildCIConfigPython(t *testing.T) {
+	constitution := &Fact{Body: "Python project"}
+	got := buildCIConfig(constitution)
+	if !strings.Contains(got, "pip") || !strings.Contains(got, "python") {
+		t.Error("Python CI should reference pip/python")
+	}
+}
+
+func TestBuildCIConfigRust(t *testing.T) {
+	constitution := &Fact{Body: "Rust project"}
+	got := buildCIConfig(constitution)
+	if !strings.Contains(got, "cargo") {
+		t.Error("Rust CI should reference cargo")
+	}
+}
+
+func TestBuildCIConfigJava(t *testing.T) {
+	constitution := &Fact{Body: "Java project with Maven"}
+	got := buildCIConfig(constitution)
+	if !strings.Contains(got, "mvn") || !strings.Contains(got, "java") {
+		t.Error("Java CI should reference mvn/java")
+	}
+}
+
+func TestBuildCIConfigShell(t *testing.T) {
+	constitution := &Fact{Body: "Shell scripts with Makefile"}
+	got := buildCIConfig(constitution)
+	if !strings.Contains(got, "shellcheck") || !strings.Contains(got, "bash") {
+		t.Error("Shell CI should reference shellcheck/bash")
+	}
+}
+
+func TestBuildGitignoreLanguages(t *testing.T) {
+	langs := []string{"go", "typescript", "python", "rust", "java", "shell", "javascript"}
+	for _, lang := range langs {
+		got := buildGitignore(lang)
+		if got == "" {
+			t.Errorf("buildGitignore(%q) should not be empty", lang)
+		}
+		if !strings.Contains(got, ".") {
+			t.Errorf("buildGitignore(%q) should contain file patterns", lang)
+		}
+	}
+}
+
+func TestBuildGoMod(t *testing.T) {
+	got := buildGoMod("myproject")
+	if !strings.Contains(got, "module") {
+		t.Error("should contain module directive")
+	}
+}
+
+func TestBuildGoMain(t *testing.T) {
+	vision := &Fact{Body: "A CLI tool"}
+	got := buildGoMain("myproject", vision)
+	if !strings.Contains(got, "package main") {
+		t.Error("should contain package main")
+	}
+}
+
+func TestBuildGoCmdRoot(t *testing.T) {
+	vision := &Fact{Body: "A CLI tool"}
+	got := buildGoCmdRoot("myproject", vision)
+	if !strings.Contains(got, "cobra") || !strings.Contains(got, "rootCmd") {
+		t.Error("should contain cobra root command")
+	}
+}
+
+func TestBuildCargoToml(t *testing.T) {
+	vision := &Fact{Body: "A Rust service"}
+	got := buildCargoToml("myproject", vision)
+	if !strings.Contains(got, "[package]") {
+		t.Error("should contain [package] section")
+	}
+}
+
+func TestBuildRustMain(t *testing.T) {
+	vision := &Fact{Body: "A Rust service"}
+	got := buildRustMain("myproject", vision)
+	if !strings.Contains(got, "fn main()") {
+		t.Error("should contain fn main()")
+	}
+}
+
+func TestBuildPomXml(t *testing.T) {
+	vision := &Fact{Body: "A Java app"}
+	got := buildPomXml("myproject", vision)
+	if !strings.Contains(got, "<project") {
+		t.Error("should contain <project tag")
+	}
+}
+
+func TestBuildJavaMain(t *testing.T) {
+	vision := &Fact{Body: "A Java app"}
+	got := buildJavaMain("myproject", vision)
+	if !strings.Contains(got, "public static void main") {
+		t.Error("should contain main method")
+	}
+}
+
+func TestBuildPyprojectToml(t *testing.T) {
+	vision := &Fact{Body: "A Python tool"}
+	got := buildPyprojectToml("myproject", vision)
+	if !strings.Contains(got, "[project]") {
+		t.Error("should contain [project] section")
+	}
+}
+
+func TestBuildPyInit(t *testing.T) {
+	vision := &Fact{Body: "A Python tool"}
+	got := buildPyInit("myproject", vision)
+	if got == "" {
+		t.Error("should produce output")
+	}
+}
+
+func TestBuildPyCLI(t *testing.T) {
+	vision := &Fact{Body: "A Python CLI"}
+	got := buildPyCLI("myproject", vision)
+	if !strings.Contains(got, "def main") {
+		t.Error("should contain main function")
+	}
+}
+
+func TestBuildPackageJSON(t *testing.T) {
+	vision := &Fact{Body: "A TS app"}
+	got := buildPackageJSON("myproject", vision)
+	if !strings.Contains(got, `"name"`) {
+		t.Error("should contain name field")
+	}
+}
+
+func TestBuildTSConfig(t *testing.T) {
+	got := buildTSConfig()
+	if !strings.Contains(got, "compilerOptions") {
+		t.Error("should contain compilerOptions")
+	}
+}
+
+func TestBuildTSIndex(t *testing.T) {
+	vision := &Fact{Body: "A TS app"}
+	got := buildTSIndex("myproject", vision)
+	if got == "" {
+		t.Error("should produce output")
+	}
+}
+
+func TestBuildDockerfile(t *testing.T) {
+	langs := []string{"go", "typescript", "python", "rust", "java", "shell"}
+	for _, lang := range langs {
+		got := buildDockerfile(lang, "myproject")
+		if !strings.Contains(got, "FROM") {
+			t.Errorf("buildDockerfile(%q) should contain FROM", lang)
+		}
+	}
+}
+
+func TestBuildKustomization(t *testing.T) {
+	got := buildKustomization("myproject")
+	if !strings.Contains(got, "apiVersion") {
+		t.Error("should contain apiVersion")
+	}
+}
+
+func TestBuildK8sDeployment(t *testing.T) {
+	got := buildK8sDeployment("myproject")
+	if !strings.Contains(got, "Deployment") {
+		t.Error("should contain Deployment kind")
+	}
+}
+
+func TestBuildK8sService(t *testing.T) {
+	got := buildK8sService("myproject")
+	if !strings.Contains(got, "Service") {
+		t.Error("should contain Service kind")
+	}
+}
+
+func TestInferProjectName(t *testing.T) {
+	vision := &Fact{Title: "My Cool Project"}
+	got := inferProjectName(vision, &InceptionState{})
+	if got == "" {
+		t.Error("should infer name from vision")
+	}
+}
+
+func TestInferProjectNameNilVision(t *testing.T) {
+	state := &InceptionState{IdeaSlug: "idea-myrepo"}
+	got := inferProjectName(nil, state)
+	if got != "myrepo" {
+		t.Errorf("nil vision should use idea slug, got %q", got)
+	}
+}
+
+func TestInferProjectNameDefault(t *testing.T) {
+	got := inferProjectName(nil, &InceptionState{})
+	if got != "myproject" {
+		t.Errorf("empty state should default to 'myproject', got %q", got)
+	}
+}
+
+func TestInferProjectType(t *testing.T) {
+	tests := []struct {
+		body string
+		want string
+	}{
+		{"Build a REST API backend", "api"},
+		{"Create a CLI tool", "cli"},
+		{"Build a web frontend with React", "ui"},
+		{"Create a reusable library", "library"},
+		{"Something else entirely", "cli"},
+	}
+	for _, tt := range tests {
+		constitution := &Fact{Body: tt.body}
+		got := inferProjectType(constitution, nil, nil)
+		if got != tt.want {
+			t.Errorf("inferProjectType(%q) = %q, want %q", tt.body, got, tt.want)
+		}
+	}
+}
+
+func TestBuildAgentsMD(t *testing.T) {
+	constitution := &Fact{Body: "Go project"}
+	constraints := []Fact{{Body: "Must be fast"}}
+	requirements := []Fact{{Body: "Support REST"}}
+	vision := &Fact{Title: "MyProject"}
+
+	got := buildAgentsMD(constitution, constraints, requirements, vision)
+	if got == "" {
+		t.Error("should produce output")
+	}
+}
+
+func TestParseInceptionFactFile(t *testing.T) {
+	content := `---
+title: My Fact
+type: requirement
+confidence: 0.8
+---
+This is the body of the fact.`
+
+	title, body, factType, confidence := parseInceptionFactFile(content, "test.md")
+	if title != "My Fact" {
+		t.Errorf("title = %q", title)
+	}
+	if !strings.Contains(body, "body of the fact") {
+		t.Errorf("body = %q", body)
+	}
+	if factType != "requirement" {
+		t.Errorf("factType = %q", factType)
+	}
+	if confidence != 0.8 {
+		t.Errorf("confidence = %f", confidence)
+	}
+}
+
+func TestParseInceptionFactFileNoFrontmatter(t *testing.T) {
+	content := "Just plain text without frontmatter"
+	title, body, _, _ := parseInceptionFactFile(content, "idea.md")
+	if title == "" && body == "" {
+		t.Error("should handle content without frontmatter")
+	}
+}
+
+func TestFormatAnswersForPrompt(t *testing.T) {
+	engine := &InceptionEngine{
+		state: &InceptionState{
+			Questions: []Question{
+				{ID: "q1", Text: "What does it do?"},
+				{ID: "q2", Text: "Who uses it?"},
+			},
+			Answers: map[string]string{
+				"q1": "It builds stuff",
+				"q2": "Developers",
+			},
+		},
+	}
+	got := engine.FormatAnswersForPrompt()
+	if !strings.Contains(got, "What does it do?") {
+		t.Error("should contain question text")
+	}
+	if !strings.Contains(got, "It builds stuff") {
+		t.Error("should contain answer text")
+	}
+}
+
+func TestFormatAnswersForPromptEmpty(t *testing.T) {
+	engine := &InceptionEngine{state: &InceptionState{}}
+	got := engine.FormatAnswersForPrompt()
+	if got != "" {
+		t.Errorf("empty answers should return empty, got %q", got)
+	}
+}

--- a/v2/pkg/knowledge/inception_state_test.go
+++ b/v2/pkg/knowledge/inception_state_test.go
@@ -1,0 +1,315 @@
+package knowledge
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func newTestEngine(t *testing.T) *InceptionEngine {
+	dir := t.TempDir()
+	return &InceptionEngine{
+		dataDir: dir,
+		logger:  slog.Default(),
+	}
+}
+
+func TestNewInceptionEngineNoState(t *testing.T) {
+	dir := t.TempDir()
+	e := &InceptionEngine{
+		dataDir: dir,
+		logger:  slog.Default(),
+	}
+	e.loadState()
+	e.connectExistingVault()
+
+	if e.state != nil {
+		t.Error("no state file should leave state nil")
+	}
+}
+
+func TestGetStateNil(t *testing.T) {
+	e := newTestEngine(t)
+	if e.GetState() != nil {
+		t.Error("initial state should be nil")
+	}
+}
+
+func TestStartGreenfield(t *testing.T) {
+	e := newTestEngine(t)
+	state, err := e.Start("build a CLI tool for managing tasks")
+	if err != nil {
+		t.Fatalf("Start error: %v", err)
+	}
+	if state == nil {
+		t.Fatal("state should not be nil")
+	}
+	if state.Phase != PhaseCapture {
+		t.Errorf("phase = %q, want %q", state.Phase, PhaseCapture)
+	}
+	if state.Mode != InceptionGreenfield {
+		t.Errorf("mode = %q, want %q", state.Mode, InceptionGreenfield)
+	}
+	if state.IdeaText != "build a CLI tool for managing tasks" {
+		t.Errorf("idea text = %q", state.IdeaText)
+	}
+	if state.IdeaSlug == "" {
+		t.Error("idea slug should be set")
+	}
+}
+
+func TestStartDuplicate(t *testing.T) {
+	e := newTestEngine(t)
+	e.Start("first idea")
+	_, err := e.Start("second idea")
+	if err == nil {
+		t.Error("starting while active should error")
+	}
+}
+
+func TestStartBrownfield(t *testing.T) {
+	e := newTestEngine(t)
+	state, err := e.StartBrownfield("https://github.com/org/repo")
+	if err != nil {
+		t.Fatalf("StartBrownfield error: %v", err)
+	}
+	if state.Mode != InceptionBrownfield {
+		t.Errorf("mode = %q, want %q", state.Mode, InceptionBrownfield)
+	}
+	if state.RepoURL != "https://github.com/org/repo" {
+		t.Errorf("repo URL = %q", state.RepoURL)
+	}
+}
+
+func TestStartBrownfieldDuplicate(t *testing.T) {
+	e := newTestEngine(t)
+	e.StartBrownfield("https://github.com/org/repo")
+	_, err := e.StartBrownfield("https://github.com/org/repo2")
+	if err == nil {
+		t.Error("starting while active should error")
+	}
+}
+
+func TestSetQuestions(t *testing.T) {
+	e := newTestEngine(t)
+	e.Start("my idea")
+
+	questions := []Question{
+		{ID: "language", Text: "What language?", Category: "language"},
+		{ID: "users", Text: "Who uses it?", Category: "users"},
+	}
+	err := e.SetQuestions(questions)
+	if err != nil {
+		t.Fatalf("SetQuestions error: %v", err)
+	}
+
+	state := e.GetState()
+	if len(state.Questions) != 2 {
+		t.Errorf("expected 2 questions, got %d", len(state.Questions))
+	}
+}
+
+func TestSetQuestionsNoState(t *testing.T) {
+	e := newTestEngine(t)
+	err := e.SetQuestions([]Question{{ID: "q1", Text: "test"}})
+	if err == nil {
+		t.Error("should error with no active inception")
+	}
+}
+
+func TestSubmitAnswers(t *testing.T) {
+	e := newTestEngine(t)
+	e.Start("my idea")
+	e.SetQuestions([]Question{
+		{ID: "language", Text: "What language?"},
+	})
+
+	answers := map[string]string{"language": "Go"}
+	_, err := e.SubmitAnswers(answers)
+	if err != nil {
+		t.Fatalf("SubmitAnswers error: %v", err)
+	}
+
+	state := e.GetState()
+	if state.Answers["language"] != "Go" {
+		t.Errorf("answer = %q", state.Answers["language"])
+	}
+}
+
+func TestSubmitAnswersNoState(t *testing.T) {
+	e := newTestEngine(t)
+	_, err := e.SubmitAnswers(map[string]string{"q1": "a1"})
+	if err == nil {
+		t.Error("should error with no active inception")
+	}
+}
+
+func TestAdvanceToCompleteNoState(t *testing.T) {
+	e := newTestEngine(t)
+	err := e.AdvanceToComplete()
+	if err == nil {
+		t.Error("should error with no active inception")
+	}
+}
+
+func TestAdvanceToCompleteWrongPhase(t *testing.T) {
+	e := newTestEngine(t)
+	e.Start("my idea")
+	err := e.AdvanceToComplete()
+	if err == nil {
+		t.Error("should error in questions phase")
+	}
+}
+
+func TestSetWikiName(t *testing.T) {
+	e := newTestEngine(t)
+	e.Start("my idea")
+	e.SetWikiName("my-cool-wiki")
+
+	state := e.GetState()
+	if state.WikiName != "my-cool-wiki" {
+		t.Errorf("wiki name = %q", state.WikiName)
+	}
+}
+
+func TestSetWikiNameNoState(t *testing.T) {
+	e := newTestEngine(t)
+	e.SetWikiName("test")
+}
+
+func TestIncrementAutoFactCount(t *testing.T) {
+	e := newTestEngine(t)
+	e.Start("my idea")
+	e.IncrementAutoFactCount(3)
+	e.IncrementAutoFactCount(2)
+
+	state := e.GetState()
+	if state.AutoFactCount != 5 {
+		t.Errorf("auto fact count = %d, want 5", state.AutoFactCount)
+	}
+}
+
+func TestIncrementAutoFactCountNoState(t *testing.T) {
+	e := newTestEngine(t)
+	e.IncrementAutoFactCount(1)
+}
+
+func TestIncrementAutoQuestionCount(t *testing.T) {
+	e := newTestEngine(t)
+	e.Start("my idea")
+	e.IncrementAutoQuestionCount(4)
+
+	state := e.GetState()
+	if state.AutoQuestionCount != 4 {
+		t.Errorf("auto question count = %d, want 4", state.AutoQuestionCount)
+	}
+}
+
+func TestHasWikiFilesEmpty(t *testing.T) {
+	e := newTestEngine(t)
+	if e.HasWikiFiles() {
+		t.Error("empty dir should have no wiki files")
+	}
+}
+
+func TestHasWikiFilesPresent(t *testing.T) {
+	e := newTestEngine(t)
+	wikiDir := filepath.Join(e.dataDir, inceptionWikiDir)
+	os.MkdirAll(wikiDir, 0755)
+	os.WriteFile(filepath.Join(wikiDir, "fact.md"), []byte("# Fact"), 0644)
+
+	if !e.HasWikiFiles() {
+		t.Error("should detect .md files in wiki dir")
+	}
+}
+
+func TestHasWikiFilesNonMD(t *testing.T) {
+	e := newTestEngine(t)
+	wikiDir := filepath.Join(e.dataDir, inceptionWikiDir)
+	os.MkdirAll(wikiDir, 0755)
+	os.WriteFile(filepath.Join(wikiDir, "readme.txt"), []byte("text"), 0644)
+
+	if e.HasWikiFiles() {
+		t.Error("non-.md files should not count")
+	}
+}
+
+func TestReset(t *testing.T) {
+	e := newTestEngine(t)
+	e.Start("my idea")
+
+	if e.GetState() == nil {
+		t.Fatal("state should be set after Start")
+	}
+
+	err := e.Reset()
+	if err != nil {
+		t.Fatalf("Reset error: %v", err)
+	}
+	if e.GetState() != nil {
+		t.Error("state should be nil after Reset")
+	}
+}
+
+func TestResetNoState(t *testing.T) {
+	e := newTestEngine(t)
+	err := e.Reset()
+	if err != nil {
+		t.Errorf("Reset with no state should not error, got %v", err)
+	}
+}
+
+func TestSaveAndLoadState(t *testing.T) {
+	e := newTestEngine(t)
+	e.Start("test idea")
+	e.SetWikiName("test-wiki")
+
+	e2 := &InceptionEngine{
+		dataDir: e.dataDir,
+		logger:  slog.Default(),
+	}
+	e2.loadState()
+
+	if e2.state == nil {
+		t.Fatal("loaded state should not be nil")
+	}
+	if e2.state.IdeaText != "test idea" {
+		t.Errorf("idea text = %q", e2.state.IdeaText)
+	}
+	if e2.state.WikiName != "test-wiki" {
+		t.Errorf("wiki name = %q", e2.state.WikiName)
+	}
+}
+
+func TestLoadStateInvalidJSON(t *testing.T) {
+	e := newTestEngine(t)
+	statePath := filepath.Join(e.dataDir, inceptionStateFile)
+	os.MkdirAll(filepath.Dir(statePath), 0755)
+	os.WriteFile(statePath, []byte("{bad json"), 0644)
+
+	e.loadState()
+	if e.state != nil {
+		t.Error("invalid JSON should leave state nil")
+	}
+}
+
+func TestReadIdeaFactNoState(t *testing.T) {
+	e := newTestEngine(t)
+	_, err := e.ReadIdeaFact(nil)
+	if err == nil {
+		t.Error("should error with no active inception")
+	}
+}
+
+func TestReadIdeaFactNoAPI(t *testing.T) {
+	e := newTestEngine(t)
+	e.Start("my idea")
+	fact, err := e.ReadIdeaFact(nil)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if fact != nil {
+		t.Error("nil API should return nil fact")
+	}
+}


### PR DESCRIPTION
## Summary
- Knowledge package: 53.1% → 83.3% coverage (+30.2%)
- Supersedes #1241, #1253, #1264

### New tests
- **RecordFacts**: success (greenfield), no state, empty, invalid type, missing title/body, brownfield confidence boost
- **GatherFactsPublic**: empty wiki, from .md files with YAML frontmatter
- **ProduceScaffold**: no state error, greenfield generates README + scaffold files
- **clearWikiVault**: removes .md files
- **writeFactsToVault**: creates wiki directory and .md fact files
- **NewInceptionEngine**: constructor smoke test
- **K8s builders**: ConfigMap, Secret, BaseKustomization, OverlayKustomization
- **CI/build**: buildNightlyCI, buildMakefile, buildI18nFile, buildI18nIndex

## Test plan
- [x] `go test ./v2/pkg/knowledge/ -cover` passes (83.3%)
- [x] All 17/17 packages still pass