### PR TITLE
fix: cap max_tokens to inference model context length

### DIFF
--- a/v2/pkg/proxy/anthropic_translate.go
+++ b/v2/pkg/proxy/anthropic_translate.go
@@ -239,7 +239,7 @@ func mapFinishReason(reason string) string {
 // endpoint, translating the request and response formats. It writes the
 // translated response directly to the provided http.ResponseWriter.
 func forwardToInference(clientReq *http.Request, clientBody []byte, w http.ResponseWriter, route *InferenceRoute) error {
-	openaiBody, err := translateAnthropicToOpenAI(clientBody, route.Model)
+	openaiBody, err := translateAnthropicToOpenAI(clientBody, route.Model, route.MaxContextLen)
 	if err != nil {
 		return fmt.Errorf("translate request: %w", err)
 	}

--- a/v2/pkg/proxy/anthropic_translate.go
+++ b/v2/pkg/proxy/anthropic_translate.go
@@ -13,7 +13,8 @@ import (
 
 // translateAnthropicToOpenAI converts an Anthropic Messages API request body
 // into an OpenAI Chat Completions API request body, overriding the model.
-func translateAnthropicToOpenAI(body []byte, targetModel string) ([]byte, error) {
+// maxContextLen is the model's max context window (0 = no cap).
+func translateAnthropicToOpenAI(body []byte, targetModel string, maxContextLen int) ([]byte, error) {
 	var req anthropicRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		return nil, fmt.Errorf("unmarshal anthropic request: %w", err)
@@ -21,7 +22,7 @@ func translateAnthropicToOpenAI(body []byte, targetModel string) ([]byte, error)
 
 	openaiReq := openaiRequest{
 		Model:     targetModel,
-		MaxTokens: req.MaxTokens,
+		MaxTokens: capMaxTokens(req.MaxTokens, maxContextLen),
 		Stream:    req.Stream,
 	}
 

--- a/v2/pkg/proxy/anthropic_translate_test.go
+++ b/v2/pkg/proxy/anthropic_translate_test.go
@@ -17,7 +17,7 @@ func TestTranslateAnthropicToOpenAI_StringSystem(t *testing.T) {
 		"stream": true
 	}`
 
-	result, err := translateAnthropicToOpenAI([]byte(body), "Qwen/Qwen2.5-1.5B-Instruct")
+	result, err := translateAnthropicToOpenAI([]byte(body), "Qwen/Qwen2.5-1.5B-Instruct", 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +60,7 @@ func TestTranslateAnthropicToOpenAI_BlockSystem(t *testing.T) {
 		]
 	}`
 
-	result, err := translateAnthropicToOpenAI([]byte(body), "test-model")
+	result, err := translateAnthropicToOpenAI([]byte(body), "test-model", 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -810,9 +810,15 @@ func newBufferedReader(c net.Conn) *bufio.Reader {
 }
 
 // SetInferenceRoute configures an agent to use a self-hosted inference backend.
+// It also queries the model's max context length from the endpoint.
 func (p *GitHubProxy) SetInferenceRoute(agentName string, route *InferenceRoute) {
+	if route.MaxContextLen == 0 {
+		if maxLen := queryMaxModelLen(route.Endpoint, route.Model); maxLen > 0 {
+			route.MaxContextLen = maxLen
+		}
+	}
 	p.inference.Set(agentName, route)
-	p.logger.Info("inference route set", "agent", agentName, "backend", route.Backend, "endpoint", route.Endpoint, "model", route.Model)
+	p.logger.Info("inference route set", "agent", agentName, "backend", route.Backend, "endpoint", route.Endpoint, "model", route.Model, "maxContextLen", route.MaxContextLen)
 }
 
 // ClearInferenceRoute removes an agent's inference backend override.
@@ -858,7 +864,7 @@ func (p *GitHubProxy) StartInferenceTranslator() error {
 
 		p.logger.Info("inference request body", "agent", agentName, "len", len(body), "preview", truncateBytes(body, 200))
 
-		openaiBody, err := translateAnthropicToOpenAI(body, route.Model)
+		openaiBody, err := translateAnthropicToOpenAI(body, route.Model, route.MaxContextLen)
 		if err != nil {
 			p.logger.Error("inference translate request failed", "agent", agentName, "error", err)
 			http.Error(w, fmt.Sprintf(`{"type":"error","error":{"type":"api_error","message":"translation error: %s"}}`, err.Error()), http.StatusBadGateway)
@@ -1011,7 +1017,7 @@ func (p *GitHubProxy) handleInferenceRequest(conn net.Conn, req *http.Request, a
 		return
 	}
 
-	openaiBody, err := translateAnthropicToOpenAI(body, route.Model)
+	openaiBody, err := translateAnthropicToOpenAI(body, route.Model, route.MaxContextLen)
 	if err != nil {
 		p.logger.Error("inference translate request failed", "agent", agentName, "error", err)
 		p.writeHTTPError(conn, http.StatusBadGateway, "translation error: "+err.Error())

--- a/v2/pkg/proxy/inference_route.go
+++ b/v2/pkg/proxy/inference_route.go
@@ -1,13 +1,21 @@
 package proxy
 
-import "sync"
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
 
 // InferenceRoute defines where to send an agent's API traffic when using
 // a self-hosted inference backend instead of the cloud API.
 type InferenceRoute struct {
-	Backend  string // "vllm" or "llm-d"
-	Endpoint string // e.g. "http://vllm-svc.hive.svc.cluster.local:8000"
-	Model    string // e.g. "Qwen/Qwen2.5-1.5B-Instruct"
+	Backend       string // "vllm" or "llm-d"
+	Endpoint      string // e.g. "http://vllm-svc.hive.svc.cluster.local:8000"
+	Model         string // e.g. "Qwen/Qwen2.5-1.5B-Instruct"
+	MaxContextLen int    // from vLLM /v1/models max_model_len; 0 = unknown
 }
 
 // inferenceRouter manages per-agent inference backend routing.
@@ -64,3 +72,60 @@ func IsInferenceBackend(backend string) bool {
 	}
 	return false
 }
+
+const maxModelLenQueryTimeout = 3 * time.Second
+
+// queryMaxModelLen queries the /v1/models endpoint and returns the
+// max_model_len for the given model. Returns 0 if the query fails.
+func queryMaxModelLen(endpoint, model string) int {
+	url := strings.TrimRight(endpoint, "/") + "/v1/models"
+	client := &http.Client{Timeout: maxModelLenQueryTimeout}
+	resp, err := client.Get(url)
+	if err != nil {
+		return 0
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0
+	}
+	var result struct {
+		Data []struct {
+			ID          string `json:"id"`
+			MaxModelLen int    `json:"max_model_len"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return 0
+	}
+	for _, m := range result.Data {
+		if m.ID == model {
+			return m.MaxModelLen
+		}
+	}
+	if len(result.Data) > 0 {
+		return result.Data[0].MaxModelLen
+	}
+	return 0
+}
+
+// capMaxTokens adjusts max_tokens to fit within the model's context window.
+// It reserves space for input tokens by capping output to contextLen - inputEstimate.
+func capMaxTokens(maxTokens, maxContextLen int) int {
+	if maxContextLen <= 0 || maxTokens <= 0 {
+		return maxTokens
+	}
+	inputReserve := maxContextLen / 4
+	limit := maxContextLen - inputReserve
+	if limit < 1 {
+		limit = 1
+	}
+	if maxTokens > limit {
+		return limit
+	}
+	return maxTokens
+}
+


### PR DESCRIPTION
## Summary

- Queries `max_model_len` from vLLM `/v1/models` when setting an inference route
- Stores it on `InferenceRoute.MaxContextLen`
- Caps `max_tokens` in the Anthropic→OpenAI translation to 75% of context window (reserving 25% for input tokens)

## Root cause

Claude Code sends `max_tokens: 32000` by default. DeepSeek R1 14B has `max_model_len: 8192`. vLLM rejects with 400: "maximum context length is 8192 tokens. However, you requested 32154 tokens". With PR #1628's error propagation fix, this error is now visible to the agent instead of being silently swallowed — but the agent still can't work. This PR fixes the actual token limit mismatch.

## Test plan

- [ ] Deploy, verify agents can successfully get responses from DeepSeek R1 14B
- [ ] Verify `max_tokens` is capped to ~6144 (75% of 8192) in proxy logs