### PR TITLE
Harden token handling: remove echoing, add log scrubbing and audit trail

### DIFF
--- a/bin/agent-launch.sh
+++ b/bin/agent-launch.sh
@@ -102,9 +102,16 @@ if [[ "$BACKEND" == "copilot" ]]; then
   fi
 fi
 
+# Scrub GitHub token patterns and JWTs from stderr before writing to disk.
+scrub_tokens() {
+  sed -u -E \
+    's/(ghs_|ghp_|gho_|github_pat_)[A-Za-z0-9_]{10,}/[REDACTED]/g;
+     s/eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}/[REDACTED-JWT]/g'
+}
+
 # Capture stderr so silent failures (e.g. invalid model name) leave a diagnostic.
 STDERR_LOG="/tmp/.hive-launch-stderr-${HIVE_AGENT:-unknown}.log"
-"${FULL_CMD[@]}" 2> >(tee "$STDERR_LOG" >&2)
+"${FULL_CMD[@]}" 2> >(scrub_tokens | tee "$STDERR_LOG" >&2)
 EXIT_CODE=$?
 if [[ $EXIT_CODE -ne 0 ]]; then
   echo "HIVE: ${CMD} exited with code ${EXIT_CODE}" >&2

--- a/bin/gh-app-token.sh
+++ b/bin/gh-app-token.sh
@@ -115,8 +115,7 @@ if [ "${1:-}" = "--scoped" ]; then
   exit 0
 fi
 
-if [ "${1:-}" = "--export" ]; then
-  echo "export GH_TOKEN=$TOKEN"
-else
-  echo "$TOKEN"
-fi
+# Token is already cached to $CACHE_FILE (line 59-60). Do not echo it to
+# stdout — callers should read the cache file directly to avoid leaking
+# the token into logs or captured output.
+echo "token cached at ${CACHE_FILE}"

--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -34,12 +34,16 @@ fi
 # Inject GitHub App token for agent gh calls (15k/hr vs PAT's 5k/hr).
 # Contributors keep their personal token — they fork+PR with their own identity.
 GH_APP_TOKEN_CACHE="/var/run/hive-metrics/gh-app-token.cache"
+TOKEN_ACCESS_LOG="/var/run/hive-metrics/token-access.jsonl"
 if [[ "${HIVE_CONTRIBUTOR_MODE:-}" != "true" ]]; then
   if [[ -f "$GH_APP_TOKEN_CACHE" ]]; then
     export GH_TOKEN="$(cat "$GH_APP_TOKEN_CACHE")"
   elif [[ -n "${HIVE_GITHUB_TOKEN:-}" ]]; then
     export GH_TOKEN="$HIVE_GITHUB_TOKEN"
   fi
+  printf '{"ts":"%s","agent":"%s","uid":%d,"op":"gh","cmd":"gh %s"}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${HIVE_AGENT:-unknown}" "$(id -u)" "$*" \
+    >> "$TOKEN_ACCESS_LOG" 2>/dev/null || true
 fi
 
 # Contributor mode — extra restrictions for remote contributor agents

--- a/bin/git-credential-hive.sh
+++ b/bin/git-credential-hive.sh
@@ -91,8 +91,13 @@ if [ -z "$TOKEN" ]; then
   exit 1
 fi
 
+TOKEN_ACCESS_LOG="/var/run/hive-metrics/token-access.jsonl"
+
 case "${1:-}" in
   get)
+    printf '{"ts":"%s","agent":"%s","uid":%d,"op":"git-credential"}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${AGENT:-unknown}" "$(id -u)" \
+      >> "$TOKEN_ACCESS_LOG" 2>/dev/null || true
     echo "protocol=https"
     echo "host=github.com"
     echo "username=x-access-token"

--- a/bin/hive-config.sh
+++ b/bin/hive-config.sh
@@ -156,14 +156,15 @@ if [[ -f "$_HIVE_CONFIG" ]]; then
   GH_APP_INSTALLATION_ID=$(_hive_read "github_app.installation_id" "")
   GH_APP_KEY_FILE=$(_hive_read "github_app.private_key_file" "/etc/hive/gh-app-key.pem")
   export GH_APP_ID GH_APP_INSTALLATION_ID GH_APP_KEY_FILE
+  GH_APP_TOKEN_CACHE="/var/run/hive-metrics/gh-app-token.cache"
   if [[ -n "$GH_APP_ID" && -n "$GH_APP_INSTALLATION_ID" && -f "$GH_APP_KEY_FILE" ]]; then
     _app_token_script="${HIVE_BIN:-/usr/local/bin}/gh-app-token.sh"
     if [[ -x "$_app_token_script" ]]; then
-      HIVE_GITHUB_TOKEN=$("$_app_token_script" 2>/dev/null || true)
-      if [[ -n "$HIVE_GITHUB_TOKEN" ]]; then
-        export HIVE_GITHUB_TOKEN
-        export GH_TOKEN="$HIVE_GITHUB_TOKEN"
-      fi
+      "$_app_token_script" >/dev/null 2>&1 || true
+    fi
+    if [[ -f "$GH_APP_TOKEN_CACHE" ]]; then
+      HIVE_GITHUB_TOKEN=$(cat "$GH_APP_TOKEN_CACHE" 2>/dev/null || true)
+      [[ -n "$HIVE_GITHUB_TOKEN" ]] && export HIVE_GITHUB_TOKEN
     fi
   fi
 

--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -74,6 +74,10 @@ else
   fi
 fi
 
+# ── Cleanup stale stderr logs from previous agent launches ────────────
+STDERR_LOG_MAX_AGE_MINUTES=60
+find /tmp -maxdepth 1 -name '.hive-launch-stderr-*.log' -mmin +"$STDERR_LOG_MAX_AGE_MINUTES" -delete 2>/dev/null || true
+
 # ── Root-only setup (runs once, then re-execs as dev) ──────────────────
 if [ "$(id -u)" = "0" ]; then
   # Fix ownership of mounted volumes (may be root-owned from host bind mounts).
@@ -202,11 +206,10 @@ if [ "$(id -u)" = "0" ]; then
   echo "[entrypoint] polling perm guard active (config.json 5s, cache 5m)"
   echo "[entrypoint] CLI config: /data/home (shared, group-writable for agent UIDs)"
 
-  # Write .bashrc so agent shells auto-source GH_TOKEN and SSL_CERT_FILE
-  # without needing credential instructions in the kick prompt.
+  # Write .bashrc for agent shells. GH_TOKEN is NOT exported here — gh-wrapper.sh
+  # injects the token at call time, avoiding exposure in shell env / transcripts.
   cat > /data/home/.bashrc <<'BASHRC' 2>/dev/null || true
 # Hive agent shell environment
-export GH_TOKEN=$(cat /var/run/hive-metrics/gh-app-token.cache 2>/dev/null)
 export SSL_CERT_FILE=/data/proxy-ca.pem
 BASHRC
   chmod 644 /data/home/.bashrc 2>/dev/null || true

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -54,6 +54,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("POST /api/restart/{agent}", s.handleRestart)
 	s.mux.HandleFunc("POST /api/reset-restarts/{agent}", s.handleResetRestarts)
 
+	s.mux.HandleFunc("GET /api/token-access", s.handleTokenAccess)
 	s.mux.HandleFunc("GET /api/tokens", s.handleTokens)
 	s.mux.HandleFunc("GET /api/issue-costs", s.handleIssueCosts)
 	s.mux.HandleFunc("GET /api/model-advisor", s.handleModelAdvisor)
@@ -1112,6 +1113,34 @@ func (s *Server) handleResetRestarts(w http.ResponseWriter, r *http.Request) {
 	s.deps.Logger.Info("audit: restart count reset", "agent", name, "trigger", "dashboard-api")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "reset", "agent": name})
+}
+
+// --- Token access audit log ---
+
+const (
+	tokenAccessLogPath    = "/var/run/hive-metrics/token-access.jsonl"
+	tokenAccessMaxEntries = 100
+)
+
+func (s *Server) handleTokenAccess(w http.ResponseWriter, r *http.Request) {
+	data, err := os.ReadFile(tokenAccessLogPath)
+	if err != nil {
+		jsonResponse(w, map[string]interface{}{"entries": []interface{}{}, "error": "no audit log"})
+		return
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	start := 0
+	if len(lines) > tokenAccessMaxEntries {
+		start = len(lines) - tokenAccessMaxEntries
+	}
+	entries := make([]json.RawMessage, 0, len(lines)-start)
+	for _, line := range lines[start:] {
+		if line == "" {
+			continue
+		}
+		entries = append(entries, json.RawMessage(line))
+	}
+	jsonResponse(w, map[string]interface{}{"entries": entries})
 }
 
 // --- Token endpoints ---


### PR DESCRIPTION
## Summary
- **Remove token echoing**: Stop exporting `GH_TOKEN` via `.bashrc` and `hive-config.sh` — `gh-wrapper.sh` already injects the token at call time, making these redundant exposure paths. Remove `--export` flag and raw token echo from `gh-app-token.sh`; callers now read the cache file directly.
- **Log scrubbing**: Add `scrub_tokens()` filter to `agent-launch.sh` stderr capture to redact GitHub token patterns (`ghs_`/`ghp_`/`gho_`/`github_pat_`) and JWTs before writing to disk. Auto-cleanup stale stderr logs at container startup.
- **Audit logging**: Add token access audit trail to `gh-wrapper.sh` and `git-credential-hive.sh`, writing JSONL entries to `/var/run/hive-metrics/token-access.jsonl`. New `GET /api/token-access` dashboard endpoint returns the last 100 entries.

## What's NOT changed
- The token injection path (`gh-wrapper.sh` reads the cache file, `git-credential-hive.sh` provides credentials to git) is untouched — agents work exactly as before
- File permissions and per-agent scoped tokens are deferred to a follow-up PR

## Test plan
- [ ] Deploy, verify `.bashrc` has no `GH_TOKEN` line
- [ ] Run `gh-app-token.sh` — stdout should say "token cached", not print the raw token
- [ ] Run `env | grep GH_TOKEN` in fresh agent shell — should be empty
- [ ] Run `gh api rate_limit` as agent — should still work (proves `gh-wrapper.sh` injection is intact)
- [ ] Inject fake token in stderr, verify it appears as `[REDACTED]` in the log file
- [ ] Check `/var/run/hive-metrics/token-access.jsonl` has entries after `gh`/`git` commands
- [ ] Hit `GET /api/token-access` on dashboard