### PR TITLE
fix: filter merge-eligible by CI status, add file-overlap detection for scanner

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1301,6 +1301,9 @@ func runEvalCycle(
 		logger.Error("failed to enumerate actionable items", "error", err)
 		return
 	}
+
+	ghClient.EnrichCIStatus(ctx, actionable.PRs.Items)
+
 	lastActionable.Store(actionable)
 	if data, err := json.Marshal(actionable); err == nil {
 		atomicWrite("/data/last-actionable.json", data)
@@ -1826,6 +1829,7 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 }
 
 const mergeEligiblePath = "/var/run/hive-metrics/merge-eligible.json"
+const ciFailingPath = "/var/run/hive-metrics/ci-failing.json"
 
 func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldResult, org string, logger *slog.Logger) {
 	holdSet := make(map[string]bool)
@@ -1844,7 +1848,16 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 		DCO       string   `json:"dco"`
 	}
 
+	type failingPR struct {
+		Number  int    `json:"number"`
+		Repo    string `json:"repo"`
+		Title   string `json:"title"`
+		Author  string `json:"author"`
+		HeadSHA string `json:"head_sha,omitempty"`
+	}
+
 	var eligible []eligiblePR
+	var failing []failingPR
 	for _, pr := range actionable.PRs.Items {
 		if pr.Draft {
 			continue
@@ -1857,6 +1870,18 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 		if !strings.Contains(fullRepo, "/") && org != "" {
 			fullRepo = org + "/" + fullRepo
 		}
+
+		if pr.CIStatus == "failure" {
+			failing = append(failing, failingPR{
+				Number:  pr.Number,
+				Repo:    fullRepo,
+				Title:   pr.Title,
+				Author:  pr.Author,
+				HeadSHA: pr.HeadSHA,
+			})
+			continue
+		}
+
 		dco := "unknown"
 		for _, l := range pr.Labels {
 			if l == "dco-signoff: yes" {
@@ -1876,6 +1901,8 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 		})
 	}
 
+	_ = os.MkdirAll("/var/run/hive-metrics", 0o755)
+
 	payload := map[string]any{
 		"generated_at":   time.Now().UTC().Format(time.RFC3339),
 		"merge_eligible": eligible,
@@ -1885,9 +1912,19 @@ func writeMergeEligible(actionable *github.ActionableResult, hold github.HoldRes
 		logger.Warn("failed to marshal merge-eligible", "error", err)
 		return
 	}
-	_ = os.MkdirAll("/var/run/hive-metrics", 0o755)
 	atomicWrite(mergeEligiblePath, data)
-	logger.Info("merge-eligible.json updated", "eligible", len(eligible), "total_prs", len(actionable.PRs.Items))
+	logger.Info("merge-eligible.json updated", "eligible", len(eligible), "ci_failing", len(failing), "total_prs", len(actionable.PRs.Items))
+
+	failPayload := map[string]any{
+		"generated_at": time.Now().UTC().Format(time.RFC3339),
+		"ci_failing":   failing,
+	}
+	failData, err := json.Marshal(failPayload)
+	if err != nil {
+		logger.Warn("failed to marshal ci-failing", "error", err)
+		return
+	}
+	atomicWrite(ciFailingPath, failData)
 }
 
 func atomicWrite(path string, data []byte) {

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -49,6 +49,8 @@ type PullRequest struct {
 	CreatedAt time.Time `json:"created_at"`
 	URL       string    `json:"url"`
 	Mergeable bool      `json:"mergeable"`
+	CIStatus  string    `json:"ci_status"`
+	HeadSHA   string    `json:"head_sha,omitempty"`
 }
 
 type ActionableResult struct {
@@ -330,6 +332,11 @@ func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRe
 			continue
 		}
 
+		headSHA := ""
+		if pr.GetHead() != nil {
+			headSHA = pr.GetHead().GetSHA()
+		}
+
 		actionable = append(actionable, PullRequest{
 			Repo:      repo,
 			Number:    pr.GetNumber(),
@@ -340,10 +347,59 @@ func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRe
 			CreatedAt: pr.GetCreatedAt().Time,
 			URL:       pr.GetHTMLURL(),
 			Mergeable: pr.GetMergeable(),
+			HeadSHA:   headSHA,
 		})
 	}
 
 	return actionable, held, totalPRs, nil
+}
+
+// EnrichCIStatus fetches check-run results for each PR's HEAD commit
+// and sets the CIStatus field to "success", "failure", or "pending".
+func (c *Client) EnrichCIStatus(ctx context.Context, prs []PullRequest) {
+	const ciStatusSuccess = "success"
+	const ciStatusFailure = "failure"
+	const ciStatusPending = "pending"
+
+	for i := range prs {
+		if prs[i].HeadSHA == "" {
+			prs[i].CIStatus = ciStatusPending
+			continue
+		}
+		owner, repoName := c.splitRepo(prs[i].Repo)
+		checkRuns, _, err := c.client.Checks.ListCheckRunsForRef(ctx, owner, repoName, prs[i].HeadSHA, &gh.ListCheckRunsOptions{
+			ListOptions: gh.ListOptions{PerPage: 100},
+		})
+		if err != nil {
+			c.logger.Warn("failed to fetch check runs", "repo", prs[i].Repo, "pr", prs[i].Number, "error", err)
+			prs[i].CIStatus = ciStatusPending
+			continue
+		}
+		if checkRuns.GetTotal() == 0 {
+			prs[i].CIStatus = ciStatusPending
+			continue
+		}
+		hasFail := false
+		allDone := true
+		for _, cr := range checkRuns.CheckRuns {
+			if cr.GetStatus() != "completed" {
+				allDone = false
+				continue
+			}
+			conclusion := cr.GetConclusion()
+			if conclusion == "failure" || conclusion == "action_required" {
+				hasFail = true
+			}
+		}
+		switch {
+		case hasFail:
+			prs[i].CIStatus = ciStatusFailure
+		case allDone:
+			prs[i].CIStatus = ciStatusSuccess
+		default:
+			prs[i].CIStatus = ciStatusPending
+		}
+	}
 }
 
 func extractLabels(labels []*gh.Label) []string {

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -252,12 +252,20 @@ func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (a
 		ListOptions: gh.ListOptions{PerPage: 100},
 	}
 
-	issues, _, err := c.client.Issues.ListByRepo(ctx, owner, repoName, opts)
-	if err != nil {
-		return nil, nil, 0, fmt.Errorf("listing issues for %s/%s: %w", owner, repoName, err)
+	var allIssues []*gh.Issue
+	for {
+		issues, resp, err := c.client.Issues.ListByRepo(ctx, owner, repoName, opts)
+		if err != nil {
+			return nil, nil, 0, fmt.Errorf("listing issues for %s/%s: %w", owner, repoName, err)
+		}
+		allIssues = append(allIssues, issues...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.ListOptions.Page = resp.NextPage
 	}
 
-	for _, issue := range issues {
+	for _, issue := range allIssues {
 		if issue.IsPullRequest() {
 			continue
 		}
@@ -305,12 +313,20 @@ func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRe
 		ListOptions: gh.ListOptions{PerPage: 100},
 	}
 
-	prs, _, err := c.client.PullRequests.List(ctx, owner, repoName, opts)
-	if err != nil {
-		return nil, nil, 0, fmt.Errorf("listing PRs for %s/%s: %w", owner, repoName, err)
+	var allPRs []*gh.PullRequest
+	for {
+		prs, resp, err := c.client.PullRequests.List(ctx, owner, repoName, opts)
+		if err != nil {
+			return nil, nil, 0, fmt.Errorf("listing PRs for %s/%s: %w", owner, repoName, err)
+		}
+		allPRs = append(allPRs, prs...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.ListOptions.Page = resp.NextPage
 	}
 
-	for _, pr := range prs {
+	for _, pr := range allPRs {
 		totalPRs++
 		labels := extractPRLabels(pr.Labels)
 

--- a/v2/pkg/policies/defaults/scanner-automerge.md
+++ b/v2/pkg/policies/defaults/scanner-automerge.md
@@ -105,14 +105,53 @@ For PRs in the PR_LIST that have merge conflicts:
 
 Skip any PR with hold labels or `do-not-merge`.
 
+## CI Repair — Fix Failing PRs
+
+The CI_FAILING list below contains PRs with failed `build-gate` checks. These PRs are **excluded from merge-eligible** until CI passes. Your job is to fix them.
+
+For each PR in CI_FAILING:
+1. **Read the CI log** — use MCP `list_workflow_runs_for_repo` to find the failed run, then `download_workflow_run_logs` to get the log
+2. **Identify the error** — lint errors, type errors, build failures, import issues
+3. **Fix it** — push a fixup commit to the PR branch using MCP `create_or_update_file` or by checking out the branch in a worktree, fixing, and pushing
+4. **Move on** — do NOT wait for CI to re-run. The next kick cycle will check again.
+
+If a PR has failed CI **3 or more times** (check commit count on the PR), close it as unfixable and reopen the linked issue.
+
+**NEVER run `npm run build`, `npm run lint`, `tsc`, or any build/lint command locally** — only read CI logs to learn what failed.
+
+## File-Overlap Detection — Prevent Cascading Conflicts
+
+Before dispatching new fix agents, check for file overlaps between:
+- PRs in the CI_FAILING list
+- PRs in the MERGE-ELIGIBLE list
+- Issues you are about to dispatch agents for
+
+Use MCP `list_pull_request_files` on each open PR to get its changed files. Then:
+1. **Build a file map** — map each changed file to the list of PRs that touch it
+2. **Identify overlapping groups** — PRs that share one or more changed files
+3. **For overlapping PRs**: merge them **sequentially** in order of PR number (oldest first). After each merge, the next PR in the group will likely have conflicts — update its branch first.
+4. **For new issues**: if an issue would touch files already modified by an open PR, do NOT dispatch a separate agent. Instead, either:
+   - Add the fix to the existing PR (push to its branch), OR
+   - Wait for the existing PR to merge before dispatching
+
+This prevents the cyclical failure pattern where 5 PRs touch the same files, each merge invalidates the others, and all of them fail CI in a loop.
+
 ## Workflow
 
-1. **Merge sweep** — process MERGE-ELIGIBLE list (5 min cap)
-2. **Group + dispatch fixes** — group related issues, launch one background agent per group using the Agent tool with `run_in_background: true`
-3. **Final merge sweep** — re-check MERGE-ELIGIBLE plus any new PRs from sub-agents
-4. **Beads + summary** — create beads, report PRs opened/merged/pending
+1. **CI repair** — fix PRs in CI_FAILING list first (they're blocking the pipeline)
+2. **File-overlap scan** — build a file map across all open PRs
+3. **Merge sweep** — process MERGE-ELIGIBLE list, respecting overlap ordering (sequential for overlapping groups)
+4. **Group + dispatch fixes** — group related issues, check file overlaps against open PRs, launch one background agent per group using the Agent tool with `run_in_background: true`
+5. **Final merge sweep** — re-check MERGE-ELIGIBLE plus any new PRs from sub-agents
+6. **Beads + summary** — create beads, report PRs opened/merged/pending
 
-## Work List
+## Work Lists
+
+CI-FAILING PRs (fix these first — they are NOT merge-eligible until CI passes):
+${CI_FAILING}
+
+MERGE-ELIGIBLE PRs (CI passing, ready to merge):
+${MERGE_ELIGIBLE}
 
 ACTIONABLE ISSUES:
 ${ISSUE_LIST}

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -161,6 +161,7 @@ func (s *Scheduler) substituteTemplate(template string, actionable *github.Actio
 	inceptionIdea, inceptionPhase, inceptionMode, inceptionAnswers, inceptionSlug, inceptionRepoURL := s.inceptionVars()
 
 	mergeEligibleList := s.buildMergeEligibleList()
+	ciFailingList := s.buildCIFailingList()
 
 	replacer := strings.NewReplacer(
 		"${AGENT_NAME}", agentName,
@@ -193,6 +194,7 @@ func (s *Scheduler) substituteTemplate(template string, actionable *github.Actio
 		"${INCEPTION_SLUG}", inceptionSlug,
 		"${INCEPTION_REPO_URL}", inceptionRepoURL,
 		"${MERGE_ELIGIBLE}", mergeEligibleList,
+		"${CI_FAILING}", ciFailingList,
 	)
 	return replacer.Replace(template)
 }
@@ -472,6 +474,7 @@ func (s *Scheduler) buildSupervisorMessage(actionable *github.ActionableResult) 
 }
 
 const mergeEligiblePath = "/var/run/hive-metrics/merge-eligible.json"
+const ciFailingPath = "/var/run/hive-metrics/ci-failing.json"
 
 func (s *Scheduler) buildMergeEligibleList() string {
 	data, err := os.ReadFile(mergeEligiblePath)
@@ -491,6 +494,30 @@ func (s *Scheduler) buildMergeEligibleList() string {
 	var b strings.Builder
 	for _, pr := range payload.Items {
 		b.WriteString(fmt.Sprintf("  #%d %s — %s\n", pr.Number, pr.Repo, pr.Title))
+	}
+	return b.String()
+}
+
+func (s *Scheduler) buildCIFailingList() string {
+	data, err := os.ReadFile(ciFailingPath)
+	if err != nil {
+		return "(none)\n"
+	}
+	var payload struct {
+		Items []struct {
+			Number  int    `json:"number"`
+			Repo    string `json:"repo"`
+			Title   string `json:"title"`
+			Author  string `json:"author"`
+			HeadSHA string `json:"head_sha"`
+		} `json:"ci_failing"`
+	}
+	if json.Unmarshal(data, &payload) != nil || len(payload.Items) == 0 {
+		return "(none)\n"
+	}
+	var b strings.Builder
+	for _, pr := range payload.Items {
+		b.WriteString(fmt.Sprintf("  #%d %s by @%s (sha:%s) — %s\n", pr.Number, pr.Repo, pr.Author, pr.HeadSHA, pr.Title))
 	}
 	return b.String()
 }

--- a/v2/policies/scanner-automerge.md
+++ b/v2/policies/scanner-automerge.md
@@ -105,14 +105,53 @@ For PRs in the PR_LIST that have merge conflicts:
 
 Skip any PR with hold labels or `do-not-merge`.
 
+## CI Repair — Fix Failing PRs
+
+The CI_FAILING list below contains PRs with failed `build-gate` checks. These PRs are **excluded from merge-eligible** until CI passes. Your job is to fix them.
+
+For each PR in CI_FAILING:
+1. **Read the CI log** — use MCP `list_workflow_runs_for_repo` to find the failed run, then `download_workflow_run_logs` to get the log
+2. **Identify the error** — lint errors, type errors, build failures, import issues
+3. **Fix it** — push a fixup commit to the PR branch using MCP `create_or_update_file` or by checking out the branch in a worktree, fixing, and pushing
+4. **Move on** — do NOT wait for CI to re-run. The next kick cycle will check again.
+
+If a PR has failed CI **3 or more times** (check commit count on the PR), close it as unfixable and reopen the linked issue.
+
+**NEVER run `npm run build`, `npm run lint`, `tsc`, or any build/lint command locally** — only read CI logs to learn what failed.
+
+## File-Overlap Detection — Prevent Cascading Conflicts
+
+Before dispatching new fix agents, check for file overlaps between:
+- PRs in the CI_FAILING list
+- PRs in the MERGE-ELIGIBLE list
+- Issues you are about to dispatch agents for
+
+Use MCP `list_pull_request_files` on each open PR to get its changed files. Then:
+1. **Build a file map** — map each changed file to the list of PRs that touch it
+2. **Identify overlapping groups** — PRs that share one or more changed files
+3. **For overlapping PRs**: merge them **sequentially** in order of PR number (oldest first). After each merge, the next PR in the group will likely have conflicts — update its branch first.
+4. **For new issues**: if an issue would touch files already modified by an open PR, do NOT dispatch a separate agent. Instead, either:
+   - Add the fix to the existing PR (push to its branch), OR
+   - Wait for the existing PR to merge before dispatching
+
+This prevents the cyclical failure pattern where 5 PRs touch the same files, each merge invalidates the others, and all of them fail CI in a loop.
+
 ## Workflow
 
-1. **Merge sweep** — process MERGE-ELIGIBLE list (5 min cap)
-2. **Group + dispatch fixes** — group related issues, launch one background agent per group using the Agent tool with `run_in_background: true`
-3. **Final merge sweep** — re-check MERGE-ELIGIBLE plus any new PRs from sub-agents
-4. **Beads + summary** — create beads, report PRs opened/merged/pending
+1. **CI repair** — fix PRs in CI_FAILING list first (they're blocking the pipeline)
+2. **File-overlap scan** — build a file map across all open PRs
+3. **Merge sweep** — process MERGE-ELIGIBLE list, respecting overlap ordering (sequential for overlapping groups)
+4. **Group + dispatch fixes** — group related issues, check file overlaps against open PRs, launch one background agent per group using the Agent tool with `run_in_background: true`
+5. **Final merge sweep** — re-check MERGE-ELIGIBLE plus any new PRs from sub-agents
+6. **Beads + summary** — create beads, report PRs opened/merged/pending
 
-## Work List
+## Work Lists
+
+CI-FAILING PRs (fix these first — they are NOT merge-eligible until CI passes):
+${CI_FAILING}
+
+MERGE-ELIGIBLE PRs (CI passing, ready to merge):
+${MERGE_ELIGIBLE}
 
 ACTIONABLE ISSUES:
 ${ISSUE_LIST}


### PR DESCRIPTION
## Summary

- **CI-failing PRs no longer appear in merge-eligible** — `writeMergeEligible()` now checks `CIStatus` field and routes failing PRs to a separate `ci-failing.json`
- **New `${CI_FAILING}` template variable** — scanner template now receives a list of PRs with failed CI checks, with SHA and author, so it can read CI logs and push fixup commits
- **File-overlap detection** — scanner template now includes instructions to build a file map across all open PRs, merge overlapping PRs sequentially (oldest first), and avoid dispatching new agents that would conflict with existing PRs
- **Workflow reordered** — CI repair runs first (unblocks the pipeline), then overlap scan, then merge sweep, then dispatch

### Problem
Scanner was wasting cycles trying to merge PRs with failing CI. Multiple PRs touching the same files caused cascading merge conflicts — each merge invalidated others, creating a cyclical failure loop.

### Fix
1. `EnrichCIStatus()` fetches check-run results for each PR's HEAD commit
2. `writeMergeEligible()` filters out CI-failing PRs and writes them to `ci-failing.json`
3. `buildCIFailingList()` in scheduler formats the failing PR list for template substitution
4. Scanner template uses the list to fix CI failures before attempting merges
5. Scanner detects file overlaps via MCP `list_pull_request_files` and sequences merges accordingly

## Test plan
- [ ] Verify hive binary compiles cleanly
- [ ] Verify merge-eligible.json excludes PRs with failing check runs
- [ ] Verify ci-failing.json is populated with failing PRs
- [ ] Verify scanner template substitution includes CI_FAILING list
- [ ] Verify scanner prioritizes CI repair before merge sweeps