### PR TITLE
feat: include Go toolchain in runtime image

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -112,6 +112,10 @@ RUN cd /opt/hive/proxy && npm install --omit=dev 2>/dev/null || true
 # are invalidated on every commit.
 ARG GIT_HASH=unknown
 
+# Go toolchain for agents that run `go test`, `go build`, etc.
+COPY --from=builder /usr/local/go /usr/local/go
+ENV PATH="/usr/local/go/bin:${PATH}"
+
 COPY --from=builder /hive /usr/local/bin/hive
 COPY --from=builder /bd /usr/local/bin/bd
 


### PR DESCRIPTION
## Summary
- Copy Go toolchain from builder stage into runtime image
- Agents (quality, etc.) can now run `go test`, `go build`, `go vet` at runtime
- Adds ~500MB to image size but enables test coverage analysis

## Test plan
- [ ] Docker image builds successfully
- [ ] Quality agent can run `go test -coverprofile=coverage.out ./...`