### PR TITLE
fix: budget-ignore checkbox contract mismatch

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -401,6 +401,9 @@ func main() {
 		if saved.BudgetLimit > 0 {
 			gov.SetBudgetLimit(saved.BudgetLimit)
 		}
+		if saved.BudgetIgnoreAll {
+			gov.SetBudgetIgnoreAll(true)
+		}
 		if len(saved.BudgetIgnored) > 0 {
 			gov.SetBudgetIgnored(saved.BudgetIgnored)
 		}
@@ -2212,6 +2215,7 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 		GovernorMode:     string(govState.Mode),
 		BudgetLimit:      budget.WeeklyLimit,
 		BudgetIgnored:    budget.IgnoredAgents,
+		BudgetIgnoreAll:  budget.IgnoreAll,
 		CadenceOverrides: cadenceOverrides,
 		LastKicks:        govState.LastKick,
 		BudgetSpend:          budget.CurrentSpend,

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1213,7 +1213,7 @@ func (s *Server) handleBudgetIgnoreSet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	budget := s.deps.Governor.GetBudget()
-	okResponse(w, map[string]interface{}{
+	jsonResponse(w, map[string]interface{}{
 		"status":  "updated",
 		"ignored": budget.IgnoreAll,
 		"agents":  budget.IgnoredAgents,

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1184,21 +1184,40 @@ func (s *Server) handleModelAdvisor(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleBudgetIgnoreGet(w http.ResponseWriter, r *http.Request) {
 	budget := s.deps.Governor.GetBudget()
 	jsonResponse(w, map[string]interface{}{
-		"ignored": budget.IgnoredAgents,
+		"ignored": budget.IgnoreAll,
+		"agents":  budget.IgnoredAgents,
 	})
 }
 
 func (s *Server) handleBudgetIgnoreSet(w http.ResponseWriter, r *http.Request) {
+	// The dashboard checkbox sends {"ignored": bool} (global bypass);
+	// {"ignored": [names]} sets the per-agent exemption list.
 	var body struct {
-		Agents []string `json:"ignored"`
+		Ignored json.RawMessage `json:"ignored"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
 		return
 	}
 
-	s.deps.Governor.SetBudgetIgnored(body.Agents)
-	okResponse(w, map[string]string{"status": "updated"})
+	var ignoreAll bool
+	if err := json.Unmarshal(body.Ignored, &ignoreAll); err == nil {
+		s.deps.Governor.SetBudgetIgnoreAll(ignoreAll)
+	} else {
+		var agents []string
+		if err := json.Unmarshal(body.Ignored, &agents); err != nil {
+			jsonError(w, "ignored must be a bool or a list of agent names", http.StatusBadRequest)
+			return
+		}
+		s.deps.Governor.SetBudgetIgnored(agents)
+	}
+
+	budget := s.deps.Governor.GetBudget()
+	okResponse(w, map[string]interface{}{
+		"status":  "updated",
+		"ignored": budget.IgnoreAll,
+		"agents":  budget.IgnoredAgents,
+	})
 }
 
 // --- GitHub endpoints ---

--- a/v2/pkg/governor/governor.go
+++ b/v2/pkg/governor/governor.go
@@ -66,6 +66,10 @@ type BudgetInfo struct {
 	ByAgent       map[string]int64 `json:"by_agent"`
 	ByModel       map[string]int64 `json:"by_model"`
 	IgnoredAgents []string         `json:"ignored_agents"`
+	// IgnoreAll disables budget kick-suppression for every agent while
+	// keeping the limit, window, and alerts intact (the dashboard's
+	// global "ignore budget" toggle).
+	IgnoreAll bool `json:"ignore_all"`
 	// ResetAt is the START of the current budget window; the window ends
 	// at ResetAt + BudgetWindowDuration.
 	ResetAt time.Time `json:"reset_at"`
@@ -322,9 +326,10 @@ func (g *Governor) updateCadences() {
 }
 
 // budgetExhausted reports whether the weekly budget gate is closed.
-// WeeklyLimit == 0 means budgeting is entirely off. Caller must hold g.mu.
+// WeeklyLimit == 0 means budgeting is entirely off; IgnoreAll keeps the
+// limit and alerts but opens the kick gate. Caller must hold g.mu.
 func (g *Governor) budgetExhausted() bool {
-	return g.budget.WeeklyLimit > 0 && g.budget.CurrentSpend >= g.budget.WeeklyLimit
+	return g.budget.WeeklyLimit > 0 && !g.budget.IgnoreAll && g.budget.CurrentSpend >= g.budget.WeeklyLimit
 }
 
 func (g *Governor) agentsDueForKick() []string {
@@ -598,6 +603,7 @@ func (g *Governor) GetBudget() BudgetInfo {
 		ByAgent:        byAgent,
 		ByModel:        byModel,
 		IgnoredAgents:  ignored,
+		IgnoreAll:      g.budget.IgnoreAll,
 		ResetAt:        g.budget.ResetAt,
 		WindowBaseline: g.budget.WindowBaseline,
 	}
@@ -678,6 +684,13 @@ func (g *Governor) SetBudgetLimit(limit int64) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	g.budget.WeeklyLimit = limit
+}
+
+// SetBudgetIgnoreAll toggles the global budget-suppression bypass.
+func (g *Governor) SetBudgetIgnoreAll(ignore bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.budget.IgnoreAll = ignore
 }
 
 func (g *Governor) SetBudgetIgnored(agents []string) {

--- a/v2/pkg/snapshot/state.go
+++ b/v2/pkg/snapshot/state.go
@@ -16,6 +16,7 @@ type PersistedState struct {
 	GovernorMode     string                           `json:"governor_mode"`
 	BudgetLimit      int64                            `json:"budget_limit"`
 	BudgetIgnored    []string                         `json:"budget_ignored"`
+	BudgetIgnoreAll  bool                             `json:"budget_ignore_all,omitempty"`
 	CadenceOverrides map[string]map[string]string     `json:"cadence_overrides,omitempty"`
 	LastKicks        map[string]time.Time             `json:"last_kicks,omitempty"`
 	BudgetSpend      int64                            `json:"budget_spend,omitempty"`


### PR DESCRIPTION
The 'ignore budget' checkbox never worked: POST sent {ignored: bool}, handler decoded []string (400 every time); GET returned an array the UI truthiness-tested. Adds governor BudgetInfo.IgnoreAll (global kick-suppression bypass that keeps limit/window/alerts intact — distinct from WeeklyLimit=0 which disables budgeting entirely), dual-shape API (bool = global toggle, array = per-agent exemptions), honest GET ({ignored: bool, agents: [...]}), and snapshot persistence. UI needs no changes — the existing checkbox code is now correct against the fixed contract.