### PR TITLE
feat(dashboard): runtime model discovery for CLI backends (copilot/claude/gemini/goose)

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -157,6 +157,16 @@ func (m *Manager) SetCopilotToken(token string) {
 	m.copilotAuthToken = token
 }
 
+// CopilotToken returns the cached Copilot (GitHub OAuth) token, or "" if
+// none is set. Used by the dashboard's model-discovery probe to authenticate
+// against the Copilot models endpoint. The value is a secret and must never
+// be logged.
+func (m *Manager) CopilotToken() string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.copilotAuthToken
+}
+
 // BackendAuthAvailable reports whether shared credentials exist for a CLI
 // backend, so the dashboard can show honest auth state even for agents with
 // no running pane (e.g. on-demand agents that never launched). Claude checks

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3775,11 +3775,21 @@ func (s *Server) handleBackends(w http.ResponseWriter, r *http.Request) {
 	llmdModels := s.queryInferenceModels("llm-d")
 	litellmModels := s.queryInferenceModels("litellm")
 
+	// CLI backends each have a DIFFERENT discovery source (see cli_models.go):
+	// copilot → per-account Copilot /models, gemini → generativelanguage
+	// /v1beta/models, claude → maintained static list (no API exists), goose →
+	// configured provider's static list. Every probe is best-effort and falls
+	// back to a current static list, so a dropdown is never empty.
+	claudeCLI := s.queryCLIModels("claude")
+	copilotCLI := s.queryCLIModels("copilot")
+	geminiCLI := s.queryCLIModels("gemini")
+	gooseCLI := s.queryCLIModels("goose")
+
 	jsonResponse(w, []map[string]interface{}{
-		{"id": "claude", "name": "Claude Code", "models": []string{"opus", "sonnet", "haiku"}},
-		{"id": "copilot", "name": "GitHub Copilot", "models": []string{"gpt-4o", "gpt-4o-mini"}},
-		{"id": "gemini", "name": "Gemini", "models": []string{"gemini-2.5-pro", "gemini-2.5-flash"}},
-		{"id": "goose", "name": "Goose", "models": []string{"default"}},
+		{"id": "claude", "name": "Claude Code", "models": claudeCLI.models, "fallback": claudeCLI.fallback},
+		{"id": "copilot", "name": "GitHub Copilot", "models": copilotCLI.models, "fallback": copilotCLI.fallback},
+		{"id": "gemini", "name": "Gemini", "models": geminiCLI.models, "fallback": geminiCLI.fallback},
+		{"id": "goose", "name": "Goose", "models": gooseCLI.models, "fallback": gooseCLI.fallback},
 		{"id": "vllm", "name": "vLLM (self-hosted)", "models": vllmModels, "inference": true},
 		{"id": "llm-d", "name": "llm-d (self-hosted)", "models": llmdModels, "inference": true},
 		{"id": "litellm", "name": "LiteLLM (proxy)", "models": litellmModels, "inference": true},

--- a/v2/pkg/dashboard/cli_models.go
+++ b/v2/pkg/dashboard/cli_models.go
@@ -1,0 +1,507 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// This file adds runtime model discovery for the CLI backends (copilot,
+// claude, gemini, goose), mirroring the /v1/models discovery already done
+// for the inference backends (vllm/llm-d/litellm) in api.go.
+//
+// Each CLI has a DIFFERENT discovery source — there is NO single uniform
+// endpoint like LiteLLM's /v1/models:
+//
+//   - copilot: GET <copilot-api>/models with the stored GitHub OAuth token
+//     and a Copilot-Integration-Id header. The api host is per-account
+//     (public vs enterprise), so it is itself discovered from
+//     api.github.com/copilot_internal/user (endpoints.api). Verified live.
+//   - gemini:  GET generativelanguage.googleapis.com/v1beta/models with the
+//     configured Gemini API key. Live only when a key is configured.
+//   - claude:  Anthropic publishes no per-subscription "list my models"
+//     endpoint and the Claude CLI has no non-interactive `claude models`
+//     command, so this is a maintained static list of CURRENT model ids
+//     (kept in sync with CLAUDE_CLI_MODELS in static/index.html).
+//   - goose:   provider-configured (Ollama/OpenAI/Anthropic/...). Without a
+//     stable machine-readable "list models for my provider" command, this
+//     returns a per-provider static list, or "default" when unconfigured.
+//
+// Every discovery is BEST-EFFORT: a failed or absent probe falls back to a
+// current static list so a dropdown is never empty and never errors. Results
+// are cached with a short TTL. Tokens are never logged.
+
+const (
+	// cliModelCacheTTL bounds how long a discovered (or fallback) CLI model
+	// list is reused before re-probing. Mirrors the inference-model dropdown
+	// cache TTL on the frontend (INFERENCE_MODEL_CACHE_TTL_MS = 30s) so the
+	// server- and client-side caches age at the same rate.
+	cliModelCacheTTL = 30 * time.Second
+
+	// cliModelQueryTimeout limits each outbound discovery HTTP call so a slow
+	// or hanging upstream cannot stall the /api/config/backends response.
+	cliModelQueryTimeout = 5 * time.Second
+
+	// --- Copilot ---
+
+	// copilotUserEndpointURL returns per-account Copilot metadata, including
+	// endpoints.api (which differs for enterprise vs public plans) — so the
+	// models host is discovered, never hardcoded.
+	copilotUserEndpointURL = "https://api.github.com/copilot_internal/user"
+
+	// copilotDefaultAPIHost is the public Copilot API host, used only if the
+	// per-account endpoint lookup fails to return one.
+	copilotDefaultAPIHost = "https://api.githubcopilot.com"
+
+	// copilotModelsPath is the models listing path on the Copilot API host.
+	copilotModelsPath = "/models"
+
+	// copilotIntegrationID identifies the calling client to the Copilot API.
+	// "vscode-chat" is the widely-accepted chat integration id (verified live
+	// against both public and enterprise hosts). Overridable via
+	// HIVE_COPILOT_INTEGRATION_ID in case the accepted value changes.
+	copilotIntegrationID = "vscode-chat"
+
+	// copilotEditorVersion is sent as Editor-Version; the Copilot endpoints
+	// require a plausible editor identifier.
+	copilotEditorVersion = "vscode/1.99.0"
+
+	// --- Gemini ---
+
+	// geminiModelsURL lists models available to a Gemini API key.
+	geminiModelsURL = "https://generativelanguage.googleapis.com/v1beta/models"
+
+	// geminiModelsPageSize caps the models page (the API allows up to 1000).
+	geminiModelsPageSize = 200
+
+	// geminiGenerateMethod is the supportedGenerationMethods entry that marks
+	// a model as usable for chat/content generation (vs embeddings, etc.).
+	geminiGenerateMethod = "generateContent"
+)
+
+// --- Static fallback lists (kept CURRENT — July 2026) ---
+
+// claudeStaticModels is the maintained fallback/authoritative list for the
+// Claude CLI. Anthropic exposes no "list my models" API and the CLI has no
+// non-interactive list command, so this list IS the source of truth. Keep it
+// in sync with CLAUDE_CLI_MODELS in static/index.html. Both the canonical
+// dated/versioned ids AND the bare aliases the CLI accepts are included.
+var claudeStaticModels = []string{
+	"claude-fable-5",
+	"claude-opus-4-8",
+	"claude-opus-4-7",
+	"claude-opus-4-6",
+	"claude-sonnet-5",
+	"claude-sonnet-4-6",
+	"claude-sonnet-4-5",
+	"claude-haiku-4-5",
+	// Bare aliases the Claude CLI also accepts.
+	"opus",
+	"sonnet",
+	"haiku",
+}
+
+// copilotStaticModels is the fallback offered when the Copilot models probe
+// cannot run (no token) or fails. Copilot's real list is entitlement-filtered
+// per plan and changes often, so live discovery is strongly preferred; this
+// is only a floor so the dropdown is never empty.
+var copilotStaticModels = []string{
+	"gpt-5.4",
+	"gpt-5.2",
+	"gpt-4.1",
+	"gpt-4o",
+	"claude-opus-4.6",
+	"claude-sonnet-4.6",
+	"claude-sonnet-4.5",
+	"claude-haiku-4.5",
+	"gemini-2.5-pro",
+	"gemini-flash-3.5",
+	"o3",
+	"o4-mini",
+}
+
+// geminiStaticModels is the fallback when no Gemini API key is configured (or
+// discovery fails). Keep CURRENT.
+var geminiStaticModels = []string{
+	"gemini-3-pro-preview",
+	"gemini-3-flash-preview",
+	"gemini-2.5-pro",
+	"gemini-2.5-flash",
+}
+
+// gooseProviderStaticModels maps a configured goose provider to a sensible
+// static model list, used when goose can't be probed for its provider's live
+// model set. "default" (last resort) means goose is unconfigured.
+var gooseProviderStaticModels = map[string][]string{
+	"ollama":     {"llama3.3", "qwen2.5", "deepseek-r1", "default"},
+	"openai":     {"gpt-5.4", "gpt-4.1", "gpt-4o", "o3", "o4-mini"},
+	"anthropic":  {"claude-opus-4-8", "claude-sonnet-4-6", "claude-haiku-4-5"},
+	"google":     {"gemini-3-pro-preview", "gemini-2.5-pro", "gemini-2.5-flash"},
+	"databricks": {"databricks-claude-opus", "databricks-meta-llama"},
+}
+
+// cliModelResult is a cached, best-effort model list for one CLI backend.
+type cliModelResult struct {
+	models   []string
+	fallback bool // true when the list is the static fallback, not live discovery
+}
+
+type cliModelCacheEntry struct {
+	result cliModelResult
+	at     time.Time
+}
+
+// cliModelCache is a short-TTL per-backend cache guarding the discovery probes.
+type cliModelCache struct {
+	mu      sync.Mutex
+	entries map[string]cliModelCacheEntry
+}
+
+func newCLIModelCache() *cliModelCache {
+	return &cliModelCache{entries: make(map[string]cliModelCacheEntry)}
+}
+
+// get returns a cached result if it is still within the TTL.
+func (c *cliModelCache) get(backend string) (cliModelResult, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[backend]
+	if !ok || time.Since(e.at) > cliModelCacheTTL {
+		return cliModelResult{}, false
+	}
+	return e.result, true
+}
+
+func (c *cliModelCache) set(backend string, r cliModelResult) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[backend] = cliModelCacheEntry{result: r, at: time.Now()}
+}
+
+// queryCLIModels returns the model list for a CLI backend (copilot, claude,
+// gemini, goose), running the backend's best-effort discovery probe (cached)
+// and falling back to a current static list on any failure. It never errors
+// and never returns an empty list.
+func (s *Server) queryCLIModels(backend string) cliModelResult {
+	if s.cliModels != nil {
+		if r, ok := s.cliModels.get(backend); ok {
+			return r
+		}
+	}
+
+	var r cliModelResult
+	switch backend {
+	case "copilot":
+		r = s.discoverCopilotModels()
+	case "gemini":
+		r = s.discoverGeminiModels()
+	case "goose":
+		r = s.discoverGooseModels()
+	case "claude":
+		// No live source exists; the maintained static list is authoritative.
+		r = cliModelResult{models: dedupeModels(claudeStaticModels), fallback: false}
+	default:
+		r = cliModelResult{models: nil, fallback: true}
+	}
+
+	if len(r.models) == 0 {
+		r.models = dedupeModels(cliStaticFallback(backend))
+		r.fallback = true
+	}
+	if s.cliModels != nil {
+		s.cliModels.set(backend, r)
+	}
+	return r
+}
+
+// cliStaticFallback returns the current static model list for a CLI backend.
+func cliStaticFallback(backend string) []string {
+	switch backend {
+	case "copilot":
+		return copilotStaticModels
+	case "gemini":
+		return geminiStaticModels
+	case "claude":
+		return claudeStaticModels
+	case "goose":
+		return []string{"default"}
+	default:
+		return nil
+	}
+}
+
+// --- Copilot discovery ---
+
+// discoverCopilotModels lists the chat-capable models available to the stored
+// Copilot token. The api host is itself discovered per-account (public vs
+// enterprise). Best-effort: any failure returns fallback=true with an empty
+// list so the caller substitutes the static list.
+func (s *Server) discoverCopilotModels() cliModelResult {
+	token := s.copilotToken()
+	if token == "" {
+		return cliModelResult{fallback: true}
+	}
+	host := s.copilotAPIHost(token)
+	integrationID := copilotIntegrationID
+	if v := os.Getenv("HIVE_COPILOT_INTEGRATION_ID"); v != "" {
+		integrationID = v
+	}
+
+	models, err := fetchCopilotModels(host+copilotModelsPath, token, integrationID)
+	if err != nil || len(models) == 0 {
+		if err != nil {
+			// Do NOT log the token or full URL query; just the failure.
+			s.logger.Warn("copilot model discovery failed", "err", err.Error())
+		}
+		return cliModelResult{fallback: true}
+	}
+	return cliModelResult{models: dedupeModels(models), fallback: false}
+}
+
+// copilotToken resolves the Copilot GitHub OAuth token from the agent manager
+// (device-flow login) or the COPILOT_GITHUB_TOKEN env var. Secret — never log.
+func (s *Server) copilotToken() string {
+	if s.deps != nil && s.deps.AgentMgr != nil {
+		if t := s.deps.AgentMgr.CopilotToken(); t != "" {
+			return t
+		}
+	}
+	return os.Getenv("COPILOT_GITHUB_TOKEN")
+}
+
+// copilotAPIHost resolves the per-account Copilot API host from
+// copilot_internal/user (enterprise plans use api.enterprise.githubcopilot.com,
+// not the public host). Falls back to the public host on any failure.
+func (s *Server) copilotAPIHost(token string) string {
+	client := &http.Client{Timeout: cliModelQueryTimeout}
+	req, err := http.NewRequest(http.MethodGet, copilotUserEndpointURL, nil)
+	if err != nil {
+		return copilotDefaultAPIHost
+	}
+	req.Header.Set("Authorization", "token "+token)
+	req.Header.Set("Editor-Version", copilotEditorVersion)
+	resp, err := client.Do(req)
+	if err != nil {
+		return copilotDefaultAPIHost
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return copilotDefaultAPIHost
+	}
+	host, ok := parseCopilotAPIHost(resp.Body)
+	if !ok || host == "" {
+		return copilotDefaultAPIHost
+	}
+	return strings.TrimRight(host, "/")
+}
+
+// parseCopilotAPIHost extracts endpoints.api from a copilot_internal/user body.
+func parseCopilotAPIHost(r io.Reader) (string, bool) {
+	var body struct {
+		Endpoints struct {
+			API string `json:"api"`
+		} `json:"endpoints"`
+	}
+	if err := json.NewDecoder(r).Decode(&body); err != nil {
+		return "", false
+	}
+	if body.Endpoints.API == "" {
+		return "", false
+	}
+	return body.Endpoints.API, true
+}
+
+// fetchCopilotModels performs the GET <host>/models call and returns the
+// chat-capable model ids.
+func fetchCopilotModels(modelsURL, token, integrationID string) ([]string, error) {
+	client := &http.Client{Timeout: cliModelQueryTimeout}
+	req, err := http.NewRequest(http.MethodGet, modelsURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Copilot-Integration-Id", integrationID)
+	req.Header.Set("Editor-Version", copilotEditorVersion)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("upstream returned %d", resp.StatusCode)
+	}
+	return parseCopilotModelsResponse(resp.Body)
+}
+
+// parseCopilotModelsResponse decodes the Copilot /models body and returns the
+// ids of chat-capable models. The response shape is:
+//
+//	{"data":[{"id":"gpt-4o","capabilities":{"type":"chat"},"model_picker_enabled":bool}, ...]}
+//
+// It filters to capabilities.type == "chat" (skipping embeddings, etc.). When
+// no item carries a capabilities.type at all (older/edge responses), it falls
+// back to returning every non-empty id rather than an empty list.
+func parseCopilotModelsResponse(r io.Reader) ([]string, error) {
+	var body struct {
+		Data []struct {
+			ID           string `json:"id"`
+			Capabilities struct {
+				Type string `json:"type"`
+			} `json:"capabilities"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(r).Decode(&body); err != nil {
+		return nil, err
+	}
+	var chat, any []string
+	sawType := false
+	for _, m := range body.Data {
+		if m.ID == "" {
+			continue
+		}
+		any = append(any, m.ID)
+		if m.Capabilities.Type != "" {
+			sawType = true
+			if m.Capabilities.Type == "chat" {
+				chat = append(chat, m.ID)
+			}
+		}
+	}
+	if sawType {
+		return chat, nil
+	}
+	return any, nil
+}
+
+// --- Gemini discovery ---
+
+// discoverGeminiModels lists content-generation models for the configured
+// Gemini API key. Best-effort: no key or a failed call → fallback=true.
+func (s *Server) discoverGeminiModels() cliModelResult {
+	key := geminiAPIKey()
+	if key == "" {
+		return cliModelResult{fallback: true}
+	}
+	models, err := fetchGeminiModels(key)
+	if err != nil || len(models) == 0 {
+		if err != nil {
+			s.logger.Warn("gemini model discovery failed", "err", err.Error())
+		}
+		return cliModelResult{fallback: true}
+	}
+	return cliModelResult{models: dedupeModels(models), fallback: false}
+}
+
+// geminiAPIKey resolves the Gemini API key from the standard env vars. Secret.
+func geminiAPIKey() string {
+	for _, v := range []string{"GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_GENAI_API_KEY"} {
+		if k := os.Getenv(v); k != "" {
+			return k
+		}
+	}
+	return ""
+}
+
+// fetchGeminiModels calls the v1beta/models list endpoint and returns the ids
+// (with the "models/" prefix stripped) of models that support generateContent.
+func fetchGeminiModels(apiKey string) ([]string, error) {
+	client := &http.Client{Timeout: cliModelQueryTimeout}
+	url := fmt.Sprintf("%s?pageSize=%d", geminiModelsURL, geminiModelsPageSize)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	// Pass the key via header (not the query string) so it never lands in a
+	// URL that might be logged upstream.
+	req.Header.Set("x-goog-api-key", apiKey)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("upstream returned %d", resp.StatusCode)
+	}
+	return parseGeminiModelsResponse(resp.Body)
+}
+
+// parseGeminiModelsResponse decodes the Gemini models list, keeping only
+// models that support generateContent and stripping the "models/" name prefix.
+func parseGeminiModelsResponse(r io.Reader) ([]string, error) {
+	var body struct {
+		Models []struct {
+			Name                       string   `json:"name"`
+			SupportedGenerationMethods []string `json:"supportedGenerationMethods"`
+		} `json:"models"`
+	}
+	if err := json.NewDecoder(r).Decode(&body); err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, m := range body.Models {
+		if m.Name == "" {
+			continue
+		}
+		if !contains(m.SupportedGenerationMethods, geminiGenerateMethod) {
+			continue
+		}
+		out = append(out, strings.TrimPrefix(m.Name, "models/"))
+	}
+	return out, nil
+}
+
+// --- Goose discovery ---
+
+// discoverGooseModels returns models for goose's configured provider. Goose has
+// no stable machine-readable "list models for my configured provider" command
+// across providers, so this maps the configured provider (via GOOSE_PROVIDER /
+// GOOSE_MODEL env, honoring the pinned model) to a static per-provider list,
+// or "default" when unconfigured. Marked fallback=true since it is not a live
+// provider query.
+func (s *Server) discoverGooseModels() cliModelResult {
+	provider := strings.ToLower(strings.TrimSpace(os.Getenv("GOOSE_PROVIDER")))
+	var models []string
+	if list, ok := gooseProviderStaticModels[provider]; ok {
+		models = append(models, list...)
+	}
+	// If a specific model is pinned via GOOSE_MODEL, surface it first.
+	if m := strings.TrimSpace(os.Getenv("GOOSE_MODEL")); m != "" {
+		models = append([]string{m}, models...)
+	}
+	if len(models) == 0 {
+		models = []string{"default"}
+	}
+	// Always fallback=true: this is a curated per-provider list, not a live
+	// enumeration of the provider's catalog.
+	return cliModelResult{models: dedupeModels(models), fallback: true}
+}
+
+// --- helpers ---
+
+// dedupeModels removes duplicate ids while preserving first-seen order.
+func dedupeModels(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, m := range in {
+		if m == "" || seen[m] {
+			continue
+		}
+		seen[m] = true
+		out = append(out, m)
+	}
+	return out
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/v2/pkg/dashboard/cli_models_test.go
+++ b/v2/pkg/dashboard/cli_models_test.go
@@ -1,0 +1,197 @@
+package dashboard
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestParseCopilotModelsResponse_FiltersChat(t *testing.T) {
+	body := `{"data":[
+		{"id":"gpt-4o","capabilities":{"type":"chat"}},
+		{"id":"gpt-4o-mini-2024-07-18","capabilities":{"type":"chat"}},
+		{"id":"text-embedding-3-small","capabilities":{"type":"embeddings"}},
+		{"id":"","capabilities":{"type":"chat"}}
+	]}`
+	got, err := parseCopilotModelsResponse(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	want := []string{"gpt-4o", "gpt-4o-mini-2024-07-18"}
+	if !equalStrings(got, want) {
+		t.Fatalf("got %v, want %v (embeddings and empty id should be dropped)", got, want)
+	}
+}
+
+func TestParseCopilotModelsResponse_NoTypeReturnsAll(t *testing.T) {
+	// Older/edge responses may omit capabilities.type entirely — we then keep
+	// every non-empty id rather than returning an empty list.
+	body := `{"data":[{"id":"gpt-4o"},{"id":"gpt-4o-mini"}]}`
+	got, err := parseCopilotModelsResponse(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !equalStrings(got, []string{"gpt-4o", "gpt-4o-mini"}) {
+		t.Fatalf("got %v, want all ids", got)
+	}
+}
+
+func TestParseCopilotModelsResponse_Malformed(t *testing.T) {
+	if _, err := parseCopilotModelsResponse(strings.NewReader("not json")); err == nil {
+		t.Fatal("expected error on malformed body")
+	}
+}
+
+func TestParseCopilotAPIHost(t *testing.T) {
+	body := `{"login":"x","endpoints":{"api":"https://api.enterprise.githubcopilot.com","proxy":"y"}}`
+	host, ok := parseCopilotAPIHost(strings.NewReader(body))
+	if !ok || host != "https://api.enterprise.githubcopilot.com" {
+		t.Fatalf("got %q ok=%v, want enterprise api host", host, ok)
+	}
+}
+
+func TestParseCopilotAPIHost_Missing(t *testing.T) {
+	if _, ok := parseCopilotAPIHost(strings.NewReader(`{"login":"x"}`)); ok {
+		t.Fatal("expected ok=false when endpoints.api absent")
+	}
+}
+
+func TestParseGeminiModelsResponse_FiltersGenerateContent(t *testing.T) {
+	body := `{"models":[
+		{"name":"models/gemini-3-pro-preview","supportedGenerationMethods":["generateContent","countTokens"]},
+		{"name":"models/embedding-001","supportedGenerationMethods":["embedContent"]},
+		{"name":"models/gemini-2.5-flash","supportedGenerationMethods":["generateContent"]}
+	]}`
+	got, err := parseGeminiModelsResponse(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	want := []string{"gemini-3-pro-preview", "gemini-2.5-flash"}
+	if !equalStrings(got, want) {
+		t.Fatalf("got %v, want %v (embedding-only + models/ prefix should be handled)", got, want)
+	}
+}
+
+func TestDedupeModels(t *testing.T) {
+	got := dedupeModels([]string{"a", "b", "a", "", "c", "b"})
+	if !equalStrings(got, []string{"a", "b", "c"}) {
+		t.Fatalf("got %v, want [a b c]", got)
+	}
+}
+
+// TestQueryCLIModels_ClaudeStatic verifies claude returns a non-empty,
+// non-fallback (authoritative static) list without any network call.
+func TestQueryCLIModels_ClaudeStatic(t *testing.T) {
+	s := &Server{cliModels: newCLIModelCache()}
+	r := s.queryCLIModels("claude")
+	if len(r.models) == 0 {
+		t.Fatal("claude models should never be empty")
+	}
+	if r.fallback {
+		t.Fatal("claude static list is authoritative, not a fallback")
+	}
+	if !contains(r.models, "claude-opus-4-8") {
+		t.Fatalf("claude models missing current id: %v", r.models)
+	}
+}
+
+// TestQueryCLIModels_CopilotFallbackNoToken verifies that without a Copilot
+// token, discovery yields the static fallback (non-empty, fallback=true) and
+// does not error.
+func TestQueryCLIModels_CopilotFallbackNoToken(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "")
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.queryCLIModels("copilot")
+	if len(r.models) == 0 {
+		t.Fatal("copilot fallback must be non-empty")
+	}
+	if !r.fallback {
+		t.Fatal("copilot with no token must be marked fallback")
+	}
+}
+
+// TestQueryCLIModels_GeminiFallbackNoKey verifies gemini falls back when no
+// API key is configured.
+func TestQueryCLIModels_GeminiFallbackNoKey(t *testing.T) {
+	for _, v := range []string{"GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_GENAI_API_KEY"} {
+		t.Setenv(v, "")
+	}
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.queryCLIModels("gemini")
+	if len(r.models) == 0 || !r.fallback {
+		t.Fatalf("gemini with no key must be a non-empty fallback, got %+v", r)
+	}
+}
+
+// TestQueryCLIModels_GooseUsesProvider verifies goose maps a configured
+// provider to its static list.
+func TestQueryCLIModels_GooseUsesProvider(t *testing.T) {
+	t.Setenv("GOOSE_PROVIDER", "anthropic")
+	t.Setenv("GOOSE_MODEL", "")
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.queryCLIModels("goose")
+	if !contains(r.models, "claude-opus-4-8") {
+		t.Fatalf("goose+anthropic should include anthropic models, got %v", r.models)
+	}
+	if !r.fallback {
+		t.Fatal("goose provider list is a curated fallback, not live discovery")
+	}
+}
+
+func TestQueryCLIModels_GooseUnconfigured(t *testing.T) {
+	t.Setenv("GOOSE_PROVIDER", "")
+	t.Setenv("GOOSE_MODEL", "")
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.queryCLIModels("goose")
+	if !equalStrings(r.models, []string{"default"}) {
+		t.Fatalf("unconfigured goose should be [default], got %v", r.models)
+	}
+}
+
+func TestQueryCLIModels_GoosePinnedModelFirst(t *testing.T) {
+	t.Setenv("GOOSE_PROVIDER", "ollama")
+	t.Setenv("GOOSE_MODEL", "my-pinned-model")
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.queryCLIModels("goose")
+	if len(r.models) == 0 || r.models[0] != "my-pinned-model" {
+		t.Fatalf("pinned GOOSE_MODEL should be first, got %v", r.models)
+	}
+}
+
+// TestCLIModelCache_TTL verifies the cache returns a stored value within TTL
+// and misses after it expires.
+func TestCLIModelCache_TTL(t *testing.T) {
+	c := newCLIModelCache()
+	c.set("copilot", cliModelResult{models: []string{"x"}})
+	if _, ok := c.get("copilot"); !ok {
+		t.Fatal("expected cache hit within TTL")
+	}
+	// Force expiry by backdating the entry.
+	c.mu.Lock()
+	c.entries["copilot"] = cliModelCacheEntry{
+		result: cliModelResult{models: []string{"x"}},
+		at:     time.Now().Add(-cliModelCacheTTL - time.Second),
+	}
+	c.mu.Unlock()
+	if _, ok := c.get("copilot"); ok {
+		t.Fatal("expected cache miss after TTL")
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -89,6 +89,11 @@ type Server struct {
 	inferenceMu        sync.RWMutex
 	inferenceEndpoints map[string][]string // backend id → list of base URLs
 
+	// cliModels caches best-effort runtime model discovery for the CLI
+	// backends (copilot/claude/gemini/goose), each with its own discovery
+	// source and static fallback. See cli_models.go.
+	cliModels *cliModelCache
+
 	ready   bool
 	readyAt time.Time
 
@@ -357,6 +362,7 @@ func NewServer(port int, logger *slog.Logger) *Server {
 		agentHooks:     make(map[string]map[string][]any),
 		audit:          newAuditLog(),
 		userSessions:   make(map[string]*userSession),
+		cliModels:      newCLIModelCache(),
 	}
 	s.registerCoreRoutes()
 	return s
@@ -373,6 +379,7 @@ func NewServerWithAuth(port int, authToken string, logger *slog.Logger) *Server 
 		agentHooks:     make(map[string]map[string][]any),
 		audit:          newAuditLog(),
 		userSessions:   make(map[string]*userSession),
+		cliModels:      newCLIModelCache(),
 	}
 	s.registerCoreRoutes()
 	return s


### PR DESCRIPTION
## Summary

Replaces the hardcoded, stale model lists for the **copilot / claude / gemini / goose** CLI backends in `handleBackends` with **per-CLI runtime discovery**, mirroring `queryInferenceModels` for the inference backends (litellm/vllm/llm-d).

Each CLI has a **different** discovery source (this is NOT one uniform `/v1/models` endpoint). Every probe is **best-effort with a current static fallback** so a dropdown is never empty or errored, and results are cached with a short TTL (`cliModelCacheTTL = 30s`, matching the frontend `INFERENCE_MODEL_CACHE_TTL_MS`).

## Discovery source per CLI

| CLI | Source | Live? |
|-----|--------|-------|
| **copilot** | `GET <api>/models` with the stored GitHub OAuth token + `Copilot-Integration-Id: vscode-chat`. The API **host is itself discovered** per-account from `copilot_internal/user` (`endpoints.api`) — enterprise plans use `api.enterprise.githubcopilot.com`, not the public host. Filters to `capabilities.type == chat`. | ✅ Live (verified against a real enterprise account) |
| **gemini** | `GET generativelanguage v1beta/models` with the configured API key (`x-goog-api-key` header, never the query string), filtered to models supporting `generateContent`. | ✅ Live when a key is configured, else static |
| **claude** | Maintained static list — Anthropic exposes **no** per-subscription "list my models" API and the Claude CLI has **no** non-interactive list command. Kept in sync with `CLAUDE_CLI_MODELS`; includes the bare aliases the CLI accepts. | ⚠️ Static only (no API exists) |
| **goose** | Configured-provider static list via `GOOSE_PROVIDER`/`GOOSE_MODEL`; `default` when unconfigured. Goose has no stable cross-provider machine-readable list command. | ⚠️ Static (per configured provider) |

## Shape / frontend

The `/api/config/backends` shape is **unchanged** (`{id,name,models,[inference]}`), plus a per-backend `fallback` marker reusing the existing litellm fallback convention. No frontend change required.

## Constraints honored

- Tokens **never logged** (only failure reasons); Copilot token read via new `Manager.CopilotToken()` getter; Gemini key passed as header not query string.
- Best-effort: absent/failed probe → static fallback, never an error or empty dropdown.
- Named constants for all endpoints + TTL + integration id (`HIVE_COPILOT_INTEGRATION_ID` override).
- Static lists current as of July 2026.
- `gofmt` clean; unit tests for parse + fallback per CLI (sample response → parsed ids; absent token/key → fallback).

## Tests

`parseCopilotModelsResponse` (chat filter + no-type-returns-all + malformed), `parseCopilotAPIHost`, `parseGeminiModelsResponse` (generateContent filter + prefix strip), dedupe, cache TTL, and `queryCLIModels` fallback paths for all four CLIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)