### PR TITLE
fix: table/list parser buffer 100→500 lines (bug #152)

### DIFF
--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -656,7 +656,7 @@ func (w *InceptionWatcher) buildInceptionKickMessage(state *knowledge.InceptionS
 // questions (with │ delimiters) even when bd create doesn't execute. This
 // catches the ~30% of cases where beads aren't created but questions exist.
 func (w *InceptionWatcher) checkForQuestionsInOutput() {
-	lines, err := w.agentMgr.GetBufferOutput("brainstorm", outputParseLineCount)
+	lines, err := w.agentMgr.GetBufferOutput("brainstorm", interceptBufferLineCount)
 	if err != nil || len(lines) == 0 {
 		return
 	}


### PR DESCRIPTION
Matches intercept buffer size. Questions in tables/lists were scrolling past 100 lines.