### PR TITLE
fix: Dockerfile pluk clone path mismatch (bug #144)

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -127,7 +127,7 @@ RUN pip3 install --no-cache-dir --break-system-packages specify-cli 2>/dev/null 
     pip3 install --no-cache-dir specify-cli 2>/dev/null || \
     echo "WARN: spec-kit (specify-cli) install failed — inception will generate facts without it"
 # pluk: structured event streaming for AI agent tmux sessions
-RUN git clone --depth 1 https://github.com/kubestellar/pluk.git /tmp/pst && \
+RUN git clone --depth 1 https://github.com/kubestellar/pluk.git /tmp/pluk && \
     bash /tmp/pluk/install.sh /usr/local && \
     rm -rf /tmp/pluk && \
     mkdir -p /var/run/pluk/logs /var/run/pluk/commands && \


### PR DESCRIPTION
Clone went to /tmp/pst but install.sh reads /tmp/pluk. One-character fix.