### PR TITLE
fix(hub): don't wedge OpenShift rolling upgrades on init-permissions chown

### DIFF
--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1074,9 +1074,19 @@ spec:
       - name: init-permissions
         image: ghcr.io/kubestellar/hive:{{.ImageTag}}
         imagePullPolicy: {{.ImagePullPolicy}}
-        command: ["sh", "-c", "chown -R {{.InitContainerUID}}:{{.InitContainerGID}} /data 2>/dev/null; echo permissions-set"]
-        securityContext:
-          runAsUser: 0
+        # Best-effort ownership normalization. /data is already 1001:1000 on
+        # these hives, so this recursive chown is belt-and-suspenders and must
+        # never be fatal: on OpenShift the restricted SCC rejects runAsUser:0
+        # and assigns an arbitrary non-root UID, so the chown runs as a
+        # non-owner and fails on any file it doesn't own (e.g. a stale
+        # root-owned /data/*.tmp). Suppress errors AND force exit 0 so a
+        # non-ownable file can't crash-loop init and wedge the rolling update
+        # (maxUnavailable=0/maxSurge=1 means a never-Ready surge pod hangs the
+        # rollout indefinitely). We deliberately do NOT request runAsUser:0:
+        # it is invalid under the restricted SCC and pointless here since the
+        # files that matter are already correctly owned — letting the SCC
+        # assign the UID makes the chown a no-op success.
+        command: ["sh", "-c", "chown -R {{.InitContainerUID}}:{{.InitContainerGID}} /data 2>/dev/null || true; echo permissions-set"]
         volumeMounts:
         - name: data
           mountPath: /data


### PR DESCRIPTION
## Problem

The `open-source/osscar` hive was stuck at 1/2 replicas for hours. Its new pod crash-looped in the `init-permissions` init container:

```
chown: changing ownership of '/data/last-actionable.json.tmp': Permission denied
BackOff restarting failed container init-permissions
```

Because the hive Deployment rolls with `maxUnavailable=0/maxSurge=1`, the never-Ready surge pod hangs the rolling update indefinitely and the dashboard route can flap.

## Root cause

On OpenShift the restricted SCC **rejects `runAsUser: 0`** and assigns an arbitrary non-root UID instead. The `init-permissions` container's `chown -R 1001:1000 /data` then runs as a non-owner and **fails** on any file it doesn't own (e.g. a stale root-owned `/data/*.tmp`), crash-looping init. Meanwhile `/data` is already owned 1001:1000 on these hives, so the recursive chown is redundant belt-and-suspenders anyway.

#1735 already changed `&&` → `;` and suppressed stderr, but the deeper structural bug — requesting `runAsUser: 0` under a restricted SCC — remained.

## Fix

- **Drop the `runAsUser: 0` request.** It is invalid under the restricted SCC and pointless here. Letting the SCC assign the UID (consistent with the main `hive` container, which sets no `runAsUser`) makes the already-correctly-owned chown a no-op success.
- **Force exit 0** (`|| true`) so a non-ownable file can never crash-loop init even if some file is unexpectedly present.

`copy-config` was checked and has no analogous fatal chown/permission op.

## Existing hives

This reaches **new provisions only**. Running OpenShift/vllm-d hives that upgrade (kellyaa, osscar, any other hosted hive) need the same live patch:

```bash
kubectl patch deployment hive -n <hive-namespace> --type=json -p='[
  {"op":"replace","path":"/spec/template/spec/initContainers/1/command",
   "value":["sh","-c","chown -R 1001:1000 /data 2>/dev/null || true; echo permissions-set"]},
  {"op":"remove","path":"/spec/template/spec/initContainers/1/securityContext"}
]'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)