### PR TITLE
feat: GitHub App install banner on spoke dashboard for 403 errors

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -225,6 +225,7 @@ func main() {
 	notifier := notify.New(cfg.Notifications, logger)
 	notifier.SetHiveID(cfg.HiveID)
 	acmmLevel := inferACMMLevel(cfg)
+	githubAppRequired := false
 
 	// Find or create the pinned advisory issue. Any level can have advisory
 	// agents whose findings should be posted to this issue.
@@ -238,6 +239,10 @@ func main() {
 			num, err := ghClient.EnsureAdvisoryIssue(ctx, primaryRepo)
 			if err != nil {
 				logger.Error("failed to ensure advisory issue", "repo", primaryRepo, "error", err)
+				if strings.Contains(err.Error(), "403") {
+					githubAppRequired = true
+					logger.Warn("GitHub App not installed — issue creation returned 403, setting githubAppRequired flag")
+				}
 			} else {
 				advisoryIssues[primaryRepo] = num
 				os.Setenv("HIVE_ADVISORY_ISSUE", fmt.Sprintf("%d", num))
@@ -722,14 +727,20 @@ func main() {
 				num, err := ghClient.EnsureAdvisoryIssue(ctx, newPrimaryRepo)
 				if err != nil {
 					logger.Error("failed to create advisory issue on new primary repo", "repo", newPrimaryRepo, "error", err)
+					if strings.Contains(err.Error(), "403") {
+						dashSrv.SetGitHubAppRequired(true)
+					}
 				} else {
 					advisoryIssues[newPrimaryRepo] = num
 					os.Setenv("HIVE_ADVISORY_ISSUE", fmt.Sprintf("%d", num))
+					dashSrv.SetGitHubAppRequired(false)
 					logger.Info("advisory issue ready on new primary repo", "repo", newPrimaryRepo, "number", num)
 				}
 			}
 		},
 	})
+
+	dashSrv.SetGitHubAppRequired(githubAppRequired)
 
 	if brainstormBeads, ok := beadStores["brainstorm"]; ok {
 		inceptionWatcher := dashboard.NewInceptionWatcher(brainstormBeads, inceptionEngine, sched, agentMgr, gov, logger)
@@ -975,8 +986,9 @@ func main() {
 				SnapshotURL:  cfg.Hub.SnapshotURL,
 				IsPublic:     cfg.Hub.IsPublic,
 				Version:      "2.0.0",
-				GitHash:      gitShort,
-				GitBranch:    gitBranch,
+				GitHash:           gitShort,
+				GitBranch:         gitBranch,
+				GitHubAppRequired: dashSrv.IsGitHubAppRequired(),
 			}
 		}, time.Duration(cfg.Governor.EvalIntervalS)*time.Second, logger)
 
@@ -1100,6 +1112,22 @@ func runEvalCycle(
 	restartedAgents []string,
 	logger *slog.Logger,
 ) {
+	if dashSrv.IsGitHubAppRequired() {
+		primaryRepo := cfg.Project.PrimaryRepo
+		if primaryRepo == "" && len(cfg.Project.Repos) > 0 {
+			primaryRepo = cfg.Project.Repos[0]
+		}
+		if primaryRepo != "" && ghClient != nil {
+			num, retryErr := ghClient.EnsureAdvisoryIssue(ctx, primaryRepo)
+			if retryErr == nil {
+				advisoryIssues[primaryRepo] = num
+				os.Setenv("HIVE_ADVISORY_ISSUE", fmt.Sprintf("%d", num))
+				dashSrv.SetGitHubAppRequired(false)
+				logger.Info("GitHub App permissions restored — advisory issue created", "repo", primaryRepo, "number", num)
+			}
+		}
+	}
+
 	actionable, err := ghClient.EnumerateActionable(ctx)
 	if err != nil {
 		logger.Error("failed to enumerate actionable items", "error", err)

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -67,6 +67,10 @@ type Server struct {
 
 	ready   bool
 	readyAt time.Time
+
+	githubAppMu         sync.RWMutex
+	githubAppRequired   bool
+	githubAppInstallURL string
 }
 
 // StatusPayload matches the JSON contract the dashboard frontend render() expects.
@@ -88,8 +92,10 @@ type StatusPayload struct {
 	ACMMLevel        int                 `json:"acmmLevel"`
 	ACMMPackAgents   []string            `json:"acmmPackAgents"`
 	AdvisoryDigest   any                 `json:"advisoryDigest,omitempty"`
-	ContributorPool  *ContributorPoolStatus `json:"contributorPool,omitempty"`
-	SystemResources  *SystemResources    `json:"systemResources,omitempty"`
+	ContributorPool    *ContributorPoolStatus `json:"contributorPool,omitempty"`
+	SystemResources    *SystemResources    `json:"systemResources,omitempty"`
+	GitHubAppRequired  bool                `json:"githubAppRequired,omitempty"`
+	GitHubAppInstallURL string             `json:"githubAppInstallURL,omitempty"`
 }
 
 type FrontendAgent struct {
@@ -388,6 +394,11 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 	}
 	status.ContributorPool = s.BuildContributorPoolStatus()
 
+	s.githubAppMu.RLock()
+	status.GitHubAppRequired = s.githubAppRequired
+	status.GitHubAppInstallURL = s.githubAppInstallURL
+	s.githubAppMu.RUnlock()
+
 	s.statusMu.Lock()
 	status.Timestamp = time.Now().UTC().Format(time.RFC3339)
 	s.status = status
@@ -403,6 +414,25 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 	}
 
 	s.broadcastFrame(fmt.Sprintf("data: %s\n\n", data))
+}
+
+const GitHubAppInstallURL = "https://github.com/apps/hive-hub/installations/select_target_repositories"
+
+func (s *Server) SetGitHubAppRequired(required bool) {
+	s.githubAppMu.Lock()
+	defer s.githubAppMu.Unlock()
+	s.githubAppRequired = required
+	if required {
+		s.githubAppInstallURL = GitHubAppInstallURL
+	} else {
+		s.githubAppInstallURL = ""
+	}
+}
+
+func (s *Server) IsGitHubAppRequired() bool {
+	s.githubAppMu.RLock()
+	defer s.githubAppMu.RUnlock()
+	return s.githubAppRequired
 }
 
 // BroadcastAgentStatus sends a lightweight agent-only SSE event on a fast

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -563,6 +563,11 @@
     .gh-auth-banner .gh-auth-btn { background: #238636; color: #fff; border: none; padding: 6px 16px; border-radius: 6px; cursor: pointer; font-weight: 600; font-size: 0.85rem; }
     .gh-auth-banner .gh-auth-btn:hover { background: #2ea043; }
     .gh-auth-banner .gh-auth-user { color: #58a6ff; font-weight: 600; }
+    .gh-app-install-banner { background: #7f1d1d; border: 1px solid #dc2626; border-radius: 8px; padding: 16px; margin-bottom: 16px; display: flex; align-items: center; gap: 12px; }
+    .gh-app-install-banner .gh-app-title { font-weight: 600; margin-bottom: 4px; color: #fff; }
+    .gh-app-install-banner .gh-app-desc { font-size: 0.85rem; color: #fca5a5; }
+    .gh-app-install-banner .gh-app-btn { padding: 8px 16px; background: #dc2626; color: #fff; border-radius: 6px; font-weight: 600; text-decoration: none; white-space: nowrap; border: none; cursor: pointer; font-size: 0.85rem; }
+    .gh-app-install-banner .gh-app-btn:hover { background: #ef4444; }
     .gh-auth-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.6); z-index: 9999; display: flex; align-items: center; justify-content: center; }
     .gh-auth-modal { background: #fff; border-radius: 12px; padding: 32px; max-width: 420px; width: 90%; text-align: center; box-shadow: 0 20px 60px rgba(0,0,0,0.3); }
     .gh-auth-modal h3 { margin: 0 0 8px; font-size: 1.2rem; color: #1a1a2e; }
@@ -1924,6 +1929,14 @@
     <div id="logs-output" style="background: #1a1a2e; color: #e2e8f0; font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.75rem; line-height: 1.5; padding: 14px; border-radius: 8px; max-height: 500px; overflow-y: auto; white-space: pre-wrap; word-break: break-all;"></div>
   </div>
 
+  <div id="gh-app-install-banner" class="gh-app-install-banner" style="display:none">
+    <span style="font-size:1.5rem">&#9888;&#65039;</span>
+    <div style="flex:1">
+      <div class="gh-app-title">GitHub App Not Installed</div>
+      <div class="gh-app-desc">This hive cannot create issues or advisory reports. Install the Hive Hub GitHub App on your repository to enable full functionality.</div>
+    </div>
+    <a id="gh-app-install-link" href="" target="_blank" rel="noopener" class="gh-app-btn">Install GitHub App</a>
+  </div>
   <div id="oc-gov-strip-outer" class="oc-gov-strip"></div>
   <div id="oc-agent-detail" class="oc-agent-detail"></div>
   <div class="agents" id="agents"></div>
@@ -3267,6 +3280,18 @@
           if (prev) prev.focus();
         }
         el.querySelectorAll('.doing').forEach(d => { d.scrollTop = d.scrollHeight; });
+      }
+    }
+
+    function renderGitHubAppBanner(data) {
+      var banner = document.getElementById('gh-app-install-banner');
+      if (!banner) return;
+      if (data.githubAppRequired && data.githubAppInstallURL) {
+        var link = document.getElementById('gh-app-install-link');
+        if (link) link.href = data.githubAppInstallURL;
+        banner.style.display = 'flex';
+      } else {
+        banner.style.display = 'none';
       }
     }
 
@@ -6572,6 +6597,7 @@ function burnAreaChart() {
         }
       }
       renderGhRateLimits(data.ghRateLimits || {});
+      renderGitHubAppBanner(data);
       if (!_dropdownOpen && !_configModalOpen) {
         applyPinOverrides(data.agents || []);
         renderAgents(data.agents || []);

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -61,7 +61,8 @@ type HeartbeatPayload struct {
 	Version      string             `json:"version"`
 	GitHash      string             `json:"git_hash"`
 	GitBranch    string             `json:"git_branch,omitempty"`
-	Timestamp    string             `json:"timestamp"`
+	Timestamp          string         `json:"timestamp"`
+	GitHubAppRequired  bool           `json:"github_app_required,omitempty"`
 }
 
 type StatusCollector func() *HeartbeatPayload

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -68,6 +68,7 @@ type RegistryEntry struct {
 	UpgradeTarget      string         `json:"upgradeTarget,omitempty"`
 	IssueHistory       []SparkPoint   `json:"issueHistory,omitempty"`
 	PRHistory          []SparkPoint   `json:"prHistory,omitempty"`
+	GitHubAppRequired  bool           `json:"githubAppRequired,omitempty"`
 }
 
 type SparkPoint struct {
@@ -321,7 +322,8 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			}
 			return payload.Leaderboard
 		}(),
-		Online: true,
+		Online:            true,
+		GitHubAppRequired: payload.GitHubAppRequired,
 	}
 
 	s.mu.Lock()

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -330,7 +330,7 @@
           : '<span style="display:inline-block;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:rgba(107,114,128,0.15);color:#9ca3af;border:1px solid rgba(107,114,128,0.3)" title="Self-hosted by the owner">local</span>';
         return '<tr>' +
           '<td style="white-space:nowrap">' + contributeButton(h) + '</td>' +
-          '<td style="display:flex;align-items:center;gap:10px"><img src="https://github.com/' + esc(h.org) + '.png" style="width:36px;height:36px;border-radius:6px;flex-shrink:0" onerror="this.style.display=\'none\'">' + dot + '<div><span class="hive-name">' + esc(h.name || h.id) + '</span></div></td>' +
+          '<td style="display:flex;align-items:center;gap:10px"><img src="https://github.com/' + esc(h.org) + '.png" style="width:36px;height:36px;border-radius:6px;flex-shrink:0" onerror="this.style.display=\'none\'">' + dot + '<div><span class="hive-name">' + esc(h.name || h.id) + '</span>' + (h.githubAppRequired ? ' <span title="GitHub App not installed — cannot create issues" style="color:#f59e0b;cursor:help">&#9888;&#65039;</span>' : '') + '</div></td>' +
           '<td>' + htype + '</td>' +
           '<td>' + repoLink + '</td>' +
           '<td>' + repoCount + '</td>' +


### PR DESCRIPTION
## Summary
- When `EnsureAdvisoryIssue` fails with a 403 error (missing issue permissions), the spoke dashboard now shows a persistent red banner directing the user to install the Hive Hub GitHub App
- The banner includes a direct link to `https://github.com/apps/hive-hub/installations/select_target_repositories`
- On each governor eval cycle, the hive retries `EnsureAdvisoryIssue` — if it succeeds, the banner auto-clears via the next SSE status push
- The hub's My Hives table shows a warning icon next to hives whose heartbeat reports `githubAppRequired: true`
- Added `GitHubAppRequired` and `GitHubAppInstallURL` fields to the status payload, `SetGitHubAppRequired`/`IsGitHubAppRequired` methods on the dashboard server, and the corresponding heartbeat/registry fields

## Files changed
- `v2/cmd/hive/main.go` — detect 403 from EnsureAdvisoryIssue, set flag on dashSrv, retry each eval cycle
- `v2/pkg/dashboard/server.go` — new fields on StatusPayload and Server, setter/getter methods, inject into SSE payload
- `v2/pkg/dashboard/static/index.html` — banner HTML, CSS, and renderGitHubAppBanner() JS function
- `v2/pkg/hub/heartbeat.go` — added `github_app_required` to HeartbeatPayload
- `v2/pkg/hub/server.go` — added `githubAppRequired` to RegistryEntry, propagated from heartbeat
- `v2/pkg/hub/static/index.html` — warning icon next to hive name in My Hives table

## Test plan
- [ ] Provision a hive with a PAT lacking issue permissions, verify the red banner appears on the spoke dashboard
- [ ] Install the GitHub App on the repo, wait for the next eval cycle, verify the banner disappears
- [ ] Verify the hub's My Hives page shows a warning icon next to hives with the flag set
- [ ] Run `go vet ./v2/...` — passes clean