### PR TITLE
fix(litellm): API-key-first entry UX, never-echo key values, and dashboard-config persistence across pod restarts

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -26,11 +26,61 @@ if [ -n "${KUBERNETES_SERVICE_HOST:-}" ] || [ -f /var/run/secrets/kubernetes.io/
 fi
 
 if [ "$IS_KUBERNETES" = "true" ]; then
-  # ── Kubernetes mode: ConfigMap is the source of truth ──────────────
+  # ── Kubernetes mode: ConfigMap seed + dashboard overlay ────────────
   if [ -f "$HIVE_CONFIG_PATH" ] && [ -s "$HIVE_CONFIG_PATH" ]; then
-    # ConfigMap is present and non-empty — use it as-is, write a backup for recovery
+    # The copy-config init container re-seeded $HIVE_CONFIG_PATH from the
+    # ConfigMap on this boot. Config saved via the dashboard (Config.Save
+    # writes /etc/hive/hive.yaml, an emptyDir) would be silently lost —
+    # so the Go binary also persists a secret-free overlay to the PVC
+    # (/data/hive.yaml.dashboard) on every save, and we merge it over the
+    # seed here, BEFORE the backup copy and before the agent-UID
+    # enumeration below reads hive.yaml.
+    #
+    # Precedence: the overlay (last dashboard save) wins for everything
+    # EXCEPT the hub/admin-managed keys, which the ConfigMap owns:
+    #   - acmm_level     (set by the hub at provision / level change)
+    #   - hub.is_public  (hub-managed visibility)
+    # A missing, empty, unparsable, or implausible overlay (no
+    # project.org / agents) leaves the ConfigMap seed untouched.
+    HIVE_DASHBOARD_OVERLAY="/data/hive.yaml.dashboard"
+    if [ -f "$HIVE_DASHBOARD_OVERLAY" ] && [ -s "$HIVE_DASHBOARD_OVERLAY" ]; then
+      if python3 - "$HIVE_CONFIG_PATH" "$HIVE_DASHBOARD_OVERLAY" <<'PYEOF'
+import os, sys, yaml
+
+seed_path, overlay_path = sys.argv[1], sys.argv[2]
+with open(seed_path) as f:
+    seed = yaml.safe_load(f) or {}
+with open(overlay_path) as f:
+    overlay = yaml.safe_load(f) or {}
+
+# Sanity: the overlay must look like a full hive config. Save()'s
+# validateSaveGuard enforces this on write; re-check before trusting it.
+if not isinstance(overlay, dict):
+    sys.exit(1)
+if not (overlay.get('project') or {}).get('org') or not overlay.get('agents'):
+    sys.exit(1)
+
+# ConfigMap (hub/admin) wins for its managed keys when it sets them.
+if 'acmm_level' in seed:
+    overlay['acmm_level'] = seed['acmm_level']
+if isinstance(seed.get('hub'), dict) and 'is_public' in seed['hub']:
+    overlay.setdefault('hub', {})['is_public'] = seed['hub']['is_public']
+
+# Atomic replace so a failure mid-write can never corrupt the seed.
+tmp_path = seed_path + '.merged'
+with open(tmp_path, 'w') as f:
+    yaml.safe_dump(overlay, f, default_flow_style=False, sort_keys=False)
+os.replace(tmp_path, seed_path)
+PYEOF
+      then
+        echo "[entrypoint] K8s mode — dashboard overlay merged over ConfigMap seed (ConfigMap wins for acmm_level, hub.is_public)"
+      else
+        echo "[entrypoint] K8s mode — dashboard overlay invalid, using ConfigMap seed as-is"
+      fi
+    fi
+    # Write the (merged) config as the disaster-recovery backup.
     cp "$HIVE_CONFIG_PATH" "$HIVE_CONFIG_BACKUP" 2>/dev/null || true
-    echo "[entrypoint] K8s mode — ConfigMap is source of truth, backup written to $HIVE_CONFIG_BACKUP"
+    echo "[entrypoint] K8s mode — ConfigMap is the seed, backup written to $HIVE_CONFIG_BACKUP"
   elif [ -f "$HIVE_CONFIG_BACKUP" ] && [ -s "$HIVE_CONFIG_BACKUP" ]; then
     # ConfigMap is missing or empty but a PVC backup exists — recover
     if cp "$HIVE_CONFIG_BACKUP" "$HIVE_CONFIG_PATH" 2>/dev/null; then

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1462,23 +1462,23 @@ func (c *Config) Save() error {
 	// and other runtime changes are lost on container restart.
 	f, err := os.OpenFile(c.SourcePath, os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
-		// File may not exist yet — fall back to create.
+		// File may not exist yet — fall back to create. Continue below so
+		// the PVC backup and dashboard overlay are still written.
 		if writeErr := os.WriteFile(c.SourcePath, data, 0o644); writeErr != nil {
 			return fmt.Errorf("writing config (create fallback): %w", writeErr)
 		}
-		return nil
-	}
-
-	if _, err := f.Write(data); err != nil {
-		f.Close()
-		return fmt.Errorf("writing config: %w", err)
-	}
-	if err := f.Sync(); err != nil {
-		f.Close()
-		return fmt.Errorf("syncing config: %w", err)
-	}
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("closing config: %w", err)
+	} else {
+		if _, err := f.Write(data); err != nil {
+			f.Close()
+			return fmt.Errorf("writing config: %w", err)
+		}
+		if err := f.Sync(); err != nil {
+			f.Close()
+			return fmt.Errorf("syncing config: %w", err)
+		}
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("closing config: %w", err)
+		}
 	}
 
 	// Write a rolling backup to the PVC. This is NOT the primary config —
@@ -1498,7 +1498,75 @@ func (c *Config) Save() error {
 	} else {
 		log.Printf("[config] PVC backup written to %s (recovery copy, not primary config)", backupPath)
 	}
+
+	c.saveDashboardOverlay()
 	return nil
+}
+
+// DashboardOverlayFile is where Save() persists a secret-free copy of the
+// dashboard-edited config on the PVC in Kubernetes mode. The copy-config
+// init container re-seeds /etc/hive/hive.yaml FROM THE CONFIGMAP on every
+// pod boot, so without this overlay every dashboard save (LiteLLM
+// endpoint, notifications, agent tweaks, ...) silently vanished on the
+// next restart or upgrade. The entrypoint merges this file over the
+// ConfigMap seed at boot; the ConfigMap stays authoritative for the
+// hub/admin-managed keys (acmm_level, hub.is_public).
+//
+// A package var (not const) only so tests can point it at a temp dir; it
+// never changes at runtime in production.
+var DashboardOverlayFile = "/data/hive.yaml.dashboard"
+
+// IsKubernetesPod reports whether the process is running inside a
+// Kubernetes pod (mirrors the entrypoint's IS_KUBERNETES detection).
+func IsKubernetesPod() bool {
+	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" {
+		return true
+	}
+	_, err := os.Stat("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	return err == nil
+}
+
+// saveDashboardOverlay writes the secret-free PVC overlay in Kubernetes
+// mode. Failures are logged, never fatal: the primary save already
+// succeeded, the overlay only affects persistence across pod restarts.
+func (c *Config) saveDashboardOverlay() {
+	if !IsKubernetesPod() {
+		// Docker/LXC mode: /data/hive.yaml.bak is already the boot-time
+		// source of truth there, so dashboard saves persist without an
+		// overlay.
+		return
+	}
+	data, err := c.dashboardOverlayBytes()
+	if err != nil {
+		log.Printf("[config] warning: failed to marshal dashboard overlay: %v", err)
+		return
+	}
+	if err := os.WriteFile(DashboardOverlayFile, data, 0o644); err != nil {
+		log.Printf("[config] warning: failed to write dashboard overlay %s (dashboard saves will not survive pod restarts): %v", DashboardOverlayFile, err)
+		return
+	}
+	log.Printf("[config] dashboard overlay written to %s (merged over the ConfigMap seed at next boot)", DashboardOverlayFile)
+}
+
+// dashboardOverlayBytes marshals the config with env-derived secret VALUES
+// collapsed back to their env-var forms, so the PVC overlay stays
+// secret-free. Load() re-expands ${VAR} references and applyBootstrapEnv
+// re-fills the dashboard auth token from the pod env, so nothing is lost.
+func (c *Config) dashboardOverlayBytes() ([]byte, error) {
+	// Shallow copy: top-level fields are struct values, so mutating the
+	// copy's GitHub/Dashboard sections leaves the live config untouched
+	// (the shared Agents map is not modified).
+	cp := *c
+	if tok := os.Getenv("HIVE_GITHUB_TOKEN"); tok != "" && cp.GitHub.Token == tok {
+		cp.GitHub.Token = "${HIVE_GITHUB_TOKEN}"
+	}
+	for _, env := range []string{"DASHBOARD_AUTH_TOKEN", "HIVE_DASHBOARD_TOKEN"} {
+		if v := os.Getenv(env); v != "" && cp.Dashboard.AuthToken == v {
+			cp.Dashboard.AuthToken = ""
+			break
+		}
+	}
+	return yaml.Marshal(&cp)
 }
 
 // WildcardMatch checks if text matches a pattern supporting:

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -423,6 +423,16 @@ const (
 	// DefaultLiteLLMAPIKeyFile is the key file consulted when api_key_file
 	// is not set. Matches the /secrets volume used for k8s Secret mounts.
 	DefaultLiteLLMAPIKeyFile = "/secrets/litellm_api_key"
+	// WritableSecretsDir is the PVC-backed directory where the dashboard
+	// persists secret VALUES entered in the UI. Unlike /secrets (a
+	// read-only Kubernetes Secret mount), /data is the hive's writable
+	// persistent volume, so files written here survive pod restarts and
+	// hosted users can set keys without cluster access.
+	WritableSecretsDir = "/data/secrets"
+	// WritableLiteLLMAPIKeyFile is where the dashboard stores an API key
+	// value entered in the LiteLLM config UI. hive.yaml references it via
+	// api_key_file; the key value itself never enters hive.yaml or logs.
+	WritableLiteLLMAPIKeyFile = WritableSecretsDir + "/litellm_api_key"
 	// LiteLLMEndpointEnv overrides governor.litellm.endpoint at runtime
 	// (mirrors HIVE_VLLM_ENDPOINT / HIVE_LLMD_ENDPOINT).
 	LiteLLMEndpointEnv = "HIVE_LITELLM_ENDPOINT"
@@ -440,26 +450,54 @@ type LiteLLMConfig struct {
 	LocalProxy   bool   `yaml:"local_proxy"`   // run the bundled litellm binary as a local translator fallback
 }
 
-// ResolveAPIKey returns the LiteLLM API key using the resolution order:
-// key file (api_key_file, falling back to DefaultLiteLLMAPIKeyFile) →
-// env var named by api_key_env → DefaultLiteLLMAPIKeyEnv. Returns "" when
-// no key is configured. The key value itself is never stored in hive.yaml.
+// ResolveAPIKey returns the LiteLLM API key. Key FILES are consulted in
+// priority order — the configured api_key_file, then the k8s Secret mount
+// (DefaultLiteLLMAPIKeyFile), then the dashboard-written PVC file
+// (WritableLiteLLMAPIKeyFile) — followed by the env var named by
+// api_key_env and finally DefaultLiteLLMAPIKeyEnv. Returns "" when no key
+// is configured. The key value itself is never stored in hive.yaml.
+//
+// Consulting all three file locations means a key saved via the dashboard
+// keeps working even if hive.yaml is reset (e.g. re-seeded from a
+// ConfigMap) and the api_key_file pointer is lost, and an admin-managed
+// Secret key keeps working if the PVC copy is wiped.
 func (c *LiteLLMConfig) ResolveAPIKey() string {
-	keyFile := c.APIKeyFile
-	if keyFile == "" {
-		keyFile = DefaultLiteLLMAPIKeyFile
-	}
-	if data, err := os.ReadFile(keyFile); err == nil {
-		if key := strings.TrimSpace(string(data)); key != "" {
-			return key
+	key, _ := c.resolveAPIKeyWithSource()
+	return key
+}
+
+// ResolveAPIKeySource reports where ResolveAPIKey found the key without
+// exposing the value: "file:<path>", "env:<NAME>", or "" when no key is
+// configured. Safe to return from APIs (the dashboard shows it as the
+// "Key detected" store).
+func (c *LiteLLMConfig) ResolveAPIKeySource() string {
+	_, source := c.resolveAPIKeyWithSource()
+	return source
+}
+
+func (c *LiteLLMConfig) resolveAPIKeyWithSource() (string, string) {
+	files := []string{c.APIKeyFile, DefaultLiteLLMAPIKeyFile, WritableLiteLLMAPIKeyFile}
+	seen := map[string]bool{"": true}
+	for _, f := range files {
+		if seen[f] {
+			continue
+		}
+		seen[f] = true
+		if data, err := os.ReadFile(f); err == nil {
+			if key := strings.TrimSpace(string(data)); key != "" {
+				return key, "file:" + f
+			}
 		}
 	}
 	if c.APIKeyEnv != "" {
 		if key := os.Getenv(c.APIKeyEnv); key != "" {
-			return key
+			return key, "env:" + c.APIKeyEnv
 		}
 	}
-	return os.Getenv(DefaultLiteLLMAPIKeyEnv)
+	if key := os.Getenv(DefaultLiteLLMAPIKeyEnv); key != "" {
+		return key, "env:" + DefaultLiteLLMAPIKeyEnv
+	}
+	return "", ""
 }
 
 // ResolveEndpoint returns the effective LiteLLM base URL: the

--- a/v2/pkg/config/config_save_test.go
+++ b/v2/pkg/config/config_save_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -132,5 +133,69 @@ func TestRemoveAgentFileSuccess(t *testing.T) {
 
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Error("agent yaml file should be removed")
+	}
+}
+
+// --- dashboard overlay (K8s persistence across pod restarts) ---
+
+func TestSaveWritesDashboardOverlayInK8sMode(t *testing.T) {
+	dir := t.TempDir()
+	origOverlay := DashboardOverlayFile
+	DashboardOverlayFile = filepath.Join(dir, "hive.yaml.dashboard")
+	t.Cleanup(func() { DashboardOverlayFile = origOverlay })
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+	t.Setenv("HIVE_GITHUB_TOKEN", "ghp_secrettoken12345")
+
+	cfg := &Config{
+		SourcePath: filepath.Join(dir, "hive.yaml"),
+		Project:    ProjectConfig{Org: "testorg"},
+		Agents:     map[string]AgentConfig{"scanner": {Role: "scanner"}},
+		GitHub:     GitHubConfig{Token: "ghp_secrettoken12345"},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	data, err := os.ReadFile(DashboardOverlayFile)
+	if err != nil {
+		t.Fatalf("overlay not written: %v", err)
+	}
+	content := string(data)
+	// Secret-free: the env-derived token is collapsed back to its ${VAR}
+	// form so the PVC overlay never holds the raw secret.
+	if strings.Contains(content, "ghp_secrettoken12345") {
+		t.Fatal("overlay contains the raw github token")
+	}
+	if !strings.Contains(content, "${HIVE_GITHUB_TOKEN}") {
+		t.Error("overlay should reference the token via ${HIVE_GITHUB_TOKEN}")
+	}
+	if !strings.Contains(content, "testorg") {
+		t.Error("overlay missing project org")
+	}
+	// The live config is untouched by the scrub.
+	if cfg.GitHub.Token != "ghp_secrettoken12345" {
+		t.Errorf("Save mutated the live config token: %q", cfg.GitHub.Token)
+	}
+}
+
+func TestSaveSkipsDashboardOverlayOutsideK8s(t *testing.T) {
+	dir := t.TempDir()
+	origOverlay := DashboardOverlayFile
+	DashboardOverlayFile = filepath.Join(dir, "hive.yaml.dashboard")
+	t.Cleanup(func() { DashboardOverlayFile = origOverlay })
+	// No KUBERNETES_SERVICE_HOST and (on dev/CI machines) no
+	// serviceaccount token file — Docker mode.
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+
+	cfg := &Config{
+		SourcePath: filepath.Join(dir, "hive.yaml"),
+		Project:    ProjectConfig{Org: "testorg"},
+		Agents:     map[string]AgentConfig{"scanner": {Role: "scanner"}},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if _, err := os.Stat(DashboardOverlayFile); !os.IsNotExist(err) {
+		t.Errorf("overlay should not be written outside Kubernetes (stat err: %v)", err)
 	}
 }

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -2708,18 +2708,7 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			"compress":   cfg.Governor.Logging.Compress,
 			"level":      cfg.Governor.Logging.Level,
 		},
-		"litellm": map[string]interface{}{
-			"endpoint":     cfg.Governor.LiteLLM.Endpoint,
-			"apiKeyEnv":    cfg.Governor.LiteLLM.APIKeyEnv,
-			"apiKeyFile":   cfg.Governor.LiteLLM.APIKeyFile,
-			"defaultModel": cfg.Governor.LiteLLM.DefaultModel,
-			"caBundle":     cfg.Governor.LiteLLM.CABundle,
-			"localProxy":   cfg.Governor.LiteLLM.LocalProxy,
-			// The key VALUE is never returned — only whether one resolves
-			// and from which store ("file:<path>" / "env:<NAME>").
-			"hasKey":    cfg.Governor.LiteLLM.ResolveAPIKey() != "",
-			"keySource": cfg.Governor.LiteLLM.ResolveAPIKeySource(),
-		},
+		"litellm": litellmSectionResponse(&cfg.Governor.LiteLLM),
 		"hub": map[string]interface{}{
 			"enabled":                  cfg.Hub.Enabled,
 			"url":                      cfg.Hub.URL,
@@ -3206,6 +3195,63 @@ func redactSecret(msg, secret string) string {
 	return strings.ReplaceAll(msg, secret, "[redacted]")
 }
 
+// maskHintVisibleChars is how many trailing characters of a secret survive
+// masking in UI hints ("••••WMg" style) — enough to recognize a key,
+// useless to reconstruct one.
+const maskHintVisibleChars = 4
+
+// maskSecretHint returns a display-safe hint for a secret value: bullets
+// plus the last few characters. Values too short to safely reveal a tail
+// are fully masked.
+func maskSecretHint(v string) string {
+	if len(v) <= maskHintVisibleChars*2 {
+		return "••••"
+	}
+	return "••••" + v[len(v)-maskHintVisibleChars:]
+}
+
+// litellmSectionResponse builds the governor-config GET payload for the
+// LiteLLM tab. The resolved key VALUE is never serialized — only hasKey,
+// the store it came from, and a masked tail hint. The apiKeyEnv/apiKeyFile
+// CONFIG fields normally hold a var NAME / file PATH (not secrets), but a
+// user who pasted an actual key into them before the guardrails existed
+// would otherwise get it echoed straight back into the tab — in one live
+// case the raw key rendered in plaintext during screen shares. Key-like
+// values in those fields are therefore masked too, with LooksLikeKey
+// flags so the UI can tell the user to move the value.
+func litellmSectionResponse(lc *config.LiteLLMConfig) map[string]interface{} {
+	apiKeyEnv := lc.APIKeyEnv
+	apiKeyEnvLooksLikeKey := looksLikeAPIKeyValue(apiKeyEnv)
+	if apiKeyEnvLooksLikeKey {
+		apiKeyEnv = maskSecretHint(apiKeyEnv)
+	}
+	apiKeyFile := lc.APIKeyFile
+	apiKeyFileLooksLikeKey := !strings.HasPrefix(apiKeyFile, "/") && looksLikeAPIKeyValue(apiKeyFile)
+	if apiKeyFileLooksLikeKey {
+		apiKeyFile = maskSecretHint(apiKeyFile)
+	}
+	key := lc.ResolveAPIKey()
+	keyHint := ""
+	if key != "" {
+		keyHint = maskSecretHint(key)
+	}
+	return map[string]interface{}{
+		"endpoint":               lc.Endpoint,
+		"apiKeyEnv":              apiKeyEnv,
+		"apiKeyEnvLooksLikeKey":  apiKeyEnvLooksLikeKey,
+		"apiKeyFile":             apiKeyFile,
+		"apiKeyFileLooksLikeKey": apiKeyFileLooksLikeKey,
+		"defaultModel":           lc.DefaultModel,
+		"caBundle":               lc.CABundle,
+		"localProxy":             lc.LocalProxy,
+		"hasKey":                 key != "",
+		"keyHint":                keyHint,
+		// redactSecret guards the pathological case of a key-like env var
+		// NAME appearing in the source string.
+		"keySource": redactSecret(lc.ResolveAPIKeySource(), key),
+	}
+}
+
 // liteLLMProbeResult runs the live probe against the effective endpoint
 // using the SAME key resolution the inference translator uses
 // (ResolveAPIKey: api_key_file → Secret mount → PVC file → env), unless
@@ -3319,6 +3365,14 @@ func (s *Server) handleGovernorLiteLLM(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		lc.APIKeyFile = keyFile
+		// Remediation for the pre-guardrail leak: a key VALUE pasted into
+		// the env-name field never worked as a name (os.Getenv("sk-...")
+		// is empty) and is a plaintext secret in hive.yaml. Now that a
+		// real key is stored properly, scrub it.
+		if looksLikeAPIKeyValue(lc.APIKeyEnv) {
+			lc.APIKeyEnv = ""
+			s.logger.Info("cleared key-like value from litellm api_key_env (replaced by stored API key)")
+		}
 	}
 	cfg.Governor.LiteLLM = lc
 

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -99,6 +99,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("PUT /api/config/governor/logging", s.handleGovernorLogging)
 	s.mux.HandleFunc("PUT /api/config/governor/hub", s.handleGovernorHub)
 	s.mux.HandleFunc("PUT /api/config/governor/litellm", s.handleGovernorLiteLLM)
+	s.mux.HandleFunc("POST /api/config/governor/litellm/test", s.handleGovernorLiteLLMTest)
 	s.mux.HandleFunc("POST /api/config/governor/agents", s.handleGovernorAddAgent)
 	s.mux.HandleFunc("DELETE /api/config/governor/agents/{name}", s.handleGovernorRemoveAgent)
 	s.mux.HandleFunc("PUT /api/config/governor/repos", s.handleGovernorRepos)
@@ -2715,8 +2716,9 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			"caBundle":     cfg.Governor.LiteLLM.CABundle,
 			"localProxy":   cfg.Governor.LiteLLM.LocalProxy,
 			// The key VALUE is never returned — only whether one resolves
-			// from the configured file/env var.
-			"hasKey": cfg.Governor.LiteLLM.ResolveAPIKey() != "",
+			// and from which store ("file:<path>" / "env:<NAME>").
+			"hasKey":    cfg.Governor.LiteLLM.ResolveAPIKey() != "",
+			"keySource": cfg.Governor.LiteLLM.ResolveAPIKeySource(),
 		},
 		"hub": map[string]interface{}{
 			"enabled":                  cfg.Hub.Enabled,
@@ -3127,12 +3129,130 @@ func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 	okResponse(w, map[string]string{"status": "updated"})
 }
 
+// apiKeyLikeLength: env var NAMES are short and conventionally use
+// underscores, while bearer keys are typically 40+ chars without any.
+const apiKeyLikeLength = 40
+
+// looksLikeAPIKeyValue guards the env-name field against users pasting an
+// actual API key VALUE into it (which would bake "sk-..." into hive.yaml
+// as an env var name and silently resolve to an empty key at runtime).
+func looksLikeAPIKeyValue(s string) bool {
+	return strings.HasPrefix(s, "sk-") ||
+		(len(s) > apiKeyLikeLength && !strings.Contains(s, "_"))
+}
+
+const (
+	// litellmProbeTimeout bounds the save-time /v1/models check.
+	litellmProbeTimeout = 8 * time.Second
+	// litellmProbeMaxErrBody caps how much of a gateway error body is
+	// surfaced back to the dialog.
+	litellmProbeMaxErrBody = 512
+)
+
+// probeLiteLLMModels queries {endpoint}/v1/models with the given key and
+// returns the number of models the gateway offers. This is a LIVE probe
+// only — it never falls back to the static model aliases, so a failing
+// gateway can never masquerade as "N models available" (the bug where
+// Test Connection reported the 7 static fallback aliases as success).
+// On failure the error carries the gateway's actual message (truncated)
+// so the UI can show e.g. LiteLLM's "token not found" instead of a bare
+// status code.
+func probeLiteLLMModels(endpoint, apiKey string) (int, error) {
+	modelsURL := strings.TrimRight(endpoint, "/") + "/v1/models"
+	req, err := http.NewRequest("GET", modelsURL, nil)
+	if err != nil {
+		return 0, fmt.Errorf("building request: %w", err)
+	}
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	client := &http.Client{Timeout: litellmProbeTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("cannot reach gateway: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, litellmProbeMaxErrBody))
+	gatewayMsg := strings.TrimSpace(string(body))
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		// The two auth failures lead users to different fixes.
+		if apiKey == "" {
+			return 0, fmt.Errorf("gateway requires an API key and none is configured (HTTP %d): %s",
+				resp.StatusCode, gatewayMsg)
+		}
+		return 0, fmt.Errorf("gateway rejected the configured key (HTTP %d): %s",
+			resp.StatusCode, gatewayMsg)
+	case resp.StatusCode != http.StatusOK:
+		return 0, fmt.Errorf("gateway returned HTTP %d: %s", resp.StatusCode, gatewayMsg)
+	}
+	var result struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return 0, fmt.Errorf("gateway returned a non-OpenAI /v1/models response")
+	}
+	return len(result.Data), nil
+}
+
+// redactSecret removes any occurrence of a secret value from a message so
+// gateway error bodies can never echo the key back to the client or logs.
+func redactSecret(msg, secret string) string {
+	if secret == "" {
+		return msg
+	}
+	return strings.ReplaceAll(msg, secret, "[redacted]")
+}
+
+// liteLLMProbeResult runs the live probe against the effective endpoint
+// using the SAME key resolution the inference translator uses
+// (ResolveAPIKey: api_key_file → Secret mount → PVC file → env), unless
+// overrideKey is set (a key just submitted in the same request, which the
+// key files may not reflect yet). Returns nil when no endpoint is
+// configured.
+func (s *Server) liteLLMProbeResult(lc *config.LiteLLMConfig, overrideKey string) map[string]interface{} {
+	ep := lc.ResolveEndpoint()
+	if ep == "" {
+		return nil
+	}
+	probeKey := overrideKey
+	if probeKey == "" {
+		probeKey = lc.ResolveAPIKey()
+	}
+	n, err := probeLiteLLMModels(ep, probeKey)
+	if err != nil {
+		return map[string]interface{}{"ok": false, "error": redactSecret(err.Error(), probeKey)}
+	}
+	return map[string]interface{}{"ok": true, "models": n}
+}
+
+// handleGovernorLiteLLMTest is the Test Connection endpoint: a live
+// /v1/models probe with the currently effective endpoint + key. Unlike
+// /api/inference/models/{backend} it NEVER substitutes the static
+// fallback aliases, so the result reflects only what the gateway said.
+func (s *Server) handleGovernorLiteLLMTest(w http.ResponseWriter, r *http.Request) {
+	lc := s.deps.Config.Governor.LiteLLM
+	probe := s.liteLLMProbeResult(&lc, "")
+	if probe == nil {
+		jsonError(w, "no litellm endpoint configured", http.StatusBadRequest)
+		return
+	}
+	jsonResponse(w, map[string]interface{}{"ok": true, "probe": probe})
+}
+
 // handleGovernorLiteLLM updates governor.litellm from the dashboard's
-// LiteLLM config tab. The API key VALUE is never accepted or stored —
-// only the env var name / key file path used to resolve it at runtime.
+// LiteLLM config tab / first-use dialog. An API key VALUE (apiKey) is
+// stored via storeLiteLLMAPIKey (PVC file + best-effort hive-secrets
+// Secret) — never in hive.yaml, logs, or responses; hive.yaml records
+// only the file path. After saving, the gateway is probed at /v1/models
+// and the result returned so a bad endpoint/key fails visibly at save
+// time instead of as agent 401s later.
 func (s *Server) handleGovernorLiteLLM(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Endpoint     *string `json:"endpoint"`
+		APIKey       *string `json:"apiKey"`
 		APIKeyEnv    *string `json:"apiKeyEnv"`
 		APIKeyFile   *string `json:"apiKeyFile"`
 		DefaultModel *string `json:"defaultModel"`
@@ -3150,10 +3270,26 @@ func (s *Server) handleGovernorLiteLLM(w http.ResponseWriter, r *http.Request) {
 		lc.Endpoint = strings.TrimSpace(*body.Endpoint)
 	}
 	if body.APIKeyEnv != nil {
-		lc.APIKeyEnv = strings.TrimSpace(*body.APIKeyEnv)
+		keyEnv := strings.TrimSpace(*body.APIKeyEnv)
+		if looksLikeAPIKeyValue(keyEnv) {
+			jsonError(w, "this looks like an API key — paste it in the API Key field instead; "+
+				"this field takes an environment variable NAME (e.g. HIVE_LITELLM_API_KEY)",
+				http.StatusBadRequest)
+			return
+		}
+		lc.APIKeyEnv = keyEnv
 	}
 	if body.APIKeyFile != nil {
-		lc.APIKeyFile = strings.TrimSpace(*body.APIKeyFile)
+		keyFile := strings.TrimSpace(*body.APIKeyFile)
+		// Same paste-the-key-value guardrail as the env-name field; real
+		// key file paths are absolute, keys never are.
+		if !strings.HasPrefix(keyFile, "/") && looksLikeAPIKeyValue(keyFile) {
+			jsonError(w, "this looks like an API key — paste it in the API Key field instead; "+
+				"this field takes a file PATH (e.g. /secrets/litellm_api_key)",
+				http.StatusBadRequest)
+			return
+		}
+		lc.APIKeyFile = keyFile
 	}
 	if body.DefaultModel != nil {
 		lc.DefaultModel = strings.TrimSpace(*body.DefaultModel)
@@ -3168,6 +3304,22 @@ func (s *Server) handleGovernorLiteLLM(w http.ResponseWriter, r *http.Request) {
 		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	// Store a submitted key VALUE outside hive.yaml and point api_key_file
+	// at it. Empty apiKey means "no change" so the tab can be re-saved
+	// without re-entering the key.
+	submittedKey := ""
+	if body.APIKey != nil {
+		submittedKey = strings.TrimSpace(*body.APIKey)
+	}
+	if submittedKey != "" {
+		keyFile, err := s.storeLiteLLMAPIKey(submittedKey)
+		if err != nil {
+			jsonError(w, "failed to store API key: "+redactSecret(err.Error(), submittedKey),
+				http.StatusInternalServerError)
+			return
+		}
+		lc.APIKeyFile = keyFile
+	}
 	cfg.Governor.LiteLLM = lc
 
 	if err := s.saveConfig(); err != nil {
@@ -3177,6 +3329,9 @@ func (s *Server) handleGovernorLiteLLM(w http.ResponseWriter, r *http.Request) {
 
 	// Register the endpoint for model discovery (empty list unregisters)
 	// and re-apply routes for live agents already running on litellm.
+	// This must come after the key store above: SetInferenceRoute
+	// snapshots the key into each route, so the refresh is what makes a
+	// rotated key take effect without an agent restart.
 	var endpoints []string
 	if ep := lc.ResolveEndpoint(); ep != "" {
 		endpoints = []string{ep}
@@ -3187,7 +3342,15 @@ func (s *Server) handleGovernorLiteLLM(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.refreshAndPersist()
-	okResponse(w, map[string]string{"status": "updated"})
+
+	// Save-time validation probe (live /v1/models — never the static
+	// fallback list) so the dialog can immediately show "N models
+	// available" or the gateway's real error.
+	resp := map[string]interface{}{"ok": true, "status": "updated"}
+	if probe := s.liteLLMProbeResult(&lc, submittedKey); probe != nil {
+		resp["probe"] = probe
+	}
+	jsonResponse(w, resp)
 }
 
 func (s *Server) handleGovernorAddAgent(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/litellm_api_test.go
+++ b/v2/pkg/dashboard/litellm_api_test.go
@@ -2,8 +2,11 @@ package dashboard
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -90,5 +93,233 @@ func TestHandleGovernorConfigGet_LiteLLMSection(t *testing.T) {
 	}
 	if section["hasKey"] != true {
 		t.Errorf("hasKey = %v, want true (key resolves from env)", section["hasKey"])
+	}
+}
+
+// --- env-name guardrail: key values pasted into the env NAME field ---
+
+func TestHandleGovernorLiteLLM_EnvNameGuardrail(t *testing.T) {
+	cases := []struct {
+		name   string
+		keyEnv string
+		wantOK bool
+	}{
+		{"sk-prefixed key value", "sk-3aF9xQ7bLm2v", false},
+		{"long dashed key value", strings.Repeat("aB3x-", 12), false},
+		{"conventional env name", "HIVE_LITELLM_API_KEY", true},
+		{"custom env name", "MY_GATEWAY_KEY", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newFullServer(t)
+			body := `{"endpoint": "https://litellm.example.com", "apiKeyEnv": "` + tc.keyEnv + `"}`
+			req := httptest.NewRequest("PUT", "/api/config/governor/litellm", strings.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			srv.handleGovernorLiteLLM(w, req)
+			if tc.wantOK && w.Code != http.StatusOK {
+				t.Fatalf("code = %d, want 200 (body: %s)", w.Code, w.Body.String())
+			}
+			if !tc.wantOK {
+				if w.Code != http.StatusBadRequest {
+					t.Fatalf("code = %d, want 400 for key-like env name", w.Code)
+				}
+				if !strings.Contains(w.Body.String(), "looks like an API key") {
+					t.Errorf("error should explain the field takes a NAME: %s", w.Body.String())
+				}
+				if srv.deps.Config.Governor.LiteLLM.APIKeyEnv != "" {
+					t.Errorf("key-like value persisted into APIKeyEnv: %q", srv.deps.Config.Governor.LiteLLM.APIKeyEnv)
+				}
+			}
+		})
+	}
+}
+
+// --- apiKey value storage: PVC file, 0600, never echoed ---
+
+func TestHandleGovernorLiteLLM_APIKeyValueStored(t *testing.T) {
+	origKeyFile := writableLiteLLMKeyFile
+	writableLiteLLMKeyFile = filepath.Join(t.TempDir(), "secrets", "litellm_api_key")
+	t.Cleanup(func() { writableLiteLLMKeyFile = origKeyFile })
+
+	const secret = "sk-verysecretkeyvalue123456"
+	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+secret {
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprint(w, `{"error":{"message":"Authentication Error: token not found"}}`)
+			return
+		}
+		fmt.Fprint(w, `{"data":[{"id":"claude_opus_4.8"},{"id":"gemini_2.5_pro"}]}`)
+	}))
+	defer gateway.Close()
+
+	srv := newFullServer(t)
+	body := `{"endpoint": "` + gateway.URL + `", "apiKey": "` + secret + `"}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/litellm", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorLiteLLM(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d (body: %s)", w.Code, w.Body.String())
+	}
+	// Key value written to the PVC file with owner-only perms.
+	data, err := os.ReadFile(writableLiteLLMKeyFile)
+	if err != nil {
+		t.Fatalf("key file not written: %v", err)
+	}
+	if string(data) != secret {
+		t.Errorf("key file content mismatch")
+	}
+	info, _ := os.Stat(writableLiteLLMKeyFile)
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("key file mode = %v, want 0600", info.Mode().Perm())
+	}
+	// hive.yaml records only the file path.
+	if got := srv.deps.Config.Governor.LiteLLM.APIKeyFile; got != writableLiteLLMKeyFile {
+		t.Errorf("APIKeyFile = %q, want %q", got, writableLiteLLMKeyFile)
+	}
+	// The key value never appears in the response.
+	if strings.Contains(w.Body.String(), secret) {
+		t.Fatal("response echoes the API key value")
+	}
+	// Save-time probe reports live model count.
+	var resp struct {
+		Probe struct {
+			OK     bool   `json:"ok"`
+			Models int    `json:"models"`
+			Error  string `json:"error"`
+		} `json:"probe"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Probe.OK || resp.Probe.Models != 2 {
+		t.Errorf("probe = %+v, want ok with 2 models", resp.Probe)
+	}
+}
+
+// --- save-time probe surfaces the gateway's real error, redacted ---
+
+func TestHandleGovernorLiteLLM_ProbeSurfacesGatewayError(t *testing.T) {
+	origKeyFile := writableLiteLLMKeyFile
+	writableLiteLLMKeyFile = filepath.Join(t.TempDir(), "litellm_api_key")
+	t.Cleanup(func() { writableLiteLLMKeyFile = origKeyFile })
+
+	const secret = "sk-wrongkeyvalue9876543210"
+	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		// Echo the key back like a chatty gateway might — it must be redacted.
+		fmt.Fprintf(w, `{"error":{"message":"token not found: %s"}}`, secret)
+	}))
+	defer gateway.Close()
+
+	srv := newFullServer(t)
+	body := `{"endpoint": "` + gateway.URL + `", "apiKey": "` + secret + `"}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/litellm", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorLiteLLM(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d (config save should succeed even when the probe fails)", w.Code)
+	}
+	if strings.Contains(w.Body.String(), secret) {
+		t.Fatal("probe error echoes the API key value")
+	}
+	var resp struct {
+		Probe struct {
+			OK    bool   `json:"ok"`
+			Error string `json:"error"`
+		} `json:"probe"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Probe.OK {
+		t.Fatal("probe.ok = true, want false for a 401 gateway")
+	}
+	if !strings.Contains(resp.Probe.Error, "token not found") {
+		t.Errorf("probe error should carry the gateway message, got: %s", resp.Probe.Error)
+	}
+	if !strings.Contains(resp.Probe.Error, "rejected the configured key") {
+		t.Errorf("probe error should say the key was rejected, got: %s", resp.Probe.Error)
+	}
+}
+
+// --- Test Connection endpoint: live results only, never static fallback ---
+
+func TestHandleGovernorLiteLLMTest_NeverCountsFallbackAliases(t *testing.T) {
+	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		fmt.Fprint(w, `{"error":{"message":"No api key passed in."}}`)
+	}))
+	defer gateway.Close()
+
+	srv := newFullServer(t)
+	srv.deps.Config.Governor.LiteLLM.Endpoint = gateway.URL
+
+	req := httptest.NewRequest("POST", "/api/config/governor/litellm/test", nil)
+	w := httptest.NewRecorder()
+	srv.handleGovernorLiteLLMTest(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d", w.Code)
+	}
+	var resp struct {
+		Probe struct {
+			OK     bool   `json:"ok"`
+			Models int    `json:"models"`
+			Error  string `json:"error"`
+		} `json:"probe"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Probe.OK {
+		t.Fatal("probe reported success against a 401 gateway (static fallback leak?)")
+	}
+	if !strings.Contains(resp.Probe.Error, "requires an API key") {
+		t.Errorf("no-key 401 should say a key is required, got: %s", resp.Probe.Error)
+	}
+	if !strings.Contains(resp.Probe.Error, "No api key passed in") {
+		t.Errorf("probe error should carry the gateway body, got: %s", resp.Probe.Error)
+	}
+}
+
+func TestHandleGovernorLiteLLMTest_NoEndpoint(t *testing.T) {
+	srv := newFullServer(t)
+	req := httptest.NewRequest("POST", "/api/config/governor/litellm/test", nil)
+	w := httptest.NewRecorder()
+	srv.handleGovernorLiteLLMTest(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 when no endpoint configured", w.Code)
+	}
+}
+
+// --- file-path field guardrail ---
+
+func TestHandleGovernorLiteLLM_KeyFileGuardrail(t *testing.T) {
+	srv := newFullServer(t)
+	body := `{"endpoint": "https://litellm.example.com", "apiKeyFile": "sk-3aF9xQ7bLm2v"}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/litellm", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorLiteLLM(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("code = %d, want 400 for key-like file path", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "file PATH") {
+		t.Errorf("error should explain the field takes a path: %s", w.Body.String())
+	}
+	// A real absolute path is accepted.
+	srv2 := newFullServer(t)
+	body = `{"endpoint": "https://litellm.example.com", "apiKeyFile": "/secrets/litellm_api_key"}`
+	req = httptest.NewRequest("PUT", "/api/config/governor/litellm", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	srv2.handleGovernorLiteLLM(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d, want 200 for absolute path (body: %s)", w.Code, w.Body.String())
 	}
 }

--- a/v2/pkg/dashboard/litellm_api_test.go
+++ b/v2/pkg/dashboard/litellm_api_test.go
@@ -323,3 +323,86 @@ func TestHandleGovernorLiteLLM_KeyFileGuardrail(t *testing.T) {
 		t.Fatalf("code = %d, want 200 for absolute path (body: %s)", w.Code, w.Body.String())
 	}
 }
+
+// --- GET masking: a key VALUE pasted into env/file fields never echoes ---
+
+func TestHandleGovernorConfigGet_MasksKeyLikeEnvName(t *testing.T) {
+	const pastedKey = "sk-8uOe6IBkSSxEU7lfEp1WMg"
+	srv := newFullServer(t)
+	srv.deps.Config.Governor.LiteLLM.Endpoint = "https://litellm.example.com"
+	// Pre-guardrail leak scenario: the user pasted the actual key into
+	// the env-name field and it was persisted to hive.yaml.
+	srv.deps.Config.Governor.LiteLLM.APIKeyEnv = pastedKey
+
+	req := httptest.NewRequest("GET", "/api/config/governor", nil)
+	w := httptest.NewRecorder()
+	srv.handleGovernorConfigGet(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d", w.Code)
+	}
+	if strings.Contains(w.Body.String(), pastedKey) {
+		t.Fatal("response echoes the pasted key value")
+	}
+	var result map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	section := result["litellm"].(map[string]any)
+	if section["apiKeyEnvLooksLikeKey"] != true {
+		t.Error("apiKeyEnvLooksLikeKey should be true")
+	}
+	masked, _ := section["apiKeyEnv"].(string)
+	if !strings.HasPrefix(masked, "••••") || !strings.HasSuffix(masked, "1WMg") {
+		t.Errorf("apiKeyEnv should be a masked tail hint, got %q", masked)
+	}
+}
+
+func TestHandleGovernorConfigGet_KeyHintMaskedTail(t *testing.T) {
+	srv := newFullServer(t)
+	t.Setenv("HIVE_LITELLM_API_KEY", "sk-resolvedsecretkeyvalue")
+	srv.deps.Config.Governor.LiteLLM.Endpoint = "https://litellm.example.com"
+
+	req := httptest.NewRequest("GET", "/api/config/governor", nil)
+	w := httptest.NewRecorder()
+	srv.handleGovernorConfigGet(w, req)
+
+	if strings.Contains(w.Body.String(), "sk-resolvedsecretkeyvalue") {
+		t.Fatal("response contains the resolved key value")
+	}
+	var result map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	section := result["litellm"].(map[string]any)
+	if section["hasKey"] != true {
+		t.Fatalf("hasKey = %v", section["hasKey"])
+	}
+	if hint, _ := section["keyHint"].(string); hint != "••••alue" {
+		t.Errorf("keyHint = %q, want masked last-4 tail", hint)
+	}
+}
+
+// --- storing a real key scrubs a pasted key from api_key_env ---
+
+func TestHandleGovernorLiteLLM_StoringKeyScrubsPastedEnvValue(t *testing.T) {
+	origKeyFile := writableLiteLLMKeyFile
+	writableLiteLLMKeyFile = filepath.Join(t.TempDir(), "litellm_api_key")
+	t.Cleanup(func() { writableLiteLLMKeyFile = origKeyFile })
+
+	srv := newFullServer(t)
+	srv.deps.Config.Governor.LiteLLM.APIKeyEnv = "sk-previouslypastedkeyvalue"
+
+	body := `{"endpoint": "https://litellm.example.com", "apiKey": "sk-thecorrectkey123"}`
+	req := httptest.NewRequest("PUT", "/api/config/governor/litellm", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleGovernorLiteLLM(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("code = %d (body: %s)", w.Code, w.Body.String())
+	}
+	if got := srv.deps.Config.Governor.LiteLLM.APIKeyEnv; got != "" {
+		t.Errorf("pasted key value still in APIKeyEnv: %q", got)
+	}
+}

--- a/v2/pkg/dashboard/litellm_key_store.go
+++ b/v2/pkg/dashboard/litellm_key_store.go
@@ -1,0 +1,176 @@
+package dashboard
+
+// Storage for API key VALUES entered in the dashboard (currently the
+// LiteLLM gateway key). hive.yaml only ever stores a file PATH
+// (api_key_file); the key value itself is written to:
+//
+//  1. A 0600 file on the PVC (/data/secrets/litellm_api_key) — the
+//     authoritative store hive.yaml points at. It takes effect instantly
+//     and works on every hive (hosted k8s, Docker, LXC).
+//  2. Best-effort, the hive's own hive-secrets Kubernetes Secret, patched
+//     via the in-cluster API (requires the hive-secrets-writer Role from
+//     the provisioning template). This keeps a durable copy outside the
+//     PVC; on hives whose deployment whole-volume-mounts the Secret it
+//     also surfaces at /secrets/litellm_api_key, which ResolveAPIKey
+//     consults ahead of the PVC file.
+//
+// The PVC file — not the Secret mount — is what api_key_file records,
+// because the Secret path cannot be assumed readable: hives provisioned
+// from older templates mount hive-secrets with an items filter that
+// excludes litellm_api_key (or do not mount /secrets at all), and even on
+// current-template hives the kubelet takes ~2 minutes to project a
+// patched Secret into the mount. The PVC file has neither problem.
+//
+// The key value must never be logged, echoed in API responses, or
+// written to hive.yaml.
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+const (
+	// hiveSecretsName is the namespace-local Secret the pod may patch
+	// (matches the provisioning template and the hive-secrets-writer Role).
+	hiveSecretsName = "hive-secrets"
+	// litellmSecretDataKey is the key inside hive-secrets holding the
+	// LiteLLM API key; it surfaces as /secrets/litellm_api_key on hives
+	// that whole-volume-mount the Secret.
+	litellmSecretDataKey = "litellm_api_key"
+	// secretPatchTimeout bounds the in-cluster API PATCH call.
+	secretPatchTimeout = 10 * time.Second
+	// litellmKeyFileMode: the key file is read only by the main hive
+	// process (dashboard + inference translator run in-process as the
+	// same user), so owner-only is the tightest mode that works.
+	litellmKeyFileMode = 0o600
+	// litellmKeyDirMode keeps the PVC secrets dir owner-only too.
+	litellmKeyDirMode = 0o700
+)
+
+// Package vars (not consts) so tests can point them at temp dirs / fake
+// API servers. Production values never change at runtime.
+var (
+	// writableLiteLLMKeyFile is the PVC key file recorded in api_key_file.
+	writableLiteLLMKeyFile = config.WritableLiteLLMAPIKeyFile
+	// serviceAccountDir holds the pod's token/namespace/ca.crt files.
+	serviceAccountDir = "/var/run/secrets/kubernetes.io/serviceaccount"
+)
+
+// errNotInCluster marks the expected condition of not running inside a
+// Kubernetes pod (Docker/LXC hives), where the Secret patch is skipped
+// silently.
+var errNotInCluster = errors.New("not running in a Kubernetes pod")
+
+// storeLiteLLMAPIKey persists a LiteLLM API key value and returns the
+// api_key_file path to record in hive.yaml. Only the chosen store is ever
+// logged — never the key.
+func (s *Server) storeLiteLLMAPIKey(key string) (string, error) {
+	if err := writeLiteLLMKeyFile(key); err != nil {
+		return "", err
+	}
+	s.logger.Info("litellm api key stored", "api_key_file", writableLiteLLMKeyFile)
+	if err := patchKeyIntoHiveSecrets(litellmSecretDataKey, key); err == nil {
+		s.logger.Info("litellm api key also patched into hive-secrets Secret",
+			"mount_path", config.DefaultLiteLLMAPIKeyFile)
+	} else if !errors.Is(err, errNotInCluster) {
+		s.logger.Info("hive-secrets Secret not patched; PVC key file is the only store",
+			"reason", err.Error())
+	}
+	return writableLiteLLMKeyFile, nil
+}
+
+// writeLiteLLMKeyFile writes the key value to the PVC key file with
+// owner-only permissions.
+func writeLiteLLMKeyFile(key string) error {
+	dir := filepath.Dir(writableLiteLLMKeyFile)
+	if err := os.MkdirAll(dir, litellmKeyDirMode); err != nil {
+		return fmt.Errorf("creating %s: %w", dir, err)
+	}
+	if err := os.WriteFile(writableLiteLLMKeyFile, []byte(key), litellmKeyFileMode); err != nil {
+		return fmt.Errorf("writing key file: %w", err)
+	}
+	// WriteFile does not change the mode of a pre-existing file.
+	if err := os.Chmod(writableLiteLLMKeyFile, litellmKeyFileMode); err != nil {
+		return fmt.Errorf("tightening key file mode: %w", err)
+	}
+	return nil
+}
+
+// patchKeyIntoHiveSecrets PATCHes the hive-secrets Secret in the pod's own
+// namespace, setting data[dataKey] = value, using the mounted
+// serviceaccount credentials. Errors never contain the value.
+func patchKeyIntoHiveSecrets(dataKey, value string) error {
+	host := os.Getenv("KUBERNETES_SERVICE_HOST")
+	port := os.Getenv("KUBERNETES_SERVICE_PORT")
+	if host == "" || port == "" {
+		return errNotInCluster
+	}
+	token, err := os.ReadFile(filepath.Join(serviceAccountDir, "token"))
+	if err != nil {
+		return fmt.Errorf("reading serviceaccount token: %w", err)
+	}
+	namespace, err := os.ReadFile(filepath.Join(serviceAccountDir, "namespace"))
+	if err != nil {
+		return fmt.Errorf("reading serviceaccount namespace: %w", err)
+	}
+	caCert, err := os.ReadFile(filepath.Join(serviceAccountDir, "ca.crt"))
+	if err != nil {
+		return fmt.Errorf("reading serviceaccount ca.crt: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caCert) {
+		return fmt.Errorf("serviceaccount ca.crt contains no certificates")
+	}
+
+	patch, err := json.Marshal(map[string]interface{}{
+		"data": map[string]string{
+			dataKey: base64.StdEncoding.EncodeToString([]byte(value)),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("building patch: %w", err)
+	}
+
+	patchURL := fmt.Sprintf("https://%s:%s/api/v1/namespaces/%s/secrets/%s",
+		host, port, strings.TrimSpace(string(namespace)), hiveSecretsName)
+	ctx, cancel := context.WithTimeout(context.Background(), secretPatchTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, patchURL, bytes.NewReader(patch))
+	if err != nil {
+		return fmt.Errorf("building request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(string(token)))
+	req.Header.Set("Content-Type", "application/strategic-merge-patch+json")
+
+	client := &http.Client{
+		Timeout: secretPatchTimeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{RootCAs: pool},
+		},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("calling kubernetes API: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		// Deliberately status-only: API error bodies can echo patch
+		// contents, which would leak the key value into logs/responses.
+		return fmt.Errorf("kubernetes API returned %d patching %s (missing hive-secrets-writer Role?)",
+			resp.StatusCode, hiveSecretsName)
+	}
+	return nil
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -11096,9 +11096,26 @@ function burnAreaChart() {
     }
 
     function renderGovLiteLLM(litellm) {
+      // The server never returns the key VALUE — only hasKey, a masked
+      // tail hint ("••••WMg"), and the store it resolved from. The API
+      // Key input always starts EMPTY (never pre-filled): typing a value
+      // replaces the stored key, leaving it blank keeps it.
+      const keyHint = litellm.keyHint ? ` (${esc(litellm.keyHint)})` : '';
       const keyLine = litellm.hasKey
-        ? `Key detected: yes — from ${esc(litellmKeySourceLabel(litellm.keySource))}`
+        ? `Key detected: yes${keyHint} — from ${esc(litellmKeySourceLabel(litellm.keySource))}`
         : 'Key detected: no — paste your gateway key above';
+      // Pre-guardrail leak remediation: a key VALUE previously pasted into
+      // the env-name/file fields comes back MASKED from the server with a
+      // LooksLikeKey flag. Render the input empty (never echo even the
+      // masked form as an editable value) plus a warning to move the key.
+      const keyEnvWarning = litellm.apiKeyEnvLooksLikeKey
+        ? `<div style="font-size:0.72rem;margin-top:3px;color:var(--red)">The saved value here (${esc(litellm.apiKeyEnv || '')}) looks like a key VALUE, not an environment variable name — move it to the API Key field above and Save; storing a key clears this field automatically.</div>`
+        : '';
+      const keyFileWarning = litellm.apiKeyFileLooksLikeKey
+        ? `<div style="font-size:0.72rem;margin-top:3px;color:var(--red)">The saved value here (${esc(litellm.apiKeyFile || '')}) looks like a key VALUE, not a file path — move it to the API Key field above and Save.</div>`
+        : '';
+      const keyEnvValue = litellm.apiKeyEnvLooksLikeKey ? '' : (litellm.apiKeyEnv || '');
+      const keyFileValue = litellm.apiKeyFileLooksLikeKey ? '' : (litellm.apiKeyFile || '');
       return `
         <div class="config-field">
           <label>Endpoint URL <span class="config-info">i<span class="config-tooltip">Base URL of the LiteLLM proxy (e.g. https://litellm.example.com). Agents reach it through the hive's inference translator — the MITM proxy stays in the path. The HIVE_LITELLM_ENDPOINT env var overrides this at runtime.</span></span></label>
@@ -11117,13 +11134,15 @@ function burnAreaChart() {
           <summary style="cursor:pointer;font-size:0.75rem;color:var(--muted)">Advanced — self-hosted key sources &amp; proxy options</summary>
           <div class="config-field" style="margin-top:10px">
             <label>Read Key From Environment Variable <span class="config-info">i<span class="config-tooltip">For self-hosted operators who manage the key outside the dashboard. Takes the NAME of an environment variable — never the key itself.</span></span></label>
-            <input type="text" value="${esc(litellm.apiKeyEnv || '')}" placeholder="HIVE_LITELLM_API_KEY" onchange="onLitellmKeyEnvChange(this)">
+            <input type="text" value="${esc(keyEnvValue)}" placeholder="HIVE_LITELLM_API_KEY" onchange="onLitellmKeyEnvChange(this)">
             <div style="font-size:0.7rem;margin-top:3px;color:var(--muted)">Enter the NAME of an environment variable on the hive container that contains your key (self-hosted installs). Hosted users: paste your key in the API Key field above instead.</div>
+            ${keyEnvWarning}
           </div>
           <div class="config-field">
             <label>Read Key From File Path <span class="config-info">i<span class="config-tooltip">For self-hosted operators. Path to a mounted file containing the key (e.g. a Kubernetes Secret mount).</span></span></label>
-            <input type="text" value="${esc(litellm.apiKeyFile || '')}" placeholder="/secrets/litellm_api_key" onchange="onLitellmKeyFileChange(this)">
+            <input type="text" value="${esc(keyFileValue)}" placeholder="/secrets/litellm_api_key" onchange="onLitellmKeyFileChange(this)">
             <div style="font-size:0.7rem;margin-top:3px;color:var(--muted)">Path to a file that contains your key, such as a Kubernetes Secret mount (self-hosted installs). Hosted users: paste your key in the API Key field above instead.</div>
+            ${keyFileWarning}
           </div>
           <div class="config-field">
             <label>CA Bundle Path <span class="config-info">i<span class="config-tooltip">Optional PEM file for a private CA (e.g. an internal VPC endpoint). Certificate verification is never disabled — the CA is added to the trust pool.</span></span></label>

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -9473,9 +9473,12 @@ function burnAreaChart() {
       dismissToast(toast, `${agent} restart counter reset`, 'success');
     }
 
-    // Prompts for the LiteLLM endpoint the first time the backend is
-    // selected anywhere in the UI. Resolves true when litellm is (or has
-    // just been) configured; false when the user cancels.
+    // Prompts for the LiteLLM endpoint + API key the first time the
+    // backend is selected anywhere in the UI. Resolves true when litellm
+    // is (or has just been) configured; false when the user cancels. The
+    // key VALUE goes to the server's private key store — never hive.yaml —
+    // and the save runs a live /v1/models test whose result is shown
+    // inline (endpoint/key mistakes fail here, not as agent 401s later).
     async function ensureLiteLLMConfigured() {
       try {
         const resp = await fetch('/api/config/governor');
@@ -9490,17 +9493,31 @@ function burnAreaChart() {
         overlay.className = 'gh-auth-overlay';
         overlay.innerHTML = `<div class="gh-auth-modal" style="max-width:480px;text-align:left">
           <h3 style="color:var(--amber);text-align:center">Configure LiteLLM</h3>
-          <p style="margin:0 0 14px;line-height:1.5">No LiteLLM endpoint is configured yet. Enter the proxy base URL (editable later under Governor Config → LiteLLM).</p>
+          <p style="margin:0 0 14px;line-height:1.5">No LiteLLM gateway is configured yet. Enter the gateway URL and your API key (editable later under Governor Config → LiteLLM).</p>
           <div class="config-field">
             <label>Endpoint URL</label>
             <input type="text" id="litellm-setup-endpoint" placeholder="https://litellm.example.com" style="width:100%;box-sizing:border-box">
           </div>
           <div class="config-field">
-            <label>API Key Env Name <span style="font-weight:400;text-transform:none">(optional — the key value is never stored)</span></label>
-            <input type="text" id="litellm-setup-keyenv" placeholder="HIVE_LITELLM_API_KEY" style="width:100%;box-sizing:border-box">
+            <label>API Key <span style="font-weight:400;text-transform:none">(stored privately on this hive — never in hive.yaml or logs)</span></label>
+            <input type="password" id="litellm-setup-key" placeholder="sk-..." autocomplete="new-password" style="width:100%;box-sizing:border-box">
           </div>
+          <details style="margin:0 0 12px">
+            <summary style="cursor:pointer;font-size:0.75rem;color:var(--muted)">Advanced — self-hosted key sources</summary>
+            <div class="config-field" style="margin-top:8px">
+              <label>Read Key From Environment Variable</label>
+              <input type="text" id="litellm-setup-keyenv" placeholder="HIVE_LITELLM_API_KEY" style="width:100%;box-sizing:border-box">
+              <div style="font-size:0.7rem;color:var(--muted);margin-top:2px">Enter the NAME of an environment variable on the hive container that contains your key (self-hosted installs). Hosted users: paste your key in the API Key field above instead.</div>
+            </div>
+            <div class="config-field">
+              <label>Read Key From File Path</label>
+              <input type="text" id="litellm-setup-keyfile" placeholder="/secrets/litellm_api_key" style="width:100%;box-sizing:border-box">
+              <div style="font-size:0.7rem;color:var(--muted);margin-top:2px">Path to a file that contains your key, such as a Kubernetes Secret mount (self-hosted installs).</div>
+            </div>
+          </details>
+          <div id="litellm-setup-result" style="display:none;font-size:0.75rem;margin:0 0 10px;white-space:pre-wrap;line-height:1.4"></div>
           <div style="display:flex;gap:8px;justify-content:center">
-            <button class="hive-dialog-btn primary">Save</button>
+            <button class="hive-dialog-btn primary">Save &amp; Test</button>
             <button class="hive-dialog-btn cancel">Cancel</button>
           </div></div>`;
         document.body.appendChild(overlay);
@@ -9508,27 +9525,56 @@ function burnAreaChart() {
         const close = (val) => { overlay.remove(); resolve(val); };
         overlay.querySelector('.cancel').onclick = () => close(false);
         overlay.onclick = (e) => { if (e.target === overlay) close(false); };
+        const resultEl = overlay.querySelector('#litellm-setup-result');
+        const showResult = (msg, ok) => {
+          resultEl.textContent = msg;
+          resultEl.style.display = 'block';
+          resultEl.style.color = ok ? 'var(--green)' : 'var(--red)';
+        };
         overlay.querySelector('.primary').onclick = async () => {
           const endpoint = overlay.querySelector('#litellm-setup-endpoint').value.trim();
-          if (!endpoint) { showToast('Endpoint URL is required', 'error'); return; }
+          if (!endpoint) { showResult('Endpoint URL is required', false); return; }
+          const key = overlay.querySelector('#litellm-setup-key').value.trim();
           const keyEnv = overlay.querySelector('#litellm-setup-keyenv').value.trim();
+          const keyFile = overlay.querySelector('#litellm-setup-keyfile').value.trim();
+          // Same guardrails as the server: a key VALUE pasted into the
+          // NAME/PATH fields would leak into hive.yaml and resolve to an
+          // empty key at runtime.
+          if (keyEnv && looksLikeApiKeyValue(keyEnv)) {
+            showResult('This looks like an API key — paste it in the API Key field above; the advanced field takes an environment variable NAME (e.g. HIVE_LITELLM_API_KEY).', false);
+            return;
+          }
+          if (keyFile && !keyFile.startsWith('/') && looksLikeApiKeyValue(keyFile)) {
+            showResult('This looks like an API key — paste it in the API Key field above; the advanced field takes a file PATH (e.g. /secrets/litellm_api_key).', false);
+            return;
+          }
           const body = { endpoint };
+          if (key) body.apiKey = key;
           if (keyEnv) body.apiKeyEnv = keyEnv;
+          if (keyFile) body.apiKeyFile = keyFile;
           try {
             const res = await fetch('/api/config/governor/litellm', {
               method: 'PUT',
               headers: _inceptionAuthHeaders(),
               body: JSON.stringify(body)
             });
+            const data = await res.json().catch(() => ({}));
             if (!res.ok) {
-              const err = await res.json().catch(() => ({}));
-              showToast(err.error || 'Failed to save LiteLLM config', 'error');
+              showResult(data.error || 'Failed to save LiteLLM config', false);
               return;
             }
-            showToast('LiteLLM endpoint saved', 'success');
+            if (data.probe && !data.probe.ok) {
+              // Saved, but the live /v1/models test failed — keep the
+              // dialog open with the gateway's actual error so the user
+              // can fix the key/endpoint and try again immediately.
+              showResult('Saved, but the connection test failed: ' + data.probe.error + '\nFix the endpoint or key and Save & Test again.', false);
+              return;
+            }
+            const n = data.probe && data.probe.ok ? data.probe.models : null;
+            showToast(n === null ? 'LiteLLM endpoint saved' : `LiteLLM configured — ${n} model${n === 1 ? '' : 's'} available`, 'success');
             close(true);
           } catch (e) {
-            showToast('Network error: ' + e.message, 'error');
+            showResult('Network error: ' + e.message, false);
           }
         };
         overlay.querySelector('#litellm-setup-endpoint').focus();
@@ -10984,51 +11030,134 @@ function burnAreaChart() {
       }
     }
 
+    // looksLikeApiKeyValue mirrors the server-side guardrail: env var
+    // NAMES are short with underscores; key values start with sk- or run
+    // long without any underscore. Catches keys pasted into the NAME/PATH
+    // fields (which would bake the key into hive.yaml and resolve to an
+    // empty key at runtime — a real leak that hit a hosted user).
+    function looksLikeApiKeyValue(v) {
+      const API_KEY_LIKE_LENGTH = 40; // matches apiKeyLikeLength server-side
+      return v.startsWith('sk-') || (v.length > API_KEY_LIKE_LENGTH && !v.includes('_'));
+    }
+
+    // litellmKeySourceLabel turns the API's keySource ("file:<path>" /
+    // "env:<NAME>") into human copy. Never contains the key value.
+    function litellmKeySourceLabel(src) {
+      if (!src) return '';
+      if (src.startsWith('env:')) return `environment variable ${src.slice(4)}`;
+      const path = src.startsWith('file:') ? src.slice(5) : src;
+      if (path.startsWith('/data/')) return `dashboard-saved key (${path})`;
+      if (path.startsWith('/secrets/')) return `Kubernetes Secret mount (${path})`;
+      return `key file ${path}`;
+    }
+
+    // litellmProbeMessage formats a probe result ({ok, models} or
+    // {ok:false, error}) from the save/test endpoints. Live results only —
+    // the server never counts static fallback aliases here.
+    function litellmProbeMessage(probe) {
+      if (probe.ok) {
+        return { ok: true, msg: `LiteLLM OK — ${probe.models} model${probe.models === 1 ? '' : 's'} available` };
+      }
+      return { ok: false, msg: `LiteLLM connection failed: ${probe.error}` };
+    }
+
+    // showLiteLLMTestResult writes a probe result to the tab's inline
+    // result line (when the LiteLLM tab is open) and returns the
+    // formatted message for toasts.
+    function showLiteLLMTestResult(probe) {
+      const r = litellmProbeMessage(probe);
+      const el = document.getElementById('litellm-test-result');
+      if (el) {
+        el.textContent = r.msg;
+        el.style.display = 'block';
+        el.style.color = r.ok ? 'var(--green)' : 'var(--red)';
+      }
+      return r;
+    }
+
+    function onLitellmKeyEnvChange(input) {
+      const v = input.value.trim();
+      if (v && looksLikeApiKeyValue(v)) {
+        showToast('This looks like an API key — paste it in the API Key field above; this field takes an environment variable NAME (e.g. HIVE_LITELLM_API_KEY)', 'error');
+        input.value = '';
+        return;
+      }
+      markDirty('litellm', 'apiKeyEnv', v);
+    }
+
+    function onLitellmKeyFileChange(input) {
+      const v = input.value.trim();
+      if (v && !v.startsWith('/') && looksLikeApiKeyValue(v)) {
+        showToast('This looks like an API key — paste it in the API Key field above; this field takes a file PATH (e.g. /secrets/litellm_api_key)', 'error');
+        input.value = '';
+        return;
+      }
+      markDirty('litellm', 'apiKeyFile', v);
+    }
+
     function renderGovLiteLLM(litellm) {
-      const keyEnvName = litellm.apiKeyEnv || 'HIVE_LITELLM_API_KEY';
-      const keyFilePath = litellm.apiKeyFile || '/secrets/litellm_api_key';
+      const keyLine = litellm.hasKey
+        ? `Key detected: yes — from ${esc(litellmKeySourceLabel(litellm.keySource))}`
+        : 'Key detected: no — paste your gateway key above';
       return `
         <div class="config-field">
           <label>Endpoint URL <span class="config-info">i<span class="config-tooltip">Base URL of the LiteLLM proxy (e.g. https://litellm.example.com). Agents reach it through the hive's inference translator — the MITM proxy stays in the path. The HIVE_LITELLM_ENDPOINT env var overrides this at runtime.</span></span></label>
           <input type="text" value="${esc(litellm.endpoint || '')}" placeholder="https://litellm.example.com" onchange="markDirty('litellm','endpoint',this.value)">
         </div>
         <div class="config-field">
-          <label>API Key Env Name <span class="config-info">i<span class="config-tooltip">Name of the environment variable holding the LiteLLM API key. The key VALUE is never stored in hive.yaml or shown here. A key file at ${esc(keyFilePath)} takes precedence when present.</span></span></label>
-          <input type="text" value="${esc(litellm.apiKeyEnv || '')}" placeholder="HIVE_LITELLM_API_KEY" onchange="markDirty('litellm','apiKeyEnv',this.value)">
-          <div style="font-size:0.72rem;margin-top:4px;color:${litellm.hasKey ? 'var(--green)' : 'var(--red)'}">Key detected: ${litellm.hasKey ? 'yes' : `no — set ${esc(keyEnvName)} or mount ${esc(keyFilePath)}`}</div>
+          <label>API Key <span class="config-info">i<span class="config-tooltip">Paste the key from your gateway/provider. It is stored privately on this hive (owner-only file on the persistent volume, plus the hive's Kubernetes Secret when available) — never in hive.yaml, logs, or config downloads. Saving runs a live connection test.</span></span></label>
+          <input type="password" value="" placeholder="${litellm.hasKey ? '(key is set — enter a new key to replace it)' : 'sk-...'}" autocomplete="new-password" onchange="markDirty('litellm','apiKey',this.value.trim())">
+          <div style="font-size:0.72rem;margin-top:4px;color:${litellm.hasKey ? 'var(--green)' : 'var(--red)'}">${keyLine}</div>
         </div>
         <div class="config-field">
           <label>Default Model <span class="config-info">i<span class="config-tooltip">Model used when an agent on the litellm backend has no model selected. Use Test Connection to list available models.</span></span></label>
           <input type="text" value="${esc(litellm.defaultModel || '')}" placeholder="e.g. gpt-4o" onchange="markDirty('litellm','defaultModel',this.value)">
         </div>
-        <div class="config-field">
-          <label>CA Bundle Path <span class="config-info">i<span class="config-tooltip">Optional PEM file for a private CA (e.g. an internal VPC endpoint). Certificate verification is never disabled — the CA is added to the trust pool.</span></span></label>
-          <input type="text" value="${esc(litellm.caBundle || '')}" placeholder="/secrets/litellm-ca.pem" onchange="markDirty('litellm','caBundle',this.value)">
-        </div>
-        <div class="config-toggle">
-          <div class="config-toggle-switch ${litellm.localProxy ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="litellm" data-key="localProxy"></div>
-          <span class="config-toggle-label">Local Proxy Fallback <span class="config-info">i<span class="config-tooltip">Run the bundled litellm binary as a local translator (config at /data/litellm/config.yaml). Off by default — the hive's Go translator forwards directly to the remote endpoint.</span></span></span>
-        </div>
+        <details style="margin:4px 0 8px">
+          <summary style="cursor:pointer;font-size:0.75rem;color:var(--muted)">Advanced — self-hosted key sources &amp; proxy options</summary>
+          <div class="config-field" style="margin-top:10px">
+            <label>Read Key From Environment Variable <span class="config-info">i<span class="config-tooltip">For self-hosted operators who manage the key outside the dashboard. Takes the NAME of an environment variable — never the key itself.</span></span></label>
+            <input type="text" value="${esc(litellm.apiKeyEnv || '')}" placeholder="HIVE_LITELLM_API_KEY" onchange="onLitellmKeyEnvChange(this)">
+            <div style="font-size:0.7rem;margin-top:3px;color:var(--muted)">Enter the NAME of an environment variable on the hive container that contains your key (self-hosted installs). Hosted users: paste your key in the API Key field above instead.</div>
+          </div>
+          <div class="config-field">
+            <label>Read Key From File Path <span class="config-info">i<span class="config-tooltip">For self-hosted operators. Path to a mounted file containing the key (e.g. a Kubernetes Secret mount).</span></span></label>
+            <input type="text" value="${esc(litellm.apiKeyFile || '')}" placeholder="/secrets/litellm_api_key" onchange="onLitellmKeyFileChange(this)">
+            <div style="font-size:0.7rem;margin-top:3px;color:var(--muted)">Path to a file that contains your key, such as a Kubernetes Secret mount (self-hosted installs). Hosted users: paste your key in the API Key field above instead.</div>
+          </div>
+          <div class="config-field">
+            <label>CA Bundle Path <span class="config-info">i<span class="config-tooltip">Optional PEM file for a private CA (e.g. an internal VPC endpoint). Certificate verification is never disabled — the CA is added to the trust pool.</span></span></label>
+            <input type="text" value="${esc(litellm.caBundle || '')}" placeholder="/secrets/litellm-ca.pem" onchange="markDirty('litellm','caBundle',this.value)">
+          </div>
+          <div class="config-toggle">
+            <div class="config-toggle-switch ${litellm.localProxy ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="litellm" data-key="localProxy"></div>
+            <span class="config-toggle-label">Local Proxy Fallback <span class="config-info">i<span class="config-tooltip">Run the bundled litellm binary as a local translator (config at /data/litellm/config.yaml). Off by default — the hive's Go translator forwards directly to the remote endpoint.</span></span></span>
+          </div>
+        </details>
         <div style="margin-top:12px">
           <button onclick="testLiteLLMConnection()" style="padding:6px 14px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--fg);cursor:pointer;font-size:0.78rem">Test Connection</button>
+          <div id="litellm-test-result" style="display:none;font-size:0.75rem;margin-top:8px;white-space:pre-wrap"></div>
         </div>`;
     }
 
     async function testLiteLLMConnection() {
       const toast = showToast('Testing LiteLLM connection…', 'info', true);
       try {
-        const resp = await fetch('/api/inference/models/litellm');
-        const data = await resp.json();
+        // Live probe only (/v1/models with the same key resolution the
+        // translator uses). The old /api/inference/models path silently
+        // substituted the static fallback aliases, reporting "OK — 7
+        // models" against gateways that 401'd everything.
+        const resp = await fetch('/api/config/governor/litellm/test', {
+          method: 'POST',
+          headers: _inceptionAuthHeaders()
+        });
+        const data = await resp.json().catch(() => ({}));
         if (!resp.ok) {
           dismissToast(toast, data.error || 'LiteLLM endpoint not configured — save the endpoint first', 'error');
           return;
         }
-        const count = (data.models || []).length;
-        if (count > 0) {
-          dismissToast(toast, `LiteLLM OK — ${count} model${count === 1 ? '' : 's'} available`, 'success');
-        } else {
-          dismissToast(toast, 'Connected, but no models returned (check the API key)', 'error');
-        }
+        const r = showLiteLLMTestResult(data.probe || { ok: false, error: 'no probe result returned' });
+        dismissToast(toast, r.msg, r.ok ? 'success' : 'error');
       } catch (e) {
         dismissToast(toast, 'LiteLLM test failed: ' + e.message, 'error');
       }
@@ -12884,6 +13013,16 @@ function burnAreaChart() {
               body: JSON.stringify(values)
             });
             if (!res.ok) throw new Error(await saveErrorMessage(res));
+            if (_configState.type === 'governor' && section === 'litellm') {
+              // Saving the LiteLLM tab auto-runs the live connection test
+              // server-side; surface its result exactly like the Test
+              // Connection button would (inline line + toast).
+              const data = await res.json().catch(() => null);
+              if (data && data.probe) {
+                const r = showLiteLLMTestResult(data.probe);
+                showToast(r.msg, r.ok ? 'success' : 'error');
+              }
+            }
           }
         } catch (err) {
           showToast(`Failed to save ${section}: ${err.message}`, 'error');

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -859,6 +859,38 @@ subjects:
   namespace: {{.Namespace}}
 ---
 {{- end}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: hive-secrets-writer
+  namespace: {{.Namespace}}
+rules:
+# Least privilege: the hive pod may read and patch ONLY its own
+# hive-secrets Secret, so dashboard-entered API keys (e.g. the LiteLLM
+# key) are stored in the Secret instead of on the PVC.
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["hive-secrets"]
+  verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hive-secrets-writer
+  namespace: {{.Namespace}}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: hive-secrets-writer
+subjects:
+- kind: ServiceAccount
+{{- if .RequiresSCC}}
+  name: hive-sa
+{{- else}}
+  name: default
+{{- end}}
+  namespace: {{.Namespace}}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -1112,11 +1144,12 @@ spec:
           mountPath: /etc/hive
         - name: data
           mountPath: /data
-{{- if .UseApp}}
+        # hive-secrets is always whole-volume-mounted (no subPath) so keys
+        # the pod patches into the Secret (e.g. litellm_api_key entered in
+        # the dashboard) propagate to /secrets/<key> without a restart.
         - name: secrets
           mountPath: /secrets
           readOnly: true
-{{- end}}
       volumes:
       - name: config
         configMap:
@@ -1126,11 +1159,9 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: hive-data
-{{- if .UseApp}}
       - name: secrets
         secret:
           secretName: hive-secrets
-{{- end}}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Why

A real hosted-hive user configuring LiteLLM hit three compounding failures:

1. **The key-entry UX invited disaster.** The Configure LiteLLM dialog's only key input was "API Key Env Name". A hosted user cannot set pod env vars, so she predictably pasted her actual API key into it — leaking the key into hive.yaml (plaintext, echoed back into the tab on every load, visible on screen shares) and producing silent empty-key 401s (`os.Getenv("sk-...") == ""`). She burned ~10 agent-retry cycles learning what a save-time probe would have said instantly — while Test Connection reported "OK — 7 models" because it counted the static fallback aliases.
2. **Dashboard saves did not survive pod restarts.** The copy-config init container re-seeds /etc/hive/hive.yaml from the ConfigMap on every boot; Config.Save writes only the emptyDir copy, so every dashboard save silently vanished on restart/upgrade.

## What changed

### Key entry (dialog + Governor → LiteLLM tab)
- **API Key (password) is the primary field.** On save the VALUE is written to `/data/secrets/litellm_api_key` (0600, dir 0700 — the only reader is the main hive process, where the dashboard and inference translator run in-process) and best-effort patched into the `hive-secrets` Secret via the in-cluster API. hive.yaml records only the file path; the value never enters hive.yaml, logs, or responses.
- **Env-name / key-file are Advanced options** ("Read Key From Environment Variable" / "Read Key From File Path") with copy explaining they're for self-hosted operators and take a NAME/PATH — never the key.
- **Guardrails (client + server):** values that look like a key (sk- prefix, or >40 chars without underscores; non-absolute for the path field) are rejected with copy pointing at the API Key field.
- **Validate-on-save:** every save runs a live `{endpoint}/v1/models` probe and surfaces the result in the dialog/tab — "N models available" on success, the gateway's actual error (e.g. LiteLLM "token not found") on failure, with distinct copy for "requires a key (none configured)" vs "rejected the configured key". New `POST /api/config/governor/litellm/test` backs the Test Connection button with a **live probe only** — the static fallback aliases are never counted (dropdowns still get them, already marked "(common alias, unverified)").
- Key saves re-fire `RefreshInferenceRoutes("litellm")` after the store, so routes (which snapshot the key) pick up a rotated key without agent restarts.

### Never echo key values (security)
- The governor-config GET builds the litellm section via `litellmSectionResponse`: the resolved key value is **never** serialized — only `hasKey`, `keySource` (which store), and `keyHint` (masked tail `••••WMg`).
- Key-like values previously pasted into `api_key_env` / `api_key_file` come back **masked** with `...LooksLikeKey` flags; the tab renders those fields empty with a "move it to the API Key field" warning. Storing a real key scrubs the pasted value out of `api_key_env` (removing the leaked secret from hive.yaml).
- The API Key input is always empty on load; blank saves keep the stored key.

### Key resolution + provisioning
- `ResolveAPIKey` order: `api_key_file` → `/secrets/litellm_api_key` (Secret mount) → `/data/secrets/litellm_api_key` (dashboard PVC file) → env vars. A dashboard key survives a hive.yaml reset; an admin Secret key survives a PVC wipe.
- Template: least-privilege `hive-secrets-writer` Role (get/patch on that one Secret), and `hive-secrets` is mounted at `/secrets` **unconditionally, whole-volume, no items filter** — an items filter on a live hive was exactly what kept a patched `litellm_api_key` from ever projecting. Note: for non-GitHub-App hives this makes `/secrets/github-token` visible in-container (precedent: `gh-app-key.pem` is already chmod 644 there); the PVC file remains authoritative for the litellm key because older-template hives lack the projection and even current mounts lag a patch by the kubelet sync (~2 min).

### Persistence across pod restarts — mechanism chosen: **PVC overlay**, not ConfigMap write-back
Investigation: there is **no ConfigMap RBAC anywhere in the spoke** (the only Role is `deployments get/patch` under RequiresSCC, and `serviceAccountName` is only set on SCC clusters), and provisioning-template RBAC reaches only NEW hives — existing hosted hives receive image-only upgrades, so ConfigMap write-back would fix nobody currently affected. The overlay ships entirely in the image:
- `Config.Save` also writes a **secret-free** `/data/hive.yaml.dashboard` in k8s mode (env-derived secrets collapsed back to `${VAR}` forms).
- `entrypoint.sh` merges it over the ConfigMap seed at boot (before the recovery backup and the agent-UID enumeration). **Precedence:** overlay wins for everything except hub/admin-managed keys — `acmm_level` and `hub.is_public` — which the ConfigMap keeps when it sets them. Corrupt/implausible overlays are ignored; the merge writes via temp + `os.replace`.

## UX flow after this change
1. User selects litellm anywhere → dialog: Endpoint + API Key (password). Pastes both → **Save & Test** → live probe → "LiteLLM configured — 23 models available" (or the gateway's real error inline, dialog stays open to fix and retry).
2. Tab shows "Key detected: yes (••••WMg) — from dashboard-saved key (/data/secrets/litellm_api_key)". Key never rendered.
3. Pod restarts/upgrades: entrypoint merges the overlay; endpoint + key pointer survive; key file lives on the PVC.

## Tests
- 11 new/updated Go tests (guardrails, key storage + 0600, probe success/401 with redaction, never-echo GET masking, env-value scrub, overlay write + secret-scrub, k8s/docker gating) — `go test ./pkg/config ./pkg/dashboard` green.
- Entrypoint merge exercised end-to-end (merge precedence, corrupt overlay, implausible overlay, absent admin keys); `sh -n` clean; index.html script blocks parse under node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)