### PR TITLE
fix: truncate advisory digest to fit GitHub comment limit

### DIFF
--- a/v2/pkg/github/advisory.go
+++ b/v2/pkg/github/advisory.go
@@ -69,12 +69,18 @@ func (c *Client) EnsureAdvisoryIssue(ctx context.Context, repo string) (int, err
 	return issue.GetNumber(), nil
 }
 
-const advisoryDigestPrefix = "## 🐝 Advisory Digest"
+const (
+	advisoryDigestPrefix    = "## 🐝 Advisory Digest"
+	githubCommentCharLimit  = 65536
+	truncationFooterPadding = 200
+)
 
 // PostAdvisoryDigest updates the existing digest comment on the advisory issue,
 // or creates one if none exists. This prevents duplicate comments on each eval cycle.
 func (c *Client) PostAdvisoryDigest(ctx context.Context, repo string, issueNum int, digest string) error {
 	owner, repoName := c.splitRepo(repo)
+
+	digest = truncateDigest(digest)
 
 	commentID, err := c.findDigestComment(ctx, owner, repoName, issueNum)
 	if err != nil {
@@ -98,6 +104,18 @@ func (c *Client) PostAdvisoryDigest(ctx context.Context, repo string, issueNum i
 		return fmt.Errorf("posting advisory digest to %s#%d: %w", repo, issueNum, err)
 	}
 	return nil
+}
+
+func truncateDigest(digest string) string {
+	if len(digest) <= githubCommentCharLimit {
+		return digest
+	}
+	cutoff := githubCommentCharLimit - truncationFooterPadding
+	lastNewline := strings.LastIndex(digest[:cutoff], "\n")
+	if lastNewline > 0 {
+		cutoff = lastNewline
+	}
+	return digest[:cutoff] + fmt.Sprintf("\n\n---\n⚠️ *Digest truncated: %d → %d characters (GitHub limit: %d)*\n", len(digest), cutoff, githubCommentCharLimit)
 }
 
 func (c *Client) findDigestComment(ctx context.Context, owner, repo string, issueNum int) (int, error) {


### PR DESCRIPTION
## Summary
- Bug #159: Advisory digest with 622 findings exceeded GitHub's 65,536 character limit, causing 422 error
- Truncates at last newline before limit, appends footer showing original vs truncated size
- No findings are lost — they're still in the in-memory digest, just the GitHub comment is trimmed

## Test plan
- [ ] Deploy to test server and verify digest comment posts successfully
- [ ] Verify truncation footer appears when digest exceeds limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)