### PR TITLE
fix: bd list truncates title at byte boundary

### DIFF
--- a/v2/cmd/bd/main.go
+++ b/v2/cmd/bd/main.go
@@ -344,8 +344,9 @@ func printTable(items []*beads.Bead) {
 
 	for _, b := range items {
 		title := b.Title
-		if len(title) > titleColWidth {
-			title = title[:titleColWidth-3] + "..."
+		runes := []rune(title)
+		if len(runes) > titleColWidth {
+			title = string(runes[:titleColWidth-3]) + "..."
 		}
 		fmt.Printf("%-*s %-*s %-*s %-*s %s\n",
 			idColWidth, b.ID,


### PR DESCRIPTION
Bug #310: Byte-level slicing splits multi-byte UTF-8. Switched to rune slicing.