### PR TITLE
fix: detect Claude OAuth and device-flow login screens

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -2134,8 +2134,10 @@ const (
 // the Copilot OAuth token; injected into agents as COPILOT_GITHUB_TOKEN.
 const CopilotUserTokenPath = "/data/copilot-user-token"
 
-// loginPromptPatterns are substrings that indicate an agent is stuck on the
-// Copilot login/authentication screen.
+// loginPromptPatterns are substrings that indicate an agent is stuck on a
+// login/authentication screen (Copilot text prompts, Claude Code OAuth flow,
+// GitHub device flow). Each must be distinctive enough to never appear in
+// ordinary agent output.
 var loginPromptPatterns = []string{
 	"/login",
 	"sign in to use",
@@ -2144,6 +2146,14 @@ var loginPromptPatterns = []string{
 	"Authenticate to use",
 	"log in to use",
 	"Log in to use",
+	// Claude Code OAuth sign-in screen
+	"Use the url below to sign in",
+	"Paste code here if prompted",
+	"Select login method",
+	"/cai/oauth/authorize",
+	// GitHub device-flow screen (Copilot CLI)
+	"Enter one-time code",
+	"github.com/login/device",
 }
 
 // fatalNetworkErrorPatterns are substrings that indicate a transient TLS or


### PR DESCRIPTION
loginPromptPatterns only matched Copilot text prompts. An agent sitting on Claude Code's OAuth sign-in screen reported needsLogin=false → dashboard showed '✓ logged in' while the pane asked for a sign-in code (kellyaa's supervisor, 256 restarts/24h). Adds distinctive patterns for the Claude OAuth screen, the login-method picker, and the GitHub device-flow screen.