### PR TITLE
fix: rename wiki panics when inception engine is nil

### DIFF
--- a/v2/pkg/dashboard/inception_handlers.go
+++ b/v2/pkg/dashboard/inception_handlers.go
@@ -351,8 +351,8 @@ func (s *Server) handleInceptionRenameWiki(w http.ResponseWriter, r *http.Reques
 		jsonError(w, fmt.Sprintf("name must be %d characters or fewer", maxWikiNameLen), http.StatusBadRequest)
 		return
 	}
-	if s.deps.Knowledge == nil {
-		jsonError(w, "knowledge not initialized", http.StatusServiceUnavailable)
+	if s.deps.Knowledge == nil || s.deps.Inception == nil {
+		jsonError(w, "knowledge or inception not initialized", http.StatusServiceUnavailable)
 		return
 	}
 	store := s.deps.Knowledge.GetVaultStore(s.deps.Inception.WikiDir())


### PR DESCRIPTION
Bug #288: Missing nil check on s.deps.Inception before calling WikiDir(). Panics if inception not initialized.