### PR TITLE
fix(hive): don't stall the dashboard on model switch; document zero-downtime rollout

### DIFF
--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1032,6 +1032,13 @@ metadata:
   namespace: {{.Namespace}}
 spec:
   replicas: 1
+  # Zero-downtime rollout: maxUnavailable=0 keeps the old pod serving until the
+  # surge pod passes its readinessProbe, so the OpenShift router never sees zero
+  # Ready endpoints (which renders as "Application is not available"). This
+  # REQUIRES the hive-data PVC to be ReadWriteMany so both pods can mount /data
+  # during the surge — see the PVC definitions above (NFS and dynamic storage
+  # both request ReadWriteMany). A ReadWriteOnce PVC would deadlock the surge
+  # pod on volume attach across nodes; do not set maxSurge>0 with an RWO volume.
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -27,12 +27,12 @@ import (
 )
 
 const (
-	proxyListenPort         = 18443
-	InferenceTranslatePort  = 18444
-	modeFilePrefix          = "/tmp/.hive-mode-"
-	maxViolationLog         = 1000
-	CACertPath              = "/data/proxy-ca.pem"
-	caKeyPath               = "/data/proxy-ca-key.pem"
+	proxyListenPort        = 18443
+	InferenceTranslatePort = 18444
+	modeFilePrefix         = "/tmp/.hive-mode-"
+	maxViolationLog        = 1000
+	CACertPath             = "/data/proxy-ca.pem"
+	caKeyPath              = "/data/proxy-ca-key.pem"
 )
 
 // GitHubProxy is an HTTP CONNECT proxy that performs MITM TLS
@@ -384,7 +384,6 @@ func (c *prefixConn) Read(b []byte) (int, error) {
 	}
 	return c.Conn.Read(b)
 }
-
 
 // identifyAgentFromReq determines the agent name for a request. It always
 // tries UID-based identification first (unforgeable, works for any client
@@ -868,15 +867,30 @@ func newBufferedReader(c net.Conn) *bufio.Reader {
 }
 
 // SetInferenceRoute configures an agent to use a self-hosted inference backend.
-// It also queries the model's max context length from the endpoint.
+//
+// The route is stored immediately and the caller returns without blocking. The
+// model's max context length is queried in the background because this function
+// is invoked from callers that hold the agent-manager mutex (agent launch,
+// SetModelOverride, SetBackendOverride). A synchronous endpoint probe here
+// (up to maxModelLenQueryTimeout) would pin that mutex for its whole duration,
+// stalling /api/status and other dashboard handlers — which on a single-replica
+// pod reads to the OpenShift router as "Application is not available". The
+// max-context-len only feeds token capping and defaults gracefully to 0
+// (no cap) until the async probe fills it in.
 func (p *GitHubProxy) SetInferenceRoute(agentName string, route *InferenceRoute) {
-	if route.MaxContextLen == 0 {
-		if maxLen := queryMaxModelLen(route.Endpoint, route.Model, route.APIKey, route.CABundle); maxLen > 0 {
-			route.MaxContextLen = maxLen
-		}
-	}
 	p.inference.Set(agentName, route)
 	p.logger.Info("inference route set", "agent", agentName, "backend", route.Backend, "endpoint", route.Endpoint, "model", route.Model, "maxContextLen", route.MaxContextLen)
+
+	if route.MaxContextLen == 0 {
+		endpoint, model, apiKey, caBundle := route.Endpoint, route.Model, route.APIKey, route.CABundle
+		go func() {
+			if maxLen := queryMaxModelLen(endpoint, model, apiKey, caBundle); maxLen > 0 {
+				if p.inference.UpdateMaxContextLen(agentName, endpoint, model, maxLen) {
+					p.logger.Info("inference route max context length resolved", "agent", agentName, "model", model, "maxContextLen", maxLen)
+				}
+			}
+		}()
+	}
 }
 
 // ClearInferenceRoute removes an agent's inference backend override.

--- a/v2/pkg/proxy/inference_route.go
+++ b/v2/pkg/proxy/inference_route.go
@@ -142,6 +142,22 @@ func (ir *inferenceRouter) Get(agentName string) *InferenceRoute {
 	return ir.routes[agentName]
 }
 
+// UpdateMaxContextLen sets the max context length on an agent's stored route,
+// but only if the route still points at the same endpoint and model that the
+// (asynchronous) query was issued for. This prevents a slow probe from an old
+// model switch from clobbering a route the user changed again in the meantime.
+// Returns true if the update was applied.
+func (ir *inferenceRouter) UpdateMaxContextLen(agentName, endpoint, model string, maxLen int) bool {
+	ir.mu.Lock()
+	defer ir.mu.Unlock()
+	route, ok := ir.routes[agentName]
+	if !ok || route.Endpoint != endpoint || route.Model != model {
+		return false
+	}
+	route.MaxContextLen = maxLen
+	return true
+}
+
 // anthropicHosts are hosts that should be intercepted when an agent has
 // an inference route configured.
 var anthropicHosts = map[string]bool{
@@ -378,4 +394,3 @@ func resolveInferencePreamble(route *InferenceRoute, agentName string) string {
 	}
 	return DefaultInferencePreamble
 }
-

--- a/v2/pkg/proxy/proxy_deep_test.go
+++ b/v2/pkg/proxy/proxy_deep_test.go
@@ -55,10 +55,10 @@ func buildClientHello(hostname string) []byte {
 	chBody = append(chBody, 0) // session ID length = 0
 
 	// Cipher suites: 2 bytes length + one suite
-	chBody = append(chBody, 0x00, 0x02)       // 2 bytes of cipher suites
-	chBody = append(chBody, 0x00, 0x2f)       // TLS_RSA_WITH_AES_128_CBC_SHA
-	chBody = append(chBody, 0x01)             // compression methods length
-	chBody = append(chBody, 0x00)             // null compression
+	chBody = append(chBody, 0x00, 0x02) // 2 bytes of cipher suites
+	chBody = append(chBody, 0x00, 0x2f) // TLS_RSA_WITH_AES_128_CBC_SHA
+	chBody = append(chBody, 0x01)       // compression methods length
+	chBody = append(chBody, 0x00)       // null compression
 
 	// Extensions
 	chBody = append(chBody, byte(len(extensions)>>8), byte(len(extensions)))
@@ -110,11 +110,11 @@ func TestExtractSNIPartialRecord(t *testing.T) {
 func TestExtractSNINoExtensions(t *testing.T) {
 	// Build a ClientHello without extensions
 	chBody := make([]byte, 0, 128)
-	chBody = append(chBody, 0x03, 0x03) // version
-	chBody = append(chBody, make([]byte, 32)...) // random
-	chBody = append(chBody, 0) // session ID len
+	chBody = append(chBody, 0x03, 0x03)             // version
+	chBody = append(chBody, make([]byte, 32)...)    // random
+	chBody = append(chBody, 0)                      // session ID len
 	chBody = append(chBody, 0x00, 0x02, 0x00, 0x2f) // cipher suites
-	chBody = append(chBody, 0x01, 0x00) // compression
+	chBody = append(chBody, 0x01, 0x00)             // compression
 
 	hsHeader := []byte{0x01}
 	hsLen := len(chBody)
@@ -178,12 +178,12 @@ func TestExtractSNIHandshakeTooShort(t *testing.T) {
 func TestExtractSNISessionIDPresent(t *testing.T) {
 	// ClientHello with a session ID
 	chBody := make([]byte, 0, 200)
-	chBody = append(chBody, 0x03, 0x03) // version
-	chBody = append(chBody, make([]byte, 32)...) // random
-	chBody = append(chBody, 4)  // session ID length = 4
+	chBody = append(chBody, 0x03, 0x03)             // version
+	chBody = append(chBody, make([]byte, 32)...)    // random
+	chBody = append(chBody, 4)                      // session ID length = 4
 	chBody = append(chBody, 0xAA, 0xBB, 0xCC, 0xDD) // session ID
 	chBody = append(chBody, 0x00, 0x02, 0x00, 0x2f) // cipher suites
-	chBody = append(chBody, 0x01, 0x00) // compression
+	chBody = append(chBody, 0x01, 0x00)             // compression
 
 	hostname := "with-session.example.com"
 	sniBytes := []byte(hostname)
@@ -716,6 +716,68 @@ func TestSetAndClearInferenceRoute(t *testing.T) {
 	}
 }
 
+// SetInferenceRoute is called while the agent-manager mutex is held (agent
+// launch, SetModelOverride, SetBackendOverride). It must return promptly and
+// never block on the up-to-3s max-model-len endpoint probe, otherwise a model
+// switch pins the manager mutex and stalls the dashboard — reading as
+// "Application is not available" on the OpenShift router. Use an unroutable
+// endpoint so the probe would hang for the full timeout if it ran inline.
+func TestSetInferenceRouteDoesNotBlockOnEndpointProbe(t *testing.T) {
+	p := newTestProxy()
+	p.inference = newInferenceRouter()
+
+	// 203.0.113.0/24 (TEST-NET-3) is reserved and unroutable: a real probe
+	// would block until maxModelLenQueryTimeout (3s).
+	route := &InferenceRoute{Backend: "vllm", Endpoint: "http://203.0.113.1:8000", Model: "test"}
+
+	done := make(chan struct{})
+	go func() {
+		p.SetInferenceRoute("agent-block", route)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Returned promptly — route was set without waiting on the probe.
+	case <-time.After(maxModelLenQueryTimeout - 500*time.Millisecond):
+		t.Fatal("SetInferenceRoute blocked on the max-model-len endpoint probe; " +
+			"it must set the route synchronously and probe asynchronously")
+	}
+
+	if got := p.inference.Get("agent-block"); got == nil || got.Model != "test" {
+		t.Error("route should be set immediately, before the async probe completes")
+	}
+}
+
+// UpdateMaxContextLen must not clobber a route that has since been changed to a
+// different endpoint/model — a slow probe from a prior model switch could
+// otherwise overwrite the value the user just switched to.
+func TestUpdateMaxContextLenStaleGuard(t *testing.T) {
+	ir := newInferenceRouter()
+	ir.Set("a", &InferenceRoute{Endpoint: "http://e1", Model: "m1"})
+
+	if !ir.UpdateMaxContextLen("a", "http://e1", "m1", 8192) {
+		t.Fatal("update should apply for the matching endpoint/model")
+	}
+	if got := ir.Get("a"); got.MaxContextLen != 8192 {
+		t.Errorf("MaxContextLen = %d, want 8192", got.MaxContextLen)
+	}
+
+	// Route changed to a new model: a stale probe result must be rejected.
+	ir.Set("a", &InferenceRoute{Endpoint: "http://e2", Model: "m2"})
+	if ir.UpdateMaxContextLen("a", "http://e1", "m1", 4096) {
+		t.Error("stale update for old endpoint/model must be rejected")
+	}
+	if got := ir.Get("a"); got.MaxContextLen != 0 {
+		t.Errorf("stale update leaked into new route: MaxContextLen = %d, want 0", got.MaxContextLen)
+	}
+
+	// Missing agent: no panic, returns false.
+	if ir.UpdateMaxContextLen("missing", "http://e1", "m1", 100) {
+		t.Error("update for a missing agent must return false")
+	}
+}
+
 // ---------- handleConn: CONNECT path (non-GitHub host) ----------
 
 func TestHandleConnCONNECTNonGitHub(t *testing.T) {
@@ -1162,7 +1224,7 @@ func TestStartInferenceTranslator(t *testing.T) {
 
 		resp, err := http.DefaultClient.Do(upstreamReq)
 		if err != nil {
-			http.Error(w, fmt.Sprintf(`{"type":"error"}`, ), http.StatusBadGateway)
+			http.Error(w, fmt.Sprintf(`{"type":"error"}`), http.StatusBadGateway)
 			return
 		}
 		defer resp.Body.Close()


### PR DESCRIPTION
## Problem

Changing an agent's model from the dashboard (model dropdown → `POST /api/model/{agent}/{model}` → `handleModelSet`) makes the whole hosted-hive dashboard briefly unavailable (\"Application is not available\" on the OpenShift route, ~30–60s). Live-observed on kellyaa. A model switch should only recycle that one agent's tmux session — never take down the dashboard or other agents.

## Root cause (FIX A)

`handleModelSet` → `Manager.SetModelOverride` fires the inference-route callback **while holding the agent-manager mutex (`m.mu`)**. That callback → `GitHubProxy.SetInferenceRoute` ran a **synchronous** `queryMaxModelLen` probe of the inference endpoint's `/v1/models` (up to `maxModelLenQueryTimeout` = 3s). For a self-hosted-inference agent (kellyaa is on vllm-d) that pins the manager mutex for the whole probe, so `/api/status` and other handlers that need `m.mu` stall long enough that the OpenShift router sees no healthy backend and reports \"Application is not available\".

Note: the model-set path itself is entirely tmux-level (`Manager.Restart` = kill + relaunch the single agent's session). There is **no** pod-level restart, no `os.Exit`/re-exec, and no `hive.yaml` rewrite — override persistence goes through the runtime snapshot, not the config watcher. The disruption was mutex-stall, not a process restart.

### Fix

`SetInferenceRoute` now stores the route immediately and probes `max_model_len` **asynchronously**, applying the result via a new guarded `inferenceRouter.UpdateMaxContextLen` (rejects a stale probe if the user switched the route again). `max_model_len` only feeds token capping and defaults gracefully to `0` (no cap) until the probe resolves. Same win for backend switch and agent launch, which share the callback.

## Zero-downtime rollout (FIX B)

The user also sees the same \"Application is not available\" on **legitimate** pod restarts (image auto-upgrade, config-driven restart). Investigation of the hive Deployment template (`v2/pkg/hub/saas_provision.go`):

- The template is **already** correct for new hives: `strategy: RollingUpdate` with `maxSurge=1, maxUnavailable=0`, RWX PVCs (NFS + dynamic both request `ReadWriteMany`), and a `readinessProbe` on `/api/health`. With `maxUnavailable=0` + readiness gating, the old pod keeps serving until the surge pod is Ready → zero-downtime (added since #1509/#1604).
- **Existing hives provisioned before those PRs are stale.** kellyaa's live Deployment is `maxSurge=0, maxUnavailable=1` (old-turn-down-first strategy) and its `hive-data` PVC is `ReadWriteOnce` (immutable once bound), even though its CephFS storage class (`ocs-storagecluster-cephfs`) supports RWX on this cluster. RWO blocks a surge pod on volume attach across nodes.

This PR adds a comment on the template documenting the zero-downtime contract (maxUnavailable=0 requires an RWX PVC) so a future edit doesn't regress it. Existing hives need a manual remediation (below); the template change only affects new provisions.

### Manual remediation for kellyaa (and any pre-RWX hive)

RWO→RWX requires recreating the PVC (access mode is immutable on a bound PVC), then patching the strategy:

```
NS=hive-hosted-hosted-kellyaa-agent-newsle-5d94
# 1. scale down, back up /data, recreate hive-data as RWX, restore, scale up
#    (RWX CephFS is supported on this cluster: ocs-storagecluster-cephfs)
# 2. patch the rollout strategy to zero-downtime:
kubectl -n $NS patch deploy hive --type=json -p '[
  {"op":"replace","path":"/spec/strategy/rollingUpdate/maxSurge","value":1},
  {"op":"replace","path":"/spec/strategy/rollingUpdate/maxUnavailable","value":0}
]'
```

Recommendation: where storage allows, bump hosted hives to `replicas: 2` for the durable answer — a single-replica RWX hive is still zero-downtime on rollout but has no headroom for node drains.

## Tests

- `TestSetInferenceRouteDoesNotBlockOnEndpointProbe` — asserts `SetInferenceRoute` returns promptly against an unroutable endpoint (would hang 3s if the probe ran inline).
- `TestUpdateMaxContextLenStaleGuard` — asserts a stale async probe can't clobber a re-switched route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)