### PR TITLE
feat: explain read-only permissions in save-failure toasts

### DIFF
--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -605,7 +605,7 @@ func (s *Server) roleEnforcement(next http.Handler) http.Handler {
 		w.Header().Set("X-Hive-User", r.Header.Get("X-Hive-User"))
 		if role == "read" && r.Method != http.MethodGet && r.Method != http.MethodHead && r.Method != http.MethodOptions {
 			if !strings.HasPrefix(r.URL.Path, "/api/contribute") && r.URL.Path != "/api/gh-user-auth/status" {
-				http.Error(w, `{"error":"read-only access"}`, http.StatusForbidden)
+				http.Error(w, `{"error":"your permissions on this hive are read-only, so changes are not allowed. Contact the owner of this hive to ask for write permissions."}`, http.StatusForbidden)
 				return
 			}
 		}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -11474,7 +11474,7 @@ function burnAreaChart() {
           headers: _inceptionAuthHeaders(),
           body: JSON.stringify({ id: newId }),
         });
-        if (!res.ok) throw new Error('HTTP ' + res.status);
+        if (!res.ok) throw new Error(await saveErrorMessage(res));
         showToast('Hive ID updated to ' + newId);
       } catch (err) {
         showToast('Failed to save Hive ID: ' + err.message, 'error');
@@ -12059,6 +12059,20 @@ function burnAreaChart() {
         .catch(err => showToast(`Failed: ${err.message}`, 'error'));
     }
 
+    // saveErrorMessage turns a failed save Response into a user-facing
+    // message. 403 means the hub proxied this user in with read-only
+    // access — explain that instead of a bare HTTP status.
+    async function saveErrorMessage(res) {
+      if (res.status === 403) {
+        return 'your permissions on this hive are read-only, so changes are not allowed. Contact the owner of this hive to ask for write permissions.';
+      }
+      try {
+        const d = await res.json();
+        if (d && d.error) return d.error;
+      } catch (e) { /* non-JSON body */ }
+      return 'HTTP ' + res.status;
+    }
+
     async function saveConfig() {
       const dirty = _configState.dirty;
 
@@ -12132,14 +12146,14 @@ function burnAreaChart() {
               headers: _inceptionAuthHeaders(),
               body: JSON.stringify({ id: values.hiveId })
             });
-            if (!idRes.ok) throw new Error('HTTP ' + idRes.status);
+            if (!idRes.ok) throw new Error(await saveErrorMessage(idRes));
           } else {
             const res = await fetch(`${base}/${section}`, {
               method: 'PUT',
               headers: _inceptionAuthHeaders(),
               body: JSON.stringify(values)
             });
-            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            if (!res.ok) throw new Error(await saveErrorMessage(res));
           }
         } catch (err) {
           showToast(`Failed to save ${section}: ${err.message}`, 'error');


### PR DESCRIPTION
Saving config with read-only access showed 'Failed to save general: HTTP 403'. Toasts now say: your permissions on this hive are read-only, changes are not allowed — contact the owner of this hive to ask for write permissions. Covers config-section saves + Hive ID save, and the role-enforcement middleware's 403 body carries the same message.