### PR TITLE
Add repo filter to ACMM proxy

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -854,7 +854,7 @@ func main() {
 	dashSrv.SetSkipReloadFunc(configWatcher.SkipNext)
 	go configWatcher.Start(ctx)
 
-	githubProxy, err := proxy.NewGitHubProxy(logger)
+	githubProxy, err := proxy.NewGitHubProxy(logger, cfg.Project.Org, cfg.Project.Repos)
 	if err != nil {
 		logger.Error("failed to create github proxy", "error", err)
 	} else {

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -34,11 +34,12 @@ const (
 // GitHubProxy is an HTTP CONNECT proxy that performs MITM TLS
 // inspection on GitHub API traffic and enforces ACMM mode rules.
 type GitHubProxy struct {
-	listenAddr string
-	caCert     tls.Certificate
-	caX509     *x509.Certificate
-	logger     *slog.Logger
-	uidMap     *agent.UIDMap
+	listenAddr   string
+	caCert       tls.Certificate
+	caX509       *x509.Certificate
+	logger       *slog.Logger
+	uidMap       *agent.UIDMap
+	allowedRepos map[string]bool
 
 	mu         sync.RWMutex
 	violations map[string]int // agent name -> blocked request count
@@ -53,7 +54,10 @@ type cachedCert struct {
 }
 
 // NewGitHubProxy creates a proxy with a self-signed CA for MITM.
-func NewGitHubProxy(logger *slog.Logger) (*GitHubProxy, error) {
+// The org and repos parameters define which repositories are allowed for
+// write operations. Repos should be bare names (e.g. "console"); the org
+// is prepended to form "org/repo" keys.
+func NewGitHubProxy(logger *slog.Logger, org string, repos []string) (*GitHubProxy, error) {
 	caCert, caX509, err := generateCA()
 	if err != nil {
 		return nil, fmt.Errorf("generate CA: %w", err)
@@ -70,14 +74,21 @@ func NewGitHubProxy(logger *slog.Logger) (*GitHubProxy, error) {
 		logger.Info("proxy loaded UID map", "agents", len(uidMap.Agents), "iptables", uidMap.IptablesActive)
 	}
 
+	allowed := make(map[string]bool, len(repos))
+	for _, repo := range repos {
+		key := org + "/" + repo
+		allowed[key] = true
+	}
+
 	p := &GitHubProxy{
-		listenAddr: fmt.Sprintf("127.0.0.1:%d", proxyListenPort),
-		caCert:     caCert,
-		caX509:     caX509,
-		logger:     logger,
-		uidMap:     uidMap,
-		violations: make(map[string]int),
-		certCache:  make(map[string]cachedCert),
+		listenAddr:   fmt.Sprintf("127.0.0.1:%d", proxyListenPort),
+		caCert:       caCert,
+		caX509:       caX509,
+		logger:       logger,
+		uidMap:       uidMap,
+		allowedRepos: allowed,
+		violations:   make(map[string]int),
+		certCache:    make(map[string]cachedCert),
 	}
 
 	// Pre-warm cert cache for known GitHub hosts to avoid startup burst
@@ -499,6 +510,9 @@ func (p *GitHubProxy) proxyHTTP(client net.Conn, upstream net.Conn, agentName st
 			req.ContentLength = int64(len(body))
 		} else if !AllowedByMode(mode, req.Method, req.URL.Path) {
 			blocked = true
+		} else if len(p.allowedRepos) > 0 && !RepoFilterAllowed(p.allowedRepos, req.Method, req.URL.Path) {
+			blocked = true
+			blockReason = "repo not in hive config"
 		}
 
 		if blocked {

--- a/v2/pkg/proxy/rules.go
+++ b/v2/pkg/proxy/rules.go
@@ -79,6 +79,41 @@ func AllowedByMode(mode agent.AgentMode, method, path string) bool {
 	return false
 }
 
+var repoPathPrefix = regexp.MustCompile(`^/repos/([^/]+/[^/]+)`)
+
+var gitPathPrefix = regexp.MustCompile(`^/([^/]+/[^/]+)\.git/`)
+
+var writeMethods = map[string]bool{
+	"POST":   true,
+	"PUT":    true,
+	"PATCH":  true,
+	"DELETE": true,
+}
+
+func ExtractRepo(path string) string {
+	if m := repoPathPrefix.FindStringSubmatch(path); len(m) > 1 {
+		return m[1]
+	}
+	if m := gitPathPrefix.FindStringSubmatch(path); len(m) > 1 {
+		return m[1]
+	}
+	return ""
+}
+
+func RepoFilterAllowed(allowedRepos map[string]bool, method, path string) bool {
+	if !writeMethods[method] {
+		return true
+	}
+	if len(allowedRepos) == 0 {
+		return true
+	}
+	repo := ExtractRepo(path)
+	if repo == "" {
+		return true
+	}
+	return allowedRepos[repo]
+}
+
 // IsGraphQLPath returns true if the path is the GitHub GraphQL endpoint.
 func IsGraphQLPath(path string) bool {
 	return path == "/graphql"

--- a/v2/pkg/proxy/rules_test.go
+++ b/v2/pkg/proxy/rules_test.go
@@ -101,6 +101,77 @@ func TestGraphQLAllowed(t *testing.T) {
 	}
 }
 
+func TestExtractRepo(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/repos/org/repo/issues", "org/repo"},
+		{"/repos/org/repo/pulls/42/merge", "org/repo"},
+		{"/repos/org/repo/git/refs", "org/repo"},
+		{"/repos/org/repo/contents/README.md", "org/repo"},
+		{"/org/repo.git/git-receive-pack", "org/repo"},
+		{"/org/repo.git/git-upload-pack", "org/repo"},
+		{"/user", ""},
+		{"/rate_limit", ""},
+		{"/search/issues", ""},
+		{"/orgs/myorg/repos", ""},
+		{"/graphql", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := ExtractRepo(tt.path)
+			if got != tt.want {
+				t.Errorf("ExtractRepo(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRepoFilterAllowed(t *testing.T) {
+	allowed := map[string]bool{
+		"myorg/console": true,
+		"myorg/docs":    true,
+	}
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		want   bool
+	}{
+		{"GET any repo passes", "GET", "/repos/myorg/other/issues", true},
+		{"HEAD any repo passes", "HEAD", "/repos/myorg/other/pulls", true},
+		{"POST allowed repo passes", "POST", "/repos/myorg/console/issues", true},
+		{"POST disallowed repo blocked", "POST", "/repos/projectbluefin/documentation/issues", false},
+		{"PATCH allowed repo passes", "PATCH", "/repos/myorg/docs/issues/42", true},
+		{"PATCH disallowed repo blocked", "PATCH", "/repos/myorg/other/issues/42", false},
+		{"PUT disallowed repo blocked", "PUT", "/repos/myorg/other/pulls/1/merge", false},
+		{"DELETE disallowed repo blocked", "DELETE", "/repos/myorg/other/git/refs/heads/branch", false},
+		{"POST non-repo path passes", "POST", "/graphql", true},
+		{"POST user endpoint passes", "POST", "/user", true},
+		{"git push allowed repo passes", "POST", "/myorg/console.git/git-receive-pack", true},
+		{"git push disallowed repo blocked", "POST", "/myorg/other.git/git-receive-pack", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RepoFilterAllowed(allowed, tt.method, tt.path)
+			if got != tt.want {
+				t.Errorf("RepoFilterAllowed(%q, %q) = %v, want %v",
+					tt.method, tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRepoFilterEmptyAllowedPassesAll(t *testing.T) {
+	empty := map[string]bool{}
+	if !RepoFilterAllowed(empty, "POST", "/repos/any/repo/issues") {
+		t.Error("empty allowedRepos should allow all requests")
+	}
+}
+
 func TestIsGitHubHost(t *testing.T) {
 	tests := []struct {
 		host string


### PR DESCRIPTION
## Summary
- Adds repo-level write filtering to the ACMM proxy so agents cannot POST/PUT/PATCH/DELETE to GitHub repos not listed in `project.repos`
- Extracts `owner/repo` from both REST API paths (`/repos/{owner}/{repo}/...`) and git smart HTTP paths (`/{owner}/{repo}.git/...`)
- Read operations (GET/HEAD) pass through to any repo; non-repo endpoints (`/user`, `/search`, `/graphql`) are unaffected
- Includes unit tests for `ExtractRepo`, `RepoFilterAllowed`, and empty-allowlist passthrough

## Context
Knuckle's hive removed `documentation` from its repo list, but agents with cached refs kept creating PRs on `projectbluefin/documentation`. This filter enforces the configured repo boundary at the proxy layer.

## Test plan
- [x] `go vet ./pkg/proxy/ ./cmd/hive/` passes
- [x] `go test ./pkg/proxy/` passes (all existing + new tests)
- [ ] CI