### PR TITLE
feat: audit programmatic events (governor kicks, crash recovery, login detection)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1231,6 +1231,8 @@ func main() {
 		logger.Info("audit: starting agent", "name", name, "trigger", "startup")
 		if err := agentMgr.Start(ctx, name); err != nil {
 			logger.Warn("failed to start agent", "name", name, "error", err)
+		} else {
+			dashSrv.AuditLog("system", "agent_start", "trigger=startup", name)
 		}
 		agentIndex++
 	}
@@ -1531,6 +1533,9 @@ func main() {
 			return
 		case <-ticker.C:
 			restarted := agentMgr.CheckAndRestartCrashedAgents(ctx)
+			for _, name := range restarted {
+				dashSrv.AuditLog("system", "restart", "trigger=crash-recovery", name)
+			}
 			// If brainstorm crashed during inception, re-kick via SendKick.
 			// SendKick waits for the CLI to be ready and sends the message
 			// If brainstorm crashed during inception, re-kick with bootstrap.
@@ -1544,6 +1549,7 @@ func main() {
 							logger.Warn("inception re-kick after crash failed", "error", err)
 						} else {
 							logger.Info("brainstorm re-kicked after crash", "phase", state.Phase)
+							dashSrv.AuditLog("system", "kick", "trigger=inception-crash-recovery", "brainstorm")
 						}
 						gov.RecordKick("brainstorm")
 					}
@@ -1688,6 +1694,7 @@ func runEvalCycle(
 				continue
 			}
 			gov.RecordKick(msg.Agent)
+			dashSrv.AuditLog("governor", "kick", "trigger=governor-eval", msg.Agent)
 
 			// Log token state at time of kick for cost attribution
 			if tokenCollector != nil {
@@ -1725,7 +1732,7 @@ func runEvalCycle(
 	}
 
 	// Scan agent panes for login-required patterns and pause + notify if detected
-	scanForLoginRequired(cfg, agentMgr, notifier, logger)
+	scanForLoginRequired(cfg, agentMgr, notifier, dashSrv, logger)
 
 	agentStatuses := agentMgr.AllStatuses()
 
@@ -1879,6 +1886,7 @@ func scanForLoginRequired(
 	cfg *config.Config,
 	agentMgr *agent.Manager,
 	notifier *notify.Notifier,
+	dashSrv *dashboard.Server,
 	logger *slog.Logger,
 ) {
 	patterns := cfg.Governor.Sensing.LoginPatterns
@@ -1927,6 +1935,8 @@ func scanForLoginRequired(
 				if pauseErr := agentMgr.Pause(name, "login-detector", "login required detected"); pauseErr != nil {
 					logger.Warn("failed to pause agent after login detection",
 						"agent", name, "error", pauseErr)
+				} else {
+					dashSrv.AuditLog("system", "pause", "trigger=login-detector", name)
 				}
 
 				// Determine the login instruction based on the agent's backend

--- a/v2/pkg/dashboard/audit.go
+++ b/v2/pkg/dashboard/audit.go
@@ -141,6 +141,12 @@ func (s *Server) auditFromRequest(r *http.Request, action, detail, agent string)
 	s.audit.Log(user, action, detail, agent)
 }
 
+// AuditLog records an audit event from non-HTTP contexts (governor eval,
+// config watcher, startup, login detector).
+func (s *Server) AuditLog(user, action, detail, agent string) {
+	s.audit.Log(user, action, detail, agent)
+}
+
 func auditDetail(kv ...string) string {
 	if len(kv) == 0 {
 		return ""


### PR DESCRIPTION
## Summary

- Exports `AuditLog()` method on `Server` for non-HTTP callers
- Adds audit events for 5 programmatic state changes that were previously invisible:
  - **Governor kicks** (`user=governor`, `trigger=governor-eval`) — every eval cycle kick now recorded
  - **Agent startup** (`user=system`, `trigger=startup`) — initial agent launches
  - **Crash recovery restarts** (`user=system`, `trigger=crash-recovery`) — `CheckAndRestartCrashedAgents`
  - **Inception crash re-kick** (`user=system`, `trigger=inception-crash-recovery`) — brainstorm re-kick after crash
  - **Login-detector pauses** (`user=system`, `trigger=login-detector`) — agents paused due to login prompts

## Context

PR #1727 added audit logging to all HTTP handlers but missed programmatic events from `main.go`'s eval loop. Governor kicks are the most frequent state change and were completely invisible in the audit log.

## Test plan

- [x] `go build ./cmd/hive/` passes
- [x] `go vet ./cmd/hive/` passes
- [ ] Deploy and verify governor kick events appear in `/api/audit` with `user=governor`