### PR TITLE
docs: remove docs from subproject list in GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -46,7 +46,6 @@ Hive is one of KubeStellar's subprojects, alongside:
   configuration management for edge, multi-cloud, and hybrid environments
 * [KubeStellar Console](https://github.com/kubestellar/console) — multi-cluster
   dashboard and observability
-* [KubeStellar Docs](https://github.com/kubestellar/docs) — project documentation
 
 As a subproject, Hive defers to the KubeStellar Steering Committee on
 cross-project matters, CNCF compliance, and trademark usage. All other


### PR DESCRIPTION
## Summary

- Removes KubeStellar Docs from the subproject list — docs is supporting infrastructure, not a subproject

## Test plan

- [x] Markdown renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)