### PR TITLE
feat(dashboard): Getting Started welcome dialog for new hive owners

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -13850,13 +13850,18 @@ function burnAreaChart() {
         title: 'Install the GitHub App',
         auto: (data) => data ? data.githubAppRequired !== true : null,
         body: 'The GitHub App unlocks issues, advisory reports, and PRs on your primary repo — without it the hive can only observe.',
-        autoNote: 'Checks itself once the app is detected on your repository.'
+        autoNote: 'Checks itself once the app is detected on your repository.',
+        actions: [
+          { label: 'Install GitHub App', onclick: 'welcomeInstallGitHubApp()' },
+          { label: 'Re-check', onclick: 'welcomeRecheckGitHubApp(event)' }
+        ]
       },
       {
         id: 'methods',
         title: 'Pick a method for each agent',
         auto: null,
-        body: 'Each agent card has a <strong>method dropdown</strong>: <strong>claude / copilot / gemini</strong> run on subscription CLIs, while <strong>vllm / llm-d / litellm</strong> use a self-hosted inference endpoint (litellm takes an endpoint + API key under Governor Config → LiteLLM). Mix and match per agent.'
+        body: 'Each agent card has a <strong>method dropdown</strong>: <strong>claude / copilot / gemini</strong> run on subscription CLIs, while <strong>vllm / llm-d / litellm</strong> use a self-hosted inference endpoint (litellm takes an endpoint + API key under Governor Config → LiteLLM). Mix and match per agent.',
+        actions: [{ label: 'Show me', onclick: 'welcomeShowAgentCard()' }]
       },
       {
         id: 'logins',
@@ -13866,49 +13871,55 @@ function burnAreaChart() {
           return data.agents.every(a => !_welcomeAgentNeedsLogin(a));
         },
         body: 'Credentials are shared <strong>per method, not per agent</strong> — one copilot device-code login covers every copilot agent, and claude uses a paste-the-code flow. Inference methods (vllm / llm-d / litellm) never log in; they use the endpoint + key instead.',
-        autoNote: 'Checks itself once every agent’s method is authenticated.'
+        autoNote: 'Checks itself once every agent’s method is authenticated.',
+        actions: [{ label: 'Show me', onclick: 'welcomeShowLogin()' }]
       },
       {
         id: 'terminal',
         title: 'Watch an agent in its terminal',
         auto: null,
-        body: 'The cyan <strong>▶ terminal</strong> button on each agent card opens the agent’s live tmux session: watch it work in real time, scroll its history, or type <strong>/login</strong> in the CLI when a login needs interaction. Etiquette: it is the agent’s working session — observe, don’t drive, except for logins.'
+        body: 'The cyan <strong>▶ terminal</strong> button on each agent card opens the agent’s live tmux session: watch it work in real time, scroll its history, or type <strong>/login</strong> in the CLI when a login needs interaction. Etiquette: it is the agent’s working session — observe, don’t drive, except for logins.',
+        actions: [{ label: '▶ Open a terminal', onclick: 'welcomeOpenTerminal()' }]
       },
       {
         id: 'models',
         title: 'Choose models',
         auto: null,
-        body: 'The <strong>model dropdown</strong> on each agent card lists models auto-discovered for its method. 📌 pinning a model stops the governor from auto-selecting a different one — it never blocks your own changes.'
+        body: 'The <strong>model dropdown</strong> on each agent card lists models auto-discovered for its method. 📌 pinning a model stops the governor from auto-selecting a different one — it never blocks your own changes.',
+        actions: [{ label: 'Show me', onclick: 'welcomeShowAgentCard()' }]
       },
       {
         id: 'repos',
         title: 'Add repos &amp; mark the primary',
         auto: () => window._primaryRepo ? true : false,
         body: 'Governor Config → <strong>Repos</strong>: add every repository the agents should watch, and set the <strong>primary</strong> repo — it hosts the advisory issue and default markings.',
-        autoNote: 'Checks itself once a primary repo is set.'
+        autoNote: 'Checks itself once a primary repo is set.',
+        actions: [{ label: 'Show me', onclick: "welcomeShowConfigTab('Repos')" }]
       },
       {
         id: 'cadences',
         title: 'Tune cadences',
         auto: null,
-        body: 'Governor Config → <strong>Agents</strong>: per-mode kick intervals (idle / quiet / busy / surge), on-demand vs scheduled agents, and pausing. The intensity bar on the Governor panel shows the current mode.'
+        body: 'Governor Config → <strong>Agents</strong>: per-mode kick intervals (idle / quiet / busy / surge), on-demand vs scheduled agents, and pausing. The intensity bar on the Governor panel shows the current mode.',
+        actions: [{ label: 'Show me', onclick: "welcomeShowConfigTab('Agents')" }]
       },
       {
         id: 'acmm',
         title: 'Set your ACMM level',
         auto: null,
-        body: 'The amber badge in the sidebar opens the <strong>maturity-level dialog</strong>: L1 (advisory-only) → L6 (fully autonomous), each level additive. A default is preset — confirm it matches how much autonomy you want.'
+        body: 'The amber badge in the sidebar opens the <strong>maturity-level dialog</strong>: L1 (advisory-only) → L6 (fully autonomous), each level additive. A default is preset — confirm it matches how much autonomy you want.',
+        actions: [{ label: 'Show me', onclick: 'welcomeShowACMM()' }]
       }
     ];
 
     // Collapsed "More to explore" one-liners under the core steps.
     const WELCOME_MORE_ITEMS = [
-      { id: 'budget', label: 'Budget', desc: 'set a weekly token budget and watch the burn rate (Governor Config → Budget).' },
-      { id: 'notifications', label: 'Notifications', desc: 'route alerts to your channels (Governor Config → Notifications).' },
-      { id: 'knowledge', label: 'Knowledge Base', desc: 'seed facts and patterns the agents reuse across passes.' },
-      { id: 'contributors', label: 'Contributor Relay', desc: 'let outside contributors drive agents, with a leaderboard.' },
-      { id: 'hub', label: 'Hub visibility', desc: 'make this hive public or private on the hub (Governor Config → Hub).' },
-      { id: 'theme', label: 'Light / Dark mode', desc: 'switch layouts any time from the toggle in the top bar.' }
+      { id: 'budget', label: 'Budget', desc: 'set a weekly token budget and watch the burn rate (Governor Config → Budget).', onclick: "welcomeShowConfigTab('Budget')" },
+      { id: 'notifications', label: 'Notifications', desc: 'route alerts to your channels (Governor Config → Notifications).', onclick: "welcomeShowConfigTab('Notifications')" },
+      { id: 'knowledge', label: 'Knowledge Base', desc: 'seed facts and patterns the agents reuse across passes.', onclick: "welcomeShowSection('knowledge-section')" },
+      { id: 'contributors', label: 'Contributor Relay', desc: 'let outside contributors drive agents, with a leaderboard.', onclick: "welcomeShowSection('contributors-section')" },
+      { id: 'hub', label: 'Hub visibility', desc: 'make this hive public or private on the hub (Governor Config → Hub).', onclick: "welcomeShowConfigTab('Hub')" },
+      { id: 'theme', label: 'Light / Dark mode', desc: 'switch layouts any time from the toggle in the top bar.', onclick: 'toggleLayout()' }
     ];
 
     /** Done-state for one step: auto steps compute from the payload, manual
@@ -13948,11 +13959,12 @@ function burnAreaChart() {
           + `</div>`
           + `<div class="welcome-step-body">${step.body}`
           + (step.autoNote ? `<span class="welcome-auto-note">${step.autoNote}</span>` : '')
+          + (step.actions ? `<div class="welcome-step-actions">` + step.actions.map(a => `<button class="btn" onclick="${a.onclick}">${a.label}</button>`).join('') + `</div>` : '')
           + `</div></div>`;
       }
       html += '<div class="welcome-more-title">More to explore</div>';
       for (const item of WELCOME_MORE_ITEMS) {
-        html += `<div class="welcome-more-item"><span class="welcome-more-link" id="welcome-more-${item.id}">${item.label}</span> — ${item.desc}</div>`;
+        html += `<div class="welcome-more-item"><span class="welcome-more-link" id="welcome-more-${item.id}" onclick="${item.onclick}">${item.label}</span> — ${item.desc}</div>`;
       }
       body.innerHTML = html;
       updateWelcomeProgress();
@@ -13993,6 +14005,72 @@ function burnAreaChart() {
       const data = window._lastStatus || null;
       const done = WELCOME_STEPS.filter(s => welcomeStepDone(s, data)).length;
       el.textContent = done + ' of ' + WELCOME_STEPS.length + ' done';
+    }
+
+    // ── Welcome deep links ("Show me" wiring) ─────────────────────────
+    // Every action reuses an existing entry point: openConfigDialog(tab),
+    // openACMMDialog(), ocSelectAgent() agent focus, terminalUrl(), and the
+    // GitHub App banner's install URL + recheckGitHubApp().
+
+    /** First agent matching pred (else first agent) from the last payload. */
+    function _welcomeFirstAgentName(pred) {
+      const agents = (window._lastStatus && window._lastStatus.agents) || [];
+      const match = pred ? agents.find(pred) : null;
+      return (match || agents[0] || {}).name || null;
+    }
+    /** Focus the first agent card (method/model dropdowns live there). */
+    function welcomeShowAgentCard() {
+      closeWelcomeDialog();
+      const name = _welcomeFirstAgentName();
+      if (name) ocSelectAgent(name);
+    }
+    /** Focus the first agent whose method still needs a login. */
+    function welcomeShowLogin() {
+      closeWelcomeDialog();
+      const name = _welcomeFirstAgentName(_welcomeAgentNeedsLogin);
+      if (name) ocSelectAgent(name);
+    }
+    /** Open the first agent's live tmux session in a new tab. */
+    function welcomeOpenTerminal() {
+      const name = _welcomeFirstAgentName();
+      if (!name) { showToast('No agents yet — terminals open from each agent card', 'info'); return; }
+      window.open(terminalUrl(name), '_blank', 'noopener');
+    }
+    /** Open the GitHub App install page (same URL the banner links to). */
+    function welcomeInstallGitHubApp() {
+      const url = (window._lastStatus && window._lastStatus.githubAppInstallURL) || '';
+      if (url) { window.open(url, '_blank', 'noopener'); return; }
+      const installed = !!(window._lastStatus) && window._lastStatus.githubAppRequired !== true;
+      showToast(installed ? 'GitHub App already installed ✓' : 'Install URL not available yet — waiting for the next status refresh', 'info');
+    }
+    /** Re-check installation via the banner action, then flip the
+        auto-check immediately instead of waiting for the next SSE tick. */
+    async function welcomeRecheckGitHubApp(ev) {
+      const btn = ev ? ev.target : null;
+      if (btn) { btn.disabled = true; btn.textContent = 'Checking…'; }
+      await recheckGitHubApp();
+      // recheckGitHubApp() hides the banner when the app is detected —
+      // mirror that outcome onto the cached payload.
+      const banner = document.getElementById('gh-app-install-banner');
+      const installed = !!(banner && banner.hasAttribute('hidden'));
+      if (installed && window._lastStatus) window._lastStatus.githubAppRequired = false;
+      if (btn) { btn.disabled = false; btn.textContent = installed ? 'Installed ✓' : 'Re-check'; }
+      refreshWelcomeAutoChecks(window._lastStatus || null);
+    }
+    /** Jump to a Governor Config tab (Repos, Agents, Budget, …). */
+    function welcomeShowConfigTab(tab) {
+      closeWelcomeDialog();
+      openConfigDialog('governor', null, tab);
+    }
+    /** Open the ACMM maturity-level dialog. */
+    function welcomeShowACMM() {
+      closeWelcomeDialog();
+      openACMMDialog();
+    }
+    /** Navigate to a dashboard section (knowledge, contributors, …). */
+    function welcomeShowSection(section) {
+      closeWelcomeDialog();
+      ocNavigate(section);
     }
 
     /** Called from render() on every status refresh so auto-checks flip

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -8286,6 +8286,7 @@ function burnAreaChart() {
       }
       renderGhRateLimits(data.ghRateLimits || {});
       renderGitHubAppBanner(data);
+      refreshWelcomeAutoChecks(data);
       renderHubBanner(data.hubBanner);
       renderSystemAlerts(data.systemAlerts || []);
       if (!_dropdownOpen && !_configModalOpen) {
@@ -13804,6 +13805,16 @@ function burnAreaChart() {
     }
 
     function openWelcomeDialog() {
+      // Refresh the primary-repo signal: window._primaryRepo is set by the
+      // /api/config fetch at boot, so a repo saved through the config dialog
+      // would otherwise stay stale until a full page reload.
+      fetch('/api/config').then(r => r.json()).then(cfg => {
+        const repoDisplay = cfg.org && cfg.primaryRepo && !cfg.primaryRepo.includes('/')
+          ? cfg.org + '/' + cfg.primaryRepo
+          : (cfg.primaryRepo || '');
+        if (repoDisplay) window._primaryRepo = repoDisplay;
+        refreshWelcomeAutoChecks(window._lastStatus || null);
+      }).catch(() => {});
       renderWelcomeDialog();
       document.getElementById('welcome-overlay').classList.remove('hidden');
     }
@@ -13816,10 +13827,184 @@ function burnAreaChart() {
       closeWelcomeDialog();
     }
 
+    /** Same needs-login formula as the agent-card Auth badge. */
+    function _welcomeAgentNeedsLogin(a) {
+      return a.needsLogin === true || (a.authKnown === true && a.authAvailable !== true);
+    }
+
+    // Checklist steps. `auto(data)` derives done-state live from the latest
+    // status payload (re-evaluated on every render pass, so checks flip as
+    // the hive changes); steps without `auto` are manual click-to-check
+    // boxes persisted in hive-welcome-state-v1. Content is static markup —
+    // the dialog renders once on open, never in the hot render path.
+    const WELCOME_STEPS = [
+      {
+        id: 'welcome',
+        title: 'Welcome to your hive',
+        // Reading this step is step one — opening the dialog completes it.
+        auto: () => true,
+        body: 'Your hive is a fleet of AI <strong>agents</strong> that work your repositories — triaging issues, writing fixes, opening PRs. The <strong>governor</strong> paces them automatically as the workload changes (idle → quiet → busy → surge). This checklist covers the one-time choices that make the hive productive, and it updates itself as you complete them.'
+      },
+      {
+        id: 'github-app',
+        title: 'Install the GitHub App',
+        auto: (data) => data ? data.githubAppRequired !== true : null,
+        body: 'The GitHub App unlocks issues, advisory reports, and PRs on your primary repo — without it the hive can only observe.',
+        autoNote: 'Checks itself once the app is detected on your repository.'
+      },
+      {
+        id: 'methods',
+        title: 'Pick a method for each agent',
+        auto: null,
+        body: 'Each agent card has a <strong>method dropdown</strong>: <strong>claude / copilot / gemini</strong> run on subscription CLIs, while <strong>vllm / llm-d / litellm</strong> use a self-hosted inference endpoint (litellm takes an endpoint + API key under Governor Config → LiteLLM). Mix and match per agent.'
+      },
+      {
+        id: 'logins',
+        title: 'Log in once per method',
+        auto: (data) => {
+          if (!data || !Array.isArray(data.agents) || data.agents.length === 0) return null;
+          return data.agents.every(a => !_welcomeAgentNeedsLogin(a));
+        },
+        body: 'Credentials are shared <strong>per method, not per agent</strong> — one copilot device-code login covers every copilot agent, and claude uses a paste-the-code flow. Inference methods (vllm / llm-d / litellm) never log in; they use the endpoint + key instead.',
+        autoNote: 'Checks itself once every agent’s method is authenticated.'
+      },
+      {
+        id: 'terminal',
+        title: 'Watch an agent in its terminal',
+        auto: null,
+        body: 'The cyan <strong>▶ terminal</strong> button on each agent card opens the agent’s live tmux session: watch it work in real time, scroll its history, or type <strong>/login</strong> in the CLI when a login needs interaction. Etiquette: it is the agent’s working session — observe, don’t drive, except for logins.'
+      },
+      {
+        id: 'models',
+        title: 'Choose models',
+        auto: null,
+        body: 'The <strong>model dropdown</strong> on each agent card lists models auto-discovered for its method. 📌 pinning a model stops the governor from auto-selecting a different one — it never blocks your own changes.'
+      },
+      {
+        id: 'repos',
+        title: 'Add repos &amp; mark the primary',
+        auto: () => window._primaryRepo ? true : false,
+        body: 'Governor Config → <strong>Repos</strong>: add every repository the agents should watch, and set the <strong>primary</strong> repo — it hosts the advisory issue and default markings.',
+        autoNote: 'Checks itself once a primary repo is set.'
+      },
+      {
+        id: 'cadences',
+        title: 'Tune cadences',
+        auto: null,
+        body: 'Governor Config → <strong>Agents</strong>: per-mode kick intervals (idle / quiet / busy / surge), on-demand vs scheduled agents, and pausing. The intensity bar on the Governor panel shows the current mode.'
+      },
+      {
+        id: 'acmm',
+        title: 'Set your ACMM level',
+        auto: null,
+        body: 'The amber badge in the sidebar opens the <strong>maturity-level dialog</strong>: L1 (advisory-only) → L6 (fully autonomous), each level additive. A default is preset — confirm it matches how much autonomy you want.'
+      }
+    ];
+
+    // Collapsed "More to explore" one-liners under the core steps.
+    const WELCOME_MORE_ITEMS = [
+      { id: 'budget', label: 'Budget', desc: 'set a weekly token budget and watch the burn rate (Governor Config → Budget).' },
+      { id: 'notifications', label: 'Notifications', desc: 'route alerts to your channels (Governor Config → Notifications).' },
+      { id: 'knowledge', label: 'Knowledge Base', desc: 'seed facts and patterns the agents reuse across passes.' },
+      { id: 'contributors', label: 'Contributor Relay', desc: 'let outside contributors drive agents, with a leaderboard.' },
+      { id: 'hub', label: 'Hub visibility', desc: 'make this hive public or private on the hub (Governor Config → Hub).' },
+      { id: 'theme', label: 'Light / Dark mode', desc: 'switch layouts any time from the toggle in the top bar.' }
+    ];
+
+    /** Done-state for one step: auto steps compute from the payload, manual
+        steps read the persisted checkbox. */
+    function welcomeStepDone(step, data) {
+      if (step.auto) return step.auto(data) === true;
+      return _welcomeState.checks[step.id] === true;
+    }
+
+    // Steps the user expanded this session (first undone step opens by default).
+    const _welcomeOpenSteps = new Set();
+
     function renderWelcomeDialog() {
       const body = document.getElementById('welcome-body');
       if (!body) return;
-      body.innerHTML = '<p class="welcome-intro">Your hive is a fleet of AI agents that work your repositories — triaging issues, writing fixes, and opening PRs — while the governor paces them to match the workload. A few one-time choices below make it productive.</p>';
+      const data = window._lastStatus || null;
+      if (_welcomeOpenSteps.size === 0) {
+        const firstUndone = WELCOME_STEPS.find(s => !welcomeStepDone(s, data));
+        _welcomeOpenSteps.add(firstUndone ? firstUndone.id : WELCOME_STEPS[0].id);
+      }
+      let html = '';
+      let n = 0;
+      for (const step of WELCOME_STEPS) {
+        n++;
+        const done = welcomeStepDone(step, data);
+        const open = _welcomeOpenSteps.has(step.id);
+        const checkCls = step.auto ? 'welcome-check' : 'welcome-check manual';
+        const checkTitle = step.auto
+          ? 'Checked automatically from the hive’s live status'
+          : 'Click to mark this step done (saved in this browser)';
+        const checkAttrs = step.auto ? '' : ` onclick="toggleWelcomeCheck(event,'${step.id}')" role="checkbox" aria-checked="${done}" tabindex="0" onkeydown="if(event.key===' '||event.key==='Enter')toggleWelcomeCheck(event,'${step.id}')"`;
+        html += `<div class="welcome-step${done ? ' done' : ''}${open ? ' open' : ''}" id="welcome-step-${step.id}">`
+          + `<div class="welcome-step-header" onclick="toggleWelcomeStep('${step.id}')">`
+          + `<span class="${checkCls}" title="${checkTitle}"${checkAttrs}>${done ? '✓' : ''}</span>`
+          + `<span class="welcome-step-title">${n}. ${step.title}</span>`
+          + `<span class="welcome-step-chevron">▶</span>`
+          + `</div>`
+          + `<div class="welcome-step-body">${step.body}`
+          + (step.autoNote ? `<span class="welcome-auto-note">${step.autoNote}</span>` : '')
+          + `</div></div>`;
+      }
+      html += '<div class="welcome-more-title">More to explore</div>';
+      for (const item of WELCOME_MORE_ITEMS) {
+        html += `<div class="welcome-more-item"><span class="welcome-more-link" id="welcome-more-${item.id}">${item.label}</span> — ${item.desc}</div>`;
+      }
+      body.innerHTML = html;
+      updateWelcomeProgress();
+    }
+
+    function toggleWelcomeStep(id) {
+      if (_welcomeOpenSteps.has(id)) _welcomeOpenSteps.delete(id); else _welcomeOpenSteps.add(id);
+      const el = document.getElementById('welcome-step-' + id);
+      if (el) el.classList.toggle('open', _welcomeOpenSteps.has(id));
+    }
+
+    function toggleWelcomeCheck(ev, id) {
+      ev.stopPropagation();
+      const step = WELCOME_STEPS.find(s => s.id === id);
+      if (!step || step.auto) return;
+      _welcomeState.checks[id] = _welcomeState.checks[id] !== true;
+      saveWelcomeState();
+      _syncWelcomeStepEl(step, window._lastStatus || null);
+      updateWelcomeProgress();
+    }
+
+    /** Update one rendered step's check/done visuals in place. */
+    function _syncWelcomeStepEl(step, data) {
+      const el = document.getElementById('welcome-step-' + step.id);
+      if (!el) return;
+      const done = welcomeStepDone(step, data);
+      el.classList.toggle('done', done);
+      const check = el.querySelector('.welcome-check');
+      if (check) {
+        check.textContent = done ? '✓' : '';
+        if (!step.auto) check.setAttribute('aria-checked', String(done));
+      }
+    }
+
+    function updateWelcomeProgress() {
+      const el = document.getElementById('welcome-progress');
+      if (!el) return;
+      const data = window._lastStatus || null;
+      const done = WELCOME_STEPS.filter(s => welcomeStepDone(s, data)).length;
+      el.textContent = done + ' of ' + WELCOME_STEPS.length + ' done';
+    }
+
+    /** Called from render() on every status refresh so auto-checks flip
+        live. No-op unless the dialog is actually open. */
+    function refreshWelcomeAutoChecks(data) {
+      if (!_welcomeWriteAccess) return;
+      const overlay = document.getElementById('welcome-overlay');
+      if (!overlay || overlay.classList.contains('hidden')) return;
+      for (const step of WELCOME_STEPS) {
+        if (step.auto) _syncWelcomeStepEl(step, data);
+      }
+      updateWelcomeProgress();
     }
 
     checkGHAuth();

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1942,6 +1942,41 @@
       border-color: var(--amber);
       text-decoration: underline;
     }
+
+    /* ══ Welcome / Getting Started dialog ══
+       Panel, overlay, and footer buttons come from the Phase-2 modal and
+       button recipes (.config-overlay/.config-modal/.hive-dialog-btn);
+       only the checklist internals are defined here. Tokens only. */
+    .welcome-modal { max-width: 680px; width: 92%; max-height: 86vh; display: flex; flex-direction: column; }
+    .welcome-body { padding: 4px 24px 16px; overflow-y: auto; }
+    .welcome-progress { font-size: 0.72em; font-weight: 400; color: var(--muted); margin-left: 8px; white-space: nowrap; }
+    .welcome-intro { font-size: var(--fs-base); color: var(--text); margin: 12px 0 16px; line-height: 1.55; }
+    .welcome-step { border: 1px solid var(--line); border-radius: var(--radius); margin-bottom: 8px; background: color-mix(in srgb, var(--panel-strong) 40%, transparent); }
+    .welcome-step-header { display: flex; align-items: center; gap: 10px; padding: 10px 12px; cursor: pointer; user-select: none; }
+    .welcome-step-title { flex: 1; font-size: var(--fs-base); font-weight: 600; color: var(--text); }
+    .welcome-step.done .welcome-step-title { color: var(--muted); }
+    .welcome-check { width: 20px; height: 20px; flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center; border: 1px solid var(--line-strong); border-radius: 5px; font-size: 0.8rem; color: var(--bg); background: transparent; transition: background 0.15s, border-color 0.15s; }
+    .welcome-step.done .welcome-check { background: var(--green); border-color: var(--green); }
+    .welcome-check.manual { cursor: pointer; }
+    .welcome-check.manual:hover { border-color: var(--green); }
+    .welcome-step-chevron { color: var(--muted); font-size: 0.7rem; transition: transform 0.15s; }
+    .welcome-step.open .welcome-step-chevron { transform: rotate(90deg); }
+    .welcome-step-body { display: none; padding: 0 12px 12px 42px; font-size: var(--fs-sm); color: var(--muted); line-height: 1.55; }
+    .welcome-step.open .welcome-step-body { display: block; }
+    .welcome-step-body strong { color: var(--text); }
+    .welcome-step-actions { display: flex; gap: 8px; margin-top: 10px; flex-wrap: wrap; }
+    .welcome-auto-note { display: block; margin-top: 8px; font-size: var(--fs-xs); color: var(--muted); font-style: italic; }
+    .welcome-more-title { font-size: var(--fs-sm); font-weight: 600; color: var(--muted); margin: 14px 0 6px; letter-spacing: 0.5px; text-transform: uppercase; }
+    .welcome-more-item { font-size: var(--fs-sm); color: var(--muted); padding: 3px 0 3px 8px; line-height: 1.5; }
+    .welcome-more-link { color: var(--blue); cursor: pointer; font-weight: 600; }
+    .welcome-more-link:hover { text-decoration: underline; }
+    .welcome-footer { justify-content: space-between; }
+    @media (max-width: 480px) {
+      .welcome-step-body { padding-left: 12px; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .welcome-check, .welcome-step-chevron { transition: none; }
+    }
   </style>
 </head>
 <body>
@@ -2100,6 +2135,19 @@
     </div>
   </div>
 </div>
+<div id="welcome-overlay" class="config-overlay hidden">
+  <div class="config-modal welcome-modal">
+    <div class="config-header">
+      <h2 class="config-title">🐝 Getting Started<span id="welcome-progress" class="welcome-progress"></span></h2>
+      <button class="config-close" onclick="closeWelcomeDialog()">&times;</button>
+    </div>
+    <div class="config-body welcome-body" id="welcome-body"></div>
+    <div class="config-footer welcome-footer">
+      <button class="hive-dialog-btn" onclick="closeWelcomeDialog()" title="Close for now — the checklist opens again on the next dashboard load">Remind me next time</button>
+      <button class="hive-dialog-btn primary" onclick="dismissWelcomeDialog()" title="Stop opening this checklist on load — reopen it any time from Getting Started in the sidebar or the ? button in the top bar">Don't show on load</button>
+    </div>
+  </div>
+</div>
 <div class="gh-auth-alert" id="gh-auth-alert">GitHub API authentication failed. Check GitHub App key or token configuration.</div>
   <div class="gh-rate-alert" id="gh-rate-alert"></div>
 
@@ -2148,6 +2196,7 @@
       <a class="oc-nav-item" data-section="contributors-section" onclick="ocNavigate('contributors-section')"><span class="oc-nav-emoji">👥</span><span class="oc-nav-text">Contributors</span><span id="contributors-sidebar-badge" class="oc-nav-count" style="display:none"></span></a>
       <a class="oc-nav-item" data-section="audit-section" onclick="ocNavigate('audit-section')"><span class="oc-nav-emoji">📋</span><span class="oc-nav-text">Audit Log</span></a>
       <a class="oc-nav-item" data-section="nous-section" onclick="ocNavigate('nous-section')"><span class="oc-nav-emoji">🧪</span><span class="oc-nav-text">Strategy Lab</span></a>
+      <a class="oc-nav-item" id="welcome-nav-item" style="display:none" onclick="openWelcomeDialog()" title="Open the Getting Started checklist — one-time setup steps for a new hive"><span class="oc-nav-emoji">🚀</span><span class="oc-nav-text">Getting Started</span></a>
       <a class="oc-nav-item" href="/api/docs" target="_blank"><span class="oc-nav-emoji">📘</span><span class="oc-nav-text">API Spec (Redoc)</span></a>
     </div>
     <div class="system-gauges" id="system-gauges">
@@ -2190,6 +2239,7 @@
       <span class="oc-health-badge" id="oc-health">● Health OK</span>
       <span id="oc-hive-id" class="git-version" title="Hive Instance ID" style="cursor:pointer;border:1px solid var(--border);padding:2px 8px;border-radius:4px" onclick="openConfigDialog('governor')"></span>
       <span class="oc-topbar-ts" id="oc-ts"></span>
+      <button class="btn" id="welcome-topbar-btn" style="display:none" onclick="openWelcomeDialog()" title="Open the Getting Started checklist">?</button>
       <a href="/api/widget" class="widget-dl" title="Download Übersicht widget">⬇ Widget</a>
       <div id="oc-gh-avatar-wrap" style="display:none;position:relative">
         <img id="oc-gh-avatar" src="" alt="" style="width:28px;height:28px;border-radius:50%;cursor:pointer;border:2px solid var(--green);vertical-align:middle" onclick="toggleGHUserMenu()">
@@ -10579,6 +10629,8 @@ function burnAreaChart() {
       if (e.key !== 'Escape') return;
       const acmmOverlay = document.getElementById('acmm-dialog-overlay');
       if (acmmOverlay && acmmOverlay.style.display === 'flex') { acmmCloseDialog(); return; }
+      const welcomeOverlay = document.getElementById('welcome-overlay');
+      if (welcomeOverlay && !welcomeOverlay.classList.contains('hidden')) { closeWelcomeDialog(); return; }
       if (_configModalOpen) { closeConfigDialog(); return; }
       if (_acmmOpen) { closeACMMDialog(); return; }
       const nousOverlay = document.getElementById('nous-config-overlay');
@@ -13702,8 +13754,77 @@ function burnAreaChart() {
       }
     }
 
+    // ── Welcome / Getting Started dialog ──────────────────────────────
+    // A living checklist for new hive owners: opens on every dashboard
+    // load (write-access users only) until dismissed, and stays reachable
+    // from the sidebar Resources list and the topbar ? button.
+
+    // Per-browser persistence blob: {dismissed: bool, checks: {stepId: bool}}
+    // (same localStorage pattern as hive-layout-mode / hive-section-collapsed-*).
+    const WELCOME_LS_KEY = 'hive-welcome-state-v1';
+    // X-Hive-Role value the hub proxies read-only preview users in with —
+    // the same /api/role signal the avatar menu uses to gate owner actions.
+    const HIVE_ROLE_READ = 'read';
+    // Role assumed when the header is absent (standalone spoke = owner);
+    // mirrors the /api/role server-side default.
+    const HIVE_ROLE_DEFAULT = 'owner';
+
+    function loadWelcomeState() {
+      try {
+        const raw = localStorage.getItem(WELCOME_LS_KEY);
+        if (raw) {
+          const s = JSON.parse(raw);
+          return { dismissed: s.dismissed === true, checks: (s && typeof s.checks === 'object' && s.checks) || {} };
+        }
+      } catch (e) { /* corrupted blob — start fresh */ }
+      return { dismissed: false, checks: {} };
+    }
+    function saveWelcomeState() {
+      try { localStorage.setItem(WELCOME_LS_KEY, JSON.stringify(_welcomeState)); } catch (e) { /* storage blocked — non-fatal */ }
+    }
+    let _welcomeState = loadWelcomeState();
+    let _welcomeWriteAccess = false;
+
+    async function initWelcomeDialog() {
+      // Write-access gating: read-only previews never see the checklist or
+      // its entry points. On fetch failure (e.g. static snapshot) stay hidden.
+      let role = HIVE_ROLE_READ;
+      try {
+        const resp = await fetch('/api/role');
+        const data = await resp.json();
+        role = data.role || HIVE_ROLE_DEFAULT;
+      } catch (e) { /* API unreachable — treat as read-only */ }
+      if (role === HIVE_ROLE_READ) return;
+      _welcomeWriteAccess = true;
+      const navItem = document.getElementById('welcome-nav-item');
+      if (navItem) navItem.style.display = '';
+      const topBtn = document.getElementById('welcome-topbar-btn');
+      if (topBtn) topBtn.style.display = '';
+      if (!_welcomeState.dismissed) openWelcomeDialog();
+    }
+
+    function openWelcomeDialog() {
+      renderWelcomeDialog();
+      document.getElementById('welcome-overlay').classList.remove('hidden');
+    }
+    function closeWelcomeDialog() {
+      document.getElementById('welcome-overlay').classList.add('hidden');
+    }
+    function dismissWelcomeDialog() {
+      _welcomeState.dismissed = true;
+      saveWelcomeState();
+      closeWelcomeDialog();
+    }
+
+    function renderWelcomeDialog() {
+      const body = document.getElementById('welcome-body');
+      if (!body) return;
+      body.innerHTML = '<p class="welcome-intro">Your hive is a fleet of AI agents that work your repositories — triaging issues, writing fixes, and opening PRs — while the governor paces them to match the workload. A few one-time choices below make it productive.</p>';
+    }
+
     checkGHAuth();
     setInterval(checkGHAuth, GH_AUTH_CHECK_INTERVAL_MS);
+    initWelcomeDialog();
     checkClaudeAuth();
     var CLAUDE_AUTH_CHECK_INTERVAL_MS = 60000;
     setInterval(checkClaudeAuth, CLAUDE_AUTH_CHECK_INTERVAL_MS);


### PR DESCRIPTION
First-run welcome/getting-started dialog on the spoke dashboard — a 9-step living checklist that persists until dismissed, reopenable from a sidebar 'Getting Started' entry and topbar ?. Steps: GitHub App install, pick method per agent, log in once per method, use the terminal to watch/login, choose models, add repos + mark primary, tune cadences, set ACMM level, plus a collapsed 'More'. Auto-checks bind to the status payload (githubAppRequired, per-agent authKnown/authAvailable, primary repo); manual steps persist in localStorage. Write-access only; read-only preview never sees it. 'Show me' deep-links reuse openConfigDialog/ACMM dialog/agent focus/terminal link. Plan: sprightly-enchanting-pine.md.