### PR TITLE
fix: scanner should merge any PR with green CI at L6

### DIFF
--- a/v2/pkg/policies/defaults/scanner-automerge.md
+++ b/v2/pkg/policies/defaults/scanner-automerge.md
@@ -7,7 +7,7 @@ You are the **scanner** agent in a Hive instance operating in **ISSUES_PRS_MERGE
 ## Rules
 
 1. **ONLY work items from the kick message** — never run `gh issue list` or `gh pr list` unprompted
-2. **Merge your own PRs when CI passes** — only merge PRs you opened in this session; never merge others'
+2. **Merge any PR with green CI** — your own, dependabot, other agents', or community PRs. Review the diff, confirm CI passes, then merge with `--squash --admin`
 3. **NEVER merge a PR with failing required checks** — wait for green CI before merging
 4. **Create GitHub issues for findings** — every confirmed bug gets an issue
 5. **Create PRs for concrete fixes** and merge them when CI passes

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -414,7 +414,7 @@ func (s *Scheduler) buildScannerMessage(issues []github.Issue, actionable *githu
 	}
 
 	b.WriteString("\n⛔ NEVER run gh issue list, gh pr list, gh search issues — the work list above is your ONLY source.\n")
-	b.WriteString("⛔ MERGE DISCIPLINE: Only merge PRs listed in MERGE-READY section. Never merge a PR you created this session.\n")
+	b.WriteString("MERGE DISCIPLINE: Review and merge ANY PR with green CI — your own, dependabot, other agents', or community PRs. Use `--squash --admin`. Prioritize dependabot and small PRs first for quick wins.\n")
 	b.WriteString("WORKFLOW: Dispatch sub-agents for each issue (Agent tool). 4-6 agents IN PARALLEL.\n")
 
 	return b.String()


### PR DESCRIPTION
## Summary
- Scanner at ACMM L6 was restricted to merging only its own PRs
- 37 dependabot, 8 outreach, 8 sec-check PRs sitting unmerged
- Update policy: merge ANY PR with green CI (dependabot, agents, community)
- Prioritize dependabot and small PRs first for quick wins

## Test plan
- [ ] Deploy to console hive, watch scanner merge dependabot PRs