### PR TITLE
fix: rate limit 403 should not trigger GitHub App missing banner

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -865,7 +865,9 @@ func main() {
 				num, err := ghClient.EnsureAdvisoryIssue(ctx, newPrimaryRepo)
 				if err != nil {
 					logger.Error("failed to create advisory issue on new primary repo", "repo", newPrimaryRepo, "error", err)
-					if strings.Contains(err.Error(), "403") || strings.Contains(err.Error(), "401") {
+					if strings.Contains(err.Error(), "rate limit") {
+						logger.Warn("GitHub API rate limit hit during advisory issue creation", "repo", newPrimaryRepo)
+					} else if strings.Contains(err.Error(), "403") || strings.Contains(err.Error(), "401") {
 						dashSrv.SetGitHubAppRequired(true)
 					}
 				} else {
@@ -1741,6 +1743,8 @@ func runEvalCycle(
 							dashSrv.SetGitHubAppPermIssue("The GitHub App is installed but lacks Issues: Read & Write permission. The org owner must approve updated permissions at the app installation settings page.")
 							dashSrv.SetGitHubAppRequired(true)
 							logger.Warn("GitHub App installed but insufficient permissions — cannot write issue comments", "repo", primaryRepo)
+						} else if strings.Contains(err.Error(), "rate limit") {
+							logger.Warn("GitHub API rate limit hit, skipping advisory digest post", "repo", primaryRepo)
 						} else if strings.Contains(err.Error(), "403") || strings.Contains(err.Error(), "401") {
 							dashSrv.SetGitHubAppRequired(true)
 						}


### PR DESCRIPTION
## Summary
- Rate limit 403 errors from GitHub API were being misinterpreted as "GitHub App not installed", causing the red banner to appear even when the app is correctly configured
- Now checks for "rate limit" in the error message before the generic 403/401 check
- Fixes both the advisory issue creation path and the advisory digest post path

## Context
Console's hive (`hosted-kubestellar-console-4vkt`) was showing "GitHub App Not Installed" after an upgrade despite having a valid GH App token (installation ID 128685788). The app was working — fetching issues, refreshing tokens — but a rate limit hit during advisory digest posting set `githubAppRequired=true`.

## Test plan
- [ ] Verify container builds successfully
- [ ] Hit rate limits on a hive and confirm the banner does NOT appear
- [ ] Verify genuine 403/401 (bad credentials) still triggers the banner correctly