### PR TITLE
🐛 fix: verify GitHub App write access on Re-check; rebuild auth on config reload

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -97,6 +97,17 @@ func main() {
 	cfg.HiveID = loadOrGenerateHiveID(logger)
 	os.Setenv("HIVE_ID", cfg.HiveID)
 
+	// Surface config provenance: when the dashboard-save backup exists, init
+	// containers restore it over the ConfigMap seed on restart, so edits made
+	// only to the seed (or only to the live file) silently lose to the backup.
+	bakPath := *configPath + ".bak"
+	if _, statErr := os.Stat(bakPath); statErr == nil {
+		logger.Info("config backup present — restored over the seed on pod restart; fixes must land in the live config so the next save refreshes it",
+			"path", bakPath,
+			"github_installation_id", cfg.GitHub.InstallationID,
+		)
+	}
+
 	logger.Info("hive starting",
 		"org", cfg.Project.Org,
 		"repos", cfg.Project.Repos,
@@ -991,7 +1002,17 @@ func main() {
 				}
 				advisoryIssues[recheckRepo] = num
 				os.Setenv("HIVE_ADVISORY_ISSUE", fmt.Sprintf("%d", num))
-				logger.Info("github app recheck: app detected", "repo", recheckRepo, "number", num)
+				// Finding the advisory issue only proves the app is installed
+				// (reads succeed on public repos even with a token from the
+				// wrong installation). Verify write capability before letting
+				// the handler clear the banner, so Re-check can't produce a
+				// clears-then-returns flip-flop.
+				if diag := diagnoseGitHubAppWrite(ctx, ghClient.AppAuth(), cfg.Project.Org); diag != "" {
+					dashSrv.SetGitHubAppPermIssue(diag)
+					logger.Warn("github app recheck: app detected but write not verified", "repo", recheckRepo, "detail", diag)
+					return false
+				}
+				logger.Info("github app recheck: app detected, write verified", "repo", recheckRepo, "number", num)
 				return true
 			})
 		}
@@ -1133,6 +1154,10 @@ func main() {
 			newCfg.ACMMLevel = cfg.ACMMLevel
 		}
 
+		// Capture the outgoing GitHub App identity before the swap so we can
+		// tell whether the reload changed it.
+		prevGitHub := cfg.GitHub
+
 		// Swap the in-memory config pointer contents
 		*cfg = *newCfg
 
@@ -1143,6 +1168,36 @@ func main() {
 		}
 		gov.UpdateConfig(cfg.Governor)
 		initAgentConfigDrivenSystems(cfg)
+
+		// Rebuild GitHub App auth when its identity changed. AppAuth captures
+		// app_id/installation_id at construction, so without this a corrected
+		// installation_id in hive.yaml keeps minting tokens for the OLD
+		// installation until the pod restarts.
+		if prevGitHub.AppID != cfg.GitHub.AppID ||
+			prevGitHub.InstallationID != cfg.GitHub.InstallationID ||
+			prevGitHub.KeyFile != cfg.GitHub.KeyFile ||
+			prevGitHub.APIURL != cfg.GitHub.APIURL {
+			if cfg.GitHub.AppID != 0 && cfg.GitHub.InstallationID != 0 && cfg.GitHub.KeyFile != "" {
+				newAppAuth, appErr := github.NewAppAuth(cfg.GitHub.AppID, cfg.GitHub.InstallationID, cfg.GitHub.KeyFile, logger, cfg.GitHub.ResolvedAPIURL())
+				if appErr != nil {
+					logger.Error("github app auth rebuild after config reload failed", "error", appErr)
+				} else {
+					newClient := github.NewClientFromApp(newAppAuth, cfg.Project.Org, cfg.Project.Repos, logger)
+					if len(cfg.Governor.Labels.Exempt) > 0 {
+						newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
+					}
+					ghClient = newClient
+					appAuth = newAppAuth
+					agentMgr.SetAppAuth(newAppAuth)
+					dashSrv.UpdateGitHubClient(newClient, newAppAuth)
+					logger.Info("github app auth rebuilt after config reload",
+						"app_id", cfg.GitHub.AppID,
+						"installation_id", cfg.GitHub.InstallationID,
+					)
+				}
+			}
+		}
+
 		refreshDashboard()
 	}, logger)
 	dashSrv.SetSkipReloadFunc(configWatcher.SkipNext)
@@ -1708,6 +1763,35 @@ func applyBudgetAlerts(gov *governor.Governor, trans governor.BudgetTransitions,
 	}
 }
 
+// diagnoseGitHubAppWrite returns "" when the configured GitHub App
+// installation belongs to expectedOwner and grants issues:write. Otherwise it
+// returns a banner-ready diagnosis distinguishing the two write-failure causes
+// that produce identical 403s: an installation_id pointing at a different
+// org's installation, and a permission update the org owner hasn't approved
+// yet. A nil appAuth (token-authenticated hive) yields "" — nothing to check.
+func diagnoseGitHubAppWrite(ctx context.Context, appAuth *github.AppAuth, expectedOwner string) string {
+	if appAuth == nil {
+		return ""
+	}
+	info, err := appAuth.VerifyInstallation(ctx)
+	if err != nil {
+		return fmt.Sprintf("Could not verify the GitHub App installation: %v", err)
+	}
+	if expectedOwner != "" && !strings.EqualFold(info.Account, expectedOwner) {
+		return fmt.Sprintf("This hive is authenticating as GitHub App installation %d, which belongs to '%s' — not '%s'. Check github.installation_id in the hive config.",
+			info.InstallationID, info.Account, expectedOwner)
+	}
+	if info.IssuesPerm != "write" {
+		granted := info.IssuesPerm
+		if granted == "" {
+			granted = "none"
+		}
+		return fmt.Sprintf("The GitHub App is installed for '%s' but granted Issues: %s (Issues: Read & Write required). The org owner must approve the updated permissions at the app installation settings page.",
+			info.Account, granted)
+	}
+	return ""
+}
+
 func runEvalCycle(
 	ctx context.Context,
 	cfg *config.Config,
@@ -1968,10 +2052,17 @@ func runEvalCycle(
 					if err := postClient.PostAdvisoryDigest(ctx, primaryRepo, issueNum, md); err != nil {
 						logger.Warn("failed to post advisory digest", "repo", primaryRepo, "issue", issueNum, "error", err)
 						if strings.Contains(err.Error(), "403") && strings.Contains(err.Error(), "Resource not accessible by integration") {
-							// App is installed (we found the issue) but can't write — permission gap
-							dashSrv.SetGitHubAppPermIssue("The GitHub App is installed but lacks Issues: Read & Write permission. The org owner must approve updated permissions at the app installation settings page.")
+							// App is installed (we found the issue) but can't write.
+							// Resolve the actual cause — pending permission approval
+							// vs. an installation_id pointing at the wrong org — so
+							// the banner tells the user what to actually fix.
+							msg := diagnoseGitHubAppWrite(ctx, ghClient.AppAuth(), cfg.Project.Org)
+							if msg == "" {
+								msg = "The GitHub App is installed but lacks Issues: Read & Write permission. The org owner must approve updated permissions at the app installation settings page."
+							}
+							dashSrv.SetGitHubAppPermIssue(msg)
 							dashSrv.SetGitHubAppRequired(true)
-							logger.Warn("GitHub App installed but insufficient permissions — cannot write issue comments", "repo", primaryRepo)
+							logger.Warn("GitHub App installed but insufficient permissions — cannot write issue comments", "repo", primaryRepo, "detail", msg)
 						} else if strings.Contains(err.Error(), "rate limit") {
 							logger.Warn("GitHub API rate limit hit, skipping advisory digest post", "repo", primaryRepo)
 						} else if strings.Contains(err.Error(), "403") || strings.Contains(err.Error(), "401") {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3988,18 +3988,27 @@
         if (isPermIssue) {
           banner.classList.add('perm-issue');
           if (title) title.textContent = 'GitHub App — Insufficient Permissions';
-          if (desc) desc.textContent = 'The app is installed but cannot write to this repository. The org owner must approve updated permissions.';
+          if (desc) desc.textContent = 'The app is installed but cannot write to this repository.';
           if (link) { link.textContent = 'View App Settings'; link.href = data.githubAppInstallURL || 'https://github.com/apps/kubestellar-hive'; }
-          if (!existingDetails) {
-            var details = document.createElement('div');
+          var details = existingDetails;
+          if (!details) {
+            details = document.createElement('div');
             details.id = 'gh-app-perm-details';
             details.className = 'gh-app-perm-details';
+            desc.parentElement.appendChild(details);
+          }
+          // The server composes the diagnosis (pending org approval vs.
+          // installation_id pointing at the wrong org), so render its exact
+          // message rather than assuming which case we're in. textContent
+          // keeps the server string safe to display verbatim.
+          if (typeof data.githubAppPermIssue === 'string' && data.githubAppPermIssue) {
+            details.textContent = data.githubAppPermIssue;
+          } else {
             details.innerHTML = '<strong>Current permissions:</strong><br>'
               + '<span class="perm-ok">✓ Issues: Read</span> — can find and read issues<br>'
               + '<span class="perm-missing">✗ Issues: Write</span> — cannot create or update issue comments<br>'
               + '<br><strong>Required:</strong> Issues: Read &amp; Write<br>'
               + '<em>The org owner must go to Organization Settings → GitHub Apps → kubestellar-hive → Configure and accept the updated permissions.</em>';
-            desc.parentElement.appendChild(details);
           }
         } else {
           banner.classList.remove('perm-issue');

--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -234,6 +234,40 @@ func (a *AppAuth) WriteAgentToken(ctx context.Context, agentName, tier string, a
 	return nil
 }
 
+// InstallationInfo describes the GitHub App installation this hive is
+// authenticating as, resolved live from the GitHub API via the app JWT.
+type InstallationInfo struct {
+	InstallationID int64
+	Account        string // login of the org/user the installation belongs to
+	IssuesPerm     string // granted issues permission: "read", "write", or "" (none)
+}
+
+// VerifyInstallation resolves the configured installation and returns the
+// account it belongs to plus the granted issues permission. A successful
+// token mint alone does not prove write access: a stale installation_id can
+// mint valid tokens for a DIFFERENT org (public reads still work, writes 403
+// with "Resource not accessible by integration"), and an installation can be
+// granted less than the app requests until the org owner approves.
+func (a *AppAuth) VerifyInstallation(ctx context.Context) (*InstallationInfo, error) {
+	jwtToken, err := a.generateJWT()
+	if err != nil {
+		return nil, fmt.Errorf("generating JWT: %w", err)
+	}
+
+	jwtClient := gh.NewClient(nil).WithAuthToken(jwtToken)
+	setBaseURL(jwtClient, a.apiURL)
+	inst, _, err := jwtClient.Apps.GetInstallation(ctx, a.installationID)
+	if err != nil {
+		return nil, fmt.Errorf("resolving installation %d: %w", a.installationID, err)
+	}
+
+	return &InstallationInfo{
+		InstallationID: a.installationID,
+		Account:        inst.GetAccount().GetLogin(),
+		IssuesPerm:     inst.GetPermissions().GetIssues(),
+	}, nil
+}
+
 type appTransport struct {
 	auth *AppAuth
 	base http.RoundTripper
@@ -261,9 +295,10 @@ func NewClientFromApp(auth *AppAuth, org string, repos []string, logger *slog.Lo
 	setBaseURL(client, auth.apiURL)
 
 	return &Client{
-		client: client,
-		org:    org,
-		repos:  repos,
-		logger: logger,
+		client:  client,
+		org:     org,
+		repos:   repos,
+		logger:  logger,
+		appAuth: auth,
 	}
 }

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -21,6 +21,7 @@ type Client struct {
 	repos        []string
 	exemptLabels []string
 	logger       *slog.Logger
+	appAuth      *AppAuth // nil for token-authenticated clients
 }
 
 // GoGitHub returns the underlying go-github client for direct API access.
@@ -29,6 +30,15 @@ func (c *Client) GoGitHub() *gh.Client {
 		return nil
 	}
 	return c.client
+}
+
+// AppAuth returns the GitHub App auth backing this client, or nil when the
+// client authenticates with a static token instead of an app installation.
+func (c *Client) AppAuth() *AppAuth {
+	if c == nil {
+		return nil
+	}
+	return c.appAuth
 }
 
 type Issue struct {


### PR DESCRIPTION
## Summary

Fixes the "Insufficient Permissions" banner flip-flop and two config-plumbing gaps found while live-debugging a hosted hive whose `github.installation_id` pointed at a **different org's installation** (tokens minted fine, reads worked, every write 403'd, and the banner blamed org-owner approval for hours).

- **Re-check now verifies write capability, not just installation.** `EnsureAdvisoryIssue` succeeds via reads (which work on public repos even with a wrong-installation token), so Re-check cleared the banner optimistically and the next digest POST re-raised it. New `AppAuth.VerifyInstallation()` resolves the configured installation via the app JWT and checks (a) the account it belongs to matches the project org and (b) `issues: write` is granted, before the banner is allowed to clear.
- **Accurate banner diagnosis.** The 403 digest path now distinguishes "installation_id belongs to '<other-org>' — check your config" from "org owner must approve updated permissions" — identical 403s, opposite fixes. The dashboard renders the server-composed message (via `textContent`).
- **Config reload rebuilds GitHub auth.** The watcher previously only re-synced repos; `AppAuth` kept the constructor-time `installation_id` until pod restart. Reload now rebuilds auth/client when `app_id` / `installation_id` / `key_file` / `api_url` change (same code as the proven `ReinitGitHubFunc` path); it is a no-op for all other config edits.
- **Config provenance log** at startup when `hive.yaml.bak` exists (the init container restores it over the ConfigMap seed, which is how a stale installation_id survived a corrected seed).

## Risk

Additive: new method + accessor; token-auth hives (`AppAuth() == nil`) are unaffected; the reload rebuild is dormant unless the github identity fields actually change; happy-path digest posting untouched. Behavior change is confined to Re-check being stricter (no longer clears the banner without verified write access) and banner text.

Fixes #1849, Fixes #1850

🤖 Generated with [Claude Code](https://claude.com/claude-code)