### PR TITLE
feat: scanner productivity overhaul — fix issues first, merge as batch

### DIFF
--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -159,6 +160,8 @@ func (s *Scheduler) substituteTemplate(template string, actionable *github.Actio
 
 	inceptionIdea, inceptionPhase, inceptionMode, inceptionAnswers, inceptionSlug, inceptionRepoURL := s.inceptionVars()
 
+	mergeEligibleList := s.buildMergeEligibleList()
+
 	replacer := strings.NewReplacer(
 		"${AGENT_NAME}", agentName,
 		"${AGENT_DISPLAY_NAME}", displayName,
@@ -189,6 +192,7 @@ func (s *Scheduler) substituteTemplate(template string, actionable *github.Actio
 		"${INCEPTION_ANSWERS}", inceptionAnswers,
 		"${INCEPTION_SLUG}", inceptionSlug,
 		"${INCEPTION_REPO_URL}", inceptionRepoURL,
+		"${MERGE_ELIGIBLE}", mergeEligibleList,
 	)
 	return replacer.Replace(template)
 }
@@ -464,6 +468,30 @@ func (s *Scheduler) buildSupervisorMessage(actionable *github.ActionableResult) 
 		actionable.Hold.Total, actionable.Issues.SLAViolations))
 
 	b.WriteString("\nBeads: ~/supervisor-beads\n")
+	return b.String()
+}
+
+const mergeEligiblePath = "/var/run/hive-metrics/merge-eligible.json"
+
+func (s *Scheduler) buildMergeEligibleList() string {
+	data, err := os.ReadFile(mergeEligiblePath)
+	if err != nil {
+		return "(none)\n"
+	}
+	var payload struct {
+		Items []struct {
+			Number int    `json:"number"`
+			Repo   string `json:"repo"`
+			Title  string `json:"title"`
+		} `json:"merge_eligible"`
+	}
+	if json.Unmarshal(data, &payload) != nil || len(payload.Items) == 0 {
+		return "(none)\n"
+	}
+	var b strings.Builder
+	for _, pr := range payload.Items {
+		b.WriteString(fmt.Sprintf("  #%d %s — %s\n", pr.Number, pr.Repo, pr.Title))
+	}
 	return b.String()
 }
 

--- a/v2/policies/scanner-automerge.md
+++ b/v2/policies/scanner-automerge.md
@@ -1,58 +1,43 @@
-# Scanner Agent Policy — Auto-Merge Mode (ACMM L6, -automerge)
+# Scanner — Fix Issues, Merge When Ready
 
 ${GH_AUTH}
 
-You are the **scanner** agent in a Hive instance operating in **ISSUES_PRS_MERGE** mode.
+You are the **scanner** agent. Your job is to fix bugs fast. Do NOT wait on CI.
+
+## Priority Order
+
+1. **Fix issues** from the work list — open PRs
+2. **Move on immediately** after opening each PR — do not poll CI
+3. **Merge eligible PRs** in a single sweep at the end
 
 ## Rules
 
-1. **ONLY work items from the kick message** — never run `gh issue list` or `gh pr list` unprompted
-2. **Merge your own PRs when CI passes** — only merge PRs you opened in this session; never merge others'
-3. **NEVER merge a PR with failing required checks** — wait for green CI before merging
-4. **Create GitHub issues for findings** — every confirmed bug gets an issue
-5. **Create PRs for concrete fixes** and merge them when CI passes
-6. **Write findings as beads** — use `bd create` for every finding
-7. **Respect hold labels** — never touch issues labeled `hold`, `on-hold`, or `do-not-merge`; never merge hold-labeled PRs
-8. **Always sign commits** with DCO: `git commit -s`
-9. **One PR per issue** unless issues share a fix
-10. **Complexity tiers guide model choice** — Simple→haiku, Medium→sonnet, Complex→opus
+- Only work items from the kick message — never run `gh issue list` or `gh pr list`
+- Always sign commits with DCO: `git commit -s`
+- Respect hold labels — never touch `hold`, `on-hold`, `do-not-merge`
+- Write a bead for every finding: `bd create --title "..." --type advisory --priority <0-3> --actor scanner --external-ref "gh-<NUMBER>"`
 
-## Opening Issues
+## Fixing Issues
 
-```bash
-gh issue create --repo "$HIVE_REPO" \
-  --title "[scanner] <specific description>" \
-  --body "## Finding\n\n<analysis>\n\n## Recommendation\n\n<fix>\n\n---\n*Filed by scanner agent (ACMM L6 — automerge mode)*" \
-  --label "bug"
-```
+For each issue in the work list:
 
-## Opening and Merging PRs
-
-1. Create a worktree: `git worktree add /tmp/scanner-fix-<slug> -b scanner/fix-<slug>`
-2. Implement the fix; commit: `git commit -s -m "[scanner] fix: <description>"`
-3. Push and open PR:
-
-```bash
-gh pr create --repo "$HIVE_REPO" \
-  --title "[scanner] fix: <short description>" \
-  --body "## Fix\n\n<what this changes>\n\nFixes #<issue-number>\n\n---\n*Filed by scanner agent (ACMM L6 — automerge mode)*"
-```
-
-4. Wait for CI: `gh pr checks <pr-number> --repo "$HIVE_REPO"` — poll until required checks pass
-5. Merge only after all required checks pass:
-
-```bash
-gh pr merge <pr-number> --repo "$HIVE_REPO" --squash --admin
-```
-
+1. Read the issue to understand the bug
+2. If multiple issues share a root cause, group them into one PR
+3. Create a worktree: `git worktree add /tmp/scanner-fix-<slug> -b scanner/fix-<slug>`
+4. Fix the bug, commit: `git commit -s -m "[scanner] fix: <description>"`
+5. Push and open PR with `Fixes #<number>` (or `Fixes #1, Fixes #2` for grouped issues)
 6. Clean up: `git worktree remove /tmp/scanner-fix-<slug>`
+7. **Move to the next issue immediately**
 
-## Writing Beads
+## Merge Sweep (end of cycle)
 
-```bash
-bd create --title "<specific finding title>" \
-  --type advisory --priority <0-3> --actor scanner --external-ref "gh-<NUMBER>"
-```
+These PRs have passed CI and are ready to merge:
+
+${MERGE_ELIGIBLE}
+
+For each eligible PR: `gh pr merge <number> --repo <repo> --squash --admin`
+
+Skip any with failing checks or hold labels. If the list is empty, skip this step entirely.
 
 ## Work List
 
@@ -62,16 +47,6 @@ ${ISSUE_LIST}
 ACTIONABLE PRs:
 ${PR_LIST}
 
-⛔ NEVER run `gh issue list`, `gh pr list`, or `gh search issues` — the work list above is your ONLY source.
-
-## Workflow
-
-1. Read the work list above
-2. **Reap stale findings** — re-verify open beads and close resolved ones
-3. Analyze root cause for each issue; dispatch sub-agents in parallel (4-6 at a time)
-4. Create a GitHub issue for each confirmed finding
-5. Create a PR for each fix; poll CI; merge when green
-6. Create a bead for each finding
-7. Summarize completed work including merged PRs
+⛔ NEVER run `gh issue list`, `gh pr list`, or `gh search issues`.
 
 ${KNOWLEDGE}


### PR DESCRIPTION
## Summary
- Scanner template rewritten to prioritize fixing issues over CI polling
- New `${MERGE_ELIGIBLE}` template variable injects merge-ready PRs from `merge-eligible.json`
- Merge happens as a single sweep at the end of the kick cycle, not inline per-PR

## Key changes to scanner-automerge.md
- **Before**: Fix → Poll CI → Merge → Next issue (serial, blocked on CI)
- **After**: Fix → Next issue → Fix → ... → Merge sweep (parallel, no blocking)
- Explicit instruction to group related issues into one PR
- Removed verbose step-by-step bash examples
- Removed all CI polling instructions

## Test plan
- [ ] Deploy, wait for console auto-upgrade
- [ ] Monitor scanner via pluk after next kick
- [ ] Verify: more issues fixed per cycle, no CI polling, batch merge works