### PR TITLE
fix(agent): don't purge a valid Copilot token on a login prompt during cold start

### DIFF
--- a/v2/pkg/agent/copilot_auth_error_test.go
+++ b/v2/pkg/agent/copilot_auth_error_test.go
@@ -1,0 +1,37 @@
+package agent
+
+import "testing"
+
+// TestMatchesAuthError_DefinitiveRejectionsOnly verifies that only genuine
+// server-side credential rejections trigger a token purge, and that a transient
+// interactive login/"re-authenticate" prompt (which the Copilot CLI can show on
+// a slow cold start after an upgrade, while the stored token is still valid)
+// does NOT — that was the cause of repeated forced re-logins on every upgrade.
+func TestMatchesAuthError_DefinitiveRejectionsOnly(t *testing.T) {
+	purge := []string{
+		"Error: Bad credentials",
+		"HTTP 401 Unauthorized",
+		"token found but could not be validated",
+		"Failed to fetch OAuth user login",
+	}
+	for _, s := range purge {
+		if !matchesAuthError(s) {
+			t.Errorf("definitive rejection should purge: %q", s)
+		}
+	}
+
+	// These must NOT purge — they are login prompts / benign output that can
+	// appear during a normal cold start with a valid token on disk.
+	noPurge := []string{
+		"Please re-authenticate to continue",              // the removed over-broad pattern
+		"To sign in, use a web browser to open the page https://github.com/login/device",
+		"Copilot CLI ready",
+		"Enter the code below to authenticate",
+		"",
+	}
+	for _, s := range noPurge {
+		if matchesAuthError(s) {
+			t.Errorf("non-rejection output must NOT purge the token: %q", s)
+		}
+	}
+}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -2949,13 +2949,32 @@ const (
 	diagnosticPollSec    = 2
 )
 
-// authErrorPatterns indicate the token is bad and should be cleared.
+// authErrorPatterns indicate the stored token was DEFINITIVELY rejected by the
+// server and should be cleared. These are server-side rejections, not CLI
+// prompts. A bare interactive login/"re-authenticate" prompt is intentionally
+// NOT here: on a slow cold start after an upgrade the Copilot CLI can surface a
+// login/device-flow prompt while the token on disk is still valid, and clearing
+// it there destroys a good token and forces the user to re-login on every
+// upgrade. Only a genuine credential rejection purges the token.
 var authErrorPatterns = []string{
 	"Bad credentials",
 	"401 Unauthorized",
 	"token found but could not be validated",
 	"Failed to fetch OAuth user login",
-	"re-authenticate",
+}
+
+// matchesAuthError reports whether copilot diagnostic output shows a definitive
+// server-side credential rejection that justifies purging the stored token. A
+// bare login/"re-authenticate" prompt does NOT match — that is handled by
+// paneShowsLoginPrompt (a non-destructive "needs login" UI signal) so a slow
+// cold start after an upgrade cannot destroy a still-valid token.
+func matchesAuthError(output string) bool {
+	for _, pat := range authErrorPatterns {
+		if strings.Contains(output, pat) {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *Manager) runCopilotDiagnostic(ctx context.Context, agent *AgentProcess) {
@@ -2998,14 +3017,7 @@ func (m *Manager) runCopilotDiagnostic(ctx context.Context, agent *AgentProcess)
 			if output == "" {
 				continue
 			}
-			isAuthError := false
-			for _, pat := range authErrorPatterns {
-				if strings.Contains(output, pat) {
-					isAuthError = true
-					break
-				}
-			}
-			if isAuthError {
+			if matchesAuthError(output) {
 				m.logger.Warn("diagnostic: auth error detected, clearing token",
 					"agent", agent.Name, "output_snippet", truncateStr(output, 200))
 				agent.LastError = "auth token expired or invalid"


### PR DESCRIPTION
## Symptom

Users are forced to **re-login to their subscription-CLI (Copilot) agents on seemingly every hive upgrade**.

## Root cause (evidence-backed)

When the Copilot CLI is slow to reach its prompt after a cold **post-upgrade** restart, the 180s hang-detector runs the auth diagnostic (`runCopilotDiagnostic`). The diagnostic's `authErrorPatterns` included **`"re-authenticate"`** — a string that appears in a normal **interactive login / device-flow prompt**, not only in a server-side credential rejection. Matching it called `clearExpiredTokens()`, which **wiped `copilotTokens`/`loggedInUsers` from the shared PVC config even though the token on disk was still valid**. Every agent then showed "needs login," forcing a manual re-auth — and with a restart storm this recurred on each upgrade.

Observed on the kellyaa hive: `/data/home/.copilot/config.json` had only `firstLaunchAt`/`trustedFolders`, the token section emptied, untouched for days across 23 restarts — while a healthy hive on the same setup kept its token across 31 restarts.

## Fix

Remove `"re-authenticate"` from `authErrorPatterns` so **only definitive server-side rejections** (`Bad credentials`, `401 Unauthorized`, `token found but could not be validated`, `Failed to fetch OAuth user login`) purge the token. A bare login prompt is still surfaced **non-destructively** as "needs login" via `paneShowsLoginPrompt` — so the dashboard signal is unchanged, but a still-valid token is no longer destroyed by a slow cold start.

Extracts the match into `matchesAuthError()` with a test: definitive rejections purge; login/device-flow/`re-authenticate` prompts do not.

## Not in scope

The underlying **upgrade restart-storm** (rolling `:v2-latest` + 503 startup probe on that pod) is a separate operational issue. This fix stops the *false purge* that turned each restart into a forced re-login.