### PR TITLE
feat(dashboard): read-only Access tab showing authorized users on the spoke

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -36,6 +36,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/config", s.handleConfig)
 	s.mux.HandleFunc("GET /api/config/download", s.handleConfigDownload)
 	s.mux.HandleFunc("GET /api/config/variables", s.handleVariablesList)
+	s.mux.HandleFunc("GET /api/config/authorized-users", s.handleAuthorizedUsersList)
 	s.mux.HandleFunc("PUT /api/config/variables/{name}", s.handleVariableUpsert)
 	s.mux.HandleFunc("DELETE /api/config/variables/{name}", s.handleVariableDelete)
 	s.mux.HandleFunc("GET /api/audit", s.handleAuditLog)
@@ -1894,6 +1895,53 @@ func looksLikeApiKeyValue(v string) bool {
 		return true
 	}
 	return false
+}
+
+// handleAuthorizedUsersList returns the spoke's device-flow login allowlist —
+// the users permitted to sign in to this hive and their roles — READ-ONLY. The
+// list is authoritative on the hub (Manage Access) and propagated to the spoke
+// via heartbeat; it is shown here so an operator can see who has access without
+// editing it on the spoke. The first entry defaults to owner, later entries to
+// read, matching AuthorizedRole's resolution.
+func (s *Server) handleAuthorizedUsersList(w http.ResponseWriter, r *http.Request) {
+	if s.deps == nil || s.deps.Config == nil {
+		jsonResponse(w, map[string]any{"users": []any{}, "enforced": false})
+		return
+	}
+	entries := s.deps.Config.Dashboard.AuthorizedUsers
+	type userView struct {
+		Username string `json:"username"`
+		Role     string `json:"role"`
+	}
+	out := make([]userView, 0, len(entries))
+	for i, e := range entries {
+		e = strings.TrimSpace(e)
+		if e == "" {
+			continue
+		}
+		name, role := e, ""
+		if idx := strings.LastIndex(e, ":"); idx >= 0 {
+			name, role = strings.TrimSpace(e[:idx]), strings.TrimSpace(e[idx+1:])
+		}
+		if name == "" {
+			continue
+		}
+		if role == "" {
+			if i == 0 {
+				role = "owner"
+			} else {
+				role = "read"
+			}
+		}
+		out = append(out, userView{Username: name, Role: role})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Username < out[j].Username })
+	jsonResponse(w, map[string]any{
+		// enforced == this is a direct-route spoke that gates logins by this list
+		// (vllm-d); false means hub-proxied (hive-oke), where nginx gates instead.
+		"users":    out,
+		"enforced": len(entries) > 0,
+	})
 }
 
 // handleVariableUpsert creates or updates a single operator variable via the

--- a/v2/pkg/dashboard/authorized_users_view_test.go
+++ b/v2/pkg/dashboard/authorized_users_view_test.go
@@ -1,0 +1,61 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestAuthorizedUsersListEndpoint verifies the read-only Access endpoint returns
+// the spoke allowlist with resolved roles (first entry = owner default, explicit
+// roles honored, bare names default to read) and the enforced flag.
+func TestAuthorizedUsersListEndpoint(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.Dashboard.AuthorizedUsers = []string{"alice:owner", "bob:read-write", "carol", ""}
+
+	rec := doGet(s, "/api/config/authorized-users")
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Users []struct {
+			Username string `json:"username"`
+			Role     string `json:"role"`
+		} `json:"users"`
+		Enforced bool `json:"enforced"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Enforced {
+		t.Error("enforced should be true when the allowlist is non-empty")
+	}
+	roles := map[string]string{}
+	for _, u := range resp.Users {
+		roles[u.Username] = u.Role
+	}
+	if roles["alice"] != "owner" || roles["bob"] != "read-write" || roles["carol"] != "read" {
+		t.Errorf("unexpected roles: %v", roles)
+	}
+	if len(resp.Users) != 3 { // the empty entry must be skipped
+		t.Errorf("expected 3 users (empty entry skipped), got %d: %v", len(resp.Users), roles)
+	}
+}
+
+// TestAuthorizedUsersListEndpoint_Empty: no allowlist -> enforced false, no users.
+func TestAuthorizedUsersListEndpoint_Empty(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.Dashboard.AuthorizedUsers = nil
+
+	rec := doGet(s, "/api/config/authorized-users")
+	if rec.Code != 200 {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var resp struct {
+		Users    []any `json:"users"`
+		Enforced bool  `json:"enforced"`
+	}
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.Enforced || len(resp.Users) != 0 {
+		t.Errorf("empty allowlist: enforced=%v users=%d", resp.Enforced, len(resp.Users))
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1260,6 +1260,11 @@
     .config-info:hover .config-tooltip { display: block; }
 
     .config-list { margin-bottom: 14px; }
+    /* Role pills for the Access tab (read-only authorized-users view). */
+    .role-badge { display: inline-block; padding: 2px 10px; border-radius: 9999px; font-weight: 600; white-space: nowrap; }
+    .role-owner { background: rgba(244,199,95,0.15); color: var(--amber); border: 1px solid rgba(244,199,95,0.3); }
+    .role-read { background: rgba(128,191,255,0.15); color: var(--blue); border: 1px solid rgba(128,191,255,0.3); }
+    .role-read-write { background: rgba(116,223,154,0.15); color: var(--green); border: 1px solid rgba(116,223,154,0.3); }
     .config-list-item {
       display: flex; align-items: center; gap: 8px;
       padding: 6px 10px; background: var(--bg); border: 1px solid var(--border);
@@ -10936,7 +10941,7 @@ function burnAreaChart() {
 
     const AGENT_CONFIG_TABS = ['General', 'Cadences', 'Pipeline', 'Hooks', 'Restrictions', 'Channels', 'Tools', 'Connections', 'Stats', 'Prompt Template', 'Last Prompt', 'Export'];
     const AGENT_CREATE_TABS = ['Import', 'General', 'Cadences', 'Channels', 'Tools', 'Prompt Template'];
-    const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Hub', 'LiteLLM', 'Variables'];
+    const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Hub', 'LiteLLM', 'Variables', 'Access'];
     const PIPELINE_STAGES = ['resolve-beads', 'track-prs', 'stale-check', 'repo-scan', 'coverage-gate', 'prompt-compose', 'budget-check', 'api-collect', 'final-compose'];
     const PIPELINE_STAGE_TIPS = {
       'resolve-beads': 'Fetch and inject knowledge beads (facts, patterns, gotchas) relevant to the agent\'s current task context.',
@@ -11478,6 +11483,7 @@ function burnAreaChart() {
         case 'Hub': return renderGovHub(d.hub || {});
         case 'LiteLLM': return renderGovLiteLLM(d.litellm || {});
         case 'Variables': return renderGovVariables();
+        case 'Access': return renderGovAccess();
         default: return '';
       }
     }
@@ -11618,6 +11624,52 @@ function burnAreaChart() {
     // variables can be added/edited/deleted here; script and http variables are
     // shown read-only because they can execute code or reach the network and are
     // therefore seed-only (GitOps), enforced server-side.
+    // ── Access tab: read-only view of who can log in to this hive ──
+    // Reads GET /api/config/authorized-users. Access is granted on the HUB
+    // (Manage Access) and propagated to the spoke via heartbeat, so this view is
+    // intentionally read-only — it shows the current allowlist, not an editor.
+    function renderGovAccess() {
+      loadAuthorizedUsers();
+      return `
+        <div style="font-size:0.8rem;color:var(--muted);margin-bottom:10px;line-height:1.5">
+          Users permitted to sign in to this hive, and their roles. Access is managed
+          on the hub's <b>Manage Access</b> screen and syncs here automatically — this
+          view is read-only.
+        </div>
+        <div id="access-users-status" style="font-size:0.72rem;color:var(--muted);margin-bottom:8px"></div>
+        <div id="access-users-list"><div style="color:var(--muted);font-size:0.75rem;padding:4px 0">Loading…</div></div>`;
+    }
+
+    async function loadAuthorizedUsers() {
+      const listEl = document.getElementById('access-users-list');
+      const statusEl = document.getElementById('access-users-status');
+      try {
+        const r = await fetch('/api/config/authorized-users');
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        const d = await r.json();
+        if (statusEl) {
+          statusEl.innerHTML = d.enforced
+            ? 'This hive enforces the allowlist below on sign-in.'
+            : 'Sign-in is gated by the hub proxy; the allowlist below is informational.';
+        }
+        const users = d.users || [];
+        if (!users.length) {
+          listEl.innerHTML = '<div style="color:var(--muted);font-size:0.75rem;padding:4px 0">No authorized users.</div>';
+          return;
+        }
+        listEl.innerHTML = users.map(function(u) {
+          var roleCls = u.role === 'owner' ? 'role-owner' : u.role === 'read-write' ? 'role-read-write' : 'role-read';
+          return '<div class="config-list-item" style="align-items:center;gap:8px">' +
+            '<img src="https://github.com/' + esc(u.username) + '.png" style="width:20px;height:20px;border-radius:50%;vertical-align:middle" onerror="this.style.display=\'none\'">' +
+            '<span style="flex:1;font-size:0.85rem">' + esc(u.username) + '</span>' +
+            '<span class="role-badge ' + roleCls + '" style="font-size:0.7rem">' + esc(u.role) + '</span>' +
+            '</div>';
+        }).join('');
+      } catch (e) {
+        if (listEl) listEl.innerHTML = '<div style="color:var(--muted);font-size:0.75rem">Could not load authorized users.</div>';
+      }
+    }
+
     function renderGovVariables() {
       loadVariables();
       return `


### PR DESCRIPTION
## What

Adds an **Access** tab to the governor config panel that shows the spoke's login allowlist (GitHub username + role) **read-only**.

## Why

Access is granted on the hub's **Manage Access** screen and propagated to heartbeat-only spokes (vllm-d) via the authorized-users heartbeat sync (#1920). Operators looking at a spoke dashboard had no way to see *who* can log in. This surfaces the current allowlist without allowing edits on the spoke (the hub remains authoritative).

## How

- New endpoint `GET /api/config/authorized-users` returns `{users:[{username, role}], enforced}`. Roles resolve exactly as at login: first entry defaults to owner, bare names to read, explicit `name:role` honored, empty entries skipped.
- `enforced` distinguishes direct-route spokes (vllm-d, gate on this list) from hub-proxied (hive-oke, nginx gates).
- Front-end `renderGovAccess`/`loadAuthorizedUsers`: avatars + role pills, escaped output, graceful load/error states.
- Tests: `TestAuthorizedUsersListEndpoint` and `_Empty`.