### PR TITLE
fix: clear stale upgrading flag when hive sends normal heartbeat

### DIFF
--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -378,9 +378,13 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			if entry.SnapshotURL == "" {
 				entry.SnapshotURL = h.SnapshotURL
 			}
-			if h.Upgrading && h.UpgradeTarget != "" {
+			if h.Upgrading && !payload.Upgrading {
+				// Non-upgrading heartbeat from a hive previously marked upgrading —
+				// the pod restarted and is healthy, clear the stale flag.
+				entry.Upgrading = false
+				entry.UpgradeTarget = ""
+			} else if h.Upgrading && h.UpgradeTarget != "" {
 				if entry.GitHash != h.GitHash && entry.GitHash != "" {
-					// SHA changed from pre-upgrade value — upgrade completed (or surpassed)
 					entry.Upgrading = false
 					entry.UpgradeTarget = ""
 				} else {


### PR DESCRIPTION
## Summary
- Hives stuck in "Upgrading" state on the hub when they restarted on the same SHA or without an upgrade target
- Root cause: the only flag-clearing path required both `UpgradeTarget != ""` and a git hash change — config-only restarts or missing targets meant the flag persisted forever
- Fix: when a non-upgrading heartbeat arrives from a previously-upgrading hive, clear the flag immediately (the pod is back and healthy)

## Test plan
- [ ] Verify llm-d-incubation clears "Upgrading" after hub redeploy
- [ ] Trigger an upgrade, verify spinner shows during restart, clears when pod comes back
- [ ] Restart a hive on the same SHA — verify no permanent "Upgrading" state