### PR TITLE
fix: Java jar has no manifest mainClass — java -jar fails

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -1557,11 +1557,27 @@ func buildPomXml(name string, vision *Fact) string {
     <groupId>com.example</groupId>
     <artifactId>%s</artifactId>
     <version>0.1.0</version>
+    <packaging>jar</packaging>
     <name>%s</name>
     <properties>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
     </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>App</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>
 `, xmlEscape(name), xmlEscape(desc))
 }


### PR DESCRIPTION
Bug #228: pom.xml missing packaging + maven-jar-plugin config. Dockerfile's 'java -jar' fails with 'no main manifest attribute'.