### PR TITLE
fix: stack toast notifications instead of overlapping

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3199,6 +3199,12 @@ const dashboardHTML = `<!DOCTYPE html>
       var t = document.createElement('div');
       t.className = 'hive-toast ' + (type || 'info');
       t.textContent = msg;
+      var toastBaseTop = 70;
+      var toastGap = 8;
+      var existing = document.querySelectorAll('.hive-toast');
+      var offset = 0;
+      existing.forEach(function(e) { offset += e.offsetHeight + toastGap; });
+      t.style.top = (toastBaseTop + offset) + 'px';
       document.body.appendChild(t);
       setTimeout(function() { t.remove(); }, 4000);
     }


### PR DESCRIPTION
## Summary
- Multiple simultaneous toasts all rendered at the same fixed position (`top: 70px`), overlapping each other
- Now each new toast calculates offset below existing toasts using their actual heights

## Test plan
- [ ] Trigger multiple toasts (e.g. delete + another action) and verify they stack vertically