### PR TITLE
perf: reduce auto-fact fallback timeout from 60s to 30s

### DIFF
--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -25,7 +25,7 @@ const (
 	minFactsForAdvance           = 3
 	targetFactCount              = 8
 	factEnrichmentGracePeriod    = 15 * time.Second
-	autoFactFallbackTimeout      = 60 * time.Second
+	autoFactFallbackTimeout      = 30 * time.Second
 	autoQuestionFallbackTimeout  = 30 * time.Second
 )
 


### PR DESCRIPTION
## Summary
- Auto-fact fallback waited 60s before generating facts from Q&A answers
- Both bead-based facts (3-4) + supplementation and Q&A-derived facts (7) produce similar quality
- 15s grace period gives agent first shot; 30s total is enough before Q&A fallback fires
- Combined with question timeout reduction (60→30s), should cut ~60s from lifecycle time

## Test plan
- [ ] Run 20-run lifecycle test — expect ~100-110s avg (was ~160s)
- [ ] Verify 7-8 wiki_facts still produced
- [ ] Verify 100% pass rate maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)