### PR TITLE
🐛 fix: switch-branch bootstrap — first hive on a new dev branch was rejected

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1960,8 +1960,19 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 	}
+	// Bootstrap case: trackedBranchList only includes branches already
+	// assigned to some hive, so the FIRST hive moved to a new dev branch
+	// would never validate. Accept any branch that actually exists on the
+	// hive repo — a live one-shot check (fetchBranchSHA populates the SHA
+	// cache as a side effect, so the branch is tracked from here on).
 	if !validBranch {
-		http.Error(w, `{"error":"unknown branch"}`, http.StatusBadRequest)
+		fetchBranchSHA(s.logger, body.Branch)
+		if getLatestSHAForBranch(body.Branch) != "" {
+			validBranch = true
+		}
+	}
+	if !validBranch {
+		http.Error(w, `{"error":"unknown branch (does not exist on the hive repo)"}`, http.StatusBadRequest)
 		return
 	}
 	cluster := s.clusterForHive(h)


### PR DESCRIPTION
`handleSwitchBranch` validated the target branch against `trackedBranchList()`, which only lists branches **already assigned to a hive**. So the *first* hive moved to a fresh dev branch (e.g. `mk`) always got `unknown branch` — a chicken-and-egg that broke the assign-a-hive-to-your-own-branch flow for its very first user (hit live provisioning Michael Kalantar's hive).

Fix: if the branch isn't already tracked, run a live `fetchBranchSHA`, which verifies the branch exists on the hive repo **and** that its `<branch>-latest` image is built on GHCR before caching its SHA. Accept the switch only when that succeeds — so it can't strand a hive in ImagePullBackOff, and the branch becomes tracked thereafter.

Completes the dev-branch story alongside #1863 (dynamic tracking + all-branch image builds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)