### PR TITLE
fix(hub): auto-upgrades say Upgrading not Switching; welcome dialog genies into the ? button

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1976,8 +1976,32 @@
     @media (max-width: 480px) {
       .welcome-step-body { padding-left: 12px; }
     }
+    /* ── Genie minimize ──
+       On dismiss the panel scales down and flies toward the top-bar ? button
+       so the user sees where the checklist went (and how to reopen it). The
+       transform target is computed at runtime; only the timing/easing live
+       here as tokens. GENIE_MS below must match --welcome-genie-ms. */
+    :root { --welcome-genie-ms: 400ms; --welcome-genie-ease: cubic-bezier(0.4, 0.0, 1, 1); }
+    .welcome-modal.welcome-genie {
+      transition: transform var(--welcome-genie-ms) var(--welcome-genie-ease),
+                  opacity var(--welcome-genie-ms) var(--welcome-genie-ease);
+      pointer-events: none;
+    }
+    #welcome-overlay.welcome-genie-overlay {
+      transition: background var(--welcome-genie-ms) var(--welcome-genie-ease);
+      background: transparent;
+    }
+    /* One-shot pulse on the ? button when the panel lands on it. */
+    @keyframes welcome-target-pulse {
+      0% { transform: scale(1); box-shadow: 0 0 0 0 color-mix(in srgb, var(--blue) 55%, transparent); }
+      50% { transform: scale(1.18); box-shadow: 0 0 0 6px color-mix(in srgb, var(--blue) 0%, transparent); }
+      100% { transform: scale(1); box-shadow: 0 0 0 0 transparent; }
+    }
+    #welcome-topbar-btn.welcome-target-pulse { animation: welcome-target-pulse 0.4s ease-out; }
     @media (prefers-reduced-motion: reduce) {
       .welcome-check, .welcome-step-chevron { transition: none; }
+      .welcome-modal.welcome-genie, #welcome-overlay.welcome-genie-overlay { transition: none; }
+      #welcome-topbar-btn.welcome-target-pulse { animation: none; }
     }
   </style>
 </head>
@@ -13850,10 +13874,92 @@ function burnAreaChart() {
         refreshWelcomeAutoChecks(window._lastStatus || null);
       }).catch(() => {});
       renderWelcomeDialog();
-      document.getElementById('welcome-overlay').classList.remove('hidden');
+      const overlay = document.getElementById('welcome-overlay');
+      // Clear any in-flight genie state so the panel opens at full size.
+      overlay.classList.remove('welcome-genie-overlay');
+      const panel = overlay.querySelector('.welcome-modal');
+      if (panel) {
+        panel.classList.remove('welcome-genie');
+        panel.style.transform = '';
+        panel.style.transformOrigin = '';
+        panel.style.opacity = '';
+      }
+      overlay.classList.remove('hidden');
     }
+    // Genie-minimize timing. GENIE_MS must match --welcome-genie-ms in CSS;
+    // it is the fallback deadline in case transitionend never fires (the
+    // panel can be display:none'd mid-flight if the tab is backgrounded).
+    const WELCOME_GENIE_MS = 400;
+    const WELCOME_GENIE_FALLBACK_MS = WELCOME_GENIE_MS + 80;
+    // Scale the panel down to roughly the ? button's footprint as it flies in.
+    const WELCOME_GENIE_MIN_SCALE = 0.06;
+
+    function _prefersReducedMotion() {
+      return window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    }
+
+    // Finalize a genie animation: hide the overlay and reset the animation
+    // state so the next open starts clean. Idempotent.
+    function _finishWelcomeGenie(overlay, panel) {
+      if (!overlay || overlay.classList.contains('hidden')) return;
+      overlay.classList.add('hidden');
+      overlay.classList.remove('welcome-genie-overlay');
+      if (panel) {
+        panel.classList.remove('welcome-genie');
+        panel.style.transform = '';
+        panel.style.transformOrigin = '';
+        panel.style.opacity = '';
+      }
+    }
+
     function closeWelcomeDialog() {
-      document.getElementById('welcome-overlay').classList.add('hidden');
+      const overlay = document.getElementById('welcome-overlay');
+      if (!overlay || overlay.classList.contains('hidden')) return;
+      const panel = overlay.querySelector('.welcome-modal');
+      const target = document.getElementById('welcome-topbar-btn');
+      // Instant hide when motion is reduced, the panel/target are missing, or
+      // the reopen affordance is not visible (nothing to fly toward).
+      if (_prefersReducedMotion() || !panel || !target ||
+          target.offsetParent === null) {
+        _finishWelcomeGenie(overlay, panel);
+        return;
+      }
+      const panelRect = panel.getBoundingClientRect();
+      const targetRect = target.getBoundingClientRect();
+      if (!panelRect.width || !panelRect.height) { _finishWelcomeGenie(overlay, panel); return; }
+      // Translate the panel's centre to the ? button's centre, then shrink it.
+      const panelCX = panelRect.left + panelRect.width / 2;
+      const panelCY = panelRect.top + panelRect.height / 2;
+      const targetCX = targetRect.left + targetRect.width / 2;
+      const targetCY = targetRect.top + targetRect.height / 2;
+      const dx = targetCX - panelCX;
+      const dy = targetCY - panelCY;
+      panel.style.transformOrigin = 'center center';
+      panel.classList.add('welcome-genie');
+      // Kick the transform on the next frame so the transition actually runs.
+      requestAnimationFrame(function () {
+        panel.style.transform = 'translate(' + dx + 'px,' + dy + 'px) scale(' + WELCOME_GENIE_MIN_SCALE + ')';
+        panel.style.opacity = '0.2';
+        overlay.classList.add('welcome-genie-overlay');
+      });
+      let done = false;
+      const finish = function () {
+        if (done) return;
+        done = true;
+        _finishWelcomeGenie(overlay, panel);
+        // Pulse the ? button once so the eye lands on where it went.
+        target.classList.remove('welcome-target-pulse');
+        void target.offsetWidth; // restart the animation
+        target.classList.add('welcome-target-pulse');
+        setTimeout(function () { target.classList.remove('welcome-target-pulse'); }, WELCOME_GENIE_FALLBACK_MS);
+      };
+      panel.addEventListener('transitionend', function te(e) {
+        if (e.target === panel && e.propertyName === 'transform') {
+          panel.removeEventListener('transitionend', te);
+          finish();
+        }
+      });
+      setTimeout(finish, WELCOME_GENIE_FALLBACK_MS);
     }
     function dismissWelcomeDialog() {
       _welcomeState.dismissed = true;

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4298,15 +4298,20 @@ const dashboardHTML = `<!DOCTYPE html>
           /* Branch switch in flight: the hive still reports the OLD branch
              (often current on it) until the new pod heartbeats — without
              this, isCurrent suppresses every progress indicator. */
-          /* Only a "<branch>-latest" target is a branch switch; plain-SHA
-             targets are same-branch upgrades and must say "Upgrading". */
-          var isBranchTarget = /-latest$/.test(h.upgradeTarget || '');
-          var targetBranch = isBranchTarget ? h.upgradeTarget.replace(/-latest$/, '') : '';
-          var isSwitching = !!(h.upgrading && isBranchTarget && targetBranch !== branchName);
-          if (_upgradingHives[h.id] === 'switching' && (isSwitching || h.upgrading)) delete _upgradingHives[h.id];
-          var isUpgrading = isSwitching || _upgradingHives[h.id] === 'switching' ||
-            (_upgradingHives[h.id] && sha === _upgradingHives[h.id]) || (h.upgrading && !isCurrent && !latestUnknown);
-          if (_upgradingHives[h.id] && _upgradingHives[h.id] !== 'switching' && sha !== _upgradingHives[h.id]) delete _upgradingHives[h.id];
+          /* Switch-vs-upgrade is decided in ONE place (hiveUpgradeState) so the
+             spinner, label and title always agree. Only a target on a DIFFERENT
+             branch is a switch; a plain-SHA (auto-upgrade) target always reads
+             "Upgrading", even if a stale switch sentinel lingers. */
+          var upgradeState = hiveUpgradeState(h, branchName);
+          var isSwitching = upgradeState.isSwitching;
+          var targetBranch = upgradeState.targetBranch;
+          /* Drop a stale switch sentinel (resolved to a same-branch SHA) so it
+             stops forcing the upgrading state on later auto-upgrades. */
+          if (upgradeState.switchSentinelStale) delete _upgradingHives[h.id];
+          var sentinel = _upgradingHives[h.id];
+          var isUpgrading = isSwitching ||
+            (sentinel && sha === sentinel) || (h.upgrading && !isCurrent && !latestUnknown);
+          if (sentinel && sha !== sentinel && !isSwitching) delete _upgradingHives[h.id];
           if (isCurrent && h.upgrading && !isSwitching) { h.upgrading = false; }
           var imageBuilding = (_latestImageStatus[branchName] || '') === 'building';
           var buildingHint = imageBuilding ? ' (image still building — upgrading now pulls the previous image)' : '';
@@ -4436,6 +4441,46 @@ const dashboardHTML = `<!DOCTYPE html>
     }
 
     var _upgradingHives = {};
+
+    /* Prefix marking a client-side branch-switch sentinel in _upgradingHives.
+       The intended target branch follows the prefix (e.g. "switch:v3") so the
+       label can tell a genuine branch switch apart from a same-branch upgrade
+       purely from state — a bare sentinel could not. */
+    var SWITCH_SENTINEL_PREFIX = 'switch:';
+    /* Suffix the hub appends to a branch-switch upgrade target. */
+    var BRANCH_TARGET_SUFFIX = '-latest';
+
+    /* Single source of truth for switch-vs-upgrade, consumed by the spinner,
+       the label and the title so they can never disagree. Resolves the target
+       branch from the server's "<branch>-latest" upgradeTarget or, before the
+       server reflects it, from the optimistic client sentinel ("switch:<branch>").
+       A genuine branch switch means a target branch that is present AND differs
+       from the branch the hive currently reports. A plain-SHA target — an
+       auto-upgrade — yields no target branch and is therefore an upgrade, never
+       a switch, regardless of any sticky sentinel. */
+    function hiveUpgradeState(h, branchName) {
+      var sentinel = _upgradingHives[h.id];
+      var hasSwitchSentinel = typeof sentinel === 'string'
+        && sentinel.indexOf(SWITCH_SENTINEL_PREFIX) === 0;
+      var upgradeTarget = h.upgradeTarget || '';
+      var isBranchTarget = upgradeTarget.length > BRANCH_TARGET_SUFFIX.length
+        && upgradeTarget.slice(-BRANCH_TARGET_SUFFIX.length) === BRANCH_TARGET_SUFFIX;
+      var targetBranch = '';
+      if (isBranchTarget) {
+        targetBranch = upgradeTarget.slice(0, -BRANCH_TARGET_SUFFIX.length);
+      } else if (hasSwitchSentinel) {
+        targetBranch = sentinel.slice(SWITCH_SENTINEL_PREFIX.length);
+      }
+      /* A same-branch target is not a switch — drop it so nothing downstream
+         mistakes an auto-upgrade for one. */
+      var isSwitching = !!(targetBranch && targetBranch !== branchName);
+      if (!isSwitching) targetBranch = '';
+      /* A switch sentinel that no longer resolves to a switch (target became a
+         same-branch SHA / auto-upgrade) is stale and must not force upgrading. */
+      var switchSentinelStale = hasSwitchSentinel && !isSwitching;
+      return { isSwitching: isSwitching, targetBranch: targetBranch, switchSentinelStale: switchSentinelStale };
+    }
+
     async function upgradeHive(id, currentSHA, branch) {
       var fromSHA = currentSHA ? currentSHA.substring(0, 7) : '?';
       var branchLatest = (branch && _latestSHAs[branch]) || _latestSHA;
@@ -4541,7 +4586,7 @@ const dashboardHTML = `<!DOCTYPE html>
         });
         var data = await resp.json();
         if (!resp.ok) { hiveToast(data.error || 'Branch switch failed', 'error'); loadHives(); return; }
-        _upgradingHives[hiveId] = 'switching';
+        _upgradingHives[hiveId] = SWITCH_SENTINEL_PREFIX + newBranch;
         hiveToast('Switched ' + hiveId + ' to ' + newBranch + ' — waiting for rollout', 'success');
         loadHives();
         setTimeout(loadHives, 10000);


### PR DESCRIPTION
Two hub-dashboard fixes.

## FIX 1 — "Switching to <sha>" shown for same-branch auto-upgrades (My Hives table)

**Root cause:** The version cell decided switch-vs-upgrade in three separate places (spinner gate, progress label, title) from overlapping conditions, and a branch switch stored a **bare `'switching'` sentinel** in `_upgradingHives`. That sentinel only cleared under narrow conditions, so it could stick. When the same hive later **auto-upgraded** to a plain SHA, the sticky sentinel forced `isUpgrading` true while the recomputed `isSwitching` was false — the two predicates disagreed, and the pill could render a switch label for an upgrade the user never branch-switched.

**Fix:** Route switch-vs-upgrade through **one predicate** (`hiveUpgradeState`) consumed by the spinner, label, and title so they cannot disagree. A switch is now defined solely as a target on a **different branch**, resolved from the server's `<branch>-latest` target or an optimistic `switch:<branch>` client sentinel (the bare `'switching'` sentinel is replaced with one carrying the target branch). A plain-SHA target is always "Upgrading"; a switch sentinel that resolves to a same-branch SHA is treated as stale and cleared so it stops forcing the upgrading state on later auto-upgrades.

Verified with a node harness extracting `hiveUpgradeState`:
- `{upgradeTarget:'dc5567c', gitBranch:'v2', upgrading:true}` → **Upgrading**
- `{upgradeTarget:'v3-latest', gitBranch:'v2'}` → **Switching to v3**
- stale `switch:v2` sentinel on an auto-upgrade → **Upgrading** (sentinel flagged stale)

## FIX 2 — welcome dialog genie-minimizes into the top-bar `?` button

Dismissing the Getting Started dialog hid it outright, with no hint of where to reopen it. On dismiss the panel now animates (translate + scale-down) toward the `?` button's live bounding rect over ~0.4s ease-in, then hides; the `?` button pulses once so the eye lands on the reopen affordance. `prefers-reduced-motion` keeps the instant hide. The animation is cosmetic — the existing dismiss/localStorage logic is untouched, and reopening resets any in-flight genie state.

Verified via headless Chrome CDP: animation branch produces the mid-flight transform toward the button and ends hidden + pulsing; reduced-motion emulation confirms instant hide with no transform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)