### PR TITLE
🐛 fix: don't auto-unpause an operator-persisted inference-agent pause on restart

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -392,11 +392,20 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 		backend = agent.BackendOverride
 	}
 	if agent.Paused {
-		if IsInferenceBackend(backend) {
+		// Auto-unpause inference agents that were only transiently paused —
+		// but NEVER override a persisted operator pause (Config.Paused set via
+		// the dashboard and saved to hive.yaml). Previously this cleared EVERY
+		// inference-backend pause on startup, so an operator pause of a
+		// litellm/vllm/llm-d agent was silently undone on every restart AND
+		// the auto-unpause overwrote the persisted flag — corrupting the saved
+		// pause set (issue: kellyaa's pauses reverted on restart despite being
+		// on inference backends).
+		if IsInferenceBackend(backend) && !agent.Config.Paused {
 			agent.Paused = false
-			m.logger.Info("auto-unpaused inference agent", "name", agent.Name, "backend", backend)
+			m.logger.Info("auto-unpaused inference agent (transient pause, not operator-persisted)", "name", agent.Name, "backend", backend)
 		} else {
 			agent.State = StatePaused
+			m.logger.Info("agent starting paused", "name", agent.Name, "backend", backend, "persisted", agent.Config.Paused)
 			return nil
 		}
 	}


### PR DESCRIPTION
**THE actual cause of pauses reverting on restart for on-cluster hives** (not #1885, which was a real but secondary race).

`Start()` auto-unpaused **every** inference-backend agent (litellm/vllm/llm-d) that came up paused. It was meant for transient pauses, but couldn't distinguish an operator's deliberate pause from a spurious one, so it cleared both — **and** overwrote the persisted `Config.Paused` flag, corrupting the saved set.

kellyaa's agents run on **litellm**, so every restart auto-unpaused all her paused agents and rewrote the config without them. That's why her pauses "wouldn't stick" no matter how many times she set them, even after the persistence-race fix (#1885): #1885 was correct, but this auto-unpause undid it on the very next startup. It also explains the audit log showing `guide restored paused (persisted)` yet guide running — restore set it paused, then this cleared it.

Fix: gate the auto-unpause on `!agent.Config.Paused` — a persisted operator pause is always honored; only a transient (non-persisted) inference pause is auto-cleared.

Honesty note: the code path is in `Start()` after `ensureTmuxSession`, so it can't be unit-tested without a live tmux server — I removed a test that didn't actually reach the path rather than ship a false guard. Verification is against the live hive: after this lands, a persisted pause on a litellm agent survives restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)