### PR TITLE
fix: skip MITM for github.com to fix copilot OAuth login

### DIFF
--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -234,8 +234,8 @@ func (p *GitHubProxy) handleTransparentTLS(conn net.Conn, peeked []byte) {
 		}
 	}
 
-	if !IsGitHubHost(host) {
-		// Non-GitHub: tunnel directly to the intended host.
+	if !IsGitHubHost(host) || !NeedsMITM(host) {
+		// Non-GitHub or non-API GitHub host: tunnel directly.
 		upstream, err := net.DialTimeout("tcp", host+":443", transparentProxyTimeout)
 		if err != nil {
 			return
@@ -445,6 +445,14 @@ func (p *GitHubProxy) handleConnectDirect(conn net.Conn, r *http.Request) {
 
 	// Non-GitHub hosts: tunnel without inspection.
 	if !IsGitHubHost(host) {
+		p.tunnelDirect(conn, r)
+		return
+	}
+
+	// github.com doesn't need MITM — OAuth device flow and git smart HTTP
+	// are handled by CLI --deny-tool flags. Only api.github.com needs
+	// request-level inspection for ACMM enforcement.
+	if !NeedsMITM(host) {
 		p.tunnelDirect(conn, r)
 		return
 	}

--- a/v2/pkg/proxy/rules.go
+++ b/v2/pkg/proxy/rules.go
@@ -36,6 +36,15 @@ func IsGitHubHost(host string) bool {
 	return githubHosts[host]
 }
 
+// NeedsMITM returns true if the host requires TLS interception for request-level
+// enforcement. Hosts like github.com are registered for awareness but only need
+// opaque tunneling — their traffic (OAuth device flow, git smart HTTP) either
+// doesn't require ACMM enforcement or is already gated by CLI --deny-tool flags.
+// Only api.github.com needs MITM for GraphQL/REST mutation inspection.
+func NeedsMITM(host string) bool {
+	return host == "api.github.com"
+}
+
 // rules defines every GitHub API operation and the minimum mode needed.
 // Order matters: more-specific patterns must come before less-specific ones
 // for the same method, because evaluation is first-match-wins.

--- a/v2/pkg/proxy/rules_test.go
+++ b/v2/pkg/proxy/rules_test.go
@@ -189,3 +189,20 @@ func TestIsGitHubHost(t *testing.T) {
 		}
 	}
 }
+
+func TestNeedsMITM(t *testing.T) {
+	tests := []struct {
+		host string
+		want bool
+	}{
+		{"api.github.com", true},
+		{"github.com", false},
+		{"example.com", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := NeedsMITM(tt.host); got != tt.want {
+			t.Errorf("NeedsMITM(%q) = %v, want %v", tt.host, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- The copilot CLI binary uses a Rust HTTP client with its own embedded TLS stack that rejects the MITM proxy's forged certificates (`invalid peer certificate: BadSignature`)
- This causes `TypeError: fetch failed` when agents try to `/login` via GitHub device flow — all agents in the console hive were unable to re-authenticate after pod restart
- Added `NeedsMITM()` helper: only `api.github.com` gets MITM'd (where ACMM enforcement matters — merge blocks, PR/issue creation, GraphQL mutations)
- `github.com` traffic (OAuth device flow, git smart HTTP) is now tunneled opaquely without TLS interception
- Git push enforcement on `github.com` is already handled by `--deny-tool` CLI flags on the copilot binary

## Test plan
- [x] `go build ./cmd/hive/` passes
- [x] `go test ./pkg/proxy/` passes (all existing + new `TestNeedsMITM`)
- [x] Manually verified on live console hive pod: `NO_PROXY=github.com` unblocked `/login` for scanner agent
- [ ] After deploy: verify all agents can `/login` without `NO_PROXY` workaround
- [ ] Verify ACMM enforcement still blocks unauthorized merges on `api.github.com`