### PR TITLE
fix: update leaderboard tests to match AGENTS/CONTRIBUTORS split

### DIFF
--- a/v2/pkg/dashboard/api_contribute_test.go
+++ b/v2/pkg/dashboard/api_contribute_test.go
@@ -312,7 +312,8 @@ func TestLeaderboardPageHTML(t *testing.T) {
 		"sort-completed":      "sortable completed column",
 		"Trust Tiers":         "trust tiers reference section",
 		"bg-stars":            "starfield background",
-		"var ENTRIES":         "JavaScript entries data",
+		"var AGENTS":          "JavaScript agent entries data",
+		"var CONTRIBUTORS":    "JavaScript contributor entries data",
 		"toggleSort":          "sort toggle function",
 		"renderRows":          "row rendering function",
 		"hover-card":          "contributor hover card CSS",
@@ -340,9 +341,12 @@ func TestLeaderboardPageEmpty(t *testing.T) {
 	}
 
 	body := w.Body.String()
-	// Empty entries array should be passed to JS
-	if !strings.Contains(body, "var ENTRIES = []") {
-		t.Error("empty page should pass empty ENTRIES array")
+	// Empty entries arrays should be passed to JS
+	if !strings.Contains(body, "var AGENTS = []") {
+		t.Error("empty page should pass empty AGENTS array")
+	}
+	if !strings.Contains(body, "var CONTRIBUTORS = []") {
+		t.Error("empty page should pass empty CONTRIBUTORS array")
 	}
 	if !strings.Contains(body, "/contribute") {
 		t.Error("empty page should link to /contribute")


### PR DESCRIPTION
## Summary

- Updates `TestLeaderboardPageHTML` to check for `var AGENTS` and `var CONTRIBUTORS` instead of the removed `var ENTRIES`
- Updates `TestLeaderboardPageEmpty` to verify both `var AGENTS = []` and `var CONTRIBUTORS = []` instead of `var ENTRIES = []`

The leaderboard HTML template was refactored to use separate agent and contributor arrays, but the tests still referenced the old single `var ENTRIES` variable.

Fixes #1539