### PR TITLE
fix: persistent permissions watcher prevents root-owned files from breaking agents

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -165,6 +165,11 @@ VOLUME ["/data", "/secrets"]
 COPY v2/deploy/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
+# Pre-create /data/home/ subdirectories with correct ownership so the
+# permissions watcher doesn't have to create them at runtime.
+RUN mkdir -p /data/home/.copilot /data/home/.cache /data/home/.config /data/home/.local && \
+    chown -R dev:node /data/home/
+
 RUN chown -R dev:node /data /home/dev 2>/dev/null || true
 
 ENTRYPOINT ["entrypoint.sh"]

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -58,6 +58,11 @@ func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	slog.SetDefault(logger)
 
+	// Start background permissions watcher for /data/home/ subdirectories.
+	// Copilot and other tools create files as root, breaking agent access.
+	// Runs on all pods (hub and spoke).
+	go agent.StartPermissionsWatcher(logger)
+
 	if os.Getenv("HIVE_MODE") == "hub" {
 		runHub(logger)
 		return

--- a/v2/pkg/agent/permissions_watcher.go
+++ b/v2/pkg/agent/permissions_watcher.go
@@ -1,0 +1,178 @@
+package agent
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+// Permission watcher constants — no magic numbers.
+const (
+	// PermissionFixInterval is how often the watcher scans for wrong ownership.
+	PermissionFixInterval = 10 * time.Second
+
+	// DevUID is the uid of the "dev" user that agents run as.
+	DevUID = 1001
+
+	// NodeGID is the gid of the "node" group shared by all agent users.
+	NodeGID = 1000
+
+	// DirPerms is the minimum permission bits required on directories (u+rwx).
+	DirPerms = 0o700
+
+	// FilePerms is the minimum permission bits required on files (u+rw).
+	FilePerms = 0o600
+)
+
+// WatchedHomeDirs are the subdirectories under the shared home that tools
+// (Copilot, Claude, etc.) frequently create with root ownership.
+var WatchedHomeDirs = []string{
+	"/data/home/.copilot",
+	"/data/home/.cache",
+	"/data/home/.config",
+	"/data/home/.local",
+}
+
+// StartPermissionsWatcher runs a background goroutine that periodically
+// scans WatchedHomeDirs and fixes files/directories that were created
+// with wrong ownership (e.g., root-owned by Copilot CLI).
+//
+// It never blocks or panics. Call it once at startup:
+//
+//	go agent.StartPermissionsWatcher(logger)
+func StartPermissionsWatcher(logger *slog.Logger) {
+	logger.Info("permissions watcher started",
+		"interval", PermissionFixInterval,
+		"watched_dirs", WatchedHomeDirs,
+		"target_uid", DevUID,
+		"target_gid", NodeGID,
+	)
+
+	// Ensure watched directories exist with correct ownership on first run.
+	ensureWatchedDirs(logger)
+
+	ticker := time.NewTicker(PermissionFixInterval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		fixPermissions(logger)
+	}
+}
+
+// ensureWatchedDirs creates each watched directory if it does not exist
+// and sets correct ownership.
+func ensureWatchedDirs(logger *slog.Logger) {
+	for _, dir := range WatchedHomeDirs {
+		if err := os.MkdirAll(dir, DirPerms|0o070); err != nil {
+			logger.Warn("permissions watcher: failed to create directory",
+				"path", dir,
+				"error", err,
+			)
+			continue
+		}
+		// Always set ownership on the top-level dir at startup.
+		if err := os.Chown(dir, DevUID, NodeGID); err != nil {
+			logger.Warn("permissions watcher: failed to chown directory",
+				"path", dir,
+				"error", err,
+			)
+		}
+	}
+}
+
+// fixPermissions walks each watched directory and fixes ownership/mode
+// on any file or directory that is wrong. It only logs when it actually
+// changes something.
+func fixPermissions(logger *slog.Logger) {
+	for _, root := range WatchedHomeDirs {
+		info, err := os.Stat(root)
+		if err != nil {
+			// Directory doesn't exist yet — create it.
+			if os.IsNotExist(err) {
+				ensureWatchedDirs(logger)
+			}
+			continue
+		}
+		if !info.IsDir() {
+			continue
+		}
+
+		err = filepath.Walk(root, func(path string, fi os.FileInfo, walkErr error) error {
+			if walkErr != nil {
+				return nil // skip unreadable entries, don't abort walk
+			}
+			fixEntry(path, fi, logger)
+			return nil
+		})
+		if err != nil {
+			logger.Warn("permissions watcher: walk error",
+				"root", root,
+				"error", err,
+			)
+		}
+	}
+}
+
+// fixEntry checks a single file or directory and corrects ownership/mode
+// if needed.
+func fixEntry(path string, fi os.FileInfo, logger *slog.Logger) {
+	stat, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return
+	}
+
+	// Fix ownership if owned by root (uid 0).
+	if stat.Uid == 0 {
+		if err := os.Chown(path, DevUID, NodeGID); err != nil {
+			logger.Warn("permissions watcher: chown failed",
+				"path", path,
+				"error", err,
+			)
+		} else {
+			logger.Warn("permissions watcher: fixed root-owned entry",
+				"path", path,
+				"was_uid", stat.Uid,
+				"new_uid", DevUID,
+			)
+		}
+	}
+
+	mode := fi.Mode()
+	if fi.IsDir() {
+		// Directories need u+rwx to be usable.
+		if mode.Perm()&DirPerms != DirPerms {
+			newMode := mode.Perm() | DirPerms
+			if err := os.Chmod(path, newMode); err != nil {
+				logger.Warn("permissions watcher: chmod dir failed",
+					"path", path,
+					"error", err,
+				)
+			} else {
+				logger.Warn("permissions watcher: fixed directory permissions",
+					"path", path,
+					"old_mode", mode.Perm().String(),
+					"new_mode", newMode.String(),
+				)
+			}
+		}
+	} else {
+		// Regular files need u+rw to be readable/writable.
+		if mode.Perm()&FilePerms != FilePerms {
+			newMode := mode.Perm() | FilePerms
+			if err := os.Chmod(path, newMode); err != nil {
+				logger.Warn("permissions watcher: chmod file failed",
+					"path", path,
+					"error", err,
+				)
+			} else {
+				logger.Warn("permissions watcher: fixed file permissions",
+					"path", path,
+					"old_mode", mode.Perm().String(),
+					"new_mode", newMode.String(),
+				)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a Go-based background goroutine (`agent.StartPermissionsWatcher`) that polls `/data/home/.copilot/`, `.cache/`, `.config/`, `.local/` every 10 seconds
- Fixes root-owned files/directories by chowning to `dev:node` (1001:1000) and ensuring `u+rwx` on dirs, `u+rw` on files
- Runs on all hive pods (hub and spoke) — started before the hub/spoke mode branch in `main.go`
- Pre-creates the directories in the Dockerfile with correct ownership
- All numeric values use named constants with comments (no magic numbers)
- Only logs when it actually changes something — no noise on clean scans

## Why

Copilot CLI and other tools create files as root under `/data/home/`, which makes them inaccessible to agent processes running as the `dev` user. The existing shell-based fix in `entrypoint.sh` (inotify + polling) is fragile and doesn't cover all cases. This Go watcher is more reliable since it runs inside the binary itself.

## Files changed

- `v2/pkg/agent/permissions_watcher.go` — new file with the watcher goroutine
- `v2/cmd/hive/main.go` — wires `go agent.StartPermissionsWatcher(logger)` into startup
- `v2/Dockerfile` — pre-creates `/data/home/` subdirs with correct ownership

## Test plan

- [x] `go vet ./...` passes
- [ ] Deploy to a hive pod and verify root-owned files under `/data/home/` get fixed within 10s
- [ ] Verify log output only appears when permissions are actually changed