### PR TITLE
feat: configurable pack agents + multi-model dashboard (Fixes #877)

### DIFF
--- a/v2/pkg/config/agent_overlay.go
+++ b/v2/pkg/config/agent_overlay.go
@@ -114,7 +114,8 @@ func (c *Config) ApplyAgentDefaults(name string) {
 	if agent.BeadsDir == "" {
 		agent.BeadsDir = fmt.Sprintf("/data/beads/%s", name)
 	}
-	if !agent.Enabled {
+	// Default to enabled unless the user explicitly set enabled: false.
+	if !agent.Enabled && !agent.enabledSet {
 		agent.Enabled = true
 	}
 	if !agent.clearOnKickSet {

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -148,6 +148,9 @@ type AgentConfig struct {
 
 	// clearOnKickSet tracks whether YAML explicitly set clear_on_kick to false
 	clearOnKickSet bool
+	// enabledSet tracks whether YAML explicitly set enabled (distinguishes
+	// "not specified" from "enabled: false").
+	enabledSet bool
 	// name is the YAML map key, set during config load
 	name string
 }
@@ -190,14 +193,22 @@ func (a *AgentConfig) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode((*plain)(a)); err != nil {
 		return err
 	}
-	// Check if clear_on_kick was explicitly present in YAML
+	// Check if clear_on_kick / enabled were explicitly present in YAML
 	for i := 0; i < len(value.Content)-1; i += 2 {
-		if value.Content[i].Value == "clear_on_kick" {
+		switch value.Content[i].Value {
+		case "clear_on_kick":
 			a.clearOnKickSet = true
-			break
+		case "enabled":
+			a.enabledSet = true
 		}
 	}
 	return nil
+}
+
+// EnabledExplicitlySet returns true when the user's YAML explicitly set the
+// "enabled" field (allowing us to distinguish "not specified" from "enabled: false").
+func (a *AgentConfig) EnabledExplicitlySet() bool {
+	return a.enabledSet
 }
 
 type GovernorConfig struct {
@@ -610,7 +621,8 @@ func (c *Config) applyDefaults() {
 		if agent.BeadsDir == "" {
 			agent.BeadsDir = fmt.Sprintf("/data/beads/%s", name)
 		}
-		if !agent.Enabled {
+		// Default to enabled unless the user explicitly set enabled: false.
+		if !agent.Enabled && !agent.enabledSet {
 			agent.Enabled = true
 		}
 		if !agent.clearOnKickSet {

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -71,6 +71,17 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 	for _, pa := range pack.Agents {
 		if existing, exists := s.deps.Config.Agents[pa.Name]; exists {
 			changed := false
+
+			// Merge pack fields as defaults — user overrides take precedence.
+			// Backend/Model: use pack value only if user left it empty.
+			if existing.Backend == "" && pa.Backend != "" {
+				existing.Backend = pa.Backend
+				changed = true
+			}
+			if existing.Model == "" && pa.Model != "" {
+				existing.Model = pa.Model
+				changed = true
+			}
 			if pa.KickTemplate != "" && existing.KickTemplate != pa.KickTemplate {
 				existing.KickTemplate = pa.KickTemplate
 				changed = true
@@ -79,6 +90,25 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 				existing.Mode = pa.Mode
 				changed = true
 			}
+			// Fill in descriptive fields from pack if user didn't set them.
+			if existing.DisplayName == "" && pa.DisplayName != "" {
+				existing.DisplayName = pa.DisplayName
+				changed = true
+			}
+			if existing.Description == "" && pa.Description != "" {
+				existing.Description = pa.Description
+				changed = true
+			}
+			if existing.Role == "" && pa.Role != "" {
+				existing.Role = pa.Role
+				changed = true
+			}
+			if existing.BeadRole == "" && pa.BeadRole != "" {
+				existing.BeadRole = pa.BeadRole
+				changed = true
+			}
+
+			// Respect user's enabled: false — don't override it.
 			if changed {
 				s.deps.Config.Agents[pa.Name] = existing
 				_ = s.deps.AgentMgr.UpdateConfig(pa.Name, existing)
@@ -120,7 +150,8 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 		finalCfg := s.deps.Config.Agents[pa.Name]
 		s.deps.AgentMgr.AddAgent(pa.Name, finalCfg)
 		// On-demand agents are only triggered explicitly (e.g. by inception).
-		if !pa.OnDemand {
+		// Also skip starting agents the user explicitly disabled.
+		if !pa.OnDemand && finalCfg.Enabled {
 			if err := s.deps.AgentMgr.Start(s.deps.Ctx, pa.Name); err != nil {
 				s.logger.Warn("failed to start agent after pack create", "agent", pa.Name, "error", err)
 			}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -532,6 +532,11 @@
     body.light-mode .model-chip.opus { background: #fef2f2; color: #dc2626; }
     body.light-mode .model-chip.sonnet { background: #fefce8; color: #ca8a04; }
     body.light-mode .model-chip.haiku { background: #eff6ff; color: #2563eb; }
+    /* Non-Claude model tiers (light mode) */
+    body.light-mode .model-chip.gpt { background: #ecfdf5; color: #047857; }
+    body.light-mode .model-chip.gemini { background: #eff6ff; color: #1d4ed8; }
+    body.light-mode .model-chip.deepseek { background: #f0fdf4; color: #16a34a; }
+    body.light-mode .model-chip.unknown { background: #f3f4f6; color: #6b7280; }
 
     /* Light kick prompt */
     body.light-mode .kick-prompt {
@@ -1033,6 +1038,11 @@
     .model-chip.haiku { background: rgba(88,166,255,0.12); color: var(--blue); }
     .model-chip.sonnet { background: rgba(210,153,34,0.12); color: var(--yellow); }
     .model-chip.opus { background: rgba(248,81,73,0.12); color: var(--red); }
+    /* Non-Claude model tiers */
+    .model-chip.gpt { background: rgba(16,163,127,0.12); color: #10a37f; }
+    .model-chip.gemini { background: rgba(66,133,244,0.12); color: #4285f4; }
+    .model-chip.deepseek { background: rgba(63,185,80,0.12); color: var(--green); }
+    .model-chip.unknown { background: rgba(139,148,158,0.12); color: var(--muted); }
 
     /* Health dots (reused inside ci-maintainer indicators) */
     .health-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; display: inline-block; }
@@ -3630,11 +3640,15 @@
 
     function _modelTier(model) {
       const m = (model || '').toLowerCase();
+      // Claude model families
       if (m.includes('haiku')) return 'haiku';
       if (m.includes('opus')) return 'opus';
       if (m.includes('sonnet')) return 'sonnet';
+      // Non-Claude models
       if (m.startsWith('gpt-')) return 'gpt';
       if (m.startsWith('gemini-')) return 'gemini';
+      if (m.startsWith('deepseek-') || m.startsWith('deepseek/')) return 'deepseek';
+      // Neutral fallback for unrecognized models
       return 'unknown';
     }
 
@@ -3658,7 +3672,7 @@
       const normalized = model.toLowerCase().replace(/\s+/g, '-');
       const shortModel = normalized.replace(/^claude-/, '').replace(/-(\d[\d-]*\d)$/, (_, v) => '-' + v.replace(/-/g, '.'));
       const tier = _modelTier(normalized);
-      const chipCls = tier === 'unknown' ? 'sonnet' : tier;
+      const chipCls = tier;
       const isBudgetOverride = reason && (reason.includes('budget_downgrade') || reason.includes('budget_critical'));
       const overrideIcon = isBudgetOverride ? ' ⬇' : '';
       const overrideTitle = isBudgetOverride ? ` (${reason})` : '';


### PR DESCRIPTION
## Summary
- **Fix 1**: Pack agents now merge user-defined `backend:` and `model:` from hive.yaml instead of silently ignoring them. User config takes precedence; pack values fill in missing fields (DisplayName, Description, Role, BeadRole).
- **Fix 2**: `enabled: false` in user config is now respected. Added `enabledSet` tracking (same pattern as `clearOnKickSet`) so `applyDefaults` can distinguish "not specified" from "explicitly disabled". Pack application also skips starting disabled agents.
- **Fix 3**: Dashboard model chips now recognize non-Claude models (deepseek, gemini, gpt) with proper tier-colored styling in both dark and light modes. Unknown models get a neutral gray style instead of silently falling back to the sonnet color class.

## Files changed
- `v2/pkg/config/config.go` — `enabledSet` field + `EnabledExplicitlySet()` accessor; `applyDefaults` respects explicit `enabled: false`
- `v2/pkg/config/agent_overlay.go` — Same `enabled: false` fix in `ApplyAgentDefaults`
- `v2/pkg/dashboard/api_packs.go` — `ApplyPack` merges user backend/model/descriptive fields; skips starting disabled agents
- `v2/pkg/dashboard/static/index.html` — `_modelTier()` recognizes deepseek/gemini/gpt; CSS for `.model-chip.gpt`, `.gemini`, `.deepseek`, `.unknown` in dark+light modes; removed `unknown → sonnet` fallback

## Test plan
- [x] `go vet ./...` passes
- [ ] Deploy with hive.yaml that defines `quality:` with `backend: claude` — verify quality agent uses claude, not copilot
- [ ] Deploy with `quality:` set to `enabled: false` — verify it does not start
- [ ] Check dashboard with agents using deepseek/gemini/gpt models — verify styled chips

Fixes #877