### PR TITLE
fix: rename Classic to Dark mode, reorder get-started options

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -527,7 +527,10 @@ func (s *Server) handleSnapshotPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	mode := r.URL.Query().Get("mode")
-	if mode != "classic" {
+	if mode == "classic" {
+		mode = "dark"
+	}
+	if mode != "dark" {
 		mode = "light"
 	}
 	snapshotFile := fmt.Sprintf("/data/snapshots/snapshot-%s.html", mode)
@@ -540,7 +543,7 @@ func (s *Server) handleSnapshotPage(w http.ResponseWriter, r *http.Request) {
 	needsRebuild := err != nil || time.Since(info.ModTime()) > staleThreshold
 
 	if needsRebuild {
-		s.buildSnapshot("/data/snapshots/snapshot-classic.html", "classic")
+		s.buildSnapshot("/data/snapshots/snapshot-dark.html", "dark")
 		s.buildSnapshot("/data/snapshots/snapshot-light.html", "light")
 	}
 
@@ -554,8 +557,8 @@ func (s *Server) handleSnapshotPage(w http.ResponseWriter, r *http.Request) {
 		`href="/live/hive/light"`,
 		`href="/snapshot?mode=light"`, -1))
 	data = []byte(strings.Replace(string(data),
-		`href="/live/hive/classic"`,
-		`href="/snapshot?mode=classic"`, -1))
+		`href="/live/hive/dark"`,
+		`href="/snapshot?mode=dark"`, -1))
 	data = []byte(strings.Replace(string(data),
 		`href="/live/hive"`,
 		`href="/snapshot"`, -1))

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1809,7 +1809,7 @@
       <span class="oc-tb-link" onclick="openConfigDialog('governor')">⚙️ Config</span>
       <span class="oc-tb-link" onclick="ocNavigate('debug-section')">🔍 Debug</span>
       <!-- Agent Logs hidden (redundant with per-agent output) -->
-      <button class="layout-toggle" onclick="toggleLayout()" title="Switch to Classic layout — dark theme with compact agent cards in a grid. Best for quick overview of all agents at once.">☰ Classic View</button>
+      <button class="layout-toggle" onclick="toggleLayout()" title="Switch to Dark mode — dark theme with compact agent cards in a grid. Best for quick overview of all agents at once.">☰ Dark Mode</button>
     </div>
     <div class="oc-topbar-right">
       <span class="oc-health-badge" id="oc-health">● Health OK</span>
@@ -1839,7 +1839,7 @@
     <span class="git-version" id="git-version"></span>
     <span class="git-version" id="hive-id-badge" title="Hive Instance ID" style="cursor:pointer;border:1px solid var(--border);padding:2px 8px;border-radius:4px" onclick="openConfigDialog('governor')"></span>
     <span class="git-version" id="acmm-badge" title="ACMM Maturity Level — click to change" style="cursor:pointer;border:1px solid var(--border);padding:2px 8px;border-radius:4px;background:linear-gradient(135deg,#3498db,#2ecc71);color:#fff;font-weight:600" onclick="openACMMDialog()"></span>
-    <button class="layout-toggle" id="layout-toggle" onclick="toggleLayout()" title="Switch between Light layout (sidebar + detail panel) and Classic layout (dark theme grid). Your preference is saved in the browser.">☰ Classic</button>
+    <button class="layout-toggle" id="layout-toggle" onclick="toggleLayout()" title="Switch between Light mode (sidebar + detail panel) and Dark mode (dark theme grid). Your preference is saved in the browser.">☰ Dark Mode</button>
     <a href="/api/widget" class="widget-dl" title="Download Übersicht widget">⬇ Widget</a>
   </h1>
 
@@ -2004,13 +2004,14 @@
       if (typeof str !== 'string') return '';
       return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
     }
-    // ── Layout mode (Classic / Light) ──
+    // ── Layout mode (Dark / Light) ──
     const LAYOUT_KEY = 'hive-layout-mode';
-    const LAYOUT_MODES = ['classic', 'light'];
-    const LAYOUT_LABELS = { classic: '☰ Light View', light: '☰ Classic View' };
+    const LAYOUT_MODES = ['dark', 'light'];
+    const LAYOUT_LABELS = { dark: '☰ Light Mode', light: '☰ Dark Mode' };
     function getLayout() {
       let stored = localStorage.getItem(LAYOUT_KEY) || 'light';
       if (stored === 'openclaw') { stored = 'light'; setLayout(stored); }
+      if (stored === 'classic') { stored = 'dark'; setLayout(stored); }
       return LAYOUT_MODES.includes(stored) ? stored : 'light';
     }
     function setLayout(mode) { localStorage.setItem(LAYOUT_KEY, mode); }
@@ -2019,13 +2020,13 @@
       document.body.classList.add('has-info-sidebar');
       const btn = document.getElementById('layout-toggle');
       if (btn) {
-        btn.textContent = LAYOUT_LABELS[mode] || LAYOUT_LABELS.classic;
-        btn.classList.toggle('active', mode !== 'classic');
+        btn.textContent = LAYOUT_LABELS[mode] || LAYOUT_LABELS.dark;
+        btn.classList.toggle('active', mode !== 'dark');
       }
       // Show/hide Light sidebar
       const sidebar = document.getElementById('oc-sidebar');
       if (sidebar) sidebar.style.display = mode === 'light' ? 'flex' : 'none';
-      // Show/hide classic header
+      // Show/hide dark mode header
       const h1 = document.querySelector('body > h1');
       if (h1) h1.style.display = mode === 'light' ? 'none' : 'flex';
       // Show/hide Light top bar

--- a/v2/pkg/hub/static/get-started.html
+++ b/v2/pkg/hub/static/get-started.html
@@ -68,7 +68,18 @@
   <div class="content">
     <h1>Get Started with Hive</h1>
 
-    <h2>Option 1: Local Install <span class="badge badge-ready">Ready</span></h2>
+    <h2>Option 1: Contribute <span class="badge badge-ready">Ready</span></h2>
+    <p>Contribute your compute to run agents for any public hive:</p>
+    <pre><code># Install the contribute CLI
+npx @kubestellar/hive-contribute
+
+# Connect to a hive
+hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID
+
+# Your CLI runs agents locally, tasks are assigned by the hive</code></pre>
+    <p>Contributors earn trust tiers (newcomer → contributor → trusted → advisor) based on completed tasks. See the <a href="/#leaderboard">leaderboard</a>.</p>
+
+    <h2>Option 2: Local Install <span class="badge badge-ready">Ready</span></h2>
     <p>Run Hive v2 on your own machine with Docker Compose. Your agents, your repos, your infrastructure.</p>
 
     <h3>Prerequisites</h3>
@@ -112,7 +123,7 @@ open http://localhost:3001</code></pre>
 HIVE_HUB_URL=https://hive.kubestellar.io</code></pre>
     <p>Your hive will appear in the Active Hives table within 5 minutes. Set <code>HIVE_PUBLIC=false</code> to keep it private.</p>
 
-    <h2>Option 2: Hosted <span class="badge badge-ready">Ready</span></h2>
+    <h2>Option 3: Hosted <span class="badge badge-ready">Ready</span></h2>
     <p>Run a hosted hive instance on our infrastructure. Login with GitHub to get started.</p>
     <div class="card">
       <h3>How it works</h3>
@@ -125,17 +136,6 @@ HIVE_HUB_URL=https://hive.kubestellar.io</code></pre>
       </ol>
       <p style="margin-top:16px"><a href="/login" style="display:inline-block;padding:10px 24px;background:#f59e0b;color:#000;font-weight:700;border-radius:8px;text-decoration:none">Login with GitHub →</a></p>
     </div>
-
-    <h2>Contributing Agents</h2>
-    <p>You can contribute your compute to run agents for any public hive:</p>
-    <pre><code># Install the contribute CLI
-npx @kubestellar/hive-contribute
-
-# Connect to a hive
-hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID
-
-# Your CLI runs agents locally, tasks are assigned by the hive</code></pre>
-    <p>Contributors earn trust tiers (newcomer → contributor → trusted → advisor) based on completed tasks. See the <a href="/#leaderboard">leaderboard</a>.</p>
   </div>
   <script>
     function esc(s){var d=document.createElement('div');d.textContent=s;return d.innerHTML;}


### PR DESCRIPTION
Fixes #1292, Fixes #1293

## Summary
- **#1292**: Rename "Classic mode" → "Dark mode" in dashboard toggle buttons, tooltips, and snapshot backend. Backwards compat: `?mode=classic` and localStorage `classic` migrate to `dark` automatically.
- **#1293**: Reorder get-started page: Option 1 (Contribute), Option 2 (Local Install), Option 3 (Hosted). Contributing is lowest barrier to entry.

## Changes
- `v2/pkg/dashboard/static/index.html` — UI labels, layout mode array, localStorage migration
- `v2/pkg/dashboard/api.go` — snapshot file names, URL param handling
- `v2/pkg/hub/static/get-started.html` — reordered sections with proper Option numbering