### PR TITLE
fix: skip recursive chown on agent dirs to prevent rolling update deadlock

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -268,10 +268,17 @@ print('\n'.join(sorted(names)))
         useradd --system -u "$AGENT_UID" -g node -d /data/home -M -s /bin/bash "hive-${agent_name}" 2>/dev/null || true
       fi
       mkdir -p "/data/agents/${agent_name}"
-      chown -R "hive-${agent_name}:node" "/data/agents/${agent_name}" 2>/dev/null || true
-      # Also fix beads dir ownership so agent can write beads.json
+      # Skip recursive chown if already owned by this agent — avoids NFS
+      # contention during rolling updates when the old pod is still writing.
+      AGENT_DIR_OWNER=$(stat -c '%u' "/data/agents/${agent_name}" 2>/dev/null || echo "0")
+      if [ "$AGENT_DIR_OWNER" != "$AGENT_UID" ]; then
+        chown -R "hive-${agent_name}:node" "/data/agents/${agent_name}" 2>/dev/null || true
+      fi
       if [ -d "/data/beads/${agent_name}" ]; then
-        chown -R "hive-${agent_name}:node" "/data/beads/${agent_name}" 2>/dev/null || true
+        BEAD_DIR_OWNER=$(stat -c '%u' "/data/beads/${agent_name}" 2>/dev/null || echo "0")
+        if [ "$BEAD_DIR_OWNER" != "$AGENT_UID" ]; then
+          chown -R "hive-${agent_name}:node" "/data/beads/${agent_name}" 2>/dev/null || true
+        fi
       fi
       echo "[entrypoint] Agent user: hive-${agent_name} (UID ${AGENT_UID})"
       UID_OFFSET=$((UID_OFFSET + 1))


### PR DESCRIPTION
## Summary

- During rolling updates on shared RWX NFS volumes, the new pod's entrypoint runs `chown -R` on every agent data directory unconditionally
- If the old pod's agents are actively writing (e.g., scanner with 55+ subdirs), `chown -R` hangs on NFS locks
- The startup probe times out and kills the new pod, which restarts and hangs again — infinite deadlock
- Fix: check top-level dir ownership first (like the existing `/data` check on line 83) and skip `chown -R` if it already matches the expected agent UID
- Same fix applied to beads directories

## Root cause

kubestellar/console spoke was stuck "Upgrading" for 70+ minutes. New pod crashlooped 6 times with exit code 137 (startup probe SIGKILL). Logs stopped at `hive-quality (UID 2006)` — the next agent was `scanner`, whose data dir had 55+ entries being actively written by the old pod.

## Test plan

- [ ] Deploy to a spoke with populated agent data dirs
- [ ] Verify entrypoint completes in <30s (vs hanging indefinitely)
- [ ] Verify rolling update completes without deadlock
- [ ] Verify fresh provision still sets correct ownership