### PR TITLE
fix: rename Open to Contribute Now

### DIFF
--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -291,7 +291,7 @@
       if (_isLoggedIn && access) {
         if (access.status === 'accepted') {
           var cUrl = 'https://' + esc(hid) + '.hive.kubestellar.io/contribute';
-          return '<a href="' + cUrl + '" target="_blank" style="padding:2px 8px;background:rgba(34,197,94,0.15);color:#4ade80;border:1px solid rgba(34,197,94,0.3);border-radius:4px;font-size:0.65rem;text-decoration:none">Open</a>';
+          return '<a href="' + cUrl + '" target="_blank" style="padding:2px 8px;background:rgba(34,197,94,0.15);color:#4ade80;border:1px solid rgba(34,197,94,0.3);border-radius:4px;font-size:0.65rem;text-decoration:none">Contribute Now</a>';
         }
         if (access.status === 'pending') {
           return '<span style="padding:2px 8px;background:rgba(245,158,11,0.15);color:#fbbf24;border:1px solid rgba(245,158,11,0.3);border-radius:4px;font-size:0.65rem">Pending</span>';


### PR DESCRIPTION
Renames the left-column button from 'Open' to 'Contribute Now' for accepted contributors.