### PR TITLE
fix: sidebar documents section not rendering

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5347,7 +5347,7 @@ function burnAreaChart() {
     let _kbGraphData = null;
     async function fetchKnowledgeStats() {
       try {
-        const [r, docsR] = await Promise.all([fetch('/api/knowledge/stats'), fetchBeadSynthStatus(), fetchFactHistory(), fetch('/api/knowledge/documents')]);
+        const [r, , , docsR] = await Promise.all([fetch('/api/knowledge/stats'), fetchBeadSynthStatus(), fetchFactHistory(), fetch('/api/knowledge/documents')]);
         if (!r.ok) return;
         const prev = _kbCache;
         _kbCache = await r.json();


### PR DESCRIPTION
## Summary
- `fetchKnowledgeStats` had `const [r, docsR] = await Promise.all([..., fetch('/api/knowledge/documents')])` — documents fetch was at index 3 but destructured as index 1, so `docsR` received the `fetchBeadSynthStatus` result instead
- Fixed to `const [r, , , docsR]` to skip indices 1 and 2
- The "Imported Documents" sidebar section never rendered because `docsR.ok` was always undefined

## Test plan
- [ ] Import a document, verify "Imported Documents" section appears in sidebar