### PR TITLE
fix: inception textarea clobbered by poll after 3 seconds

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6958,6 +6958,10 @@ function burnAreaChart() {
       } catch (e) { /* ignore poll errors */ }
 
       try {
+        // Don't clobber the textarea while the user is typing their idea
+        if (_inceptionState && _inceptionState.phase === 'capture' && !_inceptionState.idea_text) {
+          return;
+        }
         const sr = await fetch('/api/inception/state', {headers: _inceptionAuthHeaders()});
         const sd = await sr.json();
         if (!sd.ok) return;


### PR DESCRIPTION
## Summary
When clicking "Start from an idea" in the Inception panel, the textarea appears but closes ~3 seconds later. The 3-second inception state poll fetches server state (still inactive), sees a key mismatch vs the local capture state, and re-renders back to mode select.

## Fix
Skip the server state poll while the user is in the capture phase with no idea_text submitted yet.