### PR TITLE
fix: route inference to endpoint that serves the requested model

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -932,13 +932,17 @@ func main() {
 			"vllm":  vllmEndpoints,
 			"llm-d": llmdEndpoints,
 		})
-		vllmEndpoint := vllmEndpoints[0]
-		llmdEndpoint := llmdEndpoints[0]
 		agentMgr.SetInferenceCallbacks(
 			func(agentName, backend, model string) {
-				endpoint := vllmEndpoint
+				endpoints := vllmEndpoints
 				if backend == "llm-d" {
-					endpoint = llmdEndpoint
+					endpoints = llmdEndpoints
+				}
+				endpoint := proxy.FindEndpointForModel(endpoints, model)
+				if endpoint == "" {
+					logger.Warn("no endpoint serves model, using first endpoint",
+						"agent", agentName, "model", model, "backend", backend)
+					endpoint = endpoints[0]
 				}
 				githubProxy.SetInferenceRoute(agentName, &proxy.InferenceRoute{
 					Backend:  backend,

--- a/v2/pkg/proxy/inference_route.go
+++ b/v2/pkg/proxy/inference_route.go
@@ -73,6 +73,40 @@ func IsInferenceBackend(backend string) bool {
 	return false
 }
 
+// FindEndpointForModel queries /v1/models on each endpoint and returns the
+// first one that serves the requested model. Returns "" if none match.
+func FindEndpointForModel(endpoints []string, model string) string {
+	client := &http.Client{Timeout: endpointQueryTimeout}
+	for _, ep := range endpoints {
+		url := strings.TrimRight(ep, "/") + "/v1/models"
+		resp, err := client.Get(url)
+		if err != nil {
+			continue
+		}
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK || err != nil {
+			continue
+		}
+		var result struct {
+			Data []struct {
+				ID string `json:"id"`
+			} `json:"data"`
+		}
+		if json.Unmarshal(body, &result) != nil {
+			continue
+		}
+		for _, m := range result.Data {
+			if m.ID == model {
+				return ep
+			}
+		}
+	}
+	return ""
+}
+
+const endpointQueryTimeout = 3 * time.Second
+
 const maxModelLenQueryTimeout = 3 * time.Second
 
 // queryMaxModelLen queries the /v1/models endpoint and returns the


### PR DESCRIPTION
## Summary

- When multiple vLLM instances serve different models, the proxy always routed to the first endpoint regardless of which model was requested
- Added `FindEndpointForModel` that queries `/v1/models` on each configured endpoint to find which one serves the requested model
- Falls back to first endpoint with a warning if no match is found

## Test plan

- [x] All proxy tests pass
- [x] Builds clean
- [ ] Deploy, set agent to Qwen model, verify it routes to `hive-vllm-qwen-svc` instead of `hive-vllm-svc`