### PR TITLE
feat: RWX NFS provisioning for zero-downtime rollouts

### DIFF
--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -26,7 +26,11 @@ const (
 	cpuLimit              = "2000m"
 	memRequest            = "1Gi"
 	memLimit              = "4Gi"
-	pvcSize               = "10Gi"
+	nfsStorageCapacity    = "50Gi"
+	nfsMountTargetIP      = "10.0.10.30"
+	nfsExportPathPrefix   = "/hive-"
+	rolloutMaxSurge       = 1
+	rolloutMaxUnavailable = 0
 )
 
 type SaaSHive struct {
@@ -182,11 +186,16 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, logger *slog.Logger) err
 			}
 			return strings.Join(lines, "\n")
 		}(),
-		"CPURequest":      cpuRequest,
-		"CPULimit":        cpuLimit,
-		"MemRequest":      memRequest,
-		"MemLimit":        memLimit,
-		"PVCSize":         pvcSize,
+		"CPURequest":           cpuRequest,
+		"CPULimit":             cpuLimit,
+		"MemRequest":           memRequest,
+		"MemLimit":             memLimit,
+		"NFSStorageCapacity":   nfsStorageCapacity,
+		"NFSMountTargetIP":     nfsMountTargetIP,
+		"NFSExportPath":        nfsExportPathPrefix + h.ID,
+		"PVName":               "hive-" + h.ID + "-fss-pv",
+		"RolloutMaxSurge":      rolloutMaxSurge,
+		"RolloutMaxUnavailable": rolloutMaxUnavailable,
 		"DashboardToken": func() string {
 			const tokenBytes = 32
 			b := make([]byte, tokenBytes)
@@ -342,17 +351,32 @@ stringData:
 {{- end}}
 ---
 apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{.PVName}}
+spec:
+  capacity:
+    storage: {{.NFSStorageCapacity}}
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  nfs:
+    server: {{.NFSMountTargetIP}}
+    path: {{.NFSExportPath}}
+---
+apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: hive-data
   namespace: {{.Namespace}}
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
-      storage: {{.PVCSize}}
-  storageClassName: oci-bv
+      storage: {{.NFSStorageCapacity}}
+  volumeName: {{.PVName}}
+  storageClassName: ""
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -364,8 +388,8 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
+      maxSurge: {{.RolloutMaxSurge}}
+      maxUnavailable: {{.RolloutMaxUnavailable}}
   selector:
     matchLabels:
       app: hive


### PR DESCRIPTION
## Summary
- Replace RWO block volume (oci-bv) PVCs with RWX NFS PV+PVC pairs backed by OCI File Storage mount target
- Each hive gets a dedicated NFS export path (`/hive-<id>`) on the shared mount target (10.0.10.30)
- Update deployment rolling update strategy from `maxSurge:0, maxUnavailable:1` to `maxSurge:1, maxUnavailable:0`
- This eliminates 503 downtime during rollout restarts — the new pod starts and becomes ready before the old pod is terminated

## Details
RWO block volumes cannot be mounted by two pods simultaneously, forcing `maxSurge:0` (old pod must die before new pod can start). RWX NFS volumes allow concurrent mounts, enabling `maxSurge:1` for true zero-downtime rolling updates.

OCI File Storage auto-creates subdirectories on the NFS mount target, so no OCI API calls are needed — just a PV pointing to the hive-specific path.

## Test plan
- [ ] Deploy a new hosted hive and verify PV + PVC are created with ReadWriteMany
- [ ] Verify the hive pod starts and mounts the NFS volume successfully
- [ ] Trigger a rollout restart and confirm zero 503s during the transition
- [ ] Verify data persists across restarts