### PR TITLE
feat: branch selector dropdown on hive version pill

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2548,7 +2548,7 @@ func runHub(logger *slog.Logger) {
 	}
 	logger.Info("starting in HUB mode", "port", port)
 
-	hubSrv := hub.NewHubServer(port, logger, gitShort)
+	hubSrv := hub.NewHubServer(port, logger, gitShort, gitBranch)
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)

--- a/v2/pkg/hub/hub_coverage_boost_test.go
+++ b/v2/pkg/hub/hub_coverage_boost_test.go
@@ -315,7 +315,7 @@ func TestClusterIDForSaaSHive(t *testing.T) {
 // ============================================================
 
 func TestClusterNameForID(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	// The default cluster should exist
 	name := srv.clusterNameForID(defaultClusterID)
 	// It may be empty or "OKE (default)" depending on config
@@ -328,7 +328,7 @@ func TestClusterNameForID(t *testing.T) {
 }
 
 func TestClusterForHive(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	// Default cluster
 	h := &SaaSHive{ID: "test-hive"}
@@ -353,7 +353,7 @@ func TestClusterForHive(t *testing.T) {
 }
 
 func TestHubCluster(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	c := srv.hubCluster()
 	if c == nil {
 		t.Fatal("hubCluster should never return nil")
@@ -433,7 +433,7 @@ func TestValidateGitHubTokenWithMockServer(t *testing.T) {
 	}
 	ghTokenCacheMu.Unlock()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	result := srv.validateGitHubToken("mock-valid")
 	if result != "mockuser" {
 		t.Errorf("expected mockuser, got %q", result)
@@ -499,7 +499,7 @@ func TestGhcrTagExistsWithMock(t *testing.T) {
 // ============================================================
 
 func TestHandleHeartbeatValidPayload(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = "test-secret"
 
 	payload := HeartbeatPayload{
@@ -535,7 +535,7 @@ func TestHandleHeartbeatValidPayload(t *testing.T) {
 }
 
 func TestHandleHeartbeatEmptyHiveID(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = "test-secret"
 
 	payload := `{"hive_id":"","org":"test"}`
@@ -551,7 +551,7 @@ func TestHandleHeartbeatEmptyHiveID(t *testing.T) {
 }
 
 func TestHandleHeartbeatInvalidHiveID(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = "test-secret"
 
 	// sanitizeHeartbeatField strips most chars; use a string that becomes >100 chars of valid chars
@@ -569,7 +569,7 @@ func TestHandleHeartbeatInvalidHiveID(t *testing.T) {
 }
 
 func TestHandleHeartbeatInvalidOrg(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = "test-secret"
 
 	payload := `{"hive_id":"valid-id","org":"bad org name!"}`
@@ -585,7 +585,7 @@ func TestHandleHeartbeatInvalidOrg(t *testing.T) {
 }
 
 func TestHandleHeartbeatInvalidRepo(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = "test-secret"
 
 	// Use a repo name that's >100 chars (too long for isValidName)
@@ -603,7 +603,7 @@ func TestHandleHeartbeatInvalidRepo(t *testing.T) {
 }
 
 func TestHandleHeartbeatInvalidRepoInList(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = "test-secret"
 
 	payload := `{"hive_id":"valid-id","repos":["good-repo","bad repo!"]}`
@@ -619,7 +619,7 @@ func TestHandleHeartbeatInvalidRepoInList(t *testing.T) {
 }
 
 func TestHandleHeartbeatBadDashboardURL(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = "test-secret"
 
 	payload := `{"hive_id":"valid-id","dashboard_url":"ftp://bad-scheme.com"}`
@@ -635,7 +635,7 @@ func TestHandleHeartbeatBadDashboardURL(t *testing.T) {
 }
 
 func TestHandleHeartbeatBadSnapshotURL(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = "test-secret"
 
 	payload := `{"hive_id":"valid-id","snapshot_url":"ftp://bad.com"}`
@@ -651,7 +651,7 @@ func TestHandleHeartbeatBadSnapshotURL(t *testing.T) {
 }
 
 func TestHandleHeartbeatInvalidAgentName(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = "test-secret"
 
 	payload := `{"hive_id":"valid-id","agents":[{"name":"bad agent!","state":"running"}]}`
@@ -667,7 +667,7 @@ func TestHandleHeartbeatInvalidAgentName(t *testing.T) {
 }
 
 func TestHandleHeartbeatInvalidLeaderboardUsername(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = "test-secret"
 
 	payload := `{"hive_id":"valid-id","leaderboard":[{"github_username":"bad user!"}]}`
@@ -683,7 +683,7 @@ func TestHandleHeartbeatInvalidLeaderboardUsername(t *testing.T) {
 }
 
 func TestHandleHeartbeatNoSecretRequired(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	payload := `{"hive_id":"valid-id"}`
@@ -698,7 +698,7 @@ func TestHandleHeartbeatNoSecretRequired(t *testing.T) {
 }
 
 func TestHandleHeartbeatWrongSecret(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = "correct-secret"
 
 	payload := `{"hive_id":"valid-id"}`
@@ -714,7 +714,7 @@ func TestHandleHeartbeatWrongSecret(t *testing.T) {
 }
 
 func TestHandleHeartbeatExistingHive(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// Pre-populate a hive
@@ -741,7 +741,7 @@ func TestHandleHeartbeatExistingHive(t *testing.T) {
 }
 
 func TestHandleHeartbeatLocalHiveType(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	secret := srv.hubSecret
 
 	payload := `{"hive_id":"my-local-hive","hive_type":"local"}`
@@ -773,7 +773,7 @@ func TestHandleHeartbeatLocalHiveType(t *testing.T) {
 }
 
 func TestHandleHeartbeatHostedHiveRejectedWithoutSaaS(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	secret := srv.hubSecret
 
 	// hosted- prefix without SaaS entry should be rejected
@@ -794,7 +794,7 @@ func TestHandleHeartbeatHostedHiveRejectedWithoutSaaS(t *testing.T) {
 // ============================================================
 
 func TestHandleTaskStatusNoAuth(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = "secret"
 
 	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader("{}"))
@@ -808,7 +808,7 @@ func TestHandleTaskStatusNoAuth(t *testing.T) {
 }
 
 func TestHandleTaskStatusValid(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = "secret"
 
 	// Pre-populate a hive in registry
@@ -831,7 +831,7 @@ func TestHandleTaskStatusValid(t *testing.T) {
 }
 
 func TestHandleTaskStatusBadJSON(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = "secret"
 
 	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader("not json"))
@@ -846,7 +846,7 @@ func TestHandleTaskStatusBadJSON(t *testing.T) {
 }
 
 func TestHandleTaskStatusEmptyHiveID(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = "secret"
 
 	req := httptest.NewRequest("POST", "/api/task-status", strings.NewReader(`{"hive_id":""}`))
@@ -861,7 +861,7 @@ func TestHandleTaskStatusEmptyHiveID(t *testing.T) {
 }
 
 func TestHandleTaskStatusOfflineHive(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = "secret"
 
 	srv.mu.Lock()
@@ -886,7 +886,7 @@ func TestHandleTaskStatusOfflineHive(t *testing.T) {
 // ============================================================
 
 func TestHandleRegistryDeleteNoAdmin(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/hub/registry/{id}", srv.handleRegistryDelete)
@@ -901,7 +901,7 @@ func TestHandleRegistryDeleteNoAdmin(t *testing.T) {
 }
 
 func TestHandleRegistryDeleteAsAdmin(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "delete-me", Online: true},
@@ -928,7 +928,7 @@ func TestHandleRegistryDeleteAsAdmin(t *testing.T) {
 }
 
 func TestHandleRegistryDeleteNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/hub/registry/{id}", srv.handleRegistryDelete)
@@ -948,7 +948,7 @@ func TestHandleRegistryDeleteNotFound(t *testing.T) {
 // ============================================================
 
 func TestHandleHubVersionAsAdmin(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "admin-hash")
+	srv := NewHubServer(0, slog.Default(), "admin-hash", "v2")
 
 	req := httptest.NewRequest("GET", "/api/hub/version", nil)
 	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: hubAdminUsername})
@@ -968,7 +968,7 @@ func TestHandleHubVersionAsAdmin(t *testing.T) {
 }
 
 func TestHandleHubVersionNonAdmin(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "user-hash")
+	srv := NewHubServer(0, slog.Default(), "user-hash", "v2")
 
 	req := httptest.NewRequest("GET", "/api/hub/version", nil)
 	w := httptest.NewRecorder()
@@ -988,7 +988,7 @@ func TestHandleHubVersionNonAdmin(t *testing.T) {
 // ============================================================
 
 func TestMergeLeaderboards(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{
@@ -1056,7 +1056,7 @@ func TestMergeLeaderboards(t *testing.T) {
 // ============================================================
 
 func TestHandleRegistryFiltersPrivateHives(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "public-1", IsPublic: true, Online: true, LastHeartbeat: time.Now().Format(time.RFC3339)},
@@ -1083,7 +1083,7 @@ func TestHandleRegistryFiltersPrivateHives(t *testing.T) {
 }
 
 func TestHandleRegistryDedupLocalVsHosted(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	now := time.Now().Format(time.RFC3339)
 	// Use a stale heartbeat (>5min ago) so markStaleHives marks it offline
 	stale := time.Now().Add(-10 * time.Minute).Format(time.RFC3339)
@@ -1114,7 +1114,7 @@ func TestHandleRegistryDedupLocalVsHosted(t *testing.T) {
 // ============================================================
 
 func TestHandleContributeStatusNoHive(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/api/contribute/status", nil)
 	w := httptest.NewRecorder()
@@ -1131,7 +1131,7 @@ func TestHandleContributeStatusNoHive(t *testing.T) {
 }
 
 func TestHandleContributeStatusWithPublicHive(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	now := time.Now().Format(time.RFC3339)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -1158,7 +1158,7 @@ func TestHandleContributeStatusWithPublicHive(t *testing.T) {
 // ============================================================
 
 func TestHandleLatestSHA(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/api/saas/latest-sha", nil)
 	w := httptest.NewRecorder()
@@ -1179,7 +1179,7 @@ func TestHandleLatestSHA(t *testing.T) {
 // ============================================================
 
 func TestHandleAccessDenied(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/access-denied?hive=test-hive", nil)
 	w := httptest.NewRecorder()
@@ -1194,7 +1194,7 @@ func TestHandleAccessDenied(t *testing.T) {
 }
 
 func TestHandleAccessDeniedWithOwner(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "owned-hive", Owner: "owneruser"},
@@ -1219,7 +1219,7 @@ func TestHandleAccessDeniedWithOwner(t *testing.T) {
 // ============================================================
 
 func TestHandleAccessStatusNoAuth(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/api/saas/access-status", nil)
 	w := httptest.NewRecorder()
@@ -1240,7 +1240,7 @@ func TestHandleAccessStatusNoAuth(t *testing.T) {
 // ============================================================
 
 func TestHandleListClusters(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	// Call handler directly to skip requireAuth
 	req := httptest.NewRequest("GET", "/api/hub/clusters", nil)
@@ -1265,7 +1265,7 @@ func TestHandleListClusters(t *testing.T) {
 // ============================================================
 
 func TestServeStatic(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	// Test the learn page
 	req := httptest.NewRequest("GET", "/learn", nil)
@@ -1278,7 +1278,7 @@ func TestServeStatic(t *testing.T) {
 }
 
 func TestServeStaticMissing(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	handler := srv.serveStatic("static/nonexistent.html")
 	req := httptest.NewRequest("GET", "/missing", nil)
@@ -1295,7 +1295,7 @@ func TestServeStaticMissing(t *testing.T) {
 // ============================================================
 
 func TestShutdownNoServer(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	// httpServer is nil when Start hasn't been called
 	err := srv.Shutdown(time.Second)
 	if err != nil {
@@ -1308,7 +1308,7 @@ func TestShutdownNoServer(t *testing.T) {
 // ============================================================
 
 func TestMarkStaleHivesEmptyHeartbeat(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "no-heartbeat", Online: true, LastHeartbeat: ""},
@@ -1324,7 +1324,7 @@ func TestMarkStaleHivesEmptyHeartbeat(t *testing.T) {
 }
 
 func TestMarkStaleHivesRemoveOld(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	old := time.Now().Add(-48 * time.Hour).Format(time.RFC3339) // older than staleRemoveAge (24h)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -1452,7 +1452,7 @@ func TestIsHubAutoUpgrade(t *testing.T) {
 // ============================================================
 
 func TestRequireAuthCSRFFails(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	handler := srv.requireAuth(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -1472,7 +1472,7 @@ func TestRequireAuthCSRFFails(t *testing.T) {
 }
 
 func TestRequireAuthNoUser(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	handler := srv.requireAuth(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -1488,7 +1488,7 @@ func TestRequireAuthNoUser(t *testing.T) {
 }
 
 func TestRequireAdminNonAdmin(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	handler := srv.requireAdmin(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -1505,7 +1505,7 @@ func TestRequireAdminNonAdmin(t *testing.T) {
 }
 
 func TestRequireAdminNoAuth(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	handler := srv.requireAdmin(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -1524,7 +1524,7 @@ func TestRequireAdminNoAuth(t *testing.T) {
 // ============================================================
 
 func TestHandleSaaSAuthCheckPublicPath(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	// Public paths should pass without auth
 	publicPaths := []string{"/snapshot", "/leaderboard", "/contribute", "/api/leaderboard", "/api/contribute"}
@@ -1541,7 +1541,7 @@ func TestHandleSaaSAuthCheckPublicPath(t *testing.T) {
 }
 
 func TestHandleSaaSAuthCheckUnfurlBot(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test-hive", nil)
 	req.Header.Set("User-Agent", "Slackbot-LinkExpanding 1.0")
@@ -1554,7 +1554,7 @@ func TestHandleSaaSAuthCheckUnfurlBot(t *testing.T) {
 }
 
 func TestHandleSaaSAuthCheckXOriginalURL(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test-hive", nil)
 	req.Header.Set("X-Original-URL", "https://example.com/snapshot/test")
@@ -1567,7 +1567,7 @@ func TestHandleSaaSAuthCheckXOriginalURL(t *testing.T) {
 }
 
 func TestHandleSaaSAuthCheckURIParam(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test-hive&uri=/leaderboard/page", nil)
 	w := httptest.NewRecorder()
@@ -1615,7 +1615,7 @@ func TestHandleOAuthCallbackFullFlowMockGitHub(t *testing.T) {
 // ============================================================
 
 func TestHandleAuthUserWithBearerToken(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	// Pre-populate the token cache
 	ghTokenCacheMu.Lock()
@@ -1649,7 +1649,7 @@ func TestHandleAuthUserWithBearerToken(t *testing.T) {
 // ============================================================
 
 func TestHandleToggleVisibilityNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/hives/{id}/visibility", srv.handleToggleVisibility)
@@ -1665,7 +1665,7 @@ func TestHandleToggleVisibilityNotFound(t *testing.T) {
 }
 
 func TestHandleToggleVisibilityCORSPreflight(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("OPTIONS /visibility-test/{id}", srv.handleToggleVisibility)
@@ -1685,7 +1685,7 @@ func TestHandleToggleVisibilityCORSPreflight(t *testing.T) {
 // ============================================================
 
 func TestHandleToggleAutoUpgradeNotFoundNoRegistry(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/hives/{id}/auto-upgrade", srv.handleToggleAutoUpgrade)
@@ -1701,7 +1701,7 @@ func TestHandleToggleAutoUpgradeNotFoundNoRegistry(t *testing.T) {
 }
 
 func TestHandleToggleAutoUpgradeCORSPreflight(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("OPTIONS /auto-upgrade-test/{id}", srv.handleToggleAutoUpgrade)
@@ -1717,7 +1717,7 @@ func TestHandleToggleAutoUpgradeCORSPreflight(t *testing.T) {
 }
 
 func TestHandleToggleAutoUpgradeFromRegistry(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	// Hive exists in registry but not in SaaS store
 	srv.mu.Lock()
@@ -1741,7 +1741,7 @@ func TestHandleToggleAutoUpgradeFromRegistry(t *testing.T) {
 }
 
 func TestHandleToggleAutoUpgradeBadJSON(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -1767,7 +1767,7 @@ func TestHandleToggleAutoUpgradeBadJSON(t *testing.T) {
 // ============================================================
 
 func TestHandleHubAutoUpgradeBadJSON(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("PUT", "/hub-auto-upgrade", strings.NewReader(`{invalid`))
 	req.Header.Set("Content-Type", "application/json")
@@ -1892,7 +1892,7 @@ func TestSendUpgradingHeartbeatBadURL(t *testing.T) {
 // ============================================================
 
 func TestFindContributeHivePrivateURLSkipped(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "private-url", Online: true, IsPublic: true, DashboardURL: "http://10.0.0.1:3001", Owner: "user"},
@@ -1906,7 +1906,7 @@ func TestFindContributeHivePrivateURLSkipped(t *testing.T) {
 }
 
 func TestFindContributeHiveNoOwnerSkipped(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "no-owner", Online: true, IsPublic: true, DashboardURL: "https://example.com", Owner: ""},
@@ -1920,7 +1920,7 @@ func TestFindContributeHiveNoOwnerSkipped(t *testing.T) {
 }
 
 func TestFindContributeHiveOfflineSkipped(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "offline", Online: false, IsPublic: true, DashboardURL: "https://example.com", Owner: "user"},
@@ -1938,7 +1938,7 @@ func TestFindContributeHiveOfflineSkipped(t *testing.T) {
 // ============================================================
 
 func TestHandleMyHivesWithBearerAndCache(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	ghTokenCacheMu.Lock()
 	ghTokenCache["ghp_myhives_test"] = ghTokenCacheEntry{
@@ -1967,7 +1967,7 @@ func TestHandleMyHivesWithBearerAndCache(t *testing.T) {
 // ============================================================
 
 func TestHandleRequestProvisionNoAuth(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("POST", "/api/saas/request-provision", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -1980,7 +1980,7 @@ func TestHandleRequestProvisionNoAuth(t *testing.T) {
 }
 
 func TestHandleRequestProvisionBadJSON(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	ghTokenCacheMu.Lock()
 	ghTokenCache["ghp_provision_test"] = ghTokenCacheEntry{
@@ -2006,7 +2006,7 @@ func TestHandleRequestProvisionBadJSON(t *testing.T) {
 }
 
 func TestHandleRequestProvisionMissingFields(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	ghTokenCacheMu.Lock()
 	ghTokenCache["ghp_provision_miss"] = ghTokenCacheEntry{
@@ -2032,7 +2032,7 @@ func TestHandleRequestProvisionMissingFields(t *testing.T) {
 }
 
 func TestHandleRequestProvisionInvalidOrg(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	ghTokenCacheMu.Lock()
 	ghTokenCache["ghp_provision_org"] = ghTokenCacheEntry{
@@ -2058,7 +2058,7 @@ func TestHandleRequestProvisionInvalidOrg(t *testing.T) {
 }
 
 func TestHandleRequestProvisionInvalidRepo(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	ghTokenCacheMu.Lock()
 	ghTokenCache["ghp_provision_repo"] = ghTokenCacheEntry{
@@ -2088,7 +2088,7 @@ func TestHandleRequestProvisionInvalidRepo(t *testing.T) {
 // ============================================================
 
 func TestHandleApproveProvisionNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/approve-provision/{username}", srv.handleApproveProvision)
@@ -2103,7 +2103,7 @@ func TestHandleApproveProvisionNotFound(t *testing.T) {
 }
 
 func TestHandleDenyProvisionNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/deny-provision/{username}", srv.handleDenyProvision)
@@ -2122,7 +2122,7 @@ func TestHandleDenyProvisionNotFound(t *testing.T) {
 // ============================================================
 
 func TestHandleApproveAccessNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/hives/{id}/approve-access/{username}", srv.handleApproveAccess)
@@ -2137,7 +2137,7 @@ func TestHandleApproveAccessNotFound(t *testing.T) {
 }
 
 func TestHandleDenyAccessNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}/deny-access/{username}", srv.handleDenyAccess)
@@ -2156,7 +2156,7 @@ func TestHandleDenyAccessNotFound(t *testing.T) {
 // ============================================================
 
 func TestHandleMigrateHiveNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/migrate", srv.handleMigrateHive)
@@ -2176,7 +2176,7 @@ func TestHandleMigrateHiveNotFound(t *testing.T) {
 // ============================================================
 
 func TestHandleHeartbeatWithClusterHealth(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	payload := HeartbeatPayload{
@@ -2213,7 +2213,7 @@ func TestHandleHeartbeatWithClusterHealth(t *testing.T) {
 // ============================================================
 
 func TestHandleHeartbeatResponseContainsFields(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// Set up a latestSHA
@@ -2248,7 +2248,7 @@ func TestHandleHeartbeatResponseContainsFields(t *testing.T) {
 // ============================================================
 
 func TestHandleStatsWithHives(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	now := time.Now().Format(time.RFC3339)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{

--- a/v2/pkg/hub/hub_coverage_deep_test.go
+++ b/v2/pkg/hub/hub_coverage_deep_test.go
@@ -34,7 +34,7 @@ func TestHandleToggleAutoUpgradeRegistryHiveOwnerMatch(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_toggle_owner", "toggle-owner")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "toggle-reg-hive", Owner: "toggle-owner", Online: true, GitHash: "abc123", GitBranch: "v2"},
@@ -61,7 +61,7 @@ func TestHandleToggleAutoUpgradeRegistryHiveForbidden(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_toggle_nonowner", "not-the-owner")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "forbidden-hive", Owner: "actual-owner", Online: true},
@@ -87,7 +87,7 @@ func TestHandleToggleAutoUpgradeRegistryHiveBadBody(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_toggle_bad", "toggle-owner-bad")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "badbody-hive", Owner: "toggle-owner-bad", Online: true},
@@ -117,7 +117,7 @@ func TestHandleUpgradeHiveForbidden(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_upgrade_notown", "not-owner")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	// We can't create a SaaS hive file, so loadSaaSHive returns nil → 404
 	mux := http.NewServeMux()
@@ -142,7 +142,7 @@ func TestHandleToggleVisibilityForbidden(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_vis_notown", "not-vis-owner")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/hives/{id}/visibility", srv.handleToggleVisibility)
@@ -168,7 +168,7 @@ func TestHandleDeleteHiveWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_del_user", "del-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}", srv.handleDeleteHive)
@@ -200,7 +200,7 @@ func TestHandleMigrateHiveNotFoundWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_mig_user", "mig-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/migrate", srv.handleMigrateHive)
@@ -225,7 +225,7 @@ func TestHandleAccessListWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_acl_user", "acl-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/access", srv.handleAccessList)
@@ -244,7 +244,7 @@ func TestHandleAccessAddWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_add_user", "add-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/access", srv.handleAccessAdd)
@@ -265,7 +265,7 @@ func TestHandleAccessRemoveWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_rm_user", "rm-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}/access/{username}", srv.handleAccessRemove)
@@ -285,7 +285,7 @@ func TestHandleAccessRemoveWithAuth(t *testing.T) {
 // ============================================================
 
 func TestHandleAccessAddBadBody(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/access", srv.handleAccessAdd)
@@ -310,7 +310,7 @@ func TestHandleRequestAccessWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_reqacc", "req-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/request-access", srv.handleRequestAccess)
 
@@ -328,7 +328,7 @@ func TestHandleGetRequestsWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_getreq", "getreq-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/requests", srv.handleGetRequests)
 
@@ -346,7 +346,7 @@ func TestHandleApproveRequestWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_approve", "approver")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/requests/{username}/approve", srv.handleApproveRequest)
 
@@ -366,7 +366,7 @@ func TestHandleDenyRequestWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_deny", "denier")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/requests/{username}/deny", srv.handleDenyRequest)
 
@@ -388,7 +388,7 @@ func TestHandleApproveAccessWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_appracc", "approver-acc")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/hives/{id}/approve-access/{username}", srv.handleApproveAccess)
 
@@ -406,7 +406,7 @@ func TestHandleDenyAccessWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_denyacc", "denier-acc")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}/deny-access/{username}", srv.handleDenyAccess)
 
@@ -428,7 +428,7 @@ func TestHandleCreateHiveWithAuthNoUser(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_create_nouser", "create-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("POST", "/create-hive",
 		strings.NewReader(`{"org":"myorg","repos":"repo1","github_token":"ghp_fake123"}`))
@@ -451,7 +451,7 @@ func TestHandleHiveStatusWithAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_status_user", "status-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/status", srv.handleHiveStatus)
 
@@ -473,7 +473,7 @@ func TestHandleAccessStatusWithUserAndHives(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_accstat_user", "accstat-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	now := time.Now().Format(time.RFC3339)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -509,7 +509,7 @@ func TestHandleSaaSAuthCheckUserNoAccessFile(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_authcheck_user", "authcheck-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=some-hive", nil)
 	req.Header.Set("Authorization", "Bearer ghp_authcheck_user")
@@ -530,7 +530,7 @@ func TestHandleMyHivesAdminWithBearer(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_admin_my", hubAdminUsername)
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	now := time.Now().Format(time.RFC3339)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -557,7 +557,7 @@ func TestHandleUserTokenSelfRequest(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_usertoken", "token-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	body := `{"hive_id":"h1","username":"token-user"}`
 	req := httptest.NewRequest("POST", "/user-token", strings.NewReader(body))
@@ -576,7 +576,7 @@ func TestHandleUserTokenAdminRequestOther(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_admin_token", hubAdminUsername)
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	body := `{"hive_id":"h1","username":"other-user"}`
 	req := httptest.NewRequest("POST", "/user-token", strings.NewReader(body))
@@ -599,7 +599,7 @@ func TestHandleRequestProvisionValidBody(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_prov_valid", "prov-valid-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	body := `{"org":"validorg","repos":"repo1,repo2","primary_repo":"repo1","acmm_level":3,"auth_method":"token"}`
 	req := httptest.NewRequest("POST", "/provision", strings.NewReader(body))
@@ -619,7 +619,7 @@ func TestHandleRequestProvisionACMMLevelDefault(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_prov_acmm", "prov-acmm-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	body := `{"org":"validorg","repos":"repo1","acmm_level":0}`
 	req := httptest.NewRequest("POST", "/provision", strings.NewReader(body))
@@ -636,7 +636,7 @@ func TestHandleRequestProvisionACMMLevelHigh(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_prov_high", "prov-high-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	body := `{"org":"validorg","repos":"repo1","acmm_level":99}`
 	req := httptest.NewRequest("POST", "/provision", strings.NewReader(body))
@@ -657,7 +657,7 @@ func TestHandleApproveProvisionWithAdminAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_approv_admin", hubAdminUsername)
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/approve-provision/{username}", srv.handleApproveProvision)
@@ -676,7 +676,7 @@ func TestHandleDenyProvisionWithAdminAuth(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_deny_admin", hubAdminUsername)
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/deny-provision/{username}", srv.handleDenyProvision)
@@ -696,7 +696,7 @@ func TestHandleDenyProvisionWithAdminAuth(t *testing.T) {
 // ============================================================
 
 func TestHandleAdminUpdateUserWithAdminAuth(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/admin/users/{username}", srv.handleAdminUpdateUser)
@@ -722,7 +722,7 @@ func TestRequireAuthUserNilAfterEnsure(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_blocked_test", "blocked-test-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	handler := srv.requireAuth(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -747,7 +747,7 @@ func TestHandleAuthUserKnownButNotInFile(t *testing.T) {
 	cleanup := helperSetupAuthUser(t, "ghp_authuser_known", "known-user")
 	defer cleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Set("Authorization", "Bearer ghp_authuser_known")
@@ -769,7 +769,7 @@ func TestHandleAuthUserKnownButNotInFile(t *testing.T) {
 // ============================================================
 
 func TestHandleHeartbeatAutoUpgradeSpokeRequest(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// Set latest SHA
@@ -800,7 +800,7 @@ func TestHandleHeartbeatAutoUpgradeSpokeRequest(t *testing.T) {
 }
 
 func TestHandleHeartbeatAutoUpgradeNoUpgradeNeeded(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	latestSHAMu.Lock()
@@ -826,7 +826,7 @@ func TestHandleHeartbeatAutoUpgradeNoUpgradeNeeded(t *testing.T) {
 }
 
 func TestHandleHeartbeatAutoUpgradeEmptyGitHash(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	latestSHAMu.Lock()
@@ -853,7 +853,7 @@ func TestHandleHeartbeatAutoUpgradeEmptyGitHash(t *testing.T) {
 }
 
 func TestHandleHeartbeatDefaultBranch(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// No git_branch → defaults to "v2"

--- a/v2/pkg/hub/hub_coverage_extra_test.go
+++ b/v2/pkg/hub/hub_coverage_extra_test.go
@@ -147,7 +147,7 @@ func TestConvertHeartbeatToPerClusterHealthNoGPU(t *testing.T) {
 // ============================================================
 
 func TestGetHeartbeatHealthForCluster(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	// No data
 	if got := srv.getHeartbeatHealthForCluster("nonexistent"); got != nil {
@@ -190,7 +190,7 @@ func TestGetHeartbeatHealthForCluster(t *testing.T) {
 // ============================================================
 
 func TestHandleClusterHealthNotAdmin(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/api/saas/cluster-health", nil)
 	w := httptest.NewRecorder()
@@ -206,7 +206,7 @@ func TestHandleClusterHealthNotAdmin(t *testing.T) {
 // ============================================================
 
 func TestHandleAccessStatusWithBearerAuth(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	// Pre-populate cache for bearer auth
 	ghTokenCacheMu.Lock()
@@ -249,7 +249,7 @@ func TestHandleAccessStatusWithBearerAuth(t *testing.T) {
 // ============================================================
 
 func TestHandleCreateHiveNotAuthenticatedDirect(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("POST", "/test", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -266,7 +266,7 @@ func TestHandleCreateHiveNotAuthenticatedDirect(t *testing.T) {
 // ============================================================
 
 func TestHandleMigrateHiveNotAuthenticated(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/migrate", srv.handleMigrateHive)
@@ -287,7 +287,7 @@ func TestHandleMigrateHiveNotAuthenticated(t *testing.T) {
 // ============================================================
 
 func TestHandleToggleVisibilityCORSHeaders(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /visibility/{id}", srv.handleToggleVisibility)
@@ -304,7 +304,7 @@ func TestHandleToggleVisibilityCORSHeaders(t *testing.T) {
 }
 
 func TestHandleToggleVisibilityUntrustedOrigin(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /visibility/{id}", srv.handleToggleVisibility)
@@ -325,7 +325,7 @@ func TestHandleToggleVisibilityUntrustedOrigin(t *testing.T) {
 // ============================================================
 
 func TestHandleUpgradeHiveCORSHeaders(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /upgrade/{id}", srv.handleUpgradeHive)
@@ -345,7 +345,7 @@ func TestHandleUpgradeHiveCORSHeaders(t *testing.T) {
 // ============================================================
 
 func TestHandleToggleAutoUpgradeCORSHeaders(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /auto-upgrade/{id}", srv.handleToggleAutoUpgrade)
@@ -366,7 +366,7 @@ func TestHandleToggleAutoUpgradeCORSHeaders(t *testing.T) {
 // ============================================================
 
 func TestHandleHubAutoUpgradeValid(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("PUT", "/hub-auto-upgrade", strings.NewReader(`{"auto_upgrade":false}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -382,7 +382,7 @@ func TestHandleHubAutoUpgradeValid(t *testing.T) {
 }
 
 func TestHandleHubAutoUpgradeEnable(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("PUT", "/hub-auto-upgrade", strings.NewReader(`{"auto_upgrade":true}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -399,7 +399,7 @@ func TestHandleHubAutoUpgradeEnable(t *testing.T) {
 // ============================================================
 
 func TestHandleHubSelfUpgrade(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("POST", "/hub-self-upgrade", nil)
 	w := httptest.NewRecorder()
@@ -417,7 +417,7 @@ func TestHandleHubSelfUpgrade(t *testing.T) {
 // ============================================================
 
 func TestHandleHiveStatusPathTraversal(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/status", srv.handleHiveStatus)
@@ -436,7 +436,7 @@ func TestHandleHiveStatusPathTraversal(t *testing.T) {
 // ============================================================
 
 func TestHandleDeleteHiveNotOwner(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}", srv.handleDeleteHive)
@@ -479,7 +479,7 @@ func TestLoadClustersWithTempFile(t *testing.T) {
 // ============================================================
 
 func TestHandleSaaSAuthCheckPublicPathSnapshot(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test", nil)
 	req.Header.Set("X-Original-URI", "/snapshot/something")
@@ -492,7 +492,7 @@ func TestHandleSaaSAuthCheckPublicPathSnapshot(t *testing.T) {
 }
 
 func TestHandleSaaSAuthCheckPublicPathContribute(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test", nil)
 	req.Header.Set("X-Original-URI", "/contribute/something")
@@ -509,7 +509,7 @@ func TestHandleSaaSAuthCheckPublicPathContribute(t *testing.T) {
 // ============================================================
 
 func TestHandleMyHivesAdminSeesAllHives(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	// Pre-populate cache for admin user
 	ghTokenCacheMu.Lock()
@@ -545,7 +545,7 @@ func TestHandleMyHivesAdminSeesAllHives(t *testing.T) {
 // ============================================================
 
 func TestHandleApproveAccessNotAuthorized(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/hives/{id}/approve-access/{username}", srv.handleApproveAccess)
@@ -561,7 +561,7 @@ func TestHandleApproveAccessNotAuthorized(t *testing.T) {
 }
 
 func TestHandleDenyAccessNotAuthorized(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}/deny-access/{username}", srv.handleDenyAccess)
@@ -580,7 +580,7 @@ func TestHandleDenyAccessNotAuthorized(t *testing.T) {
 // ============================================================
 
 func TestHandleRequestAccessHiveNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/request-access", srv.handleRequestAccess)
@@ -599,7 +599,7 @@ func TestHandleRequestAccessHiveNotFound(t *testing.T) {
 // ============================================================
 
 func TestHandleGetRequestsHiveNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/requests", srv.handleGetRequests)
@@ -618,7 +618,7 @@ func TestHandleGetRequestsHiveNotFound(t *testing.T) {
 // ============================================================
 
 func TestHandleApproveRequestHiveNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/requests/{username}/approve", srv.handleApproveRequest)
@@ -638,7 +638,7 @@ func TestHandleApproveRequestHiveNotFound(t *testing.T) {
 // ============================================================
 
 func TestHandleDenyRequestHiveNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/requests/{username}/deny", srv.handleDenyRequest)
@@ -657,7 +657,7 @@ func TestHandleDenyRequestHiveNotFound(t *testing.T) {
 // ============================================================
 
 func TestHandleHeartbeatUpdateExistingWithSparkline(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// Pre-populate a hive with sparkline data from 20 minutes ago
@@ -703,7 +703,7 @@ func TestHandleHeartbeatUpdateExistingWithSparkline(t *testing.T) {
 // ============================================================
 
 func TestHandleHeartbeatUpgradeCompleted(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	srv.mu.Lock()
@@ -742,7 +742,7 @@ func TestHandleHeartbeatUpgradeCompleted(t *testing.T) {
 }
 
 func TestHandleHeartbeatUpgradeInProgress(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	srv.mu.Lock()
@@ -785,7 +785,7 @@ func TestHandleHeartbeatUpgradeInProgress(t *testing.T) {
 // ============================================================
 
 func TestHandleHeartbeatResponseAutoUpgrade(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// Set up a latestSHA for v2
@@ -828,7 +828,7 @@ func TestHandleHeartbeatResponseAutoUpgrade(t *testing.T) {
 // ============================================================
 
 func TestHandleHeartbeatStoresClusterHealth(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	payload := HeartbeatPayload{
@@ -866,7 +866,7 @@ func TestHandleHeartbeatStoresClusterHealth(t *testing.T) {
 // ============================================================
 
 func TestRequestSave(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	// Should not panic when called multiple times
 	srv.requestSave()
 	srv.requestSave()
@@ -884,7 +884,7 @@ func TestHandleContributeProxyRejectsPrivateURL(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "contribute-hive", Online: true, IsPublic: true, DashboardURL: upstream.URL, Owner: "user1"},
@@ -907,7 +907,7 @@ func TestHandleContributeProxyRejectsPrivateURL(t *testing.T) {
 // ============================================================
 
 func TestHandleContributeWSProxyNoHive(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/api/contribute/ws", nil)
 	w := httptest.NewRecorder()
@@ -923,7 +923,7 @@ func TestHandleContributeWSProxyNoHive(t *testing.T) {
 // ============================================================
 
 func TestHandleUserTokenEmptyBody(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("POST", "/test", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
@@ -936,7 +936,7 @@ func TestHandleUserTokenEmptyBody(t *testing.T) {
 }
 
 func TestHandleUserTokenInvalidJSON(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("POST", "/test", strings.NewReader(`{invalid`))
 	req.Header.Set("Content-Type", "application/json")
@@ -953,7 +953,7 @@ func TestHandleUserTokenInvalidJSON(t *testing.T) {
 // ============================================================
 
 func TestHandleRequestProvisionDefaultPrimaryRepo(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	ghTokenCacheMu.Lock()
 	ghTokenCache["ghp_prov_default"] = ghTokenCacheEntry{
@@ -986,7 +986,7 @@ func TestHandleRequestProvisionDefaultPrimaryRepo(t *testing.T) {
 // ============================================================
 
 func TestHandleAdminUsersResponse(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/admin-users", nil)
 	w := httptest.NewRecorder()
@@ -1027,7 +1027,7 @@ func TestDecryptTokenWithBadCiphertext(t *testing.T) {
 // ============================================================
 
 func TestHandleHeartbeatTriggersRegistrySave(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	payload := `{"hive_id":"save-trigger-hive"}`
@@ -1047,7 +1047,7 @@ func TestHandleHeartbeatTriggersRegistrySave(t *testing.T) {
 // ============================================================
 
 func TestHandleDashboardRegularBrowserWithCookie(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/dashboard", nil)
 	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "user123"})
@@ -1068,7 +1068,7 @@ func TestHandleDashboardRegularBrowserWithCookie(t *testing.T) {
 // ============================================================
 
 func TestHandleOAuthCallbackMissingCodeParam(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/callback", nil)
 	w := httptest.NewRecorder()
@@ -1084,7 +1084,7 @@ func TestHandleOAuthCallbackMissingCodeParam(t *testing.T) {
 // ============================================================
 
 func TestHandleContributeProxyBadURL(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	// Set a hive with an unparseable URL
 	srv.mu.Lock()
@@ -1110,7 +1110,7 @@ func TestHandleContributeProxyBadURL(t *testing.T) {
 // ============================================================
 
 func TestHandleProxyHiveConfigUpstreamError(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -1141,7 +1141,7 @@ func TestHandleProxyHiveConfigUpstreamError(t *testing.T) {
 // ============================================================
 
 func TestStartAndShutdown(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	// Start in background
 	errCh := make(chan error, 1)
@@ -1163,7 +1163,7 @@ func TestStartAndShutdown(t *testing.T) {
 // ============================================================
 
 func TestTriggerAutoUpgradesNoHives(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	// Should not panic with no hives
 	srv.triggerAutoUpgrades()
 }
@@ -1173,7 +1173,7 @@ func TestTriggerAutoUpgradesNoHives(t *testing.T) {
 // ============================================================
 
 func TestHandleHeartbeatSaaSHivePrefix(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	secret := srv.hubSecret
 
 	// saas- prefix without SaaS entry should be rejected
@@ -1190,7 +1190,7 @@ func TestHandleHeartbeatSaaSHivePrefix(t *testing.T) {
 }
 
 func TestHandleHeartbeatUpgradingFlag(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	payload := `{"hive_id":"upgrading-flag-test","upgrading":true,"upgrade_target_sha":"target1"}`
@@ -1213,7 +1213,7 @@ func TestHandleHeartbeatUpgradingFlag(t *testing.T) {
 }
 
 func TestHandleLeaderboardWithData(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{
@@ -1253,7 +1253,7 @@ func TestGetLatestSHAForBranchNotFound(t *testing.T) {
 }
 
 func TestHandleHeartbeatHiveTypeExplicit(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	payload := `{"hive_id":"explicit-type","hive_type":"custom-type"}`
@@ -1278,7 +1278,7 @@ func TestHandleHeartbeatHiveTypeExplicit(t *testing.T) {
 }
 
 func TestHandleHeartbeatMaxAgents(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// Create 60 agents to test the max agents cap (50)
@@ -1313,7 +1313,7 @@ func TestHandleHeartbeatMaxAgents(t *testing.T) {
 }
 
 func TestHandleHeartbeatSnapshotURL(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// First heartbeat with snapshot

--- a/v2/pkg/hub/hub_filesystem_extra_test.go
+++ b/v2/pkg/hub/hub_filesystem_extra_test.go
@@ -27,7 +27,7 @@ func TestHandleAccessStatusFullWithFilesystem(t *testing.T) {
 		{Username: "accstatus-user", RequestedAt: "2024-01-01T00:00:00Z", Status: "pending"},
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	now := time.Now().Format(time.RFC3339)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -81,7 +81,7 @@ func TestHandleToggleAutoUpgradeWithFilesystem(t *testing.T) {
 
 	saveSaaSHive(&SaaSHive{ID: "toggle-fs-hive", Owner: "toggle-fs-owner", AutoUpgrade: false})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/hives/{id}/auto-upgrade", srv.handleToggleAutoUpgrade)
 
@@ -123,7 +123,7 @@ func TestHandleMyHivesWithSaaSHivesOnly(t *testing.T) {
 		ACMMLevel:   2,
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/my-hives", nil)
 	req.Header.Set("Authorization", "Bearer ghp_myhives_saas")
@@ -173,7 +173,7 @@ func TestHandleMyHivesWithErrorHive(t *testing.T) {
 		Error:  "provisioning failed",
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/my-hives", nil)
 	req.Header.Set("Authorization", "Bearer ghp_myhives_err")
@@ -212,7 +212,7 @@ func TestHandleMyHivesAdminSeesAll(t *testing.T) {
 
 	saveSaaSHive(&SaaSHive{ID: "hosted-admin-hive", Owner: "other-owner", Status: "running"})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	now := time.Now().Format(time.RFC3339)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -259,7 +259,7 @@ func TestTriggerAutoUpgradesWithFilesystem(t *testing.T) {
 		latestSHAMu.Unlock()
 	}()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "auto-up-fs", Online: true, GitHash: "old111", GitBranch: "v2"},
@@ -291,7 +291,7 @@ func TestTriggerAutoUpgradesSkipsProvisioning(t *testing.T) {
 		Status:      "provisioning",
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.triggerAutoUpgrades()
 	// Should skip provisioning hives — no crash
 }
@@ -316,7 +316,7 @@ func TestTriggerAutoUpgradesSkipsAlreadyUpgrading(t *testing.T) {
 		latestSHAMu.Unlock()
 	}()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "already-up", Online: true, GitHash: "old1", GitBranch: "v2", Upgrading: true, UpgradeTarget: "target2"},
@@ -347,7 +347,7 @@ func TestTriggerAutoUpgradesSkipsCurrentSHA(t *testing.T) {
 		latestSHAMu.Unlock()
 	}()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{ID: "current-sha", Online: true, GitHash: "current", GitBranch: "v2"},
@@ -369,7 +369,7 @@ func TestHandleCreateHiveAppAuth(t *testing.T) {
 	u.SaaSQuota = 5
 	saveSaaSUser(u)
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	body := `{"org":"apporg","repos":"repo1","auth_method":"app","app_id":"123","installation_id":"456","app_private_key":"-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----"}`
 	req := httptest.NewRequest("POST", "/create", strings.NewReader(body))
@@ -394,7 +394,7 @@ func TestHandleCreateHiveUnknownCluster(t *testing.T) {
 	u.SaaSQuota = 5
 	saveSaaSUser(u)
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	body := `{"org":"myorg","repos":"repo1","github_token":"ghp_fake12345678","cluster_id":"unknown-cluster-xyz"}`
 	req := httptest.NewRequest("POST", "/create", strings.NewReader(body))
@@ -419,7 +419,7 @@ func TestHandleCreateHiveNoQuota(t *testing.T) {
 	u.SaaSQuota = 0
 	saveSaaSUser(u)
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	body := `{"org":"myorg","repos":"repo1","github_token":"ghp_fake12345678"}`
 	req := httptest.NewRequest("POST", "/create", strings.NewReader(body))
@@ -444,7 +444,7 @@ func TestHandleCreateHiveBlockedUser(t *testing.T) {
 	u.Blocked = true
 	saveSaaSUser(u)
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	body := `{"org":"myorg","repos":"repo1","github_token":"ghp_fake12345678"}`
 	req := httptest.NewRequest("POST", "/create", strings.NewReader(body))
@@ -471,7 +471,7 @@ func TestHandleDeleteHiveWithFilesystemFull(t *testing.T) {
 
 	saveSaaSHive(&SaaSHive{ID: "del-full-hive", Owner: "del-full-owner", Status: "running"})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	// Add to registry
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -502,7 +502,7 @@ func TestHandleHiveStatusAccessDenied(t *testing.T) {
 	ensureSaaSUser("noowner")
 	saveSaaSHive(&SaaSHive{ID: "secret-hive", Owner: "real-owner"})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/status", srv.handleHiveStatus)
 
@@ -529,7 +529,7 @@ func TestHandleHiveStatusWithAccess(t *testing.T) {
 
 	saveSaaSHive(&SaaSHive{ID: "acc-hive", Owner: "other-owner", Status: "running"})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/status", srv.handleHiveStatus)
 
@@ -549,7 +549,7 @@ func TestHandleAuthUserWithFileUser(t *testing.T) {
 
 	ensureSaaSUser("file-auth-user")
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/auth-user", nil)
 	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "file-auth-user"})
@@ -572,7 +572,7 @@ func TestHandleAuthUserAdmin(t *testing.T) {
 
 	ensureSaaSUser(hubAdminUsername)
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/auth-user", nil)
 	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: hubAdminUsername})
@@ -592,7 +592,7 @@ func TestGetAuthUserWithCookieAndFile(t *testing.T) {
 
 	ensureSaaSUser("cookie-user")
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "cookie-user"})

--- a/v2/pkg/hub/hub_filesystem_test.go
+++ b/v2/pkg/hub/hub_filesystem_test.go
@@ -377,7 +377,7 @@ func TestHandleAdminUpdateUserWithFilesystem(t *testing.T) {
 
 	ensureSaaSUser("target-user")
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/admin/users/{username}", srv.handleAdminUpdateUser)
@@ -409,7 +409,7 @@ func TestHandleAdminUsersWithFilesystem(t *testing.T) {
 	ensureSaaSUser("user-a")
 	ensureSaaSUser("user-b")
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/admin-users", nil)
 	w := httptest.NewRecorder()
@@ -433,7 +433,7 @@ func TestRequireAuthWithFilesystem(t *testing.T) {
 	authCleanup := helperSetupAuthUser(t, "ghp_auth_fs", "fs-auth-user")
 	defer authCleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	var calledWith string
 	handler := srv.requireAuth(func(w http.ResponseWriter, r *http.Request) {
 		calledWith = srv.getAuthUser(r)
@@ -465,7 +465,7 @@ func TestRequireAuthBlockedUserFS(t *testing.T) {
 	authCleanup := helperSetupAuthUser(t, "ghp_blocked_fs", "blocked-user")
 	defer authCleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	handler := srv.requireAuth(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -505,7 +505,7 @@ func TestHandleMyHivesWithFilesystem(t *testing.T) {
 		AutoUpgrade: true,
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	now := time.Now().Format(time.RFC3339)
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -545,7 +545,7 @@ func TestHandleHiveStatusWithFilesystem(t *testing.T) {
 
 	saveSaaSHive(&SaaSHive{ID: "status-hive", Owner: "status-user", Status: "running"})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/status", srv.handleHiveStatus)
 
@@ -569,7 +569,7 @@ func TestHandleDeleteHiveWithFilesystem(t *testing.T) {
 	ensureSaaSUser("delete-user")
 	saveSaaSHive(&SaaSHive{ID: "del-hive", Owner: "delete-user", Status: "running"})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}", srv.handleDeleteHive)
 
@@ -600,7 +600,7 @@ func TestHandleAccessListWithFilesystem(t *testing.T) {
 	u.Hives["acl-hive"] = "read"
 	saveSaaSUser(u)
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/access", srv.handleAccessList)
 
@@ -630,7 +630,7 @@ func TestHandleAccessAddWithFilesystem(t *testing.T) {
 	ensureSaaSUser("add-owner")
 	saveSaaSHive(&SaaSHive{ID: "add-hive", Owner: "add-owner"})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/access", srv.handleAccessAdd)
 
@@ -662,7 +662,7 @@ func TestHandleAccessAddBadRole(t *testing.T) {
 	ensureSaaSUser("role-owner")
 	saveSaaSHive(&SaaSHive{ID: "role-hive", Owner: "role-owner"})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/access", srv.handleAccessAdd)
 
@@ -692,7 +692,7 @@ func TestHandleAccessRemoveWithFilesystem(t *testing.T) {
 	target.Hives["rm-hive"] = "read"
 	saveSaaSUser(target)
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}/access/{username}", srv.handleAccessRemove)
 
@@ -720,7 +720,7 @@ func TestHandleAccessRemoveLastOwner(t *testing.T) {
 	target.Hives["lastowner-hive"] = "owner"
 	saveSaaSUser(target)
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}/access/{username}", srv.handleAccessRemove)
 
@@ -744,7 +744,7 @@ func TestHandleRequestAccessWithFilesystem(t *testing.T) {
 	ensureSaaSUser("requesting-user")
 	saveSaaSHive(&SaaSHive{ID: "req-hive-fs", Owner: "someone-else"})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/request-access", srv.handleRequestAccess)
 
@@ -780,7 +780,7 @@ func TestHandleRequestAccessAlreadyHasAccess(t *testing.T) {
 	saveSaaSUser(u)
 	saveSaaSHive(&SaaSHive{ID: "has-hive", Owner: "other"})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/request-access", srv.handleRequestAccess)
 
@@ -811,7 +811,7 @@ func TestHandleGetRequestsWithFilesystem(t *testing.T) {
 		{Username: "req2", RequestedAt: "2024-01-02T00:00:00Z", Status: "approved"},
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/saas/hives/{id}/requests", srv.handleGetRequests)
 
@@ -847,7 +847,7 @@ func TestHandleApproveRequestWithFilesystem(t *testing.T) {
 		{Username: "pending-user", RequestedAt: "2024-01-01T00:00:00Z", Status: "pending"},
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/requests/{username}/approve", srv.handleApproveRequest)
 
@@ -879,7 +879,7 @@ func TestHandleDenyRequestWithFilesystem(t *testing.T) {
 		{Username: "denied-user", RequestedAt: "2024-01-01T00:00:00Z", Status: "pending"},
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /api/saas/hives/{id}/requests/{username}/deny", srv.handleDenyRequest)
 
@@ -909,7 +909,7 @@ func TestHandleApproveAccessWithFilesystem(t *testing.T) {
 		{Username: "approved-user", RequestedAt: "2024-01-01T00:00:00Z", Status: "pending"},
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/hives/{id}/approve-access/{username}", srv.handleApproveAccess)
 
@@ -939,7 +939,7 @@ func TestHandleDenyAccessWithFilesystem(t *testing.T) {
 		{Username: "denied-acc-user", RequestedAt: "2024-01-01T00:00:00Z", Status: "pending"},
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}/deny-access/{username}", srv.handleDenyAccess)
 
@@ -960,7 +960,7 @@ func TestHandleRequestProvisionWithFilesystem(t *testing.T) {
 	authCleanup := helperSetupAuthUser(t, "ghp_reqprov_fs", "reqprov-user")
 	defer authCleanup()
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	body := `{"org":"validorg","repos":"repo1,repo2","primary_repo":"repo1","acmm_level":3}`
 	req := httptest.NewRequest("POST", "/provision", strings.NewReader(body))
@@ -998,7 +998,7 @@ func TestHandleApproveProvisionWithFilesystem(t *testing.T) {
 		Status:   provisionStatusPending,
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/approve-provision/{username}", srv.handleApproveProvision)
 
@@ -1030,7 +1030,7 @@ func TestHandleDenyProvisionWithFilesystem(t *testing.T) {
 		Status:   provisionStatusPending,
 	})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/deny-provision/{username}", srv.handleDenyProvision)
 
@@ -1062,7 +1062,7 @@ func TestHandleUserTokenWithFilesystem(t *testing.T) {
 	u.EncryptedToken = enc
 	saveSaaSUser(u)
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	body := `{"hive_id":"token-hive","username":"token-fs-user"}`
 	req := httptest.NewRequest("POST", "/user-token", strings.NewReader(body))
@@ -1093,7 +1093,7 @@ func TestHandleUserTokenNoToken(t *testing.T) {
 	u.Hives["token-hive"] = "owner"
 	saveSaaSUser(u)
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	body := `{"hive_id":"token-hive","username":"notoken-user"}`
 	req := httptest.NewRequest("POST", "/user-token", strings.NewReader(body))
@@ -1116,7 +1116,7 @@ func TestHandleUserTokenNoHiveAccess(t *testing.T) {
 
 	ensureSaaSUser("noacc-user")
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	body := `{"hive_id":"no-access-hive","username":"noacc-user"}`
 	req := httptest.NewRequest("POST", "/user-token", strings.NewReader(body))
@@ -1141,7 +1141,7 @@ func TestHandleSaaSAuthCheckWithFilesystem(t *testing.T) {
 	u.Hives["check-hive"] = "read"
 	saveSaaSUser(u)
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=check-hive", nil)
 	req.Header.Set("Authorization", "Bearer ghp_authcheck_fs")
@@ -1168,7 +1168,7 @@ func TestHandleSaaSAuthCheckNoAccess(t *testing.T) {
 
 	ensureSaaSUser("noauth-user")
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=no-access-hive", nil)
 	req.Header.Set("Authorization", "Bearer ghp_noauth_fs")
@@ -1191,7 +1191,7 @@ func TestHandleCreateHiveWithFilesystem(t *testing.T) {
 	u.SaaSQuota = 5
 	saveSaaSUser(u)
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	body := `{"org":"myorg","repos":"repo1","github_token":"ghp_faketoken12345678","project_name":"My Project","acmm_level":2}`
 	req := httptest.NewRequest("POST", "/create", strings.NewReader(body))
@@ -1225,7 +1225,7 @@ func TestHandleCreateHiveQuotaReached(t *testing.T) {
 	// Pre-create a hive owned by this user
 	saveSaaSHive(&SaaSHive{ID: "existing-hive", Owner: "quota-user"})
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	body := `{"org":"myorg","repos":"repo1","github_token":"ghp_faketoken12345678"}`
 	req := httptest.NewRequest("POST", "/create", strings.NewReader(body))

--- a/v2/pkg/hub/hub_heartbeat_test.go
+++ b/v2/pkg/hub/hub_heartbeat_test.go
@@ -308,7 +308,7 @@ func TestSendHeartbeatAutoUpgradeInPayload(t *testing.T) {
 }
 
 func TestHeartbeatNoUpgradeToForHubManagedHives(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// Simulate a heartbeat from a spoke with auto_upgrade=true
@@ -343,7 +343,7 @@ func TestHeartbeatNoUpgradeToForHubManagedHives(t *testing.T) {
 }
 
 func TestHeartbeatUpgradeToForSpokeManaged(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// Spoke declares auto_upgrade but no SaaS hive exists on hub

--- a/v2/pkg/hub/hub_saas_handlers_test.go
+++ b/v2/pkg/hub/hub_saas_handlers_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestHandleLoginRedirect(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// Register OAuth routes manually (won't register without env var)
@@ -31,7 +31,7 @@ func TestHandleLoginRedirect(t *testing.T) {
 }
 
 func TestHandleLoginWithRedirectParam(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 	srv.mux.HandleFunc("GET /login-test", srv.handleLogin)
 
@@ -49,7 +49,7 @@ func TestHandleLoginWithRedirectParam(t *testing.T) {
 }
 
 func TestHandleLoginRejectsOpenRedirect(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 	srv.mux.HandleFunc("GET /login-redir", srv.handleLogin)
 
@@ -64,7 +64,7 @@ func TestHandleLoginRejectsOpenRedirect(t *testing.T) {
 }
 
 func TestHandleLoginRdParam(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 	srv.mux.HandleFunc("GET /login-rd", srv.handleLogin)
 
@@ -78,7 +78,7 @@ func TestHandleLoginRdParam(t *testing.T) {
 }
 
 func TestHandleLogout(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 	srv.mux.HandleFunc("POST /logout-test", srv.handleLogout)
 
@@ -102,7 +102,7 @@ func TestHandleLogout(t *testing.T) {
 }
 
 func TestHandleAuthUserNoCookie(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 	srv.mux.HandleFunc("GET /auth-user-test", srv.handleAuthUser)
 
@@ -118,7 +118,7 @@ func TestHandleAuthUserNoCookie(t *testing.T) {
 }
 
 func TestHandleAuthUserEmptyCookie(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 	srv.mux.HandleFunc("GET /auth-user-empty", srv.handleAuthUser)
 
@@ -135,7 +135,7 @@ func TestHandleAuthUserEmptyCookie(t *testing.T) {
 }
 
 func TestHandleAuthUserUnknownUser(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 	srv.mux.HandleFunc("GET /auth-user-unknown", srv.handleAuthUser)
 
@@ -152,7 +152,7 @@ func TestHandleAuthUserUnknownUser(t *testing.T) {
 }
 
 func TestHandleAdminUsersAsAdmin(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// Call handler directly to skip requireAdmin middleware (no /data on macOS)
@@ -172,7 +172,7 @@ func TestHandleAdminUsersAsAdmin(t *testing.T) {
 }
 
 func TestHandleAdminUpdateUserNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// Call directly to skip requireAdmin
@@ -189,7 +189,7 @@ func TestHandleAdminUpdateUserNotFound(t *testing.T) {
 }
 
 func TestHandleAdminUpdateUserBadJSON(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	mux := http.NewServeMux()
@@ -205,7 +205,7 @@ func TestHandleAdminUpdateUserBadJSON(t *testing.T) {
 }
 
 func TestHandleHiveStatusNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	mux := http.NewServeMux()
@@ -220,7 +220,7 @@ func TestHandleHiveStatusNotFound(t *testing.T) {
 }
 
 func TestHandleDeleteHiveNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	mux := http.NewServeMux()
@@ -236,7 +236,7 @@ func TestHandleDeleteHiveNotFound(t *testing.T) {
 }
 
 func TestHandleDeleteHivePathTraversal(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	mux := http.NewServeMux()
@@ -251,7 +251,7 @@ func TestHandleDeleteHivePathTraversal(t *testing.T) {
 }
 
 func TestHandleUpgradeHiveCORSPreflight(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// Register directly to avoid requireAuth for OPTIONS
@@ -271,7 +271,7 @@ func TestHandleUpgradeHiveCORSPreflight(t *testing.T) {
 }
 
 func TestHandleUpgradeHiveNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	mux := http.NewServeMux()
@@ -287,7 +287,7 @@ func TestHandleUpgradeHiveNotFound(t *testing.T) {
 }
 
 func TestHandleAccessListNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	mux := http.NewServeMux()
@@ -302,7 +302,7 @@ func TestHandleAccessListNotFound(t *testing.T) {
 }
 
 func TestHandleAccessAddNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	mux := http.NewServeMux()
@@ -319,7 +319,7 @@ func TestHandleAccessAddNotFound(t *testing.T) {
 }
 
 func TestHandleAccessRemoveNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	mux := http.NewServeMux()
@@ -334,7 +334,7 @@ func TestHandleAccessRemoveNotFound(t *testing.T) {
 }
 
 func TestHandleRequestAccessNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	mux := http.NewServeMux()
@@ -349,7 +349,7 @@ func TestHandleRequestAccessNotFound(t *testing.T) {
 }
 
 func TestHandleGetRequestsNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	mux := http.NewServeMux()
@@ -364,7 +364,7 @@ func TestHandleGetRequestsNotFound(t *testing.T) {
 }
 
 func TestHandleApproveRequestNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	mux := http.NewServeMux()
@@ -380,7 +380,7 @@ func TestHandleApproveRequestNotFound(t *testing.T) {
 }
 
 func TestHandleDenyRequestNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	mux := http.NewServeMux()
@@ -395,7 +395,7 @@ func TestHandleDenyRequestNotFound(t *testing.T) {
 }
 
 func TestHandleCreateHiveNoAuth(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	req := httptest.NewRequest("POST", "/api/saas/hives", strings.NewReader(`{}`))
@@ -410,7 +410,7 @@ func TestHandleCreateHiveNoAuth(t *testing.T) {
 }
 
 func TestHandleCreateHiveBadJSON(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// Call handler directly to skip requireAuth
@@ -426,7 +426,7 @@ func TestHandleCreateHiveBadJSON(t *testing.T) {
 }
 
 func TestHandleCreateHiveValidation(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	tests := []struct {
@@ -458,7 +458,7 @@ func TestHandleCreateHiveValidation(t *testing.T) {
 }
 
 func TestHandleUserTokenBadBody(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	req := httptest.NewRequest("POST", "/user-token-test", strings.NewReader(`{}`))
@@ -472,7 +472,7 @@ func TestHandleUserTokenBadBody(t *testing.T) {
 }
 
 func TestHandleUserTokenMissingFields(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	req := httptest.NewRequest("POST", "/user-token-test", strings.NewReader(`{"hive_id":"h1"}`))
@@ -486,7 +486,7 @@ func TestHandleUserTokenMissingFields(t *testing.T) {
 }
 
 func TestHandleUserTokenOtherUserForbidden(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	body := `{"hive_id":"h1","username":"otheruser"}`
@@ -502,7 +502,7 @@ func TestHandleUserTokenOtherUserForbidden(t *testing.T) {
 }
 
 func TestHandleUserTokenUserNotFound(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// getAuthUser returns "" on macOS, so requester="" != username → 403
@@ -521,7 +521,7 @@ func TestHandleUserTokenUserNotFound(t *testing.T) {
 }
 
 func TestHandleProxyHiveConfigNotInRegistry(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	req := httptest.NewRequest("GET", "/proxy-config-test", nil)
@@ -535,7 +535,7 @@ func TestHandleProxyHiveConfigNotInRegistry(t *testing.T) {
 }
 
 func TestHandleProxyHiveConfigWithDashboardURL(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -562,7 +562,7 @@ func TestHandleProxyHiveConfigWithDashboardURL(t *testing.T) {
 }
 
 func TestHandleMyHivesNoAuthDirect(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	req := httptest.NewRequest("GET", "/my-hives-test", nil)
@@ -575,7 +575,7 @@ func TestHandleMyHivesNoAuthDirect(t *testing.T) {
 }
 
 func TestHandleMyHivesWithRegistryHives(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	srv.mu.Lock()
@@ -596,7 +596,7 @@ func TestHandleMyHivesWithRegistryHives(t *testing.T) {
 }
 
 func TestHandleSaaSAuthCheckNoHive(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check", nil)
@@ -609,7 +609,7 @@ func TestHandleSaaSAuthCheckNoHive(t *testing.T) {
 }
 
 func TestHandleSaaSAuthCheckNoAuthWithHive(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test-hive", nil)
@@ -622,7 +622,7 @@ func TestHandleSaaSAuthCheckNoAuthWithHive(t *testing.T) {
 }
 
 func TestHandleSaaSAuthCheckWithUserNoAccess(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test-hive", nil)
@@ -666,7 +666,7 @@ func TestDecryptTokenTooShort(t *testing.T) {
 }
 
 func TestHandleDashboardUnfurlBotReturnsOG(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	req := httptest.NewRequest("GET", "/dashboard", nil)
@@ -683,7 +683,7 @@ func TestHandleDashboardUnfurlBotReturnsOG(t *testing.T) {
 }
 
 func TestHandleDashboardNoCookieRedirects(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	req := httptest.NewRequest("GET", "/dashboard", nil)
@@ -699,7 +699,7 @@ func TestHandleDashboardNoCookieRedirects(t *testing.T) {
 }
 
 func TestHandleDashboardWithCookieReturnsDashboard(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	req := httptest.NewRequest("GET", "/dashboard", nil)
@@ -716,7 +716,7 @@ func TestHandleDashboardWithCookieReturnsDashboard(t *testing.T) {
 }
 
 func TestRequireAuthBlockedUser(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// On macOS, loadSaaSUser returns nil (no /data/saas/users)
@@ -737,7 +737,7 @@ func TestRequireAuthBlockedUser(t *testing.T) {
 }
 
 func TestHandleOAuthCallbackMissingCode(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 	srv.mux.HandleFunc("GET /callback-test", srv.handleOAuthCallback)
 
@@ -751,7 +751,7 @@ func TestHandleOAuthCallbackMissingCode(t *testing.T) {
 }
 
 func TestHandleOAuthCallbackWithCode(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// With a code present, it tries to exchange with GitHub (ghTokenURL const)
@@ -813,7 +813,7 @@ func TestIsUnfurlBotVariants(t *testing.T) {
 }
 
 func TestValidateGitHubTokenInvalid(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// Will try to call GitHub API and fail (no real token)
@@ -832,7 +832,7 @@ func TestSaveAccessRequestsNonexistentDir(t *testing.T) {
 }
 
 func TestValidateGitHubTokenCacheHit(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// Pre-populate the cache
@@ -855,7 +855,7 @@ func TestValidateGitHubTokenCacheHit(t *testing.T) {
 }
 
 func TestValidateGitHubTokenCacheExpired(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// Pre-populate with expired entry
@@ -879,7 +879,7 @@ func TestValidateGitHubTokenCacheExpired(t *testing.T) {
 }
 
 func TestValidateGitHubTokenEmpty(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	result := srv.validateGitHubToken("")
@@ -889,7 +889,7 @@ func TestValidateGitHubTokenEmpty(t *testing.T) {
 }
 
 func TestGetAuthUserBearer(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// Pre-populate cache so Bearer auth works
@@ -936,7 +936,7 @@ func TestIsTrustedOriginBadParse(t *testing.T) {
 func TestRegisterOAuthEnabled(t *testing.T) {
 	t.Setenv("HIVE_HUB_OAUTH_CLIENT_ID", "test-client-id")
 
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// OAuth routes should be registered, test /login exists
@@ -955,7 +955,7 @@ func TestRegisterOAuthEnabled(t *testing.T) {
 }
 
 func TestHandleOAuthCallbackNoAccessToken(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// Code is present but GitHub returns error (invalid code)
@@ -970,7 +970,7 @@ func TestHandleOAuthCallbackNoAccessToken(t *testing.T) {
 }
 
 func TestHandleContributeProxyWithLocalHive(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	// Hive with localhost URL → private URL → rejected by findContributeHive
@@ -992,7 +992,7 @@ func TestHandleContributeProxyWithLocalHive(t *testing.T) {
 }
 
 func TestHandleContributeWSProxyWithLocalHive(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	srv.mu.Lock()
@@ -1027,7 +1027,7 @@ func TestLoadSaaSUserValid(t *testing.T) {
 }
 
 func TestMarkStaleHivesWithOldHeartbeat(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = ""
 
 	old := "2020-01-01T00:00:00Z"

--- a/v2/pkg/hub/hub_test.go
+++ b/v2/pkg/hub/hub_test.go
@@ -147,7 +147,7 @@ func TestIsUnfurlBot(t *testing.T) {
 
 func TestNewHubServer(t *testing.T) {
 	logger := slog.Default()
-	srv := NewHubServer(8080, logger, "abc123")
+	srv := NewHubServer(8080, logger, "abc123", "v2")
 	if srv == nil {
 		t.Fatal("NewHubServer returned nil")
 	}
@@ -157,7 +157,7 @@ func TestNewHubServer(t *testing.T) {
 }
 
 func TestHandleRegistryEmpty(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	req := httptest.NewRequest("GET", "/api/registry", nil)
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -167,7 +167,7 @@ func TestHandleRegistryEmpty(t *testing.T) {
 }
 
 func TestHandleHealthCheck(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	// The hub doesn't have a /api/health endpoint registered in the mux,
 	// but the registry endpoint should work
 	req := httptest.NewRequest("GET", "/api/registry", nil)
@@ -179,7 +179,7 @@ func TestHandleHealthCheck(t *testing.T) {
 }
 
 func TestHandleHeartbeatNoAuth(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.hubSecret = "secret123"
 	req := httptest.NewRequest("POST", "/api/heartbeat", nil)
 	w := httptest.NewRecorder()
@@ -197,7 +197,7 @@ func TestDecryptTokenInvalid(t *testing.T) {
 }
 
 func TestHandleRegistryJSON(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	req := httptest.NewRequest("GET", "/api/registry", nil)
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -211,7 +211,7 @@ func TestHandleRegistryJSON(t *testing.T) {
 }
 
 func TestHandleHeartbeatBadJSON(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -222,7 +222,7 @@ func TestHandleHeartbeatBadJSON(t *testing.T) {
 }
 
 func TestHandleHubVersion(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "abc123")
+	srv := NewHubServer(0, slog.Default(), "abc123", "v2")
 	req := httptest.NewRequest("GET", "/api/hub/version", nil)
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -235,7 +235,7 @@ func TestHandleHubVersion(t *testing.T) {
 }
 
 func TestHandleLeaderboard(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	req := httptest.NewRequest("GET", "/api/hub/leaderboard", nil)
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
@@ -245,7 +245,7 @@ func TestHandleLeaderboard(t *testing.T) {
 }
 
 func TestHandleStats(t *testing.T) {
-	srv := NewHubServer(0, slog.Default(), "test")
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	req := httptest.NewRequest("GET", "/api/hub/stats", nil)
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -110,6 +110,7 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("GET /api/saas/hives/{id}/status", s.requireAuth(s.handleHiveStatus))
 	s.mux.HandleFunc("DELETE /api/saas/hives/{id}", s.requireAuth(s.handleDeleteHive))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/upgrade", s.requireAuth(s.handleUpgradeHive))
+	s.mux.HandleFunc("POST /api/saas/hives/{id}/switch-branch", s.requireAuth(s.handleSwitchBranch))
 	s.mux.HandleFunc("PUT /api/saas/hives/{id}/visibility", s.requireAuth(s.handleToggleVisibility))
 	s.mux.HandleFunc("PUT /api/saas/hives/{id}/auto-upgrade", s.requireAuth(s.handleToggleAutoUpgrade))
 	s.mux.HandleFunc("GET /api/saas/hive-config/{hiveID}", s.requireAuth(s.handleProxyHiveConfig))
@@ -1271,6 +1272,8 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		"latest_sha_messages": getLatestSHAMessages(),
 		"commit_messages":     getCommitMessages(),
 		"hub_git_hash":        s.hubGitHash,
+		"hub_git_branch":      s.hubGitBranch,
+		"tracked_branches":    trackedBranches,
 		"hub_auto_upgrade":    isHubAutoUpgrade(),
 		"show_my_hives":       true,
 	}
@@ -1767,6 +1770,87 @@ func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
 	s.mu.Unlock()
 	w.Header().Set("Content-Type", "application/json")
 	w.Write([]byte(`{"status":"upgrading"}`))
+}
+
+func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
+	origin := r.Header.Get("Origin")
+	if isTrustedOrigin(origin) {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	}
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	id := r.PathValue("id")
+	username := s.getAuthUser(r)
+	h := loadSaaSHive(id)
+	if h == nil {
+		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
+		return
+	}
+	if h.Owner != username && username != hubAdminUsername {
+		http.Error(w, `{"error":"only the owner can switch branches"}`, http.StatusForbidden)
+		return
+	}
+	var body struct {
+		Branch string `json:"branch"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Branch == "" {
+		http.Error(w, `{"error":"branch is required"}`, http.StatusBadRequest)
+		return
+	}
+	validBranch := false
+	for _, b := range trackedBranches {
+		if b == body.Branch {
+			validBranch = true
+			break
+		}
+	}
+	if !validBranch {
+		http.Error(w, `{"error":"unknown branch"}`, http.StatusBadRequest)
+		return
+	}
+	cluster := s.clusterForHive(h)
+	if cluster == nil {
+		http.Error(w, `{"error":"no cluster config for this hive"}`, http.StatusInternalServerError)
+		return
+	}
+	ns := "hive-hosted-" + id
+	imageTag := body.Branch + "-latest"
+	image := "ghcr.io/kubestellar/hive:" + imageTag
+	cmd := kubectlForCluster(cluster, "set", "image", "deployment/hive", "hive="+image, "-n", ns)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		s.logger.Warn("branch switch failed", "hive", id, "branch", body.Branch, "output", string(out))
+		http.Error(w, `{"error":"branch switch failed — check hub logs"}`, http.StatusInternalServerError)
+		return
+	}
+	// Restart the deployment to pull the new image
+	restartCmd := kubectlForCluster(cluster, "rollout", "restart", "deployment/hive", "-n", ns)
+	restartOut, restartErr := restartCmd.CombinedOutput()
+	if restartErr != nil {
+		s.logger.Warn("rollout restart after branch switch failed", "hive", id, "output", string(restartOut))
+	}
+	s.logger.Info("audit: hive branch switched", "hive_id", id, "branch", body.Branch, "image", image, "by", username)
+	s.mu.Lock()
+	for i := range s.registry.Hives {
+		if s.registry.Hives[i].ID == id {
+			s.registry.Hives[i].Upgrading = true
+			s.registry.Hives[i].UpgradeTarget = body.Branch + "-latest"
+			s.registry.Hives[i].UpgradeStartedAt = time.Now()
+			break
+		}
+	}
+	s.mu.Unlock()
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"status": "switching",
+		"branch": body.Branch,
+		"image":  image,
+	})
 }
 
 func (s *HubServer) handleToggleVisibility(w http.ResponseWriter, r *http.Request) {
@@ -3473,6 +3557,7 @@ const dashboardHTML = `<!DOCTYPE html>
     var _latestSHA = '';
     var _latestSHAs = {};
     var _latestSHAMessages = {};
+    var _trackedBranchesList = [];
     var _clusterList = [];
     var _commitMessages = {};
     var _allDashHives = [];
@@ -3507,6 +3592,7 @@ const dashboardHTML = `<!DOCTYPE html>
         _hiveRegistry = data.hives || [];
         _latestSHA = data.latest_sha || _latestSHA;
         if (data.latest_shas) _latestSHAs = data.latest_shas;
+        if (data.tracked_branches) _trackedBranchesList = data.tracked_branches;
         if (data.latest_sha_messages) _latestSHAMessages = data.latest_sha_messages;
         if (data.commit_messages) _commitMessages = data.commit_messages;
         if (data.hub_auto_upgrade !== undefined) _hubAutoUpgrade = data.hub_auto_upgrade;
@@ -3526,17 +3612,19 @@ const dashboardHTML = `<!DOCTYPE html>
           shaEl.innerHTML = lines ? '<div style="font-size:0.7rem;color:var(--muted);margin-bottom:2px">Latest images:</div>' + lines : '<div style="display:flex;align-items:center;gap:6px;font-size:0.7rem;color:var(--muted)"><span style="display:inline-block;width:12px;height:12px;border:2px solid rgba(255,255,255,0.2);border-top-color:var(--accent);border-radius:50%;animation:spin 1s linear infinite"></span>Resolving latest images…</div>';
         }
         var hubHash = data.hub_git_hash || '';
+        var hubBranch = data.hub_git_branch || 'v2';
         if (hubHash) {
           var el = document.getElementById('hub-version');
           if (el) {
-            var hubLatestUnknown = !_latestSHA;
-            var isCurrent = _latestSHA && hubHash === _latestSHA;
+            var hubBranchLatest = _latestSHAs[hubBranch] || _latestSHA;
+            var hubLatestUnknown = !hubBranchLatest;
+            var isCurrent = hubBranchLatest && hubHash === hubBranchLatest;
             var hubUpgradeBtn = '';
-            var hubIsUpgrading = _hubUpgrading || (!isCurrent && _latestSHA && _hubAutoUpgrade);
-            if (!isCurrent && _latestSHA && _isAdmin && !hubIsUpgrading) {
+            var hubIsUpgrading = _hubUpgrading || (!isCurrent && hubBranchLatest && _hubAutoUpgrade);
+            if (!isCurrent && hubBranchLatest && _isAdmin && !hubIsUpgrading) {
               hubUpgradeBtn = ' <button id="hub-upgrade-btn" onclick="upgradeHub(\'' + esc(hubHash) + '\')" style="padding:2px 8px;background:var(--green);color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.65rem;margin-left:6px;white-space:nowrap">Upgrade</button>';
             } else if (hubIsUpgrading) {
-              hubUpgradeBtn = ' <span title="Upgrading to ' + esc(_latestSHA || '?') + '" style="display:inline-block;padding:2px 8px;background:var(--surface);border:1px solid var(--border);border-radius:4px;font-size:0.65rem;margin-left:6px;white-space:nowrap;opacity:0.8"><span style="display:inline-block;width:10px;height:10px;border:2px solid rgba(255,255,255,0.3);border-top-color:#fff;border-radius:50%;animation:spin 1s linear infinite;vertical-align:middle;margin-right:3px"></span>Upgrading</span>';
+              hubUpgradeBtn = ' <span title="Upgrading to ' + esc(hubBranchLatest || '?') + '" style="display:inline-block;padding:2px 8px;background:var(--surface);border:1px solid var(--border);border-radius:4px;font-size:0.65rem;margin-left:6px;white-space:nowrap;opacity:0.8"><span style="display:inline-block;width:10px;height:10px;border:2px solid rgba(255,255,255,0.3);border-top-color:#fff;border-radius:50%;animation:spin 1s linear infinite;vertical-align:middle;margin-right:3px"></span>Upgrading</span>';
             } else if (hubLatestUnknown && _isAdmin) {
               hubUpgradeBtn = ' <button disabled title="Waiting for latest version…" style="padding:2px 8px;background:var(--surface);color:var(--muted);border:1px solid var(--border);border-radius:4px;font-size:0.65rem;margin-left:6px;white-space:nowrap;cursor:not-allowed;opacity:0.5">Upgrade</button>';
             }
@@ -3547,9 +3635,10 @@ const dashboardHTML = `<!DOCTYPE html>
             }
             var hubStatusIcon = hubLatestUnknown
               ? ' <span style="display:inline-block;width:10px;height:10px;border:2px solid rgba(255,255,255,0.2);border-top-color:var(--accent);border-radius:50%;animation:spin 1s linear infinite;vertical-align:middle;margin-left:3px" title="Resolving latest version…"></span>'
-              : isCurrent ? '<span style="color:var(--green);margin-left:3px" title="hub is on latest">✓</span>' : '<span style="color:var(--red);margin-left:3px" title="hub is behind latest ' + esc(_latestSHA) + '">↑</span>';
-            var hubMsg = _latestSHAMessages['v2'] || '';
-            el.innerHTML = '<span style="font-family:monospace;font-size:0.7rem;color:var(--muted)" title="' + esc(hubMsg) + '">' + esc(hubHash) + '</span>' +
+              : isCurrent ? '<span style="color:var(--green);margin-left:3px" title="hub is on latest">✓</span>' : '<span style="color:var(--red);margin-left:3px" title="hub is behind latest ' + esc(hubBranchLatest) + '">↑</span>';
+            var hubBranchPill = '<span style="display:inline-block;padding:1px 6px;border-radius:9999px;font-size:0.6rem;background:rgba(59,130,246,0.15);color:#60a5fa;border:1px solid rgba(59,130,246,0.3);margin-right:4px">' + esc(hubBranch) + '</span>';
+            var hubMsg = _latestSHAMessages[hubBranch] || '';
+            el.innerHTML = hubBranchPill + '<span style="font-family:monospace;font-size:0.7rem;color:var(--muted)" title="' + esc(hubMsg) + '">' + esc(hubHash) + '</span>' +
               hubStatusIcon + hubUpgradeBtn + hubAutoCheck;
           }
         }
@@ -3701,7 +3790,21 @@ const dashboardHTML = `<!DOCTYPE html>
         if (sha) {
           var branchName = h.gitBranch || 'v2';
           var branchLatest = _latestSHAs[branchName] || _latestSHA;
-          var branch = '<span style="display:inline-block;padding:1px 6px;border-radius:9999px;font-size:0.6rem;background:rgba(59,130,246,0.15);color:#60a5fa;border:1px solid rgba(59,130,246,0.3);margin-right:4px">' + esc(branchName) + '</span>';
+          var _trackedBranches = _trackedBranchesList.length > 0 ? _trackedBranchesList : Object.keys(_latestSHAs);
+          if (_trackedBranches.length === 0) _trackedBranches = ['v2'];
+          var canSwitchBranch = isHosted && h.role === 'owner' && _trackedBranches.length > 1 && !h.upgrading;
+          var branchOptions = '';
+          if (canSwitchBranch) {
+            for (var bi = 0; bi < _trackedBranches.length; bi++) {
+              var tb = _trackedBranches[bi];
+              if (tb !== branchName) {
+                branchOptions += '<div onclick="switchBranch(\'' + esc(h.id) + '\',\'' + esc(tb) + '\',this)" style="padding:4px 10px;cursor:pointer;font-size:0.65rem;white-space:nowrap;color:#c9d1d9;border-radius:4px" onmouseover="this.style.background=\'rgba(59,130,246,0.2)\'" onmouseout="this.style.background=\'transparent\'">' + esc(tb) + '</div>';
+              }
+            }
+          }
+          var branch = canSwitchBranch
+            ? '<span id="branch-pill-' + esc(h.id) + '" style="display:inline-block;position:relative;padding:1px 6px;border-radius:9999px;font-size:0.6rem;background:rgba(59,130,246,0.15);color:#60a5fa;border:1px solid rgba(59,130,246,0.3);margin-right:4px;cursor:pointer" onclick="toggleBranchMenu(\'' + esc(h.id) + '\')" title="Click to switch branch">' + esc(branchName) + ' ▾<div id="branch-menu-' + esc(h.id) + '" style="display:none;position:absolute;top:100%;left:0;margin-top:4px;background:#1c2128;border:1px solid #30363d;border-radius:6px;padding:4px 0;z-index:1000;min-width:60px;box-shadow:0 4px 12px rgba(0,0,0,0.4)">' + branchOptions + '</div></span>'
+            : '<span style="display:inline-block;padding:1px 6px;border-radius:9999px;font-size:0.6rem;background:rgba(59,130,246,0.15);color:#60a5fa;border:1px solid rgba(59,130,246,0.3);margin-right:4px">' + esc(branchName) + '</span>';
           var latestUnknown = !branchLatest;
           var isCurrent = branchLatest && sha === branchLatest;
           var isUpgrading = (_upgradingHives[h.id] && sha === _upgradingHives[h.id]) || (h.upgrading && !isCurrent && !latestUnknown);
@@ -3851,6 +3954,95 @@ const dashboardHTML = `<!DOCTYPE html>
         setTimeout(loadHives, 60000);
         setTimeout(loadHives, 90000);
       } catch(e) { hiveToast('Error: ' + e.message, 'error'); delete _upgradingHives[id]; loadHives(); }
+    }
+
+    function toggleBranchMenu(hiveId) {
+      var menu = document.getElementById('branch-menu-' + hiveId);
+      if (!menu) return;
+      var isOpen = menu.style.display !== 'none';
+      document.querySelectorAll('[id^="branch-menu-"]').forEach(function(m) { m.style.display = 'none'; });
+      if (!isOpen) {
+        menu.style.display = 'block';
+        var closeHandler = function(e) {
+          if (!e.target.closest('#branch-pill-' + hiveId)) {
+            menu.style.display = 'none';
+            document.removeEventListener('click', closeHandler);
+          }
+        };
+        setTimeout(function() { document.addEventListener('click', closeHandler); }, 0);
+      }
+    }
+
+    var _switchTimers = {};
+    function switchBranch(hiveId, newBranch, el) {
+      if (el) el.closest('[id^="branch-menu-"]').style.display = 'none';
+      if (_switchTimers[hiveId]) {
+        clearInterval(_switchTimers[hiveId].interval);
+        delete _switchTimers[hiveId];
+      }
+      var SWITCH_DELAY_SEC = 5;
+      var remaining = SWITCH_DELAY_SEC;
+      var pill = document.getElementById('branch-pill-' + hiveId);
+      if (!pill) return;
+      var origHTML = pill.innerHTML;
+      pill.style.background = 'rgba(234,179,8,0.2)';
+      pill.style.borderColor = 'rgba(234,179,8,0.5)';
+      pill.style.color = '#eab308';
+      pill.onclick = function() { cancelBranchSwitch(hiveId, origHTML); };
+      pill.innerHTML = esc(newBranch) + ' in ' + remaining + 's ✕';
+      pill.title = 'Click to cancel';
+      var interval = setInterval(function() {
+        remaining--;
+        if (remaining <= 0) {
+          clearInterval(interval);
+          delete _switchTimers[hiveId];
+          pill.innerHTML = '<span style="display:inline-block;width:10px;height:10px;border:2px solid rgba(255,255,255,0.3);border-top-color:#fff;border-radius:50%;animation:spin 1s linear infinite;vertical-align:middle;margin-right:3px"></span>' + esc(newBranch);
+          pill.style.cursor = 'default';
+          pill.onclick = null;
+          doSwitchBranch(hiveId, newBranch);
+          return;
+        }
+        pill.innerHTML = esc(newBranch) + ' in ' + remaining + 's ✕';
+      }, 1000);
+      _switchTimers[hiveId] = { interval: interval, origHTML: origHTML };
+    }
+
+    function cancelBranchSwitch(hiveId, origHTML) {
+      if (_switchTimers[hiveId]) {
+        clearInterval(_switchTimers[hiveId].interval);
+        delete _switchTimers[hiveId];
+      }
+      var pill = document.getElementById('branch-pill-' + hiveId);
+      if (!pill) return;
+      pill.style.background = 'rgba(59,130,246,0.15)';
+      pill.style.borderColor = 'rgba(59,130,246,0.3)';
+      pill.style.color = '#60a5fa';
+      pill.innerHTML = origHTML;
+      pill.onclick = function() { toggleBranchMenu(hiveId); };
+      pill.title = 'Click to switch branch';
+      hiveToast('Branch switch cancelled', 'info');
+    }
+
+    async function doSwitchBranch(hiveId, newBranch) {
+      try {
+        hiveToast('Switching ' + hiveId + ' to ' + newBranch + '...', 'info');
+        var resp = await fetch('/api/saas/hives/' + encodeURIComponent(hiveId) + '/switch-branch', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ branch: newBranch })
+        });
+        var data = await resp.json();
+        if (!resp.ok) { hiveToast(data.error || 'Branch switch failed', 'error'); loadHives(); return; }
+        _upgradingHives[hiveId] = 'switching';
+        hiveToast('Switched ' + hiveId + ' to ' + newBranch + ' — waiting for rollout', 'success');
+        loadHives();
+        setTimeout(loadHives, 10000);
+        setTimeout(loadHives, 30000);
+        setTimeout(loadHives, 60000);
+      } catch(e) {
+        hiveToast('Error: ' + e.message, 'error');
+        loadHives();
+      }
     }
 
     async function autoRequestAccessFromUrl() {

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -121,6 +121,7 @@ type HubServer struct {
 	logger         *slog.Logger
 	saveCh         chan struct{}
 	hubGitHash     string
+	hubGitBranch   string
 	hubSecret      string
 	httpServer     *http.Server
 	clusters       map[string]ClusterConfig
@@ -157,7 +158,7 @@ type HubBannerEntry struct {
 	SentAt  string `json:"sent_at"`
 }
 
-func NewHubServer(port int, logger *slog.Logger, gitHash string) *HubServer {
+func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *HubServer {
 	secret := os.Getenv("HIVE_HUB_SECRET")
 	if secret == "" {
 		if data, err := os.ReadFile("/data/saas/hub-secret.key"); err == nil {
@@ -180,6 +181,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash string) *HubServer {
 		logger:           logger,
 		saveCh:           make(chan struct{}, 1),
 		hubGitHash:       gitHash,
+		hubGitBranch:     gitBranch,
 		hubSecret:        secret,
 		clusters:         loadClusters(logger),
 		heartbeatHealth:  make(map[string]*HeartbeatHealthEntry),
@@ -794,9 +796,10 @@ func (s *HubServer) handleRegistryDelete(w http.ResponseWriter, r *http.Request)
 
 func (s *HubServer) handleHubVersion(w http.ResponseWriter, r *http.Request) {
 	resp := map[string]any{
-		"git_hash":    s.hubGitHash,
-		"latest_sha":  getLatestSHA(),
-		"latest_shas": getLatestSHAs(),
+		"git_hash":       s.hubGitHash,
+		"git_branch":     s.hubGitBranch,
+		"latest_sha":     getLatestSHA(),
+		"latest_shas":    getLatestSHAs(),
 	}
 	cookie, _ := r.Cookie("hive_hub_user")
 	if cookie != nil && cookie.Value == hubAdminUsername {


### PR DESCRIPTION
## Summary
- Adds a clickable branch pill dropdown on each hive row in My Hives table — owners can switch between tracked branches (v2/v3) with a 5-second cancellable countdown
- New `POST /api/saas/hives/{id}/switch-branch` endpoint that sets the deployment image to `{branch}-latest` and triggers rollout restart
- Adds v2 branch pill next to hub SHA in the top bar, with version comparison against the correct branch
- Passes `hubGitBranch` through `NewHubServer` and exposes `hub_git_branch` + `tracked_branches` in API responses

## Test plan
- [ ] Verify branch pill appears in hub top bar showing "v2"
- [ ] Verify branch pill dropdown appears on owned hive rows with alternative branches
- [ ] Click a branch option → verify 5-second countdown with yellow styling
- [ ] Click during countdown → verify cancel works and pill reverts
- [ ] Let countdown complete → verify switch-branch API call fires and rollout begins
- [ ] Verify non-owners do not see the dropdown (static pill only)