### PR TITLE
fix: GET requests bypass auth — token disclosure via /api/auth/token

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3674,7 +3674,7 @@ func (s *Server) handleAuthToken(w http.ResponseWriter, r *http.Request) {
 		okResponse(w, map[string]string{"token": "(not set)", "configured": "false"})
 		return
 	}
-	okResponse(w, map[string]string{"token": token, "configured": "true"})
+	okResponse(w, map[string]string{"token": maskToken(token), "configured": "true"})
 }
 
 // maskToken replaces all but the last 4 characters with bullet characters.

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -58,13 +58,15 @@ app.use((req, res, next) => {
   next();
 });
 
-const PUBLIC_POST_PATHS = ['/api/contribute/register'];
+const PUBLIC_PATHS = [
+  '/api/health',
+  '/api/openapi.json',
+  '/api/contribute/register',
+];
 app.use((req, res, next) => {
-  if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) {
-    if (PUBLIC_POST_PATHS.some(p => req.url.startsWith(p))) return next();
-    return requireAuth(req, res, next);
-  }
-  next();
+  if (!req.url.startsWith('/api/')) return next();
+  if (PUBLIC_PATHS.some(p => req.url.startsWith(p))) return next();
+  return requireAuth(req, res, next);
 });
 
 const apiProxy = createProxyMiddleware({


### PR DESCRIPTION
## Summary
**Security fix:** The Node.js proxy only required auth for POST/PUT/PATCH/DELETE. All GET `/api/` endpoints were publicly accessible, including `/api/auth/token` which returned the full plaintext dashboard token — enabling unauthenticated attackers to escalate to full dashboard access.

### Changes
- Require auth on ALL `/api/` requests (GET included)  
- Only `/api/health`, `/api/openapi.json`, `/api/contribute/register` are exempt
- `/api/auth/token` now returns masked token (last 4 chars visible)

### Impact
- Local deployments were fully open on GET — any network-adjacent attacker could read agent status, inception data, and the dashboard token
- Hosted deployments mitigated by hub OAuth but this closes the gap for direct-access scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)