### PR TITLE
fix: TypeScript package.json missing type:module for ESM

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -1702,6 +1702,7 @@ func buildPackageJSON(name string, vision *Fact) string {
   "name": "%s",
   "version": "0.1.0",
   "description": "%s",
+  "type": "module",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Bug #300: tsconfig uses NodeNext (ESM) but package.json lacks type:module — node dist/index.js fails.