### PR TITLE
🐝 feat(contribute): add LiteLLM as a supported contribute method

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -232,11 +232,40 @@ contribute-setup backend="claude": check-version
           exit 1
         fi
         ;;
+      litellm)
+        # LiteLLM: Claude Code pointed at YOUR OWN LiteLLM proxy via
+        # ANTHROPIC_BASE_URL. No Anthropic login needed — auth is your
+        # proxy's key, exported locally (never stored by this setup).
+        if ! command -v claude &>/dev/null; then
+          echo "ERROR: LiteLLM mode runs Claude Code against your LiteLLM proxy."
+          echo "Install Claude Code first: npm i -g @anthropic-ai/claude-code"
+          exit 1
+        fi
+        if [[ -z "${HIVE_LITELLM_ENDPOINT:-}" ]]; then
+          echo "ERROR: HIVE_LITELLM_ENDPOINT not set."
+          echo "  export HIVE_LITELLM_ENDPOINT=https://your-litellm-host:4000"
+          echo "  export HIVE_LITELLM_API_KEY=sk-...   # only if your proxy requires a key"
+          exit 1
+        fi
+        if [[ -z "${HIVE_LITELLM_API_KEY:-}" ]]; then
+          echo "NOTE: HIVE_LITELLM_API_KEY not set — assuming your proxy accepts unauthenticated requests."
+        fi
+        echo "LiteLLM endpoint: ${HIVE_LITELLM_ENDPOINT}"
+        echo "  Claude Code will run with ANTHROPIC_BASE_URL=${HIVE_LITELLM_ENDPOINT}"
+        echo "  Set the model your proxy serves: export AGENT_MODEL=<model>"
+        ;;
       *)
-        echo "ERROR: Unknown backend '{{backend}}'. Supported: claude, copilot, goose, codex, pi, bob"
+        echo "ERROR: Unknown backend '{{backend}}'. Supported: claude, copilot, goose, codex, pi, bob, litellm"
         exit 1
         ;;
     esac
+
+    # Persist the LiteLLM endpoint (never the API key) for later runs
+    if [[ "{{backend}}" == "litellm" && -f "{{config_dir}}/contributor.env" ]]; then
+      grep -v '^HIVE_LITELLM_ENDPOINT=' "{{config_dir}}/contributor.env" > "{{config_dir}}/contributor.env.tmp" || true
+      echo "HIVE_LITELLM_ENDPOINT=${HIVE_LITELLM_ENDPOINT}" >> "{{config_dir}}/contributor.env.tmp"
+      mv "{{config_dir}}/contributor.env.tmp" "{{config_dir}}/contributor.env"
+    fi
 
     # Copy CLI config for Docker container (Colima can't bind-mount files)
     if [[ "{{backend}}" == "claude" ]] && [[ -f "${HOME}/.claude.json" ]]; then
@@ -335,10 +364,27 @@ contribute-hive backend="" mode="docker": check-version
         exit 1
       fi
 
+      # LiteLLM: point Claude Code at the contributor's own proxy.
+      # Endpoint comes from contributor.env; the key stays env-only.
+      LITELLM_ENV=""
+      if [[ "$BACKEND" == "litellm" ]]; then
+        if [[ -z "${HIVE_LITELLM_ENDPOINT:-}" ]]; then
+          echo "ERROR: HIVE_LITELLM_ENDPOINT not set. Run: just contribute-setup litellm"
+          exit 1
+        fi
+        LITELLM_ENV="ANTHROPIC_BASE_URL=${HIVE_LITELLM_ENDPOINT}"
+        if [[ -n "${HIVE_LITELLM_API_KEY:-}" ]]; then
+          LITELLM_ENV="${LITELLM_ENV} ANTHROPIC_API_KEY=${HIVE_LITELLM_API_KEY}"
+        fi
+        if [[ -n "${AGENT_MODEL:-}" ]]; then
+          PERM_FLAG="${PERM_FLAG} --model ${AGENT_MODEL}"
+        fi
+      fi
+
       # Create tmux session with the CLI
       tmux kill-session -t "$TMUX_SESSION" 2>/dev/null || true
       tmux new-session -d -s "$TMUX_SESSION" -x 200 -y 50
-      tmux send-keys -t "$TMUX_SESSION" "$CMD $PERM_FLAG" Enter
+      tmux send-keys -t "$TMUX_SESSION" "${LITELLM_ENV:+$LITELLM_ENV }$CMD $PERM_FLAG" Enter
 
       # Start the relay
       export HIVE_AGENT_SESSION="$TMUX_SESSION"
@@ -406,6 +452,9 @@ contribute-hive backend="" mode="docker": check-version
         ${GOOSE_PROVIDER:+-e GOOSE_PROVIDER="${GOOSE_PROVIDER}"} \
         ${GOOSE_MODEL:+-e GOOSE_MODEL="${GOOSE_MODEL}"} \
         ${OPENAI_API_KEY:+-e OPENAI_API_KEY="${OPENAI_API_KEY}"} \
+        ${HIVE_LITELLM_ENDPOINT:+-e HIVE_LITELLM_ENDPOINT="${HIVE_LITELLM_ENDPOINT}"} \
+        ${HIVE_LITELLM_API_KEY:+-e HIVE_LITELLM_API_KEY="${HIVE_LITELLM_API_KEY}"} \
+        ${AGENT_MODEL:+-e AGENT_MODEL="${AGENT_MODEL}"} \
         {{hive_image}} > /dev/null
 
       echo "Container: ${CONTAINER_NAME}"

--- a/bin/contributor-agent.sh
+++ b/bin/contributor-agent.sh
@@ -46,6 +46,22 @@ elif [[ -f /usr/local/etc/hive/backends.conf ]]; then
   source /usr/local/etc/hive/backends.conf
 fi
 
+# LiteLLM backend: Claude Code pointed at the contributor's own LiteLLM proxy.
+# The endpoint comes from HIVE_LITELLM_ENDPOINT (persisted in contributor.env);
+# the API key is env-only (HIVE_LITELLM_API_KEY) and is never written to disk
+# by setup. Exported here so the tmux session and CLI inherit them.
+if [[ "$AGENT_BACKEND" == "litellm" ]]; then
+  if [[ -z "${HIVE_LITELLM_ENDPOINT:-}" ]]; then
+    echo "ERROR: AGENT_BACKEND=litellm but HIVE_LITELLM_ENDPOINT is not set."
+    echo "Run: HIVE_LITELLM_ENDPOINT=https://your-litellm-host:4000 just contribute-setup litellm"
+    exit 1
+  fi
+  export ANTHROPIC_BASE_URL="$HIVE_LITELLM_ENDPOINT"
+  if [[ -n "${HIVE_LITELLM_API_KEY:-}" ]]; then
+    export ANTHROPIC_API_KEY="$HIVE_LITELLM_API_KEY"
+  fi
+fi
+
 # Detect CLI authentication
 detect_cli() {
   local backend="$1"
@@ -59,6 +75,10 @@ detect_cli() {
 
   case "$backend" in
     claude)
+      if claude --version &>/dev/null; then echo "OK"; else echo "NOT_AUTHED"; fi
+      ;;
+    litellm)
+      # Auth is the LiteLLM endpoint/key, not a claude login — binary presence is enough
       if claude --version &>/dev/null; then echo "OK"; else echo "NOT_AUTHED"; fi
       ;;
     copilot)
@@ -169,7 +189,7 @@ KNOWLEDGE_REFRESH_SECS=600
 
 # Make agent.md visible to each CLI backend
 case "$AGENT_BACKEND" in
-  claude)
+  claude|litellm)
     ln -sf "$AGENT_MD" "${HOME}/CLAUDE.md"
     ;;
   copilot)
@@ -231,6 +251,38 @@ if [[ "$AGENT_BACKEND" == "claude" ]] && [[ -f "${CONFIG_DIR}/claude-config.json
   chmod 600 "${HOME}/.claude.json"
 fi
 
+# LiteLLM: pre-seed Claude Code config so first-run onboarding and the
+# custom-API-key approval prompt don't block the tmux session. Mirrors the
+# hub's ensureClaudeSettings pattern (v2/pkg/agent/manager.go). The key is
+# stored both in full and as its last 20 chars — customApiKeyResponses
+# matching differs across Claude Code versions.
+if [[ "$AGENT_BACKEND" == "litellm" ]]; then
+  python3 - <<'PYEOF' 2>/dev/null || true
+import json, os
+p = os.path.join(os.path.expanduser('~'), '.claude.json')
+d = {}
+if os.path.exists(p):
+    try:
+        with open(p) as f:
+            d = json.load(f)
+    except Exception:
+        d = {}
+d['hasCompletedOnboarding'] = True
+d['autoUpdates'] = False
+d['installMethod'] = 'npm'
+key = os.environ.get('ANTHROPIC_API_KEY', '')
+if key:
+    resp = d.setdefault('customApiKeyResponses', {'approved': [], 'rejected': []})
+    approved = resp.setdefault('approved', [])
+    for k in (key, key[-20:]):
+        if k and k not in approved:
+            approved.append(k)
+with open(p, 'w') as f:
+    json.dump(d, f, indent=2)
+PYEOF
+  chmod 600 "${HOME}/.claude.json" 2>/dev/null || true
+fi
+
 tmux send-keys -t "$TMUX_SESSION" "$CMD $PERM_FLAG $MODEL_FLAG" Enter
 
 # Auto-dismiss startup prompts (workspace trust, theme picker, etc.)
@@ -248,6 +300,9 @@ AUTO_DISMISS_INTERVAL=3
       tmux send-keys -t "$TMUX_SESSION" Enter 2>/dev/null || true
     elif echo "$PANE" | grep -q "Choose a provider\|Select.*provider\|Which provider"; then
       tmux send-keys -t "$TMUX_SESSION" Enter 2>/dev/null || true
+    elif echo "$PANE" | grep -qi "custom API key"; then
+      # Claude Code asks whether to use ANTHROPIC_API_KEY (litellm backend)
+      tmux send-keys -t "$TMUX_SESSION" "1" Enter 2>/dev/null || true
     elif echo "$PANE" | grep -q "bypass permissions\|autopilot\|goose>\|G >\|❯\|/ commands\|> *$"; then
       break
     fi

--- a/config/backends.conf
+++ b/config/backends.conf
@@ -20,7 +20,7 @@
 
 # ── Supported backends ──────────────────────────────────────────────────
 # BACKEND_NAME  BINARY   PERM_FLAG                    MODEL_FLAG
-KNOWN_BACKENDS="claude copilot goose codex agy bob pi aider"
+KNOWN_BACKENDS="claude copilot goose codex agy bob pi aider litellm"
 
 # ── Backend → binary mapping ────────────────────────────────────────────
 backend_binary() {
@@ -34,6 +34,8 @@ backend_binary() {
     goose)   echo "goose" ;;
     pi)      echo "pi" ;;
     aider)   echo "aider" ;;
+    # litellm runs Claude Code pointed at a LiteLLM proxy via ANTHROPIC_BASE_URL
+    litellm) echo "claude" ;;
     *)       echo "$1" ;;
   esac
 }
@@ -50,6 +52,8 @@ backend_perm_flag() {
     goose)   echo "" ;;
     pi)      echo "" ;;
     aider)   echo "--yes" ;;
+    # Same flags as claude — litellm launches the claude binary
+    litellm) echo "--dangerously-skip-permissions --permission-mode bypassPermissions" ;;
     *)       echo "" ;;
   esac
 }

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -358,6 +358,7 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 <option value="copilot" data-install="" data-host-install="" data-model-flag="--model" data-default-model="">GitHub Copilot</option>
 <option value="pi" data-install="" data-host-install="curl -fsSL https://pi.dev/install.sh | sh" data-model-flag="--model" data-default-model="">Pi</option>
 <option value="goose" data-install="" data-host-install="# Install Goose: https://github.com/block/goose/releases\n# Install Ollama: https://ollama.com/download\nollama pull llama3.2:3b\nexport GOOSE_PROVIDER=ollama GOOSE_MODEL=llama3.2:3b" data-model-flag="" data-default-model="">Goose</option>
+<option value="litellm" data-install="" data-host-install="npm i -g @anthropic-ai/claude-code" data-model-flag="--model" data-default-model="" data-env="# Your own LiteLLM proxy — exported locally, never sent to the hive\nexport HIVE_LITELLM_ENDPOINT=https://your-litellm-host:4000\nexport HIVE_LITELLM_API_KEY=sk-your-litellm-key  # only if your proxy needs one">LiteLLM (Claude Code + your proxy)</option>
 <option value="bob" data-install="" data-host-install="npm i -g bobshell" data-model-flag="" data-default-model="">Bob</option>
 <option value="other" data-install="" data-host-install="# Install your CLI tool" data-model-flag="" data-default-model="">Other (host only)</option>
 </select>
@@ -402,17 +403,20 @@ if(mode==='containerized'&&cli==='other'){modeSel.value='host';mode='host';}
 modelRow.style.display=(modelFlag||cli==='goose')?'flex':'none';
 var modelLine='';
 if(model){
-if(cli==='goose'){modelLine='\nexport GOOSE_MODEL='+model;}
-else if(modelFlag){modelLine='\nexport AGENT_MODEL='+model;}
+if(cli==='goose'){modelLine='export GOOSE_MODEL='+model+'\n';}
+else if(modelFlag){modelLine='export AGENT_MODEL='+model+'\n';}
 }
+var envLines=(opt.getAttribute('data-env')||'').replace(/\\n/g,'\n');
+if(envLines)envLines+='\n';
+var preLines=envLines+modelLine;
 var tpl,install;
 if(mode==='host'){
 tpl=hostTpl;
 install=opt.getAttribute('data-host-install');
 if(!install)install='# '+cli+' uses your existing gh auth';
-cmds.textContent=tpl.replace('INSTALL',install.replace(/\\n/g,'\n')).replace(/CLI/g,cli)+modelLine;
+cmds.textContent=tpl.replace('INSTALL',install.replace(/\\n/g,'\n')).replace(/CLI/g,cli).replace('just contribute-setup',preLines+'just contribute-setup');
 }else{
-cmds.textContent=containerTpl.replace(/CLI/g,cli)+modelLine;
+cmds.textContent=containerTpl.replace(/CLI/g,cli).replace('just contribute-setup',preLines+'just contribute-setup');
 }
 }
 sel.addEventListener('change',function(){modelInput.value='';update();});
@@ -441,7 +445,7 @@ setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},200
 </div>
 <div class="how">
 <h3>What you bring vs. what the hive provides</h3>
-<p><strong>You bring:</strong> Your GitHub account + CLI API tokens. Issues and PRs are created under YOUR name.</p>
+<p><strong>You bring:</strong> Your GitHub account + CLI API tokens. With LiteLLM you bring your own proxy instead — Claude Code on your machine talks directly to your endpoint, and the hive never sees your endpoint or key. Issues and PRs are created under YOUR name.</p>
 <p><strong>The hive provides:</strong> Work queue, task assignment, and coordination. Your credentials never leave your machine.</p>
 </div>
 <div class="how">


### PR DESCRIPTION
## What

Adds **LiteLLM** as a selectable method in the `/contribute` flow, so community members can lend their own LiteLLM proxy (OpenAI-compatible gateway) instead of a CLI subscription/login.

## How it works

Contribute agents run on the **contributor's machine** and talk to their model provider directly (same as goose→ollama or codex→OpenAI today) — the hub-side inference translator (`governor.litellm`, port 18444) is not reachable from contributor machines, so this mirrors the existing contributor-CLI pattern instead:

- `AGENT_BACKEND=litellm` launches **Claude Code** with `ANTHROPIC_BASE_URL` pointed at the contributor's own LiteLLM endpoint
- Endpoint comes from `HIVE_LITELLM_ENDPOINT` (persisted to `~/.config/hive/contributor.env`, non-secret)
- API key comes from `HIVE_LITELLM_API_KEY` — **env-only, never persisted by setup, never sent to the hive** (env var names match the hub-side `config.DefaultLiteLLMAPIKeyEnv`/`LiteLLMEndpointEnv` conventions)

## Changes

- **`config/backends.conf`**: `litellm` → `claude` binary + claude permission flags; added to `KNOWN_BACKENDS`
- **`Justfile`**: `contribute-setup litellm` validates the claude binary + `HIVE_LITELLM_ENDPOINT` and persists the endpoint; `contribute-hive` passes `HIVE_LITELLM_*` and `AGENT_MODEL` into the Docker container, and local mode prefixes the CLI launch with `ANTHROPIC_BASE_URL`/`ANTHROPIC_API_KEY` + `--model`
- **`bin/contributor-agent.sh`**: exports `ANTHROPIC_*` for litellm, pre-seeds `~/.claude.json` (onboarding + custom-API-key approval, mirroring the hub's `ensureClaudeSettings`), auto-dismisses the custom-API-key prompt
- **`v2/pkg/dashboard/api_contribute.go`**: LiteLLM option in the CLI picker with copy-paste env exports (placeholders only) via a new `data-env` attribute; env/model export lines now render *before* the `just` commands so the block pastes top-to-bottom; page copy documents the direct-to-proxy model honestly

## Limitations (documented in page copy)

- LiteLLM contribute agents talk **directly** to the contributor's proxy — no hive-side MITM/mode enforcement, identical to how goose/codex contribute agents reach their providers today
- Runs Claude Code in normal mode (not `--bare`); the hub's `--bare` translator mode remains hub-only
- `cli_backend` on the contribute WebSocket remains free-form (no server-side allowlist existed for any CLI); model gating via `ContributeAllowModels` still applies

## Testing

- `go build` + `go test ./pkg/dashboard/` pass
- `just --summary` parses; `bash -n` on touched scripts
- Inline page JS exercised under Node with a DOM shim for litellm/claude/goose × containerized/host — templates render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)