### PR TITLE
fix: workspace cleanup fails due to CephFS root_squash + add audit logging

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -831,7 +831,7 @@ func main() {
 		}
 	}()
 
-	go dashboard.StartWorkspaceCleanup(ctx, logger)
+	go dashboard.StartWorkspaceCleanup(ctx, logger, dashSrv.GetAudit())
 
 	os.MkdirAll(nousSnapshotDir, 0o755)
 	os.MkdirAll(nousGovernorDir, 0o755)

--- a/v2/pkg/dashboard/audit.go
+++ b/v2/pkg/dashboard/audit.go
@@ -147,6 +147,11 @@ func (s *Server) AuditLog(user, action, detail, agent string) {
 	s.audit.Log(user, action, detail, agent)
 }
 
+// GetAudit returns the underlying AuditLog for use by background goroutines.
+func (s *Server) GetAudit() *AuditLog {
+	return s.audit
+}
+
 func auditDetail(kv ...string) string {
 	if len(kv) == 0 {
 		return ""

--- a/v2/pkg/dashboard/workspace_cleanup.go
+++ b/v2/pkg/dashboard/workspace_cleanup.go
@@ -2,9 +2,14 @@ package dashboard
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
+	"syscall"
 	"time"
 )
 
@@ -16,12 +21,10 @@ const (
 
 // StartWorkspaceCleanup runs a background loop that periodically sweeps
 // /data/agents/*/ for stale workspace artifacts and removes them.
-// This prevents unbounded disk growth from agents that create repo clones,
-// Go caches, working directories, and temporary files during tasks.
-func StartWorkspaceCleanup(ctx context.Context, logger *slog.Logger) {
+func StartWorkspaceCleanup(ctx context.Context, logger *slog.Logger, audit *AuditLog) {
 	logger.Info("workspace cleanup enabled", "interval", workspaceCleanupInterval, "max_age", workspaceMaxAge)
 
-	sweepWorkspaces(logger)
+	sweepWorkspaces(logger, audit)
 
 	ticker := time.NewTicker(workspaceCleanupInterval)
 	defer ticker.Stop()
@@ -31,12 +34,12 @@ func StartWorkspaceCleanup(ctx context.Context, logger *slog.Logger) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			sweepWorkspaces(logger)
+			sweepWorkspaces(logger, audit)
 		}
 	}
 }
 
-func sweepWorkspaces(logger *slog.Logger) {
+func sweepWorkspaces(logger *slog.Logger, audit *AuditLog) {
 	agentDirs, err := os.ReadDir(agentWorkspaceRoot)
 	if err != nil {
 		logger.Debug("workspace cleanup: cannot read agent root", "path", agentWorkspaceRoot, "error", err)
@@ -45,6 +48,7 @@ func sweepWorkspaces(logger *slog.Logger) {
 
 	removedDirs := 0
 	removedFiles := 0
+	failedDirs := 0
 	now := time.Now()
 
 	for _, agentEntry := range agentDirs {
@@ -76,16 +80,17 @@ func sweepWorkspaces(logger *slog.Logger) {
 			}
 
 			if entry.IsDir() {
-				if err := os.RemoveAll(entryPath); err != nil {
+				if err := removeAsOwner(entryPath); err != nil {
 					logger.Warn("workspace cleanup: failed to remove stale dir",
 						"agent", agentName, "dir", name, "age", age.Round(time.Minute), "error", err)
+					failedDirs++
 					continue
 				}
 				logger.Info("workspace cleanup: removed stale dir",
 					"agent", agentName, "dir", name, "age", age.Round(time.Minute))
 				removedDirs++
 			} else {
-				if err := os.Remove(entryPath); err != nil {
+				if err := removeAsOwner(entryPath); err != nil {
 					logger.Warn("workspace cleanup: failed to remove stale file",
 						"agent", agentName, "file", name, "error", err)
 					continue
@@ -95,7 +100,41 @@ func sweepWorkspaces(logger *slog.Logger) {
 		}
 	}
 
-	logger.Info("workspace cleanup complete", "removed_dirs", removedDirs, "removed_files", removedFiles)
+	logger.Info("workspace cleanup complete",
+		"removed_dirs", removedDirs, "removed_files", removedFiles, "failed_dirs", failedDirs)
+
+	if audit != nil && (removedDirs > 0 || removedFiles > 0 || failedDirs > 0) {
+		audit.Log("system", "workspace_cleanup",
+			fmt.Sprintf("removed_dirs=%d removed_files=%d failed=%d", removedDirs, removedFiles, failedDirs), "")
+	}
+}
+
+// removeAsOwner tries os.RemoveAll first; on permission error (CephFS
+// root_squash), it detects the owning UID and retries rm -rf as that user.
+func removeAsOwner(path string) error {
+	err := os.RemoveAll(path)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, syscall.EPERM) && !errors.Is(err, os.ErrPermission) {
+		return err
+	}
+
+	info, statErr := os.Stat(path)
+	if statErr != nil {
+		return err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return err
+	}
+	ownerUID := strconv.FormatUint(uint64(stat.Uid), 10)
+
+	cmd := exec.Command("su", "-s", "/bin/sh", "-c", "rm -rf "+path, ownerUID)
+	if suErr := cmd.Run(); suErr != nil {
+		return fmt.Errorf("os.RemoveAll: %w; su %s rm -rf: %v", err, ownerUID, suErr)
+	}
+	return nil
 }
 
 func isSkippedEntry(name string) bool {


### PR DESCRIPTION
## Summary

- Fix `workspace_cleanup.go` permission errors on CephFS — root is squashed and can't delete files owned by per-agent UIDs (2000+)
- On `EPERM`, detect the owning UID and retry `rm -rf` as that user via `su`
- Add audit log entries (`workspace_cleanup` action) so cleanup results are visible in the dashboard

## Root Cause

The hourly cleanup was running every hour as designed, but **every single removal was failing** with `permission denied`. On CephFS with `root_squash`, the root user is mapped to `nfsnobody` which can't delete files owned by agent UIDs like `hive-scanner` (2007). The cleanup logged WARN entries for each failure but had no fallback — stale dirs accumulated indefinitely.

Evidence from pod logs:
```
{"level":"WARN","msg":"workspace cleanup: failed to remove stale dir","agent":"console-19858","dir":".claude","error":"unlinkat .../session-summary.md: permission denied"}
{"level":"WARN","msg":"workspace cleanup: failed to remove stale file","agent":"pr19525","file":".clomonitor.yml","error":"remove ...: permission denied"}
```

This is what caused the 95+ stale scanner dirs that triggered the startup livelock fixed in PR #1737.

## Test plan

- [x] Verified `su -s /bin/sh hive-scanner -c "rm -f ..."` works on CephFS (manually tested on console hive pod)
- [x] `go build ./...` passes
- [ ] Wait for docker CI to pass
- [ ] After deploy, verify `workspace_cleanup` audit entries appear in dashboard