### PR TITLE
feat: interactive drill-down dialogs for ACMM Evaluation card

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -106,6 +106,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("PUT /api/packs/level", s.handlePackSetLevel)
 
 	s.mux.HandleFunc("GET /api/acmm/evaluation", s.handleACMMEvaluation)
+	s.mux.HandleFunc("POST /api/acmm/issue", s.handleACMMCreateIssue)
 
 	s.mux.HandleFunc("GET /api/config/sidebar", s.handleSidebarGet)
 	s.mux.HandleFunc("PUT /api/config/sidebar", s.handleSidebarSet)

--- a/v2/pkg/dashboard/api_acmm_eval.go
+++ b/v2/pkg/dashboard/api_acmm_eval.go
@@ -40,10 +40,12 @@ type ACMMLevelScore struct {
 
 // CriterionResult records whether an individual criterion was detected.
 type CriterionResult struct {
-	ID     string `json:"id"`
-	Name   string `json:"name"`
-	Level  int    `json:"level"`
-	Passed bool   `json:"passed"`
+	ID       string   `json:"id"`
+	Name     string   `json:"name"`
+	Level    int      `json:"level"`
+	Category string   `json:"category"`
+	Patterns []string `json:"patterns"`
+	Passed   bool     `json:"passed"`
 }
 
 func (s *Server) handleACMMEvaluation(w http.ResponseWriter, r *http.Request) {
@@ -137,10 +139,12 @@ func (s *Server) evaluateCodebase() ACMMEvaluation {
 	for _, c := range universalCriteria {
 		passed := s.checkCriterion(ctx, owner, repo, c, dirCache)
 		results = append(results, CriterionResult{
-			ID:     c.ID,
-			Name:   c.Name,
-			Level:  c.Level,
-			Passed: passed,
+			ID:       c.ID,
+			Name:     c.Name,
+			Level:    c.Level,
+			Category: c.Category,
+			Patterns: c.Patterns,
+			Passed:   passed,
 		})
 	}
 

--- a/v2/pkg/dashboard/api_acmm_eval.go
+++ b/v2/pkg/dashboard/api_acmm_eval.go
@@ -2,15 +2,23 @@ package dashboard
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"sort"
 	"strings"
 	"time"
+
+	gh "github.com/google/go-github/v72/github"
 )
 
 const acmmEvalTTL = time.Hour
 const acmmLevelThreshold = 0.70
 const acmmEvalTimeout = 30 * time.Second
+const acmmPerRepoTimeout = 20 * time.Second
+const acmmIssueLabelName = "acmm"
+const acmmIssueLabelColor = "0075ca"
+const acmmIssueLabelDesc = "ACMM criterion gap identified by hive evaluation"
 
 // ACMMEvaluation is the combined codebase + operational ACMM evaluation result.
 type ACMMEvaluation struct {
@@ -24,7 +32,19 @@ type ACMMEvaluation struct {
 	LastEvaluatedAt   string            `json:"last_evaluated_at"`
 	Levels            []ACMMLevelScore  `json:"levels"`
 	CriteriaResults   []CriterionResult `json:"criteria_results,omitempty"`
+	RepoResults       []RepoEvaluation  `json:"repo_results,omitempty"`
 	Error             string            `json:"error,omitempty"`
+}
+
+// RepoEvaluation holds ACMM results for a single repository.
+type RepoEvaluation struct {
+	Repo            string            `json:"repo"`
+	CodebaseLevel   int               `json:"codebase_level"`
+	LevelName       string            `json:"level_name"`
+	CriteriaTotal   int               `json:"criteria_total"`
+	CriteriaPassed  int               `json:"criteria_passed"`
+	Levels          []ACMMLevelScore  `json:"levels"`
+	CriteriaResults []CriterionResult `json:"criteria_results"`
 }
 
 // ACMMLevelScore summarizes pass/fail for a single ACMM level.
@@ -46,6 +66,14 @@ type CriterionResult struct {
 	Category string   `json:"category"`
 	Patterns []string `json:"patterns"`
 	Passed   bool     `json:"passed"`
+	Repo     string   `json:"repo,omitempty"`
+}
+
+// ACMMIssueRequest is the payload for creating an ACMM gap issue.
+type ACMMIssueRequest struct {
+	Repo         string `json:"repo"`
+	CriterionID  string `json:"criterion_id"`
+	CriterionLvl int    `json:"criterion_level"`
 }
 
 func (s *Server) handleACMMEvaluation(w http.ResponseWriter, r *http.Request) {
@@ -55,7 +83,6 @@ func (s *Server) handleACMMEvaluation(w http.ResponseWriter, r *http.Request) {
 		opsName = "Unknown"
 	}
 
-	// Try returning cached codebase results with fresh operational level.
 	s.acmmEvalMu.RLock()
 	cached := s.acmmEvalCache
 	cacheAge := time.Since(s.acmmEvalCachedAt)
@@ -70,11 +97,9 @@ func (s *Server) handleACMMEvaluation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Stale or missing — run fresh evaluation.
 	s.acmmEvalMu.Lock()
 	defer s.acmmEvalMu.Unlock()
 
-	// Double-check after acquiring write lock.
 	if s.acmmEvalCache != nil && time.Since(s.acmmEvalCachedAt) < acmmEvalTTL {
 		result := *s.acmmEvalCache
 		result.OperationalLevel = opsLevel
@@ -84,7 +109,7 @@ func (s *Server) handleACMMEvaluation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	eval := s.evaluateCodebase()
+	eval := s.evaluateAllRepos()
 	eval.OperationalLevel = opsLevel
 	eval.OperationalName = opsName
 	eval.OverallLevel = minInt(eval.CodebaseLevel, opsLevel)
@@ -95,8 +120,143 @@ func (s *Server) handleACMMEvaluation(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, eval)
 }
 
-// evaluateCodebase scans the configured primary repo for ACMM criteria.
-func (s *Server) evaluateCodebase() ACMMEvaluation {
+// handleACMMCreateIssue creates a GitHub issue for a failed ACMM criterion.
+func (s *Server) handleACMMCreateIssue(w http.ResponseWriter, r *http.Request) {
+	var req ACMMIssueRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.Repo == "" || req.CriterionID == "" {
+		http.Error(w, "repo and criterion_id are required", http.StatusBadRequest)
+		return
+	}
+
+	var criterion *ACMMCriterion
+	for i := range universalCriteria {
+		if universalCriteria[i].ID == req.CriterionID {
+			criterion = &universalCriteria[i]
+			break
+		}
+	}
+	if criterion == nil {
+		http.Error(w, "unknown criterion", http.StatusBadRequest)
+		return
+	}
+
+	if s.deps == nil || s.deps.Config == nil {
+		http.Error(w, "config not loaded", http.StatusInternalServerError)
+		return
+	}
+	owner := s.deps.Config.Project.Org
+	if owner == "" {
+		http.Error(w, "org not configured", http.StatusInternalServerError)
+		return
+	}
+
+	if s.deps.GHClient == nil {
+		http.Error(w, "GitHub client not available", http.StatusInternalServerError)
+		return
+	}
+	ghClient := s.deps.GHClient.GoGitHub()
+	if ghClient == nil {
+		http.Error(w, "GitHub client not initialized", http.StatusInternalServerError)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), acmmEvalTimeout)
+	defer cancel()
+
+	_, _, labelErr := ghClient.Issues.CreateLabel(ctx, owner, req.Repo, &gh.Label{
+		Name:        gh.Ptr(acmmIssueLabelName),
+		Description: gh.Ptr(acmmIssueLabelDesc),
+		Color:       gh.Ptr(acmmIssueLabelColor),
+	})
+	labelExists := labelErr == nil || strings.Contains(labelErr.Error(), "already_exists")
+
+	levelName := acmmLevelNames[criterion.Level]
+	if levelName == "" {
+		levelName = "Unknown"
+	}
+
+	title := fmt.Sprintf("[ACMM L%d] Add %s", criterion.Level, criterion.Name)
+
+	var patternsStr strings.Builder
+	for _, p := range criterion.Patterns {
+		patternsStr.WriteString(fmt.Sprintf("- `%s`\n", p))
+	}
+
+	body := fmt.Sprintf("## ACMM Gap: %s\n\n"+
+		"**Level:** L%d %s\n"+
+		"**Category:** %s\n"+
+		"**Criterion ID:** `%s`\n\n"+
+		"### What's needed\n\n"+
+		"This repository is missing one of the following files or directories:\n\n"+
+		"%s\n"+
+		"Adding any one of these will satisfy this criterion and help the repository "+
+		"advance to ACMM Level %d (%s).\n\n"+
+		"### Why it matters\n\n"+
+		"%s\n\n"+
+		"### How to fix\n\n"+
+		"Create one of the files listed above. The ACMM evaluation checks for file existence — "+
+		"the content can follow your project's conventions.\n\n"+
+		"---\n"+
+		"*Opened by Hive ACMM Evaluation*",
+		criterion.Name,
+		criterion.Level, levelName,
+		criterion.Category,
+		criterion.ID,
+		patternsStr.String(),
+		criterion.Level, levelName,
+		acmmCriterionWhyItMatters(criterion.Level, criterion.Category),
+	)
+
+	issueReq := &gh.IssueRequest{
+		Title: gh.Ptr(title),
+		Body:  gh.Ptr(body),
+	}
+	if labelExists {
+		issueReq.Labels = &[]string{acmmIssueLabelName, "ai-fix-requested"}
+	}
+
+	issue, _, err := ghClient.Issues.Create(ctx, owner, req.Repo, issueReq)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("failed to create issue: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	jsonResponse(w, map[string]interface{}{
+		"issue_number": issue.GetNumber(),
+		"issue_url":    issue.GetHTMLURL(),
+	})
+}
+
+func acmmCriterionWhyItMatters(level int, category string) string {
+	switch category {
+	case "prerequisite":
+		return "Prerequisites are foundational — without test suites, CI/CD, and templates, AI agents lack the guardrails needed for safe autonomous work."
+	case "feedback-loop":
+		return "Feedback loops let agents learn from outcomes. Metrics, review rubrics, and automated review application create the signal that drives improvement."
+	case "learning":
+		return "Learning artifacts (memory, corrections, session summaries) let agents carry context across sessions instead of starting cold each time."
+	case "governance":
+		return "Governance ensures agents operate within boundaries — safety models, structural gates, and risk assessment prevent autonomous drift."
+	case "observability":
+		return "Observability makes agent behavior visible — dashboards, metrics, and quality reports let humans audit what agents are doing."
+	case "self-tuning":
+		return "Self-tuning means the system adjusts its own quality thresholds based on observed outcomes, reducing the need for manual calibration."
+	case "autonomy":
+		return "Autonomy criteria enable agents to operate independently — generating issues, orchestrating multi-agent workflows, and managing merge queues."
+	case "traceability":
+		return "Traceability links agent actions to outcomes, making it possible to audit decisions and understand why changes were made."
+	default:
+		return fmt.Sprintf("This criterion is part of ACMM Level %d, which requires a minimum set of capabilities before advancing to the next level.", level)
+	}
+}
+
+// evaluateAllRepos scans all configured repos and produces aggregate + per-repo results.
+func (s *Server) evaluateAllRepos() ACMMEvaluation {
 	if s.deps == nil || s.deps.Config == nil {
 		return ACMMEvaluation{
 			Error:           "config not loaded",
@@ -105,10 +265,20 @@ func (s *Server) evaluateCodebase() ACMMEvaluation {
 	}
 
 	owner := s.deps.Config.Project.Org
-	repo := s.deps.Config.Project.PrimaryRepo
-	if owner == "" || repo == "" {
+	if owner == "" {
 		return ACMMEvaluation{
-			Error:           "primary repo not configured",
+			Error:           "org not configured",
+			LastEvaluatedAt: time.Now().UTC().Format(time.RFC3339),
+		}
+	}
+
+	repos := s.deps.Config.Project.Repos
+	if len(repos) == 0 && s.deps.Config.Project.PrimaryRepo != "" {
+		repos = []string{s.deps.Config.Project.PrimaryRepo}
+	}
+	if len(repos) == 0 {
+		return ACMMEvaluation{
+			Error:           "no repos configured",
 			LastEvaluatedAt: time.Now().UTC().Format(time.RFC3339),
 		}
 	}
@@ -119,7 +289,6 @@ func (s *Server) evaluateCodebase() ACMMEvaluation {
 			LastEvaluatedAt: time.Now().UTC().Format(time.RFC3339),
 		}
 	}
-
 	ghClient := s.deps.GHClient.GoGitHub()
 	if ghClient == nil {
 		return ACMMEvaluation{
@@ -128,27 +297,60 @@ func (s *Server) evaluateCodebase() ACMMEvaluation {
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), acmmEvalTimeout)
-	defer cancel()
+	var repoEvals []RepoEvaluation
+	// Aggregate: a criterion passes if it passes in ANY repo.
+	aggPassed := make(map[string]bool)
 
-	// Pre-fetch directory listings for commonly checked parent directories
-	// to batch API calls instead of checking each file individually.
-	dirCache := s.prefetchDirectories(ctx, owner, repo)
+	for _, repo := range repos {
+		ctx, cancel := context.WithTimeout(context.Background(), acmmPerRepoTimeout)
+		dirCache := s.prefetchDirectories(ctx, owner, repo)
 
-	var results []CriterionResult
+		var results []CriterionResult
+		for _, c := range universalCriteria {
+			passed := s.checkCriterion(ctx, owner, repo, c, dirCache)
+			results = append(results, CriterionResult{
+				ID:       c.ID,
+				Name:     c.Name,
+				Level:    c.Level,
+				Category: c.Category,
+				Patterns: c.Patterns,
+				Passed:   passed,
+				Repo:     repo,
+			})
+			if passed {
+				aggPassed[c.ID] = true
+			}
+		}
+		cancel()
+
+		scored := s.scoreResults(results)
+		repoEvals = append(repoEvals, RepoEvaluation{
+			Repo:            repo,
+			CodebaseLevel:   scored.CodebaseLevel,
+			LevelName:       scored.CodebaseLevelName,
+			CriteriaTotal:   scored.CriteriaTotal,
+			CriteriaPassed:  scored.CriteriaPassed,
+			Levels:          scored.Levels,
+			CriteriaResults: scored.CriteriaResults,
+		})
+	}
+
+	// Build aggregate criterion results (pass if ANY repo has it).
+	var aggResults []CriterionResult
 	for _, c := range universalCriteria {
-		passed := s.checkCriterion(ctx, owner, repo, c, dirCache)
-		results = append(results, CriterionResult{
+		aggResults = append(aggResults, CriterionResult{
 			ID:       c.ID,
 			Name:     c.Name,
 			Level:    c.Level,
 			Category: c.Category,
 			Patterns: c.Patterns,
-			Passed:   passed,
+			Passed:   aggPassed[c.ID],
 		})
 	}
 
-	return s.scoreResults(results)
+	eval := s.scoreResults(aggResults)
+	eval.RepoResults = repoEvals
+	return eval
 }
 
 // prefetchDirectories fetches directory listings for parent dirs that
@@ -205,7 +407,6 @@ func (s *Server) patternExists(ctx context.Context, owner, repo, path string, di
 	isDir := strings.HasSuffix(path, "/")
 	cleanPath := strings.TrimSuffix(path, "/")
 
-	// Split into parent dir + base name for cache lookup.
 	parent := ""
 	base := cleanPath
 	if idx := strings.LastIndex(cleanPath, "/"); idx >= 0 {
@@ -220,7 +421,6 @@ func (s *Server) patternExists(ctx context.Context, owner, repo, path string, di
 		return entries[base]
 	}
 
-	// Cache miss — fall back to direct API check.
 	ghClient := s.deps.GHClient.GoGitHub()
 	_, _, _, err := ghClient.Repositories.GetContents(ctx, owner, repo, cleanPath, nil)
 	return err == nil
@@ -228,7 +428,6 @@ func (s *Server) patternExists(ctx context.Context, owner, repo, path string, di
 
 // scoreResults calculates per-level scores and the overall codebase level.
 func (s *Server) scoreResults(results []CriterionResult) ACMMEvaluation {
-	// Group by level.
 	type levelBucket struct {
 		total   int
 		matched int
@@ -249,7 +448,6 @@ func (s *Server) scoreResults(results []CriterionResult) ACMMEvaluation {
 		}
 	}
 
-	// Collect and sort level numbers.
 	levels := make([]int, 0, len(buckets))
 	for lvl := range buckets {
 		levels = append(levels, lvl)
@@ -278,7 +476,6 @@ func (s *Server) scoreResults(results []CriterionResult) ACMMEvaluation {
 		})
 	}
 
-	// Determine highest passing codebase level: all preceding levels must also pass.
 	codebaseLevel := 0
 	for _, ls := range levelScores {
 		if ls.Passed {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1982,10 +1982,10 @@
     <div class="section-body">
       <div id="acmm-eval-card" style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:16px">
         <div class="kb-stat-grid" id="acmm-eval-stats">
-          <div class="kb-stat"><div class="val" id="acmm-codebase-level">--</div><div class="lbl">Codebase Readiness</div></div>
-          <div class="kb-stat"><div class="val" id="acmm-ops-level">--</div><div class="lbl">Operational Autonomy</div></div>
-          <div class="kb-stat"><div class="val" id="acmm-overall-level">--</div><div class="lbl">Overall ACMM</div></div>
-          <div class="kb-stat"><div class="val" id="acmm-criteria-ratio">--</div><div class="lbl">Criteria Passed</div></div>
+          <div class="kb-stat" onclick="acmmShowCodebaseDialog()" style="cursor:pointer"><div class="val" id="acmm-codebase-level">--</div><div class="lbl">Codebase Readiness</div></div>
+          <div class="kb-stat" onclick="acmmShowOpsDialog()" style="cursor:pointer"><div class="val" id="acmm-ops-level">--</div><div class="lbl">Operational Autonomy</div></div>
+          <div class="kb-stat" onclick="acmmShowOverallDialog()" style="cursor:pointer"><div class="val" id="acmm-overall-level">--</div><div class="lbl">Overall ACMM</div></div>
+          <div class="kb-stat" onclick="acmmShowAllCriteriaDialog()" style="cursor:pointer"><div class="val" id="acmm-criteria-ratio">--</div><div class="lbl">Criteria Passed</div></div>
         </div>
         <div id="acmm-level-bars" style="margin-top:12px"></div>
         <div id="acmm-eval-meta" style="margin-top:10px;font-size:0.7rem;color:var(--muted);display:flex;justify-content:space-between">
@@ -9030,11 +9030,180 @@ function burnAreaChart() {
     // ACMM Evaluation
     const ACMM_EVAL_INTERVAL_MS = 3600000; // 1 hour
     const ACMM_LEVEL_NAMES = {0:'Prerequisites',2:'Instructed',3:'Measured',4:'Adaptive',5:'Automated',6:'Autonomous'};
+    const ACMM_LEVEL_DESCRIPTIONS = {
+      0: 'Foundational tooling: test suites, CI/CD, templates, and code style enforcement.',
+      2: 'AI agents receive explicit instructions via CLAUDE.md, copilot-instructions, cursor rules, and prompt catalogs.',
+      3: 'PR acceptance metrics, review rubrics, quality dashboards, and safety model enforcement are in place.',
+      4: 'Self-tuning QA, nightly compliance, automated review application, AI-fix workflows, and session continuity.',
+      5: 'GitHub Actions AI integration, auto-QA self-tuning, public metrics, policy-as-code, and reflection logs.',
+      6: 'Auto issue generation, multi-agent orchestration, strategic dashboards, merge queues, and full governance.'
+    };
+    let _acmmEvalData = null;
+
+    function acmmShowLevelDialog(level) {
+      if (!_acmmEvalData) return;
+      const lvlData = (_acmmEvalData.levels || []).find(l => l.level === level);
+      const criteria = (_acmmEvalData.criteria_results || []).filter(c => c.level === level);
+      const name = ACMM_LEVEL_NAMES[level] || ('L' + level);
+      const desc = ACMM_LEVEL_DESCRIPTIONS[level] || '';
+      const pct = lvlData ? Math.round(lvlData.score * 100) : 0;
+      const passed = lvlData ? lvlData.passed : false;
+      const statusColor = passed ? '#238636' : (pct > 40 ? '#d29922' : '#da3633');
+      const statusText = passed ? '✓ Passed' : '✗ Not passed';
+      const threshold = lvlData ? Math.round(lvlData.threshold * 100) : 70;
+
+      const byCategory = {};
+      for (const c of criteria) {
+        const cat = c.category || 'general';
+        if (!byCategory[cat]) byCategory[cat] = [];
+        byCategory[cat].push(c);
+      }
+
+      let criteriaHtml = '';
+      for (const [cat, items] of Object.entries(byCategory)) {
+        criteriaHtml += '<div style="margin-top:10px"><div style="font-size:0.7rem;text-transform:uppercase;color:var(--muted);margin-bottom:4px;font-weight:600">' + escapeHtml(cat) + '</div>';
+        for (const c of items) {
+          const icon = c.passed ? '✅' : '❌';
+          const patternList = (c.patterns || []).map(p => '<code style="font-size:0.7rem;background:var(--bg);padding:1px 4px;border-radius:3px">' + escapeHtml(p) + '</code>').join(' ');
+          criteriaHtml += '<div style="padding:6px 0;border-bottom:1px solid var(--border)">' +
+            '<div style="display:flex;align-items:center;gap:6px">' +
+            '<span>' + icon + '</span>' +
+            '<span style="font-size:0.82rem;font-weight:500">' + escapeHtml(c.name) + '</span>' +
+            '</div>' +
+            '<div style="margin-top:3px;margin-left:24px;font-size:0.72rem;color:var(--muted)">Checks: ' + patternList + '</div>' +
+            '</div>';
+        }
+        criteriaHtml += '</div>';
+      }
+
+      acmmShowDialog(
+        'L' + level + ' ' + name,
+        '<div style="margin-bottom:12px">' +
+        '<div style="display:flex;align-items:center;gap:10px;margin-bottom:8px">' +
+        '<span style="font-size:1.5rem;font-weight:700;color:' + statusColor + '">' + pct + '%</span>' +
+        '<span style="font-size:0.82rem;color:' + statusColor + ';font-weight:600">' + statusText + '</span>' +
+        '<span style="font-size:0.72rem;color:var(--muted)">(threshold: ' + threshold + '%)</span>' +
+        '</div>' +
+        '<p style="font-size:0.8rem;color:var(--muted);margin:0 0 8px">' + escapeHtml(desc) + '</p>' +
+        '</div>' +
+        '<div style="font-size:0.82rem;font-weight:600;margin-bottom:4px">Criteria (' + (lvlData ? lvlData.matched : 0) + '/' + (lvlData ? lvlData.total : 0) + ')</div>' +
+        criteriaHtml
+      );
+    }
+
+    function acmmShowCodebaseDialog() {
+      if (!_acmmEvalData) return;
+      const d = _acmmEvalData;
+      const name = ACMM_LEVEL_NAMES[d.codebase_level] || 'None';
+      let html = '<div style="margin-bottom:12px">' +
+        '<p style="font-size:0.82rem;color:var(--muted);margin:0 0 8px">Codebase readiness measures whether the repo has the files, configs, and tooling that enable AI-native development. Each level requires ≥70% of its criteria to pass, and all preceding levels must also pass.</p>' +
+        '<div style="font-size:0.82rem"><strong>Current level:</strong> L' + d.codebase_level + ' ' + escapeHtml(name) + '</div></div>';
+
+      for (const lvl of (d.levels || [])) {
+        const pct = Math.round(lvl.score * 100);
+        const color = lvl.passed ? '#238636' : (pct > 40 ? '#d29922' : '#da3633');
+        html += '<div onclick="acmmShowLevelDialog(' + lvl.level + ')" style="cursor:pointer;padding:8px;margin-bottom:4px;background:var(--bg);border-radius:6px;border:1px solid var(--border);transition:border-color .15s" onmouseover="this.style.borderColor=\'var(--muted)\'" onmouseout="this.style.borderColor=\'var(--border)\'">' +
+          '<div style="display:flex;align-items:center;justify-content:space-between">' +
+          '<span style="font-size:0.82rem;font-weight:600">L' + lvl.level + ' ' + escapeHtml(lvl.name) + '</span>' +
+          '<span style="font-size:0.75rem;color:' + color + ';font-weight:600">' + lvl.matched + '/' + lvl.total + ' (' + pct + '%)</span></div>' +
+          '<div style="margin-top:4px;height:4px;background:var(--card-bg);border-radius:2px;overflow:hidden"><div style="width:' + pct + '%;height:100%;background:' + color + ';border-radius:2px"></div></div></div>';
+      }
+      acmmShowDialog('Codebase Readiness — L' + d.codebase_level + ' ' + escapeHtml(name), html);
+    }
+
+    function acmmShowOpsDialog() {
+      if (!_acmmEvalData) return;
+      const d = _acmmEvalData;
+      const name = ACMM_LEVEL_NAMES[d.operational_level] || 'Unknown';
+      const opsDescriptions = {
+        1: 'Manual operation — agents run one-off tasks with no persistent configuration.',
+        2: 'Agents follow explicit instructions (CLAUDE.md, copilot-instructions) but require human initiation.',
+        3: 'Observability in place — metrics, dashboards, and review rubrics track agent quality.',
+        4: 'Self-tuning — agents adapt their behavior based on feedback loops and compliance checks.',
+        5: 'Fully automated — CI/CD triggers agents, auto-QA self-tunes, policies enforced as code.',
+        6: 'Autonomous — multi-agent orchestration, auto issue generation, strategic oversight.'
+      };
+      const desc = opsDescriptions[d.operational_level] || 'Level not recognized.';
+      acmmShowDialog('Operational Autonomy — L' + d.operational_level + ' ' + escapeHtml(name),
+        '<p style="font-size:0.82rem;color:var(--muted);margin:0 0 12px">Operational autonomy reflects the hive\'s current pack configuration — how much the system automates without human intervention.</p>' +
+        '<div style="padding:12px;background:var(--bg);border-radius:6px;border:1px solid var(--border)">' +
+        '<div style="font-size:1.1rem;font-weight:700;margin-bottom:4px">L' + d.operational_level + ' — ' + escapeHtml(name) + '</div>' +
+        '<div style="font-size:0.82rem;color:var(--muted)">' + escapeHtml(desc) + '</div></div>' +
+        '<p style="font-size:0.75rem;color:var(--muted);margin-top:12px">This is set by the <code>acmm_level</code> field in your hive config, or determined by your active pack.</p>'
+      );
+    }
+
+    function acmmShowOverallDialog() {
+      if (!_acmmEvalData) return;
+      const d = _acmmEvalData;
+      const codeName = ACMM_LEVEL_NAMES[d.codebase_level] || 'None';
+      const opsName = ACMM_LEVEL_NAMES[d.operational_level] || 'Unknown';
+      const overallName = ACMM_LEVEL_NAMES[d.overall_level] || 'None';
+      const lower = d.codebase_level <= d.operational_level ? 'codebase readiness' : 'operational autonomy';
+      acmmShowDialog('Overall ACMM Level — L' + d.overall_level + ' ' + escapeHtml(overallName),
+        '<p style="font-size:0.82rem;color:var(--muted);margin:0 0 12px">The overall ACMM level is the <strong>minimum</strong> of codebase readiness and operational autonomy. Both dimensions must align — a high operational level means nothing if the repo lacks foundational tooling, and vice versa.</p>' +
+        '<div style="display:flex;gap:12px;margin-bottom:12px">' +
+        '<div style="flex:1;padding:12px;background:var(--bg);border-radius:6px;border:1px solid var(--border);text-align:center;cursor:pointer" onclick="acmmCloseDialog();acmmShowCodebaseDialog()">' +
+        '<div style="font-size:1.2rem;font-weight:700">L' + d.codebase_level + '</div><div style="font-size:0.72rem;color:var(--muted)">Codebase</div></div>' +
+        '<div style="flex:1;padding:12px;background:var(--bg);border-radius:6px;border:1px solid var(--border);text-align:center;cursor:pointer" onclick="acmmCloseDialog();acmmShowOpsDialog()">' +
+        '<div style="font-size:1.2rem;font-weight:700">L' + d.operational_level + '</div><div style="font-size:0.72rem;color:var(--muted)">Operational</div></div>' +
+        '</div>' +
+        '<div style="padding:10px;background:var(--bg);border-radius:6px;border:1px solid var(--border);font-size:0.8rem">' +
+        '→ Overall is <strong>L' + d.overall_level + '</strong> because ' + lower + ' is the limiting factor.</div>'
+      );
+    }
+
+    function acmmShowAllCriteriaDialog() {
+      if (!_acmmEvalData) return;
+      const d = _acmmEvalData;
+      let html = '<p style="font-size:0.82rem;color:var(--muted);margin:0 0 12px">' + d.criteria_passed + ' of ' + d.criteria_total + ' criteria detected in the repository. Click a level row to see details.</p>';
+
+      for (const lvl of (d.levels || [])) {
+        const criteria = (d.criteria_results || []).filter(c => c.level === lvl.level);
+        const pct = Math.round(lvl.score * 100);
+        const color = lvl.passed ? '#238636' : (pct > 40 ? '#d29922' : '#da3633');
+        html += '<div style="margin-bottom:8px">' +
+          '<div onclick="acmmCloseDialog();acmmShowLevelDialog(' + lvl.level + ')" style="cursor:pointer;display:flex;align-items:center;justify-content:space-between;padding:6px 8px;background:var(--bg);border-radius:6px;border:1px solid var(--border);transition:border-color .15s" onmouseover="this.style.borderColor=\'var(--muted)\'" onmouseout="this.style.borderColor=\'var(--border)\'">' +
+          '<span style="font-size:0.82rem;font-weight:600">L' + lvl.level + ' ' + escapeHtml(lvl.name) + '</span>' +
+          '<span style="font-size:0.75rem;color:' + color + '">' + lvl.matched + '/' + lvl.total + '</span></div>';
+        for (const c of criteria) {
+          html += '<div style="display:flex;align-items:center;gap:6px;padding:3px 8px 3px 20px;font-size:0.78rem">' +
+            '<span>' + (c.passed ? '✅' : '❌') + '</span>' +
+            '<span>' + escapeHtml(c.name) + '</span></div>';
+        }
+        html += '</div>';
+      }
+      acmmShowDialog('All Criteria — ' + d.criteria_passed + '/' + d.criteria_total, html);
+    }
+
+    function acmmShowDialog(title, bodyHtml) {
+      let overlay = document.getElementById('acmm-dialog-overlay');
+      if (!overlay) {
+        overlay = document.createElement('div');
+        overlay.id = 'acmm-dialog-overlay';
+        overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:10000;display:flex;align-items:center;justify-content:center';
+        overlay.addEventListener('click', (e) => { if (e.target === overlay) acmmCloseDialog(); });
+        document.body.appendChild(overlay);
+      }
+      overlay.style.display = 'flex';
+      overlay.innerHTML = '<div style="background:var(--card-bg);border:1px solid var(--border);border-radius:12px;padding:20px;max-width:560px;width:92%;max-height:80vh;overflow-y:auto;box-shadow:0 20px 60px rgba(0,0,0,0.3)">' +
+        '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">' +
+        '<h3 style="margin:0;font-size:1rem;font-weight:700;color:var(--text)">' + title + '</h3>' +
+        '<button onclick="acmmCloseDialog()" style="background:none;border:none;cursor:pointer;font-size:1.1rem;color:var(--muted);padding:4px">✕</button></div>' +
+        '<div>' + bodyHtml + '</div></div>';
+    }
+
+    function acmmCloseDialog() {
+      const overlay = document.getElementById('acmm-dialog-overlay');
+      if (overlay) overlay.style.display = 'none';
+    }
+
     async function fetchACMMEvaluation() {
       try {
         const r = await fetch('/api/acmm/evaluation');
         if (!r.ok) return;
         const d = await r.json();
+        _acmmEvalData = d;
 
         const fmtLevel = (lvl) => {
           const name = ACMM_LEVEL_NAMES[lvl] || ('L'+lvl);
@@ -9047,14 +9216,14 @@ function burnAreaChart() {
         setIfChanged(document.getElementById('acmm-criteria-ratio'),
           '<span style="font-size:1.2rem;font-weight:700">' + d.criteria_passed + '/' + d.criteria_total + '</span>');
 
-        // Per-level bars
+        // Per-level bars (clickable)
         const barsEl = document.getElementById('acmm-level-bars');
         if (barsEl && d.levels) {
           let html = '';
           for (const lvl of d.levels) {
             const pct = Math.round(lvl.score * 100);
             const color = lvl.passed ? '#238636' : (pct > 40 ? '#d29922' : '#da3633');
-            html += '<div style="display:flex;align-items:center;gap:8px;margin-bottom:4px;font-size:0.75rem">' +
+            html += '<div onclick="acmmShowLevelDialog(' + lvl.level + ')" style="display:flex;align-items:center;gap:8px;margin-bottom:4px;font-size:0.75rem;cursor:pointer;padding:2px 4px;border-radius:4px;transition:background .15s" onmouseover="this.style.background=\'var(--bg)\'" onmouseout="this.style.background=\'transparent\'">' +
               '<span style="width:100px;color:var(--muted)">' + escapeHtml(lvl.name) + '</span>' +
               '<div style="flex:1;height:8px;background:var(--bg);border-radius:4px;overflow:hidden">' +
               '<div style="width:' + pct + '%;height:100%;background:' + color + ';border-radius:4px;transition:width .3s"></div></div>' +

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1987,6 +1987,10 @@
           <div class="kb-stat" onclick="acmmShowOverallDialog()" style="cursor:pointer"><div class="val" id="acmm-overall-level">--</div><div class="lbl">Overall ACMM</div></div>
           <div class="kb-stat" onclick="acmmShowAllCriteriaDialog()" style="cursor:pointer"><div class="val" id="acmm-criteria-ratio">--</div><div class="lbl">Criteria Passed</div></div>
         </div>
+        <div id="acmm-repo-selector" style="display:none;margin-top:8px;font-size:0.75rem;display:flex;align-items:center;gap:6px;flex-wrap:wrap">
+          <span style="color:var(--muted)">Repo:</span>
+          <button onclick="acmmSelectRepo(null)" id="acmm-repo-btn-all" style="padding:2px 8px;border-radius:4px;border:1px solid var(--border);background:var(--bg);cursor:pointer;font-size:0.72rem;color:var(--text);font-weight:600">All (aggregate)</button>
+        </div>
         <div id="acmm-level-bars" style="margin-top:12px"></div>
         <div id="acmm-eval-meta" style="margin-top:10px;font-size:0.7rem;color:var(--muted);display:flex;justify-content:space-between">
           <span id="acmm-eval-source"></span>
@@ -9039,11 +9043,177 @@ function burnAreaChart() {
       6: 'Auto issue generation, multi-agent orchestration, strategic dashboards, merge queues, and full governance.'
     };
     let _acmmEvalData = null;
+    let _acmmSelectedRepo = null; // null = aggregate view
 
-    function acmmShowLevelDialog(level) {
+    function acmmGetActiveData() {
+      if (!_acmmEvalData) return null;
+      if (!_acmmSelectedRepo || !_acmmEvalData.repo_results) return _acmmEvalData;
+      return (_acmmEvalData.repo_results || []).find(r => r.repo === _acmmSelectedRepo) || _acmmEvalData;
+    }
+
+    function acmmCriterionRow(c, repoName) {
+      const icon = c.passed ? '✅' : '❌';
+      const patternList = (c.patterns || []).map(p => '<code style="font-size:0.7rem;background:var(--bg);padding:1px 4px;border-radius:3px">' + escapeHtml(p) + '</code>').join(' ');
+      let issueBtn = '';
+      if (!c.passed) {
+        const repo = repoName || _acmmSelectedRepo || '';
+        const escapedId = escapeHtml(c.id).replace(/'/g, "\\'");
+        const escapedRepo = escapeHtml(repo).replace(/'/g, "\\'");
+        issueBtn = '<button onclick="event.stopPropagation();acmmCreateIssue(\'' + escapedRepo + '\',\'' + escapedId + '\',' + c.level + ',this)" ' +
+          'style="margin-left:auto;padding:2px 8px;font-size:0.68rem;background:var(--bg);border:1px solid var(--border);border-radius:4px;cursor:pointer;color:var(--muted);white-space:nowrap" ' +
+          'title="Open GitHub issue for agents to fix this">📋 Open Issue</button>';
+      }
+      return '<div style="padding:6px 0;border-bottom:1px solid var(--border)">' +
+        '<div style="display:flex;align-items:center;gap:6px">' +
+        '<span>' + icon + '</span>' +
+        '<span style="font-size:0.82rem;font-weight:500">' + escapeHtml(c.name) + '</span>' +
+        issueBtn +
+        '</div>' +
+        '<div style="margin-top:3px;margin-left:24px;font-size:0.72rem;color:var(--muted)">Checks: ' + patternList + '</div>' +
+        '</div>';
+    }
+
+    async function acmmCreateIssue(repo, criterionId, level, btn) {
+      if (!repo) {
+        const repos = (_acmmEvalData.repo_results || []).map(r => r.repo);
+        if (repos.length === 1) {
+          repo = repos[0];
+        } else {
+          acmmShowRepoPickerForIssue(criterionId, level);
+          return;
+        }
+      }
+      const origText = btn.textContent;
+      btn.textContent = '⏳ Creating...';
+      btn.disabled = true;
+      try {
+        const r = await fetch('/api/acmm/issue', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({repo, criterion_id: criterionId, criterion_level: level})
+        });
+        if (!r.ok) {
+          const errText = await r.text();
+          btn.textContent = '⚠ Failed';
+          btn.title = errText;
+          setTimeout(() => { btn.textContent = origText; btn.disabled = false; }, 3000);
+          return;
+        }
+        const data = await r.json();
+        btn.innerHTML = '✅ <a href="' + escapeHtml(data.issue_url) + '" target="_blank" style="color:var(--muted);font-size:0.68rem">#' + data.issue_number + '</a>';
+        btn.style.borderColor = '#238636';
+      } catch (e) {
+        btn.textContent = '⚠ Error';
+        setTimeout(() => { btn.textContent = origText; btn.disabled = false; }, 3000);
+      }
+    }
+
+    function acmmShowRepoPickerForIssue(criterionId, level) {
+      const repos = (_acmmEvalData.repo_results || []).map(r => r.repo);
+      let html = '<p style="font-size:0.82rem;color:var(--muted);margin:0 0 12px">Which repository should this issue be opened on?</p>';
+      for (const repo of repos) {
+        const repoData = (_acmmEvalData.repo_results || []).find(r => r.repo === repo);
+        const criterion = repoData ? (repoData.criteria_results || []).find(c => c.id === criterionId) : null;
+        const already = criterion && criterion.passed;
+        const escapedId = escapeHtml(criterionId).replace(/'/g, "\\'");
+        const escapedRepo = escapeHtml(repo).replace(/'/g, "\\'");
+        if (already) {
+          html += '<div style="padding:8px;margin-bottom:4px;background:var(--bg);border-radius:6px;border:1px solid var(--border);opacity:0.5">' +
+            '<span style="font-size:0.82rem">✅ ' + escapeHtml(repo) + '</span>' +
+            '<span style="font-size:0.72rem;color:var(--muted);margin-left:8px">(already passing)</span></div>';
+        } else {
+          html += '<div onclick="acmmCloseDialog();acmmCreateIssueDirectFromPicker(\'' + escapedRepo + '\',\'' + escapedId + '\',' + level + ')" ' +
+            'style="cursor:pointer;padding:8px;margin-bottom:4px;background:var(--bg);border-radius:6px;border:1px solid var(--border);transition:border-color .15s" ' +
+            'onmouseover="this.style.borderColor=\'var(--muted)\'" onmouseout="this.style.borderColor=\'var(--border)\'">' +
+            '<span style="font-size:0.82rem">❌ ' + escapeHtml(repo) + '</span></div>';
+        }
+      }
+      acmmShowDialog('Open Issue — Select Repository', html);
+    }
+
+    async function acmmCreateIssueDirectFromPicker(repo, criterionId, level) {
+      try {
+        const r = await fetch('/api/acmm/issue', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({repo, criterion_id: criterionId, criterion_level: level})
+        });
+        if (!r.ok) {
+          const errText = await r.text();
+          acmmShowDialog('Issue Creation Failed', '<p style="color:#da3633;font-size:0.82rem">' + escapeHtml(errText) + '</p>');
+          return;
+        }
+        const data = await r.json();
+        acmmShowDialog('Issue Created', '<p style="font-size:0.82rem">Issue <a href="' + escapeHtml(data.issue_url) + '" target="_blank" style="color:#58a6ff">#' + data.issue_number + '</a> created on <strong>' + escapeHtml(repo) + '</strong> with <code>acmm</code> and <code>ai-fix-requested</code> labels.</p>');
+      } catch (e) {
+        acmmShowDialog('Issue Creation Failed', '<p style="color:#da3633;font-size:0.82rem">Network error: ' + escapeHtml(e.message) + '</p>');
+      }
+    }
+
+    function acmmOpenAllIssuesForLevel(level) {
       if (!_acmmEvalData) return;
-      const lvlData = (_acmmEvalData.levels || []).find(l => l.level === level);
-      const criteria = (_acmmEvalData.criteria_results || []).filter(c => c.level === level);
+      const active = acmmGetActiveData();
+      const criteria = (active.criteria_results || active.CriteriaResults || []).filter(c => c.level === level && !c.passed);
+      if (criteria.length === 0) return;
+      const repos = (_acmmEvalData.repo_results || []);
+      const hasMultiRepo = repos.length > 1;
+      let html = '<p style="font-size:0.82rem;color:var(--muted);margin:0 0 12px">This will create ' + criteria.length + ' issue(s) for all failing criteria at L' + level + '.</p>';
+      if (hasMultiRepo && !_acmmSelectedRepo) {
+        html += '<p style="font-size:0.82rem;color:var(--muted);margin:0 0 12px">Select a target repo first, or issues will be created for each repo where the criterion fails.</p>';
+      }
+      html += '<div style="max-height:200px;overflow-y:auto;margin-bottom:12px">';
+      for (const c of criteria) { html += '<div style="font-size:0.78rem;padding:2px 0">❌ ' + escapeHtml(c.name) + '</div>'; }
+      html += '</div>';
+      html += '<div style="display:flex;gap:8px;justify-content:flex-end">' +
+        '<button onclick="acmmCloseDialog()" style="padding:6px 14px;background:var(--bg);border:1px solid var(--border);border-radius:6px;cursor:pointer;color:var(--muted);font-size:0.78rem">Cancel</button>' +
+        '<button onclick="acmmBatchCreateIssues(' + level + ')" style="padding:6px 14px;background:#238636;border:none;border-radius:6px;cursor:pointer;color:#fff;font-size:0.78rem;font-weight:600">Create ' + criteria.length + ' Issue(s)</button></div>';
+      acmmShowDialog('Open Issues for L' + level + ' ' + (ACMM_LEVEL_NAMES[level] || ''), html);
+    }
+
+    async function acmmBatchCreateIssues(level) {
+      const active = acmmGetActiveData();
+      const criteria = (active.criteria_results || []).filter(c => c.level === level && !c.passed);
+      const repos = (_acmmEvalData.repo_results || []);
+      const targetRepo = _acmmSelectedRepo || (repos.length === 1 ? repos[0].repo : null);
+
+      let created = 0, failed = 0;
+      acmmShowDialog('Creating Issues...', '<p id="acmm-batch-progress" style="font-size:0.82rem">0/' + criteria.length + ' created...</p>');
+
+      for (const c of criteria) {
+        if (targetRepo) {
+          try {
+            const r = await fetch('/api/acmm/issue', {
+              method: 'POST', headers: {'Content-Type': 'application/json'},
+              body: JSON.stringify({repo: targetRepo, criterion_id: c.id, criterion_level: level})
+            });
+            if (r.ok) created++; else failed++;
+          } catch { failed++; }
+        } else {
+          for (const rr of repos) {
+            const rc = (rr.criteria_results || []).find(x => x.id === c.id);
+            if (rc && !rc.passed) {
+              try {
+                const r = await fetch('/api/acmm/issue', {
+                  method: 'POST', headers: {'Content-Type': 'application/json'},
+                  body: JSON.stringify({repo: rr.repo, criterion_id: c.id, criterion_level: level})
+                });
+                if (r.ok) created++; else failed++;
+              } catch { failed++; }
+            }
+          }
+        }
+        const prog = document.getElementById('acmm-batch-progress');
+        if (prog) prog.textContent = created + '/' + criteria.length + ' created' + (failed > 0 ? ' (' + failed + ' failed)' : '') + '...';
+      }
+      acmmShowDialog('Issues Created', '<p style="font-size:0.82rem">' + created + ' issue(s) created' + (failed > 0 ? ', ' + failed + ' failed' : '') + ' with <code>acmm</code> + <code>ai-fix-requested</code> labels.</p>');
+    }
+
+    function acmmShowLevelDialog(level, repoName) {
+      if (!_acmmEvalData) return;
+      const source = repoName ? (_acmmEvalData.repo_results || []).find(r => r.repo === repoName) : acmmGetActiveData();
+      if (!source) return;
+      const lvlData = (source.levels || source.Levels || []).find(l => l.level === level);
+      const criteria = (source.criteria_results || source.CriteriaResults || []).filter(c => c.level === level);
       const name = ACMM_LEVEL_NAMES[level] || ('L' + level);
       const desc = ACMM_LEVEL_DESCRIPTIONS[level] || '';
       const pct = lvlData ? Math.round(lvlData.score * 100) : 0;
@@ -9051,6 +9221,7 @@ function burnAreaChart() {
       const statusColor = passed ? '#238636' : (pct > 40 ? '#d29922' : '#da3633');
       const statusText = passed ? '✓ Passed' : '✗ Not passed';
       const threshold = lvlData ? Math.round(lvlData.threshold * 100) : 70;
+      const failCount = criteria.filter(c => !c.passed).length;
 
       const byCategory = {};
       for (const c of criteria) {
@@ -9063,26 +9234,24 @@ function burnAreaChart() {
       for (const [cat, items] of Object.entries(byCategory)) {
         criteriaHtml += '<div style="margin-top:10px"><div style="font-size:0.7rem;text-transform:uppercase;color:var(--muted);margin-bottom:4px;font-weight:600">' + escapeHtml(cat) + '</div>';
         for (const c of items) {
-          const icon = c.passed ? '✅' : '❌';
-          const patternList = (c.patterns || []).map(p => '<code style="font-size:0.7rem;background:var(--bg);padding:1px 4px;border-radius:3px">' + escapeHtml(p) + '</code>').join(' ');
-          criteriaHtml += '<div style="padding:6px 0;border-bottom:1px solid var(--border)">' +
-            '<div style="display:flex;align-items:center;gap:6px">' +
-            '<span>' + icon + '</span>' +
-            '<span style="font-size:0.82rem;font-weight:500">' + escapeHtml(c.name) + '</span>' +
-            '</div>' +
-            '<div style="margin-top:3px;margin-left:24px;font-size:0.72rem;color:var(--muted)">Checks: ' + patternList + '</div>' +
-            '</div>';
+          criteriaHtml += acmmCriterionRow(c, repoName);
         }
         criteriaHtml += '</div>';
       }
 
+      let batchBtn = '';
+      if (failCount > 0) {
+        batchBtn = '<button onclick="acmmOpenAllIssuesForLevel(' + level + ')" style="padding:4px 10px;font-size:0.72rem;background:var(--bg);border:1px solid var(--border);border-radius:4px;cursor:pointer;color:var(--muted);margin-left:8px" title="Open issues for all failing criteria at this level">📋 Open All (' + failCount + ')</button>';
+      }
+
       acmmShowDialog(
-        'L' + level + ' ' + name,
+        'L' + level + ' ' + name + (repoName ? ' — ' + repoName : ''),
         '<div style="margin-bottom:12px">' +
         '<div style="display:flex;align-items:center;gap:10px;margin-bottom:8px">' +
         '<span style="font-size:1.5rem;font-weight:700;color:' + statusColor + '">' + pct + '%</span>' +
         '<span style="font-size:0.82rem;color:' + statusColor + ';font-weight:600">' + statusText + '</span>' +
         '<span style="font-size:0.72rem;color:var(--muted)">(threshold: ' + threshold + '%)</span>' +
+        batchBtn +
         '</div>' +
         '<p style="font-size:0.8rem;color:var(--muted);margin:0 0 8px">' + escapeHtml(desc) + '</p>' +
         '</div>' +
@@ -9094,12 +9263,35 @@ function burnAreaChart() {
     function acmmShowCodebaseDialog() {
       if (!_acmmEvalData) return;
       const d = _acmmEvalData;
-      const name = ACMM_LEVEL_NAMES[d.codebase_level] || 'None';
-      let html = '<div style="margin-bottom:12px">' +
-        '<p style="font-size:0.82rem;color:var(--muted);margin:0 0 8px">Codebase readiness measures whether the repo has the files, configs, and tooling that enable AI-native development. Each level requires ≥70% of its criteria to pass, and all preceding levels must also pass.</p>' +
-        '<div style="font-size:0.82rem"><strong>Current level:</strong> L' + d.codebase_level + ' ' + escapeHtml(name) + '</div></div>';
+      const hasMultiRepo = (d.repo_results || []).length > 1;
+      const active = acmmGetActiveData();
+      const codeLevel = active.codebase_level !== undefined ? active.codebase_level : active.CodebaseLevel;
+      const name = ACMM_LEVEL_NAMES[codeLevel] || 'None';
 
-      for (const lvl of (d.levels || [])) {
+      let html = '<div style="margin-bottom:12px">' +
+        '<p style="font-size:0.82rem;color:var(--muted);margin:0 0 8px">Codebase readiness measures whether repos have the files, configs, and tooling that enable AI-native development. Each level requires ≥70% of its criteria to pass, and all preceding levels must also pass.</p>';
+
+      if (hasMultiRepo) {
+        html += '<p style="font-size:0.78rem;color:var(--muted);margin:0 0 8px"><strong>Aggregate view:</strong> a criterion passes if it exists in <em>any</em> repo. Select a repo below for per-repo detail.</p>';
+      }
+      html += '<div style="font-size:0.82rem"><strong>Current level:</strong> L' + codeLevel + ' ' + escapeHtml(name) + '</div></div>';
+
+      if (hasMultiRepo) {
+        html += '<div style="margin-bottom:12px"><div style="font-size:0.72rem;text-transform:uppercase;color:var(--muted);margin-bottom:6px;font-weight:600">Per-Repository Breakdown</div>';
+        for (const rr of d.repo_results) {
+          const rName = ACMM_LEVEL_NAMES[rr.codebase_level] || 'None';
+          const rColor = rr.codebase_level >= 2 ? '#238636' : (rr.codebase_level > 0 ? '#d29922' : '#da3633');
+          html += '<div onclick="acmmShowRepoDetail(\'' + escapeHtml(rr.repo).replace(/'/g, "\\'") + '\')" ' +
+            'style="cursor:pointer;padding:8px;margin-bottom:4px;background:var(--bg);border-radius:6px;border:1px solid var(--border);display:flex;align-items:center;justify-content:space-between;transition:border-color .15s" ' +
+            'onmouseover="this.style.borderColor=\'var(--muted)\'" onmouseout="this.style.borderColor=\'var(--border)\'">' +
+            '<span style="font-size:0.82rem;font-weight:500">' + escapeHtml(rr.repo) + '</span>' +
+            '<span style="font-size:0.75rem;color:' + rColor + ';font-weight:600">L' + rr.codebase_level + ' ' + escapeHtml(rName) + ' (' + rr.criteria_passed + '/' + rr.criteria_total + ')</span></div>';
+        }
+        html += '</div>';
+      }
+
+      const levels = active.levels || active.Levels || [];
+      for (const lvl of levels) {
         const pct = Math.round(lvl.score * 100);
         const color = lvl.passed ? '#238636' : (pct > 40 ? '#d29922' : '#da3633');
         html += '<div onclick="acmmShowLevelDialog(' + lvl.level + ')" style="cursor:pointer;padding:8px;margin-bottom:4px;background:var(--bg);border-radius:6px;border:1px solid var(--border);transition:border-color .15s" onmouseover="this.style.borderColor=\'var(--muted)\'" onmouseout="this.style.borderColor=\'var(--border)\'">' +
@@ -9108,7 +9300,28 @@ function burnAreaChart() {
           '<span style="font-size:0.75rem;color:' + color + ';font-weight:600">' + lvl.matched + '/' + lvl.total + ' (' + pct + '%)</span></div>' +
           '<div style="margin-top:4px;height:4px;background:var(--card-bg);border-radius:2px;overflow:hidden"><div style="width:' + pct + '%;height:100%;background:' + color + ';border-radius:2px"></div></div></div>';
       }
-      acmmShowDialog('Codebase Readiness — L' + d.codebase_level + ' ' + escapeHtml(name), html);
+      acmmShowDialog('Codebase Readiness — L' + codeLevel + ' ' + escapeHtml(name), html);
+    }
+
+    function acmmShowRepoDetail(repoName) {
+      if (!_acmmEvalData) return;
+      const rr = (_acmmEvalData.repo_results || []).find(r => r.repo === repoName);
+      if (!rr) return;
+      const name = ACMM_LEVEL_NAMES[rr.codebase_level] || 'None';
+      let html = '<div style="margin-bottom:8px;font-size:0.82rem"><strong>Level:</strong> L' + rr.codebase_level + ' ' + escapeHtml(name) + '  |  <strong>Criteria:</strong> ' + rr.criteria_passed + '/' + rr.criteria_total + '</div>';
+      for (const lvl of (rr.levels || [])) {
+        const pct = Math.round(lvl.score * 100);
+        const color = lvl.passed ? '#238636' : (pct > 40 ? '#d29922' : '#da3633');
+        const failCount = (rr.criteria_results || []).filter(c => c.level === lvl.level && !c.passed).length;
+        html += '<div onclick="acmmShowLevelDialog(' + lvl.level + ',\'' + escapeHtml(repoName).replace(/'/g, "\\'") + '\')" ' +
+          'style="cursor:pointer;padding:8px;margin-bottom:4px;background:var(--bg);border-radius:6px;border:1px solid var(--border);transition:border-color .15s" ' +
+          'onmouseover="this.style.borderColor=\'var(--muted)\'" onmouseout="this.style.borderColor=\'var(--border)\'">' +
+          '<div style="display:flex;align-items:center;justify-content:space-between">' +
+          '<span style="font-size:0.82rem;font-weight:600">L' + lvl.level + ' ' + escapeHtml(lvl.name) + '</span>' +
+          '<span style="font-size:0.75rem;color:' + color + ';font-weight:600">' + lvl.matched + '/' + lvl.total + '</span></div>' +
+          '<div style="margin-top:4px;height:4px;background:var(--card-bg);border-radius:2px;overflow:hidden"><div style="width:' + pct + '%;height:100%;background:' + color + ';border-radius:2px"></div></div></div>';
+      }
+      acmmShowDialog(escapeHtml(repoName) + ' — L' + rr.codebase_level, html);
     }
 
     function acmmShowOpsDialog() {
@@ -9136,8 +9349,6 @@ function burnAreaChart() {
     function acmmShowOverallDialog() {
       if (!_acmmEvalData) return;
       const d = _acmmEvalData;
-      const codeName = ACMM_LEVEL_NAMES[d.codebase_level] || 'None';
-      const opsName = ACMM_LEVEL_NAMES[d.operational_level] || 'Unknown';
       const overallName = ACMM_LEVEL_NAMES[d.overall_level] || 'None';
       const lower = d.codebase_level <= d.operational_level ? 'codebase readiness' : 'operational autonomy';
       acmmShowDialog('Overall ACMM Level — L' + d.overall_level + ' ' + escapeHtml(overallName),
@@ -9156,16 +9367,27 @@ function burnAreaChart() {
     function acmmShowAllCriteriaDialog() {
       if (!_acmmEvalData) return;
       const d = _acmmEvalData;
-      let html = '<p style="font-size:0.82rem;color:var(--muted);margin:0 0 12px">' + d.criteria_passed + ' of ' + d.criteria_total + ' criteria detected in the repository. Click a level row to see details.</p>';
+      const active = acmmGetActiveData();
+      const results = active.criteria_results || active.CriteriaResults || [];
+      const levels = active.levels || active.Levels || [];
+      const totalPassed = results.filter(c => c.passed).length;
+      const hasMultiRepo = (d.repo_results || []).length > 1;
 
-      for (const lvl of (d.levels || [])) {
-        const criteria = (d.criteria_results || []).filter(c => c.level === lvl.level);
+      let html = '<p style="font-size:0.82rem;color:var(--muted);margin:0 0 12px">' + totalPassed + ' of ' + results.length + ' criteria detected' + (hasMultiRepo ? ' (aggregate across ' + d.repo_results.length + ' repos)' : '') + '. Click a level row to see details.</p>';
+
+      for (const lvl of levels) {
+        const criteria = results.filter(c => c.level === lvl.level);
         const pct = Math.round(lvl.score * 100);
         const color = lvl.passed ? '#238636' : (pct > 40 ? '#d29922' : '#da3633');
+        const failCount = criteria.filter(c => !c.passed).length;
         html += '<div style="margin-bottom:8px">' +
           '<div onclick="acmmCloseDialog();acmmShowLevelDialog(' + lvl.level + ')" style="cursor:pointer;display:flex;align-items:center;justify-content:space-between;padding:6px 8px;background:var(--bg);border-radius:6px;border:1px solid var(--border);transition:border-color .15s" onmouseover="this.style.borderColor=\'var(--muted)\'" onmouseout="this.style.borderColor=\'var(--border)\'">' +
           '<span style="font-size:0.82rem;font-weight:600">L' + lvl.level + ' ' + escapeHtml(lvl.name) + '</span>' +
-          '<span style="font-size:0.75rem;color:' + color + '">' + lvl.matched + '/' + lvl.total + '</span></div>';
+          '<div style="display:flex;align-items:center;gap:6px">';
+        if (failCount > 0) {
+          html += '<button onclick="event.stopPropagation();acmmOpenAllIssuesForLevel(' + lvl.level + ')" style="padding:2px 6px;font-size:0.65rem;background:var(--card-bg);border:1px solid var(--border);border-radius:3px;cursor:pointer;color:var(--muted)">📋 ' + failCount + '</button>';
+        }
+        html += '<span style="font-size:0.75rem;color:' + color + '">' + lvl.matched + '/' + lvl.total + '</span></div></div>';
         for (const c of criteria) {
           html += '<div style="display:flex;align-items:center;gap:6px;padding:3px 8px 3px 20px;font-size:0.78rem">' +
             '<span>' + (c.passed ? '✅' : '❌') + '</span>' +
@@ -9173,7 +9395,7 @@ function burnAreaChart() {
         }
         html += '</div>';
       }
-      acmmShowDialog('All Criteria — ' + d.criteria_passed + '/' + d.criteria_total, html);
+      acmmShowDialog('All Criteria — ' + totalPassed + '/' + results.length, html);
     }
 
     function acmmShowDialog(title, bodyHtml) {
@@ -9186,7 +9408,7 @@ function burnAreaChart() {
         document.body.appendChild(overlay);
       }
       overlay.style.display = 'flex';
-      overlay.innerHTML = '<div style="background:var(--card-bg);border:1px solid var(--border);border-radius:12px;padding:20px;max-width:560px;width:92%;max-height:80vh;overflow-y:auto;box-shadow:0 20px 60px rgba(0,0,0,0.3)">' +
+      overlay.innerHTML = '<div style="background:var(--card-bg);border:1px solid var(--border);border-radius:12px;padding:20px;max-width:600px;width:92%;max-height:80vh;overflow-y:auto;box-shadow:0 20px 60px rgba(0,0,0,0.3)">' +
         '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">' +
         '<h3 style="margin:0;font-size:1rem;font-weight:700;color:var(--text)">' + title + '</h3>' +
         '<button onclick="acmmCloseDialog()" style="background:none;border:none;cursor:pointer;font-size:1.1rem;color:var(--muted);padding:4px">✕</button></div>' +
@@ -9198,52 +9420,93 @@ function burnAreaChart() {
       if (overlay) overlay.style.display = 'none';
     }
 
+    function acmmSelectRepo(repoName) {
+      _acmmSelectedRepo = repoName;
+      acmmRenderCard();
+    }
+
+    function acmmRenderCard() {
+      const d = _acmmEvalData;
+      if (!d) return;
+
+      const fmtLevel = (lvl) => {
+        const name = ACMM_LEVEL_NAMES[lvl] || ('L'+lvl);
+        return '<span style="font-size:1.2rem;font-weight:700">L' + lvl + '</span><br><span style="font-size:0.7rem;color:var(--muted)">' + escapeHtml(name) + '</span>';
+      };
+
+      setIfChanged(document.getElementById('acmm-codebase-level'), fmtLevel(d.codebase_level));
+      setIfChanged(document.getElementById('acmm-ops-level'), fmtLevel(d.operational_level));
+      setIfChanged(document.getElementById('acmm-overall-level'), fmtLevel(d.overall_level));
+      setIfChanged(document.getElementById('acmm-criteria-ratio'),
+        '<span style="font-size:1.2rem;font-weight:700">' + d.criteria_passed + '/' + d.criteria_total + '</span>');
+
+      // Repo selector
+      const selectorEl = document.getElementById('acmm-repo-selector');
+      if (selectorEl && d.repo_results && d.repo_results.length > 1) {
+        selectorEl.style.display = 'flex';
+        const allBtn = document.getElementById('acmm-repo-btn-all');
+        if (allBtn) allBtn.style.fontWeight = _acmmSelectedRepo ? '400' : '600';
+        const existing = selectorEl.querySelectorAll('.acmm-repo-btn-repo');
+        existing.forEach(b => b.remove());
+        for (const rr of d.repo_results) {
+          let btn = selectorEl.querySelector('[data-acmm-repo="' + rr.repo + '"]');
+          if (!btn) {
+            btn = document.createElement('button');
+            btn.className = 'acmm-repo-btn-repo';
+            btn.setAttribute('data-acmm-repo', rr.repo);
+            btn.style.cssText = 'padding:2px 8px;border-radius:4px;border:1px solid var(--border);background:var(--bg);cursor:pointer;font-size:0.72rem;color:var(--text)';
+            btn.onclick = () => acmmSelectRepo(rr.repo);
+            selectorEl.appendChild(btn);
+          }
+          btn.textContent = rr.repo + ' (L' + rr.codebase_level + ')';
+          btn.style.fontWeight = _acmmSelectedRepo === rr.repo ? '600' : '400';
+        }
+      } else if (selectorEl) {
+        selectorEl.style.display = 'none';
+      }
+
+      // Per-level bars from active data
+      const active = acmmGetActiveData();
+      const levels = active.levels || active.Levels || d.levels || [];
+      const barsEl = document.getElementById('acmm-level-bars');
+      if (barsEl) {
+        let html = '';
+        for (const lvl of levels) {
+          const pct = Math.round(lvl.score * 100);
+          const color = lvl.passed ? '#238636' : (pct > 40 ? '#d29922' : '#da3633');
+          html += '<div onclick="acmmShowLevelDialog(' + lvl.level + ')" style="display:flex;align-items:center;gap:8px;margin-bottom:4px;font-size:0.75rem;cursor:pointer;padding:2px 4px;border-radius:4px;transition:background .15s" onmouseover="this.style.background=\'var(--bg)\'" onmouseout="this.style.background=\'transparent\'">' +
+            '<span style="width:100px;color:var(--muted)">' + escapeHtml(lvl.name) + '</span>' +
+            '<div style="flex:1;height:8px;background:var(--bg);border-radius:4px;overflow:hidden">' +
+            '<div style="width:' + pct + '%;height:100%;background:' + color + ';border-radius:4px;transition:width .3s"></div></div>' +
+            '<span style="width:60px;text-align:right;color:var(--muted)">' + lvl.matched + '/' + lvl.total + '</span></div>';
+        }
+        barsEl.innerHTML = html;
+      }
+
+      const tsEl = document.getElementById('acmm-eval-timestamp');
+      if (tsEl) {
+        let tsText = d.last_evaluated_at ? 'Evaluated: ' + new Date(d.last_evaluated_at).toLocaleString() : '';
+        if (d.repo_results && d.repo_results.length > 1) tsText += ' | ' + d.repo_results.length + ' repos';
+        tsEl.textContent = tsText;
+      }
+
+      const warnEl = document.getElementById('acmm-eval-warning');
+      if (warnEl) {
+        if (d.error) {
+          warnEl.style.display = 'block';
+          warnEl.textContent = d.error;
+        } else {
+          warnEl.style.display = 'none';
+        }
+      }
+    }
+
     async function fetchACMMEvaluation() {
       try {
         const r = await fetch('/api/acmm/evaluation');
         if (!r.ok) return;
-        const d = await r.json();
-        _acmmEvalData = d;
-
-        const fmtLevel = (lvl) => {
-          const name = ACMM_LEVEL_NAMES[lvl] || ('L'+lvl);
-          return '<span style="font-size:1.2rem;font-weight:700">L' + lvl + '</span><br><span style="font-size:0.7rem;color:var(--muted)">' + escapeHtml(name) + '</span>';
-        };
-
-        setIfChanged(document.getElementById('acmm-codebase-level'), fmtLevel(d.codebase_level));
-        setIfChanged(document.getElementById('acmm-ops-level'), fmtLevel(d.operational_level));
-        setIfChanged(document.getElementById('acmm-overall-level'), fmtLevel(d.overall_level));
-        setIfChanged(document.getElementById('acmm-criteria-ratio'),
-          '<span style="font-size:1.2rem;font-weight:700">' + d.criteria_passed + '/' + d.criteria_total + '</span>');
-
-        // Per-level bars (clickable)
-        const barsEl = document.getElementById('acmm-level-bars');
-        if (barsEl && d.levels) {
-          let html = '';
-          for (const lvl of d.levels) {
-            const pct = Math.round(lvl.score * 100);
-            const color = lvl.passed ? '#238636' : (pct > 40 ? '#d29922' : '#da3633');
-            html += '<div onclick="acmmShowLevelDialog(' + lvl.level + ')" style="display:flex;align-items:center;gap:8px;margin-bottom:4px;font-size:0.75rem;cursor:pointer;padding:2px 4px;border-radius:4px;transition:background .15s" onmouseover="this.style.background=\'var(--bg)\'" onmouseout="this.style.background=\'transparent\'">' +
-              '<span style="width:100px;color:var(--muted)">' + escapeHtml(lvl.name) + '</span>' +
-              '<div style="flex:1;height:8px;background:var(--bg);border-radius:4px;overflow:hidden">' +
-              '<div style="width:' + pct + '%;height:100%;background:' + color + ';border-radius:4px;transition:width .3s"></div></div>' +
-              '<span style="width:60px;text-align:right;color:var(--muted)">' + lvl.matched + '/' + lvl.total + '</span></div>';
-          }
-          barsEl.innerHTML = html;
-        }
-
-        const tsEl = document.getElementById('acmm-eval-timestamp');
-        if (tsEl) tsEl.textContent = d.last_evaluated_at ? 'Evaluated: ' + new Date(d.last_evaluated_at).toLocaleString() : '';
-
-        const warnEl = document.getElementById('acmm-eval-warning');
-        if (warnEl) {
-          if (d.error) {
-            warnEl.style.display = 'block';
-            warnEl.textContent = '⚠ ' + d.error;
-          } else {
-            warnEl.style.display = 'none';
-          }
-        }
+        _acmmEvalData = await r.json();
+        acmmRenderCard();
       } catch (e) {
         console.error('acmm eval fetch failed', e);
       }


### PR DESCRIPTION
## Summary

- All 4 stat blocks and per-level bars are clickable with drill-down dialogs
- **Multi-repo evaluation**: scans all configured repos (not just primary), with aggregate scoring (criterion passes if ANY repo has it) and per-repo breakdown with repo selector tabs
- **Issue creation**: `POST /api/acmm/issue` creates GitHub issues for failed criteria with `acmm` + `ai-fix-requested` labels, structured body with file patterns to add and category-specific "why it matters" explanation
- **Per-criterion "Open Issue" button** in level detail dialogs — when multiple repos, shows a repo picker that grays out repos where the criterion already passes
- **"Open All" button** per level to batch-create issues for all failing criteria
- API response enriched with `category`, `patterns`, and `repo` fields per criterion, plus `repo_results` array for per-repo detail

## New capabilities

- Click a stat block → explanation dialog (codebase, ops, overall min logic, all criteria)
- Click a level bar → criteria grouped by category with ✅/❌, file patterns, and Open Issue buttons
- Click "Open All (N)" on a level → batch creates N issues
- Repo selector tabs (visible when >1 repo) → switch between aggregate and per-repo views
- Codebase Readiness dialog shows per-repo breakdown with clickable rows

## Test plan

- [ ] Build passes: `go build ./...`
- [ ] Single-repo hive: card works as before, no repo selector shown
- [ ] Multi-repo hive: repo selector appears, switching repos updates bars
- [ ] Click "Open Issue" on a failed criterion → issue created with correct labels and body
- [ ] Click "Open All" on a level → batch creates issues for all failing criteria
- [ ] Multi-repo + "Open Issue" → repo picker dialog shows which repos pass/fail
- [ ] Dialogs close on ✕ button or overlay click