### PR TITLE
fix(config): re-apply dashboard overlay on watcher reload so reconciled agent fields survive

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -884,6 +884,49 @@ func LoadWithOverrides(path, envPath string) (*Config, error) {
 	return &cfg, nil
 }
 
+// LoadWithDashboardOverlay loads the config from path, then — in Kubernetes
+// mode — re-applies the dashboard overlay's agent configs on top, mirroring
+// the entrypoint's boot-time seed+overlay merge.
+//
+// Why this exists: the ConfigMap seed at path carries only provision-time
+// agent fields. Runtime reconciliation (ApplyPack raising a hive's ACMM level
+// updates kick_template/mode/model) is persisted to the dashboard overlay, NOT
+// the seed. The entrypoint merges the overlay over the seed once at boot, but a
+// live ConfigMap remount rewrites the seed back to its stale values and fires
+// the config watcher. If the watcher reloaded the raw seed it would silently
+// revert every reconciled agent field (observed: a hive raised to L5 dropped
+// its scanner back to the L2/L3 advisory template at runtime). Applying the
+// overlay here keeps the reload consistent with boot.
+func LoadWithDashboardOverlay(path string) (*Config, error) {
+	cfg, err := Load(path)
+	if err != nil {
+		return nil, err
+	}
+	if !IsKubernetesPod() {
+		return cfg, nil
+	}
+	data, err := os.ReadFile(DashboardOverlayFile)
+	if err != nil {
+		// No overlay (or unreadable) — the seed is authoritative, as at boot.
+		return cfg, nil
+	}
+	var overlay Config
+	if err := yaml.Unmarshal([]byte(expandEnvVars(string(data))), &overlay); err != nil {
+		return cfg, nil // malformed overlay: fall back to seed, don't fail the reload
+	}
+	// Guard: the overlay must look like a full hive config (same check the
+	// entrypoint and validateSaveGuard apply) before we trust its agents.
+	if overlay.Project.Org == "" || len(overlay.Agents) == 0 {
+		return cfg, nil
+	}
+	// Overlay agents win — they carry the reconciled pack-behavior fields.
+	cfg.MergeAgentOverrides(overlay.Agents)
+	for name := range overlay.Agents {
+		cfg.ApplyAgentDefaults(name)
+	}
+	return cfg, nil
+}
+
 // findConfigEnv returns the path to a config.env file, or "" if none found.
 func findConfigEnv(yamlPath string) string {
 	candidates := []string{

--- a/v2/pkg/config/dashboard_overlay_reload_test.go
+++ b/v2/pkg/config/dashboard_overlay_reload_test.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadWithDashboardOverlay_OverlayWinsOnReload is the regression test for
+// the runtime revert bug: a ConfigMap remount rewrites the seed back to its
+// provision-time values and fires the config watcher; the reload must re-apply
+// the dashboard overlay so runtime-reconciled agent fields (kick_template,
+// mode, model set by ApplyPack when a hive's ACMM level was raised) survive.
+// Before the fix, the watcher loaded the raw seed and silently reverted, e.g.
+// scanner from scanner-holdgated.md (L5) back to scanner-advisory.md.
+func TestLoadWithDashboardOverlay_OverlayWinsOnReload(t *testing.T) {
+	dir := t.TempDir()
+	seedPath := filepath.Join(dir, "hive.yaml")
+
+	// Seed = the stale ConfigMap: scanner is advisory (provision-time L2/L3).
+	seed := `
+project:
+  org: testorg
+  repos: [repo1]
+github:
+  token: ghp_test123456789
+agents:
+  scanner:
+    backend: copilot
+    model: claude-sonnet-4-6
+    kick_template: scanner-advisory.md
+    mode: ADVISORY
+`
+	if err := os.WriteFile(seedPath, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Overlay = the reconciled L5 state persisted by ApplyPack.
+	overlayPath := filepath.Join(dir, "hive.yaml.dashboard")
+	overlay := `
+project:
+  org: testorg
+  repos: [repo1]
+github:
+  token: ghp_test123456789
+agents:
+  scanner:
+    backend: copilot
+    model: claude-opus-4-6
+    kick_template: scanner-holdgated.md
+    mode: ISSUES_AND_PRS
+`
+	if err := os.WriteFile(overlayPath, []byte(overlay), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Point the package overlay var at our temp file and fake K8s mode.
+	origOverlay := DashboardOverlayFile
+	DashboardOverlayFile = overlayPath
+	t.Cleanup(func() { DashboardOverlayFile = origOverlay })
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+
+	// Raw Load must return the stale seed value (this is what the watcher used
+	// to do — and why it reverted).
+	raw, err := Load(seedPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := raw.Agents["scanner"].KickTemplate; got != "scanner-advisory.md" {
+		t.Fatalf("precondition: raw seed scanner should be advisory, got %q", got)
+	}
+
+	// LoadWithDashboardOverlay must apply the overlay so scanner is holdgated.
+	merged, err := LoadWithDashboardOverlay(seedPath)
+	if err != nil {
+		t.Fatalf("LoadWithDashboardOverlay: %v", err)
+	}
+	sc := merged.Agents["scanner"]
+	if sc.KickTemplate != "scanner-holdgated.md" {
+		t.Errorf("kick_template not restored from overlay: got %q want scanner-holdgated.md", sc.KickTemplate)
+	}
+	if sc.Mode != "ISSUES_AND_PRS" {
+		t.Errorf("mode not restored: got %q want ISSUES_AND_PRS", sc.Mode)
+	}
+	if sc.Model != "claude-opus-4-6" {
+		t.Errorf("model not restored: got %q want claude-opus-4-6", sc.Model)
+	}
+}
+
+// TestLoadWithDashboardOverlay_NoOverlayFallsBackToSeed ensures that without an
+// overlay (or outside K8s) the seed is used as-is — no behavior change.
+func TestLoadWithDashboardOverlay_NoOverlayFallsBackToSeed(t *testing.T) {
+	dir := t.TempDir()
+	seedPath := filepath.Join(dir, "hive.yaml")
+	seed := `
+project:
+  org: testorg
+  repos: [repo1]
+github:
+  token: ghp_test123456789
+agents:
+  scanner:
+    backend: copilot
+    kick_template: scanner-advisory.md
+`
+	if err := os.WriteFile(seedPath, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	DashboardOverlayFile = filepath.Join(dir, "does-not-exist.dashboard")
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+
+	cfg, err := LoadWithDashboardOverlay(seedPath)
+	if err != nil {
+		t.Fatalf("LoadWithDashboardOverlay: %v", err)
+	}
+	if got := cfg.Agents["scanner"].KickTemplate; got != "scanner-advisory.md" {
+		t.Errorf("without overlay, seed should win: got %q", got)
+	}
+}

--- a/v2/pkg/config/watcher.go
+++ b/v2/pkg/config/watcher.go
@@ -128,7 +128,13 @@ func (w *Watcher) reload() {
 	}
 	w.mu.Unlock()
 
-	cfg, err := Load(w.path)
+	// Load the seed AND re-apply the dashboard overlay, mirroring the
+	// entrypoint's boot merge. A raw Load(w.path) would drop runtime-reconciled
+	// agent fields (kick_template/mode/model persisted to the overlay by
+	// ApplyPack) whenever a ConfigMap remount rewrites the seed and fires this
+	// watcher — silently reverting a hive's agents to their provision-time
+	// (lower-ACMM) behavior.
+	cfg, err := LoadWithDashboardOverlay(w.path)
 	if err != nil {
 		w.logger.Warn("config reload failed", "path", w.path, "error", err)
 		return


### PR DESCRIPTION
## Problem

The ACMM level-change fix (#1892) reconciles agent fields correctly, but **kellyaa's scanner reverted from `scanner-holdgated.md` (L5) back to `scanner-advisory.md` a few hours later with no restart.** Root cause is deeper than the pack merge:

The config file watcher reloaded the raw ConfigMap seed (`/etc/hive/hive.yaml`) and swapped it into memory **wholesale**. The seed carries only provision-time agent fields; runtime reconciliation (ApplyPack updating `kick_template`/`mode`/`model` when a hive's ACMM level is raised) is persisted to the **dashboard overlay** (`/data/hive.yaml.dashboard`), **not** the seed.

The entrypoint merges overlay over seed once at boot — but a live **ConfigMap remount rewrites the seed** back to stale values and fires the watcher. The watcher loaded the raw seed and reverted every reconciled field at runtime. A subsequent `persistState` then wrote the reverted state back into the overlay, making the regression sticky (all three config layers ended up advisory).

## Fix

Add `LoadWithDashboardOverlay`: `Load` the seed, then — in Kubernetes mode — re-apply the dashboard overlay's agent configs on top, mirroring the entrypoint's boot merge. The watcher now uses it, so a ConfigMap remount can no longer drop reconciled agent behavior. Falls back to the seed when there's no overlay, outside K8s, or when the overlay is malformed/incomplete.

## Test

`TestLoadWithDashboardOverlay_*` — seed has advisory scanner, overlay has holdgated; asserts the merged load returns holdgated. **Verified the test fails without the merge** (`got "scanner-advisory.md" want scanner-holdgated.md`) and passes with it. Full `pkg/config` suite passes under `-race`.

## Note

This is the durable fix behind the reconcile. After it ships, kellyaa (and the other reconciled hives) will hold their reconciled state across ConfigMap remounts, not just until the next watcher event.