### PR TITLE
fix: click version_option missing version parameter

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -1599,9 +1599,11 @@ func buildPyCLI(name string, vision *Fact) string {
 
 import click
 
+from . import __version__
+
 
 @click.group()
-@click.version_option()
+@click.version_option(version=__version__)
 def main():
     """%s"""
     pass


### PR DESCRIPTION
Bug #221: @click.version_option() without version raises RuntimeError on --version. Imports __version__ from __init__.py.