### PR TITLE
fix: Python CI missing ruff lint step

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -1271,6 +1271,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install -e ".[dev]"
+      - run: ruff check .
       - run: pytest
 `
 }


### PR DESCRIPTION
Bug #213: Python CI had pytest but no linting. Added 'ruff check .' to match Makefile lint target.