### PR TITLE
Promote v3 → v2: complete spoke dashboard restyle + UX fixes

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -60,6 +60,7 @@ func main() {
 	configPath := flag.String("config", defaultConfig, "path to hive.yaml config file")
 	flag.Parse()
 	dashboard.SetGitVersion(gitHash, gitShort)
+	dashboard.SetGitBranch(gitBranch)
 
 	logger := slog.New(logscrub.NewHandler(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})))
 	slog.SetDefault(logger)

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -212,11 +212,34 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 var (
 	versionHash  = "unknown"
 	versionShort = "unknown"
+	// versionBranch is the branch this binary was built from (ldflags via
+	// cmd/hive). The self-version check compares against the tip of THIS
+	// branch — a spoke running v3 must not be told it is "behind" v2.
+	versionBranch = "unknown"
 )
+
+// defaultUpstreamBranch is the fallback branch for the self-version check
+// when the build did not inject a branch (e.g. local `go run`).
+const defaultUpstreamBranch = "v2"
 
 func SetGitVersion(hash, short string) {
 	versionHash = hash
 	versionShort = short
+}
+
+// SetGitBranch records the branch the running binary was built from so the
+// version check and Upgrade affordance compare against the right upstream.
+func SetGitBranch(branch string) {
+	versionBranch = branch
+}
+
+// upstreamBranch returns the branch to compare against for the self-version
+// check: the build's own branch when known, else defaultUpstreamBranch.
+func upstreamBranch() string {
+	if versionBranch != "" && versionBranch != "unknown" {
+		return versionBranch
+	}
+	return defaultUpstreamBranch
 }
 
 func jsonResponse(w http.ResponseWriter, data interface{}) {
@@ -371,6 +394,7 @@ func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 		"go":      "1.25",
 		"hash":    versionHash,
 		"short":   versionShort,
+		"branch":  upstreamBranch(),
 	}
 
 	s.versionMu.RLock()
@@ -420,7 +444,7 @@ func (s *Server) fetchLatestRemoteHash() (string, error) {
 	if ctx == nil {
 		return "", fmt.Errorf("no context")
 	}
-	return s.deps.GHClient.LatestCommitHash(ctx, "kubestellar", "hive", "v2")
+	return s.deps.GHClient.LatestCommitHash(ctx, "kubestellar", "hive", upstreamBranch())
 }
 
 // fetchCommitMessage returns the first line of the commit message for a given SHA.

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -229,11 +229,7 @@
     }
     .oc-topbar-center .oc-tb-link:hover { background: var(--bg); color: var(--text); border-color: var(--border); }
     .oc-topbar-right { display: flex; align-items: center; gap: 14px; }
-    .oc-health-badge {
-      font-size: 0.78rem; font-weight: 600; color: var(--green);
-      background: var(--green-bg); border: 1px solid var(--green-border);
-      padding: 4px 12px; border-radius: 20px;
-    }
+    .oc-health-badge { --pill-c: var(--green); font-weight: 600; } /* pill recipe at end of style block */
     .oc-topbar-ts { font-size: 0.75rem; color: var(--muted); }
     .oc-topbar .git-version { color: var(--muted); }
 
@@ -588,11 +584,12 @@
     .agent-state.paused { color: var(--red); }
     .agent-state.on-demand { color: var(--indigo); }
     .agent-state.off { color: color-mix(in srgb, var(--muted) 60%, var(--bg)); }
-    .status-badge { display: inline-block; font-size: 0.65rem; font-weight: 700; padding: 2px 6px; border-radius: 4px; margin-left: 6px; text-transform: uppercase; letter-spacing: 0.5px; }
-    .status-badge.blocked { background: var(--red-bg); color: var(--red); border: 1px solid var(--red-border); }
-    .status-badge.needs-context { background: rgba(210,153,34,0.2); color: var(--yellow); border: 1px solid rgba(210,153,34,0.4); }
-    .status-badge.done-concerns { background: rgba(227,139,44,0.2); color: #e38b2c; border: 1px solid rgba(227,139,44,0.4); }
-    .status-badge.done { background: var(--green-bg); color: var(--green); border: 1px solid var(--green-border); }
+    /* .status-badge — pill recipe; variants pick the color via --pill-c */
+    .status-badge { font-weight: 700; margin-left: 6px; text-transform: uppercase; letter-spacing: 0.5px; }
+    .status-badge.blocked { --pill-c: var(--red); }
+    .status-badge.needs-context { --pill-c: var(--yellow); }
+    .status-badge.done-concerns { --pill-c: #e38b2c; } /* distinct orange — no token yet */
+    .status-badge.done { --pill-c: var(--green); }
     .agent-card.status-blocked { border-color: var(--red) !important; }
     .agent-card.status-needs-context { border-color: var(--yellow) !important; }
     @keyframes pulse-amber { 0%,100% { border-color: rgba(210,153,34,0.3); } 50% { border-color: rgba(210,153,34,0.8); } }
@@ -623,9 +620,9 @@
     .value.claude { color: var(--purple); }
     .value.pi { color: var(--green); }
     .doing { font-family: var(--font-mono); font-size: 0.65rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: pre-wrap; line-height: 1.3; min-height: 5.6em; max-height: 30em; overflow-y: auto; width: 100%; }
-    .summary-age { display: inline-block; font-size: 0.6rem; font-style: normal; border-radius: 3px; padding: 1px 5px; margin-right: 5px; vertical-align: middle; white-space: nowrap; }
-    .summary-age.age-recent { background: rgba(210,153,34,0.15); color: var(--yellow); border: 1px solid rgba(210,153,34,0.3); }
-    .summary-age.age-stale  { background: var(--red-bg);  color: var(--red); border: 1px solid var(--red-border); }
+    .summary-age { font-style: normal; margin-right: 5px; vertical-align: middle; white-space: nowrap; } /* pill recipe */
+    .summary-age.age-recent { --pill-c: var(--yellow); }
+    .summary-age.age-stale  { --pill-c: var(--red); }
     /* Agent metric gauges — removed, replaced by health panel */
     .agent-actions { margin-top: 10px; display: flex; gap: 6px; flex-wrap: wrap; }
     .kick-prompt {
@@ -642,12 +639,12 @@
     .agent-card.on-demand .agent-state { color: var(--indigo); }
     .agent-card.off { border-color: color-mix(in srgb, var(--muted) 60%, var(--bg)); opacity: 0.6; }
     .agent-card.off .agent-state { color: color-mix(in srgb, var(--muted) 60%, var(--bg)); }
-    .pause-badge { display: inline-block; font-size: 0.6rem; background: var(--red-bg); color: var(--red); border: 1px solid var(--red-border); border-radius: 3px; padding: 1px 5px; margin-left: 4px; vertical-align: middle; }
+    .pause-badge { --pill-c: var(--red); margin-left: 4px; vertical-align: middle; } /* pill recipe */
     .pause-info { cursor: help; font-size: 0.7rem; margin-left: 4px; opacity: 0.8; position: relative; display: inline-block; }
     .pause-info:hover .pause-tooltip { display: block; }
     .pause-tooltip { display: none; position: absolute; bottom: 120%; left: 50%; transform: translateX(-50%); background: var(--panel-strong); color: var(--text); border: 1px solid var(--line); border-radius: 6px; padding: 6px 10px; font-size: 0.7rem; white-space: nowrap; z-index: 100; box-shadow: 0 2px 8px rgba(0,0,0,0.4); }
-    .off-badge { display: inline-block; font-size: 0.6rem; background: rgba(72,79,88,0.25); color: var(--muted); border: 1px solid rgba(72,79,88,0.4); border-radius: 3px; padding: 1px 5px; margin-left: 4px; vertical-align: middle; }
-    .on-demand-badge { display: inline-block; font-size: 0.6rem; background: rgba(99,102,241,0.15); color: var(--indigo); border: 1px solid rgba(99,102,241,0.3); border-radius: 3px; padding: 1px 5px; margin-left: 4px; vertical-align: middle; }
+    .off-badge { margin-left: 4px; vertical-align: middle; } /* pill recipe (default muted) */
+    .on-demand-badge { --pill-c: var(--indigo); margin-left: 4px; vertical-align: middle; } /* pill recipe */
 
     /* Health status panel */
     .health { margin-bottom: 24px; }
@@ -685,7 +682,6 @@
     }
     @media (max-width: 480px) {
       .governor { padding: 10px; }
-      .pause-badge { font-size: 0.55rem; padding: 0px 3px; margin-left: 2px; }
     }
     .governor.dead { border-color: var(--red); }
     .governor.starting { border-color: var(--yellow); }
@@ -715,28 +711,14 @@
     .repo-stat a:hover { text-decoration: underline !important; }
     .repo-stat a:hover .label { color: var(--fg); }
     .repo-issues { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 8px; padding-top: 6px; border-top: 1px solid var(--border); }
-    .repo-issue-pill {
-      display: inline-flex; align-items: center; gap: 3px;
-      font-size: 0.65rem; padding: 2px 6px; border-radius: 4px;
-      background: rgba(88,166,255,0.12); color: var(--blue);
-      border: 1px solid rgba(88,166,255,0.25);
-      text-decoration: none; max-width: 100%;
-      transition: background 0.15s;
-    }
-    .repo-issue-pill:hover { background: rgba(88,166,255,0.25); text-decoration: none; }
+    /* .repo-issue-pill / .repo-pr-pill — pill recipe; link hovers deepen the tint */
+    .repo-issue-pill { --pill-c: var(--blue); text-decoration: none; max-width: 100%; transition: background 0.15s; }
+    .repo-issue-pill:hover { background: color-mix(in srgb, var(--pill-c) 24%, transparent); text-decoration: none; }
     .repo-issue-pill .pill-num { font-weight: 700; white-space: nowrap; }
     .repo-issue-pill .pill-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .repo-pr-pill {
-      display: inline-flex; align-items: center; gap: 3px;
-      font-size: 0.65rem; padding: 2px 6px; border-radius: 4px;
-      background: rgba(188,140,255,0.12); color: var(--purple);
-      border: 1px solid rgba(188,140,255,0.25);
-      text-decoration: none; max-width: 100%;
-      transition: background 0.15s;
-    }
-    .repo-pr-pill:hover { background: rgba(188,140,255,0.25); text-decoration: none; }
-    .repo-pr-pill.mergeable { border-color: rgba(63,185,80,0.6); background: rgba(63,185,80,0.1); color: var(--green); }
-    .repo-pr-pill.mergeable:hover { background: rgba(63,185,80,0.22); }
+    .repo-pr-pill { --pill-c: var(--purple); text-decoration: none; max-width: 100%; transition: background 0.15s; }
+    .repo-pr-pill:hover { background: color-mix(in srgb, var(--pill-c) 24%, transparent); text-decoration: none; }
+    .repo-pr-pill.mergeable { --pill-c: var(--green); }
     .repo-pr-pill .pill-num { font-weight: 700; white-space: nowrap; }
     .repo-pr-pill .pill-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .repo-pr-pill .pill-merge-icon { font-size: 0.6rem; margin-left: 1px; }
@@ -895,20 +877,14 @@
     .ind-label { color: var(--muted); font-size: 0.65rem; }
     .ind-empty { color: var(--muted); font-style: italic; font-size: 0.7rem; }
     .ind-tags { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 3px; }
-    .ind-tag {
-      background: rgba(31,111,235,0.15); color: var(--blue); border: 1px solid rgba(31,111,235,0.3);
-      border-radius: 4px; padding: 1px 6px; font-size: 0.65rem; text-decoration: none;
-    }
-    .ind-tag:hover { background: rgba(31,111,235,0.3); }
+    /* .ind-tag family — pill recipe; variants pick --pill-c, hover deepens tint */
+    .ind-tag { --pill-c: var(--blue); text-decoration: none; }
+    .ind-tag:hover { background: color-mix(in srgb, var(--pill-c) 26%, transparent); }
     .ind-pair { display: flex; align-items: center; gap: 4px; margin-top: 3px; }
-    .ind-issue { background: rgba(35,134,54,0.15); color: var(--green); border-color: rgba(35,134,54,0.3); }
-    .ind-issue:hover { background: rgba(35,134,54,0.3); }
-    .ind-pr { background: rgba(138,99,210,0.15); color: var(--purple); border-color: rgba(138,99,210,0.3); }
-    .ind-pr:hover { background: rgba(138,99,210,0.3); }
-    .ind-merged { background: rgba(63,185,80,0.15); color: var(--green); border-color: rgba(63,185,80,0.3); }
-    .ind-merged:hover { background: rgba(63,185,80,0.3); }
-    .ind-wip { background: rgba(210,153,34,0.15); color: var(--yellow); border-color: rgba(210,153,34,0.3); }
-    .ind-wip:hover { background: rgba(210,153,34,0.3); }
+    .ind-issue { --pill-c: var(--green); }
+    .ind-pr { --pill-c: var(--purple); }
+    .ind-merged { --pill-c: var(--green); }
+    .ind-wip { --pill-c: var(--yellow); }
     .ind-arrow { color: var(--muted); font-size: 0.7rem; }
     .ind-dots { display: flex; flex-wrap: wrap; gap: 8px; }
     .ind-dot-item { display: flex; align-items: center; gap: 3px; }
@@ -938,11 +914,8 @@
     .token-stat .tval { font-size: 1.3rem; font-weight: 700; }
     .token-stat .tlabel { font-size: 0.65rem; color: var(--muted); }
     .token-models { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 10px; }
-    .token-model-chip {
-      font-family: var(--font-mono);
-      background: rgba(188,140,255,0.1); border: 1px solid rgba(188,140,255,0.25);
-      border-radius: 6px; padding: 6px 10px; font-size: 0.72rem;
-    }
+    /* .token-model-chip — pill recipe (purple, mono; size step in the recipe block) */
+    .token-model-chip { --pill-c: var(--purple); font-family: var(--font-mono); }
     .token-model-chip .mname { color: var(--purple); font-weight: 600; }
     .token-model-chip .mcount { color: var(--muted); margin-left: 6px; }
     .token-sessions { font-size: 0.7rem; color: var(--muted); }
@@ -994,17 +967,18 @@
     /* Model chip on agent cards */
     .pin-toggle { cursor: pointer; background: none; border: none; font-size: 0.7rem; padding: 0 2px; opacity: 0.6; transition: opacity 0.2s; }
     .pin-toggle:hover { opacity: 1; }
-    .model-chip { font-family: var(--font-mono); display: inline-flex; align-items: center; gap: 4px; font-size: 0.65rem; padding: 2px 6px; border-radius: 4px; }
-    .model-chip.free { background: var(--green-bg); color: var(--green); }
-    .model-chip.paid { background: rgba(210,153,34,0.12); color: var(--yellow); }
-    .model-chip.haiku { background: rgba(88,166,255,0.12); color: var(--blue); }
-    .model-chip.sonnet { background: rgba(210,153,34,0.12); color: var(--yellow); }
-    .model-chip.opus { background: var(--red-bg); color: var(--red); }
-    /* Non-Claude model tiers */
-    .model-chip.gpt { background: rgba(16,163,127,0.12); color: #10a37f; }
-    .model-chip.gemini { background: rgba(66,133,244,0.12); color: #4285f4; }
-    .model-chip.deepseek { background: var(--green-bg); color: var(--green); }
-    .model-chip.unknown { background: rgba(139,148,158,0.12); color: var(--muted); }
+    /* .model-chip — pill recipe; tiers pick --pill-c (mono for model ids) */
+    .model-chip { font-family: var(--font-mono); }
+    .model-chip.free { --pill-c: var(--green); }
+    .model-chip.paid { --pill-c: var(--yellow); }
+    .model-chip.haiku { --pill-c: var(--blue); }
+    .model-chip.sonnet { --pill-c: var(--yellow); }
+    .model-chip.opus { --pill-c: var(--red); }
+    /* Non-Claude model tiers (brand colors stay literal) */
+    .model-chip.gpt { --pill-c: #10a37f; }
+    .model-chip.gemini { --pill-c: #4285f4; }
+    .model-chip.deepseek { --pill-c: var(--green); }
+    .model-chip.unknown { --pill-c: var(--muted); }
 
     /* Health dots (reused inside ci-maintainer indicators) */
     .health-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; display: inline-block; }
@@ -1416,9 +1390,9 @@
     .nous-config-row-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 8px; }
     .nous-config-check { display: flex; align-items: center; gap: 8px; font-size: 0.8rem; color: var(--fg); cursor: pointer; padding: 4px 0; }
     .nous-config-check input[type="checkbox"] { width: 16px; height: 16px; cursor: pointer; accent-color: var(--accent); }
-    .nous-config-pill { display: inline-flex; align-items: center; gap: 4px; padding: 4px 10px; border-radius: 6px; font-size: 0.75rem; border: 1px solid var(--border); margin: 2px; cursor: pointer; transition: all 0.15s; }
-    .nous-config-pill.active { background: rgba(88,166,255,0.15); border-color: var(--accent); color: var(--accent); }
-    .nous-config-pill:not(.active) { background: var(--bg); color: var(--muted); }
+    /* .nous-config-pill — toggleable pill on the recipe; active picks the accent */
+    .nous-config-pill { margin: 2px; cursor: pointer; transition: all 0.15s; }
+    .nous-config-pill.active { --pill-c: var(--accent); }
     .nous-config-pill:hover { border-color: var(--accent); }
     .nous-config-output-modes { display: flex; gap: 0; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; margin-bottom: 10px; }
     .nous-config-output-mode { flex: 1; padding: 8px 10px; text-align: center; font-size: 0.76rem; cursor: pointer; border: none; background: var(--bg); color: var(--muted); transition: all 0.2s; }
@@ -1471,19 +1445,20 @@
     .kb-fact-title { font-size: 0.82rem; font-weight: 600; color: var(--fg); margin-bottom: 2px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
     .kb-fact-snippet { font-size: 0.72rem; color: var(--muted); line-height: 1.4; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
     .kb-fact-tags { display: flex; gap: 4px; margin-top: 4px; }
-    .kb-type-badge { font-size: 0.62rem; padding: 1px 6px; border-radius: 3px; font-weight: 600; text-transform: uppercase; }
-    .kb-type-pattern { background: #dbeafe; color: #1d4ed8; }
-    .kb-type-gotcha { background: #fef3c7; color: #92400e; }
-    .kb-type-regression { background: #fee2e2; color: #991b1b; }
-    .kb-type-decision { background: #e0e7ff; color: #3730a3; }
-    .kb-type-test_scaffold { background: #d1fae5; color: #065f46; }
-    .kb-type-integration { background: #ede9fe; color: #5b21b6; }
-    .kb-type-coverage_rule { background: #fce7f3; color: #9d174d; }
-    .kb-layer-badge { font-size: 0.62rem; padding: 1px 6px; border-radius: 3px; }
-    .kb-layer-personal { background: #dbeafe; color: #1d4ed8; }
-    .kb-layer-project { background: #d1fae5; color: #065f46; }
-    .kb-layer-org { background: #fef3c7; color: #92400e; }
-    .kb-layer-community { background: #ede9fe; color: #5b21b6; }
+    /* kb-type / kb-layer chips — pill recipe; the Phase-0 hardcoded pastel
+       pairs become token tints so they read in BOTH modes. */
+    .kb-type-badge { font-weight: 600; text-transform: uppercase; }
+    .kb-type-pattern { --pill-c: var(--blue); }
+    .kb-type-gotcha { --pill-c: var(--yellow); }
+    .kb-type-regression { --pill-c: var(--red); }
+    .kb-type-decision { --pill-c: var(--indigo); }
+    .kb-type-test_scaffold { --pill-c: var(--green); }
+    .kb-type-integration { --pill-c: var(--purple); }
+    .kb-type-coverage_rule { --pill-c: var(--cyan); }
+    .kb-layer-personal { --pill-c: var(--blue); }
+    .kb-layer-project { --pill-c: var(--green); }
+    .kb-layer-org { --pill-c: var(--yellow); }
+    .kb-layer-community { --pill-c: var(--purple); }
     .kb-detail { border: 1px solid var(--border); border-radius: 10px; background: var(--surface); padding: 16px; }
     .kb-detail-title { font-size: 1rem; font-weight: 700; color: var(--fg); margin-bottom: 8px; }
     .kb-detail-body { font-size: 0.8rem; color: var(--fg); line-height: 1.6; margin-bottom: 12px; white-space: pre-wrap; }
@@ -1691,6 +1666,30 @@
       border: none; cursor: pointer; font-family: var(--font-ui);
       transition: opacity 0.15s, background 0.15s;
     }
+
+    /* ══ Pill/badge system (Phase 2) ══
+       One recipe: 999px radius, --fs-xs, faint tint bg + colored border.
+       Each pill declares its color once via --pill-c (default: muted);
+       status pills keep readable colored labels on the faint tint (the
+       neutral-text rule applies to banners/toasts, not chips). Selectors
+       are grouped — no class renames. */
+    .status-badge, .model-chip, .token-model-chip, .repo-issue-pill, .repo-pr-pill,
+    .ind-tag, .pause-badge, .off-badge, .on-demand-badge, .oc-health-badge,
+    .nous-config-pill, .kb-type-badge, .kb-layer-badge, .summary-age {
+      display: inline-flex; align-items: center; gap: 4px;
+      font-size: var(--fs-xs); line-height: 1.5;
+      padding: 1px 8px; border-radius: 999px;
+      background: color-mix(in srgb, var(--pill-c, var(--muted)) 12%, transparent);
+      border: 1px solid color-mix(in srgb, var(--pill-c, var(--muted)) 40%, transparent);
+      color: var(--pill-c, var(--muted));
+    }
+    /* pill size steps */
+    .token-model-chip { padding: 4px 10px; font-size: var(--fs-sm); }
+    .nous-config-pill { padding: 3px 10px; font-size: var(--fs-sm); }
+    .oc-health-badge { padding: 3px 12px; font-size: var(--fs-sm); }
+    @media (max-width: 480px) {
+      .pause-badge { font-size: 0.55rem; padding: 0 5px; margin-left: 2px; }
+    }
   </style>
 </head>
 <body>
@@ -1854,7 +1853,7 @@
       </div>
     </div>
     <div style="padding:4px 16px 8px;text-align:center">
-      <span id="acmm-sidebar-badge" title="ACMM Maturity Level — click to change" style="cursor:pointer;display:inline-block;padding:4px 12px;border-radius:12px;font-size:0.7rem;font-weight:700;background:linear-gradient(135deg,#3498db,#2ecc71);color:#fff;letter-spacing:0.5px" onclick="openACMMDialog()"></span>
+      <span id="acmm-sidebar-badge" title="ACMM Maturity Level — click to change" style="cursor:pointer;display:inline-block;padding:3px 12px;border-radius:999px;font-size:0.7rem;font-weight:700;background:color-mix(in srgb, var(--amber) 14%, transparent);border:1px solid color-mix(in srgb, var(--amber) 45%, transparent);color:var(--amber);letter-spacing:0.5px" onclick="openACMMDialog()"></span>
     </div>
     <div class="oc-nav-group">
       <div class="oc-nav-label">Control</div>
@@ -1952,7 +1951,7 @@
   <h1><span class="bee">🐝</span> KubeStellar Hive Dashboard&nbsp;<span id="project-name">for KubeStellar/Console</span> <span class="timestamp" id="ts"></span>
     <span class="git-version" id="git-version"></span>
     <span class="git-version" id="hive-id-badge" title="Hive Instance ID" style="cursor:pointer;border:1px solid var(--border);padding:2px 8px;border-radius:4px" onclick="openConfigDialog('governor')"></span>
-    <span class="git-version" id="acmm-badge" title="ACMM Maturity Level — click to change" style="cursor:pointer;border:1px solid var(--border);padding:2px 8px;border-radius:4px;background:linear-gradient(135deg,#3498db,#2ecc71);color:#fff;font-weight:600" onclick="openACMMDialog()"></span>
+    <span class="git-version" id="acmm-badge" title="ACMM Maturity Level — click to change" style="cursor:pointer;border:1px solid color-mix(in srgb, var(--amber) 45%, transparent);padding:2px 8px;border-radius:999px;background:color-mix(in srgb, var(--amber) 14%, transparent);color:var(--amber);font-weight:600" onclick="openACMMDialog()"></span>
     <button class="layout-toggle" id="layout-toggle" onclick="toggleLayout()" title="Switch between Light mode (sidebar + detail panel) and Dark mode (dark theme grid). Your preference is saved in the browser.">☰ Dark Mode</button>
     <a href="/api/widget" class="widget-dl" title="Download Übersicht widget">⬇ Widget</a>
   </h1>

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1705,7 +1705,7 @@
        are grouped — no class renames. */
     .status-badge, .model-chip, .token-model-chip, .repo-issue-pill, .repo-pr-pill,
     .ind-tag, .pause-badge, .off-badge, .on-demand-badge, .oc-health-badge,
-    .nous-config-pill, .kb-type-badge, .kb-layer-badge, .summary-age {
+    .nous-config-pill, .kb-type-badge, .kb-layer-badge, .summary-age, .oc-nav-count {
       display: inline-flex; align-items: center; gap: 4px;
       font-size: var(--fs-xs); line-height: 1.5;
       padding: 1px 8px; border-radius: 999px;
@@ -1713,6 +1713,9 @@
       border: 1px solid color-mix(in srgb, var(--pill-c, var(--muted)) 40%, transparent);
       color: var(--pill-c, var(--muted));
     }
+    /* sidebar resource count pills (Repos/Beads/Knowledge/Contributors) —
+       one look, JS toggles display + textContent by id */
+    .oc-nav-count { --pill-c: var(--blue); margin-left: auto; flex-shrink: 0; font-weight: 700; }
     /* pill size steps */
     .token-model-chip { padding: 4px 10px; font-size: var(--fs-sm); }
     .nous-config-pill { padding: 3px 10px; font-size: var(--fs-sm); }
@@ -2014,11 +2017,11 @@
     </div>
     <div class="oc-nav-group">
       <div class="oc-nav-label">Resources</div>
-      <a class="oc-nav-item" data-section="repos-section" onclick="ocNavigate('repos-section')"><span class="oc-nav-emoji">📦</span><span class="oc-nav-text">Repos</span><span id="repos-sidebar-badge" style="display:none;margin-left:auto;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:700;background:rgba(88,166,255,0.15);color:var(--blue);border:1px solid rgba(88,166,255,0.3)"></span></a>
-      <a class="oc-nav-item" data-section="beads-section" onclick="ocNavigate('beads-section')"><span class="oc-nav-emoji">🔮</span><span class="oc-nav-text">Beads</span></a>
+      <a class="oc-nav-item" data-section="repos-section" onclick="ocNavigate('repos-section')"><span class="oc-nav-emoji">📦</span><span class="oc-nav-text">Repos</span><span id="repos-sidebar-badge" class="oc-nav-count" style="display:none"></span></a>
+      <a class="oc-nav-item" data-section="beads-section" onclick="ocNavigate('beads-section')"><span class="oc-nav-emoji">🔮</span><span class="oc-nav-text">Beads</span><span id="beads-sidebar-badge" class="oc-nav-count" style="display:none"></span></a>
       <a class="oc-nav-item" data-section="inception-section" onclick="ocNavigate('inception-section')"><span class="oc-nav-emoji">💡</span><span class="oc-nav-text">Inception</span></a>
-      <a class="oc-nav-item" data-section="knowledge-section" onclick="ocNavigate('knowledge-section')"><span class="oc-nav-emoji">📚</span><span class="oc-nav-text">Knowledge</span></a>
-      <a class="oc-nav-item" data-section="contributors-section" onclick="ocNavigate('contributors-section')"><span class="oc-nav-emoji">👥</span><span class="oc-nav-text">Contributors</span><span id="contributors-sidebar-badge" style="display:none;margin-left:auto;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:700;background:var(--green);color:var(--bg)"></span></a>
+      <a class="oc-nav-item" data-section="knowledge-section" onclick="ocNavigate('knowledge-section')"><span class="oc-nav-emoji">📚</span><span class="oc-nav-text">Knowledge</span><span id="knowledge-sidebar-badge" class="oc-nav-count" style="display:none"></span></a>
+      <a class="oc-nav-item" data-section="contributors-section" onclick="ocNavigate('contributors-section')"><span class="oc-nav-emoji">👥</span><span class="oc-nav-text">Contributors</span><span id="contributors-sidebar-badge" class="oc-nav-count" style="display:none"></span></a>
       <a class="oc-nav-item" data-section="audit-section" onclick="ocNavigate('audit-section')"><span class="oc-nav-emoji">📋</span><span class="oc-nav-text">Audit Log</span></a>
       <a class="oc-nav-item" data-section="nous-section" onclick="ocNavigate('nous-section')"><span class="oc-nav-emoji">🧪</span><span class="oc-nav-text">Strategy Lab</span></a>
       <a class="oc-nav-item" href="/api/docs" target="_blank"><span class="oc-nav-emoji">📘</span><span class="oc-nav-text">API Spec (Redoc)</span></a>
@@ -5575,6 +5578,18 @@ function burnAreaChart() {
         const prev = _kbCache;
         _kbCache = await r.json();
         _kbCache._documents = (docsR && docsR.ok) ? await docsR.json() : [];
+        var kbBadge = document.getElementById('knowledge-sidebar-badge');
+        if (kbBadge) {
+          var kbFacts = 0;
+          ((_kbCache && _kbCache.layers) || []).forEach(function(l) {
+            if (l && typeof l.total_pages === 'number') kbFacts += l.total_pages;
+          });
+          if (_kbCache && _kbCache.enabled && kbFacts > 0) {
+            kbBadge.style.display = 'inline-flex';
+            kbBadge.textContent = kbFacts;
+            kbBadge.title = kbFacts + ' knowledge facts';
+          } else { kbBadge.style.display = 'none'; }
+        }
         if (_kbInitialLoad && _kbCache && _kbCache.enabled) {
           _kbSetupView = 'none';
         }
@@ -7724,9 +7739,9 @@ function burnAreaChart() {
       const activeCount = pool.active || 0;
       const totalCount = pool.registered || 0;
       if (sidebarBadge) {
-        if (activeCount > 0) {
-          sidebarBadge.style.display = 'inline-block';
-          sidebarBadge.textContent = activeCount;
+        if (totalCount > 0) {
+          sidebarBadge.style.display = 'inline-flex';
+          sidebarBadge.textContent = totalCount;
           sidebarBadge.title = `${activeCount} active of ${totalCount} registered`;
         } else {
           sidebarBadge.style.display = 'none';
@@ -7966,8 +7981,19 @@ function burnAreaChart() {
       renderAdvisoryDigest(data.advisoryDigest || null);
       renderRepos(data.repos || []);
       var reposBadge = document.getElementById('repos-sidebar-badge');
-      if (reposBadge) { var rc = (data.repos || []).length; if (rc > 0) { reposBadge.style.display = 'inline-block'; reposBadge.textContent = rc; } else { reposBadge.style.display = 'none'; } }
+      if (reposBadge) { var rc = (data.repos || []).length; if (rc > 0) { reposBadge.style.display = 'inline-flex'; reposBadge.textContent = rc; } else { reposBadge.style.display = 'none'; } }
       renderBeads(data.beads || {});
+      var beadsBadge = document.getElementById('beads-sidebar-badge');
+      if (beadsBadge) {
+        var bWorkers = (data.beads && data.beads.workers >= 0) ? data.beads.workers : 0;
+        var bSupervisor = (data.beads && data.beads.supervisor >= 0) ? data.beads.supervisor : 0;
+        var bTotal = bWorkers + bSupervisor;
+        if (bTotal > 0) {
+          beadsBadge.style.display = 'inline-flex';
+          beadsBadge.textContent = bTotal;
+          beadsBadge.title = bWorkers + ' worker / ' + bSupervisor + ' supervisor beads';
+        } else { beadsBadge.style.display = 'none'; }
+      }
       updateContributorBadge(data.contributorPool || null);
       renderSystemGauges(data.systemResources || null);
       ocUpdateSidebarAgents();

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -156,7 +156,10 @@
     }
     .oc-nav-emoji { display: inline-flex; width: 18px; font-size: 0.9rem; flex-shrink: 0; justify-content: center; }
     .oc-nav-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0; }
-    .oc-nav-mode { flex-shrink: 0; font-size: 0.9rem; margin-left: 2px; }
+    .oc-nav-mode { flex-shrink: 0; font-size: 0.9rem; margin-left: 2px; transition: opacity 0.15s; }
+    /* The hover-revealed row actions (⚙/✕) take the right edge — fade the
+       passive mode icon out so they never overlap it at any sidebar width. */
+    .oc-nav-item:hover .oc-nav-mode { opacity: 0; }
     .oc-nav-item:hover { background: var(--bg); color: var(--text); }
     .oc-nav-item .oc-nav-actions {
       display: none; position: absolute; right: 4px; top: 50%;

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1455,8 +1455,12 @@
     /* .kb-layer-btn — ghost button (system recipe); layout + active state here */
     .kb-layer-btn { display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; white-space: nowrap; overflow: hidden; gap: 6px; }
     .kb-layer-btn .kb-layer-label { display: flex; align-items: center; gap: 5px; overflow: hidden; text-overflow: ellipsis; min-width: 0; }
-    .kb-layer-btn .kb-health-indicator { width: 8px; height: 8px; min-width: 8px; border-radius: 50%; display: inline-block; }
-    .kb-layer-count { font-size: 0.7rem; color: var(--muted); padding: 2px 6px; background: var(--bg); border-radius: 4px; }
+    .kb-layer-count { font-size: 0.7rem; color: var(--muted); padding: 2px 6px; background: var(--bg); border-radius: 4px; flex-shrink: 0; }
+    /* Knowledge Sources type pills — pill recipe; each source type gets its own tint */
+    .kb-src-type { font-weight: 600; text-transform: uppercase; flex-shrink: 0; margin-left: auto; }
+    .kb-src-type.wiki { --pill-c: var(--blue); }
+    .kb-src-type.vault { --pill-c: var(--purple); }
+    .kb-src-type.doc { --pill-c: var(--cyan); }
     .kb-search-box { width: 100%; } /* shared input recipe (end of style block) */
     .kb-filter-row { display: flex; gap: 4px; flex-wrap: wrap; }
     .kb-filter-pill { padding: 3px 8px; border: 1px solid var(--border); border-radius: 4px; font-size: 0.68rem; cursor: pointer; background: var(--bg); color: var(--muted); transition: all 0.15s; }
@@ -1498,8 +1502,7 @@
     .kb-stat { text-align: center; padding: 10px; border: 1px solid var(--border); border-radius: 8px; background: var(--surface); }
     .kb-stat .val { font-size: 1.2rem; font-weight: 700; color: var(--fg); }
     .kb-stat .lbl { font-size: 0.68rem; color: var(--muted); margin-top: 2px; }
-    .kb-health-item { display: flex; align-items: center; gap: 8px; font-size: 0.75rem; padding: 4px 0; }
-    .kb-health-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; }
+    .kb-health-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; display: inline-block; }
     .kb-empty { text-align: center; padding: 40px 20px; color: var(--muted); font-size: 0.82rem; }
     .kb-empty-icon { font-size: 2rem; margin-bottom: 8px; }
     .kb-disabled { text-align: center; padding: 40px 20px; color: var(--muted); }
@@ -1705,7 +1708,7 @@
        are grouped — no class renames. */
     .status-badge, .model-chip, .token-model-chip, .repo-issue-pill, .repo-pr-pill,
     .ind-tag, .pause-badge, .off-badge, .on-demand-badge, .oc-health-badge,
-    .nous-config-pill, .kb-type-badge, .kb-layer-badge, .summary-age, .oc-nav-count {
+    .nous-config-pill, .kb-type-badge, .kb-layer-badge, .kb-src-type, .summary-age, .oc-nav-count {
       display: inline-flex; align-items: center; gap: 4px;
       font-size: var(--fs-xs); line-height: 1.5;
       padding: 1px 8px; border-radius: 999px;
@@ -6366,25 +6369,50 @@ function burnAreaChart() {
       // Main layout: sidebar + content
       html += '<div class="kb-layout">';
 
-      // Left sidebar: layers + search + filters
+      // Left sidebar: one consolidated Knowledge Sources list + search + filters.
+      // Every source (wiki layer, vault, imported document) is ONE row here:
+      // health dot (tooltip = health detail) + name + type pill + count pill.
       html += '<div class="kb-sidebar">';
+      html += '<div class="section-label" style="margin:0">Knowledge Sources</div>';
       html += '<div class="kb-layer-list" id="kb-layer-btns">';
-      html += `<button class="kb-layer-btn${_kbSelectedLayer === 'all' ? ' active' : ''}" onclick="kbSelectLayer('all')">📋 All Layers</button>`;
+      // Aggregate row stays on top as the filter reset (kbSelectLayer keys on the 'All Layers' text)
+      html += `<button class="kb-layer-btn${_kbSelectedLayer === 'all' ? ' active' : ''}" onclick="kbSelectLayer('all')"><span class="kb-layer-label">📋 All Layers</span><span class="kb-layer-count">${totalPages}</span></button>`;
       for (const l of layers) {
         const icon = KB_LAYER_ICONS[l.type] || '📄';
         const label = KB_LAYER_LABELS[l.type] || l.type;
         const active = _kbSelectedLayer === l.type ? ' active' : '';
         const count = l.total_pages || 0;
         const dotColor = l.healthy ? 'var(--green)' : 'var(--red)';
+        const healthTip = `${escapeHtml(label)}: ${l.healthy ? 'healthy' : 'unreachable'}`;
         const isGitSource = l.type && l.type.startsWith('git_source:');
         const repoUrl = isGitSource && l.url ? (l.subpath ? l.url + '/tree/' + 'main/' + l.subpath : l.url) : '';
-        html += `<button class="kb-layer-btn${active}" onclick="kbSelectLayer('${escapeHtml(l.type)}')">`;
-        html += `<span class="kb-layer-label">${icon} ${escapeHtml(label)}</span>`;
-        html += `<span class="kb-health-indicator" style="background:${dotColor}"></span>`;
+        html += `<button class="kb-layer-btn${active}" onclick="kbSelectLayer('${escapeHtml(l.type)}')" title="${healthTip}">`;
+        html += `<span class="kb-layer-label"><span class="kb-health-dot" style="background:${dotColor}" title="${healthTip}"></span>${icon} ${escapeHtml(label)}</span>`;
         if (isGitSource && repoUrl) {
           html += `<a href="${escapeHtml(repoUrl)}" target="_blank" rel="noopener" onclick="event.stopPropagation()" style="color:var(--accent);text-decoration:none;font-size:0.82rem;flex-shrink:0" title="Open source repo in new tab">↗</a>`;
         }
+        html += `<span class="kb-src-type wiki">wiki</span>`;
         html += `<span class="kb-layer-count">${count}</span>`;
+        html += `</button>`;
+      }
+      // Vault rows — same list, type pill 'vault'; click behavior unchanged
+      for (const v of connectedVaults) {
+        const vTip = `${escapeHtml(v.name)}: connected — ${escapeHtml(v.root_dir)}`;
+        html += `<button class="kb-layer-btn${_kbSelectedLayer === 'vault:'+v.name ? ' active' : ''}" onclick="_kbSelectedLayer='vault:${escapeHtml(v.name)}';kbSearchVault('${escapeHtml(v.name)}')" title="${vTip}">`;
+        html += `<span class="kb-layer-label"><span class="kb-health-dot" style="background:var(--green)" title="${vTip}"></span>📂 ${escapeHtml(v.name)}</span>`;
+        html += `<span class="kb-src-type vault">vault</span>`;
+        html += `<span class="kb-layer-count">${v.pages}</span>`;
+        html += `</button>`;
+      }
+      // Imported documents — rows of type 'doc' in the same list; click behavior unchanged
+      for (const d of (_kbCache._documents || [])) {
+        const dIcon = DOC_CONTENT_ICONS[d.content_type] || '📄';
+        const dFacts = d.fact_count || 0;
+        const dTip = `${escapeHtml(d.title || d.slug)}: imported — ${escapeHtml(d.source_url || d.source_file || d.slug)}`;
+        html += `<button class="kb-layer-btn${_kbSelectedLayer === 'doc:'+d.slug ? ' active' : ''}" onclick="kbSelectLayer('doc:${escapeHtml(d.slug)}')" title="${dTip}">`;
+        html += `<span class="kb-layer-label"><span class="kb-health-dot" style="background:var(--green)" title="${dTip}"></span>${dIcon} ${escapeHtml(d.title || d.slug)}</span>`;
+        html += `<span class="kb-src-type doc">doc</span>`;
+        html += `<span class="kb-layer-count">${dFacts}</span>`;
         html += `</button>`;
       }
       html += '</div>';
@@ -6400,41 +6428,6 @@ function burnAreaChart() {
         html += `<span class="kb-filter-pill${active}" onclick="kbSelectType('${escapeHtml(t)}')">${escapeHtml(t)}</span>`;
       }
       html += '</div>';
-
-      // Health
-      html += '<div style="margin-top:8px;font-size:0.72rem;color:var(--muted)">';
-      for (const l of layers) {
-        const dot = l.healthy ? 'var(--green)' : 'var(--red)';
-        html += `<div class="kb-health-item"><span class="kb-health-dot" style="background:${dot}"></span>${escapeHtml(KB_LAYER_LABELS[l.type] || l.type)}: ${l.healthy ? 'healthy' : 'unreachable'}</div>`;
-      }
-      html += '</div>';
-
-      // Vaults section in sidebar
-      const vaults = (_kbCache.vaults || []);
-      if (vaults.length > 0) {
-        html += '<div style="margin-top:12px;font-size:0.72rem;color:var(--muted)"><strong>📂 Connected Vaults</strong></div>';
-        html += '<div class="kb-layer-list" style="margin-top:4px">';
-        for (const v of vaults) {
-          html += `<button class="kb-layer-btn${_kbSelectedLayer === 'vault:'+v.name ? ' active' : ''}" onclick="_kbSelectedLayer='vault:${escapeHtml(v.name)}';kbSearchVault('${escapeHtml(v.name)}')" title="${escapeHtml(v.root_dir)}">📂 ${escapeHtml(v.name)}<span class="kb-layer-count">${v.pages}</span></button>`;
-        }
-        html += '</div>';
-      }
-
-      // Documents section in sidebar
-      const docs = (_kbCache._documents || []);
-      if (docs.length > 0) {
-        html += '<div style="margin-top:12px;font-size:0.72rem;color:var(--muted)"><strong>📄 Imported Documents</strong></div>';
-        html += '<div class="kb-layer-list" style="margin-top:4px">';
-        for (const d of docs) {
-          const dIcon = DOC_CONTENT_ICONS[d.content_type] || '📄';
-          const dFacts = d.fact_count || 0;
-          html += `<button class="kb-layer-btn${_kbSelectedLayer === 'doc:'+d.slug ? ' active' : ''}" onclick="kbSelectLayer('doc:${escapeHtml(d.slug)}')" title="${escapeHtml(d.source_url || d.source_file || d.slug)}">`;
-          html += `<span class="kb-layer-label">${dIcon} ${escapeHtml(d.title || d.slug)}</span>`;
-          html += `<span class="kb-layer-count">${dFacts}</span>`;
-          html += `</button>`;
-        }
-        html += '</div>';
-      }
 
       html += '</div>'; // kb-sidebar
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -331,7 +331,8 @@
       background: var(--bg); border: 1px solid var(--border); border-radius: 8px;
       margin-bottom: 12px; font-size: 0.72rem; flex-wrap: wrap;
     }
-    body.oc-agent-focused #oc-gov-strip-outer { display: flex; }
+    /* Compact governor strip no longer needed: the full Governor section
+       remains visible while an agent is focused (see focus-mode rules). */
     .oc-gov-strip .gov-metric { display: flex; flex-direction: column; gap: 1px; }
     .oc-gov-strip .gov-metric .gm-label { font-size: 0.6rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.3px; }
     .oc-gov-strip .gov-metric .gm-val { font-weight: 700; font-size: 0.8rem; }
@@ -495,18 +496,9 @@
     .oc-summary-follow-btn:hover { background: rgba(0,0,0,0.8); }
     .oc-summary-follow-btn.visible { display: flex; }
 
-    /* Hide non-agent sections when an agent is focused in Light */
-    body.oc-agent-focused .governor,
-    body.oc-agent-focused .token-usage,
-    body.oc-agent-focused .repos,
-    body.oc-agent-focused #beads-section,
-    body.oc-agent-focused #nous-section,
-    body.oc-agent-focused #knowledge-section,
-    body.oc-agent-focused #contributors-section,
-    body.oc-agent-focused #audit-section,
-    body.oc-agent-focused #acmm-eval-section,
-    body.oc-agent-focused #leaderboard-section { display: none; }
-    body.oc-strategy-focused #nous-section { display: block; }
+    /* Sections stay visible when an agent is focused so scrolling up from
+       the agent detail still reaches Governor, Token Usage, etc. (previously
+       these were display:none, forcing a click on the nav to get back). */
     body.oc-agent-focused .agent-card.oc-hidden { display: none; }
 
     /* Light card overrides — surface/border/state come from the token

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1737,7 +1737,13 @@
 </head>
 <body>
 <script>
-// Apply layout immediately and hide content until first data render
+// Apply layout immediately and hide content until first data render.
+// NOTE: only body classes are set here — the .layout-toggle buttons do NOT
+// exist in the DOM yet at this point, so any label write here is a no-op.
+// applyLayout() (defined in the main script) is the single source of truth
+// for toggle labels; the DOMContentLoaded hook below guarantees it runs
+// once the topbar/sidebar buttons exist, so the label and body class always
+// sync from storage.
 (function(){
   var m=localStorage.getItem('hive-layout-mode');
   if(m==='openclaw')m='light';
@@ -1748,8 +1754,11 @@
   document.body.style.opacity='0';
   document.body.style.transition='opacity 0.15s ease-in';
   setTimeout(function(){ document.body.style.opacity='1'; }, 3000);
-  var lbl=m==='dark'?'☰ Light Mode':'☰ Dark Mode';
-  document.querySelectorAll('.layout-toggle').forEach(function(b){b.textContent=lbl});
+  document.addEventListener('DOMContentLoaded', function(){
+    if (typeof applyLayout === 'function' && typeof getLayout === 'function') {
+      applyLayout(getLayout());
+    }
+  });
 })();
 
 </script>
@@ -1965,7 +1974,7 @@
       <span class="oc-tb-link" onclick="openConfigDialog('governor')">⚙️ Config</span>
       <span class="oc-tb-link" onclick="ocNavigate('debug-section')">🔍 Debug</span>
       <!-- Agent Logs hidden (redundant with per-agent output) -->
-      <button class="layout-toggle" onclick="toggleLayout()" title="Switch to Dark mode — dark theme with compact agent cards in a grid. Best for quick overview of all agents at once.">☰ Dark Mode</button>
+      <button class="layout-toggle" onclick="toggleLayout()" title="Switch to Dark mode — dark theme with compact agent cards in a grid. Best for quick overview of all agents at once.">☾ Switch to Dark Mode</button>
     </div>
     <div class="oc-topbar-right">
       <span class="oc-health-badge" id="oc-health">● Health OK</span>
@@ -1995,7 +2004,7 @@
     <span class="git-version" id="git-version"></span>
     <span class="git-version" id="hive-id-badge" title="Hive Instance ID" style="cursor:pointer;border:1px solid var(--border);padding:2px 8px;border-radius:4px" onclick="openConfigDialog('governor')"></span>
     <span class="git-version" id="acmm-badge" title="ACMM Maturity Level — click to change" style="cursor:pointer;border:1px solid color-mix(in srgb, var(--amber) 45%, transparent);padding:2px 8px;border-radius:999px;background:color-mix(in srgb, var(--amber) 14%, transparent);color:var(--amber);font-weight:600" onclick="openACMMDialog()"></span>
-    <button class="layout-toggle" id="layout-toggle" onclick="toggleLayout()" title="Switch between Light mode (sidebar + detail panel) and Dark mode (dark theme grid). Your preference is saved in the browser.">☰ Dark Mode</button>
+    <button class="layout-toggle" id="layout-toggle" onclick="toggleLayout()" title="Switch between Light mode (sidebar + detail panel) and Dark mode (dark theme grid). Your preference is saved in the browser.">☾ Switch to Dark Mode</button>
     <a href="/api/widget" class="widget-dl" title="Download Übersicht widget">⬇ Widget</a>
   </h1>
 
@@ -2305,7 +2314,9 @@
     // ── Layout mode (Dark / Light) ──
     const LAYOUT_KEY = 'hive-layout-mode';
     const LAYOUT_MODES = ['dark', 'light'];
-    const LAYOUT_LABELS = { dark: '☰ Light Mode', light: '☰ Dark Mode' };
+    // State-explicit labels: the button names the ACTION ("Switch to …"),
+    // never the current mode, so it cannot be misread as a state indicator.
+    const LAYOUT_LABELS = { dark: '☀ Switch to Light Mode', light: '☾ Switch to Dark Mode' };
     function getLayout() {
       let stored = localStorage.getItem(LAYOUT_KEY) || 'light';
       if (stored === 'openclaw') { stored = 'light'; setLayout(stored); }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -263,7 +263,7 @@
       display: flex; align-items: center; justify-content: space-between;
       padding: 0 20px; z-index: 99;
     }
-    .oc-topbar-left { font-size: 0.85rem; color: var(--muted); }
+    .oc-topbar-left { font-size: 0.85rem; color: var(--muted); display: flex; align-items: center; gap: 4px; }
     .oc-topbar-center { display: flex; align-items: center; gap: 6px; }
     .oc-topbar-center .oc-tb-link {
       font-size: 0.72rem; color: var(--muted); cursor: pointer; padding: 4px 10px;
@@ -2135,6 +2135,7 @@
   <header id="oc-topbar" class="oc-topbar">
     <div class="oc-topbar-left">
       <span id="oc-project-name"></span>
+      <span id="oc-git-version" class="git-version"></span>
     </div>
     <div class="oc-topbar-center">
       <span class="oc-tb-link" onclick="openConfigDialog('governor')">⚙️ Config</span>
@@ -2146,7 +2147,6 @@
       <span class="oc-health-badge" id="oc-health">● Health OK</span>
       <span id="oc-hive-id" class="git-version" title="Hive Instance ID" style="cursor:pointer;border:1px solid var(--border);padding:2px 8px;border-radius:4px" onclick="openConfigDialog('governor')"></span>
       <span class="oc-topbar-ts" id="oc-ts"></span>
-      <span id="oc-git-version" class="git-version"></span>
       <a href="/api/widget" class="widget-dl" title="Download Übersicht widget">⬇ Widget</a>
       <div id="oc-gh-avatar-wrap" style="display:none;position:relative">
         <img id="oc-gh-avatar" src="" alt="" style="width:28px;height:28px;border-radius:50%;cursor:pointer;border:2px solid var(--green);vertical-align:middle" onclick="toggleGHUserMenu()">

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2771,7 +2771,6 @@
       if (govOuter) {
         const itm = window._lastStatus?.issueToMerge || {};
         const itmMedian = itm.median_minutes || 0;
-        const MTTR_COLOR = '#d2a8ff';
         const govThresh = gov.thresholds || {};
         const OC_THRESH_QUIET = govThresh.quiet ?? 2;
         const OC_THRESH_BUSY = govThresh.busy ?? 10;
@@ -2783,8 +2782,8 @@
           <div class="gov-metric"><span class="gm-label">mode</span><span class="gm-val ${govModeClass}">${esc(gov.mode || '—')}</span></div>
           <div class="gov-metric"><span class="gm-label">actionable</span><span class="gm-val">${govActionable}</span></div>
           <div class="gov-metric"><span class="gm-label">PRs</span><span class="gm-val">${govPrs}</span></div>
-          <div class="gov-metric"><span class="gm-label">MTTR</span><span class="gm-val" style="color:${MTTR_COLOR}">${formatFixTime(itmMedian)}</span></div>
-          <div class="gov-metric" title="${esc((window._lastStatus?.hold?.items || []).map(h => (h.type === 'pr' ? 'PR' : 'Issue') + ' ' + h.repo + '#' + h.number + ': ' + h.title).join('\n') || 'No items on hold')}"><span class="gm-label">on hold</span><span class="gm-val" style="color:var(--yellow)">${window._lastStatus?.hold?.total || 0}</span></div>
+          <div class="gov-metric"><span class="gm-label">MTTR</span><span class="gm-val">${formatFixTime(itmMedian)}</span></div>
+          <div class="gov-metric" title="${esc((window._lastStatus?.hold?.items || []).map(h => (h.type === 'pr' ? 'PR' : 'Issue') + ' ' + h.repo + '#' + h.number + ': ' + h.title).join('\n') || 'No items on hold')}"><span class="gm-label">on hold</span><span class="gm-val">${window._lastStatus?.hold?.total || 0}</span></div>
           <div class="oc-gov-gauge">
             <div class="temp-gauge-track" style="background:linear-gradient(to right, var(--green) 0%, var(--green) ${OC_THRESH_QUIET/OC_GAUGE_MAX*100}%, var(--blue) ${OC_THRESH_QUIET/OC_GAUGE_MAX*100}%, var(--blue) ${OC_THRESH_BUSY/OC_GAUGE_MAX*100}%, var(--yellow) ${OC_THRESH_BUSY/OC_GAUGE_MAX*100}%, var(--yellow) ${OC_THRESH_SURGE/OC_GAUGE_MAX*100}%, var(--red) ${OC_THRESH_SURGE/OC_GAUGE_MAX*100}%, var(--red) 100%)">
               <div class="temp-gauge-glow" style="width:100%"></div>
@@ -3652,12 +3651,12 @@
         return `<div class="agent-field"><span class="label">tokens (24h)</span><span class="value" style="color:var(--muted)">${t.sessions} sess · ${t.messages} msgs</span></div>`;
       }
       const avg = t.avgPerSession || (t.sessions > 0 ? Math.floor(total / t.sessions) : 0);
-      let rows = `<div class="agent-field"><span class="label">tokens (24h)</span><span class="value" style="color:var(--cyan)">${fmtTokens(total)} <span style="color:var(--muted);font-size:0.65rem">(${t.sessions} sess)</span></span></div>`;
+      let rows = `<div class="agent-field"><span class="label">tokens (24h)</span><span class="value">${fmtTokens(total)} <span style="color:var(--muted);font-size:0.65rem">(${t.sessions} sess)</span></span></div>`;
       rows += `<div class="agent-field"><span class="label">avg/pass</span><span class="value">${fmtTokens(avg)}</span></div>`;
       const issueCount = getAgentIssueCount(name);
       if (issueCount > 0) {
         const tokensPerIssue = Math.floor(total / issueCount);
-        rows += `<div class="agent-field"><span class="label">avg/issue</span><span class="value" style="color:var(--green)">${fmtTokens(tokensPerIssue)} <span style="color:var(--muted);font-size:0.65rem">(${issueCount} today)</span></span></div>`;
+        rows += `<div class="agent-field"><span class="label">avg/issue</span><span class="value">${fmtTokens(tokensPerIssue)} <span style="color:var(--muted);font-size:0.65rem">(${issueCount} today)</span></span></div>`;
       }
       const intervalMin = parseCadenceMinutes(cadence);
       if (intervalMin > 0 && avg > 0) {
@@ -3666,7 +3665,7 @@
         const passesPerHour = MINUTES_PER_HOUR / intervalMin;
         const tokensPerHour = avg * passesPerHour;
         const tokensPerWeek = tokensPerHour * HOURS_PER_WEEK;
-        rows += `<div class="agent-field"><span class="label">burn rate</span><span class="value" style="color:var(--yellow)">${fmtTokens(tokensPerHour)}/hr · ${fmtTokens(tokensPerWeek)}/wk</span></div>`;
+        rows += `<div class="agent-field"><span class="label">burn rate</span><span class="value">${fmtTokens(tokensPerHour)}/hr · ${fmtTokens(tokensPerWeek)}/wk</span></div>`;
       }
       return rows;
     }
@@ -3979,7 +3978,7 @@
       const itmAvg = itm.avg_minutes || 0;
       const itmMedian = itm.median_minutes || 0;
       const itmCount = itm.count || 0;
-      const FIX_TIME_SPARK_COLOR = '#d2a8ff';
+      const FIX_TIME_SPARK_COLOR = 'var(--muted)'; /* sparkline tint only — the value itself is neutral */
       const itmHistory = (itm.history || []).map(h => h.median || h.avg);
       const itmSpark = sparkSvg(itmHistory, FIX_TIME_SPARK_COLOR);
       const itmTitle = itmCount > 0 ? `MTTR (Mean Time to Resolution) — median: ${formatFixTime(itmMedian)} | avg: ${formatFixTime(itmAvg)} | p90: ${formatFixTime(itm.p90_minutes)} | fastest: ${formatFixTime(itm.fastest_minutes)} | slowest: ${formatFixTime(itm.slowest_minutes)} | ${itmCount} fixes in last 30d` : 'MTTR — no data yet';
@@ -3987,7 +3986,7 @@
       const holdData = data.hold || {};
       const holdTotal = holdData.total || 0;
       const holdItems = holdData.items || [];
-      const HOLD_COLOR = 'var(--yellow)';
+      const HOLD_COLOR = 'var(--muted)'; /* sparkline tint only — the count itself is neutral */
       const holdTooltip = holdItems.length > 0 ? escapeHtml(holdItems.map(h => `${h.type === 'pr' ? 'PR' : 'Issue'} ${h.repo}#${h.number}: ${h.title}`).join('\n')) : 'No items on hold';
       const holdSpark = sparkSvg(getHistorySeries('govHold'), HOLD_COLOR);
 
@@ -3998,8 +3997,8 @@
           <div class="gov-stat" title="Current governor mode based on actionable issue count. Modes: idle (few issues), quiet (normal), busy (high load), surge (critical). Each mode has different agent cadences."><div class="label">mode</div><div class="val" style="color:${modeColor}">${escapeHtml(gov.mode)}</div></div>
           <div class="gov-stat" title="Number of open GitHub issues that are actionable (not labeled as hold, wontfix, etc.). This count determines the governor mode."><div class="label">actionable issues</div><div class="spark-row"><span class="val">${issueCount}</span>${issuesSpark}</div></div>
           <div class="gov-stat" title="Number of open pull requests across all monitored repositories."><div class="label">PRs</div><div class="spark-row"><span class="val">${gov.prs}</span>${prsSpark}</div></div>
-          <div class="gov-stat" title="${itmTitle}"><div class="label">MTTR</div><div class="spark-row"><span class="val" style="color:${FIX_TIME_SPARK_COLOR}">${formatFixTime(itmMedian)}</span>${itmSpark}</div></div>
-          <div class="gov-stat" title="${holdTooltip}"><div class="label">on hold</div><div class="spark-row"><span class="val" style="color:${HOLD_COLOR}">${holdTotal}</span>${holdSpark}</div></div>
+          <div class="gov-stat" title="${itmTitle}"><div class="label">MTTR</div><div class="spark-row"><span class="val">${formatFixTime(itmMedian)}</span>${itmSpark}</div></div>
+          <div class="gov-stat" title="${holdTooltip}"><div class="label">on hold</div><div class="spark-row"><span class="val">${holdTotal}</span>${holdSpark}</div></div>
           <div class="gov-stat" title="When the governor will next evaluate mode and kick agents based on cadence schedules."><div class="label">next run</div><div class="val">${escapeHtml(gov.nextKick || '—')}</div></div>
         </div>
         <div class="temp-gauge" style="cursor:pointer" onclick="openConfigDialog('governor',null,'Thresholds')" title="Click to adjust governor thresholds">
@@ -4541,7 +4540,7 @@
 
       return `<div class="advisor-section">
         <div class="advisor-title">Cadence Advisor <span style="color:var(--muted);font-size:0.7rem">weekly projection at current cadence</span></div>
-        <div class="advisor-total">Projected: <b style="color:var(--cyan)">${fmtTokens(totalWeeklyBurn)}</b> tokens/week</div>
+        <div class="advisor-total">Projected: <b>${fmtTokens(totalWeeklyBurn)}</b> tokens/week</div>
         <div class="advisor-bars">${barRows}</div>
         ${tipsHtml}
       </div>`;
@@ -4831,7 +4830,7 @@ function burnAreaChart() {
         const aTotal = aData ? (aData.input || 0) + (aData.output || 0) + (aData.cacheRead || 0) : 0;
         const clr = _getAgentColor(name);
         const aSpark = sparkSvg(historyData.map(s => s.tokens?.[name] ?? 0), clr);
-        return `<div class="token-stat"><div class="spark-row"><span class="tval" style="color:${clr}">${fmtTokens(aTotal)}</span>${aSpark}</div><div class="tlabel">${name}</div></div>`;
+        return `<div class="token-stat"><div class="spark-row"><span class="tval">${fmtTokens(aTotal)}</span>${aSpark}</div><div class="tlabel">${name}</div></div>`;
       }).join('');
 
       el.innerHTML = `<div class="token-panel">
@@ -4841,11 +4840,11 @@ function burnAreaChart() {
           <div style="flex:1;min-width:0">${burnAreaChart()}</div>
         </div>
         <div class="token-grid">
-          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--cyan)">${fmtTokens(totalTokens)}</span>${totalSpark}</div><div class="tlabel">total tokens</div></div>
-          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--blue)">${fmtTokens(t.input)}</span>${sparkSvg(getHistorySeries('tokenInput'), 'var(--blue)')}</div><div class="tlabel">input</div></div>
-          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--purple)">${fmtTokens(t.output)}</span>${sparkSvg(getHistorySeries('tokenOutput'), 'var(--purple)')}</div><div class="tlabel">output</div></div>
-          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--green)">${fmtTokens(t.cacheRead)}</span>${sparkSvg(getHistorySeries('tokenCacheRead'), 'var(--green)')}</div><div class="tlabel">cache read</div></div>
-          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--yellow)">${fmtTokens(t.cacheCreate)}</span>${sparkSvg(getHistorySeries('tokenCacheCreate'), 'var(--yellow)')}</div><div class="tlabel">cache create</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval">${fmtTokens(totalTokens)}</span>${totalSpark}</div><div class="tlabel">total tokens</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval">${fmtTokens(t.input)}</span>${sparkSvg(getHistorySeries('tokenInput'), 'var(--blue)')}</div><div class="tlabel">input</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval">${fmtTokens(t.output)}</span>${sparkSvg(getHistorySeries('tokenOutput'), 'var(--purple)')}</div><div class="tlabel">output</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval">${fmtTokens(t.cacheRead)}</span>${sparkSvg(getHistorySeries('tokenCacheRead'), 'var(--green)')}</div><div class="tlabel">cache read</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval">${fmtTokens(t.cacheCreate)}</span>${sparkSvg(getHistorySeries('tokenCacheCreate'), 'var(--yellow)')}</div><div class="tlabel">cache create</div></div>
           <div class="token-stat"><div class="spark-row"><span class="tval">${t.messages}</span>${sparkSvg(getHistorySeries('tokenMessages'), 'var(--muted)')}</div><div class="tlabel">messages</div></div>
         </div>
         ${agentSparkRows ? `<div class="token-grid" style="margin-top:4px">${agentSparkRows}</div>` : ''}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1195,6 +1195,7 @@
     /* .config-field inputs — shared input recipe (end of style block) */
     .config-field input[type="text"],
     .config-field input[type="number"],
+    .config-field textarea,
     .config-field select { width: 100%; }
     .config-field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
     .config-field-row4 { display: grid; grid-template-columns: 1fr 1fr 1fr 1fr; gap: 12px; }
@@ -1818,6 +1819,7 @@
        remap makes this white-on-gray in light mode), var(--radius), and a
        subtle 2px amber focus ring. Grouped selectors — no renames. */
     .config-field input[type="text"], .config-field input[type="number"], .config-field select,
+    .config-field textarea,
     .nous-config-section textarea, .nous-config-section input[type="text"], .nous-config-section input[type="number"],
     .config-list-add input,
     .kick-prompt, .kb-search-box, .oc-chat-input, .hive-chat-input, .backend-select {
@@ -1831,13 +1833,15 @@
       outline: none;
     }
     .config-field input[type="text"]:focus, .config-field input[type="number"]:focus, .config-field select:focus,
+    .config-field textarea:focus,
     .nous-config-section textarea:focus, .nous-config-section input[type="text"]:focus, .nous-config-section input[type="number"]:focus,
     .config-list-add input:focus,
     .kick-prompt:focus, .kb-search-box:focus, .oc-chat-input:focus, .hive-chat-input:focus, .backend-select:focus {
       border-color: color-mix(in srgb, var(--amber) 60%, var(--line));
       box-shadow: 0 0 0 2px color-mix(in srgb, var(--amber) 22%, transparent);
     }
-    .config-field input::placeholder, .nous-config-section textarea::placeholder,
+    .config-field input::placeholder, .config-field textarea::placeholder,
+    .nous-config-section textarea::placeholder,
     .nous-config-section input::placeholder, .config-list-add input::placeholder,
     .kick-prompt::placeholder, .kb-search-box::placeholder,
     .oc-chat-input::placeholder, .hive-chat-input::placeholder { color: var(--muted); }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2850,7 +2850,7 @@
           <div class="oc-detail-field"><div class="label" title="CLI authentication status — log in to authenticate the agent's CLI tool">Auth</div><div class="value">${(() => {
             const isClaude = a.cli === 'claude';
             const isCopilot = a.cli === 'copilot';
-            const _needsLogin = a.needsLogin === true;
+            const _needsLogin = a.needsLogin === true || (a.authKnown === true && a.authAvailable !== true);
             const claudeIcon = '<span class="cli-icon claude-icon"></span>';
             const copilotIcon = '<span class="cli-icon copilot-icon"></span>';
             if (_needsLogin) {
@@ -3693,7 +3693,7 @@
       });
       const { sorted: sortedAgents } = _sortAgentsBySidebar(agents);
       const cards = sortedAgents.map(a => {
-        const needsLogin = a.needsLogin === true;
+        const needsLogin = a.needsLogin === true || (a.authKnown === true && a.authAvailable !== true);
         const isOff = a.offByCadence === true;
         const isOnDemand = a.onDemand === true;
         const isPaused = a.paused === true && !isOff && !isOnDemand;
@@ -4261,11 +4261,19 @@
       const hoursLeft = budget.HOURS_REMAINING || 0;
       const HOURS_PER_DAY = 24;
       const dailyRate = burnRate * HOURS_PER_DAY;
-      const usedFillCls = budgetIgnored ? 'safe' : pctUsed < PCT_SAFE ? 'safe' : pctUsed < PCT_WARN ? 'warning' : 'danger';
+      const PCT_BUDGET_WARN = 90; // mirrors governor.BudgetWarnPct: soft-warning threshold
+      const exhausted = !!budget.BUDGET_EXHAUSTED;
+      // Red is reserved for exhausted (kicks suspended); >=90% shows amber.
+      const usedFillCls = budgetIgnored ? 'safe' : exhausted ? 'danger' : pctUsed >= PCT_SAFE ? 'warning' : 'safe';
 
       let govAction = '';
       if (budgetIgnored) {
         govAction = '<span style="color:var(--muted)">Budget enforcement disabled by operator</span>';
+      } else if (exhausted) {
+        const windowEnds = budget.WINDOW_ENDS_AT ? new Date(budget.WINDOW_ENDS_AT).toLocaleString() : 'the next window';
+        govAction = `<span style="color:var(--red)" title="Agents on the budget exempt list keep running">budget exhausted — agent kicks suspended until ${windowEnds}</span>`;
+      } else if (pctUsed >= PCT_BUDGET_WARN) {
+        govAction = `<span style="color:var(--yellow)">Budget warning — ${pctUsed}% of weekly limit used; kicks suspend at 100%</span>`;
       } else if (projPct > PCT_WARN) {
         govAction = '<span style="color:var(--red)">Governor downgrading models to stay within budget</span>';
       } else if (projPct > PCT_SAFE) {
@@ -7666,7 +7674,28 @@ function burnAreaChart() {
       const panel = document.getElementById('contributors-panel');
       if (!panel) return;
       if (!contributors.length) {
-        setIfChanged(panel, '<div style="color:var(--muted);padding:24px;text-align:center;background:var(--card-bg);border:1px solid var(--border);border-radius:8px">No contributors registered yet.</div>');
+        const contributeUrl = window.location.origin + '/contribute';
+        setIfChanged(panel,
+          '<div style="color:var(--text);padding:24px;background:var(--card-bg);border:1px solid var(--border);border-radius:var(--radius-lg);max-width:760px">' +
+            '<div style="font-weight:600;font-size:var(--fs-md);margin-bottom:8px">\ud83e\udd1d Grow your hive with Contributor Relay</div>' +
+            '<div style="color:var(--muted);font-size:var(--fs-base);line-height:1.6;margin-bottom:12px">' +
+              'Contributor Relay lets anyone lend their own machine and AI subscription to this hive. ' +
+              'Contributors register with their GitHub account, run a lightweight worker locally, and the hive ' +
+              'relays tasks (issue fixes, reviews, docs) to their agents over a secure WebSocket \u2014 their compute, your backlog. ' +
+              'Completed tasks build trust: contributors are promoted automatically from <strong>Newcomer</strong> to <strong>Contributor</strong>, <strong>Trusted</strong>, and <strong>Advisor</strong> tiers.' +
+            '</div>' +
+            '<div style="color:var(--muted);font-size:var(--fs-base);line-height:1.6;margin-bottom:12px">' +
+              '<strong style="color:var(--text)">Invite people in three steps:</strong><br>' +
+              '1. Share your contribute link: <a href="/contribute" target="_blank" style="color:var(--blue);font-weight:600">' + escapeHtml(contributeUrl) + '</a><br>' +
+              '2. They sign in with GitHub and follow the one-command setup shown on that page.<br>' +
+              '3. Their agents appear here and start picking up tasks \u2014 you approve what merges.' +
+            '</div>' +
+            '<div style="display:flex;gap:10px;justify-content:flex-start;flex-wrap:wrap">' +
+              '<a href="/contribute" target="_blank" style="font-size:var(--fs-sm);padding:7px 16px;background:var(--amber);color:var(--bg);border-radius:var(--radius);text-decoration:none;font-weight:600">Open /contribute page \u2192</a>' +
+              '<button onclick="navigator.clipboard.writeText(\'' + contributeUrl + '\');showToast(\'Contribute link copied \u2014 share it with your community!\', \'success\')" style="font-size:var(--fs-sm);padding:7px 16px;background:transparent;color:var(--muted);border:1px solid var(--line-strong);border-radius:var(--radius);cursor:pointer;font-weight:600">\ud83d\udccb Copy invite link</button>' +
+            '</div>' +
+            '<div style="color:var(--muted);font-size:var(--fs-sm);margin-top:10px">Tip: post the link in your project README, Discord, or a pinned GitHub issue to recruit contributors.</div>' +
+          '</div>');
         return;
       }
       const filtered = contributors.filter(matchesContributorFilter);
@@ -9278,25 +9307,27 @@ function burnAreaChart() {
       } catch (e) { /* config unreachable — fall through to the prompt */ }
       return new Promise(resolve => {
         const overlay = document.createElement('div');
-        overlay.className = 'hive-dialog-overlay';
-        overlay.innerHTML = `<div class="hive-dialog">
-          <div class="hive-dialog-title">Configure LiteLLM</div>
-          <div class="hive-dialog-body">
-            <p style="margin:0 0 10px">No LiteLLM endpoint is configured yet. Enter the proxy base URL (editable later under Governor Config → LiteLLM).</p>
-            <div class="config-field">
-              <label>Endpoint URL</label>
-              <input type="text" id="litellm-setup-endpoint" placeholder="https://litellm.example.com" style="width:100%">
-            </div>
-            <div class="config-field">
-              <label>API Key Env Name (optional — the key VALUE is never stored)</label>
-              <input type="text" id="litellm-setup-keyenv" placeholder="HIVE_LITELLM_API_KEY" style="width:100%">
-            </div>
+        // Compact first-selection prompt on the gh-auth-modal pattern (the
+        // Claude login modal): centered amber title, tight labeled inputs,
+        // centered buttons, 480px max width (#1787).
+        overlay.className = 'gh-auth-overlay';
+        overlay.innerHTML = `<div class="gh-auth-modal" style="max-width:480px;text-align:left">
+          <h3 style="color:var(--amber);text-align:center">Configure LiteLLM</h3>
+          <p style="margin:0 0 14px;line-height:1.5">No LiteLLM endpoint is configured yet. Enter the proxy base URL (editable later under Governor Config → LiteLLM).</p>
+          <div class="config-field">
+            <label>Endpoint URL</label>
+            <input type="text" id="litellm-setup-endpoint" placeholder="https://litellm.example.com" style="width:100%;box-sizing:border-box">
           </div>
-          <div class="hive-dialog-buttons">
-            <button class="hive-dialog-btn cancel">Cancel</button>
+          <div class="config-field">
+            <label>API Key Env Name <span style="font-weight:400;text-transform:none">(optional — the key value is never stored)</span></label>
+            <input type="text" id="litellm-setup-keyenv" placeholder="HIVE_LITELLM_API_KEY" style="width:100%;box-sizing:border-box">
+          </div>
+          <div style="display:flex;gap:8px;justify-content:center">
             <button class="hive-dialog-btn primary">Save</button>
+            <button class="hive-dialog-btn cancel">Cancel</button>
           </div></div>`;
         document.body.appendChild(overlay);
+        overlay.style.display = 'flex';
         const close = (val) => { overlay.remove(); resolve(val); };
         overlay.querySelector('.cancel').onclick = () => close(false);
         overlay.onclick = (e) => { if (e.target === overlay) close(false); };

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -24,6 +24,7 @@
       /* Radii / shadows / fonts — defined in Phase 0, applied in later phases. */
       --radius-sm: 4px; --radius: 6px; --radius-lg: 12px;
       --shadow-modal: 0 20px 60px rgba(0, 0, 0, 0.5);
+      --shadow-raised: 0 4px 16px rgba(0, 0, 0, 0.45); /* toasts / floating chrome */
       --font-ui: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
       /* Type ramp — section headers / card titles / labels only; body-copy sizes stay. */
@@ -83,6 +84,7 @@
       --indigo: #4f46e5;
       --cyan: #0891b2; --purple: #7c3aed;
       --shadow-modal: 0 20px 60px rgba(0, 0, 0, 0.15);
+      --shadow-raised: 0 4px 16px rgba(0, 0, 0, 0.12);
       --accent: var(--red); /* light mode accent is red (openclaw identity) */
       --oc-accent-light: rgba(220,38,38,0.08);
       --green-bg: #f0fdf4; --green-border: #bbf7d0;
@@ -301,14 +303,8 @@
       display: flex; gap: 8px; align-items: flex-end;
       padding-top: 12px; border-top: 1px solid var(--border);
     }
-    .oc-chat-input {
-      flex: 1; padding: 10px 14px; border: 1px solid var(--border);
-      border-radius: 8px; font-size: 0.85rem; color: var(--text);
-      background: var(--surface); font-family: inherit; resize: none;
-      min-height: 40px; outline: none;
-    }
-    .oc-chat-input:focus { border-color: var(--oc-accent); box-shadow: 0 0 0 2px var(--oc-accent-light); }
-    .oc-chat-input::placeholder { color: var(--muted); }
+    /* .oc-chat-input — shared input recipe (end of style block) */
+    .oc-chat-input { flex: 1; resize: none; min-height: 40px; }
     .oc-chat-send {
       padding: 10px 18px; background: var(--red); color: var(--bg); border: none;
       border-radius: 8px; font-size: 0.82rem; font-weight: 600;
@@ -625,13 +621,8 @@
     .summary-age.age-stale  { --pill-c: var(--red); }
     /* Agent metric gauges — removed, replaced by health panel */
     .agent-actions { margin-top: 10px; display: flex; gap: 6px; flex-wrap: wrap; }
-    .kick-prompt {
-      flex: 1 1 100%; background: var(--bg); border: 1px solid var(--border);
-      color: var(--text); padding: 4px 8px; border-radius: 4px; font-size: 0.75rem;
-      font-family: inherit; outline: none; min-width: 0;
-    }
-    .kick-prompt:focus { border-color: var(--accent); }
-    .kick-prompt::placeholder { color: var(--muted); }
+    /* .kick-prompt — shared input recipe (end of style block) */
+    .kick-prompt { flex: 1 1 100%; min-width: 0; }
     /* .btn-toggle — ghost button with status states (system recipe at end of style block) */
     .agent-card.paused { border-color: var(--red); opacity: 0.7; }
     .agent-card.paused .agent-state { color: var(--red); }
@@ -665,13 +656,9 @@
     .health-ci.warn { color: var(--yellow); }
     .health-ci.bad { color: var(--red); }
     /* .btn / .terminal-link / .restart-btn — button system recipes at end of style block */
-    .backend-select {
-      appearance: none; -webkit-appearance: none;
-      background: var(--surface); color: var(--muted);
-      font-size: 0.7rem; padding: 3px 8px; border-radius: 4px;
-      border: 1px solid var(--border); cursor: pointer; font-family: inherit;
-    }
-    .backend-select:hover { background: var(--border); color: var(--text); }
+    /* .backend-select — shared input recipe (end of style block) */
+    .backend-select { appearance: none; -webkit-appearance: none; cursor: pointer; }
+    .backend-select:hover { color: var(--text); border-color: var(--text); }
     .backend-select option { background: var(--surface); color: var(--text); }
     .backend-select option:disabled { color: var(--muted); }
 
@@ -1022,10 +1009,18 @@
       text-overflow: ellipsis; white-space: nowrap; flex: 1;
     }
     #toast-container { position: fixed; top: 16px; right: 16px; z-index: 10001; display: flex; flex-direction: column; gap: 8px; pointer-events: none; }
-    .toast { pointer-events: auto; padding: 10px 16px; border-radius: 6px; font-size: 0.78rem; color: var(--text); box-shadow: 0 4px 12px rgba(0,0,0,0.4); animation: toast-in 0.25s ease-out; max-width: 360px; }
-    .toast.success { background: color-mix(in srgb, var(--green) 15%, var(--panel)); border: 1px solid var(--green); }
-    .toast.error { background: color-mix(in srgb, var(--red) 15%, var(--panel)); border: 1px solid var(--red); }
-    .toast.info { background: color-mix(in srgb, var(--blue) 15%, var(--panel)); border: 1px solid var(--blue); }
+    /* Toasts — neutral --text copy (Phase 0 rule); severity lives in the
+       tint, the subtle border, and a 3px colored left edge. */
+    .toast {
+      pointer-events: auto; padding: 10px 16px;
+      border-radius: var(--radius); font-size: 0.78rem; color: var(--text);
+      border: 1px solid var(--line); border-left: 3px solid var(--muted);
+      background: var(--panel);
+      box-shadow: var(--shadow-raised); animation: toast-in 0.25s ease-out; max-width: 360px;
+    }
+    .toast.success { background: color-mix(in srgb, var(--green) 14%, var(--panel)); border-color: color-mix(in srgb, var(--green) 35%, var(--line)); border-left-color: var(--green); }
+    .toast.error { background: color-mix(in srgb, var(--red) 14%, var(--panel)); border-color: color-mix(in srgb, var(--red) 35%, var(--line)); border-left-color: var(--red); }
+    .toast.info { background: color-mix(in srgb, var(--blue) 14%, var(--panel)); border-color: color-mix(in srgb, var(--blue) 35%, var(--line)); border-left-color: var(--blue); }
     .toast-spinner { display: inline-block; width: 12px; height: 12px; border: 2px solid color-mix(in srgb, var(--text) 30%, transparent); border-top-color: var(--text); border-radius: 50%; animation: spin 0.8s linear infinite; margin-right: 8px; vertical-align: middle; }
     @keyframes spin { to { transform: rotate(360deg); } }
     @keyframes toast-in { from { opacity: 0; transform: translateX(40px); } to { opacity: 1; transform: translateX(0); } }
@@ -1101,16 +1096,10 @@
 
     .config-field { margin-bottom: 14px; }
     .config-field label { display: block; font-size: var(--fs-xs); color: var(--muted); margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.5px; }
+    /* .config-field inputs — shared input recipe (end of style block) */
     .config-field input[type="text"],
     .config-field input[type="number"],
-    .config-field select {
-      width: 100%; background: var(--bg); border: 1px solid var(--border);
-      color: var(--text); padding: 8px 10px; border-radius: 6px;
-      font-family: inherit; font-size: 0.8rem;
-    }
-    .config-field input:focus, .config-field select:focus {
-      outline: none; border-color: var(--accent);
-    }
+    .config-field select { width: 100%; }
     .config-field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
     .config-field-row4 { display: grid; grid-template-columns: 1fr 1fr 1fr 1fr; gap: 12px; }
 
@@ -1135,8 +1124,7 @@
     .config-stat-row .config-field-row { display: flex; gap: 6px; flex-wrap: wrap; }
     .config-stat-row .config-field { min-width: 0; }
     .config-stat-row .config-field label { font-size: 0.65rem; margin-bottom: 2px; }
-    .config-stat-row .config-field input,
-    .config-stat-row .config-field select { padding: 4px 6px; font-size: 0.75rem; }
+    /* compact stat-row inputs — size step re-declared after the input recipe */
     /* .btn-sm / .btn-danger / .btn-add — ghost/danger/secondary buttons (system recipe) */
     .btn-sm:disabled { opacity: 0.3; cursor: default; }
     .config-stats-list { max-height: 400px; overflow-y: auto; padding-right: 12px; }
@@ -1297,13 +1285,8 @@
       display: flex; gap: 8px; padding: 10px 14px;
       border-top: 1px solid var(--border); background: var(--surface);
     }
-    .hive-chat-input {
-      flex: 1; background: var(--bg); color: var(--text);
-      border: 1px solid var(--border); border-radius: 8px;
-      padding: 8px 12px; font-size: 0.75rem; font-family: inherit;
-      outline: none; resize: none; min-height: 36px; max-height: 80px;
-    }
-    .hive-chat-input:focus { border-color: var(--purple); }
+    /* .hive-chat-input — shared input recipe (end of style block) */
+    .hive-chat-input { flex: 1; resize: none; min-height: 36px; max-height: 80px; }
     .hive-chat-send {
       background: var(--purple); color: var(--bg); border: none; border-radius: 8px;
       padding: 0 14px; cursor: pointer; font-size: 0.8rem; font-weight: 600;
@@ -1368,11 +1351,10 @@
     .nous-config-section:last-child { border-bottom: none; margin-bottom: 0; padding-bottom: 0; }
     .nous-config-section h3 { font-size: 0.85rem; color: var(--accent); margin: 0 0 10px 0; display: flex; align-items: center; gap: 6px; }
     .nous-config-section label { display: block; font-size: 0.78rem; color: var(--muted); margin-bottom: 4px; }
+    /* nous-config inputs — shared input recipe (end of style block) */
     .nous-config-section textarea, .nous-config-section input[type="text"], .nous-config-section input[type="number"] {
-      width: 100%; padding: 8px 10px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg);
-      color: var(--fg); font-size: 0.8rem; font-family: inherit; resize: vertical;
+      width: 100%; resize: vertical;
     }
-    .nous-config-section textarea:focus, .nous-config-section input:focus { outline: none; border-color: var(--accent); }
     .nous-config-row { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 12px; margin-bottom: 8px; }
     .nous-config-row-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 8px; }
     .nous-config-check { display: flex; align-items: center; gap: 8px; font-size: 0.8rem; color: var(--fg); cursor: pointer; padding: 4px 0; }
@@ -1412,9 +1394,7 @@
     .kb-layer-btn .kb-layer-label { display: flex; align-items: center; gap: 5px; overflow: hidden; text-overflow: ellipsis; min-width: 0; }
     .kb-layer-btn .kb-health-indicator { width: 8px; height: 8px; min-width: 8px; border-radius: 50%; display: inline-block; }
     .kb-layer-count { font-size: 0.7rem; color: var(--muted); padding: 2px 6px; background: var(--bg); border-radius: 4px; }
-    .kb-search-box { width: 100%; padding: 7px 10px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg); color: var(--fg); font-size: 0.78rem; }
-    .kb-search-box:focus { outline: none; border-color: var(--accent); }
-    .kb-search-box::placeholder { color: var(--muted); }
+    .kb-search-box { width: 100%; } /* shared input recipe (end of style block) */
     .kb-filter-row { display: flex; gap: 4px; flex-wrap: wrap; }
     .kb-filter-pill { padding: 3px 8px; border: 1px solid var(--border); border-radius: 4px; font-size: 0.68rem; cursor: pointer; background: var(--bg); color: var(--muted); transition: all 0.15s; }
     .kb-filter-pill:hover { border-color: var(--accent); }
@@ -1705,6 +1685,44 @@
     @media (max-width: 600px) {
       .config-modal { border-radius: 0; } /* fullscreen on mobile (see mobile block above) */
     }
+
+    /* ══ Input system (Phase 2) ══
+       One recipe for text inputs/selects/textareas (derived from the old
+       .config-field input): --bg-soft field on --line border (the token
+       remap makes this white-on-gray in light mode), var(--radius), and a
+       subtle 2px amber focus ring. Grouped selectors — no renames. */
+    .config-field input[type="text"], .config-field input[type="number"], .config-field select,
+    .nous-config-section textarea, .nous-config-section input[type="text"], .nous-config-section input[type="number"],
+    .config-list-add input,
+    .kick-prompt, .kb-search-box, .oc-chat-input, .hive-chat-input, .backend-select {
+      background: var(--bg-soft);
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      color: var(--text);
+      font-family: var(--font-ui);
+      font-size: var(--fs-base);
+      padding: 8px 10px;
+      outline: none;
+    }
+    .config-field input[type="text"]:focus, .config-field input[type="number"]:focus, .config-field select:focus,
+    .nous-config-section textarea:focus, .nous-config-section input[type="text"]:focus, .nous-config-section input[type="number"]:focus,
+    .config-list-add input:focus,
+    .kick-prompt:focus, .kb-search-box:focus, .oc-chat-input:focus, .hive-chat-input:focus, .backend-select:focus {
+      border-color: color-mix(in srgb, var(--amber) 60%, var(--line));
+      box-shadow: 0 0 0 2px color-mix(in srgb, var(--amber) 22%, transparent);
+    }
+    .config-field input::placeholder, .nous-config-section textarea::placeholder,
+    .nous-config-section input::placeholder, .config-list-add input::placeholder,
+    .kick-prompt::placeholder, .kb-search-box::placeholder,
+    .oc-chat-input::placeholder, .hive-chat-input::placeholder { color: var(--muted); }
+    /* input size steps (compact contexts keep their scale) */
+    .kick-prompt { padding: 4px 8px; font-size: var(--fs-sm); }
+    .backend-select { padding: 3px 8px; font-size: var(--fs-sm); color: var(--muted); }
+    .kb-search-box { padding: 7px 10px; font-size: var(--fs-sm); }
+    .hive-chat-input { padding: 8px 12px; font-size: var(--fs-sm); }
+    .oc-chat-input { padding: 10px 14px; }
+    .config-stat-row .config-field input,
+    .config-stat-row .config-field select { padding: 4px 6px; font-size: var(--fs-sm); }
   </style>
 </head>
 <body>

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -30,6 +30,15 @@
       /* Type ramp — section headers / card titles / labels only; body-copy sizes stay. */
       --fs-xs: .68rem; --fs-sm: .75rem; --fs-base: .82rem;
       --fs-md: .92rem; --fs-lg: 1.05rem; --fs-xl: 1.25rem;
+      /* Terminal surface — terminals always read as terminals: near-black
+         in dark mode, deep neutral (never white) in light mode. The
+         fg/muted/cyan companions are mode-independent because the
+         surface stays dark in both modes. */
+      --terminal-bg: #05070a;
+      --terminal-line: #2a3442;
+      --terminal-fg: #d7dfe9;
+      --terminal-muted: #8b98a9;
+      --terminal-cyan: #7bd8cd;
       /* Layout */
       --sidebar-w: 302px;
       /* ── Legacy aliases — every old token name keeps working ── */
@@ -88,6 +97,7 @@
       --oc-accent-light: rgba(220,38,38,0.08);
       --green-bg: #f0fdf4; --green-border: #bbf7d0;
       --red-bg: #fef2f2; --red-border: #fecaca;
+      --terminal-bg: #1d2430; /* deep neutral — terminals never go white */
       /* Legacy aliases MUST be re-declared here: a var() inside a custom
          property resolves on the element that DECLARES it, so the :root
          alias copies freeze to the dark values and descendants inherit
@@ -1129,7 +1139,7 @@
       white-space: nowrap; transition: color 0.2s, border-color 0.2s;
     }
     .config-tab:hover { color: var(--text); }
-    .config-tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+    .config-tab.active { color: var(--amber); border-bottom-color: var(--amber); }
     .config-body {
       flex: 1; overflow-y: auto; padding: 20px;
       scrollbar-width: thin; scrollbar-color: var(--border) transparent;
@@ -1227,15 +1237,19 @@
     .thresh-bar-wrap { margin: 10px 0; }
     .thresh-bar-track {
       position: relative; height: 28px; border-radius: 14px;
-      border: 1px solid rgba(255,255,255,0.08); cursor: default;
+      border: 1px solid var(--line); cursor: default;
     }
     .thresh-handle {
       position: absolute; top: -4px; width: 6px; height: 36px;
-      background: #fff; border-radius: 3px; cursor: ew-resize; z-index: 3;
-      box-shadow: 0 0 8px rgba(255,255,255,0.7), 0 0 16px rgba(255,255,255,0.3);
+      background: var(--text); border-radius: 3px; cursor: ew-resize; z-index: 3;
+      box-shadow: 0 0 8px color-mix(in srgb, var(--text) 70%, transparent),
+                  0 0 16px color-mix(in srgb, var(--text) 30%, transparent);
       transform: translateX(-50%); touch-action: none;
     }
-    .thresh-handle:hover { background: #e0e0e0; box-shadow: 0 0 12px rgba(255,255,255,0.9); }
+    .thresh-handle:hover {
+      background: color-mix(in srgb, var(--text) 88%, var(--bg));
+      box-shadow: 0 0 12px color-mix(in srgb, var(--text) 90%, transparent);
+    }
     .thresh-bar-labels {
       position: relative; margin-top: 6px; height: 1.2em;
       font-size: 0.75rem; font-weight: 600;
@@ -1769,6 +1783,35 @@
     .oc-chat-input { padding: 10px 14px; }
     .config-stat-row .config-field input,
     .config-stat-row .config-field select { padding: 4px 6px; font-size: var(--fs-sm); }
+
+    /* ══ Terminal surface (Phase 3) ══
+       Log/pane/audit/activity surfaces read as terminals in both modes:
+       slightly-inset dark bg (--terminal-bg), mono type, subtle border.
+       Surface props were stripped from the #logs-output / #audit-panel /
+       #inception-activity inline styles so these rules can apply. */
+    #logs-output, #audit-panel, #inception-activity, .oc-detail-summary, .doing {
+      background: var(--terminal-bg);
+      color: var(--terminal-fg);
+      border: 1px solid var(--terminal-line);
+      border-radius: var(--radius);
+      font-family: var(--font-mono);
+      box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.35);
+    }
+    .doing { color: var(--terminal-cyan); padding: 8px 10px; }
+    .oc-detail-summary, #inception-activity { color: var(--terminal-cyan); }
+    /* Children of the always-dark pane capture can't use mode-remapped
+       colors — pin them to the terminal companions. */
+    .oc-detail-summary .sum-text, .oc-detail-summary .sum-tool,
+    .oc-detail-summary .sum-table th { color: var(--terminal-fg); }
+    .oc-detail-summary .sum-cmd, .oc-detail-summary .sum-tree,
+    .oc-detail-summary .sum-table td { color: var(--terminal-muted); }
+    .oc-detail-summary .sum-cmd { border-left-color: var(--terminal-line); }
+    .oc-detail-summary .sum-table-wrap {
+      background: color-mix(in srgb, var(--terminal-fg) 4%, transparent);
+      border-color: var(--terminal-line);
+    }
+    .oc-detail-summary .sum-table th,
+    .oc-detail-summary .sum-table td { border-bottom-color: var(--terminal-line); }
   </style>
 </head>
 <body>
@@ -2118,7 +2161,7 @@
         <button onclick="clearAuditSearches()" title="Clear saved searches" style="padding:4px 8px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--muted);cursor:pointer;font-size:0.75rem">✕</button>
         <span id="audit-match-count" style="font-size:0.7rem;color:var(--muted);white-space:nowrap"></span>
       </div>
-      <div id="audit-panel" style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:12px;max-height:320px;overflow-y:auto">
+      <div id="audit-panel" style="padding:12px;max-height:320px;overflow-y:auto">
         <div class="loading">Loading audit log...</div>
       </div>
     </div>
@@ -2179,7 +2222,7 @@
           <input type="checkbox" id="logs-follow" checked> Follow
         </label>
       </div>
-      <div id="logs-output" style="background: var(--panel-strong); color: var(--text); font-family: var(--font-mono); font-size: 0.75rem; line-height: 1.5; padding: 14px; border-radius: 8px; max-height: 500px; overflow-y: auto; white-space: pre-wrap; word-break: break-all;"></div>
+      <div id="logs-output" style="font-size: 0.75rem; line-height: 1.5; padding: 14px; max-height: 500px; overflow-y: auto; white-space: pre-wrap; word-break: break-all;"></div>
     </div>
   </div>
 
@@ -7321,21 +7364,21 @@ function burnAreaChart() {
       var t = e.ts ? new Date(e.ts) : null;
       var timeStr = t ? t.toLocaleString() : '—';
       var user = esc(e.user||'ghost');
-      return '<tr style="border-bottom:1px solid var(--border)">' +
-        '<td style="padding:4px 8px;white-space:nowrap;color:var(--muted)">' + timeStr + '</td>' +
+      return '<tr style="border-bottom:1px solid var(--terminal-line)">' +
+        '<td style="padding:4px 8px;white-space:nowrap;color:var(--terminal-muted)">' + timeStr + '</td>' +
         '<td style="padding:4px 8px"><img src="https://github.com/' + user + '.png?s=32" style="width:16px;height:16px;border-radius:50%;vertical-align:middle;margin-right:4px">' + esc(e.user||'—') + '</td>' +
         '<td style="padding:4px 8px;font-weight:600">' + esc(e.action||'—') + '</td>' +
         '<td style="padding:4px 8px">' + esc(e.agent||'—') + '</td>' +
-        '<td style="padding:4px 8px;color:var(--muted)">' + esc(e.detail||'') + '</td>' +
+        '<td style="padding:4px 8px;color:var(--terminal-muted)">' + esc(e.detail||'') + '</td>' +
         '</tr>';
     }
 
     function renderAuditTable(entries) {
       var panel = document.getElementById('audit-panel');
       if (!panel) return;
-      if (!entries.length) { panel.innerHTML = '<div style="color:var(--muted);font-size:0.82rem;padding:8px">No audit entries yet</div>'; return; }
+      if (!entries.length) { panel.innerHTML = '<div style="color:var(--terminal-muted);font-size:0.82rem;padding:8px">No audit entries yet</div>'; return; }
       panel.innerHTML = '<table style="width:100%;border-collapse:collapse;font-size:0.78rem">' +
-        '<thead><tr style="color:var(--muted);font-size:0.7rem;border-bottom:1px solid var(--border)"><th style="text-align:left;padding:4px 8px">Time</th><th style="text-align:left;padding:4px 8px">User</th><th style="text-align:left;padding:4px 8px">Action</th><th style="text-align:left;padding:4px 8px">Agent</th><th style="text-align:left;padding:4px 8px">Details</th></tr></thead>' +
+        '<thead><tr style="color:var(--terminal-muted);font-size:0.7rem;border-bottom:1px solid var(--terminal-line)"><th style="text-align:left;padding:4px 8px">Time</th><th style="text-align:left;padding:4px 8px">User</th><th style="text-align:left;padding:4px 8px">Action</th><th style="text-align:left;padding:4px 8px">Agent</th><th style="text-align:left;padding:4px 8px">Details</th></tr></thead>' +
         '<tbody>' + entries.map(renderAuditRow).join('') + '</tbody></table>';
     }
 
@@ -8260,7 +8303,7 @@ function burnAreaChart() {
             <div style="font-size:0.72rem;color:var(--muted);margin-left:auto">Phase: ${phase}</div>
           </div>
           <div style="position:relative">
-          <div id="inception-activity" style="background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:16px;font-family:var(--font-mono);font-size:0.75rem;height:450px;overflow-y:auto;white-space:pre-wrap;color:var(--muted);resize:vertical;min-height:150px;max-height:calc(100vh - 200px)" onscroll="onInceptionScroll()">Waiting for brainstorm agent...</div>
+          <div id="inception-activity" style="padding:16px;font-size:0.75rem;height:450px;overflow-y:auto;white-space:pre-wrap;resize:vertical;min-height:150px;max-height:calc(100vh - 200px)" onscroll="onInceptionScroll()">Waiting for brainstorm agent...</div>
           <button id="inception-follow-btn" class="oc-summary-follow-btn" onclick="inceptionResumeTail()" title="Follow new output">⬇</button>
           </div>
           <div style="margin-top:12px;display:flex;gap:8px;justify-content:flex-end">
@@ -8364,7 +8407,7 @@ function burnAreaChart() {
             <div style="font-size:0.72rem;color:var(--muted);margin-left:auto">Phase: structure</div>
           </div>
           <div style="position:relative">
-          <div id="inception-activity" style="background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:16px;font-family:var(--font-mono);font-size:0.75rem;height:450px;overflow-y:auto;white-space:pre-wrap;color:var(--muted);resize:vertical;min-height:150px;max-height:calc(100vh - 200px)" onscroll="onInceptionScroll()">Brainstorm agent is producing vision, constitution, requirements, and acceptance criteria...</div>
+          <div id="inception-activity" style="padding:16px;font-size:0.75rem;height:450px;overflow-y:auto;white-space:pre-wrap;resize:vertical;min-height:150px;max-height:calc(100vh - 200px)" onscroll="onInceptionScroll()">Brainstorm agent is producing vision, constitution, requirements, and acceptance criteria...</div>
           <button id="inception-follow-btn" class="oc-summary-follow-btn" onclick="inceptionResumeTail()" title="Follow new output">⬇</button>
           </div>
           <div style="margin-top:12px;display:flex;gap:8px;justify-content:flex-end">

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -86,7 +86,6 @@
       background: var(--bg); color: var(--text);
     }
     body.light-mode .connection { display: none; }
-    body.light-mode .gh-rate-alert { border-radius: 8px; }
 
     /* Light sidebar */
     .oc-sidebar {
@@ -242,7 +241,7 @@
       font-size: 0.72rem; color: var(--oc-accent); border-color: var(--oc-accent);
       padding: 3px 10px; border-radius: 6px;
     }
-    .oc-topbar .widget-dl:hover { background: var(--oc-accent); color: #fff; }
+    .oc-topbar .widget-dl:hover { background: var(--oc-accent); color: var(--bg); }
 
     /* Light main content area */
     body.light-mode {
@@ -260,12 +259,12 @@
       box-shadow: 0 1px 3px rgba(0,0,0,0.06);
     }
     .oc-agent-detail.active { display: block; }
-    .oc-agent-detail.state-running { border-color: #16a34a; }
-    .oc-agent-detail.state-idle { border-color: #16a34a; }
-    .oc-agent-detail.state-paused { border-color: #ca8a04; }
-    .oc-agent-detail.state-on-demand { border-color: #818cf8; }
-    .oc-agent-detail.state-stopped { border-color: #dc2626; }
-    .oc-agent-detail.state-off { border-color: #d1d5db; }
+    .oc-agent-detail.state-running { border-color: var(--green); }
+    .oc-agent-detail.state-idle { border-color: var(--green); }
+    .oc-agent-detail.state-paused { border-color: var(--yellow); }
+    .oc-agent-detail.state-on-demand { border-color: var(--indigo); }
+    .oc-agent-detail.state-stopped { border-color: var(--red); }
+    .oc-agent-detail.state-off { border-color: var(--line); }
     .oc-agent-detail-header {
       display: flex; align-items: center; gap: 10px; margin-bottom: 16px;
       padding-bottom: 12px; border-bottom: 1px solid var(--border);
@@ -277,12 +276,12 @@
     .oc-agent-detail-header .status-dot {
       width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0;
     }
-    .oc-agent-detail-header .status-dot.running { background: #16a34a; animation: oc-pulse 1.5s ease-in-out infinite; }
-    .oc-agent-detail-header .status-dot.idle { background: #16a34a; }
-    .oc-agent-detail-header .status-dot.paused { background: #ca8a04; }
-    .oc-agent-detail-header .status-dot.on-demand { background: #818cf8; }
-    .oc-agent-detail-header .status-dot.stopped { background: #dc2626; }
-    .oc-agent-detail-header .status-dot.off { background: #9ca3af; }
+    .oc-agent-detail-header .status-dot.running { background: var(--green); animation: oc-pulse 1.5s ease-in-out infinite; }
+    .oc-agent-detail-header .status-dot.idle { background: var(--green); }
+    .oc-agent-detail-header .status-dot.paused { background: var(--yellow); }
+    .oc-agent-detail-header .status-dot.on-demand { background: var(--indigo); }
+    .oc-agent-detail-header .status-dot.stopped { background: var(--red); }
+    .oc-agent-detail-header .status-dot.off { background: var(--muted); }
     .oc-detail-fields {
       display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 10px 24px; margin-bottom: 16px;
     }
@@ -300,10 +299,10 @@
     .oc-gov-strip .gov-metric { display: flex; flex-direction: column; gap: 1px; }
     .oc-gov-strip .gov-metric .gm-label { font-size: 0.6rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.3px; }
     .oc-gov-strip .gov-metric .gm-val { font-weight: 700; font-size: 0.8rem; }
-    .oc-gov-strip .gov-metric .gm-val.mode-idle { color: #16a34a; }
-    .oc-gov-strip .gov-metric .gm-val.mode-quiet { color: #2563eb; }
-    .oc-gov-strip .gov-metric .gm-val.mode-busy { color: #ca8a04; }
-    .oc-gov-strip .gov-metric .gm-val.mode-surge { color: #dc2626; }
+    .oc-gov-strip .gov-metric .gm-val.mode-idle { color: var(--green); }
+    .oc-gov-strip .gov-metric .gm-val.mode-quiet { color: var(--blue); }
+    .oc-gov-strip .gov-metric .gm-val.mode-busy { color: var(--yellow); }
+    .oc-gov-strip .gov-metric .gm-val.mode-surge { color: var(--red); }
     .oc-gov-gauge { flex-basis: 100%; margin-top: 4px; }
     .oc-gov-gauge .temp-gauge-track { height: 14px; }
     .oc-gov-gauge .temp-gauge-labels { font-size: 0.55rem; }
@@ -321,11 +320,11 @@
     .oc-chat-input:focus { border-color: var(--oc-accent); box-shadow: 0 0 0 2px var(--oc-accent-light); }
     .oc-chat-input::placeholder { color: var(--muted); }
     .oc-chat-send {
-      padding: 10px 18px; background: #dc2626; color: #fff; border: none;
+      padding: 10px 18px; background: var(--red); color: var(--bg); border: none;
       border-radius: 8px; font-size: 0.82rem; font-weight: 600;
       cursor: pointer; white-space: nowrap; font-family: inherit;
     }
-    .oc-chat-send:hover { background: #b91c1c; }
+    .oc-chat-send:hover { background: color-mix(in srgb, var(--red) 85%, #000); }
     .oc-detail-actions {
       display: flex; gap: 8px; margin-bottom: 16px; flex-wrap: wrap;
     }
@@ -345,12 +344,12 @@
     .oc-nav-item .oc-agent-dot {
       width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0;
     }
-    .oc-agent-dot.running { background: #16a34a; animation: oc-pulse 1.5s ease-in-out infinite; }
-    .oc-agent-dot.idle { background: #16a34a; }
-    .oc-agent-dot.paused { background: #ca8a04; }
-    .oc-agent-dot.on-demand { background: #818cf8; }
-    .oc-agent-dot.stopped { background: #dc2626; }
-    .oc-agent-dot.off { background: #9ca3af; }
+    .oc-agent-dot.running { background: var(--green); animation: oc-pulse 1.5s ease-in-out infinite; }
+    .oc-agent-dot.idle { background: var(--green); }
+    .oc-agent-dot.paused { background: var(--yellow); }
+    .oc-agent-dot.on-demand { background: var(--indigo); }
+    .oc-agent-dot.stopped { background: var(--red); }
+    .oc-agent-dot.off { background: var(--muted); }
     @keyframes oc-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 
     /* Sidebar drag-and-drop */
@@ -372,12 +371,12 @@
     .oc-sidebar-group-children { padding-left: 0; min-height: 28px; }
     .oc-sidebar-group-children.collapsed { display: none; min-height: 0; }
     .oc-sidebar-group.drag-over > .oc-sidebar-group-children {
-      outline: 2px dashed #dc2626; outline-offset: -2px;
+      outline: 2px dashed var(--red); outline-offset: -2px;
       border-radius: 6px; background: rgba(220,38,38,0.05);
     }
     .oc-sidebar-group.dragging-group { opacity: 0.4; }
     .oc-group-drop-indicator {
-      height: 2px; background: #dc2626; border-radius: 1px; margin: 2px 0;
+      height: 2px; background: var(--red); border-radius: 1px; margin: 2px 0;
     }
     .oc-sidebar-group-header .oc-group-actions {
       margin-left: auto; display: none; gap: 4px;
@@ -389,11 +388,11 @@
     }
     .oc-sidebar-group-header .oc-group-actions button:hover { color: var(--text); }
     .oc-drop-indicator {
-      height: 2px; background: #dc2626; margin: 0 10px;
+      height: 2px; background: var(--red); margin: 0 10px;
       border-radius: 1px; pointer-events: none;
     }
     .oc-drop-indicator-group {
-      border: 2px dashed #dc2626; border-radius: 8px;
+      border: 2px dashed var(--red); border-radius: 8px;
       margin: 2px 10px; padding: 4px; opacity: 0.5;
     }
 
@@ -401,8 +400,8 @@
     .oc-detail-summary-wrap { position: relative; margin-bottom: 16px; }
     .oc-detail-summary {
       color: var(--cyan); line-height: 1.3;
-      padding: 14px; background: #f9fafb;
-      border-radius: 8px; border: 1px solid #e5e7eb;
+      padding: 14px; background: var(--bg);
+      border-radius: 8px; border: 1px solid var(--line);
       min-height: calc(1.3em * 20 + 28px); max-height: 70vh; overflow-y: auto;
       resize: vertical;
       font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
@@ -413,44 +412,44 @@
     .sum-tool {
       display: flex; align-items: center; gap: 6px;
       padding: 6px 10px; margin: 6px 0 2px; border-radius: 6px;
-      background: #eef2ff; border-left: 3px solid #6366f1;
-      font-weight: 600; font-size: 0.65rem; color: #4338ca;
+      background: rgba(99,102,241,0.12); border-left: 3px solid var(--indigo);
+      font-weight: 600; font-size: 0.65rem; color: var(--indigo);
     }
     .sum-tool .sum-tool-type {
       font-size: 0.5rem; text-transform: uppercase; font-weight: 700;
-      background: #6366f1; color: #fff; padding: 1px 5px; border-radius: 3px;
+      background: var(--indigo); color: var(--bg); padding: 1px 5px; border-radius: 3px;
     }
     .sum-cmd {
       font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
-      font-size: 0.6rem; color: #475569; padding: 4px 10px 4px 14px;
-      border-left: 2px solid #cbd5e1; margin: 0; line-height: 1.4;
+      font-size: 0.6rem; color: var(--muted); padding: 4px 10px 4px 14px;
+      border-left: 2px solid var(--line); margin: 0; line-height: 1.4;
       word-break: break-all;
     }
     .sum-tree {
-      font-size: 0.58rem; color: #9ca3af; padding: 1px 10px 1px 20px;
+      font-size: 0.58rem; color: var(--muted); padding: 1px 10px 1px 20px;
       font-style: italic;
     }
     .sum-text {
-      padding: 3px 0; font-size: 0.65rem; color: #374151; line-height: 1.4;
+      padding: 3px 0; font-size: 0.65rem; color: var(--text); line-height: 1.4;
     }
     .sum-table-wrap {
       overflow-x: auto; margin: 4px 0;
-      border: 1px solid #e2e8f0; border-radius: 6px;
-      background: #f8fafc;
+      border: 1px solid var(--line); border-radius: 6px;
+      background: var(--bg-soft);
     }
     .sum-table {
       width: 100%; border-collapse: collapse; font-size: 0.72rem;
     }
     .sum-table th {
-      text-align: left; padding: 5px 10px; background: #eef2ff;
-      border-bottom: 2px solid #c7d2fe; font-weight: 700; color: #4338ca;
+      text-align: left; padding: 5px 10px; background: rgba(99,102,241,0.12);
+      border-bottom: 2px solid var(--line); font-weight: 700; color: var(--indigo);
       font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.3px;
     }
     .sum-table td {
-      padding: 5px 10px; border-bottom: 1px solid #e2e8f0; color: #475569;
+      padding: 5px 10px; border-bottom: 1px solid var(--line); color: var(--muted);
     }
     .sum-table tr:last-child td { border-bottom: none; }
-    .sum-table tr:hover td { background: #eef2ff; }
+    .sum-table tr:hover td { background: rgba(99,102,241,0.08); }
     .oc-summary-follow-btn {
       position: absolute; bottom: 10px; right: 10px;
       width: 28px; height: 28px; border-radius: 50%;
@@ -478,13 +477,11 @@
 
     /* Light card overrides */
     body.light-mode .agent-card {
-      background: #ffffff; border: 1px solid #e5e7eb;
+      background: #ffffff; border: 1px solid var(--line);
       border-radius: 10px; box-shadow: 0 1px 3px rgba(0,0,0,0.06);
       transition: box-shadow 0.2s;
     }
     body.light-mode .agent-card:hover { box-shadow: 0 4px 12px rgba(0,0,0,0.08); }
-    body.light-mode .agent-card.working { border-color: #16a34a; }
-    body.light-mode .agent-card.stopped { border-color: #dc2626; }
     body.light-mode .agent-card.paused { border-color: #ca8a04; opacity: 0.8; }
     body.light-mode .agent-card.off { border-color: #d1d5db; opacity: 0.7; }
 
@@ -499,11 +496,11 @@
     /* Light surface panels */
     body.light-mode .governor,
     body.light-mode .token-panel {
-      background: #ffffff; border: 1px solid #e5e7eb;
+      background: #ffffff; border: 1px solid var(--line);
       border-radius: 10px; box-shadow: 0 1px 3px rgba(0,0,0,0.06);
     }
     body.light-mode .repo-card {
-      background: #ffffff; border: 1px solid #e5e7eb;
+      background: #ffffff; border: 1px solid var(--line);
       border-radius: 8px; box-shadow: 0 1px 2px rgba(0,0,0,0.04);
     }
 
@@ -520,14 +517,7 @@
     body.light-mode .terminal-link:hover { background: #dc2626; color: #fff; }
     body.light-mode .restart-btn { border-color: #ca8a04; color: #ca8a04; }
     body.light-mode .restart-btn:hover { background: #ca8a04; color: #fff; }
-    body.light-mode .btn-toggle.running { background: #f0fdf4; border-color: #16a34a; color: #16a34a; }
-    body.light-mode .btn-toggle.paused { background: #fef2f2; border-color: #dc2626; color: #dc2626; }
 
-    /* Light status badges */
-    body.light-mode .status-badge.blocked { background: #fef2f2; color: #dc2626; border-color: #fecaca; }
-    body.light-mode .status-badge.done { background: #f0fdf4; color: #16a34a; border-color: #bbf7d0; }
-    body.light-mode .pause-badge { background: #fef2f2; color: #dc2626; border-color: #fecaca; }
-    body.light-mode .on-demand-badge { background: #eef2ff; color: #4f46e5; border-color: #c7d2fe; }
 
     /* Light governor gauge */
     body.light-mode .temp-gauge-track { border: 1px solid #e5e7eb; }
@@ -535,48 +525,9 @@
 
     /* Light config modal */
     body.light-mode .config-overlay { background: rgba(0,0,0,0.3); }
-    body.light-mode .config-modal {
-      background: #ffffff; border: 1px solid #e5e7eb;
-      box-shadow: 0 20px 60px rgba(0,0,0,0.15);
-    }
-    body.light-mode .config-header { border-color: #e5e7eb; }
-    body.light-mode .config-tabs { border-color: #e5e7eb; }
-    body.light-mode .config-tab { color: #6b7280; }
-    body.light-mode .config-tab.active { color: #dc2626; border-bottom-color: #dc2626; }
-    body.light-mode .config-body { scrollbar-color: #d1d5db transparent; }
-    body.light-mode .config-field input,
-    body.light-mode .config-field select {
-      background: #f9fafb; border-color: #e5e7eb; color: #1a1a2e;
-    }
-    body.light-mode .config-field input:focus,
-    body.light-mode .config-field select:focus { border-color: #dc2626; }
-    body.light-mode .config-footer { border-color: #e5e7eb; }
-    body.light-mode .config-footer .config-save { background: #2563eb; }
-    body.light-mode .config-footer .config-cancel { color: #6b7280; border-color: #e5e7eb; }
 
-    /* Light toast overrides */
-    body.light-mode .toast.success { background: #16a34a; border-color: #15803d; }
-    body.light-mode .toast.error { background: #dc2626; border-color: #b91c1c; }
-    body.light-mode .toast.info { background: #2563eb; border-color: #1d4ed8; }
 
-    /* Light model chips */
-    body.light-mode .model-chip.free { background: #f0fdf4; color: #16a34a; }
-    body.light-mode .model-chip.paid { background: #fefce8; color: #ca8a04; }
-    body.light-mode .model-chip.opus { background: #fef2f2; color: #dc2626; }
-    body.light-mode .model-chip.sonnet { background: #fefce8; color: #ca8a04; }
-    body.light-mode .model-chip.haiku { background: #eff6ff; color: #2563eb; }
-    /* Non-Claude model tiers (light mode) */
-    body.light-mode .model-chip.gpt { background: #ecfdf5; color: #047857; }
-    body.light-mode .model-chip.gemini { background: #eff6ff; color: #1d4ed8; }
-    body.light-mode .model-chip.deepseek { background: #f0fdf4; color: #16a34a; }
-    body.light-mode .model-chip.unknown { background: #f3f4f6; color: #6b7280; }
 
-    /* Light kick prompt */
-    body.light-mode .kick-prompt {
-      background: #f9fafb; border-color: #e5e7eb; color: #1a1a2e;
-    }
-    body.light-mode .kick-prompt:focus { border-color: #dc2626; }
-    body.light-mode .kick-prompt::placeholder { color: #9ca3af; }
 
     @media (max-width: 768px) {
       .oc-sidebar { display: none !important; }
@@ -594,78 +545,78 @@
     .agent-card.working { border-color: var(--green); }
     .agent-card.idle { border-color: var(--border); }
     .agent-card.stopped { border-color: var(--red); }
-    .agent-card.needs-login { border-color: #ef4444; }
+    .agent-card.needs-login { border-color: var(--red); }
     .cli-login-btn { border: none; padding: 2px 10px; border-radius: 4px; cursor: pointer; font-weight: 600; font-size: 0.75rem; display: inline-flex; align-items: center; gap: 4px; }
     .cli-login-btn.claude { background: #d97706; color: #fff; }
     .cli-login-btn.claude:hover { background: #f59e0b; }
     .cli-login-btn.copilot { background: #238636; color: #fff; }
     .cli-login-btn.copilot:hover { background: #2ea043; }
-    .cli-login-btn.disabled { background: #555; color: #999; cursor: not-allowed; opacity: 0.5; }
+    .cli-login-btn.disabled { background: var(--panel-strong); color: var(--muted); cursor: not-allowed; opacity: 0.5; }
     .cli-login-btn .cli-icon { width: 14px; height: 14px; vertical-align: middle; display: inline-block; background-size: contain; background-repeat: no-repeat; background-position: center; border-radius: 2px; }
     .cli-login-btn .cli-icon.claude-icon { background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAABU1BMVEUAAADad1jadlnVgFXYdljjcVXZd1fZd1f/VVXYeFbZd1bYd1fYdljYeFfZdlfdd1XZd1fad1jXd1jad1bWc1rXeVHad1fYd1f/AADZd1jZeFffcFDZd1faeFbbeFjZd1fZd1jYeFnYdlfadlfZdlfaeFjZeFfZd1jZd1fZd1fad1fZeFfZdlbZd1fRdF3/gIDZdlfZd1fZd1fZd1fZeFfZd1fadlfZdlfYeFnZeFjadljZdljYdljZd1fZd1fZd1fad1jZd1bWelfXeFjad1fYeFjaeFbadlbZd1fZdlfZd1fZeVbceFXZd1fZdlfYd1fZeFbZd1fYdlfZd1bZd1fZd1fYd1fZeVm/gEDZeFfYd1fYeFfZdlfZd1fYd1fMZmbbeVXZdlbYd1jVdVXZd1fZd1bSeFrZd1jWelzVcVXaeFbaeFbZeFjVgFXeelnZd1f///+GnZeHAAAAb3RSTlMAdEUGNAn73gNi5phUhMQey1o6qx8T7s0BmpUQ11kx7+xIcFK1ZrOjwf6P4LfVCwJs9Pj8NS9hjEKAbl1OWN/6zJQsIGd3gojqmV5KJK3isnP2irTk66UoBNFpVZunuQU5f4MY7boRaxkSRFNXDBdqCrImAAAAAWJLR0Rw2ABsdAAAAAlwSFlzAAAA8wAAAPMBRvLPbQAAAAd0SU1FB+gEHhUwIfpH8hUAAADZSURBVBjTY2AAAkYmBgZmFgY4YGVj52Dg5EIIMHDn8zDw8jHwCwiCeELCIqJi4hKSUtIy+bIgATl5BUWlfGUVVbV8dYgGEQ1NLW1xcZ18XT2oEfoGhvn5RvnGJqZm5hYMipZW1ja2dvn5+WyG9g6OTgzOLq5u7lrsQAEPTy9vFgmwHh9fP+P8fAFXf7H8AJC7zAODfINDNEPDmPXDI4ACupEsUeLRMbG6UnEQa0zjE0J9EpOSU5I4UyHWpmnbMKilM9iyZSRDBDKzGBi4shkYcnKR/OeSB2UAAL9MJSEszd09AAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDI0LTA0LTMwVDIxOjQ4OjMzKzAwOjAwyl6QtAAAACV0RVh0ZGF0ZTptb2RpZnkAMjAyNC0wNC0zMFQyMTo0ODozMyswMDowMLsDKAgAAAAZdEVYdFNvZnR3YXJlAHd3dy5pbmtzY2FwZS5vcmeb7jwaAAAAV3pUWHRSYXcgcHJvZmlsZSB0eXBlIGlwdGMAAHic4/IMCHFWKCjKT8vMSeVSAAMjCy5jCxMjE0uTFAMTIESANMNkAyOzVCDL2NTIxMzEHMQHy4BIoEouAOoXEXTyQjWVAAAAAElFTkSuQmCC'); }
     .cli-login-btn .cli-icon.copilot-icon { background-color: #24292f; border-radius: 50%; background-size: 11px; background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAHdSURBVHgBvVeLbYNADDVdoHSDG4ENwgjpBMkG6QbtBkknIBtEnaDdADoBbEA6gWuXQ3GR7wOc8qSnSPhvkzuTQSQQMaefLXFDLIiGmFvxldgRG+IX8SPLsiukAAU2xDOxx3mo2BaWgismHnE9jrZ7s6tuMR1ajO0GKRaYNrhMorh35VoSBjwzbxWDCy5Lil/ailgrPnMtAe2F2wn5Hm+J9Nbxp2AvZNKuVPwetdZrKJQuGfCPMI/0baTSOai0EJ4EKlmVC3tYCdRHwOBR5Q8wHK8aOhiO1bVorK8phqPd0/4dJIKnCxULa4dw3vEZTkK7S2oegVH0u2S3mfCpPDOcQNJKPdAK+nsJ7wW10Ixn4xA+pRwDD1x5fOUOdA6bDaQLXjpEHSfw7RC+QDrsHc+b8ZJxYXUS5OPg8b8bj2LfvvcKCxEIzshHRXkavhG3+H8HaK2zMiJoYXXrQPBKGplJsK3tjObk4gl+wXiYqfFJCHublLailZ4EysjgJ814upKdRHc4uYp4gPAIQmjRdc8oFRcwExHBjdTPFAcclOc8Kp5huNN/iI90Or5DIAGHqCM+k30DEVU41/MI26jKo4DDX3JtAidcs1vg7eM0NoEeb98EBlIBAyu50DNzKv4F8Mg9kvfoSM0AAAAASUVORK5CYII='); }
-    .cli-login-btn.logged-in { background: transparent; color: var(--green, #22c55e); cursor: pointer; border: 1px solid var(--green, #22c55e); }
+    .cli-login-btn.logged-in { background: transparent; color: var(--green); cursor: pointer; border: 1px solid var(--green); }
     .cli-login-btn.logged-in:hover { background: rgba(34,197,94,0.1); }
     .gh-auth-banner { background: linear-gradient(135deg, #1a1a2e, #16213e); color: #fff; padding: 12px 24px; display: flex; align-items: center; justify-content: center; gap: 12px; font-size: 0.9rem; z-index: 200; }
     .gh-auth-banner .gh-auth-btn { background: #238636; color: #fff; border: none; padding: 6px 16px; border-radius: 6px; cursor: pointer; font-weight: 600; font-size: 0.85rem; }
     .gh-auth-banner .gh-auth-btn:hover { background: #2ea043; }
     .gh-auth-banner .gh-auth-user { color: #58a6ff; font-weight: 600; }
-    .gh-app-install-banner { background: #7f1d1d; border: 1px solid #dc2626; border-radius: 8px; padding: 16px; margin-bottom: 16px; display: flex; align-items: center; gap: 12px; }
-    .gh-app-install-banner .gh-app-title { font-weight: 600; margin-bottom: 4px; color: #fff; }
-    .gh-app-install-banner .gh-app-desc { font-size: 0.85rem; color: #fca5a5; }
-    .gh-app-install-banner .gh-app-btn { padding: 8px 16px; background: #dc2626; color: #fff; border-radius: 6px; font-weight: 600; text-decoration: none; white-space: nowrap; border: none; cursor: pointer; font-size: 0.85rem; }
-    .gh-app-install-banner .gh-app-btn:hover { background: #ef4444; }
-    .gh-app-install-banner.perm-issue { background: #78350f; border-color: #d97706; }
-    .gh-app-install-banner.perm-issue .gh-app-desc { color: #fcd34d; }
-    .gh-app-install-banner.perm-issue .gh-app-btn { background: #d97706; }
-    .gh-app-install-banner.perm-issue .gh-app-btn:hover { background: #f59e0b; }
-    .gh-app-perm-details { font-size: 0.8rem; margin-top: 6px; color: #fde68a; }
-    .gh-app-perm-details .perm-ok { color: #86efac; }
-    .gh-app-perm-details .perm-missing { color: #fca5a5; font-weight: 600; }
+    .gh-app-install-banner { background: color-mix(in srgb, var(--red) 12%, var(--panel)); border: 1px solid var(--red); border-radius: 8px; padding: 16px; margin-bottom: 16px; display: flex; align-items: center; gap: 12px; }
+    .gh-app-install-banner .gh-app-title { font-weight: 600; margin-bottom: 4px; color: var(--text); }
+    .gh-app-install-banner .gh-app-desc { font-size: 0.85rem; color: var(--text); }
+    .gh-app-install-banner .gh-app-btn { padding: 8px 16px; background: var(--red); color: var(--bg); border-radius: 6px; font-weight: 600; text-decoration: none; white-space: nowrap; border: none; cursor: pointer; font-size: 0.85rem; }
+    .gh-app-install-banner .gh-app-btn:hover { background: color-mix(in srgb, var(--red) 85%, #fff); }
+    .gh-app-install-banner.perm-issue { background: color-mix(in srgb, var(--yellow) 12%, var(--panel)); border-color: var(--yellow); }
+    .gh-app-install-banner.perm-issue .gh-app-desc { color: var(--text); }
+    .gh-app-install-banner.perm-issue .gh-app-btn { background: var(--yellow); }
+    .gh-app-install-banner.perm-issue .gh-app-btn:hover { background: color-mix(in srgb, var(--yellow) 85%, #fff); }
+    .gh-app-perm-details { font-size: 0.8rem; margin-top: 6px; color: var(--text); }
+    .gh-app-perm-details .perm-ok { color: var(--green); }
+    .gh-app-perm-details .perm-missing { color: var(--red); font-weight: 600; }
     .gh-auth-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.6); z-index: 9999; display: flex; align-items: center; justify-content: center; }
-    .gh-auth-modal { background: #fff; border-radius: 12px; padding: 32px; max-width: 420px; width: 90%; text-align: center; box-shadow: 0 20px 60px rgba(0,0,0,0.3); }
-    .gh-auth-modal h3 { margin: 0 0 8px; font-size: 1.2rem; color: #1a1a2e; }
-    .gh-auth-modal p { color: #6b7280; font-size: 0.85rem; margin: 4px 0; }
-    .gh-auth-modal .device-code { font-family: monospace; font-size: 2rem; font-weight: 800; color: #238636; letter-spacing: 4px; padding: 16px; background: #f0fdf4; border-radius: 8px; margin: 16px 0; user-select: all; }
-    .gh-auth-modal .gh-verify-link { display: inline-block; margin: 12px 0; padding: 8px 20px; background: #238636; color: #fff; text-decoration: none; border-radius: 6px; font-weight: 600; }
-    .gh-auth-modal .gh-verify-link:hover { background: #2ea043; }
-    .gh-auth-modal .gh-poll-status { color: #6b7280; font-size: 0.8rem; margin-top: 12px; }
-    .gh-auth-modal .gh-cancel { background: none; border: 1px solid #d1d5db; padding: 6px 16px; border-radius: 6px; cursor: pointer; color: #6b7280; margin-top: 12px; }
-    .gh-auth-modal .gh-cancel:hover { background: #f3f4f6; }
-    .gh-setup-modal { background: #fff; border-radius: 12px; padding: 32px; max-width: 560px; width: 92%; text-align: left; box-shadow: 0 20px 60px rgba(0,0,0,0.3); max-height: 85vh; overflow-y: auto; }
+    .gh-auth-modal { background: var(--panel); border-radius: 12px; padding: 32px; max-width: 420px; width: 90%; text-align: center; box-shadow: var(--shadow-modal); }
+    .gh-auth-modal h3 { margin: 0 0 8px; font-size: 1.2rem; color: var(--text); }
+    .gh-auth-modal p { color: var(--muted); font-size: 0.85rem; margin: 4px 0; }
+    .gh-auth-modal .device-code { font-family: monospace; font-size: 2rem; font-weight: 800; color: var(--green); letter-spacing: 4px; padding: 16px; background: var(--green-bg); border-radius: 8px; margin: 16px 0; user-select: all; }
+    .gh-auth-modal .gh-verify-link { display: inline-block; margin: 12px 0; padding: 8px 20px; background: var(--green); color: var(--bg); text-decoration: none; border-radius: 6px; font-weight: 600; }
+    .gh-auth-modal .gh-verify-link:hover { background: color-mix(in srgb, var(--green) 85%, #fff); }
+    .gh-auth-modal .gh-poll-status { color: var(--muted); font-size: 0.8rem; margin-top: 12px; }
+    .gh-auth-modal .gh-cancel { background: none; border: 1px solid var(--line); padding: 6px 16px; border-radius: 6px; cursor: pointer; color: var(--muted); margin-top: 12px; }
+    .gh-auth-modal .gh-cancel:hover { background: var(--panel-strong); }
+    .gh-setup-modal { background: var(--panel); border-radius: 12px; padding: 32px; max-width: 560px; width: 92%; text-align: left; box-shadow: var(--shadow-modal); max-height: 85vh; overflow-y: auto; }
     .claude-auth-btn { background: #d97706; color: #fff; border: none; padding: 6px 16px; border-radius: 6px; cursor: pointer; font-weight: 600; font-size: 0.85rem; }
     .claude-auth-btn:hover { background: #f59e0b; }
-    .claude-auth-status { font-size: 0.8rem; color: #6b7280; }
-    .claude-auth-status.logged-in { color: #16a34a; font-weight: 600; }
-    .gh-setup-modal h3 { margin: 0 0 16px; font-size: 1.2rem; color: #1a1a2e; text-align: center; }
-    .gh-setup-modal p { color: #6b7280; font-size: 0.85rem; margin: 8px 0; line-height: 1.5; }
-    .gh-setup-modal .setup-option { background: #f9fafb; border: 2px solid #e5e7eb; border-radius: 8px; padding: 16px; margin: 12px 0; cursor: pointer; transition: border-color 0.15s; }
-    .gh-setup-modal .setup-option:hover { border-color: #238636; }
-    .gh-setup-modal .setup-option h4 { margin: 0 0 6px; font-size: 0.95rem; color: #1a1a2e; }
+    .claude-auth-status { font-size: 0.8rem; color: var(--muted); }
+    .claude-auth-status.logged-in { color: var(--green); font-weight: 600; }
+    .gh-setup-modal h3 { margin: 0 0 16px; font-size: 1.2rem; color: var(--text); text-align: center; }
+    .gh-setup-modal p { color: var(--muted); font-size: 0.85rem; margin: 8px 0; line-height: 1.5; }
+    .gh-setup-modal .setup-option { background: var(--bg); border: 2px solid var(--line); border-radius: 8px; padding: 16px; margin: 12px 0; cursor: pointer; transition: border-color 0.15s; }
+    .gh-setup-modal .setup-option:hover { border-color: var(--green); }
+    .gh-setup-modal .setup-option h4 { margin: 0 0 6px; font-size: 0.95rem; color: var(--text); }
     .gh-setup-modal .setup-option p { margin: 0; font-size: 0.8rem; }
-    .gh-setup-modal .setup-steps { background: #f0fdf4; border-radius: 8px; padding: 16px; margin: 12px 0; font-size: 0.82rem; color: #374151; }
+    .gh-setup-modal .setup-steps { background: var(--green-bg); border-radius: 8px; padding: 16px; margin: 12px 0; font-size: 0.82rem; color: var(--text); }
     .gh-setup-modal .setup-steps ol { margin: 8px 0; padding-left: 20px; }
     .gh-setup-modal .setup-steps li { margin: 6px 0; line-height: 1.5; }
-    .gh-setup-modal .setup-steps code { background: #e5e7eb; padding: 1px 5px; border-radius: 3px; font-size: 0.78rem; }
-    .gh-setup-modal .setup-perms { background: #fffbeb; border-radius: 8px; padding: 12px 16px; margin: 12px 0; }
-    .gh-setup-modal .setup-perms h5 { margin: 0 0 6px; font-size: 0.85rem; color: #92400e; }
-    .gh-setup-modal .setup-perms ul { margin: 4px 0; padding-left: 18px; font-size: 0.78rem; color: #78350f; }
+    .gh-setup-modal .setup-steps code { background: var(--panel-strong); padding: 1px 5px; border-radius: 3px; font-size: 0.78rem; }
+    .gh-setup-modal .setup-perms { background: rgba(210,153,34,0.12); border-radius: 8px; padding: 12px 16px; margin: 12px 0; }
+    .gh-setup-modal .setup-perms h5 { margin: 0 0 6px; font-size: 0.85rem; color: var(--text); }
+    .gh-setup-modal .setup-perms ul { margin: 4px 0; padding-left: 18px; font-size: 0.78rem; color: var(--muted); }
     .gh-setup-modal .setup-perms li { margin: 3px 0; }
-    .gh-setup-modal .gh-cancel { background: none; border: 1px solid #d1d5db; padding: 6px 16px; border-radius: 6px; cursor: pointer; color: #6b7280; margin-top: 12px; display: block; width: 100%; text-align: center; }
-    .gh-setup-modal .gh-cancel:hover { background: #f3f4f6; }
+    .gh-setup-modal .gh-cancel { background: none; border: 1px solid var(--line); padding: 6px 16px; border-radius: 6px; cursor: pointer; color: var(--muted); margin-top: 12px; display: block; width: 100%; text-align: center; }
+    .gh-setup-modal .gh-cancel:hover { background: var(--panel-strong); }
     .agent-state { text-align: right; font-size: 0.75rem; font-weight: 600; margin-top: 6px; }
     .agent-state.working { color: var(--green); }
     .agent-state.idle { color: var(--muted); }
-    .agent-state.paused { color: #f85149; }
-    .agent-state.on-demand { color: #818cf8; }
-    .agent-state.off { color: #484f58; }
+    .agent-state.paused { color: var(--red); }
+    .agent-state.on-demand { color: var(--indigo); }
+    .agent-state.off { color: color-mix(in srgb, var(--muted) 60%, var(--bg)); }
     .status-badge { display: inline-block; font-size: 0.65rem; font-weight: 700; padding: 2px 6px; border-radius: 4px; margin-left: 6px; text-transform: uppercase; letter-spacing: 0.5px; }
-    .status-badge.blocked { background: rgba(248,81,73,0.2); color: #f85149; border: 1px solid rgba(248,81,73,0.4); }
-    .status-badge.needs-context { background: rgba(210,153,34,0.2); color: #d2992a; border: 1px solid rgba(210,153,34,0.4); }
+    .status-badge.blocked { background: var(--red-bg); color: var(--red); border: 1px solid var(--red-border); }
+    .status-badge.needs-context { background: rgba(210,153,34,0.2); color: var(--yellow); border: 1px solid rgba(210,153,34,0.4); }
     .status-badge.done-concerns { background: rgba(227,139,44,0.2); color: #e38b2c; border: 1px solid rgba(227,139,44,0.4); }
-    .status-badge.done { background: rgba(63,185,80,0.15); color: #3fb950; border: 1px solid rgba(63,185,80,0.3); }
-    .agent-card.status-blocked { border-color: #f85149 !important; }
-    .agent-card.status-needs-context { border-color: #d2992a !important; }
+    .status-badge.done { background: var(--green-bg); color: var(--green); border: 1px solid var(--green-border); }
+    .agent-card.status-blocked { border-color: var(--red) !important; }
+    .agent-card.status-needs-context { border-color: var(--yellow) !important; }
     @keyframes pulse-amber { 0%,100% { border-color: rgba(210,153,34,0.3); } 50% { border-color: rgba(210,153,34,0.8); } }
     .agent-card.status-stale { animation: pulse-amber 2s ease-in-out infinite; }
     .agent-name { font-size: 1.1rem; font-weight: 700; margin-bottom: 8px; }
@@ -675,9 +626,9 @@
     }
     .dot.running { background: var(--green); }
     .dot.idle { background: var(--green); }
-    .dot.paused { background: #ca8a04; }
-    .dot.on-demand { background: #818cf8; }
-    .dot.off { background: #9ca3af; }
+    .dot.paused { background: var(--yellow); }
+    .dot.on-demand { background: var(--indigo); }
+    .dot.off { background: var(--muted); }
     .dot.stopped { background: var(--red); }
     .agent-field { display: flex; justify-content: space-between; font-size: 0.8rem; padding: 2px 0; }
     .agent-field .label { color: var(--muted); }
@@ -695,8 +646,8 @@
     .value.pi { color: var(--green); }
     .doing { font-size: 0.65rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: pre-wrap; line-height: 1.3; min-height: 5.6em; max-height: 30em; overflow-y: auto; width: 100%; }
     .summary-age { display: inline-block; font-size: 0.6rem; font-style: normal; border-radius: 3px; padding: 1px 5px; margin-right: 5px; vertical-align: middle; white-space: nowrap; }
-    .summary-age.age-recent { background: rgba(210,153,34,0.15); color: #d29922; border: 1px solid rgba(210,153,34,0.3); }
-    .summary-age.age-stale  { background: rgba(248,81,73,0.15);  color: #f85149; border: 1px solid rgba(248,81,73,0.3); }
+    .summary-age.age-recent { background: rgba(210,153,34,0.15); color: var(--yellow); border: 1px solid rgba(210,153,34,0.3); }
+    .summary-age.age-stale  { background: var(--red-bg);  color: var(--red); border: 1px solid var(--red-border); }
     /* Agent metric gauges — removed, replaced by health panel */
     .agent-actions { margin-top: 10px; display: flex; gap: 6px; flex-wrap: wrap; }
     .kick-prompt {
@@ -708,23 +659,23 @@
     .kick-prompt::placeholder { color: var(--muted); }
     .btn-toggle { cursor: pointer; font-size: 0.7rem; padding: 3px 8px; border-radius: 4px; border: 1px solid var(--border); background: var(--surface); color: var(--muted); transition: all 0.2s; }
     .btn-toggle:hover { border-color: var(--accent); color: var(--text); }
-    .btn-toggle.paused { background: rgba(248,81,73,0.15); border-color: #f85149; color: #f85149; }
-    .btn-toggle.on-demand { background: rgba(99,102,241,0.15); border-color: #818cf8; color: #818cf8; }
-    .btn-toggle.running { background: rgba(63,185,80,0.15); border-color: #3fb950; color: #3fb950; }
-    .btn-toggle.off { background: rgba(72,79,88,0.15); border-color: #484f58; color: #8b949e; }
-    .agent-card.paused { border-color: #f85149; opacity: 0.7; }
-    .agent-card.paused .agent-state { color: #f85149; }
-    .agent-card.on-demand { border-color: #818cf8; opacity: 0.85; }
-    .agent-card.on-demand .agent-state { color: #818cf8; }
-    .agent-card.off { border-color: #484f58; opacity: 0.6; }
-    .agent-card.off .agent-state { color: #484f58; }
-    .pause-badge { display: inline-block; font-size: 0.6rem; background: rgba(248,81,73,0.15); color: #f85149; border: 1px solid rgba(248,81,73,0.3); border-radius: 3px; padding: 1px 5px; margin-left: 4px; vertical-align: middle; }
+    .btn-toggle.paused { background: var(--red-bg); border-color: var(--red); color: var(--red); }
+    .btn-toggle.on-demand { background: rgba(99,102,241,0.15); border-color: var(--indigo); color: var(--indigo); }
+    .btn-toggle.running { background: var(--green-bg); border-color: var(--green); color: var(--green); }
+    .btn-toggle.off { background: rgba(72,79,88,0.15); border-color: color-mix(in srgb, var(--muted) 60%, var(--bg)); color: var(--muted); }
+    .agent-card.paused { border-color: var(--red); opacity: 0.7; }
+    .agent-card.paused .agent-state { color: var(--red); }
+    .agent-card.on-demand { border-color: var(--indigo); opacity: 0.85; }
+    .agent-card.on-demand .agent-state { color: var(--indigo); }
+    .agent-card.off { border-color: color-mix(in srgb, var(--muted) 60%, var(--bg)); opacity: 0.6; }
+    .agent-card.off .agent-state { color: color-mix(in srgb, var(--muted) 60%, var(--bg)); }
+    .pause-badge { display: inline-block; font-size: 0.6rem; background: var(--red-bg); color: var(--red); border: 1px solid var(--red-border); border-radius: 3px; padding: 1px 5px; margin-left: 4px; vertical-align: middle; }
     .pause-info { cursor: help; font-size: 0.7rem; margin-left: 4px; opacity: 0.8; position: relative; display: inline-block; }
     .pause-info:hover .pause-tooltip { display: block; }
-    .pause-tooltip { display: none; position: absolute; bottom: 120%; left: 50%; transform: translateX(-50%); background: #1c1c2e; color: #c9d1d9; border: 1px solid #30363d; border-radius: 6px; padding: 6px 10px; font-size: 0.7rem; white-space: nowrap; z-index: 100; box-shadow: 0 2px 8px rgba(0,0,0,0.4); }
+    .pause-tooltip { display: none; position: absolute; bottom: 120%; left: 50%; transform: translateX(-50%); background: var(--panel-strong); color: var(--text); border: 1px solid var(--line); border-radius: 6px; padding: 6px 10px; font-size: 0.7rem; white-space: nowrap; z-index: 100; box-shadow: 0 2px 8px rgba(0,0,0,0.4); }
     body.light-mode .pause-tooltip { background: #fff; color: #1a1a2e; border-color: #d0d7de; box-shadow: 0 2px 8px rgba(0,0,0,0.1); }
-    .off-badge { display: inline-block; font-size: 0.6rem; background: rgba(72,79,88,0.25); color: #8b949e; border: 1px solid rgba(72,79,88,0.4); border-radius: 3px; padding: 1px 5px; margin-left: 4px; vertical-align: middle; }
-    .on-demand-badge { display: inline-block; font-size: 0.6rem; background: rgba(99,102,241,0.15); color: #818cf8; border: 1px solid rgba(99,102,241,0.3); border-radius: 3px; padding: 1px 5px; margin-left: 4px; vertical-align: middle; }
+    .off-badge { display: inline-block; font-size: 0.6rem; background: rgba(72,79,88,0.25); color: var(--muted); border: 1px solid rgba(72,79,88,0.4); border-radius: 3px; padding: 1px 5px; margin-left: 4px; vertical-align: middle; }
+    .on-demand-badge { display: inline-block; font-size: 0.6rem; background: rgba(99,102,241,0.15); color: var(--indigo); border: 1px solid rgba(99,102,241,0.3); border-radius: 3px; padding: 1px 5px; margin-left: 4px; vertical-align: middle; }
 
     /* Health status panel */
     .health { margin-bottom: 24px; }
@@ -736,14 +687,14 @@
       font-size: 0.8rem;
     }
     .health-dot { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; }
-    .health-dot.ok { background: #3fb950; }
-    .health-dot.fail { background: #f85149; }
-    .health-dot.unknown { background: #8b949e; }
+    .health-dot.ok { background: var(--green); }
+    .health-dot.fail { background: var(--red); }
+    .health-dot.unknown { background: var(--muted); }
     .health-label { color: var(--text); }
     .health-ci { font-weight: 700; }
-    .health-ci.good { color: #3fb950; }
-    .health-ci.warn { color: #d29922; }
-    .health-ci.bad { color: #f85149; }
+    .health-ci.good { color: var(--green); }
+    .health-ci.warn { color: var(--yellow); }
+    .health-ci.bad { color: var(--red); }
     .btn {
       font-size: 0.7rem; padding: 3px 8px; border-radius: 4px;
       border: 1px solid var(--border); background: var(--surface);
@@ -815,7 +766,7 @@
     .repo-issue-pill {
       display: inline-flex; align-items: center; gap: 3px;
       font-size: 0.65rem; padding: 2px 6px; border-radius: 4px;
-      background: rgba(88,166,255,0.12); color: #58a6ff;
+      background: rgba(88,166,255,0.12); color: var(--blue);
       border: 1px solid rgba(88,166,255,0.25);
       text-decoration: none; max-width: 100%;
       transition: background 0.15s;
@@ -826,13 +777,13 @@
     .repo-pr-pill {
       display: inline-flex; align-items: center; gap: 3px;
       font-size: 0.65rem; padding: 2px 6px; border-radius: 4px;
-      background: rgba(188,140,255,0.12); color: #bc8cff;
+      background: rgba(188,140,255,0.12); color: var(--purple);
       border: 1px solid rgba(188,140,255,0.25);
       text-decoration: none; max-width: 100%;
       transition: background 0.15s;
     }
     .repo-pr-pill:hover { background: rgba(188,140,255,0.25); text-decoration: none; }
-    .repo-pr-pill.mergeable { border-color: rgba(63,185,80,0.6); background: rgba(63,185,80,0.1); color: #3fb950; }
+    .repo-pr-pill.mergeable { border-color: rgba(63,185,80,0.6); background: rgba(63,185,80,0.1); color: var(--green); }
     .repo-pr-pill.mergeable:hover { background: rgba(63,185,80,0.22); }
     .repo-pr-pill .pill-num { font-weight: 700; white-space: nowrap; }
     .repo-pr-pill .pill-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -897,7 +848,7 @@
     .temp-gauge-label { font-size: 0.7rem; color: var(--muted); margin-bottom: 4px; display: flex; justify-content: space-between; }
     .temp-gauge-track {
       position: relative; height: 24px; border-radius: 12px; overflow: visible;
-      background: linear-gradient(to right, #238636 0%, #238636 7%, #1f6feb 7%, #1f6feb 33%, #d29922 33%, #d29922 67%, #f85149 67%, #f85149 100%);
+      background: linear-gradient(to right, var(--green) 0%, var(--green) 7%, var(--blue) 7%, var(--blue) 33%, var(--yellow) 33%, var(--yellow) 67%, var(--red) 67%, var(--red) 100%);
       border: 1px solid rgba(255,255,255,0.08);
     }
     .temp-gauge-glow {
@@ -931,19 +882,19 @@
     .temp-gauge-labels .lbl-quiet { left: 20%; }
     .temp-gauge-labels .lbl-busy  { left: 50%; }
     .temp-gauge-labels .lbl-surge { left: 83.5%; }
-    .tl-idle { color: #238636; }
-    .tl-quiet { color: #1f6feb; }
-    .tl-busy { color: #d29922; }
-    .tl-surge { color: #f85149; }
+    .tl-idle { color: var(--green); }
+    .tl-quiet { color: var(--blue); }
+    .tl-busy { color: var(--yellow); }
+    .tl-surge { color: var(--red); }
 
     /* Governor cadence matrix table */
     .gov-matrix { margin-top: 14px; width: 100%; border-collapse: collapse; font-size: 0.72rem; table-layout: fixed; }
     .gov-matrix th { color: var(--muted); font-weight: 600; padding: 3px 8px; text-align: center; border-bottom: 1px solid var(--border); }
     .gov-matrix th.mode-active { border-radius: 4px 4px 0 0; padding: 4px 10px; font-weight: 700; }
-    .gov-matrix th.mode-idle  { color: #238636; }
-    .gov-matrix th.mode-quiet { color: #1f6feb; }
-    .gov-matrix th.mode-busy  { color: #d29922; }
-    .gov-matrix th.mode-surge { color: #f85149; }
+    .gov-matrix th.mode-idle  { color: var(--green); }
+    .gov-matrix th.mode-quiet { color: var(--blue); }
+    .gov-matrix th.mode-busy  { color: var(--yellow); }
+    .gov-matrix th.mode-surge { color: var(--red); }
     .gov-matrix th.mode-active.mode-idle  { background: rgba(35,134,54,0.15); }
     .gov-matrix th.mode-active.mode-quiet { background: rgba(31,111,235,0.15); }
     .gov-matrix th.mode-active.mode-busy  { background: rgba(210,153,34,0.15); }
@@ -958,13 +909,13 @@
       .gov-matrix td:first-child { min-width: 56px; }
     }
     .gov-matrix td.col-active { font-weight: 700; color: var(--text); }
-    .gov-matrix td.col-active.mode-idle  { background: rgba(35,134,54,0.08); color: #3fb950; }
-    .gov-matrix td.col-active.mode-quiet { background: rgba(31,111,235,0.08); color: #58a6ff; }
-    .gov-matrix td.col-active.mode-busy  { background: rgba(210,153,34,0.08); color: #d29922; }
-    .gov-matrix td.col-active.mode-surge { background: rgba(248,81,73,0.08); color: #f85149; }
-    .gov-matrix td.paused { color: #484f58; font-style: italic; }
-    .gov-matrix td.on-demand { color: #818cf8; font-style: italic; }
-    .gov-matrix td.off { color: #484f58; font-style: italic; }
+    .gov-matrix td.col-active.mode-idle  { background: rgba(35,134,54,0.08); color: var(--green); }
+    .gov-matrix td.col-active.mode-quiet { background: rgba(31,111,235,0.08); color: var(--blue); }
+    .gov-matrix td.col-active.mode-busy  { background: rgba(210,153,34,0.08); color: var(--yellow); }
+    .gov-matrix td.col-active.mode-surge { background: rgba(248,81,73,0.08); color: var(--red); }
+    .gov-matrix td.paused { color: color-mix(in srgb, var(--muted) 60%, var(--bg)); font-style: italic; }
+    .gov-matrix td.on-demand { color: var(--indigo); font-style: italic; }
+    .gov-matrix td.off { color: color-mix(in srgb, var(--muted) 60%, var(--bg)); font-style: italic; }
     .gov-matrix .agent-dot {
       display: inline-block; width: 6px; height: 6px; border-radius: 50%;
       background: var(--green); margin-right: 4px; vertical-align: middle;
@@ -976,11 +927,11 @@
     .gov-timeline-label { display: flex; justify-content: space-between; font-size: 0.6rem; color: var(--muted); margin-bottom: 2px; }
     .gov-timeline-strip { display: flex; height: 6px; border-radius: 3px; overflow: hidden; }
     .gov-timeline-strip .tick { flex: 1; min-width: 1px; }
-    .tick-idle { background: #238636; }
-    .tick-quiet { background: #1f6feb; }
-    .tick-busy { background: #d29922; }
-    .tick-surge { background: #f85149; }
-    .tick-unknown { background: #484f58; }
+    .tick-idle { background: var(--green); }
+    .tick-quiet { background: var(--blue); }
+    .tick-busy { background: var(--yellow); }
+    .tick-surge { background: var(--red); }
+    .tick-unknown { background: color-mix(in srgb, var(--muted) 60%, var(--bg)); }
     .gov-timeline-legend { display: flex; gap: 12px; font-size: 0.6rem; margin-top: 3px; }
 
     /* Agent indicators */
@@ -993,18 +944,18 @@
     .ind-empty { color: var(--muted); font-style: italic; font-size: 0.7rem; }
     .ind-tags { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 3px; }
     .ind-tag {
-      background: rgba(31,111,235,0.15); color: #58a6ff; border: 1px solid rgba(31,111,235,0.3);
+      background: rgba(31,111,235,0.15); color: var(--blue); border: 1px solid rgba(31,111,235,0.3);
       border-radius: 4px; padding: 1px 6px; font-size: 0.65rem; text-decoration: none;
     }
     .ind-tag:hover { background: rgba(31,111,235,0.3); }
     .ind-pair { display: flex; align-items: center; gap: 4px; margin-top: 3px; }
-    .ind-issue { background: rgba(35,134,54,0.15); color: #3fb950; border-color: rgba(35,134,54,0.3); }
+    .ind-issue { background: rgba(35,134,54,0.15); color: var(--green); border-color: rgba(35,134,54,0.3); }
     .ind-issue:hover { background: rgba(35,134,54,0.3); }
-    .ind-pr { background: rgba(138,99,210,0.15); color: #bc8cff; border-color: rgba(138,99,210,0.3); }
+    .ind-pr { background: rgba(138,99,210,0.15); color: var(--purple); border-color: rgba(138,99,210,0.3); }
     .ind-pr:hover { background: rgba(138,99,210,0.3); }
-    .ind-merged { background: rgba(63,185,80,0.15); color: #3fb950; border-color: rgba(63,185,80,0.3); }
+    .ind-merged { background: rgba(63,185,80,0.15); color: var(--green); border-color: rgba(63,185,80,0.3); }
     .ind-merged:hover { background: rgba(63,185,80,0.3); }
-    .ind-wip { background: rgba(210,153,34,0.15); color: #d29922; border-color: rgba(210,153,34,0.3); }
+    .ind-wip { background: rgba(210,153,34,0.15); color: var(--yellow); border-color: rgba(210,153,34,0.3); }
     .ind-wip:hover { background: rgba(210,153,34,0.3); }
     .ind-arrow { color: var(--muted); font-size: 0.7rem; }
     .ind-dots { display: flex; flex-wrap: wrap; gap: 8px; }
@@ -1014,12 +965,12 @@
     .ind-group-label { font-size: 0.6rem; color: var(--muted); font-weight: 600; min-width: 52px; text-transform: uppercase; letter-spacing: 0.5px; }
     .ind-stat { display: inline-flex; align-items: baseline; gap: 3px; margin-right: 10px; }
     .ind-num { font-weight: 700; font-size: 0.9rem; color: var(--text); }
-    .ind-err { color: #f85149; }
-    .ind-err .ind-num { color: #f85149; }
-    .ind-warn { color: #d29922; }
-    .ind-warn .ind-num { color: #d29922; }
-    .ind-ok { color: #3fb950; }
-    .ind-ok .ind-num { color: #3fb950; }
+    .ind-err { color: var(--red); }
+    .ind-err .ind-num { color: var(--red); }
+    .ind-warn { color: var(--yellow); }
+    .ind-warn .ind-num { color: var(--yellow); }
+    .ind-ok { color: var(--green); }
+    .ind-ok .ind-num { color: var(--green); }
     .ind-row { display: flex; flex-wrap: wrap; gap: 12px; }
     .ind-summary { font-size: 0.7rem; color: var(--text); margin-bottom: 4px; line-height: 1.4; opacity: 0.85; }
 
@@ -1091,50 +1042,50 @@
     .pin-toggle { cursor: pointer; background: none; border: none; font-size: 0.7rem; padding: 0 2px; opacity: 0.6; transition: opacity 0.2s; }
     .pin-toggle:hover { opacity: 1; }
     .model-chip { display: inline-flex; align-items: center; gap: 4px; font-size: 0.65rem; padding: 2px 6px; border-radius: 4px; }
-    .model-chip.free { background: rgba(63,185,80,0.12); color: var(--green); }
+    .model-chip.free { background: var(--green-bg); color: var(--green); }
     .model-chip.paid { background: rgba(210,153,34,0.12); color: var(--yellow); }
     .model-chip.haiku { background: rgba(88,166,255,0.12); color: var(--blue); }
     .model-chip.sonnet { background: rgba(210,153,34,0.12); color: var(--yellow); }
-    .model-chip.opus { background: rgba(248,81,73,0.12); color: var(--red); }
+    .model-chip.opus { background: var(--red-bg); color: var(--red); }
     /* Non-Claude model tiers */
     .model-chip.gpt { background: rgba(16,163,127,0.12); color: #10a37f; }
     .model-chip.gemini { background: rgba(66,133,244,0.12); color: #4285f4; }
-    .model-chip.deepseek { background: rgba(63,185,80,0.12); color: var(--green); }
+    .model-chip.deepseek { background: var(--green-bg); color: var(--green); }
     .model-chip.unknown { background: rgba(139,148,158,0.12); color: var(--muted); }
 
     /* Health dots (reused inside ci-maintainer indicators) */
     .health-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; display: inline-block; }
-    .health-dot.ok { background: #3fb950; }
-    .health-dot.fail { background: #f85149; }
-    .health-dot.unknown { background: #8b949e; }
+    .health-dot.ok { background: var(--green); }
+    .health-dot.fail { background: var(--red); }
+    .health-dot.unknown { background: var(--muted); }
     .health-ci { font-weight: 700; font-size: 0.7rem; }
-    .health-ci.good { color: #3fb950; }
-    .health-ci.warn { color: #d29922; }
-    .health-ci.bad { color: #f85149; }
+    .health-ci.good { color: var(--green); }
+    .health-ci.warn { color: var(--yellow); }
+    .health-ci.bad { color: var(--red); }
 
     /* GitHub API rate limit alert bar */
     .gh-auth-alert {
       display: none; position: relative; z-index: 10000;
-      background: #8b1a1a; border-bottom: 2px solid #f85149; color: #e6edf3;
+      background: color-mix(in srgb, var(--red) 15%, var(--panel)); border-bottom: 2px solid var(--red); color: var(--text);
       padding: 10px 20px; font-size: 0.85rem; text-align: center;
     }
     .gh-auth-alert.active { display: block; }
-    .gh-auth-alert a { color: #79c0ff; text-decoration: underline; }
+    .gh-auth-alert a { color: var(--blue); text-decoration: underline; }
     .gh-rate-alert {
-      background: rgba(210,153,34,0.15); border: 1px solid rgba(210,153,34,0.4);
+      background: color-mix(in srgb, var(--yellow) 14%, var(--panel)); border: 1px solid var(--yellow);
       border-radius: 8px; padding: 10px 16px; margin-bottom: 16px;
       display: none; /* hidden by default, shown via JS */
     }
     .gh-rate-alert.active { display: block; }
     .gh-rate-alert-title {
-      font-size: 0.85rem; font-weight: 700; color: #d29922; margin-bottom: 6px;
+      font-size: 0.85rem; font-weight: 700; color: var(--text); margin-bottom: 6px;
     }
     .gh-rate-alert-item {
       font-size: 0.75rem; color: var(--text); padding: 3px 0;
       display: flex; align-items: baseline; gap: 8px;
     }
     .gh-rate-alert-agent {
-      font-weight: 700; color: #d29922; min-width: 70px;
+      font-weight: 700; color: var(--text); min-width: 70px;
     }
     .gh-rate-alert-age {
       color: var(--muted); font-size: 0.65rem; white-space: nowrap;
@@ -1144,11 +1095,11 @@
       text-overflow: ellipsis; white-space: nowrap; flex: 1;
     }
     #toast-container { position: fixed; top: 16px; right: 16px; z-index: 10001; display: flex; flex-direction: column; gap: 8px; pointer-events: none; }
-    .toast { pointer-events: auto; padding: 10px 16px; border-radius: 6px; font-size: 0.78rem; color: #e6edf3; box-shadow: 0 4px 12px rgba(0,0,0,0.4); animation: toast-in 0.25s ease-out; max-width: 360px; }
-    .toast.success { background: #1a7f37; border: 1px solid #238636; }
-    .toast.error { background: #8b1a1a; border: 1px solid #f85149; }
-    .toast.info { background: #1a3a5c; border: 1px solid #1f6feb; }
-    .toast-spinner { display: inline-block; width: 12px; height: 12px; border: 2px solid rgba(255,255,255,0.3); border-top-color: #fff; border-radius: 50%; animation: spin 0.8s linear infinite; margin-right: 8px; vertical-align: middle; }
+    .toast { pointer-events: auto; padding: 10px 16px; border-radius: 6px; font-size: 0.78rem; color: var(--text); box-shadow: 0 4px 12px rgba(0,0,0,0.4); animation: toast-in 0.25s ease-out; max-width: 360px; }
+    .toast.success { background: color-mix(in srgb, var(--green) 15%, var(--panel)); border: 1px solid var(--green); }
+    .toast.error { background: color-mix(in srgb, var(--red) 15%, var(--panel)); border: 1px solid var(--red); }
+    .toast.info { background: color-mix(in srgb, var(--blue) 15%, var(--panel)); border: 1px solid var(--blue); }
+    .toast-spinner { display: inline-block; width: 12px; height: 12px; border: 2px solid color-mix(in srgb, var(--text) 30%, transparent); border-top-color: var(--text); border-radius: 50%; animation: spin 0.8s linear infinite; margin-right: 8px; vertical-align: middle; }
     @keyframes spin { to { transform: rotate(360deg); } }
     @keyframes toast-in { from { opacity: 0; transform: translateX(40px); } to { opacity: 1; transform: translateX(0); } }
     @keyframes toast-out { from { opacity: 1; } to { opacity: 0; transform: translateY(-10px); } }
@@ -1190,34 +1141,29 @@
       animation: config-fade-in 0.15s ease-out;
     }
     .hive-dialog {
-      background: #1a1a2e; border: 1px solid #2d2d3d;
+      background: var(--panel); border: 1px solid var(--line);
       border-radius: 10px; width: 460px; max-width: 92vw;
-      box-shadow: 0 16px 48px rgba(0,0,0,0.5);
+      box-shadow: var(--shadow-modal);
       padding: 24px;
     }
-    body.light-mode .hive-dialog { background: #fff; border-color: #e0e0e0; }
-    .hive-dialog-title { font-size: 1rem; font-weight: 600; color: #c9d1d9; margin-bottom: 12px; }
-    body.light-mode .hive-dialog-title { color: #1a1a2e; }
-    .hive-dialog-body { font-size: 0.9rem; color: #8b949e; line-height: 1.5; white-space: pre-wrap; margin-bottom: 20px; }
-    body.light-mode .hive-dialog-body { color: #555; }
+    .hive-dialog-title { font-size: 1rem; font-weight: 600; color: var(--text); margin-bottom: 12px; }
+    .hive-dialog-body { font-size: 0.9rem; color: var(--muted); line-height: 1.5; white-space: pre-wrap; margin-bottom: 20px; }
     .hive-dialog-buttons { display: flex; gap: 10px; justify-content: flex-end; }
     .hive-dialog-btn {
       padding: 8px 20px; border-radius: 6px; border: 1px solid var(--border);
       font-size: 0.85rem; font-weight: 500; cursor: pointer;
       transition: background 0.15s, border-color 0.15s;
     }
-    .hive-dialog-btn:hover { border-color: #58a6ff; }
-    .hive-dialog-btn.primary { background: #58a6ff; color: #fff; border-color: #58a6ff; }
-    .hive-dialog-btn.primary:hover { background: #4a90e0; }
-    .hive-dialog-btn.cancel { background: #2d2d3d; color: #8b949e; border-color: #3d3d4d; }
-    .hive-dialog-btn.cancel:hover { background: #3d3d4d; }
-    body.light-mode .hive-dialog-btn.cancel { background: #f0f0f0; color: #555; border-color: #ddd; }
-    body.light-mode .hive-dialog-btn.cancel:hover { background: #e0e0e0; }
+    .hive-dialog-btn:hover { border-color: var(--blue); }
+    .hive-dialog-btn.primary { background: var(--blue); color: var(--bg); border-color: var(--blue); }
+    .hive-dialog-btn.primary:hover { background: color-mix(in srgb, var(--blue) 85%, #000); }
+    .hive-dialog-btn.cancel { background: var(--panel-strong); color: var(--muted); border-color: var(--line); }
+    .hive-dialog-btn.cancel:hover { background: var(--line); }
     .config-modal {
       background: var(--surface); border: 1px solid var(--border);
       border-radius: 12px; width: 900px; max-width: 95vw;
       height: 85vh; display: flex; flex-direction: column;
-      box-shadow: 0 20px 60px rgba(0,0,0,0.5);
+      box-shadow: var(--shadow-modal);
     }
     .config-header {
       display: flex; align-items: center; justify-content: space-between;
@@ -1239,7 +1185,7 @@
       white-space: nowrap; transition: color 0.2s, border-color 0.2s;
     }
     .config-tab:hover { color: var(--text); }
-    .config-tab.active { color: var(--blue); border-bottom-color: var(--blue); }
+    .config-tab.active { color: var(--accent); border-bottom-color: var(--accent); }
     .config-body {
       flex: 1; overflow-y: auto; padding: 20px;
       scrollbar-width: thin; scrollbar-color: var(--border) transparent;
@@ -1249,7 +1195,7 @@
       padding: 12px 20px; border-top: 1px solid var(--border);
     }
     .config-footer .btn { padding: 6px 16px; font-size: 0.8rem; border-radius: 6px; cursor: pointer; }
-    .config-footer .config-save { background: var(--blue); color: #fff; border: none; font-weight: 600; }
+    .config-footer .config-save { background: var(--blue); color: var(--bg); border: none; font-weight: 600; }
     .config-footer .config-save:hover { opacity: 0.9; }
     .config-footer .config-cancel { background: transparent; color: var(--muted); border: 1px solid var(--border); }
     .config-footer .config-cancel:hover { color: var(--text); border-color: var(--text); }
@@ -1264,7 +1210,7 @@
       font-family: inherit; font-size: 0.8rem;
     }
     .config-field input:focus, .config-field select:focus {
-      outline: none; border-color: var(--blue);
+      outline: none; border-color: var(--accent);
     }
     .config-field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
     .config-field-row4 { display: grid; grid-template-columns: 1fr 1fr 1fr 1fr; gap: 12px; }
@@ -1308,7 +1254,7 @@
       font-weight: 700; cursor: help; margin-left: 4px; position: relative;
       vertical-align: middle; flex-shrink: 0;
     }
-    .config-info:hover { background: var(--blue); color: #fff; }
+    .config-info:hover { background: var(--blue); color: var(--bg); }
     .config-info .config-tooltip {
       display: none; position: fixed; background: var(--bg); border: 1px solid var(--border);
       border-radius: 6px; padding: 6px 10px;
@@ -1406,15 +1352,15 @@
     .hive-chat-fab {
       position: fixed; bottom: 24px; right: 24px; z-index: 9000;
       width: 48px; height: 48px; border-radius: 50%;
-      background: var(--purple); color: #fff; border: none; cursor: pointer;
+      background: var(--purple); color: var(--bg); border: none; cursor: pointer;
       display: flex; align-items: center; justify-content: center;
       font-size: 1.3rem; box-shadow: 0 4px 16px rgba(0,0,0,0.4);
       transition: transform 0.15s, background 0.15s;
     }
-    .hive-chat-fab:hover { transform: scale(1.1); background: #a371f7; }
+    .hive-chat-fab:hover { transform: scale(1.1); background: color-mix(in srgb, var(--purple) 85%, #000); }
     .hive-chat-fab.has-unread::after {
       content: ''; position: absolute; top: 2px; right: 2px;
-      width: 10px; height: 10px; border-radius: 50%; background: #f85149;
+      width: 10px; height: 10px; border-radius: 50%; background: var(--red);
     }
     .hive-chat-panel {
       position: fixed; bottom: 80px; right: 24px; z-index: 9001;
@@ -1447,7 +1393,7 @@
       max-width: 88%; padding: 8px 12px; border-radius: 10px;
       font-size: 0.75rem; line-height: 1.5; word-break: break-word; white-space: pre-wrap;
     }
-    .chat-msg.user { align-self: flex-end; background: var(--purple); color: #fff; border-bottom-right-radius: 2px; }
+    .chat-msg.user { align-self: flex-end; background: var(--purple); color: var(--bg); border-bottom-right-radius: 2px; }
     .chat-msg.system { align-self: flex-start; background: var(--surface); color: var(--text); border-bottom-left-radius: 2px; border: 1px solid var(--border); }
     .chat-msg.system a { color: var(--cyan); }
     .chat-msg.thinking { align-self: flex-start; background: var(--surface); color: var(--muted); font-style: italic; border: 1px dashed var(--border); }
@@ -1463,11 +1409,11 @@
     }
     .hive-chat-input:focus { border-color: var(--purple); }
     .hive-chat-send {
-      background: var(--purple); color: #fff; border: none; border-radius: 8px;
+      background: var(--purple); color: var(--bg); border: none; border-radius: 8px;
       padding: 0 14px; cursor: pointer; font-size: 0.8rem; font-weight: 600;
       transition: background 0.15s;
     }
-    .hive-chat-send:hover { background: #a371f7; }
+    .hive-chat-send:hover { background: color-mix(in srgb, var(--purple) 85%, #000); }
     .hive-chat-send:disabled { opacity: 0.5; cursor: not-allowed; }
     .chat-sources { font-size: 0.6rem; color: var(--muted); margin-top: 4px; }
     .chat-sources span { background: rgba(255,255,255,0.06); padding: 1px 5px; border-radius: 3px; margin-right: 3px; }
@@ -1484,10 +1430,10 @@
     .nous-mode-toggle { display: flex; gap: 0; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; margin-bottom: 14px; }
     .nous-mode-btn { flex: 1; padding: 8px 12px; text-align: center; font-size: 0.78rem; cursor: pointer; border: none; background: var(--surface); color: var(--muted); transition: all 0.2s; }
     .nous-mode-btn:not(:last-child) { border-right: 1px solid var(--border); }
-    .nous-mode-btn.active-observe { background: #2563eb; color: white; }
-    .nous-mode-btn.active-suggest { background: #d97706; color: white; }
-    .nous-mode-btn.active-evolve { background: #16a34a; color: white; }
-    .nous-mode-btn:hover:not([class*="active-"]) { background: #f3f4f6; }
+    .nous-mode-btn.active-observe { background: var(--blue); color: var(--bg); }
+    .nous-mode-btn.active-suggest { background: var(--yellow); color: var(--bg); }
+    .nous-mode-btn.active-evolve { background: var(--green); color: var(--bg); }
+    .nous-mode-btn:hover:not([class*="active-"]) { background: var(--panel-strong); }
     .nous-progress { height: 6px; background: var(--border); border-radius: 3px; overflow: hidden; margin: 8px 0; }
     .nous-progress-fill { height: 100%; border-radius: 3px; transition: width 0.5s; }
     .nous-stat-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 10px; }
@@ -1497,26 +1443,26 @@
     .nous-principle { display: flex; align-items: center; gap: 10px; padding: 8px 0; border-bottom: 1px solid var(--border); }
     .nous-principle:last-child { border-bottom: none; }
     .nous-confidence-bar { width: 60px; height: 6px; background: var(--border); border-radius: 3px; flex-shrink: 0; }
-    .nous-confidence-fill { height: 100%; border-radius: 3px; background: #16a34a; }
+    .nous-confidence-fill { height: 100%; border-radius: 3px; background: var(--green); }
     .nous-principle-text { font-size: 0.78rem; color: var(--fg); flex: 1; }
     .nous-principle-score { font-size: 0.7rem; color: var(--muted); width: 35px; text-align: right; flex-shrink: 0; }
     .nous-timeline { display: flex; gap: 3px; align-items: flex-end; height: 40px; margin-top: 8px; }
     .nous-timeline-bar { flex: 1; min-width: 4px; border-radius: 2px 2px 0 0; cursor: default; }
-    .nous-pending-card { background: #fffbeb; border: 1px solid #f59e0b; border-radius: 8px; padding: 12px; margin-bottom: 10px; }
-    .nous-pending-card h4 { margin: 0 0 6px 0; font-size: 0.82rem; color: #92400e; }
+    .nous-pending-card { background: rgba(210,153,34,0.12); border: 1px solid var(--yellow); border-radius: 8px; padding: 12px; margin-bottom: 10px; }
+    .nous-pending-card h4 { margin: 0 0 6px 0; font-size: 0.82rem; color: var(--text); }
     .nous-pending-params { font-size: 0.75rem; margin: 6px 0; }
     .nous-pending-params td { padding: 2px 8px; }
     .nous-btn { padding: 6px 14px; border: none; border-radius: 6px; font-size: 0.78rem; cursor: pointer; font-weight: 600; }
-    .nous-btn-approve { background: #16a34a; color: white; }
-    .nous-btn-reject { background: #dc2626; color: white; margin-left: 8px; }
-    .nous-btn-abort { background: #dc2626; color: white; }
+    .nous-btn-approve { background: var(--green); color: var(--bg); }
+    .nous-btn-reject { background: var(--red); color: var(--bg); margin-left: 8px; }
+    .nous-btn-abort { background: var(--red); color: var(--bg); }
     .nous-btn:hover { opacity: 0.85; }
-    .nous-experiment-live { background: #f0fdf4; border: 1px solid #16a34a; border-radius: 8px; padding: 12px; margin-bottom: 10px; }
-    .nous-experiment-live h4 { margin: 0 0 6px 0; font-size: 0.82rem; color: #166534; }
+    .nous-experiment-live { background: var(--green-bg); border: 1px solid var(--green); border-radius: 8px; padding: 12px; margin-bottom: 10px; }
+    .nous-experiment-live h4 { margin: 0 0 6px 0; font-size: 0.82rem; color: var(--text); }
 
     /* Nous Config Panel */
     .nous-config-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.6); z-index: 1000; display: flex; align-items: center; justify-content: center; }
-    .nous-config-dialog { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; width: 900px; max-width: 95vw; max-height: 85vh; display: flex; flex-direction: column; padding: 0; box-shadow: 0 20px 60px rgba(0,0,0,0.5); }
+    .nous-config-dialog { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; width: 900px; max-width: 95vw; max-height: 85vh; display: flex; flex-direction: column; padding: 0; box-shadow: var(--shadow-modal); }
     .nous-config-dialog > h2 { flex-shrink: 0; padding: 24px 24px 0; }
     .nous-config-dialog > .nous-config-body { flex: 1; overflow-y: auto; padding: 16px 24px; }
     .nous-config-dialog > .nous-config-footer { flex-shrink: 0; padding: 12px 24px; border-top: 1px solid var(--border); }
@@ -1541,19 +1487,19 @@
     .nous-config-output-modes { display: flex; gap: 0; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; margin-bottom: 10px; }
     .nous-config-output-mode { flex: 1; padding: 8px 10px; text-align: center; font-size: 0.76rem; cursor: pointer; border: none; background: var(--bg); color: var(--muted); transition: all 0.2s; }
     .nous-config-output-mode:not(:last-child) { border-right: 1px solid var(--border); }
-    .nous-config-output-mode.active { background: #7c3aed; color: white; }
+    .nous-config-output-mode.active { background: var(--purple); color: var(--bg); }
     .nous-config-output-mode:hover:not(.active) { background: rgba(124,58,237,0.1); }
     .nous-config-btn-bar { display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px; }
     .nous-config-btn { padding: 8px 18px; border: none; border-radius: 6px; font-size: 0.82rem; cursor: pointer; font-weight: 600; }
-    .nous-config-btn-save { background: #7c3aed; color: white; }
-    .nous-config-btn-save:hover { background: #6d28d9; }
+    .nous-config-btn-save { background: var(--purple); color: var(--bg); }
+    .nous-config-btn-save:hover { background: color-mix(in srgb, var(--purple) 85%, #000); }
     .nous-config-btn-cancel { background: var(--bg); color: var(--muted); border: 1px solid var(--border); }
     .nous-config-btn-cancel:hover { color: var(--fg); }
     .nous-config-principle-row { display: flex; align-items: center; gap: 8px; padding: 6px 0; border-bottom: 1px solid var(--border); font-size: 0.78rem; }
     .nous-config-principle-row:last-child { border-bottom: none; }
     .nous-config-principle-row .conf { width: 40px; text-align: right; color: var(--muted); font-size: 0.72rem; flex-shrink: 0; }
     .nous-config-principle-row .text { flex: 1; color: var(--fg); }
-    .nous-config-principle-row .del-btn { background: none; border: none; color: #dc2626; cursor: pointer; font-size: 0.75rem; padding: 2px 6px; border-radius: 4px; }
+    .nous-config-principle-row .del-btn { background: none; border: none; color: var(--red); cursor: pointer; font-size: 0.75rem; padding: 2px 6px; border-radius: 4px; }
     .nous-config-principle-row .del-btn:hover { background: rgba(220,38,38,0.1); }
     .nous-trust-ladder { display: flex; align-items: center; gap: 0; margin: 12px 0; }
     .nous-trust-step { flex: 1; text-align: center; padding: 10px 8px; font-size: 0.72rem; border: 1px solid var(--border); position: relative; }
@@ -1645,16 +1591,16 @@
     /* Right info sidebar */
     #hive-info-sidebar {
       position: fixed; right: 0; top: 0; width: 220px; height: 100vh;
-      background: var(--card-bg, #161b22); border-left: 1px solid var(--border, #30363d);
+      background: var(--card-bg); border-left: 1px solid var(--border);
       padding: 20px 16px; box-sizing: border-box; z-index: 100;
-      overflow-y: auto; font-size: 0.82rem; color: var(--fg, #c9d1d9);
+      overflow-y: auto; font-size: 0.82rem; color: var(--fg);
     }
-    #hive-info-sidebar h3 { font-size: 0.95rem; margin: 0 0 10px 0; color: #f0f6fc; }
-    #hive-info-sidebar p { line-height: 1.5; margin: 0 0 16px 0; color: var(--muted, #8b949e); }
+    #hive-info-sidebar h3 { font-size: 0.95rem; margin: 0 0 10px 0; color: var(--text); }
+    #hive-info-sidebar p { line-height: 1.5; margin: 0 0 16px 0; color: var(--muted); }
     #hive-info-sidebar .sidebar-links { list-style: none; padding: 0; margin: 0; }
     #hive-info-sidebar .sidebar-links li { margin-bottom: 10px; }
     #hive-info-sidebar .sidebar-links a {
-      color: #58a6ff; text-decoration: none; display: flex; align-items: center; gap: 6px;
+      color: var(--blue); text-decoration: none; display: flex; align-items: center; gap: 6px;
     }
     #hive-info-sidebar .sidebar-links a:hover { text-decoration: underline; }
     body.has-info-sidebar { margin-right: 220px; }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -65,17 +65,10 @@
     .git-version .git-behind { color: var(--yellow); font-weight: 600; }
     .git-version .git-dirty { color: var(--yellow); }
     .header-spacer { flex: 1; }
-    .widget-dl {
-      font-size: 0.75rem; color: var(--cyan); text-decoration: none;
-      border: 1px solid var(--cyan); border-radius: 6px; padding: 4px 10px;
-      transition: background 0.2s, color 0.2s; margin-left: auto; margin-right: auto;
-    }
-    .widget-dl:hover { background: var(--cyan); color: var(--bg); }
-
-    /* Layout toggle */
-    .layout-toggle { font-size: 0.7rem; color: var(--muted); border: 1px solid var(--border); border-radius: 6px; padding: 4px 10px; cursor: pointer; background: var(--surface); transition: all 0.2s; margin-left: 12px; margin-right: 8px; font-family: inherit; }
-    .layout-toggle:hover { border-color: var(--text); color: var(--text); }
-    .layout-toggle.active { border-color: var(--cyan); color: var(--cyan); }
+    /* .widget-dl / .layout-toggle — ghost buttons (system recipe at end of
+       the style block); only placement-specific properties live here. */
+    .widget-dl { display: inline-block; text-decoration: none; margin-left: auto; margin-right: auto; }
+    .layout-toggle { margin-left: 12px; margin-right: 8px; }
 
     /* ── Light mode ── */
     body.light-mode {
@@ -163,13 +156,7 @@
       padding: 16px 20px; border-top: 1px solid var(--border);
       margin-top: auto;
     }
-    .oc-sidebar-footer .layout-toggle {
-      width: 100%; text-align: center;
-      background: var(--bg); border: 1px solid var(--border);
-      color: var(--muted); font-size: 0.76rem; padding: 8px;
-      border-radius: 8px; cursor: pointer;
-    }
-    .oc-sidebar-footer .layout-toggle:hover { background: var(--surface); color: var(--text); }
+    .oc-sidebar-footer .layout-toggle { width: 100%; text-align: center; padding: 8px; margin: 0; }
 
     /* System resource gauges */
     .system-gauges {
@@ -249,11 +236,6 @@
     }
     .oc-topbar-ts { font-size: 0.75rem; color: var(--muted); }
     .oc-topbar .git-version { color: var(--muted); }
-    .oc-topbar .widget-dl {
-      font-size: 0.72rem; color: var(--oc-accent); border-color: var(--oc-accent);
-      padding: 3px 10px; border-radius: 6px;
-    }
-    .oc-topbar .widget-dl:hover { background: var(--oc-accent); color: var(--bg); }
 
     /* Light main content area */
     body.light-mode {
@@ -463,13 +445,14 @@
     }
     .sum-table tr:last-child td { border-bottom: none; }
     .sum-table tr:hover td { background: rgba(99,102,241,0.08); }
+    /* icon-button (see button system): floating follow-scroll circle */
     .oc-summary-follow-btn {
       position: absolute; bottom: 10px; right: 10px;
       width: 28px; height: 28px; border-radius: 50%;
-      background: rgba(0,0,0,0.6); color: #fff; border: none;
-      cursor: pointer; font-size: 0.75rem; display: none;
+      background: rgba(0,0,0,0.6); color: #fff;
+      font-size: 0.75rem; display: none;
       align-items: center; justify-content: center;
-      box-shadow: 0 2px 8px rgba(0,0,0,0.3); transition: opacity 0.15s;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.3);
     }
     .oc-summary-follow-btn:hover { background: rgba(0,0,0,0.8); }
     .oc-summary-follow-btn.visible { display: flex; }
@@ -517,9 +500,6 @@
 
     /* Light typography now shares --font-ui with dark mode; .doing stays mono in both. */
 
-    /* Light button overrides */
-    body.light-mode .terminal-link { border-color: var(--accent); color: var(--accent); }
-    body.light-mode .terminal-link:hover { background: var(--accent); color: var(--bg); }
 
 
     /* Light governor gauge */
@@ -561,18 +541,15 @@
     .cli-login-btn.logged-in { background: transparent; color: var(--green); cursor: pointer; border: 1px solid var(--green); }
     .cli-login-btn.logged-in:hover { background: rgba(34,197,94,0.1); }
     .gh-auth-banner { background: linear-gradient(135deg, #1a1a2e, #16213e); color: #fff; padding: 12px 24px; display: flex; align-items: center; justify-content: center; gap: 12px; font-size: 0.9rem; z-index: 200; }
-    .gh-auth-banner .gh-auth-btn { background: #238636; color: #fff; border: none; padding: 6px 16px; border-radius: 6px; cursor: pointer; font-weight: 600; font-size: 0.85rem; }
-    .gh-auth-banner .gh-auth-btn:hover { background: #2ea043; }
+    /* .gh-auth-btn — primary button (system recipe at end of style block) */
     .gh-auth-banner .gh-auth-user { color: #58a6ff; font-weight: 600; }
     .gh-app-install-banner { background: color-mix(in srgb, var(--red) 12%, var(--panel)); border: 1px solid var(--red); border-radius: 8px; padding: 16px; margin-bottom: 16px; display: flex; align-items: center; gap: 12px; }
     .gh-app-install-banner .gh-app-title { font-weight: 600; margin-bottom: 4px; color: var(--text); }
     .gh-app-install-banner .gh-app-desc { font-size: 0.85rem; color: var(--text); }
-    .gh-app-install-banner .gh-app-btn { padding: 8px 16px; background: var(--red); color: var(--bg); border-radius: 6px; font-weight: 600; text-decoration: none; white-space: nowrap; border: none; cursor: pointer; font-size: 0.85rem; }
-    .gh-app-install-banner .gh-app-btn:hover { background: color-mix(in srgb, var(--red) 85%, #fff); }
+    /* .gh-app-btn — primary button (system recipe); banner tint carries severity */
+    .gh-app-install-banner .gh-app-btn { display: inline-block; text-decoration: none; white-space: nowrap; }
     .gh-app-install-banner.perm-issue { background: color-mix(in srgb, var(--yellow) 12%, var(--panel)); border-color: var(--yellow); }
     .gh-app-install-banner.perm-issue .gh-app-desc { color: var(--text); }
-    .gh-app-install-banner.perm-issue .gh-app-btn { background: var(--yellow); }
-    .gh-app-install-banner.perm-issue .gh-app-btn:hover { background: color-mix(in srgb, var(--yellow) 85%, #fff); }
     .gh-app-perm-details { font-size: 0.8rem; margin-top: 6px; color: var(--text); }
     .gh-app-perm-details .perm-ok { color: var(--green); }
     .gh-app-perm-details .perm-missing { color: var(--red); font-weight: 600; }
@@ -584,8 +561,7 @@
     .gh-auth-modal .gh-verify-link { display: inline-block; margin: 12px 0; padding: 8px 20px; background: var(--green); color: var(--bg); text-decoration: none; border-radius: 6px; font-weight: 600; }
     .gh-auth-modal .gh-verify-link:hover { background: color-mix(in srgb, var(--green) 85%, #fff); }
     .gh-auth-modal .gh-poll-status { color: var(--muted); font-size: 0.8rem; margin-top: 12px; }
-    .gh-auth-modal .gh-cancel { background: none; border: 1px solid var(--line); padding: 6px 16px; border-radius: 6px; cursor: pointer; color: var(--muted); margin-top: 12px; }
-    .gh-auth-modal .gh-cancel:hover { background: var(--panel-strong); }
+    .gh-auth-modal .gh-cancel { margin-top: 12px; } /* ghost button (system recipe) */
     .gh-setup-modal { background: var(--panel); border-radius: 12px; padding: 32px; max-width: 560px; width: 92%; text-align: left; box-shadow: var(--shadow-modal); max-height: 85vh; overflow-y: auto; }
     .claude-auth-btn { background: #d97706; color: #fff; border: none; padding: 6px 16px; border-radius: 6px; cursor: pointer; font-weight: 600; font-size: 0.85rem; }
     .claude-auth-btn:hover { background: #f59e0b; }
@@ -605,8 +581,7 @@
     .gh-setup-modal .setup-perms h5 { margin: 0 0 6px; font-size: 0.85rem; color: var(--text); }
     .gh-setup-modal .setup-perms ul { margin: 4px 0; padding-left: 18px; font-size: 0.78rem; color: var(--muted); }
     .gh-setup-modal .setup-perms li { margin: 3px 0; }
-    .gh-setup-modal .gh-cancel { background: none; border: 1px solid var(--line); padding: 6px 16px; border-radius: 6px; cursor: pointer; color: var(--muted); margin-top: 12px; display: block; width: 100%; text-align: center; }
-    .gh-setup-modal .gh-cancel:hover { background: var(--panel-strong); }
+    .gh-setup-modal .gh-cancel { margin-top: 12px; display: block; width: 100%; text-align: center; } /* ghost button (system recipe) */
     .agent-state { text-align: right; font-size: 0.75rem; font-weight: 600; margin-top: 6px; }
     .agent-state.working { color: var(--green); }
     .agent-state.idle { color: var(--muted); }
@@ -660,12 +635,7 @@
     }
     .kick-prompt:focus { border-color: var(--accent); }
     .kick-prompt::placeholder { color: var(--muted); }
-    .btn-toggle { cursor: pointer; font-size: 0.7rem; padding: 3px 8px; border-radius: 4px; border: 1px solid var(--border); background: var(--surface); color: var(--muted); transition: all 0.2s; }
-    .btn-toggle:hover { border-color: var(--accent); color: var(--text); }
-    .btn-toggle.paused { background: var(--red-bg); border-color: var(--red); color: var(--red); }
-    .btn-toggle.on-demand { background: rgba(99,102,241,0.15); border-color: var(--indigo); color: var(--indigo); }
-    .btn-toggle.running { background: var(--green-bg); border-color: var(--green); color: var(--green); }
-    .btn-toggle.off { background: rgba(72,79,88,0.15); border-color: color-mix(in srgb, var(--muted) 60%, var(--bg)); color: var(--muted); }
+    /* .btn-toggle — ghost button with status states (system recipe at end of style block) */
     .agent-card.paused { border-color: var(--red); opacity: 0.7; }
     .agent-card.paused .agent-state { color: var(--red); }
     .agent-card.on-demand { border-color: var(--indigo); opacity: 0.85; }
@@ -697,27 +667,7 @@
     .health-ci.good { color: var(--green); }
     .health-ci.warn { color: var(--yellow); }
     .health-ci.bad { color: var(--red); }
-    .btn {
-      font-size: 0.7rem; padding: 3px 8px; border-radius: 4px;
-      border: 1px solid var(--border); background: var(--surface);
-      color: var(--muted); cursor: pointer; font-family: inherit;
-      transition: all 0.2s;
-    }
-    .btn:hover { background: var(--border); color: var(--text); }
-    .terminal-link {
-      font-size: 0.7rem; padding: 3px 8px; border-radius: 4px;
-      border: 1px solid var(--cyan); background: transparent;
-      color: var(--cyan); cursor: pointer; font-family: inherit;
-      text-decoration: none; transition: all 0.2s; display: inline-block;
-    }
-    .terminal-link:hover { background: var(--cyan); color: var(--bg); }
-    .restart-btn {
-      font-size: 0.7rem; padding: 3px 8px; border-radius: 4px;
-      border: 1px solid var(--yellow); background: transparent;
-      color: var(--yellow); cursor: pointer; font-family: inherit;
-      transition: all 0.2s; display: inline-block;
-    }
-    .restart-btn:hover { background: var(--yellow); color: var(--bg); }
+    /* .btn / .terminal-link / .restart-btn — button system recipes at end of style block */
     .backend-select {
       appearance: none; -webkit-appearance: none;
       background: var(--surface); color: var(--muted);
@@ -1152,16 +1102,7 @@
     .hive-dialog-title { font-size: var(--fs-lg); font-weight: 600; color: var(--text); margin-bottom: 12px; }
     .hive-dialog-body { font-size: 0.9rem; color: var(--muted); line-height: 1.5; white-space: pre-wrap; margin-bottom: 20px; }
     .hive-dialog-buttons { display: flex; gap: 10px; justify-content: flex-end; }
-    .hive-dialog-btn {
-      padding: 8px 20px; border-radius: 6px; border: 1px solid var(--border);
-      font-size: 0.85rem; font-weight: 500; cursor: pointer;
-      transition: background 0.15s, border-color 0.15s;
-    }
-    .hive-dialog-btn:hover { border-color: var(--blue); }
-    .hive-dialog-btn.primary { background: var(--blue); color: var(--bg); border-color: var(--blue); }
-    .hive-dialog-btn.primary:hover { background: color-mix(in srgb, var(--blue) 85%, #000); }
-    .hive-dialog-btn.cancel { background: var(--panel-strong); color: var(--muted); border-color: var(--line); }
-    .hive-dialog-btn.cancel:hover { background: var(--line); }
+    /* .hive-dialog-btn(.primary/.cancel) — primary/ghost buttons (system recipe) */
     .config-modal {
       background: var(--surface); border: 1px solid var(--border);
       border-radius: 12px; width: 900px; max-width: 95vw;
@@ -1197,11 +1138,7 @@
       display: flex; gap: 8px; justify-content: flex-end;
       padding: 12px 20px; border-top: 1px solid var(--border);
     }
-    .config-footer .btn { padding: 6px 16px; font-size: 0.8rem; border-radius: 6px; cursor: pointer; }
-    .config-footer .config-save { background: var(--blue); color: var(--bg); border: none; font-weight: 600; }
-    .config-footer .config-save:hover { opacity: 0.9; }
-    .config-footer .config-cancel { background: transparent; color: var(--muted); border: 1px solid var(--border); }
-    .config-footer .config-cancel:hover { color: var(--text); border-color: var(--text); }
+    /* .config-save / .config-cancel — primary/ghost buttons (system recipe) */
 
     .config-field { margin-bottom: 14px; }
     .config-field label { display: block; font-size: var(--fs-xs); color: var(--muted); margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.5px; }
@@ -1241,13 +1178,8 @@
     .config-stat-row .config-field label { font-size: 0.65rem; margin-bottom: 2px; }
     .config-stat-row .config-field input,
     .config-stat-row .config-field select { padding: 4px 6px; font-size: 0.75rem; }
-    .btn-sm { padding: 2px 6px; font-size: 0.7rem; background: var(--surface); border: 1px solid var(--border); border-radius: 3px; cursor: pointer; color: var(--text); }
-    .btn-sm:hover { background: var(--border); }
+    /* .btn-sm / .btn-danger / .btn-add — ghost/danger/secondary buttons (system recipe) */
     .btn-sm:disabled { opacity: 0.3; cursor: default; }
-    .btn-sm.btn-danger { color: var(--red); border-color: var(--red); }
-    .btn-sm.btn-danger:hover { background: rgba(248,81,73,0.15); }
-    .btn-add { padding: 6px 14px; font-size: 0.8rem; background: var(--surface); border: 1px solid var(--blue); border-radius: 4px; cursor: pointer; color: var(--blue); }
-    .btn-add:hover { background: rgba(88,166,255,0.1); }
     .config-stats-list { max-height: 400px; overflow-y: auto; padding-right: 12px; }
 
     .config-info {
@@ -1337,9 +1269,10 @@
       color: var(--red); cursor: pointer; font-size: 0.9rem;
     }
 
+    /* icon-button (see button system): bare glyph button */
     .config-gear {
-      background: none; border: none; cursor: pointer;
-      font-size: 0.9rem; opacity: 0.5; transition: opacity 0.2s;
+      background: none;
+      font-size: 0.9rem; opacity: 0.5;
       padding: 2px 4px; vertical-align: middle;
     }
     .config-gear:hover { opacity: 1; }
@@ -1432,11 +1365,13 @@
     .nous-card { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 14px 16px; margin-bottom: 12px; }
     .nous-card h3 { font-size: var(--fs-md); margin: 0 0 8px 0; color: var(--fg); }
     .nous-mode-toggle { display: flex; gap: 0; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; margin-bottom: 14px; }
-    .nous-mode-btn { flex: 1; padding: 8px 12px; text-align: center; font-size: 0.78rem; cursor: pointer; border: none; background: var(--surface); color: var(--muted); transition: all 0.2s; }
+    /* Segmented mode toggle — active states are tints + colored label
+       (button-system convention), not solid semantic fills. */
+    .nous-mode-btn { flex: 1; padding: 8px 12px; text-align: center; font-size: var(--fs-sm); font-family: var(--font-ui); cursor: pointer; border: none; background: var(--surface); color: var(--muted); transition: all 0.2s; }
     .nous-mode-btn:not(:last-child) { border-right: 1px solid var(--border); }
-    .nous-mode-btn.active-observe { background: var(--blue); color: var(--bg); }
-    .nous-mode-btn.active-suggest { background: var(--yellow); color: var(--bg); }
-    .nous-mode-btn.active-evolve { background: var(--green); color: var(--bg); }
+    .nous-mode-btn.active-observe { background: color-mix(in srgb, var(--blue) 15%, transparent); color: var(--blue); font-weight: 700; }
+    .nous-mode-btn.active-suggest { background: color-mix(in srgb, var(--yellow) 15%, transparent); color: var(--yellow); font-weight: 700; }
+    .nous-mode-btn.active-evolve { background: color-mix(in srgb, var(--green) 15%, transparent); color: var(--green); font-weight: 700; }
     .nous-mode-btn:hover:not([class*="active-"]) { background: var(--panel-strong); }
     .nous-progress { height: 6px; background: var(--border); border-radius: 3px; overflow: hidden; margin: 8px 0; }
     .nous-progress-fill { height: 100%; border-radius: 3px; transition: width 0.5s; }
@@ -1456,11 +1391,8 @@
     .nous-pending-card h4 { margin: 0 0 6px 0; font-size: 0.82rem; color: var(--text); }
     .nous-pending-params { font-size: 0.75rem; margin: 6px 0; }
     .nous-pending-params td { padding: 2px 8px; }
-    .nous-btn { padding: 6px 14px; border: none; border-radius: 6px; font-size: 0.78rem; cursor: pointer; font-weight: 600; }
-    .nous-btn-approve { background: var(--green); color: var(--bg); }
-    .nous-btn-reject { background: var(--red); color: var(--bg); margin-left: 8px; }
-    .nous-btn-abort { background: var(--red); color: var(--bg); }
-    .nous-btn:hover { opacity: 0.85; }
+    /* .nous-btn(-approve/-reject/-abort) — primary/danger buttons (system recipe) */
+    .nous-btn-reject { margin-left: 8px; }
     .nous-experiment-live { background: var(--green-bg); border: 1px solid var(--green); border-radius: 8px; padding: 12px; margin-bottom: 10px; }
     .nous-experiment-live h4 { margin: 0 0 6px 0; font-size: 0.82rem; color: var(--text); }
 
@@ -1491,14 +1423,10 @@
     .nous-config-output-modes { display: flex; gap: 0; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; margin-bottom: 10px; }
     .nous-config-output-mode { flex: 1; padding: 8px 10px; text-align: center; font-size: 0.76rem; cursor: pointer; border: none; background: var(--bg); color: var(--muted); transition: all 0.2s; }
     .nous-config-output-mode:not(:last-child) { border-right: 1px solid var(--border); }
-    .nous-config-output-mode.active { background: var(--purple); color: var(--bg); }
+    .nous-config-output-mode.active { background: color-mix(in srgb, var(--purple) 15%, transparent); color: var(--purple); font-weight: 700; }
     .nous-config-output-mode:hover:not(.active) { background: rgba(124,58,237,0.1); }
     .nous-config-btn-bar { display: flex; justify-content: flex-end; gap: 8px; margin-top: 16px; }
-    .nous-config-btn { padding: 8px 18px; border: none; border-radius: 6px; font-size: 0.82rem; cursor: pointer; font-weight: 600; }
-    .nous-config-btn-save { background: var(--purple); color: var(--bg); }
-    .nous-config-btn-save:hover { background: color-mix(in srgb, var(--purple) 85%, #000); }
-    .nous-config-btn-cancel { background: var(--bg); color: var(--muted); border: 1px solid var(--border); }
-    .nous-config-btn-cancel:hover { color: var(--fg); }
+    /* .nous-config-btn(-save/-cancel) — primary/ghost buttons (system recipe) */
     .nous-config-principle-row { display: flex; align-items: center; gap: 8px; padding: 6px 0; border-bottom: 1px solid var(--border); font-size: 0.78rem; }
     .nous-config-principle-row:last-child { border-bottom: none; }
     .nous-config-principle-row .conf { width: 40px; text-align: right; color: var(--muted); font-size: 0.72rem; flex-shrink: 0; }
@@ -1518,11 +1446,10 @@
     .kb-layout { display: grid; grid-template-columns: 240px 1fr; gap: 16px; min-height: 320px; }
     .kb-sidebar { display: flex; flex-direction: column; gap: 10px; }
     .kb-layer-list { display: flex; flex-direction: column; gap: 4px; }
-    .kb-layer-btn { display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; border: 1px solid var(--border); border-radius: 8px; background: var(--surface); color: var(--fg); font-size: 0.78rem; cursor: pointer; transition: all 0.15s; white-space: nowrap; overflow: hidden; gap: 6px; }
+    /* .kb-layer-btn — ghost button (system recipe); layout + active state here */
+    .kb-layer-btn { display: flex; align-items: center; justify-content: space-between; padding: 8px 12px; white-space: nowrap; overflow: hidden; gap: 6px; }
     .kb-layer-btn .kb-layer-label { display: flex; align-items: center; gap: 5px; overflow: hidden; text-overflow: ellipsis; min-width: 0; }
     .kb-layer-btn .kb-health-indicator { width: 8px; height: 8px; min-width: 8px; border-radius: 50%; display: inline-block; }
-    .kb-layer-btn:hover { border-color: var(--accent); }
-    .kb-layer-btn.active { background: rgba(88,166,255,0.12); border-color: var(--accent); color: var(--accent); font-weight: 600; }
     .kb-layer-count { font-size: 0.7rem; color: var(--muted); padding: 2px 6px; background: var(--bg); border-radius: 4px; }
     .kb-search-box { width: 100%; padding: 7px 10px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg); color: var(--fg); font-size: 0.78rem; }
     .kb-search-box:focus { outline: none; border-color: var(--accent); }
@@ -1665,6 +1592,105 @@
     }
     .agent-card .compact-toggle:hover { background: rgba(255,255,255,0.06); }
     #kb-graph-container:fullscreen { width: 100vw; height: 100vh; border: none; border-radius: 0; }
+
+    /* ══ Button system (Phase 2) — one recipe, four variants ══
+       Existing selectors are grouped here by role; NO classes are renamed
+       (JS reads them). Variants follow the hub identity:
+         primary   = amber CTA (hub .button.primary; label uses --bg so it
+                     stays dark-on-amber in dark mode and light-on-amber in
+                     light mode, where --amber remaps darker)
+         secondary = blue tint bg + blue border (hub .button.secondary)
+         ghost     = line border + muted label, amber affordance on hover
+                     (hub .button.tertiary)
+         danger    = red tint + red border + red label (destructive)
+       Status-flavored one-offs (.btn-toggle states, .restart-btn warning,
+       .terminal-link cyan) keep their semantic colors on the shared base.
+       This block sits last in the style block on purpose: earlier retained
+       rules hold only placement/layout, so the recipes win ties. */
+    .btn, .btn-sm, .btn-add, .btn-toggle, .layout-toggle, .widget-dl,
+    .terminal-link, .restart-btn, .hive-dialog-btn, .kb-layer-btn,
+    .nous-btn, .nous-config-btn,
+    .gh-auth-banner .gh-auth-btn, .gh-app-install-banner .gh-app-btn,
+    .gh-auth-modal .gh-cancel, .gh-setup-modal .gh-cancel,
+    .config-footer .config-save, .config-footer .config-cancel {
+      font-family: var(--font-ui);
+      border: 1px solid transparent;
+      border-radius: var(--radius);
+      line-height: 1.2;
+      cursor: pointer;
+      transition: background 0.15s, color 0.15s, border-color 0.15s, opacity 0.15s;
+    }
+    /* Size steps on the --fs ramp: compact for card/table actions,
+       regular for dialog footers and banner CTAs. */
+    .btn, .btn-toggle, .layout-toggle, .widget-dl, .terminal-link, .restart-btn {
+      font-size: var(--fs-sm); padding: 3px 9px; min-height: 22px;
+    }
+    .btn-sm { font-size: var(--fs-xs); padding: 2px 6px; min-height: 20px; }
+    .btn-add, .nous-btn, .nous-config-btn, .hive-dialog-btn,
+    .gh-auth-banner .gh-auth-btn, .gh-app-install-banner .gh-app-btn,
+    .gh-auth-modal .gh-cancel, .gh-setup-modal .gh-cancel,
+    .config-footer .config-save, .config-footer .config-cancel {
+      font-size: var(--fs-base); padding: 7px 16px; min-height: 32px; font-weight: 600;
+    }
+    .kb-layer-btn { font-size: var(--fs-sm); } /* list button: keeps its own padding */
+    /* ghost */
+    .btn, .btn-sm, .btn-toggle, .layout-toggle, .widget-dl, .kb-layer-btn,
+    .hive-dialog-btn, .nous-btn,
+    .gh-auth-modal .gh-cancel, .gh-setup-modal .gh-cancel,
+    .config-footer .config-cancel, .nous-config-btn-cancel {
+      background: transparent; border-color: var(--line); color: var(--muted);
+    }
+    .btn:hover, .btn-sm:hover, .btn-toggle:hover, .layout-toggle:hover,
+    .widget-dl:hover, .kb-layer-btn:hover, .hive-dialog-btn:hover, .nous-btn:hover,
+    .gh-auth-modal .gh-cancel:hover, .gh-setup-modal .gh-cancel:hover,
+    .config-footer .config-cancel:hover, .nous-config-btn-cancel:hover {
+      border-color: var(--amber); color: var(--text);
+    }
+    /* primary */
+    .hive-dialog-btn.primary, .config-footer .config-save,
+    .nous-config-btn-save, .nous-btn-approve,
+    .gh-auth-banner .gh-auth-btn, .gh-app-install-banner .gh-app-btn {
+      background: var(--amber); border-color: transparent; color: var(--bg); font-weight: 600;
+    }
+    .hive-dialog-btn.primary:hover, .config-footer .config-save:hover,
+    .nous-config-btn-save:hover, .nous-btn-approve:hover,
+    .gh-auth-banner .gh-auth-btn:hover, .gh-app-install-banner .gh-app-btn:hover {
+      background: color-mix(in srgb, var(--amber) 85%, #fff); color: var(--bg);
+    }
+    /* secondary */
+    .btn-add {
+      background: color-mix(in srgb, var(--blue) 10%, transparent);
+      border-color: color-mix(in srgb, var(--blue) 45%, transparent);
+      color: var(--blue);
+    }
+    .btn-add:hover { background: color-mix(in srgb, var(--blue) 18%, transparent); color: var(--blue); border-color: color-mix(in srgb, var(--blue) 45%, transparent); }
+    /* danger */
+    .btn-sm.btn-danger, .nous-btn-reject, .nous-btn-abort {
+      background: color-mix(in srgb, var(--red) 10%, transparent);
+      border-color: color-mix(in srgb, var(--red) 55%, transparent);
+      color: var(--red);
+    }
+    .btn-sm.btn-danger:hover, .nous-btn-reject:hover, .nous-btn-abort:hover {
+      background: color-mix(in srgb, var(--red) 20%, transparent);
+      border-color: color-mix(in srgb, var(--red) 55%, transparent);
+      color: var(--red);
+    }
+    /* status-flavored one-offs on the shared base (semantic colors kept) */
+    .terminal-link { border-color: var(--cyan); color: var(--cyan); text-decoration: none; display: inline-block; }
+    .terminal-link:hover { background: var(--cyan); border-color: var(--cyan); color: var(--bg); }
+    .restart-btn { border-color: var(--yellow); color: var(--yellow); display: inline-block; }
+    .restart-btn:hover { background: var(--yellow); border-color: var(--yellow); color: var(--bg); }
+    .layout-toggle.active { border-color: var(--amber); color: var(--amber); }
+    .btn-toggle.paused { background: var(--red-bg); border-color: var(--red); color: var(--red); }
+    .btn-toggle.on-demand { background: color-mix(in srgb, var(--indigo) 15%, transparent); border-color: var(--indigo); color: var(--indigo); }
+    .btn-toggle.running { background: var(--green-bg); border-color: var(--green); color: var(--green); }
+    .btn-toggle.off { background: color-mix(in srgb, var(--muted) 12%, transparent); border-color: color-mix(in srgb, var(--muted) 60%, var(--bg)); color: var(--muted); }
+    .kb-layer-btn.active { background: color-mix(in srgb, var(--accent) 12%, transparent); border-color: var(--accent); color: var(--accent); font-weight: 600; }
+    /* icon-button variant — bare glyph buttons (.config-gear stays this) */
+    .config-gear, .oc-summary-follow-btn {
+      border: none; cursor: pointer; font-family: var(--font-ui);
+      transition: opacity 0.15s, background 0.15s;
+    }
   </style>
 </head>
 <body>
@@ -1937,7 +1963,7 @@
       <div class="gh-app-title">GitHub App Not Installed</div>
       <div class="gh-app-desc">This hive cannot create issues or advisory reports. Install the Hive Hub GitHub App on your repository to enable full functionality.</div>
     </div>
-    <button onclick="recheckGitHubApp()" class="gh-app-btn" style="background:#374151;margin-right:8px" id="gh-app-recheck-btn">Re-check</button>
+    <button onclick="recheckGitHubApp()" class="gh-app-btn" style="background:transparent;border-color:var(--line);color:var(--muted);margin-right:8px" id="gh-app-recheck-btn">Re-check</button>
     <a id="gh-app-install-link" href="" target="_blank" rel="noopener" class="gh-app-btn">Install GitHub App</a>
   </div>
   <div id="hub-banner" style="display:none"></div>

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -10,13 +10,34 @@
   <title>Hive Dashboard</title>
   <style>
     :root {
-      --bg: #0d1117; --surface: #161b22; --border: #30363d;
-      --text: #e6edf3; --muted: #8b949e; --green: #3fb950;
-      --yellow: #d29922; --red: #f85149; --blue: #58a6ff;
-      --cyan: #39d2c0; --purple: #bc8cff;
-      --oc-accent: #f85149; --oc-accent-light: rgba(248,81,73,0.1);
-      --green-bg: rgba(63,185,80,0.15); --green-border: rgba(63,185,80,0.3);
-      --red-bg: rgba(248,81,73,0.15); --red-border: rgba(248,81,73,0.3);
+      /* ── Authoritative design tokens (hub-aligned dark palette) ── */
+      --bg: #080b0f; --bg-soft: #0d1218;
+      --panel: #121922; --panel-strong: #17212d;
+      --text: #f6f8fb; --muted: #a8b3c2; --line: #263545;
+      /* --amber is brand/chrome ONLY — never use it for status. */
+      --amber: #f4c75f;
+      /* Semantic status colors (agent + governor state) — must stay distinct. */
+      --green: #74df9a; --blue: #80bfff; --red: #ff7e7e;
+      --yellow: #d29922; /* status warning — warm ochre, distinguishable from brand amber */
+      --indigo: #818cf8; /* on-demand agent state */
+      --cyan: #7bd8cd; --purple: #c0a6f0; /* desaturated toward the hub palette */
+      /* Radii / shadows / fonts — defined in Phase 0, applied in later phases. */
+      --radius-sm: 4px; --radius: 6px; --radius-lg: 12px;
+      --shadow-modal: 0 20px 60px rgba(0, 0, 0, 0.5);
+      --font-ui: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
+      /* Layout */
+      --sidebar-w: 302px;
+      /* ── Legacy aliases — every old token name keeps working ── */
+      --surface: var(--panel);
+      --border: var(--line);
+      --fg: var(--text);        /* was referenced but never defined */
+      --card-bg: var(--panel);  /* was referenced only via var(--card-bg, #161b22) fallback */
+      --accent: var(--blue);    /* mode accent: blue in dark, remapped to red in light */
+      --oc-accent: var(--red);
+      --oc-accent-light: rgba(255, 126, 126, 0.12);
+      --green-bg: rgba(116, 223, 154, 0.15); --green-border: rgba(116, 223, 154, 0.35);
+      --red-bg: rgba(255, 126, 126, 0.15); --red-border: rgba(255, 126, 126, 0.35);
     }
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
@@ -46,11 +67,19 @@
 
     /* ── Light mode ── */
     body.light-mode {
-      --bg: #f8f9fa; --surface: #ffffff; --border: #e5e7eb;
-      --text: #1a1a2e; --muted: #6b7280; --green: #16a34a;
-      --yellow: #ca8a04; --red: #dc2626; --blue: #2563eb;
+      /* Light mode = token remap. Old names (--surface/--border/--fg/…) follow
+         automatically via the :root aliases onto --panel/--line/--text. */
+      --bg: #f8f9fa; --bg-soft: #ffffff;
+      --panel: #ffffff; --panel-strong: #eef1f5;
+      --text: #1a1a2e; --muted: #6b7280; --line: #e5e7eb;
+      --amber: #b45309; /* brand amber darkened for readability on white */
+      --green: #16a34a; --blue: #2563eb; --red: #dc2626;
+      --yellow: #ca8a04;
+      --indigo: #4f46e5;
       --cyan: #0891b2; --purple: #7c3aed;
-      --oc-accent: #dc2626; --oc-accent-light: rgba(220,38,38,0.08);
+      --shadow-modal: 0 20px 60px rgba(0, 0, 0, 0.15);
+      --accent: var(--red); /* light mode accent is red (openclaw identity) */
+      --oc-accent-light: rgba(220,38,38,0.08);
       --green-bg: #f0fdf4; --green-border: #bbf7d0;
       --red-bg: #fef2f2; --red-border: #fecaca;
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
@@ -60,7 +89,6 @@
     body.light-mode .gh-rate-alert { border-radius: 8px; }
 
     /* Light sidebar */
-    :root { --sidebar-w: 302px; }
     .oc-sidebar {
       position: fixed; top: 0; left: 0; bottom: 0; width: var(--sidebar-w);
       background: var(--surface); border-right: 1px solid var(--border);

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2703,7 +2703,11 @@
       // summary text + status dot to avoid full DOM rebuild (prevents scroll jumps).
       // Only update summary when detailSummary is available — never replace long
       // ring buffer content with short liveSummary fallback.
-      if (existingSummary && detail.dataset.agent === a.name) {
+      // The fingerprint guards the fields only the full template renders
+      // (method/model/pins): without it a CLI or model switch stayed stale
+      // in the focused panel until a hard refresh.
+      const cfgSig = [a.cli || '', a.model || '', a.pinnedCli ? 1 : 0, a.pinnedModel ? 1 : 0, a.pinnedBoth ? 1 : 0].join('|');
+      if (existingSummary && detail.dataset.agent === a.name && detail.dataset.cfgSig === cfgSig) {
         if (a.detailSummary) {
           const newText = escBlock(a.detailSummary);
           if (existingSummary.innerHTML !== newText) {
@@ -2721,6 +2725,7 @@
         return;
       }
       detail.dataset.agent = a.name;
+      detail.dataset.cfgSig = cfgSig;
 
       const gov = window._lastStatus?.governor || {};
       const govMode = (gov.mode || 'unknown').toLowerCase();
@@ -8016,6 +8021,9 @@ function burnAreaChart() {
         applyPinOverrides(data.agents || []);
         renderAgents(data.agents || []);
         renderGovernor(data.governor || {}, data.cadenceMatrix || [], data);
+        // Keep the focused agent detail in sync with fresh payloads — its
+        // fast path only rebuilds when the config fingerprint changes.
+        if (_ocSelectedAgent) ocRenderAgentDetail();
       }
       renderTokens(data.tokens || {});
       renderAdvisoryDigest(data.advisoryDigest || null);
@@ -9277,6 +9285,12 @@ function burnAreaChart() {
         const a = window._lastAgents.find(x => x.name === agent);
         if (a) { a.cli = backend; renderAgents(window._lastAgents); }
       }
+      // Reflect the switch everywhere it is shown (focused detail panel,
+      // cadence-matrix method column), then confirm against the server.
+      ocRenderAgentDetail();
+      const lastData = window._lastStatus || {};
+      renderGovernor(lastData.governor || {}, lastData.cadenceMatrix || [], lastData);
+      fetch('/api/status').then(r => r.json()).then(render).catch(() => {});
     }
 
     async function updateModelDropdown(agent, backend) {
@@ -9312,6 +9326,12 @@ function burnAreaChart() {
         const a = window._lastAgents.find(x => x.name === agent);
         if (a) { a.model = model; renderAgents(window._lastAgents); }
       }
+      // Reflect the switch everywhere it is shown (focused detail panel,
+      // cadence-matrix model column), then confirm against the server.
+      ocRenderAgentDetail();
+      const lastData = window._lastStatus || {};
+      renderGovernor(lastData.governor || {}, lastData.cadenceMatrix || [], lastData);
+      fetch('/api/status').then(r => r.json()).then(render).catch(() => {});
     }
 
     const PIN_OVERRIDE_TTL_MS = 60000;

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1207,9 +1207,9 @@
     .config-info {
       display: inline-flex; align-items: center; justify-content: center;
       width: 15px; height: 15px; border-radius: 50%;
-      background: color-mix(in srgb, var(--blue) 12%, transparent);
-      border: 1px solid color-mix(in srgb, var(--blue) 45%, transparent);
-      color: var(--blue); font-size: 0.6rem; line-height: 1;
+      background: color-mix(in srgb, var(--blue) 18%, var(--panel));
+      border: 1px solid color-mix(in srgb, var(--blue) 60%, transparent);
+      color: var(--blue); font-size: 0.62rem; line-height: 1;
       font-weight: 700; cursor: help; margin-left: 4px; position: relative;
       vertical-align: middle; flex-shrink: 0;
     }
@@ -11030,6 +11030,7 @@ function burnAreaChart() {
           <div class="config-field">
             <label>Color <span class="config-info">i<span class="config-tooltip">The agent's identity color, used to represent it in token charts and sparklines. Does not affect card or status styling.</span></span></label>
             <input type="color" id="cfg-agent-color" value="${esc(g.color || '#3498db')}" style="height:34px" onchange="markDirty('general','color',this.value)">
+            <div style="font-size:0.65rem;color:var(--muted);margin-top:2px">Identity color for this agent's token charts and sparklines.</div>
           </div>
         </div>
         <div class="config-field-row">

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -73,8 +73,7 @@
 
     /* ── Light mode ── */
     body.light-mode {
-      /* Light mode = token remap. Old names (--surface/--border/--fg/…) follow
-         automatically via the :root aliases onto --panel/--line/--text. */
+      /* Light mode = token remap. */
       --bg: #f7f8fa; --bg-soft: #ffffff;
       --panel: #ffffff; --panel-strong: #eef1f5;
       --text: #111827; --muted: #6b7280; --line: #e5e7eb;
@@ -89,6 +88,17 @@
       --oc-accent-light: rgba(220,38,38,0.08);
       --green-bg: #f0fdf4; --green-border: #bbf7d0;
       --red-bg: #fef2f2; --red-border: #fecaca;
+      /* Legacy aliases MUST be re-declared here: a var() inside a custom
+         property resolves on the element that DECLARES it, so the :root
+         alias copies freeze to the dark values and descendants inherit
+         that resolved result. Without these lines everything styled via
+         --surface/--border/--fg/--card-bg/--oc-accent (sidebar, topbar,
+         cards, info sidebar) stays dark in light mode. */
+      --surface: var(--panel);
+      --border: var(--line);
+      --fg: var(--text);
+      --card-bg: var(--panel);
+      --oc-accent: var(--red);
       background: var(--bg); color: var(--text);
     }
     body.light-mode .connection { display: none; }
@@ -530,9 +540,9 @@
     .cli-login-btn .cli-icon.copilot-icon { background-color: #24292f; border-radius: 50%; background-size: 11px; background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAHdSURBVHgBvVeLbYNADDVdoHSDG4ENwgjpBMkG6QbtBkknIBtEnaDdADoBbEA6gWuXQ3GR7wOc8qSnSPhvkzuTQSQQMaefLXFDLIiGmFvxldgRG+IX8SPLsiukAAU2xDOxx3mo2BaWgismHnE9jrZ7s6tuMR1ajO0GKRaYNrhMorh35VoSBjwzbxWDCy5Lil/ailgrPnMtAe2F2wn5Hm+J9Nbxp2AvZNKuVPwetdZrKJQuGfCPMI/0baTSOai0EJ4EKlmVC3tYCdRHwOBR5Q8wHK8aOhiO1bVorK8phqPd0/4dJIKnCxULa4dw3vEZTkK7S2oegVH0u2S3mfCpPDOcQNJKPdAK+nsJ7wW10Ixn4xA+pRwDD1x5fOUOdA6bDaQLXjpEHSfw7RC+QDrsHc+b8ZJxYXUS5OPg8b8bj2LfvvcKCxEIzshHRXkavhG3+H8HaK2zMiJoYXXrQPBKGplJsK3tjObk4gl+wXiYqfFJCHublLailZ4EysjgJ814upKdRHc4uYp4gPAIQmjRdc8oFRcwExHBjdTPFAcclOc8Kp5huNN/iI90Or5DIAGHqCM+k30DEVU41/MI26jKo4DDX3JtAidcs1vg7eM0NoEeb98EBlIBAyu50DNzKv4F8Mg9kvfoSM0AAAAASUVORK5CYII='); }
     .cli-login-btn.logged-in { background: transparent; color: var(--green); cursor: pointer; border: 1px solid var(--green); }
     .cli-login-btn.logged-in:hover { background: rgba(34,197,94,0.1); }
-    .gh-auth-banner { background: linear-gradient(135deg, #1a1a2e, #16213e); color: #fff; padding: 12px 24px; display: flex; align-items: center; justify-content: center; gap: 12px; font-size: 0.9rem; z-index: 200; }
+    .gh-auth-banner { background: var(--panel-strong); border-bottom: 1px solid var(--line); color: var(--text); padding: 12px 24px; display: flex; align-items: center; justify-content: center; gap: 12px; font-size: 0.9rem; z-index: 200; }
     /* .gh-auth-btn — primary button (system recipe at end of style block) */
-    .gh-auth-banner .gh-auth-user { color: #58a6ff; font-weight: 600; }
+    .gh-auth-banner .gh-auth-user { color: var(--blue); font-weight: 600; }
     .gh-app-install-banner { background: color-mix(in srgb, var(--red) 12%, var(--panel)); border: 1px solid var(--red); border-radius: 8px; padding: 16px; margin-bottom: 16px; display: flex; align-items: center; gap: 12px; }
     .gh-app-install-banner .gh-app-title { font-weight: 600; margin-bottom: 4px; color: var(--text); }
     .gh-app-install-banner .gh-app-desc { font-size: 0.85rem; color: var(--text); }
@@ -1753,7 +1763,7 @@
     <p>Enter this code on GitHub to authorize Hive:</p>
     <div style="position:relative;display:inline-block">
       <div class="device-code" id="gh-device-code">--------</div>
-      <button id="gh-copy-btn" onclick="copyDeviceCode()" style="position:absolute;top:4px;right:4px;background:#238636;color:#fff;border:none;padding:3px 10px;border-radius:4px;cursor:pointer;font-size:0.7rem;font-weight:600">Copy</button>
+      <button id="gh-copy-btn" onclick="copyDeviceCode()" style="position:absolute;top:4px;right:4px;background:var(--green);color:var(--bg);border:none;padding:3px 10px;border-radius:4px;cursor:pointer;font-size:0.7rem;font-weight:600">Copy</button>
     </div>
     <a id="gh-verify-link" class="gh-verify-link" href="https://github.com/login/device" target="_blank" rel="noopener">Open GitHub →</a>
     <div class="gh-poll-status" id="gh-poll-status">Waiting for authorization...</div>
@@ -1787,7 +1797,7 @@
       <div class="setup-steps">
         <strong>Create a GitHub App:</strong>
         <ol>
-          <li>Go to <a id="setup-custom-apps-link" href="https://github.com/settings/apps/new" target="_blank" rel="noopener" style="color:#238636">github.com/settings/apps/new</a> (or your org's Settings &rarr; Developer settings &rarr; GitHub Apps)</li>
+          <li>Go to <a id="setup-custom-apps-link" href="https://github.com/settings/apps/new" target="_blank" rel="noopener" style="color:var(--green)">github.com/settings/apps/new</a> (or your org's Settings &rarr; Developer settings &rarr; GitHub Apps)</li>
           <li>Set the app name (e.g. <code>my-hive</code>)</li>
           <li>Homepage URL: any URL (e.g. <code>https://github.com/kubestellar/hive</code>)</li>
           <li>Uncheck "Webhook &rarr; Active" (not needed)</li>
@@ -1798,7 +1808,7 @@
           <li>Install the app on your org/repos and note the <strong>Installation ID</strong> (from the URL after install)</li>
           <li>Update <code>hive.yaml</code>:</li>
         </ol>
-        <pre style="background:#1a1a2e;color:#e5e7eb;padding:12px;border-radius:6px;font-size:0.75rem;overflow-x:auto">github:
+        <pre style="background:var(--panel-strong);color:var(--text);padding:12px;border-radius:6px;font-size:0.75rem;overflow-x:auto">github:
   app_id: &lt;your-app-id&gt;
   installation_id: &lt;your-installation-id&gt;
   key_file: /secrets/gh-app-key.pem
@@ -1868,7 +1878,7 @@
         with increasing autonomy. Agents are additive — higher levels build on lower ones.
       </p>
       <div id="acmm-packs-list" style="display:flex;flex-direction:column;gap:12px"></div>
-      <div id="acmm-apply-error" style="color:#dc2626;font-size:0.8rem;margin-top:12px;display:none"></div>
+      <div id="acmm-apply-error" style="color:var(--red);font-size:0.8rem;margin-top:12px;display:none"></div>
     </div>
   </div>
 </div>
@@ -1913,11 +1923,11 @@
     </div>
     <div class="oc-nav-group">
       <div class="oc-nav-label">Resources</div>
-      <a class="oc-nav-item" data-section="repos-section" onclick="ocNavigate('repos-section')"><span class="oc-nav-emoji">📦</span><span class="oc-nav-text">Repos</span><span id="repos-sidebar-badge" style="display:none;margin-left:auto;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:700;background:rgba(88,166,255,0.15);color:#58a6ff;border:1px solid rgba(88,166,255,0.3)"></span></a>
+      <a class="oc-nav-item" data-section="repos-section" onclick="ocNavigate('repos-section')"><span class="oc-nav-emoji">📦</span><span class="oc-nav-text">Repos</span><span id="repos-sidebar-badge" style="display:none;margin-left:auto;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:700;background:rgba(88,166,255,0.15);color:var(--blue);border:1px solid rgba(88,166,255,0.3)"></span></a>
       <a class="oc-nav-item" data-section="beads-section" onclick="ocNavigate('beads-section')"><span class="oc-nav-emoji">🔮</span><span class="oc-nav-text">Beads</span></a>
       <a class="oc-nav-item" data-section="inception-section" onclick="ocNavigate('inception-section')"><span class="oc-nav-emoji">💡</span><span class="oc-nav-text">Inception</span></a>
       <a class="oc-nav-item" data-section="knowledge-section" onclick="ocNavigate('knowledge-section')"><span class="oc-nav-emoji">📚</span><span class="oc-nav-text">Knowledge</span></a>
-      <a class="oc-nav-item" data-section="contributors-section" onclick="ocNavigate('contributors-section')"><span class="oc-nav-emoji">👥</span><span class="oc-nav-text">Contributors</span><span id="contributors-sidebar-badge" style="display:none;margin-left:auto;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:700;background:#238636;color:#fff"></span></a>
+      <a class="oc-nav-item" data-section="contributors-section" onclick="ocNavigate('contributors-section')"><span class="oc-nav-emoji">👥</span><span class="oc-nav-text">Contributors</span><span id="contributors-sidebar-badge" style="display:none;margin-left:auto;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:700;background:var(--green);color:var(--bg)"></span></a>
       <a class="oc-nav-item" data-section="audit-section" onclick="ocNavigate('audit-section')"><span class="oc-nav-emoji">📋</span><span class="oc-nav-text">Audit Log</span></a>
       <a class="oc-nav-item" data-section="nous-section" onclick="ocNavigate('nous-section')"><span class="oc-nav-emoji">🧪</span><span class="oc-nav-text">Strategy Lab</span></a>
       <a class="oc-nav-item" href="/api/docs" target="_blank"><span class="oc-nav-emoji">📘</span><span class="oc-nav-text">API Spec (Redoc)</span></a>
@@ -1964,13 +1974,13 @@
       <span id="oc-git-version" class="git-version"></span>
       <a href="/api/widget" class="widget-dl" title="Download Übersicht widget">⬇ Widget</a>
       <div id="oc-gh-avatar-wrap" style="display:none;position:relative">
-        <img id="oc-gh-avatar" src="" alt="" style="width:28px;height:28px;border-radius:50%;cursor:pointer;border:2px solid #3fb950;vertical-align:middle" onclick="toggleGHUserMenu()">
-        <div id="oc-gh-user-menu" style="display:none;position:absolute;right:0;top:34px;background:#161b22;border:1px solid #30363d;border-radius:8px;padding:4px 0;min-width:160px;z-index:9999;box-shadow:0 8px 24px rgba(0,0,0,0.4)">
-          <div style="padding:8px 16px;border-bottom:1px solid #21262d;color:#f0f6fc;font-weight:600;font-size:0.85rem" id="oc-gh-menu-user"></div>
-          <div id="oc-gh-menu-role" style="display:none;padding:2px 16px 6px;border-bottom:1px solid #21262d;font-size:0.72rem;color:#8b949e"></div>
-          <a href="/api/config/download" id="oc-gh-menu-download" style="display:none;padding:8px 16px;color:#e6edf3;text-decoration:none;font-size:0.82rem">Download hive.yaml</a>
-          <a href="/api/docs" target="_blank" style="display:block;padding:8px 16px;color:#e6edf3;text-decoration:none;font-size:0.82rem">API Docs ↗</a>
-          <button onclick="ghLogout()" style="display:block;width:100%;text-align:left;padding:8px 16px;background:none;border:none;color:#e6edf3;cursor:pointer;font-size:0.82rem">Sign out</button>
+        <img id="oc-gh-avatar" src="" alt="" style="width:28px;height:28px;border-radius:50%;cursor:pointer;border:2px solid var(--green);vertical-align:middle" onclick="toggleGHUserMenu()">
+        <div id="oc-gh-user-menu" style="display:none;position:absolute;right:0;top:34px;background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:4px 0;min-width:160px;z-index:9999;box-shadow:0 8px 24px rgba(0,0,0,0.4)">
+          <div style="padding:8px 16px;border-bottom:1px solid var(--line);color:var(--text);font-weight:600;font-size:0.85rem" id="oc-gh-menu-user"></div>
+          <div id="oc-gh-menu-role" style="display:none;padding:2px 16px 6px;border-bottom:1px solid var(--line);font-size:0.72rem;color:var(--muted)"></div>
+          <a href="/api/config/download" id="oc-gh-menu-download" style="display:none;padding:8px 16px;color:var(--text);text-decoration:none;font-size:0.82rem">Download hive.yaml</a>
+          <a href="/api/docs" target="_blank" style="display:block;padding:8px 16px;color:var(--text);text-decoration:none;font-size:0.82rem">API Docs ↗</a>
+          <button onclick="ghLogout()" style="display:block;width:100%;text-align:left;padding:8px 16px;background:none;border:none;color:var(--text);cursor:pointer;font-size:0.82rem">Sign out</button>
         </div>
       </div>
       <button class="gh-auth-btn" id="oc-gh-login-btn" onclick="startGHLogin()" style="display:none;font-size:0.75rem;padding:3px 10px">Sign in</button>
@@ -2095,8 +2105,8 @@
     <div style="display:flex;align-items:center;gap:12px;margin-bottom:12px;flex-wrap:wrap" class="section-header-toggle" onclick="toggleSection('contributors-section')">
       <span class="section-chevron">▼</span>
       <h2 class="section-label" style="margin:0;">👥 Contributors <span id="contributors-status-badge" style="font-size:0.7rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span></h2>
-      <a href="/contribute" target="_blank" onclick="event.stopPropagation()" style="font-size:0.75rem;padding:4px 12px;background:#238636;color:#fff;border-radius:6px;text-decoration:none;font-weight:600">Share /contribute link &rarr;</a>
-      <a href="/leaderboard" target="_blank" onclick="event.stopPropagation()" style="font-size:0.75rem;padding:4px 12px;background:transparent;color:#58a6ff;border:1px solid #58a6ff;border-radius:6px;text-decoration:none">🏆 Leaderboard</a>
+      <a href="/contribute" target="_blank" onclick="event.stopPropagation()" style="font-size:0.75rem;padding:4px 12px;background:var(--green);color:var(--bg);border-radius:6px;text-decoration:none;font-weight:600">Share /contribute link &rarr;</a>
+      <a href="/leaderboard" target="_blank" onclick="event.stopPropagation()" style="font-size:0.75rem;padding:4px 12px;background:transparent;color:var(--blue);border:1px solid var(--blue);border-radius:6px;text-decoration:none">🏆 Leaderboard</a>
     </div>
     <div class="section-body">
       <div id="contributors-filters" style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:12px"></div>
@@ -2124,7 +2134,7 @@
           <input type="checkbox" id="logs-follow" checked> Follow
         </label>
       </div>
-      <div id="logs-output" style="background: #1a1a2e; color: #e2e8f0; font-family: var(--font-mono); font-size: 0.75rem; line-height: 1.5; padding: 14px; border-radius: 8px; max-height: 500px; overflow-y: auto; white-space: pre-wrap; word-break: break-all;"></div>
+      <div id="logs-output" style="background: var(--panel-strong); color: var(--text); font-family: var(--font-mono); font-size: 0.75rem; line-height: 1.5; padding: 14px; border-radius: 8px; max-height: 500px; overflow-y: auto; white-space: pre-wrap; word-break: break-all;"></div>
     </div>
   </div>
 
@@ -2143,28 +2153,28 @@
   <aside id="hive-info-sidebar">
     <h3>What is Hive?</h3>
     <p>Hive is an open source AI agent orchestration system. A fleet of specialized agents autonomously maintain GitHub repositories &mdash; triaging issues, writing fixes, opening PRs, and merging on green CI. A governor dynamically adjusts agent pace based on issue queue depth across four modes (idle/quiet/busy/surge). ACMM maturity levels (1&ndash;6) control which agents are active and what actions they can take.</p>
-    <h4 style="font-size:0.82rem;color:#f0f6fc;margin:14px 0 6px 0;">Agents</h4>
-    <ul style="list-style:none;padding:0;margin:0 0 14px 0;font-size:0.78rem;color:#8b949e;line-height:1.6;">
-      <li><strong style="color:#c9d1d9;">Supervisor</strong> &mdash; agent health monitoring, sweep analysis, stall detection, escalation</li>
-      <li><strong style="color:#c9d1d9;">Scanner</strong> &mdash; triages issues, dispatches fixes, opens and merges PRs</li>
-      <li><strong style="color:#c9d1d9;">Guide</strong> &mdash; documentation gaps, onboarding analysis, advisory reviews</li>
-      <li><strong style="color:#c9d1d9;">CI-Maintainer</strong> &mdash; CI/CD health, workflow fixes, build monitoring</li>
-      <li><strong style="color:#c9d1d9;">Quality</strong> &mdash; test coverage, integration tests, quality gates</li>
-      <li><strong style="color:#c9d1d9;">Sec-Check</strong> &mdash; security scanning, PR security gate, contributor vetting</li>
-      <li><strong style="color:#c9d1d9;">Architect</strong> &mdash; cross-cutting RFCs, refactors, new features</li>
-      <li><strong style="color:#c9d1d9;">Strategist</strong> &mdash; experiment design, A/B testing, strategy lab</li>
-      <li><strong style="color:#c9d1d9;">Outreach</strong> &mdash; ADOPTERS outreach, ACMM badge campaigns, community engagement</li>
-      <li><strong style="color:#c9d1d9;">Brainstorm</strong> &mdash; on-demand ideation via Inception; proposes features and architecture directions</li>
+    <h4 style="font-size:0.82rem;color:var(--text);margin:14px 0 6px 0;">Agents</h4>
+    <ul style="list-style:none;padding:0;margin:0 0 14px 0;font-size:0.78rem;color:var(--muted);line-height:1.6;">
+      <li><strong style="color:var(--text);">Supervisor</strong> &mdash; agent health monitoring, sweep analysis, stall detection, escalation</li>
+      <li><strong style="color:var(--text);">Scanner</strong> &mdash; triages issues, dispatches fixes, opens and merges PRs</li>
+      <li><strong style="color:var(--text);">Guide</strong> &mdash; documentation gaps, onboarding analysis, advisory reviews</li>
+      <li><strong style="color:var(--text);">CI-Maintainer</strong> &mdash; CI/CD health, workflow fixes, build monitoring</li>
+      <li><strong style="color:var(--text);">Quality</strong> &mdash; test coverage, integration tests, quality gates</li>
+      <li><strong style="color:var(--text);">Sec-Check</strong> &mdash; security scanning, PR security gate, contributor vetting</li>
+      <li><strong style="color:var(--text);">Architect</strong> &mdash; cross-cutting RFCs, refactors, new features</li>
+      <li><strong style="color:var(--text);">Strategist</strong> &mdash; experiment design, A/B testing, strategy lab</li>
+      <li><strong style="color:var(--text);">Outreach</strong> &mdash; ADOPTERS outreach, ACMM badge campaigns, community engagement</li>
+      <li><strong style="color:var(--text);">Brainstorm</strong> &mdash; on-demand ideation via Inception; proposes features and architecture directions</li>
     </ul>
-    <h4 style="font-size:0.82rem;color:#f0f6fc;margin:14px 0 6px 0;">Key Features</h4>
-    <ul style="list-style:none;padding:0;margin:0 0 14px 0;font-size:0.78rem;color:#8b949e;line-height:1.6;">
-      <li><strong style="color:#c9d1d9;">ACMM Levels</strong> &mdash; 6 maturity levels from advisory-only (L1) to fully autonomous (L6)</li>
-      <li><strong style="color:#c9d1d9;">Governor</strong> &mdash; dynamic mode switching with per-agent cadences and budget controls</li>
-      <li><strong style="color:#c9d1d9;">Inception</strong> &mdash; interactive project scaffolding via brainstorm agent; generates llm-wiki knowledge vaults and spec-kit project specifications through clarify/structure/scaffold phases</li>
-      <li><strong style="color:#c9d1d9;">Knowledge Base</strong> &mdash; shared facts, wiki vaults, and cross-agent knowledge priming</li>
-      <li><strong style="color:#c9d1d9;">Audit Logging</strong> &mdash; all agent state changes logged with who/when/why for diagnostics</li>
-      <li><strong style="color:#c9d1d9;">ACMM Proxy</strong> &mdash; per-agent HTTP proxy enforcing mode-based action restrictions</li>
-      <li><strong style="color:#c9d1d9;">Contributing</strong> &mdash; community agent contribution system; submit, review, and install custom agents from a shared registry</li>
+    <h4 style="font-size:0.82rem;color:var(--text);margin:14px 0 6px 0;">Key Features</h4>
+    <ul style="list-style:none;padding:0;margin:0 0 14px 0;font-size:0.78rem;color:var(--muted);line-height:1.6;">
+      <li><strong style="color:var(--text);">ACMM Levels</strong> &mdash; 6 maturity levels from advisory-only (L1) to fully autonomous (L6)</li>
+      <li><strong style="color:var(--text);">Governor</strong> &mdash; dynamic mode switching with per-agent cadences and budget controls</li>
+      <li><strong style="color:var(--text);">Inception</strong> &mdash; interactive project scaffolding via brainstorm agent; generates llm-wiki knowledge vaults and spec-kit project specifications through clarify/structure/scaffold phases</li>
+      <li><strong style="color:var(--text);">Knowledge Base</strong> &mdash; shared facts, wiki vaults, and cross-agent knowledge priming</li>
+      <li><strong style="color:var(--text);">Audit Logging</strong> &mdash; all agent state changes logged with who/when/why for diagnostics</li>
+      <li><strong style="color:var(--text);">ACMM Proxy</strong> &mdash; per-agent HTTP proxy enforcing mode-based action restrictions</li>
+      <li><strong style="color:var(--text);">Contributing</strong> &mdash; community agent contribution system; submit, review, and install custom agents from a shared registry</li>
     </ul>
     <ul class="sidebar-links">
       <li><a href="https://arxiv.org/abs/2604.09388" target="_blank" rel="noopener">&#128196; ACMM Paper</a></li>
@@ -2590,14 +2600,14 @@
         const OC_GAUGE_MAX = Math.max(OC_THRESH_SURGE + 10, govActionable + 5);
         const gaugePct = Math.min(govActionable / OC_GAUGE_MAX * 100, 100);
         govOuter.innerHTML = `
-          <div class="gov-metric"><span class="gm-label">timer</span><span class="gm-val" style="color:#16a34a">${gov.active !== false ? '● active' : '○ off'}</span></div>
+          <div class="gov-metric"><span class="gm-label">timer</span><span class="gm-val" style="color:var(--green)">${gov.active !== false ? '● active' : '○ off'}</span></div>
           <div class="gov-metric"><span class="gm-label">mode</span><span class="gm-val ${govModeClass}">${esc(gov.mode || '—')}</span></div>
           <div class="gov-metric"><span class="gm-label">actionable</span><span class="gm-val">${govActionable}</span></div>
           <div class="gov-metric"><span class="gm-label">PRs</span><span class="gm-val">${govPrs}</span></div>
           <div class="gov-metric"><span class="gm-label">MTTR</span><span class="gm-val" style="color:${MTTR_COLOR}">${formatFixTime(itmMedian)}</span></div>
-          <div class="gov-metric" title="${esc((window._lastStatus?.hold?.items || []).map(h => (h.type === 'pr' ? 'PR' : 'Issue') + ' ' + h.repo + '#' + h.number + ': ' + h.title).join('\n') || 'No items on hold')}"><span class="gm-label">on hold</span><span class="gm-val" style="color:#d29922">${window._lastStatus?.hold?.total || 0}</span></div>
+          <div class="gov-metric" title="${esc((window._lastStatus?.hold?.items || []).map(h => (h.type === 'pr' ? 'PR' : 'Issue') + ' ' + h.repo + '#' + h.number + ': ' + h.title).join('\n') || 'No items on hold')}"><span class="gm-label">on hold</span><span class="gm-val" style="color:var(--yellow)">${window._lastStatus?.hold?.total || 0}</span></div>
           <div class="oc-gov-gauge">
-            <div class="temp-gauge-track" style="background:linear-gradient(to right, #238636 0%, #238636 ${OC_THRESH_QUIET/OC_GAUGE_MAX*100}%, #1f6feb ${OC_THRESH_QUIET/OC_GAUGE_MAX*100}%, #1f6feb ${OC_THRESH_BUSY/OC_GAUGE_MAX*100}%, #d29922 ${OC_THRESH_BUSY/OC_GAUGE_MAX*100}%, #d29922 ${OC_THRESH_SURGE/OC_GAUGE_MAX*100}%, #f85149 ${OC_THRESH_SURGE/OC_GAUGE_MAX*100}%, #f85149 100%)">
+            <div class="temp-gauge-track" style="background:linear-gradient(to right, var(--green) 0%, var(--green) ${OC_THRESH_QUIET/OC_GAUGE_MAX*100}%, var(--blue) ${OC_THRESH_QUIET/OC_GAUGE_MAX*100}%, var(--blue) ${OC_THRESH_BUSY/OC_GAUGE_MAX*100}%, var(--yellow) ${OC_THRESH_BUSY/OC_GAUGE_MAX*100}%, var(--yellow) ${OC_THRESH_SURGE/OC_GAUGE_MAX*100}%, var(--red) ${OC_THRESH_SURGE/OC_GAUGE_MAX*100}%, var(--red) 100%)">
               <div class="temp-gauge-glow" style="width:100%"></div>
               <div class="temp-gauge-ticks"><span style="left:2%;-webkit-transform:translate(0,-50%);transform:translate(0,-50%)">0</span><span style="left:${OC_THRESH_QUIET/OC_GAUGE_MAX*100}%;-webkit-transform:translate(-50%,-50%);transform:translate(-50%,-50%)">${OC_THRESH_QUIET}</span><span style="left:${OC_THRESH_BUSY/OC_GAUGE_MAX*100}%;-webkit-transform:translate(-50%,-50%);transform:translate(-50%,-50%)">${OC_THRESH_BUSY}</span><span style="left:${OC_THRESH_SURGE/OC_GAUGE_MAX*100}%;-webkit-transform:translate(-50%,-50%);transform:translate(-50%,-50%)">${OC_THRESH_SURGE}</span><span style="left:98%;-webkit-transform:translate(-100%,-50%);transform:translate(-100%,-50%)">${OC_GAUGE_MAX}</span></div>
               <div class="temp-gauge-needle" style="left:${gaugePct}%" data-val="${govActionable}"></div>
@@ -2736,7 +2746,7 @@
     const AGENT_DESCRIPTIONS = {};
 
     // ── Config-driven agent color/sort helpers ──────────────────────────────
-    const _DEFAULT_AGENT_COLOR = '#8b949e';
+    const _DEFAULT_AGENT_COLOR = 'var(--muted)';
     function _getAgentColor(name) {
       const agents = window._lastStatus?.agents || [];
       const agent = agents.find(a => a.name === name);
@@ -3146,7 +3156,7 @@
         .map(s => s.agents?.[agentName]?.restarts)
         .filter(v => v != null);
       if (series.length < 2 || Math.max(...series) === 0) return '';
-      return sparkSvg(series, '#f85149');
+      return sparkSvg(series, 'var(--red)');
     }
 
     // ── Fact count sparkline (30-day server-side history) ──
@@ -3171,8 +3181,8 @@
       });
       const lastPt = pts[pts.length - 1].split(',');
       return `<span class="sparkline" style="margin-left:0;margin-top:4px"><svg width="${FACT_SPARKLINE_W}" height="${FACT_SPARKLINE_H}" viewBox="0 0 ${FACT_SPARKLINE_W} ${FACT_SPARKLINE_H}">` +
-        `<polyline points="${pts.join(' ')}" fill="none" stroke="#2563eb" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>` +
-        `<circle cx="${lastPt[0]}" cy="${lastPt[1]}" r="2" fill="#2563eb"/>` +
+        `<polyline points="${pts.join(' ')}" fill="none" stroke="var(--blue)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>` +
+        `<circle cx="${lastPt[0]}" cy="${lastPt[1]}" r="2" fill="var(--blue)"/>` +
         `</svg></span>`;
     }
     // fetchFactHistory() — deferred to _deferredInit
@@ -3294,8 +3304,8 @@
       return undefined;
     }
 
-    const SPARK_COLORS = { stars: '#e3b341', outreachOpen: '#58a6ff', outreachMerged: '#3fb950', actionable: '#f85149', openPrs: '#bc8cff', mergeable: '#3fb950' };
-    const DEFAULT_SPARK_COLOR = '#58a6ff';
+    const SPARK_COLORS = { stars: '#e3b341', outreachOpen: 'var(--blue)', outreachMerged: 'var(--green)', actionable: 'var(--red)', openPrs: 'var(--purple)', mergeable: 'var(--green)' };
+    const DEFAULT_SPARK_COLOR = 'var(--blue)';
 
     function renderStatHtml(stat, name) {
       const v = resolveStatValue(stat, name);
@@ -3691,7 +3701,7 @@
       banner.style.display = 'block';
       banner.innerHTML = alerts.map(function(a) {
         var bg = a.severity === 'error' ? '#7f1d1d' : '#78350f';
-        var border = a.severity === 'error' ? '#dc2626' : '#d97706';
+        var border = a.severity === 'error' ? 'var(--red)' : '#d97706';
         var textColor = a.severity === 'error' ? '#fca5a5' : '#fcd34d';
         return '<div style="background:' + bg + ';border:1px solid ' + border + ';border-radius:8px;padding:12px 16px;margin-bottom:8px;display:flex;align-items:center;gap:10px;font-size:0.85rem">'
           + '<span style="font-size:1.3rem">⚠️</span>'
@@ -3760,9 +3770,9 @@
       const isStarting = !gov.active && !gov.mode;
       const cls = gov.active ? 'active' : (isStarting ? 'starting' : 'dead');
       el.className = `governor ${cls}`;
-      const issuesSpark = sparkSvg(getHistorySeries('govIssues'), '#58a6ff');
-      const prsSpark = sparkSvg(getHistorySeries('govPrs'), '#bc8cff');
-      const totalSpark = sparkSvg(getHistorySeries('govTotal'), '#3fb950');
+      const issuesSpark = sparkSvg(getHistorySeries('govIssues'), 'var(--blue)');
+      const prsSpark = sparkSvg(getHistorySeries('govPrs'), 'var(--purple)');
+      const totalSpark = sparkSvg(getHistorySeries('govTotal'), 'var(--green)');
       const issueCount = gov.issues || 0;
       const currentMode = gov.mode || 'idle';
       const modes = ['idle', 'quiet', 'busy', 'surge'];
@@ -3774,8 +3784,8 @@
       const CLASSIC_THRESH_SURGE = _gt.surge ?? 20;
       const maxQ = Math.max(CLASSIC_THRESH_SURGE + 10, issueCount + 5);
       const pct = Math.min(issueCount / maxQ * 100, 100);
-      const modeColors = { idle: '#238636', quiet: '#58a6ff', busy: '#d29922', surge: '#f85149' };
-      const modeColor = modeColors[gov.mode] || '#8b949e';
+      const modeColors = { idle: 'var(--green)', quiet: 'var(--blue)', busy: 'var(--yellow)', surge: 'var(--red)' };
+      const modeColor = modeColors[gov.mode] || 'var(--muted)';
 
       // Timeline strip from 24h persistent timeline data
       const rawTl = window._timelineData || {};
@@ -3797,7 +3807,7 @@
       const holdData = data.hold || {};
       const holdTotal = holdData.total || 0;
       const holdItems = holdData.items || [];
-      const HOLD_COLOR = '#d29922';
+      const HOLD_COLOR = 'var(--yellow)';
       const holdTooltip = holdItems.length > 0 ? escapeHtml(holdItems.map(h => `${h.type === 'pr' ? 'PR' : 'Issue'} ${h.repo}#${h.number}: ${h.title}`).join('\n')) : 'No items on hold';
       const holdSpark = sparkSvg(getHistorySeries('govHold'), HOLD_COLOR);
 
@@ -3814,7 +3824,7 @@
         </div>
         <div class="temp-gauge" style="cursor:pointer" onclick="openConfigDialog('governor',null,'Thresholds')" title="Click to adjust governor thresholds">
           <div class="temp-gauge-label"><span>Issues: ${issueCount}</span><span>max ${maxQ}</span></div>
-          <div class="temp-gauge-track" style="background:linear-gradient(to right, #238636 0%, #238636 ${CLASSIC_THRESH_QUIET/maxQ*100}%, #1f6feb ${CLASSIC_THRESH_QUIET/maxQ*100}%, #1f6feb ${CLASSIC_THRESH_BUSY/maxQ*100}%, #d29922 ${CLASSIC_THRESH_BUSY/maxQ*100}%, #d29922 ${CLASSIC_THRESH_SURGE/maxQ*100}%, #f85149 ${CLASSIC_THRESH_SURGE/maxQ*100}%, #f85149 100%)">
+          <div class="temp-gauge-track" style="background:linear-gradient(to right, var(--green) 0%, var(--green) ${CLASSIC_THRESH_QUIET/maxQ*100}%, var(--blue) ${CLASSIC_THRESH_QUIET/maxQ*100}%, var(--blue) ${CLASSIC_THRESH_BUSY/maxQ*100}%, var(--yellow) ${CLASSIC_THRESH_BUSY/maxQ*100}%, var(--yellow) ${CLASSIC_THRESH_SURGE/maxQ*100}%, var(--red) ${CLASSIC_THRESH_SURGE/maxQ*100}%, var(--red) 100%)">
             <div class="temp-gauge-glow" style="width:100%"></div>
             <div class="temp-gauge-ticks"><span style="left:2%;-webkit-transform:translate(0,-50%);transform:translate(0,-50%)">0</span><span style="left:${CLASSIC_THRESH_QUIET/maxQ*100}%;-webkit-transform:translate(-50%,-50%);transform:translate(-50%,-50%)">${CLASSIC_THRESH_QUIET}</span><span style="left:${CLASSIC_THRESH_BUSY/maxQ*100}%;-webkit-transform:translate(-50%,-50%);transform:translate(-50%,-50%)">${CLASSIC_THRESH_BUSY}</span><span style="left:${CLASSIC_THRESH_SURGE/maxQ*100}%;-webkit-transform:translate(-50%,-50%);transform:translate(-50%,-50%)">${CLASSIC_THRESH_SURGE}</span><span style="left:98%;-webkit-transform:translate(-100%,-50%);transform:translate(-100%,-50%)">${maxQ}</span></div>
             <div class="temp-gauge-needle" style="left:${pct}%" data-val="${issueCount}"></div>
@@ -3964,7 +3974,7 @@
           <div id="${agentKey}-body" class="advisory-agent-body${agentCollapsed ? ' collapsed' : ''}" style="display:flex;flex-direction:column;gap:4px;${agentCollapsed ? 'max-height:0' : 'max-height:none'}">`;
         for (const f of findings) {
           const loc = f.file ? ` <code style="font-size:0.72rem;color:var(--muted)">${escapeHtml(f.file)}${f.line ? ':' + f.line : ''}</code>` : '';
-          html += `<div style="font-size:0.8rem;padding:6px 10px;background:var(--bg);border-radius:4px;border-left:3px solid ${f.severity === 'critical' ? '#dc2626' : f.severity === 'high' ? '#ea580c' : f.severity === 'medium' ? '#ca8a04' : '#6b7280'}">
+          html += `<div style="font-size:0.8rem;padding:6px 10px;background:var(--bg);border-radius:4px;border-left:3px solid ${f.severity === 'critical' ? 'var(--red)' : f.severity === 'high' ? '#ea580c' : f.severity === 'medium' ? 'var(--yellow)' : 'var(--muted)'}">
             ${sevIcon(f.severity)} <strong>[${escapeHtml(f.type || 'finding')}]</strong> ${escapeHtml(f.title)}${loc}
             ${f.detail ? `<div style="margin-top:4px;color:var(--muted);font-size:0.75rem">${escapeHtml(f.detail)}</div>` : ''}
           </div>`;
@@ -3978,8 +3988,8 @@
     function renderRepos(repos) {
       const el = document.getElementById('repos');
       setIfChanged(el, repos.map(r => {
-        const iSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.issues ?? 0), '#58a6ff');
-        const pSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.prs ?? 0), '#bc8cff');
+        const iSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.issues ?? 0), 'var(--blue)');
+        const pSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.prs ?? 0), 'var(--purple)');
         const repoUrl = (window._githubBaseUrl || 'https://github.com') + '/' + (r.full || r.name);
         const MAX_PILL_TITLE_LEN = 50;
         const issuePills = (r.actionableIssues || []).map(i => {
@@ -4011,8 +4021,8 @@
 
     function renderBeads(beads) {
       const el = document.getElementById('beads');
-      const wSpark = sparkSvg(getHistorySeries('beadsWorkers'), '#39d2c0');
-      const sSpark = sparkSvg(getHistorySeries('beadsSupervisor'), '#d29922');
+      const wSpark = sparkSvg(getHistorySeries('beadsWorkers'), 'var(--cyan)');
+      const sSpark = sparkSvg(getHistorySeries('beadsSupervisor'), 'var(--yellow)');
       setIfChanged(el, `
         <div class="bead-stat"><div class="spark-row"><span class="num">${beads.workers >= 0 ? beads.workers : 0}</span>${wSpark}</div><div class="label">workers</div></div>
         <div class="bead-stat"><div class="spark-row"><span class="num">${beads.supervisor >= 0 ? beads.supervisor : 0}</span>${sSpark}</div><div class="label">supervisor</div></div>`);
@@ -4409,11 +4419,11 @@ function intensityGauge() {
   const avg = rateVals.reduce((a, b) => a + b, 0) / rateVals.length;
 
   let color;
-  if (peak === 0) color = '#8b949e';
-  else if (now / peak > 0.8) color = '#f85149';
-  else if (now / peak > 0.5) color = '#d29922';
-  else if (now / peak > 0.2) color = '#3fb950';
-  else color = '#58a6ff';
+  if (peak === 0) color = 'var(--muted)';
+  else if (now / peak > 0.8) color = 'var(--red)';
+  else if (now / peak > 0.5) color = 'var(--yellow)';
+  else if (now / peak > 0.2) color = 'var(--green)';
+  else color = 'var(--blue)';
 
   let label;
   if (peak === 0) label = 'idle';
@@ -4447,20 +4457,20 @@ function intensityGauge() {
     <div class="burn-chart-title">burn rate (tok/hr)</div>
     <div style="position:relative">
       <svg viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" style="width:100%;height:${H}px;display:block">
-        <line x1="${PAD}" y1="${yPeak}" x2="${W - PAD}" y2="${yPeak}" stroke="#f85149" stroke-width="0.5" stroke-dasharray="3,3" opacity="0.5" vector-effect="non-scaling-stroke"/>
-        <line x1="${PAD}" y1="${yAvg}" x2="${W - PAD}" y2="${yAvg}" stroke="#d29922" stroke-width="0.5" stroke-dasharray="3,3" opacity="0.5" vector-effect="non-scaling-stroke"/>
-        <line x1="${PAD}" y1="${yLow}" x2="${W - PAD}" y2="${yLow}" stroke="#58a6ff" stroke-width="0.5" stroke-dasharray="3,3" opacity="0.5" vector-effect="non-scaling-stroke"/>
+        <line x1="${PAD}" y1="${yPeak}" x2="${W - PAD}" y2="${yPeak}" stroke="var(--red)" stroke-width="0.5" stroke-dasharray="3,3" opacity="0.5" vector-effect="non-scaling-stroke"/>
+        <line x1="${PAD}" y1="${yAvg}" x2="${W - PAD}" y2="${yAvg}" stroke="var(--yellow)" stroke-width="0.5" stroke-dasharray="3,3" opacity="0.5" vector-effect="non-scaling-stroke"/>
+        <line x1="${PAD}" y1="${yLow}" x2="${W - PAD}" y2="${yLow}" stroke="var(--blue)" stroke-width="0.5" stroke-dasharray="3,3" opacity="0.5" vector-effect="non-scaling-stroke"/>
         <polyline points="${polyline}" fill="none" stroke="${color}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke"/>
       </svg>
-      <div style="position:absolute;left:${dotLeftPct}%;top:${dotTopPct}%;width:6px;height:6px;border-radius:50%;background:${color};border:1px solid #0d1117;transform:translate(-50%,-50%)"></div>
+      <div style="position:absolute;left:${dotLeftPct}%;top:${dotTopPct}%;width:6px;height:6px;border-radius:50%;background:${color};border:1px solid var(--bg);transform:translate(-50%,-50%)"></div>
     </div>
     <div style="display:flex;justify-content:space-between;font-size:0.6rem;color:var(--muted);margin-top:1px;font-family:var(--font-mono)">
       <span>${tStart}</span><span>${tEnd}</span>
     </div>
     <div class="burn-context">
-      <div class="bc-stat"><span class="bc-val" style="color:#58a6ff">${fmtTokens(low)}</span><span class="bc-label">low/hr</span></div>
-      <div class="bc-stat"><span class="bc-val" style="color:#d29922">${fmtTokens(avg)}</span><span class="bc-label">avg/hr</span></div>
-      <div class="bc-stat"><span class="bc-val" style="color:#f85149">${fmtTokens(peak)}</span><span class="bc-label">peak/hr</span></div>
+      <div class="bc-stat"><span class="bc-val" style="color:var(--blue)">${fmtTokens(low)}</span><span class="bc-label">low/hr</span></div>
+      <div class="bc-stat"><span class="bc-val" style="color:var(--yellow)">${fmtTokens(avg)}</span><span class="bc-label">avg/hr</span></div>
+      <div class="bc-stat"><span class="bc-val" style="color:var(--red)">${fmtTokens(peak)}</span><span class="bc-label">peak/hr</span></div>
       <div class="bc-stat"><span class="bc-val" style="color:${color}">${fmtTokens(now)}</span><span class="bc-label">current/hr</span></div>
     </div>
     <div style="color:${color};font-size:11px;font-family:var(--font-mono);margin-top:2px">${label}</div>
@@ -4520,20 +4530,20 @@ function burnAreaChart() {
   const nowVal = rateVals[rateVals.length - 1];
   const aboveBand = nowVal > buckets[buckets.length - 1].p75;
   const belowBand = nowVal < buckets[buckets.length - 1].p25;
-  const dotColor = aboveBand ? '#f85149' : belowBand ? '#58a6ff' : '#3fb950';
+  const dotColor = aboveBand ? 'var(--red)' : belowBand ? 'var(--blue)' : 'var(--green)';
 
   const areaDotLeftPct = (parseFloat(lastNow.split(',')[0]) / W * 100).toFixed(1);
   const areaDotTopPct = (parseFloat(lastNow.split(',')[1]) / H * 100).toFixed(1);
 
   return `<div class="burn-area-wrap">
-    <div class="burn-area-title" style="text-align:left">burn rate distribution · <span style="color:rgba(57,210,192,0.6)">p25–p75 band</span> · <span style="color:#39d2c0">actual</span></div>
+    <div class="burn-area-title" style="text-align:left">burn rate distribution · <span style="color:rgba(57,210,192,0.6)">p25–p75 band</span> · <span style="color:var(--cyan)">actual</span></div>
     <div style="position:relative">
       <svg viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" style="width:100%;height:${H}px;display:block">
         <polygon points="${bandTop.join(' ')} ${bandBot.join(' ')}" fill="rgba(57,210,192,0.12)" stroke="none"/>
         <polyline points="${medianPts.join(' ')}" fill="none" stroke="rgba(57,210,192,0.3)" stroke-width="1" stroke-dasharray="2,2" vector-effect="non-scaling-stroke"/>
-        <polyline points="${nowPts.join(' ')}" fill="none" stroke="#39d2c0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke"/>
+        <polyline points="${nowPts.join(' ')}" fill="none" stroke="var(--cyan)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke"/>
       </svg>
-      <div style="position:absolute;left:${areaDotLeftPct}%;top:${areaDotTopPct}%;width:6px;height:6px;border-radius:50%;background:${dotColor};border:1px solid #0d1117;transform:translate(-50%,-50%)"></div>
+      <div style="position:absolute;left:${areaDotLeftPct}%;top:${areaDotTopPct}%;width:6px;height:6px;border-radius:50%;background:${dotColor};border:1px solid var(--bg);transform:translate(-50%,-50%)"></div>
     </div>
   </div>`;
 }
@@ -4561,7 +4571,7 @@ function burnAreaChart() {
 
       const modelChips = models.map(([name, m]) => {
         const mTotal = m.input + m.output + m.cacheRead;
-        const mSpark = sparkSvg(historyData.map(s => s.tokenModels?.[name] ?? 0), '#bc8cff');
+        const mSpark = sparkSvg(historyData.map(s => s.tokenModels?.[name] ?? 0), 'var(--purple)');
         return `<div class="token-model-chip">
           <span class="mname">${esc(name)}</span>
           <span class="mcount">${fmtTokens(mTotal)} tokens · ${m.messages} msgs</span>
@@ -4617,7 +4627,7 @@ function burnAreaChart() {
 
       const advisorHtml = buildCadenceAdvisor(tokens.byAgent || {});
 
-      const totalSpark = sparkSvg(getHistorySeries('tokenTotal'), '#39d2c0');
+      const totalSpark = sparkSvg(getHistorySeries('tokenTotal'), 'var(--cyan)');
       const ba = tokens.byAgent || {};
       const agentNames = Object.keys(ba).sort((a, b) => {
         const aOrder = _getAgentSortOrder(a);
@@ -4640,11 +4650,11 @@ function burnAreaChart() {
         </div>
         <div class="token-grid">
           <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--cyan)">${fmtTokens(totalTokens)}</span>${totalSpark}</div><div class="tlabel">total tokens</div></div>
-          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--blue)">${fmtTokens(t.input)}</span>${sparkSvg(getHistorySeries('tokenInput'), '#58a6ff')}</div><div class="tlabel">input</div></div>
-          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--purple)">${fmtTokens(t.output)}</span>${sparkSvg(getHistorySeries('tokenOutput'), '#bc8cff')}</div><div class="tlabel">output</div></div>
-          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--green)">${fmtTokens(t.cacheRead)}</span>${sparkSvg(getHistorySeries('tokenCacheRead'), '#3fb950')}</div><div class="tlabel">cache read</div></div>
-          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--yellow)">${fmtTokens(t.cacheCreate)}</span>${sparkSvg(getHistorySeries('tokenCacheCreate'), '#d29922')}</div><div class="tlabel">cache create</div></div>
-          <div class="token-stat"><div class="spark-row"><span class="tval">${t.messages}</span>${sparkSvg(getHistorySeries('tokenMessages'), '#8b949e')}</div><div class="tlabel">messages</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--blue)">${fmtTokens(t.input)}</span>${sparkSvg(getHistorySeries('tokenInput'), 'var(--blue)')}</div><div class="tlabel">input</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--purple)">${fmtTokens(t.output)}</span>${sparkSvg(getHistorySeries('tokenOutput'), 'var(--purple)')}</div><div class="tlabel">output</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--green)">${fmtTokens(t.cacheRead)}</span>${sparkSvg(getHistorySeries('tokenCacheRead'), 'var(--green)')}</div><div class="tlabel">cache read</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval" style="color:var(--yellow)">${fmtTokens(t.cacheCreate)}</span>${sparkSvg(getHistorySeries('tokenCacheCreate'), 'var(--yellow)')}</div><div class="tlabel">cache create</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval">${t.messages}</span>${sparkSvg(getHistorySeries('tokenMessages'), 'var(--muted)')}</div><div class="tlabel">messages</div></div>
         </div>
         ${agentSparkRows ? `<div class="token-grid" style="margin-top:4px">${agentSparkRows}</div>` : ''}
         ${advisorHtml}
@@ -4735,7 +4745,7 @@ function burnAreaChart() {
         } else if (p.api_reset_epoch && p.api_reset_epoch <= now) {
           resetStr = ' · API quota restored';
         }
-        return `<div style="font-size:0.72rem;color:#d29922;margin-top:6px;padding-top:6px;border-top:1px solid rgba(210,153,34,0.25)">
+        return `<div style="font-size:0.72rem;color:var(--yellow);margin-top:6px;padding-top:6px;border-top:1px solid rgba(210,153,34,0.25)">
           ⏸ Pullback (${esc(p.cli || '?')}): paused <strong>${esc(paused)}</strong> — resumes in ${remainMin}m${resetStr}
         </div>`;
       }).join('');
@@ -4786,11 +4796,11 @@ function burnAreaChart() {
       const scope = s.scope || 'governor';
       const phases = s.phases || {};
 
-      const modeColors = { observe: '#2563eb', suggest: '#d97706', evolve: '#16a34a' };
+      const modeColors = { observe: 'var(--blue)', suggest: '#d97706', evolve: 'var(--green)' };
       const modeLabels = { observe: 'Observing', suggest: 'Suggesting', evolve: 'Evolving' };
       if (badge) {
         badge.textContent = `${modeLabels[mode] || mode} · ${scope}`;
-        badge.style.background = modeColors[mode] || '#6b7280';
+        badge.style.background = modeColors[mode] || 'var(--muted)';
         badge.style.color = 'white';
       }
 
@@ -4920,7 +4930,7 @@ function burnAreaChart() {
       // Data collection progress
       html += '<div class="nous-card" style="margin-top:12px">';
       html += '<h3>Data Collection</h3>';
-      html += `<div class="nous-progress"><div class="nous-progress-fill" style="width:${snapPct}%;background:#2563eb"></div></div>`;
+      html += `<div class="nous-progress"><div class="nous-progress-fill" style="width:${snapPct}%;background:var(--blue)"></div></div>`;
       html += `<div style="font-size:0.72rem;color:var(--muted)">${s.snapshotCount || 0} / ${s.snapshotTarget || 672} snapshots — ${snapPct >= 75 ? (mode === 'observe' ? 'Ready to upgrade to Suggest' : 'Baseline sufficient') : 'Collecting baseline data'}</div>`;
 
       // Show experiment proposals from ledger
@@ -4947,7 +4957,7 @@ function burnAreaChart() {
         const exp = s.activeExperiment;
         html += '<div class="nous-experiment-live">';
         html += `<h4>Active Experiment: ${escapeHtml(exp.id)}</h4>`;
-        html += `<div class="nous-progress"><div class="nous-progress-fill" style="width:${exp.progressPct}%;background:#16a34a"></div></div>`;
+        html += `<div class="nous-progress"><div class="nous-progress-fill" style="width:${exp.progressPct}%;background:var(--green)"></div></div>`;
         html += `<div style="font-size:0.72rem;color:var(--muted)">${exp.progressPct}% complete — ${Math.round((exp.ttlSec - exp.elapsed) / 60)}min remaining</div>`;
         html += '<div style="display:flex;gap:16px;margin-top:8px;font-size:0.75rem">';
         html += `<span>Queue limit: ${exp.fastFail.queueMax}</span>`;
@@ -4986,7 +4996,7 @@ function burnAreaChart() {
         const sorted = [...principles].sort((a, b) => (b.confidence || 0) - (a.confidence || 0));
         for (const p of sorted) {
           const conf = Math.round((p.confidence || 0) * 100);
-          const barColor = conf >= 80 ? '#16a34a' : conf >= 50 ? '#d97706' : '#dc2626';
+          const barColor = conf >= 80 ? 'var(--green)' : conf >= 50 ? '#d97706' : 'var(--red)';
           html += '<div class="nous-principle">';
           html += `<div class="nous-confidence-bar"><div class="nous-confidence-fill" style="width:${conf}%;background:${barColor}"></div></div>`;
           html += `<div class="nous-principle-text">${escapeHtml(p.text || p.id)}</div>`;
@@ -5004,7 +5014,7 @@ function burnAreaChart() {
         const TIMELINE_MAX_BARS = 30;
         const recent = ledger.slice(-TIMELINE_MAX_BARS);
         for (const entry of recent) {
-          const colors = { dry_run: '#94a3b8', active: '#2563eb', completed: '#16a34a', aborted: '#dc2626', analysis: '#7c3aed', shadow_analysis: '#a78bfa' };
+          const colors = { dry_run: '#94a3b8', active: 'var(--blue)', completed: 'var(--green)', aborted: 'var(--red)', analysis: '#7c3aed', shadow_analysis: '#a78bfa' };
           const color = colors[entry.type] || '#94a3b8';
           const outcome = entry.outcome || entry.type;
           html += `<div class="nous-timeline-bar" style="height:${20 + Math.random() * 20}px;background:${color}" title="${escapeHtml((entry.id || '?') + ': ' + outcome)}"></div>`;
@@ -5012,9 +5022,9 @@ function burnAreaChart() {
         html += '</div>';
         html += '<div style="font-size:0.65rem;color:var(--muted);margin-top:4px;display:flex;gap:12px">';
         html += '<span><span style="color:#94a3b8">■</span> dry run</span>';
-        html += '<span><span style="color:#2563eb">■</span> active</span>';
-        html += '<span><span style="color:#16a34a">■</span> completed</span>';
-        html += '<span><span style="color:#dc2626">■</span> aborted</span>';
+        html += '<span><span style="color:var(--blue)">■</span> active</span>';
+        html += '<span><span style="color:var(--green)">■</span> completed</span>';
+        html += '<span><span style="color:var(--red)">■</span> aborted</span>';
         html += '<span><span style="color:#7c3aed">■</span> analysis</span>';
         html += '</div></div>';
       }
@@ -5111,7 +5121,7 @@ function burnAreaChart() {
 
       const cfg = await fetchNousConfig();
       if (!cfg) {
-        overlay.innerHTML = '<div class="nous-config-dialog"><div style="color:#dc2626;padding:20px">Failed to load config</div><div class="nous-config-btn-bar"><button class="nous-config-btn nous-config-btn-cancel" onclick="closeNousConfig()">Close</button></div></div>';
+        overlay.innerHTML = '<div class="nous-config-dialog"><div style="color:var(--red);padding:20px">Failed to load config</div><div class="nous-config-btn-bar"><button class="nous-config-btn nous-config-btn-cancel" onclick="closeNousConfig()">Close</button></div></div>';
         return;
       }
       renderNousConfig(cfg);
@@ -5151,17 +5161,17 @@ function burnAreaChart() {
       h += '<h3>Trust Ladder</h3>';
       h += '<div class="nous-trust-ladder">';
       const trustSteps = [
-        { id: 'observe', label: 'Observe', desc: 'Data collection only', color: '#2563eb' },
+        { id: 'observe', label: 'Observe', desc: 'Data collection only', color: 'var(--blue)' },
         { id: 'suggest', label: 'Suggest', desc: 'Experiments need approval', color: '#d97706' },
-        { id: 'evolve', label: 'Evolve', desc: 'Fully autonomous', color: '#16a34a' },
+        { id: 'evolve', label: 'Evolve', desc: 'Fully autonomous', color: 'var(--green)' },
       ];
       for (const step of trustSteps) {
         const isCurrent = step.id === mode;
         const bg = isCurrent ? step.color : 'var(--bg)';
-        const fg = isCurrent ? 'white' : 'var(--muted)';
+        const fg = isCurrent ? 'var(--bg)' : 'var(--muted)';
         h += `<div class="nous-trust-step${isCurrent ? ' current' : ''}" style="background:${bg};color:${fg}">`;
         h += `<span class="step-label">${escapeHtml(step.label)}</span>`;
-        h += `<span class="step-desc" style="color:${isCurrent ? 'rgba(255,255,255,0.8)' : ''}">${escapeHtml(step.desc)}</span>`;
+        h += `<span class="step-desc" style="color:${isCurrent ? 'var(--bg)' : ''}">${escapeHtml(step.desc)}</span>`;
         h += '</div>';
       }
       h += '</div>';
@@ -5432,9 +5442,9 @@ function burnAreaChart() {
     const DOC_CONTENT_ICONS = { 'text/html': '🌐', 'application/pdf': '📄', 'text/plain': '📝', 'text/markdown': '📝', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '📋' };
 
     function confColor(c) {
-      if (c >= 0.9) return '#16a34a';
+      if (c >= 0.9) return 'var(--green)';
       if (c >= 0.7) return '#d97706';
-      return '#dc2626';
+      return 'var(--red)';
     }
 
     async function toggleKnowledge(enabled) {
@@ -5609,7 +5619,7 @@ function burnAreaChart() {
       // Loading overlay while graph simulation runs
       const loadingOverlay = document.createElement('div');
       loadingOverlay.style.cssText = 'position:absolute;inset:0;display:flex;align-items:center;justify-content:center;z-index:15;background:rgba(0,0,0,0.3);transition:opacity 0.3s';
-      loadingOverlay.innerHTML = '<div style="display:flex;flex-direction:column;align-items:center;gap:8px"><div style="width:32px;height:32px;border:3px solid rgba(255,255,255,0.2);border-top-color:var(--blue,#58a6ff);border-radius:50%;animation:kbGraphSpin 0.8s linear infinite"></div><span style="color:var(--text);font-size:0.75rem;opacity:0.8">Laying out graph…</span></div>';
+      loadingOverlay.innerHTML = '<div style="display:flex;flex-direction:column;align-items:center;gap:8px"><div style="width:32px;height:32px;border:3px solid rgba(255,255,255,0.2);border-top-color:var(--blue);border-radius:50%;animation:kbGraphSpin 0.8s linear infinite"></div><span style="color:var(--text);font-size:0.75rem;opacity:0.8">Laying out graph…</span></div>';
       container.appendChild(loadingOverlay);
       if (!document.getElementById('kb-graph-spin-style')) {
         const spinStyle = document.createElement('style');
@@ -6071,7 +6081,7 @@ function burnAreaChart() {
         html += '<div style="display:grid;grid-template-columns:2fr 1fr auto;gap:8px;align-items:center">';
         html += '<input id="kb-setup-vault-path" type="text" class="kb-search-box" placeholder="/data/vaults/hive-wiki">';
         html += '<input id="kb-setup-vault-name" type="text" class="kb-search-box" placeholder="Display name">';
-        html += '<button class="nous-btn" style="background:var(--accent);color:white;white-space:nowrap" onclick="kbSetupConnectVault()">Connect</button>';
+        html += '<button class="nous-btn" style="background:var(--accent);color:var(--bg);white-space:nowrap" onclick="kbSetupConnectVault()">Connect</button>';
         html += '</div></div>';
       }
 
@@ -6119,7 +6129,7 @@ function burnAreaChart() {
       // Enable knowledge button for webhook (webhook works without vault connection)
       if (showDone) {
         html += '<div style="border-top:1px solid var(--border);padding-top:14px;margin-top:16px;text-align:center">';
-        html += '<button onclick="_kbSetupView=\'none\';renderKnowledge()" class="nous-btn" style="background:var(--accent);color:white;padding:8px 24px;font-size:0.82rem">Done -- go to Knowledge Base</button>';
+        html += '<button onclick="_kbSetupView=\'none\';renderKnowledge()" class="nous-btn" style="background:var(--accent);color:var(--bg);padding:8px 24px;font-size:0.82rem">Done -- go to Knowledge Base</button>';
         html += '</div>';
       }
 
@@ -6191,8 +6201,8 @@ function burnAreaChart() {
       if (!panel) return;
 
       if (!_kbCache || !_kbCache.enabled) {
-        if (badge) { badge.textContent = 'disabled'; badge.style.background = '#6b7280'; badge.style.color = 'white'; }
-        panel.innerHTML = '<div class="kb-disabled"><div style="font-size:2rem;margin-bottom:8px">📚</div><div>Knowledge system not enabled</div><div style="font-size:0.72rem;margin-top:4px;color:var(--muted);margin-bottom:12px">Enable the knowledge base to store and retrieve facts across agents.</div><button onclick="toggleKnowledge(true)" style="padding:8px 20px;background:#2563eb;color:white;border:none;border-radius:6px;cursor:pointer;font-size:0.82rem;font-weight:600" title="Enable the knowledge base system. Agents will be able to store and retrieve facts (patterns, gotchas, regressions, decisions) across sessions and layers (personal, project, org, community).">Enable Knowledge</button></div>';
+        if (badge) { badge.textContent = 'disabled'; badge.style.background = 'var(--muted)'; badge.style.color = 'white'; }
+        panel.innerHTML = '<div class="kb-disabled"><div style="font-size:2rem;margin-bottom:8px">📚</div><div>Knowledge system not enabled</div><div style="font-size:0.72rem;margin-top:4px;color:var(--muted);margin-bottom:12px">Enable the knowledge base to store and retrieve facts across agents.</div><button onclick="toggleKnowledge(true)" style="padding:8px 20px;background:var(--blue);color:var(--bg);border:none;border-radius:6px;cursor:pointer;font-size:0.82rem;font-weight:600" title="Enable the knowledge base system. Agents will be able to store and retrieve facts (patterns, gotchas, regressions, decisions) across sessions and layers (personal, project, org, community).">Enable Knowledge</button></div>';
         return;
       }
 
@@ -6207,7 +6217,7 @@ function burnAreaChart() {
       const healthyCount = layers.filter(l => l.healthy).length;
       if (badge) {
         badge.textContent = healthyCount + '/' + layers.length + ' layers';
-        badge.style.background = healthyCount === layers.length ? '#16a34a' : (healthyCount > 0 ? '#d97706' : '#dc2626');
+        badge.style.background = healthyCount === layers.length ? 'var(--green)' : (healthyCount > 0 ? '#d97706' : 'var(--red)');
         badge.style.color = 'white';
       }
 
@@ -6215,12 +6225,12 @@ function burnAreaChart() {
       const synthRunning = _beadSynthStatus && _beadSynthStatus.running;
       let html = '<div style="display:flex;justify-content:flex-end;gap:8px;margin-bottom:8px">';
       if (synthEnabled) {
-        html += `<span style="font-size:0.72rem;color:#16a34a;display:flex;align-items:center;gap:4px" title="Bead synthesizer is ${synthRunning ? 'running' : 'enabled but not running'}. Schedule: ${escapeHtml((_beadSynthStatus||{}).schedule||'hourly')}"><span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:${synthRunning ? '#16a34a' : '#d97706'}"></span> Synth ${synthRunning ? 'active' : 'idle'}</span>`;
+        html += `<span style="font-size:0.72rem;color:var(--green);display:flex;align-items:center;gap:4px" title="Bead synthesizer is ${synthRunning ? 'running' : 'enabled but not running'}. Schedule: ${escapeHtml((_beadSynthStatus||{}).schedule||'hourly')}"><span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:${synthRunning ? 'var(--green)' : '#d97706'}"></span> Synth ${synthRunning ? 'active' : 'idle'}</span>`;
         html += '<button onclick="toggleBeadSynth(false)" style="padding:4px 12px;background:none;border:1px solid #d97706;color:#d97706;border-radius:4px;cursor:pointer;font-size:0.72rem" title="Disable the bead synthesizer. Completed beads will no longer be automatically converted to wiki facts.">Pause Synth</button>';
       } else {
-        html += '<button onclick="toggleBeadSynth(true)" style="padding:4px 12px;background:#2563eb;color:white;border:none;border-radius:4px;cursor:pointer;font-size:0.72rem" title="Enable the bead synthesizer. Completed beads will be automatically scanned and converted to wiki facts on an hourly schedule.">Enable Synth</button>';
+        html += '<button onclick="toggleBeadSynth(true)" style="padding:4px 12px;background:var(--blue);color:var(--bg);border:none;border-radius:4px;cursor:pointer;font-size:0.72rem" title="Enable the bead synthesizer. Completed beads will be automatically scanned and converted to wiki facts on an hourly schedule.">Enable Synth</button>';
       }
-      html += '<button onclick="toggleKnowledge(false)" style="padding:4px 12px;background:none;border:1px solid #dc2626;color:#dc2626;border-radius:4px;cursor:pointer;font-size:0.72rem" title="Disable the knowledge base. Agents will no longer inject facts into prompts. Stored facts are preserved for when re-enabled.">Disable</button>';
+      html += '<button onclick="toggleKnowledge(false)" style="padding:4px 12px;background:none;border:1px solid var(--red);color:var(--red);border-radius:4px;cursor:pointer;font-size:0.72rem" title="Disable the knowledge base. Agents will no longer inject facts into prompts. Stored facts are preserved for when re-enabled.">Disable</button>';
       html += '</div>';
 
       // Stats row
@@ -6232,12 +6242,12 @@ function burnAreaChart() {
       html += `<div class="kb-stat"><div class="val">${healthyCount}/${layers.length}</div><div class="lbl">Layers Online</div></div>`;
       html += `<div class="kb-stat"><div class="val">${escapeHtml(_kbCache.engine || 'n/a')}</div><div class="lbl">Engine</div></div>`;
       if (staleTotal > 0) html += `<div class="kb-stat"><div class="val" style="color:#d97706">${staleTotal}</div><div class="lbl">Stale</div></div>`;
-      if (orphanedTotal > 0) html += `<div class="kb-stat"><div class="val" style="color:#dc2626">${orphanedTotal}</div><div class="lbl">Orphaned</div></div>`;
+      if (orphanedTotal > 0) html += `<div class="kb-stat"><div class="val" style="color:var(--red)">${orphanedTotal}</div><div class="lbl">Orphaned</div></div>`;
       html += '</div>';
 
       // Action buttons
       html += '<div style="display:flex;gap:8px;margin-bottom:14px">';
-      html += '<button class="nous-btn" style="background:#2563eb;color:white" onclick="kbOpenCreate()" title="Create a new knowledge fact manually. Choose a layer (personal, project, org, community), type, and enter the fact content.">+ New Fact</button>';
+      html += '<button class="nous-btn" style="background:var(--blue);color:var(--bg)" onclick="kbOpenCreate()" title="Create a new knowledge fact manually. Choose a layer (personal, project, org, community), type, and enter the fact content.">+ New Fact</button>';
       html += '<button class="nous-btn" style="background:var(--surface);color:var(--fg);border:1px solid var(--border)" onclick="kbOpenSubscriptions()" title="Manage knowledge sources: git repos, wiki subscriptions, document imports, and fact imports.">🔗 Knowledge Sources</button>';
       html += '<button class="nous-btn" style="background:var(--surface);color:var(--fg);border:1px solid var(--border)" onclick="kbOpenVaults()" title="Manage knowledge vaults — collections of facts organized by topic or project. Vaults can be shared across hive instances.">📂 Vaults</button>';
       html += '<button class="nous-btn" style="background:var(--surface);color:var(--fg);border:1px solid var(--border)" onclick="kbOpenHowItWorks()">📖 How it works</button>';
@@ -6257,7 +6267,7 @@ function burnAreaChart() {
         const label = KB_LAYER_LABELS[l.type] || l.type;
         const active = _kbSelectedLayer === l.type ? ' active' : '';
         const count = l.total_pages || 0;
-        const dotColor = l.healthy ? '#16a34a' : '#dc2626';
+        const dotColor = l.healthy ? 'var(--green)' : 'var(--red)';
         const isGitSource = l.type && l.type.startsWith('git_source:');
         const repoUrl = isGitSource && l.url ? (l.subpath ? l.url + '/tree/' + 'main/' + l.subpath : l.url) : '';
         html += `<button class="kb-layer-btn${active}" onclick="kbSelectLayer('${escapeHtml(l.type)}')">`;
@@ -6286,7 +6296,7 @@ function burnAreaChart() {
       // Health
       html += '<div style="margin-top:8px;font-size:0.72rem;color:var(--muted)">';
       for (const l of layers) {
-        const dot = l.healthy ? '#16a34a' : '#dc2626';
+        const dot = l.healthy ? 'var(--green)' : 'var(--red)';
         html += `<div class="kb-health-item"><span class="kb-health-dot" style="background:${dot}"></span>${escapeHtml(KB_LAYER_LABELS[l.type] || l.type)}: ${l.healthy ? 'healthy' : 'unreachable'}</div>`;
       }
       html += '</div>';
@@ -6397,13 +6407,13 @@ function burnAreaChart() {
 
       // Action buttons
       html += '<div style="display:flex;gap:6px;margin-top:12px;flex-wrap:wrap">';
-      html += `<button class="nous-btn" style="background:#2563eb;color:white;font-size:0.72rem;padding:5px 10px" onclick="kbOpenEdit()">✏️ Edit</button>`;
+      html += `<button class="nous-btn" style="background:var(--blue);color:var(--bg);font-size:0.72rem;padding:5px 10px" onclick="kbOpenEdit()">✏️ Edit</button>`;
       const promoteTargets = { personal: 'project', project: 'org', org: 'community' };
       const promoteTo = promoteTargets[f.layer];
       if (promoteTo) {
         html += `<button class="nous-btn" style="background:#7c3aed;color:white;font-size:0.72rem;padding:5px 10px" onclick="kbPromote('${escapeHtml(f.slug)}','${escapeHtml(f.layer)}','${promoteTo}')">⬆ Promote to ${promoteTo}</button>`;
       }
-      html += `<button class="nous-btn" style="background:#dc2626;color:white;font-size:0.72rem;padding:5px 10px" onclick="kbDelete('${escapeHtml(f.slug)}','${escapeHtml(f.layer)}')">🗑 Delete</button>`;
+      html += `<button class="nous-btn" style="background:var(--red);color:var(--bg);font-size:0.72rem;padding:5px 10px" onclick="kbDelete('${escapeHtml(f.slug)}','${escapeHtml(f.layer)}')">🗑 Delete</button>`;
       html += '</div>';
 
       html += '</div>';
@@ -6485,7 +6495,7 @@ function burnAreaChart() {
           </label>
           <div style="display:flex;justify-content:flex-end;gap:8px;margin-top:8px">
             <button class="nous-btn nous-config-btn-cancel" onclick="kbCloseModal()">Cancel</button>
-            <button class="nous-btn" style="background:#2563eb;color:white" onclick="kbSubmitCreate()">Create Fact</button>
+            <button class="nous-btn" style="background:var(--blue);color:var(--bg)" onclick="kbSubmitCreate()">Create Fact</button>
           </div>
         </div>`;
       kbShowModal('New Fact', html);
@@ -6554,7 +6564,7 @@ function burnAreaChart() {
           <div style="font-size:0.7rem;color:var(--muted)">Layer: ${escapeHtml(f.layer || '')} · Slug: ${escapeHtml(f.slug || '')}</div>
           <div style="display:flex;justify-content:flex-end;gap:8px;margin-top:8px">
             <button class="nous-btn nous-config-btn-cancel" onclick="kbCloseModal()">Cancel</button>
-            <button class="nous-btn" style="background:#2563eb;color:white" onclick="kbSubmitEdit()">Save Changes</button>
+            <button class="nous-btn" style="background:var(--blue);color:var(--bg)" onclick="kbSubmitEdit()">Save Changes</button>
           </div>
         </div>`;
       kbShowModal('Edit Fact', html);
@@ -6644,7 +6654,7 @@ function burnAreaChart() {
           </div>
           <div style="display:flex;justify-content:flex-end;gap:8px;margin-top:8px">
             <button class="nous-btn nous-config-btn-cancel" onclick="kbCloseModal()">Cancel</button>
-            <button class="nous-btn" style="background:#2563eb;color:white" onclick="kbSubmitImport()">Import</button>
+            <button class="nous-btn" style="background:var(--blue);color:var(--bg)" onclick="kbSubmitImport()">Import</button>
           </div>
         </div>`;
       kbShowModal('📥 Import Facts', html, { width: 'min(700px, 80vw)', maxHeight: '85vh' });
@@ -6728,7 +6738,7 @@ function burnAreaChart() {
 
         if (gitSources && gitSources.length > 0) {
           for (const gs of gitSources) {
-            const statusColor = gs.ready ? '#16a34a' : '#eab308';
+            const statusColor = gs.ready ? 'var(--green)' : '#eab308';
             const statusText = gs.ready ? 'ready' : 'initializing';
             html += '<div style="display:flex;align-items:center;justify-content:space-between;padding:8px;border:1px solid var(--border);border-radius:6px;margin-bottom:6px">';
             html += '<div style="min-width:0;flex:1">';
@@ -6742,7 +6752,7 @@ function burnAreaChart() {
             html += ` ↗</a>`;
             html += ` &middot; ${escapeHtml(gs.layer)} &middot; ${gs.pages} pages &middot; ${statusText}</div>`;
             html += '</div>';
-            html += `<button class="nous-btn" style="background:#dc2626;color:white;font-size:0.7rem;padding:4px 8px;flex-shrink:0;margin-left:8px" onclick="kbRemoveGitSource('${escapeHtml(gs.url)}','${escapeHtml(gs.subpath || '')}')">Remove</button>`;
+            html += `<button class="nous-btn" style="background:var(--red);color:var(--bg);font-size:0.7rem;padding:4px 8px;flex-shrink:0;margin-left:8px" onclick="kbRemoveGitSource('${escapeHtml(gs.url)}','${escapeHtml(gs.subpath || '')}')">Remove</button>`;
             html += '</div>';
           }
         } else {
@@ -6762,7 +6772,7 @@ function burnAreaChart() {
           <option value="personal">Personal</option>
         </select>`;
         html += '<div style="display:flex;justify-content:flex-end">';
-        html += '<button class="nous-btn" style="background:#2563eb;color:white;padding:8px 20px" onclick="kbAddGitSource()">Clone &amp; Index</button>';
+        html += '<button class="nous-btn" style="background:var(--blue);color:var(--bg);padding:8px 20px" onclick="kbAddGitSource()">Clone &amp; Index</button>';
         html += '</div></div></details>';
         html += '</div>';
 
@@ -6779,7 +6789,7 @@ function burnAreaChart() {
             html += '<div style="display:flex;align-items:center;justify-content:space-between;padding:8px;border:1px solid var(--border);border-radius:6px;margin-bottom:6px">';
             html += `<div><div style="font-size:0.82rem;font-weight:600;color:var(--fg)">${escapeHtml(s.name || s.url)}</div>`;
             html += `<div style="font-size:0.7rem;color:var(--muted)">${escapeHtml(s.url)} &middot; ${escapeHtml(s.layer || 'org')}</div></div>`;
-            html += `<button class="nous-btn" style="background:#dc2626;color:white;font-size:0.7rem;padding:4px 8px;flex-shrink:0;margin-left:8px" onclick="kbRemoveSub('${escapeHtml(s.url)}')">Remove</button>`;
+            html += `<button class="nous-btn" style="background:var(--red);color:var(--bg);font-size:0.7rem;padding:4px 8px;flex-shrink:0;margin-left:8px" onclick="kbRemoveSub('${escapeHtml(s.url)}')">Remove</button>`;
             html += '</div>';
           }
         } else {
@@ -6797,7 +6807,7 @@ function burnAreaChart() {
           <option value="personal">Personal</option>
         </select>`;
         html += '<div style="display:flex;justify-content:flex-end">';
-        html += '<button class="nous-btn" style="background:#2563eb;color:white;padding:8px 20px" onclick="kbAddSub()">Add</button>';
+        html += '<button class="nous-btn" style="background:var(--blue);color:var(--bg);padding:8px 20px" onclick="kbAddSub()">Add</button>';
         html += '</div></div></details>';
         html += '</div>';
 
@@ -6826,7 +6836,7 @@ function burnAreaChart() {
             html += '</div>';
             html += '<div style="display:flex;gap:4px;flex-shrink:0;margin-left:8px">';
             html += `<button class="nous-btn" style="font-size:0.7rem;padding:4px 8px;background:var(--surface);color:var(--fg);border:1px solid var(--border)" onclick="kbReimportDoc('${escapeHtml(d.slug)}')" title="Re-fetch and re-extract facts">🔄</button>`;
-            html += `<button class="nous-btn" style="background:#dc2626;color:white;font-size:0.7rem;padding:4px 8px" onclick="kbDeleteDoc('${escapeHtml(d.slug)}')">Remove</button>`;
+            html += `<button class="nous-btn" style="background:var(--red);color:var(--bg);font-size:0.7rem;padding:4px 8px" onclick="kbDeleteDoc('${escapeHtml(d.slug)}')">Remove</button>`;
             html += '</div></div>';
           }
         } else {
@@ -6844,7 +6854,7 @@ function burnAreaChart() {
           <option value="personal">Personal</option>
         </select>`;
         html += '<div style="display:flex;justify-content:flex-end">';
-        html += '<button class="nous-btn" style="background:#2563eb;color:white;padding:8px 20px" onclick="kbImportDocFromModal()">Import</button>';
+        html += '<button class="nous-btn" style="background:var(--blue);color:var(--bg);padding:8px 20px" onclick="kbImportDocFromModal()">Import</button>';
         html += '</div></div></details>';
 
         html += '<details open style="margin-top:10px"><summary style="cursor:pointer;font-size:0.78rem;font-weight:600;color:var(--fg)">📚 Import from Context7</summary>';
@@ -6881,7 +6891,7 @@ function burnAreaChart() {
         html += '<textarea id="kb-import-content" rows="8" style="width:100%;padding:8px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem;font-family:var(--font-mono);resize:vertical;min-height:120px;box-sizing:border-box" placeholder="# Guard .join() against undefined\n\nAlways use (arr || []).join(\',\')..."></textarea>';
         html += '<div style="display:flex;align-items:center;justify-content:space-between">';
         html += '<label style="font-size:0.72rem;color:var(--muted);cursor:pointer;display:flex;align-items:center;gap:4px"><span>or load from file:</span><input type="file" accept=".md,.json,.txt" style="font-size:0.72rem" onchange="kbLoadFile(this)"></label>';
-        html += '<button class="nous-btn" style="background:#2563eb;color:white;padding:8px 20px" onclick="kbSubmitImport()">Import</button>';
+        html += '<button class="nous-btn" style="background:var(--blue);color:var(--bg);padding:8px 20px" onclick="kbSubmitImport()">Import</button>';
         html += '</div></div></details>';
         html += '</div>';
 
@@ -6890,7 +6900,7 @@ function burnAreaChart() {
 
         el.innerHTML = html;
       } catch (e) {
-        el.innerHTML = '<div style="color:#dc2626;padding:12px">Failed to load knowledge sources: ' + escapeHtml(e.message) + '</div>';
+        el.innerHTML = '<div style="color:var(--red);padding:12px">Failed to load knowledge sources: ' + escapeHtml(e.message) + '</div>';
       }
     }
 
@@ -7013,7 +7023,7 @@ function burnAreaChart() {
       el.innerHTML = '<div style="padding:8px;color:var(--muted);font-size:0.72rem">Searching...</div>';
       try {
         const r = await fetch('/api/knowledge/context7/search?q=' + encodeURIComponent(query));
-        if (!r.ok) { el.innerHTML = '<div style="color:#dc2626;font-size:0.72rem;padding:8px">Search failed</div>'; return; }
+        if (!r.ok) { el.innerHTML = '<div style="color:var(--red);font-size:0.72rem;padding:8px">Search failed</div>'; return; }
         const results = await r.json();
         if (!results || results.length === 0) { el.innerHTML = '<div style="padding:8px;color:var(--muted);font-size:0.72rem">No libraries found.</div>'; return; }
         let html = '';
@@ -7033,12 +7043,12 @@ function burnAreaChart() {
           html += '</div>';
           if (desc) html += '<div style="color:var(--muted);font-size:0.68rem;margin-top:2px;overflow:hidden;text-overflow:ellipsis;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical">' + escapeHtml(desc) + '</div>';
           html += '</div>';
-          html += '<button class="nous-btn" style="background:#2563eb;color:white;font-size:0.68rem;padding:4px 10px;margin-left:8px;white-space:nowrap" onclick="kbImportCtx7(\'' + escapeHtml(id) + '\',\'' + escapeHtml(name) + '\')">Import</button>';
+          html += '<button class="nous-btn" style="background:var(--blue);color:var(--bg);font-size:0.68rem;padding:4px 10px;margin-left:8px;white-space:nowrap" onclick="kbImportCtx7(\'' + escapeHtml(id) + '\',\'' + escapeHtml(name) + '\')">Import</button>';
           html += '</div>';
         }
         el.innerHTML = html;
       } catch (e) {
-        el.innerHTML = '<div style="color:#dc2626;font-size:0.72rem;padding:8px">Error: ' + escapeHtml(e.message) + '</div>';
+        el.innerHTML = '<div style="color:var(--red);font-size:0.72rem;padding:8px">Error: ' + escapeHtml(e.message) + '</div>';
       }
     }
 
@@ -7174,7 +7184,7 @@ function burnAreaChart() {
             html += `<div style="font-size:0.7rem;color:var(--muted)">${escapeHtml(v.root_dir)} · ${v.pages} pages</div></div>`;
             html += `<div style="display:flex;gap:4px">`;
             html += `<button class="nous-btn" style="background:var(--surface);color:var(--fg);border:1px solid var(--border);font-size:0.7rem;padding:4px 8px" onclick="kbReindexVault('${escapeHtml(v.root_dir)}')">↻ Reindex</button>`;
-            html += `<button class="nous-btn" style="background:#dc2626;color:white;font-size:0.7rem;padding:4px 8px" onclick="kbDisconnectVault('${escapeHtml(v.root_dir)}')">Disconnect</button>`;
+            html += `<button class="nous-btn" style="background:var(--red);color:var(--bg);font-size:0.7rem;padding:4px 8px" onclick="kbDisconnectVault('${escapeHtml(v.root_dir)}')">Disconnect</button>`;
             html += '</div></div>';
             if (tagList) html += `<div style="margin-top:4px">${tagList}</div>`;
             html += `<div style="font-size:0.65rem;color:var(--muted);margin-top:4px">Last indexed: ${v.last_indexed ? new Date(v.last_indexed).toLocaleTimeString() : 'never'}</div>`;
@@ -7193,12 +7203,12 @@ function burnAreaChart() {
         html += '<input id="kb-vault-name" type="text" class="kb-search-box" placeholder="Display name">';
         html += '</div>';
         html += '<div style="display:flex;justify-content:flex-end">';
-        html += '<button class="nous-btn" style="background:#2563eb;color:white" onclick="kbConnectVault()">Connect</button>';
+        html += '<button class="nous-btn" style="background:var(--blue);color:var(--bg)" onclick="kbConnectVault()">Connect</button>';
         html += '</div></div>';
 
         el.innerHTML = html;
       } catch (e) {
-        el.innerHTML = '<div style="color:#dc2626;padding:12px">Failed to load vaults: ' + escapeHtml(e.message) + '</div>';
+        el.innerHTML = '<div style="color:var(--red);padding:12px">Failed to load vaults: ' + escapeHtml(e.message) + '</div>';
       }
     }
 
@@ -7357,15 +7367,15 @@ function burnAreaChart() {
     const LEADERBOARD_POLL_MS = 30000;
 
     const TRUST_TIER_COLORS = {
-      newcomer:    '#d29922',
-      contributor: '#58a6ff',
-      trusted:     '#3fb950',
-      advisor:     '#bc8cff',
-      revoked:     '#f85149',
+      newcomer:    'var(--yellow)',
+      contributor: 'var(--blue)',
+      trusted:     'var(--green)',
+      advisor:     'var(--purple)',
+      revoked:     'var(--red)',
     };
 
     function trustTierBadge(tier) {
-      return `<span style="display:inline-block;padding:2px 8px;border-radius:4px;font-size:0.7rem;color:#8b949e;border:1px solid #30363d">${esc(tier || 'unknown')}</span>`;
+      return `<span style="display:inline-block;padding:2px 8px;border-radius:4px;font-size:0.7rem;color:var(--muted);border:1px solid var(--line)">${esc(tier || 'unknown')}</span>`;
     }
 
     // Active contributor filter set — empty means "all"
@@ -7393,9 +7403,9 @@ function burnAreaChart() {
 
       function pill(key, label, count) {
         const active = key === CONTRIBUTOR_FILTER_ALL ? isAllActive : _contributorFilters.has(key);
-        const bg = active ? '#30363d' : 'transparent';
-        const fg = active ? '#e6edf3' : '#8b949e';
-        const border = '#30363d';
+        const bg = active ? 'var(--line)' : 'transparent';
+        const fg = active ? 'var(--text)' : 'var(--muted)';
+        const border = 'var(--line)';
         return `<button onclick="toggleContributorFilter('${key}')" style="display:inline-flex;align-items:center;gap:4px;padding:4px 12px;border-radius:9999px;font-size:0.72rem;font-weight:600;cursor:pointer;border:1px solid ${border};background:${bg};color:${fg};transition:all 0.15s">${esc(label)} <span style="opacity:0.8">${count}</span></button>`;
       }
 
@@ -7465,7 +7475,7 @@ function burnAreaChart() {
       let html = '';
       if (nonRevoked.length > 0) {
         const cards = nonRevoked.map(c => {
-          const dotColor = c.active ? '#3fb950' : '#8b949e';
+          const dotColor = c.active ? 'var(--green)' : 'var(--muted)';
           const dotTitle = c.active ? 'Online' : 'Offline';
           const ghLink = `https://github.com/${esc(c.github_username)}`;
           const avatar = c.avatar_url || `https://github.com/${esc(c.github_username)}.png`;
@@ -7478,19 +7488,19 @@ function burnAreaChart() {
             <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;flex-wrap:wrap">
               <span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${dotColor};flex-shrink:0" title="${dotTitle}"></span>
               <img src="${avatar}" alt="" style="width:28px;height:28px;border-radius:50%;flex-shrink:0" onerror="this.style.display='none'">
-              <a href="${ghLink}" target="_blank" rel="noopener" style="color:#58a6ff;text-decoration:none;font-weight:600">@${esc(c.github_username)}</a>
+              <a href="${ghLink}" target="_blank" rel="noopener" style="color:var(--blue);text-decoration:none;font-weight:600">@${esc(c.github_username)}</a>
               <span style="flex-shrink:0">${trustTierBadge(c.trust_tier)}</span>
             </div>
             ${cliLine ? `<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">${cliLine}${roleLine ? ' · ' + roleLine : ''}</div>` : (roleLine ? `<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">${roleLine}</div>` : '')}
             <div style="display:flex;gap:16px;margin-bottom:6px;font-size:0.8rem;color:var(--muted)">
               <span>Completed: <strong style="color:var(--fg)">${c.total_tasks_completed || 0}</strong></span>
-              <span>Failed: <strong style="color:${(c.total_tasks_failed || 0) > 0 ? '#f85149' : 'var(--fg)'}">${c.total_tasks_failed || 0}</strong></span>
+              <span>Failed: <strong style="color:${(c.total_tasks_failed || 0) > 0 ? 'var(--red)' : 'var(--fg)'}">${c.total_tasks_failed || 0}</strong></span>
             </div>
-            ${(c.active_tasks && c.active_tasks.length > 0) ? '<div style="font-size:0.65rem;color:var(--muted);margin-bottom:2px;font-weight:600">Current tasks</div>' + c.active_tasks.map(t => `<div style="font-size:0.75rem;color:var(--muted);margin-bottom:4px;padding:6px 10px;background:rgba(56,139,253,0.08);border:1px solid rgba(56,139,253,0.2);border-radius:4px;word-wrap:break-word;overflow-wrap:break-word"><span style="color:#58a6ff">${esc(t.kind)}</span> <a href="https://github.com/${esc(t.repo)}/issues/${t.number}" target="_blank" rel="noopener" style="color:#58a6ff;text-decoration:underline;font-weight:600">${esc(t.repo)}#${t.number} ↗</a> — ${esc(t.title)}</div>`).join('') : (c.current_task ? `<div style="font-size:0.65rem;color:var(--muted);margin-bottom:2px;font-weight:600">Current task</div><div style="font-size:0.75rem;color:var(--muted);margin-bottom:10px;padding:8px 10px;background:rgba(56,139,253,0.08);border:1px solid rgba(56,139,253,0.2);border-radius:4px;word-wrap:break-word;overflow-wrap:break-word"><span style="color:#58a6ff">${esc(c.current_task.kind)}</span> <a href="https://github.com/${esc(c.current_task.repo)}/issues/${c.current_task.number}" target="_blank" rel="noopener" style="color:#58a6ff;text-decoration:underline;font-weight:600">${esc(c.current_task.repo)}#${c.current_task.number} ↗</a> — ${esc(c.current_task.title)}</div>` : (c.last_completed_task ? `<div style="font-size:0.65rem;color:var(--muted);margin-bottom:2px;font-weight:600">Last completed</div><div style="font-size:0.75rem;color:var(--muted);margin-bottom:10px;padding:6px 10px;background:rgba(34,197,94,0.08);border:1px solid rgba(34,197,94,0.2);border-radius:4px;word-wrap:break-word;overflow-wrap:break-word"><span style="color:#3fb950">${esc(c.last_completed_task.kind)}</span> <a href="https://github.com/${esc(c.last_completed_task.repo)}/issues/${c.last_completed_task.number}" target="_blank" rel="noopener" style="color:#3fb950;text-decoration:underline">${esc(c.last_completed_task.repo)}#${c.last_completed_task.number} ↗</a> — ${esc(c.last_completed_task.title)}</div>` : (c.active ? '<div style="font-size:0.75rem;color:#3fb950;margin-bottom:10px">Idle — waiting for task</div>' : '')))}
+            ${(c.active_tasks && c.active_tasks.length > 0) ? '<div style="font-size:0.65rem;color:var(--muted);margin-bottom:2px;font-weight:600">Current tasks</div>' + c.active_tasks.map(t => `<div style="font-size:0.75rem;color:var(--muted);margin-bottom:4px;padding:6px 10px;background:rgba(56,139,253,0.08);border:1px solid rgba(56,139,253,0.2);border-radius:4px;word-wrap:break-word;overflow-wrap:break-word"><span style="color:var(--blue)">${esc(t.kind)}</span> <a href="https://github.com/${esc(t.repo)}/issues/${t.number}" target="_blank" rel="noopener" style="color:var(--blue);text-decoration:underline;font-weight:600">${esc(t.repo)}#${t.number} ↗</a> — ${esc(t.title)}</div>`).join('') : (c.current_task ? `<div style="font-size:0.65rem;color:var(--muted);margin-bottom:2px;font-weight:600">Current task</div><div style="font-size:0.75rem;color:var(--muted);margin-bottom:10px;padding:8px 10px;background:rgba(56,139,253,0.08);border:1px solid rgba(56,139,253,0.2);border-radius:4px;word-wrap:break-word;overflow-wrap:break-word"><span style="color:var(--blue)">${esc(c.current_task.kind)}</span> <a href="https://github.com/${esc(c.current_task.repo)}/issues/${c.current_task.number}" target="_blank" rel="noopener" style="color:var(--blue);text-decoration:underline;font-weight:600">${esc(c.current_task.repo)}#${c.current_task.number} ↗</a> — ${esc(c.current_task.title)}</div>` : (c.last_completed_task ? `<div style="font-size:0.65rem;color:var(--muted);margin-bottom:2px;font-weight:600">Last completed</div><div style="font-size:0.75rem;color:var(--muted);margin-bottom:10px;padding:6px 10px;background:rgba(34,197,94,0.08);border:1px solid rgba(34,197,94,0.2);border-radius:4px;word-wrap:break-word;overflow-wrap:break-word"><span style="color:var(--green)">${esc(c.last_completed_task.kind)}</span> <a href="https://github.com/${esc(c.last_completed_task.repo)}/issues/${c.last_completed_task.number}" target="_blank" rel="noopener" style="color:var(--green);text-decoration:underline">${esc(c.last_completed_task.repo)}#${c.last_completed_task.number} ↗</a> — ${esc(c.last_completed_task.title)}</div>` : (c.active ? '<div style="font-size:0.75rem;color:var(--green);margin-bottom:10px">Idle — waiting for task</div>' : '')))}
             ${c.sessions > 1 ? `<div style="font-size:0.7rem;color:var(--muted);margin-bottom:6px">${c.sessions} active sessions</div>` : ''}
             <div style="display:flex;gap:8px;align-items:center;font-size:0.75rem">
               <select onchange="changeContributorTier('${esc(c.contributor_id)}', this.value)" style="background:var(--card-bg);color:var(--fg);border:1px solid var(--border);border-radius:4px;padding:2px 6px;font-size:0.75rem">${tierOptions}</select>
-              <button onclick="revokeContributor('${esc(c.contributor_id)}')" style="background:transparent;color:#8b949e;border:1px solid #30363d;border-radius:4px;padding:2px 10px;cursor:pointer;font-size:0.75rem">Revoke</button>
+              <button onclick="revokeContributor('${esc(c.contributor_id)}')" style="background:transparent;color:var(--muted);border:1px solid var(--line);border-radius:4px;padding:2px 10px;cursor:pointer;font-size:0.75rem">Revoke</button>
             </div>
           </div>`;
         }).join('');
@@ -7505,11 +7515,11 @@ function burnAreaChart() {
           const ghLink = `https://github.com/${esc(c.github_username)}`;
           const revokedDate = c.last_heartbeat || c.registered_at || '';
           return `<tr style="border-bottom:1px solid var(--border)">
-            <td style="padding:6px 12px"><a href="${ghLink}" target="_blank" rel="noopener" style="color:#8b949e;text-decoration:none">@${esc(c.github_username)}</a></td>
+            <td style="padding:6px 12px"><a href="${ghLink}" target="_blank" rel="noopener" style="color:var(--muted);text-decoration:none">@${esc(c.github_username)}</a></td>
             <td style="padding:6px 12px;color:var(--muted);font-size:0.75rem">${esc(revokedDate)}</td>
             <td style="padding:6px 12px;text-align:right">
-              <button onclick="changeContributorTier('${esc(c.contributor_id)}', 'newcomer')" style="background:transparent;color:#58a6ff;border:1px solid #30363d;border-radius:4px;padding:2px 10px;cursor:pointer;font-size:0.72rem;margin-right:4px">Unrevoke</button>
-              <button onclick="deleteContributor('${esc(c.contributor_id)}')" style="background:transparent;color:#f85149;border:1px solid #30363d;border-radius:4px;padding:2px 10px;cursor:pointer;font-size:0.72rem">Remove</button>
+              <button onclick="changeContributorTier('${esc(c.contributor_id)}', 'newcomer')" style="background:transparent;color:var(--blue);border:1px solid var(--line);border-radius:4px;padding:2px 10px;cursor:pointer;font-size:0.72rem;margin-right:4px">Unrevoke</button>
+              <button onclick="deleteContributor('${esc(c.contributor_id)}')" style="background:transparent;color:var(--red);border:1px solid var(--line);border-radius:4px;padding:2px 10px;cursor:pointer;font-size:0.72rem">Remove</button>
             </td>
           </tr>`;
         }).join('');
@@ -7570,10 +7580,10 @@ function burnAreaChart() {
         return `<tr style="border-bottom:1px solid var(--border)">
           <td style="padding:8px 12px;font-weight:600;color:var(--muted)">${e.rank}</td>
           <td style="padding:8px 12px">${avatarHtml}</td>
-          <td style="padding:8px 12px"><a href="${ghLink}" target="_blank" rel="noopener" style="color:#58a6ff;text-decoration:none">@${esc(e.github_username)}</a></td>
+          <td style="padding:8px 12px"><a href="${ghLink}" target="_blank" rel="noopener" style="color:var(--blue);text-decoration:none">@${esc(e.github_username)}</a></td>
           <td style="padding:8px 12px">${trustTierBadge(e.trust_tier)}</td>
           <td style="padding:8px 12px;text-align:right">${e.tasks_completed || 0}</td>
-          <td style="padding:8px 12px;text-align:right;color:${(e.tasks_failed || 0) > 0 ? '#f85149' : 'var(--muted)'}">${e.tasks_failed || 0}</td>
+          <td style="padding:8px 12px;text-align:right;color:${(e.tasks_failed || 0) > 0 ? 'var(--red)' : 'var(--muted)'}">${e.tasks_failed || 0}</td>
         </tr>`;
       }).join('');
       setIfChanged(panel, `<div style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;overflow:hidden">
@@ -7631,7 +7641,7 @@ function burnAreaChart() {
       }
       if (statusBadge) {
         statusBadge.textContent = `${activeCount} active / ${totalCount} registered`;
-        statusBadge.style.background = activeCount > 0 ? '#238636' : '#30363d';
+        statusBadge.style.background = activeCount > 0 ? 'var(--green)' : 'var(--line)';
         statusBadge.style.color = '#fff';
       }
     }
@@ -7653,7 +7663,7 @@ function burnAreaChart() {
       if (pct < SYS_GAUGE_NORMAL_MAX) return '#4b5563';  // muted gray — healthy
       if (pct < SYS_GAUGE_AMBER_MAX) return '#d97706';   // amber — elevated
       if (pct < SYS_GAUGE_ORANGE_MAX) return '#ea580c';   // orange — high
-      return '#dc2626';                                     // red — critical
+      return 'var(--red)';                                     // red — critical
     }
 
     function sysGaugeMiniSpark(values, color) {
@@ -7991,7 +8001,7 @@ function burnAreaChart() {
         (document.body.style.backgroundColor || '').indexOf('0d1117') !== -1;
 
       var COLORS = isDark
-        ? { bg: '#161b22', border: '#30363d', text: '#e6edf3', muted: '#8b949e', blue: '#58a6ff', green: '#3fb950', lineBg: '#30363d' }
+        ? { bg: 'var(--panel)', border: 'var(--line)', text: 'var(--text)', muted: 'var(--muted)', blue: 'var(--blue)', green: 'var(--green)', lineBg: 'var(--line)' }
         : { bg: '#ffffff', border: '#d0d7de', text: '#1f2328', muted: '#656d76', blue: '#0969da', green: '#1a7f37', lineBg: '#d0d7de' };
 
       var STAGE_COUNT = STAGES.length;
@@ -8146,12 +8156,12 @@ function burnAreaChart() {
     function renderInceptionModeSelect() {
       return `
         <div style="display:flex;gap:16px;max-width:700px;margin:0 auto">
-          <div onclick="startInceptionGreenfield()" style="flex:1;background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:24px;cursor:pointer;text-align:center;transition:border-color 0.2s" onmouseover="this.style.borderColor='var(--blue, #58a6ff)'" onmouseout="this.style.borderColor='var(--border)'">
+          <div onclick="startInceptionGreenfield()" style="flex:1;background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:24px;cursor:pointer;text-align:center;transition:border-color 0.2s" onmouseover="this.style.borderColor='var(--blue)'" onmouseout="this.style.borderColor='var(--border)'">
             <div style="font-size:2rem;margin-bottom:8px">🌱</div>
             <div style="font-weight:600;margin-bottom:4px">Start from an idea</div>
             <div style="font-size:0.78rem;color:var(--muted)">New project — describe what you want to build and we'll scaffold it</div>
           </div>
-          <div onclick="startInceptionBrownfield()" style="flex:1;background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:24px;cursor:pointer;text-align:center;transition:border-color 0.2s" onmouseover="this.style.borderColor='var(--blue, #58a6ff)'" onmouseout="this.style.borderColor='var(--border)'">
+          <div onclick="startInceptionBrownfield()" style="flex:1;background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:24px;cursor:pointer;text-align:center;transition:border-color 0.2s" onmouseover="this.style.borderColor='var(--blue)'" onmouseout="this.style.borderColor='var(--border)'">
             <div style="font-size:2rem;margin-bottom:8px">🏗️</div>
             <div style="font-weight:600;margin-bottom:4px">Add to existing repo</div>
             <div style="font-size:0.78rem;color:var(--muted)">Scan an existing project and capture its principles as KB facts</div>
@@ -8166,8 +8176,8 @@ function burnAreaChart() {
           <textarea id="inception-idea" placeholder="A CLI tool that syncs Obsidian vaults to a wiki server..." style="width:100%;min-height:80px;padding:12px;border:1px solid var(--border);border-radius:8px;background:var(--card-bg);color:var(--fg);font-family:inherit;font-size:0.85rem;resize:vertical"></textarea>
           <div style="margin-top:12px;display:flex;gap:8px;justify-content:flex-end">
             <button onclick="stopInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Stop</button>
-            <button onclick="clearInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--red, #f85149);cursor:pointer;font-size:0.82rem">Clear</button>
-            <button onclick="submitInceptionIdea()" style="padding:8px 24px;border:none;border-radius:6px;background:var(--blue, #58a6ff);color:#0d1117;cursor:pointer;font-size:0.82rem;font-weight:600">Start</button>
+            <button onclick="clearInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--red);cursor:pointer;font-size:0.82rem">Clear</button>
+            <button onclick="submitInceptionIdea()" style="padding:8px 24px;border:none;border-radius:6px;background:var(--blue);color:var(--bg);cursor:pointer;font-size:0.82rem;font-weight:600">Start</button>
           </div>
         </div>`;
     }
@@ -8198,7 +8208,7 @@ function burnAreaChart() {
       return `
         <div style="max-width:100%;margin:0">
           <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px">
-            <div style="width:8px;height:8px;border-radius:50%;background:var(--blue, #58a6ff);animation:pulse 1.5s infinite"></div>
+            <div style="width:8px;height:8px;border-radius:50%;background:var(--blue);animation:pulse 1.5s infinite"></div>
             <div style="font-size:0.82rem;font-weight:600">Brainstorm agent working</div>
             <div style="font-size:0.72rem;color:var(--muted);margin-left:auto">Phase: ${phase}</div>
           </div>
@@ -8208,7 +8218,7 @@ function burnAreaChart() {
           </div>
           <div style="margin-top:12px;display:flex;gap:8px;justify-content:flex-end">
             <button onclick="stopInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Stop</button>
-            <button onclick="clearInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--red, #f85149);cursor:pointer;font-size:0.82rem">Clear</button>
+            <button onclick="clearInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--red);cursor:pointer;font-size:0.82rem">Clear</button>
           </div>
         </div>`;
     }
@@ -8292,7 +8302,7 @@ function burnAreaChart() {
       });
       html += `<div style="display:flex;gap:8px;justify-content:flex-end">
         <button onclick="resetInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Reset</button>
-        <button onclick="submitInceptionAnswers()" style="padding:8px 24px;border:none;border-radius:6px;background:var(--blue, #58a6ff);color:#0d1117;cursor:pointer;font-size:0.82rem;font-weight:600">Submit</button>
+        <button onclick="submitInceptionAnswers()" style="padding:8px 24px;border:none;border-radius:6px;background:var(--blue);color:var(--bg);cursor:pointer;font-size:0.82rem;font-weight:600">Submit</button>
       </div>`;
       html += '</div>';
       return html;
@@ -8302,7 +8312,7 @@ function burnAreaChart() {
       return `
         <div style="max-width:100%;margin:0">
           <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px">
-            <div style="width:8px;height:8px;border-radius:50%;background:var(--blue, #58a6ff);animation:pulse 1.5s infinite"></div>
+            <div style="width:8px;height:8px;border-radius:50%;background:var(--blue);animation:pulse 1.5s infinite"></div>
             <div style="font-size:0.82rem;font-weight:600">Brainstorm agent structuring project</div>
             <div style="font-size:0.72rem;color:var(--muted);margin-left:auto">Phase: structure</div>
           </div>
@@ -8312,7 +8322,7 @@ function burnAreaChart() {
           </div>
           <div style="margin-top:12px;display:flex;gap:8px;justify-content:flex-end">
             <button onclick="stopInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Stop</button>
-            <button onclick="clearInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--red, #f85149);cursor:pointer;font-size:0.82rem">Clear</button>
+            <button onclick="clearInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--red);cursor:pointer;font-size:0.82rem">Clear</button>
           </div>
         </div>`;
     }
@@ -8325,7 +8335,7 @@ function burnAreaChart() {
           <div id="inception-scaffold-summary" style="margin-bottom:16px"><div style="text-align:center;color:var(--muted);padding:20px">Loading scaffold summary...</div></div>
           <div style="display:flex;gap:8px;justify-content:flex-end">
             <button onclick="resetInception()" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">Start Over</button>
-            <button onclick="approveInception()" style="padding:8px 24px;border:none;border-radius:6px;background:var(--blue, #58a6ff);color:#0d1117;cursor:pointer;font-size:0.82rem;font-weight:600">Approve</button>
+            <button onclick="approveInception()" style="padding:8px 24px;border:none;border-radius:6px;background:var(--blue);color:var(--bg);cursor:pointer;font-size:0.82rem;font-weight:600">Approve</button>
           </div>
         </div>`;
     }
@@ -8362,7 +8372,7 @@ function burnAreaChart() {
           html += '<span style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:12px;font-size:0.72rem;color:var(--muted)">.' + escapeHtml(ext) + ' ×' + count + '</span>';
         });
         html += '</div>';
-        html += '<details><summary style="cursor:pointer;font-size:0.8rem;color:var(--blue, #58a6ff)">View file tree</summary>';
+        html += '<details><summary style="cursor:pointer;font-size:0.8rem;color:var(--blue)">View file tree</summary>';
         html += '<div style="margin-top:8px">' + renderFileTree(files) + '</div>';
         html += '</details></div>';
         container.innerHTML = html;
@@ -8380,7 +8390,7 @@ function burnAreaChart() {
           <div id="inception-complete-files" style="margin-bottom:16px"></div>
           <div style="display:flex;gap:8px;justify-content:center">
             <button onclick="resetInception()" style="padding:8px 20px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer;font-size:0.82rem">New Inception</button>
-            <button onclick="downloadInceptionZip()" style="padding:8px 20px;border:none;border-radius:6px;background:var(--blue, #58a6ff);color:#0d1117;cursor:pointer;font-size:0.82rem;font-weight:600">Download Project</button>
+            <button onclick="downloadInceptionZip()" style="padding:8px 20px;border:none;border-radius:6px;background:var(--blue);color:var(--bg);cursor:pointer;font-size:0.82rem;font-weight:600">Download Project</button>
             <button onclick="loadInceptionCompleteFiles()" style="padding:8px 20px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--fg);cursor:pointer;font-size:0.82rem">Refresh Files</button>
           </div>
         </div>`;
@@ -8694,7 +8704,7 @@ function burnAreaChart() {
           <div style="${rowStyle}"><span>Identity</span><span>${ghIdentityBadge} ${esc(ghIdentityLabel)}</span></div>
           <div style="${rowStyle}"><span>Core API</span><span style="font-weight:600">${ghCoreUsed} / ${ghCoreLimit} (${ghCorePct}%)</span></div>
           <div style="${rowStyle}"><span>Resets at</span><span>${ghResetAt}</span></div>
-          <div style="margin-top:6px;height:6px;background:#e5e7eb;border-radius:3px;overflow:hidden">
+          <div style="margin-top:6px;height:6px;background:var(--line);border-radius:3px;overflow:hidden">
             <div style="height:100%;width:${ghCorePct}%;background:${ghCorePct > 80 ? 'var(--red)' : ghCorePct > 50 ? 'var(--yellow)' : 'var(--green)'};border-radius:3px;transition:width 0.3s"></div>
           </div>
         </div>
@@ -9265,7 +9275,7 @@ function burnAreaChart() {
         const issueKey = repo + ':' + c.id;
         const existing = _acmmOpenedIssues[issueKey];
         if (existing) {
-          issueBtn = '<span style="margin-left:auto;padding:3px 10px;font-size:0.7rem;border:1px solid #238636;border-radius:4px;color:var(--muted);white-space:nowrap">✅ <a href="' + escapeHtml(existing.url) + '" target="_blank" style="color:var(--muted);font-size:0.68rem">#' + existing.number + '</a></span>';
+          issueBtn = '<span style="margin-left:auto;padding:3px 10px;font-size:0.7rem;border:1px solid var(--green);border-radius:4px;color:var(--muted);white-space:nowrap">✅ <a href="' + escapeHtml(existing.url) + '" target="_blank" style="color:var(--muted);font-size:0.68rem">#' + existing.number + '</a></span>';
         } else {
           const escapedId = escapeHtml(c.id).replace(/'/g, "\\'");
           const escapedRepo = escapeHtml(repo).replace(/'/g, "\\'");
@@ -9318,7 +9328,7 @@ function burnAreaChart() {
         const data = await r.json();
         _acmmOpenedIssues[repo + ':' + criterionId] = {number: data.issue_number, url: data.issue_url};
         btn.innerHTML = '✅ <a href="' + escapeHtml(data.issue_url) + '" target="_blank" style="color:var(--muted);font-size:0.68rem">#' + data.issue_number + '</a>';
-        btn.style.borderColor = '#238636';
+        btn.style.borderColor = 'var(--green)';
       } catch (e) {
         btn.textContent = '⚠ Error';
         setTimeout(() => { btn.textContent = origText; btn.disabled = false; }, 3000);
@@ -9362,7 +9372,7 @@ function burnAreaChart() {
         }
         const data = await r.json();
         _acmmOpenedIssues[repo + ':' + criterionId] = {number: data.issue_number, url: data.issue_url};
-        acmmShowDialog('Issue Created', '<p style="font-size:0.82rem">Issue <a href="' + escapeHtml(data.issue_url) + '" target="_blank" style="color:#58a6ff">#' + data.issue_number + '</a> created on <strong>' + escapeHtml(repo) + '</strong> with <code>acmm</code> and <code>ai-fix-requested</code> labels.</p>');
+        acmmShowDialog('Issue Created', '<p style="font-size:0.82rem">Issue <a href="' + escapeHtml(data.issue_url) + '" target="_blank" style="color:var(--blue)">#' + data.issue_number + '</a> created on <strong>' + escapeHtml(repo) + '</strong> with <code>acmm</code> and <code>ai-fix-requested</code> labels.</p>');
       } catch (e) {
         acmmShowDialog('Issue Creation Failed', '<p style="color:#da3633;font-size:0.82rem">Network error: ' + escapeHtml(e.message) + '</p>');
       }
@@ -9401,7 +9411,7 @@ function burnAreaChart() {
         html += '</div>';
         html += '<div style="display:flex;gap:8px;justify-content:flex-end">' +
           '<button onclick="acmmCloseDialog()" style="padding:6px 14px;background:var(--bg);border:1px solid var(--border);border-radius:6px;cursor:pointer;color:var(--muted);font-size:0.78rem">Cancel</button>' +
-          '<button onclick="acmmBatchCreateIssues(' + level + ')" style="padding:6px 14px;background:#238636;border:none;border-radius:6px;cursor:pointer;color:#fff;font-size:0.78rem;font-weight:600">Create ' + newCriteria.length + ' Issue(s)</button></div>';
+          '<button onclick="acmmBatchCreateIssues(' + level + ')" style="padding:6px 14px;background:var(--green);border:none;border-radius:6px;cursor:pointer;color:var(--bg);font-size:0.78rem;font-weight:600">Create ' + newCriteria.length + ' Issue(s)</button></div>';
       }
       acmmShowDialog('Open Issues for L' + level + ' ' + (ACMM_LEVEL_NAMES[level] || ''), html);
     }
@@ -9466,7 +9476,7 @@ function burnAreaChart() {
       const desc = ACMM_LEVEL_DESCRIPTIONS[level] || '';
       const pct = lvlData ? Math.round(lvlData.score * 100) : 0;
       const passed = lvlData ? lvlData.passed : false;
-      const statusColor = passed ? '#238636' : (pct > 40 ? '#d29922' : '#da3633');
+      const statusColor = passed ? 'var(--green)' : (pct > 40 ? 'var(--yellow)' : '#da3633');
       const statusText = passed ? '✓ Passed' : '✗ Not passed';
       const threshold = lvlData ? Math.round(lvlData.threshold * 100) : 70;
       const failCount = criteria.filter(c => !c.passed).length;
@@ -9528,9 +9538,9 @@ function burnAreaChart() {
       if (firstFail) {
         const needed = Math.ceil(firstFail.total * acmmLevelThresholdPct / 100) - firstFail.matched;
         const fpct = Math.round(firstFail.score * 100);
-        html += '<div style="margin-bottom:12px;padding:8px 10px;background:var(--bg);border-radius:6px;font-size:0.78rem;color:var(--muted);border-left:3px solid #d29922">' +
+        html += '<div style="margin-bottom:12px;padding:8px 10px;background:var(--bg);border-radius:6px;font-size:0.78rem;color:var(--muted);border-left:3px solid var(--yellow)">' +
           '<strong>Blocked at L' + firstFail.level + ' ' + escapeHtml(firstFail.name) + '</strong> — ' + fpct + '%, need ' + needed + ' more criteria to reach 70%. ' +
-          '<span onclick="acmmShowLevelDialog(' + firstFail.level + ')" style="color:#58a6ff;cursor:pointer;text-decoration:underline">View missing criteria →</span></div>';
+          '<span onclick="acmmShowLevelDialog(' + firstFail.level + ')" style="color:var(--blue);cursor:pointer;text-decoration:underline">View missing criteria →</span></div>';
       }
 
       if (hasMultiRepo) {
@@ -9539,7 +9549,7 @@ function burnAreaChart() {
         for (let ri = 0; ri < d.repo_results.length; ri++) {
           const rr = d.repo_results[ri];
           const rPct = rr.criteria_total > 0 ? Math.round(rr.criteria_passed / rr.criteria_total * 100) : 0;
-          const rColor = rr.codebase_level >= 2 ? '#238636' : (rr.criteria_passed > rr.criteria_total * 0.5 ? '#d29922' : '#da3633');
+          const rColor = rr.codebase_level >= 2 ? 'var(--green)' : (rr.criteria_passed > rr.criteria_total * 0.5 ? 'var(--yellow)' : '#da3633');
           const expandId = 'acmm-repo-expand-' + ri;
           html += '<div style="margin-bottom:3px">' +
             '<div onclick="var el=document.getElementById(\'' + expandId + '\');el.style.display=el.style.display===\'none\'?\'block\':\'none\'" ' +
@@ -9550,7 +9560,7 @@ function burnAreaChart() {
             '<div id="' + expandId + '" style="display:none;padding:6px 8px 8px;border:1px solid var(--border);border-top:none;border-radius:0 0 6px 6px;background:var(--surface)">';
           for (const lvl of (rr.levels || [])) {
             const pct = Math.round(lvl.score * 100);
-            const color = lvl.passed ? '#238636' : (pct > 40 ? '#d29922' : '#da3633');
+            const color = lvl.passed ? 'var(--green)' : (pct > 40 ? 'var(--yellow)' : '#da3633');
             const safeRepo = escapeHtml(rr.repo).replace(/'/g, "\\'");
             html += '<div onclick="event.stopPropagation();acmmShowLevelDialog(' + lvl.level + ',\'' + safeRepo + '\')" ' +
               'style="cursor:pointer;padding:5px 6px;margin-bottom:3px;background:var(--bg);border-radius:4px;border:1px solid var(--border);transition:border-color .15s" ' +
@@ -9567,7 +9577,7 @@ function burnAreaChart() {
         // Single repo: show level bars directly
         for (const lvl of levels) {
           const pct = Math.round(lvl.score * 100);
-          const color = lvl.passed ? '#238636' : (pct > 40 ? '#d29922' : '#da3633');
+          const color = lvl.passed ? 'var(--green)' : (pct > 40 ? 'var(--yellow)' : '#da3633');
           html += '<div onclick="acmmShowLevelDialog(' + lvl.level + ')" style="cursor:pointer;padding:8px;margin-bottom:4px;background:var(--bg);border-radius:6px;border:1px solid var(--border);transition:border-color .15s" onmouseover="this.style.borderColor=\'var(--muted)\'" onmouseout="this.style.borderColor=\'var(--border)\'">' +
             '<div style="display:flex;align-items:center;justify-content:space-between">' +
             '<span style="font-size:0.82rem;font-weight:600">' + (lvl.passed ? '✓' : '✗') + ' L' + lvl.level + ' ' + escapeHtml(lvl.name) + '</span>' +
@@ -9635,7 +9645,7 @@ function burnAreaChart() {
       for (const lvl of levels) {
         const criteria = results.filter(c => c.level === lvl.level);
         const pct = Math.round(lvl.score * 100);
-        const color = lvl.passed ? '#238636' : (pct > 40 ? '#d29922' : '#da3633');
+        const color = lvl.passed ? 'var(--green)' : (pct > 40 ? 'var(--yellow)' : '#da3633');
         const failCount = criteria.filter(c => !c.passed).length;
         html += '<div style="margin-bottom:8px">' +
           '<div onclick="acmmCloseDialog();acmmShowLevelDialog(' + lvl.level + ')" style="cursor:pointer;display:flex;align-items:center;justify-content:space-between;padding:6px 8px;background:var(--bg);border-radius:6px;border:1px solid var(--border);transition:border-color .15s" onmouseover="this.style.borderColor=\'var(--muted)\'" onmouseout="this.style.borderColor=\'var(--border)\'">' +
@@ -9732,7 +9742,7 @@ function burnAreaChart() {
         let html = '';
         for (const lvl of levels) {
           const pct = Math.round(lvl.score * 100);
-          const color = lvl.passed ? '#238636' : (pct > 40 ? '#d29922' : '#da3633');
+          const color = lvl.passed ? 'var(--green)' : (pct > 40 ? 'var(--yellow)' : '#da3633');
           html += '<div onclick="acmmShowLevelDialog(' + lvl.level + ')" style="display:flex;align-items:center;gap:8px;margin-bottom:4px;font-size:0.75rem;cursor:pointer;padding:2px 4px;border-radius:4px;transition:background .15s" onmouseover="this.style.background=\'var(--bg)\'" onmouseout="this.style.background=\'transparent\'">' +
             '<span style="width:100px;color:var(--muted)">' + escapeHtml(lvl.name) + '</span>' +
             '<div style="flex:1;height:8px;background:var(--bg);border-radius:4px;overflow:hidden">' +
@@ -9792,7 +9802,7 @@ function burnAreaChart() {
           html += ' <span style="color:#22c55e" title="Up to date with remote">✓</span>';
         } else if (v.behind) {
           html += ` <span class="git-behind" title="Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">⬆ behind</span>`;
-          html += ` <button id="spoke-upgrade-btn" onclick="selfUpgrade('${escapeHtml(v.latestHash || '')}')" style="padding:3px 10px;font-size:0.7rem;background:#238636;color:#fff;border:none;border-radius:4px;cursor:pointer;margin-left:6px;white-space:nowrap" title="Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">Upgrade</button>`;
+          html += ` <button id="spoke-upgrade-btn" onclick="selfUpgrade('${escapeHtml(v.latestHash || '')}')" style="padding:3px 10px;font-size:0.7rem;background:var(--green);color:var(--bg);border:none;border-radius:4px;cursor:pointer;margin-left:6px;white-space:nowrap" title="Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">Upgrade</button>`;
         } else if (v.latestHash) {
           html += ' <span style="color:#22c55e" title="Up to date with remote">✓</span>';
         }
@@ -10026,7 +10036,7 @@ function burnAreaChart() {
             switchConfigTab(initialTab);
           } catch (err) {
             document.getElementById('config-body').innerHTML =
-              '<div style="text-align:center;padding:40px;color:#f85149">Failed to render tab: ' + err.message + '</div>';
+              '<div style="text-align:center;padding:40px;color:var(--red)">Failed to render tab: ' + err.message + '</div>';
             showToast('Config render error: ' + err.message, 'error');
           }
         });
@@ -10380,19 +10390,19 @@ function burnAreaChart() {
         '<p style="font-size:0.82rem;color:var(--muted);margin-bottom:16px">Import an agent from a YAML definition file. <a href="' + exampleURL + '" target="_blank" rel="noopener" style="color:var(--accent)">See example agent definition ↗</a></p>' +
         '<div class="config-field" style="margin-bottom:12px">' +
           '<label>Import from URL</label>' +
-          '<div style="display:flex;gap:8px"><input type="text" id="import-url-input" placeholder="' + rawURL + '" style="flex:1"><button onclick="previewImportFromURL()" style="padding:6px 16px;border-radius:6px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:#fff;white-space:nowrap">Preview</button></div>' +
+          '<div style="display:flex;gap:8px"><input type="text" id="import-url-input" placeholder="' + rawURL + '" style="flex:1"><button onclick="previewImportFromURL()" style="padding:6px 16px;border-radius:6px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg);white-space:nowrap">Preview</button></div>' +
         '</div>' +
         '<div class="config-field" style="margin-bottom:12px">' +
           '<label>Or paste agent definition</label>' +
           '<textarea id="import-paste-input" rows="20" style="width:100%;font-family:var(--font-mono);font-size:0.75rem;resize:vertical;min-height:300px" placeholder="apiVersion: hive.kubestellar.io/v1\nkind: AgentDefinition\n..."></textarea>' +
-          '<div style="text-align:right;margin-top:6px"><button onclick="previewImportFromPaste()" style="padding:6px 16px;border-radius:6px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:#fff">Preview</button></div>' +
+          '<div style="text-align:right;margin-top:6px"><button onclick="previewImportFromPaste()" style="padding:6px 16px;border-radius:6px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg)">Preview</button></div>' +
         '</div>' +
         '<div id="import-preview" style="display:none;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:16px;margin-top:16px">' +
           '<div style="font-weight:600;margin-bottom:12px">Preview</div>' +
           '<div id="import-preview-content"></div>' +
           '<div style="display:flex;justify-content:flex-end;gap:8px;margin-top:16px">' +
             '<button onclick="document.getElementById(\'import-preview\').style.display=\'none\'" style="padding:8px 16px;border:1px solid var(--border);border-radius:6px;background:none;color:var(--muted);cursor:pointer">Cancel</button>' +
-            '<button onclick="confirmImport()" style="padding:8px 20px;border:none;border-radius:6px;background:var(--green);color:#fff;cursor:pointer;font-weight:600">Create Agent</button>' +
+            '<button onclick="confirmImport()" style="padding:8px 20px;border:none;border-radius:6px;background:var(--green);color:var(--bg);cursor:pointer;font-weight:600">Create Agent</button>' +
           '</div>' +
         '</div>' +
       '</div>';
@@ -10507,7 +10517,7 @@ function burnAreaChart() {
         <div class="config-field">
           <label>API Key Env Name <span class="config-info">i<span class="config-tooltip">Name of the environment variable holding the LiteLLM API key. The key VALUE is never stored in hive.yaml or shown here. A key file at ${esc(keyFilePath)} takes precedence when present.</span></span></label>
           <input type="text" value="${esc(litellm.apiKeyEnv || '')}" placeholder="HIVE_LITELLM_API_KEY" onchange="markDirty('litellm','apiKeyEnv',this.value)">
-          <div style="font-size:0.72rem;margin-top:4px;color:${litellm.hasKey ? '#3fb950' : '#f85149'}">Key detected: ${litellm.hasKey ? 'yes' : `no — set ${esc(keyEnvName)} or mount ${esc(keyFilePath)}`}</div>
+          <div style="font-size:0.72rem;margin-top:4px;color:${litellm.hasKey ? 'var(--green)' : 'var(--red)'}">Key detected: ${litellm.hasKey ? 'yes' : `no — set ${esc(keyEnvName)} or mount ${esc(keyFilePath)}`}</div>
         </div>
         <div class="config-field">
           <label>Default Model <span class="config-info">i<span class="config-tooltip">Model used when an agent on the litellm backend has no model selected. Use Test Connection to list available models.</span></span></label>
@@ -10594,28 +10604,28 @@ function burnAreaChart() {
         <h4 style="font-size:0.8rem;color:var(--muted);margin:0 0 8px">Contribute Work Queue <span id="hub-queue-count" style="font-size:0.72rem;padding:2px 8px;border-radius:9999px;background:rgba(59,130,246,0.15);color:#60a5fa;border:1px solid rgba(59,130,246,0.3)">loading...</span></h4>
 
         <div class="config-toggle">
-          <div class="config-toggle-switch ${hub.contribute_suspended ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="hub" data-key="contribute_suspended" style="${hub.contribute_suspended ? 'background:#f85149' : ''}"></div>
-          <span class="config-toggle-label" style="${hub.contribute_suspended ? 'color:#f85149;font-weight:600' : ''}">Suspend Contributions <span class="config-info">i<span class="config-tooltip">Temporarily stop assigning tasks to contributors. Connected contributors stay online but idle.</span></span></span>
+          <div class="config-toggle-switch ${hub.contribute_suspended ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="hub" data-key="contribute_suspended" style="${hub.contribute_suspended ? 'background:var(--red)' : ''}"></div>
+          <span class="config-toggle-label" style="${hub.contribute_suspended ? 'color:var(--red);font-weight:600' : ''}">Suspend Contributions <span class="config-info">i<span class="config-tooltip">Temporarily stop assigning tasks to contributors. Connected contributors stay online but idle.</span></span></span>
         </div>
 
         <div class="config-field">
           <label>Deny Titles <span class="config-info">i<span class="config-tooltip">Issues matching these title patterns are excluded. Supports wildcards (*) and regex (/pattern/).</span></span></label>
-          <div id="hub-deny-titles" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">${denyTitles.map(function(t) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(248,81,73,0.15);color:#f85149;border:1px solid rgba(248,81,73,0.3)">' + esc(t) + ' <span onclick="removeHubFilter(\'contribute_deny_titles\',\'' + esc(t).replace(/'/g,"\\'") + '\')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('')}</div>
+          <div id="hub-deny-titles" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">${denyTitles.map(function(t) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(248,81,73,0.15);color:var(--red);border:1px solid rgba(248,81,73,0.3)">' + esc(t) + ' <span onclick="removeHubFilter(\'contribute_deny_titles\',\'' + esc(t).replace(/'/g,"\\'") + '\')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('')}</div>
           <div style="display:flex;gap:4px"><input type="text" id="hub-deny-title-input" placeholder="e.g. *dashboard*, epic:*, /renovate/i" style="flex:1" onkeydown="if(event.key==='Enter'){addHubFilter('contribute_deny_titles','hub-deny-title-input');event.preventDefault()}"><button onclick="addHubFilter('contribute_deny_titles','hub-deny-title-input')" style="padding:4px 12px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer;font-size:0.75rem">Add</button></div>
         </div>
 
         <div class="config-field">
           <label>Deny Authors <span class="config-info">i<span class="config-tooltip">Issues from these authors are excluded. Supports wildcards (*) and regex (/pattern/).</span></span></label>
-          <div id="hub-deny-authors" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">${denyAuthors.map(function(a) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(248,81,73,0.15);color:#f85149;border:1px solid rgba(248,81,73,0.3)">' + esc(a) + ' <span onclick="removeHubFilter(\'contribute_deny_authors\',\'' + esc(a).replace(/'/g,"\\'") + '\')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('')}</div>
+          <div id="hub-deny-authors" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">${denyAuthors.map(function(a) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(248,81,73,0.15);color:var(--red);border:1px solid rgba(248,81,73,0.3)">' + esc(a) + ' <span onclick="removeHubFilter(\'contribute_deny_authors\',\'' + esc(a).replace(/'/g,"\\'") + '\')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('')}</div>
           <div style="display:flex;gap:4px"><input type="text" id="hub-deny-author-input" placeholder="e.g. renovate[bot], dependabot*" style="flex:1" onkeydown="if(event.key==='Enter'){addHubFilter('contribute_deny_authors','hub-deny-author-input');event.preventDefault()}"><button onclick="addHubFilter('contribute_deny_authors','hub-deny-author-input')" style="padding:4px 12px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer;font-size:0.75rem">Add</button></div>
         </div>
 
         <hr style="border-color:var(--border);margin:16px 0">
-        <h4 style="font-size:0.8rem;color:var(--muted);margin:0 0 8px">Model Filter ${allowModels.length === 0 ? '<span style="font-weight:400;color:#3fb950;margin-left:8px">All models accepted</span>' : '<span style="font-weight:400;color:#58a6ff;margin-left:8px">' + allowModels.length + ' pattern' + (allowModels.length > 1 ? 's' : '') + '</span>'}</h4>
+        <h4 style="font-size:0.8rem;color:var(--muted);margin:0 0 8px">Model Filter ${allowModels.length === 0 ? '<span style="font-weight:400;color:var(--green);margin-left:8px">All models accepted</span>' : '<span style="font-weight:400;color:var(--blue);margin-left:8px">' + allowModels.length + ' pattern' + (allowModels.length > 1 ? 's' : '') + '</span>'}</h4>
 
         <div class="config-toggle">
-          <div class="config-toggle-switch ${rejectUnknownModels ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="hub" data-key="contribute_reject_unknown_models" style="${rejectUnknownModels ? 'background:#f85149' : ''}"></div>
-          <span class="config-toggle-label" style="${rejectUnknownModels ? 'color:#f85149;font-weight:600' : ''}">Reject Unknown Models <span class="config-info">i<span class="config-tooltip">When enabled and the allowlist is non-empty, contributors using models not in the list are rejected at connect time.</span></span></span>
+          <div class="config-toggle-switch ${rejectUnknownModels ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="hub" data-key="contribute_reject_unknown_models" style="${rejectUnknownModels ? 'background:var(--red)' : ''}"></div>
+          <span class="config-toggle-label" style="${rejectUnknownModels ? 'color:var(--red);font-weight:600' : ''}">Reject Unknown Models <span class="config-info">i<span class="config-tooltip">When enabled and the allowlist is non-empty, contributors using models not in the list are rejected at connect time.</span></span></span>
         </div>
 
         <div class="config-field">
@@ -10642,7 +10652,7 @@ function burnAreaChart() {
 
         <div class="config-field">
           <label>Deny Labels <span class="config-info">i<span class="config-tooltip">Issues with these labels will never be queued for contributors.</span></span></label>
-          <div id="hub-deny-labels" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">${denyLabels.map(function(l) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(248,81,73,0.15);color:#f85149;border:1px solid rgba(248,81,73,0.3)">' + esc(l) + ' <span onclick="removeHubLabel(\'deny\',' + "'" + esc(l) + "'" + ')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('')}</div>
+          <div id="hub-deny-labels" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">${denyLabels.map(function(l) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(248,81,73,0.15);color:var(--red);border:1px solid rgba(248,81,73,0.3)">' + esc(l) + ' <span onclick="removeHubLabel(\'deny\',' + "'" + esc(l) + "'" + ')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('')}</div>
           <div style="display:flex;gap:4px"><input type="text" id="hub-deny-label-input" placeholder="e.g. hold, wontfix, duplicate" style="flex:1" onkeydown="if(event.key==='Enter'){addHubLabel('deny');event.preventDefault()}"><button onclick="addHubLabel('deny')" style="padding:4px 12px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer;font-size:0.75rem">Add</button></div>
         </div>
 
@@ -10797,7 +10807,7 @@ function burnAreaChart() {
       let html = '';
       if (isCreate) {
         html += `<div class="config-field">
-          <label>Name <span style="color:#dc2626">*</span> <span class="config-info">i<span class="config-tooltip">The agent's internal name used as its ID, config file name, and tmux session. Lowercase, hyphens allowed.</span></span></label>
+          <label>Name <span style="color:var(--red)">*</span> <span class="config-info">i<span class="config-tooltip">The agent's internal name used as its ID, config file name, and tmux session. Lowercase, hyphens allowed.</span></span></label>
           <input type="text" id="cfg-create-name" value="" placeholder="e.g. docs-writer, sec-scanner" onchange="markDirty('_create','name',this.value)">
           <div style="font-size:0.65rem;color:var(--muted);margin-top:2px">Lowercase, hyphens allowed. Used as the agent ID.</div>
         </div>`;
@@ -10918,7 +10928,7 @@ function burnAreaChart() {
         </div>
         ${isCreate ? '' : `<div style="margin-top:24px;padding-top:16px;border-top:1px solid #fecaca">
           <label style="color:#b91c1c;font-weight:600;font-size:0.75rem;margin-bottom:8px;display:block">Danger Zone</label>
-          <button data-action="deleteAgentFromConfig" data-agent="${esc(agentName)}" style="background:#dc2626;color:#fff;border:none;padding:6px 16px;border-radius:6px;font-size:0.75rem;cursor:pointer;font-weight:600" title="Permanently remove this agent from the hive. Deletes its config file, env file, and sidebar entry. Cannot be undone.">Delete Agent</button>
+          <button data-action="deleteAgentFromConfig" data-agent="${esc(agentName)}" style="background:var(--red);color:var(--bg);border:none;padding:6px 16px;border-radius:6px;font-size:0.75rem;cursor:pointer;font-weight:600" title="Permanently remove this agent from the hive. Deletes its config file, env file, and sidebar entry. Cannot be undone.">Delete Agent</button>
           <span style="color:#9ca3af;font-size:0.65rem;margin-left:8px">Removes agent config, env file, and sidebar entry</span>
         </div>`}`;
       return html;
@@ -11026,7 +11036,7 @@ function burnAreaChart() {
           if (editable) {
             h += `<label style="font-size:0.7rem;display:flex;align-items:center;gap:4px;cursor:pointer;white-space:nowrap">`;
             h += `<input type="checkbox" ${r.enabled !== false ? 'checked' : ''} onchange="toggleRestriction(${i}, this.checked)"> on</label>`;
-            h += `<button style="background:none;border:none;color:#dc2626;cursor:pointer;font-size:1rem;padding:0 4px" data-action="removeRestriction" data-index="${i}">✕</button>`;
+            h += `<button style="background:none;border:none;color:var(--red);cursor:pointer;font-size:1rem;padding:0 4px" data-action="removeRestriction" data-index="${i}">✕</button>`;
           }
           h += '</div>';
         }
@@ -11042,9 +11052,9 @@ function burnAreaChart() {
       }
 
       let html = '<p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">Per-agent command restrictions enforced by the gh wrapper. Agent rules are editable; global and policy rules are read-only.</p>';
-      html += renderSection('Agent restrictions', '#2563eb', agentRules, { editable: true, icon: '🔧' });
+      html += renderSection('Agent restrictions', 'var(--blue)', agentRules, { editable: true, icon: '🔧' });
       html += '<div style="border-top:1px solid var(--border);padding-top:12px">';
-      html += renderSection('Global (all agents)', '#dc2626', globalRules, { icon: '🌐' });
+      html += renderSection('Global (all agents)', 'var(--red)', globalRules, { icon: '🌐' });
       html += renderSection('Policy (CLAUDE.md)', '#7c3aed', policyRules, { icon: '📋' });
       html += '</div>';
       return html;
@@ -11052,7 +11062,7 @@ function burnAreaChart() {
 
     // --- Channels tab ---
 
-    const CHANNEL_COLORS = {kick:'#2563eb',webhook:'#16a34a',discord:'#7c3aed',schedule:'#ea580c',bead:'#0891b2'};
+    const CHANNEL_COLORS = {kick:'var(--blue)',webhook:'var(--green)',discord:'#7c3aed',schedule:'#ea580c',bead:'#0891b2'};
     const CHANNEL_TYPES = ['kick','webhook','discord','schedule','bead'];
 
     function renderAgentChannels(channels) {
@@ -11074,7 +11084,7 @@ function burnAreaChart() {
           if (ch.repos && ch.repos.length) html += ' (repos: '+ch.repos.join(', ')+')';
           html += '</div>';
           html += '<label style="font-size:0.7rem;display:flex;align-items:center;gap:4px;cursor:pointer"><input type="checkbox" '+(enabled?'checked':'')+' onchange="toggleChannel('+i+',this.checked)"> on</label>';
-          html += '<button style="background:none;border:none;color:#dc2626;cursor:pointer;font-size:1rem;padding:0 4px" onclick="removeChannel('+i+')">✕</button>';
+          html += '<button style="background:none;border:none;color:var(--red);cursor:pointer;font-size:1rem;padding:0 4px" onclick="removeChannel('+i+')">✕</button>';
           html += '</div>';
         }
       }
@@ -11179,7 +11189,7 @@ function burnAreaChart() {
           html += '<div style="margin-top:8px;display:flex;gap:4px;flex-wrap:wrap">';
           denies.forEach(d => {
             const overridden = rules.some(r => r.pattern === d && r.action === 'allow');
-            html += '<span style="font-size:0.7rem;padding:2px 8px;border-radius:10px;background:'+(overridden?'#16a34a':'#dc2626')+';color:#fff;text-decoration:'+(overridden?'line-through':'none')+'">'+esc(d.replace('mcp__github__',''))+'</span>';
+            html += '<span style="font-size:0.7rem;padding:2px 8px;border-radius:10px;background:'+(overridden?'var(--green)':'var(--red)')+';color:#fff;text-decoration:'+(overridden?'line-through':'none')+'">'+esc(d.replace('mcp__github__',''))+'</span>';
           });
           html += '</div>';
         }
@@ -11190,13 +11200,13 @@ function burnAreaChart() {
         html += '<div style="font-size:0.75rem;color:var(--muted);padding:4px 0">No custom rules</div>';
       }
       rules.forEach((r, i) => {
-        const color = r.action === 'allow' ? '#16a34a' : '#dc2626';
+        const color = r.action === 'allow' ? 'var(--green)' : 'var(--red)';
         html += '<div style="font-size:0.78rem;padding:6px 8px;margin-bottom:4px;background:var(--bg);border-left:3px solid '+color+';border-radius:0 4px 4px 0;display:flex;align-items:start;gap:8px">';
         html += '<span style="font-size:0.7rem;padding:1px 8px;border-radius:8px;background:'+color+';color:#fff;text-transform:uppercase;font-weight:600">'+r.action+'</span>';
         html += '<div style="flex:1"><code style="font-size:0.75rem">'+esc(r.pattern)+'</code>';
         if (r.reason) html += '<div style="font-size:0.7rem;color:var(--muted);margin-top:2px">'+esc(r.reason)+'</div>';
         html += '</div>';
-        html += '<button style="background:none;border:none;color:#dc2626;cursor:pointer;font-size:1rem;padding:0 4px" onclick="removeToolRule('+i+')">✕</button>';
+        html += '<button style="background:none;border:none;color:var(--red);cursor:pointer;font-size:1rem;padding:0 4px" onclick="removeToolRule('+i+')">✕</button>';
         html += '</div>';
       });
       html += '<div style="display:flex;gap:6px;margin-top:6px;flex-wrap:wrap;align-items:end">';
@@ -11266,7 +11276,7 @@ function burnAreaChart() {
           if (c.uri) html += '<div style="font-size:0.72rem;color:var(--muted);font-family:var(--font-mono);overflow:hidden;text-overflow:ellipsis;max-width:400px" title="'+esc(c.uri)+'">'+esc(c.uri)+'</div>';
           if (c.auth) html += '<div style="font-size:0.68rem;color:var(--muted)">🔒 '+esc(c.auth.type)+': '+(c.auth.env_var||c.auth.file||'')+'</div>';
           html += '</div>';
-          html += '<button style="background:none;border:none;color:#dc2626;cursor:pointer;font-size:1rem;padding:0 4px" onclick="removeConnection('+i+')">✕</button>';
+          html += '<button style="background:none;border:none;color:var(--red);cursor:pointer;font-size:1rem;padding:0 4px" onclick="removeConnection('+i+')">✕</button>';
           html += '</div>';
         });
       }
@@ -11384,10 +11394,10 @@ function burnAreaChart() {
         </div>
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px;flex-shrink:0">Kick template with <code>$​{VAR}</code> placeholders. Edit the raw template or preview with variables expanded.</p>
         <div style="display:flex;gap:6px;margin-bottom:8px;flex-shrink:0">
-          <button id="prompt-btn-edit" onclick="switchPromptMode('edit')" style="font-size:0.72rem;padding:4px 12px;border-radius:4px;cursor:pointer;font-weight:600;border:1px solid var(--border);background:var(--green);color:#fff">Edit</button>
+          <button id="prompt-btn-edit" onclick="switchPromptMode('edit')" style="font-size:0.72rem;padding:4px 12px;border-radius:4px;cursor:pointer;font-weight:600;border:1px solid var(--border);background:var(--green);color:var(--bg)">Edit</button>
           <button id="prompt-btn-preview" onclick="switchPromptMode('preview')" style="font-size:0.72rem;padding:4px 12px;border-radius:4px;cursor:pointer;font-weight:600;border:1px solid var(--border);background:var(--surface);color:var(--text)">Preview</button>
           <div style="flex:1"></div>
-          <button onclick="savePromptTemplate()" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:none;background:var(--green);color:#fff">Save Template</button>
+          <button onclick="savePromptTemplate()" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:none;background:var(--green);color:var(--bg)">Save Template</button>
         </div>
         <textarea id="${editorId}" style="flex:1;min-height:300px;font-family:var(--font-mono);font-size:0.75rem;padding:12px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;resize:vertical;white-space:pre;tab-size:2" placeholder="Enter your agent's kick template here. Use \${VARIABLE} placeholders from the picker below.">${agentName ? '' : ''}</textarea>
         <div id="${previewId}" class="config-pre config-pre-fill" style="display:none;flex:1;min-height:300px;overflow-y:auto"></div>
@@ -11478,7 +11488,7 @@ function burnAreaChart() {
       return '<div style="display:flex;flex-direction:column;height:100%">'
         + '<p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px;flex-shrink:0">Portable agent definition in YAML format. Use this to share agents across hive instances.</p>'
         + '<div style="display:flex;gap:6px;margin-bottom:8px;flex-shrink:0">'
-        + '<button onclick="copyExportYaml()" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:#fff">Copy to Clipboard</button>'
+        + '<button onclick="copyExportYaml()" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg)">Copy to Clipboard</button>'
         + '<button onclick="downloadExportYaml()" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:1px solid var(--border);background:var(--surface);color:var(--text)">Download YAML</button>'
         + '</div>'
         + '<textarea id="' + yamlId + '" readonly style="flex:1;min-height:300px;font-family:var(--font-mono);font-size:0.75rem;padding:12px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;resize:vertical;white-space:pre;tab-size:2">Loading...</textarea>'
@@ -11605,7 +11615,7 @@ function burnAreaChart() {
           <label>Hive ID <span class="config-info">i<span class="config-tooltip">Unique identifier for this hive instance. Stamped into beads and available as \${HIVE_ID} in agent CLAUDE.md templates. Persists across container restarts.</span></span></label>
           <div style="display:flex;gap:8px;align-items:center">
             <input type="text" id="cfg-hive-id" value="${esc(currentId)}" placeholder="hive-xxxxxxxx" style="flex:1" oninput="markDirty('general','hiveId',this.value)">
-            <button onclick="saveHiveId()" style="font-size:0.75rem;padding:6px 14px;background:var(--green);color:#fff;border:none;border-radius:6px;cursor:pointer;font-weight:600">Save</button>
+            <button onclick="saveHiveId()" style="font-size:0.75rem;padding:6px 14px;background:var(--green);color:var(--bg);border:none;border-radius:6px;cursor:pointer;font-weight:600">Save</button>
           </div>
           <span style="font-size:0.65rem;color:var(--muted);margin-top:4px;display:block">Format: hive-adjective-noun (e.g. hive-bold-hawk). Changes take effect immediately.</span>
         </div>`;
@@ -11647,7 +11657,7 @@ function burnAreaChart() {
     }
 
     const THRESH_BAR_MAX = 200;
-    const THRESH_COLORS = { idle: '#238636', quiet: '#58a6ff', busy: '#d29922', surge: '#f85149' };
+    const THRESH_COLORS = { idle: 'var(--green)', quiet: 'var(--blue)', busy: 'var(--yellow)', surge: 'var(--red)' };
 
     function renderGovThresholds(t) {
       const merged = Object.assign({}, t, _configState.dirty.thresholds || {});
@@ -12589,8 +12599,8 @@ function burnAreaChart() {
         ok = true;
       }
       btn.textContent = ok ? 'Copied!' : 'Selected — press Cmd+C';
-      btn.style.background = '#16a34a';
-      setTimeout(() => { btn.textContent = 'Copy'; btn.style.background = '#238636'; }, 2000);
+      btn.style.background = 'var(--green)';
+      setTimeout(() => { btn.textContent = 'Copy'; btn.style.background = 'var(--green)'; }, 2000);
     }
 
     function showGHAuthState(loggedIn, username, avatarURL, role) {
@@ -12688,7 +12698,7 @@ function burnAreaChart() {
         document.getElementById('gh-device-code').textContent = data.user_code;
         document.getElementById('gh-verify-link').href = data.verification_uri;
         document.getElementById('gh-poll-status').textContent = 'Waiting for authorization...';
-        document.getElementById('gh-poll-status').style.color = '#6b7280';
+        document.getElementById('gh-poll-status').style.color = 'var(--muted)';
         document.getElementById('gh-auth-modal-overlay').style.display = 'flex';
         ghPollIntervalMs = data.interval ? (data.interval + 1) * 1000 : 6000;
         if (ghPollTimer) clearInterval(ghPollTimer);
@@ -12707,10 +12717,10 @@ function burnAreaChart() {
           ghPollTimer = null;
           const status = document.getElementById('gh-poll-status');
           status.textContent = 'Signed in as ' + data.username;
-          status.style.color = '#16a34a';
+          status.style.color = 'var(--green)';
           status.style.fontWeight = '700';
           document.getElementById('gh-device-code').textContent = data.username;
-          document.getElementById('gh-device-code').style.color = '#16a34a';
+          document.getElementById('gh-device-code').style.color = 'var(--green)';
           setTimeout(() => {
             document.getElementById('gh-auth-modal-overlay').style.display = 'none';
             document.getElementById('gh-device-code').style.color = '';
@@ -12775,15 +12785,15 @@ function burnAreaChart() {
       overlay.id = 'copilot-auth-overlay';
       overlay.className = 'gh-auth-overlay';
       overlay.innerHTML = '<div class="gh-auth-modal" style="max-width:480px;text-align:center">' +
-        '<h3 style="color:#238636">Login GitHub Copilot</h3>' +
-        '<p style="color:#6b7280;font-size:0.85rem;margin:12px 0">Enter this one-time code at github.com/login/device:</p>' +
-        '<div id="copilot-user-code" style="font-size:1.8rem;font-weight:700;letter-spacing:4px;color:#238636;' +
+        '<h3 style="color:var(--green)">Login GitHub Copilot</h3>' +
+        '<p style="color:var(--muted);font-size:0.85rem;margin:12px 0">Enter this one-time code at github.com/login/device:</p>' +
+        '<div id="copilot-user-code" style="font-size:1.8rem;font-weight:700;letter-spacing:4px;color:var(--green);' +
           'background:#f0fdf4;border:1px solid #bbf7d0;border-radius:8px;padding:14px;margin:12px 0;cursor:pointer" ' +
           'title="Click to copy" onclick="copyCopilotCode()">' + userCode + '</div>' +
-        '<div id="copilot-auth-status" style="color:#6b7280;font-size:0.8rem;min-height:20px;margin:8px 0">Waiting for authorization…</div>' +
+        '<div id="copilot-auth-status" style="color:var(--muted);font-size:0.8rem;min-height:20px;margin:8px 0">Waiting for authorization…</div>' +
         '<div style="display:flex;gap:8px;justify-content:center;margin-top:8px">' +
           '<button onclick="window.open(\x27' + verificationUri + '\x27, \x27_blank\x27)" ' +
-            'style="background:#238636;color:#fff;border:none;padding:6px 16px;border-radius:6px;font-weight:600;cursor:pointer">Open GitHub</button>' +
+            'style="background:var(--green);color:var(--bg);border:none;padding:6px 16px;border-radius:6px;font-weight:600;cursor:pointer">Open GitHub</button>' +
           '<button onclick="cancelCopilotLogin()" class="gh-cancel" style="margin-top:0">Cancel</button>' +
         '</div>' +
       '</div>';
@@ -12811,7 +12821,7 @@ function burnAreaChart() {
           return;
         }
         if (data.logged_in && !data.pending) {
-          if (statusEl) { statusEl.textContent = '✓ Logged in!'; statusEl.style.color = '#238636'; }
+          if (statusEl) { statusEl.textContent = '✓ Logged in!'; statusEl.style.color = 'var(--green)'; }
           showToast('GitHub Copilot authenticated', 'success');
           setTimeout(function() { cancelCopilotLogin(); }, 1500);
         }
@@ -12860,14 +12870,14 @@ function burnAreaChart() {
         '<h3 style="color:#d97706;text-align:center">Login Claude Code</h3>' +
         '<div id="claude-countdown" style="text-align:center;color:#d97706;font-weight:600;font-size:0.9rem;margin:8px 0">' +
           'Opening Claude login in ' + countdownSec + 's…</div>' +
-        '<ol style="color:#6b7280;font-size:0.85rem;line-height:1.8;padding-left:1.5em;margin:12px 0">' +
+        '<ol style="color:var(--muted);font-size:0.85rem;line-height:1.8;padding-left:1.5em;margin:12px 0">' +
           '<li>A new tab will open with the Claude authorization page</li>' +
           '<li>Click <strong>Authorize</strong></li>' +
           '<li>Copy the <strong>authorization code</strong> shown on the next page and paste it below</li>' +
         '</ol>' +
         '<input id="claude-callback-input" type="text" placeholder="Paste the authorization code here" ' +
           'style="width:100%;padding:10px;border:1px solid #d1d5db;border-radius:6px;font-size:0.9rem;margin:12px 0;box-sizing:border-box">' +
-        '<div id="claude-exchange-status" style="color:#6b7280;font-size:0.8rem;min-height:20px;margin-bottom:8px"></div>' +
+        '<div id="claude-exchange-status" style="color:var(--muted);font-size:0.8rem;min-height:20px;margin-bottom:8px"></div>' +
         '<div style="display:flex;gap:8px;justify-content:center">' +
           '<button onclick="submitClaudeCode()" style="background:#d97706;color:#fff;border:none;padding:6px 16px;border-radius:6px;font-weight:600;cursor:pointer">Submit</button>' +
           '<button onclick="cancelClaudeLogin()" class="gh-cancel" style="margin-top:0">Cancel</button>' +
@@ -12910,7 +12920,7 @@ function burnAreaChart() {
       } else {
         payload.code = value;
       }
-      if (statusEl) { statusEl.textContent = 'Exchanging code for token...'; statusEl.style.color = '#6b7280'; }
+      if (statusEl) { statusEl.textContent = 'Exchanging code for token...'; statusEl.style.color = 'var(--muted)'; }
       try {
         var resp = await fetch('/api/claude-auth/exchange', {
           method: 'POST',
@@ -12922,7 +12932,7 @@ function burnAreaChart() {
           if (statusEl) { statusEl.textContent = data.error; statusEl.style.color = '#ef4444'; }
           return;
         }
-        if (statusEl) { statusEl.textContent = 'Authenticated!'; statusEl.style.color = '#16a34a'; }
+        if (statusEl) { statusEl.textContent = 'Authenticated!'; statusEl.style.color = 'var(--green)'; }
         showToast('Claude Code authenticated!', 'success');
         var CLAUDE_SUCCESS_DISMISS_MS = 1500;
         setTimeout(function() {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1007,6 +1007,10 @@
     .advisor-bar-fill { height: 100%; border-radius: 4px; transition: width 0.5s ease; }
     .advisor-pct { min-width: 30px; text-align: right; color: var(--muted); }
     .advisor-burn { min-width: 80px; text-align: right; color: var(--muted); font-size: 0.65rem; }
+    /* Paused/off agents project zero — greyed row, note instead of a bar. */
+    .advisor-row-inactive { opacity: 0.55; }
+    .advisor-row-inactive .advisor-agent { color: var(--muted); font-weight: 400; }
+    .advisor-inactive-note { flex: 1; color: var(--muted); font-style: italic; font-size: 0.65rem; }
     .advisor-tips { margin-top: 8px; display: flex; flex-direction: column; gap: 4px; }
     .advisor-tip { font-size: 0.72rem; color: var(--text); padding: 4px 8px; background: rgba(210,153,34,0.08); border-left: 2px solid var(--yellow); border-radius: 0 4px 4px 0; }
     .advisor-tip b { color: var(--cyan); }
@@ -4413,12 +4417,16 @@
         const avg = tokenData.avgPerSession || 0;
         const cadenceMin = parseCadenceMinutes(agentData.cadence);
         const isOff = agentData.offByCadence === true;
-        const isPaused = !cadenceMin && !isOff;
+        const isOnDemand = agentData.onDemand === true;
+        // paused = the live paused flag (governor-mode pauses keep the
+        // configured cadence string, so the string alone is not enough)
+        // OR a non-numeric cadence ('paused'/'off'/'on demand').
+        const isPaused = (agentData.paused === true && !isOff) || (!cadenceMin && !isOff);
         const passesPerHour = (isPaused || isOff) ? 0 : MINUTES_PER_HOUR / cadenceMin;
         const weeklyBurn = avg * passesPerHour * HOURS_PER_WEEK;
         totalWeeklyBurn += weeklyBurn;
 
-        rows.push({ name, avg, cadenceMin, isPaused, isOff, passesPerHour, weeklyBurn, cli: agentData.cli });
+        rows.push({ name, avg, cadenceMin, isPaused, isOff, isOnDemand, passesPerHour, weeklyBurn, cli: agentData.cli });
       }
 
       if (totalWeeklyBurn === 0) return '';
@@ -4449,7 +4457,7 @@
       }
 
       for (const r of rows) {
-        if (r.cli === 'copilot' && r.avg === 0 && !r.isPaused) {
+        if (r.cli === 'copilot' && r.avg === 0 && !r.isPaused && !r.isOff) {
           tips.push(`<b>${r.name}</b> runs on copilot (unlimited tokens, no metering). Token burn unknown — consider switching to claude CLI for visibility.`);
         }
       }
@@ -4486,15 +4494,23 @@
         }
       }
 
-      const barRows = rows.filter(r => r.weeklyBurn > 0 || (!r.isPaused && !r.isOff)).map(r => {
+      const barRows = rows.map(r => {
+        if (r.isPaused || r.isOff) {
+          const note = r.isOff ? 'off in current mode' : r.isOnDemand ? 'on demand' : 'paused';
+          return `<div class="advisor-bar-row advisor-row-inactive">
+            <span class="advisor-agent">${r.name}</span>
+            <span class="advisor-inactive-note">${note} — projects 0</span>
+            <span class="advisor-pct">—</span>
+            <span class="advisor-burn">0/wk</span>
+          </div>`;
+        }
         const pct = totalWeeklyBurn > 0 ? Math.round((r.weeklyBurn / totalWeeklyBurn) * 100) : 0;
         const barColor = _getAgentColor(r.name);
-        const label = r.isPaused ? 'paused' : r.isOff ? 'off' : `${fmtTokens(r.weeklyBurn)}/wk`;
         return `<div class="advisor-bar-row">
           <span class="advisor-agent">${r.name}</span>
           <div class="advisor-bar-track"><div class="advisor-bar-fill" style="width:${Math.max(pct, 2)}%;background:${barColor}"></div></div>
-          <span class="advisor-pct">${(r.isPaused || r.isOff) ? '—' : pct + '%'}</span>
-          <span class="advisor-burn">${label}</span>
+          <span class="advisor-pct">${pct + '%'}</span>
+          <span class="advisor-burn">${fmtTokens(r.weeklyBurn)}/wk</span>
         </div>`;
       }).join('');
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1821,6 +1821,32 @@
     }
     .oc-detail-summary .sum-table th,
     .oc-detail-summary .sum-table td { border-bottom-color: var(--terminal-line); }
+
+    /* ══ Utility classes (Phase 4) ══
+       Extracted from the repeated inline-style recipes in the JS templates
+       (Knowledge Base + setup instructions, ACMM dialogs). Static literals
+       only — conditional style="...${...}" fragments are never touched. */
+    .stack { display: flex; flex-direction: column; gap: 8px; }
+    .row { display: flex; align-items: center; gap: 8px; }
+    .row-end { display: flex; justify-content: flex-end; gap: 8px; }
+    .row-between { display: flex; align-items: center; justify-content: space-between; }
+    .muted { color: var(--muted); }
+    .muted-note { font-size: 0.78rem; color: var(--muted); }
+    .muted-xs { font-size: 0.72rem; color: var(--muted); }
+    .title-sm { font-size: 0.92rem; font-weight: 600; color: var(--fg); }
+    .modal-h { font-size: 0.92rem; margin: 0 0 8px 0; color: var(--accent); }
+    .summary-label { cursor: pointer; font-size: 0.78rem; font-weight: 600; color: var(--fg); }
+    .card-inset { padding: 8px; border: 1px solid var(--border); border-radius: 6px; }
+    .empty-dashed { text-align: center; padding: 12px; color: var(--muted); font-size: 0.75rem; border: 1px dashed var(--border); border-radius: 6px; }
+    .field-input { padding: 6px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg); color: var(--fg); font-size: 0.78rem; }
+    .field-input-block { width: 100%; margin-top: 4px; }
+    .code-chip { background: var(--surface); padding: 1px 4px; border-radius: 3px; }
+    .tag-chip { font-size: 0.68rem; color: var(--muted); background: var(--surface); border: 1px solid var(--border); border-radius: 4px; padding: 1px 6px; }
+    /* filled-blue / surface button tints (sit after the button-system ghost
+       recipe so they win ties on .nous-btn etc.) */
+    .btn-blue { background: var(--blue); border-color: transparent; color: var(--bg); }
+    .btn-blue:hover { background: color-mix(in srgb, var(--blue) 85%, #fff); border-color: transparent; color: var(--bg); }
+    .btn-surface { background: var(--surface); border: 1px solid var(--border); color: var(--fg); }
   </style>
 </head>
 <body>
@@ -6165,9 +6191,9 @@ function burnAreaChart() {
       html += '<div style="font-size:0.92rem;font-weight:700;color:var(--fg);margin-bottom:12px">🔗 Connect via Git Repo</div>';
       html += '<ol>';
       html += '<li><strong>Install the "Obsidian Git" community plugin</strong><br>';
-      html += '<span style="color:var(--muted)">Settings &rarr; Community Plugins &rarr; Browse &rarr; search "Obsidian Git"</span></li>';
+      html += '<span class="muted">Settings &rarr; Community Plugins &rarr; Browse &rarr; search "Obsidian Git"</span></li>';
       html += '<li><strong>Initialize your vault as a git repo</strong> (or use an existing one)<br>';
-      html += '<span style="color:var(--muted)">The plugin can auto-commit and push on a configurable interval.</span></li>';
+      html += '<span class="muted">The plugin can auto-commit and push on a configurable interval.</span></li>';
       html += '<li><strong>Set the git repo URL on your Hive server:</strong><br>';
       html += '<div style="margin-top:6px"><em>Option A:</em> Set the <code>HIVE_WIKI_GIT_URL</code> environment variable before starting Hive</div>';
       html += '<div style="margin-top:6px"><em>Option B:</em> Use the API:</div>';
@@ -6176,7 +6202,7 @@ function burnAreaChart() {
       html += '  -H "Authorization: Bearer &lt;token&gt;" \\\n';
       html += '  -d \'{"path": "/data/vaults/hive-wiki", "name": "hive-wiki"}\'</pre></li>';
       html += '<li><strong>Hive auto-syncs every 60 seconds</strong> via <code>git pull</code><br>';
-      html += '<span style="color:var(--muted)">Changes appear in the Knowledge Base within ~30s of pushing.</span></li>';
+      html += '<span class="muted">Changes appear in the Knowledge Base within ~30s of pushing.</span></li>';
       html += '</ol>';
       html += '<div class="kb-tip"><strong>Recommended plugin settings:</strong><br>';
       html += '&bull; Auto pull interval: 1 minute<br>';
@@ -6207,7 +6233,7 @@ function burnAreaChart() {
       html += '<div style="font-size:0.92rem;font-weight:700;color:var(--fg);margin-bottom:12px">⚡ Connect via Webhook</div>';
       html += '<ol>';
       html += '<li><strong>Install the "Post Webhook" community plugin</strong><br>';
-      html += '<span style="color:var(--muted)">Settings &rarr; Community Plugins &rarr; Browse &rarr; search "Post Webhook"</span></li>';
+      html += '<span class="muted">Settings &rarr; Community Plugins &rarr; Browse &rarr; search "Post Webhook"</span></li>';
       html += '<li><strong>Add a webhook in the plugin settings:</strong>';
       html += '<div style="margin-top:6px;padding:10px 14px;background:var(--bg);border:1px solid var(--border);border-radius:6px;font-size:0.74rem">';
       html += '<div><strong>Name:</strong> Hive Knowledge Sync</div>';
@@ -6222,7 +6248,7 @@ function burnAreaChart() {
       html += '</div></div>';
       html += '</div></li>';
       html += '<li><strong>Use it:</strong><br>';
-      html += '<span style="color:var(--muted)">Command palette &rarr; "Post Webhook: Send current note"<br>';
+      html += '<span class="muted">Command palette &rarr; "Post Webhook: Send current note"<br>';
       html += 'Or bind to a hotkey (e.g., Ctrl+Shift+S)</span></li>';
       html += '<li><strong>Your note\'s frontmatter controls how it\'s stored:</strong>';
       html += '<pre>---\n';
@@ -6232,7 +6258,7 @@ function burnAreaChart() {
       html += 'layer: project      # personal, project, org, community\n';
       html += 'confidence: 0.85\n';
       html += '---</pre>';
-      html += '<span style="color:var(--muted)">Notes are upserted by filename -- saving the same note updates it.</span></li>';
+      html += '<span class="muted">Notes are upserted by filename -- saving the same note updates it.</span></li>';
       html += '</ol>';
       html += '<div class="kb-tip"><strong>Tip:</strong> The webhook endpoint is always available at <code>http://' + escapeHtml(hiveHost) + '/api/knowledge/obsidian/sync</code>. You can start sending notes immediately -- no vault connection required. Facts will appear in the Knowledge Base as soon as they arrive.</div>';
       html += '</div>';
@@ -6358,11 +6384,11 @@ function burnAreaChart() {
 
       // Action buttons
       html += '<div style="display:flex;gap:8px;margin-bottom:14px">';
-      html += '<button class="nous-btn" style="background:var(--blue);color:var(--bg)" onclick="kbOpenCreate()" title="Create a new knowledge fact manually. Choose a layer (personal, project, org, community), type, and enter the fact content.">+ New Fact</button>';
-      html += '<button class="nous-btn" style="background:var(--surface);color:var(--fg);border:1px solid var(--border)" onclick="kbOpenSubscriptions()" title="Manage knowledge sources: git repos, wiki subscriptions, document imports, and fact imports.">🔗 Knowledge Sources</button>';
-      html += '<button class="nous-btn" style="background:var(--surface);color:var(--fg);border:1px solid var(--border)" onclick="kbOpenVaults()" title="Manage knowledge vaults — collections of facts organized by topic or project. Vaults can be shared across hive instances.">📂 Vaults</button>';
-      html += '<button class="nous-btn" style="background:var(--surface);color:var(--fg);border:1px solid var(--border)" onclick="kbOpenHowItWorks()">📖 How it works</button>';
-      html += '<button class="nous-btn" style="background:var(--surface);color:var(--fg);border:1px solid var(--border)" onclick="kbOpenObsidianSetup()" title="View step-by-step instructions for connecting Obsidian via Git sync or webhook.">🔮 Obsidian Setup</button>';
+      html += '<button class="nous-btn btn-blue" onclick="kbOpenCreate()" title="Create a new knowledge fact manually. Choose a layer (personal, project, org, community), type, and enter the fact content.">+ New Fact</button>';
+      html += '<button class="nous-btn btn-surface" onclick="kbOpenSubscriptions()" title="Manage knowledge sources: git repos, wiki subscriptions, document imports, and fact imports.">🔗 Knowledge Sources</button>';
+      html += '<button class="nous-btn btn-surface" onclick="kbOpenVaults()" title="Manage knowledge vaults — collections of facts organized by topic or project. Vaults can be shared across hive instances.">📂 Vaults</button>';
+      html += '<button class="nous-btn btn-surface" onclick="kbOpenHowItWorks()">📖 How it works</button>';
+      html += '<button class="nous-btn btn-surface" onclick="kbOpenObsidianSetup()" title="View step-by-step instructions for connecting Obsidian via Git sync or webhook.">🔮 Obsidian Setup</button>';
       html += `<button class="nous-btn" style="background:${_kbGraphView ? 'var(--cyan)' : 'var(--surface)'};color:${_kbGraphView ? 'var(--bg)' : 'var(--fg)'};border:1px solid ${_kbGraphView ? 'var(--cyan)' : 'var(--border)'}" onclick="kbToggleGraph()" title="Toggle knowledge graph visualization showing relationships between facts.">🕸️ Graph</button>`;
       html += '</div>';
 
@@ -6573,30 +6599,30 @@ function burnAreaChart() {
       }
 
       const html = `
-        <div style="display:flex;flex-direction:column;gap:10px">
-          <label style="font-size:0.78rem;color:var(--muted)">Title
+        <div class="stack">
+          <label class="muted-note">Title
             <input id="kb-create-title" type="text" class="kb-search-box" style="margin-top:4px" placeholder="Guard .join() against undefined">
           </label>
-          <label style="font-size:0.78rem;color:var(--muted)">Body
+          <label class="muted-note">Body
             <textarea id="kb-create-body" rows="6" style="width:100%;margin-top:4px;padding:8px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.8rem;font-family:inherit;resize:vertical" placeholder="Always use (arr || []).join(',') — hooks can return undefined when endpoints fail."></textarea>
           </label>
           <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px">
-            <label style="font-size:0.78rem;color:var(--muted)">Layer
-              <select id="kb-create-layer" style="width:100%;margin-top:4px;padding:6px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">${layerOpts}</select>
+            <label class="muted-note">Layer
+              <select id="kb-create-layer" class="field-input field-input-block">${layerOpts}</select>
             </label>
-            <label style="font-size:0.78rem;color:var(--muted)">Type
-              <select id="kb-create-type" style="width:100%;margin-top:4px;padding:6px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">${typeOpts}</select>
+            <label class="muted-note">Type
+              <select id="kb-create-type" class="field-input field-input-block">${typeOpts}</select>
             </label>
-            <label style="font-size:0.78rem;color:var(--muted)">Confidence
-              <input id="kb-create-conf" type="number" min="0" max="1" step="0.1" value="0.7" style="width:100%;margin-top:4px;padding:6px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">
+            <label class="muted-note">Confidence
+              <input id="kb-create-conf" type="number" min="0" max="1" step="0.1" value="0.7" class="field-input field-input-block">
             </label>
           </div>
-          <label style="font-size:0.78rem;color:var(--muted)">Tags (comma-separated)
+          <label class="muted-note">Tags (comma-separated)
             <input id="kb-create-tags" type="text" class="kb-search-box" style="margin-top:4px" placeholder="react, testing, hooks">
           </label>
-          <div style="display:flex;justify-content:flex-end;gap:8px;margin-top:8px">
+          <div class="row-end" style="margin-top:8px">
             <button class="nous-btn nous-config-btn-cancel" onclick="kbCloseModal()">Cancel</button>
-            <button class="nous-btn" style="background:var(--blue);color:var(--bg)" onclick="kbSubmitCreate()">Create Fact</button>
+            <button class="nous-btn btn-blue" onclick="kbSubmitCreate()">Create Fact</button>
           </div>
         </div>`;
       kbShowModal('New Fact', html);
@@ -6636,36 +6662,36 @@ function burnAreaChart() {
       }
 
       const html = `
-        <div style="display:flex;flex-direction:column;gap:10px">
-          <label style="font-size:0.78rem;color:var(--muted)">Title
+        <div class="stack">
+          <label class="muted-note">Title
             <input id="kb-edit-title" type="text" class="kb-search-box" style="margin-top:4px" value="${escapeHtml(f.title || '')}">
           </label>
-          <label style="font-size:0.78rem;color:var(--muted)">Body
+          <label class="muted-note">Body
             <textarea id="kb-edit-body" rows="8" style="width:100%;margin-top:4px;padding:8px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.8rem;font-family:inherit;resize:vertical">${escapeHtml(f.body || '')}</textarea>
           </label>
           <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:10px">
-            <label style="font-size:0.78rem;color:var(--muted)">Type
-              <select id="kb-edit-type" style="width:100%;margin-top:4px;padding:6px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">${typeOpts}</select>
+            <label class="muted-note">Type
+              <select id="kb-edit-type" class="field-input field-input-block">${typeOpts}</select>
             </label>
-            <label style="font-size:0.78rem;color:var(--muted)">Status
-              <select id="kb-edit-status" style="width:100%;margin-top:4px;padding:6px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">
+            <label class="muted-note">Status
+              <select id="kb-edit-status" class="field-input field-input-block">
                 <option value="draft"${f.status === 'draft' ? ' selected' : ''}>Draft</option>
                 <option value="verified"${f.status === 'verified' ? ' selected' : ''}>Verified</option>
                 <option value="stale"${f.status === 'stale' ? ' selected' : ''}>Stale</option>
                 <option value="archived"${f.status === 'archived' ? ' selected' : ''}>Archived</option>
               </select>
             </label>
-            <label style="font-size:0.78rem;color:var(--muted)">Confidence
-              <input id="kb-edit-conf" type="number" min="0" max="1" step="0.1" value="${f.confidence || 0.7}" style="width:100%;margin-top:4px;padding:6px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">
+            <label class="muted-note">Confidence
+              <input id="kb-edit-conf" type="number" min="0" max="1" step="0.1" value="${f.confidence || 0.7}" class="field-input field-input-block">
             </label>
           </div>
-          <label style="font-size:0.78rem;color:var(--muted)">Tags (comma-separated)
+          <label class="muted-note">Tags (comma-separated)
             <input id="kb-edit-tags" type="text" class="kb-search-box" style="margin-top:4px" value="${escapeHtml((f.tags || []).join(', '))}">
           </label>
-          <div style="font-size:0.7rem;color:var(--muted)">Layer: ${escapeHtml(f.layer || '')} · Slug: ${escapeHtml(f.slug || '')}</div>
-          <div style="display:flex;justify-content:flex-end;gap:8px;margin-top:8px">
+          <div class="muted-xs">Layer: ${escapeHtml(f.layer || '')} · Slug: ${escapeHtml(f.slug || '')}</div>
+          <div class="row-end" style="margin-top:8px">
             <button class="nous-btn nous-config-btn-cancel" onclick="kbCloseModal()">Cancel</button>
-            <button class="nous-btn" style="background:var(--blue);color:var(--bg)" onclick="kbSubmitEdit()">Save Changes</button>
+            <button class="nous-btn btn-blue" onclick="kbSubmitEdit()">Save Changes</button>
           </div>
         </div>`;
       kbShowModal('Edit Fact', html);
@@ -6731,20 +6757,20 @@ function burnAreaChart() {
       if (!layerOpts) layerOpts = '<option value="project">Project</option>';
 
       const html = `
-        <div style="display:flex;flex-direction:column;gap:10px">
+        <div class="stack">
           <p style="font-size:0.78rem;color:var(--muted);margin:0">Paste markdown or JSON content. Markdown headings (# or ##) become separate facts. JSON should be an array of {title, body, type, tags} objects.</p>
           <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px">
-            <label style="font-size:0.78rem;color:var(--muted)">Layer
-              <select id="kb-import-layer" style="width:100%;margin-top:4px;padding:6px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">${layerOpts}</select>
+            <label class="muted-note">Layer
+              <select id="kb-import-layer" class="field-input field-input-block">${layerOpts}</select>
             </label>
-            <label style="font-size:0.78rem;color:var(--muted)">Format
-              <select id="kb-import-format" style="width:100%;margin-top:4px;padding:6px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">
+            <label class="muted-note">Format
+              <select id="kb-import-format" class="field-input field-input-block">
                 <option value="markdown" selected>Markdown</option>
                 <option value="json">JSON</option>
               </select>
             </label>
           </div>
-          <label style="font-size:0.78rem;color:var(--muted)">Content
+          <label class="muted-note">Content
             <textarea id="kb-import-content" rows="24" style="width:100%;margin-top:4px;padding:8px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem;font-family:var(--font-mono);resize:vertical;min-height:320px" placeholder="# Guard .join() against undefined\n\nAlways use (arr || []).join(',')..."></textarea>
           </label>
           <div style="display:flex;align-items:center;gap:10px;margin-top:4px">
@@ -6753,9 +6779,9 @@ function burnAreaChart() {
               <input type="file" accept=".md,.json,.txt" style="font-size:0.72rem" onchange="kbLoadFile(this)">
             </label>
           </div>
-          <div style="display:flex;justify-content:flex-end;gap:8px;margin-top:8px">
+          <div class="row-end" style="margin-top:8px">
             <button class="nous-btn nous-config-btn-cancel" onclick="kbCloseModal()">Cancel</button>
-            <button class="nous-btn" style="background:var(--blue);color:var(--bg)" onclick="kbSubmitImport()">Import</button>
+            <button class="nous-btn btn-blue" onclick="kbSubmitImport()">Import</button>
           </div>
         </div>`;
       kbShowModal('📥 Import Facts', html, { width: 'min(700px, 80vw)', maxHeight: '85vh' });
@@ -6831,17 +6857,17 @@ function burnAreaChart() {
 
         // ── Git Sources section ──
         html += '<div style="margin-bottom:20px">';
-        html += '<div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">';
-        html += '<span style="font-size:0.92rem;font-weight:600;color:var(--fg)">Git Sources</span>';
-        html += '<span style="font-size:0.68rem;color:var(--muted);background:var(--surface);border:1px solid var(--border);border-radius:4px;padding:1px 6px">cloned &amp; indexed locally</span>';
+        html += '<div class="row" style="margin-bottom:8px">';
+        html += '<span class="title-sm">Git Sources</span>';
+        html += '<span class="tag-chip">cloned &amp; indexed locally</span>';
         html += '</div>';
-        html += '<div style="font-size:0.72rem;color:var(--muted);margin-bottom:10px">Clone a GitHub repo locally. Hive indexes the markdown with Fisher-Rao scored search and syncs every 5 minutes.</div>';
+        html += '<div class="muted-xs" style="margin-bottom:10px">Clone a GitHub repo locally. Hive indexes the markdown with Fisher-Rao scored search and syncs every 5 minutes.</div>';
 
         if (gitSources && gitSources.length > 0) {
           for (const gs of gitSources) {
             const statusColor = gs.ready ? 'var(--green)' : '#eab308';
             const statusText = gs.ready ? 'ready' : 'initializing';
-            html += '<div style="display:flex;align-items:center;justify-content:space-between;padding:8px;border:1px solid var(--border);border-radius:6px;margin-bottom:6px">';
+            html += '<div class="card-inset row-between" style="margin-bottom:6px">';
             html += '<div style="min-width:0;flex:1">';
             html += `<div style="font-size:0.82rem;font-weight:600;color:var(--fg);display:flex;align-items:center;gap:6px;white-space:nowrap;overflow:hidden">`;
             html += `<span style="width:7px;height:7px;min-width:7px;border-radius:50%;background:${statusColor};display:inline-block"></span>`;
@@ -6857,58 +6883,58 @@ function burnAreaChart() {
             html += '</div>';
           }
         } else {
-          html += '<div style="text-align:center;padding:12px;color:var(--muted);font-size:0.75rem;border:1px dashed var(--border);border-radius:6px">No git sources yet.</div>';
+          html += '<div class="empty-dashed">No git sources yet.</div>';
         }
 
-        html += '<details open style="margin-top:10px"><summary style="cursor:pointer;font-size:0.78rem;font-weight:600;color:var(--fg)">Add Git Source</summary>';
-        html += '<div style="display:flex;flex-direction:column;gap:8px;margin-top:8px">';
+        html += '<details open style="margin-top:10px"><summary class="summary-label">Add Git Source</summary>';
+        html += '<div class="stack" style="margin-top:8px">';
         html += '<input id="kb-gs-url" type="text" class="kb-search-box" placeholder="https://github.com/org/repo">';
         html += '<input id="kb-gs-name" type="text" class="kb-search-box" placeholder="Display name">';
         html += '<input id="kb-gs-subpath" type="text" class="kb-search-box" placeholder="Subpath (e.g. docs/skills)">';
         html += '<input id="kb-gs-branch" type="text" class="kb-search-box" placeholder="Branch (default: main)">';
-        html += `<select id="kb-gs-layer" style="padding:7px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">
+        html += `<select id="kb-gs-layer" class="field-input">
           <option value="project">Project</option>
           <option value="org">Org</option>
           <option value="community">Community</option>
           <option value="personal">Personal</option>
         </select>`;
-        html += '<div style="display:flex;justify-content:flex-end">';
-        html += '<button class="nous-btn" style="background:var(--blue);color:var(--bg);padding:8px 20px" onclick="kbAddGitSource()">Clone &amp; Index</button>';
+        html += '<div class="row-end">';
+        html += '<button class="nous-btn btn-blue" style="padding:8px 20px" onclick="kbAddGitSource()">Clone &amp; Index</button>';
         html += '</div></div></details>';
         html += '</div>';
 
         // ── Wiki Subscriptions section ──
         html += '<div>';
-        html += '<div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">';
-        html += '<span style="font-size:0.92rem;font-weight:600;color:var(--fg)">Wiki Subscriptions</span>';
-        html += '<span style="font-size:0.68rem;color:var(--muted);background:var(--surface);border:1px solid var(--border);border-radius:4px;padding:1px 6px">remote llm-wiki endpoint</span>';
+        html += '<div class="row" style="margin-bottom:8px">';
+        html += '<span class="title-sm">Wiki Subscriptions</span>';
+        html += '<span class="tag-chip">remote llm-wiki endpoint</span>';
         html += '</div>';
-        html += '<div style="font-size:0.72rem;color:var(--muted);margin-bottom:10px">A running llm-wiki HTTP service. Hive queries it via MCP at prime time &mdash; facts stay remote, only search results are fetched.</div>';
+        html += '<div class="muted-xs" style="margin-bottom:10px">A running llm-wiki HTTP service. Hive queries it via MCP at prime time &mdash; facts stay remote, only search results are fetched.</div>';
 
         if (subs && subs.length > 0) {
           for (const s of subs) {
-            html += '<div style="display:flex;align-items:center;justify-content:space-between;padding:8px;border:1px solid var(--border);border-radius:6px;margin-bottom:6px">';
+            html += '<div class="card-inset row-between" style="margin-bottom:6px">';
             html += `<div><div style="font-size:0.82rem;font-weight:600;color:var(--fg)">${escapeHtml(s.name || s.url)}</div>`;
-            html += `<div style="font-size:0.7rem;color:var(--muted)">${escapeHtml(s.url)} &middot; ${escapeHtml(s.layer || 'org')}</div></div>`;
+            html += `<div class="muted-xs">${escapeHtml(s.url)} &middot; ${escapeHtml(s.layer || 'org')}</div></div>`;
             html += `<button class="nous-btn" style="background:var(--red);color:var(--bg);font-size:0.7rem;padding:4px 8px;flex-shrink:0;margin-left:8px" onclick="kbRemoveSub('${escapeHtml(s.url)}')">Remove</button>`;
             html += '</div>';
           }
         } else {
-          html += '<div style="text-align:center;padding:12px;color:var(--muted);font-size:0.75rem;border:1px dashed var(--border);border-radius:6px">No subscriptions yet.</div>';
+          html += '<div class="empty-dashed">No subscriptions yet.</div>';
         }
 
-        html += '<details open style="margin-top:10px"><summary style="cursor:pointer;font-size:0.78rem;font-weight:600;color:var(--fg)">Add Subscription</summary>';
-        html += '<div style="display:flex;flex-direction:column;gap:8px;margin-top:8px">';
+        html += '<details open style="margin-top:10px"><summary class="summary-label">Add Subscription</summary>';
+        html += '<div class="stack" style="margin-top:8px">';
         html += '<input id="kb-sub-url" type="text" class="kb-search-box" placeholder="https://wiki.example.com/mcp">';
         html += `<input id="kb-sub-name" type="text" class="kb-search-box" placeholder="Display name">`;
-        html += `<select id="kb-sub-layer" style="padding:7px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">
+        html += `<select id="kb-sub-layer" class="field-input">
           <option value="project">Project</option>
           <option value="org">Org</option>
           <option value="community">Community</option>
           <option value="personal">Personal</option>
         </select>`;
-        html += '<div style="display:flex;justify-content:flex-end">';
-        html += '<button class="nous-btn" style="background:var(--blue);color:var(--bg);padding:8px 20px" onclick="kbAddSub()">Add</button>';
+        html += '<div class="row-end">';
+        html += '<button class="nous-btn btn-blue" style="padding:8px 20px" onclick="kbAddSub()">Add</button>';
         html += '</div></div></details>';
         html += '</div>';
 
@@ -6919,18 +6945,18 @@ function burnAreaChart() {
 
         // ── Import Documents section ──
         html += '<div style="margin-bottom:20px">';
-        html += '<div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">';
-        html += '<span style="font-size:0.92rem;font-weight:600;color:var(--fg)">Documents</span>';
-        html += '<span style="font-size:0.68rem;color:var(--muted);background:var(--surface);border:1px solid var(--border);border-radius:4px;padding:1px 6px">PDF, HTML, DOCX, text</span>';
+        html += '<div class="row" style="margin-bottom:8px">';
+        html += '<span class="title-sm">Documents</span>';
+        html += '<span class="tag-chip">PDF, HTML, DOCX, text</span>';
         html += '</div>';
-        html += '<div style="font-size:0.72rem;color:var(--muted);margin-bottom:10px">Import external documents from a URL. Content is parsed into chunks and stored as knowledge facts that agents can search and cite.</div>';
+        html += '<div class="muted-xs" style="margin-bottom:10px">Import external documents from a URL. Content is parsed into chunks and stored as knowledge facts that agents can search and cite.</div>';
 
         if (documents && documents.length > 0) {
           for (const d of documents) {
             const dIcon = DOC_CONTENT_ICONS[d.content_type] || '📄';
             const dSource = d.source_url || d.source_file || '';
             const dFacts = d.fact_count || 0;
-            html += '<div style="display:flex;align-items:center;justify-content:space-between;padding:8px;border:1px solid var(--border);border-radius:6px;margin-bottom:6px">';
+            html += '<div class="card-inset row-between" style="margin-bottom:6px">';
             html += '<div style="min-width:0;flex:1">';
             html += `<div style="font-size:0.82rem;font-weight:600;color:var(--fg);display:flex;align-items:center;gap:6px">${dIcon} <span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${escapeHtml(d.slug || d.title || 'unnamed')}</span></div>`;
             html += `<div style="font-size:0.7rem;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${escapeHtml(dSource)} &middot; ${dFacts} facts</div>`;
@@ -6941,25 +6967,25 @@ function burnAreaChart() {
             html += '</div></div>';
           }
         } else {
-          html += '<div style="text-align:center;padding:12px;color:var(--muted);font-size:0.75rem;border:1px dashed var(--border);border-radius:6px">No documents imported yet.</div>';
+          html += '<div class="empty-dashed">No documents imported yet.</div>';
         }
 
-        html += '<details open style="margin-top:10px"><summary style="cursor:pointer;font-size:0.78rem;font-weight:600;color:var(--fg)">Import Document</summary>';
-        html += '<div style="display:flex;flex-direction:column;gap:8px;margin-top:8px">';
+        html += '<details open style="margin-top:10px"><summary class="summary-label">Import Document</summary>';
+        html += '<div class="stack" style="margin-top:8px">';
         html += '<input id="kb-doc-url" type="text" class="kb-search-box" placeholder="https://arxiv.org/pdf/2309.06180">';
         html += '<input id="kb-doc-name" type="text" class="kb-search-box" placeholder="Name (optional, derived from URL)">';
-        html += `<select id="kb-doc-layer" style="padding:7px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">
+        html += `<select id="kb-doc-layer" class="field-input">
           <option value="project">Project</option>
           <option value="org">Org</option>
           <option value="community">Community</option>
           <option value="personal">Personal</option>
         </select>`;
-        html += '<div style="display:flex;justify-content:flex-end">';
-        html += '<button class="nous-btn" style="background:var(--blue);color:var(--bg);padding:8px 20px" onclick="kbImportDocFromModal()">Import</button>';
+        html += '<div class="row-end">';
+        html += '<button class="nous-btn btn-blue" style="padding:8px 20px" onclick="kbImportDocFromModal()">Import</button>';
         html += '</div></div></details>';
 
-        html += '<details open style="margin-top:10px"><summary style="cursor:pointer;font-size:0.78rem;font-weight:600;color:var(--fg)">📚 Import from Context7</summary>';
-        html += '<div style="display:flex;flex-direction:column;gap:8px;margin-top:8px">';
+        html += '<details open style="margin-top:10px"><summary class="summary-label">📚 Import from Context7</summary>';
+        html += '<div class="stack" style="margin-top:8px">';
         html += '<div style="font-size:0.72rem;color:var(--muted)">Search Context7 for library documentation (e.g. "vllm", "next.js", "kubernetes").</div>';
         html += '<div style="display:flex;gap:8px">';
         html += '<input id="kb-ctx7-query" type="text" class="kb-search-box" placeholder="Search libraries..." style="flex:1">';
@@ -6976,23 +7002,23 @@ function burnAreaChart() {
         }).join('') || '<option value="project">Project</option>';
 
         html += '<div>';
-        html += '<div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">';
-        html += '<span style="font-size:0.92rem;font-weight:600;color:var(--fg)">Import Facts</span>';
-        html += '<span style="font-size:0.68rem;color:var(--muted);background:var(--surface);border:1px solid var(--border);border-radius:4px;padding:1px 6px">markdown or JSON</span>';
+        html += '<div class="row" style="margin-bottom:8px">';
+        html += '<span class="title-sm">Import Facts</span>';
+        html += '<span class="tag-chip">markdown or JSON</span>';
         html += '</div>';
-        html += '<div style="font-size:0.72rem;color:var(--muted);margin-bottom:10px">Paste markdown or JSON directly. Headings (# or ##) become separate facts. JSON should be an array of {title, body, type, tags} objects.</div>';
+        html += '<div class="muted-xs" style="margin-bottom:10px">Paste markdown or JSON directly. Headings (# or ##) become separate facts. JSON should be an array of {title, body, type, tags} objects.</div>';
 
-        html += '<details open style="margin-top:10px"><summary style="cursor:pointer;font-size:0.78rem;font-weight:600;color:var(--fg)">Paste Content</summary>';
-        html += '<div style="display:flex;flex-direction:column;gap:8px;margin-top:8px">';
-        html += `<select id="kb-import-layer" style="padding:7px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">${layerOpts2}</select>`;
-        html += `<select id="kb-import-format" style="padding:7px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem">
+        html += '<details open style="margin-top:10px"><summary class="summary-label">Paste Content</summary>';
+        html += '<div class="stack" style="margin-top:8px">';
+        html += `<select id="kb-import-layer" class="field-input">${layerOpts2}</select>`;
+        html += `<select id="kb-import-format" class="field-input">
           <option value="markdown" selected>Markdown</option>
           <option value="json">JSON</option>
         </select>`;
         html += '<textarea id="kb-import-content" rows="8" style="width:100%;padding:8px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem;font-family:var(--font-mono);resize:vertical;min-height:120px;box-sizing:border-box" placeholder="# Guard .join() against undefined\n\nAlways use (arr || []).join(\',\')..."></textarea>';
         html += '<div style="display:flex;align-items:center;justify-content:space-between">';
         html += '<label style="font-size:0.72rem;color:var(--muted);cursor:pointer;display:flex;align-items:center;gap:4px"><span>or load from file:</span><input type="file" accept=".md,.json,.txt" style="font-size:0.72rem" onchange="kbLoadFile(this)"></label>';
-        html += '<button class="nous-btn" style="background:var(--blue);color:var(--bg);padding:8px 20px" onclick="kbSubmitImport()">Import</button>';
+        html += '<button class="nous-btn btn-blue" style="padding:8px 20px" onclick="kbSubmitImport()">Import</button>';
         html += '</div></div></details>';
         html += '</div>';
 
@@ -7190,58 +7216,58 @@ function burnAreaChart() {
       const body = `
         <div style="max-height:70vh;overflow-y:auto;font-size:0.82rem;line-height:1.6;color:var(--fg);padding-right:16px">
           <div style="margin-bottom:18px">
-            <h3 style="font-size:0.92rem;margin:0 0 8px 0;color:var(--accent)">How Knowledge Works</h3>
+            <h3 class="modal-h">How Knowledge Works</h3>
             <p style="margin:0 0 6px 0">Hive organizes knowledge into <strong>4 layers</strong>, listed from highest to lowest priority:</p>
             <div style="display:flex;gap:6px;margin:8px 0;flex-wrap:wrap">
               <span style="background:var(--surface);border:1px solid var(--border);border-radius:4px;padding:3px 8px;font-size:0.75rem">personal (highest)</span>
-              <span style="color:var(--muted)">&rarr;</span>
+              <span class="muted">&rarr;</span>
               <span style="background:var(--surface);border:1px solid var(--border);border-radius:4px;padding:3px 8px;font-size:0.75rem">project</span>
-              <span style="color:var(--muted)">&rarr;</span>
+              <span class="muted">&rarr;</span>
               <span style="background:var(--surface);border:1px solid var(--border);border-radius:4px;padding:3px 8px;font-size:0.75rem">org</span>
-              <span style="color:var(--muted)">&rarr;</span>
+              <span class="muted">&rarr;</span>
               <span style="background:var(--surface);border:1px solid var(--border);border-radius:4px;padding:3px 8px;font-size:0.75rem">community (lowest)</span>
             </div>
-            <p style="margin:0;color:var(--muted);font-size:0.78rem">When the same page exists in multiple layers, the higher-priority layer wins. Each page is a Markdown file with optional tags.</p>
+            <p class="muted-note" style="margin:0">When the same page exists in multiple layers, the higher-priority layer wins. Each page is a Markdown file with optional tags.</p>
           </div>
 
           <div style="margin-bottom:18px">
-            <h3 style="font-size:0.92rem;margin:0 0 8px 0;color:var(--accent)">Knowledge Sources</h3>
+            <h3 class="modal-h">Knowledge Sources</h3>
             <p style="margin:0 0 6px 0">Knowledge comes from four types of sources, all managed through the <strong>Knowledge Sources</strong> modal:</p>
             <p style="margin:0 0 4px 0"><strong>Wiki pages</strong> — Created directly in Hive with <strong>+ New Fact</strong>. Give each page a title, layer, tags, and content. Bulk-add with the <strong>Import</strong> button.</p>
-            <p style="margin:0 0 4px 0"><strong>Obsidian vaults</strong> — Connect a vault or any directory of markdown files. Hive reads all <code style="background:var(--surface);padding:1px 4px;border-radius:3px">.md</code> files, picks up <code style="background:var(--surface);padding:1px 4px;border-radius:3px">#tags</code>, and re-scans every 30 seconds.</p>
-            <p style="margin:0 0 4px 0"><strong>Git sources</strong> — Clone a GitHub repo (or a subdirectory within it) and index its markdown files locally. Configure git sources in <code style="background:var(--surface);padding:1px 4px;border-radius:3px">hive.yaml</code> or add them through the Knowledge Sources modal. Git sources sync every 5 minutes to pick up upstream changes.</p>
-            <p style="margin:0;color:var(--muted);font-size:0.78rem"><strong>Wiki subscriptions</strong> — Follow a remote Hive instance or knowledge feed. New content syncs automatically on a periodic schedule.</p>
+            <p style="margin:0 0 4px 0"><strong>Obsidian vaults</strong> — Connect a vault or any directory of markdown files. Hive reads all <code class="code-chip">.md</code> files, picks up <code class="code-chip">#tags</code>, and re-scans every 30 seconds.</p>
+            <p style="margin:0 0 4px 0"><strong>Git sources</strong> — Clone a GitHub repo (or a subdirectory within it) and index its markdown files locally. Configure git sources in <code class="code-chip">hive.yaml</code> or add them through the Knowledge Sources modal. Git sources sync every 5 minutes to pick up upstream changes.</p>
+            <p class="muted-note" style="margin:0"><strong>Wiki subscriptions</strong> — Follow a remote Hive instance or knowledge feed. New content syncs automatically on a periodic schedule.</p>
           </div>
 
           <div style="margin-bottom:18px">
-            <h3 style="font-size:0.92rem;margin:0 0 8px 0;color:var(--accent)">Linting & Promotion</h3>
+            <h3 class="modal-h">Linting & Promotion</h3>
             <p style="margin:0">Every page starts as a <strong>draft</strong>. The system automatically checks quality (title, tags, body length) and promotes pages through <strong>draft</strong> &rarr; <strong>reviewed</strong> &rarr; <strong>canonical</strong>. No action needed on your part — just write good content and the system handles the rest.</p>
           </div>
 
           <div style="margin-bottom:18px">
-            <h3 style="font-size:0.92rem;margin:0 0 8px 0;color:var(--accent)">Fisher-Rao Scoring</h3>
+            <h3 class="modal-h">Fisher-Rao Scoring</h3>
             <p style="margin:0 0 6px 0">Search uses <strong>Fisher-Rao geodesic distance</strong> on diagonal Gaussian embeddings to find the most relevant facts. This replaces simple substring matching with a richer geometric similarity measure.</p>
-            <p style="margin:0;color:var(--muted);font-size:0.78rem">Cold facts (fewer than 10 accesses) use cosine similarity. As facts are accessed more frequently, they graduate to the full Fisher-Rao distance, which captures both the direction and uncertainty of the embedding for more accurate ranking.</p>
+            <p class="muted-note" style="margin:0">Cold facts (fewer than 10 accesses) use cosine similarity. As facts are accessed more frequently, they graduate to the full Fisher-Rao distance, which captures both the direction and uncertainty of the embedding for more accurate ranking.</p>
           </div>
 
           <div style="margin-bottom:18px">
-            <h3 style="font-size:0.92rem;margin:0 0 8px 0;color:var(--accent)">How Sources Combine</h3>
+            <h3 class="modal-h">How Sources Combine</h3>
             <p style="margin:0 0 6px 0">Pages from all sources (wiki pages, vaults, git sources, and subscriptions) are merged together. If two pages share the same title, the one from the higher-priority layer is used.</p>
-            <p style="margin:0;color:var(--muted);font-size:0.78rem">Priority order: personal &gt; project &gt; org &gt; community.</p>
+            <p class="muted-note" style="margin:0">Priority order: personal &gt; project &gt; org &gt; community.</p>
           </div>
 
           <div style="margin-bottom:18px">
-            <h3 style="font-size:0.92rem;margin:0 0 8px 0;color:var(--accent)">Sharing Knowledge</h3>
+            <h3 class="modal-h">Sharing Knowledge</h3>
             <p style="margin:0">Point multiple Hive instances at the same vault folder, use wiki subscriptions to share across teams, or add shared git sources so every instance indexes the same upstream docs. Everyone sees the same facts without copying files around.</p>
           </div>
 
           <div style="margin-bottom:4px">
-            <h3 style="font-size:0.92rem;margin:0 0 8px 0;color:var(--accent)">How Agents Use Knowledge (Priming)</h3>
+            <h3 class="modal-h">How Agents Use Knowledge (Priming)</h3>
             <p style="margin:0 0 6px 0">Before each agent kick, the <strong>knowledge primer</strong> runs a pipeline to inject relevant facts into the agent's context:</p>
             <p style="margin:0 0 4px 0"><strong>1. Keyword extraction</strong> — The primer extracts keywords from the issue title assigned to the agent.</p>
             <p style="margin:0 0 4px 0"><strong>2. Fisher-Rao search</strong> — Those keywords are searched across all connected sources (wiki layers, vaults, git sources) using Fisher-Rao scoring to find the most relevant facts.</p>
-            <p style="margin:0 0 4px 0"><strong>3. Injection</strong> — Matching facts are injected into the kick message via the <code style="background:var(--surface);padding:1px 4px;border-radius:3px">\${KNOWLEDGE}</code> template variable. The agent receives a "Relevant Knowledge" section containing patterns, gotchas, and decisions relevant to its current work.</p>
-            <p style="margin:0;color:var(--muted);font-size:0.78rem">This means your agents get smarter as you add knowledge — no prompt editing required. Add a fact about a common mistake and every agent working on a related issue will see it automatically.</p>
+            <p style="margin:0 0 4px 0"><strong>3. Injection</strong> — Matching facts are injected into the kick message via the <code class="code-chip">\${KNOWLEDGE}</code> template variable. The agent receives a "Relevant Knowledge" section containing patterns, gotchas, and decisions relevant to its current work.</p>
+            <p class="muted-note" style="margin:0">This means your agents get smarter as you add knowledge — no prompt editing required. Add a fact about a common mistake and every agent working on a related issue will see it automatically.</p>
           </div>
         </div>
       `;
@@ -7282,7 +7308,7 @@ function burnAreaChart() {
             html += `<div style="padding:10px;border:1px solid var(--border);border-radius:6px;margin-bottom:8px">`;
             html += `<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">`;
             html += `<div><div style="font-size:0.82rem;font-weight:600;color:var(--fg)">📂 ${escapeHtml(v.name)}</div>`;
-            html += `<div style="font-size:0.7rem;color:var(--muted)">${escapeHtml(v.root_dir)} · ${v.pages} pages</div></div>`;
+            html += `<div class="muted-xs">${escapeHtml(v.root_dir)} · ${v.pages} pages</div></div>`;
             html += `<div style="display:flex;gap:4px">`;
             html += `<button class="nous-btn" style="background:var(--surface);color:var(--fg);border:1px solid var(--border);font-size:0.7rem;padding:4px 8px" onclick="kbReindexVault('${escapeHtml(v.root_dir)}')">↻ Reindex</button>`;
             html += `<button class="nous-btn" style="background:var(--red);color:var(--bg);font-size:0.7rem;padding:4px 8px" onclick="kbDisconnectVault('${escapeHtml(v.root_dir)}')">Disconnect</button>`;
@@ -7303,8 +7329,8 @@ function burnAreaChart() {
         html += '<input id="kb-vault-path" type="text" class="kb-search-box" placeholder="/data/vaults/my-obsidian-vault">';
         html += '<input id="kb-vault-name" type="text" class="kb-search-box" placeholder="Display name">';
         html += '</div>';
-        html += '<div style="display:flex;justify-content:flex-end">';
-        html += '<button class="nous-btn" style="background:var(--blue);color:var(--bg)" onclick="kbConnectVault()">Connect</button>';
+        html += '<div class="row-end">';
+        html += '<button class="nous-btn btn-blue" onclick="kbConnectVault()">Connect</button>';
         html += '</div></div>';
 
         el.innerHTML = html;

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -26,6 +26,9 @@
       --shadow-modal: 0 20px 60px rgba(0, 0, 0, 0.5);
       --font-ui: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       --font-mono: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
+      /* Type ramp — section headers / card titles / labels only; body-copy sizes stay. */
+      --fs-xs: .68rem; --fs-sm: .75rem; --fs-base: .82rem;
+      --fs-md: .92rem; --fs-lg: 1.05rem; --fs-xl: 1.25rem;
       /* Layout */
       --sidebar-w: 302px;
       /* ── Legacy aliases — every old token name keeps working ── */
@@ -40,16 +43,25 @@
       --red-bg: rgba(255, 126, 126, 0.15); --red-border: rgba(255, 126, 126, 0.35);
     }
     * { margin: 0; padding: 0; box-sizing: border-box; }
+    /* ── Deliberate monospace: data surfaces only. UI chrome uses --font-ui. ── */
+    code, pre { font-family: var(--font-mono); }
+    .mono { font-family: var(--font-mono); }
+    #audit-panel { font-family: var(--font-mono); }
+    /* Section eyebrow label — hub convention (amber, uppercase, tracked). */
+    .section-label {
+      font-family: var(--font-ui); font-size: var(--fs-xs); font-weight: 800;
+      letter-spacing: 0.12em; text-transform: uppercase; color: var(--amber);
+    }
     body {
-      font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
+      font-family: var(--font-ui);
       background: var(--bg); color: var(--text);
       padding: 64px 20px 24px calc(var(--sidebar-w) + 20px);
       margin: 0; min-height: 100vh; max-width: 100vw; overflow-x: hidden;
     }
-    h1 { font-size: 1.4rem; margin-bottom: 20px; display: flex; align-items: center; }
+    h1 { font-size: var(--fs-xl); margin-bottom: 20px; display: flex; align-items: center; }
     h1 span.bee { font-size: 1.6rem; margin-right: 8px; }
     .timestamp { color: var(--muted); font-size: 0.8rem; margin-left: 12px; }
-    .git-version { font-size: 0.65rem; color: var(--muted); margin-left: 10px; font-weight: 400; font-family: monospace; }
+    .git-version { font-size: 0.65rem; color: var(--muted); margin-left: 10px; font-weight: 400; font-family: var(--font-mono); }
     .git-version .git-behind { color: var(--yellow); font-weight: 600; }
     .git-version .git-dirty { color: var(--yellow); }
     .header-spacer { flex: 1; }
@@ -82,7 +94,6 @@
       --oc-accent-light: rgba(220,38,38,0.08);
       --green-bg: #f0fdf4; --green-border: #bbf7d0;
       --red-bg: #fef2f2; --red-border: #fecaca;
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
       background: var(--bg); color: var(--text);
     }
     body.light-mode .connection { display: none; }
@@ -111,8 +122,9 @@
     .oc-logo-sub { font-size: 0.55rem; color: var(--muted); letter-spacing: 0.5px; text-transform: uppercase; }
     .oc-nav-group { padding: 12px 0; }
     .oc-nav-label {
-      font-size: 0.65rem; font-weight: 600; color: var(--muted);
-      text-transform: uppercase; letter-spacing: 0.8px;
+      /* .section-label convention */
+      font-size: var(--fs-xs); font-weight: 800; color: var(--amber);
+      text-transform: uppercase; letter-spacing: 0.12em;
       padding: 10px 14px 4px; user-select: none;
       display: flex; align-items: center; gap: 8px;
     }
@@ -270,8 +282,8 @@
       padding-bottom: 12px; border-bottom: 1px solid var(--border);
     }
     .oc-agent-detail-header .agent-name-big {
-      font-size: 1.2rem; font-weight: 700; color: var(--text);
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      font-size: var(--fs-xl); font-weight: 700; color: var(--text);
+      font-family: var(--font-ui);
     }
     .oc-agent-detail-header .status-dot {
       width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0;
@@ -404,7 +416,7 @@
       border-radius: 8px; border: 1px solid var(--line);
       min-height: calc(1.3em * 20 + 28px); max-height: 70vh; overflow-y: auto;
       resize: vertical;
-      font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
+      font-family: var(--font-mono);
       font-size: 0.65rem;
       white-space: pre-wrap;
       word-break: break-word;
@@ -420,12 +432,13 @@
       background: var(--indigo); color: var(--bg); padding: 1px 5px; border-radius: 3px;
     }
     .sum-cmd {
-      font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace;
+      font-family: var(--font-mono);
       font-size: 0.6rem; color: var(--muted); padding: 4px 10px 4px 14px;
       border-left: 2px solid var(--line); margin: 0; line-height: 1.4;
       word-break: break-all;
     }
     .sum-tree {
+      font-family: var(--font-mono);
       font-size: 0.58rem; color: var(--muted); padding: 1px 10px 1px 20px;
       font-style: italic;
     }
@@ -502,11 +515,7 @@
       border-radius: 8px; box-shadow: 0 1px 2px rgba(0,0,0,0.04);
     }
 
-    /* Light typography */
-    body.light-mode h1, body.light-mode h2,
-    body.light-mode .gov-title, body.light-mode .token-title,
-    body.light-mode .agent-name { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }
-    body.light-mode .doing { font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace; }
+    /* Light typography now shares --font-ui with dark mode; .doing stays mono in both. */
 
     /* Light button overrides */
     body.light-mode .terminal-link { border-color: var(--accent); color: var(--accent); }
@@ -569,9 +578,9 @@
     .gh-app-perm-details .perm-missing { color: var(--red); font-weight: 600; }
     .gh-auth-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.6); z-index: 9999; display: flex; align-items: center; justify-content: center; }
     .gh-auth-modal { background: var(--panel); border-radius: 12px; padding: 32px; max-width: 420px; width: 90%; text-align: center; box-shadow: var(--shadow-modal); }
-    .gh-auth-modal h3 { margin: 0 0 8px; font-size: 1.2rem; color: var(--text); }
+    .gh-auth-modal h3 { margin: 0 0 8px; font-size: var(--fs-xl); color: var(--text); }
     .gh-auth-modal p { color: var(--muted); font-size: 0.85rem; margin: 4px 0; }
-    .gh-auth-modal .device-code { font-family: monospace; font-size: 2rem; font-weight: 800; color: var(--green); letter-spacing: 4px; padding: 16px; background: var(--green-bg); border-radius: 8px; margin: 16px 0; user-select: all; }
+    .gh-auth-modal .device-code { font-family: var(--font-mono); font-size: 2rem; font-weight: 800; color: var(--green); letter-spacing: 4px; padding: 16px; background: var(--green-bg); border-radius: 8px; margin: 16px 0; user-select: all; }
     .gh-auth-modal .gh-verify-link { display: inline-block; margin: 12px 0; padding: 8px 20px; background: var(--green); color: var(--bg); text-decoration: none; border-radius: 6px; font-weight: 600; }
     .gh-auth-modal .gh-verify-link:hover { background: color-mix(in srgb, var(--green) 85%, #fff); }
     .gh-auth-modal .gh-poll-status { color: var(--muted); font-size: 0.8rem; margin-top: 12px; }
@@ -582,7 +591,7 @@
     .claude-auth-btn:hover { background: #f59e0b; }
     .claude-auth-status { font-size: 0.8rem; color: var(--muted); }
     .claude-auth-status.logged-in { color: var(--green); font-weight: 600; }
-    .gh-setup-modal h3 { margin: 0 0 16px; font-size: 1.2rem; color: var(--text); text-align: center; }
+    .gh-setup-modal h3 { margin: 0 0 16px; font-size: var(--fs-xl); color: var(--text); text-align: center; }
     .gh-setup-modal p { color: var(--muted); font-size: 0.85rem; margin: 8px 0; line-height: 1.5; }
     .gh-setup-modal .setup-option { background: var(--bg); border: 2px solid var(--line); border-radius: 8px; padding: 16px; margin: 12px 0; cursor: pointer; transition: border-color 0.15s; }
     .gh-setup-modal .setup-option:hover { border-color: var(--green); }
@@ -638,7 +647,7 @@
     .value.copilot { color: var(--cyan); }
     .value.claude { color: var(--purple); }
     .value.pi { color: var(--green); }
-    .doing { font-size: 0.65rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: pre-wrap; line-height: 1.3; min-height: 5.6em; max-height: 30em; overflow-y: auto; width: 100%; }
+    .doing { font-family: var(--font-mono); font-size: 0.65rem; color: var(--cyan); margin-top: 6px; word-break: break-word; white-space: pre-wrap; line-height: 1.3; min-height: 5.6em; max-height: 30em; overflow-y: auto; width: 100%; }
     .summary-age { display: inline-block; font-size: 0.6rem; font-style: normal; border-radius: 3px; padding: 1px 5px; margin-right: 5px; vertical-align: middle; white-space: nowrap; }
     .summary-age.age-recent { background: rgba(210,153,34,0.15); color: var(--yellow); border: 1px solid rgba(210,153,34,0.3); }
     .summary-age.age-stale  { background: var(--red-bg);  color: var(--red); border: 1px solid var(--red-border); }
@@ -672,7 +681,7 @@
 
     /* Health status panel */
     .health { margin-bottom: 24px; }
-    .health h2 { font-size: 0.95rem; margin-bottom: 8px; color: var(--muted); }
+    .health h2 { font-size: var(--fs-xs); font-weight: 800; letter-spacing: 0.12em; text-transform: uppercase; color: var(--amber); margin-bottom: 8px; }
     .health-grid { display: flex; flex-wrap: wrap; gap: 12px; }
     .health-item {
       background: var(--surface); border: 1px solid var(--border);
@@ -731,7 +740,7 @@
     .governor.dead { border-color: var(--red); }
     .governor.starting { border-color: var(--yellow); }
     .governor.active { border-color: var(--green); }
-    .gov-title { font-size: 1rem; font-weight: 700; margin-bottom: 8px; }
+    .gov-title { font-size: var(--fs-lg); font-weight: 700; margin-bottom: 8px; }
     .gov-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 8px; }
     .gov-stat { font-size: 0.85rem; }
     .gov-stat .label { color: var(--muted); font-size: 0.75rem; }
@@ -742,7 +751,7 @@
 
     /* Repos */
     .repos { margin-bottom: 24px; }
-    .repos h2 { font-size: 0.95rem; margin-bottom: 8px; color: var(--muted); }
+    .repos h2 { font-size: var(--fs-xs); font-weight: 800; letter-spacing: 0.12em; text-transform: uppercase; color: var(--amber); margin-bottom: 8px; }
     .repo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 8px; }
     .repo-card {
       background: var(--surface); border: 1px solid var(--border);
@@ -972,7 +981,7 @@
       background: var(--surface); border: 1px solid var(--border);
       border-radius: 8px; padding: 16px;
     }
-    .token-title { font-size: 1rem; font-weight: 700; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; }
+    .token-title { font-size: var(--fs-lg); font-weight: 700; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; }
     .token-title .lookback { font-size: 0.7rem; color: var(--muted); font-weight: 400; }
     .token-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 10px; margin-bottom: 12px; }
     .token-stat { text-align: left; }
@@ -980,6 +989,7 @@
     .token-stat .tlabel { font-size: 0.65rem; color: var(--muted); }
     .token-models { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 10px; }
     .token-model-chip {
+      font-family: var(--font-mono);
       background: rgba(188,140,255,0.1); border: 1px solid rgba(188,140,255,0.25);
       border-radius: 6px; padding: 6px 10px; font-size: 0.72rem;
     }
@@ -987,8 +997,8 @@
     .token-model-chip .mcount { color: var(--muted); margin-left: 6px; }
     .token-sessions { font-size: 0.7rem; color: var(--muted); }
     .token-sessions summary { cursor: pointer; font-weight: 600; color: var(--text); margin-bottom: 4px; }
-    .token-session-row { display: flex; gap: 8px; padding: 2px 0; align-items: baseline; }
-    .token-session-row .sid { color: var(--cyan); font-family: monospace; min-width: 90px; }
+    .token-session-row { font-family: var(--font-mono); display: flex; gap: 8px; padding: 2px 0; align-items: baseline; }
+    .token-session-row .sid { color: var(--cyan); font-family: var(--font-mono); min-width: 90px; }
     .token-session-row .sagent { font-weight: 600; min-width: 70px; font-size: 0.65rem; }
     /* Agent colors injected dynamically from status payload via injectAgentStyles() */
     .token-session-row .sagent.a-unknown { color: var(--muted); font-style: italic; }
@@ -1000,7 +1010,7 @@
     /* Token burn rate chart */
     .burn-chart-wrap { margin: 8px 0 12px; }
     .burn-chart-title { font-size: 0.7rem; color: var(--muted); margin-bottom: 4px; }
-    .burn-context { display: flex; justify-content: space-between; margin-top: 6px; font-size: 0.7rem; font-family: monospace; }
+    .burn-context { display: flex; justify-content: space-between; margin-top: 6px; font-size: 0.7rem; font-family: var(--font-mono); }
     .burn-context .bc-stat { display: flex; flex-direction: column; align-items: center; }
     .burn-context .bc-val { font-weight: 700; font-size: 0.85rem; }
     .burn-context .bc-label { color: var(--muted); font-size: 0.6rem; }
@@ -1034,7 +1044,7 @@
     /* Model chip on agent cards */
     .pin-toggle { cursor: pointer; background: none; border: none; font-size: 0.7rem; padding: 0 2px; opacity: 0.6; transition: opacity 0.2s; }
     .pin-toggle:hover { opacity: 1; }
-    .model-chip { display: inline-flex; align-items: center; gap: 4px; font-size: 0.65rem; padding: 2px 6px; border-radius: 4px; }
+    .model-chip { font-family: var(--font-mono); display: inline-flex; align-items: center; gap: 4px; font-size: 0.65rem; padding: 2px 6px; border-radius: 4px; }
     .model-chip.free { background: var(--green-bg); color: var(--green); }
     .model-chip.paid { background: rgba(210,153,34,0.12); color: var(--yellow); }
     .model-chip.haiku { background: rgba(88,166,255,0.12); color: var(--blue); }
@@ -1139,7 +1149,7 @@
       box-shadow: var(--shadow-modal);
       padding: 24px;
     }
-    .hive-dialog-title { font-size: 1rem; font-weight: 600; color: var(--text); margin-bottom: 12px; }
+    .hive-dialog-title { font-size: var(--fs-lg); font-weight: 600; color: var(--text); margin-bottom: 12px; }
     .hive-dialog-body { font-size: 0.9rem; color: var(--muted); line-height: 1.5; white-space: pre-wrap; margin-bottom: 20px; }
     .hive-dialog-buttons { display: flex; gap: 10px; justify-content: flex-end; }
     .hive-dialog-btn {
@@ -1194,7 +1204,7 @@
     .config-footer .config-cancel:hover { color: var(--text); border-color: var(--text); }
 
     .config-field { margin-bottom: 14px; }
-    .config-field label { display: block; font-size: 0.7rem; color: var(--muted); margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.5px; }
+    .config-field label { display: block; font-size: var(--fs-xs); color: var(--muted); margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.5px; }
     .config-field input[type="text"],
     .config-field input[type="number"],
     .config-field select {
@@ -1251,7 +1261,7 @@
     .config-info .config-tooltip {
       display: none; position: fixed; background: var(--bg); border: 1px solid var(--border);
       border-radius: 6px; padding: 6px 10px;
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      font-family: var(--font-ui);
       font-size: 0.7rem; font-weight: 400; text-transform: none; letter-spacing: normal;
       color: var(--text); white-space: normal; width: 240px; z-index: 10001;
       box-shadow: 0 4px 12px rgba(0,0,0,0.4); line-height: 1.4;
@@ -1280,6 +1290,7 @@
     .config-list-add button:hover { background: var(--blue); }
 
     .config-pre {
+      font-family: var(--font-mono);
       background: var(--bg); border: 1px solid var(--border);
       border-radius: 6px; padding: 12px; font-size: 0.75rem;
       overflow-x: auto; white-space: pre-wrap; color: var(--muted);
@@ -1419,7 +1430,7 @@
 
     /* Strategy Lab (Nous) */
     .nous-card { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 14px 16px; margin-bottom: 12px; }
-    .nous-card h3 { font-size: 0.85rem; margin: 0 0 8px 0; color: var(--fg); }
+    .nous-card h3 { font-size: var(--fs-md); margin: 0 0 8px 0; color: var(--fg); }
     .nous-mode-toggle { display: flex; gap: 0; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; margin-bottom: 14px; }
     .nous-mode-btn { flex: 1; padding: 8px 12px; text-align: center; font-size: 0.78rem; cursor: pointer; border: none; background: var(--surface); color: var(--muted); transition: all 0.2s; }
     .nous-mode-btn:not(:last-child) { border-right: 1px solid var(--border); }
@@ -1459,7 +1470,7 @@
     .nous-config-dialog > h2 { flex-shrink: 0; padding: 24px 24px 0; }
     .nous-config-dialog > .nous-config-body { flex: 1; overflow-y: auto; padding: 16px 24px; }
     .nous-config-dialog > .nous-config-footer { flex-shrink: 0; padding: 12px 24px; border-top: 1px solid var(--border); }
-    .nous-config-dialog h2 { font-size: 1.1rem; margin: 0 0 16px 0; display: flex; align-items: center; gap: 8px; }
+    .nous-config-dialog h2 { font-size: var(--fs-lg); margin: 0 0 16px 0; display: flex; align-items: center; gap: 8px; }
     .nous-config-section { margin-bottom: 20px; padding-bottom: 16px; border-bottom: 1px solid var(--border); }
     .nous-config-section:last-child { border-bottom: none; margin-bottom: 0; padding-bottom: 0; }
     .nous-config-section h3 { font-size: 0.85rem; color: var(--accent); margin: 0 0 10px 0; display: flex; align-items: center; gap: 6px; }
@@ -1565,12 +1576,12 @@
     .kb-setup-card { border: 1px solid var(--border); border-radius: 10px; background: var(--surface); padding: 20px; cursor: pointer; transition: all 0.2s; text-align: left; }
     .kb-setup-card:hover { border-color: var(--accent); box-shadow: 0 2px 12px rgba(88,166,255,0.12); }
     .kb-setup-card-icon { font-size: 1.8rem; margin-bottom: 10px; }
-    .kb-setup-card-title { font-size: 0.88rem; font-weight: 700; color: var(--fg); margin-bottom: 6px; }
+    .kb-setup-card-title { font-size: var(--fs-md); font-weight: 700; color: var(--fg); margin-bottom: 6px; }
     .kb-setup-card-desc { font-size: 0.74rem; color: var(--muted); line-height: 1.5; }
     .kb-setup-instructions { margin-top: 16px; text-align: left; font-size: 0.78rem; line-height: 1.7; color: var(--fg); }
     .kb-setup-instructions ol { padding-left: 20px; margin: 10px 0; }
     .kb-setup-instructions li { margin-bottom: 10px; }
-    .kb-setup-instructions code { background: var(--bg); padding: 2px 6px; border-radius: 4px; font-size: 0.74rem; font-family: monospace; }
+    .kb-setup-instructions code { background: var(--bg); padding: 2px 6px; border-radius: 4px; font-size: 0.74rem; font-family: var(--font-mono); }
     .kb-setup-instructions pre { background: var(--bg); padding: 10px 14px; border-radius: 6px; overflow-x: auto; font-size: 0.72rem; line-height: 1.5; margin: 8px 0; border: 1px solid var(--border); }
     .kb-setup-instructions .kb-tip { background: rgba(88,166,255,0.08); border: 1px solid rgba(88,166,255,0.2); border-radius: 6px; padding: 8px 12px; font-size: 0.72rem; color: var(--muted); margin-top: 10px; }
     .kb-setup-back { display: inline-flex; align-items: center; gap: 4px; background: none; border: none; color: var(--accent); cursor: pointer; font-size: 0.78rem; padding: 0; margin-bottom: 12px; }
@@ -1588,7 +1599,7 @@
       padding: 20px 16px; box-sizing: border-box; z-index: 100;
       overflow-y: auto; font-size: 0.82rem; color: var(--fg);
     }
-    #hive-info-sidebar h3 { font-size: 0.95rem; margin: 0 0 10px 0; color: var(--text); }
+    #hive-info-sidebar h3 { font-size: var(--fs-md); margin: 0 0 10px 0; color: var(--text); }
     #hive-info-sidebar p { line-height: 1.5; margin: 0 0 16px 0; color: var(--muted); }
     #hive-info-sidebar .sidebar-links { list-style: none; padding: 0; margin: 0; }
     #hive-info-sidebar .sidebar-links li { margin-bottom: 10px; }
@@ -1934,7 +1945,7 @@
   <div class="governor" id="governor"></div>
 
   <div id="advisory-section" style="margin-top: 16px; margin-bottom: 24px; display: none;">
-    <h2 class="advisory-collapse-header section-header-toggle" style="font-size: 0.95rem; color: var(--muted); margin-bottom: 8px; cursor: pointer; user-select: none;" onclick="toggleAdvisorySection('advisory-digest-main')">
+    <h2 class="section-label advisory-collapse-header section-header-toggle" style="margin-bottom: 8px; cursor: pointer; user-select: none;" onclick="toggleAdvisorySection('advisory-digest-main')">
       <span id="advisory-digest-main-chevron" class="collapse-chevron">▼</span> 📋 Advisory Digest
     </h2>
     <div class="section-body">
@@ -1952,14 +1963,14 @@
   </div>
 
   <div id="beads-section" style="margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 8px;" class="section-header-toggle" onclick="toggleSection('beads-section')"><span class="section-chevron">▼</span> Beads</h2>
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('beads-section')"><span class="section-chevron">▼</span> Beads</h2>
     <div class="section-body">
       <div class="beads" id="beads"></div>
     </div>
   </div>
 
   <div id="acmm-eval-section" style="margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 8px;" class="section-header-toggle" onclick="toggleSection('acmm-eval-section')"><span class="section-chevron">▼</span> 🎯 ACMM Evaluation</h2>
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('acmm-eval-section')"><span class="section-chevron">▼</span> 🎯 ACMM Evaluation</h2>
     <div class="section-body">
       <div id="acmm-eval-card" style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:16px">
         <div class="kb-stat-grid" id="acmm-eval-stats">
@@ -1983,7 +1994,7 @@
   </div>
 
   <div id="audit-section" style="margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 8px;" class="section-header-toggle" onclick="toggleSection('audit-section')"><span class="section-chevron">▼</span> 📋 Audit Log</h2>
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('audit-section')"><span class="section-chevron">▼</span> 📋 Audit Log</h2>
     <div class="section-body">
       <div style="margin-bottom:8px;display:flex;align-items:center;gap:8px">
         <div style="flex:1;position:relative">
@@ -2001,7 +2012,7 @@
   </div>
 
   <div id="nous-section" style="display:none; margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 8px;" class="section-header-toggle" onclick="toggleSection('nous-section')"><span class="section-chevron">▼</span> 🧪 Strategy Lab <span id="nous-mode-badge" style="font-size:0.75rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span> <button onclick="event.stopPropagation();openNousConfig()" style="background:none;border:none;cursor:pointer;font-size:1rem;color:var(--muted);margin-left:6px;padding:2px" title="Strategy Lab Configuration">⚙️</button></h2>
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('nous-section')"><span class="section-chevron">▼</span> 🧪 Strategy Lab <span id="nous-mode-badge" style="font-size:0.75rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span> <button onclick="event.stopPropagation();openNousConfig()" style="background:none;border:none;cursor:pointer;font-size:1rem;color:var(--muted);margin-left:6px;padding:2px" title="Strategy Lab Configuration">⚙️</button></h2>
     <div class="section-body">
       <div id="nous-panel"></div>
       <div id="nous-config-overlay" class="nous-config-overlay" style="display:none"></div>
@@ -2009,14 +2020,14 @@
   </div>
 
   <div id="inception-section" style="margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 8px;" class="section-header-toggle" onclick="toggleSection('inception-section')"><span class="section-chevron">▼</span> 💡 Project Inception</h2>
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('inception-section')"><span class="section-chevron">▼</span> 💡 Project Inception</h2>
     <div class="section-body">
       <div id="inception-panel" style="height:800px;overflow-y:auto;overflow-x:hidden;"></div>
     </div>
   </div>
 
   <div id="knowledge-section" style="margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 8px;" class="section-header-toggle" onclick="toggleSection('knowledge-section')"><span class="section-chevron">▼</span> 📚 Knowledge Base <span id="kb-status-badge" style="font-size:0.7rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span></h2>
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('knowledge-section')"><span class="section-chevron">▼</span> 📚 Knowledge Base <span id="kb-status-badge" style="font-size:0.7rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span></h2>
     <div class="section-body">
       <div id="knowledge-panel"></div>
     </div>
@@ -2025,7 +2036,7 @@
   <div id="contributors-section" style="margin-top: 16px; margin-bottom: 24px;">
     <div style="display:flex;align-items:center;gap:12px;margin-bottom:12px;flex-wrap:wrap" class="section-header-toggle" onclick="toggleSection('contributors-section')">
       <span class="section-chevron">▼</span>
-      <h2 style="font-size: 0.95rem; color: var(--muted); margin:0;">👥 Contributors <span id="contributors-status-badge" style="font-size:0.7rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span></h2>
+      <h2 class="section-label" style="margin:0;">👥 Contributors <span id="contributors-status-badge" style="font-size:0.7rem;padding:2px 8px;border-radius:9999px;margin-left:8px"></span></h2>
       <a href="/contribute" target="_blank" onclick="event.stopPropagation()" style="font-size:0.75rem;padding:4px 12px;background:#238636;color:#fff;border-radius:6px;text-decoration:none;font-weight:600">Share /contribute link &rarr;</a>
       <a href="/leaderboard" target="_blank" onclick="event.stopPropagation()" style="font-size:0.75rem;padding:4px 12px;background:transparent;color:#58a6ff;border:1px solid #58a6ff;border-radius:6px;text-decoration:none">🏆 Leaderboard</a>
     </div>
@@ -2038,14 +2049,14 @@
   </div>
 
   <div id="debug-section" style="margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 12px;" class="section-header-toggle" onclick="toggleSection('debug-section')"><span class="section-chevron">▼</span> 🔍 System Diagnostics</h2>
+    <h2 style="margin-bottom: 12px;" class="section-label section-header-toggle" onclick="toggleSection('debug-section')"><span class="section-chevron">▼</span> 🔍 System Diagnostics</h2>
     <div class="section-body">
       <div id="debug-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 12px;"></div>
     </div>
   </div>
 
   <div id="logs-section" style="display: none; margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="font-size: 0.95rem; color: var(--muted); margin-bottom: 12px;" class="section-header-toggle" onclick="toggleSection('logs-section')"><span class="section-chevron">▼</span> 📋 Agent Logs</h2>
+    <h2 style="margin-bottom: 12px;" class="section-label section-header-toggle" onclick="toggleSection('logs-section')"><span class="section-chevron">▼</span> 📋 Agent Logs</h2>
     <div class="section-body">
       <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 10px;">
         <select id="logs-agent-select" style="padding: 6px 12px; border: 1px solid var(--border); border-radius: 6px; font-size: 0.82rem; background: var(--surface); color: var(--text); cursor: pointer;" title="Filter logs to a specific agent or view all agents combined">
@@ -2055,7 +2066,7 @@
           <input type="checkbox" id="logs-follow" checked> Follow
         </label>
       </div>
-      <div id="logs-output" style="background: #1a1a2e; color: #e2e8f0; font-family: 'SF Mono', 'Fira Code', monospace; font-size: 0.75rem; line-height: 1.5; padding: 14px; border-radius: 8px; max-height: 500px; overflow-y: auto; white-space: pre-wrap; word-break: break-all;"></div>
+      <div id="logs-output" style="background: #1a1a2e; color: #e2e8f0; font-family: var(--font-mono); font-size: 0.75rem; line-height: 1.5; padding: 14px; border-radius: 8px; max-height: 500px; overflow-y: auto; white-space: pre-wrap; word-break: break-all;"></div>
     </div>
   </div>
 
@@ -2063,7 +2074,7 @@
   <div id="oc-agent-detail" class="oc-agent-detail"></div>
   <div id="agents-section">
     <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-      <h2 style="font-size: 0.95rem; color: var(--muted); margin:0; cursor:pointer" class="section-header-toggle" onclick="toggleSection('agents-section')"><span class="section-chevron">▼</span> Agents</h2>
+      <h2 style="margin:0; cursor:pointer" class="section-label section-header-toggle" onclick="toggleSection('agents-section')"><span class="section-chevron">▼</span> Agents</h2>
       <button id="agents-compact-all-btn" onclick="event.stopPropagation();toggleAllAgentsCompact()" style="font-size:0.7rem;padding:2px 10px;background:var(--surface);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer" title="Toggle all agent cards between compact and expanded view"></button>
     </div>
     <div class="section-body">
@@ -4385,7 +4396,7 @@ function intensityGauge() {
       </svg>
       <div style="position:absolute;left:${dotLeftPct}%;top:${dotTopPct}%;width:6px;height:6px;border-radius:50%;background:${color};border:1px solid #0d1117;transform:translate(-50%,-50%)"></div>
     </div>
-    <div style="display:flex;justify-content:space-between;font-size:0.6rem;color:var(--muted);margin-top:1px;font-family:monospace">
+    <div style="display:flex;justify-content:space-between;font-size:0.6rem;color:var(--muted);margin-top:1px;font-family:var(--font-mono)">
       <span>${tStart}</span><span>${tEnd}</span>
     </div>
     <div class="burn-context">
@@ -4394,7 +4405,7 @@ function intensityGauge() {
       <div class="bc-stat"><span class="bc-val" style="color:#f85149">${fmtTokens(peak)}</span><span class="bc-label">peak/hr</span></div>
       <div class="bc-stat"><span class="bc-val" style="color:${color}">${fmtTokens(now)}</span><span class="bc-label">current/hr</span></div>
     </div>
-    <div style="color:${color};font-size:11px;font-family:monospace;margin-top:2px">${label}</div>
+    <div style="color:${color};font-size:11px;font-family:var(--font-mono);margin-top:2px">${label}</div>
   </div>`;
 }
 
@@ -6565,7 +6576,7 @@ function burnAreaChart() {
             </label>
           </div>
           <label style="font-size:0.78rem;color:var(--muted)">Content
-            <textarea id="kb-import-content" rows="24" style="width:100%;margin-top:4px;padding:8px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem;font-family:'SF Mono','Fira Code',monospace;resize:vertical;min-height:320px" placeholder="# Guard .join() against undefined\n\nAlways use (arr || []).join(',')..."></textarea>
+            <textarea id="kb-import-content" rows="24" style="width:100%;margin-top:4px;padding:8px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem;font-family:var(--font-mono);resize:vertical;min-height:320px" placeholder="# Guard .join() against undefined\n\nAlways use (arr || []).join(',')..."></textarea>
           </label>
           <div style="display:flex;align-items:center;gap:10px;margin-top:4px">
             <label style="font-size:0.72rem;color:var(--muted);cursor:pointer;display:flex;align-items:center;gap:4px">
@@ -6809,7 +6820,7 @@ function burnAreaChart() {
           <option value="markdown" selected>Markdown</option>
           <option value="json">JSON</option>
         </select>`;
-        html += '<textarea id="kb-import-content" rows="8" style="width:100%;padding:8px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem;font-family:\'SF Mono\',\'Fira Code\',monospace;resize:vertical;min-height:120px;box-sizing:border-box" placeholder="# Guard .join() against undefined\n\nAlways use (arr || []).join(\',\')..."></textarea>';
+        html += '<textarea id="kb-import-content" rows="8" style="width:100%;padding:8px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);font-size:0.78rem;font-family:var(--font-mono);resize:vertical;min-height:120px;box-sizing:border-box" placeholder="# Guard .join() against undefined\n\nAlways use (arr || []).join(\',\')..."></textarea>';
         html += '<div style="display:flex;align-items:center;justify-content:space-between">';
         html += '<label style="font-size:0.72rem;color:var(--muted);cursor:pointer;display:flex;align-items:center;gap:4px"><span>or load from file:</span><input type="file" accept=".md,.json,.txt" style="font-size:0.72rem" onchange="kbLoadFile(this)"></label>';
         html += '<button class="nous-btn" style="background:#2563eb;color:white;padding:8px 20px" onclick="kbSubmitImport()">Import</button>';
@@ -7935,7 +7946,7 @@ function burnAreaChart() {
       html += 'background:' + COLORS.bg + ';';
       html += 'border:1px solid ' + COLORS.border + ';';
       html += 'border-radius:8px;';
-      html += 'font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Noto Sans,Helvetica,Arial,sans-serif;';
+      html += 'font-family:var(--font-ui);';
       html += 'position:relative;';
       html += 'margin-bottom:16px;';
       html += '">';
@@ -8134,7 +8145,7 @@ function burnAreaChart() {
             <div style="font-size:0.72rem;color:var(--muted);margin-left:auto">Phase: ${phase}</div>
           </div>
           <div style="position:relative">
-          <div id="inception-activity" style="background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:16px;font-family:'SF Mono','Cascadia Code',monospace;font-size:0.75rem;height:450px;overflow-y:auto;white-space:pre-wrap;color:var(--muted);resize:vertical;min-height:150px;max-height:calc(100vh - 200px)" onscroll="onInceptionScroll()">Waiting for brainstorm agent...</div>
+          <div id="inception-activity" style="background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:16px;font-family:var(--font-mono);font-size:0.75rem;height:450px;overflow-y:auto;white-space:pre-wrap;color:var(--muted);resize:vertical;min-height:150px;max-height:calc(100vh - 200px)" onscroll="onInceptionScroll()">Waiting for brainstorm agent...</div>
           <button id="inception-follow-btn" class="oc-summary-follow-btn" onclick="inceptionResumeTail()" title="Follow new output">⬇</button>
           </div>
           <div style="margin-top:12px;display:flex;gap:8px;justify-content:flex-end">
@@ -8238,7 +8249,7 @@ function burnAreaChart() {
             <div style="font-size:0.72rem;color:var(--muted);margin-left:auto">Phase: structure</div>
           </div>
           <div style="position:relative">
-          <div id="inception-activity" style="background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:16px;font-family:'SF Mono','Cascadia Code',monospace;font-size:0.75rem;height:450px;overflow-y:auto;white-space:pre-wrap;color:var(--muted);resize:vertical;min-height:150px;max-height:calc(100vh - 200px)" onscroll="onInceptionScroll()">Brainstorm agent is producing vision, constitution, requirements, and acceptance criteria...</div>
+          <div id="inception-activity" style="background:var(--bg);border:1px solid var(--border);border-radius:8px;padding:16px;font-family:var(--font-mono);font-size:0.75rem;height:450px;overflow-y:auto;white-space:pre-wrap;color:var(--muted);resize:vertical;min-height:150px;max-height:calc(100vh - 200px)" onscroll="onInceptionScroll()">Brainstorm agent is producing vision, constitution, requirements, and acceptance criteria...</div>
           <button id="inception-follow-btn" class="oc-summary-follow-btn" onclick="inceptionResumeTail()" title="Follow new output">⬇</button>
           </div>
           <div style="margin-top:12px;display:flex;gap:8px;justify-content:flex-end">
@@ -8369,7 +8380,7 @@ function burnAreaChart() {
           if (entry._file) {
             const f = entry._file;
             html += '<details style="margin:0;border:none">';
-            html += '<summary style="padding:2px 0;cursor:pointer;font-family:monospace;font-size:0.8rem;list-style:none;display:flex;align-items:center;gap:4px">';
+            html += '<summary style="padding:2px 0;cursor:pointer;font-family:var(--font-mono);font-size:0.8rem;list-style:none;display:flex;align-items:center;gap:4px">';
             html += '<span style="color:var(--muted);white-space:pre">' + escapeHtml(prefix + connector) + '</span>';
             html += '<span>📄 ' + escapeHtml(name) + '</span>';
             html += '<span style="font-size:0.68rem;color:var(--muted);margin-left:4px">' + f.content.length + ' chars</span>';
@@ -8377,7 +8388,7 @@ function burnAreaChart() {
             html += '<pre style="padding:12px 12px 12px 40px;margin:0;font-size:0.72rem;overflow-x:auto;background:var(--bg);white-space:pre-wrap;border-left:2px solid var(--border);margin-left:' + (prefix.length * 8 + 24) + 'px">' + escapeHtml(f.content) + '</pre>';
             html += '</details>';
           } else {
-            html += '<div style="padding:2px 0;font-family:monospace;font-size:0.8rem;display:flex;align-items:center;gap:4px">';
+            html += '<div style="padding:2px 0;font-family:var(--font-mono);font-size:0.8rem;display:flex;align-items:center;gap:4px">';
             html += '<span style="color:var(--muted);white-space:pre">' + escapeHtml(prefix + connector) + '</span>';
             html += '<span>📁 <strong>' + escapeHtml(name) + '/</strong></span>';
             html += '</div>';
@@ -8387,7 +8398,7 @@ function burnAreaChart() {
         return html;
       }
 
-      let html = '<div style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:16px;font-family:monospace">';
+      let html = '<div style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:16px;font-family:var(--font-mono)">';
       html += '<div style="font-size:0.82rem;font-weight:600;margin-bottom:8px">📦 Project Files (' + files.length + ')</div>';
       html += renderNode(root, '', true);
       html += '</div>';
@@ -9189,7 +9200,7 @@ function burnAreaChart() {
     function acmmCriterionRow(c, repoName) {
       const icon = c.passed ? '✅' : '❌';
       const tip = ACMM_CRITERION_TIPS[c.id] || '';
-      const patternItems = (c.patterns || []).map(p => '<span style="display:inline-block;font-size:0.68rem;background:var(--bg);padding:1px 6px;border-radius:3px;border:1px solid var(--border);margin:1px 2px;font-family:monospace">' + escapeHtml(p) + '</span>').join('');
+      const patternItems = (c.patterns || []).map(p => '<span style="display:inline-block;font-size:0.68rem;background:var(--bg);padding:1px 6px;border-radius:3px;border:1px solid var(--border);margin:1px 2px;font-family:var(--font-mono)">' + escapeHtml(p) + '</span>').join('');
       let issueBtn = '';
       if (!c.passed) {
         const repo = repoName || _acmmSelectedRepo || '';
@@ -10315,7 +10326,7 @@ function burnAreaChart() {
         '</div>' +
         '<div class="config-field" style="margin-bottom:12px">' +
           '<label>Or paste agent definition</label>' +
-          '<textarea id="import-paste-input" rows="20" style="width:100%;font-family:monospace;font-size:0.75rem;resize:vertical;min-height:300px" placeholder="apiVersion: hive.kubestellar.io/v1\nkind: AgentDefinition\n..."></textarea>' +
+          '<textarea id="import-paste-input" rows="20" style="width:100%;font-family:var(--font-mono);font-size:0.75rem;resize:vertical;min-height:300px" placeholder="apiVersion: hive.kubestellar.io/v1\nkind: AgentDefinition\n..."></textarea>' +
           '<div style="text-align:right;margin-top:6px"><button onclick="previewImportFromPaste()" style="padding:6px 16px;border-radius:6px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:#fff">Preview</button></div>' +
         '</div>' +
         '<div id="import-preview" style="display:none;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:16px;margin-top:16px">' +
@@ -11194,7 +11205,7 @@ function burnAreaChart() {
           html += '<span style="font-size:1.1rem">'+icon+'</span>';
           html += '<div style="flex:1">';
           html += '<div style="font-weight:600">'+esc(c.name)+' <span style="font-size:0.65rem;padding:1px 6px;border-radius:8px;background:var(--surface);border:1px solid var(--border);color:var(--muted);text-transform:uppercase;font-weight:400;margin-left:4px">'+esc(c.type)+'</span></div>';
-          if (c.uri) html += '<div style="font-size:0.72rem;color:var(--muted);font-family:monospace;overflow:hidden;text-overflow:ellipsis;max-width:400px" title="'+esc(c.uri)+'">'+esc(c.uri)+'</div>';
+          if (c.uri) html += '<div style="font-size:0.72rem;color:var(--muted);font-family:var(--font-mono);overflow:hidden;text-overflow:ellipsis;max-width:400px" title="'+esc(c.uri)+'">'+esc(c.uri)+'</div>';
           if (c.auth) html += '<div style="font-size:0.68rem;color:var(--muted)">🔒 '+esc(c.auth.type)+': '+(c.auth.env_var||c.auth.file||'')+'</div>';
           html += '</div>';
           html += '<button style="background:none;border:none;color:#dc2626;cursor:pointer;font-size:1rem;padding:0 4px" onclick="removeConnection('+i+')">✕</button>';
@@ -11277,7 +11288,7 @@ function burnAreaChart() {
               for (const sf of (data.sourceFiles || [])) {
                 const note = sf.note ? ' <span style="color:var(--muted)">(' + esc(sf.note) + ')</span>' : '';
                 items += '<li style="margin:3px 0"><strong style="color:var(--muted);min-width:80px;display:inline-block">' + esc(sf.label) + ':</strong> '
-                  + '<a href="' + esc(sf.url) + '" target="_blank" rel="noopener" style="color:var(--cyan);text-decoration:none;font-family:\'SF Mono\',\'Cascadia Code\',monospace;font-size:0.75rem">' + esc(sf.path) + '</a>'
+                  + '<a href="' + esc(sf.url) + '" target="_blank" rel="noopener" style="color:var(--cyan);text-decoration:none;font-family:var(--font-mono);font-size:0.75rem">' + esc(sf.path) + '</a>'
                   + note + '</li>';
               }
               srcEl.innerHTML = '<ul style="list-style:none;padding:0;margin:0">' + items + '</ul>';
@@ -11320,7 +11331,7 @@ function burnAreaChart() {
           <div style="flex:1"></div>
           <button onclick="savePromptTemplate()" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:none;background:var(--green);color:#fff">Save Template</button>
         </div>
-        <textarea id="${editorId}" style="flex:1;min-height:300px;font-family:'SF Mono','Cascadia Code',monospace;font-size:0.75rem;padding:12px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;resize:vertical;white-space:pre;tab-size:2" placeholder="Enter your agent's kick template here. Use \${VARIABLE} placeholders from the picker below.">${agentName ? '' : ''}</textarea>
+        <textarea id="${editorId}" style="flex:1;min-height:300px;font-family:var(--font-mono);font-size:0.75rem;padding:12px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;resize:vertical;white-space:pre;tab-size:2" placeholder="Enter your agent's kick template here. Use \${VARIABLE} placeholders from the picker below.">${agentName ? '' : ''}</textarea>
         <div id="${previewId}" class="config-pre config-pre-fill" style="display:none;flex:1;min-height:300px;overflow-y:auto"></div>
         <div style="margin-top:8px;flex-shrink:0">
           <div style="font-size:0.7rem;font-weight:600;color:var(--text);margin-bottom:6px">Variable Picker <span style="font-weight:400;color:var(--muted)">(click to insert at cursor)</span></div>
@@ -11412,7 +11423,7 @@ function burnAreaChart() {
         + '<button onclick="copyExportYaml()" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:#fff">Copy to Clipboard</button>'
         + '<button onclick="downloadExportYaml()" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:1px solid var(--border);background:var(--surface);color:var(--text)">Download YAML</button>'
         + '</div>'
-        + '<textarea id="' + yamlId + '" readonly style="flex:1;min-height:300px;font-family:\'SF Mono\',\'Cascadia Code\',monospace;font-size:0.75rem;padding:12px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;resize:vertical;white-space:pre;tab-size:2">Loading...</textarea>'
+        + '<textarea id="' + yamlId + '" readonly style="flex:1;min-height:300px;font-family:var(--font-mono);font-size:0.75rem;padding:12px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;resize:vertical;white-space:pre;tab-size:2">Loading...</textarea>'
         + '</div>';
     }
 
@@ -11487,7 +11498,7 @@ function burnAreaChart() {
             html += '</pre>';
             inCode = false;
           } else {
-            html += '<pre style="margin:8px 0;padding:10px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;font-family:monospace;font-size:0.72rem;white-space:pre-wrap;overflow-x:auto;color:var(--text)">';
+            html += '<pre style="margin:8px 0;padding:10px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;font-family:var(--font-mono);font-size:0.72rem;white-space:pre-wrap;overflow-x:auto;color:var(--text)">';
             inCode = true;
           }
           continue;
@@ -11909,7 +11920,7 @@ function burnAreaChart() {
           <div class="config-list">
             ${ghPatterns || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">No patterns configured</div>'}
             <div class="config-list-add">
-              <input type="text" id="cfg-sensing-gh-input" placeholder="e.g. 403.*rate limit" style="font-family:monospace;font-size:0.75rem" title="Regular expression to match against agent tmux pane output. When matched, the governor triggers a rate-limit pullback for that agent.">
+              <input type="text" id="cfg-sensing-gh-input" placeholder="e.g. 403.*rate limit" style="font-family:var(--font-mono);font-size:0.75rem" title="Regular expression to match against agent tmux pane output. When matched, the governor triggers a rate-limit pullback for that agent.">
               <button onclick="addSensingItem('ghRatePatterns','cfg-sensing-gh-input')" title="Add this regex pattern to the GitHub rate limit detection list">+ Add</button>
             </div>
           </div>
@@ -11919,7 +11930,7 @@ function burnAreaChart() {
           <div class="config-list">
             ${cliPatterns || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">No exclude patterns</div>'}
             <div class="config-list-add">
-              <input type="text" id="cfg-sensing-cli-input" placeholder="e.g. out of extra usage" style="font-family:monospace;font-size:0.75rem" title="Lines matching these patterns are filtered out before rate-limit detection. Use for known false positives in agent output.">
+              <input type="text" id="cfg-sensing-cli-input" placeholder="e.g. out of extra usage" style="font-family:var(--font-mono);font-size:0.75rem" title="Lines matching these patterns are filtered out before rate-limit detection. Use for known false positives in agent output.">
               <button onclick="addSensingItem('cliExcludePatterns','cfg-sensing-cli-input')" title="Add this pattern to the CLI exclusion list">+ Add</button>
             </div>
           </div>
@@ -11929,7 +11940,7 @@ function burnAreaChart() {
           <div class="config-list">
             ${loginPatterns || '<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">No login patterns configured</div>'}
             <div class="config-list-add">
-              <input type="text" id="cfg-sensing-login-input" placeholder="e.g. session expired" style="font-family:monospace;font-size:0.75rem" title="Regular expression to match against agent tmux pane output. When matched, the agent is paused and a notification is sent prompting you to log in.">
+              <input type="text" id="cfg-sensing-login-input" placeholder="e.g. session expired" style="font-family:var(--font-mono);font-size:0.75rem" title="Regular expression to match against agent tmux pane output. When matched, the agent is paused and a notification is sent prompting you to log in.">
               <button onclick="addSensingItem('loginPatterns','cfg-sensing-login-input')" title="Add this regex pattern to the login detection list">+ Add</button>
             </div>
           </div>

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1113,6 +1113,8 @@
     .config-overlay.hidden { display: none; }
     @keyframes config-fade-in { from { opacity: 0; } to { opacity: 1; } }
     .hive-dialog-overlay { z-index: 20000; }
+    .acmm-dialog-overlay { z-index: 10000; } /* JS toggles inline display flex/none */
+    .acmm-dialog { padding: 20px; max-width: 600px; width: 92%; max-height: 80vh; overflow-y: auto; }
     .hive-dialog { width: 460px; max-width: 92vw; padding: 24px; } /* modal panel recipe */
     .hive-dialog-title { font-size: var(--fs-lg); font-weight: 700; color: var(--text); margin-bottom: 12px; }
     .hive-dialog-body { font-size: 0.9rem; color: var(--muted); line-height: 1.5; white-space: pre-wrap; margin-bottom: 20px; }
@@ -1733,7 +1735,7 @@
        DOM untouched, z-indexes retained at each pattern's rule (they
        encode stacking intent). The acmm JS-built overlay keeps its inline
        styles until the Phase 4 template sweep. */
-    .gh-auth-overlay, .config-overlay, .hive-dialog-overlay, .nous-config-overlay {
+    .gh-auth-overlay, .config-overlay, .hive-dialog-overlay, .nous-config-overlay, .acmm-dialog-overlay {
       position: fixed; inset: 0;
       background: rgba(0, 0, 0, 0.55);
       -webkit-backdrop-filter: blur(4px); backdrop-filter: blur(4px);
@@ -1743,7 +1745,7 @@
     /* Glass panel — hub recipe linear-gradient(#17212deb,#0c1219eb) +
        border #ffffff1a, expressed in tokens so the light-mode remap
        (panel-strong #eef1f5 → white, near-black text border) just works. */
-    .gh-auth-modal, .gh-setup-modal, .config-modal, .hive-dialog, .nous-config-dialog {
+    .gh-auth-modal, .gh-setup-modal, .config-modal, .hive-dialog, .nous-config-dialog, .acmm-dialog {
       background: linear-gradient(
         color-mix(in srgb, var(--panel-strong) 92%, transparent),
         color-mix(in srgb, var(--bg-soft) 92%, transparent));
@@ -1847,6 +1849,15 @@
     .btn-blue { background: var(--blue); border-color: transparent; color: var(--bg); }
     .btn-blue:hover { background: color-mix(in srgb, var(--blue) 85%, #fff); border-color: transparent; color: var(--bg); }
     .btn-surface { background: var(--surface); border: 1px solid var(--border); color: var(--fg); }
+    /* ACMM dialog/card utilities */
+    .dialog-note { font-size: 0.82rem; color: var(--muted); margin: 0 0 12px; }
+    .text-base { font-size: var(--fs-base); }
+    .stat-num { font-size: 1.2rem; font-weight: 700; }
+    .dialog-btn { padding: 6px 14px; background: var(--bg); border: 1px solid var(--border); border-radius: 6px; cursor: pointer; color: var(--muted); font-size: 0.78rem; }
+    .card-tile { flex: 1; padding: 12px; background: var(--bg); border: 1px solid var(--border); border-radius: 6px; text-align: center; cursor: pointer; }
+    .row-card { cursor: pointer; padding: 8px; margin-bottom: 4px; background: var(--bg); border: 1px solid var(--border); border-radius: 6px; transition: border-color .15s; }
+    .error-note { color: var(--red); font-size: 0.82rem; }
+    .repo-chip-btn { padding: 2px 8px; border-radius: 4px; border: 1px solid var(--border); background: var(--bg); cursor: pointer; font-size: 0.72rem; color: var(--text); }
   </style>
 </head>
 <body>
@@ -2171,8 +2182,8 @@
           <div class="kb-stat" onclick="acmmShowAllCriteriaDialog()" style="cursor:pointer"><div class="val" id="acmm-criteria-ratio">--</div><div class="lbl">Criteria Passed</div></div>
         </div>
         <div id="acmm-repo-selector" style="display:none;margin-top:8px;font-size:0.75rem;display:flex;align-items:center;gap:6px;flex-wrap:wrap">
-          <span style="color:var(--muted)">Repo:</span>
-          <button onclick="acmmSelectRepo(null)" id="acmm-repo-btn-all" style="padding:2px 8px;border-radius:4px;border:1px solid var(--border);background:var(--bg);cursor:pointer;font-size:0.72rem;color:var(--text);font-weight:600">All (aggregate)</button>
+          <span class="muted">Repo:</span>
+          <button onclick="acmmSelectRepo(null)" id="acmm-repo-btn-all" class="repo-chip-btn" style="font-weight:600">All (aggregate)</button>
         </div>
         <div id="acmm-level-bars" style="margin-top:12px"></div>
         <div id="acmm-eval-meta" style="margin-top:10px;font-size:0.7rem;color:var(--muted);display:flex;justify-content:space-between">
@@ -9413,7 +9424,7 @@ function burnAreaChart() {
         const issueKey = repo + ':' + c.id;
         const existing = _acmmOpenedIssues[issueKey];
         if (existing) {
-          issueBtn = '<span style="margin-left:auto;padding:3px 10px;font-size:0.7rem;border:1px solid var(--green);border-radius:4px;color:var(--muted);white-space:nowrap">✅ <a href="' + escapeHtml(existing.url) + '" target="_blank" style="color:var(--muted);font-size:0.68rem">#' + existing.number + '</a></span>';
+          issueBtn = '<span style="margin-left:auto;padding:3px 10px;font-size:0.7rem;border:1px solid var(--green);border-radius:4px;color:var(--muted);white-space:nowrap">✅ <a href="' + escapeHtml(existing.url) + '" target="_blank" class="muted-xs">#' + existing.number + '</a></span>';
         } else {
           const escapedId = escapeHtml(c.id).replace(/'/g, "\\'");
           const escapedRepo = escapeHtml(repo).replace(/'/g, "\\'");
@@ -9465,7 +9476,7 @@ function burnAreaChart() {
         }
         const data = await r.json();
         _acmmOpenedIssues[repo + ':' + criterionId] = {number: data.issue_number, url: data.issue_url};
-        btn.innerHTML = '✅ <a href="' + escapeHtml(data.issue_url) + '" target="_blank" style="color:var(--muted);font-size:0.68rem">#' + data.issue_number + '</a>';
+        btn.innerHTML = '✅ <a href="' + escapeHtml(data.issue_url) + '" target="_blank" class="muted-xs">#' + data.issue_number + '</a>';
         btn.style.borderColor = 'var(--green)';
       } catch (e) {
         btn.textContent = '⚠ Error';
@@ -9475,7 +9486,7 @@ function burnAreaChart() {
 
     function acmmShowRepoPickerForIssue(criterionId, level) {
       const repos = (_acmmEvalData.repo_results || []).map(r => r.repo);
-      let html = '<p style="font-size:0.82rem;color:var(--muted);margin:0 0 12px">Which repository should this issue be opened on?</p>';
+      let html = '<p class="dialog-note">Which repository should this issue be opened on?</p>';
       for (const repo of repos) {
         const repoData = (_acmmEvalData.repo_results || []).find(r => r.repo === repo);
         const criterion = repoData ? (repoData.criteria_results || []).find(c => c.id === criterionId) : null;
@@ -9484,13 +9495,13 @@ function burnAreaChart() {
         const escapedRepo = escapeHtml(repo).replace(/'/g, "\\'");
         if (already) {
           html += '<div style="padding:8px;margin-bottom:4px;background:var(--bg);border-radius:6px;border:1px solid var(--border);opacity:0.5">' +
-            '<span style="font-size:0.82rem">✅ ' + escapeHtml(repo) + '</span>' +
+            '<span class="text-base">✅ ' + escapeHtml(repo) + '</span>' +
             '<span style="font-size:0.72rem;color:var(--muted);margin-left:8px">(already passing)</span></div>';
         } else {
           html += '<div onclick="acmmCloseDialog();acmmCreateIssueDirectFromPicker(\'' + escapedRepo + '\',\'' + escapedId + '\',' + level + ')" ' +
-            'style="cursor:pointer;padding:8px;margin-bottom:4px;background:var(--bg);border-radius:6px;border:1px solid var(--border);transition:border-color .15s" ' +
+            'class="row-card" ' +
             'onmouseover="this.style.borderColor=\'var(--muted)\'" onmouseout="this.style.borderColor=\'var(--border)\'">' +
-            '<span style="font-size:0.82rem">❌ ' + escapeHtml(repo) + '</span></div>';
+            '<span class="text-base">❌ ' + escapeHtml(repo) + '</span></div>';
         }
       }
       acmmShowDialog('Open Issue — Select Repository', html);
@@ -9505,14 +9516,14 @@ function burnAreaChart() {
         });
         if (!r.ok) {
           const errText = await r.text();
-          acmmShowDialog('Issue Creation Failed', '<p style="color:#da3633;font-size:0.82rem">' + escapeHtml(errText) + '</p>');
+          acmmShowDialog('Issue Creation Failed', '<p class="error-note">' + escapeHtml(errText) + '</p>');
           return;
         }
         const data = await r.json();
         _acmmOpenedIssues[repo + ':' + criterionId] = {number: data.issue_number, url: data.issue_url};
-        acmmShowDialog('Issue Created', '<p style="font-size:0.82rem">Issue <a href="' + escapeHtml(data.issue_url) + '" target="_blank" style="color:var(--blue)">#' + data.issue_number + '</a> created on <strong>' + escapeHtml(repo) + '</strong> with <code>acmm</code> and <code>ai-fix-requested</code> labels.</p>');
+        acmmShowDialog('Issue Created', '<p class="text-base">Issue <a href="' + escapeHtml(data.issue_url) + '" target="_blank" style="color:var(--blue)">#' + data.issue_number + '</a> created on <strong>' + escapeHtml(repo) + '</strong> with <code>acmm</code> and <code>ai-fix-requested</code> labels.</p>');
       } catch (e) {
-        acmmShowDialog('Issue Creation Failed', '<p style="color:#da3633;font-size:0.82rem">Network error: ' + escapeHtml(e.message) + '</p>');
+        acmmShowDialog('Issue Creation Failed', '<p class="error-note">Network error: ' + escapeHtml(e.message) + '</p>');
       }
     }
 
@@ -9528,27 +9539,27 @@ function burnAreaChart() {
       const alreadyOpened = criteria.length - newCriteria.length;
       let html = '';
       if (newCriteria.length === 0) {
-        html += '<p style="font-size:0.82rem;color:var(--muted);margin:0 0 12px">All ' + criteria.length + ' failing criteria already have issues opened.</p>';
-        html += '<div style="display:flex;gap:8px;justify-content:flex-end">' +
-          '<button onclick="acmmCloseDialog()" style="padding:6px 14px;background:var(--bg);border:1px solid var(--border);border-radius:6px;cursor:pointer;color:var(--muted);font-size:0.78rem">Close</button></div>';
+        html += '<p class="dialog-note">All ' + criteria.length + ' failing criteria already have issues opened.</p>';
+        html += '<div class="row-end">' +
+          '<button onclick="acmmCloseDialog()" class="dialog-btn">Close</button></div>';
       } else {
-        html += '<p style="font-size:0.82rem;color:var(--muted);margin:0 0 12px">This will create ' + newCriteria.length + ' issue(s) for failing criteria at L' + level + '.' +
+        html += '<p class="dialog-note">This will create ' + newCriteria.length + ' issue(s) for failing criteria at L' + level + '.' +
           (alreadyOpened > 0 ? ' (' + alreadyOpened + ' already opened, will be skipped)' : '') + '</p>';
         if (hasMultiRepo && !_acmmSelectedRepo) {
-          html += '<p style="font-size:0.82rem;color:var(--muted);margin:0 0 12px">Select a target repo first, or issues will be created for each repo where the criterion fails.</p>';
+          html += '<p class="dialog-note">Select a target repo first, or issues will be created for each repo where the criterion fails.</p>';
         }
         html += '<div style="max-height:200px;overflow-y:auto;margin-bottom:12px">';
         for (const c of criteria) {
           const opened = _acmmOpenedIssues[(targetRepo || '') + ':' + c.id];
           if (opened) {
-            html += '<div style="font-size:0.78rem;padding:2px 0;color:var(--muted)">✅ ' + escapeHtml(c.name) + ' <a href="' + escapeHtml(opened.url) + '" target="_blank" style="color:var(--muted);font-size:0.68rem">#' + opened.number + '</a></div>';
+            html += '<div style="font-size:0.78rem;padding:2px 0;color:var(--muted)">✅ ' + escapeHtml(c.name) + ' <a href="' + escapeHtml(opened.url) + '" target="_blank" class="muted-xs">#' + opened.number + '</a></div>';
           } else {
             html += '<div style="font-size:0.78rem;padding:2px 0">❌ ' + escapeHtml(c.name) + '</div>';
           }
         }
         html += '</div>';
-        html += '<div style="display:flex;gap:8px;justify-content:flex-end">' +
-          '<button onclick="acmmCloseDialog()" style="padding:6px 14px;background:var(--bg);border:1px solid var(--border);border-radius:6px;cursor:pointer;color:var(--muted);font-size:0.78rem">Cancel</button>' +
+        html += '<div class="row-end">' +
+          '<button onclick="acmmCloseDialog()" class="dialog-btn">Cancel</button>' +
           '<button onclick="acmmBatchCreateIssues(' + level + ')" style="padding:6px 14px;background:var(--green);border:none;border-radius:6px;cursor:pointer;color:var(--bg);font-size:0.78rem;font-weight:600">Create ' + newCriteria.length + ' Issue(s)</button></div>';
       }
       acmmShowDialog('Open Issues for L' + level + ' ' + (ACMM_LEVEL_NAMES[level] || ''), html);
@@ -9561,7 +9572,7 @@ function burnAreaChart() {
       const targetRepo = _acmmSelectedRepo || (repos.length === 1 ? repos[0].repo : null);
 
       let created = 0, failed = 0, skipped = 0;
-      acmmShowDialog('Creating Issues...', '<p id="acmm-batch-progress" style="font-size:0.82rem">0/' + criteria.length + ' created...</p>');
+      acmmShowDialog('Creating Issues...', '<p id="acmm-batch-progress" class="text-base">0/' + criteria.length + ' created...</p>');
 
       for (const c of criteria) {
         if (targetRepo) {
@@ -9601,7 +9612,7 @@ function burnAreaChart() {
         const prog = document.getElementById('acmm-batch-progress');
         if (prog) prog.textContent = created + '/' + criteria.length + ' created' + (failed > 0 ? ' (' + failed + ' failed)' : '') + (skipped > 0 ? ' (' + skipped + ' skipped)' : '') + '...';
       }
-      acmmShowDialog('Issues Created', '<p style="font-size:0.82rem">' + created + ' issue(s) created' + (failed > 0 ? ', ' + failed + ' failed' : '') + (skipped > 0 ? ', ' + skipped + ' already existed' : '') + ' with <code>acmm</code> + <code>ai-fix-requested</code> labels.</p>');
+      acmmShowDialog('Issues Created', '<p class="text-base">' + created + ' issue(s) created' + (failed > 0 ? ', ' + failed + ' failed' : '') + (skipped > 0 ? ', ' + skipped + ' already existed' : '') + ' with <code>acmm</code> + <code>ai-fix-requested</code> labels.</p>');
     }
 
     function acmmShowLevelDialog(level, repoName) {
@@ -9646,7 +9657,7 @@ function burnAreaChart() {
         '<div style="display:flex;align-items:center;gap:10px;margin-bottom:8px">' +
         '<span style="font-size:1.5rem;font-weight:700;color:' + statusColor + '">' + pct + '%</span>' +
         '<span style="font-size:0.82rem;color:' + statusColor + ';font-weight:600">' + statusText + '</span>' +
-        '<span style="font-size:0.72rem;color:var(--muted)">(threshold: ' + threshold + '%)</span>' +
+        '<span class="muted-xs">(threshold: ' + threshold + '%)</span>' +
         batchBtn +
         '</div>' +
         '<p style="font-size:0.8rem;color:var(--muted);margin:0 0 8px">' + escapeHtml(desc) + '</p>' +
@@ -9703,7 +9714,7 @@ function burnAreaChart() {
             html += '<div onclick="event.stopPropagation();acmmShowLevelDialog(' + lvl.level + ',\'' + safeRepo + '\')" ' +
               'style="cursor:pointer;padding:5px 6px;margin-bottom:3px;background:var(--bg);border-radius:4px;border:1px solid var(--border);transition:border-color .15s" ' +
               'onmouseover="this.style.borderColor=\'var(--muted)\'" onmouseout="this.style.borderColor=\'var(--border)\'">' +
-              '<div style="display:flex;align-items:center;justify-content:space-between">' +
+              '<div class="row-between">' +
               '<span style="font-size:0.75rem;font-weight:500">' + (lvl.passed ? '✓' : '✗') + ' L' + lvl.level + ' ' + escapeHtml(lvl.name) + '</span>' +
               '<span style="font-size:0.7rem;color:' + color + ';font-weight:600">' + lvl.matched + '/' + lvl.total + '</span></div>' +
               '<div style="margin-top:3px;height:3px;background:var(--border);border-radius:2px;overflow:hidden"><div style="width:' + pct + '%;height:100%;background:' + color + ';border-radius:2px"></div></div></div>';
@@ -9716,8 +9727,8 @@ function burnAreaChart() {
         for (const lvl of levels) {
           const pct = Math.round(lvl.score * 100);
           const color = lvl.passed ? 'var(--green)' : (pct > 40 ? 'var(--yellow)' : '#da3633');
-          html += '<div onclick="acmmShowLevelDialog(' + lvl.level + ')" style="cursor:pointer;padding:8px;margin-bottom:4px;background:var(--bg);border-radius:6px;border:1px solid var(--border);transition:border-color .15s" onmouseover="this.style.borderColor=\'var(--muted)\'" onmouseout="this.style.borderColor=\'var(--border)\'">' +
-            '<div style="display:flex;align-items:center;justify-content:space-between">' +
+          html += '<div onclick="acmmShowLevelDialog(' + lvl.level + ')" class="row-card" onmouseover="this.style.borderColor=\'var(--muted)\'" onmouseout="this.style.borderColor=\'var(--border)\'">' +
+            '<div class="row-between">' +
             '<span style="font-size:0.82rem;font-weight:600">' + (lvl.passed ? '✓' : '✗') + ' L' + lvl.level + ' ' + escapeHtml(lvl.name) + '</span>' +
             '<span style="font-size:0.75rem;color:' + color + ';font-weight:600">' + lvl.matched + '/' + lvl.total + ' (' + pct + '%)</span></div>' +
             '<div style="margin-top:4px;height:4px;background:var(--bg);border-radius:2px;overflow:hidden"><div style="width:' + pct + '%;height:100%;background:' + color + ';border-radius:2px"></div></div></div>';
@@ -9743,7 +9754,7 @@ function burnAreaChart() {
       };
       const desc = opsDescriptions[d.operational_level] || 'Level not recognized.';
       acmmShowDialog('Operational Autonomy — L' + d.operational_level + ' ' + escapeHtml(name),
-        '<p style="font-size:0.82rem;color:var(--muted);margin:0 0 12px">Operational autonomy reflects the hive\'s current pack configuration — how much the system automates without human intervention.</p>' +
+        '<p class="dialog-note">Operational autonomy reflects the hive\'s current pack configuration — how much the system automates without human intervention.</p>' +
         '<div style="padding:12px;background:var(--bg);border-radius:6px;border:1px solid var(--border)">' +
         '<div style="font-size:1.1rem;font-weight:700;margin-bottom:4px">L' + d.operational_level + ' — ' + escapeHtml(name) + '</div>' +
         '<div style="font-size:0.82rem;color:var(--muted)">' + escapeHtml(desc) + '</div></div>' +
@@ -9757,12 +9768,12 @@ function burnAreaChart() {
       const overallName = ACMM_LEVEL_NAMES[d.overall_level] || 'None';
       const lower = d.codebase_level <= d.operational_level ? 'codebase readiness' : 'operational autonomy';
       acmmShowDialog('Overall ACMM Level — L' + d.overall_level + ' ' + escapeHtml(overallName),
-        '<p style="font-size:0.82rem;color:var(--muted);margin:0 0 12px">The overall ACMM level is the <strong>minimum</strong> of codebase readiness and operational autonomy. Both dimensions must align — a high operational level means nothing if the repo lacks foundational tooling, and vice versa.</p>' +
+        '<p class="dialog-note">The overall ACMM level is the <strong>minimum</strong> of codebase readiness and operational autonomy. Both dimensions must align — a high operational level means nothing if the repo lacks foundational tooling, and vice versa.</p>' +
         '<div style="display:flex;gap:12px;margin-bottom:12px">' +
-        '<div style="flex:1;padding:12px;background:var(--bg);border-radius:6px;border:1px solid var(--border);text-align:center;cursor:pointer" onclick="acmmCloseDialog();acmmShowCodebaseDialog()">' +
-        '<div style="font-size:1.2rem;font-weight:700">L' + d.codebase_level + '</div><div style="font-size:0.72rem;color:var(--muted)">Codebase</div></div>' +
-        '<div style="flex:1;padding:12px;background:var(--bg);border-radius:6px;border:1px solid var(--border);text-align:center;cursor:pointer" onclick="acmmCloseDialog();acmmShowOpsDialog()">' +
-        '<div style="font-size:1.2rem;font-weight:700">L' + d.operational_level + '</div><div style="font-size:0.72rem;color:var(--muted)">Operational</div></div>' +
+        '<div class="card-tile" onclick="acmmCloseDialog();acmmShowCodebaseDialog()">' +
+        '<div class="stat-num">L' + d.codebase_level + '</div><div class="muted-xs">Codebase</div></div>' +
+        '<div class="card-tile" onclick="acmmCloseDialog();acmmShowOpsDialog()">' +
+        '<div class="stat-num">L' + d.operational_level + '</div><div class="muted-xs">Operational</div></div>' +
         '</div>' +
         '<div style="padding:10px;background:var(--bg);border-radius:6px;border:1px solid var(--border);font-size:0.8rem">' +
         '→ Overall is <strong>L' + d.overall_level + '</strong> because ' + lower + ' is the limiting factor.</div>'
@@ -9778,7 +9789,7 @@ function burnAreaChart() {
       const totalPassed = results.filter(c => c.passed).length;
       const hasMultiRepo = (d.repo_results || []).length > 1;
 
-      let html = '<p style="font-size:0.82rem;color:var(--muted);margin:0 0 12px">' + totalPassed + ' of ' + results.length + ' criteria detected' + (hasMultiRepo ? ' (aggregate across ' + d.repo_results.length + ' repos)' : '') + '. Click a level row to see details.</p>';
+      let html = '<p class="dialog-note">' + totalPassed + ' of ' + results.length + ' criteria detected' + (hasMultiRepo ? ' (aggregate across ' + d.repo_results.length + ' repos)' : '') + '. Click a level row to see details.</p>';
 
       for (const lvl of levels) {
         const criteria = results.filter(c => c.level === lvl.level);
@@ -9808,14 +9819,14 @@ function burnAreaChart() {
       if (!overlay) {
         overlay = document.createElement('div');
         overlay.id = 'acmm-dialog-overlay';
-        overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:10000;display:flex;align-items:center;justify-content:center';
+        overlay.className = 'acmm-dialog-overlay'; // modal recipe (Phase 2); z-index kept in its own rule
         overlay.addEventListener('click', (e) => { if (e.target === overlay) acmmCloseDialog(); });
         document.body.appendChild(overlay);
       }
       overlay.style.display = 'flex';
       document.body.style.overflow = 'hidden';
-      overlay.innerHTML = '<div style="background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:20px;max-width:600px;width:92%;max-height:80vh;overflow-y:auto;box-shadow:0 20px 60px rgba(0,0,0,0.3)">' +
-        '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">' +
+      overlay.innerHTML = '<div class="acmm-dialog">' +
+        '<div class="row-between" style="margin-bottom:12px">' +
         '<h3 style="margin:0;font-size:1rem;font-weight:700;color:var(--text)">' + title + '</h3>' +
         '<button onclick="acmmCloseDialog()" style="background:none;border:none;cursor:pointer;font-size:1.1rem;color:var(--muted);padding:4px">✕</button></div>' +
         '<div>' + bodyHtml + '</div></div>';
@@ -9838,14 +9849,14 @@ function burnAreaChart() {
 
       const fmtLevel = (lvl) => {
         const name = ACMM_LEVEL_NAMES[lvl] || ('L'+lvl);
-        return '<span style="font-size:1.2rem;font-weight:700">L' + lvl + '</span><br><span style="font-size:0.7rem;color:var(--muted)">' + escapeHtml(name) + '</span>';
+        return '<span class="stat-num">L' + lvl + '</span><br><span style="font-size:0.7rem;color:var(--muted)">' + escapeHtml(name) + '</span>';
       };
 
       setIfChanged(document.getElementById('acmm-codebase-level'), fmtLevel(d.codebase_level));
       setIfChanged(document.getElementById('acmm-ops-level'), fmtLevel(d.operational_level));
       setIfChanged(document.getElementById('acmm-overall-level'), fmtLevel(d.overall_level));
       setIfChanged(document.getElementById('acmm-criteria-ratio'),
-        '<span style="font-size:1.2rem;font-weight:700">' + d.criteria_passed + '/' + d.criteria_total + '</span>');
+        '<span class="stat-num">' + d.criteria_passed + '/' + d.criteria_total + '</span>');
 
       // Repo selector
       const selectorEl = document.getElementById('acmm-repo-selector');
@@ -9859,9 +9870,8 @@ function burnAreaChart() {
           let btn = selectorEl.querySelector('[data-acmm-repo="' + rr.repo + '"]');
           if (!btn) {
             btn = document.createElement('button');
-            btn.className = 'acmm-repo-btn-repo';
+            btn.className = 'acmm-repo-btn-repo repo-chip-btn';
             btn.setAttribute('data-acmm-repo', rr.repo);
-            btn.style.cssText = 'padding:2px 8px;border-radius:4px;border:1px solid var(--border);background:var(--bg);cursor:pointer;font-size:0.72rem;color:var(--text)';
             btn.onclick = () => acmmSelectRepo(rr.repo);
             selectorEl.appendChild(btn);
           }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -69,12 +69,12 @@
     body.light-mode {
       /* Light mode = token remap. Old names (--surface/--border/--fg/…) follow
          automatically via the :root aliases onto --panel/--line/--text. */
-      --bg: #f8f9fa; --bg-soft: #ffffff;
+      --bg: #f7f8fa; --bg-soft: #ffffff;
       --panel: #ffffff; --panel-strong: #eef1f5;
-      --text: #1a1a2e; --muted: #6b7280; --line: #e5e7eb;
+      --text: #111827; --muted: #6b7280; --line: #e5e7eb;
       --amber: #b45309; /* brand amber darkened for readability on white */
       --green: #16a34a; --blue: #2563eb; --red: #dc2626;
-      --yellow: #ca8a04;
+      --yellow: #a16207;
       --indigo: #4f46e5;
       --cyan: #0891b2; --purple: #7c3aed;
       --shadow-modal: 0 20px 60px rgba(0, 0, 0, 0.15);
@@ -475,15 +475,15 @@
     body.oc-strategy-focused #nous-section { display: block; }
     body.oc-agent-focused .agent-card.oc-hidden { display: none; }
 
-    /* Light card overrides */
+    /* Light card overrides — bg/border come from the token remap; only
+       radius/shadow/state differences that can't be tokens live here. */
     body.light-mode .agent-card {
-      background: #ffffff; border: 1px solid var(--line);
       border-radius: 10px; box-shadow: 0 1px 3px rgba(0,0,0,0.06);
       transition: box-shadow 0.2s;
     }
     body.light-mode .agent-card:hover { box-shadow: 0 4px 12px rgba(0,0,0,0.08); }
-    body.light-mode .agent-card.paused { border-color: #ca8a04; opacity: 0.8; }
-    body.light-mode .agent-card.off { border-color: #d1d5db; opacity: 0.7; }
+    body.light-mode .agent-card.paused { border-color: var(--yellow); opacity: 0.8; }
+    body.light-mode .agent-card.off { border-color: var(--line); opacity: 0.7; }
 
     /* Light agents grid — rows for Governor/Overview, columns when agent is focused */
     body.light-mode .agents {
@@ -493,14 +493,12 @@
       grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     }
 
-    /* Light surface panels */
+    /* Light surface panels — bg/border via token remap; radius/shadow only */
     body.light-mode .governor,
     body.light-mode .token-panel {
-      background: #ffffff; border: 1px solid var(--line);
       border-radius: 10px; box-shadow: 0 1px 3px rgba(0,0,0,0.06);
     }
     body.light-mode .repo-card {
-      background: #ffffff; border: 1px solid var(--line);
       border-radius: 8px; box-shadow: 0 1px 2px rgba(0,0,0,0.04);
     }
 
@@ -511,17 +509,13 @@
     body.light-mode .doing { font-family: 'SF Mono', 'Cascadia Code', 'Fira Code', monospace; }
 
     /* Light button overrides */
-    body.light-mode .btn { background: #f9fafb; border-color: #e5e7eb; color: #374151; }
-    body.light-mode .btn:hover { background: #f3f4f6; border-color: #d1d5db; }
-    body.light-mode .terminal-link { border-color: #dc2626; color: #dc2626; }
-    body.light-mode .terminal-link:hover { background: #dc2626; color: #fff; }
-    body.light-mode .restart-btn { border-color: #ca8a04; color: #ca8a04; }
-    body.light-mode .restart-btn:hover { background: #ca8a04; color: #fff; }
+    body.light-mode .terminal-link { border-color: var(--accent); color: var(--accent); }
+    body.light-mode .terminal-link:hover { background: var(--accent); color: var(--bg); }
 
 
     /* Light governor gauge */
-    body.light-mode .temp-gauge-track { border: 1px solid #e5e7eb; }
-    body.light-mode .temp-gauge-needle { background: #1a1a2e; box-shadow: 0 0 6px rgba(26,26,46,0.4); }
+    body.light-mode .temp-gauge-track { border: 1px solid var(--line); }
+    body.light-mode .temp-gauge-needle { background: var(--text); box-shadow: 0 0 6px rgba(17,24,39,0.4); }
 
     /* Light config modal */
     body.light-mode .config-overlay { background: rgba(0,0,0,0.3); }
@@ -673,7 +667,6 @@
     .pause-info { cursor: help; font-size: 0.7rem; margin-left: 4px; opacity: 0.8; position: relative; display: inline-block; }
     .pause-info:hover .pause-tooltip { display: block; }
     .pause-tooltip { display: none; position: absolute; bottom: 120%; left: 50%; transform: translateX(-50%); background: var(--panel-strong); color: var(--text); border: 1px solid var(--line); border-radius: 6px; padding: 6px 10px; font-size: 0.7rem; white-space: nowrap; z-index: 100; box-shadow: 0 2px 8px rgba(0,0,0,0.4); }
-    body.light-mode .pause-tooltip { background: #fff; color: #1a1a2e; border-color: #d0d7de; box-shadow: 0 2px 8px rgba(0,0,0,0.1); }
     .off-badge { display: inline-block; font-size: 0.6rem; background: rgba(72,79,88,0.25); color: var(--muted); border: 1px solid rgba(72,79,88,0.4); border-radius: 3px; padding: 1px 5px; margin-left: 4px; vertical-align: middle; }
     .on-demand-badge { display: inline-block; font-size: 0.6rem; background: rgba(99,102,241,0.15); color: var(--indigo); border: 1px solid rgba(99,102,241,0.3); border-radius: 3px; padding: 1px 5px; margin-left: 4px; vertical-align: middle; }
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -14,6 +14,10 @@
       --bg: #080b0f; --bg-soft: #0d1218;
       --panel: #121922; --panel-strong: #17212d;
       --text: #f6f8fb; --muted: #a8b3c2; --line: #263545;
+      /* Ghost-button / clickable-tile outlines. Same as --line in dark;
+         remapped a step darker in light mode where --line hairlines all
+         but vanish on white. */
+      --line-strong: #263545;
       /* --amber is brand/chrome ONLY — never use it for status. */
       --amber: #f4c75f;
       /* Semantic status colors (agent + governor state) — must stay distinct. */
@@ -86,6 +90,7 @@
       --bg: #f7f8fa; --bg-soft: #ffffff;
       --panel: #ffffff; --panel-strong: #eef1f5;
       --text: #111827; --muted: #6b7280; --line: #e5e7eb;
+      --line-strong: #c6cdd6; /* visible ghost outlines on white */
       --amber: #b45309; /* brand amber darkened for readability on white */
       --green: #16a34a; --blue: #2563eb; --red: #dc2626;
       --yellow: #a16207;
@@ -1652,7 +1657,7 @@
     .hive-dialog-btn, .nous-btn,
     .gh-auth-modal .gh-cancel, .gh-setup-modal .gh-cancel,
     .config-footer .config-cancel, .nous-config-btn-cancel {
-      background: transparent; border-color: var(--line); color: var(--muted);
+      background: transparent; border-color: var(--line-strong); color: var(--muted);
     }
     .btn:hover, .btn-sm:hover, .btn-toggle:hover, .layout-toggle:hover,
     .widget-dl:hover, .kb-layer-btn:hover, .hive-dialog-btn:hover, .nous-btn:hover,
@@ -1857,11 +1862,11 @@
     .dialog-note { font-size: 0.82rem; color: var(--muted); margin: 0 0 12px; }
     .text-base { font-size: var(--fs-base); }
     .stat-num { font-size: 1.2rem; font-weight: 700; }
-    .dialog-btn { padding: 6px 14px; background: var(--bg); border: 1px solid var(--border); border-radius: 6px; cursor: pointer; color: var(--muted); font-size: 0.78rem; }
-    .card-tile { flex: 1; padding: 12px; background: var(--bg); border: 1px solid var(--border); border-radius: 6px; text-align: center; cursor: pointer; }
-    .row-card { cursor: pointer; padding: 8px; margin-bottom: 4px; background: var(--bg); border: 1px solid var(--border); border-radius: 6px; transition: border-color .15s; }
+    .dialog-btn { padding: 6px 14px; background: var(--bg); border: 1px solid var(--line-strong); border-radius: 6px; cursor: pointer; color: var(--muted); font-size: 0.78rem; }
+    .card-tile { flex: 1; padding: 12px; background: var(--bg); border: 1px solid var(--line-strong); border-radius: 6px; text-align: center; cursor: pointer; }
+    .row-card { cursor: pointer; padding: 8px; margin-bottom: 4px; background: var(--bg); border: 1px solid var(--line-strong); border-radius: 6px; transition: border-color .15s; }
     .error-note { color: var(--red); font-size: 0.82rem; }
-    .repo-chip-btn { padding: 2px 8px; border-radius: 4px; border: 1px solid var(--border); background: var(--bg); cursor: pointer; font-size: 0.72rem; color: var(--text); }
+    .repo-chip-btn { padding: 2px 8px; border-radius: 4px; border: 1px solid var(--line-strong); background: var(--bg); cursor: pointer; font-size: 0.72rem; color: var(--text); }
   </style>
 </head>
 <body>
@@ -10342,7 +10347,7 @@ function burnAreaChart() {
           </div>`
         ).join('');
 
-        return `<div style="border:2px solid ${isCurrent ? color : 'var(--border)'};border-radius:10px;padding:16px;${isCurrent ? 'background:var(--surface);box-shadow:0 0 12px ' + color + '40' : ''}">
+        return `<div style="border:2px solid ${isCurrent ? color : 'var(--line-strong)'};border-radius:10px;padding:16px;${isCurrent ? 'background:var(--surface);box-shadow:0 0 12px ' + color + '40' : ''}">
           <div style="display:flex;align-items:center;gap:10px;margin-bottom:8px">
             <span style="font-size:1.5rem;font-weight:800;color:${color};min-width:32px">L${p.level}</span>
             <div style="flex:1">

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -515,9 +515,7 @@
 
 
 
-    /* Light governor gauge */
-    body.light-mode .temp-gauge-track { border: 1px solid var(--line); }
-    body.light-mode .temp-gauge-needle { background: var(--text); box-shadow: 0 0 6px rgba(17,24,39,0.4); }
+    /* Governor gauge is fully tokenized — no light overrides needed. */
 
 
 
@@ -695,10 +693,14 @@
     .backend-select option { background: var(--surface); color: var(--text); }
     .backend-select option:disabled { color: var(--muted); }
 
-    /* Governor */
+    /* Governor — glass panel (hub recipe via tokens); .dead/.starting/
+       .active keep recoloring the perimeter border below. */
     .governor {
-      background: var(--surface); border: 1px solid var(--border);
-      border-radius: 8px; padding: 16px; margin-bottom: 24px;
+      background: linear-gradient(
+        color-mix(in srgb, var(--panel-strong) 92%, transparent),
+        color-mix(in srgb, var(--bg-soft) 92%, transparent));
+      border: 1px solid color-mix(in srgb, var(--text) 10%, transparent);
+      border-radius: var(--radius-lg); padding: 16px; margin-bottom: 24px;
     }
     @media (max-width: 480px) {
       .governor { padding: 10px; }
@@ -709,8 +711,12 @@
     .gov-title { font-size: var(--fs-lg); font-weight: 700; margin-bottom: 8px; }
     .gov-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 8px; }
     .gov-stat { font-size: 0.85rem; }
-    .gov-stat .label { color: var(--muted); font-size: 0.75rem; }
-    .gov-stat .val { font-size: 1.2rem; font-weight: 700; }
+    .gov-stat .label {
+      /* .section-label convention */
+      font-size: var(--fs-xs); font-weight: 800; letter-spacing: 0.12em;
+      text-transform: uppercase; color: var(--amber);
+    }
+    .gov-stat .val { font-size: var(--fs-xl); font-weight: 700; }
     .gov-stat .val.active { color: var(--green); }
     .gov-stat .val.dead { color: var(--red); }
     .gov-stat .val.starting { color: var(--yellow); }
@@ -802,12 +808,15 @@
     .temp-gauge-label { font-size: 0.7rem; color: var(--muted); margin-bottom: 4px; display: flex; justify-content: space-between; }
     .temp-gauge-track {
       position: relative; height: 24px; border-radius: 12px; overflow: visible;
-      background: linear-gradient(to right, var(--green) 0%, var(--green) 7%, var(--blue) 7%, var(--blue) 33%, var(--yellow) 33%, var(--yellow) 67%, var(--red) 67%, var(--red) 100%);
-      border: 1px solid rgba(255,255,255,0.08);
+      /* semantic zone gradient (keep) over a --panel-strong track */
+      background: linear-gradient(to right, var(--green) 0%, var(--green) 7%, var(--blue) 7%, var(--blue) 33%, var(--yellow) 33%, var(--yellow) 67%, var(--red) 67%, var(--red) 100%) var(--panel-strong);
+      border: 1px solid var(--line);
     }
     .temp-gauge-glow {
       position: absolute; top: 0; left: 0; height: 100%; border-radius: 12px;
-      background: linear-gradient(to right, rgba(35,134,54,0.25), rgba(248,81,73,0.25));
+      background: linear-gradient(to right,
+        color-mix(in srgb, var(--green) 25%, transparent),
+        color-mix(in srgb, var(--red) 25%, transparent));
       filter: blur(6px); pointer-events: none;
     }
     .temp-gauge-ticks {
@@ -817,15 +826,16 @@
     .temp-gauge-ticks span { position: absolute; top: 50%; text-shadow: 0 1px 3px rgba(0,0,0,0.6); }
     .temp-gauge-needle {
       position: absolute; top: -4px; width: 4px; height: 32px;
-      background: #fff; border-radius: 2px;
-      box-shadow: 0 0 8px rgba(255,255,255,0.8), 0 0 16px rgba(255,255,255,0.4);
+      background: var(--text); border-radius: 2px;
+      box-shadow: 0 0 8px color-mix(in srgb, var(--text) 80%, transparent),
+                  0 0 16px color-mix(in srgb, var(--text) 40%, transparent);
       transition: left 0.6s cubic-bezier(0.4, 0, 0.2, 1);
       z-index: 2;
     }
     .temp-gauge-needle::after {
       content: attr(data-val); position: absolute; bottom: -16px; left: 50%;
-      transform: translateX(-50%); font-size: 0.75rem; font-weight: 700; color: #fff;
-      text-shadow: 0 1px 4px rgba(0,0,0,0.8);
+      transform: translateX(-50%); font-size: 0.75rem; font-weight: 700;
+      color: var(--text); text-shadow: 0 1px 4px var(--bg);
     }
     .temp-gauge-labels {
       position: relative; margin-top: 4px; height: 1em;
@@ -849,11 +859,11 @@
     .gov-matrix th.mode-quiet { color: var(--blue); }
     .gov-matrix th.mode-busy  { color: var(--yellow); }
     .gov-matrix th.mode-surge { color: var(--red); }
-    .gov-matrix th.mode-active.mode-idle  { background: rgba(35,134,54,0.15); }
-    .gov-matrix th.mode-active.mode-quiet { background: rgba(31,111,235,0.15); }
-    .gov-matrix th.mode-active.mode-busy  { background: rgba(210,153,34,0.15); }
-    .gov-matrix th.mode-active.mode-surge { background: rgba(248,81,73,0.15); }
-    .gov-matrix td { padding: 3px 8px; text-align: center; color: var(--muted); border-bottom: 1px solid rgba(48,54,61,0.5); }
+    .gov-matrix th.mode-active.mode-idle  { background: color-mix(in srgb, var(--green) 15%, transparent); }
+    .gov-matrix th.mode-active.mode-quiet { background: color-mix(in srgb, var(--blue) 15%, transparent); }
+    .gov-matrix th.mode-active.mode-busy  { background: color-mix(in srgb, var(--yellow) 15%, transparent); }
+    .gov-matrix th.mode-active.mode-surge { background: color-mix(in srgb, var(--red) 15%, transparent); }
+    .gov-matrix td { padding: 3px 8px; text-align: center; color: var(--muted); border-bottom: 1px solid color-mix(in srgb, var(--line) 60%, transparent); }
     .gov-matrix td:first-child { text-align: left; color: var(--text); font-weight: 600; min-width: 72px; }
     @media (max-width: 480px) {
       .gov-matrix { font-size: 0.65rem; }
@@ -863,10 +873,10 @@
       .gov-matrix td:first-child { min-width: 56px; }
     }
     .gov-matrix td.col-active { font-weight: 700; color: var(--text); }
-    .gov-matrix td.col-active.mode-idle  { background: rgba(35,134,54,0.08); color: var(--green); }
-    .gov-matrix td.col-active.mode-quiet { background: rgba(31,111,235,0.08); color: var(--blue); }
-    .gov-matrix td.col-active.mode-busy  { background: rgba(210,153,34,0.08); color: var(--yellow); }
-    .gov-matrix td.col-active.mode-surge { background: rgba(248,81,73,0.08); color: var(--red); }
+    .gov-matrix td.col-active.mode-idle  { background: color-mix(in srgb, var(--green) 8%, transparent); color: var(--green); }
+    .gov-matrix td.col-active.mode-quiet { background: color-mix(in srgb, var(--blue) 8%, transparent); color: var(--blue); }
+    .gov-matrix td.col-active.mode-busy  { background: color-mix(in srgb, var(--yellow) 8%, transparent); color: var(--yellow); }
+    .gov-matrix td.col-active.mode-surge { background: color-mix(in srgb, var(--red) 8%, transparent); color: var(--red); }
     .gov-matrix td.paused { color: color-mix(in srgb, var(--muted) 60%, var(--bg)); font-style: italic; }
     .gov-matrix td.on-demand { color: var(--indigo); font-style: italic; }
     .gov-matrix td.off { color: color-mix(in srgb, var(--muted) 60%, var(--bg)); font-style: italic; }
@@ -922,10 +932,13 @@
     .ind-row { display: flex; flex-wrap: wrap; gap: 12px; }
     .ind-summary { font-size: 0.7rem; color: var(--text); margin-bottom: 4px; line-height: 1.4; opacity: 0.85; }
 
-    /* Token usage panel */
+    /* Token usage panel — glass panel (hub recipe via tokens) */
     .token-panel {
-      background: var(--surface); border: 1px solid var(--border);
-      border-radius: 8px; padding: 16px;
+      background: linear-gradient(
+        color-mix(in srgb, var(--panel-strong) 92%, transparent),
+        color-mix(in srgb, var(--bg-soft) 92%, transparent));
+      border: 1px solid color-mix(in srgb, var(--text) 10%, transparent);
+      border-radius: var(--radius-lg); padding: 16px;
     }
     .token-title { font-size: var(--fs-lg); font-weight: 700; margin-bottom: 10px; display: flex; align-items: center; gap: 8px; }
     .token-title .lookback { font-size: 0.7rem; color: var(--muted); font-weight: 400; }
@@ -967,7 +980,7 @@
     .advisor-bars { display: flex; flex-direction: column; gap: 4px; margin-bottom: 8px; }
     .advisor-bar-row { display: flex; align-items: center; gap: 8px; font-size: 0.72rem; }
     .advisor-agent { min-width: 70px; color: var(--text); font-weight: 600; }
-    .advisor-bar-track { flex: 1; height: 10px; background: var(--bg); border-radius: 4px; overflow: hidden; }
+    .advisor-bar-track { flex: 1; height: 10px; background: var(--panel-strong); border-radius: 4px; overflow: hidden; }
     .advisor-bar-fill { height: 100%; border-radius: 4px; transition: width 0.5s ease; }
     .advisor-pct { min-width: 30px; text-align: right; color: var(--muted); }
     .advisor-burn { min-width: 80px; text-align: right; color: var(--muted); font-size: 0.65rem; }
@@ -978,7 +991,7 @@
     /* Budget bar */
     .budget-bar { margin: 8px 0; }
     .budget-bar-label { font-size: 0.72rem; color: var(--muted); margin-bottom: 3px; display: flex; justify-content: space-between; }
-    .budget-bar-track { height: 8px; background: var(--bg); border-radius: 4px; overflow: hidden; }
+    .budget-bar-track { height: 8px; background: var(--panel-strong); border-radius: 4px; overflow: hidden; }
     .budget-bar-fill { height: 100%; border-radius: 4px; transition: width 0.5s ease; }
     .budget-bar-fill.safe { background: var(--green); }
     .budget-bar-fill.warning { background: var(--yellow); }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1202,12 +1202,14 @@
 
     .config-info {
       display: inline-flex; align-items: center; justify-content: center;
-      width: 14px; height: 14px; border-radius: 50%;
-      background: var(--border); color: var(--muted); font-size: 0.55rem;
+      width: 15px; height: 15px; border-radius: 50%;
+      background: color-mix(in srgb, var(--blue) 12%, transparent);
+      border: 1px solid color-mix(in srgb, var(--blue) 45%, transparent);
+      color: var(--blue); font-size: 0.6rem; line-height: 1;
       font-weight: 700; cursor: help; margin-left: 4px; position: relative;
       vertical-align: middle; flex-shrink: 0;
     }
-    .config-info:hover { background: var(--blue); color: var(--bg); }
+    .config-info:hover { background: var(--blue); border-color: var(--blue); color: var(--bg); }
     .config-info .config-tooltip {
       display: none; position: fixed; background: var(--bg); border: 1px solid var(--border);
       border-radius: 6px; padding: 6px 10px;
@@ -11010,7 +11012,7 @@ function burnAreaChart() {
             <input type="text" id="cfg-agent-emoji" value="${esc(g.emoji || '')}" placeholder="🤖" onchange="markDirty('general','emoji',this.value)">
           </div>
           <div class="config-field">
-            <label>Color <span class="config-info">i<span class="config-tooltip">Agent color used in the dashboard for visual distinction.</span></span></label>
+            <label>Color <span class="config-info">i<span class="config-tooltip">The agent's identity color, used to represent it in token charts and sparklines. Does not affect card or status styling.</span></span></label>
             <input type="color" id="cfg-agent-color" value="${esc(g.color || '#3498db')}" style="height:34px" onchange="markDirty('general','color',this.value)">
           </div>
         </div>

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -549,6 +549,26 @@
       .oc-topbar { left: 0; }
       body { padding-left: 16px; }
     }
+    @media (max-width: 600px) {
+      /* The fixed 48px topbar can't hold its content at phone widths —
+         wrapped buttons were painting over the page. Let it wrap and
+         grow, and drop low-value chrome. flex-shrink:0 makes the three
+         groups wrap to a new row instead of squishing their contents off
+         the right edge. Top clearance lives in the mobile body-padding
+         rule further down (it wins the cascade over this block). */
+      .oc-topbar { flex-wrap: wrap; height: auto; min-height: 48px; padding: 6px 12px; row-gap: 4px; }
+      .oc-topbar-left, .oc-topbar-center, .oc-topbar-right { flex-shrink: 0; }
+      /* center grows to fill row 1, so the health/right group always
+         drops to its own row instead of half-fitting at the edge */
+      .oc-topbar-center { flex-grow: 1; justify-content: center; }
+      .oc-topbar-ts, #oc-git-version, .widget-dl { display: none; }
+      /* keep the pill one line so the right group wraps as a unit
+         instead of being clipped at the viewport edge */
+      .oc-health-badge { white-space: nowrap; }
+      /* the nowrap Install button was pushing the app banner past the
+         viewport — let the banner's items wrap instead */
+      .gh-app-install-banner { flex-wrap: wrap; }
+    }
 
     /* Agent cards */
     .agents { display: grid; grid-template-columns: 1fr; gap: 12px; margin-bottom: 24px; }
@@ -1099,9 +1119,12 @@
     @keyframes toast-in { from { opacity: 0; transform: translateX(40px); } to { opacity: 1; transform: translateX(0); } }
     @keyframes toast-out { from { opacity: 1; } to { opacity: 0; transform: translateY(-10px); } }
 
-    /* Mobile: prevent title and sessions from overflowing viewport */
+    /* Mobile: prevent title and sessions from overflowing viewport.
+       Top padding must clear the fixed topbar, which wraps to ~2 rows
+       at phone widths (see the topbar mobile block earlier) — a plain
+       10px here put the first ~75px of content underneath it. */
     @media (max-width: 600px) {
-      body { padding: 10px; }
+      body { padding: 104px 10px 10px; }
       h1 { flex-wrap: wrap; font-size: 1rem; gap: 4px; }
       .timestamp { margin-left: 0; }
       .git-version { margin-left: 0; width: 100%; }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1150,7 +1150,7 @@
     .hive-dialog-buttons { display: flex; gap: 10px; justify-content: flex-end; }
     /* .hive-dialog-btn(.primary/.cancel) — primary/ghost buttons (system recipe) */
     .config-modal {
-      width: 900px; max-width: 95vw;
+      width: 1200px; max-width: 96vw;
       height: 85vh; display: flex; flex-direction: column;
     } /* modal panel recipe */
     .config-header {
@@ -1164,8 +1164,9 @@
     }
     .config-close:hover { color: var(--text); background: var(--border); }
     .config-tabs {
-      display: flex; gap: 0; border-bottom: 1px solid var(--border);
-      overflow-x: auto; padding: 0 20px; flex-shrink: 0;
+      display: flex; flex-wrap: wrap; gap: 0;
+      border-bottom: 1px solid var(--border);
+      padding: 0 20px; flex-shrink: 0;
     }
     .config-tab {
       padding: 10px 10px; font-size: 0.75rem; color: var(--muted);
@@ -1173,6 +1174,11 @@
       white-space: nowrap; transition: color 0.2s, border-color 0.2s;
     }
     .config-tab:hover { color: var(--text); }
+    .config-color-input {
+      width: 44px; height: 26px; padding: 2px;
+      border: 1px solid var(--border); border-radius: 6px;
+      background: var(--bg-soft); cursor: pointer;
+    }
     .config-tab.active { color: var(--amber); border-bottom-color: var(--amber); }
     .config-body {
       flex: 1; overflow-y: auto; padding: 20px;
@@ -11101,7 +11107,7 @@ function burnAreaChart() {
           </div>
           <div class="config-field">
             <label>Color <span class="config-info">i<span class="config-tooltip">The agent's identity color, used to represent it in token charts and sparklines. Does not affect card or status styling.</span></span></label>
-            <input type="color" id="cfg-agent-color" value="${esc(g.color || '#3498db')}" style="height:34px" onchange="markDirty('general','color',this.value)">
+            <input type="color" id="cfg-agent-color" class="config-color-input" value="${esc(g.color || '#3498db')}" onchange="markDirty('general','color',this.value)">
             <div style="font-size:0.65rem;color:var(--muted);margin-top:2px">Identity color for this agent's token charts and sparklines.</div>
           </div>
         </div>

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1465,7 +1465,6 @@
     .kb-layer-count { font-size: 0.7rem; color: var(--muted); padding: 2px 6px; background: var(--bg); border-radius: 4px; flex-shrink: 0; }
     /* Knowledge Sources type pills — pill recipe; each source type gets its own tint */
     .kb-src-type { font-weight: 600; text-transform: uppercase; flex-shrink: 0; margin-left: auto; }
-    .kb-src-type.wiki { --pill-c: var(--blue); }
     .kb-src-type.vault { --pill-c: var(--purple); }
     .kb-src-type.doc { --pill-c: var(--cyan); }
     .kb-search-box { width: 100%; } /* shared input recipe (end of style block) */
@@ -6413,33 +6412,38 @@ function burnAreaChart() {
       html += '<div class="kb-layout">';
 
       // Left sidebar: one consolidated Knowledge Sources list + search + filters.
-      // Every source (wiki layer, vault, imported document) is ONE row here:
-      // health dot (tooltip = health detail) + name + type pill + count pill.
+      // Every source is ONE row here: health dot (tooltip = health detail) +
+      // name + type pill (vault / doc) + count pill. The backend already
+      // reports each connected vault as a layer (knowledge.Stats appends
+      // vaults to the layers list), so the separate vaults array is only
+      // rendered for entries NOT already present as a layer.
       html += '<div class="kb-sidebar">';
       html += '<div class="section-label" style="margin:0">Knowledge Sources</div>';
       html += '<div class="kb-layer-list" id="kb-layer-btns">';
       // Aggregate row stays on top as the filter reset (kbSelectLayer keys on the 'All Layers' text)
       html += `<button class="kb-layer-btn${_kbSelectedLayer === 'all' ? ' active' : ''}" onclick="kbSelectLayer('all')"><span class="kb-layer-label">📋 All Layers</span><span class="kb-layer-count">${totalPages}</span></button>`;
       for (const l of layers) {
-        const icon = KB_LAYER_ICONS[l.type] || '📄';
+        const isGitSource = l.type && l.type.startsWith('git_source:');
+        const icon = KB_LAYER_ICONS[l.type] || (isGitSource ? '📄' : '📂');
         const label = KB_LAYER_LABELS[l.type] || l.type;
         const active = _kbSelectedLayer === l.type ? ' active' : '';
         const count = l.total_pages || 0;
         const dotColor = l.healthy ? 'var(--green)' : 'var(--red)';
         const healthTip = `${escapeHtml(label)}: ${l.healthy ? 'healthy' : 'unreachable'}`;
-        const isGitSource = l.type && l.type.startsWith('git_source:');
         const repoUrl = isGitSource && l.url ? (l.subpath ? l.url + '/tree/' + 'main/' + l.subpath : l.url) : '';
         html += `<button class="kb-layer-btn${active}" onclick="kbSelectLayer('${escapeHtml(l.type)}')" title="${healthTip}">`;
         html += `<span class="kb-layer-label"><span class="kb-health-dot" style="background:${dotColor}" title="${healthTip}"></span>${icon} ${escapeHtml(label)}</span>`;
         if (isGitSource && repoUrl) {
           html += `<a href="${escapeHtml(repoUrl)}" target="_blank" rel="noopener" onclick="event.stopPropagation()" style="color:var(--accent);text-decoration:none;font-size:0.82rem;flex-shrink:0" title="Open source repo in new tab">↗</a>`;
         }
-        html += `<span class="kb-src-type wiki">wiki</span>`;
+        html += `<span class="kb-src-type vault">vault</span>`;
         html += `<span class="kb-layer-count">${count}</span>`;
         html += `</button>`;
       }
-      // Vault rows — same list, type pill 'vault'; click behavior unchanged
-      for (const v of connectedVaults) {
+      // Vaults not already mirrored into the layers list (dedupe by name);
+      // same row shape, click behavior unchanged
+      const layerTypes = new Set(layers.map(l => l.type));
+      for (const v of connectedVaults.filter(v => !layerTypes.has(v.name))) {
         const vTip = `${escapeHtml(v.name)}: connected — ${escapeHtml(v.root_dir)}`;
         html += `<button class="kb-layer-btn${_kbSelectedLayer === 'vault:'+v.name ? ' active' : ''}" onclick="_kbSelectedLayer='vault:${escapeHtml(v.name)}';kbSearchVault('${escapeHtml(v.name)}')" title="${vTip}">`;
         html += `<span class="kb-layer-label"><span class="kb-health-dot" style="background:var(--green)" title="${vTip}"></span>📂 ${escapeHtml(v.name)}</span>`;

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -486,15 +486,13 @@
     body.oc-strategy-focused #nous-section { display: block; }
     body.oc-agent-focused .agent-card.oc-hidden { display: none; }
 
-    /* Light card overrides — bg/border come from the token remap; only
-       radius/shadow/state differences that can't be tokens live here. */
+    /* Light card overrides — surface/border/state come from the token
+       remap; only the light-specific shadow lives here. */
     body.light-mode .agent-card {
-      border-radius: 10px; box-shadow: 0 1px 3px rgba(0,0,0,0.06);
-      transition: box-shadow 0.2s;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+      transition: box-shadow 0.2s, border-color 0.3s;
     }
     body.light-mode .agent-card:hover { box-shadow: 0 4px 12px rgba(0,0,0,0.08); }
-    body.light-mode .agent-card.paused { border-color: var(--yellow); opacity: 0.8; }
-    body.light-mode .agent-card.off { border-color: var(--line); opacity: 0.7; }
 
     /* Light agents grid — rows for Governor/Overview, columns when agent is focused */
     body.light-mode .agents {
@@ -533,15 +531,24 @@
 
     /* Agent cards */
     .agents { display: grid; grid-template-columns: 1fr; gap: 12px; margin-bottom: 24px; }
+    /* Glass panel (hub recipe expressed in tokens so the light-mode remap
+       just works); status is conveyed by the 3px left border + the
+       existing status pills. JS toggles .working/.stopped/.paused/.off/
+       .status-blocked — class names must not change. */
     .agent-card {
-      background: var(--surface); border: 1px solid var(--border);
-      border-radius: 8px; padding: 16px; transition: border-color 0.3s;
+      background: linear-gradient(
+        color-mix(in srgb, var(--panel-strong) 92%, transparent),
+        color-mix(in srgb, var(--bg-soft) 92%, transparent));
+      border: 1px solid color-mix(in srgb, var(--text) 10%, transparent);
+      border-left: 3px solid var(--line);
+      border-radius: var(--radius-lg); padding: 16px;
+      transition: border-color 0.3s;
       position: relative;
     }
-    .agent-card.working { border-color: var(--green); }
-    .agent-card.idle { border-color: var(--border); }
-    .agent-card.stopped { border-color: var(--red); }
-    .agent-card.needs-login { border-color: var(--red); }
+    .agent-card.working { border-left-color: var(--green); }
+    .agent-card.idle { border-left-color: var(--line); }
+    .agent-card.stopped { border-left-color: var(--red); }
+    .agent-card.needs-login { border-left-color: var(--red); }
     .cli-login-btn { border: none; padding: 2px 10px; border-radius: 4px; cursor: pointer; font-weight: 600; font-size: 0.75rem; display: inline-flex; align-items: center; gap: 4px; }
     .cli-login-btn.claude { background: #d97706; color: #fff; }
     .cli-login-btn.claude:hover { background: #f59e0b; }
@@ -609,9 +616,12 @@
     .status-badge.needs-context { --pill-c: var(--yellow); }
     .status-badge.done-concerns { --pill-c: #e38b2c; } /* distinct orange — no token yet */
     .status-badge.done { --pill-c: var(--green); }
-    .agent-card.status-blocked { border-color: var(--red) !important; }
-    .agent-card.status-needs-context { border-color: var(--yellow) !important; }
-    @keyframes pulse-amber { 0%,100% { border-color: rgba(210,153,34,0.3); } 50% { border-color: rgba(210,153,34,0.8); } }
+    .agent-card.status-blocked { border-left-color: var(--red) !important; }
+    .agent-card.status-needs-context { border-left-color: var(--yellow) !important; }
+    @keyframes pulse-amber {
+      0%,100% { border-left-color: color-mix(in srgb, var(--yellow) 30%, transparent); }
+      50% { border-left-color: color-mix(in srgb, var(--yellow) 80%, transparent); }
+    }
     .agent-card.status-stale { animation: pulse-amber 2s ease-in-out infinite; }
     .agent-name { font-size: 1.1rem; font-weight: 700; margin-bottom: 8px; }
     .agent-name .dot {
@@ -647,11 +657,11 @@
     /* .kick-prompt — shared input recipe (end of style block) */
     .kick-prompt { flex: 1 1 100%; min-width: 0; }
     /* .btn-toggle — ghost button with status states (system recipe at end of style block) */
-    .agent-card.paused { border-color: var(--red); opacity: 0.7; }
+    .agent-card.paused { border-left-color: var(--red); opacity: 0.7; }
     .agent-card.paused .agent-state { color: var(--red); }
-    .agent-card.on-demand { border-color: var(--indigo); opacity: 0.85; }
+    .agent-card.on-demand { border-left-color: var(--indigo); opacity: 0.85; }
     .agent-card.on-demand .agent-state { color: var(--indigo); }
-    .agent-card.off { border-color: color-mix(in srgb, var(--muted) 60%, var(--bg)); opacity: 0.6; }
+    .agent-card.off { border-left-color: color-mix(in srgb, var(--muted) 60%, var(--bg)); opacity: 0.6; }
     .agent-card.off .agent-state { color: color-mix(in srgb, var(--muted) 60%, var(--bg)); }
     .pause-badge { --pill-c: var(--red); margin-left: 4px; vertical-align: middle; } /* pill recipe */
     .pause-info { cursor: help; font-size: 0.7rem; margin-left: 4px; opacity: 0.8; position: relative; display: inline-block; }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -103,10 +103,10 @@
     }
     body.light-mode .connection { display: none; }
 
-    /* Light sidebar */
+    /* Sidebar — --bg-soft surface (hub identity), amber chrome accents */
     .oc-sidebar {
       position: fixed; top: 0; left: 0; bottom: 0; width: var(--sidebar-w);
-      background: var(--surface); border-right: 1px solid var(--border);
+      background: var(--bg-soft); border-right: 1px solid var(--line);
       display: flex; flex-direction: column; padding: 0;
       z-index: 100; overflow-y: auto;
     }
@@ -116,7 +116,7 @@
       cursor: col-resize; z-index: 101;
     }
     .oc-sidebar-resize:hover, .oc-sidebar-resize.dragging {
-      background: rgba(220,38,38,0.25);
+      background: color-mix(in srgb, var(--amber) 30%, transparent);
     }
     .oc-sidebar-logo {
       display: flex; align-items: center; gap: 10px;
@@ -161,8 +161,15 @@
     .oc-nav-actions button:hover { background: var(--border); color: var(--text); }
     .oc-nav-actions .oc-nav-delete:hover { background: var(--oc-accent-light); color: var(--oc-accent); }
     .mode-badge { font-size: 0.7rem; margin-left: 2px; opacity: 0.8; }
+    /* Active nav — amber accent bar (brand chrome), both modes.
+       --oc-accent stays red for non-nav uses (delete affordances). */
     .oc-nav-item.active {
-      background: var(--oc-accent-light); color: var(--oc-accent); font-weight: 600;
+      background: color-mix(in srgb, var(--amber) 12%, transparent);
+      color: var(--text); font-weight: 600;
+    }
+    .oc-nav-item.active::before {
+      content: ''; position: absolute; left: 0; top: 4px; bottom: 4px;
+      width: 3px; border-radius: 0 2px 2px 0; background: var(--amber);
     }
     .oc-sidebar-footer {
       padding: 16px 20px; border-top: 1px solid var(--border);
@@ -226,10 +233,14 @@
       transition: width 0.5s ease, background 0.5s ease;
     }
 
-    /* Light top bar */
+    /* Topbar — sticky blurred header (hub .site-header recipe). Fixed
+       positioning kept (functionally sticky: content scrolls under it)
+       because the sidebar offset layout depends on it. */
     .oc-topbar {
       position: fixed; top: 0; left: var(--sidebar-w); right: 0; height: 48px;
-      background: var(--surface); border-bottom: 1px solid var(--border);
+      background: color-mix(in srgb, var(--bg) 85%, transparent);
+      -webkit-backdrop-filter: blur(18px); backdrop-filter: blur(18px);
+      border-bottom: 1px solid var(--line);
       display: flex; align-items: center; justify-content: space-between;
       padding: 0 20px; z-index: 99;
     }
@@ -327,10 +338,11 @@
 
     /* Sidebar agent tree */
     .oc-tree-toggle {
+      /* .section-label convention */
       display: flex; align-items: center; gap: 8px;
-      padding: 10px 20px 6px; font-size: 0.65rem; color: var(--muted);
+      padding: 10px 20px 6px; font-size: var(--fs-xs); color: var(--amber);
       cursor: pointer; user-select: none;
-      text-transform: uppercase; letter-spacing: 0.8px; font-weight: 600;
+      text-transform: uppercase; letter-spacing: 0.12em; font-weight: 800;
     }
     .oc-tree-toggle:hover { color: var(--text); }
     .oc-tree-arrow { font-size: 0.55rem; transition: transform 0.15s; }
@@ -353,9 +365,10 @@
     .oc-nav-item.dragging { opacity: 0.4; }
     .oc-sidebar-group { position: relative; }
     .oc-sidebar-group-header {
+      /* .section-label convention */
       display: flex; align-items: center; gap: 6px;
-      padding: 8px 14px 4px; font-size: 0.65rem; color: var(--muted);
-      text-transform: uppercase; letter-spacing: 0.8px; font-weight: 600;
+      padding: 8px 14px 4px; font-size: var(--fs-xs); color: var(--amber);
+      text-transform: uppercase; letter-spacing: 0.12em; font-weight: 800;
       cursor: pointer; user-select: none;
     }
     .oc-sidebar-group-header { cursor: grab; }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -19,6 +19,7 @@
       /* Semantic status colors (agent + governor state) — must stay distinct. */
       --green: #74df9a; --blue: #80bfff; --red: #ff7e7e;
       --yellow: #d29922; /* status warning — warm ochre, distinguishable from brand amber */
+      --orange: #e38b2c; /* status alert — between warning yellow and critical red */
       --indigo: #818cf8; /* on-demand agent state */
       --cyan: #7bd8cd; --purple: #c0a6f0; /* desaturated toward the hub palette */
       /* Radii / shadows / fonts — defined in Phase 0, applied in later phases. */
@@ -56,7 +57,6 @@
     /* ── Deliberate monospace: data surfaces only. UI chrome uses --font-ui. ── */
     code, pre { font-family: var(--font-mono); }
     .mono { font-family: var(--font-mono); }
-    #audit-panel { font-family: var(--font-mono); }
     /* Section eyebrow label — hub convention (amber, uppercase, tracked). */
     .section-label {
       font-family: var(--font-ui); font-size: var(--fs-xs); font-weight: 800;
@@ -89,6 +89,7 @@
       --amber: #b45309; /* brand amber darkened for readability on white */
       --green: #16a34a; --blue: #2563eb; --red: #dc2626;
       --yellow: #a16207;
+      --orange: #c2570f; /* status alert darkened for readability on white */
       --indigo: #4f46e5;
       --cyan: #0891b2; --purple: #7c3aed;
       --shadow-modal: 0 20px 60px rgba(0, 0, 0, 0.15);
@@ -279,9 +280,13 @@
     body.light-mode .agents { grid-template-columns: 1fr; }
 
     /* Light agent detail panel (shown when agent selected in sidebar) */
-    .oc-agent-detail {
-      display: none; background: var(--surface); border: 2px solid var(--border);
-      border-radius: 10px; padding: 20px; margin-bottom: 16px;
+    .oc-agent-detail { /* glass panel — same recipe as .agent-card */
+      display: none;
+      background: linear-gradient(
+        color-mix(in srgb, var(--panel-strong) 92%, transparent),
+        color-mix(in srgb, var(--bg-soft) 92%, transparent));
+      border: 2px solid color-mix(in srgb, var(--text) 10%, transparent);
+      border-radius: var(--radius-lg); padding: 20px; margin-bottom: 16px;
       box-shadow: 0 1px 3px rgba(0,0,0,0.06);
     }
     .oc-agent-detail.active { display: block; }
@@ -393,12 +398,12 @@
     .oc-sidebar-group-children { padding-left: 0; min-height: 28px; }
     .oc-sidebar-group-children.collapsed { display: none; min-height: 0; }
     .oc-sidebar-group.drag-over > .oc-sidebar-group-children {
-      outline: 2px dashed var(--red); outline-offset: -2px;
-      border-radius: 6px; background: rgba(220,38,38,0.05);
+      outline: 2px dashed var(--amber); outline-offset: -2px;
+      border-radius: 6px; background: color-mix(in srgb, var(--amber) 6%, transparent);
     }
     .oc-sidebar-group.dragging-group { opacity: 0.4; }
     .oc-group-drop-indicator {
-      height: 2px; background: var(--red); border-radius: 1px; margin: 2px 0;
+      height: 2px; background: var(--amber); border-radius: 1px; margin: 2px 0;
     }
     .oc-sidebar-group-header .oc-group-actions {
       margin-left: auto; display: none; gap: 4px;
@@ -410,11 +415,11 @@
     }
     .oc-sidebar-group-header .oc-group-actions button:hover { color: var(--text); }
     .oc-drop-indicator {
-      height: 2px; background: var(--red); margin: 0 10px;
+      height: 2px; background: var(--amber); margin: 0 10px;
       border-radius: 1px; pointer-events: none;
     }
     .oc-drop-indicator-group {
-      border: 2px dashed var(--red); border-radius: 8px;
+      border: 2px dashed var(--amber); border-radius: 8px;
       margin: 2px 10px; padding: 4px; opacity: 0.5;
     }
 
@@ -625,7 +630,7 @@
     .status-badge { font-weight: 700; margin-left: 6px; text-transform: uppercase; letter-spacing: 0.5px; }
     .status-badge.blocked { --pill-c: var(--red); }
     .status-badge.needs-context { --pill-c: var(--yellow); }
-    .status-badge.done-concerns { --pill-c: #e38b2c; } /* distinct orange — no token yet */
+    .status-badge.done-concerns { --pill-c: var(--orange); }
     .status-badge.done { --pill-c: var(--green); }
     .agent-card.status-blocked { border-left-color: var(--red) !important; }
     .agent-card.status-needs-context { border-left-color: var(--yellow) !important; }
@@ -2190,7 +2195,7 @@
           <span id="acmm-eval-source"></span>
           <span id="acmm-eval-timestamp"></span>
         </div>
-        <div id="acmm-eval-warning" style="display:none;margin-top:8px;padding:6px 10px;border-radius:6px;background:#fef3c7;color:#92400e;font-size:0.75rem"></div>
+        <div id="acmm-eval-warning" style="display:none;margin-top:8px;padding:6px 10px;border-radius:6px;background:color-mix(in srgb, var(--yellow) 15%, transparent);border:1px solid color-mix(in srgb, var(--yellow) 40%, transparent);color:var(--text);font-size:0.75rem"></div>
       </div>
     </div>
   </div>
@@ -2820,7 +2825,7 @@
         </div>
         <div class="oc-detail-indicators">${agentIndicators(a.name)}</div>
         <div class="oc-detail-summary-wrap">
-          <div class="oc-detail-summary" id="oc-summary-scroll">${(a.detailSummary || a.liveSummary) ? escBlock(a.detailSummary || a.liveSummary) : '<span style="color:#9ca3af">No activity summary</span>'}</div>
+          <div class="oc-detail-summary" id="oc-summary-scroll">${(a.detailSummary || a.liveSummary) ? escBlock(a.detailSummary || a.liveSummary) : '<span style="color:var(--muted)">No activity summary</span>'}</div>
           <button class="oc-summary-follow-btn" id="oc-summary-follow" title="Follow new output" onclick="ocSummaryResumeTail()">⬇</button>
         </div>
         <div class="oc-chat-prompt">
@@ -3799,10 +3804,11 @@
     }
 
     var _hubBannerColorMap = {
-      green: {bg: 'rgba(22,163,74,0.12)', border: 'rgba(22,163,74,0.3)', color: '#4ade80'},
-      blue:  {bg: 'rgba(59,130,246,0.12)', border: 'rgba(59,130,246,0.3)', color: '#93c5fd'},
-      amber: {bg: 'rgba(245,158,11,0.12)', border: 'rgba(245,158,11,0.3)', color: '#fcd34d'},
-      gray:  {bg: 'rgba(107,114,128,0.12)', border: 'rgba(107,114,128,0.3)', color: '#d1d5db'}
+      /* banner copy stays neutral (--text); the semantic color lives in the tint/border */
+      green: {bg: 'rgba(22,163,74,0.12)', border: 'rgba(22,163,74,0.3)', color: 'var(--text)'},
+      blue:  {bg: 'rgba(59,130,246,0.12)', border: 'rgba(59,130,246,0.3)', color: 'var(--text)'},
+      amber: {bg: 'rgba(245,158,11,0.12)', border: 'rgba(245,158,11,0.3)', color: 'var(--text)'},
+      gray:  {bg: 'rgba(107,114,128,0.12)', border: 'rgba(107,114,128,0.3)', color: 'var(--text)'}
     };
 
     function renderHubBanner(banner) {
@@ -3836,9 +3842,9 @@
       }
       banner.style.display = 'block';
       banner.innerHTML = alerts.map(function(a) {
-        var bg = a.severity === 'error' ? '#7f1d1d' : '#78350f';
-        var border = a.severity === 'error' ? 'var(--red)' : '#d97706';
-        var textColor = a.severity === 'error' ? '#fca5a5' : '#fcd34d';
+        var bg = a.severity === 'error' ? 'color-mix(in srgb, var(--red) 14%, transparent)' : 'color-mix(in srgb, var(--yellow) 14%, transparent)';
+        var border = a.severity === 'error' ? 'var(--red)' : 'var(--yellow)';
+        var textColor = 'var(--text)'; // banner copy stays neutral; severity lives in the tint/border
         return '<div style="background:' + bg + ';border:1px solid ' + border + ';border-radius:8px;padding:12px 16px;margin-bottom:8px;display:flex;align-items:center;gap:10px;font-size:0.85rem">'
           + '<span style="font-size:1.3rem">⚠️</span>'
           + '<span style="color:' + textColor + '">' + a.message.replace(/</g, '&lt;') + '</span>'
@@ -4110,7 +4116,7 @@
           <div id="${agentKey}-body" class="advisory-agent-body${agentCollapsed ? ' collapsed' : ''}" style="display:flex;flex-direction:column;gap:4px;${agentCollapsed ? 'max-height:0' : 'max-height:none'}">`;
         for (const f of findings) {
           const loc = f.file ? ` <code style="font-size:0.72rem;color:var(--muted)">${escapeHtml(f.file)}${f.line ? ':' + f.line : ''}</code>` : '';
-          html += `<div style="font-size:0.8rem;padding:6px 10px;background:var(--bg);border-radius:4px;border-left:3px solid ${f.severity === 'critical' ? 'var(--red)' : f.severity === 'high' ? '#ea580c' : f.severity === 'medium' ? 'var(--yellow)' : 'var(--muted)'}">
+          html += `<div style="font-size:0.8rem;padding:6px 10px;background:var(--bg);border-radius:4px;border-left:3px solid ${f.severity === 'critical' ? 'var(--red)' : f.severity === 'high' ? 'var(--orange)' : f.severity === 'medium' ? 'var(--yellow)' : 'var(--muted)'}">
             ${sevIcon(f.severity)} <strong>[${escapeHtml(f.type || 'finding')}]</strong> ${escapeHtml(f.title)}${loc}
             ${f.detail ? `<div style="margin-top:4px;color:var(--muted);font-size:0.75rem">${escapeHtml(f.detail)}</div>` : ''}
           </div>`;
@@ -4932,7 +4938,7 @@ function burnAreaChart() {
       const scope = s.scope || 'governor';
       const phases = s.phases || {};
 
-      const modeColors = { observe: 'var(--blue)', suggest: '#d97706', evolve: 'var(--green)' };
+      const modeColors = { observe: 'var(--blue)', suggest: 'var(--yellow)', evolve: 'var(--green)' };
       const modeLabels = { observe: 'Observing', suggest: 'Suggesting', evolve: 'Evolving' };
       if (badge) {
         badge.textContent = `${modeLabels[mode] || mode} · ${scope}`;
@@ -5117,7 +5123,7 @@ function burnAreaChart() {
           html += '</tbody></table>';
         }
         if (p.predicted) {
-          html += `<div style="font-size:0.72rem;color:#92400e">Predicted: ${escapeHtml(JSON.stringify(p.predicted))}</div>`;
+          html += `<div style="font-size:0.72rem;color:var(--yellow)">Predicted: ${escapeHtml(JSON.stringify(p.predicted))}</div>`;
         }
         html += '<div style="margin-top:10px">';
         html += '<button class="nous-btn nous-btn-approve" onclick="nousApprove()" title="Approve this experiment proposal and start running it. The governor will apply the proposed parameter changes for the configured experiment duration.">Apply</button>';
@@ -5132,7 +5138,7 @@ function burnAreaChart() {
         const sorted = [...principles].sort((a, b) => (b.confidence || 0) - (a.confidence || 0));
         for (const p of sorted) {
           const conf = Math.round((p.confidence || 0) * 100);
-          const barColor = conf >= 80 ? 'var(--green)' : conf >= 50 ? '#d97706' : 'var(--red)';
+          const barColor = conf >= 80 ? 'var(--green)' : conf >= 50 ? 'var(--yellow)' : 'var(--red)';
           html += '<div class="nous-principle">';
           html += `<div class="nous-confidence-bar"><div class="nous-confidence-fill" style="width:${conf}%;background:${barColor}"></div></div>`;
           html += `<div class="nous-principle-text">${escapeHtml(p.text || p.id)}</div>`;
@@ -5150,14 +5156,14 @@ function burnAreaChart() {
         const TIMELINE_MAX_BARS = 30;
         const recent = ledger.slice(-TIMELINE_MAX_BARS);
         for (const entry of recent) {
-          const colors = { dry_run: '#94a3b8', active: 'var(--blue)', completed: 'var(--green)', aborted: 'var(--red)', analysis: '#7c3aed', shadow_analysis: '#a78bfa' };
-          const color = colors[entry.type] || '#94a3b8';
+          const colors = { dry_run: 'var(--muted)', active: 'var(--blue)', completed: 'var(--green)', aborted: 'var(--red)', analysis: '#7c3aed', shadow_analysis: '#a78bfa' };
+          const color = colors[entry.type] || 'var(--muted)';
           const outcome = entry.outcome || entry.type;
           html += `<div class="nous-timeline-bar" style="height:${20 + Math.random() * 20}px;background:${color}" title="${escapeHtml((entry.id || '?') + ': ' + outcome)}"></div>`;
         }
         html += '</div>';
         html += '<div style="font-size:0.65rem;color:var(--muted);margin-top:4px;display:flex;gap:12px">';
-        html += '<span><span style="color:#94a3b8">■</span> dry run</span>';
+        html += '<span><span style="color:var(--muted)">■</span> dry run</span>';
         html += '<span><span style="color:var(--blue)">■</span> active</span>';
         html += '<span><span style="color:var(--green)">■</span> completed</span>';
         html += '<span><span style="color:var(--red)">■</span> aborted</span>';
@@ -5298,7 +5304,7 @@ function burnAreaChart() {
       h += '<div class="nous-trust-ladder">';
       const trustSteps = [
         { id: 'observe', label: 'Observe', desc: 'Data collection only', color: 'var(--blue)' },
-        { id: 'suggest', label: 'Suggest', desc: 'Experiments need approval', color: '#d97706' },
+        { id: 'suggest', label: 'Suggest', desc: 'Experiments need approval', color: 'var(--yellow)' },
         { id: 'evolve', label: 'Evolve', desc: 'Fully autonomous', color: 'var(--green)' },
       ];
       for (const step of trustSteps) {
@@ -5579,7 +5585,7 @@ function burnAreaChart() {
 
     function confColor(c) {
       if (c >= 0.9) return 'var(--green)';
-      if (c >= 0.7) return '#d97706';
+      if (c >= 0.7) return 'var(--yellow)';
       return 'var(--red)';
     }
 
@@ -6146,7 +6152,7 @@ function burnAreaChart() {
     function renderKnowledgeSetup(panel, badge) {
       if (badge) {
         badge.textContent = 'setup';
-        badge.style.background = '#d97706';
+        badge.style.background = 'var(--yellow)';
         badge.style.color = 'white';
       }
 
@@ -6365,7 +6371,7 @@ function burnAreaChart() {
       const healthyCount = layers.filter(l => l.healthy).length;
       if (badge) {
         badge.textContent = healthyCount + '/' + layers.length + ' layers';
-        badge.style.background = healthyCount === layers.length ? 'var(--green)' : (healthyCount > 0 ? '#d97706' : 'var(--red)');
+        badge.style.background = healthyCount === layers.length ? 'var(--green)' : (healthyCount > 0 ? 'var(--yellow)' : 'var(--red)');
         badge.style.color = 'white';
       }
 
@@ -6373,8 +6379,8 @@ function burnAreaChart() {
       const synthRunning = _beadSynthStatus && _beadSynthStatus.running;
       let html = '<div style="display:flex;justify-content:flex-end;gap:8px;margin-bottom:8px">';
       if (synthEnabled) {
-        html += `<span style="font-size:0.72rem;color:var(--green);display:flex;align-items:center;gap:4px" title="Bead synthesizer is ${synthRunning ? 'running' : 'enabled but not running'}. Schedule: ${escapeHtml((_beadSynthStatus||{}).schedule||'hourly')}"><span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:${synthRunning ? 'var(--green)' : '#d97706'}"></span> Synth ${synthRunning ? 'active' : 'idle'}</span>`;
-        html += '<button onclick="toggleBeadSynth(false)" style="padding:4px 12px;background:none;border:1px solid #d97706;color:#d97706;border-radius:4px;cursor:pointer;font-size:0.72rem" title="Disable the bead synthesizer. Completed beads will no longer be automatically converted to wiki facts.">Pause Synth</button>';
+        html += `<span style="font-size:0.72rem;color:var(--green);display:flex;align-items:center;gap:4px" title="Bead synthesizer is ${synthRunning ? 'running' : 'enabled but not running'}. Schedule: ${escapeHtml((_beadSynthStatus||{}).schedule||'hourly')}"><span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:${synthRunning ? 'var(--green)' : 'var(--yellow)'}"></span> Synth ${synthRunning ? 'active' : 'idle'}</span>`;
+        html += '<button onclick="toggleBeadSynth(false)" style="padding:4px 12px;background:none;border:1px solid var(--yellow);color:var(--yellow);border-radius:4px;cursor:pointer;font-size:0.72rem" title="Disable the bead synthesizer. Completed beads will no longer be automatically converted to wiki facts.">Pause Synth</button>';
       } else {
         html += '<button onclick="toggleBeadSynth(true)" style="padding:4px 12px;background:var(--blue);color:var(--bg);border:none;border-radius:4px;cursor:pointer;font-size:0.72rem" title="Enable the bead synthesizer. Completed beads will be automatically scanned and converted to wiki facts on an hourly schedule.">Enable Synth</button>';
       }
@@ -6389,7 +6395,7 @@ function burnAreaChart() {
       html += `<div class="kb-stat"><div class="val">${totalPages}</div><div class="lbl">Total Facts</div>${factSparkSvg()}</div>`;
       html += `<div class="kb-stat"><div class="val">${healthyCount}/${layers.length}</div><div class="lbl">Layers Online</div></div>`;
       html += `<div class="kb-stat"><div class="val">${escapeHtml(_kbCache.engine || 'n/a')}</div><div class="lbl">Engine</div></div>`;
-      if (staleTotal > 0) html += `<div class="kb-stat"><div class="val" style="color:#d97706">${staleTotal}</div><div class="lbl">Stale</div></div>`;
+      if (staleTotal > 0) html += `<div class="kb-stat"><div class="val" style="color:var(--yellow)">${staleTotal}</div><div class="lbl">Stale</div></div>`;
       if (orphanedTotal > 0) html += `<div class="kb-stat"><div class="val" style="color:var(--red)">${orphanedTotal}</div><div class="lbl">Orphaned</div></div>`;
       html += '</div>';
 
@@ -7798,9 +7804,9 @@ function burnAreaChart() {
     const SYS_GAUGE_SPARK_H = 8;       // sparkline height in px
 
     function sysGaugeColor(pct) {
-      if (pct < SYS_GAUGE_NORMAL_MAX) return '#4b5563';  // muted gray — healthy
-      if (pct < SYS_GAUGE_AMBER_MAX) return '#d97706';   // amber — elevated
-      if (pct < SYS_GAUGE_ORANGE_MAX) return '#ea580c';   // orange — high
+      if (pct < SYS_GAUGE_NORMAL_MAX) return 'var(--muted)'; // muted gray — healthy
+      if (pct < SYS_GAUGE_AMBER_MAX) return 'var(--yellow)'; // warning — elevated
+      if (pct < SYS_GAUGE_ORANGE_MAX) return 'var(--orange)'; // orange — high
       return 'var(--red)';                                     // red — critical
     }
 
@@ -9625,7 +9631,7 @@ function burnAreaChart() {
       const desc = ACMM_LEVEL_DESCRIPTIONS[level] || '';
       const pct = lvlData ? Math.round(lvlData.score * 100) : 0;
       const passed = lvlData ? lvlData.passed : false;
-      const statusColor = passed ? 'var(--green)' : (pct > 40 ? 'var(--yellow)' : '#da3633');
+      const statusColor = passed ? 'var(--green)' : (pct > 40 ? 'var(--yellow)' : 'var(--red)');
       const statusText = passed ? '✓ Passed' : '✗ Not passed';
       const threshold = lvlData ? Math.round(lvlData.threshold * 100) : 70;
       const failCount = criteria.filter(c => !c.passed).length;
@@ -9698,7 +9704,7 @@ function burnAreaChart() {
         for (let ri = 0; ri < d.repo_results.length; ri++) {
           const rr = d.repo_results[ri];
           const rPct = rr.criteria_total > 0 ? Math.round(rr.criteria_passed / rr.criteria_total * 100) : 0;
-          const rColor = rr.codebase_level >= 2 ? 'var(--green)' : (rr.criteria_passed > rr.criteria_total * 0.5 ? 'var(--yellow)' : '#da3633');
+          const rColor = rr.codebase_level >= 2 ? 'var(--green)' : (rr.criteria_passed > rr.criteria_total * 0.5 ? 'var(--yellow)' : 'var(--red)');
           const expandId = 'acmm-repo-expand-' + ri;
           html += '<div style="margin-bottom:3px">' +
             '<div onclick="var el=document.getElementById(\'' + expandId + '\');el.style.display=el.style.display===\'none\'?\'block\':\'none\'" ' +
@@ -9709,7 +9715,7 @@ function burnAreaChart() {
             '<div id="' + expandId + '" style="display:none;padding:6px 8px 8px;border:1px solid var(--border);border-top:none;border-radius:0 0 6px 6px;background:var(--surface)">';
           for (const lvl of (rr.levels || [])) {
             const pct = Math.round(lvl.score * 100);
-            const color = lvl.passed ? 'var(--green)' : (pct > 40 ? 'var(--yellow)' : '#da3633');
+            const color = lvl.passed ? 'var(--green)' : (pct > 40 ? 'var(--yellow)' : 'var(--red)');
             const safeRepo = escapeHtml(rr.repo).replace(/'/g, "\\'");
             html += '<div onclick="event.stopPropagation();acmmShowLevelDialog(' + lvl.level + ',\'' + safeRepo + '\')" ' +
               'style="cursor:pointer;padding:5px 6px;margin-bottom:3px;background:var(--bg);border-radius:4px;border:1px solid var(--border);transition:border-color .15s" ' +
@@ -9726,7 +9732,7 @@ function burnAreaChart() {
         // Single repo: show level bars directly
         for (const lvl of levels) {
           const pct = Math.round(lvl.score * 100);
-          const color = lvl.passed ? 'var(--green)' : (pct > 40 ? 'var(--yellow)' : '#da3633');
+          const color = lvl.passed ? 'var(--green)' : (pct > 40 ? 'var(--yellow)' : 'var(--red)');
           html += '<div onclick="acmmShowLevelDialog(' + lvl.level + ')" class="row-card" onmouseover="this.style.borderColor=\'var(--muted)\'" onmouseout="this.style.borderColor=\'var(--border)\'">' +
             '<div class="row-between">' +
             '<span style="font-size:0.82rem;font-weight:600">' + (lvl.passed ? '✓' : '✗') + ' L' + lvl.level + ' ' + escapeHtml(lvl.name) + '</span>' +
@@ -9794,7 +9800,7 @@ function burnAreaChart() {
       for (const lvl of levels) {
         const criteria = results.filter(c => c.level === lvl.level);
         const pct = Math.round(lvl.score * 100);
-        const color = lvl.passed ? 'var(--green)' : (pct > 40 ? 'var(--yellow)' : '#da3633');
+        const color = lvl.passed ? 'var(--green)' : (pct > 40 ? 'var(--yellow)' : 'var(--red)');
         const failCount = criteria.filter(c => !c.passed).length;
         html += '<div style="margin-bottom:8px">' +
           '<div onclick="acmmCloseDialog();acmmShowLevelDialog(' + lvl.level + ')" style="cursor:pointer;display:flex;align-items:center;justify-content:space-between;padding:6px 8px;background:var(--bg);border-radius:6px;border:1px solid var(--border);transition:border-color .15s" onmouseover="this.style.borderColor=\'var(--muted)\'" onmouseout="this.style.borderColor=\'var(--border)\'">' +
@@ -9890,7 +9896,7 @@ function burnAreaChart() {
         let html = '';
         for (const lvl of levels) {
           const pct = Math.round(lvl.score * 100);
-          const color = lvl.passed ? 'var(--green)' : (pct > 40 ? 'var(--yellow)' : '#da3633');
+          const color = lvl.passed ? 'var(--green)' : (pct > 40 ? 'var(--yellow)' : 'var(--red)');
           html += '<div onclick="acmmShowLevelDialog(' + lvl.level + ')" style="display:flex;align-items:center;gap:8px;margin-bottom:4px;font-size:0.75rem;cursor:pointer;padding:2px 4px;border-radius:4px;transition:background .15s" onmouseover="this.style.background=\'var(--bg)\'" onmouseout="this.style.background=\'transparent\'">' +
             '<span style="width:100px;color:var(--muted)">' + escapeHtml(lvl.name) + '</span>' +
             '<div style="flex:1;height:8px;background:var(--bg);border-radius:4px;overflow:hidden">' +
@@ -9947,12 +9953,12 @@ function burnAreaChart() {
           _upgradeInProgress = false;
           _upgradeTargetHash = null;
           showToast('Upgrade complete!', 'success');
-          html += ' <span style="color:#22c55e" title="Up to date with remote">✓</span>';
+          html += ' <span style="color:var(--green)" title="Up to date with remote">✓</span>';
         } else if (v.behind) {
           html += ` <span class="git-behind" title="Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">⬆ behind</span>`;
           html += ` <button id="spoke-upgrade-btn" onclick="selfUpgrade('${escapeHtml(v.latestHash || '')}')" style="padding:3px 10px;font-size:0.7rem;background:var(--green);color:var(--bg);border:none;border-radius:4px;cursor:pointer;margin-left:6px;white-space:nowrap" title="Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">Upgrade</button>`;
         } else if (v.latestHash) {
-          html += ' <span style="color:#22c55e" title="Up to date with remote">✓</span>';
+          html += ' <span style="color:var(--green)" title="Up to date with remote">✓</span>';
         }
         el.innerHTML = html;
         if (ocEl) ocEl.innerHTML = html;
@@ -10778,7 +10784,7 @@ function burnAreaChart() {
 
         <div class="config-field">
           <label>Allowed Models <span class="config-info">i<span class="config-tooltip">Models matching these patterns are accepted. Supports wildcards (*) and regex (/pattern/). Empty = allow all.</span></span></label>
-          <div id="hub-allow-models" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">${allowModels.map(function(m) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(34,197,94,0.15);color:#4ade80;border:1px solid rgba(34,197,94,0.3)">' + esc(m) + ' <span onclick="removeHubFilter(\'contribute_allow_models\',\'' + esc(m).replace(/'/g,"\\'") + '\')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('')}</div>
+          <div id="hub-allow-models" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">${allowModels.map(function(m) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(34,197,94,0.15);color:var(--green);border:1px solid rgba(34,197,94,0.3)">' + esc(m) + ' <span onclick="removeHubFilter(\'contribute_allow_models\',\'' + esc(m).replace(/'/g,"\\'") + '\')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('')}</div>
           <div style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:6px">
             <button onclick="addModelPreset('claude-opus*')" style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:9999px;color:var(--muted);cursor:pointer;font-size:0.65rem">+ opus</button>
             <button onclick="addModelPreset('claude-sonnet*')" style="padding:2px 8px;background:var(--bg);border:1px solid var(--border);border-radius:9999px;color:var(--muted);cursor:pointer;font-size:0.65rem">+ sonnet</button>
@@ -10794,7 +10800,7 @@ function burnAreaChart() {
 
         <div class="config-field">
           <label>Allow Labels <span class="config-info">i<span class="config-tooltip">Only issues with these labels will be queued for contributors. Leave empty to allow all.</span></span></label>
-          <div id="hub-allow-labels" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">${allowLabels.map(function(l) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(34,197,94,0.15);color:#4ade80;border:1px solid rgba(34,197,94,0.3)">' + esc(l) + ' <span onclick="removeHubLabel(\'allow\',' + "'" + esc(l) + "'" + ')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('')}</div>
+          <div id="hub-allow-labels" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">${allowLabels.map(function(l) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(34,197,94,0.15);color:var(--green);border:1px solid rgba(34,197,94,0.3)">' + esc(l) + ' <span onclick="removeHubLabel(\'allow\',' + "'" + esc(l) + "'" + ')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('')}</div>
           <div style="display:flex;gap:4px"><input type="text" id="hub-allow-label-input" placeholder="e.g. good-first-issue, help-wanted" style="flex:1" onkeydown="if(event.key==='Enter'){addHubLabel('allow');event.preventDefault()}"><button onclick="addHubLabel('allow')" style="padding:4px 12px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer;font-size:0.75rem">Add</button></div>
         </div>
 
@@ -11074,10 +11080,10 @@ function burnAreaChart() {
           <label>Aliases <span class="config-info">i<span class="config-tooltip">Comma-separated short aliases for Discord commands.</span></span></label>
           <input type="text" id="cfg-agent-aliases" value="${esc((g.aliases || []).join(', '))}" placeholder="e.g. sc, scan" onchange="markDirty('general','aliases',this.value.split(',').map(s=>s.trim()).filter(Boolean))">
         </div>
-        ${isCreate ? '' : `<div style="margin-top:24px;padding-top:16px;border-top:1px solid #fecaca">
+        ${isCreate ? '' : `<div style="margin-top:24px;padding-top:16px;border-top:1px solid var(--red-border)">
           <label style="color:#b91c1c;font-weight:600;font-size:0.75rem;margin-bottom:8px;display:block">Danger Zone</label>
           <button data-action="deleteAgentFromConfig" data-agent="${esc(agentName)}" style="background:var(--red);color:var(--bg);border:none;padding:6px 16px;border-radius:6px;font-size:0.75rem;cursor:pointer;font-weight:600" title="Permanently remove this agent from the hive. Deletes its config file, env file, and sidebar entry. Cannot be undone.">Delete Agent</button>
-          <span style="color:#9ca3af;font-size:0.65rem;margin-left:8px">Removes agent config, env file, and sidebar entry</span>
+          <span style="color:var(--muted);font-size:0.65rem;margin-left:8px">Removes agent config, env file, and sidebar entry</span>
         </div>`}`;
       return html;
     }
@@ -11210,7 +11216,7 @@ function burnAreaChart() {
 
     // --- Channels tab ---
 
-    const CHANNEL_COLORS = {kick:'var(--blue)',webhook:'var(--green)',discord:'#7c3aed',schedule:'#ea580c',bead:'#0891b2'};
+    const CHANNEL_COLORS = {kick:'var(--blue)',webhook:'var(--green)',discord:'#7c3aed',schedule:'var(--orange)',bead:'#0891b2'};
     const CHANNEL_TYPES = ['kick','webhook','discord','schedule','bead'];
 
     function renderAgentChannels(channels) {
@@ -11639,7 +11645,7 @@ function burnAreaChart() {
         + '<button onclick="copyExportYaml()" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg)">Copy to Clipboard</button>'
         + '<button onclick="downloadExportYaml()" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:1px solid var(--border);background:var(--surface);color:var(--text)">Download YAML</button>'
         + '</div>'
-        + '<textarea id="' + yamlId + '" readonly style="flex:1;min-height:300px;font-family:var(--font-mono);font-size:0.75rem;padding:12px;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:6px;resize:vertical;white-space:pre;tab-size:2">Loading...</textarea>'
+        + '<textarea id="' + yamlId + '" readonly style="flex:1;min-height:300px;font-family:var(--font-mono);font-size:0.75rem;padding:12px;background:var(--terminal-bg);color:var(--terminal-fg);border:1px solid var(--terminal-line);border-radius:6px;resize:vertical;white-space:pre;tab-size:2">Loading...</textarea>'
         + '</div>';
     }
 
@@ -11943,7 +11949,7 @@ function burnAreaChart() {
       const list = repos.map((r, i) => {
         const isDefault = r === primary;
         const starStyle = isDefault
-          ? 'color:#f59e0b;cursor:pointer;font-size:1rem;margin-right:6px'
+          ? 'color:var(--amber);cursor:pointer;font-size:1rem;margin-right:6px'
           : 'color:var(--muted);cursor:pointer;font-size:1rem;margin-right:6px;opacity:0.4';
         const starTitle = isDefault
           ? 'Default repo (advisory issue lives here)'
@@ -12884,7 +12890,7 @@ function burnAreaChart() {
           clearInterval(ghPollTimer);
           ghPollTimer = null;
           document.getElementById('gh-poll-status').textContent = 'Error: ' + (data.error || 'unknown');
-          document.getElementById('gh-poll-status').style.color = '#ef4444';
+          document.getElementById('gh-poll-status').style.color = 'var(--red)';
         }
       } catch (e) {
         // network hiccup — keep polling
@@ -12964,7 +12970,7 @@ function burnAreaChart() {
         var resp = await fetch('/api/copilot-auth/status');
         var data = await resp.json();
         if (data.error) {
-          if (statusEl) { statusEl.textContent = data.error; statusEl.style.color = '#ef4444'; }
+          if (statusEl) { statusEl.textContent = data.error; statusEl.style.color = 'var(--red)'; }
           cancelCopilotLogin(true);
           return;
         }
@@ -13057,7 +13063,7 @@ function burnAreaChart() {
       var input = document.getElementById('claude-callback-input');
       var statusEl = document.getElementById('claude-exchange-status');
       if (!input || !input.value.trim()) {
-        if (statusEl) { statusEl.textContent = 'Please paste the callback URL'; statusEl.style.color = '#ef4444'; }
+        if (statusEl) { statusEl.textContent = 'Please paste the callback URL'; statusEl.style.color = 'var(--red)'; }
         return;
       }
       var value = input.value.trim();
@@ -13077,7 +13083,7 @@ function burnAreaChart() {
         });
         var data = await resp.json();
         if (data.error) {
-          if (statusEl) { statusEl.textContent = data.error; statusEl.style.color = '#ef4444'; }
+          if (statusEl) { statusEl.textContent = data.error; statusEl.style.color = 'var(--red)'; }
           return;
         }
         if (statusEl) { statusEl.textContent = 'Authenticated!'; statusEl.style.color = 'var(--green)'; }
@@ -13089,7 +13095,7 @@ function burnAreaChart() {
           checkClaudeAuth();
         }, CLAUDE_SUCCESS_DISMISS_MS);
       } catch (e) {
-        if (statusEl) { statusEl.textContent = 'Error: ' + e.message; statusEl.style.color = '#ef4444'; }
+        if (statusEl) { statusEl.textContent = 'Error: ' + e.message; statusEl.style.color = 'var(--red)'; }
       }
     }
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -502,8 +502,6 @@
     body.light-mode .temp-gauge-track { border: 1px solid var(--line); }
     body.light-mode .temp-gauge-needle { background: var(--text); box-shadow: 0 0 6px rgba(17,24,39,0.4); }
 
-    /* Light config modal */
-    body.light-mode .config-overlay { background: rgba(0,0,0,0.3); }
 
 
 
@@ -549,21 +547,23 @@
     .gh-app-perm-details { font-size: 0.8rem; margin-top: 6px; color: var(--text); }
     .gh-app-perm-details .perm-ok { color: var(--green); }
     .gh-app-perm-details .perm-missing { color: var(--red); font-weight: 600; }
-    .gh-auth-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.6); z-index: 9999; display: flex; align-items: center; justify-content: center; }
-    .gh-auth-modal { background: var(--panel); border-radius: 12px; padding: 32px; max-width: 420px; width: 90%; text-align: center; box-shadow: var(--shadow-modal); }
-    .gh-auth-modal h3 { margin: 0 0 8px; font-size: var(--fs-xl); color: var(--text); }
+    /* .gh-auth-overlay/.gh-auth-modal — modal overlay/panel recipes (end of style block).
+       z-index encodes stacking intent — do not change. */
+    .gh-auth-overlay { z-index: 9999; }
+    .gh-auth-modal { padding: 32px; max-width: 420px; width: 90%; text-align: center; }
+    .gh-auth-modal h3 { margin: 0 0 8px; font-size: var(--fs-lg); font-weight: 700; color: var(--text); }
     .gh-auth-modal p { color: var(--muted); font-size: 0.85rem; margin: 4px 0; }
     .gh-auth-modal .device-code { font-family: var(--font-mono); font-size: 2rem; font-weight: 800; color: var(--green); letter-spacing: 4px; padding: 16px; background: var(--green-bg); border-radius: 8px; margin: 16px 0; user-select: all; }
     .gh-auth-modal .gh-verify-link { display: inline-block; margin: 12px 0; padding: 8px 20px; background: var(--green); color: var(--bg); text-decoration: none; border-radius: 6px; font-weight: 600; }
     .gh-auth-modal .gh-verify-link:hover { background: color-mix(in srgb, var(--green) 85%, #fff); }
     .gh-auth-modal .gh-poll-status { color: var(--muted); font-size: 0.8rem; margin-top: 12px; }
     .gh-auth-modal .gh-cancel { margin-top: 12px; } /* ghost button (system recipe) */
-    .gh-setup-modal { background: var(--panel); border-radius: 12px; padding: 32px; max-width: 560px; width: 92%; text-align: left; box-shadow: var(--shadow-modal); max-height: 85vh; overflow-y: auto; }
+    .gh-setup-modal { padding: 32px; max-width: 560px; width: 92%; text-align: left; max-height: 85vh; overflow-y: auto; } /* modal panel recipe */
     .claude-auth-btn { background: #d97706; color: #fff; border: none; padding: 6px 16px; border-radius: 6px; cursor: pointer; font-weight: 600; font-size: 0.85rem; }
     .claude-auth-btn:hover { background: #f59e0b; }
     .claude-auth-status { font-size: 0.8rem; color: var(--muted); }
     .claude-auth-status.logged-in { color: var(--green); font-weight: 600; }
-    .gh-setup-modal h3 { margin: 0 0 16px; font-size: var(--fs-xl); color: var(--text); text-align: center; }
+    .gh-setup-modal h3 { margin: 0 0 16px; font-size: var(--fs-lg); font-weight: 700; color: var(--text); text-align: center; }
     .gh-setup-modal p { color: var(--muted); font-size: 0.85rem; margin: 8px 0; line-height: 1.5; }
     .gh-setup-modal .setup-option { background: var(--bg); border: 2px solid var(--line); border-radius: 8px; padding: 16px; margin: 12px 0; cursor: pointer; transition: border-color 0.15s; }
     .gh-setup-modal .setup-option:hover { border-color: var(--green); }
@@ -1053,41 +1053,26 @@
     }
 
     /* Configuration Dialog */
-    .config-overlay {
-      position: fixed; inset: 0; z-index: 10000;
-      background: rgba(0,0,0,0.7); backdrop-filter: blur(2px);
-      display: flex; align-items: center; justify-content: center;
-      animation: config-fade-in 0.15s ease-out;
-    }
+    /* .config-overlay / .hive-dialog-overlay — modal overlay recipe (end of
+       style block); z-indexes encode stacking intent — do not change. */
+    .config-overlay { z-index: 10000; }
     .config-overlay.hidden { display: none; }
     @keyframes config-fade-in { from { opacity: 0; } to { opacity: 1; } }
-    .hive-dialog-overlay {
-      position: fixed; inset: 0; z-index: 20000;
-      background: rgba(0,0,0,0.6); backdrop-filter: blur(2px);
-      display: flex; align-items: center; justify-content: center;
-      animation: config-fade-in 0.15s ease-out;
-    }
-    .hive-dialog {
-      background: var(--panel); border: 1px solid var(--line);
-      border-radius: 10px; width: 460px; max-width: 92vw;
-      box-shadow: var(--shadow-modal);
-      padding: 24px;
-    }
-    .hive-dialog-title { font-size: var(--fs-lg); font-weight: 600; color: var(--text); margin-bottom: 12px; }
+    .hive-dialog-overlay { z-index: 20000; }
+    .hive-dialog { width: 460px; max-width: 92vw; padding: 24px; } /* modal panel recipe */
+    .hive-dialog-title { font-size: var(--fs-lg); font-weight: 700; color: var(--text); margin-bottom: 12px; }
     .hive-dialog-body { font-size: 0.9rem; color: var(--muted); line-height: 1.5; white-space: pre-wrap; margin-bottom: 20px; }
     .hive-dialog-buttons { display: flex; gap: 10px; justify-content: flex-end; }
     /* .hive-dialog-btn(.primary/.cancel) — primary/ghost buttons (system recipe) */
     .config-modal {
-      background: var(--surface); border: 1px solid var(--border);
-      border-radius: 12px; width: 900px; max-width: 95vw;
+      width: 900px; max-width: 95vw;
       height: 85vh; display: flex; flex-direction: column;
-      box-shadow: var(--shadow-modal);
-    }
+    } /* modal panel recipe */
     .config-header {
       display: flex; align-items: center; justify-content: space-between;
       padding: 16px 20px; border-bottom: 1px solid var(--border);
     }
-    .config-title { font-size: 1.1rem; font-weight: 600; }
+    .config-title { font-size: var(--fs-lg); font-weight: 700; }
     .config-close {
       background: none; border: none; color: var(--muted); font-size: 1.4rem;
       cursor: pointer; padding: 4px 8px; border-radius: 4px;
@@ -1371,8 +1356,10 @@
     .nous-experiment-live h4 { margin: 0 0 6px 0; font-size: 0.82rem; color: var(--text); }
 
     /* Nous Config Panel */
-    .nous-config-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.6); z-index: 1000; display: flex; align-items: center; justify-content: center; }
-    .nous-config-dialog { background: var(--surface); border: 1px solid var(--border); border-radius: 12px; width: 900px; max-width: 95vw; max-height: 85vh; display: flex; flex-direction: column; padding: 0; box-shadow: var(--shadow-modal); }
+    /* .nous-config-overlay/.nous-config-dialog — modal overlay/panel recipes
+       (also reused by the kb modals via className); z-index stays. */
+    .nous-config-overlay { z-index: 1000; }
+    .nous-config-dialog { width: 900px; max-width: 95vw; max-height: 85vh; display: flex; flex-direction: column; padding: 0; }
     .nous-config-dialog > h2 { flex-shrink: 0; padding: 24px 24px 0; }
     .nous-config-dialog > .nous-config-body { flex: 1; overflow-y: auto; padding: 16px 24px; }
     .nous-config-dialog > .nous-config-footer { flex-shrink: 0; padding: 12px 24px; border-top: 1px solid var(--border); }
@@ -1689,6 +1676,34 @@
     .oc-health-badge { padding: 3px 12px; font-size: var(--fs-sm); }
     @media (max-width: 480px) {
       .pause-badge { font-size: 0.55rem; padding: 0 5px; margin-left: 2px; }
+    }
+
+    /* ══ Modal system (Phase 2) ══
+       One overlay recipe + one glassy panel recipe (hub identity), applied
+       by restyling the five existing overlay/panel patterns in place —
+       DOM untouched, z-indexes retained at each pattern's rule (they
+       encode stacking intent). The acmm JS-built overlay keeps its inline
+       styles until the Phase 4 template sweep. */
+    .gh-auth-overlay, .config-overlay, .hive-dialog-overlay, .nous-config-overlay {
+      position: fixed; inset: 0;
+      background: rgba(0, 0, 0, 0.55);
+      -webkit-backdrop-filter: blur(4px); backdrop-filter: blur(4px);
+      display: flex; align-items: center; justify-content: center;
+      animation: config-fade-in 0.15s ease-out;
+    }
+    /* Glass panel — hub recipe linear-gradient(#17212deb,#0c1219eb) +
+       border #ffffff1a, expressed in tokens so the light-mode remap
+       (panel-strong #eef1f5 → white, near-black text border) just works. */
+    .gh-auth-modal, .gh-setup-modal, .config-modal, .hive-dialog, .nous-config-dialog {
+      background: linear-gradient(
+        color-mix(in srgb, var(--panel-strong) 92%, transparent),
+        color-mix(in srgb, var(--bg-soft) 92%, transparent));
+      border: 1px solid color-mix(in srgb, var(--text) 10%, transparent);
+      border-radius: var(--radius-lg);
+      box-shadow: var(--shadow-modal);
+    }
+    @media (max-width: 600px) {
+      .config-modal { border-radius: 0; } /* fullscreen on mobile (see mobile block above) */
     }
   </style>
 </head>


### PR DESCRIPTION
Promotes the finished v3 line onto v2. v2 is fully contained in v3 (verified merge-base ancestor), so this brings only v3's own work:

**Design system restyle (5 phases):** hub-aligned tokens with light mode as a pure token remap (fixed the frozen-alias bug), Inter typography with deliberate monospace, one button system / one pill recipe / one modal treatment / shared input recipe (incl. textareas), sticky blurred topbar, glassy agent cards with status borders, deliberate terminal surfaces, JS-template hex sweep (CSS hexes 423→72, JS hexes 387→79).

**UX/behavior fixes:** branch-aware self-version check (server-side gitBranch), truthful mode-toggle labels, wider config dialog with wrapping tabs + compact color swatch + visible info badges + color usage caption, Knowledge Sources consolidation (one list, vault/document type pills, count pills), live method/model updates without refresh, Cadence Advisor zero-projection for paused agents, color discipline (neutral metric values), sidebar hover fix, Beads/Knowledge/Contributors count pills, real mobile topbar fix at 390px, #1798 parity ports.

Merge with a MERGE COMMIT (not squash) for single-revert rollback.