### PR TITLE
fix: Go Dockerfile runs go mod tidy before source copy

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -1852,8 +1852,9 @@ func buildDockerfile(lang, name string) string {
 WORKDIR /app
 COPY go.mod ./
 COPY go.sum* ./
-RUN go mod tidy && go mod download
+RUN go mod download 2>/dev/null || true
 COPY . .
+RUN go mod tidy
 RUN CGO_ENABLED=0 go build -o /bin/%s .
 
 FROM alpine:3.21


### PR DESCRIPTION
Bug #325: go mod tidy needs source to scan imports — ran before COPY, removed cobra. Fixed ordering.