### PR TITLE
feat(dashboard): Variables config tab + hide upgrade button on hub-managed spokes

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -36,6 +36,8 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/config", s.handleConfig)
 	s.mux.HandleFunc("GET /api/config/download", s.handleConfigDownload)
 	s.mux.HandleFunc("GET /api/config/variables", s.handleVariablesList)
+	s.mux.HandleFunc("PUT /api/config/variables/{name}", s.handleVariableUpsert)
+	s.mux.HandleFunc("DELETE /api/config/variables/{name}", s.handleVariableDelete)
 	s.mux.HandleFunc("GET /api/audit", s.handleAuditLog)
 	s.mux.HandleFunc("POST /api/self-upgrade", s.handleSelfUpgrade)
 	s.mux.HandleFunc("GET /api/snapshot", s.handleSnapshotAPI)
@@ -400,6 +402,13 @@ func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 		"hash":    versionHash,
 		"short":   versionShort,
 		"branch":  upstreamBranch(),
+	}
+	// autoUpgrade tells the dashboard whether the hub manages this spoke's
+	// upgrades. When true the manual spoke Upgrade button is hidden — the hub
+	// rolls the upgrade out automatically, so offering a manual button is
+	// redundant and confusing.
+	if s.deps != nil && s.deps.Config != nil {
+		resp["autoUpgrade"] = s.deps.Config.Hub.AutoUpgrade
 	}
 
 	s.versionMu.RLock()
@@ -1847,6 +1856,129 @@ func (s *Server) handleVariablesList(w http.ResponseWriter, r *http.Request) {
 		"exec_enabled": v.Security.AllowExec,
 		"http_enabled": v.Security.AllowHTTP,
 	})
+}
+
+// variableNamePattern restricts dashboard-created variable names to the safe
+// ${NAME} identifier shape (letters, digits, underscore; not starting with a
+// digit). This is what a kick template references as ${NAME}.
+var variableNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// looksLikeApiKeyValue heuristically flags a string that looks like a secret
+// key value rather than a safe static config value — an sk-/ghp-/token-style
+// prefix, or a long high-entropy run with no spaces. Mirrors the client-side
+// guard that keeps operators from inlining a secret into hive.yaml (where
+// Config.Save would persist it in plaintext).
+func looksLikeApiKeyValue(v string) bool {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return false
+	}
+	lower := strings.ToLower(v)
+	for _, p := range []string{"sk-", "sk_", "ghp_", "gho_", "github_pat_", "xoxb-", "bearer "} {
+		if strings.HasPrefix(lower, p) {
+			return true
+		}
+	}
+	// A long token with no whitespace and no path/URL punctuation is likely a
+	// secret, not a config value like "production" or "us-east-1".
+	if len(v) >= 32 && !strings.ContainsAny(v, " /\\:.") {
+		return true
+	}
+	return false
+}
+
+// handleVariableUpsert creates or updates a single operator variable via the
+// dashboard. It is deliberately restricted to the two SAFE resolver types —
+// static and env — which cannot execute code or reach the network. script and
+// http variables, and the exec/http security policy, are seed-only (GitOps): a
+// user-writable overlay must never be able to introduce them, so this endpoint
+// rejects them. The change is persisted to the dashboard overlay like any other
+// dashboard config edit.
+func (s *Server) handleVariableUpsert(w http.ResponseWriter, r *http.Request) {
+	if s.deps == nil || s.deps.Config == nil {
+		jsonError(w, "config not loaded", http.StatusInternalServerError)
+		return
+	}
+	name := r.PathValue("name")
+	if !variableNamePattern.MatchString(name) {
+		jsonError(w, "invalid variable name (use letters, digits, underscore; not starting with a digit)", http.StatusBadRequest)
+		return
+	}
+	var body struct {
+		Type    string  `json:"type"`
+		Scope   string  `json:"scope"`
+		Value   string  `json:"value"`
+		Env     string  `json:"env"`
+		Default *string `json:"default"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	switch body.Type {
+	case "static", "env":
+		// allowed
+	case "script", "http":
+		jsonError(w, "script and http variables can only be defined in the seed config (GitOps), not from the dashboard", http.StatusForbidden)
+		return
+	default:
+		jsonError(w, "type must be 'static' or 'env'", http.StatusBadRequest)
+		return
+	}
+	switch body.Scope {
+	case "", "template", "config", "both":
+		// allowed
+	default:
+		jsonError(w, "scope must be 'template', 'config', or 'both'", http.StatusBadRequest)
+		return
+	}
+	// Guard against a secret value being pasted into a static var (it would be
+	// persisted to hive.yaml in plaintext). Reuse the same heuristic the LiteLLM
+	// key fields use.
+	if body.Type == "static" && looksLikeApiKeyValue(body.Value) {
+		jsonError(w, "that value looks like an API key or secret; use type 'env' pointing at an environment variable instead of inlining a secret", http.StatusBadRequest)
+		return
+	}
+
+	def := config.VarDef{Type: body.Type, Scope: body.Scope, Value: body.Value, Env: body.Env, Default: body.Default}
+
+	if s.deps.Config.Variables.Defs == nil {
+		s.deps.Config.Variables.Defs = map[string]config.VarDef{}
+	}
+	s.deps.Config.Variables.Defs[name] = def
+	if err := s.saveConfig(); err != nil {
+		jsonError(w, "failed to save: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	s.auditFromRequest(r, "variable_upsert", auditDetail("name", name, "type", body.Type), "")
+	jsonResponse(w, map[string]any{"status": "saved", "name": name})
+}
+
+// handleVariableDelete removes an operator variable. Only static/env variables
+// are dashboard-managed, so this refuses to delete a script/http variable
+// (those are seed-only and must be removed via the seed config).
+func (s *Server) handleVariableDelete(w http.ResponseWriter, r *http.Request) {
+	if s.deps == nil || s.deps.Config == nil {
+		jsonError(w, "config not loaded", http.StatusInternalServerError)
+		return
+	}
+	name := r.PathValue("name")
+	def, ok := s.deps.Config.Variables.Defs[name]
+	if !ok {
+		jsonError(w, "variable not found", http.StatusNotFound)
+		return
+	}
+	if def.Type == "script" || def.Type == "http" {
+		jsonError(w, "script and http variables are seed-managed and cannot be deleted from the dashboard", http.StatusForbidden)
+		return
+	}
+	delete(s.deps.Config.Variables.Defs, name)
+	if err := s.saveConfig(); err != nil {
+		jsonError(w, "failed to save: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	s.auditFromRequest(r, "variable_delete", auditDetail("name", name), "")
+	jsonResponse(w, map[string]any{"status": "deleted", "name": name})
 }
 
 func (s *Server) substituteTemplateVars(template, agentName string) string {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -10731,8 +10731,14 @@ function burnAreaChart() {
           showToast('Upgrade complete!', 'success');
           html += ' <span style="color:var(--green)" title="Up to date with remote">✓</span>';
         } else if (v.behind) {
-          html += ` <span class="git-behind" title="Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">⬆ behind</span>`;
-          html += ` <button id="spoke-upgrade-btn" onclick="selfUpgrade('${escapeHtml(v.latestHash || '')}')" style="padding:3px 10px;font-size:0.7rem;background:var(--green);color:var(--bg);border:none;border-radius:4px;cursor:pointer;margin-left:6px;white-space:nowrap" title="Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">Upgrade</button>`;
+          html += ` <span class="git-behind" title="Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">⬆</span>`;
+          if (v.autoUpgrade) {
+            // Hub-managed: the hub rolls the upgrade automatically, so no manual
+            // button — show a "managed" hint instead.
+            html += ` <span style="color:var(--muted);font-size:0.68rem;margin-left:6px;white-space:nowrap" title="This hive is upgraded automatically by the hub (auto-upgrade). Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">managed</span>`;
+          } else {
+            html += ` <button id="spoke-upgrade-btn" onclick="selfUpgrade('${escapeHtml(v.latestHash || '')}')" style="padding:3px 10px;font-size:0.7rem;background:var(--green);color:var(--bg);border:none;border-radius:4px;cursor:pointer;margin-left:6px;white-space:nowrap" title="Current: ${escapeHtml(v.short || '?')} → Latest: ${escapeHtml(v.latestShort || '?')}">Upgrade</button>`;
+          }
         } else if (v.latestHash) {
           html += ' <span style="color:var(--green)" title="Up to date with remote">✓</span>';
         }
@@ -10917,7 +10923,7 @@ function burnAreaChart() {
 
     const AGENT_CONFIG_TABS = ['General', 'Cadences', 'Pipeline', 'Hooks', 'Restrictions', 'Channels', 'Tools', 'Connections', 'Stats', 'Prompt Template', 'Last Prompt', 'Export'];
     const AGENT_CREATE_TABS = ['Import', 'General', 'Cadences', 'Channels', 'Tools', 'Prompt Template'];
-    const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Hub', 'LiteLLM'];
+    const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Hub', 'LiteLLM', 'Variables'];
     const PIPELINE_STAGES = ['resolve-beads', 'track-prs', 'stale-check', 'repo-scan', 'coverage-gate', 'prompt-compose', 'budget-check', 'api-collect', 'final-compose'];
     const PIPELINE_STAGE_TIPS = {
       'resolve-beads': 'Fetch and inject knowledge beads (facts, patterns, gotchas) relevant to the agent\'s current task context.',
@@ -11458,6 +11464,7 @@ function burnAreaChart() {
         case 'Logging': return renderGovLogging(d.logging || {});
         case 'Hub': return renderGovHub(d.hub || {});
         case 'LiteLLM': return renderGovLiteLLM(d.litellm || {});
+        case 'Variables': return renderGovVariables();
         default: return '';
       }
     }
@@ -11590,6 +11597,129 @@ function burnAreaChart() {
       const saved = (_configState.data.litellm || {}).defaultModel;
       const current = dirtyVal !== undefined ? dirtyVal : (saved || '');
       host.innerHTML = litellmDefaultModelFieldHtml(current);
+    }
+
+    // ── Variables tab: operator-defined ${VAR} substitutions ──
+    // Reads GET /api/config/variables (never returns secret values — only
+    // name/type/scope/source + the exec/http gate flags). static and env
+    // variables can be added/edited/deleted here; script and http variables are
+    // shown read-only because they can execute code or reach the network and are
+    // therefore seed-only (GitOps), enforced server-side.
+    function renderGovVariables() {
+      loadVariables();
+      return `
+        <div style="font-size:0.8rem;color:var(--muted);margin-bottom:10px;line-height:1.5">
+          Define your own <code>\${NAME}</code> substitutions for kick templates and config.
+          <b>static</b> and <b>env</b> variables can be managed here; <b>script</b> and <b>http</b>
+          variables (which run commands or fetch URLs) are configured in the seed config only.
+        </div>
+        <div id="variables-status" style="font-size:0.72rem;color:var(--muted);margin-bottom:8px"></div>
+        <div id="variables-list"><div style="color:var(--muted);font-size:0.75rem;padding:4px 0">Loading variables…</div></div>
+        <div style="margin-top:16px;border-top:1px solid var(--border,#2a2a2a);padding-top:12px">
+          <div style="font-weight:600;font-size:0.78rem;margin-bottom:8px">Add a variable</div>
+          <div class="config-field-row">
+            <div class="config-field"><label>Name</label><input id="var-add-name" placeholder="MY_VAR" style="text-transform:uppercase"></div>
+            <div class="config-field"><label>Type</label>
+              <select id="var-add-type" onchange="onVarAddTypeChange()">
+                <option value="static">static (fixed value)</option>
+                <option value="env">env (environment variable)</option>
+              </select>
+            </div>
+            <div class="config-field"><label>Scope</label>
+              <select id="var-add-scope">
+                <option value="template">template</option>
+                <option value="config">config</option>
+                <option value="both">both</option>
+              </select>
+            </div>
+          </div>
+          <div class="config-field-row">
+            <div class="config-field" id="var-add-value-field"><label>Value</label><input id="var-add-value" placeholder="production"></div>
+            <div class="config-field" id="var-add-env-field" style="display:none"><label>Env var name</label><input id="var-add-env" placeholder="HIVE_REGION"></div>
+            <div class="config-field"><label>Default (optional)</label><input id="var-add-default" placeholder="fallback if unset"></div>
+          </div>
+          <button class="config-btn" onclick="saveNewVariable()" style="margin-top:6px">Add variable</button>
+        </div>`;
+    }
+
+    function onVarAddTypeChange() {
+      const t = document.getElementById('var-add-type').value;
+      const vf = document.getElementById('var-add-value-field');
+      const ef = document.getElementById('var-add-env-field');
+      if (t === 'env') { vf.style.display = 'none'; ef.style.display = ''; }
+      else { vf.style.display = ''; ef.style.display = 'none'; }
+    }
+
+    async function loadVariables() {
+      const listEl = document.getElementById('variables-list');
+      const statusEl = document.getElementById('variables-status');
+      try {
+        const r = await fetch('/api/config/variables');
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        const d = await r.json();
+        if (statusEl) {
+          statusEl.innerHTML = `script execution: <b>${d.exec_enabled ? 'enabled' : 'disabled'}</b> · http fetch: <b>${d.http_enabled ? 'enabled' : 'disabled'}</b> <span style="opacity:0.7">(seed-only)</span>`;
+        }
+        renderVariablesList(d.variables || []);
+      } catch (e) {
+        if (listEl) listEl.innerHTML = '<div style="color:var(--muted);font-size:0.75rem">Could not load variables.</div>';
+      }
+    }
+
+    function renderVariablesList(vars) {
+      const el = document.getElementById('variables-list');
+      if (!el) return;
+      if (vars.length === 0) {
+        el.innerHTML = '<div style="color:var(--muted);font-size:0.75rem;padding:4px 0">No variables defined.</div>';
+        return;
+      }
+      el.innerHTML = vars.map(v => {
+        const seedOnly = (v.type === 'script' || v.type === 'http');
+        const del = seedOnly
+          ? '<span style="color:var(--muted);font-size:0.68rem;white-space:nowrap" title="script/http variables are managed in the seed config">seed-managed</span>'
+          : `<button class="config-btn" style="padding:2px 8px;font-size:0.68rem" onclick="deleteVariable('${esc(v.name)}')">delete</button>`;
+        return `<div class="config-list-item" style="align-items:center;gap:8px">
+          <code style="flex:0 0 auto">\${${esc(v.name)}}</code>
+          <span style="color:var(--muted);font-size:0.7rem">${esc(v.type)}</span>
+          <span style="color:var(--muted);font-size:0.7rem">${esc(v.scope)}</span>
+          <span style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--muted);font-size:0.7rem" title="${esc(v.source)}">${esc(v.source)}</span>
+          ${del}
+        </div>`;
+      }).join('');
+    }
+
+    async function saveNewVariable() {
+      const name = (document.getElementById('var-add-name').value || '').trim().toUpperCase();
+      const type = document.getElementById('var-add-type').value;
+      const scope = document.getElementById('var-add-scope').value;
+      const def = (document.getElementById('var-add-default').value || '').trim();
+      if (!name) { showToast('Enter a variable name', 'error'); return; }
+      const body = { type, scope };
+      if (def) body.default = def;
+      if (type === 'env') body.env = (document.getElementById('var-add-env').value || '').trim() || name;
+      else body.value = document.getElementById('var-add-value').value || '';
+      try {
+        const r = await fetch('/api/config/variables/' + encodeURIComponent(name), {
+          method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body)
+        });
+        const d = await r.json().catch(() => ({}));
+        if (!r.ok) { showToast(d.error || ('Failed (HTTP ' + r.status + ')'), 'error'); return; }
+        showToast('Variable ${' + name + '} saved', 'success');
+        document.getElementById('var-add-name').value = '';
+        document.getElementById('var-add-value').value = '';
+        document.getElementById('var-add-default').value = '';
+        loadVariables();
+      } catch (e) { showToast('Failed to save variable', 'error'); }
+    }
+
+    async function deleteVariable(name) {
+      try {
+        const r = await fetch('/api/config/variables/' + encodeURIComponent(name), { method: 'DELETE' });
+        const d = await r.json().catch(() => ({}));
+        if (!r.ok) { showToast(d.error || ('Failed (HTTP ' + r.status + ')'), 'error'); return; }
+        showToast('Variable ${' + name + '} deleted', 'success');
+        loadVariables();
+      } catch (e) { showToast('Failed to delete variable', 'error'); }
     }
 
     function renderGovLiteLLM(litellm) {

--- a/v2/pkg/dashboard/variables_api_test.go
+++ b/v2/pkg/dashboard/variables_api_test.go
@@ -1,0 +1,115 @@
+package dashboard
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+func newVarServer(t *testing.T) *Server {
+	t.Helper()
+	cfg := &config.Config{
+		Project:    config.ProjectConfig{Org: "o", Repos: []string{"r"}},
+		GitHub:     config.GitHubConfig{Token: "ghp_x"},
+		Agents:     map[string]config.AgentConfig{"scanner": {Backend: "copilot"}},
+		SourcePath: t.TempDir() + "/hive.yaml",
+	}
+	srv := NewServer(0, nil)
+	srv.deps = &Dependencies{Config: cfg, RefreshFunc: func() {}, PersistFunc: func() {}, SkipReloadFunc: func() {}}
+	srv.RegisterAPI(srv.deps)
+	return srv
+}
+
+func putVar(t *testing.T, srv *Server, name, body string) int {
+	t.Helper()
+	req := httptest.NewRequest("PUT", "/api/config/variables/"+name, strings.NewReader(body))
+	req.SetPathValue("name", name)
+	w := httptest.NewRecorder()
+	srv.handleVariableUpsert(w, req)
+	return w.Code
+}
+
+func TestVariableUpsert_StaticAndEnvAllowed(t *testing.T) {
+	srv := newVarServer(t)
+	if code := putVar(t, srv, "DEPLOY_ENV", `{"type":"static","value":"production","scope":"both"}`); code != 200 {
+		t.Fatalf("static upsert: got %d", code)
+	}
+	if got := srv.deps.Config.Variables.Defs["DEPLOY_ENV"].Value; got != "production" {
+		t.Errorf("static not saved: %q", got)
+	}
+	if code := putVar(t, srv, "REGION", `{"type":"env","env":"HIVE_REGION","scope":"config"}`); code != 200 {
+		t.Fatalf("env upsert: got %d", code)
+	}
+}
+
+func TestVariableUpsert_RejectsScriptAndHTTP(t *testing.T) {
+	srv := newVarServer(t)
+	if code := putVar(t, srv, "X", `{"type":"script","command":["echo","hi"]}`); code != 403 {
+		t.Errorf("script from dashboard should be 403, got %d", code)
+	}
+	if code := putVar(t, srv, "Y", `{"type":"http","url":"http://x/y"}`); code != 403 {
+		t.Errorf("http from dashboard should be 403, got %d", code)
+	}
+	if _, ok := srv.deps.Config.Variables.Defs["X"]; ok {
+		t.Error("script var must not have been saved")
+	}
+}
+
+func TestVariableUpsert_RejectsSecretInStatic(t *testing.T) {
+	srv := newVarServer(t)
+	if code := putVar(t, srv, "TOK", `{"type":"static","value":"sk-abcdef1234567890abcdef"}`); code != 400 {
+		t.Errorf("secret-looking static value should be 400, got %d", code)
+	}
+}
+
+func TestVariableUpsert_RejectsBadName(t *testing.T) {
+	srv := newVarServer(t)
+	if code := putVar(t, srv, "1bad-name", `{"type":"static","value":"x"}`); code != 400 {
+		t.Errorf("bad name should be 400, got %d", code)
+	}
+}
+
+func TestVariableDelete_GuardsSeedTypes(t *testing.T) {
+	srv := newVarServer(t)
+	// Seed a script var directly (as if from the seed config).
+	srv.deps.Config.Variables.Defs = map[string]config.VarDef{
+		"SEED_SCRIPT": {Type: "script", Command: []string{"echo", "x"}},
+		"UI_STATIC":   {Type: "static", Value: "v"},
+	}
+	// Deleting a script var via the dashboard is forbidden.
+	req := httptest.NewRequest("DELETE", "/api/config/variables/SEED_SCRIPT", nil)
+	req.SetPathValue("name", "SEED_SCRIPT")
+	w := httptest.NewRecorder()
+	srv.handleVariableDelete(w, req)
+	if w.Code != 403 {
+		t.Errorf("deleting script var should be 403, got %d", w.Code)
+	}
+	// Deleting a static var is allowed.
+	req2 := httptest.NewRequest("DELETE", "/api/config/variables/UI_STATIC", nil)
+	req2.SetPathValue("name", "UI_STATIC")
+	w2 := httptest.NewRecorder()
+	srv.handleVariableDelete(w2, req2)
+	if w2.Code != 200 {
+		t.Errorf("deleting static var should be 200, got %d", w2.Code)
+	}
+	if _, ok := srv.deps.Config.Variables.Defs["UI_STATIC"]; ok {
+		t.Error("static var should have been deleted")
+	}
+}
+
+func TestLooksLikeApiKeyValue(t *testing.T) {
+	secrets := []string{"sk-abcdef123456", "ghp_xxxxxxxxxxxx", "Bearer abc", "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5"}
+	safe := []string{"production", "us-east-1", "v2", "my-value", "some/path", ""}
+	for _, s := range secrets {
+		if !looksLikeApiKeyValue(s) {
+			t.Errorf("should flag %q as secret", s)
+		}
+	}
+	for _, s := range safe {
+		if looksLikeApiKeyValue(s) {
+			t.Errorf("should NOT flag %q", s)
+		}
+	}
+}


### PR DESCRIPTION
## Variables tab

Adds a **Variables** tab to the Governor Configuration modal so admins can view and manage the operator-defined `${VAR}` substitutions (the pluggable resolvers from #1898–#1901) without editing YAML.

- **Read-only list** of every defined variable — name, type, scope, non-secret source tag — plus **"script execution / http fetch: enabled|disabled"** badges.
- **Add / edit / delete** limited to the **safe** resolver types: `static` and `env`. New endpoints `PUT`/`DELETE /api/config/variables/{name}` enforce this server-side — `script`/`http` variables return **403** (they run commands or reach the network, so they're **seed-only / GitOps**, matching the existing rule that a user-writable overlay can never enable code/network resolvers). A `static` value that looks like an API key is rejected so a secret is never inlined into `hive.yaml`.

This answers "how is variable substitution exposed to the admin": config + `GET /api/config/variables` (already shipped) **plus** this UI for the safe types.

## Version-header fixes (same area)

- **Hub-managed spokes hide the manual Upgrade button.** When `hub.auto_upgrade` is on, the hub rolls upgrades automatically, so the manual button was redundant/confusing — it's replaced with a small **"managed"** hint. `/api/version` now reports `autoUpgrade`.
- The behind indicator drops the word "behind" and shows just the up-arrow **⬆**.

## Tests

Backend: upsert static/env allowed, script/http rejected (403), secret-looking static rejected (400), invalid name rejected, delete guards seed-only types, api-key heuristic. New dashboard JS validated with `node --check`.

Docs follow-up (kubestellar/docs): note the dashboard Variables tab in variable-substitution.md.