### PR TITLE
fix: undefined newTestEngine breaks go vet and tests

### DIFF
--- a/v2/pkg/knowledge/inception_record_test.go
+++ b/v2/pkg/knowledge/inception_record_test.go
@@ -281,7 +281,7 @@ func TestBuildK8sSecret(t *testing.T) {
 }
 
 func TestBuildK8sBaseKustomization(t *testing.T) {
-	got := buildK8sBaseKustomization("myproject")
+	got := buildK8sBaseKustomization()
 	if got == "" {
 		t.Error("should produce output")
 	}

--- a/v2/pkg/knowledge/inception_scaffold_test.go
+++ b/v2/pkg/knowledge/inception_scaffold_test.go
@@ -314,7 +314,7 @@ func TestBuildDockerfile(t *testing.T) {
 }
 
 func TestBuildKustomization(t *testing.T) {
-	got := buildKustomization("myproject")
+	got := buildKustomization()
 	if !strings.Contains(got, "apiVersion") {
 		t.Error("should contain apiVersion")
 	}

--- a/v2/pkg/knowledge/inception_test_helpers_test.go
+++ b/v2/pkg/knowledge/inception_test_helpers_test.go
@@ -1,0 +1,11 @@
+package knowledge
+
+import (
+	"log/slog"
+	"testing"
+)
+
+func newTestEngine(t *testing.T) *InceptionEngine {
+	t.Helper()
+	return NewInceptionEngine(t.TempDir(), nil, slog.Default())
+}


### PR DESCRIPTION
## Summary
- Bug #216: `newTestEngine` referenced in 14 test locations but never defined — `go vet` fails, tests don't compile
- Added shared `newTestEngine` helper in `inception_test_helpers_test.go`
- Fixed `buildKustomization()` / `buildK8sBaseKustomization()` test calls after param removal in #1402

🤖 Generated with [Claude Code](https://claude.com/claude-code)