### PR TITLE
fix: shell test stubs bypass deduplicateFactTitles

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -586,7 +586,7 @@ func (e *InceptionEngine) ProduceScaffold(ctx context.Context) (*ScaffoldResult,
 		)
 		if len(acceptance) > 0 {
 			result.Files = append(result.Files, ScaffoldFile{
-				Path: "test.sh", Content: buildShellTestStubs(acceptance), Purpose: "test_stub", IsNew: true,
+				Path: "test.sh", Content: buildShellTestStubs(deduplicateFactTitles(acceptance)), Purpose: "test_stub", IsNew: true,
 			})
 		}
 	}


### PR DESCRIPTION
Bug #304: Shell test stubs called directly, missing dedup from #1433.