### PR TITLE
fix(packs): reconcile all pack-behavior fields on ACMM level change

### DIFF
--- a/v2/pkg/dashboard/acmm_roster_reconcile_test.go
+++ b/v2/pkg/dashboard/acmm_roster_reconcile_test.go
@@ -139,3 +139,60 @@ func TestSetLevelFailsWhenRosterReconcileFails(t *testing.T) {
 		t.Errorf("expected reconciliation-failed error, got body=%s", w.Body.String())
 	}
 }
+
+// TestApplyPackReconcilesStalePackFields is the regression test for the
+// level-change drift bug: an agent carrying pack-behavior fields from a LOWER
+// level (kick_template, mode, model, description) must be reconciled to the
+// CURRENT level's pack when the level changes. Before the fix, kick_template
+// and mode reconciled but model/description/role did not — so hives that
+// climbed levels (kellyaa L5, ai-native L3, console L6) kept scanner/quality on
+// their old advisory templates and sonnet model even though acmm_level moved up.
+func TestApplyPackReconcilesStalePackFields(t *testing.T) {
+	srv := newFullServer(t) // L2, scanner present
+
+	// Seed the scanner with STALE fields as if left over from a lower level:
+	// the L2/L3 advisory template + description, and the sonnet model.
+	scanner := srv.deps.Config.Agents["scanner"]
+	scanner.KickTemplate = "scanner-advisory.md"
+	scanner.Mode = "ADVISORY"
+	scanner.Model = "claude-sonnet-4-6"
+	scanner.Description = "Scans code for issues and suggests fixes, but does NOT create PRs or issues."
+	srv.deps.Config.Agents["scanner"] = scanner
+
+	if _, err := srv.ApplyPack(5); err != nil {
+		t.Fatalf("ApplyPack(5): %v", err)
+	}
+
+	// The L5 pack's scanner definition is the source of truth.
+	pack, err := config.ACMMPackByLevel(5)
+	if err != nil {
+		t.Fatalf("ACMMPackByLevel(5): %v", err)
+	}
+	var want config.PackAgent
+	for _, pa := range pack.Agents {
+		if pa.Name == "scanner" {
+			want = pa
+		}
+	}
+	if want.Name == "" {
+		t.Fatal("scanner not found in L5 pack")
+	}
+
+	got := srv.deps.Config.Agents["scanner"]
+	if got.KickTemplate != want.KickTemplate {
+		t.Errorf("kick_template not reconciled: got %q want %q", got.KickTemplate, want.KickTemplate)
+	}
+	if got.Mode != want.Mode {
+		t.Errorf("mode not reconciled: got %q want %q", got.Mode, want.Mode)
+	}
+	if want.Model != "" && got.Model != want.Model {
+		t.Errorf("model not reconciled (the specific gap): got %q want %q", got.Model, want.Model)
+	}
+	if want.Description != "" && got.Description != want.Description {
+		t.Errorf("description not reconciled: got %q want %q", got.Description, want.Description)
+	}
+	// The stale advisory template must be gone.
+	if got.KickTemplate == "scanner-advisory.md" {
+		t.Error("scanner still on stale advisory template after L5 apply")
+	}
+}

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -80,16 +80,20 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 		if existing, exists := s.deps.Config.Agents[pa.Name]; exists {
 			changed := false
 
-			// Merge pack fields as defaults — user overrides take precedence.
-			// Backend/Model: use pack value only if user left it empty.
-			if existing.Backend == "" && pa.Backend != "" {
-				existing.Backend = pa.Backend
-				changed = true
-			}
-			if existing.Model == "" && pa.Model != "" {
-				existing.Model = pa.Model
-				changed = true
-			}
+			// Pack-behavior fields define what an agent DOES at a given ACMM
+			// level (which kick template it runs, its issue/PR mode, which model,
+			// its role/description). These MUST be reconciled to the current pack
+			// on every level change — otherwise a value written by a PREVIOUS
+			// level's pack is indistinguishable from a user override and sticks
+			// forever, so the agent keeps behaving at its old level. That is the
+			// exact drift observed in the field: hives that climbed levels kept
+			// scanner/ci-maintainer/quality on their lower-level advisory
+			// templates and models even though acmm_level had moved up. Reconcile
+			// these replace-on-diff (kick_template and mode already did; model,
+			// description, role, bead_role, display_name did NOT — that gap is the
+			// bug). Genuine per-agent overrides belong in the explicit override
+			// fields (BackendOverride, ModelOverride, pins), which live on the
+			// agent process and are NOT touched here.
 			if pa.KickTemplate != "" && existing.KickTemplate != pa.KickTemplate {
 				existing.KickTemplate = pa.KickTemplate
 				changed = true
@@ -98,21 +102,32 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 				existing.Mode = pa.Mode
 				changed = true
 			}
-			// Fill in descriptive fields from pack if user didn't set them.
-			if existing.DisplayName == "" && pa.DisplayName != "" {
-				existing.DisplayName = pa.DisplayName
+			if pa.Model != "" && existing.Model != pa.Model {
+				existing.Model = pa.Model
 				changed = true
 			}
-			if existing.Description == "" && pa.Description != "" {
+			if pa.Description != "" && existing.Description != pa.Description {
 				existing.Description = pa.Description
 				changed = true
 			}
-			if existing.Role == "" && pa.Role != "" {
+			if pa.Role != "" && existing.Role != pa.Role {
 				existing.Role = pa.Role
 				changed = true
 			}
-			if existing.BeadRole == "" && pa.BeadRole != "" {
+			if pa.BeadRole != "" && existing.BeadRole != pa.BeadRole {
 				existing.BeadRole = pa.BeadRole
+				changed = true
+			}
+			if pa.DisplayName != "" && existing.DisplayName != pa.DisplayName {
+				existing.DisplayName = pa.DisplayName
+				changed = true
+			}
+
+			// Backend is fill-if-empty: it never varies by level (always the same
+			// per agent across all packs), and users legitimately pin it, so the
+			// pack must not stomp a user's choice.
+			if existing.Backend == "" && pa.Backend != "" {
+				existing.Backend = pa.Backend
 				changed = true
 			}
 


### PR DESCRIPTION
## Problem

`ApplyPack` merged pack fields **inconsistently**: `kick_template` and `mode` were reconciled *replace-on-diff*, but `model`, `description`, `role`, `bead_role`, and `display_name` were only filled in **when empty**. Under fill-if-empty, a value written by a *previous* level's pack is indistinguishable from a user override, so it sticks forever — the agent keeps behaving at its old level after the hive moves up or down.

Compounding it, `handlePackSetLevel` writes `acmm_level` *before* reconciling agents, so the level number can run ahead of the agent fields.

## Blast radius (audited across the live fleet)

Hives that **changed levels** carried stale lower-level values; hives that never moved were clean (9 of 12):

| Hive | Level | Drift |
|---|---|---|
| kellyaa | 5 | scanner → `scanner-advisory.md` + sonnet (want holdgated + opus); ci-maintainer → advisory template + `ADVISORY` mode |
| ai-native-systems-research | 3 | quality → advisory + sonnet; scanner stuck in `ISSUES_AND_PRS` after dropping back down |
| kubestellar-console | 6 | scanner → sonnet (want opus) |

The drift is bidirectional — stale fields survive both up- and down-level moves.

## Fix

Reconcile the **pack-behavior fields** (`kick_template`, `mode`, `model`, `description`, `role`, `bead_role`, `display_name`) *replace-on-diff*, so a level change brings every agent fully to the current pack. 

`backend` stays fill-if-empty — it never varies by level (always `copilot`) and users legitimately pin it. Genuine per-agent overrides live in the explicit override fields (`BackendOverride`, `ModelOverride`, pins), which are separate and untouched here.

## Test

Adds `TestApplyPackReconcilesStalePackFields`: seeds an agent with stale lower-level fields, applies a higher level, asserts they reconcile. **Verified it fails without the fix** (`model not reconciled: sonnet want opus`). Full `pkg/dashboard` suite passes.

## Follow-up

The 3 drifted hives will be re-reconciled to their pack after this ships (separate operational step) — this PR fixes the root cause so it can't recur.