### PR TITLE
fix(dashboard): redact LiteLLM key hash and key hints from gateway error output

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3268,6 +3268,37 @@ const (
 	litellmProbeMaxErrBody = 512
 )
 
+// litellmKeyMaterialPatterns match key-identifying material that some gateways
+// (e.g. LiteLLM) echo back in auth-failure bodies: the SHA-256 key hash, the
+// masked "Received API Key = sk-...XXXX" hint, and bare sk- tokens. We keep the
+// human-useful "401 auth failed" signal but strip these — the key hash is a
+// stable fingerprint of the secret that should not appear in the dashboard or
+// logs.
+var litellmKeyMaterialPatterns = []*regexp.Regexp{
+	// "Key Hash (Token) = <64 hex>" (also matches "Key Hash = <hex>").
+	regexp.MustCompile(`(?i)(key hash[^=]*=\s*)[0-9a-f]{16,}`),
+	// "Received API Key = sk-...GTNw" (masked hint) or any explicit key= field.
+	regexp.MustCompile(`(?i)(received api key\s*=\s*)\S+`),
+	// Any bare sk- token that slipped through.
+	regexp.MustCompile(`sk-[A-Za-z0-9._\-]{6,}`),
+	// A long standalone hex fingerprint (32+ hex chars).
+	regexp.MustCompile(`\b[0-9a-f]{32,}\b`),
+}
+
+// redactLiteLLMKeyMaterial removes API-key hints and key hashes from a gateway
+// error body before it is surfaced to the dashboard or logged.
+func redactLiteLLMKeyMaterial(s string) string {
+	for i, re := range litellmKeyMaterialPatterns {
+		if i < 2 {
+			// Keep the field label, redact the value.
+			s = re.ReplaceAllString(s, "${1}[redacted]")
+		} else {
+			s = re.ReplaceAllString(s, "[redacted]")
+		}
+	}
+	return s
+}
+
 // probeLiteLLMModels queries {endpoint}/v1/models with the given key and
 // returns the number of models the gateway offers. This is a LIVE probe
 // only — it never falls back to the static model aliases, so a failing
@@ -3296,7 +3327,7 @@ func probeLiteLLMModels(endpoint, apiKey string) (int, error) {
 		// Error path: only a truncated slice of the body is surfaced to the
 		// dialog (error bodies can be huge and may echo the key).
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, litellmProbeMaxErrBody))
-		gatewayMsg := strings.TrimSpace(string(body))
+		gatewayMsg := redactLiteLLMKeyMaterial(strings.TrimSpace(string(body)))
 		switch {
 		case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
 			// The two auth failures lead users to different fixes.

--- a/v2/pkg/dashboard/redact_litellm_test.go
+++ b/v2/pkg/dashboard/redact_litellm_test.go
@@ -1,0 +1,49 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRedactLiteLLMKeyMaterial scrubs key-identifying material a gateway echoes
+// in an auth-failure body — the SHA-256 key hash, the masked "Received API Key"
+// hint, and any bare sk- token — while keeping the human-useful error text.
+func TestRedactLiteLLMKeyMaterial(t *testing.T) {
+	in := `{"error":{"message":"Authentication Error, Invalid proxy server token passed. Received API Key = sk-...GTNw, Key Hash (Token) =262b781f7b1e8d33076fba20db1ade92afdcb1f88867648849cdd25a49581fb2. Unable to find token in cache or ` + "`LiteLLM_VerificationTokenTable`" + `","type":"token_not_found_in_db","param":"key","code":"401"}}`
+
+	out := redactLiteLLMKeyMaterial(in)
+
+	// The specific leaked material must be gone.
+	if strings.Contains(out, "262b781f7b1e8d33076fba20db1ade92afdcb1f88867648849cdd25a49581fb2") {
+		t.Errorf("key hash not redacted:\n%s", out)
+	}
+	if strings.Contains(out, "sk-...GTNw") {
+		t.Errorf("masked api key hint not redacted:\n%s", out)
+	}
+	// The useful diagnostic text must survive.
+	for _, want := range []string{"Authentication Error", "token_not_found_in_db", "401", "[redacted]"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q to survive redaction:\n%s", want, out)
+		}
+	}
+}
+
+// TestRedactLiteLLMKeyMaterial_BareToken redacts a bare sk- token anywhere.
+func TestRedactLiteLLMKeyMaterial_BareToken(t *testing.T) {
+	out := redactLiteLLMKeyMaterial("failed with key sk-abcdef1234567890 at gateway")
+	if strings.Contains(out, "sk-abcdef1234567890") {
+		t.Errorf("bare token not redacted: %s", out)
+	}
+	if !strings.Contains(out, "[redacted]") {
+		t.Errorf("expected [redacted]: %s", out)
+	}
+}
+
+// TestRedactLiteLLMKeyMaterial_NoFalsePositiveOnPlainText leaves ordinary error
+// text (no key material) untouched.
+func TestRedactLiteLLMKeyMaterial_NoFalsePositiveOnPlainText(t *testing.T) {
+	in := "gateway returned 503: service temporarily unavailable"
+	if out := redactLiteLLMKeyMaterial(in); out != in {
+		t.Errorf("plain text should be unchanged:\n got  %q\n want %q", out, in)
+	}
+}


### PR DESCRIPTION
## Problem

When a LiteLLM gateway rejects the configured key, its 401 body echoes key-identifying material:

```
Authentication Error, Invalid proxy server token passed.
Received API Key = sk-...GTNw, Key Hash (Token) = 262b781f...49581fb2.
Unable to find token in cache or LiteLLM_VerificationTokenTable ... "code":"401"
```

hive surfaced that body **verbatim** in the dashboard's Test Connection result and in logs. The plaintext key isn't leaked, but the **SHA-256 key hash** is a stable fingerprint of the secret that shouldn't appear in the UI or logs — it enables offline match-confirmation of a candidate key and correlates the key across logs.

Truncating the body (the existing guard) isn't enough: the key material appears at the very start of the body, well within the limit.

## Fix

`redactLiteLLMKeyMaterial` scrubs the key hash, the `Received API Key = ...` hint, bare `sk-` tokens, and long standalone hex fingerprints, while preserving the useful diagnostic text (`Authentication Error`, `token_not_found_in_db`, the `401`). Applied to the gateway error path in the save-time `/v1/models` probe.

## Tests

Against the actual leaked 401 body (hash + masked key both redacted, diagnostic text retained), a bare `sk-` token, and a plain non-key error (left unchanged).