### PR TITLE
docs: add ADOPTERS.md with Tuna OS entry

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -14,6 +14,7 @@ Listed below are organizations that have adopted, or benefitted from, KubeStella
 
 | Organization | Description | Maturity Level | Further Information |
 | --- | --- | --- | --- |
+| [Tuna OS](https://github.com/tuna-os) | Autonomous development operations for tuna-os projects | Pre-production | |
 
 ## Adopter Tiers
 


### PR DESCRIPTION
Adds an ADOPTERS.md with Tuna OS as the inaugural adopter.

Tuna OS runs Hive at ACMM L6 on a 2-node Talos Linux K8s cluster with 9 goose agents managing `tuna-os/tunaos` and `tuna-os/tacklebox`, and also runs the KubeStellar Hive Console to contribute GPU capacity back to the upstream network.