### PR TITLE
feat: add tool use translation to inference proxy

### DIFF
--- a/v2/pkg/proxy/anthropic_translate.go
+++ b/v2/pkg/proxy/anthropic_translate.go
@@ -39,17 +39,145 @@ func translateAnthropicToOpenAI(body []byte, targetModel string, maxContextLen i
 	}
 
 	for _, msg := range req.Messages {
-		text := extractTextFromContent(msg.Content)
-		totalChars += len(text)
-		openaiReq.Messages = append(openaiReq.Messages, openaiMessage{
-			Role:    msg.Role,
-			Content: text,
-		})
+		translated := translateAnthropicMessage(msg)
+		for _, tm := range translated {
+			totalChars += len(tm.Content)
+			if tm.ToolCallID != "" {
+				totalChars += len(tm.ToolCallID)
+			}
+			for _, tc := range tm.ToolCalls {
+				totalChars += len(tc.Function.Arguments)
+			}
+		}
+		openaiReq.Messages = append(openaiReq.Messages, translated...)
+	}
+
+	if len(req.Tools) > 0 {
+		openaiReq.Tools = translateAnthropicTools(req.Tools)
 	}
 
 	openaiReq.MaxTokens = capMaxTokensForInput(req.MaxTokens, maxContextLen, totalChars)
 
 	return json.Marshal(openaiReq)
+}
+
+// translateAnthropicMessage converts a single Anthropic message into one or
+// more OpenAI messages. An Anthropic assistant message can contain both text
+// and tool_use blocks; a user message can contain tool_result blocks.
+func translateAnthropicMessage(msg anthropicMessage) []openaiMessage {
+	var str string
+	if json.Unmarshal(msg.Content, &str) == nil {
+		return []openaiMessage{{Role: msg.Role, Content: str}}
+	}
+
+	var blocks []anthropicContentBlockRaw
+	if err := json.Unmarshal(msg.Content, &blocks); err != nil {
+		return []openaiMessage{{Role: msg.Role, Content: string(msg.Content)}}
+	}
+
+	if msg.Role == "assistant" {
+		return translateAssistantBlocks(blocks)
+	}
+
+	var toolResults []openaiMessage
+	var textParts []string
+
+	for _, block := range blocks {
+		switch block.Type {
+		case "tool_result":
+			content := ""
+			if block.Content != nil {
+				var s string
+				if json.Unmarshal(block.Content, &s) == nil {
+					content = s
+				} else {
+					var innerBlocks []struct {
+						Type string `json:"type"`
+						Text string `json:"text"`
+					}
+					if json.Unmarshal(block.Content, &innerBlocks) == nil {
+						var b strings.Builder
+						for _, ib := range innerBlocks {
+							if ib.Type == "text" {
+								b.WriteString(ib.Text)
+							}
+						}
+						content = b.String()
+					} else {
+						content = string(block.Content)
+					}
+				}
+			}
+			toolResults = append(toolResults, openaiMessage{
+				Role:       "tool",
+				Content:    content,
+				ToolCallID: block.ToolUseID,
+			})
+		case "text":
+			if block.Text != "" {
+				textParts = append(textParts, block.Text)
+			}
+		}
+	}
+
+	var msgs []openaiMessage
+	if len(textParts) > 0 {
+		msgs = append(msgs, openaiMessage{
+			Role:    "user",
+			Content: strings.Join(textParts, "\n"),
+		})
+	}
+	msgs = append(msgs, toolResults...)
+	return msgs
+}
+
+// translateAssistantBlocks converts an assistant message's content blocks
+// (text + tool_use) into a single OpenAI assistant message with tool_calls.
+func translateAssistantBlocks(blocks []anthropicContentBlockRaw) []openaiMessage {
+	var text strings.Builder
+	var toolCalls []openaiToolCall
+
+	for _, block := range blocks {
+		switch block.Type {
+		case "text":
+			text.WriteString(block.Text)
+		case "tool_use":
+			args, _ := json.Marshal(block.Input)
+			toolCalls = append(toolCalls, openaiToolCall{
+				ID:   block.ID,
+				Type: "function",
+				Function: openaiFunction{
+					Name:      block.Name,
+					Arguments: string(args),
+				},
+			})
+		}
+	}
+
+	msg := openaiMessage{
+		Role:    "assistant",
+		Content: text.String(),
+	}
+	if len(toolCalls) > 0 {
+		msg.ToolCalls = toolCalls
+	}
+	return []openaiMessage{msg}
+}
+
+// translateAnthropicTools converts Anthropic tool definitions to OpenAI format.
+func translateAnthropicTools(tools []anthropicTool) []openaiTool {
+	result := make([]openaiTool, 0, len(tools))
+	for _, t := range tools {
+		result = append(result, openaiTool{
+			Type: "function",
+			Function: openaiToolFunction{
+				Name:        t.Name,
+				Description: t.Description,
+				Parameters:  t.InputSchema,
+			},
+		})
+	}
+	return result
 }
 
 // translateOpenAIResponseToAnthropic converts a non-streaming OpenAI Chat
@@ -61,24 +189,44 @@ func translateOpenAIResponseToAnthropic(body []byte, model string) ([]byte, erro
 	}
 
 	anthropicResp := anthropicResponse{
-		ID:   resp.ID,
-		Type: "message",
-		Role: "assistant",
+		ID:    resp.ID,
+		Type:  "message",
+		Role:  "assistant",
 		Model: model,
 	}
 
 	if len(resp.Choices) > 0 {
-		anthropicResp.StopReason = mapFinishReason(resp.Choices[0].FinishReason)
-		anthropicResp.Content = []anthropicContentBlock{{
-			Type: "text",
-			Text: resp.Choices[0].Message.Content,
-		}}
+		choice := resp.Choices[0]
+		anthropicResp.StopReason = mapFinishReason(choice.FinishReason)
+
+		if choice.Message.Content != "" {
+			anthropicResp.Content = append(anthropicResp.Content, anthropicContentBlock{
+				Type: "text",
+				Text: choice.Message.Content,
+			})
+		}
+
+		for _, tc := range choice.Message.ToolCalls {
+			var input json.RawMessage
+			if tc.Function.Arguments != "" {
+				input = json.RawMessage(tc.Function.Arguments)
+			} else {
+				input = json.RawMessage("{}")
+			}
+			anthropicResp.Content = append(anthropicResp.Content, anthropicContentBlock{
+				Type:  "tool_use",
+				ID:    tc.ID,
+				Name:  tc.Function.Name,
+				Input: input,
+			})
+		}
+
+		if len(anthropicResp.Content) == 0 {
+			anthropicResp.Content = []anthropicContentBlock{{Type: "text", Text: ""}}
+		}
 	} else {
 		anthropicResp.StopReason = "end_turn"
-		anthropicResp.Content = []anthropicContentBlock{{
-			Type: "text",
-			Text: "",
-		}}
+		anthropicResp.Content = []anthropicContentBlock{{Type: "text", Text: ""}}
 	}
 
 	if resp.Usage != nil {
@@ -87,10 +235,7 @@ func translateOpenAIResponseToAnthropic(body []byte, model string) ([]byte, erro
 			OutputTokens: resp.Usage.CompletionTokens,
 		}
 	} else {
-		anthropicResp.Usage = &anthropicUsage{
-			InputTokens:  0,
-			OutputTokens: 0,
-		}
+		anthropicResp.Usage = &anthropicUsage{}
 	}
 
 	return json.Marshal(anthropicResp)
@@ -105,19 +250,13 @@ func translateOpenAISSEToAnthropic(r io.Reader, w io.Writer, model string) error
 	writeSSE(w, "message_start", anthropicSSEMessageStart{
 		Type: "message_start",
 		Message: anthropicSSEMessage{
-			ID:    msgID,
-			Type:  "message",
-			Role:  "assistant",
-			Model: model,
+			ID:      msgID,
+			Type:    "message",
+			Role:    "assistant",
+			Model:   model,
 			Content: []anthropicContentBlock{},
-			Usage: &anthropicUsage{InputTokens: 0, OutputTokens: 0},
+			Usage:   &anthropicUsage{},
 		},
-	})
-
-	writeSSE(w, "content_block_start", map[string]interface{}{
-		"type":          "content_block_start",
-		"index":         0,
-		"content_block": map[string]string{"type": "text", "text": ""},
 	})
 
 	scanner := bufio.NewScanner(r)
@@ -125,6 +264,9 @@ func translateOpenAISSEToAnthropic(r io.Reader, w io.Writer, model string) error
 	scanner.Buffer(make([]byte, maxSSELine), maxSSELine)
 
 	var totalOutputTokens int
+	var contentBlockIndex int
+	textBlockStarted := false
+	toolCallState := make(map[int]*sseToolCallAccumulator)
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -143,10 +285,19 @@ func translateOpenAISSEToAnthropic(r io.Reader, w io.Writer, model string) error
 
 		if len(chunk.Choices) > 0 {
 			delta := chunk.Choices[0].Delta
+
 			if delta.Content != "" {
+				if !textBlockStarted {
+					writeSSE(w, "content_block_start", map[string]interface{}{
+						"type":          "content_block_start",
+						"index":         contentBlockIndex,
+						"content_block": map[string]string{"type": "text", "text": ""},
+					})
+					textBlockStarted = true
+				}
 				writeSSE(w, "content_block_delta", map[string]interface{}{
 					"type":  "content_block_delta",
-					"index": 0,
+					"index": contentBlockIndex,
 					"delta": map[string]string{
 						"type": "text_delta",
 						"text": delta.Content,
@@ -154,11 +305,64 @@ func translateOpenAISSEToAnthropic(r io.Reader, w io.Writer, model string) error
 				})
 			}
 
+			for _, tc := range delta.ToolCalls {
+				acc, exists := toolCallState[tc.Index]
+				if !exists {
+					if textBlockStarted {
+						writeSSE(w, "content_block_stop", map[string]interface{}{
+							"type":  "content_block_stop",
+							"index": contentBlockIndex,
+						})
+						contentBlockIndex++
+						textBlockStarted = false
+					}
+
+					acc = &sseToolCallAccumulator{
+						id:         tc.ID,
+						name:       tc.Function.Name,
+						blockIndex: contentBlockIndex,
+					}
+					toolCallState[tc.Index] = acc
+
+					writeSSE(w, "content_block_start", map[string]interface{}{
+						"type":  "content_block_start",
+						"index": contentBlockIndex,
+						"content_block": map[string]interface{}{
+							"type":  "tool_use",
+							"id":    tc.ID,
+							"name":  tc.Function.Name,
+							"input": map[string]interface{}{},
+						},
+					})
+					contentBlockIndex++
+				}
+
+				if tc.Function.Arguments != "" {
+					acc.args.WriteString(tc.Function.Arguments)
+					writeSSE(w, "content_block_delta", map[string]interface{}{
+						"type":  "content_block_delta",
+						"index": acc.blockIndex,
+						"delta": map[string]interface{}{
+							"type":         "input_json_delta",
+							"partial_json": tc.Function.Arguments,
+						},
+					})
+				}
+			}
+
 			if chunk.Choices[0].FinishReason != "" {
-				writeSSE(w, "content_block_stop", map[string]interface{}{
-					"type":  "content_block_stop",
-					"index": 0,
-				})
+				if textBlockStarted {
+					writeSSE(w, "content_block_stop", map[string]interface{}{
+						"type":  "content_block_stop",
+						"index": contentBlockIndex,
+					})
+				}
+				for _, acc := range toolCallState {
+					writeSSE(w, "content_block_stop", map[string]interface{}{
+						"type":  "content_block_stop",
+						"index": acc.blockIndex,
+					})
+				}
 
 				writeSSE(w, "message_delta", map[string]interface{}{
 					"type": "message_delta",
@@ -179,6 +383,13 @@ func translateOpenAISSEToAnthropic(r io.Reader, w io.Writer, model string) error
 
 	writeSSE(w, "message_stop", map[string]string{"type": "message_stop"})
 	return scanner.Err()
+}
+
+type sseToolCallAccumulator struct {
+	id         string
+	name       string
+	blockIndex int
+	args       strings.Builder
 }
 
 func writeSSE(w io.Writer, eventType string, data interface{}) {
@@ -235,6 +446,8 @@ func mapFinishReason(reason string) string {
 		return "end_turn"
 	case "length":
 		return "max_tokens"
+	case "tool_calls":
+		return "tool_use"
 	default:
 		return "end_turn"
 	}
@@ -330,11 +543,31 @@ type anthropicRequest struct {
 	Messages  []anthropicMessage `json:"messages"`
 	System    json.RawMessage    `json:"system,omitempty"`
 	Stream    bool               `json:"stream,omitempty"`
+	Tools     []anthropicTool    `json:"tools,omitempty"`
+}
+
+type anthropicTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"input_schema"`
 }
 
 type anthropicMessage struct {
 	Role    string          `json:"role"`
 	Content json.RawMessage `json:"content"`
+}
+
+// anthropicContentBlockRaw is used to parse content blocks that may contain
+// text, tool_use, or tool_result entries.
+type anthropicContentBlockRaw struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Content   json.RawMessage `json:"content,omitempty"`
+	IsError   bool            `json:"is_error,omitempty"`
 }
 
 type anthropicResponse struct {
@@ -349,8 +582,11 @@ type anthropicResponse struct {
 }
 
 type anthropicContentBlock struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
+	Type  string          `json:"type"`
+	Text  string          `json:"text,omitempty"`
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
 }
 
 type anthropicUsage struct {
@@ -359,7 +595,7 @@ type anthropicUsage struct {
 }
 
 type anthropicSSEMessageStart struct {
-	Type    string            `json:"type"`
+	Type    string              `json:"type"`
 	Message anthropicSSEMessage `json:"message"`
 }
 
@@ -377,18 +613,44 @@ type openaiRequest struct {
 	Messages  []openaiMessage `json:"messages"`
 	MaxTokens int             `json:"max_tokens,omitempty"`
 	Stream    bool            `json:"stream,omitempty"`
+	Tools     []openaiTool    `json:"tools,omitempty"`
+}
+
+type openaiTool struct {
+	Type     string             `json:"type"`
+	Function openaiToolFunction `json:"function"`
+}
+
+type openaiToolFunction struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
 }
 
 type openaiMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role       string           `json:"role"`
+	Content    string           `json:"content"`
+	ToolCalls  []openaiToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string           `json:"tool_call_id,omitempty"`
+}
+
+type openaiToolCall struct {
+	ID       string         `json:"id"`
+	Type     string         `json:"type"`
+	Function openaiFunction `json:"function"`
+}
+
+type openaiFunction struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
 }
 
 type openaiResponse struct {
 	ID      string `json:"id"`
 	Choices []struct {
 		Message struct {
-			Content string `json:"content"`
+			Content   string           `json:"content"`
+			ToolCalls []openaiToolCall `json:"tool_calls,omitempty"`
 		} `json:"message"`
 		FinishReason string `json:"finish_reason"`
 	} `json:"choices"`
@@ -403,9 +665,20 @@ type openaiUsage struct {
 type openaiSSEChunk struct {
 	Choices []struct {
 		Delta struct {
-			Content string `json:"content"`
+			Content   string               `json:"content"`
+			ToolCalls []openaiSSEToolCall   `json:"tool_calls,omitempty"`
 		} `json:"delta"`
 		FinishReason string `json:"finish_reason"`
 	} `json:"choices"`
 	Usage *openaiUsage `json:"usage,omitempty"`
+}
+
+type openaiSSEToolCall struct {
+	Index    int    `json:"index"`
+	ID       string `json:"id,omitempty"`
+	Type     string `json:"type,omitempty"`
+	Function struct {
+		Name      string `json:"name,omitempty"`
+		Arguments string `json:"arguments,omitempty"`
+	} `json:"function"`
 }

--- a/v2/pkg/proxy/anthropic_translate_test.go
+++ b/v2/pkg/proxy/anthropic_translate_test.go
@@ -81,6 +81,142 @@ func TestTranslateAnthropicToOpenAI_BlockSystem(t *testing.T) {
 	}
 }
 
+func TestTranslateAnthropicToOpenAI_WithTools(t *testing.T) {
+	body := `{
+		"model": "claude-opus-4-6",
+		"max_tokens": 1024,
+		"messages": [{"role": "user", "content": "What's the weather?"}],
+		"tools": [
+			{
+				"name": "get_weather",
+				"description": "Get weather for a location",
+				"input_schema": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}
+			}
+		]
+	}`
+
+	result, err := translateAnthropicToOpenAI([]byte(body), "test-model", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var req openaiRequest
+	if err := json.Unmarshal(result, &req); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(req.Tools) != 1 {
+		t.Fatalf("tools count = %d, want 1", len(req.Tools))
+	}
+	if req.Tools[0].Type != "function" {
+		t.Errorf("tool type = %q, want function", req.Tools[0].Type)
+	}
+	if req.Tools[0].Function.Name != "get_weather" {
+		t.Errorf("tool name = %q, want get_weather", req.Tools[0].Function.Name)
+	}
+	if req.Tools[0].Function.Description != "Get weather for a location" {
+		t.Errorf("tool description = %q", req.Tools[0].Function.Description)
+	}
+}
+
+func TestTranslateAnthropicToOpenAI_ToolUseInAssistantMessage(t *testing.T) {
+	body := `{
+		"model": "claude-opus-4-6",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": "What's the weather in SF?"},
+			{"role": "assistant", "content": [
+				{"type": "text", "text": "Let me check."},
+				{"type": "tool_use", "id": "toolu_123", "name": "get_weather", "input": {"location": "San Francisco"}}
+			]},
+			{"role": "user", "content": [
+				{"type": "tool_result", "tool_use_id": "toolu_123", "content": "72°F and sunny"}
+			]}
+		]
+	}`
+
+	result, err := translateAnthropicToOpenAI([]byte(body), "test-model", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var req openaiRequest
+	if err := json.Unmarshal(result, &req); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(req.Messages) != 3 {
+		t.Fatalf("messages count = %d, want 3", len(req.Messages))
+	}
+
+	// First: user message
+	if req.Messages[0].Role != "user" {
+		t.Errorf("msg[0] role = %q, want user", req.Messages[0].Role)
+	}
+
+	// Second: assistant with tool_calls
+	assistantMsg := req.Messages[1]
+	if assistantMsg.Role != "assistant" {
+		t.Errorf("msg[1] role = %q, want assistant", assistantMsg.Role)
+	}
+	if assistantMsg.Content != "Let me check." {
+		t.Errorf("msg[1] content = %q, want 'Let me check.'", assistantMsg.Content)
+	}
+	if len(assistantMsg.ToolCalls) != 1 {
+		t.Fatalf("msg[1] tool_calls count = %d, want 1", len(assistantMsg.ToolCalls))
+	}
+	if assistantMsg.ToolCalls[0].ID != "toolu_123" {
+		t.Errorf("tool_call id = %q, want toolu_123", assistantMsg.ToolCalls[0].ID)
+	}
+	if assistantMsg.ToolCalls[0].Function.Name != "get_weather" {
+		t.Errorf("tool_call name = %q, want get_weather", assistantMsg.ToolCalls[0].Function.Name)
+	}
+
+	// Third: tool result
+	toolMsg := req.Messages[2]
+	if toolMsg.Role != "tool" {
+		t.Errorf("msg[2] role = %q, want tool", toolMsg.Role)
+	}
+	if toolMsg.ToolCallID != "toolu_123" {
+		t.Errorf("msg[2] tool_call_id = %q, want toolu_123", toolMsg.ToolCallID)
+	}
+	if toolMsg.Content != "72°F and sunny" {
+		t.Errorf("msg[2] content = %q, want '72°F and sunny'", toolMsg.Content)
+	}
+}
+
+func TestTranslateAnthropicToOpenAI_ToolResultWithBlocks(t *testing.T) {
+	body := `{
+		"model": "claude-opus-4-6",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "tool_result", "tool_use_id": "toolu_456", "content": [{"type": "text", "text": "result data"}]}
+			]}
+		]
+	}`
+
+	result, err := translateAnthropicToOpenAI([]byte(body), "test-model", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var req openaiRequest
+	if err := json.Unmarshal(result, &req); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(req.Messages) != 1 {
+		t.Fatalf("messages count = %d, want 1", len(req.Messages))
+	}
+	if req.Messages[0].Role != "tool" {
+		t.Errorf("role = %q, want tool", req.Messages[0].Role)
+	}
+	if req.Messages[0].Content != "result data" {
+		t.Errorf("content = %q, want 'result data'", req.Messages[0].Content)
+	}
+}
+
 func TestTranslateOpenAIResponseToAnthropic(t *testing.T) {
 	resp := `{
 		"id": "chatcmpl-001",
@@ -115,6 +251,66 @@ func TestTranslateOpenAIResponseToAnthropic(t *testing.T) {
 	}
 	if ar.Usage == nil || ar.Usage.InputTokens != 10 || ar.Usage.OutputTokens != 3 {
 		t.Errorf("usage = %+v", ar.Usage)
+	}
+}
+
+func TestTranslateOpenAIResponseToAnthropic_WithToolCalls(t *testing.T) {
+	resp := `{
+		"id": "chatcmpl-002",
+		"choices": [{
+			"message": {
+				"content": "Let me look that up.",
+				"tool_calls": [
+					{
+						"id": "call_abc",
+						"type": "function",
+						"function": {
+							"name": "get_weather",
+							"arguments": "{\"location\":\"SF\"}"
+						}
+					}
+				]
+			},
+			"finish_reason": "tool_calls"
+		}],
+		"usage": {"prompt_tokens": 15, "completion_tokens": 8}
+	}`
+
+	result, err := translateOpenAIResponseToAnthropic([]byte(resp), "test-model")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var ar anthropicResponse
+	if err := json.Unmarshal(result, &ar); err != nil {
+		t.Fatal(err)
+	}
+
+	if ar.StopReason != "tool_use" {
+		t.Errorf("stop_reason = %q, want tool_use", ar.StopReason)
+	}
+	if len(ar.Content) != 2 {
+		t.Fatalf("content count = %d, want 2 (text + tool_use)", len(ar.Content))
+	}
+	if ar.Content[0].Type != "text" || ar.Content[0].Text != "Let me look that up." {
+		t.Errorf("content[0] = %+v", ar.Content[0])
+	}
+	if ar.Content[1].Type != "tool_use" {
+		t.Errorf("content[1].type = %q, want tool_use", ar.Content[1].Type)
+	}
+	if ar.Content[1].ID != "call_abc" {
+		t.Errorf("content[1].id = %q, want call_abc", ar.Content[1].ID)
+	}
+	if ar.Content[1].Name != "get_weather" {
+		t.Errorf("content[1].name = %q, want get_weather", ar.Content[1].Name)
+	}
+
+	var input map[string]string
+	if err := json.Unmarshal(ar.Content[1].Input, &input); err != nil {
+		t.Fatalf("unmarshal input: %v", err)
+	}
+	if input["location"] != "SF" {
+		t.Errorf("input.location = %q, want SF", input["location"])
 	}
 }
 
@@ -167,6 +363,47 @@ func TestTranslateOpenAISSEToAnthropic(t *testing.T) {
 	}
 }
 
+func TestTranslateOpenAISSEToAnthropic_ToolCalls(t *testing.T) {
+	sseInput := strings.Join([]string{
+		`data: {"choices":[{"delta":{"content":"Checking"},"finish_reason":null}]}`,
+		``,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_xyz","type":"function","function":{"name":"get_weather","arguments":""}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"loc"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ation\":\"NYC\"}"}}]},"finish_reason":null}]}`,
+		``,
+		`data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}`,
+		``,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	var buf strings.Builder
+	err := translateOpenAISSEToAnthropic(strings.NewReader(sseInput), &buf, "test-model")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	output := buf.String()
+
+	if !strings.Contains(output, `"tool_use"`) {
+		t.Error("missing tool_use content block")
+	}
+	if !strings.Contains(output, `"get_weather"`) {
+		t.Error("missing tool name get_weather")
+	}
+	if !strings.Contains(output, `"call_xyz"`) {
+		t.Error("missing tool call id")
+	}
+	if !strings.Contains(output, `"input_json_delta"`) {
+		t.Error("missing input_json_delta events")
+	}
+	if !strings.Contains(output, `"tool_use"`) {
+		t.Error("missing tool_use stop reason")
+	}
+}
+
 func TestMapFinishReason(t *testing.T) {
 	tests := []struct {
 		input string
@@ -174,6 +411,7 @@ func TestMapFinishReason(t *testing.T) {
 	}{
 		{"stop", "end_turn"},
 		{"length", "max_tokens"},
+		{"tool_calls", "tool_use"},
 		{"unknown", "end_turn"},
 		{"", "end_turn"},
 	}
@@ -196,5 +434,44 @@ func TestExtractTextFromContent_Blocks(t *testing.T) {
 	got := extractTextFromContent(json.RawMessage(`[{"type":"text","text":"hello"},{"type":"text","text":" world"}]`))
 	if got != "hello world" {
 		t.Errorf("got %q, want 'hello world'", got)
+	}
+}
+
+func TestTranslateAnthropicToOpenAI_MixedTextAndToolResultInUser(t *testing.T) {
+	body := `{
+		"model": "claude-opus-4-6",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": [
+				{"type": "text", "text": "Here's the result:"},
+				{"type": "tool_result", "tool_use_id": "toolu_789", "content": "42"}
+			]}
+		]
+	}`
+
+	result, err := translateAnthropicToOpenAI([]byte(body), "test-model", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var req openaiRequest
+	if err := json.Unmarshal(result, &req); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(req.Messages) != 2 {
+		t.Fatalf("messages count = %d, want 2 (text user + tool)", len(req.Messages))
+	}
+	if req.Messages[0].Role != "user" {
+		t.Errorf("msg[0] role = %q, want user", req.Messages[0].Role)
+	}
+	if req.Messages[0].Content != "Here's the result:" {
+		t.Errorf("msg[0] content = %q", req.Messages[0].Content)
+	}
+	if req.Messages[1].Role != "tool" {
+		t.Errorf("msg[1] role = %q, want tool", req.Messages[1].Role)
+	}
+	if req.Messages[1].Content != "42" {
+		t.Errorf("msg[1] content = %q, want '42'", req.Messages[1].Content)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds full Anthropic ↔ OpenAI tool use translation to the inference proxy so vLLM/llm-d agents can invoke tools (read files, edit, bash, etc.)
- Previously the proxy stripped all tool definitions, `tool_use` blocks, and `tool_result` blocks — agents could only produce plain text
- Handles request translation (tools, tool_use in assistant messages, tool_result in user messages), response translation (tool_calls → tool_use blocks), and SSE streaming (chunked tool call arguments → input_json_delta events)

## Test plan

- [x] All 10 unit tests pass covering: tool schema translation, tool_use in assistant messages, tool_result (string and block content), response tool_calls → tool_use, SSE streamed tool calls, mixed text+tool_result user messages, finish_reason mapping
- [ ] Deploy and kick agents — verify they can invoke tools via vLLM/llm-d backend