### PR TITLE
fix: user model switch succeeds on pinned agents

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -3145,8 +3145,12 @@ func (m *Manager) SetModelOverride(name, model string) error {
 		return fmt.Errorf("agent %s not found", name)
 	}
 
+	// A pin blocks the governor's auto-selection, never a user's explicit
+	// switch: retarget the pin to the new model so the pin state is
+	// unchanged (still pinned) while the change takes effect.
 	if agent.PinnedModel != "" {
-		return fmt.Errorf("agent %s model is pinned to %s", name, agent.PinnedModel)
+		agent.PinnedModel = model
+		m.logger.Info("agent model pin retargeted by user switch", "name", name, "model", model)
 	}
 
 	agent.ModelOverride = model

--- a/v2/pkg/agent/manager_extra_test.go
+++ b/v2/pkg/agent/manager_extra_test.go
@@ -229,10 +229,18 @@ func TestSetModelOverride_Pinned(t *testing.T) {
 		"scanner": {Backend: "claude", Model: "sonnet"},
 	}, discardLogger(), ProjectContext{})
 
+	// A pin blocks governor auto-selection, not a user's explicit switch:
+	// the switch succeeds and the pin retargets to the new model.
 	m.PinModel("scanner", "opus")
-	err := m.SetModelOverride("scanner", "haiku")
-	if err == nil {
-		t.Error("expected error when model is pinned")
+	if err := m.SetModelOverride("scanner", "haiku"); err != nil {
+		t.Errorf("user switch on pinned model should succeed, got %v", err)
+	}
+	st := m.AllStatuses()["scanner"]
+	if st.ModelOverride != "haiku" {
+		t.Errorf("ModelOverride = %q, want haiku", st.ModelOverride)
+	}
+	if st.PinnedModel != "haiku" {
+		t.Errorf("PinnedModel = %q, want haiku (pin retargeted, still pinned)", st.PinnedModel)
 	}
 }
 


### PR DESCRIPTION
Switching a pinned agent's model from the dashboard errored ('model is pinned to X'). Pinning blocks the governor's auto-selection, not the user: the switch now succeeds and the pin retargets to the newly chosen model — pin state stays exactly as it was (pinned before → pinned to the new value; unpinned stays unpinned). Backend/CLI switching was never pin-blocked (PinnedCLI is a version pin). Test updated.