### PR TITLE
feat: heartbeat-based auto-upgrade for firewalled spokes

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -48,6 +48,7 @@ var (
 )
 
 func main() {
+	startTime := time.Now()
 	defaultConfig := "/etc/hive/hive.yaml"
 	if envCfg := os.Getenv("HIVE_CONFIG"); envCfg != "" {
 		defaultConfig = envCfg
@@ -1080,9 +1081,35 @@ func main() {
 				GitHash:           gitShort,
 				GitBranch:         gitBranch,
 				GitHubAppRequired: dashSrv.IsGitHubAppRequired(),
+				AutoUpgrade:       cfg.Hub.AutoUpgrade,
 			}
 		}, time.Duration(cfg.Governor.EvalIntervalS)*time.Second, logger, func(targetSHA string) {
-			logger.Info("hub requested upgrade via heartbeat — restarting", "target", targetSHA, "current", gitShort)
+			// Minimum uptime before allowing self-upgrade to avoid restart loops.
+			const minUptimeBeforeUpgrade = 5 * time.Minute
+			uptime := time.Since(startTime)
+			if uptime < minUptimeBeforeUpgrade {
+				logger.Warn("self-upgrade deferred: minimum uptime not reached",
+					"target", targetSHA,
+					"current", gitShort,
+					"uptime", uptime.Round(time.Second),
+					"min_uptime", minUptimeBeforeUpgrade,
+				)
+				return
+			}
+
+			// Write upgrade marker so the entrypoint can detect intentional restart.
+			const upgradeMarkerPath = "/data/upgrade-requested"
+			marker := fmt.Sprintf(`{"target_sha":"%s","current_sha":"%s","requested_at":"%s"}`,
+				targetSHA, gitShort, time.Now().UTC().Format(time.RFC3339))
+			if err := os.WriteFile(upgradeMarkerPath, []byte(marker), 0o644); err != nil {
+				logger.Warn("failed to write upgrade marker", "path", upgradeMarkerPath, "error", err)
+			}
+
+			logger.Info("self-upgrade triggered: exiting to pull new image",
+				"current", gitShort,
+				"latest", targetSHA,
+				"uptime", uptime.Round(time.Second),
+			)
 			os.Exit(0)
 		})
 

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -374,6 +374,7 @@ type HubConfig struct {
 	DashboardURL           string   `yaml:"dashboard_url"`
 	HiveType               string   `yaml:"hive_type"`
 	AutoSnapshot           bool     `yaml:"auto_snapshot"`
+	AutoUpgrade            bool     `yaml:"auto_upgrade"`
 	ContributeSuspended    bool     `yaml:"contribute_suspended"`
 	ContributeAllowLabels  []string `yaml:"contribute_allow_labels"`
 	ContributeDenyLabels   []string `yaml:"contribute_deny_labels"`

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -2357,6 +2357,7 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			"snapshot_url":             cfg.Hub.SnapshotURL,
 			"is_public":               cfg.Hub.IsPublic,
 			"auto_snapshot":           cfg.Hub.AutoSnapshot,
+			"auto_upgrade":            cfg.Hub.AutoUpgrade,
 			"snapshot_interval_min":   cfg.Hub.SnapshotIntervalMin,
 			"contribute_suspended":             cfg.Hub.ContributeSuspended,
 			"contribute_allow_labels":          cfg.Hub.ContributeAllowLabels,
@@ -2680,6 +2681,7 @@ func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 		SnapshotURL                   string              `json:"snapshot_url"`
 		IsPublic                      *bool               `json:"is_public"`
 		AutoSnapshot                  *bool               `json:"auto_snapshot"`
+		AutoUpgrade                   *bool               `json:"auto_upgrade"`
 		ContributeSuspended           *bool               `json:"contribute_suspended"`
 		ContributeAllowLabels         []string            `json:"contribute_allow_labels"`
 		ContributeDenyLabels          []string            `json:"contribute_deny_labels"`
@@ -2711,6 +2713,9 @@ func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 	}
 	if body.AutoSnapshot != nil {
 		cfg.Hub.AutoSnapshot = *body.AutoSnapshot
+	}
+	if body.AutoUpgrade != nil {
+		cfg.Hub.AutoUpgrade = *body.AutoUpgrade
 	}
 	if body.ContributeSuspended != nil {
 		cfg.Hub.ContributeSuspended = *body.ContributeSuspended

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -66,6 +66,7 @@ type HeartbeatPayload struct {
 	GitBranch    string             `json:"git_branch,omitempty"`
 	Timestamp          string         `json:"timestamp"`
 	GitHubAppRequired  bool           `json:"github_app_required,omitempty"`
+	AutoUpgrade        bool           `json:"auto_upgrade,omitempty"`
 }
 
 type StatusCollector func() *HeartbeatPayload
@@ -200,14 +201,28 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 		return ""
 	}
 
-	var hbResp struct {
-		UpgradeTo string `json:"upgrade_to"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&hbResp); err == nil && hbResp.UpgradeTo != "" {
-		logger.Info("hub instructed upgrade via heartbeat", "target", hbResp.UpgradeTo)
-		return hbResp.UpgradeTo
+	var hbResp HeartbeatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&hbResp); err == nil {
+		if hbResp.HubGitHash != "" {
+			logger.Debug("hub version info", "hub_git_hash", hbResp.HubGitHash, "latest_sha", hbResp.LatestSHA)
+		}
+		if hbResp.UpgradeTo != "" {
+			logger.Info("hub instructed upgrade via heartbeat", "target", hbResp.UpgradeTo)
+			return hbResp.UpgradeTo
+		}
 	}
 	return ""
+}
+
+// HeartbeatResponse is the JSON body returned by the hub's heartbeat endpoint.
+// It includes version info so the spoke can display hub version on its dashboard
+// and self-upgrade when behind.
+type HeartbeatResponse struct {
+	OK         bool   `json:"ok"`
+	UpgradeTo  string `json:"upgrade_to,omitempty"`
+	HubGitHash string `json:"hub_git_hash,omitempty"`
+	LatestSHA  string `json:"latest_sha,omitempty"`
+	LatestTag  string `json:"latest_tag,omitempty"`
 }
 
 const taskPushInterval = 30 * time.Second

--- a/v2/pkg/hub/hub_heartbeat_test.go
+++ b/v2/pkg/hub/hub_heartbeat_test.go
@@ -235,3 +235,69 @@ func TestSendHeartbeatCancelledContext(t *testing.T) {
 		return &HeartbeatPayload{HiveID: "test"}
 	}, slog.Default())
 }
+
+func TestSendHeartbeatUpgradeResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := HeartbeatResponse{
+			OK:         true,
+			UpgradeTo:  "abc1234",
+			HubGitHash: "hub-xyz",
+			LatestSHA:  "abc1234",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	target := sendHeartbeat(ctx, server.URL, func() *HeartbeatPayload {
+		return &HeartbeatPayload{HiveID: "test", GitHash: "old123"}
+	}, slog.Default())
+
+	if target != "abc1234" {
+		t.Errorf("expected upgrade target 'abc1234', got %q", target)
+	}
+}
+
+func TestSendHeartbeatNoUpgrade(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := HeartbeatResponse{
+			OK:         true,
+			HubGitHash: "hub-xyz",
+			LatestSHA:  "current123",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	target := sendHeartbeat(ctx, server.URL, func() *HeartbeatPayload {
+		return &HeartbeatPayload{HiveID: "test", GitHash: "current123"}
+	}, slog.Default())
+
+	if target != "" {
+		t.Errorf("expected empty upgrade target, got %q", target)
+	}
+}
+
+func TestSendHeartbeatAutoUpgradeInPayload(t *testing.T) {
+	var gotAutoUpgrade bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload HeartbeatPayload
+		json.NewDecoder(r.Body).Decode(&payload)
+		gotAutoUpgrade = payload.AutoUpgrade
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(HeartbeatResponse{OK: true})
+	}))
+	defer server.Close()
+
+	ctx := context.Background()
+	sendHeartbeat(ctx, server.URL, func() *HeartbeatPayload {
+		return &HeartbeatPayload{HiveID: "test", AutoUpgrade: true}
+	}, slog.Default())
+
+	if !gotAutoUpgrade {
+		t.Error("expected auto_upgrade=true in heartbeat payload")
+	}
+}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -427,21 +427,35 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		"agents", len(payload.Agents),
 	)
 
-	// Check if the hive should upgrade (auto-upgrade enabled and behind latest).
-	resp := struct {
-		OK        bool   `json:"ok"`
-		UpgradeTo string `json:"upgrade_to,omitempty"`
-	}{OK: true}
+	// Build the heartbeat response with version info for all spokes.
+	branch := payload.GitBranch
+	if branch == "" {
+		branch = "v2"
+	}
+	latestSHA := getLatestSHAForBranch(branch)
+	resp := HeartbeatResponse{
+		OK:         true,
+		HubGitHash: s.hubGitHash,
+		LatestSHA:  latestSHA,
+	}
+
+	// Check if the hive should upgrade. Two paths:
+	// 1. Hub-managed (SaaS hive with AutoUpgrade enabled on the hub)
+	// 2. Spoke-managed (spoke declares auto_upgrade in its heartbeat payload)
+	autoUpgrade := false
 	if sh := loadSaaSHive(payload.HiveID); sh != nil && sh.AutoUpgrade {
-		branch := payload.GitBranch
-		if branch == "" {
-			branch = "v2"
-		}
-		latestSHA := getLatestSHAForBranch(branch)
-		if latestSHA != "" && payload.GitHash != "" && payload.GitHash != latestSHA {
-			resp.UpgradeTo = latestSHA
-			s.logger.Info("heartbeat: instructing hive to upgrade", "hive_id", payload.HiveID, "from", payload.GitHash, "to", latestSHA)
-		}
+		autoUpgrade = true
+	} else if payload.AutoUpgrade {
+		autoUpgrade = true
+	}
+	if autoUpgrade && latestSHA != "" && payload.GitHash != "" && payload.GitHash != latestSHA {
+		resp.UpgradeTo = latestSHA
+		s.logger.Info("heartbeat: instructing hive to upgrade",
+			"hive_id", payload.HiveID,
+			"from", payload.GitHash,
+			"to", latestSHA,
+			"spoke_requested", payload.AutoUpgrade,
+		)
 	}
 
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary

Implements Phase 6 of the multi-cluster support plan: heartbeat-based auto-upgrade for spokes that the hub can't reach directly (e.g., behind a firewall like vllm-d on IBM Cloud OpenShift).

- Hub heartbeat response now includes `hub_git_hash`, `latest_sha`, and `latest_tag` for all spokes (not just auto-upgrade-enabled ones), enabling version display on spoke dashboards
- Spokes declare `auto_upgrade: true` in heartbeat payload (from `hub.auto_upgrade` config). Hub respects both spoke-declared and hub-managed (SaaS) auto-upgrade flags
- Spoke self-upgrade writes `/data/upgrade-requested` marker with timestamp before exiting, so the entrypoint can detect intentional restart vs crash
- 5-minute minimum uptime guard prevents restart loops on bad images
- Dashboard hub settings tab exposes the `auto_upgrade` toggle for spoke-side control

### Files changed

| File | Change |
|------|--------|
| `v2/pkg/config/config.go` | `AutoUpgrade` field in `HubConfig` |
| `v2/pkg/hub/heartbeat.go` | `AutoUpgrade` in payload, `HeartbeatResponse` struct with enriched fields |
| `v2/pkg/hub/server.go` | Enriched heartbeat response; spoke-declared auto-upgrade support |
| `v2/cmd/hive/main.go` | Wire config, uptime guard, upgrade marker file |
| `v2/pkg/dashboard/api.go` | `auto_upgrade` in hub settings read/write |
| `v2/pkg/hub/hub_heartbeat_test.go` | 3 new tests for upgrade response parsing |

## Test plan

- [x] `go vet` passes on all changed packages
- [x] All heartbeat tests pass (12/12 including 3 new)
- [ ] Deploy spoke with `hub.auto_upgrade: true`, verify it self-restarts when hub has newer SHA
- [ ] Verify `/data/upgrade-requested` marker file is written with correct JSON
- [ ] Verify spoke does NOT restart within first 5 minutes of uptime
- [ ] Verify spoke without `auto_upgrade` config does not receive `upgrade_to` in response
- [ ] Verify hub dashboard "My Hives" auto checkbox still works for SaaS hives