### PR TITLE
security: per-user authz + per-user sessions on direct-route spokes

### DIFF
--- a/v2/pkg/config/authorized_users_test.go
+++ b/v2/pkg/config/authorized_users_test.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseAuthorizedUsers(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"clubanderson", []string{"clubanderson"}},
+		{"clubanderson,kellyaa", []string{"clubanderson", "kellyaa"}},
+		{" clubanderson , kellyaa ", []string{"clubanderson", "kellyaa"}},
+		{"clubanderson,,kellyaa,", []string{"clubanderson", "kellyaa"}},
+		{"", []string{}},
+	}
+	for _, c := range cases {
+		got := parseAuthorizedUsers(c.in)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("parseAuthorizedUsers(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestApplyBootstrapEnv_ReadsAuthorizedUsers(t *testing.T) {
+	t.Setenv("HIVE_AUTHORIZED_USERS", "clubanderson,kellyaa")
+	c := &Config{}
+	c.applyBootstrapEnv()
+	if len(c.Dashboard.AuthorizedUsers) != 2 ||
+		c.Dashboard.AuthorizedUsers[0] != "clubanderson" ||
+		c.Dashboard.AuthorizedUsers[1] != "kellyaa" {
+		t.Fatalf("expected authorized users from env, got %v", c.Dashboard.AuthorizedUsers)
+	}
+	if !c.Dashboard.IsDirectRouteAuthzEnabled() {
+		t.Fatal("direct-route authz should be enabled when list is populated")
+	}
+}
+
+func TestApplyBootstrapEnv_ConfigListWins(t *testing.T) {
+	t.Setenv("HIVE_AUTHORIZED_USERS", "envuser")
+	c := &Config{}
+	c.Dashboard.AuthorizedUsers = []string{"yamluser"}
+	c.applyBootstrapEnv()
+	if len(c.Dashboard.AuthorizedUsers) != 1 || c.Dashboard.AuthorizedUsers[0] != "yamluser" {
+		t.Fatalf("explicit config list must win over env, got %v", c.Dashboard.AuthorizedUsers)
+	}
+}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -14,18 +14,18 @@ import (
 )
 
 type Config struct {
-	Project       ProjectConfig                `yaml:"project"`
-	Policies      PoliciesConfig               `yaml:"policies"`
-	Agents        map[string]AgentConfig        `yaml:"agents"`
-	Governor      GovernorConfig               `yaml:"governor"`
-	GitHub        GitHubConfig                 `yaml:"github"`
-	Notifications NotificationsConfig          `yaml:"notifications"`
-	Dashboard     DashboardConfig              `yaml:"dashboard"`
-	Data          DataConfig                   `yaml:"data"`
-	Knowledge     KnowledgeConfig              `yaml:"knowledge"`
-	Hub           HubConfig                    `yaml:"hub"`
-	HiveID        string                       `yaml:"hive_id"`
-	ACMMLevel     *int                         `yaml:"acmm_level,omitempty" json:"acmm_level"`
+	Project       ProjectConfig          `yaml:"project"`
+	Policies      PoliciesConfig         `yaml:"policies"`
+	Agents        map[string]AgentConfig `yaml:"agents"`
+	Governor      GovernorConfig         `yaml:"governor"`
+	GitHub        GitHubConfig           `yaml:"github"`
+	Notifications NotificationsConfig    `yaml:"notifications"`
+	Dashboard     DashboardConfig        `yaml:"dashboard"`
+	Data          DataConfig             `yaml:"data"`
+	Knowledge     KnowledgeConfig        `yaml:"knowledge"`
+	Hub           HubConfig              `yaml:"hub"`
+	HiveID        string                 `yaml:"hive_id"`
+	ACMMLevel     *int                   `yaml:"acmm_level,omitempty" json:"acmm_level"`
 
 	SourcePath string `yaml:"-" json:"-"`
 }
@@ -39,15 +39,15 @@ type DocSourceConfigYAML struct {
 }
 
 type KnowledgeConfig struct {
-	Enabled    bool                  `yaml:"enabled"`
-	Engine     string                `yaml:"engine"`
-	Layers     []KnowledgeLayer      `yaml:"layers"`
-	Vaults     []VaultConfig         `yaml:"vaults"`
-	GitSources []GitSourceConfigYAML `yaml:"git_sources"`
-	Documents  []DocSourceConfigYAML `yaml:"documents"`
-	Curator         KnowledgeCurator         `yaml:"curator"`
-	Primer          KnowledgePrimer          `yaml:"primer"`
-	BeadSynthesizer BeadSynthesizerConfig    `yaml:"bead_synthesizer"`
+	Enabled         bool                  `yaml:"enabled"`
+	Engine          string                `yaml:"engine"`
+	Layers          []KnowledgeLayer      `yaml:"layers"`
+	Vaults          []VaultConfig         `yaml:"vaults"`
+	GitSources      []GitSourceConfigYAML `yaml:"git_sources"`
+	Documents       []DocSourceConfigYAML `yaml:"documents"`
+	Curator         KnowledgeCurator      `yaml:"curator"`
+	Primer          KnowledgePrimer       `yaml:"primer"`
+	BeadSynthesizer BeadSynthesizerConfig `yaml:"bead_synthesizer"`
 }
 
 // BeadSynthesizerConfig controls automatic synthesis of completed beads into wiki facts.
@@ -218,22 +218,22 @@ type AgentConfig struct {
 	Description     string `yaml:"description" json:"description,omitempty"`
 
 	// Phase 2: config-driven agent behavior fields
-	Role             string            `yaml:"role" json:"role,omitempty"`
-	SortOrder        int               `yaml:"sort_order" json:"sort_order,omitempty"`
-	Emoji            string            `yaml:"emoji" json:"emoji,omitempty"`
-	Color            string            `yaml:"color" json:"color,omitempty"`
-	Aliases          []string          `yaml:"aliases" json:"aliases,omitempty"`
-	LaneKeywords     []string          `yaml:"lane_keywords" json:"lane_keywords,omitempty"`
-	DetectKeywords   []string          `yaml:"detect_keywords" json:"detect_keywords,omitempty"`
-	KickTemplate     string            `yaml:"kick_template" json:"kick_template,omitempty"`
-	IncludeRepos     *bool             `yaml:"include_repos" json:"include_repos,omitempty"`
-	MetricsCollector string            `yaml:"metrics_collector" json:"metrics_collector,omitempty"`
-	BeadRole         string            `yaml:"bead_role" json:"bead_role,omitempty"`
+	Role             string              `yaml:"role" json:"role,omitempty"`
+	SortOrder        int                 `yaml:"sort_order" json:"sort_order,omitempty"`
+	Emoji            string              `yaml:"emoji" json:"emoji,omitempty"`
+	Color            string              `yaml:"color" json:"color,omitempty"`
+	Aliases          []string            `yaml:"aliases" json:"aliases,omitempty"`
+	LaneKeywords     []string            `yaml:"lane_keywords" json:"lane_keywords,omitempty"`
+	DetectKeywords   []string            `yaml:"detect_keywords" json:"detect_keywords,omitempty"`
+	KickTemplate     string              `yaml:"kick_template" json:"kick_template,omitempty"`
+	IncludeRepos     *bool               `yaml:"include_repos" json:"include_repos,omitempty"`
+	MetricsCollector string              `yaml:"metrics_collector" json:"metrics_collector,omitempty"`
+	BeadRole         string              `yaml:"bead_role" json:"bead_role,omitempty"`
 	StatsDisplay     []StatsDisplayEntry `yaml:"stats_display" json:"stats_display,omitempty"`
-	ACMMLevels       []int             `yaml:"acmm_levels" json:"acmm_levels,omitempty"`
-	Mode             string            `yaml:"mode" json:"mode,omitempty"`
-	OnDemand         bool              `yaml:"on_demand" json:"on_demand,omitempty"`
-	CavemanMode      string            `yaml:"caveman_mode" json:"caveman_mode,omitempty"`
+	ACMMLevels       []int               `yaml:"acmm_levels" json:"acmm_levels,omitempty"`
+	Mode             string              `yaml:"mode" json:"mode,omitempty"`
+	OnDemand         bool                `yaml:"on_demand" json:"on_demand,omitempty"`
+	CavemanMode      string              `yaml:"caveman_mode" json:"caveman_mode,omitempty"`
 
 	// Channels declares how this agent gets triggered (kick, webhook, discord, schedule, bead).
 	// When nil/empty, the agent uses governor timer kicks by default (implicit kick channel).
@@ -603,12 +603,12 @@ func (m ModeConfig) MarshalYAML() (interface{}, error) {
 }
 
 type GitHubConfig struct {
-	AppID                int64  `yaml:"app_id"`
-	InstallationID       int64  `yaml:"installation_id"`
-	DocsInstallationID   int64  `yaml:"docs_installation_id"`
-	KeyFile              string `yaml:"key_file"`
-	Token                string `yaml:"token"`
-	OAuthClientID        string `yaml:"oauth_client_id"`
+	AppID              int64  `yaml:"app_id"`
+	InstallationID     int64  `yaml:"installation_id"`
+	DocsInstallationID int64  `yaml:"docs_installation_id"`
+	KeyFile            string `yaml:"key_file"`
+	Token              string `yaml:"token"`
+	OAuthClientID      string `yaml:"oauth_client_id"`
 	// AppSlug is the GitHub App URL slug for the install link.
 	// For public GitHub: "kubestellar-hive". For GHE: your app's slug.
 	AppSlug string `yaml:"app_slug"`
@@ -692,26 +692,26 @@ type DiscordConfig struct {
 }
 
 type HubConfig struct {
-	Enabled                bool     `yaml:"enabled"`
-	URL                    string   `yaml:"url"`
-	IsPublic               bool     `yaml:"is_public"`
-	SnapshotURL            string   `yaml:"snapshot_url"`
-	DashboardURL           string   `yaml:"dashboard_url"`
-	HiveType               string   `yaml:"hive_type"`
-	ClusterID              string   `yaml:"cluster_id"`
-	AutoSnapshot           bool     `yaml:"auto_snapshot"`
-	AutoUpgrade            bool     `yaml:"auto_upgrade"`
-	ContributeSuspended    bool     `yaml:"contribute_suspended"`
-	ContributeAllowLabels  []string `yaml:"contribute_allow_labels"`
-	ContributeDenyLabels   []string `yaml:"contribute_deny_labels"`
-	ContributeDenyTitles   []string `yaml:"contribute_deny_titles"`
-	ContributeDenyAuthors         []string `yaml:"contribute_deny_authors"`
-	ContributeAllowModels         []string `yaml:"contribute_allow_models"`
-	ContributeRejectUnknownModels bool     `yaml:"contribute_reject_unknown_models"`
+	Enabled                       bool                `yaml:"enabled"`
+	URL                           string              `yaml:"url"`
+	IsPublic                      bool                `yaml:"is_public"`
+	SnapshotURL                   string              `yaml:"snapshot_url"`
+	DashboardURL                  string              `yaml:"dashboard_url"`
+	HiveType                      string              `yaml:"hive_type"`
+	ClusterID                     string              `yaml:"cluster_id"`
+	AutoSnapshot                  bool                `yaml:"auto_snapshot"`
+	AutoUpgrade                   bool                `yaml:"auto_upgrade"`
+	ContributeSuspended           bool                `yaml:"contribute_suspended"`
+	ContributeAllowLabels         []string            `yaml:"contribute_allow_labels"`
+	ContributeDenyLabels          []string            `yaml:"contribute_deny_labels"`
+	ContributeDenyTitles          []string            `yaml:"contribute_deny_titles"`
+	ContributeDenyAuthors         []string            `yaml:"contribute_deny_authors"`
+	ContributeAllowModels         []string            `yaml:"contribute_allow_models"`
+	ContributeRejectUnknownModels bool                `yaml:"contribute_reject_unknown_models"`
 	DisabledRepos                 []string            `yaml:"disabled_repos"`
-	DisabledTiers          []string            `yaml:"disabled_tiers"`
-	TierLimits             map[string]TierRate `yaml:"tier_limits"`
-	SnapshotIntervalMin    int                 `yaml:"snapshot_interval_min"`
+	DisabledTiers                 []string            `yaml:"disabled_tiers"`
+	TierLimits                    map[string]TierRate `yaml:"tier_limits"`
+	SnapshotIntervalMin           int                 `yaml:"snapshot_interval_min"`
 }
 
 type TierRate struct {
@@ -725,14 +725,89 @@ type DashboardConfig struct {
 	SnapshotDir        string `yaml:"snapshot_dir"`
 	AuthToken          string `yaml:"auth_token"`
 	AgentPollIntervalS int    `yaml:"agent_poll_interval_s"`
+	// AuthorizedUsers is the allowlist of GitHub usernames permitted to log in
+	// to a direct-route (non-hub-proxied) spoke via the device flow. The first
+	// entry is treated as the owner (read-write); the rest are granted viewers
+	// (read-only) unless an explicit "username:role" suffix is given. On the
+	// hub-proxied path, nginx injects X-Hive-User/X-Hive-Role and this list is
+	// not consulted. Empty on hub-proxied hives; populated by provisioning for
+	// hosted hives so direct-route device-flow logins are per-user authorized.
+	AuthorizedUsers []string `yaml:"authorized_users"`
+}
+
+// Role strings used for direct-route spoke authorization. These mirror the
+// roles the hub injects via X-Hive-Role on the proxied path so the read-only
+// gating in the dashboard behaves identically on both paths.
+const (
+	RoleOwner = "owner"
+	RoleRead  = "read"
+)
+
+// AuthorizedRole resolves a GitHub username against the spoke's authorized-users
+// allowlist and returns the user's role and whether they are authorized.
+//
+// Each entry is either "username" or "username:role" (role = "owner" or "read").
+// An entry without an explicit role defaults to "owner" for the first entry
+// (the hive owner) and "read" for the rest (granted viewers). Matching is
+// case-insensitive because GitHub usernames are case-insensitive.
+//
+// A spoke with an empty AuthorizedUsers list is NOT a direct-route spoke that
+// enforces device-flow authz (it is either hub-proxied or misconfigured); the
+// caller decides how to treat that case — see IsDirectRouteAuthzEnabled.
+func (d DashboardConfig) AuthorizedRole(username string) (string, bool) {
+	if username == "" {
+		return "", false
+	}
+	want := strings.ToLower(username)
+	for i, entry := range d.AuthorizedUsers {
+		name, role := splitAuthorizedEntry(entry)
+		if name == "" {
+			continue
+		}
+		if strings.ToLower(name) != want {
+			continue
+		}
+		if role == "" {
+			if i == 0 {
+				role = RoleOwner
+			} else {
+				role = RoleRead
+			}
+		}
+		return role, true
+	}
+	return "", false
+}
+
+// IsDirectRouteAuthzEnabled reports whether this spoke has a per-hive
+// authorized-users allowlist and must therefore enforce per-user authorization
+// on device-flow logins. Hub-proxied hives leave this empty and rely on nginx.
+func (d DashboardConfig) IsDirectRouteAuthzEnabled() bool {
+	return len(d.AuthorizedUsers) > 0
+}
+
+// splitAuthorizedEntry parses a "username" or "username:role" allowlist entry.
+func splitAuthorizedEntry(entry string) (name, role string) {
+	entry = strings.TrimSpace(entry)
+	if idx := strings.LastIndex(entry, ":"); idx >= 0 {
+		name = strings.TrimSpace(entry[:idx])
+		role = strings.ToLower(strings.TrimSpace(entry[idx+1:]))
+		if role != RoleOwner && role != RoleRead {
+			// Unknown role suffix — treat the whole thing as a bare username so
+			// a stray colon can never silently downgrade or escalate access.
+			return strings.TrimSpace(entry), ""
+		}
+		return name, role
+	}
+	return entry, ""
 }
 
 type DataConfig struct {
-	MetricsDir          string `yaml:"metrics_dir"`
-	LogsDir             string `yaml:"logs_dir"`
-	ClaudeSessionsDir   string `yaml:"claude_sessions_dir"`
-	CopilotSessionsDir  string `yaml:"copilot_sessions_dir"`
-	AgentsDir           string `yaml:"agents_dir"`
+	MetricsDir         string `yaml:"metrics_dir"`
+	LogsDir            string `yaml:"logs_dir"`
+	ClaudeSessionsDir  string `yaml:"claude_sessions_dir"`
+	CopilotSessionsDir string `yaml:"copilot_sessions_dir"`
+	AgentsDir          string `yaml:"agents_dir"`
 }
 
 var envVarPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
@@ -912,6 +987,28 @@ func (c *Config) applyBootstrapEnv() {
 			c.Dashboard.AuthToken = v
 		}
 	}
+	// K8s-provisioned spokes receive their per-hive authorized GitHub users as a
+	// comma-separated env var (owner first). This is what lets a direct-route
+	// spoke reject unauthorized device-flow logins without the hub proxy.
+	if len(c.Dashboard.AuthorizedUsers) == 0 {
+		if v := os.Getenv("HIVE_AUTHORIZED_USERS"); v != "" {
+			c.Dashboard.AuthorizedUsers = parseAuthorizedUsers(v)
+		}
+	}
+}
+
+// parseAuthorizedUsers splits a comma-separated authorized-users list, trimming
+// whitespace and dropping empty entries. Order is preserved so the first entry
+// remains the owner.
+func parseAuthorizedUsers(v string) []string {
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if u := strings.TrimSpace(p); u != "" {
+			out = append(out, u)
+		}
+	}
+	return out
 }
 
 func expandEnvVars(s string) string {
@@ -1163,52 +1260,52 @@ func applyKnownAgentDefaults(name string, agent *AgentConfig) {
 			Emoji: "🔍", Color: "#3498db", Aliases: []string{"sc"},
 			LaneKeywords:   []string{"bug", "triage", "typo", "fix"},
 			DetectKeywords: []string{"scanner", "triage", "issue", "bug"},
-			BeadRole: "worker", SortOrder: 20, IncludeRepos: true,
+			BeadRole:       "worker", SortOrder: 20, IncludeRepos: true,
 		},
 		"ci-maintainer": {
 			Emoji: "🔧", Color: "#2ecc71", Aliases: []string{"ci"},
 			LaneKeywords:   []string{"workflow-failure", "ci-failure", "nightly", "coverage", "regression", "ga4", "analytics"},
 			DetectKeywords: []string{"ci-maintainer", "review", "ci", "coverage", "ga4"},
-			BeadRole: "worker", SortOrder: 30, IncludeRepos: true,
+			BeadRole:       "worker", SortOrder: 30, IncludeRepos: true,
 		},
 		"architect": {
 			Emoji: "🏗", Color: "#9b59b6", Aliases: []string{"ar"},
 			LaneKeywords:   []string{"rfc", "architecture", "refactor", "redesign", "migration", "breaking change", "protocol", "api design"},
 			DetectKeywords: []string{"architect", "rfc", "refactor"},
-			BeadRole: "worker", SortOrder: 40, IncludeRepos: true,
+			BeadRole:       "worker", SortOrder: 40, IncludeRepos: true,
 		},
 		"outreach": {
 			Emoji: "🌐", Color: "#e67e22", Aliases: []string{"ou"},
 			LaneKeywords:   []string{"adopters", "outreach", "community", "engagement"},
 			DetectKeywords: []string{"outreach", "adopters", "community"},
-			BeadRole: "worker", SortOrder: 50, IncludeRepos: false,
+			BeadRole:       "worker", SortOrder: 50, IncludeRepos: false,
 		},
 		"supervisor": {
 			Emoji: "👑", Color: "#e74c3c", Aliases: []string{"su"},
 			DetectKeywords: []string{"supervisor", "sweep", "monitor"},
-			BeadRole: "supervisor", SortOrder: 10, IncludeRepos: true,
+			BeadRole:       "supervisor", SortOrder: 10, IncludeRepos: true,
 		},
 		"sec-check": {
 			Emoji: "🛡", Color: "#1abc9c", Aliases: []string{"se"},
 			DetectKeywords: []string{"security", "sec-check", "vulnerability"},
-			BeadRole: "worker", SortOrder: 60, IncludeRepos: true,
+			BeadRole:       "worker", SortOrder: 60, IncludeRepos: true,
 		},
 		"quality": {
 			Emoji: "🧪", Color: "#3498db", Aliases: []string{"te", "qa"},
 			LaneKeywords:   []string{"test-gap", "test-strategy", "test-coverage", "test-scaffold", "untested", "missing-tests"},
 			DetectKeywords: []string{"quality", "test", "coverage"},
-			BeadRole: "worker", SortOrder: 35, IncludeRepos: true,
+			BeadRole:       "worker", SortOrder: 35, IncludeRepos: true,
 		},
 		"strategist": {
 			Emoji: "🧠", Color: "#f39c12", Aliases: []string{"sg"},
 			DetectKeywords: []string{"strategist", "strategy"},
-			BeadRole: "worker", SortOrder: 70, IncludeRepos: true,
+			BeadRole:       "worker", SortOrder: 70, IncludeRepos: true,
 		},
 		"guide": {
 			Emoji: "📖", Color: "#8e44ad", Aliases: []string{"gu"},
 			LaneKeywords:   []string{"docs", "documentation", "readme", "guide", "tutorial", "onboarding"},
 			DetectKeywords: []string{"guide", "docs", "documentation"},
-			BeadRole: "worker", SortOrder: 45, IncludeRepos: true,
+			BeadRole:       "worker", SortOrder: 45, IncludeRepos: true,
 		},
 	}
 

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -530,15 +530,15 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 		githubBaseURL = "https://github.com"
 	}
 	jsonResponse(w, map[string]interface{}{
-		"org":              cfg.Project.Org,
-		"repos":            cfg.Project.Repos,
-		"ai_author":        cfg.Project.AIAuthor,
-		"agents":           len(cfg.EnabledAgents()),
-		"eval_interval_s":  cfg.Governor.EvalIntervalS,
-		"primaryRepo":      primaryRepo,
-		"hub_url":          cfg.Hub.URL,
-		"hive_id":          cfg.HiveID,
-		"github_base_url":  githubBaseURL,
+		"org":             cfg.Project.Org,
+		"repos":           cfg.Project.Repos,
+		"ai_author":       cfg.Project.AIAuthor,
+		"agents":          len(cfg.EnabledAgents()),
+		"eval_interval_s": cfg.Governor.EvalIntervalS,
+		"primaryRepo":     primaryRepo,
+		"hub_url":         cfg.Hub.URL,
+		"hive_id":         cfg.HiveID,
+		"github_base_url": githubBaseURL,
 	})
 }
 
@@ -885,11 +885,11 @@ func (s *Server) handleWidget(w http.ResponseWriter, r *http.Request) {
 	}
 
 	jsonResponse(w, map[string]interface{}{
-		"mode":     state.Mode,
-		"issues":   state.QueueIssues,
-		"prs":      state.QueuePRs,
-		"running":  running,
-		"paused":   paused,
+		"mode":      state.Mode,
+		"issues":    state.QueueIssues,
+		"prs":       state.QueuePRs,
+		"running":   running,
+		"paused":    paused,
 		"last_eval": state.LastEval,
 	})
 }
@@ -923,9 +923,9 @@ func (s *Server) handlePane(w http.ResponseWriter, r *http.Request) {
 	}
 
 	jsonResponse(w, map[string]interface{}{
-		"agent":  name,
-		"lines":  output,
-		"count":  len(output),
+		"agent": name,
+		"lines": output,
+		"count": len(output),
 	})
 }
 
@@ -1201,7 +1201,7 @@ func (s *Server) handleIssueCosts(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleModelAdvisor(w http.ResponseWriter, r *http.Request) {
 	budget := s.deps.Governor.GetBudget()
 	jsonResponse(w, map[string]interface{}{
-		"budget":        budget,
+		"budget":         budget,
 		"recommendation": "Use haiku for simple tasks, sonnet for default, opus for complex refactors",
 	})
 }
@@ -1267,6 +1267,27 @@ func (s *Server) handleGHAuth(w http.ResponseWriter, r *http.Request) {
 const userTokenPath = "/data/gh-user-token"
 
 func (s *Server) handleGHUserAuthStatus(w http.ResponseWriter, r *http.Request) {
+	// The login status must reflect THIS request's user, not the single
+	// persisted token. On a direct-route spoke, resolving from the per-user
+	// session is the only correct answer — otherwise every visitor would see
+	// the last-authenticated user's identity (the reported vulnerability).
+	if sess := s.sessionFromRequest(r); sess != nil {
+		jsonResponse(w, map[string]interface{}{"logged_in": true, "username": sess.Username, "role": sess.Role})
+		return
+	}
+	// Hub-proxied path: nginx injects the per-user X-Hive-User/X-Hive-Role, so
+	// report THAT user rather than the single shared persisted token (which
+	// would show every proxied visitor the owner's identity).
+	if hubUser := r.Header.Get("X-Hive-User"); hubUser != "" {
+		jsonResponse(w, map[string]interface{}{"logged_in": true, "username": hubUser, "role": r.Header.Get("X-Hive-Role")})
+		return
+	}
+	if s.directRouteAuthzEnabled() {
+		// No valid session on a direct-route spoke → not logged in for this
+		// request, regardless of any persisted owner token on disk.
+		jsonResponse(w, map[string]interface{}{"logged_in": false})
+		return
+	}
 	tokenData, err := os.ReadFile(userTokenPath)
 	if err != nil || len(strings.TrimSpace(string(tokenData))) == 0 {
 		jsonResponse(w, map[string]interface{}{"logged_in": false})
@@ -1331,40 +1352,69 @@ func (s *Server) handleGHUserAuthPoll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tmpTokenPath := userTokenPath + ".tmp"
-	if err := os.WriteFile(tmpTokenPath, []byte(token), 0o600); err != nil {
-		jsonError(w, "failed to save token: "+err.Error(), http.StatusInternalServerError)
+	// Resolve the GitHub identity BEFORE persisting anything. An unauthorized
+	// user's token must never be written to disk or wired in as the hive's user
+	// client — otherwise a rejected login would still leak its token into the
+	// shared client and become the hive's identity.
+	user, err := github.ValidateToken(token, s.deps.Config.GitHub.ResolvedAPIURL())
+	if err != nil || user == nil || user.Login == "" {
+		s.deviceFlowState = nil
+		jsonResponse(w, map[string]interface{}{"status": "error", "error": "could not verify GitHub identity"})
 		return
 	}
-	if err := os.Rename(tmpTokenPath, userTokenPath); err != nil {
-		jsonError(w, "failed to persist token: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	user, _ := github.ValidateToken(token, s.deps.Config.GitHub.ResolvedAPIURL())
 	s.deviceFlowState = nil
-	username := ""
-	avatarURL := ""
-	if user != nil {
-		username = user.Login
-		avatarURL = user.AvatarURL
-	}
-	s.deps.Logger.Info("GitHub user authenticated via device flow", "username", username)
+	username := user.Login
+	avatarURL := user.AvatarURL
 
-	if s.deps.SetUserClient != nil {
-		s.deps.SetUserClient(token)
+	// Per-hive authorization: on a direct-route spoke, only GitHub users on the
+	// configured allowlist may obtain a session. The hub-proxied path is gated
+	// upstream by nginx and leaves the allowlist empty, so it is unaffected.
+	role := config.RoleOwner
+	if s.directRouteAuthzEnabled() {
+		resolvedRole, ok := s.deps.Config.Dashboard.AuthorizedRole(username)
+		if !ok {
+			// Do NOT persist the token, do NOT set a session, do NOT log the
+			// user in. Reject before any state is written.
+			s.deps.Logger.Warn("device-flow login rejected: user not authorized for this hive", "username", username)
+			s.auditFromRequest(r, "gh_auth_denied", auditDetail("username", username), "")
+			jsonError(w, "your GitHub account is not authorized to access this hive. Contact the hive owner to request access.", http.StatusForbidden)
+			return
+		}
+		role = resolvedRole
 	}
 
+	// The persisted token and the hive's shared user GitHub client represent the
+	// hive's WRITE identity (advisory posting, autonomous actions). Only the
+	// owner (read-write) may set them; a read-only viewer logging in must never
+	// clobber the owner's token/client with their own identity. Viewers still
+	// get a per-user session below, they just don't become the hive's actor.
+	if role == config.RoleOwner {
+		tmpTokenPath := userTokenPath + ".tmp"
+		if err := os.WriteFile(tmpTokenPath, []byte(token), 0o600); err != nil {
+			jsonError(w, "failed to save token: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if err := os.Rename(tmpTokenPath, userTokenPath); err != nil {
+			jsonError(w, "failed to persist token: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if s.deps.SetUserClient != nil {
+			s.deps.SetUserClient(token)
+		}
+	}
+
+	s.deps.Logger.Info("GitHub user authenticated via device flow", "username", username, "role", role)
+
+	// Issue a per-user session (opaque random id → username+role) instead of a
+	// single shared cookie. Each authenticated user gets their own session so
+	// requests resolve to the user that owns their cookie — never a shared one.
 	if s.authToken != "" {
-		http.SetCookie(w, &http.Cookie{
-			Name:     sessionCookieName,
-			Value:    s.authToken,
-			Path:     "/",
-			MaxAge:   sessionCookieMaxAge,
-			HttpOnly: true,
-			Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
-			SameSite: http.SameSiteLaxMode,
-		})
+		sid := s.createUserSession(username, role)
+		if sid == "" {
+			jsonError(w, "failed to create session", http.StatusInternalServerError)
+			return
+		}
+		setSessionCookie(w, r, sid)
 	}
 
 	s.auditFromRequest(r, "gh_auth_complete", auditDetail("username", username), "")
@@ -1372,39 +1422,38 @@ func (s *Server) handleGHUserAuthPoll(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGHUserAuthLogout(w http.ResponseWriter, r *http.Request) {
-	os.Remove(userTokenPath)
-	http.SetCookie(w, &http.Cookie{
-		Name:     sessionCookieName,
-		Value:    "",
-		Path:     "/",
-		MaxAge:   -1,
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-	})
+	// Clear only THIS request's session so logging out affects one user, not
+	// everyone. Removing the disk token only makes sense when the logging-out
+	// user is the one whose token is persisted (the owner/last-authenticated
+	// user); on a direct-route spoke a read-only viewer logging out must not
+	// wipe the owner's persisted token.
+	var loggedOut, loggedOutRole string
+	if c, err := r.Cookie(sessionCookieName); err == nil && c.Value != "" {
+		if sess := s.lookupSession(c.Value); sess != nil {
+			loggedOut = sess.Username
+			loggedOutRole = sess.Role
+		}
+		s.deleteSession(c.Value)
+	}
+	// Only clear the persisted GitHub token when the logging-out user is the
+	// owner (read-write). Use the role bound to the session at login time — not
+	// a fresh config lookup — so a later allowlist change can't leave a
+	// logging-out owner's own token stranded on disk. Viewer logouts leave the
+	// hive's user client intact.
+	if !s.directRouteAuthzEnabled() || loggedOutRole == config.RoleOwner {
+		os.Remove(userTokenPath)
+	}
+	clearSessionCookie(w)
 	s.auditFromRequest(r, "gh_auth_logout", "", "")
-	s.deps.Logger.Info("GitHub user logged out")
+	s.deps.Logger.Info("GitHub user logged out", "username", loggedOut)
 	jsonResponse(w, map[string]interface{}{"status": "logged_out"})
 }
 
 func (s *Server) handleGHUserAuthSession(w http.ResponseWriter, r *http.Request) {
-	if s.authToken == "" {
-		http.Redirect(w, r, "/", http.StatusFound)
-		return
-	}
-	tokenData, err := os.ReadFile(userTokenPath)
-	if err != nil || strings.TrimSpace(string(tokenData)) == "" {
-		http.Redirect(w, r, "/", http.StatusFound)
-		return
-	}
-	http.SetCookie(w, &http.Cookie{
-		Name:     sessionCookieName,
-		Value:    s.authToken,
-		Path:     "/",
-		MaxAge:   sessionCookieMaxAge,
-		HttpOnly: true,
-		Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
-		SameSite: http.SameSiteLaxMode,
-	})
+	// This endpoint only lands the user on the dashboard after the device flow
+	// completed. The per-user session cookie was already set by the poll
+	// handler; we never mint a session here (doing so from a shared secret or a
+	// disk token file would grant any caller a valid session).
 	http.Redirect(w, r, "/", http.StatusFound)
 }
 
@@ -1592,10 +1641,10 @@ func (s *Server) handleAgentConfigGet(w http.ResponseWriter, r *http.Request) {
 			"aliases":         agentCfg.Aliases,
 			"cavemanMode":     agentCfg.CavemanMode,
 		},
-		"cadences": cadences,
-		"models":   models,
-		"pipeline": pipeline,
-		"hooks":    hooks,
+		"cadences":       cadences,
+		"models":         models,
+		"pipeline":       pipeline,
+		"hooks":          hooks,
 		"restrictions":   restrictions,
 		"stats":          stats,
 		"prompt":         lastPrompt,
@@ -2710,14 +2759,14 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 		},
 		"litellm": litellmSectionResponse(&cfg.Governor.LiteLLM),
 		"hub": map[string]interface{}{
-			"enabled":                  cfg.Hub.Enabled,
-			"url":                      cfg.Hub.URL,
-			"dashboard_url":            cfg.Hub.DashboardURL,
-			"snapshot_url":             cfg.Hub.SnapshotURL,
-			"is_public":               cfg.Hub.IsPublic,
-			"auto_snapshot":           cfg.Hub.AutoSnapshot,
-			"auto_upgrade":            cfg.Hub.AutoUpgrade,
-			"snapshot_interval_min":   cfg.Hub.SnapshotIntervalMin,
+			"enabled":                          cfg.Hub.Enabled,
+			"url":                              cfg.Hub.URL,
+			"dashboard_url":                    cfg.Hub.DashboardURL,
+			"snapshot_url":                     cfg.Hub.SnapshotURL,
+			"is_public":                        cfg.Hub.IsPublic,
+			"auto_snapshot":                    cfg.Hub.AutoSnapshot,
+			"auto_upgrade":                     cfg.Hub.AutoUpgrade,
+			"snapshot_interval_min":            cfg.Hub.SnapshotIntervalMin,
 			"contribute_suspended":             cfg.Hub.ContributeSuspended,
 			"contribute_allow_labels":          cfg.Hub.ContributeAllowLabels,
 			"contribute_deny_labels":           cfg.Hub.ContributeDenyLabels,
@@ -2805,7 +2854,9 @@ func (s *Server) handleGovernorSensing(w http.ResponseWriter, r *http.Request) {
 		s.deps.Config.Governor.Sensing.PullbackSeconds = body.PullbackSeconds
 	}
 
-	if err := s.saveConfig(); err != nil { s.logger.Error("failed to persist config", "error", err) }
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config", "error", err)
+	}
 	s.auditFromRequest(r, "config_governor_sensing", auditDetail("section", "sensing"), "")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})
@@ -2916,7 +2967,9 @@ func (s *Server) handleGovernorBudget(w http.ResponseWriter, r *http.Request) {
 		s.deps.Config.Governor.Budget.CriticalPct = body.CriticalPct
 	}
 
-	if err := s.saveConfig(); err != nil { s.logger.Error("failed to persist config after budget update", "error", err) }
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after budget update", "error", err)
+	}
 	s.auditFromRequest(r, "config_governor_budget", auditDetail("section", "budget"), "")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})
@@ -2959,7 +3012,9 @@ func (s *Server) handleGovernorNotifications(w http.ResponseWriter, r *http.Requ
 		}
 		s.deps.Config.Notifications.Discord.Webhook = body.DiscordWebhook
 	}
-	if err := s.saveConfig(); err != nil { s.logger.Error("failed to persist config after notification update", "error", err) }
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after notification update", "error", err)
+	}
 	s.auditFromRequest(r, "config_governor_notifications", auditDetail("section", "notifications"), "")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})
@@ -2989,7 +3044,9 @@ func (s *Server) handleGovernorHealth(w http.ResponseWriter, r *http.Request) {
 	if body.ModelLock != nil {
 		s.deps.Config.Governor.Health.ModelLock = *body.ModelLock
 	}
-	if err := s.saveConfig(); err != nil { s.logger.Error("failed to persist config after health update", "error", err) }
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after health update", "error", err)
+	}
 	s.auditFromRequest(r, "config_governor_health", auditDetail("section", "health"), "")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})
@@ -3033,7 +3090,9 @@ func (s *Server) handleGovernorLogging(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if err := s.saveConfig(); err != nil { s.logger.Error("failed to persist config after logging update", "error", err) }
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after logging update", "error", err)
+	}
 	s.auditFromRequest(r, "config_governor_logging", auditDetail("section", "logging"), "")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})
@@ -3041,22 +3100,22 @@ func (s *Server) handleGovernorLogging(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		Enabled                       *bool               `json:"enabled"`
-		URL                           string              `json:"url"`
-		DashboardURL                  string              `json:"dashboard_url"`
-		SnapshotURL                   string              `json:"snapshot_url"`
-		IsPublic                      *bool               `json:"is_public"`
-		AutoSnapshot                  *bool               `json:"auto_snapshot"`
-		AutoUpgrade                   *bool               `json:"auto_upgrade"`
-		ContributeSuspended           *bool               `json:"contribute_suspended"`
-		ContributeAllowLabels         []string            `json:"contribute_allow_labels"`
-		ContributeDenyLabels          []string            `json:"contribute_deny_labels"`
-		ContributeDenyTitles          []string            `json:"contribute_deny_titles"`
-		ContributeDenyAuthors         []string            `json:"contribute_deny_authors"`
-		ContributeAllowModels         []string            `json:"contribute_allow_models"`
-		ContributeRejectUnknownModels *bool               `json:"contribute_reject_unknown_models"`
-		DisabledRepos                 []string            `json:"disabled_repos"`
-		DisabledTiers                 []string            `json:"disabled_tiers"`
+		Enabled                       *bool                      `json:"enabled"`
+		URL                           string                     `json:"url"`
+		DashboardURL                  string                     `json:"dashboard_url"`
+		SnapshotURL                   string                     `json:"snapshot_url"`
+		IsPublic                      *bool                      `json:"is_public"`
+		AutoSnapshot                  *bool                      `json:"auto_snapshot"`
+		AutoUpgrade                   *bool                      `json:"auto_upgrade"`
+		ContributeSuspended           *bool                      `json:"contribute_suspended"`
+		ContributeAllowLabels         []string                   `json:"contribute_allow_labels"`
+		ContributeDenyLabels          []string                   `json:"contribute_deny_labels"`
+		ContributeDenyTitles          []string                   `json:"contribute_deny_titles"`
+		ContributeDenyAuthors         []string                   `json:"contribute_deny_authors"`
+		ContributeAllowModels         []string                   `json:"contribute_allow_models"`
+		ContributeRejectUnknownModels *bool                      `json:"contribute_reject_unknown_models"`
+		DisabledRepos                 []string                   `json:"disabled_repos"`
+		DisabledTiers                 []string                   `json:"disabled_tiers"`
 		TierLimits                    map[string]config.TierRate `json:"tier_limits"`
 	}
 	if err := decodeBody(r, &body); err != nil {
@@ -3461,7 +3520,9 @@ func (s *Server) handleGovernorAddAgent(w http.ResponseWriter, r *http.Request) 
 	}
 	s.deps.Config.Agents[body.Name] = agentCfg
 	s.deps.AgentMgr.AddAgent(body.Name, agentCfg)
-	if err := s.saveConfig(); err != nil { s.logger.Error("failed to persist config", "error", err) }
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config", "error", err)
+	}
 
 	s.auditFromRequest(r, "add_agent", auditDetail("backend", body.Backend, "model", body.Model), body.Name)
 	s.refreshAndPersist()
@@ -3556,7 +3617,9 @@ func (s *Server) handleGovernorRepos(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err := s.saveConfig(); err != nil { s.logger.Error("failed to persist config", "error", err) }
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config", "error", err)
+	}
 	if s.deps.EnumerateFunc != nil {
 		go s.deps.EnumerateFunc()
 	}
@@ -3575,10 +3638,10 @@ func (s *Server) handleGitHubAppInstallClicked(w http.ResponseWriter, r *http.Re
 
 func (s *Server) handleConfigGitHub(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		AppID          *int64  `json:"app_id"`
-		InstallationID *int64  `json:"installation_id"`
-		KeyFile        string  `json:"key_file"`
-		PrivateKey     string  `json:"private_key"`
+		AppID          *int64 `json:"app_id"`
+		InstallationID *int64 `json:"installation_id"`
+		KeyFile        string `json:"key_file"`
+		PrivateKey     string `json:"private_key"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
@@ -4049,20 +4112,20 @@ func (s *Server) handleKnowledgeExport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	typeLabels := map[string]string{
-		"pattern":        "Patterns",
-		"gotcha":         "Gotchas",
-		"decision":       "Decisions",
-		"regression":     "Regressions",
-		"test_scaffold":  "Test Scaffolds",
-		"integration":    "Integration",
-		"coverage_rule":  "Coverage Rules",
-		"idea":           "Ideas",
-		"vision":         "Vision",
-		"constitution":   "Constitution",
-		"requirement":    "Requirements",
-		"constraint":     "Constraints",
-		"stakeholder":    "Stakeholders",
-		"general":        "General",
+		"pattern":       "Patterns",
+		"gotcha":        "Gotchas",
+		"decision":      "Decisions",
+		"regression":    "Regressions",
+		"test_scaffold": "Test Scaffolds",
+		"integration":   "Integration",
+		"coverage_rule": "Coverage Rules",
+		"idea":          "Ideas",
+		"vision":        "Vision",
+		"constitution":  "Constitution",
+		"requirement":   "Requirements",
+		"constraint":    "Constraints",
+		"stakeholder":   "Stakeholders",
+		"general":       "General",
 	}
 
 	var sb strings.Builder
@@ -5321,6 +5384,15 @@ func maskSecret(s string) string {
 }
 
 func (s *Server) handleAuthToken(w http.ResponseWriter, r *http.Request) {
+	// On a direct-route spoke the shared token must never be handed to a
+	// browser: identity there is per-user (device-flow sessions), and the
+	// shared token no longer grants API access on that path (see authenticate).
+	// Exposing it publicly here would leak the internal server-to-server secret
+	// (used as X-Hive-Internal by the local proxy) to any visitor.
+	if s.directRouteAuthzEnabled() {
+		jsonError(w, "not available on this hive", http.StatusNotFound)
+		return
+	}
 	token := s.authToken
 	if token == "" {
 		token = os.Getenv("HIVE_DASHBOARD_TOKEN")
@@ -5507,4 +5579,3 @@ func (s *Server) handleBeadsCreate(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 	jsonResponse(w, b)
 }
-

--- a/v2/pkg/dashboard/coverage_boost3_test.go
+++ b/v2/pkg/dashboard/coverage_boost3_test.go
@@ -561,7 +561,9 @@ func TestSecurityHeaders_WithAuthToken(t *testing.T) {
 	srv := NewServer(0, logger)
 	srv.authToken = "secret-token"
 
-	handler := srv.securityHeaders(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Authentication now lives in the authenticate middleware (moved out of
+	// securityHeaders so it runs before roleEnforcement); test it there.
+	handler := srv.authenticate(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -823,7 +825,7 @@ func newFullServerWithAgents(t *testing.T) *Server {
 			Org: "testorg", Name: "test", PrimaryRepo: "testrepo",
 			Repos: []string{"testrepo"},
 		},
-		Data:   config.DataConfig{AgentsDir: t.TempDir()},
+		Data: config.DataConfig{AgentsDir: t.TempDir()},
 		Agents: map[string]config.AgentConfig{
 			"scanner":    {ID: "scan-001", Role: "scanner", Backend: "claude", Model: "sonnet", DisplayName: "Scanner", Enabled: true},
 			"reviewer":   {ID: "rev-001", Role: "reviewer", Backend: "claude", Model: "sonnet", DisplayName: "Reviewer", Enabled: true},
@@ -850,11 +852,11 @@ func newFullServerWithAgents(t *testing.T) *Server {
 
 	srv := NewServer(0, logger)
 	srv.deps = &Dependencies{
-		Config:   cfg,
-		AgentMgr: mgr,
-		Governor: gov,
-		Logger:   logger,
-		Ctx:      context.Background(),
+		Config:         cfg,
+		AgentMgr:       mgr,
+		Governor:       gov,
+		Logger:         logger,
+		Ctx:            context.Background(),
 		RefreshFunc:    func() {},
 		PersistFunc:    func() {},
 		SkipReloadFunc: func() {},

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -66,6 +66,13 @@ type Server struct {
 	deviceFlowMu    sync.Mutex
 	deviceFlowState *github.DeviceFlowState
 
+	// userSessions maps a random opaque session id (stored in the client's
+	// hive_session cookie on direct-route spokes) to the authenticated user.
+	// This replaces the previous single shared s.authToken cookie so two
+	// different people get two distinct sessions and each sees THEMSELVES.
+	sessionMu    sync.RWMutex
+	userSessions map[string]*userSession
+
 	claudeOAuthFlow claudeOAuthFlow
 
 	copilotAuthFlow copilotAuthFlow
@@ -85,12 +92,12 @@ type Server struct {
 	ready   bool
 	readyAt time.Time
 
-	githubAppMu                 sync.RWMutex
-	githubAppRequired           bool
-	githubAppInstallURL         string
-	githubAppPermIssue          string // non-empty when app is installed but lacks required permissions
-	pendingGitHubAppInstall     bool
-	pendingGitHubAppInstallAt   time.Time
+	githubAppMu               sync.RWMutex
+	githubAppRequired         bool
+	githubAppInstallURL       string
+	githubAppPermIssue        string // non-empty when app is installed but lacks required permissions
+	pendingGitHubAppInstall   bool
+	pendingGitHubAppInstallAt time.Time
 
 	systemAlertsMu sync.RWMutex
 	systemAlerts   []SystemAlert
@@ -103,32 +110,32 @@ type Server struct {
 
 // StatusPayload matches the JSON contract the dashboard frontend render() expects.
 type StatusPayload struct {
-	Timestamp     string              `json:"timestamp"`
-	HiveID        string              `json:"hiveId"`
-	Agents        []FrontendAgent     `json:"agents"`
-	Governor      FrontendGovernor    `json:"governor"`
-	Tokens        FrontendTokens      `json:"tokens"`
-	Repos         []FrontendRepo      `json:"repos"`
-	Beads         FrontendBeads       `json:"beads"`
-	Health        map[string]any      `json:"health"`
-	Budget        FrontendBudget      `json:"budget"`
-	CadenceMatrix []FrontendCadence   `json:"cadenceMatrix"`
-	GHRateLimits  map[string]any      `json:"ghRateLimits"`
-	AgentMetrics  map[string]any      `json:"agentMetrics"`
-	Hold          FrontendHold        `json:"hold"`
-	IssueToMerge  map[string]any      `json:"issueToMerge"`
-	ACMMLevel        int                 `json:"acmmLevel"`
-	ACMMPackAgents   []string            `json:"acmmPackAgents"`
-	AdvisoryDigest   any                 `json:"advisoryDigest,omitempty"`
-	ContributorPool    *ContributorPoolStatus `json:"contributorPool,omitempty"`
-	SystemResources     *SystemResources    `json:"systemResources,omitempty"`
-	GitHubAppRequired   bool               `json:"githubAppRequired,omitempty"`
-	GitHubAppInstallURL string             `json:"githubAppInstallURL,omitempty"`
-	GitHubAppPermIssue  string             `json:"githubAppPermIssue,omitempty"`
-	GitHubBaseURL       string             `json:"githubBaseURL,omitempty"`
-	InferenceBackends   []InferenceBackend `json:"inferenceBackends,omitempty"`
-	SystemAlerts        []SystemAlert      `json:"systemAlerts,omitempty"`
-	HubBanner           *HubBannerState    `json:"hubBanner,omitempty"`
+	Timestamp           string                 `json:"timestamp"`
+	HiveID              string                 `json:"hiveId"`
+	Agents              []FrontendAgent        `json:"agents"`
+	Governor            FrontendGovernor       `json:"governor"`
+	Tokens              FrontendTokens         `json:"tokens"`
+	Repos               []FrontendRepo         `json:"repos"`
+	Beads               FrontendBeads          `json:"beads"`
+	Health              map[string]any         `json:"health"`
+	Budget              FrontendBudget         `json:"budget"`
+	CadenceMatrix       []FrontendCadence      `json:"cadenceMatrix"`
+	GHRateLimits        map[string]any         `json:"ghRateLimits"`
+	AgentMetrics        map[string]any         `json:"agentMetrics"`
+	Hold                FrontendHold           `json:"hold"`
+	IssueToMerge        map[string]any         `json:"issueToMerge"`
+	ACMMLevel           int                    `json:"acmmLevel"`
+	ACMMPackAgents      []string               `json:"acmmPackAgents"`
+	AdvisoryDigest      any                    `json:"advisoryDigest,omitempty"`
+	ContributorPool     *ContributorPoolStatus `json:"contributorPool,omitempty"`
+	SystemResources     *SystemResources       `json:"systemResources,omitempty"`
+	GitHubAppRequired   bool                   `json:"githubAppRequired,omitempty"`
+	GitHubAppInstallURL string                 `json:"githubAppInstallURL,omitempty"`
+	GitHubAppPermIssue  string                 `json:"githubAppPermIssue,omitempty"`
+	GitHubBaseURL       string                 `json:"githubBaseURL,omitempty"`
+	InferenceBackends   []InferenceBackend     `json:"inferenceBackends,omitempty"`
+	SystemAlerts        []SystemAlert          `json:"systemAlerts,omitempty"`
+	HubBanner           *HubBannerState        `json:"hubBanner,omitempty"`
 }
 
 // HubBannerState is a banner message from the hub admin displayed on spoke dashboards.
@@ -209,12 +216,12 @@ type FrontendAgent struct {
 }
 
 type FrontendGovernor struct {
-	Active     bool                    `json:"active"`
-	Mode       string                  `json:"mode"`
-	Issues     int                     `json:"issues"`
-	PRs        int                     `json:"prs"`
-	Thresholds FrontendThresholds      `json:"thresholds"`
-	NextKick   string                  `json:"nextKick,omitempty"`
+	Active     bool               `json:"active"`
+	Mode       string             `json:"mode"`
+	Issues     int                `json:"issues"`
+	PRs        int                `json:"prs"`
+	Thresholds FrontendThresholds `json:"thresholds"`
+	NextKick   string             `json:"nextKick,omitempty"`
 }
 
 type FrontendThresholds struct {
@@ -224,11 +231,11 @@ type FrontendThresholds struct {
 }
 
 type FrontendTokens struct {
-	LookbackHours  int                            `json:"lookbackHours"`
-	Sessions       []FrontendSession              `json:"sessions"`
-	Totals         FrontendTokenTotals             `json:"totals"`
-	ByAgent        map[string]FrontendTokenBucket  `json:"byAgent"`
-	ByModel        map[string]FrontendTokenBucket  `json:"byModel"`
+	LookbackHours int                            `json:"lookbackHours"`
+	Sessions      []FrontendSession              `json:"sessions"`
+	Totals        FrontendTokenTotals            `json:"totals"`
+	ByAgent       map[string]FrontendTokenBucket `json:"byAgent"`
+	ByModel       map[string]FrontendTokenBucket `json:"byModel"`
 }
 
 type FrontendTokenTotals struct {
@@ -262,12 +269,12 @@ type FrontendSession struct {
 }
 
 type FrontendRepo struct {
-	Name             string        `json:"name"`
-	Full             string        `json:"full"`
-	Issues           int           `json:"issues"`
-	PRs              int           `json:"prs"`
-	ActionableIssues []any         `json:"actionableIssues"`
-	OpenPrs          []any         `json:"openPrs"`
+	Name             string `json:"name"`
+	Full             string `json:"full"`
+	Issues           int    `json:"issues"`
+	PRs              int    `json:"prs"`
+	ActionableIssues []any  `json:"actionableIssues"`
+	OpenPrs          []any  `json:"openPrs"`
 }
 
 type FrontendBeads struct {
@@ -313,14 +320,14 @@ type FrontendHold struct {
 // TokenSparklineEntry is a single timestamped snapshot of token metrics,
 // persisted to disk so sparklines survive container restarts.
 type TokenSparklineEntry struct {
-	Timestamp    int64                       `json:"t"`
-	Input        int64                       `json:"tokenInput"`
-	Output       int64                       `json:"tokenOutput"`
-	CacheRead    int64                       `json:"tokenCacheRead"`
-	CacheCreate  int64                       `json:"tokenCacheCreate"`
-	Messages     int                         `json:"tokenMessages"`
-	ByAgent      map[string]int64            `json:"tokens,omitempty"`
-	ByModel      map[string]int64            `json:"tokenModels,omitempty"`
+	Timestamp   int64            `json:"t"`
+	Input       int64            `json:"tokenInput"`
+	Output      int64            `json:"tokenOutput"`
+	CacheRead   int64            `json:"tokenCacheRead"`
+	CacheCreate int64            `json:"tokenCacheCreate"`
+	Messages    int              `json:"tokenMessages"`
+	ByAgent     map[string]int64 `json:"tokens,omitempty"`
+	ByModel     map[string]int64 `json:"tokenModels,omitempty"`
 }
 
 // tokenSparklineMaxEntries caps the on-disk history to ~24h at 5-min intervals.
@@ -349,6 +356,7 @@ func NewServer(port int, logger *slog.Logger) *Server {
 		agentPipelines: make(map[string]map[string]bool),
 		agentHooks:     make(map[string]map[string][]any),
 		audit:          newAuditLog(),
+		userSessions:   make(map[string]*userSession),
 	}
 	s.registerCoreRoutes()
 	return s
@@ -364,6 +372,7 @@ func NewServerWithAuth(port int, authToken string, logger *slog.Logger) *Server 
 		agentPipelines: make(map[string]map[string]bool),
 		agentHooks:     make(map[string]map[string][]any),
 		audit:          newAuditLog(),
+		userSessions:   make(map[string]*userSession),
 	}
 	s.registerCoreRoutes()
 	return s
@@ -448,7 +457,9 @@ func (s *Server) Start() error {
 	}
 	s.mux.Handle("GET /", http.FileServer(http.FS(staticContent)))
 
-	handler := s.roleEnforcement(s.securityHeaders(s.mux))
+	// authenticate is outermost so the identity headers it injects from a
+	// per-user session are visible to roleEnforcement's read-only write-gate.
+	handler := s.authenticate(s.roleEnforcement(s.securityHeaders(s.mux)))
 
 	const dashboardReadTimeout = 30 * time.Second
 	const dashboardIdleTimeout = 120 * time.Second
@@ -471,42 +482,101 @@ func (s *Server) securityHeaders(next http.Handler) http.Handler {
 		w.Header().Set("Content-Security-Policy",
 			"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws: wss:; object-src 'none'; base-uri 'self'; frame-ancestors 'none'")
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+		next.ServeHTTP(w, r)
+	})
+}
 
-		if s.authToken != "" && !isPublicPath(r.URL.Path) {
-			trusted := secureCompare(r.Header.Get("X-Hive-Internal"), s.authToken)
-			if !trusted && r.Header.Get("X-Hive-User") != "" && r.Header.Get("X-Hive-Role") != "" {
-				// Trust nginx auth-url proxied requests that have both user
-				// and role headers (set by the hub's auth endpoint). Requiring
-				// both headers prevents trivial bypass via a single forged header.
+// authenticate resolves the caller's identity and enforces authentication. It
+// runs OUTERMOST — before roleEnforcement — so that the X-Hive-User/X-Hive-Role
+// it injects from a per-user session are visible to roleEnforcement's read-only
+// write-gate. (If this ran inside roleEnforcement, roleEnforcement would read an
+// empty role and never block a read-only viewer's writes.)
+func (s *Server) authenticate(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.authToken == "" || isPublicPath(r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		directRouteAuthz := s.directRouteAuthzEnabled()
+
+		// On a direct-route spoke (per-hive allowlist present) we MUST NOT trust
+		// client-supplied X-Hive-User/X-Hive-Role: there is no hub nginx in
+		// front to strip forged identity headers. Strip them here so identity
+		// can only come from a server-side session we minted.
+		if directRouteAuthz {
+			r.Header.Del("X-Hive-User")
+			r.Header.Del("X-Hive-Role")
+		}
+
+		// Internal automation authenticates with the shared token via the
+		// X-Hive-Internal header; this is a trusted server-to-server path
+		// (the local proxy injects it) and carries no browser user identity.
+		trusted := secureCompare(r.Header.Get("X-Hive-Internal"), s.authToken)
+
+		// Hub-proxied path: nginx injects both headers from the hub's
+		// per-user/per-hive auth-check. Only trust them when this spoke is NOT a
+		// direct-route spoke (see strip above). Requiring both headers prevents
+		// trivial bypass via a single forged header.
+		if !trusted && !directRouteAuthz &&
+			r.Header.Get("X-Hive-User") != "" && r.Header.Get("X-Hive-Role") != "" {
+			trusted = true
+		}
+
+		// Per-user session path (device flow): resolve the session id in the
+		// hive_session cookie to THIS request's user and inject that user's
+		// identity. Two different people therefore get two different sessions
+		// and each sees themselves — no shared identity.
+		if !trusted {
+			if sess := s.sessionFromRequest(r); sess != nil {
+				r.Header.Set("X-Hive-User", sess.Username)
+				r.Header.Set("X-Hive-Role", sess.Role)
 				trusted = true
 			}
-			if !trusted {
-				token := r.Header.Get("Authorization")
-				if token == "" {
-					token = r.URL.Query().Get("token")
-				}
-				if token == "" {
-					if c, err := r.Cookie(sessionCookieName); err == nil {
-						token = c.Value
-					}
-				}
-				expected := "Bearer " + s.authToken
-				if !secureCompare(token, expected) && !secureCompare(token, s.authToken) {
-					if strings.HasPrefix(r.URL.Path, "/api/") {
-						w.Header().Set("Content-Type", "application/json")
-						http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
-					} else {
-						w.Header().Set("Content-Type", "text/html; charset=utf-8")
-						w.WriteHeader(http.StatusUnauthorized)
-						w.Write([]byte(loginPage))
-					}
-					return
-				}
+		}
+
+		// Bearer/query shared-token path for programmatic API clients. This is
+		// an internal credential, not a browser session, so it is only accepted
+		// from the Authorization header or ?token= — never from the session
+		// cookie. On a direct-route spoke it is DISABLED: the shared token grants
+		// no per-user identity, so accepting it would let any holder act as an
+		// unscoped owner and defeat the per-hive allowlist. Direct-route callers
+		// must use a per-user session instead.
+		if !trusted && !directRouteAuthz {
+			token := r.Header.Get("Authorization")
+			if token == "" {
+				token = r.URL.Query().Get("token")
 			}
+			expected := "Bearer " + s.authToken
+			if secureCompare(token, expected) || secureCompare(token, s.authToken) {
+				trusted = true
+			}
+		}
+
+		if !trusted {
+			if strings.HasPrefix(r.URL.Path, "/api/") {
+				w.Header().Set("Content-Type", "application/json")
+				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+			} else {
+				w.Header().Set("Content-Type", "text/html; charset=utf-8")
+				w.WriteHeader(http.StatusUnauthorized)
+				w.Write([]byte(loginPage))
+			}
+			return
 		}
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+// directRouteAuthzEnabled reports whether this spoke enforces per-user
+// authorization on device-flow logins (a per-hive authorized-users allowlist is
+// configured). When true the spoke is reached directly (no hub nginx), so
+// client-supplied identity headers are untrusted and identity comes only from a
+// server-side session.
+func (s *Server) directRouteAuthzEnabled() bool {
+	return s.deps != nil && s.deps.Config != nil &&
+		s.deps.Config.Dashboard.IsDirectRouteAuthzEnabled()
 }
 
 // isPublicPath returns true for paths that should be accessible without
@@ -640,7 +710,7 @@ async function poll(interval){
 </script></body></html>`
 
 func (s *Server) Handler() http.Handler {
-	return s.roleEnforcement(s.securityHeaders(s.mux))
+	return s.authenticate(s.roleEnforcement(s.securityHeaders(s.mux)))
 }
 
 func (s *Server) roleEnforcement(next http.Handler) http.Handler {
@@ -979,7 +1049,7 @@ func (s *Server) handleHealthDeep(w http.ResponseWriter, r *http.Request) {
 	if s.contributeHub != nil {
 		active := s.contributeHub.ActiveCount()
 		checks["contribute"] = map[string]any{
-			"status":             "pass",
+			"status":              "pass",
 			"active_contributors": active,
 		}
 	}
@@ -1045,9 +1115,9 @@ func (s *Server) handleHealthDeep(w http.ResponseWriter, r *http.Request) {
 		}
 		if len(stalled) > 0 {
 			checks["stall_detection"] = map[string]any{
-				"status":  "warn",
-				"detail":  "agents kicked but no output for 30+ min",
-				"agents":  stalled,
+				"status": "warn",
+				"detail": "agents kicked but no output for 30+ min",
+				"agents": stalled,
 			}
 			if overall == "ok" {
 				overall = "degraded"

--- a/v2/pkg/dashboard/session.go
+++ b/v2/pkg/dashboard/session.go
@@ -1,0 +1,134 @@
+package dashboard
+
+import (
+	crand "crypto/rand"
+	"encoding/hex"
+	"net/http"
+	"time"
+)
+
+// userSession is a per-user server-side session created after a successful,
+// AUTHORIZED device-flow login on a direct-route spoke. Sessions are keyed by a
+// random opaque id held in the client's hive_session cookie, so two different
+// GitHub users get two distinct sessions and each request resolves to the user
+// that owns ITS cookie — never a single shared identity.
+//
+// The GitHub OAuth token is intentionally NOT stored on the session; the token
+// lives only where it is needed (SetUserClient / userTokenPath) and is never
+// exposed through the session. The session carries only identity + role.
+type userSession struct {
+	Username  string
+	Role      string
+	ExpiresAt time.Time
+}
+
+// sessionIDBytes is the entropy of an opaque session id. 32 bytes (256 bits) is
+// well beyond guessing range and matches the dashboard auth token strength.
+const sessionIDBytes = 32
+
+// sessionTTL bounds how long a device-flow session remains valid before the
+// user must re-authenticate. It mirrors the cookie MaxAge.
+const sessionTTL = time.Duration(sessionCookieMaxAge) * time.Second
+
+// newSessionID returns a cryptographically-random opaque session id, or empty
+// string if the system RNG fails (the caller must treat that as an error and
+// refuse to create a session rather than fall back to a predictable value).
+func newSessionID() string {
+	b := make([]byte, sessionIDBytes)
+	if _, err := crand.Read(b); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(b)
+}
+
+// createUserSession registers a new per-user session and returns its opaque id.
+// Returns "" if a secure id could not be generated.
+func (s *Server) createUserSession(username, role string) string {
+	id := newSessionID()
+	if id == "" {
+		return ""
+	}
+	now := time.Now()
+	s.sessionMu.Lock()
+	// Opportunistically reap expired sessions so abandoned logins (browser
+	// closed without logout) don't accumulate forever. lookupSession only
+	// evicts on access, so a login-time sweep bounds the map to live sessions.
+	for k, sess := range s.userSessions {
+		if now.After(sess.ExpiresAt) {
+			delete(s.userSessions, k)
+		}
+	}
+	s.userSessions[id] = &userSession{
+		Username:  username,
+		Role:      role,
+		ExpiresAt: now.Add(sessionTTL),
+	}
+	s.sessionMu.Unlock()
+	return id
+}
+
+// lookupSession resolves a session id to its user session, dropping and
+// rejecting expired sessions. Returns nil if unknown or expired.
+func (s *Server) lookupSession(id string) *userSession {
+	if id == "" {
+		return nil
+	}
+	s.sessionMu.RLock()
+	sess, ok := s.userSessions[id]
+	s.sessionMu.RUnlock()
+	if !ok {
+		return nil
+	}
+	if time.Now().After(sess.ExpiresAt) {
+		s.sessionMu.Lock()
+		delete(s.userSessions, id)
+		s.sessionMu.Unlock()
+		return nil
+	}
+	return sess
+}
+
+// deleteSession removes a single session (logout affects only that session).
+func (s *Server) deleteSession(id string) {
+	if id == "" {
+		return
+	}
+	s.sessionMu.Lock()
+	delete(s.userSessions, id)
+	s.sessionMu.Unlock()
+}
+
+// sessionFromRequest resolves the current request's per-user session from its
+// hive_session cookie, if any. Returns nil when there is no valid session.
+func (s *Server) sessionFromRequest(r *http.Request) *userSession {
+	c, err := r.Cookie(sessionCookieName)
+	if err != nil || c.Value == "" {
+		return nil
+	}
+	return s.lookupSession(c.Value)
+}
+
+// setSessionCookie writes the per-user session cookie for the given id.
+func setSessionCookie(w http.ResponseWriter, r *http.Request, id string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    id,
+		Path:     "/",
+		MaxAge:   sessionCookieMaxAge,
+		HttpOnly: true,
+		Secure:   r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https",
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// clearSessionCookie expires the per-user session cookie on the client.
+func clearSessionCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}

--- a/v2/pkg/dashboard/spoke_authz_test.go
+++ b/v2/pkg/dashboard/spoke_authz_test.go
@@ -1,0 +1,350 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// --- config.AuthorizedRole ---
+
+func TestAuthorizedRole_OwnerFirstEntryIsWrite(t *testing.T) {
+	d := config.DashboardConfig{AuthorizedUsers: []string{"clubanderson", "kellyaa"}}
+	role, ok := d.AuthorizedRole("clubanderson")
+	if !ok || role != config.RoleOwner {
+		t.Fatalf("expected owner for first entry, got role=%q ok=%v", role, ok)
+	}
+}
+
+func TestAuthorizedRole_NonOwnerDefaultsToRead(t *testing.T) {
+	d := config.DashboardConfig{AuthorizedUsers: []string{"clubanderson", "kellyaa"}}
+	role, ok := d.AuthorizedRole("kellyaa")
+	if !ok || role != config.RoleRead {
+		t.Fatalf("expected read for non-first entry, got role=%q ok=%v", role, ok)
+	}
+}
+
+func TestAuthorizedRole_CaseInsensitive(t *testing.T) {
+	d := config.DashboardConfig{AuthorizedUsers: []string{"ClubAnderson"}}
+	if role, ok := d.AuthorizedRole("clubanderson"); !ok || role != config.RoleOwner {
+		t.Fatalf("expected case-insensitive owner match, got role=%q ok=%v", role, ok)
+	}
+}
+
+func TestAuthorizedRole_ExplicitRoleSuffix(t *testing.T) {
+	d := config.DashboardConfig{AuthorizedUsers: []string{"owneruser:owner", "vieweruser:read"}}
+	if role, ok := d.AuthorizedRole("vieweruser"); !ok || role != config.RoleRead {
+		t.Fatalf("expected explicit read role, got role=%q ok=%v", role, ok)
+	}
+	if role, ok := d.AuthorizedRole("owneruser"); !ok || role != config.RoleOwner {
+		t.Fatalf("expected explicit owner role, got role=%q ok=%v", role, ok)
+	}
+}
+
+func TestAuthorizedRole_UnauthorizedUserRejected(t *testing.T) {
+	d := config.DashboardConfig{AuthorizedUsers: []string{"clubanderson"}}
+	if _, ok := d.AuthorizedRole("attacker"); ok {
+		t.Fatal("unauthorized user must not resolve to a role")
+	}
+}
+
+func TestAuthorizedRole_EmptyListNotEnabled(t *testing.T) {
+	d := config.DashboardConfig{}
+	if d.IsDirectRouteAuthzEnabled() {
+		t.Fatal("empty allowlist must not enable direct-route authz")
+	}
+	if _, ok := d.AuthorizedRole("anyone"); ok {
+		t.Fatal("empty allowlist must authorize nobody")
+	}
+}
+
+// --- per-user session store ---
+
+func TestUserSession_DistinctPerUser(t *testing.T) {
+	s := &Server{userSessions: map[string]*userSession{}}
+	idA := s.createUserSession("alice", config.RoleOwner)
+	idB := s.createUserSession("bob", config.RoleRead)
+	if idA == "" || idB == "" || idA == idB {
+		t.Fatalf("expected two distinct non-empty session ids, got %q and %q", idA, idB)
+	}
+	a := s.lookupSession(idA)
+	b := s.lookupSession(idB)
+	if a == nil || a.Username != "alice" || a.Role != config.RoleOwner {
+		t.Fatalf("session A resolved wrong user: %+v", a)
+	}
+	if b == nil || b.Username != "bob" || b.Role != config.RoleRead {
+		t.Fatalf("session B resolved wrong user: %+v", b)
+	}
+}
+
+func TestUserSession_LogoutClearsOnlyThatSession(t *testing.T) {
+	s := &Server{userSessions: map[string]*userSession{}}
+	idA := s.createUserSession("alice", config.RoleOwner)
+	idB := s.createUserSession("bob", config.RoleRead)
+	s.deleteSession(idA)
+	if s.lookupSession(idA) != nil {
+		t.Fatal("deleted session must not resolve")
+	}
+	if s.lookupSession(idB) == nil {
+		t.Fatal("other user's session must survive logout")
+	}
+}
+
+func TestUserSession_UnknownIDResolvesNil(t *testing.T) {
+	s := &Server{userSessions: map[string]*userSession{}}
+	if s.lookupSession("does-not-exist") != nil {
+		t.Fatal("unknown session id must resolve to nil")
+	}
+}
+
+// --- middleware: direct-route strips forged identity headers ---
+
+func newDirectRouteServer(t *testing.T, authorized ...string) *Server {
+	t.Helper()
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	s.deps.Config.Dashboard.AuthorizedUsers = authorized
+	return s
+}
+
+// okHandler is a terminal handler that records the identity headers it sees.
+func recordingHandler(sawUser, sawRole *string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if sawUser != nil {
+			*sawUser = r.Header.Get("X-Hive-User")
+		}
+		if sawRole != nil {
+			*sawRole = r.Header.Get("X-Hive-Role")
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestMiddleware_DirectRouteStripsForgedHeaders(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson")
+	var sawUser string
+	handler := s.authenticate(recordingHandler(&sawUser, nil))
+	req := httptest.NewRequest("GET", "/api/config", nil)
+	req.Header.Set("X-Hive-User", "kellyaa")
+	req.Header.Set("X-Hive-Role", "owner")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	// No valid session/token → request must be rejected, not trusted.
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("forged headers on direct route must be unauthorized, got %d", w.Code)
+	}
+	if sawUser != "" {
+		t.Errorf("forged X-Hive-User must not reach the handler: %q", sawUser)
+	}
+}
+
+func TestMiddleware_DirectRouteSessionResolvesUser(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson")
+	sid := s.createUserSession("clubanderson", config.RoleOwner)
+	var sawUser, sawRole string
+	handler := s.authenticate(recordingHandler(&sawUser, &sawRole))
+	req := httptest.NewRequest("GET", "/api/config", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("valid session must be authorized, got %d", w.Code)
+	}
+	if sawUser != "clubanderson" || sawRole != config.RoleOwner {
+		t.Fatalf("session must inject its own identity, got user=%q role=%q", sawUser, sawRole)
+	}
+}
+
+func TestMiddleware_HubProxiedHeadersStillTrusted(t *testing.T) {
+	// Empty allowlist = hub-proxied hive; nginx-injected headers must still work.
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	var sawUser string
+	handler := s.authenticate(recordingHandler(&sawUser, nil))
+	req := httptest.NewRequest("GET", "/api/config", nil)
+	req.Header.Set("X-Hive-User", "clubanderson")
+	req.Header.Set("X-Hive-Role", "owner")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("hub-proxied request must be authorized, got %d", w.Code)
+	}
+	if sawUser != "clubanderson" {
+		t.Errorf("hub-proxied identity must be preserved, got %q", sawUser)
+	}
+}
+
+func TestMiddleware_SharedCookieNoLongerAuthenticates(t *testing.T) {
+	// The old vulnerability: the shared s.authToken placed in the session cookie
+	// granted access. It must no longer be accepted as a session id.
+	s := newDirectRouteServer(t, "clubanderson")
+	handler := s.authenticate(recordingHandler(nil, nil))
+	req := httptest.NewRequest("GET", "/api/config", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: s.authToken})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code == http.StatusOK {
+		t.Fatal("shared auth token in session cookie must NOT authenticate")
+	}
+}
+
+func TestMiddleware_BearerTokenDisabledOnDirectRoute(t *testing.T) {
+	// The shared token is publicly discoverable and carries no per-user
+	// identity; it must NOT grant access on a direct-route spoke, else it
+	// defeats the per-hive allowlist.
+	s := newDirectRouteServer(t, "clubanderson")
+	handler := s.authenticate(recordingHandler(nil, nil))
+	req := httptest.NewRequest("GET", "/api/config", nil)
+	req.Header.Set("Authorization", "Bearer "+s.authToken)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code == http.StatusOK {
+		t.Fatal("shared bearer token must NOT authenticate on a direct-route spoke")
+	}
+}
+
+func TestMiddleware_BearerTokenWorksWhenNoAllowlist(t *testing.T) {
+	// Self-hosted single-user path (no allowlist): the shared bearer token is
+	// how the browser fetch wrapper authenticates and must still work.
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	handler := s.authenticate(recordingHandler(nil, nil))
+	req := httptest.NewRequest("GET", "/api/config", nil)
+	req.Header.Set("Authorization", "Bearer "+s.authToken)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("bearer shared-token API access must still work without allowlist, got %d", w.Code)
+	}
+}
+
+func TestMiddleware_InternalHeaderTrustedOnDirectRoute(t *testing.T) {
+	// The local proxy authenticates server-to-server with X-Hive-Internal; this
+	// must still work even on a direct-route spoke.
+	s := newDirectRouteServer(t, "clubanderson")
+	handler := s.authenticate(recordingHandler(nil, nil))
+	req := httptest.NewRequest("GET", "/api/config", nil)
+	req.Header.Set("X-Hive-Internal", s.authToken)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("X-Hive-Internal must authenticate on a direct-route spoke, got %d", w.Code)
+	}
+}
+
+// TestFullChain_ReadViewerCannotWrite exercises the REAL middleware order
+// (authenticate → roleEnforcement) to prove a read-only session is blocked on a
+// mutating request. If authenticate ran INSIDE roleEnforcement, roleEnforcement
+// would read an empty role and let the write through.
+func TestFullChain_ReadViewerCannotWrite(t *testing.T) {
+	s := newDirectRouteServer(t, "owneruser", "vieweruser:read")
+	sid := s.createUserSession("vieweruser", config.RoleRead)
+
+	reached := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := s.authenticate(s.roleEnforcement(inner))
+
+	req := httptest.NewRequest("POST", "/api/pause/scanner", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("read-only viewer POST must be 403, got %d", w.Code)
+	}
+	if reached {
+		t.Fatal("read-only viewer's write reached the handler — read-only gate bypassed")
+	}
+}
+
+func TestFullChain_OwnerCanWrite(t *testing.T) {
+	s := newDirectRouteServer(t, "owneruser")
+	sid := s.createUserSession("owneruser", config.RoleOwner)
+
+	reached := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := s.authenticate(s.roleEnforcement(inner))
+
+	req := httptest.NewRequest("POST", "/api/pause/scanner", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if !reached || w.Code != http.StatusOK {
+		t.Fatalf("owner POST must reach handler with 200, got code=%d reached=%v", w.Code, reached)
+	}
+}
+
+// --- status endpoint reflects the CURRENT session, not the persisted token ---
+
+func TestHandleGHUserAuthStatus_DirectRouteNoSessionIsLoggedOut(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson")
+	req := httptest.NewRequest("GET", "/api/gh-user-auth/status", nil)
+	w := httptest.NewRecorder()
+	s.handleGHUserAuthStatus(w, req)
+	if got := w.Body.String(); !strings.Contains(got, `"logged_in":false`) {
+		t.Fatalf("direct-route status without session must be logged_in:false, got %s", got)
+	}
+}
+
+func TestHandleGHUserAuthStatus_ReflectsSessionUser(t *testing.T) {
+	s := newDirectRouteServer(t, "clubanderson")
+	sid := s.createUserSession("clubanderson", config.RoleOwner)
+	req := httptest.NewRequest("GET", "/api/gh-user-auth/status", nil)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: sid})
+	w := httptest.NewRecorder()
+	s.handleGHUserAuthStatus(w, req)
+	got := w.Body.String()
+	if !strings.Contains(got, `"logged_in":true`) || !strings.Contains(got, `"clubanderson"`) {
+		t.Fatalf("status must reflect the session user, got %s", got)
+	}
+}
+
+func TestHandleGHUserAuthStatus_HubProxiedReflectsHeaderUser(t *testing.T) {
+	// Hub-proxied hive: report the nginx-injected user, not the shared token.
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	req := httptest.NewRequest("GET", "/api/gh-user-auth/status", nil)
+	req.Header.Set("X-Hive-User", "kellyaa")
+	req.Header.Set("X-Hive-Role", "read")
+	w := httptest.NewRecorder()
+	s.handleGHUserAuthStatus(w, req)
+	got := w.Body.String()
+	if !strings.Contains(got, `"logged_in":true`) || !strings.Contains(got, `"kellyaa"`) {
+		t.Fatalf("hub-proxied status must reflect the header user, got %s", got)
+	}
+}
+
+func TestHandleAuthToken_HiddenOnDirectRoute(t *testing.T) {
+	// The shared token must never be exposed to a browser on a direct-route hive.
+	s := newDirectRouteServer(t, "clubanderson")
+	req := httptest.NewRequest("GET", "/api/auth/token", nil)
+	w := httptest.NewRecorder()
+	s.handleAuthToken(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("auth token endpoint must 404 on direct-route spoke, got %d", w.Code)
+	}
+	if strings.Contains(w.Body.String(), s.authToken) {
+		t.Fatal("shared token must never be returned on a direct-route spoke")
+	}
+}
+
+func TestHandleAuthToken_AvailableWithoutAllowlist(t *testing.T) {
+	s := newFullServer(t)
+	s.authToken = "shared-secret-token"
+	req := httptest.NewRequest("GET", "/api/auth/token", nil)
+	w := httptest.NewRecorder()
+	s.handleAuthToken(w, req)
+	if w.Code != http.StatusOK || !strings.Contains(w.Body.String(), s.authToken) {
+		t.Fatalf("auth token must be available on non-allowlist hive, got code=%d", w.Code)
+	}
+}

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -49,6 +49,11 @@ const (
 	// dashboardTokenBytes is the number of random bytes for dashboard auth tokens.
 	dashboardTokenBytes = 32
 
+	// saasRoleOwner / saasRoleRead are the role strings stored in each
+	// SaaSUser.Hives map and injected into the spoke's authorized-users list.
+	saasRoleOwner = "owner"
+	saasRoleRead  = "read"
+
 	// ingressTypeOpenShiftRoute selects OpenShift Route generation.
 	ingressTypeOpenShiftRoute = "openshift-route"
 
@@ -368,6 +373,40 @@ func countUserHives(username string) int {
 	return count
 }
 
+// authorizedUsersForHive builds the comma-separated authorized-users list a
+// spoke needs to enforce per-user device-flow authorization on its direct
+// (non-hub-proxied) route. Format: "owner:owner,viewer1:read,viewer2:read".
+//
+// The owner always comes first with role "owner" (read-write). Every OTHER
+// SaaS user the hub granted this hive (any of "owner"/"read-write"/"read") is
+// appended as "read" — a read-only viewer on the direct route. Granting a
+// non-owner write access on the direct route is deliberately deferred (only the
+// single provisioned owner is write-capable there); see the PR notes for the
+// multi-user-grant follow-up. This fails safe: a grant can never widen access
+// beyond read on the direct route. Usernames are sanitized to guard the env
+// value, and the owner is de-duplicated so they appear exactly once.
+func authorizedUsersForHive(h *SaaSHive) string {
+	entries := make([]string, 0, 4)
+	seen := map[string]bool{}
+	owner := sanitize(h.Owner)
+	if owner != "" {
+		entries = append(entries, owner+":"+saasRoleOwner)
+		seen[strings.ToLower(owner)] = true
+	}
+	for _, u := range listAllSaaSUsers() {
+		if _, ok := u.Hives[h.ID]; !ok {
+			continue
+		}
+		name := sanitize(u.GitHubUsername)
+		if name == "" || seen[strings.ToLower(name)] {
+			continue
+		}
+		entries = append(entries, name+":"+saasRoleRead)
+		seen[strings.ToLower(name)] = true
+	}
+	return strings.Join(entries, ",")
+}
+
 func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, logger *slog.Logger) error {
 	dir := filepath.Join(saasHivesDir, h.ID, "manifests")
 	os.MkdirAll(dir, 0o755)
@@ -408,17 +447,18 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 	}
 
 	data := map[string]any{
-		"ID":             h.ID,
-		"Namespace":      "hive-hosted-" + h.ID,
-		"Org":            sanitize(h.Org),
-		"Repos":          reposYAML,
-		"PrimaryRepo":    sanitize(h.PrimaryRepo),
-		"ACMMLevel":      h.ACMMLevel,
-		"Token":          req.GitHubToken,
-		"UseApp":         useApp,
-		"UseAppFull":     useAppFull,
-		"AppID":          sanitize(req.AppID),
-		"InstallationID": sanitize(req.InstallationID),
+		"ID":              h.ID,
+		"Namespace":       "hive-hosted-" + h.ID,
+		"Org":             sanitize(h.Org),
+		"Repos":           reposYAML,
+		"PrimaryRepo":     sanitize(h.PrimaryRepo),
+		"AuthorizedUsers": authorizedUsersForHive(h),
+		"ACMMLevel":       h.ACMMLevel,
+		"Token":           req.GitHubToken,
+		"UseApp":          useApp,
+		"UseAppFull":      useAppFull,
+		"AppID":           sanitize(req.AppID),
+		"InstallationID":  sanitize(req.InstallationID),
 		"AppPrivateKey": func() string {
 			lines := strings.Split(strings.TrimSpace(req.AppPrivateKey), "\n")
 			for i := range lines {
@@ -1123,6 +1163,10 @@ spec:
           value: https://hive.kubestellar.io
         - name: HIVE_HUB_SECRET
           value: "{{.HubSecret}}"
+{{- if .AuthorizedUsers}}
+        - name: HIVE_AUTHORIZED_USERS
+          value: "{{.AuthorizedUsers}}"
+{{- end}}
 {{- if .HasInference}}
         - name: HIVE_VLLM_ENDPOINT
           value: "{{.InferenceEndpoint}}"

--- a/v2/pkg/hub/spoke_authz_test.go
+++ b/v2/pkg/hub/spoke_authz_test.go
@@ -1,0 +1,74 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAuthorizedUsersForHive_OwnerOnly(t *testing.T) {
+	saasUsersDir = t.TempDir()
+	h := &SaaSHive{ID: "abc123", Owner: "clubanderson"}
+	got := authorizedUsersForHive(h)
+	if got != "clubanderson:owner" {
+		t.Fatalf("expected owner-only list, got %q", got)
+	}
+}
+
+func TestAuthorizedUsersForHive_IncludesGrantedViewers(t *testing.T) {
+	saasUsersDir = t.TempDir()
+	// Owner record.
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "clubanderson", Hives: map[string]string{"abc123": "owner"}}); err != nil {
+		t.Fatal(err)
+	}
+	// A granted viewer.
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "kellyaa", Hives: map[string]string{"abc123": "read"}}); err != nil {
+		t.Fatal(err)
+	}
+	// A user with no access to this hive — must be excluded.
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "stranger", Hives: map[string]string{"other": "read"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	h := &SaaSHive{ID: "abc123", Owner: "clubanderson"}
+	got := authorizedUsersForHive(h)
+
+	if !strings.HasPrefix(got, "clubanderson:owner") {
+		t.Fatalf("owner must be first with owner role, got %q", got)
+	}
+	if !strings.Contains(got, "kellyaa:read") {
+		t.Fatalf("granted viewer must be included as read, got %q", got)
+	}
+	if strings.Contains(got, "stranger") {
+		t.Fatalf("user without access to this hive must be excluded, got %q", got)
+	}
+}
+
+func TestAuthorizedUsersForHive_OwnerNotDuplicated(t *testing.T) {
+	saasUsersDir = t.TempDir()
+	// Owner also has a user record granting owner on the hive.
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "clubanderson", Hives: map[string]string{"abc123": "owner"}}); err != nil {
+		t.Fatal(err)
+	}
+	h := &SaaSHive{ID: "abc123", Owner: "clubanderson"}
+	got := authorizedUsersForHive(h)
+	if strings.Count(got, "clubanderson") != 1 {
+		t.Fatalf("owner must appear exactly once, got %q", got)
+	}
+}
+
+func TestAuthorizedUsersForHive_GrantedUserGetsReadNotWrite(t *testing.T) {
+	saasUsersDir = t.TempDir()
+	// A non-owner user whose stored role is "owner" for the hive must still be
+	// downgraded to read on the direct route (only the provisioned owner writes).
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: "escalate", Hives: map[string]string{"abc123": "owner"}}); err != nil {
+		t.Fatal(err)
+	}
+	h := &SaaSHive{ID: "abc123", Owner: "clubanderson"}
+	got := authorizedUsersForHive(h)
+	if !strings.Contains(got, "escalate:read") {
+		t.Fatalf("non-owner grant must be downgraded to read, got %q", got)
+	}
+	if strings.Contains(got, "escalate:owner") {
+		t.Fatalf("non-owner must not get owner role, got %q", got)
+	}
+}


### PR DESCRIPTION
## Vulnerability

Direct-route hive spokes (OpenShift hives reached at `*.apps.fmaas-vllm-d...`, **not** via the hub's `*.hive.kubestellar.io` nginx proxy) had two compounding auth holes:

1. **No per-hive authorization.** `handleGHUserAuthPoll` accepted *any* GitHub user who completed the device flow and granted them a session — no check that the user was authorized for *this* hive. The hub's per-user/per-hive access control was entirely bypassed on the direct route.
2. **A single shared session token.** On login the spoke wrote the token to one shared file and set the session cookie to `s.authToken` (a static shared secret). Whoever logged in last became THE session for everyone. A hive owner (clubanderson) clicking through from the hub could see a *different* user's (kellyaa's) avatar/session because the spoke served the last-persisted identity to every visitor.

## Did the spoke receive an authorized-users list?

**No — that was the core gap.** Provisioning (`saas_provision.go`) injected `HIVE_ID`, `HIVE_HUB_SECRET`, etc., but **nothing** about the owner or allowed users. All per-user authorization lived hub-side in each `SaaSUser.Hives` (`hiveID→role`) map, enforced only at the nginx `auth-check` gate that direct routes never traverse. This PR adds that list to provisioning + spoke config.

## Fix

- **Per-hive authz on device-flow login.** New `dashboard.authorized_users` config / `HIVE_AUTHORIZED_USERS` env (owner first). `handleGHUserAuthPoll` resolves the GitHub identity and **rejects with 403 before persisting any token or session** if the user is not on the allowlist. The hub populates the list from the SaaS record's owner + access grants (`authorizedUsersForHive`).
- **Per-user sessions.** Login mints an opaque random session id (server-side map → username+role) in the `hive_session` cookie. The middleware resolves the *current* request's user from *its* cookie — two people get two sessions, each sees themselves. Logout clears only that session. The shared `s.authToken` cookie is no longer accepted as identity.
- **Role gating on the direct route.** owner=read-write, granted=read. Auth identity resolution moved to a dedicated `authenticate` middleware that runs **before** `roleEnforcement`, so the injected `X-Hive-Role` is visible to the read-only write-gate (otherwise a read viewer could still write).
- **Hardening surfaced during review:** on a direct-route spoke, client-supplied `X-Hive-User`/`X-Hive-Role` are stripped (no nginx to strip forgeries), the publicly-readable `/api/auth/token` is hidden, and the shared bearer token no longer grants access (it carries no per-user identity). A read-only viewer's login no longer clobbers the owner's persisted token / GitHub write-client.

## Hub-proxied path unchanged

`hive-oke` hives where nginx injects `X-Hive-User`/`X-Hive-Role` keep working exactly as before — enforcement is **only added** for the direct device-flow path (allowlist empty ⇒ hub-proxied behavior).

## Manual lockdown for kellyaa's already-running spoke

Template changes reach only **new** provisions. Existing spokes need the env applied + the shared session cleared. Patch the running spoke deployment (namespace `hive-hosted-<id>`):

```sh
# 1. Add the authorized-users allowlist (owner first) to the running spoke.
kubectl -n hive-hosted-<id> set env deploy/hive \
  HIVE_AUTHORIZED_USERS="kellyaa,clubanderson"

# 2. Wipe the shared/persisted GitHub user token so the leaked shared session
#    is destroyed on restart (device-flow re-login required, now per-user).
kubectl -n hive-hosted-<id> exec deploy/hive -- rm -f /data/gh-user-token

# 3. Roll the pod to pick up the env + clear in-memory sessions.
kubectl -n hive-hosted-<id> rollout restart deploy/hive
```

(Order the owner first in `HIVE_AUTHORIZED_USERS`; additional names are read-only for now — see follow-up.)

## Follow-up (hub-side, out of scope here)

Multi-user **write** grants on the direct route are deferred: non-owner grants are provisioned read-only for now (fails safe). Granting a non-owner write access on the direct route needs the hub to pass a richer per-user role map (and the spoke to honor it) — a larger hub change. The interim lock-to-owner is the safe default per the security-first requirement.

## Tests

Authz 403 reject, per-user session isolation, forged-header stripping, the full `authenticate → roleEnforcement` chain proving a read-only viewer's write is blocked, bearer-token disablement on the direct route, `/api/auth/token` hidden on direct route, hub `authorizedUsersForHive` construction (owner dedup, non-owner downgrade to read, exclusion of users without access).

🤖 Generated with [Claude Code](https://claude.com/claude-code)