### PR TITLE
feat: distinguish insufficient GitHub App permissions from not-installed

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1099,7 +1099,8 @@ func main() {
 				Version:           "3.0.0",
 				GitHash:           gitShort,
 				GitBranch:         gitBranch,
-				GitHubAppRequired: dashSrv.IsGitHubAppRequired(),
+				GitHubAppRequired:  dashSrv.IsGitHubAppRequired(),
+				GitHubAppPermIssue: dashSrv.GetGitHubAppPermIssue(),
 				AutoUpgrade:       cfg.Hub.AutoUpgrade,
 				ClusterHealth: func() *hub.HeartbeatClusterHealthReport {
 					if os.Getenv("HIVE_CLUSTER_ID") == "" {
@@ -1514,11 +1515,17 @@ func runEvalCycle(
 					}
 					if err := postClient.PostAdvisoryDigest(ctx, primaryRepo, issueNum, md); err != nil {
 						logger.Warn("failed to post advisory digest", "repo", primaryRepo, "issue", issueNum, "error", err)
-						if strings.Contains(err.Error(), "403") {
+						if strings.Contains(err.Error(), "403") && strings.Contains(err.Error(), "Resource not accessible by integration") {
+							// App is installed (we found the issue) but can't write — permission gap
+							dashSrv.SetGitHubAppPermIssue("The GitHub App is installed but lacks Issues: Read & Write permission. The org owner must approve updated permissions at the app installation settings page.")
+							dashSrv.SetGitHubAppRequired(true)
+							logger.Warn("GitHub App installed but insufficient permissions — cannot write issue comments", "repo", primaryRepo)
+						} else if strings.Contains(err.Error(), "403") {
 							dashSrv.SetGitHubAppRequired(true)
 						}
 					} else {
 						logger.Info("posted advisory digest", "repo", primaryRepo, "issue", issueNum, "findings", digest.TotalCount)
+						dashSrv.SetGitHubAppPermIssue("")
 					}
 				}
 			}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -76,6 +76,7 @@ type Server struct {
 	githubAppMu         sync.RWMutex
 	githubAppRequired   bool
 	githubAppInstallURL string
+	githubAppPermIssue  string // non-empty when app is installed but lacks required permissions
 
 	githubAppRecheckFn func() bool
 }
@@ -103,6 +104,7 @@ type StatusPayload struct {
 	SystemResources     *SystemResources    `json:"systemResources,omitempty"`
 	GitHubAppRequired   bool               `json:"githubAppRequired,omitempty"`
 	GitHubAppInstallURL string             `json:"githubAppInstallURL,omitempty"`
+	GitHubAppPermIssue  string             `json:"githubAppPermIssue,omitempty"`
 	GitHubBaseURL       string             `json:"githubBaseURL,omitempty"`
 	InferenceBackends   []InferenceBackend `json:"inferenceBackends,omitempty"`
 }
@@ -574,6 +576,7 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 	s.githubAppMu.RLock()
 	status.GitHubAppRequired = s.githubAppRequired
 	status.GitHubAppInstallURL = s.githubAppInstallURL
+	status.GitHubAppPermIssue = s.githubAppPermIssue
 	s.githubAppMu.RUnlock()
 
 	status.InferenceBackends = s.buildInferenceBackends()
@@ -605,7 +608,23 @@ func (s *Server) SetGitHubAppRequired(required bool) {
 		s.githubAppInstallURL = "https://github.com/apps/kubestellar-hive/installations/new"
 	} else {
 		s.githubAppInstallURL = ""
+		s.githubAppPermIssue = ""
 	}
+}
+
+// SetGitHubAppPermIssue records that the app IS installed but lacks a specific
+// write permission. The banner shows an "Insufficient Permissions" message
+// instead of "Not Installed". Pass "" to clear.
+func (s *Server) SetGitHubAppPermIssue(issue string) {
+	s.githubAppMu.Lock()
+	defer s.githubAppMu.Unlock()
+	s.githubAppPermIssue = issue
+}
+
+func (s *Server) GetGitHubAppPermIssue() string {
+	s.githubAppMu.RLock()
+	defer s.githubAppMu.RUnlock()
+	return s.githubAppPermIssue
 }
 
 func (s *Server) IsGitHubAppRequired() bool {
@@ -627,9 +646,18 @@ func (s *Server) handleGitHubAppRecheck(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("Content-Type", "application/json")
 	if ok {
 		s.SetGitHubAppRequired(false)
+		s.SetGitHubAppPermIssue("")
 		w.Write([]byte(`{"status":"installed"}`))
 	} else {
-		w.Write([]byte(`{"status":"not_installed"}`))
+		s.githubAppMu.RLock()
+		permIssue := s.githubAppPermIssue
+		s.githubAppMu.RUnlock()
+		if permIssue != "" {
+			detail, _ := json.Marshal(permIssue)
+			w.Write([]byte(`{"status":"insufficient_permissions","detail":` + string(detail) + `}`))
+		} else {
+			w.Write([]byte(`{"status":"not_installed"}`))
+		}
 	}
 }
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -573,6 +573,13 @@
     .gh-app-install-banner .gh-app-desc { font-size: 0.85rem; color: #fca5a5; }
     .gh-app-install-banner .gh-app-btn { padding: 8px 16px; background: #dc2626; color: #fff; border-radius: 6px; font-weight: 600; text-decoration: none; white-space: nowrap; border: none; cursor: pointer; font-size: 0.85rem; }
     .gh-app-install-banner .gh-app-btn:hover { background: #ef4444; }
+    .gh-app-install-banner.perm-issue { background: #78350f; border-color: #d97706; }
+    .gh-app-install-banner.perm-issue .gh-app-desc { color: #fcd34d; }
+    .gh-app-install-banner.perm-issue .gh-app-btn { background: #d97706; }
+    .gh-app-install-banner.perm-issue .gh-app-btn:hover { background: #f59e0b; }
+    .gh-app-perm-details { font-size: 0.8rem; margin-top: 6px; color: #fde68a; }
+    .gh-app-perm-details .perm-ok { color: #86efac; }
+    .gh-app-perm-details .perm-missing { color: #fca5a5; font-weight: 600; }
     .gh-auth-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.6); z-index: 9999; display: flex; align-items: center; justify-content: center; }
     .gh-auth-modal { background: #fff; border-radius: 12px; padding: 32px; max-width: 420px; width: 90%; text-align: center; box-shadow: 0 20px 60px rgba(0,0,0,0.3); }
     .gh-auth-modal h3 { margin: 0 0 8px; font-size: 1.2rem; color: #1a1a2e; }
@@ -3458,19 +3465,44 @@
     function renderGitHubAppBanner(data) {
       var banner = document.getElementById('gh-app-install-banner');
       if (!banner) return;
-      if (data.githubAppRequired && data.githubAppInstallURL) {
+      var isPermIssue = data.githubAppRequired && data.githubAppPermIssue;
+      if (data.githubAppRequired && (data.githubAppInstallURL || isPermIssue)) {
         var link = document.getElementById('gh-app-install-link');
-        if (link) link.href = data.githubAppInstallURL;
-        var isGHE = data.githubBaseURL && data.githubBaseURL !== 'https://github.com';
         var title = document.querySelector('#gh-app-install-banner .gh-app-title');
         var desc = document.querySelector('#gh-app-install-banner .gh-app-desc');
-        if (title) title.textContent = isGHE ? 'GitHub App Not Installed on ' + data.githubBaseURL.replace('https://', '') : 'GitHub App Not Installed';
-        if (desc) desc.textContent = isGHE
-          ? 'This hive cannot post advisory reports. Install the GitHub App on your GHE org to enable full functionality.'
-          : 'This hive cannot create issues or advisory reports. Install the Hive Hub GitHub App on your repository to enable full functionality.';
+        var existingDetails = document.getElementById('gh-app-perm-details');
+        if (isPermIssue) {
+          banner.classList.add('perm-issue');
+          if (title) title.textContent = 'GitHub App — Insufficient Permissions';
+          if (desc) desc.textContent = 'The app is installed but cannot write to this repository. The org owner must approve updated permissions.';
+          if (link) { link.textContent = 'View App Settings'; link.href = data.githubAppInstallURL || 'https://github.com/apps/kubestellar-hive'; }
+          if (!existingDetails) {
+            var details = document.createElement('div');
+            details.id = 'gh-app-perm-details';
+            details.className = 'gh-app-perm-details';
+            details.innerHTML = '<strong>Current permissions:</strong><br>'
+              + '<span class="perm-ok">✓ Issues: Read</span> — can find and read issues<br>'
+              + '<span class="perm-missing">✗ Issues: Write</span> — cannot create or update issue comments<br>'
+              + '<br><strong>Required:</strong> Issues: Read &amp; Write<br>'
+              + '<em>The org owner must go to Organization Settings → GitHub Apps → kubestellar-hive → Configure and accept the updated permissions.</em>';
+            desc.parentElement.appendChild(details);
+          }
+        } else {
+          banner.classList.remove('perm-issue');
+          if (existingDetails) existingDetails.remove();
+          var isGHE = data.githubBaseURL && data.githubBaseURL !== 'https://github.com';
+          if (title) title.textContent = isGHE ? 'GitHub App Not Installed on ' + data.githubBaseURL.replace('https://', '') : 'GitHub App Not Installed';
+          if (desc) desc.textContent = isGHE
+            ? 'This hive cannot post advisory reports. Install the GitHub App on your GHE org to enable full functionality.'
+            : 'This hive cannot create issues or advisory reports. Install the Hive Hub GitHub App on your repository to enable full functionality.';
+          if (link) { link.textContent = 'Install GitHub App'; link.href = data.githubAppInstallURL; }
+        }
         banner.removeAttribute('hidden');
         banner.style.cssText = 'display:flex !important';
       } else {
+        banner.classList.remove('perm-issue');
+        var oldDetails = document.getElementById('gh-app-perm-details');
+        if (oldDetails) oldDetails.remove();
         banner.setAttribute('hidden', '');
         banner.style.cssText = 'display:none';
       }
@@ -3484,7 +3516,11 @@
         var data = await resp.json();
         if (data.status === 'installed') {
           var banner = document.getElementById('gh-app-install-banner');
-          if (banner) { banner.setAttribute('hidden', ''); banner.style.cssText = 'display:none'; }
+          if (banner) { banner.classList.remove('perm-issue'); banner.setAttribute('hidden', ''); banner.style.cssText = 'display:none'; }
+          var oldDetails = document.getElementById('gh-app-perm-details');
+          if (oldDetails) oldDetails.remove();
+        } else if (data.status === 'insufficient_permissions') {
+          if (btn) btn.textContent = 'Permissions insufficient';
         } else {
           if (btn) btn.textContent = 'Not found — try again';
         }

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -114,6 +114,7 @@ type HeartbeatPayload struct {
 	GitBranch    string             `json:"git_branch,omitempty"`
 	Timestamp          string         `json:"timestamp"`
 	GitHubAppRequired  bool           `json:"github_app_required,omitempty"`
+	GitHubAppPermIssue string         `json:"github_app_perm_issue,omitempty"`
 	AutoUpgrade        bool           `json:"auto_upgrade,omitempty"`
 	Upgrading          bool           `json:"upgrading,omitempty"`
 	UpgradeTargetSHA   string         `json:"upgrade_target_sha,omitempty"`

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3306,8 +3306,9 @@ const dashboardHTML = `<!DOCTYPE html>
         if (ck.detail) line += ': ' + ck.detail;
         lines.push(line);
       }
-      if (h.githubAppRequired && h.githubAppPermIssue) { lines.push('⚠ GitHub App: insufficient permissions'); st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel; }
+      if (h.githubAppRequired && h.githubAppPermIssue) { lines.push('✓ GitHub App installed'); lines.push('⚠ GitHub App: permissions insufficient'); st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel; }
       else if (h.githubAppRequired) { lines.push('✕ GitHub App not installed'); st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel; }
+      else if (!h.githubAppRequired) { lines.push('✓ GitHub App installed'); }
       if (!checks.length) lines.push('No check data');
       return '<span title="' + esc(lines.join('\n')) + '" style="display:inline-flex;align-items:center;gap:4px;cursor:help;white-space:pre-line"><span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + c + '"></span><span style="font-size:0.7rem;color:' + c + ';font-weight:600">' + ic + '</span></span>';
     }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3306,7 +3306,8 @@ const dashboardHTML = `<!DOCTYPE html>
         if (ck.detail) line += ': ' + ck.detail;
         lines.push(line);
       }
-      if (h.githubAppRequired) { lines.push('✕ GitHub App not installed'); st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel; }
+      if (h.githubAppRequired && h.githubAppPermIssue) { lines.push('⚠ GitHub App: insufficient permissions'); st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel; }
+      else if (h.githubAppRequired) { lines.push('✕ GitHub App not installed'); st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel; }
       if (!checks.length) lines.push('No check data');
       return '<span title="' + esc(lines.join('\n')) + '" style="display:inline-flex;align-items:center;gap:4px;cursor:help;white-space:pre-line"><span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:' + c + '"></span><span style="font-size:0.7rem;color:' + c + ';font-weight:600">' + ic + '</span></span>';
     }

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -72,6 +72,7 @@ type RegistryEntry struct {
 	IssueHistory       []SparkPoint   `json:"issueHistory,omitempty"`
 	PRHistory          []SparkPoint   `json:"prHistory,omitempty"`
 	GitHubAppRequired  bool           `json:"githubAppRequired,omitempty"`
+	GitHubAppPermIssue string         `json:"githubAppPermIssue,omitempty"`
 }
 
 type SparkPoint struct {
@@ -345,7 +346,8 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			return payload.Leaderboard
 		}(),
 		Online:            true,
-		GitHubAppRequired: payload.GitHubAppRequired,
+		GitHubAppRequired:  payload.GitHubAppRequired,
+		GitHubAppPermIssue: sanitizeHeartbeatField(payload.GitHubAppPermIssue),
 	}
 
 	// Populate ClusterID from SaaS hive record, heartbeat payload, or default.


### PR DESCRIPTION
## Summary
- When the GitHub App is installed but lacks Issues: Write permission, show an **orange "Insufficient Permissions" banner** instead of the misleading red "Not Installed" banner
- The banner displays a permission table showing what's allowed (✓ Issues: Read) and what's missing (✗ Issues: Write), plus instructions for the org owner to approve updated permissions
- Hub SaaS tooltip now shows **two lines** when permissions are insufficient: "✓ GitHub App installed" and "⚠ GitHub App: permissions insufficient"
- When the app is fully working (not required), the tooltip shows "✓ GitHub App installed" as a green checkmark
- Detected via the specific 403 "Resource not accessible by integration" error from GitHub's API, separate from generic 403s

## Context
The certus hive had the GitHub App installed but the org owner hadn't approved the updated Issues: Write permission. The banner kept cycling between hidden (after Re-check found the app) and showing "Not Installed" (when write failed). This fix accurately represents the three states: not installed, installed but insufficient permissions, and fully working.

## Files changed
- `v2/cmd/hive/main.go` — detect specific 403 error, wire heartbeat payload
- `v2/pkg/dashboard/server.go` — new field, getter/setter, recheck handler
- `v2/pkg/dashboard/static/index.html` — orange banner with permission details
- `v2/pkg/hub/heartbeat.go` — add field to heartbeat struct
- `v2/pkg/hub/saas.go` — hub tooltip with checkmark + permissions line
- `v2/pkg/hub/server.go` — registry entry + heartbeat handler wiring

## Test plan
- [ ] Deploy to certus hive (app installed, no write perms) — verify orange banner appears with permission table
- [ ] Deploy to console hive (app installed, full perms) — verify no banner and hub shows "✓ GitHub App installed"
- [ ] Test Re-check button on certus — should show "Permissions insufficient" instead of "Not found"
- [ ] Verify hub SaaS tooltip shows two lines for certus: "✓ GitHub App installed" + "⚠ GitHub App: permissions insufficient"