### PR TITLE
🐛 fix: guard docker digest-merge against empty digests dir

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -120,10 +120,16 @@ jobs:
         if: steps.head-check.outputs.stale != 'true'
         working-directory: /tmp/digests
         run: |
+          shopt -s nullglob
+          digests=(*)
+          if [ ${#digests[@]} -eq 0 ]; then
+            echo "No digests to merge (per-arch builds published none) — skipping."
+            exit 0
+          fi
           docker buildx imagetools create \
             -t ghcr.io/kubestellar/hive:${{ github.ref_name }}-latest \
             -t ghcr.io/kubestellar/hive:${{ steps.meta.outputs.git_short }} \
-            $(printf 'ghcr.io/kubestellar/hive@sha256:%s ' *)
+            $(printf 'ghcr.io/kubestellar/hive@sha256:%s ' "${digests[@]}")
 
   build-contributor:
     strategy:
@@ -222,11 +228,17 @@ jobs:
         if: steps.head-check.outputs.stale != 'true'
         working-directory: /tmp/contrib-digests
         run: |
+          shopt -s nullglob
+          digests=(*)
+          if [ ${#digests[@]} -eq 0 ]; then
+            echo "No digests to merge (per-arch builds published none) — skipping."
+            exit 0
+          fi
           docker buildx imagetools create \
             -t ghcr.io/kubestellar/hive-contributor:latest \
             -t ghcr.io/kubestellar/hive-contributor:${{ github.ref_name }}-latest \
             -t ghcr.io/kubestellar/hive-contributor:${{ steps.meta.outputs.git_short }} \
-            $(printf 'ghcr.io/kubestellar/hive-contributor@sha256:%s ' *)
+            $(printf 'ghcr.io/kubestellar/hive-contributor@sha256:%s ' "${digests[@]}")
 
   build-hub:
     strategy:
@@ -327,8 +339,14 @@ jobs:
         if: steps.head-check.outputs.stale != 'true'
         working-directory: /tmp/hub-digests
         run: |
+          shopt -s nullglob
+          digests=(*)
+          if [ ${#digests[@]} -eq 0 ]; then
+            echo "No digests to merge (per-arch builds published none) — skipping."
+            exit 0
+          fi
           docker buildx imagetools create \
             -t ghcr.io/kubestellar/hive-hub:latest \
             -t ghcr.io/kubestellar/hive-hub:${{ github.ref_name }}-latest \
             -t ghcr.io/kubestellar/hive-hub:${{ steps.meta.outputs.git_short }} \
-            $(printf 'ghcr.io/kubestellar/hive-hub@sha256:%s ' *)
+            $(printf 'ghcr.io/kubestellar/hive-hub@sha256:%s ' "${digests[@]}")


### PR DESCRIPTION
The three `Create manifest list and push` steps run `$(printf 'ghcr.io/...@sha256:%s ' *)` in the digests working dir with no nullglob guard. When a push produces no per-arch digests to merge — which happens on **any push that edits `docker.yml` itself** (the merge-manifest jobs run per-PR only when the workflow file changed, with nothing to merge) — the glob stays literal `*` and buildx fails `invalid reference format`, reddening `merge` / `merge-hub` / `merge-contributor`.

This blocked PR #1863 (which edits `docker.yml`) despite its real gates (build-and-test, dco, docker) being green. `nullglob` + empty-array early-exit fixes it for all three images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)