### PR TITLE
fix: remove userinfo from proxy URL to fix Claude Code FailedToOpenSocket

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1353,6 +1353,7 @@ func main() {
 						"target", targetSHA,
 						"current", gitShort,
 					)
+					os.Remove(upgradeMarkerPath)
 					return
 				}
 			}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -2615,11 +2615,16 @@ func (m *Manager) agentEnvPairs(agent *AgentProcess) []agentEnvPair {
 	if err := os.WriteFile(modeFile, []byte(mode.String()), 0o644); err != nil {
 		m.logger.Warn("agentBootstrapEnv: mode file write failed", "file", modeFile, "error", err)
 	}
-	// Empty password (colon after username) prevents git from prompting for proxy credentials
-	proxyURL := fmt.Sprintf("http://%s:@127.0.0.1:%d", agent.Name, proxyListenPort)
+	// Plain proxy URL without userinfo — Claude Code's native binary fails
+	// to open a socket when the URL contains username:password@ (FailedToOpenSocket).
+	// Agent identification uses UID-based /proc/net/tcp lookup instead of
+	// Proxy-Authorization headers. GIT_TERMINAL_PROMPT=0 prevents git from
+	// prompting for proxy credentials.
+	proxyURL := fmt.Sprintf("http://127.0.0.1:%d", proxyListenPort)
 	vars = append(vars, agentEnvPair{"HTTPS_PROXY", proxyURL, false})
 	vars = append(vars, agentEnvPair{"HTTP_PROXY", proxyURL, false})
 	vars = append(vars, agentEnvPair{"HIVE_PROXY_AGENT", agent.Name, false})
+	vars = append(vars, agentEnvPair{"GIT_TERMINAL_PROMPT", "0", false})
 	vars = append(vars, agentEnvPair{"NODE_EXTRA_CA_CERTS", proxyCACertPath, false})
 	if sha := os.Getenv("HIVE_SHA"); sha != "" {
 		vars = append(vars, agentEnvPair{"HIVE_SHA", sha, false})

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -212,7 +212,7 @@ func (p *GitHubProxy) handleTransparentTLS(conn net.Conn, peeked []byte) {
 
 	// Identify agent by UID from /proc/net/tcp
 	agentName := ""
-	if p.uidMap != nil && p.uidMap.IptablesActive {
+	if p.uidMap != nil {
 		_, portStr, splitErr := net.SplitHostPort(conn.RemoteAddr().String())
 		if splitErr == nil {
 			port := 0
@@ -386,11 +386,12 @@ func (c *prefixConn) Read(b []byte) (int, error) {
 }
 
 
-// identifyAgentFromReq determines the agent name for a request. It prefers UID-based
-// identification (unforgeable) when iptables is active, falling back to
-// Proxy-Authorization headers for non-iptables deployments.
+// identifyAgentFromReq determines the agent name for a request. It always
+// tries UID-based identification first (unforgeable, works for any client
+// including native binaries that don't send Proxy-Authorization), falling
+// back to Proxy-Authorization headers when UID lookup fails.
 func (p *GitHubProxy) identifyAgentFromReq(r *http.Request) string {
-	if p.uidMap != nil && p.uidMap.IptablesActive {
+	if p.uidMap != nil {
 		if name := p.identifyAgentByUID(r.RemoteAddr); name != "" {
 			return name
 		}


### PR DESCRIPTION
## Summary

- **Claude Code native binary** fails with `FailedToOpenSocket` when `HTTPS_PROXY` contains userinfo (`http://agent:@host:port`). The binary never even opens a TCP connection to the proxy — it fails during URL parsing. Removing userinfo fixes it.
- **Agent identification** now uses UID-based `/proc/net/tcp` lookup unconditionally (not gated on `IptablesActive`). Each agent runs as its own Unix user, so this is reliable without iptables.
- **`GIT_TERMINAL_PROMPT=0`** prevents git from prompting for proxy credentials (previously suppressed by the empty-password userinfo format).
- **Spoke upgrade marker** is now cleared when the spoke skips a no-op upgrade, preventing the dashboard from perpetually showing "Upgrading".

## Root cause

Claude Code v2.1.190+ is a compiled native binary (Rust). Its HTTP client (`reqwest`) cannot parse proxy URLs with the `username:@` format — it fails before attempting any TCP connection. Confirmed by:
1. `HTTPS_PROXY=http://scanner:@127.0.0.1:18443` → FailedToOpenSocket (no connection to proxy)
2. `HTTPS_PROXY=http://127.0.0.1:18443` → works perfectly through the proxy

## Test plan

- [ ] Claude Code starts successfully with `backend: claude` through the proxy
- [ ] Copilot CLI still works (no regression)
- [ ] Proxy correctly identifies agents by UID (check proxy logs)
- [ ] Git operations work without credential prompts
- [ ] Spoke clears upgrade marker on no-op upgrade skip