### PR TITLE
fix: auto-upgrade skips hives with empty provisioning status

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1439,7 +1439,12 @@ func (s *HubServer) StartLatestSHAPoller() {
 func (s *HubServer) triggerAutoUpgrades() {
 	hives := listSaaSHives()
 	for _, h := range hives {
-		if !h.AutoUpgrade || h.Status != "running" {
+		if !h.AutoUpgrade {
+			continue
+		}
+		// Skip hives that are actively provisioning or in error state.
+		// Empty status means the hive predates the provisioning system — treat as eligible.
+		if h.Status == "provisioning" || h.Status == "error" {
 			continue
 		}
 		s.mu.RLock()


### PR DESCRIPTION
## Summary
`triggerAutoUpgrades()` required `h.Status == "running"`, but hives created before the provisioning status system (like aslom's) have an empty status field. These hives were silently excluded from auto-upgrade even with the toggle enabled.

Changed to a deny-list approach: skip only `"provisioning"` and `"error"` states. Empty/unknown status is treated as eligible — these are established hives that are clearly online.

## Test plan
- [x] `go build ./pkg/hub/` compiles clean
- [ ] After merge + hub auto-upgrade, aslom's hive should auto-upgrade on the next 2-minute poll cycle