### PR TITLE
fix(dashboard): stop model auto-heal stampede on flapping CLI discovery

### DIFF
--- a/v2/pkg/dashboard/cli_models.go
+++ b/v2/pkg/dashboard/cli_models.go
@@ -47,6 +47,21 @@ const (
 	// or hanging upstream cannot stall the /api/config/backends response.
 	cliModelQueryTimeout = 5 * time.Second
 
+	// cliModelDropAfterMisses is how many consecutive successful live
+	// discovery probes a previously-seen model must be missing from before
+	// it is dropped from the served list. The Copilot /models response is
+	// nondeterministic mid-rollout — verified live: the same token returned
+	// 31 vs 35 chat-capable models across calls seconds apart, with
+	// rollout-gated ids (claude-opus-4.6, claude-fable-5, gemini-3.x,
+	// kimi-k2.7-code) absent from individual samples. Serving one bad
+	// sample as authoritative made the dashboard auto-heal switch every
+	// agent off a model the account is in fact entitled to. Retention only
+	// smooths LIVE results; static fallback lists bypass it entirely, and a
+	// genuinely revoked model still drops after this many consecutive
+	// misses (roughly cliModelDropAfterMisses × cliModelCacheTTL of stable
+	// absence).
+	cliModelDropAfterMisses = 3
+
 	// --- Copilot ---
 
 	// copilotUserEndpointURL returns per-account Copilot metadata, including
@@ -157,13 +172,69 @@ type cliModelCacheEntry struct {
 }
 
 // cliModelCache is a short-TTL per-backend cache guarding the discovery probes.
+// It also carries the live-list retention state (see stabilize).
 type cliModelCache struct {
 	mu      sync.Mutex
 	entries map[string]cliModelCacheEntry
+	// retained tracks, per backend, every model id seen in a successful live
+	// probe together with its consecutive-miss count (0 = present in the
+	// latest probe). Used by stabilize() to smooth nondeterministic upstream
+	// responses. Insertion order is kept in retainedOrder so the served list
+	// stays stable for the frontend's list-change detection.
+	retained      map[string]map[string]int
+	retainedOrder map[string][]string
 }
 
 func newCLIModelCache() *cliModelCache {
-	return &cliModelCache{entries: make(map[string]cliModelCacheEntry)}
+	return &cliModelCache{
+		entries:       make(map[string]cliModelCacheEntry),
+		retained:      make(map[string]map[string]int),
+		retainedOrder: make(map[string][]string),
+	}
+}
+
+// stabilize merges a fresh successful LIVE discovery result with recently-seen
+// models for the backend: a model that was present in earlier live probes but
+// is missing from this one is retained (appended after the fresh ids, in
+// first-seen order) until it has been missing from cliModelDropAfterMisses
+// consecutive probes. This shields consumers — most importantly the
+// dashboard's model auto-heal — from upstream sampling noise while still
+// converging on genuine entitlement changes. Never called for fallback lists.
+func (c *cliModelCache) stabilize(backend string, fresh []string) []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	misses := c.retained[backend]
+	if misses == nil {
+		misses = make(map[string]int)
+		c.retained[backend] = misses
+	}
+	inFresh := make(map[string]bool, len(fresh))
+	for _, m := range fresh {
+		inFresh[m] = true
+		if _, known := misses[m]; !known {
+			c.retainedOrder[backend] = append(c.retainedOrder[backend], m)
+		}
+		misses[m] = 0
+	}
+
+	out := append([]string(nil), fresh...)
+	keptOrder := c.retainedOrder[backend][:0]
+	for _, m := range c.retainedOrder[backend] {
+		if inFresh[m] {
+			keptOrder = append(keptOrder, m)
+			continue
+		}
+		misses[m]++
+		if misses[m] >= cliModelDropAfterMisses {
+			delete(misses, m) // genuinely gone — stop retaining
+			continue
+		}
+		keptOrder = append(keptOrder, m)
+		out = append(out, m) // retained: missing, but not yet confirmed gone
+	}
+	c.retainedOrder[backend] = keptOrder
+	return out
 }
 
 // get returns a cached result if it is still within the TTL.
@@ -212,6 +283,11 @@ func (s *Server) queryCLIModels(backend string) cliModelResult {
 	if len(r.models) == 0 {
 		r.models = dedupeModels(cliStaticFallback(backend))
 		r.fallback = true
+	} else if !r.fallback && s.cliModels != nil {
+		// Smooth nondeterministic live results (see cliModelDropAfterMisses):
+		// a model seen recently is kept through transient upstream omissions
+		// so a single bad sample cannot trigger downstream auto-heal churn.
+		r.models = s.cliModels.stabilize(backend, r.models)
 	}
 	if s.cliModels != nil {
 		s.cliModels.set(backend, r)

--- a/v2/pkg/dashboard/cli_models_test.go
+++ b/v2/pkg/dashboard/cli_models_test.go
@@ -195,3 +195,70 @@ func equalStrings(a, b []string) bool {
 	}
 	return true
 }
+
+// --- stabilize: live-list retention across nondeterministic upstream samples ---
+
+// TestCLIModelCacheStabilize_TransientMissRetained verifies a model seen in a
+// previous live probe survives samples that transiently omit it (the observed
+// Copilot /models 31-vs-35 flapping), and reappearance resets its miss count.
+func TestCLIModelCacheStabilize_TransientMissRetained(t *testing.T) {
+	c := newCLIModelCache()
+	full := []string{"claude-opus-4.7", "claude-opus-4.6", "gpt-5.4"}
+	bad := []string{"claude-opus-4.7", "gpt-5.4"} // sample missing claude-opus-4.6
+
+	if got := c.stabilize("copilot", full); !equalStrings(got, full) {
+		t.Fatalf("first probe should pass through, got %v", got)
+	}
+	// Misses 1..cliModelDropAfterMisses-1: the model must be retained.
+	for i := 1; i < cliModelDropAfterMisses; i++ {
+		got := c.stabilize("copilot", bad)
+		if !contains(got, "claude-opus-4.6") {
+			t.Fatalf("miss %d: claude-opus-4.6 must be retained, got %v", i, got)
+		}
+	}
+	// Reappearance resets the miss counter...
+	if got := c.stabilize("copilot", full); !contains(got, "claude-opus-4.6") {
+		t.Fatalf("reappearance: got %v", got)
+	}
+	// ...so the drop clock starts over.
+	for i := 1; i < cliModelDropAfterMisses; i++ {
+		if got := c.stabilize("copilot", bad); !contains(got, "claude-opus-4.6") {
+			t.Fatalf("post-reset miss %d: claude-opus-4.6 must be retained, got %v", i, got)
+		}
+	}
+}
+
+// TestCLIModelCacheStabilize_DropsAfterConsecutiveMisses verifies a genuinely
+// removed model is dropped once (and only once) it has been missing from
+// cliModelDropAfterMisses consecutive live probes.
+func TestCLIModelCacheStabilize_DropsAfterConsecutiveMisses(t *testing.T) {
+	c := newCLIModelCache()
+	full := []string{"claude-opus-4.7", "claude-opus-4.6"}
+	bad := []string{"claude-opus-4.7"}
+
+	c.stabilize("copilot", full)
+	var got []string
+	for i := 0; i < cliModelDropAfterMisses; i++ {
+		got = c.stabilize("copilot", bad)
+	}
+	if contains(got, "claude-opus-4.6") {
+		t.Fatalf("model must drop after %d consecutive misses, got %v", cliModelDropAfterMisses, got)
+	}
+	// And the served order/content now equals the fresh probe exactly.
+	if !equalStrings(got, bad) {
+		t.Fatalf("got %v, want %v", got, bad)
+	}
+}
+
+// TestCLIModelCacheStabilize_PerBackendIsolation verifies retention state is
+// keyed per backend.
+func TestCLIModelCacheStabilize_PerBackendIsolation(t *testing.T) {
+	c := newCLIModelCache()
+	c.stabilize("copilot", []string{"a", "b"})
+	if got := c.stabilize("gemini", []string{"x"}); !equalStrings(got, []string{"x"}) {
+		t.Fatalf("gemini must not inherit copilot retention, got %v", got)
+	}
+	if got := c.stabilize("copilot", []string{"a"}); !contains(got, "b") {
+		t.Fatalf("copilot retention lost, got %v", got)
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4644,12 +4644,54 @@
     // reconcileModelsAfterDiscovery auto-heals selections that a key swap
     // (or endpoint change) stripped out: when a REAL discovery (not the
     // static fallback) returns a non-empty model set, any agent on this
-    // backend whose selected model is no longer in the set is switched to
-    // the first available model, via the same switchModel() path the
-    // dropdown uses (so it persists + relaunches, not a cosmetic change).
+    // backend whose selected model is GENUINELY no longer in the set is
+    // switched to the first available model, via the same switchModel()
+    // path the dropdown uses (so it persists + relaunches, not a cosmetic
+    // change).
+    //
+    // Auto-heal policy: a model may switch automatically in exactly two
+    // cases — (a) unpinned + governor auto-selection (server-side; pins
+    // block that path there), or (b) the current model is genuinely gone
+    // from discovery. Case (b) applies to every backend, CLI included, and
+    // may heal even a PINNED model (a pinned-but-dead model would leave the
+    // agent broken) — but only under the strict confirmation rules below.
+    //
+    // "Genuinely gone" is enforced three ways, because live CLI discovery
+    // is nondeterministic: the Copilot /models endpoint was observed live
+    // returning 31 vs 35 chat models for the SAME token across calls
+    // seconds apart, with rollout-gated ids (e.g. claude-opus-4.6,
+    // claude-fable-5) dropping out of individual samples. Treating one
+    // sample as authoritative stampeded every agent — pinned included —
+    // onto the first model of a bad sample, repeatedly (#1845 regression):
+    //   1. availability uses the SAME tolerant matcher as the dropdown
+    //      preselect (_modelIdMatches: exact, prefix-stripped tail, and
+    //      dotted/hyphenated version normalization) — a model present in
+    //      any id spelling is KEPT, never switched;
+    //   2. absence must persist for MODEL_HEAL_CONFIRM_MS across repeated
+    //      discovery refreshes (spanning multiple independent server-side
+    //      probes) — a lone bad sample warns on the console and heals
+    //      nothing; reappearance resets the clock;
+    //   3. a heal fires at most once per (backend, agent, model) until that
+    //      model is seen available again — repeated refresh ticks with an
+    //      unchanged list can never re-fire a switch/restart loop.
     // Strictly: keep the current model when it is still present — no
     // re-select, no toast, no relaunch. Idempotent: repeated refreshes with
     // a compatible list never mutate a valid selection.
+
+    // How long a model must be CONTINUOUSLY absent from successful
+    // discoveries before auto-heal may act. Longer than two server-side
+    // discovery cache TTLs (cliModelCacheTTL = 30s), so confirmation always
+    // spans at least two independent upstream probes, not one cached bad
+    // sample re-served within its TTL.
+    const MODEL_HEAL_CONFIRM_MS = 65000;
+    // First-seen-absent timestamps: `${backend}|${agent}` -> {model, since}.
+    // Cleared the moment the model shows up as available again.
+    const _modelAbsenceSince = {};
+    // Fired-heal guard: `${backend}|${agent}|${model}` -> true. Ensures one
+    // switch (one session restart) per genuine disappearance; cleared only
+    // when the model is observed available again.
+    const _modelHealFired = {};
+
     function reconcileModelsAfterDiscovery(backend, models, fallback) {
       // Guard: only act on a genuinely successful discovery. Never switch
       // based on unverified static aliases or an empty list.
@@ -4657,23 +4699,58 @@
       const available = models.map(m => m.value);
       const first = available[0];
       const isAvailable = (m) => available.some(v => _modelIdMatches(v, m));
+      const now = Date.now();
+
+      // _confirmAbsent implements rules 2+3 above for one keyed selection.
+      // Returns true only when the model has been absent long enough AND
+      // this disappearance has not already been healed.
+      const _confirmAbsent = (key, model) => {
+        const firedKey = `${key}|${model}`;
+        const rec = _modelAbsenceSince[key];
+        if (!rec || rec.model !== model) {
+          // First observation of this absence — start the clock, warn, keep.
+          _modelAbsenceSince[key] = { model, since: now };
+          console.warn(`model ${model} missing from ${backend} discovery (${available.length} models) — keeping selection; auto-heal only if still absent after ${Math.round(MODEL_HEAL_CONFIRM_MS / 1000)}s`);
+          return false;
+        }
+        if (now - rec.since < MODEL_HEAL_CONFIRM_MS) return false;
+        if (_modelHealFired[firedKey]) return false; // already healed this disappearance
+        _modelHealFired[firedKey] = true;
+        delete _modelAbsenceSince[key];
+        return true;
+      };
+      // _markAvailable clears absence/fired state so a future GENUINE
+      // disappearance of the same model is eligible to heal again.
+      const _markAvailable = (key, model) => {
+        const rec = _modelAbsenceSince[key];
+        if (rec && rec.model === model) delete _modelAbsenceSince[key];
+        delete _modelHealFired[`${key}|${model}`];
+      };
 
       // 1) Agents whose effective method is this backend.
       (window._lastAgents || []).forEach(a => {
         if (a.cli !== backend) return;
         if (!a.model) return;                 // no explicit model — nothing to heal
-        if (isAvailable(a.model)) return;     // still valid — leave untouched (idempotent)
+        const key = `${backend}|${a.name}`;
+        if (isAvailable(a.model)) { _markAvailable(key, a.model); return; } // still valid — leave untouched (idempotent)
+        if (!_confirmAbsent(key, a.model)) return; // unconfirmed or already healed — no switch
         const label = a.displayName || a.name;
-        showToast(`${label}: model ${a.model.split('/').pop()} unavailable on ${backend} — switched to ${first.split('/').pop()}`, 'info');
+        const pinNote = (a.pinnedModel || a.pinnedBoth) ? ' (was pinned — model gone from provider)' : '';
+        showToast(`${label}: model ${a.model.split('/').pop()} no longer available on ${backend} — switched to ${first.split('/').pop()}${pinNote}`, 'info');
         switchModel(a.name, first);           // persists + relaunches via /api/model
       });
 
       // 2) LiteLLM Default Model — only when the config dialog holds governor
       // data (that is where the saved default is available to the UI). If the
       // saved default is gone from the new set, persist the first available.
+      // Same confirmation rules as agent heals — a lone bad sample or a
+      // repeated refresh tick never rewrites the saved default.
       if (backend === 'litellm' && _configState.type === 'governor') {
         const saved = (_configState.data.litellm || {}).defaultModel;
-        if (saved && !isAvailable(saved)) {
+        const defKey = `${backend}|__defaultModel__`;
+        if (saved && isAvailable(saved)) {
+          _markAvailable(defKey, saved);
+        } else if (saved && _confirmAbsent(defKey, saved)) {
           _configState.data.litellm.defaultModel = first;
           fetch('/api/config/governor/litellm', {
             method: 'PUT',


### PR DESCRIPTION
## Summary

After #1845 wired `reconcileModelsAfterDiscovery()` to CLI backends, every agent on the console hive — including a **pinned** scanner on `claude-opus-4.6` — was auto-switched to `claude-opus-4.7` with repeated session restarts.

## Root cause (verified live)

The Copilot `/models` endpoint is **nondeterministic mid-rollout**: the same enterprise token returned **31 vs 35** chat-capable models across calls seconds apart, with rollout-gated ids (`claude-opus-4.6`, `claude-fable-5`, `gemini-3.x`, `kimi-k2.7-code`) absent from individual samples. `claude-opus-4.6` IS entitled and present in good samples — the heal fired on a **bad sample that omitted it** (heal target `claude-opus-4.7` = first id of that bad sample), **not** on an id-format mismatch (`_modelIdMatches` handles exact/prefix/dots-hyphens correctly; verified). The reconcile treated every successful sample as authoritative, re-evaluated on every ~30s refresh tick with no once-guard, and never considered pins. The switch loop is purely frontend-driven (`POST /api/model` per agent) — confirmed via audit logs (`trigger: dashboard-api`, all 10 agents at 20:36) — so the guards belong in the frontend, plus a server-side list stabilizer.

## Policy enforced

A model may switch automatically in exactly two cases:
- **(a)** unpinned + governor auto-selection — pins already block this path (`Manager.PinModel`/`SetModelOverride`)
- **(b)** discovery shows the current model is **genuinely** no longer available — any backend, CLI included; may heal even a pinned model (a pinned-but-dead model would leave the agent broken)

## Changes

**Server** (`cli_models.go`): `stabilize()` — a model seen in earlier live probes is retained through transient omissions and dropped only after `cliModelDropAfterMisses = 3` consecutive successful probes without it. Live results only; static fallbacks bypass it. Unit tests: retention, drop-after-misses, reappearance reset, per-backend isolation.

**Frontend** (`index.html`):
- availability keeps the tolerant `_modelIdMatches` matcher — a model present in **any** id spelling is always kept
- absence must persist `MODEL_HEAL_CONFIRM_MS = 65s` (≥ two independent server probes) before any switch; first observation logs a console warning only; reappearance resets the clock
- a heal fires **at most once** per (backend, agent, model) disappearance — repeated refresh ticks with an unchanged list can never re-fire a switch/restart loop
- pinned models switch only via this genuine-unavailability path (toast notes it); LiteLLM default-model heal gets the same confirmation + fire-once rules

## Verification

- `node --check` on both extracted script blocks — clean
- 17-scenario vm simulation: model present in any variant → no switch; lone bad sample → warn only; genuine removal → exactly one switch incl. pinned, zero repeats on later ticks; fallback/empty lists inert; litellm default → single PUT, no repeats
- Live sampling of Copilot `/models` (6 calls): membership flaps 31↔35 while `claude-opus-4.6` stays entitled — exactly the pattern the fix absorbs
- `go build` / `go vet` / `go test ./pkg/dashboard/` clean

Fixes the console-hive stampede observed 2026-07-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)