### PR TITLE
fix: prevent duplicate advisory issues on repos with many open issues

### DIFF
--- a/v2/pkg/github/advisory.go
+++ b/v2/pkg/github/advisory.go
@@ -140,29 +140,35 @@ func (c *Client) findDigestComment(ctx context.Context, owner, repo string, issu
 }
 
 func (c *Client) findAdvisoryIssue(ctx context.Context, owner, repo string) (int, error) {
-	opts := &gh.IssueListByRepoOptions{
-		State:  "open",
-		Labels: []string{advisoryLabelName},
+	// Use search API to find the advisory issue across all open issues,
+	// regardless of how many issues the repo has.
+	query := fmt.Sprintf(`repo:%s/%s is:issue is:open in:title "%s"`, owner, repo, advisoryTitle)
+	result, _, err := c.client.Search.Issues(ctx, query, &gh.SearchOptions{
 		ListOptions: gh.ListOptions{PerPage: 5},
-	}
-	issues, _, err := c.client.Issues.ListByRepo(ctx, owner, repo, opts)
+	})
 	if err == nil {
-		for _, issue := range issues {
+		for _, issue := range result.Issues {
 			if issue.GetTitle() == advisoryTitle {
 				return issue.GetNumber(), nil
 			}
 		}
+	} else {
+		c.logger.Warn("search API failed, falling back to label filter", slog.String("error", err.Error()))
 	}
 
-	// Fallback: search by title if label-based search failed or found nothing
-	// (label may not exist if we don't have permission to create it)
-	titleOpts := &gh.IssueListByRepoOptions{
-		State:       "open",
-		ListOptions: gh.ListOptions{PerPage: 20},
+	// Fallback: list by label (works even when search API is unavailable,
+	// e.g. GitHub App tokens without search scope)
+	opts := &gh.IssueListByRepoOptions{
+		State:  "open",
+		Labels: []string{advisoryLabelName},
+		ListOptions: gh.ListOptions{PerPage: 10},
 	}
-	issues, _, err = c.client.Issues.ListByRepo(ctx, owner, repo, titleOpts)
-	if err != nil {
-		return 0, err
+	issues, _, listErr := c.client.Issues.ListByRepo(ctx, owner, repo, opts)
+	if listErr != nil {
+		if err != nil {
+			return 0, fmt.Errorf("search failed: %w; list fallback also failed: %w", err, listErr)
+		}
+		return 0, listErr
 	}
 	for _, issue := range issues {
 		if issue.GetTitle() == advisoryTitle {


### PR DESCRIPTION
## Summary
- `findAdvisoryIssue()` only fetched the first page of issues (5 by label, 20 by title scan)
- On repos with hundreds of open issues (like kubestellar/console), the existing advisory issue is beyond page 1
- A second hive instance connecting to the same repo creates a duplicate instead of finding the existing one
- **Fix**: Use GitHub's Search API which filters by title across all issues without pagination limits
- Label-based list kept as fallback for tokens that lack search scope

## Root cause
kubestellar/console has two advisory issues (#17528 from Jun 11, #18753 from Jun 17) because the title-scan fallback path used `PerPage: 20` — not enough to find the existing advisory among 500+ open issues.

## Test plan
- [ ] Start two hive instances against the same repo — verify only one advisory issue exists
- [ ] Verify search API correctly finds existing advisory issue
- [ ] Verify fallback works when search API is unavailable

🐝 Generated with [Claude Code](https://claude.com/claude-code)