### PR TITLE
fix: tolerate chown failures in init-permissions container

### DIFF
--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1026,7 +1026,7 @@ spec:
       - name: init-permissions
         image: ghcr.io/kubestellar/hive:{{.ImageTag}}
         imagePullPolicy: {{.ImagePullPolicy}}
-        command: ["sh", "-c", "chown -R {{.InitContainerUID}}:{{.InitContainerGID}} /data && echo permissions-set"]
+        command: ["sh", "-c", "chown -R {{.InitContainerUID}}:{{.InitContainerGID}} /data 2>/dev/null; echo permissions-set"]
         securityContext:
           runAsUser: 0
         volumeMounts:


### PR DESCRIPTION
## Summary

- Makes the `init-permissions` init container tolerant of `chown` failures on CephFS with root_squash
- Fixes stuck rollouts where the new pod enters `Init:CrashLoopBackOff` while the old pod keeps serving

## Root cause

On CephFS (e.g. `ocs-storagecluster-cephfs` on OpenShift), `root_squash` prevents root from chowning files created by UID 1001. The hive process creates `.tmp` files (`fact-history.json.tmp`, `mode-history.json.tmp`, `hive-state.json.tmp`) that the init container can't chown, causing it to exit non-zero and CrashLoopBackOff.

Observed on `hosted-open-source-osscar-appli-rc57` (vllm-d cluster) — 1012 restarts over 3.5 days.

## Fix

Changed `chown -R ... /data && echo permissions-set` to `chown -R ... /data 2>/dev/null; echo permissions-set` — chown fixes what it can, skips what it can't, container always succeeds.

## Test plan

- [x] `go build ./pkg/hub/` passes
- [x] `go vet ./pkg/hub/` passes
- [ ] After deploy, verify osscar rollout completes on vllm-d cluster