### PR TITLE
fix: resolve UID to username for workspace cleanup su

### DIFF
--- a/v2/pkg/dashboard/workspace_cleanup.go
+++ b/v2/pkg/dashboard/workspace_cleanup.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"strconv"
 	"syscall"
@@ -130,9 +131,15 @@ func removeAsOwner(path string) error {
 	}
 	ownerUID := strconv.FormatUint(uint64(stat.Uid), 10)
 
-	cmd := exec.Command("su", "-s", "/bin/sh", "-c", "rm -rf "+path, ownerUID)
+	// Some distros' su doesn't accept numeric UIDs — resolve to username
+	suTarget := ownerUID
+	if u, lookupErr := user.LookupId(ownerUID); lookupErr == nil {
+		suTarget = u.Username
+	}
+
+	cmd := exec.Command("su", "-s", "/bin/sh", "-c", "rm -rf "+path, suTarget)
 	if suErr := cmd.Run(); suErr != nil {
-		return fmt.Errorf("os.RemoveAll: %w; su %s rm -rf: %v", err, ownerUID, suErr)
+		return fmt.Errorf("os.RemoveAll: %w; su %s rm -rf: %v", err, suTarget, suErr)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Workspace cleanup runs every hour but consistently fails with `failed=3` because `su` on the container's distro doesn't accept numeric UIDs
- Root cause: `removeAsOwner()` passes the numeric UID (e.g. `2007`) to `su`, which fails with "user 2007 does not exist" even though the user exists in `/etc/passwd` as `hive-scanner`
- Fix: use `os/user.LookupId()` to resolve the UID to its username before passing to `su`

## Verified
- Confirmed `su -s /bin/sh 2007 -c "id"` fails on the container
- Confirmed `su -s /bin/sh hive-scanner -c "id"` succeeds
- Confirmed `su -s /bin/sh hive-scanner -c "rm -f /data/agents/scanner-console/.test-file.txt"` removes files successfully

## Test plan
- [ ] After deploy, next workspace_cleanup should show `failed=0` in audit log