### PR TITLE
✨ Inject agentic preamble into system prompt for inference backends (vLLM/llm-d)

### DIFF
--- a/v2/pkg/proxy/anthropic_translate.go
+++ b/v2/pkg/proxy/anthropic_translate.go
@@ -14,7 +14,10 @@ import (
 // translateAnthropicToOpenAI converts an Anthropic Messages API request body
 // into an OpenAI Chat Completions API request body, overriding the model.
 // maxContextLen is the model's max context window (0 = no cap).
-func translateAnthropicToOpenAI(body []byte, targetModel string, maxContextLen int) ([]byte, error) {
+// preamble, when non-empty, is prepended to the system message to steer
+// open-source models toward agentic tool-calling behaviour. Pass "" to
+// leave the system prompt unchanged (used by tests and non-inference paths).
+func translateAnthropicToOpenAI(body []byte, targetModel string, maxContextLen int, preamble string) ([]byte, error) {
 	var req anthropicRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		return nil, fmt.Errorf("unmarshal anthropic request: %w", err)
@@ -30,12 +33,22 @@ func translateAnthropicToOpenAI(body []byte, targetModel string, maxContextLen i
 	if len(req.System) > 0 {
 		systemText := extractSystemText(req.System)
 		if systemText != "" {
+			if preamble != "" {
+				systemText = preamble + systemText
+			}
 			totalChars += len(systemText)
 			openaiReq.Messages = append(openaiReq.Messages, openaiMessage{
 				Role:    "system",
 				Content: systemText,
 			})
 		}
+	} else if preamble != "" {
+		// No system prompt from the CLI — inject the preamble as the system message.
+		totalChars += len(preamble)
+		openaiReq.Messages = append(openaiReq.Messages, openaiMessage{
+			Role:    "system",
+			Content: preamble,
+		})
 	}
 
 	for _, msg := range req.Messages {
@@ -489,7 +502,7 @@ func mapFinishReason(reason string) string {
 // endpoint, translating the request and response formats. It writes the
 // translated response directly to the provided http.ResponseWriter.
 func forwardToInference(clientReq *http.Request, clientBody []byte, w http.ResponseWriter, route *InferenceRoute) error {
-	openaiBody, err := translateAnthropicToOpenAI(clientBody, route.Model, route.MaxContextLen)
+	openaiBody, err := translateAnthropicToOpenAI(clientBody, route.Model, route.MaxContextLen, resolveInferencePreamble(route))
 	if err != nil {
 		return fmt.Errorf("translate request: %w", err)
 	}

--- a/v2/pkg/proxy/anthropic_translate_test.go
+++ b/v2/pkg/proxy/anthropic_translate_test.go
@@ -17,7 +17,7 @@ func TestTranslateAnthropicToOpenAI_StringSystem(t *testing.T) {
 		"stream": true
 	}`
 
-	result, err := translateAnthropicToOpenAI([]byte(body), "Qwen/Qwen2.5-1.5B-Instruct", 0)
+	result, err := translateAnthropicToOpenAI([]byte(body), "Qwen/Qwen2.5-1.5B-Instruct", 0, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +60,7 @@ func TestTranslateAnthropicToOpenAI_BlockSystem(t *testing.T) {
 		]
 	}`
 
-	result, err := translateAnthropicToOpenAI([]byte(body), "test-model", 0)
+	result, err := translateAnthropicToOpenAI([]byte(body), "test-model", 0, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,7 +95,7 @@ func TestTranslateAnthropicToOpenAI_WithTools(t *testing.T) {
 		]
 	}`
 
-	result, err := translateAnthropicToOpenAI([]byte(body), "test-model", 0)
+	result, err := translateAnthropicToOpenAI([]byte(body), "test-model", 0, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,7 +135,7 @@ func TestTranslateAnthropicToOpenAI_ToolUseInAssistantMessage(t *testing.T) {
 		]
 	}`
 
-	result, err := translateAnthropicToOpenAI([]byte(body), "test-model", 0)
+	result, err := translateAnthropicToOpenAI([]byte(body), "test-model", 0, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,7 +196,7 @@ func TestTranslateAnthropicToOpenAI_ToolResultWithBlocks(t *testing.T) {
 		]
 	}`
 
-	result, err := translateAnthropicToOpenAI([]byte(body), "test-model", 0)
+	result, err := translateAnthropicToOpenAI([]byte(body), "test-model", 0, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -449,7 +449,7 @@ func TestTranslateAnthropicToOpenAI_MixedTextAndToolResultInUser(t *testing.T) {
 		]
 	}`
 
-	result, err := translateAnthropicToOpenAI([]byte(body), "test-model", 0)
+	result, err := translateAnthropicToOpenAI([]byte(body), "test-model", 0, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -473,5 +473,99 @@ func TestTranslateAnthropicToOpenAI_MixedTextAndToolResultInUser(t *testing.T) {
 	}
 	if req.Messages[1].Content != "42" {
 		t.Errorf("msg[1] content = %q, want '42'", req.Messages[1].Content)
+	}
+}
+
+func TestTranslateAnthropicToOpenAI_InferencePreamble(t *testing.T) {
+	body := `{
+		"model": "claude-sonnet-4-6",
+		"max_tokens": 1024,
+		"system": "You are Claude Code, Anthropic's official CLI for Claude.CWD: /data/agents/scanner\nDate: 2026-06-23",
+		"messages": [
+			{"role": "user", "content": "Check CI status"}
+		]
+	}`
+
+	preamble := "You are an autonomous agent.\n\n"
+
+	result, err := translateAnthropicToOpenAI([]byte(body), "test-model", 0, preamble)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var req openaiRequest
+	if err := json.Unmarshal(result, &req); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(req.Messages) != 2 {
+		t.Fatalf("messages count = %d, want 2", len(req.Messages))
+	}
+	sys := req.Messages[0]
+	if sys.Role != "system" {
+		t.Errorf("first message role = %q, want system", sys.Role)
+	}
+	if !strings.HasPrefix(sys.Content, preamble) {
+		t.Errorf("system prompt should start with preamble, got: %q", sys.Content[:80])
+	}
+	if !strings.Contains(sys.Content, "CWD: /data/agents/scanner") {
+		t.Error("original system content (CWD) should be preserved after preamble")
+	}
+}
+
+func TestTranslateAnthropicToOpenAI_NoPreamble(t *testing.T) {
+	body := `{
+		"model": "claude-sonnet-4-6",
+		"max_tokens": 1024,
+		"system": "You are Claude Code.",
+		"messages": [
+			{"role": "user", "content": "Hello"}
+		]
+	}`
+
+	result, err := translateAnthropicToOpenAI([]byte(body), "test-model", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var req openaiRequest
+	if err := json.Unmarshal(result, &req); err != nil {
+		t.Fatal(err)
+	}
+
+	if req.Messages[0].Content != "You are Claude Code." {
+		t.Errorf("system prompt should be unchanged when preamble is empty, got: %q", req.Messages[0].Content)
+	}
+}
+
+func TestTranslateAnthropicToOpenAI_PreambleNoSystem(t *testing.T) {
+	body := `{
+		"model": "claude-sonnet-4-6",
+		"max_tokens": 1024,
+		"messages": [
+			{"role": "user", "content": "Hello"}
+		]
+	}`
+
+	preamble := "You are an autonomous agent.\n"
+
+	result, err := translateAnthropicToOpenAI([]byte(body), "test-model", 0, preamble)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var req openaiRequest
+	if err := json.Unmarshal(result, &req); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(req.Messages) != 2 {
+		t.Fatalf("messages count = %d, want 2 (system + user)", len(req.Messages))
+	}
+	if req.Messages[0].Role != "system" {
+		t.Errorf("first message role = %q, want system", req.Messages[0].Role)
+	}
+	if req.Messages[0].Content != preamble {
+		t.Errorf("system content = %q, want preamble", req.Messages[0].Content)
 	}
 }

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -920,7 +920,7 @@ func (p *GitHubProxy) StartInferenceTranslator() error {
 
 		p.logger.Info("inference request body", "agent", agentName, "len", len(body), "preview", truncateBytes(body, 200))
 
-		openaiBody, err := translateAnthropicToOpenAI(body, route.Model, route.MaxContextLen)
+		openaiBody, err := translateAnthropicToOpenAI(body, route.Model, route.MaxContextLen, resolveInferencePreamble(route))
 		if err != nil {
 			p.logger.Error("inference translate request failed", "agent", agentName, "error", err)
 			http.Error(w, fmt.Sprintf(`{"type":"error","error":{"type":"api_error","message":"translation error: %s"}}`, err.Error()), http.StatusBadGateway)
@@ -1073,7 +1073,7 @@ func (p *GitHubProxy) handleInferenceRequest(conn net.Conn, req *http.Request, a
 		return
 	}
 
-	openaiBody, err := translateAnthropicToOpenAI(body, route.Model, route.MaxContextLen)
+	openaiBody, err := translateAnthropicToOpenAI(body, route.Model, route.MaxContextLen, resolveInferencePreamble(route))
 	if err != nil {
 		p.logger.Error("inference translate request failed", "agent", agentName, "error", err)
 		p.writeHTTPError(conn, http.StatusBadGateway, "translation error: "+err.Error())

--- a/v2/pkg/proxy/inference_route.go
+++ b/v2/pkg/proxy/inference_route.go
@@ -16,7 +16,25 @@ type InferenceRoute struct {
 	Endpoint      string // e.g. "http://vllm-svc.hive.svc.cluster.local:8000"
 	Model         string // e.g. "Qwen/Qwen2.5-1.5B-Instruct"
 	MaxContextLen int    // from vLLM /v1/models max_model_len; 0 = unknown
+	Preamble      string // prepended to the system prompt for inference backends; empty = use DefaultInferencePreamble
 }
+
+// DefaultInferencePreamble is injected at the top of the system prompt when
+// requests are routed to a self-hosted inference backend (vLLM / llm-d).
+// It makes open-source models behave more agentically — calling tools
+// proactively, iterating autonomously, and never asking for permission.
+// CLI backends (claude, copilot, goose, etc.) are unaffected.
+const DefaultInferencePreamble = `You are an autonomous AI coding agent. You have access to tools (Bash, Read, Write/Edit, etc.) and MUST use them to accomplish every task.
+
+CRITICAL RULES:
+- ALWAYS call tools to gather information and take action. Never describe what you would do — actually do it.
+- NEVER ask for permission or clarification. Execute immediately with the information available.
+- After each tool result, decide your next action and call the next tool. Continue until the task is fully complete.
+- If a tool call fails, try an alternative approach. Do not stop or ask the user.
+- Produce concrete artifacts (files, commands, analysis) — not plans or proposals.
+- When you have completed the task, summarize what you did.
+
+`
 
 // inferenceRouter manages per-agent inference backend routing.
 type inferenceRouter struct {
@@ -173,5 +191,18 @@ func capMaxTokensForInput(maxTokens, maxContextLen, totalInputChars int) int {
 		return available
 	}
 	return maxTokens
+}
+
+// resolveInferencePreamble returns the preamble string to inject into the
+// system prompt for inference-backed requests. If the route has an explicit
+// Preamble it is used; otherwise DefaultInferencePreamble is returned.
+func resolveInferencePreamble(route *InferenceRoute) string {
+	if route == nil {
+		return ""
+	}
+	if route.Preamble != "" {
+		return route.Preamble
+	}
+	return DefaultInferencePreamble
 }
 


### PR DESCRIPTION
## Summary

When requests are routed to self-hosted inference backends (vLLM / llm-d), this PR prepends a `DefaultInferencePreamble` to the system prompt that instructs open-source models to:

- **Use tools proactively** — never describe what they would do, actually call the tool
- **Iterate autonomously** — after each tool result, decide the next action and continue
- **Never ask for permission** — execute immediately with available information
- **Recover from failures** — try alternative approaches instead of stopping

### Why this is needed

The Copilot CLI sends a system prompt that says *"You are Claude Code, Anthropic's official CLI for Claude."* — Claude models understand this identity and behave agentically, but open-source models like Qwen 2.5 72B don't. They tend to:
- Describe what they would do instead of calling tools
- Ask for permission before acting
- Stop after one round instead of iterating

The preamble bridges this behavioral gap without changing any per-agent config or kick templates.

### Design

- New `Preamble` field on `InferenceRoute` — defaults to `DefaultInferencePreamble`, can be overridden per-route
- `translateAnthropicToOpenAI()` gains an optional `preamble string` parameter
- Preamble is prepended to the system message at all 3 inference call sites
- **CLI backends (claude, copilot, goose, etc.) are completely unaffected** — they never call the translation code

### Files changed
- `inference_route.go` — `Preamble` field + `DefaultInferencePreamble` constant + `resolveInferencePreamble()` helper
- `anthropic_translate.go` — preamble injection in system prompt extraction
- `github_proxy.go` — pass preamble at both inference call sites
- `anthropic_translate_test.go` — 3 new tests (preamble injection, no-preamble passthrough, preamble-without-system)

### Testing
- All existing proxy tests pass unchanged (they pass `""` for preamble)
- 3 new tests validate preamble injection behavior
- Full binary builds cleanly