### PR TITLE
fix: increase expired token timeout to 3min and add more CLI ready indicators

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1735,7 +1735,7 @@ const (
 	sharedCopilotConfigPath    = "/data/home/.copilot/config.json"
 	sharedConfigDesiredMode    = 0o660
 	tokenRestartCooldownSec    = 60  // minimum seconds between token-triggered restarts per agent
-	expiredTokenHangTimeoutSec = 45  // blank pane after this many seconds triggers token purge + restart
+	expiredTokenHangTimeoutSec = 180 // blank pane after this many seconds triggers token purge + restart
 )
 
 // loginPromptPatterns are substrings that indicate an agent is stuck on the
@@ -1823,6 +1823,10 @@ var cliReadyIndicators = []string{
 	"/login",
 	"sign in",
 	"Sign in",
+	"Copilot v",
+	"Tip: /init",
+	"Loading:",
+	"● Loading",
 }
 
 // paneShowsCLIReady returns true if the pane shows any indicator that


### PR DESCRIPTION
## Summary
- Increases `expiredTokenHangTimeoutSec` from 45s to 180s (3 minutes)
- Adds copilot startup banner indicators ("Copilot v", "Tip: /init", "Loading:") to `paneShowsCLIReady`

## Problem
The 45s timeout was causing false positives on knuckle's supervisor agent. Copilot shows its startup banner and "Loading: N skills" for >45s before the `❯` prompt appears. The detection fired, cleared the valid token, forced re-login, and the cycle repeated (supervisor reached restart_count 2152).

## Fix
- 180s gives copilot enough time to fully initialize even with slow skill loading
- The new indicators recognize the copilot banner as a successful launch, preventing false token clears