### PR TITLE
fix(dashboard): Test Connection false-negative on valid /v1/models response

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3161,29 +3161,38 @@ func probeLiteLLMModels(endpoint, apiKey string) (int, error) {
 		return 0, fmt.Errorf("cannot reach gateway: %w", err)
 	}
 	defer resp.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, litellmProbeMaxErrBody))
-	gatewayMsg := strings.TrimSpace(string(body))
-	switch {
-	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
-		// The two auth failures lead users to different fixes.
-		if apiKey == "" {
-			return 0, fmt.Errorf("gateway requires an API key and none is configured (HTTP %d): %s",
+
+	if resp.StatusCode != http.StatusOK {
+		// Error path: only a truncated slice of the body is surfaced to the
+		// dialog (error bodies can be huge and may echo the key).
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, litellmProbeMaxErrBody))
+		gatewayMsg := strings.TrimSpace(string(body))
+		switch {
+		case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+			// The two auth failures lead users to different fixes.
+			if apiKey == "" {
+				return 0, fmt.Errorf("gateway requires an API key and none is configured (HTTP %d): %s",
+					resp.StatusCode, gatewayMsg)
+			}
+			return 0, fmt.Errorf("gateway rejected the configured key (HTTP %d): %s",
 				resp.StatusCode, gatewayMsg)
+		default:
+			return 0, fmt.Errorf("gateway returned HTTP %d: %s", resp.StatusCode, gatewayMsg)
 		}
-		return 0, fmt.Errorf("gateway rejected the configured key (HTTP %d): %s",
-			resp.StatusCode, gatewayMsg)
-	case resp.StatusCode != http.StatusOK:
-		return 0, fmt.Errorf("gateway returned HTTP %d: %s", resp.StatusCode, gatewayMsg)
 	}
-	var result struct {
-		Data []struct {
-			ID string `json:"id"`
-		} `json:"data"`
-	}
-	if err := json.Unmarshal(body, &result); err != nil {
+
+	// Success path: parse the FULL body with the exact same lenient decoder
+	// the model-discovery dropdown uses (fetchModelsFromEndpoint) — a JSON
+	// object with a "data" array of items each carrying an "id" string is
+	// sufficient. We do NOT require top-level object=="list" (some gateways
+	// omit or reorder it) and tolerate extra/unknown fields. Reading only a
+	// truncated prefix here (the old bug) corrupted large valid lists into
+	// invalid JSON and produced a false "non-OpenAI response" negative.
+	models, err := parseModelsResponse(resp.Body)
+	if err != nil {
 		return 0, fmt.Errorf("gateway returned a non-OpenAI /v1/models response")
 	}
-	return len(result.Data), nil
+	return len(models), nil
 }
 
 // redactSecret removes any occurrence of a secret value from a message so
@@ -3861,20 +3870,33 @@ func fetchModelsFromEndpoint(baseURL, apiKey string) ([]string, error) {
 		return nil, fmt.Errorf("upstream returned %d", resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	models, err := parseModelsResponse(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("read body: %w", err)
+		return nil, fmt.Errorf("parse response: %w", err)
 	}
+	return models, nil
+}
 
+// parseModelsResponse decodes an OpenAI-style GET /v1/models body into the
+// list of model IDs. It is the single source of truth shared by the
+// model-discovery dropdown (fetchModelsFromEndpoint) and the Test Connection
+// probe (probeLiteLLMModels), so both agree on what "N models" means.
+//
+// It is deliberately lenient: any JSON object with a "data" array whose items
+// carry a non-empty "id" string is accepted. It does NOT require top-level
+// object=="list" (gateways may omit or reorder it), imposes no field order,
+// and tolerates extra/unknown per-item fields (object, created, owned_by, …).
+// IDs are returned verbatim, so provider-prefixed / hyphenated ids like
+// "Azure/gpt-5.1-codex-2025-11-13" or "claude-opus-4-7" survive intact.
+func parseModelsResponse(r io.Reader) ([]string, error) {
 	var result struct {
 		Data []struct {
 			ID string `json:"id"`
 		} `json:"data"`
 	}
-	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, fmt.Errorf("parse response: %w", err)
+	if err := json.NewDecoder(r).Decode(&result); err != nil {
+		return nil, err
 	}
-
 	models := make([]string, 0, len(result.Data))
 	for _, m := range result.Data {
 		if m.ID != "" {

--- a/v2/pkg/dashboard/litellm_probe_test.go
+++ b/v2/pkg/dashboard/litellm_probe_test.go
@@ -1,0 +1,94 @@
+package dashboard
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The Test Connection probe must accept the exact OpenAI-shaped /v1/models
+// payload the live LiteLLM gateway returns — including per-item object /
+// created / owned_by fields and provider-prefixed, hyphenated model ids — and
+// report the real model count. Before the fix the probe read only a truncated
+// prefix of the body, so a large valid list decoded as invalid JSON and
+// produced a false "non-OpenAI response" negative.
+func TestProbeLiteLLMModels_AcceptsFullOpenAIPayload(t *testing.T) {
+	// Captured-shape payload: top-level {"data":[...],"object":"list"}, each
+	// item id/object/created/owned_by, ids with Azure/ aws/ azure/ prefixes
+	// and hyphenated versions. Padded well past the old 512-byte read cap.
+	const modelCount = 40
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/models" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		var b strings.Builder
+		b.WriteString(`{"data":[`)
+		for i := 0; i < modelCount; i++ {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			fmt.Fprintf(&b,
+				`{"id":"Azure/gpt-5.1-codex-2025-11-13-variant-%02d","object":"model","created":1677610602,"owned_by":"openai"}`, i)
+		}
+		b.WriteString(`],"object":"list"}`)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, b.String())
+	}))
+	defer srv.Close()
+
+	n, err := probeLiteLLMModels(srv.URL, "sk-livekeyvalue")
+	if err != nil {
+		t.Fatalf("probe failed on a valid OpenAI payload: %v", err)
+	}
+	if n != modelCount {
+		t.Errorf("probe reported %d models, want %d", n, modelCount)
+	}
+}
+
+// The probe must not require top-level object=="list" (some gateways omit it)
+// nor a specific field order, and must tolerate unknown fields — exactly what
+// the discovery dropdown parser accepts.
+func TestProbeLiteLLMModels_LenientShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// No top-level "object"; extra unknown top-level + per-item fields;
+		// provider-prefixed and hyphenated ids.
+		fmt.Fprint(w, `{"unexpected_top":true,"data":[`+
+			`{"owned_by":"aws","id":"aws/claude-opus-4-7","object":"model","extra":123},`+
+			`{"id":"azure/gemini-2.5-flash"}`+
+			`]}`)
+	}))
+	defer srv.Close()
+
+	n, err := probeLiteLLMModels(srv.URL, "")
+	if err != nil {
+		t.Fatalf("probe rejected a lenient-but-valid payload: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("probe reported %d models, want 2", n)
+	}
+}
+
+// parseModelsResponse is the shared source of truth; verify it returns
+// provider-prefixed ids verbatim and skips id-less entries.
+func TestParseModelsResponse_VerbatimIDs(t *testing.T) {
+	body := `{"object":"list","data":[` +
+		`{"id":"Azure/gpt-5.1-codex-2025-11-13"},` +
+		`{"id":"claude-opus-4-7"},` +
+		`{"object":"model"}` + // no id — skipped
+		`]}`
+	models, err := parseModelsResponse(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	want := []string{"Azure/gpt-5.1-codex-2025-11-13", "claude-opus-4-7"}
+	if len(models) != len(want) {
+		t.Fatalf("got %v, want %v", models, want)
+	}
+	for i, m := range models {
+		if m != want[i] {
+			t.Errorf("models[%d] = %q, want %q", i, m, want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Problem

With a valid LiteLLM key, **model discovery succeeds** (the dashboard fires "New model available on litellm: gpt-4.1 / claude-opus-4-8 / gemini-2.5-flash…" toasts and the dropdown populates), but **Test Connection** reports:

```
LiteLLM connection failed: gateway returned a non-OpenAI /v1/models response
```

The gateway response is a perfectly valid OpenAI shape (captured live):

```json
{"data":[{"id":"Azure/gpt-5.1-codex-2025-11-13","object":"model","created":1677610602,"owned_by":"openai"}, ...],"object":"list"}
```

## Root cause

`probeLiteLLMModels` read the **success** body through `io.ReadAll(io.LimitReader(resp.Body, litellmProbeMaxErrBody))` — a 512-byte cap intended for **error** bodies. A real `/v1/models` list (dozens of models, each with `id`/`object`/`created`/`owned_by`) far exceeds 512 bytes, so `json.Unmarshal` saw **truncated, invalid JSON** and returned the false "non-OpenAI response" error.

The discovery dropdown (`fetchModelsFromEndpoint`) reads the full body with `io.ReadAll(resp.Body)` and the same lenient struct — which is exactly why discovery succeeded while the probe failed on the identical response. It was never a strictness problem (no `DisallowUnknownFields`, no `object=="list"` gate); it was a truncation problem.

## Fix

- Apply the 512-byte truncation **only to error bodies**; parse the **full** success body.
- Extract `parseModelsResponse` as the **single source of truth** shared by discovery and the probe, so "N models available" reflects reality. It is lenient by design: any JSON object with a `data` array of items carrying a non-empty `id` string is accepted — **no** top-level `object=="list"` requirement, **no** field-order requirement, unknown top-level/per-item fields tolerated. Model ids are returned **verbatim** (`Azure/…`, `aws/…`, `azure/…`, hyphenated versions like `claude-opus-4-7`).
- Tests feed the captured live payload (padded past 512 bytes, provider-prefixed ids) to the probe and assert success with the real model count, plus lenient-shape and verbatim-id cases.

## Verification

- New `TestProbeLiteLLMModels_AcceptsFullOpenAIPayload` reproduces the bug (40-model payload > old 512-byte cap) and passes with the fix.
- `gofmt -e`, `go vet`, full `go test ./pkg/dashboard/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)