### PR TITLE
feat: contributor token reissue endpoint (Fixes #1537)

### DIFF
--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -101,6 +101,7 @@ func (s *Server) registerContributeRoutes() {
 	s.mux.HandleFunc("GET /contribute", s.handleContributeLanding)
 	s.mux.HandleFunc("GET /api/contribute/ws", s.contributeHub.HandleWS)
 	s.mux.HandleFunc("POST /api/contribute/register", s.handleContributeRegister)
+	s.mux.HandleFunc("POST /api/contribute/reissue-token", s.handleContributeReissueToken)
 	s.mux.HandleFunc("GET /api/contribute/status", s.handleContributeStatus)
 	s.mux.HandleFunc("GET /api/contribute/activity", s.handleContributeActivity)
 	s.mux.HandleFunc("GET /api/contributors", s.handleContributorsList)
@@ -512,6 +513,7 @@ const maxRequestBodyBytes = 4096
 func (s *Server) handleContributeRegister(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		GitHubUsername string `json:"github_username"`
+		Force          bool   `json:"force"`
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -536,9 +538,20 @@ func (s *Server) handleContributeRegister(w http.ResponseWriter, r *http.Request
 			jsonError(w, "Account revoked — contact the hive administrator to reinstate", http.StatusForbidden)
 			return
 		}
+		if req.Force {
+			// Reissue token: generate a new one and invalidate the old
+			newToken := reissueContributorToken(existing)
+			s.logger.Info("contributor token reissued via force register", "username", username, "id", existing.ContributorID)
+			jsonResponse(w, map[string]string{
+				"contributor_id":     existing.ContributorID,
+				"registration_token": newToken,
+				"message":            "Token reissued — save this new token, it replaces the previous one",
+			})
+			return
+		}
 		jsonResponse(w, map[string]string{
 			"contributor_id": existing.ContributorID,
-			"message":        "Already registered — use your existing token to connect",
+			"message":        "Already registered — use force:true to reissue token, or POST /api/contribute/reissue-token with GitHub auth",
 		})
 		return
 	}
@@ -554,6 +567,60 @@ func (s *Server) handleContributeRegister(w http.ResponseWriter, r *http.Request
 		"contributor_id":     profile.ContributorID,
 		"registration_token": token,
 		"message":            "Registered successfully — save this token, it cannot be recovered",
+	})
+}
+
+// reissueContributorToken generates a new registration token for an existing
+// contributor, invalidating the previous one. Returns the new plaintext token.
+func reissueContributorToken(p *ContributorProfile) string {
+	const tokenBytes = 32 // 256-bit token
+	newToken := randomHex(tokenBytes)
+	p.RegistrationToken = sha256Hex(newToken)
+	p.TokenPlain = ""
+	_ = saveContributorProfile(p)
+	return newToken
+}
+
+// handleContributeReissueToken lets a contributor recover access by proving
+// ownership of their GitHub identity. Requires Authorization: Bearer <gh-token>.
+func (s *Server) handleContributeReissueToken(w http.ResponseWriter, r *http.Request) {
+	// Authenticate via GitHub personal access token
+	token := r.Header.Get("Authorization")
+	if strings.HasPrefix(token, "Bearer ") {
+		const bearerPrefixLen = 7 // len("Bearer ")
+		token = token[bearerPrefixLen:]
+	} else if strings.HasPrefix(token, "token ") {
+		const tokenPrefixLen = 6 // len("token ")
+		token = token[tokenPrefixLen:]
+	} else {
+		token = ""
+	}
+
+	username := validateGitHubToken(token)
+	if username == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":"Invalid or missing GitHub token. Use: Authorization: Bearer <gh-personal-access-token>"}`))
+		return
+	}
+
+	profile, _ := loadContributorProfile(username)
+	if profile == nil {
+		jsonError(w, "Not registered as a contributor — register first via POST /api/contribute/register", http.StatusNotFound)
+		return
+	}
+	if profile.TrustTier == "revoked" {
+		jsonError(w, "Account revoked — contact the hive administrator to reinstate", http.StatusForbidden)
+		return
+	}
+
+	newToken := reissueContributorToken(profile)
+	s.logger.Info("contributor token reissued via GitHub auth", "username", username, "id", profile.ContributorID)
+
+	jsonResponse(w, map[string]string{
+		"contributor_id":     profile.ContributorID,
+		"registration_token": newToken,
+		"message":            "Token reissued — save this new token, it replaces the previous one",
 	})
 }
 
@@ -1833,6 +1900,20 @@ a{color:#58a6ff}
 <pre>curl -H "Authorization: Bearer $TOKEN" %s/api/v1/knowledge</pre>
 </div>
 
-</body></html>`, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL)
+<h2>Token Management</h2>
+
+<div class="endpoint">
+<span class="method">POST</span><span class="path">/api/contribute/reissue-token</span>
+<div class="desc">Reissue your registration token using GitHub auth — invalidates the old token</div>
+<pre>curl -X POST -H "Authorization: Bearer $(gh auth token)" %s/api/contribute/reissue-token</pre>
+</div>
+
+<div class="endpoint">
+<span class="method">POST</span><span class="path">/api/contribute/register</span>
+<div class="desc">Register (or re-register with <code>force:true</code> to reissue token)</div>
+<pre>curl -X POST -d '{"github_username":"you","force":true}' %s/api/contribute/register</pre>
+</div>
+
+</body></html>`, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL, baseURL)
 }
 

--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -460,6 +460,68 @@ func registerTestUser(t *testing.T, s *Server, username string) (contributorID, 
 	return resp["contributor_id"], resp["registration_token"]
 }
 
+func TestRegisterForceReissue(t *testing.T) {
+	setupContributeEnv(t)
+	s := NewServer(0, slog.Default())
+	s.registerContributeRoutes()
+
+	// First registration — should succeed with a token
+	cid, token1 := registerTestUser(t, s, "force-user")
+	if token1 == "" {
+		t.Fatal("expected token on first register")
+	}
+
+	// Second registration without force — should say already registered, no token
+	body := `{"github_username":"force-user"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/contribute/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp map[string]string
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["registration_token"] != "" {
+		t.Error("should not return token without force")
+	}
+
+	// Third registration with force — should reissue a new token
+	body = `{"github_username":"force-user","force":true}`
+	req = httptest.NewRequest(http.MethodPost, "/api/contribute/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	s.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	token2 := resp["registration_token"]
+	if token2 == "" {
+		t.Fatal("expected new token with force:true")
+	}
+	if token2 == token1 {
+		t.Error("reissued token should differ from original")
+	}
+	if resp["contributor_id"] != cid {
+		t.Error("contributor_id should be preserved on reissue")
+	}
+
+	// Verify old token no longer works by checking the stored hash
+	profile, _ := loadContributorProfile("force-user")
+	if profile == nil {
+		t.Fatal("profile should exist")
+	}
+	oldHash := sha256Hex(token1)
+	if profile.RegistrationToken == oldHash {
+		t.Error("old token hash should have been replaced")
+	}
+	newHash := sha256Hex(token2)
+	if profile.RegistrationToken != newHash {
+		t.Error("stored hash should match the new token")
+	}
+}
+
 func TestContributorsList(t *testing.T) {
 	setupContributeEnv(t)
 	s := NewServer(0, slog.Default())


### PR DESCRIPTION
## Summary

- Adds `POST /api/contribute/reissue-token` endpoint that lets contributors recover a lost registration token by authenticating with their GitHub personal access token (`Authorization: Bearer <gh-token>`)
- Adds `force` parameter to `POST /api/contribute/register` that reissues a new token for already-registered contributors
- Both methods generate a new 256-bit token, store only the SHA-256 hash on disk, and invalidate the previous token
- Contributor ID and all profile data are preserved across reissue
- Updated API docs page with the new endpoints
- Added test coverage for force-register flow

## Test plan

- [x] `go vet ./pkg/dashboard/` passes
- [x] `TestRegisterForceReissue` — verifies force reissue returns new token, old token hash is replaced, contributor_id preserved
- [x] All existing contribute tests still pass
- [ ] Manual: `curl -X POST -d '{"github_username":"user","force":true}' /api/contribute/register` returns new token
- [ ] Manual: `curl -X POST -H "Authorization: Bearer $(gh auth token)" /api/contribute/reissue-token` returns new token
- [ ] Manual: old token fails WebSocket auth after reissue

Fixes #1537