### PR TITLE
feat(knowledge): bead synthesizer emits relationship triples

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -757,6 +757,9 @@ func main() {
 		if knowledgeAPI != nil {
 			knowledgeAPI.SetGraphStore(graphStore)
 		}
+		if beadSynth != nil {
+			beadSynth.SetGraphStore(graphStore)
+		}
 		for _, ls := range knowledgeAPI.FileStores() {
 			if n, err := graphStore.SyncFromFileStore(ls); err != nil {
 				logger.Warn("graph sync failed", "store", ls.Name(), "error", err)

--- a/v2/pkg/knowledge/bead_synthesizer.go
+++ b/v2/pkg/knowledge/bead_synthesizer.go
@@ -39,10 +39,16 @@ type BeadSynthesizer struct {
 	vaultBaseDir     string
 	enricher         *PREnricher
 	lifecycleManager *BeadLifecycleManager
+	graphStore       *GraphStore
 
 	mu       sync.Mutex
 	cancel   context.CancelFunc
 	running  bool
+}
+
+// SetGraphStore attaches a graph store so synthesized facts emit relationship triples.
+func (s *BeadSynthesizer) SetGraphStore(gs *GraphStore) {
+	s.graphStore = gs
 }
 
 // NewBeadSynthesizer creates a synthesizer that bridges bead stores to the wiki.
@@ -202,6 +208,7 @@ func (s *BeadSynthesizer) RunSynthesis(ctx context.Context) (int, error) {
 			Type:       factType,
 			Confidence: confidence,
 			Tags:       extractBeadTags(c.bead),
+			Related:    s.resolveBeadRelations(c.bead, c.agent),
 			SourcePR:   fmt.Sprintf("bead:%s/%s", c.agent, c.bead.ID),
 			SourceDate: c.bead.UpdatedAt.Time,
 		}
@@ -479,6 +486,9 @@ func (s *BeadSynthesizer) writeFactToVault(fact ExtractedFact) error {
 	if len(fact.Tags) > 0 {
 		fmt.Fprintf(&buf, "tags: [%s]\n", strings.Join(fact.Tags, ", "))
 	}
+	if len(fact.Related) > 0 {
+		fmt.Fprintf(&buf, "related: [%s]\n", strings.Join(fact.Related, ", "))
+	}
 	fmt.Fprintf(&buf, "source: %s\n", fact.SourcePR)
 	fmt.Fprintf(&buf, "synthesized: %s\n", time.Now().UTC().Format(time.RFC3339))
 	buf.WriteString("---\n\n")
@@ -493,7 +503,53 @@ func (s *BeadSynthesizer) writeFactToVault(fact ExtractedFact) error {
 	}
 
 	s.knowledgeAPI.triggerVaultReindex(dir)
+
+	if s.graphStore != nil && len(fact.Related) > 0 {
+		factSlug := slugify(fact.Title)
+		for _, rel := range fact.Related {
+			if err := s.graphStore.AddTriple(Triple{
+				Subject:   factSlug,
+				Predicate: "related_to",
+				Object:    rel,
+			}); err != nil {
+				s.logger.Warn("failed to add graph triple",
+					"subject", factSlug,
+					"object", rel,
+					"error", err,
+				)
+			}
+		}
+	}
+
 	return nil
+}
+
+// resolveBeadRelations maps a bead's DependsOn IDs to fact slugs by looking up
+// each dependent bead across all stores and slugifying its title.
+func (s *BeadSynthesizer) resolveBeadRelations(b *beads.Bead, agent string) []string {
+	if len(b.DependsOn) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var related []string
+
+	for _, depID := range b.DependsOn {
+		for _, store := range s.beadStores {
+			dep, err := store.Get(depID)
+			if err != nil || dep == nil {
+				continue
+			}
+			slug := slugify(dep.Title)
+			if slug != "" && !seen[slug] {
+				seen[slug] = true
+				related = append(related, slug)
+			}
+			break
+		}
+	}
+
+	return related
 }
 
 // buildEnrichedBody produces the fact body, enriching with GitHub PR data when possible.

--- a/v2/pkg/knowledge/bead_synthesizer_test.go
+++ b/v2/pkg/knowledge/bead_synthesizer_test.go
@@ -1422,3 +1422,153 @@ func TestBeadSynthesizerConfig_IsEnabled_ExplicitFalse(t *testing.T) {
 		t.Error("IsEnabled() should be false when explicitly set to false")
 	}
 }
+
+func TestResolveBeadRelations(t *testing.T) {
+	store := newTestStore(t)
+	parent, _ := store.Create("auth handler fix", beads.TypeBug, beads.PriorityHigh, "scanner", "")
+	child, _ := store.Create("login validation", beads.TypeTask, beads.PriorityMedium, "scanner", "")
+	store.Close(parent.ID)
+	store.Close(child.ID)
+
+	store.Update(parent.ID, func(b *beads.Bead) {
+		b.DependsOn = []string{child.ID}
+	})
+
+	stores := map[string]*beads.Store{"scanner": store}
+	srv, _ := newMockWikiServer(t)
+	synth := newTestSynthesizer(t, stores, srv.URL)
+
+	reloaded, _ := store.Get(parent.ID)
+	related := synth.resolveBeadRelations(reloaded, "scanner")
+
+	if len(related) != 1 {
+		t.Fatalf("expected 1 related slug, got %d", len(related))
+	}
+	want := slugify("login validation")
+	if related[0] != want {
+		t.Errorf("related[0] = %q, want %q", related[0], want)
+	}
+}
+
+func TestResolveBeadRelations_NoDeps(t *testing.T) {
+	store := newTestStore(t)
+	b, _ := store.Create("standalone finding", beads.TypeBug, beads.PriorityMedium, "scanner", "")
+	store.Close(b.ID)
+
+	stores := map[string]*beads.Store{"scanner": store}
+	srv, _ := newMockWikiServer(t)
+	synth := newTestSynthesizer(t, stores, srv.URL)
+
+	got, _ := store.Get(b.ID)
+	related := synth.resolveBeadRelations(got, "scanner")
+	if related != nil {
+		t.Errorf("expected nil for bead with no deps, got %v", related)
+	}
+}
+
+func TestResolveBeadRelations_CrossStore(t *testing.T) {
+	storeA := newTestStore(t)
+	storeB := newTestStore(t)
+	dep, _ := storeB.Create("shared utility pattern", beads.TypeTask, beads.PriorityLow, "helper", "")
+	storeB.Close(dep.ID)
+
+	parent, _ := storeA.Create("main finding", beads.TypeBug, beads.PriorityHigh, "scanner", "")
+	storeA.Close(parent.ID)
+	storeA.Update(parent.ID, func(b *beads.Bead) {
+		b.DependsOn = []string{dep.ID}
+	})
+
+	stores := map[string]*beads.Store{"scanner": storeA, "helper": storeB}
+	srv, _ := newMockWikiServer(t)
+	synth := newTestSynthesizer(t, stores, srv.URL)
+
+	reloaded, _ := storeA.Get(parent.ID)
+	related := synth.resolveBeadRelations(reloaded, "scanner")
+
+	if len(related) != 1 {
+		t.Fatalf("expected 1 related slug from cross-store lookup, got %d", len(related))
+	}
+	want := slugify("shared utility pattern")
+	if related[0] != want {
+		t.Errorf("related[0] = %q, want %q", related[0], want)
+	}
+}
+
+func TestWriteFactToVault_RelatedFrontmatter(t *testing.T) {
+	srv, _ := newMockWikiServer(t)
+	store := newTestStore(t)
+	stores := map[string]*beads.Store{"scanner": store}
+	synth := newTestSynthesizer(t, stores, srv.URL)
+
+	fact := ExtractedFact{
+		Title:      "test fact with relations",
+		Body:       "some body content",
+		Type:       FactGotcha,
+		Confidence: 0.75,
+		Tags:       []string{"testing"},
+		Related:    []string{"auth-handler-fix", "login-validation"},
+		SourcePR:   "bead:scanner/abc123",
+		SourceDate: time.Now(),
+	}
+
+	if err := synth.writeFactToVault(fact); err != nil {
+		t.Fatalf("writeFactToVault failed: %v", err)
+	}
+
+	slug := slugify(fact.Title)
+	content, err := os.ReadFile(filepath.Join(synth.vaultBaseDir, slug+".md"))
+	if err != nil {
+		t.Fatalf("failed to read vault file: %v", err)
+	}
+
+	s := string(content)
+	if !strings.Contains(s, "related: [auth-handler-fix, login-validation]") {
+		t.Errorf("vault file missing related frontmatter, got:\n%s", s)
+	}
+}
+
+func TestWriteFactToVault_EmitsGraphTriples(t *testing.T) {
+	srv, _ := newMockWikiServer(t)
+	store := newTestStore(t)
+	stores := map[string]*beads.Store{"scanner": store}
+	synth := newTestSynthesizer(t, stores, srv.URL)
+
+	graphPath := filepath.Join(t.TempDir(), "test-graph.db")
+	gs, err := NewGraphStore(graphPath, synthTestLogger())
+	if err != nil {
+		t.Fatalf("failed to create graph store: %v", err)
+	}
+	defer gs.Close()
+	synth.SetGraphStore(gs)
+
+	fact := ExtractedFact{
+		Title:      "parent fact",
+		Body:       "body",
+		Type:       FactPattern,
+		Confidence: 0.9,
+		Related:    []string{"child-a", "child-b"},
+		SourcePR:   "bead:scanner/xyz",
+		SourceDate: time.Now(),
+	}
+
+	if err := synth.writeFactToVault(fact); err != nil {
+		t.Fatalf("writeFactToVault failed: %v", err)
+	}
+
+	factSlug := slugify(fact.Title)
+	outgoing := gs.Outgoing(factSlug)
+	if len(outgoing) != 2 {
+		t.Fatalf("expected 2 outgoing triples, got %d", len(outgoing))
+	}
+
+	objects := map[string]bool{}
+	for _, tr := range outgoing {
+		if tr.Predicate != "related_to" {
+			t.Errorf("unexpected predicate %q", tr.Predicate)
+		}
+		objects[tr.Object] = true
+	}
+	if !objects["child-a"] || !objects["child-b"] {
+		t.Errorf("expected child-a and child-b in triples, got %v", objects)
+	}
+}

--- a/v2/pkg/knowledge/curator.go
+++ b/v2/pkg/knowledge/curator.go
@@ -43,12 +43,13 @@ func NewCurator(ghClient *gh.Client, wikiURL string, org string, repos []string,
 
 // ExtractedFact is a fact candidate extracted from a PR before ingestion.
 type ExtractedFact struct {
-	Title      string   `json:"title"`
-	Body       string   `json:"body"`
-	Type       FactType `json:"type"`
-	Confidence float64  `json:"confidence"`
-	Tags       []string `json:"tags"`
-	SourcePR   string   `json:"source_pr"`
+	Title      string    `json:"title"`
+	Body       string    `json:"body"`
+	Type       FactType  `json:"type"`
+	Confidence float64   `json:"confidence"`
+	Tags       []string  `json:"tags"`
+	Related    []string  `json:"related,omitempty"`
+	SourcePR   string    `json:"source_pr"`
 	SourceDate time.Time `json:"source_date"`
 }
 


### PR DESCRIPTION
## Summary
- Implements `resolveBeadRelations()` — maps bead `DependsOn` IDs to fact slugs via cross-store lookup
- Updates `writeFactToVault()` to write `related: [slug-a, slug-b]` YAML frontmatter
- Emits `related_to` graph triples to the GraphStore after writing vault files
- Wires `graphStore` to `beadSynth` in main.go startup
- Adds `Related []string` to `ExtractedFact` struct

## Test plan
- [x] `TestResolveBeadRelations` — single-store dependency resolution
- [x] `TestResolveBeadRelations_NoDeps` — no-op for beads without dependencies
- [x] `TestResolveBeadRelations_CrossStore` — finds deps across different agent stores
- [x] `TestWriteFactToVault_RelatedFrontmatter` — verifies `related:` in YAML output
- [x] `TestWriteFactToVault_EmitsGraphTriples` — verifies triples added to GraphStore
- [x] All existing tests pass