### PR TITLE
fix: constraint check must precede requirement in inferFactType

### DIFF
--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -235,10 +235,11 @@ func inferFactType(title string) string {
 		return "vision"
 	case strings.Contains(lower, "constitution") || strings.Contains(lower, "principles") || strings.Contains(lower, "code style") || strings.Contains(lower, "architecture"):
 		return "constitution"
+	case strings.Contains(lower, "constraint") || strings.Contains(lower, "boundary") || strings.Contains(lower, "limitation") ||
+		strings.Contains(lower, "must not") || strings.Contains(lower, "should not") || strings.Contains(lower, "do not"):
+		return "constraint"
 	case strings.Contains(lower, "requirement") || strings.Contains(lower, "must") || strings.Contains(lower, "feature"):
 		return "requirement"
-	case strings.Contains(lower, "constraint") || strings.Contains(lower, "boundary") || strings.Contains(lower, "limitation") || strings.Contains(lower, "must not"):
-		return "constraint"
 	case strings.Contains(lower, "stakeholder") || strings.Contains(lower, "user") || strings.Contains(lower, "audience"):
 		return "stakeholder"
 	case strings.Contains(lower, "acceptance") || strings.Contains(lower, "success") || strings.Contains(lower, "criteria") || strings.Contains(lower, "test"):


### PR DESCRIPTION
Bug #194: 'must not' in constraint case was dead code — 'must' in requirement case always matched first. Reordered and added 'should not'/'do not' patterns.