### PR TITLE
fix(agent): suppress Bypass-Permissions consent for inference agents — seed the real gate

### DIFF
--- a/v2/pkg/agent/coverage_boost_test.go
+++ b/v2/pkg/agent/coverage_boost_test.go
@@ -719,10 +719,21 @@ func TestEnsureClaudeSettings_CreatesFiles(t *testing.T) {
 	if parsed["bypassPermissions"] != true {
 		t.Error("bypassPermissions should be true")
 	}
+	if parsed["skipDangerousModePermissionPrompt"] != true {
+		t.Error("skipDangerousModePermissionPrompt should be true — it is the only key that suppresses the bypass-permissions consent dialog")
+	}
 
 	// Check standalone settings file
-	if _, err := os.Stat(claudeInferenceSettingsPath); err != nil {
-		t.Errorf("standalone settings file not created: %v", err)
+	flagData, err := os.ReadFile(claudeInferenceSettingsPath)
+	if err != nil {
+		t.Fatalf("standalone settings file not created: %v", err)
+	}
+	var flagParsed map[string]interface{}
+	if err := json.Unmarshal(flagData, &flagParsed); err != nil {
+		t.Fatalf("standalone settings invalid JSON: %v", err)
+	}
+	if flagParsed["skipDangerousModePermissionPrompt"] != true {
+		t.Error("standalone settings skipDangerousModePermissionPrompt should be true")
 	}
 
 	// Check .claude.json user config
@@ -757,6 +768,159 @@ func TestEnsureClaudeSettings_Idempotent(t *testing.T) {
 	settingsFile := filepath.Join(idempotentHomePath, ".claude", "settings.json")
 	if _, err := os.Stat(settingsFile); err != nil {
 		t.Errorf("settings should still exist: %v", err)
+	}
+}
+
+func TestSeedClaudeSettingsFile_RepairsMissingKey(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+
+	// Simulate a settings file seeded by an older hive version: no
+	// skipDangerousModePermissionPrompt, plus keys that must be preserved.
+	old := `{"permissions":{"allow":["Bash"],"deny":[]},"hasCompletedOnboarding":true,"bypassPermissions":true,"hasAcknowledgedDisclaimer":true}`
+	if err := os.WriteFile(path, []byte(old), 0o666); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	m.seedClaudeSettingsFile("repair-agent", path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid JSON after repair: %v", err)
+	}
+	if parsed["skipDangerousModePermissionPrompt"] != true {
+		t.Error("skipDangerousModePermissionPrompt should be merged in")
+	}
+	perms, ok := parsed["permissions"].(map[string]interface{})
+	if !ok {
+		t.Fatal("permissions should remain an object")
+	}
+	allow, ok := perms["allow"].([]interface{})
+	if !ok || len(allow) != 1 || allow[0] != "Bash" {
+		t.Error("existing permissions must not be overwritten on repair")
+	}
+}
+
+func TestSeedClaudeSettingsFile_CompleteFileUntouched(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+
+	m.seedClaudeSettingsFile("complete-agent", path)
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after seed: %v", err)
+	}
+
+	m.seedClaudeSettingsFile("complete-agent", path)
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after reseed: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Error("complete settings should not be rewritten")
+	}
+}
+
+func TestInferenceUserConfigSeed_ApprovedKeyForms(t *testing.T) {
+	// Short name: full key is within the CLI's 20-char comparison suffix,
+	// so only the full form is needed.
+	seed := inferenceUserConfigSeed("kellyaa")
+	responses := seed["customApiKeyResponses"].(map[string]any)
+	approved := responses["approved"].([]string)
+	if len(approved) != 1 || approved[0] != "sk-hive-kellyaa" {
+		t.Errorf("short-name approved = %v, want [sk-hive-kellyaa]", approved)
+	}
+
+	// Long name: the CLI matches key.slice(-20), so the truncated form must
+	// be seeded alongside the full key.
+	seed = inferenceUserConfigSeed("test-settings")
+	responses = seed["customApiKeyResponses"].(map[string]any)
+	approved = responses["approved"].([]string)
+	fullKey := "sk-hive-test-settings"
+	wantSuffix := fullKey[len(fullKey)-apiKeyApprovalSuffixLen:]
+	if len(approved) != 2 || approved[0] != fullKey || approved[1] != wantSuffix {
+		t.Errorf("long-name approved = %v, want [%s %s]", approved, fullKey, wantSuffix)
+	}
+}
+
+func TestSeedClaudeUserConfig_MergesTruncatedAPIKey(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{}, discardLogger(), ProjectContext{})
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude.json")
+
+	// Config seeded by an older hive version: full key only, no truncated
+	// form. The top-level merge alone would skip customApiKeyResponses.
+	old := `{"hasCompletedOnboarding":true,"bypassPermissionsModeAccepted":true,"customApiKeyResponses":{"approved":["sk-hive-long-agent-name"],"rejected":["other"]}}`
+	if err := os.WriteFile(path, []byte(old), 0o666); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	m.seedClaudeUserConfig("long-agent-name", path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid JSON after repair: %v", err)
+	}
+	responses := parsed["customApiKeyResponses"].(map[string]interface{})
+	approved := responses["approved"].([]interface{})
+	fullKey := "sk-hive-long-agent-name"
+	wantSuffix := fullKey[len(fullKey)-apiKeyApprovalSuffixLen:]
+	found := false
+	for _, v := range approved {
+		if v == wantSuffix {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("approved = %v, should include truncated form %q", approved, wantSuffix)
+	}
+	rejected := responses["rejected"].([]interface{})
+	if len(rejected) != 1 || rejected[0] != "other" {
+		t.Errorf("rejected = %v, existing entries must be preserved", rejected)
+	}
+}
+
+func TestSelectedMenuOption(t *testing.T) {
+	tests := []struct {
+		name string
+		pane string
+		want string
+	}{
+		{
+			name: "no-first consent variant",
+			pane: "WARNING: Claude Code running in Bypass Permissions mode\n ❯ 1. No, exit\n   2. Yes, I accept\nEnter to confirm · Esc to cancel",
+			want: "❯ 1. No, exit",
+		},
+		{
+			name: "yes-first consent variant",
+			pane: "WARNING: Claude Code running in Bypass Permissions mode\n ❯ 1. Yes, I accept\n   2. No, exit\nEnter to confirm · Esc to cancel",
+			want: "❯ 1. Yes, I accept",
+		},
+		{
+			name: "no selection",
+			pane: "plain shell output\n$ ",
+			want: "",
+		},
+		{
+			name: "empty pane",
+			pane: "",
+			want: "",
+		},
+	}
+	for _, tc := range tests {
+		if got := selectedMenuOption(tc.pane); got != tc.want {
+			t.Errorf("selectedMenuOption(%s) = %q, want %q", tc.name, got, tc.want)
+		}
 	}
 }
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -536,6 +536,18 @@ const (
 	// bypassConsentDefaultOption is the default (negative) option on the
 	// bypass-permissions consent screen.
 	bypassConsentDefaultOption = "No, exit"
+	// bypassConsentAcceptOption is the affirmative option on the
+	// bypass-permissions consent screen. Its position varies between CLI
+	// versions, so acceptance navigates by matching the selected-line text.
+	bypassConsentAcceptOption = "Yes, I accept"
+	// apiKeyPromptTitle is the heading of the custom-API-key approval prompt,
+	// shown when ANTHROPIC_API_KEY is not in customApiKeyResponses.approved.
+	// Its default selection is "No (recommended)" with the affirmative option
+	// above it.
+	apiKeyPromptTitle = "Detected a custom API key"
+	// apiKeyPromptAcceptOption is the affirmative option on the
+	// custom-API-key approval prompt.
+	apiKeyPromptAcceptOption = "Yes"
 	// cliWorkingMarker is shown while Claude Code is actively processing a
 	// request; a pane in this state is never a consent screen.
 	cliWorkingMarker = "esc to interrupt"
@@ -1945,30 +1957,73 @@ func (m *Manager) tmuxSendLiteralForAgent(agent *AgentProcess, text string) {
 }
 
 // dismissInferencePrompts polls the tmux pane for Claude Code interactive
-// prompts and auto-dismisses them. Works dynamically regardless of prompt
-// text changes between Claude Code versions by:
+// prompts and auto-dismisses them. The "Bypass Permissions mode" consent
+// screen and the custom-API-key approval prompt are handled first and
+// explicitly (see confirmMenuOption): their default selections are negative
+// ("No, exit" / "No (recommended)"), so confirming blind terminates the CLI
+// or declines the seeded key.
+// Other prompts are handled dynamically regardless of prompt text changes
+// between Claude Code versions by:
 //  1. Detecting "Enter to confirm" (universal prompt footer)
 //  2. Finding the selected option (line with "❯" marker)
 //  3. If selected option looks negative (contains "No" or "exit"), navigate
 //     away from it before confirming
 //  4. For "Press Enter to continue" screens, just press Enter
 //
+// The pane is polled fast for the first 10s — the consent screen appears
+// within ~5-8s of launch and every second it lingers is a window for a kick
+// to be swallowed by the menu — then at a relaxed interval.
+//
 // Stops when the main Claude Code input prompt appears ("esc to interrupt").
 func (m *Manager) dismissInferencePrompts(agent *AgentProcess) {
 	const (
-		promptPollInterval   = 1 * time.Second
-		promptDismissTimeout = 60 * time.Second
-		postKeystrokeDelay   = 500 * time.Millisecond
+		// promptFastPollWindow covers the launch window in which the consent
+		// screen normally appears (~5-8s after CLI start).
+		promptFastPollWindow   = 10 * time.Second
+		promptFastPollInterval = 250 * time.Millisecond
+		promptPollInterval     = 1 * time.Second
+		promptDismissTimeout   = 60 * time.Second
+		postKeystrokeDelay     = 500 * time.Millisecond
 	)
 
-	deadline := time.Now().Add(promptDismissTimeout)
+	start := time.Now()
+	deadline := start.Add(promptDismissTimeout)
 	lastPane := ""
 
 	for time.Now().Before(deadline) {
-		time.Sleep(promptPollInterval)
+		interval := promptPollInterval
+		if time.Since(start) < promptFastPollWindow {
+			interval = promptFastPollInterval
+		}
+		time.Sleep(interval)
 
 		pane := m.captureVisiblePaneForAgent(agent)
-		if pane == "" || pane == lastPane {
+		if pane == "" {
+			continue
+		}
+
+		// Bypass-permissions consent screen: handle first and explicitly,
+		// even if the pane is unchanged since the last poll (a mistimed
+		// keystroke must be retried, not skipped). The affirmative option
+		// sits below the default "No, exit".
+		if strings.Contains(pane, bypassConsentTitle) && !strings.Contains(pane, cliWorkingMarker) {
+			m.logger.Info("accepting bypass-permissions consent", "agent", agent.Name)
+			m.confirmMenuOption(agent, bypassConsentTitle, bypassConsentAcceptOption, "Down")
+			lastPane = "" // re-capture fresh on the next pass
+			continue
+		}
+
+		// Custom-API-key approval prompt: the affirmative "Yes" sits ABOVE
+		// the default "No (recommended)" selection, so the generic
+		// Down-then-Enter fallback below would decline it.
+		if strings.Contains(pane, apiKeyPromptTitle) && !strings.Contains(pane, cliWorkingMarker) {
+			m.logger.Info("approving seeded inference API key", "agent", agent.Name)
+			m.confirmMenuOption(agent, apiKeyPromptTitle, apiKeyPromptAcceptOption, "Up")
+			lastPane = ""
+			continue
+		}
+
+		if pane == lastPane {
 			continue
 		}
 		lastPane = pane
@@ -1992,14 +2047,7 @@ func (m *Manager) dismissInferencePrompts(agent *AgentProcess) {
 		}
 
 		// Find the currently selected option (marked with ❯)
-		selected := ""
-		for _, line := range strings.Split(pane, "\n") {
-			trimmed := strings.TrimSpace(line)
-			if strings.HasPrefix(trimmed, "❯") {
-				selected = trimmed
-				break
-			}
-		}
+		selected := selectedMenuOption(pane)
 
 		m.logger.Info("inference prompt detected",
 			"agent", agent.Name,
@@ -2025,6 +2073,50 @@ func (m *Manager) dismissInferencePrompts(agent *AgentProcess) {
 	}
 
 	m.logger.Warn("inference prompt dismissal timed out", "agent", agent.Name)
+}
+
+// selectedMenuOption returns the trimmed text of the "❯"-selected line of an
+// interactive CLI menu, or "" if no line is selected.
+func selectedMenuOption(pane string) string {
+	for _, line := range strings.Split(pane, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "❯") {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+// confirmMenuOption drives an interactive CLI menu identified by title to the
+// option whose text contains want, then confirms it with Enter. Navigation
+// matches the "❯"-selected line text rather than pressing a fixed number of
+// keys, so it lands on the right option whichever position it occupies (menu
+// option order differs between Claude CLI versions). navKey is the arrow key
+// to step with ("Down" or "Up"). Returns true once the option was confirmed
+// or the screen is gone.
+func (m *Manager) confirmMenuOption(agent *AgentProcess, title, want, navKey string) bool {
+	const (
+		// menuMaxNavigateSteps bounds arrow-key navigation; the handled menus
+		// have 2 options, extra headroom covers future variants.
+		menuMaxNavigateSteps = 4
+		postKeystrokeDelay   = 500 * time.Millisecond
+	)
+	for step := 0; step < menuMaxNavigateSteps; step++ {
+		pane := m.captureVisiblePaneForAgent(agent)
+		if !strings.Contains(pane, title) || strings.Contains(pane, cliWorkingMarker) {
+			return true // screen already dismissed
+		}
+		if strings.Contains(selectedMenuOption(pane), want) {
+			m.tmuxSendKeysForAgent(agent, "Enter")
+			time.Sleep(postKeystrokeDelay)
+			return true
+		}
+		m.tmuxSendKeysForAgent(agent, navKey)
+		time.Sleep(postKeystrokeDelay)
+	}
+	m.logger.Warn("inference menu: wanted option not reached",
+		"agent", agent.Name, "title", title, "want", want)
+	return false
 }
 
 const (

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -2875,17 +2875,28 @@ const inferenceConfigMigrationVersion = 13
 
 // inferenceUserConfigSeed returns the required top-level keys for an inference
 // agent's ~/.claude.json. These skip the first-run setup (onboarding,
-// migrations), pre-approve the per-agent inference API key, and pre-accept
-// the "Bypass Permissions mode" consent screen.
+// migrations) and pre-approve the per-agent inference API key.
 //
-// The key name "bypassPermissionsModeAccepted" is verified against Claude CLI
-// v2.1.204: the binary reads it from the .claude.json config accessor and its
-// own sandbox-setup path seeds the same key. Without it every launch with
-// --dangerously-skip-permissions shows a consent menu whose default selection
-// is "No, exit" — if dismissal loses the race, the CLI exits and the pane
-// degrades to bare bash.
+// NOTE: "bypassPermissionsModeAccepted" does NOT suppress the interactive
+// "Bypass Permissions mode" consent dialog — verified live against Claude CLI
+// v2.1.190 and v2.1.204, the dialog is gated only on the settings key
+// "skipDangerousModePermissionPrompt" (see inferenceSettingsSeed). The
+// .claude.json key is still read by non-interactive CLI paths (e.g. the --bg
+// bypass check), so it stays in the seed for those.
+// apiKeyApprovalSuffixLen is how many trailing characters of an API key the
+// Claude CLI compares against customApiKeyResponses.approved entries
+// (key.slice(-20), verified in CLI v2.1.190). Seeding only the full key
+// leaves keys longer than this unapproved — "sk-hive-" plus an agent name
+// over 12 chars — so the CLI shows the "Detected a custom API key" prompt,
+// whose default selection is "No (recommended)".
+const apiKeyApprovalSuffixLen = 20
+
 func inferenceUserConfigSeed(agentName string) map[string]any {
 	apiKey := "sk-hive-" + agentName
+	approved := []string{apiKey}
+	if len(apiKey) > apiKeyApprovalSuffixLen {
+		approved = append(approved, apiKey[len(apiKey)-apiKeyApprovalSuffixLen:])
+	}
 	return map[string]any{
 		"hasCompletedOnboarding":        true,
 		"opusProMigrationComplete":      true,
@@ -2893,9 +2904,34 @@ func inferenceUserConfigSeed(agentName string) map[string]any {
 		"migrationVersion":              inferenceConfigMigrationVersion,
 		"bypassPermissionsModeAccepted": true,
 		"customApiKeyResponses": map[string]any{
-			"approved": []string{apiKey},
+			"approved": approved,
 			"rejected": []string{},
 		},
+	}
+}
+
+// inferenceSettingsSeed returns the required keys for an inference agent's
+// Claude settings.json — both ~/.claude/settings.json (userSettings) and the
+// standalone file passed via --settings (flagSettings).
+//
+// "skipDangerousModePermissionPrompt" is the key that actually suppresses the
+// "Bypass Permissions mode" consent dialog. Verified live against Claude CLI
+// v2.1.190 and v2.1.204 with a scratch HOME: the interactive dialog is gated
+// only on this settings key (honored from userSettings, localSettings,
+// flagSettings, or policySettings), and accepting the dialog interactively
+// persists this same key into ~/.claude/settings.json. Seeding
+// bypassPermissionsModeAccepted in .claude.json does NOT suppress the dialog
+// on either version, and IS_SANDBOX=1 does not suppress it either. Without
+// this key every --dangerously-skip-permissions launch shows a consent menu
+// whose default selection is "No, exit" — if dismissal loses the race, the
+// CLI exits and the pane degrades to bare bash.
+func inferenceSettingsSeed() map[string]any {
+	return map[string]any{
+		"permissions":                       map[string]any{"allow": []any{}, "deny": []any{}},
+		"hasCompletedOnboarding":            true,
+		"bypassPermissions":                 true,
+		"hasAcknowledgedDisclaimer":         true,
+		"skipDangerousModePermissionPrompt": true,
 	}
 }
 
@@ -2905,17 +2941,81 @@ func inferenceUserConfigSeed(agentName string) map[string]any {
 // without bypassPermissionsModeAccepted) and rewrites a file that fails to
 // parse. A complete, parseable file is left untouched.
 func (m *Manager) seedClaudeUserConfig(agentName, path string) {
+	m.seedJSONFile(agentName, path, inferenceUserConfigSeed(agentName))
+	m.mergeApprovedAPIKeys(agentName, path)
+}
+
+// mergeApprovedAPIKeys ensures every seeded approved API key form is present
+// in an existing customApiKeyResponses.approved list. The top-level merge in
+// seedJSONFile skips a key that already exists, which would leave configs
+// seeded by older hive versions without the truncated key form the CLI
+// actually matches against (see apiKeyApprovalSuffixLen).
+func (m *Manager) mergeApprovedAPIKeys(agentName, path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	existing := map[string]any{}
+	if err := json.Unmarshal(data, &existing); err != nil {
+		return
+	}
+	responses, ok := existing["customApiKeyResponses"].(map[string]any)
+	if !ok {
+		return
+	}
+	approved, _ := responses["approved"].([]any)
+	present := make(map[string]bool, len(approved))
+	for _, v := range approved {
+		if s, ok := v.(string); ok {
+			present[s] = true
+		}
+	}
+	seedResponses, _ := inferenceUserConfigSeed(agentName)["customApiKeyResponses"].(map[string]any)
+	seedApproved, _ := seedResponses["approved"].([]string)
+	changed := false
+	for _, key := range seedApproved {
+		if !present[key] {
+			approved = append(approved, key)
+			changed = true
+		}
+	}
+	if !changed {
+		return
+	}
+	responses["approved"] = approved
+	out, err := json.Marshal(existing)
+	if err != nil {
+		return
+	}
+	if err := os.WriteFile(path, out, 0o666); err != nil {
+		m.logger.Warn("failed to write inference config", "agent", agentName, "path", path, "error", err)
+	}
+}
+
+// seedClaudeSettingsFile writes or repairs a Claude settings.json, merging in
+// the keys from inferenceSettingsSeed (e.g. a file seeded by an older hive
+// version without skipDangerousModePermissionPrompt gains the key instead of
+// being skipped by an exists-check).
+func (m *Manager) seedClaudeSettingsFile(agentName, path string) {
+	m.seedJSONFile(agentName, path, inferenceSettingsSeed())
+}
+
+// seedJSONFile merges required top-level keys into the JSON object stored at
+// path. Missing keys are added, existing keys are never overwritten, and a
+// file that fails to parse is rewritten from the seed alone. A complete,
+// parseable file is left untouched.
+func (m *Manager) seedJSONFile(agentName, path string, seed map[string]any) {
 	existing := map[string]any{}
 	if data, err := os.ReadFile(path); err == nil {
 		if jsonErr := json.Unmarshal(data, &existing); jsonErr != nil {
-			m.logger.Warn("inference .claude.json unparseable, rewriting",
+			m.logger.Warn("inference config unparseable, rewriting",
 				"agent", agentName, "path", path, "error", jsonErr)
 			existing = map[string]any{}
 		}
 	}
 
 	needsWrite := false
-	for key, value := range inferenceUserConfigSeed(agentName) {
+	for key, value := range seed {
 		if _, ok := existing[key]; !ok {
 			existing[key] = value
 			needsWrite = true
@@ -2927,11 +3027,11 @@ func (m *Manager) seedClaudeUserConfig(agentName, path string) {
 
 	data, err := json.Marshal(existing)
 	if err != nil {
-		m.logger.Warn("failed to marshal inference .claude.json", "agent", agentName, "error", err)
+		m.logger.Warn("failed to marshal inference config", "agent", agentName, "path", path, "error", err)
 		return
 	}
 	if err := os.WriteFile(path, data, 0o666); err != nil {
-		m.logger.Warn("failed to write inference .claude.json", "agent", agentName, "error", err)
+		m.logger.Warn("failed to write inference config", "agent", agentName, "path", path, "error", err)
 	}
 }
 
@@ -2941,31 +3041,25 @@ func (m *Manager) seedClaudeUserConfig(agentName, path string) {
 // files. Directories use 0o777 so the agent UID can create subdirs freely
 // (hive runs as dev, not root, so chown is not available).
 //
-// The .claude.json seed is repaired on every call (missing keys merged in,
-// corrupt files rewritten) so agents launched by older hive versions pick up
-// newly required keys instead of being skipped by an exists-check.
+// The .claude.json and settings.json seeds are repaired on every call
+// (missing keys merged in, corrupt files rewritten) so agents launched by
+// older hive versions pick up newly required keys instead of being skipped
+// by an exists-check.
 func (m *Manager) ensureClaudeSettings(agentName string, uid int) {
 	homePath := inferenceHomePath(agentName)
 	settingsDir := filepath.Join(homePath, ".claude")
 	settingsFile := filepath.Join(settingsDir, "settings.json")
 
-	settings := `{"permissions":{"allow":[],"deny":[]},"hasCompletedOnboarding":true,"bypassPermissions":true,"hasAcknowledgedDisclaimer":true}`
-
 	if err := os.MkdirAll(settingsDir, 0o777); err != nil {
 		m.logger.Warn("failed to create claude inference home", "agent", agentName, "error", err)
 		return
 	}
-	if _, err := os.Stat(settingsFile); err != nil {
-		if err := os.WriteFile(settingsFile, []byte(settings), 0o666); err != nil {
-			m.logger.Warn("failed to write claude settings", "agent", agentName, "error", err)
-		}
-	}
-	// Also write the standalone settings file for --settings flag
-	if _, err := os.Stat(claudeInferenceSettingsPath); err != nil {
-		_ = os.WriteFile(claudeInferenceSettingsPath, []byte(settings), 0o666)
-	}
-	// Pre-populate (or repair) .claude.json so the CLI skips first-run setup
-	// and interactive consent screens entirely.
+	// Write (or repair) both settings files: the HOME userSettings file and
+	// the standalone file passed via --settings. The CLI honors
+	// skipDangerousModePermissionPrompt from either source.
+	m.seedClaudeSettingsFile(agentName, settingsFile)
+	m.seedClaudeSettingsFile(agentName, claudeInferenceSettingsPath)
+	// Pre-populate (or repair) .claude.json so the CLI skips first-run setup.
 	m.seedClaudeUserConfig(agentName, filepath.Join(homePath, ".claude.json"))
 	m.ensureWorldWritable(homePath)
 }


### PR DESCRIPTION
## Problem

Inference agents still hit the interactive **"Bypass Permissions mode"** consent screen at launch (observed live on the kellyaa pod, image CLI = 2.1.190) despite the #1814 seed. If dismissal loses the race, the CLI exits via the default "No, exit" and the pane degrades to bare bash.

## Root cause (proven live, not static analysis)

Scratch-HOME launches of the CLI in tmux (`--dangerously-skip-permissions --bare --settings <file>`, dead-localhost `ANTHROPIC_BASE_URL`) against **both** v2.1.190 and v2.1.204:

| Seed | 2.1.190 | 2.1.204 |
|---|---|---|
| `.claude.json` `bypassPermissionsModeAccepted: true` (#1814 seed) | consent shown | **consent shown** |
| settings `skipDangerousModePermissionPrompt: true` (HOME or `--settings` file) | suppressed | suppressed |
| `IS_SANDBOX=1`, no skip key | consent shown | — |

The CLI bundle confirms it: the dialog is gated solely on `skipDangerousModePermissionPrompt` across userSettings/localSettings/flagSettings/policySettings, and **accepting the dialog interactively persists exactly that key into `~/.claude/settings.json`** — matching the pod observation that accepting wrote nothing into `.claude.json`. The #1814 verification was static string analysis and does not hold on either version, so **no CLI pin bump is made** (bumping would not fix anything; `.claude.json` seeding stays for the CLI's non-interactive paths, e.g. the `--bg` bypass check).

Bonus find: the CLI matches `ANTHROPIC_API_KEY` against `customApiKeyResponses.approved` by the key's **last 20 chars** (`key.slice(-20)`), so agents with names >12 chars also faced a "Detected a custom API key" prompt defaulting to "No (recommended)". Both key forms are now seeded.

## Changes

1. **Seed `skipDangerousModePermissionPrompt`** into both settings files (per-agent HOME + standalone `--settings` file), with merge-repair so existing agents seeded by older hive versions gain the key.
2. **Seed the truncated API-key approval form** alongside the full key, merged into existing configs.
3. **Harden the dismisser** as last line of defense: consent screen handled first and explicitly (retries even on an unchanged pane), menus navigated by matching the ❯-selected text instead of fixed Down counts, explicit handling for the API-key prompt (affirmative option is *above* the default), and 250ms polling for the first 10s (consent appears ~5-8s after launch).

## Verification

End-to-end with the exact Go-generated seed files: both v2.1.190 and v2.1.204 launch straight to the ready prompt with **zero** interactive screens. `go build`, `go vet`, new + existing seed/consent tests pass; new code is gofmt-clean (the two pre-existing env-count test failures on this package reproduce identically on clean origin/v2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)