### PR TITLE
fix: landing copy covers closed source maintenance too

### DIFF
--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -6,7 +6,7 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🍯</text></svg>">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta property="og:title" content="Hive — AI agents that maintain your repo">
-  <meta property="og:description" content="A fleet of AI agents handles the repetitive parts of open source maintenance — triaging issues, writing fixes, keeping dependencies secure, and merging on green CI.">
+  <meta property="og:description" content="A fleet of AI agents handles the repetitive parts of software maintenance — open source or private — triaging issues, writing fixes, keeping dependencies secure, and merging on green CI.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://hive.kubestellar.io">
   <meta name="description" content="Hive — AI agents that maintain your repo. Automated issue triage, dependency security, test fixes, and PR merges so maintainers can focus on innovation.">
@@ -415,9 +415,9 @@
     <!-- ── Hero ── -->
     <section class="hero section-pad" id="product">
       <div>
-        <p class="section-label">Open Source Maintenance on Autopilot</p>
+        <p class="section-label">Open &amp; Closed Source Maintenance on Autopilot</p>
         <h1>Put your repo on autopilot</h1>
-        <p class="hero-lede">Hive is a fleet of AI agents that handle the repetitive parts of maintaining an open source project &mdash; triaging issues, writing fixes, keeping dependencies secure, and merging on green CI. Maintainers are freed to innovate, grow adoption, and focus on strategy.</p>
+        <p class="hero-lede">Hive is a fleet of AI agents that handle the repetitive parts of maintaining a software project &mdash; open source or private &mdash; triaging issues, writing fixes, keeping dependencies secure, and merging on green CI. Maintainers are freed to innovate, grow adoption, and focus on strategy.</p>
         <div class="hero-actions">
           <a class="button primary" href="/get-started">Request a Hive</a>
           <a class="button secondary" href="#how-it-works">See how it works</a>


### PR DESCRIPTION
The hero eyebrow, lede, and og:description limited hive to open source maintenance. Hive serves private/closed-source repos as well — copy updated to say so.