### PR TITLE
fix: SubmitAnswers accepts nil/empty answers causing stall

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -210,6 +210,9 @@ func (e *InceptionEngine) SubmitAnswers(answers map[string]string) (*InceptionSt
 	if e.state.Phase != PhaseClarify && e.state.Phase != PhaseStructure {
 		return nil, fmt.Errorf("cannot submit answers in phase %s", e.state.Phase)
 	}
+	if len(answers) == 0 {
+		return nil, fmt.Errorf("at least one answer is required")
+	}
 
 	// Validate answer keys match known question IDs
 	if len(e.state.Questions) > 0 {


### PR DESCRIPTION
Bug #292: nil answers pass validation but stall lifecycle — autoGenerateFacts returns early on empty answers.