### PR TITLE
fix: don't clear githubAppRequired on eval cycle retry

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1122,8 +1122,7 @@ func runEvalCycle(
 			if retryErr == nil {
 				advisoryIssues[primaryRepo] = num
 				os.Setenv("HIVE_ADVISORY_ISSUE", fmt.Sprintf("%d", num))
-				dashSrv.SetGitHubAppRequired(false)
-				logger.Info("GitHub App permissions restored — advisory issue created", "repo", primaryRepo, "number", num)
+				logger.Info("advisory issue created on retry", "repo", primaryRepo, "number", num)
 			}
 		}
 	}

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1339,6 +1339,9 @@ func runEvalCycle(
 					}
 					if err := postClient.PostAdvisoryDigest(ctx, primaryRepo, issueNum, md); err != nil {
 						logger.Warn("failed to post advisory digest", "repo", primaryRepo, "issue", issueNum, "error", err)
+						if strings.Contains(err.Error(), "403") {
+							dashSrv.SetGitHubAppRequired(true)
+						}
 					} else {
 						logger.Info("posted advisory digest", "repo", primaryRepo, "issue", issueNum, "findings", digest.TotalCount)
 					}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1848,6 +1848,14 @@
     <a href="/api/widget" class="widget-dl" title="Download Übersicht widget">⬇ Widget</a>
   </h1>
 
+  <div id="gh-app-install-banner" class="gh-app-install-banner" style="display:none">
+    <span style="font-size:1.5rem">&#9888;&#65039;</span>
+    <div style="flex:1">
+      <div class="gh-app-title">GitHub App Not Installed</div>
+      <div class="gh-app-desc">This hive cannot create issues or advisory reports. Install the Hive Hub GitHub App on your repository to enable full functionality.</div>
+    </div>
+    <a id="gh-app-install-link" href="" target="_blank" rel="noopener" class="gh-app-btn">Install GitHub App</a>
+  </div>
   <div class="governor" id="governor"></div>
 
   <div id="advisory-section" style="margin-top: 16px; margin-bottom: 24px; display: none;">
@@ -1929,14 +1937,6 @@
     <div id="logs-output" style="background: #1a1a2e; color: #e2e8f0; font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.75rem; line-height: 1.5; padding: 14px; border-radius: 8px; max-height: 500px; overflow-y: auto; white-space: pre-wrap; word-break: break-all;"></div>
   </div>
 
-  <div id="gh-app-install-banner" class="gh-app-install-banner" style="display:none">
-    <span style="font-size:1.5rem">&#9888;&#65039;</span>
-    <div style="flex:1">
-      <div class="gh-app-title">GitHub App Not Installed</div>
-      <div class="gh-app-desc">This hive cannot create issues or advisory reports. Install the Hive Hub GitHub App on your repository to enable full functionality.</div>
-    </div>
-    <a id="gh-app-install-link" href="" target="_blank" rel="noopener" class="gh-app-btn">Install GitHub App</a>
-  </div>
   <div id="oc-gov-strip-outer" class="oc-gov-strip"></div>
   <div id="oc-agent-detail" class="oc-agent-detail"></div>
   <div class="agents" id="agents"></div>

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -253,11 +253,12 @@
     }
 
     function renderStats(hives) {
-      var agents = 0, contributors = 0, online = 0;
-      hives.forEach(function(h) { agents += h.agentCount || 0; contributors += h.activeContributors || 0; if (h.online) online++; });
+      var agents = 0, contributors = 0, online = 0, repos = 0;
+      hives.forEach(function(h) { agents += h.agentCount || 0; contributors += h.activeContributors || 0; repos += (h.repos || []).length; if (h.online) online++; });
       document.getElementById('hero-stats').innerHTML =
         '<span>' + online + '/' + hives.length + ' hives online</span>' +
         '<span class="dot"></span><span>' + agents + ' agents running</span>' +
+        '<span class="dot"></span><span>' + repos + ' managed repos</span>' +
         '<span class="dot"></span><span>' + contributors + ' contributors</span>';
     }
 


### PR DESCRIPTION
Prevents banner from disappearing when advisory issue creates successfully but digest update still fails with 403.