### PR TITLE
fix(hub): decouple spoke heartbeat cadence from governor eval interval

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1425,6 +1425,15 @@ func main() {
 		cfg.Hub.ClusterID = envCluster
 	}
 	if cfg.Hub.Enabled && hubURL != "" {
+		// Heartbeat cadence is INDEPENDENT of the governor eval interval. It was
+		// previously tied to cfg.Governor.EvalIntervalS, so a low-ACMM hive
+		// (which evaluates infrequently by design — e.g. ~10 min at L2) beat the
+		// hub only every ~10 min. The hub marks a hive stale after
+		// heartbeatHealthStaleness (5 min), so such hives showed a gray/stale
+		// dot for half of every cycle despite being perfectly healthy. Beat on a
+		// fixed interval comfortably under that 5-min threshold so every hive,
+		// regardless of ACMM level, stays fresh on the hub.
+		const heartbeatSendInterval = 2 * time.Minute
 		go hub.StartHeartbeat(ctx, hubURL, func() *hub.HeartbeatPayload {
 			if !cfg.Hub.Enabled {
 				return nil
@@ -1529,7 +1538,7 @@ func main() {
 					return hub.CollectClusterHealth(logger)
 				}(),
 			}
-		}, time.Duration(cfg.Governor.EvalIntervalS)*time.Second, logger, hub.UpgradeCallback(func(targetSHA string) {
+		}, heartbeatSendInterval, logger, hub.UpgradeCallback(func(targetSHA string) {
 			const upgradeMarkerPath = "/data/upgrade-requested"
 
 			// If a previous process already attempted an upgrade and we booted


### PR DESCRIPTION
## Problem

The spoke heartbeat interval was `cfg.Governor.EvalIntervalS`, so a low-ACMM hive — which evaluates infrequently by design (~10 min at L2) — beat the hub only every ~10 min. The hub marks a hive **stale** after `heartbeatHealthStaleness` (5 min) and `Online=false` after `maxHeartbeatAge` (5 min), so these healthy hives showed a **gray/stale dot for roughly half of every cycle**.

Observed on **kalantar** (L2 on vllm-d): pod up and working, heartbeats landing at the hub 10 min apart (`04:34:56` → `04:44:56`), yet gray between beats.

## Fix

Beat on a **fixed 2-minute interval, independent of ACMM level**, comfortably under the 5-minute staleness/online thresholds (and well under the 15-minute hard `staleThreshold`). Every hive stays fresh regardless of how often its governor evaluates.

Threshold ordering after the fix: **send 2m < staleness/online 5m < hard-stale 15m.**

Safe by construction: the heartbeat endpoint has no min-interval guard or rate limit, and `Online` is a max-age check (`age <= maxHeartbeatAge`), so a more frequent beat is strictly beneficial. Extra traffic is one small POST per hive per 2 min.