### PR TITLE
feat(dashboard): refinement batch — knowledge hygiene, live config updates, health tooltips, budget exemptions, empty states

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -149,6 +149,9 @@ type StatsDisplayEntry struct {
 	Style      string `yaml:"style" json:"style"`
 	TrendField string `yaml:"trend_field,omitempty" json:"trendField,omitempty"`
 	Target     int    `yaml:"target,omitempty" json:"target,omitempty"`
+	// Desc is a one-line explanation of what the stat verifies, rendered
+	// as a hover tooltip in the dashboard (health checks especially).
+	Desc string `yaml:"desc,omitempty" json:"desc,omitempty"`
 }
 
 // ChannelConfig declares a trigger channel for an agent.

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1210,6 +1210,9 @@ func (s *Server) handleBudgetIgnoreGet(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, map[string]interface{}{
 		"ignored": budget.IgnoreAll,
 		"agents":  budget.IgnoredAgents,
+		// by_agent lets the Budget config tab show each agent's tracked
+		// token burn next to its exemption toggle.
+		"by_agent": budget.ByAgent,
 	})
 }
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1009,7 +1009,7 @@
     .burn-area-title { font-size: 0.7rem; color: var(--muted); margin-bottom: 4px; }
 
     /* Cadence advisor */
-    .advisor-section { margin: 12px 0; padding: 12px; background: rgba(88,166,255,0.05); border: 1px solid rgba(88,166,255,0.15); border-radius: 6px; }
+    .advisor-section { margin: 12px 0; padding: 12px; background: color-mix(in srgb, var(--blue) 5%, transparent); border: 1px solid color-mix(in srgb, var(--blue) 15%, transparent); border-radius: 6px; }
     .advisor-title { font-size: 0.85rem; font-weight: 700; margin-bottom: 6px; }
     .advisor-total { font-size: 0.8rem; margin-bottom: 10px; }
     .advisor-bars { display: flex; flex-direction: column; gap: 4px; margin-bottom: 8px; }
@@ -1024,8 +1024,11 @@
     .advisor-row-inactive .advisor-agent { color: var(--muted); font-weight: 400; }
     .advisor-inactive-note { flex: 1; color: var(--muted); font-style: italic; font-size: 0.65rem; }
     .advisor-tips { margin-top: 8px; display: flex; flex-direction: column; gap: 4px; }
-    .advisor-tip { font-size: 0.72rem; color: var(--text); padding: 4px 8px; background: rgba(210,153,34,0.08); border-left: 2px solid var(--yellow); border-radius: 0 4px 4px 0; }
-    .advisor-tip b { color: var(--cyan); }
+    .advisor-tip { font-size: 0.72rem; color: var(--text); padding: 4px 8px; background: color-mix(in srgb, var(--yellow) 8%, transparent); border-left: 2px solid var(--yellow); border-radius: 0 4px 4px 0; }
+    /* Agent names inside tips: bold text color only — the tip's yellow
+       tint/border carries the accent (banner-contrast principle); a second
+       hue (cyan-on-yellow) fought the tint in both modes. */
+    .advisor-tip b { color: var(--text); }
 
     /* Budget bar */
     .budget-bar { margin: 8px 0; }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -12184,6 +12184,7 @@ function burnAreaChart() {
     }
 
     function renderGovBudget(b) {
+      loadBudgetExemptions();
       return `
         <div class="config-field-row">
           <div class="config-field"><label>Total Tokens <span class="config-info">i<span class="config-tooltip">Maximum token budget for the period. When usage approaches this limit, the governor will downgrade models or skip low-priority kicks. Set to 0 to disable budget tracking.</span></span></label><input type="number" value="${b.totalTokens || 0}" onchange="markDirty('budget','totalTokens',Number(this.value))"></div>
@@ -12192,7 +12193,73 @@ function burnAreaChart() {
         <div class="config-field">
           <label>Critical Percent <span class="config-info">i<span class="config-tooltip">When token usage exceeds this percentage of the total budget, the governor enters budget-critical mode: downgrading models to cheaper alternatives and potentially skipping non-essential kicks. Default is 90%.</span></span></label>
           <input type="number" value="${b.criticalPct || 90}" onchange="markDirty('budget','criticalPct',Number(this.value))">
+        </div>
+        <div class="config-field" style="margin-top:14px">
+          <label>Per-Agent Exemptions <span class="config-info">i<span class="config-tooltip">Exempt agents keep getting kicked even while an exhausted budget suppresses everyone else. Toggles apply immediately (no Save needed). The governor panel's global "ignore budget" checkbox bypasses enforcement for ALL agents; these exemptions are per-agent.</span></span></label>
+          <div id="budget-exempt-list"><div style="color:var(--muted);font-size:0.75rem;padding:4px 0">Loading exemptions...</div></div>
         </div>`;
+    }
+
+    // ── Budget per-agent exemptions (governor IgnoredAgents) ──
+    // Toggles POST the array form of /api/budget-ignore ({ignored: [names]}),
+    // which sets the per-agent list; the bool form remains the global toggle.
+    let _budgetExemptAgents = new Set();
+
+    async function loadBudgetExemptions() {
+      try {
+        const r = await fetch('/api/budget-ignore');
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        const d = await r.json();
+        _budgetExemptAgents = new Set(d.agents || []);
+        renderBudgetExemptList(d.by_agent || {});
+      } catch (e) {
+        const el = document.getElementById('budget-exempt-list');
+        if (el) el.innerHTML = '<div style="color:var(--muted);font-size:0.75rem">Could not load exemptions.</div>';
+      }
+    }
+
+    function renderBudgetExemptList(byAgent) {
+      const el = document.getElementById('budget-exempt-list');
+      if (!el) return;
+      const agents = [...(window._lastAgents || [])].sort((a, b) => (a.sortOrder || 100) - (b.sortOrder || 100));
+      if (agents.length === 0) {
+        el.innerHTML = '<div style="color:var(--muted);font-size:0.75rem">No agents configured.</div>';
+        return;
+      }
+      const rows = agents.map(a => {
+        const burn = byAgent[a.name] || 0;
+        const exempt = _budgetExemptAgents.has(a.name);
+        return `<div class="config-list-item" style="align-items:center;gap:8px">
+          <span style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${a.emoji ? a.emoji + ' ' : ''}${esc(a.displayName || a.name)}</span>
+          <span style="color:var(--muted);font-size:0.7rem;white-space:nowrap" title="Tokens recorded for this agent by the governor's budget tracker">${burn > 0 ? burn.toLocaleString() + ' tok' : '—'}</span>
+          <label style="display:flex;align-items:center;gap:4px;font-size:0.72rem;color:var(--muted);cursor:pointer;white-space:nowrap">
+            <input type="checkbox" ${exempt ? 'checked' : ''} onchange="toggleBudgetExempt('${esc(a.name)}', this.checked)" style="cursor:pointer"> exempt
+          </label>
+        </div>`;
+      }).join('');
+      el.innerHTML = rows;
+    }
+
+    async function toggleBudgetExempt(name, checked) {
+      if (checked) _budgetExemptAgents.add(name);
+      else _budgetExemptAgents.delete(name);
+      try {
+        const r = await fetch('/api/budget-ignore', {
+          method: 'POST',
+          headers: _inceptionAuthHeaders(),
+          body: JSON.stringify({ ignored: [..._budgetExemptAgents] })
+        });
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        const d = await r.json();
+        _budgetExemptAgents = new Set(d.agents || []);
+        showToast(checked ? `${name} exempted from budget suppression` : `${name} no longer exempt`, 'success');
+      } catch (e) {
+        // Revert the optimistic flip and re-render so the checkbox matches reality.
+        if (checked) _budgetExemptAgents.delete(name);
+        else _budgetExemptAgents.add(name);
+        showToast('Failed to update budget exemptions: ' + e.message, 'error');
+        loadBudgetExemptions();
+      }
     }
 
     function renderGovNotifications(n) {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4247,13 +4247,31 @@
       }).join(''));
     }
 
+    // Contributors-style empty-state card, reused by sections that would
+    // otherwise show bare/blank content on a new hive.
+    function emptyStateCard(icon, title, bodyHtml) {
+      return '<div style="color:var(--text);padding:24px;background:var(--card-bg);border:1px solid var(--border);border-radius:var(--radius-lg);max-width:760px">' +
+        `<div style="font-weight:600;font-size:var(--fs-md);margin-bottom:8px">${icon} ${title}</div>` +
+        `<div style="color:var(--muted);font-size:var(--fs-base);line-height:1.6">${bodyHtml}</div>` +
+      '</div>';
+    }
+
     function renderBeads(beads) {
       const el = document.getElementById('beads');
+      const workers = beads.workers >= 0 ? beads.workers : 0;
+      const supervisor = beads.supervisor >= 0 ? beads.supervisor : 0;
+      if (workers === 0 && supervisor === 0) {
+        setIfChanged(el, emptyStateCard('🔮', 'Beads — your hive’s shared work ledger',
+          'Beads are the findings and work items agents file for each other — bugs, tasks, decisions, and advisories, each with a status and priority. ' +
+          'Worker agents open beads as they discover issues; the supervisor triages the ledger and dispatches follow-up work. ' +
+          'Counts appear here as soon as agents start filing beads — kick an agent, or let the governor cadence run, and check back.'));
+        return;
+      }
       const wSpark = sparkSvg(getHistorySeries('beadsWorkers'), 'var(--cyan)');
       const sSpark = sparkSvg(getHistorySeries('beadsSupervisor'), 'var(--yellow)');
       setIfChanged(el, `
-        <div class="bead-stat"><div class="spark-row"><span class="num">${beads.workers >= 0 ? beads.workers : 0}</span>${wSpark}</div><div class="label">workers</div></div>
-        <div class="bead-stat"><div class="spark-row"><span class="num">${beads.supervisor >= 0 ? beads.supervisor : 0}</span>${sSpark}</div><div class="label">supervisor</div></div>`);
+        <div class="bead-stat"><div class="spark-row"><span class="num">${workers}</span>${wSpark}</div><div class="label">workers</div></div>
+        <div class="bead-stat"><div class="spark-row"><span class="num">${supervisor}</span>${sSpark}</div><div class="label">supervisor</div></div>`);
     }
 
     function fmtTokens(n) {
@@ -5046,7 +5064,19 @@ function burnAreaChart() {
           principles: await principlesRes.json(),
         };
         renderNous();
-      } catch (_) { /* nous endpoints may not exist yet */ }
+      } catch (_) {
+        // Nous endpoints may not exist yet — show the explainer rather
+        // than a blank section on new hives.
+        const panel = document.getElementById('nous-panel');
+        if (panel && !panel.innerHTML.trim()) panel.innerHTML = _nousExplainerCard();
+      }
+    }
+
+    function _nousExplainerCard() {
+      return emptyStateCard('🧪', 'Strategy Lab — controlled experiments on your hive’s strategy',
+        'The Strategy Lab is the hive’s strategist: it designs controlled experiments on governor strategy — cadences, model assignments, thresholds — and measures each one against a recorded baseline of hive behavior. ' +
+        '<strong>Observe</strong> only collects baseline data, <strong>Suggest</strong> proposes experiments for your approval, and <strong>Evolve</strong> runs them autonomously, distilling proven changes into principles. ' +
+        'To get started, leave it in Observe while it builds a baseline (it needs a few days of snapshots), then switch to Suggest to review its first proposals.');
     }
 
     function renderNous() {
@@ -5062,6 +5092,15 @@ function burnAreaChart() {
 
       const modeColors = { observe: 'var(--blue)', suggest: 'var(--yellow)', evolve: 'var(--green)' };
       const modeLabels = { observe: 'Observing', suggest: 'Suggesting', evolve: 'Evolving' };
+
+      // Not configured server-side: explain what the lab is instead of a
+      // control surface whose actions would all fail.
+      if (s.status === 'not_configured') {
+        if (badge) { badge.textContent = 'not configured'; badge.style.background = 'var(--muted)'; badge.style.color = 'var(--bg)'; }
+        panel.innerHTML = _nousExplainerCard();
+        return;
+      }
+
       if (badge) {
         badge.textContent = `${modeLabels[mode] || mode} · ${scope}`;
         badge.style.background = modeColors[mode] || 'var(--muted)';
@@ -5094,6 +5133,13 @@ function burnAreaChart() {
       }
 
       let html = '';
+
+      // Fresh lab (no baseline, no experiments, no principles yet):
+      // lead with the explainer so a new hive isn't greeted by bare zeros.
+      const isFreshLab = (s.snapshotCount || 0) === 0 && ledger.length === 0 && principles.length === 0;
+      if (isFreshLab) {
+        html += `<div style="margin-bottom:14px">${_nousExplainerCard()}</div>`;
+      }
 
       // Mode toggle
       html += '<div class="nous-mode-toggle">';
@@ -8516,6 +8562,10 @@ function burnAreaChart() {
 
     function renderInceptionModeSelect() {
       return `
+        <div style="max-width:700px;margin:0 auto 16px">${emptyStateCard('💡', 'Project Inception — bootstrap a project with your hive',
+          'Inception takes a project from raw idea to structured knowledge and a scaffolded repo. ' +
+          'In greenfield mode a brainstorm agent captures your one-line idea, asks clarifying questions, structures the answers into vision, requirements, and constraints (stored as Knowledge Base facts), then scaffolds the project. ' +
+          'In brownfield mode it scans an existing repo and captures its conventions and principles as KB facts instead. Pick a mode below to begin.')}</div>
         <div style="display:flex;gap:16px;max-width:700px;margin:0 auto">
           <div onclick="startInceptionGreenfield()" style="flex:1;background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:24px;cursor:pointer;text-align:center;transition:border-color 0.2s" onmouseover="this.style.borderColor='var(--blue)'" onmouseout="this.style.borderColor='var(--border)'">
             <div style="font-size:2rem;margin-bottom:8px">🌱</div>

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1023,6 +1023,8 @@
     .advisor-row-inactive { opacity: 0.55; }
     .advisor-row-inactive .advisor-agent { color: var(--muted); font-weight: 400; }
     .advisor-inactive-note { flex: 1; color: var(--muted); font-style: italic; font-size: 0.65rem; }
+    /* Actual window burn of agents the projection excludes (on-demand/paused/off). */
+    .advisor-excluded-burn { font-size: 0.68rem; color: var(--muted); margin-top: 2px; }
     .advisor-tips { margin-top: 8px; display: flex; flex-direction: column; gap: 4px; }
     .advisor-tip { font-size: 0.72rem; color: var(--text); padding: 4px 8px; background: color-mix(in srgb, var(--yellow) 8%, transparent); border-left: 2px solid var(--yellow); border-radius: 0 4px 4px 0; }
     /* Agent names inside tips: bold text color only — the tip's yellow
@@ -4593,10 +4595,26 @@
 
       const tipsHtml = tips.length > 0 ? `<div class="advisor-tips">${tips.map(t => `<div class="advisor-tip">💡 ${t}</div>`).join('')}</div>` : '';
 
+      // On-demand/paused/off agents project 0 by cadence — correctly — but
+      // they still burn real tokens when kicked manually. Surface that
+      // actual window burn so the projection's blind spot is visible.
+      const excludedBurn = rows
+        .filter(r => r.isPaused || r.isOff)
+        .reduce((sum, r) => {
+          const d = byAgent[r.name] || {};
+          return sum + (d.input || 0) + (d.output || 0) + (d.cacheRead || 0);
+        }, 0);
+      const DEFAULT_LOOKBACK_HOURS = 24;
+      const lookbackHours = (window._lastStatus?.tokens?.lookbackHours) || DEFAULT_LOOKBACK_HOURS;
+      const excludedHtml = excludedBurn > 0
+        ? `<div class="advisor-excluded-burn">on-demand/manual burn last ${lookbackHours}h: <b>${fmtTokens(excludedBurn)}</b> tokens (excluded from projection)</div>`
+        : '';
+
       return `<div class="advisor-section">
         <div class="advisor-title">Cadence Advisor <span style="color:var(--muted);font-size:0.7rem">weekly projection at current cadence</span></div>
         <div class="advisor-total">Projected: <b>${fmtTokens(totalWeeklyBurn)}</b> tokens/week</div>
         <div class="advisor-bars">${barRows}</div>
+        ${excludedHtml}
         ${tipsHtml}
       </div>`;
     }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3525,16 +3525,21 @@
       const label = escapeHtml(stat.label || stat.key);
       const icon = stat.icon ? escapeHtml(stat.icon) + ' ' : '';
 
+      // Health-check stats carry a desc (what the check verifies) —
+      // surface it as a hover tooltip on the chip.
+      const desc = stat.desc || (stat.source === 'health' && HEALTH_DESC_DEFAULTS[stat.field]) || '';
+      const tipAttr = desc ? ` title="${escapeHtml(desc)}" style="cursor:help"` : '';
+
       if (style === 'dot') {
         const dotCls = v === 1 ? 'ok' : v === 0 ? 'fail' : 'unknown';
-        return `<span class="ind-dot-item"><span class="health-dot ${dotCls}"></span><span class="ind-dlabel">${label}</span></span>`;
+        return `<span class="ind-dot-item"${tipAttr}><span class="health-dot ${dotCls}"></span><span class="ind-dlabel">${label}</span></span>`;
       }
 
       if (style === 'pct') {
         const PCT_GOOD = 90;
         const PCT_WARN = 70;
         const cls = v >= PCT_GOOD ? 'good' : v >= PCT_WARN ? 'warn' : 'bad';
-        return `<span class="ind-dot-item"><span class="health-ci ${cls}">${v || 0}%</span><span class="ind-dlabel">${label}</span></span>`;
+        return `<span class="ind-dot-item"${tipAttr}><span class="health-ci ${cls}">${v || 0}%</span><span class="ind-dlabel">${label}</span></span>`;
       }
 
       if (style === 'pct-bar') {
@@ -8241,6 +8246,38 @@ function burnAreaChart() {
       return labels;
     }
 
+    // One-line explanations of what each health check verifies (mirrors
+    // pkg/github/health.go). Used as tooltip fallback when the stats config
+    // entry carries no desc of its own. The health payload holds only ints,
+    // so no last-run timestamp is available to show.
+    const HEALTH_DESC_DEFAULTS = {
+      ci: 'Pass rate over the last 10 completed workflow runs on the primary repo (success or skipped count as passing)',
+      brew: 'Homebrew tap formula version matches a recent console release tag (stable or nightly, last 20 releases)',
+      helm: 'Helm chart exists at deploy/helm/kubestellar-console/Chart.yaml in the primary repo',
+      nightly: "Most recent 'Nightly Test Suite' workflow run did not fail",
+      nightlyCompliance: "Most recent 'Nightly Compliance & Perf' workflow run did not fail",
+      nightlyDashboard: "Most recent 'Nightly Dashboard Health' workflow run did not fail",
+      nightlyGhaw: "Most recent 'Nightly gh-aw Version Check' workflow run did not fail",
+      nightlyPlaywright: "Most recent 'Playwright Cross-Browser (Nightly)' workflow run did not fail",
+      nightlyRel: "Most recent scheduled weekday 'Release' workflow run succeeded (nightly release; Sundays belong to the weekly release)",
+      weeklyRel: "Most recent scheduled Sunday 'Release' workflow run succeeded (weekly release)",
+      weekly: "Most recent 'Weekly Coverage Review' workflow run did not fail",
+      hourly: 'Latest runs of the perf workflows (React commits per navigation, TTFI gate) did not fail',
+      deploy_vllm_d: "deploy-vllm-d job of the latest completed 'Build and Deploy KC' run on main did not fail",
+      deploy_pok_prod: "deploy-pok-prod job of the latest completed 'Build and Deploy KC' run on main did not fail",
+    };
+    function _buildHealthDescs(agents) {
+      const descs = { ...HEALTH_DESC_DEFAULTS };
+      for (const a of agents || []) {
+        for (const s of a.statsConfig || []) {
+          if (s.source === 'health' && s.field && s.desc) {
+            descs[s.field] = s.desc;
+          }
+        }
+      }
+      return descs;
+    }
+
     // ── Inception section ──
     let _inceptionState = null;
 
@@ -8954,16 +8991,21 @@ function burnAreaChart() {
           .map(s => s.field)
       );
 
+      const HEALTH_DESCS = _buildHealthDescs(agents);
       let healthRows = '';
       for (const [k, v] of Object.entries(health)) {
         if (ciHealthFields.size > 0 && !ciHealthFields.has(k)) continue;
         const label = HEALTH_LABELS[k] || k;
+        const desc = HEALTH_DESCS[k] || '';
+        const labelHtml = desc
+          ? `<span style="cursor:help;text-decoration:underline dotted;text-underline-offset:3px" title="${escapeHtml(desc)}">${label}</span>`
+          : `<span>${label}</span>`;
         const ok = k === 'ci' ? v >= CI_PASS_THRESHOLD : (v === true || v === 1);
         const skip = v === -1;
         const dot = skip ? '⊘' : ok ? '✓' : '✗';
         const color = skip ? 'var(--muted)' : ok ? 'var(--green)' : 'var(--red)';
         const val = k === 'ci' ? `${v}%` : skip ? 'skipped' : ok ? 'ok' : 'fail';
-        healthRows += `<div style="${rowStyle}"><span>${label}</span><span style="color:${color};font-weight:600">${dot} ${val}</span></div>`;
+        healthRows += `<div style="${rowStyle}">${labelHtml}<span style="color:${color};font-weight:600">${dot} ${val}</span></div>`;
       }
 
       const { sorted: sortedForStates, groups: stateGroups } = _sortAgentsBySidebar(agents);

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1404,6 +1404,16 @@
     .chat-raw-details pre { white-space: pre-wrap; word-break: break-all; font-size: 0.65rem; color: var(--muted); margin-top: 4px; max-height: 200px; overflow-y: auto; }
     @media (max-width: 500px) {
       .hive-chat-panel { width: calc(100vw - 32px); right: 16px; bottom: 72px; }
+      /* Phone: the fixed FAB used to sit on top of in-flow controls at the
+         bottom of the page (audit-log Save button, right edge of the last
+         section). Shrink it into the corner and give the body matching
+         bottom clearance so content can always scroll clear of it.
+         Clearance = FAB size (40) + FAB offset (12) + breathing room (12). */
+      .hive-chat-fab { width: 40px; height: 40px; bottom: 12px; right: 12px; font-size: 1.1rem; }
+      body { padding-bottom: 64px; }
+      /* Audit search controls: keep the Save/clear buttons out of the FAB
+         column entirely. Clearance = FAB size (40) + FAB offset (12). */
+      .audit-controls-row { padding-right: 52px; }
     }
 
     /* Strategy Lab (Nous) */
@@ -2257,7 +2267,7 @@
   <div id="audit-section" style="margin-top: 16px; margin-bottom: 24px;">
     <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('audit-section')"><span class="section-chevron">▼</span> 📋 Audit Log</h2>
     <div class="section-body">
-      <div style="margin-bottom:8px;display:flex;align-items:center;gap:8px">
+      <div class="audit-controls-row" style="margin-bottom:8px;display:flex;align-items:center;gap:8px">
         <div style="flex:1;position:relative">
           <input id="audit-search" list="audit-saved-searches" type="text" placeholder="Search audit log... (supports /regex/)" oninput="filterAuditLog()" onkeydown="if(event.key==='Enter')saveAuditSearch()" style="width:100%;padding:6px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.82rem">
           <datalist id="audit-saved-searches"></datalist>

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2771,7 +2771,7 @@
       // The fingerprint guards the fields only the full template renders
       // (method/model/pins): without it a CLI or model switch stayed stale
       // in the focused panel until a hard refresh.
-      const cfgSig = [a.cli || '', a.model || '', a.pinnedCli ? 1 : 0, a.pinnedModel ? 1 : 0, a.pinnedBoth ? 1 : 0].join('|');
+      const cfgSig = [a.cli || '', a.model || '', a.pinnedCli ? 1 : 0, a.pinnedModel ? 1 : 0, a.pinnedBoth ? 1 : 0, a.displayName || '', a.emoji || '', a.color || ''].join('|');
       if (existingSummary && detail.dataset.agent === a.name && detail.dataset.cfgSig === cfgSig) {
         if (a.detailSummary) {
           const newText = escBlock(a.detailSummary);
@@ -12654,8 +12654,34 @@ function burnAreaChart() {
       }
       if (success) {
         showToast('Configuration saved', 'success');
+        // Optimistically reflect agent-level identity fields that render
+        // outside this dialog (sidebar rows, agent cards, token panel,
+        // focused detail header) before the confirming refetch lands —
+        // the same optimistic-update + refetch pattern switchCli/switchModel
+        // use. _lastAgents and _lastStatus.agents share object references,
+        // so one mutation covers every render site.
+        const savedGeneral = dirty.general;
+        const savedAgentUpdate = _configState.type === 'agent' && savedGeneral && Array.isArray(window._lastAgents);
+        if (savedAgentUpdate) {
+          const liveAgent = window._lastAgents.find(x => x.name === _configState.agent);
+          if (liveAgent) {
+            if (savedGeneral.displayName !== undefined) liveAgent.displayName = savedGeneral.displayName;
+            if (savedGeneral.emoji !== undefined) liveAgent.emoji = savedGeneral.emoji;
+            if (savedGeneral.color !== undefined) liveAgent.color = savedGeneral.color;
+            if (savedGeneral.sortOrder !== undefined) liveAgent.sortOrder = savedGeneral.sortOrder;
+          }
+        }
         _configState.dirty = {};
-        closeConfigDialog();
+        closeConfigDialog(); // resets _configState — do not read it below
+        if (savedAgentUpdate) {
+          renderAgents(window._lastAgents);
+          ocUpdateSidebarAgents();
+          injectAgentStyles(window._lastAgents);
+          if (typeof ocRenderAgentDetail === 'function') ocRenderAgentDetail();
+          const lastData = window._lastStatus || {};
+          renderGovernor(lastData.governor || {}, lastData.cadenceMatrix || [], lastData);
+          renderTokens(lastData.tokens || {});
+        }
         fetch('/api/status').then(r => r.json()).then(render).catch(() => {});
       }
     }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5916,9 +5916,9 @@ function burnAreaChart() {
           vx: 0, vy: 0,
           r: GRAPH_NODE_RADIUS_MIN + ratio * (GRAPH_NODE_RADIUS_MAX - GRAPH_NODE_RADIUS_MIN),
           color: layerColors[n.layer] || layerColors.personal,
-          label: (n.title || n.slug).length > GRAPH_LABEL_TRUNCATE_LEN
-            ? (n.title || n.slug).slice(0, GRAPH_LABEL_TRUNCATE_LEN) + '...'
-            : (n.title || n.slug),
+          label: (kbCleanFactTitle(n.title) || n.slug).length > GRAPH_LABEL_TRUNCATE_LEN
+            ? (kbCleanFactTitle(n.title) || n.slug).slice(0, GRAPH_LABEL_TRUNCATE_LEN) + '...'
+            : (kbCleanFactTitle(n.title) || n.slug),
           slug: n.slug,
           data: n,
           pinned: false,
@@ -6085,7 +6085,7 @@ function burnAreaChart() {
           const confPct = Math.round((d.confidence || 0) * 100);
           const tags = (d.tags || []).slice(0, 5).map(t => escapeHtml(t)).join(', ');
           const bodyText = d.body ? escapeHtml(d.body).replace(/\n/g, '<br>') : '';
-          tooltip.innerHTML = `<strong>${escapeHtml(d.title || d.slug)}</strong><br>` +
+          tooltip.innerHTML = `<strong>${escapeHtml(kbCleanFactTitle(d.title) || d.slug)}</strong><br>` +
             `<span style="color:var(--muted)">Type:</span> ${escapeHtml(d.type || 'pattern')} &middot; ` +
             `<span style="color:var(--muted)">Layer:</span> ${escapeHtml(d.layer || 'personal')} &middot; ` +
             `<span style="color:var(--muted)">Confidence:</span> ${confPct}%` +
@@ -6584,17 +6584,40 @@ function burnAreaChart() {
       }
     }
 
+    // Fact hygiene: synthesized/imported facts can carry raw markdown heading
+    // markers in titles ("### Configure build...") or be nothing but a
+    // horizontal-rule line ("--------"). Clean both at render time.
+    const KB_HEADING_MARKER_RE = /^\s*#{1,6}\s+/;   // leading markdown heading syntax
+    const KB_DIVIDER_ONLY_RE = /^[\s\-=_*]+$/;      // content made only of divider chars
+
+    function kbCleanFactTitle(t) {
+      return String(t || '').replace(KB_HEADING_MARKER_RE, '').trim();
+    }
+
+    function kbCleanFactPreview(b) {
+      return String(b || '').replace(KB_HEADING_MARKER_RE, '').trim();
+    }
+
+    function kbIsDividerOnlyFact(f) {
+      const title = String(f.title || '').trim();
+      const body = String(f.body || '').trim();
+      const titleJunk = title === '' || KB_DIVIDER_ONLY_RE.test(title);
+      const bodyJunk = body === '' || KB_DIVIDER_ONLY_RE.test(body);
+      return titleJunk && bodyJunk;
+    }
+
     function renderKnowledgeFacts() {
       const el = document.getElementById('kb-fact-list');
       if (!el) return;
 
-      if (_kbFacts.length === 0) {
+      const visibleFacts = _kbFacts.filter(f => !kbIsDividerOnlyFact(f));
+      if (visibleFacts.length === 0) {
         el.innerHTML = '<div class="kb-empty"><div class="kb-empty-icon">🔍</div>No facts found. Try a different search or layer.</div>';
         return;
       }
 
       let html = '';
-      for (const f of _kbFacts) {
+      for (const f of visibleFacts) {
         const conf = typeof f.confidence === 'number' ? f.confidence : 0;
         const confPct = Math.round(conf * 100);
         const typeClass = 'kb-type-' + (f.type || 'pattern');
@@ -6606,8 +6629,8 @@ function burnAreaChart() {
         html += `<div class="kb-fact-conf-bar"><div class="kb-fact-conf-fill" style="width:${confPct}%;background:${confColor(conf)}"></div></div>`;
         html += '</div>';
         html += '<div class="kb-fact-body">';
-        html += `<div class="kb-fact-title">${escapeHtml(f.title || f.slug || 'Untitled')}</div>`;
-        html += `<div class="kb-fact-snippet">${escapeHtml(f.body || '')}</div>`;
+        html += `<div class="kb-fact-title">${escapeHtml(kbCleanFactTitle(f.title) || f.slug || 'Untitled')}</div>`;
+        html += `<div class="kb-fact-snippet">${escapeHtml(kbCleanFactPreview(f.body))}</div>`;
         html += '<div class="kb-fact-tags">';
         html += `<span class="kb-type-badge ${typeClass}">${escapeHtml(f.type || 'unknown')}</span>`;
         html += `<span class="kb-layer-badge ${layerClass}">${escapeHtml(f.layer || '')}</span>`;
@@ -6627,7 +6650,7 @@ function burnAreaChart() {
       const layerClass = 'kb-layer-' + (f.layer || 'project');
 
       let html = '<div class="kb-detail">';
-      html += `<div class="kb-detail-title">${escapeHtml(f.title || f.slug || 'Untitled')}</div>`;
+      html += `<div class="kb-detail-title">${escapeHtml(kbCleanFactTitle(f.title) || f.slug || 'Untitled')}</div>`;
       html += '<div style="display:flex;gap:6px;margin-bottom:10px">';
       html += `<span class="kb-type-badge ${typeClass}">${escapeHtml(f.type || 'unknown')}</span>`;
       html += `<span class="kb-layer-badge ${layerClass}">${escapeHtml(f.layer || '')}</span>`;
@@ -6658,7 +6681,7 @@ function burnAreaChart() {
       document.querySelectorAll('.kb-fact-item').forEach(item => item.classList.remove('selected'));
       const items = document.querySelectorAll('.kb-fact-item');
       for (const item of items) {
-        if (item.querySelector('.kb-fact-title')?.textContent === (f.title || f.slug)) {
+        if (item.querySelector('.kb-fact-title')?.textContent === (kbCleanFactTitle(f.title) || f.slug)) {
           item.classList.add('selected');
           break;
         }

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -332,6 +332,9 @@ func LoadStatsConfigWithCfg(name string, cfg *config.Config) []any {
 			if s.Target > 0 {
 				entry["target"] = s.Target
 			}
+			if s.Desc != "" {
+				entry["desc"] = s.Desc
+			}
 			result = append(result, entry)
 		}
 		return result
@@ -347,20 +350,23 @@ func defaultStatsConfig(name string) []any {
 			map[string]any{"key": "mergeable", "label": "Mergeable", "source": "status", "field": "mergeableCount", "style": "spark", "trendField": "mergeable"},
 		},
 		"ci-maintainer": {
+			// desc strings explain what each health check verifies (see
+			// pkg/github/health.go); the dashboard renders them as hover
+			// tooltips on the HEALTH CHECKS rows and agent stat chips.
 			map[string]any{"key": "coverage", "label": "Coverage", "source": "agentMetrics", "field": "coverage", "style": "pct-bar", "target": 91},
-			map[string]any{"key": "brew", "label": "Brew", "source": "health", "field": "brew", "style": "dot"},
-			map[string]any{"key": "helm", "label": "Helm", "source": "health", "field": "helm", "style": "dot"},
-			map[string]any{"key": "ci", "label": "CI", "source": "health", "field": "ci", "style": "pct"},
-			map[string]any{"key": "weekly", "label": "Weekly", "source": "health", "field": "weekly", "style": "dot"},
-			map[string]any{"key": "nightly", "label": "Nightly Tests", "source": "health", "field": "nightly", "style": "dot"},
-			map[string]any{"key": "nightlyCompliance", "label": "Compliance", "source": "health", "field": "nightlyCompliance", "style": "dot"},
-			map[string]any{"key": "nightlyDashboard", "label": "Dashboard", "source": "health", "field": "nightlyDashboard", "style": "dot"},
-			map[string]any{"key": "nightlyGhaw", "label": "gh-aw", "source": "health", "field": "nightlyGhaw", "style": "dot"},
-			map[string]any{"key": "nightlyPlaywright", "label": "Playwright", "source": "health", "field": "nightlyPlaywright", "style": "dot"},
-			map[string]any{"key": "nightlyRel", "label": "Nightly Rel", "source": "health", "field": "nightlyRel", "style": "dot"},
-			map[string]any{"key": "weeklyRel", "label": "Weekly Rel", "source": "health", "field": "weeklyRel", "style": "dot"},
-			map[string]any{"key": "deploy_vllm_d", "label": "vLLM-d", "source": "health", "field": "deploy_vllm_d", "style": "dot"},
-			map[string]any{"key": "deploy_pok_prod", "label": "PokProd", "source": "health", "field": "deploy_pok_prod", "style": "dot"},
+			map[string]any{"key": "brew", "label": "Brew", "source": "health", "field": "brew", "style": "dot", "desc": "Homebrew tap formula version matches a recent console release tag (stable or nightly, last 20 releases)"},
+			map[string]any{"key": "helm", "label": "Helm", "source": "health", "field": "helm", "style": "dot", "desc": "Helm chart exists at deploy/helm/kubestellar-console/Chart.yaml in the primary repo"},
+			map[string]any{"key": "ci", "label": "CI", "source": "health", "field": "ci", "style": "pct", "desc": "Pass rate over the last 10 completed workflow runs on the primary repo (success or skipped count as passing)"},
+			map[string]any{"key": "weekly", "label": "Weekly", "source": "health", "field": "weekly", "style": "dot", "desc": "Most recent 'Weekly Coverage Review' workflow run did not fail"},
+			map[string]any{"key": "nightly", "label": "Nightly Tests", "source": "health", "field": "nightly", "style": "dot", "desc": "Most recent 'Nightly Test Suite' workflow run did not fail"},
+			map[string]any{"key": "nightlyCompliance", "label": "Compliance", "source": "health", "field": "nightlyCompliance", "style": "dot", "desc": "Most recent 'Nightly Compliance & Perf' workflow run did not fail"},
+			map[string]any{"key": "nightlyDashboard", "label": "Dashboard", "source": "health", "field": "nightlyDashboard", "style": "dot", "desc": "Most recent 'Nightly Dashboard Health' workflow run did not fail"},
+			map[string]any{"key": "nightlyGhaw", "label": "gh-aw", "source": "health", "field": "nightlyGhaw", "style": "dot", "desc": "Most recent 'Nightly gh-aw Version Check' workflow run did not fail"},
+			map[string]any{"key": "nightlyPlaywright", "label": "Playwright", "source": "health", "field": "nightlyPlaywright", "style": "dot", "desc": "Most recent 'Playwright Cross-Browser (Nightly)' workflow run did not fail"},
+			map[string]any{"key": "nightlyRel", "label": "Nightly Rel", "source": "health", "field": "nightlyRel", "style": "dot", "desc": "Most recent scheduled weekday 'Release' workflow run succeeded (nightly release; Sundays belong to the weekly release)"},
+			map[string]any{"key": "weeklyRel", "label": "Weekly Rel", "source": "health", "field": "weeklyRel", "style": "dot", "desc": "Most recent scheduled Sunday 'Release' workflow run succeeded (weekly release)"},
+			map[string]any{"key": "deploy_vllm_d", "label": "vLLM-d", "source": "health", "field": "deploy_vllm_d", "style": "dot", "desc": "deploy-vllm-d job of the latest completed 'Build and Deploy KC' run on main did not fail"},
+			map[string]any{"key": "deploy_pok_prod", "label": "PokProd", "source": "health", "field": "deploy_pok_prod", "style": "dot", "desc": "deploy-pok-prod job of the latest completed 'Build and Deploy KC' run on main did not fail"},
 		},
 		"outreach": {
 			map[string]any{"key": "stars", "label": "Stars", "source": "agentMetrics", "field": "stars", "style": "spark", "trendField": "stars"},

--- a/v2/pkg/knowledge/docparser.go
+++ b/v2/pkg/knowledge/docparser.go
@@ -231,7 +231,7 @@ func sanitizePDFText(s string) string {
 // extractPageTitle returns the first line if it looks like a heading (short, no
 // trailing period), otherwise "Page N".
 func extractPageTitle(text string, pageNum int) string {
-	firstLine := strings.TrimSpace(strings.SplitN(text, "\n", 2)[0])
+	firstLine := stripHeadingMarkers(strings.SplitN(text, "\n", 2)[0])
 	if firstLine != "" && len(firstLine) <= chunkTitleMaxChars && !strings.HasSuffix(firstLine, ".") {
 		return firstLine
 	}
@@ -401,11 +401,31 @@ func parseRawText(text string) []DocChunk {
 	return chunks
 }
 
+// headingMarkerRe matches leading markdown heading syntax ("# ".."###### ")
+// so auto-extracted titles don't carry raw markdown into fact titles.
+var headingMarkerRe = regexp.MustCompile(`^\s*#{1,6}\s+`)
+
+// dividerOnlyRe matches content made only of divider characters
+// (horizontal rules, setext underlines) and whitespace.
+var dividerOnlyRe = regexp.MustCompile(`^[\s\-=_*]+$`)
+
+// stripHeadingMarkers removes leading markdown heading syntax from a title.
+func stripHeadingMarkers(s string) string {
+	return strings.TrimSpace(headingMarkerRe.ReplaceAllString(s, ""))
+}
+
+// isDividerOnly reports whether the string is empty or made only of divider
+// characters — such content carries no information and should not become a fact.
+func isDividerOnly(s string) bool {
+	s = strings.TrimSpace(s)
+	return s == "" || dividerOnlyRe.MatchString(s)
+}
+
 // extractChunkTitle returns the first sentence (up to chunkTitleMaxChars) or
 // falls back to "Section N".
 func extractChunkTitle(body string, sectionNum int) string {
 	firstLine := strings.SplitN(body, "\n", 2)[0]
-	firstLine = strings.TrimSpace(firstLine)
+	firstLine = stripHeadingMarkers(firstLine)
 
 	// Try first sentence (period-delimited).
 	if idx := strings.Index(firstLine, ". "); idx > 0 && idx < chunkTitleMaxChars {
@@ -472,7 +492,7 @@ func chunksToFacts(chunks []DocChunk, sourceSlug, sourceURL string, sourceDate t
 		summaryBody = summaryBody[:docSummaryMaxChars]
 	}
 	facts = append(facts, ExtractedFact{
-		Title:      "Summary: " + chunks[0].Title,
+		Title:      "Summary: " + stripHeadingMarkers(chunks[0].Title),
 		Body:       summaryBody,
 		Type:       FactReference,
 		Confidence: defaultDocConfidence,
@@ -482,13 +502,17 @@ func chunksToFacts(chunks []DocChunk, sourceSlug, sourceURL string, sourceDate t
 	})
 
 	// Section facts from all chunks (including the first, which may have
-	// content beyond the summary).
+	// content beyond the summary). Divider-only chunks (horizontal rules,
+	// setext underlines) carry no information and are dropped.
 	for _, chunk := range chunks {
 		if len(facts) >= maxFactsPerDocument {
 			break
 		}
+		if isDividerOnly(chunk.Title) && isDividerOnly(chunk.Body) {
+			continue
+		}
 		facts = append(facts, ExtractedFact{
-			Title:      chunk.Title,
+			Title:      stripHeadingMarkers(chunk.Title),
 			Body:       chunk.Body,
 			Type:       FactReference,
 			Confidence: defaultDocConfidence,


### PR DESCRIPTION
Eight spoke-dashboard refinements in two waves, one single-purpose commit each.

## Wave 1 — quick wins

- **370e26b6** fix(dashboard): strip markdown heading markers from fact titles and hide divider-only facts — render-time hygiene in the fact list, detail pane, graph labels/tooltips.
- **38dc2e3b** fix(knowledge): strip heading markers from doc-import titles and drop divider-only chunks — same filter at the docparser ingestion point so junk facts stop being created.
- **69cc000b** fix(dashboard): keep chat FAB clear of audit-log controls at phone widths — smaller corner FAB, body clearance, audit-row right padding; verified zero rect overlap at 390px (Playwright iPhone 12 emulation), both modes.
- **5a220f83** fix(dashboard): agent identity config changes update the UI immediately — generalizes the 277ab7b3 optimistic-update + refetch pattern to display_name/emoji/color/sort_order across sidebar rows, agent cards, token panel, and the focused detail panel (cfgSig now includes identity fields).
- **77689a54** style(dashboard): tokenize cadence-advisor tints, drop cyan agent names in tips — literal rgba blues/yellows become color-mix over palette tokens; tip agent names are bold var(--text) per the banner-contrast principle.

## Wave 2 — medium

- **5ce2e230** feat(dashboard): explain each health check with a hover tooltip — new optional `desc` on StatsDisplayEntry, accurate per-check descriptions in the ci-maintainer defaults (written from pkg/github/health.go), rendered as cursor:help tooltips on HEALTH CHECKS rows and stat chips. No last-run time shown: the health payload carries only ints.
- **d4f4f67a** feat(dashboard): per-agent budget exemption toggles in the Budget config tab — lists agents with tracked burn (new `by_agent` on GET /api/budget-ignore) and an exempt checkbox wired to the existing array form of POST /api/budget-ignore; the bool/global form keeps working.
- **4f95c8db** feat(dashboard): cadence advisor discloses on-demand/manual burn it excludes — one muted line summing excluded agents' actual window burn, rendered only when nonzero.
- **3b93c1f4** feat(dashboard): Contributors-style empty states for Beads, Inception, Strategy Lab — shared emptyStateCard helper, copy written from each feature's implementation.

## Verification

- Every commit: node script-block parse + CSS brace-balance check on index.html
- Go: `go build ./...` clean; budget-ignore and dashboard tests pass (two docsource test failures pre-exist on origin/v2)
- Headless simulations for live-config updates, health tooltips, budget toggles, advisor line, and empty states; screenshots in light + dark
- No class renames; no magic numbers (named constants throughout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)