### PR TITLE
fix(dashboard): fact sparkline never populated

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3438,13 +3438,11 @@ func (s *Server) handleKnowledgeStats(w http.ResponseWriter, r *http.Request) {
 	stats["vaults"] = s.deps.Knowledge.Vaults()
 	stats["git_sources"] = s.deps.Knowledge.GitSources()
 
-	if layers, ok := stats["layers"].([]interface{}); ok {
+	if layers, ok := stats["layers"].([]map[string]interface{}); ok {
 		total := 0
-		for _, l := range layers {
-			if m, ok := l.(map[string]interface{}); ok {
-				if p, ok := m["total_pages"].(int); ok {
-					total += p
-				}
+		for _, m := range layers {
+			if p, ok := m["total_pages"].(int); ok {
+				total += p
 			}
 		}
 		s.AppendFactHistory(total)


### PR DESCRIPTION
## Summary
- `Stats()` returns `[]map[string]interface{}` but `handleKnowledgeStats` asserted `[]interface{}` — the type assertion always failed silently
- `AppendFactHistory()` was never called, so the Total Facts sparkline was always empty
- Fixed by asserting the correct type `[]map[string]interface{}`

## Test plan
- [x] Build passes
- [ ] After deploy, wait 5+ minutes with dashboard open — sparkline should appear on the Total Facts block