### PR TITLE
feat: integrate Context7 library docs into knowledge system

### DIFF
--- a/v2/cmd/bd/kb.go
+++ b/v2/cmd/bd/kb.go
@@ -40,6 +40,10 @@ func cmdKB(args []string) {
 		cmdKBImportURL(args[1:])
 	case "import-file":
 		cmdKBImportFile(args[1:])
+	case "import-ctx7":
+		cmdKBImportCtx7(args[1:])
+	case "ctx7-search":
+		cmdKBCtx7Search(args[1:])
 	case "list-docs":
 		cmdKBListDocs()
 	case "help", "--help", "-h":
@@ -59,6 +63,8 @@ Subcommands:
   read <slug>                     Print full fact body
   import-url <url> [--name <n>]   Import document from URL
   import-file <path> [--name <n>] Import document from local file
+  import-ctx7 <library-id>        Import library docs from Context7
+  ctx7-search <name>              Search Context7 for available libraries
   list-docs                       List imported documents
 
 Environment:
@@ -247,6 +253,103 @@ func cmdKBListDocs() {
 		}
 		fmt.Printf("  %-30s  %s  (%d facts)  %s\n", slug, ct, int(factCount), source)
 	}
+}
+
+func cmdKBCtx7Search(args []string) {
+	if len(args) < 1 {
+		fmt.Fprintln(os.Stderr, "bd kb ctx7-search: library name required")
+		os.Exit(1)
+	}
+	query := strings.Join(args, " ")
+
+	base := dashboardURL()
+	u := fmt.Sprintf("%s/api/knowledge/context7/search?q=%s", base, url.QueryEscape(query))
+
+	body, err := kbGet(u)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bd kb ctx7-search: %v\n", err)
+		os.Exit(1)
+	}
+
+	var results []map[string]interface{}
+	if err := json.Unmarshal(body, &results); err != nil {
+		fmt.Fprintf(os.Stderr, "bd kb ctx7-search: invalid response: %v\n", err)
+		os.Exit(1)
+	}
+
+	if len(results) == 0 {
+		fmt.Println("No libraries found.")
+		return
+	}
+
+	for _, r := range results {
+		id, _ := r["id"].(string)
+		name, _ := r["name"].(string)
+		desc, _ := r["description"].(string)
+		trust, _ := r["sourceReputation"].(string)
+		snippets, _ := r["codeSnippets"].(float64)
+
+		fmt.Printf("  %-35s  %s\n", id, name)
+		if trust != "" || snippets > 0 {
+			fmt.Printf("    trust: %s  snippets: %d\n", trust, int(snippets))
+		}
+		if desc != "" {
+			const maxDescChars = 120
+			if len(desc) > maxDescChars {
+				desc = desc[:maxDescChars] + "..."
+			}
+			fmt.Printf("    %s\n", desc)
+		}
+		fmt.Println()
+	}
+	fmt.Println("Import with: bd kb import-ctx7 <library-id> [--name <name>] [--query <topic>]")
+}
+
+func cmdKBImportCtx7(args []string) {
+	fs := flag.NewFlagSet("import-ctx7", flag.ExitOnError)
+	name := fs.String("name", "", "document name (defaults to library ID)")
+	query := fs.String("query", "", "topic to focus documentation on")
+	layer := fs.String("layer", "community", "knowledge layer")
+	fs.Parse(args)
+
+	if fs.NArg() < 1 {
+		fmt.Fprintln(os.Stderr, "bd kb import-ctx7: library ID required (e.g. /vllm-project/vllm)")
+		fmt.Fprintln(os.Stderr, "  Use 'bd kb ctx7-search <name>' to find library IDs")
+		os.Exit(1)
+	}
+	libraryID := fs.Arg(0)
+
+	docName := *name
+	if docName == "" {
+		docName = strings.TrimLeft(libraryID, "/")
+		docName = strings.ReplaceAll(docName, "/", "-")
+	}
+
+	payload := map[string]string{
+		"name":       docName,
+		"context7_id": libraryID,
+		"layer":      *layer,
+	}
+	if *query != "" {
+		payload["name"] = docName + " (" + *query + ")"
+	}
+
+	payloadJSON, _ := json.Marshal(payload)
+	body, err := kbPost(dashboardURL()+"/api/knowledge/documents", string(payloadJSON))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bd kb import-ctx7: %v\n", err)
+		os.Exit(1)
+	}
+
+	var meta map[string]interface{}
+	if err := json.Unmarshal(body, &meta); err != nil {
+		fmt.Fprintf(os.Stderr, "bd kb import-ctx7: invalid response: %v\n", err)
+		os.Exit(1)
+	}
+
+	factCount, _ := meta["fact_count"].(float64)
+	slug, _ := meta["slug"].(string)
+	fmt.Printf("Imported Context7 docs for %q → %d facts (slug: %s)\n", libraryID, int(factCount), slug)
 }
 
 func kbGet(url string) ([]byte, error) {

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -813,6 +813,9 @@ func main() {
 		}
 		if knowledgeAPI != nil {
 			knowledgeAPI.SetGraphStore(graphStore)
+			if primer := sched.GetPrimer(); primer != nil {
+				knowledgeAPI.WireContext7Suggester(primer)
+			}
 		}
 		if beadSynth != nil {
 			beadSynth.SetGraphStore(graphStore)

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -144,6 +144,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/knowledge/documents/{slug}", s.handleDocumentGet)
 	s.mux.HandleFunc("DELETE /api/knowledge/documents/{slug}", s.handleDocumentDelete)
 	s.mux.HandleFunc("POST /api/knowledge/documents/{slug}/reimport", s.handleDocumentReimport)
+	s.mux.HandleFunc("GET /api/knowledge/context7/search", s.handleContext7Search)
 	s.mux.HandleFunc("POST /api/knowledge/cleanup-orphans", s.handleCleanupOrphans)
 
 	s.mux.HandleFunc("GET /api/hive-id", s.handleHiveIDGet)
@@ -4214,6 +4215,26 @@ func (s *Server) handleCleanupOrphans(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	jsonResponse(w, map[string]interface{}{"ok": true, "removed": removed})
+}
+
+func (s *Server) handleContext7Search(w http.ResponseWriter, r *http.Request) {
+	if !s.ensureKnowledge() {
+		jsonError(w, "knowledge not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	query := r.URL.Query().Get("q")
+	if query == "" {
+		jsonError(w, "missing q parameter", http.StatusBadRequest)
+		return
+	}
+
+	results, err := s.deps.Knowledge.SearchContext7Libraries(r.Context(), query)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	jsonResponse(w, results)
 }
 
 // --- Hive ID endpoints ---

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -6717,6 +6717,16 @@ function burnAreaChart() {
         html += '<div style="display:flex;justify-content:flex-end">';
         html += '<button class="nous-btn" style="background:#2563eb;color:white;padding:8px 20px" onclick="kbImportDocFromModal()">Import</button>';
         html += '</div></div></details>';
+
+        html += '<details style="margin-top:10px"><summary style="cursor:pointer;font-size:0.78rem;font-weight:600;color:var(--fg)">📚 Import from Context7</summary>';
+        html += '<div style="display:flex;flex-direction:column;gap:8px;margin-top:8px">';
+        html += '<div style="font-size:0.72rem;color:var(--muted)">Search Context7 for library documentation (e.g. "vllm", "next.js", "kubernetes").</div>';
+        html += '<div style="display:flex;gap:8px">';
+        html += '<input id="kb-ctx7-query" type="text" class="kb-search-box" placeholder="Search libraries..." style="flex:1">';
+        html += '<button class="nous-btn" style="background:var(--surface);color:var(--fg);border:1px solid var(--border);padding:6px 14px;font-size:0.78rem" onclick="kbCtx7Search()">Search</button>';
+        html += '</div>';
+        html += '<div id="kb-ctx7-results" style="max-height:200px;overflow-y:auto"></div>';
+        html += '</div></details>';
         html += '</div>';
 
         // ── Import Facts section ──
@@ -6863,6 +6873,63 @@ function burnAreaChart() {
         kbLoadSubscriptions();
         fetchKnowledgeStats();
       } catch (e) { await hiveAlert('Error: ' + e.message); }
+    }
+
+    async function kbCtx7Search() {
+      const query = document.getElementById('kb-ctx7-query')?.value?.trim();
+      if (!query) return;
+      const el = document.getElementById('kb-ctx7-results');
+      if (!el) return;
+      el.innerHTML = '<div style="padding:8px;color:var(--muted);font-size:0.72rem">Searching...</div>';
+      try {
+        const r = await fetch('/api/knowledge/context7/search?q=' + encodeURIComponent(query));
+        if (!r.ok) { el.innerHTML = '<div style="color:#dc2626;font-size:0.72rem;padding:8px">Search failed</div>'; return; }
+        const results = await r.json();
+        if (!results || results.length === 0) { el.innerHTML = '<div style="padding:8px;color:var(--muted);font-size:0.72rem">No libraries found.</div>'; return; }
+        let html = '';
+        for (const lib of results.slice(0, 8)) {
+          const id = lib.id || '';
+          const name = lib.name || id;
+          const desc = lib.description || '';
+          const trust = lib.sourceReputation || '';
+          const snippets = lib.codeSnippets || 0;
+          html += '<div style="display:flex;align-items:center;justify-content:space-between;padding:6px 8px;border:1px solid var(--border);border-radius:6px;margin-bottom:4px;font-size:0.72rem">';
+          html += '<div style="flex:1;min-width:0">';
+          html += '<div style="font-weight:600;color:var(--fg)">' + escapeHtml(name) + '</div>';
+          html += '<div style="color:var(--muted);font-size:0.68rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' + escapeHtml(id);
+          if (trust) html += ' · ' + escapeHtml(trust);
+          if (snippets > 0) html += ' · ' + snippets + ' snippets';
+          html += '</div>';
+          if (desc) html += '<div style="color:var(--muted);font-size:0.68rem;margin-top:2px;overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical">' + escapeHtml(desc) + '</div>';
+          html += '</div>';
+          html += '<button class="nous-btn" style="background:#2563eb;color:white;font-size:0.68rem;padding:4px 10px;margin-left:8px;white-space:nowrap" onclick="kbImportCtx7(\'' + escapeHtml(id) + '\',\'' + escapeHtml(name) + '\')">Import</button>';
+          html += '</div>';
+        }
+        el.innerHTML = html;
+      } catch (e) {
+        el.innerHTML = '<div style="color:#dc2626;font-size:0.72rem;padding:8px">Error: ' + escapeHtml(e.message) + '</div>';
+      }
+    }
+
+    async function kbImportCtx7(libraryId, name) {
+      const btn = event?.target;
+      if (btn) { btn.disabled = true; btn.textContent = 'Importing...'; }
+      try {
+        const docName = name || libraryId.replace(/^\//, '').replace(/\//g, '-');
+        const r = await fetch('/api/knowledge/documents', {
+          method: 'POST', headers: {'Content-Type':'application/json'},
+          body: JSON.stringify({ name: docName, context7_id: libraryId, layer: 'community' }),
+        });
+        if (!r.ok) { const t = await r.text(); await hiveAlert('Import failed: ' + t); return; }
+        const meta = await r.json();
+        await hiveAlert('Imported Context7 docs for "' + (meta.slug || libraryId) + '" → ' + (meta.fact_count || 0) + ' facts');
+        kbLoadSubscriptions();
+        fetchKnowledgeStats();
+      } catch (e) {
+        await hiveAlert('Error: ' + e.message);
+      } finally {
+        if (btn) { btn.disabled = false; btn.textContent = 'Import'; }
+      }
     }
 
     async function kbDeleteDoc(slug) {

--- a/v2/pkg/knowledge/api.go
+++ b/v2/pkg/knowledge/api.go
@@ -17,16 +17,17 @@ const localKnowledgeDir = "/data/knowledge"
 // KnowledgeAPI provides a unified interface for dashboard endpoints to query
 // across all configured wiki layers.
 type KnowledgeAPI struct {
-	mu            sync.RWMutex
-	layers        []layerClient
-	config        KnowledgeConfig
-	promoter      *Promoter
-	subscriptions []Subscription
-	vaults        []*FileStore
-	gitSources    []*GitSource
-	docSources    []*DocumentSource
-	graphStore    *GraphStore
-	logger        *slog.Logger
+	mu             sync.RWMutex
+	layers         []layerClient
+	config         KnowledgeConfig
+	promoter       *Promoter
+	subscriptions  []Subscription
+	vaults         []*FileStore
+	gitSources     []*GitSource
+	docSources     []*DocumentSource
+	graphStore     *GraphStore
+	logger         *slog.Logger
+	context7APIKey string
 }
 
 // Subscription represents a user-added wiki endpoint.
@@ -54,13 +55,48 @@ func NewKnowledgeAPI(layers []LayerConfig, config KnowledgeConfig, logger *slog.
 	promoter := NewPromoter(layers, config.Curator, logger)
 
 	api := &KnowledgeAPI{
-		layers:   clients,
-		config:   config,
-		promoter: promoter,
-		logger:   logger,
+		layers:         clients,
+		config:         config,
+		promoter:       promoter,
+		logger:         logger,
+		context7APIKey: os.Getenv("CONTEXT7_API_KEY"),
 	}
 	api.reloadDocuments()
+	api.autoImportContext7()
 	return api
+}
+
+// SetContext7APIKey configures the API key for Context7 library imports.
+func (k *KnowledgeAPI) SetContext7APIKey(key string) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.context7APIKey = key
+}
+
+// WireContext7Suggester attaches a Context7 suggestion callback to the primer.
+// When the primer builds knowledge for an agent kick, it checks if Context7
+// has docs for any of the task's keywords that aren't already imported.
+func (k *KnowledgeAPI) WireContext7Suggester(primer *Primer) {
+	if k.context7APIKey == "" {
+		return
+	}
+	primer.SetContext7Suggester(func(ctx context.Context, keyword string) string {
+		k.mu.RLock()
+		for _, ds := range k.docSources {
+			if strings.Contains(strings.ToLower(ds.metadata.Title), strings.ToLower(keyword)) {
+				k.mu.RUnlock()
+				return ""
+			}
+		}
+		k.mu.RUnlock()
+
+		results, err := SearchContext7(ctx, keyword, k.context7APIKey)
+		if err != nil || len(results) == 0 {
+			return ""
+		}
+		best := results[0]
+		return fmt.Sprintf("Context7 docs available for **%s** (%s) — run `bd kb import-ctx7 %s` to import", best.Name, best.ID, best.ID)
+	})
 }
 
 // LayerStatus describes the health of a single wiki layer.
@@ -671,7 +707,7 @@ func (k *KnowledgeAPI) ImportDocument(ctx context.Context, config DocSourceConfi
 	k.mu.Unlock()
 
 	vaultDir := k.docVaultDir()
-	ds := NewDocumentSource(config, localKnowledgeDir, vaultDir, k.graphStore, k.logger)
+	ds := NewDocumentSource(config, localKnowledgeDir, vaultDir, k.graphStore, k.logger, k.context7APIKey)
 	meta, err := ds.Import(ctx)
 	if err != nil {
 		return nil, err
@@ -754,6 +790,11 @@ func (k *KnowledgeAPI) ReimportDocument(ctx context.Context, slug string) (*DocM
 	return meta, nil
 }
 
+// SearchContext7Libraries searches Context7 for libraries matching the query.
+func (k *KnowledgeAPI) SearchContext7Libraries(ctx context.Context, query string) ([]Context7SearchResult, error) {
+	return SearchContext7(ctx, query, k.context7APIKey)
+}
+
 // reloadDocuments scans the documents directory for previously imported
 // documents and restores them into memory from their metadata.json files.
 func (k *KnowledgeAPI) reloadDocuments() {
@@ -769,13 +810,58 @@ func (k *KnowledgeAPI) reloadDocuments() {
 			continue
 		}
 		dir := filepath.Join(docsDir, entry.Name())
-		ds, err := LoadDocumentSource(dir, vaultDir, k.graphStore, k.logger)
+		ds, err := LoadDocumentSource(dir, vaultDir, k.graphStore, k.logger, k.context7APIKey)
 		if err != nil {
 			k.logger.Warn("failed to reload document", "dir", entry.Name(), "error", err)
 			continue
 		}
 		k.docSources = append(k.docSources, ds)
 		k.logger.Info("reloaded document from disk", "slug", ds.slug, "facts", ds.metadata.FactCount)
+	}
+}
+
+// autoImportContext7 imports any Context7 libraries from config that aren't
+// already present as document sources. Runs at startup after reloadDocuments.
+func (k *KnowledgeAPI) autoImportContext7() {
+	if k.context7APIKey == "" {
+		return
+	}
+	for _, item := range k.config.Context7.AutoImport {
+		if item.ID == "" {
+			continue
+		}
+		name := strings.TrimLeft(item.ID, "/")
+		name = strings.ReplaceAll(name, "/", "-")
+		slug := slugify(name)
+
+		alreadyImported := false
+		k.mu.RLock()
+		for _, ds := range k.docSources {
+			if ds.slug == slug {
+				alreadyImported = true
+				break
+			}
+		}
+		k.mu.RUnlock()
+
+		if alreadyImported {
+			k.logger.Info("context7 auto-import: already present", "id", item.ID, "slug", slug)
+			continue
+		}
+
+		config := DocSourceConfig{
+			Name:       name,
+			Context7ID: item.ID,
+			Layer:      LayerCommunity,
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), context7Timeout)
+		meta, err := k.ImportDocument(ctx, config)
+		cancel()
+		if err != nil {
+			k.logger.Warn("context7 auto-import failed", "id", item.ID, "error", err)
+			continue
+		}
+		k.logger.Info("context7 auto-imported", "id", item.ID, "facts", meta.FactCount)
 	}
 }
 

--- a/v2/pkg/knowledge/context7.go
+++ b/v2/pkg/knowledge/context7.go
@@ -1,0 +1,108 @@
+package knowledge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	context7BaseURL    = "https://context7.com"
+	context7SearchPath = "/api/v2/libs/search"
+	context7DocsPath   = "/api/v2/context"
+	context7Timeout    = 30 * time.Second
+	context7MaxBody    = 10 * 1024 * 1024 // 10 MB
+)
+
+// Context7SearchResult is a single library match from Context7's search API.
+type Context7SearchResult struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Snippets    int    `json:"codeSnippets,omitempty"`
+	Trust       string `json:"sourceReputation,omitempty"`
+	Score       int    `json:"benchmarkScore,omitempty"`
+}
+
+// Context7DocsResult holds the documentation content returned by Context7.
+type Context7DocsResult struct {
+	LibraryID string
+	Title     string
+	Content   string
+}
+
+// SearchContext7 resolves a library name to Context7 IDs.
+func SearchContext7(ctx context.Context, name, apiKey string) ([]Context7SearchResult, error) {
+	params := url.Values{
+		"libraryName": {name},
+		"query":       {name},
+	}
+	reqURL := context7BaseURL + context7SearchPath + "?" + params.Encode()
+
+	body, err := context7Get(ctx, reqURL, apiKey)
+	if err != nil {
+		return nil, fmt.Errorf("context7 search: %w", err)
+	}
+
+	var results []Context7SearchResult
+	if err := json.Unmarshal(body, &results); err != nil {
+		return nil, fmt.Errorf("context7 search decode: %w", err)
+	}
+	return results, nil
+}
+
+// FetchContext7Docs retrieves documentation for a library+query from Context7.
+func FetchContext7Docs(ctx context.Context, libraryID, query, apiKey string) (*Context7DocsResult, error) {
+	if query == "" {
+		query = "overview getting started API reference"
+	}
+	params := url.Values{
+		"libraryId": {libraryID},
+		"query":     {query},
+	}
+	reqURL := context7BaseURL + context7DocsPath + "?" + params.Encode()
+
+	body, err := context7Get(ctx, reqURL, apiKey)
+	if err != nil {
+		return nil, fmt.Errorf("context7 docs: %w", err)
+	}
+
+	return &Context7DocsResult{
+		LibraryID: libraryID,
+		Title:     libraryID,
+		Content:   string(body),
+	}, nil
+}
+
+func context7Get(ctx context.Context, reqURL, apiKey string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, context7Timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	req.Header.Set("User-Agent", "hive-knowledge/1.0")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, fmt.Errorf("rate limited (429), retry after %s", resp.Header.Get("Retry-After"))
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d from Context7", resp.StatusCode)
+	}
+
+	return io.ReadAll(io.LimitReader(resp.Body, context7MaxBody))
+}

--- a/v2/pkg/knowledge/docparser.go
+++ b/v2/pkg/knowledge/docparser.go
@@ -107,16 +107,20 @@ func parsePDF(data []byte) ([]DocChunk, string) {
 	return chunks, docTitle
 }
 
-// extractPageText reconstructs readable text from a PDF page by using positioned
-// text objects, preserving spaces and inserting newlines based on Y-coordinate gaps.
+// extractPageText extracts readable text from a PDF page. Prefers the PDF's
+// own text stream (GetPlainText) which preserves correct character ordering.
+// Falls back to positioned-glyph reconstruction only when GetPlainText fails.
 func extractPageText(page pdf.Page) string {
+	text, err := page.GetPlainText(nil)
+	if err == nil && strings.TrimSpace(text) != "" {
+		result := strings.ReplaceAll(text, "\r\n", "\n")
+		result = strings.ReplaceAll(result, "\r", "\n")
+		return sanitizePDFText(result)
+	}
+
 	content := page.Content()
 	if len(content.Text) == 0 {
-		text, err := page.GetPlainText(nil)
-		if err != nil {
-			return ""
-		}
-		return text
+		return ""
 	}
 
 	texts := make([]pdf.Text, len(content.Text))

--- a/v2/pkg/knowledge/docsource.go
+++ b/v2/pkg/knowledge/docsource.go
@@ -40,31 +40,33 @@ type DocMetadata struct {
 // DocumentSource manages a single imported document: fetch/read, parse, extract
 // facts to the vault, and maintain graph relationships.
 type DocumentSource struct {
-	slug       string
-	config     DocSourceConfig
-	metadata   DocMetadata
-	storageDir string
-	vaultDir   string
-	graphStore *GraphStore
-	logger     *slog.Logger
+	slug           string
+	config         DocSourceConfig
+	metadata       DocMetadata
+	storageDir     string
+	vaultDir       string
+	graphStore     *GraphStore
+	logger         *slog.Logger
+	context7APIKey string
 }
 
 // NewDocumentSource creates a document source. Call Import to fetch and extract.
-func NewDocumentSource(config DocSourceConfig, baseDir, vaultDir string, graphStore *GraphStore, logger *slog.Logger) *DocumentSource {
+func NewDocumentSource(config DocSourceConfig, baseDir, vaultDir string, graphStore *GraphStore, logger *slog.Logger, context7Key string) *DocumentSource {
 	slug := slugify(config.Name)
 	return &DocumentSource{
-		slug:       slug,
-		config:     config,
-		storageDir: filepath.Join(baseDir, docStorageDir, slug),
-		vaultDir:   vaultDir,
-		graphStore: graphStore,
-		logger:     logger,
+		slug:           slug,
+		config:         config,
+		storageDir:     filepath.Join(baseDir, docStorageDir, slug),
+		vaultDir:       vaultDir,
+		graphStore:     graphStore,
+		logger:         logger,
+		context7APIKey: context7Key,
 	}
 }
 
 // LoadDocumentSource restores a DocumentSource from its on-disk metadata.json.
 // Used at startup to reload previously imported documents.
-func LoadDocumentSource(dir, vaultDir string, graphStore *GraphStore, logger *slog.Logger) (*DocumentSource, error) {
+func LoadDocumentSource(dir, vaultDir string, graphStore *GraphStore, logger *slog.Logger, context7Key string) (*DocumentSource, error) {
 	metaPath := filepath.Join(dir, docMetadataFile)
 	data, err := os.ReadFile(metaPath)
 	if err != nil {
@@ -76,14 +78,21 @@ func LoadDocumentSource(dir, vaultDir string, graphStore *GraphStore, logger *sl
 		return nil, fmt.Errorf("parsing metadata: %w", err)
 	}
 
+	config := DocSourceConfig{Name: meta.Title, URL: meta.SourceURL, FilePath: meta.SourceFile}
+	if strings.HasPrefix(meta.SourceURL, "context7://") {
+		config.Context7ID = strings.TrimPrefix(meta.SourceURL, "context7://")
+		config.URL = ""
+	}
+
 	ds := &DocumentSource{
-		slug:       meta.Slug,
-		config:     DocSourceConfig{Name: meta.Title, URL: meta.SourceURL, FilePath: meta.SourceFile},
-		metadata:   meta,
-		storageDir: dir,
-		vaultDir:   vaultDir,
-		graphStore: graphStore,
-		logger:     logger,
+		slug:           meta.Slug,
+		config:         config,
+		metadata:       meta,
+		storageDir:     dir,
+		vaultDir:       vaultDir,
+		graphStore:     graphStore,
+		logger:         logger,
+		context7APIKey: context7Key,
 	}
 	return ds, nil
 }
@@ -104,7 +113,14 @@ func (ds *DocumentSource) Import(ctx context.Context) (*DocMetadata, error) {
 		err         error
 	)
 
-	if ds.config.URL != "" {
+	if ds.config.Context7ID != "" {
+		result, fetchErr := FetchContext7Docs(ctx, ds.config.Context7ID, ds.config.Name, ds.context7APIKey)
+		if fetchErr != nil {
+			return nil, fmt.Errorf("fetching Context7 docs: %w", fetchErr)
+		}
+		content = []byte(result.Content)
+		contentType = "text/plain"
+	} else if ds.config.URL != "" {
 		content, contentType, err = ds.fetchURL(ctx, ds.config.URL)
 		if err != nil {
 			return nil, fmt.Errorf("fetching URL: %w", err)
@@ -116,7 +132,7 @@ func (ds *DocumentSource) Import(ctx context.Context) (*DocMetadata, error) {
 		}
 		contentType = detectContentType(ds.config.FilePath)
 	} else {
-		return nil, fmt.Errorf("document source %q has neither url nor file_path", ds.config.Name)
+		return nil, fmt.Errorf("document source %q has no url, file_path, or context7_id", ds.config.Name)
 	}
 
 	ext := extensionForType(contentType)
@@ -131,8 +147,13 @@ func (ds *DocumentSource) Import(ctx context.Context) (*DocMetadata, error) {
 		title = extractedTitle
 	}
 
+	sourceURL := ds.config.URL
+	if sourceURL == "" && ds.config.Context7ID != "" {
+		sourceURL = "context7://" + ds.config.Context7ID
+	}
+
 	now := time.Now().UTC()
-	facts := chunksToFacts(chunks, ds.slug, ds.config.URL, now)
+	facts := chunksToFacts(chunks, ds.slug, sourceURL, now)
 
 	factSlugs, err := ds.writeFactsToVault(facts, now)
 	if err != nil {
@@ -144,7 +165,7 @@ func (ds *DocumentSource) Import(ctx context.Context) (*DocMetadata, error) {
 	ds.metadata = DocMetadata{
 		Slug:        ds.slug,
 		Title:       title,
-		SourceURL:   ds.config.URL,
+		SourceURL:   sourceURL,
 		SourceFile:  ds.config.FilePath,
 		ContentType: contentType,
 		FetchedAt:   now,

--- a/v2/pkg/knowledge/docsource_test.go
+++ b/v2/pkg/knowledge/docsource_test.go
@@ -28,7 +28,7 @@ func TestDocumentSource_ImportFile(t *testing.T) {
 		Name:     "test-doc",
 		FilePath: srcFile,
 		Layer:    LayerProject,
-	}, baseDir, vaultDir, nil, logger)
+	}, baseDir, vaultDir, nil, logger, "")
 
 	meta, err := ds.Import(context.Background())
 	if err != nil {
@@ -86,7 +86,7 @@ func TestDocumentSource_ImportURL(t *testing.T) {
 		Name:  "test-paper",
 		URL:   server.URL,
 		Layer: LayerCommunity,
-	}, baseDir, vaultDir, nil, logger)
+	}, baseDir, vaultDir, nil, logger, "")
 
 	meta, err := ds.Import(context.Background())
 	if err != nil {
@@ -124,7 +124,7 @@ func TestDocumentSource_Delete(t *testing.T) {
 		Name:     "deleteme",
 		FilePath: srcFile,
 		Layer:    LayerProject,
-	}, baseDir, vaultDir, nil, logger)
+	}, baseDir, vaultDir, nil, logger, "")
 
 	meta, err := ds.Import(context.Background())
 	if err != nil {
@@ -167,7 +167,7 @@ func TestDocumentSource_Reimport(t *testing.T) {
 		Name:     "reimportme",
 		FilePath: srcFile,
 		Layer:    LayerProject,
-	}, baseDir, vaultDir, nil, logger)
+	}, baseDir, vaultDir, nil, logger, "")
 
 	meta1, err := ds.Import(context.Background())
 	if err != nil {
@@ -201,7 +201,7 @@ func TestDocumentSource_NoSourceError(t *testing.T) {
 	ds := NewDocumentSource(DocSourceConfig{
 		Name:  "no-source",
 		Layer: LayerProject,
-	}, tmpDir, filepath.Join(tmpDir, "vault"), nil, logger)
+	}, tmpDir, filepath.Join(tmpDir, "vault"), nil, logger, "")
 
 	_, err := ds.Import(context.Background())
 	if err == nil {

--- a/v2/pkg/knowledge/primer.go
+++ b/v2/pkg/knowledge/primer.go
@@ -15,13 +15,18 @@ import (
 // After collecting BM25 results from wiki layers, the primer reranks them using
 // Fisher-Rao geodesic distance on term-frequency embeddings. This catches
 // semantic matches that keyword search misses.
+// Context7Suggester checks if Context7 has docs for a keyword. Returns a hint
+// string if docs are available and not yet imported, or "" if not.
+type Context7Suggester func(ctx context.Context, keyword string) string
+
 type Primer struct {
-	layers     []layerClient
-	fileStores []localStore
-	graphStore *GraphStore
-	config     PrimerConfig
-	logger     *slog.Logger
-	embedder   *EmbeddingCache
+	layers           []layerClient
+	fileStores       []localStore
+	graphStore       *GraphStore
+	config           PrimerConfig
+	logger           *slog.Logger
+	embedder         *EmbeddingCache
+	context7Suggest  Context7Suggester
 }
 
 type layerClient struct {
@@ -142,8 +147,23 @@ func (p *Primer) Prime(ctx context.Context, filePaths []string, keywords []strin
 		"query_ms", elapsed,
 	)
 
+	var hints []string
+	if p.context7Suggest != nil {
+		seen := make(map[string]bool)
+		for _, kw := range keywords {
+			if seen[kw] {
+				continue
+			}
+			seen[kw] = true
+			if hint := p.context7Suggest(ctx, kw); hint != "" {
+				hints = append(hints, hint)
+			}
+		}
+	}
+
 	return &PrimedKnowledge{
 		Facts:     prioritized,
+		Hints:     hints,
 		QueryTime: elapsed,
 	}
 }
@@ -221,6 +241,11 @@ func (p *Primer) applyPriority(facts []Fact) []Fact {
 	})
 
 	return facts
+}
+
+// SetContext7Suggester sets the callback that checks Context7 for library docs.
+func (p *Primer) SetContext7Suggester(fn Context7Suggester) {
+	p.context7Suggest = fn
 }
 
 // SetGraphStore attaches a graph store for one-hop related-fact expansion.

--- a/v2/pkg/knowledge/types.go
+++ b/v2/pkg/knowledge/types.go
@@ -46,13 +46,25 @@ func (l LayerConfig) Endpoint() string {
 	return ""
 }
 
-// DocSourceConfig describes an external document (PDF, URL, or text file)
-// to import as knowledge facts.
+// DocSourceConfig describes an external document (PDF, URL, text file, or
+// Context7 library) to import as knowledge facts.
 type DocSourceConfig struct {
-	Name     string    `yaml:"name"      json:"name"`
-	URL      string    `yaml:"url"       json:"url,omitempty"`
-	FilePath string    `yaml:"file_path" json:"file_path,omitempty"`
-	Layer    LayerType `yaml:"layer"     json:"layer"`
+	Name       string    `yaml:"name"        json:"name"`
+	URL        string    `yaml:"url"         json:"url,omitempty"`
+	FilePath   string    `yaml:"file_path"   json:"file_path,omitempty"`
+	Context7ID string    `yaml:"context7_id" json:"context7_id,omitempty"`
+	Layer      LayerType `yaml:"layer"       json:"layer"`
+}
+
+// Context7AutoImport describes a library to auto-import from Context7 at startup.
+type Context7AutoImport struct {
+	ID    string `yaml:"id"    json:"id"`
+	Query string `yaml:"query" json:"query,omitempty"`
+}
+
+// Context7Config configures automatic Context7 library documentation imports.
+type Context7Config struct {
+	AutoImport []Context7AutoImport `yaml:"auto_import" json:"auto_import,omitempty"`
 }
 
 // KnowledgeConfig is the top-level knowledge section of hive.yaml.
@@ -62,6 +74,7 @@ type KnowledgeConfig struct {
 	Layers          []LayerConfig         `yaml:"layers"           json:"layers"`
 	GitSources      []GitSourceConfig     `yaml:"git_sources"      json:"git_sources,omitempty"`
 	Documents       []DocSourceConfig     `yaml:"documents"        json:"documents,omitempty"`
+	Context7        Context7Config        `yaml:"context7"         json:"context7,omitempty"`
 	Curator         CuratorConfig         `yaml:"curator"          json:"curator"`
 	Primer          PrimerConfig          `yaml:"primer"           json:"primer"`
 	BeadSynthesizer BeadSynthesizerConfig `yaml:"bead_synthesizer" json:"bead_synthesizer"`
@@ -193,8 +206,9 @@ type Source struct {
 
 // PrimedKnowledge is the result of priming — ready to inject into an agent kick.
 type PrimedKnowledge struct {
-	Facts     []Fact `json:"facts"`
-	QueryTime int64  `json:"query_time_ms"`
+	Facts     []Fact   `json:"facts"`
+	Hints     []string `json:"hints,omitempty"`
+	QueryTime int64    `json:"query_time_ms"`
 }
 
 // FormatForPrompt renders primed facts as markdown for injection into an agent's
@@ -237,6 +251,16 @@ func (pk *PrimedKnowledge) FormatForPrompt() string {
 			b = append(b, f.Body...)
 			b = append(b, "\n\n"...)
 		}
+	}
+
+	if len(pk.Hints) > 0 {
+		b = append(b, "## Available Documentation\n\n"...)
+		for _, hint := range pk.Hints {
+			b = append(b, "- "...)
+			b = append(b, hint...)
+			b = append(b, "\n"...)
+		}
+		b = append(b, "\n"...)
 	}
 
 	return string(b)


### PR DESCRIPTION
## Summary
- Adds Context7 (Upstash's library documentation API) as a third document source type alongside URL and file path imports
- Agents can import up-to-date library docs (e.g. vLLM, KubeRay, Next.js) into the knowledge vault via CLI, dashboard, or auto-import config
- Primer-time hints suggest available Context7 docs for task keywords that don't yet have imported docs
- Also fixes PDF text extraction: prefers `GetPlainText` over positioned-glyph reconstruction, which was scrambling character order

### New files
- `v2/pkg/knowledge/context7.go` — Context7 REST API client (search libraries + fetch docs)

### Modified files
- `types.go` — `Context7ID` on `DocSourceConfig`, `Context7Config`/`Context7AutoImport` structs, `Hints` on `PrimedKnowledge`
- `docsource.go` — Context7 fetch branch in `Import()`, `context7://` URL scheme
- `api.go` — API key from env, `SearchContext7Libraries()`, `autoImportContext7()`, `WireContext7Suggester()`
- `primer.go` — `Context7Suggester` callback, hint injection during `Prime()`
- `dashboard/api.go` — `/api/knowledge/context7/search` proxy endpoint
- `dashboard/static/index.html` — Context7 library search + import UI in Knowledge panel
- `cmd/bd/kb.go` — `bd kb import-ctx7` and `bd kb ctx7-search` subcommands
- `cmd/hive/main.go` — Wire Context7 suggester to primer
- `docparser.go` — Prefer `GetPlainText` for PDF extraction (fixes garbled text)

### Configuration
Set `CONTEXT7_API_KEY` env var. Optional `hive.yaml`:
```yaml
knowledge:
  context7:
    auto_import:
      - id: /vllm-project/vllm
        query: "inference serving"
```

## Test plan
- [ ] Build passes
- [ ] `bd kb ctx7-search "vllm"` returns library results
- [ ] `bd kb import-ctx7 /vllm-project/vllm` imports docs as vault facts
- [ ] Dashboard Knowledge panel shows Context7 search + import UI
- [ ] Reimport ACMM PDF produces readable text (no garbled characters)
- [ ] Auto-import from config works at startup