### PR TITLE
fix: don't report empty queue when all repo fetches fail

### DIFF
--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -183,10 +183,15 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 	var holdItems []HoldItem
 	totalByRepo := make(map[string]RepoCounts)
 
-	for _, repo := range c.getRepos() {
+	repos := c.getRepos()
+	failedRepos := 0
+	var lastFetchErr error
+	for _, repo := range repos {
 		issues, held, issueTotal, err := c.fetchIssues(ctx, repo, now)
 		if err != nil {
 			c.logger.Warn("failed to fetch issues", "repo", repo, "error", err)
+			failedRepos++
+			lastFetchErr = err
 			continue
 		}
 		allIssues = append(allIssues, issues...)
@@ -195,12 +200,21 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 		prs, heldPRs, prTotal, err := c.fetchPRs(ctx, repo)
 		if err != nil {
 			c.logger.Warn("failed to fetch PRs", "repo", repo, "error", err)
+			failedRepos++
+			lastFetchErr = err
 			continue
 		}
 		allPRs = append(allPRs, prs...)
 		holdItems = append(holdItems, heldPRs...)
 
 		totalByRepo[repo] = RepoCounts{Issues: issueTotal, PRs: prTotal}
+	}
+
+	// If every repo failed (e.g. API rate limit exhausted), returning a
+	// zero-count result would tell the governor the queue is empty and
+	// idle the agents. Surface the failure so callers keep prior state.
+	if len(repos) > 0 && failedRepos >= len(repos) {
+		return nil, fmt.Errorf("all %d repos failed to enumerate (last error: %w)", len(repos), lastFetchErr)
 	}
 
 	sort.Slice(allIssues, func(i, j int) bool {


### PR DESCRIPTION
The console hive (L6, 10 agents) exhausted its GitHub App installation rate limit (15k/hr). Every `fetchIssues`/`fetchPRs` 403'd, `EnumerateActionable` swallowed the per-repo errors and returned a zero-count result, and the governor idled the fleet believing the queue was empty — while 10 issues and 10 PRs were open.

If every repo fails to enumerate, return an error instead. The caller (`runGovernorCycle`) already handles an error by keeping the previous actionable state, so counts freeze at their last known values instead of collapsing to zero. Partial failures keep the current best-effort behavior.