### PR TITLE
feat: add provider-auth step to landing Get Started rail

### DIFF
--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -516,6 +516,10 @@
           </div>
           <div class="install-step">
             <span>4</span>
+            <div><h3>Connect your AI provider</h3><p style="font-size:.88rem">On each agent card, pick the CLI (Claude Code, Copilot, &hellip;) and model, then authenticate &mdash; open the agent's terminal and run the CLI's login command, or use the card's Login button. Prefer local? Point agents at your own models via vLLM or llm-d &mdash; no provider account needed.</p></div>
+          </div>
+          <div class="install-step">
+            <span>5</span>
             <div><h3>Agents start working</h3><p style="font-size:.88rem">Within minutes, agents begin triaging issues, writing fixes, and opening PRs. Watch from your dashboard.</p></div>
           </div>
         </div>


### PR DESCRIPTION
The Get Started steps skipped provider authentication. New step 4 of 5: pick the CLI (Claude Code, Copilot, …) and model on each agent card, then authenticate — open the agent's terminal and run the CLI's login command, or use the card's Login button. Also mentions the local-model path (vLLM / llm-d) that needs no provider account.