### PR TITLE
feat: rebase v3 onto v2 HEAD — restore all v2 functionality + inference

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - v2
+      - v3
   workflow_dispatch:
 
 # Serialize Docker builds so concurrent merges don't race to tag v2-latest.

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -165,6 +165,11 @@ VOLUME ["/data", "/secrets"]
 COPY v2/deploy/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
+# Pre-create /data/home/ subdirectories with correct ownership so the
+# permissions watcher doesn't have to create them at runtime.
+RUN mkdir -p /data/home/.copilot /data/home/.cache /data/home/.config /data/home/.local && \
+    chown -R dev:node /data/home/
+
 RUN chown -R dev:node /data /home/dev 2>/dev/null || true
 
 ENTRYPOINT ["entrypoint.sh"]

--- a/v2/cmd/apiproxy/main.go
+++ b/v2/cmd/apiproxy/main.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/apiproxy"
+)
+
+func main() {
+	port := flag.Int("port", 9000, "port to listen on")
+	upstream := flag.String("upstream", "https://api.anthropic.com", "upstream API URL")
+	logFile := flag.String("log", "", "log file path (default: stdout)")
+	flag.Parse()
+
+	var logWriter *json.Encoder
+	if *logFile != "" {
+		f, err := os.OpenFile(*logFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+		if err != nil {
+			log.Fatalf("failed to open log file: %v", err)
+		}
+		defer f.Close()
+		logWriter = json.NewEncoder(f)
+	} else {
+		logWriter = json.NewEncoder(os.Stdout)
+	}
+
+	handler := func(evt apiproxy.Event) {
+		entry := struct {
+			Timestamp string          `json:"ts"`
+			Agent     string          `json:"agent,omitempty"`
+			Direction string          `json:"direction"`
+			Method    string          `json:"method,omitempty"`
+			Path      string          `json:"path"`
+			Status    int             `json:"status,omitempty"`
+			Model     string          `json:"model,omitempty"`
+			SSEType   string          `json:"sse_type,omitempty"`
+			BodySize  int             `json:"body_size"`
+			Body      json.RawMessage `json:"body,omitempty"`
+		}{
+			Timestamp: evt.Timestamp.Format(time.RFC3339),
+			Agent:     evt.Agent,
+			Direction: evt.Direction,
+			Method:    evt.Method,
+			Path:      evt.Path,
+			Status:    evt.Status,
+			Model:     evt.Model,
+			SSEType:   evt.SSEType,
+			BodySize:  len(evt.Body),
+		}
+		if evt.SSEType != "" && len(evt.Body) > 0 {
+			entry.Body = evt.Body
+		}
+		logWriter.Encode(entry)
+	}
+
+	authToken := os.Getenv("PROXY_AUTH_TOKEN")
+	if authToken == "" {
+		authToken = os.Getenv("ANTHROPIC_API_KEY")
+	}
+	proxy, err := apiproxy.New(*upstream, handler, authToken)
+	if err != nil {
+		log.Fatalf("failed to create proxy: %v", err)
+	}
+
+	addr := fmt.Sprintf(":%d", *port)
+	log.Printf("[apiproxy] listening on %s → %s", addr, *upstream)
+	if err := http.ListenAndServe(addr, proxy); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -58,6 +58,11 @@ func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	slog.SetDefault(logger)
 
+	// Start background permissions watcher for /data/home/ subdirectories.
+	// Copilot and other tools create files as root, breaking agent access.
+	// Runs on all pods (hub and spoke).
+	go agent.StartPermissionsWatcher(logger)
+
 	if os.Getenv("HIVE_MODE") == "hub" {
 		runHub(logger)
 		return

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -58,11 +58,6 @@ func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	slog.SetDefault(logger)
 
-	// Start background permissions watcher for /data/home/ subdirectories.
-	// Copilot and other tools create files as root, breaking agent access.
-	// Runs on all pods (hub and spoke).
-	go agent.StartPermissionsWatcher(logger)
-
 	if os.Getenv("HIVE_MODE") == "hub" {
 		runHub(logger)
 		return
@@ -864,9 +859,34 @@ func main() {
 		logger.Error("failed to create github proxy", "error", err)
 	} else {
 		dashboard.SetProxyViolationsProvider(githubProxy.Violations)
+
+		vllmEndpoint := envOrDefault("HIVE_VLLM_ENDPOINT", "http://vllm-svc.hive.svc.cluster.local:8000")
+		llmdEndpoint := envOrDefault("HIVE_LLMD_ENDPOINT", "http://llm-d-epp.hive.svc.cluster.local:8000")
+		agentMgr.SetInferenceCallbacks(
+			func(agentName, backend, model string) {
+				endpoint := vllmEndpoint
+				if backend == "llm-d" {
+					endpoint = llmdEndpoint
+				}
+				githubProxy.SetInferenceRoute(agentName, &proxy.InferenceRoute{
+					Backend:  backend,
+					Endpoint: endpoint,
+					Model:    model,
+				})
+			},
+			func(agentName string) {
+				githubProxy.ClearInferenceRoute(agentName)
+			},
+		)
+
 		go func() {
 			if err := githubProxy.Start(); err != nil {
 				logger.Error("github proxy failed", "error", err)
+			}
+		}()
+		go func() {
+			if err := githubProxy.StartInferenceTranslator(); err != nil {
+				logger.Error("inference translation server failed", "error", err)
 			}
 		}()
 		logger.Info("github proxy started", "addr", githubProxy.ListenAddr())
@@ -990,7 +1010,7 @@ func main() {
 				}(),
 				SnapshotURL:  cfg.Hub.SnapshotURL,
 				IsPublic:     cfg.Hub.IsPublic,
-				Version:      "2.0.0",
+				Version:           "3.0.0",
 				GitHash:           gitShort,
 				GitBranch:         gitBranch,
 				GitHubAppRequired: dashSrv.IsGitHubAppRequired(),
@@ -2027,4 +2047,11 @@ func runHub(logger *slog.Logger) {
 		os.Exit(1)
 	}
 	logger.Info("hub server stopped")
+}
+
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
 }

--- a/v2/deploy/inference/kustomization.yaml
+++ b/v2/deploy/inference/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - vllm-deployment.yaml
+  - llm-d-deployment.yaml

--- a/v2/deploy/inference/llm-d-deployment.yaml
+++ b/v2/deploy/inference/llm-d-deployment.yaml
@@ -1,0 +1,153 @@
+---
+# llm-d EPP (Endpoint Picker Policy) deployment.
+#
+# Prerequisites (applied separately before this manifest):
+#   1. Gateway API CRDs v1.2+:
+#      kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
+#   2. Gateway API Inference Extension CRDs v1.5.0:
+#      kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/download/v1.5.0/manifests.yaml
+#   3. vLLM deployment running in hive-inference namespace
+
+---
+# InferencePool (GA v1): targets vLLM pods by label, with EPP as endpoint picker
+apiVersion: inference.networking.k8s.io/v1
+kind: InferencePool
+metadata:
+  name: hive-vllm-pool
+  namespace: hive-inference
+spec:
+  targetPorts:
+    - number: 8000
+  selector:
+    matchLabels:
+      app: vllm
+  endpointPickerRef:
+    name: llm-d-epp
+    port:
+      number: 9002
+
+---
+# InferenceModel (v1alpha2): maps model name to pool
+apiVersion: inference.networking.x-k8s.io/v1alpha2
+kind: InferenceModel
+metadata:
+  name: qwen-0-5b
+  namespace: hive-inference
+spec:
+  modelName: "qwen2.5-0.5b-instruct"
+  poolRef:
+    name: hive-vllm-pool
+  criticality: Standard
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: llm-d-epp
+  namespace: hive-inference
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: llm-d-epp
+rules:
+  - apiGroups: ["inference.networking.k8s.io"]
+    resources: ["inferencepools"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["inference.networking.x-k8s.io"]
+    resources: ["inferencepools", "inferencemodels", "inferencemodelrewrites", "inferenceobjectives", "inferencepoolimports"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["endpoints", "services"]
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: llm-d-epp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: llm-d-epp
+subjects:
+  - kind: ServiceAccount
+    name: llm-d-epp
+    namespace: hive-inference
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm-d-epp
+  namespace: hive-inference
+  labels:
+    app: llm-d-epp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: llm-d-epp
+  template:
+    metadata:
+      labels:
+        app: llm-d-epp
+    spec:
+      serviceAccountName: llm-d-epp
+      containers:
+        - name: epp
+          image: ghcr.io/llm-d/llm-d-inference-scheduler:latest
+          args:
+            - "--pool-name=hive-vllm-pool"
+            - "--pool-namespace=hive-inference"
+            - "--secure-serving=false"
+          ports:
+            - containerPort: 9002
+              name: grpc
+              protocol: TCP
+            - containerPort: 9003
+              name: health
+              protocol: TCP
+          resources:
+            requests:
+              cpu: "250m"
+              memory: 256Mi
+            limits:
+              cpu: "500m"
+              memory: 512Mi
+          readinessProbe:
+            grpc:
+              port: 9003
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            grpc:
+              port: 9003
+            initialDelaySeconds: 10
+            periodSeconds: 30
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm-d-epp
+  namespace: hive-inference
+  labels:
+    app: llm-d-epp
+spec:
+  selector:
+    app: llm-d-epp
+  ports:
+    - port: 9002
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+    - port: 9003
+      targetPort: health
+      protocol: TCP
+      name: health
+  type: ClusterIP

--- a/v2/deploy/inference/vllm-deployment.yaml
+++ b/v2/deploy/inference/vllm-deployment.yaml
@@ -1,0 +1,124 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hive-inference
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hf-token
+  namespace: hive-inference
+type: Opaque
+stringData:
+  token: "placeholder"
+---
+# vLLM-compatible inference backend using llama.cpp server.
+# llama.cpp provides the same OpenAI Chat Completions API that vLLM does,
+# but runs natively on ARM64 CPU without CUDA dependencies.
+# The proxy translation layer (Anthropic <-> OpenAI) works identically.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm
+  namespace: hive-inference
+  labels:
+    app: vllm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vllm
+  template:
+    metadata:
+      labels:
+        app: vllm
+    spec:
+      initContainers:
+        - name: model-download
+          image: curlimages/curl:8.13.0
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "[model-download] Downloading Qwen2.5-0.5B-Instruct GGUF..."
+              curl -L -o /models/qwen2.5-0.5b-instruct-q4_k_m.gguf \
+                "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/main/qwen2.5-0.5b-instruct-q4_k_m.gguf"
+              ls -lh /models/
+              echo "[model-download] Done."
+          volumeMounts:
+            - name: models
+              mountPath: /models
+      containers:
+        - name: llama-server
+          image: ghcr.io/ggml-org/llama.cpp:server
+          args:
+            - "--model"
+            - "/models/qwen2.5-0.5b-instruct-q4_k_m.gguf"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "8000"
+            - "--ctx-size"
+            - "8192"
+            - "--threads"
+            - "2"
+            - "--chat-template"
+            - "chatml"
+          ports:
+            - containerPort: 8000
+              name: http
+              protocol: TCP
+          volumeMounts:
+            - name: models
+              mountPath: /models
+              readOnly: true
+          resources:
+            requests:
+              cpu: "2"
+              memory: 4Gi
+            limits:
+              cpu: "3"
+              memory: 6Gi
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 60
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+      volumes:
+        - name: models
+          emptyDir:
+            sizeLimit: 2Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm-svc
+  namespace: hive-inference
+  labels:
+    app: vllm
+spec:
+  selector:
+    app: vllm
+  ports:
+    - port: 8000
+      targetPort: http
+      protocol: TCP
+      name: http
+  type: ClusterIP

--- a/v2/deploy/k8s/deployment.yaml
+++ b/v2/deploy/k8s/deployment.yaml
@@ -48,6 +48,14 @@ spec:
                   name: hive-secrets
                   key: HIVE_DASHBOARD_TOKEN
                   optional: true
+            - name: HIVE_VLLM_ENDPOINT
+              value: "http://vllm-svc.hive-inference.svc.cluster.local:8000"
+            - name: HIVE_LLMD_ENDPOINT
+              value: "http://llm-d-epp.hive-inference.svc.cluster.local:8000"
+            - name: HIVE_VLLM_MODELS
+              value: "qwen2.5-0.5b-instruct"
+            - name: HIVE_LLMD_MODELS
+              value: "qwen2.5-0.5b-instruct"
           volumeMounts:
             - name: config
               mountPath: /etc/hive

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -98,6 +98,27 @@ type Manager struct {
 	project          ProjectContext
 	copilotAuthToken string
 	uidMap           *UIDMap
+
+	inferenceRouteCallback      func(agentName, backend, model string)
+	clearInferenceRouteCallback func(agentName string)
+}
+
+// IsInferenceBackend returns true if the backend is a self-hosted inference
+// backend (vllm, llm-d) rather than a CLI tool.
+func IsInferenceBackend(backend string) bool {
+	return backend == "vllm" || backend == "llm-d"
+}
+
+// SetInferenceCallbacks registers callbacks that the manager uses to
+// configure/clear inference routing on the proxy when launching agents.
+func (m *Manager) SetInferenceCallbacks(
+	setRoute func(agentName, backend, model string),
+	clearRoute func(agentName string),
+) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.inferenceRouteCallback = setRoute
+	m.clearInferenceRouteCallback = clearRoute
 }
 
 func truncateStr(s string, maxRunes int) string {
@@ -214,9 +235,18 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 		return err
 	}
 
+	backend := agent.Config.Backend
+	if agent.BackendOverride != "" {
+		backend = agent.BackendOverride
+	}
 	if agent.Paused {
-		agent.State = StatePaused
-		return nil
+		if IsInferenceBackend(backend) {
+			agent.Paused = false
+			m.logger.Info("auto-unpaused inference agent", "name", agent.Name, "backend", backend)
+		} else {
+			agent.State = StatePaused
+			return nil
+		}
 	}
 
 	return m.launchInTmux(ctx, agent)
@@ -294,7 +324,10 @@ func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
 		_ = os.MkdirAll("/var/run/pluk/logs", 0o1777)
 		_ = os.MkdirAll("/var/run/pluk/commands", 0o1777)
 		backend := agent.Config.Backend
-		if backend == "" {
+		if agent.BackendOverride != "" {
+			backend = agent.BackendOverride
+		}
+		if backend == "" || IsInferenceBackend(backend) {
 			backend = "claude"
 		}
 		pipePaneCmd := fmt.Sprintf("%s --session %s --cli %s", plukPath, agent.tmuxSession, backend)
@@ -393,9 +426,27 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	agent.LaunchedMode = mode
 	agent.HasLaunched = true
 
+	// Inference backends (vllm, llm-d) use Claude Code as the CLI tool
+	// and route API traffic through the proxy to the self-hosted endpoint.
+	isInference := IsInferenceBackend(backend)
+	if isInference {
+		binary = "claude"
+		m.ensureClaudeSettings()
+		if m.inferenceRouteCallback != nil {
+			m.inferenceRouteCallback(agent.Name, backend, model)
+		}
+		backend = "claude"
+	} else if m.clearInferenceRouteCallback != nil {
+		m.clearInferenceRouteCallback(agent.Name)
+	}
+
 	switch backend {
 	case "claude":
-		base := fmt.Sprintf("%s --model %s --dangerously-skip-permissions", binary, model)
+		bareFlag := ""
+		if isInference {
+			bareFlag = fmt.Sprintf(" --bare --settings %s", claudeInferenceSettingsPath)
+		}
+		base := fmt.Sprintf("%s --model %s --dangerously-skip-permissions%s", binary, model, bareFlag)
 		switch {
 		case mode >= ModeIssuesAndPRs:
 			launchCmd = base
@@ -441,6 +492,10 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		launchCmd = binary
 	}
 
+	if bootstrapPrompt == "" && isInference {
+		bootstrapPrompt = "You are an AI agent. Await further instructions."
+	}
+
 	if bootstrapPrompt != "" {
 		now := time.Now()
 		agent.LastKick = &now
@@ -466,8 +521,10 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 			case "claude":
 				// Write a launcher script instead of using $(cat) in send-keys.
 				// $(cat file) fails when the tmux shell hasn't fully initialized.
+				// Use -- to separate options from the positional prompt argument,
+				// otherwise --disallowed-tools consumes the prompt as tool names.
 				launcherFile := fmt.Sprintf("/tmp/.hive-launch-%s.sh", agent.Name)
-				launcherContent := fmt.Sprintf("#!/bin/sh\nexec %s \"$(cat %s)\"\n", launchCmd, promptFile)
+				launcherContent := fmt.Sprintf("#!/bin/sh\nexec %s -- \"$(cat %s)\"\n", launchCmd, promptFile)
 				if err := os.WriteFile(launcherFile, []byte(launcherContent), 0o755); err != nil {
 					m.logger.Warn("failed to write launcher script", "error", err)
 					launchCmd += fmt.Sprintf(" \"$(cat %s)\"", promptFile)
@@ -516,6 +573,10 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	m.tmuxSendLiteralForAgent(agent, fullCmd)
 	time.Sleep(textToEnterDelay)
 	m.tmuxSendEntersForAgent(agent)
+
+	if isInference {
+		go m.dismissInferencePrompts(agent)
+	}
 
 	now := time.Now()
 	agent.State = StateRunning
@@ -598,7 +659,8 @@ func (m *Manager) pollTmuxOutputForAgent(agent *AgentProcess, ctx context.Contex
 			// Detect copilot hung: if running long enough with no CLI prompt,
 			// launch bare `copilot` to diagnose the error. Only clear the
 			// token if the diagnostic shows an auth error.
-			if agent.Config.Backend == "copilot" && agent.StartedAt != nil &&
+			// Skip for inference backends — they use Claude -p mode (non-interactive).
+			if agent.Config.Backend == "copilot" && !IsInferenceBackend(agent.BackendOverride) && agent.StartedAt != nil &&
 				time.Since(*agent.StartedAt).Seconds() >= expiredTokenHangTimeoutSec &&
 				!paneShowsCLIReady(filtered) {
 				sinceLastRestart := time.Since(agent.lastTokenRestart).Seconds()
@@ -1466,6 +1528,89 @@ func (m *Manager) tmuxSendLiteralForAgent(agent *AgentProcess, text string) {
 	_ = m.tmuxCmd(agent, "send-keys", "-t", agent.tmuxSession, "-l", text).Run()
 }
 
+// dismissInferencePrompts polls the tmux pane for Claude Code interactive
+// prompts and auto-dismisses them. Works dynamically regardless of prompt
+// text changes between Claude Code versions by:
+//  1. Detecting "Enter to confirm" (universal prompt footer)
+//  2. Finding the selected option (line with "❯" marker)
+//  3. If selected option looks negative (contains "No" or "exit"), navigate
+//     away from it before confirming
+//  4. For "Press Enter to continue" screens, just press Enter
+//
+// Stops when the main Claude Code input prompt appears ("esc to interrupt").
+func (m *Manager) dismissInferencePrompts(agent *AgentProcess) {
+	const (
+		promptPollInterval   = 1 * time.Second
+		promptDismissTimeout = 60 * time.Second
+		postKeystrokeDelay   = 500 * time.Millisecond
+	)
+
+	deadline := time.Now().Add(promptDismissTimeout)
+	lastPane := ""
+
+	for time.Now().Before(deadline) {
+		time.Sleep(promptPollInterval)
+
+		pane := m.captureVisiblePaneForAgent(agent)
+		if pane == "" || pane == lastPane {
+			continue
+		}
+		lastPane = pane
+
+		// Main prompt visible — agent is ready
+		if strings.Contains(pane, "bypass permissions on") || strings.Contains(pane, "esc to interrupt") {
+			m.logger.Info("inference agent ready", "agent", agent.Name)
+			return
+		}
+
+		// "Press Enter to continue" screens
+		if strings.Contains(pane, "Press Enter to continue") {
+			m.logger.Info("inference prompt: press enter", "agent", agent.Name)
+			m.tmuxSendKeysForAgent(agent, "Enter")
+			continue
+		}
+
+		// Selection prompts have "Enter to confirm" footer
+		if !strings.Contains(pane, "Enter to confirm") {
+			continue
+		}
+
+		// Find the currently selected option (marked with ❯)
+		selected := ""
+		for _, line := range strings.Split(pane, "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "❯") {
+				selected = trimmed
+				break
+			}
+		}
+
+		m.logger.Info("inference prompt detected",
+			"agent", agent.Name,
+			"selected", selected,
+		)
+
+		// If current selection looks negative, navigate away from it
+		selectedLower := strings.ToLower(selected)
+		if strings.Contains(selectedLower, "no,") || strings.Contains(selectedLower, "no ") ||
+			strings.Contains(selectedLower, "exit") {
+			// Try moving down first (most prompts put the positive option below)
+			m.tmuxSendKeysForAgent(agent, "Down")
+			time.Sleep(postKeystrokeDelay)
+		} else if strings.Contains(selectedLower, "fix with") {
+			// Settings error: skip past "Fix with Claude" and "Exit" to "Continue without"
+			m.tmuxSendKeysForAgent(agent, "Down")
+			time.Sleep(postKeystrokeDelay)
+			m.tmuxSendKeysForAgent(agent, "Down")
+			time.Sleep(postKeystrokeDelay)
+		}
+
+		m.tmuxSendKeysForAgent(agent, "Enter")
+	}
+
+	m.logger.Warn("inference prompt dismissal timed out", "agent", agent.Name)
+}
+
 // tmuxSendEntersForAgent sends Enter presses using the agent's tmux socket.
 func (m *Manager) tmuxSendEntersForAgent(agent *AgentProcess) {
 	for i := 0; i < enterCount; i++ {
@@ -1755,6 +1900,8 @@ func backendBinary(backend string) (string, error) {
 		"goose":   "goose",
 		"pi":      "goose",
 		"bob":     "bob",
+		"vllm":    "claude",
+		"llm-d":   "claude",
 	}
 
 	binary, ok := binaries[backend]
@@ -2000,6 +2147,41 @@ func (m *Manager) fixSharedConfigPerms(agent *AgentProcess) {
 	}
 }
 
+const (
+	claudeInferenceSettingsPath = "/tmp/.claude-inference-settings.json"
+	claudeInferenceHomePath     = "/tmp/.claude-inference-home"
+)
+
+// ensureClaudeSettings creates a writable HOME directory for inference agents
+// with pre-populated .claude/settings.json. This avoids ALL interactive prompts
+// (settings error, theme, API key, bypass permissions, trust folder, onboarding)
+// because Claude Code reads hasCompletedOnboarding/hasAcknowledgedDisclaimer/
+// bypassPermissions from the settings file at $HOME/.claude/settings.json.
+// The default /data/home is root:root 770 so agent UIDs can't access it.
+func (m *Manager) ensureClaudeSettings() {
+	settingsDir := filepath.Join(claudeInferenceHomePath, ".claude")
+	settingsFile := filepath.Join(settingsDir, "settings.json")
+	if _, err := os.Stat(settingsFile); err == nil {
+		return
+	}
+	if err := os.MkdirAll(settingsDir, 0o777); err != nil {
+		m.logger.Warn("failed to create claude inference home", "error", err)
+		return
+	}
+	settings := `{"permissions":{"allow":[],"deny":[]},"hasCompletedOnboarding":true,"bypassPermissions":true,"hasAcknowledgedDisclaimer":true}`
+	if err := os.WriteFile(settingsFile, []byte(settings), 0o644); err != nil {
+		m.logger.Warn("failed to write claude settings", "error", err)
+	}
+	// Also write the standalone settings file for --settings flag
+	_ = os.WriteFile(claudeInferenceSettingsPath, []byte(settings), 0o644)
+	// Pre-populate .claude.json to skip first-run setup (GrowthBook, migrations)
+	userConfig := filepath.Join(claudeInferenceHomePath, ".claude.json")
+	if _, err := os.Stat(userConfig); err != nil {
+		cfg := `{"hasCompletedOnboarding":true,"opusProMigrationComplete":true,"sonnet1m45MigrationComplete":true,"migrationVersion":13}`
+		_ = os.WriteFile(userConfig, []byte(cfg), 0o644)
+	}
+}
+
 // normalizeModelName converts YAML-friendly model names (claude-sonnet-4-6) to
 // the format CLIs expect (claude-sonnet-4.6). The last hyphen before a trailing
 // digit group becomes a dot.
@@ -2217,6 +2399,13 @@ func (m *Manager) agentEnvPairs(agent *AgentProcess) []agentEnvPair {
 	if advisory := os.Getenv("HIVE_ADVISORY_ISSUE"); advisory != "" {
 		vars = append(vars, agentEnvPair{"HIVE_ADVISORY_ISSUE", advisory, false})
 	}
+	if IsInferenceBackend(backend) {
+		const inferenceTranslatePort = 18444
+		vars = append(vars, agentEnvPair{"ANTHROPIC_API_KEY", "sk-hive-" + agent.Name, false})
+		baseURL := fmt.Sprintf("http://127.0.0.1:%d", inferenceTranslatePort)
+		vars = append(vars, agentEnvPair{"ANTHROPIC_BASE_URL", baseURL, false})
+		vars = append(vars, agentEnvPair{"NO_PROXY", "127.0.0.1,localhost", false})
+	}
 	if m.copilotAuthToken != "" {
 		vars = append(vars, agentEnvPair{"COPILOT_GITHUB_TOKEN", m.copilotAuthToken, true})
 	}
@@ -2230,7 +2419,11 @@ func (m *Manager) agentEnvPairs(agent *AgentProcess) []agentEnvPair {
 	// GIT_SSL_CAINFO only — NOT SSL_CERT_FILE (that breaks Copilot API TLS)
 	vars = append(vars, agentEnvPair{"GIT_SSL_CAINFO", proxyCACertPath, false})
 	if agent.UID > 0 {
-		vars = append(vars, agentEnvPair{"HOME", "/data/home", false})
+		home := "/data/home"
+		if IsInferenceBackend(backend) {
+			home = claudeInferenceHomePath
+		}
+		vars = append(vars, agentEnvPair{"HOME", home, false})
 	}
 	return vars
 }

--- a/v2/pkg/agent/permissions_watcher.go
+++ b/v2/pkg/agent/permissions_watcher.go
@@ -19,11 +19,12 @@ const (
 	// NodeGID is the gid of the "node" group shared by all agent users.
 	NodeGID = 1000
 
-	// DirPerms is the minimum permission bits required on directories (u+rwx).
-	DirPerms = 0o700
+	// DirPerms is the minimum permission bits required on directories (u+rwx, g+rwx).
+	// Group access is essential because agents run as different users sharing the node group.
+	DirPerms = 0o770
 
-	// FilePerms is the minimum permission bits required on files (u+rw).
-	FilePerms = 0o600
+	// FilePerms is the minimum permission bits required on files (u+rw, g+rw).
+	FilePerms = 0o660
 )
 
 // WatchedHomeDirs are the subdirectories under the shared home that tools
@@ -123,18 +124,30 @@ func fixEntry(path string, fi os.FileInfo, logger *slog.Logger) {
 		return
 	}
 
-	// Fix ownership if owned by root (uid 0).
+	// Fix group ownership if not in the node group — all agents share this group.
+	// Also fix root-owned files (uid 0) to the dev user.
+	needsChown := false
+	newUID := int(stat.Uid)
 	if stat.Uid == 0 {
-		if err := os.Chown(path, DevUID, NodeGID); err != nil {
+		newUID = DevUID
+		needsChown = true
+	}
+	if stat.Gid != uint32(NodeGID) {
+		needsChown = true
+	}
+	if needsChown {
+		if err := os.Chown(path, newUID, NodeGID); err != nil {
 			logger.Warn("permissions watcher: chown failed",
 				"path", path,
 				"error", err,
 			)
 		} else {
-			logger.Warn("permissions watcher: fixed root-owned entry",
+			logger.Warn("permissions watcher: fixed ownership",
 				"path", path,
 				"was_uid", stat.Uid,
-				"new_uid", DevUID,
+				"was_gid", stat.Gid,
+				"new_uid", newUID,
+				"new_gid", NodeGID,
 			)
 		}
 	}

--- a/v2/pkg/agent/permissions_watcher.go
+++ b/v2/pkg/agent/permissions_watcher.go
@@ -1,0 +1,178 @@
+package agent
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+// Permission watcher constants — no magic numbers.
+const (
+	// PermissionFixInterval is how often the watcher scans for wrong ownership.
+	PermissionFixInterval = 10 * time.Second
+
+	// DevUID is the uid of the "dev" user that agents run as.
+	DevUID = 1001
+
+	// NodeGID is the gid of the "node" group shared by all agent users.
+	NodeGID = 1000
+
+	// DirPerms is the minimum permission bits required on directories (u+rwx).
+	DirPerms = 0o700
+
+	// FilePerms is the minimum permission bits required on files (u+rw).
+	FilePerms = 0o600
+)
+
+// WatchedHomeDirs are the subdirectories under the shared home that tools
+// (Copilot, Claude, etc.) frequently create with root ownership.
+var WatchedHomeDirs = []string{
+	"/data/home/.copilot",
+	"/data/home/.cache",
+	"/data/home/.config",
+	"/data/home/.local",
+}
+
+// StartPermissionsWatcher runs a background goroutine that periodically
+// scans WatchedHomeDirs and fixes files/directories that were created
+// with wrong ownership (e.g., root-owned by Copilot CLI).
+//
+// It never blocks or panics. Call it once at startup:
+//
+//	go agent.StartPermissionsWatcher(logger)
+func StartPermissionsWatcher(logger *slog.Logger) {
+	logger.Info("permissions watcher started",
+		"interval", PermissionFixInterval,
+		"watched_dirs", WatchedHomeDirs,
+		"target_uid", DevUID,
+		"target_gid", NodeGID,
+	)
+
+	// Ensure watched directories exist with correct ownership on first run.
+	ensureWatchedDirs(logger)
+
+	ticker := time.NewTicker(PermissionFixInterval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		fixPermissions(logger)
+	}
+}
+
+// ensureWatchedDirs creates each watched directory if it does not exist
+// and sets correct ownership.
+func ensureWatchedDirs(logger *slog.Logger) {
+	for _, dir := range WatchedHomeDirs {
+		if err := os.MkdirAll(dir, DirPerms|0o070); err != nil {
+			logger.Warn("permissions watcher: failed to create directory",
+				"path", dir,
+				"error", err,
+			)
+			continue
+		}
+		// Always set ownership on the top-level dir at startup.
+		if err := os.Chown(dir, DevUID, NodeGID); err != nil {
+			logger.Warn("permissions watcher: failed to chown directory",
+				"path", dir,
+				"error", err,
+			)
+		}
+	}
+}
+
+// fixPermissions walks each watched directory and fixes ownership/mode
+// on any file or directory that is wrong. It only logs when it actually
+// changes something.
+func fixPermissions(logger *slog.Logger) {
+	for _, root := range WatchedHomeDirs {
+		info, err := os.Stat(root)
+		if err != nil {
+			// Directory doesn't exist yet — create it.
+			if os.IsNotExist(err) {
+				ensureWatchedDirs(logger)
+			}
+			continue
+		}
+		if !info.IsDir() {
+			continue
+		}
+
+		err = filepath.Walk(root, func(path string, fi os.FileInfo, walkErr error) error {
+			if walkErr != nil {
+				return nil // skip unreadable entries, don't abort walk
+			}
+			fixEntry(path, fi, logger)
+			return nil
+		})
+		if err != nil {
+			logger.Warn("permissions watcher: walk error",
+				"root", root,
+				"error", err,
+			)
+		}
+	}
+}
+
+// fixEntry checks a single file or directory and corrects ownership/mode
+// if needed.
+func fixEntry(path string, fi os.FileInfo, logger *slog.Logger) {
+	stat, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return
+	}
+
+	// Fix ownership if owned by root (uid 0).
+	if stat.Uid == 0 {
+		if err := os.Chown(path, DevUID, NodeGID); err != nil {
+			logger.Warn("permissions watcher: chown failed",
+				"path", path,
+				"error", err,
+			)
+		} else {
+			logger.Warn("permissions watcher: fixed root-owned entry",
+				"path", path,
+				"was_uid", stat.Uid,
+				"new_uid", DevUID,
+			)
+		}
+	}
+
+	mode := fi.Mode()
+	if fi.IsDir() {
+		// Directories need u+rwx to be usable.
+		if mode.Perm()&DirPerms != DirPerms {
+			newMode := mode.Perm() | DirPerms
+			if err := os.Chmod(path, newMode); err != nil {
+				logger.Warn("permissions watcher: chmod dir failed",
+					"path", path,
+					"error", err,
+				)
+			} else {
+				logger.Warn("permissions watcher: fixed directory permissions",
+					"path", path,
+					"old_mode", mode.Perm().String(),
+					"new_mode", newMode.String(),
+				)
+			}
+		}
+	} else {
+		// Regular files need u+rw to be readable/writable.
+		if mode.Perm()&FilePerms != FilePerms {
+			newMode := mode.Perm() | FilePerms
+			if err := os.Chmod(path, newMode); err != nil {
+				logger.Warn("permissions watcher: chmod file failed",
+					"path", path,
+					"error", err,
+				)
+			} else {
+				logger.Warn("permissions watcher: fixed file permissions",
+					"path", path,
+					"old_mode", mode.Perm().String(),
+					"new_mode", newMode.String(),
+				)
+			}
+		}
+	}
+}

--- a/v2/pkg/apiproxy/proxy.go
+++ b/v2/pkg/apiproxy/proxy.go
@@ -1,0 +1,301 @@
+package apiproxy
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultUpstream    = "https://api.anthropic.com"
+	maxBodyLog         = 64 * 1024 // 64KB max per request/response body in logs
+	sseContentType     = "text/event-stream"
+	sseDataPrefix      = "data: "
+	sseEventMsgStart   = "message_start"
+	sseEventMsgDelta   = "message_delta"
+	sseEventMsgStop    = "message_stop"
+	sseEventContentDlt = "content_block_delta"
+)
+
+// Event represents a logged API interaction.
+type Event struct {
+	Timestamp time.Time       `json:"ts"`
+	Agent     string          `json:"agent,omitempty"`
+	Direction string          `json:"direction"` // "request", "response", or "sse"
+	Method    string          `json:"method,omitempty"`
+	Path      string          `json:"path,omitempty"`
+	Status    int             `json:"status,omitempty"`
+	Model     string          `json:"model,omitempty"`
+	SSEType   string          `json:"sse_type,omitempty"`
+	Body      json.RawMessage `json:"body,omitempty"`
+}
+
+// EventHandler is called for each logged API event.
+type EventHandler func(Event)
+
+type Proxy struct {
+	upstream     *url.URL
+	reverseProxy *httputil.ReverseProxy
+	handler      EventHandler
+	apiKey       string
+	mu           sync.RWMutex
+}
+
+func New(upstreamURL string, handler EventHandler, apiKey string) (*Proxy, error) {
+	if upstreamURL == "" {
+		upstreamURL = defaultUpstream
+	}
+	u, err := url.Parse(upstreamURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid upstream URL: %w", err)
+	}
+
+	p := &Proxy{
+		upstream: u,
+		handler:  handler,
+		apiKey:   apiKey,
+	}
+
+	p.reverseProxy = &httputil.ReverseProxy{
+		Director:       p.director,
+		ModifyResponse: p.modifyResponse,
+		ErrorHandler:   p.errorHandler,
+		FlushInterval:  -1, // flush SSE chunks immediately
+		Transport: &http.Transport{
+			DisableCompression: true, // get plaintext SSE for logging
+		},
+	}
+
+	return p, nil
+}
+
+func isValidAuth(req *http.Request) bool {
+	const minKeyLen = 20
+	if auth := req.Header.Get("Authorization"); auth != "" && len(auth) > minKeyLen {
+		return true
+	}
+	if key := req.Header.Get("X-Api-Key"); key != "" && !strings.HasPrefix(key, "sk-ant-dummy") && len(key) > minKeyLen {
+		return true
+	}
+	return false
+}
+
+func (p *Proxy) director(req *http.Request) {
+	req.URL.Scheme = p.upstream.Scheme
+	req.URL.Host = p.upstream.Host
+	req.Host = p.upstream.Host
+
+	// Remove client's Accept-Encoding so upstream sends uncompressed SSE.
+	// Negligible overhead for a local proxy; allows line-by-line SSE parsing.
+	req.Header.Del("Accept-Encoding")
+
+	if p.apiKey != "" && !isValidAuth(req) {
+		req.Header.Set("Authorization", "Bearer "+p.apiKey)
+		req.Header.Del("X-Api-Key")
+	}
+}
+
+func (p *Proxy) modifyResponse(resp *http.Response) error {
+	if p.handler == nil {
+		return nil
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if strings.HasPrefix(ct, sseContentType) {
+		resp.Body = p.wrapSSEBody(resp.Body, resp.Request.URL.Path, resp.StatusCode)
+		return nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBodyLog))
+	if err != nil {
+		return err
+	}
+	resp.Body = io.NopCloser(io.MultiReader(bytes.NewReader(body), resp.Body))
+
+	evt := Event{
+		Timestamp: time.Now().UTC(),
+		Direction: "response",
+		Path:      resp.Request.URL.Path,
+		Status:    resp.StatusCode,
+	}
+
+	if json.Valid(body) {
+		evt.Body = json.RawMessage(body)
+		var respBody struct {
+			Model string `json:"model"`
+		}
+		if json.Unmarshal(body, &respBody) == nil {
+			evt.Model = respBody.Model
+		}
+	}
+
+	p.handler(evt)
+	return nil
+}
+
+// wrapSSEBody wraps a streaming response body, emitting an Event for each
+// meaningful SSE data line as it passes through to the client.
+func (p *Proxy) wrapSSEBody(orig io.ReadCloser, path string, status int) io.ReadCloser {
+	pr, pw := io.Pipe()
+
+	go func() {
+		defer orig.Close()
+		defer pw.Close()
+
+		lineCount := 0
+		scanner := bufio.NewScanner(orig)
+		scanner.Buffer(make([]byte, maxBodyLog), maxBodyLog)
+
+		var (
+			totalBytes int
+			model      string
+			textParts  []string
+		)
+
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			lineCount++
+			totalBytes += len(line) + 1
+
+			if _, err := pw.Write(line); err != nil {
+				return
+			}
+			if _, err := pw.Write([]byte("\n")); err != nil {
+				return
+			}
+
+			if !bytes.HasPrefix(line, []byte(sseDataPrefix)) {
+				continue
+			}
+			data := line[len(sseDataPrefix):]
+			if len(data) == 0 || string(data) == "[DONE]" {
+				continue
+			}
+
+			var sseData struct {
+				Type    string `json:"type"`
+				Message *struct {
+					Model string `json:"model"`
+					Usage *struct {
+						InputTokens  int `json:"input_tokens"`
+						OutputTokens int `json:"output_tokens"`
+					} `json:"usage"`
+				} `json:"message"`
+				Delta *struct {
+					Type       string `json:"type"`
+					Text       string `json:"text"`
+					StopReason string `json:"stop_reason"`
+				} `json:"delta"`
+				Usage *struct {
+					OutputTokens int `json:"output_tokens"`
+				} `json:"usage"`
+			}
+			if json.Unmarshal(data, &sseData) != nil {
+				continue
+			}
+
+			switch sseData.Type {
+			case sseEventMsgStart:
+				if sseData.Message != nil {
+					model = sseData.Message.Model
+				}
+				p.handler(Event{
+					Timestamp: time.Now().UTC(),
+					Direction: "sse",
+					Path:      path,
+					Status:    status,
+					SSEType:   sseEventMsgStart,
+					Model:     model,
+					Body:      json.RawMessage(data),
+				})
+
+			case sseEventContentDlt:
+				if sseData.Delta != nil && sseData.Delta.Text != "" {
+					textParts = append(textParts, sseData.Delta.Text)
+				}
+
+			case sseEventMsgDelta:
+				p.handler(Event{
+					Timestamp: time.Now().UTC(),
+					Direction: "sse",
+					Path:      path,
+					SSEType:   sseEventMsgDelta,
+					Model:     model,
+					Body:      json.RawMessage(data),
+				})
+
+			case sseEventMsgStop:
+				fullText := strings.Join(textParts, "")
+				summary := map[string]interface{}{
+					"type":        "stream_complete",
+					"model":       model,
+					"text_length": len(fullText),
+					"total_bytes": totalBytes,
+				}
+				if len(fullText) <= maxBodyLog {
+					summary["text"] = fullText
+				}
+				summaryJSON, _ := json.Marshal(summary)
+				p.handler(Event{
+					Timestamp: time.Now().UTC(),
+					Direction: "sse",
+					Path:      path,
+					SSEType:   sseEventMsgStop,
+					Model:     model,
+					Body:      json.RawMessage(summaryJSON),
+				})
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			log.Printf("[apiproxy] SSE scanner error: %v", err)
+		}
+	}()
+
+	return pr
+}
+
+func (p *Proxy) errorHandler(w http.ResponseWriter, r *http.Request, err error) {
+	log.Printf("[apiproxy] upstream error: %v", err)
+	http.Error(w, "proxy upstream error", http.StatusBadGateway)
+}
+
+// ServeHTTP implements http.Handler.
+func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if p.handler != nil {
+		body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyLog))
+		if err == nil {
+			r.Body = io.NopCloser(io.MultiReader(bytes.NewReader(body), r.Body))
+
+			evt := Event{
+				Timestamp: time.Now().UTC(),
+				Direction: "request",
+				Method:    r.Method,
+				Path:      r.URL.Path,
+				Agent:     r.Header.Get("X-Hive-Agent"),
+			}
+
+			if json.Valid(body) {
+				evt.Body = json.RawMessage(body)
+				var reqBody struct {
+					Model string `json:"model"`
+				}
+				if json.Unmarshal(body, &reqBody) == nil {
+					evt.Model = reqBody.Model
+				}
+			}
+
+			p.handler(evt)
+		}
+	}
+
+	p.reverseProxy.ServeHTTP(w, r)
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2527,17 +2527,17 @@
           <button class="restart-btn" data-action="restartAgent" data-agent="${esc(a.name)}" title="Kill this agent's tmux session — supervisor will respawn it with fresh context">↻ restart</button>
           <button class="config-gear" data-action="openConfigDialog" data-config-type="agent" data-agent="${esc(a.name)}" style="font-size:1rem;opacity:0.7" title="Open configuration dialog for this agent (cadences, model, pipeline, hooks, etc.)">⚙️</button>
           <button class="btn" data-action="kickEmpty" data-agent="${esc(a.name)}" style="margin-left:auto" title="Kick this agent now with its default prompt, bypassing the governor cadence timer">kick</button>
-          <select class="btn backend-select" data-change-action="switchCli" data-agent="${esc(a.name)}" title="Switch this agent to a different CLI backend">
-            <option value="" disabled selected>cli ▾</option>
-            ${KNOWN_BACKENDS.map(b => `<option value="${b}" ${a.cli === b ? 'disabled' : ''}>${b}</option>`).join('')}
+          <select class="btn backend-select" data-change-action="switchCli" data-agent="${esc(a.name)}" title="Switch this agent to a different method (CLI or inference backend)">
+            <option value="" disabled selected>method ▾</option>
+            ${KNOWN_BACKENDS.map(b => `<option value="${b}" ${a.cli === b ? 'disabled' : ''}>${backendLabel(b)}</option>`).join('')}
           </select>
           <select class="btn backend-select" data-change-action="switchModel" data-agent="${esc(a.name)}" title="Switch this agent to a different LLM model">
             <option value="" disabled selected>model ▾</option>
-            ${KNOWN_MODELS.map(m => `<option value="${m.value}">${m.label}</option>`).join('')}
+            ${modelsForBackend(a.cli).map(m => `<option value="${m.value}">${m.label}</option>`).join('')}
           </select>
         </div>
         <div class="oc-detail-fields">
-          <div class="oc-detail-field"><div class="label" title="The CLI backend running this agent (e.g. claude, copilot, gemini)">CLI</div><div class="value">${esc(a.cli || '—')}${(a.pinnedBoth || a.pinnedCli) ? ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="true" style="cursor:pointer" title="Unpin CLI">📌</span>` : ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="false" style="cursor:pointer;opacity:0.3" title="Pin CLI">📌</span>`}</div></div>
+          <div class="oc-detail-field"><div class="label" title="${INFERENCE_BACKENDS.includes(a.cli) ? 'Inference backend (self-hosted model server)' : 'The CLI backend running this agent (e.g. claude, copilot, gemini)'}">${INFERENCE_BACKENDS.includes(a.cli) ? 'Method' : 'CLI'}</div><div class="value">${INFERENCE_BACKENDS.includes(a.cli) ? backendLabel(a.cli) : esc(a.cli || '—')}${(a.pinnedBoth || a.pinnedCli) ? ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="true" style="cursor:pointer" title="Unpin CLI">📌</span>` : ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="false" style="cursor:pointer;opacity:0.3" title="Pin CLI">📌</span>`}</div></div>
           <div class="oc-detail-field"><div class="label" title="The LLM model powering this agent. Governor may change it based on budget.">Model</div><div class="value">${esc(a.model || '—')}${(a.pinnedBoth || a.pinnedModel) ? ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="model" data-unpin="true" style="cursor:pointer" title="Unpin model">📌</span>` : ` <span data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="model" data-unpin="false" style="cursor:pointer;opacity:0.3" title="Pin model">📌</span>`}</div></div>
           <div class="oc-detail-field"><div class="label" title="Time between governor kicks in the current mode. Configured per mode (idle/quiet/busy/surge).">Interval</div><div class="value">${isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : esc(a.cadence || '—')}</div></div>
           <div class="oc-detail-field"><div class="label" title="When the governor last kicked (started a work pass for) this agent.">Last Run</div><div class="value">${esc(a.lastKick || '—')}</div></div>
@@ -3410,7 +3410,7 @@
             return '';
           })()}</div>
           <div class="agent-card-details">
-          <div class="agent-field"><span class="label" title="The CLI backend running this agent (e.g. claude, copilot). Pin to prevent governor from switching it.">cli</span><span class="value">${cliChip(a.cli, a.pinnedBoth || a.pinnedCli, a.name)}${(a.pinnedBoth || a.pinnedCli) ? '' : ` <button class="pin-toggle" data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="false" title="Pin CLI — lock current backend" style="opacity:0.4;cursor:pointer;border:none;background:none">📌</button>`}</span></div>
+          <div class="agent-field"><span class="label" title="${INFERENCE_BACKENDS.includes(a.cli) ? 'Inference backend (self-hosted model server)' : 'The CLI backend running this agent (e.g. claude, copilot). Pin to prevent governor from switching it.'}">${INFERENCE_BACKENDS.includes(a.cli) ? 'method' : 'cli'}</span><span class="value">${cliChip(a.cli, a.pinnedBoth || a.pinnedCli, a.name)}${(a.pinnedBoth || a.pinnedCli) ? '' : ` <button class="pin-toggle" data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="false" title="Pin CLI — lock current backend" style="opacity:0.4;cursor:pointer;border:none;background:none">📌</button>`}</span></div>
           <div class="agent-field"><span class="label" title="The LLM model powering this agent. Governor may change it based on budget or mode. Pin to lock.">model</span><span class="value">${modelChip(a.model, a.govReason, a.pinnedBoth || a.pinnedModel, a.name)}${(a.pinnedBoth || a.pinnedModel) ? '' : ` <button class="pin-toggle" data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="model" data-unpin="false" title="Pin model — lock current model" style="opacity:0.4;cursor:pointer;border:none;background:none">📌</button>`}</span></div>
           <div class="agent-field"><span class="label" title="Agent operating mode — controls what GitHub actions this agent can take (advisory, issues, PRs, merge).">mode</span><span class="value">${modeLabel(a)}${a.needsRestart ? ' <span class="status-badge needs-context" title="CLI flags are stale — restart agent to apply new mode">⚠ restart needed</span>' : ''}</span></div>
           <div class="agent-field"><span class="label" title="Number of HTTP requests blocked by the ACMM proxy for this agent. Non-zero means the agent attempted actions above its mode.">proxy</span><span class="value">${a.proxyViolations > 0 ? '<span style="color:var(--danger)">⛔ ' + a.proxyViolations + ' blocked</span>' : '✓ clean'}</span></div>
@@ -3425,13 +3425,13 @@
             <input type="text" class="kick-prompt" id="kick-prompt-${esc(a.name)}" placeholder="custom prompt (optional)" data-enter-action="kick" data-agent="${esc(a.name)}" title="Type a custom prompt to send to this agent instead of its default kick prompt. Press Enter to send." />
             <button class="btn" data-action="kick" data-agent="${esc(a.name)}" title="Send the custom prompt above to this agent immediately, bypassing the governor cadence timer">send</button>
             <button class="btn" data-action="kickEmpty" data-agent="${esc(a.name)}" title="Kick this agent now with its default prompt, bypassing the governor cadence timer">kick</button>
-            <select class="btn backend-select" data-change-action="switchCli" data-agent="${esc(a.name)}" title="Switch this agent to a different CLI backend. Free backends (copilot, goose) do not count toward token budget.">
-              <option value="" disabled selected>cli ▾</option>
-              ${KNOWN_BACKENDS.map(b => `<option value="${b}" ${a.cli === b ? 'disabled' : ''}>${b}</option>`).join('')}
+            <select class="btn backend-select" data-change-action="switchCli" data-agent="${esc(a.name)}" title="Switch this agent to a different method (CLI or inference backend). Free backends (copilot, goose) do not count toward token budget.">
+              <option value="" disabled selected>method ▾</option>
+              ${KNOWN_BACKENDS.map(b => `<option value="${b}" ${a.cli === b ? 'disabled' : ''}>${backendLabel(b)}</option>`).join('')}
             </select>
             <select class="btn backend-select" data-change-action="switchModel" data-agent="${esc(a.name)}" title="Switch this agent to a different LLM model. Higher-tier models (Opus) cost more tokens; lower-tier (Haiku) are cheaper but less capable.">
               <option value="" disabled selected>model ▾</option>
-              ${KNOWN_MODELS.map(m => `<option value="${m.value}">${m.label}</option>`).join('')}
+              ${modelsForBackend(a.cli).map(m => `<option value="${m.value}">${m.label}</option>`).join('')}
             </select>
           </div>
           </div>
@@ -3836,8 +3836,9 @@
     }
 
     // ── Centralized backend/model config (mirrors backends.conf) ──────────
-    const KNOWN_BACKENDS = ['claude', 'copilot', 'bob', 'gemini', 'codex', 'amazonq', 'goose', 'aider'];
+    const KNOWN_BACKENDS = ['claude', 'copilot', 'bob', 'gemini', 'codex', 'amazonq', 'goose', 'aider', 'vllm', 'llm-d'];
     const FREE_BACKENDS = ['copilot', 'goose'];
+    const INFERENCE_BACKENDS = ['vllm', 'llm-d'];
     const KNOWN_MODELS = [
       { value: 'claude-opus-4-6', label: 'Opus 4.6' },
       { value: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
@@ -3846,6 +3847,37 @@
       { value: 'gpt-5.4', label: 'GPT-5.4' },
       { value: 'gpt-5.2', label: 'GPT-5.2' },
     ];
+    const INFERENCE_MODELS = {
+      'vllm': [{ value: 'qwen2.5-0.5b-instruct', label: 'Qwen 2.5 0.5B' }],
+      'llm-d': [{ value: 'qwen2.5-0.5b-instruct', label: 'Qwen 2.5 0.5B' }],
+    };
+    function backendLabel(b) {
+      if (INFERENCE_BACKENDS.includes(b)) return b + ' ⚡';
+      return b;
+    }
+    function modelsForBackend(backend) {
+      if (INFERENCE_BACKENDS.includes(backend)) return INFERENCE_MODELS[backend] || [];
+      return KNOWN_MODELS;
+    }
+
+    let _cachedInferenceModels = null;
+    async function fetchInferenceModels() {
+      if (_cachedInferenceModels) return _cachedInferenceModels;
+      try {
+        const resp = await fetch('/api/config/backends');
+        const backends = await resp.json();
+        const models = {};
+        for (const b of backends) {
+          if (b.inference) {
+            models[b.id] = (b.models || []).map(m => ({ value: m, label: m.split('/').pop() }));
+          }
+        }
+        _cachedInferenceModels = models;
+        Object.assign(INFERENCE_MODELS, models);
+      } catch (e) { /* use defaults */ }
+      return INFERENCE_MODELS;
+    }
+    fetchInferenceModels();
 
     function _normalizeModel(m) { return (m || '').replace(/(\d+)\.(\d+)$/, '$1-$2'); }
     function _modelsEqual(a, b) { return _normalizeModel(a) === _normalizeModel(b); }
@@ -8008,11 +8040,27 @@ function burnAreaChart() {
 
     async function switchCli(agent, backend) {
       if (!backend) return;
-      const toast = showToast(`Switching ${agent} → ${backend}...`, 'info', true);
+      const label = INFERENCE_BACKENDS.includes(backend) ? 'method' : 'CLI';
+      const toast = showToast(`Switching ${agent} ${label} → ${backend}...`, 'info', true);
       const res = await fetch(`/api/switch/${agent}/${backend}`, { method: 'POST' });
       const data = await res.json();
       if (!data.ok) { dismissToast(toast, `Switch failed: ${data.error || 'unknown'}`, 'error'); return; }
-      dismissToast(toast, `${agent} CLI → ${backend}`, 'success');
+      dismissToast(toast, `${agent} ${label} → ${backend}`, 'success');
+      updateModelDropdown(agent, backend);
+      if (window._lastAgents) {
+        const a = window._lastAgents.find(x => x.name === agent);
+        if (a) { a.cli = backend; renderAgents(window._lastAgents); }
+      }
+    }
+
+    function updateModelDropdown(agent, backend) {
+      const modelSelects = document.querySelectorAll(`select[data-change-action="switchModel"][data-agent="${agent}"]`);
+      const isInference = INFERENCE_BACKENDS.includes(backend);
+      const models = isInference ? (INFERENCE_MODELS[backend] || []) : KNOWN_MODELS;
+      modelSelects.forEach(sel => {
+        sel.innerHTML = '<option value="">model ▾</option>' +
+          models.map(m => `<option value="${m.value}">${m.label}</option>`).join('');
+      });
     }
 
     async function switchModel(agent, model) {
@@ -8022,6 +8070,10 @@ function burnAreaChart() {
       const data = await res.json();
       if (!data.ok) { dismissToast(toast, `Model switch failed: ${data.error || 'unknown'}`, 'error'); return; }
       dismissToast(toast, `${agent} model → ${model}`, 'success');
+      if (window._lastAgents) {
+        const a = window._lastAgents.find(x => x.name === agent);
+        if (a) { a.model = model; renderAgents(window._lastAgents); }
+      }
     }
 
     const PIN_OVERRIDE_TTL_MS = 60000;
@@ -9104,7 +9156,7 @@ function burnAreaChart() {
         <div class="config-field">
           <label>CLI Pin Value <span class="config-info">i<span class="config-tooltip">Which CLI backend to pin this agent to when CLI Pinned is on. Options: claude, copilot, bob, gemini, codex, amazonq, goose, aider. copilot and goose are free backends (no token cost).</span></span></label>
           <select id="cfg-pin-value" onchange="markDirty('general','cliPinValue',this.value);updateLaunchCmd(this.value)">
-            ${KNOWN_BACKENDS.map(b => `<option value="${b}" ${g.cliPinValue === b ? 'selected' : ''}>${b}</option>`).join('')}
+            ${KNOWN_BACKENDS.map(b => `<option value="${b}" ${g.cliPinValue === b ? 'selected' : ''}>${backendLabel(b)}</option>`).join('')}
           </select>
         </div>
         <div class="config-field-row">

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
+	"regexp"
 	"time"
 )
 
@@ -126,12 +128,30 @@ func waitForReady(ctx context.Context, logger *slog.Logger) {
 	}
 }
 
+var validNamePattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
 func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, logger *slog.Logger) {
 	payload := collect()
 	if payload == nil {
 		return
 	}
 	payload.Timestamp = time.Now().UTC().Format(time.RFC3339)
+
+	filtered := payload.Leaderboard[:0]
+	for _, lb := range payload.Leaderboard {
+		if lb.GitHubUsername != "" && validNamePattern.MatchString(lb.GitHubUsername) {
+			filtered = append(filtered, lb)
+		}
+	}
+	payload.Leaderboard = filtered
+
+	filteredAgents := payload.Agents[:0]
+	for _, a := range payload.Agents {
+		if a.Name != "" && validNamePattern.MatchString(a.Name) {
+			filteredAgents = append(filteredAgents, a)
+		}
+	}
+	payload.Agents = filteredAgents
 
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -160,7 +180,8 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 300 {
-		logger.Warn("hub heartbeat rejected", "status", resp.StatusCode)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		logger.Warn("hub heartbeat rejected", "status", resp.StatusCode, "body", string(respBody))
 	}
 }
 

--- a/v2/pkg/hub/oci_fss.go
+++ b/v2/pkg/hub/oci_fss.go
@@ -268,10 +268,11 @@ func createOCIFileSystem(displayName string, logger *slog.Logger) (string, error
 
 // createOCIExport creates an NFS export for the given file system on the
 // configured export set, making it accessible via NFS at the specified path.
-func createOCIExport(fileSystemID, exportPath string, logger *slog.Logger) error {
+// It returns the OCID of the newly created export.
+func createOCIExport(fileSystemID, exportPath string, logger *slog.Logger) (string, error) {
 	cfg, err := loadOCIConfig()
 	if err != nil {
-		return fmt.Errorf("load OCI config: %w", err)
+		return "", fmt.Errorf("load OCI config: %w", err)
 	}
 
 	endpoint := fmt.Sprintf(ociFSSEndpointFmt, cfg.region)
@@ -283,33 +284,119 @@ func createOCIExport(fileSystemID, exportPath string, logger *slog.Logger) error
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return fmt.Errorf("marshal export request: %w", err)
+		return "", fmt.Errorf("marshal export request: %w", err)
 	}
 
 	reqURL := endpoint + ociExportsPath
 	req, err := http.NewRequest(http.MethodPost, reqURL, bytes.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("build request: %w", err)
+		return "", fmt.Errorf("build request: %w", err)
 	}
 	req.Host = req.URL.Host
 
 	if err := ociSignRequest(req, body, cfg); err != nil {
-		return fmt.Errorf("sign request: %w", err)
+		return "", fmt.Errorf("sign request: %w", err)
 	}
 
 	client := &http.Client{Timeout: ociHTTPTimeoutSec * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("OCI export API call failed: %w", err)
+		return "", fmt.Errorf("OCI export API call failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	respBody, _ := io.ReadAll(resp.Body)
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("OCI export API returned %d: %s", resp.StatusCode, string(respBody))
+		return "", fmt.Errorf("OCI export API returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
-	logger.Info("OCI NFS export created", "fileSystemID", fileSystemID, "exportPath", exportPath)
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("parse OCI export response: %w", err)
+	}
+	if result.ID == "" {
+		return "", fmt.Errorf("OCI export response missing export ID")
+	}
+
+	logger.Info("OCI NFS export created", "fileSystemID", fileSystemID, "exportPath", exportPath, "exportID", result.ID)
+	return result.ID, nil
+}
+
+// deleteOCIExport deletes an OCI NFS export by its OCID.
+// DELETE requests use the same signing headers as GET (date, request-target, host).
+func deleteOCIExport(exportID string, logger *slog.Logger) error {
+	cfg, err := loadOCIConfig()
+	if err != nil {
+		return fmt.Errorf("load OCI config: %w", err)
+	}
+
+	endpoint := fmt.Sprintf(ociFSSEndpointFmt, cfg.region)
+	reqURL := endpoint + ociExportsPath + "/" + exportID
+
+	req, err := http.NewRequest(http.MethodDelete, reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Host = req.URL.Host
+
+	if err := ociSignRequest(req, nil, cfg); err != nil {
+		return fmt.Errorf("sign request: %w", err)
+	}
+
+	client := &http.Client{Timeout: ociHTTPTimeoutSec * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("OCI export delete API call failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// 204 No Content is the expected success response for DELETE.
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("OCI export delete API returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	logger.Info("OCI NFS export deleted", "exportID", exportID)
+	return nil
+}
+
+// deleteOCIFileSystem deletes an OCI File System by its OCID.
+// The file system must have no remaining exports before deletion.
+func deleteOCIFileSystem(fileSystemID string, logger *slog.Logger) error {
+	cfg, err := loadOCIConfig()
+	if err != nil {
+		return fmt.Errorf("load OCI config: %w", err)
+	}
+
+	endpoint := fmt.Sprintf(ociFSSEndpointFmt, cfg.region)
+	reqURL := endpoint + ociFileSystemsPath + "/" + fileSystemID
+
+	req, err := http.NewRequest(http.MethodDelete, reqURL, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Host = req.URL.Host
+
+	if err := ociSignRequest(req, nil, cfg); err != nil {
+		return fmt.Errorf("sign request: %w", err)
+	}
+
+	client := &http.Client{Timeout: ociHTTPTimeoutSec * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("OCI file system delete API call failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// 204 No Content is the expected success response for DELETE.
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("OCI file system delete API returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	logger.Info("OCI file system deleted", "fileSystemID", fileSystemID)
 	return nil
 }

--- a/v2/pkg/hub/oci_fss.go
+++ b/v2/pkg/hub/oci_fss.go
@@ -1,0 +1,315 @@
+package hub
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// OCI File Storage Service API constants
+const (
+	// ociAPIVersion is the FSS REST API version path prefix.
+	ociAPIVersion = "20171215"
+
+	// ociFileSystemsPath is the REST path for file system operations.
+	ociFileSystemsPath = "/" + ociAPIVersion + "/fileSystems"
+
+	// ociExportsPath is the REST path for export operations.
+	ociExportsPath = "/" + ociAPIVersion + "/exports"
+
+	// ociFSSEndpointFmt is the endpoint template for the FSS API.
+	// The %s placeholder is the OCI region identifier.
+	ociFSSEndpointFmt = "https://filestorage.%s.oraclecloud.com"
+
+	// ociHTTPTimeoutSec is the HTTP client timeout for OCI API calls.
+	ociHTTPTimeoutSec = 30
+
+	// ociSignatureVersion is the version field in the Authorization header.
+	ociSignatureVersion = "1"
+
+	// ociSigningAlgorithm is the algorithm identifier for the Authorization header.
+	ociSigningAlgorithm = "rsa-sha256"
+
+	// ociGetSignedHeaders lists the headers signed for GET/DELETE requests.
+	ociGetSignedHeaders = "date (request-target) host"
+
+	// ociPostSignedHeaders lists the headers signed for POST/PUT requests.
+	ociPostSignedHeaders = "date (request-target) host content-length content-type x-content-sha256"
+
+	// ociContentType is the Content-Type header value for OCI API POST requests.
+	ociContentType = "application/json"
+)
+
+// OCI environment variable names
+const (
+	envOCITenancy         = "OCI_TENANCY_OCID"
+	envOCIUser            = "OCI_USER_OCID"
+	envOCIFingerprint     = "OCI_FINGERPRINT"
+	envOCIPrivateKey      = "OCI_PRIVATE_KEY"
+	envOCIRegion          = "OCI_FSS_REGION"
+	envOCICompartmentID   = "OCI_COMPARTMENT_ID"
+	envOCIAvailDomain     = "OCI_AVAILABILITY_DOMAIN"
+	envOCIMountTargetID   = "OCI_MOUNT_TARGET_ID"
+	envOCIExportSetID     = "OCI_EXPORT_SET_ID"
+)
+
+// Default values for OCI configuration (non-secret infrastructure identifiers).
+const (
+	defaultOCICompartmentID   = "ocid1.compartment.oc1..aaaaaaaa6ry2pwgcmatdwrtoll7pjbwomt3zjqs7wy7wa6nmywljrbrjc7wa"
+	defaultOCIAvailDomain     = "qKAe:US-ASHBURN-AD-1"
+	defaultOCIMountTargetID   = "ocid1.mounttarget.oc1.iad.aaaaaa4np2zu32denfqwillqojxwiotjmfsc2ylefuzqaaaa"
+	defaultOCIExportSetID     = "ocid1.exportset.oc1.iad.aaaaaa4np2zu32ddnfqwillqojxwiotjmfsc2ylefuzqaaaa"
+	defaultOCIRegion          = "us-ashburn-1"
+)
+
+// ociConfig holds the cached OCI API authentication and resource configuration.
+type ociConfig struct {
+	tenancy       string
+	user          string
+	fingerprint   string
+	privateKey    *rsa.PrivateKey
+	region        string
+	compartmentID string
+	availDomain   string
+	mountTargetID string
+	exportSetID   string
+}
+
+var (
+	ociCfg     *ociConfig
+	ociCfgOnce sync.Once
+	ociCfgErr  error
+)
+
+// getEnvOrDefault returns the environment variable value, or fallback if unset/empty.
+func getEnvOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// loadOCIConfig reads OCI credentials and resource IDs from environment variables.
+// It is called once and the result is cached for the lifetime of the process.
+func loadOCIConfig() (*ociConfig, error) {
+	ociCfgOnce.Do(func() {
+		tenancy := os.Getenv(envOCITenancy)
+		user := os.Getenv(envOCIUser)
+		fingerprint := os.Getenv(envOCIFingerprint)
+		keyPEM := os.Getenv(envOCIPrivateKey)
+
+		if tenancy == "" || user == "" || fingerprint == "" || keyPEM == "" {
+			ociCfgErr = fmt.Errorf("OCI credentials not configured — set %s, %s, %s, and %s",
+				envOCITenancy, envOCIUser, envOCIFingerprint, envOCIPrivateKey)
+			return
+		}
+
+		block, _ := pem.Decode([]byte(keyPEM))
+		if block == nil {
+			ociCfgErr = fmt.Errorf("failed to decode OCI private key PEM")
+			return
+		}
+
+		parsedKey, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			// Fall back to PKCS1 format
+			parsedKey, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+			if err != nil {
+				ociCfgErr = fmt.Errorf("failed to parse OCI private key: %w", err)
+				return
+			}
+		}
+
+		rsaKey, ok := parsedKey.(*rsa.PrivateKey)
+		if !ok {
+			ociCfgErr = fmt.Errorf("OCI private key is not RSA")
+			return
+		}
+
+		ociCfg = &ociConfig{
+			tenancy:       tenancy,
+			user:          user,
+			fingerprint:   fingerprint,
+			privateKey:    rsaKey,
+			region:        getEnvOrDefault(envOCIRegion, defaultOCIRegion),
+			compartmentID: getEnvOrDefault(envOCICompartmentID, defaultOCICompartmentID),
+			availDomain:   getEnvOrDefault(envOCIAvailDomain, defaultOCIAvailDomain),
+			mountTargetID: getEnvOrDefault(envOCIMountTargetID, defaultOCIMountTargetID),
+			exportSetID:   getEnvOrDefault(envOCIExportSetID, defaultOCIExportSetID),
+		}
+	})
+	return ociCfg, ociCfgErr
+}
+
+// ociKeyID returns the keyId value for the OCI Authorization header:
+// "{tenancy}/{user}/{fingerprint}".
+func ociKeyID(cfg *ociConfig) string {
+	return cfg.tenancy + "/" + cfg.user + "/" + cfg.fingerprint
+}
+
+// ociSignRequest signs an *http.Request per the OCI HTTP Signature specification.
+// For POST requests it also sets Content-Type, Content-Length, and x-content-sha256.
+func ociSignRequest(req *http.Request, body []byte, cfg *ociConfig) error {
+	req.Header.Set("date", time.Now().UTC().Format(http.TimeFormat))
+
+	requestTarget := strings.ToLower(req.Method) + " " + req.URL.RequestURI()
+	signedHeaders := ociGetSignedHeaders
+
+	if req.Method == http.MethodPost || req.Method == http.MethodPut {
+		bodyHash := sha256.Sum256(body)
+		req.Header.Set("x-content-sha256", base64.StdEncoding.EncodeToString(bodyHash[:]))
+		req.Header.Set("content-type", ociContentType)
+		req.Header.Set("content-length", fmt.Sprintf("%d", len(body)))
+		signedHeaders = ociPostSignedHeaders
+	}
+
+	// Build the signing string: each header on its own line as "name: value".
+	var signingParts []string
+	for _, h := range strings.Split(signedHeaders, " ") {
+		switch h {
+		case "(request-target)":
+			signingParts = append(signingParts, "(request-target): "+requestTarget)
+		case "host":
+			signingParts = append(signingParts, "host: "+req.Host)
+		default:
+			signingParts = append(signingParts, h+": "+req.Header.Get(h))
+		}
+	}
+	signingString := strings.Join(signingParts, "\n")
+
+	hash := sha256.Sum256([]byte(signingString))
+	sig, err := rsa.SignPKCS1v15(nil, cfg.privateKey, crypto.SHA256, hash[:])
+	if err != nil {
+		return fmt.Errorf("RSA sign: %w", err)
+	}
+
+	authHeader := fmt.Sprintf(
+		`Signature version="%s",keyId="%s",algorithm="%s",headers="%s",signature="%s"`,
+		ociSignatureVersion,
+		ociKeyID(cfg),
+		ociSigningAlgorithm,
+		signedHeaders,
+		base64.StdEncoding.EncodeToString(sig),
+	)
+	req.Header.Set("Authorization", authHeader)
+	return nil
+}
+
+// createOCIFileSystem creates a new OCI File System in the configured compartment
+// and availability domain. It returns the OCID of the newly created file system.
+func createOCIFileSystem(displayName string, logger *slog.Logger) (string, error) {
+	cfg, err := loadOCIConfig()
+	if err != nil {
+		return "", fmt.Errorf("load OCI config: %w", err)
+	}
+
+	endpoint := fmt.Sprintf(ociFSSEndpointFmt, cfg.region)
+
+	payload := map[string]string{
+		"compartmentId":      cfg.compartmentID,
+		"availabilityDomain": cfg.availDomain,
+		"displayName":        displayName,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal file system request: %w", err)
+	}
+
+	reqURL := endpoint + ociFileSystemsPath
+	req, err := http.NewRequest(http.MethodPost, reqURL, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Host = req.URL.Host
+
+	if err := ociSignRequest(req, body, cfg); err != nil {
+		return "", fmt.Errorf("sign request: %w", err)
+	}
+
+	client := &http.Client{Timeout: ociHTTPTimeoutSec * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("OCI FSS API call failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("OCI FSS API returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("parse OCI FSS response: %w", err)
+	}
+	if result.ID == "" {
+		return "", fmt.Errorf("OCI FSS response missing file system ID")
+	}
+
+	logger.Info("OCI file system created", "displayName", displayName, "fileSystemID", result.ID)
+	return result.ID, nil
+}
+
+// createOCIExport creates an NFS export for the given file system on the
+// configured export set, making it accessible via NFS at the specified path.
+func createOCIExport(fileSystemID, exportPath string, logger *slog.Logger) error {
+	cfg, err := loadOCIConfig()
+	if err != nil {
+		return fmt.Errorf("load OCI config: %w", err)
+	}
+
+	endpoint := fmt.Sprintf(ociFSSEndpointFmt, cfg.region)
+
+	payload := map[string]string{
+		"exportSetId":  cfg.exportSetID,
+		"fileSystemId": fileSystemID,
+		"path":         exportPath,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal export request: %w", err)
+	}
+
+	reqURL := endpoint + ociExportsPath
+	req, err := http.NewRequest(http.MethodPost, reqURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	req.Host = req.URL.Host
+
+	if err := ociSignRequest(req, body, cfg); err != nil {
+		return fmt.Errorf("sign request: %w", err)
+	}
+
+	client := &http.Client{Timeout: ociHTTPTimeoutSec * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("OCI export API call failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("OCI export API returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	logger.Info("OCI NFS export created", "fileSystemID", fileSystemID, "exportPath", exportPath)
+	return nil
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1133,21 +1133,8 @@ func (s *HubServer) handleDeleteHive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ns := "hive-hosted-" + id
-	cmd := exec.Command("kubectl", "delete", "namespace", ns, "--ignore-not-found")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		s.logger.Warn("kubectl delete ns failed", "hive", id, "output", string(out))
-	}
-
-	os.RemoveAll(filepath.Join(saasHivesDir, id))
-
-	for _, u := range listAllSaaSUsers() {
-		if _, ok := u.Hives[id]; ok {
-			delete(u.Hives, id)
-			saveSaaSUser(&u)
-		}
-	}
+	// Full de-provisioning: namespace, PV, OCI export, OCI file system, disk record, user cleanup.
+	deprovisionHive(h, s.logger)
 
 	s.logger.Info("audit: hosted hive deleted", "hive_id", id, "by", username)
 	w.Header().Set("Content-Type", "application/json")
@@ -3514,7 +3501,7 @@ const dashboardHTML = `<!DOCTYPE html>
     }
 
     async function deleteHive(id) {
-      if (!await hiveConfirm('Delete ' + id + '? This removes all data.')) return;
+      if (!await hiveConfirm('Delete ' + id + '? This removes the namespace, PV, OCI storage, and all data.')) return;
       var btns = document.querySelectorAll('button[onclick*="deleteHive"]');
       btns.forEach(function(b) { b.disabled = true; b.textContent = 'Deleting...'; b.style.opacity = '0.6'; });
       try {

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3289,16 +3289,42 @@ const dashboardHTML = `<!DOCTYPE html>
       return 'var(--green)';
     }
 
-    function renderHealthBar(pct, warnThreshold, dangerThreshold) {
+    var SPARKLINE_BLOCKS = '▁▂▃▄▅▆▇█';
+    var SPARKLINE_HISTORY_LEN = 10;
+    var _clusterSparkHistory = {};
+
+    function pushSparkPoint(nodeKey, metric, value) {
+      var key = nodeKey + ':' + metric;
+      if (!_clusterSparkHistory[key]) _clusterSparkHistory[key] = [];
+      _clusterSparkHistory[key].push(value);
+      if (_clusterSparkHistory[key].length > SPARKLINE_HISTORY_LEN) _clusterSparkHistory[key].shift();
+    }
+
+    function renderUnicodeSparkline(nodeKey, metric, color) {
+      var key = nodeKey + ':' + metric;
+      var pts = _clusterSparkHistory[key] || [];
+      if (pts.length < 2) return '';
+      var max = Math.max.apply(null, pts);
+      if (max === 0) max = 1;
+      var blocks = SPARKLINE_BLOCKS;
+      var spark = pts.map(function(v) {
+        var idx = Math.round((v / max) * (blocks.length - 1));
+        return blocks[Math.min(idx, blocks.length - 1)];
+      }).join('');
+      return '<span style="font-family:monospace;font-size:0.7rem;color:' + color + ';letter-spacing:-1px">' + spark + '</span>';
+    }
+
+    function renderHealthMetric(label, used, total, unit, pct, warnThreshold, dangerThreshold, nodeKey, metric) {
       var color = healthBarColor(pct, warnThreshold, dangerThreshold);
-      var MAX_BAR_WIDTH_PCT = 100;
-      var clampedPct = Math.min(pct, MAX_BAR_WIDTH_PCT);
-      return '<div style="display:flex;align-items:center;gap:8px">' +
-        '<div style="flex:1;height:6px;background:var(--border);border-radius:3px;overflow:hidden">' +
-        '<div style="width:' + clampedPct + '%;height:100%;background:' + color + ';border-radius:3px;transition:width 0.3s"></div>' +
-        '</div>' +
-        '<span style="font-size:0.75rem;min-width:32px;text-align:right;color:' + color + '">' + pct + '%</span>' +
-        '</div>';
+      pushSparkPoint(nodeKey, metric, pct);
+      var spark = renderUnicodeSparkline(nodeKey, metric, color);
+      return '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:4px">' +
+        '<span style="font-size:0.7rem;color:var(--muted)">' + label + '</span>' +
+        '<span style="display:flex;align-items:center;gap:6px">' +
+        spark +
+        '<span style="font-family:monospace;font-size:0.75rem;color:' + color + '">' + used + ' / ' + total + ' ' + unit + '</span>' +
+        '<span style="font-size:0.7rem;min-width:28px;text-align:right;color:' + color + '">' + pct + '%</span>' +
+        '</span></div>';
     }
 
     async function loadClusterHealth() {
@@ -3316,7 +3342,14 @@ const dashboardHTML = `<!DOCTYPE html>
         var s = data.summary || {};
         var summaryBar = document.getElementById('cluster-health-summary-bar');
         if (summaryBar) {
-          summaryBar.textContent = (s.total_nodes || 0) + ' nodes · ' + (s.total_cpu_cores || 0) + ' vCPU · ' + (s.total_mem_percent || 0) + '% mem · ' + (s.hive_count || 0) + ' hives';
+          pushSparkPoint('_cluster', 'cpu', s.total_cpu_percent || 0);
+          pushSparkPoint('_cluster', 'mem', s.total_mem_percent || 0);
+          var cpuColor = healthBarColor(s.total_cpu_percent || 0, CLUSTER_CPU_WARN_PCT, CLUSTER_CPU_DANGER_PCT);
+          var memColor = healthBarColor(s.total_mem_percent || 0, CLUSTER_MEM_WARN_PCT, CLUSTER_MEM_DANGER_PCT);
+          summaryBar.innerHTML = (s.total_nodes || 0) + ' nodes · ' + (s.total_cpu_cores || 0) + ' vCPU · ' +
+            renderUnicodeSparkline('_cluster', 'cpu', cpuColor) + ' <span style="color:' + cpuColor + '">' + (s.total_cpu_percent || 0) + '% cpu</span> · ' +
+            renderUnicodeSparkline('_cluster', 'mem', memColor) + ' <span style="color:' + memColor + '">' + (s.total_mem_percent || 0) + '% mem</span> · ' +
+            (s.hive_count || 0) + ' hives';
         }
 
         var body = document.getElementById('cluster-health-body');
@@ -3335,22 +3368,24 @@ const dashboardHTML = `<!DOCTYPE html>
         }
 
         grid.innerHTML = nodes.map(function(n) {
+          var nk = n.name;
           var readyBadge = (n.conditions || []).indexOf('Ready') >= 0
             ? '<span style="color:var(--green);font-size:0.7rem;font-weight:600">Ready</span>'
             : '<span style="color:var(--red);font-size:0.7rem;font-weight:600">NotReady</span>';
           var diskWarn = n.disk_pressure
-            ? '<div style="margin-top:6px;padding:4px 8px;background:rgba(239,68,68,0.1);border:1px solid rgba(239,68,68,0.3);border-radius:4px;font-size:0.7rem;color:var(--red)">Disk Pressure</div>'
+            ? '<div style="margin-top:6px;padding:4px 8px;background:rgba(239,68,68,0.1);border:1px solid rgba(239,68,68,0.3);border-radius:4px;font-size:0.7rem;color:var(--red)">⚠ Disk Pressure</div>'
             : '';
+          var cpuUsed = (n.cpu_used_millicores / 1000).toFixed(1);
+          var memUsedGB = (n.mem_used_mb / 1024).toFixed(1);
+          var memTotalGB = Math.round(n.mem_total_mb / 1024);
           return '<div style="background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:14px">' +
-            '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px">' +
-            '<span style="font-family:monospace;font-size:0.8rem;color:var(--text)">' + esc(n.name) + '</span>' +
-            readyBadge +
-            '</div>' +
-            '<div style="margin-bottom:6px"><span style="font-size:0.7rem;color:var(--muted)">CPU (' + n.cpu_cores + ' cores)</span>' + renderHealthBar(n.cpu_percent, CLUSTER_CPU_WARN_PCT, CLUSTER_CPU_DANGER_PCT) + '</div>' +
-            '<div style="margin-bottom:6px"><span style="font-size:0.7rem;color:var(--muted)">Memory (' + Math.round(n.mem_total_mb / 1024) + ' GB)</span>' + renderHealthBar(n.mem_percent, CLUSTER_MEM_WARN_PCT, CLUSTER_MEM_DANGER_PCT) + '</div>' +
-            '<div style="display:flex;align-items:center;gap:8px;margin-top:8px">' +
-            '<span style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:4px;font-size:0.7rem;color:var(--muted)">' + (n.pods || 0) + '/' + (n.pod_capacity || 0) + ' pods</span>' +
-            '</div>' +
+            '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px">' +
+            '<span style="font-family:monospace;font-size:0.8rem;color:var(--text)">' + esc(nk) + '</span>' +
+            '<span style="display:flex;align-items:center;gap:6px">' + readyBadge +
+            '<span style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:4px;font-size:0.65rem;color:var(--muted)">' + (n.pods || 0) + '/' + (n.pod_capacity || 0) + ' pods</span>' +
+            '</span></div>' +
+            renderHealthMetric('CPU', cpuUsed, n.cpu_cores, 'cores', n.cpu_percent, CLUSTER_CPU_WARN_PCT, CLUSTER_CPU_DANGER_PCT, nk, 'cpu') +
+            renderHealthMetric('MEM', memUsedGB, memTotalGB, 'GB', n.mem_percent, CLUSTER_MEM_WARN_PCT, CLUSTER_MEM_DANGER_PCT, nk, 'mem') +
             diskWarn +
             '</div>';
         }).join('');

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -131,6 +131,7 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("DELETE /api/saas/deny-provision/{username}", s.requireAdmin(s.handleDenyProvision))
 	s.mux.HandleFunc("GET /api/saas/admin/users", s.requireAdmin(s.handleAdminUsers))
 	s.mux.HandleFunc("PUT /api/saas/admin/users/{username}", s.requireAdmin(s.handleAdminUpdateUser))
+	s.mux.HandleFunc("GET /api/saas/cluster-health", s.requireAdmin(s.handleClusterHealth))
 
 	go StartProvisionWatcher(s.logger, &s.mu)
 	go s.StartLatestSHAPoller()
@@ -394,6 +395,350 @@ func (s *HubServer) handleAdminUpdateUser(w http.ResponseWriter, r *http.Request
 	s.logger.Info("audit: admin updated user", "target", username, "quota", u.SaaSQuota, "blocked", u.Blocked)
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "updated"})
+}
+
+// --- Cluster Health ---
+
+const clusterHealthCacheTTL = 30 * time.Second
+
+// clusterHealthCPUWarnPct is the CPU usage percentage threshold for warning state.
+const clusterHealthCPUWarnPct = 60
+
+// clusterHealthCPUDangerPct is the CPU usage percentage threshold for danger state.
+const clusterHealthCPUDangerPct = 80
+
+// clusterHealthMemWarnPct is the memory usage percentage threshold for warning state.
+const clusterHealthMemWarnPct = 60
+
+// clusterHealthMemDangerPct is the memory usage percentage threshold for danger state.
+const clusterHealthMemDangerPct = 80
+
+// kubectlTopTimeoutSec is the timeout for kubectl top nodes commands.
+const kubectlTopTimeoutSec = 10
+
+// kubectlGetTimeoutSec is the timeout for kubectl get nodes commands.
+const kubectlGetTimeoutSec = 10
+
+// millicoresPerCore converts cores to millicores.
+const millicoresPerCore = 1000
+
+// mbPerGB converts megabytes to gigabytes.
+const mbPerGB = 1024
+
+// kiToBytes converts Ki units to bytes.
+const kiToBytes = 1024
+
+// miToBytes converts Mi units to bytes.
+const miToBytes = 1024 * 1024
+
+// giToBytes converts Gi units to bytes.
+const giToBytes = 1024 * 1024 * 1024
+
+// bytesPerMB converts bytes to megabytes.
+const bytesPerMB = 1024 * 1024
+
+// percentMultiplier converts a ratio to a percentage.
+const percentMultiplier = 100
+
+type ClusterHealthNode struct {
+	Name            string   `json:"name"`
+	CPUCores        int      `json:"cpu_cores"`
+	CPUUsedMillis   int64    `json:"cpu_used_millicores"`
+	CPUPercent      int      `json:"cpu_percent"`
+	MemTotalMB      int64    `json:"mem_total_mb"`
+	MemUsedMB       int64    `json:"mem_used_mb"`
+	MemPercent      int      `json:"mem_percent"`
+	DiskPressure    bool     `json:"disk_pressure"`
+	Pods            int      `json:"pods"`
+	PodCapacity     int      `json:"pod_capacity"`
+	Conditions      []string `json:"conditions"`
+}
+
+type ClusterHealthSummary struct {
+	TotalNodes    int `json:"total_nodes"`
+	TotalCPUCores int `json:"total_cpu_cores"`
+	TotalCPUPct   int `json:"total_cpu_percent"`
+	TotalMemGB    int `json:"total_mem_gb"`
+	TotalMemPct   int `json:"total_mem_percent"`
+	HiveCount     int `json:"hive_count"`
+}
+
+type ClusterHealthResponse struct {
+	Nodes   []ClusterHealthNode  `json:"nodes"`
+	Summary ClusterHealthSummary `json:"summary"`
+}
+
+var (
+	clusterHealthCache     *ClusterHealthResponse
+	clusterHealthCacheTime time.Time
+	clusterHealthCacheMu   sync.Mutex
+)
+
+func (s *HubServer) handleClusterHealth(w http.ResponseWriter, r *http.Request) {
+	clusterHealthCacheMu.Lock()
+	if clusterHealthCache != nil && time.Since(clusterHealthCacheTime) < clusterHealthCacheTTL {
+		cached := clusterHealthCache
+		clusterHealthCacheMu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(cached)
+		return
+	}
+	clusterHealthCacheMu.Unlock()
+
+	resp, err := buildClusterHealth(s)
+	if err != nil {
+		s.logger.Error("cluster health failed", "error", err)
+		http.Error(w, `{"error":"failed to gather cluster health"}`, http.StatusInternalServerError)
+		return
+	}
+
+	clusterHealthCacheMu.Lock()
+	clusterHealthCache = resp
+	clusterHealthCacheTime = time.Now()
+	clusterHealthCacheMu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+func buildClusterHealth(s *HubServer) (*ClusterHealthResponse, error) {
+	// Run kubectl top nodes
+	topOut, err := exec.Command("kubectl", "top", "nodes", "--no-headers").Output()
+	if err != nil {
+		return nil, fmt.Errorf("kubectl top nodes: %w", err)
+	}
+
+	// Run kubectl get nodes -o json
+	getOut, err := exec.Command("kubectl", "get", "nodes", "-o", "json").Output()
+	if err != nil {
+		return nil, fmt.Errorf("kubectl get nodes: %w", err)
+	}
+
+	// Parse kubectl get nodes output
+	var nodesJSON struct {
+		Items []struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+			Status struct {
+				Allocatable map[string]string `json:"allocatable"`
+				Capacity    map[string]string `json:"capacity"`
+				Conditions  []struct {
+					Type   string `json:"type"`
+					Status string `json:"status"`
+				} `json:"conditions"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(getOut, &nodesJSON); err != nil {
+		return nil, fmt.Errorf("parse nodes JSON: %w", err)
+	}
+
+	// Build a map of node info from kubectl get
+	type nodeInfo struct {
+		cpuAllocatable  int64 // millicores
+		memAllocatable  int64 // bytes
+		podCapacity     int
+		diskPressure    bool
+		conditions      []string
+	}
+	nodeMap := make(map[string]*nodeInfo)
+	for _, item := range nodesJSON.Items {
+		ni := &nodeInfo{}
+		ni.cpuAllocatable = parseK8sCPU(item.Status.Allocatable["cpu"])
+		ni.memAllocatable = parseK8sMemory(item.Status.Allocatable["memory"])
+		ni.podCapacity = parseInt(item.Status.Capacity["pods"])
+		for _, cond := range item.Status.Conditions {
+			if cond.Type == "DiskPressure" && cond.Status == "True" {
+				ni.diskPressure = true
+			}
+			if cond.Type == "Ready" && cond.Status == "True" {
+				ni.conditions = append(ni.conditions, "Ready")
+			} else if cond.Type == "Ready" && cond.Status != "True" {
+				ni.conditions = append(ni.conditions, "NotReady")
+			}
+		}
+		if len(ni.conditions) == 0 {
+			ni.conditions = []string{"Unknown"}
+		}
+		nodeMap[item.Metadata.Name] = ni
+	}
+
+	// Parse kubectl top nodes output
+	// Format: NAME  CPU(cores)  CPU%  MEMORY(bytes)  MEMORY%
+	var nodes []ClusterHealthNode
+	lines := strings.Split(strings.TrimSpace(string(topOut)), "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		const topFieldCount = 5
+		if len(fields) < topFieldCount {
+			continue
+		}
+		name := fields[0]
+		cpuUsed := parseTopCPU(fields[1])     // e.g. "1200m" or "2"
+		memUsed := parseTopMemory(fields[3])   // e.g. "4096Mi"
+
+		ni, ok := nodeMap[name]
+		if !ok {
+			continue
+		}
+
+		cpuCores := int(ni.cpuAllocatable / millicoresPerCore)
+		cpuPct := 0
+		if ni.cpuAllocatable > 0 {
+			cpuPct = int(cpuUsed * percentMultiplier / ni.cpuAllocatable)
+		}
+
+		memTotalMB := ni.memAllocatable / bytesPerMB
+		memUsedMB := memUsed / bytesPerMB
+		memPct := 0
+		if ni.memAllocatable > 0 {
+			memPct = int(memUsed * percentMultiplier / ni.memAllocatable)
+		}
+
+		nodes = append(nodes, ClusterHealthNode{
+			Name:          name,
+			CPUCores:      cpuCores,
+			CPUUsedMillis: cpuUsed,
+			CPUPercent:    cpuPct,
+			MemTotalMB:    memTotalMB,
+			MemUsedMB:     memUsedMB,
+			MemPercent:    memPct,
+			DiskPressure:  ni.diskPressure,
+			Pods:          0, // populated below
+			PodCapacity:   ni.podCapacity,
+			Conditions:    ni.conditions,
+		})
+	}
+
+	// Count running pods per node
+	podOut, _ := exec.Command("kubectl", "get", "pods", "--all-namespaces", "--field-selector=status.phase=Running", "-o", "json").Output()
+	if len(podOut) > 0 {
+		var podsJSON struct {
+			Items []struct {
+				Spec struct {
+					NodeName string `json:"nodeName"`
+				} `json:"spec"`
+			} `json:"items"`
+		}
+		if json.Unmarshal(podOut, &podsJSON) == nil {
+			podCounts := make(map[string]int)
+			for _, p := range podsJSON.Items {
+				podCounts[p.Spec.NodeName]++
+			}
+			for i := range nodes {
+				nodes[i].Pods = podCounts[nodes[i].Name]
+			}
+		}
+	}
+
+	// Count hives from registry
+	s.mu.RLock()
+	hiveCount := len(s.registry.Hives)
+	s.mu.RUnlock()
+
+	// Build summary
+	var totalCPUCores int
+	var totalCPUUsed int64
+	var totalCPUAlloc int64
+	var totalMemAlloc int64
+	var totalMemUsed int64
+	for _, n := range nodes {
+		totalCPUCores += n.CPUCores
+		totalCPUUsed += n.CPUUsedMillis
+		if ni, ok := nodeMap[n.Name]; ok {
+			totalCPUAlloc += ni.cpuAllocatable
+			totalMemAlloc += ni.memAllocatable
+		}
+		totalMemUsed += n.MemUsedMB * bytesPerMB
+	}
+
+	totalCPUPct := 0
+	if totalCPUAlloc > 0 {
+		totalCPUPct = int(totalCPUUsed * percentMultiplier / totalCPUAlloc)
+	}
+	totalMemPct := 0
+	if totalMemAlloc > 0 {
+		totalMemPct = int(totalMemUsed * percentMultiplier / totalMemAlloc)
+	}
+	totalMemGB := int(totalMemAlloc / giToBytes)
+
+	return &ClusterHealthResponse{
+		Nodes: nodes,
+		Summary: ClusterHealthSummary{
+			TotalNodes:    len(nodes),
+			TotalCPUCores: totalCPUCores,
+			TotalCPUPct:   totalCPUPct,
+			TotalMemGB:    totalMemGB,
+			TotalMemPct:   totalMemPct,
+			HiveCount:     hiveCount,
+		},
+	}, nil
+}
+
+// parseK8sCPU parses Kubernetes CPU resource strings (e.g. "4", "4000m").
+func parseK8sCPU(s string) int64 {
+	s = strings.TrimSpace(s)
+	if strings.HasSuffix(s, "m") {
+		v := parseInt(strings.TrimSuffix(s, "m"))
+		return int64(v)
+	}
+	v := parseInt(s)
+	return int64(v) * millicoresPerCore
+}
+
+// parseK8sMemory parses Kubernetes memory resource strings (e.g. "16384Ki", "8Gi").
+func parseK8sMemory(s string) int64 {
+	s = strings.TrimSpace(s)
+	if strings.HasSuffix(s, "Ki") {
+		v := parseInt(strings.TrimSuffix(s, "Ki"))
+		return int64(v) * kiToBytes
+	}
+	if strings.HasSuffix(s, "Mi") {
+		v := parseInt(strings.TrimSuffix(s, "Mi"))
+		return int64(v) * miToBytes
+	}
+	if strings.HasSuffix(s, "Gi") {
+		v := parseInt(strings.TrimSuffix(s, "Gi"))
+		return int64(v) * giToBytes
+	}
+	return int64(parseInt(s))
+}
+
+// parseTopCPU parses kubectl top CPU values (e.g. "1200m", "2").
+func parseTopCPU(s string) int64 {
+	s = strings.TrimSpace(s)
+	if strings.HasSuffix(s, "m") {
+		v := parseInt(strings.TrimSuffix(s, "m"))
+		return int64(v)
+	}
+	v := parseInt(s)
+	return int64(v) * millicoresPerCore
+}
+
+// parseTopMemory parses kubectl top memory values (e.g. "4096Mi", "8Gi").
+func parseTopMemory(s string) int64 {
+	s = strings.TrimSpace(s)
+	if strings.HasSuffix(s, "Ki") {
+		v := parseInt(strings.TrimSuffix(s, "Ki"))
+		return int64(v) * kiToBytes
+	}
+	if strings.HasSuffix(s, "Mi") {
+		v := parseInt(strings.TrimSuffix(s, "Mi"))
+		return int64(v) * miToBytes
+	}
+	if strings.HasSuffix(s, "Gi") {
+		v := parseInt(strings.TrimSuffix(s, "Gi"))
+		return int64(v) * giToBytes
+	}
+	return int64(parseInt(s))
+}
+
+// parseInt parses an integer from a string, returning 0 on failure.
+func parseInt(s string) int {
+	var v int
+	fmt.Sscanf(s, "%d", &v)
+	return v
 }
 
 type MyHiveEntry struct {
@@ -2186,6 +2531,17 @@ const dashboardHTML = `<!DOCTYPE html>
       </div>
       <div id="users-container"><div class="loading">Loading users...</div></div>
     </div>
+
+    <div id="cluster-health-section" style="display:none;margin-top:48px">
+      <div onclick="toggleClusterHealth()" style="display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none;margin-bottom:16px">
+        <span id="cluster-health-toggle" style="font-size:0.7rem;color:var(--muted);transition:transform 0.2s">&#9654;</span>
+        <h2 style="font-size:1.3rem;color:var(--accent);margin:0">Cluster Health</h2>
+        <span id="cluster-health-summary-bar" style="font-size:0.8rem;color:var(--muted);margin-left:8px"></span>
+      </div>
+      <div id="cluster-health-body" style="display:none">
+        <div id="cluster-health-grid" style="display:grid;grid-template-columns:repeat(2,1fr);gap:12px"></div>
+      </div>
+    </div>
   </div>
 
   <script>
@@ -2910,17 +3266,112 @@ const dashboardHTML = `<!DOCTYPE html>
       finally { _requestInProgress = false; btn.disabled = false; btn.textContent = 'Submit Request'; }
     }
 
+    // --- Cluster Health Panel ---
+    var CLUSTER_HEALTH_POLL_MS = 30000;
+    var CLUSTER_CPU_WARN_PCT = 60;
+    var CLUSTER_CPU_DANGER_PCT = 80;
+    var CLUSTER_MEM_WARN_PCT = 60;
+    var CLUSTER_MEM_DANGER_PCT = 80;
+    var _clusterHealthCollapsed = localStorage.getItem('hive-cluster-health-collapsed') !== 'false';
+
+    function toggleClusterHealth() {
+      _clusterHealthCollapsed = !_clusterHealthCollapsed;
+      localStorage.setItem('hive-cluster-health-collapsed', _clusterHealthCollapsed ? 'true' : 'false');
+      var body = document.getElementById('cluster-health-body');
+      var toggle = document.getElementById('cluster-health-toggle');
+      if (body) body.style.display = _clusterHealthCollapsed ? 'none' : '';
+      if (toggle) toggle.style.transform = _clusterHealthCollapsed ? '' : 'rotate(90deg)';
+    }
+
+    function healthBarColor(pct, warnThreshold, dangerThreshold) {
+      if (pct >= dangerThreshold) return 'var(--red)';
+      if (pct >= warnThreshold) return 'var(--accent)';
+      return 'var(--green)';
+    }
+
+    function renderHealthBar(pct, warnThreshold, dangerThreshold) {
+      var color = healthBarColor(pct, warnThreshold, dangerThreshold);
+      var MAX_BAR_WIDTH_PCT = 100;
+      var clampedPct = Math.min(pct, MAX_BAR_WIDTH_PCT);
+      return '<div style="display:flex;align-items:center;gap:8px">' +
+        '<div style="flex:1;height:6px;background:var(--border);border-radius:3px;overflow:hidden">' +
+        '<div style="width:' + clampedPct + '%;height:100%;background:' + color + ';border-radius:3px;transition:width 0.3s"></div>' +
+        '</div>' +
+        '<span style="font-size:0.75rem;min-width:32px;text-align:right;color:' + color + '">' + pct + '%</span>' +
+        '</div>';
+    }
+
+    async function loadClusterHealth() {
+      if (!_isAdmin) return;
+      try {
+        var resp = await fetch('/api/saas/cluster-health');
+        if (resp.status === 403) {
+          document.getElementById('cluster-health-section').style.display = 'none';
+          return;
+        }
+        if (!resp.ok) return;
+        var data = await resp.json();
+        document.getElementById('cluster-health-section').style.display = '';
+
+        var s = data.summary || {};
+        var summaryBar = document.getElementById('cluster-health-summary-bar');
+        if (summaryBar) {
+          summaryBar.textContent = (s.total_nodes || 0) + ' nodes · ' + (s.total_cpu_cores || 0) + ' vCPU · ' + (s.total_mem_percent || 0) + '% mem · ' + (s.hive_count || 0) + ' hives';
+        }
+
+        var body = document.getElementById('cluster-health-body');
+        var toggle = document.getElementById('cluster-health-toggle');
+        if (!_clusterHealthCollapsed) {
+          if (body) body.style.display = '';
+          if (toggle) toggle.style.transform = 'rotate(90deg)';
+        }
+
+        var grid = document.getElementById('cluster-health-grid');
+        if (!grid) return;
+        var nodes = data.nodes || [];
+        if (!nodes.length) {
+          grid.innerHTML = '<div style="color:var(--muted);font-size:0.85rem;grid-column:span 2">No node data available</div>';
+          return;
+        }
+
+        grid.innerHTML = nodes.map(function(n) {
+          var readyBadge = (n.conditions || []).indexOf('Ready') >= 0
+            ? '<span style="color:var(--green);font-size:0.7rem;font-weight:600">Ready</span>'
+            : '<span style="color:var(--red);font-size:0.7rem;font-weight:600">NotReady</span>';
+          var diskWarn = n.disk_pressure
+            ? '<div style="margin-top:6px;padding:4px 8px;background:rgba(239,68,68,0.1);border:1px solid rgba(239,68,68,0.3);border-radius:4px;font-size:0.7rem;color:var(--red)">Disk Pressure</div>'
+            : '';
+          return '<div style="background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:14px">' +
+            '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px">' +
+            '<span style="font-family:monospace;font-size:0.8rem;color:var(--text)">' + esc(n.name) + '</span>' +
+            readyBadge +
+            '</div>' +
+            '<div style="margin-bottom:6px"><span style="font-size:0.7rem;color:var(--muted)">CPU (' + n.cpu_cores + ' cores)</span>' + renderHealthBar(n.cpu_percent, CLUSTER_CPU_WARN_PCT, CLUSTER_CPU_DANGER_PCT) + '</div>' +
+            '<div style="margin-bottom:6px"><span style="font-size:0.7rem;color:var(--muted)">Memory (' + Math.round(n.mem_total_mb / 1024) + ' GB)</span>' + renderHealthBar(n.mem_percent, CLUSTER_MEM_WARN_PCT, CLUSTER_MEM_DANGER_PCT) + '</div>' +
+            '<div style="display:flex;align-items:center;gap:8px;margin-top:8px">' +
+            '<span style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:4px;font-size:0.7rem;color:var(--muted)">' + (n.pods || 0) + '/' + (n.pod_capacity || 0) + ' pods</span>' +
+            '</div>' +
+            diskWarn +
+            '</div>';
+        }).join('');
+      } catch(e) {
+        console.error('cluster health error:', e);
+      }
+    }
+
     async function init() {
       await loadUser();
       await autoRequestAccessFromUrl();
       await loadHives();
       await loadAdminUsers();
       if (!_adminLoaded) setTimeout(loadAdminUsers, 2000);
+      loadClusterHealth();
     }
     init();
     var POLL_INTERVAL_MS = 30000;
     setInterval(loadHives, POLL_INTERVAL_MS);
     setInterval(loadAdminUsers, POLL_INTERVAL_MS);
+    setInterval(loadClusterHealth, CLUSTER_HEALTH_POLL_MS);
     var _refreshTimer = null;
     var REFRESH_DEBOUNCE_MS = 500;
     function debouncedRefresh() {

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -52,6 +52,8 @@ type SaaSHive struct {
 	Error           string                 `json:"error,omitempty"`
 	AutoUpgrade     bool                   `json:"auto_upgrade"`
 	PendingRequests []PendingAccessRequest `json:"pending_requests,omitempty"`
+	OCIFileSystemID string                 `json:"oci_file_system_id,omitempty"`
+	OCIExportID     string                 `json:"oci_export_id,omitempty"`
 }
 
 type CreateHiveRequest struct {
@@ -229,8 +231,12 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, logger *slog.Logger) err
 	if err != nil {
 		logger.Warn("OCI FSS creation failed — admin must create manually", "hive", h.ID, "error", err)
 	} else {
-		if exportErr := createOCIExport(fsID, exportPath, logger); exportErr != nil {
+		h.OCIFileSystemID = fsID
+		exportID, exportErr := createOCIExport(fsID, exportPath, logger)
+		if exportErr != nil {
 			logger.Warn("OCI export creation failed — admin must create manually", "hive", h.ID, "error", exportErr)
+		} else {
+			h.OCIExportID = exportID
 		}
 	}
 
@@ -265,6 +271,67 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, logger *slog.Logger) err
 
 	logger.Info("audit: saas hive provisioned", "hive_id", h.ID, "owner", h.Owner, "org", h.Org)
 	return nil
+}
+
+// deprovisionHive performs best-effort cleanup of all resources associated
+// with a hosted hive: K8s namespace (cascading to deployment, service, ingress,
+// configmap, secret, PVC), cluster-scoped PV, OCI NFS export, OCI file system,
+// and the on-disk SaaS hive record. It also decrements the owner's quota.
+// Order matters: namespace before PV, export before file system.
+// Errors are logged but do not stop the remaining cleanup steps.
+func deprovisionHive(h *SaaSHive, logger *slog.Logger) {
+	hiveID := h.ID
+
+	// Step 1: Delete K8s namespace (cascading delete removes deployment, service,
+	// ingress, configmap, secret, and PVC).
+	ns := "hive-hosted-" + hiveID
+	logger.Info("deprovision: deleting namespace", "namespace", ns)
+	cmd := exec.Command("kubectl", "delete", "namespace", ns, "--ignore-not-found")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		logger.Warn("deprovision: namespace delete failed", "namespace", ns, "output", string(out), "error", err)
+	}
+
+	// Step 2: Delete cluster-scoped PV (not removed by namespace deletion).
+	pvName := "hive-" + hiveID + "-fss-pv"
+	logger.Info("deprovision: deleting PV", "pv", pvName)
+	cmd = exec.Command("kubectl", "delete", "pv", pvName, "--ignore-not-found")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		logger.Warn("deprovision: PV delete failed", "pv", pvName, "output", string(out), "error", err)
+	}
+
+	// Step 3: Delete OCI NFS export (must happen before file system deletion).
+	if h.OCIExportID != "" {
+		logger.Info("deprovision: deleting OCI export", "exportID", h.OCIExportID)
+		if err := deleteOCIExport(h.OCIExportID, logger); err != nil {
+			logger.Warn("deprovision: OCI export delete failed", "exportID", h.OCIExportID, "error", err)
+		}
+	}
+
+	// Step 4: Delete OCI file system (must be empty of exports first).
+	if h.OCIFileSystemID != "" {
+		logger.Info("deprovision: deleting OCI file system", "fileSystemID", h.OCIFileSystemID)
+		if err := deleteOCIFileSystem(h.OCIFileSystemID, logger); err != nil {
+			logger.Warn("deprovision: OCI file system delete failed", "fileSystemID", h.OCIFileSystemID, "error", err)
+		}
+	}
+
+	// Step 5: Remove the on-disk SaaS hive record.
+	hiveDir := filepath.Join(saasHivesDir, hiveID)
+	if err := os.RemoveAll(hiveDir); err != nil {
+		logger.Warn("deprovision: failed to remove hive directory", "path", hiveDir, "error", err)
+	}
+
+	// Step 6: Remove hive from all user records (decrement quota).
+	for _, u := range listAllSaaSUsers() {
+		if _, ok := u.Hives[hiveID]; ok {
+			delete(u.Hives, hiveID)
+			if err := saveSaaSUser(&u); err != nil {
+				logger.Warn("deprovision: failed to update user record", "user", u.GitHubUsername, "error", err)
+			}
+		}
+	}
+
+	logger.Info("audit: hive deprovisioned", "hive_id", hiveID, "owner", h.Owner)
 }
 
 func StartProvisionWatcher(logger *slog.Logger, mu *sync.RWMutex) {

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -222,6 +222,18 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, logger *slog.Logger) err
 		}(),
 	}
 
+	// Auto-create OCI File System + NFS export for this hive.
+	// Failures are non-fatal — the admin can create them manually.
+	exportPath := nfsExportPathPrefix + h.ID
+	fsID, err := createOCIFileSystem("hive-"+h.ID, logger)
+	if err != nil {
+		logger.Warn("OCI FSS creation failed — admin must create manually", "hive", h.ID, "error", err)
+	} else {
+		if exportErr := createOCIExport(fsID, exportPath, logger); exportErr != nil {
+			logger.Warn("OCI export creation failed — admin must create manually", "hive", h.ID, "error", exportErr)
+		}
+	}
+
 	tmpl, err := template.New("manifests").Parse(k8sManifestTemplate)
 	if err != nil {
 		return fmt.Errorf("template parse: %w", err)

--- a/v2/pkg/proxy/anthropic_translate.go
+++ b/v2/pkg/proxy/anthropic_translate.go
@@ -1,0 +1,405 @@
+package proxy
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// translateAnthropicToOpenAI converts an Anthropic Messages API request body
+// into an OpenAI Chat Completions API request body, overriding the model.
+func translateAnthropicToOpenAI(body []byte, targetModel string) ([]byte, error) {
+	var req anthropicRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("unmarshal anthropic request: %w", err)
+	}
+
+	openaiReq := openaiRequest{
+		Model:     targetModel,
+		MaxTokens: req.MaxTokens,
+		Stream:    req.Stream,
+	}
+
+	if len(req.System) > 0 {
+		systemText := extractSystemText(req.System)
+		if systemText != "" {
+			openaiReq.Messages = append(openaiReq.Messages, openaiMessage{
+				Role:    "system",
+				Content: systemText,
+			})
+		}
+	}
+
+	for _, msg := range req.Messages {
+		text := extractTextFromContent(msg.Content)
+		openaiReq.Messages = append(openaiReq.Messages, openaiMessage{
+			Role:    msg.Role,
+			Content: text,
+		})
+	}
+
+	return json.Marshal(openaiReq)
+}
+
+// translateOpenAIResponseToAnthropic converts a non-streaming OpenAI Chat
+// Completions response into an Anthropic Messages response.
+func translateOpenAIResponseToAnthropic(body []byte, model string) ([]byte, error) {
+	var resp openaiResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal openai response: %w", err)
+	}
+
+	anthropicResp := anthropicResponse{
+		ID:   resp.ID,
+		Type: "message",
+		Role: "assistant",
+		Model: model,
+	}
+
+	if len(resp.Choices) > 0 {
+		anthropicResp.StopReason = mapFinishReason(resp.Choices[0].FinishReason)
+		anthropicResp.Content = []anthropicContentBlock{{
+			Type: "text",
+			Text: resp.Choices[0].Message.Content,
+		}}
+	} else {
+		anthropicResp.StopReason = "end_turn"
+		anthropicResp.Content = []anthropicContentBlock{{
+			Type: "text",
+			Text: "",
+		}}
+	}
+
+	if resp.Usage != nil {
+		anthropicResp.Usage = &anthropicUsage{
+			InputTokens:  resp.Usage.PromptTokens,
+			OutputTokens: resp.Usage.CompletionTokens,
+		}
+	} else {
+		anthropicResp.Usage = &anthropicUsage{
+			InputTokens:  0,
+			OutputTokens: 0,
+		}
+	}
+
+	return json.Marshal(anthropicResp)
+}
+
+// translateOpenAISSEToAnthropic reads an OpenAI SSE stream and writes the
+// equivalent Anthropic SSE events to the writer. The caller must close the
+// reader when done.
+func translateOpenAISSEToAnthropic(r io.Reader, w io.Writer, model string) error {
+	msgID := fmt.Sprintf("msg_%d", time.Now().UnixNano())
+
+	writeSSE(w, "message_start", anthropicSSEMessageStart{
+		Type: "message_start",
+		Message: anthropicSSEMessage{
+			ID:    msgID,
+			Type:  "message",
+			Role:  "assistant",
+			Model: model,
+			Content: []anthropicContentBlock{},
+			Usage: &anthropicUsage{InputTokens: 0, OutputTokens: 0},
+		},
+	})
+
+	writeSSE(w, "content_block_start", map[string]interface{}{
+		"type":          "content_block_start",
+		"index":         0,
+		"content_block": map[string]string{"type": "text", "text": ""},
+	})
+
+	scanner := bufio.NewScanner(r)
+	const maxSSELine = 256 * 1024
+	scanner.Buffer(make([]byte, maxSSELine), maxSSELine)
+
+	var totalOutputTokens int
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := line[len("data: "):]
+		if data == "[DONE]" {
+			break
+		}
+
+		var chunk openaiSSEChunk
+		if json.Unmarshal([]byte(data), &chunk) != nil {
+			continue
+		}
+
+		if len(chunk.Choices) > 0 {
+			delta := chunk.Choices[0].Delta
+			if delta.Content != "" {
+				writeSSE(w, "content_block_delta", map[string]interface{}{
+					"type":  "content_block_delta",
+					"index": 0,
+					"delta": map[string]string{
+						"type": "text_delta",
+						"text": delta.Content,
+					},
+				})
+			}
+
+			if chunk.Choices[0].FinishReason != "" {
+				writeSSE(w, "content_block_stop", map[string]interface{}{
+					"type":  "content_block_stop",
+					"index": 0,
+				})
+
+				writeSSE(w, "message_delta", map[string]interface{}{
+					"type": "message_delta",
+					"delta": map[string]string{
+						"stop_reason": mapFinishReason(chunk.Choices[0].FinishReason),
+					},
+					"usage": map[string]int{
+						"output_tokens": totalOutputTokens,
+					},
+				})
+			}
+		}
+
+		if chunk.Usage != nil {
+			totalOutputTokens = chunk.Usage.CompletionTokens
+		}
+	}
+
+	writeSSE(w, "message_stop", map[string]string{"type": "message_stop"})
+	return scanner.Err()
+}
+
+func writeSSE(w io.Writer, eventType string, data interface{}) {
+	jsonData, _ := json.Marshal(data)
+	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, jsonData)
+}
+
+func extractSystemText(raw json.RawMessage) string {
+	var str string
+	if json.Unmarshal(raw, &str) == nil {
+		return str
+	}
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &blocks) == nil {
+		var b strings.Builder
+		for _, block := range blocks {
+			if block.Type == "text" {
+				b.WriteString(block.Text)
+			}
+		}
+		return b.String()
+	}
+	return ""
+}
+
+func extractTextFromContent(content json.RawMessage) string {
+	var str string
+	if json.Unmarshal(content, &str) == nil {
+		return str
+	}
+
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(content, &blocks) == nil {
+		var b strings.Builder
+		for _, block := range blocks {
+			if block.Type == "text" {
+				b.WriteString(block.Text)
+			}
+		}
+		return b.String()
+	}
+	return string(content)
+}
+
+func mapFinishReason(reason string) string {
+	switch reason {
+	case "stop":
+		return "end_turn"
+	case "length":
+		return "max_tokens"
+	default:
+		return "end_turn"
+	}
+}
+
+// forwardToInference sends an Anthropic Messages API request to a vLLM/llm-d
+// endpoint, translating the request and response formats. It writes the
+// translated response directly to the provided http.ResponseWriter.
+func forwardToInference(clientReq *http.Request, clientBody []byte, w http.ResponseWriter, route *InferenceRoute) error {
+	openaiBody, err := translateAnthropicToOpenAI(clientBody, route.Model)
+	if err != nil {
+		return fmt.Errorf("translate request: %w", err)
+	}
+
+	upstreamURL := strings.TrimRight(route.Endpoint, "/") + "/v1/chat/completions"
+	upstreamReq, err := http.NewRequestWithContext(
+		clientReq.Context(), "POST", upstreamURL, bytes.NewReader(openaiBody))
+	if err != nil {
+		return fmt.Errorf("create upstream request: %w", err)
+	}
+	upstreamReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(upstreamReq)
+	if err != nil {
+		return fmt.Errorf("upstream request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		errBody, _ := io.ReadAll(resp.Body)
+		anthropicErr := map[string]interface{}{
+			"type": "error",
+			"error": map[string]interface{}{
+				"type":    "api_error",
+				"message": fmt.Sprintf("inference backend returned %d: %s", resp.StatusCode, string(errBody)),
+			},
+		}
+		errJSON, _ := json.Marshal(anthropicErr)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(resp.StatusCode)
+		_, writeErr := w.Write(errJSON)
+		return writeErr
+	}
+
+	isStreaming := resp.Header.Get("Content-Type") == "text/event-stream" ||
+		strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream")
+
+	if isStreaming {
+		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.WriteHeader(http.StatusOK)
+
+		if f, ok := w.(http.Flusher); ok {
+			flushWriter := &flushResponseWriter{w: w, f: f}
+			return translateOpenAISSEToAnthropic(resp.Body, flushWriter, route.Model)
+		}
+		return translateOpenAISSEToAnthropic(resp.Body, w, route.Model)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read upstream response: %w", err)
+	}
+
+	translated, err := translateOpenAIResponseToAnthropic(body, route.Model)
+	if err != nil {
+		return fmt.Errorf("translate response: %w", err)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, err = w.Write(translated)
+	return err
+}
+
+type flushResponseWriter struct {
+	w io.Writer
+	f http.Flusher
+}
+
+func (fw *flushResponseWriter) Write(p []byte) (int, error) {
+	n, err := fw.w.Write(p)
+	fw.f.Flush()
+	return n, err
+}
+
+// --- Request/response types ---
+
+type anthropicRequest struct {
+	Model     string             `json:"model"`
+	MaxTokens int                `json:"max_tokens"`
+	Messages  []anthropicMessage `json:"messages"`
+	System    json.RawMessage    `json:"system,omitempty"`
+	Stream    bool               `json:"stream,omitempty"`
+}
+
+type anthropicMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}
+
+type anthropicResponse struct {
+	ID           string                  `json:"id"`
+	Type         string                  `json:"type"`
+	Role         string                  `json:"role"`
+	Model        string                  `json:"model"`
+	Content      []anthropicContentBlock `json:"content"`
+	StopReason   string                  `json:"stop_reason"`
+	StopSequence *string                 `json:"stop_sequence"`
+	Usage        *anthropicUsage         `json:"usage,omitempty"`
+}
+
+type anthropicContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type anthropicUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+type anthropicSSEMessageStart struct {
+	Type    string            `json:"type"`
+	Message anthropicSSEMessage `json:"message"`
+}
+
+type anthropicSSEMessage struct {
+	ID      string                  `json:"id"`
+	Type    string                  `json:"type"`
+	Role    string                  `json:"role"`
+	Model   string                  `json:"model"`
+	Content []anthropicContentBlock `json:"content"`
+	Usage   *anthropicUsage         `json:"usage,omitempty"`
+}
+
+type openaiRequest struct {
+	Model     string          `json:"model"`
+	Messages  []openaiMessage `json:"messages"`
+	MaxTokens int             `json:"max_tokens,omitempty"`
+	Stream    bool            `json:"stream,omitempty"`
+}
+
+type openaiMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openaiResponse struct {
+	ID      string `json:"id"`
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage *openaiUsage `json:"usage,omitempty"`
+}
+
+type openaiUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+}
+
+type openaiSSEChunk struct {
+	Choices []struct {
+		Delta struct {
+			Content string `json:"content"`
+		} `json:"delta"`
+		FinishReason string `json:"finish_reason"`
+	} `json:"choices"`
+	Usage *openaiUsage `json:"usage,omitempty"`
+}

--- a/v2/pkg/proxy/anthropic_translate_test.go
+++ b/v2/pkg/proxy/anthropic_translate_test.go
@@ -1,0 +1,200 @@
+package proxy
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestTranslateAnthropicToOpenAI_StringSystem(t *testing.T) {
+	body := `{
+		"model": "claude-opus-4-6",
+		"max_tokens": 1024,
+		"system": "You are a helpful assistant.",
+		"messages": [
+			{"role": "user", "content": "Hello"}
+		],
+		"stream": true
+	}`
+
+	result, err := translateAnthropicToOpenAI([]byte(body), "Qwen/Qwen2.5-1.5B-Instruct")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var req openaiRequest
+	if err := json.Unmarshal(result, &req); err != nil {
+		t.Fatal(err)
+	}
+
+	if req.Model != "Qwen/Qwen2.5-1.5B-Instruct" {
+		t.Errorf("model = %q, want Qwen/Qwen2.5-1.5B-Instruct", req.Model)
+	}
+	if req.MaxTokens != 1024 {
+		t.Errorf("max_tokens = %d, want 1024", req.MaxTokens)
+	}
+	if !req.Stream {
+		t.Error("stream should be true")
+	}
+	if len(req.Messages) != 2 {
+		t.Fatalf("messages count = %d, want 2", len(req.Messages))
+	}
+	if req.Messages[0].Role != "system" {
+		t.Errorf("first message role = %q, want system", req.Messages[0].Role)
+	}
+	if req.Messages[0].Content != "You are a helpful assistant." {
+		t.Errorf("system content = %q", req.Messages[0].Content)
+	}
+	if req.Messages[1].Role != "user" || req.Messages[1].Content != "Hello" {
+		t.Errorf("user message = %+v", req.Messages[1])
+	}
+}
+
+func TestTranslateAnthropicToOpenAI_BlockSystem(t *testing.T) {
+	body := `{
+		"model": "claude-sonnet-4-6",
+		"max_tokens": 512,
+		"system": [{"type": "text", "text": "Be concise."}],
+		"messages": [
+			{"role": "user", "content": [{"type": "text", "text": "Hi"}]}
+		]
+	}`
+
+	result, err := translateAnthropicToOpenAI([]byte(body), "test-model")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var req openaiRequest
+	if err := json.Unmarshal(result, &req); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(req.Messages) != 2 {
+		t.Fatalf("messages count = %d, want 2", len(req.Messages))
+	}
+	if req.Messages[0].Content != "Be concise." {
+		t.Errorf("system = %q, want 'Be concise.'", req.Messages[0].Content)
+	}
+	if req.Messages[1].Content != "Hi" {
+		t.Errorf("user = %q, want 'Hi'", req.Messages[1].Content)
+	}
+}
+
+func TestTranslateOpenAIResponseToAnthropic(t *testing.T) {
+	resp := `{
+		"id": "chatcmpl-001",
+		"choices": [{
+			"message": {"content": "Hello there!"},
+			"finish_reason": "stop"
+		}],
+		"usage": {"prompt_tokens": 10, "completion_tokens": 3}
+	}`
+
+	result, err := translateOpenAIResponseToAnthropic([]byte(resp), "test-model")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var ar anthropicResponse
+	if err := json.Unmarshal(result, &ar); err != nil {
+		t.Fatal(err)
+	}
+
+	if ar.Type != "message" {
+		t.Errorf("type = %q, want message", ar.Type)
+	}
+	if ar.Role != "assistant" {
+		t.Errorf("role = %q, want assistant", ar.Role)
+	}
+	if ar.StopReason != "end_turn" {
+		t.Errorf("stop_reason = %q, want end_turn", ar.StopReason)
+	}
+	if len(ar.Content) != 1 || ar.Content[0].Text != "Hello there!" {
+		t.Errorf("content = %+v", ar.Content)
+	}
+	if ar.Usage == nil || ar.Usage.InputTokens != 10 || ar.Usage.OutputTokens != 3 {
+		t.Errorf("usage = %+v", ar.Usage)
+	}
+}
+
+func TestTranslateOpenAISSEToAnthropic(t *testing.T) {
+	sseInput := strings.Join([]string{
+		`data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}`,
+		``,
+		`data: {"choices":[{"delta":{"content":" world"},"finish_reason":null}]}`,
+		``,
+		`data: {"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2}}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	var buf strings.Builder
+	err := translateOpenAISSEToAnthropic(strings.NewReader(sseInput), &buf, "test-model")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	output := buf.String()
+
+	if !strings.Contains(output, "event: message_start") {
+		t.Error("missing message_start event")
+	}
+	if !strings.Contains(output, "event: content_block_start") {
+		t.Error("missing content_block_start event")
+	}
+	if !strings.Contains(output, `"text_delta"`) {
+		t.Error("missing text_delta in output")
+	}
+	if !strings.Contains(output, `"Hello"`) {
+		t.Error("missing 'Hello' text delta")
+	}
+	if !strings.Contains(output, `" world"`) {
+		t.Error("missing ' world' text delta")
+	}
+	if !strings.Contains(output, "event: content_block_stop") {
+		t.Error("missing content_block_stop event")
+	}
+	if !strings.Contains(output, "event: message_delta") {
+		t.Error("missing message_delta event")
+	}
+	if !strings.Contains(output, `"end_turn"`) {
+		t.Error("missing end_turn stop reason")
+	}
+	if !strings.Contains(output, "event: message_stop") {
+		t.Error("missing message_stop event")
+	}
+}
+
+func TestMapFinishReason(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"stop", "end_turn"},
+		{"length", "max_tokens"},
+		{"unknown", "end_turn"},
+		{"", "end_turn"},
+	}
+	for _, tt := range tests {
+		got := mapFinishReason(tt.input)
+		if got != tt.want {
+			t.Errorf("mapFinishReason(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestExtractTextFromContent_String(t *testing.T) {
+	got := extractTextFromContent(json.RawMessage(`"plain text"`))
+	if got != "plain text" {
+		t.Errorf("got %q, want 'plain text'", got)
+	}
+}
+
+func TestExtractTextFromContent_Blocks(t *testing.T) {
+	got := extractTextFromContent(json.RawMessage(`[{"type":"text","text":"hello"},{"type":"text","text":" world"}]`))
+	if got != "hello world" {
+		t.Errorf("got %q, want 'hello world'", got)
+	}
+}

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"bufio"
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -25,10 +26,11 @@ import (
 )
 
 const (
-	proxyListenPort = 18443
-	modeFilePrefix  = "/tmp/.hive-mode-"
-	maxViolationLog = 1000
-	CACertPath      = "/data/proxy-ca.pem"
+	proxyListenPort         = 18443
+	InferenceTranslatePort  = 18444
+	modeFilePrefix          = "/tmp/.hive-mode-"
+	maxViolationLog         = 1000
+	CACertPath              = "/data/proxy-ca.pem"
 )
 
 // GitHubProxy is an HTTP CONNECT proxy that performs MITM TLS
@@ -46,6 +48,8 @@ type GitHubProxy struct {
 
 	certMu    sync.RWMutex
 	certCache map[string]cachedCert
+
+	inference *inferenceRouter
 }
 
 type cachedCert struct {
@@ -89,6 +93,7 @@ func NewGitHubProxy(logger *slog.Logger, org string, repos []string) (*GitHubPro
 		allowedRepos: allowed,
 		violations:   make(map[string]int),
 		certCache:    make(map[string]cachedCert),
+		inference:    newInferenceRouter(),
 	}
 
 	// Pre-warm cert cache for known GitHub hosts to avoid startup burst
@@ -429,6 +434,14 @@ func (p *GitHubProxy) handleConnectDirect(conn net.Conn, r *http.Request) {
 	}
 
 	agentName := p.identifyAgentFromReq(r)
+
+	// Anthropic hosts with an inference route: reroute to self-hosted backend.
+	if IsAnthropicHost(host) {
+		if route := p.inference.Get(agentName); route != nil {
+			p.handleAnthropicReroute(conn, r, host, agentName, route)
+			return
+		}
+	}
 
 	// Non-GitHub hosts: tunnel without inspection.
 	if !IsGitHubHost(host) {
@@ -794,4 +807,273 @@ func newBufferedConn(c net.Conn) *bufio.Reader {
 
 func newBufferedReader(c net.Conn) *bufio.Reader {
 	return bufio.NewReader(c)
+}
+
+// SetInferenceRoute configures an agent to use a self-hosted inference backend.
+func (p *GitHubProxy) SetInferenceRoute(agentName string, route *InferenceRoute) {
+	p.inference.Set(agentName, route)
+	p.logger.Info("inference route set", "agent", agentName, "backend", route.Backend, "endpoint", route.Endpoint, "model", route.Model)
+}
+
+// ClearInferenceRoute removes an agent's inference backend override.
+func (p *GitHubProxy) ClearInferenceRoute(agentName string) {
+	p.inference.Clear(agentName)
+	p.logger.Info("inference route cleared", "agent", agentName)
+}
+
+// StartInferenceTranslator runs a plain HTTP server that accepts Anthropic
+// Messages API requests and translates+forwards them to the configured
+// inference backend. Agents use ANTHROPIC_BASE_URL=http://127.0.0.1:18444
+// to reach this server instead of api.anthropic.com.
+func (p *GitHubProxy) StartInferenceTranslator() error {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		apiKey := r.Header.Get("x-api-key")
+		agentName := strings.TrimPrefix(apiKey, "sk-hive-")
+
+		p.logger.Info("inference request",
+			"agent", agentName,
+			"method", r.Method,
+			"path", r.URL.Path,
+			"content-type", r.Header.Get("Content-Type"),
+			"anthropic-version", r.Header.Get("anthropic-version"),
+		)
+
+		route := p.inference.Get(agentName)
+		if route == nil {
+			p.logger.Warn("inference no route", "agent", agentName)
+			http.Error(w, `{"type":"error","error":{"type":"api_error","message":"no inference route for agent"}}`, http.StatusBadGateway)
+			return
+		}
+
+		body, err := io.ReadAll(r.Body)
+		if r.Body != nil {
+			r.Body.Close()
+		}
+		if err != nil {
+			http.Error(w, `{"type":"error","error":{"type":"api_error","message":"failed to read request"}}`, http.StatusBadRequest)
+			return
+		}
+
+		p.logger.Info("inference request body", "agent", agentName, "len", len(body), "preview", truncateBytes(body, 200))
+
+		openaiBody, err := translateAnthropicToOpenAI(body, route.Model)
+		if err != nil {
+			p.logger.Error("inference translate request failed", "agent", agentName, "error", err)
+			http.Error(w, fmt.Sprintf(`{"type":"error","error":{"type":"api_error","message":"translation error: %s"}}`, err.Error()), http.StatusBadGateway)
+			return
+		}
+
+		upstreamURL := strings.TrimRight(route.Endpoint, "/") + "/v1/chat/completions"
+		upstreamReq, err := http.NewRequestWithContext(r.Context(), "POST", upstreamURL, bytes.NewReader(openaiBody))
+		if err != nil {
+			http.Error(w, `{"type":"error","error":{"type":"api_error","message":"failed to create upstream request"}}`, http.StatusBadGateway)
+			return
+		}
+		upstreamReq.Header.Set("Content-Type", "application/json")
+
+		p.logger.Info("inference forward",
+			"agent", agentName,
+			"backend", route.Backend,
+			"model", route.Model,
+			"url", upstreamURL,
+			"openai_body", truncateBytes(openaiBody, 300),
+		)
+
+		resp, err := http.DefaultClient.Do(upstreamReq)
+		if err != nil {
+			p.logger.Error("inference upstream failed", "agent", agentName, "error", err)
+			http.Error(w, fmt.Sprintf(`{"type":"error","error":{"type":"api_error","message":"inference backend unreachable: %s"}}`, err.Error()), http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+
+		p.logger.Info("inference upstream response",
+			"agent", agentName,
+			"status", resp.StatusCode,
+			"content-type", resp.Header.Get("Content-Type"),
+		)
+
+		isStreaming := strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream")
+
+		if isStreaming {
+			w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.Header().Set("Connection", "keep-alive")
+			w.WriteHeader(http.StatusOK)
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			if err := translateOpenAISSEToAnthropic(resp.Body, w, route.Model); err != nil {
+				p.logger.Error("inference SSE translation failed", "agent", agentName, "error", err)
+			}
+			return
+		}
+
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			http.Error(w, `{"type":"error","error":{"type":"api_error","message":"failed to read inference response"}}`, http.StatusBadGateway)
+			return
+		}
+
+		p.logger.Info("inference upstream raw response",
+			"agent", agentName,
+			"len", len(respBody),
+			"preview", truncateBytes(respBody, 500),
+		)
+
+		translated, err := translateOpenAIResponseToAnthropic(respBody, route.Model)
+		if err != nil {
+			p.logger.Error("inference translate response failed", "agent", agentName, "error", err)
+			http.Error(w, `{"type":"error","error":{"type":"api_error","message":"response translation error"}}`, http.StatusBadGateway)
+			return
+		}
+
+		p.logger.Info("inference translated response",
+			"agent", agentName,
+			"len", len(translated),
+			"preview", truncateBytes(translated, 500),
+		)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(translated)
+	})
+
+	addr := fmt.Sprintf("127.0.0.1:%d", InferenceTranslatePort)
+	p.logger.Info("inference translation server starting", "addr", addr)
+	server := &http.Server{Addr: addr, Handler: mux}
+	return server.ListenAndServe()
+}
+
+// handleAnthropicReroute performs MITM on an Anthropic API connection and
+// reroutes requests to a self-hosted vLLM/llm-d endpoint, translating
+// between Anthropic and OpenAI API formats.
+func (p *GitHubProxy) handleAnthropicReroute(conn net.Conn, r *http.Request, host, agentName string, route *InferenceRoute) {
+	p.logger.Info("inference reroute", "agent", agentName, "backend", route.Backend, "host", host)
+
+	if _, err := fmt.Fprintf(conn, "HTTP/1.1 200 Connection established\r\n\r\n"); err != nil {
+		p.logger.Error("inference reroute: CONNECT response failed", "error", err)
+		return
+	}
+
+	tlsCert, err := p.forgeCert(host)
+	if err != nil {
+		p.logger.Error("inference reroute: forge cert failed", "host", host, "error", err)
+		return
+	}
+
+	tlsConn := tls.Server(conn, &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+	})
+	if err := tlsConn.Handshake(); err != nil {
+		p.logger.Warn("inference reroute: TLS handshake failed", "error", err)
+		return
+	}
+	defer tlsConn.Close()
+
+	clientBuf := bufio.NewReader(tlsConn)
+	for {
+		req, err := http.ReadRequest(clientBuf)
+		if err != nil {
+			return
+		}
+
+		p.handleInferenceRequest(tlsConn, req, agentName, route)
+	}
+}
+
+// handleInferenceRequest translates a single Anthropic API request and
+// forwards it to the inference backend.
+func (p *GitHubProxy) handleInferenceRequest(conn net.Conn, req *http.Request, agentName string, route *InferenceRoute) {
+	body, err := io.ReadAll(req.Body)
+	if req.Body != nil {
+		req.Body.Close()
+	}
+	if err != nil {
+		p.writeHTTPError(conn, http.StatusBadGateway, "failed to read request body")
+		return
+	}
+
+	openaiBody, err := translateAnthropicToOpenAI(body, route.Model)
+	if err != nil {
+		p.logger.Error("inference translate request failed", "agent", agentName, "error", err)
+		p.writeHTTPError(conn, http.StatusBadGateway, "translation error: "+err.Error())
+		return
+	}
+
+	upstreamURL := strings.TrimRight(route.Endpoint, "/") + "/v1/chat/completions"
+	upstreamReq, err := http.NewRequestWithContext(req.Context(), "POST", upstreamURL, bytes.NewReader(openaiBody))
+	if err != nil {
+		p.writeHTTPError(conn, http.StatusBadGateway, "failed to create upstream request")
+		return
+	}
+	upstreamReq.Header.Set("Content-Type", "application/json")
+
+	p.logger.Info("inference forward", "agent", agentName, "backend", route.Backend, "model", route.Model, "url", upstreamURL)
+
+	resp, err := http.DefaultClient.Do(upstreamReq)
+	if err != nil {
+		p.logger.Error("inference upstream failed", "agent", agentName, "error", err)
+		p.writeHTTPError(conn, http.StatusBadGateway, "inference backend unreachable: "+err.Error())
+		return
+	}
+	defer resp.Body.Close()
+
+	isStreaming := strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream")
+
+	if isStreaming {
+		hdr := "HTTP/1.1 200 OK\r\n" +
+			"Content-Type: text/event-stream; charset=utf-8\r\n" +
+			"Cache-Control: no-cache\r\n" +
+			"Connection: keep-alive\r\n\r\n"
+		if _, err := conn.Write([]byte(hdr)); err != nil {
+			return
+		}
+		if err := translateOpenAISSEToAnthropic(resp.Body, conn, route.Model); err != nil {
+			p.logger.Error("inference SSE translation failed", "agent", agentName, "error", err)
+		}
+		return
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		p.writeHTTPError(conn, http.StatusBadGateway, "failed to read inference response")
+		return
+	}
+
+	translated, err := translateOpenAIResponseToAnthropic(respBody, route.Model)
+	if err != nil {
+		p.logger.Error("inference translate response failed", "agent", agentName, "error", err)
+		p.writeHTTPError(conn, http.StatusBadGateway, "response translation error")
+		return
+	}
+
+	httpResp := &http.Response{
+		StatusCode: http.StatusOK,
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader(translated)),
+	}
+	httpResp.Write(conn)
+}
+
+func (p *GitHubProxy) writeHTTPError(conn net.Conn, status int, msg string) {
+	resp := &http.Response{
+		StatusCode: status,
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(fmt.Sprintf(`{"type":"error","error":{"type":"api_error","message":"%s"}}`, msg))),
+	}
+	resp.Write(conn)
+}
+
+func truncateBytes(b []byte, max int) string {
+	if len(b) <= max {
+		return string(b)
+	}
+	return string(b[:max]) + "..."
 }

--- a/v2/pkg/proxy/inference_integration_test.go
+++ b/v2/pkg/proxy/inference_integration_test.go
@@ -1,0 +1,222 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func startMockVLLM(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Model    string          `json:"model"`
+			Messages json.RawMessage `json:"messages"`
+			Stream   bool            `json:"stream"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if req.Stream {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			flusher := w.(http.Flusher)
+
+			chunks := []string{"Hello", " from", " vLLM!"}
+			for _, c := range chunks {
+				data, _ := json.Marshal(map[string]interface{}{
+					"choices": []map[string]interface{}{
+						{"delta": map[string]string{"content": c}, "finish_reason": nil},
+					},
+				})
+				fmt.Fprintf(w, "data: %s\n\n", data)
+				flusher.Flush()
+			}
+
+			finalData, _ := json.Marshal(map[string]interface{}{
+				"choices": []map[string]interface{}{
+					{"delta": map[string]string{}, "finish_reason": "stop"},
+				},
+				"usage": map[string]int{"prompt_tokens": 10, "completion_tokens": 3},
+			})
+			fmt.Fprintf(w, "data: %s\n\n", finalData)
+			fmt.Fprintf(w, "data: [DONE]\n\n")
+			flusher.Flush()
+			return
+		}
+
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id": "chatcmpl-test",
+			"choices": []map[string]interface{}{
+				{
+					"message":       map[string]string{"role": "assistant", "content": "Mock response for " + req.Model},
+					"finish_reason": "stop",
+				},
+			},
+			"usage": map[string]int{"prompt_tokens": 10, "completion_tokens": 5},
+		})
+	}))
+}
+
+func TestForwardToInference_NonStreaming(t *testing.T) {
+	mock := startMockVLLM(t)
+	defer mock.Close()
+
+	anthropicBody := `{
+		"model": "claude-opus-4-6",
+		"max_tokens": 1024,
+		"system": "You are a test assistant.",
+		"messages": [{"role": "user", "content": "Say hello"}],
+		"stream": false
+	}`
+
+	route := &InferenceRoute{
+		Backend:  "vllm",
+		Endpoint: mock.URL,
+		Model:    "test-model",
+	}
+
+	req, _ := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", strings.NewReader(anthropicBody))
+	w := httptest.NewRecorder()
+
+	err := forwardToInference(req, []byte(anthropicBody), w, route)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var ar anthropicResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ar); err != nil {
+		t.Fatal(err)
+	}
+
+	if ar.Type != "message" {
+		t.Errorf("type = %q, want message", ar.Type)
+	}
+	if ar.Role != "assistant" {
+		t.Errorf("role = %q, want assistant", ar.Role)
+	}
+	if len(ar.Content) == 0 {
+		t.Fatal("no content blocks")
+	}
+	if !strings.Contains(ar.Content[0].Text, "test-model") {
+		t.Errorf("response text = %q, expected to contain 'test-model'", ar.Content[0].Text)
+	}
+	if ar.StopReason != "end_turn" {
+		t.Errorf("stop_reason = %q, want end_turn", ar.StopReason)
+	}
+	if ar.Usage == nil {
+		t.Fatal("usage is nil")
+	}
+	if ar.Usage.InputTokens != 10 {
+		t.Errorf("input_tokens = %d, want 10", ar.Usage.InputTokens)
+	}
+}
+
+func TestForwardToInference_Streaming(t *testing.T) {
+	mock := startMockVLLM(t)
+	defer mock.Close()
+
+	anthropicBody := `{
+		"model": "claude-opus-4-6",
+		"max_tokens": 1024,
+		"messages": [{"role": "user", "content": "Hello"}],
+		"stream": true
+	}`
+
+	route := &InferenceRoute{
+		Backend:  "vllm",
+		Endpoint: mock.URL,
+		Model:    "test-model",
+	}
+
+	req, _ := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", strings.NewReader(anthropicBody))
+	w := httptest.NewRecorder()
+
+	err := forwardToInference(req, []byte(anthropicBody), w, route)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := w.Body.String()
+
+	expectedEvents := []string{
+		"event: message_start",
+		"event: content_block_start",
+		"event: content_block_delta",
+		"event: content_block_stop",
+		"event: message_delta",
+		"event: message_stop",
+	}
+	for _, evt := range expectedEvents {
+		if !strings.Contains(body, evt) {
+			t.Errorf("missing event: %s", evt)
+		}
+	}
+
+	if !strings.Contains(body, "Hello") {
+		t.Error("missing 'Hello' in SSE output")
+	}
+	if !strings.Contains(body, "vLLM!") {
+		t.Error("missing 'vLLM!' in SSE output")
+	}
+	if !strings.Contains(body, `"end_turn"`) {
+		t.Error("missing end_turn stop reason")
+	}
+}
+
+func TestInferenceRouter(t *testing.T) {
+	router := newInferenceRouter()
+
+	if got := router.Get("agent-1"); got != nil {
+		t.Error("expected nil for unknown agent")
+	}
+
+	route := &InferenceRoute{Backend: "vllm", Endpoint: "http://localhost:8000", Model: "test"}
+	router.Set("agent-1", route)
+
+	got := router.Get("agent-1")
+	if got == nil {
+		t.Fatal("expected route for agent-1")
+	}
+	if got.Backend != "vllm" {
+		t.Errorf("backend = %q, want vllm", got.Backend)
+	}
+
+	router.Clear("agent-1")
+	if got := router.Get("agent-1"); got != nil {
+		t.Error("expected nil after clear")
+	}
+}
+
+func TestIsAnthropicHost(t *testing.T) {
+	if !IsAnthropicHost("api.anthropic.com") {
+		t.Error("api.anthropic.com should be anthropic host")
+	}
+	if IsAnthropicHost("api.openai.com") {
+		t.Error("api.openai.com should not be anthropic host")
+	}
+}
+
+func TestIsInferenceBackend(t *testing.T) {
+	_ = time.Now() // suppress unused import
+	if !IsInferenceBackend("vllm") {
+		t.Error("vllm should be inference backend")
+	}
+	if !IsInferenceBackend("llm-d") {
+		t.Error("llm-d should be inference backend")
+	}
+	if IsInferenceBackend("claude") {
+		t.Error("claude should not be inference backend")
+	}
+}

--- a/v2/pkg/proxy/inference_route.go
+++ b/v2/pkg/proxy/inference_route.go
@@ -1,0 +1,66 @@
+package proxy
+
+import "sync"
+
+// InferenceRoute defines where to send an agent's API traffic when using
+// a self-hosted inference backend instead of the cloud API.
+type InferenceRoute struct {
+	Backend  string // "vllm" or "llm-d"
+	Endpoint string // e.g. "http://vllm-svc.hive.svc.cluster.local:8000"
+	Model    string // e.g. "Qwen/Qwen2.5-1.5B-Instruct"
+}
+
+// inferenceRouter manages per-agent inference backend routing.
+type inferenceRouter struct {
+	mu     sync.RWMutex
+	routes map[string]*InferenceRoute // agent name → route
+}
+
+func newInferenceRouter() *inferenceRouter {
+	return &inferenceRouter{
+		routes: make(map[string]*InferenceRoute),
+	}
+}
+
+func (ir *inferenceRouter) Set(agentName string, route *InferenceRoute) {
+	ir.mu.Lock()
+	defer ir.mu.Unlock()
+	ir.routes[agentName] = route
+}
+
+func (ir *inferenceRouter) Clear(agentName string) {
+	ir.mu.Lock()
+	defer ir.mu.Unlock()
+	delete(ir.routes, agentName)
+}
+
+func (ir *inferenceRouter) Get(agentName string) *InferenceRoute {
+	ir.mu.RLock()
+	defer ir.mu.RUnlock()
+	return ir.routes[agentName]
+}
+
+// anthropicHosts are hosts that should be intercepted when an agent has
+// an inference route configured.
+var anthropicHosts = map[string]bool{
+	"api.anthropic.com": true,
+}
+
+// IsAnthropicHost returns true if the host is an Anthropic API endpoint.
+func IsAnthropicHost(host string) bool {
+	return anthropicHosts[host]
+}
+
+// InferenceBackends lists the valid self-hosted inference backend IDs.
+var InferenceBackends = []string{"vllm", "llm-d"}
+
+// IsInferenceBackend returns true if the backend name is a self-hosted
+// inference backend rather than a CLI tool.
+func IsInferenceBackend(backend string) bool {
+	for _, b := range InferenceBackends {
+		if b == backend {
+			return true
+		}
+	}
+	return false
+}

--- a/v2/test/mock_vllm.go
+++ b/v2/test/mock_vllm.go
@@ -1,0 +1,167 @@
+// mock_vllm.go — a minimal OpenAI Chat Completions API server for testing
+// the Anthropic ↔ OpenAI proxy translation layer.
+//
+// Usage: go run test/mock_vllm.go [-port 8000] [-stream]
+//
+// Responds to POST /v1/chat/completions with either a non-streaming JSON
+// response or an SSE stream, depending on the request's "stream" field.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+)
+
+func main() {
+	port := flag.Int("port", 8000, "listen port")
+	flag.Parse()
+
+	http.HandleFunc("/v1/chat/completions", handleCompletions)
+	http.HandleFunc("/v1/models", handleModels)
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	addr := fmt.Sprintf(":%d", *port)
+	log.Printf("[mock-vllm] listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, nil))
+}
+
+func handleModels(w http.ResponseWriter, r *http.Request) {
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"data": []map[string]string{
+			{"id": "Qwen/Qwen2.5-1.5B-Instruct", "object": "model"},
+		},
+	})
+}
+
+func handleCompletions(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Model    string `json:"model"`
+		Messages []struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"messages"`
+		Stream    bool `json:"stream"`
+		MaxTokens int  `json:"max_tokens"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	log.Printf("[mock-vllm] model=%s stream=%v messages=%d", req.Model, req.Stream, len(req.Messages))
+	for i, m := range req.Messages {
+		preview := m.Content
+		const maxPreview = 100
+		if len(preview) > maxPreview {
+			preview = preview[:maxPreview] + "..."
+		}
+		log.Printf("  msg[%d] role=%s: %s", i, m.Role, preview)
+	}
+
+	responseText := fmt.Sprintf("Hello from mock vLLM! Model: %s. I received %d messages. "+
+		"The last message was from '%s'.",
+		req.Model, len(req.Messages),
+		req.Messages[len(req.Messages)-1].Role)
+
+	if req.Stream {
+		handleStreamingResponse(w, req.Model, responseText)
+		return
+	}
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"id":      "chatcmpl-mock-001",
+		"object":  "chat.completion",
+		"created": time.Now().Unix(),
+		"model":   req.Model,
+		"choices": []map[string]interface{}{
+			{
+				"index": 0,
+				"message": map[string]string{
+					"role":    "assistant",
+					"content": responseText,
+				},
+				"finish_reason": "stop",
+			},
+		},
+		"usage": map[string]int{
+			"prompt_tokens":     42,
+			"completion_tokens": 20,
+			"total_tokens":      62,
+		},
+	})
+}
+
+func handleStreamingResponse(w http.ResponseWriter, model, text string) {
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	words := strings.Fields(text)
+	const chunkDelayMs = 50
+
+	for i, word := range words {
+		content := word
+		if i < len(words)-1 {
+			content += " "
+		}
+
+		chunk := map[string]interface{}{
+			"id":      "chatcmpl-mock-001",
+			"object":  "chat.completion.chunk",
+			"created": time.Now().Unix(),
+			"model":   model,
+			"choices": []map[string]interface{}{
+				{
+					"index": 0,
+					"delta": map[string]string{
+						"content": content,
+					},
+					"finish_reason": nil,
+				},
+			},
+		}
+
+		data, _ := json.Marshal(chunk)
+		fmt.Fprintf(w, "data: %s\n\n", data)
+		flusher.Flush()
+		time.Sleep(chunkDelayMs * time.Millisecond)
+	}
+
+	// Final chunk with finish_reason
+	finalChunk := map[string]interface{}{
+		"id":      "chatcmpl-mock-001",
+		"object":  "chat.completion.chunk",
+		"created": time.Now().Unix(),
+		"model":   model,
+		"choices": []map[string]interface{}{
+			{
+				"index":         0,
+				"delta":         map[string]string{},
+				"finish_reason": "stop",
+			},
+		},
+		"usage": map[string]int{
+			"prompt_tokens":     42,
+			"completion_tokens": len(words),
+			"total_tokens":      42 + len(words),
+		},
+	}
+	data, _ := json.Marshal(finalChunk)
+	fmt.Fprintf(w, "data: %s\n\n", data)
+	fmt.Fprintf(w, "data: [DONE]\n\n")
+	flusher.Flush()
+}


### PR DESCRIPTION
## Summary
Rebases v3 onto current v2 HEAD so v3 has **all v2 functionality** plus the v3 inference additions.

**v3 was 2,159 commits behind v2** — missing inception engine fixes, hub provisioning, permissions watcher, agent export/import, leaderboard, and dozens of other features.

### What this PR does
- Starts from v2 HEAD (commit `7f58b17`)
- Applies v3's inference-only additions on top (17 files, +2,336 lines)
- **Zero v2 deletions** — all v2 functionality preserved

### v3 inference additions preserved
- `cmd/apiproxy/` — Anthropic-to-vLLM/llm-d translation proxy
- `pkg/apiproxy/proxy.go` — proxy server implementation
- `pkg/proxy/anthropic_translate.go` — Anthropic ↔ OpenAI format translation
- `pkg/proxy/inference_route.go` — inference routing in github_proxy
- `deploy/inference/` — vLLM + llm-d K8s manifests
- `pkg/agent/manager.go` — inference agent support (NO_PROXY, prompt dismissal)
- `pkg/dashboard/static/index.html` — inference backend UI (vllm/llm-d selectors)
- `pkg/hub/heartbeat.go` — inference status in heartbeats
- `.github/workflows/docker.yml` — v3 branch trigger

### v2 features restored (were missing from v3)
- Full hub provisioning (OCI FSS, saas_provision)
- Permissions watcher
- Agent export/import/prompt save
- All 31 inception engine bug fixes from this session
- Dashboard features (leaderboard, collapsible sections, etc.)
- 648 unit tests, 7M+ fuzz iterations

## Test plan
- [x] `go build ./cmd/... ./pkg/...` passes
- [x] `go test ./pkg/proxy/` passes
- [x] `go test ./pkg/knowledge/` passes
- [ ] Docker CI builds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)