### PR TITLE
fix(agent): inference-backend reliability chain — consent seeding, consent-aware readiness, re-armed dismissal, post-kick stall watchdog

### DIFF
--- a/v2/pkg/agent/coverage_boost_test.go
+++ b/v2/pkg/agent/coverage_boost_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
 )
@@ -1106,6 +1107,55 @@ Enter to confirm`
 				t.Errorf("paneShowsConsentScreen(%s) = %v, want %v", tc.name, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestDismissConsentIfStuck_GraceAndCooldown(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{
+		"vinf": {Backend: "vllm"},
+	}, discardLogger(), ProjectContext{})
+	m.mu.RLock()
+	agent := m.agents["vinf"]
+	m.mu.RUnlock()
+
+	// First sighting only starts the grace timer.
+	m.dismissConsentIfStuck("vinf")
+	if agent.consentSeenAt.IsZero() {
+		t.Fatal("first sighting should start the grace timer")
+	}
+	if !agent.lastConsentDismiss.IsZero() {
+		t.Fatal("no dismissal should fire within the grace period")
+	}
+
+	// Simulate the screen having been visible past the grace period.
+	agent.consentSeenAt = time.Now().Add(-consentStuckGracePeriod - time.Second)
+	m.dismissConsentIfStuck("vinf")
+	if agent.lastConsentDismiss.IsZero() {
+		t.Fatal("dismissal should fire once past the grace period")
+	}
+	first := agent.lastConsentDismiss
+
+	// Cooldown: an immediate re-check must not re-fire.
+	m.dismissConsentIfStuck("vinf")
+	if !agent.lastConsentDismiss.Equal(first) {
+		t.Fatal("cooldown should prevent immediate re-dismissal")
+	}
+
+	// A pane without a consent screen resets the grace timer.
+	m.clearConsentTracking("vinf")
+	if !agent.consentSeenAt.IsZero() {
+		t.Fatal("clearConsentTracking should reset consentSeenAt")
+	}
+}
+
+func TestEffectiveBackend(t *testing.T) {
+	agent := &AgentProcess{Config: config.AgentConfig{Backend: "copilot"}}
+	if got := effectiveBackend(agent); got != "copilot" {
+		t.Errorf("effectiveBackend = %q, want copilot", got)
+	}
+	agent.BackendOverride = "vllm"
+	if got := effectiveBackend(agent); got != "vllm" {
+		t.Errorf("effectiveBackend with override = %q, want vllm", got)
 	}
 }
 

--- a/v2/pkg/agent/coverage_boost_test.go
+++ b/v2/pkg/agent/coverage_boost_test.go
@@ -726,8 +726,22 @@ func TestEnsureClaudeSettings_CreatesFiles(t *testing.T) {
 
 	// Check .claude.json user config
 	userConfig := filepath.Join(testHomePath, ".claude.json")
-	if _, err := os.Stat(userConfig); err != nil {
-		t.Errorf("user config not created: %v", err)
+	userData, err := os.ReadFile(userConfig)
+	if err != nil {
+		t.Fatalf("user config not created: %v", err)
+	}
+	var userParsed map[string]interface{}
+	if err := json.Unmarshal(userData, &userParsed); err != nil {
+		t.Fatalf("user config invalid JSON: %v", err)
+	}
+	if userParsed["hasCompletedOnboarding"] != true {
+		t.Error("user config hasCompletedOnboarding should be true")
+	}
+	if userParsed["bypassPermissionsModeAccepted"] != true {
+		t.Error("user config bypassPermissionsModeAccepted should be true")
+	}
+	if _, ok := userParsed["customApiKeyResponses"]; !ok {
+		t.Error("user config should include customApiKeyResponses")
 	}
 }
 
@@ -742,6 +756,80 @@ func TestEnsureClaudeSettings_Idempotent(t *testing.T) {
 	settingsFile := filepath.Join(idempotentHomePath, ".claude", "settings.json")
 	if _, err := os.Stat(settingsFile); err != nil {
 		t.Errorf("settings should still exist: %v", err)
+	}
+}
+
+func TestSeedClaudeUserConfig_RepairsMissingKeys(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude.json")
+
+	// Simulate a seed from an older hive version: no bypassPermissionsModeAccepted,
+	// plus a CLI-written key that must be preserved.
+	old := `{"hasCompletedOnboarding":true,"someCliKey":"keep-me"}`
+	if err := os.WriteFile(path, []byte(old), 0o666); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	m.seedClaudeUserConfig("repair-agent", path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid JSON after repair: %v", err)
+	}
+	if parsed["bypassPermissionsModeAccepted"] != true {
+		t.Error("bypassPermissionsModeAccepted should be merged in")
+	}
+	if parsed["someCliKey"] != "keep-me" {
+		t.Error("existing keys should be preserved on repair")
+	}
+}
+
+func TestSeedClaudeUserConfig_RewritesCorruptFile(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o666); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	m.seedClaudeUserConfig("corrupt-agent", path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("corrupt file should be rewritten as valid JSON: %v", err)
+	}
+	if parsed["bypassPermissionsModeAccepted"] != true {
+		t.Error("bypassPermissionsModeAccepted should be true after rewrite")
+	}
+}
+
+func TestSeedClaudeUserConfig_CompleteFileUntouched(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude.json")
+
+	m.seedClaudeUserConfig("complete-agent", path)
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after seed: %v", err)
+	}
+
+	m.seedClaudeUserConfig("complete-agent", path)
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after reseed: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Error("complete config should not be rewritten")
 	}
 }
 

--- a/v2/pkg/agent/coverage_boost_test.go
+++ b/v2/pkg/agent/coverage_boost_test.go
@@ -1148,6 +1148,78 @@ func TestDismissConsentIfStuck_GraceAndCooldown(t *testing.T) {
 	}
 }
 
+func TestNudgeIfKickStalled(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{
+		"vinf": {Backend: "vllm"},
+	}, discardLogger(), ProjectContext{})
+	m.mu.RLock()
+	agent := m.agents["vinf"]
+	m.mu.RUnlock()
+
+	idlePane := "╭───╮\n│ ❯ │\n╰───╯\n? for shortcuts"
+
+	// No kick recorded — never nudges.
+	m.nudgeIfKickStalled("vinf", idlePane)
+	if agent.StallNudges != 0 {
+		t.Fatal("no nudge without a recorded kick")
+	}
+
+	// Kick recorded but timeout not elapsed — no nudge.
+	agent.lastInferKickAt = time.Now()
+	agent.lastInferKickPane = paneContentHash(idlePane)
+	agent.stallNudgeSent = false
+	m.nudgeIfKickStalled("vinf", idlePane)
+	if agent.StallNudges != 0 {
+		t.Fatal("no nudge before the stall timeout")
+	}
+
+	// Timeout elapsed, pane unchanged, idle prompt — exactly one nudge.
+	agent.lastInferKickAt = time.Now().Add(-inferenceKickStallTimeout - time.Minute)
+	m.nudgeIfKickStalled("vinf", idlePane)
+	if agent.StallNudges != 1 || !agent.stallNudgeSent {
+		t.Fatalf("expected one nudge, got %d (sent=%v)", agent.StallNudges, agent.stallNudgeSent)
+	}
+
+	// Second watcher pass: still max one nudge per kick.
+	m.nudgeIfKickStalled("vinf", idlePane)
+	if agent.StallNudges != 1 {
+		t.Fatalf("max one nudge per kick, got %d", agent.StallNudges)
+	}
+
+	// New kick re-arms, but a working pane is never nudged.
+	workingPane := idlePane + "\nesc to interrupt"
+	agent.lastInferKickAt = time.Now().Add(-inferenceKickStallTimeout - time.Minute)
+	agent.lastInferKickPane = paneContentHash(workingPane)
+	agent.stallNudgeSent = false
+	m.nudgeIfKickStalled("vinf", workingPane)
+	if agent.StallNudges != 1 {
+		t.Fatal("working pane must not be nudged")
+	}
+
+	// A pane change since the kick disarms the watchdog.
+	agent.lastInferKickPane = paneContentHash("what the pane looked like at kick time")
+	m.nudgeIfKickStalled("vinf", idlePane)
+	if agent.StallNudges != 1 {
+		t.Fatal("changed pane must not be nudged")
+	}
+	if agent.lastInferKickPane != "" {
+		t.Fatal("changed pane should disarm the watchdog")
+	}
+}
+
+func TestPaneContentHash_StableAndDistinct(t *testing.T) {
+	a := paneContentHash("pane content")
+	if a != paneContentHash("pane content") {
+		t.Error("hash should be stable")
+	}
+	if a == paneContentHash("other content") {
+		t.Error("different content should hash differently")
+	}
+	if len(a) != 16 {
+		t.Errorf("hash should be 16 hex chars, got %d", len(a))
+	}
+}
+
 func TestEffectiveBackend(t *testing.T) {
 	agent := &AgentProcess{Config: config.AgentConfig{Backend: "copilot"}}
 	if got := effectiveBackend(agent); got != "copilot" {

--- a/v2/pkg/agent/coverage_boost_test.go
+++ b/v2/pkg/agent/coverage_boost_test.go
@@ -1057,6 +1057,71 @@ func TestCliPaneMarkers_HasExpectedEntries(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// paneShowsConsentScreen
+// ---------------------------------------------------------------------------
+
+func TestPaneShowsConsentScreen(t *testing.T) {
+	bypassConsent := `WARNING: Claude Code running in Bypass Permissions mode
+
+In Bypass Permissions mode, Claude Code will not ask for your approval before running potentially dangerous commands.
+
+ ❯ 1. No, exit
+   2. Yes, I accept
+
+Enter to confirm · Esc to exit`
+
+	genericSelection := `Do you trust the files in this folder?
+
+ ❯ 1. Yes, proceed
+   2. No, exit
+
+Enter to confirm`
+
+	readyPane := `╭──────────────────────────╮
+│ ❯                        │
+╰──────────────────────────╯
+  ? for shortcuts`
+
+	workingPane := `Thinking...
+(esc to interrupt)
+❯ 1. No, exit
+Enter to confirm`
+
+	cases := []struct {
+		name string
+		pane string
+		want bool
+	}{
+		{"empty pane", "", false},
+		{"bypass permissions consent", bypassConsent, true},
+		{"generic selection with confirm footer", genericSelection, true},
+		{"ready input prompt", readyPane, false},
+		{"working state is never consent", workingPane, false},
+		{"bare bash", "dev@hive:~$ ", false},
+		{"confirm footer without selection", "Enter to confirm something in output", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := paneShowsConsentScreen(tc.pane); got != tc.want {
+				t.Errorf("paneShowsConsentScreen(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPaneHasCLIMarker(t *testing.T) {
+	if paneHasCLIMarker("") {
+		t.Error("empty pane should have no CLI marker")
+	}
+	if paneHasCLIMarker("dev@hive:~$ ls\n-bash: NEVER: command not found") {
+		t.Error("bare bash pane should have no CLI marker")
+	}
+	if !paneHasCLIMarker("❯ ") {
+		t.Error("input prompt marker should match")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // loginPromptPatterns — verify
 // ---------------------------------------------------------------------------
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -83,6 +84,10 @@ type AgentProcess struct {
 	NeedsLogin          bool   // true when pane shows a login prompt
 	consentSeenAt       time.Time // watcher: when a consent screen was first seen in the pane
 	lastConsentDismiss  time.Time // watcher: cooldown for re-running dismissInferencePrompts
+	lastInferKickAt     time.Time // stall watchdog: when the last kick was delivered to an inference agent
+	lastInferKickPane   string    // stall watchdog: hash of the visible pane just after kick delivery
+	stallNudgeSent      bool      // stall watchdog: at most one nudge per kick
+	StallNudges         int       // total post-kick stall nudges sent (surfaced to the dashboard)
 }
 
 // effectiveBackend returns the agent's backend accounting for any override.
@@ -1622,6 +1627,13 @@ func (m *Manager) RemoveAgent(name string) {
 	m.logger.Info("audit: agent removed", "name", name, "id", agent.ID)
 }
 
+// inferencePaneCheck pairs an inference agent name with its captured visible
+// pane for post-kick stall inspection outside the manager read lock.
+type inferencePaneCheck struct {
+	name string
+	pane string
+}
+
 // CheckAndRestartCrashedAgents checks all running agents for crashed CLI
 // processes (bare shell prompt with no child process) and restarts them.
 // Returns the names of agents that were successfully restarted so the
@@ -1630,6 +1642,7 @@ func (m *Manager) CheckAndRestartCrashedAgents(ctx context.Context) []string {
 	m.mu.RLock()
 	var crashed []string
 	var consentStuck, consentCleared []string
+	var stallChecks []inferencePaneCheck
 	for name, agent := range m.agents {
 		if agent.State != StateRunning {
 			continue
@@ -1675,8 +1688,11 @@ func (m *Manager) CheckAndRestartCrashedAgents(ctx context.Context) []string {
 		if IsInferenceBackend(effectiveBackend(agent)) {
 			if paneShowsConsentScreen(pane) {
 				consentStuck = append(consentStuck, name)
-			} else if !agent.consentSeenAt.IsZero() {
-				consentCleared = append(consentCleared, name)
+			} else {
+				if !agent.consentSeenAt.IsZero() {
+					consentCleared = append(consentCleared, name)
+				}
+				stallChecks = append(stallChecks, inferencePaneCheck{name: name, pane: pane})
 			}
 		}
 	}
@@ -1687,6 +1703,9 @@ func (m *Manager) CheckAndRestartCrashedAgents(ctx context.Context) []string {
 	}
 	for _, name := range consentStuck {
 		m.dismissConsentIfStuck(name)
+	}
+	for _, check := range stallChecks {
+		m.nudgeIfKickStalled(check.name, check.pane)
 	}
 
 	var restarted []string
@@ -1805,6 +1824,13 @@ func (m *Manager) SendKick(name string, message string) error {
 	agent.LastKickMessage = message
 	agent.KickRefused = false
 	agent.KickRefusalReason = ""
+
+	// Arm the post-kick stall watchdog for inference agents: if the pane
+	// never changes after this kick and sits at an idle prompt, the watcher
+	// loop sends a single "continue" nudge.
+	if IsInferenceBackend(effectiveBackend(agent)) {
+		m.recordInferenceKick(agent, now)
+	}
 
 	snippet := message
 	const maxSnippetLen = 120
@@ -1971,6 +1997,77 @@ func (m *Manager) dismissConsentIfStuck(name string) {
 	go m.dismissInferencePrompts(agent)
 }
 
+const (
+	// inferenceKickStallTimeout is how long after a kick an unchanged, idle
+	// pane counts as a stalled kick (message swallowed without a response).
+	inferenceKickStallTimeout = 5 * time.Minute
+	// inferenceStallNudgeMessage is the literal message typed into the CLI to
+	// unstick a stalled kick.
+	inferenceStallNudgeMessage = "continue"
+	// cliInputPromptMarker is the CLI's idle input prompt indicator.
+	cliInputPromptMarker = "❯"
+)
+
+// paneContentHash returns a short stable hash of pane content, used to detect
+// whether a pane has changed since a kick was delivered.
+func paneContentHash(pane string) string {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(pane))
+	return fmt.Sprintf("%016x", h.Sum64())
+}
+
+// recordInferenceKick arms the post-kick stall watchdog for an inference
+// agent: remembers when the kick was delivered and what the pane looked like
+// right after delivery. Caller must hold m.mu.
+func (m *Manager) recordInferenceKick(agent *AgentProcess, at time.Time) {
+	agent.lastInferKickAt = at
+	agent.lastInferKickPane = paneContentHash(m.captureVisiblePaneForAgent(agent))
+	agent.stallNudgeSent = false
+}
+
+// nudgeIfKickStalled sends a single "continue" nudge to an inference agent
+// whose pane has not changed since the last kick was delivered, the stall
+// timeout has elapsed, and the pane shows an idle input prompt (a working CLI
+// shows cliWorkingMarker and is left alone). Any pane change since the kick
+// disarms the watchdog — the CLI consumed the message. At most one nudge is
+// sent per kick; the total is surfaced on the agent snapshot as StallNudges.
+func (m *Manager) nudgeIfKickStalled(name, pane string) {
+	now := time.Now()
+	m.mu.Lock()
+	agent, ok := m.agents[name]
+	if !ok || agent.stallNudgeSent || agent.lastInferKickAt.IsZero() || agent.lastInferKickPane == "" {
+		m.mu.Unlock()
+		return
+	}
+	sinceKick := now.Sub(agent.lastInferKickAt)
+	if sinceKick < inferenceKickStallTimeout {
+		m.mu.Unlock()
+		return
+	}
+	if paneContentHash(pane) != agent.lastInferKickPane {
+		// The pane moved since the kick — the CLI consumed it. Disarm.
+		agent.lastInferKickPane = ""
+		m.mu.Unlock()
+		return
+	}
+	if strings.Contains(pane, cliWorkingMarker) || !strings.Contains(pane, cliInputPromptMarker) {
+		m.mu.Unlock()
+		return
+	}
+	agent.stallNudgeSent = true
+	agent.StallNudges++
+	totalNudges := agent.StallNudges
+	m.mu.Unlock()
+
+	m.logger.Warn("inference agent stalled after kick, sending continue nudge",
+		"name", name,
+		"minutes_since_kick", int(sinceKick.Minutes()),
+		"total_nudges", totalNudges)
+	m.tmuxSendLiteralForAgent(agent, inferenceStallNudgeMessage)
+	time.Sleep(textToEnterDelay)
+	m.tmuxSendEntersForAgent(agent)
+}
+
 // tmuxSendEntersForAgent sends Enter presses using the agent's tmux socket.
 func (m *Manager) tmuxSendEntersForAgent(agent *AgentProcess) {
 	for i := 0; i < enterCount; i++ {
@@ -2076,6 +2173,7 @@ func (a *AgentProcess) snapshot() AgentProcess {
 		KickHistory:     history,
 		LastKickMessage: a.LastKickMessage,
 		NeedsLogin:      needsLogin,
+		StallNudges:     a.StallNudges,
 		HasLaunched:     a.HasLaunched,
 		LaunchedMode:    a.LaunchedMode,
 		tmuxSession:     a.tmuxSession,

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -2432,11 +2432,81 @@ func inferenceHomePath(agentName string) string {
 	return claudeInferenceHomePrefix + agentName
 }
 
+// inferenceConfigMigrationVersion matches the Claude CLI internal config
+// migration version so the CLI skips first-run migration prompts.
+const inferenceConfigMigrationVersion = 13
+
+// inferenceUserConfigSeed returns the required top-level keys for an inference
+// agent's ~/.claude.json. These skip the first-run setup (onboarding,
+// migrations), pre-approve the per-agent inference API key, and pre-accept
+// the "Bypass Permissions mode" consent screen.
+//
+// The key name "bypassPermissionsModeAccepted" is verified against Claude CLI
+// v2.1.204: the binary reads it from the .claude.json config accessor and its
+// own sandbox-setup path seeds the same key. Without it every launch with
+// --dangerously-skip-permissions shows a consent menu whose default selection
+// is "No, exit" — if dismissal loses the race, the CLI exits and the pane
+// degrades to bare bash.
+func inferenceUserConfigSeed(agentName string) map[string]any {
+	apiKey := "sk-hive-" + agentName
+	return map[string]any{
+		"hasCompletedOnboarding":        true,
+		"opusProMigrationComplete":      true,
+		"sonnet1m45MigrationComplete":   true,
+		"migrationVersion":              inferenceConfigMigrationVersion,
+		"bypassPermissionsModeAccepted": true,
+		"customApiKeyResponses": map[string]any{
+			"approved": []string{apiKey},
+			"rejected": []string{},
+		},
+	}
+}
+
+// seedClaudeUserConfig writes or repairs the inference agent's .claude.json.
+// Unlike a plain exists-check, this merges required keys into an existing
+// file that is missing some of them (e.g. seeded by an older hive version
+// without bypassPermissionsModeAccepted) and rewrites a file that fails to
+// parse. A complete, parseable file is left untouched.
+func (m *Manager) seedClaudeUserConfig(agentName, path string) {
+	existing := map[string]any{}
+	if data, err := os.ReadFile(path); err == nil {
+		if jsonErr := json.Unmarshal(data, &existing); jsonErr != nil {
+			m.logger.Warn("inference .claude.json unparseable, rewriting",
+				"agent", agentName, "path", path, "error", jsonErr)
+			existing = map[string]any{}
+		}
+	}
+
+	needsWrite := false
+	for key, value := range inferenceUserConfigSeed(agentName) {
+		if _, ok := existing[key]; !ok {
+			existing[key] = value
+			needsWrite = true
+		}
+	}
+	if !needsWrite {
+		return
+	}
+
+	data, err := json.Marshal(existing)
+	if err != nil {
+		m.logger.Warn("failed to marshal inference .claude.json", "agent", agentName, "error", err)
+		return
+	}
+	if err := os.WriteFile(path, data, 0o666); err != nil {
+		m.logger.Warn("failed to write inference .claude.json", "agent", agentName, "error", err)
+	}
+}
+
 // ensureClaudeSettings creates a per-agent writable HOME directory for inference
 // agents with pre-populated .claude/settings.json. Each agent gets its own dir
 // to avoid cross-agent permission conflicts when Claude Code creates session
 // files. Directories use 0o777 so the agent UID can create subdirs freely
 // (hive runs as dev, not root, so chown is not available).
+//
+// The .claude.json seed is repaired on every call (missing keys merged in,
+// corrupt files rewritten) so agents launched by older hive versions pick up
+// newly required keys instead of being skipped by an exists-check.
 func (m *Manager) ensureClaudeSettings(agentName string, uid int) {
 	homePath := inferenceHomePath(agentName)
 	settingsDir := filepath.Join(homePath, ".claude")
@@ -2444,27 +2514,22 @@ func (m *Manager) ensureClaudeSettings(agentName string, uid int) {
 
 	settings := `{"permissions":{"allow":[],"deny":[]},"hasCompletedOnboarding":true,"bypassPermissions":true,"hasAcknowledgedDisclaimer":true}`
 
-	if _, err := os.Stat(settingsFile); err == nil {
-		m.ensureWorldWritable(homePath)
-		return
-	}
 	if err := os.MkdirAll(settingsDir, 0o777); err != nil {
 		m.logger.Warn("failed to create claude inference home", "agent", agentName, "error", err)
 		return
 	}
-	if err := os.WriteFile(settingsFile, []byte(settings), 0o666); err != nil {
-		m.logger.Warn("failed to write claude settings", "agent", agentName, "error", err)
+	if _, err := os.Stat(settingsFile); err != nil {
+		if err := os.WriteFile(settingsFile, []byte(settings), 0o666); err != nil {
+			m.logger.Warn("failed to write claude settings", "agent", agentName, "error", err)
+		}
 	}
 	// Also write the standalone settings file for --settings flag
-	_ = os.WriteFile(claudeInferenceSettingsPath, []byte(settings), 0o666)
-	// Pre-populate .claude.json to skip first-run setup (GrowthBook, migrations)
-	// and pre-approve the inference API key so the CLI sends tools immediately.
-	userConfig := filepath.Join(homePath, ".claude.json")
-	if _, err := os.Stat(userConfig); err != nil {
-		apiKey := "sk-hive-" + agentName
-		cfg := fmt.Sprintf(`{"hasCompletedOnboarding":true,"opusProMigrationComplete":true,"sonnet1m45MigrationComplete":true,"migrationVersion":13,"customApiKeyResponses":{"approved":[%q],"rejected":[]}}`, apiKey)
-		_ = os.WriteFile(userConfig, []byte(cfg), 0o666)
+	if _, err := os.Stat(claudeInferenceSettingsPath); err != nil {
+		_ = os.WriteFile(claudeInferenceSettingsPath, []byte(settings), 0o666)
 	}
+	// Pre-populate (or repair) .claude.json so the CLI skips first-run setup
+	// and interactive consent screens entirely.
+	m.seedClaudeUserConfig(agentName, filepath.Join(homePath, ".claude.json"))
 	m.ensureWorldWritable(homePath)
 }
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -81,6 +81,16 @@ type AgentProcess struct {
 	LastError           string // captured from bare copilot diagnostic launch
 	lastTokenRestart    time.Time // cooldown for auto-restart after token detection
 	NeedsLogin          bool   // true when pane shows a login prompt
+	consentSeenAt       time.Time // watcher: when a consent screen was first seen in the pane
+	lastConsentDismiss  time.Time // watcher: cooldown for re-running dismissInferencePrompts
+}
+
+// effectiveBackend returns the agent's backend accounting for any override.
+func effectiveBackend(agent *AgentProcess) string {
+	if agent.BackendOverride != "" {
+		return agent.BackendOverride
+	}
+	return agent.Config.Backend
 }
 
 // ProjectContext holds project-level config injected into agent boot prompts.
@@ -729,6 +739,13 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 
 		if backend == "copilot" {
 			go m.watchForTrustPromptForAgent(agent, agentCtx)
+		}
+		if isInference {
+			// The surviving pane may be parked on a consent screen (e.g.
+			// the hub restarted while the CLI awaited consent). The marker
+			// check above cannot tell the difference, so re-arm dismissal;
+			// it exits quickly once the main prompt is visible.
+			go m.dismissInferencePrompts(agent)
 		}
 		return nil
 	}
@@ -1612,6 +1629,7 @@ func (m *Manager) RemoveAgent(name string) {
 func (m *Manager) CheckAndRestartCrashedAgents(ctx context.Context) []string {
 	m.mu.RLock()
 	var crashed []string
+	var consentStuck, consentCleared []string
 	for name, agent := range m.agents {
 		if agent.State != StateRunning {
 			continue
@@ -1636,7 +1654,8 @@ func (m *Manager) CheckAndRestartCrashedAgents(ctx context.Context) []string {
 			crashed = append(crashed, name)
 			continue
 		}
-		if !m.tmuxPaneHasCLIForAgent(agent) {
+		pane := m.captureVisiblePaneForAgent(agent)
+		if !paneHasCLIMarker(pane) {
 			var uptimeSeconds float64
 			if agent.StartedAt != nil {
 				uptimeSeconds = time.Since(*agent.StartedAt).Seconds()
@@ -1648,9 +1667,27 @@ func (m *Manager) CheckAndRestartCrashedAgents(ctx context.Context) []string {
 				"uptime_seconds", int(uptimeSeconds),
 			)
 			crashed = append(crashed, name)
+			continue
+		}
+		// An inference agent parked on a consent screen has a live CLI, so
+		// it is not "crashed" — but it is stuck. Restarting would loop back
+		// to the same screen; re-running prompt dismissal recovers it.
+		if IsInferenceBackend(effectiveBackend(agent)) {
+			if paneShowsConsentScreen(pane) {
+				consentStuck = append(consentStuck, name)
+			} else if !agent.consentSeenAt.IsZero() {
+				consentCleared = append(consentCleared, name)
+			}
 		}
 	}
 	m.mu.RUnlock()
+
+	for _, name := range consentCleared {
+		m.clearConsentTracking(name)
+	}
+	for _, name := range consentStuck {
+		m.dismissConsentIfStuck(name)
+	}
 
 	var restarted []string
 	for _, name := range crashed {
@@ -1878,6 +1915,60 @@ func (m *Manager) dismissInferencePrompts(agent *AgentProcess) {
 	}
 
 	m.logger.Warn("inference prompt dismissal timed out", "agent", agent.Name)
+}
+
+const (
+	// consentStuckGracePeriod is how long a consent screen must stay visible
+	// across watcher passes before the agent counts as stuck. The launch-time
+	// dismissal goroutine runs for 60s, so a screen still visible this long
+	// after first being seen by the watcher means dismissal lost the race.
+	consentStuckGracePeriod = 30 * time.Second
+	// consentDismissCooldown is the minimum interval between watcher-triggered
+	// dismissal passes for one agent, so a stubborn screen can't spam
+	// keystroke goroutines (each dismissal pass itself polls for 60s).
+	consentDismissCooldown = 2 * time.Minute
+)
+
+// clearConsentTracking resets the consent-stuck timer for an agent whose pane
+// no longer shows a consent screen.
+func (m *Manager) clearConsentTracking(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if agent, ok := m.agents[name]; ok {
+		agent.consentSeenAt = time.Time{}
+	}
+}
+
+// dismissConsentIfStuck re-runs dismissInferencePrompts for an inference agent
+// whose pane has shown a consent screen for longer than the grace period,
+// subject to a per-agent cooldown. Called from the watcher loop
+// (CheckAndRestartCrashedAgents) so an agent that lands on a consent screen
+// after launch — e.g. a crash-recovery restart whose launch-time dismissal
+// timed out — recovers instead of sitting stuck while kicks appear to succeed.
+func (m *Manager) dismissConsentIfStuck(name string) {
+	now := time.Now()
+	m.mu.Lock()
+	agent, ok := m.agents[name]
+	if !ok {
+		m.mu.Unlock()
+		return
+	}
+	if agent.consentSeenAt.IsZero() {
+		agent.consentSeenAt = now
+		m.mu.Unlock()
+		return
+	}
+	stuckFor := now.Sub(agent.consentSeenAt)
+	if stuckFor < consentStuckGracePeriod || now.Sub(agent.lastConsentDismiss) < consentDismissCooldown {
+		m.mu.Unlock()
+		return
+	}
+	agent.lastConsentDismiss = now
+	m.mu.Unlock()
+
+	m.logger.Warn("inference agent stuck on consent screen, re-running prompt dismissal",
+		"name", name, "stuck_seconds", int(stuckFor.Seconds()))
+	go m.dismissInferencePrompts(agent)
 }
 
 // tmuxSendEntersForAgent sends Enter presses using the agent's tmux socket.

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -479,10 +479,9 @@ var cliPaneMarkers = []string{
 	"goose",
 }
 
-// tmuxPaneHasCLI reports whether a CLI is running in the pane by inspecting
-// the visible pane content for known CLI UI markers.
-func (m *Manager) tmuxPaneHasCLI(session string) bool {
-	output := m.captureTmuxPane(session)
+// paneHasCLIMarker reports whether the given pane content contains any known
+// CLI UI marker.
+func paneHasCLIMarker(output string) bool {
 	if output == "" {
 		return false
 	}
@@ -494,16 +493,54 @@ func (m *Manager) tmuxPaneHasCLI(session string) bool {
 	return false
 }
 
+// tmuxPaneHasCLI reports whether a CLI is running in the pane by inspecting
+// the visible pane content for known CLI UI markers.
+func (m *Manager) tmuxPaneHasCLI(session string) bool {
+	return paneHasCLIMarker(m.captureTmuxPane(session))
+}
+
 // tmuxPaneHasCLIForAgent checks for CLI markers using the agent's tmux socket.
 // Uses visible pane only (no scrollback) to avoid false positives from stale
 // markers left in scroll history after a CLI exits.
 func (m *Manager) tmuxPaneHasCLIForAgent(agent *AgentProcess) bool {
-	output := m.captureVisiblePaneForAgent(agent)
-	if output == "" {
+	return paneHasCLIMarker(m.captureVisiblePaneForAgent(agent))
+}
+
+const (
+	// consentConfirmFooter appears at the bottom of Claude Code interactive
+	// selection screens (consent dialogs, settings-error menus).
+	consentConfirmFooter = "Enter to confirm"
+	// bypassConsentTitle is the heading of the --dangerously-skip-permissions
+	// consent screen. Its default selection is "No, exit" — confirming it
+	// terminates the CLI and leaves a bare bash pane.
+	bypassConsentTitle = "Bypass Permissions mode"
+	// bypassConsentDefaultOption is the default (negative) option on the
+	// bypass-permissions consent screen.
+	bypassConsentDefaultOption = "No, exit"
+	// cliWorkingMarker is shown while Claude Code is actively processing a
+	// request; a pane in this state is never a consent screen.
+	cliWorkingMarker = "esc to interrupt"
+)
+
+// paneShowsConsentScreen reports whether the pane is showing an interactive
+// consent/selection screen rather than a ready CLI input prompt. Such screens
+// contain a "❯"-selected menu option (e.g. "❯ 1. No, exit"), so they satisfy
+// marker-based CLI presence checks ("❯" is also a cliPaneMarkers entry) — a
+// kick typed into one is consumed by the menu, or by bash once the default
+// "No, exit" selection terminates the CLI. Callers should pass the visible
+// pane only (no scrollback): dismissed consent screens linger in history.
+func paneShowsConsentScreen(pane string) bool {
+	if pane == "" || strings.Contains(pane, cliWorkingMarker) {
 		return false
 	}
-	for _, marker := range cliPaneMarkers {
-		if strings.Contains(output, marker) {
+	if strings.Contains(pane, bypassConsentTitle) && strings.Contains(pane, bypassConsentDefaultOption) {
+		return true
+	}
+	if !strings.Contains(pane, consentConfirmFooter) {
+		return false
+	}
+	for _, line := range strings.Split(pane, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "❯") {
 			return true
 		}
 	}
@@ -1406,6 +1443,13 @@ func (m *Manager) waitForInputPromptForAgent(agent *AgentProcess) bool {
 				"head_500", truncateHead(output, 500), "tail_500", truncateTail(output, 500))
 			return false
 		case <-ticker.C:
+			// A consent/selection screen also contains "❯" but is NOT a
+			// ready input prompt — sending a kick there feeds the menu.
+			// Check the visible pane only: a dismissed consent screen
+			// lingers in the scrollback that captureTmuxPaneForAgent sees.
+			if paneShowsConsentScreen(m.captureVisiblePaneForAgent(agent)) {
+				continue
+			}
 			output := m.captureTmuxPaneForAgent(agent)
 			if strings.Contains(output, "❯") || strings.Contains(output, "goose is ready") || strings.Contains(output, "> Enter to send") || strings.Contains(output, "\n>\n") {
 				return true
@@ -1645,9 +1689,15 @@ func (m *Manager) SendKick(name string, message string) error {
 		return fmt.Errorf("tmux session %s not found", agent.tmuxSession)
 	}
 
-	// Detect crashed CLI and restart before sending kick
-	if !m.tmuxPaneHasCLIForAgent(agent) {
-		m.logger.Warn("agent CLI crashed, restarting before kick", "name", name)
+	// Detect a crashed CLI (bare shell) or a CLI stuck on a consent screen
+	// and restart before sending the kick. A consent pane contains "❯" so it
+	// passes the marker check, but a kick typed into it is consumed by the
+	// menu — or by bash once the default "No, exit" selection exits the CLI
+	// (observed live: "-bash: NEVER: command not found").
+	pane := m.captureVisiblePaneForAgent(agent)
+	if !paneHasCLIMarker(pane) || paneShowsConsentScreen(pane) {
+		m.logger.Warn("agent CLI crashed or stuck on consent screen, restarting before kick",
+			"name", name, "consent_screen", paneShowsConsentScreen(pane))
 		m.mu.Unlock()
 		if err := m.Restart(context.Background(), name); err != nil {
 			m.mu.Lock()

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -204,6 +204,7 @@ type FrontendAgent struct {
 	ProxyViolations  int    `json:"proxyViolations"`
 	OnDemand         bool   `json:"onDemand,omitempty"`
 	LastError        string `json:"lastError,omitempty"`
+	StallNudges      int    `json:"stallNudges,omitempty"`
 }
 
 type FrontendGovernor struct {

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -249,6 +249,7 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 			DetailSummary: detailSummary,
 			StatsConfig:   loadStatsConfig(name),
 			LastError:     proc.LastError,
+			StallNudges:   proc.StallNudges,
 		}
 
 		acmmLevel := 0


### PR DESCRIPTION
Fixes the inference-backend (vllm/llm-d/litellm) reliability chain: agents halted after kicks because the Claude CLI got stuck on interactive consent screens and every safety net false-positived. Root-caused on the live kellyaa hive (litellm+deepseek), where kick messages were observed being typed into bash (`-bash: NEVER: command not found`).

### The failure chain
1. `ensureClaudeSettings` seeded `.claude.json` with onboarding/migration keys but **not** `bypassPermissionsModeAccepted`, so every launch showed the "Bypass Permissions mode" consent screen (default selection **"No, exit"**). The launch-time `dismissInferencePrompts` goroutine raced it and sometimes timed out → CLI exited → pane degraded to bare bash.
2. Pane "CLI present" checks false-positived on consent screens: `cliPaneMarkers` includes `❯`, which also appears in the consent menu (`❯ 1. No, exit`) — so `SendKick`'s `tmuxPaneHasCLIForAgent` + `waitForInputPromptForAgent` passed and the kick was typed into the menu/bash.
3. Nothing re-prodded after launch: if dismissal timed out, or a crash-recovery restart landed on a consent screen later, the agent stayed stuck forever while kicks kept "succeeding".

### Commits (kept separate for revertability)
1. **Deterministic consent seeding** — add `bypassPermissionsModeAccepted:true` to the `.claude.json` seed and make the seed self-repairing (corrupt file → rewrite; missing required keys → merge, preserving CLI-written keys). Key name verified against Claude CLI v2.1.204: the binary reads it from the `.claude.json` config accessor and its own sandbox-setup path seeds the identical key.
2. **Consent screens are not a ready CLI** — new `paneShowsConsentScreen` helper; `waitForInputPromptForAgent` keeps polling instead of reporting ready, and `SendKick`'s pre-check treats a consent pane as crashed/not-ready → existing restart path (whose relaunch re-arms dismissal).
3. **Re-armed dismissal** — the `launchInTmux` early-return path (surviving pane after hub restart) now re-arms `dismissInferencePrompts`; the watcher loop re-runs a dismissal pass for an inference agent parked on a consent screen past a grace period (per-agent cooldown, named constants). Restart flows already reach launch-time dismissal via `forceRelaunch` — verified.
4. **Post-kick stall watchdog** — `SendKick` to an inference agent records kick time + pane hash; the watcher sends a single `continue` nudge if >5m passed, the pane never changed, and it shows an idle input prompt (never nudges the `esc to interrupt` working state). Max one nudge per kick; `stallNudges` counter surfaced on `FrontendAgent` for the dashboard.

### Testing
- `go build ./...` clean; `go test ./pkg/agent/ ./pkg/dashboard/` — only pre-existing, environment-dependent failures also present on base (`TestAgentEnvPairs_*`, `TestQueryInferenceModels_DefaultModel`).
- New tests: consent-screen detection table test, `.claude.json` repair/rewrite/untouched cases, consent grace+cooldown gating, stall-nudge arm/fire/once/disarm semantics, pane-hash stability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)