### PR TITLE
fix: add cobra to go.mod + sanitize multiline scaffold descriptions

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -1433,13 +1433,18 @@ func buildGitignore(lang string) string {
 }
 
 func buildGoMod(name string) string {
-	return fmt.Sprintf("module %s\n\ngo 1.23\n", name)
+	return fmt.Sprintf(`module %s
+
+go 1.23
+
+require github.com/spf13/cobra v1.8.1
+`, name)
 }
 
 func buildGoMain(name string, vision *Fact) string {
-	desc := name
+	desc := singleLine(name)
 	if vision != nil {
-		desc = vision.Title
+		desc = singleLine(vision.Title)
 	}
 	return fmt.Sprintf(`package main
 
@@ -1453,9 +1458,9 @@ func main() {
 }
 
 func buildGoCmdRoot(name string, vision *Fact) string {
-	desc := name
+	desc := singleLine(name)
 	if vision != nil {
-		desc = vision.Title
+		desc = singleLine(vision.Title)
 	}
 	return fmt.Sprintf(`package cmd
 
@@ -2063,6 +2068,12 @@ func xmlEscape(s string) string {
 	s = strings.ReplaceAll(s, ">", "&gt;")
 	s = strings.ReplaceAll(s, `"`, "&quot;")
 	return s
+}
+
+func singleLine(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", "")
+	return strings.TrimSpace(s)
 }
 
 func tomlEscape(s string) string {


### PR DESCRIPTION
## Summary
- Bug #179: go.mod missing `require github.com/spf13/cobra` — `go build` fails on scaffolded projects
- Bug #180: Go comments and cobra `Short` field inject user text without newline sanitization
- Added `singleLine()` helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)