### PR TITLE
feat: LiteLLM inference backend with governor config tab

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -163,6 +163,18 @@ RUN (which git && git clone -b feat/cli-agent-mode https://github.com/clubanders
     /opt/nous/venv/bin/pip install --no-cache-dir -e /opt/nous 2>&1) || \
     echo "WARN: Nous install failed — run_campaign.py may not work"
 
+# --- LiteLLM proxy (pinned; optional local Anthropic-compat translator) ---
+# Used only when governor.litellm.local_proxy is true; the default flow
+# forwards to the remote LiteLLM endpoint via the Go inference translator.
+# All heavy deps ship manylinux aarch64 wheels, so multi-arch builds work
+# without compilation. || echo matches the Nous/Goose optional-layer convention.
+ARG LITELLM_VERSION=1.74.3
+RUN (python3 -m venv /opt/litellm/venv && \
+    /opt/litellm/venv/bin/pip install --no-cache-dir "litellm[proxy]==${LITELLM_VERSION}" && \
+    ln -s /opt/litellm/venv/bin/litellm /usr/local/bin/litellm) || \
+    echo "WARN: litellm install failed — local litellm proxy unavailable"
+RUN mkdir -p /data/litellm
+
 EXPOSE 3001 3002 7681
 VOLUME ["/data", "/secrets"]
 

--- a/v2/README.md
+++ b/v2/README.md
@@ -78,7 +78,7 @@ Seven agents ship as defaults (scanner, ci-maintainer, quality, architect, super
 agents:
   scanner:
     enabled: true
-    backend: claude        # claude | copilot | gemini | goose
+    backend: claude        # claude | copilot | gemini | goose | vllm | llm-d | litellm
     model: claude-sonnet-4-6
     caveman_mode: full     # lite | full | ultra | wenyan — compresses output ~65%
     beads_dir: /data/beads/scanner
@@ -136,6 +136,39 @@ governor:
     idle:
       threshold: 0
 ```
+
+## Inference Backends
+
+Besides CLI backends (claude, copilot, …), agents can run against
+self-hosted, OpenAI-compatible inference backends: **vllm**, **llm-d**, and
+**litellm**. The agent still launches the Claude CLI (bare mode); the hive's
+inference translator converts Anthropic Messages API calls to OpenAI format
+and forwards them to the backend. The MITM proxy stays in the path, so mode
+enforcement, logging, and per-agent attribution are unchanged.
+
+Endpoints for vllm/llm-d come from `HIVE_VLLM_ENDPOINT` /
+`HIVE_LLMD_ENDPOINT` (in-cluster defaults exist). LiteLLM is configured
+under `governor.litellm` — via the dashboard's Governor Config → LiteLLM
+tab, or in YAML:
+
+```yaml
+governor:
+  litellm:
+    endpoint: https://litellm.example.com   # HIVE_LITELLM_ENDPOINT overrides
+    api_key_env: HIVE_LITELLM_API_KEY       # env var NAME — never the key value
+    api_key_file: /secrets/litellm_api_key  # or a mounted key file (wins over env)
+    default_model: gpt-4o
+    ca_bundle: /secrets/litellm-ca.pem      # optional PEM for a private CA
+    local_proxy: false                      # run the bundled litellm binary locally
+```
+
+The API key is resolved at use time (file → named env var →
+`HIVE_LITELLM_API_KEY`) and is never written to `hive.yaml` or exposed via
+the API. Model discovery uses the backend's `/v1/models` (with bearer auth
+for litellm); `HIVE_LITELLM_MODELS` is a comma-separated fallback list.
+With `local_proxy: true`, hive supervises a bundled `litellm` process on
+loopback (config at `/data/litellm/config.yaml`) and routes through it
+instead of the remote endpoint — agents never bypass the Go translator.
 
 ## Knowledge
 

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1153,12 +1153,46 @@ func main() {
 
 		vllmEndpoints := parseEndpointList(envOrDefault("HIVE_VLLM_ENDPOINT", "http://hive-vllm-svc.hive-inference.svc.cluster.local:8000"))
 		llmdEndpoints := parseEndpointList(envOrDefault("HIVE_LLMD_ENDPOINT", "http://hive-llm-d-epp.hive-inference.svc.cluster.local:8000"))
-		dashSrv.SetInferenceEndpoints(map[string][]string{
+		inferenceEndpoints := map[string][]string{
 			"vllm":  vllmEndpoints,
 			"llm-d": llmdEndpoints,
-		})
+		}
+		// litellm has no in-cluster default: register it only when an
+		// endpoint is configured (yaml or HIVE_LITELLM_ENDPOINT), so an
+		// unconfigured backend doesn't show up in model discovery. A URL
+		// saved later from the governor LiteLLM tab is registered at
+		// runtime via dashSrv.UpdateInferenceEndpoint.
+		if litellmEndpoint := cfg.Governor.LiteLLM.ResolveEndpoint(); litellmEndpoint != "" {
+			inferenceEndpoints["litellm"] = parseEndpointList(litellmEndpoint)
+		}
+		dashSrv.SetInferenceEndpoints(inferenceEndpoints)
 		agentMgr.SetInferenceCallbacks(
 			func(agentName, backend, model string) {
+				if backend == "litellm" {
+					// Resolve endpoint/key at call time so a URL saved from
+					// the governor LiteLLM tab (or a rotated key) takes
+					// effect without a hive restart. cfg is the live config
+					// pointer — the config watcher swaps its contents in
+					// place on reload.
+					lc := cfg.Governor.LiteLLM
+					endpoint := lc.ResolveEndpoint()
+					if endpoint == "" {
+						logger.Warn("litellm backend selected but no endpoint configured",
+							"agent", agentName, "model", model)
+						return
+					}
+					if model == "" {
+						model = lc.DefaultModel
+					}
+					githubProxy.SetInferenceRoute(agentName, &proxy.InferenceRoute{
+						Backend:  backend,
+						Endpoint: endpoint,
+						Model:    model,
+						APIKey:   lc.ResolveAPIKey(),
+						CABundle: lc.CABundle,
+					})
+					return
+				}
 				endpoints := vllmEndpoints
 				if backend == "llm-d" {
 					endpoints = llmdEndpoints

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1163,7 +1163,9 @@ func main() {
 				if backend == "llm-d" {
 					endpoints = llmdEndpoints
 				}
-				endpoint := proxy.FindEndpointForModel(endpoints, model)
+				// vllm/llm-d endpoints are unauthenticated with a public
+				// or in-cluster CA — no bearer key or custom CA bundle.
+				endpoint := proxy.FindEndpointForModel(endpoints, model, "", "")
 				if endpoint == "" {
 					logger.Warn("no endpoint serves model, using first endpoint",
 						"agent", agentName, "model", model, "backend", backend)

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"regexp"
@@ -1162,7 +1163,9 @@ func main() {
 		// unconfigured backend doesn't show up in model discovery. A URL
 		// saved later from the governor LiteLLM tab is registered at
 		// runtime via dashSrv.UpdateInferenceEndpoint.
-		if litellmEndpoint := cfg.Governor.LiteLLM.ResolveEndpoint(); litellmEndpoint != "" {
+		if cfg.Governor.LiteLLM.LocalProxy {
+			inferenceEndpoints["litellm"] = []string{litellmLocalProxyURL()}
+		} else if litellmEndpoint := cfg.Governor.LiteLLM.ResolveEndpoint(); litellmEndpoint != "" {
 			inferenceEndpoints["litellm"] = parseEndpointList(litellmEndpoint)
 		}
 		dashSrv.SetInferenceEndpoints(inferenceEndpoints)
@@ -1176,6 +1179,12 @@ func main() {
 					// place on reload.
 					lc := cfg.Governor.LiteLLM
 					endpoint := lc.ResolveEndpoint()
+					if lc.LocalProxy {
+						// Local fallback: the Go translator forwards to the
+						// bundled litellm proxy on loopback instead of the
+						// remote endpoint.
+						endpoint = litellmLocalProxyURL()
+					}
 					if endpoint == "" {
 						logger.Warn("litellm backend selected but no endpoint configured",
 							"agent", agentName, "model", model)
@@ -1226,6 +1235,9 @@ func main() {
 				logger.Error("inference translation server failed", "error", err)
 			}
 		}()
+		if cfg.Governor.LiteLLM.LocalProxy {
+			go superviseLocalLiteLLM(ctx, logger)
+		}
 		logger.Info("github proxy started", "addr", githubProxy.ListenAddr())
 	}
 
@@ -2626,6 +2638,58 @@ func envOrDefault(key, fallback string) string {
 
 // parseEndpointList splits a comma-separated list of URLs into a slice.
 // A single URL is returned as a one-element slice.
+const (
+	// litellmLocalProxyPort is the loopback port the bundled litellm proxy
+	// listens on when governor.litellm.local_proxy is enabled. Distinct from
+	// proxy.InferenceTranslatePort (18444): agents always talk to the Go
+	// translator, which forwards to this local litellm instance.
+	litellmLocalProxyPort = 18445
+	// litellmLocalConfigPath is the user-provided litellm proxy config
+	// (model list, upstream keys) on the /data volume.
+	litellmLocalConfigPath = "/data/litellm/config.yaml"
+	// litellmRestartDelay is the pause before restarting a crashed local
+	// litellm proxy, to avoid a tight crash loop.
+	litellmRestartDelay = 5 * time.Second
+)
+
+// litellmLocalProxyURL is the endpoint the Go inference translator forwards
+// to when the local litellm proxy fallback is enabled.
+func litellmLocalProxyURL() string {
+	return fmt.Sprintf("http://127.0.0.1:%d", litellmLocalProxyPort)
+}
+
+// superviseLocalLiteLLM runs the bundled litellm binary as a local
+// Anthropic-compat translator fallback (governor.litellm.local_proxy: true),
+// restarting it on exit like StartInferenceTranslator's supervision.
+// Agents never talk to it directly — the Go translator stays in front so
+// per-agent attribution, mode enforcement, and the MITM proxy path are
+// preserved.
+func superviseLocalLiteLLM(ctx context.Context, logger *slog.Logger) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		cmd := exec.CommandContext(ctx, "litellm",
+			"--host", "127.0.0.1",
+			"--port", strconv.Itoa(litellmLocalProxyPort),
+			"--config", litellmLocalConfigPath)
+		logger.Info("starting local litellm proxy",
+			"port", litellmLocalProxyPort, "config", litellmLocalConfigPath)
+		if err := cmd.Run(); err != nil {
+			logger.Warn("local litellm proxy exited", "error", err)
+		} else {
+			logger.Warn("local litellm proxy exited cleanly; restarting")
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(litellmRestartDelay):
+		}
+	}
+}
+
 func parseEndpointList(raw string) []string {
 	parts := strings.Split(raw, ",")
 	out := make([]string, 0, len(parts))

--- a/v2/hive.yaml.example
+++ b/v2/hive.yaml.example
@@ -162,6 +162,22 @@ governor:
       tester: 30m                         # most active when nothing else is happening
       architect: 30m
 
+  # LiteLLM inference backend (optional) — route agents through an
+  # OpenAI-compatible LiteLLM proxy. Agents using backend "litellm" launch
+  # the claude CLI in bare mode and reach the endpoint through the hive's
+  # inference translator (the MITM proxy stays in the path).
+  # SECURITY: never put the API key VALUE here — hive.yaml is rewritten by
+  # the dashboard with env vars expanded. Store only the env var NAME or a
+  # key file path; the key is resolved at use time.
+  # litellm:
+  #   endpoint: https://litellm.example.com   # base URL (HIVE_LITELLM_ENDPOINT overrides)
+  #   api_key_env: HIVE_LITELLM_API_KEY       # env var NAME holding the key (default)
+  #   api_key_file: /secrets/litellm_api_key  # or a mounted key file (default path)
+  #   default_model: gpt-4o                   # model used when an agent has none selected
+  #   ca_bundle: /secrets/litellm-ca.pem      # optional PEM for a private CA
+  #   local_proxy: false                      # run the bundled litellm binary locally
+  #                                           # (config at /data/litellm/config.yaml)
+
 # GitHub authentication — use ONE of these methods
 github:
   # Option 1: Personal access token (simplest)

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -3154,6 +3154,32 @@ func (m *Manager) SetBackendOverride(name, backend string) error {
 	return nil
 }
 
+// RefreshInferenceRoutes re-fires the inference route callback for every
+// agent whose effective backend matches, so endpoint or credential changes
+// (e.g. a governor LiteLLM config save) take effect on live agents without
+// a restart.
+func (m *Manager) RefreshInferenceRoutes(backend string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.inferenceRouteCallback == nil || !IsInferenceBackend(backend) {
+		return
+	}
+	for name, agent := range m.agents {
+		effective := agent.Config.Backend
+		if agent.BackendOverride != "" {
+			effective = agent.BackendOverride
+		}
+		if effective != backend {
+			continue
+		}
+		model := agent.ModelOverride
+		if model == "" {
+			model = agent.Config.Model
+		}
+		m.inferenceRouteCallback(name, backend, model)
+	}
+}
+
 // GetBufferOutput returns output from the ring buffer directly, bypassing
 // the tmux pane capture. The ring buffer accumulates all output over time
 // (up to 500 lines) while the pane capture only has visible lines.

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -114,9 +114,11 @@ type AppTokenMinter interface {
 }
 
 // IsInferenceBackend returns true if the backend is a self-hosted inference
-// backend (vllm, llm-d) rather than a CLI tool.
+// backend (vllm, llm-d, litellm) rather than a CLI tool. Delegates to the
+// canonical list in the config package (shared with the proxy package,
+// which cannot be imported from here without a cycle).
 func IsInferenceBackend(backend string) bool {
-	return backend == "vllm" || backend == "llm-d"
+	return config.IsInferenceBackend(backend)
 }
 
 // ReloadClaudeToken re-reads the Claude credentials file and updates the
@@ -2103,6 +2105,7 @@ func backendBinary(backend string) (string, error) {
 		"bob":     "bob",
 		"vllm":    "claude",
 		"llm-d":   "claude",
+		"litellm": "claude",
 	}
 
 	binary, ok := binaries[backend]

--- a/v2/pkg/agent/manager_coverage2_test.go
+++ b/v2/pkg/agent/manager_coverage2_test.go
@@ -1039,6 +1039,7 @@ func TestIsInferenceBackend(t *testing.T) {
 	}{
 		{"vllm", true},
 		{"llm-d", true},
+		{"litellm", true},
 		{"claude", false},
 		{"copilot", false},
 		{"gemini", false},
@@ -1692,8 +1693,8 @@ func TestReadCoveragePreamble_MissingTarget(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestBackendBinary_InferenceBackends(t *testing.T) {
-	// vllm and llm-d should map to claude binary
-	for _, backend := range []string{"vllm", "llm-d"} {
+	// vllm, llm-d, and litellm should map to claude binary
+	for _, backend := range []string{"vllm", "llm-d", "litellm"} {
 		path, err := backendBinary(backend)
 		if err != nil {
 			t.Errorf("backendBinary(%q) error: %v", backend, err)

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -348,6 +349,7 @@ type GovernorConfig struct {
 	Health        HealthConfig          `yaml:"health"`
 	Budget        BudgetConfig          `yaml:"budget"`
 	Logging       LoggingConfig         `yaml:"logging"`
+	LiteLLM       LiteLLMConfig         `yaml:"litellm"`
 }
 
 type LoggingConfig struct {
@@ -357,6 +359,81 @@ type LoggingConfig struct {
 	MaxBackups int    `yaml:"max_backups"`
 	Compress   bool   `yaml:"compress"`
 	Level      string `yaml:"level"`
+}
+
+// LiteLLM key/endpoint resolution defaults. hive.yaml stores only the env
+// var NAME and/or key FILE PATH — never the key value itself. Config.Save()
+// writes the expanded config back to disk, so a key value stored in YAML
+// would be baked into the file in plaintext.
+const (
+	// DefaultLiteLLMAPIKeyEnv is the env var consulted for the LiteLLM API
+	// key when api_key_env is not set in hive.yaml.
+	DefaultLiteLLMAPIKeyEnv = "HIVE_LITELLM_API_KEY"
+	// DefaultLiteLLMAPIKeyFile is the key file consulted when api_key_file
+	// is not set. Matches the /secrets volume used for k8s Secret mounts.
+	DefaultLiteLLMAPIKeyFile = "/secrets/litellm_api_key"
+	// LiteLLMEndpointEnv overrides governor.litellm.endpoint at runtime
+	// (mirrors HIVE_VLLM_ENDPOINT / HIVE_LLMD_ENDPOINT).
+	LiteLLMEndpointEnv = "HIVE_LITELLM_ENDPOINT"
+)
+
+// LiteLLMConfig configures the litellm inference backend: an OpenAI-compatible
+// LiteLLM proxy (remote or local) that agents reach through the hive's
+// inference translator.
+type LiteLLMConfig struct {
+	Endpoint     string `yaml:"endpoint"`      // base URL, e.g. https://litellm.example.com
+	APIKeyEnv    string `yaml:"api_key_env"`   // env var NAME holding the key; default HIVE_LITELLM_API_KEY
+	APIKeyFile   string `yaml:"api_key_file"`  // path to a file holding the key; default /secrets/litellm_api_key
+	DefaultModel string `yaml:"default_model"` // model used when an agent has none selected
+	CABundle     string `yaml:"ca_bundle"`     // optional PEM path for a private CA (never disables verification)
+	LocalProxy   bool   `yaml:"local_proxy"`   // run the bundled litellm binary as a local translator fallback
+}
+
+// ResolveAPIKey returns the LiteLLM API key using the resolution order:
+// key file (api_key_file, falling back to DefaultLiteLLMAPIKeyFile) →
+// env var named by api_key_env → DefaultLiteLLMAPIKeyEnv. Returns "" when
+// no key is configured. The key value itself is never stored in hive.yaml.
+func (c *LiteLLMConfig) ResolveAPIKey() string {
+	keyFile := c.APIKeyFile
+	if keyFile == "" {
+		keyFile = DefaultLiteLLMAPIKeyFile
+	}
+	if data, err := os.ReadFile(keyFile); err == nil {
+		if key := strings.TrimSpace(string(data)); key != "" {
+			return key
+		}
+	}
+	if c.APIKeyEnv != "" {
+		if key := os.Getenv(c.APIKeyEnv); key != "" {
+			return key
+		}
+	}
+	return os.Getenv(DefaultLiteLLMAPIKeyEnv)
+}
+
+// ResolveEndpoint returns the effective LiteLLM base URL: the
+// HIVE_LITELLM_ENDPOINT env var when set, otherwise the YAML endpoint.
+func (c *LiteLLMConfig) ResolveEndpoint() string {
+	if ep := os.Getenv(LiteLLMEndpointEnv); ep != "" {
+		return ep
+	}
+	return c.Endpoint
+}
+
+// Validate checks that the configured endpoint (when set) parses as an
+// absolute http(s) URL.
+func (c *LiteLLMConfig) Validate() error {
+	if c.Endpoint == "" {
+		return nil
+	}
+	u, err := url.Parse(c.Endpoint)
+	if err != nil {
+		return fmt.Errorf("governor.litellm.endpoint %q is not a valid URL: %w", c.Endpoint, err)
+	}
+	if (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return fmt.Errorf("governor.litellm.endpoint %q must be an absolute http(s) URL", c.Endpoint)
+	}
+	return nil
 }
 
 type LabelsConfig struct {
@@ -1078,6 +1155,23 @@ func applyKnownAgentDefaults(name string, agent *AgentConfig) {
 	}
 }
 
+// InferenceBackends is the canonical list of self-hosted inference backend
+// IDs. It lives in the config package (a leaf in the import graph) so the
+// agent and proxy packages can share it without an import cycle
+// (proxy → agent → config).
+var InferenceBackends = []string{"vllm", "llm-d", "litellm"}
+
+// IsInferenceBackend returns true if the backend name is a self-hosted
+// inference backend rather than a CLI tool.
+func IsInferenceBackend(backend string) bool {
+	for _, b := range InferenceBackends {
+		if b == backend {
+			return true
+		}
+	}
+	return false
+}
+
 func (c *Config) validate() error {
 	if c.Project.Org == "" {
 		return fmt.Errorf("project.org is required")
@@ -1089,10 +1183,19 @@ func (c *Config) validate() error {
 	if c.GitHub.Token == "" && c.GitHub.AppID == 0 {
 		return fmt.Errorf("github.token or github.app_id is required")
 	}
+	if err := c.Governor.LiteLLM.Validate(); err != nil {
+		return err
+	}
 	for name, agent := range c.Agents {
 		validBackends := map[string]bool{"claude": true, "copilot": true, "goose": true, "codex": true, "pi": true, "bob": true, "aider": true}
+		// Inference backends (vllm, llm-d, litellm) are valid persisted
+		// agent backends too — they launch the claude CLI routed through
+		// the inference translator.
+		for _, b := range InferenceBackends {
+			validBackends[b] = true
+		}
 		if agent.Backend != "" && !validBackends[agent.Backend] {
-			return fmt.Errorf("agent %s: invalid backend %q (must be claude, copilot, goose, codex, pi, bob, or aider)", name, agent.Backend)
+			return fmt.Errorf("agent %s: invalid backend %q (must be claude, copilot, goose, codex, pi, bob, aider, or an inference backend: %s)", name, agent.Backend, strings.Join(InferenceBackends, ", "))
 		}
 		validCavemanModes := map[string]bool{"": true, "lite": true, "full": true, "ultra": true, "wenyan": true}
 		if !validCavemanModes[agent.CavemanMode] {

--- a/v2/pkg/config/config_test.go
+++ b/v2/pkg/config/config_test.go
@@ -385,7 +385,7 @@ agents:
 }
 
 func TestValidate_ValidBackends(t *testing.T) {
-	validBackends := []string{"claude", "copilot", "goose", "codex", "pi", "bob", "aider"}
+	validBackends := []string{"claude", "copilot", "goose", "codex", "pi", "bob", "aider", "vllm", "llm-d", "litellm"}
 	for _, backend := range validBackends {
 		t.Run(backend, func(t *testing.T) {
 			yaml := `

--- a/v2/pkg/config/litellm_test.go
+++ b/v2/pkg/config/litellm_test.go
@@ -1,0 +1,124 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// LiteLLMConfig.ResolveAPIKey — resolution order (file → named env → default env)
+// ---------------------------------------------------------------------------
+
+func TestLiteLLMResolveAPIKey_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "litellm_api_key")
+	if err := os.WriteFile(keyPath, []byte("sk-file-key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HIVE_LITELLM_TEST_KEY", "sk-env-key")
+	t.Setenv(DefaultLiteLLMAPIKeyEnv, "sk-default-env-key")
+
+	c := &LiteLLMConfig{APIKeyFile: keyPath, APIKeyEnv: "HIVE_LITELLM_TEST_KEY"}
+	if got := c.ResolveAPIKey(); got != "sk-file-key" {
+		t.Errorf("ResolveAPIKey() = %q, want key file to win", got)
+	}
+}
+
+func TestLiteLLMResolveAPIKey_FromNamedEnv(t *testing.T) {
+	t.Setenv("HIVE_LITELLM_TEST_KEY", "sk-env-key")
+	t.Setenv(DefaultLiteLLMAPIKeyEnv, "sk-default-env-key")
+
+	c := &LiteLLMConfig{APIKeyFile: filepath.Join(t.TempDir(), "missing"), APIKeyEnv: "HIVE_LITELLM_TEST_KEY"}
+	if got := c.ResolveAPIKey(); got != "sk-env-key" {
+		t.Errorf("ResolveAPIKey() = %q, want named env var to win over default", got)
+	}
+}
+
+func TestLiteLLMResolveAPIKey_FromDefaultEnv(t *testing.T) {
+	t.Setenv(DefaultLiteLLMAPIKeyEnv, "sk-default-env-key")
+
+	c := &LiteLLMConfig{APIKeyFile: filepath.Join(t.TempDir(), "missing")}
+	if got := c.ResolveAPIKey(); got != "sk-default-env-key" {
+		t.Errorf("ResolveAPIKey() = %q, want default env fallback", got)
+	}
+}
+
+func TestLiteLLMResolveAPIKey_Unconfigured(t *testing.T) {
+	t.Setenv(DefaultLiteLLMAPIKeyEnv, "")
+
+	c := &LiteLLMConfig{APIKeyFile: filepath.Join(t.TempDir(), "missing")}
+	if got := c.ResolveAPIKey(); got != "" {
+		t.Errorf("ResolveAPIKey() = %q, want empty when nothing configured", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LiteLLMConfig.ResolveEndpoint — env override
+// ---------------------------------------------------------------------------
+
+func TestLiteLLMResolveEndpoint(t *testing.T) {
+	c := &LiteLLMConfig{Endpoint: "https://yaml.example.com"}
+
+	t.Setenv(LiteLLMEndpointEnv, "")
+	if got := c.ResolveEndpoint(); got != "https://yaml.example.com" {
+		t.Errorf("ResolveEndpoint() = %q, want yaml value", got)
+	}
+
+	t.Setenv(LiteLLMEndpointEnv, "https://env.example.com")
+	if got := c.ResolveEndpoint(); got != "https://env.example.com" {
+		t.Errorf("ResolveEndpoint() = %q, want env override", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LiteLLMConfig.Validate — endpoint URL validation
+// ---------------------------------------------------------------------------
+
+func TestLiteLLMValidate(t *testing.T) {
+	tests := []struct {
+		endpoint string
+		wantErr  bool
+	}{
+		{"", false},
+		{"https://litellm.example.com", false},
+		{"http://127.0.0.1:4000", false},
+		{"litellm.example.com", true},       // no scheme
+		{"ftp://litellm.example.com", true}, // wrong scheme
+		{"https://", true},                  // no host
+	}
+	for _, tt := range tests {
+		c := &LiteLLMConfig{Endpoint: tt.endpoint}
+		err := c.Validate()
+		if (err != nil) != tt.wantErr {
+			t.Errorf("Validate(%q) error = %v, wantErr %v", tt.endpoint, err, tt.wantErr)
+		}
+	}
+}
+
+func TestValidate_LiteLLMEndpointRejected(t *testing.T) {
+	yaml := minimalValidYAML("my-org", "ghp_tok") + `
+governor:
+  litellm:
+    endpoint: not-a-url
+`
+	path := writeTempConfig(t, yaml)
+	if _, err := Load(path); err == nil {
+		t.Fatal("Load() expected error for invalid litellm endpoint, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// config.IsInferenceBackend — canonical list
+// ---------------------------------------------------------------------------
+
+func TestIsInferenceBackend_Config(t *testing.T) {
+	for _, b := range []string{"vllm", "llm-d", "litellm"} {
+		if !IsInferenceBackend(b) {
+			t.Errorf("IsInferenceBackend(%q) = false, want true", b)
+		}
+	}
+	if IsInferenceBackend("claude") {
+		t.Error("IsInferenceBackend(claude) = true, want false")
+	}
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -98,6 +98,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("PUT /api/config/governor/health", s.handleGovernorHealth)
 	s.mux.HandleFunc("PUT /api/config/governor/logging", s.handleGovernorLogging)
 	s.mux.HandleFunc("PUT /api/config/governor/hub", s.handleGovernorHub)
+	s.mux.HandleFunc("PUT /api/config/governor/litellm", s.handleGovernorLiteLLM)
 	s.mux.HandleFunc("POST /api/config/governor/agents", s.handleGovernorAddAgent)
 	s.mux.HandleFunc("DELETE /api/config/governor/agents/{name}", s.handleGovernorRemoveAgent)
 	s.mux.HandleFunc("PUT /api/config/governor/repos", s.handleGovernorRepos)
@@ -2660,6 +2661,17 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			"compress":   cfg.Governor.Logging.Compress,
 			"level":      cfg.Governor.Logging.Level,
 		},
+		"litellm": map[string]interface{}{
+			"endpoint":     cfg.Governor.LiteLLM.Endpoint,
+			"apiKeyEnv":    cfg.Governor.LiteLLM.APIKeyEnv,
+			"apiKeyFile":   cfg.Governor.LiteLLM.APIKeyFile,
+			"defaultModel": cfg.Governor.LiteLLM.DefaultModel,
+			"caBundle":     cfg.Governor.LiteLLM.CABundle,
+			"localProxy":   cfg.Governor.LiteLLM.LocalProxy,
+			// The key VALUE is never returned — only whether one resolves
+			// from the configured file/env var.
+			"hasKey": cfg.Governor.LiteLLM.ResolveAPIKey() != "",
+		},
 		"hub": map[string]interface{}{
 			"enabled":                  cfg.Hub.Enabled,
 			"url":                      cfg.Hub.URL,
@@ -3069,6 +3081,69 @@ func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 	okResponse(w, map[string]string{"status": "updated"})
 }
 
+// handleGovernorLiteLLM updates governor.litellm from the dashboard's
+// LiteLLM config tab. The API key VALUE is never accepted or stored —
+// only the env var name / key file path used to resolve it at runtime.
+func (s *Server) handleGovernorLiteLLM(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Endpoint     *string `json:"endpoint"`
+		APIKeyEnv    *string `json:"apiKeyEnv"`
+		APIKeyFile   *string `json:"apiKeyFile"`
+		DefaultModel *string `json:"defaultModel"`
+		CABundle     *string `json:"caBundle"`
+		LocalProxy   *bool   `json:"localProxy"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	cfg := s.deps.Config
+	// Apply to a copy first so validation failure leaves config untouched.
+	lc := cfg.Governor.LiteLLM
+	if body.Endpoint != nil {
+		lc.Endpoint = strings.TrimSpace(*body.Endpoint)
+	}
+	if body.APIKeyEnv != nil {
+		lc.APIKeyEnv = strings.TrimSpace(*body.APIKeyEnv)
+	}
+	if body.APIKeyFile != nil {
+		lc.APIKeyFile = strings.TrimSpace(*body.APIKeyFile)
+	}
+	if body.DefaultModel != nil {
+		lc.DefaultModel = strings.TrimSpace(*body.DefaultModel)
+	}
+	if body.CABundle != nil {
+		lc.CABundle = strings.TrimSpace(*body.CABundle)
+	}
+	if body.LocalProxy != nil {
+		lc.LocalProxy = *body.LocalProxy
+	}
+	if err := lc.Validate(); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	cfg.Governor.LiteLLM = lc
+
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after litellm update", "error", err)
+	}
+	s.auditFromRequest(r, "config_governor_litellm", auditDetail("section", "litellm"), "")
+
+	// Register the endpoint for model discovery (empty list unregisters)
+	// and re-apply routes for live agents already running on litellm.
+	var endpoints []string
+	if ep := lc.ResolveEndpoint(); ep != "" {
+		endpoints = []string{ep}
+	}
+	s.UpdateInferenceEndpoint("litellm", endpoints)
+	if s.deps.AgentMgr != nil {
+		s.deps.AgentMgr.RefreshInferenceRoutes("litellm")
+	}
+
+	s.refreshAndPersist()
+	okResponse(w, map[string]string{"status": "updated"})
+}
+
 func (s *Server) handleGovernorAddAgent(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Name    string `json:"name"`
@@ -3363,6 +3438,7 @@ func (s *Server) saveSidebarToDisk(sb interface{}) {
 func (s *Server) handleBackends(w http.ResponseWriter, r *http.Request) {
 	vllmModels := s.queryInferenceModels("vllm")
 	llmdModels := s.queryInferenceModels("llm-d")
+	litellmModels := s.queryInferenceModels("litellm")
 
 	jsonResponse(w, []map[string]interface{}{
 		{"id": "claude", "name": "Claude Code", "models": []string{"opus", "sonnet", "haiku"}},
@@ -3371,6 +3447,7 @@ func (s *Server) handleBackends(w http.ResponseWriter, r *http.Request) {
 		{"id": "goose", "name": "Goose", "models": []string{"default"}},
 		{"id": "vllm", "name": "vLLM (self-hosted)", "models": vllmModels, "inference": true},
 		{"id": "llm-d", "name": "llm-d (self-hosted)", "models": llmdModels, "inference": true},
+		{"id": "litellm", "name": "LiteLLM (proxy)", "models": litellmModels, "inference": true},
 	})
 }
 
@@ -3386,7 +3463,7 @@ func (s *Server) handleInferenceModels(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	models := fetchModelsFromEndpoints(endpoints)
+	models := fetchModelsFromEndpoints(endpoints, s.inferenceAPIKey(backend))
 	if len(models) == 0 {
 		s.logger.Warn("no models found from any endpoint", "backend", backend, "endpoints", len(endpoints))
 	}
@@ -3396,16 +3473,29 @@ func (s *Server) handleInferenceModels(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// inferenceAPIKey returns the bearer key used for a backend's model
+// discovery requests. Only litellm requires auth on /v1/models;
+// vllm/llm-d endpoints are unauthenticated.
+func (s *Server) inferenceAPIKey(backend string) string {
+	if backend != "litellm" || s.deps == nil || s.deps.Config == nil {
+		return ""
+	}
+	return s.deps.Config.Governor.LiteLLM.ResolveAPIKey()
+}
+
 func (s *Server) queryInferenceModels(backend string) []string {
 	if endpoints, ok := s.getInferenceEndpoints(backend); ok {
-		models := fetchModelsFromEndpoints(endpoints)
+		models := fetchModelsFromEndpoints(endpoints, s.inferenceAPIKey(backend))
 		if len(models) > 0 {
 			return models
 		}
 	}
 	envVar := "HIVE_VLLM_MODELS"
-	if backend == "llm-d" {
+	switch backend {
+	case "llm-d":
 		envVar = "HIVE_LLMD_MODELS"
+	case "litellm":
+		envVar = "HIVE_LITELLM_MODELS"
 	}
 	if val := os.Getenv(envVar); val != "" {
 		return inferenceModelsFromEnv(envVar, "")
@@ -3416,12 +3506,13 @@ func (s *Server) queryInferenceModels(backend string) []string {
 const inferenceModelQueryTimeout = 5 * time.Second
 
 // fetchModelsFromEndpoints queries /v1/models on each endpoint and returns
-// a deduplicated, combined list of all model IDs found.
-func fetchModelsFromEndpoints(endpoints []string) []string {
+// a deduplicated, combined list of all model IDs found. apiKey is optional
+// (litellm requires bearer auth; vllm/llm-d do not).
+func fetchModelsFromEndpoints(endpoints []string, apiKey string) []string {
 	seen := make(map[string]bool)
 	var all []string
 	for _, ep := range endpoints {
-		models, err := fetchModelsFromEndpoint(ep)
+		models, err := fetchModelsFromEndpoint(ep, apiKey)
 		if err != nil {
 			continue
 		}
@@ -3435,10 +3526,17 @@ func fetchModelsFromEndpoints(endpoints []string) []string {
 	return all
 }
 
-func fetchModelsFromEndpoint(baseURL string) ([]string, error) {
+func fetchModelsFromEndpoint(baseURL, apiKey string) ([]string, error) {
 	modelsURL := strings.TrimRight(baseURL, "/") + "/v1/models"
 	client := &http.Client{Timeout: inferenceModelQueryTimeout}
-	resp, err := client.Get(modelsURL)
+	req, err := http.NewRequest("GET", modelsURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3380,7 +3380,7 @@ func (s *Server) handleInferenceModels(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, "backend required", http.StatusBadRequest)
 		return
 	}
-	endpoints, ok := s.inferenceEndpoints[backend]
+	endpoints, ok := s.getInferenceEndpoints(backend)
 	if !ok {
 		jsonError(w, "unknown inference backend: "+backend, http.StatusNotFound)
 		return
@@ -3397,7 +3397,7 @@ func (s *Server) handleInferenceModels(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) queryInferenceModels(backend string) []string {
-	if endpoints, ok := s.inferenceEndpoints[backend]; ok {
+	if endpoints, ok := s.getInferenceEndpoints(backend); ok {
 		models := fetchModelsFromEndpoints(endpoints)
 		if len(models) > 0 {
 			return models

--- a/v2/pkg/dashboard/coverage_boost_test.go
+++ b/v2/pkg/dashboard/coverage_boost_test.go
@@ -900,7 +900,7 @@ func TestFetchModelsFromEndpoint_Success(t *testing.T) {
 	}))
 	defer mockSrv.Close()
 
-	models, err := fetchModelsFromEndpoint(mockSrv.URL)
+	models, err := fetchModelsFromEndpoint(mockSrv.URL, "")
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}
@@ -915,7 +915,7 @@ func TestFetchModelsFromEndpoint_ServerError(t *testing.T) {
 	}))
 	defer mockSrv.Close()
 
-	_, err := fetchModelsFromEndpoint(mockSrv.URL)
+	_, err := fetchModelsFromEndpoint(mockSrv.URL, "")
 	if err == nil {
 		t.Error("expected error for 500 response")
 	}
@@ -931,7 +931,7 @@ func TestFetchModelsFromEndpoints_Deduplicates(t *testing.T) {
 	}))
 	defer mockSrv.Close()
 
-	models := fetchModelsFromEndpoints([]string{mockSrv.URL, mockSrv.URL})
+	models := fetchModelsFromEndpoints([]string{mockSrv.URL, mockSrv.URL}, "")
 	if len(models) != 1 {
 		t.Errorf("expected 1 deduplicated model, got %d", len(models))
 	}

--- a/v2/pkg/dashboard/litellm_api_test.go
+++ b/v2/pkg/dashboard/litellm_api_test.go
@@ -1,0 +1,94 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// --- handleGovernorLiteLLM ---
+
+func TestHandleGovernorLiteLLM_Update(t *testing.T) {
+	srv := newFullServer(t)
+	body := `{
+		"endpoint": "https://litellm.example.com",
+		"apiKeyEnv": "MY_LITELLM_KEY",
+		"defaultModel": "gpt-4o",
+		"caBundle": "/secrets/litellm-ca.pem",
+		"localProxy": false
+	}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/litellm", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorLiteLLM(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200 (body: %s)", w.Code, w.Body.String())
+	}
+	lc := srv.deps.Config.Governor.LiteLLM
+	if lc.Endpoint != "https://litellm.example.com" {
+		t.Errorf("Endpoint = %q", lc.Endpoint)
+	}
+	if lc.APIKeyEnv != "MY_LITELLM_KEY" {
+		t.Errorf("APIKeyEnv = %q", lc.APIKeyEnv)
+	}
+	if lc.DefaultModel != "gpt-4o" {
+		t.Errorf("DefaultModel = %q", lc.DefaultModel)
+	}
+	// The endpoint must now be registered for model discovery.
+	endpoints, ok := srv.getInferenceEndpoints("litellm")
+	if !ok || len(endpoints) != 1 || endpoints[0] != "https://litellm.example.com" {
+		t.Errorf("registered endpoints = %v, ok = %v", endpoints, ok)
+	}
+}
+
+func TestHandleGovernorLiteLLM_InvalidEndpointRejected(t *testing.T) {
+	srv := newFullServer(t)
+	body := `{"endpoint": "not-a-url"}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/litellm", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorLiteLLM(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("code = %d, want 400", w.Code)
+	}
+	if srv.deps.Config.Governor.LiteLLM.Endpoint != "" {
+		t.Errorf("config endpoint mutated on validation failure: %q", srv.deps.Config.Governor.LiteLLM.Endpoint)
+	}
+}
+
+// --- handleGovernorConfigGet: litellm section never leaks a key value ---
+
+func TestHandleGovernorConfigGet_LiteLLMSection(t *testing.T) {
+	srv := newFullServer(t)
+	t.Setenv("HIVE_LITELLM_API_KEY", "sk-super-secret")
+	srv.deps.Config.Governor.LiteLLM.Endpoint = "https://litellm.example.com"
+
+	req := httptest.NewRequest("GET", "/api/config/governor", nil)
+	w := httptest.NewRecorder()
+	srv.handleGovernorConfigGet(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "sk-super-secret") {
+		t.Fatal("response body contains the raw API key")
+	}
+	var result map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	section, ok := result["litellm"].(map[string]any)
+	if !ok {
+		t.Fatalf("no litellm section in response: %v", result)
+	}
+	if section["endpoint"] != "https://litellm.example.com" {
+		t.Errorf("endpoint = %v", section["endpoint"])
+	}
+	if section["hasKey"] != true {
+		t.Errorf("hasKey = %v, want true (key resolves from env)", section["hasKey"])
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -402,6 +402,14 @@ func (s *Server) buildInferenceBackends() []InferenceBackend {
 			ID: b.id, Name: b.name, Inference: true, Models: models,
 		})
 	}
+	// litellm has no in-cluster default — include it only when an endpoint
+	// is registered, so an unconfigured backend isn't SSE-pushed empty.
+	if endpoints, ok := s.getInferenceEndpoints("litellm"); ok && len(endpoints) > 0 {
+		backends = append(backends, InferenceBackend{
+			ID: "litellm", Name: "LiteLLM (proxy)", Inference: true,
+			Models: s.queryInferenceModels("litellm"),
+		})
+	}
 	return backends
 }
 

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -79,6 +79,7 @@ type Server struct {
 
 	contributeHub *ContributeWSHub
 
+	inferenceMu        sync.RWMutex
 	inferenceEndpoints map[string][]string // backend id → list of base URLs
 
 	ready   bool
@@ -361,7 +362,33 @@ func NewServerWithAuth(port int, authToken string, logger *slog.Logger) *Server 
 // SetInferenceEndpoints registers base URLs for inference backends
 // so the dashboard can query them for available models at runtime.
 func (s *Server) SetInferenceEndpoints(endpoints map[string][]string) {
+	s.inferenceMu.Lock()
+	defer s.inferenceMu.Unlock()
 	s.inferenceEndpoints = endpoints
+}
+
+// UpdateInferenceEndpoint registers or replaces the endpoint list for a
+// single inference backend at runtime (e.g. after a governor LiteLLM
+// config save). An empty list unregisters the backend.
+func (s *Server) UpdateInferenceEndpoint(backend string, endpoints []string) {
+	s.inferenceMu.Lock()
+	defer s.inferenceMu.Unlock()
+	if s.inferenceEndpoints == nil {
+		s.inferenceEndpoints = make(map[string][]string)
+	}
+	if len(endpoints) == 0 {
+		delete(s.inferenceEndpoints, backend)
+		return
+	}
+	s.inferenceEndpoints[backend] = endpoints
+}
+
+// getInferenceEndpoints returns the registered base URLs for a backend.
+func (s *Server) getInferenceEndpoints(backend string) ([]string, bool) {
+	s.inferenceMu.RLock()
+	defer s.inferenceMu.RUnlock()
+	endpoints, ok := s.inferenceEndpoints[backend]
+	return endpoints, ok
 }
 
 func (s *Server) buildInferenceBackends() []InferenceBackend {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4057,9 +4057,9 @@
     }
 
     // ── Centralized backend/model config (mirrors backends.conf) ──────────
-    const KNOWN_BACKENDS = ['claude', 'copilot', 'bob', 'gemini', 'codex', 'amazonq', 'goose', 'aider', 'vllm', 'llm-d'];
+    const KNOWN_BACKENDS = ['claude', 'copilot', 'bob', 'gemini', 'codex', 'amazonq', 'goose', 'aider', 'vllm', 'llm-d', 'litellm'];
     const FREE_BACKENDS = ['copilot', 'goose'];
-    const INFERENCE_BACKENDS = ['vllm', 'llm-d'];
+    const INFERENCE_BACKENDS = ['vllm', 'llm-d', 'litellm'];
     const CLAUDE_CLI_MODELS = [
       { value: 'claude-opus-4-8', label: 'Opus 4.8' },
       { value: 'claude-opus-4-7', label: 'Opus 4.7' },
@@ -8998,8 +8998,69 @@ function burnAreaChart() {
       dismissToast(toast, `${agent} restart counter reset`, 'success');
     }
 
+    // Prompts for the LiteLLM endpoint the first time the backend is
+    // selected anywhere in the UI. Resolves true when litellm is (or has
+    // just been) configured; false when the user cancels.
+    async function ensureLiteLLMConfigured() {
+      try {
+        const resp = await fetch('/api/config/governor');
+        const data = await resp.json();
+        if (data.litellm && data.litellm.endpoint) return true;
+      } catch (e) { /* config unreachable — fall through to the prompt */ }
+      return new Promise(resolve => {
+        const overlay = document.createElement('div');
+        overlay.className = 'hive-dialog-overlay';
+        overlay.innerHTML = `<div class="hive-dialog">
+          <div class="hive-dialog-title">Configure LiteLLM</div>
+          <div class="hive-dialog-body">
+            <p style="margin:0 0 10px">No LiteLLM endpoint is configured yet. Enter the proxy base URL (editable later under Governor Config → LiteLLM).</p>
+            <div class="config-field">
+              <label>Endpoint URL</label>
+              <input type="text" id="litellm-setup-endpoint" placeholder="https://litellm.example.com" style="width:100%">
+            </div>
+            <div class="config-field">
+              <label>API Key Env Name (optional — the key VALUE is never stored)</label>
+              <input type="text" id="litellm-setup-keyenv" placeholder="HIVE_LITELLM_API_KEY" style="width:100%">
+            </div>
+          </div>
+          <div class="hive-dialog-buttons">
+            <button class="hive-dialog-btn cancel">Cancel</button>
+            <button class="hive-dialog-btn primary">Save</button>
+          </div></div>`;
+        document.body.appendChild(overlay);
+        const close = (val) => { overlay.remove(); resolve(val); };
+        overlay.querySelector('.cancel').onclick = () => close(false);
+        overlay.onclick = (e) => { if (e.target === overlay) close(false); };
+        overlay.querySelector('.primary').onclick = async () => {
+          const endpoint = overlay.querySelector('#litellm-setup-endpoint').value.trim();
+          if (!endpoint) { showToast('Endpoint URL is required', 'error'); return; }
+          const keyEnv = overlay.querySelector('#litellm-setup-keyenv').value.trim();
+          const body = { endpoint };
+          if (keyEnv) body.apiKeyEnv = keyEnv;
+          try {
+            const res = await fetch('/api/config/governor/litellm', {
+              method: 'PUT',
+              headers: _inceptionAuthHeaders(),
+              body: JSON.stringify(body)
+            });
+            if (!res.ok) {
+              const err = await res.json().catch(() => ({}));
+              showToast(err.error || 'Failed to save LiteLLM config', 'error');
+              return;
+            }
+            showToast('LiteLLM endpoint saved', 'success');
+            close(true);
+          } catch (e) {
+            showToast('Network error: ' + e.message, 'error');
+          }
+        };
+        overlay.querySelector('#litellm-setup-endpoint').focus();
+      });
+    }
+
     async function switchCli(agent, backend) {
       if (!backend) return;
+      if (backend === 'litellm' && !(await ensureLiteLLMConfigured())) return;
       const label = INFERENCE_BACKENDS.includes(backend) ? 'method' : 'CLI';
       const toast = showToast(`Switching ${agent} ${label} → ${backend} (restarting session)...`, 'info', true);
       const res = await fetch(`/api/switch/${agent}/${backend}`, { method: 'POST' });
@@ -9880,7 +9941,7 @@ function burnAreaChart() {
 
     const AGENT_CONFIG_TABS = ['General', 'Cadences', 'Pipeline', 'Hooks', 'Restrictions', 'Channels', 'Tools', 'Connections', 'Stats', 'Prompt Template', 'Last Prompt', 'Export'];
     const AGENT_CREATE_TABS = ['Import', 'General', 'Cadences', 'Channels', 'Tools', 'Prompt Template'];
-    const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Hub'];
+    const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Hub', 'LiteLLM'];
     const PIPELINE_STAGES = ['resolve-beads', 'track-prs', 'stale-check', 'repo-scan', 'coverage-gate', 'prompt-compose', 'budget-check', 'api-collect', 'final-compose'];
     const PIPELINE_STAGE_TIPS = {
       'resolve-beads': 'Fetch and inject knowledge beads (facts, patterns, gotchas) relevant to the agent\'s current task context.',
@@ -10394,7 +10455,58 @@ function burnAreaChart() {
         case 'Sensing': return renderGovSensing(d.sensing || {});
         case 'Logging': return renderGovLogging(d.logging || {});
         case 'Hub': return renderGovHub(d.hub || {});
+        case 'LiteLLM': return renderGovLiteLLM(d.litellm || {});
         default: return '';
+      }
+    }
+
+    function renderGovLiteLLM(litellm) {
+      const keyEnvName = litellm.apiKeyEnv || 'HIVE_LITELLM_API_KEY';
+      const keyFilePath = litellm.apiKeyFile || '/secrets/litellm_api_key';
+      return `
+        <div class="config-field">
+          <label>Endpoint URL <span class="config-info">i<span class="config-tooltip">Base URL of the LiteLLM proxy (e.g. https://litellm.example.com). Agents reach it through the hive's inference translator — the MITM proxy stays in the path. The HIVE_LITELLM_ENDPOINT env var overrides this at runtime.</span></span></label>
+          <input type="text" value="${esc(litellm.endpoint || '')}" placeholder="https://litellm.example.com" onchange="markDirty('litellm','endpoint',this.value)">
+        </div>
+        <div class="config-field">
+          <label>API Key Env Name <span class="config-info">i<span class="config-tooltip">Name of the environment variable holding the LiteLLM API key. The key VALUE is never stored in hive.yaml or shown here. A key file at ${esc(keyFilePath)} takes precedence when present.</span></span></label>
+          <input type="text" value="${esc(litellm.apiKeyEnv || '')}" placeholder="HIVE_LITELLM_API_KEY" onchange="markDirty('litellm','apiKeyEnv',this.value)">
+          <div style="font-size:0.72rem;margin-top:4px;color:${litellm.hasKey ? '#3fb950' : '#f85149'}">Key detected: ${litellm.hasKey ? 'yes' : `no — set ${esc(keyEnvName)} or mount ${esc(keyFilePath)}`}</div>
+        </div>
+        <div class="config-field">
+          <label>Default Model <span class="config-info">i<span class="config-tooltip">Model used when an agent on the litellm backend has no model selected. Use Test Connection to list available models.</span></span></label>
+          <input type="text" value="${esc(litellm.defaultModel || '')}" placeholder="e.g. gpt-4o" onchange="markDirty('litellm','defaultModel',this.value)">
+        </div>
+        <div class="config-field">
+          <label>CA Bundle Path <span class="config-info">i<span class="config-tooltip">Optional PEM file for a private CA (e.g. an internal VPC endpoint). Certificate verification is never disabled — the CA is added to the trust pool.</span></span></label>
+          <input type="text" value="${esc(litellm.caBundle || '')}" placeholder="/secrets/litellm-ca.pem" onchange="markDirty('litellm','caBundle',this.value)">
+        </div>
+        <div class="config-toggle">
+          <div class="config-toggle-switch ${litellm.localProxy ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="litellm" data-key="localProxy"></div>
+          <span class="config-toggle-label">Local Proxy Fallback <span class="config-info">i<span class="config-tooltip">Run the bundled litellm binary as a local translator (config at /data/litellm/config.yaml). Off by default — the hive's Go translator forwards directly to the remote endpoint.</span></span></span>
+        </div>
+        <div style="margin-top:12px">
+          <button onclick="testLiteLLMConnection()" style="padding:6px 14px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--fg);cursor:pointer;font-size:0.78rem">Test Connection</button>
+        </div>`;
+    }
+
+    async function testLiteLLMConnection() {
+      const toast = showToast('Testing LiteLLM connection…', 'info', true);
+      try {
+        const resp = await fetch('/api/inference/models/litellm');
+        const data = await resp.json();
+        if (!resp.ok) {
+          dismissToast(toast, data.error || 'LiteLLM endpoint not configured — save the endpoint first', 'error');
+          return;
+        }
+        const count = (data.models || []).length;
+        if (count > 0) {
+          dismissToast(toast, `LiteLLM OK — ${count} model${count === 1 ? '' : 's'} available`, 'success');
+        } else {
+          dismissToast(toast, 'Connected, but no models returned (check the API key)', 'error');
+        }
+      } catch (e) {
+        dismissToast(toast, 'LiteLLM test failed: ' + e.message, 'error');
       }
     }
 
@@ -10727,7 +10839,7 @@ function burnAreaChart() {
         </div>
         <div class="config-field">
           <label>CLI Pin Value <span class="config-info">i<span class="config-tooltip">Which CLI backend to pin this agent to when CLI Pinned is on. Options: claude, copilot, bob, gemini, codex, amazonq, goose, aider. copilot and goose are free backends (no token cost).</span></span></label>
-          <select id="cfg-pin-value" onchange="markDirty('general','cliPinValue',this.value);updateLaunchCmd(this.value)">
+          <select id="cfg-pin-value" data-prev="${esc(g.cliPinValue || '')}" onchange="onCliPinChange(this)">
             ${KNOWN_BACKENDS.map(b => `<option value="${b}" ${g.cliPinValue === b ? 'selected' : ''}>${backendLabel(b)}</option>`).join('')}
           </select>
         </div>
@@ -11916,6 +12028,19 @@ function burnAreaChart() {
       markDirty(section, key, isOn);
     }
 
+    // onchange handler for the CLI Pin Value select — prompts for the
+    // LiteLLM endpoint (and reverts the selection on cancel) before
+    // recording the change.
+    async function onCliPinChange(sel) {
+      if (sel.value === 'litellm' && !(await ensureLiteLLMConfigured())) {
+        sel.value = sel.dataset.prev || 'claude';
+        return;
+      }
+      sel.dataset.prev = sel.value;
+      markDirty('general', 'cliPinValue', sel.value);
+      updateLaunchCmd(sel.value);
+    }
+
     function updateLaunchCmd(cli) {
       const input = document.getElementById('cfg-launch-cmd');
       if (!input) return;
@@ -12089,6 +12214,7 @@ function burnAreaChart() {
           showToast('Name must be lowercase letters, numbers, and hyphens', 'error');
           return;
         }
+        if (generalData.cliPinValue === 'litellm' && !(await ensureLiteLLMConfigured())) return;
         const agent = {
           backend: generalData.cliPinValue || 'copilot',
           model: generalData.model || '',
@@ -12136,6 +12262,9 @@ function burnAreaChart() {
         showToast('No changes to save', 'info');
         return;
       }
+      // Pinning an agent to litellm requires a configured endpoint —
+      // prompt (and abort the save on cancel) before PUTting the section.
+      if (dirty.general && dirty.general.cliPinValue === 'litellm' && !(await ensureLiteLLMConfigured())) return;
       const base = _configState.type === 'governor' ? '/api/config/governor' : `/api/config/agent/${_configState.agent}`;
       let success = true;
       for (const [section, values] of Object.entries(dirty)) {

--- a/v2/pkg/proxy/anthropic_translate.go
+++ b/v2/pkg/proxy/anthropic_translate.go
@@ -521,8 +521,13 @@ func forwardToInference(clientReq *http.Request, clientBody []byte, w http.Respo
 		return fmt.Errorf("create upstream request: %w", err)
 	}
 	upstreamReq.Header.Set("Content-Type", "application/json")
+	applyInferenceAuth(upstreamReq, route)
 
-	resp, err := http.DefaultClient.Do(upstreamReq)
+	client, err := inferenceHTTPClient(route)
+	if err != nil {
+		return fmt.Errorf("inference client setup: %w", err)
+	}
+	resp, err := client.Do(upstreamReq)
 	if err != nil {
 		return fmt.Errorf("upstream request: %w", err)
 	}

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -871,7 +871,7 @@ func newBufferedReader(c net.Conn) *bufio.Reader {
 // It also queries the model's max context length from the endpoint.
 func (p *GitHubProxy) SetInferenceRoute(agentName string, route *InferenceRoute) {
 	if route.MaxContextLen == 0 {
-		if maxLen := queryMaxModelLen(route.Endpoint, route.Model); maxLen > 0 {
+		if maxLen := queryMaxModelLen(route.Endpoint, route.Model, route.APIKey, route.CABundle); maxLen > 0 {
 			route.MaxContextLen = maxLen
 		}
 	}
@@ -947,6 +947,7 @@ func (p *GitHubProxy) StartInferenceTranslator() error {
 			return
 		}
 		upstreamReq.Header.Set("Content-Type", "application/json")
+		applyInferenceAuth(upstreamReq, route)
 
 		p.logger.Info("inference forward",
 			"agent", agentName,
@@ -956,7 +957,13 @@ func (p *GitHubProxy) StartInferenceTranslator() error {
 			"openai_body", truncateBytes(openaiBody, 300),
 		)
 
-		resp, err := http.DefaultClient.Do(upstreamReq)
+		client, err := inferenceHTTPClient(route)
+		if err != nil {
+			p.logger.Error("inference client setup failed", "agent", agentName, "error", err)
+			http.Error(w, fmt.Sprintf(`{"type":"error","error":{"type":"api_error","message":"inference client setup failed: %s"}}`, err.Error()), http.StatusBadGateway)
+			return
+		}
+		resp, err := client.Do(upstreamReq)
 		if err != nil {
 			p.logger.Error("inference upstream failed", "agent", agentName, "error", err)
 			http.Error(w, fmt.Sprintf(`{"type":"error","error":{"type":"api_error","message":"inference backend unreachable: %s"}}`, err.Error()), http.StatusBadGateway)
@@ -1100,10 +1107,17 @@ func (p *GitHubProxy) handleInferenceRequest(conn net.Conn, req *http.Request, a
 		return
 	}
 	upstreamReq.Header.Set("Content-Type", "application/json")
+	applyInferenceAuth(upstreamReq, route)
 
 	p.logger.Info("inference forward", "agent", agentName, "backend", route.Backend, "model", route.Model, "url", upstreamURL)
 
-	resp, err := http.DefaultClient.Do(upstreamReq)
+	client, err := inferenceHTTPClient(route)
+	if err != nil {
+		p.logger.Error("inference client setup failed", "agent", agentName, "error", err)
+		p.writeHTTPError(conn, http.StatusBadGateway, "inference client setup failed: "+err.Error())
+		return
+	}
+	resp, err := client.Do(upstreamReq)
 	if err != nil {
 		p.logger.Error("inference upstream failed", "agent", agentName, "error", err)
 		p.writeHTTPError(conn, http.StatusBadGateway, "inference backend unreachable: "+err.Error())

--- a/v2/pkg/proxy/inference_auth_test.go
+++ b/v2/pkg/proxy/inference_auth_test.go
@@ -1,0 +1,190 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// startMockAuthedUpstream mimics a LiteLLM proxy: /v1/chat/completions
+// requires "Authorization: Bearer <wantKey>" and returns 401 otherwise.
+// The Authorization header seen on the last request is recorded in gotAuth.
+func startMockAuthedUpstream(t *testing.T, wantKey string, gotAuth *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*gotAuth = r.Header.Get("Authorization")
+		if *gotAuth != "Bearer "+wantKey {
+			http.Error(w, `{"error":"invalid api key"}`, http.StatusUnauthorized)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id": "chatcmpl-authed",
+			"choices": []map[string]interface{}{
+				{
+					"message":       map[string]string{"role": "assistant", "content": "authed response"},
+					"finish_reason": "stop",
+				},
+			},
+			"usage": map[string]int{"prompt_tokens": 4, "completion_tokens": 2},
+		})
+	}))
+}
+
+func TestForwardToInference_BearerAuthReachesUpstream(t *testing.T) {
+	var gotAuth string
+	mock := startMockAuthedUpstream(t, "sk-litellm-test", &gotAuth)
+	defer mock.Close()
+
+	anthropicBody := `{
+		"model": "claude-opus-4-6",
+		"max_tokens": 128,
+		"messages": [{"role": "user", "content": "hi"}],
+		"stream": false
+	}`
+
+	route := &InferenceRoute{
+		Backend:  "litellm",
+		Endpoint: mock.URL,
+		Model:    "gpt-4o",
+		APIKey:   "sk-litellm-test",
+	}
+
+	req, _ := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", strings.NewReader(anthropicBody))
+	w := httptest.NewRecorder()
+
+	if err := forwardToInference(req, []byte(anthropicBody), w, route, "test-agent"); err != nil {
+		t.Fatal(err)
+	}
+
+	if gotAuth != "Bearer sk-litellm-test" {
+		t.Errorf("upstream Authorization = %q, want %q", gotAuth, "Bearer sk-litellm-test")
+	}
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+	var ar anthropicResponse
+	if err := json.NewDecoder(resp.Body).Decode(&ar); err != nil {
+		t.Fatal(err)
+	}
+	if len(ar.Content) == 0 || !strings.Contains(ar.Content[0].Text, "authed response") {
+		t.Errorf("response content = %+v, want authed response text", ar.Content)
+	}
+}
+
+func TestForwardToInference_MissingKeyGets401(t *testing.T) {
+	var gotAuth string
+	mock := startMockAuthedUpstream(t, "sk-litellm-test", &gotAuth)
+	defer mock.Close()
+
+	anthropicBody := `{
+		"model": "claude-opus-4-6",
+		"max_tokens": 128,
+		"messages": [{"role": "user", "content": "hi"}],
+		"stream": false
+	}`
+
+	route := &InferenceRoute{
+		Backend:  "litellm",
+		Endpoint: mock.URL,
+		Model:    "gpt-4o",
+		// APIKey intentionally empty
+	}
+
+	req, _ := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", strings.NewReader(anthropicBody))
+	w := httptest.NewRecorder()
+
+	if err := forwardToInference(req, []byte(anthropicBody), w, route, "test-agent"); err != nil {
+		t.Fatal(err)
+	}
+
+	if gotAuth != "" {
+		t.Errorf("upstream Authorization = %q, want empty when route has no key", gotAuth)
+	}
+	if w.Result().StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 passed through from upstream", w.Result().StatusCode)
+	}
+}
+
+func TestForwardToInference_NoAuthHeaderForVLLM(t *testing.T) {
+	var gotAuth string
+	sawRequest := false
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawRequest = true
+		gotAuth = r.Header.Get("Authorization")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id": "chatcmpl-open",
+			"choices": []map[string]interface{}{
+				{
+					"message":       map[string]string{"role": "assistant", "content": "open response"},
+					"finish_reason": "stop",
+				},
+			},
+			"usage": map[string]int{"prompt_tokens": 4, "completion_tokens": 2},
+		})
+	}))
+	defer mock.Close()
+
+	anthropicBody := `{
+		"model": "claude-opus-4-6",
+		"max_tokens": 128,
+		"messages": [{"role": "user", "content": "hi"}],
+		"stream": false
+	}`
+
+	route := &InferenceRoute{Backend: "vllm", Endpoint: mock.URL, Model: "test-model"}
+	req, _ := http.NewRequest("POST", "https://api.anthropic.com/v1/messages", strings.NewReader(anthropicBody))
+	w := httptest.NewRecorder()
+
+	if err := forwardToInference(req, []byte(anthropicBody), w, route, "test-agent"); err != nil {
+		t.Fatal(err)
+	}
+	if !sawRequest {
+		t.Fatal("mock upstream never received a request")
+	}
+	if gotAuth != "" {
+		t.Errorf("upstream Authorization = %q, want none for keyless vllm route", gotAuth)
+	}
+}
+
+func TestFindEndpointForModel_WithBearerKey(t *testing.T) {
+	var gotAuth string
+	mock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		if gotAuth != "Bearer sk-models-key" {
+			http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"data": []map[string]interface{}{{"id": "gpt-4o"}},
+		})
+	}))
+	defer mock.Close()
+
+	if got := FindEndpointForModel([]string{mock.URL}, "gpt-4o", "", ""); got != "" {
+		t.Errorf("FindEndpointForModel without key = %q, want no match against authed endpoint", got)
+	}
+	if got := FindEndpointForModel([]string{mock.URL}, "gpt-4o", "sk-models-key", ""); got != mock.URL {
+		t.Errorf("FindEndpointForModel with key = %q, want %q", got, mock.URL)
+	}
+}
+
+func TestInferenceHTTPClient_BadCABundle(t *testing.T) {
+	route := &InferenceRoute{Backend: "litellm", CABundle: "/nonexistent/ca.pem"}
+	if _, err := inferenceHTTPClient(route); err == nil {
+		t.Error("expected error for missing CA bundle, got nil")
+	}
+}
+
+func TestInferenceHTTPClient_DefaultWithoutCABundle(t *testing.T) {
+	route := &InferenceRoute{Backend: "litellm"}
+	client, err := inferenceHTTPClient(route)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client != http.DefaultClient {
+		t.Error("expected http.DefaultClient when no CA bundle is set")
+	}
+}

--- a/v2/pkg/proxy/inference_integration_test.go
+++ b/v2/pkg/proxy/inference_integration_test.go
@@ -216,6 +216,9 @@ func TestIsInferenceBackend(t *testing.T) {
 	if !IsInferenceBackend("llm-d") {
 		t.Error("llm-d should be inference backend")
 	}
+	if !IsInferenceBackend("litellm") {
+		t.Error("litellm should be inference backend")
+	}
 	if IsInferenceBackend("claude") {
 		t.Error("claude should not be inference backend")
 	}

--- a/v2/pkg/proxy/inference_route.go
+++ b/v2/pkg/proxy/inference_route.go
@@ -368,6 +368,11 @@ func resolveInferencePreamble(route *InferenceRoute, agentName string) string {
 	if route.Preamble != "" {
 		return route.Preamble
 	}
+	// litellm may front frontier models that don't need the vLLM agentic
+	// preamble — opt out unless a preamble is explicitly configured.
+	if route.Backend == "litellm" {
+		return ""
+	}
 	if agentName == "supervisor" {
 		return SupervisorInferencePreamble
 	}

--- a/v2/pkg/proxy/inference_route.go
+++ b/v2/pkg/proxy/inference_route.go
@@ -1,22 +1,30 @@
 package proxy
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
 )
 
 // InferenceRoute defines where to send an agent's API traffic when using
 // a self-hosted inference backend instead of the cloud API.
 type InferenceRoute struct {
-	Backend       string // "vllm" or "llm-d"
+	Backend       string // "vllm", "llm-d", or "litellm"
 	Endpoint      string // e.g. "http://vllm-svc.hive.svc.cluster.local:8000"
 	Model         string // e.g. "Qwen/Qwen2.5-1.5B-Instruct"
 	MaxContextLen int    // from vLLM /v1/models max_model_len; 0 = unknown
 	Preamble      string // prepended to the system prompt for inference backends; empty = use DefaultInferencePreamble
+	APIKey        string // optional bearer token for the upstream (litellm requires auth); never logged
+	CABundle      string // optional PEM path for a private CA; verification is never disabled
 }
 
 // DefaultInferencePreamble is injected at the top of the system prompt when
@@ -146,26 +154,106 @@ func IsAnthropicHost(host string) bool {
 }
 
 // InferenceBackends lists the valid self-hosted inference backend IDs.
-var InferenceBackends = []string{"vllm", "llm-d"}
+// The canonical list lives in the config package (see
+// config.InferenceBackends) so agent and proxy share it without an
+// import cycle.
+var InferenceBackends = config.InferenceBackends
 
 // IsInferenceBackend returns true if the backend name is a self-hosted
 // inference backend rather than a CLI tool.
 func IsInferenceBackend(backend string) bool {
-	for _, b := range InferenceBackends {
-		if b == backend {
-			return true
-		}
+	return config.IsInferenceBackend(backend)
+}
+
+// applyInferenceAuth sets the upstream Authorization header when the route
+// has an API key (litellm endpoints require bearer auth; vllm/llm-d
+// typically do not).
+func applyInferenceAuth(req *http.Request, route *InferenceRoute) {
+	if route.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+route.APIKey)
 	}
-	return false
+}
+
+// caTransportCache caches one transport per CA bundle path so TLS session
+// state and connection pools are reused across requests.
+var (
+	caTransportMu    sync.Mutex
+	caTransportCache = map[string]*http.Transport{}
+)
+
+// inferenceTransport returns the transport for the given CA bundle path.
+// An empty path returns the default transport (system trust store).
+// Certificate verification is NEVER disabled — a private CA is trusted by
+// adding its PEM to the root pool, not by skipping verification.
+func inferenceTransport(caBundle string) (http.RoundTripper, error) {
+	if caBundle == "" {
+		return http.DefaultTransport, nil
+	}
+	caTransportMu.Lock()
+	defer caTransportMu.Unlock()
+	if t, ok := caTransportCache[caBundle]; ok {
+		return t, nil
+	}
+	pem, err := os.ReadFile(caBundle)
+	if err != nil {
+		return nil, fmt.Errorf("read ca bundle %s: %w", caBundle, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("no certificates parsed from ca bundle %s", caBundle)
+	}
+	t, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("default transport is not *http.Transport")
+	}
+	t = t.Clone()
+	t.TLSClientConfig = &tls.Config{RootCAs: pool}
+	caTransportCache[caBundle] = t
+	return t, nil
+}
+
+// inferenceHTTPClient returns the client for forwarding translated requests
+// to the route's endpoint. Like http.DefaultClient it has no overall
+// timeout — streaming completions can legitimately run for minutes.
+func inferenceHTTPClient(route *InferenceRoute) (*http.Client, error) {
+	rt, err := inferenceTransport(route.CABundle)
+	if err != nil {
+		return nil, err
+	}
+	if rt == http.DefaultTransport {
+		return http.DefaultClient, nil
+	}
+	return &http.Client{Transport: rt}, nil
+}
+
+// newModelsRequest builds an authenticated GET {endpoint}/v1/models request.
+func newModelsRequest(endpoint, apiKey string) (*http.Request, error) {
+	req, err := http.NewRequest("GET", strings.TrimRight(endpoint, "/")+"/v1/models", nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	return req, nil
 }
 
 // FindEndpointForModel queries /v1/models on each endpoint and returns the
 // first one that serves the requested model. Returns "" if none match.
-func FindEndpointForModel(endpoints []string, model string) string {
-	client := &http.Client{Timeout: endpointQueryTimeout}
+// apiKey and caBundle are optional (litellm endpoints require bearer auth
+// and may be signed by a private CA).
+func FindEndpointForModel(endpoints []string, model, apiKey, caBundle string) string {
+	rt, err := inferenceTransport(caBundle)
+	if err != nil {
+		return ""
+	}
+	client := &http.Client{Timeout: endpointQueryTimeout, Transport: rt}
 	for _, ep := range endpoints {
-		url := strings.TrimRight(ep, "/") + "/v1/models"
-		resp, err := client.Get(url)
+		req, err := newModelsRequest(ep, apiKey)
+		if err != nil {
+			continue
+		}
+		resp, err := client.Do(req)
 		if err != nil {
 			continue
 		}
@@ -197,10 +285,18 @@ const maxModelLenQueryTimeout = 3 * time.Second
 
 // queryMaxModelLen queries the /v1/models endpoint and returns the
 // max_model_len for the given model. Returns 0 if the query fails.
-func queryMaxModelLen(endpoint, model string) int {
-	url := strings.TrimRight(endpoint, "/") + "/v1/models"
-	client := &http.Client{Timeout: maxModelLenQueryTimeout}
-	resp, err := client.Get(url)
+// apiKey and caBundle are optional (see FindEndpointForModel).
+func queryMaxModelLen(endpoint, model, apiKey, caBundle string) int {
+	rt, rtErr := inferenceTransport(caBundle)
+	if rtErr != nil {
+		return 0
+	}
+	client := &http.Client{Timeout: maxModelLenQueryTimeout, Transport: rt}
+	req, err := newModelsRequest(endpoint, apiKey)
+	if err != nil {
+		return 0
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return 0
 	}


### PR DESCRIPTION
Adds **litellm** as a third inference backend, reusing the existing vllm/llm-d chain end to end: agents launch the Claude CLI in bare mode, the hive's Go inference translator converts Anthropic Messages API calls to OpenAI format and forwards them to the LiteLLM endpoint. **The MITM proxy stays in the path** — mode enforcement, logging, per-agent attribution (`sk-hive-<agent>`), and the CONNECT interception fallback all apply unchanged.

## What's new

- **Bearer auth + CA-aware upstream client** — `InferenceRoute` gains `APIKey`/`CABundle`; all three forward paths set `Authorization: Bearer <key>` and use a per-CA-bundle cached transport. Certificate verification is never disabled (no `InsecureSkipVerify`).
- **Secret-safe config** — `governor.litellm` stores only the API key **env var name** (`api_key_env`) and/or **key file path** (`api_key_file`), never a key value (Config.Save() writes the env-expanded YAML back to disk). Resolution at use time: key file → named env → `HIVE_LITELLM_API_KEY`.
- **Governor LiteLLM tab** — endpoint URL, key env name (with a read-only "key detected" indicator; the key value never reaches the UI or API), default model, CA bundle path, local-proxy toggle, and a Test Connection button. Saves via `PUT /api/config/governor/litellm`, which re-registers model discovery and refreshes routes on live litellm agents without a restart.
- **Selection-time URL prompt** — picking litellm from the agent-card method dropdown or the agent config CLI Pin select prompts for the endpoint when none is configured (no prompt once configured).
- **Model discovery** — `GET /api/inference/models/litellm` via authenticated `/v1/models`; `HIVE_LITELLM_MODELS` env fallback; SSE backend list includes litellm only when an endpoint is configured.
- **Pinned `litellm[proxy]` Dockerfile layer** (`LITELLM_VERSION=1.74.3`) as an **optional local fallback**: with `governor.litellm.local_proxy: true`, hive supervises one shared litellm process on loopback (`/data/litellm/config.yaml`) and routes through it — agents never bypass the Go translator.

## Plan deviation

The plan had `agent.IsInferenceBackend` delegating to `proxy.InferenceBackends`, but `proxy` imports `agent` which imports `config` — so the canonical list lives in `config.InferenceBackends` (leaf package) and both `agent` and `proxy` delegate to it.

## Commits

1. `ec89b0ed` feat(config): add governor.litellm config with secret-safe key resolution
2. `6296aec9` feat(proxy): bearer auth + CA-aware client for inference routes; litellm backend ID
3. `02ed6891` feat(agent): accept litellm backend; delegate inference list; preamble opt-out
4. `45866d85` feat(wiring): call-time litellm endpoint/key resolution and live route refresh
5. `38d77ed4` feat(dashboard-api): governor litellm section, authed model discovery
6. `dee3018d` feat(dashboard-ui): LiteLLM governor tab, backend lists, selection-time setup prompt
7. `80729ac2` feat(litellm): pinned litellm[proxy] Dockerfile layer + optional local proxy fallback
8. `f0fb1389` docs: document inference backends and governor.litellm configuration