### PR TITLE
fix(agent): route startup kicks through SendKick's readiness gate

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -88,6 +88,7 @@ type AgentProcess struct {
 	lastInferKickPane   string    // stall watchdog: hash of the visible pane just after kick delivery
 	stallNudgeSent      bool      // stall watchdog: at most one nudge per kick
 	StallNudges         int       // total post-kick stall nudges sent (surfaced to the dashboard)
+	launchGen           int       // increments per launch; stale deliverStartupKick goroutines check it and drop
 }
 
 // effectiveBackend returns the agent's backend accounting for any override.
@@ -680,6 +681,25 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		bootstrapPrompt = "You are an AI agent. Await further instructions."
 	}
 
+	// Interactive backends get the bootstrap prompt delivered AFTER the CLI
+	// is ready (deliverStartupKick, spawned below) instead of embedding it in
+	// the launch command. Embedding raced the CLI boot: the prompt-bearing
+	// launch line was typed into the pane in the same second as the (re)start
+	// (observed live: `audit: agent kicked trigger=startup` 60ms after
+	// `audit: agent restarting`), before the CLI — or even bash — was ready
+	// to consume it, so the kick text landed in bash and an unbalanced quote
+	// left the shell in PS2 continuation. Goose keeps the embedded --text
+	// prompt: goose run needs it to stay interactive and exits on the ^C that
+	// readiness-gated delivery sends.
+	deferredStartupKick := ""
+	if bootstrapPrompt != "" {
+		switch backend {
+		case "claude", "copilot", "gemini":
+			deferredStartupKick = bootstrapPrompt
+			bootstrapPrompt = ""
+		}
+	}
+
 	if bootstrapPrompt != "" {
 		now := time.Now()
 		agent.LastKick = &now
@@ -695,31 +715,14 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 			"trigger", "startup",
 		)
 
+		// Only goose (and unknown backends, which never embed) reach this
+		// block — claude/copilot/gemini bootstrap prompts were deferred to
+		// deliverStartupKick above.
 		promptFile := fmt.Sprintf("/tmp/.hive-bootstrap-%s.txt", agent.Name)
 		if err := os.WriteFile(promptFile, []byte(bootstrapPrompt), 0o644); err != nil {
 			m.logger.Warn("failed to write bootstrap prompt", "name", agent.Name, "error", err)
-		} else {
-			switch backend {
-			case "copilot":
-				launchCmd += fmt.Sprintf(" -i \"$(cat %s)\"", promptFile)
-			case "claude":
-				// Write a launcher script instead of using $(cat) in send-keys.
-				// $(cat file) fails when the tmux shell hasn't fully initialized.
-				// Use -- to separate options from the positional prompt argument,
-				// otherwise --disallowed-tools consumes the prompt as tool names.
-				launcherFile := fmt.Sprintf("/tmp/.hive-launch-%s.sh", agent.Name)
-				launcherContent := fmt.Sprintf("#!/bin/sh\nexec %s -- \"$(cat %s)\"\n", launchCmd, promptFile)
-				if err := os.WriteFile(launcherFile, []byte(launcherContent), 0o755); err != nil {
-					m.logger.Warn("failed to write launcher script", "error", err)
-					launchCmd += fmt.Sprintf(" \"$(cat %s)\"", promptFile)
-				} else {
-					launchCmd = launcherFile
-				}
-			case "gemini":
-				launchCmd += fmt.Sprintf(" -i \"$(cat %s)\"", promptFile)
-			case "goose":
-				launchCmd += fmt.Sprintf(" --text \"$(cat %s)\"", promptFile)
-			}
+		} else if backend == "goose" {
+			launchCmd += fmt.Sprintf(" --text \"$(cat %s)\"", promptFile)
 		}
 	}
 
@@ -772,6 +775,7 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	now := time.Now()
 	agent.State = StateRunning
 	agent.StartedAt = &now
+	agent.launchGen++
 	m.logger.Info("audit: agent started",
 		"name", agent.Name,
 		"backend", backend,
@@ -786,6 +790,12 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 
 	if backend == "copilot" {
 		go m.watchForTrustPromptForAgent(agent, agentCtx)
+	}
+
+	// Deliver the bootstrap prompt once the CLI is ready — fire-and-forget,
+	// same semantics as the old embedded delivery but gated on readiness.
+	if deferredStartupKick != "" {
+		go m.deliverStartupKick(agent, deferredStartupKick, agent.launchGen)
 	}
 
 	if agent.Config.CavemanMode != "" {
@@ -1784,6 +1794,17 @@ func (m *Manager) SendKick(name string, message string) error {
 		return fmt.Errorf("agent %s disappeared while waiting for input prompt", name)
 	}
 
+	m.deliverKickLocked(agent, message, "send-kick")
+
+	return nil
+}
+
+// deliverKickLocked types a message into the agent's CLI and records the
+// kick bookkeeping (LastKick, history, stall watchdog, audit log). Callers
+// must hold m.mu and must already have verified the CLI is ready for input
+// (crash detect + waitForCLIReadyForAgent + waitForInputPromptForAgent) —
+// this function does no readiness checking of its own.
+func (m *Manager) deliverKickLocked(agent *AgentProcess, message, trigger string) {
 	// Clear stale input before kick (Ctrl+C then Ctrl+U).
 	// Goose 1.37 exits on ^C — skip clear for goose backend.
 	if agent.Config.Backend != "goose" && agent.BackendOverride != "goose" {
@@ -1835,7 +1856,7 @@ func (m *Manager) SendKick(name string, message string) error {
 	snippet := message
 	const maxSnippetLen = 120
 	snippet = truncateStr(snippet, maxSnippetLen)
-	record := KickRecord{Timestamp: now, Agent: name, Snippet: snippet}
+	record := KickRecord{Timestamp: now, Agent: agent.Name, Snippet: snippet}
 	if len(agent.KickHistory) >= kickHistoryCapacity {
 		agent.KickHistory = agent.KickHistory[1:]
 	}
@@ -1847,12 +1868,45 @@ func (m *Manager) SendKick(name string, message string) error {
 		kickPreview = truncateStr(kickPreview, maxKickPreviewLen)
 	}
 	m.logger.Info("audit: agent kicked",
-		"name", name,
+		"name", agent.Name,
 		"message_len", len(message),
 		"preview", kickPreview,
+		"trigger", trigger,
 	)
+}
 
-	return nil
+// deliverStartupKick delivers a bootstrap prompt to a freshly launched agent
+// once its CLI is actually ready for input, mirroring SendKick's readiness
+// chain (CLI marker visible, input prompt shown, not parked on a consent
+// screen — the consent check lives inside waitForInputPromptForAgent). It
+// runs fire-and-forget in a goroutine, bounded by cliReadyTimeout +
+// inputPromptTimeout. If the CLI never becomes ready the prompt is dropped
+// with a warning rather than typed into a bare bash pane — the crash
+// detector restarts the agent and the next launch builds a fresh bootstrap.
+// gen is the agent's launch generation at spawn time; a mismatch at delivery
+// time means the agent was relaunched while we waited (the new launch owns
+// its own startup kick, so this one is stale and dropped).
+func (m *Manager) deliverStartupKick(agent *AgentProcess, prompt string, gen int) {
+	if !m.waitForCLIReadyForAgent(agent) {
+		m.logger.Warn("startup kick dropped: CLI never became ready",
+			"name", agent.Name, "session", agent.tmuxSession, "trigger", "startup")
+		return
+	}
+	if !m.waitForInputPromptForAgent(agent) {
+		m.logger.Warn("startup kick dropped: CLI never reached input prompt",
+			"name", agent.Name, "session", agent.tmuxSession, "trigger", "startup")
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	current, ok := m.agents[agent.Name]
+	if !ok || current != agent || agent.State != StateRunning || agent.launchGen != gen {
+		m.logger.Warn("startup kick dropped: agent restarted or stopped while waiting",
+			"name", agent.Name, "trigger", "startup")
+		return
+	}
+	m.deliverKickLocked(agent, prompt, "startup")
 }
 
 // tmuxSendLiteralForAgent sends text using the agent's tmux socket.

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -764,6 +764,16 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	envCmd := m.buildEnvPrefix(agent)
 	fullCmd := envCmd + launchCmd
 
+	// A previously spilled kick can leave bash in PS2 quote-continuation
+	// (an unbalanced quote): anything typed next is appended to the open
+	// string literal instead of executing, so the launch command would be
+	// silently eaten. Abort any pending continuation or partially typed
+	// line before typing the launch command. The pane holds only bash at
+	// this point (the CLI-already-running check above returned early), so
+	// C-c cannot kill a live CLI.
+	m.tmuxSendKeysForAgent(agent, "C-c")
+	time.Sleep(preLaunchShellClearDelay)
+
 	m.tmuxSendLiteralForAgent(agent, fullCmd)
 	time.Sleep(textToEnterDelay)
 	m.tmuxSendEntersForAgent(agent)
@@ -2151,6 +2161,10 @@ const (
 	inputPromptPollInterval = 2 * time.Second
 	inputPromptTimeout      = 120 * time.Second
 	cavemanActivationDelay  = 5 * time.Second
+	// preLaunchShellClearDelay gives bash time to process the C-c that
+	// clears stale PS2 quote-continuation state before the launch command
+	// is typed into the pane.
+	preLaunchShellClearDelay = 500 * time.Millisecond
 )
 
 func (m *Manager) SeedLastKick(name string, t time.Time) {

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -812,7 +812,13 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		switch backend {
 		case "goose", "codex", "aider":
 			go func(a *AgentProcess, cavemanMode string) {
-				time.Sleep(cavemanActivationDelay)
+				// Same readiness gate as kicks: a fixed post-launch delay
+				// raced the CLI boot and could type /caveman into bash.
+				if !m.waitForInputPromptForAgent(a) {
+					m.logger.Warn("caveman activation skipped: CLI never reached input prompt",
+						"agent", a.Name, "mode", cavemanMode)
+					return
+				}
 				m.tmuxSendLiteralForAgent(a, "/caveman "+cavemanMode)
 				time.Sleep(textToEnterDelay)
 				m.tmuxSendEntersForAgent(a)
@@ -2160,7 +2166,6 @@ const (
 	cliReadyTimeout         = 60 * time.Second
 	inputPromptPollInterval = 2 * time.Second
 	inputPromptTimeout      = 120 * time.Second
-	cavemanActivationDelay  = 5 * time.Second
 	// preLaunchShellClearDelay gives bash time to process the C-c that
 	// clears stale PS2 quote-continuation state before the launch command
 	// is typed into the pane.


### PR DESCRIPTION
## Problem

Observed live on a running hive: kicks with `trigger: "startup"` are sent in the **same second** as an agent (re)start — before the Claude CLI has booted in the tmux session:

```
"audit: agent restarting" restart_count:97   @ 21:26:01.98
"audit: agent kicked" trigger:"startup"      @ 21:26:02.04
```

The startup/bootstrap kick was embedded in the launch command and typed into the pane immediately after the tmux session was (re)created, so the kick text landed in **bash** instead of the CLI. An unbalanced quote then left bash in PS2 quote-continuation, which silently ate the *next* relaunch command too — feeding the crash-restart loop (restart_count 97). Guarded governor kicks, by contrast, go through `SendKick`'s full readiness chain (crash detect → restart → `waitForCLIReadyForAgent` → `waitForInputPromptForAgent`, which also refuses consent screens).

## Unguarded send sites found

1. **`launchInTmux` bootstrap prompt** (the `trigger:"startup"` kick, incl. the 48-char inference default "You are an AI agent. Await further instructions.") — embedded in the launch command, typed with zero readiness gating.
2. **`launchInTmux` launch command itself** — typed into a bash pane that may be stuck in PS2 quote-continuation from a prior spill.
3. **Caveman activation** (`/caveman <mode>`) — sent after a blind 5s sleep, racing the CLI boot.

Audited and found already guarded: governor kicks + restarted-agent kick list (`SendKick`), `RestartThenSendKick`, inception watcher/handlers (`SendKick`/`RestartWithBootstrap`), stall nudge from #1814 (caller classifies the pane first), consent/trust-prompt dismissers (guarded by detection).

## Fix (one commit each)

- **Readiness-gated startup kick**: extracted `SendKick`'s post-readiness delivery body into `deliverKickLocked` (now logs a `trigger` field). For claude/copilot/gemini (incl. inference agents) the bootstrap prompt is no longer embedded in the launch command; the bare CLI is launched and the prompt is delivered by `deliverStartupKick` — a fire-and-forget goroutine (preserving launch semantics) that waits for CLI readiness + input prompt (bounded by `cliReadyTimeout` + `inputPromptTimeout`) before typing. Never becomes ready → prompt is dropped with a warning, never typed into bash; the crash detector restarts and the next launch builds a fresh bootstrap. A per-launch generation counter drops stale deliveries after a concurrent relaunch. Goose keeps the embedded `--text` prompt (needs it to stay interactive; exits on `^C`).
- **PS2 clear before launch**: `C-c` + `preLaunchShellClearDelay` (named constant) sent to the pane before typing the launch command, so stale quote-continuation state can't eat the relaunch. `launchInTmux` did not previously clear the pane.
- **Caveman activation gate**: replaced the fixed `cavemanActivationDelay` sleep with `waitForInputPromptForAgent`.

## Notes

- Also removes a misleading `audit: agent kicked` log on the skip-launch path (CLI already running), where the prompt was never actually delivered.
- `go build`, `go vet`, `go test ./pkg/agent -short -race` pass (two `TestAgentEnvPairs_*` failures are pre-existing on `origin/v2` in this environment and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)