### PR TITLE
feat(agent): action-forcing prods for inference-backend agents

### DIFF
--- a/v2/pkg/agent/coverage_boost_test.go
+++ b/v2/pkg/agent/coverage_boost_test.go
@@ -1196,14 +1196,127 @@ func TestNudgeIfKickStalled(t *testing.T) {
 		t.Fatal("working pane must not be nudged")
 	}
 
-	// A pane change since the kick disarms the watchdog.
+	// A pane change with post-kick tool activity disarms the watchdog.
+	// (No tmux session in tests → captureTmuxPaneForAgent returns "" →
+	// countToolMarkers is 0; a negative baseline simulates "count rose".)
 	agent.lastInferKickPane = paneContentHash("what the pane looked like at kick time")
+	agent.lastInferKickMarks = -1
 	m.nudgeIfKickStalled("vinf", idlePane)
-	if agent.StallNudges != 1 {
-		t.Fatal("changed pane must not be nudged")
+	if agent.StallNudges != 1 || agent.ActionNudges != 0 {
+		t.Fatal("changed pane with tool activity must not be nudged")
 	}
 	if agent.lastInferKickPane != "" {
-		t.Fatal("changed pane should disarm the watchdog")
+		t.Fatal("changed pane with tool activity should disarm the watchdog")
+	}
+}
+
+func TestNudgeIfKickStalled_ActionNudge(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{
+		"vinf": {Backend: "vllm"},
+	}, discardLogger(), ProjectContext{})
+	m.mu.RLock()
+	agent := m.agents["vinf"]
+	m.mu.RUnlock()
+
+	// Prose-only response: the model answered the kick with a plan and
+	// returned to the idle prompt without a single tool marker.
+	prosePane := "❯ [agent:scanner] fix the failing issues\n" +
+		"⏺ To fix the failing issues, follow these steps. First you ensure the\n" +
+		"  branch is up to date, then you open a pull request with the fix.\n" +
+		"✻ Worked for 26s\n" +
+		"❯ \n" +
+		"  ⏵⏵ bypass permissions on (shift+tab to cycle)"
+
+	// Within the grace period — never nudged.
+	agent.lastInferKickAt = time.Now().Add(-inferenceActionNudgeGrace + time.Minute)
+	agent.lastInferKickPane = paneContentHash("pane as captured at kick delivery")
+	agent.lastInferKickMarks = 0
+	m.nudgeIfKickStalled("vinf", prosePane)
+	if agent.ActionNudges != 0 {
+		t.Fatal("no action nudge within the grace period")
+	}
+
+	// Past the grace period with zero new tool markers — exactly one nudge.
+	// (No tmux session in tests → the scrollback capture is empty → the
+	// marker count stays at the baseline.)
+	agent.lastInferKickAt = time.Now().Add(-inferenceActionNudgeGrace - time.Minute)
+	m.nudgeIfKickStalled("vinf", prosePane)
+	if agent.ActionNudges != 1 || !agent.actionNudgeSent {
+		t.Fatalf("expected one action nudge, got %d (sent=%v)", agent.ActionNudges, agent.actionNudgeSent)
+	}
+	if agent.StallNudges != 0 {
+		t.Fatal("prose-only response must not count as a frozen-pane stall")
+	}
+
+	// Second watcher pass: max one action nudge per kick.
+	m.nudgeIfKickStalled("vinf", prosePane)
+	if agent.ActionNudges != 1 {
+		t.Fatalf("max one action nudge per kick, got %d", agent.ActionNudges)
+	}
+
+	// A CLI mid-response (live spinner counter) is left alone even though
+	// the footer no longer shows "esc to interrupt" on v2.1.204.
+	streamingPane := prosePane + "\n✶ Infusing… (18s · ↓ 94 tokens)"
+	agent.actionNudgeSent = false
+	m.nudgeIfKickStalled("vinf", streamingPane)
+	if agent.ActionNudges != 1 {
+		t.Fatal("streaming pane must not be nudged")
+	}
+
+	// A new kick re-arms both nudges.
+	now := time.Now()
+	m.mu.Lock()
+	m.recordInferenceKick(agent, now)
+	m.mu.Unlock()
+	if agent.actionNudgeSent || agent.stallNudgeSent {
+		t.Fatal("recordInferenceKick must reset both nudge flags")
+	}
+}
+
+func TestCountToolMarkers(t *testing.T) {
+	cases := []struct {
+		name string
+		pane string
+		want int
+	}{
+		{"empty", "", 0},
+		// A bare ⏺ is the bullet for every assistant block, prose included.
+		{"prose only", "⏺ To fix this, follow these steps and you ensure the tests pass.\n✻ Worked for 26s", 0},
+		{"mid-run bash (v2.1.204)", "⏺ Running 1 shell command…\n  ⎿  $ sleep 15 && echo probe3 (12s)", 2},
+		{"collapsed summary (v2.1.204)", "  Ran 1 shell command\n⏺ Done — it printed probe3.", 1},
+		{"collapsed read+bash (v2.1.204)", "  Read 1 file, ran 1 shell command\n⏺ Done.", 2},
+		{"expanded legacy tool call", "⏺ Bash(git status)\n  ⎿  On branch main", 2},
+		{"expanded legacy read", "⏺ Read(main.go)", 1},
+		{"plural summary", "  Ran 3 shell commands\n  Edited 2 files", 2},
+		{"idle prompt only", "❯ \n  ⏵⏵ bypass permissions on (shift+tab to cycle)", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := countToolMarkers(tc.pane); got != tc.want {
+				t.Errorf("countToolMarkers(%s) = %d, want %d", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPaneShowsActiveWork(t *testing.T) {
+	cases := []struct {
+		name string
+		pane string
+		want bool
+	}{
+		{"legacy footer hint", "some output\nesc to interrupt", true},
+		{"live spinner counter (v2.1.204)", "✶ Infusing… (18s · ↓ 94 tokens)", true},
+		{"completed response", "⏺ Done.\n✻ Worked for 26s\n❯ ", false},
+		{"idle prompt", "❯ \n  ⏵⏵ bypass permissions on", false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := paneShowsActiveWork(tc.pane); got != tc.want {
+				t.Errorf("paneShowsActiveWork(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -89,6 +89,9 @@ type AgentProcess struct {
 	stallNudgeSent      bool      // stall watchdog: at most one nudge per kick
 	StallNudges         int       // total post-kick stall nudges sent (surfaced to the dashboard)
 	launchGen           int       // increments per launch; stale deliverStartupKick goroutines check it and drop
+	lastInferKickMarks  int       // no-action watchdog: tool-marker count in pane+scrollback just after kick delivery
+	actionNudgeSent     bool      // no-action watchdog: at most one action nudge per kick
+	ActionNudges        int       // total prose-only-response action nudges sent (surfaced to the dashboard)
 }
 
 // effectiveBackend returns the agent's backend accounting for any override.
@@ -1873,9 +1876,9 @@ func (m *Manager) deliverKickLocked(agent *AgentProcess, message, trigger string
 	agent.KickRefused = false
 	agent.KickRefusalReason = ""
 
-	// Arm the post-kick stall watchdog for inference agents: if the pane
-	// never changes after this kick and sits at an idle prompt, the watcher
-	// loop sends a single "continue" nudge.
+	// Arm the post-kick watchdog for inference agents: the watcher loop
+	// sends a "continue" nudge if the pane freezes at an idle prompt, and
+	// an action nudge if the model responds with prose but runs no tools.
 	if IsInferenceBackend(effectiveBackend(agent)) {
 		m.recordInferenceKick(agent, now)
 	}
@@ -2098,7 +2101,68 @@ const (
 	inferenceStallNudgeMessage = "continue"
 	// cliInputPromptMarker is the CLI's idle input prompt indicator.
 	cliInputPromptMarker = "❯"
+	// inferenceActionNudgeGrace is the minimum time after a kick before the
+	// no-action check may fire, so the watcher never misreads the brief
+	// post-Enter window (kick echoed, spinner not yet rendered) as a
+	// completed prose-only response.
+	inferenceActionNudgeGrace = 2 * time.Minute
+	// inferenceActionNudgeMessage is typed into the CLI when the model
+	// answered a kick with prose only — a plan addressed to a reader with
+	// zero tool executions (observed live with weak OSS models on
+	// inference backends, e.g. deepseek-r1-14b via litellm/vllm).
+	inferenceActionNudgeMessage = "You produced a plan but executed nothing. Execute it yourself NOW using your tools, starting with step 1. Do not reply with prose only."
+	// cliActiveCounterMarker appears inside Claude Code's live activity
+	// spinner, e.g. "✶ Infusing… (18s · ↓ 94 tokens)" (verified against
+	// Claude Code v2.1.204). The completed form ("✻ Worked for 26s") has no
+	// counter, so this distinguishes an in-flight response from a finished
+	// one on versions whose footer no longer shows cliWorkingMarker.
+	cliActiveCounterMarker = "s · ↓"
 )
+
+// toolSummaryRe matches Claude Code's collapsed tool-activity summary lines,
+// rendered only when tools actually executed (verified against Claude Code
+// v2.1.204): "Running 1 shell command…" while a Bash call is in flight, and
+// "Ran 1 shell command" / "Read 1 file, ran 2 shell commands" once done.
+// Edit/write variants are included for completeness across versions.
+var toolSummaryRe = regexp.MustCompile(`(?i)\b(?:ran|running) \d+ shell command|\bread \d+ file|\bedited \d+ file|\bwrote \d+ file|\bupdated \d+ file`)
+
+// expandedToolCallMarkers are literal fragments of Claude Code's expanded
+// per-tool rendering. "⎿" is the result elbow drawn under a tool call
+// (verified live on v2.1.204: "⎿  $ sleep 15 && echo probe3"); the
+// "⏺ Name(" forms are the expanded tool-call headers older CLI versions
+// render. A bare "⏺" is NOT a tool marker — v2.1.204 uses it as the bullet
+// for every assistant response block, including pure prose.
+var expandedToolCallMarkers = []string{
+	"⎿",
+	"⏺ Bash(",
+	"⏺ Read(",
+	"⏺ Write(",
+	"⏺ Edit(",
+	"⏺ Update(",
+	"⏺ Search(",
+	"⏺ Fetch(",
+	"⏺ Task(",
+}
+
+// countToolMarkers counts tool-execution markers in captured pane content.
+// The no-action watchdog compares the count after a kick against the count
+// recorded at kick delivery: scrollback keeps markers from work done before
+// the kick, so only an increase proves the model executed tools since.
+func countToolMarkers(pane string) int {
+	n := len(toolSummaryRe.FindAllStringIndex(pane, -1))
+	for _, marker := range expandedToolCallMarkers {
+		n += strings.Count(pane, marker)
+	}
+	return n
+}
+
+// paneShowsActiveWork reports whether the CLI is mid-response: either the
+// legacy "esc to interrupt" footer hint or the live spinner counter is
+// visible. The idle input prompt "❯" alone proves nothing on v2.1.204 —
+// the input box stays rendered while a response streams.
+func paneShowsActiveWork(pane string) bool {
+	return strings.Contains(pane, cliWorkingMarker) || strings.Contains(pane, cliActiveCounterMarker)
+}
 
 // paneContentHash returns a short stable hash of pane content, used to detect
 // whether a pane has changed since a kick was delivered.
@@ -2115,47 +2179,85 @@ func (m *Manager) recordInferenceKick(agent *AgentProcess, at time.Time) {
 	agent.lastInferKickAt = at
 	agent.lastInferKickPane = paneContentHash(m.captureVisiblePaneForAgent(agent))
 	agent.stallNudgeSent = false
+	// Baseline for the no-action check: markers already in scrollback from
+	// work done before this kick must not count as post-kick tool activity.
+	agent.lastInferKickMarks = countToolMarkers(m.captureTmuxPaneForAgent(agent))
+	agent.actionNudgeSent = false
 }
 
-// nudgeIfKickStalled sends a single "continue" nudge to an inference agent
-// whose pane has not changed since the last kick was delivered, the stall
-// timeout has elapsed, and the pane shows an idle input prompt (a working CLI
-// shows cliWorkingMarker and is left alone). Any pane change since the kick
-// disarms the watchdog — the CLI consumed the message. At most one nudge is
-// sent per kick; the total is surfaced on the agent snapshot as StallNudges.
+// nudgeIfKickStalled watches an inference agent after a kick and corrects
+// two distinct failure modes, sending at most one nudge each (so at most two
+// combined nudges per kick):
+//
+//   - Frozen pane: the pane has not changed since the kick was delivered and
+//     the stall timeout elapsed — the CLI swallowed the message. Sends the
+//     "continue" nudge (counted in StallNudges).
+//   - Prose-only response: the pane changed (the CLI consumed the kick), the
+//     response completed back at the idle input prompt, but the tool-marker
+//     count has not risen above the baseline recorded at kick delivery — the
+//     model narrated a plan instead of acting. Sends the action nudge
+//     (counted in ActionNudges).
+//
+// A CLI that is mid-response (paneShowsActiveWork) is always left alone, and
+// post-kick tool activity disarms the watchdog entirely.
 func (m *Manager) nudgeIfKickStalled(name, pane string) {
 	now := time.Now()
 	m.mu.Lock()
 	agent, ok := m.agents[name]
-	if !ok || agent.stallNudgeSent || agent.lastInferKickAt.IsZero() || agent.lastInferKickPane == "" {
+	if !ok || agent.lastInferKickAt.IsZero() || agent.lastInferKickPane == "" {
+		m.mu.Unlock()
+		return
+	}
+	if paneShowsActiveWork(pane) || !strings.Contains(pane, cliInputPromptMarker) {
 		m.mu.Unlock()
 		return
 	}
 	sinceKick := now.Sub(agent.lastInferKickAt)
-	if sinceKick < inferenceKickStallTimeout {
+
+	if paneContentHash(pane) == agent.lastInferKickPane {
+		// Frozen pane: the CLI never consumed the kick.
+		if agent.stallNudgeSent || sinceKick < inferenceKickStallTimeout {
+			m.mu.Unlock()
+			return
+		}
+		agent.stallNudgeSent = true
+		agent.StallNudges++
+		totalNudges := agent.StallNudges
+		m.mu.Unlock()
+
+		m.logger.Warn("inference agent stalled after kick, sending continue nudge",
+			"name", name,
+			"minutes_since_kick", int(sinceKick.Minutes()),
+			"total_nudges", totalNudges)
+		m.tmuxSendLiteralForAgent(agent, inferenceStallNudgeMessage)
+		time.Sleep(textToEnterDelay)
+		m.tmuxSendEntersForAgent(agent)
+		return
+	}
+
+	// The pane moved since the kick — the CLI consumed it and the response
+	// completed (idle prompt, no active-work indicator). Check whether any
+	// tools ran since the kick before declaring the response prose-only.
+	if agent.actionNudgeSent || sinceKick < inferenceActionNudgeGrace {
 		m.mu.Unlock()
 		return
 	}
-	if paneContentHash(pane) != agent.lastInferKickPane {
-		// The pane moved since the kick — the CLI consumed it. Disarm.
+	if countToolMarkers(m.captureTmuxPaneForAgent(agent)) > agent.lastInferKickMarks {
+		// Real tool activity since the kick — the agent is acting. Disarm.
 		agent.lastInferKickPane = ""
 		m.mu.Unlock()
 		return
 	}
-	if strings.Contains(pane, cliWorkingMarker) || !strings.Contains(pane, cliInputPromptMarker) {
-		m.mu.Unlock()
-		return
-	}
-	agent.stallNudgeSent = true
-	agent.StallNudges++
-	totalNudges := agent.StallNudges
+	agent.actionNudgeSent = true
+	agent.ActionNudges++
+	totalActionNudges := agent.ActionNudges
 	m.mu.Unlock()
 
-	m.logger.Warn("inference agent stalled after kick, sending continue nudge",
+	m.logger.Warn("inference agent answered kick with prose only, sending action nudge",
 		"name", name,
 		"minutes_since_kick", int(sinceKick.Minutes()),
-		"total_nudges", totalNudges)
-	m.tmuxSendLiteralForAgent(agent, inferenceStallNudgeMessage)
+		"total_action_nudges", totalActionNudges)
+	m.tmuxSendLiteralForAgent(agent, inferenceActionNudgeMessage)
 	time.Sleep(textToEnterDelay)
 	m.tmuxSendEntersForAgent(agent)
 }
@@ -2269,6 +2371,7 @@ func (a *AgentProcess) snapshot() AgentProcess {
 		LastKickMessage: a.LastKickMessage,
 		NeedsLogin:      needsLogin,
 		StallNudges:     a.StallNudges,
+		ActionNudges:    a.ActionNudges,
 		HasLaunched:     a.HasLaunched,
 		LaunchedMode:    a.LaunchedMode,
 		tmuxSession:     a.tmuxSession,

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1837,6 +1837,17 @@ func (m *Manager) deliverKickLocked(agent *AgentProcess, message, trigger string
 		time.Sleep(clearBeforeKickDelay)
 	}
 
+	// Weak OSS models served over inference backends often answer a kick
+	// with a prose plan addressed to a reader and execute zero tool calls
+	// (observed live: litellm/vllm + deepseek-r1-14b produced a coherent
+	// PLAN and returned to the idle prompt without running anything).
+	// Append an action-forcing block here — where the effective backend is
+	// knowable — instead of editing the kick templates, which are shared
+	// with commercial CLI backends that do not need it.
+	if IsInferenceBackend(effectiveBackend(agent)) {
+		message += "\n\n" + inferenceKickActionSuffix
+	}
+
 	// Send message in chunks (400 rune max per chunk, rune-safe)
 	runes := []rune(message)
 	if len(runes) <= chunkSize {
@@ -2066,6 +2077,17 @@ func (m *Manager) dismissConsentIfStuck(name string) {
 		"name", name, "stuck_seconds", int(stuckFor.Seconds()))
 	go m.dismissInferencePrompts(agent)
 }
+
+// inferenceKickActionSuffix is appended to every kick sent to an agent whose
+// effective backend is a self-hosted inference backend (vllm/llm-d/litellm).
+// Weak OSS models tend to answer a kick conversationally — describing steps
+// for someone else to follow — instead of acting; this block demands
+// immediate tool execution. Commercial CLI backends don't receive it.
+const inferenceKickActionSuffix = "IMPORTANT — EXECUTE, DO NOT NARRATE: " +
+	"You have real tools (Bash, file edit, gh). Perform the work NOW in " +
+	"this session. Do not describe steps for someone else, do not summarize " +
+	"a plan and stop. Begin immediately by running your first command. " +
+	"Every response that contains no tool execution is a failure."
 
 const (
 	// inferenceKickStallTimeout is how long after a kick an unchanged, idle

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -205,6 +205,7 @@ type FrontendAgent struct {
 	OnDemand         bool   `json:"onDemand,omitempty"`
 	LastError        string `json:"lastError,omitempty"`
 	StallNudges      int    `json:"stallNudges,omitempty"`
+	ActionNudges     int    `json:"actionNudges,omitempty"`
 }
 
 type FrontendGovernor struct {

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -250,6 +250,7 @@ func buildAgents(statuses map[string]*agent.AgentProcess, cfg *config.Config, go
 			StatsConfig:   loadStatsConfig(name),
 			LastError:     proc.LastError,
 			StallNudges:   proc.StallNudges,
+			ActionNudges:  proc.ActionNudges,
 		}
 
 		acmmLevel := 0


### PR DESCRIPTION
## Problem

Live-observed failure on kellyaa (litellm/vllm + deepseek-r1-14b): the CLI is healthy, kicks land, and the model produces a coherent PLAN as prose addressed to a reader ("follow these steps... you ensure...") — then executes **zero tool calls** and returns to the idle input prompt. Weak OSS models answer conversationally instead of acting. The #1814 stall watchdog only covers a frozen pane (kick swallowed, no response at all), so this failure mode went uncorrected.

## Changes

**Commit 1 — imperative kick suffix.** Every kick delivered to an agent whose *effective* backend (override-or-config) is an inference backend (vllm/llm-d/litellm) gets an appended `EXECUTE, DO NOT NARRATE` block (`inferenceKickActionSuffix`). Applied in `deliverKickLocked`, where the backend is knowable — kick templates are untouched since they're shared with commercial CLI backends. Covers both governor kicks (`SendKick`) and startup kicks.

**Commit 2 — no-action nudge.** Extends the post-kick watchdog for the observed case: pane CHANGED (model responded) but is back at the idle prompt with no tool activity. Detection compares the tool-execution marker count in pane+scrollback against a baseline recorded at kick delivery (`recordInferenceKick`), so pre-kick scrollback markers don't mask a prose-only response. If no increase after a grace period → one follow-up nudge (`inferenceActionNudgeMessage`): *"You produced a plan but executed nothing. Execute it yourself NOW using your tools, starting with step 1. Do not reply with prose only."* Per-kick bookkeeping mirrors the stall nudge — max one of each, so combined nudges per kick are capped at 2. Surfaced as `ActionNudges` next to `StallNudges` on the snapshot and dashboard JSON.

## Tool markers — verified empirically against Claude Code v2.1.204

Driven live in a tmux pane and captured mid-run and post-completion:

- A bare `⏺` bullets **every** assistant block, prose included — it is NOT a tool marker on its own
- Tool activity renders as `Running 1 shell command…` / `Ran 1 shell command` / `Read 1 file, ran 1 shell command` summaries plus the `⎿` result elbow (`⎿  $ sleep 15 && echo probe3`)
- Legacy expanded headers (`⏺ Bash(`, `⏺ Read(`, ...) kept for older CLI versions
- A streaming response shows a live counter (`✶ Infusing… (18s · ↓ 94 tokens)`) rather than the legacy `esc to interrupt` footer, and the `❯` input box stays rendered while working — `paneShowsActiveWork` covers both generations so a thinking model is never nudged

## Tests

Table tests for `countToolMarkers` and `paneShowsActiveWork` (fixtures from the live captures), plus `TestNudgeIfKickStalled_ActionNudge` covering grace period, single-nudge cap, streaming-pane suppression, tool-activity disarm, and re-arm on new kick. Existing `TestNudgeIfKickStalled` updated to the new disarm semantics.

Rebased on v2 after the startup-kick-readiness change landed (`deliverKickLocked` split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)