### PR TITLE
fix: use rune-aware chunking in SendKick to preserve UTF-8

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1345,16 +1345,17 @@ func (m *Manager) SendKick(name string, message string) error {
 		time.Sleep(clearBeforeKickDelay)
 	}
 
-	// Send message in chunks (old hive pattern: 400 char max per chunk)
-	if len(message) <= chunkSize {
+	// Send message in chunks (400 rune max per chunk, rune-safe)
+	runes := []rune(message)
+	if len(runes) <= chunkSize {
 		m.tmuxSendLiteralForAgent(agent, message)
 	} else {
-		for offset := 0; offset < len(message); offset += chunkSize {
+		for offset := 0; offset < len(runes); offset += chunkSize {
 			end := offset + chunkSize
-			if end > len(message) {
-				end = len(message)
+			if end > len(runes) {
+				end = len(runes)
 			}
-			m.tmuxSendLiteralForAgent(agent, message[offset:end])
+			m.tmuxSendLiteralForAgent(agent, string(runes[offset:end]))
 			time.Sleep(chunkDelay)
 		}
 	}


### PR DESCRIPTION
## Summary
- Bug #190: SendKick chunked messages at byte boundaries, splitting multi-byte UTF-8 characters
- Converted to `[]rune` slicing — each chunk is a valid UTF-8 string

🤖 Generated with [Claude Code](https://claude.com/claude-code)