### PR TITLE
feat: deliver GitHub App config via heartbeat response

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1342,7 +1342,50 @@ func main() {
 			}, targetSHA, logger)
 
 			os.Exit(0)
-		})
+		}, hub.GitHubAppConfigCallback(func(ghCfg *hub.HeartbeatGitHubAppConfig) {
+			logger.Info("received github app config via heartbeat",
+				"app_id", ghCfg.AppID,
+				"installation_id", ghCfg.InstallationID,
+				"has_key", ghCfg.PrivateKey != "",
+			)
+
+			keyPath := "/data/gh-app-key.pem"
+			if ghCfg.PrivateKey != "" {
+				const keyFileMode = 0o600
+				if err := os.WriteFile(keyPath, []byte(ghCfg.PrivateKey), keyFileMode); err != nil {
+					logger.Error("failed to write github app key from heartbeat", "error", err)
+					return
+				}
+				logger.Info("github app private key written via heartbeat", "path", keyPath)
+			}
+
+			cfg.GitHub.AppID = ghCfg.AppID
+			cfg.GitHub.InstallationID = ghCfg.InstallationID
+			if ghCfg.PrivateKey != "" {
+				cfg.GitHub.KeyFile = keyPath
+			}
+
+			if cfg.GitHub.AppID != 0 && cfg.GitHub.InstallationID != 0 && cfg.GitHub.KeyFile != "" {
+				newAppAuth, err := github.NewAppAuth(cfg.GitHub.AppID, cfg.GitHub.InstallationID, cfg.GitHub.KeyFile, logger, cfg.GitHub.ResolvedAPIURL())
+				if err != nil {
+					logger.Error("github app auth init via heartbeat failed", "error", err)
+					return
+				}
+				newClient := github.NewClientFromApp(newAppAuth, cfg.Project.Org, cfg.Project.Repos, logger)
+				if len(cfg.Governor.Labels.Exempt) > 0 {
+					newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
+				}
+				ghClient = newClient
+				appAuth = newAppAuth
+				dashSrv.UpdateGitHubClient(newClient, newAppAuth)
+				dashSrv.SetGitHubAppRequired(false)
+				dashSrv.ClearPendingGitHubAppInstall()
+				logger.Info("github app configured via heartbeat delivery",
+					"app_id", cfg.GitHub.AppID,
+					"installation_id", cfg.GitHub.InstallationID,
+				)
+			}
+		}))
 
 		go hub.StartTaskStatusPush(ctx, hubURL, func() *hub.TaskStatusPayload {
 			reg, active := dashSrv.ContributorSummary()

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -129,23 +129,39 @@ type StatusCollector func() *HeartbeatPayload
 // to a specific SHA via the heartbeat response.
 type UpgradeCallback func(targetSHA string)
 
-func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, interval time.Duration, logger *slog.Logger, opts ...UpgradeCallback) {
+func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, interval time.Duration, logger *slog.Logger, callbacks ...any) {
 	if hubURL == "" {
 		logger.Info("hub heartbeat disabled (no HIVE_HUB_URL)")
 		return
 	}
 	var onUpgrade UpgradeCallback
-	if len(opts) > 0 {
-		onUpgrade = opts[0]
+	var onGitHubAppConfig GitHubAppConfigCallback
+	for _, cb := range callbacks {
+		switch fn := cb.(type) {
+		case UpgradeCallback:
+			onUpgrade = fn
+		case GitHubAppConfigCallback:
+			onGitHubAppConfig = fn
+		}
 	}
 
 	logger.Info("hub heartbeat enabled", "url", hubURL, "interval", interval)
 
 	waitForReady(ctx, logger)
 
-	if target := sendHeartbeat(ctx, hubURL, collect, logger); target != "" && onUpgrade != nil {
-		onUpgrade(target)
+	processHeartbeatResponse := func(resp *HeartbeatResponse) {
+		if resp == nil {
+			return
+		}
+		if resp.UpgradeTo != "" && onUpgrade != nil {
+			onUpgrade(resp.UpgradeTo)
+		}
+		if resp.GitHubAppConfig != nil && onGitHubAppConfig != nil {
+			onGitHubAppConfig(resp.GitHubAppConfig)
+		}
 	}
+
+	processHeartbeatResponse(sendHeartbeat(ctx, hubURL, collect, logger))
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
@@ -156,9 +172,7 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 			logger.Info("hub heartbeat stopped")
 			return
 		case <-ticker.C:
-			if target := sendHeartbeat(ctx, hubURL, collect, logger); target != "" && onUpgrade != nil {
-				onUpgrade(target)
-			}
+			processHeartbeatResponse(sendHeartbeat(ctx, hubURL, collect, logger))
 		}
 	}
 }
@@ -198,12 +212,10 @@ func waitForReady(ctx context.Context, logger *slog.Logger) {
 
 var validNamePattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
-// sendHeartbeat posts the heartbeat payload and returns the upgrade target SHA
-// if the hub instructs this hive to upgrade (empty string otherwise).
-func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, logger *slog.Logger) string {
+func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, logger *slog.Logger) *HeartbeatResponse {
 	payload := collect()
 	if payload == nil {
-		return ""
+		return nil
 	}
 	payload.Timestamp = time.Now().UTC().Format(time.RFC3339)
 
@@ -226,7 +238,7 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 	body, err := json.Marshal(payload)
 	if err != nil {
 		logger.Warn("hub heartbeat marshal failed", "error", err)
-		return ""
+		return nil
 	}
 
 	reqCtx, cancel := context.WithTimeout(ctx, heartbeatTimeout)
@@ -235,7 +247,7 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, hubURL+"/api/heartbeat", bytes.NewReader(body))
 	if err != nil {
 		logger.Warn("hub heartbeat request failed", "error", err)
-		return ""
+		return nil
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if secret := os.Getenv("HIVE_HUB_SECRET"); secret != "" {
@@ -245,14 +257,14 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		logger.Debug("hub heartbeat unreachable", "error", err)
-		return ""
+		return nil
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 300 {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
 		logger.Warn("hub heartbeat rejected", "status", resp.StatusCode, "body", string(respBody))
-		return ""
+		return nil
 	}
 
 	var hbResp HeartbeatResponse
@@ -262,10 +274,16 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 		}
 		if hbResp.UpgradeTo != "" {
 			logger.Info("hub instructed upgrade via heartbeat", "target", hbResp.UpgradeTo)
-			return hbResp.UpgradeTo
 		}
+		if hbResp.GitHubAppConfig != nil {
+			logger.Info("hub delivered github app config via heartbeat",
+				"app_id", hbResp.GitHubAppConfig.AppID,
+				"installation_id", hbResp.GitHubAppConfig.InstallationID,
+			)
+		}
+		return &hbResp
 	}
-	return ""
+	return nil
 }
 
 // SendUpgradingHeartbeat sends a final heartbeat to the hub indicating this
@@ -306,16 +324,30 @@ func SendUpgradingHeartbeat(hubURL string, collect StatusCollector, targetSHA st
 	logger.Info("upgrading heartbeat sent to hub", "target", targetSHA)
 }
 
+// HeartbeatGitHubAppConfig carries GitHub App credentials from the hub to
+// a spoke via the heartbeat response, bypassing OAuth proxies that block
+// direct HTTP pushes.
+type HeartbeatGitHubAppConfig struct {
+	AppID          int64  `json:"app_id"`
+	InstallationID int64  `json:"installation_id"`
+	PrivateKey     string `json:"private_key,omitempty"`
+}
+
 // HeartbeatResponse is the JSON body returned by the hub's heartbeat endpoint.
 // It includes version info so the spoke can display hub version on its dashboard
 // and self-upgrade when behind.
 type HeartbeatResponse struct {
-	OK         bool   `json:"ok"`
-	UpgradeTo  string `json:"upgrade_to,omitempty"`
-	HubGitHash string `json:"hub_git_hash,omitempty"`
-	LatestSHA  string `json:"latest_sha,omitempty"`
-	LatestTag  string `json:"latest_tag,omitempty"`
+	OK              bool                      `json:"ok"`
+	UpgradeTo       string                    `json:"upgrade_to,omitempty"`
+	HubGitHash      string                    `json:"hub_git_hash,omitempty"`
+	LatestSHA       string                    `json:"latest_sha,omitempty"`
+	LatestTag       string                    `json:"latest_tag,omitempty"`
+	GitHubAppConfig *HeartbeatGitHubAppConfig `json:"github_app_config,omitempty"`
 }
+
+// GitHubAppConfigCallback is called when the hub delivers GitHub App config
+// via the heartbeat response (app ID, installation ID, private key).
+type GitHubAppConfigCallback func(cfg *HeartbeatGitHubAppConfig)
 
 const taskPushInterval = 30 * time.Second
 

--- a/v2/pkg/hub/hub_heartbeat_test.go
+++ b/v2/pkg/hub/hub_heartbeat_test.go
@@ -251,12 +251,16 @@ func TestSendHeartbeatUpgradeResponse(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	target := sendHeartbeat(ctx, server.URL, func() *HeartbeatPayload {
+	resp := sendHeartbeat(ctx, server.URL, func() *HeartbeatPayload {
 		return &HeartbeatPayload{HiveID: "test", GitHash: "old123"}
 	}, slog.Default())
 
-	if target != "abc1234" {
-		t.Errorf("expected upgrade target 'abc1234', got %q", target)
+	if resp == nil || resp.UpgradeTo != "abc1234" {
+		got := ""
+		if resp != nil {
+			got = resp.UpgradeTo
+		}
+		t.Errorf("expected upgrade target 'abc1234', got %q", got)
 	}
 }
 
@@ -273,12 +277,12 @@ func TestSendHeartbeatNoUpgrade(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	target := sendHeartbeat(ctx, server.URL, func() *HeartbeatPayload {
+	resp := sendHeartbeat(ctx, server.URL, func() *HeartbeatPayload {
 		return &HeartbeatPayload{HiveID: "test", GitHash: "current123"}
 	}, slog.Default())
 
-	if target != "" {
-		t.Errorf("expected empty upgrade target, got %q", target)
+	if resp != nil && resp.UpgradeTo != "" {
+		t.Errorf("expected empty upgrade target, got %q", resp.UpgradeTo)
 	}
 }
 

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -137,6 +137,11 @@ type HubServer struct {
 	// before the matching spoke heartbeat.  Key: lowercase org name.
 	pendingWebhooks   map[string]*pendingWebhookEntry
 	pendingWebhooksMu sync.Mutex
+
+	// pendingGitHubAppConfigs stores GitHub App config to deliver to spokes
+	// via heartbeat response (bypasses OAuth proxies). Key: hive ID.
+	pendingGitHubAppConfigs   map[string]*HeartbeatGitHubAppConfig
+	pendingGitHubAppConfigsMu sync.Mutex
 }
 
 func NewHubServer(port int, logger *slog.Logger, gitHash string) *HubServer {
@@ -166,7 +171,8 @@ func NewHubServer(port int, logger *slog.Logger, gitHash string) *HubServer {
 		clusters:         loadClusters(logger),
 		heartbeatHealth:  make(map[string]*HeartbeatHealthEntry),
 		heartbeatUpgrade: make(map[string]string),
-		pendingWebhooks:  make(map[string]*pendingWebhookEntry),
+		pendingWebhooks:         make(map[string]*pendingWebhookEntry),
+		pendingGitHubAppConfigs: make(map[string]*HeartbeatGitHubAppConfig),
 	}
 
 	s.loadRegistry()
@@ -561,9 +567,35 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		)
 	}
 
+	if ghCfg := s.consumePendingGitHubAppConfig(payload.HiveID); ghCfg != nil {
+		resp.GitHubAppConfig = ghCfg
+		s.logger.Info("heartbeat: delivering github app config to spoke",
+			"hive_id", payload.HiveID,
+			"app_id", ghCfg.AppID,
+			"installation_id", ghCfg.InstallationID,
+		)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	data, _ := json.Marshal(resp)
 	w.Write(data)
+}
+
+func (s *HubServer) storePendingGitHubAppConfig(hiveID string, cfg *HeartbeatGitHubAppConfig) {
+	s.pendingGitHubAppConfigsMu.Lock()
+	defer s.pendingGitHubAppConfigsMu.Unlock()
+	s.pendingGitHubAppConfigs[hiveID] = cfg
+}
+
+func (s *HubServer) consumePendingGitHubAppConfig(hiveID string) *HeartbeatGitHubAppConfig {
+	s.pendingGitHubAppConfigsMu.Lock()
+	defer s.pendingGitHubAppConfigsMu.Unlock()
+	cfg, ok := s.pendingGitHubAppConfigs[hiveID]
+	if !ok {
+		return nil
+	}
+	delete(s.pendingGitHubAppConfigs, hiveID)
+	return cfg
 }
 
 func (s *HubServer) handleRegistry(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/hub/webhook.go
+++ b/v2/pkg/hub/webhook.go
@@ -125,14 +125,10 @@ func (s *HubServer) handleInstallationEvent(body []byte) {
 		return
 	}
 
-	if hive.DashboardURL == "" {
-		s.logger.Warn("matching hive has no dashboard URL", "hive_id", hive.ID)
-		return
-	}
+	privateKey := s.loadAppPrivateKey(hive)
 
-	s.logger.Info("pushing github app config to spoke",
+	s.logger.Info("storing github app config for heartbeat delivery",
 		"hive_id", hive.ID,
-		"dashboard_url", hive.DashboardURL,
 		"installation_id", installationID,
 		"match_method", func() string {
 			if hive.PendingGitHubAppInstall {
@@ -142,7 +138,11 @@ func (s *HubServer) handleInstallationEvent(body []byte) {
 		}(),
 	)
 
-	go s.pushGitHubConfigToSpoke(hive, appID, installationID)
+	s.storePendingGitHubAppConfig(hive.ID, &HeartbeatGitHubAppConfig{
+		AppID:          appID,
+		InstallationID: installationID,
+		PrivateKey:     privateKey,
+	})
 }
 
 func (s *HubServer) findHiveByOrgRepos(org string, repos []string) *RegistryEntry {
@@ -405,17 +405,23 @@ func (s *HubServer) checkPendingWebhookMatch(org, hiveID string) {
 	}
 	s.mu.RUnlock()
 
-	if hive == nil || hive.DashboardURL == "" {
-		s.logger.Warn("pending webhook matched but hive not found or has no dashboard URL",
+	if hive == nil {
+		s.logger.Warn("pending webhook matched but hive not found",
 			"hive_id", hiveID, "org", org)
 		return
 	}
 
-	s.logger.Info("pending webhook matched via heartbeat",
+	privateKey := s.loadAppPrivateKey(hive)
+
+	s.logger.Info("pending webhook matched via heartbeat, storing for heartbeat delivery",
 		"hive_id", hiveID,
 		"org", org,
 		"installation_id", pw.InstallationID,
 	)
 
-	go s.pushGitHubConfigToSpoke(hive, pw.AppID, pw.InstallationID)
+	s.storePendingGitHubAppConfig(hiveID, &HeartbeatGitHubAppConfig{
+		AppID:          pw.AppID,
+		InstallationID: pw.InstallationID,
+		PrivateKey:     privateKey,
+	})
 }


### PR DESCRIPTION
## Summary

When a GitHub App webhook arrives, the hub now stores the config and delivers it in the next heartbeat response instead of pushing directly to the spoke via HTTP. This bypasses OAuth proxies that intercept the direct HTTP push (the root cause of the aslom spoke's GitHub App configuration failure).

### How it works

1. **Hub receives webhook** → stores config in `pendingGitHubAppConfigs` map (keyed by hive ID)
2. **Spoke sends heartbeat** → hub checks for pending config, includes it in `HeartbeatResponse.GitHubAppConfig`
3. **Spoke processes response** → writes private key to `/data/gh-app-key.pem`, updates config, reinitializes GitHub client, clears pending-install flag

### Changes

- **heartbeat.go**: Add `HeartbeatGitHubAppConfig` struct, `GitHubAppConfigCallback` type, `GitHubAppConfig` field on `HeartbeatResponse`. Change `sendHeartbeat` return from `string` to `*HeartbeatResponse`. Change `StartHeartbeat` variadic from `...UpgradeCallback` to `...any` with type switch.
- **server.go**: Add `pendingGitHubAppConfigs` map with store/consume methods. Inject config into heartbeat response before marshal.
- **webhook.go**: Replace `go s.pushGitHubConfigToSpoke()` calls with `s.storePendingGitHubAppConfig()` in both `handleInstallationEvent` and `checkPendingWebhookMatch`.
- **main.go**: Wire up `GitHubAppConfigCallback` in `StartHeartbeat` call — writes key, updates config, reinits GitHub client.
- **hub_heartbeat_test.go**: Update tests for new `*HeartbeatResponse` return type.

### Testing

After merge and auto-upgrade, redeliver the aslom webhook from GitHub and verify the spoke auto-configures via heartbeat.

Fixes the OAuth proxy interception issue where `pushGitHubConfigToSpoke` got back GitHub's OAuth HTML page instead of reaching the spoke's API.