### PR TITLE
fix: update all layout toggle buttons on mode change

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -16,6 +16,7 @@
       --cyan: #39d2c0; --purple: #bc8cff;
       --oc-accent: #f85149; --oc-accent-light: rgba(248,81,73,0.1);
       --green-bg: rgba(63,185,80,0.15); --green-border: rgba(63,185,80,0.3);
+      --red-bg: rgba(248,81,73,0.15); --red-border: rgba(248,81,73,0.3);
     }
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
@@ -51,6 +52,7 @@
       --cyan: #0891b2; --purple: #7c3aed;
       --oc-accent: #dc2626; --oc-accent-light: rgba(220,38,38,0.08);
       --green-bg: #f0fdf4; --green-border: #bbf7d0;
+      --red-bg: #fef2f2; --red-border: #fecaca;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
       background: var(--bg); color: var(--text);
     }
@@ -7209,14 +7211,14 @@ function burnAreaChart() {
         ocHealth.title = hoverLines.join('\n\n') || 'No health data';
         if (failing.length > 0) {
           ocHealth.textContent = `● ${failing.length} Issue${failing.length > 1 ? 's' : ''}`;
-          ocHealth.style.color = '#dc2626';
-          ocHealth.style.background = '#fef2f2';
-          ocHealth.style.borderColor = '#fecaca';
+          ocHealth.style.color = 'var(--red)';
+          ocHealth.style.background = 'var(--red-bg)';
+          ocHealth.style.borderColor = 'var(--red-border)';
         } else {
           ocHealth.textContent = '● Health OK';
-          ocHealth.style.color = '#16a34a';
-          ocHealth.style.background = '#f0fdf4';
-          ocHealth.style.borderColor = '#bbf7d0';
+          ocHealth.style.color = 'var(--green)';
+          ocHealth.style.background = 'var(--green-bg)';
+          ocHealth.style.borderColor = 'var(--green-border)';
         }
       }
       renderGhRateLimits(data.ghRateLimits || {});

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2221,11 +2221,11 @@
     function applyLayout(mode) {
       document.body.classList.toggle('light-mode', mode === 'light');
       document.body.classList.add('has-info-sidebar');
-      const btn = document.getElementById('layout-toggle');
-      if (btn) {
-        btn.textContent = LAYOUT_LABELS[mode] || LAYOUT_LABELS.dark;
+      const lbl = LAYOUT_LABELS[mode] || LAYOUT_LABELS.dark;
+      document.querySelectorAll('.layout-toggle').forEach(btn => {
+        btn.textContent = lbl;
         btn.classList.toggle('active', mode !== 'dark');
-      }
+      });
       const sidebar = document.getElementById('oc-sidebar');
       if (sidebar) sidebar.style.display = 'flex';
       const h1 = document.querySelector('body > h1');


### PR DESCRIPTION
## Summary
- PR #1703 added an early IIFE to set the button label, but the IIFE runs before the buttons exist in the DOM (they're later in the HTML), so `querySelectorAll` finds nothing.
- `applyLayout()` (which runs after the DOM is parsed) only updated the button with `id="layout-toggle"`, missing the sidebar footer button.
- **Fix**: Change `applyLayout()` to use `querySelectorAll('.layout-toggle')` so all toggle buttons get the correct label when the mode is applied.

## Test plan
- [ ] Load dashboard in dark mode — button should say "Light Mode"
- [ ] Load dashboard in light mode — button should say "Dark Mode"
- [ ] Toggle mode — button label should update immediately
- [ ] Both topbar and sidebar footer buttons show correct label