### PR TITLE
feat: spoke-declared hive_type and dashboard_url in heartbeat

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1009,6 +1009,7 @@ func main() {
 					return fmt.Sprintf("http://localhost:%d", cfg.Dashboard.Port)
 				}(),
 				SnapshotURL:  cfg.Hub.SnapshotURL,
+				HiveType:     cfg.Hub.HiveType,
 				IsPublic:     cfg.Hub.IsPublic,
 				Version:           "3.0.0",
 				GitHash:           gitShort,

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -343,6 +343,7 @@ type HubConfig struct {
 	IsPublic               bool     `yaml:"is_public"`
 	SnapshotURL            string   `yaml:"snapshot_url"`
 	DashboardURL           string   `yaml:"dashboard_url"`
+	HiveType               string   `yaml:"hive_type"`
 	AutoSnapshot           bool     `yaml:"auto_snapshot"`
 	ContributeSuspended    bool     `yaml:"contribute_suspended"`
 	ContributeAllowLabels  []string `yaml:"contribute_allow_labels"`

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -59,6 +59,7 @@ type HeartbeatPayload struct {
 	DashboardURL string             `json:"dashboard_url"`
 	SnapshotURL  string             `json:"snapshot_url"`
 	Owner        string             `json:"owner,omitempty"`
+	HiveType     string             `json:"hive_type,omitempty"`
 	IsPublic     bool               `json:"is_public"`
 	Version      string             `json:"version"`
 	GitHash      string             `json:"git_hash"`

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -292,6 +292,9 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		ActiveContributors: clampInt(payload.Contributors.Active, 0, 10_000),
 		Owner:              sanitizeHeartbeatField(payload.Owner),
 		HiveType: func() string {
+			if payload.HiveType != "" {
+				return sanitizeHeartbeatField(payload.HiveType)
+			}
 			if strings.HasPrefix(payload.HiveID, "hosted-") || strings.HasPrefix(payload.HiveID, "saas-") {
 				return "hosted"
 			}


### PR DESCRIPTION
## Summary
- Add `hive_type` field to `HeartbeatPayload` and `HubConfig` so spokes can self-declare as `hosted` without needing a `hosted-`/`saas-` ID prefix
- Hub respects spoke-declared type when present, falls back to existing ID-prefix heuristic
- Enables multi-cluster spokes (e.g., vllm-d) to register correctly with proper dashboard URL and type badge

## Files changed
- `v2/pkg/hub/heartbeat.go` — add `HiveType` to payload struct
- `v2/pkg/hub/server.go` — respect spoke-declared type in registration
- `v2/pkg/config/config.go` — add `HiveType` to `HubConfig`
- `v2/cmd/hive/main.go` — wire `HiveType` into heartbeat builder