### PR TITLE
fix(hub): distinct pill color per ACMM level on My Hives (L2/L3 were identical)

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4117,7 +4117,8 @@ const dashboardHTML = `<!DOCTYPE html>
     .acmm-badge { display: inline-block; padding: 4px 12px; border-radius: 9999px; font-size: 0.7rem; font-weight: 700; white-space: nowrap; cursor: help; }
     .acmm-1 { background: rgba(128,191,255,0.15); color: #80bfff; border: 1px solid rgba(128,191,255,0.3); }
     .acmm-2 { background: rgba(116,223,154,0.15); color: #74df9a; border: 1px solid rgba(116,223,154,0.3); }
-    .acmm-3 { background: rgba(116,223,154,0.15); color: #74df9a; border: 1px solid rgba(116,223,154,0.3); }
+    /* L3 gets its own teal so it is distinct from L2's green (they were both #74df9a). */
+    .acmm-3 { background: rgba(45,212,191,0.15); color: #2dd4bf; border: 1px solid rgba(45,212,191,0.3); }
     .acmm-4 { background: rgba(244,199,95,0.15); color: #f4c75f; border: 1px solid rgba(244,199,95,0.3); }
     .acmm-5 { background: rgba(255,126,126,0.15); color: #ff7e7e; border: 1px solid rgba(255,126,126,0.3); }
     .acmm-6 { background: rgba(180,130,255,0.15); color: #b482ff; border: 1px solid rgba(180,130,255,0.3); }


### PR DESCRIPTION
## What
On the hub's **My Hives** page, L2 Instructed and L3 Measured pills were the same green — `.acmm-2` and `.acmm-3` had a byte-identical CSS rule (`#74df9a`).

## Fix
Give L3 its own teal (`#2dd4bf`) so all six level pills are distinct: L1 blue, L2 green, L3 teal, L4 amber, L5 red, L6 purple.

(Companion to the spoke-dashboard fix #1922, which fixed the same L2/L3 collision there.)