### PR TITLE
fix: clean up registry on hive delete when saas entry already removed

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1513,7 +1513,11 @@ func (s *HubServer) handleDeleteHive(w http.ResponseWriter, r *http.Request) {
 
 	h := loadSaaSHive(id)
 	if h == nil {
-		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
+		// SaaS entry already gone — still clean up the in-memory registry
+		// so the hive disappears from the listing immediately.
+		s.removeRegistryEntry(id, username)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"deleted"}`))
 		return
 	}
 	if h.Owner != username && username != hubAdminUsername {
@@ -1529,6 +1533,7 @@ func (s *HubServer) handleDeleteHive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	deprovisionHive(h, cluster, s.logger)
+	s.removeRegistryEntry(id, username)
 
 	s.logger.Info("audit: hosted hive deleted", "hive_id", id, "by", username)
 	w.Header().Set("Content-Type", "application/json")

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -630,6 +630,21 @@ func (s *HubServer) handleStats(w http.ResponseWriter, r *http.Request) {
 	w.Write(data)
 }
 
+// removeRegistryEntry removes a hive from the in-memory registry by ID.
+func (s *HubServer) removeRegistryEntry(id, by string) {
+	s.mu.Lock()
+	for i, h := range s.registry.Hives {
+		if h.ID == id {
+			s.registry.Hives = append(s.registry.Hives[:i], s.registry.Hives[i+1:]...)
+			s.mu.Unlock()
+			s.requestSave()
+			s.logger.Info("audit: registry entry removed", "id", id, "by", by)
+			return
+		}
+	}
+	s.mu.Unlock()
+}
+
 func (s *HubServer) handleRegistryDelete(w http.ResponseWriter, r *http.Request) {
 	cookie, err := r.Cookie("hive_hub_user")
 	if err != nil || cookie.Value != hubAdminUsername {


### PR DESCRIPTION
## Summary
- When deleting a hosted hive whose saas entry was already gone, the handler returned "hive not found" but left the in-memory registry entry — hive stayed visible in Hub listing
- Now `handleDeleteHive` removes the registry entry in both cases: saas entry missing (stale) and successful full deprovision
- Extracted `removeRegistryEntry()` helper for reuse

## Context
Follow-up to #1647. After deleting a hive's K8s resources and saas record, the in-memory registry entry (populated via heartbeats) persisted until the 24h stale timeout. Users clicking "Delete" again saw "hive not found" but the listing didn't update.

## Test plan
- [ ] Delete a hosted hive whose saas entry is already gone — verify it disappears from listing
- [ ] Delete a fully provisioned hive — verify both saas and registry entries are cleaned up
- [ ] Verify registry entries still auto-prune after 24h heartbeat timeout