### PR TITLE
🐛 fix: inference auto-unpause honors operator pause by trigger, not backend

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -400,12 +400,20 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 		// the auto-unpause overwrote the persisted flag — corrupting the saved
 		// pause set (issue: kellyaa's pauses reverted on restart despite being
 		// on inference backends).
-		if IsInferenceBackend(backend) && !agent.Config.Paused {
+		// Auto-unpause inference agents ONLY for a non-operator (transient/
+		// system) pause. An operator pause — dashboard-api trigger, or the
+		// persisted Config.Paused flag — must ALWAYS survive, exactly like a
+		// copilot-backed agent does. Keying on the backend alone wiped
+		// operator pauses of litellm/vllm/llm-d agents on every restart
+		// (kellyaa: her litellm-routed agents un-paused while the copilot
+		// strategist stayed paused, which is what exposed this).
+		operatorPaused := agent.Config.Paused || agent.PausedTrigger == "dashboard-api"
+		if IsInferenceBackend(backend) && !operatorPaused {
 			agent.Paused = false
-			m.logger.Info("auto-unpaused inference agent (transient pause, not operator-persisted)", "name", agent.Name, "backend", backend)
+			m.logger.Info("auto-unpaused inference agent (transient pause, not operator)", "name", agent.Name, "backend", backend, "trigger", agent.PausedTrigger)
 		} else {
 			agent.State = StatePaused
-			m.logger.Info("agent starting paused", "name", agent.Name, "backend", backend, "persisted", agent.Config.Paused)
+			m.logger.Info("agent starting paused", "name", agent.Name, "backend", backend, "trigger", agent.PausedTrigger, "persisted", agent.Config.Paused)
 			return nil
 		}
 	}


### PR DESCRIPTION
**Direct answer to why strategist stayed paused but the others didn't:** the auto-unpause in `Start()` keys on the *effective* backend (`BackendOverride`). kellyaa's agents are config-`copilot` but most get a **litellm** override at startup → `IsInferenceBackend` true → auto-unpaused. strategist has no litellm override → stays `copilot` → honored. So litellm-routed operator pauses were wiped every restart; copilot ones survived.

#1888 gated on `!Config.Paused`, but during config churn that flag can be stale-false, so the auto-unpause still fired. This gates on **operator intent**: `Config.Paused || PausedTrigger == "dashboard-api"`. An operator pause is now inviolable on restart regardless of backend — identical to a copilot agent. Only genuinely transient/system pauses (acmm-pack, login-detector, …) on inference backends are auto-cleared.

Honesty: this path is in `Start()` after `ensureTmuxSession`, not unit-testable without a live tmux server. Verified by reasoning + live-hive behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)