### PR TITLE
feat: enrich bead-to-wiki facts with PR content + intelligent lifecycle

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -22,6 +22,8 @@ import (
 
 	"gopkg.in/natefinch/lumberjack.v2"
 
+	gh "github.com/google/go-github/v72/github"
+
 	"github.com/kubestellar/hive/v2/pkg/advisory"
 	"github.com/kubestellar/hive/v2/pkg/hub"
 	"github.com/kubestellar/hive/v2/pkg/agent"
@@ -664,13 +666,42 @@ func main() {
 				logger.Info("auto-connected bead-synth vault", "path", synthVaultPath)
 			}
 		}
+		var rawGH *gh.Client
+		if ghClient != nil {
+			rawGH = ghClient.GoGitHub()
+		}
+
+		var kRetention *knowledge.RetentionPolicy
+		if rp := cfg.Knowledge.BeadSynthesizer.RetentionPolicy; rp != nil {
+			kRetention = &knowledge.RetentionPolicy{
+				MaxBeads:               rp.MaxBeads,
+				ArchiveAfterSynthDays:  rp.ArchiveAfterSynthDays,
+				HighPriorityRetainDays: rp.HighPriorityRetainDays,
+				PreserveWithDeps:       rp.PreserveWithDeps,
+			}
+		} else {
+			kRetention = &knowledge.RetentionPolicy{
+				PreserveWithDeps: true,
+			}
+		}
+
 		beadSynth = knowledge.NewBeadSynthesizer(beadStores, knowledgeAPI, knowledge.BeadSynthesizerConfig{
 			Schedule:         cfg.Knowledge.BeadSynthesizer.Schedule,
 			MinConfidence:    cfg.Knowledge.BeadSynthesizer.MinConfidence,
 			TargetLayer:      cfg.Knowledge.BeadSynthesizer.TargetLayer,
 			MaxFactsPerCycle: cfg.Knowledge.BeadSynthesizer.MaxFactsPerCycle,
 			VaultPath:        synthVaultPath,
-		}, logger)
+			Org:              cfg.Project.Org,
+			Repos:            cfg.Project.Repos,
+			RetentionPolicy:  kRetention,
+		}, logger, rawGH)
+
+		if cleaned, err := beadSynth.CleanupVault(); err != nil {
+			logger.Warn("vault cleanup failed", "error", err)
+		} else if cleaned > 0 {
+			logger.Info("cleaned up low-quality bead-synth facts", "removed", cleaned)
+		}
+
 		if cfg.Knowledge.Enabled && cfg.Knowledge.BeadSynthesizer.IsEnabled() && knowledgeAPI != nil {
 			beadSynth.StartBackground(ctx)
 			logger.Info("bead-to-wiki synthesizer started",

--- a/v2/deploy/hive.yaml
+++ b/v2/deploy/hive.yaml
@@ -215,6 +215,11 @@ knowledge:
     target_layer: project
     max_facts_per_cycle: 20
     vault_path: /data/vaults/bead-synth-wiki
+    retention_policy:
+      max_beads: 5000
+      archive_after_synth_days: 7
+      high_priority_retain_days: 30
+      preserve_with_deps: true
   vaults:
     - name: hive-wiki
       path: /data/vaults/hive-wiki

--- a/v2/pkg/beads/beads.go
+++ b/v2/pkg/beads/beads.go
@@ -406,6 +406,88 @@ func (s *Store) Count() int {
 	return len(s.beads)
 }
 
+const archiveFileName = "archive.jsonl"
+
+// ArchivedBead is the compact representation written to the archive log.
+type ArchivedBead struct {
+	ID          string    `json:"id"`
+	Title       string    `json:"title"`
+	Type        BeadType  `json:"type"`
+	Priority    Priority  `json:"priority"`
+	ExternalRef string    `json:"external_ref,omitempty"`
+	ClosedAt    time.Time `json:"closed_at,omitempty"`
+	ArchivedAt  time.Time `json:"archived_at"`
+}
+
+// Archive writes a compact summary of the bead to archive.jsonl, then removes
+// it from the store. This preserves an audit trail without the full bead weight.
+func (s *Store) Archive(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	b, ok := s.beads[id]
+	if !ok {
+		return fmt.Errorf("bead %s not found", id)
+	}
+
+	entry := ArchivedBead{
+		ID:          b.ID,
+		Title:       b.Title,
+		Type:        b.Type,
+		Priority:    b.Priority,
+		ExternalRef: b.ExternalRef,
+		ArchivedAt:  time.Now().UTC(),
+	}
+	if b.ClosedAt != nil {
+		entry.ClosedAt = b.ClosedAt.Time
+	}
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return fmt.Errorf("marshaling archive entry: %w", err)
+	}
+
+	archivePath := filepath.Join(s.dir, archiveFileName)
+	f, err := os.OpenFile(archivePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("opening archive file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("writing archive entry: %w", err)
+	}
+
+	delete(s.beads, id)
+	return s.persist(nil)
+}
+
+// AllClosed returns all beads with done or closed status.
+func (s *Store) AllClosed() []*Bead {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var result []*Bead
+	for _, b := range s.beads {
+		if b.Status == StatusDone || b.Status == StatusClosed {
+			result = append(result, b)
+		}
+	}
+	return result
+}
+
+// HasOpenBead checks if a bead with the given ID exists and is not done/closed.
+func (s *Store) HasOpenBead(id string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	b, ok := s.beads[id]
+	if !ok {
+		return false
+	}
+	return b.Status != StatusDone && b.Status != StatusClosed
+}
+
 // Unsynthesized returns all done/closed beads that have not yet been
 // synthesized into wiki facts (i.e., missing the "synthesized_at" metadata key).
 func (s *Store) Unsynthesized() []*Bead {

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -43,12 +43,21 @@ type KnowledgeConfig struct {
 // BeadSynthesizerConfig controls automatic synthesis of completed beads into wiki facts.
 // Enabled defaults to true when knowledge is enabled; set to false to opt out.
 type BeadSynthesizerConfig struct {
-	Enabled          *bool   `yaml:"enabled,omitempty"`
-	Schedule         string  `yaml:"schedule"`
-	MinConfidence    float64 `yaml:"min_confidence"`
-	TargetLayer      string  `yaml:"target_layer"`
-	MaxFactsPerCycle int     `yaml:"max_facts_per_cycle"`
-	VaultPath        string  `yaml:"vault_path"`
+	Enabled          *bool            `yaml:"enabled,omitempty"`
+	Schedule         string           `yaml:"schedule"`
+	MinConfidence    float64          `yaml:"min_confidence"`
+	TargetLayer      string           `yaml:"target_layer"`
+	MaxFactsPerCycle int              `yaml:"max_facts_per_cycle"`
+	VaultPath        string           `yaml:"vault_path"`
+	RetentionPolicy  *RetentionPolicy `yaml:"retention_policy"`
+}
+
+// RetentionPolicy controls intelligent bead lifecycle management.
+type RetentionPolicy struct {
+	MaxBeads               int  `yaml:"max_beads"`
+	ArchiveAfterSynthDays  int  `yaml:"archive_after_synth_days"`
+	HighPriorityRetainDays int  `yaml:"high_priority_retain_days"`
+	PreserveWithDeps       bool `yaml:"preserve_with_deps"`
 }
 
 // IsEnabled returns whether bead synthesis is enabled (defaults to true).

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -23,6 +23,14 @@ type Client struct {
 	logger       *slog.Logger
 }
 
+// GoGitHub returns the underlying go-github client for direct API access.
+func (c *Client) GoGitHub() *gh.Client {
+	if c == nil {
+		return nil
+	}
+	return c.client
+}
+
 type Issue struct {
 	Repo           string    `json:"repo"`
 	Number         int       `json:"number"`

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -879,6 +879,11 @@ data:
         target_layer: project
         max_facts_per_cycle: 20
         vault_path: /data/vaults/bead-synth-wiki
+        retention_policy:
+          max_beads: 5000
+          archive_after_synth_days: 7
+          high_priority_retain_days: 30
+          preserve_with_deps: true
       vaults:
         - name: bead-synth-wiki
           path: /data/vaults/bead-synth-wiki

--- a/v2/pkg/knowledge/bead_lifecycle.go
+++ b/v2/pkg/knowledge/bead_lifecycle.go
@@ -1,0 +1,185 @@
+package knowledge
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"sort"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/beads"
+)
+
+const (
+	retentionBaseScore   = 100
+	retentionCritBonus   = 50
+	retentionHighBonus   = 30
+	retentionMedBonus    = 10
+	retentionBugBonus    = 20
+	retentionDecBonus    = 15
+	retentionAdvBonus    = 10
+	retentionFeatBonus   = 5
+	retentionChorePenalty = 10
+	retentionDepPinBonus = 100
+	retentionAgeDayDecay = 2
+	retentionSynthDecay  = 30
+	retentionArchiveThreshold = 0
+	retentionHeadroomRatio    = 0.8
+
+	defaultMaxBeads               = 5000
+	defaultArchiveAfterSynthDays  = 7
+	defaultHighPriorityRetainDays = 30
+)
+
+// BeadLifecycleManager applies signal-based archival to bead stores,
+// replacing the simple oldest-first eviction with retention scoring.
+type BeadLifecycleManager struct {
+	stores map[string]*beads.Store
+	policy *RetentionPolicy
+	logger *slog.Logger
+}
+
+// NewBeadLifecycleManager creates a lifecycle manager with the given policy.
+func NewBeadLifecycleManager(
+	stores map[string]*beads.Store,
+	policy *RetentionPolicy,
+	logger *slog.Logger,
+) *BeadLifecycleManager {
+	if policy.MaxBeads == 0 {
+		policy.MaxBeads = defaultMaxBeads
+	}
+	if policy.ArchiveAfterSynthDays == 0 {
+		policy.ArchiveAfterSynthDays = defaultArchiveAfterSynthDays
+	}
+	if policy.HighPriorityRetainDays == 0 {
+		policy.HighPriorityRetainDays = defaultHighPriorityRetainDays
+	}
+	return &BeadLifecycleManager{
+		stores: stores,
+		policy: policy,
+		logger: logger,
+	}
+}
+
+type scoredBead struct {
+	bead      *beads.Bead
+	agent     string
+	score     float64
+}
+
+// RunCulling scores all closed/done beads and archives those below the
+// retention threshold, stopping when counts drop to 80% of MaxBeads.
+func (lm *BeadLifecycleManager) RunCulling(_ context.Context) (int, error) {
+	now := time.Now().UTC()
+	target := int(math.Floor(float64(lm.policy.MaxBeads) * retentionHeadroomRatio))
+
+	var scored []scoredBead
+
+	for agentName, store := range lm.stores {
+		if store.Count() <= target {
+			continue
+		}
+
+		for _, b := range store.AllClosed() {
+			s := lm.retentionScore(b, agentName, now)
+			scored = append(scored, scoredBead{bead: b, agent: agentName, score: s})
+		}
+	}
+
+	sort.Slice(scored, func(i, j int) bool {
+		return scored[i].score < scored[j].score
+	})
+
+	archived := 0
+	for _, sb := range scored {
+		if sb.score > retentionArchiveThreshold {
+			break
+		}
+
+		store := lm.stores[sb.agent]
+		if store.Count() <= target {
+			continue
+		}
+
+		if err := store.Archive(sb.bead.ID); err != nil {
+			lm.logger.Warn("failed to archive bead",
+				"bead_id", sb.bead.ID, "agent", sb.agent, "error", err)
+			continue
+		}
+		archived++
+	}
+
+	return archived, nil
+}
+
+// retentionScore computes how valuable a bead is to keep.
+func (lm *BeadLifecycleManager) retentionScore(b *beads.Bead, agent string, now time.Time) float64 {
+	score := float64(retentionBaseScore)
+
+	switch b.Priority {
+	case beads.PriorityCritical:
+		score += retentionCritBonus
+	case beads.PriorityHigh:
+		score += retentionHighBonus
+	case beads.PriorityMedium:
+		score += retentionMedBonus
+	}
+
+	switch b.Type {
+	case beads.TypeBug:
+		score += retentionBugBonus
+	case beads.TypeDecision:
+		score += retentionDecBonus
+	case beads.TypeAdvisory:
+		score += retentionAdvBonus
+	case beads.TypeFeature:
+		score += retentionFeatBonus
+	case beads.TypeChore:
+		score -= retentionChorePenalty
+	}
+
+	if lm.policy.PreserveWithDeps && lm.hasOpenDependents(b, agent) {
+		score += retentionDepPinBonus
+	}
+
+	closedAt := b.UpdatedAt.Time
+	if b.ClosedAt != nil {
+		closedAt = b.ClosedAt.Time
+	}
+	daysSinceClosed := now.Sub(closedAt).Hours() / 24
+	score -= daysSinceClosed * retentionAgeDayDecay
+
+	if b.Meta("synthesized_at") != "" {
+		synthTime, err := time.Parse(time.RFC3339, b.Meta("synthesized_at"))
+		if err == nil {
+			daysSinceSynth := now.Sub(synthTime).Hours() / 24
+			if daysSinceSynth >= float64(lm.policy.ArchiveAfterSynthDays) {
+				score -= retentionSynthDecay
+			}
+		} else {
+			score -= retentionSynthDecay
+		}
+	}
+
+	return score
+}
+
+// hasOpenDependents checks if any bead in any store depends on this bead and is still open.
+func (lm *BeadLifecycleManager) hasOpenDependents(b *beads.Bead, _ string) bool {
+	for _, store := range lm.stores {
+		for _, other := range store.AllClosed() {
+			if other.Status == beads.StatusDone || other.Status == beads.StatusClosed {
+				continue
+			}
+		}
+
+		for _, dep := range b.DependsOn {
+			for _, store2 := range lm.stores {
+				if store2.HasOpenBead(dep) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/v2/pkg/knowledge/bead_synthesizer.go
+++ b/v2/pkg/knowledge/bead_synthesizer.go
@@ -6,10 +6,13 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	gh "github.com/google/go-github/v72/github"
 	"github.com/kubestellar/hive/v2/pkg/beads"
 )
 
@@ -21,16 +24,21 @@ const (
 	beadSynthHighPriorityBoost    = 0.1
 
 	beadSynthMetaKeySynthesizedAt = "synthesized_at"
+
+	prDescriptionMaxLen = 300
+	prEnricherCacheSize = 200
 )
 
 // BeadSynthesizer periodically scans completed beads across all agents and
 // synthesizes them into wiki facts for the shared knowledge layer.
 type BeadSynthesizer struct {
-	beadStores   map[string]*beads.Store
-	knowledgeAPI *KnowledgeAPI
-	config       BeadSynthesizerConfig
-	logger       *slog.Logger
-	vaultBaseDir string
+	beadStores       map[string]*beads.Store
+	knowledgeAPI     *KnowledgeAPI
+	config           BeadSynthesizerConfig
+	logger           *slog.Logger
+	vaultBaseDir     string
+	enricher         *PREnricher
+	lifecycleManager *BeadLifecycleManager
 
 	mu       sync.Mutex
 	cancel   context.CancelFunc
@@ -43,14 +51,30 @@ func NewBeadSynthesizer(
 	api *KnowledgeAPI,
 	config BeadSynthesizerConfig,
 	logger *slog.Logger,
+	ghClient *gh.Client,
 ) *BeadSynthesizer {
-	return &BeadSynthesizer{
+	s := &BeadSynthesizer{
 		beadStores:   stores,
 		knowledgeAPI: api,
 		config:       config,
 		logger:       logger,
 		vaultBaseDir: config.VaultPath,
 	}
+
+	if ghClient != nil && config.Org != "" {
+		s.enricher = NewPREnricher(ghClient, config.Org, config.Repos, logger)
+	}
+
+	if config.RetentionPolicy != nil {
+		s.lifecycleManager = NewBeadLifecycleManager(stores, config.RetentionPolicy, logger)
+	}
+
+	return s
+}
+
+// SetLifecycleManager attaches or replaces the lifecycle manager.
+func (s *BeadSynthesizer) SetLifecycleManager(lm *BeadLifecycleManager) {
+	s.lifecycleManager = lm
 }
 
 // Start runs the synthesis loop in the background until ctx is cancelled.
@@ -116,6 +140,19 @@ func (s *BeadSynthesizer) runOnce(ctx context.Context) {
 	if count > 0 {
 		s.logger.Info("bead synthesis cycle complete", "facts_synthesized", count)
 	}
+
+	if s.lifecycleManager != nil {
+		archived, err := s.lifecycleManager.RunCulling(ctx)
+		if err != nil {
+			s.logger.Warn("bead lifecycle culling failed", "error", err)
+		} else if archived > 0 {
+			s.logger.Info("bead lifecycle culling complete", "beads_archived", archived)
+		}
+	}
+
+	if s.enricher != nil {
+		s.enricher.ClearCache()
+	}
 }
 
 // beadCandidate pairs a bead with its source agent for provenance tracking.
@@ -154,9 +191,14 @@ func (s *BeadSynthesizer) RunSynthesis(ctx context.Context) (int, error) {
 			continue
 		}
 
+		body := s.buildEnrichedBody(ctx, c.bead, c.agent)
+		if body == "" {
+			continue
+		}
+
 		fact := ExtractedFact{
 			Title:      c.bead.Title,
-			Body:       BuildFactBody(c.bead, c.agent),
+			Body:       body,
 			Type:       factType,
 			Confidence: confidence,
 			Tags:       extractBeadTags(c.bead),
@@ -451,6 +493,273 @@ func (s *BeadSynthesizer) writeFactToVault(fact ExtractedFact) error {
 	}
 
 	s.knowledgeAPI.triggerVaultReindex(dir)
+	return nil
+}
+
+// buildEnrichedBody produces the fact body, enriching with GitHub PR data when possible.
+// Returns empty string if the bead is too low-quality to synthesize.
+func (s *BeadSynthesizer) buildEnrichedBody(ctx context.Context, b *beads.Bead, agent string) string {
+	baseBody := BuildFactBody(b, agent)
+
+	if s.enricher != nil && b.ExternalRef != "" {
+		enriched := s.enricher.EnrichBody(ctx, b, agent)
+		if enriched != "" {
+			return enriched
+		}
+	}
+
+	if isLowQualityMergeBead(b) && s.enricher == nil {
+		s.logger.Debug("skipping low-quality merge bead without enricher",
+			"bead_id", b.ID, "title", b.Title)
+		return ""
+	}
+
+	return baseBody
+}
+
+// isLowQualityMergeBead detects beads that are just PR merge event titles
+// with no substantive content.
+func isLowQualityMergeBead(b *beads.Bead) bool {
+	return strings.HasPrefix(b.Title, "Merged:") && strings.TrimSpace(b.Notes) == ""
+}
+
+// CleanupVault removes low-quality facts from the vault directory that were
+// previously synthesized without enrichment. Call at startup to purge junk.
+func (s *BeadSynthesizer) CleanupVault() (int, error) {
+	if s.vaultBaseDir == "" {
+		return 0, nil
+	}
+
+	entries, err := os.ReadDir(s.vaultBaseDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("reading vault dir: %w", err)
+	}
+
+	removed := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+
+		path := filepath.Join(s.vaultBaseDir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+
+		content := string(data)
+		if isJunkFact(content) {
+			if err := os.Remove(path); err != nil {
+				s.logger.Warn("failed to remove junk fact", "path", path, "error", err)
+				continue
+			}
+			removed++
+		}
+	}
+
+	if removed > 0 {
+		s.knowledgeAPI.triggerVaultReindex(s.vaultBaseDir)
+	}
+
+	return removed, nil
+}
+
+// isJunkFact detects vault files that contain only merge titles and metadata
+// lines (External/Source) with no substantive knowledge content.
+func isJunkFact(content string) bool {
+	bodyStart := strings.Index(content, "---\n")
+	if bodyStart < 0 {
+		return false
+	}
+	secondFence := strings.Index(content[bodyStart+4:], "---\n")
+	if secondFence < 0 {
+		return false
+	}
+
+	body := strings.TrimSpace(content[bodyStart+4+secondFence+4:])
+	if body == "" {
+		return true
+	}
+
+	if !strings.Contains(strings.ToLower(content), "merged:") {
+		return false
+	}
+
+	lines := strings.Split(body, "\n")
+	substantiveLines := 0
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "- External:") ||
+			strings.HasPrefix(trimmed, "- Source:") ||
+			strings.HasPrefix(trimmed, "- Severity:") ||
+			strings.HasPrefix(trimmed, "- File:") {
+			continue
+		}
+		substantiveLines++
+	}
+
+	return substantiveLines == 0
+}
+
+// PREnricher fetches structured PR data from GitHub to produce meaningful
+// fact bodies instead of just echoing bead titles.
+type PREnricher struct {
+	ghClient *gh.Client
+	org      string
+	repos    []string
+	logger   *slog.Logger
+	mu       sync.Mutex
+	cache    map[string]*gh.PullRequest
+}
+
+var (
+	ghRefPattern   = regexp.MustCompile(`^gh-(\d+)$`)
+	repoRefPattern = regexp.MustCompile(`^(?:([^/]+)/)?([^#]+)#(\d+)$`)
+)
+
+// NewPREnricher creates an enricher with the given GitHub client and repo context.
+func NewPREnricher(client *gh.Client, org string, repos []string, logger *slog.Logger) *PREnricher {
+	return &PREnricher{
+		ghClient: client,
+		org:      org,
+		repos:    repos,
+		logger:   logger,
+		cache:    make(map[string]*gh.PullRequest),
+	}
+}
+
+// ClearCache resets the in-memory PR cache between synthesis cycles.
+func (e *PREnricher) ClearCache() {
+	e.mu.Lock()
+	e.cache = make(map[string]*gh.PullRequest)
+	e.mu.Unlock()
+}
+
+// EnrichBody fetches PR data for a bead's ExternalRef and builds a fact body
+// with the PR description, labels, and change stats.
+func (e *PREnricher) EnrichBody(ctx context.Context, b *beads.Bead, agent string) string {
+	owner, repo, number := e.parseRef(b.ExternalRef)
+	if number == 0 {
+		return ""
+	}
+
+	pr := e.fetchPR(ctx, owner, repo, number)
+	if pr == nil {
+		return ""
+	}
+
+	var buf strings.Builder
+
+	desc := pr.GetBody()
+	if desc != "" {
+		desc = strings.TrimSpace(desc)
+		if len([]rune(desc)) > prDescriptionMaxLen {
+			desc = string([]rune(desc)[:prDescriptionMaxLen]) + "..."
+		}
+		buf.WriteString(desc)
+		buf.WriteString("\n")
+	}
+
+	buf.WriteString("\n")
+
+	if changed := pr.GetChangedFiles(); changed > 0 {
+		fmt.Fprintf(&buf, "- Changed: %d files (+%d, -%d)\n",
+			changed, pr.GetAdditions(), pr.GetDeletions())
+	}
+
+	var labelNames []string
+	for _, l := range pr.Labels {
+		labelNames = append(labelNames, l.GetName())
+	}
+	if len(labelNames) > 0 {
+		fmt.Fprintf(&buf, "- Labels: %s\n", strings.Join(labelNames, ", "))
+	}
+
+	if mergedAt := pr.GetMergedAt(); !mergedAt.IsZero() {
+		fmt.Fprintf(&buf, "- Merged: %s\n", mergedAt.Format("2006-01-02"))
+	}
+
+	fmt.Fprintf(&buf, "- Source: bead:%s/%s\n", agent, b.ID)
+
+	body := buf.String()
+	if len([]rune(body)) > beadSynthMaxBodyLen {
+		body = string([]rune(body)[:beadSynthMaxBodyLen]) + "..."
+	}
+
+	return body
+}
+
+// parseRef extracts owner, repo, and PR number from an ExternalRef string.
+func (e *PREnricher) parseRef(ref string) (string, string, int) {
+	if m := ghRefPattern.FindStringSubmatch(ref); m != nil {
+		n, _ := strconv.Atoi(m[1])
+		if len(e.repos) > 0 {
+			return e.org, e.repos[0], n
+		}
+		return e.org, "", n
+	}
+
+	if m := repoRefPattern.FindStringSubmatch(ref); m != nil {
+		owner := m[1]
+		if owner == "" {
+			owner = e.org
+		}
+		repo := m[2]
+		n, _ := strconv.Atoi(m[3])
+		return owner, repo, n
+	}
+
+	return "", "", 0
+}
+
+// fetchPR retrieves a PR from GitHub, using the in-memory cache first.
+func (e *PREnricher) fetchPR(ctx context.Context, owner, repo string, number int) *gh.PullRequest {
+	if e.ghClient == nil {
+		return nil
+	}
+	if repo == "" {
+		return e.fetchPRFromRepos(ctx, owner, number)
+	}
+
+	key := fmt.Sprintf("%s/%s#%d", owner, repo, number)
+
+	e.mu.Lock()
+	if cached, ok := e.cache[key]; ok {
+		e.mu.Unlock()
+		return cached
+	}
+	e.mu.Unlock()
+
+	pr, _, err := e.ghClient.PullRequests.Get(ctx, owner, repo, number)
+	if err != nil {
+		e.logger.Debug("failed to fetch PR for enrichment",
+			"owner", owner, "repo", repo, "number", number, "error", err)
+		return nil
+	}
+
+	e.mu.Lock()
+	if len(e.cache) < prEnricherCacheSize {
+		e.cache[key] = pr
+	}
+	e.mu.Unlock()
+
+	return pr
+}
+
+// fetchPRFromRepos tries each configured repo to find the PR.
+func (e *PREnricher) fetchPRFromRepos(ctx context.Context, owner string, number int) *gh.PullRequest {
+	for _, repo := range e.repos {
+		pr := e.fetchPR(ctx, owner, repo, number)
+		if pr != nil {
+			return pr
+		}
+	}
 	return nil
 }
 

--- a/v2/pkg/knowledge/bead_synthesizer_test.go
+++ b/v2/pkg/knowledge/bead_synthesizer_test.go
@@ -608,7 +608,7 @@ func newTestSynthesizer(t *testing.T, stores map[string]*beads.Store, wikiURL st
 		TargetLayer:      "project",
 		MaxFactsPerCycle: 20,
 		VaultPath:        t.TempDir(),
-	}, synthTestLogger())
+	}, synthTestLogger(), nil)
 }
 
 func TestRunSynthesis_BasicFlow(t *testing.T) {
@@ -690,7 +690,7 @@ func TestRunSynthesis_MaxFactsPerCycle(t *testing.T) {
 		TargetLayer:      "project",
 		MaxFactsPerCycle: 2,
 		VaultPath:        t.TempDir(),
-	}, synthTestLogger())
+	}, synthTestLogger(), nil)
 
 	count, err := synth.RunSynthesis(context.Background())
 	if err != nil {
@@ -723,7 +723,7 @@ func TestRunSynthesis_MinConfidenceFilter(t *testing.T) {
 		TargetLayer:      "project",
 		MaxFactsPerCycle: 20,
 		VaultPath:        t.TempDir(),
-	}, synthTestLogger())
+	}, synthTestLogger(), nil)
 
 	count, err := synth.RunSynthesis(context.Background())
 	if err != nil {
@@ -734,6 +734,218 @@ func TestRunSynthesis_MinConfidenceFilter(t *testing.T) {
 	}
 	if len(*ingested) != 0 {
 		t.Errorf("ingested = %d, want 0", len(*ingested))
+	}
+}
+
+func TestPREnricher_ParseRef_GhFormat(t *testing.T) {
+	e := NewPREnricher(nil, "kubestellar", []string{"console", "docs"}, synthTestLogger())
+
+	owner, repo, num := e.parseRef("gh-42")
+	if owner != "kubestellar" || repo != "console" || num != 42 {
+		t.Errorf("parseRef(gh-42) = %q, %q, %d; want kubestellar, console, 42", owner, repo, num)
+	}
+}
+
+func TestPREnricher_ParseRef_RepoHash(t *testing.T) {
+	e := NewPREnricher(nil, "kubestellar", []string{"console"}, synthTestLogger())
+
+	owner, repo, num := e.parseRef("docs#123")
+	if owner != "kubestellar" || repo != "docs" || num != 123 {
+		t.Errorf("parseRef(docs#123) = %q, %q, %d; want kubestellar, docs, 123", owner, repo, num)
+	}
+}
+
+func TestPREnricher_ParseRef_OrgRepoHash(t *testing.T) {
+	e := NewPREnricher(nil, "kubestellar", nil, synthTestLogger())
+
+	owner, repo, num := e.parseRef("other-org/my-repo#99")
+	if owner != "other-org" || repo != "my-repo" || num != 99 {
+		t.Errorf("parseRef(other-org/my-repo#99) = %q, %q, %d; want other-org, my-repo, 99", owner, repo, num)
+	}
+}
+
+func TestPREnricher_ParseRef_Invalid(t *testing.T) {
+	e := NewPREnricher(nil, "kubestellar", nil, synthTestLogger())
+
+	_, _, num := e.parseRef("not-a-ref")
+	if num != 0 {
+		t.Errorf("parseRef(not-a-ref) num = %d; want 0", num)
+	}
+}
+
+func TestPREnricher_FallbackOnNilClient(t *testing.T) {
+	e := NewPREnricher(nil, "kubestellar", []string{"console"}, synthTestLogger())
+
+	b := &beads.Bead{ID: "abc", ExternalRef: "gh-1"}
+	body := e.EnrichBody(context.Background(), b, "scanner")
+	if body != "" {
+		t.Errorf("EnrichBody with nil client should return empty, got %q", body)
+	}
+}
+
+func TestIsLowQualityMergeBead(t *testing.T) {
+	tests := []struct {
+		title string
+		notes string
+		want  bool
+	}{
+		{"Merged: console#100 — add feature", "", true},
+		{"Merged: docs#5 — fix typo", "some notes", false},
+		{"Found a bug in auth handler", "", false},
+	}
+
+	for _, tt := range tests {
+		b := &beads.Bead{Title: tt.title, Notes: tt.notes}
+		got := isLowQualityMergeBead(b)
+		if got != tt.want {
+			t.Errorf("isLowQualityMergeBead(%q, %q) = %v; want %v", tt.title, tt.notes, got, tt.want)
+		}
+	}
+}
+
+func TestIsJunkFact(t *testing.T) {
+	junk := "---\ntitle: Merged: console-marketplace#228\ntype: pattern\n---\n\n- External: gh-228\n- Source: bead:scanner/abc123\n"
+	if !isJunkFact(junk) {
+		t.Error("expected junk fact to be detected")
+	}
+
+	good := "---\ntitle: Auth handler pattern\ntype: pattern\n---\n\nAlways validate OAuth tokens before checking session cookies.\n- Source: bead:scanner/xyz\n"
+	if isJunkFact(good) {
+		t.Error("expected good fact not to be junk")
+	}
+
+	noMerge := "---\ntitle: Something else\ntype: gotcha\n---\n\n- External: gh-5\n- Source: bead:scanner/def\n"
+	if isJunkFact(noMerge) {
+		t.Error("non-merge fact with only metadata should not be junk")
+	}
+}
+
+func TestCleanupVault_RemovesJunk(t *testing.T) {
+	vaultDir := t.TempDir()
+
+	junk := "---\ntitle: Merged: console#100 — updated README\ntype: pattern\nconfidence: 0.70\nsource: bead:scanner/abc\n---\n\n- External: gh-100\n- Source: bead:scanner/abc\n"
+	good := "---\ntitle: Always check OAuth scopes\ntype: gotcha\nconfidence: 0.80\n---\n\nWhen handling OAuth callbacks, always verify the returned scopes match what was requested.\n- Source: bead:guide/xyz\n"
+
+	os.WriteFile(filepath.Join(vaultDir, "merged-console100.md"), []byte(junk), 0644)
+	os.WriteFile(filepath.Join(vaultDir, "oauth-scopes.md"), []byte(good), 0644)
+
+	api := NewKnowledgeAPI(nil, KnowledgeConfig{Enabled: true}, synthTestLogger())
+	synth := NewBeadSynthesizer(nil, api, BeadSynthesizerConfig{
+		VaultPath: vaultDir,
+	}, synthTestLogger(), nil)
+
+	removed, err := synth.CleanupVault()
+	if err != nil {
+		t.Fatalf("CleanupVault failed: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("removed = %d; want 1", removed)
+	}
+
+	entries, _ := os.ReadDir(vaultDir)
+	mdCount := 0
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".md") {
+			mdCount++
+		}
+	}
+	if mdCount != 1 {
+		t.Errorf("remaining md files = %d; want 1", mdCount)
+	}
+}
+
+func TestRetentionScore_Priority(t *testing.T) {
+	policy := &RetentionPolicy{PreserveWithDeps: false}
+	stores := map[string]*beads.Store{}
+	lm := NewBeadLifecycleManager(stores, policy, synthTestLogger())
+
+	now := time.Now().UTC()
+	base := &beads.Bead{
+		Type:     beads.TypeTask,
+		Priority: beads.PriorityMinor,
+		Status:   beads.StatusClosed,
+	}
+
+	critical := *base
+	critical.Priority = beads.PriorityCritical
+
+	scoreLow := lm.retentionScore(base, "scanner", now)
+	scoreHigh := lm.retentionScore(&critical, "scanner", now)
+
+	if scoreHigh <= scoreLow {
+		t.Errorf("critical priority score (%f) should be higher than minor (%f)", scoreHigh, scoreLow)
+	}
+}
+
+func TestRetentionScore_SynthDecay(t *testing.T) {
+	policy := &RetentionPolicy{
+		ArchiveAfterSynthDays: 7,
+		PreserveWithDeps:      false,
+	}
+	stores := map[string]*beads.Store{}
+	lm := NewBeadLifecycleManager(stores, policy, synthTestLogger())
+
+	now := time.Now().UTC()
+	eightDaysAgo := now.Add(-8 * 24 * time.Hour)
+
+	unsynthed := &beads.Bead{
+		Type:     beads.TypeBug,
+		Priority: beads.PriorityMedium,
+		Status:   beads.StatusClosed,
+	}
+
+	synthed := *unsynthed
+	synthed.Metadata = map[string]interface{}{
+		"synthesized_at": eightDaysAgo.Format(time.RFC3339),
+	}
+
+	scoreUnsynthed := lm.retentionScore(unsynthed, "scanner", now)
+	scoreSynthed := lm.retentionScore(&synthed, "scanner", now)
+
+	if scoreSynthed >= scoreUnsynthed {
+		t.Errorf("synthesized bead score (%f) should be lower than unsynthesized (%f)", scoreSynthed, scoreUnsynthed)
+	}
+}
+
+func TestBeadArchive(t *testing.T) {
+	dir := t.TempDir()
+	store, err := beads.NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	b, err := store.Create("test bead", beads.TypeBug, beads.PriorityHigh, "scanner", "gh-1")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	store.Close(b.ID)
+
+	if store.Count() != 1 {
+		t.Fatalf("count = %d before archive; want 1", store.Count())
+	}
+
+	if err := store.Archive(b.ID); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	if store.Count() != 0 {
+		t.Errorf("count = %d after archive; want 0", store.Count())
+	}
+
+	archiveData, err := os.ReadFile(filepath.Join(dir, "archive.jsonl"))
+	if err != nil {
+		t.Fatalf("reading archive: %v", err)
+	}
+	if !strings.Contains(string(archiveData), "test bead") {
+		t.Error("archive.jsonl should contain the bead title")
+	}
+
+	var entry beads.ArchivedBead
+	if err := json.Unmarshal(archiveData[:len(archiveData)-1], &entry); err != nil {
+		t.Fatalf("unmarshal archive entry: %v", err)
+	}
+	if entry.ID != b.ID {
+		t.Errorf("archived ID = %q; want %q", entry.ID, b.ID)
 	}
 }
 

--- a/v2/pkg/knowledge/filestore.go
+++ b/v2/pkg/knowledge/filestore.go
@@ -1,6 +1,7 @@
 package knowledge
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -11,6 +12,8 @@ import (
 	"sync"
 	"time"
 )
+
+const accessCountsFile = "access_counts.json"
 
 const (
 	maxFileSizeBytes = 512 * 1024 // skip files larger than 512KB
@@ -66,6 +69,7 @@ func NewFileStore(rootDir string, name string, logger *slog.Logger) (*FileStore,
 		accessCounts: make(map[string]int),
 	}
 
+	s.loadAccessCounts()
 	s.reindex()
 	return s, nil
 }
@@ -150,6 +154,8 @@ func (s *FileStore) reindex() {
 			"page_delta", len(pages)-prevCount,
 		)
 	}
+
+	s.persistAccessCounts()
 }
 
 func (s *FileStore) refreshIfStale() {
@@ -451,4 +457,47 @@ func containsTag(tags []string, tag string) bool {
 		}
 	}
 	return false
+}
+
+// loadAccessCounts reads persisted access counts from disk.
+func (s *FileStore) loadAccessCounts() {
+	path := filepath.Join(s.rootDir, accessCountsFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+
+	var counts map[string]int
+	if err := json.Unmarshal(data, &counts); err != nil {
+		s.logger.Warn("corrupted access counts file, resetting", "path", path, "error", err)
+		return
+	}
+
+	s.mu.Lock()
+	s.accessCounts = counts
+	s.mu.Unlock()
+}
+
+// persistAccessCounts writes the current access counts to disk.
+func (s *FileStore) persistAccessCounts() {
+	s.mu.RLock()
+	if len(s.accessCounts) == 0 {
+		s.mu.RUnlock()
+		return
+	}
+	data, err := json.Marshal(s.accessCounts)
+	s.mu.RUnlock()
+
+	if err != nil {
+		s.logger.Warn("failed to marshal access counts", "error", err)
+		return
+	}
+
+	path := filepath.Join(s.rootDir, accessCountsFile)
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
+		s.logger.Warn("failed to write access counts", "path", path, "error", err)
+		return
+	}
+	os.Rename(tmpPath, path)
 }

--- a/v2/pkg/knowledge/types.go
+++ b/v2/pkg/knowledge/types.go
@@ -60,12 +60,23 @@ type KnowledgeConfig struct {
 // BeadSynthesizerConfig controls automatic synthesis of completed beads into wiki facts.
 // Enabled defaults to true when knowledge is enabled; set to false to opt out.
 type BeadSynthesizerConfig struct {
-	Enabled          *bool   `yaml:"enabled,omitempty"   json:"enabled"`
-	Schedule         string  `yaml:"schedule"            json:"schedule"`
-	MinConfidence    float64 `yaml:"min_confidence"      json:"min_confidence"`
-	TargetLayer      string  `yaml:"target_layer"        json:"target_layer"`
-	MaxFactsPerCycle int     `yaml:"max_facts_per_cycle" json:"max_facts_per_cycle"`
-	VaultPath        string  `yaml:"vault_path"          json:"vault_path"`
+	Enabled          *bool            `yaml:"enabled,omitempty"    json:"enabled"`
+	Schedule         string           `yaml:"schedule"             json:"schedule"`
+	MinConfidence    float64          `yaml:"min_confidence"       json:"min_confidence"`
+	TargetLayer      string           `yaml:"target_layer"         json:"target_layer"`
+	MaxFactsPerCycle int              `yaml:"max_facts_per_cycle"  json:"max_facts_per_cycle"`
+	VaultPath        string           `yaml:"vault_path"           json:"vault_path"`
+	Org              string           `yaml:"org"                  json:"org"`
+	Repos            []string         `yaml:"repos"                json:"repos"`
+	RetentionPolicy  *RetentionPolicy `yaml:"retention_policy"     json:"retention_policy,omitempty"`
+}
+
+// RetentionPolicy controls intelligent bead lifecycle management.
+type RetentionPolicy struct {
+	MaxBeads               int  `yaml:"max_beads"                json:"max_beads"`
+	ArchiveAfterSynthDays  int  `yaml:"archive_after_synth_days" json:"archive_after_synth_days"`
+	HighPriorityRetainDays int  `yaml:"high_priority_retain_days" json:"high_priority_retain_days"`
+	PreserveWithDeps       bool `yaml:"preserve_with_deps"       json:"preserve_with_deps"`
 }
 
 // IsEnabled returns whether bead synthesis is enabled (defaults to true).


### PR DESCRIPTION
## Summary

- **PR Enrichment**: When the synthesizer encounters a bead linked to a PR (`gh-NNN` or `repo#NNN`), it now fetches the PR description, labels, and change stats from GitHub to build a meaningful wiki fact — instead of just echoing the merge title
- **Quality Gate**: Beads that are just merge event titles with no content are now skipped unless the enricher can add substance
- **Vault Cleanup**: On startup, removes existing junk facts (merge-title-only entries with no real knowledge content)
- **Intelligent Lifecycle**: Replaces simple oldest-first eviction with signal-based retention scoring (priority, type, dependency chains, synthesis status, age) — beads are archived to `archive.jsonl` instead of deleted
- **Access Count Persistence**: Fact usage counts in FileStore now survive restarts via `access_counts.json`

## Files Changed

| File | Change |
|------|--------|
| `v2/pkg/knowledge/bead_synthesizer.go` | PREnricher, quality gate, CleanupVault, enriched body builder |
| `v2/pkg/knowledge/bead_lifecycle.go` | NEW — BeadLifecycleManager with retention scoring |
| `v2/pkg/knowledge/types.go` | RetentionPolicy type, Org/Repos config fields |
| `v2/pkg/knowledge/filestore.go` | Access count persistence (load/save) |
| `v2/pkg/beads/beads.go` | Archive method, AllClosed, HasOpenBead |
| `v2/pkg/github/client.go` | GoGitHub() accessor |
| `v2/pkg/config/config.go` | RetentionPolicy config struct |
| `v2/cmd/hive/main.go` | Wire enricher, lifecycle manager, vault cleanup |
| `v2/deploy/hive.yaml` | retention_policy defaults |
| `v2/pkg/hub/saas_provision.go` | retention_policy in provisioning template |

## Test plan

- [x] 11 new tests: enricher ref parsing (4 formats), nil-client fallback, quality gate, junk detection, vault cleanup, retention scoring (priority + synth decay), bead archival
- [x] All existing synthesizer tests pass unchanged
- [x] All beads package tests pass
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [ ] Deploy to hosted instance and verify wiki facts contain PR descriptions
- [ ] Verify old junk facts are cleaned up on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)