### PR TITLE
fix: UnsetMetadata panics on nil Metadata map

### DIFF
--- a/v2/pkg/beads/beads.go
+++ b/v2/pkg/beads/beads.go
@@ -304,7 +304,9 @@ func (s *Store) SetMetadata(id, key, value string) error {
 
 func (s *Store) UnsetMetadata(id, key string) error {
 	return s.Update(id, func(b *Bead) {
-		delete(b.Metadata, key)
+		if b.Metadata != nil {
+			delete(b.Metadata, key)
+		}
 	})
 }
 


### PR DESCRIPTION
Bug #314: delete() on nil map panics. Added nil guard matching SetMetadata.