### PR TITLE
fix: SHA poller misses auto-upgrade after hub restart + increase token timeout

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1735,7 +1735,7 @@ const (
 	sharedCopilotConfigPath    = "/data/home/.copilot/config.json"
 	sharedConfigDesiredMode    = 0o660
 	tokenRestartCooldownSec    = 60  // minimum seconds between token-triggered restarts per agent
-	expiredTokenHangTimeoutSec = 45  // blank pane after this many seconds triggers token purge + restart
+	expiredTokenHangTimeoutSec = 180 // blank pane after this many seconds triggers token purge + restart
 )
 
 // loginPromptPatterns are substrings that indicate an agent is stuck on the
@@ -1823,6 +1823,10 @@ var cliReadyIndicators = []string{
 	"/login",
 	"sign in",
 	"Sign in",
+	"Copilot v",
+	"Tip: /init",
+	"Loading:",
+	"● Loading",
 }
 
 // paneShowsCLIReady returns true if the pane shows any indicator that

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -953,7 +953,7 @@ func (s *HubServer) StartLatestSHAPoller() {
 		oldSHA := getLatestSHA()
 		fetchSHA(s.logger)
 		newSHA := getLatestSHA()
-		if oldSHA != "" && newSHA != "" && oldSHA != newSHA {
+		if newSHA != "" && (oldSHA != newSHA || oldSHA == "") {
 			s.triggerAutoUpgrades(newSHA)
 			// Hub auto-upgrade
 			if isHubAutoUpgrade() && newSHA != s.hubGitHash {
@@ -1021,10 +1021,12 @@ func fetchSHA(logger *slog.Logger) {
 	req.Header.Set("Accept", "application/vnd.github+json")
 	resp, err := client.Do(req)
 	if err != nil {
+		logger.Warn("SHA poll: GitHub Actions API request failed", "error", err)
 		return
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
+		logger.Warn("SHA poll: GitHub Actions API non-200", "status", resp.StatusCode)
 		return
 	}
 	var result struct {
@@ -1034,6 +1036,7 @@ func fetchSHA(logger *slog.Logger) {
 		} `json:"workflow_runs"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		logger.Warn("SHA poll: failed to decode response", "error", err)
 		return
 	}
 	for _, run := range result.Runs {
@@ -1043,11 +1046,12 @@ func fetchSHA(logger *slog.Logger) {
 				latestSHAMu.Lock()
 				latestSHACache = sha
 				latestSHAMu.Unlock()
-				logger.Debug("latest image SHA from successful build", "sha", sha)
+				logger.Info("SHA poll: latest image", "sha", sha)
 				return
 			}
 		}
 	}
+	logger.Warn("SHA poll: no matching Docker/Build workflow run found")
 }
 
 func (s *HubServer) handleProxyHiveConfig(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- **SHA poller bug**: When `fetchSHA` fails on initial startup (network not ready), the ticker loop never triggers auto-upgrades because it requires `oldSHA != ""` — first successful fetch has empty oldSHA
- **Token timeout**: Increased from 45s to 180s (supervisor takes >45s to show CLI prompt, causing false token clears)
- **Logging**: `fetchSHA` now logs at Info/Warn instead of Debug-only/silent

## Root cause
After hub restart at 17:21, `fetchSHA` likely failed on the initial call. The ticker loop's condition `oldSHA != "" && newSHA != "" && oldSHA != newSHA` never passed because `oldSHA` was always `""` on the first successful fetch.

## Fix
Changed condition to: `newSHA != "" && (oldSHA != newSHA || oldSHA == "")` — triggers on first successful fetch even if initial startup fetch failed.