### PR TITLE
fix: pyproject.toml build-backend references nonexistent module

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -1578,7 +1578,7 @@ dev = ["pytest", "ruff"]
 
 [build-system]
 requires = ["setuptools>=68.0"]
-build-backend = "setuptools.backends._legacy:_Backend"
+build-backend = "setuptools.build_meta"
 `, tomlEscape(name), tomlEscape(desc), tomlEscape(name), pyPackageName(name))
 }
 


### PR DESCRIPTION
Bug #220: 'setuptools.backends._legacy:_Backend' doesn't exist. Corrected to 'setuptools.build_meta' (PEP 517 standard).