### PR TITLE
fix: spoke checks GHCR for container image before showing Upgrade

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/beads"
@@ -369,9 +370,11 @@ func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 		if len(latestShort) > shortHashLen {
 			latestShort = latestShort[:shortHashLen]
 		}
+		// Only report "behind" if the container image exists on GHCR
+		containerReady := ghcrTagExistsCached(latestShort)
 		resp["latestHash"] = cached
 		resp["latestShort"] = latestShort
-		resp["behind"] = cached != versionHash
+		resp["behind"] = containerReady && cached != versionHash
 	}
 
 	jsonResponse(w, resp)
@@ -386,6 +389,60 @@ func (s *Server) fetchLatestRemoteHash() (string, error) {
 		return "", fmt.Errorf("no context")
 	}
 	return s.deps.GHClient.LatestCommitHash(ctx, "kubestellar", "hive", "v2")
+}
+
+// ghcrTagExistsCached checks whether a container tag exists on ghcr.io/kubestellar/hive,
+// caching the result to avoid repeated network calls on each version poll.
+var (
+	ghcrCacheMu     sync.RWMutex
+	ghcrCacheResult = map[string]bool{}
+	ghcrCacheExpiry = map[string]time.Time{}
+)
+
+const ghcrCacheTTL = 2 * time.Minute
+const ghcrCheckTimeout = 5 * time.Second
+
+func ghcrTagExistsCached(tag string) bool {
+	ghcrCacheMu.RLock()
+	if exp, ok := ghcrCacheExpiry[tag]; ok && time.Now().Before(exp) {
+		result := ghcrCacheResult[tag]
+		ghcrCacheMu.RUnlock()
+		return result
+	}
+	ghcrCacheMu.RUnlock()
+
+	result := ghcrTagExists(tag)
+	ghcrCacheMu.Lock()
+	ghcrCacheResult[tag] = result
+	ghcrCacheExpiry[tag] = time.Now().Add(ghcrCacheTTL)
+	ghcrCacheMu.Unlock()
+	return result
+}
+
+func ghcrTagExists(tag string) bool {
+	client := &http.Client{Timeout: ghcrCheckTimeout}
+	tokenResp, err := client.Get("https://ghcr.io/token?scope=repository:kubestellar/hive:pull")
+	if err != nil {
+		return false
+	}
+	defer tokenResp.Body.Close()
+	var tok struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(tokenResp.Body).Decode(&tok); err != nil {
+		return false
+	}
+
+	manifestURL := fmt.Sprintf("https://ghcr.io/v2/kubestellar/hive/manifests/%s", tag)
+	req, _ := http.NewRequest("HEAD", manifestURL, nil)
+	req.Header.Set("Authorization", "Bearer "+tok.Token)
+	req.Header.Set("Accept", "application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
 }
 
 func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -7839,8 +7839,8 @@ function burnAreaChart() {
           showToast('Upgrade complete!', 'success');
           html += ' <span style="color:#22c55e" title="Up to date with remote">✓</span>';
         } else if (v.behind) {
-          html += ` <span class="git-behind" title="Latest: ${escapeHtml(v.latestShort || '?')}">⬆ behind</span>`;
-          html += ` <button id="spoke-upgrade-btn" onclick="selfUpgrade('${escapeHtml(v.latestHash || '')}')" style="padding:3px 10px;font-size:0.7rem;background:#238636;color:#fff;border:none;border-radius:4px;cursor:pointer;margin-left:6px;white-space:nowrap" title="Upgrade to latest">Upgrade</button>`;
+          html += ` <span class="git-behind" title="Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">⬆ behind</span>`;
+          html += ` <button id="spoke-upgrade-btn" onclick="selfUpgrade('${escapeHtml(v.latestHash || '')}')" style="padding:3px 10px;font-size:0.7rem;background:#238636;color:#fff;border:none;border-radius:4px;cursor:pointer;margin-left:6px;white-space:nowrap" title="Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">Upgrade</button>`;
         } else if (v.latestHash) {
           html += ' <span style="color:#22c55e" title="Up to date with remote">✓</span>';
         }


### PR DESCRIPTION
## Summary
- Spoke `/api/version` now verifies container tag on ghcr.io before `behind=true`
- GHCR result cached for 2min to avoid hammering the registry
- Upgrade button + "behind" indicator show "Current: abc → Latest: def" on hover
- Matches hub behavior (PR #1540 added GHCR check to hub SHA poller)

## Test plan
- [ ] When container hasn't been pushed yet, no Upgrade button appears
- [ ] Once container exists, "behind" + Upgrade shows with proper tooltip
- [ ] Hover over Upgrade shows current→latest SHA