### PR TITLE
🐛 agent: add goose 1.37.0 CLI support

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -328,6 +328,7 @@ var cliPaneMarkers = []string{
 	"Claude",
 	"Copilot",
 	"Gemini",
+	"goose",
 }
 
 // tmuxPaneHasCLI reports whether a CLI is running in the pane by inspecting
@@ -430,8 +431,9 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	case "gemini":
 		launchCmd = fmt.Sprintf("%s --model %s", binary, model)
 	case "goose":
+		launchCmd = fmt.Sprintf("%s run -s", binary)
 		if model != "" {
-			launchCmd = fmt.Sprintf("%s --model %s", binary, model)
+			launchCmd = fmt.Sprintf("%s --model %s", launchCmd, model)
 		}
 	case "bob":
 		launchCmd = binary
@@ -475,7 +477,7 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 			case "gemini":
 				launchCmd += fmt.Sprintf(" -i \"$(cat %s)\"", promptFile)
 			case "goose":
-				launchCmd += fmt.Sprintf(" --prompt \"$(cat %s)\"", promptFile)
+				launchCmd += fmt.Sprintf(" --text \"$(cat %s)\"", promptFile)
 			}
 		}
 	}
@@ -1087,7 +1089,7 @@ func (m *Manager) waitForInputPromptForAgent(agent *AgentProcess) bool {
 			return false
 		case <-ticker.C:
 			output := m.captureTmuxPaneForAgent(agent)
-			if strings.Contains(output, "❯") {
+			if strings.Contains(output, "❯") || strings.Contains(output, "goose is ready") || strings.Contains(output, "> Enter to send") {
 				return true
 			}
 		}
@@ -1108,7 +1110,7 @@ func (m *Manager) waitForInputPrompt(session string) bool {
 			return false
 		case <-ticker.C:
 			output := m.captureTmuxPane(session)
-			if strings.Contains(output, "❯") {
+			if strings.Contains(output, "❯") || strings.Contains(output, "goose is ready") || strings.Contains(output, "> Enter to send") {
 				return true
 			}
 		}
@@ -1358,11 +1360,14 @@ func (m *Manager) SendKick(name string, message string) error {
 		return fmt.Errorf("agent %s disappeared while waiting for input prompt", name)
 	}
 
-	// Clear stale input before kick (Ctrl+C then Ctrl+U)
-	m.tmuxSendKeysForAgent(agent, "C-c")
-	time.Sleep(staleCheckDelay)
-	m.tmuxSendKeysForAgent(agent, "C-u")
-	time.Sleep(staleCheckDelay)
+	// Clear stale input before kick (Ctrl+C then Ctrl+U).
+	// Goose 1.37 exits on ^C — skip clear for goose backend.
+	if agent.Config.Backend != "goose" && agent.BackendOverride != "goose" {
+		m.tmuxSendKeysForAgent(agent, "C-c")
+		time.Sleep(staleCheckDelay)
+		m.tmuxSendKeysForAgent(agent, "C-u")
+		time.Sleep(staleCheckDelay)
+	}
 
 	if agent.Config.ClearOnKick {
 		m.tmuxSendLiteralForAgent(agent, "/clear")
@@ -1451,7 +1456,7 @@ const (
 	cliReadyPollInterval  = 2 * time.Second
 	cliReadyTimeout       = 60 * time.Second
 	inputPromptPollInterval = 2 * time.Second
-	inputPromptTimeout      = 30 * time.Second
+	inputPromptTimeout      = 120 * time.Second
 )
 
 func (m *Manager) SeedLastKick(name string, t time.Time) {

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1078,6 +1078,15 @@ func (m *Manager) waitForCLIReadyForAgent(agent *AgentProcess) bool {
 
 // waitForInputPromptForAgent polls until the CLI shows its input prompt (❯)
 // using the agent's tmux socket.
+
+func truncateTail(s string, n int) string {
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return "..." + string(runes[len(runes)-n:])
+}
+
 func (m *Manager) waitForInputPromptForAgent(agent *AgentProcess) bool {
 	deadline := time.After(inputPromptTimeout)
 	ticker := time.NewTicker(inputPromptPollInterval)
@@ -1086,6 +1095,17 @@ func (m *Manager) waitForInputPromptForAgent(agent *AgentProcess) bool {
 	for {
 		select {
 		case <-deadline:
+			m.logger.Warn("prompt timeout — dumping pane",
+				"agent", agent.Name,
+				"session", agent.tmuxSession)
+			output := m.captureTmuxPaneForAgent(agent)
+			m.logger.Warn("pane content at timeout",
+				"agent", agent.Name,
+				"len", len(output),
+				"has_goose_ready", strings.Contains(output, "goose is ready"),
+				"has_enter", strings.Contains(output, "> Enter to send"),
+				"has_arrow", strings.Contains(output, "❯"),
+				"tail_200", truncateTail(output, 200))
 			return false
 		case <-ticker.C:
 			output := m.captureTmuxPaneForAgent(agent)

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -483,9 +483,12 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	}
 
 	// Goose 1.37 requires --instructions or --text to stay interactive.
-	// Without bootstrap, use --instructions - (read from TTY).
+	// Without bootstrap, use a minimal --text prompt so goose output is
+	// visible to tmux capture-pane (--instructions - uses hidden TUI).
 	if backend == "goose" && bootstrapPrompt == "" {
-		launchCmd += " --instructions -"
+		minimalPrompt := fmt.Sprintf("/tmp/.hive-bootstrap-%s.txt", agent.Name)
+		os.WriteFile(minimalPrompt, []byte("You are an AI agent. Wait for instructions from the supervisor."), 0o644)
+		launchCmd += fmt.Sprintf(" --text \"$(cat %s)\"", minimalPrompt)
 	}
 
 	if !agent.forceRelaunch && m.tmuxPaneHasCLIForAgent(agent) {

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1716,6 +1716,7 @@ func backendBinary(backend string) (string, error) {
 		"copilot": "copilot",
 		"gemini":  "gemini",
 		"goose":   "goose",
+		"pi":      "goose",
 		"bob":     "bob",
 	}
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -482,6 +482,12 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		}
 	}
 
+	// Goose 1.37 requires --instructions or --text to stay interactive.
+	// Without bootstrap, use --instructions - (read from TTY).
+	if backend == "goose" && bootstrapPrompt == "" {
+		launchCmd += " --instructions -"
+	}
+
 	if !agent.forceRelaunch && m.tmuxPaneHasCLIForAgent(agent) {
 		m.logger.Info("CLI already running in tmux pane, skipping launch", "name", agent.Name, "session", agent.tmuxSession)
 		now := time.Now()
@@ -1079,6 +1085,14 @@ func (m *Manager) waitForCLIReadyForAgent(agent *AgentProcess) bool {
 // waitForInputPromptForAgent polls until the CLI shows its input prompt (❯)
 // using the agent's tmux socket.
 
+func truncateHead(s string, n int) string {
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n]) + "..."
+}
+
 func truncateTail(s string, n int) string {
 	runes := []rune(s)
 	if len(runes) <= n {
@@ -1105,7 +1119,7 @@ func (m *Manager) waitForInputPromptForAgent(agent *AgentProcess) bool {
 				"has_goose_ready", strings.Contains(output, "goose is ready"),
 				"has_enter", strings.Contains(output, "> Enter to send"),
 				"has_arrow", strings.Contains(output, "❯"),
-				"tail_200", truncateTail(output, 200))
+				"head_500", truncateHead(output, 500), "tail_500", truncateTail(output, 500))
 			return false
 		case <-ticker.C:
 			output := m.captureTmuxPaneForAgent(agent)

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1126,7 +1126,7 @@ func (m *Manager) waitForInputPromptForAgent(agent *AgentProcess) bool {
 			return false
 		case <-ticker.C:
 			output := m.captureTmuxPaneForAgent(agent)
-			if strings.Contains(output, "❯") || strings.Contains(output, "goose is ready") || strings.Contains(output, "> Enter to send") {
+			if strings.Contains(output, "❯") || strings.Contains(output, "goose is ready") || strings.Contains(output, "> Enter to send") || strings.Contains(output, "\n>\n") {
 				return true
 			}
 		}
@@ -1147,7 +1147,7 @@ func (m *Manager) waitForInputPrompt(session string) bool {
 			return false
 		case <-ticker.C:
 			output := m.captureTmuxPane(session)
-			if strings.Contains(output, "❯") || strings.Contains(output, "goose is ready") || strings.Contains(output, "> Enter to send") {
+			if strings.Contains(output, "❯") || strings.Contains(output, "goose is ready") || strings.Contains(output, "> Enter to send") || strings.Contains(output, "\n>\n") {
 				return true
 			}
 		}


### PR DESCRIPTION
Goose 1.37.0 uses subcommands (`goose run -s`) and requires `--text` or `--instructions` to stay interactive. It also shows different prompt indicators: 'goose is ready' and '> Enter to send' instead of ❯.

## Changes
- Launch goose via `goose run -s` subcommand instead of bare `goose --model X`
- Use `--text` instead of `--prompt` for bootstrap prompt
- Add 'goose' to `cliPaneMarkers` for CLI alive detection
- Check for 'goose is ready' and '> Enter to send' in prompt detection (in addition to ❯)
- Skip ^C+^U clear for goose backend (goose 1.37 exits on ^C)
- Provide minimal `--text` bootstrap when no kick template is available (goose requires `--text` or `--instructions` to stay interactive)
- Increase input prompt timeout to 120s
- Map 'pi' backend to goose for backward compatibility

## Testing
Tested on a live Talos K8s cluster with 9 goose-backed agents running DeepSeek v4. Agents receive kicks, process them, and produce output correctly.