### PR TITLE
feat: config API for GitHub App setup + webhook auto-push

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -810,6 +810,37 @@ func main() {
 				}
 			}
 		},
+		ReinitGitHubFunc: func(newAppID, newInstallationID int64, keyFile string) error {
+			newAppAuth, err := github.NewAppAuth(newAppID, newInstallationID, keyFile, logger, cfg.GitHub.ResolvedAPIURL())
+			if err != nil {
+				return fmt.Errorf("initializing app auth: %w", err)
+			}
+			newClient := github.NewClientFromApp(newAppAuth, cfg.Project.Org, cfg.Project.Repos, logger)
+			if len(cfg.Governor.Labels.Exempt) > 0 {
+				newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
+			}
+
+			ghClient = newClient
+			appAuth = newAppAuth
+			dashSrv.UpdateGitHubClient(newClient, newAppAuth)
+			logger.Info("github client reinitialized via config API", "app_id", newAppID, "installation_id", newInstallationID)
+
+			primaryRepo := cfg.Project.PrimaryRepo
+			if primaryRepo == "" && len(cfg.Project.Repos) > 0 {
+				primaryRepo = cfg.Project.Repos[0]
+			}
+			if primaryRepo != "" {
+				num, advErr := ghClient.EnsureAdvisoryIssue(ctx, primaryRepo)
+				if advErr != nil {
+					logger.Warn("advisory issue creation failed after reinit", "repo", primaryRepo, "error", advErr)
+				} else {
+					advisoryIssues[primaryRepo] = num
+					os.Setenv("HIVE_ADVISORY_ISSUE", fmt.Sprintf("%d", num))
+					logger.Info("advisory issue ready after reinit", "repo", primaryRepo, "number", num)
+				}
+			}
+			return nil
+		},
 	})
 
 	dashSrv.SetGitHubAppRequired(githubAppRequired)

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -94,6 +94,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("POST /api/config/governor/agents", s.handleGovernorAddAgent)
 	s.mux.HandleFunc("DELETE /api/config/governor/agents/{name}", s.handleGovernorRemoveAgent)
 	s.mux.HandleFunc("PUT /api/config/governor/repos", s.handleGovernorRepos)
+	s.mux.HandleFunc("PUT /api/config/github", s.handleConfigGitHub)
 
 	s.mux.HandleFunc("GET /api/agents", s.handleAgentsList)
 	s.mux.HandleFunc("POST /api/agents", s.handleAgentCreate)
@@ -2953,6 +2954,87 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 	}
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})
+}
+
+// --- GitHub config endpoint ---
+
+func (s *Server) handleConfigGitHub(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		AppID          *int64  `json:"app_id"`
+		InstallationID *int64  `json:"installation_id"`
+		KeyFile        string  `json:"key_file"`
+		PrivateKey     string  `json:"private_key"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+
+	if body.AppID == nil && body.InstallationID == nil && body.KeyFile == "" && body.PrivateKey == "" {
+		jsonError(w, "at least one field required: app_id, installation_id, key_file, private_key", http.StatusBadRequest)
+		return
+	}
+
+	cfg := s.deps.Config
+
+	if body.PrivateKey != "" {
+		keyPath := cfg.GitHub.KeyFile
+		if keyPath == "" {
+			keyPath = "/secrets/gh-app-key.pem"
+		}
+		if body.KeyFile != "" {
+			keyPath = body.KeyFile
+		}
+		if err := os.MkdirAll(filepath.Dir(keyPath), 0o755); err != nil {
+			s.logger.Warn("could not create key directory, falling back to /data", "path", keyPath, "error", err)
+			keyPath = "/data/gh-app-key.pem"
+		}
+		const keyFileMode = 0o600
+		if err := os.WriteFile(keyPath, []byte(body.PrivateKey), keyFileMode); err != nil {
+			jsonError(w, fmt.Sprintf("failed to write key file: %v", err), http.StatusInternalServerError)
+			return
+		}
+		cfg.GitHub.KeyFile = keyPath
+		s.logger.Info("github app private key written", "path", keyPath)
+	} else if body.KeyFile != "" {
+		cfg.GitHub.KeyFile = body.KeyFile
+	}
+
+	if body.AppID != nil {
+		cfg.GitHub.AppID = *body.AppID
+	}
+	if body.InstallationID != nil {
+		cfg.GitHub.InstallationID = *body.InstallationID
+	}
+
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist github config", "error", err)
+		jsonError(w, "failed to save config", http.StatusInternalServerError)
+		return
+	}
+
+	result := map[string]interface{}{
+		"status":          "updated",
+		"app_id":          cfg.GitHub.AppID,
+		"installation_id": cfg.GitHub.InstallationID,
+		"key_file":        cfg.GitHub.KeyFile,
+	}
+
+	if cfg.GitHub.AppID != 0 && cfg.GitHub.InstallationID != 0 && cfg.GitHub.KeyFile != "" {
+		if s.deps.ReinitGitHubFunc != nil {
+			if err := s.deps.ReinitGitHubFunc(cfg.GitHub.AppID, cfg.GitHub.InstallationID, cfg.GitHub.KeyFile); err != nil {
+				s.logger.Error("github client reinit failed", "error", err)
+				result["reinit"] = "failed"
+				result["reinit_error"] = err.Error()
+			} else {
+				result["reinit"] = "ok"
+				s.SetGitHubAppRequired(false)
+			}
+		}
+	}
+
+	s.refreshAndPersist()
+	jsonResponse(w, result)
 }
 
 // --- Sidebar endpoints ---

--- a/v2/pkg/dashboard/deps.go
+++ b/v2/pkg/dashboard/deps.go
@@ -42,6 +42,7 @@ type Dependencies struct {
 	SetUserClient    func(token string)
 	EnumerateFunc      func()
 	AdvisoryResetFunc  func(newPrimaryRepo string)
+	ReinitGitHubFunc   func(appID, installationID int64, keyFile string) error
 }
 
 type NousState struct {

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -633,6 +633,15 @@ func (s *Server) IsGitHubAppRequired() bool {
 	return s.githubAppRequired
 }
 
+// UpdateGitHubClient swaps the GitHub client and app auth references stored in
+// the dashboard dependencies. Called after the config API reinitializes app auth.
+func (s *Server) UpdateGitHubClient(client *github.Client, auth *github.AppAuth) {
+	if s.deps != nil {
+		s.deps.GHClient = client
+		s.deps.GHAppAuth = auth
+	}
+}
+
 func (s *Server) SetGitHubAppRecheckFn(fn func() bool) {
 	s.githubAppRecheckFn = fn
 }

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -171,6 +171,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash string) *HubServer {
 	s.mux.HandleFunc("POST /api/contribute/register", s.handleContributeProxy)
 	s.mux.HandleFunc("GET /api/contribute/status", s.handleContributeStatus)
 	s.mux.HandleFunc("GET /api/contribute/ws", s.handleContributeWSProxy)
+	s.mux.HandleFunc("POST /api/github/webhook", s.handleGitHubWebhook)
 	s.mux.HandleFunc("GET /learn", s.serveStatic("static/learn.html"))
 	s.mux.HandleFunc("GET /get-started", s.serveStatic("static/get-started.html"))
 	s.mux.HandleFunc("GET /api/docs", s.serveStatic("static/api-docs.html"))

--- a/v2/pkg/hub/webhook.go
+++ b/v2/pkg/hub/webhook.go
@@ -205,8 +205,10 @@ func (s *HubServer) pushGitHubConfigToSpoke(hive *RegistryEntry, appID, installa
 	)
 }
 
+const sharedKeyNamespace = "hive-shared"
+const sharedKeySecretName = "hive-app-key"
+
 func (s *HubServer) loadAppPrivateKey(hive *RegistryEntry) string {
-	ns := "hive-hosted-" + hive.ID
 	clusterID := hive.ClusterID
 	if clusterID == "" {
 		clusterID = "hive-oke"
@@ -218,6 +220,8 @@ func (s *HubServer) loadAppPrivateKey(hive *RegistryEntry) string {
 		return ""
 	}
 
+	// First: check the hive's own secret (already configured hives).
+	ns := "hive-hosted-" + hive.ID
 	out, err := kubectlForCluster(&cluster, "get", "secret", "hive-secrets", "-n", ns,
 		"-o", "jsonpath={.data.gh-app-key\\.pem}").Output()
 	if err == nil && len(out) > 0 {
@@ -226,37 +230,20 @@ func (s *HubServer) loadAppPrivateKey(hive *RegistryEntry) string {
 		}
 	}
 
-	consoleNS := s.findConsoleHiveNamespace()
-	if consoleNS == "" {
-		return ""
-	}
-	out, err = kubectlForCluster(&cluster, "get", "secret", "hive-secrets", "-n", consoleNS,
+	// Fallback: read from the shared namespace (cluster-scoped, independent of any hive).
+	out, err = kubectlForCluster(&cluster, "get", "secret", sharedKeySecretName, "-n", sharedKeyNamespace,
 		"-o", "jsonpath={.data.gh-app-key\\.pem}").Output()
 	if err != nil || len(out) == 0 {
+		s.logger.Warn("app key not found in shared namespace", "cluster_id", clusterID, "namespace", sharedKeyNamespace)
 		return ""
 	}
 
 	decoded, err := base64Decode(string(out))
 	if err != nil {
-		s.logger.Warn("failed to decode app key from console hive", "error", err)
+		s.logger.Warn("failed to decode app key from shared secret", "error", err)
 		return ""
 	}
 	return decoded
-}
-
-func (s *HubServer) findConsoleHiveNamespace() string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	for _, h := range s.registry.Hives {
-		if strings.EqualFold(h.Org, "kubestellar") {
-			for _, r := range h.Repos {
-				if r == "console" {
-					return "hive-hosted-" + h.ID
-				}
-			}
-		}
-	}
-	return ""
 }
 
 func (s *HubServer) loadSpokeAuthToken(hive *RegistryEntry) string {

--- a/v2/pkg/hub/webhook.go
+++ b/v2/pkg/hub/webhook.go
@@ -1,0 +1,309 @@
+package hub
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	webhookSecretEnvVar = "GITHUB_WEBHOOK_SECRET"
+	webhookSecretPath   = "/data/saas/webhook-secret.key"
+	webhookMaxBodyBytes = 256 * 1024
+	webhookPushTimeout  = 30 * time.Second
+)
+
+type installationEvent struct {
+	Action       string `json:"action"`
+	Installation struct {
+		ID      int64 `json:"id"`
+		Account struct {
+			Login string `json:"login"`
+		} `json:"account"`
+		AppID int64 `json:"app_id"`
+	} `json:"installation"`
+	Repositories []struct {
+		Name     string `json:"name"`
+		FullName string `json:"full_name"`
+	} `json:"repositories"`
+}
+
+func (s *HubServer) handleGitHubWebhook(w http.ResponseWriter, r *http.Request) {
+	event := r.Header.Get("X-GitHub-Event")
+	if event == "" {
+		http.Error(w, `{"error":"missing X-GitHub-Event header"}`, http.StatusBadRequest)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, webhookMaxBodyBytes))
+	if err != nil {
+		http.Error(w, `{"error":"failed to read body"}`, http.StatusBadRequest)
+		return
+	}
+
+	if secret := loadWebhookSecret(); secret != "" {
+		sig := r.Header.Get("X-Hub-Signature-256")
+		if !verifyWebhookSignature(body, sig, secret) {
+			s.logger.Warn("webhook signature verification failed")
+			http.Error(w, `{"error":"invalid signature"}`, http.StatusUnauthorized)
+			return
+		}
+	}
+
+	switch event {
+	case "installation", "installation_repositories":
+		s.handleInstallationEvent(body)
+	default:
+		s.logger.Debug("ignoring webhook event", "event", event)
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{"status":"ok"}`))
+}
+
+func (s *HubServer) handleInstallationEvent(body []byte) {
+	var evt installationEvent
+	if err := json.Unmarshal(body, &evt); err != nil {
+		s.logger.Warn("failed to parse installation event", "error", err)
+		return
+	}
+
+	if evt.Action != "created" && evt.Action != "added" {
+		s.logger.Debug("ignoring installation event", "action", evt.Action)
+		return
+	}
+
+	org := evt.Installation.Account.Login
+	installationID := evt.Installation.ID
+	appID := evt.Installation.AppID
+
+	repos := make([]string, 0, len(evt.Repositories))
+	for _, r := range evt.Repositories {
+		repos = append(repos, r.Name)
+	}
+
+	s.logger.Info("github app installation detected",
+		"action", evt.Action,
+		"org", org,
+		"installation_id", installationID,
+		"app_id", appID,
+		"repos", repos,
+	)
+
+	hive := s.findHiveByOrgRepos(org, repos)
+	if hive == nil {
+		s.logger.Info("no matching hive found for installation", "org", org, "repos", repos)
+		return
+	}
+
+	if hive.DashboardURL == "" {
+		s.logger.Warn("matching hive has no dashboard URL", "hive_id", hive.ID)
+		return
+	}
+
+	s.logger.Info("pushing github app config to spoke",
+		"hive_id", hive.ID,
+		"dashboard_url", hive.DashboardURL,
+		"installation_id", installationID,
+	)
+
+	go s.pushGitHubConfigToSpoke(hive, appID, installationID)
+}
+
+func (s *HubServer) findHiveByOrgRepos(org string, repos []string) *RegistryEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	repoSet := make(map[string]bool, len(repos))
+	for _, r := range repos {
+		repoSet[strings.ToLower(r)] = true
+	}
+
+	for i := range s.registry.Hives {
+		h := &s.registry.Hives[i]
+		if !strings.EqualFold(h.Org, org) {
+			continue
+		}
+		for _, hiveRepo := range h.Repos {
+			if repoSet[strings.ToLower(hiveRepo)] {
+				return h
+			}
+		}
+		if repoSet[strings.ToLower(h.PrimaryRepo)] {
+			return h
+		}
+	}
+	return nil
+}
+
+func (s *HubServer) pushGitHubConfigToSpoke(hive *RegistryEntry, appID, installationID int64) {
+	privateKey := s.loadAppPrivateKey(hive)
+	if privateKey == "" {
+		s.logger.Warn("could not load app private key for spoke push", "hive_id", hive.ID)
+	}
+
+	payload := map[string]interface{}{
+		"app_id":          appID,
+		"installation_id": installationID,
+	}
+	if privateKey != "" {
+		payload["private_key"] = privateKey
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		s.logger.Error("failed to marshal config payload", "error", err)
+		return
+	}
+
+	spokeURL := strings.TrimRight(hive.DashboardURL, "/") + "/api/config/github"
+
+	ctx, cancel := context.WithTimeout(context.Background(), webhookPushTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, spokeURL, bytes.NewReader(body))
+	if err != nil {
+		s.logger.Error("failed to create spoke request", "error", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	authToken := s.loadSpokeAuthToken(hive)
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		s.logger.Error("failed to push config to spoke", "hive_id", hive.ID, "error", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode >= http.StatusBadRequest {
+		s.logger.Error("spoke rejected config push",
+			"hive_id", hive.ID,
+			"status", resp.StatusCode,
+			"body", string(respBody),
+		)
+		return
+	}
+
+	s.logger.Info("github app config pushed to spoke",
+		"hive_id", hive.ID,
+		"status", resp.StatusCode,
+		"response", string(respBody),
+	)
+}
+
+func (s *HubServer) loadAppPrivateKey(hive *RegistryEntry) string {
+	ns := "hive-hosted-" + hive.ID
+	clusterID := hive.ClusterID
+	if clusterID == "" {
+		clusterID = "hive-oke"
+	}
+
+	cluster, ok := s.clusters[clusterID]
+	if !ok {
+		s.logger.Warn("cluster not found for key lookup", "cluster_id", clusterID)
+		return ""
+	}
+
+	out, err := kubectlForCluster(&cluster, "get", "secret", "hive-secrets", "-n", ns,
+		"-o", "jsonpath={.data.gh-app-key\\.pem}").Output()
+	if err == nil && len(out) > 0 {
+		if decoded, decErr := base64Decode(string(out)); decErr == nil && strings.HasPrefix(strings.TrimSpace(decoded), "-----BEGIN") {
+			return decoded
+		}
+	}
+
+	consoleNS := s.findConsoleHiveNamespace()
+	if consoleNS == "" {
+		return ""
+	}
+	out, err = kubectlForCluster(&cluster, "get", "secret", "hive-secrets", "-n", consoleNS,
+		"-o", "jsonpath={.data.gh-app-key\\.pem}").Output()
+	if err != nil || len(out) == 0 {
+		return ""
+	}
+
+	decoded, err := base64Decode(string(out))
+	if err != nil {
+		s.logger.Warn("failed to decode app key from console hive", "error", err)
+		return ""
+	}
+	return decoded
+}
+
+func (s *HubServer) findConsoleHiveNamespace() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, h := range s.registry.Hives {
+		if strings.EqualFold(h.Org, "kubestellar") {
+			for _, r := range h.Repos {
+				if r == "console" {
+					return "hive-hosted-" + h.ID
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func (s *HubServer) loadSpokeAuthToken(hive *RegistryEntry) string {
+	ns := "hive-hosted-" + hive.ID
+	clusterID := hive.ClusterID
+	if clusterID == "" {
+		clusterID = "hive-oke"
+	}
+
+	cluster, ok := s.clusters[clusterID]
+	if !ok {
+		return ""
+	}
+
+	out, err := kubectlForCluster(&cluster, "get", "secret", "hive-secrets", "-n", ns,
+		"-o", "jsonpath={.data.dashboard-token}").Output()
+	if err != nil || len(out) == 0 {
+		return ""
+	}
+
+	decoded, err := base64Decode(string(out))
+	if err != nil {
+		return ""
+	}
+	return decoded
+}
+
+func loadWebhookSecret() string {
+	if s := os.Getenv(webhookSecretEnvVar); s != "" {
+		return s
+	}
+	if data, err := os.ReadFile(webhookSecretPath); err == nil {
+		return strings.TrimSpace(string(data))
+	}
+	return ""
+}
+
+func verifyWebhookSignature(payload []byte, signature, secret string) bool {
+	if !strings.HasPrefix(signature, "sha256=") {
+		return false
+	}
+	sig, err := hex.DecodeString(strings.TrimPrefix(signature, "sha256="))
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+	expected := mac.Sum(nil)
+	return hmac.Equal(sig, expected)
+}


### PR DESCRIPTION
## Summary

- Adds `PUT /api/config/github` endpoint on the spoke dashboard that accepts `app_id`, `installation_id`, `key_file`, and `private_key`. Writes the key to disk, updates the live config, reinitializes the GitHub App client, and creates the advisory issue — all without a pod restart.
- Adds `POST /api/github/webhook` on the hub that receives GitHub App `installation` webhook events. When a user installs the kubestellar-hive app on their repo, the hub matches the org/repos to a registered hive and pushes the app credentials to the spoke via the new config API.
- Adds `ReinitGitHubFunc` callback to `Dependencies` so the spoke dashboard can hot-swap the GitHub client from PAT to App auth without restarting the binary.

## Motivation

Currently, configuring GitHub App auth after provisioning with "Configure Later" requires manual kubectl patching of ConfigMaps, PVC configs, secrets, and deployment volume mounts — then multiple rollout restarts to get the config picked up. This caused issues for Kelly's hive (kellyaa/agent-newsletter) and any future user who provisions first and installs the app later.

With this change, the entire flow is automated:
1. User provisions hive with "Configure Later"
2. User installs the kubestellar-hive GitHub App on their repo
3. GitHub sends installation webhook → hub matches hive → pushes config to spoke
4. Spoke writes key, updates config, reinits client, creates advisory issue
5. Zero manual intervention required

## Test plan

- [ ] Verify spoke PUT /api/config/github accepts and persists config changes
- [ ] Verify spoke reinits GitHub client and clears githubAppRequired flag
- [ ] Verify hub webhook handler parses installation events correctly
- [ ] Verify hub matches org/repos to registered hive from registry
- [ ] Verify hub pushes config to spoke via dashboard URL with auth token
- [ ] Verify private key is read from console hive secret as fallback
- [ ] End-to-end: provision with Configure Later → install app → verify auto-config