### PR TITLE
fix: escape quotes in cobra Short field

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -1465,6 +1465,7 @@ func buildGoCmdRoot(name string, vision *Fact) string {
 	if vision != nil {
 		desc = singleLine(vision.Title)
 	}
+	escapedDesc := strings.ReplaceAll(desc, `"`, `\"`)
 	return fmt.Sprintf(`package cmd
 
 import (
@@ -1488,7 +1489,7 @@ func Execute() {
 		os.Exit(1)
 	}
 }
-`, name, desc)
+`, name, escapedDesc)
 }
 
 func buildCargoToml(name string, vision *Fact) string {


### PR DESCRIPTION
Bug #211: Vision title with quotes breaks generated Go source in cobra command definition.