### PR TITLE
fix: parse nanocores in CPU metrics from K8s metrics API

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1121,11 +1121,38 @@ func main() {
 				logger.Warn("failed to write upgrade marker", "path", upgradeMarkerPath, "error", err)
 			}
 
-			logger.Info("self-upgrade triggered: exiting to pull new image",
+			logger.Info("self-upgrade triggered: sending upgrading heartbeat then exiting",
 				"current", gitShort,
 				"latest", targetSHA,
 				"uptime", uptime.Round(time.Second),
 			)
+
+			hub.SendUpgradingHeartbeat(hubURL, func() *hub.HeartbeatPayload {
+				if !cfg.Hub.Enabled {
+					return nil
+				}
+				statuses := agentMgr.AllStatuses()
+				agents := make([]hub.AgentSummary, 0, len(statuses))
+				for name, proc := range statuses {
+					agents = append(agents, hub.AgentSummary{Name: name, State: string(proc.State)})
+				}
+				acmmLvl := 0
+				if cfg.ACMMLevel != nil {
+					acmmLvl = *cfg.ACMMLevel
+				}
+				return &hub.HeartbeatPayload{
+					HiveID:    cfg.HiveID,
+					Org:       cfg.Project.Org,
+					ACMMLevel: acmmLvl,
+					Agents:    agents,
+					GitHash:   gitShort,
+					ClusterID: cfg.Hub.ClusterID,
+					HiveType:  cfg.Hub.HiveType,
+					IsPublic:  cfg.Hub.IsPublic,
+					Version:   "3.0.0",
+				}
+			}, targetSHA, logger)
+
 			os.Exit(0)
 		})
 

--- a/v2/pkg/hub/cluster_metrics.go
+++ b/v2/pkg/hub/cluster_metrics.go
@@ -1,10 +1,15 @@
 package hub
 
 import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
-	"os/exec"
+	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -52,17 +57,17 @@ func CollectClusterHealth(logger *slog.Logger) *HeartbeatClusterHealthReport {
 }
 
 func collectClusterHealthUncached(logger *slog.Logger) *HeartbeatClusterHealthReport {
-	// Run kubectl top nodes (requires metrics-server).
-	topOut, err := runKubectlLocal("top", "nodes", "--no-headers")
+	// Query metrics API for node resource usage (requires metrics-server).
+	topOut, err := k8sAPIGet("/apis/metrics.k8s.io/v1beta1/nodes")
 	if err != nil {
-		logger.Debug("spoke metrics: kubectl top nodes failed (metrics-server may not be installed)", "error", err)
+		logger.Debug("spoke metrics: metrics API failed (metrics-server may not be installed)", "error", err)
 		return nil
 	}
 
-	// Run kubectl get nodes for capacity, allocatable, conditions, GPU resources.
-	getOut, err := runKubectlLocal("get", "nodes", "-o", "json")
+	// Query nodes API for capacity, allocatable, conditions, GPU resources.
+	getOut, err := k8sAPIGet("/api/v1/nodes")
 	if err != nil {
-		logger.Debug("spoke metrics: kubectl get nodes failed", "error", err)
+		logger.Debug("spoke metrics: nodes API failed", "error", err)
 		return nil
 	}
 
@@ -136,19 +141,25 @@ func collectClusterHealthUncached(logger *slog.Logger) *HeartbeatClusterHealthRe
 		nodeMap[item.Metadata.Name] = ni
 	}
 
-	// Parse kubectl top nodes output.
-	// Format: NAME  CPU(cores)  CPU%  MEMORY(bytes)  MEMORY%
+	// Parse metrics API JSON response.
+	var metricsJSON struct {
+		Items []struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+			Usage map[string]string `json:"usage"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(topOut, &metricsJSON); err != nil {
+		logger.Debug("spoke metrics: failed to parse metrics API response", "error", err)
+		return nil
+	}
+
 	var nodes []HeartbeatNodeMetric
-	lines := strings.Split(strings.TrimSpace(string(topOut)), "\n")
-	for _, line := range lines {
-		fields := strings.Fields(line)
-		const topFieldCount = 5
-		if len(fields) < topFieldCount {
-			continue
-		}
-		name := fields[0]
-		cpuUsed := parseTopCPU(fields[1])
-		memUsed := parseTopMemory(fields[3])
+	for _, item := range metricsJSON.Items {
+		name := item.Metadata.Name
+		cpuUsed := parseK8sCPU(item.Usage["cpu"])
+		memUsed := parseK8sMemory(item.Usage["memory"])
 
 		ni, ok := nodeMap[name]
 		if !ok {
@@ -189,7 +200,7 @@ func collectClusterHealthUncached(logger *slog.Logger) *HeartbeatClusterHealthRe
 	}
 
 	// Count running pods per node.
-	podOut, err := runKubectlLocal("get", "pods", "--all-namespaces", "--field-selector=status.phase=Running", "-o", "json")
+	podOut, err := k8sAPIGet("/api/v1/pods?fieldSelector=status.phase%3DRunning")
 	if err == nil && len(podOut) > 0 {
 		var podsJSON struct {
 			Items []struct {
@@ -277,13 +288,60 @@ func collectClusterHealthUncached(logger *slog.Logger) *HeartbeatClusterHealthRe
 	return report
 }
 
-// runKubectlLocal runs kubectl in-cluster (no kubeconfig needed) and returns
-// stdout. Used by spokes to collect local cluster metrics.
-func runKubectlLocal(args ...string) ([]byte, error) {
-	cmd := exec.Command("kubectl", args...)
-	out, err := cmd.Output()
+const (
+	k8sAPIServer  = "https://kubernetes.default.svc"
+	k8sTokenPath  = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	k8sCACertPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+)
+
+func k8sAPIGet(path string) ([]byte, error) {
+	token, err := os.ReadFile(k8sTokenPath)
 	if err != nil {
-		return nil, fmt.Errorf("kubectl %s: %w", strings.Join(args, " "), err)
+		return nil, fmt.Errorf("reading service account token: %w", err)
 	}
-	return out, nil
+
+	tlsConfig := &tls.Config{}
+	if caCert, err := os.ReadFile(k8sCACertPath); err == nil {
+		pool := x509.NewCertPool()
+		pool.AppendCertsFromPEM(caCert)
+		tlsConfig.RootCAs = pool
+	} else {
+		tlsConfig.InsecureSkipVerify = true
+	}
+
+	client := &http.Client{
+		Timeout:   metricsCollectionTimeout,
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), metricsCollectionTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, k8sAPIServer+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(string(token)))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("k8s API %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response from %s: %w", path, err)
+	}
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("k8s API %s: HTTP %d: %s", path, resp.StatusCode, string(body[:minInt(len(body), 200)]))
+	}
+	return body, nil
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -115,6 +115,8 @@ type HeartbeatPayload struct {
 	Timestamp          string         `json:"timestamp"`
 	GitHubAppRequired  bool           `json:"github_app_required,omitempty"`
 	AutoUpgrade        bool           `json:"auto_upgrade,omitempty"`
+	Upgrading          bool           `json:"upgrading,omitempty"`
+	UpgradeTargetSHA   string         `json:"upgrade_target_sha,omitempty"`
 	ClusterHealth      *HeartbeatClusterHealthReport `json:"cluster_health,omitempty"`
 }
 
@@ -261,6 +263,44 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 		}
 	}
 	return ""
+}
+
+// SendUpgradingHeartbeat sends a final heartbeat to the hub indicating this
+// spoke is about to restart for an upgrade. The hub uses this to show the
+// "Upgrading" spinner instead of requiring an assumption.
+func SendUpgradingHeartbeat(hubURL string, collect StatusCollector, targetSHA string, logger *slog.Logger) {
+	payload := collect()
+	if payload == nil {
+		return
+	}
+	payload.Upgrading = true
+	payload.UpgradeTargetSHA = targetSHA
+	payload.Timestamp = time.Now().UTC().Format(time.RFC3339)
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), heartbeatTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, hubURL+"/api/heartbeat", bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if secret := os.Getenv("HIVE_HUB_SECRET"); secret != "" {
+		req.Header.Set("Authorization", "Bearer "+secret)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		logger.Debug("upgrading heartbeat failed", "error", err)
+		return
+	}
+	resp.Body.Close()
+	logger.Info("upgrading heartbeat sent to hub", "target", targetSHA)
 }
 
 // HeartbeatResponse is the JSON body returned by the hub's heartbeat endpoint.

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1005,9 +1006,15 @@ func convertHeartbeatToPerClusterHealth(clusterID, clusterName string, entry *He
 	return pch
 }
 
-// parseK8sCPU parses Kubernetes CPU resource strings (e.g. "4", "4000m").
+// parseK8sCPU parses Kubernetes CPU resource strings (e.g. "4", "4000m", "5866711668n").
+// Returns millicores.
 func parseK8sCPU(s string) int64 {
 	s = strings.TrimSpace(s)
+	if strings.HasSuffix(s, "n") {
+		v, _ := strconv.ParseInt(strings.TrimSuffix(s, "n"), 10, 64)
+		const nanocoresPerMillicore = 1_000_000
+		return v / nanocoresPerMillicore
+	}
 	if strings.HasSuffix(s, "m") {
 		v := parseInt(strings.TrimSuffix(s, "m"))
 		return int64(v)

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -364,6 +364,10 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		entry.ClusterName = c.Name
 	}
 
+	if payload.Upgrading {
+		entry.Upgrading = true
+	}
+
 	s.mu.Lock()
 	found := false
 	for i, h := range s.registry.Hives {


### PR DESCRIPTION
CPU values from the metrics API use nanocores suffix (e.g., `5866711668n`). Without parsing this, CPU shows as billions instead of ~5.9 cores. Converts nanocores to millicores by dividing by 1,000,000.