### PR TITLE
fix: quote fact titles in YAML frontmatter

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -356,7 +356,7 @@ func (e *InceptionEngine) writeFactsToVault(facts []IdeationFact) {
 
 		var content strings.Builder
 		content.WriteString("---\n")
-		fmt.Fprintf(&content, "title: %s\n", f.Title)
+		fmt.Fprintf(&content, "title: \"%s\"\n", strings.ReplaceAll(f.Title, `"`, `\"`))
 		fmt.Fprintf(&content, "type: %s\n", string(f.Type))
 		fmt.Fprintf(&content, "confidence: %.2f\n", conf)
 		if len(tags) > 0 {
@@ -858,6 +858,8 @@ func parseInceptionFactFile(content, filename string) (title, body, factType str
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "title:") {
 			title = strings.TrimSpace(strings.TrimPrefix(line, "title:"))
+			title = strings.Trim(title, `"`)
+			title = strings.ReplaceAll(title, `\"`, `"`)
 		}
 		if strings.HasPrefix(line, "type:") {
 			factType = strings.TrimSpace(strings.TrimPrefix(line, "type:"))


### PR DESCRIPTION
## Summary
- Bug #189: Fact titles with colons break YAML frontmatter parsing (colon interpreted as nested key)
- Wraps title in double quotes with `\"` escaping
- Updated parser to strip quotes and unescape on read-back

🤖 Generated with [Claude Code](https://claude.com/claude-code)