### PR TITLE
🐛 fix: paginate branch discovery + 🧹 prune GHCR untagged images

### DIFF
--- a/.github/workflows/prune-ghcr.yml
+++ b/.github/workflows/prune-ghcr.yml
@@ -1,0 +1,35 @@
+name: Prune GHCR untagged images
+
+# Docker builds push per-arch digests and attestation manifests that become
+# untagged once the <branch>-latest manifest list is created. These orphaned
+# versions accumulate fast (thousands/day) and bury the real -latest tags in
+# the registry tag list. Prune old UNTAGGED versions only; never touch tagged
+# ones (v2-latest, v3-latest, mk-latest, SHA tags, and their live per-arch
+# children are all tagged/referenced and thus spared).
+#
+# NOTE: deleting org-owned package versions requires a PAT (classic) with the
+# `delete:packages` scope, stored as secret GHCR_PRUNE_TOKEN. The default
+# GITHUB_TOKEN cannot delete versions of an organization package.
+on:
+  schedule:
+    - cron: '17 4 * * *'   # daily, 04:17 UTC — off-peak
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'List what would be deleted without deleting'
+        type: boolean
+        default: true
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune untagged hive images
+        uses: snok/container-retention-policy@v3.0.0
+        with:
+          account: kubestellar
+          token: ${{ secrets.GHCR_PRUNE_TOKEN }}
+          image-names: "hive hive-hub hive-contributor"
+          tag-selection: untagged
+          cut-off: 2d              # spare untagged from the last 2 days (in-flight builds)
+          dry-run: ${{ github.event_name == 'schedule' && 'false' || inputs.dry_run }}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2351,29 +2351,64 @@ func listLatestImageBranches(client *http.Client) []string {
 	if err := json.NewDecoder(tokenResp.Body).Decode(&tok); err != nil {
 		return nil
 	}
-	req, _ := http.NewRequest("GET", "https://ghcr.io/v2/kubestellar/hive/tags/list?n=200", nil)
-	req.Header.Set("Authorization", "Bearer "+tok.Token)
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil
-	}
-	var body struct {
-		Tags []string `json:"tags"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
-		return nil
-	}
-	var branches []string
-	for _, t := range body.Tags {
-		if strings.HasSuffix(t, "-latest") {
-			branches = append(branches, strings.TrimSuffix(t, "-latest"))
+
+	// The registry tag list is paginated via RFC5988 Link headers. Untagged
+	// build digests aside, the repo can hold thousands of SHA tags, so the
+	// "<branch>-latest" tags we want may live on a later page — follow Link
+	// until exhausted (bounded) rather than reading only the first page.
+	branchSet := map[string]struct{}{}
+	next := "https://ghcr.io/v2/kubestellar/hive/tags/list?n=1000"
+	const maxPages = 20 // bound: up to ~20k tags
+	for page := 0; next != "" && page < maxPages; page++ {
+		req, _ := http.NewRequest("GET", next, nil)
+		req.Header.Set("Authorization", "Bearer "+tok.Token)
+		resp, err := client.Do(req)
+		if err != nil {
+			break
 		}
+		var body struct {
+			Tags []string `json:"tags"`
+		}
+		decodeErr := json.NewDecoder(resp.Body).Decode(&body)
+		link := resp.Header.Get("Link")
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK || decodeErr != nil {
+			break
+		}
+		for _, t := range body.Tags {
+			if strings.HasSuffix(t, "-latest") {
+				branchSet[strings.TrimSuffix(t, "-latest")] = struct{}{}
+			}
+		}
+		next = nextLinkURL(link)
+	}
+	branches := make([]string, 0, len(branchSet))
+	for b := range branchSet {
+		branches = append(branches, b)
 	}
 	return branches
+}
+
+// nextLinkURL extracts the rel="next" URL from a registry Link header, or "".
+// GHCR returns a relative path (e.g. </v2/.../tags/list?last=...&n=1000>),
+// which we resolve against the registry host.
+func nextLinkURL(link string) string {
+	for _, part := range strings.Split(link, ",") {
+		if !strings.Contains(part, `rel="next"`) {
+			continue
+		}
+		start := strings.Index(part, "<")
+		end := strings.Index(part, ">")
+		if start < 0 || end < 0 || end <= start {
+			return ""
+		}
+		u := part[start+1 : end]
+		if strings.HasPrefix(u, "/") {
+			return "https://ghcr.io" + u
+		}
+		return u
+	}
+	return ""
 }
 
 // provisionWG tracks async hive-provisioning goroutines so tests (which swap


### PR DESCRIPTION
**Root cause of both "mk isn't in the list" and the image bloat:** GHCR accumulates **9,500+ untagged build digests per day** (per-arch + attestation manifests, orphaned once the `<branch>-latest` manifest list is created). 25k+ versions across hive / hive-hub / hive-contributor.

**1. Branch discovery pagination.** `listLatestImageBranches` read only the first page of the registry tag list. With thousands of SHA tags ordered ahead of them, the `<branch>-latest` tags fell off the page — `mk-latest` exists on GHCR but never appeared in "Latest available images" or as an assignable branch. Now follows the RFC5988 `Link` header across pages (bounded ~20k tags) and collects every `-latest` tag.

**2. Prune workflow** (`prune-ghcr.yml`): daily + manual (dry-run by default) prune of **untagged** versions older than 2 days via `snok/container-retention-policy`, sparing all tagged versions and in-flight builds. **Requires** a PAT with `delete:packages` as secret `GHCR_PRUNE_TOKEN` — `GITHUB_TOKEN` can't delete org package versions (called out in the workflow header).

Follow-up worth doing separately: stop the leak at the source (the `push-by-digest` builds), so prune becomes cleanup-of-history rather than a daily necessity.

@operator: to run the first prune, add the `GHCR_PRUNE_TOKEN` secret, then trigger the workflow manually with dry-run=true to preview the count before a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)