### PR TITLE
feat: enable knowledge + bead synthesizer in hosted provisioning

### DIFF
--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -870,6 +870,20 @@ data:
 {{- if .OAuthClientID}}
       oauth_client_id: {{.OAuthClientID}}
 {{- end}}
+    knowledge:
+      enabled: true
+      engine: llm-wiki
+      bead_synthesizer:
+        schedule: hourly
+        min_confidence: 0.5
+        target_layer: project
+        max_facts_per_cycle: 20
+        vault_path: /data/vaults/bead-synth-wiki
+      vaults:
+        - name: bead-synth-wiki
+          path: /data/vaults/bead-synth-wiki
+          auto_index: true
+          git_sync: false
     dashboard:
       port: {{.DashboardPort}}
     hub:


### PR DESCRIPTION
## Summary

- The hosted hive configmap template didn't include `knowledge:` at all, so `knowledge.enabled` defaulted to `false` and the bead synthesizer never started on any hosted instance
- Adds `knowledge.enabled: true`, `bead_synthesizer` config, and `bead-synth-wiki` vault to the provisioning template
- All new and reprovisioned hosted instances will now get automatic bead-to-wiki synthesis

## Test plan

- [x] `go build ./...` passes
- [ ] Verify existing hosted instance picks up knowledge config after configmap patch + pod restart
- [ ] Verify `bead-synth-wiki` vault appears in Connected Vaults on dashboard
- [ ] Verify synthesized facts appear after first hourly cycle