### PR TITLE
fix: persist browser session after device flow login

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1252,11 +1252,31 @@ func (s *Server) handleGHUserAuthPoll(w http.ResponseWriter, r *http.Request) {
 		s.deps.SetUserClient(token)
 	}
 
+	if s.authToken != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     sessionCookieName,
+			Value:    s.authToken,
+			Path:     "/",
+			MaxAge:   sessionCookieMaxAge,
+			HttpOnly: true,
+			Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
+			SameSite: http.SameSiteStrictMode,
+		})
+	}
+
 	jsonResponse(w, map[string]interface{}{"status": "complete", "username": username, "avatar_url": avatarURL})
 }
 
 func (s *Server) handleGHUserAuthLogout(w http.ResponseWriter, r *http.Request) {
 	os.Remove(userTokenPath)
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+	})
 	s.deps.Logger.Info("GitHub user logged out")
 	jsonResponse(w, map[string]interface{}{"status": "logged_out"})
 }

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -25,6 +25,8 @@ func secureCompare(a, b string) bool {
 
 const agentSkipAfterFullBroadcastS = 5 * time.Second
 const maxSSEClients = 100
+const sessionCookieName = "hive_session"
+const sessionCookieMaxAge = 30 * 24 * 60 * 60 // 30 days
 
 type Server struct {
 	port       int
@@ -387,6 +389,11 @@ func (s *Server) securityHeaders(next http.Handler) http.Handler {
 				token := r.Header.Get("Authorization")
 				if token == "" {
 					token = r.URL.Query().Get("token")
+				}
+				if token == "" {
+					if c, err := r.Cookie(sessionCookieName); err == nil {
+						token = c.Value
+					}
 				}
 				expected := "Bearer " + s.authToken
 				if !secureCompare(token, expected) && !secureCompare(token, s.authToken) {


### PR DESCRIPTION
## Summary
- After completing the GitHub Device Flow, the login page reloads but the browser has no credentials — landing the user back on the login page
- Sets an `HttpOnly; Secure; SameSite=Strict` session cookie (`hive_session`) with the dashboard auth token on successful device flow completion
- Auth middleware now checks this cookie alongside existing `Authorization` header and `?token=` query param methods
- Cookie is cleared on logout via `/api/gh-user-auth/logout`

## Test plan
- [ ] Open a vllm-d hive (e.g. jjs-world) in incognito — see login page
- [ ] Complete device flow — should land on dashboard, not loop back to login
- [ ] Refresh the page — should stay authenticated (cookie persists)
- [ ] Verify hive-oke spokes still work (nginx auth path unaffected)