### PR TITLE
fix(tokens): count inference-agent tokens and report them to the hub

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -26,9 +26,7 @@ import (
 	gh "github.com/google/go-github/v72/github"
 
 	"github.com/kubestellar/hive/v2/pkg/advisory"
-	"github.com/kubestellar/hive/v2/pkg/hub"
 	"github.com/kubestellar/hive/v2/pkg/agent"
-	"github.com/kubestellar/hive/v2/pkg/logscrub"
 	"github.com/kubestellar/hive/v2/pkg/beads"
 	"github.com/kubestellar/hive/v2/pkg/classify"
 	"github.com/kubestellar/hive/v2/pkg/config"
@@ -36,7 +34,9 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/discord"
 	"github.com/kubestellar/hive/v2/pkg/github"
 	"github.com/kubestellar/hive/v2/pkg/governor"
+	"github.com/kubestellar/hive/v2/pkg/hub"
 	"github.com/kubestellar/hive/v2/pkg/knowledge"
+	"github.com/kubestellar/hive/v2/pkg/logscrub"
 	"github.com/kubestellar/hive/v2/pkg/notify"
 	"github.com/kubestellar/hive/v2/pkg/policies"
 	"github.com/kubestellar/hive/v2/pkg/proxy"
@@ -558,7 +558,7 @@ func main() {
 	if badgeURL == "" {
 		badgeURL = "https://gist.githubusercontent.com/clubanderson/b9a9ae8469f1897a22d5a40629bc1e82/raw/coverage-badge.json"
 	}
-		primaryRepo := cfg.Project.PrimaryRepo
+	primaryRepo := cfg.Project.PrimaryRepo
 	if primaryRepo == "" && len(cfg.Project.Repos) > 0 {
 		primaryRepo = cfg.Project.Repos[0]
 	}
@@ -1164,6 +1164,13 @@ func main() {
 	} else {
 		dashboard.SetProxyViolationsProvider(githubProxy.Violations)
 
+		// Wire the inference token sink so the translator records per-agent
+		// usage (from the gateway's OpenAI usage block) into the same metrics
+		// dir the token collector scans. Without this, bare-mode inference
+		// agents (litellm/vllm/llm-d) never write a scannable session file and
+		// their consumption reads as zero.
+		githubProxy.SetTokenSink(tokens.NewInferenceSink(cfg.Data.MetricsDir, logger))
+
 		vllmEndpoints := parseEndpointList(envOrDefault("HIVE_VLLM_ENDPOINT", "http://hive-vllm-svc.hive-inference.svc.cluster.local:8000"))
 		llmdEndpoints := parseEndpointList(envOrDefault("HIVE_LLMD_ENDPOINT", "http://hive-llm-d-epp.hive-inference.svc.cluster.local:8000"))
 		inferenceEndpoints := map[string][]string{
@@ -1340,6 +1347,23 @@ func main() {
 				ACMMLevel:   acmmLvl,
 				Agents:      agents,
 				Governor:    hub.GovernorSummary{Mode: string(govState.Mode), Issues: govState.QueueIssues, PRs: govState.QueuePRs},
+				// Tokens carries the spoke's authoritative cumulative token
+				// total (same store the dashboard token panel and governor
+				// budget read). It flows to the hub's My Hives token column so
+				// heartbeat-only hives (reached via heartbeat, not hub-kubectl)
+				// display real consumption. Refreshed each heartbeat, so the
+				// column is as fresh as the last heartbeat. Despite the
+				// "24h"-suffixed field name this is a lifetime/window total,
+				// consistent with what the spoke dashboard already shows.
+				Tokens24h: func() int64 {
+					if tokenCollector == nil {
+						return 0
+					}
+					if summary := tokenCollector.Summary(); summary != nil {
+						return summary.TotalTokens
+					}
+					return 0
+				}(),
 				Contributors: func() hub.ContributorSummary {
 					reg, active := dashSrv.ContributorSummary()
 					return hub.ContributorSummary{Registered: reg, Active: active}
@@ -1349,7 +1373,7 @@ func main() {
 					out := make([]hub.LeaderboardEntry, len(lb))
 					for i, e := range lb {
 						out[i] = hub.LeaderboardEntry{
-							GitHubUsername:  e.GitHubUsername,
+							GitHubUsername: e.GitHubUsername,
 							AvatarURL:      e.AvatarURL,
 							TrustTier:      e.TrustTier,
 							TasksCompleted: e.TasksCompleted,
@@ -1371,7 +1395,7 @@ func main() {
 					}
 					return ""
 				}(),
-				Health:       dashSrv.HealthSummary(),
+				Health: dashSrv.HealthSummary(),
 				DashboardURL: func() string {
 					if cfg.Hub.DashboardURL != "" {
 						return cfg.Hub.DashboardURL
@@ -1383,13 +1407,13 @@ func main() {
 					}
 					return fmt.Sprintf("http://localhost:%d", cfg.Dashboard.Port)
 				}(),
-				SnapshotURL:  cfg.Hub.SnapshotURL,
-				HiveType:     cfg.Hub.HiveType,
-				ClusterID:    cfg.Hub.ClusterID,
-				IsPublic:     cfg.Hub.IsPublic,
-				Version:           "3.0.0",
-				GitHash:           gitShort,
-				GitBranch:         gitBranch,
+				SnapshotURL:             cfg.Hub.SnapshotURL,
+				HiveType:                cfg.Hub.HiveType,
+				ClusterID:               cfg.Hub.ClusterID,
+				IsPublic:                cfg.Hub.IsPublic,
+				Version:                 "3.0.0",
+				GitHash:                 gitShort,
+				GitBranch:               gitBranch,
 				GitHubAppRequired:       dashSrv.IsGitHubAppRequired(),
 				GitHubAppPermIssue:      dashSrv.GetGitHubAppPermIssue(),
 				PendingGitHubAppInstall: dashSrv.IsPendingGitHubAppInstall(),
@@ -1548,7 +1572,7 @@ func main() {
 			out := make([]hub.LeaderboardEntry, len(lb))
 			for i, e := range lb {
 				out[i] = hub.LeaderboardEntry{
-					GitHubUsername:  e.GitHubUsername,
+					GitHubUsername: e.GitHubUsername,
 					AvatarURL:      e.AvatarURL,
 					TrustTier:      e.TrustTier,
 					TasksCompleted: e.TasksCompleted,
@@ -2217,22 +2241,22 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 	}
 
 	state := &snapshot.PersistedState{
-		Agents:           agents,
-		GovernorMode:     string(govState.Mode),
-		BudgetLimit:      budget.WeeklyLimit,
-		BudgetIgnored:    budget.IgnoredAgents,
-		BudgetIgnoreAll:  budget.IgnoreAll,
-		CadenceOverrides: cadenceOverrides,
-		LastKicks:        govState.LastKick,
+		Agents:               agents,
+		GovernorMode:         string(govState.Mode),
+		BudgetLimit:          budget.WeeklyLimit,
+		BudgetIgnored:        budget.IgnoredAgents,
+		BudgetIgnoreAll:      budget.IgnoreAll,
+		CadenceOverrides:     cadenceOverrides,
+		LastKicks:            govState.LastKick,
 		BudgetSpend:          budget.CurrentSpend,
 		BudgetResetAt:        budget.ResetAt,
 		BudgetByAgent:        budget.ByAgent,
 		BudgetByModel:        budget.ByModel,
 		BudgetWindowBaseline: budget.WindowBaseline,
-		KickHistory:      kickEntries,
-		IssueCosts:       issueCosts,
-		LastEval:         govState.LastEval,
-		ACMMLevel:        cfg.ACMMLevel,
+		KickHistory:          kickEntries,
+		IssueCosts:           issueCosts,
+		LastEval:             govState.LastEval,
+		ACMMLevel:            cfg.ACMMLevel,
 	}
 
 	if err := snapshot.SaveState(path, state, logger); err != nil {

--- a/v2/pkg/hub/hub_heartbeat_tokens_test.go
+++ b/v2/pkg/hub/hub_heartbeat_tokens_test.go
@@ -1,0 +1,84 @@
+package hub
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestHeartbeatStoresTokenTotal verifies that a heartbeat carrying tokens_24h
+// is stored on the registry entry's TotalTokens24h, so heartbeat-only hives
+// (reached via heartbeat, not hub-kubectl) show real token consumption on the
+// My Hives token column.
+func TestHeartbeatStoresTokenTotal(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv.hubSecret = ""
+
+	const wantTokens = int64(1234567)
+	payload := `{
+		"hive_id":"kellyaa",
+		"org":"testorg",
+		"primary_repo":"repo",
+		"tokens_24h":1234567
+	}`
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleHeartbeat(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var got int64 = -1
+	srv.mu.RLock()
+	for _, h := range srv.registry.Hives {
+		if h.ID == "kellyaa" {
+			got = h.TotalTokens24h
+		}
+	}
+	srv.mu.RUnlock()
+
+	if got != wantTokens {
+		t.Fatalf("TotalTokens24h = %d, want %d", got, wantTokens)
+	}
+}
+
+// TestHeartbeatTokenTotalClamped verifies the token total is clamped to a sane
+// maximum so a corrupt/hostile spoke cannot inject an absurd value.
+func TestHeartbeatTokenTotalClamped(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	srv.hubSecret = ""
+
+	payload := `{
+		"hive_id":"clamphive",
+		"org":"testorg",
+		"primary_repo":"repo",
+		"tokens_24h":999999999999
+	}`
+	req := httptest.NewRequest("POST", "/api/heartbeat", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handleHeartbeat(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var got int64 = -1
+	srv.mu.RLock()
+	for _, h := range srv.registry.Hives {
+		if h.ID == "clamphive" {
+			got = h.TotalTokens24h
+		}
+	}
+	srv.mu.RUnlock()
+
+	// clampInt64(payload.Tokens24h, 0, 100_000_000)
+	const maxTokens = int64(100_000_000)
+	if got != maxTokens {
+		t.Fatalf("clamped TotalTokens24h = %d, want %d", got, maxTokens)
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3947,6 +3947,14 @@ const dashboardHTML = `<!DOCTYPE html>
       var cls = role === 'owner' ? 'role-owner' : role === 'read-write' ? 'role-read-write' : 'role-read';
       return '<span class="role-badge ' + cls + '">' + esc(role) + '</span>';
     }
+    function fmtTokens(n) {
+      n = Number(n) || 0;
+      if (n <= 0) return '<span style="color:var(--muted)">—</span>';
+      if (n >= 1e9) return (n / 1e9).toFixed(1).replace(/\.0$/, '') + 'B';
+      if (n >= 1e6) return (n / 1e6).toFixed(1).replace(/\.0$/, '') + 'M';
+      if (n >= 1e3) return (n / 1e3).toFixed(1).replace(/\.0$/, '') + 'K';
+      return String(n);
+    }
     function clusterBadge(clusterId, clusterName) {
       var cid = clusterId || 'hive-oke';
       var isGPU = cid === 'vllm-d' || (clusterName || '').toLowerCase().indexOf('gpu') >= 0;
@@ -4344,7 +4352,7 @@ const dashboardHTML = `<!DOCTYPE html>
         if (h.pendingRequestCount > 0 && (h.role === 'owner' || h.role === 'read-write')) {
           pendingPill = '<a href="#" onclick="togglePendingRow(\'' + esc(h.id) + '\');return false" style="display:inline-flex;align-items:center;gap:4px;padding:3px 10px;background:rgba(59,130,246,0.12);color:#60a5fa;border:1px solid rgba(59,130,246,0.3);border-radius:4px;font-size:0.7rem;text-decoration:none;cursor:pointer;white-space:nowrap">&#x1F514; ' + h.pendingRequestCount + ' pending</a>';
         }
-        var TOTAL_COLUMNS = 12;
+        var TOTAL_COLUMNS = 13;
         var pendingExpandRow = '';
         if (h.pendingRequestCount > 0 && (h.role === 'owner' || h.role === 'read-write') && (h.pending_requests || []).length > 0) {
           var prItems = (h.pending_requests || []).map(function(pr) {
@@ -4367,6 +4375,7 @@ const dashboardHTML = `<!DOCTYPE html>
           '<td title="' + esc((h.repos || []).join('\n')) + '" style="cursor:' + (repoCount > 0 ? 'help' : 'default') + '">' + repoCount + '</td>' +
           '<td>' + acmmBadge(h.acmmLevel) + '</td>' +
           '<td title="' + esc((h.agents || []).map(function(a){ var label = a.name + ' (' + a.state + ')'; if (a.mode === 'on_demand') label += ' — on demand'; return label; }).join('\n')) + '" style="cursor:' + ((h.agentCount || 0) > 0 ? 'help' : 'default') + '">' + (h.agentCount || 0) + '</td>' +
+          '<td title="Cumulative tokens consumed, as of the last heartbeat" style="white-space:nowrap;cursor:help">' + fmtTokens(h.totalTokens24h || 0) + '</td>' +
           '<td>' + modeCell + '</td>' +
           '<td>' + sparkline(h.issueHistory, '#f59e0b', 50, 14) + (h.actionableIssues || 0) + '</td>' +
           '<td>' + sparkline(h.prHistory, '#3b82f6', 50, 14) + (h.actionablePRs || 0) + '</td>' +
@@ -4375,7 +4384,7 @@ const dashboardHTML = `<!DOCTYPE html>
       }).join('');
       document.getElementById('hives-container').innerHTML =
         '<div class="table-wrap"><table class="hive-table"><thead><tr>' +
-        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer">Location ⇅</th><th>Public</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th>' +
+        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer">Location ⇅</th><th>Public</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table></div>';
       setTimeout(function() {
         var tw = document.querySelector('.table-wrap');

--- a/v2/pkg/proxy/anthropic_translate.go
+++ b/v2/pkg/proxy/anthropic_translate.go
@@ -27,6 +27,11 @@ func translateAnthropicToOpenAI(body []byte, targetModel string, maxContextLen i
 		Model:  targetModel,
 		Stream: req.Stream,
 	}
+	if req.Stream {
+		// Request the terminal usage chunk so streamed inference responses
+		// carry token counts we can attribute to the agent.
+		openaiReq.StreamOptions = &openaiStreamOptions{IncludeUsage: true}
+	}
 
 	var totalChars int
 
@@ -232,6 +237,21 @@ func translateAnthropicToolChoice(raw json.RawMessage) json.RawMessage {
 	}
 }
 
+// extractOpenAIUsage pulls the prompt/completion token counts from an upstream
+// OpenAI (non-streaming) chat completion response body. Returns (0, 0) when no
+// usage block is present. Used to attribute inference-agent token consumption
+// into the token store.
+func extractOpenAIUsage(body []byte) (inputTokens, outputTokens int64) {
+	var resp openaiResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return 0, 0
+	}
+	if resp.Usage == nil {
+		return 0, 0
+	}
+	return int64(resp.Usage.PromptTokens), int64(resp.Usage.CompletionTokens)
+}
+
 // translateOpenAIResponseToAnthropic converts a non-streaming OpenAI Chat
 // Completions response into an Anthropic Messages response.
 func translateOpenAIResponseToAnthropic(body []byte, model string) ([]byte, error) {
@@ -295,8 +315,11 @@ func translateOpenAIResponseToAnthropic(body []byte, model string) ([]byte, erro
 
 // translateOpenAISSEToAnthropic reads an OpenAI SSE stream and writes the
 // equivalent Anthropic SSE events to the writer. The caller must close the
-// reader when done.
-func translateOpenAISSEToAnthropic(r io.Reader, w io.Writer, model string) error {
+// reader when done. It returns the token usage reported in the stream's
+// terminal usage chunk (present when the outbound request set
+// stream_options.include_usage). Returns (0, 0) when the gateway did not emit
+// usage.
+func translateOpenAISSEToAnthropic(r io.Reader, w io.Writer, model string) (inputTokens, outputTokens int64, err error) {
 	msgID := fmt.Sprintf("msg_%d", time.Now().UnixNano())
 
 	writeSSE(w, "message_start", anthropicSSEMessageStart{
@@ -315,6 +338,7 @@ func translateOpenAISSEToAnthropic(r io.Reader, w io.Writer, model string) error
 	const maxSSELine = 256 * 1024
 	scanner.Buffer(make([]byte, maxSSELine), maxSSELine)
 
+	var totalInputTokens int
 	var totalOutputTokens int
 	var contentBlockIndex int
 	textBlockStarted := false
@@ -430,11 +454,14 @@ func translateOpenAISSEToAnthropic(r io.Reader, w io.Writer, model string) error
 
 		if chunk.Usage != nil {
 			totalOutputTokens = chunk.Usage.CompletionTokens
+			if chunk.Usage.PromptTokens > 0 {
+				totalInputTokens = chunk.Usage.PromptTokens
+			}
 		}
 	}
 
 	writeSSE(w, "message_stop", map[string]string{"type": "message_stop"})
-	return scanner.Err()
+	return int64(totalInputTokens), int64(totalOutputTokens), scanner.Err()
 }
 
 type sseToolCallAccumulator struct {
@@ -560,9 +587,11 @@ func forwardToInference(clientReq *http.Request, clientBody []byte, w http.Respo
 
 		if f, ok := w.(http.Flusher); ok {
 			flushWriter := &flushResponseWriter{w: w, f: f}
-			return translateOpenAISSEToAnthropic(resp.Body, flushWriter, route.Model)
+			_, _, err := translateOpenAISSEToAnthropic(resp.Body, flushWriter, route.Model)
+			return err
 		}
-		return translateOpenAISSEToAnthropic(resp.Body, w, route.Model)
+		_, _, err := translateOpenAISSEToAnthropic(resp.Body, w, route.Model)
+		return err
 	}
 
 	body, err := io.ReadAll(resp.Body)
@@ -672,17 +701,26 @@ type anthropicSSEMessage struct {
 }
 
 type openaiRequest struct {
-	Model      string          `json:"model"`
-	Messages   []openaiMessage `json:"messages"`
-	MaxTokens  int             `json:"max_tokens,omitempty"`
-	Stream     bool            `json:"stream,omitempty"`
-	Tools      []openaiTool    `json:"tools,omitempty"`
-	ToolChoice json.RawMessage `json:"tool_choice,omitempty"`
+	Model         string               `json:"model"`
+	Messages      []openaiMessage      `json:"messages"`
+	MaxTokens     int                  `json:"max_tokens,omitempty"`
+	Stream        bool                 `json:"stream,omitempty"`
+	StreamOptions *openaiStreamOptions `json:"stream_options,omitempty"`
+	Tools         []openaiTool         `json:"tools,omitempty"`
+	ToolChoice    json.RawMessage      `json:"tool_choice,omitempty"`
+}
+
+// openaiStreamOptions asks the gateway to emit a terminal usage chunk on
+// streamed responses. Without include_usage most OpenAI-compatible gateways
+// omit token counts from SSE responses, so inference-agent streaming usage
+// would be uncountable.
+type openaiStreamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
 }
 
 type openaiToolChoiceNamed struct {
-	Type     string                    `json:"type"`
-	Function openaiToolChoiceFunction  `json:"function"`
+	Type     string                   `json:"type"`
+	Function openaiToolChoiceFunction `json:"function"`
 }
 
 type openaiToolChoiceFunction struct {
@@ -733,13 +771,14 @@ type openaiResponse struct {
 type openaiUsage struct {
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
 }
 
 type openaiSSEChunk struct {
 	Choices []struct {
 		Delta struct {
-			Content   string               `json:"content"`
-			ToolCalls []openaiSSEToolCall   `json:"tool_calls,omitempty"`
+			Content   string              `json:"content"`
+			ToolCalls []openaiSSEToolCall `json:"tool_calls,omitempty"`
 		} `json:"delta"`
 		FinishReason string `json:"finish_reason"`
 	} `json:"choices"`

--- a/v2/pkg/proxy/anthropic_translate_test.go
+++ b/v2/pkg/proxy/anthropic_translate_test.go
@@ -363,7 +363,7 @@ func TestTranslateOpenAISSEToAnthropic(t *testing.T) {
 	}, "\n")
 
 	var buf strings.Builder
-	err := translateOpenAISSEToAnthropic(strings.NewReader(sseInput), &buf, "test-model")
+	_, _, err := translateOpenAISSEToAnthropic(strings.NewReader(sseInput), &buf, "test-model")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -416,7 +416,7 @@ func TestTranslateOpenAISSEToAnthropic_ToolCalls(t *testing.T) {
 	}, "\n")
 
 	var buf strings.Builder
-	err := translateOpenAISSEToAnthropic(strings.NewReader(sseInput), &buf, "test-model")
+	_, _, err := translateOpenAISSEToAnthropic(strings.NewReader(sseInput), &buf, "test-model")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/agent"
+	"github.com/kubestellar/hive/v2/pkg/tokens"
 )
 
 const (
@@ -52,6 +53,17 @@ type GitHubProxy struct {
 	certCache map[string]cachedCert
 
 	inference *inferenceRouter
+
+	// tokenSink records per-agent token usage for bare-mode inference
+	// agents, whose usage the file-scanning token collector cannot see
+	// otherwise. May be nil (Record is a safe no-op on a nil sink).
+	tokenSink *tokens.InferenceSink
+}
+
+// SetTokenSink wires the inference token sink so the translator can record
+// per-agent usage from upstream OpenAI responses into the shared token store.
+func (p *GitHubProxy) SetTokenSink(sink *tokens.InferenceSink) {
+	p.tokenSink = sink
 }
 
 type cachedCert struct {
@@ -1016,8 +1028,12 @@ func (p *GitHubProxy) StartInferenceTranslator() error {
 			if f, ok := w.(http.Flusher); ok {
 				f.Flush()
 			}
-			if err := translateOpenAISSEToAnthropic(resp.Body, w, route.Model); err != nil {
+			in, out, err := translateOpenAISSEToAnthropic(resp.Body, w, route.Model)
+			if err != nil {
 				p.logger.Error("inference SSE translation failed", "agent", agentName, "error", err)
+			}
+			if in > 0 || out > 0 {
+				p.tokenSink.Record(agentName, route.Model, in, out)
 			}
 			return
 		}
@@ -1033,6 +1049,10 @@ func (p *GitHubProxy) StartInferenceTranslator() error {
 			"len", len(respBody),
 			"preview", truncateBytes(respBody, 500),
 		)
+
+		if in, out := extractOpenAIUsage(respBody); in > 0 || out > 0 {
+			p.tokenSink.Record(agentName, route.Model, in, out)
+		}
 
 		translated, err := translateOpenAIResponseToAnthropic(respBody, route.Model)
 		if err != nil {
@@ -1149,8 +1169,12 @@ func (p *GitHubProxy) handleInferenceRequest(conn net.Conn, req *http.Request, a
 		if _, err := conn.Write([]byte(hdr)); err != nil {
 			return
 		}
-		if err := translateOpenAISSEToAnthropic(resp.Body, conn, route.Model); err != nil {
+		in, out, err := translateOpenAISSEToAnthropic(resp.Body, conn, route.Model)
+		if err != nil {
 			p.logger.Error("inference SSE translation failed", "agent", agentName, "error", err)
+		}
+		if in > 0 || out > 0 {
+			p.tokenSink.Record(agentName, route.Model, in, out)
 		}
 		return
 	}
@@ -1159,6 +1183,10 @@ func (p *GitHubProxy) handleInferenceRequest(conn net.Conn, req *http.Request, a
 	if err != nil {
 		p.writeHTTPError(conn, http.StatusBadGateway, "failed to read inference response")
 		return
+	}
+
+	if in, out := extractOpenAIUsage(respBody); in > 0 || out > 0 {
+		p.tokenSink.Record(agentName, route.Model, in, out)
 	}
 
 	translated, err := translateOpenAIResponseToAnthropic(respBody, route.Model)

--- a/v2/pkg/proxy/proxy_deep3_test.go
+++ b/v2/pkg/proxy/proxy_deep3_test.go
@@ -167,7 +167,7 @@ func TestStartInferenceTranslatorReal(t *testing.T) {
 			if f, ok := w.(http.Flusher); ok {
 				f.Flush()
 			}
-			if err := translateOpenAISSEToAnthropic(resp.Body, w, route.Model); err != nil {
+			if _, _, err := translateOpenAISSEToAnthropic(resp.Body, w, route.Model); err != nil {
 				p.logger.Error("inference SSE translation failed", "agent", agentName, "error", err)
 			}
 			return

--- a/v2/pkg/proxy/proxy_deep_test.go
+++ b/v2/pkg/proxy/proxy_deep_test.go
@@ -1589,7 +1589,7 @@ func TestHandleInferenceRequestStreaming(t *testing.T) {
 func TestTranslateOpenAISSEToAnthropicEmptyStream(t *testing.T) {
 	sseInput := "data: [DONE]\n\n"
 	var buf strings.Builder
-	err := translateOpenAISSEToAnthropic(strings.NewReader(sseInput), &buf, "model")
+	_, _, err := translateOpenAISSEToAnthropic(strings.NewReader(sseInput), &buf, "model")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1605,7 +1605,7 @@ func TestTranslateOpenAISSEToAnthropicEmptyStream(t *testing.T) {
 func TestTranslateOpenAISSEToAnthropicBadJSON(t *testing.T) {
 	sseInput := "data: {invalid json}\n\ndata: [DONE]\n\n"
 	var buf strings.Builder
-	err := translateOpenAISSEToAnthropic(strings.NewReader(sseInput), &buf, "model")
+	_, _, err := translateOpenAISSEToAnthropic(strings.NewReader(sseInput), &buf, "model")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1618,7 +1618,7 @@ func TestTranslateOpenAISSEToAnthropicBadJSON(t *testing.T) {
 func TestTranslateOpenAISSEToAnthropicNonDataLines(t *testing.T) {
 	sseInput := ": comment\nevent: something\nretry: 1000\ndata: [DONE]\n\n"
 	var buf strings.Builder
-	err := translateOpenAISSEToAnthropic(strings.NewReader(sseInput), &buf, "model")
+	_, _, err := translateOpenAISSEToAnthropic(strings.NewReader(sseInput), &buf, "model")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1635,7 +1635,7 @@ func TestTranslateOpenAISSEWithUsage(t *testing.T) {
 	}, "\n")
 
 	var buf strings.Builder
-	err := translateOpenAISSEToAnthropic(strings.NewReader(sseInput), &buf, "model")
+	_, _, err := translateOpenAISSEToAnthropic(strings.NewReader(sseInput), &buf, "model")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/v2/pkg/tokens/collector.go
+++ b/v2/pkg/tokens/collector.go
@@ -21,6 +21,11 @@ type SessionEntry struct {
 	OutputTokens  int64  `json:"output_tokens,omitempty"`
 	Message       string `json:"message,omitempty"`
 	Role          string `json:"role,omitempty"`
+	// Agent, when set, pins the session to a specific agent instead of
+	// relying on keyword detection from the first user message. Inference
+	// (bare-mode) agents set this so the translator-written usage records
+	// attribute cleanly. Normal Claude/Copilot session files omit it.
+	Agent string `json:"agent,omitempty"`
 }
 
 type SessionSummary struct {
@@ -47,39 +52,39 @@ type AgentModelBucket struct {
 }
 
 type AggregateSummary struct {
-	TotalTokens    int64                        `json:"total_tokens"`
-	TotalInput     int64                        `json:"total_input"`
-	TotalOutput    int64                        `json:"total_output"`
-	TotalCacheRead int64                        `json:"total_cache_read"`
-	TotalCacheCreate int64                      `json:"total_cache_create"`
-	TotalMessages  int                          `json:"total_messages"`
-	ByAgent        map[string]int64             `json:"by_agent"`
-	ByModel        map[string]int64             `json:"by_model"`
-	ByAgentDetail  map[string]*AgentModelBucket `json:"by_agent_detail"`
-	ByModelDetail  map[string]*AgentModelBucket `json:"by_model_detail"`
-	Sessions       []SessionSummary             `json:"sessions"`
-	SessionCount   int                          `json:"session_count"`
+	TotalTokens      int64                        `json:"total_tokens"`
+	TotalInput       int64                        `json:"total_input"`
+	TotalOutput      int64                        `json:"total_output"`
+	TotalCacheRead   int64                        `json:"total_cache_read"`
+	TotalCacheCreate int64                        `json:"total_cache_create"`
+	TotalMessages    int                          `json:"total_messages"`
+	ByAgent          map[string]int64             `json:"by_agent"`
+	ByModel          map[string]int64             `json:"by_model"`
+	ByAgentDetail    map[string]*AgentModelBucket `json:"by_agent_detail"`
+	ByModelDetail    map[string]*AgentModelBucket `json:"by_model_detail"`
+	Sessions         []SessionSummary             `json:"sessions"`
+	SessionCount     int                          `json:"session_count"`
 }
 
 const (
-	defaultScanInterval  = 30 * time.Second
-	defaultPersistPath   = "/data/token-summary.json"
+	defaultScanInterval = 30 * time.Second
+	defaultPersistPath  = "/data/token-summary.json"
 )
 
 type Collector struct {
-	sessionsDir         string
-	claudeSessionsDir   string
-	copilotSessionsDir  string
-	persistPath         string
-	detector            func(string) string
-	logger              *slog.Logger
-	mu                  sync.RWMutex
-	latest              *AggregateSummary
-	issueCosts          map[string]int64
-	scanInterval        time.Duration
-	prevSessionCount    int
-	prevTotalTokens     int64
-	prevByAgent         map[string]int64
+	sessionsDir        string
+	claudeSessionsDir  string
+	copilotSessionsDir string
+	persistPath        string
+	detector           func(string) string
+	logger             *slog.Logger
+	mu                 sync.RWMutex
+	latest             *AggregateSummary
+	issueCosts         map[string]int64
+	scanInterval       time.Duration
+	prevSessionCount   int
+	prevTotalTokens    int64
+	prevByAgent        map[string]int64
 }
 
 func NewCollector(sessionsDir string, logger *slog.Logger) *Collector {
@@ -290,11 +295,16 @@ func parseSessionFile(path string, agentDetector func(string) string) (*SessionS
 	scanner.Buffer(make([]byte, 0, maxScanBufSize), maxScanBufSize)
 
 	firstUserMsg := ""
+	explicitAgent := ""
 	var lastTimestamp int64
 	for scanner.Scan() {
 		var entry SessionEntry
 		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
 			continue
+		}
+
+		if entry.Agent != "" && explicitAgent == "" {
+			explicitAgent = entry.Agent
 		}
 
 		if entry.Role == "user" && firstUserMsg == "" {
@@ -318,7 +328,9 @@ func parseSessionFile(path string, agentDetector func(string) string) (*SessionS
 	summary.TotalTokens = summary.InputTokens + summary.OutputTokens + summary.CacheRead + summary.CacheCreate
 	summary.LastActive = lastTimestamp
 
-	if agentDetector != nil && firstUserMsg != "" {
+	if explicitAgent != "" {
+		summary.Agent = explicitAgent
+	} else if agentDetector != nil && firstUserMsg != "" {
 		summary.Agent = agentDetector(firstUserMsg)
 	}
 

--- a/v2/pkg/tokens/inference_sink.go
+++ b/v2/pkg/tokens/inference_sink.go
@@ -1,0 +1,132 @@
+package tokens
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// inferenceSessionFilePrefix is prepended to per-agent inference usage files
+// written under the metrics dir. The token Collector globs "*.jsonl" in that
+// dir, so these files are picked up by the normal scan without any extra
+// wiring. The prefix keeps them visually distinct from CLI session files.
+const inferenceSessionFilePrefix = "inference-"
+
+// inferenceFilePerm is the mode for the per-agent inference usage files.
+const inferenceFilePerm = 0o644
+
+// InferenceSink records token usage for bare-mode inference agents (litellm /
+// vllm / llm-d) that run `claude --bare` against the translator and therefore
+// never write a Claude session transcript for the collector to scan.
+//
+// The translator calls Record after each upstream response with the OpenAI
+// usage block. The sink keeps a cumulative per-agent counter in memory and
+// mirrors it to one atomically-rewritten "*.jsonl" file per agent under the
+// metrics dir. The existing token Collector globs that dir every scan, so
+// inference usage flows into the same AggregateSummary the dashboard, the
+// governor budget, and the hub heartbeat all read — no parallel counter.
+type InferenceSink struct {
+	dir    string
+	logger *slog.Logger
+
+	mu     sync.Mutex
+	totals map[string]*inferenceAgentTotals
+}
+
+type inferenceAgentTotals struct {
+	Model        string
+	InputTokens  int64
+	OutputTokens int64
+}
+
+// NewInferenceSink returns a sink that writes per-agent usage files into dir.
+// dir is created if missing. A nil sink (dir == "") is a safe no-op.
+func NewInferenceSink(dir string, logger *slog.Logger) *InferenceSink {
+	return &InferenceSink{
+		dir:    dir,
+		logger: logger,
+		totals: make(map[string]*inferenceAgentTotals),
+	}
+}
+
+// Record adds one response's token usage for agent to the running total and
+// rewrites that agent's usage file. inputTokens/outputTokens come from the
+// gateway's OpenAI "usage" block (prompt_tokens / completion_tokens). It is a
+// no-op when the sink is disabled, the agent name is empty, or the usage is
+// non-positive, so callers can invoke it unconditionally.
+func (s *InferenceSink) Record(agent, model string, inputTokens, outputTokens int64) {
+	if s == nil || s.dir == "" || agent == "" {
+		return
+	}
+	if inputTokens <= 0 && outputTokens <= 0 {
+		return
+	}
+
+	s.mu.Lock()
+	t, ok := s.totals[agent]
+	if !ok {
+		t = &inferenceAgentTotals{}
+		s.totals[agent] = t
+	}
+	if model != "" {
+		t.Model = model
+	}
+	if inputTokens > 0 {
+		t.InputTokens += inputTokens
+	}
+	if outputTokens > 0 {
+		t.OutputTokens += outputTokens
+	}
+	snapshot := *t
+	s.mu.Unlock()
+
+	if err := s.writeAgentFile(agent, &snapshot); err != nil && s.logger != nil {
+		// Never log token values as sensitive; count magnitudes are fine.
+		s.logger.Warn("inference token sink write failed", "agent", agent, "error", err)
+	}
+}
+
+// writeAgentFile atomically rewrites the cumulative usage file for one agent.
+// The file is a single-session ".jsonl" whose session ID is stable (the agent
+// name), so the Collector's dedup-by-session-ID replaces rather than sums
+// across scans. The first line pins the agent explicitly via SessionEntry.Agent
+// so attribution does not depend on keyword detection.
+func (s *InferenceSink) writeAgentFile(agent string, t *inferenceAgentTotals) error {
+	if err := os.MkdirAll(s.dir, 0o755); err != nil {
+		return fmt.Errorf("creating metrics dir: %w", err)
+	}
+
+	entries := []SessionEntry{
+		{Role: "user", Agent: agent, Message: agent, Model: t.Model},
+		{
+			Role:         "assistant",
+			Agent:        agent,
+			Model:        t.Model,
+			InputTokens:  t.InputTokens,
+			OutputTokens: t.OutputTokens,
+		},
+	}
+
+	var buf []byte
+	for _, e := range entries {
+		line, err := json.Marshal(e)
+		if err != nil {
+			return fmt.Errorf("marshaling usage entry: %w", err)
+		}
+		buf = append(buf, line...)
+		buf = append(buf, '\n')
+	}
+
+	path := filepath.Join(s.dir, inferenceSessionFilePrefix+agent+".jsonl")
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, buf, inferenceFilePerm); err != nil {
+		return fmt.Errorf("writing usage file: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("renaming usage file: %w", err)
+	}
+	return nil
+}

--- a/v2/pkg/tokens/inference_sink_test.go
+++ b/v2/pkg/tokens/inference_sink_test.go
@@ -1,0 +1,82 @@
+package tokens
+
+import (
+	"log/slog"
+	"testing"
+)
+
+// TestInferenceSinkRecordsIntoCollectableFile verifies that usage recorded by
+// the sink lands in a file the token Collector globs and aggregates, attributed
+// to the correct agent. This is the counting fix for bare-mode inference agents
+// (litellm/vllm/llm-d) that never write a Claude session transcript.
+func TestInferenceSinkRecordsIntoCollectableFile(t *testing.T) {
+	dir := t.TempDir()
+	sink := NewInferenceSink(dir, slog.Default())
+
+	// Two responses for the same agent should accumulate.
+	sink.Record("kellyaa", "litellm-model", 100, 40)
+	sink.Record("kellyaa", "litellm-model", 60, 30)
+	// A different agent tracked separately.
+	sink.Record("scanner", "litellm-model", 10, 5)
+
+	agg, err := CollectFromDir(dir, DefaultAgentDetector)
+	if err != nil {
+		t.Fatalf("CollectFromDir: %v", err)
+	}
+
+	// kellyaa: input 160 + output 70 = 230; scanner: 15; total 245.
+	const wantTotal = int64(245)
+	if agg.TotalTokens != wantTotal {
+		t.Fatalf("TotalTokens = %d, want %d", agg.TotalTokens, wantTotal)
+	}
+	if got := agg.ByAgent["kellyaa"]; got != 230 {
+		t.Fatalf("ByAgent[kellyaa] = %d, want 230", got)
+	}
+	if got := agg.ByAgent["scanner"]; got != 15 {
+		t.Fatalf("ByAgent[scanner] = %d, want 15", got)
+	}
+	// Explicit agent attribution must not fall through to "unknown".
+	if _, ok := agg.ByAgent["unknown"]; ok {
+		t.Fatalf("unexpected 'unknown' agent bucket: %+v", agg.ByAgent)
+	}
+}
+
+// TestInferenceSinkNoOps verifies the sink safely ignores empty agents, zero
+// usage, and a disabled (empty-dir) sink without writing files or panicking.
+func TestInferenceSinkNoOps(t *testing.T) {
+	dir := t.TempDir()
+	sink := NewInferenceSink(dir, slog.Default())
+
+	sink.Record("", "model", 100, 100)  // empty agent
+	sink.Record("agent", "model", 0, 0) // no usage
+	var nilSink *InferenceSink
+	nilSink.Record("agent", "model", 100, 100) // nil sink
+
+	agg, err := CollectFromDir(dir, DefaultAgentDetector)
+	if err != nil {
+		t.Fatalf("CollectFromDir: %v", err)
+	}
+	if agg.TotalTokens != 0 {
+		t.Fatalf("expected no tokens recorded, got %d", agg.TotalTokens)
+	}
+}
+
+// TestParseSessionFileExplicitAgent verifies the parser honors an explicit
+// per-entry agent field over keyword detection.
+func TestParseSessionFileExplicitAgent(t *testing.T) {
+	dir := t.TempDir()
+	// First user message ("architect") would keyword-detect as architect,
+	// but the explicit agent field must win.
+	content := `{"role":"user","agent":"kellyaa","message":"architect"}
+{"role":"assistant","agent":"kellyaa","model":"m","input_tokens":10,"output_tokens":5}
+`
+	writeFile(t, dir, "inference-kellyaa.jsonl", content)
+
+	agg, err := CollectFromDir(dir, DefaultAgentDetector)
+	if err != nil {
+		t.Fatalf("CollectFromDir: %v", err)
+	}
+	if got := agg.ByAgent["kellyaa"]; got != 15 {
+		t.Fatalf("ByAgent[kellyaa] = %d, want 15 (explicit agent should win)", got)
+	}
+}


### PR DESCRIPTION
## Problem

Hosted hives on heartbeat-only clusters (reached via heartbeat, not hub-kubectl) showed **zero tokens** on the hub's My Hives page even while their agents were actively consuming. Live-confirmed on `kellyaa`: 5 inference agents running on entitled litellm models, mid-response, but the hub — and the spoke's own `/api/tokens` — reported `total_tokens:0`.

Root cause was **two layers**:

1. **The spoke never counted inference-agent tokens at all.** Bare-mode inference agents (litellm/vllm/llm-d) run `claude --bare` against the on-spoke Anthropic→OpenAI translator, so they never write a Claude session transcript. The token collector only scans session `*.jsonl` files, so their usage was invisible. The "tokens: zero consumed" health warning was *accurate*.
2. **The heartbeat never sent a token total.** The `tokens_24h` wire field existed on the hub receiver but had no sender, and the My Hives page had no Tokens column.

## Fix

### (A) Counting — capture usage at the translator
- The translator now reads the gateway's OpenAI `usage` block (`prompt_tokens`/`completion_tokens`) for every inference response — **both non-streaming and streaming** — and records it per-agent via a new `tokens.InferenceSink`.
- Streaming requests now set `stream_options.include_usage` so gateways emit the terminal usage chunk (otherwise SSE responses carry no counts).
- The sink mirrors cumulative per-agent totals into atomically-rewritten `*.jsonl` files under the metrics dir the collector **already globs** — so inference usage flows into the same `AggregateSummary` the dashboard, governor budget, and heartbeat read. **No parallel counter.**
- `SessionEntry` gains an explicit `agent` field so attribution is exact, not keyword-guessed. Backward compatible (normal Claude/Copilot sessions omit it).

### (B) Reporting — heartbeat + hub display
- The spoke heartbeat now populates `tokens_24h` from the collector's authoritative cumulative total.
- The My Hives page renders a **Tokens** column (compact K/M/B, sortable), refreshed each heartbeat (~5 min cadence — as fresh as the last heartbeat).
- **hub-kubectl hives need no change** — they already get tokens the same way (heartbeat); there was never a separate kubectl token path.

### Semantics
The field name keeps its historical `24h` suffix, but the value is a **lifetime/window cumulative total**, consistent with what the spoke dashboard already shows. Column labeled "Cumulative tokens consumed, as of the last heartbeat".

The "tokens: zero consumed" warning clears once a nonzero total arrives.

## Result
After this change, `kellyaa`'s `/api/tokens` returns nonzero for its running litellm agents (translator now records their usage), and that total propagates to the hub's My Hives Tokens column each heartbeat.

## Tests
- `InferenceSink` → collector aggregation (per-agent accumulation, no `unknown` bucket, no-op safety on nil/empty/zero).
- Explicit-agent parsing wins over keyword detection.
- Hub stores and clamps the heartbeat token total onto `RegistryEntry.TotalTokens24h`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)