### PR TITLE
fix: set session cookie via redirect instead of fetch response

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -66,6 +66,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("POST /api/gh-user-auth/start", s.handleGHUserAuthStart)
 	s.mux.HandleFunc("POST /api/gh-user-auth/poll", s.handleGHUserAuthPoll)
 	s.mux.HandleFunc("POST /api/gh-user-auth/logout", s.handleGHUserAuthLogout)
+	s.mux.HandleFunc("GET /api/gh-user-auth/session", s.handleGHUserAuthSession)
 	s.mux.HandleFunc("GET /api/summaries", s.handleSummaries)
 
 	s.mux.HandleFunc("GET /api/config/agent/{name}", s.handleAgentConfigGet)
@@ -1279,6 +1280,28 @@ func (s *Server) handleGHUserAuthLogout(w http.ResponseWriter, r *http.Request) 
 	})
 	s.deps.Logger.Info("GitHub user logged out")
 	jsonResponse(w, map[string]interface{}{"status": "logged_out"})
+}
+
+func (s *Server) handleGHUserAuthSession(w http.ResponseWriter, r *http.Request) {
+	if s.authToken == "" {
+		http.Redirect(w, r, "/", http.StatusFound)
+		return
+	}
+	tokenData, err := os.ReadFile(userTokenPath)
+	if err != nil || strings.TrimSpace(string(tokenData)) == "" {
+		http.Redirect(w, r, "/", http.StatusFound)
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    s.authToken,
+		Path:     "/",
+		MaxAge:   sessionCookieMaxAge,
+		HttpOnly: true,
+		Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
+		SameSite: http.SameSiteLaxMode,
+	})
+	http.Redirect(w, r, "/", http.StatusFound)
 }
 
 // restoreGHUserSession loads a previously-saved GitHub user OAuth token from

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -530,7 +530,7 @@ async function poll(interval){
     try{
       var r=await fetch('/api/gh-user-auth/poll',{method:'POST'});
       var d=await r.json();
-      if(d.status==='complete'){showStep('step-done');setTimeout(function(){location.reload()},1000);return}
+      if(d.status==='complete'){showStep('step-done');setTimeout(function(){location.href='/api/gh-user-auth/session'},1000);return}
       if(d.status==='error'){showError(d.error||'Authorization failed');return}
       if(d.status==='slow_down'){ms=Math.min(ms+5000,30000)}
       setTimeout(check,ms);


### PR DESCRIPTION
## Summary
- Safari ignores `Set-Cookie` headers on `fetch()` responses in certain contexts, so the session cookie set by the poll endpoint was not being stored
- Added `GET /api/gh-user-auth/session` endpoint that sets the cookie via a `302` redirect — a top-level navigation response that Safari respects
- Login page now redirects to this endpoint after successful device flow instead of calling `location.reload()`
- Fixes: user authenticates successfully but gets re-prompted when navigating from the hub or reopening the dashboard in Safari

## Test plan
- [ ] Complete device flow on jjs-world in Safari — should redirect to dashboard
- [ ] Click Dashboard from the hub — should stay authenticated (cookie sent on cross-origin navigation)
- [ ] Open jjs-world in a new tab — should stay authenticated
- [ ] Verify hive-oke spokes unaffected (nginx auth path)