### PR TITLE
fix: start bead-synth-wiki regardless of knowledge.enabled

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -734,7 +734,7 @@ func main() {
 			logger.Info("cleaned up low-quality bead-synth facts", "removed", cleaned)
 		}
 
-		if cfg.Knowledge.Enabled && cfg.Knowledge.BeadSynthesizer.IsEnabled() && knowledgeAPI != nil {
+		if cfg.Knowledge.BeadSynthesizer.IsEnabled() && knowledgeAPI != nil {
 			beadSynth.StartBackground(ctx)
 			logger.Info("bead-to-wiki synthesizer started",
 				"schedule", cfg.Knowledge.BeadSynthesizer.Schedule,


### PR DESCRIPTION
## Summary
- Bead synthesizer startup was gated on `cfg.Knowledge.Enabled`, so hosted hives with `knowledge.enabled: false` (the default) never ran the synth — dashboard showed "Synth idle" permanently
- Remove the `Knowledge.Enabled` gate so synth runs whenever `BeadSynthesizer.IsEnabled()` is true (default) and bead stores exist
- Pause/Enable Synth buttons continue to work via the existing toggle endpoint

## Root cause
Discovered on the `ai-native-systems-research/ai-native-storage-certus` hosted hive: agents were producing beads but the bead-synth-wiki never started because `knowledge.enabled: false`. Console and bluefin hives had the same config but worked because inception had been run manually, which toggled knowledge on as a side effect.

## Test plan
- [x] Verified certus hive has beads but empty `inception-wiki/`
- [x] Verified console/bluefin hives have `inception-wiki/` content
- [x] One-line change — removes `cfg.Knowledge.Enabled &&` from startup gate
- [ ] Deploy to hive-oke and verify certus hive shows "Synth active"

🤖 Generated with [Claude Code](https://claude.com/claude-code)