### PR TITLE
✨ feat: show branch pill next to SHA on spoke dashboard

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,6 +61,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           build-args: |
             GIT_HASH=${{ github.sha }}
+            GIT_BRANCH=${{ github.ref_name }}
           no-cache-filters: builder
           outputs: type=image,name=ghcr.io/kubestellar/hive,push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ steps.slug.outputs.slug }}

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -11,9 +11,10 @@ COPY .git /repo/.git
 COPY v2/ .
 
 ARG GIT_HASH=unknown
+ARG GIT_BRANCH=unknown
 RUN GIT_HASH=$(git -C /repo rev-parse HEAD 2>/dev/null || echo "unknown") && \
     GIT_SHORT=$(git -C /repo rev-parse --short HEAD 2>/dev/null || echo "unknown") && \
-    GIT_BRANCH=$(git -C /repo rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown") && \
+    if [ "$GIT_BRANCH" = "unknown" ] || [ -z "$GIT_BRANCH" ]; then GIT_BRANCH=$(git -C /repo rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown"); fi && \
     GOCACHE=/tmp/gobuild CGO_ENABLED=0 go build -ldflags "-X main.gitHash=${GIT_HASH} -X main.gitShort=${GIT_SHORT} -X main.gitBranch=${GIT_BRANCH}" -o /hive ./cmd/hive && \
     GOCACHE=/tmp/gobuild CGO_ENABLED=0 go build -o /bd ./cmd/bd
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -10666,6 +10666,12 @@ function burnAreaChart() {
         const ocEl = document.getElementById('oc-git-version');
         const commitTooltip = v.latestMessage ? escapeHtml(v.latestMessage) : escapeHtml(v.hash);
         let html = `<a href="https://github.com/kubestellar/hive/commit/${escapeHtml(v.hash)}" target="_blank" style="color:inherit;text-decoration:none" title="${commitTooltip}">${escapeHtml(v.short)}</a>`;
+        // Branch pill next to the SHA — shows which branch this spoke tracks
+        // (v2/v3 release, or a personal dev branch like mk). Skip only the
+        // unknown placeholder so the pill is always present for real builds.
+        if (v.branch && v.branch !== 'unknown') {
+          html += ` <span title="Tracking branch ${escapeHtml(v.branch)}" style="display:inline-block;padding:1px 7px;margin-left:6px;border-radius:999px;font-size:0.62rem;font-weight:600;background:color-mix(in srgb, var(--accent) 16%, transparent);border:1px solid color-mix(in srgb, var(--accent) 40%, transparent);color:var(--accent);vertical-align:middle">${escapeHtml(v.branch)}</span>`;
+        }
         if (v.dirty) html += ' <span class="git-dirty">*</span>';
         if (_upgradeInProgress && v.hash !== _upgradeTargetHash) {
           html += ` <span class="git-behind" title="Upgrading to ${escapeHtml(v.latestShort || '?')}">⬆ upgrading</span>`;


### PR DESCRIPTION
The spoke top-bar showed only the short SHA — a hive on a personal dev branch (`mk`) was visually identical to one on `v2`. Adds a small accent **branch pill** next to the SHA.

Wiring fix: `gitBranch` was plumbed via ldflags, but the Dockerfile derived it from `rev-parse --abbrev-ref HEAD` on a detached CI checkout (→ `HEAD`), and the build workflow never passed a branch. Now a `GIT_BRANCH=${{ github.ref_name }}` build-arg feeds the reliable branch name (preferred over the rev-parse fallback). `/api/version` already returns `branch`; the frontend renders it (hidden only for the `unknown` placeholder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)