### PR TITLE
feat(dashboard): enlarge ACMM badge caret, one-shot attention shimmy on open

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1936,11 +1936,37 @@
        not status labels. Ghost-button affordance: amber outline at rest,
        brighter tint + solid border + underline on hover. Amber remaps per
        theme, so this reads correctly in both light and dark modes. */
-    #acmm-badge, #acmm-sidebar-badge { transition: background 0.15s, border-color 0.15s; }
+    #acmm-badge, #acmm-sidebar-badge { display: inline-block; transition: background 0.15s, border-color 0.15s; }
     #acmm-badge:hover, #acmm-sidebar-badge:hover {
       background: color-mix(in srgb, var(--amber) 26%, transparent);
       border-color: var(--amber);
       text-decoration: underline;
+    }
+    /* Dropdown caret sized up relative to the badge text so the control
+       affordance catches the eye; zero line-height + middle alignment keep
+       the taller glyph from stretching the pill in either theme. */
+    #acmm-badge .acmm-caret, #acmm-sidebar-badge .acmm-caret {
+      font-size: 1.25em;
+      line-height: 0;
+      margin-left: 4px;
+      vertical-align: middle;
+      display: inline-block;
+    }
+    /* One-shot attention shimmy when the dashboard opens (class added on
+       first badge render, removed on animationend — see updateACMMBadge). */
+    @keyframes acmm-shimmy {
+      0%, 100% { transform: translateX(0); }
+      15% { transform: translateX(-3px); }
+      30% { transform: translateX(3px); }
+      45% { transform: translateX(-2px); }
+      60% { transform: translateX(2px); }
+      75% { transform: translateX(-1px); }
+    }
+    #acmm-badge.acmm-shimmy, #acmm-sidebar-badge.acmm-shimmy {
+      animation: acmm-shimmy 0.7s ease-in-out 1;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      #acmm-badge.acmm-shimmy, #acmm-sidebar-badge.acmm-shimmy { animation: none; }
     }
   </style>
 </head>
@@ -10735,13 +10761,39 @@ function burnAreaChart() {
     }
 
     function updateACMMBadge(level, packAgents) {
-      // Trailing ▾ signals the badge is a dropdown-style control, not a label.
-      const text = 'ACMM ' + acmmLevelLabel(level) + ' ▾';
+      // Trailing ▾ signals the badge is a dropdown-style control, not a
+      // label. Rendered as a span so CSS can size it up relative to the
+      // badge text (acmmLevelLabel returns fixed constants — HTML-safe).
+      const html = 'ACMM ' + acmmLevelLabel(level) + '<span class="acmm-caret">▾</span>';
       const badge = document.getElementById('acmm-badge');
-      if (badge) badge.textContent = text;
+      if (badge) badge.innerHTML = html;
       const sbBadge = document.getElementById('acmm-sidebar-badge');
-      if (sbBadge) sbBadge.textContent = text;
+      if (sbBadge) sbBadge.innerHTML = html;
       applyACMMVisibility(level, packAgents);
+      scheduleACMMShimmy();
+    }
+
+    // One-shot attention shimmy: each time the dashboard opens, wiggle the
+    // ACMM badges once so the level control catches the eye. Scheduled from
+    // the first badge render, after a settle delay; never loops, and skipped
+    // entirely for users who prefer reduced motion (CSS also disables it).
+    const ACMM_SHIMMY_DELAY_MS = 1500;   // let the page settle before drawing the eye
+    const ACMM_SHIMMY_CLEANUP_MS = 1500; // fallback class removal (> 0.7s animation) if animationend never fires
+    let _acmmShimmied = false;
+    function scheduleACMMShimmy() {
+      if (_acmmShimmied) return;
+      _acmmShimmied = true;
+      if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+      setTimeout(() => {
+        ['acmm-badge', 'acmm-sidebar-badge'].forEach(id => {
+          const el = document.getElementById(id);
+          if (!el) return;
+          el.classList.add('acmm-shimmy');
+          const cleanup = () => el.classList.remove('acmm-shimmy');
+          el.addEventListener('animationend', cleanup, { once: true });
+          setTimeout(cleanup, ACMM_SHIMMY_CLEANUP_MS);
+        });
+      }, ACMM_SHIMMY_DELAY_MS);
     }
 
     function applyACMMVisibility(level, packAgents) {


### PR DESCRIPTION
## Summary

Follow-up to #1823 from user feedback:

1. **Bigger caret** — the ▾ on the sidebar/header ACMM badges is now a dedicated `.acmm-caret` span sized at **1.25em** relative to the badge text, with a touch of `margin-left`. Zero line-height + middle vertical alignment keep the pill height unchanged; verified in light and dark modes.
2. **One-shot shimmy on open** — each time the dashboard opens, the ACMM badges wiggle once (±3px horizontal, 0.7s ease-in-out, single iteration) after a 1.5s settle delay, as an attention draw to the level control. Triggered from the first badge render; the class is removed on `animationend` with a timeout fallback so it can never linger. Runs exactly once per page load (no localStorage gating, per spec) and never loops.
3. **Reduced motion respected** — skipped in JS via `matchMedia('(prefers-reduced-motion: reduce)')` and disabled in CSS via the matching media query.

Timing values are named constants (`ACMM_SHIMMY_DELAY_MS`, `ACMM_SHIMMY_CLEANUP_MS`).

## Verification

- Script blocks parse (`new Function` per extracted block), brace-balanced.
- Headless Chrome: caret computed at 14px vs 11.2px badge text, pill height unchanged, both themes.
- Lifecycle harness: shimmy class absent at t+1.0s, present at t+1.8s, removed by t+3.5s; second render does not reschedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)