### PR TITLE
feat: multi-endpoint inference model discovery

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -926,12 +926,14 @@ func main() {
 	} else {
 		dashboard.SetProxyViolationsProvider(githubProxy.Violations)
 
-		vllmEndpoint := envOrDefault("HIVE_VLLM_ENDPOINT", "http://vllm-svc.hive.svc.cluster.local:8000")
-		llmdEndpoint := envOrDefault("HIVE_LLMD_ENDPOINT", "http://llm-d-epp.hive.svc.cluster.local:8000")
-		dashSrv.SetInferenceEndpoints(map[string]string{
-			"vllm":  vllmEndpoint,
-			"llm-d": llmdEndpoint,
+		vllmEndpoints := parseEndpointList(envOrDefault("HIVE_VLLM_ENDPOINT", "http://hive-vllm-svc.hive-inference.svc.cluster.local:8000"))
+		llmdEndpoints := parseEndpointList(envOrDefault("HIVE_LLMD_ENDPOINT", "http://hive-llm-d-epp.hive-inference.svc.cluster.local:8000"))
+		dashSrv.SetInferenceEndpoints(map[string][]string{
+			"vllm":  vllmEndpoints,
+			"llm-d": llmdEndpoints,
 		})
+		vllmEndpoint := vllmEndpoints[0]
+		llmdEndpoint := llmdEndpoints[0]
 		agentMgr.SetInferenceCallbacks(
 			func(agentName, backend, model string) {
 				endpoint := vllmEndpoint
@@ -2158,4 +2160,21 @@ func envOrDefault(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// parseEndpointList splits a comma-separated list of URLs into a slice.
+// A single URL is returned as a one-element slice.
+func parseEndpointList(raw string) []string {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return []string{raw}
+	}
+	return out
 }

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -2972,21 +2972,15 @@ func (s *Server) handleInferenceModels(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "backend required", http.StatusBadRequest)
 		return
 	}
-	endpoint, ok := s.inferenceEndpoints[backend]
+	endpoints, ok := s.inferenceEndpoints[backend]
 	if !ok {
 		jsonError(w, "unknown inference backend: "+backend, http.StatusNotFound)
 		return
 	}
 
-	models, err := fetchModelsFromEndpoint(endpoint)
-	if err != nil {
-		s.logger.Warn("failed to query inference models", "backend", backend, "error", err)
-		jsonResponse(w, map[string]interface{}{
-			"backend": backend,
-			"models":  []string{},
-			"error":   err.Error(),
-		})
-		return
+	models := fetchModelsFromEndpoints(endpoints)
+	if len(models) == 0 {
+		s.logger.Warn("no models found from any endpoint", "backend", backend, "endpoints", len(endpoints))
 	}
 	jsonResponse(w, map[string]interface{}{
 		"backend": backend,
@@ -2995,9 +2989,9 @@ func (s *Server) handleInferenceModels(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) queryInferenceModels(backend string) []string {
-	if endpoint, ok := s.inferenceEndpoints[backend]; ok {
-		models, err := fetchModelsFromEndpoint(endpoint)
-		if err == nil && len(models) > 0 {
+	if endpoints, ok := s.inferenceEndpoints[backend]; ok {
+		models := fetchModelsFromEndpoints(endpoints)
+		if len(models) > 0 {
 			return models
 		}
 	}
@@ -3010,6 +3004,26 @@ func (s *Server) queryInferenceModels(backend string) []string {
 }
 
 const inferenceModelQueryTimeout = 5 * time.Second
+
+// fetchModelsFromEndpoints queries /v1/models on each endpoint and returns
+// a deduplicated, combined list of all model IDs found.
+func fetchModelsFromEndpoints(endpoints []string) []string {
+	seen := make(map[string]bool)
+	var all []string
+	for _, ep := range endpoints {
+		models, err := fetchModelsFromEndpoint(ep)
+		if err != nil {
+			continue
+		}
+		for _, m := range models {
+			if !seen[m] {
+				seen[m] = true
+				all = append(all, m)
+			}
+		}
+	}
+	return all
+}
 
 func fetchModelsFromEndpoint(baseURL string) ([]string, error) {
 	modelsURL := strings.TrimRight(baseURL, "/") + "/v1/models"

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -66,7 +66,7 @@ type Server struct {
 
 	contributeHub *ContributeWSHub
 
-	inferenceEndpoints map[string]string // backend id → base URL
+	inferenceEndpoints map[string][]string // backend id → list of base URLs
 
 	ready   bool
 	readyAt time.Time
@@ -299,7 +299,7 @@ func NewServerWithAuth(port int, authToken string, logger *slog.Logger) *Server 
 
 // SetInferenceEndpoints registers base URLs for inference backends
 // so the dashboard can query them for available models at runtime.
-func (s *Server) SetInferenceEndpoints(endpoints map[string]string) {
+func (s *Server) SetInferenceEndpoints(endpoints map[string][]string) {
 	s.inferenceEndpoints = endpoints
 }
 


### PR DESCRIPTION
## Summary
- `HIVE_VLLM_ENDPOINT` and `HIVE_LLMD_ENDPOINT` now accept comma-separated lists of URLs
- Dashboard aggregates `/v1/models` responses from all endpoints per backend, deduplicating results
- Adding a new vLLM instance serving a different model automatically populates the dropdown — no config changes needed
- Existing single-URL configs work unchanged

## Example
```
HIVE_VLLM_ENDPOINT=http://hive-vllm-svc:8000,http://hive-vllm-qwen-svc:8000
```
This discovers models from both vLLM instances (e.g. DeepSeek-R1-14B + Qwen2.5-72B).

## Test plan
- [ ] Single endpoint — same behavior as before
- [ ] Comma-separated endpoints — both models appear in dropdown
- [ ] One endpoint down — models from healthy endpoint still returned
- [ ] Duplicate model IDs across endpoints — deduplicated