### PR TITLE
fix(dashboard): diagnostics (activity) icon for the System Diagnostics button

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2286,7 +2286,7 @@
     </div>
     <div class="oc-topbar-center">
       <span class="oc-tb-link" onclick="openConfigDialog('governor')" title="Config — governor, agents, thresholds, and all hive settings" aria-label="Config">⚙️</span>
-      <span class="oc-tb-link" onclick="ocNavigate('debug-section')" title="Debug — system diagnostics and troubleshooting" aria-label="Debug">🐛</span>
+      <span class="oc-tb-link" onclick="ocNavigate('debug-section')" title="System Diagnostics — health checks and troubleshooting" aria-label="System Diagnostics"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle"><path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"/></svg></span>
       <!-- Agent Logs hidden (redundant with per-agent output) -->
       <button class="layout-toggle" onclick="toggleLayout()" title="Switch to Dark Mode" aria-label="Switch to Dark Mode">☾</button>
     </div>


### PR DESCRIPTION
The top-bar button labeled *Debug* actually navigates to the **System Diagnostics** section, so a bug icon was semantically off (and the `🐛` emoji it briefly used rendered as a caterpillar on some platforms). Replaces it with the standard **activity / pulse** SVG (heart-monitor line) — reads clearly as system health/diagnostics, renders identically everywhere via `currentColor`, and won't be confused with the adjacent Config gear. Title/aria-label updated to *System Diagnostics*. Frontend-only.