### PR TITLE
🐛 fix: manual agent kicks delivered an empty work list; stop promising GH_TOKEN

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -953,7 +953,7 @@ func (s *Server) handleKick(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if msg == "" && s.deps.Scheduler != nil {
-		msg = s.deps.Scheduler.BuildAgentMessage(name, nil, s.deps.Scheduler.GetLastActionable())
+		msg = s.deps.Scheduler.BuildAgentMessageFromLastActionable(name)
 	}
 
 	if err := s.deps.AgentMgr.SendKick(name, msg); err != nil {

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -295,6 +295,22 @@ func (s *Scheduler) BuildKickMessages(actionable *github.ActionableResult, agent
 	return messages
 }
 
+// BuildAgentMessageFromLastActionable builds a kick message for the named
+// agent from the scheduler's cached actionable snapshot, classifying issues
+// exactly like governor-driven kicks do. The dashboard's manual-kick path
+// previously called BuildAgentMessage with a nil issue list, so every manual
+// kick delivered an EMPTY work list — agents (whose policies forbid running
+// gh issue list themselves) then correctly reported "nothing to do" no matter
+// how deep the queue was.
+func (s *Scheduler) BuildAgentMessageFromLastActionable(agentName string) string {
+	actionable := s.GetLastActionable()
+	var classified []github.Issue
+	if actionable != nil {
+		classified = classify.ClassifyAll(actionable.Issues.Items)
+	}
+	return s.BuildAgentMessage(agentName, classified, actionable)
+}
+
 func (s *Scheduler) buildReposSection() string {
 	var b strings.Builder
 	b.WriteString("AUTHORIZED REPOS (you may ONLY interact with these):\n")
@@ -525,9 +541,11 @@ func (s *Scheduler) buildCIFailingList() string {
 func (s *Scheduler) ghAuthInstructions() string {
 	return `## Project Authentication
 
-GitHub access is pre-configured in your environment. The GH_TOKEN and
-SSL_CERT_FILE variables are already set by the hive runtime. Use gh
-commands normally — authentication is handled automatically.
+GitHub access is handled transparently by the hive proxy. Do NOT expect a
+GH_TOKEN environment variable — it is deliberately unset in agent sessions
+(the Copilot CLI claims it for its own auth). Run gh and git commands
+normally; requests are authenticated in transit. Never treat a missing
+GH_TOKEN as a blocker.
 
 `
 }


### PR DESCRIPTION
Two bugs found live while investigating why a hosted hive's scanner never picked up six human-filed feature requests despite manual kicks:

1. **Manual kicks send an empty work list.** `handleKick` called `BuildAgentMessage(name, nil, lastActionable)` — nil issue list — so the kick rendered `ACTIONABLE ISSUES: (none)` no matter what was queued. Governor kicks classify `actionable.Issues.Items`; manual kicks never did. Since agent policies forbid running `gh issue list` themselves, manually-kicked agents dutifully reported empty cycles (six sessions of "work list: empty" beads on the observed hive, with 17 actionable issues queued). New `Scheduler.BuildAgentMessageFromLastActionable` mirrors the governor path; the handler now uses it.

2. **`${GH_AUTH}` lies about GH_TOKEN.** It tells agents "GH_TOKEN is already set — use gh normally", but `agent-launch.sh` deliberately *unsets* GH_TOKEN (Copilot CLI claims that variable) and authentication is injected transparently by the hive proxy. The observed scanner echoed the empty variable and declared itself blocked, citing the instruction. The text now tells the truth: auth is transparent, missing GH_TOKEN is expected and is not a blocker.

Together with #1855, this closes the loop on "human-filed issues never get worked": ingestion ✅ (already correct), policy framing ✅ (#1855), manual-kick delivery ✅ (this PR), agent auth confidence ✅ (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)