### PR TITLE
fix: correct GitHub App install URL slug and path

### DIFF
--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -417,7 +417,7 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 	s.broadcastFrame(fmt.Sprintf("data: %s\n\n", data))
 }
 
-const GitHubAppInstallURL = "https://github.com/apps/hive-hub/installations/select_target_repositories"
+const GitHubAppInstallURL = "https://github.com/apps/kubestellar-hive/installations/new"
 
 func (s *Server) SetGitHubAppRequired(required bool) {
 	s.githubAppMu.Lock()


### PR DESCRIPTION
## Summary
- The install button in the Hive dashboard pointed to `https://github.com/apps/hive-hub/installations/select_target_repositories`, which returns a 404 because no GitHub App with slug `hive-hub` exists
- The actual app slug is `kubestellar-hive` (installed on kubestellar org since 2026-05-01)
- Changed path from `/installations/select_target_repositories` (requires existing install) to `/installations/new` (for fresh installs)

Fixes the 404 Daniel Waddington reported when clicking "Install GitHub App" in the dashboard.

## Test plan
- [ ] Click "Install GitHub App" in Hive dashboard and verify it loads the correct GitHub App installation page