### PR TITLE
fix: Go Dockerfile go mod download misses indirect deps

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -1764,7 +1764,7 @@ func buildDockerfile(lang, name string) string {
 WORKDIR /app
 COPY go.mod ./
 COPY go.sum* ./
-RUN go mod download
+RUN go mod tidy && go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o /bin/%s .
 


### PR DESCRIPTION
Bug #229: go mod download only fetches direct deps. Added go mod tidy to resolve cobra's transitive dependencies before download.