### PR TITLE
🐛 fix(hub): hosted hives provisioned since #1604 default to private, vanishing from /api/registry

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1564,6 +1564,10 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 		Status:      "provisioning",
 		CreatedAt:   time.Now().UTC().Format(time.RFC3339),
 		Subdomain:   subdomain,
+		// Default to public when the request omits is_public — matches
+		// the pre-#1604 template that hardcoded is_public: true. Owners
+		// can toggle visibility later from My Hives.
+		IsPublic: req.IsPublic == nil || *req.IsPublic,
 	}
 
 	if err := saveSaaSHive(h); err != nil {
@@ -5063,7 +5067,7 @@ const dashboardHTML = `<!DOCTYPE html>
       if (method === 'later') { method = 'app'; appId = '3568013'; installId = ''; appKey = ''; }
 
       try {
-        var body = {org: org, repos: repos, primary_repo: primary || repos.split(',')[0].trim(), project_name: name, acmm_level: level, cluster_id: clusterId, auth_method: method};
+        var body = {org: org, repos: repos, primary_repo: primary || repos.split(',')[0].trim(), project_name: name, acmm_level: level, cluster_id: clusterId, auth_method: method, is_public: document.getElementById('f-public').checked};
         if (method === 'pat') body.github_token = token;
         else { body.app_id = appId.trim(); body.installation_id = installId.trim(); body.app_private_key = appKey.trim(); }
 
@@ -5251,6 +5255,9 @@ const dashboardHTML = `<!DOCTYPE html>
             <option value="">Loading clusters...</option>
           </select>
         </div>
+      </div>
+      <div style="margin-bottom:12px">
+        <label style="display:flex;align-items:center;gap:8px;cursor:pointer;font-size:0.8rem;color:var(--muted)"><input type="checkbox" id="f-public" checked> Publicly visible in the hive registry <span style="font-size:0.7rem">(owners can toggle later from My Hives)</span></label>
       </div>
       <div style="margin-bottom:12px">
         <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">Authentication Method</label>

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -246,7 +246,12 @@ type CreateHiveRequest struct {
 	AppID          string `json:"app_id"`
 	InstallationID string `json:"installation_id"`
 	AppPrivateKey  string `json:"app_private_key"`
-	IsPublic       bool   `json:"is_public"`
+	// IsPublic controls registry visibility. A pointer so that "field
+	// absent" (the admin create modal and older API callers never sent
+	// it) defaults to public — the behavior before PR #1604 hardcoded
+	// is_public: true in the provisioning template. Send false explicitly
+	// to provision a private hive.
+	IsPublic *bool `json:"is_public"`
 }
 
 func generateHiveID(org, repo string) string {
@@ -472,7 +477,7 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 		"InitContainerGID":  initContainerGID,
 		"InferenceEndpoint": cluster.InferenceEndpoint,
 		"HasInference":      cluster.InferenceEndpoint != "",
-		"IsPublic":          req.IsPublic,
+		"IsPublic":          h.IsPublic,
 		"HiveType":          "hosted",
 		"HasGHE":            cluster.GitHubBaseURL != "",
 		"GitHubBaseURL":     cluster.GitHubBaseURL,
@@ -673,11 +678,14 @@ func (s *HubServer) migrateHive(h *SaaSHive, fromCluster, toCluster *ClusterConf
 		}
 	}
 
-	// Determine visibility from the source (is_public).
+	// Determine visibility from the source (is_public). The registry may
+	// know the hive is public even when the SaaS record predates the
+	// IsPublic field (pre-#1604 provisions), so only ever upgrade to
+	// public here — never downgrade a record the owner toggled public.
 	s.mu.RLock()
 	for _, re := range s.registry.Hives {
 		if re.ID == h.ID {
-			req.IsPublic = re.IsPublic
+			h.IsPublic = h.IsPublic || re.IsPublic
 			break
 		}
 	}


### PR DESCRIPTION
## Root cause

PR #1604 (multi-cluster provisioning template variants) replaced the hardcoded `is_public: true` in the provisioning ConfigMap template with `is_public: {{.IsPublic}}`, sourced from `CreateHiveRequest.IsPublic` — but:

1. The admin **+ Add Hosted Hive** modal never sends `is_public`, so the Go zero value `false` wins for every provision.
2. `handleCreateHive` never copied `req.IsPublic` onto the `SaaSHive` record either, so the SaaS record is also private.

Every hosted hive provisioned after Jun 17 heartbeats fine and lands in the hub's internal registry, but with `isPublic: false` — and `handleRegistry` filters `!IsPublic` entries out of `GET /api/registry`, so the hive silently never appears in the public registry/leaderboard views.

**Evidence** (hive-oke cluster, read-only):
- `hosted-ibm-alchemy-logg-ptoo` (provisioned Jun 23): spoke logs show `hub heartbeat enabled` + `starting heartbeats`; hub logs show `audit: hub heartbeat received hive_id=hosted-ibm-alchemy-logg-ptoo` every 5 min; `/data/hub-registry.json` has the entry with a current `lastHeartbeat` but `isPublic: false`; its ConfigMap hive.yaml has `is_public: false`; its SaaS `meta.json` has no `is_public` field.
- `hosted-open-source-osscar-appli-rc57` (Jun 29): same state.
- `hosted-daviddiaz0317-visual-hive--1jos` (Jul 7): provisioned private too, but the owner used the My Hives visibility toggle, so its SaaS record says `is_public: true` and the hub-side preservation in the heartbeat handler keeps it public.
- All pre-#1604 hives have `is_public: true` baked into their ConfigMaps by the old template — that's why only newer hives are affected.

## Fix

- `CreateHiveRequest.IsPublic` becomes `*bool`: field absent ⇒ default **public** (restores pre-#1604 behavior); explicit `false` provisions a private hive.
- `handleCreateHive` persists the resolved visibility on the `SaaSHive` record so SaaS/registry/toggle state agree from creation.
- `provisionHive` templates `is_public` from the `SaaSHive` record; the migration path only ever *upgrades* visibility from the registry entry (never downgrades an owner-toggled public hive whose old meta.json lacks the field).
- The Add Hosted Hive modal gains a **Publicly visible in the hive registry** checkbox (default checked) and sends `is_public` explicitly.

## Remediation for existing hives

No data migration needed — toggle visibility from My Hives (or `PUT /api/saas/hives/{id}/visibility` with `{"is_public": true}`) for `hosted-ibm-alchemy-logg-ptoo` and `hosted-open-source-osscar-appli-rc57`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)