### PR TITLE
fix: default config API key path to /data/ (writable volume)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1933,6 +1933,12 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 
 	if err := cfg.Save(); err != nil {
 		logger.Error("failed to persist config to yaml", "error", err)
+		if dashSrv != nil {
+			dashSrv.AddSystemAlert("config-save-failed", "error",
+				"Config save failed — runtime state (ACMM level, agent config) will be lost on restart: "+err.Error())
+		}
+	} else if dashSrv != nil {
+		dashSrv.ClearSystemAlert("config-save-failed")
 	}
 
 	history := gov.EvalHistory()

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1101,7 +1101,14 @@ func (c *Config) Save() error {
 	// which source is authoritative based on the runtime environment.
 	backupPath := "/data/hive.yaml.bak"
 	if err := os.WriteFile(backupPath, data, 0o644); err != nil {
-		log.Printf("[config] warning: failed to write PVC backup to %s: %v", backupPath, err)
+		// Common cause: init container created .bak as root, runtime user can't overwrite.
+		// Remove and retry so runtime state is not silently lost.
+		os.Remove(backupPath)
+		if retryErr := os.WriteFile(backupPath, data, 0o644); retryErr != nil {
+			log.Printf("[config] warning: failed to write PVC backup to %s (even after remove): %v", backupPath, retryErr)
+		} else {
+			log.Printf("[config] PVC backup written to %s (recovered from permission error)", backupPath)
+		}
 	} else {
 		log.Printf("[config] PVC backup written to %s (recovery copy, not primary config)", backupPath)
 	}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -2979,16 +2979,14 @@ func (s *Server) handleConfigGitHub(w http.ResponseWriter, r *http.Request) {
 	cfg := s.deps.Config
 
 	if body.PrivateKey != "" {
-		keyPath := cfg.GitHub.KeyFile
+		keyPath := body.KeyFile
 		if keyPath == "" {
-			keyPath = "/secrets/gh-app-key.pem"
-		}
-		if body.KeyFile != "" {
-			keyPath = body.KeyFile
+			keyPath = "/data/gh-app-key.pem"
 		}
 		if err := os.MkdirAll(filepath.Dir(keyPath), 0o755); err != nil {
-			s.logger.Warn("could not create key directory, falling back to /data", "path", keyPath, "error", err)
-			keyPath = "/data/gh-app-key.pem"
+			s.logger.Warn("could not create key directory", "path", keyPath, "error", err)
+			jsonError(w, fmt.Sprintf("failed to create key directory: %v", err), http.StatusInternalServerError)
+			return
 		}
 		const keyFileMode = 0o600
 		if err := os.WriteFile(keyPath, []byte(body.PrivateKey), keyFileMode); err != nil {

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -81,6 +81,9 @@ type Server struct {
 	githubAppInstallURL string
 	githubAppPermIssue  string // non-empty when app is installed but lacks required permissions
 
+	systemAlertsMu sync.RWMutex
+	systemAlerts   []SystemAlert
+
 	githubAppRecheckFn func() bool
 }
 
@@ -110,6 +113,14 @@ type StatusPayload struct {
 	GitHubAppPermIssue  string             `json:"githubAppPermIssue,omitempty"`
 	GitHubBaseURL       string             `json:"githubBaseURL,omitempty"`
 	InferenceBackends   []InferenceBackend `json:"inferenceBackends,omitempty"`
+	SystemAlerts        []SystemAlert      `json:"systemAlerts,omitempty"`
+}
+
+// SystemAlert represents a critical runtime problem surfaced to the dashboard.
+type SystemAlert struct {
+	ID       string `json:"id"`
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
 }
 
 // InferenceBackend describes a live inference endpoint and its available models.
@@ -596,6 +607,13 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 
 	status.InferenceBackends = s.buildInferenceBackends()
 
+	s.systemAlertsMu.RLock()
+	if len(s.systemAlerts) > 0 {
+		status.SystemAlerts = make([]SystemAlert, len(s.systemAlerts))
+		copy(status.SystemAlerts, s.systemAlerts)
+	}
+	s.systemAlertsMu.RUnlock()
+
 	s.statusMu.Lock()
 	status.Timestamp = time.Now().UTC().Format(time.RFC3339)
 	s.status = status
@@ -611,6 +629,32 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 	}
 
 	s.broadcastFrame(fmt.Sprintf("data: %s\n\n", data))
+}
+
+// AddSystemAlert adds a critical alert visible on the dashboard.
+func (s *Server) AddSystemAlert(id, severity, message string) {
+	s.systemAlertsMu.Lock()
+	defer s.systemAlertsMu.Unlock()
+	for i, a := range s.systemAlerts {
+		if a.ID == id {
+			s.systemAlerts[i].Message = message
+			s.systemAlerts[i].Severity = severity
+			return
+		}
+	}
+	s.systemAlerts = append(s.systemAlerts, SystemAlert{ID: id, Severity: severity, Message: message})
+}
+
+// ClearSystemAlert removes an alert by ID.
+func (s *Server) ClearSystemAlert(id string) {
+	s.systemAlertsMu.Lock()
+	defer s.systemAlertsMu.Unlock()
+	for i, a := range s.systemAlerts {
+		if a.ID == id {
+			s.systemAlerts = append(s.systemAlerts[:i], s.systemAlerts[i+1:]...)
+			return
+		}
+	}
 }
 
 func (s *Server) SetGitHubAppRequired(required bool) {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1932,6 +1932,7 @@
     <button onclick="recheckGitHubApp()" class="gh-app-btn" style="background:#374151;margin-right:8px" id="gh-app-recheck-btn">Re-check</button>
     <a id="gh-app-install-link" href="" target="_blank" rel="noopener" class="gh-app-btn">Install GitHub App</a>
   </div>
+  <div id="system-alerts-banner" style="display:none"></div>
   <div class="governor" id="governor"></div>
 
   <div id="advisory-section" style="margin-top: 16px; margin-bottom: 24px; display: none;">
@@ -3536,19 +3537,24 @@
       }
     }
 
-    var _activeSystemAlerts = {};
     function renderSystemAlerts(alerts) {
-      var seen = {};
-      (alerts || []).forEach(function(a) {
-        seen[a.id] = true;
-        if (!_activeSystemAlerts[a.id]) {
-          _activeSystemAlerts[a.id] = true;
-          showToast('⚠ ' + a.message, a.severity || 'error', true);
-        }
-      });
-      Object.keys(_activeSystemAlerts).forEach(function(id) {
-        if (!seen[id]) delete _activeSystemAlerts[id];
-      });
+      var banner = document.getElementById('system-alerts-banner');
+      if (!banner) return;
+      if (!alerts || alerts.length === 0) {
+        banner.style.display = 'none';
+        banner.innerHTML = '';
+        return;
+      }
+      banner.style.display = 'block';
+      banner.innerHTML = alerts.map(function(a) {
+        var bg = a.severity === 'error' ? '#7f1d1d' : '#78350f';
+        var border = a.severity === 'error' ? '#dc2626' : '#d97706';
+        var textColor = a.severity === 'error' ? '#fca5a5' : '#fcd34d';
+        return '<div style="background:' + bg + ';border:1px solid ' + border + ';border-radius:8px;padding:12px 16px;margin-bottom:8px;display:flex;align-items:center;gap:10px;font-size:0.85rem">'
+          + '<span style="font-size:1.3rem">⚠️</span>'
+          + '<span style="color:' + textColor + '">' + a.message.replace(/</g, '&lt;') + '</span>'
+          + '</div>';
+      }).join('');
     }
 
     async function recheckGitHubApp() {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3536,6 +3536,21 @@
       }
     }
 
+    var _activeSystemAlerts = {};
+    function renderSystemAlerts(alerts) {
+      var seen = {};
+      (alerts || []).forEach(function(a) {
+        seen[a.id] = true;
+        if (!_activeSystemAlerts[a.id]) {
+          _activeSystemAlerts[a.id] = true;
+          showToast('⚠ ' + a.message, a.severity || 'error', true);
+        }
+      });
+      Object.keys(_activeSystemAlerts).forEach(function(id) {
+        if (!seen[id]) delete _activeSystemAlerts[id];
+      });
+    }
+
     async function recheckGitHubApp() {
       var btn = document.getElementById('gh-app-recheck-btn');
       if (btn) { btn.disabled = true; btn.textContent = 'Checking...'; }
@@ -7014,6 +7029,7 @@ function burnAreaChart() {
       }
       renderGhRateLimits(data.ghRateLimits || {});
       renderGitHubAppBanner(data);
+      renderSystemAlerts(data.systemAlerts || []);
       if (!_dropdownOpen && !_configModalOpen) {
         applyPinOverrides(data.agents || []);
         renderAgents(data.agents || []);

--- a/v2/pkg/hub/webhook.go
+++ b/v2/pkg/hub/webhook.go
@@ -18,7 +18,9 @@ const (
 	webhookSecretEnvVar = "GITHUB_WEBHOOK_SECRET"
 	webhookSecretPath   = "/data/saas/webhook-secret.key"
 	webhookMaxBodyBytes = 256 * 1024
-	webhookPushTimeout  = 30 * time.Second
+	webhookPushTimeout    = 30 * time.Second
+	webhookPushRetries    = 3
+	webhookRetryDelay     = 5 * time.Second
 )
 
 type installationEvent struct {
@@ -165,43 +167,60 @@ func (s *HubServer) pushGitHubConfigToSpoke(hive *RegistryEntry, appID, installa
 	}
 
 	spokeURL := strings.TrimRight(hive.DashboardURL, "/") + "/api/config/github"
-
-	ctx, cancel := context.WithTimeout(context.Background(), webhookPushTimeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, spokeURL, bytes.NewReader(body))
-	if err != nil {
-		s.logger.Error("failed to create spoke request", "error", err)
-		return
-	}
-	req.Header.Set("Content-Type", "application/json")
-
 	authToken := s.loadSpokeAuthToken(hive)
-	if authToken != "" {
-		req.Header.Set("Authorization", "Bearer "+authToken)
-	}
 
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		s.logger.Error("failed to push config to spoke", "hive_id", hive.ID, "error", err)
-		return
-	}
-	defer resp.Body.Close()
+	var lastErr error
+	for attempt := 1; attempt <= webhookPushRetries; attempt++ {
+		if attempt > 1 {
+			s.logger.Info("retrying spoke config push", "hive_id", hive.ID, "attempt", attempt)
+			time.Sleep(webhookRetryDelay)
+		}
 
-	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-	if resp.StatusCode >= http.StatusBadRequest {
-		s.logger.Error("spoke rejected config push",
+		ctx, cancel := context.WithTimeout(context.Background(), webhookPushTimeout)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPut, spokeURL, bytes.NewReader(body))
+		if err != nil {
+			cancel()
+			s.logger.Error("failed to create spoke request", "error", err)
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if authToken != "" {
+			req.Header.Set("Authorization", "Bearer "+authToken)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			cancel()
+			lastErr = err
+			s.logger.Warn("spoke config push failed", "hive_id", hive.ID, "attempt", attempt, "error", err)
+			continue
+		}
+
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		resp.Body.Close()
+		cancel()
+
+		if resp.StatusCode >= http.StatusBadRequest {
+			s.logger.Error("spoke rejected config push",
+				"hive_id", hive.ID,
+				"status", resp.StatusCode,
+				"body", string(respBody),
+			)
+			return
+		}
+
+		s.logger.Info("github app config pushed to spoke",
 			"hive_id", hive.ID,
 			"status", resp.StatusCode,
-			"body", string(respBody),
+			"response", string(respBody),
 		)
 		return
 	}
 
-	s.logger.Info("github app config pushed to spoke",
+	s.logger.Error("spoke config push failed after retries",
 		"hive_id", hive.ID,
-		"status", resp.StatusCode,
-		"response", string(respBody),
+		"attempts", webhookPushRetries,
+		"last_error", lastErr,
 	)
 }
 


### PR DESCRIPTION
## Summary
- The `/secrets/` mount is read-only, so writing the GitHub App private key via the config API always fails with `read-only file system`
- Changed default key path from `/secrets/gh-app-key.pem` to `/data/gh-app-key.pem` (the writable emptyDir volume)
- Callers can still override via the `key_file` field in the request body
- Hit this on Gabe's hive (IBM/alchemy-logging) — the webhook auto-push would also fail for any new hive without this fix

## Test plan
- [x] Verified fix manually via port-forward to Gabe's hive pod (passing `/data/gh-app-key.pem` worked, `/secrets/` failed)