### PR TITLE
feat(dashboard): always offer mai-code-1-flash-picker in copilot model dropdown

### DIFF
--- a/v2/pkg/dashboard/cli_models.go
+++ b/v2/pkg/dashboard/cli_models.go
@@ -140,6 +140,17 @@ var copilotStaticModels = []string{
 	"o4-mini",
 }
 
+// copilotAlwaysIncludeModels are ids that must ALWAYS be offered in the
+// copilot dropdown, whether the served list came from live discovery or the
+// static fallback. The Copilot /models endpoint omits rollout-gated ids
+// nondeterministically (see cliModelDropAfterMisses), and an id that never
+// appears in a live sample can neither be selected nor survive the
+// dashboard's model auto-heal. Ids listed here are appended to every served
+// copilot list so agents can be pinned to them safely.
+var copilotAlwaysIncludeModels = []string{
+	"mai-code-1-flash-picker",
+}
+
 // geminiStaticModels is the fallback when no Gemini API key is configured (or
 // discovery fails). Keep CURRENT.
 var geminiStaticModels = []string{
@@ -288,6 +299,12 @@ func (s *Server) queryCLIModels(backend string) cliModelResult {
 		// a model seen recently is kept through transient upstream omissions
 		// so a single bad sample cannot trigger downstream auto-heal churn.
 		r.models = s.cliModels.stabilize(backend, r.models)
+	}
+	// Applied after stabilization/fallback so the pinned ids survive BOTH
+	// paths: a live sample that omits a rollout-gated id and the static
+	// fallback list (see copilotAlwaysIncludeModels).
+	if backend == "copilot" {
+		r.models = dedupeModels(append(r.models, copilotAlwaysIncludeModels...))
 	}
 	if s.cliModels != nil {
 		s.cliModels.set(backend, r)

--- a/v2/pkg/dashboard/cli_models_test.go
+++ b/v2/pkg/dashboard/cli_models_test.go
@@ -116,6 +116,21 @@ func TestQueryCLIModels_CopilotFallbackNoToken(t *testing.T) {
 	}
 }
 
+// TestQueryCLIModels_CopilotAlwaysIncludePinned verifies every id in
+// copilotAlwaysIncludeModels is present in the served copilot list even when
+// it is the static fallback (no token), so rollout-gated ids stay selectable
+// and safe from model auto-heal regardless of what live discovery returns.
+func TestQueryCLIModels_CopilotAlwaysIncludePinned(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "")
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.queryCLIModels("copilot")
+	for _, m := range copilotAlwaysIncludeModels {
+		if !contains(r.models, m) {
+			t.Fatalf("always-include id %q missing from served copilot list: %v", m, r.models)
+		}
+	}
+}
+
 // TestQueryCLIModels_GeminiFallbackNoKey verifies gemini falls back when no
 // API key is configured.
 func TestQueryCLIModels_GeminiFallbackNoKey(t *testing.T) {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4587,6 +4587,7 @@
       { value: 'claude-fable-5', label: 'Fable 5' },
     ];
     const COPILOT_CLI_MODELS = [
+      { value: 'mai-code-1-flash-picker', label: 'MAI Code 1 Flash' },
       { value: 'claude-opus-4.6', label: 'Opus 4.6' },
       { value: 'claude-sonnet-4.6', label: 'Sonnet 4.6' },
       { value: 'claude-sonnet-4.5', label: 'Sonnet 4.5' },


### PR DESCRIPTION
## Summary
Adds `mai-code-1-flash-picker` to the copilot models dropdown via a new server-side **always-include** list rather than just the static fallback.

Why an always-include list: the Copilot `/models` endpoint omits rollout-gated ids nondeterministically (the existing `cliModelDropAfterMisses` retention only smooths ids that have been seen live at least once). An id that never shows up in a live sample can neither be selected in the dropdown nor survive the dashboard's model auto-heal — it would switch agents right back off it. Ids in `copilotAlwaysIncludeModels` are appended to every served copilot list (live and fallback), making agents safe to pin to them.

## Changes
- `cli_models.go`: `copilotAlwaysIncludeModels = [mai-code-1-flash-picker]`, unioned into the served list in `queryCLIModels` after stabilization/fallback
- `static/index.html`: `MAI Code 1 Flash` added to `COPILOT_CLI_MODELS` (paint-time fallback before first `/api/config/backends` response)
- Test: `TestQueryCLIModels_CopilotAlwaysIncludePinned`

🤖 Generated with [Claude Code](https://claude.com/claude-code)