### PR TITLE
🐛 fix: branch switch via heartbeat fallback for unreachable clusters

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1627,6 +1627,33 @@ func main() {
 					"was", cfg.Hub.IsPublic, "now", isPublic)
 				cfg.Hub.IsPublic = isPublic
 			}
+		}), hub.SwitchBranchCallback(func(tag string) {
+			// Branch switch delivered via heartbeat (the hub couldn't reach
+			// this cluster over kubectl). We patch our OWN deployment image
+			// from inside the cluster — the pod's SA holds the
+			// hive-self-upgrade role (patch on deployment/hive). K8s then
+			// rolls the pod onto the new tag.
+			image := "ghcr.io/kubestellar/hive:" + tag
+			ns := os.Getenv("POD_NAMESPACE")
+			if ns == "" {
+				if b, rerr := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); rerr == nil {
+					ns = strings.TrimSpace(string(b))
+				}
+			}
+			if ns == "" {
+				logger.Warn("branch switch via heartbeat: cannot determine namespace, skipping", "tag", tag)
+				return
+			}
+			// "*=" updates every container (incl. init containers) so nothing
+			// is left on the old tag — mirrors the hub-side kubectl path.
+			cmd := exec.CommandContext(ctx, "kubectl", "set", "image", "deployment/hive", "*="+image, "-n", ns)
+			if out, cerr := cmd.CombinedOutput(); cerr != nil {
+				logger.Warn("branch switch via heartbeat: kubectl set image failed",
+					"tag", tag, "ns", ns, "error", cerr, "output", string(out))
+				return
+			}
+			logger.Info("branch switch via heartbeat: deployment image patched, pod will roll",
+				"tag", tag, "image", image, "ns", ns)
 		}))
 
 		go hub.StartTaskStatusPush(ctx, hubURL, func() *hub.TaskStatusPayload {

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -146,6 +146,7 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 	var onGitHubAppConfig GitHubAppConfigCallback
 	var onHubBanner HubBannerCallback
 	var onVisibility VisibilityCallback
+	var onSwitchBranch SwitchBranchCallback
 	for _, cb := range callbacks {
 		switch fn := cb.(type) {
 		case UpgradeCallback:
@@ -156,6 +157,8 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 			onHubBanner = fn
 		case VisibilityCallback:
 			onVisibility = fn
+		case SwitchBranchCallback:
+			onSwitchBranch = fn
 		}
 	}
 
@@ -167,7 +170,11 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 		if resp == nil {
 			return
 		}
-		if resp.UpgradeTo != "" && onUpgrade != nil {
+		if resp.SwitchToTag != "" && onSwitchBranch != nil {
+			// Branch switch takes precedence over a plain SHA upgrade — it
+			// changes the image tag, which a same-tag re-pull can't do.
+			onSwitchBranch(resp.SwitchToTag)
+		} else if resp.UpgradeTo != "" && onUpgrade != nil {
 			onUpgrade(resp.UpgradeTo)
 		}
 		if resp.GitHubAppConfig != nil && onGitHubAppConfig != nil {
@@ -362,6 +369,11 @@ type HeartbeatResponse struct {
 	HubGitHash      string                    `json:"hub_git_hash,omitempty"`
 	LatestSHA       string                    `json:"latest_sha,omitempty"`
 	LatestTag       string                    `json:"latest_tag,omitempty"`
+	// SwitchToTag instructs the spoke to change its own deployment image to
+	// ghcr.io/kubestellar/hive:<SwitchToTag> and restart. Used for branch
+	// switches on clusters the hub can't reach over kubectl — the spoke has
+	// in-cluster RBAC (hive-self-upgrade role) to patch its own deployment.
+	SwitchToTag     string                    `json:"switch_to_tag,omitempty"`
 	GitHubAppConfig *HeartbeatGitHubAppConfig `json:"github_app_config,omitempty"`
 	HubBanner       *HubBanner                `json:"hub_banner,omitempty"`
 	IsPublic        *bool                     `json:"is_public,omitempty"`
@@ -380,6 +392,11 @@ type HubBannerCallback func(banner *HubBanner)
 
 // VisibilityCallback is called when the hub overrides the spoke's IsPublic setting.
 type VisibilityCallback func(isPublic bool)
+
+// SwitchBranchCallback is called when the hub instructs the spoke (via
+// heartbeat) to switch its deployment image to a specific tag — used for
+// branch switches on clusters the hub can't reach over kubectl.
+type SwitchBranchCallback func(tag string)
 
 // GitHubAppConfigCallback is called when the hub delivers GitHub App config
 // via the heartbeat response (app ID, installation ID, private key).

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1996,8 +1996,28 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 	cmd := kubectlForCluster(cluster, "set", "image", "deployment/hive", "*="+image, "-n", ns)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		s.logger.Warn("branch switch failed", "hive", id, "branch", body.Branch, "output", string(out))
-		http.Error(w, `{"error":"branch switch failed — check hub logs"}`, http.StatusInternalServerError)
+		// The hub can't reach this hive's cluster over kubectl (e.g. vllm-d
+		// from the hive-oke hub). Fall back to the heartbeat path: record the
+		// target tag; the spoke — which has in-cluster RBAC (hive-self-upgrade
+		// role) to patch its own deployment — applies it on its next
+		// heartbeat. This is the ONLY path that works for unreachable
+		// clusters, so it's not an error.
+		s.logger.Warn("branch switch kubectl failed, using heartbeat fallback",
+			"hive", id, "branch", body.Branch, "output", string(out))
+		s.mu.Lock()
+		s.heartbeatSwitchTag[id] = imageTag
+		for i := range s.registry.Hives {
+			if s.registry.Hives[i].ID == id {
+				s.registry.Hives[i].Upgrading = true
+				s.registry.Hives[i].UpgradeTarget = imageTag
+				s.registry.Hives[i].UpgradeStartedAt = time.Now()
+				break
+			}
+		}
+		s.mu.Unlock()
+		s.logger.Info("audit: hive branch switch queued via heartbeat", "hive_id", id, "branch", body.Branch, "image", image, "by", username)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"status": "switching", "branch": body.Branch, "image": image, "via": "heartbeat"})
 		return
 	}
 	// Restart the deployment to pull the new image

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -156,6 +156,10 @@ type HubServer struct {
 	// Key: hive ID, value: target SHA.  Cleared when the spoke reports the
 	// target SHA, proving the upgrade completed.
 	heartbeatUpgrade map[string]string
+	// heartbeatSwitchTag tracks hives that should switch their deployment
+	// image to a specific tag (branch switch) via heartbeat, for clusters
+	// the hub can't reach over kubectl. Cleared once the spoke reports it.
+	heartbeatSwitchTag map[string]string
 
 	// pendingWebhooks stores GitHub App installation webhooks that arrived
 	// before the matching spoke heartbeat.  Key: lowercase org name.
@@ -211,7 +215,8 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		hubSecret:        secret,
 		clusters:         loadClusters(logger),
 		heartbeatHealth:  make(map[string]*HeartbeatHealthEntry),
-		heartbeatUpgrade: make(map[string]string),
+		heartbeatUpgrade:   make(map[string]string),
+		heartbeatSwitchTag: make(map[string]string),
 		pendingWebhooks:         make(map[string]*pendingWebhookEntry),
 		pendingGitHubAppConfigs: make(map[string]*HeartbeatGitHubAppConfig),
 		hubBanners:              make(map[string]*HubBannerEntry),
@@ -608,10 +613,36 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		spokeManaged = false
 	}
 
-	// Fallback for hub-managed hives where kubectl failed (path 3).
+	// Pending branch switch (image-tag change) delivered via heartbeat for
+	// clusters the hub can't kubectl-reach. Takes precedence over a plain
+	// SHA upgrade. Cleared when the spoke reports running that tag's build.
 	s.mu.RLock()
+	switchTag := s.heartbeatSwitchTag[payload.HiveID]
 	hbTarget := s.heartbeatUpgrade[payload.HiveID]
 	s.mu.RUnlock()
+	if switchTag != "" {
+		// Clear once the spoke reports it's on the target branch — its tag is
+		// branchToTag(GitBranch)+"-latest". Otherwise keep instructing.
+		if payload.GitBranch != "" && branchToTag(payload.GitBranch)+"-latest" == switchTag {
+			s.mu.Lock()
+			delete(s.heartbeatSwitchTag, payload.HiveID)
+			for i := range s.registry.Hives {
+				if s.registry.Hives[i].ID == payload.HiveID {
+					s.registry.Hives[i].Upgrading = false
+					s.registry.Hives[i].UpgradeTarget = ""
+					break
+				}
+			}
+			s.mu.Unlock()
+			s.logger.Info("heartbeat: spoke branch switch complete",
+				"hive_id", payload.HiveID, "branch", payload.GitBranch)
+			switchTag = ""
+		} else {
+			resp.SwitchToTag = switchTag
+			s.logger.Info("heartbeat: instructing spoke to switch branch image",
+				"hive_id", payload.HiveID, "tag", switchTag)
+		}
+	}
 	if hbTarget != "" && (payload.GitHash == hbTarget || (latestSHA != "" && payload.GitHash == latestSHA)) {
 		// Spoke already at the target or at latest — clear the fallback entry.
 		s.mu.Lock()


### PR DESCRIPTION
**Why kalantar's mk switch failed silently.** `handleSwitchBranch` only applied the switch via the hub's direct `kubectl set image` + rollout. On a cluster the hub can't reach over kubectl (vllm-d from the hive-oke hub), the call times out, the handler returned 500, and the UI spinner cleared with no change — the hive stayed on `v2`.

Adds a heartbeat fallback, mirroring the upgrade path:
- New heartbeat `SwitchToTag` field + `SwitchBranchCallback`.
- **Hub:** on kubectl failure, record `heartbeatSwitchTag[hive]=<branch>-latest` and mark upgrading (no more 500). The next heartbeat delivers the tag; cleared once the spoke reports `GitBranch == target`.
- **Spoke:** on `SwitchToTag`, patches its **own** deployment image from inside the cluster — the pod SA holds the `hive-self-upgrade` role (patch on deployment/hive), so this works where the hub can't reach. K8s rolls the pod onto the new tag.
- Branch switch takes precedence over a plain SHA upgrade in the spoke dispatch (a tag change can't be done by a same-tag re-pull).

Completes the dev-branch story: #1863 (discovery/builds), #1870 (switch validation bootstrap), this (switch delivery on unreachable clusters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)