### PR TITLE
fix: use /fleet for parallel sub-agents in scanner

### DIFF
--- a/v2/pkg/policies/defaults/scanner-automerge.md
+++ b/v2/pkg/policies/defaults/scanner-automerge.md
@@ -70,7 +70,7 @@ ${PR_LIST}
 2. **Quick merges (10 min cap)** — scan PRs for green CI, merge with `--squash --admin`. Skip PRs with merge conflicts or failing checks. Comment `@dependabot rebase` on stale dependabot PRs. Move on after 10 minutes regardless.
 3. **Fix blockers** — identify the single highest-leverage fix that unblocks the most PRs or issues (e.g. a shared test helper signature change, a broken import, a missing dependency). Clone, fix, push, open PR, poll CI, merge. One fix that unblocks many is worth more than many small fixes.
 4. **Reap stale findings** — re-verify open beads and close resolved ones
-5. Analyze root cause for remaining issues; dispatch sub-agents in parallel (4-6 at a time)
+5. Analyze root cause for remaining issues; use `/fleet` to dispatch sub-agents in parallel (4-6 at a time)
 6. Create a GitHub issue for each confirmed finding
 7. Create a PR for each fix; poll CI; merge when green
 8. Create a bead for each finding

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -419,7 +419,7 @@ func (s *Scheduler) buildScannerMessage(issues []github.Issue, actionable *githu
 	b.WriteString("  1. Check beads (`bd list --status open`) for context from previous cycles\n")
 	b.WriteString("  2. Quick merges (10 min cap) — merge green PRs, `@dependabot rebase` stale ones, then MOVE ON\n")
 	b.WriteString("  3. Fix blockers — find the ONE fix that unblocks the most PRs/issues (broken test helper, missing import, etc). Clone, fix, push, merge.\n")
-	b.WriteString("  4. Work issues — dispatch sub-agents for remaining issues (Agent tool). 4-6 agents IN PARALLEL.\n")
+	b.WriteString("  4. Work issues — use `/fleet` to dispatch sub-agents for remaining issues. 4-6 agents IN PARALLEL.\n")
 
 	return b.String()
 }


### PR DESCRIPTION
Copilot CLI uses /fleet for parallel sub-agent dispatch, not Agent tool.