### PR TITLE
fix: autoGenerateFacts fails in brownfield mode (empty IdeaText)

### DIFF
--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -1016,13 +1016,19 @@ func (w *InceptionWatcher) autoGenerateFacts(ctx context.Context, state *knowled
 
 	var facts []knowledge.IdeationFact
 
-	// Vision fact from the idea text
-	facts = append(facts, knowledge.IdeationFact{
-		Title: "Project Vision",
-		Body:  state.IdeaText,
-		Type:  knowledge.FactVision,
-		Tags:  []string{"auto-generated"},
-	})
+	// Vision fact from the idea text (greenfield) or repo URL (brownfield)
+	visionBody := state.IdeaText
+	if visionBody == "" && state.RepoURL != "" {
+		visionBody = "Brownfield project from " + state.RepoURL
+	}
+	if visionBody != "" {
+		facts = append(facts, knowledge.IdeationFact{
+			Title: "Project Vision",
+			Body:  visionBody,
+			Type:  knowledge.FactVision,
+			Tags:  []string{"auto-generated"},
+		})
+	}
 
 	// Map question categories to fact types
 	categoryToFact := map[string]knowledge.FactType{


### PR DESCRIPTION
## Summary
- Bug #195: `autoGenerateFacts` created a vision fact with empty body in brownfield mode (no IdeaText)
- `RecordFacts` rejects empty bodies — the entire fallback silently failed
- Fix: use RepoURL as vision body fallback, skip vision fact if both empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)