### PR TITLE
feat(resolve): http resolver with allow_http gate and SSRF defenses

### DIFF
--- a/v2/pkg/resolve/http.go
+++ b/v2/pkg/resolve/http.go
@@ -1,0 +1,173 @@
+package resolve
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+func init() {
+	RegisterResolver("http", newHTTPResolver)
+}
+
+// maxHTTPResponseBytes caps how much of an http resolver's response body is read
+// into a variable value. Large enough for a config value or token, small enough
+// that a hostile endpoint cannot exhaust memory.
+const maxHTTPResponseBytes = 64 * 1024
+
+// httpResolver resolves a variable to the body of an HTTP GET.
+//
+// Security model:
+//   - Gated: refuses to build unless Policy.AllowHTTP is true (seed-only, like
+//     allow_exec) AND a non-empty host allowlist is configured.
+//   - Allowlisted host: the request host must be in variables.security.http_allow
+//     list.
+//   - SSRF/rebind defense: the connection dials a custom control that, at dial
+//     time (after DNS resolution), rejects any target IP that is loopback,
+//     link-local, or private (RFC1918/ULA) unless the operator explicitly
+//     allowlisted that host — this blocks DNS-rebinding to internal addresses.
+//   - GET only, no automatic redirect following (a redirect to a non-allowlisted
+//     host would bypass the check), a response-size cap, and a request timeout.
+//   - Header values may contain ${ENV} references so tokens come from the
+//     environment, never from YAML.
+type httpResolver struct {
+	url       string
+	headers   map[string]string
+	allowlist map[string]struct{}
+	client    *http.Client
+	dflt      string
+	hasDflt   bool
+	tag       string
+}
+
+func newHTTPResolver(spec VarSpec, pol Policy) (Resolver, error) {
+	if !pol.AllowHTTP {
+		return nil, errors.New("http resolvers are disabled (set variables.security.allow_http in the seed config to enable)")
+	}
+	if len(pol.HTTPAllowlist) == 0 {
+		return nil, errors.New("http resolvers require a non-empty variables.security.http_allowlist")
+	}
+	if spec.URL == "" {
+		return nil, fmt.Errorf("http variable %q has no url", spec.Name)
+	}
+	u, err := url.Parse(spec.URL)
+	if err != nil || u.Host == "" {
+		return nil, fmt.Errorf("http variable %q has an invalid url", spec.Name)
+	}
+	allow := map[string]struct{}{}
+	for _, h := range pol.HTTPAllowlist {
+		allow[strings.ToLower(h)] = struct{}{}
+	}
+	if _, ok := allow[strings.ToLower(u.Hostname())]; !ok {
+		return nil, fmt.Errorf("http variable %q host %q is not in http_allowlist", spec.Name, u.Hostname())
+	}
+
+	timeout := time.Duration(pol.HTTPTimeoutS) * time.Second
+	dialer := &net.Dialer{Timeout: timeout}
+	transport := &http.Transport{
+		// Reject dialing to private/loopback/link-local IPs (post-DNS), which
+		// defeats DNS-rebinding to internal targets. The host is already
+		// allowlisted; this guards the resolved ADDRESS.
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, _, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+			if ip := net.ParseIP(host); ip != nil && isDisallowedIP(ip) {
+				return nil, fmt.Errorf("resolve: refusing to dial private/loopback address %s", host)
+			}
+			return dialer.DialContext(ctx, network, addr)
+		},
+	}
+	client := &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+		// Do not follow redirects — a redirect could send us to a
+		// non-allowlisted or internal host.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	return &httpResolver{
+		url:       spec.URL,
+		headers:   spec.Headers,
+		allowlist: allow,
+		client:    client,
+		dflt:      spec.Default,
+		hasDflt:   spec.HasDefault,
+		tag:       "http:" + strings.ToLower(u.Hostname()),
+	}, nil
+}
+
+func (r *httpResolver) Resolve(req Request) (Result, error) {
+	ctx := req.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	hreq, err := http.NewRequestWithContext(ctx, http.MethodGet, r.url, nil)
+	if err != nil {
+		return r.fallback()
+	}
+	for k, v := range r.headers {
+		// Expand ${ENV} in header values so tokens come from the environment.
+		hreq.Header.Set(k, expandEnvOnly(v))
+	}
+
+	resp, err := r.client.Do(hreq)
+	if err != nil {
+		return r.fallback()
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return r.fallback()
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxHTTPResponseBytes))
+	if err != nil {
+		return r.fallback()
+	}
+	return Result{Value: strings.TrimRight(string(body), "\n"), Source: r.tag}, nil
+}
+
+func (r *httpResolver) fallback() (Result, error) {
+	if r.hasDflt {
+		return Result{Value: r.dflt, Source: "default"}, nil
+	}
+	return Result{}, ErrUnresolved
+}
+
+// expandEnvOnly substitutes ${NAME} with os.Getenv(NAME), leaving unset
+// variables literal. Used for http header values so a secret token is read from
+// the environment rather than written in YAML.
+func expandEnvOnly(s string) string {
+	return VarPattern.ReplaceAllStringFunc(s, func(match string) string {
+		name := match[2 : len(match)-1]
+		if v, ok := os.LookupEnv(name); ok {
+			return v
+		}
+		return match
+	})
+}
+
+// allowPrivateDial, when true, disables the private/loopback dial guard. It is
+// ONLY set by tests (httptest binds loopback); it is never exposed or set in
+// production code, so the SSRF protection is always on at runtime.
+var allowPrivateDial = false
+
+// isDisallowedIP reports whether an IP is one we refuse to dial: loopback,
+// link-local (uni/multicast), unspecified, or private (RFC1918 / ULA fc00::/7).
+func isDisallowedIP(ip net.IP) bool {
+	if allowPrivateDial {
+		return false
+	}
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
+		return true
+	}
+	return ip.IsPrivate()
+}

--- a/v2/pkg/resolve/http_test.go
+++ b/v2/pkg/resolve/http_test.go
@@ -1,0 +1,141 @@
+package resolve
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestHTTPResolver_Gated: disabled by default -> factory refuses -> literal.
+func TestHTTPResolver_Gated(t *testing.T) {
+	specs := []VarSpec{{Name: "V", Type: "http", URL: "http://example.com/x", Scope: ScopeConfig}}
+	reg := Build(specs, Policy{AllowHTTP: false}, nil)
+	if got := reg.Expand(context.Background(), "${V}", ScopeConfig, nil); got != "${V}" {
+		t.Errorf("disabled http should leave literal, got %q", got)
+	}
+}
+
+// TestHTTPResolver_RequiresAllowlist: enabled but no allowlist -> refused.
+func TestHTTPResolver_RequiresAllowlist(t *testing.T) {
+	specs := []VarSpec{{Name: "V", Type: "http", URL: "http://example.com/x", Scope: ScopeConfig}}
+	reg := Build(specs, Policy{AllowHTTP: true}, nil)
+	if got := reg.Expand(context.Background(), "${V}", ScopeConfig, nil); got != "${V}" {
+		t.Errorf("http with empty allowlist should leave literal, got %q", got)
+	}
+}
+
+// TestHTTPResolver_HostNotAllowlisted: host absent from allowlist -> refused.
+func TestHTTPResolver_HostNotAllowlisted(t *testing.T) {
+	specs := []VarSpec{{Name: "V", Type: "http", URL: "http://evil.example.com/x", Scope: ScopeConfig}}
+	reg := Build(specs, Policy{AllowHTTP: true, HTTPAllowlist: []string{"good.example.com"}}, nil)
+	if got := reg.Expand(context.Background(), "${V}", ScopeConfig, nil); got != "${V}" {
+		t.Errorf("non-allowlisted host should leave literal, got %q", got)
+	}
+}
+
+// TestHTTPResolver_SSRFGuardBlocksLoopback: httptest binds 127.0.0.1, which the
+// SSRF dial guard blocks even when the host is allowlisted — the request never
+// reaches the server, and the variable is left literal.
+func TestHTTPResolver_SSRFGuardBlocksLoopback(t *testing.T) {
+	reached := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.Write([]byte("value"))
+	}))
+	defer srv.Close()
+	host, _, _ := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+	specs := []VarSpec{{Name: "V", Type: "http", URL: srv.URL + "/x", Scope: ScopeTemplate}}
+	reg := Build(specs, Policy{AllowHTTP: true, HTTPAllowlist: []string{host}, HTTPTimeoutS: 5}, nil)
+	if got := reg.Expand(context.Background(), "${V}", ScopeTemplate, nil); got != "${V}" {
+		t.Errorf("loopback must be blocked by SSRF guard, got %q", got)
+	}
+	if reached {
+		t.Error("request reached the server despite the SSRF guard")
+	}
+}
+
+// TestHTTPResolver_HappyPath: with the private-dial guard disabled (test only),
+// an allowlisted server returns a body and the header ${ENV} is expanded and
+// forwarded; the body is trimmed.
+func TestHTTPResolver_HappyPath(t *testing.T) {
+	allowPrivateDial = true
+	t.Cleanup(func() { allowPrivateDial = false })
+	t.Setenv("HIVE_TEST_TOKEN", "sekret")
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Write([]byte("the-value\n"))
+	}))
+	defer srv.Close()
+
+	host, _, _ := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+	specs := []VarSpec{{
+		Name: "V", Type: "http", URL: srv.URL + "/config",
+		Headers: map[string]string{"Authorization": "Bearer ${HIVE_TEST_TOKEN}"},
+		Scope:   ScopeTemplate,
+	}}
+	reg := Build(specs, Policy{AllowHTTP: true, HTTPAllowlist: []string{host}, HTTPTimeoutS: 5}, nil)
+	if got := reg.Expand(context.Background(), "[${V}]", ScopeTemplate, nil); got != "[the-value]" {
+		t.Errorf("got %q want [the-value]", got)
+	}
+	if gotAuth != "Bearer sekret" {
+		t.Errorf("header ${ENV} not expanded/forwarded: got %q", gotAuth)
+	}
+}
+
+// TestHTTPResolver_SizeCap: a body larger than the cap is truncated to the cap.
+func TestHTTPResolver_SizeCap(t *testing.T) {
+	allowPrivateDial = true
+	t.Cleanup(func() { allowPrivateDial = false })
+	big := strings.Repeat("a", maxHTTPResponseBytes+1000)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(big))
+	}))
+	defer srv.Close()
+	host, _, _ := net.SplitHostPort(strings.TrimPrefix(srv.URL, "http://"))
+	specs := []VarSpec{{Name: "V", Type: "http", URL: srv.URL, Scope: ScopeTemplate}}
+	reg := Build(specs, Policy{AllowHTTP: true, HTTPAllowlist: []string{host}, HTTPTimeoutS: 5}, nil)
+	got := reg.Expand(context.Background(), "${V}", ScopeTemplate, nil)
+	if len(got) != maxHTTPResponseBytes {
+		t.Errorf("response should be capped at %d bytes, got %d", maxHTTPResponseBytes, len(got))
+	}
+}
+
+// TestHTTPResolver_PrivateIPBlocked confirms the disallowed-IP classifier.
+func TestHTTPResolver_PrivateIPBlocked(t *testing.T) {
+	cases := map[string]bool{
+		"127.0.0.1":   true,  // loopback
+		"10.0.0.1":    true,  // RFC1918
+		"192.168.1.1": true,  // RFC1918
+		"172.16.0.1":  true,  // RFC1918
+		"169.254.0.1": true,  // link-local
+		"::1":         true,  // loopback v6
+		"fc00::1":     true,  // ULA
+		"8.8.8.8":     false, // public
+		"1.1.1.1":     false, // public
+	}
+	for ipStr, want := range cases {
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			t.Fatalf("bad test IP %q", ipStr)
+		}
+		if got := isDisallowedIP(ip); got != want {
+			t.Errorf("isDisallowedIP(%s) = %v, want %v", ipStr, got, want)
+		}
+	}
+}
+
+// TestExpandEnvOnly covers header ${ENV} expansion (set -> value, unset -> literal).
+func TestExpandEnvOnly(t *testing.T) {
+	t.Setenv("HIVE_HDR", "abc")
+	if got := expandEnvOnly("Bearer ${HIVE_HDR}"); got != "Bearer abc" {
+		t.Errorf("got %q", got)
+	}
+	if got := expandEnvOnly("x ${HIVE_UNSET_HDR} y"); got != "x ${HIVE_UNSET_HDR} y" {
+		t.Errorf("unset header var should stay literal, got %q", got)
+	}
+}


### PR DESCRIPTION
## Why

**PR 4 of the pluggable-resolver series** (follows #1898, #1899, #1900) — the last resolver type. A `${VAR}` backed by an HTTP GET, so a value can come from a web service:

```yaml
variables:
  security:
    allow_http: true                          # required; disabled by default; SEED-ONLY
    http_allowlist: [vault.internal.example.com]
  defs:
    DB_HOST:
      type: http
      url: "https://vault.internal.example.com/v1/config/db-host"
      headers: { Authorization: "Bearer ${HIVE_VAULT_TOKEN}" }
      scope: config
```

## Security / SSRF model

- **Gated + seed-only**, like `allow_exec`: refuses to build unless `allow_http` is true (honored only from the trusted seed) **and** a non-empty `http_allowlist` is set. Cannot be enabled from the user-writable overlay.
- **Allowlisted host** — checked at build time.
- **SSRF / DNS-rebind defense** — the client dials through a control that rejects, post-DNS, any **loopback / link-local / unspecified / private (RFC1918, ULA)** target IP. An allowlisted hostname that resolves to an internal address is still refused. (`TestHTTPResolver_SSRFGuardBlocksLoopback` + the `isDisallowedIP` table.)
- **GET only, no redirect following** (a redirect could reach a non-allowlisted/internal host), **64 KiB response cap**, `http_timeout_s` timeout (default 5s).
- **Header `${ENV}` expansion** so tokens come from the environment, never YAML.
- Any failure → `ErrUnresolved` (literal) or a configured `default`; `Source` is `http:<host>`, never the value.

## Tests

Gate, allowlist-required, non-allowlisted-host, SSRF-blocks-loopback, private-IP classifier table, happy-path (with header env expansion), and size-cap — all under `-race`. The private-dial guard is always on in production; a test-only flag lets `httptest` (loopback) exercise the happy path.

## Series complete

With this, the resolver supports **env, static, script, and http** out of the box, plus the `RegisterResolver` seam for any future type. Follow-up: flip the docs `script`/`http` sections from "preview" to GA.