### PR TITLE
fix: curator truncate functions split UTF-8

### DIFF
--- a/v2/pkg/knowledge/curator.go
+++ b/v2/pkg/knowledge/curator.go
@@ -287,8 +287,8 @@ func extractTitle(comment string) string {
 			continue
 		}
 		const maxTitleLen = 120
-		if len(trimmed) > maxTitleLen {
-			trimmed = trimmed[:maxTitleLen] + "..."
+		if runes := []rune(trimmed); len(runes) > maxTitleLen {
+			trimmed = string(runes[:maxTitleLen]) + "..."
 		}
 		return trimmed
 	}
@@ -326,8 +326,9 @@ func extractTags(comment string) []string {
 }
 
 func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
+	runes := []rune(s)
+	if len(runes) <= maxLen {
 		return s
 	}
-	return s[:maxLen] + "..."
+	return string(runes[:maxLen]) + "..."
 }


### PR DESCRIPTION
Bug #313: Last two byte-level truncation+ellipsis patterns in the codebase. All now use rune slicing.