### PR TITLE
fix: GHE host in frontend repo links and config display

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1009,6 +1009,7 @@ func main() {
 					return fmt.Sprintf("http://localhost:%d", cfg.Dashboard.Port)
 				}(),
 				SnapshotURL:  cfg.Hub.SnapshotURL,
+				HiveType:     cfg.Hub.HiveType,
 				IsPublic:     cfg.Hub.IsPublic,
 				Version:           "3.0.0",
 				GitHash:           gitShort,

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -343,6 +343,7 @@ type HubConfig struct {
 	IsPublic               bool     `yaml:"is_public"`
 	SnapshotURL            string   `yaml:"snapshot_url"`
 	DashboardURL           string   `yaml:"dashboard_url"`
+	HiveType               string   `yaml:"hive_type"`
 	AutoSnapshot           bool     `yaml:"auto_snapshot"`
 	ContributeSuspended    bool     `yaml:"contribute_suspended"`
 	ContributeAllowLabels  []string `yaml:"contribute_allow_labels"`

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -475,6 +475,10 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 	if primaryRepo != "" && cfg.Project.Org != "" && !strings.Contains(primaryRepo, "/") {
 		primaryRepo = cfg.Project.Org + "/" + primaryRepo
 	}
+	githubBaseURL := cfg.GitHub.BaseURL
+	if githubBaseURL == "" {
+		githubBaseURL = "https://github.com"
+	}
 	jsonResponse(w, map[string]interface{}{
 		"org":              cfg.Project.Org,
 		"repos":            cfg.Project.Repos,
@@ -484,6 +488,7 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 		"primaryRepo":      primaryRepo,
 		"hub_url":          cfg.Hub.URL,
 		"hive_id":          cfg.HiveID,
+		"github_base_url":  githubBaseURL,
 	})
 }
 

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -2832,6 +2832,20 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 				jsonError(w, fmt.Sprintf("invalid repo name: %s", repo), http.StatusBadRequest)
 				return
 			}
+			if parsed, err := url.Parse(repo); err == nil && parsed.Scheme != "" && parsed.Host != "" {
+				parts := strings.SplitN(strings.TrimPrefix(parsed.Path, "/"), "/", 3)
+				if len(parts) >= 2 {
+					if parts[0] != "" {
+						org = parts[0]
+						s.deps.Config.Project.Org = org
+					}
+					repo = parts[1]
+					if parsed.Host != "github.com" {
+						s.deps.Config.GitHub.BaseURL = parsed.Scheme + "://" + parsed.Host
+						s.deps.Config.GitHub.APIURL = parsed.Scheme + "://" + parsed.Host + "/api/v3"
+					}
+				}
+			}
 			if org != "" && strings.HasPrefix(repo, org+"/") {
 				stripped = append(stripped, strings.TrimPrefix(repo, org+"/"))
 			} else {
@@ -2846,6 +2860,12 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 
 	if body.PrimaryRepo != nil {
 		newPrimary := sanitizeString(*body.PrimaryRepo)
+		if parsed, err := url.Parse(newPrimary); err == nil && parsed.Scheme != "" && parsed.Host != "" {
+			parts := strings.SplitN(strings.TrimPrefix(parsed.Path, "/"), "/", 3)
+			if len(parts) >= 2 {
+				newPrimary = parts[1]
+			}
+		}
 		if org != "" && strings.HasPrefix(newPrimary, org+"/") {
 			newPrimary = strings.TrimPrefix(newPrimary, org+"/")
 		}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3237,7 +3237,8 @@
         const mergedPairs = pairs.filter(p => p.state === 'merged');
         const _org = (window._primaryRepo || 'kubestellar/console').split('/')[0];
         const _defaultRepo = (window._primaryRepo || 'kubestellar/console').split('/')[1];
-        const _ghUrl = (p, type) => `https://github.com/${encodeURIComponent(_org)}/${encodeURIComponent(p.repo || _defaultRepo)}/${type}/${type === 'issues' ? p.issue : p.pr}`;
+        const _ghBase = window._githubBaseUrl || 'https://github.com';
+        const _ghUrl = (p, type) => `${_ghBase}/${encodeURIComponent(_org)}/${encodeURIComponent(p.repo || _defaultRepo)}/${type}/${type === 'issues' ? p.issue : p.pr}`;
         const _repoTag = (p) => (p.repo && p.repo !== _defaultRepo) ? `<span style="color:var(--muted);font-size:0.65rem">${esc(p.repo)}/</span>` : '';
         const renderPair = (p) => {
           const issueLabel = p.issueTitle ? `⊙ #${p.issue} — ${esc(p.issueTitle.length > 48 ? p.issueTitle.slice(0, 48) + '…' : p.issueTitle)}` : `⊙ #${p.issue}`;
@@ -3267,7 +3268,7 @@
           const title = ip.title ? esc(ip.title.length > 48 ? ip.title.slice(0, 48) + '…' : ip.title) : '';
           const label = title ? `⏳ #${ip.number} — ${title}` : `⏳ #${ip.number}`;
           return `<div class="ind-pair">
-          <a class="ind-tag ind-wip" href="https://github.com/${_org}/${_defaultRepo}/issues/${ip.number}" target="_blank" title="${ip.title ? esc(ip.title) : ''}">${label}</a>
+          <a class="ind-tag ind-wip" href="${_ghBase}/${_org}/${_defaultRepo}/issues/${ip.number}" target="_blank" title="${ip.title ? esc(ip.title) : ''}">${label}</a>
         </div>`;
         };
         const standaloneMerged = m.mergedPrs || [];
@@ -3723,7 +3724,7 @@
       setIfChanged(el, repos.map(r => {
         const iSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.issues ?? 0), '#58a6ff');
         const pSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.prs ?? 0), '#bc8cff');
-        const repoUrl = 'https://github.com/' + (r.full || r.name);
+        const repoUrl = (window._githubBaseUrl || 'https://github.com') + '/' + (r.full || r.name);
         const MAX_PILL_TITLE_LEN = 50;
         const issuePills = (r.actionableIssues || []).map(i => {
           const title = i.title && i.title.length > MAX_PILL_TITLE_LEN ? i.title.slice(0, MAX_PILL_TITLE_LEN) + '…' : (i.title || '');
@@ -8281,6 +8282,8 @@ function burnAreaChart() {
 
     // Set project name and repo from API
     fetch("/api/config").then(r => r.json()).then(cfg => {
+      const ghBase = cfg.github_base_url || 'https://github.com';
+      window._githubBaseUrl = ghBase;
       const repoDisplay = cfg.org && cfg.primaryRepo && !cfg.primaryRepo.includes('/')
         ? cfg.org + '/' + cfg.primaryRepo
         : (cfg.primaryRepo || '');
@@ -9795,6 +9798,9 @@ function burnAreaChart() {
 
     function renderGovRepos(repos) {
       const primary = _configState.data.primaryRepo || '';
+      const ghBase = window._githubBaseUrl || 'https://github.com';
+      const ghHost = ghBase.replace(/^https?:\/\//, '');
+      const isGHE = ghHost !== 'github.com';
       const list = repos.map((r, i) => {
         const isDefault = r === primary;
         const starStyle = isDefault
@@ -9803,7 +9809,8 @@ function burnAreaChart() {
         const starTitle = isDefault
           ? 'Default repo (advisory issue lives here)'
           : 'Set as default repo for advisory issue';
-        return `<div class="config-list-item" style="align-items:center"><span onclick="setDefaultRepo('${esc(r)}')" style="${starStyle}" title="${starTitle}">${isDefault ? '★' : '☆'}</span><span style="flex:1">${esc(r)}</span><button class="remove-item" onclick="removeListItem('repos','list',${i})">&#x2715;</button></div>`;
+        const displayName = isGHE ? ghHost + '/' + r : r;
+        return `<div class="config-list-item" style="align-items:center"><span onclick="setDefaultRepo('${esc(r)}')" style="${starStyle}" title="${starTitle}">${isDefault ? '★' : '☆'}</span><span style="flex:1">${esc(displayName)}</span><button class="remove-item" onclick="removeListItem('repos','list',${i})">&#x2715;</button></div>`;
       }).join('');
       return `
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">GitHub repositories monitored by this hive. Click the star to set the default repo where the advisory issue is maintained.</p>

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -59,6 +59,7 @@ type HeartbeatPayload struct {
 	DashboardURL string             `json:"dashboard_url"`
 	SnapshotURL  string             `json:"snapshot_url"`
 	Owner        string             `json:"owner,omitempty"`
+	HiveType     string             `json:"hive_type,omitempty"`
 	IsPublic     bool               `json:"is_public"`
 	Version      string             `json:"version"`
 	GitHash      string             `json:"git_hash"`

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2755,13 +2755,13 @@ const dashboardHTML = `<!DOCTYPE html>
       return '<span title="' + esc(lines.join('\n')) + '" style="display:inline-flex;align-items:center;gap:4px;cursor:help;white-space:pre-line"><span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + c + '"></span><span style="font-size:0.7rem;color:' + c + ';font-weight:600">' + ic + '</span></span>';
     }
     function dashboardLink(h) {
-      var isHosted = h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'));
+      var isHosted = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-')));
+      if (h.dashboardUrl && !h.dashboardUrl.includes('localhost'))
+        return '<a href="' + esc(h.dashboardUrl) + '" target="_blank" class="dash-link">' + esc(h.dashboardUrl.replace(/^https?:\/\//,'').substring(0,30)) + '...</a>';
       if (isHosted) {
         var url = 'https://' + esc(h.id) + '.hive.kubestellar.io';
         return '<a href="' + url + '" target="_blank" class="dash-link">' + esc(h.id) + '.hive...</a>';
       }
-      if (h.dashboardUrl && !h.dashboardUrl.includes('localhost'))
-        return '<a href="' + esc(h.dashboardUrl) + '" target="_blank" class="dash-link">' + esc(h.dashboardUrl.replace('http://','')) + '</a>';
       return '<span style="color:var(--muted);font-size:0.75rem">—</span>';
     }
     function snapshotLink(h) {
@@ -2769,12 +2769,12 @@ const dashboardHTML = `<!DOCTYPE html>
       return '';
     }
     function apiLink(h) {
-      var isHosted = h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'));
+      var isHosted = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-')));
       var base = '';
-      if (isHosted) {
-        base = 'https://' + esc(h.id) + '.hive.kubestellar.io';
-      } else if (h.dashboardUrl && !h.dashboardUrl.includes('localhost')) {
+      if (h.dashboardUrl && !h.dashboardUrl.includes('localhost')) {
         base = esc(h.dashboardUrl);
+      } else if (isHosted) {
+        base = 'https://' + esc(h.id) + '.hive.kubestellar.io';
       }
       if (!base) return '';
       return '<a href="' + base + '/api/docs" target="_blank" style="padding:3px 10px;background:rgba(88,166,255,0.15);color:#58a6ff;border:1px solid rgba(88,166,255,0.3);border-radius:4px;font-size:0.7rem;text-decoration:none;white-space:nowrap">API ↗</a>';
@@ -2962,7 +2962,7 @@ const dashboardHTML = `<!DOCTYPE html>
         var rp = repoPath(h);
         var repoLink = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" class="repo-link">' + esc(h.primaryRepo) + '</a>' : '';
         var repoCount = (h.repos || []).length;
-        var isHosted = h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'));
+        var isHosted = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-')));
         var isLocal = !isHosted;
         var canConvert = isLocal && h.role === 'owner' && (_userQuota < 0 || _userQuota > _userUsed);
         var typeBadge = isHosted

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -292,6 +292,9 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		ActiveContributors: clampInt(payload.Contributors.Active, 0, 10_000),
 		Owner:              sanitizeHeartbeatField(payload.Owner),
 		HiveType: func() string {
+			if payload.HiveType != "" {
+				return sanitizeHeartbeatField(payload.HiveType)
+			}
 			if strings.HasPrefix(payload.HiveID, "hosted-") || strings.HasPrefix(payload.HiveID, "saas-") {
 				return "hosted"
 			}


### PR DESCRIPTION
## Summary
- Expose `github_base_url` in `/api/config` response so frontend knows the GitHub host
- Replace all hardcoded `github.com` repo links with `window._githubBaseUrl`
- Repos config dialog shows `github.ibm.com/org/repo` when GHE is configured
- Dashboard repo links, issue links, PR links all use the correct GHE host
- Hub dashboard uses `hiveType === 'hosted'` for type badge instead of ID prefix

## Test plan
- [ ] GHE hive shows `github.ibm.com/open-source/osscar-application` in repos config
- [ ] Clicking repo link opens `https://github.ibm.com/open-source/osscar-application`
- [ ] github.com hives still link to `github.com` (default)
- [ ] Hub dashboard shows "hosted" badge for self-declared hosted hives