### PR TITLE
fix: broaden junk fact cleanup + add total facts sparkline

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -213,6 +213,15 @@ func main() {
 		}
 	}
 
+	// Restore fact count history from disk so the knowledge sparkline survives restarts
+	const factHistoryPath = "/data/fact-history.json"
+	var pendingFactSeed []dashboard.FactHistoryEntry
+	if factData, err := os.ReadFile(factHistoryPath); err == nil {
+		if err := json.Unmarshal(factData, &pendingFactSeed); err == nil && len(pendingFactSeed) > 0 {
+			logger.Info("fact history loaded", "entries", len(pendingFactSeed))
+		}
+	}
+
 	if cfg.Knowledge.Enabled {
 		layers := convertKnowledgeLayers(cfg.Knowledge.Layers)
 		primerCfg := knowledge.PrimerConfig{
@@ -456,6 +465,11 @@ func main() {
 	if len(pendingTokenSeed) > 0 {
 		dashSrv.SeedTokenSparklineHistory(pendingTokenSeed)
 		logger.Info("token sparkline history restored", "entries", len(pendingTokenSeed))
+	}
+
+	if len(pendingFactSeed) > 0 {
+		dashSrv.SeedFactHistory(pendingFactSeed)
+		logger.Info("fact history restored", "entries", len(pendingFactSeed))
 	}
 
 	beadStores := make(map[string]*beads.Store)
@@ -1912,6 +1926,14 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 			tokenData, err := json.Marshal(tokenHistory)
 			if err == nil {
 				atomicWrite("/data/token-sparkline-history.json", tokenData)
+			}
+		}
+
+		factHist := dashSrv.FactHistory()
+		if len(factHist) > 0 {
+			factData, err := json.Marshal(factHist)
+			if err == nil {
+				atomicWrite("/data/fact-history.json", factData)
 			}
 		}
 	}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -114,6 +114,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/knowledge/search", s.handleKnowledgeSearch)
 	s.mux.HandleFunc("GET /api/knowledge/health", s.handleKnowledgeHealth)
 	s.mux.HandleFunc("GET /api/knowledge/stats", s.handleKnowledgeStats)
+	s.mux.HandleFunc("GET /api/knowledge/fact-history", s.handleFactHistory)
 	s.mux.HandleFunc("POST /api/knowledge/create", s.handleKnowledgeCreate)
 	s.mux.HandleFunc("POST /api/knowledge/import", s.handleKnowledgeImport)
 	s.mux.HandleFunc("POST /api/knowledge/promote", s.handleKnowledgePromote)
@@ -3355,7 +3356,24 @@ func (s *Server) handleKnowledgeStats(w http.ResponseWriter, r *http.Request) {
 	stats := s.deps.Knowledge.Stats(s.deps.Ctx)
 	stats["vaults"] = s.deps.Knowledge.Vaults()
 	stats["git_sources"] = s.deps.Knowledge.GitSources()
+
+	if layers, ok := stats["layers"].([]interface{}); ok {
+		total := 0
+		for _, l := range layers {
+			if m, ok := l.(map[string]interface{}); ok {
+				if p, ok := m["total_pages"].(int); ok {
+					total += p
+				}
+			}
+		}
+		s.AppendFactHistory(total)
+	}
+
 	jsonResponse(w, stats)
+}
+
+func (s *Server) handleFactHistory(w http.ResponseWriter, r *http.Request) {
+	jsonResponse(w, s.FactHistory())
 }
 
 func (s *Server) handleKnowledgeLayer(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -53,6 +53,9 @@ type Server struct {
 	tokenHistory      []TokenSparklineEntry
 	lastFullBroadcast time.Time
 
+	factHistoryMu sync.RWMutex
+	factHistory   []FactHistoryEntry
+
 	advisoryMu     sync.RWMutex
 	advisoryDigest any
 
@@ -279,6 +282,18 @@ type TokenSparklineEntry struct {
 
 // tokenSparklineMaxEntries caps the on-disk history to ~24h at 5-min intervals.
 const tokenSparklineMaxEntries = 288
+
+// FactHistoryEntry records a total-facts snapshot at a point in time.
+type FactHistoryEntry struct {
+	Timestamp int64 `json:"t"`
+	Count     int   `json:"count"`
+}
+
+// factHistoryMaxEntries caps the fact sparkline to ~30 days at hourly intervals.
+const factHistoryMaxEntries = 720
+
+// factHistoryMinIntervalMs prevents recording more than once per hour (ms).
+const factHistoryMinIntervalMs = 3_600_000
 
 const sseRetryMs = 3000
 
@@ -1043,6 +1058,48 @@ func (s *Server) SeedTokenSparklineHistory(entries []TokenSparklineEntry) {
 		entries = entries[len(entries)-tokenSparklineMaxEntries:]
 	}
 	s.tokenHistory = entries
+}
+
+// AppendFactHistory records a total-facts count if enough time has passed.
+func (s *Server) AppendFactHistory(count int) {
+	now := time.Now().UnixMilli()
+
+	s.factHistoryMu.Lock()
+	defer s.factHistoryMu.Unlock()
+
+	if len(s.factHistory) > 0 {
+		last := s.factHistory[len(s.factHistory)-1]
+		if now-last.Timestamp < factHistoryMinIntervalMs {
+			return
+		}
+	}
+
+	s.factHistory = append(s.factHistory, FactHistoryEntry{
+		Timestamp: now,
+		Count:     count,
+	})
+	if len(s.factHistory) > factHistoryMaxEntries {
+		s.factHistory = s.factHistory[len(s.factHistory)-factHistoryMaxEntries:]
+	}
+}
+
+// FactHistory returns a copy of the fact count history.
+func (s *Server) FactHistory() []FactHistoryEntry {
+	s.factHistoryMu.RLock()
+	defer s.factHistoryMu.RUnlock()
+	out := make([]FactHistoryEntry, len(s.factHistory))
+	copy(out, s.factHistory)
+	return out
+}
+
+// SeedFactHistory restores persisted fact history on startup.
+func (s *Server) SeedFactHistory(entries []FactHistoryEntry) {
+	s.factHistoryMu.Lock()
+	defer s.factHistoryMu.Unlock()
+	if len(entries) > factHistoryMaxEntries {
+		entries = entries[len(entries)-factHistoryMaxEntries:]
+	}
+	s.factHistory = entries
 }
 
 // SetAdvisoryDigest stores the latest advisory digest for SSE broadcast.

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3042,6 +3042,34 @@
       return sparkSvg(series, '#f85149');
     }
 
+    // ── Fact count sparkline (30-day server-side history) ──
+    let _factHistory = [];
+    const FACT_SPARKLINE_W = 100, FACT_SPARKLINE_H = 24;
+    async function fetchFactHistory() {
+      try {
+        const r = await fetch('/api/knowledge/fact-history');
+        _factHistory = await r.json();
+      } catch { /* non-critical */ }
+    }
+    function factSparkSvg() {
+      if (!_factHistory || _factHistory.length < 2) return '';
+      const values = _factHistory.map(e => e.count);
+      const max = Math.max(...values);
+      const min = Math.min(...values);
+      const range = (max - min) || max || 1;
+      const pts = values.map((v, i) => {
+        const x = (i / (values.length - 1)) * FACT_SPARKLINE_W;
+        const y = FACT_SPARKLINE_H - ((v - min) / range) * (FACT_SPARKLINE_H - 2) - 1;
+        return `${x.toFixed(1)},${y.toFixed(1)}`;
+      });
+      const lastPt = pts[pts.length - 1].split(',');
+      return `<span class="sparkline" style="margin-left:0;margin-top:4px"><svg width="${FACT_SPARKLINE_W}" height="${FACT_SPARKLINE_H}" viewBox="0 0 ${FACT_SPARKLINE_W} ${FACT_SPARKLINE_H}">` +
+        `<polyline points="${pts.join(' ')}" fill="none" stroke="#2563eb" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>` +
+        `<circle cx="${lastPt[0]}" cy="${lastPt[1]}" r="2" fill="#2563eb"/>` +
+        `</svg></span>`;
+    }
+    fetchFactHistory();
+
     async function fetchHistory() {
       try {
         const r = await fetch('/api/history');
@@ -5259,7 +5287,7 @@ function burnAreaChart() {
     let _kbRendered = false;
     async function fetchKnowledgeStats() {
       try {
-        const [r] = await Promise.all([fetch('/api/knowledge/stats'), fetchBeadSynthStatus()]);
+        const [r] = await Promise.all([fetch('/api/knowledge/stats'), fetchBeadSynthStatus(), fetchFactHistory()]);
         if (!r.ok) return;
         const prev = _kbCache;
         _kbCache = await r.json();
@@ -5591,7 +5619,7 @@ function burnAreaChart() {
       const staleTotal = layers.reduce((sum, l) => sum + (l.stale || 0), 0);
       const orphanedTotal = layers.reduce((sum, l) => sum + (l.orphaned || 0), 0);
       html += '<div class="kb-stat-grid" style="margin-bottom:14px">';
-      html += `<div class="kb-stat"><div class="val">${totalPages}</div><div class="lbl">Total Facts</div></div>`;
+      html += `<div class="kb-stat"><div class="val">${totalPages}</div><div class="lbl">Total Facts</div>${factSparkSvg()}</div>`;
       html += `<div class="kb-stat"><div class="val">${healthyCount}/${layers.length}</div><div class="lbl">Layers Online</div></div>`;
       html += `<div class="kb-stat"><div class="val">${escapeHtml(_kbCache.engine || 'n/a')}</div><div class="lbl">Engine</div></div>`;
       if (staleTotal > 0) html += `<div class="kb-stat"><div class="val" style="color:#d97706">${staleTotal}</div><div class="lbl">Stale</div></div>`;

--- a/v2/pkg/knowledge/bead_synthesizer.go
+++ b/v2/pkg/knowledge/bead_synthesizer.go
@@ -567,8 +567,8 @@ func (s *BeadSynthesizer) CleanupVault() (int, error) {
 	return removed, nil
 }
 
-// isJunkFact detects vault files that contain only merge titles and metadata
-// lines (External/Source) with no substantive knowledge content.
+// isJunkFact detects vault files whose body contains only metadata lines
+// (External/Source/Severity/File/Recommendation) with no substantive content.
 func isJunkFact(content string) bool {
 	bodyStart := strings.Index(content, "---\n")
 	if bodyStart < 0 {
@@ -584,10 +584,6 @@ func isJunkFact(content string) bool {
 		return true
 	}
 
-	if !strings.Contains(strings.ToLower(content), "merged:") {
-		return false
-	}
-
 	lines := strings.Split(body, "\n")
 	substantiveLines := 0
 	for _, line := range lines {
@@ -598,7 +594,8 @@ func isJunkFact(content string) bool {
 		if strings.HasPrefix(trimmed, "- External:") ||
 			strings.HasPrefix(trimmed, "- Source:") ||
 			strings.HasPrefix(trimmed, "- Severity:") ||
-			strings.HasPrefix(trimmed, "- File:") {
+			strings.HasPrefix(trimmed, "- File:") ||
+			strings.HasPrefix(trimmed, "- Recommendation:") {
 			continue
 		}
 		substantiveLines++

--- a/v2/pkg/knowledge/bead_synthesizer_test.go
+++ b/v2/pkg/knowledge/bead_synthesizer_test.go
@@ -814,19 +814,21 @@ func TestIsJunkFact(t *testing.T) {
 		t.Error("expected good fact not to be junk")
 	}
 
-	noMerge := "---\ntitle: Something else\ntype: gotcha\n---\n\n- External: gh-5\n- Source: bead:scanner/def\n"
-	if isJunkFact(noMerge) {
-		t.Error("non-merge fact with only metadata should not be junk")
+	metadataOnly := "---\ntitle: Something else\ntype: gotcha\n---\n\n- External: gh-5\n- Source: bead:scanner/def\n"
+	if !isJunkFact(metadataOnly) {
+		t.Error("fact with only metadata lines and no substantive content should be junk")
 	}
 }
 
 func TestCleanupVault_RemovesJunk(t *testing.T) {
 	vaultDir := t.TempDir()
 
-	junk := "---\ntitle: Merged: console#100 — updated README\ntype: pattern\nconfidence: 0.70\nsource: bead:scanner/abc\n---\n\n- External: gh-100\n- Source: bead:scanner/abc\n"
+	mergeJunk := "---\ntitle: Merged: console#100 — updated README\ntype: pattern\nconfidence: 0.70\nsource: bead:scanner/abc\n---\n\n- External: gh-100\n- Source: bead:scanner/abc\n"
+	metadataOnlyJunk := "---\ntitle: console: merged CSP wss wildcard removal PR#17301\ntype: pattern\nconfidence: 0.60\n---\n\n- External: gh-17301\n- Source: bead:scanner/ef3346c5-501\n"
 	good := "---\ntitle: Always check OAuth scopes\ntype: gotcha\nconfidence: 0.80\n---\n\nWhen handling OAuth callbacks, always verify the returned scopes match what was requested.\n- Source: bead:guide/xyz\n"
 
-	os.WriteFile(filepath.Join(vaultDir, "merged-console100.md"), []byte(junk), 0644)
+	os.WriteFile(filepath.Join(vaultDir, "merged-console100.md"), []byte(mergeJunk), 0644)
+	os.WriteFile(filepath.Join(vaultDir, "csp-wss-removal.md"), []byte(metadataOnlyJunk), 0644)
 	os.WriteFile(filepath.Join(vaultDir, "oauth-scopes.md"), []byte(good), 0644)
 
 	api := NewKnowledgeAPI(nil, KnowledgeConfig{Enabled: true}, synthTestLogger())
@@ -838,8 +840,8 @@ func TestCleanupVault_RemovesJunk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CleanupVault failed: %v", err)
 	}
-	if removed != 1 {
-		t.Errorf("removed = %d; want 1", removed)
+	if removed != 2 {
+		t.Errorf("removed = %d; want 2", removed)
 	}
 
 	entries, _ := os.ReadDir(vaultDir)


### PR DESCRIPTION
## Summary
- **Vault cleanup fix**: Removed the `"merged:"` title requirement from `isJunkFact()`. Now any vault entry whose body contains only metadata lines (`- External:`, `- Source:`, etc.) with no substantive content is correctly removed at startup. Previously ~250 content-less entries survived because their titles used patterns like `"console: merged..."` instead of `"Merged:"`.
- **Total Facts sparkline**: Added 30-day server-side fact count history (`FactHistoryEntry`) recorded hourly, persisted to `/data/fact-history.json` across restarts. The knowledge dashboard's "Total Facts" stat card now renders an inline SVG sparkline showing the count rising and falling over time.

## Changes
- `bead_synthesizer.go`: `isJunkFact()` no longer requires `"merged:"` in the content — checks body-only-metadata universally
- `server.go`: `FactHistoryEntry` type, `AppendFactHistory()`, `FactHistory()`, `SeedFactHistory()` methods
- `api.go`: `GET /api/knowledge/fact-history` endpoint + recording in stats handler
- `main.go`: Load/save fact history from `/data/fact-history.json`
- `index.html`: `factSparkSvg()` renderer + wired into Total Facts stat card

## Test plan
- [x] `TestIsJunkFact` updated — metadata-only entries without "merged:" now correctly detected as junk
- [x] `TestCleanupVault_RemovesJunk` updated — verifies both merge-titled and non-merge metadata-only entries are removed
- [x] `go build ./...` passes
- [x] Dashboard tests pass