### PR TITLE
fix: read original URI from query param for public path bypass

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1438,6 +1438,16 @@ func (s *HubServer) handleSaaSAuthCheck(w http.ResponseWriter, r *http.Request) 
 	}
 
 	originalURI := r.Header.Get("X-Original-URI")
+	if originalURI == "" {
+		if origURL := r.Header.Get("X-Original-URL"); origURL != "" {
+			if u, err := url.Parse(origURL); err == nil {
+				originalURI = u.Path
+			}
+		}
+	}
+	if originalURI == "" {
+		originalURI = r.URL.Query().Get("uri")
+	}
 	for _, p := range publicPaths {
 		if strings.HasPrefix(originalURI, p) {
 			w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Ingress annotations updated to pass `$request_uri` as `&uri=` query param. Hub reads it as fallback when X-Original-URI/URL headers are empty.