### PR TITLE
docs: add copy-config init container gotcha to cross-cluster migration guide

### DIFF
--- a/v2/docs/cross-cluster-migration.md
+++ b/v2/docs/cross-cluster-migration.md
@@ -109,6 +109,35 @@ hub:
 > `hub.dashboard_url` is unset on the spoke, hand-editing the hub registry
 > gets silently overwritten within ~5 minutes by the next heartbeat.
 
+> **Gotcha — old `copy-config` init containers invert config precedence.**
+> Deployments provisioned from older templates ship a `copy-config` init
+> container that prefers the PVC backup over the ConfigMap:
+>
+> ```sh
+> if [ -f /data/hive.yaml.bak ]; then cp /data/hive.yaml.bak /etc/hive/hive.yaml; ...
+> ```
+>
+> If the migrated `/data` volume carries a stale `hive.yaml.bak`, **every
+> ConfigMap edit is silently overridden on restart**. Symptom: keys present
+> in the ConfigMap but empty (or missing) in the pod's
+> `/etc/hive/hive.yaml`. Fix during migration:
+>
+> 1. Move the stale backup aside:
+>
+>    ```sh
+>    mv /data/hive.yaml.bak /data/hive.yaml.bak.stale-<ts>
+>    ```
+>
+> 2. Patch the init container to the current template's command, where the
+>    ConfigMap always wins:
+>
+>    ```sh
+>    cp /etc/hive-seed/hive.yaml /etc/hive/hive.yaml && echo configmap-copied; if [ -f /data/hive.yaml.bak ]; then echo backup-exists-for-recovery; fi
+>    ```
+>
+> Checking the `copy-config` command should be a **standard migration step**
+> whenever the source hive was provisioned before the template fix.
+
 Then restart the spoke to pick up the ConfigMap:
 
 ```sh


### PR DESCRIPTION
## Summary

Follow-up to #1805, adding one more gotcha discovered live during the kellyaa migration:

**Old `copy-config` init containers invert config precedence.** Deployments provisioned from older templates prefer the PVC backup: `if [ -f /data/hive.yaml.bak ]; then cp /data/hive.yaml.bak /etc/hive/hive.yaml; ...`. If the migrated `/data` volume carries a stale `hive.yaml.bak`, every ConfigMap edit is silently overridden on restart (symptom: keys present in the ConfigMap but empty in the pod's `/etc/hive/hive.yaml`).

Documented fix:
1. Move the stale backup aside (`mv /data/hive.yaml.bak /data/hive.yaml.bak.stale-<ts>`)
2. Patch the init container to the current template's command where the ConfigMap always wins: `cp /etc/hive-seed/hive.yaml /etc/hive/hive.yaml && echo configmap-copied; if [ -f /data/hive.yaml.bak ]; then echo backup-exists-for-recovery; fi`

Also recommends checking the `copy-config` command as a standard migration step whenever the source hive was provisioned before the template fix.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)