### PR TITLE
fix: use SameSite=Lax for session cookie

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1260,7 +1260,7 @@ func (s *Server) handleGHUserAuthPoll(w http.ResponseWriter, r *http.Request) {
 			MaxAge:   sessionCookieMaxAge,
 			HttpOnly: true,
 			Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
-			SameSite: http.SameSiteStrictMode,
+			SameSite: http.SameSiteLaxMode,
 		})
 	}
 
@@ -1275,7 +1275,7 @@ func (s *Server) handleGHUserAuthLogout(w http.ResponseWriter, r *http.Request) 
 		Path:     "/",
 		MaxAge:   -1,
 		HttpOnly: true,
-		SameSite: http.SameSiteStrictMode,
+		SameSite: http.SameSiteLaxMode,
 	})
 	s.deps.Logger.Info("GitHub user logged out")
 	jsonResponse(w, map[string]interface{}{"status": "logged_out"})


### PR DESCRIPTION
## Summary
- `SameSite=Strict` blocks the session cookie when navigating from the hub to a spoke (cross-origin top-level navigation)
- Changed to `SameSite=Lax` which sends the cookie on safe top-level navigations (GET) while still blocking cross-origin POST/iframe requests
- Fixes: user logs in successfully but gets re-prompted when clicking the spoke link from the hub

## Test plan
- [ ] Log in via device flow on a vllm-d spoke
- [ ] Navigate away, then click the spoke link from the hub — should stay authenticated
- [ ] Paste URL in a new tab — should stay authenticated (still works)
- [ ] hive-oke spokes unaffected (use nginx auth, not cookies)