### PR TITLE
fix: SetLevel API must call ApplyPack to cascade agent modes

### DIFF
--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -298,15 +298,24 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 
 	s.deps.AgentMgr.SetACMMLevel(level)
 	s.deps.AgentMgr.ClearAllModeOverrides()
+
+	// ApplyPack cascades pack-defined agent fields (mode, kick_template,
+	// description, etc.) into the live config. Without this, the mode-clear
+	// above leaves every agent with mode="" and the gh proxy blocks merges.
+	packResult, packErr := s.ApplyPack(level)
+	if packErr != nil {
+		s.logger.Warn("failed to apply pack after level change", "level", level, "error", packErr)
+	}
+
 	paused, resumed := s.syncAgentVisibility(level)
 	s.deps.AgentMgr.SyncModeFiles(level)
 
 	s.persistOnly()
 	s.refreshAsync()
 
-	pack, packErr := config.ACMMPackByLevel(level)
+	pack, packLookupErr := config.ACMMPackByLevel(level)
 	var packAgentNames []string
-	if packErr == nil {
+	if packLookupErr == nil {
 		for _, a := range pack.Agents {
 			if !a.Hidden {
 				packAgentNames = append(packAgentNames, a.Name)
@@ -335,20 +344,25 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if packErr == nil && (len(pack.Governor.Cadences) > 0 || len(pack.Governor.Thresholds) > 0 || pack.Governor.EvalIntervalS > 0) {
+	if packLookupErr == nil && (len(pack.Governor.Cadences) > 0 || len(pack.Governor.Thresholds) > 0 || pack.Governor.EvalIntervalS > 0) {
 		if err := s.saveConfig(); err != nil {
 			s.logger.Error("failed to persist config after pack cadence update", "error", err)
 		}
 	}
 
+	var packUpdated []string
+	if packResult != nil {
+		packUpdated = packResult.Updated
+	}
 	s.auditFromRequest(r, "set_acmm_level", auditDetail("level", strconv.Itoa(body.Level)), "")
-	s.logger.Info("ACMM level set", "level", body.Level, "paused", len(paused), "resumed", len(resumed))
+	s.logger.Info("ACMM level set", "level", body.Level, "paused", len(paused), "resumed", len(resumed), "packUpdated", packUpdated)
 	jsonResponse(w, map[string]interface{}{
-		"ok":         true,
-		"level":      body.Level,
-		"packAgents": packAgentNames,
-		"paused":     paused,
-		"resumed":    resumed,
+		"ok":          true,
+		"level":       body.Level,
+		"packAgents":  packAgentNames,
+		"packUpdated": packUpdated,
+		"paused":      paused,
+		"resumed":     resumed,
 	})
 }
 


### PR DESCRIPTION
## Summary
- `handlePackSetLevel` cleared all agent modes before saving but never called `ApplyPack` to re-apply pack-defined fields (mode, kick_template, description)
- This left every agent with `mode=""` after an API-driven level change, causing the gh proxy to block merge operations even at L6
- The UI-driven L3→L6 toggle worked because it went through a different code path that called `ApplyPack`
- Now the API handler calls `ApplyPack` immediately after clearing modes, ensuring the full cascade happens regardless of how the level is set
- Response now includes `packUpdated` field showing which agents were updated by the pack

## Root cause
Scanner stopped merging PRs because `mode: ""` meant the gh proxy denied merge requests. The mode was blank because the API endpoint set `acmm_level: 6` in config but never cascaded the L6 pack's `ISSUES_PRS_MERGE` mode to the scanner agent.

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./pkg/dashboard/ ./pkg/config/` — all pass
- [ ] CI build-and-test