### PR TITLE
revert: GET auth breaks SSE EventSource

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3674,7 +3674,7 @@ func (s *Server) handleAuthToken(w http.ResponseWriter, r *http.Request) {
 		okResponse(w, map[string]string{"token": "(not set)", "configured": "false"})
 		return
 	}
-	okResponse(w, map[string]string{"token": maskToken(token), "configured": "true"})
+	okResponse(w, map[string]string{"token": token, "configured": "true"})
 }
 
 // maskToken replaces all but the last 4 characters with bullet characters.

--- a/v2/proxy/server.js
+++ b/v2/proxy/server.js
@@ -58,15 +58,13 @@ app.use((req, res, next) => {
   next();
 });
 
-const PUBLIC_PATHS = [
-  '/api/health',
-  '/api/openapi.json',
-  '/api/contribute/register',
-];
+const PUBLIC_POST_PATHS = ['/api/contribute/register'];
 app.use((req, res, next) => {
-  if (!req.url.startsWith('/api/')) return next();
-  if (PUBLIC_PATHS.some(p => req.url.startsWith(p))) return next();
-  return requireAuth(req, res, next);
+  if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) {
+    if (PUBLIC_POST_PATHS.some(p => req.url.startsWith(p))) return next();
+    return requireAuth(req, res, next);
+  }
+  next();
 });
 
 const apiProxy = createProxyMiddleware({


### PR DESCRIPTION
Reverts #1456. EventSource can't set headers — SSE gets 401, breaking dashboard.