### PR TITLE
fix: leaderboard page and API are public on the spoke

### DIFF
--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -524,6 +524,10 @@ func isPublicPath(path string) bool {
 		return true
 	case strings.HasPrefix(path, "/api/contribute"):
 		return true
+	case path == "/leaderboard" || strings.HasPrefix(path, "/leaderboard/"):
+		return true
+	case strings.HasPrefix(path, "/api/leaderboard"):
+		return true
 	case strings.HasPrefix(path, "/api/gh-user-auth/"):
 		return true
 	default:


### PR DESCRIPTION
The 🏆 Leaderboard link from the Contributors section opened a login page. The hub's auth-check publicPaths already exempt /leaderboard, but the spoke's own isPublicPath never included it — the request cleared the ingress then got the spoke's login screen. Adds /leaderboard and /api/leaderboard to the spoke's public paths, matching the hub and the /contribute precedent.