### PR TITLE
fix: kick all eligible agents immediately on startup

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -993,6 +993,8 @@ func main() {
 		return
 	}
 
+	gov.ClearLastKicks()
+	logger.Info("cleared last kicks for startup — all eligible agents will be kicked on first eval")
 	runEvalCycle(ctx, cfg, ghClient, gov, sched, agentMgr, dashSrv, notifier, beadStores, tokenCollector, metricsCollector, nousState, &lastActionable, advisoryStore, advisoryIssues, &userGHClient, nil, logger)
 	persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
 

--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -453,6 +453,15 @@ func (g *Governor) SeedLastKicks(kicks map[string]time.Time) {
 	}
 }
 
+// ClearLastKicks resets all LastKick timestamps so every agent is "due"
+// on the next eval cycle. Paused and on-demand agents are still skipped
+// by agentsDueForKick() — this just clears the timing gate.
+func (g *Governor) ClearLastKicks() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.state.LastKick = make(map[string]time.Time)
+}
+
 func (g *Governor) SeedKickHistory(records []KickRecord) {
 	g.mu.Lock()
 	defer g.mu.Unlock()


### PR DESCRIPTION
## Summary
- Add `ClearLastKicks()` on Governor — wipes persisted LastKick timestamps
- Call it before the first eval cycle on startup
- Ensures all non-paused, non-on-demand agents are "due" and get kicked immediately with fully substituted templates

## Root cause
On restart, `SeedLastKicks()` restores old timestamps from the state file. The governor thinks agents were recently kicked and waits for the cadence interval to expire before the next kick.

## Test plan
- [ ] Restart a hive, verify scanner gets kicked within 10s instead of waiting for cadence interval
- [ ] Verify paused and on-demand agents are NOT kicked