### PR TITLE
fix: auth badge reflects credential availability

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1147,6 +1147,8 @@ func main() {
 		}
 	}
 
+	dashboard.SetBackendAuthProvider(agentMgr.BackendAuthAvailable)
+
 	githubProxy, err := proxy.NewGitHubProxy(logger, cfg.Project.Org, cfg.Project.Repos)
 	if err != nil {
 		logger.Error("failed to create github proxy", "error", err)

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -138,6 +138,28 @@ func (m *Manager) SetCopilotToken(token string) {
 	m.copilotAuthToken = token
 }
 
+// BackendAuthAvailable reports whether shared credentials exist for a CLI
+// backend, so the dashboard can show honest auth state even for agents with
+// no running pane (e.g. on-demand agents that never launched). Claude checks
+// the credentials file (with expiry); Copilot checks the cached token. For
+// backends we cannot introspect it returns (false, false) = unknown.
+func (m *Manager) BackendAuthAvailable(backend string) (available, known bool) {
+	switch backend {
+	case "claude":
+		return claude.HasValidToken(claude.CredentialsPath), true
+	case "copilot":
+		m.mu.RLock()
+		tok := m.copilotAuthToken
+		m.mu.RUnlock()
+		if tok != "" {
+			return true, true
+		}
+		return configHasTokens(), true
+	default:
+		return false, false
+	}
+}
+
 // SetInferenceCallbacks registers callbacks that the manager uses to
 // configure/clear inference routing on the proxy when launching agents.
 func (m *Manager) SetInferenceCallbacks(

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -173,6 +173,8 @@ type FrontendAgent struct {
 	PausedTrigger    string `json:"pausedTrigger,omitempty"`
 	OffByCadence     bool   `json:"offByCadence"`
 	NeedsLogin       bool   `json:"needsLogin"`
+	AuthAvailable    bool   `json:"authAvailable"`
+	AuthKnown        bool   `json:"authKnown"`
 	CLI              string `json:"cli"`
 	Model            string `json:"model"`
 	Cadence          string `json:"cadence"`

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2623,7 +2623,7 @@
           <div class="oc-detail-field"><div class="label" title="CLI authentication status — log in to authenticate the agent's CLI tool">Auth</div><div class="value">${(() => {
             const isClaude = a.cli === 'claude';
             const isCopilot = a.cli === 'copilot';
-            const _needsLogin = a.needsLogin === true;
+            const _needsLogin = a.needsLogin === true || (a.authKnown === true && a.authAvailable !== true);
             const claudeIcon = '<span class="cli-icon claude-icon"></span>';
             const copilotIcon = '<span class="cli-icon copilot-icon"></span>';
             if (_needsLogin) {
@@ -3466,7 +3466,7 @@
       });
       const { sorted: sortedAgents } = _sortAgentsBySidebar(agents);
       const cards = sortedAgents.map(a => {
-        const needsLogin = a.needsLogin === true;
+        const needsLogin = a.needsLogin === true || (a.authKnown === true && a.authAvailable !== true);
         const isOff = a.offByCadence === true;
         const isOnDemand = a.onDemand === true;
         const isPaused = a.paused === true && !isOff && !isOnDemand;

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -39,7 +39,25 @@ func getProxyViolationsFn() func() map[string]int {
 	return proxyViolationsFn
 }
 
+// SetBackendAuthProvider registers a function reporting whether shared
+// credentials exist for a CLI backend (available, known). Lets the status
+// build show honest auth state for agents with no running pane.
+func SetBackendAuthProvider(fn func(backend string) (bool, bool)) {
+	backendAuthMu.Lock()
+	defer backendAuthMu.Unlock()
+	backendAuthFn = fn
+}
+
+func getBackendAuthFn() func(backend string) (bool, bool) {
+	backendAuthMu.RLock()
+	defer backendAuthMu.RUnlock()
+	return backendAuthFn
+}
+
 var (
+	backendAuthMu sync.RWMutex
+	backendAuthFn func(backend string) (bool, bool)
+
 	cachedHealth   map[string]any
 	cachedHealthMu sync.RWMutex
 
@@ -249,6 +267,11 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 		a.DefaultMode = defaultMode.String()
 		a.IsCustomMode = mode != defaultMode
 		a.NeedsLogin = proc.NeedsLogin
+		if authFn := getBackendAuthFn(); authFn != nil {
+			avail, known := authFn(cli)
+			a.AuthAvailable = avail
+			a.AuthKnown = known
+		}
 		a.NeedsRestart = proc.HasLaunched && proc.LaunchedMode != mode
 		a.OnDemand = agentCfg.OnDemand || onDemandSet[name]
 		if pvFn := getProxyViolationsFn(); pvFn != nil {


### PR DESCRIPTION
Never-launched (on-demand) agents showed '✓ logged in' with no credentials at all — the badge was purely !needsLogin from pane detection. Adds manager.BackendAuthAvailable (claude: HasValidToken on the shared credentials file; copilot: cached token or config.json tokens; others: unknown), exposed per-agent as authAvailable/authKnown in the status payload via a provider hook (mirrors the proxy-violations provider). The badge now requires known-present credentials to claim logged in; unknown-auth backends keep prior behavior.