### PR TITLE
fix: SetQuestions can revert progress by resetting phase

### DIFF
--- a/v2/pkg/knowledge/inception.go
+++ b/v2/pkg/knowledge/inception.go
@@ -174,6 +174,9 @@ func (e *InceptionEngine) SetQuestions(questions []Question) error {
 	if e.state == nil {
 		return fmt.Errorf("no inception in progress")
 	}
+	if e.state.Phase != PhaseCapture {
+		return fmt.Errorf("cannot set questions in phase %s — must be in capture phase", e.state.Phase)
+	}
 
 	if len(questions) == 0 {
 		return fmt.Errorf("at least one question is required")


### PR DESCRIPTION
Bug #332: No phase guard — calling during structure/scaffold reverts to clarify, losing work. Added capture-phase check.