### PR TITLE
fix: treat zero governor thresholds as unset

### DIFF
--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -538,13 +538,15 @@ func buildGovernor(state governor.State, cfg *config.Config) FrontendGovernor {
 		Surge: defaultSurge,
 	}
 
-	if m, ok := cfg.Governor.Modes["quiet"]; ok {
+	// Threshold zero means unset (mode entry present only for cadences);
+	// keep the defaults so the gauge matches the governor's evaluation.
+	if m, ok := cfg.Governor.Modes["quiet"]; ok && m.Threshold > 0 {
 		thresholds.Quiet = m.Threshold
 	}
-	if m, ok := cfg.Governor.Modes["busy"]; ok {
+	if m, ok := cfg.Governor.Modes["busy"]; ok && m.Threshold > 0 {
 		thresholds.Busy = m.Threshold
 	}
-	if m, ok := cfg.Governor.Modes["surge"]; ok {
+	if m, ok := cfg.Governor.Modes["surge"]; ok && m.Threshold > 0 {
 		thresholds.Surge = m.Threshold
 	}
 

--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -224,7 +224,10 @@ func (g *Governor) computeMode(queueDepth int) Mode {
 }
 
 func (g *Governor) thresholdFor(modeName string) int {
-	if mode, ok := g.cfg.Modes[modeName]; ok {
+	// A mode entry may exist only for cadences with threshold unset
+	// (zero). Zero thresholds would make every non-empty queue surge,
+	// so fall through to the defaults in that case.
+	if mode, ok := g.cfg.Modes[modeName]; ok && mode.Threshold > 0 {
 		return mode.Threshold
 	}
 	switch modeName {


### PR DESCRIPTION
On hives whose hive.yaml defines governor mode entries only for cadences (threshold field unset → 0), the governor classified any non-empty queue as **surge** and the dashboard intensity scale rendered degenerate (all zone boundaries at 0, surge label colliding with the needle at midpoint — seen on daviddiaz0317/visual-hive-demo-site at 5 issues / max 10).

Both the governor's mode evaluation and the status API now treat threshold <= 0 as unset and fall back to the defaults (quiet=2, busy=10, surge=20) — which is what the Thresholds config dialog was already claiming.