### PR TITLE
feat: add fix-blockers step to scanner workflow

### DIFF
--- a/v2/pkg/policies/defaults/scanner-automerge.md
+++ b/v2/pkg/policies/defaults/scanner-automerge.md
@@ -66,12 +66,14 @@ ${PR_LIST}
 
 ## Workflow
 
-1. Read the work list above
-2. **Reap stale findings** — re-verify open beads and close resolved ones
-3. Analyze root cause for each issue; dispatch sub-agents in parallel (4-6 at a time)
-4. Create a GitHub issue for each confirmed finding
-5. Create a PR for each fix; poll CI; merge when green
-6. Create a bead for each finding
-7. Summarize completed work including merged PRs
+1. Read the work list above and check open beads (`bd list --status open`) for context from previous cycles
+2. **Quick merges (10 min cap)** — scan PRs for green CI, merge with `--squash --admin`. Skip PRs with merge conflicts or failing checks. Comment `@dependabot rebase` on stale dependabot PRs. Move on after 10 minutes regardless.
+3. **Fix blockers** — identify the single highest-leverage fix that unblocks the most PRs or issues (e.g. a shared test helper signature change, a broken import, a missing dependency). Clone, fix, push, open PR, poll CI, merge. One fix that unblocks many is worth more than many small fixes.
+4. **Reap stale findings** — re-verify open beads and close resolved ones
+5. Analyze root cause for remaining issues; dispatch sub-agents in parallel (4-6 at a time)
+6. Create a GitHub issue for each confirmed finding
+7. Create a PR for each fix; poll CI; merge when green
+8. Create a bead for each finding
+9. Summarize completed work including merged PRs
 
 ${KNOWLEDGE}

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -415,7 +415,11 @@ func (s *Scheduler) buildScannerMessage(issues []github.Issue, actionable *githu
 
 	b.WriteString("\n⛔ NEVER run gh issue list, gh pr list, gh search issues — the work list above is your ONLY source.\n")
 	b.WriteString("MERGE DISCIPLINE: Review and merge ANY PR with green CI — your own, dependabot, other agents', or community PRs. Use `--squash --admin`. Prioritize dependabot and small PRs first for quick wins.\n")
-	b.WriteString("WORKFLOW: Dispatch sub-agents for each issue (Agent tool). 4-6 agents IN PARALLEL.\n")
+	b.WriteString("WORKFLOW:\n")
+	b.WriteString("  1. Check beads (`bd list --status open`) for context from previous cycles\n")
+	b.WriteString("  2. Quick merges (10 min cap) — merge green PRs, `@dependabot rebase` stale ones, then MOVE ON\n")
+	b.WriteString("  3. Fix blockers — find the ONE fix that unblocks the most PRs/issues (broken test helper, missing import, etc). Clone, fix, push, merge.\n")
+	b.WriteString("  4. Work issues — dispatch sub-agents for remaining issues (Agent tool). 4-6 agents IN PARALLEL.\n")
 
 	return b.String()
 }


### PR DESCRIPTION
## Summary
- Add structured workflow: beads check → quick merges (10 min cap) → fix blockers → work issues
- Prevents scanner from spending entire cycles on merge triage
- "Fix blockers" step: find the ONE fix that unblocks the most PRs

## Test plan
- [ ] Deploy, watch scanner cycle — should merge green PRs quickly, then fix a blocker