### PR TITLE
feat(contribute): podman support for containerized contributor mode

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -8,6 +8,9 @@ set shell := ["bash", "-euo", "pipefail", "-c"]
 hive_image := env("HIVE_CONTRIBUTOR_IMAGE", "ghcr.io/kubestellar/hive-contributor:latest")
 hive_hub := env("HIVE_HUB", "wss://hive.kubestellar.io/contribute")
 config_dir := env("HOME") + "/.config/hive"
+# Container runtime for containerized mode. Empty = auto-detect (docker, then
+# podman). Set HIVE_CONTAINER_RUNTIME=podman to force podman.
+container_runtime := env("HIVE_CONTAINER_RUNTIME", "")
 
 # Show available commands
 default:
@@ -282,13 +285,11 @@ contribute-setup backend="claude": check-version
     echo ""
     echo "Run 'just contribute-hive' to start contributing."
 
-# Start contributing — Docker (default) or local mode
-# Usage: just contribute-hive        (Docker, reads CLI from contributor.env)
-#        just contribute-hive local   (native, starts relay + CLI directly)
-# Start contributing — Docker (default) or local mode
-# Usage: just contribute-hive              (Docker, default CLI from setup)
-#        just contribute-hive copilot      (Docker, copilot backend)
+# Start contributing — containerized (default; docker or podman) or local mode
+# Usage: just contribute-hive              (container, default CLI from setup)
+#        just contribute-hive copilot      (container, copilot backend)
 #        just contribute-hive claude local  (native mode, claude)
+# Runtime: auto-detects docker then podman; force with HIVE_CONTAINER_RUNTIME=podman
 contribute-hive backend="" mode="docker": check-version
     #!/usr/bin/env bash
     set -euo pipefail
@@ -412,35 +413,63 @@ contribute-hive backend="" mode="docker": check-version
       echo "Relay logs:"
       wait "$RELAY_PID"
     else
-      # ── Docker mode: stop existing, start fresh ──
+      # ── Container mode: stop existing, start fresh ──
+      # Resolve the container runtime: HIVE_CONTAINER_RUNTIME wins, else
+      # docker, else podman. Podman gets --userns=keep-id (rootless UID
+      # mapping so the container's dev user can read the mounted configs)
+      # and SELinux-friendly volume labels (,Z).
+      RUNTIME="{{container_runtime}}"
+      if [[ -z "$RUNTIME" ]]; then
+        if command -v docker >/dev/null 2>&1; then RUNTIME=docker
+        elif command -v podman >/dev/null 2>&1; then RUNTIME=podman
+        else
+          echo "ERROR: no container runtime found. Install docker or podman,"
+          echo "set HIVE_CONTAINER_RUNTIME, or run: just contribute-hive <cli> local"
+          exit 1
+        fi
+      fi
+      RUNTIME_FLAGS=""
+      VOLSUF=""      # volume-option suffix for read-write mounts
+      ROSUF=":ro"    # volume-option suffix for read-only mounts
+      NET_FLAGS="--network host"
+      if [[ "$RUNTIME" == "podman" ]]; then
+        RUNTIME_FLAGS="--userns=keep-id"
+        VOLSUF=":Z"
+        ROSUF=":ro,Z"
+        # podman machine on macOS has no host networking (host = the VM,
+        # not the Mac). The relay only dials out, so the default network
+        # works; reach a localhost LiteLLM proxy via host.containers.internal.
+        if [[ "$OSTYPE" == darwin* ]]; then NET_FLAGS=""; fi
+      fi
       if [[ "${HIVE_SKIP_PULL:-}" != "true" ]]; then
-        echo "Pulling {{hive_image}}..."
-        docker pull {{hive_image}} 2>/dev/null || echo "Pull failed — using local image"
+        echo "Pulling {{hive_image}} (${RUNTIME})..."
+        "$RUNTIME" pull {{hive_image}} 2>/dev/null || echo "Pull failed — using local image"
         echo ""
       fi
       # Mount CLI-specific config directories
       CLI_MOUNTS=""
       case "${BACKEND}" in
         claude)
-          CLI_MOUNTS="-v ${HOME}/.claude:/home/dev/.claude -v ${HOME}/.config/claude-code:/home/dev/.config/claude-code"
+          CLI_MOUNTS="-v ${HOME}/.claude:/home/dev/.claude${VOLSUF} -v ${HOME}/.config/claude-code:/home/dev/.config/claude-code${VOLSUF}"
           ;;
         copilot)
-          [ -d "${HOME}/.copilot" ] && CLI_MOUNTS="-v ${HOME}/.copilot:/home/dev/.copilot"
+          [ -d "${HOME}/.copilot" ] && CLI_MOUNTS="-v ${HOME}/.copilot:/home/dev/.copilot${VOLSUF}"
           ;;
         goose)
-          [ -d "${HOME}/.config/goose" ] && CLI_MOUNTS="-v ${HOME}/.config/goose:/home/dev/.config/goose"
+          [ -d "${HOME}/.config/goose" ] && CLI_MOUNTS="-v ${HOME}/.config/goose:/home/dev/.config/goose${VOLSUF}"
           ;;
         codex)
-          [ -d "${HOME}/.codex" ] && CLI_MOUNTS="-v ${HOME}/.codex:/home/dev/.codex"
+          [ -d "${HOME}/.codex" ] && CLI_MOUNTS="-v ${HOME}/.codex:/home/dev/.codex${VOLSUF}"
           ;;
       esac
       CONTAINER_NAME="hive-contributor-${BACKEND}-$(head -c 4 /dev/urandom | od -An -tx1 | tr -d ' ')"
-      docker run -d --rm \
+      "$RUNTIME" run -d --rm \
         --name "${CONTAINER_NAME}" \
-        --network host \
-        -v "{{config_dir}}:/home/dev/.config/hive:ro" \
+        ${RUNTIME_FLAGS} \
+        ${NET_FLAGS} \
+        -v "{{config_dir}}:/home/dev/.config/hive${ROSUF}" \
         ${CLI_MOUNTS} \
-        -v "${HOME}/.config/gh:/home/dev/.config/gh:ro" \
+        -v "${HOME}/.config/gh:/home/dev/.config/gh${ROSUF}" \
         -e HIVE_HUB="{{hive_hub}}" \
         -e AGENT_BACKEND="${BACKEND}" \
         -e GH_TOKEN="${GH_TOKEN}" \
@@ -462,7 +491,7 @@ contribute-hive backend="" mode="docker": check-version
       sleep 3
 
       # Open the CLI session in a new terminal window
-      ATTACH_CMD="docker exec -it ${CONTAINER_NAME} tmux attach -t contributor"
+      ATTACH_CMD="${RUNTIME} exec -it ${CONTAINER_NAME} tmux attach -t contributor"
       if [[ "$OSTYPE" == "darwin"* ]]; then
         if pgrep -x "iTerm2" > /dev/null 2>&1; then
           osascript -e "tell application \"iTerm2\" to tell current window to create tab with default profile command \"${ATTACH_CMD}\""
@@ -479,7 +508,7 @@ contribute-hive backend="" mode="docker": check-version
 
       echo ""
       echo "Relay logs:"
-      docker logs -f "${CONTAINER_NAME}"
+      "$RUNTIME" logs -f "${CONTAINER_NAME}"
     fi
 
 # Check hub status and your contributor profile
@@ -535,7 +564,16 @@ hive-api-docs:
 # Stop contributing (if running in background)
 contribute-stop:
     #!/usr/bin/env bash
-    docker ps --filter "name=hive-contributor-" --format '{{ "{{" }}.Names{{ "}}" }}' | xargs -r docker stop 2>/dev/null && echo "Stopped." || echo "Not running."
+    # Stop contributor containers under whichever runtimes are installed.
+    STOPPED=false
+    for RT in docker podman; do
+      command -v "$RT" >/dev/null 2>&1 || continue
+      NAMES=$("$RT" ps --filter "name=hive-contributor-" --format '{{ "{{" }}.Names{{ "}}" }}' 2>/dev/null || true)
+      if [[ -n "$NAMES" ]]; then
+        echo "$NAMES" | xargs -r "$RT" stop 2>/dev/null && STOPPED=true
+      fi
+    done
+    $STOPPED && echo "Stopped." || echo "Not running."
 
 # Generate K8s ConfigMap + Secret YAML from contributor.env
 # Usage: just contribute-k8s                          (default namespace: hive-contributor)

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -364,7 +364,7 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 </select>
 <label style="font-size:.9rem;color:#8b949e">Mode:</label>
 <select id="mode-select" style="background:#161b22;color:#e6edf3;border:1px solid #30363d;border-radius:6px;padding:6px 12px;font-size:.9rem;cursor:pointer">
-<option value="containerized">Containerized (recommended)</option>
+<option value="containerized">Containerized (recommended — docker or podman)</option>
 <option value="host">Host (non-containerized)</option>
 </select>
 </div>
@@ -439,6 +439,7 @@ setTimeout(function(){btn.textContent='Copy';btn.style.background='#238636'},200
 })();
 </script>
 </div>
+<p style="color:#6e7681;font-size:.78rem;margin-top:8px">Containerized mode auto-detects docker, then podman &mdash; force one with <code>export HIVE_CONTAINER_RUNTIME=podman</code>. Rootless podman (keep-id, SELinux labels) is handled automatically.</p>
 <p style="color:#6e7681;font-size:.78rem;margin-top:8px">Don't see your CLI? <a href="https://github.com/kubestellar/hive/issues/new?title=CLI+request:+&labels=contribute,enhancement" target="_blank" style="color:#58a6ff">Open an issue</a> and we'll add support for it.</p>
 <div style="margin-top:20px;display:flex;gap:12px;flex-wrap:wrap">
 <a href="/leaderboard" style="display:inline-block;padding:8px 20px;background:#161b22;border:1px solid #30363d;border-radius:8px;color:#58a6ff;text-decoration:none;font-size:.9rem">🏆 View Leaderboard</a>


### PR DESCRIPTION
## Summary
Containerized contributor mode (`just contribute-hive`) hardcoded the `docker` CLI in five places (pull/run/exec/logs and `contribute-stop`'s ps/stop). This adds podman as a first-class runtime.

## Changes
- New `HIVE_CONTAINER_RUNTIME` env (justfile var `container_runtime`); empty = auto-detect docker, then podman, with a clear error suggesting local mode when neither exists
- Podman-specific flags, applied only when the resolved runtime is podman:
  - `--userns=keep-id` — rootless UID remapping otherwise makes the mounted `~/.claude`, `~/.config/gh`, `~/.config/hive` unreadable by the container's `dev` user
  - `,Z` SELinux labels on every bind mount (Fedora/RHEL hosts)
  - drop `--network host` on podman-machine/macOS (host = the VM there); the relay is outbound-only so the default network works — a localhost LiteLLM proxy is reachable as `host.containers.internal`
- `contribute-stop` sweeps contributor containers under whichever of docker/podman is installed
- Docker behavior is byte-for-byte unchanged (empty suffixes/flags); local mode untouched

Validated: `just --list` parses, `just -n contribute-stop` renders correct `{{.Names}}` templating, generated script passes `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)