### PR TITLE
fix: add re-check button and background retry for GitHub App detection

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -742,6 +742,62 @@ func main() {
 
 	dashSrv.SetGitHubAppRequired(githubAppRequired)
 
+	// Wire up the manual re-check callback for the dashboard button.
+	{
+		recheckRepo := cfg.Project.PrimaryRepo
+		if recheckRepo == "" && len(cfg.Project.Repos) > 0 {
+			recheckRepo = cfg.Project.Repos[0]
+		}
+		if recheckRepo != "" {
+			dashSrv.SetGitHubAppRecheckFn(func() bool {
+				num, err := ghClient.EnsureAdvisoryIssue(ctx, recheckRepo)
+				if err != nil {
+					logger.Debug("github app recheck: not accessible", "repo", recheckRepo, "error", err)
+					return false
+				}
+				advisoryIssues[recheckRepo] = num
+				os.Setenv("HIVE_ADVISORY_ISSUE", fmt.Sprintf("%d", num))
+				logger.Info("github app recheck: app detected", "repo", recheckRepo, "number", num)
+				return true
+			})
+		}
+	}
+
+	// Retry GitHub App check every 10 minutes when the flag is set.
+	// Stops retrying once the app is detected (advisory issue created successfully).
+	{
+		primaryRepo := cfg.Project.PrimaryRepo
+		if primaryRepo == "" && len(cfg.Project.Repos) > 0 {
+			primaryRepo = cfg.Project.Repos[0]
+		}
+		if primaryRepo != "" {
+			const appRetryInterval = 10 * time.Minute
+			go func() {
+				ticker := time.NewTicker(appRetryInterval)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-ticker.C:
+						if !dashSrv.IsGitHubAppRequired() {
+							continue
+						}
+						num, err := ghClient.EnsureAdvisoryIssue(ctx, primaryRepo)
+						if err != nil {
+							logger.Debug("github app retry: still not accessible", "repo", primaryRepo, "error", err)
+							continue
+						}
+						advisoryIssues[primaryRepo] = num
+						os.Setenv("HIVE_ADVISORY_ISSUE", fmt.Sprintf("%d", num))
+						dashSrv.SetGitHubAppRequired(false)
+						logger.Info("github app retry: app detected, advisory issue ready", "repo", primaryRepo, "number", num)
+					}
+				}
+			}()
+		}
+	}
+
 	if brainstormBeads, ok := beadStores["brainstorm"]; ok {
 		inceptionWatcher := dashboard.NewInceptionWatcher(brainstormBeads, inceptionEngine, sched, agentMgr, gov, logger)
 		go inceptionWatcher.Run(ctx)

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -72,6 +72,8 @@ type Server struct {
 	githubAppMu         sync.RWMutex
 	githubAppRequired   bool
 	githubAppInstallURL string
+
+	githubAppRecheckFn func() bool
 }
 
 // StatusPayload matches the JSON contract the dashboard frontend render() expects.
@@ -307,6 +309,7 @@ func (s *Server) registerCoreRoutes() {
 	s.mux.HandleFunc("GET /api/health/deep", s.handleHealthDeep)
 	s.mux.HandleFunc("GET /api/status", s.handleStatus)
 	s.mux.HandleFunc("GET /api/events", s.handleSSE)
+	s.mux.HandleFunc("POST /api/github-app/recheck", s.handleGitHubAppRecheck)
 }
 
 func (s *Server) Start() error {
@@ -434,6 +437,25 @@ func (s *Server) IsGitHubAppRequired() bool {
 	s.githubAppMu.RLock()
 	defer s.githubAppMu.RUnlock()
 	return s.githubAppRequired
+}
+
+func (s *Server) SetGitHubAppRecheckFn(fn func() bool) {
+	s.githubAppRecheckFn = fn
+}
+
+func (s *Server) handleGitHubAppRecheck(w http.ResponseWriter, r *http.Request) {
+	if s.githubAppRecheckFn == nil {
+		http.Error(w, "recheck not configured", http.StatusNotImplemented)
+		return
+	}
+	ok := s.githubAppRecheckFn()
+	w.Header().Set("Content-Type", "application/json")
+	if ok {
+		s.SetGitHubAppRequired(false)
+		w.Write([]byte(`{"status":"installed"}`))
+	} else {
+		w.Write([]byte(`{"status":"not_installed"}`))
+	}
 }
 
 // BroadcastAgentStatus sends a lightweight agent-only SSE event on a fast

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1921,6 +1921,7 @@
       <div class="gh-app-title">GitHub App Not Installed</div>
       <div class="gh-app-desc">This hive cannot create issues or advisory reports. Install the Hive Hub GitHub App on your repository to enable full functionality.</div>
     </div>
+    <button onclick="recheckGitHubApp()" class="gh-app-btn" style="background:#374151;margin-right:8px" id="gh-app-recheck-btn">Re-check</button>
     <a id="gh-app-install-link" href="" target="_blank" rel="noopener" class="gh-app-btn">Install GitHub App</a>
   </div>
   <div class="governor" id="governor"></div>
@@ -3463,6 +3464,25 @@
       } else {
         banner.setAttribute('hidden', '');
         banner.style.cssText = 'display:none';
+      }
+    }
+
+    async function recheckGitHubApp() {
+      var btn = document.getElementById('gh-app-recheck-btn');
+      if (btn) { btn.disabled = true; btn.textContent = 'Checking...'; }
+      try {
+        var resp = await fetch('/api/github-app/recheck', { method: 'POST' });
+        var data = await resp.json();
+        if (data.status === 'installed') {
+          var banner = document.getElementById('gh-app-install-banner');
+          if (banner) { banner.setAttribute('hidden', ''); banner.style.cssText = 'display:none'; }
+        } else {
+          if (btn) btn.textContent = 'Not found — try again';
+        }
+      } catch(e) {
+        if (btn) btn.textContent = 'Error — try again';
+      } finally {
+        if (btn) { btn.disabled = false; setTimeout(function() { btn.textContent = 'Re-check'; }, 3000); }
       }
     }
 


### PR DESCRIPTION
## Summary
- The GitHub App check only ran at startup — if the app was installed after the hive started, the "Not Installed" banner stayed forever
- Adds a **Re-check** button on the banner for immediate verification after installing the app
- Adds **background retry every 10 minutes** when the flag is true (zero overhead when app is already installed)
- New `POST /api/github-app/recheck` endpoint
- Banner auto-hides when re-check succeeds; shows "Not found — try again" feedback on failure

Triggered by Daniel Waddington's experience installing the app on certus — the banner persisted even after the app was installed on the repo.

## Test plan
- [ ] Start a hive without the GitHub App installed — verify banner shows with Re-check + Install buttons
- [ ] Click Re-check before installing — verify "Not found — try again" feedback
- [ ] Install the app, click Re-check — verify banner disappears
- [ ] Wait 10 minutes without clicking — verify banner auto-clears via background retry