### PR TITLE
fix: propagate inference errors + sync model on override

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -2849,6 +2849,14 @@ func (m *Manager) SetModelOverride(name, model string) error {
 
 	agent.ModelOverride = model
 	m.logger.Info("agent model override set", "name", name, "model", model)
+
+	effectiveBackend := agent.Config.Backend
+	if agent.BackendOverride != "" {
+		effectiveBackend = agent.BackendOverride
+	}
+	if IsInferenceBackend(effectiveBackend) && m.inferenceRouteCallback != nil {
+		m.inferenceRouteCallback(name, effectiveBackend, model)
+	}
 	return nil
 }
 
@@ -2863,6 +2871,16 @@ func (m *Manager) SetBackendOverride(name, backend string) error {
 
 	agent.BackendOverride = backend
 	m.logger.Info("agent backend override set", "name", name, "backend", backend)
+
+	if IsInferenceBackend(backend) && m.inferenceRouteCallback != nil {
+		model := agent.ModelOverride
+		if model == "" {
+			model = agent.Config.Model
+		}
+		m.inferenceRouteCallback(name, backend, model)
+	} else if !IsInferenceBackend(backend) && m.clearInferenceRouteCallback != nil {
+		m.clearInferenceRouteCallback(name)
+	}
 	return nil
 }
 

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3008,11 +3008,13 @@ func (s *Server) queryInferenceModels(backend string) []string {
 		}
 	}
 	envVar := "HIVE_VLLM_MODELS"
-	defaultModel := "qwen2.5-0.5b-instruct"
 	if backend == "llm-d" {
 		envVar = "HIVE_LLMD_MODELS"
 	}
-	return inferenceModelsFromEnv(envVar, defaultModel)
+	if val := os.Getenv(envVar); val != "" {
+		return inferenceModelsFromEnv(envVar, "")
+	}
+	return nil
 }
 
 const inferenceModelQueryTimeout = 5 * time.Second

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -895,6 +895,21 @@ func (p *GitHubProxy) StartInferenceTranslator() error {
 			"content-type", resp.Header.Get("Content-Type"),
 		)
 
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			errBody, _ := io.ReadAll(resp.Body)
+			p.logger.Error("inference upstream error",
+				"agent", agentName,
+				"status", resp.StatusCode,
+				"body", truncateBytes(errBody, 500),
+			)
+			anthropicErr := fmt.Sprintf(`{"type":"error","error":{"type":"api_error","message":"inference backend returned %d: %s"}}`,
+				resp.StatusCode, truncateBytes(errBody, 200))
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(resp.StatusCode)
+			w.Write([]byte(anthropicErr))
+			return
+		}
+
 		isStreaming := strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream")
 
 		if isStreaming {


### PR DESCRIPTION
## Summary

- **Proxy propagates upstream errors**: When vLLM returns a non-2xx (e.g. 404 "model not found"), the proxy now returns an Anthropic-format error instead of translating the error body into an empty successful response `{"content":[{"type":"text","text":""}]}`. This caused all agents to silently go idle — they received an empty response and returned to the prompt.

- **Model/backend override syncs proxy route**: `SetModelOverride` and `SetBackendOverride` now update the proxy's inference route immediately. Previously, changing the model via the dashboard only updated the agent struct — the proxy kept forwarding requests with the old model name set at launch time.

- **Remove stale hardcoded default**: The fallback model `qwen2.5-0.5b-instruct` no longer exists on vLLM (replaced by DeepSeek R1 14B). When dynamic discovery returns no models and no `HIVE_VLLM_MODELS` env var is set, return nil instead of a dead model name.

## Root cause

All 5 agents were configured with model `qwen2.5-0.5b-instruct` (the hardcoded default). vLLM now serves `/models/deepseek-r1-14b`. The proxy forwarded requests to vLLM with the wrong model, got 404, translated it to an empty Anthropic response, and Claude Code received nothing and sat idle at the `❯` prompt.

## Test plan

- [ ] Deploy to vllm-d cluster, verify agents get proper error messages instead of empty responses
- [ ] Change model via dashboard dropdown, verify proxy forwards with new model name
- [ ] Switch backend from vllm to claude and back, verify inference route is set/cleared