### PR TITLE
fix: branch switch updates init container images too

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1821,7 +1821,9 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 	ns := "hive-hosted-" + id
 	imageTag := body.Branch + "-latest"
 	image := "ghcr.io/kubestellar/hive:" + imageTag
-	cmd := kubectlForCluster(cluster, "set", "image", "deployment/hive", "hive="+image, "-n", ns)
+	// "*=" updates every container including init containers (copy-config,
+	// init-permissions) — pinning only "hive" left inits on the old branch tag.
+	cmd := kubectlForCluster(cluster, "set", "image", "deployment/hive", "*="+image, "-n", ns)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		s.logger.Warn("branch switch failed", "hive", id, "branch", body.Branch, "output", string(out))


### PR DESCRIPTION
Switching a hive's branch patched only the `hive` container image; the `copy-config` (and `init-permissions`) init containers stayed on the provision-time tag — observed on the console hive's v3 switch, where the v3 pod booted with a v2-latest copy-config. `kubectl set image deployment/hive '*='` covers all containers including inits.