### PR TITLE
fix: clear stuck Upgrading state when spoke is at latest SHA

### DIFF
--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -429,9 +429,15 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			if entry.SnapshotURL == "" {
 				entry.SnapshotURL = h.SnapshotURL
 			}
-			if h.Upgrading && !payload.Upgrading && payload.GitHash == h.UpgradeTarget {
-				// Non-upgrading heartbeat reporting the target SHA — upgrade
-				// completed, pod restarted successfully on the new image.
+			branchForLatest := payload.GitBranch
+			if branchForLatest == "" {
+				branchForLatest = "v2"
+			}
+			registryLatestSHA := getLatestSHAForBranch(branchForLatest)
+			if h.Upgrading && !payload.Upgrading && (payload.GitHash == h.UpgradeTarget || (registryLatestSHA != "" && payload.GitHash == registryLatestSHA)) {
+				// Non-upgrading heartbeat at the target SHA or at latest —
+				// upgrade completed (image may have advanced past the
+				// original target before the spoke pulled it).
 				entry.Upgrading = false
 				entry.UpgradeTarget = ""
 			} else if h.Upgrading && !payload.Upgrading && h.UpgradeTarget == "" {
@@ -562,8 +568,8 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	s.mu.RLock()
 	hbTarget := s.heartbeatUpgrade[payload.HiveID]
 	s.mu.RUnlock()
-	if hbTarget != "" && payload.GitHash == hbTarget {
-		// Spoke already upgraded — clear the fallback entry.
+	if hbTarget != "" && (payload.GitHash == hbTarget || (latestSHA != "" && payload.GitHash == latestSHA)) {
+		// Spoke already at the target or at latest — clear the fallback entry.
 		s.mu.Lock()
 		delete(s.heartbeatUpgrade, payload.HiveID)
 		s.mu.Unlock()


### PR DESCRIPTION
## Summary

- Fix hub heartbeat handler to accept spoke GitHash == latestSHA as upgrade completion (not just exact target match)
- Fix heartbeat fallback map (`heartbeatUpgrade`) to clear entry when spoke is already at latest SHA

## Root cause

When the `v2-latest` image is rebuilt between the time the hub sets an upgrade target and the spoke pulls it, the spoke runs a SHA newer than the target. Both the registry clearing logic and the heartbeat fallback map required an exact SHA match against the original target, so the `Upgrading` flag was never cleared.

The **open-source** hive on vllm-d was stuck in `Upgrading` state for 4 days:
1. Hub set target `c3659d4` (PR #1762)
2. Image rebuilt to `cbadb9b` (PR #1763) before spoke pulled it
3. Spoke reported `cbadb9b ≠ c3659d4`, hub kept `Upgrading=true`
4. Hub kept sending `UpgradeTo=c3659d4` via heartbeat fallback
5. Spoke skipped upgrade ("already attempted from this SHA")

## Test plan

- [x] `go build ./...` passes
- [ ] Deploy hub with fix, verify open-source hive clears Upgrading state on next heartbeat
- [ ] Verify spoke-managed and hub-managed upgrade paths still work correctly