### PR TITLE
feat: agent import/export and enhanced prompt template editor

### DIFF
--- a/v2/examples/agents/customized-agent.yaml
+++ b/v2/examples/agents/customized-agent.yaml
@@ -1,0 +1,56 @@
+# Example Agent Definition for Hive v2
+# Import this via the dashboard: + agent → Import from URL
+# URL: https://raw.githubusercontent.com/kubestellar/hive/v2/v2/examples/agents/customized-agent.yaml
+apiVersion: hive.kubestellar.io/v1
+kind: AgentDefinition
+metadata:
+  name: customized-agent
+  displayName: "Customized Agent"
+  description: "A template agent that demonstrates the portable agent definition format. Customize this to create your own specialized agent."
+  emoji: "\U0001F6E0"
+  color: "#e67e22"
+spec:
+  backend: copilot
+  model: claude-sonnet-4-6
+  role: custom
+  mode: ADVISORY
+  sortOrder: 50
+  beadRole: worker
+  staleTimeout: 28800
+  restartStrategy: immediate
+  clearOnKick: true
+  includeRepos: true
+  laneKeywords:
+    - custom
+    - review
+  detectKeywords:
+    - customized
+  aliases:
+    - cu
+  cadences:
+    idle: 4h
+    quiet: 4h
+    busy: 2h
+    surge: "off"
+  promptTemplate: |
+    # ${AGENT_DISPLAY_NAME} — Custom Agent Policy
+
+    ${GH_AUTH}
+
+    You are the **${AGENT_NAME}** agent for ${PROJECT_ORG}/${PROJECT_PRIMARY_REPO}.
+
+    ## Your Role
+    Analyze the codebase and provide recommendations based on your expertise.
+    Focus on the repositories listed below and create advisory beads for your findings.
+
+    ## Rules
+    - Only work items from the kick message
+    - Always sign commits with DCO: git commit -s
+    - Respect hold labels
+    - Write a bead for every finding
+
+    ## Work List
+    ISSUES: ${ISSUE_LIST}
+    PRs: ${PR_LIST}
+
+    ${KNOWLEDGE}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -76,6 +76,8 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("PUT /api/config/agent/{name}/restrictions", s.handleAgentConfigRestrictions)
 	s.mux.HandleFunc("PUT /api/config/agent/{name}/stats", s.handleAgentConfigStats)
 	s.mux.HandleFunc("GET /api/config/agent/{name}/prompt", s.handleAgentPrompt)
+	s.mux.HandleFunc("PUT /api/config/agent/{name}/prompt", s.handleAgentPromptSave)
+	s.mux.HandleFunc("GET /api/config/agent/{name}/export", s.handleAgentExport)
 	s.mux.HandleFunc("GET /api/config/stat-sources", s.handleStatSources)
 
 	s.mux.HandleFunc("GET /api/config/governor", s.handleGovernorConfigGet)
@@ -93,6 +95,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 
 	s.mux.HandleFunc("GET /api/agents", s.handleAgentsList)
 	s.mux.HandleFunc("POST /api/agents", s.handleAgentCreate)
+	s.mux.HandleFunc("POST /api/agents/import", s.handleAgentImport)
 	s.mux.HandleFunc("DELETE /api/agents/{name}", s.handleAgentDelete)
 
 	s.mux.HandleFunc("GET /api/packs", s.handlePacksList)
@@ -1903,7 +1906,13 @@ func (s *Server) handleAgentPrompt(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	template := s.loadPromptTemplate(name)
+	rawParam := r.URL.Query().Get("raw")
+	var template string
+	if rawParam == "1" {
+		template = s.loadPromptTemplateRaw(name)
+	} else {
+		template = s.loadPromptTemplate(name)
+	}
 
 	const repoBaseURL = "https://github.com/kubestellar/hive/blob/v2/"
 	sourceFiles := []map[string]string{}
@@ -1928,6 +1937,217 @@ func (s *Server) handleAgentPrompt(w http.ResponseWriter, r *http.Request) {
 		"prompt":      template,
 		"sourceFiles": sourceFiles,
 	})
+}
+
+// loadPromptTemplateRaw returns the raw template content without variable substitution.
+func (s *Server) loadPromptTemplateRaw(name string) string {
+	templateName := ""
+	if s.deps != nil && s.deps.Config != nil {
+		if ac, ok := s.deps.Config.Agents[name]; ok && ac.KickTemplate != "" {
+			templateName = ac.KickTemplate
+		}
+	}
+	if templateName == "" {
+		templateName = name + ".md"
+	}
+
+	paths := []string{
+		fmt.Sprintf("/data/policies/examples/kubestellar/agents/%s", templateName),
+	}
+	if s.deps != nil && s.deps.Config != nil {
+		policyDir := s.deps.Config.Policies.LocalDir
+		if policyDir != "" {
+			paths = append(paths,
+				fmt.Sprintf("%s/examples/kubestellar/agents/%s", policyDir, templateName),
+				fmt.Sprintf("%s/%s%s", policyDir, s.deps.Config.Policies.Path, templateName),
+			)
+		}
+	}
+	// Check /data/policies first (user-saved templates)
+	userPath := fmt.Sprintf("/data/policies/%s", templateName)
+	if data, err := os.ReadFile(userPath); err == nil {
+		return string(data)
+	}
+	for _, p := range paths {
+		if data, err := os.ReadFile(p); err == nil {
+			return string(data)
+		}
+	}
+	if data, err := policies.DefaultPolicies.ReadFile("defaults/" + templateName); err == nil {
+		return string(data)
+	}
+	return ""
+}
+
+const promptTemplateSaveDir = "/data/policies"
+
+func (s *Server) handleAgentPromptSave(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	if _, ok := s.deps.Config.Agents[name]; !ok {
+		jsonError(w, "agent not found", http.StatusNotFound)
+		return
+	}
+
+	var body struct {
+		Template string `json:"template"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	templateFileName := name + ".md"
+	if ac, ok := s.deps.Config.Agents[name]; ok && ac.KickTemplate != "" {
+		templateFileName = ac.KickTemplate
+	}
+
+	if err := os.MkdirAll(promptTemplateSaveDir, 0o755); err != nil {
+		jsonError(w, "failed to create policies directory: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	savePath := filepath.Join(promptTemplateSaveDir, templateFileName)
+	if err := os.WriteFile(savePath, []byte(body.Template), 0o644); err != nil {
+		jsonError(w, "failed to save template: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Point the agent's KickTemplate to the saved file
+	agentCfg := s.deps.Config.Agents[name]
+	agentCfg.KickTemplate = templateFileName
+	s.deps.Config.Agents[name] = agentCfg
+
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after template save", "agent", name, "error", err)
+	}
+	s.refreshAndPersist()
+
+	s.logger.Info("prompt template saved", "agent", name, "path", savePath)
+	okResponse(w, map[string]string{"status": "saved", "path": savePath})
+}
+
+const exportAPIVersion = "hive.kubestellar.io/v1"
+const exportKind = "AgentDefinition"
+
+func (s *Server) handleAgentExport(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	agentCfg, ok := s.deps.Config.Agents[name]
+	if !ok {
+		jsonError(w, "agent not found", http.StatusNotFound)
+		return
+	}
+
+	rawTemplate := s.loadPromptTemplateRaw(name)
+
+	includeRepos := true
+	if agentCfg.IncludeRepos != nil {
+		includeRepos = *agentCfg.IncludeRepos
+	}
+
+	// Collect cadences from governor modes
+	cadences := map[string]string{}
+	for modeName, modeCfg := range s.deps.Config.Governor.Modes {
+		if c, ok := modeCfg.Cadences[name]; ok {
+			cadences[modeName] = c
+		}
+	}
+
+	yamlContent := s.buildExportYAML(name, agentCfg, cadences, includeRepos, rawTemplate)
+
+	accept := r.Header.Get("Accept")
+	if strings.Contains(accept, "text/yaml") || strings.Contains(accept, "application/yaml") {
+		w.Header().Set("Content-Type", "text/yaml; charset=utf-8")
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s.yaml", name))
+		w.Write([]byte(yamlContent))
+		return
+	}
+
+	jsonResponse(w, map[string]interface{}{
+		"name": name,
+		"yaml": yamlContent,
+	})
+}
+
+func (s *Server) buildExportYAML(name string, cfg config.AgentConfig, cadences map[string]string, includeRepos bool, promptTemplate string) string {
+	var b strings.Builder
+
+	b.WriteString(fmt.Sprintf("apiVersion: %s\n", exportAPIVersion))
+	b.WriteString(fmt.Sprintf("kind: %s\n", exportKind))
+	b.WriteString("metadata:\n")
+	b.WriteString(fmt.Sprintf("  name: %s\n", name))
+	if cfg.DisplayName != "" {
+		b.WriteString(fmt.Sprintf("  displayName: %q\n", cfg.DisplayName))
+	}
+	if cfg.Description != "" {
+		b.WriteString(fmt.Sprintf("  description: %q\n", cfg.Description))
+	}
+	if cfg.Emoji != "" {
+		b.WriteString(fmt.Sprintf("  emoji: %q\n", cfg.Emoji))
+	}
+	if cfg.Color != "" {
+		b.WriteString(fmt.Sprintf("  color: %q\n", cfg.Color))
+	}
+	b.WriteString("spec:\n")
+	b.WriteString(fmt.Sprintf("  backend: %s\n", valueOrDefault(cfg.Backend, "copilot")))
+	if cfg.Model != "" {
+		b.WriteString(fmt.Sprintf("  model: %s\n", cfg.Model))
+	}
+	if cfg.Role != "" {
+		b.WriteString(fmt.Sprintf("  role: %s\n", cfg.Role))
+	}
+	if cfg.Mode != "" {
+		b.WriteString(fmt.Sprintf("  mode: %s\n", cfg.Mode))
+	}
+	b.WriteString(fmt.Sprintf("  sortOrder: %d\n", cfg.SortOrder))
+	b.WriteString(fmt.Sprintf("  beadRole: %s\n", cfg.GetBeadRole()))
+	b.WriteString(fmt.Sprintf("  staleTimeout: %d\n", cfg.StaleTimeout))
+	b.WriteString(fmt.Sprintf("  restartStrategy: %s\n", valueOrDefault(cfg.RestartStrategy, "immediate")))
+	b.WriteString(fmt.Sprintf("  clearOnKick: %t\n", cfg.ClearOnKick))
+	b.WriteString(fmt.Sprintf("  includeRepos: %t\n", includeRepos))
+
+	if len(cfg.LaneKeywords) > 0 {
+		b.WriteString("  laneKeywords:\n")
+		for _, kw := range cfg.LaneKeywords {
+			b.WriteString(fmt.Sprintf("    - %s\n", kw))
+		}
+	}
+	if len(cfg.DetectKeywords) > 0 {
+		b.WriteString("  detectKeywords:\n")
+		for _, kw := range cfg.DetectKeywords {
+			b.WriteString(fmt.Sprintf("    - %s\n", kw))
+		}
+	}
+	if len(cfg.Aliases) > 0 {
+		b.WriteString("  aliases:\n")
+		for _, a := range cfg.Aliases {
+			b.WriteString(fmt.Sprintf("    - %s\n", a))
+		}
+	}
+
+	if len(cadences) > 0 {
+		b.WriteString("  cadences:\n")
+		modeOrder := []string{"idle", "quiet", "busy", "surge"}
+		for _, mode := range modeOrder {
+			if c, ok := cadences[mode]; ok {
+				b.WriteString(fmt.Sprintf("    %s: %s\n", mode, c))
+			}
+		}
+	}
+
+	if promptTemplate != "" {
+		b.WriteString("  promptTemplate: |\n")
+		for _, line := range strings.Split(promptTemplate, "\n") {
+			b.WriteString("    " + line + "\n")
+		}
+	}
+
+	return b.String()
+}
+
+func valueOrDefault(v, dflt string) string {
+	if v != "" {
+		return v
+	}
+	return dflt
 }
 
 func (s *Server) handleStatSources(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/api_agents.go
+++ b/v2/pkg/dashboard/api_agents.go
@@ -1,8 +1,14 @@
 package dashboard
 
 import (
+	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
 )
@@ -120,6 +126,197 @@ func (s *Server) handleAgentDelete(w http.ResponseWriter, r *http.Request) {
 
 	s.logger.Info("agent deleted via API", "name", name)
 	okResponse(w, map[string]string{"status": "deleted", "agent": name})
+}
+
+// agentDefinition is the portable YAML format for importing/exporting agents.
+type agentDefinition struct {
+	APIVersion string                 `yaml:"apiVersion"`
+	Kind       string                 `yaml:"kind"`
+	Metadata   agentDefinitionMeta    `yaml:"metadata"`
+	Spec       agentDefinitionSpec    `yaml:"spec"`
+}
+
+type agentDefinitionMeta struct {
+	Name        string `yaml:"name"`
+	DisplayName string `yaml:"displayName,omitempty"`
+	Description string `yaml:"description,omitempty"`
+	Emoji       string `yaml:"emoji,omitempty"`
+	Color       string `yaml:"color,omitempty"`
+}
+
+type agentDefinitionSpec struct {
+	Backend         string            `yaml:"backend,omitempty"`
+	Model           string            `yaml:"model,omitempty"`
+	Role            string            `yaml:"role,omitempty"`
+	Mode            string            `yaml:"mode,omitempty"`
+	SortOrder       int               `yaml:"sortOrder,omitempty"`
+	BeadRole        string            `yaml:"beadRole,omitempty"`
+	StaleTimeout    int               `yaml:"staleTimeout,omitempty"`
+	RestartStrategy string            `yaml:"restartStrategy,omitempty"`
+	ClearOnKick     bool              `yaml:"clearOnKick,omitempty"`
+	IncludeRepos    bool              `yaml:"includeRepos,omitempty"`
+	LaneKeywords    []string          `yaml:"laneKeywords,omitempty"`
+	DetectKeywords  []string          `yaml:"detectKeywords,omitempty"`
+	Aliases         []string          `yaml:"aliases,omitempty"`
+	Cadences        map[string]string `yaml:"cadences,omitempty"`
+	PromptTemplate  string            `yaml:"promptTemplate,omitempty"`
+}
+
+const (
+	importMaxURLLen     = 2048
+	importMaxContentLen = 512 * 1024 // 512 KiB
+	importHTTPTimeoutS  = 10
+)
+
+func (s *Server) handleAgentImport(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Source  string `json:"source"`
+		URL     string `json:"url"`
+		Content string `json:"content"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	var yamlContent string
+	switch body.Source {
+	case "url":
+		if body.URL == "" {
+			jsonError(w, "url is required when source is url", http.StatusBadRequest)
+			return
+		}
+		if len(body.URL) > importMaxURLLen {
+			jsonError(w, fmt.Sprintf("url must be at most %d characters", importMaxURLLen), http.StatusBadRequest)
+			return
+		}
+		client := &http.Client{Timeout: importHTTPTimeoutS * 1e9} // nanoseconds
+		resp, err := client.Get(body.URL)
+		if err != nil {
+			jsonError(w, "failed to fetch URL: "+err.Error(), http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			jsonError(w, fmt.Sprintf("URL returned HTTP %d", resp.StatusCode), http.StatusBadGateway)
+			return
+		}
+		data, err := io.ReadAll(io.LimitReader(resp.Body, importMaxContentLen))
+		if err != nil {
+			jsonError(w, "failed to read URL response: "+err.Error(), http.StatusBadGateway)
+			return
+		}
+		yamlContent = string(data)
+
+	case "paste":
+		if body.Content == "" {
+			jsonError(w, "content is required when source is paste", http.StatusBadRequest)
+			return
+		}
+		yamlContent = body.Content
+
+	default:
+		jsonError(w, "source must be 'url' or 'paste'", http.StatusBadRequest)
+		return
+	}
+
+	var def agentDefinition
+	if err := yaml.Unmarshal([]byte(yamlContent), &def); err != nil {
+		jsonError(w, "invalid YAML: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if def.Kind != exportKind {
+		jsonError(w, fmt.Sprintf("expected kind %q, got %q", exportKind, def.Kind), http.StatusBadRequest)
+		return
+	}
+	if def.Metadata.Name == "" {
+		jsonError(w, "metadata.name is required", http.StatusBadRequest)
+		return
+	}
+
+	name := strings.ToLower(strings.ReplaceAll(def.Metadata.Name, " ", "-"))
+	if strings.ContainsAny(name, " ./\\") || !kickTemplatePattern.MatchString(name+".md") {
+		jsonError(w, "agent name contains invalid characters", http.StatusBadRequest)
+		return
+	}
+	const maxAgentNameLen = 64
+	if len(name) > maxAgentNameLen {
+		jsonError(w, fmt.Sprintf("agent name must be at most %d characters", maxAgentNameLen), http.StatusBadRequest)
+		return
+	}
+
+	if _, exists := s.deps.Config.Agents[name]; exists {
+		jsonError(w, "agent already exists: "+name, http.StatusConflict)
+		return
+	}
+
+	agentsDir := s.deps.Config.Data.AgentsDir
+	if agentsDir == "" {
+		jsonError(w, "agents_dir not configured", http.StatusInternalServerError)
+		return
+	}
+
+	includeRepos := def.Spec.IncludeRepos
+	agentCfg := config.AgentConfig{
+		Backend:         valueOrDefault(def.Spec.Backend, "copilot"),
+		Model:           def.Spec.Model,
+		Enabled:         true,
+		ClearOnKick:     def.Spec.ClearOnKick,
+		StaleTimeout:    def.Spec.StaleTimeout,
+		RestartStrategy: valueOrDefault(def.Spec.RestartStrategy, "immediate"),
+		DisplayName:     def.Metadata.DisplayName,
+		Description:     def.Metadata.Description,
+		Role:            def.Spec.Role,
+		SortOrder:       def.Spec.SortOrder,
+		Emoji:           def.Metadata.Emoji,
+		Color:           def.Metadata.Color,
+		LaneKeywords:    def.Spec.LaneKeywords,
+		DetectKeywords:  def.Spec.DetectKeywords,
+		Aliases:         def.Spec.Aliases,
+		Mode:            def.Spec.Mode,
+		BeadRole:        valueOrDefault(def.Spec.BeadRole, "worker"),
+		IncludeRepos:    &includeRepos,
+		Managed:         true,
+	}
+
+	if err := config.SaveAgentFile(agentsDir, name, agentCfg); err != nil {
+		s.logger.Error("failed to save imported agent file", "agent", name, "error", err)
+		jsonError(w, "failed to save agent: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Save prompt template if provided
+	if def.Spec.PromptTemplate != "" {
+		templateFileName := name + ".md"
+		agentCfg.KickTemplate = templateFileName
+
+		if err := os.MkdirAll(promptTemplateSaveDir, 0o755); err != nil {
+			s.logger.Error("failed to create policies dir for import", "error", err)
+		} else {
+			savePath := filepath.Join(promptTemplateSaveDir, templateFileName)
+			if err := os.WriteFile(savePath, []byte(def.Spec.PromptTemplate), 0o644); err != nil {
+				s.logger.Error("failed to save imported prompt template", "agent", name, "error", err)
+			}
+		}
+
+		// Re-save agent with updated KickTemplate
+		if err := config.SaveAgentFile(agentsDir, name, agentCfg); err != nil {
+			s.logger.Error("failed to re-save agent with template", "agent", name, "error", err)
+		}
+	}
+
+	s.deps.Config.Agents[name] = agentCfg
+	s.deps.Config.ApplyAgentDefaults(name)
+
+	finalCfg := s.deps.Config.Agents[name]
+	s.deps.AgentMgr.AddAgent(name, finalCfg)
+
+	s.reInitSubsystems()
+	s.refreshAndPersist()
+
+	s.logger.Info("agent imported via API", "name", name, "source", body.Source)
+	okResponse(w, map[string]string{"status": "imported", "name": name})
 }
 
 func (s *Server) reInitSubsystems() {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -8029,7 +8029,7 @@ function burnAreaChart() {
     let _configState = { type: null, agent: null, tab: null, data: {}, dirty: {} };
     const _configTabMemory = {};
 
-    const AGENT_CONFIG_TABS = ['General', 'Cadences', 'Pipeline', 'Hooks', 'Restrictions', 'Stats', 'Prompt Template', 'Last Prompt'];
+    const AGENT_CONFIG_TABS = ['General', 'Cadences', 'Pipeline', 'Hooks', 'Restrictions', 'Stats', 'Prompt Template', 'Last Prompt', 'Export'];
     const AGENT_CREATE_TABS = ['General', 'Cadences'];
     const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Hub'];
     const PIPELINE_STAGES = ['resolve-beads', 'track-prs', 'stale-check', 'repo-scan', 'coverage-gate', 'prompt-compose', 'budget-check', 'api-collect', 'final-compose'];
@@ -8428,6 +8428,7 @@ function burnAreaChart() {
         case 'Stats': return renderAgentStatsTab(d.stats || []);
         case 'Prompt Template': return renderAgentPromptTemplate();
         case 'Last Prompt': return renderAgentLastPrompt(d.prompt || '');
+        case 'Export': return renderAgentExport();
         default: return '';
       }
     }
@@ -8701,6 +8702,25 @@ function burnAreaChart() {
       let html = '';
       if (isCreate) {
         html += `
+        <div style="background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:14px;margin-bottom:16px">
+          <div style="font-size:0.78rem;font-weight:600;color:var(--text);margin-bottom:10px">Import Agent Definition</div>
+          <div class="config-field" style="margin-bottom:8px">
+            <label style="font-size:0.72rem">Import from URL</label>
+            <div style="display:flex;gap:6px">
+              <input type="text" id="import-url-input" placeholder="https://raw.githubusercontent.com/..." style="flex:1;font-size:0.72rem">
+              <button onclick="importAgentFromURL()" style="font-size:0.72rem;padding:4px 12px;border-radius:4px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:#fff;white-space:nowrap">Import</button>
+            </div>
+          </div>
+          <div class="config-field" style="margin-bottom:4px">
+            <label style="font-size:0.72rem">Or paste agent definition</label>
+            <textarea id="import-paste-input" rows="4" style="width:100%;font-family:'SF Mono','Cascadia Code',monospace;font-size:0.7rem;resize:vertical" placeholder="apiVersion: hive.kubestellar.io/v1\nkind: AgentDefinition\n..."></textarea>
+            <div style="display:flex;justify-content:space-between;align-items:center;margin-top:4px">
+              <span style="font-size:0.65rem;color:var(--muted)">Supports YAML agent definitions</span>
+              <button onclick="importAgentFromPaste()" style="font-size:0.72rem;padding:4px 12px;border-radius:4px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:#fff">Import</button>
+            </div>
+          </div>
+        </div>
+        <div style="border-bottom:1px solid var(--border);margin-bottom:14px;padding-bottom:4px;font-size:0.7rem;color:var(--muted);text-align:center">or create manually</div>
         <div class="config-field">
           <label>Name <span style="color:#dc2626">*</span> <span class="config-info">i<span class="config-tooltip">The agent's internal name used as its ID, config file name, and tmux session. Lowercase, hyphens allowed.</span></span></label>
           <input type="text" id="cfg-create-name" value="" placeholder="e.g. docs-writer, sec-scanner" onchange="markDirty('_create','name',this.value)">
@@ -8949,24 +8969,41 @@ function burnAreaChart() {
       return html;
     }
 
+    var TEMPLATE_VARS = [
+      {name: '${AGENT_NAME}', desc: 'Agent internal name'},
+      {name: '${AGENT_DISPLAY_NAME}', desc: 'Friendly display name'},
+      {name: '${TIMESTAMP}', desc: 'Current date/time'},
+      {name: '${QUEUE_ISSUES}', desc: 'Actionable issues count'},
+      {name: '${QUEUE_PRS}', desc: 'Actionable PRs count'},
+      {name: '${ISSUE_LIST}', desc: 'Formatted issue list'},
+      {name: '${PR_LIST}', desc: 'Formatted PR list'},
+      {name: '${GH_AUTH}', desc: 'GitHub auth instructions'},
+      {name: '${PROJECT_ORG}', desc: 'Organization name'},
+      {name: '${PROJECT_PRIMARY_REPO}', desc: 'Primary repo path'},
+      {name: '${PROJECT_REPOS_LIST}', desc: 'Comma-separated repos'},
+      {name: '${HIVE_REPO}', desc: 'Hive repository path'},
+      {name: '${HIVE_ID}', desc: 'Hive instance ID'},
+      {name: '${KNOWLEDGE}', desc: 'Knowledge primer section'},
+      {name: '${MERGE_ELIGIBLE}', desc: 'Merge-eligible PR list'},
+      {name: '${AUTHORIZED_REPOS}', desc: 'Monitored repos section'},
+      {name: '${AGENT_LIST}', desc: 'List of enabled agents'},
+    ];
+
+    var _promptTemplateEditorMode = 'edit';
+
     function renderAgentPromptTemplate() {
       const agentName = _configState.agent;
-      const elId = 'prompt-template-content';
+      const editorId = 'prompt-template-editor';
+      const previewId = 'prompt-template-preview';
       const srcId = 'prompt-source-files';
       if (agentName) {
         fetch(`/api/config/agent/${agentName}/prompt`)
           .then(r => r.json())
           .then(data => {
-            const el = document.getElementById(elId);
-            if (el) {
-              const raw = data.prompt || '';
-              if (!raw) { el.textContent = '(no template found — check kick_template in agent config)'; }
-              else { el.innerHTML = formatMarkdownPrompt(raw); }
-            }
             const srcEl = document.getElementById(srcId);
-            if (srcEl && data.sourceFiles && data.sourceFiles.length > 0) {
+            if (srcEl && data.sourceFiles && (data.sourceFiles || []).length > 0) {
               let items = '';
-              for (const sf of data.sourceFiles) {
+              for (const sf of (data.sourceFiles || [])) {
                 const note = sf.note ? ' <span style="color:var(--muted)">(' + esc(sf.note) + ')</span>' : '';
                 items += '<li style="margin:3px 0"><strong style="color:var(--muted);min-width:80px;display:inline-block">' + esc(sf.label) + ':</strong> '
                   + '<a href="' + esc(sf.url) + '" target="_blank" rel="noopener" style="color:var(--cyan);text-decoration:none;font-family:\'SF Mono\',\'Cascadia Code\',monospace;font-size:0.75rem">' + esc(sf.path) + '</a>'
@@ -8975,17 +9012,197 @@ function burnAreaChart() {
               srcEl.innerHTML = '<ul style="list-style:none;padding:0;margin:0">' + items + '</ul>';
               srcEl.style.display = 'block';
             }
+            const previewEl = document.getElementById(previewId);
+            if (previewEl) {
+              const raw = data.prompt || '';
+              if (!raw) { previewEl.innerHTML = '<span style="color:var(--muted);font-style:italic">(no template found)</span>'; }
+              else { previewEl.innerHTML = formatMarkdownPrompt(raw); }
+            }
+          })
+          .catch(() => {});
+
+        fetch(`/api/config/agent/${agentName}/prompt?raw=1`)
+          .then(r => r.json())
+          .then(data => {
+            const el = document.getElementById(editorId);
+            if (el) { el.value = data.prompt || ''; }
           })
           .catch(() => {});
       }
+
+      const varPickerItems = TEMPLATE_VARS.map(v =>
+        '<button onclick="insertTemplateVar(\'' + v.name.replace(/'/g, "\\'") + '\')" style="display:flex;align-items:center;gap:6px;padding:4px 8px;background:var(--surface);border:1px solid var(--border);border-radius:4px;cursor:pointer;font-size:0.7rem;color:var(--text);white-space:nowrap" title="' + esc(v.desc) + '">'
+        + '<code style="color:var(--cyan);font-size:0.68rem">' + esc(v.name) + '</code>'
+        + '<span style="color:var(--muted)">' + esc(v.desc) + '</span>'
+        + '</button>'
+      ).join('');
+
       return `
         <div style="display:flex;flex-direction:column;height:100%">
         <div id="${srcId}" style="display:none;background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:10px 14px;margin-bottom:10px;flex-shrink:0">
           <div style="font-size:0.7rem;font-weight:600;color:var(--text);margin-bottom:6px">Source files <span style="font-weight:400;color:var(--muted)">(edit these on your fork)</span></div>
         </div>
-        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px;flex-shrink:0">Kick template with <code>\${VAR}</code> placeholders resolved from config. This is the policy sent to the agent on each governor kick.</p>
-        <pre class="config-pre config-pre-fill" id="${elId}">${esc('Loading template…')}</pre>
+        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px;flex-shrink:0">Kick template with <code>$​{VAR}</code> placeholders. Edit the raw template or preview with variables expanded.</p>
+        <div style="display:flex;gap:6px;margin-bottom:8px;flex-shrink:0">
+          <button id="prompt-btn-edit" onclick="switchPromptMode('edit')" style="font-size:0.72rem;padding:4px 12px;border-radius:4px;cursor:pointer;font-weight:600;border:1px solid var(--border);background:var(--green);color:#fff">Edit</button>
+          <button id="prompt-btn-preview" onclick="switchPromptMode('preview')" style="font-size:0.72rem;padding:4px 12px;border-radius:4px;cursor:pointer;font-weight:600;border:1px solid var(--border);background:var(--surface);color:var(--text)">Preview</button>
+          <div style="flex:1"></div>
+          <button onclick="savePromptTemplate()" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:none;background:var(--green);color:#fff">Save Template</button>
+        </div>
+        <textarea id="${editorId}" style="flex:1;min-height:300px;font-family:'SF Mono','Cascadia Code',monospace;font-size:0.75rem;padding:12px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;resize:vertical;white-space:pre;tab-size:2" placeholder="Loading template...">${esc('Loading...')}</textarea>
+        <div id="${previewId}" class="config-pre config-pre-fill" style="display:none;flex:1;min-height:300px;overflow-y:auto">${esc('Loading preview...')}</div>
+        <div style="margin-top:8px;flex-shrink:0">
+          <div style="font-size:0.7rem;font-weight:600;color:var(--text);margin-bottom:6px">Variable Picker <span style="font-weight:400;color:var(--muted)">(click to insert at cursor)</span></div>
+          <div style="display:flex;flex-wrap:wrap;gap:4px;max-height:120px;overflow-y:auto;padding:6px;background:var(--surface);border:1px solid var(--border);border-radius:6px">${varPickerItems}</div>
+        </div>
         </div>`;
+    }
+
+    function switchPromptMode(mode) {
+      _promptTemplateEditorMode = mode;
+      var editor = document.getElementById('prompt-template-editor');
+      var preview = document.getElementById('prompt-template-preview');
+      var btnEdit = document.getElementById('prompt-btn-edit');
+      var btnPreview = document.getElementById('prompt-btn-preview');
+      if (!editor || !preview) return;
+      if (mode === 'edit') {
+        editor.style.display = '';
+        preview.style.display = 'none';
+        btnEdit.style.background = 'var(--green)';
+        btnEdit.style.color = '#fff';
+        btnPreview.style.background = 'var(--surface)';
+        btnPreview.style.color = 'var(--text)';
+      } else {
+        editor.style.display = 'none';
+        preview.style.display = '';
+        btnEdit.style.background = 'var(--surface)';
+        btnEdit.style.color = 'var(--text)';
+        btnPreview.style.background = 'var(--green)';
+        btnPreview.style.color = '#fff';
+        fetch('/api/config/agent/' + _configState.agent + '/prompt')
+          .then(function(r) { return r.json(); })
+          .then(function(data) {
+            var raw = data.prompt || '';
+            preview.innerHTML = raw ? formatMarkdownPrompt(raw) : '<span style="color:var(--muted)">(no template)</span>';
+          })
+          .catch(function() {});
+      }
+    }
+
+    function insertTemplateVar(varName) {
+      var editor = document.getElementById('prompt-template-editor');
+      if (!editor) return;
+      var start = editor.selectionStart;
+      var end = editor.selectionEnd;
+      var text = editor.value;
+      editor.value = text.substring(0, start) + varName + text.substring(end);
+      var cursorPos = start + varName.length;
+      editor.selectionStart = cursorPos;
+      editor.selectionEnd = cursorPos;
+      editor.focus();
+    }
+
+    function savePromptTemplate() {
+      var editor = document.getElementById('prompt-template-editor');
+      if (!editor) return;
+      var agentName = _configState.agent;
+      if (!agentName) return;
+      fetch('/api/config/agent/' + agentName + '/prompt', {
+        method: 'PUT',
+        headers: _inceptionAuthHeaders(),
+        body: JSON.stringify({ template: editor.value })
+      })
+        .then(function(r) { return r.json().then(function(d) { return {ok: r.ok, data: d}; }); })
+        .then(function(result) {
+          if (result.ok) {
+            showToast('Template saved', 'success');
+          } else {
+            showToast(result.data.error || 'Failed to save', 'error');
+          }
+        })
+        .catch(function(err) { showToast('Network error: ' + err.message, 'error'); });
+    }
+
+    function renderAgentExport() {
+      var agentName = _configState.agent;
+      var yamlId = 'export-yaml-content';
+      if (agentName) {
+        fetch('/api/config/agent/' + agentName + '/export')
+          .then(function(r) { return r.json(); })
+          .then(function(data) {
+            var el = document.getElementById(yamlId);
+            if (el) { el.value = data.yaml || ''; }
+          })
+          .catch(function() {});
+      }
+      return '<div style="display:flex;flex-direction:column;height:100%">'
+        + '<p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px;flex-shrink:0">Portable agent definition in YAML format. Use this to share agents across hive instances.</p>'
+        + '<div style="display:flex;gap:6px;margin-bottom:8px;flex-shrink:0">'
+        + '<button onclick="copyExportYaml()" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:#fff">Copy to Clipboard</button>'
+        + '<button onclick="downloadExportYaml()" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:1px solid var(--border);background:var(--surface);color:var(--text)">Download YAML</button>'
+        + '</div>'
+        + '<textarea id="' + yamlId + '" readonly style="flex:1;min-height:300px;font-family:\'SF Mono\',\'Cascadia Code\',monospace;font-size:0.75rem;padding:12px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;resize:vertical;white-space:pre;tab-size:2">Loading...</textarea>'
+        + '</div>';
+    }
+
+    function copyExportYaml() {
+      var el = document.getElementById('export-yaml-content');
+      if (!el) return;
+      navigator.clipboard.writeText(el.value)
+        .then(function() { showToast('Copied to clipboard', 'success'); })
+        .catch(function() { showToast('Copy failed', 'error'); });
+    }
+
+    function downloadExportYaml() {
+      var el = document.getElementById('export-yaml-content');
+      if (!el) return;
+      var agentName = _configState.agent || 'agent';
+      var blob = new Blob([el.value], {type: 'text/yaml'});
+      var url = URL.createObjectURL(blob);
+      var a = document.createElement('a');
+      a.href = url;
+      a.download = agentName + '.yaml';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    }
+
+    function importAgentFromURL() {
+      var urlInput = document.getElementById('import-url-input');
+      if (!urlInput || !urlInput.value.trim()) {
+        showToast('Enter a URL to import from', 'error');
+        return;
+      }
+      _doAgentImport('url', urlInput.value.trim(), '');
+    }
+
+    function importAgentFromPaste() {
+      var pasteInput = document.getElementById('import-paste-input');
+      if (!pasteInput || !pasteInput.value.trim()) {
+        showToast('Paste an agent definition to import', 'error');
+        return;
+      }
+      _doAgentImport('paste', '', pasteInput.value.trim());
+    }
+
+    function _doAgentImport(source, url, content) {
+      fetch('/api/agents/import', {
+        method: 'POST',
+        headers: _inceptionAuthHeaders(),
+        body: JSON.stringify({ source: source, url: url, content: content })
+      })
+        .then(function(r) { return r.json().then(function(d) { return {ok: r.ok, data: d}; }); })
+        .then(function(result) {
+          if (result.ok) {
+            showToast('Agent "' + (result.data.name || '') + '" imported', 'success');
+            closeConfigDialog();
+            fetch('/api/status').then(function(r) { return r.json(); }).then(render).catch(function() {});
+          } else {
+            showToast(result.data.error || 'Import failed', 'error');
+          }
+        })
+        .catch(function(err) { showToast('Network error: ' + err.message, 'error'); });
     }
 
     function formatMarkdownPrompt(text) {


### PR DESCRIPTION
## Summary
- Enhanced Prompt Template tab: editable textarea with variable picker (click-to-insert), save button, edit/preview toggle
- New Export tab: portable YAML agent definition with copy-to-clipboard and download buttons
- Import section in agent creation dialog: supports URL fetch and YAML paste with validation
- Example agent definition at `v2/examples/agents/customized-agent.yaml`

## New API Endpoints
- `PUT /api/config/agent/{name}/prompt` — save prompt template to `/data/policies/{name}.md`
- `GET /api/config/agent/{name}/export` — export agent as portable YAML
- `GET /api/config/agent/{name}/prompt?raw=1` — raw template without variable substitution
- `POST /api/agents/import` — import agent from URL or pasted YAML

## Portable Format
```yaml
apiVersion: hive.kubestellar.io/v1
kind: AgentDefinition
metadata:
  name: ...
  displayName: ...
spec:
  backend: ...
  cadences: ...
  promptTemplate: |
    ...
```

## Test plan
- [ ] Open agent config, verify Export tab shows YAML and copy/download work
- [ ] Open agent config, verify Prompt Template tab has editable textarea and variable picker
- [ ] Click variables in picker, verify they insert at cursor
- [ ] Save template, verify it persists across page reload
- [ ] Preview toggle shows expanded variables
- [ ] Click "+ agent", verify Import section appears at top of General tab
- [ ] Paste the example YAML, verify agent is created with all fields
- [ ] Import from URL pointing to the example file
- [ ] `go vet ./pkg/dashboard/` passes clean