### PR TITLE
feat(resolve): script/exec resolver, gated by allow_exec and seed-only

### DIFF
--- a/v2/pkg/config/variables_seed_only_test.go
+++ b/v2/pkg/config/variables_seed_only_test.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestVariables_OverlayCannotEnableExec proves the seed-only security invariant:
+// a dashboard overlay (user-writable) that declares variables.security.allow_exec
+// and a script variable must NOT take effect after LoadWithDashboardOverlay —
+// only the trusted seed's variables block is honored. Otherwise a compromised
+// overlay would be a remote-code-execution path.
+func TestVariables_OverlayCannotEnableExec(t *testing.T) {
+	dir := t.TempDir()
+	seedPath := filepath.Join(dir, "hive.yaml")
+
+	// Seed: no variables block at all (exec disabled by default).
+	seed := `
+project:
+  org: testorg
+  repos: [repo1]
+github:
+  token: ghp_x
+agents:
+  scanner:
+    backend: copilot
+`
+	if err := os.WriteFile(seedPath, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Overlay: tries to enable exec and define a script variable.
+	overlayPath := filepath.Join(dir, "hive.yaml.dashboard")
+	overlay := `
+project:
+  org: testorg
+  repos: [repo1]
+github:
+  token: ghp_x
+agents:
+  scanner:
+    backend: copilot
+variables:
+  security:
+    allow_exec: true
+  defs:
+    PWNED:
+      type: script
+      command: [echo, pwned]
+      scope: both
+`
+	if err := os.WriteFile(overlayPath, []byte(overlay), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origOverlay := DashboardOverlayFile
+	DashboardOverlayFile = overlayPath
+	t.Cleanup(func() { DashboardOverlayFile = origOverlay })
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+
+	cfg, err := LoadWithDashboardOverlay(seedPath)
+	if err != nil {
+		t.Fatalf("LoadWithDashboardOverlay: %v", err)
+	}
+
+	// The overlay's variables block must be ignored: exec stays disabled and the
+	// PWNED def must not exist.
+	if cfg.Variables.Security.AllowExec {
+		t.Error("overlay must NOT be able to enable allow_exec (seed-only)")
+	}
+	if _, ok := cfg.Variables.Defs["PWNED"]; ok {
+		t.Error("overlay must NOT be able to add a script variable")
+	}
+
+	// And a template built from this config must leave ${PWNED} literal (the
+	// resolver was never enabled or defined).
+	reg := cfg.ResolveRegistry(nil)
+	if out := reg.Expand(nil, "x=${PWNED}", "template", nil); out != "x=${PWNED}" {
+		t.Errorf("overlay script var must not resolve, got %q", out)
+	}
+}
+
+// TestVariables_SeedExecEnables confirms the positive path: the SEED enabling
+// exec + defining a script var does take effect.
+func TestVariables_SeedExecEnables(t *testing.T) {
+	dir := t.TempDir()
+	seedPath := filepath.Join(dir, "hive.yaml")
+	seed := `
+project:
+  org: testorg
+  repos: [repo1]
+github:
+  token: ghp_x
+agents:
+  scanner:
+    backend: copilot
+variables:
+  security:
+    allow_exec: true
+    exec_timeout_s: 5
+  defs:
+    GREET:
+      type: script
+      command: [echo, hi-from-seed]
+      scope: template
+`
+	if err := os.WriteFile(seedPath, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(seedPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.Variables.Security.AllowExec {
+		t.Fatal("seed should enable allow_exec")
+	}
+	reg := cfg.ResolveRegistry(nil)
+	if out := reg.Expand(nil, "${GREET}", "template", nil); out != "hi-from-seed" {
+		t.Errorf("seed script var should resolve, got %q", out)
+	}
+}

--- a/v2/pkg/resolve/exec.go
+++ b/v2/pkg/resolve/exec.go
@@ -1,0 +1,95 @@
+package resolve
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func init() {
+	RegisterResolver("script", newScriptResolver)
+}
+
+// scriptResolver resolves a variable to the trimmed stdout of a command.
+//
+// Security model:
+//   - Gated: the factory refuses to build unless Policy.AllowExec is true. Since
+//     the policy is honored only from the trusted config seed (the config
+//     package discards the dashboard overlay's security block), a user-editable
+//     overlay can never enable script execution.
+//   - No shell: the command is an argv slice run directly via exec.CommandContext,
+//     never `sh -c` on a string, so there is no shell-injection surface.
+//   - Bounded: each run has a context timeout (Policy.ExecTimeoutS). A timeout or
+//     non-zero exit yields ErrUnresolved (the ${VAR} is left literal), never a
+//     crash and never a partial/garbage value.
+//   - Scrubbed environment: the child inherits only a minimal PATH-style env, not
+//     the hive process environment, so secrets in hive's env are not exposed to
+//     arbitrary configured scripts.
+type scriptResolver struct {
+	command []string
+	timeout time.Duration
+	dflt    string
+	hasDflt bool
+	tag     string // non-secret provenance: "script:<sha8-of-argv>"
+}
+
+func newScriptResolver(spec VarSpec, pol Policy) (Resolver, error) {
+	if !pol.AllowExec {
+		return nil, errors.New("script resolvers are disabled (set variables.security.allow_exec in the seed config to enable)")
+	}
+	if len(spec.Command) == 0 {
+		return nil, fmt.Errorf("script variable %q has no command", spec.Name)
+	}
+	sum := sha256.Sum256([]byte(strings.Join(spec.Command, "\x00")))
+	return &scriptResolver{
+		command: spec.Command,
+		timeout: time.Duration(pol.ExecTimeoutS) * time.Second,
+		dflt:    spec.Default,
+		hasDflt: spec.HasDefault,
+		tag:     "script:" + hex.EncodeToString(sum[:])[:8],
+	}, nil
+}
+
+// scrubbedEnv is the minimal environment a script resolver runs with. It
+// deliberately excludes hive's process environment (which holds tokens/keys).
+var scrubbedEnv = []string{
+	"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+}
+
+func (r *scriptResolver) Resolve(req Request) (Result, error) {
+	ctx := req.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if r.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, r.timeout)
+		defer cancel()
+	}
+
+	// #nosec G204 — command is an operator-declared argv slice from the trusted
+	// seed config (gated by AllowExec), executed without a shell. Not derived
+	// from untrusted input.
+	cmd := exec.CommandContext(ctx, r.command[0], r.command[1:]...)
+	cmd.Env = scrubbedEnv
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	// stderr is intentionally discarded from the value (never injected into the
+	// prompt); it is left unset so it goes nowhere.
+
+	if err := cmd.Run(); err != nil {
+		// Timeout or non-zero exit: fall back to a default if provided, else
+		// leave the variable unresolved (literal). Never surface partial output.
+		if r.hasDflt {
+			return Result{Value: r.dflt, Source: "default"}, nil
+		}
+		return Result{}, ErrUnresolved
+	}
+	return Result{Value: strings.TrimRight(stdout.String(), "\n"), Source: r.tag}, nil
+}

--- a/v2/pkg/resolve/exec_test.go
+++ b/v2/pkg/resolve/exec_test.go
@@ -1,0 +1,98 @@
+package resolve
+
+import (
+	"context"
+	"runtime"
+	"testing"
+)
+
+func skipIfWindows(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX shell utilities not available on Windows")
+	}
+}
+
+// TestScriptResolver_Gated: the factory refuses to build when AllowExec is false,
+// so a script def with exec disabled resolves to its literal ${VAR}.
+func TestScriptResolver_Gated(t *testing.T) {
+	specs := []VarSpec{{Name: "SHA", Type: "script", Command: []string{"echo", "hi"}, Scope: ScopeConfig}}
+	reg := Build(specs, Policy{AllowExec: false}, nil)
+	// Config scope so bare-env fallback could apply — but SHA isn't an env var,
+	// so it must remain literal.
+	if got := reg.Expand(context.Background(), "${SHA}", ScopeConfig, nil); got != "${SHA}" {
+		t.Errorf("disabled script should leave literal, got %q", got)
+	}
+}
+
+// TestScriptResolver_RunsAndTrims: with AllowExec, stdout is captured and
+// trailing newline trimmed.
+func TestScriptResolver_RunsAndTrims(t *testing.T) {
+	skipIfWindows(t)
+	specs := []VarSpec{{Name: "GREET", Type: "script", Command: []string{"echo", "hello world"}, Scope: ScopeTemplate}}
+	reg := Build(specs, Policy{AllowExec: true, ExecTimeoutS: 5}, nil)
+	got := reg.Expand(context.Background(), "[${GREET}]", ScopeTemplate, nil)
+	if got != "[hello world]" {
+		t.Errorf("got %q want [hello world]", got)
+	}
+}
+
+// TestScriptResolver_NonZeroExitLeavesLiteral: a failing command yields
+// ErrUnresolved (literal), not a crash or partial value.
+func TestScriptResolver_NonZeroExitLeavesLiteral(t *testing.T) {
+	skipIfWindows(t)
+	specs := []VarSpec{{Name: "FAIL", Type: "script", Command: []string{"false"}, Scope: ScopeTemplate}}
+	reg := Build(specs, Policy{AllowExec: true, ExecTimeoutS: 5}, nil)
+	if got := reg.Expand(context.Background(), "x=${FAIL}", ScopeTemplate, nil); got != "x=${FAIL}" {
+		t.Errorf("non-zero exit should leave literal, got %q", got)
+	}
+}
+
+// TestScriptResolver_NonZeroExitUsesDefault: a failing command with a default
+// resolves to the default.
+func TestScriptResolver_NonZeroExitUsesDefault(t *testing.T) {
+	skipIfWindows(t)
+	d := "fallback"
+	specs := []VarSpec{{Name: "FAIL", Type: "script", Command: []string{"false"}, HasDefault: true, Default: d, Scope: ScopeTemplate}}
+	reg := Build(specs, Policy{AllowExec: true, ExecTimeoutS: 5}, nil)
+	if got := reg.Expand(context.Background(), "x=${FAIL}", ScopeTemplate, nil); got != "x=fallback" {
+		t.Errorf("failing script with default: got %q", got)
+	}
+}
+
+// TestScriptResolver_Timeout: a command that runs longer than the timeout is
+// killed and the variable left literal.
+func TestScriptResolver_Timeout(t *testing.T) {
+	skipIfWindows(t)
+	specs := []VarSpec{{Name: "SLOW", Type: "script", Command: []string{"sleep", "5"}, Scope: ScopeTemplate}}
+	reg := Build(specs, Policy{AllowExec: true, ExecTimeoutS: 1}, nil)
+	if got := reg.Expand(context.Background(), "${SLOW}", ScopeTemplate, nil); got != "${SLOW}" {
+		t.Errorf("timed-out script should leave literal, got %q", got)
+	}
+}
+
+// TestScriptResolver_NoShellInjection: argv is executed directly, so shell
+// metacharacters are passed as literal arguments, not interpreted.
+func TestScriptResolver_NoShellInjection(t *testing.T) {
+	skipIfWindows(t)
+	// If this went through a shell, "; echo pwned" would run a second command.
+	// As argv, echo prints the whole string literally.
+	specs := []VarSpec{{Name: "INJ", Type: "script", Command: []string{"echo", "safe; echo pwned"}, Scope: ScopeTemplate}}
+	reg := Build(specs, Policy{AllowExec: true, ExecTimeoutS: 5}, nil)
+	got := reg.Expand(context.Background(), "${INJ}", ScopeTemplate, nil)
+	if got != "safe; echo pwned" {
+		t.Errorf("argv must not be shell-interpreted, got %q", got)
+	}
+}
+
+// TestScriptResolver_ScrubbedEnv: the child does not inherit hive's process
+// environment, so a secret in the parent env is not visible to the script.
+func TestScriptResolver_ScrubbedEnv(t *testing.T) {
+	skipIfWindows(t)
+	t.Setenv("HIVE_SECRET_XYZ", "topsecret")
+	specs := []VarSpec{{Name: "LEAK", Type: "script", Command: []string{"printenv", "HIVE_SECRET_XYZ"}, Scope: ScopeTemplate}}
+	reg := Build(specs, Policy{AllowExec: true, ExecTimeoutS: 5}, nil)
+	// printenv exits non-zero when the var is absent -> ErrUnresolved -> literal.
+	if got := reg.Expand(context.Background(), "${LEAK}", ScopeTemplate, nil); got != "${LEAK}" {
+		t.Errorf("scrubbed env should hide the secret (expected literal), got %q", got)
+	}
+}


### PR DESCRIPTION
## Why

**PR 3 of the pluggable-resolver series** (follows #1898, #1899). Adds the `script` resolver: a `${VAR}` backed by the trimmed stdout of a command, e.g.

```yaml
variables:
  security:
    allow_exec: true          # required; disabled by default; SEED-ONLY
    exec_timeout_s: 3
  defs:
    BUILD_SHA:
      type: script
      command: [git, rev-parse, --short, HEAD]   # argv, not a shell string
      scope: template
```

## Security model (this is the first resolver that executes code)

- **Gated + seed-only.** The factory refuses to build unless `variables.security.allow_exec` is true, and that flag is honored **only from the trusted config seed** — the loader never merges the dashboard overlay's `variables` block. So a user-writable overlay can never enable execution. Proven: `TestVariables_OverlayCannotEnableExec` (overlay setting `allow_exec: true` + a script def has no effect) vs `TestVariables_SeedExecEnables`.
- **No shell.** argv slice via `exec.CommandContext`, never `sh -c` — no shell-injection surface (`TestScriptResolver_NoShellInjection`).
- **Bounded.** context timeout (`exec_timeout_s`, default 5s); timeout or non-zero exit → `ErrUnresolved` (leave literal), or a configured `default` — never a crash or partial value.
- **Scrubbed env.** child inherits only a minimal `PATH`, not hive's process env, so tokens/keys aren't exposed to configured scripts (`TestScriptResolver_ScrubbedEnv`).
- **Non-secret provenance:** `Source` is `script:<sha8-of-argv>`, never the value.

## Tests

Gate enforcement, run-and-trim, non-zero-exit → literal/default, timeout, no-shell-injection, scrubbed-env, and the config-level seed-only enforcement — all under `-race`.

## Next

- PR 4: `http` resolver + `allow_http` + SSRF guards, then flip the docs `script`/`http` sections from preview to GA.