### PR TITLE
feat(resolve): pluggable ${VAR} resolution engine foundation (env/static)

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"log"
 	"net/url"
@@ -11,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kubestellar/hive/v2/pkg/resolve"
 	"gopkg.in/yaml.v3"
 )
 
@@ -37,8 +39,45 @@ type Config struct {
 	Hub           HubConfig              `yaml:"hub"`
 	HiveID        string                 `yaml:"hive_id"`
 	ACMMLevel     *int                   `yaml:"acmm_level,omitempty" json:"acmm_level"`
+	Variables     VariablesConfig        `yaml:"variables,omitempty"`
 
 	SourcePath string `yaml:"-" json:"-"`
+}
+
+// VariablesConfig declares operator-defined ${VAR} substitutions and the trust
+// policy for resolvers that execute code or do network I/O. It drives the
+// pluggable resolve engine (pkg/resolve) used by both config-load and per-kick
+// template substitution. Absent (the default) means env-only substitution,
+// byte-identical to hive's legacy behavior.
+type VariablesConfig struct {
+	// Security gates script/http resolvers. Honored ONLY from the trusted config
+	// seed — the dashboard overlay's Security block is discarded on load so a
+	// user-editable overlay can never enable code execution or network access.
+	Security VarSecurityConfig `yaml:"security,omitempty"`
+	// Defs maps a variable name (used as ${name}) to its definition.
+	Defs map[string]VarDef `yaml:"defs,omitempty"`
+}
+
+// VarSecurityConfig is the resolver trust model. Defaults are deny.
+type VarSecurityConfig struct {
+	AllowExec     bool     `yaml:"allow_exec,omitempty"`
+	AllowHTTP     bool     `yaml:"allow_http,omitempty"`
+	HTTPAllowlist []string `yaml:"http_allowlist,omitempty"`
+	ExecTimeoutS  int      `yaml:"exec_timeout_s,omitempty"`
+	HTTPTimeoutS  int      `yaml:"http_timeout_s,omitempty"`
+}
+
+// VarDef is one operator-declared variable. `default` uses a pointer so an
+// explicit empty-string default is distinguishable from "no default".
+type VarDef struct {
+	Type    string            `yaml:"type,omitempty"`  // env|static|script|http
+	Scope   string            `yaml:"scope,omitempty"` // config|template|both (default template)
+	Default *string           `yaml:"default,omitempty"`
+	Value   string            `yaml:"value,omitempty"`   // static
+	Env     string            `yaml:"env,omitempty"`     // env source var name
+	Command []string          `yaml:"command,omitempty"` // script argv
+	URL     string            `yaml:"url,omitempty"`     // http
+	Headers map[string]string `yaml:"headers,omitempty"` // http
 }
 
 // DocSourceConfigYAML describes an external document to import as knowledge.
@@ -825,8 +864,6 @@ type DataConfig struct {
 	AgentsDir          string `yaml:"agents_dir"`
 }
 
-var envVarPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
-
 // Load reads hive.yaml, then applies config.env overrides if present.
 // Precedence: hive.yaml < config.env < explicit env vars (via ${} interpolation).
 func Load(path string) (*Config, error) {
@@ -924,6 +961,11 @@ func LoadWithDashboardOverlay(path string) (*Config, error) {
 	for name := range overlay.Agents {
 		cfg.ApplyAgentDefaults(name)
 	}
+	// Security invariant: cfg.Variables (resolver defs + the exec/http trust
+	// policy) comes ONLY from the seed loaded above — the overlay's Variables
+	// block is intentionally NOT merged. The dashboard overlay is user-writable,
+	// so honoring its resolver policy would let a compromised overlay enable
+	// script/http execution. Keep this true if overlay merging is ever expanded.
 	return cfg, nil
 }
 
@@ -1069,14 +1111,70 @@ func parseAuthorizedUsers(v string) []string {
 	return out
 }
 
+// expandEnvVars substitutes ${VAR} references in the raw config text. It runs
+// BEFORE the YAML is parsed, so to honor an operator `variables:` block it
+// first bootstrap-parses just that block from the same text, builds a
+// config-scoped resolve.Registry, and delegates. With no `variables:` block the
+// registry is env-only and the result is byte-identical to the legacy behavior
+// (${NAME} -> os.LookupEnv(NAME), unset left literal).
 func expandEnvVars(s string) string {
-	return envVarPattern.ReplaceAllStringFunc(s, func(match string) string {
-		varName := strings.TrimSuffix(strings.TrimPrefix(match, "${"), "}")
-		if val, ok := os.LookupEnv(varName); ok {
-			return val
+	reg := configRegistryFromText(s)
+	return reg.Expand(context.Background(), s, resolve.ScopeConfig, nil)
+}
+
+// bootstrapVariables is a minimal view of hive.yaml used to read the
+// `variables:` block before the whole document is expanded/parsed. Unknown keys
+// are ignored by yaml.Unmarshal, so this is cheap and tolerant.
+type bootstrapVariables struct {
+	Variables VariablesConfig `yaml:"variables"`
+}
+
+// configRegistryFromText bootstrap-parses the variables block from raw config
+// text and returns a config-scoped resolve.Registry. On any parse failure it
+// falls back to an env-only registry (legacy behavior), never an error — config
+// expansion must not fail the load.
+func configRegistryFromText(raw string) *resolve.Registry {
+	var bv bootstrapVariables
+	if err := yaml.Unmarshal([]byte(raw), &bv); err != nil {
+		return resolve.EnvOnly()
+	}
+	if len(bv.Variables.Defs) == 0 {
+		// No custom variables — env-only, byte-identical to legacy.
+		return resolve.EnvOnly()
+	}
+	specs, pol := bv.Variables.toResolveSpecs()
+	return resolve.Build(specs, pol, nil)
+}
+
+// toResolveSpecs translates the config-level variables block into the
+// resolve package's VarSpec list and Policy.
+func (v VariablesConfig) toResolveSpecs() ([]resolve.VarSpec, resolve.Policy) {
+	specs := make([]resolve.VarSpec, 0, len(v.Defs))
+	for name, def := range v.Defs {
+		spec := resolve.VarSpec{
+			Name:    name,
+			Type:    def.Type,
+			Scope:   resolve.Scope(def.Scope),
+			Value:   def.Value,
+			Env:     def.Env,
+			Command: def.Command,
+			URL:     def.URL,
+			Headers: def.Headers,
 		}
-		return match
-	})
+		if def.Default != nil {
+			spec.HasDefault = true
+			spec.Default = *def.Default
+		}
+		specs = append(specs, spec)
+	}
+	pol := resolve.Policy{
+		AllowExec:     v.Security.AllowExec,
+		AllowHTTP:     v.Security.AllowHTTP,
+		HTTPAllowlist: v.Security.HTTPAllowlist,
+		ExecTimeoutS:  v.Security.ExecTimeoutS,
+		HTTPTimeoutS:  v.Security.HTTPTimeoutS,
+	}
+	return specs, pol
 }
 
 const (

--- a/v2/pkg/config/expand_env_parity_test.go
+++ b/v2/pkg/config/expand_env_parity_test.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"os"
+	"regexp"
+	"testing"
+)
+
+// legacyExpandEnvVars is the exact pre-resolver implementation, kept here to
+// prove the new resolver-backed expandEnvVars is byte-identical for configs
+// without a `variables:` block.
+func legacyExpandEnvVars(s string) string {
+	pat := regexp.MustCompile(`\$\{([^}]+)\}`)
+	return pat.ReplaceAllStringFunc(s, func(match string) string {
+		varName := match[2 : len(match)-1]
+		if val, ok := os.LookupEnv(varName); ok {
+			return val
+		}
+		return match
+	})
+}
+
+// TestExpandEnvVars_ByteIdenticalToLegacy runs a battery of inputs through both
+// the legacy and the new (resolver-delegating) expandEnvVars and asserts
+// identical output. Guards the "no behavior change" contract of PR 1.
+func TestExpandEnvVars_ByteIdenticalToLegacy(t *testing.T) {
+	t.Setenv("HIVE_GITHUB_TOKEN", "ghp_secret123")
+	t.Setenv("SLACK_WEBHOOK_URL", "https://hooks.example/xyz")
+	t.Setenv("EMPTY_VAR", "")
+	os.Unsetenv("MISSING_VAR")
+
+	inputs := []string{
+		"",
+		"plain text no vars",
+		"github:\n  token: ${HIVE_GITHUB_TOKEN}\n",
+		"webhook: ${SLACK_WEBHOOK_URL}",
+		"${MISSING_VAR} stays literal",
+		"empty=[${EMPTY_VAR}]",
+		"a ${HIVE_GITHUB_TOKEN} b ${MISSING_VAR} c ${EMPTY_VAR} d",
+		"nested-ish ${${HIVE_GITHUB_TOKEN}}",  // regex is non-recursive; must match legacy
+		"kick uses ${ISSUE_LIST} and ${AGENT_NAME}", // template vars unset at config time -> literal
+		"$notavar ${} ${ x }",                       // odd shapes
+	}
+	for _, in := range inputs {
+		got := expandEnvVars(in)
+		want := legacyExpandEnvVars(in)
+		if got != want {
+			t.Errorf("expandEnvVars(%q)\n  got  %q\n  want %q", in, got, want)
+		}
+	}
+}
+
+// TestExpandEnvVars_WithVariablesBlock verifies that a config that DOES declare
+// a variables block gets operator substitutions, while everything else still
+// matches env behavior.
+func TestExpandEnvVars_WithVariablesBlock(t *testing.T) {
+	os.Unsetenv("HIVE_REGION")
+	raw := `
+variables:
+  defs:
+    DEPLOY_ENV:
+      type: static
+      value: production
+      scope: both
+    REGION:
+      type: env
+      env: HIVE_REGION
+      default: us-east-1
+      scope: config
+project:
+  org: testorg
+  name: ${DEPLOY_ENV}
+  region_note: ${REGION}
+  missing: ${STILL_MISSING}
+`
+	out := expandEnvVars(raw)
+	if !contains(out, "name: production") {
+		t.Errorf("static var not substituted:\n%s", out)
+	}
+	if !contains(out, "region_note: us-east-1") {
+		t.Errorf("env default not substituted:\n%s", out)
+	}
+	if !contains(out, "missing: ${STILL_MISSING}") {
+		t.Errorf("unknown var should stay literal:\n%s", out)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/v2/pkg/resolve/context.go
+++ b/v2/pkg/resolve/context.go
@@ -1,0 +1,23 @@
+package resolve
+
+// RuntimeContext carries the live, per-kick built-in variable producers for
+// System B (prompt templating). It lives in this package — rather than in
+// scheduler — so resolve/ has no dependency on github/scheduler/dashboard,
+// avoiding an import cycle. Callers fill Vars with thunks; a thunk runs only if
+// the template actually references its variable, so expensive producers (e.g.
+// knowledge priming) are not computed for templates that don't use them.
+type RuntimeContext struct {
+	// Vars maps a built-in variable name (without braces) to a producer. The
+	// producer is called at most once per Expand call for a given name; see
+	// Registry.Expand for memoization.
+	Vars map[string]func() string
+}
+
+// lookup returns the producer for name and whether it exists.
+func (rc *RuntimeContext) lookup(name string) (func() string, bool) {
+	if rc == nil || rc.Vars == nil {
+		return nil, false
+	}
+	fn, ok := rc.Vars[name]
+	return fn, ok
+}

--- a/v2/pkg/resolve/env.go
+++ b/v2/pkg/resolve/env.go
@@ -1,0 +1,45 @@
+package resolve
+
+import "os"
+
+func init() {
+	RegisterResolver("env", newEnvResolver)
+}
+
+// envResolver resolves a variable from an environment variable. It is the
+// always-on default that reproduces the legacy os.LookupEnv behavior: a set
+// variable (even to empty string) resolves to its value; an unset variable is
+// ErrUnresolved unless the spec supplies a default.
+type envResolver struct {
+	spec VarSpec
+}
+
+func newEnvResolver(spec VarSpec, _ Policy) (Resolver, error) {
+	return &envResolver{spec: spec}, nil
+}
+
+func (r *envResolver) Resolve(req Request) (Result, error) {
+	name := r.spec.Env
+	if name == "" {
+		name = req.Name
+	}
+	if val, ok := os.LookupEnv(name); ok {
+		return Result{Value: val, Source: "env:" + name}, nil
+	}
+	if r.spec.HasDefault {
+		return Result{Value: r.spec.Default, Source: "default"}, nil
+	}
+	return Result{}, ErrUnresolved
+}
+
+// bareEnvResolver is the implicit resolver used for any ${NAME} that has no
+// operator VarSpec: look up the environment variable of the same name, leave
+// literal if unset. This is exactly the legacy config.expandEnvVars behavior.
+type bareEnvResolver struct{}
+
+func (bareEnvResolver) Resolve(req Request) (Result, error) {
+	if val, ok := os.LookupEnv(req.Name); ok {
+		return Result{Value: val, Source: "env:" + req.Name}, nil
+	}
+	return Result{}, ErrUnresolved
+}

--- a/v2/pkg/resolve/policy.go
+++ b/v2/pkg/resolve/policy.go
@@ -1,0 +1,95 @@
+package resolve
+
+// Scope declares which substitution system(s) an operator-defined variable
+// serves. This split matters because config-load resolution (System A) runs
+// pre-parse over the whole YAML with no runtime context, while per-kick
+// resolution (System B) has rich runtime context. A script/http variable
+// generally belongs to template scope; a static/env value can serve either.
+type Scope string
+
+const (
+	// ScopeTemplate — resolved only during per-kick prompt templating. Default.
+	ScopeTemplate Scope = "template"
+	// ScopeConfig — resolved during config load (hive.yaml text expansion).
+	ScopeConfig Scope = "config"
+	// ScopeBoth — resolved in both systems.
+	ScopeBoth Scope = "both"
+)
+
+// InScope reports whether a variable with the given declared scope participates
+// in the requested system. An empty declared scope defaults to template.
+func (s Scope) matches(want Scope) bool {
+	switch s {
+	case "", ScopeTemplate:
+		return want == ScopeTemplate
+	case ScopeConfig:
+		return want == ScopeConfig
+	case ScopeBoth:
+		return true
+	default:
+		return false
+	}
+}
+
+// VarSpec is one operator-declared variable from the config `variables.defs`
+// block. Which fields are meaningful depends on Type; unrelated fields are
+// ignored by each resolver's factory.
+type VarSpec struct {
+	// Name is the variable name (the map key in config), i.e. ${Name}.
+	Name string
+	// Type selects the resolver: "env" | "static" | "script" | "http". An empty
+	// Type defaults to "static" when Value is set, else "env".
+	Type string
+	// Scope controls which substitution system this var serves.
+	Scope Scope
+	// Default is the fallback value used when the resolver would otherwise be
+	// ErrUnresolved (e.g. env var unset). Empty means "no default" (leave literal).
+	Default string
+	// HasDefault distinguishes an explicit empty-string default from no default.
+	HasDefault bool
+
+	// Static.
+	Value string
+	// Env: the source environment variable name (defaults to Name if empty).
+	Env string
+	// Script: argv (NOT a shell string — no shell interpolation).
+	Command []string
+	// HTTP.
+	URL     string
+	Headers map[string]string
+}
+
+// Policy is the process-wide trust model for resolvers that execute code or do
+// network I/O. It is built only from the cluster-trusted config seed, never
+// from the dashboard overlay (the config package enforces that), so a
+// compromised or user-edited overlay cannot enable script/http execution.
+type Policy struct {
+	// AllowExec gates script (exec) resolvers. Default false.
+	AllowExec bool
+	// AllowHTTP gates http resolvers. Default false.
+	AllowHTTP bool
+	// HTTPAllowlist is the set of hostnames an http resolver may contact.
+	// Required (non-empty) for any http resolver to be built.
+	HTTPAllowlist []string
+	// ExecTimeoutS bounds a single script resolver's runtime. Default 5.
+	ExecTimeoutS int
+	// HTTPTimeoutS bounds a single http resolver's request. Default 5.
+	HTTPTimeoutS int
+}
+
+// Default timeouts (seconds) applied when a Policy leaves them at zero.
+const (
+	DefaultExecTimeoutS = 5
+	DefaultHTTPTimeoutS = 5
+)
+
+// withDefaults returns a copy of the policy with zero timeouts filled in.
+func (p Policy) withDefaults() Policy {
+	if p.ExecTimeoutS <= 0 {
+		p.ExecTimeoutS = DefaultExecTimeoutS
+	}
+	if p.HTTPTimeoutS <= 0 {
+		p.HTTPTimeoutS = DefaultHTTPTimeoutS
+	}
+	return p
+}

--- a/v2/pkg/resolve/registry.go
+++ b/v2/pkg/resolve/registry.go
@@ -1,0 +1,151 @@
+package resolve
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+)
+
+// factories holds the registered resolver Factory per type name. Populated by
+// each built-in's init() and by any RegisterResolver call. Guarded because
+// registration can happen from init() across packages.
+var (
+	factoriesMu sync.RWMutex
+	factories   = map[string]Factory{}
+)
+
+// RegisterResolver registers a Factory under a type name (e.g. "env", "script").
+// This is the extensibility seam: a new resolver type is one file with an
+// init() that calls RegisterResolver — no changes to the call sites or the
+// Registry. Re-registering a type overwrites the prior factory.
+func RegisterResolver(typ string, f Factory) {
+	factoriesMu.Lock()
+	defer factoriesMu.Unlock()
+	factories[typ] = f
+}
+
+func lookupFactory(typ string) (Factory, bool) {
+	factoriesMu.RLock()
+	defer factoriesMu.RUnlock()
+	f, ok := factories[typ]
+	return f, ok
+}
+
+// defKind describes how a compiled operator variable is dispatched.
+type compiledDef struct {
+	spec     VarSpec
+	scope    Scope
+	resolver Resolver
+}
+
+// Registry is an immutable, built-from-config set of operator variable
+// definitions plus a policy. It is safe for concurrent use by many goroutines
+// (e.g. parallel kicks) — Build happens once, Expand is read-only.
+type Registry struct {
+	defs   map[string]compiledDef // by variable name
+	policy Policy
+	logger *slog.Logger
+}
+
+// Build compiles a Registry from operator VarSpecs and a Policy. Specs whose
+// type is unknown, or whose factory refuses construction (e.g. script/http when
+// the policy disallows it), are logged and skipped — they will resolve to their
+// literal ${VAR}, never crash the load. A nil logger discards diagnostics.
+func Build(specs []VarSpec, pol Policy, logger *slog.Logger) *Registry {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(discard{}, nil))
+	}
+	pol = pol.withDefaults()
+	r := &Registry{defs: map[string]compiledDef{}, policy: pol, logger: logger}
+	for _, spec := range specs {
+		typ := spec.Type
+		if typ == "" {
+			if spec.Value != "" {
+				typ = "static"
+			} else {
+				typ = "env"
+			}
+		}
+		factory, ok := lookupFactory(typ)
+		if !ok {
+			logger.Warn("unknown variable resolver type, leaving literal", "var", spec.Name, "type", typ)
+			continue
+		}
+		res, err := factory(spec, pol)
+		if err != nil {
+			logger.Warn("variable resolver disabled, leaving literal", "var", spec.Name, "type", typ, "error", err)
+			continue
+		}
+		r.defs[spec.Name] = compiledDef{spec: spec, scope: spec.Scope, resolver: res}
+	}
+	return r
+}
+
+// EnvOnly returns a Registry with no operator defs and a zero policy. Its Expand
+// reproduces the legacy behavior exactly: ${NAME} → os.LookupEnv(NAME), unset
+// left literal. Used when no `variables:` block is configured, guaranteeing a
+// byte-identical config load.
+func EnvOnly() *Registry {
+	return &Registry{defs: map[string]compiledDef{}, policy: Policy{}.withDefaults(), logger: slog.New(slog.NewTextHandler(discard{}, nil))}
+}
+
+// Expand replaces every ${VAR} in s using the resolution chain for the given
+// scope. rt may be nil (config scope). Resolution order per match:
+//  1. a runtime built-in producer (rt.Vars[name]) — always wins, non-overridable;
+//  2. an operator VarSpec whose scope matches `want`;
+//  3. the bare environment variable of the same name;
+//  4. otherwise the literal ${VAR} is left in place.
+//
+// A runtime built-in producer is memoized within a single Expand call so it
+// runs at most once even if the template references it multiple times.
+func (r *Registry) Expand(ctx context.Context, s string, want Scope, rt *RuntimeContext) string {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	memo := map[string]string{}
+	return VarPattern.ReplaceAllStringFunc(s, func(match string) string {
+		name := match[2 : len(match)-1] // strip ${ and }
+		if v, ok := memo[name]; ok {
+			return v
+		}
+		out := r.resolveOne(ctx, name, match, want, rt)
+		memo[name] = out
+		return out
+	})
+}
+
+func (r *Registry) resolveOne(ctx context.Context, name, raw string, want Scope, rt *RuntimeContext) string {
+	req := Request{Name: name, Raw: raw, Ctx: ctx, Runtime: rt}
+
+	// 1. Runtime built-ins win and are non-overridable — this preserves the
+	//    exact per-kick output of the legacy strings.NewReplacer.
+	if fn, ok := rt.lookup(name); ok {
+		return fn()
+	}
+
+	// 2. Operator-defined variable, if in scope.
+	if def, ok := r.defs[name]; ok && def.scope.matches(want) {
+		res, err := def.resolver.Resolve(req)
+		if err == nil {
+			return res.Value
+		}
+		if err != ErrUnresolved {
+			r.logger.Warn("variable resolver error, leaving literal", "var", name, "error", err)
+		}
+		return raw
+	}
+
+	// 3. Bare environment variable of the same name (legacy default).
+	res, err := bareEnvResolver{}.Resolve(req)
+	if err == nil {
+		return res.Value
+	}
+
+	// 4. Unresolved: leave the literal ${VAR}.
+	return raw
+}
+
+// discard is an io.Writer that drops everything (for the nil-logger case).
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) { return len(p), nil }

--- a/v2/pkg/resolve/resolve_test.go
+++ b/v2/pkg/resolve/resolve_test.go
@@ -1,0 +1,114 @@
+package resolve
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+// TestEnvOnly_LegacyParity verifies the env-only registry reproduces the exact
+// legacy config.expandEnvVars behavior: ${SET} -> value, ${UNSET} -> literal,
+// ${EMPTY} -> "" (set-but-empty resolves to empty, not literal).
+func TestEnvOnly_LegacyParity(t *testing.T) {
+	t.Setenv("HIVE_TEST_SET", "value1")
+	t.Setenv("HIVE_TEST_EMPTY", "")
+	os.Unsetenv("HIVE_TEST_UNSET")
+
+	reg := EnvOnly()
+	cases := []struct{ in, want string }{
+		{"${HIVE_TEST_SET}", "value1"},
+		{"${HIVE_TEST_UNSET}", "${HIVE_TEST_UNSET}"}, // literal passthrough
+		{"${HIVE_TEST_EMPTY}", ""},                   // set-but-empty -> empty
+		{"a ${HIVE_TEST_SET} b ${HIVE_TEST_UNSET} c", "a value1 b ${HIVE_TEST_UNSET} c"},
+		{"no vars here", "no vars here"},
+		{"${A}${HIVE_TEST_SET}", "${A}value1"},
+	}
+	for _, c := range cases {
+		got := reg.Expand(context.Background(), c.in, ScopeConfig, nil)
+		if got != c.want {
+			t.Errorf("Expand(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestStaticAndEnvDefaults covers operator-defined static vars and env vars with
+// defaults (the ${VAR:-x} equivalent hive never had).
+func TestStaticAndEnvDefaults(t *testing.T) {
+	os.Unsetenv("HIVE_TEST_REGION")
+	dflt := "us-east-1"
+	specs := []VarSpec{
+		{Name: "DEPLOY", Type: "static", Value: "production", Scope: ScopeBoth},
+		{Name: "REGION", Type: "env", Env: "HIVE_TEST_REGION", HasDefault: true, Default: dflt, Scope: ScopeConfig},
+	}
+	reg := Build(specs, Policy{}, nil)
+
+	if got := reg.Expand(context.Background(), "${DEPLOY}", ScopeConfig, nil); got != "production" {
+		t.Errorf("static config-scope: got %q", got)
+	}
+	if got := reg.Expand(context.Background(), "${DEPLOY}", ScopeTemplate, nil); got != "production" {
+		t.Errorf("static both-scope in template: got %q", got)
+	}
+	if got := reg.Expand(context.Background(), "${REGION}", ScopeConfig, nil); got != dflt {
+		t.Errorf("env default: got %q want %q", got, dflt)
+	}
+	// REGION is config-scoped only; in template scope it should fall through to
+	// bare-env (unset) -> literal.
+	if got := reg.Expand(context.Background(), "${REGION}", ScopeTemplate, nil); got != "${REGION}" {
+		t.Errorf("out-of-scope var should be literal: got %q", got)
+	}
+	// Env default kicks in only when unset; a set value wins.
+	t.Setenv("HIVE_TEST_REGION", "eu-west-1")
+	reg2 := Build(specs, Policy{}, nil)
+	if got := reg2.Expand(context.Background(), "${REGION}", ScopeConfig, nil); got != "eu-west-1" {
+		t.Errorf("set env should override default: got %q", got)
+	}
+}
+
+// TestRuntimeBuiltinsWin ensures a runtime built-in producer wins over an
+// operator def and over env, and is memoized (runs once).
+func TestRuntimeBuiltinsWin(t *testing.T) {
+	t.Setenv("AGENT_NAME", "from-env")
+	calls := 0
+	rt := &RuntimeContext{Vars: map[string]func() string{
+		"AGENT_NAME": func() string { calls++; return "scanner" },
+	}}
+	// Even with an operator def of the same name, the built-in wins.
+	specs := []VarSpec{{Name: "AGENT_NAME", Type: "static", Value: "override", Scope: ScopeBoth}}
+	reg := Build(specs, Policy{}, nil)
+
+	got := reg.Expand(context.Background(), "${AGENT_NAME}/${AGENT_NAME}", ScopeTemplate, rt)
+	if got != "scanner/scanner" {
+		t.Errorf("built-in should win: got %q", got)
+	}
+	if calls != 1 {
+		t.Errorf("producer should be memoized to 1 call, ran %d", calls)
+	}
+}
+
+// TestRegistrationSeam proves a new resolver type registered via
+// RegisterResolver resolves without touching Expand or the call sites.
+func TestRegistrationSeam(t *testing.T) {
+	RegisterResolver("test-upper", func(spec VarSpec, _ Policy) (Resolver, error) {
+		return resolverFunc(func(req Request) (Result, error) {
+			return Result{Value: "UP:" + spec.Value, Source: "test"}, nil
+		}), nil
+	})
+	reg := Build([]VarSpec{{Name: "X", Type: "test-upper", Value: "hi", Scope: ScopeConfig}}, Policy{}, nil)
+	if got := reg.Expand(context.Background(), "${X}", ScopeConfig, nil); got != "UP:hi" {
+		t.Errorf("custom resolver: got %q", got)
+	}
+}
+
+// TestUnknownTypeLeavesLiteral: a def with an unregistered type is skipped and
+// its ${VAR} left literal, never crashing the build.
+func TestUnknownTypeLeavesLiteral(t *testing.T) {
+	os.Unsetenv("NOPE")
+	reg := Build([]VarSpec{{Name: "NOPE", Type: "does-not-exist", Scope: ScopeConfig}}, Policy{}, nil)
+	if got := reg.Expand(context.Background(), "${NOPE}", ScopeConfig, nil); got != "${NOPE}" {
+		t.Errorf("unknown type should leave literal: got %q", got)
+	}
+}
+
+type resolverFunc func(Request) (Result, error)
+
+func (f resolverFunc) Resolve(r Request) (Result, error) { return f(r) }

--- a/v2/pkg/resolve/resolver.go
+++ b/v2/pkg/resolve/resolver.go
@@ -1,0 +1,73 @@
+// Package resolve provides a pluggable ${VAR} substitution engine shared by
+// hive's two substitution sites: config loading (config.expandEnvVars, over the
+// raw hive.yaml text) and per-kick prompt templating (scheduler/dashboard).
+//
+// Historically each site hardcoded its variables — config used a single
+// os.LookupEnv regex, and the scheduler used a fixed strings.NewReplacer of ~29
+// pairs. Neither could gain a new variable without a Go edit. This package makes
+// the set of resolvable variables extensible via config (a `variables:` block)
+// and via code (RegisterResolver), while preserving the exact legacy behavior
+// when nothing custom is configured — an unset or unknown ${VAR} is always left
+// verbatim, never blanked.
+package resolve
+
+import (
+	"context"
+	"errors"
+	"regexp"
+)
+
+// VarPattern matches ${NAME}. It is the same pattern config used for
+// expandEnvVars, exported so the config package can share the single source of
+// truth for what a substitutable reference looks like.
+var VarPattern = regexp.MustCompile(`\$\{([^}]+)\}`)
+
+// ErrUnresolved is returned by a Resolver when it does not handle the requested
+// variable, or handles it but has no value (e.g. an unset env var with no
+// default). It is a sentinel, NOT a failure: the registry falls through to the
+// next resolver, and if every resolver returns it the original ${VAR} text is
+// left in place. Resolvers return a real (non-ErrUnresolved) error only for a
+// genuine fault worth logging (e.g. a script that timed out); the registry
+// still leaves the literal in place but records the error.
+var ErrUnresolved = errors.New("resolve: unresolved")
+
+// Request is what a Resolver is asked to resolve.
+type Request struct {
+	// Name is the bare variable name inside the braces, e.g. "AGENT_NAME" for
+	// "${AGENT_NAME}".
+	Name string
+	// Raw is the full literal match, e.g. "${AGENT_NAME}". Returned unchanged
+	// when a variable is left unresolved.
+	Raw string
+	// Ctx carries timeout/cancellation for resolvers that do I/O (script, http).
+	Ctx context.Context
+	// Runtime is non-nil only at per-kick call sites (System B). It exposes the
+	// live built-in producers (issue lists, knowledge, etc.). It is nil during
+	// config load (System A), where no runtime context exists.
+	Runtime *RuntimeContext
+}
+
+// Result carries a resolved value plus a non-secret provenance tag.
+type Result struct {
+	// Value is the substituted text.
+	Value string
+	// Source is a non-secret provenance tag, e.g. "env:HIVE_REGION", "static",
+	// "builtin", "script:<hash>", "http:<host>". Safe to surface in the UI/logs;
+	// never contains the resolved value for secret-bearing resolvers.
+	Source string
+}
+
+// Resolver resolves a single variable reference. Implementations must return
+// ErrUnresolved (not a hard error, not an empty Result) for variables they do
+// not handle, so the registry can fall through and ultimately preserve the
+// literal ${VAR}.
+type Resolver interface {
+	Resolve(req Request) (Result, error)
+}
+
+// Factory builds a Resolver from an operator-declared VarSpec and the active
+// Policy. It is the registration seam: a new resolver type is one Factory
+// registered via RegisterResolver, with no changes to the call sites. A Factory
+// may return an error to refuse construction — e.g. a script/http factory when
+// the Policy has not enabled execution/network access.
+type Factory func(spec VarSpec, pol Policy) (Resolver, error)

--- a/v2/pkg/resolve/static.go
+++ b/v2/pkg/resolve/static.go
@@ -1,0 +1,19 @@
+package resolve
+
+func init() {
+	RegisterResolver("static", newStaticResolver)
+}
+
+// staticResolver resolves a variable to a fixed literal value declared in
+// config. Always available (no policy gate).
+type staticResolver struct {
+	value string
+}
+
+func newStaticResolver(spec VarSpec, _ Policy) (Resolver, error) {
+	return &staticResolver{value: spec.Value}, nil
+}
+
+func (r *staticResolver) Resolve(_ Request) (Result, error) {
+	return Result{Value: r.value, Source: "static"}, nil
+}


### PR DESCRIPTION
## Why

Hive's `${VAR}` substitution is closed: config `${VAR}` resolves only via `os.LookupEnv`, and per-kick template vars are a fixed `strings.NewReplacer` of ~29 pairs in `scheduler.go`. Adding any new substituted value requires a Go edit. This series makes substitution **extensible and adaptable to yet-unknown use cases** — operators define new `${VAR}`s (static / script / web-service / custom) via config, and developers add new resolver *types* with one registered factory.

This is **PR 1 of a series**, and it is a **no-behavior-change foundation**.

## What's in this PR

- **`v2/pkg/resolve/`** — `Resolver` interface, `Registry`, and a `RegisterResolver(type, Factory)` seam. A new resolver type is one file + one `init()` registration; the call sites never change.
- **Built-ins: `env` and `static`** (always on). `env` reproduces `os.LookupEnv` and adds an optional `default:` (the `${VAR:-x}` hive never had). `script`/`http` resolvers + their trust policy land in later PRs; the `Policy` type and seed-only invariant are already here.
- **Resolution chain** per `${VAR}`: runtime built-in (per-kick, memoized, non-overridable) → operator def in scope → bare env of same name → **leave literal**. `ErrUnresolved` is a fall-through sentinel, never a failure.
- **`variables:` config block** (`VariablesConfig`: security policy + `defs`). `config.expandEnvVars` bootstrap-parses just that block from the raw YAML and delegates to a config-scoped `Registry`.

## No behavior change

With no `variables:` block, the registry is env-only and config expansion is **byte-identical** to the legacy regex + `os.LookupEnv` + literal-passthrough — proven by `TestExpandEnvVars_ByteIdenticalToLegacy` against the retained pre-resolver implementation. The existing `dashboardOverlayBytes` secret-collapse tests still pass (env substitution is value-preserving).

## Security invariant (structural, from the start)

`LoadWithDashboardOverlay` merges only overlay **agents** — `cfg.Variables` (resolver defs + the exec/http trust policy) comes **only from the trusted seed**. The user-writable dashboard overlay's `Variables` block is not merged, so an overlay can never enable code/network resolvers. Documented in-code so later PRs preserve it.

## Tests

`pkg/resolve` + `pkg/config` pass under `-race`: legacy parity, static/env-default resolution, runtime-built-in-wins + memoization, the registration seam (custom resolver with no call-site edit), unknown-type-leaves-literal, and byte-identical config expansion.

## Follow-ups (this series)

- PR 2: route `scheduler.substituteTemplate` + `dashboard.substituteTemplateVars` through the engine (unifies the two, kills their drift).
- PR 3: `script`/exec resolver + `allow_exec` gate (argv-only, scrubbed env, timeout, seed-only).
- PR 4: `http` resolver + `allow_http` + SSRF guards.

Docs for the governor and this substitution system are a parallel PR to kubestellar/docs.