### PR TITLE
feat(dashboard): make the ACMM level changer discoverable

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2256,7 +2256,7 @@
   </div>
 
   <div id="acmm-eval-section" style="margin-top: 16px; margin-bottom: 24px;">
-    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('acmm-eval-section')"><span class="section-chevron">▼</span> 🎯 ACMM Evaluation</h2>
+    <h2 style="margin-bottom: 8px;" class="section-label section-header-toggle" onclick="toggleSection('acmm-eval-section')"><span class="section-chevron">▼</span> 🎯 ACMM Evaluation <button class="btn" onclick="event.stopPropagation();openACMMDialog()" title="Click to change maturity level" style="vertical-align:middle;margin-left:8px;font-weight:400">Change level ▾</button></h2>
     <div class="section-body">
       <div id="acmm-eval-card" style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:16px">
         <div class="kb-stat-grid" id="acmm-eval-stats">
@@ -12064,6 +12064,7 @@ function burnAreaChart() {
     // ── Governor Tab Renderers ──
     function renderGovGeneral() {
       const currentId = (window._lastStatus || {}).hiveId || '';
+      const currentACMMLevel = (window._lastStatus || {}).acmmLevel || 0;
       return `
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">General hive instance settings.</p>
         <div class="config-field">
@@ -12073,6 +12074,14 @@ function burnAreaChart() {
             <button onclick="saveHiveId()" style="font-size:0.75rem;padding:6px 14px;background:var(--green);color:var(--bg);border:none;border-radius:6px;cursor:pointer;font-weight:600">Save</button>
           </div>
           <span style="font-size:0.65rem;color:var(--muted);margin-top:4px;display:block">Format: hive-adjective-noun (e.g. hive-bold-hawk). Changes take effect immediately.</span>
+        </div>
+        <div class="config-field">
+          <label>Maturity Level <span class="config-info">i<span class="config-tooltip">ACMM (AI-native Continuous Maturity Model) level — controls which agents run and how autonomous they are, from advisory-only (L1) to fully autonomous (L6).</span></span></label>
+          <div style="display:flex;gap:10px;align-items:center">
+            <span style="display:inline-block;padding:3px 12px;border-radius:999px;font-size:0.75rem;font-weight:700;background:color-mix(in srgb, var(--amber) 14%, transparent);border:1px solid color-mix(in srgb, var(--amber) 45%, transparent);color:var(--amber)">${currentACMMLevel > 0 ? acmmLevelLabel(currentACMMLevel) : 'Not set'}</span>
+            <button class="btn" onclick="closeConfigDialog();openACMMDialog()" title="Open the ACMM maturity level selector">Change&hellip;</button>
+          </div>
+          <span style="font-size:0.65rem;color:var(--muted);margin-top:4px;display:block">Each level applies a curated agent pack. Change&hellip; opens the level selector.</span>
         </div>`;
     }
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1932,6 +1932,16 @@
     .row-card { cursor: pointer; padding: 8px; margin-bottom: 4px; background: var(--bg); border: 1px solid var(--line-strong); border-radius: 6px; transition: border-color .15s; }
     .error-note { color: var(--red); font-size: 0.82rem; }
     .repo-chip-btn { padding: 2px 8px; border-radius: 4px; border: 1px solid var(--line-strong); background: var(--bg); cursor: pointer; font-size: 0.72rem; color: var(--text); }
+    /* ACMM level badges — interactive controls that open the level selector,
+       not status labels. Ghost-button affordance: amber outline at rest,
+       brighter tint + solid border + underline on hover. Amber remaps per
+       theme, so this reads correctly in both light and dark modes. */
+    #acmm-badge, #acmm-sidebar-badge { transition: background 0.15s, border-color 0.15s; }
+    #acmm-badge:hover, #acmm-sidebar-badge:hover {
+      background: color-mix(in srgb, var(--amber) 26%, transparent);
+      border-color: var(--amber);
+      text-decoration: underline;
+    }
   </style>
 </head>
 <body>
@@ -2077,7 +2087,7 @@
 <div id="acmm-overlay" class="config-overlay hidden">
   <div class="config-modal" style="max-width:800px;max-height:85vh">
     <div class="config-header">
-      <h2 class="config-title">ACMM Maturity Level</h2>
+      <h2 class="config-title">ACMM Maturity Level <span id="acmm-dialog-current" style="font-size:0.72em;font-weight:400;color:var(--muted)"></span></h2>
       <button class="config-close" onclick="closeACMMDialog()">&times;</button>
     </div>
     <div class="config-body" style="padding:16px 24px;overflow-y:auto;max-height:calc(85vh - 120px)">
@@ -2104,7 +2114,7 @@
       </div>
     </div>
     <div style="padding:4px 16px 8px;text-align:center">
-      <span id="acmm-sidebar-badge" title="ACMM Maturity Level — click to change" style="cursor:pointer;display:inline-block;padding:3px 12px;border-radius:999px;font-size:0.7rem;font-weight:700;background:color-mix(in srgb, var(--amber) 14%, transparent);border:1px solid color-mix(in srgb, var(--amber) 45%, transparent);color:var(--amber);letter-spacing:0.5px" onclick="openACMMDialog()"></span>
+      <span id="acmm-sidebar-badge" title="Click to change maturity level" style="cursor:pointer;display:inline-block;padding:3px 12px;border-radius:999px;font-size:0.7rem;font-weight:700;background:color-mix(in srgb, var(--amber) 14%, transparent);border:1px solid color-mix(in srgb, var(--amber) 45%, transparent);color:var(--amber);letter-spacing:0.5px" onclick="openACMMDialog()"></span>
     </div>
     <div class="oc-nav-group">
       <div class="oc-nav-label">Control</div>
@@ -2202,7 +2212,7 @@
   <h1><span class="bee">🐝</span> KubeStellar Hive Dashboard&nbsp;<span id="project-name">for KubeStellar/Console</span> <span class="timestamp" id="ts"></span>
     <span class="git-version" id="git-version"></span>
     <span class="git-version" id="hive-id-badge" title="Hive Instance ID" style="cursor:pointer;border:1px solid var(--border);padding:2px 8px;border-radius:4px" onclick="openConfigDialog('governor')"></span>
-    <span class="git-version" id="acmm-badge" title="ACMM Maturity Level — click to change" style="cursor:pointer;border:1px solid color-mix(in srgb, var(--amber) 45%, transparent);padding:2px 8px;border-radius:999px;background:color-mix(in srgb, var(--amber) 14%, transparent);color:var(--amber);font-weight:600" onclick="openACMMDialog()"></span>
+    <span class="git-version" id="acmm-badge" title="Click to change maturity level" style="cursor:pointer;border:1px solid color-mix(in srgb, var(--amber) 45%, transparent);padding:2px 8px;border-radius:999px;background:color-mix(in srgb, var(--amber) 14%, transparent);color:var(--amber);font-weight:600" onclick="openACMMDialog()"></span>
     <button class="layout-toggle" id="layout-toggle" onclick="toggleLayout()" title="Switch between Light mode (sidebar + detail panel) and Dark mode (dark theme grid). Your preference is saved in the browser.">☾ Switch to Dark Mode</button>
     <a href="/api/widget" class="widget-dl" title="Download Übersicht widget">⬇ Widget</a>
   </h1>
@@ -10522,6 +10532,14 @@ function burnAreaChart() {
       document.getElementById('acmm-overlay').classList.remove('hidden');
       document.getElementById('acmm-apply-error').style.display = 'none';
 
+      // Restate the current level in the title so users arriving from any
+      // entry point (badge, config dialog, eval section) see where they are.
+      const currentEl = document.getElementById('acmm-dialog-current');
+      if (currentEl) {
+        const lvl = window._lastStatus ? (window._lastStatus.acmmLevel || 0) : 0;
+        currentEl.textContent = '(current: ' + (lvl > 0 ? acmmLevelLabel(lvl) : 'not set') + ')';
+      }
+
       if (!_acmmPacks) {
         try {
           const res = await fetch('/api/packs');
@@ -10685,13 +10703,20 @@ function burnAreaChart() {
       }
     }
 
-    function updateACMMBadge(level, packAgents) {
+    // Short "L3 Measured"-style label for an ACMM pack level. Shared by the
+    // badges, the level dialog subtitle, and the Governor config General tab.
+    function acmmLevelLabel(level) {
       const levelNames = ['', 'L1 Assisted', 'L2 Instructed', 'L3 Measured', 'L4 Adaptive', 'L5 Semi-Automated', 'L6 Autonomous'];
-      const text = levelNames[level] || 'L' + level;
+      return levelNames[level] || 'L' + level;
+    }
+
+    function updateACMMBadge(level, packAgents) {
+      // Trailing ▾ signals the badge is a dropdown-style control, not a label.
+      const text = 'ACMM ' + acmmLevelLabel(level) + ' ▾';
       const badge = document.getElementById('acmm-badge');
-      if (badge) badge.textContent = 'ACMM ' + text;
+      if (badge) badge.textContent = text;
       const sbBadge = document.getElementById('acmm-sidebar-badge');
-      if (sbBadge) sbBadge.textContent = 'ACMM ' + text;
+      if (sbBadge) sbBadge.textContent = text;
       applyACMMVisibility(level, packAgents);
     }
 


### PR DESCRIPTION
## Summary

User feedback: a hive user couldn't find where to change the ACMM level. The only entry point — the "ACMM L3 Measured" badge at the top of the sidebar — read as a status label, not a control.

Four changes across two commits:

1. **Badge affordance** — the sidebar and classic-header ACMM badges now look interactive: hover state (brighter amber tint, solid border, underline), a trailing ▾ dropdown glyph, and tooltip "Click to change maturity level". Uses the existing amber design tokens, so it renders correctly in both light and dark modes.
2. **Dialog title context** — the ACMM Maturity Level dialog title now restates where you are: "ACMM Maturity Level (current: L3 Measured)". Badge label logic factored into a shared `acmmLevelLabel()` helper.
3. **Governor config entry** — the Governor Configuration → General tab gains a "Maturity Level" row: current level as an amber pill + a ghost "Change…" button that closes the config dialog and opens the level selector (no overlay stacking).
4. **ACMM Eval entry** — the ACMM Evaluation section header gains a ghost "Change level ▾" button (with `stopPropagation` so it doesn't toggle the section collapse).

## Read-only / snapshot behavior

Both new entry points are `button[onclick]` controls, so the snapshot builder's existing write-control gating (pointer-events none + dimming; `.config-overlay` hidden entirely) applies unchanged.

## Verification

- Both script blocks parse (`new Function` on each extracted block) and brace-balance to zero.
- Headless Chrome renders (light + dark, with injected `acmmLevel: 3` status): badge shows "ACMM L3 Measured ▾" as an outlined pill in both themes; Governor config General tab shows the Maturity Level row with pill + Change… button; ACMM Evaluation header shows Change level ▾; level dialog title shows "(current: L3 Measured)".

No class renames; existing Phase 2 ghost button recipe (`.btn`) reused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)