### PR TITLE
fix: dark mode toggle button shows correct label on load

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1672,11 +1672,15 @@
 (function(){
   var m=localStorage.getItem('hive-layout-mode');
   if(m==='openclaw')m='light';
+  if(m==='classic')m='dark';
+  if(!m)m='light';
   document.body.classList.add('has-info-sidebar');
   if(m==='light'){document.body.classList.add('light-mode')}
   document.body.style.opacity='0';
   document.body.style.transition='opacity 0.15s ease-in';
   setTimeout(function(){ document.body.style.opacity='1'; }, 3000);
+  var lbl=m==='dark'?'☰ Light Mode':'☰ Dark Mode';
+  document.querySelectorAll('.layout-toggle').forEach(function(b){b.textContent=lbl});
 })();
 
 </script>


### PR DESCRIPTION
## Summary
- Toggle button always showed "Dark Mode" on page load, even when already in dark mode
- Now shows "Light Mode" when in dark mode and "Dark Mode" when in light mode
- Also ensures light mode is the default when no preference is stored

## Test plan
- [x] Load dashboard with no localStorage → light mode, button says "Dark Mode"
- [x] Switch to dark mode → button says "Light Mode"
- [x] Reload in dark mode → button still says "Light Mode"

🤖 Generated with [Claude Code](https://claude.com/claude-code)