### PR TITLE
fix: sanitize zip file paths in scaffold download

### DIFF
--- a/v2/pkg/dashboard/inception_handlers.go
+++ b/v2/pkg/dashboard/inception_handlers.go
@@ -313,7 +313,11 @@ func (s *Server) handleInceptionDownload(w http.ResponseWriter, r *http.Request)
 	defer zw.Close()
 
 	for _, f := range result.Files {
-		fw, err := zw.Create(f.Path)
+		clean := filepath.Clean(f.Path)
+		if strings.HasPrefix(clean, "..") || filepath.IsAbs(clean) {
+			continue
+		}
+		fw, err := zw.Create(filepath.ToSlash(clean))
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
## Summary
- Bug #164: Scaffold download wrote file paths directly into zip entries without sanitization
- Adds path traversal defense: rejects `..` prefixed and absolute paths, normalizes with `filepath.Clean`
- Defense-in-depth — paths are internally generated but should be sanitized at the boundary

## Test plan
- [ ] Download scaffold zip and verify paths are clean
- [ ] Verify no regression in file count

🤖 Generated with [Claude Code](https://claude.com/claude-code)