### PR TITLE
fix: filter template placeholders + reduce question fallback to 30s

### DIFF
--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -26,7 +26,7 @@ const (
 	targetFactCount              = 8
 	factEnrichmentGracePeriod    = 15 * time.Second
 	autoFactFallbackTimeout      = 60 * time.Second
-	autoQuestionFallbackTimeout  = 60 * time.Second
+	autoQuestionFallbackTimeout  = 30 * time.Second
 )
 
 // InceptionWatcher polls brainstorm beads and bridges them into the inception

--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -1264,6 +1264,26 @@ func (w *InceptionWatcher) interceptQuestionsFromBuffer(state *knowledge.Incepti
 // bdCreateTitleRe extracts the --title value from a bd create command line.
 var bdCreateTitleRe = regexp.MustCompile(`--title\s+"([^"]+)"`)
 
+// isTemplatePlaceholder rejects placeholder titles that the agent outputs
+// as part of showing a command template before filling in actual values.
+func isTemplatePlaceholder(title string) bool {
+	lower := strings.ToLower(title)
+	if strings.HasPrefix(lower, "<") && strings.HasSuffix(lower, ">") {
+		return true
+	}
+	placeholders := []string{
+		"<fact title>", "<question title>", "<title>",
+		"<your question>", "<description>", "<bead title>",
+		"fact_title", "question_title", "your question here",
+	}
+	for _, p := range placeholders {
+		if lower == p {
+			return true
+		}
+	}
+	return false
+}
+
 // parseQuestionFromBdCreate extracts a question from a bd create command
 // in the agent's raw output. Works regardless of --type, --actor, or
 // --external-ref values — the title IS the question.
@@ -1274,6 +1294,9 @@ func (w *InceptionWatcher) parseQuestionFromBdCreate(line string) *knowledge.Que
 	}
 	title := strings.TrimSpace(m[1])
 	if title == "" {
+		return nil
+	}
+	if isTemplatePlaceholder(title) {
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
- Bug #160: Buffer interceptor captured `<fact title>` from kick prompt templates, not real agent output
- Adds `isTemplatePlaceholder()` filter to reject placeholder titles (`<fact title>`, `<question title>`, etc.)
- Reduces auto-question fallback from 60s to 30s — Copilot CLI TUI doesn't echo to tmux buffer, so buffer interception never catches real questions. Saves ~30s per lifecycle.

## Test plan
- [ ] Verify no more `<fact title>` entries in intercepted question logs
- [ ] Verify lifecycle time drops by ~30s with the shorter fallback
- [ ] Verify pass rate stays at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)