### PR TITLE
Add slog token scrubbing handler

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/advisory"
 	"github.com/kubestellar/hive/v2/pkg/hub"
 	"github.com/kubestellar/hive/v2/pkg/agent"
+	"github.com/kubestellar/hive/v2/pkg/logscrub"
 	"github.com/kubestellar/hive/v2/pkg/beads"
 	"github.com/kubestellar/hive/v2/pkg/classify"
 	"github.com/kubestellar/hive/v2/pkg/config"
@@ -59,7 +60,7 @@ func main() {
 	flag.Parse()
 	dashboard.SetGitVersion(gitHash, gitShort)
 
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger := slog.New(logscrub.NewHandler(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})))
 	slog.SetDefault(logger)
 
 	// Clear stale upgrade marker if the current SHA differs from the marker's

--- a/v2/pkg/logscrub/handler.go
+++ b/v2/pkg/logscrub/handler.go
@@ -1,0 +1,68 @@
+package logscrub
+
+import (
+	"context"
+	"log/slog"
+	"regexp"
+)
+
+var tokenPattern = regexp.MustCompile(
+	`(ghs_|ghp_|gho_|github_pat_)[A-Za-z0-9_]{10,}` +
+		`|eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}`,
+)
+
+const redacted = "[REDACTED]"
+
+// Handler wraps a slog.Handler and redacts GitHub token patterns from string
+// attribute values before forwarding to the inner handler.
+type Handler struct {
+	inner slog.Handler
+}
+
+func NewHandler(inner slog.Handler) *Handler {
+	return &Handler{inner: inner}
+}
+
+func (h *Handler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+func (h *Handler) Handle(ctx context.Context, r slog.Record) error {
+	scrubbed := slog.NewRecord(r.Time, r.Level, scrub(r.Message), r.PC)
+	r.Attrs(func(a slog.Attr) bool {
+		scrubbed.AddAttrs(scrubAttr(a))
+		return true
+	})
+	return h.inner.Handle(ctx, scrubbed)
+}
+
+func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	out := make([]slog.Attr, len(attrs))
+	for i, a := range attrs {
+		out[i] = scrubAttr(a)
+	}
+	return &Handler{inner: h.inner.WithAttrs(out)}
+}
+
+func (h *Handler) WithGroup(name string) slog.Handler {
+	return &Handler{inner: h.inner.WithGroup(name)}
+}
+
+func scrub(s string) string {
+	return tokenPattern.ReplaceAllString(s, redacted)
+}
+
+func scrubAttr(a slog.Attr) slog.Attr {
+	if a.Value.Kind() == slog.KindString {
+		return slog.String(a.Key, scrub(a.Value.String()))
+	}
+	if a.Value.Kind() == slog.KindGroup {
+		attrs := a.Value.Group()
+		out := make([]slog.Attr, len(attrs))
+		for i, ga := range attrs {
+			out[i] = scrubAttr(ga)
+		}
+		return slog.Attr{Key: a.Key, Value: slog.GroupValue(out...)}
+	}
+	return a
+}

--- a/v2/pkg/logscrub/handler_test.go
+++ b/v2/pkg/logscrub/handler_test.go
@@ -1,0 +1,94 @@
+package logscrub
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestScrubsGitHubTokenInMessage(t *testing.T) {
+	var buf bytes.Buffer
+	inner := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	logger := slog.New(NewHandler(inner))
+
+	logger.Info("token is ghs_abc1234567890XYZ")
+	if strings.Contains(buf.String(), "ghs_") {
+		t.Errorf("token not scrubbed from message: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "[REDACTED]") {
+		t.Errorf("expected [REDACTED] in output: %s", buf.String())
+	}
+}
+
+func TestScrubsGitHubTokenInAttr(t *testing.T) {
+	var buf bytes.Buffer
+	inner := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	logger := slog.New(NewHandler(inner))
+
+	logger.Info("auth loaded", "token", "ghp_secretvalue1234567890")
+	if strings.Contains(buf.String(), "ghp_") {
+		t.Errorf("token not scrubbed from attr: %s", buf.String())
+	}
+}
+
+func TestScrubsJWT(t *testing.T) {
+	var buf bytes.Buffer
+	inner := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	logger := slog.New(NewHandler(inner))
+
+	jwt := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MDAwMDAwMDAsImV4cCI6MTYwMDAwMDYwMH0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+	logger.Info("jwt used", "value", jwt)
+	if strings.Contains(buf.String(), "eyJhbGci") {
+		t.Errorf("JWT not scrubbed: %s", buf.String())
+	}
+}
+
+func TestPassesThroughNonSecrets(t *testing.T) {
+	var buf bytes.Buffer
+	inner := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	logger := slog.New(NewHandler(inner))
+
+	logger.Info("normal message", "key", "normal_value", "count", 42)
+	if !strings.Contains(buf.String(), "normal message") {
+		t.Errorf("message was altered: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "normal_value") {
+		t.Errorf("non-secret attr was altered: %s", buf.String())
+	}
+}
+
+func TestScrubsMultiplePatterns(t *testing.T) {
+	var buf bytes.Buffer
+	inner := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	logger := slog.New(NewHandler(inner))
+
+	logger.Info("tokens: gho_oauthtoken12345678 and github_pat_longpersonaltoken1234567890")
+	if strings.Contains(buf.String(), "gho_") || strings.Contains(buf.String(), "github_pat_") {
+		t.Errorf("not all tokens scrubbed: %s", buf.String())
+	}
+}
+
+func TestWithAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	inner := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	logger := slog.New(NewHandler(inner)).With("secret", "ghs_presettoken1234567890")
+
+	logger.Info("test")
+	if strings.Contains(buf.String(), "ghs_") {
+		t.Errorf("token in WithAttrs not scrubbed: %s", buf.String())
+	}
+}
+
+func TestEnabled(t *testing.T) {
+	inner := slog.NewTextHandler(&bytes.Buffer{}, &slog.HandlerOptions{Level: slog.LevelWarn})
+	h := NewHandler(inner)
+
+	if h.Enabled(context.Background(), slog.LevelInfo) {
+		t.Error("should not be enabled for INFO when inner is WARN")
+	}
+	if !h.Enabled(context.Background(), slog.LevelWarn) {
+		t.Error("should be enabled for WARN")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `pkg/logscrub` package with a `slog.Handler` wrapper that redacts GitHub token patterns (`ghs_`/`ghp_`/`gho_`/`github_pat_`) and JWTs from log messages and string attributes
- Wrap the main binary's JSON logger with the scrubbing handler
- 7 unit tests covering message scrubbing, attribute scrubbing, JWT scrubbing, WithAttrs, non-secret passthrough, and level filtering

## What this does
If a token value ever leaks into a `slog.Info/Warn/Error` call (via message text or string attribute), it will be replaced with `[REDACTED]` before reaching stdout/log output. Belt-and-suspenders defense — the Go binary doesn't currently log token values, but this prevents accidental future leaks.

## Test plan
- [x] `go test ./pkg/logscrub/ -v` — all 7 tests pass
- [x] `go build ./cmd/hive/` — compiles clean
- [ ] Deploy and verify logs still emit correctly (no format changes, just scrubbing)