### PR TITLE
fix: threshold UI showed fake defaults when actual value was 0

### DIFF
--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -22,7 +22,7 @@ const rawHub = process.env.HIVE_HUB || 'wss://hive.kubestellar.io:3001/contribut
 const HUB_URL = rawHub.replace(/\/contribute\/?$/, '/api/contribute/ws');
 const REG_TOKEN = process.env.HIVE_REGISTRATION_TOKEN;
 const BACKEND = process.env.AGENT_BACKEND || 'claude';
-const MODEL = process.env.AGENT_MODEL || '';
+const MODEL = process.env.AGENT_MODEL || process.env.GOOSE_MODEL || '';
 const TMUX_SESSION = process.env.HIVE_AGENT_SESSION || 'contributor';
 const GH_TOKEN_CACHE = fs.existsSync('/var/run/hive-metrics')
   ? '/var/run/hive-metrics/gh-app-token.cache'

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2295,9 +2295,9 @@
         const itmMedian = itm.median_minutes || 0;
         const MTTR_COLOR = '#d2a8ff';
         const govThresh = gov.thresholds || {};
-        const OC_THRESH_QUIET = govThresh.quiet || 2;
-        const OC_THRESH_BUSY = govThresh.busy || 10;
-        const OC_THRESH_SURGE = govThresh.surge || 20;
+        const OC_THRESH_QUIET = govThresh.quiet ?? 2;
+        const OC_THRESH_BUSY = govThresh.busy ?? 10;
+        const OC_THRESH_SURGE = govThresh.surge ?? 20;
         const OC_GAUGE_MAX = Math.max(OC_THRESH_SURGE + 10, govActionable + 5);
         const gaugePct = Math.min(govActionable / OC_GAUGE_MAX * 100, 100);
         govOuter.innerHTML = `
@@ -3315,9 +3315,9 @@
 
       // Gauge bar — thresholds from governor.env (dynamic via status API)
       const _gt = gov.thresholds || {};
-      const CLASSIC_THRESH_QUIET = _gt.quiet || 2;
-      const CLASSIC_THRESH_BUSY = _gt.busy || 10;
-      const CLASSIC_THRESH_SURGE = _gt.surge || 20;
+      const CLASSIC_THRESH_QUIET = _gt.quiet ?? 2;
+      const CLASSIC_THRESH_BUSY = _gt.busy ?? 10;
+      const CLASSIC_THRESH_SURGE = _gt.surge ?? 20;
       const maxQ = Math.max(CLASSIC_THRESH_SURGE + 10, issueCount + 5);
       const pct = Math.min(issueCount / maxQ * 100, 100);
       const modeColors = { idle: '#238636', quiet: '#58a6ff', busy: '#d29922', surge: '#f85149' };


### PR DESCRIPTION
Used `||` instead of `??` — JavaScript treated 0 as falsy and substituted hardcoded defaults. Certus appeared to have thresholds 2/10/20 but actually had 0/0/0, causing permanent surge mode.