### PR TITLE
feat(dashboard-api): union static Claude aliases into LiteLLM model dropdown

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -353,6 +353,54 @@ type GovernorConfig struct {
 	Budget        BudgetConfig          `yaml:"budget"`
 	Logging       LoggingConfig         `yaml:"logging"`
 	LiteLLM       LiteLLMConfig         `yaml:"litellm"`
+	VLLM          InferenceAuthConfig   `yaml:"vllm"`
+	LLMD          InferenceAuthConfig   `yaml:"llm-d"`
+}
+
+// Discovery-auth defaults for the self-hosted inference backends. Like
+// LiteLLM, hive.yaml stores only the env var NAME and/or key FILE PATH —
+// never the key value itself (Config.Save() writes the expanded config
+// back to disk, so a key value in YAML would be persisted in plaintext).
+const (
+	// DefaultVLLMAPIKeyEnv is the env var consulted for the vLLM model
+	// discovery API key when governor.vllm.api_key_env is not set.
+	DefaultVLLMAPIKeyEnv = "HIVE_VLLM_API_KEY"
+	// DefaultLLMDAPIKeyEnv is the env var consulted for the llm-d model
+	// discovery API key when governor.llm-d.api_key_env is not set.
+	DefaultLLMDAPIKeyEnv = "HIVE_LLMD_API_KEY"
+)
+
+// InferenceAuthConfig holds optional /v1/models discovery auth for a
+// self-hosted inference backend (vllm, llm-d). Plain vLLM/llm-d servers
+// need no key, but the configured endpoint may actually be a LiteLLM
+// gateway, which entitlement-filters /v1/models per API key and hides
+// key-gated models from anonymous callers.
+type InferenceAuthConfig struct {
+	APIKeyEnv  string `yaml:"api_key_env"`  // env var NAME holding the key; never the key value
+	APIKeyFile string `yaml:"api_key_file"` // path to a file holding the key
+}
+
+// ResolveAPIKey returns the backend's discovery API key using the
+// resolution order: key file (api_key_file) → env var named by
+// api_key_env → defaultEnv. Returns "" when no key is configured. The key
+// value itself is never stored in hive.yaml.
+func (c *InferenceAuthConfig) ResolveAPIKey(defaultEnv string) string {
+	if c.APIKeyFile != "" {
+		if data, err := os.ReadFile(c.APIKeyFile); err == nil {
+			if key := strings.TrimSpace(string(data)); key != "" {
+				return key
+			}
+		}
+	}
+	if c.APIKeyEnv != "" {
+		if key := os.Getenv(c.APIKeyEnv); key != "" {
+			return key
+		}
+	}
+	if defaultEnv != "" {
+		return os.Getenv(defaultEnv)
+	}
+	return ""
 }
 
 type LoggingConfig struct {

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3513,14 +3513,12 @@ func (s *Server) handleInferenceModels(w http.ResponseWriter, r *http.Request) {
 	fallback := false
 	if len(models) == 0 {
 		s.logger.Warn("no models found from any endpoint", "backend", backend, "endpoints", len(endpoints))
-		if backend == "litellm" {
-			// Discovery is authoritative (LiteLLM entitlement-filters
-			// /v1/models per API key); only when it fails do we fall back
-			// to the common static aliases, flagged so the UI can mark
-			// them as unverified against the configured key.
-			models = litellmStaticModelAliases
-			fallback = true
-		}
+		// Discovery is authoritative (a LiteLLM gateway entitlement-filters
+		// /v1/models per API key); only when it fails do we fall back to
+		// the common static aliases, flagged so the UI can mark them as
+		// unverified against the configured endpoint/key.
+		models = inferenceStaticModelAliases
+		fallback = true
 	}
 	jsonResponse(w, map[string]interface{}{
 		"backend":  backend,
@@ -3530,36 +3528,55 @@ func (s *Server) handleInferenceModels(w http.ResponseWriter, r *http.Request) {
 }
 
 // inferenceAPIKey returns the bearer key used for a backend's model
-// discovery requests. Only litellm requires auth on /v1/models;
-// vllm/llm-d endpoints are unauthenticated.
+// discovery requests. litellm requires auth on /v1/models. vllm/llm-d are
+// usually unauthenticated, but the configured endpoint may in fact be a
+// LiteLLM gateway, which entitlement-filters /v1/models and hides
+// key-gated models from anonymous callers — so resolve a backend-specific
+// key first (governor.vllm / governor.llm-d api_key_env|api_key_file, or
+// the HIVE_VLLM_API_KEY / HIVE_LLMD_API_KEY defaults), then fall back to
+// the litellm key. A plain vLLM/llm-d server without --api-key ignores the
+// Authorization header, so sending a key is harmless there.
 func (s *Server) inferenceAPIKey(backend string) string {
-	if backend != "litellm" || s.deps == nil || s.deps.Config == nil {
+	if s.deps == nil || s.deps.Config == nil {
 		return ""
 	}
-	return s.deps.Config.Governor.LiteLLM.ResolveAPIKey()
+	gov := &s.deps.Config.Governor
+	switch backend {
+	case "vllm":
+		if key := gov.VLLM.ResolveAPIKey(config.DefaultVLLMAPIKeyEnv); key != "" {
+			return key
+		}
+	case "llm-d":
+		if key := gov.LLMD.ResolveAPIKey(config.DefaultLLMDAPIKeyEnv); key != "" {
+			return key
+		}
+	}
+	return gov.LiteLLM.ResolveAPIKey()
 }
 
-// litellmStaticModelAliases is the FALLBACK model list for the LiteLLM
-// dropdown, offered only when authed model discovery against the configured
-// endpoint fails (or no endpoint/env override is configured), so the
-// dropdown is never empty. Discovery is authoritative: LiteLLM's /v1/models
-// is entitlement-filtered per API key, so when discovery succeeds we show
-// ONLY the discovered set — appending these aliases on top would offer
-// unlicensed models that just 403 at runtime. The entries are the common
-// Claude/Gemini CLI-backend models in the UNDERSCORE version convention
-// LiteLLM proxies expect (claude-opus-4_8, gemini-2_5-pro) — unlike the
-// Claude CLI (hyphens, claude-opus-4-8) and the Copilot/Gemini backends
-// (dots, claude-opus-4.8 / gemini-2.5-pro). Derived from the
-// CLAUDE_CLI_MODELS/COPILOT_CLI_MODELS lists in static/index.html and the
-// gemini backend list in handleBackends; keep in sync when those change.
-var litellmStaticModelAliases = []string{
-	"claude-opus-4_8",
-	"claude-opus-4_7",
-	"claude-opus-4_6",
-	"claude-sonnet-4_6",
-	"claude-haiku-4_5",
-	"gemini-2_5-pro",
-	"gemini-2_5-flash",
+// inferenceStaticModelAliases is the FALLBACK model list for the inference
+// model dropdowns (vllm, llm-d, litellm), offered only when runtime
+// /v1/models discovery against the backend's configured endpoint fails
+// (and no HIVE_*_MODELS env override is set), so a dropdown is never
+// empty. Discovery is authoritative: a LiteLLM gateway entitlement-filters
+// /v1/models per API key, so when discovery succeeds we show ONLY the
+// discovered set — appending these aliases on top would offer unlicensed
+// models that just 403 at runtime. The entries use the LiteLLM gateway
+// naming convention observed live: UNDERSCORES between words and a DOT in
+// the version (claude_opus_4.8) — unlike the Claude CLI (all hyphens,
+// claude-opus-4-8) and the Copilot/Gemini backends (hyphenated words with
+// a dotted version, claude-opus-4.8 / gemini-2.5-pro). Model set derived
+// from the CLAUDE_CLI_MODELS/COPILOT_CLI_MODELS lists in static/index.html
+// and the gemini backend list in handleBackends; keep in sync when those
+// change.
+var inferenceStaticModelAliases = []string{
+	"claude_opus_4.8",
+	"claude_opus_4.7",
+	"claude_opus_4.6",
+	"claude_sonnet_4.6",
+	"claude_haiku_4.5",
+	"gemini_2.5_pro",
+	"gemini_2.5_flash",
 }
 
 func (s *Server) queryInferenceModels(backend string) []string {
@@ -3579,12 +3596,9 @@ func (s *Server) queryInferenceModels(backend string) []string {
 	if val := os.Getenv(envVar); val != "" {
 		return inferenceModelsFromEnv(envVar, "")
 	}
-	if backend == "litellm" {
-		// Discovery failed or litellm is unconfigured — fall back to the
-		// common static aliases (unverified against any API key).
-		return litellmStaticModelAliases
-	}
-	return nil
+	// Discovery failed or the backend is unconfigured — fall back to the
+	// common static aliases (unverified against any endpoint/key).
+	return inferenceStaticModelAliases
 }
 
 const inferenceModelQueryTimeout = 5 * time.Second

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3514,9 +3514,10 @@ func (s *Server) handleInferenceModels(w http.ResponseWriter, r *http.Request) {
 		s.logger.Warn("no models found from any endpoint", "backend", backend, "endpoints", len(endpoints))
 	}
 	if backend == "litellm" {
-		// LiteLLM also proxies the Claude CLI/Copilot model families —
-		// offer those aliases in addition to whatever the endpoint reports.
-		models = unionLitellmClaudeModels(models)
+		// LiteLLM also proxies the Claude and Gemini CLI-backend model
+		// families — offer those aliases in addition to whatever the
+		// endpoint reports.
+		models = unionLitellmStaticModels(models)
 	}
 	jsonResponse(w, map[string]interface{}{
 		"backend": backend,
@@ -3534,38 +3535,39 @@ func (s *Server) inferenceAPIKey(backend string) string {
 	return s.deps.Config.Governor.LiteLLM.ResolveAPIKey()
 }
 
-// litellmClaudeModelAliases is the static list of Claude-family models that
-// are reachable through the claude/copilot CLI backends and therefore worth
-// offering in the LiteLLM model dropdown alongside live-discovered endpoint
-// models. LiteLLM proxies expect these aliases with UNDERSCORE version
-// separators (claude-opus-4_8) — unlike the Claude CLI (hyphens,
-// claude-opus-4-8) and the Copilot CLI (dots, claude-opus-4.8). Derived from
-// the CLAUDE_CLI_MODELS/COPILOT_CLI_MODELS lists in static/index.html; keep
-// in sync when those lists change.
-var litellmClaudeModelAliases = []string{
+// litellmStaticModelAliases is the static list of Claude- and Gemini-family
+// models that are reachable through the claude/copilot/gemini CLI backends
+// and therefore worth offering in the LiteLLM model dropdown alongside
+// live-discovered endpoint models. LiteLLM proxies expect these aliases with
+// UNDERSCORE version separators (claude-opus-4_8, gemini-2_5-pro) — unlike
+// the Claude CLI (hyphens, claude-opus-4-8) and the Copilot/Gemini backends
+// (dots, claude-opus-4.8 / gemini-2.5-pro). Derived from the
+// CLAUDE_CLI_MODELS/COPILOT_CLI_MODELS lists in static/index.html and the
+// gemini backend list in handleBackends; keep in sync when those change.
+var litellmStaticModelAliases = []string{
 	"claude-opus-4_8",
 	"claude-opus-4_7",
 	"claude-opus-4_6",
 	"claude-sonnet-4_6",
-	"claude-sonnet-4_5",
 	"claude-haiku-4_5",
-	"claude-fable-5",
+	"gemini-2_5-pro",
+	"gemini-2_5-flash",
 }
 
-// unionLitellmClaudeModels merges the models discovered from the LiteLLM
-// endpoint with the static Claude aliases. Discovered models keep their
-// order and come first; static aliases are appended after, de-duplicated —
-// a discovered model with the same name wins and appears once.
-func unionLitellmClaudeModels(discovered []string) []string {
+// unionLitellmStaticModels merges the models discovered from the LiteLLM
+// endpoint with the static aliases. Discovered models keep their order and
+// come first; static aliases are appended after, de-duplicated — a
+// discovered model with the same name wins and appears once.
+func unionLitellmStaticModels(discovered []string) []string {
 	seen := make(map[string]bool, len(discovered))
-	merged := make([]string, 0, len(discovered)+len(litellmClaudeModelAliases))
+	merged := make([]string, 0, len(discovered)+len(litellmStaticModelAliases))
 	for _, m := range discovered {
 		if !seen[m] {
 			seen[m] = true
 			merged = append(merged, m)
 		}
 	}
-	for _, m := range litellmClaudeModelAliases {
+	for _, m := range litellmStaticModelAliases {
 		if !seen[m] {
 			seen[m] = true
 			merged = append(merged, m)
@@ -3592,7 +3594,7 @@ func (s *Server) queryInferenceModels(backend string) []string {
 		}
 	}
 	if backend == "litellm" {
-		return unionLitellmClaudeModels(models)
+		return unionLitellmStaticModels(models)
 	}
 	return models
 }

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3513,6 +3513,11 @@ func (s *Server) handleInferenceModels(w http.ResponseWriter, r *http.Request) {
 	if len(models) == 0 {
 		s.logger.Warn("no models found from any endpoint", "backend", backend, "endpoints", len(endpoints))
 	}
+	if backend == "litellm" {
+		// LiteLLM also proxies the Claude CLI/Copilot model families —
+		// offer those aliases in addition to whatever the endpoint reports.
+		models = unionLitellmClaudeModels(models)
+	}
 	jsonResponse(w, map[string]interface{}{
 		"backend": backend,
 		"models":  models,
@@ -3529,24 +3534,67 @@ func (s *Server) inferenceAPIKey(backend string) string {
 	return s.deps.Config.Governor.LiteLLM.ResolveAPIKey()
 }
 
-func (s *Server) queryInferenceModels(backend string) []string {
-	if endpoints, ok := s.getInferenceEndpoints(backend); ok {
-		models := fetchModelsFromEndpoints(endpoints, s.inferenceAPIKey(backend))
-		if len(models) > 0 {
-			return models
+// litellmClaudeModelAliases is the static list of Claude-family models that
+// are reachable through the claude/copilot CLI backends and therefore worth
+// offering in the LiteLLM model dropdown alongside live-discovered endpoint
+// models. LiteLLM proxies expect these aliases with UNDERSCORE version
+// separators (claude-opus-4_8) — unlike the Claude CLI (hyphens,
+// claude-opus-4-8) and the Copilot CLI (dots, claude-opus-4.8). Derived from
+// the CLAUDE_CLI_MODELS/COPILOT_CLI_MODELS lists in static/index.html; keep
+// in sync when those lists change.
+var litellmClaudeModelAliases = []string{
+	"claude-opus-4_8",
+	"claude-opus-4_7",
+	"claude-opus-4_6",
+	"claude-sonnet-4_6",
+	"claude-sonnet-4_5",
+	"claude-haiku-4_5",
+	"claude-fable-5",
+}
+
+// unionLitellmClaudeModels merges the models discovered from the LiteLLM
+// endpoint with the static Claude aliases. Discovered models keep their
+// order and come first; static aliases are appended after, de-duplicated —
+// a discovered model with the same name wins and appears once.
+func unionLitellmClaudeModels(discovered []string) []string {
+	seen := make(map[string]bool, len(discovered))
+	merged := make([]string, 0, len(discovered)+len(litellmClaudeModelAliases))
+	for _, m := range discovered {
+		if !seen[m] {
+			seen[m] = true
+			merged = append(merged, m)
 		}
 	}
-	envVar := "HIVE_VLLM_MODELS"
-	switch backend {
-	case "llm-d":
-		envVar = "HIVE_LLMD_MODELS"
-	case "litellm":
-		envVar = "HIVE_LITELLM_MODELS"
+	for _, m := range litellmClaudeModelAliases {
+		if !seen[m] {
+			seen[m] = true
+			merged = append(merged, m)
+		}
 	}
-	if val := os.Getenv(envVar); val != "" {
-		return inferenceModelsFromEnv(envVar, "")
+	return merged
+}
+
+func (s *Server) queryInferenceModels(backend string) []string {
+	var models []string
+	if endpoints, ok := s.getInferenceEndpoints(backend); ok {
+		models = fetchModelsFromEndpoints(endpoints, s.inferenceAPIKey(backend))
 	}
-	return nil
+	if len(models) == 0 {
+		envVar := "HIVE_VLLM_MODELS"
+		switch backend {
+		case "llm-d":
+			envVar = "HIVE_LLMD_MODELS"
+		case "litellm":
+			envVar = "HIVE_LITELLM_MODELS"
+		}
+		if val := os.Getenv(envVar); val != "" {
+			models = inferenceModelsFromEnv(envVar, "")
+		}
+	}
+	if backend == "litellm" {
+		return unionLitellmClaudeModels(models)
+	}
+	return models
 }
 
 const inferenceModelQueryTimeout = 5 * time.Second

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3510,18 +3510,22 @@ func (s *Server) handleInferenceModels(w http.ResponseWriter, r *http.Request) {
 	}
 
 	models := fetchModelsFromEndpoints(endpoints, s.inferenceAPIKey(backend))
+	fallback := false
 	if len(models) == 0 {
 		s.logger.Warn("no models found from any endpoint", "backend", backend, "endpoints", len(endpoints))
-	}
-	if backend == "litellm" {
-		// LiteLLM also proxies the Claude and Gemini CLI-backend model
-		// families — offer those aliases in addition to whatever the
-		// endpoint reports.
-		models = unionLitellmStaticModels(models)
+		if backend == "litellm" {
+			// Discovery is authoritative (LiteLLM entitlement-filters
+			// /v1/models per API key); only when it fails do we fall back
+			// to the common static aliases, flagged so the UI can mark
+			// them as unverified against the configured key.
+			models = litellmStaticModelAliases
+			fallback = true
+		}
 	}
 	jsonResponse(w, map[string]interface{}{
-		"backend": backend,
-		"models":  models,
+		"backend":  backend,
+		"models":   models,
+		"fallback": fallback,
 	})
 }
 
@@ -3535,12 +3539,16 @@ func (s *Server) inferenceAPIKey(backend string) string {
 	return s.deps.Config.Governor.LiteLLM.ResolveAPIKey()
 }
 
-// litellmStaticModelAliases is the static list of Claude- and Gemini-family
-// models that are reachable through the claude/copilot/gemini CLI backends
-// and therefore worth offering in the LiteLLM model dropdown alongside
-// live-discovered endpoint models. LiteLLM proxies expect these aliases with
-// UNDERSCORE version separators (claude-opus-4_8, gemini-2_5-pro) — unlike
-// the Claude CLI (hyphens, claude-opus-4-8) and the Copilot/Gemini backends
+// litellmStaticModelAliases is the FALLBACK model list for the LiteLLM
+// dropdown, offered only when authed model discovery against the configured
+// endpoint fails (or no endpoint/env override is configured), so the
+// dropdown is never empty. Discovery is authoritative: LiteLLM's /v1/models
+// is entitlement-filtered per API key, so when discovery succeeds we show
+// ONLY the discovered set — appending these aliases on top would offer
+// unlicensed models that just 403 at runtime. The entries are the common
+// Claude/Gemini CLI-backend models in the UNDERSCORE version convention
+// LiteLLM proxies expect (claude-opus-4_8, gemini-2_5-pro) — unlike the
+// Claude CLI (hyphens, claude-opus-4-8) and the Copilot/Gemini backends
 // (dots, claude-opus-4.8 / gemini-2.5-pro). Derived from the
 // CLAUDE_CLI_MODELS/COPILOT_CLI_MODELS lists in static/index.html and the
 // gemini backend list in handleBackends; keep in sync when those change.
@@ -3554,49 +3562,29 @@ var litellmStaticModelAliases = []string{
 	"gemini-2_5-flash",
 }
 
-// unionLitellmStaticModels merges the models discovered from the LiteLLM
-// endpoint with the static aliases. Discovered models keep their order and
-// come first; static aliases are appended after, de-duplicated — a
-// discovered model with the same name wins and appears once.
-func unionLitellmStaticModels(discovered []string) []string {
-	seen := make(map[string]bool, len(discovered))
-	merged := make([]string, 0, len(discovered)+len(litellmStaticModelAliases))
-	for _, m := range discovered {
-		if !seen[m] {
-			seen[m] = true
-			merged = append(merged, m)
-		}
-	}
-	for _, m := range litellmStaticModelAliases {
-		if !seen[m] {
-			seen[m] = true
-			merged = append(merged, m)
-		}
-	}
-	return merged
-}
-
 func (s *Server) queryInferenceModels(backend string) []string {
-	var models []string
 	if endpoints, ok := s.getInferenceEndpoints(backend); ok {
-		models = fetchModelsFromEndpoints(endpoints, s.inferenceAPIKey(backend))
+		models := fetchModelsFromEndpoints(endpoints, s.inferenceAPIKey(backend))
+		if len(models) > 0 {
+			return models
+		}
 	}
-	if len(models) == 0 {
-		envVar := "HIVE_VLLM_MODELS"
-		switch backend {
-		case "llm-d":
-			envVar = "HIVE_LLMD_MODELS"
-		case "litellm":
-			envVar = "HIVE_LITELLM_MODELS"
-		}
-		if val := os.Getenv(envVar); val != "" {
-			models = inferenceModelsFromEnv(envVar, "")
-		}
+	envVar := "HIVE_VLLM_MODELS"
+	switch backend {
+	case "llm-d":
+		envVar = "HIVE_LLMD_MODELS"
+	case "litellm":
+		envVar = "HIVE_LITELLM_MODELS"
+	}
+	if val := os.Getenv(envVar); val != "" {
+		return inferenceModelsFromEnv(envVar, "")
 	}
 	if backend == "litellm" {
-		return unionLitellmStaticModels(models)
+		// Discovery failed or litellm is unconfigured — fall back to the
+		// common static aliases (unverified against any API key).
+		return litellmStaticModelAliases
 	}
-	return models
+	return nil
 }
 
 const inferenceModelQueryTimeout = 5 * time.Second

--- a/v2/pkg/dashboard/coverage_boost2_test.go
+++ b/v2/pkg/dashboard/coverage_boost2_test.go
@@ -673,9 +673,11 @@ func TestQueryInferenceModels_DefaultModel(t *testing.T) {
 	t.Setenv("HIVE_VLLM_MODELS", "")
 	t.Setenv("HIVE_LLMD_MODELS", "")
 
+	// With no endpoints registered and no env override, every inference
+	// backend falls back to the static common aliases.
 	models := srv.queryInferenceModels("vllm")
-	if len(models) != 1 {
-		t.Errorf("expected 1 default model, got %v", models)
+	if len(models) != len(inferenceStaticModelAliases) {
+		t.Errorf("expected %d static fallback aliases, got %v", len(inferenceStaticModelAliases), models)
 	}
 }
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -9569,6 +9569,27 @@ function burnAreaChart() {
       }
     }
 
+    // Refresh an inference backend's model list whenever its dropdown is
+    // opened, so options reflect runtime state (endpoint/key changes, new
+    // models). fetchInferenceModels rate-limits via its
+    // INFERENCE_MODEL_CACHE_TTL_MS cache, so this cannot hammer the API.
+    document.addEventListener('focusin', async (e) => {
+      const sel = e.target;
+      if (!sel || !sel.matches || !sel.matches('select[data-change-action="switchModel"]')) return;
+      const agentName = sel.dataset.agent;
+      const a = (window._lastAgents || []).find(x => x.name === agentName);
+      const backend = a && a.cli;
+      if (!backend || !INFERENCE_BACKENDS.includes(backend)) return;
+      const prev = JSON.stringify(INFERENCE_MODELS[backend] || []);
+      const models = await fetchInferenceModels(backend);
+      if (JSON.stringify(models) !== prev) {
+        const current = sel.value;
+        sel.innerHTML = '<option value="">model ▾</option>' +
+          models.map(m => `<option value="${m.value}">${m.label}</option>`).join('');
+        sel.value = current;
+      }
+    });
+
     async function switchModel(agent, model) {
       if (!model) return;
       const toast = showToast(`Switching ${agent} model → ${model} (restarting session)...`, 'info', true);

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4400,7 +4400,10 @@
       try {
         const resp = await fetch(`/api/inference/models/${encodeURIComponent(backend)}`);
         const data = await resp.json();
-        const models = (data.models || []).map(m => ({ value: m, label: m.split('/').pop() }));
+        // data.fallback: endpoint discovery failed and the server returned
+        // static common aliases — mark them as unverified against the key.
+        const labelSuffix = data.fallback ? ' (common alias, unverified)' : '';
+        const models = (data.models || []).map(m => ({ value: m, label: m.split('/').pop() + labelSuffix }));
         INFERENCE_MODELS[backend] = models;
         _inferenceModelCache[backend] = { models, ts: now };
         return models;


### PR DESCRIPTION
## Summary
Uniform, comprehensive runtime model auto-discovery for all three inference backends (vllm, llm-d, litellm) on the spoke dashboard (v2), plus a never-empty fallback model list.

### Discovery (authoritative)
- All three backends query OpenAI-compatible `GET /v1/models` on their configured endpoint at runtime — no server-side cache, every dropdown request is a live fetch.
- **Auth for all three**: `inferenceAPIKey` resolves a backend-specific key first — new optional `governor.vllm` / `governor.llm-d` sections (`api_key_env` / `api_key_file`, defaults `HIVE_VLLM_API_KEY` / `HIVE_LLMD_API_KEY`; only env var names / file paths are stored, never key values) — then falls back to the litellm key. This fixes keyless discovery against a LiteLLM gateway fronting the vllm method, which entitlement-filters `/v1/models` and hid key-gated models (dropdown showed only deepseek). Plain vLLM/llm-d servers ignore the Authorization header.
- When discovery succeeds, the dropdown shows ONLY the discovered set (offering unlicensed models would 403 at runtime).

### Fallback (never-empty dropdown)
- When discovery fails and no `HIVE_*_MODELS` env override is set, all three backends fall back to `inferenceStaticModelAliases` in `v2/pkg/dashboard/api.go`, using the LiteLLM gateway naming convention observed live (underscores between words, dot in version): `claude_opus_4.8`, `claude_opus_4.7`, `claude_opus_4.6`, `claude_sonnet_4.6`, `claude_haiku_4.5`, `gemini_2.5_pro`, `gemini_2.5_flash` — vs Claude CLI all-hyphens (`claude-opus-4-8`) and Copilot/Gemini dotted versions (`claude-opus-4.8`). Model set derived from the existing `CLAUDE_CLI_MODELS`/`COPILOT_CLI_MODELS` sets and the gemini backend list.
- `/api/inference/models/{backend}` returns a `fallback` flag; the dashboard JS suffixes fallback option labels with `(common alias, unverified)`.

### Freshness
- Inference model dropdowns re-fetch on focus/open (rate-limited by the existing `INFERENCE_MODEL_CACHE_TTL_MS` client cache); governor litellm config save re-registers the endpoint and SSE-refreshes clients immediately; keys are resolved fresh at every discovery call.

### Also
- Fixes `TestQueryInferenceModels_DefaultModel` (previously failing on v2) to assert the static fallback.

## Test plan
- gofmt -e clean on changed code; `go build ./...`; targeted dashboard + config tests pass locally; JS parse check on index.html script blocks
- CI: build-and-test + docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)