### PR TITLE
fix: auto-restart agents on transient TLS/network errors

### DIFF
--- a/v2/pkg/agent/agent_unit_test.go
+++ b/v2/pkg/agent/agent_unit_test.go
@@ -221,6 +221,40 @@ func TestPaneShowsLoginPromptUnit(t *testing.T) {
 	}
 }
 
+func TestPaneShowsFatalNetworkErrorUnit(t *testing.T) {
+	tlsError := []string{
+		"Copilot v1.0.63 uses AI.",
+		"Error auto updating: Failed to fetch latest release: HttpError: request failed: error sending request for url",
+		"(https://api.github.com/repos/github/copilot-cli/releases/latest): client error (Connect): invalid peer certificate: BadSignature",
+		"❯",
+		"/ commands · ? help",
+	}
+	if !paneShowsFatalNetworkError(tlsError) {
+		t.Error("should detect BadSignature TLS error")
+	}
+
+	fetchFailed := []string{
+		"Error during sign-in: TypeError: fetch failed",
+		"Press any key to retry",
+	}
+	if !paneShowsFatalNetworkError(fetchFailed) {
+		t.Error("should detect fetch failed error")
+	}
+
+	normalLines := []string{
+		"normal output",
+		"❯",
+		"/ commands · ? help",
+	}
+	if paneShowsFatalNetworkError(normalLines) {
+		t.Error("should not detect error in normal output")
+	}
+
+	if paneShowsFatalNetworkError(nil) {
+		t.Error("nil pane should not show error")
+	}
+}
+
 func TestSeedRestartCountUnit(t *testing.T) {
 	m := NewManager(map[string]config.AgentConfig{
 		"scanner": {Backend: "claude"},

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -656,6 +656,30 @@ func (m *Manager) pollTmuxOutputForAgent(agent *AgentProcess, ctx context.Contex
 				}
 			}
 
+			// Detect fatal TLS/network errors that leave the agent visually
+			// "ready" (the Copilot chrome shows ❯ and / commands) but actually
+			// dead. These errors are transient — a restart will succeed once
+			// the network recovers.
+			if agent.Config.Backend == "copilot" && paneShowsFatalNetworkError(filtered) {
+				sinceLastRestart := time.Since(agent.lastTokenRestart).Seconds()
+				if sinceLastRestart >= float64(tlsErrorRestartCooldownSec) {
+					m.logger.Warn("fatal network/TLS error detected, restarting agent",
+						"agent", agent.Name,
+					)
+					agent.lastTokenRestart = time.Now()
+					agent.LastError = "transient TLS/network error"
+					go func() {
+						if err := m.Restart(ctx, agent.Name); err != nil {
+							m.logger.Warn("tls-error-triggered restart failed",
+								"agent", agent.Name,
+								"error", err,
+							)
+						}
+					}()
+					return
+				}
+			}
+
 			// Detect copilot hung: if running long enough with no CLI prompt,
 			// launch bare `copilot` to diagnose the error. Only clear the
 			// token if the diagnostic shows an auth error.
@@ -1922,6 +1946,7 @@ const (
 	sharedConfigDesiredMode    = 0o660
 	tokenRestartCooldownSec    = 60  // minimum seconds between token-triggered restarts per agent
 	expiredTokenHangTimeoutSec = 180 // blank pane after this many seconds triggers token purge + restart
+	tlsErrorRestartCooldownSec = 120 // minimum seconds between TLS-error-triggered restarts per agent
 )
 
 // loginPromptPatterns are substrings that indicate an agent is stuck on the
@@ -1934,6 +1959,29 @@ var loginPromptPatterns = []string{
 	"Authenticate to use",
 	"log in to use",
 	"Log in to use",
+}
+
+// fatalNetworkErrorPatterns are substrings that indicate a transient TLS or
+// network failure killed the agent at startup. These errors leave the Copilot
+// chrome visible (❯, / commands) so paneShowsCLIReady returns true, but the
+// agent is dead and will never recover without a restart.
+var fatalNetworkErrorPatterns = []string{
+	"invalid peer certificate",
+	"BadSignature",
+	"fetch failed",
+}
+
+// paneShowsFatalNetworkError returns true if any line contains a fatal
+// TLS/network error pattern that requires an agent restart.
+func paneShowsFatalNetworkError(lines []string) bool {
+	for _, line := range lines {
+		for _, pat := range fatalNetworkErrorPatterns {
+			if strings.Contains(line, pat) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // configHasTokens reads the shared Copilot config.json, strips single-line


### PR DESCRIPTION
## Summary
- Copilot agents that hit transient TLS errors (e.g. `invalid peer certificate: BadSignature` from rustls during CDN/proxy cert rotation) die at startup but leave the Copilot CLI chrome visible in the pane (`❯`, `/ commands`)
- The existing hung-agent detection (`paneShowsCLIReady`) returns true for these dead agents, so they're never restarted
- This was observed on OKE (Oracle Kubernetes Engine) where a transient TLS proxy/CDN glitch killed all 6 Copilot agents simultaneously — none recovered without a manual pod restart

## Changes
- Add `fatalNetworkErrorPatterns` detection: `"invalid peer certificate"`, `"BadSignature"`, `"fetch failed"`
- New `paneShowsFatalNetworkError()` helper that scans pane output regardless of CLI ready state
- Auto-restart with 120s cooldown (longer than the 60s token cooldown to avoid loops on persistent network outages)
- Unit tests covering all three patterns plus negative cases

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/agent/ -run TestPaneShowsFatalNetworkErrorUnit` passes
- [ ] Deploy to a hive and verify agents auto-restart after simulated TLS failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)