### PR TITLE
fix: Python .gitignore missing .ruff_cache/

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -1473,7 +1473,7 @@ func buildGitignore(lang string) string {
 	case "go":
 		return common + "# Go\n/bin/\n*.exe\ncoverage.out\n"
 	case "python":
-		return common + "# Python\n__pycache__/\n*.pyc\n*.egg-info/\ndist/\nbuild/\n.venv/\nvenv/\n.pytest_cache/\n"
+		return common + "# Python\n__pycache__/\n*.pyc\n*.egg-info/\ndist/\nbuild/\n.venv/\nvenv/\n.pytest_cache/\n.ruff_cache/\n"
 	case "typescript":
 		return common + "# Node\nnode_modules/\ndist/\ncoverage/\n*.tsbuildinfo\n"
 	case "javascript":


### PR DESCRIPTION
Bug #265: ruff generates .ruff_cache/ that gets committed without this.