### PR TITLE
fix: cluster badge shows context name, spokes declare cluster_id

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1076,6 +1076,7 @@ func main() {
 				}(),
 				SnapshotURL:  cfg.Hub.SnapshotURL,
 				HiveType:     cfg.Hub.HiveType,
+				ClusterID:    cfg.Hub.ClusterID,
 				IsPublic:     cfg.Hub.IsPublic,
 				Version:           "3.0.0",
 				GitHash:           gitShort,

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -373,6 +373,7 @@ type HubConfig struct {
 	SnapshotURL            string   `yaml:"snapshot_url"`
 	DashboardURL           string   `yaml:"dashboard_url"`
 	HiveType               string   `yaml:"hive_type"`
+	ClusterID              string   `yaml:"cluster_id"`
 	AutoSnapshot           bool     `yaml:"auto_snapshot"`
 	AutoUpgrade            bool     `yaml:"auto_upgrade"`
 	ContributeSuspended    bool     `yaml:"contribute_suspended"`

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -60,6 +60,7 @@ type HeartbeatPayload struct {
 	SnapshotURL  string             `json:"snapshot_url"`
 	Owner        string             `json:"owner,omitempty"`
 	HiveType     string             `json:"hive_type,omitempty"`
+	ClusterID    string             `json:"cluster_id,omitempty"`
 	IsPublic     bool               `json:"is_public"`
 	Version      string             `json:"version"`
 	GitHash      string             `json:"git_hash"`

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3113,15 +3113,12 @@ const dashboardHTML = `<!DOCTYPE html>
     }
     function clusterBadge(clusterId, clusterName) {
       var cid = clusterId || 'hive-oke';
-      var label = cid.replace(/^hive-/, '').toUpperCase();
-      // GPU clusters get a special color scheme.
-      var isGPU = label === 'VLLM-D' || (clusterName || '').toLowerCase().indexOf('gpu') >= 0;
-      if (isGPU) label = 'GPU';
+      var isGPU = cid === 'vllm-d' || (clusterName || '').toLowerCase().indexOf('gpu') >= 0;
       var bg = isGPU ? 'rgba(34,197,94,0.15)' : 'rgba(59,130,246,0.15)';
       var color = isGPU ? '#3fb950' : '#60a5fa';
       var border = isGPU ? 'rgba(34,197,94,0.3)' : 'rgba(59,130,246,0.3)';
       var title = clusterName || cid;
-      return '<span class="cluster-badge" style="display:inline-block;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:' + bg + ';color:' + color + ';border:1px solid ' + border + '" title="' + esc(title) + '">' + esc(label) + '</span>';
+      return '<span class="cluster-badge" style="display:inline-block;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:' + bg + ';color:' + color + ';border:1px solid ' + border + '" title="' + esc(title) + '">' + esc(cid) + '</span>';
     }
     function modeBadge(mode) {
       var m = (mode || 'idle').toUpperCase();

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -334,16 +334,20 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		GitHubAppRequired: payload.GitHubAppRequired,
 	}
 
-	// Populate ClusterID and ClusterName from the SaaS hive record (if this is a hosted hive).
+	// Populate ClusterID from SaaS hive record, heartbeat payload, or default.
+	clusterID := ""
 	if sh := loadSaaSHive(payload.HiveID); sh != nil {
-		clusterID := sh.ClusterID
-		if clusterID == "" {
-			clusterID = defaultClusterID
-		}
-		entry.ClusterID = clusterID
-		if c, ok := s.clusters[clusterID]; ok {
-			entry.ClusterName = c.Name
-		}
+		clusterID = sh.ClusterID
+	}
+	if clusterID == "" && payload.ClusterID != "" {
+		clusterID = sanitizeHeartbeatField(payload.ClusterID)
+	}
+	if clusterID == "" {
+		clusterID = defaultClusterID
+	}
+	entry.ClusterID = clusterID
+	if c, ok := s.clusters[clusterID]; ok {
+		entry.ClusterName = c.Name
 	}
 
 	s.mu.Lock()


### PR DESCRIPTION
## Summary
- Cluster badge shows raw context name (e.g., `hive-oke`, `vllm-d`) instead of stripping prefix to `OKE`
- Added `cluster_id` to `HeartbeatPayload` and `HubConfig` so spokes can self-declare their cluster
- Hub checks spoke-declared `cluster_id` from heartbeat, falls back to SaaS record, then default
- GPU clusters (`vllm-d`) get green badge, others get blue

## Test plan
- [ ] OKE hives show `hive-oke` badge
- [ ] jjs-world shows `vllm-d` badge after spoke restart
- [ ] Hover shows cluster display name as tooltip