### PR TITLE
fix: use engine WikiDir() instead of hardcoded path in import

### DIFF
--- a/v2/pkg/dashboard/inception_handlers.go
+++ b/v2/pkg/dashboard/inception_handlers.go
@@ -396,7 +396,7 @@ func (s *Server) handleInceptionImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	wikiDir := "/data/inception-wiki"
+	wikiDir := s.deps.Inception.WikiDir()
 	os.MkdirAll(wikiDir, 0o755)
 
 	imported := 0

--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -692,6 +692,10 @@ func (e *InceptionEngine) IncrementAutoQuestionCount(count int) {
 }
 
 // HasWikiFiles returns true if the inception wiki has any files from a previous run.
+func (e *InceptionEngine) WikiDir() string {
+	return filepath.Join(e.dataDir, inceptionWikiDir)
+}
+
 func (e *InceptionEngine) HasWikiFiles() bool {
 	wikiDir := filepath.Join(e.dataDir, inceptionWikiDir)
 	entries, err := os.ReadDir(wikiDir)


### PR DESCRIPTION
## Summary
- Bug #165: Import handler hardcoded `/data/inception-wiki` path
- Added `WikiDir()` method to `InceptionEngine` to expose the configured wiki directory
- Handler now uses the engine's path, consistent with all other wiki operations

## Test plan
- [ ] Verify import still works with default `/data` dataDir
- [ ] Verify wiki files are written to correct location

🤖 Generated with [Claude Code](https://claude.com/claude-code)