### PR TITLE
fix: misplaced Reset() comment on SetWikiName

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -670,7 +670,6 @@ func (e *InceptionEngine) ReadIdeaFact(ctx context.Context) (*Fact, error) {
 	return e.api.ReadFact(ctx, e.state.IdeaSlug)
 }
 
-// Reset clears the inception state so the user can start over.
 // SetWikiName persists a vanity name for the inception wiki.
 func (e *InceptionEngine) SetWikiName(name string) {
 	e.mu.Lock()


### PR DESCRIPTION
Bug #260: Comment describing Reset() was on SetWikiName function.