### PR TITLE
fix: route [agent-name] prefixed issues back to their lane

### DIFF
--- a/v2/pkg/classify/classifier.go
+++ b/v2/pkg/classify/classifier.go
@@ -101,6 +101,23 @@ func Classify(issue github.Issue) Classification {
 }
 
 func classifyLane(titleLower, labelsStr string) Lane {
+	// Title-prefix routing: issues prefixed with [agent-name] route back to
+	// that agent's lane so agents see their own previously-filed issues.
+	for _, lane := range activeLanes() {
+		prefix := "[" + lane.Name + "]"
+		if strings.HasPrefix(titleLower, prefix) {
+			return Lane(lane.Name)
+		}
+	}
+
+	// Label-based routing: a label matching a lane name routes to that lane.
+	for _, lane := range activeLanes() {
+		if strings.Contains(labelsStr, lane.Name) {
+			return Lane(lane.Name)
+		}
+	}
+
+	// Keyword routing (original behavior).
 	for _, lane := range activeLanes() {
 		for _, kw := range lane.Keywords {
 			if strings.Contains(titleLower, kw) || strings.Contains(labelsStr, kw) {

--- a/v2/pkg/classify/classifier_test.go
+++ b/v2/pkg/classify/classifier_test.go
@@ -209,6 +209,59 @@ func TestClassify_OutreachLane(t *testing.T) {
 	}
 }
 
+func TestClassify_TitlePrefixRoutesToLane(t *testing.T) {
+	cases := []struct {
+		title    string
+		wantLane Lane
+	}{
+		{"[quality] kernel-swap.sh has no test coverage", LaneQuality},
+		{"[quality] Add unit tests for Python scripts", LaneQuality},
+		{"[architect] Redesign the webhook subsystem", LaneArchitect},
+		{"[ci-maintainer] Fix nightly build", LaneCIMaintainer},
+		{"[outreach] Contact CNCF project leads", LaneOutreach},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.title, func(t *testing.T) {
+			got := Classify(makeIssue(tc.title))
+			if got.Lane != tc.wantLane {
+				t.Errorf("title %q: want %v, got %v", tc.title, tc.wantLane, got.Lane)
+			}
+		})
+	}
+}
+
+func TestClassify_LabelRoutesToLane(t *testing.T) {
+	cases := []struct {
+		desc     string
+		title    string
+		label    string
+		wantLane Lane
+	}{
+		{"quality label", "Some issue about testing", "quality", LaneQuality},
+		{"architect label", "Improve error handling", "architect", LaneArchitect},
+		{"outreach label", "Follow up with users", "outreach", LaneOutreach},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := Classify(makeIssue(tc.title, tc.label))
+			if got.Lane != tc.wantLane {
+				t.Errorf("%s: want %v, got %v", tc.desc, tc.wantLane, got.Lane)
+			}
+		})
+	}
+}
+
+func TestClassify_PrefixBeatsKeywordMismatch(t *testing.T) {
+	// Title has [quality] prefix but no quality keywords — prefix should win
+	issue := makeIssue("[quality] Build scripts lack test parity with bluefin main")
+	got := Classify(issue)
+	if got.Lane != LaneQuality {
+		t.Errorf("want LaneQuality (prefix routing), got %v", got.Lane)
+	}
+}
+
 func TestClassify_DefaultLaneIsScanner(t *testing.T) {
 	issue := makeIssue("Fix edge case in issue parser")
 	got := Classify(issue)


### PR DESCRIPTION
## Summary

Fixes duplicate issue filing by agents (reported on projectbluefin/dakota — quality agent filed 17+ identical issues about "Python scripts need tests").

**Root cause:** The classifier routes issues to agent lanes by keyword matching. Quality's keywords are `test-gap`, `test-coverage`, etc. But the quality agent's own issues have titles like `[quality] kernel-swap.sh has no test coverage` — "has no test coverage" doesn't match `test-coverage` (space vs hyphen). These issues fall through to the default `scanner` lane, get filtered out of quality's `${ISSUE_LIST}`, and the agent never sees its own prior work. Every kick it rediscovers the same gaps and files new issues.

**Fix:** Add two new routing tiers in `classifyLane()` before keyword matching:

1. **Title-prefix routing** — `[agent-name]` prefix routes to that agent's lane
2. **Label-based routing** — a label matching a lane name routes to that lane

This is generic — works for any agent that prefixes issues with its name. Keyword routing remains as the final fallback.

## Changed files

- `v2/pkg/classify/classifier.go` — added prefix + label routing in `classifyLane()`
- `v2/pkg/classify/classifier_test.go` — 3 new test functions covering prefix routing, label routing, and prefix-beats-keyword-mismatch

## Test plan

- [x] All 39 existing + new classifier tests pass
- [ ] Deploy to a hive instance, verify quality agent's `${ISSUE_LIST}` includes its own `[quality]`-prefixed issues
- [ ] Confirm quality agent stops filing duplicates on next kick