### PR TITLE
feat: show on-demand label for agents in hub tooltip

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1037,7 +1037,11 @@ func main() {
 			govState := gov.GetState()
 			agents := make([]hub.AgentSummary, 0, len(statuses))
 			for name, proc := range statuses {
-				agents = append(agents, hub.AgentSummary{Name: name, State: string(proc.State)})
+				as := hub.AgentSummary{Name: name, State: string(proc.State)}
+				if ac, ok := cfg.Agents[name]; (ok && ac.OnDemand) || onDemandFromPack[name] {
+					as.Mode = "on_demand"
+				}
+				agents = append(agents, as)
 			}
 			acmmLvl := 0
 			if cfg.ACMMLevel != nil {
@@ -1146,7 +1150,11 @@ func main() {
 				statuses := agentMgr.AllStatuses()
 				agents := make([]hub.AgentSummary, 0, len(statuses))
 				for name, proc := range statuses {
-					agents = append(agents, hub.AgentSummary{Name: name, State: string(proc.State)})
+					as := hub.AgentSummary{Name: name, State: string(proc.State)}
+					if ac, ok := cfg.Agents[name]; (ok && ac.OnDemand) || onDemandFromPack[name] {
+						as.Mode = "on_demand"
+					}
+					agents = append(agents, as)
 				}
 				acmmLvl := 0
 				if cfg.ACMMLevel != nil {

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -20,6 +20,7 @@ const (
 type AgentSummary struct {
 	Name  string `json:"name"`
 	State string `json:"state"`
+	Mode  string `json:"mode,omitempty"`
 }
 
 type GovernorSummary struct {

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3635,7 +3635,7 @@ const dashboardHTML = `<!DOCTYPE html>
           '<td style="font-size:0.7rem;white-space:nowrap">' + versionCell + '</td>' +
           '<td title="' + esc((h.repos || []).join('\n')) + '" style="cursor:' + (repoCount > 0 ? 'help' : 'default') + '">' + repoCount + '</td>' +
           '<td>' + acmmBadge(h.acmmLevel) + '</td>' +
-          '<td title="' + esc((h.agents || []).map(function(a){ return a.name + ' (' + a.state + ')'; }).join('\n')) + '" style="cursor:' + ((h.agentCount || 0) > 0 ? 'help' : 'default') + '">' + (h.agentCount || 0) + '</td>' +
+          '<td title="' + esc((h.agents || []).map(function(a){ var label = a.name + ' (' + a.state + ')'; if (a.mode === 'on_demand') label += ' — on demand'; return label; }).join('\n')) + '" style="cursor:' + ((h.agentCount || 0) > 0 ? 'help' : 'default') + '">' + (h.agentCount || 0) + '</td>' +
           '<td>' + modeCell + '</td>' +
           '<td>' + sparkline(h.issueHistory, '#f59e0b', 50, 14) + (h.actionableIssues || 0) + '</td>' +
           '<td>' + sparkline(h.prHistory, '#3b82f6', 50, 14) + (h.actionablePRs || 0) + '</td>' +

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -336,6 +336,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			for i := range payload.Agents {
 				payload.Agents[i].Name = sanitizeHeartbeatField(payload.Agents[i].Name)
 				payload.Agents[i].State = sanitizeHeartbeatField(payload.Agents[i].State)
+				payload.Agents[i].Mode = sanitizeHeartbeatField(payload.Agents[i].Mode)
 			}
 			const maxAgents = 50
 			if len(payload.Agents) > maxAgents {


### PR DESCRIPTION
## Summary
- Adds `Mode` field to `AgentSummary` heartbeat struct (`on_demand` for on-demand agents)
- Spoke populates mode from agent config and pack definitions
- Hub dashboard tooltip now shows "— on demand" next to on-demand agents (e.g. brainstorm)

## Test plan
- [ ] Deploy hub and spoke with an on-demand agent (brainstorm)
- [ ] Hover over agent count in hub dashboard — verify "(on demand)" label appears
- [ ] Verify non-on-demand agents show only name and state as before