### PR TITLE
feat: dynamic model discovery for inference backends

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -928,6 +928,10 @@ func main() {
 
 		vllmEndpoint := envOrDefault("HIVE_VLLM_ENDPOINT", "http://vllm-svc.hive.svc.cluster.local:8000")
 		llmdEndpoint := envOrDefault("HIVE_LLMD_ENDPOINT", "http://llm-d-epp.hive.svc.cluster.local:8000")
+		dashSrv.SetInferenceEndpoints(map[string]string{
+			"vllm":  vllmEndpoint,
+			"llm-d": llmdEndpoint,
+		})
 		agentMgr.SetInferenceCallbacks(
 			func(agentName, backend, model string) {
 				endpoint := vllmEndpoint

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -106,6 +106,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/config/sidebar", s.handleSidebarGet)
 	s.mux.HandleFunc("PUT /api/config/sidebar", s.handleSidebarSet)
 	s.mux.HandleFunc("GET /api/config/backends", s.handleBackends)
+	s.mux.HandleFunc("GET /api/inference/models/{backend}", s.handleInferenceModels)
 
 	s.mux.HandleFunc("GET /api/knowledge", s.handleKnowledgeList)
 	s.mux.HandleFunc("GET /api/knowledge/export", s.handleKnowledgeExport)
@@ -2952,12 +2953,110 @@ func (s *Server) saveSidebarToDisk(sb interface{}) {
 }
 
 func (s *Server) handleBackends(w http.ResponseWriter, r *http.Request) {
+	vllmModels := s.queryInferenceModels("vllm")
+	llmdModels := s.queryInferenceModels("llm-d")
+
 	jsonResponse(w, []map[string]interface{}{
 		{"id": "claude", "name": "Claude Code", "models": []string{"opus", "sonnet", "haiku"}},
 		{"id": "copilot", "name": "GitHub Copilot", "models": []string{"gpt-4o", "gpt-4o-mini"}},
 		{"id": "gemini", "name": "Gemini", "models": []string{"gemini-2.5-pro", "gemini-2.5-flash"}},
 		{"id": "goose", "name": "Goose", "models": []string{"default"}},
+		{"id": "vllm", "name": "vLLM (self-hosted)", "models": vllmModels, "inference": true},
+		{"id": "llm-d", "name": "llm-d (self-hosted)", "models": llmdModels, "inference": true},
 	})
+}
+
+func (s *Server) handleInferenceModels(w http.ResponseWriter, r *http.Request) {
+	backend := r.PathValue("backend")
+	if backend == "" {
+		jsonError(w, "backend required", http.StatusBadRequest)
+		return
+	}
+	endpoint, ok := s.inferenceEndpoints[backend]
+	if !ok {
+		jsonError(w, "unknown inference backend: "+backend, http.StatusNotFound)
+		return
+	}
+
+	models, err := fetchModelsFromEndpoint(endpoint)
+	if err != nil {
+		s.logger.Warn("failed to query inference models", "backend", backend, "error", err)
+		jsonResponse(w, map[string]interface{}{
+			"backend": backend,
+			"models":  []string{},
+			"error":   err.Error(),
+		})
+		return
+	}
+	jsonResponse(w, map[string]interface{}{
+		"backend": backend,
+		"models":  models,
+	})
+}
+
+func (s *Server) queryInferenceModels(backend string) []string {
+	if endpoint, ok := s.inferenceEndpoints[backend]; ok {
+		models, err := fetchModelsFromEndpoint(endpoint)
+		if err == nil && len(models) > 0 {
+			return models
+		}
+	}
+	envVar := "HIVE_VLLM_MODELS"
+	defaultModel := "qwen2.5-0.5b-instruct"
+	if backend == "llm-d" {
+		envVar = "HIVE_LLMD_MODELS"
+	}
+	return inferenceModelsFromEnv(envVar, defaultModel)
+}
+
+const inferenceModelQueryTimeout = 5 * time.Second
+
+func fetchModelsFromEndpoint(baseURL string) ([]string, error) {
+	modelsURL := strings.TrimRight(baseURL, "/") + "/v1/models"
+	client := &http.Client{Timeout: inferenceModelQueryTimeout}
+	resp, err := client.Get(modelsURL)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("upstream returned %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	var result struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("parse response: %w", err)
+	}
+
+	models := make([]string, 0, len(result.Data))
+	for _, m := range result.Data {
+		if m.ID != "" {
+			models = append(models, m.ID)
+		}
+	}
+	return models, nil
+}
+
+func inferenceModelsFromEnv(envVar, defaultModel string) []string {
+	val := os.Getenv(envVar)
+	if val == "" {
+		return []string{defaultModel}
+	}
+	models := strings.Split(val, ",")
+	for i := range models {
+		models[i] = strings.TrimSpace(models[i])
+	}
+	return models
 }
 
 // --- Knowledge endpoints ---

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -66,6 +66,8 @@ type Server struct {
 
 	contributeHub *ContributeWSHub
 
+	inferenceEndpoints map[string]string // backend id → base URL
+
 	ready   bool
 	readyAt time.Time
 
@@ -293,6 +295,12 @@ func NewServerWithAuth(port int, authToken string, logger *slog.Logger) *Server 
 	}
 	s.registerCoreRoutes()
 	return s
+}
+
+// SetInferenceEndpoints registers base URLs for inference backends
+// so the dashboard can query them for available models at runtime.
+func (s *Server) SetInferenceEndpoints(endpoints map[string]string) {
+	s.inferenceEndpoints = endpoints
 }
 
 // SetSkipReloadFunc sets the callback used by saveConfig to skip the

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3868,10 +3868,9 @@
       { value: 'gpt-5.4', label: 'GPT-5.4' },
       { value: 'gpt-5.2', label: 'GPT-5.2' },
     ];
-    const INFERENCE_MODELS = {
-      'vllm': [{ value: 'qwen2.5-0.5b-instruct', label: 'Qwen 2.5 0.5B' }],
-      'llm-d': [{ value: 'qwen2.5-0.5b-instruct', label: 'Qwen 2.5 0.5B' }],
-    };
+    const INFERENCE_MODELS = {};
+    const INFERENCE_MODEL_CACHE_TTL_MS = 30000;
+    const _inferenceModelCache = {};
     function backendLabel(b) {
       if (INFERENCE_BACKENDS.includes(b)) return b + ' ⚡';
       return b;
@@ -3880,25 +3879,70 @@
       if (INFERENCE_BACKENDS.includes(backend)) return INFERENCE_MODELS[backend] || [];
       return KNOWN_MODELS;
     }
-
-    let _cachedInferenceModels = null;
-    async function fetchInferenceModels() {
-      if (_cachedInferenceModels) return _cachedInferenceModels;
+    async function fetchInferenceModels(backend) {
+      const now = Date.now();
+      const cached = _inferenceModelCache[backend];
+      if (cached && (now - cached.ts) < INFERENCE_MODEL_CACHE_TTL_MS) {
+        return cached.models;
+      }
       try {
-        const resp = await fetch('/api/config/backends');
-        const backends = await resp.json();
-        const models = {};
-        for (const b of backends) {
-          if (b.inference) {
-            models[b.id] = (b.models || []).map(m => ({ value: m, label: m.split('/').pop() }));
-          }
-        }
-        _cachedInferenceModels = models;
-        Object.assign(INFERENCE_MODELS, models);
-      } catch (e) { /* use defaults */ }
-      return INFERENCE_MODELS;
+        const resp = await fetch(`/api/inference/models/${encodeURIComponent(backend)}`);
+        const data = await resp.json();
+        const models = (data.models || []).map(m => ({ value: m, label: m.split('/').pop() }));
+        INFERENCE_MODELS[backend] = models;
+        _inferenceModelCache[backend] = { models, ts: now };
+        return models;
+      } catch (e) {
+        return INFERENCE_MODELS[backend] || [];
+      }
     }
-    fetchInferenceModels();
+    INFERENCE_BACKENDS.forEach(b => fetchInferenceModels(b));
+
+    const INFERENCE_MODEL_POLL_MS = 60000;
+    const _lastKnownModels = {};
+    const _dismissedModelBanners = new Set();
+    async function pollInferenceModelChanges() {
+      for (const backend of INFERENCE_BACKENDS) {
+        try {
+          const resp = await fetch(`/api/inference/models/${encodeURIComponent(backend)}`);
+          const data = await resp.json();
+          const currentIds = (data.models || []).sort();
+          const prevIds = (_lastKnownModels[backend] || []).sort();
+          if (prevIds.length === 0) { _lastKnownModels[backend] = currentIds; continue; }
+          if (JSON.stringify(currentIds) === JSON.stringify(prevIds)) continue;
+
+          const added = currentIds.filter(m => !prevIds.includes(m));
+          const removed = prevIds.filter(m => !currentIds.includes(m));
+
+          added.forEach(m => {
+            const key = `added:${backend}:${m}`;
+            if (_dismissedModelBanners.has(key)) return;
+            const label = m.split('/').pop();
+            showToast(`New model available on ${backend}: ${label}`, 'success');
+            _dismissedModelBanners.add(key);
+          });
+
+          removed.forEach(m => {
+            const label = m.split('/').pop();
+            showToast(`Model removed from ${backend}: ${label}`, 'error');
+            if (window._lastAgents) {
+              const affected = (window._lastAgents || []).filter(a =>
+                a.cli === backend && a.model === m
+              );
+              affected.forEach(a => {
+                showToast(`⚠ ${a.displayName || a.name} uses removed model ${label} — update its model selection`, 'error');
+              });
+            }
+          });
+
+          _lastKnownModels[backend] = currentIds;
+          const models = currentIds.map(m => ({ value: m, label: m.split('/').pop() }));
+          INFERENCE_MODELS[backend] = models;
+          _inferenceModelCache[backend] = { models, ts: Date.now() };
+        } catch (e) { /* skip on error */ }
+      }
+    }
+    setInterval(pollInferenceModelChanges, INFERENCE_MODEL_POLL_MS);
 
     function _normalizeModel(m) { return (m || '').replace(/(\d+)\.(\d+)$/, '$1-$2'); }
     function _modelsEqual(a, b) { return _normalizeModel(a) === _normalizeModel(b); }
@@ -8067,21 +8111,33 @@ function burnAreaChart() {
       const data = await res.json();
       if (!data.ok) { dismissToast(toast, `Switch failed: ${data.error || 'unknown'}`, 'error'); return; }
       dismissToast(toast, `${agent} ${label} → ${backend}`, 'success');
-      updateModelDropdown(agent, backend);
+      await updateModelDropdown(agent, backend);
       if (window._lastAgents) {
         const a = window._lastAgents.find(x => x.name === agent);
         if (a) { a.cli = backend; renderAgents(window._lastAgents); }
       }
     }
 
-    function updateModelDropdown(agent, backend) {
+    async function updateModelDropdown(agent, backend) {
       const modelSelects = document.querySelectorAll(`select[data-change-action="switchModel"][data-agent="${agent}"]`);
       const isInference = INFERENCE_BACKENDS.includes(backend);
-      const models = isInference ? (INFERENCE_MODELS[backend] || []) : KNOWN_MODELS;
-      modelSelects.forEach(sel => {
-        sel.innerHTML = '<option value="">model ▾</option>' +
-          models.map(m => `<option value="${m.value}">${m.label}</option>`).join('');
-      });
+      if (isInference) {
+        modelSelects.forEach(sel => {
+          sel.innerHTML = '<option value="">loading models…</option>';
+          sel.disabled = true;
+        });
+        const models = await fetchInferenceModels(backend);
+        modelSelects.forEach(sel => {
+          sel.innerHTML = '<option value="">model ▾</option>' +
+            models.map(m => `<option value="${m.value}">${m.label}</option>`).join('');
+          sel.disabled = false;
+        });
+      } else {
+        modelSelects.forEach(sel => {
+          sel.innerHTML = '<option value="">model ▾</option>' +
+            KNOWN_MODELS.map(m => `<option value="${m.value}">${m.label}</option>`).join('');
+        });
+      }
     }
 
     async function switchModel(agent, model) {


### PR DESCRIPTION
## Summary
- Adds `GET /api/inference/models/{backend}` endpoint that queries live vLLM/llm-d `/v1/models` at runtime
- Dashboard model dropdown fetches available models dynamically when switching to an inference backend (30s client-side cache)
- Falls back to env var config (`HIVE_VLLM_MODELS`, `HIVE_LLMD_MODELS`) if endpoint unreachable
- No more hardcoded inference model lists — dropdown always reflects what's deployed
- Background poll (60s) detects model changes:
  - **New model added**: success toast announcing availability
  - **Model removed**: error toast + warns any agents still using that model

## Files changed
- `v2/cmd/hive/main.go` — wire `SetInferenceEndpoints` with vllm/llm-d URLs
- `v2/pkg/dashboard/api.go` — `handleInferenceModels`, `fetchModelsFromEndpoint`, `queryInferenceModels`
- `v2/pkg/dashboard/server.go` — `inferenceEndpoints` map + `SetInferenceEndpoints`
- `v2/pkg/dashboard/static/index.html` — async fetch, loading UX, model change polling + banners

## Test plan
- [ ] Switch method to vllm → model dropdown shows live models
- [ ] Switch method to llm-d → model dropdown shows live models
- [ ] Switch back to claude → dropdown shows KNOWN_MODELS
- [ ] Add a model to vLLM → success toast appears within 60s
- [ ] Remove a model from vLLM while agent uses it → error toast warns affected agent
- [ ] Kill vLLM pod → graceful fallback to env var defaults