### PR TITLE
fix: repair knowledge tests broken by document import changes

### DIFF
--- a/v2/pkg/knowledge/bead_synthesizer_test.go
+++ b/v2/pkg/knowledge/bead_synthesizer_test.go
@@ -619,6 +619,7 @@ func TestRunSynthesis_BasicFlow(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	store.Update(b.ID, func(b *beads.Bead) { b.Notes = "Auth handler allows unauthenticated access to admin endpoints." })
 	if err := store.Close(b.ID); err != nil {
 		t.Fatal(err)
 	}
@@ -959,9 +960,11 @@ func TestRunSynthesis_MultipleAgents(t *testing.T) {
 	store2 := newTestStore(t)
 
 	b1, _ := store1.Create("scanner found auth bug", beads.TypeBug, beads.PriorityMedium, "scanner", "")
+	store1.Update(b1.ID, func(b *beads.Bead) { b.Notes = "Auth handler allows unauthenticated access." })
 	store1.Close(b1.ID)
 
 	b2, _ := store2.Create("quality found test gap", beads.TypeAdvisory, beads.PriorityMedium, "quality", "")
+	store2.Update(b2.ID, func(b *beads.Bead) { b.Notes = "Missing integration tests for auth flow." })
 	store2.SetMetadata(b2.ID, "finding_type", "test")
 	store2.Close(b2.ID)
 
@@ -1022,8 +1025,10 @@ func TestDedup_SameTitleWithinBatch(t *testing.T) {
 	store := newTestStore(t)
 
 	b1, _ := store.Create("duplicate finding title", beads.TypeBug, beads.PriorityMedium, "scanner", "")
+	store.Update(b1.ID, func(b *beads.Bead) { b.Notes = "Found a duplicate issue in the scanner." })
 	store.Close(b1.ID)
 	b2, _ := store.Create("duplicate finding title", beads.TypeBug, beads.PriorityMedium, "scanner", "")
+	store.Update(b2.ID, func(b *beads.Bead) { b.Notes = "Found a duplicate issue in the scanner." })
 	store.Close(b2.ID)
 
 	stores := map[string]*beads.Store{"scanner": store}
@@ -1047,8 +1052,10 @@ func TestDedup_CrossAgent(t *testing.T) {
 	store2 := newTestStore(t)
 
 	b1, _ := store1.Create("same finding from both agents", beads.TypeBug, beads.PriorityMedium, "scanner", "")
+	store1.Update(b1.ID, func(b *beads.Bead) { b.Notes = "Cross-agent finding details." })
 	store1.Close(b1.ID)
 	b2, _ := store2.Create("same finding from both agents", beads.TypeBug, beads.PriorityMedium, "quality", "")
+	store2.Update(b2.ID, func(b *beads.Bead) { b.Notes = "Cross-agent finding details." })
 	store2.Close(b2.ID)
 
 	stores := map[string]*beads.Store{"scanner": store1, "quality": store2}
@@ -1247,6 +1254,7 @@ func TestRunOnce_LogsSuccess(t *testing.T) {
 	store := newTestStore(t)
 
 	b, _ := store.Create("finding for runOnce test", beads.TypeBug, beads.PriorityMedium, "scanner", "")
+	store.Update(b.ID, func(b *beads.Bead) { b.Notes = "runOnce test bead with notes." })
 	store.Close(b.ID)
 
 	stores := map[string]*beads.Store{"scanner": store}

--- a/v2/pkg/knowledge/graphstore_test.go
+++ b/v2/pkg/knowledge/graphstore_test.go
@@ -176,8 +176,8 @@ Always verify scopes.
 		t.Fatal(err)
 	}
 
-	if n != 3 {
-		t.Fatalf("expected 3 triples (2 from related + 1 from wikilink), got %d", n)
+	if n != 4 {
+		t.Fatalf("expected 4 triples (2 from related + 1 from wikilink + 1 shared_tag for auth), got %d", n)
 	}
 
 	out := gs.Outgoing("auth-pattern", PredicateRelatedTo)


### PR DESCRIPTION
## Summary
- Fix 4 bead synthesizer tests that failed because `isLowQualityBead()` (added in PR #1682) rejects beads with no `Notes` field — tests now set Notes on test beads
- Fix graph store test that expected 3 triples but `buildTagEdges` now generates a `shared_tag` triple for pages sharing the `auth` tag (4 total)

## Test plan
- [x] All 6 previously failing tests now pass
- [x] `go build ./...` passes