### PR TITLE
feat: multi-cluster support — cluster registry and kubectl context wrapper

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -133,7 +132,7 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("PUT /api/saas/admin/users/{username}", s.requireAdmin(s.handleAdminUpdateUser))
 	s.mux.HandleFunc("GET /api/saas/cluster-health", s.requireAdmin(s.handleClusterHealth))
 
-	go StartProvisionWatcher(s.logger, &s.mu)
+	go s.startProvisionWatcher()
 	go s.StartLatestSHAPoller()
 }
 
@@ -503,14 +502,16 @@ func (s *HubServer) handleClusterHealth(w http.ResponseWriter, r *http.Request) 
 }
 
 func buildClusterHealth(s *HubServer) (*ClusterHealthResponse, error) {
+	hubC := s.hubCluster()
+
 	// Run kubectl top nodes
-	topOut, err := exec.Command("kubectl", "top", "nodes", "--no-headers").Output()
+	topOut, err := kubectlForCluster(hubC, "top", "nodes", "--no-headers").Output()
 	if err != nil {
 		return nil, fmt.Errorf("kubectl top nodes: %w", err)
 	}
 
 	// Run kubectl get nodes -o json
-	getOut, err := exec.Command("kubectl", "get", "nodes", "-o", "json").Output()
+	getOut, err := kubectlForCluster(hubC, "get", "nodes", "-o", "json").Output()
 	if err != nil {
 		return nil, fmt.Errorf("kubectl get nodes: %w", err)
 	}
@@ -613,7 +614,7 @@ func buildClusterHealth(s *HubServer) (*ClusterHealthResponse, error) {
 	}
 
 	// Count running pods per node
-	podOut, _ := exec.Command("kubectl", "get", "pods", "--all-namespaces", "--field-selector=status.phase=Running", "-o", "json").Output()
+	podOut, _ := kubectlForCluster(hubC, "get", "pods", "--all-namespaces", "--field-selector=status.phase=Running", "-o", "json").Output()
 	if len(podOut) > 0 {
 		var podsJSON struct {
 			Items []struct {
@@ -1078,7 +1079,15 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 	saveSaaSUser(user)
 
 	go func() {
-		if err := provisionHive(h, &req, s.logger); err != nil {
+		cluster := s.clusterForHive(h)
+		if cluster == nil {
+			h.Status = "error"
+			h.Error = "no cluster config available"
+			saveSaaSHive(h)
+			s.logger.Error("no cluster config for provisioning", "hive_id", hiveID, "cluster_id", h.ClusterID)
+			return
+		}
+		if err := provisionHive(h, &req, cluster, s.logger); err != nil {
 			h.Status = "error"
 			h.Error = err.Error()
 			saveSaaSHive(h)
@@ -1139,7 +1148,13 @@ func (s *HubServer) handleDeleteHive(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Full de-provisioning: namespace, PV, OCI export, OCI file system, disk record, user cleanup.
-	deprovisionHive(h, s.logger)
+	cluster := s.clusterForHive(h)
+	if cluster == nil {
+		s.logger.Error("no cluster config for deprovision", "hive_id", id, "cluster_id", h.ClusterID)
+		http.Error(w, `{"error":"no cluster config — cannot deprovision"}`, http.StatusInternalServerError)
+		return
+	}
+	deprovisionHive(h, cluster, s.logger)
 
 	s.logger.Info("audit: hosted hive deleted", "hive_id", id, "by", username)
 	w.Header().Set("Content-Type", "application/json")
@@ -1176,7 +1191,7 @@ func (s *HubServer) handleHubAutoUpgrade(w http.ResponseWriter, r *http.Request)
 		latestSHA := getLatestSHA()
 		if latestSHA != "" && latestSHA != s.hubGitHash {
 			s.logger.Info("audit: hub auto-upgrade initial trigger", "from", s.hubGitHash, "to", latestSHA)
-			cmd := exec.Command("kubectl", "rollout", "restart", "deployment/hive-hub", "-n", "hive-hub")
+			cmd := kubectlForCluster(s.hubCluster(), "rollout", "restart", "deployment/hive-hub", "-n", "hive-hub")
 			if out, err := cmd.CombinedOutput(); err != nil {
 				s.logger.Warn("hub auto-upgrade failed", "output", string(out))
 			}
@@ -1190,7 +1205,7 @@ func (s *HubServer) handleHubAutoUpgrade(w http.ResponseWriter, r *http.Request)
 func (s *HubServer) handleHubSelfUpgrade(w http.ResponseWriter, r *http.Request) {
 	username := s.getAuthUser(r)
 	s.logger.Info("audit: hub self-upgrade triggered", "by", username)
-	cmd := exec.Command("kubectl", "rollout", "restart", "deployment/hive-hub", "-n", "hive-hub")
+	cmd := kubectlForCluster(s.hubCluster(), "rollout", "restart", "deployment/hive-hub", "-n", "hive-hub")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		s.logger.Warn("hub self-upgrade failed", "output", string(out))
@@ -1224,15 +1239,20 @@ func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"only the owner can upgrade"}`, http.StatusForbidden)
 		return
 	}
+	cluster := s.clusterForHive(h)
+	if cluster == nil {
+		http.Error(w, `{"error":"no cluster config for this hive"}`, http.StatusInternalServerError)
+		return
+	}
 	ns := "hive-hosted-" + id
-	cmd := exec.Command("kubectl", "rollout", "restart", "deployment/hive", "-n", ns)
+	cmd := kubectlForCluster(cluster, "rollout", "restart", "deployment/hive", "-n", ns)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		s.logger.Warn("upgrade failed", "hive", id, "output", string(out))
+		s.logger.Warn("upgrade failed", "hive", id, "cluster", cluster.ID, "output", string(out))
 		http.Error(w, `{"error":"upgrade failed — check hub logs for details"}`, http.StatusInternalServerError)
 		return
 	}
-	s.logger.Info("audit: hosted hive upgraded", "hive_id", id, "by", username)
+	s.logger.Info("audit: hosted hive upgraded", "hive_id", id, "by", username, "cluster", cluster.ID)
 	s.mu.Lock()
 	for i := range s.registry.Hives {
 		if s.registry.Hives[i].ID == id {
@@ -1366,10 +1386,13 @@ func (s *HubServer) handleToggleAutoUpgrade(w http.ResponseWriter, r *http.Reque
 			s.mu.RUnlock()
 			if currentSHA != "" && currentSHA != latestSHA {
 				s.logger.Info("audit: auto-upgrade initial trigger", "hive_id", id, "from", currentSHA, "to", latestSHA)
-				ns := "hive-hosted-" + id
-				cmd := exec.Command("kubectl", "rollout", "restart", "deployment/hive", "-n", ns)
-				if out, err := cmd.CombinedOutput(); err != nil {
-					s.logger.Warn("auto-upgrade initial trigger failed", "hive", id, "output", string(out))
+				hiveCluster := s.clusterForHive(h)
+				if hiveCluster != nil {
+					ns := "hive-hosted-" + id
+					cmd := kubectlForCluster(hiveCluster, "rollout", "restart", "deployment/hive", "-n", ns)
+					if out, err := cmd.CombinedOutput(); err != nil {
+						s.logger.Warn("auto-upgrade initial trigger failed", "hive", id, "cluster", hiveCluster.ID, "output", string(out))
+					}
 				}
 			}
 		}
@@ -1464,7 +1487,7 @@ func (s *HubServer) StartLatestSHAPoller() {
 			hubBranchSHA := getLatestSHAForBranch("v2")
 			if isHubAutoUpgrade() && hubBranchSHA != "" && hubBranchSHA != s.hubGitHash {
 				s.logger.Info("audit: hub auto-upgrade triggered", "from", s.hubGitHash, "to", hubBranchSHA)
-				cmd := exec.Command("kubectl", "rollout", "restart", "deployment/hive-hub", "-n", "hive-hub")
+				cmd := kubectlForCluster(s.hubCluster(), "rollout", "restart", "deployment/hive-hub", "-n", "hive-hub")
 				if out, err := cmd.CombinedOutput(); err != nil {
 					s.logger.Warn("hub auto-upgrade failed", "output", string(out))
 				}
@@ -1509,7 +1532,12 @@ func (s *HubServer) triggerAutoUpgrades() {
 		if latestSHA == "" || currentSHA == latestSHA {
 			continue
 		}
-		s.logger.Info("audit: auto-upgrade triggered", "hive_id", h.ID, "branch", branch, "from", currentSHA, "to", latestSHA)
+		hiveCluster := s.clusterForHive(&h)
+		if hiveCluster == nil {
+			s.logger.Warn("auto-upgrade skipped — no cluster config", "hive_id", h.ID, "cluster_id", h.ClusterID)
+			continue
+		}
+		s.logger.Info("audit: auto-upgrade triggered", "hive_id", h.ID, "branch", branch, "from", currentSHA, "to", latestSHA, "cluster", hiveCluster.ID)
 		s.mu.Lock()
 		for i := range s.registry.Hives {
 			if s.registry.Hives[i].ID == h.ID {
@@ -1520,9 +1548,9 @@ func (s *HubServer) triggerAutoUpgrades() {
 		}
 		s.mu.Unlock()
 		ns := "hive-hosted-" + h.ID
-		cmd := exec.Command("kubectl", "rollout", "restart", "deployment/hive", "-n", ns)
+		cmd := kubectlForCluster(hiveCluster, "rollout", "restart", "deployment/hive", "-n", ns)
 		if out, err := cmd.CombinedOutput(); err != nil {
-			s.logger.Warn("auto-upgrade failed", "hive", h.ID, "output", string(out))
+			s.logger.Warn("auto-upgrade failed", "hive", h.ID, "cluster", hiveCluster.ID, "output", string(out))
 			s.mu.Lock()
 			for i := range s.registry.Hives {
 				if s.registry.Hives[i].ID == h.ID {

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"sync"
 	"text/template"
 	"time"
 )
@@ -32,6 +31,103 @@ const (
 	rolloutMaxSurge       = 1
 	rolloutMaxUnavailable = 0
 )
+
+// defaultClusterID is the cluster ID assigned to hives that predate
+// multi-cluster support.
+const defaultClusterID = "hive-oke"
+
+// clustersConfigPath is the on-disk location where the hub reads cluster
+// definitions. It is a JSON array of ClusterConfig objects.
+const clustersConfigPath = "/data/saas/clusters.json"
+
+// ClusterConfig describes a Kubernetes cluster that the hub can provision
+// hive spokes onto. Each cluster has its own kubeconfig, storage backend,
+// ingress style, and optional platform-specific settings (OCI, OpenShift).
+type ClusterConfig struct {
+	ID              string `json:"id" yaml:"id"`
+	Name            string `json:"name" yaml:"name"`
+	KubeconfigPath  string `json:"kubeconfig_path,omitempty" yaml:"kubeconfig_path,omitempty"`
+	Context         string `json:"context" yaml:"context"`
+	InCluster       bool   `json:"in_cluster" yaml:"in_cluster"`
+	StorageClass    string `json:"storage_class" yaml:"storage_class"`
+	StorageType     string `json:"storage_type" yaml:"storage_type"`
+	NFSMountIP      string `json:"nfs_mount_ip,omitempty" yaml:"nfs_mount_ip,omitempty"`
+	IngressType     string `json:"ingress_type" yaml:"ingress_type"`
+	IngressClass    string `json:"ingress_class,omitempty" yaml:"ingress_class,omitempty"`
+	CertIssuer      string `json:"cert_issuer,omitempty" yaml:"cert_issuer,omitempty"`
+	Domain          string `json:"domain" yaml:"domain"`
+	DomainPrefix    string `json:"domain_prefix,omitempty" yaml:"domain_prefix,omitempty"`
+	OCICompartment  string `json:"oci_compartment,omitempty" yaml:"oci_compartment,omitempty"`
+	OCIAvailDomain  string `json:"oci_avail_domain,omitempty" yaml:"oci_avail_domain,omitempty"`
+	OCIMountTarget  string `json:"oci_mount_target,omitempty" yaml:"oci_mount_target,omitempty"`
+	OCIExportSet    string `json:"oci_export_set,omitempty" yaml:"oci_export_set,omitempty"`
+	RequiresSCC     bool   `json:"requires_scc" yaml:"requires_scc"`
+	SCCName         string `json:"scc_name,omitempty" yaml:"scc_name,omitempty"`
+	HasGPU          bool   `json:"has_gpu" yaml:"has_gpu"`
+	Arch            string `json:"arch" yaml:"arch"`
+	ImageTag        string `json:"image_tag" yaml:"image_tag"`
+	ImagePullPolicy string `json:"image_pull_policy,omitempty" yaml:"image_pull_policy,omitempty"`
+}
+
+// kubectlForCluster builds an exec.Cmd that targets a specific cluster.
+// For in-cluster configs (InCluster == true) it runs plain kubectl;
+// for remote clusters it injects --kubeconfig and --context flags.
+func kubectlForCluster(cluster *ClusterConfig, args ...string) *exec.Cmd {
+	fullArgs := []string{}
+	if !cluster.InCluster {
+		fullArgs = append(fullArgs, "--kubeconfig", cluster.KubeconfigPath, "--context", cluster.Context)
+	}
+	fullArgs = append(fullArgs, args...)
+	return exec.Command("kubectl", fullArgs...)
+}
+
+// loadClusters reads the clusters config file and returns a validated
+// map of cluster ID → ClusterConfig. If the file does not exist, it
+// returns a single default entry for hive-oke (backward compatibility).
+func loadClusters(logger *slog.Logger) map[string]ClusterConfig {
+	clusters := make(map[string]ClusterConfig)
+
+	data, err := os.ReadFile(clustersConfigPath)
+	if err != nil {
+		logger.Info("no clusters config found, using default hive-oke cluster", "path", clustersConfigPath)
+		clusters[defaultClusterID] = ClusterConfig{
+			ID:          defaultClusterID,
+			Name:        "OKE (default)",
+			InCluster:   true,
+			StorageType: "nfs",
+			IngressType: "nginx",
+			Domain:      "hive.kubestellar.io",
+			Arch:        "arm64",
+			ImageTag:    "v2-latest",
+		}
+		return clusters
+	}
+
+	var configs []ClusterConfig
+	if err := json.Unmarshal(data, &configs); err != nil {
+		logger.Error("failed to parse clusters config", "path", clustersConfigPath, "error", err)
+		return clusters
+	}
+
+	for _, c := range configs {
+		if c.ID == "" {
+			logger.Warn("skipping cluster config with empty ID")
+			continue
+		}
+		if !c.InCluster && c.KubeconfigPath == "" {
+			logger.Warn("skipping remote cluster with no kubeconfig_path", "cluster", c.ID)
+			continue
+		}
+		if c.Domain == "" {
+			logger.Warn("skipping cluster with no domain", "cluster", c.ID)
+			continue
+		}
+		clusters[c.ID] = c
+	}
+
+	logger.Info("loaded cluster configs", "count", len(clusters))
+	return clusters
+}
 
 type PendingAccessRequest struct {
 	Username    string `json:"username"`
@@ -54,6 +150,7 @@ type SaaSHive struct {
 	PendingRequests []PendingAccessRequest `json:"pending_requests,omitempty"`
 	OCIFileSystemID string                 `json:"oci_file_system_id,omitempty"`
 	OCIExportID     string                 `json:"oci_export_id,omitempty"`
+	ClusterID       string                 `json:"cluster_id,omitempty"`
 }
 
 type CreateHiveRequest struct {
@@ -91,6 +188,34 @@ func sanitize(s string) string {
 		}
 	}
 	return b.String()
+}
+
+// clusterForHive returns the ClusterConfig for a given hive, falling back
+// to the default cluster if the hive has no cluster_id or the ID is unknown.
+func (s *HubServer) clusterForHive(h *SaaSHive) *ClusterConfig {
+	clusterID := h.ClusterID
+	if clusterID == "" {
+		clusterID = defaultClusterID
+	}
+	if c, ok := s.clusters[clusterID]; ok {
+		return &c
+	}
+	// Fallback: return the default cluster if it exists.
+	if c, ok := s.clusters[defaultClusterID]; ok {
+		return &c
+	}
+	return nil
+}
+
+// hubCluster returns the cluster config for the hub itself (always the
+// default in-cluster config). Hub operations like self-upgrade always
+// target this cluster.
+func (s *HubServer) hubCluster() *ClusterConfig {
+	if c, ok := s.clusters[defaultClusterID]; ok {
+		return &c
+	}
+	// Fallback: synthesize an in-cluster config so hub operations still work.
+	return &ClusterConfig{ID: defaultClusterID, InCluster: true}
 }
 
 func loadSaaSHive(id string) *SaaSHive {
@@ -155,7 +280,7 @@ func countUserHives(username string) int {
 	return count
 }
 
-func provisionHive(h *SaaSHive, req *CreateHiveRequest, logger *slog.Logger) error {
+func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, logger *slog.Logger) error {
 	dir := filepath.Join(saasHivesDir, h.ID, "manifests")
 	os.MkdirAll(dir, 0o755)
 
@@ -256,7 +381,7 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, logger *slog.Logger) err
 	}
 	f.Close()
 
-	cmd := exec.Command("kubectl", "apply", "-f", manifestPath)
+	cmd := kubectlForCluster(cluster, "apply", "-f", manifestPath)
 	out, err := cmd.CombinedOutput()
 
 	// Remove manifest immediately — it contains GitHub tokens in plaintext
@@ -265,11 +390,11 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, logger *slog.Logger) err
 	}
 
 	if err != nil {
-		logger.Warn("kubectl apply failed", "hive", h.ID, "output", string(out), "error", err)
+		logger.Warn("kubectl apply failed", "hive", h.ID, "cluster", cluster.ID, "output", string(out), "error", err)
 		return fmt.Errorf("provisioning failed — check hub logs for details")
 	}
 
-	logger.Info("audit: saas hive provisioned", "hive_id", h.ID, "owner", h.Owner, "org", h.Org)
+	logger.Info("audit: saas hive provisioned", "hive_id", h.ID, "owner", h.Owner, "org", h.Org, "cluster", cluster.ID)
 	return nil
 }
 
@@ -279,14 +404,14 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, logger *slog.Logger) err
 // and the on-disk SaaS hive record. It also decrements the owner's quota.
 // Order matters: namespace before PV, export before file system.
 // Errors are logged but do not stop the remaining cleanup steps.
-func deprovisionHive(h *SaaSHive, logger *slog.Logger) {
+func deprovisionHive(h *SaaSHive, cluster *ClusterConfig, logger *slog.Logger) {
 	hiveID := h.ID
 
 	// Step 1: Delete K8s namespace (cascading delete removes deployment, service,
 	// ingress, configmap, secret, and PVC).
 	ns := "hive-hosted-" + hiveID
-	logger.Info("deprovision: deleting namespace", "namespace", ns)
-	cmd := exec.Command("kubectl", "delete", "namespace", ns, "--ignore-not-found")
+	logger.Info("deprovision: deleting namespace", "namespace", ns, "cluster", cluster.ID)
+	cmd := kubectlForCluster(cluster, "delete", "namespace", ns, "--ignore-not-found")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		logger.Warn("deprovision: namespace delete failed", "namespace", ns, "output", string(out), "error", err)
 	}
@@ -294,7 +419,7 @@ func deprovisionHive(h *SaaSHive, logger *slog.Logger) {
 	// Step 2: Delete cluster-scoped PV (not removed by namespace deletion).
 	pvName := "hive-" + hiveID + "-fss-pv"
 	logger.Info("deprovision: deleting PV", "pv", pvName)
-	cmd = exec.Command("kubectl", "delete", "pv", pvName, "--ignore-not-found")
+	cmd = kubectlForCluster(cluster, "delete", "pv", pvName, "--ignore-not-found")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		logger.Warn("deprovision: PV delete failed", "pv", pvName, "output", string(out), "error", err)
 	}
@@ -334,7 +459,7 @@ func deprovisionHive(h *SaaSHive, logger *slog.Logger) {
 	logger.Info("audit: hive deprovisioned", "hive_id", hiveID, "owner", h.Owner)
 }
 
-func StartProvisionWatcher(logger *slog.Logger, mu *sync.RWMutex) {
+func (s *HubServer) startProvisionWatcher() {
 	ticker := time.NewTicker(provisionPollInterval)
 	defer ticker.Stop()
 
@@ -349,12 +474,17 @@ func StartProvisionWatcher(logger *slog.Logger, mu *sync.RWMutex) {
 				h.Status = "error"
 				h.Error = "provisioning timed out"
 				saveSaaSHive(&h)
-				logger.Warn("saas hive provision timeout", "hive_id", h.ID)
+				s.logger.Warn("saas hive provision timeout", "hive_id", h.ID)
 				continue
 			}
 
+			cluster := s.clusterForHive(&h)
+			if cluster == nil {
+				s.logger.Warn("no cluster config for hive", "hive_id", h.ID, "cluster_id", h.ClusterID)
+				continue
+			}
 			ns := "hive-hosted-" + h.ID
-			cmd := exec.Command("kubectl", "get", "deployment", "hive", "-n", ns, "-o", "jsonpath={.status.availableReplicas}")
+			cmd := kubectlForCluster(cluster, "get", "deployment", "hive", "-n", ns, "-o", "jsonpath={.status.availableReplicas}")
 			out, err := cmd.Output()
 			if err != nil {
 				continue
@@ -362,7 +492,7 @@ func StartProvisionWatcher(logger *slog.Logger, mu *sync.RWMutex) {
 			if strings.TrimSpace(string(out)) == "1" {
 				h.Status = "running"
 				saveSaaSHive(&h)
-				logger.Info("audit: saas hive running", "hive_id", h.ID)
+				s.logger.Info("audit: saas hive running", "hive_id", h.ID, "cluster", cluster.ID)
 			}
 		}
 	}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -54,6 +54,7 @@ type RegistryEntry struct {
 	ContributorCount   int            `json:"contributorCount"`
 	ActiveContributors int            `json:"activeContributors"`
 	Owner              string         `json:"owner,omitempty"`
+	ClusterID          string         `json:"clusterId,omitempty"`
 	HiveType           string         `json:"hiveType,omitempty"`
 	IsPublic           bool           `json:"isPublic"`
 	RegisteredAt       string         `json:"registeredAt"`
@@ -105,6 +106,7 @@ type HubServer struct {
 	hubGitHash string
 	hubSecret  string
 	httpServer *http.Server
+	clusters   map[string]ClusterConfig
 }
 
 func NewHubServer(port int, logger *slog.Logger, gitHash string) *HubServer {
@@ -131,6 +133,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash string) *HubServer {
 		saveCh:     make(chan struct{}, 1),
 		hubGitHash: gitHash,
 		hubSecret:  secret,
+		clusters:   loadClusters(logger),
 	}
 
 	s.loadRegistry()
@@ -328,6 +331,15 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		}(),
 		Online:            true,
 		GitHubAppRequired: payload.GitHubAppRequired,
+	}
+
+	// Populate ClusterID from the SaaS hive record (if this is a hosted hive).
+	if sh := loadSaaSHive(payload.HiveID); sh != nil {
+		clusterID := sh.ClusterID
+		if clusterID == "" {
+			clusterID = defaultClusterID
+		}
+		entry.ClusterID = clusterID
 	}
 
 	s.mu.Lock()


### PR DESCRIPTION
## Summary

Implements Phase 1 (Cluster Registry & Config) and Phase 2 (Kubectl Context Wrapper) of the multi-cluster support plan for the hive hub.

### Phase 1: Cluster Registry & Config
- **`ClusterConfig` struct** in `saas_provision.go` — per-cluster config with kubeconfig path, context, storage type/class, ingress type, domain, SCC, GPU, architecture, OCI-specific fields
- **`ClusterID` field** added to `SaaSHive` and `RegistryEntry` — defaults to `"hive-oke"` for existing hives
- **`Clusters` map** on `HubServer` — loaded at startup via `loadClusters()`
- **`loadClusters()`** reads `/data/saas/clusters.json`, validates entries, falls back to a single default hive-oke entry when the file doesn't exist (backward compatible)
- **`clusterForHive()`** and **`hubCluster()`** helpers for looking up the right cluster

### Phase 2: Kubectl Context Wrapper
- **`kubectlForCluster()`** helper builds `exec.Cmd` with `--kubeconfig`/`--context` for remote clusters, plain `kubectl` for in-cluster
- **All 13 bare `exec.Command("kubectl", ...)` calls** replaced with `kubectlForCluster()` across:
  - Provisioning (`kubectl apply`)
  - Deprovisioning (`kubectl delete namespace`, `kubectl delete pv`)
  - Provision watcher (`kubectl get deployment`)
  - Hive upgrades (`kubectl rollout restart`)
  - Auto-upgrades (per-hive and hub self-upgrade)
  - Cluster health (`kubectl top nodes`, `kubectl get nodes`, `kubectl get pods`)
- `StartProvisionWatcher` converted to `HubServer` method for cluster access
- `os/exec` import removed from `saas.go` (no longer needed directly)

### Backward Compatibility
- No clusters.json file = single default hive-oke cluster, identical behavior to before
- Existing hives with no `cluster_id` default to `"hive-oke"`
- No changes to heartbeat protocol, REST API, or dashboard

## Test plan
- [ ] Verify existing OKE hives continue to work (no clusters.json = default behavior)
- [ ] Verify provision/deprovision/upgrade still work for OKE hives
- [ ] Add a `clusters.json` with a second cluster entry and verify `loadClusters()` loads both
- [ ] Verify `kubectlForCluster()` adds `--kubeconfig`/`--context` for remote clusters
- [ ] Verify `kubectlForCluster()` uses plain kubectl for `InCluster: true`