### PR TITLE
fix: dynamic max_tokens cap based on actual input size

### DIFF
--- a/v2/pkg/proxy/anthropic_translate.go
+++ b/v2/pkg/proxy/anthropic_translate.go
@@ -21,14 +21,16 @@ func translateAnthropicToOpenAI(body []byte, targetModel string, maxContextLen i
 	}
 
 	openaiReq := openaiRequest{
-		Model:     targetModel,
-		MaxTokens: capMaxTokens(req.MaxTokens, maxContextLen),
-		Stream:    req.Stream,
+		Model:  targetModel,
+		Stream: req.Stream,
 	}
+
+	var totalChars int
 
 	if len(req.System) > 0 {
 		systemText := extractSystemText(req.System)
 		if systemText != "" {
+			totalChars += len(systemText)
 			openaiReq.Messages = append(openaiReq.Messages, openaiMessage{
 				Role:    "system",
 				Content: systemText,
@@ -38,11 +40,14 @@ func translateAnthropicToOpenAI(body []byte, targetModel string, maxContextLen i
 
 	for _, msg := range req.Messages {
 		text := extractTextFromContent(msg.Content)
+		totalChars += len(text)
 		openaiReq.Messages = append(openaiReq.Messages, openaiMessage{
 			Role:    msg.Role,
 			Content: text,
 		})
 	}
+
+	openaiReq.MaxTokens = capMaxTokensForInput(req.MaxTokens, maxContextLen, totalChars)
 
 	return json.Marshal(openaiReq)
 }

--- a/v2/pkg/proxy/inference_route.go
+++ b/v2/pkg/proxy/inference_route.go
@@ -112,19 +112,28 @@ func queryMaxModelLen(endpoint, model string) int {
 	return 0
 }
 
-// capMaxTokens adjusts max_tokens to fit within the model's context window.
-// It reserves space for input tokens by capping output to contextLen - inputEstimate.
-func capMaxTokens(maxTokens, maxContextLen int) int {
+// charsPerToken is a conservative estimate for tokenization overhead.
+// Most LLM tokenizers average ~3-4 chars/token; we use 3 to overestimate
+// input token count and avoid hitting the context ceiling.
+const charsPerToken = 3
+
+// safetyMarginTokens is subtracted from the available output budget to
+// account for tokenizer variance and special tokens.
+const safetyMarginTokens = 128
+
+// capMaxTokensForInput adjusts max_tokens based on estimated input size.
+// totalInputChars is the total character count of all messages + system prompt.
+func capMaxTokensForInput(maxTokens, maxContextLen, totalInputChars int) int {
 	if maxContextLen <= 0 || maxTokens <= 0 {
 		return maxTokens
 	}
-	inputReserve := maxContextLen / 4
-	limit := maxContextLen - inputReserve
-	if limit < 1 {
-		limit = 1
+	estimatedInputTokens := totalInputChars / charsPerToken
+	available := maxContextLen - estimatedInputTokens - safetyMarginTokens
+	if available < 1 {
+		available = 1
 	}
-	if maxTokens > limit {
-		return limit
+	if maxTokens > available {
+		return available
 	}
 	return maxTokens
 }


### PR DESCRIPTION
## Summary

Replaces the static 75/25 context split with input-aware capping. Estimates input tokens from actual message character count (~3 chars/token) and sets `max_tokens = contextLen - estimatedInput - 128`.

## Root cause

Quality agent hit 400: "maximum context length is 8192 tokens. However, you requested 8192 tokens (2048 in the messages, 6144 in the completion)." The static cap set max_tokens to 6144 (75% of 8192), but with 2048 input tokens that's exactly 8192 — the ceiling. Each request needs a different cap based on its actual input size.

## Test plan

- [ ] Kick quality agent, verify it completes without 400 errors
- [ ] Verify small requests still get reasonable max_tokens (not over-capped)