### PR TITLE
🐛 fix: persist operator agent pause across restarts/upgrades

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1207,6 +1207,22 @@ func main() {
 	dashSrv.SetSkipReloadFunc(configWatcher.SkipNext)
 	go configWatcher.Start(ctx)
 
+	// Persist operator pause/resume into the on-disk config so it survives
+	// restarts and upgrades. Without this, a pod restart rebuilt every agent
+	// un-paused, silently undoing an operator's pause on the next upgrade.
+	agentMgr.SetPersistPauseCallback(func(name string, paused bool) {
+		ac, ok := cfg.Agents[name]
+		if !ok || ac.Paused == paused {
+			return
+		}
+		ac.Paused = paused
+		cfg.Agents[name] = ac
+		configWatcher.SkipNext() // don't let our own write trigger a reload
+		if err := cfg.Save(); err != nil {
+			logger.Warn("failed to persist agent pause state", "agent", name, "paused", paused, "error", err)
+		}
+	})
+
 	// Register custom GHE hostnames with the proxy allowlist so mode
 	// enforcement applies to GitHub Enterprise API and web requests.
 	for _, rawURL := range []string{cfg.GitHub.ResolvedAPIURL(), cfg.GitHub.ResolvedBaseURL()} {

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -125,6 +125,19 @@ type Manager struct {
 
 	inferenceRouteCallback      func(agentName, backend, model string)
 	clearInferenceRouteCallback func(agentName string)
+
+	// persistPauseCallback, when set, persists an agent's paused state to
+	// the on-disk config so it survives restarts. Nil in tests / bare setups.
+	persistPauseCallback func(name string, paused bool)
+}
+
+// SetPersistPauseCallback wires a function that persists an agent's paused
+// state to config (called on pause/resume). Idempotent saves are the
+// caller's responsibility.
+func (m *Manager) SetPersistPauseCallback(fn func(name string, paused bool)) {
+	m.mu.Lock()
+	m.persistPauseCallback = fn
+	m.mu.Unlock()
 }
 
 // AppTokenMinter is implemented by github.AppAuth to mint per-agent scoped tokens.
@@ -327,6 +340,9 @@ func NewManager(agents map[string]config.AgentConfig, logger *slog.Logger, proje
 			Config:       cfg,
 			State:        StateStopped,
 			UID:          agentUID,
+			// Restore a persisted operator pause so a restart/upgrade
+			// doesn't silently un-pause the agent.
+			Paused:       cfg.Paused,
 			OutputBuffer: NewRingBuffer(outputBufferCapacity),
 			tmuxSession:  "hive-" + name,
 			tmuxSocket:   tmuxSocket,
@@ -3579,6 +3595,10 @@ func (m *Manager) Pause(name, trigger, reason string) error {
 		m.tmuxSendKeysForAgent(agent, "C-c", "")
 	}
 	agent.State = StatePaused
+	agent.Config.Paused = true
+	if m.persistPauseCallback != nil {
+		m.persistPauseCallback(name, true)
+	}
 	m.logger.Info("audit: agent paused",
 		"name", name,
 		"trigger", trigger,
@@ -3610,6 +3630,10 @@ func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) erro
 	prevTrigger := agent.PausedTrigger
 	prevReason := agent.PausedReason
 	agent.Paused = false
+	agent.Config.Paused = false
+	if m.persistPauseCallback != nil {
+		m.persistPauseCallback(name, false)
+	}
 	agent.PausedAt = time.Time{}
 	agent.PausedReason = ""
 	agent.PausedTrigger = ""

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -209,6 +209,10 @@ type AgentConfig struct {
 	Model           string `yaml:"model" json:"model,omitempty"`
 	BeadsDir        string `yaml:"beads_dir" json:"beads_dir,omitempty"`
 	Enabled         bool   `yaml:"enabled" json:"enabled,omitempty"`
+	// Paused persists an operator pause across restarts/upgrades. Without
+	// this, every pod restart rebuilt agents un-paused (Go zero value), so
+	// an operator pause was silently undone on the next upgrade.
+	Paused          bool   `yaml:"paused" json:"paused,omitempty"`
 	ClearOnKick     bool   `yaml:"clear_on_kick" json:"clear_on_kick"`
 	CLIPinned       bool   `yaml:"cli_pinned" json:"cli_pinned,omitempty"`
 	StaleTimeout    int    `yaml:"stale_timeout" json:"stale_timeout,omitempty"`


### PR DESCRIPTION
**Operator agent pause was in-memory only, so it did not survive restarts/upgrades.** `agent.Paused` lived only in the Manager; every pod restart rebuilt agents from config with `Paused` defaulting to `false`, silently un-pausing them. On an auto-upgrading hive this meant an operator had to re-pause the same agents after each upgrade — kellyaa's audit log shows the same agents (sec-check, architect, guide) re-paused three times across three upgrade restarts in one hour.

The fix persists pause where it belongs — the PVC's `hive.yaml`:

- `config.AgentConfig` gains a persisted `paused` field (written to `hive.yaml`).
- `Manager.Pause`/`Resume` update `Config.Paused` and invoke a persist callback.
- Agents restore `Paused` from config at startup construction.
- `main.go` wires the callback → `cfg.Agents[name]` + `Config.Save()`, skipping the next config-watcher reload to avoid a self-trigger race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)