### PR TITLE
fix: hub-side public/private toggle no longer reverted by heartbeat

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1468,6 +1468,12 @@ func main() {
 				return
 			}
 			dashSrv.SetHubBanner(banner.ID, banner.Message, banner.Color)
+		}), hub.VisibilityCallback(func(isPublic bool) {
+			if cfg.Hub.IsPublic != isPublic {
+				logger.Info("hub overrode visibility via heartbeat",
+					"was", cfg.Hub.IsPublic, "now", isPublic)
+				cfg.Hub.IsPublic = isPublic
+			}
 		}))
 
 		go hub.StartTaskStatusPush(ctx, hubURL, func() *hub.TaskStatusPayload {

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -137,6 +137,7 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 	var onUpgrade UpgradeCallback
 	var onGitHubAppConfig GitHubAppConfigCallback
 	var onHubBanner HubBannerCallback
+	var onVisibility VisibilityCallback
 	for _, cb := range callbacks {
 		switch fn := cb.(type) {
 		case UpgradeCallback:
@@ -145,6 +146,8 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 			onGitHubAppConfig = fn
 		case HubBannerCallback:
 			onHubBanner = fn
+		case VisibilityCallback:
+			onVisibility = fn
 		}
 	}
 
@@ -164,6 +167,9 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 		}
 		if onHubBanner != nil {
 			onHubBanner(resp.HubBanner)
+		}
+		if resp.IsPublic != nil && onVisibility != nil {
+			onVisibility(*resp.IsPublic)
 		}
 	}
 
@@ -350,6 +356,7 @@ type HeartbeatResponse struct {
 	LatestTag       string                    `json:"latest_tag,omitempty"`
 	GitHubAppConfig *HeartbeatGitHubAppConfig `json:"github_app_config,omitempty"`
 	HubBanner       *HubBanner                `json:"hub_banner,omitempty"`
+	IsPublic        *bool                     `json:"is_public,omitempty"`
 }
 
 // HubBanner is a message from the hub admin displayed on spoke dashboards.
@@ -362,6 +369,9 @@ type HubBanner struct {
 // HubBannerCallback is called when the hub delivers a banner message
 // via the heartbeat response.
 type HubBannerCallback func(banner *HubBanner)
+
+// VisibilityCallback is called when the hub overrides the spoke's IsPublic setting.
+type VisibilityCallback func(isPublic bool)
 
 // GitHubAppConfigCallback is called when the hub delivers GitHub App config
 // via the heartbeat response (app ID, installation ID, private key).

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -553,6 +553,10 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		LatestSHA:  latestSHA,
 	}
 
+	if entry.IsPublic != payload.IsPublic {
+		resp.IsPublic = &entry.IsPublic
+	}
+
 	// Check if the hive should self-upgrade via heartbeat response.
 	//
 	// Three upgrade paths, all controlled by a single toggle:

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -429,6 +429,11 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			if entry.SnapshotURL == "" {
 				entry.SnapshotURL = h.SnapshotURL
 			}
+			// Preserve hub-side visibility: if the hub set this hive
+			// to public, don't let the spoke's heartbeat revert it.
+			if h.IsPublic && !payload.IsPublic {
+				entry.IsPublic = h.IsPublic
+			}
 			branchForLatest := payload.GitBranch
 			if branchForLatest == "" {
 				branchForLatest = "v2"


### PR DESCRIPTION
Backports the IsPublic heartbeat fixes from v3:

1. **Preserve hub-side visibility** — the spoke's heartbeat unconditionally overwrote the hub's stored `IsPublic`, so setting a hive to public on the hub reverted to private on the next heartbeat.
2. **Sync back to the spoke** — the hub now includes `is_public` in the heartbeat response when it differs from what the spoke sent, and the spoke updates its local config to match, making the hub the source of truth.