### PR TITLE
fix: stop eval cycle from clearing githubAppRequired

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1122,8 +1122,7 @@ func runEvalCycle(
 			if retryErr == nil {
 				advisoryIssues[primaryRepo] = num
 				os.Setenv("HIVE_ADVISORY_ISSUE", fmt.Sprintf("%d", num))
-				dashSrv.SetGitHubAppRequired(false)
-				logger.Info("GitHub App permissions restored — advisory issue created", "repo", primaryRepo, "number", num)
+				logger.Info("advisory issue created on retry", "repo", primaryRepo, "number", num)
 			}
 		}
 	}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1848,7 +1848,7 @@
     <a href="/api/widget" class="widget-dl" title="Download Übersicht widget">⬇ Widget</a>
   </h1>
 
-  <div id="gh-app-install-banner" class="gh-app-install-banner" style="display:none">
+  <div id="gh-app-install-banner" class="gh-app-install-banner" hidden
     <span style="font-size:1.5rem">&#9888;&#65039;</span>
     <div style="flex:1">
       <div class="gh-app-title">GitHub App Not Installed</div>
@@ -3289,9 +3289,11 @@
       if (data.githubAppRequired && data.githubAppInstallURL) {
         var link = document.getElementById('gh-app-install-link');
         if (link) link.href = data.githubAppInstallURL;
-        banner.style.display = 'flex';
+        banner.removeAttribute('hidden');
+        banner.style.cssText = 'display:flex !important';
       } else {
-        banner.style.display = 'none';
+        banner.setAttribute('hidden', '');
+        banner.style.cssText = 'display:none';
       }
     }
 


### PR DESCRIPTION
Banner flashes 1s then disappears because eval retry clears the flag before digest 403 re-sets it.