### PR TITLE
💄 fix: Hub Admin Users timestamps use 12-hour time with a/p suffix

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -5064,7 +5064,10 @@ const dashboardHTML = `<!DOCTYPE html>
       if (!ts) return '';
       var d = new Date(ts);
       if (isNaN(d.getTime())) return ts.substring(0, 10);
-      return d.toLocaleString('en-US', {year:'numeric',month:'2-digit',day:'2-digit',hour:'2-digit',minute:'2-digit',hour12:false,timeZone:'America/New_York'}).replace(',','') + ' EDT';
+      // 12-hour clock with a compact single-letter meridiem (e.g. "9:21p").
+      var parts = d.toLocaleString('en-US', {year:'numeric',month:'2-digit',day:'2-digit',hour:'numeric',minute:'2-digit',hour12:true,timeZone:'America/New_York'}).replace(',','').split(' ');
+      var meridiem = (parts.pop() || '').toLowerCase().charAt(0); // "AM"->"a", "PM"->"p"
+      return parts.join(' ') + meridiem + ' EDT';
     }
 
     function sortUsers(key) {


### PR DESCRIPTION
The Hub Admin → Users table's Joined / Last Login columns rendered 24-hour time (`07/08/2026 21:55 EDT`). Operator wants 12-hour with a compact a/p suffix. `fmtUserTS` now emits `07/08/2026 9:55p EDT` (`hour12:true`, unpadded hour, single-letter lowercase meridiem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)