### PR TITLE
fix: boot prompt uses embedded kick_template — was loading wrong file

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/policies"
 )
 
 type ProcessState string
@@ -696,22 +697,31 @@ func (m *Manager) buildBootstrapPrompt(agent *AgentProcess) string {
 		filepath.Join(policiesRoot, "examples", "agents", agent.Name+".md"),
 		fmt.Sprintf("/opt/hive/examples/agents/%s.md", agent.Name),
 	)
-	var policyPath string
-	for _, p := range paths {
-		if _, err := os.Stat(p); err == nil {
-			policyPath = p
-			break
+	var base string
+	var foundTemplate bool
+
+	// Try embedded defaults first for kick_template (most templates are embedded)
+	if agent.Config.KickTemplate != "" {
+		if data, err := m.readEmbeddedPolicy("defaults/" + agent.Config.KickTemplate); err == nil {
+			base = fmt.Sprintf("[agent:%s] [KICK]\n\n%s", agent.Name, string(data))
+			foundTemplate = true
 		}
 	}
 
-	var base string
-	if policyPath != "" {
-		if policyContent, err := os.ReadFile(policyPath); err == nil {
-			base = fmt.Sprintf("[agent:%s] [KICK]\n\n%s", agent.Name, string(policyContent))
-		} else {
-			base = fmt.Sprintf("[agent:%s] [BOOT] Read %s for your instructions.", agent.Name, policyPath)
+	// Fall back to filesystem paths
+	if !foundTemplate {
+		for _, p := range paths {
+			if _, err := os.Stat(p); err == nil {
+				if data, err := os.ReadFile(p); err == nil {
+					base = fmt.Sprintf("[agent:%s] [KICK]\n\n%s", agent.Name, string(data))
+					foundTemplate = true
+				}
+				break
+			}
 		}
-	} else {
+	}
+
+	if !foundTemplate {
 		base = fmt.Sprintf("[agent:%s] [BOOT] Read your policy file for instructions and begin your first pass.", agent.Name)
 	}
 
@@ -784,6 +794,10 @@ func (m *Manager) findACMMFragments() []string {
 	return files
 }
 
+
+func (m *Manager) readEmbeddedPolicy(path string) ([]byte, error) {
+	return policies.DefaultPolicies.ReadFile(path)
+}
 
 func (m *Manager) buildProjectPreamble(agent *AgentProcess) string {
 	p := m.project


### PR DESCRIPTION
scanner-automerge.md is embedded, not on disk. Boot fell through to /opt/hive/examples/agents/scanner.md (wrong template with raw ${PROJECT_NAME}). Now checks embedded defaults first.