### PR TITLE
Kill orphaned copilot processes by UID on restart

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -9,8 +10,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
@@ -2239,6 +2242,12 @@ func (m *Manager) RestartWithBootstrap(ctx context.Context, name, prompt string)
 		}
 	}
 
+	if agent.UID > 0 {
+		killed := killAgentProcesses(agent.UID, m.logger)
+		m.logger.Info("killed orphaned agent processes",
+			"name", name, "uid", agent.UID, "killed", killed)
+	}
+
 	_ = m.tmuxCmd(agent, "kill-session", "-t", agent.tmuxSession).Run()
 
 	agent.RestartCount++
@@ -2288,6 +2297,60 @@ func (m *Manager) RestartThenSendKick(ctx context.Context, name, message string)
 	return m.SendKick(name, message)
 }
 
+// killAgentProcesses finds all processes owned by the given UID via /proc and
+// sends SIGKILL to each. Hung copilot binaries ignore SIGINT, so brute-force
+// cleanup is needed to prevent orphan accumulation on the shared SQLite store.
+func killAgentProcesses(uid int, logger *slog.Logger) int {
+	const procPath = "/proc"
+	entries, err := os.ReadDir(procPath)
+	if err != nil {
+		logger.Warn("failed to read /proc for process cleanup", "uid", uid, "error", err)
+		return 0
+	}
+
+	killed := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+
+		statusPath := filepath.Join(procPath, entry.Name(), "status")
+		f, err := os.Open(statusPath)
+		if err != nil {
+			continue
+		}
+
+		ownerUID := -1
+		scanner := bufio.NewScanner(f)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "Uid:") {
+				fields := strings.Fields(line)
+				if len(fields) >= 2 {
+					if parsed, err := strconv.Atoi(fields[1]); err == nil {
+						ownerUID = parsed
+					}
+				}
+				break
+			}
+		}
+		f.Close()
+
+		if ownerUID != uid {
+			continue
+		}
+
+		if err := syscall.Kill(pid, syscall.SIGKILL); err == nil {
+			killed++
+		}
+	}
+	return killed
+}
+
 func (m *Manager) Restart(ctx context.Context, name string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -2302,6 +2365,12 @@ func (m *Manager) Restart(ctx context.Context, name string) error {
 		if agent.cancel != nil {
 			agent.cancel()
 		}
+	}
+
+	if agent.UID > 0 {
+		killed := killAgentProcesses(agent.UID, m.logger)
+		m.logger.Info("killed orphaned agent processes",
+			"name", name, "uid", agent.UID, "killed", killed)
 	}
 
 	_ = m.tmuxCmd(agent, "kill-session", "-t", agent.tmuxSession).Run()


### PR DESCRIPTION
## Summary
- Adds `killAgentProcesses(uid)` that reads `/proc/[pid]/status` to find all processes owned by an agent's UID and sends SIGKILL via `syscall.Kill`
- Called in both `Restart` and `RestartWithBootstrap` before `tmux kill-session`, only when `agent.UID > 0`
- Prevents orphaned copilot Rust binaries (which ignore SIGINT) from accumulating and fighting over the shared SQLite session-store.db

## Problem
When the agent manager restarts a copilot agent, it sends C-c (SIGINT) and kills the tmux session. But hung copilot Rust binaries don't respond to SIGINT. Orphaned processes accumulate (we saw 18 running at once), contending on the shared SQLite store and preventing new instances from starting.

## Test plan
- [ ] Verify `go vet ./pkg/agent/` passes
- [ ] Deploy and confirm orphaned copilot processes are cleaned up on restart
- [ ] Verify agents with UID=0 (no isolation) are unaffected