### PR TITLE
fix: toSnakeCase/toPascalCase return fallback for empty input

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -2190,6 +2190,9 @@ func toPascalCase(s string) string {
 		}
 		b.WriteString(strings.ToUpper(w[:1]) + w[1:])
 	}
+	if b.Len() == 0 {
+		return "Unnamed"
+	}
 	return b.String()
 }
 
@@ -2207,5 +2210,9 @@ func toSnakeCase(s string) string {
 			filtered = append(filtered, w)
 		}
 	}
-	return strings.Join(filtered, "_")
+	result := strings.Join(filtered, "_")
+	if result == "" {
+		return "unnamed"
+	}
+	return result
 }


### PR DESCRIPTION
Bug #207: All-special-char titles produced empty function names in test stubs, breaking syntax. Returns 'unnamed'/'Unnamed' as fallback.