### PR TITLE
🐛 fix: accept cross-org repos in create-hive and edit-repos

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1536,7 +1536,7 @@ func (s *HubServer) handleCreateHive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for _, r := range strings.Split(req.Repos, ",") {
-		if !isValidName(strings.TrimSpace(r)) {
+		if !isValidRepoRef(strings.TrimSpace(r)) {
 			http.Error(w, `{"error":"invalid repo name"}`, http.StatusBadRequest)
 			return
 		}
@@ -3550,7 +3550,7 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	for _, repo := range strings.Split(body.Repos, ",") {
-		if !isValidName(strings.TrimSpace(repo)) {
+		if !isValidRepoRef(strings.TrimSpace(repo)) {
 			http.Error(w, `{"error":"invalid repo name"}`, http.StatusBadRequest)
 			return
 		}


### PR DESCRIPTION
Follow-up to #1872 (which fixed the heartbeat path). The create-hive and edit-repos handlers still validated repos with `isValidName` (no `/`), so provisioning/editing a hive with a cross-org `owner/repo` via the hub API/UI would 400 — even though the Repos config box shows an `org/repo` placeholder. Both now use `isValidRepoRef`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)