### PR TITLE
feat: enforce governor token budget

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1635,6 +1635,40 @@ func main() {
 	}
 }
 
+// Dashboard system-alert IDs for the budget thresholds.
+const (
+	budgetWarnAlertID      = "budget-warn"
+	budgetExhaustedAlertID = "budget-exhausted"
+)
+
+// applyBudgetAlerts turns budget threshold crossings into dashboard system
+// alerts and notifications. Crossings fire once per window (governor tracks
+// the one-shot flags); alerts are cleared when the threshold no longer
+// applies (window rolled, limit raised, or budgeting disabled).
+func applyBudgetAlerts(gov *governor.Governor, trans governor.BudgetTransitions, dashSrv *dashboard.Server, notifier *notify.Notifier) {
+	if !trans.WarnActive {
+		dashSrv.ClearSystemAlert(budgetWarnAlertID)
+	}
+	if !trans.ExhaustedActive {
+		dashSrv.ClearSystemAlert(budgetExhaustedAlertID)
+	}
+
+	budget := gov.GetBudget()
+	if trans.WarnCrossed {
+		msg := fmt.Sprintf("token budget at %d%%+ of weekly limit: %d of %d tokens used",
+			governor.BudgetWarnPct, budget.CurrentSpend, budget.WeeklyLimit)
+		dashSrv.AddSystemAlert(budgetWarnAlertID, "warning", msg)
+		notifier.Send("Budget warning", msg, notify.PriorityDefault)
+	}
+	if trans.ExhaustedCrossed {
+		windowEnd := budget.ResetAt.Add(governor.BudgetWindowDuration)
+		msg := fmt.Sprintf("token budget exhausted: %d of %d tokens used — agent kicks suspended until %s (exempt agents keep running)",
+			budget.CurrentSpend, budget.WeeklyLimit, windowEnd.Format(time.RFC1123))
+		dashSrv.AddSystemAlert(budgetExhaustedAlertID, "error", msg)
+		notifier.Send("Budget exhausted", msg, notify.PriorityHigh)
+	}
+}
+
 func runEvalCycle(
 	ctx context.Context,
 	cfg *config.Config,
@@ -1704,7 +1738,8 @@ func runEvalCycle(
 	// the kick gate sees current-window numbers.
 	if tokenCollector != nil {
 		if summary := tokenCollector.Summary(); summary != nil {
-			gov.UpdateBudgetFromTotals(summary.TotalTokens, summary.ByAgent, summary.ByModel)
+			trans := gov.UpdateBudgetFromTotals(summary.TotalTokens, summary.ByAgent, summary.ByModel)
+			applyBudgetAlerts(gov, trans, dashSrv, notifier)
 		}
 	}
 

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -430,7 +430,8 @@ func main() {
 		}
 		if saved.BudgetSpend > 0 || !saved.BudgetResetAt.IsZero() || len(saved.BudgetByAgent) > 0 {
 			gov.SeedBudget(saved.BudgetSpend, saved.BudgetByAgent, saved.BudgetByModel, saved.BudgetResetAt)
-			logger.Info("budget state restored", "spend", saved.BudgetSpend, "reset_at", saved.BudgetResetAt)
+			gov.SeedBudgetWindowBaseline(saved.BudgetWindowBaseline)
+			logger.Info("budget state restored", "spend", saved.BudgetSpend, "reset_at", saved.BudgetResetAt, "window_baseline", saved.BudgetWindowBaseline)
 		}
 		if len(saved.KickHistory) > 0 {
 			records := make([]governor.KickRecord, len(saved.KickHistory))
@@ -1699,6 +1700,14 @@ func runEvalCycle(
 		)
 	}
 
+	// Refresh budget spend from lifetime token totals before Evaluate so
+	// the kick gate sees current-window numbers.
+	if tokenCollector != nil {
+		if summary := tokenCollector.Summary(); summary != nil {
+			gov.UpdateBudgetFromTotals(summary.TotalTokens, summary.ByAgent, summary.ByModel)
+		}
+	}
+
 	agentsDue := gov.Evaluate(
 		actionable.Issues.Count,
 		actionable.PRs.Count,
@@ -2168,10 +2177,11 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 		BudgetIgnored:    budget.IgnoredAgents,
 		CadenceOverrides: cadenceOverrides,
 		LastKicks:        govState.LastKick,
-		BudgetSpend:      budget.CurrentSpend,
-		BudgetResetAt:    budget.ResetAt,
-		BudgetByAgent:    budget.ByAgent,
-		BudgetByModel:    budget.ByModel,
+		BudgetSpend:          budget.CurrentSpend,
+		BudgetResetAt:        budget.ResetAt,
+		BudgetByAgent:        budget.ByAgent,
+		BudgetByModel:        budget.ByModel,
+		BudgetWindowBaseline: budget.WindowBaseline,
 		KickHistory:      kickEntries,
 		IssueCosts:       issueCosts,
 		LastEval:         govState.LastEval,

--- a/v2/pkg/dashboard/api_coverage_test.go
+++ b/v2/pkg/dashboard/api_coverage_test.go
@@ -3160,7 +3160,9 @@ func TestBuildBudget_WithWeeklyLimit(t *testing.T) {
 	}
 	gov := governor.New(cfg, agents, logger)
 	gov.SetBudgetLimit(1000000)
-	gov.UpdateBudget(250000, map[string]int64{"scanner": 250000}, map[string]int64{"sonnet": 250000})
+	// Open the window first so the totals count as in-window spend.
+	gov.SetBudgetResetAt(time.Now())
+	gov.UpdateBudgetFromTotals(250000, map[string]int64{"scanner": 250000}, map[string]int64{"sonnet": 250000})
 
 	budget := buildBudget(gov, nil)
 	if budget.WeeklyBudget != 1000000 {

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -283,6 +283,12 @@ type FrontendBudget struct {
 	ProjectedWeekly int64   `json:"PROJECTED_WEEKLY"`
 	ProjectedPct    float64 `json:"PROJECTED_PCT"`
 	LastUpdated     string  `json:"LAST_UPDATED"`
+	// Exhausted is true when the weekly limit is set and window spend has
+	// reached it — the governor is suppressing kicks for non-exempt agents.
+	Exhausted bool `json:"BUDGET_EXHAUSTED"`
+	// WindowEndsAt is when the current budget window rolls (RFC3339);
+	// empty unless a weekly limit is set and a window is open.
+	WindowEndsAt string `json:"WINDOW_ENDS_AT"`
 }
 
 type FrontendCadence struct {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4025,11 +4025,19 @@
       const hoursLeft = budget.HOURS_REMAINING || 0;
       const HOURS_PER_DAY = 24;
       const dailyRate = burnRate * HOURS_PER_DAY;
-      const usedFillCls = budgetIgnored ? 'safe' : pctUsed < PCT_SAFE ? 'safe' : pctUsed < PCT_WARN ? 'warning' : 'danger';
+      const PCT_BUDGET_WARN = 90; // mirrors governor.BudgetWarnPct: soft-warning threshold
+      const exhausted = !!budget.BUDGET_EXHAUSTED;
+      // Red is reserved for exhausted (kicks suspended); >=90% shows amber.
+      const usedFillCls = budgetIgnored ? 'safe' : exhausted ? 'danger' : pctUsed >= PCT_SAFE ? 'warning' : 'safe';
 
       let govAction = '';
       if (budgetIgnored) {
         govAction = '<span style="color:var(--muted)">Budget enforcement disabled by operator</span>';
+      } else if (exhausted) {
+        const windowEnds = budget.WINDOW_ENDS_AT ? new Date(budget.WINDOW_ENDS_AT).toLocaleString() : 'the next window';
+        govAction = `<span style="color:var(--red)" title="Agents on the budget exempt list keep running">budget exhausted — agent kicks suspended until ${windowEnds}</span>`;
+      } else if (pctUsed >= PCT_BUDGET_WARN) {
+        govAction = `<span style="color:var(--yellow)">Budget warning — ${pctUsed}% of weekly limit used; kicks suspend at 100%</span>`;
       } else if (projPct > PCT_WARN) {
         govAction = '<span style="color:var(--red)">Governor downgrading models to stay within budget</span>';
       } else if (projPct > PCT_SAFE) {

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -757,7 +757,10 @@ func buildBudget(gov *governor.Governor, tokenCollector *tokens.Collector) Front
 	}
 
 	used := totalTokens
-	if budget.CurrentSpend > 0 {
+	if !budget.ResetAt.IsZero() {
+		// Governor window is open: CurrentSpend is the live window-relative
+		// spend. The collector lifetime total remains the fallback for
+		// limit-less tracking before any window exists.
 		used = budget.CurrentSpend
 	}
 
@@ -788,6 +791,11 @@ func buildBudget(gov *governor.Governor, tokenCollector *tokens.Collector) Front
 			}
 		}
 		fb.HoursElapsed = hoursElapsed
+
+		fb.Exhausted = used >= budget.WeeklyLimit
+		if !budget.ResetAt.IsZero() {
+			fb.WindowEndsAt = budget.ResetAt.Add(governor.BudgetWindowDuration).UTC().Format(time.RFC3339)
+		}
 	}
 
 	return fb

--- a/v2/pkg/dashboard/status_builder_test.go
+++ b/v2/pkg/dashboard/status_builder_test.go
@@ -432,7 +432,9 @@ func TestBuildBudget_WithSpend(t *testing.T) {
 	cfg := config.GovernorConfig{}
 	gov := governor.New(cfg, map[string]config.AgentConfig{}, nil)
 	gov.SetBudgetLimit(1000000)
-	gov.UpdateBudget(250000, nil, nil)
+	// Open the window first so the totals count as in-window spend.
+	gov.SetBudgetResetAt(time.Now())
+	gov.UpdateBudgetFromTotals(250000, nil, nil)
 
 	fb := buildBudget(gov, nil)
 	if fb.WeeklyBudget != 1000000 {
@@ -450,7 +452,9 @@ func TestBuildBudget_OverSpend(t *testing.T) {
 	cfg := config.GovernorConfig{}
 	gov := governor.New(cfg, map[string]config.AgentConfig{}, nil)
 	gov.SetBudgetLimit(1000)
-	gov.UpdateBudget(2000, nil, nil)
+	// Open the window first so the totals count as in-window spend.
+	gov.SetBudgetResetAt(time.Now())
+	gov.UpdateBudgetFromTotals(2000, nil, nil)
 
 	fb := buildBudget(gov, nil)
 	if fb.Remaining != 0 {
@@ -758,9 +762,9 @@ func TestBuildBudget_BurnRate(t *testing.T) {
 	cfg := config.GovernorConfig{}
 	gov := governor.New(cfg, map[string]config.AgentConfig{}, nil)
 	gov.SetBudgetLimit(1000000)
-	gov.UpdateBudget(100000, nil, nil)
 	// Set reset time to 10 hours ago to trigger burn rate calculation
 	gov.SetBudgetResetAt(time.Now().Add(-10 * time.Hour))
+	gov.UpdateBudgetFromTotals(100000, nil, nil)
 
 	fb := buildBudget(gov, nil)
 	if fb.WeeklyBudget != 1000000 {

--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -87,6 +87,10 @@ type State struct {
 	LastKick      map[string]time.Time    `json:"last_kick"`
 	LastEval      time.Time               `json:"last_eval"`
 	SLAViolations int                     `json:"sla_violations"`
+	// BudgetExhausted mirrors the budget gate as of the last eval: the
+	// weekly limit is set and window spend has reached it, so kicks for
+	// non-exempt agents are suppressed.
+	BudgetExhausted bool `json:"budget_exhausted"`
 }
 
 const (
@@ -192,6 +196,8 @@ func (g *Governor) Evaluate(queueIssues, queuePRs, queueHold, slaViolations int)
 		}
 	}
 
+	g.state.BudgetExhausted = g.budgetExhausted()
+
 	due := g.agentsDueForKick()
 
 	snap := EvalSnapshot{
@@ -290,9 +296,24 @@ func (g *Governor) updateCadences() {
 	}
 }
 
+// budgetExhausted reports whether the weekly budget gate is closed.
+// WeeklyLimit == 0 means budgeting is entirely off. Caller must hold g.mu.
+func (g *Governor) budgetExhausted() bool {
+	return g.budget.WeeklyLimit > 0 && g.budget.CurrentSpend >= g.budget.WeeklyLimit
+}
+
 func (g *Governor) agentsDueForKick() []string {
 	now := time.Now()
 	var due []string
+
+	exhausted := g.budgetExhausted()
+	// IgnoredAgents are exempt from budget suppression: they keep getting
+	// kicked even when the weekly budget is exhausted.
+	exempt := make(map[string]bool, len(g.budget.IgnoredAgents))
+	for _, name := range g.budget.IgnoredAgents {
+		exempt[name] = true
+	}
+	suppressed := 0
 
 	for agentName, cadence := range g.state.Cadences {
 		if cadence.Paused {
@@ -307,11 +328,23 @@ func (g *Governor) agentsDueForKick() []string {
 		if ac, ok := g.agents[agentName]; ok && !ac.UsesGovernorKick() {
 			continue
 		}
+		if exhausted && !exempt[agentName] {
+			suppressed++
+			continue
+		}
 
 		lastKick, kicked := g.state.LastKick[agentName]
 		if !kicked || now.Sub(lastKick) >= cadence.Interval {
 			due = append(due, agentName)
 		}
+	}
+
+	if exhausted {
+		g.logger.Info("budget exhausted — suppressing kicks",
+			"spend", g.budget.CurrentSpend,
+			"limit", g.budget.WeeklyLimit,
+			"suppressed", suppressed,
+		)
 	}
 
 	return due
@@ -338,14 +371,15 @@ func (g *Governor) GetState() State {
 		lastKick[k] = v
 	}
 	return State{
-		Mode:          g.state.Mode,
-		QueueIssues:   g.state.QueueIssues,
-		QueuePRs:      g.state.QueuePRs,
-		QueueHold:     g.state.QueueHold,
-		Cadences:      cadences,
-		LastKick:      lastKick,
-		LastEval:      g.state.LastEval,
-		SLAViolations: g.state.SLAViolations,
+		Mode:            g.state.Mode,
+		QueueIssues:     g.state.QueueIssues,
+		QueuePRs:        g.state.QueuePRs,
+		QueueHold:       g.state.QueueHold,
+		Cadences:        cadences,
+		LastKick:        lastKick,
+		LastEval:        g.state.LastEval,
+		SLAViolations:   g.state.SLAViolations,
+		BudgetExhausted: g.state.BudgetExhausted,
 	}
 }
 

--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -66,8 +66,17 @@ type BudgetInfo struct {
 	ByAgent       map[string]int64 `json:"by_agent"`
 	ByModel       map[string]int64 `json:"by_model"`
 	IgnoredAgents []string         `json:"ignored_agents"`
-	ResetAt       time.Time        `json:"reset_at"`
+	// ResetAt is the START of the current budget window; the window ends
+	// at ResetAt + BudgetWindowDuration.
+	ResetAt time.Time `json:"reset_at"`
+	// WindowBaseline is the lifetime token total observed when the current
+	// window opened. Spend inside the window is lifetime total minus this.
+	WindowBaseline int64 `json:"window_baseline"`
 }
+
+// BudgetWindowDuration is the length of one budget accounting window; the
+// "weekly" limit applies to spend accumulated within it.
+const BudgetWindowDuration = 7 * 24 * time.Hour
 
 type State struct {
 	Mode          Mode                    `json:"mode"`
@@ -525,25 +534,63 @@ func (g *Governor) GetBudget() BudgetInfo {
 	ignored := make([]string, len(g.budget.IgnoredAgents))
 	copy(ignored, g.budget.IgnoredAgents)
 	return BudgetInfo{
-		WeeklyLimit:   g.budget.WeeklyLimit,
-		CurrentSpend:  g.budget.CurrentSpend,
-		ByAgent:       byAgent,
-		ByModel:       byModel,
-		IgnoredAgents: ignored,
-		ResetAt:       g.budget.ResetAt,
+		WeeklyLimit:    g.budget.WeeklyLimit,
+		CurrentSpend:   g.budget.CurrentSpend,
+		ByAgent:        byAgent,
+		ByModel:        byModel,
+		IgnoredAgents:  ignored,
+		ResetAt:        g.budget.ResetAt,
+		WindowBaseline: g.budget.WindowBaseline,
 	}
 }
 
-func (g *Governor) UpdateBudget(totalTokens int64, byAgent map[string]int64, byModel map[string]int64) {
+// UpdateBudgetFromTotals refreshes budget spend from the token collector's
+// lifetime totals. Session-file scans are cumulative, so window spend is
+// derived by subtracting the baseline captured when the window opened.
+// Rolls the window forward once BudgetWindowDuration has elapsed.
+func (g *Governor) UpdateBudgetFromTotals(totalTokens int64, byAgent map[string]int64, byModel map[string]int64) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	g.budget.CurrentSpend = totalTokens
+
+	now := time.Now()
+	if g.budget.ResetAt.IsZero() {
+		// First run or legacy snapshot without a window: open one now.
+		g.budget.ResetAt = now
+		g.budget.WindowBaseline = totalTokens
+	} else if now.Sub(g.budget.ResetAt) >= BudgetWindowDuration {
+		g.budget.ResetAt = now
+		g.budget.WindowBaseline = totalTokens
+		if g.logger != nil {
+			g.logger.Info("budget window rolled",
+				"reset_at", now,
+				"baseline", totalTokens,
+			)
+		}
+	}
+
+	if totalTokens < g.budget.WindowBaseline {
+		// Lifetime totals shrank (session files pruned); re-baseline so
+		// spend never goes negative.
+		g.budget.WindowBaseline = totalTokens
+	}
+	g.budget.CurrentSpend = totalTokens - g.budget.WindowBaseline
+
+	// ByAgent/ByModel remain lifetime totals: window-relative breakdowns
+	// would need per-key baselines and these maps are informational only.
 	for k, v := range byAgent {
 		g.budget.ByAgent[k] = v
 	}
 	for k, v := range byModel {
 		g.budget.ByModel[k] = v
 	}
+}
+
+// SeedBudgetWindowBaseline restores the window baseline from a persisted
+// snapshot so the current window's spend survives restarts.
+func (g *Governor) SeedBudgetWindowBaseline(baseline int64) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.budget.WindowBaseline = baseline
 }
 
 func (g *Governor) SetBudgetLimit(limit int64) {

--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -78,6 +78,26 @@ type BudgetInfo struct {
 // "weekly" limit applies to spend accumulated within it.
 const BudgetWindowDuration = 7 * 24 * time.Hour
 
+// BudgetWarnPct is the percent of the weekly limit at which the soft
+// budget warning fires.
+const BudgetWarnPct = 90
+
+// percentDenominator converts a percentage into a fraction of a whole.
+const percentDenominator = 100
+
+// BudgetTransitions reports budget threshold state from a single
+// UpdateBudgetFromTotals call. WarnCrossed and ExhaustedCrossed are
+// one-shot: they fire at most once per window (flags reset when the window
+// rolls). The Active fields reflect the current spend level every call so
+// callers can clear alerts that no longer apply.
+type BudgetTransitions struct {
+	WarnCrossed      bool
+	ExhaustedCrossed bool
+	Rolled           bool
+	WarnActive       bool
+	ExhaustedActive  bool
+}
+
 type State struct {
 	Mode          Mode                    `json:"mode"`
 	QueueIssues   int                     `json:"queue_issues"`
@@ -110,6 +130,11 @@ type Governor struct {
 	evalHistory []EvalSnapshot
 	kickHistory []KickRecord
 	budget      BudgetInfo
+
+	// One-shot alert flags for the current budget window; reset when the
+	// window rolls so each window alerts at most once per threshold.
+	budgetWarned           bool
+	budgetExhaustedAlerted bool
 }
 
 func New(cfg config.GovernorConfig, agents map[string]config.AgentConfig, logger *slog.Logger) *Governor {
@@ -581,11 +606,13 @@ func (g *Governor) GetBudget() BudgetInfo {
 // UpdateBudgetFromTotals refreshes budget spend from the token collector's
 // lifetime totals. Session-file scans are cumulative, so window spend is
 // derived by subtracting the baseline captured when the window opened.
-// Rolls the window forward once BudgetWindowDuration has elapsed.
-func (g *Governor) UpdateBudgetFromTotals(totalTokens int64, byAgent map[string]int64, byModel map[string]int64) {
+// Rolls the window forward once BudgetWindowDuration has elapsed and
+// reports threshold crossings so callers can alert exactly once per window.
+func (g *Governor) UpdateBudgetFromTotals(totalTokens int64, byAgent map[string]int64, byModel map[string]int64) BudgetTransitions {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
+	var trans BudgetTransitions
 	now := time.Now()
 	if g.budget.ResetAt.IsZero() {
 		// First run or legacy snapshot without a window: open one now.
@@ -594,6 +621,9 @@ func (g *Governor) UpdateBudgetFromTotals(totalTokens int64, byAgent map[string]
 	} else if now.Sub(g.budget.ResetAt) >= BudgetWindowDuration {
 		g.budget.ResetAt = now
 		g.budget.WindowBaseline = totalTokens
+		g.budgetWarned = false
+		g.budgetExhaustedAlerted = false
+		trans.Rolled = true
 		if g.logger != nil {
 			g.logger.Info("budget window rolled",
 				"reset_at", now,
@@ -617,6 +647,23 @@ func (g *Governor) UpdateBudgetFromTotals(totalTokens int64, byAgent map[string]
 	for k, v := range byModel {
 		g.budget.ByModel[k] = v
 	}
+
+	// WeeklyLimit == 0 disables budgeting entirely: no thresholds, no alerts.
+	if g.budget.WeeklyLimit > 0 {
+		warnThreshold := g.budget.WeeklyLimit * BudgetWarnPct / percentDenominator
+		trans.WarnActive = g.budget.CurrentSpend >= warnThreshold
+		trans.ExhaustedActive = g.budget.CurrentSpend >= g.budget.WeeklyLimit
+		if trans.WarnActive && !g.budgetWarned {
+			g.budgetWarned = true
+			trans.WarnCrossed = true
+		}
+		if trans.ExhaustedActive && !g.budgetExhaustedAlerted {
+			g.budgetExhaustedAlerted = true
+			trans.ExhaustedCrossed = true
+		}
+	}
+
+	return trans
 }
 
 // SeedBudgetWindowBaseline restores the window baseline from a persisted

--- a/v2/pkg/governor/governor_budget_test.go
+++ b/v2/pkg/governor/governor_budget_test.go
@@ -64,6 +64,49 @@ func TestBudgetZeroLimit_NeverSuppresses(t *testing.T) {
 	}
 }
 
+func TestBudgetTransitions_OneShotPerWindow(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	g := New(cfg, agents, testLogger())
+
+	g.SetBudgetLimit(1000)
+	g.SetBudgetResetAt(time.Now()) // open the window with baseline 0
+
+	trans := g.UpdateBudgetFromTotals(950, nil, nil)
+	if !trans.WarnCrossed || !trans.WarnActive {
+		t.Errorf("expected warn crossing at 95%%, got %+v", trans)
+	}
+	if trans.ExhaustedCrossed || trans.ExhaustedActive {
+		t.Errorf("unexpected exhausted state below limit: %+v", trans)
+	}
+
+	trans = g.UpdateBudgetFromTotals(1200, nil, nil)
+	if trans.WarnCrossed {
+		t.Error("warn crossing must fire only once per window")
+	}
+	if !trans.ExhaustedCrossed || !trans.ExhaustedActive {
+		t.Errorf("expected exhausted crossing over limit, got %+v", trans)
+	}
+
+	trans = g.UpdateBudgetFromTotals(1300, nil, nil)
+	if trans.WarnCrossed || trans.ExhaustedCrossed {
+		t.Errorf("crossings must not repeat within a window: %+v", trans)
+	}
+	if !trans.WarnActive || !trans.ExhaustedActive {
+		t.Errorf("active levels should keep reporting: %+v", trans)
+	}
+}
+
+func TestBudgetTransitions_ZeroLimitNeverAlerts(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	g := New(cfg, agents, testLogger())
+
+	g.UpdateBudgetFromTotals(0, nil, nil) // opens the window at baseline 0
+	trans := g.UpdateBudgetFromTotals(1_000_000, nil, nil)
+	if trans.WarnCrossed || trans.ExhaustedCrossed || trans.WarnActive || trans.ExhaustedActive {
+		t.Errorf("zero limit must never trigger budget alerts: %+v", trans)
+	}
+}
+
 func TestBudgetWindowRoll_ClearsSuppression(t *testing.T) {
 	cfg, agents := standardConfig("scanner")
 	g := New(cfg, agents, testLogger())

--- a/v2/pkg/governor/governor_budget_test.go
+++ b/v2/pkg/governor/governor_budget_test.go
@@ -1,0 +1,89 @@
+package governor
+
+import (
+	"testing"
+	"time"
+)
+
+// dueSet runs one eval and returns the set of agents due for a kick.
+func dueSet(g *Governor) map[string]bool {
+	due := g.Evaluate(0, 0, 0, 0)
+	set := make(map[string]bool, len(due))
+	for _, name := range due {
+		set[name] = true
+	}
+	return set
+}
+
+func TestBudgetExhausted_SuppressesKicks(t *testing.T) {
+	cfg, agents := standardConfig("scanner", "outreach")
+	g := New(cfg, agents, testLogger())
+
+	g.SetBudgetLimit(1000)
+	g.SeedBudget(1000, nil, nil, time.Now())
+
+	due := dueSet(g)
+	if due["scanner"] || due["outreach"] {
+		t.Errorf("exhausted budget should suppress kicks, got due=%v", due)
+	}
+	if !g.GetState().BudgetExhausted {
+		t.Error("state should report budget exhausted")
+	}
+}
+
+func TestBudgetExhausted_ExemptAgentsStillDue(t *testing.T) {
+	cfg, agents := standardConfig("scanner", "outreach")
+	g := New(cfg, agents, testLogger())
+
+	g.SetBudgetLimit(1000)
+	g.SeedBudget(1500, nil, nil, time.Now())
+	g.SetBudgetIgnored([]string{"outreach"})
+
+	due := dueSet(g)
+	if due["scanner"] {
+		t.Error("non-exempt scanner should be suppressed")
+	}
+	if !due["outreach"] {
+		t.Error("exempt outreach should still be due")
+	}
+}
+
+func TestBudgetZeroLimit_NeverSuppresses(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	g := New(cfg, agents, testLogger())
+
+	// Massive spend but no limit: budgeting is entirely off.
+	g.SeedBudget(1_000_000_000, nil, nil, time.Now())
+
+	due := dueSet(g)
+	if !due["scanner"] {
+		t.Error("zero limit must never suppress kicks")
+	}
+	if g.GetState().BudgetExhausted {
+		t.Error("zero limit must never report exhausted")
+	}
+}
+
+func TestBudgetWindowRoll_ClearsSuppression(t *testing.T) {
+	cfg, agents := standardConfig("scanner")
+	g := New(cfg, agents, testLogger())
+
+	g.SetBudgetLimit(1000)
+	// Exhausted window that expired more than a week ago.
+	g.SeedBudget(1500, nil, nil, time.Now().Add(-BudgetWindowDuration-time.Hour))
+
+	if due := dueSet(g); due["scanner"] {
+		t.Fatal("scanner should be suppressed before the window rolls")
+	}
+
+	// Next totals update rolls the window and resets spend to zero.
+	g.UpdateBudgetFromTotals(5000, nil, nil)
+
+	due := dueSet(g)
+	if !due["scanner"] {
+		t.Error("window roll should clear kick suppression")
+	}
+	if g.GetState().BudgetExhausted {
+		t.Error("state should clear exhausted after window roll")
+	}
+}

--- a/v2/pkg/governor/governor_coverage_test.go
+++ b/v2/pkg/governor/governor_coverage_test.go
@@ -189,7 +189,7 @@ func TestSeedQueueState(t *testing.T) {
 
 func TestGetBudget_ReturnsCopy(t *testing.T) {
 	g := testGovernor()
-	g.UpdateBudget(1000, map[string]int64{"scanner": 500}, map[string]int64{"sonnet": 500})
+	g.UpdateBudgetFromTotals(1000, map[string]int64{"scanner": 500}, map[string]int64{"sonnet": 500})
 
 	budget := g.GetBudget()
 	budget.ByAgent["scanner"] = 9999 // mutate copy

--- a/v2/pkg/governor/governor_extra_test.go
+++ b/v2/pkg/governor/governor_extra_test.go
@@ -109,18 +109,70 @@ func TestSetBudgetResetAt(t *testing.T) {
 	}
 }
 
-func TestUpdateBudget(t *testing.T) {
+func TestUpdateBudgetFromTotals_InitializesWindow(t *testing.T) {
 	g := testGovernor()
 	byAgent := map[string]int64{"scanner": 1000, "supervisor": 500}
 	byModel := map[string]int64{"sonnet": 1200, "opus": 300}
-	g.UpdateBudget(1500, byAgent, byModel)
+	g.UpdateBudgetFromTotals(1500, byAgent, byModel)
 
 	budget := g.GetBudget()
-	if budget.CurrentSpend != 1500 {
-		t.Errorf("current spend = %d", budget.CurrentSpend)
+	if budget.ResetAt.IsZero() {
+		t.Error("first update should open a budget window")
+	}
+	if budget.WindowBaseline != 1500 {
+		t.Errorf("baseline = %d, want 1500", budget.WindowBaseline)
+	}
+	if budget.CurrentSpend != 0 {
+		t.Errorf("current spend = %d, want 0 at window open", budget.CurrentSpend)
 	}
 	if budget.ByAgent["scanner"] != 1000 {
 		t.Errorf("scanner spend = %d", budget.ByAgent["scanner"])
+	}
+}
+
+func TestUpdateBudgetFromTotals_SpendIsWindowRelative(t *testing.T) {
+	g := testGovernor()
+	g.UpdateBudgetFromTotals(1000, nil, nil)
+	g.UpdateBudgetFromTotals(1500, nil, nil)
+
+	budget := g.GetBudget()
+	if budget.CurrentSpend != 500 {
+		t.Errorf("current spend = %d, want 500", budget.CurrentSpend)
+	}
+	if budget.WindowBaseline != 1000 {
+		t.Errorf("baseline = %d, want 1000", budget.WindowBaseline)
+	}
+}
+
+func TestUpdateBudgetFromTotals_RollsExpiredWindow(t *testing.T) {
+	g := testGovernor()
+	g.SeedBudget(900, nil, nil, time.Now().Add(-BudgetWindowDuration-time.Hour))
+	g.UpdateBudgetFromTotals(2000, nil, nil)
+
+	budget := g.GetBudget()
+	if budget.WindowBaseline != 2000 {
+		t.Errorf("baseline = %d, want 2000 after roll", budget.WindowBaseline)
+	}
+	if budget.CurrentSpend != 0 {
+		t.Errorf("current spend = %d, want 0 after roll", budget.CurrentSpend)
+	}
+	if time.Since(budget.ResetAt) > time.Minute {
+		t.Errorf("reset_at not advanced on roll: %v", budget.ResetAt)
+	}
+}
+
+func TestUpdateBudgetFromTotals_RebaselinesOnShrink(t *testing.T) {
+	g := testGovernor()
+	g.UpdateBudgetFromTotals(1000, nil, nil)
+	// Session files pruned: lifetime totals drop below the baseline.
+	g.UpdateBudgetFromTotals(400, nil, nil)
+
+	budget := g.GetBudget()
+	if budget.WindowBaseline != 400 {
+		t.Errorf("baseline = %d, want 400 after shrink", budget.WindowBaseline)
+	}
+	if budget.CurrentSpend != 0 {
+		t.Errorf("current spend = %d, want 0 after shrink", budget.CurrentSpend)
 	}
 }
 

--- a/v2/pkg/snapshot/state.go
+++ b/v2/pkg/snapshot/state.go
@@ -22,6 +22,9 @@ type PersistedState struct {
 	BudgetResetAt    time.Time                        `json:"budget_reset_at,omitempty"`
 	BudgetByAgent    map[string]int64                 `json:"budget_by_agent,omitempty"`
 	BudgetByModel    map[string]int64                 `json:"budget_by_model,omitempty"`
+	// BudgetWindowBaseline is the lifetime token total at the start of the
+	// current budget window (see governor.BudgetInfo.WindowBaseline).
+	BudgetWindowBaseline int64                        `json:"budget_window_baseline,omitempty"`
 	KickHistory      []GovKickEntry                   `json:"kick_history,omitempty"`
 	IssueCosts       map[string]int64                 `json:"issue_costs,omitempty"`
 	LastEval         time.Time                        `json:"last_eval,omitempty"`


### PR DESCRIPTION
## Summary

The governor's token budget was display-only: `UpdateBudget` and `SetBudgetResetAt` had no production callers, `agentsDueForKick()` never consulted the budget, `IgnoredAgents` was consumed by nothing, and the weekly window never rolled — so the configured limit could never stop spend. This PR makes the limit real.

- **Weekly window with baseline + roll**: token session scans are cumulative lifetime totals, so window spend is derived from a `WindowBaseline` captured when the window opens (`spend = lifetime - baseline`). The window rolls forward after 7 days (`BudgetWindowDuration`), re-baselining and clearing per-window alert flags. Baseline is persisted in the state snapshot so spend survives restarts. If lifetime totals shrink (pruned session files), the window re-baselines instead of going negative.
- **Kick suppression at the limit**: once window spend reaches `WeeklyLimit`, `agentsDueForKick()` suppresses kicks for all agents except those in `IgnoredAgents` (exempt agents keep getting kicked). Exposed as `State.BudgetExhausted`; each eval under exhaustion logs spend/limit/suppressed-count.
- **Alerts**: one-shot per window — a `budget-warn` (warning) system alert + notification at 90% of the limit (`BudgetWarnPct`), and a `budget-exhausted` (error) alert + high-priority notification on exhaustion, including when kicks resume. Alerts clear when no longer applicable (window rolled, limit raised, budgeting disabled).
- **Dashboard**: `FrontendBudget` gains `BUDGET_EXHAUSTED` and `WINDOW_ENDS_AT`; the budget bar shows a red exhausted state ("budget exhausted — agent kicks suspended until <local time>", tooltip notes exempt agents keep running) and an amber warning at 90%+. Also fixes the stale-spend display bug: `buildBudget` now uses live window-relative spend whenever a window is open, instead of preferring seeded snapshot spend.
- **`WeeklyLimit == 0` disables budgeting entirely**: no enforcement, no warnings, tracking-only display behavior unchanged.

## Commits

1. `feat(governor): derive weekly budget window from lifetime token totals`
2. `feat(governor): suppress agent kicks when weekly budget is exhausted`
3. `feat: alert at 90% budget and on exhaustion via system alerts and ntfy`
4. `feat(dashboard): show budget exhausted and 90% warning states`

## Notes

- `UpdateBudget` (dead) was replaced by `UpdateBudgetFromTotals`; governor/dashboard tests updated accordingly, plus new governor tests covering suppression, exemption, zero-limit, window roll, and one-shot alert semantics.
- Pre-existing, untouched: the budget-bar "ignore budget" checkbox POSTs a boolean to `/api/budget-ignore`, whose handler decodes `ignored` as a `[]string` of agent names — that client/server mismatch predates this PR.