### PR TITLE
feat: add shared-tag edges to knowledge graph

### DIFF
--- a/v2/pkg/knowledge/graphstore.go
+++ b/v2/pkg/knowledge/graphstore.go
@@ -315,7 +315,8 @@ func (g *GraphStore) BuildGraphData(stores []*FileStore, rootSlug string, depth 
 }
 
 // SyncFromFileStore scans all pages in the given FileStore and adds
-// "related_to" triples for each page's Related slugs.
+// "related_to" triples for each page's Related slugs, plus "shared_tag"
+// triples between facts that share a tag.
 func (g *GraphStore) SyncFromFileStore(store *FileStore) (int, error) {
 	store.refreshIfStale()
 	store.mu.RLock()
@@ -336,6 +337,8 @@ func (g *GraphStore) SyncFromFileStore(store *FileStore) (int, error) {
 		}
 	}
 
+	triples = append(triples, buildTagEdges(pages)...)
+
 	if err := g.AddTriples(triples); err != nil {
 		return 0, fmt.Errorf("sync graph from file store: %w", err)
 	}
@@ -346,6 +349,39 @@ func (g *GraphStore) SyncFromFileStore(store *FileStore) (int, error) {
 		"triples_added", len(triples),
 	)
 	return len(triples), nil
+}
+
+const (
+	// PredicateSharedTag links two facts that share a tag.
+	PredicateSharedTag = "shared_tag"
+	// maxEdgesPerTag caps edges for popular tags to avoid graph clutter.
+	maxEdgesPerTag = 20
+)
+
+func buildTagEdges(pages []filePage) []Triple {
+	tagToSlugs := make(map[string][]string)
+	for _, p := range pages {
+		for _, tag := range p.Tags {
+			tagToSlugs[tag] = append(tagToSlugs[tag], p.Slug)
+		}
+	}
+
+	var triples []Triple
+	for _, slugs := range tagToSlugs {
+		if len(slugs) < 2 || len(slugs) > maxEdgesPerTag {
+			continue
+		}
+		for i := 0; i < len(slugs); i++ {
+			for j := i + 1; j < len(slugs); j++ {
+				triples = append(triples, Triple{
+					Subject:   slugs[i],
+					Predicate: PredicateSharedTag,
+					Object:    slugs[j],
+				})
+			}
+		}
+	}
+	return triples
 }
 
 // ExportJSON serializes all triples as JSON for backup/debugging.


### PR DESCRIPTION
## Summary
- Facts sharing the same tag are now connected with `shared_tag` edges in the knowledge graph
- Makes the graph functional even when facts have no explicit `related:` frontmatter (currently all 172 facts have tags but zero have Related)
- Tags with >20 facts are skipped to avoid graph clutter
- Edges appear alongside existing `related_to` edges — frontend renders all predicates

## Test plan
- [ ] Deploy and verify Knowledge Graph tab shows nodes and edges
- [ ] Verify facts with shared tags are connected
- [ ] Verify popular tags don't create excessive edges