### PR TITLE
feat(dashboard): wire discovered LiteLLM/vllm/llm-d models into both model dropdowns

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4531,13 +4531,64 @@
         const labelSuffix = data.fallback ? ' (common alias, unverified)' : '';
         const models = (data.models || []).map(m => ({ value: m, label: m.split('/').pop() + labelSuffix }));
         INFERENCE_MODELS[backend] = models;
-        _inferenceModelCache[backend] = { models, ts: now };
+        _inferenceModelCache[backend] = { models, ts: now, fallback: !!data.fallback };
+        // A real (non-fallback) discovery may have changed the entitlement-
+        // filtered model set — reconcile agents/defaults whose selected model
+        // is no longer available. No-op when the list is a static fallback or
+        // when every current selection is still present (idempotent).
+        reconcileModelsAfterDiscovery(backend, models, !!data.fallback);
         return models;
       } catch (e) {
         return INFERENCE_MODELS[backend] || [];
       }
     }
     INFERENCE_BACKENDS.forEach(b => fetchInferenceModels(b));
+
+    // reconcileModelsAfterDiscovery auto-heals selections that a key swap
+    // (or endpoint change) stripped out: when a REAL discovery (not the
+    // static fallback) returns a non-empty model set, any agent on this
+    // backend whose selected model is no longer in the set is switched to
+    // the first available model, via the same switchModel() path the
+    // dropdown uses (so it persists + relaunches, not a cosmetic change).
+    // Strictly: keep the current model when it is still present — no
+    // re-select, no toast, no relaunch. Idempotent: repeated refreshes with
+    // a compatible list never mutate a valid selection.
+    function reconcileModelsAfterDiscovery(backend, models, fallback) {
+      // Guard: only act on a genuinely successful discovery. Never switch
+      // based on unverified static aliases or an empty list.
+      if (fallback || !models || !models.length) return;
+      const available = models.map(m => m.value);
+      const first = available[0];
+      const isAvailable = (m) => available.some(v => _modelIdMatches(v, m));
+
+      // 1) Agents whose effective method is this backend.
+      (window._lastAgents || []).forEach(a => {
+        if (a.cli !== backend) return;
+        if (!a.model) return;                 // no explicit model — nothing to heal
+        if (isAvailable(a.model)) return;     // still valid — leave untouched (idempotent)
+        const label = a.displayName || a.name;
+        showToast(`${label}: model ${a.model.split('/').pop()} unavailable on ${backend} — switched to ${first.split('/').pop()}`, 'info');
+        switchModel(a.name, first);           // persists + relaunches via /api/model
+      });
+
+      // 2) LiteLLM Default Model — only when the config dialog holds governor
+      // data (that is where the saved default is available to the UI). If the
+      // saved default is gone from the new set, persist the first available.
+      if (backend === 'litellm' && _configState.type === 'governor') {
+        const saved = (_configState.data.litellm || {}).defaultModel;
+        if (saved && !isAvailable(saved)) {
+          _configState.data.litellm.defaultModel = first;
+          fetch('/api/config/governor/litellm', {
+            method: 'PUT',
+            headers: _inceptionAuthHeaders(),
+            body: JSON.stringify({ defaultModel: first })
+          }).then(() => {
+            showToast(`Default LiteLLM model ${saved.split('/').pop()} unavailable on new key — set to ${first.split('/').pop()}`, 'info');
+            refreshLitellmDefaultModelField();
+          }).catch(() => {});
+        }
+      }
+    }
 
     const _lastKnownModels = {};
     const _dismissedModelBanners = new Set();

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2959,8 +2959,8 @@
             ${KNOWN_BACKENDS.map(b => `<option value="${b}" ${a.cli === b ? 'disabled' : ''}>${backendLabel(b)}</option>`).join('')}
           </select>
           <select class="btn backend-select" data-change-action="switchModel" data-agent="${esc(a.name)}" title="Switch this agent to a different LLM model">
-            <option value="" disabled selected>model ▾</option>
-            ${modelsForBackend(a.cli).map(m => `<option value="${m.value}">${m.label}</option>`).join('')}
+            <option value="" disabled${a.model ? '' : ' selected'}>model ▾</option>
+            ${modelOptionsHtml(a.cli, a.model)}
           </select>
         </div>
         <div class="oc-detail-fields">
@@ -3907,8 +3907,8 @@
               ${KNOWN_BACKENDS.map(b => `<option value="${b}" ${a.cli === b ? 'disabled' : ''}>${backendLabel(b)}</option>`).join('')}
             </select>
             <select class="btn backend-select" data-change-action="switchModel" data-agent="${esc(a.name)}" title="Switch this agent to a different LLM model. Higher-tier models (Opus) cost more tokens; lower-tier (Haiku) are cheaper but less capable.">
-              <option value="" disabled selected>model ▾</option>
-              ${modelsForBackend(a.cli).map(m => `<option value="${m.value}">${m.label}</option>`).join('')}
+              <option value="" disabled${a.model ? '' : ' selected'}>model ▾</option>
+              ${modelOptionsHtml(a.cli, a.model)}
             </select>
           </div>
           </div>
@@ -4485,10 +4485,42 @@
       if (backend === 'claude') return CLAUDE_CLI_MODELS;
       return COPILOT_CLI_MODELS;
     }
-    async function fetchInferenceModels(backend) {
+    // _modelIdMatches: an agent's stored model may lack (or carry) the
+    // gateway provider prefix that discovery reports (e.g. stored "gpt-4o"
+    // vs discovered "Azure/gpt-4o", or vice-versa). Match on the full id,
+    // the suffix after the last slash, or the normalized dotted/hyphenated
+    // version so the current model preselects regardless of prefix.
+    function _modelIdMatches(optionValue, current) {
+      if (!current) return false;
+      if (optionValue === current) return true;
+      const optTail = optionValue.split('/').pop();
+      const curTail = current.split('/').pop();
+      if (optTail === curTail) return true;
+      return _modelsEqual(optTail, curTail);
+    }
+    // modelOptionsHtml builds the <option> list for a model dropdown:
+    // discovered/known models first (already discovered-first from the API),
+    // the current model preselected (prefix-insensitive), and — if the
+    // current model is not in the list — a preselected fallback option so
+    // the dropdown never silently drops an agent's active selection.
+    function modelOptionsHtml(backend, currentModel) {
+      const models = modelsForBackend(backend);
+      const cur = currentModel || '';
+      let matched = false;
+      const opts = models.map(m => {
+        const sel = !matched && _modelIdMatches(m.value, cur);
+        if (sel) matched = true;
+        return `<option value="${esc(m.value)}"${sel ? ' selected' : ''}>${esc(m.label)}</option>`;
+      });
+      if (cur && !matched) {
+        opts.unshift(`<option value="${esc(cur)}" selected>${esc(cur.split('/').pop())} (current)</option>`);
+      }
+      return opts.join('');
+    }
+    async function fetchInferenceModels(backend, force) {
       const now = Date.now();
       const cached = _inferenceModelCache[backend];
-      if (cached && (now - cached.ts) < INFERENCE_MODEL_CACHE_TTL_MS) {
+      if (!force && cached && (now - cached.ts) < INFERENCE_MODEL_CACHE_TTL_MS) {
         return cached.models;
       }
       try {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4575,6 +4575,10 @@
         const models = currentIds.map(m => ({ value: m, label: m.split('/').pop() }));
         INFERENCE_MODELS[b.id] = models;
         _inferenceModelCache[b.id] = { models, ts: Date.now() };
+        // If the Governor→LiteLLM tab is open when a live "models pulled"
+        // push arrives, re-render the Default Model dropdown against the
+        // same freshly-discovered data (no separate fetch).
+        if (b.id === 'litellm') refreshLitellmDefaultModelField();
       }
     }
 
@@ -11023,6 +11027,12 @@ function burnAreaChart() {
       } else {
         body.innerHTML = renderGovernorTab(tabId);
         if (tabId === 'Hub') fetchQueueCount();
+        // Opening the LiteLLM tab triggers a fresh model discovery (bypassing
+        // the TTL cache) so a just-added key's models populate the Default
+        // Model dropdown without a full reload.
+        if (tabId === 'LiteLLM') {
+          fetchInferenceModels('litellm', true).then(refreshLitellmDefaultModelField).catch(() => {});
+        }
       }
     }
 
@@ -11214,6 +11224,65 @@ function burnAreaChart() {
       markDirty('litellm', 'apiKeyFile', v);
     }
 
+    // Sentinel value for the "type a custom id" option in the Default Model
+    // select — chosen so it can never collide with a real model id.
+    const LITELLM_CUSTOM_MODEL_SENTINEL = '__custom__';
+
+    // litellmDefaultModelFieldHtml renders the Governor→LiteLLM "Default
+    // Model" control. When discovery has returned models for the litellm
+    // backend it renders a <select> of the discovered ids (verbatim,
+    // prefixes intact) with the current value preselected, plus a
+    // "Custom…" escape hatch that reveals a free-text input. When
+    // discovery is empty/unconfigured it falls back to a plain text input
+    // so the field is never a dead end.
+    function litellmDefaultModelFieldHtml(current) {
+      const models = modelsForBackend('litellm');
+      const cur = current || '';
+      if (!models.length) {
+        return `<input type="text" value="${esc(cur)}" placeholder="e.g. gpt-4o" onchange="markDirty('litellm','defaultModel',this.value)">`;
+      }
+      const inList = cur && models.some(m => m.value === cur);
+      const options = models.map(m =>
+        `<option value="${esc(m.value)}"${m.value === cur ? ' selected' : ''}>${esc(m.value)}</option>`).join('');
+      // Current value is set but not among discovered ids → preselect a
+      // "(custom)" option carrying it so the selection is never lost.
+      const customOptLabel = inList ? 'Custom…' : `${esc(cur)} (custom)`;
+      const customSelected = cur && !inList;
+      const emptyOpt = cur ? '' : '<option value="" selected disabled>Select a discovered model…</option>';
+      return `
+        <select onchange="onLitellmDefaultModelSelect(this)">
+          ${emptyOpt}${options}
+          <option value="${LITELLM_CUSTOM_MODEL_SENTINEL}"${customSelected ? ' selected' : ''}>${customOptLabel}</option>
+        </select>
+        <input type="text" value="${customSelected ? esc(cur) : ''}" placeholder="e.g. Azure/gpt-4o" style="margin-top:6px;display:${customSelected ? 'block' : 'none'}" data-litellm-custom-model onchange="markDirty('litellm','defaultModel',this.value)">`;
+    }
+
+    // onLitellmDefaultModelSelect handles the discovered-model <select>:
+    // picking a real id records it; picking "Custom…" reveals the free-text
+    // input and defers the value to its onchange.
+    function onLitellmDefaultModelSelect(sel) {
+      const custom = sel.parentElement.querySelector('[data-litellm-custom-model]');
+      if (sel.value === LITELLM_CUSTOM_MODEL_SENTINEL) {
+        if (custom) { custom.style.display = 'block'; custom.focus(); }
+        return;
+      }
+      if (custom) custom.style.display = 'none';
+      markDirty('litellm', 'defaultModel', sel.value);
+    }
+
+    // refreshLitellmDefaultModelField re-renders the Default Model control
+    // in place after a fresh discovery lands (tab open / key save), so a
+    // just-added key's models appear without a full reload. Preserves any
+    // unsaved dirty value the user has already typed/picked.
+    function refreshLitellmDefaultModelField() {
+      const host = document.getElementById('litellm-default-model-field');
+      if (!host) return;
+      const dirtyVal = (_configState.dirty.litellm || {}).defaultModel;
+      const saved = (_configState.data.litellm || {}).defaultModel;
+      const current = dirtyVal !== undefined ? dirtyVal : (saved || '');
+      host.innerHTML = litellmDefaultModelFieldHtml(current);
+    }
+
     function renderGovLiteLLM(litellm) {
       // The server never returns the key VALUE — only hasKey, a masked
       // tail hint ("••••WMg"), and the store it resolved from. The API
@@ -11246,8 +11315,8 @@ function burnAreaChart() {
           <div style="font-size:0.72rem;margin-top:4px;color:${litellm.hasKey ? 'var(--green)' : 'var(--red)'}">${keyLine}</div>
         </div>
         <div class="config-field">
-          <label>Default Model <span class="config-info">i<span class="config-tooltip">Model used when an agent on the litellm backend has no model selected. Use Test Connection to list available models.</span></span></label>
-          <input type="text" value="${esc(litellm.defaultModel || '')}" placeholder="e.g. gpt-4o" onchange="markDirty('litellm','defaultModel',this.value)">
+          <label>Default Model <span class="config-info">i<span class="config-tooltip">Model used when an agent on the litellm backend has no model selected. Populated from the models discovered on the configured endpoint — choose "Custom…" to type an id the gateway does not list yet.</span></span></label>
+          <div id="litellm-default-model-field">${litellmDefaultModelFieldHtml(litellm.defaultModel || '')}</div>
         </div>
         <details style="margin:4px 0 8px">
           <summary style="cursor:pointer;font-size:0.75rem;color:var(--muted)">Advanced — self-hosted key sources &amp; proxy options</summary>
@@ -13160,6 +13229,10 @@ function burnAreaChart() {
                 const r = showLiteLLMTestResult(data.probe);
                 showToast(r.msg, r.ok ? 'success' : 'error');
               }
+              // A saved key can unlock (or change) the entitlement-filtered
+              // model set — force a fresh discovery and re-render the
+              // Default Model dropdown so the new models appear immediately.
+              fetchInferenceModels('litellm', true).then(refreshLitellmDefaultModelField).catch(() => {});
             }
           }
         } catch (err) {


### PR DESCRIPTION
Wires the runtime-discovered model list (LiteLLM gateway, vllm, llm-d) into the two model-selection dropdowns in the spoke dashboard. Reuses the existing discovery mechanism — the \`/api/inference/models/{backend}\` endpoint and \`fetchInferenceModels()\` — with **no parallel discovery path** and **no changes to api.go**.

## 1. Governor Config → LiteLLM: Default Model becomes a dropdown
Was a free-text input (\"e.g. gpt-4o\"). Now renders a \`<select>\` of the discovered model ids (verbatim, provider prefixes like \`Azure/\`/\`aws/\` intact) with the current value preselected. Keeps a free-text escape hatch: a **Custom…** option reveals a text input for an id the gateway doesn't list yet, and when discovery is empty/unconfigured it falls back to a plain text input so it's never a dead end. Uses the shared \`.config-field\` recipe (selects already covered) so width/font match.

## 2. Agent cards: per-agent model dropdown preselects the current model
The dropdown already listed discovered-first models with fallback marking (PR #1820), but never marked the agent's active model as selected and dropped the selection when the stored id's provider prefix differed from discovery. New shared \`modelOptionsHtml(backend, current)\` helper: discovered-first ordering, prefix-insensitive preselection (full id / post-slash tail / normalized), and a synthesized \"(current)\" option so a live selection is never silently lost. Applies to litellm/vllm/llm-d.

## 3. Freshness
Forces a cache-bypassing discovery + re-render when the LiteLLM tab is opened and after a key save (a saved key can unlock entitlement-filtered models), and re-renders in place on the live \"models pulled\" SSE push — hooking the same data that fires the existing \"New model available\" toast. Short TTL cache (\`INFERENCE_MODEL_CACHE_TTL_MS\`).

## 4. Auto-heal on key swap
A key swap can strip an agent's model out from under it (scanner 403-looped on a stale deepseek model). On every **real** discovery refresh, each inference agent's selected model is reconciled against the new set:
- Still present (prefix-insensitive) → **kept**, no re-select/toast/relaunch. Fully idempotent.
- Genuinely absent AND new set non-empty → switched to the first available via the existing \`switchModel()\` path (persists + relaunches), with a per-agent toast — never silent.
- Same for the saved Default Model when the config dialog holds governor data.
- Guard: acts only on a non-empty, non-fallback list — never switches based on unverified static aliases.

## Verification
- All \`<script>\` blocks pass \`node --check\`; \`<style>\` braces balanced.
- Reconcile logic unit-tested in node across present/absent/fallback/empty/other-backend cases (idempotent).
- Headless Chrome screenshot of the Default Model select (discovered value preselected, prefix intact), the free-text fallback, and the prefix-insensitive agent-card preselection.
- \`go build ./pkg/dashboard/\` passes; api.go untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)