### PR TITLE
fix: contribute workflow UX and My Hives nav visibility

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -123,6 +123,7 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("GET /api/saas/hives/{id}/requests", s.requireAuth(s.handleGetRequests))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/requests/{username}/approve", s.requireAuth(s.handleApproveRequest))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/requests/{username}/deny", s.requireAuth(s.handleDenyRequest))
+	s.mux.HandleFunc("GET /api/saas/access-status", s.handleAccessStatus)
 	s.mux.HandleFunc("GET /api/saas/admin/users", s.requireAdmin(s.handleAdminUsers))
 	s.mux.HandleFunc("PUT /api/saas/admin/users/{username}", s.requireAdmin(s.handleAdminUpdateUser))
 
@@ -524,15 +525,93 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	showMyHives := isAdmin || len(result) > 0
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{
-		"hives":          result,
-		"saas_quota":     user.SaaSQuota,
-		"saas_used":      saasCount,
-		"is_admin":       user.GitHubUsername == hubAdminUsername,
-		"latest_sha":     getLatestSHA(),
-		"hub_git_hash":   s.hubGitHash,
+		"hives":            result,
+		"saas_quota":       user.SaaSQuota,
+		"saas_used":        saasCount,
+		"is_admin":         user.GitHubUsername == hubAdminUsername,
+		"latest_sha":       getLatestSHA(),
+		"hub_git_hash":     s.hubGitHash,
 		"hub_auto_upgrade": isHubAutoUpgrade(),
+		"show_my_hives":    showMyHives,
+	})
+}
+
+func (s *HubServer) handleAccessStatus(w http.ResponseWriter, r *http.Request) {
+	username := s.getAuthUser(r)
+	if username == "" {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"authenticated": false,
+			"show_my_hives": false,
+		})
+		return
+	}
+
+	user := loadSaaSUser(username)
+	if user == nil {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"authenticated": true,
+			"show_my_hives": username == hubAdminUsername,
+			"hives":         map[string]string{},
+		})
+		return
+	}
+
+	s.mu.Lock()
+	s.markStaleHives()
+	allHives := make([]RegistryEntry, len(s.registry.Hives))
+	copy(allHives, s.registry.Hives)
+	s.mu.Unlock()
+
+	type hiveAccessInfo struct {
+		Role   string `json:"role"`
+		Status string `json:"status"`
+	}
+	hiveAccess := make(map[string]hiveAccessInfo)
+
+	isAdmin := username == hubAdminUsername
+	for _, h := range allHives {
+		if role, ok := user.Hives[h.ID]; ok {
+			hiveAccess[h.ID] = hiveAccessInfo{Role: role, Status: "accepted"}
+			continue
+		}
+		if strings.EqualFold(h.Owner, username) {
+			hiveAccess[h.ID] = hiveAccessInfo{Role: "owner", Status: "accepted"}
+			continue
+		}
+		if isAdmin {
+			hiveAccess[h.ID] = hiveAccessInfo{Role: "owner", Status: "accepted"}
+			continue
+		}
+		reqs := loadAccessRequests(h.ID)
+		for _, req := range reqs {
+			if req.Username == username && req.Status == "pending" {
+				hiveAccess[h.ID] = hiveAccessInfo{Status: "pending"}
+				break
+			}
+		}
+	}
+
+	showMyHives := isAdmin || len(user.Hives) > 0
+	if !showMyHives {
+		for _, h := range allHives {
+			if strings.EqualFold(h.Owner, username) {
+				showMyHives = true
+				break
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"authenticated": true,
+		"show_my_hives": showMyHives,
+		"hives":         hiveAccess,
 	})
 }
 
@@ -1720,6 +1799,11 @@ const dashboardHTML = `<!DOCTYPE html>
 
     <div id="hives-container"><div class="loading">Loading your hives...</div></div>
 
+    <div id="public-hives-section" style="display:none;margin-top:48px">
+      <h2 style="font-size:1.3rem;color:var(--accent);margin-bottom:16px">Public Hives</h2>
+      <div id="public-hives-container"></div>
+    </div>
+
     <div id="admin-section" style="display:none;margin-top:48px">
       <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px">
         <h2 style="font-size:1.3rem;color:var(--accent)">Hub Admin — Users</h2>
@@ -1934,6 +2018,7 @@ const dashboardHTML = `<!DOCTYPE html>
         }
         renderHives(data.hives || []);
         renderPendingBanner(data.hives || []);
+        loadPublicHives(data.hives || []);
       } catch(e) {
         if (!_allDashHives.length) {
           document.getElementById('hives-container').innerHTML = '<div class="loading">Failed to load hives</div>';
@@ -1941,6 +2026,57 @@ const dashboardHTML = `<!DOCTYPE html>
       } finally {
         _hivesLoading = false;
       }
+    }
+
+    async function loadPublicHives(myHives) {
+      try {
+        var resp = await fetch('/api/registry');
+        var data = await resp.json();
+        var allPublic = (data.hives || []).filter(function(h) { return h.isPublic !== false && h.hiveType === 'hosted'; });
+        var myIds = {};
+        (myHives || []).forEach(function(h) { myIds[h.id] = true; });
+        var otherHives = allPublic.filter(function(h) { return !myIds[h.id]; });
+        var section = document.getElementById('public-hives-section');
+        if (!otherHives.length) { section.style.display = 'none'; return; }
+        section.style.display = '';
+        var statusResp = await fetch('/api/saas/access-status');
+        var statusData = await statusResp.json();
+        var accessMap = statusData.hives || {};
+        var rows = otherHives.map(function(h) {
+          var repoPath = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : h.primaryRepo || '';
+          var repoLink = repoPath ? '<a href="https://github.com/' + esc(repoPath) + '" target="_blank" class="repo-link">' + esc(h.primaryRepo) + '</a>' : '';
+          var actionCell = '';
+          var access = accessMap[h.id];
+          if (access && access.status === 'accepted') {
+            var cUrl = 'https://' + esc(h.id) + '.hive.kubestellar.io/contribute';
+            actionCell = '<a href="' + cUrl + '" target="_blank" style="padding:3px 10px;background:rgba(34,197,94,0.15);color:#4ade80;border:1px solid rgba(34,197,94,0.3);border-radius:4px;font-size:0.7rem;text-decoration:none">Contribute</a>';
+          } else if (access && access.status === 'pending') {
+            actionCell = '<span style="padding:3px 10px;background:rgba(245,158,11,0.15);color:#fbbf24;border:1px solid rgba(245,158,11,0.3);border-radius:4px;font-size:0.7rem">Pending</span>';
+          } else {
+            actionCell = '<button onclick="dashRequestAccess(\'' + esc(h.id) + '\',this)" style="padding:3px 10px;background:rgba(59,130,246,0.15);color:#60a5fa;border:1px solid rgba(59,130,246,0.3);border-radius:4px;font-size:0.7rem;cursor:pointer;border:1px solid rgba(59,130,246,0.3)">Request Access</button>';
+          }
+          return '<tr>' +
+            '<td style="text-align:left">' + esc(h.name || h.id) + '</td>' +
+            '<td>' + repoLink + '</td>' +
+            '<td>' + acmmBadge(h.acmmLevel) + '</td>' +
+            '<td>' + actionCell + '</td>' +
+            '</tr>';
+        }).join('');
+        document.getElementById('public-hives-container').innerHTML =
+          '<table class="hive-table"><thead><tr><th style="text-align:left">Hive</th><th>Repo</th><th>ACMM</th><th></th></tr></thead><tbody>' + rows + '</tbody></table>';
+      } catch(e) {}
+    }
+
+    async function dashRequestAccess(hiveId, btn) {
+      btn.disabled = true;
+      btn.textContent = 'Requesting...';
+      try {
+        var resp = await fetch('/api/saas/hives/' + encodeURIComponent(hiveId) + '/request-access', {method: 'POST'});
+        var data = await resp.json();
+        if (!resp.ok) { hiveToast(data.error || 'Request failed', 'error'); btn.textContent = 'Request Access'; btn.disabled = false; return; }
+        btn.outerHTML = '<span style="padding:3px 10px;background:rgba(245,158,11,0.15);color:#fbbf24;border:1px solid rgba(245,158,11,0.3);border-radius:4px;font-size:0.7rem">Pending</span>';
+        hiveToast('Access request sent!', 'success');
+      } catch(e) { hiveToast('Error: ' + e.message, 'error'); btn.textContent = 'Request Access'; btn.disabled = false; }
     }
 
     function renderHives(hives, force) {

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -284,6 +284,38 @@
       renderHives(filtered);
     }
 
+    function contributeButton(h) {
+      if (h.hiveType !== 'hosted') return '';
+      var hid = h.id;
+      var access = _userAccessStatus[hid];
+      if (_isLoggedIn && access) {
+        if (access.status === 'accepted') {
+          var cUrl = 'https://' + esc(hid) + '.hive.kubestellar.io/contribute';
+          return '<a href="' + cUrl + '" target="_blank" style="padding:2px 8px;background:rgba(34,197,94,0.15);color:#4ade80;border:1px solid rgba(34,197,94,0.3);border-radius:4px;font-size:0.65rem;text-decoration:none">Open</a>';
+        }
+        if (access.status === 'pending') {
+          return '<span style="padding:2px 8px;background:rgba(245,158,11,0.15);color:#fbbf24;border:1px solid rgba(245,158,11,0.3);border-radius:4px;font-size:0.65rem">Pending</span>';
+        }
+      }
+      if (_isLoggedIn) {
+        return '<button onclick="requestAccessInline(\'' + esc(hid) + '\',this)" style="padding:2px 8px;background:rgba(59,130,246,0.15);color:#60a5fa;border:1px solid rgba(59,130,246,0.3);border-radius:4px;font-size:0.65rem;cursor:pointer">Request Access</button>';
+      }
+      return '<button onclick="openContributeInfo(\'' + esc(h.name || h.id) + '\',\'' + esc(hid) + '\')" style="padding:2px 8px;background:rgba(34,197,94,0.15);color:#4ade80;border:1px solid rgba(34,197,94,0.3);border-radius:4px;font-size:0.65rem;cursor:pointer">Contribute</button>';
+    }
+
+    async function requestAccessInline(hiveId, btn) {
+      btn.disabled = true;
+      btn.textContent = 'Requesting...';
+      try {
+        var resp = await fetch('/api/saas/hives/' + encodeURIComponent(hiveId) + '/request-access', {method: 'POST'});
+        var data = await resp.json();
+        if (!resp.ok) { hiveToast(data.error || 'Request failed', 'error'); btn.textContent = 'Request Access'; btn.disabled = false; return; }
+        _userAccessStatus[hiveId] = {status: 'pending'};
+        btn.outerHTML = '<span style="padding:2px 8px;background:rgba(245,158,11,0.15);color:#fbbf24;border:1px solid rgba(245,158,11,0.3);border-radius:4px;font-size:0.65rem">Pending</span>';
+        hiveToast('Access request sent!', 'success');
+      } catch(e) { hiveToast('Error: ' + e.message, 'error'); btn.textContent = 'Request Access'; btn.disabled = false; }
+    }
+
     function renderHives(hives) {
       var pub = hives.filter(function(h) { return h.isPublic !== false; });
       if (!pub.length) { document.getElementById('hive-table-container').innerHTML = '<div class="loading">No public hives registered yet</div>'; return; }
@@ -309,9 +341,7 @@
           '<td>' + sparkline(h.prHistory, '#3b82f6', 50, 14) + (h.actionablePRs || 0) + '</td>' +
           '<td>' + (h.activeContributors || 0) + '</td>' +
           '<td>' + link + '</td>' +
-          '<td style="white-space:nowrap">' +
-            (h.hiveType === 'hosted' ? '<button onclick="openContributeInfo(\'' + esc(h.name || h.id) + '\',\'' + esc(h.id) + '\')" style="padding:2px 8px;background:rgba(34,197,94,0.15);color:#4ade80;border:1px solid rgba(34,197,94,0.3);border-radius:4px;font-size:0.65rem;cursor:pointer">Contribute</button>' : '') +
-          '</td>' +
+          '<td style="white-space:nowrap">' + contributeButton(h) + '</td>' +
           '</tr>';
       }).join('');
       document.getElementById('hive-table-container').innerHTML =
@@ -365,15 +395,22 @@
     });
     window.addEventListener('focus', function() { loadRegistry(); loadLeaderboard(); });
 
+    var _userAccessStatus = {};
+
     fetch('/api/auth/user').then(function(r){return r.json()}).then(function(d){
       if(d.authenticated){
         _isLoggedIn = true;
         document.getElementById('nav-login').style.display='none';
         document.getElementById('nav-logout').style.display='';
-        document.getElementById('nav-dashboard').style.display='';
         var u=document.getElementById('nav-user');
         u.style.display='';
         u.innerHTML='<img src="'+esc(d.avatar_url)+'" style="width:24px;height:24px;border-radius:50%;vertical-align:middle">'+' <span style="font-size:0.85rem">'+esc(d.login)+'</span>';
+        return fetch('/api/saas/access-status').then(function(r2){return r2.json()}).then(function(as){
+          _userAccessStatus = as.hives || {};
+          if(as.show_my_hives) document.getElementById('nav-dashboard').style.display='';
+          renderHives(_allMainHives);
+          handleAutoRequestFromUrl();
+        });
       }
     }).catch(function(){});
     async function requestAccess(hiveId) {
@@ -394,27 +431,23 @@
       var area = document.getElementById('contrib-access-area');
 
       if (!_isLoggedIn) {
-        var loginRedirect = '/login?redirect=' + encodeURIComponent('/dashboard?request_hive=' + encodeURIComponent(id));
-        area.innerHTML = '<p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px">Login with GitHub to request access or contribute.</p>' +
+        var loginRedirect = '/login?redirect=' + encodeURIComponent('/?request_hive=' + encodeURIComponent(id));
+        area.innerHTML = '<p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px">Login with GitHub to request access to <strong>' + esc(name) + '</strong>.</p>' +
           '<a href="' + loginRedirect + '" style="padding:8px 16px;background:var(--accent);color:#000;border-radius:6px;font-size:0.85rem;font-weight:600;text-decoration:none;display:inline-block">Login with GitHub</a>';
         return;
       }
 
-      area.innerHTML = '<span style="color:var(--muted);font-size:0.8rem">Checking access...</span>';
-      try {
-        var resp = await fetch('/api/saas/my-hives');
-        if (resp.ok) {
-          var data = await resp.json();
-          var hive = (data.hives || []).find(function(h) { return h.id === id; });
-          if (hive) {
-            var isHosted = id.startsWith('hosted-') || id.startsWith('saas-');
-            var cUrl = isHosted ? 'https://' + id + '.hive.kubestellar.io/contribute' : (hive.dashboardUrl && !hive.dashboardUrl.includes('localhost') ? hive.dashboardUrl + '/contribute' : '');
-            area.innerHTML = '<p style="font-size:0.75rem;color:var(--green);margin-bottom:8px">✓ You have <strong>' + esc(hive.role) + '</strong> access to this hive.</p>' +
-              (cUrl ? '<a href="' + esc(cUrl) + '" target="_blank" style="padding:8px 16px;background:var(--green);color:#fff;border-radius:6px;font-size:0.85rem;font-weight:600;text-decoration:none;display:inline-block">Open Contribute Page</a>' : '');
-            return;
-          }
-        }
-      } catch(e) {}
+      var access = _userAccessStatus[id];
+      if (access && access.status === 'accepted') {
+        var cUrl = 'https://' + esc(id) + '.hive.kubestellar.io/contribute';
+        area.innerHTML = '<p style="font-size:0.75rem;color:var(--green);margin-bottom:8px">You have <strong>' + esc(access.role) + '</strong> access to this hive.</p>' +
+          '<a href="' + cUrl + '" target="_blank" style="padding:8px 16px;background:var(--green);color:#fff;border-radius:6px;font-size:0.85rem;font-weight:600;text-decoration:none;display:inline-block">Open Contribute Page</a>';
+        return;
+      }
+      if (access && access.status === 'pending') {
+        area.innerHTML = '<p style="font-size:0.75rem;color:var(--accent);margin-bottom:8px">Your access request is pending approval.</p>';
+        return;
+      }
 
       area.innerHTML = '<p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px">Request access to view the hive dashboard, agents, and config.</p>' +
         '<button onclick="requestAccessFromModal()" id="contrib-req-btn" style="padding:8px 16px;background:var(--blue);color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:0.85rem">Request Access</button>';
@@ -427,9 +460,32 @@
         var resp = await fetch('/api/saas/hives/' + encodeURIComponent(_contribHiveId) + '/request-access', {method: 'POST'});
         var data = await resp.json();
         if (!resp.ok) { btn.textContent = data.error || 'Failed'; return; }
-        btn.textContent = '✓ Request sent!';
+        _userAccessStatus[_contribHiveId] = {status: 'pending'};
+        btn.textContent = 'Request sent!';
         btn.style.background = 'var(--green)';
+        renderHives(_allMainHives);
       } catch(e) { btn.textContent = 'Error'; }
+    }
+
+    async function handleAutoRequestFromUrl() {
+      var params = new URLSearchParams(window.location.search);
+      var hiveId = params.get('request_hive');
+      if (!hiveId || !_isLoggedIn) return;
+      window.history.replaceState({}, '', '/');
+      if (_userAccessStatus[hiveId]) return;
+      try {
+        var resp = await fetch('/api/saas/hives/' + encodeURIComponent(hiveId) + '/request-access', {method: 'POST'});
+        var data = await resp.json();
+        if (resp.ok) {
+          _userAccessStatus[hiveId] = {status: 'pending'};
+          var hiveName = hiveId;
+          (_allMainHives || []).forEach(function(h) { if (h.id === hiveId) hiveName = h.name || h.id; });
+          hiveToast('Access request sent for ' + hiveName + '!', 'success');
+          renderHives(_allMainHives);
+        } else {
+          hiveToast(data.error || 'Request failed', 'error');
+        }
+      } catch(e) { hiveToast('Error: ' + e.message, 'error'); }
     }
 
     (async function loadHubVersion() {


### PR DESCRIPTION
## Summary
- **My Hives nav visibility**: Only shown for users who own/have accepted access to a hive, or are hub admin. New `show_my_hives` field in `/api/saas/my-hives` response. Public page uses new `/api/saas/access-status` endpoint.
- **Public page contribute buttons**: Context-aware — green "Open" (accepted access), yellow "Pending" (request pending), blue "Request Access" (logged in, no access), or "Contribute" modal (not logged in with login redirect).
- **Dashboard Public Hives section**: Below user's own hives, shows all public hosted hives the user doesn't own, with Request Access / Pending / Contribute actions.
- **Auto-request after login redirect**: When redirected to `/?request_hive={id}` after login, auto-fires the access request and shows a toast.

## Test plan
- [ ] Visit public page logged out — all hosted hives show "Contribute" button opening modal
- [ ] Log in as user with no hives — "My Hives" nav link should NOT appear
- [ ] Log in as user with hives — "My Hives" nav link should appear
- [ ] Log in as admin — "My Hives" nav link always appears
- [ ] On public page while logged in — buttons show "Request Access" for hives without access
- [ ] Click "Request Access" — button changes to "Pending" badge inline
- [ ] Visit `/dashboard` — "Public Hives" section shows hives not owned by user
- [ ] Click "Contribute" while not logged in — modal shows login redirect to `/?request_hive={id}`
- [ ] After login redirect — access request fires automatically, toast shown, button updates to Pending