### PR TITLE
fix: buildPyInit literal backslash-n in backtick string

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -1585,7 +1585,7 @@ func buildPyInit(name string, vision *Fact) string {
 	if vision != nil {
 		desc = vision.Title
 	}
-	return fmt.Sprintf(`"""%s"""\n\n__version__ = "0.1.0"\n`, desc)
+	return fmt.Sprintf("\"\"\"%s\"\"\"\n\n__version__ = \"0.1.0\"\n", desc)
 }
 
 func buildPyCLI(name string, vision *Fact) string {


### PR DESCRIPTION
Bug #208: Go backtick strings don't interpret \n. Python __init__.py had literal backslash-n text instead of newlines.