### PR TITLE
🧹 prune: widen untagged cut-off 2d → 3h to reclaim ~all orphans

### DIFF
--- a/.github/workflows/prune-ghcr.yml
+++ b/.github/workflows/prune-ghcr.yml
@@ -31,5 +31,8 @@ jobs:
           token: ${{ secrets.GHCR_PRUNE_TOKEN }}
           image-names: "hive hive-hub hive-contributor"
           tag-selection: untagged
-          cut-off: 2d              # spare untagged from the last 2 days (in-flight builds)
+          cut-off: 3h              # untagged digests are unreachable by name; only
+                                  # spare the last few hours so an in-flight build's
+                                  # per-arch children aren't deleted before their
+                                  # manifest list is created.
           dry-run: ${{ github.event_name == 'schedule' && 'false' || inputs.dry_run }}


### PR DESCRIPTION
Untagged versions are unreachable-by-name build digests/attestations — age doesn't affect safety, so spare only the last 3h (in-flight builds) and reclaim the full ~23k untagged backlog instead of ~5k. Tagged images untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)