### PR TITLE
feat: add per-agent caveman_mode for output compression

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -80,6 +80,7 @@ agents:
     enabled: true
     backend: claude        # claude | copilot | gemini | goose
     model: claude-sonnet-4-6
+    caveman_mode: full     # lite | full | ultra | wenyan — compresses output ~65%
     beads_dir: /data/beads/scanner
     clear_on_kick: true
 ```

--- a/v2/deploy/data/wiki/agents.md
+++ b/v2/deploy/data/wiki/agents.md
@@ -61,6 +61,7 @@ my-agent:
   enabled: true
   backend: copilot
   model: claude-opus-4.6
+  caveman_mode: full                    # lite | full | ultra | wenyan — compresses output ~65%
   beads_dir: /data/beads/my-agent
   stale_timeout: 1800
   restart_strategy: immediate

--- a/v2/hive.yaml.example
+++ b/v2/hive.yaml.example
@@ -31,6 +31,7 @@ agents:
     enabled: true
     backend: claude                       # claude | copilot | gemini | goose
     model: claude-sonnet-4-6
+    caveman_mode: full                    # lite | full | ultra | wenyan — compresses output ~65%
     beads_dir: /data/beads/scanner
     clear_on_kick: true                   # Send /clear before each kick to reset context
     display_name: Code Scanner

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -442,6 +442,10 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		m.clearInferenceRouteCallback(agent.Name)
 	}
 
+	if agent.Config.CavemanMode != "" {
+		m.installCavemanForAgent(agent, backend)
+	}
+
 	switch backend {
 	case "claude":
 		bareFlag := ""
@@ -599,7 +603,67 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		go m.watchForTrustPromptForAgent(agent, agentCtx)
 	}
 
+	if agent.Config.CavemanMode != "" {
+		switch backend {
+		case "goose", "codex", "aider":
+			go func(a *AgentProcess, cavemanMode string) {
+				time.Sleep(cavemanActivationDelay)
+				m.tmuxSendLiteralForAgent(a, "/caveman "+cavemanMode)
+				time.Sleep(textToEnterDelay)
+				m.tmuxSendEntersForAgent(a)
+				m.logger.Info("sent caveman activation", "agent", a.Name, "mode", cavemanMode)
+			}(agent, agent.Config.CavemanMode)
+		}
+	}
+
 	return nil
+}
+
+// installCavemanForAgent runs the backend-specific caveman installer before
+// the agent CLI starts. Auto-activating backends (claude, copilot, gemini)
+// get caveman wired in so it's active from message one. Per-session backends
+// (goose, codex, aider) get the skill pre-installed; activation happens via
+// /caveman command sent after launch.
+func (m *Manager) installCavemanForAgent(agent *AgentProcess, backend string) {
+	mode := agent.Config.CavemanMode
+	if mode == "" {
+		return
+	}
+
+	home := "/data/home"
+	if agent.UID == 0 {
+		home = os.Getenv("HOME")
+		if home == "" {
+			home = "/root"
+		}
+	}
+
+	m.logger.Info("installing caveman", "agent", agent.Name, "backend", backend, "mode", mode)
+
+	var cmd *exec.Cmd
+	switch backend {
+	case "claude":
+		cmd = exec.Command("npx", "-y", "github:JuliusBrussee/caveman", "--", "--only", "claude", "--mode", mode)
+	case "copilot":
+		cmd = exec.Command("npx", "-y", "github:JuliusBrussee/caveman", "--", "--only", "copilot", "--with-init", "--mode", mode)
+	case "gemini":
+		cmd = exec.Command("npx", "-y", "github:JuliusBrussee/caveman", "--", "--only", "gemini", "--mode", mode)
+	case "goose":
+		cmd = exec.Command("npx", "-y", "skills", "add", "JuliusBrussee/caveman", "-a", "goose")
+	case "codex":
+		cmd = exec.Command("npx", "-y", "skills", "add", "JuliusBrussee/caveman", "-a", "codex")
+	case "aider":
+		cmd = exec.Command("npx", "-y", "skills", "add", "JuliusBrussee/caveman", "-a", "aider-desk")
+	default:
+		m.logger.Info("caveman not supported for backend", "backend", backend)
+		return
+	}
+
+	cmd.Dir = filepath.Join("/data/agents", agent.Name)
+	cmd.Env = append(os.Environ(), "HOME="+home)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		m.logger.Warn("caveman install failed", "agent", agent.Name, "error", err, "output", string(out))
+	}
 }
 
 // pollTmuxOutputForAgent is pollTmuxOutput using the agent's tmux socket.
@@ -1661,10 +1725,11 @@ const (
 	chunkSize             = 400
 	chunkDelay            = 1 * time.Second
 	staleCheckDelay       = 1 * time.Second
-	cliReadyPollInterval  = 2 * time.Second
-	cliReadyTimeout       = 60 * time.Second
+	cliReadyPollInterval    = 2 * time.Second
+	cliReadyTimeout         = 60 * time.Second
 	inputPromptPollInterval = 2 * time.Second
 	inputPromptTimeout      = 120 * time.Second
+	cavemanActivationDelay  = 5 * time.Second
 )
 
 func (m *Manager) SeedLastKick(name string, t time.Time) {
@@ -2499,6 +2564,9 @@ func (m *Manager) agentEnvPairs(agent *AgentProcess) []agentEnvPair {
 	// dashboard and advisory digest.
 	if agent.Config.BeadsDir != "" {
 		vars = append(vars, agentEnvPair{"BD_DIR", agent.Config.BeadsDir, false})
+	}
+	if agent.Config.CavemanMode != "" {
+		vars = append(vars, agentEnvPair{"HIVE_CAVEMAN_MODE", agent.Config.CavemanMode, false})
 	}
 	// GIT_SSL_CAINFO only — NOT SSL_CERT_FILE (that breaks Copilot API TLS)
 	vars = append(vars, agentEnvPair{"GIT_SSL_CAINFO", proxyCACertPath, false})

--- a/v2/pkg/config/acmm_packs.go
+++ b/v2/pkg/config/acmm_packs.go
@@ -42,6 +42,7 @@ type PackAgent struct {
 	StaleTimeout int      `json:"staleTimeout,omitempty" yaml:"stale_timeout,omitempty"`
 	Mode         string   `json:"mode,omitempty" yaml:"mode,omitempty"`
 	OnDemand     bool     `json:"onDemand,omitempty" yaml:"on_demand,omitempty"`
+	CavemanMode  string   `json:"cavemanMode,omitempty" yaml:"caveman_mode,omitempty"`
 }
 
 // PackGovernor describes the governor configuration recommended for a level.

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -180,6 +180,7 @@ type AgentConfig struct {
 	ACMMLevels       []int             `yaml:"acmm_levels" json:"acmm_levels,omitempty"`
 	Mode             string            `yaml:"mode" json:"mode,omitempty"`
 	OnDemand         bool              `yaml:"on_demand" json:"on_demand,omitempty"`
+	CavemanMode      string            `yaml:"caveman_mode" json:"caveman_mode,omitempty"`
 
 	// Managed is true for agents loaded from the overlay directory (not base config).
 	Managed bool `yaml:"-" json:"managed"`
@@ -1002,6 +1003,10 @@ func (c *Config) validate() error {
 		validBackends := map[string]bool{"claude": true, "copilot": true, "goose": true, "codex": true, "pi": true, "bob": true, "aider": true}
 		if agent.Backend != "" && !validBackends[agent.Backend] {
 			return fmt.Errorf("agent %s: invalid backend %q (must be claude, copilot, goose, codex, pi, bob, or aider)", name, agent.Backend)
+		}
+		validCavemanModes := map[string]bool{"": true, "lite": true, "full": true, "ultra": true, "wenyan": true}
+		if !validCavemanModes[agent.CavemanMode] {
+			return fmt.Errorf("agent %s: invalid caveman_mode %q (must be lite, full, ultra, or wenyan)", name, agent.CavemanMode)
 		}
 	}
 	return nil

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1507,6 +1507,7 @@ func (s *Server) handleAgentConfigGet(w http.ResponseWriter, r *http.Request) {
 			"laneKeywords":    agentCfg.LaneKeywords,
 			"detectKeywords":  agentCfg.DetectKeywords,
 			"aliases":         agentCfg.Aliases,
+			"cavemanMode":     agentCfg.CavemanMode,
 		},
 		"cadences": cadences,
 		"models":   models,
@@ -1840,6 +1841,17 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 				}
 			}
 			agentCfg.Aliases = a
+		}
+	}
+	if v, ok := body["cavemanMode"]; ok {
+		if s, ok := v.(string); ok {
+			s = sanitizeString(s)
+			validCavemanModes := map[string]bool{"": true, "lite": true, "full": true, "ultra": true, "wenyan": true}
+			if !validCavemanModes[s] {
+				jsonError(w, "caveman_mode must be one of: lite, full, ultra, wenyan (or empty to disable)", http.StatusBadRequest)
+				return
+			}
+			agentCfg.CavemanMode = s
 		}
 	}
 	s.deps.Config.Agents[name] = agentCfg

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -9737,6 +9737,7 @@ function burnAreaChart() {
       'final-compose': 'Final prompt assembly — resolve all variables, inject pipeline data, and produce the complete prompt sent to the agent.',
     };
     const RESTART_STRATEGIES = ['immediate', 'backoff', 'none'];
+    const CAVEMAN_MODES = ['', 'lite', 'full', 'ultra', 'wenyan'];
 
     function openConfigDialog(type, agentName, initialTabOverride) {
       const isCreate = type === 'agent' && !agentName;
@@ -10584,6 +10585,12 @@ function burnAreaChart() {
           <select id="cfg-model" onchange="markDirty('general','model',this.value)">
             <option value="">(from launch command)</option>
             ${KNOWN_MODELS.map(m => `<option value="${m.value}" ${_modelsEqual(g.model, m.value) ? 'selected' : ''}>${m.label}</option>`).join('')}
+          </select>
+        </div>
+        <div class="config-field">
+          <label>Caveman Mode <span class="config-info">i<span class="config-tooltip">Enable Caveman output compression to reduce token usage by ~65%. Modes: lite (removes filler), full (caveman-speak), ultra (telegraphic), wenyan (classical Chinese). Leave empty to disable.</span></span></label>
+          <select id="cfg-caveman-mode" onchange="markDirty('general','cavemanMode',this.value)">
+            ${CAVEMAN_MODES.map(m => `<option value="${m}" ${(g.cavemanMode || '') === m ? 'selected' : ''}>${m || '(disabled)'}</option>`).join('')}
           </select>
         </div>
         <div class="config-field">
@@ -11666,6 +11673,7 @@ function burnAreaChart() {
           lane_keywords: generalData.laneKeywords || [],
           detect_keywords: generalData.detectKeywords || [],
           aliases: generalData.aliases || [],
+          caveman_mode: generalData.cavemanMode || '',
         };
         try {
           const res = await fetch('/api/agents', {


### PR DESCRIPTION
## Summary

- Add `caveman_mode` config field to `AgentConfig` and `PackAgent` (values: `lite`, `full`, `ultra`, `wenyan`)
- Pre-install caveman via backend-specific installer before agent launch
- Auto-activate for claude/copilot/gemini backends; send `/caveman` post-launch for goose/codex/aider
- Expose `HIVE_CAVEMAN_MODE` env var for policy templates
- Validate caveman_mode values in config validation

Caveman (github.com/JuliusBrussee/caveman) compresses agent output by ~65% while maintaining technical accuracy, reducing token costs across the hive fleet.

## Backend support matrix

| Backend | Install method | Activation |
|---------|---------------|------------|
| `claude` | Hooks in `~/.claude/hooks/` | Auto (SessionStart hook) |
| `copilot` | Rule file `.github/copilot-instructions.md` | Auto (static rule) |
| `gemini` | Extension install | Auto |
| `goose` | `npx skills add` | Per-session (`/caveman`) |
| `codex` | `npx skills add` | Per-session (`/caveman`) |
| `aider` | `npx skills add` (aider-desk) | Per-session (`/caveman`) |

## Example config

```yaml
agents:
  scanner:
    backend: copilot
    model: claude-sonnet-4-6
    caveman_mode: full    # saves ~65% output tokens
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/config/...` passes
- [x] `go test ./pkg/agent/...` passes
- [ ] Deploy with `caveman_mode: full` on a claude-backend agent, verify compressed output
- [ ] Verify `HIVE_CAVEMAN_MODE` env var is set in agent environment