### PR TITLE
fix: persist last-known-good latest-image SHAs across hub restarts

### DIFF
--- a/v2/pkg/hub/hub_filesystem_test.go
+++ b/v2/pkg/hub/hub_filesystem_test.go
@@ -52,10 +52,10 @@ func TestSaveSaaSUserAndLoad(t *testing.T) {
 
 	u := &SaaSUser{
 		GitHubUsername: "testuser",
-		CreatedAt:     "2024-01-01T00:00:00Z",
-		LastLogin:     "2024-06-01T00:00:00Z",
-		Hives:         map[string]string{"hive1": "owner"},
-		SaaSQuota:     3,
+		CreatedAt:      "2024-01-01T00:00:00Z",
+		LastLogin:      "2024-06-01T00:00:00Z",
+		Hives:          map[string]string{"hive1": "owner"},
+		SaaSQuota:      3,
 	}
 	if err := saveSaaSUser(u); err != nil {
 		t.Fatalf("saveSaaSUser failed: %v", err)
@@ -1236,5 +1236,86 @@ func TestHandleCreateHiveQuotaReached(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("expected 400 (quota reached), got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+// TestPersistAndLoadLatestSHAs verifies last-known-good semantics for the
+// branch SHA cache across hub restarts: persisted SHAs are restored on load,
+// untracked branches are dropped, and live values are never overwritten.
+func TestPersistAndLoadLatestSHAs(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := latestSHAsPath
+	latestSHAsPath = filepath.Join(dir, "latest-shas.json")
+	defer func() { latestSHAsPath = oldPath }()
+
+	// Snapshot and clear global cache state; restore after the test.
+	latestSHAMu.Lock()
+	savedBranches := latestSHAByBranch
+	savedMsgs := commitMsgBySHA
+	latestSHAByBranch = map[string]branchSHAInfo{
+		"v2":         {SHA: "aaa1111", Message: "v2 commit"},
+		"v3":         {SHA: "bbb2222", Message: "v3 commit"},
+		"old-branch": {SHA: "ccc3333", Message: "untracked commit"},
+	}
+	commitMsgBySHA = map[string]string{}
+	latestSHAMu.Unlock()
+	defer func() {
+		latestSHAMu.Lock()
+		latestSHAByBranch = savedBranches
+		commitMsgBySHA = savedMsgs
+		latestSHAMu.Unlock()
+	}()
+
+	persistLatestSHAs(slog.Default())
+	if _, err := os.Stat(latestSHAsPath); err != nil {
+		t.Fatalf("persistLatestSHAs did not write %s: %v", latestSHAsPath, err)
+	}
+
+	// Simulate a hub restart with a partially failed initial fetch: only v3
+	// was fetched live; v2's fetch was rate-limited so its entry is missing.
+	latestSHAMu.Lock()
+	latestSHAByBranch = map[string]branchSHAInfo{
+		"v3": {SHA: "ddd4444", Message: "newer v3 commit"},
+	}
+	latestSHAMu.Unlock()
+
+	loadPersistedSHAs(slog.Default())
+
+	if got := getLatestSHAForBranch("v2"); got != "aaa1111" {
+		t.Errorf("v2 SHA not restored from disk: got %q, want aaa1111", got)
+	}
+	if got := getLatestSHAForBranch("v3"); got != "ddd4444" {
+		t.Errorf("live v3 SHA was overwritten by persisted value: got %q, want ddd4444", got)
+	}
+	if got := getLatestSHAForBranch("old-branch"); got != "" {
+		t.Errorf("untracked branch restored from disk: got %q, want empty", got)
+	}
+	if msgs := getLatestSHAMessages(); msgs["v2"] != "v2 commit" {
+		t.Errorf("v2 commit message not restored: got %q, want 'v2 commit'", msgs["v2"])
+	}
+	if cm := getCommitMessages(); cm["aaa1111"] != "v2 commit" {
+		t.Errorf("commitMsgBySHA not backfilled on load: got %q, want 'v2 commit'", cm["aaa1111"])
+	}
+
+	// An empty cache must never clobber the good file on disk.
+	latestSHAMu.Lock()
+	latestSHAByBranch = map[string]branchSHAInfo{}
+	latestSHAMu.Unlock()
+	persistLatestSHAs(slog.Default())
+	loadPersistedSHAs(slog.Default())
+	if got := getLatestSHAForBranch("v2"); got != "aaa1111" {
+		t.Errorf("empty persist clobbered file: v2 = %q, want aaa1111", got)
+	}
+
+	// A corrupt file is ignored (no panic, no partial state).
+	if err := os.WriteFile(latestSHAsPath, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	latestSHAMu.Lock()
+	latestSHAByBranch = map[string]branchSHAInfo{}
+	latestSHAMu.Unlock()
+	loadPersistedSHAs(slog.Default())
+	if got := getLatestSHAForBranch("v2"); got != "" {
+		t.Errorf("corrupt file should restore nothing, got v2 = %q", got)
 	}
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
@@ -36,6 +37,7 @@ type SaaSUser struct {
 }
 
 var hmacKeyPath = "/data/saas/hmac.key"
+
 const hmacKeySize = 32
 
 func loadOrCreateHMACKey() ([]byte, error) {
@@ -2120,16 +2122,100 @@ func getCommitMessages() map[string]string {
 	return cp
 }
 
+// latestSHAsPath persists the last-known-good branch→SHA cache across hub
+// restarts (PVC-backed, like the rest of /data/saas). The hub restarts on
+// every auto-upgrade; without this file the cache starts empty, and if the
+// unauthenticated GitHub branches API is rate-limited for one branch at
+// startup, that branch silently disappears from "Latest images" until a
+// later poll succeeds (up to an hour under rate limiting).
+var latestSHAsPath = "/data/saas/latest-shas.json"
+
+// snapshotBranchSHAs returns a copy of the full branch→info cache.
+func snapshotBranchSHAs() map[string]branchSHAInfo {
+	latestSHAMu.RLock()
+	defer latestSHAMu.RUnlock()
+	cp := make(map[string]branchSHAInfo, len(latestSHAByBranch))
+	for k, v := range latestSHAByBranch {
+		cp[k] = v
+	}
+	return cp
+}
+
+// loadPersistedSHAs restores the last-known-good SHA cache from disk so a
+// freshly restarted hub serves the previous values while live fetches are
+// failing or rate-limited. Branches no longer in trackedBranches are dropped;
+// branches already populated by a live fetch are never overwritten.
+func loadPersistedSHAs(logger *slog.Logger) {
+	data, err := os.ReadFile(latestSHAsPath)
+	if err != nil {
+		return // first run or no PVC — nothing to restore
+	}
+	var persisted map[string]branchSHAInfo
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		logger.Warn("SHA poll: persisted SHA cache unreadable, ignoring", "path", latestSHAsPath, "error", err)
+		return
+	}
+	latestSHAMu.Lock()
+	defer latestSHAMu.Unlock()
+	for _, branch := range trackedBranches {
+		info, ok := persisted[branch]
+		if !ok || info.SHA == "" {
+			continue
+		}
+		if _, exists := latestSHAByBranch[branch]; exists {
+			continue // live fetch already populated this branch
+		}
+		latestSHAByBranch[branch] = info
+		if info.Message != "" {
+			commitMsgBySHA[info.SHA] = info.Message
+		}
+		logger.Info("SHA poll: restored last-known SHA from disk", "branch", branch, "sha", info.SHA)
+	}
+}
+
+// persistLatestSHAs writes the current SHA cache to disk (atomic tmp+rename,
+// same pattern as the other /data/saas state files).
+func persistLatestSHAs(logger *slog.Logger) {
+	snapshot := snapshotBranchSHAs()
+	if len(snapshot) == 0 {
+		return // never overwrite a good file with an empty cache
+	}
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		logger.Warn("SHA poll: persist marshal failed", "error", err)
+		return
+	}
+	os.MkdirAll(filepath.Dir(latestSHAsPath), 0o755)
+	tmpPath := latestSHAsPath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		logger.Warn("SHA poll: persist write failed", "path", latestSHAsPath, "error", err)
+		return
+	}
+	if err := os.Rename(tmpPath, latestSHAsPath); err != nil {
+		logger.Warn("SHA poll: persist rename failed", "path", latestSHAsPath, "error", err)
+	}
+}
+
 func (s *HubServer) StartLatestSHAPoller() {
+	// Serve last-known-good SHAs immediately; live fetches below refresh them.
+	loadPersistedSHAs(s.logger)
+	prevInfos := snapshotBranchSHAs()
 	fetchAllBranchSHAs(s.logger)
+	if cur := snapshotBranchSHAs(); !maps.Equal(cur, prevInfos) {
+		persistLatestSHAs(s.logger)
+	}
 	// On first poll, check if any auto-upgrade hives are behind
 	s.triggerAutoUpgrades()
 	ticker := time.NewTicker(latestSHAPollInterval)
 	defer ticker.Stop()
 	for range ticker.C {
 		oldSHAs := getLatestSHAs()
+		oldInfos := snapshotBranchSHAs()
 		fetchAllBranchSHAs(s.logger)
 		newSHAs := getLatestSHAs()
+		if !maps.Equal(snapshotBranchSHAs(), oldInfos) {
+			persistLatestSHAs(s.logger)
+		}
 		// Always check for pending auto-upgrades (retries failed/missed hives).
 		s.triggerAutoUpgrades()
 		changed := false


### PR DESCRIPTION
## Problem

The **Latest images:** list on hive.kubestellar.io (My Hives page) intermittently drops a branch — showing only `v2`, or only `v3` — and later shows both again.

## Root cause

The frontend renders `Object.keys(latest_shas)` straight from `/api/hub/version` / `/api/saas/my-hives`, which read the in-memory `latestSHAByBranch` cache in `v2/pkg/hub/saas.go`.

That cache already has keep-on-failure semantics: `fetchBranchSHA` returns early on any error and never deletes entries. The problem is that it's **process-local and starts empty**, and the hub restarts frequently — it rollout-restarts itself on every new v2 image via auto-upgrade.

After a restart, the initial `fetchAllBranchSHAs` hits the **unauthenticated** GitHub branches API. The 2-minute poller alone keeps the hub near GitHub's 60 req/hr per-IP anonymous rate limit, and restarts happen exactly when a new commit lands (i.e., when the API budget is most likely exhausted). If one branch's fetch is rate-limited (or its GHCR image verification transiently fails) at startup, that branch is simply **absent from the map** — and from the API responses — until a later poll succeeds, which under sustained rate limiting can take up to an hour. Hence: one branch vanishes, then reappears.

## Fix — last-known-good across restarts

- Persist the branch→SHA cache to `/data/saas/latest-shas.json` (PVC-backed, atomic tmp+rename, same pattern as the other `/data/saas` state files) whenever it changes.
- Restore it at poller startup **before** the first live fetch, so a cold hub immediately serves the last known values while live fetches are failing or rate-limited.
- Restored entries are filtered to `trackedBranches` — a branch is only dropped when removed from tracking.
- Live-fetched values always win over persisted ones; an empty cache never clobbers a good file on disk; a corrupt file is ignored with a Warn log.
- All fetch failure paths were already logged at Warn with branch + error; unchanged.

## Test

`TestPersistAndLoadLatestSHAs` (in `hub_filesystem_test.go`, following the existing path-override conventions) covers: persist/restore round trip, untracked-branch filtering, live-value precedence, commit-message backfill on restore, empty-cache no-clobber, and corrupt-file handling.