### PR TITLE
fix: import handler double LimitReader could corrupt zip

### DIFF
--- a/v2/pkg/dashboard/inception_handlers.go
+++ b/v2/pkg/dashboard/inception_handlers.go
@@ -387,7 +387,7 @@ func (s *Server) handleInceptionImport(w http.ResponseWriter, r *http.Request) {
 	}
 	defer file.Close()
 
-	data, err := io.ReadAll(io.LimitReader(file, maxZipUploadBytes))
+	data, err := io.ReadAll(file)
 	if err != nil {
 		jsonError(w, "failed to read upload", http.StatusBadRequest)
 		return


### PR DESCRIPTION
Bug #284: MaxBytesReader (413 on overflow) + LimitReader (silent truncation) — redundant. Silent truncation corrupts zip. Removed inner limit.