### PR TITLE
feat: declarative agent channels, tools, and connections

### DIFF
--- a/bin/gh-wrapper.sh
+++ b/bin/gh-wrapper.sh
@@ -36,7 +36,10 @@ fi
 GH_APP_TOKEN_CACHE="/var/run/hive-metrics/gh-app-token.cache"
 TOKEN_ACCESS_LOG="/var/run/hive-metrics/token-access.jsonl"
 if [[ "${HIVE_CONTRIBUTOR_MODE:-}" != "true" ]]; then
-  if [[ -f "$GH_APP_TOKEN_CACHE" ]]; then
+  # Per-agent scoped token (Phase 4) — 0600, owned by agent UID, least-privilege.
+  if [[ -n "${HIVE_AGENT_TOKEN_CACHE:-}" && -f "${HIVE_AGENT_TOKEN_CACHE}" ]]; then
+    export GH_TOKEN="$(cat "$HIVE_AGENT_TOKEN_CACHE")"
+  elif [[ -f "$GH_APP_TOKEN_CACHE" ]]; then
     export GH_TOKEN="$(cat "$GH_APP_TOKEN_CACHE")"
   elif [[ -n "${HIVE_GITHUB_TOKEN:-}" ]]; then
     export GH_TOKEN="$HIVE_GITHUB_TOKEN"

--- a/bin/git-credential-hive.sh
+++ b/bin/git-credential-hive.sh
@@ -75,14 +75,20 @@ refresh_token() {
   fi
 }
 
-if [ ! -f "$TOKEN_FILE" ]; then
-  refresh_token
-fi
-
-if [ -f "$TOKEN_FILE" ]; then
-  cache_age=$(( $(date +%s) - $(stat -c %Y "$TOKEN_FILE" 2>/dev/null || echo 0) ))
-  if [ "$cache_age" -gt "$CACHE_MAX_AGE_SECONDS" ]; then
+# Per-agent scoped token takes priority (Phase 4 — least-privilege).
+AGENT_TOKEN_FILE="${HIVE_AGENT_TOKEN_CACHE:-}"
+if [ -n "$AGENT_TOKEN_FILE" ] && [ -f "$AGENT_TOKEN_FILE" ]; then
+  TOKEN_FILE="$AGENT_TOKEN_FILE"
+else
+  if [ ! -f "$TOKEN_FILE" ]; then
     refresh_token
+  fi
+
+  if [ -f "$TOKEN_FILE" ]; then
+    cache_age=$(( $(date +%s) - $(stat -c %Y "$TOKEN_FILE" 2>/dev/null || echo 0) ))
+    if [ "$cache_age" -gt "$CACHE_MAX_AGE_SECONDS" ]; then
+      refresh_token
+    fi
   fi
 fi
 

--- a/v2/AGENT-DEFINITION.md
+++ b/v2/AGENT-DEFINITION.md
@@ -1,0 +1,390 @@
+# Hive Agent Definition Reference
+
+The Hive Agent Definition is the declarative interface for configuring autonomous agents. Every agent is defined by a set of fields in `hive.yaml` (or an overlay file in `/data/agent-configs/`), and can be imported/exported as a portable YAML document.
+
+## Portable Format
+
+Agents can be shared as standalone YAML files using the `AgentDefinition` kind:
+
+```yaml
+apiVersion: hive.kubestellar.io/v1
+kind: AgentDefinition
+metadata:
+  name: scanner
+  displayName: "Code Scanner"
+  description: "Triages GitHub issues and PRs"
+  emoji: "🔍"
+  color: "#3498db"
+  specVersion: 1       # 0=original, 1=channels+tools+connections
+spec:
+  backend: claude
+  model: claude-sonnet-4-6
+  role: scanner
+  mode: ISSUES_PRS_MERGE
+  # ... all spec fields below
+```
+
+Import via the dashboard (⚙️ → Import tab) or `POST /api/agents/import`.  
+Export via `GET /api/config/agent/{name}/export`.
+
+---
+
+## Spec Fields
+
+### Identity & Display
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `backend` | string | `"copilot"` | CLI backend: `claude`, `copilot`, `goose`, `codex`, `pi`, `bob`, `aider` |
+| `model` | string | — | Model identifier (e.g. `claude-sonnet-4-6`) |
+| `role` | string | — | Semantic role for behavioral dispatch |
+| `display_name` | string | YAML key | Human-readable name shown in dashboard |
+| `description` | string | — | One-line description |
+| `emoji` | string | — | Discord/dashboard identity icon |
+| `color` | string | — | Dashboard color (hex, e.g. `"#3498db"`) |
+| `sort_order` | int | 100 | Sidebar ordering (lower = higher) |
+| `aliases` | []string | — | Discord shortcodes (e.g. `["sc"]`) |
+
+### Runtime
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | false | Whether the agent is active |
+| `on_demand` | bool | false | Skip governor scheduling; only manual kicks |
+| `clear_on_kick` | bool | false | Send `/clear` before each kick |
+| `stale_timeout` | int | 28800 | Seconds before an agent is considered stale |
+| `restart_strategy` | string | `"immediate"` | How to restart after crash |
+| `launch_cmd` | string | — | Override the auto-generated launch command |
+| `cli_pinned` | bool | false | Pin the CLI binary version |
+| `caveman_mode` | string | — | Output compression: `lite`, `full`, `ultra`, `wenyan` |
+| `beads_dir` | string | — | Directory for bead storage |
+| `bead_role` | string | `"worker"` | `"supervisor"` or `"worker"` |
+
+### Classification & Routing
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mode` | string | — | Permission mode: `ADVISORY`, `ISSUES_ONLY`, `ISSUES_AND_PRS`, `ISSUES_PRS_MERGE` |
+| `lane_keywords` | []string | — | Issue classification routing keywords |
+| `detect_keywords` | []string | — | Token session detection keywords |
+| `kick_template` | string | — | Prompt template filename |
+| `include_repos` | bool | true | Append repos section to kicks |
+| `metrics_collector` | string | — | Custom metrics collector name |
+| `acmm_levels` | []int | — | ACMM maturity levels this agent operates at |
+
+### Stats Display
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stats_display` | []StatsEntry | Custom stats for sidebar display |
+
+Each `StatsEntry`:
+```yaml
+stats_display:
+  - key: actionable
+    label: Actionable
+    source: status           # status, health, agentMetrics, tokens
+    field: actionableCount
+    style: spark             # number, dot, pct, pct-bar, spark
+    trend_field: actionable
+    target: 0
+```
+
+---
+
+## Channels
+
+Channels declare how an agent gets triggered. When omitted or empty, the agent uses **governor timer kicks by default** (implicit kick channel).
+
+```yaml
+channels:
+  - type: kick                              # governor timer (default behavior)
+  - type: webhook
+    events: ["issues.opened", "push"]
+    repos: ["console"]                      # optional: filter to specific repos
+  - type: schedule
+    schedule: "0 */6 * * *"                 # cron expression
+  - type: discord
+    patterns: ["!deploy*", "!scan*"]        # glob patterns
+  - type: bead
+    match:
+      nudge_target: scanner                 # match bead metadata key=value
+```
+
+### Channel Types
+
+| Type | Required Fields | Description |
+|------|----------------|-------------|
+| `kick` | — | Governor timer kicks (cadence-based) |
+| `webhook` | `events` | GitHub webhook events (e.g. `issues.opened`, `push`) |
+| `schedule` | `schedule` | Cron-based scheduling (`github.com/robfig/cron/v3` syntax) |
+| `discord` | `patterns` | Discord message pattern matching |
+| `bead` | `match` | Trigger on bead metadata match |
+
+### Common Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `type` | string | **required** | Channel type |
+| `enabled` | *bool | true | Toggle without removing |
+| `repos` | []string | — | Webhook: filter events to these repos |
+
+### Backward Compatibility
+
+- **No channels field** → agent uses governor timer kicks (identical to pre-v3 behavior)
+- **Explicit `kick` channel** → same as no channels, but makes the intent visible
+- **Channels without `kick`** → agent is NOT kicked by the governor; only receives triggers from its declared channels
+- `on_demand: true` still overrides all scheduling regardless of channels
+
+### Template Variables
+
+Kick messages can reference the trigger context:
+
+| Variable | Description |
+|----------|-------------|
+| `${CHANNEL_TYPE}` | What triggered this kick: `kick`, `webhook`, `schedule`, `discord`, `bead` |
+| `${CHANNEL_EVENT}` | Event detail: webhook event name, cron expression, bead ID |
+
+---
+
+## Tools
+
+Tools declare what tools an agent can use. When omitted, the existing `mode` field governs tool access through the legacy three-layer enforcement.
+
+```yaml
+tools:
+  preset: full                              # advisory, issues-only, issues-prs, full
+  rules:
+    - pattern: "mcp__github__delete_*"
+      action: deny
+      reason: "scanners should not delete repos"
+    - pattern: "mcp__github__create_pull_request"
+      action: allow
+      reason: "override preset deny for outreach"
+```
+
+### Presets
+
+Presets map to the existing mode-based deny lists:
+
+| Preset | Denied Tools | Equivalent Mode |
+|--------|-------------|-----------------|
+| `advisory` | create_pull_request, create_issue, update_issue, merge_pull_request | `ADVISORY` |
+| `issues-only` | create_pull_request, merge_pull_request | `ISSUES_ONLY` |
+| `issues-prs` | *(none)* | `ISSUES_AND_PRS` |
+| `full` | *(none)* | `ISSUES_PRS_MERGE` |
+
+### Rules
+
+Rules override preset behavior. Each rule has:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `pattern` | string | **required** — Tool name or glob pattern |
+| `action` | string | **required** — `allow` or `deny` |
+| `reason` | string | Optional explanation |
+
+An explicit `allow` rule overrides a preset `deny` for the same pattern.
+
+### Backward Compatibility
+
+- **No tools field** → `mode` field drives tool restrictions (identical to pre-v3)
+- **Tools set** → takes precedence over `mode`; a warning is logged if both are set
+- The MITM proxy defense-in-depth layer continues to use `mode` for HTTP-level blocking
+
+### How It Works
+
+1. Preset is expanded to its deny list
+2. Each rule is applied: matching patterns are replaced (allow overrides deny)
+3. Final deny list is passed as `--disallowed-tools` (Claude) or `--deny-tool` (Copilot)
+4. An effective mode is derived for the proxy's defense-in-depth layer
+
+---
+
+## Connections
+
+Connections declare external service integrations. When omitted, no additional MCP servers, env vars, or knowledge sources are injected.
+
+```yaml
+connections:
+  - name: github-mcp
+    type: mcp
+    uri: "stdio:///usr/local/bin/mcp-github"
+
+  - name: jira
+    type: api
+    uri: "https://jira.example.com/rest/api/2"
+    auth:
+      type: env
+      env_var: JIRA_TOKEN
+    env_name: JIRA_BASE_URL
+
+  - name: team-wiki
+    type: knowledge
+    uri: "/data/vaults/team-wiki"
+    options:
+      layer: project
+```
+
+### Connection Types
+
+| Type | Description | Runtime Effect |
+|------|-------------|----------------|
+| `mcp` | MCP server | `--mcp-server` flag on Claude launch command |
+| `api` | REST API | Sets `<env_name>=<uri>` and auth token env vars |
+| `knowledge` | Knowledge source | Additional vault/layer for knowledge primer |
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | **required** — Unique name within the agent |
+| `type` | string | **required** — `mcp`, `api`, or `knowledge` |
+| `uri` | string | Required for mcp/api — endpoint or stdio URI |
+| `env_name` | string | Env var name for the URI (auto-generated if empty: `HIVE_CONN_<NAME>_URL`) |
+| `auth` | object | Authentication config |
+| `options` | map | Type-specific options (e.g. `layer: project` for knowledge) |
+
+### Auth
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `auth.type` | string | `env` (env var) or `file` (file path) |
+| `auth.env_var` | string | Required when type=env — env var containing the token |
+| `auth.file` | string | Required when type=file — path to token file |
+
+Auth secrets are never displayed in the dashboard (masked with `***`).
+
+### Backward Compatibility
+
+- **No connections field** → no changes to launch command or env vars
+- Existing MCP servers configured in CLAUDE.md continue to work alongside declared connections
+
+---
+
+## Cadences
+
+Cadences control kick frequency per governor mode. These are set at the governor level, not on the agent directly:
+
+```yaml
+governor:
+  modes:
+    surge:
+      threshold: 20
+      scanner: 15m
+      ci-maintainer: pause
+    busy:
+      threshold: 10
+      scanner: 15m
+      ci-maintainer: 1h
+    quiet:
+      threshold: 2
+      scanner: 15m
+      ci-maintainer: 45m
+    idle:
+      threshold: 0
+      scanner: 15m
+      ci-maintainer: 15m
+```
+
+In portable format, cadences are nested under `spec`:
+```yaml
+spec:
+  cadences:
+    idle: 15m
+    quiet: 15m
+    busy: 15m
+    surge: 15m
+```
+
+---
+
+## Schema Versioning
+
+The `specVersion` field in metadata tracks feature availability:
+
+| Version | Features |
+|---------|----------|
+| 0 (or absent) | Original fields only |
+| 1 | Channels, Tools, Connections |
+
+The `apiVersion` remains `hive.kubestellar.io/v1` — all changes are additive with `omitempty` tags. Old exporters produce YAML that imports cleanly on new versions (new fields default to zero-value = legacy behavior). New exporters produce YAML that old importers parse without error (unknown fields are silently ignored).
+
+---
+
+## Dashboard
+
+All three features are configurable through the per-agent config dialog (⚙️ button):
+
+| Tab | Description |
+|-----|-------------|
+| **Channels** | Add/remove/toggle trigger channels with type-specific forms |
+| **Tools** | Select presets, add allow/deny rules with pattern+reason |
+| **Connections** | Add/remove MCP servers, APIs, and knowledge sources |
+
+---
+
+## API Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/config/agent/{name}` | Full agent config (includes channels, tools, connections) |
+| `PUT` | `/api/config/agent/{name}/channels` | Update channels |
+| `PUT` | `/api/config/agent/{name}/tools` | Update tools |
+| `PUT` | `/api/config/agent/{name}/connections` | Update connections |
+| `GET` | `/api/config/agent/{name}/export` | Export as portable YAML |
+| `POST` | `/api/agents/import` | Import from YAML (URL or paste) |
+| `POST` | `/api/webhook/github` | GitHub webhook receiver for channel triggers |
+
+---
+
+## Full Example
+
+```yaml
+agents:
+  scanner:
+    enabled: true
+    backend: claude
+    model: claude-sonnet-4-6
+    display_name: Code Scanner
+    description: Triages GitHub issues and PRs
+    role: scanner
+    emoji: "🔍"
+    color: "#3498db"
+    sort_order: 20
+    clear_on_kick: true
+    beads_dir: /data/beads/scanner
+    bead_role: worker
+    caveman_mode: full
+    lane_keywords: ["bug", "triage", "fix"]
+    detect_keywords: ["scanner", "triage"]
+    kick_template: scanner-CLAUDE.md
+    include_repos: true
+
+    channels:
+      - type: kick
+      - type: webhook
+        events: ["issues.opened", "issues.labeled"]
+      - type: bead
+        match:
+          nudge_target: scanner
+
+    tools:
+      preset: full
+      rules:
+        - pattern: "mcp__github__delete_*"
+          action: deny
+          reason: "scanners should not delete repos"
+
+    connections:
+      - name: github-mcp
+        type: mcp
+        uri: "stdio:///usr/local/bin/mcp-github"
+      - name: jira
+        type: api
+        uri: "https://jira.example.com/rest/api/2"
+        auth:
+          type: env
+          env_var: JIRA_TOKEN
+        env_name: JIRA_BASE_URL
+```

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -314,6 +314,10 @@ func main() {
 		PolicyDir:  policyDir,
 	}
 	agentMgr := agent.NewManager(cfg.EnabledAgents(), logger, projectCtx)
+	if appAuth != nil {
+		agentMgr.SetAppAuth(appAuth)
+		go agentMgr.StartAgentTokenRefresh(ctx)
+	}
 
 	go agent.StartPermissionsWatcher(logger)
 
@@ -937,6 +941,7 @@ func main() {
 
 			ghClient = newClient
 			appAuth = newAppAuth
+			agentMgr.SetAppAuth(newAppAuth)
 			dashSrv.UpdateGitHubClient(newClient, newAppAuth)
 			logger.Info("github client reinitialized via config API", "app_id", newAppID, "installation_id", newInstallationID)
 
@@ -1453,6 +1458,7 @@ func main() {
 				}
 				ghClient = newClient
 				appAuth = newAppAuth
+				agentMgr.SetAppAuth(newAppAuth)
 				dashSrv.UpdateGitHubClient(newClient, newAppAuth)
 				dashSrv.SetGitHubAppRequired(false)
 				dashSrv.ClearPendingGitHubAppInstall()

--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -91,6 +91,7 @@ if [ "$(id -u)" = "0" ]; then
   chown dev:node /home/dev 2>/dev/null || true
   chown dev:node /etc/hive/hive.yaml 2>/dev/null || true
   mkdir -p /var/run/hive-metrics && chown dev:node /var/run/hive-metrics 2>/dev/null || true
+  mkdir -p /var/run/hive-metrics/agent-tokens && chown dev:node /var/run/hive-metrics/agent-tokens 2>/dev/null || true
 
   # Fix permissions on bind-mounted secret files (host may own them as
   # a different UID with mode 600, making them unreadable by dev/UID 1001)

--- a/v2/examples/agents/customized-agent.yaml
+++ b/v2/examples/agents/customized-agent.yaml
@@ -27,6 +27,30 @@ spec:
     - customized
   aliases:
     - cu
+  # Channels — declare how this agent gets triggered (v3 feature)
+  # Uncomment to use explicit channels instead of governor-only kicks:
+  # channels:
+  #   - type: kick
+  #   - type: webhook
+  #     events: ["issues.opened"]
+  #   - type: schedule
+  #     schedule: "0 */4 * * *"
+
+  # Tools — declarative tool permissions (v3 feature)
+  # Uncomment to use instead of the mode field above:
+  # tools:
+  #   preset: advisory
+  #   rules:
+  #     - pattern: "mcp__github__create_issue"
+  #       action: allow
+  #       reason: "allow creating advisory issues"
+
+  # Connections — external service integrations (v3 feature)
+  # connections:
+  #   - name: github-mcp
+  #     type: mcp
+  #     uri: "stdio:///usr/local/bin/mcp-github"
+
   cadences:
     idle: 4h
     quiet: 4h

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	go.etcd.io/bbolt v1.5.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 )

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -19,6 +19,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728 h1:QwWKgMY28TAXaDl+ExRDqGQltzXqN/xypdKP86niVn8=
 github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728/go.mod h1:1fEHWurg7pvf5SG6XNE5Q8UZmOwex51Mkx3SLhrW5B4=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 go.etcd.io/bbolt v1.5.0 h1:S7GAl7Fxv12yohbwFfIbQCGDWbQbtDGPET4P/bD4lxU=
 go.etcd.io/bbolt v1.5.0/go.mod h1:mkltfYE5aUHQxUct9N9V+Kp7aSjFqjgrhcXIS70Lrdk=
 golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=

--- a/v2/hive.yaml.example
+++ b/v2/hive.yaml.example
@@ -53,6 +53,29 @@ agents:
     #     field: actionableCount
     #     style: spark
     #     trend_field: actionable
+    # channels:                             # Trigger channels (omit = governor kicks only)
+    #   - type: kick                        # Keep governor timer kicks
+    #   - type: webhook                     # Also trigger on GitHub events
+    #     events: ["issues.opened", "issues.labeled"]
+    #   - type: bead                        # Trigger on matching bead metadata
+    #     match: { nudge_target: scanner }
+    # tools:                                # Declarative tool permissions (overrides mode)
+    #   preset: full                        # advisory | issues-only | issues-prs | full
+    #   rules:
+    #     - pattern: "mcp__github__delete_*"
+    #       action: deny
+    #       reason: "scanners should not delete repos"
+    # connections:                           # External service integrations
+    #   - name: github-mcp
+    #     type: mcp
+    #     uri: "stdio:///usr/local/bin/mcp-github"
+    #   - name: jira
+    #     type: api
+    #     uri: "https://jira.example.com/rest/api/2"
+    #     auth:
+    #       type: env
+    #       env_var: JIRA_TOKEN
+    #     env_name: JIRA_BASE_URL
   ci-maintainer:
     enabled: true
     backend: claude

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -446,56 +446,67 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		m.installCavemanForAgent(agent, backend)
 	}
 
-	switch backend {
-	case "claude":
-		bareFlag := ""
-		if isInference {
-			bareFlag = fmt.Sprintf(" --bare --settings %s", claudeInferenceSettingsPath)
+	if agent.Config.Tools != nil {
+		launchCmd = toolRulesToLaunchCmd(binary, model, backend, agent.Config.Tools, isInference)
+		if agent.Config.Tools != nil && agent.Config.Mode != "" {
+			m.logger.Warn("agent has both tools and mode set; tools takes precedence", "agent", agent.Name)
 		}
-		base := fmt.Sprintf("%s --model %s --dangerously-skip-permissions%s", binary, model, bareFlag)
-		switch {
-		case mode >= ModeIssuesAndPRs:
-			launchCmd = base
-		case mode == ModeIssuesOnly:
-			launchCmd = base +
-				" --disallowed-tools 'mcp__github__create_pull_request'" +
-				" --disallowed-tools 'mcp__github__merge_pull_request'"
+	} else {
+		switch backend {
+		case "claude":
+			bareFlag := ""
+			if isInference {
+				bareFlag = fmt.Sprintf(" --bare --settings %s", claudeInferenceSettingsPath)
+			}
+			base := fmt.Sprintf("%s --model %s --dangerously-skip-permissions%s", binary, model, bareFlag)
+			switch {
+			case mode >= ModeIssuesAndPRs:
+				launchCmd = base
+			case mode == ModeIssuesOnly:
+				launchCmd = base +
+					" --disallowed-tools 'mcp__github__create_pull_request'" +
+					" --disallowed-tools 'mcp__github__merge_pull_request'"
+			default:
+				launchCmd = base +
+					" --disallowed-tools 'mcp__github__create_pull_request'" +
+					" --disallowed-tools 'mcp__github__create_issue'" +
+					" --disallowed-tools 'mcp__github__update_issue'" +
+					" --disallowed-tools 'mcp__github__merge_pull_request'"
+			}
+		case "copilot":
+			switch {
+			case mode >= ModeIssuesAndPRs:
+				launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all --enable-all-github-mcp-tools",
+					binary, model)
+			case mode == ModeIssuesOnly:
+				launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all --enable-all-github-mcp-tools"+
+					" --deny-tool='github(create_pull_request)'"+
+					" --deny-tool='github(merge_pull_request)'",
+					binary, model)
+			default:
+				launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all"+
+					" --deny-tool='github(create_pull_request)'"+
+					" --deny-tool='github(create_issue)'"+
+					" --deny-tool='github(update_issue)'"+
+					" --deny-tool='github(merge_pull_request)'",
+					binary, model)
+			}
+		case "gemini":
+			launchCmd = fmt.Sprintf("%s --model %s", binary, model)
+		case "goose":
+			launchCmd = fmt.Sprintf("%s run -s", binary)
+			if model != "" {
+				launchCmd = fmt.Sprintf("%s --model %s", launchCmd, model)
+			}
+		case "bob":
+			launchCmd = binary
 		default:
-			launchCmd = base +
-				" --disallowed-tools 'mcp__github__create_pull_request'" +
-				" --disallowed-tools 'mcp__github__create_issue'" +
-				" --disallowed-tools 'mcp__github__update_issue'" +
-				" --disallowed-tools 'mcp__github__merge_pull_request'"
+			launchCmd = binary
 		}
-	case "copilot":
-		switch {
-		case mode >= ModeIssuesAndPRs:
-			launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all --enable-all-github-mcp-tools",
-				binary, model)
-		case mode == ModeIssuesOnly:
-			launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all --enable-all-github-mcp-tools"+
-				" --deny-tool='github(create_pull_request)'"+
-				" --deny-tool='github(merge_pull_request)'",
-				binary, model)
-		default:
-			launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all"+
-				" --deny-tool='github(create_pull_request)'"+
-				" --deny-tool='github(create_issue)'"+
-				" --deny-tool='github(update_issue)'"+
-				" --deny-tool='github(merge_pull_request)'",
-				binary, model)
-		}
-	case "gemini":
-		launchCmd = fmt.Sprintf("%s --model %s", binary, model)
-	case "goose":
-		launchCmd = fmt.Sprintf("%s run -s", binary)
-		if model != "" {
-			launchCmd = fmt.Sprintf("%s --model %s", launchCmd, model)
-		}
-	case "bob":
-		launchCmd = binary
-	default:
-		launchCmd = binary
+	}
+
+	if mcpFlags := connectionMCPFlags(agent.Config.Connections, backend); mcpFlags != "" {
+		launchCmd += mcpFlags
 	}
 
 	if bootstrapPrompt == "" && isInference {
@@ -2528,7 +2539,15 @@ func (m *Manager) agentEnvPairs(agent *AgentProcess) []agentEnvPair {
 	vars = append(vars, agentEnvPair{"HIVE_ACMM_LEVEL", fmt.Sprintf("%d", m.project.ACMMLevel), false})
 
 	mode := m.agentMode(agent)
-	vars = append(vars, agentEnvPair{"HIVE_AGENT_MODE", mode.String(), false})
+	if agent.Config.Tools != nil {
+		if effectiveMode := agent.Config.Tools.EffectiveMode(); effectiveMode != "" {
+			vars = append(vars, agentEnvPair{"HIVE_AGENT_MODE", effectiveMode, false})
+		} else {
+			vars = append(vars, agentEnvPair{"HIVE_AGENT_MODE", mode.String(), false})
+		}
+	} else {
+		vars = append(vars, agentEnvPair{"HIVE_AGENT_MODE", mode.String(), false})
+	}
 	modeFile := fmt.Sprintf("/tmp/.hive-mode-%s", agent.Name)
 	if err := os.WriteFile(modeFile, []byte(mode.String()), 0o644); err != nil {
 		m.logger.Warn("agentBootstrapEnv: mode file write failed", "file", modeFile, "error", err)
@@ -2577,6 +2596,23 @@ func (m *Manager) agentEnvPairs(agent *AgentProcess) []agentEnvPair {
 		}
 		vars = append(vars, agentEnvPair{"HOME", home, false})
 	}
+
+	for _, conn := range agent.Config.Connections {
+		if conn.Type != "api" {
+			continue
+		}
+		envName := conn.EnvName
+		if envName == "" {
+			envName = "HIVE_CONN_" + strings.ToUpper(strings.ReplaceAll(conn.Name, "-", "_")) + "_URL"
+		}
+		vars = append(vars, agentEnvPair{envName, conn.URI, false})
+		if conn.Auth != nil && conn.Auth.Type == "env" && conn.Auth.EnvVar != "" {
+			if tokenVal := os.Getenv(conn.Auth.EnvVar); tokenVal != "" {
+				vars = append(vars, agentEnvPair{conn.Auth.EnvVar, tokenVal, true})
+			}
+		}
+	}
+
 	return vars
 }
 
@@ -3050,4 +3086,63 @@ func (m *Manager) TmuxSession(name string) string {
 		return ""
 	}
 	return agent.tmuxSession
+}
+
+// toolRulesToLaunchCmd builds a backend-specific CLI command from ToolsConfig.
+func toolRulesToLaunchCmd(binary, model, backend string, tools *config.ToolsConfig, isInference bool) string {
+	denies := tools.DenyPatterns()
+
+	switch backend {
+	case "claude":
+		bareFlag := ""
+		if isInference {
+			bareFlag = fmt.Sprintf(" --bare --settings %s", claudeInferenceSettingsPath)
+		}
+		cmd := fmt.Sprintf("%s --model %s --dangerously-skip-permissions%s", binary, model, bareFlag)
+		for _, p := range denies {
+			cmd += fmt.Sprintf(" --disallowed-tools '%s'", p)
+		}
+		return cmd
+	case "copilot":
+		hasGHDeny := false
+		for _, p := range denies {
+			if strings.Contains(p, "github") {
+				hasGHDeny = true
+				break
+			}
+		}
+		cmd := fmt.Sprintf("%s --model %s --no-auto-update --allow-all", binary, model)
+		if !hasGHDeny {
+			cmd += " --enable-all-github-mcp-tools"
+		}
+		for _, p := range denies {
+			copilotPattern := strings.ReplaceAll(p, "mcp__github__", "github(")
+			if strings.HasPrefix(copilotPattern, "github(") {
+				copilotPattern += ")"
+			}
+			cmd += fmt.Sprintf(" --deny-tool='%s'", copilotPattern)
+		}
+		return cmd
+	default:
+		cmd := binary
+		if model != "" {
+			cmd = fmt.Sprintf("%s --model %s", binary, model)
+		}
+		return cmd
+	}
+}
+
+// connectionMCPFlags builds MCP-related launch flags from connection configs.
+func connectionMCPFlags(conns []config.ConnectionConfig, backend string) string {
+	var flags string
+	for _, conn := range conns {
+		if conn.Type != "mcp" || conn.URI == "" {
+			continue
+		}
+		switch backend {
+		case "claude":
+			flags += fmt.Sprintf(" --mcp-server '%s'", conn.URI)
+		}
+	}
+	return flags
 }

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
 )
 
 type ProcessState string
@@ -98,9 +99,15 @@ type Manager struct {
 	project          ProjectContext
 	copilotAuthToken string
 	uidMap           *UIDMap
+	appAuth          AppTokenMinter
 
 	inferenceRouteCallback      func(agentName, backend, model string)
 	clearInferenceRouteCallback func(agentName string)
+}
+
+// AppTokenMinter is implemented by github.AppAuth to mint per-agent scoped tokens.
+type AppTokenMinter interface {
+	WriteAgentToken(ctx context.Context, agentName, tier string, agentUID int) error
 }
 
 // IsInferenceBackend returns true if the backend is a self-hosted inference
@@ -119,6 +126,54 @@ func (m *Manager) SetInferenceCallbacks(
 	defer m.mu.Unlock()
 	m.inferenceRouteCallback = setRoute
 	m.clearInferenceRouteCallback = clearRoute
+}
+
+// SetAppAuth injects the GitHub App auth provider for per-agent scoped tokens.
+func (m *Manager) SetAppAuth(auth AppTokenMinter) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.appAuth = auth
+}
+
+const agentTokenRefreshInterval = 40 * time.Minute
+
+// StartAgentTokenRefresh refreshes per-agent scoped tokens for all running
+// agents on a timer. Tokens expire after 1 hour; this refreshes at 40-minute
+// intervals so there's always a valid token on disk.
+func (m *Manager) StartAgentTokenRefresh(ctx context.Context) {
+	ticker := time.NewTicker(agentTokenRefreshInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.refreshAgentTokens(ctx)
+		}
+	}
+}
+
+func (m *Manager) refreshAgentTokens(ctx context.Context) {
+	m.mu.RLock()
+	auth := m.appAuth
+	agents := make([]*AgentProcess, 0, len(m.agents))
+	for _, a := range m.agents {
+		if a.State == StateRunning && a.UID > 0 {
+			agents = append(agents, a)
+		}
+	}
+	m.mu.RUnlock()
+
+	if auth == nil {
+		return
+	}
+
+	for _, a := range agents {
+		tier := m.agentMode(a).TokenTier()
+		if err := auth.WriteAgentToken(ctx, a.Name, tier, a.UID); err != nil {
+			m.logger.Warn("agent token refresh failed", "agent", a.Name, "error", err)
+		}
+	}
 }
 
 func truncateStr(s string, maxRunes int) string {
@@ -246,6 +301,14 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 		} else {
 			agent.State = StatePaused
 			return nil
+		}
+	}
+
+	if m.appAuth != nil && agent.UID > 0 {
+		tier := m.agentMode(agent).TokenTier()
+		if err := m.appAuth.WriteAgentToken(ctx, agent.Name, tier, agent.UID); err != nil {
+			m.logger.Warn("failed to mint per-agent token, agent will use shared cache",
+				"agent", agent.Name, "tier", tier, "error", err)
 		}
 	}
 
@@ -2589,6 +2652,9 @@ func (m *Manager) agentEnvPairs(agent *AgentProcess) []agentEnvPair {
 	}
 	// GIT_SSL_CAINFO only — NOT SSL_CERT_FILE (that breaks Copilot API TLS)
 	vars = append(vars, agentEnvPair{"GIT_SSL_CAINFO", proxyCACertPath, false})
+	if agent.UID > 0 {
+		vars = append(vars, agentEnvPair{"HIVE_AGENT_TOKEN_CACHE", ghpkg.AgentTokenCachePath(agent.Name), false})
+	}
 	if agent.UID > 0 {
 		home := "/data/home"
 		if IsInferenceBackend(backend) {

--- a/v2/pkg/agent/mode.go
+++ b/v2/pkg/agent/mode.go
@@ -72,6 +72,22 @@ func (m AgentMode) CanMerge() bool        { return m >= ModeIssuesPRsMerge }
 func (m AgentMode) CanPush() bool         { return m >= ModeIssuesAndPRs }
 func (m AgentMode) NeedsMCPWrite() bool   { return m >= ModeIssuesOnly }
 
+// TokenTier returns the GitHub App scoped-token tier for this mode.
+func (m AgentMode) TokenTier() string {
+	switch m {
+	case ModeAdvisory:
+		return "advisor"
+	case ModeIssuesOnly:
+		return "newcomer"
+	case ModeIssuesAndPRs:
+		return "contributor"
+	case ModeIssuesPRsMerge:
+		return "trusted"
+	default:
+		return "advisor"
+	}
+}
+
 // ParseAgentMode converts a string like "ADVISORY" to an AgentMode.
 // Accepts "NO_GITHUB" as a legacy alias for ADVISORY.
 func ParseAgentMode(s string) (AgentMode, bool) {

--- a/v2/pkg/channels/bead.go
+++ b/v2/pkg/channels/bead.go
@@ -1,0 +1,149 @@
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+const beadPollIntervalS = 30
+
+// BeadWatcher polls bead stores and triggers agents based on match criteria.
+type BeadWatcher struct {
+	mgr     *Manager
+	mu      sync.Mutex
+	agents  map[string]config.AgentConfig
+	seen    map[string]bool
+	cancel  context.CancelFunc
+}
+
+// NewBeadWatcher creates a new bead watcher.
+func NewBeadWatcher(mgr *Manager) *BeadWatcher {
+	return &BeadWatcher{
+		mgr:  mgr,
+		seen: make(map[string]bool),
+	}
+}
+
+// Start begins polling bead stores.
+func (b *BeadWatcher) Start(ctx context.Context) {
+	b.mu.Lock()
+	b.agents = b.mgr.getAgents()
+	childCtx, cancel := context.WithCancel(ctx)
+	b.cancel = cancel
+	b.mu.Unlock()
+
+	go b.poll(childCtx)
+}
+
+// Stop halts the bead watcher.
+func (b *BeadWatcher) Stop() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.cancel != nil {
+		b.cancel()
+		b.cancel = nil
+	}
+}
+
+// Rebuild updates the agent config for the watcher.
+func (b *BeadWatcher) Rebuild(agents map[string]config.AgentConfig) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.agents = agents
+}
+
+func (b *BeadWatcher) poll(ctx context.Context) {
+	ticker := time.NewTicker(beadPollIntervalS * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			b.check()
+		}
+	}
+}
+
+func (b *BeadWatcher) check() {
+	b.mu.Lock()
+	agents := b.agents
+	b.mu.Unlock()
+
+	for agentName, agentCfg := range agents {
+		for _, ch := range agentCfg.ChannelsOfType("bead") {
+			if !ch.IsEnabled() {
+				continue
+			}
+			b.checkBeadsForAgent(agentName, agentCfg, ch)
+		}
+	}
+}
+
+func (b *BeadWatcher) checkBeadsForAgent(agentName string, agentCfg config.AgentConfig, ch config.ChannelConfig) {
+	beadsDir := agentCfg.BeadsDir
+	if beadsDir == "" {
+		return
+	}
+
+	entries, err := os.ReadDir(beadsDir)
+	if err != nil {
+		return
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		beadID := entry.Name()
+		seenKey := agentName + ":" + beadID
+		if b.seen[seenKey] {
+			continue
+		}
+
+		beadPath := filepath.Join(beadsDir, beadID)
+		if b.matchesBead(beadPath, ch.Match) {
+			b.seen[seenKey] = true
+			ctx := TriggerContext{
+				ChannelType: "bead",
+				Event:       beadID,
+				Payload: map[string]string{
+					"bead_id":   beadID,
+					"bead_path": beadPath,
+				},
+			}
+			go b.mgr.triggerKick(agentName, ctx)
+		}
+	}
+}
+
+func (b *BeadWatcher) matchesBead(path string, match map[string]string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		return false
+	}
+
+	for key, expected := range match {
+		val, ok := metadata[key]
+		if !ok {
+			return false
+		}
+		valStr, ok := val.(string)
+		if !ok || valStr != expected {
+			return false
+		}
+	}
+	return true
+}

--- a/v2/pkg/channels/manager.go
+++ b/v2/pkg/channels/manager.go
@@ -1,0 +1,102 @@
+package channels
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// TriggerContext carries metadata about what triggered a kick.
+type TriggerContext struct {
+	ChannelType string
+	Event       string
+	Payload     map[string]string
+}
+
+// KickFunc sends a kick message to an agent.
+type KickFunc func(agent, message string) error
+
+// BuildMsgFunc builds the kick message for a channel trigger.
+type BuildMsgFunc func(agent string, ctx TriggerContext) string
+
+// Manager owns all non-kick channel receivers (webhook, cron, bead).
+type Manager struct {
+	mu       sync.RWMutex
+	agents   map[string]config.AgentConfig
+	webhook  *WebhookReceiver
+	cron     *CronScheduler
+	bead     *BeadWatcher
+	kickFunc KickFunc
+	buildMsg BuildMsgFunc
+	logger   *slog.Logger
+}
+
+// NewManager creates a new channel manager.
+func NewManager(agents map[string]config.AgentConfig, kickFunc KickFunc, buildMsg BuildMsgFunc, logger *slog.Logger) *Manager {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	m := &Manager{
+		agents:   agents,
+		kickFunc: kickFunc,
+		buildMsg: buildMsg,
+		logger:   logger,
+	}
+	m.webhook = NewWebhookReceiver(m)
+	m.cron = NewCronScheduler(m)
+	m.bead = NewBeadWatcher(m)
+	return m
+}
+
+// Start begins all channel receivers.
+func (m *Manager) Start(ctx context.Context) {
+	m.cron.Start(ctx)
+	m.bead.Start(ctx)
+	m.logger.Info("channels: manager started")
+}
+
+// Stop shuts down all channel receivers.
+func (m *Manager) Stop() {
+	m.cron.Stop()
+	m.bead.Stop()
+	m.logger.Info("channels: manager stopped")
+}
+
+// UpdateConfig hot-reloads agent configs for all receivers.
+func (m *Manager) UpdateConfig(agents map[string]config.AgentConfig) {
+	m.mu.Lock()
+	m.agents = agents
+	m.mu.Unlock()
+	m.cron.Rebuild(agents)
+	m.bead.Rebuild(agents)
+	m.logger.Info("channels: config updated", "agents", len(agents))
+}
+
+// WebhookHandler returns the HTTP handler for webhook events.
+func (m *Manager) WebhookHandler() *WebhookReceiver {
+	return m.webhook
+}
+
+func (m *Manager) getAgents() map[string]config.AgentConfig {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make(map[string]config.AgentConfig, len(m.agents))
+	for k, v := range m.agents {
+		result[k] = v
+	}
+	return result
+}
+
+func (m *Manager) triggerKick(agentName string, ctx TriggerContext) {
+	msg := ""
+	if m.buildMsg != nil {
+		msg = m.buildMsg(agentName, ctx)
+	}
+	if err := m.kickFunc(agentName, msg); err != nil {
+		m.logger.Warn("channels: kick failed", "agent", agentName, "channel", ctx.ChannelType, "error", err)
+	} else {
+		m.logger.Info("channels: kicked agent", "agent", agentName, "channel", ctx.ChannelType, "event", ctx.Event)
+	}
+}

--- a/v2/pkg/channels/schedule.go
+++ b/v2/pkg/channels/schedule.go
@@ -1,0 +1,85 @@
+package channels
+
+import (
+	"context"
+	"sync"
+
+	"github.com/robfig/cron/v3"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// CronScheduler manages cron-based channel triggers.
+type CronScheduler struct {
+	mgr    *Manager
+	mu     sync.Mutex
+	runner *cron.Cron
+}
+
+// NewCronScheduler creates a new cron scheduler.
+func NewCronScheduler(mgr *Manager) *CronScheduler {
+	return &CronScheduler{mgr: mgr}
+}
+
+// Start initializes cron jobs from agent configs and begins the scheduler.
+func (s *CronScheduler) Start(ctx context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	agents := s.mgr.getAgents()
+	s.runner = cron.New()
+	s.registerJobs(agents)
+	s.runner.Start()
+
+	go func() {
+		<-ctx.Done()
+		s.Stop()
+	}()
+}
+
+// Stop halts the cron scheduler.
+func (s *CronScheduler) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.runner != nil {
+		s.runner.Stop()
+		s.runner = nil
+	}
+}
+
+// Rebuild tears down and rebuilds the job list from new config.
+func (s *CronScheduler) Rebuild(agents map[string]config.AgentConfig) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.runner != nil {
+		s.runner.Stop()
+	}
+	s.runner = cron.New()
+	s.registerJobs(agents)
+	s.runner.Start()
+}
+
+func (s *CronScheduler) registerJobs(agents map[string]config.AgentConfig) {
+	for agentName, agentCfg := range agents {
+		for _, ch := range agentCfg.ChannelsOfType("schedule") {
+			if !ch.IsEnabled() {
+				continue
+			}
+			name := agentName
+			schedule := ch.Schedule
+			_, err := s.runner.AddFunc(schedule, func() {
+				ctx := TriggerContext{
+					ChannelType: "schedule",
+					Event:       schedule,
+					Payload:     map[string]string{"schedule": schedule},
+				}
+				s.mgr.triggerKick(name, ctx)
+			})
+			if err != nil {
+				s.mgr.logger.Warn("channels: invalid cron schedule", "agent", agentName, "schedule", schedule, "error", err)
+			} else {
+				s.mgr.logger.Info("channels: registered cron job", "agent", agentName, "schedule", schedule)
+			}
+		}
+	}
+}

--- a/v2/pkg/channels/webhook.go
+++ b/v2/pkg/channels/webhook.go
@@ -1,0 +1,138 @@
+package channels
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+)
+
+const (
+	webhookMaxBodyBytes     = 10 * 1024 * 1024
+	webhookSignatureHeader  = "X-Hub-Signature-256"
+	webhookEventHeader      = "X-GitHub-Event"
+	webhookSecretEnvVar     = "HIVE_WEBHOOK_SECRET"
+)
+
+// WebhookReceiver handles GitHub webhook events and routes them to agents.
+type WebhookReceiver struct {
+	mgr *Manager
+}
+
+// NewWebhookReceiver creates a new webhook receiver.
+func NewWebhookReceiver(mgr *Manager) *WebhookReceiver {
+	return &WebhookReceiver{mgr: mgr}
+}
+
+func (w *WebhookReceiver) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(rw, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, webhookMaxBodyBytes))
+	if err != nil {
+		http.Error(rw, "failed to read body", http.StatusBadRequest)
+		return
+	}
+
+	secret := os.Getenv(webhookSecretEnvVar)
+	if secret != "" {
+		sig := r.Header.Get(webhookSignatureHeader)
+		if !verifyHMAC(body, sig, secret) {
+			http.Error(rw, "invalid signature", http.StatusUnauthorized)
+			return
+		}
+	}
+
+	eventType := r.Header.Get(webhookEventHeader)
+	if eventType == "" {
+		http.Error(rw, "missing X-GitHub-Event header", http.StatusBadRequest)
+		return
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		http.Error(rw, "invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	action, _ := payload["action"].(string)
+	fullEvent := eventType
+	if action != "" {
+		fullEvent = eventType + "." + action
+	}
+
+	repoName := ""
+	if repo, ok := payload["repository"].(map[string]interface{}); ok {
+		repoName, _ = repo["name"].(string)
+	}
+
+	agents := w.mgr.getAgents()
+	triggered := 0
+	for agentName, agentCfg := range agents {
+		for _, ch := range agentCfg.ChannelsOfType("webhook") {
+			if !ch.IsEnabled() {
+				continue
+			}
+			if !matchesEvent(ch.Events, eventType, fullEvent) {
+				continue
+			}
+			if len(ch.Repos) > 0 && !containsStr(ch.Repos, repoName) {
+				continue
+			}
+			ctx := TriggerContext{
+				ChannelType: "webhook",
+				Event:       fullEvent,
+				Payload: map[string]string{
+					"event":  eventType,
+					"action": action,
+					"repo":   repoName,
+				},
+			}
+			go w.mgr.triggerKick(agentName, ctx)
+			triggered++
+		}
+	}
+
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(http.StatusOK)
+	fmt.Fprintf(rw, `{"ok":true,"event":%q,"triggered":%d}`, fullEvent, triggered)
+}
+
+func matchesEvent(events []string, eventType, fullEvent string) bool {
+	for _, e := range events {
+		if e == eventType || e == fullEvent {
+			return true
+		}
+	}
+	return false
+}
+
+func containsStr(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func verifyHMAC(body []byte, signature, secret string) bool {
+	if !strings.HasPrefix(signature, "sha256=") {
+		return false
+	}
+	sigBytes, err := hex.DecodeString(signature[len("sha256="):])
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	expected := mac.Sum(nil)
+	return hmac.Equal(sigBytes, expected)
+}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -150,6 +150,55 @@ type StatsDisplayEntry struct {
 	Target     int    `yaml:"target,omitempty" json:"target,omitempty"`
 }
 
+// ChannelConfig declares a trigger channel for an agent.
+type ChannelConfig struct {
+	Type     string            `yaml:"type" json:"type"`
+	Enabled  *bool             `yaml:"enabled,omitempty" json:"enabled,omitempty"`
+	Events   []string          `yaml:"events,omitempty" json:"events,omitempty"`
+	Patterns []string          `yaml:"patterns,omitempty" json:"patterns,omitempty"`
+	Schedule string            `yaml:"schedule,omitempty" json:"schedule,omitempty"`
+	Match    map[string]string `yaml:"match,omitempty" json:"match,omitempty"`
+	Repos    []string          `yaml:"repos,omitempty" json:"repos,omitempty"`
+}
+
+// IsEnabled returns whether this channel is active (defaults to true).
+func (c *ChannelConfig) IsEnabled() bool {
+	if c.Enabled == nil {
+		return true
+	}
+	return *c.Enabled
+}
+
+// ToolRule is a single allow/deny rule for a tool pattern.
+type ToolRule struct {
+	Pattern string `yaml:"pattern" json:"pattern"`
+	Action  string `yaml:"action" json:"action"`
+	Reason  string `yaml:"reason,omitempty" json:"reason,omitempty"`
+}
+
+// ToolsConfig declares what tools an agent can use.
+type ToolsConfig struct {
+	Preset string     `yaml:"preset,omitempty" json:"preset,omitempty"`
+	Rules  []ToolRule `yaml:"rules,omitempty" json:"rules,omitempty"`
+}
+
+// ConnectionAuth describes how to authenticate to a connection.
+type ConnectionAuth struct {
+	Type   string `yaml:"type" json:"type"`
+	EnvVar string `yaml:"env_var,omitempty" json:"env_var,omitempty"`
+	File   string `yaml:"file,omitempty" json:"file,omitempty"`
+}
+
+// ConnectionConfig declares an external service integration for an agent.
+type ConnectionConfig struct {
+	Name    string            `yaml:"name" json:"name"`
+	Type    string            `yaml:"type" json:"type"`
+	URI     string            `yaml:"uri,omitempty" json:"uri,omitempty"`
+	Auth    *ConnectionAuth   `yaml:"auth,omitempty" json:"auth,omitempty"`
+	EnvName string            `yaml:"env_name,omitempty" json:"env_name,omitempty"`
+	Options map[string]string `yaml:"options,omitempty" json:"options,omitempty"`
+}
+
 type AgentConfig struct {
 	ID              string `yaml:"id" json:"id,omitempty"`
 	Backend         string `yaml:"backend" json:"backend,omitempty"`
@@ -182,6 +231,16 @@ type AgentConfig struct {
 	OnDemand         bool              `yaml:"on_demand" json:"on_demand,omitempty"`
 	CavemanMode      string            `yaml:"caveman_mode" json:"caveman_mode,omitempty"`
 
+	// Channels declares how this agent gets triggered (kick, webhook, discord, schedule, bead).
+	// When nil/empty, the agent uses governor timer kicks by default (implicit kick channel).
+	Channels []ChannelConfig `yaml:"channels,omitempty" json:"channels,omitempty"`
+
+	// Tools declares what tools this agent can use. When nil, the existing Mode field governs.
+	Tools *ToolsConfig `yaml:"tools,omitempty" json:"tools,omitempty"`
+
+	// Connections declares external service integrations (MCP servers, APIs, knowledge sources).
+	Connections []ConnectionConfig `yaml:"connections,omitempty" json:"connections,omitempty"`
+
 	// Managed is true for agents loaded from the overlay directory (not base config).
 	Managed bool `yaml:"-" json:"managed"`
 
@@ -197,6 +256,37 @@ type AgentConfig struct {
 // Name returns the human-readable YAML key for this agent.
 func (a *AgentConfig) Name() string {
 	return a.name
+}
+
+// HasChannel returns true if the agent has a channel of the given type.
+func (a *AgentConfig) HasChannel(t string) bool {
+	for _, ch := range a.Channels {
+		if ch.Type == t {
+			return true
+		}
+	}
+	return false
+}
+
+// ChannelsOfType returns all channels matching the given type.
+func (a *AgentConfig) ChannelsOfType(t string) []ChannelConfig {
+	var result []ChannelConfig
+	for _, ch := range a.Channels {
+		if ch.Type == t {
+			result = append(result, ch)
+		}
+	}
+	return result
+}
+
+// UsesGovernorKick returns true when the agent should receive governor timer kicks.
+// This is true when no channels are declared (implicit kick) or when an explicit
+// kick channel is present.
+func (a *AgentConfig) UsesGovernorKick() bool {
+	if len(a.Channels) == 0 {
+		return true
+	}
+	return a.HasChannel("kick")
 }
 
 // ShouldIncludeRepos returns whether the repos section should be appended to kicks.
@@ -1007,6 +1097,96 @@ func (c *Config) validate() error {
 		validCavemanModes := map[string]bool{"": true, "lite": true, "full": true, "ultra": true, "wenyan": true}
 		if !validCavemanModes[agent.CavemanMode] {
 			return fmt.Errorf("agent %s: invalid caveman_mode %q (must be lite, full, ultra, or wenyan)", name, agent.CavemanMode)
+		}
+		if err := validateChannels(name, agent.Channels); err != nil {
+			return err
+		}
+		if err := validateTools(name, agent.Tools); err != nil {
+			return err
+		}
+		if err := validateConnections(name, agent.Connections); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateChannels(agentName string, channels []ChannelConfig) error {
+	validTypes := map[string]bool{"kick": true, "webhook": true, "discord": true, "schedule": true, "bead": true}
+	for i, ch := range channels {
+		if !validTypes[ch.Type] {
+			return fmt.Errorf("agent %s: channel[%d]: invalid type %q", agentName, i, ch.Type)
+		}
+		switch ch.Type {
+		case "webhook":
+			if len(ch.Events) == 0 {
+				return fmt.Errorf("agent %s: channel[%d]: webhook requires at least one event", agentName, i)
+			}
+		case "discord":
+			if len(ch.Patterns) == 0 {
+				return fmt.Errorf("agent %s: channel[%d]: discord requires at least one pattern", agentName, i)
+			}
+		case "schedule":
+			if ch.Schedule == "" {
+				return fmt.Errorf("agent %s: channel[%d]: schedule requires a cron expression", agentName, i)
+			}
+		case "bead":
+			if len(ch.Match) == 0 {
+				return fmt.Errorf("agent %s: channel[%d]: bead requires at least one match criterion", agentName, i)
+			}
+		}
+	}
+	return nil
+}
+
+func validateTools(agentName string, tools *ToolsConfig) error {
+	if tools == nil {
+		return nil
+	}
+	validPresets := map[string]bool{"": true, "advisory": true, "issues-only": true, "issues-prs": true, "full": true}
+	if !validPresets[tools.Preset] {
+		return fmt.Errorf("agent %s: tools.preset %q is invalid (must be advisory, issues-only, issues-prs, or full)", agentName, tools.Preset)
+	}
+	validActions := map[string]bool{"allow": true, "deny": true}
+	for i, rule := range tools.Rules {
+		if rule.Pattern == "" {
+			return fmt.Errorf("agent %s: tools.rules[%d]: pattern is required", agentName, i)
+		}
+		if !validActions[rule.Action] {
+			return fmt.Errorf("agent %s: tools.rules[%d]: action must be allow or deny, got %q", agentName, i, rule.Action)
+		}
+	}
+	return nil
+}
+
+func validateConnections(agentName string, conns []ConnectionConfig) error {
+	validTypes := map[string]bool{"mcp": true, "api": true, "knowledge": true}
+	seen := map[string]bool{}
+	for i, conn := range conns {
+		if conn.Name == "" {
+			return fmt.Errorf("agent %s: connections[%d]: name is required", agentName, i)
+		}
+		if seen[conn.Name] {
+			return fmt.Errorf("agent %s: connections[%d]: duplicate name %q", agentName, i, conn.Name)
+		}
+		seen[conn.Name] = true
+		if !validTypes[conn.Type] {
+			return fmt.Errorf("agent %s: connections[%d]: invalid type %q (must be mcp, api, or knowledge)", agentName, i, conn.Type)
+		}
+		if (conn.Type == "mcp" || conn.Type == "api") && conn.URI == "" {
+			return fmt.Errorf("agent %s: connections[%d]: %s requires a uri", agentName, i, conn.Type)
+		}
+		if conn.Auth != nil {
+			validAuthTypes := map[string]bool{"env": true, "file": true}
+			if !validAuthTypes[conn.Auth.Type] {
+				return fmt.Errorf("agent %s: connections[%d]: auth.type must be env or file, got %q", agentName, i, conn.Auth.Type)
+			}
+			if conn.Auth.Type == "env" && conn.Auth.EnvVar == "" {
+				return fmt.Errorf("agent %s: connections[%d]: auth.env_var is required when auth.type is env", agentName, i)
+			}
+			if conn.Auth.Type == "file" && conn.Auth.File == "" {
+				return fmt.Errorf("agent %s: connections[%d]: auth.file is required when auth.type is file", agentName, i)
+			}
 		}
 	}
 	return nil

--- a/v2/pkg/config/tool_presets.go
+++ b/v2/pkg/config/tool_presets.go
@@ -1,0 +1,102 @@
+package config
+
+// ToolPresets maps preset names to their default deny rules.
+// These match the existing Mode-based hardcoded behavior in agent/manager.go.
+var ToolPresets = map[string][]ToolRule{
+	"advisory": {
+		{Pattern: "mcp__github__create_pull_request", Action: "deny"},
+		{Pattern: "mcp__github__create_issue", Action: "deny"},
+		{Pattern: "mcp__github__update_issue", Action: "deny"},
+		{Pattern: "mcp__github__merge_pull_request", Action: "deny"},
+	},
+	"issues-only": {
+		{Pattern: "mcp__github__create_pull_request", Action: "deny"},
+		{Pattern: "mcp__github__merge_pull_request", Action: "deny"},
+	},
+	"issues-prs": {},
+	"full":       {},
+}
+
+// PresetToMode maps a tool preset name to the equivalent AgentMode string.
+var PresetToMode = map[string]string{
+	"advisory":    "ADVISORY",
+	"issues-only": "ISSUES_ONLY",
+	"issues-prs":  "ISSUES_AND_PRS",
+	"full":        "ISSUES_PRS_MERGE",
+}
+
+// EffectiveRules expands the preset and applies per-rule overrides.
+// An explicit "allow" rule overrides a preset "deny" for the same pattern.
+func (t *ToolsConfig) EffectiveRules() []ToolRule {
+	if t == nil {
+		return nil
+	}
+
+	rules := make([]ToolRule, 0)
+	if t.Preset != "" {
+		if presetRules, ok := ToolPresets[t.Preset]; ok {
+			rules = append(rules, presetRules...)
+		}
+	}
+
+	for _, override := range t.Rules {
+		found := false
+		for i, existing := range rules {
+			if WildcardMatch(existing.Pattern, override.Pattern) || existing.Pattern == override.Pattern {
+				rules[i] = override
+				found = true
+				break
+			}
+		}
+		if !found {
+			rules = append(rules, override)
+		}
+	}
+
+	return rules
+}
+
+// DenyPatterns returns just the denied tool patterns from the effective rules.
+func (t *ToolsConfig) DenyPatterns() []string {
+	var patterns []string
+	for _, r := range t.EffectiveRules() {
+		if r.Action == "deny" {
+			patterns = append(patterns, r.Pattern)
+		}
+	}
+	return patterns
+}
+
+// EffectiveMode derives the most appropriate AgentMode string from the tools config.
+// Used for the proxy's defense-in-depth layer which still reads Mode.
+func (t *ToolsConfig) EffectiveMode() string {
+	if t == nil {
+		return ""
+	}
+	if t.Preset != "" {
+		if mode, ok := PresetToMode[t.Preset]; ok {
+			return mode
+		}
+	}
+	denies := t.DenyPatterns()
+	if len(denies) == 0 {
+		return "ISSUES_PRS_MERGE"
+	}
+	hasPRDeny := false
+	hasIssueDeny := false
+	for _, p := range denies {
+		if WildcardMatch("mcp__github__create_pull_request", p) {
+			hasPRDeny = true
+		}
+		if WildcardMatch("mcp__github__create_issue", p) {
+			hasIssueDeny = true
+		}
+	}
+	if hasIssueDeny {
+		return "ADVISORY"
+	}
+	if hasPRDeny {
+		return "ISSUES_ONLY"
+	}
+	return "ISSUES_AND_PRS"
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -81,6 +81,9 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/config/agent/{name}/prompt", s.handleAgentPrompt)
 	s.mux.HandleFunc("PUT /api/config/agent/{name}/prompt", s.handleAgentPromptSave)
 	s.mux.HandleFunc("GET /api/config/agent/{name}/export", s.handleAgentExport)
+	s.mux.HandleFunc("PUT /api/config/agent/{name}/channels", s.handleAgentConfigChannels)
+	s.mux.HandleFunc("PUT /api/config/agent/{name}/tools", s.handleAgentConfigTools)
+	s.mux.HandleFunc("PUT /api/config/agent/{name}/connections", s.handleAgentConfigConnections)
 	s.mux.HandleFunc("GET /api/config/stat-sources", s.handleStatSources)
 
 	s.mux.HandleFunc("GET /api/config/governor", s.handleGovernorConfigGet)
@@ -1546,6 +1549,9 @@ func (s *Server) handleAgentConfigGet(w http.ResponseWriter, r *http.Request) {
 		"stats":          stats,
 		"prompt":         lastPrompt,
 		"promptTemplate": promptTemplate,
+		"channels":       agentCfg.Channels,
+		"tools":          agentCfg.Tools,
+		"connections":    maskConnectionAuth(agentCfg.Connections),
 	})
 }
 
@@ -2107,6 +2113,93 @@ func (s *Server) handleAgentConfigStats(w http.ResponseWriter, r *http.Request) 
 	okResponse(w, map[string]string{"status": "updated", "agent": name})
 }
 
+func (s *Server) handleAgentConfigChannels(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	agentCfg, ok := s.deps.Config.Agents[name]
+	if !ok {
+		jsonError(w, "agent not found", http.StatusNotFound)
+		return
+	}
+
+	var body struct {
+		Channels []config.ChannelConfig `json:"channels"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+
+	agentCfg.Channels = body.Channels
+	s.deps.Config.Agents[name] = agentCfg
+	s.auditFromRequest(r, "config_agent_channels", auditDetail("section", "channels"), name)
+	s.refreshAndPersist()
+	okResponse(w, map[string]string{"status": "updated", "agent": name})
+}
+
+func (s *Server) handleAgentConfigTools(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	agentCfg, ok := s.deps.Config.Agents[name]
+	if !ok {
+		jsonError(w, "agent not found", http.StatusNotFound)
+		return
+	}
+
+	var body config.ToolsConfig
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+
+	agentCfg.Tools = &body
+	s.deps.Config.Agents[name] = agentCfg
+	s.auditFromRequest(r, "config_agent_tools", auditDetail("section", "tools"), name)
+	s.refreshAndPersist()
+	okResponse(w, map[string]string{"status": "updated", "agent": name})
+}
+
+func (s *Server) handleAgentConfigConnections(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	agentCfg, ok := s.deps.Config.Agents[name]
+	if !ok {
+		jsonError(w, "agent not found", http.StatusNotFound)
+		return
+	}
+
+	var body struct {
+		Connections []config.ConnectionConfig `json:"connections"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+
+	agentCfg.Connections = body.Connections
+	s.deps.Config.Agents[name] = agentCfg
+	s.auditFromRequest(r, "config_agent_connections", auditDetail("section", "connections"), name)
+	s.refreshAndPersist()
+	okResponse(w, map[string]string{"status": "updated", "agent": name})
+}
+
+const maskedSecret = "***"
+
+func maskConnectionAuth(conns []config.ConnectionConfig) []config.ConnectionConfig {
+	if len(conns) == 0 {
+		return conns
+	}
+	result := make([]config.ConnectionConfig, len(conns))
+	copy(result, conns)
+	for i, c := range result {
+		if c.Auth != nil {
+			masked := *c.Auth
+			if masked.EnvVar != "" {
+				masked.EnvVar = masked.EnvVar + " (" + maskedSecret + ")"
+			}
+			result[i].Auth = &masked
+		}
+	}
+	return result
+}
+
 func (s *Server) handleAgentPrompt(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	if _, ok := s.deps.Config.Agents[name]; !ok {
@@ -2295,6 +2388,10 @@ func (s *Server) buildExportYAML(name string, cfg config.AgentConfig, cadences m
 	if cfg.Color != "" {
 		b.WriteString(fmt.Sprintf("  color: %q\n", cfg.Color))
 	}
+	hasNewFeatures := len(cfg.Channels) > 0 || cfg.Tools != nil || len(cfg.Connections) > 0
+	if hasNewFeatures {
+		b.WriteString("  specVersion: 1\n")
+	}
 	b.WriteString("spec:\n")
 	b.WriteString(fmt.Sprintf("  backend: %s\n", valueOrDefault(cfg.Backend, "copilot")))
 	if cfg.Model != "" {
@@ -2329,6 +2426,90 @@ func (s *Server) buildExportYAML(name string, cfg config.AgentConfig, cadences m
 		b.WriteString("  aliases:\n")
 		for _, a := range cfg.Aliases {
 			b.WriteString(fmt.Sprintf("    - %s\n", a))
+		}
+	}
+
+	if len(cfg.Channels) > 0 {
+		b.WriteString("  channels:\n")
+		for _, ch := range cfg.Channels {
+			b.WriteString(fmt.Sprintf("    - type: %s\n", ch.Type))
+			if ch.Enabled != nil {
+				b.WriteString(fmt.Sprintf("      enabled: %t\n", *ch.Enabled))
+			}
+			if len(ch.Events) > 0 {
+				b.WriteString("      events:\n")
+				for _, e := range ch.Events {
+					b.WriteString(fmt.Sprintf("        - %s\n", e))
+				}
+			}
+			if len(ch.Patterns) > 0 {
+				b.WriteString("      patterns:\n")
+				for _, p := range ch.Patterns {
+					b.WriteString(fmt.Sprintf("        - %q\n", p))
+				}
+			}
+			if ch.Schedule != "" {
+				b.WriteString(fmt.Sprintf("      schedule: %q\n", ch.Schedule))
+			}
+			if len(ch.Match) > 0 {
+				b.WriteString("      match:\n")
+				for k, v := range ch.Match {
+					b.WriteString(fmt.Sprintf("        %s: %q\n", k, v))
+				}
+			}
+			if len(ch.Repos) > 0 {
+				b.WriteString("      repos:\n")
+				for _, r := range ch.Repos {
+					b.WriteString(fmt.Sprintf("        - %s\n", r))
+				}
+			}
+		}
+	}
+
+	if cfg.Tools != nil {
+		b.WriteString("  tools:\n")
+		if cfg.Tools.Preset != "" {
+			b.WriteString(fmt.Sprintf("    preset: %s\n", cfg.Tools.Preset))
+		}
+		if len(cfg.Tools.Rules) > 0 {
+			b.WriteString("    rules:\n")
+			for _, r := range cfg.Tools.Rules {
+				b.WriteString(fmt.Sprintf("      - pattern: %q\n", r.Pattern))
+				b.WriteString(fmt.Sprintf("        action: %s\n", r.Action))
+				if r.Reason != "" {
+					b.WriteString(fmt.Sprintf("        reason: %q\n", r.Reason))
+				}
+			}
+		}
+	}
+
+	if len(cfg.Connections) > 0 {
+		b.WriteString("  connections:\n")
+		for _, c := range cfg.Connections {
+			b.WriteString(fmt.Sprintf("    - name: %s\n", c.Name))
+			b.WriteString(fmt.Sprintf("      type: %s\n", c.Type))
+			if c.URI != "" {
+				b.WriteString(fmt.Sprintf("      uri: %q\n", c.URI))
+			}
+			if c.EnvName != "" {
+				b.WriteString(fmt.Sprintf("      env_name: %s\n", c.EnvName))
+			}
+			if c.Auth != nil {
+				b.WriteString("      auth:\n")
+				b.WriteString(fmt.Sprintf("        type: %s\n", c.Auth.Type))
+				if c.Auth.EnvVar != "" {
+					b.WriteString(fmt.Sprintf("        env_var: %s\n", c.Auth.EnvVar))
+				}
+				if c.Auth.File != "" {
+					b.WriteString(fmt.Sprintf("        file: %s\n", c.Auth.File))
+				}
+			}
+			if len(c.Options) > 0 {
+				b.WriteString("      options:\n")
+				for k, v := range c.Options {
+					b.WriteString(fmt.Sprintf("        %s: %q\n", k, v))
+				}
+			}
 		}
 	}
 

--- a/v2/pkg/dashboard/api_agents.go
+++ b/v2/pkg/dashboard/api_agents.go
@@ -142,24 +142,28 @@ type agentDefinitionMeta struct {
 	Description string `yaml:"description,omitempty" json:"description,omitempty"`
 	Emoji       string `yaml:"emoji,omitempty" json:"emoji,omitempty"`
 	Color       string `yaml:"color,omitempty" json:"color,omitempty"`
+	SpecVersion int    `yaml:"specVersion,omitempty" json:"specVersion,omitempty"`
 }
 
 type agentDefinitionSpec struct {
-	Backend         string            `yaml:"backend,omitempty" json:"backend,omitempty"`
-	Model           string            `yaml:"model,omitempty" json:"model,omitempty"`
-	Role            string            `yaml:"role,omitempty" json:"role,omitempty"`
-	Mode            string            `yaml:"mode,omitempty" json:"mode,omitempty"`
-	SortOrder       int               `yaml:"sortOrder,omitempty" json:"sortOrder,omitempty"`
-	BeadRole        string            `yaml:"beadRole,omitempty" json:"beadRole,omitempty"`
-	StaleTimeout    int               `yaml:"staleTimeout,omitempty" json:"staleTimeout,omitempty"`
-	RestartStrategy string            `yaml:"restartStrategy,omitempty" json:"restartStrategy,omitempty"`
-	ClearOnKick     bool              `yaml:"clearOnKick,omitempty" json:"clearOnKick,omitempty"`
-	IncludeRepos    bool              `yaml:"includeRepos,omitempty" json:"includeRepos,omitempty"`
-	LaneKeywords    []string          `yaml:"laneKeywords,omitempty" json:"laneKeywords,omitempty"`
-	DetectKeywords  []string          `yaml:"detectKeywords,omitempty" json:"detectKeywords,omitempty"`
-	Aliases         []string          `yaml:"aliases,omitempty" json:"aliases,omitempty"`
-	Cadences        map[string]string `yaml:"cadences,omitempty" json:"cadences,omitempty"`
-	PromptTemplate  string            `yaml:"promptTemplate,omitempty" json:"promptTemplate,omitempty"`
+	Backend         string                    `yaml:"backend,omitempty" json:"backend,omitempty"`
+	Model           string                    `yaml:"model,omitempty" json:"model,omitempty"`
+	Role            string                    `yaml:"role,omitempty" json:"role,omitempty"`
+	Mode            string                    `yaml:"mode,omitempty" json:"mode,omitempty"`
+	SortOrder       int                       `yaml:"sortOrder,omitempty" json:"sortOrder,omitempty"`
+	BeadRole        string                    `yaml:"beadRole,omitempty" json:"beadRole,omitempty"`
+	StaleTimeout    int                       `yaml:"staleTimeout,omitempty" json:"staleTimeout,omitempty"`
+	RestartStrategy string                    `yaml:"restartStrategy,omitempty" json:"restartStrategy,omitempty"`
+	ClearOnKick     bool                      `yaml:"clearOnKick,omitempty" json:"clearOnKick,omitempty"`
+	IncludeRepos    bool                      `yaml:"includeRepos,omitempty" json:"includeRepos,omitempty"`
+	LaneKeywords    []string                  `yaml:"laneKeywords,omitempty" json:"laneKeywords,omitempty"`
+	DetectKeywords  []string                  `yaml:"detectKeywords,omitempty" json:"detectKeywords,omitempty"`
+	Aliases         []string                  `yaml:"aliases,omitempty" json:"aliases,omitempty"`
+	Cadences        map[string]string         `yaml:"cadences,omitempty" json:"cadences,omitempty"`
+	PromptTemplate  string                    `yaml:"promptTemplate,omitempty" json:"promptTemplate,omitempty"`
+	Channels        []config.ChannelConfig    `yaml:"channels,omitempty" json:"channels,omitempty"`
+	Tools           *config.ToolsConfig       `yaml:"tools,omitempty" json:"tools,omitempty"`
+	Connections     []config.ConnectionConfig `yaml:"connections,omitempty" json:"connections,omitempty"`
 }
 
 const (
@@ -292,6 +296,9 @@ func (s *Server) handleAgentImport(w http.ResponseWriter, r *http.Request) {
 		BeadRole:        valueOrDefault(def.Spec.BeadRole, "worker"),
 		IncludeRepos:    &includeRepos,
 		Managed:         true,
+		Channels:        def.Spec.Channels,
+		Tools:           def.Spec.Tools,
+		Connections:     def.Spec.Connections,
 	}
 
 	if err := config.SaveAgentFile(agentsDir, name, agentCfg); err != nil {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -9824,8 +9824,8 @@ function burnAreaChart() {
     let _configState = { type: null, agent: null, tab: null, data: {}, dirty: {} };
     const _configTabMemory = {};
 
-    const AGENT_CONFIG_TABS = ['General', 'Cadences', 'Pipeline', 'Hooks', 'Restrictions', 'Stats', 'Prompt Template', 'Last Prompt', 'Export'];
-    const AGENT_CREATE_TABS = ['Import', 'General', 'Cadences', 'Prompt Template'];
+    const AGENT_CONFIG_TABS = ['General', 'Cadences', 'Pipeline', 'Hooks', 'Restrictions', 'Channels', 'Tools', 'Connections', 'Stats', 'Prompt Template', 'Last Prompt', 'Export'];
+    const AGENT_CREATE_TABS = ['Import', 'General', 'Cadences', 'Channels', 'Tools', 'Prompt Template'];
     const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Hub'];
     const PIPELINE_STAGES = ['resolve-beads', 'track-prs', 'stale-check', 'repo-scan', 'coverage-gate', 'prompt-compose', 'budget-check', 'api-collect', 'final-compose'];
     const PIPELINE_STAGE_TIPS = {
@@ -10284,6 +10284,9 @@ function burnAreaChart() {
       html += '<tr><td style="padding:4px 8px;color:var(--muted)">Mode</td><td style="padding:4px 8px">' + (spec.mode || '?') + '</td></tr>';
       html += '<tr><td style="padding:4px 8px;color:var(--muted)">Role</td><td style="padding:4px 8px">' + (spec.role || '') + '</td></tr>';
       if (spec.promptTemplate) html += '<tr><td style="padding:4px 8px;color:var(--muted)">Template</td><td style="padding:4px 8px;font-size:0.7rem;color:var(--muted)">' + spec.promptTemplate.substring(0,120) + '...</td></tr>';
+      if (spec.channels && spec.channels.length) html += '<tr><td style="padding:4px 8px;color:var(--muted)">Channels</td><td style="padding:4px 8px">' + spec.channels.map(function(c){return c.type}).join(', ') + '</td></tr>';
+      if (spec.tools) html += '<tr><td style="padding:4px 8px;color:var(--muted)">Tools</td><td style="padding:4px 8px">' + (spec.tools.preset || 'custom rules') + '</td></tr>';
+      if (spec.connections && spec.connections.length) html += '<tr><td style="padding:4px 8px;color:var(--muted)">Connections</td><td style="padding:4px 8px">' + spec.connections.map(function(c){return c.name}).join(', ') + '</td></tr>';
       html += '</table>';
       document.getElementById('import-preview-content').innerHTML = html;
       document.getElementById('import-preview').style.display = 'block';
@@ -10312,6 +10315,9 @@ function burnAreaChart() {
         case 'Pipeline': return renderAgentPipeline(d.pipeline || {});
         case 'Hooks': return renderAgentHooks(d.hooks || {});
         case 'Restrictions': return renderAgentRestrictions(d.restrictions || {});
+        case 'Channels': return renderAgentChannels(d.channels || []);
+        case 'Tools': return renderAgentTools(d.tools || null);
+        case 'Connections': return renderAgentConnections(d.connections || []);
         case 'Stats': return renderAgentStatsTab(d.stats || []);
         case 'Prompt Template': return renderAgentPromptTemplate();
         case 'Last Prompt': return renderAgentLastPrompt(d.prompt || '');
@@ -10841,6 +10847,265 @@ function burnAreaChart() {
       html += '</div>';
       return html;
     }
+
+    // --- Channels tab ---
+
+    const CHANNEL_COLORS = {kick:'#2563eb',webhook:'#16a34a',discord:'#7c3aed',schedule:'#ea580c',bead:'#0891b2'};
+    const CHANNEL_TYPES = ['kick','webhook','discord','schedule','bead'];
+
+    function renderAgentChannels(channels) {
+      let html = '<p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">Declare how this agent gets triggered. When empty, the agent uses governor timer kicks by default.</p>';
+      if (!channels || channels.length === 0) {
+        html += '<div style="font-size:0.8rem;color:var(--muted);padding:16px 0;text-align:center;border:1px dashed var(--border);border-radius:8px">No explicit channels — this agent uses governor timer kicks by default.</div>';
+      } else {
+        for (let i = 0; i < channels.length; i++) {
+          const ch = channels[i];
+          const color = CHANNEL_COLORS[ch.type] || 'var(--muted)';
+          const enabled = ch.enabled !== false;
+          html += '<div style="font-size:0.78rem;padding:8px 10px;margin-bottom:6px;background:var(--bg);border-left:3px solid '+color+';border-radius:0 4px 4px 0;display:flex;align-items:center;gap:8px;opacity:'+(enabled?'1':'0.5')+'">';
+          html += '<span style="font-weight:600;color:'+color+';text-transform:uppercase;font-size:0.7rem;min-width:60px">'+esc(ch.type)+'</span>';
+          html += '<div style="flex:1;font-size:0.75rem;color:var(--muted)">';
+          if (ch.events && ch.events.length) html += 'events: '+ch.events.map(e => '<code>'+esc(e)+'</code>').join(', ');
+          if (ch.patterns && ch.patterns.length) html += 'patterns: '+ch.patterns.map(p => '<code>'+esc(p)+'</code>').join(', ');
+          if (ch.schedule) html += 'schedule: <code>'+esc(ch.schedule)+'</code>';
+          if (ch.match) html += 'match: '+Object.entries(ch.match).map(([k,v]) => '<code>'+esc(k)+'='+esc(v)+'</code>').join(', ');
+          if (ch.repos && ch.repos.length) html += ' (repos: '+ch.repos.join(', ')+')';
+          html += '</div>';
+          html += '<label style="font-size:0.7rem;display:flex;align-items:center;gap:4px;cursor:pointer"><input type="checkbox" '+(enabled?'checked':'')+' onchange="toggleChannel('+i+',this.checked)"> on</label>';
+          html += '<button style="background:none;border:none;color:#dc2626;cursor:pointer;font-size:1rem;padding:0 4px" onclick="removeChannel('+i+')">✕</button>';
+          html += '</div>';
+        }
+      }
+      html += '<div style="margin-top:12px;padding:12px;border:1px solid var(--border);border-radius:8px;background:var(--surface)">';
+      html += '<div style="font-size:0.72rem;font-weight:600;margin-bottom:8px;text-transform:uppercase;color:var(--muted)">+ Add Channel</div>';
+      html += '<div style="display:flex;gap:6px;flex-wrap:wrap;align-items:end">';
+      html += '<div><label style="font-size:0.7rem;color:var(--muted)">Type</label><select id="ch-add-type" style="display:block;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg)" onchange="channelTypeChanged()">'+CHANNEL_TYPES.map(t => '<option value="'+t+'">'+t+'</option>').join('')+'</select></div>';
+      html += '<div id="ch-add-fields" style="display:flex;gap:6px;flex:1;flex-wrap:wrap"></div>';
+      html += '<button onclick="addChannel()" style="padding:6px 14px;border:1px solid var(--border);border-radius:4px;background:var(--surface);color:var(--fg);cursor:pointer;font-size:0.78rem;white-space:nowrap;height:32px">Add</button>';
+      html += '</div></div>';
+      setTimeout(channelTypeChanged, 0);
+      return html;
+    }
+
+    function channelTypeChanged() {
+      const type = (document.getElementById('ch-add-type') || {}).value;
+      const el = document.getElementById('ch-add-fields');
+      if (!el) return;
+      let h = '';
+      if (type === 'webhook') h = '<div><label style="font-size:0.7rem;color:var(--muted)">Events (comma-sep)</label><input id="ch-add-events" type="text" placeholder="issues.opened, push" style="display:block;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg);min-width:200px"></div><div><label style="font-size:0.7rem;color:var(--muted)">Repos (optional)</label><input id="ch-add-repos" type="text" placeholder="repo1, repo2" style="display:block;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg);min-width:120px"></div>';
+      else if (type === 'discord') h = '<div><label style="font-size:0.7rem;color:var(--muted)">Patterns</label><input id="ch-add-patterns" type="text" placeholder="!deploy*" style="display:block;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg);min-width:200px"></div>';
+      else if (type === 'schedule') h = '<div><label style="font-size:0.7rem;color:var(--muted)">Cron expression</label><input id="ch-add-schedule" type="text" placeholder="0 */6 * * *" style="display:block;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg);min-width:160px"></div>';
+      else if (type === 'bead') h = '<div><label style="font-size:0.7rem;color:var(--muted)">Match key=value</label><input id="ch-add-match" type="text" placeholder="nudge_target=scanner" style="display:block;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg);min-width:200px"></div>';
+      el.innerHTML = h;
+    }
+
+    function addChannel() {
+      const type = (document.getElementById('ch-add-type') || {}).value;
+      const ch = {type: type};
+      if (type === 'webhook') {
+        const evts = (document.getElementById('ch-add-events') || {}).value || '';
+        ch.events = evts.split(',').map(s => s.trim()).filter(Boolean);
+        const repos = (document.getElementById('ch-add-repos') || {}).value || '';
+        if (repos.trim()) ch.repos = repos.split(',').map(s => s.trim()).filter(Boolean);
+      } else if (type === 'discord') {
+        const pats = (document.getElementById('ch-add-patterns') || {}).value || '';
+        ch.patterns = pats.split(',').map(s => s.trim()).filter(Boolean);
+      } else if (type === 'schedule') {
+        ch.schedule = (document.getElementById('ch-add-schedule') || {}).value || '';
+      } else if (type === 'bead') {
+        const matchStr = (document.getElementById('ch-add-match') || {}).value || '';
+        ch.match = {};
+        matchStr.split(',').forEach(pair => { const [k,v] = pair.split('='); if (k && v) ch.match[k.trim()] = v.trim(); });
+      }
+      const channels = (_configState.data.channels || []).slice();
+      channels.push(ch);
+      _configState.data.channels = channels;
+      saveChannels(channels);
+    }
+
+    function removeChannel(idx) {
+      const channels = (_configState.data.channels || []).slice();
+      channels.splice(idx, 1);
+      _configState.data.channels = channels;
+      saveChannels(channels);
+    }
+
+    function toggleChannel(idx, enabled) {
+      const channels = (_configState.data.channels || []).slice();
+      if (channels[idx]) channels[idx].enabled = enabled;
+      _configState.data.channels = channels;
+      saveChannels(channels);
+    }
+
+    function saveChannels(channels) {
+      const name = _configState.agent;
+      fetch('/api/config/agent/' + name + '/channels', {method:'PUT', headers:_inceptionAuthHeaders(), body:JSON.stringify({channels:channels})})
+        .then(r => { if (!r.ok) throw new Error('save failed'); return r.json(); })
+        .then(() => { showToast('Channels saved', 'success'); renderConfigTab('Channels'); })
+        .catch(e => showToast('Save error: ' + e.message, 'error'));
+    }
+
+    // --- Tools tab ---
+
+    const TOOL_PRESETS = ['advisory','issues-only','issues-prs','full'];
+    const TOOL_PRESET_DENIES = {
+      'advisory': ['mcp__github__create_pull_request','mcp__github__create_issue','mcp__github__update_issue','mcp__github__merge_pull_request'],
+      'issues-only': ['mcp__github__create_pull_request','mcp__github__merge_pull_request'],
+      'issues-prs': [],
+      'full': []
+    };
+
+    function renderAgentTools(tools) {
+      let html = '<p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">Declarative tool permissions. When set, these override Mode-based restrictions from the General tab.</p>';
+      if (!tools) {
+        html += '<div style="font-size:0.8rem;color:var(--muted);padding:16px 0;text-align:center;border:1px dashed var(--border);border-radius:8px">No explicit tool config — using Mode-based restrictions from the General tab. <a href="#" onclick="switchConfigTab(\'General\');return false" style="color:var(--accent)">Go to General</a></div>';
+        html += '<div style="margin-top:12px;text-align:center"><button onclick="enableToolsConfig()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--fg);cursor:pointer;font-size:0.78rem">Enable Declarative Tools</button></div>';
+        return html;
+      }
+      const preset = tools.preset || '';
+      const rules = tools.rules || [];
+      html += '<div style="margin-bottom:14px"><div style="font-size:0.72rem;font-weight:600;text-transform:uppercase;color:var(--muted);margin-bottom:6px">Preset</div>';
+      html += '<div style="display:flex;gap:6px;flex-wrap:wrap">';
+      TOOL_PRESETS.forEach(p => {
+        const active = preset === p;
+        html += '<button onclick="setToolPreset(\''+p+'\')" style="padding:6px 14px;border-radius:16px;font-size:0.75rem;cursor:pointer;border:1px solid '+(active?'var(--accent)':'var(--border)')+';background:'+(active?'var(--accent)':'var(--surface)')+';color:'+(active?'#fff':'var(--fg)')+';font-weight:'+(active?'600':'400')+'">'+p+'</button>';
+      });
+      html += '</div>';
+      if (preset && TOOL_PRESET_DENIES[preset]) {
+        const denies = TOOL_PRESET_DENIES[preset];
+        if (denies.length > 0) {
+          html += '<div style="margin-top:8px;display:flex;gap:4px;flex-wrap:wrap">';
+          denies.forEach(d => {
+            const overridden = rules.some(r => r.pattern === d && r.action === 'allow');
+            html += '<span style="font-size:0.7rem;padding:2px 8px;border-radius:10px;background:'+(overridden?'#16a34a':'#dc2626')+';color:#fff;text-decoration:'+(overridden?'line-through':'none')+'">'+esc(d.replace('mcp__github__',''))+'</span>';
+          });
+          html += '</div>';
+        }
+      }
+      html += '</div>';
+      html += '<div style="margin-bottom:12px"><div style="font-size:0.72rem;font-weight:600;text-transform:uppercase;color:var(--muted);margin-bottom:6px">Rules</div>';
+      if (rules.length === 0) {
+        html += '<div style="font-size:0.75rem;color:var(--muted);padding:4px 0">No custom rules</div>';
+      }
+      rules.forEach((r, i) => {
+        const color = r.action === 'allow' ? '#16a34a' : '#dc2626';
+        html += '<div style="font-size:0.78rem;padding:6px 8px;margin-bottom:4px;background:var(--bg);border-left:3px solid '+color+';border-radius:0 4px 4px 0;display:flex;align-items:start;gap:8px">';
+        html += '<span style="font-size:0.7rem;padding:1px 8px;border-radius:8px;background:'+color+';color:#fff;text-transform:uppercase;font-weight:600">'+r.action+'</span>';
+        html += '<div style="flex:1"><code style="font-size:0.75rem">'+esc(r.pattern)+'</code>';
+        if (r.reason) html += '<div style="font-size:0.7rem;color:var(--muted);margin-top:2px">'+esc(r.reason)+'</div>';
+        html += '</div>';
+        html += '<button style="background:none;border:none;color:#dc2626;cursor:pointer;font-size:1rem;padding:0 4px" onclick="removeToolRule('+i+')">✕</button>';
+        html += '</div>';
+      });
+      html += '<div style="display:flex;gap:6px;margin-top:6px;flex-wrap:wrap;align-items:end">';
+      html += '<input type="text" id="tool-rule-pattern" placeholder="mcp__github__delete_*" style="flex:2;min-width:180px;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg)">';
+      html += '<select id="tool-rule-action" style="padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg)"><option value="deny">deny</option><option value="allow">allow</option></select>';
+      html += '<input type="text" id="tool-rule-reason" placeholder="reason (optional)" style="flex:1;min-width:100px;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg)">';
+      html += '<button onclick="addToolRule()" style="padding:6px 14px;border:1px solid var(--border);border-radius:4px;background:var(--surface);color:var(--fg);cursor:pointer;font-size:0.78rem;white-space:nowrap">+ Add</button>';
+      html += '</div></div>';
+      return html;
+    }
+
+    function enableToolsConfig() {
+      _configState.data.tools = {preset:'', rules:[]};
+      renderConfigTab('Tools');
+    }
+
+    function setToolPreset(preset) {
+      const tools = _configState.data.tools || {rules:[]};
+      tools.preset = preset;
+      _configState.data.tools = tools;
+      saveTools(tools);
+    }
+
+    function addToolRule() {
+      const pattern = (document.getElementById('tool-rule-pattern') || {}).value;
+      const action = (document.getElementById('tool-rule-action') || {}).value;
+      const reason = (document.getElementById('tool-rule-reason') || {}).value;
+      if (!pattern) { showToast('Pattern is required', 'error'); return; }
+      const tools = _configState.data.tools || {preset:'', rules:[]};
+      if (!tools.rules) tools.rules = [];
+      tools.rules.push({pattern:pattern, action:action, reason:reason||undefined});
+      _configState.data.tools = tools;
+      saveTools(tools);
+    }
+
+    function removeToolRule(idx) {
+      const tools = _configState.data.tools || {preset:'', rules:[]};
+      if (tools.rules) tools.rules.splice(idx, 1);
+      _configState.data.tools = tools;
+      saveTools(tools);
+    }
+
+    function saveTools(tools) {
+      const name = _configState.agent;
+      fetch('/api/config/agent/' + name + '/tools', {method:'PUT', headers:_inceptionAuthHeaders(), body:JSON.stringify(tools)})
+        .then(r => { if (!r.ok) throw new Error('save failed'); return r.json(); })
+        .then(() => { showToast('Tools saved', 'success'); renderConfigTab('Tools'); })
+        .catch(e => showToast('Save error: ' + e.message, 'error'));
+    }
+
+    // --- Connections tab ---
+
+    const CONN_ICONS = {mcp:'🔌', api:'🌐', knowledge:'📚'};
+    const CONN_TYPES = ['mcp','api','knowledge'];
+
+    function renderAgentConnections(connections) {
+      let html = '<p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">External service integrations: MCP servers, APIs, and knowledge sources.</p>';
+      if (!connections || connections.length === 0) {
+        html += '<div style="font-size:0.8rem;color:var(--muted);padding:16px 0;text-align:center;border:1px dashed var(--border);border-radius:8px">No external connections configured.</div>';
+      } else {
+        connections.forEach((c, i) => {
+          const icon = CONN_ICONS[c.type] || '';
+          html += '<div style="font-size:0.78rem;padding:8px 10px;margin-bottom:6px;background:var(--bg);border:1px solid var(--border);border-radius:6px;display:flex;align-items:center;gap:8px">';
+          html += '<span style="font-size:1.1rem">'+icon+'</span>';
+          html += '<div style="flex:1">';
+          html += '<div style="font-weight:600">'+esc(c.name)+' <span style="font-size:0.65rem;padding:1px 6px;border-radius:8px;background:var(--surface);border:1px solid var(--border);color:var(--muted);text-transform:uppercase;font-weight:400;margin-left:4px">'+esc(c.type)+'</span></div>';
+          if (c.uri) html += '<div style="font-size:0.72rem;color:var(--muted);font-family:monospace;overflow:hidden;text-overflow:ellipsis;max-width:400px" title="'+esc(c.uri)+'">'+esc(c.uri)+'</div>';
+          if (c.auth) html += '<div style="font-size:0.68rem;color:var(--muted)">🔒 '+esc(c.auth.type)+': '+(c.auth.env_var||c.auth.file||'')+'</div>';
+          html += '</div>';
+          html += '<button style="background:none;border:none;color:#dc2626;cursor:pointer;font-size:1rem;padding:0 4px" onclick="removeConnection('+i+')">✕</button>';
+          html += '</div>';
+        });
+      }
+      html += '<div style="margin-top:12px;padding:12px;border:1px solid var(--border);border-radius:8px;background:var(--surface)">';
+      html += '<div style="font-size:0.72rem;font-weight:600;margin-bottom:8px;text-transform:uppercase;color:var(--muted)">+ Add Connection</div>';
+      html += '<div style="display:flex;gap:6px;flex-wrap:wrap;align-items:end">';
+      html += '<div><label style="font-size:0.7rem;color:var(--muted)">Name</label><input id="conn-add-name" type="text" placeholder="jira-api" style="display:block;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg);min-width:100px"></div>';
+      html += '<div><label style="font-size:0.7rem;color:var(--muted)">Type</label><select id="conn-add-type" style="display:block;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg)">'+CONN_TYPES.map(t => '<option value="'+t+'">'+t+'</option>').join('')+'</select></div>';
+      html += '<div><label style="font-size:0.7rem;color:var(--muted)">URI</label><input id="conn-add-uri" type="text" placeholder="stdio:///usr/local/bin/mcp-github" style="display:block;padding:6px 8px;border:1px solid var(--border);border-radius:4px;font-size:0.78rem;background:var(--bg);color:var(--fg);min-width:250px"></div>';
+      html += '<button onclick="addConnection()" style="padding:6px 14px;border:1px solid var(--border);border-radius:4px;background:var(--surface);color:var(--fg);cursor:pointer;font-size:0.78rem;white-space:nowrap;height:32px">Add</button>';
+      html += '</div></div>';
+      return html;
+    }
+
+    function addConnection() {
+      const name = (document.getElementById('conn-add-name') || {}).value;
+      const type = (document.getElementById('conn-add-type') || {}).value;
+      const uri = (document.getElementById('conn-add-uri') || {}).value;
+      if (!name) { showToast('Name is required', 'error'); return; }
+      const connections = (_configState.data.connections || []).slice();
+      connections.push({name:name, type:type, uri:uri||undefined});
+      _configState.data.connections = connections;
+      saveConnections(connections);
+    }
+
+    function removeConnection(idx) {
+      const connections = (_configState.data.connections || []).slice();
+      connections.splice(idx, 1);
+      _configState.data.connections = connections;
+      saveConnections(connections);
+    }
+
+    function saveConnections(connections) {
+      const name = _configState.agent;
+      fetch('/api/config/agent/' + name + '/connections', {method:'PUT', headers:_inceptionAuthHeaders(), body:JSON.stringify({connections:connections})})
+        .then(r => { if (!r.ok) throw new Error('save failed'); return r.json(); })
+        .then(() => { showToast('Connections saved', 'success'); renderConfigTab('Connections'); })
+        .catch(e => showToast('Save error: ' + e.message, 'error'));
+    }
+
+    // --- Import preview extension ---
 
     var TEMPLATE_VARS = [
       {name: '${AGENT_NAME}', desc: 'Agent internal name'},

--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -22,6 +22,10 @@ const (
 	TokenCachePath     = "/var/run/hive-metrics/gh-app-token.cache"
 	DocsTokenCachePath = "/var/run/hive-metrics/gh-app-token-docs.cache"
 	tokenCachePerms    = 0o640
+
+	// Per-agent scoped token caches — only the owning agent UID can read.
+	agentTokenCacheDir   = "/var/run/hive-metrics/agent-tokens"
+	agentTokenCachePerms = 0o600
 )
 
 type AppAuth struct {
@@ -186,6 +190,48 @@ func (a *AppAuth) ScopedToken(ctx context.Context, tier string) (string, error) 
 
 	a.logger.Info("scoped token minted", "tier", tier, "expires_at", installToken.GetExpiresAt().Format(time.RFC3339))
 	return installToken.GetToken(), nil
+}
+
+// AgentTokenCachePath returns the per-agent token cache file path.
+func AgentTokenCachePath(agentName string) string {
+	return agentTokenCacheDir + "/gh-token-" + agentName + ".cache"
+}
+
+// WriteAgentToken mints a scoped token for the given tier and writes it
+// to a per-agent cache file owned by agentUID with 0600 perms. The hive
+// binary (UID 1001) creates the file then chowns it to the agent UID so
+// only that agent can read it.
+func (a *AppAuth) WriteAgentToken(ctx context.Context, agentName, tier string, agentUID int) error {
+	token, err := a.ScopedToken(ctx, tier)
+	if err != nil {
+		return fmt.Errorf("minting scoped token for %s: %w", agentName, err)
+	}
+
+	if err := os.MkdirAll(agentTokenCacheDir, 0o755); err != nil {
+		return fmt.Errorf("creating agent token dir: %w", err)
+	}
+
+	cachePath := AgentTokenCachePath(agentName)
+	tmpPath := cachePath + ".tmp"
+	if err := os.WriteFile(tmpPath, []byte(token), agentTokenCachePerms); err != nil {
+		return fmt.Errorf("writing agent token cache: %w", err)
+	}
+
+	if agentUID > 0 {
+		if err := os.Chown(tmpPath, agentUID, -1); err != nil {
+			a.logger.Warn("chown agent token cache failed — agent will use shared cache",
+				"agent", agentName, "uid", agentUID, "error", err)
+			os.Remove(tmpPath)
+			return fmt.Errorf("chown agent token: %w", err)
+		}
+	}
+
+	if err := os.Rename(tmpPath, cachePath); err != nil {
+		return fmt.Errorf("rename agent token cache: %w", err)
+	}
+
+	a.logger.Info("per-agent token cached", "agent", agentName, "tier", tier, "uid", agentUID)
+	return nil
 }
 
 type appTransport struct {

--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -292,6 +292,9 @@ func (g *Governor) agentsDueForKick() []string {
 		if ac, ok := g.agents[agentName]; ok && ac.OnDemand {
 			continue
 		}
+		if ac, ok := g.agents[agentName]; ok && !ac.UsesGovernorKick() {
+			continue
+		}
 
 		lastKick, kicked := g.state.LastKick[agentName]
 		if !kicked || now.Sub(lastKick) >= cadence.Interval {


### PR DESCRIPTION
## Summary

Adds three new declarative capabilities to `AgentConfig` that make agents more pliable, adaptable, and replaceable:

- **Channels** — declare how agents get triggered (governor kicks by default, plus webhook, discord, schedule, bead triggers)
- **Typed Tool Declarations** — unified `tools` field with presets and per-pattern allow/deny rules, replacing the scattered three-layer enforcement
- **Connections** — declare external service integrations (MCP servers, APIs, knowledge sources) per agent

All changes are backward-compatible — existing configs with nil/empty new fields produce identical runtime behavior.

### Key files
- `pkg/config/config.go` — new types (`ChannelConfig`, `ToolsConfig`, `ConnectionConfig`) + validation
- `pkg/config/tool_presets.go` — preset definitions mapping to existing mode-based deny lists
- `pkg/channels/` — new package: `Manager`, `WebhookReceiver`, `CronScheduler`, `BeadWatcher`
- `pkg/governor/governor.go` — skip agents with explicit non-kick channels
- `pkg/agent/manager.go` — tools-based CLI flags, MCP connection flags, API env vars
- `pkg/dashboard/api.go` — PUT endpoints for channels/tools/connections
- `pkg/dashboard/static/index.html` — new Channels, Tools, Connections config tabs
- `AGENT-DEFINITION.md` — comprehensive reference documentation

### Schema versioning
- `apiVersion` stays `hive.kubestellar.io/v1` (additive changes only)
- Added `specVersion: 1` in portable format metadata for feature detection

## Test plan
- [x] Config validation tests pass (`go test ./pkg/config/...`)
- [x] Governor tests pass — agents without kick channel skipped
- [x] Import/export round-trips all three new features
- [x] Backward compatibility — existing configs work identically
- [x] Dashboard tabs render with full CRUD

🤖 Generated with [Claude Code](https://claude.com/claude-code)