### PR TITLE
fix(dashboard): guarantee writable /data/secrets for LiteLLM key save

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -140,6 +140,18 @@ if [ "$(id -u)" = "0" ]; then
   fi
   chown dev:node /home/dev 2>/dev/null || true
   chown dev:node /etc/hive/hive.yaml 2>/dev/null || true
+
+  # Ensure the PVC secrets dir the dashboard writes API keys into
+  # (/data/secrets/litellm_api_key) exists and is owned by the dev user.
+  # The Go binary runs as non-root (uid 1001) and CANNOT chown, so if this
+  # dir ever ends up root-owned the key save fails with EACCES. We create
+  # and chown it here (as root, before dropping to dev) UNCONDITIONALLY —
+  # not gated on DATA_OWNER — because the recursive /data chown above is
+  # skipped when /data is already dev-owned, which would leave a
+  # root-owned /data/secrets uncorrected. Mode 700: owner-only secrets.
+  mkdir -p /data/secrets && chown dev:node /data/secrets 2>/dev/null || true
+  chmod 700 /data/secrets 2>/dev/null || true
+
   mkdir -p /var/run/hive-metrics && chown dev:node /var/run/hive-metrics 2>/dev/null || true
   mkdir -p /var/run/hive-metrics/agent-tokens && chown dev:node /var/run/hive-metrics/agent-tokens 2>/dev/null || true
 

--- a/v2/pkg/dashboard/litellm_key_store.go
+++ b/v2/pkg/dashboard/litellm_key_store.go
@@ -37,6 +37,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
@@ -78,35 +79,90 @@ var errNotInCluster = errors.New("not running in a Kubernetes pod")
 // api_key_file path to record in hive.yaml. Only the chosen store is ever
 // logged — never the key.
 func (s *Server) storeLiteLLMAPIKey(key string) (string, error) {
-	if err := writeLiteLLMKeyFile(key); err != nil {
-		return "", err
+	pvcErr := writeLiteLLMKeyFile(key)
+	if pvcErr == nil {
+		s.logger.Info("litellm api key stored", "api_key_file", writableLiteLLMKeyFile)
+	} else {
+		// The PVC file is the store hive.yaml points at, but a misowned or
+		// read-only volume must not sink the whole save: an in-cluster hive
+		// with the hive-secrets-writer Role can still persist the key via the
+		// Secret (which surfaces at /secrets/litellm_api_key). Attempt that
+		// fallback below and only fail the save if BOTH stores fail.
+		s.logger.Info("litellm api key PVC file write failed; attempting hive-secrets Secret fallback",
+			"api_key_file", writableLiteLLMKeyFile, "reason", pvcErr.Error())
 	}
-	s.logger.Info("litellm api key stored", "api_key_file", writableLiteLLMKeyFile)
-	if err := patchKeyIntoHiveSecrets(litellmSecretDataKey, key); err == nil {
+
+	secretErr := patchKeyIntoHiveSecrets(litellmSecretDataKey, key)
+	switch {
+	case secretErr == nil:
 		s.logger.Info("litellm api key also patched into hive-secrets Secret",
 			"mount_path", config.DefaultLiteLLMAPIKeyFile)
-	} else if !errors.Is(err, errNotInCluster) {
+	case errors.Is(secretErr, errNotInCluster):
+		// Docker/LXC hive — Secret patch legitimately unavailable.
+	default:
 		s.logger.Info("hive-secrets Secret not patched; PVC key file is the only store",
-			"reason", err.Error())
+			"reason", secretErr.Error())
 	}
-	return writableLiteLLMKeyFile, nil
+
+	if pvcErr == nil {
+		// PVC file written: hive.yaml records that path (the authoritative,
+		// instantly-effective store), regardless of the Secret patch outcome.
+		return writableLiteLLMKeyFile, nil
+	}
+
+	// PVC write failed. If the Secret fallback succeeded, the key IS persisted
+	// and surfaces at DefaultLiteLLMAPIKeyFile on Secret-mounting hives — record
+	// that path so ResolveAPIKey finds it.
+	if secretErr == nil || errors.Is(secretErr, errNotInCluster) {
+		if secretErr == nil {
+			return config.DefaultLiteLLMAPIKeyFile, nil
+		}
+		// Not in cluster AND the PVC write failed — nothing persisted the key.
+		return "", pvcErr
+	}
+	// Both stores failed: surface the actionable PVC error (the primary path).
+	return "", pvcErr
 }
 
 // writeLiteLLMKeyFile writes the key value to the PVC key file with
 // owner-only permissions.
+//
+// The hive process runs as a non-root user (uid 1001, the /data owner) and
+// therefore cannot chown. If /data/secrets already exists but is owned by
+// root (or is otherwise unwritable), MkdirAll is a no-op and WriteFile fails
+// with EACCES. We cannot fix ownership from here, but we CAN surface a clear,
+// actionable error instead of a raw "permission denied" — the entrypoint's
+// root-only setup is responsible for pre-creating /data/secrets as dev:node,
+// and this message points the operator at that path when it hasn't.
 func writeLiteLLMKeyFile(key string) error {
 	dir := filepath.Dir(writableLiteLLMKeyFile)
 	if err := os.MkdirAll(dir, litellmKeyDirMode); err != nil {
-		return fmt.Errorf("creating %s: %w", dir, err)
+		return actionableWriteError(dir, err)
 	}
 	if err := os.WriteFile(writableLiteLLMKeyFile, []byte(key), litellmKeyFileMode); err != nil {
-		return fmt.Errorf("writing key file: %w", err)
+		return actionableWriteError(writableLiteLLMKeyFile, err)
 	}
 	// WriteFile does not change the mode of a pre-existing file.
 	if err := os.Chmod(writableLiteLLMKeyFile, litellmKeyFileMode); err != nil {
-		return fmt.Errorf("tightening key file mode: %w", err)
+		return actionableWriteError(writableLiteLLMKeyFile, err)
 	}
 	return nil
+}
+
+// actionableWriteError turns a low-level filesystem error into an operator-
+// readable message. Permission and read-only-filesystem failures on the PVC
+// key path almost always mean the hive's data volume is misowned (the dir is
+// root-owned but the hive runs non-root) or mounted read-only — so we say so
+// explicitly rather than leaking a bare "permission denied". The key value is
+// never part of these errors (only the path is), so they are safe to log.
+func actionableWriteError(path string, err error) error {
+	if errors.Is(err, os.ErrPermission) || errors.Is(err, syscall.EROFS) {
+		return fmt.Errorf("could not write key to %s — the hive's data volume "+
+			"may be read-only or misowned (expected owner uid 1001); "+
+			"restart the hive so its entrypoint can repair the secrets directory: %w",
+			path, err)
+	}
+	return fmt.Errorf("writing %s: %w", path, err)
 }
 
 // patchKeyIntoHiveSecrets PATCHes the hive-secrets Secret in the pod's own

--- a/v2/pkg/dashboard/litellm_key_store_test.go
+++ b/v2/pkg/dashboard/litellm_key_store_test.go
@@ -1,0 +1,87 @@
+package dashboard
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// writeLiteLLMKeyFile creates the secrets dir and writes the key 0600 when the
+// parent is writable — the normal PVC path.
+func TestWriteLiteLLMKeyFile_CreatesDirAndFile(t *testing.T) {
+	orig := writableLiteLLMKeyFile
+	writableLiteLLMKeyFile = filepath.Join(t.TempDir(), "secrets", "litellm_api_key")
+	t.Cleanup(func() { writableLiteLLMKeyFile = orig })
+
+	const key = "sk-keyvalue-abcdefghijklmnop"
+	if err := writeLiteLLMKeyFile(key); err != nil {
+		t.Fatalf("writeLiteLLMKeyFile: %v", err)
+	}
+
+	got, err := os.ReadFile(writableLiteLLMKeyFile)
+	if err != nil {
+		t.Fatalf("reading key file: %v", err)
+	}
+	if string(got) != key {
+		t.Errorf("key file content mismatch")
+	}
+	info, err := os.Stat(writableLiteLLMKeyFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != litellmKeyFileMode {
+		t.Errorf("key file mode = %v, want %v", info.Mode().Perm(), os.FileMode(litellmKeyFileMode))
+	}
+	dirInfo, err := os.Stat(filepath.Dir(writableLiteLLMKeyFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dirInfo.Mode().Perm() != litellmKeyDirMode {
+		t.Errorf("secrets dir mode = %v, want %v", dirInfo.Mode().Perm(), os.FileMode(litellmKeyDirMode))
+	}
+}
+
+// When the secrets dir pre-exists but is not writable (the root-owned-dir /
+// misowned-PVC case that produced the original EACCES bug), the error is
+// human-readable and actionable — not a bare "permission denied" — and never
+// contains the key value.
+func TestWriteLiteLLMKeyFile_UnwritableDirYieldsActionableError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix permission model")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory permissions")
+	}
+
+	base := t.TempDir()
+	secretsDir := filepath.Join(base, "secrets")
+	if err := os.Mkdir(secretsDir, 0o500); err != nil { // r-x, no write
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(secretsDir, 0o700) }) // let TempDir cleanup remove it
+
+	orig := writableLiteLLMKeyFile
+	writableLiteLLMKeyFile = filepath.Join(secretsDir, "litellm_api_key")
+	t.Cleanup(func() { writableLiteLLMKeyFile = orig })
+
+	const key = "sk-verysecretkeyvalue123456"
+	err := writeLiteLLMKeyFile(key)
+	if err == nil {
+		t.Fatal("expected an error writing into an unwritable dir")
+	}
+	if !errors.Is(err, os.ErrPermission) {
+		t.Errorf("error should wrap os.ErrPermission, got: %v", err)
+	}
+	msg := err.Error()
+	if strings.Contains(msg, key) {
+		t.Fatal("error message leaks the key value")
+	}
+	for _, want := range []string{"read-only or misowned", writableLiteLLMKeyFile} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q; got: %s", want, msg)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Saving a LiteLLM API key from the dashboard failed with:

```
failed to store API key: writing key file: open /data/secrets/litellm_api_key: permission denied
```

## Root cause

The hive process runs as a **non-root** user (uid 1001 — the `/data` owner, `dev`). The key-save path (`writeLiteLLMKeyFile`) creates `/data/secrets` lazily via `os.MkdirAll` at write time. When `/data/secrets` already exists **root-owned**, `MkdirAll` is a no-op and the non-root writer gets `EACCES` — and it cannot `chown` the dir to fix it.

The entrypoint's recursive `/data` chown is **skipped when `/data` is already dev-owned** (`DATA_OWNER == 1001`, an NFS-perf optimization), so a root-owned `/data/secrets` was never repaired on existing hives.

Confirmed live: the kellyaa pod's `/data/secrets` was root-owned; manually chowning to `dev:node 700` fixed the save. This change makes new and restarted hives reach that state automatically.

## Fix

- **`entrypoint.sh`** (root-only setup, before dropping to dev): unconditionally `mkdir -p /data/secrets` + `chown dev:node` + `chmod 700`, **not** gated on `DATA_OWNER`, mirroring the existing `dev:node` ownership convention. Root can chown; the app user cannot.
- **`writeLiteLLMKeyFile`**: on `EACCES`/`EROFS`, surface an actionable error ("the hive's data volume may be read-only or misowned ... restart the hive so its entrypoint can repair the secrets directory") instead of a bare `permission denied`. The key value never appears in the message (path only).
- **`storeLiteLLMAPIKey`**: still attempt the `hive-secrets` Secret patch fallback when the PVC write fails, so an in-cluster hive with the `hive-secrets-writer` Role persists the key and records the Secret mount path (`/secrets/litellm_api_key`). The save only fails when both stores fail.
- **Tests**: normal write (dir + file created, 0700/0600), and the unwritable-dir case (wraps `os.ErrPermission`, actionable message, no key leak).

## Verification

- `gofmt -e`, `go vet`, `bash -n deploy/entrypoint.sh` clean
- `go test ./pkg/dashboard/ -run LiteLLM` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)