### PR TITLE
ci(docker): add 'dd' to the long-lived branch set

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Decide push policy
         id: decide
         env:
-          LONG_LIVED: "v2 v3 mk"
+          LONG_LIVED: "v2 v3 mk dd"
           REF_NAME: ${{ github.ref_name }}
           EVENT: ${{ github.event_name }}
         run: |


### PR DESCRIPTION
Adds `dd` to `LONG_LIVED` in the docker workflow so pushes to the **dd** branch build **and push** their `<branch>-latest` image to GHCR — making `dd` selectable in the hub's branch switcher and listed under *Latest available images*, exactly like `v2`/`v3`/`mk`.

`dd` is a standing per-hive dev line for David Diaz's `daviddiaz0317` hive, tracking `v2`. One-line change — the whole workflow derives from this single list. The `dd` branch itself is created off v2 once this merges.