### PR TITLE
fix: restore missing symbols breaking v3 Docker build

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/beads"
@@ -94,6 +95,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/agents", s.handleAgentsList)
 	s.mux.HandleFunc("POST /api/agents", s.handleAgentCreate)
 	s.mux.HandleFunc("DELETE /api/agents/{name}", s.handleAgentDelete)
+	s.mux.HandleFunc("POST /api/agents/import", s.handleAgentImport)
 
 	s.mux.HandleFunc("GET /api/packs", s.handlePacksList)
 	s.mux.HandleFunc("POST /api/packs/{level}/apply", s.handlePackApply)
@@ -301,6 +303,60 @@ func sanitizeString(s string) string {
 var envVarEscapePattern = regexp.MustCompile(`\$\{[^}]*\}`)
 
 var tokenRedactor = regexp.MustCompile(`(ghp_|gho_|ghs_|github_pat_)[A-Za-z0-9_]{10,}`)
+
+// ghcrTagExistsCached checks whether a container tag exists on ghcr.io/kubestellar/hive,
+// caching the result to avoid repeated network calls on each version poll.
+var (
+	ghcrCacheMu     sync.RWMutex
+	ghcrCacheResult = map[string]bool{}
+	ghcrCacheExpiry = map[string]time.Time{}
+)
+
+const ghcrCacheTTL = 2 * time.Minute
+const ghcrCheckTimeout = 5 * time.Second
+
+func ghcrTagExistsCached(tag string) bool {
+	ghcrCacheMu.RLock()
+	if exp, ok := ghcrCacheExpiry[tag]; ok && time.Now().Before(exp) {
+		result := ghcrCacheResult[tag]
+		ghcrCacheMu.RUnlock()
+		return result
+	}
+	ghcrCacheMu.RUnlock()
+
+	result := ghcrTagExists(tag)
+	ghcrCacheMu.Lock()
+	ghcrCacheResult[tag] = result
+	ghcrCacheExpiry[tag] = time.Now().Add(ghcrCacheTTL)
+	ghcrCacheMu.Unlock()
+	return result
+}
+
+func ghcrTagExists(tag string) bool {
+	client := &http.Client{Timeout: ghcrCheckTimeout}
+	tokenResp, err := client.Get("https://ghcr.io/token?scope=repository:kubestellar/hive:pull")
+	if err != nil {
+		return false
+	}
+	defer tokenResp.Body.Close()
+	var tok struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(tokenResp.Body).Decode(&tok); err != nil {
+		return false
+	}
+
+	manifestURL := fmt.Sprintf("https://ghcr.io/v2/kubestellar/hive/manifests/%s", tag)
+	req, _ := http.NewRequest("HEAD", manifestURL, nil)
+	req.Header.Set("Authorization", "Bearer "+tok.Token)
+	req.Header.Set("Accept", "application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
 
 func redactTokensInLine(s string) string {
 	return tokenRedactor.ReplaceAllStringFunc(s, func(m string) string {
@@ -3068,7 +3124,7 @@ func (s *Server) handleKnowledgeSubsAdd(w http.ResponseWriter, r *http.Request) 
 		jsonError(w, "url must use http or https scheme", http.StatusBadRequest)
 		return
 	}
-	if isPrivateURL(sub.URL) {
+	if isPrivateURL(r.Context(), sub.URL) {
 		jsonError(w, "subscription url must not point to private/internal addresses", http.StatusBadRequest)
 		return
 	}

--- a/v2/pkg/dashboard/api_agents.go
+++ b/v2/pkg/dashboard/api_agents.go
@@ -13,6 +13,16 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/config"
 )
 
+const promptTemplateSaveDir = "/data/policies"
+const exportKind = "AgentDefinition"
+
+func valueOrDefault(v, dflt string) string {
+	if v != "" {
+		return v
+	}
+	return dflt
+}
+
 type agentListEntry struct {
 	Name        string `json:"name"`
 	ID          string `json:"id"`


### PR DESCRIPTION
## Summary
- Restores `exportKind`, `valueOrDefault`, `promptTemplateSaveDir` definitions lost during v3 rebase
- Adds `ghcrTagExistsCached` and `ghcrTagExists` GHCR container verification functions
- Fixes `isPrivateURL` call missing `context.Context` argument
- Registers `/api/agents/import` route

## Root cause
The last 2 v3 Docker CI runs failed with `go build` errors (`undefined: exportKind`, `undefined: valueOrDefault`, etc.). These symbols existed in v2's `api.go` but were lost when v3 was rebased. Without a passing Docker build, GHCR has no v3 image, so the Hive Hub dashboard shows no v3 digest.

## Test plan
- [x] `go build ./cmd/... ./pkg/...` passes
- [x] All `TestHandleAgentImport_*` tests pass
- [ ] Docker CI should pass after merge, restoring v3 image on GHCR
- [ ] Hive Hub should show v3 digest after next SHA poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)