### PR TITLE
fix: snapshot builder gets unauthorized after auth gating

### DIFF
--- a/dashboard/build-snapshot.mjs
+++ b/dashboard/build-snapshot.mjs
@@ -26,12 +26,15 @@ if (htmlIdx >= 0) { skipIdxSet.add(htmlIdx); skipIdxSet.add(htmlIdx + 1); }
 const positional = args.filter((_, i) => !skipIdxSet.has(i));
 const dashboardUrl = positional[0] || process.env.HIVE_DASHBOARD_URL || 'http://localhost:3001';
 const outputFile = positional[1] || 'snapshot.html';
+const authToken = process.env.DASHBOARD_AUTH_TOKEN || '';
 
 async function fetchJson(endpoint, fallback = '{}') {
   try {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-    const res = await fetch(`${dashboardUrl}${endpoint}`, { signal: controller.signal });
+    const headers = {};
+    if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
+    const res = await fetch(`${dashboardUrl}${endpoint}`, { signal: controller.signal, headers });
     clearTimeout(timer);
     return await res.text();
   } catch {

--- a/v2/pkg/dashboard/snapshot_test.go
+++ b/v2/pkg/dashboard/snapshot_test.go
@@ -1,0 +1,145 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSnapshotAPIMatchesStatus(t *testing.T) {
+	srv := newFullServer(t)
+	srv.deps.Config.Hub.AutoSnapshot = true
+
+	// Seed status data
+	status := &StatusPayload{
+		Timestamp: "2026-01-01T00:00:00Z",
+		Agents: []FrontendAgent{
+			{Name: "scanner", State: "running"},
+			{Name: "guide", State: "paused"},
+		},
+		Governor: FrontendGovernor{Mode: "busy", Issues: 5, PRs: 3},
+	}
+	srv.statusMu.Lock()
+	srv.status = status
+	srv.statusMu.Unlock()
+
+	// Fetch /api/snapshot
+	req := httptest.NewRequest("GET", "/api/snapshot", nil)
+	w := httptest.NewRecorder()
+	srv.handleSnapshotAPI(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var snapData StatusPayload
+	if err := json.Unmarshal(w.Body.Bytes(), &snapData); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if snapData.Timestamp != status.Timestamp {
+		t.Errorf("timestamp mismatch: snapshot=%q status=%q", snapData.Timestamp, status.Timestamp)
+	}
+	if len(snapData.Agents) != len(status.Agents) {
+		t.Errorf("agent count mismatch: snapshot=%d status=%d", len(snapData.Agents), len(status.Agents))
+	}
+	for i, a := range snapData.Agents {
+		if a.Name != status.Agents[i].Name || a.State != status.Agents[i].State {
+			t.Errorf("agent %d mismatch: snapshot=%s/%s status=%s/%s",
+				i, a.Name, a.State, status.Agents[i].Name, status.Agents[i].State)
+		}
+	}
+	if snapData.Governor.Mode != status.Governor.Mode {
+		t.Errorf("governor mode mismatch: snapshot=%q status=%q", snapData.Governor.Mode, status.Governor.Mode)
+	}
+}
+
+func TestSnapshotAPIDisabled(t *testing.T) {
+	srv := newFullServer(t)
+	srv.deps.Config.Hub.AutoSnapshot = false
+
+	req := httptest.NewRequest("GET", "/api/snapshot", nil)
+	w := httptest.NewRecorder()
+	srv.handleSnapshotAPI(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404 when snapshots disabled, got %d", w.Code)
+	}
+}
+
+func TestSnapshotAPINoData(t *testing.T) {
+	srv := newFullServer(t)
+	srv.deps.Config.Hub.AutoSnapshot = true
+	srv.statusMu.Lock()
+	srv.status = nil
+	srv.statusMu.Unlock()
+
+	req := httptest.NewRequest("GET", "/api/snapshot", nil)
+	w := httptest.NewRecorder()
+	srv.handleSnapshotAPI(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 when no data, got %d", w.Code)
+	}
+}
+
+func TestSnapshotReadOnly(t *testing.T) {
+	srv := newFullServer(t)
+
+	methods := []string{"POST", "PUT", "PATCH", "DELETE"}
+	paths := []string{"/snapshot", "/api/snapshot"}
+
+	for _, method := range methods {
+		for _, path := range paths {
+			req := httptest.NewRequest(method, path, nil)
+			w := httptest.NewRecorder()
+			srv.mux.ServeHTTP(w, req)
+
+			if w.Code == http.StatusOK {
+				t.Errorf("%s %s should not return 200 (got %d) — snapshot must be read-only",
+					method, path, w.Code)
+			}
+		}
+	}
+}
+
+func TestSnapshotIsPublicPath(t *testing.T) {
+	tests := []struct {
+		path   string
+		public bool
+	}{
+		{"/snapshot", true},
+		{"/snapshot/light", true},
+		{"/api/snapshot", true},
+		{"/api/status", false},
+		{"/api/agents", false},
+	}
+	for _, tt := range tests {
+		got := isPublicPath(tt.path)
+		if got != tt.public {
+			t.Errorf("isPublicPath(%q) = %v, want %v", tt.path, got, tt.public)
+		}
+	}
+}
+
+func TestSnapshotCacheHeaders(t *testing.T) {
+	srv := newFullServer(t)
+	srv.deps.Config.Hub.AutoSnapshot = true
+	srv.statusMu.Lock()
+	srv.status = &StatusPayload{Timestamp: "2026-01-01T00:00:00Z"}
+	srv.statusMu.Unlock()
+
+	req := httptest.NewRequest("GET", "/api/snapshot", nil)
+	w := httptest.NewRecorder()
+	srv.handleSnapshotAPI(w, req)
+
+	cc := w.Header().Get("Cache-Control")
+	if cc == "" {
+		t.Error("snapshot API should set Cache-Control header")
+	}
+	ct := w.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("expected application/json, got %q", ct)
+	}
+}


### PR DESCRIPTION
## Summary

- Fix broken public snapshots caused by PR #1647 (auth gating all `/api/` paths)
- The `build-snapshot.mjs` script fetches from `localhost/api/status` without auth, getting `{"error":"unauthorized"}` baked into the HTML
- Add `DASHBOARD_AUTH_TOKEN` as Bearer token to all fetch calls in the builder
- Add 6 snapshot tests for content consistency, read-only enforcement, and public access

## Root Cause

`build-snapshot.mjs` fetches live data from `http://localhost:3001/api/status` to bake into the static snapshot HTML. After #1647 gated all `/api/` paths behind `DASHBOARD_AUTH_TOKEN`, the builder's unauthenticated requests return `{"error":"unauthorized"}`. This gets baked into the snapshot, so the public `/snapshot` page renders an empty/broken dashboard.

The `DASHBOARD_AUTH_TOKEN` env var is already available to the builder (the Go caller passes `os.Environ()`), it just wasn't being used.

## Changes

1. **`dashboard/build-snapshot.mjs`**: Read `DASHBOARD_AUTH_TOKEN` from env, include as `Authorization: Bearer` header in all fetch calls
2. **`v2/pkg/dashboard/snapshot_test.go`**: 6 new tests:
   - `TestSnapshotAPIMatchesStatus` — verifies snapshot returns same agents/governor/timestamp as live status
   - `TestSnapshotAPIDisabled` — returns 404 when `auto_snapshot: false`
   - `TestSnapshotAPINoData` — returns 503 when no status collected yet
   - `TestSnapshotReadOnly` — POST/PUT/PATCH/DELETE all rejected on `/snapshot` and `/api/snapshot`
   - `TestSnapshotIsPublicPath` — snapshot paths exempt from auth, status paths are not
   - `TestSnapshotCacheHeaders` — Cache-Control and Content-Type headers set correctly

## Test plan

- [x] All snapshot tests pass
- [x] Verified on `hosted-kubestellar-console-4vkt` — snapshot has `render({"error":"unauthorized"})` baked in
- [ ] After deploy, verify snapshot shows live agent states