### PR TITLE
feat: GitHub Enterprise support for hive spokes

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1009,6 +1009,7 @@ func main() {
 					return fmt.Sprintf("http://localhost:%d", cfg.Dashboard.Port)
 				}(),
 				SnapshotURL:  cfg.Hub.SnapshotURL,
+				HiveType:     cfg.Hub.HiveType,
 				IsPublic:     cfg.Hub.IsPublic,
 				Version:           "3.0.0",
 				GitHash:           gitShort,

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -108,7 +109,7 @@ func main() {
 			keyFile = "/secrets/gh-app-key.pem"
 		}
 		var err error
-		appAuth, err = github.NewAppAuth(cfg.GitHub.AppID, cfg.GitHub.InstallationID, keyFile, logger)
+		appAuth, err = github.NewAppAuth(cfg.GitHub.AppID, cfg.GitHub.InstallationID, keyFile, logger, cfg.GitHub.ResolvedAPIURL())
 		if err != nil {
 			logger.Error("failed to init GitHub App auth", "error", err)
 			os.Exit(1)
@@ -119,7 +120,7 @@ func main() {
 		if cfg.GitHub.DocsInstallationID != 0 {
 			docsAuth, err := github.NewAppAuthWithCache(
 				cfg.GitHub.AppID, cfg.GitHub.DocsInstallationID,
-				keyFile, github.DocsTokenCachePath, logger,
+				keyFile, github.DocsTokenCachePath, logger, cfg.GitHub.ResolvedAPIURL(),
 			)
 			if err != nil {
 				logger.Warn("failed to init docs org token", "error", err)
@@ -155,7 +156,7 @@ func main() {
 			logger.Error("no GitHub token configured (set github.token or github.app_id in config)")
 			os.Exit(1)
 		}
-		ghClient = github.NewClient(ghToken, cfg.Project.Org, cfg.Project.Repos, logger)
+		ghClient = github.NewClient(ghToken, cfg.Project.Org, cfg.Project.Repos, logger, cfg.GitHub.ResolvedAPIURL())
 	}
 	if len(cfg.Governor.Labels.Exempt) > 0 {
 		ghClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
@@ -165,8 +166,8 @@ func main() {
 	if tokenData, err := os.ReadFile("/data/gh-user-token"); err == nil {
 		userToken := strings.TrimSpace(string(tokenData))
 		if userToken != "" {
-			if username, err := github.ValidateToken(userToken); err == nil {
-				uc := github.NewClient(userToken, cfg.Project.Org, cfg.Project.Repos, logger)
+			if username, err := github.ValidateToken(userToken, cfg.GitHub.ResolvedAPIURL()); err == nil {
+				uc := github.NewClient(userToken, cfg.Project.Org, cfg.Project.Repos, logger, cfg.GitHub.ResolvedAPIURL())
 				userGHClient.Store(uc)
 				logger.Info("user GitHub token loaded for advisory posting", "username", username)
 			} else {
@@ -714,7 +715,7 @@ func main() {
 			initAgentConfigDrivenSystems(cfg)
 		},
 		SetUserClient: func(token string) {
-			uc := github.NewClient(token, cfg.Project.Org, cfg.Project.Repos, logger)
+			uc := github.NewClient(token, cfg.Project.Org, cfg.Project.Repos, logger, cfg.GitHub.ResolvedAPIURL())
 			userGHClient.Store(uc)
 			logger.Info("user GitHub client updated via device flow")
 		},
@@ -853,6 +854,14 @@ func main() {
 	}, logger)
 	dashSrv.SetSkipReloadFunc(configWatcher.SkipNext)
 	go configWatcher.Start(ctx)
+
+	// Register custom GHE hostnames with the proxy allowlist so mode
+	// enforcement applies to GitHub Enterprise API and web requests.
+	for _, rawURL := range []string{cfg.GitHub.ResolvedAPIURL(), cfg.GitHub.ResolvedBaseURL()} {
+		if parsed, err := url.Parse(rawURL); err == nil && parsed.Host != "" {
+			proxy.RegisterGitHubHost(parsed.Host)
+		}
+	}
 
 	githubProxy, err := proxy.NewGitHubProxy(logger, cfg.Project.Org, cfg.Project.Repos)
 	if err != nil {
@@ -994,7 +1003,7 @@ func main() {
 					if td, err := os.ReadFile("/data/gh-user-token"); err == nil {
 						tok := strings.TrimSpace(string(td))
 						if tok != "" {
-							if u, err := github.ValidateToken(tok); err == nil {
+							if u, err := github.ValidateToken(tok, cfg.GitHub.ResolvedAPIURL()); err == nil {
 								return u.Login
 							}
 						}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -343,6 +343,7 @@ type HubConfig struct {
 	IsPublic               bool     `yaml:"is_public"`
 	SnapshotURL            string   `yaml:"snapshot_url"`
 	DashboardURL           string   `yaml:"dashboard_url"`
+	HiveType               string   `yaml:"hive_type"`
 	AutoSnapshot           bool     `yaml:"auto_snapshot"`
 	ContributeSuspended    bool     `yaml:"contribute_suspended"`
 	ContributeAllowLabels  []string `yaml:"contribute_allow_labels"`

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -314,6 +314,35 @@ type GitHubConfig struct {
 	KeyFile              string `yaml:"key_file"`
 	Token                string `yaml:"token"`
 	OAuthClientID        string `yaml:"oauth_client_id"`
+	// APIURL is the GitHub API base URL. Defaults to DefaultGitHubAPIURL.
+	// For GitHub Enterprise, set to e.g. "https://github.ibm.com/api/v3".
+	APIURL string `yaml:"api_url"`
+	// BaseURL is the GitHub web base URL. Defaults to DefaultGitHubBaseURL.
+	// For GitHub Enterprise, set to e.g. "https://github.ibm.com".
+	BaseURL string `yaml:"base_url"`
+}
+
+const (
+	// DefaultGitHubAPIURL is the default GitHub API endpoint (public github.com).
+	DefaultGitHubAPIURL = "https://api.github.com"
+	// DefaultGitHubBaseURL is the default GitHub web URL (public github.com).
+	DefaultGitHubBaseURL = "https://github.com"
+)
+
+// ResolvedAPIURL returns the configured API URL or the default for github.com.
+func (g GitHubConfig) ResolvedAPIURL() string {
+	if g.APIURL != "" {
+		return g.APIURL
+	}
+	return DefaultGitHubAPIURL
+}
+
+// ResolvedBaseURL returns the configured base URL or the default for github.com.
+func (g GitHubConfig) ResolvedBaseURL() string {
+	if g.BaseURL != "" {
+		return g.BaseURL
+	}
+	return DefaultGitHubBaseURL
 }
 
 type NotificationsConfig struct {

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1153,7 +1153,7 @@ func (s *Server) handleGHUserAuthStatus(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	token := strings.TrimSpace(string(tokenData))
-	user, err := github.ValidateToken(token)
+	user, err := github.ValidateToken(token, s.deps.Config.GitHub.ResolvedAPIURL())
 	if err != nil {
 		jsonResponse(w, map[string]interface{}{"logged_in": false, "error": "token expired or revoked"})
 		return
@@ -1171,7 +1171,7 @@ func (s *Server) handleGHUserAuthStart(w http.ResponseWriter, r *http.Request) {
 	s.deviceFlowMu.Lock()
 	defer s.deviceFlowMu.Unlock()
 
-	state, err := github.StartDeviceFlow(clientID)
+	state, err := github.StartDeviceFlow(clientID, s.deps.Config.GitHub.ResolvedBaseURL(), s.deps.Config.GitHub.ResolvedAPIURL())
 	if err != nil {
 		jsonError(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -1195,7 +1195,7 @@ func (s *Server) handleGHUserAuthPoll(w http.ResponseWriter, r *http.Request) {
 	}
 
 	clientID := s.deps.Config.GitHub.OAuthClientID
-	token, status, err := github.PollDeviceFlow(clientID, s.deviceFlowState.DeviceCode)
+	token, status, err := github.PollDeviceFlow(clientID, s.deviceFlowState.DeviceCode, s.deps.Config.GitHub.ResolvedBaseURL(), s.deps.Config.GitHub.ResolvedAPIURL())
 	if err != nil {
 		s.deviceFlowState = nil
 		jsonResponse(w, map[string]interface{}{"status": "error", "error": err.Error()})
@@ -1220,7 +1220,7 @@ func (s *Server) handleGHUserAuthPoll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, _ := github.ValidateToken(token)
+	user, _ := github.ValidateToken(token, s.deps.Config.GitHub.ResolvedAPIURL())
 	s.deviceFlowState = nil
 	username := ""
 	avatarURL := ""
@@ -1261,7 +1261,7 @@ func (s *Server) restoreGHUserSession() {
 		return
 	}
 
-	user, err := github.ValidateToken(token)
+	user, err := github.ValidateToken(token, s.deps.Config.GitHub.ResolvedAPIURL())
 	if err != nil {
 		s.deps.Logger.Warn("saved GitHub user token is invalid, removing", "error", err)
 		os.Remove(userTokenPath)

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -598,7 +598,7 @@ func (s *Server) handleContributeReissueToken(w http.ResponseWriter, r *http.Req
 		token = ""
 	}
 
-	username := validateGitHubToken(token)
+	username := validateGitHubToken(token, s.deps.Config.GitHub.ResolvedAPIURL())
 	if username == "" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
@@ -1759,7 +1759,9 @@ type ghTokenCacheEntry struct {
 	expiresAt time.Time
 }
 
-func validateGitHubToken(token string) string {
+// validateGitHubToken checks a token against the GitHub API user endpoint.
+// apiURL overrides the API base for GHE; pass empty for default github.com.
+func validateGitHubToken(token, apiURL string) string {
 	if token == "" {
 		return ""
 	}
@@ -1771,8 +1773,14 @@ func validateGitHubToken(token string) string {
 	}
 	ghTokenCacheMu.RUnlock()
 
-	client := &http.Client{Timeout: 10 * time.Second}
-	req, err := http.NewRequest("GET", "https://api.github.com/user", nil)
+	userEndpoint := "https://api.github.com/user"
+	if apiURL != "" && apiURL != "https://api.github.com" {
+		userEndpoint = apiURL + "/user"
+	}
+
+	const tokenValidateTimeout = 10 * time.Second
+	client := &http.Client{Timeout: tokenValidateTimeout}
+	req, err := http.NewRequest("GET", userEndpoint, nil)
 	if err != nil {
 		return ""
 	}
@@ -1809,7 +1817,7 @@ func (s *Server) handleAPIv1(w http.ResponseWriter, r *http.Request) {
 		token = r.URL.Query().Get("token")
 	}
 
-	username := validateGitHubToken(token)
+	username := validateGitHubToken(token, s.deps.Config.GitHub.ResolvedAPIURL())
 	if username == "" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)

--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -30,17 +30,18 @@ type AppAuth struct {
 	key            *rsa.PrivateKey
 	logger         *slog.Logger
 	cachePath      string
+	apiURL         string // custom GitHub API URL for GHE; empty means default (github.com)
 
 	mu          sync.RWMutex
 	cachedToken string
 	tokenExpiry time.Time
 }
 
-func NewAppAuth(appID, installationID int64, keyFile string, logger *slog.Logger) (*AppAuth, error) {
-	return NewAppAuthWithCache(appID, installationID, keyFile, TokenCachePath, logger)
+func NewAppAuth(appID, installationID int64, keyFile string, logger *slog.Logger, apiURL string) (*AppAuth, error) {
+	return NewAppAuthWithCache(appID, installationID, keyFile, TokenCachePath, logger, apiURL)
 }
 
-func NewAppAuthWithCache(appID, installationID int64, keyFile, cachePath string, logger *slog.Logger) (*AppAuth, error) {
+func NewAppAuthWithCache(appID, installationID int64, keyFile, cachePath string, logger *slog.Logger, apiURL string) (*AppAuth, error) {
 	keyData, err := os.ReadFile(keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("reading app key %s: %w", keyFile, err)
@@ -70,6 +71,7 @@ func NewAppAuthWithCache(appID, installationID int64, keyFile, cachePath string,
 		key:            key,
 		logger:         logger,
 		cachePath:      cachePath,
+		apiURL:         apiURL,
 	}, nil
 }
 
@@ -107,6 +109,7 @@ func (a *AppAuth) Token(ctx context.Context) (string, error) {
 	}
 
 	jwtClient := gh.NewClient(nil).WithAuthToken(jwtToken)
+	setBaseURL(jwtClient, a.apiURL)
 	installToken, _, err := jwtClient.Apps.CreateInstallationToken(ctx, a.installationID, nil)
 	if err != nil {
 		return "", fmt.Errorf("creating installation token: %w", err)
@@ -175,6 +178,7 @@ func (a *AppAuth) ScopedToken(ctx context.Context, tier string) (string, error) 
 
 	opts := &gh.InstallationTokenOptions{Permissions: perms}
 	jwtClient := gh.NewClient(nil).WithAuthToken(jwtToken)
+	setBaseURL(jwtClient, a.apiURL)
 	installToken, _, err := jwtClient.Apps.CreateInstallationToken(ctx, a.installationID, opts)
 	if err != nil {
 		return "", fmt.Errorf("creating scoped token for tier %s: %w", tier, err)
@@ -208,6 +212,7 @@ func NewClientFromApp(auth *AppAuth, org string, repos []string, logger *slog.Lo
 	const appClientTimeout = 30 * time.Second
 	httpClient := &http.Client{Transport: transport, Timeout: appClientTimeout}
 	client := gh.NewClient(httpClient)
+	setBaseURL(client, auth.apiURL)
 
 	return &Client{
 		client: client,

--- a/v2/pkg/github/app_test.go
+++ b/v2/pkg/github/app_test.go
@@ -37,7 +37,7 @@ func TestNewAppAuth_ValidKey(t *testing.T) {
 	tmpFile.Close()
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	auth, err := NewAppAuth(12345, 67890, tmpFile.Name(), logger)
+	auth, err := NewAppAuth(12345, 67890, tmpFile.Name(), logger, "")
 	if err != nil {
 		t.Fatalf("NewAppAuth: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestNewAppAuth_PKCS8Key(t *testing.T) {
 	tmpFile.Close()
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	auth, err := NewAppAuth(1, 2, tmpFile.Name(), logger)
+	auth, err := NewAppAuth(1, 2, tmpFile.Name(), logger, "")
 	if err != nil {
 		t.Fatalf("NewAppAuth PKCS8: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestNewAppAuth_PKCS8Key(t *testing.T) {
 
 func TestNewAppAuth_FileNotFound(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	_, err := NewAppAuth(1, 2, "/nonexistent/key.pem", logger)
+	_, err := NewAppAuth(1, 2, "/nonexistent/key.pem", logger, "")
 	if err == nil {
 		t.Error("expected error for missing file")
 	}
@@ -104,7 +104,7 @@ func TestNewAppAuth_NoPEMBlock(t *testing.T) {
 	tmpFile.Close()
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	_, err = NewAppAuth(1, 2, tmpFile.Name(), logger)
+	_, err = NewAppAuth(1, 2, tmpFile.Name(), logger, "")
 	if err == nil {
 		t.Error("expected error for invalid PEM")
 	}
@@ -123,7 +123,7 @@ func TestNewAppAuth_InvalidKeyBytes(t *testing.T) {
 	tmpFile.Close()
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	_, err = NewAppAuth(1, 2, tmpFile.Name(), logger)
+	_, err = NewAppAuth(1, 2, tmpFile.Name(), logger, "")
 	if err == nil {
 		t.Error("expected error for garbage key bytes")
 	}

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -102,8 +102,12 @@ var exemptFiles = []string{"ADOPTERS.md", "ADOPTERS.MD"}
 
 const slaThresholdMinutes = 30
 
-func NewClient(token string, org string, repos []string, logger *slog.Logger) *Client {
+// NewClient creates a GitHub API client. If apiURL is non-empty and differs
+// from the default (https://api.github.com), the client's BaseURL and
+// UploadURL are overridden for GitHub Enterprise compatibility.
+func NewClient(token string, org string, repos []string, logger *slog.Logger, apiURL string) *Client {
 	client := gh.NewClient(nil).WithAuthToken(token)
+	setBaseURL(client, apiURL)
 	return &Client{
 		client: client,
 		org:    org,
@@ -112,10 +116,30 @@ func NewClient(token string, org string, repos []string, logger *slog.Logger) *C
 	}
 }
 
+// setBaseURL configures a go-github client for a custom API URL (GHE).
+// If apiURL is empty or the default, no change is made.
+func setBaseURL(client *gh.Client, apiURL string) {
+	if apiURL == "" || apiURL == "https://api.github.com" {
+		return
+	}
+	// Ensure trailing slash for url.Parse compatibility.
+	normalized := apiURL
+	if !strings.HasSuffix(normalized, "/") {
+		normalized += "/"
+	}
+	base, err := url.Parse(normalized)
+	if err != nil {
+		return
+	}
+	client.BaseURL = base
+	// Upload URL follows the same base for GHE instances.
+	client.UploadURL = base
+}
+
 // NewClientForTest creates a client pointing at a test server. Exported for
 // cross-package testing (e.g. dashboard tests that need a mock GH client).
 func NewClientForTest(serverURL string, org string, repos []string, logger *slog.Logger) *Client {
-	c := NewClient("fake", org, repos, logger)
+	c := NewClient("fake", org, repos, logger, "")
 	base, err := url.Parse(serverURL + "/")
 	if err != nil {
 		panic("bad test server URL: " + err.Error())

--- a/v2/pkg/github/client_test.go
+++ b/v2/pkg/github/client_test.go
@@ -20,7 +20,7 @@ import (
 func newTestClient(t *testing.T, server *httptest.Server, org string, repos []string) *Client {
 	t.Helper()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
-	c := NewClient("fake-token", org, repos, logger)
+	c := NewClient("fake-token", org, repos, logger, "")
 	base, err := url.Parse(server.URL + "/")
 	if err != nil {
 		t.Fatalf("parse server URL: %v", err)
@@ -86,7 +86,7 @@ func hoursAgo(h float64) string {
 
 func TestNewClient(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	c := NewClient("tok", "myorg", []string{"repo1", "repo2"}, logger)
+	c := NewClient("tok", "myorg", []string{"repo1", "repo2"}, logger, "")
 	if c == nil {
 		t.Fatal("NewClient returned nil")
 	}
@@ -229,7 +229,7 @@ func TestEnumerateActionable_EmptyRepos(t *testing.T) {
 	defer server.Close()
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	c := NewClient("tok", "org", []string{}, logger)
+	c := NewClient("tok", "org", []string{}, logger, "")
 	base, _ := url.Parse(server.URL + "/")
 	c.client.BaseURL = base
 

--- a/v2/pkg/github/deviceflow.go
+++ b/v2/pkg/github/deviceflow.go
@@ -15,11 +15,31 @@ const deviceFlowHTTPTimeout = 15 * time.Second
 var deviceFlowClient = &http.Client{Timeout: deviceFlowHTTPTimeout}
 
 const (
-	deviceCodeURL = "https://github.com/login/device/code"
-	tokenURL      = "https://github.com/login/oauth/access_token"
-	userURL       = "https://api.github.com/user"
-	deviceScope   = "repo"
+	// defaultDeviceCodeURL is the GitHub.com device flow code endpoint.
+	defaultDeviceCodeURL = "https://github.com/login/device/code"
+	// defaultTokenURL is the GitHub.com OAuth token exchange endpoint.
+	defaultTokenURL = "https://github.com/login/oauth/access_token"
+	// defaultUserURL is the GitHub.com API user endpoint.
+	defaultUserURL = "https://api.github.com/user"
+	deviceScope    = "repo"
 )
+
+// deviceFlowURLs derives the device flow endpoints from a custom base URL.
+// If baseURL is empty or the default (https://github.com), the standard
+// github.com URLs are returned.
+func deviceFlowURLs(baseURL, apiURL string) (codeURL, tokURL, uURL string) {
+	codeURL = defaultDeviceCodeURL
+	tokURL = defaultTokenURL
+	uURL = defaultUserURL
+	if baseURL != "" && baseURL != "https://github.com" {
+		codeURL = baseURL + "/login/device/code"
+		tokURL = baseURL + "/login/oauth/access_token"
+	}
+	if apiURL != "" && apiURL != "https://api.github.com" {
+		uURL = apiURL + "/user"
+	}
+	return
+}
 
 type DeviceFlowState struct {
 	DeviceCode      string `json:"device_code"`
@@ -29,12 +49,16 @@ type DeviceFlowState struct {
 	Interval        int    `json:"interval"`
 }
 
-func StartDeviceFlow(clientID string) (*DeviceFlowState, error) {
+// StartDeviceFlow initiates GitHub device flow authentication.
+// baseURL and apiURL allow overriding endpoints for GHE; pass empty strings
+// for default github.com behavior.
+func StartDeviceFlow(clientID, baseURL, apiURL string) (*DeviceFlowState, error) {
+	codeURL, _, _ := deviceFlowURLs(baseURL, apiURL)
 	data := url.Values{
 		"client_id": {clientID},
 		"scope":     {deviceScope},
 	}
-	req, err := http.NewRequest("POST", deviceCodeURL, strings.NewReader(data.Encode()))
+	req, err := http.NewRequest("POST", codeURL, strings.NewReader(data.Encode()))
 	if err != nil {
 		return nil, err
 	}
@@ -73,13 +97,17 @@ type pollResponse struct {
 	ErrorDesc   string `json:"error_description"`
 }
 
-func PollDeviceFlow(clientID, deviceCode string) (token string, status string, err error) {
+// PollDeviceFlow polls for a completed device flow token exchange.
+// baseURL and apiURL allow overriding endpoints for GHE; pass empty strings
+// for default github.com behavior.
+func PollDeviceFlow(clientID, deviceCode, baseURL, apiURL string) (token string, status string, err error) {
+	_, tokURL, _ := deviceFlowURLs(baseURL, apiURL)
 	data := url.Values{
 		"client_id":   {clientID},
 		"device_code": {deviceCode},
 		"grant_type":  {"urn:ietf:params:oauth:grant-type:device_code"},
 	}
-	req, err := http.NewRequest("POST", tokenURL, strings.NewReader(data.Encode()))
+	req, err := http.NewRequest("POST", tokURL, strings.NewReader(data.Encode()))
 	if err != nil {
 		return "", "", err
 	}
@@ -116,8 +144,12 @@ type GitHubUser struct {
 	AvatarURL string `json:"avatar_url"`
 }
 
-func ValidateToken(token string) (*GitHubUser, error) {
-	req, err := http.NewRequest("GET", userURL, nil)
+// ValidateToken validates a GitHub token by fetching the authenticated user.
+// apiURL allows overriding the API endpoint for GHE; pass empty string for
+// default github.com behavior.
+func ValidateToken(token, apiURL string) (*GitHubUser, error) {
+	_, _, uURL := deviceFlowURLs("", apiURL)
+	req, err := http.NewRequest("GET", uURL, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/pkg/github/deviceflow_extra_test.go
+++ b/v2/pkg/github/deviceflow_extra_test.go
@@ -14,7 +14,7 @@ func TestValidateTokenBadJSON(t *testing.T) {
 			Body:       io.NopCloser(strings.NewReader(`{invalid json`)),
 		}, nil
 	}, func() {
-		_, err := ValidateToken("ghp_test")
+		_, err := ValidateToken("ghp_test", "")
 		if err == nil {
 			t.Error("should error on invalid JSON response")
 		}
@@ -31,7 +31,7 @@ func TestStartDeviceFlowBadJSON(t *testing.T) {
 			Body:       io.NopCloser(strings.NewReader(`not json`)),
 		}, nil
 	}, func() {
-		_, err := StartDeviceFlow("test-client-id")
+		_, err := StartDeviceFlow("test-client-id", "", "")
 		if err == nil {
 			t.Error("should error on invalid JSON response")
 		}
@@ -45,7 +45,7 @@ func TestPollDeviceFlowBadJSON(t *testing.T) {
 			Body:       io.NopCloser(strings.NewReader(`not json`)),
 		}, nil
 	}, func() {
-		_, _, err := PollDeviceFlow("test-client-id", "test-device-code")
+		_, _, err := PollDeviceFlow("test-client-id", "test-device-code", "", "")
 		if err == nil {
 			t.Error("should error on invalid JSON response")
 		}
@@ -56,7 +56,7 @@ func TestStartDeviceFlowNetworkError(t *testing.T) {
 	withMockDeviceFlow(func(req *http.Request) (*http.Response, error) {
 		return nil, &http.MaxBytesError{}
 	}, func() {
-		_, err := StartDeviceFlow("test-client-id")
+		_, err := StartDeviceFlow("test-client-id", "", "")
 		if err == nil {
 			t.Error("should error on network failure")
 		}
@@ -67,7 +67,7 @@ func TestPollDeviceFlowNetworkError(t *testing.T) {
 	withMockDeviceFlow(func(req *http.Request) (*http.Response, error) {
 		return nil, &http.MaxBytesError{}
 	}, func() {
-		_, _, err := PollDeviceFlow("test-client-id", "test-device-code")
+		_, _, err := PollDeviceFlow("test-client-id", "test-device-code", "", "")
 		if err == nil {
 			t.Error("should error on network failure")
 		}
@@ -78,7 +78,7 @@ func TestValidateTokenNetworkError(t *testing.T) {
 	withMockDeviceFlow(func(req *http.Request) (*http.Response, error) {
 		return nil, &http.MaxBytesError{}
 	}, func() {
-		_, err := ValidateToken("ghp_test")
+		_, err := ValidateToken("ghp_test", "")
 		if err == nil {
 			t.Error("should error on network failure")
 		}

--- a/v2/pkg/github/deviceflow_test.go
+++ b/v2/pkg/github/deviceflow_test.go
@@ -28,7 +28,7 @@ func TestStartDeviceFlowSuccess(t *testing.T) {
 		}
 		return jsonBodyResponse(200, resp), nil
 	}, func() {
-		state, err := StartDeviceFlow("test-client-id")
+		state, err := StartDeviceFlow("test-client-id", "", "")
 		if err != nil {
 			t.Fatalf("error: %v", err)
 		}
@@ -53,7 +53,7 @@ func TestStartDeviceFlowDefaultInterval(t *testing.T) {
 		}
 		return jsonBodyResponse(200, resp), nil
 	}, func() {
-		state, err := StartDeviceFlow("test-client-id")
+		state, err := StartDeviceFlow("test-client-id", "", "")
 		if err != nil {
 			t.Fatalf("error: %v", err)
 		}
@@ -67,7 +67,7 @@ func TestStartDeviceFlowServerError(t *testing.T) {
 	withMockDeviceFlow(func(req *http.Request) (*http.Response, error) {
 		return jsonBodyResponse(500, map[string]string{"error": "server error"}), nil
 	}, func() {
-		_, err := StartDeviceFlow("test-client-id")
+		_, err := StartDeviceFlow("test-client-id", "", "")
 		if err == nil {
 			t.Error("expected error on 500")
 		}
@@ -82,7 +82,7 @@ func TestPollDeviceFlowComplete(t *testing.T) {
 			Scope:       "repo",
 		}), nil
 	}, func() {
-		token, status, err := PollDeviceFlow("client-id", "device-code")
+		token, status, err := PollDeviceFlow("client-id", "device-code", "", "")
 		if err != nil {
 			t.Fatalf("error: %v", err)
 		}
@@ -102,7 +102,7 @@ func TestPollDeviceFlowPending(t *testing.T) {
 			ErrorDesc: "waiting for user",
 		}), nil
 	}, func() {
-		token, status, err := PollDeviceFlow("client-id", "device-code")
+		token, status, err := PollDeviceFlow("client-id", "device-code", "", "")
 		if err != nil {
 			t.Fatalf("error: %v", err)
 		}
@@ -121,7 +121,7 @@ func TestPollDeviceFlowSlowDown(t *testing.T) {
 			Error: "slow_down",
 		}), nil
 	}, func() {
-		_, status, err := PollDeviceFlow("client-id", "device-code")
+		_, status, err := PollDeviceFlow("client-id", "device-code", "", "")
 		if err != nil {
 			t.Fatalf("error: %v", err)
 		}
@@ -138,7 +138,7 @@ func TestPollDeviceFlowError(t *testing.T) {
 			ErrorDesc: "user denied",
 		}), nil
 	}, func() {
-		_, _, err := PollDeviceFlow("client-id", "device-code")
+		_, _, err := PollDeviceFlow("client-id", "device-code", "", "")
 		if err == nil {
 			t.Error("expected error on access_denied")
 		}
@@ -152,7 +152,7 @@ func TestValidateTokenSuccess(t *testing.T) {
 			AvatarURL: "https://example.com/avatar.png",
 		}), nil
 	}, func() {
-		user, err := ValidateToken("gho_valid_token")
+		user, err := ValidateToken("gho_valid_token", "")
 		if err != nil {
 			t.Fatalf("error: %v", err)
 		}
@@ -166,7 +166,7 @@ func TestValidateTokenInvalid(t *testing.T) {
 	withMockDeviceFlow(func(req *http.Request) (*http.Response, error) {
 		return jsonBodyResponse(401, map[string]string{"message": "Bad credentials"}), nil
 	}, func() {
-		_, err := ValidateToken("invalid-token")
+		_, err := ValidateToken("invalid-token", "")
 		if err == nil {
 			t.Error("expected error on 401")
 		}

--- a/v2/pkg/github/github_extra_test.go
+++ b/v2/pkg/github/github_extra_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSetRepos(t *testing.T) {
-	c := NewClient("token", "testorg", []string{"repo1"}, slog.Default())
+	c := NewClient("token", "testorg", []string{"repo1"}, slog.Default(), "")
 	repos := c.getRepos()
 	if len(repos) != 1 || repos[0] != "repo1" {
 		t.Errorf("initial repos = %v", repos)
@@ -22,7 +22,7 @@ func TestSetRepos(t *testing.T) {
 }
 
 func TestSplitRepo(t *testing.T) {
-	c := NewClient("token", "defaultorg", nil, slog.Default())
+	c := NewClient("token", "defaultorg", nil, slog.Default(), "")
 
 	owner, repo := c.splitRepo("myorg/myrepo")
 	if owner != "myorg" || repo != "myrepo" {
@@ -36,19 +36,19 @@ func TestSplitRepo(t *testing.T) {
 }
 
 func TestPrimaryRepoExtended(t *testing.T) {
-	c := NewClient("token", "org", []string{"first", "second"}, slog.Default())
+	c := NewClient("token", "org", []string{"first", "second"}, slog.Default(), "")
 	if got := c.primaryRepo(); got != "first" {
 		t.Errorf("primaryRepo = %q, want first", got)
 	}
 
-	c2 := NewClient("token", "org", nil, slog.Default())
+	c2 := NewClient("token", "org", nil, slog.Default(), "")
 	if got := c2.primaryRepo(); got != "console" {
 		t.Errorf("primaryRepo empty = %q, want console", got)
 	}
 }
 
 func TestGetReposCopy(t *testing.T) {
-	c := NewClient("token", "org", []string{"a", "b"}, slog.Default())
+	c := NewClient("token", "org", []string{"a", "b"}, slog.Default(), "")
 	repos := c.getRepos()
 	repos[0] = "modified"
 	original := c.getRepos()
@@ -90,7 +90,7 @@ func TestIsHeldExtended(t *testing.T) {
 }
 
 func TestNewClientBasic(t *testing.T) {
-	c := NewClient("token", "org", []string{"repo"}, slog.Default())
+	c := NewClient("token", "org", []string{"repo"}, slog.Default(), "")
 	if c == nil {
 		t.Fatal("NewClient returned nil")
 	}

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -59,6 +59,7 @@ type HeartbeatPayload struct {
 	DashboardURL string             `json:"dashboard_url"`
 	SnapshotURL  string             `json:"snapshot_url"`
 	Owner        string             `json:"owner,omitempty"`
+	HiveType     string             `json:"hive_type,omitempty"`
 	IsPublic     bool               `json:"is_public"`
 	Version      string             `json:"version"`
 	GitHash      string             `json:"git_hash"`

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -12,9 +12,12 @@ import (
 )
 
 const (
-	ghAuthorizeURL   = "https://github.com/login/oauth/authorize"
-	ghTokenURL       = "https://github.com/login/oauth/access_token"
-	ghUserURL        = "https://api.github.com/user"
+	// defaultGHAuthorizeURL is the GitHub.com OAuth authorization endpoint.
+	defaultGHAuthorizeURL = "https://github.com/login/oauth/authorize"
+	// defaultGHTokenURL is the GitHub.com OAuth token exchange endpoint.
+	defaultGHTokenURL = "https://github.com/login/oauth/access_token"
+	// defaultGHUserURL is the GitHub.com API user endpoint.
+	defaultGHUserURL = "https://api.github.com/user"
 	oauthTimeout     = 10 * time.Second
 	cookieMaxAgeDays = 7 // login session cookie lifetime
 )
@@ -43,7 +46,7 @@ func (s *HubServer) handleLogin(w http.ResponseWriter, r *http.Request) {
 	}
 	state := url.QueryEscape(redirect)
 	authURL := fmt.Sprintf("%s?client_id=%s&scope=read:user&redirect_uri=%s&state=%s",
-		ghAuthorizeURL, clientID, "https://hive.kubestellar.io/api/auth/callback", state)
+		defaultGHAuthorizeURL, clientID, "https://hive.kubestellar.io/api/auth/callback", state)
 	http.Redirect(w, r, authURL, http.StatusTemporaryRedirect)
 }
 
@@ -57,7 +60,7 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	clientID := os.Getenv("HIVE_HUB_OAUTH_CLIENT_ID")
 	clientSecret := os.Getenv("HIVE_HUB_OAUTH_CLIENT_SECRET")
 
-	tokenReq, _ := http.NewRequest("POST", ghTokenURL, nil)
+	tokenReq, _ := http.NewRequest("POST", defaultGHTokenURL, nil)
 	q := tokenReq.URL.Query()
 	q.Set("client_id", clientID)
 	q.Set("client_secret", clientSecret)
@@ -93,7 +96,7 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	userReq, _ := http.NewRequest("GET", ghUserURL, nil)
+	userReq, _ := http.NewRequest("GET", defaultGHUserURL, nil)
 	userReq.Header.Set("Authorization", "Bearer "+tokenResp.AccessToken)
 	userResp, err := client.Do(userReq)
 	if err != nil {

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -245,7 +245,8 @@ func (s *HubServer) validateGitHubToken(token string) string {
 	ghTokenCacheMu.RUnlock()
 
 	client := &http.Client{Timeout: 10 * time.Second}
-	req, err := http.NewRequest("GET", "https://api.github.com/user", nil)
+	// Hub always validates tokens against github.com (the hub is a SaaS service).
+	req, err := http.NewRequest("GET", defaultGHUserURL, nil)
 	if err != nil {
 		return ""
 	}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -292,6 +292,9 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		ActiveContributors: clampInt(payload.Contributors.Active, 0, 10_000),
 		Owner:              sanitizeHeartbeatField(payload.Owner),
 		HiveType: func() string {
+			if payload.HiveType != "" {
+				return sanitizeHeartbeatField(payload.HiveType)
+			}
 			if strings.HasPrefix(payload.HiveID, "hosted-") || strings.HasPrefix(payload.HiveID, "saas-") {
 				return "hosted"
 			}

--- a/v2/pkg/proxy/rules.go
+++ b/v2/pkg/proxy/rules.go
@@ -22,6 +22,15 @@ var githubHosts = map[string]bool{
 	"github.com":     true,
 }
 
+// RegisterGitHubHost adds a custom hostname (e.g. GHE instance) to the
+// allowlist so that the proxy applies mode enforcement to it.
+func RegisterGitHubHost(host string) {
+	if host == "" {
+		return
+	}
+	githubHosts[host] = true
+}
+
 // IsGitHubHost returns true if the host should be subject to mode enforcement.
 func IsGitHubHost(host string) bool {
 	return githubHosts[host]


### PR DESCRIPTION
## Summary

Add `api_url` and `base_url` fields to the `github:` config block so hive spokes can target GitHub Enterprise (GHE) instances (e.g. `github.ibm.com`) alongside standard `github.com` repos. Default behavior is completely unchanged — empty fields default to `github.com`.

### Config example (GHE)
```yaml
github:
  api_url: "https://github.ibm.com/api/v3"
  base_url: "https://github.ibm.com"
  token: "ghp_..."
```

### Changes by file
- **config.go** — `APIURL`/`BaseURL` fields on `GitHubConfig` with `ResolvedAPIURL()`/`ResolvedBaseURL()` helpers and named default constants
- **client.go** — `NewClient()` accepts `apiURL`; new `setBaseURL()` helper configures `BaseURL`/`UploadURL` on the go-github client
- **app.go** — `AppAuth` carries `apiURL`; all JWT/installation-token clients use it via `setBaseURL()`
- **deviceflow.go** — `StartDeviceFlow()`, `PollDeviceFlow()`, `ValidateToken()` derive endpoints from configured base/API URLs
- **api.go / api_contribute.go** — pass configured URLs through to device flow and token validation
- **proxy/rules.go** — `RegisterGitHubHost()` adds GHE hostnames to the proxy allowlist dynamically
- **main.go** — wires config URLs to all client/auth/proxy constructors; registers GHE hosts with the proxy
- **oauth.go / saas.go** — hub-only endpoints use named constants but remain hardcoded to `github.com` (the hub is always a `github.com` service)

### What stays on github.com
- Hub OAuth login flow (oauth.go)
- Hub SaaS token validation (saas.go)
- Hub self-update SHA polling (saas.go lines 1543, 1605) — these check `kubestellar/hive` releases

## Test plan
- [ ] Verify existing github.com spokes work identically (empty `api_url`/`base_url`)
- [ ] Test with GHE instance: set `api_url` and `base_url`, verify issues/PRs/cloning work
- [ ] Verify device flow login works against both github.com and GHE
- [ ] Verify proxy mode enforcement applies to GHE API hostname
- [ ] Run existing unit tests (`go test ./v2/...`)