### PR TITLE
fix(acmm): reconcile full roster on level apply, gate set-level on success

### DIFF
--- a/v2/pkg/dashboard/acmm_roster_reconcile_test.go
+++ b/v2/pkg/dashboard/acmm_roster_reconcile_test.go
@@ -1,0 +1,141 @@
+package dashboard
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// packAgentNames returns the non-hidden agent names defined by a pack level.
+func packAgentNames(t *testing.T, level int) []string {
+	t.Helper()
+	pack, err := config.ACMMPackByLevel(level)
+	if err != nil {
+		t.Fatalf("ACMMPackByLevel(%d): %v", level, err)
+	}
+	var names []string
+	for _, a := range pack.Agents {
+		if !a.Hidden {
+			names = append(names, a.Name)
+		}
+	}
+	return names
+}
+
+// TestApplyPackReconcilesFullRoster is the core regression test for the ACMM
+// apply bug: setting a hive's level to N must bring the agent roster AND the
+// governor cadences up to level N's pack. Upgrading from a lower level must ADD
+// every agent the higher level introduces (architect + strategist at L5), each
+// with its pack cadence in every governor mode.
+func TestApplyPackReconcilesFullRoster(t *testing.T) {
+	srv := newFullServer(t) // starts at L2 with only scanner in config
+
+	if _, err := srv.ApplyPack(5); err != nil {
+		t.Fatalf("ApplyPack(5): %v", err)
+	}
+
+	// Every non-hidden agent the L5 pack defines must be in config.Agents.
+	for _, name := range packAgentNames(t, 5) {
+		if _, ok := srv.deps.Config.Agents[name]; !ok {
+			t.Errorf("agent %q missing from config after L5 apply", name)
+		}
+	}
+	// strategist is the specific agent that went missing on kellyaa.
+	if _, ok := srv.deps.Config.Agents["strategist"]; !ok {
+		t.Error("strategist missing from config.Agents after L5 apply")
+	}
+
+	// Cadences must also be reconciled: every governor mode must carry a
+	// strategist cadence, otherwise a newly-added agent never gets scheduled.
+	pack, err := config.ACMMPackByLevel(5)
+	if err != nil {
+		t.Fatalf("ACMMPackByLevel(5): %v", err)
+	}
+	for modeName, packCadences := range pack.Governor.Cadences {
+		mode, ok := srv.deps.Config.Governor.Modes[modeName]
+		if !ok {
+			t.Errorf("governor mode %q missing after L5 apply", modeName)
+			continue
+		}
+		for agent, want := range packCadences {
+			got, ok := mode.Cadences[agent]
+			if !ok {
+				t.Errorf("mode %q: cadence for %q missing after L5 apply", modeName, agent)
+				continue
+			}
+			if got != want {
+				t.Errorf("mode %q: cadence for %q = %q, want %q", modeName, agent, got, want)
+			}
+		}
+	}
+}
+
+// TestApplyPackAllLevelsRosterMatchesPack verifies that applying any level N
+// leaves config.Agents a superset of level N's non-hidden pack roster.
+func TestApplyPackAllLevelsRosterMatchesPack(t *testing.T) {
+	for level := 1; level <= 6; level++ {
+		srv := newFullServer(t)
+		if _, err := srv.ApplyPack(level); err != nil {
+			t.Fatalf("ApplyPack(%d): %v", level, err)
+		}
+		for _, name := range packAgentNames(t, level) {
+			if _, ok := srv.deps.Config.Agents[name]; !ok {
+				t.Errorf("L%d: agent %q missing from config after apply", level, name)
+			}
+		}
+	}
+}
+
+// TestApplyPackReconcilesOrphanAgent covers the orphan case: an agent already
+// present in config as a bare/leftover entry (the leftover strategist that was
+// running but had no proper config backing) must be reconciled with its pack
+// fields and cadence when the level that includes it is applied — turning an
+// orphan into a legitimately configured agent rather than leaving it stranded.
+func TestApplyPackReconcilesOrphanAgent(t *testing.T) {
+	srv := newFullServer(t)
+	// Pre-seed a bare strategist entry (no backend/model/kick template).
+	srv.deps.Config.Agents["strategist"] = config.AgentConfig{Role: "strategist"}
+
+	if _, err := srv.ApplyPack(5); err != nil {
+		t.Fatalf("ApplyPack(5): %v", err)
+	}
+
+	sc := srv.deps.Config.Agents["strategist"]
+	if sc.KickTemplate == "" {
+		t.Error("orphan strategist did not get its pack kick_template after apply")
+	}
+	if sc.Mode == "" {
+		t.Error("orphan strategist did not get its pack mode after apply")
+	}
+	for modeName := range map[string]struct{}{"surge": {}, "busy": {}, "quiet": {}, "idle": {}} {
+		mode := srv.deps.Config.Governor.Modes[modeName]
+		if _, ok := mode.Cadences["strategist"]; !ok {
+			t.Errorf("mode %q: strategist cadence missing after orphan reconcile", modeName)
+		}
+	}
+}
+
+// TestSetLevelFailsWhenRosterReconcileFails locks in the fix for the decoupling
+// bug: PUT /api/packs/level must NOT report success when the roster could not
+// be reconciled to the requested level. Previously it wrote acmm_level, then
+// only logged a warning if ApplyPack failed, returning HTTP 200 — leaving
+// "level says N, roster says fewer" with no error surfaced.
+func TestSetLevelFailsWhenRosterReconcileFails(t *testing.T) {
+	srv := newFullServer(t)
+	// Force ApplyPack to fail: no agents dir configured.
+	srv.deps.Config.Data.AgentsDir = ""
+
+	req := httptest.NewRequest("PUT", "/api/packs/level", strings.NewReader(`{"level":5}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.handlePackSetLevel(w, req)
+
+	if w.Code == 200 {
+		t.Fatalf("expected non-200 when roster reconcile fails, got 200 body=%s", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "reconciliation failed") {
+		t.Errorf("expected reconciliation-failed error, got body=%s", w.Body.String())
+	}
+}

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
@@ -15,12 +16,12 @@ func (s *Server) handlePacksList(w http.ResponseWriter, r *http.Request) {
 	currentLevel := s.detectCurrentLevel()
 
 	type packSummary struct {
-		Level       int                `json:"level"`
-		Name        string             `json:"name"`
-		Description string             `json:"description"`
-		AgentCount  int                `json:"agentCount"`
+		Level       int                 `json:"level"`
+		Name        string              `json:"name"`
+		Description string              `json:"description"`
+		AgentCount  int                 `json:"agentCount"`
 		Governor    config.PackGovernor `json:"governor"`
-		Current     bool               `json:"current"`
+		Current     bool                `json:"current"`
 		Agents      []config.PackAgent  `json:"agents"`
 	}
 
@@ -68,6 +69,13 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 	var skipped []string
 
 	var updated []string
+	// Collect per-agent create failures instead of aborting the whole apply on
+	// the first one. Aborting mid-loop leaves a partially reconciled roster
+	// (some of the level's agents added, the rest missing) that no longer
+	// matches acmm_level — the exact "level says N, roster says fewer" drift we
+	// are fixing. We reconcile every agent we can, then surface a combined
+	// error so the caller does NOT record the level as cleanly applied.
+	var createErrs []string
 	for _, pa := range pack.Agents {
 		if existing, exists := s.deps.Config.Agents[pa.Name]; exists {
 			changed := false
@@ -140,8 +148,13 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 		}
 
 		if err := config.SaveAgentFile(agentsDir, pa.Name, agentCfg); err != nil {
-			s.logger.Error("failed to save agent from pack", "agent", pa.Name, "error", err)
-			return nil, fmt.Errorf("failed to save agent %s: %w", pa.Name, err)
+			// Do not abort: keep reconciling the rest of the roster. The agent
+			// is still added to the in-memory config below so it appears in
+			// /api/status and is retried on the next apply; the combined error
+			// returned at the end prevents the level from being recorded as
+			// cleanly applied.
+			s.logger.Error("failed to save agent overlay file from pack (continuing)", "agent", pa.Name, "error", err)
+			createErrs = append(createErrs, fmt.Sprintf("%s: %v", pa.Name, err))
 		}
 
 		s.deps.Config.Agents[pa.Name] = agentCfg
@@ -223,14 +236,21 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 	go s.refreshAsync()
 	s.logger.Info("ACMM pack applied", "level", level, "name", pack.Name, "created", len(created), "updated", len(updated), "skipped", len(skipped), "paused", len(paused), "resumed", len(resumed))
 
-	return &ApplyPackResult{
+	result := &ApplyPackResult{
 		Name:    pack.Name,
 		Created: created,
 		Updated: updated,
 		Skipped: skipped,
 		Paused:  paused,
 		Resumed: resumed,
-	}, nil
+	}
+	if len(createErrs) > 0 {
+		// Return the result alongside the error so callers can still see what
+		// was reconciled, but the non-nil error signals the roster is not
+		// fully persisted and the level must not be reported as cleanly set.
+		return result, fmt.Errorf("failed to persist %d pack agent(s): %s", len(createErrs), strings.Join(createErrs, "; "))
+	}
+	return result, nil
 }
 
 func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
@@ -252,15 +272,15 @@ func (s *Server) handlePackApply(w http.ResponseWriter, r *http.Request) {
 
 	s.auditFromRequest(r, "apply_pack", auditDetail("level", levelStr, "name", result.Name), "")
 	jsonResponse(w, map[string]interface{}{
-		"ok":         true,
-		"status":     "applied",
-		"level":      level,
-		"name":       result.Name,
-		"created":    result.Created,
-		"updated":    result.Updated,
-		"skipped":    result.Skipped,
-		"paused":     result.Paused,
-		"resumed":    result.Resumed,
+		"ok":      true,
+		"status":  "applied",
+		"level":   level,
+		"name":    result.Name,
+		"created": result.Created,
+		"updated": result.Updated,
+		"skipped": result.Skipped,
+		"paused":  result.Paused,
+		"resumed": result.Resumed,
 	})
 }
 
@@ -300,11 +320,21 @@ func (s *Server) handlePackSetLevel(w http.ResponseWriter, r *http.Request) {
 	s.deps.AgentMgr.ClearAllModeOverrides()
 
 	// ApplyPack cascades pack-defined agent fields (mode, kick_template,
-	// description, etc.) into the live config. Without this, the mode-clear
-	// above leaves every agent with mode="" and the gh proxy blocks merges.
+	// description, etc.) into the live config AND reconciles the roster —
+	// adding every agent the level introduces (e.g. strategist/architect at
+	// L5) plus their governor cadences. Without this, the mode-clear above
+	// leaves every agent with mode="" and the gh proxy blocks merges.
+	//
+	// If ApplyPack fails the roster is NOT reconciled to the level, so we must
+	// NOT report success: acmm_level was already written above, and returning
+	// 200 here is exactly what left kellyaa at "acmm_level: 5, 8 agents,
+	// strategist missing". Surface the error so the operator sees the drift
+	// and can retry instead of trusting a false success.
 	packResult, packErr := s.ApplyPack(level)
 	if packErr != nil {
-		s.logger.Warn("failed to apply pack after level change", "level", level, "error", packErr)
+		s.logger.Error("failed to reconcile roster after level change", "level", level, "error", packErr)
+		jsonError(w, "level set but roster reconciliation failed: "+packErr.Error(), http.StatusInternalServerError)
+		return
 	}
 
 	paused, resumed := s.syncAgentVisibility(level)


### PR DESCRIPTION
## Problem

Setting a hive's ACMM level could leave `acmm_level` ahead of the actual agent roster. Observed live on a hub-managed hive: runtime config had `acmm_level: 5` but only 8 agents — **strategist was missing** from both `config.Agents` and every governor cadence, even though the L5 pack (`v2/pkg/config/packs/level-5.yaml`) defines strategist with a full agent def and a `strategist: 4h` cadence in all four modes. The L5 dialog UI still showed "9 agents" while the sidebar (rendered from `/api/status` = real config) showed 8. A leftover strategist process was left orphaned — running with no config backing.

## Root cause — two combined defects

1. **`handlePackSetLevel` decoupled the level write from the roster reconcile.** It wrote `acmm_level` and called `saveConfig()` *before* `ApplyPack`, then only logged a `Warn` if `ApplyPack` failed — returning **HTTP 200** with the pack's full agent list in the response body. The dashboard rendered 9 agents from that response; the persisted config never got them. This is the exact fingerprint of the live drift: level persisted, roster not, success reported.

2. **`ApplyPack` aborted the whole apply on the first agent overlay write failure** (`SaveAgentFile` err → `return nil, err`), leaving a partially reconciled roster while `acmm_level` had already been advanced.

## Fix

- `handlePackSetLevel` now returns **HTTP 500** if `ApplyPack` fails, so the level write and roster reconcile succeed or fail together from the caller's view — no more false-success.
- `ApplyPack` now collects per-agent create failures, keeps reconciling the rest of the roster (each agent still lands in the in-memory config so it shows in `/api/status` and is retried on the next apply), and returns a combined error so the level is not recorded as cleanly applied.

Upgrading to level N reliably ADDS every agent the level introduces (architect + strategist at L5) with its pack cadence in all governor modes, and turns a leftover/orphan agent entry into a properly configured one (verified: orphan strategist gains its pack `kick_template`, `mode`, and cadence).

## Cadences

Cadences were also affected on the failure path (strategist had no cadence entry). Confirmed the reconcile writes the strategist cadence into `surge/busy/quiet/idle` for all pack-defined agents once `ApplyPack` completes.

## Tests

`v2/pkg/dashboard/acmm_roster_reconcile_test.go`:
- `TestApplyPackReconcilesFullRoster` — apply L5 → config agents + all-mode cadences == L5 pack.
- `TestApplyPackAllLevelsRosterMatchesPack` — L1–L6 roster is a superset of each pack.
- `TestApplyPackReconcilesOrphanAgent` — leftover strategist gains pack fields + cadence.
- `TestSetLevelFailsWhenRosterReconcileFails` — set-level surfaces reconcile failure instead of reporting success.

All dashboard + config package tests pass; `go build ./...` clean; `gofmt` clean.