### PR TITLE
🐛 fix: DeleteHive tests assert pre-idempotency 404 contract

### DIFF
--- a/v2/pkg/hub/hub_coverage_deep_test.go
+++ b/v2/pkg/hub/hub_coverage_deep_test.go
@@ -182,13 +182,14 @@ func TestHandleDeleteHiveWithAuth(t *testing.T) {
 		t.Errorf("expected 400 or 404, got %d", w.Code)
 	}
 
-	// Normal not found
+	// Deleting a hive whose SaaS entry is already gone is idempotent: the
+	// handler still purges any in-memory registry entry and reports deleted.
 	req2 := httptest.NewRequest("DELETE", "/api/saas/hives/nonexist", nil)
 	req2.Header.Set("Authorization", "Bearer ghp_del_user")
 	w2 := httptest.NewRecorder()
 	mux.ServeHTTP(w2, req2)
-	if w2.Code != http.StatusNotFound {
-		t.Errorf("expected 404, got %d", w2.Code)
+	if w2.Code != http.StatusOK {
+		t.Errorf("expected 200 (idempotent delete), got %d", w2.Code)
 	}
 }
 

--- a/v2/pkg/hub/hub_coverage_extra_test.go
+++ b/v2/pkg/hub/hub_coverage_extra_test.go
@@ -441,13 +441,14 @@ func TestHandleDeleteHiveNotOwner(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/saas/hives/{id}", srv.handleDeleteHive)
 
-	// Hive doesn't exist → 404 (covers the loadSaaSHive nil path)
+	// Hive doesn't exist → idempotent 200 (covers the loadSaaSHive nil
+	// path, which purges any registry leftover and reports deleted).
 	req := httptest.NewRequest("DELETE", "/api/saas/hives/nonexistent", nil)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
-	if w.Code != http.StatusNotFound {
-		t.Errorf("expected 404, got %d", w.Code)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 (idempotent delete), got %d", w.Code)
 	}
 }
 


### PR DESCRIPTION
The final red in `v2 Tests`: `handleDeleteHive` deliberately treats a missing SaaS record as **idempotent success** (still purging any in-memory registry entry so the hive vanishes from listings — the code comments the rationale). `TestHandleDeleteHiveWithAuth` and `TestHandleDeleteHiveNotOwner` still asserted the pre-idempotency 404. Updated both to expect 200.

With this, all 26 originally-failing tests across 5 packages are addressed (#1857 → 3 packages green, #1859 → hub pollers + proxy contract, this → last two).

🤖 Generated with [Claude Code](https://claude.com/claude-code)