### PR TITLE
🐛 fix: heartbeat rejects cross-org repo refs, taking the hive offline

### DIFF
--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -99,6 +99,28 @@ func isValidName(s string) bool {
 	return safeNamePattern.MatchString(s) && len(s) <= 100
 }
 
+// isValidRepoRef validates a repo entry, which may be a bare name ("repo")
+// or a cross-org "owner/repo" reference. Both segments must be safe names
+// (no path traversal); at most one slash is allowed. Cross-org repos are a
+// supported hive config (e.g. a primary repo in one org plus a secondary in
+// another), so the heartbeat must not 400-reject them — doing so silently
+// took a whole hive offline (no heartbeats → no upgrades, shows offline).
+func isValidRepoRef(s string) bool {
+	if len(s) > 201 {
+		return false
+	}
+	parts := strings.Split(s, "/")
+	if len(parts) > 2 {
+		return false
+	}
+	for _, p := range parts {
+		if !isValidName(p) {
+			return false
+		}
+	}
+	return true
+}
+
 func secureCompareHub(a, b string) bool {
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }
@@ -291,12 +313,12 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid org name", http.StatusBadRequest)
 		return
 	}
-	if payload.PrimaryRepo != "" && !isValidName(payload.PrimaryRepo) {
+	if payload.PrimaryRepo != "" && !isValidRepoRef(payload.PrimaryRepo) {
 		http.Error(w, "invalid repo name", http.StatusBadRequest)
 		return
 	}
 	for _, repo := range payload.Repos {
-		if !isValidName(repo) {
+		if !isValidRepoRef(repo) {
 			http.Error(w, "invalid repo name in list", http.StatusBadRequest)
 			return
 		}


### PR DESCRIPTION
**This is why kalantar-msb never finished upgrading.** Its repos are `soft-reflective` + `inference-sim/sim2real`. The heartbeat handler validated every repo with `isValidName` (`^[a-zA-Z0-9._-]+$`, no `/`), so the cross-org `inference-sim/sim2real` entry made the hub **400-reject the entire heartbeat** (`invalid repo name in list`). No heartbeat → the hive never receives the upgrade instruction (even with the #1871 fallback correctly armed) and shows `online:false` forever.

Cross-org repos are a supported hive config. New `isValidRepoRef` accepts a bare name or a single-slash `owner/repo`, validating both segments as safe names (no path traversal, at most one slash); used for `PrimaryRepo` and each `Repos` entry.

Chain that stuck this hive: #1871 (fallback re-arm) got it *armed*, but this 400 meant the instruction could never be delivered. With both merged, kalantar-msb heartbeats, receives the target, and self-restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)