### PR TITLE
fix: use WikiDir() in rename handler instead of hardcoded path

### DIFF
--- a/v2/pkg/dashboard/inception_handlers.go
+++ b/v2/pkg/dashboard/inception_handlers.go
@@ -352,7 +352,7 @@ func (s *Server) handleInceptionRenameWiki(w http.ResponseWriter, r *http.Reques
 		jsonError(w, "knowledge not initialized", http.StatusServiceUnavailable)
 		return
 	}
-	store := s.deps.Knowledge.GetVaultStore("/data/inception-wiki")
+	store := s.deps.Knowledge.GetVaultStore(s.deps.Inception.WikiDir())
 	if store == nil {
 		jsonError(w, "inception wiki vault not found", http.StatusNotFound)
 		return


### PR DESCRIPTION
## Summary
- Bug #166: `handleInceptionRenameWiki` had the same hardcoded `/data/inception-wiki` path as bug #165
- Uses `WikiDir()` for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)