### PR TITLE
fix: fallback hub branch to v2 when ldflags not set

### DIFF
--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -159,6 +159,9 @@ type HubBannerEntry struct {
 }
 
 func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *HubServer {
+	if gitBranch == "" || gitBranch == "unknown" {
+		gitBranch = "v2"
+	}
 	secret := os.Getenv("HIVE_HUB_SECRET")
 	if secret == "" {
 		if data, err := os.ReadFile("/data/saas/hub-secret.key"); err == nil {


### PR DESCRIPTION
## Summary
- When `gitBranch` is empty or `"unknown"` (ldflags not set at build time), default to `"v2"` instead of showing "unknown" in the hub top bar branch pill

## Test plan
- [ ] Hub built without `-X main.gitBranch=...` shows "v2" pill instead of "unknown"