### PR TITLE
fix: update pluk from Go binary to TypeScript npm package

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -17,11 +17,6 @@ RUN GIT_HASH=$(git -C /repo rev-parse HEAD 2>/dev/null || echo "unknown") && \
     GOCACHE=/tmp/gobuild CGO_ENABLED=0 go build -ldflags "-X main.gitHash=${GIT_HASH} -X main.gitShort=${GIT_SHORT} -X main.gitBranch=${GIT_BRANCH}" -o /hive ./cmd/hive && \
     GOCACHE=/tmp/gobuild CGO_ENABLED=0 go build -o /bd ./cmd/bd
 
-# Build pluk (Go binary) in the builder stage — keep config for pattern files
-RUN git clone --depth 1 https://github.com/kubestellar/pluk.git /tmp/pluk && \
-    cd /tmp/pluk && GOCACHE=/tmp/gobuild CGO_ENABLED=0 go build -o /pluk ./cmd/pluk/ && \
-    mkdir -p /pluk-patterns && cp -r /tmp/pluk/config/patterns.d /pluk-patterns/ && \
-    rm -rf /tmp/pluk
 
 # --- tmux from source (cached until TMUX_VERSION changes) ---
 FROM node:24-slim AS tmux-builder
@@ -154,16 +149,11 @@ RUN pip3 install --no-cache-dir --break-system-packages pyyaml 2>/dev/null || \
 RUN pip3 install --no-cache-dir --break-system-packages specify-cli 2>/dev/null || \
     pip3 install --no-cache-dir specify-cli 2>/dev/null || \
     echo "WARN: spec-kit (specify-cli) install failed — inception will generate facts without it"
-# pluk (v3 — Go binary): structured event streaming for AI agent tmux sessions
-COPY --from=builder /pluk /usr/local/bin/pluk
-RUN ln -sf pluk /usr/local/bin/pluk-publish && \
-    ln -sf pluk /usr/local/bin/pluk-subscribe && \
-    ln -sf pluk /usr/local/bin/pluk-send && \
-    mkdir -p /var/run/pluk/logs /var/run/pluk/commands && \
+# pluk (TypeScript): structured event streaming for AI agent tmux sessions
+ARG PLUK_VERSION=0.8.0
+RUN npm install -g @kubestellar/pluk@${PLUK_VERSION} && npm cache clean --force
+RUN mkdir -p /var/run/pluk/logs /var/run/pluk/commands && \
     chmod 1777 /var/run/pluk/logs /var/run/pluk/commands
-# Pattern files from builder stage — no second clone needed
-RUN mkdir -p /usr/local/etc/pluk/patterns.d
-COPY --from=builder /pluk-patterns/patterns.d/ /usr/local/etc/pluk/patterns.d/
 RUN (which git && git clone -b feat/cli-agent-mode https://github.com/clubanderson/agentic-strategy-evolution /opt/nous && \
     python3 -m venv /opt/nous/venv && \
     /opt/nous/venv/bin/pip install --no-cache-dir -e /opt/nous 2>&1) || \

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -320,7 +320,7 @@ func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
 
 	// Attach pluk publisher if available — streams structured events
 	// from the agent's tmux output to a JSONL log for subscribers.
-	if plukPath, err := exec.LookPath("pluk-publish"); err == nil {
+	if plukPath, err := exec.LookPath("pluk"); err == nil {
 		_ = os.MkdirAll("/var/run/pluk/logs", 0o1777)
 		_ = os.MkdirAll("/var/run/pluk/commands", 0o1777)
 		backend := agent.Config.Backend
@@ -330,7 +330,7 @@ func (m *Manager) ensureTmuxSession(agent *AgentProcess) error {
 		if backend == "" || IsInferenceBackend(backend) {
 			backend = "claude"
 		}
-		pipePaneCmd := fmt.Sprintf("%s --session %s --cli %s", plukPath, agent.tmuxSession, backend)
+		pipePaneCmd := fmt.Sprintf("%s watch %s --cli=%s", plukPath, agent.tmuxSession, backend)
 		_ = m.tmuxCmd(agent, "pipe-pane", "-t", agent.tmuxSession, "-o", pipePaneCmd).Run()
 		m.logger.Info("pluk publisher attached", "agent", agent.Name, "cli", backend)
 	}

--- a/v2/pkg/dashboard/inception_handlers.go
+++ b/v2/pkg/dashboard/inception_handlers.go
@@ -550,9 +550,9 @@ func (s *Server) sendKickBrainstorm() {
 
 		msg := s.buildStructureKickMessage(state)
 		if err := s.deps.AgentMgr.SendKick("brainstorm", msg); err != nil {
-			s.logger.Warn("sendKick for structure phase failed, trying pluk-send", "error", err)
+			s.logger.Warn("sendKick for structure phase failed, trying pluk send", "error", err)
 			if err2 := plukSendKick("brainstorm", msg); err2 != nil {
-				s.logger.Warn("pluk-send also failed", "error", err2)
+				s.logger.Warn("pluk send also failed", "error", err2)
 			}
 		}
 
@@ -580,23 +580,23 @@ func (s *Server) buildStructureKickMessage(state *knowledge.InceptionState) stri
 	return sb.String()
 }
 
-// plukSendKick sends the inception prompt via pluk's pluk-send command.
-// This is more reliable than tmux send-keys + $(cat file) because pluk-send
+// plukSendKick sends the inception prompt via pluk's send subcommand.
+// This is more reliable than tmux send-keys + $(cat file) because pluk send
 // writes to a named FIFO and confirms delivery via a command_received event.
-// Returns error if pluk-send is not installed or the send fails.
+// Returns error if pluk is not installed or the send fails.
 func plukSendKick(session, message string) error {
-	plukPath, err := exec.LookPath("pluk-send")
+	plukPath, err := exec.LookPath("pluk")
 	if err != nil {
-		return fmt.Errorf("pluk-send not found: %w", err)
+		return fmt.Errorf("pluk not found: %w", err)
 	}
 
 	cmd := exec.Command(plukPath,
-		"--session", "hive-"+session,
-		"--text", message,
+		"send", "hive-"+session,
+		"--text="+message,
 		"--enter",
 	)
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("pluk-send failed: %w (output: %s)", err, string(out))
+		return fmt.Errorf("pluk send failed: %w (output: %s)", err, string(out))
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

The `kubestellar/pluk` repo was rewritten from Go to TypeScript (kubestellar/pluk#10), which broke the hive docker build. The Dockerfile tried to `go build` a repo that no longer has a `go.mod`.

- Install pluk via `npm install -g @kubestellar/pluk` instead of building from Go source
- Update `manager.go` to use `pluk watch` subcommand (replaces `pluk-publish` symlink)
- Update `inception_handlers.go` to use `pluk send` subcommand (replaces `pluk-send` symlink)
- Remove pattern file copy from builder stage (patterns are now bundled in the npm package)

## Test plan

- [ ] Docker build passes in CI
- [ ] Agents can be kicked and pluk events are captured in JSONL logs
- [ ] Inception brainstorm pluk-send kick works via `pluk send` subcommand