### PR TITLE
feat: external document sources for knowledge system

### DIFF
--- a/v2/cmd/bd/kb.go
+++ b/v2/cmd/bd/kb.go
@@ -1,0 +1,299 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	defaultDashboardURL = "http://localhost:3001"
+	kbMaxResponseBytes  = 10 * 1024 * 1024 // 10MB
+)
+
+func dashboardURL() string {
+	if u := os.Getenv("BD_DASHBOARD_URL"); u != "" {
+		return strings.TrimRight(u, "/")
+	}
+	return defaultDashboardURL
+}
+
+func cmdKB(args []string) {
+	if len(args) < 1 {
+		printKBUsage()
+		os.Exit(1)
+	}
+
+	sub := args[0]
+	switch sub {
+	case "search":
+		cmdKBSearch(args[1:])
+	case "read":
+		cmdKBRead(args[1:])
+	case "import-url":
+		cmdKBImportURL(args[1:])
+	case "import-file":
+		cmdKBImportFile(args[1:])
+	case "list-docs":
+		cmdKBListDocs()
+	case "help", "--help", "-h":
+		printKBUsage()
+	default:
+		fmt.Fprintf(os.Stderr, "bd kb: unknown subcommand %q\n", sub)
+		printKBUsage()
+		os.Exit(1)
+	}
+}
+
+func printKBUsage() {
+	fmt.Fprintln(os.Stderr, `Usage: bd kb <subcommand> [options]
+
+Subcommands:
+  search "query"                  Search knowledge, print top results
+  read <slug>                     Print full fact body
+  import-url <url> [--name <n>]   Import document from URL
+  import-file <path> [--name <n>] Import document from local file
+  list-docs                       List imported documents
+
+Environment:
+  BD_DASHBOARD_URL   Dashboard API base URL (default: http://localhost:3001)`)
+}
+
+func cmdKBSearch(args []string) {
+	if len(args) < 1 {
+		fmt.Fprintln(os.Stderr, "bd kb search: query required")
+		os.Exit(1)
+	}
+	query := strings.Join(args, " ")
+
+	base := dashboardURL()
+	u := fmt.Sprintf("%s/api/knowledge/search?q=%s&limit=10", base, url.QueryEscape(query))
+
+	body, err := kbGet(u)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bd kb search: %v\n", err)
+		os.Exit(1)
+	}
+
+	var facts []map[string]interface{}
+	if err := json.Unmarshal(body, &facts); err != nil {
+		fmt.Fprintf(os.Stderr, "bd kb search: invalid response: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(facts) == 0 {
+		fmt.Println("No results found.")
+		return
+	}
+
+	for _, f := range facts {
+		slug, _ := f["slug"].(string)
+		title, _ := f["title"].(string)
+		confidence, _ := f["confidence"].(float64)
+		factType, _ := f["type"].(string)
+		bodyText, _ := f["body"].(string)
+
+		fmt.Printf("## %s\n", title)
+		fmt.Printf("   slug: %s | type: %s | confidence: %.0f%%\n", slug, factType, confidence*100)
+		preview := bodyText
+		const maxPreviewChars = 200
+		if len(preview) > maxPreviewChars {
+			preview = preview[:maxPreviewChars] + "..."
+		}
+		if preview != "" {
+			fmt.Printf("   %s\n", strings.ReplaceAll(preview, "\n", "\n   "))
+		}
+		fmt.Println()
+	}
+}
+
+func cmdKBRead(args []string) {
+	if len(args) < 1 {
+		fmt.Fprintln(os.Stderr, "bd kb read: slug required")
+		os.Exit(1)
+	}
+	slug := args[0]
+
+	base := dashboardURL()
+	body, err := kbGet(fmt.Sprintf("%s/api/knowledge/search?q=%s&limit=50", base, url.QueryEscape(slug)))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bd kb read: %v\n", err)
+		os.Exit(1)
+	}
+
+	var facts []map[string]interface{}
+	if err := json.Unmarshal(body, &facts); err != nil {
+		fmt.Fprintf(os.Stderr, "bd kb read: invalid response: %v\n", err)
+		os.Exit(1)
+	}
+
+	for _, f := range facts {
+		if s, _ := f["slug"].(string); s == slug {
+			title, _ := f["title"].(string)
+			bodyText, _ := f["body"].(string)
+			fmt.Printf("# %s\n\n%s\n", title, bodyText)
+			return
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "bd kb read: fact %q not found\n", slug)
+	os.Exit(1)
+}
+
+func cmdKBImportURL(args []string) {
+	fs := flag.NewFlagSet("import-url", flag.ExitOnError)
+	name := fs.String("name", "", "document name (defaults to URL slug)")
+	layer := fs.String("layer", "project", "knowledge layer")
+	fs.Parse(args)
+
+	if fs.NArg() < 1 {
+		fmt.Fprintln(os.Stderr, "bd kb import-url: URL required")
+		os.Exit(1)
+	}
+	docURL := fs.Arg(0)
+
+	docName := *name
+	if docName == "" {
+		docName = urlToName(docURL)
+	}
+
+	payload := fmt.Sprintf(`{"name":%q,"url":%q,"layer":%q}`, docName, docURL, *layer)
+	body, err := kbPost(dashboardURL()+"/api/knowledge/documents", payload)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bd kb import-url: %v\n", err)
+		os.Exit(1)
+	}
+
+	var meta map[string]interface{}
+	if err := json.Unmarshal(body, &meta); err != nil {
+		fmt.Fprintf(os.Stderr, "bd kb import-url: invalid response: %v\n", err)
+		os.Exit(1)
+	}
+
+	factCount, _ := meta["fact_count"].(float64)
+	slug, _ := meta["slug"].(string)
+	fmt.Printf("Imported %q → %d facts (slug: %s)\n", docName, int(factCount), slug)
+}
+
+func cmdKBImportFile(args []string) {
+	fs := flag.NewFlagSet("import-file", flag.ExitOnError)
+	name := fs.String("name", "", "document name (defaults to filename)")
+	layer := fs.String("layer", "project", "knowledge layer")
+	fs.Parse(args)
+
+	if fs.NArg() < 1 {
+		fmt.Fprintln(os.Stderr, "bd kb import-file: file path required")
+		os.Exit(1)
+	}
+	filePath := fs.Arg(0)
+
+	docName := *name
+	if docName == "" {
+		docName = strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath))
+	}
+
+	payload := fmt.Sprintf(`{"name":%q,"file_path":%q,"layer":%q}`, docName, filePath, *layer)
+	body, err := kbPost(dashboardURL()+"/api/knowledge/documents", payload)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bd kb import-file: %v\n", err)
+		os.Exit(1)
+	}
+
+	var meta map[string]interface{}
+	if err := json.Unmarshal(body, &meta); err != nil {
+		fmt.Fprintf(os.Stderr, "bd kb import-file: invalid response: %v\n", err)
+		os.Exit(1)
+	}
+
+	factCount, _ := meta["fact_count"].(float64)
+	slug, _ := meta["slug"].(string)
+	fmt.Printf("Imported %q → %d facts (slug: %s)\n", docName, int(factCount), slug)
+}
+
+func cmdKBListDocs() {
+	body, err := kbGet(dashboardURL() + "/api/knowledge/documents")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bd kb list-docs: %v\n", err)
+		os.Exit(1)
+	}
+
+	var docs []map[string]interface{}
+	if err := json.Unmarshal(body, &docs); err != nil {
+		fmt.Fprintf(os.Stderr, "bd kb list-docs: invalid response: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(docs) == 0 {
+		fmt.Println("No documents imported.")
+		return
+	}
+
+	for _, d := range docs {
+		slug, _ := d["slug"].(string)
+		ct, _ := d["content_type"].(string)
+		factCount, _ := d["fact_count"].(float64)
+		srcURL, _ := d["source_url"].(string)
+		srcFile, _ := d["source_file"].(string)
+
+		source := srcURL
+		if source == "" {
+			source = srcFile
+		}
+		fmt.Printf("  %-30s  %s  (%d facts)  %s\n", slug, ct, int(factCount), source)
+	}
+}
+
+func kbGet(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP GET: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, kbMaxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+	return body, nil
+}
+
+func kbPost(url, jsonBody string) ([]byte, error) {
+	resp, err := http.Post(url, "application/json", strings.NewReader(jsonBody))
+	if err != nil {
+		return nil, fmt.Errorf("HTTP POST: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, kbMaxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
+	}
+	return body, nil
+}
+
+func urlToName(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "unnamed-document"
+	}
+	path := strings.TrimRight(u.Path, "/")
+	if path == "" {
+		return u.Host
+	}
+	base := filepath.Base(path)
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}

--- a/v2/cmd/bd/main.go
+++ b/v2/cmd/bd/main.go
@@ -73,6 +73,8 @@ func main() {
 		cmdReset(os.Args[2:])
 	case "remember":
 		cmdRemember(os.Args[2:])
+	case "kb":
+		cmdKB(os.Args[2:])
 	case "dolt":
 		cmdDolt(os.Args[2:])
 	case "init":
@@ -97,6 +99,11 @@ Commands:
   update <id> --status <status>            Change status
   update <id> --set-metadata key=value     Set metadata key
   update <id> --unset-metadata key         Remove metadata key
+  kb       search "query"                  Search knowledge base
+  kb       read <slug>                    Read full fact body
+  kb       import-url <url> [--name <n>]  Import document from URL
+  kb       import-file <path> [--name <n>] Import document from file
+  kb       list-docs                      List imported documents
   remember "<fact>"                        Quick-add an advisory bead
   close  <id>                              Close a bead
   reset  [--reason "..."]                  Close all open/in_progress/blocked beads

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -680,6 +680,36 @@ func main() {
 		}
 	}
 
+	// Auto-import configured document sources (PDFs, URLs as knowledge)
+	for _, doc := range cfg.Knowledge.Documents {
+		if knowledgeAPI == nil {
+			knowledgeAPI = knowledge.NewKnowledgeAPI(nil, knowledge.KnowledgeConfig{
+				Enabled: true,
+				Engine:  "file",
+			}, logger)
+			logger.Info("auto-enabled knowledge API for document sources")
+		}
+		docConfig := knowledge.DocSourceConfig{
+			Name:     doc.Name,
+			URL:      doc.URL,
+			FilePath: doc.FilePath,
+			Layer:    knowledge.LayerType(doc.Layer),
+		}
+		meta, err := knowledgeAPI.ImportDocument(ctx, docConfig)
+		if err != nil {
+			logger.Warn("failed to import document source",
+				"name", doc.Name,
+				"error", err,
+			)
+		} else {
+			logger.Info("document source imported",
+				"name", doc.Name,
+				"facts", meta.FactCount,
+				"content_type", meta.ContentType,
+			)
+		}
+	}
+
 	go gitSyncer.Start(ctx)
 
 	// Auto-enable knowledge API when not explicitly configured.

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -29,12 +29,21 @@ type Config struct {
 	SourcePath string `yaml:"-" json:"-"`
 }
 
+// DocSourceConfigYAML describes an external document to import as knowledge.
+type DocSourceConfigYAML struct {
+	Name     string `yaml:"name"`
+	URL      string `yaml:"url,omitempty"`
+	FilePath string `yaml:"file_path,omitempty"`
+	Layer    string `yaml:"layer"`
+}
+
 type KnowledgeConfig struct {
-	Enabled    bool                `yaml:"enabled"`
-	Engine     string              `yaml:"engine"`
-	Layers     []KnowledgeLayer    `yaml:"layers"`
-	Vaults     []VaultConfig       `yaml:"vaults"`
+	Enabled    bool                  `yaml:"enabled"`
+	Engine     string                `yaml:"engine"`
+	Layers     []KnowledgeLayer      `yaml:"layers"`
+	Vaults     []VaultConfig         `yaml:"vaults"`
 	GitSources []GitSourceConfigYAML `yaml:"git_sources"`
+	Documents  []DocSourceConfigYAML `yaml:"documents"`
 	Curator         KnowledgeCurator         `yaml:"curator"`
 	Primer          KnowledgePrimer          `yaml:"primer"`
 	BeadSynthesizer BeadSynthesizerConfig    `yaml:"bead_synthesizer"`

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -139,6 +139,11 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("POST /api/knowledge/git-sources", s.handleGitSourcesConnect)
 	s.mux.HandleFunc("DELETE /api/knowledge/git-sources", s.handleGitSourcesDisconnect)
 	s.mux.HandleFunc("POST /api/knowledge/obsidian/sync", s.handleObsidianSync)
+	s.mux.HandleFunc("GET /api/knowledge/documents", s.handleDocumentsList)
+	s.mux.HandleFunc("POST /api/knowledge/documents", s.handleDocumentsImport)
+	s.mux.HandleFunc("GET /api/knowledge/documents/{slug}", s.handleDocumentGet)
+	s.mux.HandleFunc("DELETE /api/knowledge/documents/{slug}", s.handleDocumentDelete)
+	s.mux.HandleFunc("POST /api/knowledge/documents/{slug}/reimport", s.handleDocumentReimport)
 
 	s.mux.HandleFunc("GET /api/hive-id", s.handleHiveIDGet)
 	s.mux.HandleFunc("PUT /api/hive-id", s.handleHiveIDSet)
@@ -4090,6 +4095,91 @@ func (s *Server) handleObsidianSync(w http.ResponseWriter, r *http.Request) {
 		"action": result.Action,
 		"fact":   result.Fact,
 	})
+}
+
+// --- Document source endpoints ---
+
+func (s *Server) handleDocumentsList(w http.ResponseWriter, r *http.Request) {
+	if !s.ensureKnowledge() {
+		jsonError(w, "knowledge not configured", http.StatusServiceUnavailable)
+		return
+	}
+	jsonResponse(w, s.deps.Knowledge.ListDocuments())
+}
+
+func (s *Server) handleDocumentsImport(w http.ResponseWriter, r *http.Request) {
+	if !s.ensureKnowledge() {
+		jsonError(w, "knowledge not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	var req knowledge.DocSourceConfig
+	if err := decodeBody(r, &req); err != nil {
+		jsonError(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if req.Name == "" {
+		jsonError(w, "name is required", http.StatusBadRequest)
+		return
+	}
+	if req.URL == "" && req.FilePath == "" {
+		jsonError(w, "url or file_path is required", http.StatusBadRequest)
+		return
+	}
+	if req.Layer == "" {
+		req.Layer = knowledge.LayerProject
+	}
+
+	meta, err := s.deps.Knowledge.ImportDocument(s.deps.Ctx, req)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, meta)
+}
+
+func (s *Server) handleDocumentGet(w http.ResponseWriter, r *http.Request) {
+	if !s.ensureKnowledge() {
+		jsonError(w, "knowledge not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	slug := r.PathValue("slug")
+	meta, err := s.deps.Knowledge.GetDocument(slug)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	jsonResponse(w, meta)
+}
+
+func (s *Server) handleDocumentDelete(w http.ResponseWriter, r *http.Request) {
+	if !s.ensureKnowledge() {
+		jsonError(w, "knowledge not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	slug := r.PathValue("slug")
+	if err := s.deps.Knowledge.DeleteDocument(slug); err != nil {
+		jsonError(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	okResponse(w, map[string]string{"status": "deleted", "slug": slug})
+}
+
+func (s *Server) handleDocumentReimport(w http.ResponseWriter, r *http.Request) {
+	if !s.ensureKnowledge() {
+		jsonError(w, "knowledge not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	slug := r.PathValue("slug")
+	meta, err := s.deps.Knowledge.ReimportDocument(s.deps.Ctx, slug)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, meta)
 }
 
 // --- Hive ID endpoints ---

--- a/v2/pkg/knowledge/api.go
+++ b/v2/pkg/knowledge/api.go
@@ -24,6 +24,7 @@ type KnowledgeAPI struct {
 	subscriptions []Subscription
 	vaults        []*FileStore
 	gitSources    []*GitSource
+	docSources    []*DocumentSource
 	graphStore    *GraphStore
 	logger        *slog.Logger
 }
@@ -653,6 +654,110 @@ func (k *KnowledgeAPI) GitSources() []GitSourceInfo {
 		infos[i] = gs.Info()
 	}
 	return infos
+}
+
+// ImportDocument fetches/reads an external document, extracts facts into the
+// vault, and registers graph relationships.
+func (k *KnowledgeAPI) ImportDocument(ctx context.Context, config DocSourceConfig) (*DocMetadata, error) {
+	k.mu.Lock()
+	for _, ds := range k.docSources {
+		if ds.slug == slugify(config.Name) {
+			k.mu.Unlock()
+			return nil, fmt.Errorf("document %q already imported", config.Name)
+		}
+	}
+	k.mu.Unlock()
+
+	vaultDir := k.docVaultDir()
+	ds := NewDocumentSource(config, localKnowledgeDir, vaultDir, k.graphStore, k.logger)
+	meta, err := ds.Import(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	k.mu.Lock()
+	k.docSources = append(k.docSources, ds)
+	k.mu.Unlock()
+
+	k.triggerVaultReindex(vaultDir)
+	return meta, nil
+}
+
+// ListDocuments returns metadata for all imported documents.
+func (k *KnowledgeAPI) ListDocuments() []DocMetadata {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+
+	metas := make([]DocMetadata, len(k.docSources))
+	for i, ds := range k.docSources {
+		metas[i] = ds.Metadata()
+	}
+	return metas
+}
+
+// GetDocument returns metadata for a specific imported document.
+func (k *KnowledgeAPI) GetDocument(slug string) (*DocMetadata, error) {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+
+	for _, ds := range k.docSources {
+		if ds.slug == slug {
+			meta := ds.Metadata()
+			return &meta, nil
+		}
+	}
+	return nil, fmt.Errorf("document %q not found", slug)
+}
+
+// DeleteDocument removes an imported document and its extracted facts.
+func (k *KnowledgeAPI) DeleteDocument(slug string) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	for i, ds := range k.docSources {
+		if ds.slug == slug {
+			if err := ds.Delete(); err != nil {
+				return err
+			}
+			k.docSources = append(k.docSources[:i], k.docSources[i+1:]...)
+			return nil
+		}
+	}
+	return fmt.Errorf("document %q not found", slug)
+}
+
+// ReimportDocument re-fetches a document and replaces its extracted facts.
+func (k *KnowledgeAPI) ReimportDocument(ctx context.Context, slug string) (*DocMetadata, error) {
+	k.mu.RLock()
+	var target *DocumentSource
+	for _, ds := range k.docSources {
+		if ds.slug == slug {
+			target = ds
+			break
+		}
+	}
+	k.mu.RUnlock()
+
+	if target == nil {
+		return nil, fmt.Errorf("document %q not found", slug)
+	}
+
+	meta, err := target.Reimport(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	k.triggerVaultReindex(k.docVaultDir())
+	return meta, nil
+}
+
+func (k *KnowledgeAPI) docVaultDir() string {
+	for _, v := range k.vaults {
+		if v.rootDir != "" {
+			return v.rootDir
+		}
+	}
+	return filepath.Join(localKnowledgeDir, "documents-vault")
 }
 
 // ObsidianSyncRequest is the payload from the Obsidian Post Webhook plugin.

--- a/v2/pkg/knowledge/docparser.go
+++ b/v2/pkg/knowledge/docparser.go
@@ -275,9 +275,9 @@ func chunksToFacts(chunks []DocChunk, sourceSlug, sourceURL string, sourceDate t
 	facts = append(facts, ExtractedFact{
 		Title:      "Summary: " + chunks[0].Title,
 		Body:       summaryBody,
-		Type:       FactType("reference"),
+		Type:       FactReference,
 		Confidence: defaultDocConfidence,
-		Tags:       append([]string{"doc-import", sourceSlug, "doc-summary"}),
+		Tags:       []string{"doc-import", sourceSlug, "doc-summary"},
 		SourcePR:   sourcePR,
 		SourceDate: sourceDate,
 	})
@@ -291,7 +291,7 @@ func chunksToFacts(chunks []DocChunk, sourceSlug, sourceURL string, sourceDate t
 		facts = append(facts, ExtractedFact{
 			Title:      chunk.Title,
 			Body:       chunk.Body,
-			Type:       FactType("reference"),
+			Type:       FactReference,
 			Confidence: defaultDocConfidence,
 			Tags:       append([]string{}, tags...),
 			SourcePR:   sourcePR,

--- a/v2/pkg/knowledge/docparser.go
+++ b/v2/pkg/knowledge/docparser.go
@@ -1,0 +1,306 @@
+package knowledge
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	// maxChunkChars is the maximum characters per chunk before splitting further.
+	maxChunkChars = 2000
+
+	// maxFactsPerDocument caps how many facts a single document can produce.
+	maxFactsPerDocument = 50
+
+	// defaultDocConfidence is the confidence score for externally-sourced facts.
+	defaultDocConfidence = 0.6
+
+	// docSummaryMaxChars is the max body length for the summary fact.
+	docSummaryMaxChars = 500
+
+	// rawTextSplitTarget is the target chunk size when splitting raw text.
+	rawTextSplitTarget = 1500
+
+	// chunkTitleMaxChars caps the auto-extracted title from chunk content.
+	chunkTitleMaxChars = 80
+)
+
+// DocChunk is a section of a parsed document, ready for conversion to a fact.
+type DocChunk struct {
+	Title   string
+	Body    string
+	PageNum int
+	Section string
+}
+
+// parsePDFText splits already-extracted PDF text into chunks by page boundary.
+// Pages are delimited by form-feed characters (\f). Pages exceeding
+// maxChunkChars are split further at paragraph boundaries.
+func parsePDFText(text string) []DocChunk {
+	pages := strings.Split(text, "\f")
+	var chunks []DocChunk
+
+	for i, page := range pages {
+		page = strings.TrimSpace(page)
+		if page == "" {
+			continue
+		}
+		pageNum := i + 1
+
+		if len(page) <= maxChunkChars {
+			chunks = append(chunks, DocChunk{
+				Title:   extractPageTitle(page, pageNum),
+				Body:    page,
+				PageNum: pageNum,
+			})
+			continue
+		}
+
+		subChunks := splitAtParagraphs(page, maxChunkChars)
+		for j, sub := range subChunks {
+			title := extractPageTitle(sub, pageNum)
+			if len(subChunks) > 1 {
+				title = fmt.Sprintf("Page %d, Part %d", pageNum, j+1)
+			}
+			chunks = append(chunks, DocChunk{
+				Title:   title,
+				Body:    sub,
+				PageNum: pageNum,
+			})
+		}
+	}
+	return chunks
+}
+
+// extractPageTitle returns the first line if it looks like a heading (short, no
+// trailing period), otherwise "Page N".
+func extractPageTitle(text string, pageNum int) string {
+	firstLine := strings.TrimSpace(strings.SplitN(text, "\n", 2)[0])
+	if firstLine != "" && len(firstLine) <= chunkTitleMaxChars && !strings.HasSuffix(firstLine, ".") {
+		return firstLine
+	}
+	return fmt.Sprintf("Page %d", pageNum)
+}
+
+var (
+	reScript = regexp.MustCompile(`(?is)<script[^>]*>.*?</script>`)
+	reStyle  = regexp.MustCompile(`(?is)<style[^>]*>.*?</style>`)
+	reNav    = regexp.MustCompile(`(?is)<nav[^>]*>.*?</nav>`)
+	reHeader = regexp.MustCompile(`(?is)<header[^>]*>.*?</header>`)
+	reFooter = regexp.MustCompile(`(?is)<footer[^>]*>.*?</footer>`)
+	reTitle  = regexp.MustCompile(`(?is)<title[^>]*>(.*?)</title>`)
+	reTags   = regexp.MustCompile(`<[^>]*>`)
+)
+
+// parseHTMLText strips HTML to plain text and splits into chunks. It returns
+// the chunks and the extracted <title> (empty string if none found).
+func parseHTMLText(htmlBytes []byte) ([]DocChunk, string) {
+	html := string(htmlBytes)
+
+	// Extract title before stripping.
+	var title string
+	if m := reTitle.FindStringSubmatch(html); len(m) > 1 {
+		title = strings.TrimSpace(decodeHTMLEntities(m[1]))
+	}
+
+	// Remove non-content blocks.
+	html = reScript.ReplaceAllString(html, "")
+	html = reStyle.ReplaceAllString(html, "")
+	html = reNav.ReplaceAllString(html, "")
+	html = reHeader.ReplaceAllString(html, "")
+	html = reFooter.ReplaceAllString(html, "")
+
+	// Strip remaining tags.
+	text := reTags.ReplaceAllString(html, "")
+	text = decodeHTMLEntities(text)
+
+	// Collapse whitespace runs but preserve paragraph breaks.
+	text = collapseWhitespace(text)
+
+	chunks := parseRawText(text)
+	return chunks, title
+}
+
+// decodeHTMLEntities replaces common HTML entities with their plain-text form.
+func decodeHTMLEntities(s string) string {
+	replacer := strings.NewReplacer(
+		"&amp;", "&",
+		"&lt;", "<",
+		"&gt;", ">",
+		"&quot;", `"`,
+		"&#39;", "'",
+		"&apos;", "'",
+		"&nbsp;", " ",
+	)
+	return replacer.Replace(s)
+}
+
+// collapseWhitespace normalises whitespace: runs of spaces/tabs become a single
+// space; runs of 2+ newlines become a double-newline paragraph break.
+func collapseWhitespace(s string) string {
+	// Normalise line endings.
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+
+	// Collapse blank-line runs into exactly two newlines.
+	reBlankRun := regexp.MustCompile(`\n{3,}`)
+	s = reBlankRun.ReplaceAllString(s, "\n\n")
+
+	// Within each line, collapse horizontal whitespace.
+	var lines []string
+	for _, line := range strings.Split(s, "\n") {
+		line = strings.Join(strings.Fields(line), " ")
+		lines = append(lines, line)
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}
+
+// parseRawText splits plain text into chunks of approximately
+// rawTextSplitTarget characters, breaking at paragraph boundaries.
+func parseRawText(text string) []DocChunk {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+
+	paragraphs := strings.Split(text, "\n\n")
+	var chunks []DocChunk
+	var current strings.Builder
+	sectionNum := 1
+
+	for _, para := range paragraphs {
+		para = strings.TrimSpace(para)
+		if para == "" {
+			continue
+		}
+
+		if current.Len() > 0 && current.Len()+len(para)+2 > rawTextSplitTarget {
+			body := current.String()
+			chunks = append(chunks, DocChunk{
+				Title: extractChunkTitle(body, sectionNum),
+				Body:  body,
+			})
+			current.Reset()
+			sectionNum++
+		}
+
+		if current.Len() > 0 {
+			current.WriteString("\n\n")
+		}
+		current.WriteString(para)
+	}
+
+	if current.Len() > 0 {
+		body := current.String()
+		chunks = append(chunks, DocChunk{
+			Title: extractChunkTitle(body, sectionNum),
+			Body:  body,
+		})
+	}
+	return chunks
+}
+
+// extractChunkTitle returns the first sentence (up to chunkTitleMaxChars) or
+// falls back to "Section N".
+func extractChunkTitle(body string, sectionNum int) string {
+	firstLine := strings.SplitN(body, "\n", 2)[0]
+	firstLine = strings.TrimSpace(firstLine)
+
+	// Try first sentence (period-delimited).
+	if idx := strings.Index(firstLine, ". "); idx > 0 && idx < chunkTitleMaxChars {
+		return firstLine[:idx]
+	}
+
+	if len(firstLine) > 0 && len(firstLine) <= chunkTitleMaxChars {
+		return firstLine
+	}
+
+	if len(firstLine) > chunkTitleMaxChars {
+		return firstLine[:chunkTitleMaxChars]
+	}
+
+	return fmt.Sprintf("Section %d", sectionNum)
+}
+
+// splitAtParagraphs splits text into pieces of at most maxLen characters,
+// breaking at double-newline paragraph boundaries where possible.
+func splitAtParagraphs(text string, maxLen int) []string {
+	paragraphs := strings.Split(text, "\n\n")
+	var result []string
+	var current strings.Builder
+
+	for _, para := range paragraphs {
+		para = strings.TrimSpace(para)
+		if para == "" {
+			continue
+		}
+
+		if current.Len() > 0 && current.Len()+len(para)+2 > maxLen {
+			result = append(result, current.String())
+			current.Reset()
+		}
+
+		if current.Len() > 0 {
+			current.WriteString("\n\n")
+		}
+		current.WriteString(para)
+	}
+
+	if current.Len() > 0 {
+		result = append(result, current.String())
+	}
+	return result
+}
+
+// chunksToFacts converts parsed document chunks into ExtractedFact values ready
+// for vault ingestion. The first fact is a summary; subsequent facts are
+// individual sections. The total is capped at maxFactsPerDocument.
+func chunksToFacts(chunks []DocChunk, sourceSlug, sourceURL string, sourceDate time.Time) []ExtractedFact {
+	if len(chunks) == 0 {
+		return nil
+	}
+
+	tags := []string{"doc-import", sourceSlug}
+	sourcePR := "doc:" + sourceSlug
+
+	var facts []ExtractedFact
+
+	// Summary fact from the first chunk.
+	summaryBody := chunks[0].Body
+	if len(summaryBody) > docSummaryMaxChars {
+		summaryBody = summaryBody[:docSummaryMaxChars]
+	}
+	facts = append(facts, ExtractedFact{
+		Title:      "Summary: " + chunks[0].Title,
+		Body:       summaryBody,
+		Type:       FactType("reference"),
+		Confidence: defaultDocConfidence,
+		Tags:       append([]string{"doc-import", sourceSlug, "doc-summary"}),
+		SourcePR:   sourcePR,
+		SourceDate: sourceDate,
+	})
+
+	// Section facts from all chunks (including the first, which may have
+	// content beyond the summary).
+	for _, chunk := range chunks {
+		if len(facts) >= maxFactsPerDocument {
+			break
+		}
+		facts = append(facts, ExtractedFact{
+			Title:      chunk.Title,
+			Body:       chunk.Body,
+			Type:       FactType("reference"),
+			Confidence: defaultDocConfidence,
+			Tags:       append([]string{}, tags...),
+			SourcePR:   sourcePR,
+			SourceDate: sourceDate,
+		})
+	}
+
+	if len(facts) > maxFactsPerDocument {
+		facts = facts[:maxFactsPerDocument]
+	}
+	return facts
+}

--- a/v2/pkg/knowledge/docparser_test.go
+++ b/v2/pkg/knowledge/docparser_test.go
@@ -1,0 +1,246 @@
+package knowledge
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseRawText(t *testing.T) {
+	// Build text with several paragraphs that exceed rawTextSplitTarget.
+	var paragraphs []string
+	for i := 0; i < 10; i++ {
+		paragraphs = append(paragraphs, fmt.Sprintf("Paragraph %d. %s", i, strings.Repeat("word ", 60)))
+	}
+	text := strings.Join(paragraphs, "\n\n")
+
+	chunks := parseRawText(text)
+	if len(chunks) < 2 {
+		t.Fatalf("expected at least 2 chunks, got %d", len(chunks))
+	}
+
+	for i, c := range chunks {
+		if c.Body == "" {
+			t.Errorf("chunk %d has empty body", i)
+		}
+		if c.Title == "" {
+			t.Errorf("chunk %d has empty title", i)
+		}
+	}
+}
+
+func TestParseRawText_Short(t *testing.T) {
+	text := "This is a short paragraph.\n\nAnother short one."
+	chunks := parseRawText(text)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk for short text, got %d", len(chunks))
+	}
+	if !strings.Contains(chunks[0].Body, "short paragraph") {
+		t.Error("chunk body missing expected content")
+	}
+}
+
+func TestParseRawText_Empty(t *testing.T) {
+	chunks := parseRawText("")
+	if len(chunks) != 0 {
+		t.Fatalf("expected 0 chunks for empty text, got %d", len(chunks))
+	}
+}
+
+func TestParseHTMLText(t *testing.T) {
+	html := `<html>
+<head><title>Test Document</title></head>
+<body>
+<nav><a href="/">Home</a></nav>
+<script>var x = 1;</script>
+<style>.hidden { display: none; }</style>
+<header><h1>Header</h1></header>
+<main>
+<p>First paragraph with &amp; entity.</p>
+<p>Second paragraph with &lt;code&gt; blocks.</p>
+</main>
+<footer>Copyright 2024</footer>
+</body></html>`
+
+	chunks, title := parseHTMLText([]byte(html))
+
+	if title != "Test Document" {
+		t.Errorf("expected title 'Test Document', got %q", title)
+	}
+
+	if len(chunks) == 0 {
+		t.Fatal("expected at least 1 chunk from HTML")
+	}
+
+	combined := ""
+	for _, c := range chunks {
+		combined += c.Body
+	}
+
+	if strings.Contains(combined, "var x = 1") {
+		t.Error("script content should have been stripped")
+	}
+	if strings.Contains(combined, "display: none") {
+		t.Error("style content should have been stripped")
+	}
+	if strings.Contains(combined, "Copyright 2024") {
+		t.Error("footer content should have been stripped")
+	}
+	if !strings.Contains(combined, "First paragraph with & entity") {
+		t.Error("HTML entities should have been decoded")
+	}
+}
+
+func TestParseHTMLText_NoTitle(t *testing.T) {
+	html := `<html><body><p>Just text.</p></body></html>`
+	chunks, title := parseHTMLText([]byte(html))
+
+	if title != "" {
+		t.Errorf("expected empty title, got %q", title)
+	}
+	if len(chunks) == 0 {
+		t.Fatal("expected at least 1 chunk")
+	}
+}
+
+func TestParsePDFText(t *testing.T) {
+	// Simulate 3 pages separated by form-feeds.
+	page1 := "Introduction to Transformers\n\nTransformer models use self-attention."
+	page2 := "Related Work\n\nPrior approaches used RNNs and CNNs for sequence tasks."
+	page3 := "Methodology\n\nWe propose a novel attention mechanism."
+	text := page1 + "\f" + page2 + "\f" + page3
+
+	chunks := parsePDFText(text)
+	if len(chunks) != 3 {
+		t.Fatalf("expected 3 chunks (one per page), got %d", len(chunks))
+	}
+
+	if chunks[0].PageNum != 1 || chunks[1].PageNum != 2 || chunks[2].PageNum != 3 {
+		t.Error("page numbers should be 1-indexed sequential")
+	}
+
+	// First page title should be "Introduction to Transformers" (heading-like).
+	if chunks[0].Title != "Introduction to Transformers" {
+		t.Errorf("expected heading title, got %q", chunks[0].Title)
+	}
+}
+
+func TestParsePDFText_LargePage(t *testing.T) {
+	// A page exceeding maxChunkChars should be split.
+	largePara1 := strings.Repeat("Alpha word. ", 120)
+	largePara2 := strings.Repeat("Beta word. ", 120)
+	text := largePara1 + "\n\n" + largePara2
+
+	chunks := parsePDFText(text)
+	if len(chunks) < 2 {
+		t.Fatalf("expected large page to be split into at least 2 chunks, got %d", len(chunks))
+	}
+	if chunks[0].PageNum != 1 {
+		t.Errorf("expected page 1, got %d", chunks[0].PageNum)
+	}
+}
+
+func TestParsePDFText_EmptyPages(t *testing.T) {
+	text := "\f\f\fActual content\f\f"
+	chunks := parsePDFText(text)
+	if len(chunks) != 1 {
+		t.Fatalf("expected 1 chunk (empty pages skipped), got %d", len(chunks))
+	}
+}
+
+func TestChunksToFacts(t *testing.T) {
+	chunks := []DocChunk{
+		{Title: "Introduction", Body: "This is the intro."},
+		{Title: "Methods", Body: "We used method X."},
+		{Title: "Results", Body: "Results were positive."},
+	}
+
+	sourceDate := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
+	facts := chunksToFacts(chunks, "test-paper", "https://example.com/paper.pdf", sourceDate)
+
+	// 1 summary + 3 section facts = 4
+	if len(facts) != 4 {
+		t.Fatalf("expected 4 facts (1 summary + 3 sections), got %d", len(facts))
+	}
+
+	// Verify summary fact.
+	summary := facts[0]
+	if !strings.HasPrefix(summary.Title, "Summary: ") {
+		t.Errorf("summary title should start with 'Summary: ', got %q", summary.Title)
+	}
+	if summary.Type != FactType("reference") {
+		t.Errorf("expected type 'reference', got %q", summary.Type)
+	}
+
+	hasSummaryTag := false
+	for _, tag := range summary.Tags {
+		if tag == "doc-summary" {
+			hasSummaryTag = true
+		}
+	}
+	if !hasSummaryTag {
+		t.Error("summary fact should have 'doc-summary' tag")
+	}
+
+	// Verify section facts.
+	for i := 1; i < len(facts); i++ {
+		f := facts[i]
+		if f.SourcePR != "doc:test-paper" {
+			t.Errorf("fact %d: expected SourcePR 'doc:test-paper', got %q", i, f.SourcePR)
+		}
+		if f.Confidence != defaultDocConfidence {
+			t.Errorf("fact %d: expected confidence %f, got %f", i, defaultDocConfidence, f.Confidence)
+		}
+
+		hasImportTag := false
+		for _, tag := range f.Tags {
+			if tag == "doc-import" {
+				hasImportTag = true
+			}
+		}
+		if !hasImportTag {
+			t.Errorf("fact %d: missing 'doc-import' tag", i)
+		}
+	}
+}
+
+func TestChunksToFacts_Cap(t *testing.T) {
+	// 60 chunks should produce at most maxFactsPerDocument facts.
+	const chunkCount = 60
+	chunks := make([]DocChunk, chunkCount)
+	for i := range chunks {
+		chunks[i] = DocChunk{
+			Title: fmt.Sprintf("Section %d", i+1),
+			Body:  fmt.Sprintf("Content for section %d.", i+1),
+		}
+	}
+
+	facts := chunksToFacts(chunks, "big-doc", "", time.Now())
+	if len(facts) > maxFactsPerDocument {
+		t.Errorf("expected at most %d facts, got %d", maxFactsPerDocument, len(facts))
+	}
+	if len(facts) != maxFactsPerDocument {
+		t.Errorf("expected exactly %d facts (cap hit), got %d", maxFactsPerDocument, len(facts))
+	}
+}
+
+func TestChunksToFacts_Empty(t *testing.T) {
+	facts := chunksToFacts(nil, "empty", "", time.Now())
+	if len(facts) != 0 {
+		t.Fatalf("expected 0 facts for nil chunks, got %d", len(facts))
+	}
+}
+
+func TestChunksToFacts_SummaryTruncation(t *testing.T) {
+	longBody := strings.Repeat("x", docSummaryMaxChars*2)
+	chunks := []DocChunk{{Title: "Long", Body: longBody}}
+
+	facts := chunksToFacts(chunks, "long-doc", "", time.Now())
+	if len(facts) == 0 {
+		t.Fatal("expected at least 1 fact")
+	}
+	if len(facts[0].Body) > docSummaryMaxChars {
+		t.Errorf("summary body should be truncated to %d chars, got %d", docSummaryMaxChars, len(facts[0].Body))
+	}
+}

--- a/v2/pkg/knowledge/docsource.go
+++ b/v2/pkg/knowledge/docsource.go
@@ -1,0 +1,350 @@
+package knowledge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	docStorageDir    = "documents"
+	docFetchTimeout  = 30 * time.Second
+	docUserAgent     = "HiveKnowledge/1.0"
+	docMetadataFile  = "metadata.json"
+	docSourceFile    = "source"
+	docFactPrefix    = "doc-"
+	docMaxFetchBytes = 50 * 1024 * 1024 // 50MB
+)
+
+// DocMetadata describes an imported document and the facts extracted from it.
+type DocMetadata struct {
+	Slug        string    `json:"slug"`
+	Title       string    `json:"title"`
+	Author      string    `json:"author,omitempty"`
+	SourceURL   string    `json:"source_url,omitempty"`
+	SourceFile  string    `json:"source_file,omitempty"`
+	ContentType string    `json:"content_type"`
+	FetchedAt   time.Time `json:"fetched_at"`
+	PageCount   int       `json:"page_count,omitempty"`
+	FactCount   int       `json:"fact_count"`
+	FactSlugs   []string  `json:"fact_slugs"`
+}
+
+// DocumentSource manages a single imported document: fetch/read, parse, extract
+// facts to the vault, and maintain graph relationships.
+type DocumentSource struct {
+	slug       string
+	config     DocSourceConfig
+	metadata   DocMetadata
+	storageDir string
+	vaultDir   string
+	graphStore *GraphStore
+	logger     *slog.Logger
+}
+
+// NewDocumentSource creates a document source. Call Import to fetch and extract.
+func NewDocumentSource(config DocSourceConfig, baseDir, vaultDir string, graphStore *GraphStore, logger *slog.Logger) *DocumentSource {
+	slug := slugify(config.Name)
+	return &DocumentSource{
+		slug:       slug,
+		config:     config,
+		storageDir: filepath.Join(baseDir, docStorageDir, slug),
+		vaultDir:   vaultDir,
+		graphStore: graphStore,
+		logger:     logger,
+	}
+}
+
+// Import fetches (or reads) the document, parses it into chunks, writes
+// extracted facts to the vault, and stores the original artifact + metadata.
+func (ds *DocumentSource) Import(ctx context.Context) (*DocMetadata, error) {
+	if err := os.MkdirAll(ds.storageDir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating document storage dir: %w", err)
+	}
+	if err := os.MkdirAll(ds.vaultDir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating vault dir: %w", err)
+	}
+
+	var (
+		content     []byte
+		contentType string
+		err         error
+	)
+
+	if ds.config.URL != "" {
+		content, contentType, err = ds.fetchURL(ctx, ds.config.URL)
+		if err != nil {
+			return nil, fmt.Errorf("fetching URL: %w", err)
+		}
+	} else if ds.config.FilePath != "" {
+		content, err = os.ReadFile(ds.config.FilePath)
+		if err != nil {
+			return nil, fmt.Errorf("reading file: %w", err)
+		}
+		contentType = detectContentType(ds.config.FilePath)
+	} else {
+		return nil, fmt.Errorf("document source %q has neither url nor file_path", ds.config.Name)
+	}
+
+	ext := extensionForType(contentType)
+	artifactPath := filepath.Join(ds.storageDir, docSourceFile+ext)
+	if err := os.WriteFile(artifactPath, content, 0o644); err != nil {
+		return nil, fmt.Errorf("storing artifact: %w", err)
+	}
+
+	chunks, title := ds.parseContent(content, contentType)
+	if title == "" {
+		title = ds.config.Name
+	}
+
+	now := time.Now().UTC()
+	facts := chunksToFacts(chunks, ds.slug, ds.config.URL, now)
+
+	factSlugs, err := ds.writeFactsToVault(facts, now)
+	if err != nil {
+		return nil, fmt.Errorf("writing facts to vault: %w", err)
+	}
+
+	ds.emitGraphTriples(factSlugs)
+
+	ds.metadata = DocMetadata{
+		Slug:        ds.slug,
+		Title:       title,
+		SourceURL:   ds.config.URL,
+		SourceFile:  ds.config.FilePath,
+		ContentType: contentType,
+		FetchedAt:   now,
+		PageCount:   countPages(chunks),
+		FactCount:   len(factSlugs),
+		FactSlugs:   factSlugs,
+	}
+
+	if err := ds.writeMetadata(); err != nil {
+		ds.logger.Warn("failed to write document metadata", "slug", ds.slug, "error", err)
+	}
+
+	ds.logger.Info("document imported",
+		"slug", ds.slug,
+		"title", title,
+		"content_type", contentType,
+		"facts", len(factSlugs),
+	)
+	return &ds.metadata, nil
+}
+
+// Delete removes the document's artifact, metadata, and extracted vault facts.
+func (ds *DocumentSource) Delete() error {
+	for _, slug := range ds.metadata.FactSlugs {
+		path := filepath.Join(ds.vaultDir, slug+".md")
+		_ = os.Remove(path)
+	}
+
+	if ds.graphStore != nil {
+		for _, slug := range ds.metadata.FactSlugs {
+			ds.graphStore.RemoveTriple(Triple{Subject: slug, Predicate: PredicateDerivedFrom, Object: "doc:" + ds.slug})
+		}
+		for i := 1; i < len(ds.metadata.FactSlugs); i++ {
+			ds.graphStore.RemoveTriple(Triple{
+				Subject:   ds.metadata.FactSlugs[i-1],
+				Predicate: PredicateRelatedTo,
+				Object:    ds.metadata.FactSlugs[i],
+			})
+		}
+	}
+
+	if err := os.RemoveAll(ds.storageDir); err != nil {
+		return fmt.Errorf("removing document storage: %w", err)
+	}
+
+	ds.logger.Info("document deleted", "slug", ds.slug, "facts_removed", len(ds.metadata.FactSlugs))
+	return nil
+}
+
+// Reimport deletes existing facts and re-imports the document.
+func (ds *DocumentSource) Reimport(ctx context.Context) (*DocMetadata, error) {
+	if err := ds.Delete(); err != nil {
+		ds.logger.Warn("cleanup before reimport failed", "slug", ds.slug, "error", err)
+	}
+	return ds.Import(ctx)
+}
+
+// Metadata returns the current document metadata.
+func (ds *DocumentSource) Metadata() DocMetadata {
+	return ds.metadata
+}
+
+func (ds *DocumentSource) fetchURL(ctx context.Context, url string) ([]byte, string, error) {
+	ctx, cancel := context.WithTimeout(ctx, docFetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("User-Agent", docUserAgent)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("HTTP GET: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, docMaxFetchBytes))
+	if err != nil {
+		return nil, "", fmt.Errorf("reading response: %w", err)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if ct == "" {
+		ct = detectContentType(url)
+	}
+	return body, normalizeContentType(ct), nil
+}
+
+func (ds *DocumentSource) parseContent(content []byte, contentType string) ([]DocChunk, string) {
+	switch contentType {
+	case "application/pdf":
+		chunks := parsePDFText(string(content))
+		title := ""
+		if len(chunks) > 0 {
+			title = chunks[0].Title
+		}
+		return chunks, title
+	case "text/html":
+		return parseHTMLText(content)
+	default:
+		chunks := parseRawText(string(content))
+		title := ""
+		if len(chunks) > 0 {
+			title = chunks[0].Title
+		}
+		return chunks, title
+	}
+}
+
+func (ds *DocumentSource) writeFactsToVault(facts []ExtractedFact, synthesized time.Time) ([]string, error) {
+	var slugs []string
+	for i, fact := range facts {
+		factSlug := fmt.Sprintf("%s%s-%03d", docFactPrefix, ds.slug, i)
+		filename := factSlug + ".md"
+		path := filepath.Join(ds.vaultDir, filename)
+
+		var buf strings.Builder
+		buf.WriteString("---\n")
+		fmt.Fprintf(&buf, "title: %s\n", fact.Title)
+		fmt.Fprintf(&buf, "type: %s\n", string(fact.Type))
+		fmt.Fprintf(&buf, "layer: %s\n", string(ds.config.Layer))
+		fmt.Fprintf(&buf, "confidence: %.2f\n", fact.Confidence)
+		if len(fact.Tags) > 0 {
+			fmt.Fprintf(&buf, "tags: [%s]\n", strings.Join(fact.Tags, ", "))
+		}
+		fmt.Fprintf(&buf, "source: %s\n", fact.SourcePR)
+		if ds.config.URL != "" {
+			fmt.Fprintf(&buf, "source_url: %s\n", ds.config.URL)
+		}
+		fmt.Fprintf(&buf, "synthesized: %s\n", synthesized.Format(time.RFC3339))
+		buf.WriteString("---\n\n")
+		buf.WriteString(fact.Body)
+
+		tmpPath := path + ".tmp"
+		if err := os.WriteFile(tmpPath, []byte(buf.String()), 0o644); err != nil {
+			return slugs, fmt.Errorf("writing fact %d: %w", i, err)
+		}
+		if err := os.Rename(tmpPath, path); err != nil {
+			return slugs, fmt.Errorf("renaming fact %d: %w", i, err)
+		}
+		slugs = append(slugs, factSlug)
+	}
+	return slugs, nil
+}
+
+func (ds *DocumentSource) emitGraphTriples(factSlugs []string) {
+	if ds.graphStore == nil || len(factSlugs) == 0 {
+		return
+	}
+
+	docNode := "doc:" + ds.slug
+	for _, slug := range factSlugs {
+		if err := ds.graphStore.AddTriple(Triple{
+			Subject: slug, Predicate: PredicateDerivedFrom, Object: docNode,
+		}); err != nil {
+			ds.logger.Warn("graph triple failed", "triple", slug+"→"+docNode, "error", err)
+		}
+	}
+
+	for i := 1; i < len(factSlugs); i++ {
+		if err := ds.graphStore.AddTriple(Triple{
+			Subject: factSlugs[i-1], Predicate: PredicateRelatedTo, Object: factSlugs[i],
+		}); err != nil {
+			ds.logger.Warn("graph triple failed", "from", factSlugs[i-1], "to", factSlugs[i], "error", err)
+		}
+	}
+}
+
+func (ds *DocumentSource) writeMetadata() error {
+	data, err := json.MarshalIndent(ds.metadata, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(ds.storageDir, docMetadataFile), data, 0o644)
+}
+
+func detectContentType(pathOrURL string) string {
+	lower := strings.ToLower(pathOrURL)
+	switch {
+	case strings.HasSuffix(lower, ".pdf"):
+		return "application/pdf"
+	case strings.HasSuffix(lower, ".html"), strings.HasSuffix(lower, ".htm"):
+		return "text/html"
+	case strings.HasSuffix(lower, ".md"), strings.HasSuffix(lower, ".markdown"):
+		return "text/plain"
+	case strings.HasSuffix(lower, ".txt"):
+		return "text/plain"
+	default:
+		return "text/plain"
+	}
+}
+
+func normalizeContentType(ct string) string {
+	ct = strings.ToLower(ct)
+	switch {
+	case strings.Contains(ct, "pdf"):
+		return "application/pdf"
+	case strings.Contains(ct, "html"):
+		return "text/html"
+	default:
+		return "text/plain"
+	}
+}
+
+func extensionForType(contentType string) string {
+	switch contentType {
+	case "application/pdf":
+		return ".pdf"
+	case "text/html":
+		return ".html"
+	default:
+		return ".txt"
+	}
+}
+
+func countPages(chunks []DocChunk) int {
+	seen := make(map[int]bool)
+	for _, c := range chunks {
+		if c.PageNum > 0 {
+			seen[c.PageNum] = true
+		}
+	}
+	return len(seen)
+}

--- a/v2/pkg/knowledge/docsource_test.go
+++ b/v2/pkg/knowledge/docsource_test.go
@@ -1,0 +1,253 @@
+package knowledge
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDocumentSource_ImportFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	vaultDir := filepath.Join(tmpDir, "vault")
+	baseDir := filepath.Join(tmpDir, "knowledge")
+
+	srcFile := filepath.Join(tmpDir, "test.txt")
+	content := "First paragraph about transformers.\n\nSecond paragraph about attention mechanisms.\n\nThird paragraph about KV cache management."
+	if err := os.WriteFile(srcFile, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	ds := NewDocumentSource(DocSourceConfig{
+		Name:     "test-doc",
+		FilePath: srcFile,
+		Layer:    LayerProject,
+	}, baseDir, vaultDir, nil, logger)
+
+	meta, err := ds.Import(context.Background())
+	if err != nil {
+		t.Fatalf("Import failed: %v", err)
+	}
+
+	if meta.Slug != "test-doc" {
+		t.Errorf("slug = %q, want test-doc", meta.Slug)
+	}
+	if meta.ContentType != "text/plain" {
+		t.Errorf("content_type = %q, want text/plain", meta.ContentType)
+	}
+	if meta.FactCount < 1 {
+		t.Errorf("fact_count = %d, want >= 1", meta.FactCount)
+	}
+
+	for _, slug := range meta.FactSlugs {
+		path := filepath.Join(vaultDir, slug+".md")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("fact file %s not found: %v", slug, err)
+			continue
+		}
+		if !strings.Contains(string(data), "type: reference") {
+			t.Errorf("fact %s missing type: reference", slug)
+		}
+		if !strings.Contains(string(data), "layer: project") {
+			t.Errorf("fact %s missing layer: project", slug)
+		}
+	}
+
+	mdPath := filepath.Join(baseDir, docStorageDir, "test-doc", docMetadataFile)
+	if _, err := os.Stat(mdPath); os.IsNotExist(err) {
+		t.Error("metadata.json not created")
+	}
+}
+
+func TestDocumentSource_ImportURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<html><head><title>Test Paper</title></head>
+<body><nav>Menu</nav><article>
+<h2>Introduction</h2><p>This is the introduction to the paper.</p>
+<h2>Methods</h2><p>We used several methods.</p>
+</article><footer>Copyright</footer></body></html>`)
+	}))
+	defer server.Close()
+
+	tmpDir := t.TempDir()
+	vaultDir := filepath.Join(tmpDir, "vault")
+	baseDir := filepath.Join(tmpDir, "knowledge")
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	ds := NewDocumentSource(DocSourceConfig{
+		Name:  "test-paper",
+		URL:   server.URL,
+		Layer: LayerCommunity,
+	}, baseDir, vaultDir, nil, logger)
+
+	meta, err := ds.Import(context.Background())
+	if err != nil {
+		t.Fatalf("Import failed: %v", err)
+	}
+
+	if meta.Title != "Test Paper" {
+		t.Errorf("title = %q, want Test Paper", meta.Title)
+	}
+	if meta.ContentType != "text/html" {
+		t.Errorf("content_type = %q, want text/html", meta.ContentType)
+	}
+	if meta.FactCount < 1 {
+		t.Errorf("fact_count = %d, want >= 1", meta.FactCount)
+	}
+
+	artifactPath := filepath.Join(baseDir, docStorageDir, "test-paper", docSourceFile+".html")
+	if _, err := os.Stat(artifactPath); os.IsNotExist(err) {
+		t.Error("source artifact not saved")
+	}
+}
+
+func TestDocumentSource_Delete(t *testing.T) {
+	tmpDir := t.TempDir()
+	vaultDir := filepath.Join(tmpDir, "vault")
+	baseDir := filepath.Join(tmpDir, "knowledge")
+
+	srcFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(srcFile, []byte("Some content to import."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	ds := NewDocumentSource(DocSourceConfig{
+		Name:     "deleteme",
+		FilePath: srcFile,
+		Layer:    LayerProject,
+	}, baseDir, vaultDir, nil, logger)
+
+	meta, err := ds.Import(context.Background())
+	if err != nil {
+		t.Fatalf("Import failed: %v", err)
+	}
+
+	if len(meta.FactSlugs) == 0 {
+		t.Fatal("no facts created")
+	}
+
+	if err := ds.Delete(); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	for _, slug := range meta.FactSlugs {
+		path := filepath.Join(vaultDir, slug+".md")
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("fact file %s still exists after delete", slug)
+		}
+	}
+
+	storageDir := filepath.Join(baseDir, docStorageDir, "deleteme")
+	if _, err := os.Stat(storageDir); !os.IsNotExist(err) {
+		t.Error("storage dir still exists after delete")
+	}
+}
+
+func TestDocumentSource_Reimport(t *testing.T) {
+	tmpDir := t.TempDir()
+	vaultDir := filepath.Join(tmpDir, "vault")
+	baseDir := filepath.Join(tmpDir, "knowledge")
+
+	srcFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(srcFile, []byte("Version 1 content."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	ds := NewDocumentSource(DocSourceConfig{
+		Name:     "reimportme",
+		FilePath: srcFile,
+		Layer:    LayerProject,
+	}, baseDir, vaultDir, nil, logger)
+
+	meta1, err := ds.Import(context.Background())
+	if err != nil {
+		t.Fatalf("Import failed: %v", err)
+	}
+
+	if err := os.WriteFile(srcFile, []byte("Version 2 content with more text.\n\nAnd a second paragraph."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	meta2, err := ds.Reimport(context.Background())
+	if err != nil {
+		t.Fatalf("Reimport failed: %v", err)
+	}
+
+	for _, slug := range meta1.FactSlugs {
+		path := filepath.Join(vaultDir, slug+".md")
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			continue
+		}
+	}
+
+	if meta2.FactCount < 1 {
+		t.Error("reimport produced no facts")
+	}
+}
+
+func TestDocumentSource_NoSourceError(t *testing.T) {
+	tmpDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	ds := NewDocumentSource(DocSourceConfig{
+		Name:  "no-source",
+		Layer: LayerProject,
+	}, tmpDir, filepath.Join(tmpDir, "vault"), nil, logger)
+
+	_, err := ds.Import(context.Background())
+	if err == nil {
+		t.Fatal("expected error for document with no URL or file path")
+	}
+	if !strings.Contains(err.Error(), "neither url nor file_path") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDetectContentType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"paper.pdf", "application/pdf"},
+		{"page.html", "text/html"},
+		{"page.htm", "text/html"},
+		{"notes.md", "text/plain"},
+		{"notes.txt", "text/plain"},
+		{"unknown", "text/plain"},
+		{"PAPER.PDF", "application/pdf"},
+	}
+	for _, tt := range tests {
+		got := detectContentType(tt.input)
+		if got != tt.want {
+			t.Errorf("detectContentType(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestNormalizeContentType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"application/pdf", "application/pdf"},
+		{"application/pdf; charset=utf-8", "application/pdf"},
+		{"text/html; charset=utf-8", "text/html"},
+		{"text/plain", "text/plain"},
+		{"application/octet-stream", "text/plain"},
+	}
+	for _, tt := range tests {
+		got := normalizeContentType(tt.input)
+		if got != tt.want {
+			t.Errorf("normalizeContentType(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/v2/pkg/knowledge/types.go
+++ b/v2/pkg/knowledge/types.go
@@ -46,12 +46,22 @@ func (l LayerConfig) Endpoint() string {
 	return ""
 }
 
+// DocSourceConfig describes an external document (PDF, URL, or text file)
+// to import as knowledge facts.
+type DocSourceConfig struct {
+	Name     string    `yaml:"name"      json:"name"`
+	URL      string    `yaml:"url"       json:"url,omitempty"`
+	FilePath string    `yaml:"file_path" json:"file_path,omitempty"`
+	Layer    LayerType `yaml:"layer"     json:"layer"`
+}
+
 // KnowledgeConfig is the top-level knowledge section of hive.yaml.
 type KnowledgeConfig struct {
 	Enabled         bool                  `yaml:"enabled"          json:"enabled"`
 	Engine          string                `yaml:"engine"           json:"engine"`
 	Layers          []LayerConfig         `yaml:"layers"           json:"layers"`
 	GitSources      []GitSourceConfig     `yaml:"git_sources"      json:"git_sources,omitempty"`
+	Documents       []DocSourceConfig     `yaml:"documents"        json:"documents,omitempty"`
 	Curator         CuratorConfig         `yaml:"curator"          json:"curator"`
 	Primer          PrimerConfig          `yaml:"primer"           json:"primer"`
 	BeadSynthesizer BeadSynthesizerConfig `yaml:"bead_synthesizer" json:"bead_synthesizer"`
@@ -113,6 +123,7 @@ const (
 	FactTestScaff   FactType = "test_scaffold"
 	FactIntegration FactType = "integration"
 	FactCoverage    FactType = "coverage_rule"
+	FactReference   FactType = "reference"
 
 	// Ideation fact types (L1 — project inception)
 	FactIdea         FactType = "idea"
@@ -176,6 +187,8 @@ type Source struct {
 	Comment string    `json:"comment,omitempty"`
 	Author  string    `json:"author,omitempty"`
 	Date    time.Time `json:"date"`
+	DocURL  string    `json:"doc_url,omitempty"`
+	DocSlug string    `json:"doc_slug,omitempty"`
 }
 
 // PrimedKnowledge is the result of priming — ready to inject into an agent kick.
@@ -215,6 +228,11 @@ func (pk *PrimedKnowledge) FormatForPrompt() string {
 				b = append(b, formatConfidence(f.Confidence)...)
 				b = append(b, ")"...)
 			}
+			if docURL := factDocURL(f); docURL != "" {
+				b = append(b, " (source: "...)
+				b = append(b, docURL...)
+				b = append(b, ")"...)
+			}
 			b = append(b, "\n  "...)
 			b = append(b, f.Body...)
 			b = append(b, "\n\n"...)
@@ -222,6 +240,15 @@ func (pk *PrimedKnowledge) FormatForPrompt() string {
 	}
 
 	return string(b)
+}
+
+func factDocURL(f Fact) string {
+	for _, s := range f.Sources {
+		if s.DocURL != "" {
+			return s.DocURL
+		}
+	}
+	return ""
 }
 
 // InceptionMode distinguishes greenfield (new project) from brownfield (existing repo).


### PR DESCRIPTION
## Summary

- Adds external document ingestion (PDFs, URLs, raw text) as knowledge sources
- Hybrid storage: original artifacts stored for reference, facts extracted into vault for primer injection
- Agent CLI (`bd kb`) for mid-session knowledge search and on-demand full-text reads
- Dashboard API endpoints for document management (import, list, get, delete, reimport)
- Graph relationships: `derived_from` links facts to source documents, `related_to` chains sequential sections

## New Files
- `v2/pkg/knowledge/docsource.go` — Document source manager
- `v2/pkg/knowledge/docsource_test.go` — 7 tests
- `v2/cmd/bd/kb.go` — `bd kb search/read/import-url/import-file/list-docs`

## Modified Files
- `v2/pkg/knowledge/types.go` — `FactReference` type, `DocSourceConfig`, `Source.DocURL`/`DocSlug`, `FormatForPrompt` citation
- `v2/pkg/knowledge/api.go` — Document CRUD methods on `KnowledgeAPI`
- `v2/pkg/knowledge/docparser.go` — Use `FactReference` constant
- `v2/pkg/config/config.go` — `documents[]` config section
- `v2/cmd/hive/main.go` — Startup wiring for configured documents
- `v2/pkg/dashboard/api.go` — REST endpoints for document management
- `v2/cmd/bd/main.go` — `kb` subcommand routing

## How agents use it

1. **Kick time**: Primer injects relevant document facts via `${KNOWLEDGE}` (automatic)
2. **Mid-session**: `bd kb search "transformer quantization"` returns matching facts
3. **Deep read**: `bd kb read doc-vllm-paper-003` returns full section body
4. **Citation**: `FormatForPrompt` includes source URL for reference facts

## Config example
```yaml
knowledge:
  documents:
    - name: vllm-paper
      url: https://arxiv.org/pdf/2309.06180
      layer: community
```

## Test plan
- [x] Parser tests pass (12 tests)
- [x] Document source tests pass (7 tests)
- [x] Full build passes (`go build ./...`)
- [ ] Deploy to hive-oke, import a real paper, verify facts in knowledge panel
- [ ] Kick agent, verify document facts appear in `${KNOWLEDGE}`