### PR TITLE
fix: kill brainstorm session on force-reset (bug #153)

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1996,6 +1996,20 @@ func (m *Manager) agentEnvPairs(agent *AgentProcess) []agentEnvPair {
 	return vars
 }
 
+func (m *Manager) KillSession(name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	agent, ok := m.agents[name]
+	if !ok {
+		return fmt.Errorf("agent %s not found", name)
+	}
+
+	_ = m.tmuxCmd(agent, "kill-session", "-t", agent.tmuxSession).Run()
+	m.logger.Info("agent tmux session killed", "name", name, "session", agent.tmuxSession)
+	return nil
+}
+
 func (m *Manager) Pause(name, trigger, reason string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/v2/pkg/dashboard/inception_handlers.go
+++ b/v2/pkg/dashboard/inception_handlers.go
@@ -35,6 +35,10 @@ func (s *Server) handleInceptionStart(w http.ResponseWriter, r *http.Request) {
 	if req.Force {
 		_ = s.deps.Inception.Reset()
 		if s.deps.AgentMgr != nil {
+			// Kill the tmux session to ensure a clean slate — stale
+			// session state from a previous inception causes the agent
+			// to alternate between responsive and unresponsive.
+			_ = s.deps.AgentMgr.KillSession("brainstorm")
 			_ = s.deps.AgentMgr.Pause("brainstorm", "inception-force-reset", "forced reset before new inception")
 		}
 	}


### PR DESCRIPTION
Stale tmux session caused alternating responsive/unresponsive pattern. Kill session on force-reset for clean start.