### PR TITLE
fix: SHA poller per_page=1 misses Docker build runs

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1161,7 +1161,8 @@ func fetchAllBranchSHAs(logger *slog.Logger) {
 }
 
 func fetchBranchSHA(logger *slog.Logger, branch string) {
-	actionsURL := "https://api.github.com/repos/kubestellar/hive/actions/runs?branch=" + branch + "&status=success&per_page=1"
+	const shaFetchPerPage = 20
+	actionsURL := fmt.Sprintf("https://api.github.com/repos/kubestellar/hive/actions/runs?branch=%s&status=success&per_page=%d", branch, shaFetchPerPage)
 	const shaFetchTimeout = 10 * time.Second
 	client := &http.Client{Timeout: shaFetchTimeout}
 	req, _ := http.NewRequest("GET", actionsURL, nil)


### PR DESCRIPTION
## Summary
- The SHA poller used `per_page=1` in the GitHub Actions API query
- Non-Docker workflows (Assignment Helper, Label Helper) often run after Docker builds
- With only 1 result, the poller never finds the Docker build run → `latest_sha` stays empty → upgrade system breaks
- Fix: increase to `per_page=20` so we always find the Docker build

## Test plan
- [ ] After deploy, verify `/api/saas/latest-sha` returns a non-empty SHA
- [ ] Verify upgrade buttons appear on My Hives dashboard