### PR TITLE
fix: auto-enable knowledge API before bead-synth-wiki startup

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -671,6 +671,16 @@ func main() {
 
 	go gitSyncer.Start(ctx)
 
+	// Auto-enable knowledge API when not explicitly configured.
+	// Both bead-synth-wiki and inception require it.
+	if knowledgeAPI == nil {
+		knowledgeAPI = knowledge.NewKnowledgeAPI(nil, knowledge.KnowledgeConfig{
+			Enabled: true,
+			Engine:  "file",
+		}, logger)
+		logger.Info("auto-enabled file-based knowledge API")
+	}
+
 	var beadSynth *knowledge.BeadSynthesizer
 	if len(beadStores) > 0 {
 		synthVaultPath := cfg.Knowledge.BeadSynthesizer.VaultPath
@@ -784,15 +794,6 @@ func main() {
 	nousState := loadNousState(logger)
 	nousState.SnapshotDir = nousSnapshotDir
 
-	// Auto-enable knowledge API for inception if not already configured.
-	// Inception needs it to connect the inception wiki vault.
-	if knowledgeAPI == nil {
-		knowledgeAPI = knowledge.NewKnowledgeAPI(nil, knowledge.KnowledgeConfig{
-			Enabled: true,
-			Engine:  "file",
-		}, logger)
-		logger.Info("created file-based knowledge API for inception wiki")
-	}
 	inceptionEngine := knowledge.NewInceptionEngine("/data", knowledgeAPI, logger)
 	sched.SetInception(inceptionEngine)
 


### PR DESCRIPTION
## Summary
- **Root cause**: `knowledgeAPI` was only created when `cfg.Knowledge.Enabled` was `true` (line 576). For hosted hives where `Knowledge.Enabled` defaults to `false`, `knowledgeAPI` stayed `nil` — causing the bead-synth-wiki to skip startup at line 737 (`if ... && knowledgeAPI != nil`), even after PR #1702 removed the `Knowledge.Enabled` gate from that line.
- **Fix**: Move the auto-enable block (previously at line 789 for inception) to before the bead-synth section, so `knowledgeAPI` is available for both bead-synth-wiki and inception.
- The inception auto-enable block is removed since it's now redundant (the earlier block covers it).

## Test plan
- [ ] Deploy to a hosted hive with `Knowledge.Enabled: false` (e.g. aslom)
- [ ] Verify "auto-enabled file-based knowledge API" appears in startup logs
- [ ] Verify "bead-to-wiki synthesizer started" appears in startup logs
- [ ] Verify "auto-connected bead-synth vault" appears in startup logs
- [ ] Verify closed beads are synthesized into wiki facts