### PR TITLE
fix: workspace cleanup uses su-exec for cross-user removal

### DIFF
--- a/v2/pkg/dashboard/workspace_cleanup.go
+++ b/v2/pkg/dashboard/workspace_cleanup.go
@@ -6,7 +6,9 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -111,12 +113,11 @@ func sweepWorkspaces(logger *slog.Logger, audit *AuditLog) {
 
 // removeTree removes a file or directory tree. The hive binary runs as an
 // unprivileged user (dev/UID 1001) while agent workspaces are owned by
-// per-agent UIDs (hive-scanner, hive-architect, etc.). All share the "node"
-// group (GID 1000). Strategy:
+// per-agent UIDs (hive-scanner, hive-architect, etc.). Strategy:
 //  1. Try os.RemoveAll directly (works when group-writable or same owner).
-//  2. On EPERM, chmod the tree to be group-writable, then retry RemoveAll.
-//  3. As last resort, shell out to rm -rf (handles edge cases like stale
-//     NFS handles that Go's RemoveAll retries can't recover from).
+//  2. On EPERM, use su-exec (SUID binary) to run rm -rf as the file owner.
+//  3. chmod the tree writable and retry (works when current user owns the files).
+//  4. As last resort, shell out to rm -rf as the current user.
 func removeTree(path string) error {
 	err := os.RemoveAll(path)
 	if err == nil {
@@ -126,8 +127,19 @@ func removeTree(path string) error {
 		return err
 	}
 
-	// Make the tree group-writable so the dev user (same group) can delete.
-	chmodErr := filepath.WalkDir(path, func(p string, d os.DirEntry, walkErr error) error {
+	// Use su-exec to remove as the file owner — su-exec has the SUID bit,
+	// so the unprivileged dev user can switch to agent UIDs.
+	ownerName, lookupErr := fileOwnerName(path)
+	if lookupErr == nil && ownerName != "" {
+		cmd := exec.Command("su-exec", ownerName, "rm", "-rf", path)
+		if suErr := cmd.Run(); suErr == nil {
+			return nil
+		}
+	}
+
+	// chmod writable and retry — works when the current user owns the files
+	// (e.g. same-user read-only dirs) but not cross-user.
+	filepath.WalkDir(path, func(p string, d os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return nil
 		}
@@ -138,18 +150,34 @@ func removeTree(path string) error {
 		}
 		return nil
 	})
-	if chmodErr == nil {
-		if retryErr := os.RemoveAll(path); retryErr == nil {
-			return nil
-		}
+	if retryErr := os.RemoveAll(path); retryErr == nil {
+		return nil
 	}
 
-	// Last resort: shell out to rm -rf which may handle cases Go can't.
+	// Last resort: shell out to rm -rf as current user.
 	cmd := exec.Command("rm", "-rf", path)
 	if shellErr := cmd.Run(); shellErr != nil {
-		return fmt.Errorf("os.RemoveAll: %w; chmod+retry failed; rm -rf: %v", err, shellErr)
+		return fmt.Errorf("os.RemoveAll: %w; su-exec rm (owner=%s, lookup=%v); rm -rf: %v",
+			err, ownerName, lookupErr, shellErr)
 	}
 	return nil
+}
+
+// fileOwnerName returns the username that owns the given path.
+func fileOwnerName(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "", fmt.Errorf("not a unix stat")
+	}
+	u, err := user.LookupId(strconv.FormatUint(uint64(stat.Uid), 10))
+	if err != nil {
+		return "", err
+	}
+	return u.Username, nil
 }
 
 func isPermError(err error) bool {

--- a/v2/pkg/dashboard/workspace_cleanup_test.go
+++ b/v2/pkg/dashboard/workspace_cleanup_test.go
@@ -77,6 +77,27 @@ func TestRemoveTreeReadOnlyDir(t *testing.T) {
 	}
 }
 
+func TestFileOwnerName(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "owned.txt")
+	if err := os.WriteFile(f, []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	name, err := fileOwnerName(f)
+	if err != nil {
+		t.Fatalf("fileOwnerName failed: %v", err)
+	}
+	if name == "" {
+		t.Fatal("expected non-empty owner name")
+	}
+}
+
+func TestFileOwnerNameNotExist(t *testing.T) {
+	_, err := fileOwnerName("/nonexistent/path/xyz")
+	if err == nil {
+		t.Fatal("expected error for non-existent path")
+	}
+}
+
 func TestSweepWorkspacesSkipsRecent(t *testing.T) {
 	origRoot := agentWorkspaceRoot
 	root := t.TempDir()


### PR DESCRIPTION
## Summary

- **Root cause**: PR #1752 fixed the `su` fallback but replaced it with `chmod g+rwX` + retry. This cannot work cross-user because `chmod` requires file ownership or `CAP_FOWNER` — the `dev` user (UID 1001) has neither for files owned by agent UIDs (2001+). Nested dirs like `.git/` (mode `700`) are never made group-writable, so `WalkDir` can't traverse them and removal fails on every sweep.
- **Fix**: Use `su-exec` (SUID binary, already in the image) to run `rm -rf` as the file owner. New `fileOwnerName()` helper stats the path and resolves the owner UID to a username.
- **Fallback chain**: `os.RemoveAll` → `su-exec <owner> rm -rf` → `chmod` + retry (still works for same-owner read-only dirs) → plain `rm -rf`.

## Evidence

From `hive-oke` console hive pod logs (today, after #1752 deploy):
```
workspace cleanup: failed to remove stale dir  agent=scanner  dir=console-fix-20096
  error="os.RemoveAll: unlinkat .git/branches: permission denied; chmod+retry failed; rm -rf: exit status 1"
```

Audit log shows `failed=1` on every sweep cycle.

## Test plan

- [x] Existing `TestRemoveTree` and `TestRemoveTreeReadOnlyDir` pass
- [x] New `TestFileOwnerName` and `TestFileOwnerNameNotExist` pass
- [ ] After deploy to `hive-oke`, verify `workspace_cleanup` audit entries show `failed=0`

Fixes the remaining failure from #1752.

🤖 Generated with [Claude Code](https://claude.com/claude-code)