### PR TITLE
fix: clean default agent names + snapshot() dropping login/restart state

### DIFF
--- a/v2/deploy/hive-level2-knuckle.yaml
+++ b/v2/deploy/hive-level2-knuckle.yaml
@@ -39,7 +39,7 @@ agents:
     stale_timeout: 3600
     restart_strategy: immediate
     launch_cmd: "agent-launch.sh --backend copilot --model claude-sonnet-4-6"
-    display_name: guide (advisory)
+    display_name: guide
     kick_template: guide-advisory.md
   scanner:
     enabled: true
@@ -51,7 +51,7 @@ agents:
     stale_timeout: 7200
     restart_strategy: immediate
     launch_cmd: "agent-launch.sh --backend copilot --model claude-sonnet-4-6"
-    display_name: scanner (advisory)
+    display_name: scanner
     kick_template: scanner-advisory.md
   quality:
     enabled: true
@@ -63,7 +63,7 @@ agents:
     stale_timeout: 7200
     restart_strategy: immediate
     launch_cmd: "agent-launch.sh --backend copilot --model claude-sonnet-4-6"
-    display_name: quality (advisory)
+    display_name: quality
     kick_template: quality-advisory.md
 
 governor:

--- a/v2/deploy/hive-level3-knuckle.yaml
+++ b/v2/deploy/hive-level3-knuckle.yaml
@@ -41,7 +41,7 @@ agents:
     stale_timeout: 3600
     restart_strategy: immediate
     launch_cmd: "agent-launch.sh --backend copilot --model claude-sonnet-4-6"
-    display_name: guide (advisory)
+    display_name: guide
     kick_template: guide-advisory.md
   scanner:
     enabled: true
@@ -53,7 +53,7 @@ agents:
     stale_timeout: 7200
     restart_strategy: immediate
     launch_cmd: "agent-launch.sh --backend copilot --model claude-sonnet-4-6"
-    display_name: scanner (advisory)
+    display_name: scanner
     kick_template: scanner-advisory.md
   quality:
     enabled: true

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1887,6 +1887,8 @@ func (a *AgentProcess) snapshot() AgentProcess {
 	a.paneMu.RLock()
 	pane := make([]string, len(a.lastPaneCapture))
 	copy(pane, a.lastPaneCapture)
+	// NeedsLogin is written by the pane poller under paneMu.
+	needsLogin := a.NeedsLogin
 	a.paneMu.RUnlock()
 	return AgentProcess{
 		Name:            a.Name,
@@ -1908,6 +1910,9 @@ func (a *AgentProcess) snapshot() AgentProcess {
 		RestartCount:    a.RestartCount,
 		KickHistory:     history,
 		LastKickMessage: a.LastKickMessage,
+		NeedsLogin:      needsLogin,
+		HasLaunched:     a.HasLaunched,
+		LaunchedMode:    a.LaunchedMode,
 		tmuxSession:     a.tmuxSession,
 		tmuxSocket:      a.tmuxSocket,
 		OutputBuffer:    a.OutputBuffer,

--- a/v2/pkg/config/packs/level-2.yaml
+++ b/v2/pkg/config/packs/level-2.yaml
@@ -55,7 +55,7 @@ agents:
       Reads agent health history and operational patterns. Produces sweep
       reports and health assessments.
   - name: guide
-    display_name: guide (advisory)
+    display_name: guide
     role: guide
     description: >
       Audits project documentation and onboarding experience. At L2, reports
@@ -75,7 +75,7 @@ agents:
       Reads community wiki and project patterns. Starts contributing review
       insights as knowledge entries.
   - name: scanner
-    display_name: scanner (advisory)
+    display_name: scanner
     role: scanner
     description: >
       Scans code for issues and suggests fixes, but does NOT create PRs or
@@ -96,7 +96,7 @@ agents:
       Reads project patterns and known issues. Produces findings as knowledge
       entries for the team to review.
   - name: quality
-    display_name: quality (advisory)
+    display_name: quality
     role: quality
     description: >
       Analyzes test coverage gaps and suggests test strategies. At L2, reports

--- a/v2/pkg/config/packs/level-3.yaml
+++ b/v2/pkg/config/packs/level-3.yaml
@@ -67,7 +67,7 @@ agents:
 
     '
 - name: scanner
-  display_name: scanner (advisory)
+  display_name: scanner
   role: scanner
   description: 'Scans code for issues and suggests fixes, but does NOT create PRs
     or issues. Reports findings as beads for the advisory digest.
@@ -93,7 +93,7 @@ agents:
 
     '
 - name: ci-maintainer
-  display_name: ci-maintainer (advisory)
+  display_name: ci-maintainer
   role: ci-maintainer
   description: 'Monitors CI health, workflow status, and build trends. Reports findings
     as beads for the advisory digest. Does NOT create PRs or issues.
@@ -148,7 +148,7 @@ agents:
 
     '
 - name: guide
-  display_name: guide (advisory)
+  display_name: guide
   role: guide
   description: 'Audits project documentation and onboarding experience. Reports findings
     as beads for the advisory digest. Does NOT create PRs or issues.


### PR DESCRIPTION
Two fixes, one commit each (individually revertable):

1. **Remove '(advisory)' from default agent display names** — level-2/level-3 ACMM packs and the knuckle deploy examples shipped `display_name: scanner (advisory)` etc. Mode is already conveyed by the ACMM/mode badges; names stay clean. Fixes out-of-the-box provisioning (existing hives keep their PVC config).

2. **snapshot() dropped NeedsLogin/HasLaunched/LaunchedMode** — the pane poller sets NeedsLogin on the live agent struct, but AllStatuses() snapshots never copied it, so the dashboard showed '✓ logged in' for every agent — including daviddiaz0317's scanner whose pane says 'Please use /login to sign in to use Copilot'. Same hole silently disabled the NeedsRestart indicator.