### PR TITLE
fix: prevent auto-upgrade restart loop for hives with many agents

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1485,14 +1485,19 @@ func (s *HubServer) triggerAutoUpgrades() {
 		}
 		s.mu.RLock()
 		var currentSHA, branch string
+		var alreadyUpgrading bool
 		for _, reg := range s.registry.Hives {
 			if reg.ID == h.ID {
 				currentSHA = reg.GitHash
 				branch = reg.GitBranch
+				alreadyUpgrading = reg.Upgrading
 				break
 			}
 		}
 		s.mu.RUnlock()
+		if alreadyUpgrading {
+			continue
+		}
 		if branch == "" {
 			branch = "v2"
 		}


### PR DESCRIPTION
## Summary
- `triggerAutoUpgrades()` didn't check the `Upgrading` flag before issuing `kubectl rollout restart`
- For hives with many agents (10 agents × 15s stagger = ~150s startup), the old pod keeps reporting the old SHA while the new pod starts up
- Each poll cycle saw a SHA mismatch and fired another restart, killing the in-progress pod — infinite restart loop
- Fix: skip hives that already have `Upgrading=true`

This was observed on the `kubestellar/console` hive (L6, 10 agents) which was stuck in a restart loop with 312 revisions.

## Test plan
- [ ] Trigger auto-upgrade on a hive with multiple agents
- [ ] Verify only one `rollout restart` is issued
- [ ] Verify the new pod has time to start all agents and become ready