### PR TITLE
fix: scanner sub-agents must study existing code before changing it

### DIFF
--- a/v2/pkg/policies/defaults/scanner-automerge.md
+++ b/v2/pkg/policies/defaults/scanner-automerge.md
@@ -23,7 +23,7 @@ You are the **scanner** agent. Your job is to fix bugs fast using parallel sub-a
 
 Do NOT fix issues yourself in the main thread. For each issue, **launch a background agent** using the Agent tool.
 
-For each issue in the ISSUE_LIST below, call the Agent tool with `run_in_background: true` and the following prompt (fill in the issue-specific values):
+For each issue in the ISSUE_LIST below, call the Agent tool with `run_in_background: true` and the **most capable model available** (opus or its equivalent — never use a weaker model for code fixes). Set the model parameter explicitly on every agent call. Use the following prompt (fill in the issue-specific values):
 
 ```
 Fix this issue and open a PR. Then return immediately.

--- a/v2/pkg/policies/defaults/scanner-automerge.md
+++ b/v2/pkg/policies/defaults/scanner-automerge.md
@@ -36,13 +36,14 @@ Steps:
 2. Read the issue: gh issue view <number> --repo <org>/<repo>
 3. Verify the bug exists in code — read files, confirm the pattern
 4. If invalid or already fixed: comment with evidence, close as "not planned", clean up worktree, and return
-5. Implement the fix in the worktree
-6. git add the changed files
-7. git commit -s -m "[scanner] fix: <short description>"
-8. git push -u origin scanner/fix-<number>
-9. gh pr create --repo <org>/<repo> --title "[scanner] fix: <short description>" --body "Fixes #<number>"
-10. git worktree remove /tmp/scanner-fix-<number>
-11. Return immediately — do NOT wait for CI, do NOT merge, do NOT run build or lint
+5. Before changing anything, read the surrounding code and nearby files to understand the project's patterns and conventions. Use existing utilities, follow established naming and style — do not introduce new abstractions or deviate from how the codebase already solves similar problems. The existing code is the reference model.
+6. Implement the fix in the worktree
+7. git add the changed files
+8. git commit -s -m "[scanner] fix: <short description>"
+9. git push -u origin scanner/fix-<number>
+10. gh pr create --repo <org>/<repo> --title "[scanner] fix: <short description>" --body "Fixes #<number>"
+11. git worktree remove /tmp/scanner-fix-<number>
+12. Return immediately — do NOT wait for CI, do NOT merge, do NOT run build or lint
 ```
 
 **Launch ALL agents in a single batch** — do not wait for one to complete before launching the next. Aim for 4-8 agents running simultaneously.

--- a/v2/policies/scanner-automerge.md
+++ b/v2/policies/scanner-automerge.md
@@ -23,7 +23,7 @@ You are the **scanner** agent. Your job is to fix bugs fast using parallel sub-a
 
 Do NOT fix issues yourself in the main thread. For each issue, **launch a background agent** using the Agent tool.
 
-For each issue in the ISSUE_LIST below, call the Agent tool with `run_in_background: true` and the following prompt (fill in the issue-specific values):
+For each issue in the ISSUE_LIST below, call the Agent tool with `run_in_background: true` and the **most capable model available** (opus or its equivalent — never use a weaker model for code fixes). Set the model parameter explicitly on every agent call. Use the following prompt (fill in the issue-specific values):
 
 ```
 Fix this issue and open a PR. Then return immediately.

--- a/v2/policies/scanner-automerge.md
+++ b/v2/policies/scanner-automerge.md
@@ -36,13 +36,14 @@ Steps:
 2. Read the issue: gh issue view <number> --repo <org>/<repo>
 3. Verify the bug exists in code — read files, confirm the pattern
 4. If invalid or already fixed: comment with evidence, close as "not planned", clean up worktree, and return
-5. Implement the fix in the worktree
-6. git add the changed files
-7. git commit -s -m "[scanner] fix: <short description>"
-8. git push -u origin scanner/fix-<number>
-9. gh pr create --repo <org>/<repo> --title "[scanner] fix: <short description>" --body "Fixes #<number>"
-10. git worktree remove /tmp/scanner-fix-<number>
-11. Return immediately — do NOT wait for CI, do NOT merge, do NOT run build or lint
+5. Before changing anything, read the surrounding code and nearby files to understand the project's patterns and conventions. Use existing utilities, follow established naming and style — do not introduce new abstractions or deviate from how the codebase already solves similar problems. The existing code is the reference model.
+6. Implement the fix in the worktree
+7. git add the changed files
+8. git commit -s -m "[scanner] fix: <short description>"
+9. git push -u origin scanner/fix-<number>
+10. gh pr create --repo <org>/<repo> --title "[scanner] fix: <short description>" --body "Fixes #<number>"
+11. git worktree remove /tmp/scanner-fix-<number>
+12. Return immediately — do NOT wait for CI, do NOT merge, do NOT run build or lint
 ```
 
 **Launch ALL agents in a single batch** — do not wait for one to complete before launching the next. Aim for 4-8 agents running simultaneously.


### PR DESCRIPTION
## Summary

Adds a step to the sub-agent prompt template: before implementing any fix, the sub-agent must read surrounding code to understand the project's patterns, conventions, and existing utilities. The existing codebase is the reference model — sub-agents should not introduce new abstractions or deviate from established style.

Without this, sub-agents were making fixes that didn't match project conventions.