### PR TITLE
fix: brownfield scan handler missing force flag

### DIFF
--- a/v2/pkg/dashboard/inception_handlers.go
+++ b/v2/pkg/dashboard/inception_handlers.go
@@ -70,10 +70,21 @@ func (s *Server) handleInceptionScan(w http.ResponseWriter, r *http.Request) {
 
 	var req struct {
 		RepoURL string `json:"repo_url"`
+		Force   bool   `json:"force,omitempty"`
 	}
 	if err := readJSON(r, &req); err != nil {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
+	}
+
+	if req.Force {
+		_ = s.deps.Inception.Reset()
+		if s.deps.AgentMgr != nil {
+			_ = s.deps.AgentMgr.Pause("brainstorm", "inception-force-reset", "forced reset before brownfield scan")
+		}
+		if store, ok := s.deps.BeadStores["brainstorm"]; ok {
+			s.clearInceptionBeads(store)
+		}
 	}
 
 	state, err := s.deps.Inception.StartBrownfield(req.RepoURL)


### PR DESCRIPTION
Bug #329: Can't override in-progress inception from scan. Added force:true support matching handleInceptionStart.