### PR TITLE
fix: repoBaseName returns empty for URLs with trailing slash

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -2115,12 +2115,15 @@ func truncateSlug(s string) string {
 }
 
 func repoBaseName(url string) string {
+	url = strings.TrimSuffix(url, "/")
 	url = strings.TrimSuffix(url, ".git")
 	parts := strings.Split(url, "/")
-	if len(parts) == 0 {
-		return "repo"
+	for i := len(parts) - 1; i >= 0; i-- {
+		if parts[i] != "" {
+			return parts[i]
+		}
 	}
-	return parts[len(parts)-1]
+	return "repo"
 }
 
 func inferLanguage(constitution *Fact) string {


### PR DESCRIPTION
Bug #196: Trailing slash on repo URL caused empty wiki name and slug. Trim slash first, scan backwards for non-empty part.