### PR TITLE
feat(hub): propagate hive access grants to heartbeat-only spokes

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1688,6 +1688,17 @@ func main() {
 				logger.Warn("branch switch via heartbeat failed", "tag", tag, "image", image, "error", err)
 				return
 			}
+		}), hub.AuthorizedUsersCallback(func(users []string) {
+			// The hub delivered its authoritative access list. Reconcile our
+			// login allowlist so Manage Access grants take effect on this
+			// heartbeat-only spoke without any kubectl push. The dashboard reads
+			// cfg.Dashboard.AuthorizedUsers live on each login, so updating it in
+			// place is enough. Only log when it actually changes to avoid noise.
+			if !sameStringSlice(cfg.Dashboard.AuthorizedUsers, users) {
+				logger.Info("authorized users updated from hub heartbeat",
+					"was", len(cfg.Dashboard.AuthorizedUsers), "now", len(users))
+				cfg.Dashboard.AuthorizedUsers = users
+			}
 		}))
 
 		go hub.StartTaskStatusPush(ctx, hubURL, func() *hub.TaskStatusPayload {
@@ -2848,6 +2859,20 @@ func initAgentConfigDrivenSystems(cfg *config.Config) {
 }
 
 // inferACMMLevel returns the configured ACMM level, defaulting to L1 (advisory-only).
+// sameStringSlice reports whether two string slices have identical contents in
+// the same order. Used to skip no-op authorized-users updates from heartbeats.
+func sameStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func inferACMMLevel(cfg *config.Config) int {
 	if cfg.ACMMLevel != nil {
 		return *cfg.ACMMLevel

--- a/v2/pkg/hub/authorized_users_heartbeat_test.go
+++ b/v2/pkg/hub/authorized_users_heartbeat_test.go
@@ -1,0 +1,79 @@
+package hub
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// TestAuthorizedUsersForHiveID verifies the hub builds the per-hive access list
+// delivered to spokes via heartbeat: the owner is always included as owner,
+// granted users appear with their role, and a hive with no SaaS record yields
+// nil (so a non-hosted spoke's own allowlist is left untouched).
+func TestAuthorizedUsersForHiveID(t *testing.T) {
+	dir := t.TempDir()
+	origHives, origUsers := saasHivesDir, saasUsersDir
+	saasHivesDir = filepath.Join(dir, "hives")
+	saasUsersDir = filepath.Join(dir, "users")
+	os.MkdirAll(saasHivesDir, 0o755)
+	os.MkdirAll(saasUsersDir, 0o755)
+	t.Cleanup(func() { saasHivesDir, saasUsersDir = origHives, origUsers })
+
+	// No SaaS record -> nil.
+	if got := authorizedUsersForHiveID("hosted-nope"); got != nil {
+		t.Errorf("unknown hive should return nil, got %v", got)
+	}
+
+	// Create a hive owned by "alice".
+	h := &SaaSHive{ID: "hosted-x", Owner: "alice"}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+	// Grant "bob" read-write and "carol" read on that hive.
+	for name, role := range map[string]string{"bob": "read-write", "carol": "read"} {
+		u := ensureSaaSUser(name)
+		u.GitHubUsername = name
+		if u.Hives == nil {
+			u.Hives = map[string]string{}
+		}
+		u.Hives["hosted-x"] = role
+		saveSaaSUser(u)
+	}
+
+	got := authorizedUsersForHiveID("hosted-x")
+	sort.Strings(got)
+	want := []string{"alice:owner", "bob:read-write", "carol:read"}
+	sort.Strings(want)
+	if len(got) != len(want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("entry %d: got %q want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestAuthorizedUsersForHiveID_OwnerNotDuplicated ensures an owner who ALSO has
+// an explicit access record is listed once, as owner.
+func TestAuthorizedUsersForHiveID_OwnerNotDuplicated(t *testing.T) {
+	dir := t.TempDir()
+	origHives, origUsers := saasHivesDir, saasUsersDir
+	saasHivesDir = filepath.Join(dir, "hives")
+	saasUsersDir = filepath.Join(dir, "users")
+	os.MkdirAll(saasHivesDir, 0o755)
+	os.MkdirAll(saasUsersDir, 0o755)
+	t.Cleanup(func() { saasHivesDir, saasUsersDir = origHives, origUsers })
+
+	saveSaaSHive(&SaaSHive{ID: "hosted-y", Owner: "dave"})
+	u := ensureSaaSUser("dave")
+	u.GitHubUsername = "dave"
+	u.Hives = map[string]string{"hosted-y": "owner"}
+	saveSaaSUser(u)
+
+	got := authorizedUsersForHiveID("hosted-y")
+	if len(got) != 1 || got[0] != "dave:owner" {
+		t.Errorf("owner should appear once as owner, got %v", got)
+	}
+}

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -147,6 +147,7 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 	var onHubBanner HubBannerCallback
 	var onVisibility VisibilityCallback
 	var onSwitchBranch SwitchBranchCallback
+	var onAuthorizedUsers AuthorizedUsersCallback
 	for _, cb := range callbacks {
 		switch fn := cb.(type) {
 		case UpgradeCallback:
@@ -159,6 +160,8 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 			onVisibility = fn
 		case SwitchBranchCallback:
 			onSwitchBranch = fn
+		case AuthorizedUsersCallback:
+			onAuthorizedUsers = fn
 		}
 	}
 
@@ -185,6 +188,11 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 		}
 		if resp.IsPublic != nil && onVisibility != nil {
 			onVisibility(*resp.IsPublic)
+		}
+		// A non-nil slice (even empty) is an authoritative replacement of the
+		// spoke's allowlist; nil means the hub sent nothing, leave it alone.
+		if resp.AuthorizedUsers != nil && onAuthorizedUsers != nil {
+			onAuthorizedUsers(resp.AuthorizedUsers)
 		}
 	}
 
@@ -377,6 +385,15 @@ type HeartbeatResponse struct {
 	GitHubAppConfig *HeartbeatGitHubAppConfig `json:"github_app_config,omitempty"`
 	HubBanner       *HubBanner                `json:"hub_banner,omitempty"`
 	IsPublic        *bool                     `json:"is_public,omitempty"`
+	// AuthorizedUsers is the hub's authoritative per-hive access list, as
+	// "username:role" entries. The hub can't reach heartbeat-only spokes (e.g.
+	// vllm-d) over kubectl, and those spokes authorize their own device-flow
+	// logins against a local allowlist — so a grant made in the hub's Manage
+	// Access UI would never reach them. Delivering the list in the heartbeat
+	// response lets the spoke reconcile its allowlist every beat, so access
+	// changes propagate automatically. nil means "hub sent nothing" (leave the
+	// spoke's list unchanged); a non-nil (possibly empty) slice replaces it.
+	AuthorizedUsers []string `json:"authorized_users,omitempty"`
 }
 
 // HubBanner is a message from the hub admin displayed on spoke dashboards.
@@ -397,6 +414,12 @@ type VisibilityCallback func(isPublic bool)
 // heartbeat) to switch its deployment image to a specific tag — used for
 // branch switches on clusters the hub can't reach over kubectl.
 type SwitchBranchCallback func(tag string)
+
+// AuthorizedUsersCallback is called with the hub's authoritative per-hive
+// access list ("username:role" entries) so the spoke can reconcile its
+// device-flow login allowlist with Manage Access grants. Used for
+// heartbeat-only clusters where the hub cannot push config over kubectl.
+type AuthorizedUsersCallback func(users []string)
 
 // GitHubAppConfigCallback is called when the hub delivers GitHub App config
 // via the heartbeat response (app ID, installation ID, private key).

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3149,6 +3149,36 @@ func (s *HubServer) handleLatestSHA(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]string{"sha": getLatestSHA()})
 }
 
+// authorizedUsersForHiveID returns the hub's access list for a hive as
+// "username:role" entries, for delivery to the spoke in its heartbeat response.
+// Returns nil (not an empty slice) when the hive has no SaaS record, so a
+// non-hosted spoke's own allowlist is left untouched. The owner is always
+// included as owner even if no explicit access record names them.
+func authorizedUsersForHiveID(hiveID string) []string {
+	h := loadSaaSHive(hiveID)
+	if h == nil {
+		return nil
+	}
+	out := make([]string, 0, 4)
+	seen := map[string]bool{}
+	if h.Owner != "" {
+		out = append(out, h.Owner+":owner")
+		seen[strings.ToLower(h.Owner)] = true
+	}
+	for _, u := range listAllSaaSUsers() {
+		role, ok := u.Hives[hiveID]
+		if !ok || u.GitHubUsername == "" {
+			continue
+		}
+		if seen[strings.ToLower(u.GitHubUsername)] {
+			continue // owner already added
+		}
+		out = append(out, u.GitHubUsername+":"+role)
+		seen[strings.ToLower(u.GitHubUsername)] = true
+	}
+	return out
+}
+
 func (s *HubServer) handleAccessList(w http.ResponseWriter, r *http.Request) {
 	hiveID := r.PathValue("id")
 	username := s.getAuthUser(r)

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -597,6 +597,14 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		resp.IsPublic = &entry.IsPublic
 	}
 
+	// Deliver the hub's authoritative access list so heartbeat-only spokes
+	// (which authorize their own logins) stay in sync with Manage Access grants.
+	// Only for hives the hub actually has a SaaS record for; a bare non-SaaS
+	// spoke gets nothing and keeps its own configured allowlist.
+	if authUsers := authorizedUsersForHiveID(payload.HiveID); authUsers != nil {
+		resp.AuthorizedUsers = authUsers
+	}
+
 	// Check if the hive should self-upgrade via heartbeat response.
 	//
 	// Three upgrade paths, all controlled by a single toggle:


### PR DESCRIPTION
## Problem

Granting a user access in the hub's **Manage Access** UI **never reached spokes the hub can't `kubectl` to** (e.g. vllm-d). Those spokes authorize their own device-flow logins against a local allowlist (`Dashboard.AuthorizedUsers`), so a hub-side grant left them rejecting the user — `device-flow login rejected: user not authorized for this hive` — until the deployment env was hand-edited. Hit live: `lionelvillard` was granted owner on the `wva` hive but kept getting rejected.

## Fix

Deliver the hub's authoritative access list in the **heartbeat response** (the only channel to those spokes):

- `HeartbeatResponse` gains `AuthorizedUsers` (`[]string` of `"username:role"`).
- Hub populates it from SaaS access records (`authorizedUsersForHiveID`: owner always included, plus granted users, deduped). `nil` for a non-SaaS hive → bare spoke untouched.
- Spoke applies it via `AuthorizedUsersCallback`, reconciling `cfg.Dashboard.AuthorizedUsers` in place (read live on each login), logging only on change.

Manage Access grants now take effect on vllm-d hives within one heartbeat — no kubectl push, no env edit.

## Tests

`authorizedUsersForHiveID`: owner inclusion, granted users with roles, dedup, `nil` for unknown hive. `pkg/hub` + vet pass.

## Follow-up

After deploy I'll verify `lionelvillard` propagates to the wva spoke and can log in.