### PR TITLE
fix: reload imported documents from disk on startup

### DIFF
--- a/v2/pkg/knowledge/api.go
+++ b/v2/pkg/knowledge/api.go
@@ -53,12 +53,14 @@ func NewKnowledgeAPI(layers []LayerConfig, config KnowledgeConfig, logger *slog.
 
 	promoter := NewPromoter(layers, config.Curator, logger)
 
-	return &KnowledgeAPI{
+	api := &KnowledgeAPI{
 		layers:   clients,
 		config:   config,
 		promoter: promoter,
 		logger:   logger,
 	}
+	api.reloadDocuments()
+	return api
 }
 
 // LayerStatus describes the health of a single wiki layer.
@@ -750,6 +752,31 @@ func (k *KnowledgeAPI) ReimportDocument(ctx context.Context, slug string) (*DocM
 
 	k.triggerVaultReindex(k.docVaultDir())
 	return meta, nil
+}
+
+// reloadDocuments scans the documents directory for previously imported
+// documents and restores them into memory from their metadata.json files.
+func (k *KnowledgeAPI) reloadDocuments() {
+	docsDir := filepath.Join(localKnowledgeDir, docStorageDir)
+	entries, err := os.ReadDir(docsDir)
+	if err != nil {
+		return
+	}
+
+	vaultDir := k.docVaultDir()
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		dir := filepath.Join(docsDir, entry.Name())
+		ds, err := LoadDocumentSource(dir, vaultDir, k.graphStore, k.logger)
+		if err != nil {
+			k.logger.Warn("failed to reload document", "dir", entry.Name(), "error", err)
+			continue
+		}
+		k.docSources = append(k.docSources, ds)
+		k.logger.Info("reloaded document from disk", "slug", ds.slug, "facts", ds.metadata.FactCount)
+	}
 }
 
 func (k *KnowledgeAPI) docVaultDir() string {

--- a/v2/pkg/knowledge/docsource.go
+++ b/v2/pkg/knowledge/docsource.go
@@ -62,6 +62,32 @@ func NewDocumentSource(config DocSourceConfig, baseDir, vaultDir string, graphSt
 	}
 }
 
+// LoadDocumentSource restores a DocumentSource from its on-disk metadata.json.
+// Used at startup to reload previously imported documents.
+func LoadDocumentSource(dir, vaultDir string, graphStore *GraphStore, logger *slog.Logger) (*DocumentSource, error) {
+	metaPath := filepath.Join(dir, docMetadataFile)
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading metadata: %w", err)
+	}
+
+	var meta DocMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, fmt.Errorf("parsing metadata: %w", err)
+	}
+
+	ds := &DocumentSource{
+		slug:       meta.Slug,
+		config:     DocSourceConfig{Name: meta.Title, URL: meta.SourceURL, FilePath: meta.SourceFile},
+		metadata:   meta,
+		storageDir: dir,
+		vaultDir:   vaultDir,
+		graphStore: graphStore,
+		logger:     logger,
+	}
+	return ds, nil
+}
+
 // Import fetches (or reads) the document, parses it into chunks, writes
 // extracted facts to the vault, and stores the original artifact + metadata.
 func (ds *DocumentSource) Import(ctx context.Context) (*DocMetadata, error) {


### PR DESCRIPTION
## Summary
- Documents were only tracked in-memory (`docSources` slice) — on pod restart, document entries disappeared from the API and sidebar even though fact files remained in the vault
- Add `LoadDocumentSource()` to restore a `DocumentSource` from its on-disk `metadata.json`
- Add `reloadDocuments()` called from `NewKnowledgeAPI()` to scan `/data/knowledge/documents/` at startup and restore all previously imported documents

## Test plan
- [x] `go build ./...` passes
- [x] Existing tests pass
- [ ] Import a document, restart the pod, verify the document still appears in Knowledge Sources and sidebar