### PR TITLE
feat: ACMM Evaluation dashboard card with local repo scanning

### DIFF
--- a/v2/pkg/dashboard/acmm_criteria.go
+++ b/v2/pkg/dashboard/acmm_criteria.go
@@ -1,0 +1,143 @@
+package dashboard
+
+// ACMMCriterion defines a single ACMM evaluation criterion that can be
+// checked against a repository via file-existence detection.
+type ACMMCriterion struct {
+	ID       string
+	Source   string   // "acmm" or "aef"
+	Level    int      // 0, 2, 3, 4, 5, 6
+	Category string
+	Name     string
+	Patterns []string // file paths to check (pass if ANY exists)
+}
+
+// acmmLevelNames maps numeric ACMM levels to human-readable names.
+var acmmLevelNames = map[int]string{
+	0: "Prerequisites",
+	2: "Instructed",
+	3: "Measured",
+	4: "Adaptive",
+	5: "Automated",
+	6: "Autonomous",
+}
+
+// universalCriteria contains the 43 repo-universal ACMM criteria ported
+// from the console scan API (acmm:* and aef:* sources). CNCF-specific
+// criteria (fullsend:*, claude-reflect:*) are intentionally excluded so
+// that hive spokes running against private/internal repos get meaningful
+// evaluations.
+var universalCriteria = []ACMMCriterion{
+	// ── L0 Prerequisites (8) ──
+	{ID: "acmm:prereq-test-suite", Source: "acmm", Level: 0, Category: "prerequisite", Name: "Test suite",
+		Patterns: []string{"vitest.config.ts", "vitest.config.js", "jest.config.js", "jest.config.ts", "go.mod", "pytest.ini", "pyproject.toml", "test/", "tests/", "__tests__/", "spec/"}},
+	{ID: "acmm:prereq-e2e", Source: "acmm", Level: 0, Category: "prerequisite", Name: "E2E tests",
+		Patterns: []string{"playwright.config.ts", "playwright.config.js", "cypress.config.ts", "e2e/"}},
+	{ID: "acmm:prereq-cicd", Source: "acmm", Level: 0, Category: "prerequisite", Name: "CI/CD pipeline",
+		Patterns: []string{".github/workflows/", ".gitlab-ci.yml", "Jenkinsfile", ".circleci/"}},
+	{ID: "acmm:prereq-pr-template", Source: "acmm", Level: 0, Category: "prerequisite", Name: "PR template",
+		Patterns: []string{".github/pull_request_template.md", ".github/PULL_REQUEST_TEMPLATE.md"}},
+	{ID: "acmm:prereq-issue-template", Source: "acmm", Level: 0, Category: "prerequisite", Name: "Issue templates",
+		Patterns: []string{".github/ISSUE_TEMPLATE/", ".github/issue_template.md"}},
+	{ID: "acmm:prereq-contrib-guide", Source: "acmm", Level: 0, Category: "prerequisite", Name: "Contributing guide",
+		Patterns: []string{"CONTRIBUTING.md", "docs/contributing.md", ".github/CONTRIBUTING.md"}},
+	{ID: "acmm:prereq-code-style", Source: "acmm", Level: 0, Category: "prerequisite", Name: "Code style config",
+		Patterns: []string{".eslintrc", ".eslintrc.json", ".eslintrc.js", "eslint.config.js", "eslint.config.mjs", ".prettierrc", ".prettierrc.json", "prettier.config.js", "ruff.toml", ".golangci.yml", "biome.json"}},
+	{ID: "acmm:prereq-coverage-gate", Source: "acmm", Level: 0, Category: "prerequisite", Name: "Coverage gate",
+		Patterns: []string{"codecov.yml", ".codecov.yml", ".github/workflows/coverage-gate.yml", "coverage.yml", ".coverage-thresholds.json"}},
+
+	// ── L2 Instructed (8) ──
+	{ID: "acmm:claude-md", Source: "acmm", Level: 2, Category: "feedback-loop", Name: "CLAUDE.md instruction file",
+		Patterns: []string{"CLAUDE.md", ".claude/CLAUDE.md"}},
+	{ID: "acmm:copilot-instructions", Source: "acmm", Level: 2, Category: "feedback-loop", Name: "Copilot instructions",
+		Patterns: []string{".github/copilot-instructions.md"}},
+	{ID: "acmm:agents-md", Source: "acmm", Level: 2, Category: "feedback-loop", Name: "AGENTS.md",
+		Patterns: []string{"AGENTS.md"}},
+	{ID: "acmm:cursor-rules", Source: "acmm", Level: 2, Category: "feedback-loop", Name: "Cursor rules",
+		Patterns: []string{".cursorrules", ".cursor/rules"}},
+	{ID: "acmm:prompts-catalog", Source: "acmm", Level: 2, Category: "feedback-loop", Name: "Prompts catalog",
+		Patterns: []string{"prompts/", ".prompts/", "docs/prompts/", ".github/prompts/", ".github/agents/"}},
+	{ID: "acmm:editor-config", Source: "acmm", Level: 2, Category: "feedback-loop", Name: "EditorConfig",
+		Patterns: []string{".editorconfig"}},
+	{ID: "acmm:simple-skills", Source: "acmm", Level: 2, Category: "feedback-loop", Name: "Simple skills",
+		Patterns: []string{".claude/skills/", ".claude/commands/", "skills/"}},
+	{ID: "acmm:correction-capture", Source: "acmm", Level: 2, Category: "learning", Name: "Correction capture",
+		Patterns: []string{".claude/memory/", ".memory/", "corrections.jsonl"}},
+
+	// ── L3 Measured (8) ──
+	{ID: "acmm:pr-acceptance-metric", Source: "acmm", Level: 3, Category: "feedback-loop", Name: "PR acceptance metric",
+		Patterns: []string{"scripts/build-accm-history.mjs", ".github/workflows/accm-history-update.yml", "scripts/pr-metrics.mjs", ".github/workflows/pr-metrics.yml", "docs/metrics.md"}},
+	{ID: "acmm:pr-review-rubric", Source: "acmm", Level: 3, Category: "feedback-loop", Name: "PR review rubric",
+		Patterns: []string{".github/workflows/review.yml", "docs/review-rubric.md", ".github/review-checklist.md", ".github/prompts/review.md", "docs/qa/"}},
+	{ID: "acmm:quality-dashboard", Source: "acmm", Level: 3, Category: "observability", Name: "Quality dashboard",
+		Patterns: []string{"public/analytics.js", "web/public/analytics.js", "web/src/components/analytics/", "docs/quality.md", ".github/workflows/quality-report.yml", "docs/AI-QUALITY-ASSURANCE.md"}},
+	{ID: "acmm:ci-matrix", Source: "acmm", Level: 3, Category: "feedback-loop", Name: "CI test matrix",
+		Patterns: []string{".github/workflows/ci.yml", ".github/workflows/test.yml", ".github/workflows/build.yml"}},
+	{ID: "acmm:layered-safety", Source: "acmm", Level: 3, Category: "governance", Name: "Layered safety model",
+		Patterns: []string{".claude/settings.json", ".claude/settings.local.json"}},
+	{ID: "acmm:mechanical-enforcement", Source: "acmm", Level: 3, Category: "governance", Name: "Mechanical enforcement",
+		Patterns: []string{".claude/settings.json"}},
+	{ID: "acmm:session-summary", Source: "acmm", Level: 3, Category: "learning", Name: "Session summary artifact",
+		Patterns: []string{".claude/session-summary.md", ".claude/checkpoint.md"}},
+	{ID: "acmm:structural-gates", Source: "acmm", Level: 3, Category: "traceability", Name: "Structural gates",
+		Patterns: []string{".claude/settings.json"}},
+
+	// ── L4 Adaptive (9) ──
+	{ID: "acmm:auto-qa-tuning", Source: "acmm", Level: 4, Category: "self-tuning", Name: "Auto-QA self-tuning",
+		Patterns: []string{".github/auto-qa-tuning.json", ".github/workflows/auto-qa.yml", "scripts/auto-qa-tuner.mjs"}},
+	{ID: "acmm:nightly-compliance", Source: "acmm", Level: 4, Category: "feedback-loop", Name: "Nightly compliance",
+		Patterns: []string{".github/workflows/nightly-compliance.yml", ".github/workflows/nightly.yml", ".github/workflows/nightly-test.yml", ".github/workflows/nightly-test-suite.yml"}},
+	{ID: "acmm:copilot-review-apply", Source: "acmm", Level: 4, Category: "feedback-loop", Name: "Automated review application",
+		Patterns: []string{".github/workflows/copilot-review-apply.yml", ".github/workflows/apply-copilot.yml", ".github/workflows/ai-fix.yml", ".github/workflows/auto-review.yml"}},
+	{ID: "acmm:auto-label", Source: "acmm", Level: 4, Category: "feedback-loop", Name: "Automated issue labeling",
+		Patterns: []string{".github/labeler.yml", ".github/workflows/labeler.yml", ".github/workflows/triage.yml"}},
+	{ID: "acmm:ai-fix-workflow", Source: "acmm", Level: 4, Category: "feedback-loop", Name: "AI-fix-requested workflow",
+		Patterns: []string{".github/workflows/ai-fix.yml", ".github/workflows/ai-fix-requested.yml", ".github/workflows/claude.yml"}},
+	{ID: "acmm:tier-classifier", Source: "acmm", Level: 4, Category: "governance", Name: "Change classification",
+		Patterns: []string{".github/workflows/tier-classifier.yml", "docs/risk-tiers.md", ".github/risk-tiers.yml", ".github/workflows/pr-size.yml"}},
+	{ID: "acmm:security-ai-md", Source: "acmm", Level: 4, Category: "governance", Name: "AI security policy",
+		Patterns: []string{"docs/security/SECURITY-AI.md", "SECURITY-AI.md", "docs/SECURITY-AI.md"}},
+	{ID: "acmm:session-continuity", Source: "acmm", Level: 4, Category: "learning", Name: "Session continuity",
+		Patterns: []string{".claude/checkpoint.md", ".claude/session-summary.md"}},
+	{ID: "acmm:cross-session-knowledge", Source: "acmm", Level: 4, Category: "learning", Name: "Cross-session knowledge",
+		Patterns: []string{"knowledge.jsonl", ".knowledge/", "docs/reflections/"}},
+
+	// ── L5 Automated (5) ──
+	{ID: "acmm:github-actions-ai", Source: "acmm", Level: 5, Category: "feedback-loop", Name: "GitHub Actions AI integration",
+		Patterns: []string{".github/workflows/claude.yml", ".github/workflows/claude-code-review.yml"}},
+	{ID: "acmm:auto-qa-self-tuning", Source: "acmm", Level: 5, Category: "self-tuning", Name: "Auto-QA with self-tuning",
+		Patterns: []string{".github/workflows/auto-qa.yml", ".github/auto-qa-tuning.json"}},
+	{ID: "acmm:public-metrics", Source: "acmm", Level: 5, Category: "observability", Name: "Public metrics",
+		Patterns: []string{"web/netlify/functions/analytics-accm.mts", "web/public/analytics.js", "docs/metrics/"}},
+	{ID: "acmm:policy-as-code", Source: "acmm", Level: 5, Category: "governance", Name: "Policy-as-code",
+		Patterns: []string{"policies/", ".github/policies/", "kyverno/", "conftest.yaml", "opa/"}},
+	{ID: "acmm:reflection-log", Source: "acmm", Level: 5, Category: "feedback-loop", Name: "Reflection log",
+		Patterns: []string{".claude/reflections/", "memory/", ".memory/", "docs/reflections/", "REFLECTIONS.md"}},
+
+	// ── L6 Autonomous (6 acmm) ──
+	{ID: "acmm:auto-issue-gen", Source: "acmm", Level: 6, Category: "autonomy", Name: "Auto issue generation",
+		Patterns: []string{".github/workflows/auto-issues.yml", ".github/workflows/auto-issue.yml", ".github/workflows/issue-gen.yml", ".github/workflows/auto-generate-issues.yml", "scripts/generate-issues.mjs"}},
+	{ID: "acmm:multi-agent-orchestration", Source: "acmm", Level: 6, Category: "autonomy", Name: "Multi-agent orchestration",
+		Patterns: []string{".github/workflows/dispatcher.yml", ".github/workflows/orchestrate.yml", "scripts/orchestrate.mjs", "docs/multi-agent.md", ".claude/dispatcher/", "orchestrator/"}},
+	{ID: "acmm:strategic-dashboard", Source: "acmm", Level: 6, Category: "observability", Name: "Strategic dashboard",
+		Patterns: []string{"web/src/components/acmm/", "docs/strategy.md", ".github/workflows/strategy-report.yml", "docs/autonomous-work-log.md"}},
+	{ID: "acmm:merge-queue", Source: "acmm", Level: 6, Category: "autonomy", Name: "Merge queue",
+		Patterns: []string{".github/workflows/merge-queue.yml", ".github/merge-queue.yml", ".prow.yaml", "tide.yaml"}},
+	{ID: "acmm:risk-assessment-config", Source: "acmm", Level: 6, Category: "governance", Name: "Risk assessment config",
+		Patterns: []string{"risk-config.json", ".claude/risk-config.json", ".github/risk-assessment.yml"}},
+	{ID: "acmm:observability-runbook", Source: "acmm", Level: 6, Category: "governance", Name: "Observability runbook",
+		Patterns: []string{"docs/ai-ops-runbook.md", "docs/runbook/", "RUNBOOK.md"}},
+
+	// ── L6 Agentic Engineering Framework (6 aef) ──
+	{ID: "aef:task-traceability", Source: "aef", Level: 6, Category: "governance", Name: "Task traceability",
+		Patterns: []string{".agent/tasks/", "docs/agent-tasks/", ".github/agent-log/", "agent-tasks.md"}},
+	{ID: "aef:structural-gates", Source: "aef", Level: 6, Category: "governance", Name: "Structural gates",
+		Patterns: []string{"CODEOWNERS", ".github/CODEOWNERS", ".agent/boundaries.yml", "docs/agent-boundaries.md"}},
+	{ID: "aef:session-continuity", Source: "aef", Level: 6, Category: "governance", Name: "Session continuity",
+		Patterns: []string{"CLAUDE.md", "AGENTS.md", ".cursorrules", ".github/copilot-instructions.md", "docs/agent-context.md"}},
+	{ID: "aef:audit-trail", Source: "aef", Level: 6, Category: "governance", Name: "Audit trail workflow",
+		Patterns: []string{".github/workflows/ai-audit.yml", ".github/workflows/agent-audit.yml", "scripts/ai-audit-report.mjs"}},
+	{ID: "aef:cross-tool-config", Source: "aef", Level: 6, Category: "governance", Name: "Cross-tool agent config",
+		Patterns: []string{"AGENTS.md", "docs/ai-contributors.md", ".github/ai-config.yml"}},
+	{ID: "aef:change-classification", Source: "aef", Level: 6, Category: "governance", Name: "Change classification",
+		Patterns: []string{"docs/change-classification.md", ".github/change-tiers.yml", "docs/risk-tiers.md"}},
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -105,6 +105,8 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("POST /api/packs/{level}/apply", s.handlePackApply)
 	s.mux.HandleFunc("PUT /api/packs/level", s.handlePackSetLevel)
 
+	s.mux.HandleFunc("GET /api/acmm/evaluation", s.handleACMMEvaluation)
+
 	s.mux.HandleFunc("GET /api/config/sidebar", s.handleSidebarGet)
 	s.mux.HandleFunc("PUT /api/config/sidebar", s.handleSidebarSet)
 	s.mux.HandleFunc("GET /api/config/backends", s.handleBackends)

--- a/v2/pkg/dashboard/api_acmm_eval.go
+++ b/v2/pkg/dashboard/api_acmm_eval.go
@@ -1,0 +1,308 @@
+package dashboard
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+const acmmEvalTTL = time.Hour
+const acmmLevelThreshold = 0.70
+const acmmEvalTimeout = 30 * time.Second
+
+// ACMMEvaluation is the combined codebase + operational ACMM evaluation result.
+type ACMMEvaluation struct {
+	CodebaseLevel     int               `json:"codebase_level"`
+	CodebaseLevelName string            `json:"codebase_level_name"`
+	OperationalLevel  int               `json:"operational_level"`
+	OperationalName   string            `json:"operational_name"`
+	OverallLevel      int               `json:"overall_level"`
+	CriteriaTotal     int               `json:"criteria_total"`
+	CriteriaPassed    int               `json:"criteria_passed"`
+	LastEvaluatedAt   string            `json:"last_evaluated_at"`
+	Levels            []ACMMLevelScore  `json:"levels"`
+	CriteriaResults   []CriterionResult `json:"criteria_results,omitempty"`
+	Error             string            `json:"error,omitempty"`
+}
+
+// ACMMLevelScore summarizes pass/fail for a single ACMM level.
+type ACMMLevelScore struct {
+	Level     int     `json:"level"`
+	Name      string  `json:"name"`
+	Score     float64 `json:"score"`
+	Threshold float64 `json:"threshold"`
+	Passed    bool    `json:"passed"`
+	Total     int     `json:"total"`
+	Matched   int     `json:"matched"`
+}
+
+// CriterionResult records whether an individual criterion was detected.
+type CriterionResult struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Level  int    `json:"level"`
+	Passed bool   `json:"passed"`
+}
+
+func (s *Server) handleACMMEvaluation(w http.ResponseWriter, r *http.Request) {
+	opsLevel := s.detectCurrentLevel()
+	opsName := acmmLevelNames[opsLevel]
+	if opsName == "" {
+		opsName = "Unknown"
+	}
+
+	// Try returning cached codebase results with fresh operational level.
+	s.acmmEvalMu.RLock()
+	cached := s.acmmEvalCache
+	cacheAge := time.Since(s.acmmEvalCachedAt)
+	s.acmmEvalMu.RUnlock()
+
+	if cached != nil && cacheAge < acmmEvalTTL {
+		result := *cached
+		result.OperationalLevel = opsLevel
+		result.OperationalName = opsName
+		result.OverallLevel = minInt(result.CodebaseLevel, opsLevel)
+		jsonResponse(w, result)
+		return
+	}
+
+	// Stale or missing — run fresh evaluation.
+	s.acmmEvalMu.Lock()
+	defer s.acmmEvalMu.Unlock()
+
+	// Double-check after acquiring write lock.
+	if s.acmmEvalCache != nil && time.Since(s.acmmEvalCachedAt) < acmmEvalTTL {
+		result := *s.acmmEvalCache
+		result.OperationalLevel = opsLevel
+		result.OperationalName = opsName
+		result.OverallLevel = minInt(result.CodebaseLevel, opsLevel)
+		jsonResponse(w, result)
+		return
+	}
+
+	eval := s.evaluateCodebase()
+	eval.OperationalLevel = opsLevel
+	eval.OperationalName = opsName
+	eval.OverallLevel = minInt(eval.CodebaseLevel, opsLevel)
+
+	s.acmmEvalCache = &eval
+	s.acmmEvalCachedAt = time.Now()
+
+	jsonResponse(w, eval)
+}
+
+// evaluateCodebase scans the configured primary repo for ACMM criteria.
+func (s *Server) evaluateCodebase() ACMMEvaluation {
+	if s.deps == nil || s.deps.Config == nil {
+		return ACMMEvaluation{
+			Error:           "config not loaded",
+			LastEvaluatedAt: time.Now().UTC().Format(time.RFC3339),
+		}
+	}
+
+	owner := s.deps.Config.Project.Org
+	repo := s.deps.Config.Project.PrimaryRepo
+	if owner == "" || repo == "" {
+		return ACMMEvaluation{
+			Error:           "primary repo not configured",
+			LastEvaluatedAt: time.Now().UTC().Format(time.RFC3339),
+		}
+	}
+
+	if s.deps.GHClient == nil {
+		return ACMMEvaluation{
+			Error:           "GitHub client not available",
+			LastEvaluatedAt: time.Now().UTC().Format(time.RFC3339),
+		}
+	}
+
+	ghClient := s.deps.GHClient.GoGitHub()
+	if ghClient == nil {
+		return ACMMEvaluation{
+			Error:           "GitHub client not initialized",
+			LastEvaluatedAt: time.Now().UTC().Format(time.RFC3339),
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), acmmEvalTimeout)
+	defer cancel()
+
+	// Pre-fetch directory listings for commonly checked parent directories
+	// to batch API calls instead of checking each file individually.
+	dirCache := s.prefetchDirectories(ctx, owner, repo)
+
+	var results []CriterionResult
+	for _, c := range universalCriteria {
+		passed := s.checkCriterion(ctx, owner, repo, c, dirCache)
+		results = append(results, CriterionResult{
+			ID:     c.ID,
+			Name:   c.Name,
+			Level:  c.Level,
+			Passed: passed,
+		})
+	}
+
+	return s.scoreResults(results)
+}
+
+// prefetchDirectories fetches directory listings for parent dirs that
+// many criteria share, reducing individual API calls.
+func (s *Server) prefetchDirectories(ctx context.Context, owner, repo string) map[string]map[string]bool {
+	cache := make(map[string]map[string]bool)
+
+	dirs := []string{
+		"",                   // root
+		".github",            // templates, configs
+		".github/workflows",  // CI workflows
+		".github/ISSUE_TEMPLATE",
+		".github/prompts",
+		".github/agents",
+		".claude",
+		"docs",
+		"docs/security",
+	}
+
+	ghClient := s.deps.GHClient.GoGitHub()
+	for _, dir := range dirs {
+		_, dirContents, _, err := ghClient.Repositories.GetContents(ctx, owner, repo, dir, nil)
+		if err != nil {
+			continue
+		}
+		entries := make(map[string]bool)
+		for _, entry := range dirContents {
+			name := entry.GetName()
+			entryType := entry.GetType()
+			entries[name] = true
+			if entryType == "dir" {
+				entries[name+"/"] = true
+			}
+		}
+		cache[dir] = entries
+	}
+
+	return cache
+}
+
+// checkCriterion returns true if any of the criterion's patterns exist in the repo.
+func (s *Server) checkCriterion(ctx context.Context, owner, repo string, c ACMMCriterion, dirCache map[string]map[string]bool) bool {
+	for _, pattern := range c.Patterns {
+		if s.patternExists(ctx, owner, repo, pattern, dirCache) {
+			return true
+		}
+	}
+	return false
+}
+
+// patternExists checks if a file or directory path exists, using the
+// pre-fetched directory cache when possible.
+func (s *Server) patternExists(ctx context.Context, owner, repo, path string, dirCache map[string]map[string]bool) bool {
+	isDir := strings.HasSuffix(path, "/")
+	cleanPath := strings.TrimSuffix(path, "/")
+
+	// Split into parent dir + base name for cache lookup.
+	parent := ""
+	base := cleanPath
+	if idx := strings.LastIndex(cleanPath, "/"); idx >= 0 {
+		parent = cleanPath[:idx]
+		base = cleanPath[idx+1:]
+	}
+
+	if entries, ok := dirCache[parent]; ok {
+		if isDir {
+			return entries[base+"/"] || entries[base]
+		}
+		return entries[base]
+	}
+
+	// Cache miss — fall back to direct API check.
+	ghClient := s.deps.GHClient.GoGitHub()
+	_, _, _, err := ghClient.Repositories.GetContents(ctx, owner, repo, cleanPath, nil)
+	return err == nil
+}
+
+// scoreResults calculates per-level scores and the overall codebase level.
+func (s *Server) scoreResults(results []CriterionResult) ACMMEvaluation {
+	// Group by level.
+	type levelBucket struct {
+		total   int
+		matched int
+	}
+	buckets := make(map[int]*levelBucket)
+
+	totalPassed := 0
+	for _, r := range results {
+		b, ok := buckets[r.Level]
+		if !ok {
+			b = &levelBucket{}
+			buckets[r.Level] = b
+		}
+		b.total++
+		if r.Passed {
+			b.matched++
+			totalPassed++
+		}
+	}
+
+	// Collect and sort level numbers.
+	levels := make([]int, 0, len(buckets))
+	for lvl := range buckets {
+		levels = append(levels, lvl)
+	}
+	sort.Ints(levels)
+
+	var levelScores []ACMMLevelScore
+	for _, lvl := range levels {
+		b := buckets[lvl]
+		score := float64(0)
+		if b.total > 0 {
+			score = float64(b.matched) / float64(b.total)
+		}
+		name := acmmLevelNames[lvl]
+		if name == "" {
+			name = "Unknown"
+		}
+		levelScores = append(levelScores, ACMMLevelScore{
+			Level:     lvl,
+			Name:      name,
+			Score:     score,
+			Threshold: acmmLevelThreshold,
+			Passed:    score >= acmmLevelThreshold,
+			Total:     b.total,
+			Matched:   b.matched,
+		})
+	}
+
+	// Determine highest passing codebase level: all preceding levels must also pass.
+	codebaseLevel := 0
+	for _, ls := range levelScores {
+		if ls.Passed {
+			codebaseLevel = ls.Level
+		} else {
+			break
+		}
+	}
+
+	codeLevelName := acmmLevelNames[codebaseLevel]
+	if codeLevelName == "" {
+		codeLevelName = "None"
+	}
+
+	return ACMMEvaluation{
+		CodebaseLevel:     codebaseLevel,
+		CodebaseLevelName: codeLevelName,
+		CriteriaTotal:     len(results),
+		CriteriaPassed:    totalPassed,
+		LastEvaluatedAt:   time.Now().UTC().Format(time.RFC3339),
+		Levels:            levelScores,
+		CriteriaResults:   results,
+	}
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -49,6 +49,10 @@ type Server struct {
 	levelMu        sync.Mutex
 	restartMu      sync.Mutex // serializes concurrent agent restart operations
 
+	acmmEvalMu       sync.RWMutex
+	acmmEvalCache    *ACMMEvaluation
+	acmmEvalCachedAt time.Time
+
 	tokenHistoryMu    sync.RWMutex
 	tokenHistory      []TokenSparklineEntry
 	lastFullBroadcast time.Time

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -443,6 +443,7 @@
     body.oc-agent-focused #knowledge-section,
     body.oc-agent-focused #contributors-section,
     body.oc-agent-focused #audit-section,
+    body.oc-agent-focused #acmm-eval-section,
     body.oc-agent-focused #leaderboard-section { display: none; }
     body.oc-strategy-focused #nous-section { display: block; }
     body.oc-agent-focused .agent-card.oc-hidden { display: none; }
@@ -1841,6 +1842,7 @@
       <div class="oc-nav-label">Control</div>
       <a class="oc-nav-item active" data-section="governor" onclick="ocNavigate('governor')"><span class="oc-nav-emoji">📊</span><span class="oc-nav-text">Governor</span></a>
       <a class="oc-nav-item" data-section="advisory-section" onclick="ocNavigate('advisory-section')"><span class="oc-nav-emoji">📋</span><span class="oc-nav-text">Advisory</span></a>
+      <a class="oc-nav-item" data-section="acmm-eval-section" onclick="ocNavigate('acmm-eval-section')"><span class="oc-nav-emoji">🎯</span><span class="oc-nav-text">ACMM Eval</span></a>
       <a class="oc-nav-item" data-section="token-panel" onclick="ocNavigate('token-panel')"><span class="oc-nav-emoji">🪙</span><span class="oc-nav-text">Tokens</span></a>
     </div>
     <div class="oc-nav-group">
@@ -1972,6 +1974,26 @@
     <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 8px;" class="section-header-toggle" onclick="toggleSection('beads-section')"><span class="section-chevron">▼</span> Beads</h2>
     <div class="section-body">
       <div class="beads" id="beads"></div>
+    </div>
+  </div>
+
+  <div id="acmm-eval-section" style="margin-top: 16px; margin-bottom: 24px;">
+    <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 8px;" class="section-header-toggle" onclick="toggleSection('acmm-eval-section')"><span class="section-chevron">▼</span> 🎯 ACMM Evaluation</h2>
+    <div class="section-body">
+      <div id="acmm-eval-card" style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:16px">
+        <div class="kb-stat-grid" id="acmm-eval-stats">
+          <div class="kb-stat"><div class="val" id="acmm-codebase-level">--</div><div class="lbl">Codebase Readiness</div></div>
+          <div class="kb-stat"><div class="val" id="acmm-ops-level">--</div><div class="lbl">Operational Autonomy</div></div>
+          <div class="kb-stat"><div class="val" id="acmm-overall-level">--</div><div class="lbl">Overall ACMM</div></div>
+          <div class="kb-stat"><div class="val" id="acmm-criteria-ratio">--</div><div class="lbl">Criteria Passed</div></div>
+        </div>
+        <div id="acmm-level-bars" style="margin-top:12px"></div>
+        <div id="acmm-eval-meta" style="margin-top:10px;font-size:0.7rem;color:var(--muted);display:flex;justify-content:space-between">
+          <span id="acmm-eval-source"></span>
+          <span id="acmm-eval-timestamp"></span>
+        </div>
+        <div id="acmm-eval-warning" style="display:none;margin-top:8px;padding:6px 10px;border-radius:6px;background:#fef3c7;color:#92400e;font-size:0.75rem"></div>
+      </div>
     </div>
   </div>
 
@@ -7755,8 +7777,8 @@ function burnAreaChart() {
       renderDebugSection();
       // Restore persisted collapsed state for all collapsible sections
       const COLLAPSIBLE_SECTION_IDS = [
-        'advisory-section', 'repos-section', 'beads-section', 'audit-section',
-        'nous-section', 'inception-section', 'knowledge-section',
+        'advisory-section', 'repos-section', 'beads-section', 'acmm-eval-section',
+        'audit-section', 'nous-section', 'inception-section', 'knowledge-section',
         'contributors-section', 'debug-section', 'logs-section', 'agents-section'
       ];
       COLLAPSIBLE_SECTION_IDS.forEach(applySectionCollapse);
@@ -9002,6 +9024,59 @@ function burnAreaChart() {
         if (dimension === 'cli') { a.pinnedCli = v; if (!v && a.pinnedBoth) { a.pinnedBoth = false; a.pinnedModel = true; } }
         else if (dimension === 'model') { a.pinnedModel = v; if (!v && a.pinnedBoth) { a.pinnedBoth = false; a.pinnedCli = true; } }
         else { a.pinnedBoth = v; a.pinnedCli = v; a.pinnedModel = v; }
+      }
+    }
+
+    // ACMM Evaluation
+    const ACMM_EVAL_INTERVAL_MS = 3600000; // 1 hour
+    const ACMM_LEVEL_NAMES = {0:'Prerequisites',2:'Instructed',3:'Measured',4:'Adaptive',5:'Automated',6:'Autonomous'};
+    async function fetchACMMEvaluation() {
+      try {
+        const r = await fetch('/api/acmm/evaluation');
+        if (!r.ok) return;
+        const d = await r.json();
+
+        const fmtLevel = (lvl) => {
+          const name = ACMM_LEVEL_NAMES[lvl] || ('L'+lvl);
+          return '<span style="font-size:1.2rem;font-weight:700">L' + lvl + '</span><br><span style="font-size:0.7rem;color:var(--muted)">' + escapeHtml(name) + '</span>';
+        };
+
+        setIfChanged(document.getElementById('acmm-codebase-level'), fmtLevel(d.codebase_level));
+        setIfChanged(document.getElementById('acmm-ops-level'), fmtLevel(d.operational_level));
+        setIfChanged(document.getElementById('acmm-overall-level'), fmtLevel(d.overall_level));
+        setIfChanged(document.getElementById('acmm-criteria-ratio'),
+          '<span style="font-size:1.2rem;font-weight:700">' + d.criteria_passed + '/' + d.criteria_total + '</span>');
+
+        // Per-level bars
+        const barsEl = document.getElementById('acmm-level-bars');
+        if (barsEl && d.levels) {
+          let html = '';
+          for (const lvl of d.levels) {
+            const pct = Math.round(lvl.score * 100);
+            const color = lvl.passed ? '#238636' : (pct > 40 ? '#d29922' : '#da3633');
+            html += '<div style="display:flex;align-items:center;gap:8px;margin-bottom:4px;font-size:0.75rem">' +
+              '<span style="width:100px;color:var(--muted)">' + escapeHtml(lvl.name) + '</span>' +
+              '<div style="flex:1;height:8px;background:var(--bg);border-radius:4px;overflow:hidden">' +
+              '<div style="width:' + pct + '%;height:100%;background:' + color + ';border-radius:4px;transition:width .3s"></div></div>' +
+              '<span style="width:60px;text-align:right;color:var(--muted)">' + lvl.matched + '/' + lvl.total + '</span></div>';
+          }
+          barsEl.innerHTML = html;
+        }
+
+        const tsEl = document.getElementById('acmm-eval-timestamp');
+        if (tsEl) tsEl.textContent = d.last_evaluated_at ? 'Evaluated: ' + new Date(d.last_evaluated_at).toLocaleString() : '';
+
+        const warnEl = document.getElementById('acmm-eval-warning');
+        if (warnEl) {
+          if (d.error) {
+            warnEl.style.display = 'block';
+            warnEl.textContent = '⚠ ' + d.error;
+          } else {
+            warnEl.style.display = 'none';
+          }
+        }
+      } catch (e) {
+        console.error('acmm eval fetch failed', e);
       }
     }
 
@@ -11644,6 +11719,7 @@ function burnAreaChart() {
           () => fetchContributors().then(() => { setInterval(fetchContributors, CONTRIBUTOR_POLL_MS); }),
           () => fetchLeaderboard().then(() => { setInterval(fetchLeaderboard, LEADERBOARD_POLL_MS); }),
           () => fetchGitVersion().then(() => { setInterval(fetchGitVersion, GIT_VERSION_POLL_MS); }),
+          () => fetchACMMEvaluation().then(() => { setInterval(fetchACMMEvaluation, ACMM_EVAL_INTERVAL_MS); }),
           () => Promise.resolve(startVersionCheck()),
           () => fetch('/api/trends?range=week').then(r => r.json()).then(applyTrends).catch(() => {}).then(() => { setInterval(() => { fetch('/api/trends?range=week').then(r => r.json()).then(applyTrends).catch(() => {}); }, TREND_REFRESH_MS); }),
           () => fetchTimeline().then(() => { setInterval(fetchTimeline, TIMELINE_REFRESH_MS); }),


### PR DESCRIPTION
## Summary

- Ports 43 universal ACMM criteria (acmm:* and aef:* sources) from the console scan API for local evaluation against the configured primary repo
- CNCF-specific criteria (fullsend:*, claude-reflect:*) excluded so hive spokes targeting private/internal repos get meaningful results
- Two-dimensional scoring: **codebase readiness** (file-existence detection via GitHub API with directory prefetching) + **operational autonomy** (from pack config)
- Overall level = min(codebase, operational), 70% threshold per level, levels must pass sequentially
- Results cached for 1 hour with RLock/Lock double-check pattern
- Dashboard card: codebase level, operational level, overall ACMM, criteria passed ratio, per-level progress bars with color coding

## New files

- `pkg/dashboard/acmm_criteria.go` — 43 universal criteria definitions organized by level (L0–L6)
- `pkg/dashboard/api_acmm_eval.go` — `GET /api/acmm/evaluation` handler with caching, GitHub API scanning via directory prefetching, and sequential level scoring

## Modified files

- `pkg/dashboard/server.go` — Cache fields for evaluation results
- `pkg/dashboard/api.go` — Route registration
- `pkg/dashboard/static/index.html` — Nav item, card HTML, CSS, fetch function with hourly polling

## Test plan

- [ ] Build passes: `go build ./...`
- [ ] `GET /api/acmm/evaluation` returns correct JSON with codebase_level, operational_level, overall_level, and per-level scores
- [ ] Dashboard card renders with 4 stat boxes and per-level progress bars
- [ ] Card hides when agent-focused view is active
- [ ] Section collapse/expand persists via localStorage
- [ ] Error states (no repo configured, no GitHub client) show warning message