### PR TITLE
fix: pin/unpin renders optimistically before API call

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -7754,14 +7754,10 @@ function burnAreaChart() {
       dismissToast(toast, `${agent} model → ${model}`, 'success');
     }
 
-    const PIN_OVERRIDE_TTL_MS = 8000;
+    const PIN_OVERRIDE_TTL_MS = 60000;
     const _pinOverrides = {};
     async function togglePin(agent, dimension, currentlyPinned) {
       const action = currentlyPinned ? 'unpin' : 'pin';
-      const res = await fetch(`/api/${action}/${agent}/${dimension}`, { method: 'POST' });
-      const data = await res.json();
-      if (!data.ok) { showToast(`${action} failed: ` + (data.error || 'unknown'), 'error'); return; }
-      showToast(`${agent} ${dimension} ${action}ned`, 'success');
       const nowPinned = !currentlyPinned;
       const key = `${agent}:${dimension}`;
       _pinOverrides[key] = { value: nowPinned, expires: Date.now() + PIN_OVERRIDE_TTL_MS };
@@ -7770,6 +7766,16 @@ function burnAreaChart() {
       renderAgents(agents);
       const lastData = window._lastStatus || {};
       renderGovernor(lastData.governor || {}, lastData.cadenceMatrix || [], lastData);
+      const res = await fetch(`/api/${action}/${agent}/${dimension}`, { method: 'POST' });
+      const data = await res.json();
+      if (!data.ok) {
+        showToast(`${action} failed: ` + (data.error || 'unknown'), 'error');
+        delete _pinOverrides[key];
+        fetch('/api/status').then(r => r.json()).then(render).catch(() => {});
+        return;
+      }
+      showToast(`${agent} ${dimension} ${action}ned`, 'success');
+      fetch('/api/status').then(r => r.json()).then(render).catch(() => {});
     }
     function applyPinOverrides(agents) {
       const now = Date.now();


### PR DESCRIPTION
## Summary
Pin/unpin clicks took ~30 seconds to show effect because `togglePin` awaited the API call before rendering. The Go binary's eval cycle blocked the response.

## Fix
Render the optimistic override immediately, then fire the API call in the background. On error, roll back and fetch fresh status. On success, fetch fresh status to sync.