### PR TITLE
fix: inferFactType returns empty for unrecognized titles

### DIFF
--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -244,7 +244,7 @@ func inferFactType(title string) string {
 	case strings.Contains(lower, "acceptance") || strings.Contains(lower, "success") || strings.Contains(lower, "criteria") || strings.Contains(lower, "test"):
 		return "acceptance"
 	}
-	return "requirement"
+	return ""
 }
 
 func (w *InceptionWatcher) findInceptionBeads() []*beads.Bead {


### PR DESCRIPTION
Bug #193: Default 'requirement' for unmatched titles inflated fact count with irrelevant beads. Changed to empty string — caller already skips.