### PR TITLE
fix: prevent crash when hive provisioned with Configure Later

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -101,7 +101,7 @@ func main() {
 
 	var ghClient *github.Client
 	var appAuth *github.AppAuth
-	if cfg.GitHub.AppID != 0 {
+	if cfg.GitHub.AppID != 0 && cfg.GitHub.InstallationID != 0 {
 		keyFile := cfg.GitHub.KeyFile
 		if envKey := os.Getenv("GH_APP_KEY_FILE"); envKey != "" {
 			keyFile = envKey
@@ -153,7 +153,9 @@ func main() {
 		if ghToken == "" {
 			ghToken = os.Getenv("HIVE_GITHUB_TOKEN")
 		}
-		if ghToken == "" {
+		if ghToken == "" && cfg.GitHub.AppID != 0 {
+			logger.Warn("GitHub App configured without credentials — hive starting in dashboard-only mode. Install the app and provide installation_id + key to enable agents.")
+		} else if ghToken == "" {
 			logger.Error("no GitHub token configured (set github.token or github.app_id in config)")
 			os.Exit(1)
 		}


### PR DESCRIPTION
## Summary
- Hives provisioned with "Configure Later" auth have `app_id` set but no `installation_id` or private key
- The binary entered the App auth path and called `os.Exit(1)` when the key file was missing, causing CrashLoopBackOff
- Now requires both `app_id` AND `installation_id` to attempt App auth init
- When `app_id` is set without credentials, logs a warning and creates a degraded client so the dashboard starts

## Test plan
- [ ] Provision a hive with "Configure Later" — verify it starts without crash
- [ ] Verify dashboard is accessible and shows on hub
- [ ] Verify agents don't run (no GitHub auth available)
- [ ] After installing the app and updating config, verify full functionality resumes