### PR TITLE
fix: StartBrownfield accepts arbitrarily long repo URLs

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -118,8 +118,13 @@ func (e *InceptionEngine) StartBrownfield(repoURL string) (*InceptionState, erro
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
+	repoURL = strings.TrimSpace(repoURL)
 	if repoURL == "" {
 		return nil, fmt.Errorf("repo URL is required")
+	}
+	const maxRepoURLLen = 2000
+	if len(repoURL) > maxRepoURLLen {
+		return nil, fmt.Errorf("repo URL must be at most %d characters", maxRepoURLLen)
 	}
 	if !strings.HasPrefix(repoURL, "https://") && !strings.HasPrefix(repoURL, "http://") {
 		return nil, fmt.Errorf("repo URL must start with https:// or http://")


### PR DESCRIPTION
Bug #331: No URL length limit. Added 2000-char max + TrimSpace.