### PR TITLE
fix(dashboard): keep modals above the GitHub auth error banner

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1068,8 +1068,12 @@
     .health-ci.bad { color: var(--red); }
 
     /* GitHub API rate limit alert bar */
+    /* z-index 9500: a global system alert sits above page content/FABs (9000–9001)
+       but BELOW modal overlays (.config-overlay 10000, .hive-dialog-overlay 20000)
+       so an open modal — e.g. the Getting Started checklist — is never punched
+       through by this banner. Do not raise to/above the modal layer. */
     .gh-auth-alert {
-      display: none; position: relative; z-index: 10000;
+      display: none; position: relative; z-index: 9500;
       background: color-mix(in srgb, var(--red) 15%, var(--panel)); border-bottom: 2px solid var(--red); color: var(--text);
       padding: 10px 20px; font-size: 0.85rem; text-align: center;
     }


### PR DESCRIPTION
## Bug

On the hive dashboard, the global error banner with the text *"GitHub API authentication failed. Check GitHub App key or token configuration."* (`.gh-auth-alert`) rendered **on top of** an open modal dialog — specifically the **Getting Started** onboarding checklist — punching through it and overlapping the modal's header/title.

Root cause: the banner had `z-index: 10000`, tying with the modal overlay `.config-overlay` (also `10000`). Because the banner appears later in the DOM, equal z-index means it wins the paint order and covers the modal.

## Fix

Lower `.gh-auth-alert` to `z-index: 9500`. This keeps a global system alert above ordinary page content and the floating action buttons (9000–9001) but **strictly below** the modal overlay layer:

| Element | z-index (old → new) |
|---|---|
| `.gh-auth-alert` (error banner) | 10000 → **9500** |
| `.config-overlay` (Getting Started / config modals) | 10000 (unchanged) |
| `.hive-dialog-overlay` | 20000 (unchanged) |

Now any open modal sits above the banner. A short comment documents the layering intent so the value isn't re-raised by mistake.

Minimal change — only the banner's `z-index` (plus an explanatory comment) is touched; no restyling or refactoring.