### PR TITLE
🔒 fix: teach agents gh auth via their per-agent scoped token

### DIFF
--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -465,7 +465,7 @@ func (s *Scheduler) buildSupervisorMessage(actionable *github.ActionableResult) 
 	b.WriteString("[agent:supervisor]\n")
 	b.WriteString(fmt.Sprintf("MONITORING PASS %s\n\n", now.Format("1/2 3:04 PM MST")))
 
-	b.WriteString(s.ghAuthInstructions())
+	b.WriteString(s.ghAuthInstructions("supervisor"))
 	b.WriteString(s.reposSection())
 
 	b.WriteString("ROLE: You are the SUPERVISOR. Your job is to MONITOR other agents, NOT to fix issues yourself.\n")
@@ -657,7 +657,7 @@ func (s *Scheduler) buildArchitectMessage(issues []github.Issue, actionable *git
 	b.WriteString("[agent:architect]\n")
 	b.WriteString("Full architect pass — refactor/perf scan across all repos.\n\n")
 
-	b.WriteString(s.ghAuthInstructions())
+	b.WriteString(s.ghAuthInstructions("architect"))
 
 	architectIssues := filterByLane(issues, "architect")
 	if len(architectIssues) > 0 {
@@ -711,7 +711,7 @@ func (s *Scheduler) buildOutreachMessage(actionable *github.ActionableResult) st
 	b.WriteString("[agent:outreach]\n")
 	b.WriteString(fmt.Sprintf("Full outreach pass. Time: %s\n\n", now.Format("1/2 3:04 PM MST")))
 
-	b.WriteString(s.ghAuthInstructions())
+	b.WriteString(s.ghAuthInstructions("outreach"))
 
 	b.WriteString("YOUR RESPONSIBILITIES:\n")
 	b.WriteString("  1. Open PRs on external repos to promote adoption (awesome-lists, adopters files, install guides)\n")
@@ -736,7 +736,7 @@ func (s *Scheduler) buildSecCheckMessage(actionable *github.ActionableResult) st
 	b.WriteString("[agent:sec-check]\n")
 	b.WriteString(fmt.Sprintf("Security review pass. Time: %s\n\n", now.Format("1/2 3:04 PM MST")))
 
-	b.WriteString(s.ghAuthInstructions())
+	b.WriteString(s.ghAuthInstructions("sec-check"))
 
 	b.WriteString("YOUR RESPONSIBILITIES:\n")
 	b.WriteString("  1. Scan repos for security vulnerabilities (OWASP top 10, dependency CVEs)\n")

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -174,7 +174,7 @@ func (s *Scheduler) substituteTemplate(template string, actionable *github.Actio
 		"${ISSUE_LIST}", issueList,
 		"${PR_LIST}", prList,
 		"${AUTHORIZED_REPOS}", s.buildReposSection(),
-		"${GH_AUTH}", s.ghAuthInstructions(),
+		"${GH_AUTH}", s.ghAuthInstructions(agentName),
 		"${PROJECT_ORG}", s.cfg.Project.Org,
 		"${PROJECT_NAME}", s.cfg.Project.Name,
 		"${PROJECT_PRIMARY_REPO}", fullPrimaryRepo,
@@ -538,16 +538,27 @@ func (s *Scheduler) buildCIFailingList() string {
 	return b.String()
 }
 
-func (s *Scheduler) ghAuthInstructions() string {
-	return `## Project Authentication
+// ghAuthInstructions tells the agent how to authenticate each tool class.
+// The per-agent token file is 0600, owned by the agent's UID, and scoped to
+// the agent's trust tier — pointing gh at it preserves both enforcement
+// layers (tier-scoped token + proxy mode inspection). Never point agents at
+// the shared gh-app-token.cache: reading it skips the credential helper's
+// UID/mode gate and hands every agent an unscoped token.
+func (s *Scheduler) ghAuthInstructions(agentName string) string {
+	return fmt.Sprintf(`## Project Authentication
 
-GitHub access is handled transparently by the hive proxy. Do NOT expect a
-GH_TOKEN environment variable — it is deliberately unset in agent sessions
-(the Copilot CLI claims it for its own auth). Run gh and git commands
-normally; requests are authenticated in transit. Never treat a missing
-GH_TOKEN as a blocker.
+- git push / git fetch: run them normally. A credential helper supplies a
+  push-capable token automatically. Do NOT export GH_TOKEN for git and do
+  NOT use HIVE_GITHUB_TOKEN (it is read-only; overriding breaks pushes).
+- gh CLI: export your per-agent token first:
+    export GH_TOKEN=$(cat /var/run/hive-metrics/agent-tokens/gh-token-%s.cache)
+  It is scoped to YOUR tier. Never read another agent's token file or the
+  shared gh-app-token.cache.
+- A missing GH_TOKEN at session start is expected (the Copilot CLI owns that
+  variable) — it is never a blocker. All GitHub traffic flows through the
+  hive proxy either way.
 
-`
+`, agentName)
 }
 
 func (s *Scheduler) reposSection() string {


### PR DESCRIPTION
The `${GH_AUTH}` kick section never told agents how the **gh CLI** should authenticate, so they improvised — the observed field path was `cat`-ing the **shared** `gh-app-token.cache` (0640, group `node`, readable by every agent UID). That skips the git credential helper's UID-verification and mode gate: an advisory-only agent can hold an unscoped app token, leaving the MITM proxy as the only enforcement layer.

This PR points `gh` at the **per-agent scoped token** (`agent-tokens/gh-token-<agent>.cache` — 0600, owned by the agent's UID, tier-scoped at mint), which keeps both layers intact, and spells out the git rules field debugging showed agents get wrong (credential helper handles git; never export the read-only `HIVE_GITHUB_TOKEN`; missing `GH_TOKEN` at session start is expected).

Longer-term fix tracked separately: proxy-side auth injection so agents never hold tokens at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)