### PR TITLE
feat: match GitHub App webhooks via heartbeat pending-install flag

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -870,6 +870,7 @@ func main() {
 					advisoryIssues[newPrimaryRepo] = num
 					os.Setenv("HIVE_ADVISORY_ISSUE", fmt.Sprintf("%d", num))
 					dashSrv.SetGitHubAppRequired(false)
+					dashSrv.ClearPendingGitHubAppInstall()
 					logger.Info("advisory issue ready on new primary repo", "repo", newPrimaryRepo, "number", num)
 				}
 			}
@@ -958,6 +959,7 @@ func main() {
 						advisoryIssues[primaryRepo] = num
 						os.Setenv("HIVE_ADVISORY_ISSUE", fmt.Sprintf("%d", num))
 						dashSrv.SetGitHubAppRequired(false)
+						dashSrv.ClearPendingGitHubAppInstall()
 						logger.Info("github app retry: app detected, advisory issue ready", "repo", primaryRepo, "number", num)
 					}
 				}
@@ -1268,9 +1270,10 @@ func main() {
 				Version:           "3.0.0",
 				GitHash:           gitShort,
 				GitBranch:         gitBranch,
-				GitHubAppRequired:  dashSrv.IsGitHubAppRequired(),
-				GitHubAppPermIssue: dashSrv.GetGitHubAppPermIssue(),
-				AutoUpgrade:       cfg.Hub.AutoUpgrade,
+				GitHubAppRequired:       dashSrv.IsGitHubAppRequired(),
+				GitHubAppPermIssue:      dashSrv.GetGitHubAppPermIssue(),
+				PendingGitHubAppInstall: dashSrv.IsPendingGitHubAppInstall(),
+				AutoUpgrade:             cfg.Hub.AutoUpgrade,
 				ClusterHealth: func() *hub.HeartbeatClusterHealthReport {
 					if os.Getenv("HIVE_CLUSTER_ID") == "" {
 						return nil

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -2958,6 +2958,12 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 	okResponse(w, map[string]string{"status": "updated"})
 }
 
+func (s *Server) handleGitHubAppInstallClicked(w http.ResponseWriter, r *http.Request) {
+	s.SetPendingGitHubAppInstall()
+	s.deps.Logger.Info("github app install link clicked, flagging heartbeat")
+	okResponse(w, map[string]string{"status": "pending"})
+}
+
 // --- GitHub config endpoint ---
 
 func (s *Server) handleConfigGitHub(w http.ResponseWriter, r *http.Request) {
@@ -3029,6 +3035,7 @@ func (s *Server) handleConfigGitHub(w http.ResponseWriter, r *http.Request) {
 			} else {
 				result["reinit"] = "ok"
 				s.SetGitHubAppRequired(false)
+				s.ClearPendingGitHubAppInstall()
 			}
 		}
 	}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -76,10 +76,12 @@ type Server struct {
 	ready   bool
 	readyAt time.Time
 
-	githubAppMu         sync.RWMutex
-	githubAppRequired   bool
-	githubAppInstallURL string
-	githubAppPermIssue  string // non-empty when app is installed but lacks required permissions
+	githubAppMu                 sync.RWMutex
+	githubAppRequired           bool
+	githubAppInstallURL         string
+	githubAppPermIssue          string // non-empty when app is installed but lacks required permissions
+	pendingGitHubAppInstall     bool
+	pendingGitHubAppInstallAt   time.Time
 
 	systemAlertsMu sync.RWMutex
 	systemAlerts   []SystemAlert
@@ -372,6 +374,7 @@ func (s *Server) registerCoreRoutes() {
 	s.mux.HandleFunc("GET /api/status", s.handleStatus)
 	s.mux.HandleFunc("GET /api/events", s.handleSSE)
 	s.mux.HandleFunc("POST /api/github-app/recheck", s.handleGitHubAppRecheck)
+	s.mux.HandleFunc("POST /api/github-app/install-clicked", s.handleGitHubAppInstallClicked)
 }
 
 func (s *Server) Start() error {
@@ -692,6 +695,32 @@ func (s *Server) IsGitHubAppRequired() bool {
 	return s.githubAppRequired
 }
 
+func (s *Server) SetPendingGitHubAppInstall() {
+	s.githubAppMu.Lock()
+	defer s.githubAppMu.Unlock()
+	s.pendingGitHubAppInstall = true
+	s.pendingGitHubAppInstallAt = time.Now()
+}
+
+func (s *Server) IsPendingGitHubAppInstall() bool {
+	s.githubAppMu.RLock()
+	defer s.githubAppMu.RUnlock()
+	if !s.pendingGitHubAppInstall {
+		return false
+	}
+	const pendingInstallExpiry = 10 * time.Minute
+	if time.Since(s.pendingGitHubAppInstallAt) > pendingInstallExpiry {
+		return false
+	}
+	return true
+}
+
+func (s *Server) ClearPendingGitHubAppInstall() {
+	s.githubAppMu.Lock()
+	defer s.githubAppMu.Unlock()
+	s.pendingGitHubAppInstall = false
+}
+
 // UpdateGitHubClient swaps the GitHub client and app auth references stored in
 // the dashboard dependencies. Called after the config API reinitializes app auth.
 func (s *Server) UpdateGitHubClient(client *github.Client, auth *github.AppAuth) {
@@ -715,6 +744,7 @@ func (s *Server) handleGitHubAppRecheck(w http.ResponseWriter, r *http.Request) 
 	if ok {
 		s.SetGitHubAppRequired(false)
 		s.SetGitHubAppPermIssue("")
+		s.ClearPendingGitHubAppInstall()
 		w.Write([]byte(`{"status":"installed"}`))
 	} else {
 		s.githubAppMu.RLock()

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -118,8 +118,9 @@ type HeartbeatPayload struct {
 	GitHubAppPermIssue string         `json:"github_app_perm_issue,omitempty"`
 	AutoUpgrade        bool           `json:"auto_upgrade,omitempty"`
 	Upgrading          bool           `json:"upgrading,omitempty"`
-	UpgradeTargetSHA   string         `json:"upgrade_target_sha,omitempty"`
-	ClusterHealth      *HeartbeatClusterHealthReport `json:"cluster_health,omitempty"`
+	UpgradeTargetSHA        string         `json:"upgrade_target_sha,omitempty"`
+	PendingGitHubAppInstall bool           `json:"pending_github_app_install,omitempty"`
+	ClusterHealth           *HeartbeatClusterHealthReport `json:"cluster_health,omitempty"`
 }
 
 type StatusCollector func() *HeartbeatPayload

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -73,8 +73,10 @@ type RegistryEntry struct {
 	UpgradeStartedAt   time.Time      `json:"upgradeStartedAt,omitempty"`
 	IssueHistory       []SparkPoint   `json:"issueHistory,omitempty"`
 	PRHistory          []SparkPoint   `json:"prHistory,omitempty"`
-	GitHubAppRequired  bool           `json:"githubAppRequired,omitempty"`
-	GitHubAppPermIssue string         `json:"githubAppPermIssue,omitempty"`
+	GitHubAppRequired       bool           `json:"githubAppRequired,omitempty"`
+	GitHubAppPermIssue      string         `json:"githubAppPermIssue,omitempty"`
+	PendingGitHubAppInstall bool           `json:"pendingGitHubAppInstall,omitempty"`
+	PendingGitHubAppInstallAt time.Time    `json:"pendingGitHubAppInstallAt,omitempty"`
 }
 
 type SparkPoint struct {
@@ -130,6 +132,11 @@ type HubServer struct {
 	// Key: hive ID, value: target SHA.  Cleared when the spoke reports the
 	// target SHA, proving the upgrade completed.
 	heartbeatUpgrade map[string]string
+
+	// pendingWebhooks stores GitHub App installation webhooks that arrived
+	// before the matching spoke heartbeat.  Key: lowercase org name.
+	pendingWebhooks   map[string]*pendingWebhookEntry
+	pendingWebhooksMu sync.Mutex
 }
 
 func NewHubServer(port int, logger *slog.Logger, gitHash string) *HubServer {
@@ -159,6 +166,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash string) *HubServer {
 		clusters:         loadClusters(logger),
 		heartbeatHealth:  make(map[string]*HeartbeatHealthEntry),
 		heartbeatUpgrade: make(map[string]string),
+		pendingWebhooks:  make(map[string]*pendingWebhookEntry),
 	}
 
 	s.loadRegistry()
@@ -357,8 +365,15 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			return payload.Leaderboard
 		}(),
 		Online:            true,
-		GitHubAppRequired:  payload.GitHubAppRequired,
-		GitHubAppPermIssue: sanitizeHeartbeatField(payload.GitHubAppPermIssue),
+		GitHubAppRequired:       payload.GitHubAppRequired,
+		GitHubAppPermIssue:      sanitizeHeartbeatField(payload.GitHubAppPermIssue),
+		PendingGitHubAppInstall: payload.PendingGitHubAppInstall,
+		PendingGitHubAppInstallAt: func() time.Time {
+			if payload.PendingGitHubAppInstall {
+				return time.Now()
+			}
+			return time.Time{}
+		}(),
 	}
 
 	// Populate ClusterID from SaaS hive record, heartbeat payload, or default.
@@ -476,6 +491,11 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			"cluster_id", entry.ClusterID,
 			"nodes", len(payload.ClusterHealth.Nodes),
 		)
+	}
+
+	// Check if a pending webhook matches this heartbeat's pending install flag.
+	if payload.PendingGitHubAppInstall {
+		s.checkPendingWebhookMatch(payload.Org, payload.HiveID)
 	}
 
 	s.logger.Info("audit: hub heartbeat received",

--- a/v2/pkg/hub/webhook.go
+++ b/v2/pkg/hub/webhook.go
@@ -107,9 +107,21 @@ func (s *HubServer) handleInstallationEvent(body []byte) {
 		"repos", repos,
 	)
 
-	hive := s.findHiveByOrgRepos(org, repos)
+	// 1. Check for a spoke that recently signaled it's waiting for a GitHub App install.
+	hive := s.findHiveByPendingInstall(org)
+
+	// 2. Fall back to repo-name matching for hives that were already registered.
 	if hive == nil {
-		s.logger.Info("no matching hive found for installation", "org", org, "repos", repos)
+		hive = s.findHiveByOrgRepos(org, repos)
+	}
+
+	// 3. No match yet — store the webhook for deferred heartbeat matching.
+	if hive == nil {
+		s.storePendingWebhook(org, appID, installationID)
+		s.logger.Info("no matching hive found, storing webhook for deferred heartbeat matching",
+			"org", org,
+			"installation_id", installationID,
+		)
 		return
 	}
 
@@ -122,6 +134,12 @@ func (s *HubServer) handleInstallationEvent(body []byte) {
 		"hive_id", hive.ID,
 		"dashboard_url", hive.DashboardURL,
 		"installation_id", installationID,
+		"match_method", func() string {
+			if hive.PendingGitHubAppInstall {
+				return "pending-install-heartbeat"
+			}
+			return "org-repo-match"
+		}(),
 	)
 
 	go s.pushGitHubConfigToSpoke(hive, appID, installationID)
@@ -329,4 +347,75 @@ func verifyWebhookSignature(payload []byte, signature, secret string) bool {
 	mac.Write(payload)
 	expected := mac.Sum(nil)
 	return hmac.Equal(sig, expected)
+}
+
+const pendingWebhookExpiry = 5 * time.Minute
+
+type pendingWebhookEntry struct {
+	Org            string
+	AppID          int64
+	InstallationID int64
+	ReceivedAt     time.Time
+}
+
+func (s *HubServer) storePendingWebhook(org string, appID, installationID int64) {
+	s.pendingWebhooksMu.Lock()
+	defer s.pendingWebhooksMu.Unlock()
+	s.pendingWebhooks[strings.ToLower(org)] = &pendingWebhookEntry{
+		Org:            org,
+		AppID:          appID,
+		InstallationID: installationID,
+		ReceivedAt:     time.Now(),
+	}
+}
+
+func (s *HubServer) findHiveByPendingInstall(org string) *RegistryEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for i := range s.registry.Hives {
+		h := &s.registry.Hives[i]
+		if !h.PendingGitHubAppInstall {
+			continue
+		}
+		if strings.EqualFold(h.Org, org) {
+			return h
+		}
+	}
+	return nil
+}
+
+func (s *HubServer) checkPendingWebhookMatch(org, hiveID string) {
+	s.pendingWebhooksMu.Lock()
+	key := strings.ToLower(org)
+	pw, ok := s.pendingWebhooks[key]
+	if !ok || time.Since(pw.ReceivedAt) > pendingWebhookExpiry {
+		s.pendingWebhooksMu.Unlock()
+		return
+	}
+	delete(s.pendingWebhooks, key)
+	s.pendingWebhooksMu.Unlock()
+
+	s.mu.RLock()
+	var hive *RegistryEntry
+	for i := range s.registry.Hives {
+		if s.registry.Hives[i].ID == hiveID {
+			hive = &s.registry.Hives[i]
+			break
+		}
+	}
+	s.mu.RUnlock()
+
+	if hive == nil || hive.DashboardURL == "" {
+		s.logger.Warn("pending webhook matched but hive not found or has no dashboard URL",
+			"hive_id", hiveID, "org", org)
+		return
+	}
+
+	s.logger.Info("pending webhook matched via heartbeat",
+		"hive_id", hiveID,
+		"org", org,
+		"installation_id", pw.InstallationID,
+	)
+
+	go s.pushGitHubConfigToSpoke(hive, pw.AppID, pw.InstallationID)
 }


### PR DESCRIPTION
## Summary
- Replaces unreliable repo-name matching for GitHub App webhook→spoke correlation with a heartbeat-based approach
- When a user clicks the install link, the spoke sets `PendingGitHubAppInstall` in its heartbeat
- Hub uses a 3-tier matching strategy: pending-install heartbeat → org/repo fallback → store webhook for deferred matching (5 min TTL)

## Problem
When a user installs the GitHub App on their org, GitHub sends an `installation_repositories` webhook to the hub. The hub needs to match this to the correct spoke. The previous approach parsed repo names from the webhook payload, but:
- `installation_repositories.added` events use `repositories_added` not `repositories`
- Org-level installs can have an empty repo list
- No temporal correlation between the user action and the webhook

## How it works now
1. **Spoke**: User clicks install link → `POST /api/github-app/install-clicked` → sets `PendingGitHubAppInstall=true` in next heartbeat (auto-expires after 10 min)
2. **Hub receives webhook**: Checks registry for a spoke with `PendingGitHubAppInstall=true` matching the org. If found, pushes config immediately.
3. **Hub receives webhook first**: If no pending match, stores the webhook (5 min TTL). When a heartbeat arrives with the flag, it checks stored webhooks and pushes config.
4. **Fallback**: Existing org/repo matching still works as tier 2

## Changes
- **`v2/pkg/hub/heartbeat.go`**: Added `PendingGitHubAppInstall` to `HeartbeatPayload`
- **`v2/pkg/hub/server.go`**: Added fields to `RegistryEntry` and `HubServer`, heartbeat handler checks pending webhooks
- **`v2/pkg/hub/webhook.go`**: 3-tier matching, `pendingWebhookEntry` type, store/find/check methods
- **`v2/pkg/dashboard/server.go`**: Pending install state + methods, new route registration
- **`v2/pkg/dashboard/api.go`**: `handleGitHubAppInstallClicked` handler, clear on config success
- **`v2/cmd/hive/main.go`**: Heartbeat builder includes flag, clear at all `SetGitHubAppRequired(false)` sites

## Test plan
- [ ] Install GitHub App on a new org — verify hub logs show `pending-install-heartbeat` match method
- [ ] Redeliver webhook after spoke is running — verify deferred matching works
- [ ] Verify existing org/repo fallback still works for already-configured hives
- [ ] Verify pending flag auto-expires after 10 minutes