### PR TITLE
Fix dashboard timeline deferred load

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -10261,7 +10261,7 @@ function burnAreaChart() {
     const TREND_REFRESH_MS = 900000;
     window._timelineData = [];
     function fetchTimeline() {
-      fetch('/api/timeline').then(r => r.json()).then(d => { window._timelineData = d; }).catch(() => {});
+      return fetch('/api/timeline').then(r => r.json()).then(d => { window._timelineData = d; }).catch(() => {});
     }
     const TIMELINE_REFRESH_MS = 60000;
     // ── Configuration Dialog ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- return the /api/timeline fetch promise from etchTimeline
- fixes deferred startup code that calls etchTimeline().then(...)

## Validation
- git diff --check passed locally
- go test ./pkg/dashboard/... is blocked on Windows by unrelated existing syscall build errors: undefined: syscall.Kill and undefined: syscall.Stat_t in pkg/agent
