### PR TITLE
fix: scanner uses /fleet, Agent, or sub-agents for parallel fixes

### DIFF
--- a/v2/pkg/policies/defaults/scanner-automerge.md
+++ b/v2/pkg/policies/defaults/scanner-automerge.md
@@ -63,7 +63,7 @@ ${PR_LIST}
 1. Check open beads (`bd list --status open`) for context from previous cycles — skip items already tracked
 2. **Quick merges (10 min cap)** — review PRs with passing CI and merge them. Before merging, ensure every PR body contains `Fixes #<issue>` — if missing, search for the related issue and add it with `gh pr edit`. Skip PRs with merge conflicts or failing checks. Comment `@dependabot rebase` on stale dependabot PRs. Move on after 10 minutes.
 3. **Fix blockers** — identify the single highest-leverage fix that unblocks the most PRs or issues (e.g. a shared test helper signature change, a broken import). Clone, fix, push, open PR, merge when green. One fix that unblocks many is worth more than many small fixes.
-4. **Crank quick fixes** — pick the simplest issues and create PRs fast. Auto-qa findings (TODO comments, spacing, type safety, missing error handling) are 5-minute fixes. Clone, fix, commit, push, PR — one PR per issue, move fast. Aim for 3-5 PRs per cycle. Don't over-investigate — fix and move on.
+4. **Crank quick fixes** — use `/fleet` (Copilot), `Agent` tool (Claude Code), or sub-agent sessions (Goose) to fix the remaining issues in parallel. One PR per issue, move fast.
 5. **Reap stale findings** — re-verify open beads and close resolved ones
 6. Summarize completed work including merged PRs
 

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -423,7 +423,7 @@ func (s *Scheduler) buildScannerMessage(issues []github.Issue, actionable *githu
 	b.WriteString("  1. Check beads (`bd list --status open`) for context from previous cycles\n")
 	b.WriteString("  2. Quick merges (10 min cap) — review PRs with passing CI. Ensure `Fixes #<issue>` in PR body. Merge with `--squash --admin` (always use --admin — tide labels cannot be self-applied). `@dependabot rebase` stale ones. Move on after 10 min.\n")
 	b.WriteString("  3. Fix blockers — find the ONE fix that unblocks the most PRs/issues. Clone, fix, push, merge.\n")
-	b.WriteString("  4. Crank quick fixes — pick simplest issues, create PRs fast. Auto-qa (TODOs, spacing, types) are 5-min fixes. One PR per issue. Aim for 3-5 PRs per cycle. Don't over-investigate.\n")
+	b.WriteString("  4. Crank quick fixes — use /fleet (Copilot), Agent tool (Claude Code), or sub-agent sessions (Goose) to fix remaining issues in parallel. One PR per issue, move fast.\n")
 
 	return b.String()
 }


### PR DESCRIPTION
All CLI triggers on one line.