### PR TITLE
Fix contributor issue reassignment loop

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -7,7 +7,7 @@ set shell := ["bash", "-euo", "pipefail", "-c"]
 
 hive_image := env("HIVE_CONTRIBUTOR_IMAGE", "ghcr.io/kubestellar/hive-contributor:latest")
 hive_hub := env("HIVE_HUB", "wss://hive.kubestellar.io/contribute")
-config_dir := env("HOME") + "/.config/hive"
+config_dir := env("HIVE_CONFIG_DIR", env("HOME") + "/.config/hive")
 
 # Show available commands
 default:

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -94,7 +94,7 @@ function getCLIState() {
     } else if (BACKEND === 'bob') {
       if (/bob>|>\s*$|Bob-Shell/.test(text)) return 'ready';
     } else if (BACKEND === 'codex') {
-      if (/codex>|>\s*$|Codex CLI/.test(text)) return 'ready';
+      if (/codex>|>\s*$|›\s+Explain this codebase|model:\s+.*\/model to change|Codex CLI/.test(text)) return 'ready';
     } else if (BACKEND === 'pi') {
       if (/pi v\d|0\.0%|auto\)|\d+\.\d+%/.test(text)) return 'ready';
     } else {
@@ -314,7 +314,7 @@ function checkTmuxIdle() {
       hasCompletionMarker = /completed|done|finished|✓/i.test(text);
       isWorking = /running|executing|thinking/i.test(text);
     } else if (BACKEND === 'codex') {
-      hasIdlePrompt = /codex>|>\s*$/.test(text);
+      hasIdlePrompt = /codex>|>\s*$|›\s+Explain this codebase|model:\s+.*\/model to change/.test(text);
       hasCompletionMarker = /completed|done|finished/i.test(text);
       isWorking = /running|executing|thinking/i.test(text);
     } else if (BACKEND === 'pi') {

--- a/bin/contributor-relay.sh
+++ b/bin/contributor-relay.sh
@@ -314,9 +314,10 @@ function checkTmuxIdle() {
       hasCompletionMarker = /completed|done|finished|✓/i.test(text);
       isWorking = /running|executing|thinking/i.test(text);
     } else if (BACKEND === 'codex') {
-      hasIdlePrompt = /codex>|>\s*$|›\s+Explain this codebase|model:\s+.*\/model to change/.test(text);
+      const lastLines = text.split('\n').slice(-20).join('\n');
+      hasIdlePrompt = /codex>|>\s*$|›\s+(Explain this codebase|Write tests for @filename)|model:\s+.*\/model to change/.test(lastLines);
       hasCompletionMarker = /completed|done|finished/i.test(text);
-      isWorking = /running|executing|thinking/i.test(text);
+      isWorking = /running|executing|thinking/i.test(lastLines);
     } else if (BACKEND === 'pi') {
       hasIdlePrompt = /pi v\d|0\.0%|auto\)|\d+\.\d+%/.test(text);
       hasCompletionMarker = /completed|done|finished|tokens\)|\d+\.\d+%/i.test(text);

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -10407,7 +10407,7 @@ function burnAreaChart() {
     const TREND_REFRESH_MS = 900000;
     window._timelineData = [];
     function fetchTimeline() {
-      fetch('/api/timeline').then(r => r.json()).then(d => { window._timelineData = d; }).catch(() => {});
+      return fetch('/api/timeline').then(r => r.json()).then(d => { window._timelineData = d; }).catch(() => {});
     }
     const TIMELINE_REFRESH_MS = 60000;
     // ── Configuration Dialog ──────────────────────────────────────────

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -51,6 +51,7 @@ type PullRequest struct {
 	Repo      string    `json:"repo"`
 	Number    int       `json:"number"`
 	Title     string    `json:"title"`
+	Body      string    `json:"body,omitempty"`
 	Author    string    `json:"author"`
 	Labels    []string  `json:"labels"`
 	Draft     bool      `json:"draft"`
@@ -62,12 +63,12 @@ type PullRequest struct {
 }
 
 type ActionableResult struct {
-	GeneratedAt   time.Time          `json:"generated_at"`
-	Issues        IssueResult        `json:"issues"`
-	PRs           PRResult           `json:"prs"`
-	Hold          HoldResult         `json:"hold"`
-	Clusters      []IssueCluster     `json:"clusters,omitempty"`
-	TotalByRepo   map[string]RepoCounts `json:"total_by_repo,omitempty"`
+	GeneratedAt time.Time             `json:"generated_at"`
+	Issues      IssueResult           `json:"issues"`
+	PRs         PRResult              `json:"prs"`
+	Hold        HoldResult            `json:"hold"`
+	Clusters    []IssueCluster        `json:"clusters,omitempty"`
+	TotalByRepo map[string]RepoCounts `json:"total_by_repo,omitempty"`
 }
 
 type RepoCounts struct {
@@ -87,10 +88,10 @@ type PRResult struct {
 }
 
 type HoldResult struct {
-	Issues int         `json:"issues"`
-	PRs    int         `json:"prs"`
-	Total  int         `json:"total"`
-	Items  []HoldItem  `json:"items"`
+	Issues int        `json:"issues"`
+	PRs    int        `json:"prs"`
+	Total  int        `json:"total"`
+	Items  []HoldItem `json:"items"`
 }
 
 type HoldItem struct {
@@ -180,6 +181,7 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 
 	var allIssues []Issue
 	var allPRs []PullRequest
+	var issueLinkingPRs []PullRequest
 	var holdItems []HoldItem
 	totalByRepo := make(map[string]RepoCounts)
 
@@ -197,7 +199,7 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 		allIssues = append(allIssues, issues...)
 		holdItems = append(holdItems, held...)
 
-		prs, heldPRs, prTotal, err := c.fetchPRs(ctx, repo)
+		prs, linkedPRs, heldPRs, prTotal, err := c.fetchPRs(ctx, repo)
 		if err != nil {
 			c.logger.Warn("failed to fetch PRs", "repo", repo, "error", err)
 			failedRepos++
@@ -205,10 +207,12 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 			continue
 		}
 		allPRs = append(allPRs, prs...)
+		issueLinkingPRs = append(issueLinkingPRs, linkedPRs...)
 		holdItems = append(holdItems, heldPRs...)
 
 		totalByRepo[repo] = RepoCounts{Issues: issueTotal, PRs: prTotal}
 	}
+	allIssues = filterIssuesWithOpenRepairPRs(allIssues, issueLinkingPRs)
 
 	// If every repo failed (e.g. API rate limit exhausted), returning a
 	// zero-count result would tell the governor the queue is empty and
@@ -328,7 +332,7 @@ func (c *Client) fetchIssues(ctx context.Context, repo string, now time.Time) (a
 	return actionable, held, totalIssues, nil
 }
 
-func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRequest, held []HoldItem, totalPRs int, err error) {
+func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRequest, issueLinking []PullRequest, held []HoldItem, totalPRs int, err error) {
 	owner, repoName := c.splitRepo(repo)
 	opts := &gh.PullRequestListOptions{
 		State:       "open",
@@ -339,7 +343,7 @@ func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRe
 	for {
 		prs, resp, err := c.client.PullRequests.List(ctx, owner, repoName, opts)
 		if err != nil {
-			return nil, nil, 0, fmt.Errorf("listing PRs for %s/%s: %w", owner, repoName, err)
+			return nil, nil, nil, 0, fmt.Errorf("listing PRs for %s/%s: %w", owner, repoName, err)
 		}
 		allPRs = append(allPRs, prs...)
 		if resp.NextPage == 0 {
@@ -351,6 +355,24 @@ func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRe
 	for _, pr := range allPRs {
 		totalPRs++
 		labels := extractPRLabels(pr.Labels)
+		candidate := PullRequest{
+			Repo:      repo,
+			Number:    pr.GetNumber(),
+			Title:     pr.GetTitle(),
+			Body:      pr.GetBody(),
+			Author:    safeGetLogin(pr.GetUser()),
+			Labels:    labels,
+			Draft:     pr.GetDraft(),
+			CreatedAt: pr.GetCreatedAt().Time,
+			URL:       pr.GetHTMLURL(),
+			Mergeable: pr.GetMergeable(),
+		}
+		if pr.GetHead() != nil {
+			candidate.HeadSHA = pr.GetHead().GetSHA()
+		}
+		if len(referencedIssueNumbers(candidate.Title+"\n"+candidate.Body)) > 0 {
+			issueLinking = append(issueLinking, candidate)
+		}
 
 		if isHeld(labels) {
 			held = append(held, HoldItem{
@@ -370,26 +392,63 @@ func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRe
 			continue
 		}
 
-		headSHA := ""
-		if pr.GetHead() != nil {
-			headSHA = pr.GetHead().GetSHA()
-		}
-
-		actionable = append(actionable, PullRequest{
-			Repo:      repo,
-			Number:    pr.GetNumber(),
-			Title:     pr.GetTitle(),
-			Author:    safeGetLogin(pr.GetUser()),
-			Labels:    labels,
-			Draft:     pr.GetDraft(),
-			CreatedAt: pr.GetCreatedAt().Time,
-			URL:       pr.GetHTMLURL(),
-			Mergeable: pr.GetMergeable(),
-			HeadSHA:   headSHA,
-		})
+		actionable = append(actionable, candidate)
 	}
 
-	return actionable, held, totalPRs, nil
+	return actionable, issueLinking, held, totalPRs, nil
+}
+
+func filterIssuesWithOpenRepairPRs(issues []Issue, prs []PullRequest) []Issue {
+	if len(issues) == 0 || len(prs) == 0 {
+		return issues
+	}
+
+	linked := make(map[string]struct{})
+	for _, pr := range prs {
+		for _, issueNumber := range referencedIssueNumbers(pr.Title + "\n" + pr.Body) {
+			linked[issueKey(pr.Repo, issueNumber)] = struct{}{}
+		}
+	}
+	if len(linked) == 0 {
+		return issues
+	}
+
+	filtered := issues[:0]
+	for _, issue := range issues {
+		if _, ok := linked[issueKey(issue.Repo, issue.Number)]; ok {
+			continue
+		}
+		filtered = append(filtered, issue)
+	}
+	return filtered
+}
+
+func issueKey(repo string, number int) string {
+	return fmt.Sprintf("%s#%d", repo, number)
+}
+
+func referencedIssueNumbers(text string) []int {
+	matches := issueRefPattern.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := make(map[int]struct{})
+	var numbers []int
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		var n int
+		if _, err := fmt.Sscanf(match[1], "%d", &n); err != nil || n <= 0 {
+			continue
+		}
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		numbers = append(numbers, n)
+	}
+	return numbers
 }
 
 // EnrichCIStatus fetches check-run results for each PR's HEAD commit
@@ -676,6 +735,7 @@ func (c *Client) SearchOutreachPRCount(ctx context.Context, author, org, project
 const perPage = 100
 
 var shaPattern = regexp.MustCompile(`[0-9a-f]{7,40}\b`)
+var issueRefPattern = regexp.MustCompile(`(?:#|GH-|/issues/)(\d+)\b`)
 
 const shaHoldComment = "Thanks for filing this issue! To help us reproduce and investigate, " +
 	"could you please include the **commit SHA** of the build you're running?\n\n" +

--- a/v2/pkg/github/client_test.go
+++ b/v2/pkg/github/client_test.go
@@ -44,6 +44,7 @@ type wireUser struct {
 type wirePR struct {
 	Number    int         `json:"number"`
 	Title     string      `json:"title"`
+	Body      string      `json:"body,omitempty"`
 	User      wireUser    `json:"user"`
 	Labels    []wireLabel `json:"labels"`
 	Draft     bool        `json:"draft"`
@@ -78,6 +79,52 @@ const rfc3339Ago = "2006-01-02T15:04:05Z"
 
 func hoursAgo(h float64) string {
 	return time.Now().UTC().Add(-time.Duration(float64(time.Hour) * h)).Format(time.RFC3339)
+}
+
+func TestEnumerateActionable_SuppressesIssuesWithOpenLinkedPRs(t *testing.T) {
+	org, repo := "org", "repo"
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/issues", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		issues := []wireIssue{
+			{Number: 2, Title: "Add visual coverage", User: wireUser{"visual-hive"}, CreatedAt: hoursAgo(3)},
+			{Number: 3, Title: "Another actionable issue", User: wireUser{"visual-hive"}, CreatedAt: hoursAgo(2)},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mustMarshal(t, issues))
+	})
+	mux.HandleFunc(fmt.Sprintf("/repos/%s/%s/pulls", org, repo), func(w http.ResponseWriter, r *http.Request) {
+		prs := []wirePR{
+			{
+				Number:    37,
+				Title:     "[codex] Add hosted reference changed-file selection",
+				Body:      "Fixes #2\n\nValidation: Visual Hive PR check passed.",
+				User:      wireUser{"codex"},
+				Draft:     true,
+				CreatedAt: hoursAgo(1),
+				HTMLURL:   "https://github.com/org/repo/pull/37",
+				Mergeable: boolPtr(true),
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(mustMarshal(t, prs))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := newTestClient(t, server, org, []string{repo})
+	result, err := c.EnumerateActionable(context.Background())
+	if err != nil {
+		t.Fatalf("EnumerateActionable: %v", err)
+	}
+	if result.Issues.Count != 1 {
+		t.Fatalf("Issues.Count = %d, want 1; items=%+v", result.Issues.Count, result.Issues.Items)
+	}
+	if got := result.Issues.Items[0].Number; got != 3 {
+		t.Fatalf("remaining issue = #%d, want #3", got)
+	}
+	if result.PRs.Count != 0 {
+		t.Fatalf("PRs.Count = %d, want 0 because draft PRs are not actionable", result.PRs.Count)
+	}
 }
 
 // --------------------------------------------------------------------------
@@ -506,8 +553,8 @@ func TestIsHeld(t *testing.T) {
 		{[]string{"hold"}, true},
 		{[]string{"on-hold"}, true},
 		{[]string{"hold/review"}, true},
-		{[]string{"HOLD"}, true},             // case-insensitive
-		{[]string{"bug", "hold"}, true},      // mixed labels
+		{[]string{"HOLD"}, true},        // case-insensitive
+		{[]string{"bug", "hold"}, true}, // mixed labels
 		{[]string{"bug", "enhancement"}, false},
 		{[]string{}, false},
 		{nil, false},


### PR DESCRIPTION
## Summary

This is a narrow operational fix set for Hive contributor loops observed while dogfooding Visual Hive-generated issues.

- Fixes the dashboard timeline deferred load by returning the `/api/timeline` fetch promise.
- Allows `HIVE_CONFIG_DIR` to override contributor config location for local contributor runs.
- Updates the contributor relay to recognize the current Codex CLI ready/idle prompt text.
- Prevents Hive from reassigning an issue when an open linked PR already references it, including draft PRs.

## Root cause

While testing Hive against `DavidDiaz0317/visual-hive-demo-site`, Hive assigned issue `#2`, Codex opened draft PR `#37` with `Closes #2`, and the Visual Hive PR check passed. Because the issue remains open until the PR merges, the hosted queue assigned the same issue again.

## Fix details

`fetchPRs` now separates:

- actionable PRs: non-held, non-exempt, non-draft PRs used by the normal PR queue;
- issue-linking PRs: any open PR that references an issue in title/body.

Issue enumeration suppresses open issues that are already referenced by open issue-linking PRs in the same repo. This avoids duplicate contributor assignment without making draft PRs actionable or mergeable.

## Validation

- `go test ./pkg/github -run TestEnumerateActionable_SuppressesIssuesWithOpenLinkedPRs -count=1`
- `git diff --check`

Known local limitation: broader Hive tests have unrelated Windows-only blockers in this checkout, so this PR is validated with the targeted regression test for the queue behavior.

## Safety

- Draft PRs remain non-actionable in the PR queue.
- No merge behavior is changed.
- This PR should be reviewed before merge; it is intentionally opened as draft.
