### PR TITLE
feat: embed deep health in heartbeat, show in My Hives

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -933,7 +933,7 @@ func main() {
 					}
 					return ""
 				}(),
-				Health:       map[string]any{},
+				Health:       dashSrv.HealthSummary(),
 				DashboardURL: func() string {
 					if cfg.Hub.DashboardURL != "" {
 						return cfg.Hub.DashboardURL

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -787,3 +787,79 @@ func (s *Server) GetAdvisoryDigest() any {
 	defer s.advisoryMu.RUnlock()
 	return s.advisoryDigest
 }
+
+// HealthSummary returns a compact deep-health summary for embedding in heartbeats.
+func (s *Server) HealthSummary() map[string]any {
+	summary := map[string]any{"status": "ok", "fails": 0, "warns": 0}
+	fails := 0
+	warns := 0
+
+	s.statusMu.RLock()
+	ready := s.status != nil && s.ready
+	s.statusMu.RUnlock()
+	if !ready {
+		fails++
+	}
+
+	if s.deps != nil && s.deps.GHAppAuth != nil {
+		if _, err := s.deps.GHAppAuth.Token(s.deps.Ctx); err != nil {
+			fails++
+			summary["github_auth"] = "fail"
+		}
+	} else if s.deps == nil || s.deps.GHClient == nil {
+		fails++
+		summary["github_auth"] = "fail"
+	}
+
+	if s.deps != nil && s.deps.AgentMgr != nil {
+		stalled := 0
+		running := 0
+		const staleOutputThreshold = 30 * time.Minute
+		for _, proc := range s.deps.AgentMgr.AllStatuses() {
+			if proc.Paused {
+				continue
+			}
+			if proc.State == agent.StateRunning {
+				running++
+				if proc.LastKickMessage != "" {
+					for _, v := range []string{"${ISSUE_LIST}", "${PR_LIST}", "${HIVE_REPO}", "${KNOWLEDGE}"} {
+						if strings.Contains(proc.LastKickMessage, v) {
+							warns++
+							break
+						}
+					}
+				}
+				if proc.OutputBuffer != nil && proc.OutputBuffer.Count() == 0 && proc.LastKick != nil {
+					if time.Since(*proc.LastKick) > staleOutputThreshold {
+						stalled++
+					}
+				}
+			} else {
+				fails++
+			}
+		}
+		summary["agents_running"] = running
+		if stalled > 0 {
+			warns++
+			summary["stalled"] = stalled
+		}
+	}
+
+	if s.deps != nil && s.deps.Tokens != nil {
+		ts := s.deps.Tokens.Summary()
+		if ts != nil && ts.TotalTokens == 0 {
+			warns++
+		}
+	}
+
+	summary["fails"] = fails
+	summary["warns"] = warns
+	if fails > 2 {
+		summary["status"] = "critical"
+	} else if fails > 0 {
+		summary["status"] = "degraded"
+	} else if warns > 0 {
+		summary["status"] = "warning"
+	}
+	return summary
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1629,6 +1629,22 @@ const dashboardHTML = `<!DOCTYPE html>
       }
       return '<span title="' + m + '" style="display:inline-flex;align-items:center;gap:4px"><svg width="24" height="20" viewBox="0 0 24 20">' + bars + '</svg><span style="font-size:0.7rem;color:' + c + ';font-weight:600">' + m + '</span></span>';
     }
+    function healthBadge(h) {
+      var hp = h.health || {};
+      var st = hp.status || 'unknown';
+      var fails = hp.fails || 0;
+      var warns = hp.warns || 0;
+      var colors = {ok:'#3fb950',warning:'#d29922',degraded:'#f85149',critical:'#ff4040',unknown:'#6b7280'};
+      var icons = {ok:'✓',warning:'⚠',degraded:'⚠',critical:'✕',unknown:'?'};
+      var c = colors[st] || colors.unknown;
+      var ic = icons[st] || '?';
+      var tip = st.charAt(0).toUpperCase() + st.slice(1);
+      if (fails > 0) tip += ' · ' + fails + ' fail' + (fails > 1 ? 's' : '');
+      if (warns > 0) tip += ' · ' + warns + ' warn' + (warns > 1 ? 's' : '');
+      if (hp.agents_running !== undefined) tip += ' · ' + hp.agents_running + ' running';
+      if (hp.stalled) tip += ' · ' + hp.stalled + ' stalled';
+      return '<span title="' + esc(tip) + '" style="display:inline-flex;align-items:center;gap:4px;cursor:help"><span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + c + '"></span><span style="font-size:0.7rem;color:' + c + ';font-weight:600">' + ic + '</span></span>';
+    }
     function dashboardLink(h) {
       var isHosted = h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'));
       if (isHosted) {
@@ -1810,6 +1826,7 @@ const dashboardHTML = `<!DOCTYPE html>
           '<td class="hive-menu-cell" style="position:relative;width:30px;text-align:center;overflow:visible"><span style="cursor:pointer;font-size:1.1rem;color:var(--muted);user-select:none">⋮</span><div class="hive-menu-dropdown" style="display:none;position:absolute;left:0;bottom:auto;background:#1c2128;border:1px solid #30363d;border-radius:8px;min-width:160px;padding:4px 0;z-index:1000;box-shadow:0 8px 24px rgba(0,0,0,0.5)">' + menuItems.join('') + '</div></td>' +
           '<td style="text-align:left;line-height:1.4">' + (function() { var dh = isHosted ? 'https://' + esc(h.id) + '.hive.kubestellar.io' : (h.dashboardUrl && !h.dashboardUrl.includes('localhost') ? esc(h.dashboardUrl) : ''); var displayName = h.name || h.id; var parts = displayName.split('/'); var orgName = parts.length > 1 ? parts[0] : ''; var repoName = parts.length > 1 ? parts.slice(1).join('/') : displayName; var rp = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : ''; var ghIcon = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>' : ''; var link = function(text, bold) { var s = bold ? 'font-weight:700;color:inherit' : 'color:#6b7280;font-weight:400'; return dh ? '<a href="' + dh + '" target="_blank" style="' + s + ';text-decoration:none">' + esc(text) + '</a>' : '<span style="' + s + '">' + esc(text) + '</span>'; }; var line1 = dot + ' ' + link(orgName || repoName, true); var line2 = orgName ? '<div style="padding-left:18px;font-size:0.8rem">' + link(repoName, false) + ' ' + ghIcon + ' ' + roleBadge(h.role) + '</div>' : '<div style="padding-left:18px">' + ghIcon + ' ' + roleBadge(h.role) + '</div>'; return line1 + line2; })() + '</td>' +
           '<td>' + typeBadge + '</td>' +
+          '<td>' + (h.online ? healthBadge(h) : '<span style="color:var(--muted);font-size:0.7rem">offline</span>') + '</td>' +
           '<td>' + (function() { var pub = !!h.isPublic; var tid = 'vis-' + esc(h.id); if (isHosted && h.role === 'owner') { return '<label style="position:relative;display:inline-block;width:36px;height:20px;cursor:pointer"><input type="checkbox" id="' + tid + '" ' + (pub ? 'checked' : '') + ' onchange="toggleVisibility(\'' + esc(h.id) + '\',this.checked)" style="opacity:0;width:0;height:0"><span style="position:absolute;inset:0;background:' + (pub ? 'var(--green)' : 'var(--border)') + ';border-radius:10px;transition:background 0.2s"></span><span style="position:absolute;top:2px;left:' + (pub ? '18px' : '2px') + ';width:16px;height:16px;background:#fff;border-radius:50%;transition:left 0.2s"></span></label>'; } if (isLocal) { var dh = h.dashboardUrl && !h.dashboardUrl.includes('localhost') ? h.dashboardUrl : ''; var badge = pub ? '<span style="color:var(--green)">Public</span>' : '<span style="color:var(--muted)">Private</span>'; return dh ? '<a href="' + esc(dh) + '" target="_blank" title="Change in Governor Config → Hub tab" style="text-decoration:none;cursor:pointer">' + badge + ' <span style="font-size:0.6rem;color:var(--muted)">↗</span></a>' : badge; } return pub ? '<span style="color:var(--green)">✓</span>' : '<span style="color:var(--muted)">—</span>'; })() + '</td>' +
           '<td style="font-size:0.7rem;white-space:nowrap">' + versionCell + '</td>' +
           '<td>' + repoCount + '</td>' +
@@ -1823,7 +1840,7 @@ const dashboardHTML = `<!DOCTYPE html>
       }).join('');
       document.getElementById('hives-container').innerHTML =
         '<div class="table-wrap"><table class="hive-table"><thead><tr>' +
-        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'hiveType\')" style="cursor:pointer">Type ⇅</th><th>Public</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th>' +
+        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'hiveType\')" style="cursor:pointer">Type ⇅</th><th>Health</th><th>Public</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table></div>';
       setTimeout(function() {
         var tw = document.querySelector('.table-wrap');


### PR DESCRIPTION
## Summary
- Add `HealthSummary()` method on dashboard `Server` — runs compact deep health checks (readiness, GitHub auth, agent state, stall detection, token consumption) and returns a status map
- Wire into heartbeat collector so each spoke sends health summary to hub every heartbeat cycle (replaces the previous empty `Health: map[string]any{}`)
- Add a **Health** column to the My Hives table in hive hub — colored dot (green/yellow/red) with tooltip showing fail/warn counts, running agents, and stalled agents. Offline hives show "offline"

No extra HTTP calls — health rides the existing heartbeat payload.

## Files changed
- `v2/cmd/hive/main.go` — call `dashSrv.HealthSummary()` in heartbeat collector
- `v2/pkg/dashboard/server.go` — add `HealthSummary()` method (76 lines)
- `v2/pkg/hub/saas.go` — add `healthBadge()` JS function + Health column in table

## Test plan
- [ ] Deploy spoke, verify heartbeat payload includes `health.status`, `health.fails`, `health.warns`
- [ ] Check My Hives table shows green dot for healthy hives
- [ ] Stop GitHub auth on a spoke, verify hub shows yellow/red health
- [ ] Take a spoke offline, verify "offline" text appears