### PR TITLE
fix: add periodic workspace cleanup for stale agent repo clones

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -777,6 +777,8 @@ func main() {
 		}
 	}()
 
+	go dashboard.StartWorkspaceCleanup(ctx, logger)
+
 	os.MkdirAll(nousSnapshotDir, 0o755)
 	os.MkdirAll(nousGovernorDir, 0o755)
 	nousState := loadNousState(logger)

--- a/v2/pkg/dashboard/workspace_cleanup.go
+++ b/v2/pkg/dashboard/workspace_cleanup.go
@@ -1,0 +1,107 @@
+package dashboard
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	workspaceCleanupInterval = 1 * time.Hour
+	workspaceMaxAge          = 2 * time.Hour
+	agentWorkspaceRoot       = "/data/agents"
+)
+
+// StartWorkspaceCleanup runs a background loop that periodically sweeps
+// /data/agents/*/ for stale git repository clones and removes them.
+// This prevents unbounded disk growth from scanner and other agents that
+// clone repos for each task but never clean up.
+func StartWorkspaceCleanup(ctx context.Context, logger *slog.Logger) {
+	logger.Info("workspace cleanup enabled", "interval", workspaceCleanupInterval, "max_age", workspaceMaxAge)
+
+	sweepWorkspaces(logger)
+
+	ticker := time.NewTicker(workspaceCleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			sweepWorkspaces(logger)
+		}
+	}
+}
+
+func sweepWorkspaces(logger *slog.Logger) {
+	agentDirs, err := os.ReadDir(agentWorkspaceRoot)
+	if err != nil {
+		logger.Debug("workspace cleanup: cannot read agent root", "path", agentWorkspaceRoot, "error", err)
+		return
+	}
+
+	removed := 0
+	now := time.Now()
+
+	for _, agentEntry := range agentDirs {
+		if !agentEntry.IsDir() {
+			continue
+		}
+		agentName := agentEntry.Name()
+		agentPath := filepath.Join(agentWorkspaceRoot, agentName)
+
+		subdirs, err := os.ReadDir(agentPath)
+		if err != nil {
+			continue
+		}
+
+		for _, sub := range subdirs {
+			if !sub.IsDir() {
+				continue
+			}
+			dirName := sub.Name()
+			if isSkippedDir(dirName) {
+				continue
+			}
+
+			dirPath := filepath.Join(agentPath, dirName)
+			gitPath := filepath.Join(dirPath, ".git")
+
+			if _, err := os.Stat(gitPath); err != nil {
+				continue
+			}
+
+			info, err := sub.Info()
+			if err != nil {
+				continue
+			}
+			age := now.Sub(info.ModTime())
+			if age < workspaceMaxAge {
+				continue
+			}
+
+			if err := os.RemoveAll(dirPath); err != nil {
+				logger.Warn("workspace cleanup: failed to remove stale clone",
+					"agent", agentName, "dir", dirName, "error", err)
+				continue
+			}
+
+			logger.Info("workspace cleanup: removed stale clone",
+				"agent", agentName, "dir", dirName, "age", age.Round(time.Minute))
+			removed++
+		}
+	}
+
+	logger.Info("workspace cleanup complete", "removed", removed)
+}
+
+func isSkippedDir(name string) bool {
+	switch name {
+	case ".cache", ".config", ".npm-cache", "bin":
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Adds a background goroutine that sweeps `/data/agents/*/` every hour and removes git repository clones older than 2 hours
- Prevents unbounded disk growth from agents (especially scanner) that clone repos per task but never clean up
- Keeps entrypoint `chown -R` fast during rolling updates — the 20GB scanner dir was causing new pods to hang for 10+ minutes

## Root cause
Scanner agent accumulated 57 git repo clones (20GB) in `/data/agents/scanner/`. During rolling updates, the entrypoint's `chown -R` recursed through all of them over NFS, blocking pod startup past the startup probe timeout.

## Changes
- **`v2/pkg/dashboard/workspace_cleanup.go`** (new): `StartWorkspaceCleanup` goroutine — hourly sweep, removes `.git`-containing dirs older than 2h, skips `.cache`/`.config`/`.npm-cache`/`bin`
- **`v2/cmd/hive/main.go`**: Wire up cleanup goroutine after graph store init

## Test plan
- [ ] Verify cleanup logs appear in pod logs after 1 hour
- [ ] Verify scanner dir stays small across agent kicks
- [ ] Verify rolling updates complete within startup probe timeout