### PR TITLE
fix: pre-cleanup stale repo clones in entrypoint to prevent chown deadlock

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -255,6 +255,35 @@ print('\n'.join(sorted(names)))
 " 2>/dev/null) || true
   fi
 
+  # Pre-cleanup: remove stale git clones from agent workspaces BEFORE the
+  # chown loop. The Go binary's workspace_cleanup.go does this at runtime,
+  # but it can't start until the entrypoint finishes — and chown -R on
+  # 300K+ files from accumulated clones takes forever on NFS, creating a
+  # circular dependency. This breaks the cycle.
+  WORKSPACE_MAX_AGE_SECS=7200
+  if [ -d "$agentWorkspaceRoot" ] 2>/dev/null || [ -d /data/agents ]; then
+    _CLEANUP_ROOT="${agentWorkspaceRoot:-/data/agents}"
+    _CLEANUP_COUNT=0
+    _NOW=$(date +%s)
+    for _agent_dir in "$_CLEANUP_ROOT"/*/; do
+      [ -d "$_agent_dir" ] || continue
+      for _sub_dir in "$_agent_dir"*/; do
+        [ -d "$_sub_dir" ] || continue
+        [ -d "$_sub_dir/.git" ] || continue
+        _sub_name=$(basename "$_sub_dir")
+        case "$_sub_name" in .cache|.config|.npm-cache|bin) continue ;; esac
+        _MTIME=$(stat -c '%Y' "$_sub_dir" 2>/dev/null || echo "$_NOW")
+        _AGE=$((_NOW - _MTIME))
+        if [ "$_AGE" -gt "$WORKSPACE_MAX_AGE_SECS" ]; then
+          rm -rf "$_sub_dir" 2>/dev/null && _CLEANUP_COUNT=$((_CLEANUP_COUNT + 1))
+        fi
+      done
+    done
+    if [ "$_CLEANUP_COUNT" -gt 0 ]; then
+      echo "[entrypoint] Pre-cleanup: removed $_CLEANUP_COUNT stale repo clones"
+    fi
+  fi
+
   if [ -n "$AGENT_NAMES" ]; then
     echo "[entrypoint] Creating per-agent users for UID isolation..."
     mkdir -p /var/run/hive


### PR DESCRIPTION
## Summary

- The Go binary's `workspace_cleanup.go` removes stale git clones hourly, but it can't start until the entrypoint finishes
- The entrypoint runs `chown -R` on every agent data dir, which hangs on NFS when scanner has accumulated 300K+ files
- This creates a circular dependency: cleanup needs binary → binary needs entrypoint → entrypoint needs chown → chown is slow because cleanup never ran
- Fix: run a lightweight clone sweep in the entrypoint **before** the user-creation/chown loop
- Uses the same 2-hour max age and skip list as `workspace_cleanup.go`

Companion to #1704 (skip chown when ownership is correct).

## Root cause

kubestellar/console spoke had 310K files in `/data/agents/scanner/` from 32 accumulated repo clones. `chown -R` on NFS took longer than the 10-minute startup probe window, causing infinite crashloop.

## Test plan

- [ ] Deploy to spoke with accumulated scanner clones
- [ ] Verify entrypoint logs show "Pre-cleanup: removed N stale repo clones"
- [ ] Verify entrypoint completes within startup probe window
- [ ] Verify fresh provision (no stale clones) still works