### PR TITLE
fix: Discord bot dashboard commands get 401 — missing auth

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -845,9 +845,10 @@ func main() {
 
 	if cfg.Notifications.Discord != nil && cfg.Notifications.Discord.BotToken != "" && cfg.Notifications.Discord.ChannelID != "" {
 		discordBot := discord.NewBot(discord.Config{
-			Token:        cfg.Notifications.Discord.BotToken,
-			ChannelID:    cfg.Notifications.Discord.ChannelID,
-			DashboardURL: fmt.Sprintf("http://localhost:%d", cfg.Dashboard.Port),
+			Token:          cfg.Notifications.Discord.BotToken,
+			ChannelID:      cfg.Notifications.Discord.ChannelID,
+			DashboardURL:   fmt.Sprintf("http://localhost:%d", cfg.Dashboard.Port),
+			DashboardToken: os.Getenv("HIVE_DASHBOARD_TOKEN"),
 		}, logger)
 		var agentNameList []string
 		for name := range cfg.EnabledAgents() {

--- a/v2/pkg/discord/bot.go
+++ b/v2/pkg/discord/bot.go
@@ -75,13 +75,15 @@ type CommandHandler func(ctx context.Context, args string) (string, error)
 type Config struct {
 	Token        string
 	ChannelID    string
-	DashboardURL string
+	DashboardURL   string
+	DashboardToken string
 }
 
 type Bot struct {
-	token        string
-	channelID    string
-	dashboardURL string
+	token          string
+	channelID      string
+	dashboardURL   string
+	dashboardToken string
 	commands     map[string]CommandHandler
 	agentNames   []string
 	mu           sync.RWMutex
@@ -127,9 +129,10 @@ type budgetSnapshot struct {
 
 func NewBot(cfg Config, logger *slog.Logger) *Bot {
 	return &Bot{
-		token:        cfg.Token,
-		channelID:    cfg.ChannelID,
-		dashboardURL: cfg.DashboardURL,
+		token:          cfg.Token,
+		channelID:      cfg.ChannelID,
+		dashboardURL:   cfg.DashboardURL,
+		dashboardToken: cfg.DashboardToken,
 		commands:     make(map[string]CommandHandler),
 		logger:       logger,
 		client: &http.Client{
@@ -789,6 +792,9 @@ func (b *Bot) dashboardPost(path string, body []byte) error {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	if b.dashboardToken != "" {
+		req.Header.Set("Authorization", "Bearer "+b.dashboardToken)
+	}
 
 	resp, err := b.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Bug #341: dashboardPost had no Authorization header. Proxy requires Bearer for POST. Added DashboardToken.