### PR TITLE
feat: contributor model visibility + model filtering

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -428,6 +428,11 @@ function handleMessage(data) {
 
     case 'auth_failed':
       console.error(`Authentication failed: ${msg.reason}`);
+      if (msg.accepted_models && msg.accepted_models.length > 0) {
+        console.error('\nThis hive accepts the following models:');
+        msg.accepted_models.forEach(m => console.error('  - ' + m));
+        console.error('\nSet your model: export AGENT_MODEL=<model>');
+      }
       process.exit(1);
       break;
 

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -337,8 +337,10 @@ type HubConfig struct {
 	ContributeAllowLabels  []string `yaml:"contribute_allow_labels"`
 	ContributeDenyLabels   []string `yaml:"contribute_deny_labels"`
 	ContributeDenyTitles   []string `yaml:"contribute_deny_titles"`
-	ContributeDenyAuthors  []string `yaml:"contribute_deny_authors"`
-	DisabledRepos          []string            `yaml:"disabled_repos"`
+	ContributeDenyAuthors         []string `yaml:"contribute_deny_authors"`
+	ContributeAllowModels         []string `yaml:"contribute_allow_models"`
+	ContributeRejectUnknownModels bool     `yaml:"contribute_reject_unknown_models"`
+	DisabledRepos                 []string            `yaml:"disabled_repos"`
 	DisabledTiers          []string            `yaml:"disabled_tiers"`
 	TierLimits             map[string]TierRate `yaml:"tier_limits"`
 	SnapshotIntervalMin    int                 `yaml:"snapshot_interval_min"`

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -2065,10 +2065,16 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			"is_public":               cfg.Hub.IsPublic,
 			"auto_snapshot":           cfg.Hub.AutoSnapshot,
 			"snapshot_interval_min":   cfg.Hub.SnapshotIntervalMin,
-			"contribute_allow_labels": cfg.Hub.ContributeAllowLabels,
-			"contribute_deny_labels":  cfg.Hub.ContributeDenyLabels,
-			"disabled_repos":          cfg.Hub.DisabledRepos,
-			"disabled_tiers":          cfg.Hub.DisabledTiers,
+			"contribute_suspended":             cfg.Hub.ContributeSuspended,
+			"contribute_allow_labels":          cfg.Hub.ContributeAllowLabels,
+			"contribute_deny_labels":           cfg.Hub.ContributeDenyLabels,
+			"contribute_deny_titles":           cfg.Hub.ContributeDenyTitles,
+			"contribute_deny_authors":          cfg.Hub.ContributeDenyAuthors,
+			"contribute_allow_models":          cfg.Hub.ContributeAllowModels,
+			"contribute_reject_unknown_models": cfg.Hub.ContributeRejectUnknownModels,
+			"disabled_repos":                   cfg.Hub.DisabledRepos,
+			"disabled_tiers":                   cfg.Hub.DisabledTiers,
+			"tier_limits":                      cfg.Hub.TierLimits,
 		},
 	})
 }
@@ -2353,16 +2359,22 @@ func (s *Server) handleGovernorLogging(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		Enabled              *bool    `json:"enabled"`
-		URL                  string   `json:"url"`
-		DashboardURL         string   `json:"dashboard_url"`
-		SnapshotURL          string   `json:"snapshot_url"`
-		IsPublic             *bool    `json:"is_public"`
-		AutoSnapshot         *bool    `json:"auto_snapshot"`
-		ContributeAllowLabels []string `json:"contribute_allow_labels"`
-		ContributeDenyLabels  []string `json:"contribute_deny_labels"`
-		DisabledRepos         []string `json:"disabled_repos"`
-		DisabledTiers         []string `json:"disabled_tiers"`
+		Enabled                       *bool               `json:"enabled"`
+		URL                           string              `json:"url"`
+		DashboardURL                  string              `json:"dashboard_url"`
+		SnapshotURL                   string              `json:"snapshot_url"`
+		IsPublic                      *bool               `json:"is_public"`
+		AutoSnapshot                  *bool               `json:"auto_snapshot"`
+		ContributeSuspended           *bool               `json:"contribute_suspended"`
+		ContributeAllowLabels         []string            `json:"contribute_allow_labels"`
+		ContributeDenyLabels          []string            `json:"contribute_deny_labels"`
+		ContributeDenyTitles          []string            `json:"contribute_deny_titles"`
+		ContributeDenyAuthors         []string            `json:"contribute_deny_authors"`
+		ContributeAllowModels         []string            `json:"contribute_allow_models"`
+		ContributeRejectUnknownModels *bool               `json:"contribute_reject_unknown_models"`
+		DisabledRepos                 []string            `json:"disabled_repos"`
+		DisabledTiers                 []string            `json:"disabled_tiers"`
+		TierLimits                    map[string]config.TierRate `json:"tier_limits"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
@@ -2385,17 +2397,35 @@ func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 	if body.AutoSnapshot != nil {
 		cfg.Hub.AutoSnapshot = *body.AutoSnapshot
 	}
+	if body.ContributeSuspended != nil {
+		cfg.Hub.ContributeSuspended = *body.ContributeSuspended
+	}
 	if body.ContributeAllowLabels != nil {
 		cfg.Hub.ContributeAllowLabels = body.ContributeAllowLabels
 	}
 	if body.ContributeDenyLabels != nil {
 		cfg.Hub.ContributeDenyLabels = body.ContributeDenyLabels
 	}
+	if body.ContributeDenyTitles != nil {
+		cfg.Hub.ContributeDenyTitles = body.ContributeDenyTitles
+	}
+	if body.ContributeDenyAuthors != nil {
+		cfg.Hub.ContributeDenyAuthors = body.ContributeDenyAuthors
+	}
+	if body.ContributeAllowModels != nil {
+		cfg.Hub.ContributeAllowModels = body.ContributeAllowModels
+	}
+	if body.ContributeRejectUnknownModels != nil {
+		cfg.Hub.ContributeRejectUnknownModels = *body.ContributeRejectUnknownModels
+	}
 	if body.DisabledRepos != nil {
 		cfg.Hub.DisabledRepos = body.DisabledRepos
 	}
 	if body.DisabledTiers != nil {
 		cfg.Hub.DisabledTiers = body.DisabledTiers
+	}
+	if body.TierLimits != nil {
+		cfg.Hub.TierLimits = body.TierLimits
 	}
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -81,6 +81,7 @@ type WSMessage struct {
 	Result            string          `json:"result,omitempty"`
 	Summary           string          `json:"summary,omitempty"`
 	TmuxOutput        []string        `json:"tmux_output,omitempty"`
+	AcceptedModels    []string        `json:"accepted_models,omitempty"`
 }
 
 type WSTaskAssign struct {
@@ -480,6 +481,17 @@ func (h *ContributeWSHub) HandleWS(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
+			if allowed, acceptedModels := h.checkModelAllowed(msg.Model); !allowed {
+				reason := fmt.Sprintf("Model %q is not accepted by this hive", msg.Model)
+				if msg.Model == "" {
+					reason = "No model specified — this hive requires an accepted model"
+				}
+				_ = sendJSON(conn, WSMessage{Type: "auth_failed", Reason: reason, AcceptedModels: acceptedModels})
+				h.logger.Info("[contribute-ws] model rejected", "username", profile.GitHubUsername, "model", msg.Model)
+				conn.Close()
+				return
+			}
+
 			profile.LastActive = time.Now().UTC().Format(time.RFC3339)
 			if msg.CLIBackend != "" {
 				profile.CLIBackend = msg.CLIBackend
@@ -705,6 +717,26 @@ func (h *ContributeWSHub) heartbeatLoop(c *ContributorConnection) {
 			return
 		}
 	}
+}
+
+func (h *ContributeWSHub) checkModelAllowed(model string) (bool, []string) {
+	if h.server == nil || h.server.deps == nil || h.server.deps.Config == nil {
+		return true, nil
+	}
+	cfg := h.server.deps.Config.Hub
+	if len(cfg.ContributeAllowModels) == 0 {
+		return true, nil
+	}
+	if model == "" {
+		return !cfg.ContributeRejectUnknownModels, cfg.ContributeAllowModels
+	}
+	if config.MatchesAny(model, cfg.ContributeAllowModels) {
+		return true, nil
+	}
+	if cfg.ContributeRejectUnknownModels {
+		return false, cfg.ContributeAllowModels
+	}
+	return true, nil
 }
 
 func (h *ContributeWSHub) cleanupLoop() {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -8333,6 +8333,8 @@ function burnAreaChart() {
       const denyLabels = (hub.contribute_deny_labels || []);
       const denyTitles = (hub.contribute_deny_titles || []);
       const denyAuthors = (hub.contribute_deny_authors || []);
+      const allowModels = (hub.contribute_allow_models || []);
+      const rejectUnknownModels = hub.contribute_reject_unknown_models || false;
       return `
         <div class="config-toggle">
           <div class="config-toggle-switch ${hub.enabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="hub" data-key="enabled"></div>
@@ -8381,6 +8383,30 @@ function burnAreaChart() {
           <div id="hub-deny-authors" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">${denyAuthors.map(function(a) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(248,81,73,0.15);color:#f85149;border:1px solid rgba(248,81,73,0.3)">' + esc(a) + ' <span onclick="removeHubFilter(\'contribute_deny_authors\',\'' + esc(a).replace(/'/g,"\\'") + '\')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('')}</div>
           <div style="display:flex;gap:4px"><input type="text" id="hub-deny-author-input" placeholder="e.g. renovate[bot], dependabot*" style="flex:1" onkeydown="if(event.key==='Enter'){addHubFilter('contribute_deny_authors','hub-deny-author-input');event.preventDefault()}"><button onclick="addHubFilter('contribute_deny_authors','hub-deny-author-input')" style="padding:4px 12px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer;font-size:0.75rem">Add</button></div>
         </div>
+
+        <hr style="border-color:var(--border);margin:16px 0">
+        <h4 style="font-size:0.8rem;color:var(--muted);margin:0 0 8px">Model Filter ${allowModels.length === 0 ? '<span style="font-weight:400;color:#3fb950;margin-left:8px">All models accepted</span>' : '<span style="font-weight:400;color:#58a6ff;margin-left:8px">' + allowModels.length + ' pattern' + (allowModels.length > 1 ? 's' : '') + '</span>'}</h4>
+
+        <div class="config-toggle">
+          <div class="config-toggle-switch ${rejectUnknownModels ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="hub" data-key="contribute_reject_unknown_models" style="${rejectUnknownModels ? 'background:#f85149' : ''}"></div>
+          <span class="config-toggle-label" style="${rejectUnknownModels ? 'color:#f85149;font-weight:600' : ''}">Reject Unknown Models <span class="config-info">i<span class="config-tooltip">When enabled and the allowlist is non-empty, contributors using models not in the list are rejected at connect time.</span></span></span>
+        </div>
+
+        <div class="config-field">
+          <label>Allowed Models <span class="config-info">i<span class="config-tooltip">Models matching these patterns are accepted. Supports wildcards (*) and regex (/pattern/). Empty = allow all.</span></span></label>
+          <div id="hub-allow-models" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">${allowModels.map(function(m) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(34,197,94,0.15);color:#4ade80;border:1px solid rgba(34,197,94,0.3)">' + esc(m) + ' <span onclick="removeHubFilter(\'contribute_allow_models\',\'' + esc(m).replace(/'/g,"\\'") + '\')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('')}</div>
+          <div style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:6px">
+            <button onclick="addModelPreset('claude-opus*')" style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:9999px;color:var(--muted);cursor:pointer;font-size:0.65rem">+ opus</button>
+            <button onclick="addModelPreset('claude-sonnet*')" style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:9999px;color:var(--muted);cursor:pointer;font-size:0.65rem">+ sonnet</button>
+            <button onclick="addModelPreset('claude-haiku*')" style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:9999px;color:var(--muted);cursor:pointer;font-size:0.65rem">+ haiku</button>
+            <button onclick="addModelPreset('gpt-4o*')" style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:9999px;color:var(--muted);cursor:pointer;font-size:0.65rem">+ gpt-4o</button>
+            <button onclick="addModelPreset('gemini*')" style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:9999px;color:var(--muted);cursor:pointer;font-size:0.65rem">+ gemini</button>
+            <button onclick="addModelPreset('deepseek*')" style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:9999px;color:var(--muted);cursor:pointer;font-size:0.65rem">+ deepseek</button>
+          </div>
+          <div style="display:flex;gap:4px"><input type="text" id="hub-allow-model-input" placeholder="e.g. claude-opus*, /gemini-\\d/" style="flex:1" onkeydown="if(event.key==='Enter'){addHubFilter('contribute_allow_models','hub-allow-model-input');event.preventDefault()}"><button onclick="addHubFilter('contribute_allow_models','hub-allow-model-input')" style="padding:4px 12px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer;font-size:0.75rem">Add</button></div>
+        </div>
+
+        <hr style="border-color:var(--border);margin:16px 0">
 
         <div class="config-field">
           <label>Allow Labels <span class="config-info">i<span class="config-tooltip">Only issues with these labels will be queued for contributors. Leave empty to allow all.</span></span></label>
@@ -8470,6 +8496,16 @@ function burnAreaChart() {
       if (!_configState.data.hub || !_configState.data.hub[key]) return;
       _configState.data.hub[key] = _configState.data.hub[key].filter(function(l) { return l !== label; });
       markDirty('hub', key, _configState.data.hub[key]);
+      renderConfigTab('Hub');
+    }
+
+    function addModelPreset(val) {
+      if (!_configState.data.hub) _configState.data.hub = {};
+      if (!_configState.data.hub.contribute_allow_models) _configState.data.hub.contribute_allow_models = [];
+      if (_configState.data.hub.contribute_allow_models.indexOf(val) === -1) {
+        _configState.data.hub.contribute_allow_models.push(val);
+        markDirty('hub', 'contribute_allow_models', _configState.data.hub.contribute_allow_models);
+      }
       renderConfigTab('Hub');
     }
 


### PR DESCRIPTION
## Summary
- Model check at auth time — rejected contributors see accepted model list
- Hub config tab: Model Filter with presets (opus, sonnet, haiku, gpt-4o, gemini, deepseek) + freeform wildcard/regex
- "Reject Unknown Models" toggle
- Shows "All models accepted" when allowlist is empty
- Relay displays rejection + accepted models list
- **Fixes pre-existing bug**: deny_titles, deny_authors, tier_limits, contribute_suspended now persist through Go API

## Test plan
- [ ] Connect with unfiltered model → accepted
- [ ] Add `claude-sonnet*` to allowlist, enable reject → `deepseek-r1` rejected with model list
- [ ] Verify deny_titles/authors/tier_limits persist across save/reload