### PR TITLE
fix: My Hives header version cluster beside Logout

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3475,7 +3475,7 @@ const dashboardHTML = `<!DOCTYPE html>
       padding: .72rem 1rem;
       font-weight: 700;
     }
-    #hub-version { margin-left: 8px; }
+    .header-right { display: flex; align-items: center; gap: .8rem; justify-self: end; }
     .nav-user { display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; color: var(--text); }
     .nav-avatar { width: 28px; height: 28px; border-radius: 50%; }
 
@@ -3585,7 +3585,6 @@ const dashboardHTML = `<!DOCTYPE html>
       <span class="brand-mark">🐝</span>
       <span>Hive</span>
       <span onclick="window.open(&#39;https://github.com/kubestellar/hive&#39;,&#39;_blank&#39;)" title="Source Code" style="opacity:0.6;margin-left:2px;cursor:pointer;display:inline-flex"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></span>
-      <span id="hub-version"></span>
     </a>
     <nav>
       <a href="/">Hives</a>
@@ -3595,7 +3594,10 @@ const dashboardHTML = `<!DOCTYPE html>
       <a href="/api/docs" target="_blank">API</a>
       <span id="nav-user" class="nav-user"></span>
     </nav>
-    <a href="#" class="header-link" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.href='/'});return false;">Logout</a>
+    <div class="header-right">
+      <span id="hub-version"></span>
+      <a href="#" class="header-link" onclick="fetch('/api/auth/logout',{method:'POST'}).then(function(){location.href='/'});return false;">Logout</a>
+    </div>
   </header>
 
   <div class="content">


### PR DESCRIPTION
Moves the v2/SHA/check/auto cluster from the left brand area to a right-aligned header group just left of Logout — same placement as the hive.kubestellar.io landing header.