### PR TITLE
fix: auto-upgrade reliability — retry, race guard, stale error clearing

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1414,6 +1414,8 @@ func (s *HubServer) StartLatestSHAPoller() {
 		oldSHAs := getLatestSHAs()
 		fetchAllBranchSHAs(s.logger)
 		newSHAs := getLatestSHAs()
+		// Always check for pending auto-upgrades (retries failed/missed hives).
+		s.triggerAutoUpgrades()
 		changed := false
 		for branch, sha := range newSHAs {
 			if sha != "" && sha != oldSHAs[branch] {
@@ -1422,7 +1424,6 @@ func (s *HubServer) StartLatestSHAPoller() {
 			}
 		}
 		if changed {
-			s.triggerAutoUpgrades()
 			// Hub auto-upgrade (hub runs on v2)
 			hubBranchSHA := getLatestSHAForBranch("v2")
 			if isHubAutoUpgrade() && hubBranchSHA != "" && hubBranchSHA != s.hubGitHash {
@@ -1459,6 +1460,9 @@ func (s *HubServer) triggerAutoUpgrades() {
 		s.mu.RUnlock()
 		if branch == "" {
 			branch = "v2"
+		}
+		if currentSHA == "" {
+			continue
 		}
 		latestSHA := getLatestSHAForBranch(branch)
 		if latestSHA == "" || currentSHA == latestSHA {

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -364,6 +364,14 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			}
 			s.registry.Hives[i] = entry
 			found = true
+			// Clear stale "error" status on SaaS hives that are actively heartbeating.
+			if strings.HasPrefix(payload.HiveID, "hosted-") {
+				if sh := loadSaaSHive(payload.HiveID); sh != nil && sh.Status == "error" {
+					sh.Status = "running"
+					sh.Error = ""
+					_ = saveSaaSHive(sh)
+				}
+			}
 			break
 		}
 	}


### PR DESCRIPTION
## Summary
- **Clear stale error status on heartbeat**: When a hosted hive sends a heartbeat (proving it's running fine), any leftover `status: "error"` from a past provisioning failure is automatically cleared to `"running"`. This was the root cause of aslom's hive being skipped for auto-upgrade despite being online and having auto-upgrade enabled.
- **Skip unconnected hives at startup**: `triggerAutoUpgrades()` now skips hives with empty `currentSHA` (not yet connected via WebSocket), preventing needless rollout restarts during hub startup before spokes have reconnected.
- **Retry on every poll tick**: `triggerAutoUpgrades()` now runs every 2-minute poll cycle instead of only when the latest SHA changes. This ensures failed or missed upgrades are retried automatically rather than requiring a new code push or hub restart.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/hub/` passes (all hub tests)
- [ ] CI build/lint