### PR TITLE
fix: defer graph store open to unblock rolling updates

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -745,11 +745,17 @@ func main() {
 		}
 	}
 
+	// Open the graph store in a background goroutine. NewGraphStore acquires
+	// a SQLite file lock that blocks if the old pod still holds it. Deferring
+	// this lets the HTTP server start so the readiness probe passes, which
+	// tells Kubernetes to terminate the old pod and release the lock.
 	const graphStorePath = "/data/graph/knowledge.db"
-	graphStore, graphErr := knowledge.NewGraphStore(graphStorePath, logger)
-	if graphErr != nil {
-		logger.Warn("failed to open knowledge graph store", "path", graphStorePath, "error", graphErr)
-	} else {
+	go func() {
+		graphStore, graphErr := knowledge.NewGraphStore(graphStorePath, logger)
+		if graphErr != nil {
+			logger.Warn("failed to open knowledge graph store", "path", graphStorePath, "error", graphErr)
+			return
+		}
 		logger.Info("knowledge graph store opened", "path", graphStorePath)
 		if primer := sched.GetPrimer(); primer != nil {
 			primer.SetGraphStore(graphStore)
@@ -769,7 +775,7 @@ func main() {
 				}
 			}
 		}
-	}
+	}()
 
 	os.MkdirAll(nousSnapshotDir, 0o755)
 	os.MkdirAll(nousGovernorDir, 0o755)


### PR DESCRIPTION
## Summary
Fixes rolling update deadlock that prevents all hosted hive spokes from upgrading.

## Root cause
`NewGraphStore()` acquires a SQLite file lock on `/data/graph/knowledge.db`. During a rolling update, the old pod holds this lock. The new pod blocks on `NewGraphStore()` at line 749 — before the HTTP server starts — so the readiness probe never passes and Kubernetes never terminates the old pod. Result: permanent deadlock, new pod stays 0/1 forever.

Currently affecting **all hosted hive spokes on hive-oke** — ai-native-systems-research, kubestellar, kellyaa, aslom, llm-d-incubation, ibm (and previously open-source on vllm-d).

## Fix
Move graph store initialization into a background goroutine. The HTTP server starts immediately, readiness probe passes, Kubernetes kills the old pod, SQLite lock releases, goroutine completes setup. No downtime, no data loss.

## Test plan
- [ ] Rolling update completes — new pod passes readiness before graph store opens
- [ ] Graph store initializes after old pod terminates
- [ ] Knowledge API, primer, and bead synth wire up correctly after deferred init