### PR TITLE
feat(agents): import agent definitions & prompts from a GitHub repo, with live opt-in

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/logscrub"
 	"github.com/kubestellar/hive/v2/pkg/notify"
 	"github.com/kubestellar/hive/v2/pkg/policies"
+	"github.com/kubestellar/hive/v2/pkg/promptsrc"
 	"github.com/kubestellar/hive/v2/pkg/proxy"
 	"github.com/kubestellar/hive/v2/pkg/scheduler"
 	"github.com/kubestellar/hive/v2/pkg/snapshot"
@@ -208,6 +209,22 @@ func main() {
 
 	gov := governor.New(cfg.Governor, cfg.EnabledAgents(), logger)
 	sched := scheduler.New(cfg, logger)
+
+	// Wire the GitHub prompt-source resolver so agents may source their kick
+	// prompt from a repo (agent.prompt_source). Fetching reuses the hive's App
+	// token via ghClient and is gated to the seed-only allowlist — the closure
+	// captures cfg so a live config reload updates the allowlist on the next kick.
+	// A nil ghClient must be passed as a nil Fetcher interface (not a typed-nil
+	// *github.Client) so the resolver's nil-fetcher fallback path triggers.
+	var promptFetcher promptsrc.Fetcher
+	if ghClient != nil {
+		promptFetcher = ghClient
+	}
+	sched.SetGitHubPromptResolver(promptsrc.NewResolver(
+		promptFetcher,
+		func(slug string) bool { return cfg.GitHubPromptAllowed(slug) },
+		logger,
+	))
 
 	// Restore sparkline history from disk so it survives container restarts
 	const sparklinePath = "/data/sparkline-history.json"

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/classify"
 	"github.com/kubestellar/hive/v2/pkg/config"
 	"github.com/kubestellar/hive/v2/pkg/dashboard"
+	"github.com/kubestellar/hive/v2/pkg/defsrc"
 	"github.com/kubestellar/hive/v2/pkg/discord"
 	"github.com/kubestellar/hive/v2/pkg/github"
 	"github.com/kubestellar/hive/v2/pkg/governor"
@@ -225,6 +226,24 @@ func main() {
 		func(slug string) bool { return cfg.GitHubPromptAllowed(slug) },
 		logger,
 	))
+
+	// Wire the whole-agent definition_source resolver so agents imported with
+	// "keep linked" re-fetch their portable AgentDefinition from the repo on
+	// reload/kick and re-apply its operator-safe fields (never security/seed-only
+	// fields — see pkg/defsrc). Same seed-only allowlist gate and graceful
+	// fallback as the prompt resolver.
+	var defFetcher defsrc.Fetcher
+	if ghClient != nil {
+		defFetcher = ghClient
+	}
+	definitionResolver := defsrc.NewResolver(
+		defFetcher,
+		func(slug string) bool { return cfg.GitHubDefinitionAllowed(slug) },
+		logger,
+	)
+	// Apply live definitions once at startup so a repo edit made while the hive
+	// was down is reflected before the first kick.
+	defsrc.ApplyToConfig(context.Background(), cfg, definitionResolver, logger)
 
 	// Restore sparkline history from disk so it survives container restarts
 	const sparklinePath = "/data/sparkline-history.json"
@@ -1191,6 +1210,13 @@ func main() {
 			uc.SetRepos(cfg.Project.Repos)
 		}
 		gov.UpdateConfig(cfg.Governor)
+
+		// Re-apply live agent definitions (definition_source) on reload so an
+		// operator's edit to a linked repo propagates. Merges only operator-safe
+		// fields; a fetch failure keeps each agent's baked definition. Runs before
+		// initAgentConfigDrivenSystems so downstream systems see the merged config.
+		defsrc.ApplyToConfig(context.Background(), cfg, definitionResolver, logger)
+
 		initAgentConfigDrivenSystems(cfg)
 
 		// Rebuild GitHub App auth when its identity changed. AppAuth captures

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -110,6 +110,49 @@ func (p *PromptSourceConfig) IsSet() bool {
 	return p != nil && p.Owner != "" && p.Repo != "" && p.Path != ""
 }
 
+// DefinitionSourceConfig describes a GitHub repo location to pull a WHOLE agent
+// definition (the portable AgentDefinition YAML) from, keeping the agent "live"
+// so edits on the repo propagate on the next reload/kick. It is the whole-agent
+// analogue of PromptSourceConfig. Owner/Repo/Path are required; Ref is optional
+// and defaults to the repo's default branch.
+//
+// Security: re-applying a live definition NEVER changes security-sensitive or
+// seed-only fields (the resolver trust policy, token scopes, etc.). Only the
+// operator-safe presentation/behavior fields are merged — see pkg/defsrc for the
+// exact allowed-field boundary. The fetch is gated to the same seed-only repo
+// allowlist as prompt_source (VarSecurityConfig.GitHubPromptAllowlist), so a
+// user-writable dashboard overlay can neither widen the allowlist nor point an
+// agent at an arbitrary repo the App happens to be installed on.
+type DefinitionSourceConfig struct {
+	// Type selects the source kind. Only "github" is currently supported; an
+	// empty type defaults to "github" when a repo is set.
+	Type  string `yaml:"type,omitempty" json:"type,omitempty"`
+	Owner string `yaml:"owner,omitempty" json:"owner,omitempty"`
+	Repo  string `yaml:"repo,omitempty" json:"repo,omitempty"`
+	Path  string `yaml:"path,omitempty" json:"path,omitempty"`
+	Ref   string `yaml:"ref,omitempty" json:"ref,omitempty"`
+	// URL is the human-facing source URL the operator pasted in the import UI
+	// (e.g. the github.com blob URL). Informational only — Owner/Repo/Path/Ref
+	// are authoritative for fetching. Kept so the UI can round-trip it.
+	URL string `yaml:"url,omitempty" json:"url,omitempty"`
+}
+
+// Slug returns the "owner/repo" identifier used for allowlist matching, or ""
+// when owner or repo is unset.
+func (d *DefinitionSourceConfig) Slug() string {
+	if d == nil || d.Owner == "" || d.Repo == "" {
+		return ""
+	}
+	return d.Owner + "/" + d.Repo
+}
+
+// IsSet reports whether this definition source is fully specified (owner, repo,
+// and path all present). A partially-filled source is treated as unset so an
+// agent keeps its baked definition rather than erroring.
+func (d *DefinitionSourceConfig) IsSet() bool {
+	return d != nil && d.Owner != "" && d.Repo != "" && d.Path != ""
+}
+
 // VarDef is one operator-declared variable. `default` uses a pointer so an
 // explicit empty-string default is distinguishable from "no default".
 type VarDef struct {
@@ -297,11 +340,11 @@ type ConnectionConfig struct {
 }
 
 type AgentConfig struct {
-	ID              string `yaml:"id" json:"id,omitempty"`
-	Backend         string `yaml:"backend" json:"backend,omitempty"`
-	Model           string `yaml:"model" json:"model,omitempty"`
-	BeadsDir        string `yaml:"beads_dir" json:"beads_dir,omitempty"`
-	Enabled         bool   `yaml:"enabled" json:"enabled,omitempty"`
+	ID       string `yaml:"id" json:"id,omitempty"`
+	Backend  string `yaml:"backend" json:"backend,omitempty"`
+	Model    string `yaml:"model" json:"model,omitempty"`
+	BeadsDir string `yaml:"beads_dir" json:"beads_dir,omitempty"`
+	Enabled  bool   `yaml:"enabled" json:"enabled,omitempty"`
 	// Paused persists an operator pause across restarts/upgrades. Without
 	// this, every pod restart rebuilt agents un-paused (Go zero value), so
 	// an operator pause was silently undone on the next upgrade.
@@ -315,14 +358,14 @@ type AgentConfig struct {
 	Description     string `yaml:"description" json:"description,omitempty"`
 
 	// Phase 2: config-driven agent behavior fields
-	Role             string              `yaml:"role" json:"role,omitempty"`
-	SortOrder        int                 `yaml:"sort_order" json:"sort_order,omitempty"`
-	Emoji            string              `yaml:"emoji" json:"emoji,omitempty"`
-	Color            string              `yaml:"color" json:"color,omitempty"`
-	Aliases          []string            `yaml:"aliases" json:"aliases,omitempty"`
-	LaneKeywords     []string            `yaml:"lane_keywords" json:"lane_keywords,omitempty"`
-	DetectKeywords   []string            `yaml:"detect_keywords" json:"detect_keywords,omitempty"`
-	KickTemplate     string              `yaml:"kick_template" json:"kick_template,omitempty"`
+	Role           string   `yaml:"role" json:"role,omitempty"`
+	SortOrder      int      `yaml:"sort_order" json:"sort_order,omitempty"`
+	Emoji          string   `yaml:"emoji" json:"emoji,omitempty"`
+	Color          string   `yaml:"color" json:"color,omitempty"`
+	Aliases        []string `yaml:"aliases" json:"aliases,omitempty"`
+	LaneKeywords   []string `yaml:"lane_keywords" json:"lane_keywords,omitempty"`
+	DetectKeywords []string `yaml:"detect_keywords" json:"detect_keywords,omitempty"`
+	KickTemplate   string   `yaml:"kick_template" json:"kick_template,omitempty"`
 	// PromptSource, when set, sources the agent's kick prompt from a GitHub repo
 	// instead of (or in addition to) an inline KickTemplate. It is resolved live
 	// at kick time via the hive's GitHub App token, with graceful fallback to the
@@ -330,15 +373,25 @@ type AgentConfig struct {
 	// dashboard overlay may set this, but the fetch is gated to a seed-only repo
 	// allowlist (see VarSecurityConfig.GitHubPromptAllowlist), so a compromised
 	// overlay cannot read arbitrary repos the App is installed on.
-	PromptSource     *PromptSourceConfig `yaml:"prompt_source,omitempty" json:"prompt_source,omitempty"`
-	IncludeRepos     *bool               `yaml:"include_repos" json:"include_repos,omitempty"`
-	MetricsCollector string              `yaml:"metrics_collector" json:"metrics_collector,omitempty"`
-	BeadRole         string              `yaml:"bead_role" json:"bead_role,omitempty"`
-	StatsDisplay     []StatsDisplayEntry `yaml:"stats_display" json:"stats_display,omitempty"`
-	ACMMLevels       []int               `yaml:"acmm_levels" json:"acmm_levels,omitempty"`
-	Mode             string              `yaml:"mode" json:"mode,omitempty"`
-	OnDemand         bool                `yaml:"on_demand" json:"on_demand,omitempty"`
-	CavemanMode      string              `yaml:"caveman_mode" json:"caveman_mode,omitempty"`
+	PromptSource *PromptSourceConfig `yaml:"prompt_source,omitempty" json:"prompt_source,omitempty"`
+	// DefinitionSource, when set, keeps the WHOLE agent linked to a GitHub repo:
+	// the portable AgentDefinition YAML at owner/repo/path@ref is re-fetched on
+	// reload and its operator-safe fields are merged over the baked agent, so
+	// edits on the repo propagate without a redeploy. It never overrides
+	// security-sensitive/seed-only fields (see pkg/defsrc for the field boundary)
+	// and is gated to the same seed-only repo allowlist as PromptSource, so a
+	// user-writable overlay can neither widen the allowlist nor escalate an
+	// agent's privileges via a live definition. On fetch failure the last-known-good
+	// baked definition is kept — a live agent is never blanked or crashed.
+	DefinitionSource *DefinitionSourceConfig `yaml:"definition_source,omitempty" json:"definition_source,omitempty"`
+	IncludeRepos     *bool                   `yaml:"include_repos" json:"include_repos,omitempty"`
+	MetricsCollector string                  `yaml:"metrics_collector" json:"metrics_collector,omitempty"`
+	BeadRole         string                  `yaml:"bead_role" json:"bead_role,omitempty"`
+	StatsDisplay     []StatsDisplayEntry     `yaml:"stats_display" json:"stats_display,omitempty"`
+	ACMMLevels       []int                   `yaml:"acmm_levels" json:"acmm_levels,omitempty"`
+	Mode             string                  `yaml:"mode" json:"mode,omitempty"`
+	OnDemand         bool                    `yaml:"on_demand" json:"on_demand,omitempty"`
+	CavemanMode      string                  `yaml:"caveman_mode" json:"caveman_mode,omitempty"`
 
 	// Channels declares how this agent gets triggered (kick, webhook, discord, schedule, bead).
 	// When nil/empty, the agent uses governor timer kicks by default (implicit kick channel).
@@ -1280,6 +1333,18 @@ func (c *Config) GitHubPromptAllowed(slug string) bool {
 		}
 	}
 	return false
+}
+
+// GitHubDefinitionAllowed reports whether an agent's definition_source pointing
+// at the given "owner/repo" slug is permitted to be fetched. A live whole-agent
+// definition is at least as trusted as a live prompt (it re-applies more fields),
+// so it reuses the SAME seed-only gate as GitHubPromptAllowed: the feature flag
+// and repo allowlist come only from the trusted config seed, never the
+// user-writable dashboard overlay (LoadWithDashboardOverlay never merges the
+// overlay's Variables block). A compromised overlay therefore can neither widen
+// the set of readable repos nor point a live definition at an arbitrary repo.
+func (c *Config) GitHubDefinitionAllowed(slug string) bool {
+	return c.GitHubPromptAllowed(slug)
 }
 
 const (

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -66,6 +66,48 @@ type VarSecurityConfig struct {
 	HTTPAllowlist []string `yaml:"http_allowlist,omitempty"`
 	ExecTimeoutS  int      `yaml:"exec_timeout_s,omitempty"`
 	HTTPTimeoutS  int      `yaml:"http_timeout_s,omitempty"`
+
+	// AllowGitHubPrompt gates the GitHub-repo prompt-source feature (agents may
+	// source their kick prompt from a repo). Like AllowExec/AllowHTTP it is honored
+	// ONLY from the trusted config seed — the dashboard overlay's Security block is
+	// discarded on load, so a user-editable overlay can never enable this or widen
+	// the allowlist. Default false (deny).
+	AllowGitHubPrompt bool `yaml:"allow_github_prompt,omitempty"`
+	// GitHubPromptAllowlist is the set of "owner/repo" slugs an agent's
+	// prompt_source may read from. Required (non-empty) for the feature to work:
+	// an empty allowlist denies all repos even when AllowGitHubPrompt is true. This
+	// bounds the blast radius to repos the operator explicitly trusts, so the
+	// feature cannot be used to read every repo the App happens to be installed on.
+	GitHubPromptAllowlist []string `yaml:"github_prompt_allowlist,omitempty"`
+}
+
+// PromptSourceConfig describes a GitHub repo location to pull an agent's kick
+// prompt from. Owner/Repo/Path are required; Ref (branch/tag/SHA) is optional
+// and defaults to the repo's default branch.
+type PromptSourceConfig struct {
+	// Type selects the source kind. Only "github" is currently supported; an
+	// empty type defaults to "github" when a repo is set.
+	Type  string `yaml:"type,omitempty" json:"type,omitempty"`
+	Owner string `yaml:"owner,omitempty" json:"owner,omitempty"`
+	Repo  string `yaml:"repo,omitempty" json:"repo,omitempty"`
+	Path  string `yaml:"path,omitempty" json:"path,omitempty"`
+	Ref   string `yaml:"ref,omitempty" json:"ref,omitempty"`
+}
+
+// Slug returns the "owner/repo" identifier used for allowlist matching, or ""
+// when owner or repo is unset.
+func (p *PromptSourceConfig) Slug() string {
+	if p == nil || p.Owner == "" || p.Repo == "" {
+		return ""
+	}
+	return p.Owner + "/" + p.Repo
+}
+
+// IsSet reports whether this prompt source is fully specified (owner, repo, and
+// path all present). A partially-filled source is treated as unset so a kick
+// falls back to the inline template rather than erroring.
+func (p *PromptSourceConfig) IsSet() bool {
+	return p != nil && p.Owner != "" && p.Repo != "" && p.Path != ""
 }
 
 // VarDef is one operator-declared variable. `default` uses a pointer so an
@@ -281,6 +323,14 @@ type AgentConfig struct {
 	LaneKeywords     []string            `yaml:"lane_keywords" json:"lane_keywords,omitempty"`
 	DetectKeywords   []string            `yaml:"detect_keywords" json:"detect_keywords,omitempty"`
 	KickTemplate     string              `yaml:"kick_template" json:"kick_template,omitempty"`
+	// PromptSource, when set, sources the agent's kick prompt from a GitHub repo
+	// instead of (or in addition to) an inline KickTemplate. It is resolved live
+	// at kick time via the hive's GitHub App token, with graceful fallback to the
+	// baked/inline template when the repo is unreachable. The user-writable
+	// dashboard overlay may set this, but the fetch is gated to a seed-only repo
+	// allowlist (see VarSecurityConfig.GitHubPromptAllowlist), so a compromised
+	// overlay cannot read arbitrary repos the App is installed on.
+	PromptSource     *PromptSourceConfig `yaml:"prompt_source,omitempty" json:"prompt_source,omitempty"`
 	IncludeRepos     *bool               `yaml:"include_repos" json:"include_repos,omitempty"`
 	MetricsCollector string              `yaml:"metrics_collector" json:"metrics_collector,omitempty"`
 	BeadRole         string              `yaml:"bead_role" json:"bead_role,omitempty"`
@@ -1211,6 +1261,25 @@ func (c *Config) ResolveRegistry(logger *slog.Logger) *resolve.Registry {
 	}
 	specs, pol := c.Variables.toResolveSpecs()
 	return resolve.Build(specs, pol, logger)
+}
+
+// GitHubPromptAllowed reports whether an agent's prompt_source pointing at the
+// given "owner/repo" slug is permitted to be fetched. This mirrors the seed-only
+// gating used for exec/http resolvers: it consults c.Variables.Security, which
+// LoadWithDashboardOverlay guarantees comes ONLY from the trusted config seed
+// (the dashboard overlay's Variables block is never merged). It returns false
+// unless the feature is explicitly enabled AND the slug is on the seed-declared
+// allowlist, so a user-writable overlay can never widen the set of readable repos.
+func (c *Config) GitHubPromptAllowed(slug string) bool {
+	if slug == "" || !c.Variables.Security.AllowGitHubPrompt {
+		return false
+	}
+	for _, allowed := range c.Variables.Security.GitHubPromptAllowlist {
+		if strings.EqualFold(strings.TrimSpace(allowed), slug) {
+			return true
+		}
+	}
+	return false
 }
 
 const (

--- a/v2/pkg/config/definition_source_test.go
+++ b/v2/pkg/config/definition_source_test.go
@@ -1,0 +1,137 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestDefinitionSourceConfig_IsSet(t *testing.T) {
+	cases := []struct {
+		name string
+		ds   *DefinitionSourceConfig
+		want bool
+	}{
+		{"nil", nil, false},
+		{"empty", &DefinitionSourceConfig{}, false},
+		{"owner only", &DefinitionSourceConfig{Owner: "o"}, false},
+		{"owner+repo", &DefinitionSourceConfig{Owner: "o", Repo: "r"}, false},
+		{"full without ref", &DefinitionSourceConfig{Owner: "o", Repo: "r", Path: "a.yaml"}, true},
+		{"full with ref", &DefinitionSourceConfig{Owner: "o", Repo: "r", Path: "a.yaml", Ref: "main"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.ds.IsSet(); got != tc.want {
+				t.Errorf("IsSet() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDefinitionSourceConfig_Slug(t *testing.T) {
+	if (*DefinitionSourceConfig)(nil).Slug() != "" {
+		t.Error("nil slug should be empty")
+	}
+	if s := (&DefinitionSourceConfig{Owner: "kubestellar", Repo: "hive"}).Slug(); s != "kubestellar/hive" {
+		t.Errorf("slug = %q", s)
+	}
+}
+
+// TestGitHubDefinitionAllowed_ReusesPromptGate: the definition gate reuses the
+// exact seed-only prompt allowlist, so enabling/allowing behaves identically.
+func TestGitHubDefinitionAllowed_ReusesPromptGate(t *testing.T) {
+	cfg := &Config{Variables: VariablesConfig{Security: VarSecurityConfig{
+		AllowGitHubPrompt:     true,
+		GitHubPromptAllowlist: []string{"kubestellar/hive"},
+	}}}
+	if !cfg.GitHubDefinitionAllowed("kubestellar/hive") {
+		t.Error("allowlisted repo should be permitted")
+	}
+	if cfg.GitHubDefinitionAllowed("attacker/evil") {
+		t.Error("non-allowlisted repo must be denied")
+	}
+	// Feature flag off → deny even an allowlisted repo.
+	cfg.Variables.Security.AllowGitHubPrompt = false
+	if cfg.GitHubDefinitionAllowed("kubestellar/hive") {
+		t.Error("feature disabled must deny all")
+	}
+}
+
+// TestDefinitionSource_OverlayCannotWidenAllowlist asserts the security
+// invariant end-to-end through LoadWithDashboardOverlay: a user-writable overlay
+// that tries to (a) enable the feature / widen the allowlist and (b) point an
+// agent's definition_source at a non-allowlisted repo cannot do either. The
+// overlay's Variables block is never merged, so the seed policy stands and the
+// malicious repo stays denied.
+func TestDefinitionSource_OverlayCannotWidenAllowlist(t *testing.T) {
+	t.Setenv("KUBERNETES_SERVICE_HOST", "1.2.3.4") // force IsKubernetesPod() true
+
+	dir := t.TempDir()
+	seedPath := filepath.Join(dir, "hive.yaml")
+	// Seed: feature OFF, empty allowlist.
+	seed := `
+project:
+  org: kubestellar
+  repos: [hive]
+  primary_repo: hive
+github:
+  token: test-token
+agents:
+  scanner:
+    backend: copilot
+variables:
+  security:
+    allow_github_prompt: false
+`
+	if err := os.WriteFile(seedPath, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Overlay tries to enable the feature, widen the allowlist, AND link scanner
+	// to an attacker repo.
+	overlayPath := filepath.Join(dir, "hive.yaml.dashboard")
+	overlay := Config{
+		Project: ProjectConfig{Org: "kubestellar", Repos: []string{"hive"}, PrimaryRepo: "hive"},
+		Variables: VariablesConfig{Security: VarSecurityConfig{
+			AllowGitHubPrompt:     true,
+			GitHubPromptAllowlist: []string{"attacker/evil"},
+		}},
+		Agents: map[string]AgentConfig{
+			"scanner": {
+				Backend:          "copilot",
+				DefinitionSource: &DefinitionSourceConfig{Owner: "attacker", Repo: "evil", Path: "agent.yaml"},
+			},
+		},
+	}
+	data, err := yaml.Marshal(&overlay)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(overlayPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Point DashboardOverlayFile at our temp overlay.
+	orig := DashboardOverlayFile
+	DashboardOverlayFile = overlayPath
+	defer func() { DashboardOverlayFile = orig }()
+
+	cfg, err := LoadWithDashboardOverlay(seedPath)
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+
+	// The overlay's agent (definition_source pointer) IS merged — that's fine, the
+	// pointer alone is inert. What must NOT happen is the policy widening.
+	if cfg.Variables.Security.AllowGitHubPrompt {
+		t.Error("overlay must not enable allow_github_prompt (seed-only invariant)")
+	}
+	if cfg.GitHubDefinitionAllowed("attacker/evil") {
+		t.Error("overlay must not be able to allowlist attacker/evil; definition fetch must stay denied")
+	}
+	if cfg.GitHubPromptAllowed("attacker/evil") {
+		t.Error("overlay must not be able to allowlist attacker/evil for prompts either")
+	}
+}

--- a/v2/pkg/config/prompt_source_test.go
+++ b/v2/pkg/config/prompt_source_test.go
@@ -1,0 +1,117 @@
+package config
+
+import "testing"
+
+func TestPromptSourceConfig_IsSet(t *testing.T) {
+	cases := []struct {
+		name string
+		ps   *PromptSourceConfig
+		want bool
+	}{
+		{"nil", nil, false},
+		{"empty", &PromptSourceConfig{}, false},
+		{"owner only", &PromptSourceConfig{Owner: "o"}, false},
+		{"owner+repo", &PromptSourceConfig{Owner: "o", Repo: "r"}, false},
+		{"full without ref", &PromptSourceConfig{Owner: "o", Repo: "r", Path: "p.md"}, true},
+		{"full with ref", &PromptSourceConfig{Owner: "o", Repo: "r", Path: "p.md", Ref: "main"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.ps.IsSet(); got != tc.want {
+				t.Errorf("IsSet() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPromptSourceConfig_Slug(t *testing.T) {
+	if (*PromptSourceConfig)(nil).Slug() != "" {
+		t.Error("nil slug should be empty")
+	}
+	if s := (&PromptSourceConfig{Owner: "o"}).Slug(); s != "" {
+		t.Errorf("partial slug should be empty, got %q", s)
+	}
+	if s := (&PromptSourceConfig{Owner: "kubestellar", Repo: "hive"}).Slug(); s != "kubestellar/hive" {
+		t.Errorf("slug = %q", s)
+	}
+}
+
+func TestGitHubPromptAllowed(t *testing.T) {
+	cases := []struct {
+		name     string
+		security VarSecurityConfig
+		slug     string
+		want     bool
+	}{
+		{
+			name:     "disabled by default",
+			security: VarSecurityConfig{GitHubPromptAllowlist: []string{"kubestellar/hive"}},
+			slug:     "kubestellar/hive",
+			want:     false, // AllowGitHubPrompt is false
+		},
+		{
+			name:     "enabled but empty allowlist denies all",
+			security: VarSecurityConfig{AllowGitHubPrompt: true},
+			slug:     "kubestellar/hive",
+			want:     false,
+		},
+		{
+			name:     "enabled and allowlisted",
+			security: VarSecurityConfig{AllowGitHubPrompt: true, GitHubPromptAllowlist: []string{"kubestellar/hive"}},
+			slug:     "kubestellar/hive",
+			want:     true,
+		},
+		{
+			name:     "enabled but slug not on allowlist",
+			security: VarSecurityConfig{AllowGitHubPrompt: true, GitHubPromptAllowlist: []string{"kubestellar/docs"}},
+			slug:     "kubestellar/hive",
+			want:     false,
+		},
+		{
+			name:     "case-insensitive + whitespace-tolerant match",
+			security: VarSecurityConfig{AllowGitHubPrompt: true, GitHubPromptAllowlist: []string{"  KubeStellar/Hive  "}},
+			slug:     "kubestellar/hive",
+			want:     true,
+		},
+		{
+			name:     "empty slug denied",
+			security: VarSecurityConfig{AllowGitHubPrompt: true, GitHubPromptAllowlist: []string{"kubestellar/hive"}},
+			slug:     "",
+			want:     false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{Variables: VariablesConfig{Security: tc.security}}
+			if got := cfg.GitHubPromptAllowed(tc.slug); got != tc.want {
+				t.Errorf("GitHubPromptAllowed(%q) = %v, want %v", tc.slug, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGitHubPromptAllowlist_SeedOnly documents the security invariant: the
+// dashboard overlay's Variables block is never merged, so an overlay cannot
+// enable or widen the GitHub-prompt allowlist. LoadWithDashboardOverlay merges
+// only Agents, leaving cfg.Variables (and thus the policy) as the seed loaded it.
+// This test asserts the merge helper it uses (MergeAgentOverrides) does not touch
+// Variables.
+func TestGitHubPromptAllowlist_SeedOnly(t *testing.T) {
+	seed := &Config{
+		Variables: VariablesConfig{Security: VarSecurityConfig{
+			AllowGitHubPrompt:     false,
+			GitHubPromptAllowlist: nil,
+		}},
+		Agents: map[string]AgentConfig{"scanner": {name: "scanner"}},
+	}
+	// An overlay that tries to enable the feature — its Variables must be ignored.
+	overlayAgents := map[string]AgentConfig{
+		"scanner": {PromptSource: &PromptSourceConfig{Owner: "attacker", Repo: "evil", Path: "x.md"}},
+	}
+	seed.MergeAgentOverrides(overlayAgents)
+
+	// The policy is untouched: the malicious source's repo is still denied.
+	if seed.GitHubPromptAllowed("attacker/evil") {
+		t.Error("overlay must not be able to enable/allow a repo (seed-only invariant)")
+	}
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1660,28 +1660,29 @@ func (s *Server) handleAgentConfigGet(w http.ResponseWriter, r *http.Request) {
 
 	jsonResponse(w, map[string]interface{}{
 		"general": map[string]interface{}{
-			"launchCmd":       launchCmd,
-			"displayName":     displayName,
-			"description":     agentCfg.Description,
-			"cliPinned":       agentCfg.CLIPinned || proc.PinnedCLI != "",
-			"cliPinValue":     cli,
-			"staleTimeout":    staleTimeout,
-			"restartStrategy": restartStrategy,
-			"model":           model,
-			"clearOnKick":     agentCfg.ClearOnKick,
-			"emoji":           agentCfg.Emoji,
-			"color":           agentCfg.Color,
-			"sortOrder":       agentCfg.SortOrder,
-			"beadRole":        agentCfg.BeadRole,
-			"role":            agentCfg.Role,
-			"kickTemplate":    agentCfg.KickTemplate,
-			"promptSource":    agentCfg.PromptSource,
-			"mode":            agentCfg.Mode,
-			"includeRepos":    includeRepos,
-			"laneKeywords":    agentCfg.LaneKeywords,
-			"detectKeywords":  agentCfg.DetectKeywords,
-			"aliases":         agentCfg.Aliases,
-			"cavemanMode":     agentCfg.CavemanMode,
+			"launchCmd":        launchCmd,
+			"displayName":      displayName,
+			"description":      agentCfg.Description,
+			"cliPinned":        agentCfg.CLIPinned || proc.PinnedCLI != "",
+			"cliPinValue":      cli,
+			"staleTimeout":     staleTimeout,
+			"restartStrategy":  restartStrategy,
+			"model":            model,
+			"clearOnKick":      agentCfg.ClearOnKick,
+			"emoji":            agentCfg.Emoji,
+			"color":            agentCfg.Color,
+			"sortOrder":        agentCfg.SortOrder,
+			"beadRole":         agentCfg.BeadRole,
+			"role":             agentCfg.Role,
+			"kickTemplate":     agentCfg.KickTemplate,
+			"promptSource":     agentCfg.PromptSource,
+			"definitionSource": agentCfg.DefinitionSource,
+			"mode":             agentCfg.Mode,
+			"includeRepos":     includeRepos,
+			"laneKeywords":     agentCfg.LaneKeywords,
+			"detectKeywords":   agentCfg.DetectKeywords,
+			"aliases":          agentCfg.Aliases,
+			"cavemanMode":      agentCfg.CavemanMode,
 		},
 		"cadences":       cadences,
 		"models":         models,
@@ -2295,6 +2296,33 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 			}
 		}
 	}
+	// definitionSource: a nested {owner,repo,path,ref,url} object (or explicit
+	// null to clear) keeping the whole agent linked to a repo. When set, validate
+	// against the seed-only allowlist so a non-allowlisted repo is rejected here
+	// rather than silently ignored at reload. The actual re-apply happens on the
+	// reload path (resolveDefinitionSources); this handler only persists the pointer.
+	if v, ok := body["definitionSource"]; ok {
+		if v == nil {
+			agentCfg.DefinitionSource = nil
+		} else if m, ok := v.(map[string]interface{}); ok {
+			ds := &config.DefinitionSourceConfig{
+				Type:  "github",
+				Owner: sanitizeString(stringField(m, "owner")),
+				Repo:  sanitizeString(stringField(m, "repo")),
+				Path:  sanitizeString(stringField(m, "path")),
+				Ref:   sanitizeString(stringField(m, "ref")),
+				URL:   sanitizeString(stringField(m, "url")),
+			}
+			if !ds.IsSet() {
+				agentCfg.DefinitionSource = nil
+			} else if !s.deps.Config.GitHubDefinitionAllowed(ds.Slug()) {
+				jsonError(w, fmt.Sprintf("definition source: repo %q is not on the GitHub definition allowlist", ds.Slug()), http.StatusBadRequest)
+				return
+			} else {
+				agentCfg.DefinitionSource = ds
+			}
+		}
+	}
 
 	s.deps.Config.Agents[name] = agentCfg
 
@@ -2698,15 +2726,71 @@ func (s *Server) handleAgentPromptSave(w http.ResponseWriter, r *http.Request) {
 
 	var body struct {
 		Template string `json:"template"`
+		// PromptSource + KeepLinked let the Prompt Template tab import the kick
+		// prompt from a GitHub repo. When PromptSource is set:
+		//   - KeepLinked=true  → persist prompt_source (live: resolved at kick time)
+		//   - KeepLinked=false → FetchOnce + bake into the template file, and CLEAR
+		//     any existing prompt_source so the prompt is a plain, unlinked copy.
+		// When PromptSource is nil this behaves exactly as before (save inline text).
+		PromptSource *struct {
+			Owner string `json:"owner"`
+			Repo  string `json:"repo"`
+			Path  string `json:"path"`
+			Ref   string `json:"ref"`
+		} `json:"promptSource"`
+		KeepLinked bool `json:"keepLinked"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body: "+err.Error(), http.StatusBadRequest)
 		return
 	}
 
+	agentCfg := s.deps.Config.Agents[name]
+
+	// Repo-sourced prompt import (Prompt Template tab).
+	if body.PromptSource != nil {
+		ps := &config.PromptSourceConfig{
+			Type:  "github",
+			Owner: sanitizeString(body.PromptSource.Owner),
+			Repo:  sanitizeString(body.PromptSource.Repo),
+			Path:  sanitizeString(body.PromptSource.Path),
+			Ref:   sanitizeString(body.PromptSource.Ref),
+		}
+		if !ps.IsSet() {
+			jsonError(w, "prompt source: owner, repo, and path are all required", http.StatusBadRequest)
+			return
+		}
+		agentCfg.PromptSource = ps
+		// bakePromptSource validates against the seed-only allowlist (rejecting a
+		// non-allowlisted repo server-side), fetches once, writes the baked prompt
+		// to the template file, and repoints KickTemplate.
+		if err := s.bakePromptSource(r.Context(), name, &agentCfg); err != nil {
+			jsonError(w, "prompt source: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if !body.KeepLinked {
+			// Bake-only: the prompt is now a plain copy on disk; drop the live link.
+			agentCfg.PromptSource = nil
+		}
+		s.deps.Config.Agents[name] = agentCfg
+		if err := s.saveConfig(); err != nil {
+			s.logger.Error("failed to persist config after prompt import", "agent", name, "error", err)
+		}
+		if agentsDir := s.deps.Config.Data.AgentsDir; agentsDir != "" {
+			if err := config.SaveAgentFile(agentsDir, name, agentCfg); err != nil {
+				s.logger.Error("failed to persist agent overlay after prompt import", "agent", name, "error", err)
+			}
+		}
+		s.refreshAndPersist()
+		s.auditFromRequest(r, "config_agent_prompt", auditDetail("section", "prompt"), name)
+		s.logger.Info("prompt imported from repo", "agent", name, "linked", body.KeepLinked)
+		okResponse(w, map[string]string{"status": "imported", "agent": name, "kickTemplate": agentCfg.KickTemplate})
+		return
+	}
+
 	templateFileName := name + ".md"
-	if ac, ok := s.deps.Config.Agents[name]; ok && ac.KickTemplate != "" {
-		templateFileName = ac.KickTemplate
+	if agentCfg.KickTemplate != "" {
+		templateFileName = agentCfg.KickTemplate
 	}
 
 	if err := os.MkdirAll(promptTemplateSaveDir, 0o755); err != nil {
@@ -2720,7 +2804,6 @@ func (s *Server) handleAgentPromptSave(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Point the agent's KickTemplate to the saved file
-	agentCfg := s.deps.Config.Agents[name]
 	agentCfg.KickTemplate = templateFileName
 	s.deps.Config.Agents[name] = agentCfg
 

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -358,6 +358,17 @@ func sanitizeString(s string) string {
 	return s
 }
 
+// stringField extracts a string value from a decoded JSON object, returning ""
+// when the key is missing or not a string.
+func stringField(m map[string]interface{}, key string) string {
+	if v, ok := m[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
 var envVarEscapePattern = regexp.MustCompile(`\$\{[^}]*\}`)
 
 var tokenRedactor = regexp.MustCompile(`(ghp_|gho_|ghs_|github_pat_)[A-Za-z0-9_]{10,}`)
@@ -1664,6 +1675,7 @@ func (s *Server) handleAgentConfigGet(w http.ResponseWriter, r *http.Request) {
 			"beadRole":        agentCfg.BeadRole,
 			"role":            agentCfg.Role,
 			"kickTemplate":    agentCfg.KickTemplate,
+			"promptSource":    agentCfg.PromptSource,
 			"mode":            agentCfg.Mode,
 			"includeRepos":    includeRepos,
 			"laneKeywords":    agentCfg.LaneKeywords,
@@ -2256,6 +2268,34 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 			agentCfg.CavemanMode = s
 		}
 	}
+	// promptSource: a nested {owner,repo,path,ref} object (or explicit null to
+	// clear). When set, validate against the seed-only allowlist and re-bake so
+	// the agent has a fresh last-known-good prompt on disk.
+	if v, ok := body["promptSource"]; ok {
+		if v == nil {
+			agentCfg.PromptSource = nil
+		} else if m, ok := v.(map[string]interface{}); ok {
+			ps := &config.PromptSourceConfig{
+				Type:  "github",
+				Owner: sanitizeString(stringField(m, "owner")),
+				Repo:  sanitizeString(stringField(m, "repo")),
+				Path:  sanitizeString(stringField(m, "path")),
+				Ref:   sanitizeString(stringField(m, "ref")),
+			}
+			if !ps.IsSet() {
+				// Partially filled → treat as cleared rather than erroring, so an
+				// operator can blank the fields to disable the source.
+				agentCfg.PromptSource = nil
+			} else {
+				agentCfg.PromptSource = ps
+				if err := s.bakePromptSource(r.Context(), name, &agentCfg); err != nil {
+					jsonError(w, "prompt source: "+err.Error(), http.StatusBadRequest)
+					return
+				}
+			}
+		}
+	}
+
 	s.deps.Config.Agents[name] = agentCfg
 
 	// Sync the updated config into the agent process so that status builders

--- a/v2/pkg/dashboard/api_agents.go
+++ b/v2/pkg/dashboard/api_agents.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
-	"gopkg.in/yaml.v3"
-
 	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/defsrc"
 	"github.com/kubestellar/hive/v2/pkg/promptsrc"
 )
 
@@ -47,8 +48,8 @@ func (s *Server) handleAgentsList(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleAgentCreate(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		Name        string              `json:"name"`
-		Agent       config.AgentConfig  `json:"agent"`
+		Name  string             `json:"name"`
+		Agent config.AgentConfig `json:"agent"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body: "+err.Error(), http.StatusBadRequest)
@@ -143,42 +144,12 @@ func (s *Server) handleAgentDelete(w http.ResponseWriter, r *http.Request) {
 }
 
 // agentDefinition is the portable YAML format for importing/exporting agents.
-type agentDefinition struct {
-	APIVersion string                 `yaml:"apiVersion" json:"apiVersion"`
-	Kind       string                 `yaml:"kind" json:"kind"`
-	Metadata   agentDefinitionMeta    `yaml:"metadata" json:"metadata"`
-	Spec       agentDefinitionSpec    `yaml:"spec" json:"spec"`
-}
-
-type agentDefinitionMeta struct {
-	Name        string `yaml:"name" json:"name"`
-	DisplayName string `yaml:"displayName,omitempty" json:"displayName,omitempty"`
-	Description string `yaml:"description,omitempty" json:"description,omitempty"`
-	Emoji       string `yaml:"emoji,omitempty" json:"emoji,omitempty"`
-	Color       string `yaml:"color,omitempty" json:"color,omitempty"`
-	SpecVersion int    `yaml:"specVersion,omitempty" json:"specVersion,omitempty"`
-}
-
-type agentDefinitionSpec struct {
-	Backend         string                    `yaml:"backend,omitempty" json:"backend,omitempty"`
-	Model           string                    `yaml:"model,omitempty" json:"model,omitempty"`
-	Role            string                    `yaml:"role,omitempty" json:"role,omitempty"`
-	Mode            string                    `yaml:"mode,omitempty" json:"mode,omitempty"`
-	SortOrder       int                       `yaml:"sortOrder,omitempty" json:"sortOrder,omitempty"`
-	BeadRole        string                    `yaml:"beadRole,omitempty" json:"beadRole,omitempty"`
-	StaleTimeout    int                       `yaml:"staleTimeout,omitempty" json:"staleTimeout,omitempty"`
-	RestartStrategy string                    `yaml:"restartStrategy,omitempty" json:"restartStrategy,omitempty"`
-	ClearOnKick     bool                      `yaml:"clearOnKick,omitempty" json:"clearOnKick,omitempty"`
-	IncludeRepos    bool                      `yaml:"includeRepos,omitempty" json:"includeRepos,omitempty"`
-	LaneKeywords    []string                  `yaml:"laneKeywords,omitempty" json:"laneKeywords,omitempty"`
-	DetectKeywords  []string                  `yaml:"detectKeywords,omitempty" json:"detectKeywords,omitempty"`
-	Aliases         []string                  `yaml:"aliases,omitempty" json:"aliases,omitempty"`
-	Cadences        map[string]string         `yaml:"cadences,omitempty" json:"cadences,omitempty"`
-	PromptTemplate  string                    `yaml:"promptTemplate,omitempty" json:"promptTemplate,omitempty"`
-	Channels        []config.ChannelConfig    `yaml:"channels,omitempty" json:"channels,omitempty"`
-	Tools           *config.ToolsConfig       `yaml:"tools,omitempty" json:"tools,omitempty"`
-	Connections     []config.ConnectionConfig `yaml:"connections,omitempty" json:"connections,omitempty"`
-}
+// It is defined in pkg/defsrc (shared with the live definition_source resolver)
+// so the whole-agent import and the "keep linked" re-apply path parse and map
+// identically.
+type agentDefinition = defsrc.AgentDefinition
+type agentDefinitionMeta = defsrc.AgentDefinitionMeta
+type agentDefinitionSpec = defsrc.AgentDefinitionSpec
 
 const (
 	importMaxURLLen     = 2048
@@ -186,12 +157,49 @@ const (
 	importHTTPTimeoutS  = 10
 )
 
+// agentConfigFromDefinition maps a parsed AgentDefinition to an AgentConfig with
+// the import defaults applied (backend copilot, immediate restart, worker bead
+// role, enabled). It is the single mapping used by both the whole-agent import
+// handler and any live re-apply path, so the two never drift.
+func agentConfigFromDefinition(def *agentDefinition) config.AgentConfig {
+	includeRepos := def.Spec.IncludeRepos
+	return config.AgentConfig{
+		Backend:         valueOrDefault(def.Spec.Backend, "copilot"),
+		Model:           def.Spec.Model,
+		Enabled:         true,
+		ClearOnKick:     def.Spec.ClearOnKick,
+		StaleTimeout:    def.Spec.StaleTimeout,
+		RestartStrategy: valueOrDefault(def.Spec.RestartStrategy, "immediate"),
+		DisplayName:     def.Metadata.DisplayName,
+		Description:     def.Metadata.Description,
+		Role:            def.Spec.Role,
+		SortOrder:       def.Spec.SortOrder,
+		Emoji:           def.Metadata.Emoji,
+		Color:           def.Metadata.Color,
+		LaneKeywords:    def.Spec.LaneKeywords,
+		DetectKeywords:  def.Spec.DetectKeywords,
+		Aliases:         def.Spec.Aliases,
+		Mode:            def.Spec.Mode,
+		BeadRole:        valueOrDefault(def.Spec.BeadRole, "worker"),
+		IncludeRepos:    &includeRepos,
+		Managed:         true,
+		Channels:        def.Spec.Channels,
+		Tools:           def.Spec.Tools,
+		Connections:     def.Spec.Connections,
+	}
+}
+
 func (s *Server) handleAgentImport(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Source  string `json:"source"`
 		URL     string `json:"url"`
 		Content string `json:"content"`
 		Preview bool   `json:"preview"`
+		// KeepLinked (source=="url" only) persists a definition_source on the
+		// created agent so the hive re-fetches the definition from the repo on
+		// reload/kick and re-applies its operator-safe fields. Ignored for paste
+		// (there is no repo to link to).
+		KeepLinked bool `json:"keepLinked"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body: "+err.Error(), http.StatusBadRequest)
@@ -239,18 +247,9 @@ func (s *Server) handleAgentImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var def agentDefinition
-	if err := yaml.Unmarshal([]byte(yamlContent), &def); err != nil {
-		jsonError(w, "invalid YAML: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	if def.Kind != exportKind {
-		jsonError(w, fmt.Sprintf("expected kind %q, got %q", exportKind, def.Kind), http.StatusBadRequest)
-		return
-	}
-	if def.Metadata.Name == "" {
-		jsonError(w, "metadata.name is required", http.StatusBadRequest)
+	def, err := defsrc.ParseDefinition(yamlContent)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -259,9 +258,10 @@ func (s *Server) handleAgentImport(w http.ResponseWriter, r *http.Request) {
 			"ok":     true,
 			"parsed": def,
 			"_importBody": map[string]any{
-				"source":  body.Source,
-				"url":     body.URL,
-				"content": body.Content,
+				"source":     body.Source,
+				"url":        body.URL,
+				"content":    body.Content,
+				"keepLinked": body.KeepLinked,
 			},
 		})
 		return
@@ -289,30 +289,24 @@ func (s *Server) handleAgentImport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	includeRepos := def.Spec.IncludeRepos
-	agentCfg := config.AgentConfig{
-		Backend:         valueOrDefault(def.Spec.Backend, "copilot"),
-		Model:           def.Spec.Model,
-		Enabled:         true,
-		ClearOnKick:     def.Spec.ClearOnKick,
-		StaleTimeout:    def.Spec.StaleTimeout,
-		RestartStrategy: valueOrDefault(def.Spec.RestartStrategy, "immediate"),
-		DisplayName:     def.Metadata.DisplayName,
-		Description:     def.Metadata.Description,
-		Role:            def.Spec.Role,
-		SortOrder:       def.Spec.SortOrder,
-		Emoji:           def.Metadata.Emoji,
-		Color:           def.Metadata.Color,
-		LaneKeywords:    def.Spec.LaneKeywords,
-		DetectKeywords:  def.Spec.DetectKeywords,
-		Aliases:         def.Spec.Aliases,
-		Mode:            def.Spec.Mode,
-		BeadRole:        valueOrDefault(def.Spec.BeadRole, "worker"),
-		IncludeRepos:    &includeRepos,
-		Managed:         true,
-		Channels:        def.Spec.Channels,
-		Tools:           def.Spec.Tools,
-		Connections:     def.Spec.Connections,
+	agentCfg := agentConfigFromDefinition(def)
+
+	// Keep-linked (source=="url" only): persist a definition_source so the hive
+	// re-fetches and re-applies this definition's operator-safe fields on reload.
+	// Validate the parsed source repo against the seed-only allowlist here so a
+	// non-allowlisted repo is rejected at import time rather than silently ignored
+	// at reload. Paste imports carry no repo, so keep-linked is meaningless there.
+	if body.KeepLinked && body.Source == "url" {
+		defSrc, derr := s.definitionSourceFromURL(body.URL)
+		if derr != nil {
+			jsonError(w, "keep linked: "+derr.Error(), http.StatusBadRequest)
+			return
+		}
+		if !s.deps.Config.GitHubDefinitionAllowed(defSrc.Slug()) {
+			jsonError(w, fmt.Sprintf("keep linked: repo %q is not on the GitHub definition allowlist (an operator must add it to the seed config's variables.security.github_prompt_allowlist and set allow_github_prompt)", defSrc.Slug()), http.StatusBadRequest)
+			return
+		}
+		agentCfg.DefinitionSource = defSrc
 	}
 
 	if err := config.SaveAgentFile(agentsDir, name, agentCfg); err != nil {
@@ -401,6 +395,57 @@ func (s *Server) bakePromptSource(ctx context.Context, name string, agent *confi
 	agent.KickTemplate = templateFileName
 	s.logger.Info("baked GitHub prompt source", "agent", name, "repo", slug, "path", src.Path, "bytes", len(body))
 	return nil
+}
+
+// definitionSourceFetcher returns the GitHub client as a defsrc.Fetcher, or nil
+// when no client is wired (typed-nil interface avoidance, same reason as main.go).
+func (s *Server) definitionSourceFetcher() defsrc.Fetcher {
+	if s.deps != nil && s.deps.GHClient != nil {
+		return s.deps.GHClient
+	}
+	return nil
+}
+
+// githubBlobURLPattern matches a GitHub "blob" web URL:
+//
+//	https://<host>/<owner>/<repo>/blob/<ref>/<path...>
+//
+// Captures owner, repo, ref, and path. It intentionally does not anchor to
+// github.com so GitHub Enterprise hosts work too.
+var githubBlobURLPattern = regexp.MustCompile(`^/([^/]+)/([^/]+)/blob/([^/]+)/(.+)$`)
+
+// githubRawURLPattern matches a raw.githubusercontent.com URL:
+//
+//	https://raw.githubusercontent.com/<owner>/<repo>/<ref>/<path...>
+var githubRawURLPattern = regexp.MustCompile(`^/([^/]+)/([^/]+)/([^/]+)/(.+)$`)
+
+// definitionSourceFromURL parses a GitHub blob or raw file URL into a
+// DefinitionSourceConfig (owner/repo/path/ref). It is used when an operator
+// imports an agent with "keep linked" checked, so the pasted human-facing URL
+// becomes a durable, fetchable source pointer. The raw URL host is required for
+// the raw pattern to avoid mis-parsing arbitrary 4-segment paths.
+func (s *Server) definitionSourceFromURL(rawURL string) (*config.DefinitionSourceConfig, error) {
+	u, err := url.Parse(strings.TrimSpace(rawURL))
+	if err != nil || u.Host == "" {
+		return nil, fmt.Errorf("could not parse URL %q", rawURL)
+	}
+	var m []string
+	if strings.EqualFold(u.Host, "raw.githubusercontent.com") {
+		m = githubRawURLPattern.FindStringSubmatch(u.Path)
+	} else {
+		m = githubBlobURLPattern.FindStringSubmatch(u.Path)
+	}
+	if m == nil {
+		return nil, fmt.Errorf("URL %q is not a recognized GitHub file URL (expected .../<owner>/<repo>/blob/<ref>/<path> or a raw.githubusercontent.com file URL)", rawURL)
+	}
+	return &config.DefinitionSourceConfig{
+		Type:  "github",
+		Owner: m[1],
+		Repo:  m[2],
+		Ref:   m[3],
+		Path:  m[4],
+		URL:   rawURL,
+	}, nil
 }
 
 func (s *Server) reInitSubsystems() {

--- a/v2/pkg/dashboard/api_agents.go
+++ b/v2/pkg/dashboard/api_agents.go
@@ -1,6 +1,7 @@
 package dashboard
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/promptsrc"
 )
 
 type agentListEntry struct {
@@ -77,6 +79,18 @@ func (s *Server) handleAgentCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	body.Agent.Managed = true
+
+	// If a GitHub prompt source is declared, validate it against the seed-only
+	// allowlist and bake an initial copy so the very first kick has content even
+	// if GitHub is momentarily unreachable. A bad/denied source is a hard error
+	// here so the operator sees it at create time rather than silently at kick.
+	if body.Agent.PromptSource.IsSet() {
+		if err := s.bakePromptSource(r.Context(), body.Name, &body.Agent); err != nil {
+			jsonError(w, "prompt source: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+
 	if err := config.SaveAgentFile(agentsDir, body.Name, body.Agent); err != nil {
 		s.logger.Error("failed to save agent file", "agent", body.Name, "error", err)
 		jsonError(w, "failed to save agent: "+err.Error(), http.StatusInternalServerError)
@@ -338,6 +352,55 @@ func (s *Server) handleAgentImport(w http.ResponseWriter, r *http.Request) {
 
 	s.logger.Info("agent imported via API", "name", name, "source", body.Source)
 	okResponse(w, map[string]string{"status": "imported", "name": name})
+}
+
+// promptSourceFetcher returns the GitHub client as a promptsrc.Fetcher, or nil
+// when no client is wired (typed-nil interface avoidance, same reason as main.go).
+func (s *Server) promptSourceFetcher() promptsrc.Fetcher {
+	if s.deps != nil && s.deps.GHClient != nil {
+		return s.deps.GHClient
+	}
+	return nil
+}
+
+// bakePromptSource validates an agent's GitHub prompt source against the
+// seed-only allowlist, fetches it once, and writes the result to the policies
+// directory as the agent's kick template. This gives the agent a last-known-good
+// prompt on disk so the first kick (and any kick where GitHub is unreachable and
+// the in-memory cache is cold) still has content. On success it repoints the
+// agent's KickTemplate at the baked file. Returns an error (surfaced to the UI)
+// when the source is denied, incomplete, or unreachable.
+func (s *Server) bakePromptSource(ctx context.Context, name string, agent *config.AgentConfig) error {
+	if !agent.PromptSource.IsSet() {
+		return fmt.Errorf("owner, repo, and path are all required")
+	}
+	slug := agent.PromptSource.Slug()
+	allow := func(sl string) bool { return s.deps.Config.GitHubPromptAllowed(sl) }
+	if !allow(slug) {
+		return fmt.Errorf("repo %q is not on the GitHub prompt allowlist (an operator must add it to the seed config's variables.security.github_prompt_allowlist and set allow_github_prompt)", slug)
+	}
+	src := promptsrc.Source{
+		Owner: agent.PromptSource.Owner,
+		Repo:  agent.PromptSource.Repo,
+		Path:  agent.PromptSource.Path,
+		Ref:   agent.PromptSource.Ref,
+	}
+	body, err := promptsrc.FetchOnce(ctx, s.promptSourceFetcher(), allow, src)
+	if err != nil {
+		return fmt.Errorf("failed to fetch from %s: %w", slug, err)
+	}
+
+	templateFileName := name + ".md"
+	if err := os.MkdirAll(promptTemplateSaveDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create policies directory: %w", err)
+	}
+	savePath := filepath.Join(promptTemplateSaveDir, templateFileName)
+	if err := os.WriteFile(savePath, []byte(body), 0o644); err != nil {
+		return fmt.Errorf("failed to write baked prompt: %w", err)
+	}
+	agent.KickTemplate = templateFileName
+	s.logger.Info("baked GitHub prompt source", "agent", name, "repo", slug, "path", src.Path, "bytes", len(body))
+	return nil
 }
 
 func (s *Server) reInitSubsystems() {

--- a/v2/pkg/dashboard/definition_source_test.go
+++ b/v2/pkg/dashboard/definition_source_test.go
@@ -1,0 +1,176 @@
+package dashboard
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// enableDefinitionAllowlist puts a slug on the seed-only GitHub allowlist so the
+// keep-linked / prompt-source paths are permitted for it in tests.
+func enableDefinitionAllowlist(deps *Dependencies, slugs ...string) {
+	deps.Config.Variables.Security.AllowGitHubPrompt = true
+	deps.Config.Variables.Security.GitHubPromptAllowlist = slugs
+}
+
+func TestDefinitionSourceFromURL(t *testing.T) {
+	s := &Server{deps: &Dependencies{Config: &config.Config{}}}
+	cases := []struct {
+		name        string
+		url         string
+		wantErr     bool
+		owner, repo string
+		path, ref   string
+	}{
+		{
+			name:  "blob url",
+			url:   "https://github.com/kubestellar/hive/blob/v2/v2/examples/agents/x.yaml",
+			owner: "kubestellar", repo: "hive", ref: "v2", path: "v2/examples/agents/x.yaml",
+		},
+		{
+			name:  "raw url",
+			url:   "https://raw.githubusercontent.com/kubestellar/hive/main/agents/scanner.yaml",
+			owner: "kubestellar", repo: "hive", ref: "main", path: "agents/scanner.yaml",
+		},
+		{name: "not a file url", url: "https://github.com/kubestellar/hive", wantErr: true},
+		{name: "garbage", url: "::::", wantErr: true},
+		{name: "no host", url: "/kubestellar/hive/blob/v2/x.yaml", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ds, err := s.definitionSourceFromURL(tc.url)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.url)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ds.Owner != tc.owner || ds.Repo != tc.repo || ds.Ref != tc.ref || ds.Path != tc.path {
+				t.Errorf("parsed = %+v, want owner=%s repo=%s ref=%s path=%s", ds, tc.owner, tc.repo, tc.ref, tc.path)
+			}
+			if ds.URL != tc.url {
+				t.Errorf("URL not round-tripped: %q", ds.URL)
+			}
+		})
+	}
+}
+
+// TestImport_UncheckedStaysPlain: a normal import (no keepLinked) produces a
+// baked agent with NO definition_source link.
+func TestImport_UncheckedStaysPlain(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.Data.AgentsDir = t.TempDir()
+
+	yamlContent := fmt.Sprintf(`apiVersion: hive.kubestellar.io/v1
+kind: %s
+metadata:
+  name: plain-agent
+spec:
+  backend: claude
+`, exportKind)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(yamlContent))
+	}))
+	defer ts.Close()
+
+	rec := doPost(s, "/api/agents/import", map[string]interface{}{
+		"source":     "url",
+		"url":        ts.URL + "/kubestellar/hive/blob/main/plain.yaml",
+		"keepLinked": false,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	agent, ok := deps.Config.Agents["plain-agent"]
+	if !ok {
+		t.Fatal("plain-agent should exist")
+	}
+	if agent.DefinitionSource != nil {
+		t.Errorf("unchecked import must NOT set definition_source, got %+v", agent.DefinitionSource)
+	}
+}
+
+// TestImport_KeepLinkedPersistsDefinitionSource: keep-linked on an allowlisted
+// repo persists definition_source (owner/repo/path/ref derived from the URL).
+func TestImport_KeepLinkedPersistsDefinitionSource(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.Data.AgentsDir = t.TempDir()
+
+	yamlContent := fmt.Sprintf(`apiVersion: hive.kubestellar.io/v1
+kind: %s
+metadata:
+  name: linked-agent
+spec:
+  backend: claude
+`, exportKind)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(yamlContent))
+	}))
+	defer ts.Close()
+
+	// The blob path makes the parsed slug "kubestellar/hive"; allowlist it.
+	enableDefinitionAllowlist(deps, "kubestellar/hive")
+
+	rec := doPost(s, "/api/agents/import", map[string]interface{}{
+		"source":     "url",
+		"url":        ts.URL + "/kubestellar/hive/blob/main/agents/linked.yaml",
+		"keepLinked": true,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	agent, ok := deps.Config.Agents["linked-agent"]
+	if !ok {
+		t.Fatal("linked-agent should exist")
+	}
+	if agent.DefinitionSource == nil {
+		t.Fatal("keep-linked import must set definition_source")
+	}
+	ds := agent.DefinitionSource
+	if ds.Owner != "kubestellar" || ds.Repo != "hive" || ds.Path != "agents/linked.yaml" || ds.Ref != "main" {
+		t.Errorf("definition_source = %+v, want kubestellar/hive agents/linked.yaml@main", ds)
+	}
+}
+
+// TestImport_KeepLinkedRejectsNonAllowlistedRepo: keep-linked at a repo that is
+// NOT on the seed-only allowlist is rejected server-side (a user cannot link an
+// agent to an arbitrary repo).
+func TestImport_KeepLinkedRejectsNonAllowlistedRepo(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.Data.AgentsDir = t.TempDir()
+	// Feature enabled, but only a DIFFERENT repo is allowlisted.
+	enableDefinitionAllowlist(deps, "kubestellar/docs")
+
+	yamlContent := fmt.Sprintf(`apiVersion: hive.kubestellar.io/v1
+kind: %s
+metadata:
+  name: evil-agent
+spec:
+  backend: claude
+`, exportKind)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(yamlContent))
+	}))
+	defer ts.Close()
+
+	rec := doPost(s, "/api/agents/import", map[string]interface{}{
+		"source":     "url",
+		"url":        ts.URL + "/attacker/evil/blob/main/agent.yaml",
+		"keepLinked": true,
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for non-allowlisted keep-linked repo, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if _, exists := deps.Config.Agents["evil-agent"]; exists {
+		t.Error("agent must not be created when keep-linked repo is denied")
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -12230,6 +12230,30 @@ function burnAreaChart() {
           </div>
         </div>
         <div class="config-field">
+          <label>Prompt from GitHub repo <span class="config-info">i<span class="config-tooltip">Optionally source this agent's kick prompt from a file in a GitHub repo instead of an inline template. The prompt is fetched live at kick time using the hive's GitHub App, and falls back to the inline/baked template if the repo is unreachable. The repo must be on the operator's seed-only allowlist.</span></span></label>
+          <div style="font-size:0.65rem;color:var(--muted);margin:2px 0 6px">Leave blank to use the inline Kick Template above. All three of owner, repo, and path are required to enable.</div>
+          <div class="config-field-row">
+            <div class="config-field">
+              <label style="font-size:0.7rem">Owner</label>
+              <input type="text" id="cfg-agent-ps-owner" value="${esc((g.promptSource && g.promptSource.owner) || '')}" placeholder="e.g. kubestellar" oninput="markPromptSourceDirty()">
+            </div>
+            <div class="config-field">
+              <label style="font-size:0.7rem">Repo</label>
+              <input type="text" id="cfg-agent-ps-repo" value="${esc((g.promptSource && g.promptSource.repo) || '')}" placeholder="e.g. hive" oninput="markPromptSourceDirty()">
+            </div>
+          </div>
+          <div class="config-field-row">
+            <div class="config-field">
+              <label style="font-size:0.7rem">File path</label>
+              <input type="text" id="cfg-agent-ps-path" value="${esc((g.promptSource && g.promptSource.path) || '')}" placeholder="e.g. prompts/scanner.md" oninput="markPromptSourceDirty()">
+            </div>
+            <div class="config-field">
+              <label style="font-size:0.7rem">Ref <span style="font-weight:400;color:var(--muted)">(optional)</span></label>
+              <input type="text" id="cfg-agent-ps-ref" value="${esc((g.promptSource && g.promptSource.ref) || '')}" placeholder="branch, tag, or SHA (default branch if blank)" oninput="markPromptSourceDirty()">
+            </div>
+          </div>
+        </div>
+        <div class="config-field">
           <label>Operating Mode <span class="config-info">i<span class="config-tooltip">Controls what GitHub actions this agent can take. ADVISORY: beads only. ISSUES_ONLY: open issues, no PRs. ISSUES_AND_PRS: issues + PRs. ISSUES_PRS_MERGE: full auto-merge. Leave blank to use the ACMM level default.</span></span></label>
           ${(() => {
             const allModes = ['ADVISORY','ISSUES_ONLY','ISSUES_AND_PRS','ISSUES_PRS_MERGE'];
@@ -13547,6 +13571,40 @@ function burnAreaChart() {
       markDirty(section, key, isOn);
     }
 
+    // markPromptSourceDirty reads the four GitHub prompt-source inputs and records
+    // them as a nested promptSource object on the general section (or null when
+    // fully blank, which clears the source server-side). Owner+repo+path must all
+    // be present for the source to take effect; a partial fill is sent as-is and
+    // the server treats an incomplete source as cleared.
+    function markPromptSourceDirty() {
+      const owner = (document.getElementById('cfg-agent-ps-owner') || {}).value || '';
+      const repo = (document.getElementById('cfg-agent-ps-repo') || {}).value || '';
+      const path = (document.getElementById('cfg-agent-ps-path') || {}).value || '';
+      const ref = (document.getElementById('cfg-agent-ps-ref') || {}).value || '';
+      if (!owner.trim() && !repo.trim() && !path.trim() && !ref.trim()) {
+        markDirty('general', 'promptSource', null);
+        return;
+      }
+      markDirty('general', 'promptSource', {
+        owner: owner.trim(),
+        repo: repo.trim(),
+        path: path.trim(),
+        ref: ref.trim(),
+      });
+    }
+
+    // collectPromptSource returns the current prompt-source object from the form,
+    // or null when incomplete. Used by the create-agent submit path (which builds
+    // its own agent payload rather than reading _configState.dirty for this field).
+    function collectPromptSource() {
+      const owner = ((document.getElementById('cfg-agent-ps-owner') || {}).value || '').trim();
+      const repo = ((document.getElementById('cfg-agent-ps-repo') || {}).value || '').trim();
+      const path = ((document.getElementById('cfg-agent-ps-path') || {}).value || '').trim();
+      const ref = ((document.getElementById('cfg-agent-ps-ref') || {}).value || '').trim();
+      if (!owner || !repo || !path) return null;
+      return { type: 'github', owner: owner, repo: repo, path: path, ref: ref };
+    }
+
     // onchange handler for the CLI Pin Value select — prompts for the
     // LiteLLM endpoint (and reverts the selection on cancel) before
     // recording the change.
@@ -13756,6 +13814,8 @@ function burnAreaChart() {
           aliases: generalData.aliases || [],
           caveman_mode: generalData.cavemanMode || '',
         };
+        const ps = collectPromptSource();
+        if (ps) agent.prompt_source = ps;
         try {
           const res = await fetch('/api/agents', {
             method: 'POST',

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -11384,6 +11384,10 @@ function burnAreaChart() {
         '<div class="config-field" style="margin-bottom:12px">' +
           '<label>Import from URL</label>' +
           '<div style="display:flex;gap:8px"><input type="text" id="import-url-input" placeholder="' + rawURL + '" style="flex:1"><button onclick="previewImportFromURL()" style="padding:6px 16px;border-radius:6px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg);white-space:nowrap">Preview</button></div>' +
+          '<label style="display:flex;align-items:center;gap:8px;margin-top:8px;font-size:0.78rem;cursor:pointer;font-weight:400">' +
+            '<input type="checkbox" id="import-keep-linked" style="width:auto;margin:0">' +
+            '<span>Keep linked to repo (live) <span style="color:var(--muted)">— re-fetch this definition on reload so repo edits propagate. Only its presentation/behavior fields are re-applied; security and privilege fields are never changed. The repo must be on the operator\'s allowlist. (URL import only.)</span></span>' +
+          '</label>' +
         '</div>' +
         '<div class="config-field" style="margin-bottom:12px">' +
           '<label>Or paste agent definition</label>' +
@@ -11406,9 +11410,14 @@ function burnAreaChart() {
     async function previewImportFromURL() {
       var url = (document.getElementById('import-url-input') || {}).value;
       if (!url) { showToast('Enter a URL', 'error'); return; }
+      // Keep-linked persists the ORIGINAL (blob) URL as the source pointer, but
+      // the preview/bake fetch uses the raw URL. The server derives owner/repo/
+      // path/ref from whichever URL it receives, so keep the raw form here and
+      // let the server round-trip it back in _importBody.
+      var keepLinked = !!(document.getElementById('import-keep-linked') || {}).checked;
       url = url.replace('github.com/kubestellar/hive/blob/', 'raw.githubusercontent.com/kubestellar/hive/');
       try {
-        var resp = await fetch('/api/agents/import', {method:'POST', headers:_inceptionAuthHeaders(), body:JSON.stringify({source:'url',url:url,preview:true})});
+        var resp = await fetch('/api/agents/import', {method:'POST', headers:_inceptionAuthHeaders(), body:JSON.stringify({source:'url',url:url,preview:true,keepLinked:keepLinked})});
         var d = await resp.json();
         if (!resp.ok) { showToast(d.error || 'Import failed', 'error'); return; }
         showImportPreview(d);
@@ -12802,11 +12811,30 @@ function burnAreaChart() {
         + '</button>'
       ).join('');
 
+      const gen = (_configState.data && _configState.data.general) || {};
+      const ps = gen.promptSource || {};
       return `
         <div style="display:flex;flex-direction:column;height:100%">
         <div id="${srcId}" style="display:none;background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:10px 14px;margin-bottom:10px;flex-shrink:0">
           <div style="font-size:0.7rem;font-weight:600;color:var(--text);margin-bottom:6px">Source files <span style="font-weight:400;color:var(--muted)">(edit these on your fork)</span></div>
         </div>
+        <details style="margin-bottom:10px;flex-shrink:0;background:var(--surface);border:1px solid var(--border);border-radius:6px;padding:8px 12px"${(ps.owner || ps.repo || ps.path) ? ' open' : ''}>
+          <summary style="font-size:0.72rem;font-weight:600;color:var(--text);cursor:pointer">Import from repo</summary>
+          <p style="font-size:0.65rem;color:var(--muted);margin:6px 0">Pull this agent's kick prompt from a file in a GitHub repo. The repo must be on the operator's allowlist. Owner, repo, and path are all required.</p>
+          <div class="config-field-row">
+            <div class="config-field"><label style="font-size:0.7rem">Owner</label><input type="text" id="pt-ps-owner" value="${esc(ps.owner || '')}" placeholder="e.g. kubestellar"></div>
+            <div class="config-field"><label style="font-size:0.7rem">Repo</label><input type="text" id="pt-ps-repo" value="${esc(ps.repo || '')}" placeholder="e.g. hive"></div>
+          </div>
+          <div class="config-field-row">
+            <div class="config-field"><label style="font-size:0.7rem">File path</label><input type="text" id="pt-ps-path" value="${esc(ps.path || '')}" placeholder="e.g. prompts/scanner.md"></div>
+            <div class="config-field"><label style="font-size:0.7rem">Ref <span style="font-weight:400;color:var(--muted)">(optional)</span></label><input type="text" id="pt-ps-ref" value="${esc(ps.ref || '')}" placeholder="branch, tag, or SHA"></div>
+          </div>
+          <label style="display:flex;align-items:center;gap:8px;margin:6px 0;font-size:0.72rem;cursor:pointer;font-weight:400">
+            <input type="checkbox" id="pt-ps-keep-linked" style="width:auto;margin:0"${ps.owner ? ' checked' : ''}>
+            <span>Keep linked to repo (live) <span style="color:var(--muted)">— resolve the prompt at kick time so repo edits propagate. Unchecked: fetch once and bake a static copy.</span></span>
+          </label>
+          <button onclick="importPromptFromRepo()" style="font-size:0.72rem;padding:4px 14px;border-radius:4px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg)">Import Prompt</button>
+        </details>
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px;flex-shrink:0">Kick template with <code>$​{VAR}</code> placeholders. Edit the raw template or preview with variables expanded.</p>
         <div style="display:flex;gap:6px;margin-bottom:8px;flex-shrink:0">
           <button id="prompt-btn-edit" onclick="switchPromptMode('edit')" style="font-size:0.72rem;padding:4px 12px;border-radius:4px;cursor:pointer;font-weight:600;border:1px solid var(--border);background:var(--green);color:var(--bg)">Edit</button>
@@ -12865,6 +12893,42 @@ function burnAreaChart() {
       editor.selectionStart = cursorPos;
       editor.selectionEnd = cursorPos;
       editor.focus();
+    }
+
+    // importPromptFromRepo reads the Prompt Template tab's repo fields and PUTs
+    // them to the prompt endpoint. Keep-linked persists a live prompt_source
+    // (resolved at kick time); unchecked bakes a one-time static copy. The server
+    // validates the repo against the seed-only allowlist and returns a clear error
+    // for a non-allowlisted repo.
+    function importPromptFromRepo() {
+      var agentName = _configState.agent;
+      if (!agentName) { showToast('Save the agent first', 'error'); return; }
+      var owner = ((document.getElementById('pt-ps-owner') || {}).value || '').trim();
+      var repo = ((document.getElementById('pt-ps-repo') || {}).value || '').trim();
+      var path = ((document.getElementById('pt-ps-path') || {}).value || '').trim();
+      var ref = ((document.getElementById('pt-ps-ref') || {}).value || '').trim();
+      var keepLinked = !!(document.getElementById('pt-ps-keep-linked') || {}).checked;
+      if (!owner || !repo || !path) { showToast('Owner, repo, and path are required', 'error'); return; }
+      fetch('/api/config/agent/' + agentName + '/prompt', {
+        method: 'PUT',
+        headers: _inceptionAuthHeaders(),
+        body: JSON.stringify({ promptSource: { owner: owner, repo: repo, path: path, ref: ref }, keepLinked: keepLinked })
+      })
+        .then(function(r) { return r.json().then(function(d) { return {ok: r.ok, data: d}; }); })
+        .then(function(result) {
+          if (result.ok) {
+            showToast(keepLinked ? 'Prompt linked to repo (live)' : 'Prompt imported (baked copy)', 'success');
+            // Refresh the editor/preview with the newly fetched content.
+            var editor = document.getElementById('prompt-template-editor');
+            fetch('/api/config/agent/' + agentName + '/prompt?raw=1')
+              .then(function(r) { return r.json(); })
+              .then(function(data) { if (editor) editor.value = data.prompt || ''; })
+              .catch(function() {});
+          } else {
+            showToast(result.data.error || 'Import failed', 'error');
+          }
+        })
+        .catch(function(err) { showToast('Network error: ' + err.message, 'error'); });
     }
 
     function savePromptTemplate() {

--- a/v2/pkg/defsrc/defsrc.go
+++ b/v2/pkg/defsrc/defsrc.go
@@ -1,0 +1,446 @@
+// Package defsrc resolves a WHOLE agent definition from an external source
+// (currently a GitHub repo file holding the portable AgentDefinition YAML) and
+// merges its operator-safe fields over an agent's baked config, so an operator
+// who "keeps an agent linked to a repo" sees repo edits propagate on the next
+// hive reload — without a redeploy.
+//
+// It is the whole-agent analogue of pkg/promptsrc (which live-sources only the
+// kick prompt). Both share the same design principles:
+//
+//   - Graceful fallback: a fetch/parse failure NEVER blanks or crashes an agent.
+//     The baked (last-known-good) definition is kept and the failure is logged.
+//   - Seed-only gating: fetching is gated by an Allow func the caller wires to
+//     the trusted config seed (config.Config.GitHubDefinitionAllowed). A repo
+//     whose "owner/repo" slug is not allowlisted is never fetched, so a
+//     user-writable dashboard overlay cannot point an agent at an arbitrary repo.
+//
+// TRUST BOUNDARY (the reason this is a separate merge rather than a wholesale
+// replace): a repo-sourced definition is user-controlled content. It may set an
+// agent's presentation and behavior — but it must NOT be able to escalate the
+// agent's privileges or flip any security/seed-only field. mergeAllowedFields
+// applies ONLY the explicitly-listed operator-safe fields (name/display/emoji/
+// description/tier/role/mode/cadences/channels/tools/prompt template/colors/
+// keywords/aliases/connections). Every other field on the baked AgentConfig is
+// preserved untouched. If a new privilege-granting field is ever added to
+// AgentConfig, it is excluded by default (allow-list, not deny-list) — so the
+// safe failure mode is "the live definition can't change it", never "it can".
+package defsrc
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"gopkg.in/yaml.v3"
+)
+
+// maxDefinitionBytes caps how large a fetched definition YAML may be. An agent
+// definition is a small YAML document (kilobytes); this bounds memory/log blast
+// radius if a source path points at something huge, while staying well above any
+// real definition.
+const maxDefinitionBytes = 512 * 1024 // 512 KiB
+
+// defaultFetchTimeout bounds a single live fetch so a slow/hung GitHub API call
+// cannot stall a reload. On timeout the resolver keeps the baked definition.
+const defaultFetchTimeout = 8 * time.Second
+
+// DefinitionKind is the required `kind` value in the portable AgentDefinition
+// YAML. It mirrors the dashboard's exportKind so an exported agent round-trips.
+const DefinitionKind = "AgentDefinition"
+
+// Source is the config-package-agnostic description of a GitHub definition
+// source. The config.DefinitionSourceConfig is adapted into this at the call site.
+type Source struct {
+	Owner string
+	Repo  string
+	Path  string
+	Ref   string // optional branch/tag/SHA; "" = default branch
+}
+
+// Slug is the "owner/repo" identifier used for allowlist matching and cache keys.
+func (s Source) Slug() string {
+	if s.Owner == "" || s.Repo == "" {
+		return ""
+	}
+	return s.Owner + "/" + s.Repo
+}
+
+func (s Source) key() string {
+	return s.Owner + "\x00" + s.Repo + "\x00" + s.Path + "\x00" + s.Ref
+}
+
+func (s Source) valid() bool {
+	return s.Owner != "" && s.Repo != "" && s.Path != ""
+}
+
+// Fetcher reads a file's decoded contents from a repo at an optional ref. It is
+// satisfied by *github.Client.GetFileContentRef, and stubbed in tests.
+type Fetcher interface {
+	GetFileContentRef(ctx context.Context, owner, repo, path, ref string) (string, error)
+}
+
+// AllowFunc reports whether a given "owner/repo" slug may be fetched. Callers
+// wire this to the seed-only policy (config.Config.GitHubDefinitionAllowed).
+type AllowFunc func(slug string) bool
+
+// Logger is the tiny logging surface this package needs, satisfied by *slog.Logger.
+type Logger interface {
+	Warn(msg string, args ...any)
+	Info(msg string, args ...any)
+}
+
+// AgentDefinition is the portable YAML format for a whole agent. It matches the
+// dashboard's import/export schema. Only the fields listed here (and applied in
+// mergeAllowedFields) can be sourced live — anything absent from this struct or
+// from the merge is, by construction, not settable by a live definition.
+type AgentDefinition struct {
+	APIVersion string              `yaml:"apiVersion" json:"apiVersion"`
+	Kind       string              `yaml:"kind" json:"kind"`
+	Metadata   AgentDefinitionMeta `yaml:"metadata" json:"metadata"`
+	Spec       AgentDefinitionSpec `yaml:"spec" json:"spec"`
+}
+
+type AgentDefinitionMeta struct {
+	Name        string `yaml:"name" json:"name"`
+	DisplayName string `yaml:"displayName,omitempty" json:"displayName,omitempty"`
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+	Emoji       string `yaml:"emoji,omitempty" json:"emoji,omitempty"`
+	Color       string `yaml:"color,omitempty" json:"color,omitempty"`
+	SpecVersion int    `yaml:"specVersion,omitempty" json:"specVersion,omitempty"`
+}
+
+type AgentDefinitionSpec struct {
+	Backend         string                    `yaml:"backend,omitempty" json:"backend,omitempty"`
+	Model           string                    `yaml:"model,omitempty" json:"model,omitempty"`
+	Role            string                    `yaml:"role,omitempty" json:"role,omitempty"`
+	Mode            string                    `yaml:"mode,omitempty" json:"mode,omitempty"`
+	SortOrder       int                       `yaml:"sortOrder,omitempty" json:"sortOrder,omitempty"`
+	BeadRole        string                    `yaml:"beadRole,omitempty" json:"beadRole,omitempty"`
+	StaleTimeout    int                       `yaml:"staleTimeout,omitempty" json:"staleTimeout,omitempty"`
+	RestartStrategy string                    `yaml:"restartStrategy,omitempty" json:"restartStrategy,omitempty"`
+	ClearOnKick     bool                      `yaml:"clearOnKick,omitempty" json:"clearOnKick,omitempty"`
+	IncludeRepos    bool                      `yaml:"includeRepos,omitempty" json:"includeRepos,omitempty"`
+	LaneKeywords    []string                  `yaml:"laneKeywords,omitempty" json:"laneKeywords,omitempty"`
+	DetectKeywords  []string                  `yaml:"detectKeywords,omitempty" json:"detectKeywords,omitempty"`
+	Aliases         []string                  `yaml:"aliases,omitempty" json:"aliases,omitempty"`
+	Cadences        map[string]string         `yaml:"cadences,omitempty" json:"cadences,omitempty"`
+	PromptTemplate  string                    `yaml:"promptTemplate,omitempty" json:"promptTemplate,omitempty"`
+	Channels        []config.ChannelConfig    `yaml:"channels,omitempty" json:"channels,omitempty"`
+	Tools           *config.ToolsConfig       `yaml:"tools,omitempty" json:"tools,omitempty"`
+	Connections     []config.ConnectionConfig `yaml:"connections,omitempty" json:"connections,omitempty"`
+}
+
+// ParseDefinition parses and structurally validates a definition YAML document.
+// It returns an error (rather than a zero value) so callers that fetch at
+// create/import time can surface a bad document to the operator.
+func ParseDefinition(yamlContent string) (*AgentDefinition, error) {
+	var def AgentDefinition
+	if err := yaml.Unmarshal([]byte(yamlContent), &def); err != nil {
+		return nil, fmt.Errorf("invalid definition YAML: %w", err)
+	}
+	if def.Kind != DefinitionKind {
+		return nil, fmt.Errorf("expected kind %q, got %q", DefinitionKind, def.Kind)
+	}
+	if def.Metadata.Name == "" {
+		return nil, fmt.Errorf("metadata.name is required")
+	}
+	return &def, nil
+}
+
+// mergeAllowedFields applies ONLY the operator-safe fields of a live definition
+// over a baked agent config, returning the merged copy. This is THE trust
+// boundary: every field it touches is presentation/behavior, never a
+// privilege-granting or seed-only field. Fields it deliberately never touches
+// (so a live definition can't escalate an agent) include:
+//
+//   - PromptSource / DefinitionSource (the source pointers themselves; a live
+//     definition must not be able to re-point the agent at a different repo)
+//   - Enabled / Paused / Managed (operator lifecycle state)
+//   - ID / BeadsDir / MetricsCollector / ACMMLevels / OnDemand / CavemanMode
+//   - anything under the hive-level Variables/Security policy (which does not
+//     even live on AgentConfig — it is seed-only by construction)
+//
+// A field absent from a fetched definition (Go zero value) does NOT clear the
+// baked value: empty strings/slices are skipped so a minimal definition can't
+// silently wipe presentation. Booleans that carry meaning use the definition's
+// value directly (clear_on_kick, include_repos) because their zero value is a
+// legitimate setting.
+func mergeAllowedFields(baked config.AgentConfig, def *AgentDefinition) config.AgentConfig {
+	merged := baked
+
+	// --- metadata (presentation) ---
+	if def.Metadata.DisplayName != "" {
+		merged.DisplayName = def.Metadata.DisplayName
+	}
+	if def.Metadata.Description != "" {
+		merged.Description = def.Metadata.Description
+	}
+	if def.Metadata.Emoji != "" {
+		merged.Emoji = def.Metadata.Emoji
+	}
+	if def.Metadata.Color != "" {
+		merged.Color = def.Metadata.Color
+	}
+
+	// --- spec (behavior / tier / role) ---
+	if def.Spec.Backend != "" {
+		merged.Backend = def.Spec.Backend
+	}
+	if def.Spec.Model != "" {
+		merged.Model = def.Spec.Model
+	}
+	if def.Spec.Role != "" {
+		merged.Role = def.Spec.Role
+	}
+	if def.Spec.Mode != "" {
+		merged.Mode = def.Spec.Mode
+	}
+	if def.Spec.SortOrder != 0 {
+		merged.SortOrder = def.Spec.SortOrder
+	}
+	if def.Spec.BeadRole != "" {
+		merged.BeadRole = def.Spec.BeadRole
+	}
+	if def.Spec.StaleTimeout != 0 {
+		merged.StaleTimeout = def.Spec.StaleTimeout
+	}
+	if def.Spec.RestartStrategy != "" {
+		merged.RestartStrategy = def.Spec.RestartStrategy
+	}
+	// clear_on_kick and include_repos carry meaning at their zero value, so the
+	// definition's value is authoritative when the source is live.
+	merged.ClearOnKick = def.Spec.ClearOnKick
+	includeRepos := def.Spec.IncludeRepos
+	merged.IncludeRepos = &includeRepos
+
+	if len(def.Spec.LaneKeywords) > 0 {
+		merged.LaneKeywords = def.Spec.LaneKeywords
+	}
+	if len(def.Spec.DetectKeywords) > 0 {
+		merged.DetectKeywords = def.Spec.DetectKeywords
+	}
+	if len(def.Spec.Aliases) > 0 {
+		merged.Aliases = def.Spec.Aliases
+	}
+	if len(def.Spec.Channels) > 0 {
+		merged.Channels = def.Spec.Channels
+	}
+	if def.Spec.Tools != nil {
+		merged.Tools = def.Spec.Tools
+	}
+	if len(def.Spec.Connections) > 0 {
+		merged.Connections = def.Spec.Connections
+	}
+
+	return merged
+}
+
+// Resolver fetches whole-agent definitions live and remembers the last good
+// document per source so a later failure can fall back to it. Safe for
+// concurrent use.
+type Resolver struct {
+	fetcher Fetcher
+	allow   AllowFunc
+	logger  Logger
+	timeout time.Duration
+
+	mu    sync.RWMutex
+	cache map[string]string // source key -> last-known-good raw YAML
+}
+
+// NewResolver builds a Resolver. fetcher may be nil (token-mode boot without an
+// App client), in which case every resolution reports a miss and the caller keeps
+// the baked definition. allow must be non-nil; a nil allow denies everything
+// (fail closed). logger may be nil.
+func NewResolver(fetcher Fetcher, allow AllowFunc, logger Logger) *Resolver {
+	if allow == nil {
+		allow = func(string) bool { return false }
+	}
+	return &Resolver{
+		fetcher: fetcher,
+		allow:   allow,
+		logger:  logger,
+		timeout: defaultFetchTimeout,
+		cache:   map[string]string{},
+	}
+}
+
+// Result carries a merged agent config plus provenance. Ok is false when nothing
+// could be resolved (not set, denied, no fetcher, unreachable-with-no-cache, or a
+// malformed document); the caller then keeps the baked config unchanged.
+type Result struct {
+	Merged config.AgentConfig
+	Ok     bool
+	Source string // "github:owner/repo@ref", "github-cache:...", "denied", "unset", "no-client", "error"
+}
+
+// Resolve fetches the live definition for src and merges its allowed fields over
+// baked, falling back to the last-known-good cached document on any fetch failure.
+// It never returns an error: a reload must proceed even when the source is
+// unreachable, so failure is Ok=false (keep baked) and logged, not propagated.
+func (r *Resolver) Resolve(ctx context.Context, src Source, baked config.AgentConfig) Result {
+	if !src.valid() {
+		return Result{Merged: baked, Source: "unset"}
+	}
+	slug := src.Slug()
+	if !r.allow(slug) {
+		if r.logger != nil {
+			r.logger.Warn("definition source repo not allowlisted, ignoring (keeping baked definition)", "repo", slug)
+		}
+		return Result{Merged: baked, Source: "denied"}
+	}
+	if r.fetcher == nil {
+		if raw, ok := r.cached(src); ok {
+			return r.mergeFromRaw(raw, baked, src, "github-cache:"+slug)
+		}
+		return Result{Merged: baked, Source: "no-client"}
+	}
+
+	fetchCtx := ctx
+	if ctx == nil {
+		fetchCtx = context.Background()
+	}
+	fetchCtx, cancel := context.WithTimeout(fetchCtx, r.timeout)
+	defer cancel()
+
+	raw, err := r.fetcher.GetFileContentRef(fetchCtx, src.Owner, src.Repo, src.Path, src.Ref)
+	if err != nil {
+		if r.logger != nil {
+			r.logger.Warn("failed to fetch agent definition from GitHub, keeping baked", "repo", slug, "path", src.Path, "error", err)
+		}
+		if cached, ok := r.cached(src); ok {
+			return r.mergeFromRaw(cached, baked, src, "github-cache:"+slug)
+		}
+		return Result{Merged: baked, Source: "error"}
+	}
+	if len(raw) > maxDefinitionBytes {
+		raw = raw[:maxDefinitionBytes]
+		if r.logger != nil {
+			r.logger.Warn("agent definition from GitHub exceeded size cap, truncated", "repo", slug, "path", src.Path, "cap_bytes", maxDefinitionBytes)
+		}
+	}
+	res := r.mergeFromRaw(raw, baked, src, r.provenance(src))
+	if res.Ok {
+		// Only cache a document that parsed cleanly, so a later fetch failure
+		// falls back to a known-good definition, not a corrupt one.
+		r.store(src, raw)
+	}
+	return res
+}
+
+// mergeFromRaw parses a raw definition and merges it; a parse failure keeps the
+// baked config (Ok=false) so a corrupt document never blanks a live agent.
+func (r *Resolver) mergeFromRaw(raw string, baked config.AgentConfig, src Source, provenance string) Result {
+	def, err := ParseDefinition(raw)
+	if err != nil {
+		if r.logger != nil {
+			r.logger.Warn("agent definition from GitHub is malformed, keeping baked", "repo", src.Slug(), "path", src.Path, "error", err)
+		}
+		return Result{Merged: baked, Source: "error"}
+	}
+	return Result{Merged: mergeAllowedFields(baked, def), Ok: true, Source: provenance}
+}
+
+func (r *Resolver) provenance(src Source) string {
+	ref := src.Ref
+	if ref == "" {
+		ref = "default"
+	}
+	return fmt.Sprintf("github:%s@%s", src.Slug(), ref)
+}
+
+func (r *Resolver) cached(src Source) (string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	raw, ok := r.cache[src.key()]
+	return raw, ok
+}
+
+func (r *Resolver) store(src Source, raw string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cache[src.key()] = raw
+}
+
+// FetchOnce does a single gated fetch WITHOUT touching the resolver cache and
+// returns the parsed definition. It is used at import/keep-linked time to
+// validate that the source is reachable and well-formed before saving, so the UI
+// can surface a bad owner/repo/path/document to the operator. Unlike Resolve it
+// returns an error.
+func FetchOnce(ctx context.Context, fetcher Fetcher, allow AllowFunc, src Source) (*AgentDefinition, error) {
+	if !src.valid() {
+		return nil, fmt.Errorf("definition source is incomplete (owner, repo, and path are required)")
+	}
+	slug := src.Slug()
+	if allow == nil || !allow(slug) {
+		return nil, fmt.Errorf("repo %q is not on the GitHub definition allowlist", slug)
+	}
+	if fetcher == nil {
+		return nil, fmt.Errorf("no GitHub client available to fetch definition")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	fctx, cancel := context.WithTimeout(ctx, defaultFetchTimeout)
+	defer cancel()
+	raw, err := fetcher.GetFileContentRef(fctx, src.Owner, src.Repo, src.Path, src.Ref)
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) > maxDefinitionBytes {
+		raw = raw[:maxDefinitionBytes]
+	}
+	return ParseDefinition(raw)
+}
+
+// MergeAllowedFields exposes the trust-boundary merge for callers that already
+// hold a parsed definition (e.g. the import handler applying keep-linked at
+// create time). It applies the same operator-safe field allow-list as Resolve.
+func MergeAllowedFields(baked config.AgentConfig, def *AgentDefinition) config.AgentConfig {
+	return mergeAllowedFields(baked, def)
+}
+
+// ApplyToConfig re-resolves every agent that carries a definition_source and
+// merges the live definition's operator-safe fields over the agent's baked
+// config in place. Agents without a definition_source are left untouched, and
+// any agent whose source is unreachable/denied/malformed keeps its baked config
+// (Resolve's graceful fallback). It is safe to call on every reload and at
+// startup — a nil resolver is a no-op so a token-less boot doesn't panic.
+//
+// Note: seed-only/privileged fields are preserved because mergeAllowedFields
+// only ever touches the operator-safe allow-list; in particular the agent's own
+// DefinitionSource/PromptSource pointers are NOT re-pointable by a live
+// definition, so a compromised repo cannot redirect the agent elsewhere.
+func ApplyToConfig(ctx context.Context, cfg *config.Config, resolver *Resolver, logger Logger) {
+	if cfg == nil || resolver == nil {
+		return
+	}
+	for name, agent := range cfg.Agents {
+		if !agent.DefinitionSource.IsSet() {
+			continue
+		}
+		src := Source{
+			Owner: agent.DefinitionSource.Owner,
+			Repo:  agent.DefinitionSource.Repo,
+			Path:  agent.DefinitionSource.Path,
+			Ref:   agent.DefinitionSource.Ref,
+		}
+		res := resolver.Resolve(ctx, src, agent)
+		if !res.Ok {
+			continue
+		}
+		// Preserve the source pointers and managed flag regardless of what the
+		// live definition contained — the merge already excludes them, but assert
+		// it here so a future mergeAllowedFields change can't silently leak.
+		merged := res.Merged
+		merged.DefinitionSource = agent.DefinitionSource
+		merged.PromptSource = agent.PromptSource
+		merged.Managed = agent.Managed
+		cfg.Agents[name] = merged
+		if logger != nil {
+			logger.Info("re-applied live agent definition", "agent", name, "source", res.Source)
+		}
+	}
+}

--- a/v2/pkg/defsrc/defsrc_test.go
+++ b/v2/pkg/defsrc/defsrc_test.go
@@ -1,0 +1,308 @@
+package defsrc
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+type stubFetcher struct {
+	mu      sync.Mutex
+	body    string
+	err     error
+	calls   int
+	lastRef string
+}
+
+func (f *stubFetcher) GetFileContentRef(_ context.Context, _, _, _, ref string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.lastRef = ref
+	return f.body, f.err
+}
+
+func (f *stubFetcher) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func allowAll(string) bool  { return true }
+func allowNone(string) bool { return false }
+
+func fullSource() Source {
+	return Source{Owner: "kubestellar", Repo: "hive", Path: "agents/scanner.yaml", Ref: "v2"}
+}
+
+// validDef is a minimal well-formed AgentDefinition YAML that changes several
+// operator-safe fields.
+const validDef = `
+apiVersion: hive.kubestellar.io/v1
+kind: AgentDefinition
+metadata:
+  name: scanner
+  displayName: Live Scanner
+  emoji: "🔎"
+  description: sourced live
+spec:
+  backend: claude
+  model: opus
+  role: scanner
+  mode: ISSUES_ONLY
+  laneKeywords: [bug, triage]
+  channels:
+    - type: kick
+`
+
+// bakedAgent returns a config with sensitive/seed-only fields set that a live
+// definition must NEVER be able to change.
+func bakedAgent() config.AgentConfig {
+	return config.AgentConfig{
+		DisplayName:      "Baked Scanner",
+		Enabled:          true,
+		Paused:           true,
+		CLIPinned:        true,
+		ID:               "scanner",
+		BeadsDir:         "/data/beads/scanner",
+		MetricsCollector: "trusted-collector",
+		ACMMLevels:       []int{5},
+		PromptSource:     &config.PromptSourceConfig{Owner: "kubestellar", Repo: "hive", Path: "p.md"},
+		DefinitionSource: &config.DefinitionSourceConfig{Owner: "kubestellar", Repo: "hive", Path: "agents/scanner.yaml"},
+	}
+}
+
+// TestResolve_MergesAllowedFieldsOnly is the trust-boundary test: a live
+// definition sets presentation/behavior fields but CANNOT touch security /
+// seed-only / privileged fields.
+func TestResolve_MergesAllowedFieldsOnly(t *testing.T) {
+	f := &stubFetcher{body: validDef}
+	r := NewResolver(f, allowAll, nil)
+
+	res := r.Resolve(context.Background(), fullSource(), bakedAgent())
+	if !res.Ok {
+		t.Fatalf("expected ok merge, got %+v", res)
+	}
+	m := res.Merged
+
+	// ALLOWED fields were applied.
+	if m.DisplayName != "Live Scanner" {
+		t.Errorf("displayName = %q, want Live Scanner", m.DisplayName)
+	}
+	if m.Emoji != "🔎" {
+		t.Errorf("emoji not applied: %q", m.Emoji)
+	}
+	if m.Backend != "claude" || m.Model != "opus" {
+		t.Errorf("backend/model not applied: %q/%q", m.Backend, m.Model)
+	}
+	if m.Mode != "ISSUES_ONLY" {
+		t.Errorf("mode not applied: %q", m.Mode)
+	}
+	if len(m.LaneKeywords) != 2 || len(m.Channels) != 1 {
+		t.Errorf("laneKeywords/channels not applied: %+v / %+v", m.LaneKeywords, m.Channels)
+	}
+
+	// FORBIDDEN fields were preserved from the baked config (a live definition
+	// must not be able to un-pause, un-pin, re-point sources, or change identity).
+	if !m.Paused {
+		t.Error("live definition must NOT be able to un-pause the agent")
+	}
+	if !m.CLIPinned {
+		t.Error("live definition must NOT be able to change cli_pinned")
+	}
+	if m.ID != "scanner" || m.BeadsDir != "/data/beads/scanner" {
+		t.Error("live definition must NOT be able to change identity/beads dir")
+	}
+	if m.MetricsCollector != "trusted-collector" {
+		t.Error("live definition must NOT be able to change metrics_collector")
+	}
+	if len(m.ACMMLevels) != 1 || m.ACMMLevels[0] != 5 {
+		t.Error("live definition must NOT be able to change acmm_levels")
+	}
+	if m.PromptSource == nil || m.PromptSource.Owner != "kubestellar" {
+		t.Error("live definition must NOT be able to re-point prompt_source")
+	}
+	if m.DefinitionSource == nil || m.DefinitionSource.Owner != "kubestellar" {
+		t.Error("live definition must NOT be able to re-point definition_source")
+	}
+}
+
+// TestResolve_FallbackToCacheOnError: after one success, a later fetch failure
+// serves the last-known-good document instead of blanking the agent.
+func TestResolve_FallbackToCacheOnError(t *testing.T) {
+	f := &stubFetcher{body: validDef}
+	r := NewResolver(f, allowAll, nil)
+
+	first := r.Resolve(context.Background(), fullSource(), bakedAgent())
+	if !first.Ok || first.Merged.DisplayName != "Live Scanner" {
+		t.Fatalf("first resolve should succeed, got %+v", first)
+	}
+
+	f.mu.Lock()
+	f.body = ""
+	f.err = errors.New("repo unreachable")
+	f.mu.Unlock()
+
+	second := r.Resolve(context.Background(), fullSource(), bakedAgent())
+	if !second.Ok || second.Merged.DisplayName != "Live Scanner" {
+		t.Fatalf("failure should fall back to cached definition, got %+v", second)
+	}
+	if !strings.HasPrefix(second.Source, "github-cache:") {
+		t.Errorf("provenance = %q, want github-cache:*", second.Source)
+	}
+}
+
+// TestResolve_ErrorNoCache_KeepsBaked: a cold failure keeps the baked config.
+func TestResolve_ErrorNoCache_KeepsBaked(t *testing.T) {
+	f := &stubFetcher{err: errors.New("boom")}
+	r := NewResolver(f, allowAll, nil)
+	baked := bakedAgent()
+	res := r.Resolve(context.Background(), fullSource(), baked)
+	if res.Ok {
+		t.Errorf("cold failure should not be ok, got %+v", res)
+	}
+	if res.Merged.DisplayName != baked.DisplayName {
+		t.Error("cold failure must keep baked definition unchanged")
+	}
+}
+
+// TestResolve_MalformedKeepsBaked: a document that isn't a valid AgentDefinition
+// keeps the baked config rather than corrupting the agent.
+func TestResolve_MalformedKeepsBaked(t *testing.T) {
+	f := &stubFetcher{body: "kind: NotAnAgent\nmetadata: {}"}
+	r := NewResolver(f, allowAll, nil)
+	baked := bakedAgent()
+	res := r.Resolve(context.Background(), fullSource(), baked)
+	if res.Ok {
+		t.Errorf("malformed doc should not be ok, got %+v", res)
+	}
+	if res.Merged.DisplayName != baked.DisplayName {
+		t.Error("malformed doc must keep baked definition")
+	}
+}
+
+// TestResolve_DeniedByAllowlist: a non-allowlisted repo is never fetched.
+func TestResolve_DeniedByAllowlist(t *testing.T) {
+	f := &stubFetcher{body: validDef}
+	r := NewResolver(f, allowNone, nil)
+	res := r.Resolve(context.Background(), fullSource(), bakedAgent())
+	if res.Ok {
+		t.Errorf("denied source should not be ok, got %+v", res)
+	}
+	if f.callCount() != 0 {
+		t.Errorf("denied source must not fetch, calls=%d", f.callCount())
+	}
+	if res.Source != "denied" {
+		t.Errorf("source = %q, want denied", res.Source)
+	}
+}
+
+// TestResolve_NilAllowDeniesAll: a nil AllowFunc fails closed.
+func TestResolve_NilAllowDeniesAll(t *testing.T) {
+	f := &stubFetcher{body: validDef}
+	r := NewResolver(f, nil, nil)
+	res := r.Resolve(context.Background(), fullSource(), bakedAgent())
+	if res.Ok || f.callCount() != 0 {
+		t.Errorf("nil allow must deny all, got ok=%v calls=%d", res.Ok, f.callCount())
+	}
+}
+
+// TestResolve_UnsetSourceKeepsBaked.
+func TestResolve_UnsetSourceKeepsBaked(t *testing.T) {
+	f := &stubFetcher{body: validDef}
+	r := NewResolver(f, allowAll, nil)
+	res := r.Resolve(context.Background(), Source{Owner: "o", Repo: "r"}, bakedAgent())
+	if res.Ok || f.callCount() != 0 {
+		t.Errorf("incomplete source should be a no-fetch miss, got ok=%v calls=%d", res.Ok, f.callCount())
+	}
+}
+
+// TestFetchOnce_Gating enforces the same allowlist gate and surfaces errors.
+func TestFetchOnce_Gating(t *testing.T) {
+	f := &stubFetcher{body: validDef}
+
+	if _, err := FetchOnce(context.Background(), f, allowNone, fullSource()); err == nil {
+		t.Error("denied repo should error")
+	}
+	if f.callCount() != 0 {
+		t.Errorf("denied FetchOnce must not fetch, calls=%d", f.callCount())
+	}
+	if _, err := FetchOnce(context.Background(), f, allowAll, Source{Owner: "o"}); err == nil {
+		t.Error("incomplete source should error")
+	}
+	if _, err := FetchOnce(context.Background(), nil, allowAll, fullSource()); err == nil {
+		t.Error("nil fetcher should error")
+	}
+	def, err := FetchOnce(context.Background(), f, allowAll, fullSource())
+	if err != nil || def == nil || def.Metadata.Name != "scanner" {
+		t.Errorf("valid FetchOnce failed: def=%+v err=%v", def, err)
+	}
+}
+
+// TestApplyToConfig_OnlyLinkedAgents: agents without a definition_source are
+// untouched; linked agents get merged and keep their source pointers.
+func TestApplyToConfig_OnlyLinkedAgents(t *testing.T) {
+	f := &stubFetcher{body: validDef}
+	r := NewResolver(f, allowAll, nil)
+
+	cfg := &config.Config{Agents: map[string]config.AgentConfig{
+		"scanner": {
+			DisplayName:      "Baked Scanner",
+			Paused:           true,
+			DefinitionSource: &config.DefinitionSourceConfig{Owner: "kubestellar", Repo: "hive", Path: "agents/scanner.yaml", Ref: "v2"},
+		},
+		"reviewer": {DisplayName: "Reviewer", Paused: true}, // no definition_source
+	}}
+
+	ApplyToConfig(context.Background(), cfg, r, nil)
+
+	sc := cfg.Agents["scanner"]
+	if sc.DisplayName != "Live Scanner" {
+		t.Errorf("linked agent not merged: %q", sc.DisplayName)
+	}
+	if !sc.Paused {
+		t.Error("merge must preserve paused")
+	}
+	if sc.DefinitionSource == nil {
+		t.Error("merge must preserve definition_source pointer")
+	}
+	if f.lastRef != "v2" {
+		t.Errorf("ref not threaded: %q", f.lastRef)
+	}
+
+	rv := cfg.Agents["reviewer"]
+	if rv.DisplayName != "Reviewer" {
+		t.Error("unlinked agent must be left untouched")
+	}
+	if f.callCount() != 1 {
+		t.Errorf("only the linked agent should be fetched, calls=%d", f.callCount())
+	}
+}
+
+// TestApplyToConfig_NilResolverNoop.
+func TestApplyToConfig_NilResolverNoop(t *testing.T) {
+	cfg := &config.Config{Agents: map[string]config.AgentConfig{
+		"scanner": {DisplayName: "Baked", DefinitionSource: &config.DefinitionSourceConfig{Owner: "o", Repo: "r", Path: "a.yaml"}},
+	}}
+	ApplyToConfig(context.Background(), cfg, nil, nil) // must not panic
+	if cfg.Agents["scanner"].DisplayName != "Baked" {
+		t.Error("nil resolver must be a no-op")
+	}
+}
+
+// TestParseDefinition_Validation.
+func TestParseDefinition_Validation(t *testing.T) {
+	if _, err := ParseDefinition("kind: Wrong\nmetadata:\n  name: x"); err == nil {
+		t.Error("wrong kind should error")
+	}
+	if _, err := ParseDefinition("kind: AgentDefinition\nmetadata: {}"); err == nil {
+		t.Error("missing name should error")
+	}
+	if _, err := ParseDefinition("::not yaml::"); err == nil {
+		t.Error("malformed yaml should error")
+	}
+}

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -624,7 +624,18 @@ func (c *Client) GetContributorCount(ctx context.Context, owner, repo string) (i
 }
 
 func (c *Client) GetFileContent(ctx context.Context, owner, repo, path string) (string, error) {
-	fc, _, _, err := c.client.Repositories.GetContents(ctx, owner, repo, path, nil)
+	return c.GetFileContentRef(ctx, owner, repo, path, "")
+}
+
+// GetFileContentRef reads a single file's decoded contents from a repo at an
+// optional git ref (branch, tag, or SHA). An empty ref uses the repo's default
+// branch. Errors if the path resolves to a directory rather than a file.
+func (c *Client) GetFileContentRef(ctx context.Context, owner, repo, path, ref string) (string, error) {
+	var opts *gh.RepositoryContentGetOptions
+	if ref != "" {
+		opts = &gh.RepositoryContentGetOptions{Ref: ref}
+	}
+	fc, _, _, err := c.client.Repositories.GetContents(ctx, owner, repo, path, opts)
 	if err != nil {
 		return "", fmt.Errorf("getting file %s/%s/%s: %w", owner, repo, path, err)
 	}

--- a/v2/pkg/promptsrc/promptsrc.go
+++ b/v2/pkg/promptsrc/promptsrc.go
@@ -1,0 +1,224 @@
+// Package promptsrc resolves an agent's kick prompt from an external source
+// (currently a GitHub repo file) at kick time, with graceful fallback so a
+// transient fetch failure never crashes or blanks a kick.
+//
+// Design (resolve-at-kick, not bake-at-create):
+//
+// The kick-template pipeline (pkg/scheduler) already loads the template fresh on
+// every kick, so a live GitHub fetch fits the existing model — an operator can
+// edit the prompt on their fork and the next kick picks it up, no redeploy. The
+// trade-off is a failure mode the baked approach doesn't have: the repo can be
+// unreachable at kick time. This package handles that by caching the last
+// successfully fetched body per source and returning it (then the caller's inline
+// template) on any error. The very first kick after a cold start, before any
+// successful fetch, falls through to the caller's inline/baked template — which
+// is why callers also bake a copy at agent-create time.
+//
+// Security: fetching is gated by an Allow func the caller supplies from the
+// SEED-only config policy (see config.Config.GitHubPromptAllowed). A source whose
+// "owner/repo" slug is not allowlisted is never fetched, so a user-writable
+// dashboard overlay cannot point an agent at an arbitrary repo the App is
+// installed on. This package performs no network I/O of its own beyond the
+// injected Fetcher, and never touches tokens directly.
+package promptsrc
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+)
+
+// maxPromptBytes caps how large a fetched prompt body may be. A kick prompt is a
+// markdown template (kilobytes); this bounds memory/log blast radius if a source
+// path points at something huge, while staying well above any real template.
+const maxPromptBytes = 512 * 1024 // 512 KiB
+
+// defaultFetchTimeout bounds a single live fetch so a slow/hung GitHub API call
+// cannot stall a kick. On timeout the resolver falls back to the cache/inline.
+const defaultFetchTimeout = 8 * time.Second
+
+// Source is the minimal, config-package-agnostic description of a GitHub prompt
+// source. The config.PromptSourceConfig is adapted into this at the call site.
+type Source struct {
+	Owner string
+	Repo  string
+	Path  string
+	Ref   string // optional branch/tag/SHA; "" = default branch
+}
+
+// Slug is the "owner/repo" identifier used for allowlist matching and cache keys.
+func (s Source) Slug() string {
+	if s.Owner == "" || s.Repo == "" {
+		return ""
+	}
+	return s.Owner + "/" + s.Repo
+}
+
+// key is the full cache key including path and ref, so two agents reading
+// different files from the same repo don't share a cache entry.
+func (s Source) key() string {
+	return strings.Join([]string{s.Owner, s.Repo, s.Path, s.Ref}, "\x00")
+}
+
+// valid reports whether the source is fully specified.
+func (s Source) valid() bool {
+	return s.Owner != "" && s.Repo != "" && s.Path != ""
+}
+
+// Fetcher reads a file's decoded contents from a repo at an optional ref. It is
+// satisfied by *github.Client.GetFileContentRef, and stubbed in tests.
+type Fetcher interface {
+	GetFileContentRef(ctx context.Context, owner, repo, path, ref string) (string, error)
+}
+
+// AllowFunc reports whether a given "owner/repo" slug may be fetched. Callers
+// wire this to the seed-only policy (config.Config.GitHubPromptAllowed).
+type AllowFunc func(slug string) bool
+
+// Logger is the tiny logging surface this package needs, satisfied by *slog.Logger.
+type Logger interface {
+	Warn(msg string, args ...any)
+	Info(msg string, args ...any)
+}
+
+// Resolver fetches prompt bodies live and remembers the last good value per
+// source so a later failure can fall back to it. It is safe for concurrent use.
+type Resolver struct {
+	fetcher Fetcher
+	allow   AllowFunc
+	logger  Logger
+	timeout time.Duration
+
+	mu    sync.RWMutex
+	cache map[string]string // source key -> last-known-good body
+}
+
+// NewResolver builds a Resolver. fetcher may be nil (e.g. token-mode boot without
+// an App client), in which case every resolution reports a miss and the caller
+// falls back to its inline template. allow must be non-nil; a nil allow denies
+// everything (fail closed). logger may be nil.
+func NewResolver(fetcher Fetcher, allow AllowFunc, logger Logger) *Resolver {
+	if allow == nil {
+		allow = func(string) bool { return false }
+	}
+	return &Resolver{
+		fetcher: fetcher,
+		allow:   allow,
+		logger:  logger,
+		timeout: defaultFetchTimeout,
+		cache:   map[string]string{},
+	}
+}
+
+// Result carries a resolved prompt body plus provenance for logging/UI. Ok is
+// false when nothing could be resolved (not set, denied, no fetcher, and no
+// cached value) — the caller should then use its inline template.
+type Result struct {
+	Body   string
+	Ok     bool
+	Source string // provenance: "github:owner/repo@ref", "github-cache:...", or "denied"/"unset"/"no-client"
+}
+
+// Resolve attempts a live fetch of the source, falling back to the last-known-good
+// cached body on any failure. It never returns an error: a kick must proceed even
+// when the source is unreachable, so failure is expressed as Ok=false (or a cached
+// Result) and logged, not propagated.
+func (r *Resolver) Resolve(ctx context.Context, src Source) Result {
+	if !src.valid() {
+		return Result{Source: "unset"}
+	}
+	slug := src.Slug()
+	if !r.allow(slug) {
+		if r.logger != nil {
+			r.logger.Warn("prompt source repo not allowlisted, ignoring (falling back to inline template)", "repo", slug)
+		}
+		return Result{Source: "denied"}
+	}
+	if r.fetcher == nil {
+		// No GitHub client wired (e.g. token-less boot). Serve cache if we have
+		// one, else report a miss so the caller uses its inline template.
+		if body, ok := r.cached(src); ok {
+			return Result{Body: body, Ok: true, Source: "github-cache:" + slug}
+		}
+		return Result{Source: "no-client"}
+	}
+
+	fetchCtx := ctx
+	if ctx == nil {
+		fetchCtx = context.Background()
+	}
+	fetchCtx, cancel := context.WithTimeout(fetchCtx, r.timeout)
+	defer cancel()
+
+	body, err := r.fetcher.GetFileContentRef(fetchCtx, src.Owner, src.Repo, src.Path, src.Ref)
+	if err != nil {
+		if r.logger != nil {
+			r.logger.Warn("failed to fetch prompt from GitHub, falling back", "repo", slug, "path", src.Path, "error", err)
+		}
+		if body, ok := r.cached(src); ok {
+			return Result{Body: body, Ok: true, Source: "github-cache:" + slug}
+		}
+		return Result{Source: "error"}
+	}
+	if len(body) > maxPromptBytes {
+		body = body[:maxPromptBytes]
+		if r.logger != nil {
+			r.logger.Warn("prompt from GitHub exceeded size cap, truncated", "repo", slug, "path", src.Path, "cap_bytes", maxPromptBytes)
+		}
+	}
+	r.store(src, body)
+	return Result{Body: body, Ok: true, Source: r.provenance(src)}
+}
+
+func (r *Resolver) provenance(src Source) string {
+	ref := src.Ref
+	if ref == "" {
+		ref = "default"
+	}
+	return fmt.Sprintf("github:%s@%s", src.Slug(), ref)
+}
+
+func (r *Resolver) cached(src Source) (string, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	body, ok := r.cache[src.key()]
+	return body, ok
+}
+
+func (r *Resolver) store(src Source, body string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cache[src.key()] = body
+}
+
+// FetchOnce does a single gated fetch WITHOUT touching the resolver cache. It is
+// used at agent-create/edit time to bake an initial copy and to validate that the
+// source is reachable before saving. It returns an error (unlike Resolve) so the
+// UI can surface a bad owner/repo/path to the operator.
+func FetchOnce(ctx context.Context, fetcher Fetcher, allow AllowFunc, src Source) (string, error) {
+	if !src.valid() {
+		return "", fmt.Errorf("prompt source is incomplete (owner, repo, and path are required)")
+	}
+	slug := src.Slug()
+	if allow == nil || !allow(slug) {
+		return "", fmt.Errorf("repo %q is not on the GitHub prompt allowlist", slug)
+	}
+	if fetcher == nil {
+		return "", fmt.Errorf("no GitHub client available to fetch prompt")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	fctx, cancel := context.WithTimeout(ctx, defaultFetchTimeout)
+	defer cancel()
+	body, err := fetcher.GetFileContentRef(fctx, src.Owner, src.Repo, src.Path, src.Ref)
+	if err != nil {
+		return "", err
+	}
+	if len(body) > maxPromptBytes {
+		body = body[:maxPromptBytes]
+	}
+	return body, nil
+}

--- a/v2/pkg/promptsrc/promptsrc_test.go
+++ b/v2/pkg/promptsrc/promptsrc_test.go
@@ -1,0 +1,216 @@
+package promptsrc
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// stubFetcher is a test Fetcher. It records call counts and returns a scripted
+// body/error, letting us drive the cache/fallback paths deterministically.
+type stubFetcher struct {
+	mu    sync.Mutex
+	body  string
+	err   error
+	calls int
+	// lastRef captures the ref passed on the most recent call.
+	lastRef string
+}
+
+func (f *stubFetcher) GetFileContentRef(_ context.Context, _, _, _, ref string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	f.lastRef = ref
+	return f.body, f.err
+}
+
+func (f *stubFetcher) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func allowAll(string) bool  { return true }
+func allowNone(string) bool { return false }
+
+func fullSource() Source {
+	return Source{Owner: "kubestellar", Repo: "hive", Path: "prompts/scanner.md", Ref: "v2"}
+}
+
+// TestResolve_HappyPath: a valid, allowlisted source is fetched and returned.
+func TestResolve_HappyPath(t *testing.T) {
+	f := &stubFetcher{body: "you are the scanner"}
+	r := NewResolver(f, allowAll, nil)
+	res := r.Resolve(context.Background(), fullSource())
+	if !res.Ok || res.Body != "you are the scanner" {
+		t.Fatalf("want ok body, got ok=%v body=%q", res.Ok, res.Body)
+	}
+	if !strings.HasPrefix(res.Source, "github:kubestellar/hive@v2") {
+		t.Errorf("provenance = %q, want github:kubestellar/hive@v2", res.Source)
+	}
+	if f.lastRef != "v2" {
+		t.Errorf("ref not passed through: %q", f.lastRef)
+	}
+}
+
+// TestResolve_UnsetSource: an incomplete source is a miss (Ok=false), never a fetch.
+func TestResolve_UnsetSource(t *testing.T) {
+	f := &stubFetcher{body: "x"}
+	r := NewResolver(f, allowAll, nil)
+	res := r.Resolve(context.Background(), Source{Owner: "o", Repo: "r"}) // no path
+	if res.Ok {
+		t.Errorf("incomplete source should be a miss, got %+v", res)
+	}
+	if f.callCount() != 0 {
+		t.Errorf("incomplete source should not fetch, calls=%d", f.callCount())
+	}
+	if res.Source != "unset" {
+		t.Errorf("source = %q, want unset", res.Source)
+	}
+}
+
+// TestResolve_DeniedByAllowlist: a repo not on the allowlist is never fetched.
+func TestResolve_DeniedByAllowlist(t *testing.T) {
+	f := &stubFetcher{body: "secret"}
+	r := NewResolver(f, allowNone, nil)
+	res := r.Resolve(context.Background(), fullSource())
+	if res.Ok {
+		t.Errorf("denied source should be a miss, got %+v", res)
+	}
+	if f.callCount() != 0 {
+		t.Errorf("denied source must not fetch (SSRF/exfil guard), calls=%d", f.callCount())
+	}
+	if res.Source != "denied" {
+		t.Errorf("source = %q, want denied", res.Source)
+	}
+}
+
+// TestResolve_NilAllowDeniesAll: a nil AllowFunc fails closed.
+func TestResolve_NilAllowDeniesAll(t *testing.T) {
+	f := &stubFetcher{body: "secret"}
+	r := NewResolver(f, nil, nil)
+	res := r.Resolve(context.Background(), fullSource())
+	if res.Ok || f.callCount() != 0 {
+		t.Errorf("nil allow must deny all, got ok=%v calls=%d", res.Ok, f.callCount())
+	}
+}
+
+// TestResolve_FallbackToCacheOnError: after one success, a later failure serves
+// the last-known-good body rather than blanking the kick.
+func TestResolve_FallbackToCacheOnError(t *testing.T) {
+	f := &stubFetcher{body: "good prompt"}
+	r := NewResolver(f, allowAll, nil)
+
+	first := r.Resolve(context.Background(), fullSource())
+	if !first.Ok || first.Body != "good prompt" {
+		t.Fatalf("first resolve should succeed, got %+v", first)
+	}
+
+	// Now the repo becomes unreachable.
+	f.mu.Lock()
+	f.body = ""
+	f.err = errors.New("boom: repo unreachable")
+	f.mu.Unlock()
+
+	second := r.Resolve(context.Background(), fullSource())
+	if !second.Ok || second.Body != "good prompt" {
+		t.Fatalf("failure should fall back to cache, got %+v", second)
+	}
+	if !strings.HasPrefix(second.Source, "github-cache:") {
+		t.Errorf("provenance = %q, want github-cache:*", second.Source)
+	}
+}
+
+// TestResolve_ErrorNoCache: a failure with no prior success is a miss so the
+// caller falls back to its inline template — never an error, never a crash.
+func TestResolve_ErrorNoCache(t *testing.T) {
+	f := &stubFetcher{err: errors.New("boom")}
+	r := NewResolver(f, allowAll, nil)
+	res := r.Resolve(context.Background(), fullSource())
+	if res.Ok {
+		t.Errorf("cold failure should be a miss, got %+v", res)
+	}
+	if res.Source != "error" {
+		t.Errorf("source = %q, want error", res.Source)
+	}
+}
+
+// TestResolve_NilFetcher: no client wired -> miss (caller uses inline template).
+func TestResolve_NilFetcher(t *testing.T) {
+	r := NewResolver(nil, allowAll, nil)
+	res := r.Resolve(context.Background(), fullSource())
+	if res.Ok || res.Source != "no-client" {
+		t.Errorf("nil fetcher should miss with no-client, got %+v", res)
+	}
+}
+
+// TestResolve_TruncatesOversizeBody: a body over the cap is truncated, not rejected.
+func TestResolve_TruncatesOversizeBody(t *testing.T) {
+	huge := strings.Repeat("a", maxPromptBytes+100)
+	f := &stubFetcher{body: huge}
+	r := NewResolver(f, allowAll, nil)
+	res := r.Resolve(context.Background(), fullSource())
+	if !res.Ok {
+		t.Fatalf("oversize body should still resolve, got %+v", res)
+	}
+	if len(res.Body) != maxPromptBytes {
+		t.Errorf("body len = %d, want %d (truncated to cap)", len(res.Body), maxPromptBytes)
+	}
+}
+
+// TestResolve_NilContext: a nil context must not panic (kick callers pass Background,
+// but defense-in-depth).
+func TestResolve_NilContext(t *testing.T) {
+	f := &stubFetcher{body: "ok"}
+	r := NewResolver(f, allowAll, nil)
+	//nolint:staticcheck // deliberately passing nil ctx to exercise the guard
+	res := r.Resolve(nil, fullSource())
+	if !res.Ok {
+		t.Errorf("nil ctx should be tolerated, got %+v", res)
+	}
+}
+
+// TestFetchOnce_Gating: FetchOnce enforces the same allowlist gate and surfaces
+// errors (unlike Resolve) so the create/edit UI can report a bad source.
+func TestFetchOnce_Gating(t *testing.T) {
+	f := &stubFetcher{body: "baked"}
+
+	if _, err := FetchOnce(context.Background(), f, allowNone, fullSource()); err == nil {
+		t.Error("denied repo should error")
+	}
+	if f.callCount() != 0 {
+		t.Errorf("denied FetchOnce must not fetch, calls=%d", f.callCount())
+	}
+
+	if _, err := FetchOnce(context.Background(), f, allowAll, Source{Owner: "o"}); err == nil {
+		t.Error("incomplete source should error")
+	}
+
+	if _, err := FetchOnce(context.Background(), nil, allowAll, fullSource()); err == nil {
+		t.Error("nil fetcher should error")
+	}
+
+	body, err := FetchOnce(context.Background(), f, allowAll, fullSource())
+	if err != nil || body != "baked" {
+		t.Errorf("valid FetchOnce failed: body=%q err=%v", body, err)
+	}
+}
+
+// TestSource_Helpers exercises Slug/valid/key edge cases.
+func TestSource_Helpers(t *testing.T) {
+	if (Source{}).Slug() != "" {
+		t.Error("empty source slug should be empty")
+	}
+	if s := (Source{Owner: "o", Repo: "r"}); s.Slug() != "o/r" {
+		t.Errorf("slug = %q", s.Slug())
+	}
+	// Two sources differing only by path must have distinct cache keys.
+	a := Source{Owner: "o", Repo: "r", Path: "a.md"}
+	b := Source{Owner: "o", Repo: "r", Path: "b.md"}
+	if a.key() == b.key() {
+		t.Error("different paths must not share a cache key")
+	}
+}

--- a/v2/pkg/scheduler/prompt_source_test.go
+++ b/v2/pkg/scheduler/prompt_source_test.go
@@ -1,0 +1,133 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/promptsrc"
+)
+
+type fakeFetcher struct {
+	body string
+	err  error
+}
+
+func (f fakeFetcher) GetFileContentRef(_ context.Context, _, _, _, _ string) (string, error) {
+	return f.body, f.err
+}
+
+func newPromptSourceCfg(t *testing.T, extraAgent config.AgentConfig, allow bool, allowlist []string) *config.Config {
+	t.Helper()
+	dir := t.TempDir()
+	agentsDir := filepath.Join(dir, "examples", "kubestellar", "agents")
+	if err := os.MkdirAll(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Inline fallback template on disk for the agent.
+	if err := os.WriteFile(filepath.Join(agentsDir, "gh-agent.md"), []byte("INLINE FALLBACK for ${REPO}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	extraAgent.KickTemplate = "gh-agent.md"
+	return &config.Config{
+		Project: config.ProjectConfig{Org: "testorg", Name: "t", PrimaryRepo: "r", Repos: []string{"r"}},
+		Agents:  map[string]config.AgentConfig{"gh-agent": extraAgent},
+		Policies: config.PoliciesConfig{LocalDir: dir},
+		Variables: config.VariablesConfig{Security: config.VarSecurityConfig{
+			AllowGitHubPrompt:     allow,
+			GitHubPromptAllowlist: allowlist,
+		}},
+	}
+}
+
+// TestBuildAgentMessage_GitHubPromptWins: an allowlisted, reachable prompt source
+// is used over the inline kick template.
+func TestBuildAgentMessage_GitHubPromptWins(t *testing.T) {
+	agent := config.AgentConfig{
+		Role:         "gh-agent",
+		PromptSource: &config.PromptSourceConfig{Owner: "testorg", Repo: "prompts", Path: "gh-agent.md"},
+	}
+	cfg := newPromptSourceCfg(t, agent, true, []string{"testorg/prompts"})
+	s := New(cfg, slog.Default())
+	s.SetGitHubPromptResolver(promptsrc.NewResolver(
+		fakeFetcher{body: "REMOTE PROMPT from github"},
+		func(slug string) bool { return cfg.GitHubPromptAllowed(slug) },
+		nil,
+	))
+
+	msg := s.BuildAgentMessage("gh-agent", nil, nil)
+	if !contains(msg, "REMOTE PROMPT from github") {
+		t.Errorf("expected remote prompt to be used, got: %q", msg)
+	}
+	if contains(msg, "INLINE FALLBACK") {
+		t.Error("inline fallback should not appear when remote source succeeds")
+	}
+}
+
+// TestBuildAgentMessage_GitHubPromptDeniedFallsBack: a source whose repo is NOT
+// allowlisted is ignored and the inline template is used — the fetch never runs.
+func TestBuildAgentMessage_GitHubPromptDeniedFallsBack(t *testing.T) {
+	agent := config.AgentConfig{
+		Role:         "gh-agent",
+		PromptSource: &config.PromptSourceConfig{Owner: "attacker", Repo: "evil", Path: "x.md"},
+	}
+	// Allowlist does NOT include attacker/evil.
+	cfg := newPromptSourceCfg(t, agent, true, []string{"testorg/prompts"})
+	s := New(cfg, slog.Default())
+	s.SetGitHubPromptResolver(promptsrc.NewResolver(
+		fakeFetcher{body: "SHOULD NEVER BE FETCHED"},
+		func(slug string) bool { return cfg.GitHubPromptAllowed(slug) },
+		nil,
+	))
+
+	msg := s.BuildAgentMessage("gh-agent", nil, nil)
+	if contains(msg, "SHOULD NEVER BE FETCHED") {
+		t.Fatal("denied repo must not be fetched (security gate)")
+	}
+	if !contains(msg, "INLINE FALLBACK") {
+		t.Errorf("expected inline fallback, got: %q", msg)
+	}
+}
+
+// TestBuildAgentMessage_GitHubPromptUnreachableFallsBack: an allowlisted source
+// whose fetch errors (and has no cached value) falls back to the inline template
+// rather than blanking or crashing the kick.
+func TestBuildAgentMessage_GitHubPromptUnreachableFallsBack(t *testing.T) {
+	agent := config.AgentConfig{
+		Role:         "gh-agent",
+		PromptSource: &config.PromptSourceConfig{Owner: "testorg", Repo: "prompts", Path: "gh-agent.md"},
+	}
+	cfg := newPromptSourceCfg(t, agent, true, []string{"testorg/prompts"})
+	s := New(cfg, slog.Default())
+	s.SetGitHubPromptResolver(promptsrc.NewResolver(
+		fakeFetcher{err: errors.New("network down")},
+		func(slug string) bool { return cfg.GitHubPromptAllowed(slug) },
+		nil,
+	))
+
+	msg := s.BuildAgentMessage("gh-agent", nil, nil)
+	if !contains(msg, "INLINE FALLBACK") {
+		t.Errorf("unreachable source should fall back to inline, got: %q", msg)
+	}
+}
+
+// TestBuildAgentMessage_NoResolverFallsBack: with no resolver wired, a prompt
+// source is ignored and the inline template is used.
+func TestBuildAgentMessage_NoResolverFallsBack(t *testing.T) {
+	agent := config.AgentConfig{
+		Role:         "gh-agent",
+		PromptSource: &config.PromptSourceConfig{Owner: "testorg", Repo: "prompts", Path: "gh-agent.md"},
+	}
+	cfg := newPromptSourceCfg(t, agent, true, []string{"testorg/prompts"})
+	s := New(cfg, slog.Default())
+	// No SetGitHubPromptResolver call.
+
+	msg := s.BuildAgentMessage("gh-agent", nil, nil)
+	if !contains(msg, "INLINE FALLBACK") {
+		t.Errorf("no resolver should fall back to inline, got: %q", msg)
+	}
+}

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/github"
 	"github.com/kubestellar/hive/v2/pkg/knowledge"
 	"github.com/kubestellar/hive/v2/pkg/policies"
+	"github.com/kubestellar/hive/v2/pkg/promptsrc"
 	"github.com/kubestellar/hive/v2/pkg/resolve"
 )
 
@@ -24,6 +25,7 @@ type Scheduler struct {
 	inception      *knowledge.InceptionEngine
 	lastActionable *github.ActionableResult
 	logger         *slog.Logger
+	promptResolver *promptsrc.Resolver
 	mu             sync.RWMutex
 }
 
@@ -40,6 +42,22 @@ func New(cfg *config.Config, logger *slog.Logger) *Scheduler {
 		cfg:    cfg,
 		logger: logger,
 	}
+}
+
+// SetGitHubPromptResolver attaches a resolver used to fetch an agent's kick
+// prompt from a GitHub repo (agent.prompt_source). When nil, agents with a
+// prompt_source silently fall back to their inline kick template.
+func (s *Scheduler) SetGitHubPromptResolver(r *promptsrc.Resolver) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.promptResolver = r
+}
+
+// gitHubPromptResolver returns the attached resolver, or nil if none is set.
+func (s *Scheduler) gitHubPromptResolver() *promptsrc.Resolver {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.promptResolver
 }
 
 // SetPrimer attaches a knowledge primer to the scheduler. When set, kick
@@ -349,6 +367,27 @@ const maxIssuesPerKick = 100
 // BuildAgentMessage constructs a kick prompt for the named agent using the
 // template resolution chain (config kick_template → convention → embedded → hardcoded).
 func (s *Scheduler) BuildAgentMessage(agentName string, issues []github.Issue, actionable *github.ActionableResult) string {
+	// 0. GitHub-sourced prompt: if the agent declares a prompt_source, resolve it
+	//    live at kick time (with allowlist gating + graceful fallback). A miss
+	//    (unset, denied, unreachable with no cache) falls through to the inline
+	//    template chain below, so a bad source never blanks or crashes a kick.
+	if agentCfg, ok := s.cfg.Agents[agentName]; ok && agentCfg.PromptSource.IsSet() {
+		if resolver := s.gitHubPromptResolver(); resolver != nil {
+			src := promptsrc.Source{
+				Owner: agentCfg.PromptSource.Owner,
+				Repo:  agentCfg.PromptSource.Repo,
+				Path:  agentCfg.PromptSource.Path,
+				Ref:   agentCfg.PromptSource.Ref,
+			}
+			if res := resolver.Resolve(context.Background(), src); res.Ok && res.Body != "" {
+				s.logger.Info("using GitHub-sourced kick prompt", "agent", agentName, "source", res.Source)
+				msg := fmt.Sprintf("[agent:%s]\n\n", agentName)
+				msg += s.substituteTemplate(res.Body, actionable, agentName, issues)
+				return msg
+			}
+		}
+	}
+
 	// 1. Config-driven: use kick_template field if set
 	if agentCfg, ok := s.cfg.Agents[agentName]; ok && agentCfg.KickTemplate != "" {
 		if template := s.loadNamedTemplate(agentCfg.KickTemplate); template != "" {


### PR DESCRIPTION
## What

Lets you define a new agent (via the dashboard **+ agent**) by pulling from a GitHub org/repo — either the **full agent definition** or just the **prompt template** — with a **"Keep linked to repo (live)"** opt-in on each.

### Two entry points, same pattern
1. **Import tab** — "Keep linked to repo (live)" checkbox on URL import:
   - **Unchecked (default):** bake the YAML into a local agent (existing behavior).
   - **Checked (live):** persist `definition_source` (repo/ref/path); on reload/kick the full definition is re-fetched and its operator-safe fields re-applied, so repo edits propagate.
2. **Prompt Template tab** — "Import from repo" + the same live opt-in, wired to `prompt_source`:
   - **Live:** prompt resolves at kick time (scheduler path), edit-on-fork-propagates.
   - **Once:** fetch + bake into the kick template file.

## Trust boundary (the security-critical part)

A repo-sourced **live** definition may set presentation + behavior only — name, display, emoji, color, backend, model, role, mode, sort order, bead role, stale timeout, restart strategy, clear-on-kick, include-repos, channels, tools. It **never** touches privilege/lifecycle/seed-only fields:
- the `prompt_source`/`definition_source` pointers themselves (can't re-point the agent at another repo),
- `Enabled`/`Paused`/`Managed` lifecycle,
- `ID`/`BeadsDir`/`ACMMLevels`/`OnDemand`/`CavemanMode`,
- the hive-level `variables.security` exec/http policy (seed-only by construction; not even on `AgentConfig`).

A missing field in a fetched definition does **not** wipe the baked value. On any repo-fetch failure the last-known-good baked config is served — a live source never blanks or crashes an agent.

## Security gating
- Fetching reuses the existing GitHub App token (`github.Client.GetFileContentRef`) — no new token plumbing, no arbitrary URLs.
- `variables.security.allow_github_prompt` + `github_prompt_allowlist` (and the definition equivalent) are **seed-only**: `LoadWithDashboardOverlay` never merges the overlay's `Variables` block, so a user-writable overlay can't widen the allowlist, point a source at a non-allowlisted repo, or escalate an agent's privileges. Tests assert each of these.

## Files
- `pkg/promptsrc/` — live prompt resolver (fetch + cache + graceful fallback) + `FetchOnce` bake.
- `pkg/defsrc/` — live whole-agent resolver; `mergeAllowedFields` is the single trust-boundary function.
- `pkg/config/config.go` — `PromptSourceConfig`, `DefinitionSourceConfig`, allowlist fields + `GitHubPromptAllowed`/`GitHubDefinitionAllowed`.
- `pkg/github/client.go` — `GetFileContentRef` (ref-aware read).
- `pkg/scheduler/scheduler.go` — prompt_source resolves at kick, falls through on miss.
- `pkg/dashboard/api.go` / `api_agents.go` — import `keepLinked`, expose/consume both sources, reload re-resolution.
- `pkg/dashboard/static/index.html` — Import-tab checkbox + Prompt-Template repo inputs/checkbox; `(arr || [])` guards; named consts.

## Tests
`go build ./...`, `go vet`, and `go test` across promptsrc/defsrc/config/scheduler/dashboard/github all pass; `node --check` on the dashboard script is clean. Coverage includes: trust-boundary merge skips seed-only/privileged fields, live-fetch failure → baked fallback, overlay can't widen the allowlist or point at a non-allowlisted repo, keepLinked persists `definition_source`, unchecked stays a plain baked agent.