### PR TITLE
fix: defer anchor scroll until deferred sections load + fix Context7 search

### DIFF
--- a/v2/cmd/bd/kb.go
+++ b/v2/cmd/bd/kb.go
@@ -284,14 +284,15 @@ func cmdKBCtx7Search(args []string) {
 
 	for _, r := range results {
 		id, _ := r["id"].(string)
-		name, _ := r["name"].(string)
+		name, _ := r["title"].(string)
 		desc, _ := r["description"].(string)
-		trust, _ := r["sourceReputation"].(string)
-		snippets, _ := r["codeSnippets"].(float64)
+		trust, _ := r["trustScore"].(float64)
+		snippets, _ := r["totalSnippets"].(float64)
+		stars, _ := r["stars"].(float64)
 
 		fmt.Printf("  %-35s  %s\n", id, name)
-		if trust != "" || snippets > 0 {
-			fmt.Printf("    trust: %s  snippets: %d\n", trust, int(snippets))
+		if trust > 0 || snippets > 0 {
+			fmt.Printf("    trust: %.1f  snippets: %d  stars: %d\n", trust, int(snippets), int(stars))
 		}
 		if desc != "" {
 			const maxDescChars = 120

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -822,6 +822,11 @@
     .agent-card.working .agent-name { animation: pulse 2s ease-in-out infinite; }
 
     /* Breathing green indicator for working agent cards — top right */
+    @keyframes anchor-flash {
+      0% { box-shadow: inset 0 0 0 2px rgba(88,166,255,0.6); }
+      100% { box-shadow: inset 0 0 0 2px transparent; }
+    }
+    .anchor-highlight { animation: anchor-flash 1.2s ease-out; }
     @keyframes breathe-green {
       0%,100% { opacity: 1; box-shadow: 0 0 6px 2px rgba(63,185,80,0.5); }
       50% { opacity: 0.25; box-shadow: 0 0 2px 0px rgba(63,185,80,0.1); }
@@ -2300,6 +2305,9 @@
         if (el) {
           const y = el.getBoundingClientRect().top + window.scrollY - OC_TOPBAR_HEIGHT;
           window.scrollTo({ top: y, behavior: 'smooth' });
+          el.classList.remove('anchor-highlight');
+          void el.offsetWidth;
+          el.classList.add('anchor-highlight');
         }
       }
       document.querySelectorAll('.oc-nav-item').forEach(i => i.classList.remove('active'));
@@ -6889,15 +6897,16 @@ function burnAreaChart() {
         let html = '';
         for (const lib of results.slice(0, 8)) {
           const id = lib.id || '';
-          const name = lib.name || id;
+          const name = lib.title || id;
           const desc = lib.description || '';
-          const trust = lib.sourceReputation || '';
-          const snippets = lib.codeSnippets || 0;
+          const trust = lib.trustScore ? lib.trustScore.toFixed(1) : '';
+          const snippets = lib.totalSnippets || 0;
           html += '<div style="display:flex;align-items:center;justify-content:space-between;padding:6px 8px;border:1px solid var(--border);border-radius:6px;margin-bottom:4px;font-size:0.72rem">';
           html += '<div style="flex:1;min-width:0">';
           html += '<div style="font-weight:600;color:var(--fg)">' + escapeHtml(name) + '</div>';
           html += '<div style="color:var(--muted);font-size:0.68rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">' + escapeHtml(id);
-          if (trust) html += ' · ' + escapeHtml(trust);
+          if (trust) html += ' · trust ' + trust;
+          if (lib.stars) html += ' · ' + lib.stars.toLocaleString() + ' ★';
           if (snippets > 0) html += ' · ' + snippets + ' snippets';
           html += '</div>';
           if (desc) html += '<div style="color:var(--muted);font-size:0.68rem;margin-top:2px;overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical">' + escapeHtml(desc) + '</div>';
@@ -7628,14 +7637,26 @@ function burnAreaChart() {
 
     let _hashScrollPending = false;
     var SCROLL_SETTLE_DELAY_MS = 500;
+    var _deferredLoadPromise = null;
     function _afterPaint(callback) {
       _hashScrollPending = true;
-      requestAnimationFrame(function() {
-        requestAnimationFrame(function() {
-          setTimeout(callback, SCROLL_SETTLE_DELAY_MS);
-          setTimeout(function() { _hashScrollPending = false; }, 500);
+      if (_deferredLoadPromise) {
+        _deferredLoadPromise.then(function() {
+          requestAnimationFrame(function() {
+            requestAnimationFrame(function() {
+              callback();
+              setTimeout(function() { _hashScrollPending = false; }, 200);
+            });
+          });
         });
-      });
+      } else {
+        requestAnimationFrame(function() {
+          requestAnimationFrame(function() {
+            setTimeout(callback, SCROLL_SETTLE_DELAY_MS);
+            setTimeout(function() { _hashScrollPending = false; }, 500);
+          });
+        });
+      }
     }
 
     function render(data) {
@@ -11600,28 +11621,34 @@ function burnAreaChart() {
 
     connect();
 
-    // Deferred initialization — non-critical fetches staggered after first paint
+    // Deferred initialization — non-critical fetches staggered after first paint.
+    // Each entry returns a promise so anchor scrolling can wait for layout to settle.
     const DEFERRED_INIT_DELAY_MS = 1500;
     const DEFERRED_STAGGER_MS = 200;
-    setTimeout(() => {
-      const deferred = [
-        () => { fetchFactHistory(); },
-        () => { fetchHistory(); setInterval(fetchHistory, HISTORY_REFRESH_MS); },
-        () => { fetchIssueCosts(); setInterval(fetchIssueCosts, ISSUE_COSTS_REFRESH_MS); },
-        () => { fetch('/api/budget-ignore').then(r => r.json()).then(d => { budgetIgnored = d.ignored; }).catch(() => {}); },
-        () => { fetchNousStatus(); setInterval(fetchNousStatus, NOUS_POLL_MS); },
-        () => { fetchKnowledgeStats(); setInterval(fetchKnowledgeStats, KB_POLL_MS); },
-        () => { fetchAuditLog(); setInterval(fetchAuditLog, AUDIT_POLL_MS); },
-        () => { fetchContributors(); setInterval(fetchContributors, CONTRIBUTOR_POLL_MS); },
-        () => { fetchLeaderboard(); setInterval(fetchLeaderboard, LEADERBOARD_POLL_MS); },
-        () => { fetchGitVersion(); setInterval(fetchGitVersion, GIT_VERSION_POLL_MS); },
-        () => { startVersionCheck(); },
-        () => { fetch('/api/trends?range=week').then(r => r.json()).then(applyTrends).catch(() => {}); setInterval(() => { fetch('/api/trends?range=week').then(r => r.json()).then(applyTrends).catch(() => {}); }, TREND_REFRESH_MS); },
-        () => { fetchTimeline(); setInterval(fetchTimeline, TIMELINE_REFRESH_MS); },
-        () => { fetchAgentLogs(); setInterval(fetchAgentLogs, LOGS_REFRESH_MS); },
-      ];
-      deferred.forEach((fn, i) => setTimeout(fn, i * DEFERRED_STAGGER_MS));
-    }, DEFERRED_INIT_DELAY_MS);
+    _deferredLoadPromise = new Promise(function(resolveAll) {
+      setTimeout(() => {
+        const deferred = [
+          () => fetchFactHistory(),
+          () => fetchHistory().then(() => { setInterval(fetchHistory, HISTORY_REFRESH_MS); }),
+          () => fetchIssueCosts().then(() => { setInterval(fetchIssueCosts, ISSUE_COSTS_REFRESH_MS); }),
+          () => fetch('/api/budget-ignore').then(r => r.json()).then(d => { budgetIgnored = d.ignored; }).catch(() => {}),
+          () => fetchNousStatus().then(() => { setInterval(fetchNousStatus, NOUS_POLL_MS); }),
+          () => fetchKnowledgeStats().then(() => { setInterval(fetchKnowledgeStats, KB_POLL_MS); }),
+          () => fetchAuditLog().then(() => { setInterval(fetchAuditLog, AUDIT_POLL_MS); }),
+          () => fetchContributors().then(() => { setInterval(fetchContributors, CONTRIBUTOR_POLL_MS); }),
+          () => fetchLeaderboard().then(() => { setInterval(fetchLeaderboard, LEADERBOARD_POLL_MS); }),
+          () => fetchGitVersion().then(() => { setInterval(fetchGitVersion, GIT_VERSION_POLL_MS); }),
+          () => Promise.resolve(startVersionCheck()),
+          () => fetch('/api/trends?range=week').then(r => r.json()).then(applyTrends).catch(() => {}).then(() => { setInterval(() => { fetch('/api/trends?range=week').then(r => r.json()).then(applyTrends).catch(() => {}); }, TREND_REFRESH_MS); }),
+          () => fetchTimeline().then(() => { setInterval(fetchTimeline, TIMELINE_REFRESH_MS); }),
+          () => fetchAgentLogs().then(() => { setInterval(fetchAgentLogs, LOGS_REFRESH_MS); }),
+        ];
+        const allDone = deferred.map((fn, i) =>
+          new Promise(resolve => setTimeout(() => fn().then(resolve, resolve), i * DEFERRED_STAGGER_MS))
+        );
+        Promise.all(allDone).then(resolveAll);
+      }, DEFERRED_INIT_DELAY_MS);
+    });
   </script>
 </body>
 </html>

--- a/v2/pkg/knowledge/api.go
+++ b/v2/pkg/knowledge/api.go
@@ -95,7 +95,7 @@ func (k *KnowledgeAPI) WireContext7Suggester(primer *Primer) {
 			return ""
 		}
 		best := results[0]
-		return fmt.Sprintf("Context7 docs available for **%s** (%s) — run `bd kb import-ctx7 %s` to import", best.Name, best.ID, best.ID)
+		return fmt.Sprintf("Context7 docs available for **%s** (%s) — run `bd kb import-ctx7 %s` to import", best.Title, best.ID, best.ID)
 	})
 }
 

--- a/v2/pkg/knowledge/context7.go
+++ b/v2/pkg/knowledge/context7.go
@@ -20,12 +20,17 @@ const (
 
 // Context7SearchResult is a single library match from Context7's search API.
 type Context7SearchResult struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	Snippets    int    `json:"codeSnippets,omitempty"`
-	Trust       string `json:"sourceReputation,omitempty"`
-	Score       int    `json:"benchmarkScore,omitempty"`
+	ID          string  `json:"id"`
+	Title       string  `json:"title"`
+	Description string  `json:"description,omitempty"`
+	Snippets    int     `json:"totalSnippets,omitempty"`
+	Trust       float64 `json:"trustScore,omitempty"`
+	Score       float64 `json:"benchmarkScore,omitempty"`
+	Stars       int     `json:"stars,omitempty"`
+}
+
+type context7SearchResponse struct {
+	Results []Context7SearchResult `json:"results"`
 }
 
 // Context7DocsResult holds the documentation content returned by Context7.
@@ -48,11 +53,11 @@ func SearchContext7(ctx context.Context, name, apiKey string) ([]Context7SearchR
 		return nil, fmt.Errorf("context7 search: %w", err)
 	}
 
-	var results []Context7SearchResult
-	if err := json.Unmarshal(body, &results); err != nil {
+	var wrapper context7SearchResponse
+	if err := json.Unmarshal(body, &wrapper); err != nil {
 		return nil, fmt.Errorf("context7 search decode: %w", err)
 	}
-	return results, nil
+	return wrapper.Results, nil
 }
 
 // FetchContext7Docs retrieves documentation for a library+query from Context7.


### PR DESCRIPTION
## Summary

- **Anchor scroll fix**: URL hash scrolling now waits for all deferred section fetches to complete before scrolling to the target. Previously, `_afterPaint` scrolled after a fixed 500ms delay, but deferred sections load 1.5-4.3s after page load, causing the scroll target to shift as sections render.
- **Visual feedback**: Adds a subtle blue inset flash animation on the target section after scroll lands, so the user knows where it landed.
- **Context7 API fix**: The search API returns `{"results": [...]}` (wrapped object), not a bare array. Field names also differ from initial implementation: `title` not `name`, `trustScore` (float) not `sourceReputation` (string), `totalSnippets` not `codeSnippets`, plus `stars` field. Updated Go struct, JSON decode, dashboard JS, and CLI to match actual API response.

## Changes

| File | Change |
|------|--------|
| `v2/pkg/dashboard/static/index.html` | `_afterPaint` waits on `_deferredLoadPromise`; deferred init block tracks all fetch promises; anchor-flash CSS animation; updated Context7 field names in JS |
| `v2/pkg/knowledge/context7.go` | Added `context7SearchResponse` wrapper type; updated `Context7SearchResult` fields to match API; unwrap `results` in `SearchContext7` |
| `v2/pkg/knowledge/api.go` | `best.Name` → `best.Title` |
| `v2/cmd/bd/kb.go` | Updated field names in CLI output (`title`, `trustScore`, `totalSnippets`, `stars`) |