### PR TITLE
fix: add timeout to DNS lookup in SSRF guard (Fixes #570)

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3324,7 +3324,7 @@ func (s *Server) handleKnowledgeSubsAdd(w http.ResponseWriter, r *http.Request) 
 		jsonError(w, "url must use http or https scheme", http.StatusBadRequest)
 		return
 	}
-	if isPrivateURL(sub.URL) {
+	if isPrivateURL(r.Context(), sub.URL) {
 		jsonError(w, "subscription url must not point to private/internal addresses", http.StatusBadRequest)
 		return
 	}

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -1,12 +1,14 @@
 package dashboard
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"html"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -824,11 +826,11 @@ func (s *Server) handleHivesRegister(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "dashboard_url must start with http://, https://, ws://, or wss://", http.StatusBadRequest)
 		return
 	}
-	if isPrivateURL(req.HubURL) {
+	if isPrivateURL(r.Context(), req.HubURL) {
 		jsonError(w, "hub_url must not target private/internal addresses", http.StatusBadRequest)
 		return
 	}
-	if req.DashboardURL != "" && isPrivateURL(req.DashboardURL) {
+	if req.DashboardURL != "" && isPrivateURL(r.Context(), req.DashboardURL) {
 		jsonError(w, "dashboard_url must not target private/internal addresses", http.StatusBadRequest)
 		return
 	}
@@ -1692,7 +1694,11 @@ func isValidUsername(s string) bool {
 	return true
 }
 
-func isPrivateURL(rawURL string) bool {
+// privateURLDNSTimeout bounds DNS resolution inside the SSRF guard so a
+// slow or malicious DNS server cannot block the handler indefinitely.
+const privateURLDNSTimeout = 5 * time.Second
+
+func isPrivateURL(ctx context.Context, rawURL string) bool {
 	for _, scheme := range []string{"https://", "http://", "wss://", "ws://"} {
 		if strings.HasPrefix(rawURL, scheme) {
 			rawURL = strings.TrimPrefix(rawURL, scheme)
@@ -1712,6 +1718,24 @@ func isPrivateURL(rawURL string) bool {
 			return true
 		}
 	}
+
+	// Resolve hostname to catch DNS names that map to private IPs (DNS rebinding).
+	resolveCtx, cancel := context.WithTimeout(ctx, privateURLDNSTimeout)
+	defer cancel()
+	resolver := &net.Resolver{}
+	addrs, err := resolver.LookupHost(resolveCtx, host)
+	if err != nil {
+		// If DNS fails, treat as private (fail-closed) to prevent bypass.
+		return true
+	}
+	for _, addr := range addrs {
+		for _, p := range blocked {
+			if strings.HasPrefix(addr, p) {
+				return true
+			}
+		}
+	}
+
 	return false
 }
 

--- a/v2/pkg/hub/hub_test.go
+++ b/v2/pkg/hub/hub_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -108,15 +109,15 @@ func TestIsPrivateURL(t *testing.T) {
 		{"http://192.168.1.1", true},
 		{"http://172.16.0.1", true},
 		{"http://169.254.1.1", true},
-		{"http://[::1]:8080", false},
-		{"http://[::ffff:127.0.0.1]", false},
+		{"http://[::1]:8080", true},         // IPv6 loopback — private
+		{"http://[::ffff:127.0.0.1]", true}, // IPv4-mapped loopback — private
 		{"http://0.0.0.0", true},
 		{"https://github.com", false},
 		{"https://api.github.com/repos", false},
 		{"https://hive.kubestellar.io", false},
 	}
 	for _, tt := range tests {
-		got := isPrivateURL(tt.url)
+		got := isPrivateURL(context.Background(), tt.url)
 		if got != tt.want {
 			t.Errorf("isPrivateURL(%q) = %v, want %v", tt.url, got, tt.want)
 		}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -10,6 +10,7 @@ import (
 	"html"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -690,7 +691,7 @@ func (s *HubServer) findContributeHive() *RegistryEntry {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	for _, h := range s.registry.Hives {
-		if h.Online && h.IsPublic && h.DashboardURL != "" && !isPrivateURL(h.DashboardURL) && h.Owner != "" {
+		if h.Online && h.IsPublic && h.DashboardURL != "" && !isPrivateURL(context.Background(), h.DashboardURL) && h.Owner != "" {
 			cp := h
 			return &cp
 		}
@@ -754,7 +755,11 @@ func (s *HubServer) handleContributeWSProxy(w http.ResponseWriter, r *http.Reque
 	proxy.ServeHTTP(w, r)
 }
 
-func isPrivateURL(rawURL string) bool {
+// privateURLDNSTimeout bounds DNS resolution inside the SSRF guard so a
+// slow or malicious DNS server cannot block the caller indefinitely.
+const privateURLDNSTimeout = 5 * time.Second
+
+func isPrivateURL(ctx context.Context, rawURL string) bool {
 	for _, scheme := range []string{"https://", "http://", "wss://", "ws://"} {
 		if strings.HasPrefix(rawURL, scheme) {
 			rawURL = strings.TrimPrefix(rawURL, scheme)
@@ -774,6 +779,24 @@ func isPrivateURL(rawURL string) bool {
 			return true
 		}
 	}
+
+	// Resolve hostname to catch DNS names that map to private IPs (DNS rebinding).
+	resolveCtx, cancel := context.WithTimeout(ctx, privateURLDNSTimeout)
+	defer cancel()
+	resolver := &net.Resolver{}
+	addrs, err := resolver.LookupHost(resolveCtx, host)
+	if err != nil {
+		// If DNS fails, treat as private (fail-closed) to prevent bypass.
+		return true
+	}
+	for _, addr := range addrs {
+		for _, p := range blocked {
+			if strings.HasPrefix(addr, p) {
+				return true
+			}
+		}
+	}
+
 	return false
 }
 


### PR DESCRIPTION
## Summary

- `isPrivateURL()` only checked hostnames by string prefix, allowing DNS rebinding attacks where a hostname resolving to a private IP would bypass the SSRF guard
- Added `net.Resolver.LookupHost` with a 5-second context-bounded timeout (`privateURLDNSTimeout` named constant) so resolved IPs are also checked against the blocked prefix list
- Fail-closed: if DNS resolution fails (timeout, NXDOMAIN, etc.), the host is treated as private
- Fixed both copies of `isPrivateURL` — in `pkg/dashboard/api_contribute.go` and `pkg/hub/server.go`
- Corrected two test expectations: `[::1]` and `[::ffff:127.0.0.1]` are private addresses that were previously not caught

## Files changed

- `v2/pkg/dashboard/api_contribute.go` — added `context` and `net` imports, added DNS resolution to `isPrivateURL`, updated callers to pass `r.Context()`
- `v2/pkg/dashboard/api.go` — updated caller to pass `r.Context()`
- `v2/pkg/hub/server.go` — added `net` import, added DNS resolution to `isPrivateURL`, updated caller to use `context.Background()`
- `v2/pkg/hub/hub_test.go` — added `context` import, updated test to pass context, fixed IPv6 loopback expectations

Fixes #570