### PR TITLE
fix(dashboard): surface login failures on the sign-in page

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1396,7 +1396,14 @@ func (s *Server) handleGHUserAuthPoll(w http.ResponseWriter, r *http.Request) {
 			// Audit the denied login with the attempted GitHub username as the
 			// actor so the owner can see WHO tried and was rejected.
 			s.audit.Log(username, "login_denied", auditDetail("reason", "not authorized for this hive"), "")
-			jsonError(w, "your GitHub account is not authorized to access this hive. Contact the hive owner to request access.", http.StatusForbidden)
+			// Return a terminal {status:"error"} the login page understands, not a
+			// bare jsonError — the device-flow poll loop only stops on status
+			// "complete" or "error", so a plain {error} would leave it spinning
+			// "Waiting for authorization…" forever after a denial.
+			jsonResponse(w, map[string]interface{}{
+				"status": "error",
+				"error":  "your GitHub account (" + username + ") is not authorized to access this hive. Contact the hive owner to request access.",
+			})
 			return
 		}
 		role = resolvedRole
@@ -1410,11 +1417,11 @@ func (s *Server) handleGHUserAuthPoll(w http.ResponseWriter, r *http.Request) {
 	if role == config.RoleOwner {
 		tmpTokenPath := userTokenPath + ".tmp"
 		if err := os.WriteFile(tmpTokenPath, []byte(token), 0o600); err != nil {
-			jsonError(w, "failed to save token: "+err.Error(), http.StatusInternalServerError)
+			jsonResponse(w, map[string]interface{}{"status": "error", "error": "failed to save token: " + err.Error()})
 			return
 		}
 		if err := os.Rename(tmpTokenPath, userTokenPath); err != nil {
-			jsonError(w, "failed to persist token: "+err.Error(), http.StatusInternalServerError)
+			jsonResponse(w, map[string]interface{}{"status": "error", "error": "failed to persist token: " + err.Error()})
 			return
 		}
 		if s.deps.SetUserClient != nil {
@@ -1430,7 +1437,7 @@ func (s *Server) handleGHUserAuthPoll(w http.ResponseWriter, r *http.Request) {
 	if s.authToken != "" {
 		sid := s.createUserSession(username, role)
 		if sid == "" {
-			jsonError(w, "failed to create session", http.StatusInternalServerError)
+			jsonResponse(w, map[string]interface{}{"status": "error", "error": "failed to create session"})
 			return
 		}
 		setSessionCookie(w, r, sid)

--- a/v2/pkg/dashboard/login_page_feedback_test.go
+++ b/v2/pkg/dashboard/login_page_feedback_test.go
@@ -1,0 +1,24 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLoginPageSurfacesFailures locks in the fix for the login page silently
+// spinning "Waiting for authorization…" forever after a denied login. The
+// device-flow poll loop must treat a denial (status "error") AND any non-ok
+// HTTP body carrying an error as TERMINAL — otherwise it re-polls indefinitely
+// and the user never learns the login failed.
+func TestLoginPageSurfacesFailures(t *testing.T) {
+	required := []string{
+		"d.status==='error'",                                    // terminal on explicit error status
+		"if(!r.ok||d.error){showError(",                         // terminal on any other error-bearing shape
+		"if(d.status==='pending'){setTimeout(check,ms);return}", // pending re-polls, does not fall through
+	}
+	for _, sub := range required {
+		if !strings.Contains(loginPage, sub) {
+			t.Errorf("login page must contain %q so failed logins are surfaced, not silently re-polled", sub)
+		}
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -718,7 +718,11 @@ async function poll(interval){
       var d=await r.json();
       if(d.status==='complete'){showStep('step-done');setTimeout(function(){location.href='/api/gh-user-auth/session'},1000);return}
       if(d.status==='error'){showError(d.error||'Authorization failed');return}
-      if(d.status==='slow_down'){ms=Math.min(ms+5000,30000)}
+      if(d.status==='slow_down'){ms=Math.min(ms+5000,30000);setTimeout(check,ms);return}
+      if(d.status==='pending'){setTimeout(check,ms);return}
+      // Any other shape is terminal (e.g. an HTTP error body with no status) —
+      // surface it instead of silently polling forever.
+      if(!r.ok||d.error){showError(d.error||('Login failed ('+r.status+')'));return}
       setTimeout(check,ms);
     }catch(e){setTimeout(check,ms)}
   }


### PR DESCRIPTION
## What
The device-flow sign-in page now shows an error when a login is denied, instead of spinning `Waiting for authorization…` forever.

## Why
A user not on a spoke's authorized-users allowlist authorizes on GitHub, then the poll returns a bare `{error:...}` (HTTP 403) with **no `status` field**. The login page's poll loop only reacts to `status==='complete'|'error'`, so it fell through and kept polling — the user saw an endless spinner and no feedback. This is the exact experience of users hitting a hive they aren't authorized for.

## How
- `handleGHUserAuthPoll`: the denial (and the token-save / session-create failure paths) now return `{status:'error', error:...}`. The denial message names the attempted GitHub username.
- Login-page poll loop: `pending`/`slow_down` re-poll; **any** other shape (including a non-ok body carrying an error) is terminal → `showError`. No response shape can leave it spinning.
- `TestLoginPageSurfacesFailures` locks the terminal branches into the served page.