### PR TITLE
fix: add cleanup-orphans endpoint to remove orphaned doc-import facts

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -144,6 +144,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/knowledge/documents/{slug}", s.handleDocumentGet)
 	s.mux.HandleFunc("DELETE /api/knowledge/documents/{slug}", s.handleDocumentDelete)
 	s.mux.HandleFunc("POST /api/knowledge/documents/{slug}/reimport", s.handleDocumentReimport)
+	s.mux.HandleFunc("POST /api/knowledge/cleanup-orphans", s.handleCleanupOrphans)
 
 	s.mux.HandleFunc("GET /api/hive-id", s.handleHiveIDGet)
 	s.mux.HandleFunc("PUT /api/hive-id", s.handleHiveIDSet)
@@ -4199,6 +4200,20 @@ func (s *Server) handleDocumentReimport(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	jsonResponse(w, meta)
+}
+
+func (s *Server) handleCleanupOrphans(w http.ResponseWriter, r *http.Request) {
+	if !s.ensureKnowledge() {
+		jsonError(w, "knowledge not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	removed, err := s.deps.Knowledge.CleanupOrphanedDocFacts()
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jsonResponse(w, map[string]interface{}{"ok": true, "removed": removed})
 }
 
 // --- Hive ID endpoints ---

--- a/v2/pkg/knowledge/api.go
+++ b/v2/pkg/knowledge/api.go
@@ -779,6 +779,56 @@ func (k *KnowledgeAPI) reloadDocuments() {
 	}
 }
 
+// CleanupOrphanedDocFacts scans vault directories for doc-import fact files
+// that are not claimed by any active document source and removes them.
+func (k *KnowledgeAPI) CleanupOrphanedDocFacts() (int, error) {
+	k.mu.RLock()
+	owned := make(map[string]bool)
+	for _, ds := range k.docSources {
+		for _, slug := range ds.metadata.FactSlugs {
+			owned[slug] = true
+		}
+	}
+	k.mu.RUnlock()
+
+	vaultDir := k.docVaultDir()
+	entries, err := os.ReadDir(vaultDir)
+	if err != nil {
+		return 0, fmt.Errorf("reading vault dir: %w", err)
+	}
+
+	const docFactPrefix = "doc-"
+	removed := 0
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		slug := strings.TrimSuffix(name, ".md")
+		if slug == name {
+			continue
+		}
+		if !strings.HasPrefix(slug, docFactPrefix) {
+			continue
+		}
+		if owned[slug] {
+			continue
+		}
+		path := filepath.Join(vaultDir, name)
+		if err := os.Remove(path); err != nil {
+			k.logger.Warn("failed to remove orphaned doc fact", "path", path, "error", err)
+			continue
+		}
+		removed++
+	}
+
+	if removed > 0 {
+		k.triggerVaultReindex(vaultDir)
+		k.logger.Info("cleaned up orphaned doc facts", "removed", removed)
+	}
+	return removed, nil
+}
+
 func (k *KnowledgeAPI) docVaultDir() string {
 	for _, v := range k.vaults {
 		if v.rootDir != "" {


### PR DESCRIPTION
## Summary
- Adds `POST /api/knowledge/cleanup-orphans` endpoint that scans vault directories for `doc-*` prefixed fact files not claimed by any active document source
- Removes orphaned files and triggers vault reindex
- Fixes the case where deleting a document source leaves behind extracted vault facts (e.g. when slug/directory name mismatch causes `Delete()` to miss the files)

## Context
When a document was imported with slug `test` but the storage directory was renamed to `ai-codebase-maturity-model`, the metadata.json retained the old slug. On pod restart, `LoadDocumentSource` used the metadata slug, creating a mismatch. Deleting via the API removed the directory but left 29 orphaned `doc-test-*.md` files in the vault.

## Test plan
- [ ] Build passes
- [ ] Deploy to hosted hive
- [ ] Call `POST /api/knowledge/cleanup-orphans` and verify orphaned doc-test-* facts are removed
- [ ] Verify vault tag counts no longer show `doc-import` entries