### PR TITLE
feat: full hive de-provisioning with OCI FSS cleanup

### DIFF
--- a/v2/pkg/hub/oci_fss.go
+++ b/v2/pkg/hub/oci_fss.go
@@ -268,10 +268,11 @@ func createOCIFileSystem(displayName string, logger *slog.Logger) (string, error
 
 // createOCIExport creates an NFS export for the given file system on the
 // configured export set, making it accessible via NFS at the specified path.
-func createOCIExport(fileSystemID, exportPath string, logger *slog.Logger) error {
+// It returns the OCID of the newly created export.
+func createOCIExport(fileSystemID, exportPath string, logger *slog.Logger) (string, error) {
 	cfg, err := loadOCIConfig()
 	if err != nil {
-		return fmt.Errorf("load OCI config: %w", err)
+		return "", fmt.Errorf("load OCI config: %w", err)
 	}
 
 	endpoint := fmt.Sprintf(ociFSSEndpointFmt, cfg.region)
@@ -283,33 +284,119 @@ func createOCIExport(fileSystemID, exportPath string, logger *slog.Logger) error
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return fmt.Errorf("marshal export request: %w", err)
+		return "", fmt.Errorf("marshal export request: %w", err)
 	}
 
 	reqURL := endpoint + ociExportsPath
 	req, err := http.NewRequest(http.MethodPost, reqURL, bytes.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("build request: %w", err)
+		return "", fmt.Errorf("build request: %w", err)
 	}
 	req.Host = req.URL.Host
 
 	if err := ociSignRequest(req, body, cfg); err != nil {
-		return fmt.Errorf("sign request: %w", err)
+		return "", fmt.Errorf("sign request: %w", err)
 	}
 
 	client := &http.Client{Timeout: ociHTTPTimeoutSec * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("OCI export API call failed: %w", err)
+		return "", fmt.Errorf("OCI export API call failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	respBody, _ := io.ReadAll(resp.Body)
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("OCI export API returned %d: %s", resp.StatusCode, string(respBody))
+		return "", fmt.Errorf("OCI export API returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
-	logger.Info("OCI NFS export created", "fileSystemID", fileSystemID, "exportPath", exportPath)
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("parse OCI export response: %w", err)
+	}
+	if result.ID == "" {
+		return "", fmt.Errorf("OCI export response missing export ID")
+	}
+
+	logger.Info("OCI NFS export created", "fileSystemID", fileSystemID, "exportPath", exportPath, "exportID", result.ID)
+	return result.ID, nil
+}
+
+// deleteOCIExport deletes an OCI NFS export by its OCID.
+// DELETE requests use the same signing headers as GET (date, request-target, host).
+func deleteOCIExport(exportID string, logger *slog.Logger) error {
+	cfg, err := loadOCIConfig()
+	if err != nil {
+		return fmt.Errorf("load OCI config: %w", err)
+	}
+
+	endpoint := fmt.Sprintf(ociFSSEndpointFmt, cfg.region)
+	reqURL := endpoint + ociExportsPath + "/" + exportID
+
+	req, err := http.NewRequest(http.MethodDelete, reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Host = req.URL.Host
+
+	if err := ociSignRequest(req, nil, cfg); err != nil {
+		return fmt.Errorf("sign request: %w", err)
+	}
+
+	client := &http.Client{Timeout: ociHTTPTimeoutSec * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("OCI export delete API call failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// 204 No Content is the expected success response for DELETE.
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("OCI export delete API returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	logger.Info("OCI NFS export deleted", "exportID", exportID)
+	return nil
+}
+
+// deleteOCIFileSystem deletes an OCI File System by its OCID.
+// The file system must have no remaining exports before deletion.
+func deleteOCIFileSystem(fileSystemID string, logger *slog.Logger) error {
+	cfg, err := loadOCIConfig()
+	if err != nil {
+		return fmt.Errorf("load OCI config: %w", err)
+	}
+
+	endpoint := fmt.Sprintf(ociFSSEndpointFmt, cfg.region)
+	reqURL := endpoint + ociFileSystemsPath + "/" + fileSystemID
+
+	req, err := http.NewRequest(http.MethodDelete, reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Host = req.URL.Host
+
+	if err := ociSignRequest(req, nil, cfg); err != nil {
+		return fmt.Errorf("sign request: %w", err)
+	}
+
+	client := &http.Client{Timeout: ociHTTPTimeoutSec * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("OCI file system delete API call failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// 204 No Content is the expected success response for DELETE.
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("OCI file system delete API returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	logger.Info("OCI file system deleted", "fileSystemID", fileSystemID)
 	return nil
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1133,21 +1133,8 @@ func (s *HubServer) handleDeleteHive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ns := "hive-hosted-" + id
-	cmd := exec.Command("kubectl", "delete", "namespace", ns, "--ignore-not-found")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		s.logger.Warn("kubectl delete ns failed", "hive", id, "output", string(out))
-	}
-
-	os.RemoveAll(filepath.Join(saasHivesDir, id))
-
-	for _, u := range listAllSaaSUsers() {
-		if _, ok := u.Hives[id]; ok {
-			delete(u.Hives, id)
-			saveSaaSUser(&u)
-		}
-	}
+	// Full de-provisioning: namespace, PV, OCI export, OCI file system, disk record, user cleanup.
+	deprovisionHive(h, s.logger)
 
 	s.logger.Info("audit: hosted hive deleted", "hive_id", id, "by", username)
 	w.Header().Set("Content-Type", "application/json")
@@ -3514,7 +3501,7 @@ const dashboardHTML = `<!DOCTYPE html>
     }
 
     async function deleteHive(id) {
-      if (!await hiveConfirm('Delete ' + id + '? This removes all data.')) return;
+      if (!await hiveConfirm('Delete ' + id + '? This removes the namespace, PV, OCI storage, and all data.')) return;
       var btns = document.querySelectorAll('button[onclick*="deleteHive"]');
       btns.forEach(function(b) { b.disabled = true; b.textContent = 'Deleting...'; b.style.opacity = '0.6'; });
       try {

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -52,6 +52,8 @@ type SaaSHive struct {
 	Error           string                 `json:"error,omitempty"`
 	AutoUpgrade     bool                   `json:"auto_upgrade"`
 	PendingRequests []PendingAccessRequest `json:"pending_requests,omitempty"`
+	OCIFileSystemID string                 `json:"oci_file_system_id,omitempty"`
+	OCIExportID     string                 `json:"oci_export_id,omitempty"`
 }
 
 type CreateHiveRequest struct {
@@ -229,8 +231,12 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, logger *slog.Logger) err
 	if err != nil {
 		logger.Warn("OCI FSS creation failed — admin must create manually", "hive", h.ID, "error", err)
 	} else {
-		if exportErr := createOCIExport(fsID, exportPath, logger); exportErr != nil {
+		h.OCIFileSystemID = fsID
+		exportID, exportErr := createOCIExport(fsID, exportPath, logger)
+		if exportErr != nil {
 			logger.Warn("OCI export creation failed — admin must create manually", "hive", h.ID, "error", exportErr)
+		} else {
+			h.OCIExportID = exportID
 		}
 	}
 
@@ -265,6 +271,67 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, logger *slog.Logger) err
 
 	logger.Info("audit: saas hive provisioned", "hive_id", h.ID, "owner", h.Owner, "org", h.Org)
 	return nil
+}
+
+// deprovisionHive performs best-effort cleanup of all resources associated
+// with a hosted hive: K8s namespace (cascading to deployment, service, ingress,
+// configmap, secret, PVC), cluster-scoped PV, OCI NFS export, OCI file system,
+// and the on-disk SaaS hive record. It also decrements the owner's quota.
+// Order matters: namespace before PV, export before file system.
+// Errors are logged but do not stop the remaining cleanup steps.
+func deprovisionHive(h *SaaSHive, logger *slog.Logger) {
+	hiveID := h.ID
+
+	// Step 1: Delete K8s namespace (cascading delete removes deployment, service,
+	// ingress, configmap, secret, and PVC).
+	ns := "hive-hosted-" + hiveID
+	logger.Info("deprovision: deleting namespace", "namespace", ns)
+	cmd := exec.Command("kubectl", "delete", "namespace", ns, "--ignore-not-found")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		logger.Warn("deprovision: namespace delete failed", "namespace", ns, "output", string(out), "error", err)
+	}
+
+	// Step 2: Delete cluster-scoped PV (not removed by namespace deletion).
+	pvName := "hive-" + hiveID + "-fss-pv"
+	logger.Info("deprovision: deleting PV", "pv", pvName)
+	cmd = exec.Command("kubectl", "delete", "pv", pvName, "--ignore-not-found")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		logger.Warn("deprovision: PV delete failed", "pv", pvName, "output", string(out), "error", err)
+	}
+
+	// Step 3: Delete OCI NFS export (must happen before file system deletion).
+	if h.OCIExportID != "" {
+		logger.Info("deprovision: deleting OCI export", "exportID", h.OCIExportID)
+		if err := deleteOCIExport(h.OCIExportID, logger); err != nil {
+			logger.Warn("deprovision: OCI export delete failed", "exportID", h.OCIExportID, "error", err)
+		}
+	}
+
+	// Step 4: Delete OCI file system (must be empty of exports first).
+	if h.OCIFileSystemID != "" {
+		logger.Info("deprovision: deleting OCI file system", "fileSystemID", h.OCIFileSystemID)
+		if err := deleteOCIFileSystem(h.OCIFileSystemID, logger); err != nil {
+			logger.Warn("deprovision: OCI file system delete failed", "fileSystemID", h.OCIFileSystemID, "error", err)
+		}
+	}
+
+	// Step 5: Remove the on-disk SaaS hive record.
+	hiveDir := filepath.Join(saasHivesDir, hiveID)
+	if err := os.RemoveAll(hiveDir); err != nil {
+		logger.Warn("deprovision: failed to remove hive directory", "path", hiveDir, "error", err)
+	}
+
+	// Step 6: Remove hive from all user records (decrement quota).
+	for _, u := range listAllSaaSUsers() {
+		if _, ok := u.Hives[hiveID]; ok {
+			delete(u.Hives, hiveID)
+			if err := saveSaaSUser(&u); err != nil {
+				logger.Warn("deprovision: failed to update user record", "user", u.GitHubUsername, "error", err)
+			}
+		}
+	}
+
+	logger.Info("audit: hive deprovisioned", "hive_id", hiveID, "owner", h.Owner)
 }
 
 func StartProvisionWatcher(logger *slog.Logger, mu *sync.RWMutex) {


### PR DESCRIPTION
## Summary

- Adds full de-provisioning when a hosted hive is deleted: K8s namespace (cascading delete of deployment, service, ingress, configmap, secret, PVC), cluster-scoped PV, OCI NFS export, OCI file system, on-disk metadata, and user quota decrement
- Stores `OCIFileSystemID` and `OCIExportID` on the `SaaSHive` record at provision time so teardown can find them
- Updates `createOCIExport` to return the export OCID (parsed from response JSON)
- Adds `deleteOCIExport` and `deleteOCIFileSystem` functions using OCI REST DELETE with the same HTTP signature auth
- All cleanup steps are best-effort — errors are logged but don't block remaining steps
- Order is enforced: namespace before PV, export before file system

## Test plan

- [ ] `go vet ./...` and `go build ./...` pass (verified locally)
- [ ] Create a hosted hive, confirm `meta.json` contains `oci_file_system_id` and `oci_export_id`
- [ ] Delete the hive via dashboard, confirm namespace + PV + OCI resources are cleaned up
- [ ] Delete a hive that was created before this change (missing OCI IDs) — should skip OCI cleanup gracefully