### PR TITLE
fix(pause): serialize all config saves to stop lost-write race dropping pauses

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"sync"
 	"os/signal"
 	"path/filepath"
 	"regexp"
@@ -1221,20 +1220,13 @@ func main() {
 	// the rest were silently lost on the next restart. Serialize the
 	// read-modify-save under a dedicated mutex so every pause transition is
 	// durably persisted.
-	var pausePersistMu sync.Mutex
 	agentMgr.SetPersistPauseCallback(func(name string, paused bool) {
-		pausePersistMu.Lock()
-		defer pausePersistMu.Unlock()
-		ac, ok := cfg.Agents[name]
-		if !ok || ac.Paused == paused {
-			return
-		}
-		ac.Paused = paused
-		cfg.Agents[name] = ac
 		configWatcher.SkipNext() // don't let our own write trigger a reload
-		if err := cfg.Save(); err != nil {
+		changed, err := cfg.SetAgentPausedAndSave(name, paused)
+		if err != nil {
 			logger.Warn("failed to persist agent pause state", "agent", name, "paused", paused, "error", err)
 		}
+		_ = changed
 	})
 
 	// Register custom GHE hostnames with the proxy allowlist so mode
@@ -2431,7 +2423,17 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 		logger.Error("failed to persist state", "error", err)
 	}
 
-	if err := cfg.Save(); err != nil {
+	// Reconcile the persisted pause field from the authoritative live manager
+	// state and save, atomically under the config save mutex. persistState runs
+	// async (go PersistFunc()) on every pause/resume; doing the c.Agents update
+	// and Save under saveMu (via ReconcilePausedAndSave) means it can neither
+	// race the pause callback's map write nor clobber its file write with a
+	// stale paused=false. livePaused is built from AllStatuses(), read above.
+	livePaused := make(map[string]bool, len(agents))
+	for name, as := range agents {
+		livePaused[name] = as.Paused
+	}
+	if err := cfg.ReconcilePausedAndSave(livePaused); err != nil {
 		logger.Error("failed to persist config to yaml", "error", err)
 		if dashSrv != nil {
 			dashSrv.AddSystemAlert("config-save-failed", "error",

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -8,10 +8,21 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"gopkg.in/yaml.v3"
 )
+
+// saveMu serializes all Config.Save() calls process-wide. Multiple goroutines
+// persist config concurrently — the mutex-guarded pause callback, the async
+// dashboard PersistFunc, the ACMM-level saver, HTTP mutation handlers. Each
+// does yaml.Marshal(c) + write. Without serialization, two Save() calls race:
+// the one that finishes writing LAST wins the file, and if it marshaled a
+// staler snapshot (e.g. before a later pause committed to c.Agents), that
+// pause is silently lost. Pausing 7 agents in quick succession reliably left
+// only the last 1-2 on the PVC. Serializing every Save() closes the race.
+var saveMu sync.Mutex
 
 type Config struct {
 	Project       ProjectConfig          `yaml:"project"`
@@ -1546,6 +1557,50 @@ func (c *Config) validateSaveGuard() error {
 // from overwriting the bind-mounted hive.yaml — a scenario that causes
 // crash-loops on the next startup ("project.org is required").
 func (c *Config) Save() error {
+	saveMu.Lock()
+	defer saveMu.Unlock()
+	return c.saveLocked()
+}
+
+// SetAgentPausedAndSave atomically updates one agent's Paused field and
+// persists the config, all under saveMu. This is the pause-callback path
+// (AgentMgr.Pause/Resume). Doing the c.Agents read-modify-write and the Save
+// under the SAME lock as every other saver eliminates both the map-mutation
+// race (two goroutines writing c.Agents) and the file-level lost-write race.
+// Returns whether a change was made (false when already at the target state).
+func (c *Config) SetAgentPausedAndSave(name string, paused bool) (bool, error) {
+	saveMu.Lock()
+	defer saveMu.Unlock()
+	ac, ok := c.Agents[name]
+	if !ok || ac.Paused == paused {
+		return false, nil
+	}
+	ac.Paused = paused
+	c.Agents[name] = ac
+	return true, c.saveLocked()
+}
+
+// ReconcilePausedAndSave sets each named agent's Paused field to the given
+// live value and persists, all under saveMu. This is the async PersistFunc
+// path (persistState): it carries the authoritative live paused set from the
+// agent manager, so its write is a correcting one rather than a stale snapshot
+// that could clobber a concurrent pause. Serializing it with SetAgentPausedAndSave
+// under saveMu is what closes the race that dropped pauses when many agents
+// were paused in quick succession.
+func (c *Config) ReconcilePausedAndSave(livePaused map[string]bool) error {
+	saveMu.Lock()
+	defer saveMu.Unlock()
+	for name, paused := range livePaused {
+		if ac, ok := c.Agents[name]; ok && ac.Paused != paused {
+			ac.Paused = paused
+			c.Agents[name] = ac
+		}
+	}
+	return c.saveLocked()
+}
+
+// saveLocked performs the actual marshal-and-write. Callers MUST hold saveMu.
+func (c *Config) saveLocked() error {
 	if c.SourcePath == "" {
 		return fmt.Errorf("config has no source path")
 	}

--- a/v2/pkg/config/pause_persist_soak_test.go
+++ b/v2/pkg/config/pause_persist_soak_test.go
@@ -37,19 +37,10 @@ func TestPausePersist_ConcurrentSoak(t *testing.T) {
 		Agents:     agents,
 	}
 
-	// The mutex-serialized persist callback from cmd/hive/main.go.
-	var persistMu sync.Mutex
+	// The persist callback from cmd/hive/main.go, via the real production method.
 	persist := func(name string, paused bool) {
-		persistMu.Lock()
-		defer persistMu.Unlock()
-		ac, ok := cfg.Agents[name]
-		if !ok || ac.Paused == paused {
-			return
-		}
-		ac.Paused = paused
-		cfg.Agents[name] = ac
-		if err := cfg.Save(); err != nil {
-			t.Errorf("Save: %v", err)
+		if _, err := cfg.SetAgentPausedAndSave(name, paused); err != nil {
+			t.Errorf("persist: %v", err)
 		}
 	}
 
@@ -106,4 +97,100 @@ func TestPausePersist_ConcurrentSoak(t *testing.T) {
 		}
 	}
 	_ = fmt.Sprint // keep import if trimmed
+}
+
+// TestPausePersist_TwoUnsynchronizedSavers reproduces the ACTUAL production bug
+// the earlier soak test missed: there are TWO independent goroutines that call
+// cfg.Save(), and they are NOT guarded by the same higher-level mutex.
+//
+//   - Path A: AgentMgr.Pause() -> mutex-guarded persist callback -> cfg.Save()
+//   - Path B: handlePause HTTP handler -> go PersistFunc() -> persistState() ->
+//     cfg.Save(), running fully async with NO shared lock with Path A.
+//
+// When 7 agents are paused in quick succession, each pause fires BOTH paths.
+// Path B marshals c.Agents at whatever partial state it holds and can land its
+// write AFTER Path A's, clobbering it — so only the last agent or two reach the
+// PVC. Modeling Path B WITHOUT the callback mutex proves the file-level saveMu
+// in Config.Save() is what actually closes the race: remove saveMu and this
+// test drops pauses; with it, all survive.
+func TestPausePersist_TwoUnsynchronizedSavers(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hive.yaml")
+
+	names := []string{"supervisor", "quality", "ci-maintainer", "architect",
+		"guide", "sec-check", "strategist"}
+	agents := map[string]AgentConfig{"scanner": {Backend: "claude"}}
+	for _, n := range names {
+		agents[n] = AgentConfig{Backend: "claude"}
+	}
+	cfg := &Config{
+		SourcePath: path,
+		Project:    ProjectConfig{Org: "testorg", Repos: []string{"repo1"}},
+		GitHub:     GitHubConfig{AppID: 3568013},
+		Agents:     agents,
+	}
+
+	// Path A: the pause callback (main.go) -> SetAgentPausedAndSave.
+	pathA := func(name string) {
+		if _, err := cfg.SetAgentPausedAndSave(name, true); err != nil {
+			t.Errorf("pathA: %v", err)
+		}
+	}
+	// Path B: the async PersistFunc (persistState) -> ReconcilePausedAndSave,
+	// carrying the authoritative live paused set. Both paths go through the
+	// real production methods, which share saveMu — so the map mutation and
+	// the file write are both serialized. Remove saveMu and this races/drops.
+	pathB := func(livePaused map[string]bool) {
+		if err := cfg.ReconcilePausedAndSave(livePaused); err != nil {
+			t.Errorf("pathB: %v", err)
+		}
+	}
+
+	// Build the full target paused set once; each goroutine gets its own copy
+	// so the test harness itself is race-free (production's persistState builds
+	// a fresh map from AllStatuses on every call). The concurrency under test is
+	// pathA vs pathB both mutating cfg.Agents and writing the file.
+	fullPaused := make(map[string]bool, len(names))
+	for _, n := range names {
+		fullPaused[n] = true
+	}
+
+	for cycle := 0; cycle < 30; cycle++ {
+		var wg sync.WaitGroup
+		for _, name := range names {
+			wg.Add(1)
+			go func(n string) {
+				defer wg.Done()
+				pathA(n)                     // Path A: this pause
+				pathB(cloneBoolMap(fullPaused)) // Path B: async full persist
+			}(name)
+		}
+		wg.Wait()
+
+		reloaded, err := Load(path)
+		if err != nil {
+			t.Fatalf("cycle %d: reload: %v", cycle, err)
+		}
+		for _, n := range names {
+			if !reloaded.Agents[n].Paused {
+				t.Fatalf("cycle %d: agent %q not paused after restart — lost-write race", cycle, n)
+			}
+		}
+		// Reset for next cycle (mutex-guarded, no map race).
+		reset := make(map[string]bool, len(names))
+		for _, n := range names {
+			reset[n] = false
+		}
+		if err := cfg.ReconcilePausedAndSave(reset); err != nil {
+			t.Fatalf("cycle %d: reset save: %v", cycle, err)
+		}
+	}
+}
+
+func cloneBoolMap(m map[string]bool) map[string]bool {
+	out := make(map[string]bool, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
 }


### PR DESCRIPTION
## Problem

Pausing several agents in quick succession left only the **last one or two** persisted to the PVC. On the next restart/upgrade, the rest came back **running** — the operator's pauses were silently lost. This is the bug that repeatedly forced re-pausing agents on kellyaa's hive.

## Root cause

Two independent, unsynchronized goroutines both call `cfg.Save()`:

- **Path A** — the mutex-guarded pause callback (`AgentMgr.Pause` → persist)
- **Path B** — the async dashboard `PersistFunc` (`handlePause` → `go persistState` → `cfg.Save()`)

PR #1885 only guarded **Path A** with a *local* mutex. Path B took no shared lock, mutated `cfg.Agents` from another goroutine, and its `Save()` could land **after** Path A's — clobbering a just-committed pause with a staler snapshot (last-writer-wins). Under `-race` this is a data race on both the `cfg.Agents` map and the file write.

Diagnostic that pinned it: pausing 7 agents (audit log showed all 7 `agent paused` events fire), yet the PVC held only `guide` + `strategist` — the last two to pause.

## Fix

A **process-wide `saveMu`** in the `config` package serializes every save. Two mutex-guarded helpers do the read-modify-write **and** the save atomically under that lock:

- `Config.SetAgentPausedAndSave` — pause-callback path
- `Config.ReconcilePausedAndSave` — async `persistState` path, carrying the authoritative live paused set from `AllStatuses()`, so its write **corrects** rather than clobbers

`Config.Save()` also takes `saveMu`, so all other savers (ACMM level, HTTP mutation handlers) are serialized too.

## Test

Adds `TestPausePersist_TwoUnsynchronizedSavers`, which models **both** save paths. It **fails under `-race` without the shared `saveMu`** (verified by disabling it — DATA RACE on `cfg.Agents` + file write) and passes with the fix. Unlike the prior soak test, which only exercised one path and passed even with the bug present.

Both soak tests + `pkg/config` and `pkg/agent` suites pass clean under `-race`.