### PR TITLE
fix: Dockerfile clones pluk repo twice

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -17,9 +17,10 @@ RUN GIT_HASH=$(git -C /repo rev-parse HEAD 2>/dev/null || echo "unknown") && \
     GOCACHE=/tmp/gobuild CGO_ENABLED=0 go build -ldflags "-X main.gitHash=${GIT_HASH} -X main.gitShort=${GIT_SHORT} -X main.gitBranch=${GIT_BRANCH}" -o /hive ./cmd/hive && \
     GOCACHE=/tmp/gobuild CGO_ENABLED=0 go build -o /bd ./cmd/bd
 
-# Build pluk (Go binary) in the builder stage
+# Build pluk (Go binary) in the builder stage — keep config for pattern files
 RUN git clone --depth 1 https://github.com/kubestellar/pluk.git /tmp/pluk && \
     cd /tmp/pluk && GOCACHE=/tmp/gobuild CGO_ENABLED=0 go build -o /pluk ./cmd/pluk/ && \
+    mkdir -p /pluk-patterns && cp -r /tmp/pluk/config/patterns.d /pluk-patterns/ && \
     rm -rf /tmp/pluk
 
 # --- tmux from source (cached until TMUX_VERSION changes) ---
@@ -138,11 +139,9 @@ RUN ln -sf pluk /usr/local/bin/pluk-publish && \
     ln -sf pluk /usr/local/bin/pluk-send && \
     mkdir -p /var/run/pluk/logs /var/run/pluk/commands && \
     chmod 1777 /var/run/pluk/logs /var/run/pluk/commands
-# Pattern files are embedded in the binary — copy config dir for custom overrides
-RUN git clone --depth 1 https://github.com/kubestellar/pluk.git /tmp/pluk && \
-    mkdir -p /usr/local/etc/pluk/patterns.d && \
-    cp -r /tmp/pluk/config/patterns.d/* /usr/local/etc/pluk/patterns.d/ && \
-    rm -rf /tmp/pluk
+# Pattern files from builder stage — no second clone needed
+RUN mkdir -p /usr/local/etc/pluk/patterns.d
+COPY --from=builder /pluk-patterns/patterns.d/ /usr/local/etc/pluk/patterns.d/
 RUN (which git && git clone -b feat/cli-agent-mode https://github.com/clubanderson/agentic-strategy-evolution /opt/nous && \
     python3 -m venv /opt/nous/venv && \
     /opt/nous/venv/bin/pip install --no-cache-dir -e /opt/nous 2>&1) || \


### PR DESCRIPTION
Bug #282: Second clone just for pattern files. Now reuses builder stage with COPY --from=builder.