### PR TITLE
feat: runtime bead synthesizer toggle with dashboard UI

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -648,30 +648,38 @@ func main() {
 
 	go gitSyncer.Start(ctx)
 
-	if cfg.Knowledge.Enabled && cfg.Knowledge.BeadSynthesizer.IsEnabled() && knowledgeAPI != nil && len(beadStores) > 0 {
+	var beadSynth *knowledge.BeadSynthesizer
+	if len(beadStores) > 0 {
 		synthVaultPath := cfg.Knowledge.BeadSynthesizer.VaultPath
+		if synthVaultPath == "" {
+			synthVaultPath = "/data/vaults/bead-synth-wiki"
+		}
 		if err := os.MkdirAll(synthVaultPath, 0o755); err != nil {
 			logger.Warn("failed to create bead-synth vault dir", "path", synthVaultPath, "error", err)
 		}
-		if connErr := knowledgeAPI.ConnectVault(synthVaultPath, "bead-synth-wiki"); connErr != nil {
-			logger.Warn("failed to auto-connect bead-synth vault", "path", synthVaultPath, "error", connErr)
-		} else {
-			logger.Info("auto-connected bead-synth vault", "path", synthVaultPath)
+		if knowledgeAPI != nil {
+			if connErr := knowledgeAPI.ConnectVault(synthVaultPath, "bead-synth-wiki"); connErr != nil {
+				logger.Warn("failed to auto-connect bead-synth vault", "path", synthVaultPath, "error", connErr)
+			} else {
+				logger.Info("auto-connected bead-synth vault", "path", synthVaultPath)
+			}
 		}
-		beadSynth := knowledge.NewBeadSynthesizer(beadStores, knowledgeAPI, knowledge.BeadSynthesizerConfig{
+		beadSynth = knowledge.NewBeadSynthesizer(beadStores, knowledgeAPI, knowledge.BeadSynthesizerConfig{
 			Schedule:         cfg.Knowledge.BeadSynthesizer.Schedule,
 			MinConfidence:    cfg.Knowledge.BeadSynthesizer.MinConfidence,
 			TargetLayer:      cfg.Knowledge.BeadSynthesizer.TargetLayer,
 			MaxFactsPerCycle: cfg.Knowledge.BeadSynthesizer.MaxFactsPerCycle,
 			VaultPath:        synthVaultPath,
 		}, logger)
-		go beadSynth.Start(ctx)
-		logger.Info("bead-to-wiki synthesizer started",
-			"schedule", cfg.Knowledge.BeadSynthesizer.Schedule,
-			"target_layer", cfg.Knowledge.BeadSynthesizer.TargetLayer,
-			"vault_path", synthVaultPath,
-			"bead_stores", len(beadStores),
-		)
+		if cfg.Knowledge.Enabled && cfg.Knowledge.BeadSynthesizer.IsEnabled() && knowledgeAPI != nil {
+			beadSynth.StartBackground(ctx)
+			logger.Info("bead-to-wiki synthesizer started",
+				"schedule", cfg.Knowledge.BeadSynthesizer.Schedule,
+				"target_layer", cfg.Knowledge.BeadSynthesizer.TargetLayer,
+				"vault_path", synthVaultPath,
+				"bead_stores", len(beadStores),
+			)
+		}
 	}
 
 	os.MkdirAll(nousSnapshotDir, 0o755)
@@ -735,6 +743,7 @@ func main() {
 		Nous:             nousState,
 		Scheduler:        sched,
 		MetricsCollector: metricsCollector,
+		BeadSynthesizer:  beadSynth,
 		BeadStores:       beadStores,
 		Logger:           logger,
 		Ctx:              ctx,

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3164,6 +3164,16 @@ func (s *Server) handleKnowledgeToggle(w http.ResponseWriter, r *http.Request) {
 		s.deps.Knowledge = nil
 	}
 
+	if s.deps.BeadSynthesizer != nil {
+		if body.Enabled && s.deps.Config.Knowledge.BeadSynthesizer.IsEnabled() {
+			s.deps.BeadSynthesizer.StartBackground(s.deps.Ctx)
+			s.logger.Info("bead synthesizer started via knowledge toggle")
+		} else if !body.Enabled {
+			s.deps.BeadSynthesizer.Stop()
+			s.logger.Info("bead synthesizer stopped via knowledge toggle")
+		}
+	}
+
 	if err := s.saveConfig(); err != nil {
 		s.logger.Error("failed to persist config after knowledge toggle", "error", err)
 	}
@@ -3173,13 +3183,18 @@ func (s *Server) handleKnowledgeToggle(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleBeadSynthStatus(w http.ResponseWriter, r *http.Request) {
 	cfg := s.deps.Config.Knowledge.BeadSynthesizer
+	running := false
+	if s.deps.BeadSynthesizer != nil {
+		running = s.deps.BeadSynthesizer.IsRunning()
+	}
 	jsonResponse(w, map[string]interface{}{
-		"enabled":            cfg.IsEnabled(),
-		"schedule":           cfg.Schedule,
-		"min_confidence":     cfg.MinConfidence,
-		"target_layer":       cfg.TargetLayer,
+		"enabled":             cfg.IsEnabled(),
+		"running":             running,
+		"schedule":            cfg.Schedule,
+		"min_confidence":      cfg.MinConfidence,
+		"target_layer":        cfg.TargetLayer,
 		"max_facts_per_cycle": cfg.MaxFactsPerCycle,
-		"vault_path":         cfg.VaultPath,
+		"vault_path":          cfg.VaultPath,
 	})
 }
 
@@ -3194,6 +3209,16 @@ func (s *Server) handleBeadSynthToggle(w http.ResponseWriter, r *http.Request) {
 
 	enabled := body.Enabled
 	s.deps.Config.Knowledge.BeadSynthesizer.Enabled = &enabled
+
+	if s.deps.BeadSynthesizer != nil {
+		if enabled {
+			s.deps.BeadSynthesizer.StartBackground(s.deps.Ctx)
+			s.logger.Info("bead synthesizer enabled via dashboard")
+		} else {
+			s.deps.BeadSynthesizer.Stop()
+			s.logger.Info("bead synthesizer disabled via dashboard")
+		}
+	}
 
 	if err := s.saveConfig(); err != nil {
 		s.logger.Error("failed to persist config after bead-synth toggle", "error", err)

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5240,11 +5240,26 @@ function burnAreaChart() {
       } catch (e) { console.error('toggle knowledge failed', e); }
     }
 
+    let _beadSynthStatus = null;
+    async function toggleBeadSynth(enabled) {
+      try {
+        await fetch('/api/knowledge/bead-synthesizer/enabled', { method: 'PUT', headers: {'Content-Type':'application/json'}, body: JSON.stringify({enabled}) });
+        await fetchBeadSynthStatus();
+        await fetchKnowledgeStats();
+      } catch (e) { console.error('toggle bead synth failed', e); }
+    }
+    async function fetchBeadSynthStatus() {
+      try {
+        const r = await fetch('/api/knowledge/bead-synthesizer');
+        if (r.ok) _beadSynthStatus = await r.json();
+      } catch (e) { _beadSynthStatus = null; }
+    }
+
     let _kbInitialLoad = true;
     let _kbRendered = false;
     async function fetchKnowledgeStats() {
       try {
-        const r = await fetch('/api/knowledge/stats');
+        const [r] = await Promise.all([fetch('/api/knowledge/stats'), fetchBeadSynthStatus()]);
         if (!r.ok) return;
         const prev = _kbCache;
         _kbCache = await r.json();
@@ -5559,7 +5574,17 @@ function burnAreaChart() {
         badge.style.color = 'white';
       }
 
-      let html = '<div style="display:flex;justify-content:flex-end;margin-bottom:8px"><button onclick="toggleKnowledge(false)" style="padding:4px 12px;background:none;border:1px solid #dc2626;color:#dc2626;border-radius:4px;cursor:pointer;font-size:0.72rem" title="Disable the knowledge base. Agents will no longer inject facts into prompts. Stored facts are preserved for when re-enabled.">Disable</button></div>';
+      const synthEnabled = _beadSynthStatus && _beadSynthStatus.enabled;
+      const synthRunning = _beadSynthStatus && _beadSynthStatus.running;
+      let html = '<div style="display:flex;justify-content:flex-end;gap:8px;margin-bottom:8px">';
+      if (synthEnabled) {
+        html += `<span style="font-size:0.72rem;color:#16a34a;display:flex;align-items:center;gap:4px" title="Bead synthesizer is ${synthRunning ? 'running' : 'enabled but not running'}. Schedule: ${escapeHtml((_beadSynthStatus||{}).schedule||'hourly')}"><span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:${synthRunning ? '#16a34a' : '#d97706'}"></span> Synth ${synthRunning ? 'active' : 'idle'}</span>`;
+        html += '<button onclick="toggleBeadSynth(false)" style="padding:4px 12px;background:none;border:1px solid #d97706;color:#d97706;border-radius:4px;cursor:pointer;font-size:0.72rem" title="Disable the bead synthesizer. Completed beads will no longer be automatically converted to wiki facts.">Pause Synth</button>';
+      } else {
+        html += '<button onclick="toggleBeadSynth(true)" style="padding:4px 12px;background:#2563eb;color:white;border:none;border-radius:4px;cursor:pointer;font-size:0.72rem" title="Enable the bead synthesizer. Completed beads will be automatically scanned and converted to wiki facts on an hourly schedule.">Enable Synth</button>';
+      }
+      html += '<button onclick="toggleKnowledge(false)" style="padding:4px 12px;background:none;border:1px solid #dc2626;color:#dc2626;border-radius:4px;cursor:pointer;font-size:0.72rem" title="Disable the knowledge base. Agents will no longer inject facts into prompts. Stored facts are preserved for when re-enabled.">Disable</button>';
+      html += '</div>';
 
       // Stats row
       const totalPages = layers.reduce((sum, l) => sum + (l.total_pages || 0), 0);

--- a/v2/pkg/knowledge/bead_synthesizer.go
+++ b/v2/pkg/knowledge/bead_synthesizer.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/beads"
@@ -30,6 +31,10 @@ type BeadSynthesizer struct {
 	config       BeadSynthesizerConfig
 	logger       *slog.Logger
 	vaultBaseDir string
+
+	mu       sync.Mutex
+	cancel   context.CancelFunc
+	running  bool
 }
 
 // NewBeadSynthesizer creates a synthesizer that bridges bead stores to the wiki.
@@ -64,6 +69,42 @@ func (s *BeadSynthesizer) Start(ctx context.Context) {
 			s.runOnce(ctx)
 		}
 	}
+}
+
+// StartBackground launches the synthesis loop in a goroutine and tracks its
+// lifecycle so it can be stopped and restarted via the dashboard toggle.
+func (s *BeadSynthesizer) StartBackground(parent context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.running {
+		return
+	}
+	ctx, cancel := context.WithCancel(parent)
+	s.cancel = cancel
+	s.running = true
+	go func() {
+		s.Start(ctx)
+		s.mu.Lock()
+		s.running = false
+		s.mu.Unlock()
+	}()
+}
+
+// Stop cancels the background synthesis loop.
+func (s *BeadSynthesizer) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cancel != nil {
+		s.cancel()
+		s.cancel = nil
+	}
+}
+
+// IsRunning returns whether the background synthesis loop is active.
+func (s *BeadSynthesizer) IsRunning() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.running
 }
 
 func (s *BeadSynthesizer) runOnce(ctx context.Context) {


### PR DESCRIPTION
## Summary

- Adds `StartBackground()`/`Stop()`/`IsRunning()` lifecycle methods to `BeadSynthesizer` so it can be started/stopped at runtime
- Wires `BeadSynthesizer` into dashboard `Dependencies` — the toggle endpoint now actually starts/stops the goroutine
- `handleKnowledgeToggle` cascades: enabling knowledge also starts the synthesizer; disabling stops it
- **Dashboard UI**: adds synth status indicator (green dot + "active"/"idle") and Enable/Pause toggle buttons in the Knowledge Base section
- Synthesizer is always created at boot when bead stores exist, but only started if both `knowledge.enabled` and `bead_synthesizer.enabled` are true
- Admins can now enable the synthesizer from the UI without a pod restart

## Test plan

- [x] `go build ./...` passes
- [x] All synthesizer tests pass
- [ ] Enable knowledge via dashboard → verify synthesizer starts (check logs for "bead synthesizer started via knowledge toggle")
- [ ] Click "Pause Synth" → verify synthesizer stops
- [ ] Click "Enable Synth" → verify it restarts
- [ ] Verify synthesized facts appear in bead-synth-wiki vault