### PR TITLE
fix: stream git pack data through MITM proxy instead of buffering

### DIFF
--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -527,6 +527,23 @@ func (p *GitHubProxy) proxyHTTP(client net.Conn, upstream net.Conn, agentName st
 			continue
 		}
 
+		// Git smart HTTP uses chunked streaming that http.ReadResponse
+		// can't handle reliably. After the ACMM check passes, forward
+		// the request and switch to raw bidirectional streaming.
+		if isGitPath(req.URL.Path) {
+			if err := req.Write(upstream); err != nil {
+				return
+			}
+			done := make(chan struct{})
+			go func() {
+				io.Copy(upstream, client)
+				close(done)
+			}()
+			io.Copy(client, upstream)
+			<-done
+			return
+		}
+
 		// Forward to upstream.
 		if err := req.Write(upstream); err != nil {
 			return
@@ -552,6 +569,12 @@ func (p *GitHubProxy) recordViolation(agentName, method, path string) {
 	if _, exists := p.violations[agentName]; exists || len(p.violations) < maxViolationLog {
 		p.violations[agentName]++
 	}
+}
+
+func isGitPath(path string) bool {
+	return strings.HasSuffix(path, "/git-receive-pack") ||
+		strings.HasSuffix(path, "/git-upload-pack") ||
+		strings.HasSuffix(path, "/info/refs")
 }
 
 // tunnelDirect creates a raw TCP tunnel for non-GitHub CONNECT requests.


### PR DESCRIPTION
## Summary
- Git push hangs through the MITM proxy because `http.ReadResponse` can't handle git's chunked streaming protocol
- Detect git paths (`git-receive-pack`, `git-upload-pack`, `info/refs`) after ACMM mode check passes
- Switch to raw bidirectional `io.Copy` streaming for git traffic instead of request/response buffering
- ACMM enforcement still runs — `git-receive-pack` blocked for read-only modes

## Root cause
The proxy's `proxyHTTP` reads full HTTP request/response pairs. Git smart HTTP uses `Transfer-Encoding: chunked` with streaming pack data that doesn't fit this model. `http.ReadResponse` blocks waiting for the complete response body, causing git push to hang indefinitely.

## Test plan
- [ ] Deploy to console hive, exec into container as scanner user
- [ ] `cd /tmp/scanner-fix-typed-nil && git push origin scanner/fix-typed-nil-event` should complete in seconds
- [ ] Verify ACMM mode enforcement still blocks unauthorized pushes
- [ ] Verify regular API calls (REST/GraphQL) still work normally