### PR TITLE
fix: read DASHBOARD_AUTH_TOKEN from OS env vars

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -604,6 +604,19 @@ func (c *Config) applyBootstrapEnv() {
 			}
 		}
 	}
+	// K8s deployments pass the auth token as an OS env var from a Secret.
+	// applyConfigEnv only reads file-based config.env, so without this
+	// the token is silently ignored and the dashboard is unauthenticated.
+	if c.Dashboard.AuthToken == "" {
+		if v := os.Getenv("DASHBOARD_AUTH_TOKEN"); v != "" {
+			c.Dashboard.AuthToken = v
+		}
+	}
+	if c.Dashboard.AuthToken == "" {
+		if v := os.Getenv("HIVE_DASHBOARD_TOKEN"); v != "" {
+			c.Dashboard.AuthToken = v
+		}
+	}
 }
 
 func expandEnvVars(s string) string {


### PR DESCRIPTION
## Summary
- `applyConfigEnv()` reads `DASHBOARD_AUTH_TOKEN` from a file-based `config.env`, but K8s deployments inject the token as a container env var from a Secret
- `applyBootstrapEnv()` (which reads `os.Getenv()`) never checked for the token
- Hosted hives on vllm-d (and any other cluster using K8s Secrets) silently ran without auth protection — the dashboard was wide open
- Fix: check `DASHBOARD_AUTH_TOKEN` and `HIVE_DASHBOARD_TOKEN` in `applyBootstrapEnv()` as fallback when config.env doesn't set them

## Test plan
- [ ] Deploy to vllm-d osscar hive, verify `https://jjs-world.apps.fmaas-vllm-d.fmaas.res.ibm.com` returns 401 without auth
- [ ] Verify snapshot/contribute/health endpoints remain public
- [ ] Verify GitHub OAuth flow still works for authenticated access