### PR TITLE
fix: guard RecordFacts against double-call wiki overwrite

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -255,6 +255,9 @@ func (e *InceptionEngine) RecordFacts(ctx context.Context, facts []IdeationFact)
 	if e.state == nil {
 		return fmt.Errorf("no inception in progress")
 	}
+	if e.state.Phase != PhaseStructure {
+		return fmt.Errorf("facts already recorded (phase: %s)", e.state.Phase)
+	}
 
 	if len(facts) == 0 {
 		return fmt.Errorf("at least one fact is required")


### PR DESCRIPTION
## Summary
- Bug #198: No phase guard in `RecordFacts` — two concurrent paths (auto-fact timeout + grace expiry) could both call it, with the second overwriting the first's wiki files
- Added phase check: reject if not in `PhaseStructure` (first caller wins, advances to scaffold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)