### PR TITLE
fix: permissions watcher — skip agent-owned files and pre-create goose logs dir

### DIFF
--- a/v2/pkg/agent/permissions_watcher.go
+++ b/v2/pkg/agent/permissions_watcher.go
@@ -36,6 +36,11 @@ var WatchedHomeDirs = []string{
 	"/data/home/.local",
 }
 
+// GooseLogsDir is the rolling log directory goose 1.37 creates on startup.
+// Goose panics if this directory doesn't exist, so the watcher ensures it
+// is created at startup with correct permissions.
+const GooseLogsDir = "/data/home/.local/state/goose/logs/cli"
+
 // StartPermissionsWatcher runs a background goroutine that periodically
 // scans WatchedHomeDirs and fixes files/directories that were created
 // with wrong ownership (e.g., root-owned by Copilot CLI).
@@ -65,7 +70,8 @@ func StartPermissionsWatcher(logger *slog.Logger) {
 // ensureWatchedDirs creates each watched directory if it does not exist
 // and sets correct ownership.
 func ensureWatchedDirs(logger *slog.Logger) {
-	for _, dir := range WatchedHomeDirs {
+	allDirs := append([]string{GooseLogsDir}, WatchedHomeDirs...)
+	for _, dir := range allDirs {
 		if err := os.MkdirAll(dir, DirPerms|0o070); err != nil {
 			logger.Warn("permissions watcher: failed to create directory",
 				"path", dir,
@@ -150,6 +156,13 @@ func fixEntry(path string, fi os.FileInfo, logger *slog.Logger) {
 				"new_gid", NodeGID,
 			)
 		}
+	}
+
+	// Only fix permissions on files we own or just chowned.
+	// Skipping files owned by other users avoids "operation not permitted"
+	// spam when agents create files as their own users.
+	if newUID != DevUID && stat.Uid != uint32(DevUID) {
+		return
 	}
 
 	mode := fi.Mode()


### PR DESCRIPTION
Two fixes for the permissions watcher (#1581):

### Fix 1: Skip chmod on agent-owned files

The watcher attempted `os.Chmod()` on every file under `/data/home/`, including files owned by agent users (e.g., `hive-scanner`, uid 2007). Since the watcher runs as `dev` (uid 1001), chmod fails with "operation not permitted", producing log spam every 10 seconds:

```
permissions watcher: chmod file failed
  path="/data/home/.local/state/goose/logs/cli/2026-06-17/20260617_041606.log"
  error="operation not permitted"
```

Now skips files not owned by root (pre-chown) or the dev user.

### Fix 2: Pre-create goose 1.37 log directory

Goose 1.37 uses `tracing-appender` for rolling file logging. On first startup, it tries to create files under `~/.local/state/goose/logs/cli/YYYY-MM-DD/`. If the parent directory tree doesn't exist, goose panics:

```
initializing rolling file appender failed: InitError { context: "failed to create log file", source: Os { code: 13, kind: PermissionDenied, message: "Permission denied" } }
Error: goose-cli main thread panicked
```

This causes ALL goose-backed agents to fail on startup (ci-maintainer, sec-check, supervisor, outreach, guide, architect via pi→goose mapping, scanner via goose).

The watcher now pre-creates `/data/home/.local/state/goose/logs/cli/` in `ensureWatchedDirs()`.

## Testing

- [x] Compiles: `go build ./pkg/agent/`
- [x] Unit tests pass
- [x] Verified in production: hive hub with 9 agents, no panics, no chmod spam