### PR TITLE
fix: show commit message inline next to SHA

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2843,7 +2843,7 @@ const dashboardHTML = `<!DOCTYPE html>
             for (var bi = 0; bi < branches.length; bi++) {
               var br = branches[bi];
               var brMsg = _latestSHAMessages[br] || '';
-              lines += '<div style="display:flex;align-items:center;gap:6px;margin-bottom:2px"><span style="display:inline-block;padding:1px 6px;border-radius:9999px;font-size:0.6rem;background:rgba(59,130,246,0.15);color:#60a5fa;border:1px solid rgba(59,130,246,0.3)">' + esc(br) + '</span><span style="font-family:monospace;color:var(--muted)" title="' + esc(brMsg) + '">' + esc(_latestSHAs[br]) + '</span></div>';
+              lines += '<div style="display:flex;align-items:center;gap:6px;margin-bottom:2px"><span style="display:inline-block;padding:1px 6px;border-radius:9999px;font-size:0.6rem;background:rgba(59,130,246,0.15);color:#60a5fa;border:1px solid rgba(59,130,246,0.3)">' + esc(br) + '</span><span style="font-family:monospace;color:var(--muted)">' + esc(_latestSHAs[br]) + '</span>' + (brMsg ? '<span style="font-size:0.7rem;color:var(--muted);opacity:0.7">: ' + esc(brMsg) + '</span>' : '') + '</div>';
             }
           } else if (_latestSHA) {
             lines = '<span style="font-family:monospace;color:var(--muted)">' + esc(_latestSHA) + '</span>';


### PR DESCRIPTION
## Summary
- The "Latest images" section showed the commit message only on hover (tooltip)
- Changed to display it inline as visible text: `v2  916611e : fix: move mock_vllm to its own package...`
- Message is slightly dimmed (opacity 0.7) to keep the SHA prominent

## Test plan
- [ ] Verify "Latest images" section shows `<SHA> : <commit message>` instead of requiring hover