### PR TITLE
fix: unstick hives stuck in Upgrading with a stale target

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2182,7 +2182,10 @@ func (s *HubServer) triggerAutoUpgrades() {
 				branch = "v2"
 			}
 			upgradeAge := time.Since(upgradeStartedAt)
-			isStale := !upgradeStartedAt.IsZero() && upgradeAge > staleUpgradeTimeout
+			// Zero UpgradeStartedAt means the timestamp was lost (heartbeats
+			// used to wipe it on rebuild) — treat as stale so already-stuck
+			// hives self-heal instead of upgrading forever.
+			isStale := upgradeStartedAt.IsZero() || upgradeAge > staleUpgradeTimeout
 
 			if isStale {
 				// Upgrade has been stuck longer than staleUpgradeTimeout.

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -456,6 +456,10 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				} else {
 					entry.Upgrading = true
 					entry.UpgradeTarget = h.UpgradeTarget
+					// Preserve the trigger timestamp — losing it here made
+					// the stale-upgrade recovery in triggerAutoUpgrades()
+					// unreachable (it saw a zero UpgradeStartedAt forever).
+					entry.UpgradeStartedAt = h.UpgradeStartedAt
 				}
 			}
 			// Sparkline history: sample every 15 min, keep 7 days (672 points)


### PR DESCRIPTION
daviddiaz0317's hive has been stuck 'Upgrading' toward `4f4d065` while already running `5ae9efe` (newer). Root cause chain:

1. The auto-upgrade sweep stamps `UpgradeStartedAt` when it sets a target, and has a stale-upgrade recovery that advances the target to latest after `staleUpgradeTimeout`.
2. But the heartbeat handler rebuilds the registry entry on every heartbeat and **never preserved `UpgradeStartedAt`** — so the recovery always saw a zero timestamp and `isStale` could never be true (dead code).
3. With the spoke's hash never changing (it was already past the stale target), no clear condition could ever fire → Upgrading forever.

Fix: preserve `UpgradeStartedAt` across heartbeats, and treat a zero timestamp as stale so hives already stuck (like David's) self-heal on the next sweep — target advances to latest, kubectl restart + heartbeat fallback fire.