### PR TITLE
fix: make ConfigMap source of truth for K8s config backup/restore

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -12,34 +12,66 @@ export HIVE_STATIC_DIR="${HIVE_STATIC_DIR:-/opt/hive/proxy/public}"
 # the bind-mounted hive.yaml during shutdown or early startup, wiping the
 # host file. /data/ is a Docker named volume that persists across container
 # recreations, so we keep a rolling backup there.
+#
+# In Kubernetes, the ConfigMap is the source of truth — admins update it to
+# change settings like acmm_level, is_public, etc. The PVC backup is only
+# used for disaster recovery if the ConfigMap volume is missing or empty.
 HIVE_CONFIG_PATH="${HIVE_CONFIG:-/etc/hive/hive.yaml}"
 HIVE_CONFIG_BACKUP="/data/hive.yaml.bak"
 
-if [ -f "$HIVE_CONFIG_PATH" ] && [ -s "$HIVE_CONFIG_PATH" ] && [ ! -f "$HIVE_CONFIG_BACKUP" ]; then
-  # First boot: config exists but no PVC backup yet — seed the backup
-  cp "$HIVE_CONFIG_PATH" "$HIVE_CONFIG_BACKUP"
-  echo "[entrypoint] First boot — config seeded to PVC: $HIVE_CONFIG_BACKUP"
-elif [ -f "$HIVE_CONFIG_PATH" ] && [ -s "$HIVE_CONFIG_PATH" ] && [ -f "$HIVE_CONFIG_BACKUP" ] && [ -s "$HIVE_CONFIG_BACKUP" ]; then
-  # PVC backup is the source of truth (updated by Save()).
-  # Try to copy it over the config path; if read-only (Docker bind mount),
-  # override HIVE_CONFIG so the Go binary reads from the backup directly.
-  if cp "$HIVE_CONFIG_BACKUP" "$HIVE_CONFIG_PATH" 2>/dev/null; then
-    echo "[entrypoint] PVC backup restored to config path"
+# Detect Kubernetes vs Docker environment
+IS_KUBERNETES=false
+if [ -n "${KUBERNETES_SERVICE_HOST:-}" ] || [ -f /var/run/secrets/kubernetes.io/serviceaccount/token ]; then
+  IS_KUBERNETES=true
+fi
+
+if [ "$IS_KUBERNETES" = "true" ]; then
+  # ── Kubernetes mode: ConfigMap is the source of truth ──────────────
+  if [ -f "$HIVE_CONFIG_PATH" ] && [ -s "$HIVE_CONFIG_PATH" ]; then
+    # ConfigMap is present and non-empty — use it as-is, write a backup for recovery
+    cp "$HIVE_CONFIG_PATH" "$HIVE_CONFIG_BACKUP" 2>/dev/null || true
+    echo "[entrypoint] K8s mode — ConfigMap is source of truth, backup written to $HIVE_CONFIG_BACKUP"
+  elif [ -f "$HIVE_CONFIG_BACKUP" ] && [ -s "$HIVE_CONFIG_BACKUP" ]; then
+    # ConfigMap is missing or empty but a PVC backup exists — recover
+    if cp "$HIVE_CONFIG_BACKUP" "$HIVE_CONFIG_PATH" 2>/dev/null; then
+      echo "[entrypoint] K8s mode — ConfigMap missing/empty, RECOVERED from PVC backup"
+    else
+      export HIVE_CONFIG="$HIVE_CONFIG_BACKUP"
+      echo "[entrypoint] K8s mode — ConfigMap missing/empty and read-only, using PVC backup directly"
+    fi
   else
-    export HIVE_CONFIG="$HIVE_CONFIG_BACKUP"
-    echo "[entrypoint] Config path is read-only — using PVC backup directly"
+    echo "[entrypoint] ERROR: No ConfigMap at $HIVE_CONFIG_PATH and no PVC backup at $HIVE_CONFIG_BACKUP."
+    echo "[entrypoint] Ensure the hive ConfigMap is created before deploying."
+    exit 1
   fi
-elif [ -f "$HIVE_CONFIG_PATH" ] && [ ! -s "$HIVE_CONFIG_PATH" ] && [ -f "$HIVE_CONFIG_BACKUP" ] && [ -s "$HIVE_CONFIG_BACKUP" ]; then
-  # Config was wiped to 0 bytes (Watchtower recreation) but backup exists — restore
-  cp "$HIVE_CONFIG_BACKUP" "$HIVE_CONFIG_PATH"
-  echo "[entrypoint] RECOVERED: $HIVE_CONFIG_PATH was empty (0 bytes), restored from $HIVE_CONFIG_BACKUP"
-elif [ -f "$HIVE_CONFIG_PATH" ] && [ ! -s "$HIVE_CONFIG_PATH" ]; then
-  # Config is empty and no backup exists — fatal, cannot recover
-  echo "[entrypoint] ERROR: $HIVE_CONFIG_PATH exists but is empty (0 bytes)."
-  echo "[entrypoint] No backup found at $HIVE_CONFIG_BACKUP."
-  echo "[entrypoint] This usually happens after 'docker compose down -v' wipes the data volume."
-  echo "[entrypoint] Restore your hive.yaml from backup or version control and restart."
-  exit 1
+else
+  # ── Docker mode: PVC backup is the source of truth ─────────────────
+  if [ -f "$HIVE_CONFIG_PATH" ] && [ -s "$HIVE_CONFIG_PATH" ] && [ ! -f "$HIVE_CONFIG_BACKUP" ]; then
+    # First boot: config exists but no PVC backup yet — seed the backup
+    cp "$HIVE_CONFIG_PATH" "$HIVE_CONFIG_BACKUP"
+    echo "[entrypoint] First boot — config seeded to PVC: $HIVE_CONFIG_BACKUP"
+  elif [ -f "$HIVE_CONFIG_PATH" ] && [ -s "$HIVE_CONFIG_PATH" ] && [ -f "$HIVE_CONFIG_BACKUP" ] && [ -s "$HIVE_CONFIG_BACKUP" ]; then
+    # PVC backup is the source of truth (updated by Save()).
+    # Try to copy it over the config path; if read-only (Docker bind mount),
+    # override HIVE_CONFIG so the Go binary reads from the backup directly.
+    if cp "$HIVE_CONFIG_BACKUP" "$HIVE_CONFIG_PATH" 2>/dev/null; then
+      echo "[entrypoint] PVC backup restored to config path"
+    else
+      export HIVE_CONFIG="$HIVE_CONFIG_BACKUP"
+      echo "[entrypoint] Config path is read-only — using PVC backup directly"
+    fi
+  elif [ -f "$HIVE_CONFIG_PATH" ] && [ ! -s "$HIVE_CONFIG_PATH" ] && [ -f "$HIVE_CONFIG_BACKUP" ] && [ -s "$HIVE_CONFIG_BACKUP" ]; then
+    # Config was wiped to 0 bytes (Watchtower recreation) but backup exists — restore
+    cp "$HIVE_CONFIG_BACKUP" "$HIVE_CONFIG_PATH"
+    echo "[entrypoint] RECOVERED: $HIVE_CONFIG_PATH was empty (0 bytes), restored from $HIVE_CONFIG_BACKUP"
+  elif [ -f "$HIVE_CONFIG_PATH" ] && [ ! -s "$HIVE_CONFIG_PATH" ]; then
+    # Config is empty and no backup exists — fatal, cannot recover
+    echo "[entrypoint] ERROR: $HIVE_CONFIG_PATH exists but is empty (0 bytes)."
+    echo "[entrypoint] No backup found at $HIVE_CONFIG_BACKUP."
+    echo "[entrypoint] This usually happens after 'docker compose down -v' wipes the data volume."
+    echo "[entrypoint] Restore your hive.yaml from backup or version control and restart."
+    exit 1
+  fi
 fi
 
 # ── Root-only setup (runs once, then re-execs as dev) ──────────────────

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -976,9 +976,15 @@ func (c *Config) Save() error {
 		return fmt.Errorf("closing config: %w", err)
 	}
 
+	// Write a rolling backup to the PVC. This is NOT the primary config —
+	// it exists for disaster recovery (e.g. ConfigMap deleted in K8s, or
+	// Watchtower wiping a bind mount in Docker). The entrypoint determines
+	// which source is authoritative based on the runtime environment.
 	backupPath := "/data/hive.yaml.bak"
 	if err := os.WriteFile(backupPath, data, 0o644); err != nil {
-		log.Printf("[config] warning: failed to write PVC backup: %v", err)
+		log.Printf("[config] warning: failed to write PVC backup to %s: %v", backupPath, err)
+	} else {
+		log.Printf("[config] PVC backup written to %s (recovery copy, not primary config)", backupPath)
 	}
 	return nil
 }

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -489,7 +489,7 @@ spec:
       - name: copy-config
         image: ghcr.io/kubestellar/hive:v2-latest
         imagePullPolicy: Always
-        command: ["sh", "-c", "if [ -f /data/hive.yaml.bak ]; then cp /data/hive.yaml.bak /etc/hive/hive.yaml; echo override-used; else cp /etc/hive-seed/hive.yaml /etc/hive/hive.yaml; echo seed-copied; fi"]
+        command: ["sh", "-c", "cp /etc/hive-seed/hive.yaml /etc/hive/hive.yaml && echo configmap-copied; if [ -f /data/hive.yaml.bak ]; then echo backup-exists-for-recovery; fi"]
         volumeMounts:
         - name: config
           mountPath: /etc/hive-seed


### PR DESCRIPTION
## Summary

- **entrypoint.sh**: Detect Kubernetes environment (`KUBERNETES_SERVICE_HOST` or SA token) and treat the ConfigMap as authoritative on boot. The PVC backup (`/data/hive.yaml.bak`) is only used for disaster recovery when the ConfigMap is missing or empty. Docker/Watchtower behavior is unchanged — PVC backup remains the source of truth there.
- **saas_provision.go init container**: Always copy from the ConfigMap seed volume (`/etc/hive-seed/hive.yaml`) instead of preferring the PVC backup. The backup is noted for recovery but never overwrites the seed.
- **config.go Save()**: Added clarifying log messages that the PVC write is a recovery backup, not the primary config source.

## Problem

When both the ConfigMap and PVC backup existed, the PVC backup overwrote the ConfigMap on every pod restart. This meant admin changes to `acmm_level`, `is_public`, and other settings via `kubectl edit configmap` were silently reverted.

## Test plan

- [ ] Deploy a hosted hive in K8s, change `acmm_level` in the ConfigMap, restart the pod — verify the new value is used
- [ ] Deploy a Docker hive with Watchtower, verify PVC backup still restores correctly after container recreation
- [ ] Verify `config.Save()` still writes the backup and logs the clarifying message
- [ ] Verify init container uses ConfigMap seed, not stale PVC backup