### PR TITLE
fix: allow context7_id as valid document source in import validation

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -4185,8 +4185,8 @@ func (s *Server) handleDocumentsImport(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "name is required", http.StatusBadRequest)
 		return
 	}
-	if req.URL == "" && req.FilePath == "" {
-		jsonError(w, "url or file_path is required", http.StatusBadRequest)
+	if req.URL == "" && req.FilePath == "" && req.Context7ID == "" {
+		jsonError(w, "url, file_path, or context7_id is required", http.StatusBadRequest)
 		return
 	}
 	if req.Layer == "" {


### PR DESCRIPTION
## Summary

- Import handler validation only checked for `url` or `file_path`, rejecting Context7 imports (`context7_id`) with "url or file_path is required"
- Now accepts `context7_id` as a third valid source type

One-line fix in `handleDocumentsImport` validation.