### PR TITLE
fix: undefined withMockDeviceFlow breaks github package tests

### DIFF
--- a/v2/pkg/github/deviceflow_test_helpers_test.go
+++ b/v2/pkg/github/deviceflow_test_helpers_test.go
@@ -1,0 +1,16 @@
+package github
+
+import "net/http"
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func withMockDeviceFlow(rt func(*http.Request) (*http.Response, error), fn func()) {
+	orig := deviceFlowClient.Transport
+	deviceFlowClient.Transport = roundTripFunc(rt)
+	defer func() { deviceFlowClient.Transport = orig }()
+	fn()
+}


### PR DESCRIPTION
Bug #217: Test helper never defined. Added roundTripFunc + withMockDeviceFlow to swap deviceFlowClient transport for tests.