### PR TITLE
fix: clear inception beads on explicit reset

### DIFF
--- a/v2/pkg/dashboard/inception_handlers.go
+++ b/v2/pkg/dashboard/inception_handlers.go
@@ -245,7 +245,10 @@ func (s *Server) handleInceptionReset(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Re-pause brainstorm after reset so the governor doesn't kick it.
+	if store, ok := s.deps.BeadStores["brainstorm"]; ok {
+		s.clearInceptionBeads(store)
+	}
+
 	if s.deps.AgentMgr != nil {
 		_ = s.deps.AgentMgr.Pause("brainstorm", "inception-reset", "inception reset — on-demand only")
 	}


### PR DESCRIPTION
## Summary
- Bug #188: `handleInceptionReset` didn't clear brainstorm beads — stale beads from previous inception could leak into next run
- `handleInceptionStart` with `force:true` already cleared beads — now explicit `/api/inception/reset` does too

🤖 Generated with [Claude Code](https://claude.com/claude-code)