### PR TITLE
fix: guard knowledgeAPI.FileStores() against nil when knowledge is disabled

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -760,11 +760,13 @@ func main() {
 		if beadSynth != nil {
 			beadSynth.SetGraphStore(graphStore)
 		}
-		for _, ls := range knowledgeAPI.FileStores() {
-			if n, err := graphStore.SyncFromFileStore(ls); err != nil {
-				logger.Warn("graph sync failed", "store", ls.Name(), "error", err)
-			} else if n > 0 {
-				logger.Info("graph synced from vault", "store", ls.Name(), "triples", n)
+		if knowledgeAPI != nil {
+			for _, ls := range knowledgeAPI.FileStores() {
+				if n, err := graphStore.SyncFromFileStore(ls); err != nil {
+					logger.Warn("graph sync failed", "store", ls.Name(), "error", err)
+				} else if n > 0 {
+					logger.Info("graph synced from vault", "store", ls.Name(), "triples", n)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Fixes nil pointer panic that crashes all hives without `knowledge.enabled` set in config.

## Root cause
PR #1684 added a `knowledgeAPI.FileStores()` call at `main.go:763` outside the nil guard. `knowledgeAPI` is only initialized when `cfg.Knowledge.Enabled` is true, but `FileStores()` is called unconditionally — causing a nil pointer dereference on startup.

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/kubestellar/hive/v2/pkg/knowledge.(*KnowledgeAPI).FileStores(...)
    /src/pkg/knowledge/api.go:501 +0x28
main.main()
    /src/cmd/hive/main.go:763 +0x43c0
```

## Impact
**6 hosted hives are currently in CrashLoopBackOff** — ai-native-systems-research, kothya, aslom, llm-d-incubation, open-source, ibm. Their old pods (pre-#1684) are still running but the new pods crash immediately on startup.

## Fix
Wrap the `FileStores()` loop in the same `if knowledgeAPI != nil` guard used for `SetGraphStore()` on the line above.

## Test plan
- [ ] Hive without knowledge enabled starts without panic
- [ ] Hive with knowledge enabled still syncs vaults to graph store