### PR TITLE
🐛 fix: remaining v2 test reds — leaked hub pollers and stale proxy CONNECT contract

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 )
 
@@ -143,8 +144,15 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("DELETE /api/saas/admin/hub-banner", s.requireAdmin(s.handleClearHubBanner))
 	s.mux.HandleFunc("GET /api/saas/admin/hub-banner", s.requireAdmin(s.handleGetHubBanner))
 
-	go s.startProvisionWatcher()
-	go s.StartLatestSHAPoller()
+	// Under `go test` these long-lived pollers leak across test cases: they
+	// immediately hit the GitHub API and read the package-level saas path
+	// variables that the filesystem test helper swaps per-test, which the
+	// race detector rightly flags. Production behavior is unchanged; tests
+	// that need poller logic call the functions directly.
+	if !testing.Testing() {
+		go s.startProvisionWatcher()
+		go s.StartLatestSHAPoller()
+	}
 }
 
 func (s *HubServer) requireAuth(next http.HandlerFunc) http.HandlerFunc {

--- a/v2/pkg/proxy/proxy_deep6_test.go
+++ b/v2/pkg/proxy/proxy_deep6_test.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"bufio"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"

--- a/v2/pkg/proxy/proxy_deep6_test.go
+++ b/v2/pkg/proxy/proxy_deep6_test.go
@@ -177,7 +177,7 @@ func TestHandleConnectDirectUpstreamDialFail(t *testing.T) {
 
 	// Register a fake GitHub host that won't resolve
 	RegisterGitHubHost("fake-github-for-test.invalid")
-	defer delete(githubHosts, "fake-github-for-test.invalid")
+	defer unregisterGitHubHost("fake-github-for-test.invalid")
 
 	clientConn, proxyClient := net.Pipe()
 
@@ -190,37 +190,14 @@ func TestHandleConnectDirectUpstreamDialFail(t *testing.T) {
 		proxyClient.Close()
 	}()
 
-	// Read "200 Connection established"
+	// The proxy dials upstream BEFORE answering CONNECT, so the
+	// unresolvable host fails the dial and the client gets 502 — no tunnel,
+	// no TLS handshake.
 	reader := bufio.NewReader(clientConn)
 	statusLine, _ := reader.ReadString('\n')
-	if !strings.Contains(statusLine, "200") {
-		t.Fatalf("expected 200, got %q", statusLine)
+	if !strings.Contains(statusLine, "502") {
+		t.Fatalf("expected 502 on upstream dial failure, got %q", statusLine)
 	}
-	for {
-		l, _ := reader.ReadString('\n')
-		if l == "\r\n" || l == "\n" {
-			break
-		}
-	}
-
-	// Do proper TLS handshake with the proxy's forged cert
-	caPool := newCertPool(p)
-	tlsConn := tls.Client(&prefixConn{Conn: clientConn, prefix: nil}, &tls.Config{
-		ServerName: "fake-github-for-test.invalid",
-		RootCAs:    caPool,
-	})
-	defer tlsConn.Close()
-
-	if err := tlsConn.Handshake(); err != nil {
-		t.Fatalf("TLS handshake failed: %v", err)
-	}
-
-	// After TLS handshake succeeds, the proxy tries tls.Dial to upstream
-	// which will fail (port 1, invalid host)
-	// The proxy will close the connection
-	buf := make([]byte, 1024)
-	tlsConn.SetReadDeadline(time.Now().Add(15 * time.Second))
-	_, _ = tlsConn.Read(buf)
 }
 
 func newCertPool(p *GitHubProxy) *x509.CertPool {

--- a/v2/pkg/proxy/rules.go
+++ b/v2/pkg/proxy/rules.go
@@ -37,6 +37,13 @@ func RegisterGitHubHost(host string) {
 	githubHostsMu.Unlock()
 }
 
+// unregisterGitHubHost removes a hostname from the allowlist (test cleanup).
+func unregisterGitHubHost(host string) {
+	githubHostsMu.Lock()
+	delete(githubHosts, host)
+	githubHostsMu.Unlock()
+}
+
 // IsGitHubHost returns true if the host should be subject to mode enforcement.
 func IsGitHubHost(host string) bool {
 	githubHostsMu.RLock()


### PR DESCRIPTION
Follow-up to #1857 (which turned dashboard/github/knowledge green). The two survivors and their real causes:

- **pkg/hub**: `RegisterSaaSRoutes` spawns `startProvisionWatcher` + `StartLatestSHAPoller` unconditionally — unstoppable goroutines that hit the GitHub API on launch and read the swappable saas path globals. Every test-constructed hub server leaks them across subsequent tests, so the race detector flags a *different* set of handler tests each run (12 last run, 9 this run — same root cause). Gated with `testing.Testing()`; production is untouched and tests exercise poller logic by direct call.
- **pkg/proxy**: the proxy was changed to dial upstream *before* answering CONNECT (correct: 502 on dial failure, no phantom tunnel). `TestHandleConnectDirectUpstreamDialFail` still asserted the legacy 200-then-close contract and then attempted a TLS handshake that can no longer occur. Now expects 502. Its cleanup also wrote the `githubHosts` map directly, which is mutex-guarded since #1857 — added a locked unregister helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)