### PR TITLE
🐛 fix: clear GitHub App 'not installed' banner on successful advisory post

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2101,7 +2101,16 @@ func runEvalCycle(
 						}
 					} else {
 						logger.Info("posted advisory digest", "repo", primaryRepo, "issue", issueNum, "findings", digest.TotalCount)
+						// A successful write proves the app is installed AND has
+						// write access — clear BOTH the perm issue and the
+						// app-required banner flag. Previously only the perm
+						// issue was cleared, so githubAppRequired (set true at
+						// startup or on an early transient failure) stuck on
+						// forever and the "GitHub App Not Installed" banner
+						// never went away despite tokens working.
 						dashSrv.SetGitHubAppPermIssue("")
+						dashSrv.SetGitHubAppRequired(false)
+						dashSrv.ClearPendingGitHubAppInstall()
 					}
 				}
 			}


### PR DESCRIPTION
`githubAppRequired` starts true (or is set true on an early transient 403/401), and only re-check / reinit cleared it. The advisory-digest **success** branch cleared the perm-issue string but **not** `githubAppRequired` — so once the flag was true, a hive posting digests successfully (app installed, writing fine) showed **"GitHub App Not Installed" forever**. Re-check cleared it momentarily, but the next successful post left it stuck true again.

Observed on kellyaa: `using GitHub App authentication`, tokens refreshing on her own installation `141187540`, digests posting — yet `githubAppRequired: true` even immediately after a successful re-check.

Fix: clear `githubAppRequired` (and pending-install) on a successful digest post. A successful write is proof the app is installed and authorized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)