### PR TITLE
fix: CLAUDE.md never generated despite buildClaudeMD existing

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -483,6 +483,13 @@ func (e *InceptionEngine) ProduceScaffold(ctx context.Context) (*ScaffoldResult,
 		IsNew:   true,
 	})
 
+	result.Files = append(result.Files, ScaffoldFile{
+		Path:    "CLAUDE.md",
+		Content: buildClaudeMD(constitution, constraints),
+		Purpose: "claude_md",
+		IsNew:   true,
+	})
+
 	// CI/CD — multi-tiered: PR checks, nightly full suite
 	result.Files = append(result.Files, ScaffoldFile{
 		Path:    ".github/workflows/ci.yml",


### PR DESCRIPTION
Bug #223: buildClaudeMD was defined but never called — CLAUDE.md missing from all scaffolded projects. Added to ProduceScaffold output.