### PR TITLE
🐛 fix: repair v2 test suite — stale contracts and data races across 5 packages

### DIFF
--- a/v2/pkg/dashboard/coverage_boost2_test.go
+++ b/v2/pkg/dashboard/coverage_boost2_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1085,17 +1086,19 @@ func TestRefreshAfterMutation_NilDeps_Boost(t *testing.T) {
 
 func TestRefreshAndPersist(t *testing.T) {
 	srv := newFullServer(t)
-	refreshed := false
-	persisted := false
-	srv.deps.RefreshFunc = func() { refreshed = true }
-	srv.deps.PersistFunc = func() { persisted = true }
+	var refreshed, persisted atomic.Bool
+	srv.deps.RefreshFunc = func() { refreshed.Store(true) }
+	srv.deps.PersistFunc = func() { persisted.Store(true) }
 	srv.refreshAndPersist()
-	// These are async (go func), give a moment
-	time.Sleep(50 * time.Millisecond)
-	if !refreshed {
+	// These run in goroutines — poll instead of racing on plain bools.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && !(refreshed.Load() && persisted.Load()) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !refreshed.Load() {
 		t.Error("refresh not called")
 	}
-	if !persisted {
+	if !persisted.Load() {
 		t.Error("persist not called")
 	}
 }

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -209,9 +209,10 @@ func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, er
 
 		prs, heldPRs, prTotal, err := c.fetchPRs(ctx, repo)
 		if err != nil {
+			// Issues for this repo were already collected; a PR-only failure
+			// is partial and must not count toward the all-repos-failed guard,
+			// which would discard real issue data and report an outage.
 			c.logger.Warn("failed to fetch PRs", "repo", repo, "error", err)
-			failedRepos++
-			lastFetchErr = err
 			continue
 		}
 		allPRs = append(allPRs, prs...)

--- a/v2/pkg/github/client_test.go
+++ b/v2/pkg/github/client_test.go
@@ -255,16 +255,15 @@ func TestEnumerateActionable_APIError(t *testing.T) {
 	defer server.Close()
 
 	c := newTestClient(t, server, org, []string{repo})
-	// EnumerateActionable logs warnings but does not return an error when individual
-	// repos fail — it continues to the next repo.
+	// When EVERY repo fails to enumerate, EnumerateActionable returns an
+	// error so the governor keeps prior state instead of reading an API
+	// outage as an empty queue.
 	result, err := c.EnumerateActionable(context.Background())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err == nil {
+		t.Fatal("expected error when all repos fail to enumerate")
 	}
-	// No data collected — counts should be zero.
-	if result.Issues.Count != 0 || result.PRs.Count != 0 {
-		t.Errorf("expected zero counts on API error, got issues=%d prs=%d",
-			result.Issues.Count, result.PRs.Count)
+	if result != nil {
+		t.Errorf("expected nil result on total failure, got %+v", result)
 	}
 }
 
@@ -685,18 +684,13 @@ func TestEnumerateActionable_IssuesErrorContinuesToPRs(t *testing.T) {
 
 	c := newTestClient(t, server, org, []string{repo})
 	result, err := c.EnumerateActionable(context.Background())
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	// The issues failure skips fetchPRs, so the single repo counts as fully
+	// failed — and with every repo failed, an error is returned.
+	if err == nil {
+		t.Fatal("expected error when the only repo fails to enumerate")
 	}
-	// When issues fetch fails, fetchIssues returns error; EnumerateActionable
-	// logs and calls `continue` — so fetchPRs is NOT called for that repo.
-	// Both counts should be 0.
-	if result.Issues.Count != 0 {
-		t.Errorf("Issues.Count = %d, want 0", result.Issues.Count)
-	}
-	// PRs also 0 because the continue skips fetchPRs.
-	if result.PRs.Count != 0 {
-		t.Errorf("PRs.Count = %d, want 0 (fetchPRs skipped after issues error)", result.PRs.Count)
+	if result != nil {
+		t.Errorf("expected nil result on total failure, got %+v", result)
 	}
 }
 

--- a/v2/pkg/github/health_test.go
+++ b/v2/pkg/github/health_test.go
@@ -462,9 +462,9 @@ func TestBrewCheck_VersionMatch(t *testing.T) {
 			"content":  "dmVyc2lvbiAiMS4yLjMi", // version "1.2.3"
 		})
 	})
-	mux.HandleFunc("/repos/org/repo1/releases/latest", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
-			"tag_name": "v1.2.3",
+	mux.HandleFunc("/repos/org/repo1/releases", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]map[string]any{
+			{"tag_name": "v1.2.3"},
 		})
 	})
 	server := httptest.NewServer(mux)
@@ -486,9 +486,9 @@ func TestBrewCheck_VersionMismatch(t *testing.T) {
 			"content":  "dmVyc2lvbiAiMS4yLjMi", // version "1.2.3"
 		})
 	})
-	mux.HandleFunc("/repos/org/repo1/releases/latest", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
-			"tag_name": "v2.0.0",
+	mux.HandleFunc("/repos/org/repo1/releases", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]map[string]any{
+			{"tag_name": "v2.0.0"},
 		})
 	})
 	server := httptest.NewServer(mux)
@@ -1171,12 +1171,13 @@ func TestEnumerateActionable_SingleRepoError(t *testing.T) {
 	})
 
 	result, err := client.EnumerateActionable(context.Background())
-	// Should not fail entirely but may have empty results
-	if err != nil {
-		t.Logf("error (expected): %v", err)
+	// The only repo failed entirely, so EnumerateActionable reports the
+	// outage instead of returning an empty (queue-looks-idle) result.
+	if err == nil {
+		t.Fatal("expected error when the only repo fails to enumerate")
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result even with errors")
+	if result != nil {
+		t.Errorf("expected nil result on total failure, got %+v", result)
 	}
 }
 

--- a/v2/pkg/hub/hub_filesystem_test.go
+++ b/v2/pkg/hub/hub_filesystem_test.go
@@ -17,6 +17,10 @@ func helperSetupTempDirs(t *testing.T) func() {
 	t.Helper()
 	dir := t.TempDir()
 
+	// Async provisioning goroutines from previously-run tests read the
+	// package-level path variables swapped below; drain them first.
+	provisionWG.Wait()
+
 	oldUsers := saasUsersDir
 	oldHives := saasHivesDir
 	oldHMAC := hmacKeyPath
@@ -34,6 +38,7 @@ func helperSetupTempDirs(t *testing.T) func() {
 	os.MkdirAll(provisionRequestsDir, 0o755)
 
 	return func() {
+		provisionWG.Wait()
 		saasUsersDir = oldUsers
 		saasHivesDir = oldHives
 		hmacKeyPath = oldHMAC

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1580,7 +1580,9 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 	user.Hives[hiveID] = "owner"
 	saveSaaSUser(user)
 
+	provisionWG.Add(1)
 	go func() {
+		defer provisionWG.Done()
 		cluster := s.clusterForHive(h)
 		if cluster == nil {
 			h.Status = "error"
@@ -2189,6 +2191,11 @@ var (
 
 // trackedBranches lists branches that produce Docker images via CI.
 var trackedBranches = []string{"v2", "v3"}
+
+// provisionWG tracks async hive-provisioning goroutines so tests (which swap
+// the package-level saas*Dir path variables) can wait for them to drain
+// before mutating shared state.
+var provisionWG sync.WaitGroup
 
 const latestSHAPollInterval = 2 * time.Minute
 

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -124,6 +124,7 @@ type HubServer struct {
 	hubGitBranch   string
 	hubSecret      string
 	httpServer     *http.Server
+	httpMu         sync.Mutex // guards httpServer (Start runs in a goroutine; Shutdown races it)
 	clusters       map[string]ClusterConfig
 	heartbeatHealth   map[string]*HeartbeatHealthEntry // cluster ID → latest health from spoke heartbeat
 	heartbeatHealthMu sync.RWMutex
@@ -229,23 +230,31 @@ const (
 func (s *HubServer) Start(port int) error {
 	addr := fmt.Sprintf(":%d", port)
 	s.logger.Info("hub server starting", "addr", addr)
-	s.httpServer = &http.Server{
+	srv := &http.Server{
 		Addr:         addr,
 		Handler:      s.mux,
 		ReadTimeout:  hubReadTimeout,
 		WriteTimeout: hubWriteTimeout,
 		IdleTimeout:  hubIdleTimeout,
 	}
-	return s.httpServer.ListenAndServe()
+	// Start typically runs in its own goroutine while Shutdown is called
+	// from another; guard the handoff of the server handle.
+	s.httpMu.Lock()
+	s.httpServer = srv
+	s.httpMu.Unlock()
+	return srv.ListenAndServe()
 }
 
 func (s *HubServer) Shutdown(timeout time.Duration) error {
-	if s.httpServer == nil {
+	s.httpMu.Lock()
+	srv := s.httpServer
+	s.httpMu.Unlock()
+	if srv == nil {
 		return nil
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	return s.httpServer.Shutdown(ctx)
+	return srv.Shutdown(ctx)
 }
 
 func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/knowledge/docsource_test.go
+++ b/v2/pkg/knowledge/docsource_test.go
@@ -93,8 +93,10 @@ func TestDocumentSource_ImportURL(t *testing.T) {
 		t.Fatalf("Import failed: %v", err)
 	}
 
-	if meta.Title != "Test Paper" {
-		t.Errorf("title = %q, want Test Paper", meta.Title)
+	// The configured Name wins over the HTML-extracted title; extraction is
+	// only the fallback when Name is empty.
+	if meta.Title != "test-paper" {
+		t.Errorf("title = %q, want test-paper (config name)", meta.Title)
 	}
 	if meta.ContentType != "text/html" {
 		t.Errorf("content_type = %q, want text/html", meta.ContentType)
@@ -207,7 +209,7 @@ func TestDocumentSource_NoSourceError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for document with no URL or file path")
 	}
-	if !strings.Contains(err.Error(), "neither url nor file_path") {
+	if !strings.Contains(err.Error(), "has no url, file_path, or context7_id") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/v2/pkg/proxy/rules.go
+++ b/v2/pkg/proxy/rules.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"sync"
 	"encoding/json"
 	"regexp"
 	"strings"
@@ -17,22 +18,29 @@ type ProxyRule struct {
 }
 
 // githubHosts are the hostnames the proxy inspects.
+var githubHostsMu sync.RWMutex
 var githubHosts = map[string]bool{
 	"api.github.com": true,
 	"github.com":     true,
 }
 
 // RegisterGitHubHost adds a custom hostname (e.g. GHE instance) to the
-// allowlist so that the proxy applies mode enforcement to it.
+// allowlist so that the proxy applies mode enforcement to it. Callers can
+// register hosts while proxy goroutines are already serving, so the map is
+// mutex-guarded.
 func RegisterGitHubHost(host string) {
 	if host == "" {
 		return
 	}
+	githubHostsMu.Lock()
 	githubHosts[host] = true
+	githubHostsMu.Unlock()
 }
 
 // IsGitHubHost returns true if the host should be subject to mode enforcement.
 func IsGitHubHost(host string) bool {
+	githubHostsMu.RLock()
+	defer githubHostsMu.RUnlock()
 	return githubHosts[host]
 }
 


### PR DESCRIPTION
\`v2 Tests\` has been red on every run today (since at least 13:56Z, pre-dating today's merges): 26 failures, 9 root causes across 5 packages. Full breakdown in the commit message. Highlights:

- **Two production races fixed**: \`HubServer.httpServer\` (Start-in-goroutine vs Shutdown) and proxy's \`githubHosts\` map (RegisterGitHubHost vs IsGitHubHost under live traffic).
- **One production behavior fix**: a repo whose issues fetch succeeded but PR fetch failed counted toward "all repos failed" — a single-repo hive with a flaky PR endpoint would discard real issue data and report a total outage.
- **One cascade killer**: hub's filesystem-swapping test helper races async provisioning goroutines from earlier tests; a single race there flunked ~12 unrelated hub tests per run. Provisioning goroutines now join a WaitGroup the helper drains.
- The rest are tests updated to deliberate contract changes (EnumerateActionable all-failed error, brewCheck's ListReleases migration, knowledge title/name precedence and error wording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)