### PR TITLE
fix: broaden workspace cleanup to catch all stale artifacts

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -255,32 +255,37 @@ print('\n'.join(sorted(names)))
 " 2>/dev/null) || true
   fi
 
-  # Pre-cleanup: remove stale git clones from agent workspaces BEFORE the
-  # chown loop. The Go binary's workspace_cleanup.go does this at runtime,
+  # Pre-cleanup: remove ALL stale workspace artifacts from agent dirs BEFORE
+  # the chown loop. The Go binary's workspace_cleanup.go does this at runtime,
   # but it can't start until the entrypoint finishes — and chown -R on
-  # 300K+ files from accumulated clones takes forever on NFS, creating a
-  # circular dependency. This breaks the cycle.
+  # 300K+ accumulated files takes forever on NFS, creating a circular
+  # dependency. This breaks the cycle by cleaning dirs, Go caches, and
+  # loose files (not just git clones).
   WORKSPACE_MAX_AGE_SECS=7200
   if [ -d "$agentWorkspaceRoot" ] 2>/dev/null || [ -d /data/agents ]; then
     _CLEANUP_ROOT="${agentWorkspaceRoot:-/data/agents}"
-    _CLEANUP_COUNT=0
+    _CLEANUP_DIRS=0
+    _CLEANUP_FILES=0
     _NOW=$(date +%s)
     for _agent_dir in "$_CLEANUP_ROOT"/*/; do
       [ -d "$_agent_dir" ] || continue
-      for _sub_dir in "$_agent_dir"*/; do
-        [ -d "$_sub_dir" ] || continue
-        [ -d "$_sub_dir/.git" ] || continue
-        _sub_name=$(basename "$_sub_dir")
-        case "$_sub_name" in .cache|.config|.npm-cache|bin) continue ;; esac
-        _MTIME=$(stat -c '%Y' "$_sub_dir" 2>/dev/null || echo "$_NOW")
+      for _entry in "$_agent_dir"*; do
+        [ -e "$_entry" ] || continue
+        _entry_name=$(basename "$_entry")
+        case "$_entry_name" in .cache|.config|.npm-cache|bin|beads.json) continue ;; esac
+        _MTIME=$(stat -c '%Y' "$_entry" 2>/dev/null || echo "$_NOW")
         _AGE=$((_NOW - _MTIME))
         if [ "$_AGE" -gt "$WORKSPACE_MAX_AGE_SECS" ]; then
-          rm -rf "$_sub_dir" 2>/dev/null && _CLEANUP_COUNT=$((_CLEANUP_COUNT + 1))
+          if [ -d "$_entry" ]; then
+            rm -rf "$_entry" 2>/dev/null && _CLEANUP_DIRS=$((_CLEANUP_DIRS + 1))
+          else
+            rm -f "$_entry" 2>/dev/null && _CLEANUP_FILES=$((_CLEANUP_FILES + 1))
+          fi
         fi
       done
     done
-    if [ "$_CLEANUP_COUNT" -gt 0 ]; then
-      echo "[entrypoint] Pre-cleanup: removed $_CLEANUP_COUNT stale repo clones"
+    if [ "$_CLEANUP_DIRS" -gt 0 ] || [ "$_CLEANUP_FILES" -gt 0 ]; then
+      echo "[entrypoint] Pre-cleanup: removed $_CLEANUP_DIRS stale dirs, $_CLEANUP_FILES stale files"
     fi
   fi
 

--- a/v2/pkg/dashboard/workspace_cleanup.go
+++ b/v2/pkg/dashboard/workspace_cleanup.go
@@ -15,9 +15,9 @@ const (
 )
 
 // StartWorkspaceCleanup runs a background loop that periodically sweeps
-// /data/agents/*/ for stale git repository clones and removes them.
-// This prevents unbounded disk growth from scanner and other agents that
-// clone repos for each task but never clean up.
+// /data/agents/*/ for stale workspace artifacts and removes them.
+// This prevents unbounded disk growth from agents that create repo clones,
+// Go caches, working directories, and temporary files during tasks.
 func StartWorkspaceCleanup(ctx context.Context, logger *slog.Logger) {
 	logger.Info("workspace cleanup enabled", "interval", workspaceCleanupInterval, "max_age", workspaceMaxAge)
 
@@ -43,7 +43,8 @@ func sweepWorkspaces(logger *slog.Logger) {
 		return
 	}
 
-	removed := 0
+	removedDirs := 0
+	removedFiles := 0
 	now := time.Now()
 
 	for _, agentEntry := range agentDirs {
@@ -53,28 +54,19 @@ func sweepWorkspaces(logger *slog.Logger) {
 		agentName := agentEntry.Name()
 		agentPath := filepath.Join(agentWorkspaceRoot, agentName)
 
-		subdirs, err := os.ReadDir(agentPath)
+		entries, err := os.ReadDir(agentPath)
 		if err != nil {
 			continue
 		}
 
-		for _, sub := range subdirs {
-			if !sub.IsDir() {
-				continue
-			}
-			dirName := sub.Name()
-			if isSkippedDir(dirName) {
+		for _, entry := range entries {
+			name := entry.Name()
+			if isSkippedEntry(name) {
 				continue
 			}
 
-			dirPath := filepath.Join(agentPath, dirName)
-			gitPath := filepath.Join(dirPath, ".git")
-
-			if _, err := os.Stat(gitPath); err != nil {
-				continue
-			}
-
-			info, err := sub.Info()
+			entryPath := filepath.Join(agentPath, name)
+			info, err := entry.Info()
 			if err != nil {
 				continue
 			}
@@ -83,24 +75,32 @@ func sweepWorkspaces(logger *slog.Logger) {
 				continue
 			}
 
-			if err := os.RemoveAll(dirPath); err != nil {
-				logger.Warn("workspace cleanup: failed to remove stale clone",
-					"agent", agentName, "dir", dirName, "error", err)
-				continue
+			if entry.IsDir() {
+				if err := os.RemoveAll(entryPath); err != nil {
+					logger.Warn("workspace cleanup: failed to remove stale dir",
+						"agent", agentName, "dir", name, "age", age.Round(time.Minute), "error", err)
+					continue
+				}
+				logger.Info("workspace cleanup: removed stale dir",
+					"agent", agentName, "dir", name, "age", age.Round(time.Minute))
+				removedDirs++
+			} else {
+				if err := os.Remove(entryPath); err != nil {
+					logger.Warn("workspace cleanup: failed to remove stale file",
+						"agent", agentName, "file", name, "error", err)
+					continue
+				}
+				removedFiles++
 			}
-
-			logger.Info("workspace cleanup: removed stale clone",
-				"agent", agentName, "dir", dirName, "age", age.Round(time.Minute))
-			removed++
 		}
 	}
 
-	logger.Info("workspace cleanup complete", "removed", removed)
+	logger.Info("workspace cleanup complete", "removed_dirs", removedDirs, "removed_files", removedFiles)
 }
 
-func isSkippedDir(name string) bool {
+func isSkippedEntry(name string) bool {
 	switch name {
-	case ".cache", ".config", ".npm-cache", "bin":
+	case ".cache", ".config", ".npm-cache", "bin", "beads.json":
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary

- Workspace cleanup previously only removed subdirectories containing `.git` — missing Go module caches (`go`, `go-workspace`, `gopath`), working dirs without `.git` (failed clones, worktree leftovers), and loose files (patches, scripts, analysis docs, base64 blobs)
- These accumulated to 300K+ files and 6.7GB on NFS in the scanner agent workspace, causing the chown deadlock fixed in #1704 and #1705
- Now removes **any** directory or file older than 2 hours, except preserved entries (`.cache`, `.config`, `.npm-cache`, `bin`, `beads.json`)
- Updated both the Go runtime cleanup (`workspace_cleanup.go`) and the entrypoint pre-cleanup (`entrypoint.sh`) to match
- Cleanup logging now reports dirs and files separately for better observability

## Changes

- `workspace_cleanup.go`: Removed `.git` requirement, added loose file cleanup, renamed `isSkippedDir` → `isSkippedEntry` with `beads.json` added
- `entrypoint.sh`: Pre-cleanup now handles both dirs and files, not just git-clone dirs

## Test plan

- [ ] Deploy to spoke with accumulated scanner artifacts (Go caches, loose files)
- [ ] Verify cleanup log shows `removed_dirs` and `removed_files` counts
- [ ] Verify `beads.json` is preserved after cleanup
- [ ] Verify `.cache`, `.config`, `.npm-cache`, `bin` dirs are preserved
- [ ] Verify fresh provision works (no false positives on new workspaces)