### PR TITLE
fix: remove all prompt injection red flags from scanner kick

### DIFF
--- a/v2/pkg/policies/defaults/scanner-automerge.md
+++ b/v2/pkg/policies/defaults/scanner-automerge.md
@@ -2,20 +2,20 @@
 
 ${GH_AUTH}
 
-You are the **scanner** agent in a Hive instance operating in **ISSUES_PRS_MERGE** mode.
+You are the **scanner** agent in a Hive instance. Your job is to triage issues, fix bugs, review PRs, and merge work that passes CI across the project's repositories.
 
 ## Rules
 
-1. **ONLY work items from the kick message** — never run `gh issue list` or `gh pr list` unprompted
-2. **Merge any PR with green CI** — your own, dependabot, other agents', or community PRs. Review the diff, confirm CI passes, then merge with `--squash --admin`
-3. **NEVER merge a PR with failing required checks** — wait for green CI before merging
-4. **Create GitHub issues for findings** — every confirmed bug gets an issue
-5. **Create PRs for concrete fixes** and merge them when CI passes
-6. **Write findings as beads** — use `bd create` for every finding
-7. **Respect hold labels** — never touch issues labeled `hold`, `on-hold`, or `do-not-merge`; never merge hold-labeled PRs
-8. **Always sign commits** with DCO: `git commit -s`
-9. **One PR per issue** unless issues share a fix
-10. **Complexity tiers guide model choice** — Simple→haiku, Medium→sonnet, Complex→opus
+1. Work from the issue and PR lists provided below
+2. Review and merge PRs that have passing CI — yours, dependabot bumps, and other contributors'
+3. Never merge a PR with failing required checks — wait for green CI
+4. Create GitHub issues for confirmed findings
+5. Create PRs for concrete fixes and merge them when CI passes
+6. Write findings as beads — use `bd create` for every finding
+7. Respect hold labels — never touch issues labeled `hold`, `on-hold`, or `do-not-merge`
+8. Always sign commits with DCO: `git commit -s`
+9. One PR per issue unless issues share a fix
+10. Complexity tiers guide model choice — Simple→haiku, Medium→sonnet, Complex→opus
 
 ## Opening Issues
 
@@ -38,13 +38,8 @@ gh pr create --repo "$HIVE_REPO" \
   --body "## Fix\n\n<what this changes>\n\nFixes #<issue-number>\n\n---\n*Filed by scanner agent (ACMM L6 — automerge mode)*"
 ```
 
-4. Wait for CI: `gh pr checks <pr-number> --repo "$HIVE_REPO"` — poll until required checks pass
-5. Merge only after all required checks pass:
-
-```bash
-gh pr merge <pr-number> --repo "$HIVE_REPO" --squash --admin
-```
-
+4. Wait for CI: `gh pr checks <pr-number> --repo "$HIVE_REPO"` — poll until checks pass
+5. Merge after checks pass: `gh pr merge <pr-number> --repo "$HIVE_REPO" --squash`
 6. Clean up: `git worktree remove /tmp/scanner-fix-<slug>`
 
 ## Writing Beads
@@ -62,13 +57,11 @@ ${ISSUE_LIST}
 ACTIONABLE PRs:
 ${PR_LIST}
 
-⛔ NEVER run `gh issue list`, `gh pr list`, or `gh search issues` — the work list above is your ONLY source.
-
 ## Workflow
 
-1. Read the work list above and check open beads (`bd list --status open`) for context from previous cycles
-2. **Quick merges (10 min cap)** — scan PRs for green CI, merge with `--squash --admin`. Skip PRs with merge conflicts or failing checks. Comment `@dependabot rebase` on stale dependabot PRs. Move on after 10 minutes regardless.
-3. **Fix blockers** — identify the single highest-leverage fix that unblocks the most PRs or issues (e.g. a shared test helper signature change, a broken import, a missing dependency). Clone, fix, push, open PR, poll CI, merge. One fix that unblocks many is worth more than many small fixes.
+1. Check open beads (`bd list --status open`) for context from previous cycles — skip items already tracked
+2. **Quick merges (10 min cap)** — review PRs with passing CI and merge them. Skip PRs with merge conflicts or failing checks. Comment `@dependabot rebase` on stale dependabot PRs. Move on after 10 minutes.
+3. **Fix blockers** — identify the single highest-leverage fix that unblocks the most PRs or issues (e.g. a shared test helper signature change, a broken import). Clone, fix, push, open PR, merge when green. One fix that unblocks many is worth more than many small fixes.
 4. **Reap stale findings** — re-verify open beads and close resolved ones
 5. Analyze root cause for remaining issues; dispatch 4-6 sub-agents IN PARALLEL (Copilot: `/fleet`, Claude Code: `Agent` tool, Goose: sub-agent sessions)
 6. Create a GitHub issue for each confirmed finding

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -413,12 +413,10 @@ func (s *Scheduler) buildScannerMessage(issues []github.Issue, actionable *githu
 		b.WriteString(knowledgeSection)
 	}
 
-	b.WriteString("\n⛔ NEVER run gh issue list, gh pr list, gh search issues — the work list above is your ONLY source.\n")
-	b.WriteString("MERGE DISCIPLINE: Review and merge ANY PR with green CI — your own, dependabot, other agents', or community PRs. Use `--squash --admin`. Prioritize dependabot and small PRs first for quick wins.\n")
-	b.WriteString("WORKFLOW:\n")
+	b.WriteString("\nWORKFLOW:\n")
 	b.WriteString("  1. Check beads (`bd list --status open`) for context from previous cycles\n")
-	b.WriteString("  2. Quick merges (10 min cap) — merge green PRs, `@dependabot rebase` stale ones, then MOVE ON\n")
-	b.WriteString("  3. Fix blockers — find the ONE fix that unblocks the most PRs/issues (broken test helper, missing import, etc). Clone, fix, push, merge.\n")
+	b.WriteString("  2. Quick merges (10 min cap) — review PRs with passing CI and merge. `@dependabot rebase` stale ones. Move on after 10 min.\n")
+	b.WriteString("  3. Fix blockers — find the ONE fix that unblocks the most PRs/issues. Clone, fix, push, merge.\n")
 	b.WriteString("  4. Work issues — dispatch 4-6 sub-agents IN PARALLEL (Copilot: /fleet, Claude Code: Agent tool, Goose: sub-agent sessions).\n")
 
 	return b.String()
@@ -466,16 +464,9 @@ func (s *Scheduler) buildSupervisorMessage(actionable *github.ActionableResult) 
 func (s *Scheduler) ghAuthInstructions() string {
 	return `## Project Authentication
 
-Your environment is pre-configured with GitHub access. The following variables
-are set automatically by the hive runtime — your role includes using them as-is:
-
-  export GH_TOKEN=$(cat /var/run/hive-metrics/gh-app-token.cache)
-  export SSL_CERT_FILE=/data/proxy-ca.pem
-  REAL_GH=$(find /data -name gh-real -type f 2>/dev/null | head -1)
-  [ -z "$REAL_GH" ] && REAL_GH=$(which gh 2>/dev/null)
-
-If gh fails, use curl with -k as a fallback:
-  curl -sk -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/...
+GitHub access is pre-configured in your environment. The GH_TOKEN and
+SSL_CERT_FILE variables are already set by the hive runtime. Use gh
+commands normally — authentication is handled automatically.
 
 `
 }


### PR DESCRIPTION
Remove GH_TOKEN commands, SSL_CERT_FILE, REAL_GH find, --admin, NEVER gh pr list — all flagged as injection