### PR TITLE
feat: heartbeat-based cluster health for firewalled spokes

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1092,7 +1092,12 @@ func main() {
 				GitBranch:         gitBranch,
 				GitHubAppRequired: dashSrv.IsGitHubAppRequired(),
 				AutoUpgrade:       cfg.Hub.AutoUpgrade,
-				ClusterHealth:     hub.CollectClusterHealth(logger),
+				ClusterHealth: func() *hub.HeartbeatClusterHealthReport {
+					if os.Getenv("HIVE_CLUSTER_ID") == "" {
+						return nil
+					}
+					return hub.CollectClusterHealth(logger)
+				}(),
 			}
 		}, time.Duration(cfg.Governor.EvalIntervalS)*time.Second, logger, func(targetSHA string) {
 			// Minimum uptime before allowing self-upgrade to avoid restart loops.

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1092,6 +1092,7 @@ func main() {
 				GitBranch:         gitBranch,
 				GitHubAppRequired: dashSrv.IsGitHubAppRequired(),
 				AutoUpgrade:       cfg.Hub.AutoUpgrade,
+				ClusterHealth:     hub.CollectClusterHealth(logger),
 			}
 		}, time.Duration(cfg.Governor.EvalIntervalS)*time.Second, logger, func(targetSHA string) {
 			// Minimum uptime before allowing self-upgrade to avoid restart loops.

--- a/v2/pkg/hub/cluster_metrics.go
+++ b/v2/pkg/hub/cluster_metrics.go
@@ -1,0 +1,289 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// metricsCollectionCacheTTL is how long we cache spoke-side cluster metrics
+// before running kubectl again. Prevents running kubectl on every heartbeat.
+const metricsCollectionCacheTTL = 60 * time.Second
+
+// metricsCollectionTimeout bounds how long we wait for each kubectl command
+// during spoke-side metrics collection.
+const metricsCollectionTimeout = 10 * time.Second
+
+// maxNodesInHeartbeat limits the number of nodes reported in a heartbeat
+// to prevent oversized payloads on large clusters.
+const maxNodesInHeartbeat = 100
+
+var (
+	cachedClusterHealth     *HeartbeatClusterHealthReport
+	cachedClusterHealthTime time.Time
+	cachedClusterHealthMu   sync.Mutex
+)
+
+// CollectClusterHealth gathers node-level CPU, memory, pod, and GPU metrics
+// by running kubectl in-cluster on the spoke. Results are cached for
+// metricsCollectionCacheTTL to avoid excessive kubectl calls.
+// Returns nil if metrics-server is not installed or kubectl fails.
+func CollectClusterHealth(logger *slog.Logger) *HeartbeatClusterHealthReport {
+	cachedClusterHealthMu.Lock()
+	if cachedClusterHealth != nil && time.Since(cachedClusterHealthTime) < metricsCollectionCacheTTL {
+		cached := cachedClusterHealth
+		cachedClusterHealthMu.Unlock()
+		return cached
+	}
+	cachedClusterHealthMu.Unlock()
+
+	report := collectClusterHealthUncached(logger)
+
+	cachedClusterHealthMu.Lock()
+	cachedClusterHealth = report
+	cachedClusterHealthTime = time.Now()
+	cachedClusterHealthMu.Unlock()
+
+	return report
+}
+
+func collectClusterHealthUncached(logger *slog.Logger) *HeartbeatClusterHealthReport {
+	// Run kubectl top nodes (requires metrics-server).
+	topOut, err := runKubectlLocal("top", "nodes", "--no-headers")
+	if err != nil {
+		logger.Debug("spoke metrics: kubectl top nodes failed (metrics-server may not be installed)", "error", err)
+		return nil
+	}
+
+	// Run kubectl get nodes for capacity, allocatable, conditions, GPU resources.
+	getOut, err := runKubectlLocal("get", "nodes", "-o", "json")
+	if err != nil {
+		logger.Debug("spoke metrics: kubectl get nodes failed", "error", err)
+		return nil
+	}
+
+	// Parse node metadata from kubectl get nodes.
+	var nodesJSON struct {
+		Items []struct {
+			Metadata struct {
+				Name   string            `json:"name"`
+				Labels map[string]string `json:"labels"`
+			} `json:"metadata"`
+			Status struct {
+				Allocatable map[string]string `json:"allocatable"`
+				Capacity    map[string]string `json:"capacity"`
+				Conditions  []struct {
+					Type   string `json:"type"`
+					Status string `json:"status"`
+				} `json:"conditions"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(getOut, &nodesJSON); err != nil {
+		logger.Debug("spoke metrics: failed to parse nodes JSON", "error", err)
+		return nil
+	}
+
+	type nodeInfo struct {
+		cpuAllocatable int64 // millicores
+		memAllocatable int64 // bytes
+		podCapacity    int
+		gpuCapacity    int
+		gpuAllocatable int
+		gpuType        string
+		ready          bool
+		conditions     []string
+		diskPressure   bool
+	}
+	nodeMap := make(map[string]*nodeInfo)
+	var totalGPUCapacity, totalGPUAllocatable int
+	gpuTypes := map[string]bool{}
+
+	for _, item := range nodesJSON.Items {
+		ni := &nodeInfo{}
+		ni.cpuAllocatable = parseK8sCPU(item.Status.Allocatable["cpu"])
+		ni.memAllocatable = parseK8sMemory(item.Status.Allocatable["memory"])
+		ni.podCapacity = parseInt(item.Status.Capacity["pods"])
+		ni.gpuCapacity = parseInt(item.Status.Capacity[gpuResourceKey])
+		ni.gpuAllocatable = parseInt(item.Status.Allocatable[gpuResourceKey])
+		totalGPUCapacity += ni.gpuCapacity
+		totalGPUAllocatable += ni.gpuAllocatable
+
+		// Detect GPU type from common node labels.
+		if gpuLabel, ok := item.Metadata.Labels["nvidia.com/gpu.product"]; ok && gpuLabel != "" {
+			ni.gpuType = gpuLabel
+			gpuTypes[gpuLabel] = true
+		}
+
+		for _, cond := range item.Status.Conditions {
+			if cond.Type == "Ready" && cond.Status == "True" {
+				ni.ready = true
+				ni.conditions = append(ni.conditions, "Ready")
+			} else if cond.Type == "Ready" && cond.Status != "True" {
+				ni.conditions = append(ni.conditions, "NotReady")
+			}
+			if cond.Type == "DiskPressure" && cond.Status == "True" {
+				ni.diskPressure = true
+			}
+		}
+		if len(ni.conditions) == 0 {
+			ni.conditions = []string{"Unknown"}
+		}
+		nodeMap[item.Metadata.Name] = ni
+	}
+
+	// Parse kubectl top nodes output.
+	// Format: NAME  CPU(cores)  CPU%  MEMORY(bytes)  MEMORY%
+	var nodes []HeartbeatNodeMetric
+	lines := strings.Split(strings.TrimSpace(string(topOut)), "\n")
+	for _, line := range lines {
+		fields := strings.Fields(line)
+		const topFieldCount = 5
+		if len(fields) < topFieldCount {
+			continue
+		}
+		name := fields[0]
+		cpuUsed := parseTopCPU(fields[1])
+		memUsed := parseTopMemory(fields[3])
+
+		ni, ok := nodeMap[name]
+		if !ok {
+			continue
+		}
+
+		cpuCores := int(ni.cpuAllocatable / millicoresPerCore)
+		cpuPct := 0
+		if ni.cpuAllocatable > 0 {
+			cpuPct = int(cpuUsed * percentMultiplier / ni.cpuAllocatable)
+		}
+
+		memTotalMB := ni.memAllocatable / bytesPerMB
+		memUsedMB := memUsed / bytesPerMB
+		memPct := 0
+		if ni.memAllocatable > 0 {
+			memPct = int(memUsed * percentMultiplier / ni.memAllocatable)
+		}
+
+		node := HeartbeatNodeMetric{
+			Name:          name,
+			CPUCores:      cpuCores,
+			CPUUsedMillis: cpuUsed,
+			CPUPercent:    cpuPct,
+			MemTotalMB:    memTotalMB,
+			MemUsedMB:     memUsedMB,
+			MemPercent:    memPct,
+			PodCapacity:   ni.podCapacity,
+			Ready:         ni.ready,
+			Conditions:    ni.conditions,
+			DiskPressure:  ni.diskPressure,
+		}
+		if ni.gpuCapacity > 0 {
+			node.GPUs = ni.gpuCapacity
+			node.GPUType = ni.gpuType
+		}
+		nodes = append(nodes, node)
+	}
+
+	// Count running pods per node.
+	podOut, err := runKubectlLocal("get", "pods", "--all-namespaces", "--field-selector=status.phase=Running", "-o", "json")
+	if err == nil && len(podOut) > 0 {
+		var podsJSON struct {
+			Items []struct {
+				Spec struct {
+					NodeName string `json:"nodeName"`
+				} `json:"spec"`
+			} `json:"items"`
+		}
+		if json.Unmarshal(podOut, &podsJSON) == nil {
+			podCounts := make(map[string]int)
+			for _, p := range podsJSON.Items {
+				podCounts[p.Spec.NodeName]++
+			}
+			for i := range nodes {
+				nodes[i].Pods = podCounts[nodes[i].Name]
+			}
+		}
+	}
+
+	// Cap the number of nodes to prevent oversized payloads.
+	if len(nodes) > maxNodesInHeartbeat {
+		nodes = nodes[:maxNodesInHeartbeat]
+	}
+
+	// Build summary.
+	var totalCPUCores int
+	var totalCPUUsed int64
+	var totalCPUAlloc int64
+	var totalMemAlloc int64
+	var totalMemUsed int64
+	var totalPods int
+	readyNodes := 0
+
+	for _, n := range nodes {
+		totalCPUCores += n.CPUCores
+		totalCPUUsed += n.CPUUsedMillis
+		totalPods += n.Pods
+		if n.Ready {
+			readyNodes++
+		}
+		if ni, ok := nodeMap[n.Name]; ok {
+			totalCPUAlloc += ni.cpuAllocatable
+			totalMemAlloc += ni.memAllocatable
+		}
+		totalMemUsed += n.MemUsedMB * bytesPerMB
+	}
+
+	totalCPUPct := 0
+	if totalCPUAlloc > 0 {
+		totalCPUPct = int(totalCPUUsed * percentMultiplier / totalCPUAlloc)
+	}
+	totalMemPct := 0
+	if totalMemAlloc > 0 {
+		totalMemPct = int(totalMemUsed * percentMultiplier / totalMemAlloc)
+	}
+	totalMemGB := int(totalMemAlloc / giToBytes)
+
+	report := &HeartbeatClusterHealthReport{
+		Nodes: nodes,
+		Summary: HeartbeatClusterSummary{
+			TotalNodes:    len(nodes),
+			ReadyNodes:    readyNodes,
+			TotalCPUCores: totalCPUCores,
+			TotalCPUPct:   totalCPUPct,
+			TotalMemGB:    totalMemGB,
+			TotalMemPct:   totalMemPct,
+			TotalPods:     totalPods,
+		},
+		CollectedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+
+	// Include GPU summary if the cluster has GPUs.
+	if totalGPUCapacity > 0 {
+		types := make([]string, 0, len(gpuTypes))
+		for t := range gpuTypes {
+			types = append(types, t)
+		}
+		report.GPUSummary = &HeartbeatGPUSummary{
+			Total:     totalGPUCapacity,
+			Allocated: totalGPUCapacity - totalGPUAllocatable,
+			Types:     types,
+		}
+	}
+
+	return report
+}
+
+// runKubectlLocal runs kubectl in-cluster (no kubeconfig needed) and returns
+// stdout. Used by spokes to collect local cluster metrics.
+func runKubectlLocal(args ...string) ([]byte, error) {
+	cmd := exec.Command("kubectl", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("kubectl %s: %w", strings.Join(args, " "), err)
+	}
+	return out, nil
+}

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -44,6 +44,53 @@ type LeaderboardEntry struct {
 	HiveName       string `json:"hive_name,omitempty"`
 }
 
+// HeartbeatClusterHealthReport contains cluster node and GPU metrics
+// collected by the spoke in-cluster and sent to the hub via heartbeat.
+// This allows the hub to display health data for firewalled clusters
+// that it cannot query directly via kubectl.
+type HeartbeatClusterHealthReport struct {
+	Nodes      []HeartbeatNodeMetric      `json:"nodes"`
+	Summary    HeartbeatClusterSummary    `json:"summary"`
+	GPUSummary *HeartbeatGPUSummary       `json:"gpu_summary,omitempty"`
+	CollectedAt string                    `json:"collected_at"`
+}
+
+// HeartbeatNodeMetric holds per-node resource usage collected on the spoke.
+type HeartbeatNodeMetric struct {
+	Name           string   `json:"name"`
+	CPUCores       int      `json:"cpu_cores"`
+	CPUUsedMillis  int64    `json:"cpu_used_millicores"`
+	CPUPercent     int      `json:"cpu_percent"`
+	MemTotalMB     int64    `json:"mem_total_mb"`
+	MemUsedMB      int64    `json:"mem_used_mb"`
+	MemPercent     int      `json:"mem_percent"`
+	Pods           int      `json:"pods"`
+	PodCapacity    int      `json:"pod_capacity"`
+	Ready          bool     `json:"ready"`
+	Conditions     []string `json:"conditions"`
+	DiskPressure   bool     `json:"disk_pressure"`
+	GPUs           int      `json:"gpus,omitempty"`
+	GPUType        string   `json:"gpu_type,omitempty"`
+}
+
+// HeartbeatClusterSummary aggregates node-level data into cluster totals.
+type HeartbeatClusterSummary struct {
+	TotalNodes    int `json:"total_nodes"`
+	ReadyNodes    int `json:"ready_nodes"`
+	TotalCPUCores int `json:"total_cpu_cores"`
+	TotalCPUPct   int `json:"total_cpu_percent"`
+	TotalMemGB    int `json:"total_mem_gb"`
+	TotalMemPct   int `json:"total_mem_percent"`
+	TotalPods     int `json:"total_pods"`
+}
+
+// HeartbeatGPUSummary reports aggregate GPU counts collected on the spoke.
+type HeartbeatGPUSummary struct {
+	Total     int      `json:"total"`
+	Allocated int      `json:"allocated"`
+	Types     []string `json:"types"`
+}
+
 type HeartbeatPayload struct {
 	HiveID       string             `json:"hive_id"`
 	Org          string             `json:"org"`
@@ -68,6 +115,7 @@ type HeartbeatPayload struct {
 	Timestamp          string         `json:"timestamp"`
 	GitHubAppRequired  bool           `json:"github_app_required,omitempty"`
 	AutoUpgrade        bool           `json:"auto_upgrade,omitempty"`
+	ClusterHealth      *HeartbeatClusterHealthReport `json:"cluster_health,omitempty"`
 }
 
 type StatusCollector func() *HeartbeatPayload

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -522,13 +522,16 @@ type GPUSummary struct {
 
 // PerClusterHealth holds health data for a single cluster.
 type PerClusterHealth struct {
-	ID        string              `json:"id"`
-	Name      string              `json:"name"`
-	Nodes     []ClusterHealthNode `json:"nodes"`
-	Summary   ClusterHealthSummary `json:"summary"`
-	GPUSummary *GPUSummary         `json:"gpu_summary,omitempty"`
-	HiveCount int                 `json:"hive_count"`
-	Error     string              `json:"error,omitempty"`
+	ID         string              `json:"id"`
+	Name       string              `json:"name"`
+	Nodes      []ClusterHealthNode `json:"nodes"`
+	Summary    ClusterHealthSummary `json:"summary"`
+	GPUSummary *GPUSummary          `json:"gpu_summary,omitempty"`
+	HiveCount  int                  `json:"hive_count"`
+	Error      string               `json:"error,omitempty"`
+	DataSource string               `json:"data_source,omitempty"` // "heartbeat" when data comes from spoke heartbeat instead of kubectl
+	DataStale  bool                 `json:"data_stale,omitempty"`  // true when heartbeat data is older than heartbeatHealthStaleness
+	DataAge    string               `json:"data_age,omitempty"`    // human-readable age or collection timestamp
 }
 
 type ClusterHealthResponse struct {
@@ -625,6 +628,19 @@ func buildClusterHealth(s *HubServer) (*ClusterHealthResponse, error) {
 		case res := <-ch:
 			if res.err != nil {
 				s.logger.Warn("cluster health query failed", "cluster", cID, "error", res.err)
+				// Fall back to heartbeat-reported health if available.
+				if hbHealth := s.getHeartbeatHealthForCluster(cID); hbHealth != nil {
+					pch := convertHeartbeatToPerClusterHealth(cID, s.clusterNameForID(cID), hbHealth, hiveCounts[cID])
+					perCluster = append(perCluster, pch)
+					allNodes = append(allNodes, pch.Nodes...)
+					aggCPUCores += pch.Summary.TotalCPUCores
+					aggCPUUsed += int64(pch.Summary.TotalCPUPct) * int64(pch.Summary.TotalCPUCores) * millicoresPerCore / percentMultiplier
+					aggCPUAlloc += int64(pch.Summary.TotalCPUCores) * millicoresPerCore
+					aggMemAlloc += int64(pch.Summary.TotalMemGB) * giToBytes
+					aggMemUsed += int64(pch.Summary.TotalMemPct) * int64(pch.Summary.TotalMemGB) * giToBytes / percentMultiplier
+					s.logger.Info("cluster health: using heartbeat fallback", "cluster", cID)
+					continue
+				}
 				perCluster = append(perCluster, PerClusterHealth{
 					ID:    cID,
 					Name:  s.clusterNameForID(cID),
@@ -644,6 +660,19 @@ func buildClusterHealth(s *HubServer) (*ClusterHealthResponse, error) {
 			aggMemUsed += int64(pch.Summary.TotalMemPct) * int64(pch.Summary.TotalMemGB) * giToBytes / percentMultiplier
 		case <-time.After(clusterHealthQueryTimeout):
 			s.logger.Warn("cluster health query timed out", "cluster", cID)
+			// Fall back to heartbeat-reported health if available.
+			if hbHealth := s.getHeartbeatHealthForCluster(cID); hbHealth != nil {
+				pch := convertHeartbeatToPerClusterHealth(cID, s.clusterNameForID(cID), hbHealth, hiveCounts[cID])
+				perCluster = append(perCluster, pch)
+				allNodes = append(allNodes, pch.Nodes...)
+				aggCPUCores += pch.Summary.TotalCPUCores
+				aggCPUUsed += int64(pch.Summary.TotalCPUPct) * int64(pch.Summary.TotalCPUCores) * millicoresPerCore / percentMultiplier
+				aggCPUAlloc += int64(pch.Summary.TotalCPUCores) * millicoresPerCore
+				aggMemAlloc += int64(pch.Summary.TotalMemGB) * giToBytes
+				aggMemUsed += int64(pch.Summary.TotalMemPct) * int64(pch.Summary.TotalMemGB) * giToBytes / percentMultiplier
+				s.logger.Info("cluster health: using heartbeat fallback after timeout", "cluster", cID)
+				continue
+			}
 			perCluster = append(perCluster, PerClusterHealth{
 				ID:    cID,
 				Name:  s.clusterNameForID(cID),
@@ -661,6 +690,40 @@ func buildClusterHealth(s *HubServer) (*ClusterHealthResponse, error) {
 		aggMemPct = int(aggMemUsed * percentMultiplier / aggMemAlloc)
 	}
 	aggMemGB := int(aggMemAlloc / giToBytes)
+
+	// Include heartbeat-only clusters that are NOT in s.clusters but do have
+	// heartbeat-reported health data. This handles firewalled spokes whose
+	// cluster isn't in the hub's clusters.json.
+	clusterSeen := make(map[string]bool, len(results))
+	for cID := range results {
+		clusterSeen[cID] = true
+	}
+	s.heartbeatHealthMu.RLock()
+	for cID, entry := range s.heartbeatHealth {
+		if clusterSeen[cID] || entry == nil || entry.Report == nil {
+			continue
+		}
+		pch := convertHeartbeatToPerClusterHealth(cID, s.clusterNameForID(cID), entry, hiveCounts[cID])
+		perCluster = append(perCluster, pch)
+		allNodes = append(allNodes, pch.Nodes...)
+		aggCPUCores += pch.Summary.TotalCPUCores
+		aggCPUUsed += int64(pch.Summary.TotalCPUPct) * int64(pch.Summary.TotalCPUCores) * millicoresPerCore / percentMultiplier
+		aggCPUAlloc += int64(pch.Summary.TotalCPUCores) * millicoresPerCore
+		aggMemAlloc += int64(pch.Summary.TotalMemGB) * giToBytes
+		aggMemUsed += int64(pch.Summary.TotalMemPct) * int64(pch.Summary.TotalMemGB) * giToBytes / percentMultiplier
+	}
+	s.heartbeatHealthMu.RUnlock()
+
+	// Recompute aggregates after including heartbeat-only clusters.
+	aggCPUPct = 0
+	if aggCPUAlloc > 0 {
+		aggCPUPct = int(aggCPUUsed * percentMultiplier / aggCPUAlloc)
+	}
+	aggMemPct = 0
+	if aggMemAlloc > 0 {
+		aggMemPct = int(aggMemUsed * percentMultiplier / aggMemAlloc)
+	}
+	aggMemGB = int(aggMemAlloc / giToBytes)
 
 	// Sort clusters by ID for deterministic output.
 	sort.Slice(perCluster, func(i, j int) bool {
@@ -868,6 +931,78 @@ func buildSingleClusterHealth(cluster *ClusterConfig, hiveCount int, logger *slo
 	}
 
 	return result, nil
+}
+
+// getHeartbeatHealthForCluster retrieves the latest heartbeat-reported health
+// for a cluster. Returns nil if no data exists or the data is too old.
+func (s *HubServer) getHeartbeatHealthForCluster(clusterID string) *HeartbeatHealthEntry {
+	s.heartbeatHealthMu.RLock()
+	entry, ok := s.heartbeatHealth[clusterID]
+	s.heartbeatHealthMu.RUnlock()
+	if !ok || entry == nil || entry.Report == nil {
+		return nil
+	}
+	return entry
+}
+
+// convertHeartbeatToPerClusterHealth converts heartbeat-reported health data
+// into the hub's PerClusterHealth format for display. If the data is older
+// than heartbeatHealthStaleness, it is marked with a staleness warning.
+func convertHeartbeatToPerClusterHealth(clusterID, clusterName string, entry *HeartbeatHealthEntry, hiveCount int) PerClusterHealth {
+	report := entry.Report
+
+	// Convert HeartbeatNodeMetric to ClusterHealthNode.
+	nodes := make([]ClusterHealthNode, len(report.Nodes))
+	for i, n := range report.Nodes {
+		nodes[i] = ClusterHealthNode{
+			Name:          n.Name,
+			CPUCores:      n.CPUCores,
+			CPUUsedMillis: n.CPUUsedMillis,
+			CPUPercent:    n.CPUPercent,
+			MemTotalMB:    n.MemTotalMB,
+			MemUsedMB:     n.MemUsedMB,
+			MemPercent:    n.MemPercent,
+			DiskPressure:  n.DiskPressure,
+			Pods:          n.Pods,
+			PodCapacity:   n.PodCapacity,
+			Conditions:    n.Conditions,
+		}
+	}
+
+	pch := PerClusterHealth{
+		ID:   clusterID,
+		Name: clusterName,
+		Nodes: nodes,
+		Summary: ClusterHealthSummary{
+			TotalNodes:    report.Summary.TotalNodes,
+			TotalCPUCores: report.Summary.TotalCPUCores,
+			TotalCPUPct:   report.Summary.TotalCPUPct,
+			TotalMemGB:    report.Summary.TotalMemGB,
+			TotalMemPct:   report.Summary.TotalMemPct,
+			HiveCount:     hiveCount,
+		},
+		HiveCount:    hiveCount,
+		DataSource:   "heartbeat",
+	}
+
+	// Mark staleness if heartbeat data is too old.
+	age := time.Since(entry.ReceivedAt)
+	if age > heartbeatHealthStaleness {
+		pch.DataStale = true
+		pch.DataAge = fmt.Sprintf("%dm ago", int(age.Minutes()))
+	} else if report.CollectedAt != "" {
+		pch.DataAge = report.CollectedAt
+	}
+
+	// Convert GPU summary.
+	if report.GPUSummary != nil {
+		pch.GPUSummary = &GPUSummary{
+			TotalGPUs:       report.GPUSummary.Total,
+			AllocatableGPUs: report.GPUSummary.Total - report.GPUSummary.Allocated,
+		}
+	}
+
+	return pch
 }
 
 // parseK8sCPU parses Kubernetes CPU resource strings (e.g. "4", "4000m").

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -98,16 +98,29 @@ func secureCompareHub(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }
 
+// heartbeatHealthStaleness is the maximum age of heartbeat-reported health
+// data before it is considered stale and displayed with a warning.
+const heartbeatHealthStaleness = 5 * time.Minute
+
+// HeartbeatHealthEntry stores heartbeat-reported cluster health along with
+// the timestamp it was received, so the hub can detect staleness.
+type HeartbeatHealthEntry struct {
+	Report     *HeartbeatClusterHealthReport
+	ReceivedAt time.Time
+}
+
 type HubServer struct {
-	mux        *http.ServeMux
-	registry   Registry
-	mu         sync.RWMutex
-	logger     *slog.Logger
-	saveCh     chan struct{}
-	hubGitHash string
-	hubSecret  string
-	httpServer *http.Server
-	clusters   map[string]ClusterConfig
+	mux            *http.ServeMux
+	registry       Registry
+	mu             sync.RWMutex
+	logger         *slog.Logger
+	saveCh         chan struct{}
+	hubGitHash     string
+	hubSecret      string
+	httpServer     *http.Server
+	clusters       map[string]ClusterConfig
+	heartbeatHealth   map[string]*HeartbeatHealthEntry // cluster ID → latest health from spoke heartbeat
+	heartbeatHealthMu sync.RWMutex
 }
 
 func NewHubServer(port int, logger *slog.Logger, gitHash string) *HubServer {
@@ -129,12 +142,13 @@ func NewHubServer(port int, logger *slog.Logger, gitHash string) *HubServer {
 		logger.Info("generated hub secret", "path", "/data/saas/hub-secret.key")
 	}
 	s := &HubServer{
-		mux:        http.NewServeMux(),
-		logger:     logger,
-		saveCh:     make(chan struct{}, 1),
-		hubGitHash: gitHash,
-		hubSecret:  secret,
-		clusters:   loadClusters(logger),
+		mux:             http.NewServeMux(),
+		logger:          logger,
+		saveCh:          make(chan struct{}, 1),
+		hubGitHash:      gitHash,
+		hubSecret:       secret,
+		clusters:        loadClusters(logger),
+		heartbeatHealth: make(map[string]*HeartbeatHealthEntry),
 	}
 
 	s.loadRegistry()
@@ -423,6 +437,21 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 
 	s.requestSave()
 
+	// Store heartbeat-reported cluster health so the hub can use it as a
+	// fallback when it cannot reach the cluster directly via kubectl.
+	if payload.ClusterHealth != nil && entry.ClusterID != "" {
+		s.heartbeatHealthMu.Lock()
+		s.heartbeatHealth[entry.ClusterID] = &HeartbeatHealthEntry{
+			Report:     payload.ClusterHealth,
+			ReceivedAt: time.Now(),
+		}
+		s.heartbeatHealthMu.Unlock()
+		s.logger.Debug("stored heartbeat cluster health",
+			"hive_id", payload.HiveID,
+			"cluster_id", entry.ClusterID,
+			"nodes", len(payload.ClusterHealth.Nodes),
+		)
+	}
 
 	s.logger.Info("audit: hub heartbeat received",
 		"hive_id", payload.HiveID,


### PR DESCRIPTION
## Summary

- Spokes behind firewalls (e.g., vllm-d clusters) cannot be queried by the hub via `kubectl top nodes` — the hub has no kubeconfig and gets "exit status 1"
- This adds spoke-side metric collection that runs `kubectl top nodes` and `kubectl get nodes` in-cluster on the spoke, then sends the data to the hub via heartbeat
- The hub falls back to heartbeat-reported health when direct kubectl queries fail or time out
- Heartbeat-only clusters (not in `clusters.json`) also appear in the health response

## Changes

### `v2/pkg/hub/heartbeat.go`
- Added `HeartbeatClusterHealthReport`, `HeartbeatNodeMetric`, `HeartbeatClusterSummary`, `HeartbeatGPUSummary` types
- Added `ClusterHealth` field to `HeartbeatPayload`

### `v2/pkg/hub/cluster_metrics.go` (new)
- `CollectClusterHealth()` — spoke-side collector that runs `kubectl top nodes` and `kubectl get nodes -o json` in-cluster
- Parses CPU, memory, pod counts, GPU resources (nvidia.com/gpu), node conditions
- Caches results for 60 seconds to avoid running kubectl on every heartbeat
- Returns nil if metrics-server is not installed

### `v2/cmd/hive/main.go`
- Wired `CollectClusterHealth()` into the heartbeat payload builder

### `v2/pkg/hub/server.go`
- Added `heartbeatHealth` map to `HubServer` (cluster ID → latest health from spoke)
- Stores heartbeat-reported health when processing heartbeats with `ClusterHealth` data
- Added `heartbeatHealthStaleness` constant (5 minutes)

### `v2/pkg/hub/saas.go`
- `buildClusterHealth()` falls back to heartbeat data when `buildSingleClusterHealth()` fails or times out
- Includes heartbeat-only clusters (not in `clusters.json`) in the health response
- Added `DataSource`, `DataStale`, `DataAge` fields to `PerClusterHealth` for UI indication
- Added `getHeartbeatHealthForCluster()` and `convertHeartbeatToPerClusterHealth()` helpers

## Test plan

- [ ] Deploy a spoke on a firewalled cluster with metrics-server installed
- [ ] Verify `cluster_health` field appears in heartbeat payload
- [ ] Verify hub displays health data with "heartbeat" data source indicator
- [ ] Verify staleness warning appears when heartbeat data is older than 5 minutes
- [ ] Verify clusters reachable via kubectl still use direct queries (no regression)
- [ ] Verify spoke without metrics-server sends `cluster_health: null` (no errors)