### PR TITLE
feat: per-agent scoped GitHub tokens (Phase 2+4)

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -35,7 +35,10 @@ fi
 # Contributors keep their personal token — they fork+PR with their own identity.
 GH_APP_TOKEN_CACHE="/var/run/hive-metrics/gh-app-token.cache"
 if [[ "${HIVE_CONTRIBUTOR_MODE:-}" != "true" ]]; then
-  if [[ -f "$GH_APP_TOKEN_CACHE" ]]; then
+  # Per-agent scoped token (Phase 4) — 0600, owned by agent UID, least-privilege.
+  if [[ -n "${HIVE_AGENT_TOKEN_CACHE:-}" && -f "${HIVE_AGENT_TOKEN_CACHE}" ]]; then
+    export GH_TOKEN="$(cat "$HIVE_AGENT_TOKEN_CACHE")"
+  elif [[ -f "$GH_APP_TOKEN_CACHE" ]]; then
     export GH_TOKEN="$(cat "$GH_APP_TOKEN_CACHE")"
   elif [[ -n "${HIVE_GITHUB_TOKEN:-}" ]]; then
     export GH_TOKEN="$HIVE_GITHUB_TOKEN"

--- a/bin/git-credential-hive.sh
+++ b/bin/git-credential-hive.sh
@@ -75,14 +75,20 @@ refresh_token() {
   fi
 }
 
-if [ ! -f "$TOKEN_FILE" ]; then
-  refresh_token
-fi
-
-if [ -f "$TOKEN_FILE" ]; then
-  cache_age=$(( $(date +%s) - $(stat -c %Y "$TOKEN_FILE" 2>/dev/null || echo 0) ))
-  if [ "$cache_age" -gt "$CACHE_MAX_AGE_SECONDS" ]; then
+# Per-agent scoped token takes priority (Phase 4 — least-privilege).
+AGENT_TOKEN_FILE="${HIVE_AGENT_TOKEN_CACHE:-}"
+if [ -n "$AGENT_TOKEN_FILE" ] && [ -f "$AGENT_TOKEN_FILE" ]; then
+  TOKEN_FILE="$AGENT_TOKEN_FILE"
+else
+  if [ ! -f "$TOKEN_FILE" ]; then
     refresh_token
+  fi
+
+  if [ -f "$TOKEN_FILE" ]; then
+    cache_age=$(( $(date +%s) - $(stat -c %Y "$TOKEN_FILE" 2>/dev/null || echo 0) ))
+    if [ "$cache_age" -gt "$CACHE_MAX_AGE_SECONDS" ]; then
+      refresh_token
+    fi
   fi
 fi
 

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -313,6 +313,10 @@ func main() {
 		PolicyDir:  policyDir,
 	}
 	agentMgr := agent.NewManager(cfg.EnabledAgents(), logger, projectCtx)
+	if appAuth != nil {
+		agentMgr.SetAppAuth(appAuth)
+		go agentMgr.StartAgentTokenRefresh(ctx)
+	}
 
 	go agent.StartPermissionsWatcher(logger)
 
@@ -936,6 +940,7 @@ func main() {
 
 			ghClient = newClient
 			appAuth = newAppAuth
+			agentMgr.SetAppAuth(newAppAuth)
 			dashSrv.UpdateGitHubClient(newClient, newAppAuth)
 			logger.Info("github client reinitialized via config API", "app_id", newAppID, "installation_id", newInstallationID)
 
@@ -1452,6 +1457,7 @@ func main() {
 				}
 				ghClient = newClient
 				appAuth = newAppAuth
+				agentMgr.SetAppAuth(newAppAuth)
 				dashSrv.UpdateGitHubClient(newClient, newAppAuth)
 				dashSrv.SetGitHubAppRequired(false)
 				dashSrv.ClearPendingGitHubAppInstall()

--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -87,6 +87,7 @@ if [ "$(id -u)" = "0" ]; then
   chown dev:node /home/dev 2>/dev/null || true
   chown dev:node /etc/hive/hive.yaml 2>/dev/null || true
   mkdir -p /var/run/hive-metrics && chown dev:node /var/run/hive-metrics 2>/dev/null || true
+  mkdir -p /var/run/hive-metrics/agent-tokens && chown dev:node /var/run/hive-metrics/agent-tokens 2>/dev/null || true
 
   # Fix permissions on bind-mounted secret files (host may own them as
   # a different UID with mode 600, making them unreadable by dev/UID 1001)

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
 )
 
 type ProcessState string
@@ -98,9 +99,15 @@ type Manager struct {
 	project          ProjectContext
 	copilotAuthToken string
 	uidMap           *UIDMap
+	appAuth          AppTokenMinter
 
 	inferenceRouteCallback      func(agentName, backend, model string)
 	clearInferenceRouteCallback func(agentName string)
+}
+
+// AppTokenMinter is implemented by github.AppAuth to mint per-agent scoped tokens.
+type AppTokenMinter interface {
+	WriteAgentToken(ctx context.Context, agentName, tier string, agentUID int) error
 }
 
 // IsInferenceBackend returns true if the backend is a self-hosted inference
@@ -119,6 +126,54 @@ func (m *Manager) SetInferenceCallbacks(
 	defer m.mu.Unlock()
 	m.inferenceRouteCallback = setRoute
 	m.clearInferenceRouteCallback = clearRoute
+}
+
+// SetAppAuth injects the GitHub App auth provider for per-agent scoped tokens.
+func (m *Manager) SetAppAuth(auth AppTokenMinter) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.appAuth = auth
+}
+
+const agentTokenRefreshInterval = 40 * time.Minute
+
+// StartAgentTokenRefresh refreshes per-agent scoped tokens for all running
+// agents on a timer. Tokens expire after 1 hour; this refreshes at 40-minute
+// intervals so there's always a valid token on disk.
+func (m *Manager) StartAgentTokenRefresh(ctx context.Context) {
+	ticker := time.NewTicker(agentTokenRefreshInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.refreshAgentTokens(ctx)
+		}
+	}
+}
+
+func (m *Manager) refreshAgentTokens(ctx context.Context) {
+	m.mu.RLock()
+	auth := m.appAuth
+	agents := make([]*AgentProcess, 0, len(m.agents))
+	for _, a := range m.agents {
+		if a.State == StateRunning && a.UID > 0 {
+			agents = append(agents, a)
+		}
+	}
+	m.mu.RUnlock()
+
+	if auth == nil {
+		return
+	}
+
+	for _, a := range agents {
+		tier := m.agentMode(a).TokenTier()
+		if err := auth.WriteAgentToken(ctx, a.Name, tier, a.UID); err != nil {
+			m.logger.Warn("agent token refresh failed", "agent", a.Name, "error", err)
+		}
+	}
 }
 
 func truncateStr(s string, maxRunes int) string {
@@ -246,6 +301,14 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 		} else {
 			agent.State = StatePaused
 			return nil
+		}
+	}
+
+	if m.appAuth != nil && agent.UID > 0 {
+		tier := m.agentMode(agent).TokenTier()
+		if err := m.appAuth.WriteAgentToken(ctx, agent.Name, tier, agent.UID); err != nil {
+			m.logger.Warn("failed to mint per-agent token, agent will use shared cache",
+				"agent", agent.Name, "tier", tier, "error", err)
 		}
 	}
 
@@ -2570,6 +2633,9 @@ func (m *Manager) agentEnvPairs(agent *AgentProcess) []agentEnvPair {
 	}
 	// GIT_SSL_CAINFO only — NOT SSL_CERT_FILE (that breaks Copilot API TLS)
 	vars = append(vars, agentEnvPair{"GIT_SSL_CAINFO", proxyCACertPath, false})
+	if agent.UID > 0 {
+		vars = append(vars, agentEnvPair{"HIVE_AGENT_TOKEN_CACHE", ghpkg.AgentTokenCachePath(agent.Name), false})
+	}
 	if agent.UID > 0 {
 		home := "/data/home"
 		if IsInferenceBackend(backend) {

--- a/v2/pkg/agent/mode.go
+++ b/v2/pkg/agent/mode.go
@@ -72,6 +72,22 @@ func (m AgentMode) CanMerge() bool        { return m >= ModeIssuesPRsMerge }
 func (m AgentMode) CanPush() bool         { return m >= ModeIssuesAndPRs }
 func (m AgentMode) NeedsMCPWrite() bool   { return m >= ModeIssuesOnly }
 
+// TokenTier returns the GitHub App scoped-token tier for this mode.
+func (m AgentMode) TokenTier() string {
+	switch m {
+	case ModeAdvisory:
+		return "advisor"
+	case ModeIssuesOnly:
+		return "newcomer"
+	case ModeIssuesAndPRs:
+		return "contributor"
+	case ModeIssuesPRsMerge:
+		return "trusted"
+	default:
+		return "advisor"
+	}
+}
+
 // ParseAgentMode converts a string like "ADVISORY" to an AgentMode.
 // Accepts "NO_GITHUB" as a legacy alias for ADVISORY.
 func ParseAgentMode(s string) (AgentMode, bool) {

--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -22,6 +22,10 @@ const (
 	TokenCachePath     = "/var/run/hive-metrics/gh-app-token.cache"
 	DocsTokenCachePath = "/var/run/hive-metrics/gh-app-token-docs.cache"
 	tokenCachePerms    = 0o640
+
+	// Per-agent scoped token caches — only the owning agent UID can read.
+	agentTokenCacheDir   = "/var/run/hive-metrics/agent-tokens"
+	agentTokenCachePerms = 0o600
 )
 
 type AppAuth struct {
@@ -186,6 +190,48 @@ func (a *AppAuth) ScopedToken(ctx context.Context, tier string) (string, error) 
 
 	a.logger.Info("scoped token minted", "tier", tier, "expires_at", installToken.GetExpiresAt().Format(time.RFC3339))
 	return installToken.GetToken(), nil
+}
+
+// AgentTokenCachePath returns the per-agent token cache file path.
+func AgentTokenCachePath(agentName string) string {
+	return agentTokenCacheDir + "/gh-token-" + agentName + ".cache"
+}
+
+// WriteAgentToken mints a scoped token for the given tier and writes it
+// to a per-agent cache file owned by agentUID with 0600 perms. The hive
+// binary (UID 1001) creates the file then chowns it to the agent UID so
+// only that agent can read it.
+func (a *AppAuth) WriteAgentToken(ctx context.Context, agentName, tier string, agentUID int) error {
+	token, err := a.ScopedToken(ctx, tier)
+	if err != nil {
+		return fmt.Errorf("minting scoped token for %s: %w", agentName, err)
+	}
+
+	if err := os.MkdirAll(agentTokenCacheDir, 0o755); err != nil {
+		return fmt.Errorf("creating agent token dir: %w", err)
+	}
+
+	cachePath := AgentTokenCachePath(agentName)
+	tmpPath := cachePath + ".tmp"
+	if err := os.WriteFile(tmpPath, []byte(token), agentTokenCachePerms); err != nil {
+		return fmt.Errorf("writing agent token cache: %w", err)
+	}
+
+	if agentUID > 0 {
+		if err := os.Chown(tmpPath, agentUID, -1); err != nil {
+			a.logger.Warn("chown agent token cache failed — agent will use shared cache",
+				"agent", agentName, "uid", agentUID, "error", err)
+			os.Remove(tmpPath)
+			return fmt.Errorf("chown agent token: %w", err)
+		}
+	}
+
+	if err := os.Rename(tmpPath, cachePath); err != nil {
+		return fmt.Errorf("rename agent token cache: %w", err)
+	}
+
+	a.logger.Info("per-agent token cached", "agent", agentName, "tier", tier, "uid", agentUID)
+	return nil
 }
 
 type appTransport struct {


### PR DESCRIPTION
## Summary

- Each agent gets a **scoped GitHub App token** with only the permissions its mode requires:
  - `advisor` (read-only) for advisory agents
  - `newcomer` (issues:write) for issues-only agents  
  - `contributor` (issues+contents+PRs:write) for PR-capable agents
  - `trusted` (contributor + checks:read) for auto-merge agents
- Per-agent token cache files at `/var/run/hive-metrics/agent-tokens/gh-token-<name>.cache` with **0600 perms** chowned to each agent's UID — agents can only read their own token
- `gh-wrapper.sh` and `git-credential-hive.sh` prefer the per-agent cache, falling back to the shared full-permission cache
- 40-minute refresh goroutine keeps tokens valid (they expire after 1 hour)
- Graceful fallback — if scoped token minting fails, agents use the shared cache as before

## Files Changed

| File | Change |
|------|--------|
| `v2/pkg/github/app.go` | `AgentTokenCachePath()`, `WriteAgentToken()` — mint scoped token + write per-agent cache with chown |
| `v2/pkg/agent/mode.go` | `TokenTier()` — maps AgentMode to GitHub App token tier |
| `v2/pkg/agent/manager.go` | `AppTokenMinter` interface, `SetAppAuth()`, `StartAgentTokenRefresh()`, token minting in `Start()`, `HIVE_AGENT_TOKEN_CACHE` env var |
| `v2/cmd/hive/main.go` | Wire `SetAppAuth` + start refresh goroutine, update on hot-reload |
| `bin/gh-wrapper.sh` | Prefer `HIVE_AGENT_TOKEN_CACHE` over shared cache |
| `bin/git-credential-hive.sh` | Prefer `HIVE_AGENT_TOKEN_CACHE` over shared cache |
| `v2/deploy/entrypoint.sh` | Create `agent-tokens/` directory |

## Test plan

- [ ] Deploy on v3 test hive, verify agents launch and can run `gh api rate_limit`
- [ ] Check `/var/run/hive-metrics/agent-tokens/` has per-agent files with correct ownership
- [ ] Verify advisory agent gets 403 on `gh pr create` (scoped to read-only)
- [ ] Verify token refresh works after 40 minutes
- [ ] Kill AppAuth (break key file) and verify fallback to shared cache