### PR TITLE
feat(hub): add Docs link to HIVE HUB dashboard top bar

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3791,6 +3791,7 @@ const dashboardHTML = `<!DOCTYPE html>
       <a href="/get-started">Get Started</a>
       <a href="/dashboard" style="color:var(--amber)">My Hives</a>
       <a href="/api/docs" target="_blank">API</a>
+      <a href="https://kubestellar.io/docs/hive/overview/introduction" target="_blank" rel="noopener">Docs</a>
       <span id="nav-user" class="nav-user"></span>
     </nav>
     <div class="header-right">


### PR DESCRIPTION
## Summary
- Adds a "Docs" link to the HIVE HUB dashboard top bar (`hive.kubestellar.io` — My Hives page), pointing at https://kubestellar.io/docs/hive/overview/introduction
- Opens in a new tab (`target="_blank" rel="noopener"`)
- Placed in the nav alongside the existing global links (Hives, Learn, Get Started, My Hives, API), before the user avatar — styled identically to the existing "API" link using existing design tokens, no new CSS

## Test plan
- [x] `gofmt -e pkg/hub/saas.go` — clean, no diff
- [x] `go build ./pkg/hub/...` — succeeds
- [x] Verified the raw Go string still compiles (no backticks introduced)
- [ ] Visual check on hive.kubestellar.io after deploy (light/dark theme, narrow width)