### PR TITLE
fix: scanner gets all issues + merge-eligible includes all non-draft PRs

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1621,9 +1621,6 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 		if pr.Draft {
 			continue
 		}
-		if !pr.Mergeable {
-			continue
-		}
 		key := fmt.Sprintf("%s/%d", pr.Repo, pr.Number)
 		if holdSet[key] {
 			continue

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -131,7 +131,13 @@ func (s *Scheduler) substituteTemplate(template string, actionable *github.Actio
 	}
 	now := time.Now().Local()
 
-	issueList := s.formatIssueList(filterByLane(issues, agentName))
+	var agentIssuesForList []github.Issue
+	if agentName == "scanner" {
+		agentIssuesForList = issues
+	} else {
+		agentIssuesForList = filterByLane(issues, agentName)
+	}
+	issueList := s.formatIssueList(agentIssuesForList)
 	prList := s.formatPRList(actionable)
 
 	reposList := strings.Join(s.cfg.Project.Repos, ", ")


### PR DESCRIPTION
Scanner template sees all 61 issues. merge-eligible.json includes all non-draft non-hold PRs (Mergeable field unreliable from GitHub API).