### PR TITLE
fix: force copilot Node.js path for MITM proxy compatibility

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -81,6 +81,10 @@ RUN ARCH=$(uname -m) && \
 ARG COPILOT_VERSION=1.0.59
 RUN npm install -g @github/copilot@${COPILOT_VERSION} && npm cache clean --force || \
     echo "WARN: GitHub Copilot CLI install failed — skipping"
+# Remove the native Rust binary so copilot falls back to the Node.js path.
+# The Rust binary embeds its own TLS stack (rustls + webpki-roots) which rejects
+# the MITM proxy's forged certificates. The Node.js path respects NODE_EXTRA_CA_CERTS.
+RUN rm -f /usr/local/lib/node_modules/@github/copilot/node_modules/@github/copilot-linux-*/copilot 2>/dev/null; true
 
 # --- Layer 7: Claude Code (most frequent updates) ---
 ARG CLAUDE_CODE_VERSION=latest

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -464,15 +464,15 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	case "copilot":
 		switch {
 		case mode >= ModeIssuesAndPRs:
-			launchCmd = fmt.Sprintf("%s --model %s --allow-all --enable-all-github-mcp-tools",
+			launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all --enable-all-github-mcp-tools",
 				binary, model)
 		case mode == ModeIssuesOnly:
-			launchCmd = fmt.Sprintf("%s --model %s --allow-all --enable-all-github-mcp-tools"+
+			launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all --enable-all-github-mcp-tools"+
 				" --deny-tool='github(create_pull_request)'"+
 				" --deny-tool='github(merge_pull_request)'",
 				binary, model)
 		default:
-			launchCmd = fmt.Sprintf("%s --model %s --allow-all"+
+			launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all"+
 				" --deny-tool='github(create_pull_request)'"+
 				" --deny-tool='github(create_issue)'"+
 				" --deny-tool='github(update_issue)'"+


### PR DESCRIPTION
## Summary
- Remove copilot native Rust binary from Docker image — it embeds rustls which rejects MITM-forged certs
- Add `--no-auto-update` to all copilot launch commands — auto-update from 1.0.59→1.0.63 re-downloaded the native binary and broke all agent authentication today
- Node.js fallback path respects `NODE_EXTRA_CA_CERTS` and works with the ACMM MITM proxy

## Root cause
Copilot auto-updated itself from 1.0.59 to 1.0.63 today. The cached 1.0.63 native binary replaced the working Node.js path, causing `TypeError: fetch failed` / `invalid peer certificate: BadSignature` for all agents trying to `/login` or validate tokens.

## Test plan
- [x] `go build ./cmd/hive/` passes
- [x] `go test ./pkg/proxy/` and `go test ./pkg/agent/` pass
- [x] Manually verified on live console hive pod: renamed native binary → copilot fell back to Node.js → `/login` succeeded through MITM proxy → device code `122D-C2D6` generated and authorized
- [ ] After deploy: verify all agents authenticate and ACMM enforcement works on `api.github.com`