### PR TITLE
fix: GHE-aware GitHub App install URL and sign-in flow

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -314,6 +314,9 @@ type GitHubConfig struct {
 	KeyFile              string `yaml:"key_file"`
 	Token                string `yaml:"token"`
 	OAuthClientID        string `yaml:"oauth_client_id"`
+	// AppSlug is the GitHub App URL slug for the install link.
+	// For public GitHub: "kubestellar-hive". For GHE: your app's slug.
+	AppSlug string `yaml:"app_slug"`
 	// APIURL is the GitHub API base URL. Defaults to DefaultGitHubAPIURL.
 	// For GitHub Enterprise, set to e.g. "https://github.ibm.com/api/v3".
 	APIURL string `yaml:"api_url"`
@@ -327,6 +330,8 @@ const (
 	DefaultGitHubAPIURL = "https://api.github.com"
 	// DefaultGitHubBaseURL is the default GitHub web URL (public github.com).
 	DefaultGitHubBaseURL = "https://github.com"
+	// DefaultGitHubAppSlug is the public Hive GitHub App slug.
+	DefaultGitHubAppSlug = "kubestellar-hive"
 )
 
 // ResolvedAPIURL returns the configured API URL or the default for github.com.
@@ -343,6 +348,31 @@ func (g GitHubConfig) ResolvedBaseURL() string {
 		return g.BaseURL
 	}
 	return DefaultGitHubBaseURL
+}
+
+// IsGHE returns true if the configured base URL points to a GitHub Enterprise instance.
+func (g GitHubConfig) IsGHE() bool {
+	return g.BaseURL != "" && g.BaseURL != DefaultGitHubBaseURL
+}
+
+// ResolvedAppSlug returns the configured app slug or the default public Hive app slug.
+func (g GitHubConfig) ResolvedAppSlug() string {
+	if g.AppSlug != "" {
+		return g.AppSlug
+	}
+	return DefaultGitHubAppSlug
+}
+
+// AppInstallURL returns the full URL to install the GitHub App.
+// For GHE: {base_url}/github-apps/{slug}/installations/new
+// For github.com: https://github.com/apps/{slug}/installations/new
+func (g GitHubConfig) AppInstallURL() string {
+	base := strings.TrimRight(g.ResolvedBaseURL(), "/")
+	slug := g.ResolvedAppSlug()
+	if g.IsGHE() {
+		return base + "/github-apps/" + slug + "/installations/new"
+	}
+	return base + "/apps/" + slug + "/installations/new"
 }
 
 type NotificationsConfig struct {

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -101,6 +101,7 @@ type StatusPayload struct {
 	SystemResources     *SystemResources    `json:"systemResources,omitempty"`
 	GitHubAppRequired   bool               `json:"githubAppRequired,omitempty"`
 	GitHubAppInstallURL string             `json:"githubAppInstallURL,omitempty"`
+	GitHubBaseURL       string             `json:"githubBaseURL,omitempty"`
 	InferenceBackends   []InferenceBackend `json:"inferenceBackends,omitempty"`
 }
 
@@ -426,6 +427,7 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 	if s.deps != nil && s.deps.Config != nil {
 		status.ACMMLevel = detectACMMLevel(s.deps.Config)
 		status.ACMMPackAgents = buildACMMPackAgents(s.deps.Config)
+		status.GitHubBaseURL = s.deps.Config.GitHub.ResolvedBaseURL()
 	}
 	status.ContributorPool = s.BuildContributorPoolStatus()
 
@@ -453,14 +455,14 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 	s.broadcastFrame(fmt.Sprintf("data: %s\n\n", data))
 }
 
-const GitHubAppInstallURL = "https://github.com/apps/kubestellar-hive/installations/new"
-
 func (s *Server) SetGitHubAppRequired(required bool) {
 	s.githubAppMu.Lock()
 	defer s.githubAppMu.Unlock()
 	s.githubAppRequired = required
-	if required {
-		s.githubAppInstallURL = GitHubAppInstallURL
+	if required && s.deps != nil && s.deps.Config != nil {
+		s.githubAppInstallURL = s.deps.Config.GitHub.AppInstallURL()
+	} else if required {
+		s.githubAppInstallURL = "https://github.com/apps/kubestellar-hive/installations/new"
 	} else {
 		s.githubAppInstallURL = ""
 	}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1691,7 +1691,7 @@
   <div class="gh-setup-modal">
     <h3>GitHub App Setup Required</h3>
     <p>Hive needs a GitHub App to authenticate. Choose an option:</p>
-    <div class="setup-option" onclick="showSetupDetails('public')">
+    <div id="setup-option-public" class="setup-option" onclick="showSetupDetails('public')">
       <h4>Use the public Hive App (quickest)</h4>
       <p>Dashboard login only. Agents can read repos but cannot create issues, PRs, or merge.</p>
     </div>
@@ -1714,7 +1714,7 @@
       <div class="setup-steps">
         <strong>Create a GitHub App:</strong>
         <ol>
-          <li>Go to <a href="https://github.com/settings/apps/new" target="_blank" rel="noopener" style="color:#238636">github.com/settings/apps/new</a> (or your org's Settings &rarr; Developer settings &rarr; GitHub Apps)</li>
+          <li>Go to <a id="setup-custom-apps-link" href="https://github.com/settings/apps/new" target="_blank" rel="noopener" style="color:#238636">github.com/settings/apps/new</a> (or your org's Settings &rarr; Developer settings &rarr; GitHub Apps)</li>
           <li>Set the app name (e.g. <code>my-hive</code>)</li>
           <li>Homepage URL: any URL (e.g. <code>https://github.com/kubestellar/hive</code>)</li>
           <li>Uncheck "Webhook &rarr; Active" (not needed)</li>
@@ -3460,6 +3460,13 @@
       if (data.githubAppRequired && data.githubAppInstallURL) {
         var link = document.getElementById('gh-app-install-link');
         if (link) link.href = data.githubAppInstallURL;
+        var isGHE = data.githubBaseURL && data.githubBaseURL !== 'https://github.com';
+        var title = document.querySelector('#gh-app-install-banner .gh-app-title');
+        var desc = document.querySelector('#gh-app-install-banner .gh-app-desc');
+        if (title) title.textContent = isGHE ? 'GitHub App Not Installed on ' + data.githubBaseURL.replace('https://', '') : 'GitHub App Not Installed';
+        if (desc) desc.textContent = isGHE
+          ? 'This hive cannot post advisory reports. Install the GitHub App on your GHE org to enable full functionality.'
+          : 'This hive cannot create issues or advisory reports. Install the Hive Hub GitHub App on your repository to enable full functionality.';
         banner.removeAttribute('hidden');
         banner.style.cssText = 'display:flex !important';
       } else {
@@ -10728,9 +10735,15 @@ function burnAreaChart() {
         const data = await resp.json();
         if (data.error) {
           if (data.error.includes('oauth_client_id')) {
+            var ghBase = window._lastStatus && window._lastStatus.githubBaseURL || 'https://github.com';
+            var isGHE = ghBase !== 'https://github.com';
+            var publicOption = document.getElementById('setup-option-public');
+            if (publicOption) publicOption.style.display = isGHE ? 'none' : '';
+            var customLink = document.getElementById('setup-custom-apps-link');
+            if (customLink) { customLink.href = ghBase + '/settings/apps/new'; customLink.textContent = ghBase.replace('https://', '') + '/settings/apps/new'; }
             document.getElementById('gh-setup-overlay').style.display = 'flex';
             document.getElementById('setup-details-public').style.display = 'none';
-            document.getElementById('setup-details-custom').style.display = 'none';
+            document.getElementById('setup-details-custom').style.display = isGHE ? 'block' : 'none';
           } else {
             showToast('Login error: ' + data.error, 'error');
           }


### PR DESCRIPTION
## Summary
- Install banner and setup modal were hardcoded to github.com URLs — wrong for GHE hives
- Add `app_slug` config field and `AppInstallURL()` helper that builds the correct URL from `base_url`
- Send `githubBaseURL` in the status payload so the frontend adapts dynamically
- For GHE: hide the "public Hive App" option, auto-show the custom app setup with correct GHE link
- Banner text adapts for GHE (shows hostname, adjusted description)
- Updated vllm-d configmap with `oauth_client_id` and `app_slug` for the GHE app

## Test plan
- [ ] Verify GHE hive shows install banner with `github.ibm.com` hostname
- [ ] Verify install link points to `https://github.ibm.com/github-apps/kubestellar-hive-ghe/installations/new`
- [ ] Verify Sign in flow triggers device flow against GHE (not github.com)
- [ ] Verify public GitHub hives still show the default github.com URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)