### PR TITLE
fix: track issues created via repo picker in ACMM memory

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -9210,6 +9210,7 @@ function burnAreaChart() {
           return;
         }
         const data = await r.json();
+        _acmmOpenedIssues[repo + ':' + criterionId] = {number: data.issue_number, url: data.issue_url};
         acmmShowDialog('Issue Created', '<p style="font-size:0.82rem">Issue <a href="' + escapeHtml(data.issue_url) + '" target="_blank" style="color:#58a6ff">#' + data.issue_number + '</a> created on <strong>' + escapeHtml(repo) + '</strong> with <code>acmm</code> and <code>ai-fix-requested</code> labels.</p>');
       } catch (e) {
         acmmShowDialog('Issue Creation Failed', '<p style="color:#da3633;font-size:0.82rem">Network error: ' + escapeHtml(e.message) + '</p>');


### PR DESCRIPTION
## Summary
- Fix: issues created through the multi-repo picker (`acmmCreateIssueDirectFromPicker`) weren't stored in `_acmmOpenedIssues`, so reopening the level dialog showed "Open Issue" again instead of the issue link

## Test plan
- [ ] In multi-repo mode, click "Open Issue" on a failing criterion
- [ ] Select a repo from the picker, confirm issue creation
- [ ] Close the dialog, reopen the same level — the criterion should show ✅ #N link instead of Open Issue button