### PR TITLE
feat: healthy endpoint selection, dynamic model discovery, Hub URL fix

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -261,22 +261,27 @@ func main() {
 		policyDir = policyDir + "/" + cfg.Policies.Path
 	}
 
-	// Write brainstorm policy to disk so the agent can find it.
-	// The policy is embedded in the binary but the agent searches the filesystem.
-	brainstormPolicyDir := policyDir
-	if brainstormPolicyDir == "" {
-		brainstormPolicyDir = "/data/policies/examples/kubestellar/agents"
+	// Extract all embedded kick templates to disk so agents can find them.
+	kickPolicyDir := policyDir
+	if kickPolicyDir == "" {
+		kickPolicyDir = "/data/policies/examples/kubestellar/agents"
 	}
-	os.MkdirAll(brainstormPolicyDir, 0o755)
-	if policyData, err := policies.DefaultPolicies.ReadFile("defaults/brainstorm-advisory.md"); err == nil {
-		policyPath := filepath.Join(brainstormPolicyDir, "brainstorm-advisory.md")
-		// Always overwrite — the embedded policy may have been updated
-		// (e.g., inception reaping guard added in bug #113 fix).
-		if err := os.WriteFile(policyPath, policyData, 0o644); err != nil {
-			logger.Warn("failed to write brainstorm policy", "path", policyPath, "error", err)
-		} else {
-			logger.Info("wrote brainstorm policy to disk", "path", policyPath)
+	os.MkdirAll(kickPolicyDir, 0o755)
+	if entries, err := policies.DefaultPolicies.ReadDir("defaults"); err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			policyData, err := policies.DefaultPolicies.ReadFile("defaults/" + entry.Name())
+			if err != nil {
+				continue
+			}
+			policyPath := filepath.Join(kickPolicyDir, entry.Name())
+			if err := os.WriteFile(policyPath, policyData, 0o644); err != nil {
+				logger.Warn("failed to write policy", "path", policyPath, "error", err)
+			}
 		}
+		logger.Info("extracted embedded kick templates", "dir", kickPolicyDir, "count", len(entries))
 	}
 
 	projectCtx := agent.ProjectContext{
@@ -860,14 +865,15 @@ func main() {
 	} else {
 		dashboard.SetProxyViolationsProvider(githubProxy.Violations)
 
-		vllmEndpoint := envOrDefault("HIVE_VLLM_ENDPOINT", "http://vllm-svc.hive.svc.cluster.local:8000")
-		llmdEndpoint := envOrDefault("HIVE_LLMD_ENDPOINT", "http://llm-d-epp.hive.svc.cluster.local:8000")
+		vllmEndpoints := envOrDefault("HIVE_VLLM_ENDPOINT", "http://vllm-svc.hive.svc.cluster.local:8000")
+		llmdEndpoints := envOrDefault("HIVE_LLMD_ENDPOINT", "http://llm-d-epp.hive.svc.cluster.local:8000")
 		agentMgr.SetInferenceCallbacks(
 			func(agentName, backend, model string) {
-				endpoint := vllmEndpoint
+				endpoints := vllmEndpoints
 				if backend == "llm-d" {
-					endpoint = llmdEndpoint
+					endpoints = llmdEndpoints
 				}
+				endpoint := pickHealthyEndpoint(endpoints, model, logger)
 				githubProxy.SetInferenceRoute(agentName, &proxy.InferenceRoute{
 					Backend:  backend,
 					Endpoint: endpoint,
@@ -1010,6 +1016,8 @@ func main() {
 				}(),
 				SnapshotURL:  cfg.Hub.SnapshotURL,
 				IsPublic:     cfg.Hub.IsPublic,
+				HiveType:     cfg.Hub.HiveType,
+				ClusterID:    cfg.Hub.ClusterID,
 				Version:           "3.0.0",
 				GitHash:           gitShort,
 				GitBranch:         gitBranch,
@@ -2054,4 +2062,57 @@ func envOrDefault(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// pickHealthyEndpoint iterates comma-separated endpoints and returns the first
+// one that has the requested model available (or any model if model is empty).
+// Falls back to the first endpoint if none respond.
+func pickHealthyEndpoint(endpoints, model string, logger *slog.Logger) string {
+	const healthCheckTimeout = 3 * time.Second
+	parts := strings.Split(endpoints, ",")
+	var first string
+	for _, ep := range parts {
+		ep = strings.TrimSpace(ep)
+		if ep == "" {
+			continue
+		}
+		if first == "" {
+			first = ep
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), healthCheckTimeout)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, ep+"/v1/models", nil)
+		if err != nil {
+			cancel()
+			continue
+		}
+		resp, err := http.DefaultClient.Do(req)
+		cancel()
+		if err != nil {
+			logger.Debug("endpoint unreachable", "endpoint", ep, "error", err)
+			continue
+		}
+		var result struct {
+			Data []struct {
+				ID string `json:"id"`
+			} `json:"data"`
+		}
+		decodeErr := json.NewDecoder(resp.Body).Decode(&result)
+		resp.Body.Close()
+		if decodeErr != nil {
+			continue
+		}
+		if model == "" || len(result.Data) == 0 {
+			logger.Info("picked healthy endpoint", "endpoint", ep)
+			return ep
+		}
+		for _, m := range result.Data {
+			if m.ID == model {
+				logger.Info("picked healthy endpoint with model", "endpoint", ep, "model", model)
+				return ep
+			}
+		}
+		logger.Debug("endpoint healthy but model not found", "endpoint", ep, "model", model)
+	}
+	logger.Warn("no healthy endpoint found, using first", "endpoint", first)
+	return first
 }

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -343,6 +343,9 @@ type HubConfig struct {
 	IsPublic               bool     `yaml:"is_public"`
 	SnapshotURL            string   `yaml:"snapshot_url"`
 	DashboardURL           string   `yaml:"dashboard_url"`
+	HiveType               string   `yaml:"hive_type"`
+	ClusterID              string   `yaml:"cluster_id"`
+	AutoUpgrade            bool     `yaml:"auto_upgrade"`
 	AutoSnapshot           bool     `yaml:"auto_snapshot"`
 	ContributeSuspended    bool     `yaml:"contribute_suspended"`
 	ContributeAllowLabels  []string `yaml:"contribute_allow_labels"`

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -2901,12 +2902,81 @@ func (s *Server) saveSidebarToDisk(sb interface{}) {
 }
 
 func (s *Server) handleBackends(w http.ResponseWriter, r *http.Request) {
-	jsonResponse(w, []map[string]interface{}{
+	backends := []map[string]interface{}{
 		{"id": "claude", "name": "Claude Code", "models": []string{"opus", "sonnet", "haiku"}},
 		{"id": "copilot", "name": "GitHub Copilot", "models": []string{"gpt-4o", "gpt-4o-mini"}},
 		{"id": "gemini", "name": "Gemini", "models": []string{"gemini-2.5-pro", "gemini-2.5-flash"}},
 		{"id": "goose", "name": "Goose", "models": []string{"default"}},
-	})
+	}
+
+	vllmEndpoint := os.Getenv("HIVE_VLLM_ENDPOINT")
+	if vllmEndpoint == "" {
+		vllmEndpoint = "http://hive-vllm-svc:8000"
+	}
+	llmdEndpoint := os.Getenv("HIVE_LLMD_ENDPOINT")
+	if llmdEndpoint == "" {
+		llmdEndpoint = "http://hive-llm-d-epp:9002"
+	}
+
+	vllmModels := discoverModelsMulti(vllmEndpoint)
+	llmdModels := discoverModelsMulti(llmdEndpoint)
+
+	backends = append(backends,
+		map[string]interface{}{"id": "vllm", "name": "vLLM (self-hosted)", "inference": true, "models": vllmModels},
+		map[string]interface{}{"id": "llm-d", "name": "llm-d (self-hosted)", "inference": true, "models": llmdModels},
+	)
+
+	jsonResponse(w, backends)
+}
+
+func discoverModelsMulti(endpoints string) []string {
+	seen := make(map[string]bool)
+	var models []string
+	for _, ep := range strings.Split(endpoints, ",") {
+		ep = strings.TrimSpace(ep)
+		if ep == "" {
+			continue
+		}
+		for _, m := range discoverModels(ep) {
+			if !seen[m] {
+				seen[m] = true
+				models = append(models, m)
+			}
+		}
+	}
+	return models
+}
+
+func discoverModels(endpoint string) []string {
+	const discoverTimeout = 3 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), discoverTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"/v1/models", nil)
+	if err != nil {
+		return nil
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil
+	}
+	models := make([]string, 0, len(result.Data))
+	for _, m := range result.Data {
+		if m.ID != "" {
+			models = append(models, m.ID)
+		}
+	}
+	return models
 }
 
 // --- Knowledge endpoints ---

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3860,9 +3860,9 @@
       return KNOWN_MODELS;
     }
 
+    const MODEL_DISCOVERY_INTERVAL_MS = 30000;
     let _cachedInferenceModels = null;
     async function fetchInferenceModels() {
-      if (_cachedInferenceModels) return _cachedInferenceModels;
       try {
         const resp = await fetch('/api/config/backends');
         const backends = await resp.json();
@@ -3872,12 +3872,40 @@
             models[b.id] = (b.models || []).map(m => ({ value: m, label: m.split('/').pop() }));
           }
         }
+        const prev = _cachedInferenceModels;
         _cachedInferenceModels = models;
         Object.assign(INFERENCE_MODELS, models);
+        if (prev) {
+          for (const [bid, mList] of Object.entries(models)) {
+            const prevIds = new Set((prev[bid] || []).map(m => m.value));
+            const newModels = mList.filter(m => !prevIds.has(m.value));
+            if (newModels.length > 0) {
+              for (const m of newModels) {
+                showToast(`New model discovered: ${m.label} (${bid})`, 'success', false, true);
+              }
+              refreshInferenceDropdowns(bid);
+            }
+          }
+        }
       } catch (e) { /* use defaults */ }
       return INFERENCE_MODELS;
     }
     fetchInferenceModels();
+    setInterval(fetchInferenceModels, MODEL_DISCOVERY_INTERVAL_MS);
+
+    function refreshInferenceDropdowns(backend) {
+      if (!window._lastAgents) return;
+      const models = INFERENCE_MODELS[backend] || [];
+      for (const a of window._lastAgents) {
+        if (a.cli !== backend) continue;
+        const selects = document.querySelectorAll(`select[data-change-action="switchModel"][data-agent="${a.name}"]`);
+        selects.forEach(sel => {
+          const current = sel.value;
+          sel.innerHTML = '<option value="">model ▾</option>' +
+            models.map(m => `<option value="${m.value}"${m.value === current ? ' selected' : ''}>${m.label}</option>`).join('');
+        });
+      }
+    }
 
     function _normalizeModel(m) { return (m || '').replace(/(\d+)\.(\d+)$/, '$1-$2'); }
     function _modelsEqual(a, b) { return _normalizeModel(a) === _normalizeModel(b); }
@@ -7936,12 +7964,22 @@ function burnAreaChart() {
         overlay.querySelector('.primary').focus();
       });
     }
-    function showToast(msg, type = 'info', persistent = false) {
+    function showToast(msg, type = 'info', persistent = false, dismissable = false) {
       const container = document.getElementById('toast-container');
       const el = document.createElement('div');
       el.className = `toast ${type}`;
       el.textContent = msg;
       container.appendChild(el);
+      if (dismissable) {
+        el.style.cursor = 'pointer';
+        const closeBtn = document.createElement('span');
+        closeBtn.textContent = ' ✕';
+        closeBtn.style.marginLeft = '8px';
+        closeBtn.style.opacity = '0.7';
+        el.appendChild(closeBtn);
+        el.addEventListener('click', () => dismissToast(el));
+        return el;
+      }
       if (persistent) {
         const spinner = document.createElement('span');
         spinner.className = 'toast-spinner';

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -60,6 +60,8 @@ type HeartbeatPayload struct {
 	SnapshotURL  string             `json:"snapshot_url"`
 	Owner        string             `json:"owner,omitempty"`
 	IsPublic     bool               `json:"is_public"`
+	HiveType     string             `json:"hive_type,omitempty"`
+	ClusterID    string             `json:"cluster_id,omitempty"`
 	Version      string             `json:"version"`
 	GitHash      string             `json:"git_hash"`
 	GitBranch    string             `json:"git_branch,omitempty"`

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2641,30 +2641,27 @@ const dashboardHTML = `<!DOCTYPE html>
       if (!checks.length) lines.push('No check data');
       return '<span title="' + esc(lines.join('\n')) + '" style="display:inline-flex;align-items:center;gap:4px;cursor:help;white-space:pre-line"><span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + c + '"></span><span style="font-size:0.7rem;color:' + c + ';font-weight:600">' + ic + '</span></span>';
     }
+    function hiveDashUrl(h) {
+      if (h.dashboardUrl && !h.dashboardUrl.includes('localhost')) return h.dashboardUrl;
+      var isHosted = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-')));
+      if (isHosted) return 'https://' + h.id + '.hive.kubestellar.io';
+      return '';
+    }
     function dashboardLink(h) {
-      var isHosted = h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'));
-      if (isHosted) {
-        var url = 'https://' + esc(h.id) + '.hive.kubestellar.io';
-        return '<a href="' + url + '" target="_blank" class="dash-link">' + esc(h.id) + '.hive...</a>';
-      }
-      if (h.dashboardUrl && !h.dashboardUrl.includes('localhost'))
-        return '<a href="' + esc(h.dashboardUrl) + '" target="_blank" class="dash-link">' + esc(h.dashboardUrl.replace('http://','')) + '</a>';
-      return '<span style="color:var(--muted);font-size:0.75rem">—</span>';
+      var url = hiveDashUrl(h);
+      if (!url) return '<span style="color:var(--muted);font-size:0.75rem">—</span>';
+      var label = url.replace(/^https?:\/\//, '');
+      if (label.length > 30) label = label.substring(0, 27) + '...';
+      return '<a href="' + esc(url) + '" target="_blank" class="dash-link">' + esc(label) + '</a>';
     }
     function snapshotLink(h) {
       if (h.snapshotUrl) return '<a href="' + esc(h.snapshotUrl) + '" target="_blank" class="dash-link">↗</a>';
       return '';
     }
     function apiLink(h) {
-      var isHosted = h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'));
-      var base = '';
-      if (isHosted) {
-        base = 'https://' + esc(h.id) + '.hive.kubestellar.io';
-      } else if (h.dashboardUrl && !h.dashboardUrl.includes('localhost')) {
-        base = esc(h.dashboardUrl);
-      }
+      var base = hiveDashUrl(h);
       if (!base) return '';
-      return '<a href="' + base + '/api/docs" target="_blank" style="padding:3px 10px;background:rgba(88,166,255,0.15);color:#58a6ff;border:1px solid rgba(88,166,255,0.3);border-radius:4px;font-size:0.7rem;text-decoration:none;white-space:nowrap">API ↗</a>';
+      return '<a href="' + esc(base) + '/api/docs" target="_blank" style="padding:3px 10px;background:rgba(88,166,255,0.15);color:#58a6ff;border:1px solid rgba(88,166,255,0.3);border-radius:4px;font-size:0.7rem;text-decoration:none;white-space:nowrap">API ↗</a>';
     }
 
     async function loadUser() {
@@ -2794,7 +2791,7 @@ const dashboardHTML = `<!DOCTYPE html>
           var actionCell = '';
           var access = accessMap[h.id];
           if (access && access.status === 'accepted') {
-            var cUrl = 'https://' + esc(h.id) + '.hive.kubestellar.io/contribute';
+            var cUrl = hiveDashUrl(h) ? hiveDashUrl(h) + '/contribute' : '';
             actionCell = '<a href="' + cUrl + '" target="_blank" style="padding:3px 10px;background:rgba(34,197,94,0.15);color:#4ade80;border:1px solid rgba(34,197,94,0.3);border-radius:4px;font-size:0.7rem;text-decoration:none">Contribute</a>';
           } else if (access && access.status === 'pending') {
             actionCell = '<span style="padding:3px 10px;background:rgba(245,158,11,0.15);color:#fbbf24;border:1px solid rgba(245,158,11,0.3);border-radius:4px;font-size:0.7rem">Pending</span>';
@@ -2843,7 +2840,7 @@ const dashboardHTML = `<!DOCTYPE html>
         var rp = repoPath(h);
         var repoLink = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" class="repo-link">' + esc(h.primaryRepo) + '</a>' : '';
         var repoCount = (h.repos || []).length;
-        var isHosted = h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'));
+        var isHosted = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-')));
         var isLocal = !isHosted;
         var canConvert = isLocal && h.role === 'owner' && (_userQuota < 0 || _userQuota > _userUsed);
         var typeBadge = isHosted
@@ -2854,10 +2851,10 @@ const dashboardHTML = `<!DOCTYPE html>
           : h.provStatus === 'provisioning'
           ? '<span style="color:var(--accent);white-space:nowrap">⏳ Provisioning</span>'
           : modeBadge(h.governorMode);
-        var contributeUrl = isHosted ? 'https://' + esc(h.id) + '.hive.kubestellar.io/contribute' : (h.dashboardUrl && !h.dashboardUrl.includes('localhost') ? h.dashboardUrl + '/contribute' : '');
+        var contributeUrl = hiveDashUrl(h) ? hiveDashUrl(h) + '/contribute' : '';
         var contributeCell = '';
         if (h.role === 'owner') {
-          var dashHref = isHosted ? 'https://' + esc(h.id) + '.hive.kubestellar.io' : (h.dashboardUrl && !h.dashboardUrl.includes('localhost') ? esc(h.dashboardUrl) : '');
+          var dashHref = hiveDashUrl(h) ? esc(hiveDashUrl(h)) : '';
           if (dashHref) contributeCell = '<a href="' + dashHref + '" target="_blank" style="padding:2px 8px;background:rgba(34,197,94,0.15);color:#4ade80;border:1px solid rgba(34,197,94,0.3);border-radius:4px;font-size:0.65rem;white-space:nowrap;text-decoration:none">Dashboard</a>';
         } else if (h.role === 'read' || h.role === 'read-write') {
           if (contributeUrl) contributeCell = '<a href="' + contributeUrl + '" target="_blank" style="padding:2px 8px;background:rgba(34,197,94,0.15);color:#4ade80;border:1px solid rgba(34,197,94,0.3);border-radius:4px;font-size:0.65rem;white-space:nowrap;text-decoration:none">Contribute</a>';
@@ -2882,7 +2879,7 @@ const dashboardHTML = `<!DOCTYPE html>
         var mi = 'display:block;padding:7px 14px;color:#c9d1d9;text-decoration:none;font-size:0.78rem;cursor:pointer';
         if (contributeUrl) menuItems.push('<a href="' + contributeUrl + '" target="_blank" style="' + mi + '">Contribute</a>');
         if (h.snapshotUrl) menuItems.push('<a href="' + esc(h.snapshotUrl) + '" target="_blank" style="' + mi + '">Preview</a>');
-        var apiBase = isHosted ? 'https://' + esc(h.id) + '.hive.kubestellar.io' : (h.dashboardUrl && !h.dashboardUrl.includes('localhost') ? esc(h.dashboardUrl) : '');
+        var apiBase = hiveDashUrl(h) ? esc(hiveDashUrl(h)) : '';
         if (apiBase) menuItems.push('<a href="' + apiBase + '/api/docs" target="_blank" style="' + mi + '">API Docs</a>');
         if (menuItems.length > 0 && (canConvert || isHosted || isLocal)) menuItems.push('<div style="border-top:1px solid #30363d;margin:4px 0"></div>');
         if (canConvert) menuItems.push('<div onclick="openConvert(this)" data-hive-id="' + esc(h.id) + '" data-dash-url="' + esc(h.dashboardUrl||'') + '" data-org="' + esc(h.org) + '" data-repos="' + esc((h.repos||[]).join(', ')) + '" data-primary="' + esc(h.primaryRepo) + '" data-level="' + (h.acmmLevel||1) + '" data-name="' + esc(h.name||'') + '" style="' + mi + '">Convert to Hosted</div>');
@@ -2936,7 +2933,7 @@ const dashboardHTML = `<!DOCTYPE html>
         return '<tr>' +
           '<td style="white-space:nowrap">' + contributeCell + (pendingPill ? '<div style="margin-top:4px">' + pendingPill + '</div>' : '') + '</td>' +
           '<td class="hive-menu-cell" style="position:relative;width:30px;text-align:center;overflow:visible"><span style="cursor:pointer;font-size:1.1rem;color:var(--muted);user-select:none">⋮</span>' + pendingBadge + '<div class="hive-menu-dropdown" style="display:none;position:absolute;left:0;bottom:auto;background:#1c2128;border:1px solid #30363d;border-radius:8px;min-width:160px;padding:4px 0;z-index:1000;box-shadow:0 8px 24px rgba(0,0,0,0.5)">' + menuItems.join('') + '</div></td>' +
-          '<td style="text-align:left;line-height:1.4">' + (function() { var dh = isHosted ? 'https://' + esc(h.id) + '.hive.kubestellar.io' : (h.dashboardUrl && !h.dashboardUrl.includes('localhost') ? esc(h.dashboardUrl) : ''); var displayName = h.name || h.id; var parts = displayName.split('/'); var orgName = parts.length > 1 ? parts[0] : ''; var repoName = parts.length > 1 ? parts.slice(1).join('/') : displayName; var rp = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : ''; var ghIcon = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>' : ''; var link = function(text, bold) { var s = bold ? 'font-weight:700;color:inherit' : 'color:#6b7280;font-weight:400'; return dh ? '<a href="' + dh + '" target="_blank" style="' + s + ';text-decoration:none">' + esc(text) + '</a>' : '<span style="' + s + '">' + esc(text) + '</span>'; }; var line1 = dot + ' ' + link(orgName || repoName, true); var line2 = orgName ? '<div style="padding-left:18px;font-size:0.8rem">' + link(repoName, false) + ' ' + ghIcon + ' ' + roleBadge(h.role) + '</div>' : '<div style="padding-left:18px">' + ghIcon + ' ' + roleBadge(h.role) + '</div>'; return line1 + line2; })() + '</td>' +
+          '<td style="text-align:left;line-height:1.4">' + (function() { var dh = hiveDashUrl(h) ? esc(hiveDashUrl(h)) : ''; var displayName = h.name || h.id; var parts = displayName.split('/'); var orgName = parts.length > 1 ? parts[0] : ''; var repoName = parts.length > 1 ? parts.slice(1).join('/') : displayName; var rp = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : ''; var ghIcon = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>' : ''; var link = function(text, bold) { var s = bold ? 'font-weight:700;color:inherit' : 'color:#6b7280;font-weight:400'; return dh ? '<a href="' + dh + '" target="_blank" style="' + s + ';text-decoration:none">' + esc(text) + '</a>' : '<span style="' + s + '">' + esc(text) + '</span>'; }; var line1 = dot + ' ' + link(orgName || repoName, true); var line2 = orgName ? '<div style="padding-left:18px;font-size:0.8rem">' + link(repoName, false) + ' ' + ghIcon + ' ' + roleBadge(h.role) + '</div>' : '<div style="padding-left:18px">' + ghIcon + ' ' + roleBadge(h.role) + '</div>'; return line1 + line2; })() + '</td>' +
           '<td>' + typeBadge + '</td>' +
           '<td>' + (function() { var pub = !!h.isPublic; var tid = 'vis-' + esc(h.id); if (isHosted && h.role === 'owner') { return '<label style="position:relative;display:inline-block;width:36px;height:20px;cursor:pointer"><input type="checkbox" id="' + tid + '" ' + (pub ? 'checked' : '') + ' onchange="toggleVisibility(\'' + esc(h.id) + '\',this.checked)" style="opacity:0;width:0;height:0"><span style="position:absolute;inset:0;background:' + (pub ? 'var(--green)' : 'var(--border)') + ';border-radius:10px;transition:background 0.2s"></span><span style="position:absolute;top:2px;left:' + (pub ? '18px' : '2px') + ';width:16px;height:16px;background:#fff;border-radius:50%;transition:left 0.2s"></span></label>'; } if (isLocal) { var dh = h.dashboardUrl && !h.dashboardUrl.includes('localhost') ? h.dashboardUrl : ''; var badge = pub ? '<span style="color:var(--green)">Public</span>' : '<span style="color:var(--muted)">Private</span>'; return dh ? '<a href="' + esc(dh) + '#config/governor/Hub" target="_blank" title="Change in Governor Config → Hub tab" style="text-decoration:none;cursor:pointer">' + badge + ' <span style="font-size:0.6rem;color:var(--muted)">↗</span></a>' : badge; } return pub ? '<span style="color:var(--green)">✓</span>' : '<span style="color:var(--muted)">—</span>'; })() + '</td>' +
           '<td style="font-size:0.7rem;white-space:nowrap">' + versionCell + '</td>' +
@@ -3463,10 +3460,11 @@ const dashboardHTML = `<!DOCTYPE html>
           hiveRows += '<table style="width:100%;border-collapse:collapse"><thead><tr style="color:var(--muted);font-size:0.7rem"><th style="text-align:left;padding:4px 8px">Hive</th><th>Role</th><th>Type</th><th>Link</th></tr></thead><tbody>';
           hiveIds.forEach(function(hid) {
             var role = hivesObj[hid];
-            var isHosted = hid.startsWith('hosted-') || hid.startsWith('saas-');
             var regEntry = (_hiveRegistry || []).find(function(h) { return h.id === hid; });
+            var isHosted = (regEntry && regEntry.hiveType === 'hosted') || hid.startsWith('hosted-') || hid.startsWith('saas-');
             var hiveName = regEntry ? (regEntry.name || hid) : hid;
-            var link = isHosted ? '<a href="https://' + esc(hid) + '.hive.kubestellar.io" target="_blank" class="dash-link">' + esc(hid) + '.hive.kubestellar.io</a>' : '<span style="color:var(--muted)">local</span>';
+            var dUrl = regEntry ? hiveDashUrl(regEntry) : (isHosted ? 'https://' + esc(hid) + '.hive.kubestellar.io' : '');
+            var link = dUrl ? '<a href="' + dUrl + '" target="_blank" class="dash-link">' + esc(hiveName) + '</a>' : '<span style="color:var(--muted)">local</span>';
             var typeBadge = isHosted ? '<span style="color:#60a5fa">hosted</span>' : '<span style="color:#9ca3af">local</span>';
             hiveRows += '<tr><td style="padding:4px 8px">' + esc(hiveName) + '</td><td style="text-align:center">' + esc(role) + '</td><td style="text-align:center">' + typeBadge + '</td><td>' + link + '</td></tr>';
           });

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -55,6 +55,7 @@ type RegistryEntry struct {
 	ActiveContributors int            `json:"activeContributors"`
 	Owner              string         `json:"owner,omitempty"`
 	HiveType           string         `json:"hiveType,omitempty"`
+	ClusterID          string         `json:"clusterId,omitempty"`
 	IsPublic           bool           `json:"isPublic"`
 	RegisteredAt       string         `json:"registeredAt"`
 	LastHeartbeat      string         `json:"lastHeartbeat"`
@@ -292,11 +293,15 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		ActiveContributors: clampInt(payload.Contributors.Active, 0, 10_000),
 		Owner:              sanitizeHeartbeatField(payload.Owner),
 		HiveType: func() string {
+			if payload.HiveType == "hosted" || payload.HiveType == "local" {
+				return payload.HiveType
+			}
 			if strings.HasPrefix(payload.HiveID, "hosted-") || strings.HasPrefix(payload.HiveID, "saas-") {
 				return "hosted"
 			}
 			return "local"
 		}(),
+		ClusterID: sanitizeHeartbeatField(payload.ClusterID),
 		IsPublic: payload.IsPublic,
 		LastHeartbeat:      time.Now().UTC().Format(time.RFC3339),
 		Health:             payload.Health,

--- a/v2/pkg/policies/defaults/supervisor-nogithub.md
+++ b/v2/pkg/policies/defaults/supervisor-nogithub.md
@@ -1,0 +1,21 @@
+# Supervisor Agent Policy — No-GitHub Mode (-nogithub)
+
+You are the **supervisor** agent in a Hive instance operating in **ADVISORY** mode.
+
+## Rules
+
+1. **NO GitHub interaction whatsoever** — no `gh` commands, no API calls, no reading issues or PRs
+2. **Internal orchestration only** — kick agents, monitor health, read beads, coordinate the pipeline
+3. **Never create beads that reference GitHub** — no `--external-ref "gh-*"` in any bead
+4. **Respect hold labels** — never touch issues labeled `hold`, `on-hold`, or `do-not-merge`
+5. **Always sign commits** with DCO: `git commit -s` (for local analysis only; never push)
+6. **You are the orchestrator, not a fixer** — delegate all analysis to specialist agents
+
+## Workflow
+
+1. Read the kick message for operational directives
+2. Check agent health: query bead store for recent activity per actor
+3. Kick agents that need to run (scanner, quality, guide, etc.) via internal kick mechanism
+4. Monitor agent progress via beads — do not use `gh` to cross-check
+5. Summarize pipeline health and agent status in your response
+6. Flag stale or stuck agents (no bead activity in expected window)


### PR DESCRIPTION
## Summary
- Pick first healthy endpoint from comma-separated `HIVE_VLLM_ENDPOINT` list via `/v1/models` health check instead of using the raw string as a single URL
- Dynamic model discovery with 30s periodic refresh — dropdowns auto-update without page reload
- Dismissable toasts for new model discovery notifications
- Fix Hub admin table to use `hiveDashUrl()` instead of hardcoded `.hive.kubestellar.io` URLs
- Extract all embedded kick templates at startup, not just brainstorm
- Add `supervisor-nogithub.md` kick template
- Add `hive_type` and `cluster_id` to heartbeat protocol

## Test plan
- [ ] Verify agents route to healthy Llama 8B endpoint when hive-vllm-svc is down
- [ ] Verify model dropdown auto-updates when new models come online
- [ ] Verify dismissable toasts appear and persist until clicked
- [ ] Verify Hub admin table links to correct dashboard URL
- [ ] Verify all kick templates extracted on pod startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)