### PR TITLE
fix: sanitize multiline text in shell scaffold comment

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -1105,12 +1105,9 @@ func buildJavaTestStubs(acceptance []Fact) string {
 }
 
 func buildShellMain(name string, vision *Fact) string {
-	desc := name
-	if vision != nil && vision.Body != "" {
-		desc = vision.Body
-		if len(desc) > maxDescriptionLen {
-			desc = desc[:maxDescriptionLen]
-		}
+	desc := singleLine(name)
+	if vision != nil && vision.Title != "" {
+		desc = singleLine(vision.Title)
 	}
 	return fmt.Sprintf(`#!/usr/bin/env bash
 set -euo pipefail


### PR DESCRIPTION
## Summary
- Bug #182: Last remaining scaffold builder using `vision.Body` in single-line comment
- Changed to `vision.Title` + `singleLine()`, completing the series from #1366 and #1367

🤖 Generated with [Claude Code](https://claude.com/claude-code)