### PR TITLE
feat: zero-downtime spoke upgrades via in-cluster rolling restart

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1341,7 +1341,17 @@ func main() {
 				}
 			}, targetSHA, logger)
 
-			os.Exit(0)
+			if err := hub.RolloutRestartSelf(logger); err != nil {
+				logger.Warn("rolling restart failed, falling back to os.Exit",
+					"error", err,
+				)
+				os.Exit(0)
+			}
+			// Rolling restart initiated — K8s will start a new pod and
+			// send SIGTERM to this one once the replacement is Ready.
+			// Block here so the process stays alive until terminated.
+			logger.Info("waiting for SIGTERM after rolling restart")
+			<-ctx.Done()
 		}, hub.GitHubAppConfigCallback(func(ghCfg *hub.HeartbeatGitHubAppConfig) {
 			logger.Info("received github app config via heartbeat",
 				"app_id", ghCfg.AppID,

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -823,6 +823,31 @@ subjects:
   name: hive-sa
   namespace: {{.Namespace}}
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: hive-self-upgrade
+  namespace: {{.Namespace}}
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  resourceNames: ["hive"]
+  verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hive-self-upgrade
+  namespace: {{.Namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: hive-self-upgrade
+subjects:
+- kind: ServiceAccount
+  name: hive-sa
+  namespace: {{.Namespace}}
+---
 {{- end}}
 apiVersion: v1
 kind: ConfigMap

--- a/v2/pkg/hub/self_upgrade.go
+++ b/v2/pkg/hub/self_upgrade.go
@@ -1,0 +1,98 @@
+package hub
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	k8sNamespacePath        = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	selfUpgradeDeployName   = "hive"
+	selfUpgradeTimeout      = 10 * time.Second
+)
+
+// RolloutRestartSelf patches this pod's own Deployment to trigger a
+// rolling restart via the in-cluster K8s API.  This avoids os.Exit(0)
+// which kills the pod immediately and causes downtime for spokes whose
+// hub can't reach them via kubectl.
+//
+// Returns nil on success (K8s will send SIGTERM once the new pod is
+// Ready).  On any failure the caller should fall back to os.Exit(0).
+func RolloutRestartSelf(logger *slog.Logger) error {
+	ns, err := os.ReadFile(k8sNamespacePath)
+	if err != nil {
+		return fmt.Errorf("reading namespace: %w", err)
+	}
+	namespace := strings.TrimSpace(string(ns))
+	if namespace == "" {
+		return fmt.Errorf("empty namespace from %s", k8sNamespacePath)
+	}
+
+	restartAnnotation := fmt.Sprintf(
+		`{"spec":{"template":{"metadata":{"annotations":{"hive.kubestellar.io/restart-at":"%s"}}}}}`,
+		time.Now().UTC().Format(time.RFC3339),
+	)
+
+	path := fmt.Sprintf("/apis/apps/v1/namespaces/%s/deployments/%s", namespace, selfUpgradeDeployName)
+	if err := k8sAPIPatch(path, []byte(restartAnnotation)); err != nil {
+		return fmt.Errorf("patching deployment %s/%s: %w", namespace, selfUpgradeDeployName, err)
+	}
+
+	logger.Info("deployment patched for rolling restart, waiting for SIGTERM",
+		"namespace", namespace,
+		"deployment", selfUpgradeDeployName,
+	)
+	return nil
+}
+
+func k8sAPIPatch(path string, body []byte) error {
+	token, err := os.ReadFile(k8sTokenPath)
+	if err != nil {
+		return fmt.Errorf("reading service account token: %w", err)
+	}
+
+	tlsConfig := &tls.Config{}
+	if caCert, err := os.ReadFile(k8sCACertPath); err == nil {
+		pool := x509.NewCertPool()
+		pool.AppendCertsFromPEM(caCert)
+		tlsConfig.RootCAs = pool
+	} else {
+		tlsConfig.InsecureSkipVerify = true
+	}
+
+	client := &http.Client{
+		Timeout:   selfUpgradeTimeout,
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), selfUpgradeTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, k8sAPIServer+path, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(string(token)))
+	req.Header.Set("Content-Type", "application/strategic-merge-patch+json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("k8s API PATCH %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("k8s API PATCH %s: HTTP %d: %s", path, resp.StatusCode, string(respBody))
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Replace `os.Exit(0)` in the spoke upgrade callback with an in-cluster K8s API PATCH that annotates the Deployment, triggering a proper rolling restart
- K8s starts the new pod, waits for readiness, then sends SIGTERM to the old one — zero downtime
- Falls back to `os.Exit(0)` if the patch fails (missing RBAC or not running in-cluster)
- Adds `hive-self-upgrade` Role + RoleBinding to the SaaS provisioning template for automatic RBAC on new spokes

## Context
The open-source/jjs-world spoke on vllm-d goes offline during upgrades because the hub can't reach it via kubectl. The spoke self-upgrades via heartbeat `UpgradeTo`, but the previous implementation called `os.Exit(0)` — killing the pod immediately before K8s could start a replacement.

The deployment already has `RollingUpdate` with `maxSurge=1, maxUnavailable=0`, and the PVC is RWX — so a proper rolling restart works. The only missing piece was the RBAC for the pod to patch its own Deployment.

RBAC has been manually applied to the vllm-d cluster for the existing open-source spoke.

## Test plan
- [ ] Verify container builds successfully
- [ ] Trigger an upgrade on open-source/jjs-world and confirm zero downtime
- [ ] Verify fallback to os.Exit(0) works on non-SCC clusters (hive-oke spokes)