### PR TITLE
fix: persist git source changes and fix layer filtering

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -2811,6 +2811,26 @@ func (s *Server) handleKnowledgeLayer(w http.ResponseWriter, r *http.Request) {
 	layer := r.PathValue("layer")
 	typeFilter := r.URL.Query().Get("type")
 
+	const gitSourcePrefix = "git_source:"
+	if strings.HasPrefix(layer, gitSourcePrefix) {
+		name := strings.TrimPrefix(layer, gitSourcePrefix)
+		store := s.deps.Knowledge.GetGitSourceStore(name)
+		if store == nil {
+			jsonResponse(w, map[string]interface{}{"layer": layer, "count": 0, "facts": []interface{}{}})
+			return
+		}
+		facts := store.ListPages(typeFilter)
+		for i := range facts {
+			facts[i].Layer = knowledge.LayerType(layer)
+		}
+		jsonResponse(w, map[string]interface{}{
+			"layer": layer,
+			"count": len(facts),
+			"facts": facts,
+		})
+		return
+	}
+
 	knowledgeLayer := knowledge.LayerType(layer)
 	facts := s.deps.Knowledge.LayerFacts(s.deps.Ctx, knowledgeLayer, typeFilter)
 	if facts == nil {
@@ -3258,6 +3278,27 @@ func (s *Server) handleGitSourcesConnect(w http.ResponseWriter, r *http.Request)
 		jsonError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	alreadyInConfig := false
+	for _, gs := range s.deps.Config.Knowledge.GitSources {
+		if gs.URL == req.URL && gs.Subpath == req.Subpath {
+			alreadyInConfig = true
+			break
+		}
+	}
+	if !alreadyInConfig {
+		s.deps.Config.Knowledge.GitSources = append(s.deps.Config.Knowledge.GitSources, config.GitSourceConfigYAML{
+			Name:    req.Name,
+			URL:     req.URL,
+			Branch:  req.Branch,
+			Subpath: req.Subpath,
+			Layer:   req.Layer,
+		})
+	}
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after git source connect", "error", err)
+	}
+
 	jsonResponse(w, map[string]interface{}{"ok": true, "name": req.Name, "url": req.URL})
 }
 
@@ -3284,6 +3325,19 @@ func (s *Server) handleGitSourcesDisconnect(w http.ResponseWriter, r *http.Reque
 		jsonError(w, err.Error(), http.StatusNotFound)
 		return
 	}
+
+	filtered := make([]config.GitSourceConfigYAML, 0, len(s.deps.Config.Knowledge.GitSources))
+	for _, gs := range s.deps.Config.Knowledge.GitSources {
+		if gs.URL == req.URL && gs.Subpath == req.Subpath {
+			continue
+		}
+		filtered = append(filtered, gs)
+	}
+	s.deps.Config.Knowledge.GitSources = filtered
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after git source disconnect", "error", err)
+	}
+
 	jsonResponse(w, map[string]interface{}{"ok": true, "removed": req.URL})
 }
 


### PR DESCRIPTION
## Summary
- `handleKnowledgeLayer()` now handles `git_source:` prefixed layers by looking up the GitSourceStore directly instead of casting to LayerType enum (which doesn't include git source values)
- `handleGitSourcesConnect()` persists new git sources to config via `saveConfig()` so they survive pod restarts
- `handleGitSourcesDisconnect()` removes git sources from config and persists

Fixes Jorge's knowledge reset issue on knuckle where dashboard-added git sources were lost on pod restart.

## Test plan
- [ ] Add a git source via dashboard, restart pod, verify it's still there
- [ ] Click on a `git_source:*` layer in knowledge panel, verify facts load