### PR TITLE
🐛 fix: scanner policies treat human-filed enhancements as implementation work

### DIFF
--- a/v2/policies/scanner-automerge.md
+++ b/v2/policies/scanner-automerge.md
@@ -2,7 +2,7 @@
 
 ${GH_AUTH}
 
-You are the **scanner** agent. Your job is to fix bugs fast using parallel sub-agents.
+You are the **scanner** agent. Your job is to fix bugs and implement enhancement/feature requests fast using parallel sub-agents. Every issue in the work list is actionable work — features included.
 
 ## Priority Order
 

--- a/v2/policies/scanner-full.md
+++ b/v2/policies/scanner-full.md
@@ -71,9 +71,9 @@ For PRs in the PR_LIST that have merge conflicts:
 1. Read the work list above
 2. **Resolve merge conflicts** — update PR branches and fix simple conflicts
 3. **Reap stale findings** — re-verify open beads and close resolved ones
-4. Analyze root cause for each issue
-5. Create a GitHub issue for each confirmed finding
-6. For findings with a clear fix, create a worktree, implement, and open a PR
+4. Triage each work-list item: **bug reports** get root-cause analysis; **enhancement/feature requests** go straight to implementation (they need no confirmation)
+5. Create a GitHub issue for each NEW confirmed finding you discover yourself
+6. For work-list bugs with a clear fix AND for work-list enhancements/features, create a worktree, implement, and open a PR
 7. Create a bead for each finding
 8. Summarize completed work
 

--- a/v2/policies/scanner-holdgated.md
+++ b/v2/policies/scanner-holdgated.md
@@ -7,10 +7,11 @@ You are the **scanner** agent in a Hive instance operating in **ISSUES_AND_PRS h
 ## Rules
 
 1. **ONLY work items from the kick message** — never run `gh issue list` or `gh pr list` unprompted
-2. **NEVER merge** — not your own PRs, not anyone else's
-3. **NEVER remove the `hold` label** from any PR — humans remove it when ready
-4. **Create GitHub issues for findings** — every confirmed bug gets an issue
-5. **Create hold-labeled PRs for concrete fixes** — always label PRs `hold`
+2. **The work list is your implementation queue, not just a diagnosis queue** — a human-filed enhancement or feature request in the work list is already-approved work: implement it and open a hold-gated PR. Do NOT wait for it to become a "finding", and do NOT re-file it as a new issue
+3. **NEVER merge** — not your own PRs, not anyone else's
+4. **NEVER remove the `hold` label** from any PR — humans remove it when ready
+5. **Create GitHub issues for findings** — every confirmed bug gets an issue
+6. **Create hold-labeled PRs for concrete fixes** — always label PRs `hold`
 6. **Write findings as beads** — use `bd create` for every finding
 7. **Respect hold labels** — never touch issues labeled `hold`, `on-hold`, or `do-not-merge`
 8. **Always sign commits** with DCO: `git commit -s`
@@ -61,9 +62,9 @@ ${PR_LIST}
 
 1. Read the work list above
 2. **Reap stale findings** — re-verify open beads and close resolved ones
-3. Analyze root cause for each issue
-4. Create a GitHub issue for each confirmed finding
-5. For findings with a clear fix, create a worktree, implement, and open a hold-gated PR
+3. Triage each work-list item: **bug reports** get root-cause analysis; **enhancement/feature requests** go straight to implementation (they need no confirmation)
+4. Create a GitHub issue for each NEW confirmed finding you discover yourself
+5. For work-list bugs with a clear fix AND for work-list enhancements/features, create a worktree, implement, and open a hold-gated PR
 6. Create a bead for each finding
 7. Summarize completed work
 

--- a/v2/policies/scanner-issues.md
+++ b/v2/policies/scanner-issues.md
@@ -69,7 +69,7 @@ ${PR_LIST}
 1. Read the work list above
 2. **Reap stale findings** — re-verify open beads (`bd list --status=open --actor=scanner --json`) and close resolved ones
 3. For each issue, analyze the codebase to understand root cause and complexity
-4. Create a GitHub issue for each confirmed finding
+4. Create a GitHub issue for each NEW confirmed finding you discover yourself — for human-filed enhancements already in the work list, post an analysis comment with an implementation plan on the EXISTING issue instead of filing a duplicate
 5. Create a bead linking to the GitHub issue
 6. Summarize findings in your response
 


### PR DESCRIPTION
## Field report

On a hosted hive (ACMM L5), six human-filed enhancement issues sat in every scanner kick's work list — oldest-first, far under the 100-issue cap, no exempt/hold labels — yet were only ever *mentioned* in the advisory digest and never picked up. The operator's user asked: *"What would I need to do for that to happen?"* The answer should be: nothing.

## Root cause

The L4/L5/full scanner policies frame the whole workflow around **findings**: "create a GitHub issue for each *confirmed finding*", "for *findings* with a clear fix … open a PR". A pre-existing feature request is never a "finding" — so the scanner analyzes it, writes advisory beads (which is why the digest mentions it), and implements nothing. `scanner-automerge` (L6) has the same bias via "your job is to fix **bugs** fast". Ingestion is *not* the problem: classification lanes, exempt labels, and the kick list all deliver these issues to the scanner correctly.

## Change

- **scanner-holdgated (L5) / scanner-full**: work-list enhancements/features go straight to implementation (hold-gated PR at L5); "confirmed finding" issue-filing now applies only to new self-discovered findings; new explicit rule: *the work list is your implementation queue, not just a diagnosis queue*.
- **scanner-automerge (L6)**: job statement covers enhancements/features explicitly.
- **scanner-issues (L4)**: issues-only by design — now posts an implementation-plan comment on the existing issue instead of filing a duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)