### PR TITLE
fix(auth): hub-proxied hives break when granted an authorized_users allowlist

### DIFF
--- a/v2/pkg/config/authorized_users_test.go
+++ b/v2/pkg/config/authorized_users_test.go
@@ -47,3 +47,29 @@ func TestApplyBootstrapEnv_ConfigListWins(t *testing.T) {
 		t.Fatalf("explicit config list must win over env, got %v", c.Dashboard.AuthorizedUsers)
 	}
 }
+
+// TestIsDirectRouteAuthzEnabled_DecoupledFromHubProxied locks in the fix for
+// hub-proxied hives being wrongly forced into standalone direct-route mode.
+// direct-route authz must be on ONLY for a standalone spoke (allowlist AND not
+// hub-proxied); a hub-proxied hive keeps nginx as its gate even with a list.
+func TestIsDirectRouteAuthzEnabled_DecoupledFromHubProxied(t *testing.T) {
+	cases := []struct {
+		name       string
+		users      []string
+		hubProxied bool
+		want       bool
+	}{
+		{"standalone spoke with allowlist -> direct-route", []string{"clubanderson:owner"}, false, true},
+		{"hub-proxied with allowlist -> NOT direct-route (nginx gates)", []string{"clubanderson:owner", "MikeSpreitzer:read"}, true, false},
+		{"hub-proxied, no allowlist", nil, true, false},
+		{"standalone, no allowlist (misconfigured/hub-proxied)", nil, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := DashboardConfig{AuthorizedUsers: tc.users, HubProxied: tc.hubProxied}
+			if got := d.IsDirectRouteAuthzEnabled(); got != tc.want {
+				t.Errorf("IsDirectRouteAuthzEnabled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -785,9 +785,23 @@ type DashboardConfig struct {
 	// entry is treated as the owner (read-write); the rest are granted viewers
 	// (read-only) unless an explicit "username:role" suffix is given. On the
 	// hub-proxied path, nginx injects X-Hive-User/X-Hive-Role and this list is
-	// not consulted. Empty on hub-proxied hives; populated by provisioning for
-	// hosted hives so direct-route device-flow logins are per-user authorized.
+	// consulted only by the read-only Access tab, NOT for gating logins.
+	// Populated on both hub-proxied hosted hives (for the Access view + hub
+	// Manage Access) and standalone direct-route spokes (for device-flow authz).
 	AuthorizedUsers []string `yaml:"authorized_users"`
+	// HubProxied is true when this hive sits behind the hub's nginx auth-proxy,
+	// which authenticates every request and injects trusted X-Hive-User/X-Hive-Role
+	// headers (hive-oke hosted hives). When true the hive TRUSTS those headers and
+	// keeps the shared-token path enabled even if AuthorizedUsers is non-empty —
+	// nginx is the gate, and the allowlist is informational (Access tab) only.
+	//
+	// When false (the default) a non-empty AuthorizedUsers list means this is a
+	// STANDALONE direct-route spoke with no nginx in front (vllm-d), so it must
+	// strip client-supplied identity headers and enforce per-user device-flow
+	// authz itself. Decoupling these two meanings fixes hub-proxied hives being
+	// wrongly forced into direct-route mode (which broke their dashboard link and
+	// snapshot preview) the moment they were granted an authorized_users list.
+	HubProxied bool `yaml:"hub_proxied"`
 }
 
 // Role strings used for direct-route spoke authorization. These mirror the
@@ -834,11 +848,18 @@ func (d DashboardConfig) AuthorizedRole(username string) (string, bool) {
 	return "", false
 }
 
-// IsDirectRouteAuthzEnabled reports whether this spoke has a per-hive
-// authorized-users allowlist and must therefore enforce per-user authorization
-// on device-flow logins. Hub-proxied hives leave this empty and rely on nginx.
+// IsDirectRouteAuthzEnabled reports whether this hive must enforce per-user
+// authorization on device-flow logins ITSELF because there is no hub nginx in
+// front of it. True only for a STANDALONE spoke: it has an authorized-users
+// allowlist AND is not hub-proxied.
+//
+// A hub-proxied hive (HubProxied=true) can also carry an allowlist — for the
+// read-only Access tab and the hub's Manage Access screen — but nginx is the
+// gate there, so it must NOT flip into direct-route mode (which would strip the
+// trusted X-Hive-User/X-Hive-Role headers nginx injects and disable the shared
+// token, breaking the dashboard link and the snapshot preview).
 func (d DashboardConfig) IsDirectRouteAuthzEnabled() bool {
-	return len(d.AuthorizedUsers) > 0
+	return !d.HubProxied && len(d.AuthorizedUsers) > 0
 }
 
 // splitAuthorizedEntry parses a "username" or "username:role" allowlist entry.

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1058,6 +1058,18 @@ data:
           git_sync: false
     dashboard:
       port: {{.DashboardPort}}
+      # hub_proxied is true ONLY on the nginx-ingress path (hive-oke), where the
+      # hub's auth-proxy (see the auth-url/auth-signin/auth-response-headers
+      # annotations below) authenticates every request and injects trusted
+      # X-Hive-User/X-Hive-Role headers. That keeps the hive from flipping into
+      # standalone direct-route mode when it carries an authorized_users list
+      # (which would strip those headers and disable the shared token, breaking
+      # the dashboard link and the snapshot preview).
+      #
+      # On the OpenShift-Route path (vllm-d) there is NO nginx auth-proxy — the
+      # hive is reached directly — so it stays hub_proxied:false and correctly
+      # enforces per-user device-flow authz itself from authorized_users.
+      hub_proxied: {{.IsNginxIngress}}
     hub:
       enabled: true
       url: https://hive.kubestellar.io


### PR DESCRIPTION
## Symptom
Two hub-proxied hosted hives (kubestellar-console, aslom) broke after being granted an `authorized_users` allowlist:
- Clicking the hive link in the Hive Hub **bounces to `hive.kubestellar.io/dashboard`** instead of opening the hive.
- The read-only `/snapshot` preview renders **every stat as `--`**.

## Root cause
`IsDirectRouteAuthzEnabled()` treated **any** non-empty `authorized_users` list as 'this is a standalone direct-route spoke.' On such a hive the dashboard auth middleware then:
1. **Strips** the trusted `X-Hive-User`/`X-Hive-Role` headers the hub's nginx injects → the user is seen as unauthenticated → bounced to OAuth → lands on the hub. (#1839 behavior)
2. **Disables** the shared/Bearer token → the snapshot builder gets 401 → bakes `render({"error":"unauthorized"})` → `--` everywhere.

But a **hub-proxied** hive (hive-oke) legitimately has nginx in front injecting trusted identity headers; the allowlist there is informational (Access tab / hub Manage Access), not a device-flow gate. Granting access should never have flipped it into direct-route mode.

Confirmed live: the affected hive is hub-proxied (nginx `auth-url`/`auth-signin`/`auth-response-headers` ingress annotations) yet its config carries `authorized_users`, so `IsDirectRouteAuthzEnabled()` wrongly returned true.

## Fix
Add `dashboard.hub_proxied`:
- **true** (nginx path / hive-oke): trust nginx headers, keep the shared-token path even with an allowlist. `IsDirectRouteAuthzEnabled()` returns false.
- **false** (default; OpenShift-Route path / vllm-d): a non-empty allowlist still means standalone direct-route — enforce per-user device-flow authz. Unchanged.

Provisioning sets `hub_proxied: {{.IsNginxIngress}}` from the same conditional that chooses Ingress vs Route, so each hive gets the right value automatically.

**Security:** `hub_proxied` is seed-only — `LoadWithDashboardOverlay` merges only `overlay.Agents`, never `Dashboard` fields, so a writable dashboard overlay cannot forge `hub_proxied:true` to make a standalone spoke trust forged headers.

## Tests
`TestIsDirectRouteAuthzEnabled_DecoupledFromHubProxied` covers all four (allowlist × hub_proxied) combinations.

## Rollout note
Existing hosted hives were provisioned before this flag existed, so their config lacks `hub_proxied`. After merge+deploy, affected hives need `hub_proxied: true` added to their seed config (re-provision or a one-line config patch) to pick up the fix.