### PR TITLE
fix: provisioning — port 3002, auth-url with uri, custom error pages

### DIFF
--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -319,7 +319,7 @@ data:
       token: "${HIVE_GITHUB_TOKEN}"
 {{- end}}
     dashboard:
-      port: 3001
+      port: 3002
     hub:
       enabled: true
       url: https://hive.kubestellar.io
@@ -494,7 +494,9 @@ metadata:
   namespace: {{.Namespace}}
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
-    nginx.ingress.kubernetes.io/auth-url: "https://hive.kubestellar.io/api/saas/auth-check?hive={{.ID}}"
+    nginx.ingress.kubernetes.io/auth-url: "https://hive.kubestellar.io/api/saas/auth-check?hive={{.ID}}&uri=$request_uri"
+    nginx.ingress.kubernetes.io/custom-http-errors: "502,503"
+    nginx.ingress.kubernetes.io/default-backend: hive-error-pages
     nginx.ingress.kubernetes.io/auth-signin: "https://hive.kubestellar.io/login?redirect=$scheme://$http_host$request_uri"
     nginx.ingress.kubernetes.io/auth-response-headers: "X-Hive-User,X-Hive-Role"
 spec:


### PR DESCRIPTION
Fixes provisioning template: Go binary port 3002, public path auth bypass, custom 502/503 pages. Kelly's hive was broken by port 3001 conflict.