### PR TITLE
fix: enricher tries all repos for gh-NNN refs + skip unenriched empty beads

### DIFF
--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -289,11 +289,11 @@ type FactHistoryEntry struct {
 	Count     int   `json:"count"`
 }
 
-// factHistoryMaxEntries caps the fact sparkline to ~30 days at hourly intervals.
-const factHistoryMaxEntries = 720
+// factHistoryMaxEntries caps the fact sparkline to ~30 days at 5-min intervals.
+const factHistoryMaxEntries = 8640
 
-// factHistoryMinIntervalMs prevents recording more than once per hour (ms).
-const factHistoryMinIntervalMs = 3_600_000
+// factHistoryMinIntervalMs prevents recording more than once per 5 minutes (ms).
+const factHistoryMinIntervalMs = 300_000
 
 const sseRetryMs = 3000
 

--- a/v2/pkg/knowledge/bead_synthesizer.go
+++ b/v2/pkg/knowledge/bead_synthesizer.go
@@ -501,26 +501,32 @@ func (s *BeadSynthesizer) writeFactToVault(fact ExtractedFact) error {
 func (s *BeadSynthesizer) buildEnrichedBody(ctx context.Context, b *beads.Bead, agent string) string {
 	baseBody := BuildFactBody(b, agent)
 
+	enriched := ""
 	if s.enricher != nil && b.ExternalRef != "" {
-		enriched := s.enricher.EnrichBody(ctx, b, agent)
+		enriched = s.enricher.EnrichBody(ctx, b, agent)
 		if enriched != "" {
 			return enriched
 		}
 	}
 
-	if isLowQualityMergeBead(b) && s.enricher == nil {
-		s.logger.Debug("skipping low-quality merge bead without enricher",
-			"bead_id", b.ID, "title", b.Title)
+	if isLowQualityBead(b) {
+		s.logger.Debug("skipping low-quality bead",
+			"bead_id", b.ID, "title", b.Title, "enrichment_attempted", enriched == "" && s.enricher != nil)
 		return ""
 	}
 
 	return baseBody
 }
 
-// isLowQualityMergeBead detects beads that are just PR merge event titles
-// with no substantive content.
-func isLowQualityMergeBead(b *beads.Bead) bool {
-	return strings.HasPrefix(b.Title, "Merged:") && strings.TrimSpace(b.Notes) == ""
+// isLowQualityBead detects beads with no substantive content beyond the title.
+func isLowQualityBead(b *beads.Bead) bool {
+	if strings.TrimSpace(b.Notes) != "" {
+		return false
+	}
+	if b.Meta("detail") != "" || b.Meta("recommendation") != "" {
+		return false
+	}
+	return true
 }
 
 // CleanupVault removes low-quality facts from the vault directory that were
@@ -696,9 +702,6 @@ func (e *PREnricher) EnrichBody(ctx context.Context, b *beads.Bead, agent string
 func (e *PREnricher) parseRef(ref string) (string, string, int) {
 	if m := ghRefPattern.FindStringSubmatch(ref); m != nil {
 		n, _ := strconv.Atoi(m[1])
-		if len(e.repos) > 0 {
-			return e.org, e.repos[0], n
-		}
 		return e.org, "", n
 	}
 

--- a/v2/pkg/knowledge/bead_synthesizer_test.go
+++ b/v2/pkg/knowledge/bead_synthesizer_test.go
@@ -741,8 +741,8 @@ func TestPREnricher_ParseRef_GhFormat(t *testing.T) {
 	e := NewPREnricher(nil, "kubestellar", []string{"console", "docs"}, synthTestLogger())
 
 	owner, repo, num := e.parseRef("gh-42")
-	if owner != "kubestellar" || repo != "console" || num != 42 {
-		t.Errorf("parseRef(gh-42) = %q, %q, %d; want kubestellar, console, 42", owner, repo, num)
+	if owner != "kubestellar" || repo != "" || num != 42 {
+		t.Errorf("parseRef(gh-42) = %q, %q, %d; want kubestellar, (empty), 42", owner, repo, num)
 	}
 }
 
@@ -783,7 +783,7 @@ func TestPREnricher_FallbackOnNilClient(t *testing.T) {
 	}
 }
 
-func TestIsLowQualityMergeBead(t *testing.T) {
+func TestIsLowQualityBead(t *testing.T) {
 	tests := []struct {
 		title string
 		notes string
@@ -791,14 +791,16 @@ func TestIsLowQualityMergeBead(t *testing.T) {
 	}{
 		{"Merged: console#100 — add feature", "", true},
 		{"Merged: docs#5 — fix typo", "some notes", false},
-		{"Found a bug in auth handler", "", false},
+		{"Found a bug in auth handler", "", true},
+		{"XSS regression in sanitizeHtmlForMdx", "", true},
+		{"CSP connect-src bare wss: wildcard", "important detail here", false},
 	}
 
 	for _, tt := range tests {
 		b := &beads.Bead{Title: tt.title, Notes: tt.notes}
-		got := isLowQualityMergeBead(b)
+		got := isLowQualityBead(b)
 		if got != tt.want {
-			t.Errorf("isLowQualityMergeBead(%q, %q) = %v; want %v", tt.title, tt.notes, got, tt.want)
+			t.Errorf("isLowQualityBead(%q, %q) = %v; want %v", tt.title, tt.notes, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- **Enricher fix**: `parseRef("gh-NNN")` was returning `repos[0]` (console) as the repo, so PRs from other repos (docs, console-kb, etc.) were never found. Now returns empty repo to trigger `fetchPRFromRepos` which tries ALL configured repos.
- **Quality gate fix**: `isLowQualityMergeBead` only caught beads with "Merged:" title prefix. Replaced with `isLowQualityBead` which catches ANY bead with empty notes/detail/recommendation — regardless of title. Combined with enrichment fallback: if enrichment fails AND bead has no content, it's skipped instead of producing a junk vault entry.
- **Sparkline interval**: Reduced fact history recording interval from 1h to 5min so the sparkline populates quickly.

## Root cause
The live instance had 63 vault entries that were ALL metadata-only (`- External: gh-NNN` / `- Source: bead:...`). Three interacting bugs:
1. `gh-5839` (a docs PR) → `parseRef` returned `(kubestellar, console, 5839)` → 404 → no enrichment
2. Without enrichment, `buildEnrichedBody` fell back to `BuildFactBody` which produces the empty-notes body
3. `isLowQualityMergeBead` didn't catch these beads because their titles don't start with "Merged:"

## Test plan
- [x] `TestPREnricher_ParseRef_GhFormat` — verifies empty repo for multi-repo lookup
- [x] `TestIsLowQualityBead` — catches empty-notes beads regardless of title
- [x] `go build ./...` clean
- [x] Dashboard tests pass