### PR TITLE
feat(resolve): route per-kick template substitution through the resolver engine

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"net/url"
 	"os"
 	"regexp"
@@ -1175,6 +1176,20 @@ func (v VariablesConfig) toResolveSpecs() ([]resolve.VarSpec, resolve.Policy) {
 		HTTPTimeoutS:  v.Security.HTTPTimeoutS,
 	}
 	return specs, pol
+}
+
+// ResolveRegistry builds a resolve.Registry from this config's `variables:`
+// block, for use at per-kick template substitution sites (scheduler, dashboard
+// preview). With no variables configured it returns an env-only registry whose
+// Expand — in template scope, where the runtime built-ins win and there is no
+// env fallback — reproduces the previous strings.NewReplacer output exactly.
+// Pass a logger to surface disabled/invalid resolver diagnostics; nil is fine.
+func (c *Config) ResolveRegistry(logger *slog.Logger) *resolve.Registry {
+	if len(c.Variables.Defs) == 0 {
+		return resolve.EnvOnly()
+	}
+	specs, pol := c.Variables.toResolveSpecs()
+	return resolve.Build(specs, pol, logger)
 }
 
 const (

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -21,6 +23,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/github"
 	"github.com/kubestellar/hive/v2/pkg/knowledge"
 	"github.com/kubestellar/hive/v2/pkg/policies"
+	"github.com/kubestellar/hive/v2/pkg/resolve"
 )
 
 func (s *Server) RegisterAPI(deps *Dependencies) {
@@ -32,6 +35,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/version", s.handleVersion)
 	s.mux.HandleFunc("GET /api/config", s.handleConfig)
 	s.mux.HandleFunc("GET /api/config/download", s.handleConfigDownload)
+	s.mux.HandleFunc("GET /api/config/variables", s.handleVariablesList)
 	s.mux.HandleFunc("GET /api/audit", s.handleAuditLog)
 	s.mux.HandleFunc("POST /api/self-upgrade", s.handleSelfUpgrade)
 	s.mux.HandleFunc("GET /api/snapshot", s.handleSnapshotAPI)
@@ -1785,6 +1789,66 @@ func (s *Server) loadPromptTemplate(name string) string {
 // substituteTemplateVars replaces ${VAR} placeholders in a prompt template
 // with values from the running config, so the dashboard shows resolved content
 // instead of raw variable names.
+// handleVariablesList returns the operator-defined ${VAR} substitutions from
+// the config `variables:` block, plus whether the exec/http resolver gates are
+// enabled. It is READ-ONLY and never returns any secret value — only the
+// variable name, type, scope, and (for env vars) the source env var NAME. This
+// is the admin-facing view of custom variables; script/http variables and the
+// security gates remain seed-only (GitOps/ConfigMap), so there is intentionally
+// no companion write endpoint for them.
+func (s *Server) handleVariablesList(w http.ResponseWriter, r *http.Request) {
+	if s.deps == nil || s.deps.Config == nil {
+		jsonResponse(w, map[string]any{"variables": []any{}, "exec_enabled": false, "http_enabled": false})
+		return
+	}
+	v := s.deps.Config.Variables
+	type varView struct {
+		Name  string `json:"name"`
+		Type  string `json:"type"`
+		Scope string `json:"scope"`
+		// Source is a non-secret provenance hint: for env, the source env var
+		// name; for static, "static"; for script, "script"; for http, the host.
+		Source string `json:"source"`
+	}
+	out := make([]varView, 0, len(v.Defs))
+	for name, def := range v.Defs {
+		typ := def.Type
+		if typ == "" {
+			if def.Value != "" {
+				typ = "static"
+			} else {
+				typ = "env"
+			}
+		}
+		scope := def.Scope
+		if scope == "" {
+			scope = "template"
+		}
+		source := typ
+		switch typ {
+		case "env":
+			if def.Env != "" {
+				source = "env:" + def.Env
+			} else {
+				source = "env:" + name
+			}
+		case "http":
+			if u, err := url.Parse(def.URL); err == nil && u.Host != "" {
+				source = "http:" + u.Host
+			} else {
+				source = "http"
+			}
+		}
+		out = append(out, varView{Name: name, Type: typ, Scope: scope, Source: source})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	jsonResponse(w, map[string]any{
+		"variables":    out,
+		"exec_enabled": v.Security.AllowExec,
+		"http_enabled": v.Security.AllowHTTP,
+	})
+}
+
 func (s *Server) substituteTemplateVars(template, agentName string) string {
 	if s.deps == nil || s.deps.Config == nil {
 		return template
@@ -1806,18 +1870,25 @@ func (s *Server) substituteTemplateVars(template, agentName string) string {
 		displayName = ac.DisplayName
 	}
 
-	replacer := strings.NewReplacer(
-		"${AGENT_NAME}", agentName,
-		"${AGENT_DISPLAY_NAME}", displayName,
-		"${PROJECT_NAME}", cfg.Project.Name,
-		"${PROJECT_ORG}", org,
-		"${PROJECT_PRIMARY_REPO}", fullPrimaryRepo,
-		"${PROJECT_AI_AUTHOR}", cfg.Project.AIAuthor,
-		"${PROJECT_REPOS_LIST}", reposList,
-		"${HIVE_REPO}", fmt.Sprintf("%s/hive", org),
-		"${HIVE_ID}", cfg.HiveID,
-	)
-	return replacer.Replace(template)
+	// The dashboard preview substitutes the config-only subset of kick-template
+	// variables (it has no live GitHub context). Route it through the same
+	// resolve engine as the scheduler so operator-defined ${VAR}s (from the
+	// config `variables:` block) render in previews too, and the two paths can
+	// no longer drift. Built-ins win; with no operator variables the output
+	// matches the previous strings.NewReplacer exactly.
+	lit := func(v string) func() string { return func() string { return v } }
+	rt := &resolve.RuntimeContext{Vars: map[string]func() string{
+		"AGENT_NAME":           lit(agentName),
+		"AGENT_DISPLAY_NAME":   lit(displayName),
+		"PROJECT_NAME":         lit(cfg.Project.Name),
+		"PROJECT_ORG":          lit(org),
+		"PROJECT_PRIMARY_REPO": lit(fullPrimaryRepo),
+		"PROJECT_AI_AUTHOR":    lit(cfg.Project.AIAuthor),
+		"PROJECT_REPOS_LIST":   lit(reposList),
+		"HIVE_REPO":            lit(fmt.Sprintf("%s/hive", org)),
+		"HIVE_ID":              lit(cfg.HiveID),
+	}}
+	return cfg.ResolveRegistry(s.deps.Logger).Expand(context.Background(), template, resolve.ScopeTemplate, rt)
 }
 
 func (s *Server) loadAgentStats(name string) []any {

--- a/v2/pkg/resolve/registry.go
+++ b/v2/pkg/resolve/registry.go
@@ -135,10 +135,17 @@ func (r *Registry) resolveOne(ctx context.Context, name, raw string, want Scope,
 		return raw
 	}
 
-	// 3. Bare environment variable of the same name (legacy default).
-	res, err := bareEnvResolver{}.Resolve(req)
-	if err == nil {
-		return res.Value
+	// 3. Bare environment variable of the same name — but only in config scope.
+	//    Config-load substitution (System A) has always fallen back to
+	//    os.LookupEnv for any ${NAME}; per-kick templating (System B) has not
+	//    (its legacy strings.NewReplacer left unknown ${VAR} literal, never
+	//    consulting the environment). Restricting the fallback to config scope
+	//    keeps both systems byte-identical to their legacy behavior.
+	if want == ScopeConfig {
+		res, err := bareEnvResolver{}.Resolve(req)
+		if err == nil {
+			return res.Value
+		}
 	}
 
 	// 4. Unresolved: leave the literal ${VAR}.

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/github"
 	"github.com/kubestellar/hive/v2/pkg/knowledge"
 	"github.com/kubestellar/hive/v2/pkg/policies"
+	"github.com/kubestellar/hive/v2/pkg/resolve"
 )
 
 type Scheduler struct {
@@ -24,6 +25,14 @@ type Scheduler struct {
 	lastActionable *github.ActionableResult
 	logger         *slog.Logger
 	mu             sync.RWMutex
+}
+
+// registry builds the variable-resolution registry from the current config's
+// `variables:` block. It is rebuilt per call (cheap: env/static factories only),
+// so a live config reload that changes variable definitions is picked up on the
+// next kick without extra wiring.
+func (s *Scheduler) registry() *resolve.Registry {
+	return s.cfg.ResolveRegistry(s.logger)
 }
 
 func New(cfg *config.Config, logger *slog.Logger) *Scheduler {
@@ -163,40 +172,49 @@ func (s *Scheduler) substituteTemplate(template string, actionable *github.Actio
 	mergeEligibleList := s.buildMergeEligibleList()
 	ciFailingList := s.buildCIFailingList()
 
-	replacer := strings.NewReplacer(
-		"${AGENT_NAME}", agentName,
-		"${AGENT_DISPLAY_NAME}", displayName,
-		"${TIMESTAMP}", now.Format("1/2 3:04 PM MST"),
-		"${QUEUE_ISSUES}", fmt.Sprintf("%d", actionable.Issues.Count),
-		"${QUEUE_PRS}", fmt.Sprintf("%d", actionable.PRs.Count),
-		"${QUEUE_HOLD}", fmt.Sprintf("%d", actionable.Hold.Total),
-		"${SLA_VIOLATIONS}", fmt.Sprintf("%d", actionable.Issues.SLAViolations),
-		"${ISSUE_LIST}", issueList,
-		"${PR_LIST}", prList,
-		"${AUTHORIZED_REPOS}", s.buildReposSection(),
-		"${GH_AUTH}", s.ghAuthInstructions(agentName),
-		"${PROJECT_ORG}", s.cfg.Project.Org,
-		"${PROJECT_NAME}", s.cfg.Project.Name,
-		"${PROJECT_PRIMARY_REPO}", fullPrimaryRepo,
-		"${PROJECT_AI_AUTHOR}", s.cfg.Project.AIAuthor,
-		"${PROJECT_REPOS_LIST}", reposList,
-		"${PROJECT_HOMEBREW_REPO}", fmt.Sprintf("%s/homebrew-tap", s.cfg.Project.Org),
-		"${HIVE_REPO}", fmt.Sprintf("%s/hive", s.cfg.Project.Org),
-		"${HIVE_ID}", s.cfg.HiveID,
-		"${AGENT_LIST}", agentList,
-		"${AGENT_ROLES}", agentRoles,
-		"${ENABLED_AGENTS}", agentList,
-		"${KNOWLEDGE}", knowledgeSection,
-		"${INCEPTION_IDEA}", inceptionIdea,
-		"${INCEPTION_PHASE}", inceptionPhase,
-		"${INCEPTION_MODE}", inceptionMode,
-		"${INCEPTION_ANSWERS}", inceptionAnswers,
-		"${INCEPTION_SLUG}", inceptionSlug,
-		"${INCEPTION_REPO_URL}", inceptionRepoURL,
-		"${MERGE_ELIGIBLE}", mergeEligibleList,
-		"${CI_FAILING}", ciFailingList,
-	)
-	return replacer.Replace(template)
+	// The built-in per-kick variables. Each value is already computed above, so
+	// the thunks just return it — but wrapping them as resolve.RuntimeContext
+	// producers routes this through the same pluggable engine as config
+	// substitution, letting operators add their own ${VAR}s (via the config
+	// `variables:` block) while these built-ins always win. With no operator
+	// variables configured, Expand reproduces the previous strings.NewReplacer
+	// output exactly (unknown ${VAR} left literal; no env fallback in template
+	// scope).
+	lit := func(v string) func() string { return func() string { return v } }
+	rt := &resolve.RuntimeContext{Vars: map[string]func() string{
+		"AGENT_NAME":            lit(agentName),
+		"AGENT_DISPLAY_NAME":    lit(displayName),
+		"TIMESTAMP":             lit(now.Format("1/2 3:04 PM MST")),
+		"QUEUE_ISSUES":          lit(fmt.Sprintf("%d", actionable.Issues.Count)),
+		"QUEUE_PRS":             lit(fmt.Sprintf("%d", actionable.PRs.Count)),
+		"QUEUE_HOLD":            lit(fmt.Sprintf("%d", actionable.Hold.Total)),
+		"SLA_VIOLATIONS":        lit(fmt.Sprintf("%d", actionable.Issues.SLAViolations)),
+		"ISSUE_LIST":            lit(issueList),
+		"PR_LIST":               lit(prList),
+		"AUTHORIZED_REPOS":      lit(s.buildReposSection()),
+		"GH_AUTH":               lit(s.ghAuthInstructions(agentName)),
+		"PROJECT_ORG":           lit(s.cfg.Project.Org),
+		"PROJECT_NAME":          lit(s.cfg.Project.Name),
+		"PROJECT_PRIMARY_REPO":  lit(fullPrimaryRepo),
+		"PROJECT_AI_AUTHOR":     lit(s.cfg.Project.AIAuthor),
+		"PROJECT_REPOS_LIST":    lit(reposList),
+		"PROJECT_HOMEBREW_REPO": lit(fmt.Sprintf("%s/homebrew-tap", s.cfg.Project.Org)),
+		"HIVE_REPO":             lit(fmt.Sprintf("%s/hive", s.cfg.Project.Org)),
+		"HIVE_ID":               lit(s.cfg.HiveID),
+		"AGENT_LIST":            lit(agentList),
+		"AGENT_ROLES":           lit(agentRoles),
+		"ENABLED_AGENTS":        lit(agentList),
+		"KNOWLEDGE":             lit(knowledgeSection),
+		"INCEPTION_IDEA":        lit(inceptionIdea),
+		"INCEPTION_PHASE":       lit(inceptionPhase),
+		"INCEPTION_MODE":        lit(inceptionMode),
+		"INCEPTION_ANSWERS":     lit(inceptionAnswers),
+		"INCEPTION_SLUG":        lit(inceptionSlug),
+		"INCEPTION_REPO_URL":    lit(inceptionRepoURL),
+		"MERGE_ELIGIBLE":        lit(mergeEligibleList),
+		"CI_FAILING":            lit(ciFailingList),
+	}}
+	return s.registry().Expand(context.Background(), template, resolve.ScopeTemplate, rt)
 }
 
 func (s *Scheduler) formatIssueList(issues []github.Issue) string {

--- a/v2/pkg/scheduler/template_resolver_test.go
+++ b/v2/pkg/scheduler/template_resolver_test.go
@@ -1,0 +1,69 @@
+package scheduler
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// TestSubstituteTemplate_BuiltinsAndOperatorVars verifies the resolver-backed
+// substituteTemplate: built-in ${VAR}s still render; an operator-defined
+// template variable renders; a built-in wins over a same-named operator def;
+// and an unknown ${VAR} is left literal (no env fallback in template scope).
+func TestSubstituteTemplate_BuiltinsAndOperatorVars(t *testing.T) {
+	// An env var whose name matches an unknown template ${VAR}: it must NOT be
+	// substituted in template scope (only config scope falls back to env).
+	t.Setenv("UNKNOWN_TEMPLATE_VAR", "leaked-from-env")
+
+	dflt := "prod"
+	cfg := &config.Config{
+		Project: config.ProjectConfig{Org: "acme", Name: "widgets", Repos: []string{"widgets"}},
+		Agents:  map[string]config.AgentConfig{"scanner": {Role: "scanner"}},
+		Variables: config.VariablesConfig{
+			Defs: map[string]config.VarDef{
+				// Custom template variable.
+				"DEPLOY_ENV": {Type: "static", Value: dflt, Scope: "template"},
+				// Same name as a built-in — the built-in must win.
+				"PROJECT_ORG": {Type: "static", Value: "SHOULD-NOT-WIN", Scope: "both"},
+			},
+		},
+	}
+	s := New(cfg, slog.Default())
+
+	tmpl := "org=${PROJECT_ORG} deploy=${DEPLOY_ENV} agent=${AGENT_NAME} miss=${UNKNOWN_TEMPLATE_VAR}"
+	out := s.substituteTemplate(tmpl, nil, "scanner", nil)
+
+	if !contains(out, "org=acme") {
+		t.Errorf("built-in PROJECT_ORG should win over operator def: %q", out)
+	}
+	if !contains(out, "deploy=prod") {
+		t.Errorf("operator template var not substituted: %q", out)
+	}
+	if !contains(out, "agent=scanner") {
+		t.Errorf("built-in AGENT_NAME not substituted: %q", out)
+	}
+	if !contains(out, "miss=${UNKNOWN_TEMPLATE_VAR}") {
+		t.Errorf("unknown template var must stay literal (no env fallback): %q", out)
+	}
+	if contains(out, "leaked-from-env") {
+		t.Errorf("template scope must NOT fall back to env: %q", out)
+	}
+}
+
+// TestSubstituteTemplate_NoVariablesBlock is the byte-identical guard: with no
+// `variables:` block, output matches building the same string by hand from the
+// built-ins (an unknown var stays literal, exactly like the old replacer).
+func TestSubstituteTemplate_NoVariablesBlock(t *testing.T) {
+	os.Unsetenv("PROJECT_NAME") // ensure no accidental env influence
+	cfg := &config.Config{
+		Project: config.ProjectConfig{Org: "acme", Name: "widgets", Repos: []string{"widgets"}},
+		Agents:  map[string]config.AgentConfig{"scanner": {Role: "scanner"}},
+	}
+	s := New(cfg, slog.Default())
+	out := s.substituteTemplate("a=${PROJECT_ORG} b=${NOPE}", nil, "scanner", nil)
+	if out != "a=acme b=${NOPE}" {
+		t.Errorf("unexpected: %q", out)
+	}
+}


### PR DESCRIPTION
## Why

**PR 2 of the pluggable-resolver series** (follows #1898). Converts hive's two per-kick `${VAR}` substitution sites to the `pkg/resolve` engine, so operator-defined variables work inside kick templates and the two sites stop drifting.

- `scheduler.substituteTemplate` — the ~29 built-in kick variables.
- `dashboard.substituteTemplateVars` — the 9-variable preview subset (previously a separate, drift-prone replacer).

## What changes for users

- Custom `${VAR}`s from the config `variables:` block now render **in kick prompts** and **in the dashboard template preview**.
- New read-only **`GET /api/config/variables`** — lists the defined variables (name, type, scope, non-secret source) and whether the exec/http gates are on. This is the admin-facing view; `script`/`http` variables and the security gates stay **seed-only** (GitOps/ConfigMap), so there is intentionally no write endpoint for them.

## No behavior change when unconfigured

- The built-ins are supplied as `resolve.RuntimeContext` producers and **always win** (non-overridable) → built-in output is byte-identical.
- **Template scope does not fall back to `os.LookupEnv`** for unknown `${VAR}` — the legacy replacer left unknown vars literal and never touched the environment. The env fallback in `resolve.Registry` is now restricted to *config* scope, keeping both systems byte-identical. Regression-tested: an env var matching an unknown template `${VAR}` is not leaked into the prompt.

## Tests

Existing scheduler + dashboard template tests still pass (byte-identical), plus new tests: operator-defined template var renders, built-in wins over a same-named operator def, unknown var stays literal, no env fallback. All under `-race`.

## Next

- PR 3: `script`/exec resolver + `allow_exec` gate + seed-only enforcement in `LoadWithDashboardOverlay`.
- PR 4: `http` resolver + `allow_http` + SSRF guards.