### PR TITLE
feat(dashboard): surface trajectory review on Governor General tab; default on

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1774,7 +1774,7 @@ func main() {
 	// cannot be constructed (no LiteLLM endpoint/model), the lane is disabled
 	// with a single warning rather than erroring every tick.
 	var trajLane *trajectory.Lane
-	if cfg.Governor.Trajectory.Enabled {
+	if cfg.Governor.Trajectory.IsEnabled() {
 		reviewModel := cfg.Governor.Trajectory.Model
 		if reviewModel == "" {
 			reviewModel = cfg.Governor.LiteLLM.DefaultModel

--- a/v2/docs/trajectory-review.md
+++ b/v2/docs/trajectory-review.md
@@ -1,6 +1,6 @@
 # Trajectory-Review Lane
 
-The **trajectory-review lane** is an opt-in safety layer that periodically reads
+The **trajectory-review lane** is a safety layer (on by default) that periodically reads
 each running agent's recent transcript and asks a second model whether the
 *sequence* of actions is still working toward the agent's assigned intent. If
 the trajectory has diverged — individually-innocuous steps assembling toward an
@@ -47,7 +47,12 @@ model is appropriate — this is a divergence classifier, not a coding model.
 
 ## Configuration
 
-Under `governor.trajectory` in `hive.yaml`:
+**Dashboard:** Governor Config → **General** tab has a **Trajectory Review**
+toggle (on by default) with an info tooltip explaining the check. Toggling it
+persists immediately and takes effect on the next hive restart. The review
+model, cadence, and exemptions are set in `hive.yaml` (below).
+
+**hive.yaml** — under `governor.trajectory`:
 
 ```yaml
 governor:
@@ -56,7 +61,7 @@ governor:
     api_key_env: HIVE_LITELLM_API_KEY
     default_model: claude-haiku-4-5
   trajectory:
-    enabled: true                 # off by default
+    enabled: true                 # ON by default; set false to disable
     interval_s: 600               # review cadence (floored by eval_interval_s)
     model: claude-haiku-4-5       # reviewer model; empty → litellm.default_model
     transcript_lines: 120         # trailing lines sent per agent
@@ -67,7 +72,7 @@ governor:
 
 | Field | Default | Meaning |
 | --- | --- | --- |
-| `enabled` | `false` | Turn the lane on. Off = zero cost. |
+| `enabled` | `true` | Turn the lane on/off. Also on the Governor → General tab. No reviews run (zero cost) until a LiteLLM reviewer endpoint is configured. |
 | `interval_s` | `600` | Seconds between reviews; the governor eval interval is the floor. |
 | `model` | `litellm.default_model` | Reviewer model id sent to LiteLLM. |
 | `transcript_lines` | `120` | Trailing transcript lines sent per agent. |

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -522,11 +522,12 @@ type GovernorConfig struct {
 // assigned intent (its last kick), pausing the agent when it diverges. This
 // is defense against trajectory-level goal drift — individually-innocuous
 // steps that assemble toward an unauthorized outcome — which action-level
-// gating cannot see. Disabled by default; opt in per hive.
+// gating cannot see. On by default; the lane no-ops when no LiteLLM reviewer
+// endpoint is configured, so "on" is safe even without inference set up.
 type TrajectoryConfig struct {
-	// Enabled turns the review lane on. When false, no reviews run and the
-	// feature adds zero cost.
-	Enabled bool `yaml:"enabled"`
+	// Enabled turns the review lane on. Pointer so an omitted key defaults to
+	// enabled (applyDefaults sets it), while an explicit "false" disables it.
+	Enabled *bool `yaml:"enabled"`
 	// IntervalS is how often (seconds) the lane evaluates running agents.
 	// It runs off the governor tick, so the effective floor is the governor
 	// eval interval; a value below that reviews every tick. 0 → default.
@@ -545,6 +546,14 @@ type TrajectoryConfig struct {
 	// ExemptAgents are never reviewed (e.g. advisory-only agents that open no
 	// PRs and touch no infrastructure).
 	ExemptAgents []string `yaml:"exempt_agents"`
+}
+
+// IsEnabled reports whether the trajectory-review lane is on. Default is ON:
+// a nil Enabled (key omitted) counts as enabled, only an explicit false
+// disables it. The lane itself no-ops when no reviewer endpoint resolves, so
+// defaulting on is safe even for hives without inference configured.
+func (t TrajectoryConfig) IsEnabled() bool {
+	return t.Enabled == nil || *t.Enabled
 }
 
 // Discovery-auth defaults for the self-hosted inference backends. Like
@@ -1416,7 +1425,7 @@ func (c *Config) applyDefaults() {
 	if c.Governor.EvalIntervalS == 0 {
 		c.Governor.EvalIntervalS = defaultEvalIntervalS
 	}
-	if c.Governor.Trajectory.Enabled {
+	if c.Governor.Trajectory.IsEnabled() {
 		if c.Governor.Trajectory.OnDivergence == "" {
 			c.Governor.Trajectory.OnDivergence = "pause"
 		}

--- a/v2/pkg/config/trajectory_default_test.go
+++ b/v2/pkg/config/trajectory_default_test.go
@@ -1,0 +1,31 @@
+package config
+
+import "testing"
+
+func TestTrajectoryDefaultOn(t *testing.T) {
+	// nil Enabled (key omitted) → enabled
+	var tc TrajectoryConfig
+	if !tc.IsEnabled() {
+		t.Error("omitted trajectory.enabled must default to on")
+	}
+	// explicit false → disabled
+	f := false
+	tc.Enabled = &f
+	if tc.IsEnabled() {
+		t.Error("explicit trajectory.enabled=false must disable")
+	}
+	// explicit true → enabled
+	tr := true
+	tc.Enabled = &tr
+	if !tc.IsEnabled() {
+		t.Error("explicit trajectory.enabled=true must enable")
+	}
+}
+
+func TestTrajectoryDefaultsApplied(t *testing.T) {
+	c := &Config{}
+	c.applyDefaults()
+	if c.Governor.Trajectory.OnDivergence != "pause" {
+		t.Errorf("on_divergence default = %q, want pause", c.Governor.Trajectory.OnDivergence)
+	}
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -106,6 +106,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("PUT /api/config/governor/logging", s.handleGovernorLogging)
 	s.mux.HandleFunc("PUT /api/config/governor/hub", s.handleGovernorHub)
 	s.mux.HandleFunc("PUT /api/config/governor/litellm", s.handleGovernorLiteLLM)
+	s.mux.HandleFunc("PUT /api/config/governor/trajectory", s.handleGovernorTrajectory)
 	s.mux.HandleFunc("POST /api/config/governor/litellm/test", s.handleGovernorLiteLLMTest)
 	s.mux.HandleFunc("POST /api/config/governor/agents", s.handleGovernorAddAgent)
 	s.mux.HandleFunc("DELETE /api/config/governor/agents/{name}", s.handleGovernorRemoveAgent)
@@ -3148,6 +3149,14 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			"level":      cfg.Governor.Logging.Level,
 		},
 		"litellm": litellmSectionResponse(&cfg.Governor.LiteLLM),
+		"trajectory": map[string]interface{}{
+			"enabled":         cfg.Governor.Trajectory.IsEnabled(),
+			"intervalS":       cfg.Governor.Trajectory.IntervalS,
+			"model":           cfg.Governor.Trajectory.Model,
+			"transcriptLines": cfg.Governor.Trajectory.TranscriptLines,
+			"onDivergence":    cfg.Governor.Trajectory.OnDivergence,
+			"exemptAgents":    cfg.Governor.Trajectory.ExemptAgents,
+		},
 		"hub": map[string]interface{}{
 			"enabled":                          cfg.Hub.Enabled,
 			"url":                              cfg.Hub.URL,

--- a/v2/pkg/dashboard/api_trajectory.go
+++ b/v2/pkg/dashboard/api_trajectory.go
@@ -1,0 +1,27 @@
+package dashboard
+
+import "net/http"
+
+// handleGovernorTrajectory updates the trajectory-review lane config. The
+// General tab sends only the enabled toggle; the other fields are optional and
+// left untouched when omitted (they're edited via hive.yaml for now). Takes
+// effect on the next hive restart, like other governor.trajectory changes.
+func (s *Server) handleGovernorTrajectory(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Enabled *bool `json:"enabled"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	if body.Enabled != nil {
+		v := *body.Enabled
+		s.deps.Config.Governor.Trajectory.Enabled = &v
+	}
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after trajectory update", "error", err)
+	}
+	s.auditFromRequest(r, "config_governor_trajectory", auditDetail("section", "trajectory"), "")
+	s.refreshAndPersist()
+	okResponse(w, map[string]string{"status": "updated"})
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -13090,6 +13090,8 @@ function burnAreaChart() {
     function renderGovGeneral() {
       const currentId = (window._lastStatus || {}).hiveId || '';
       const currentACMMLevel = (window._lastStatus || {}).acmmLevel || 0;
+      const traj = (_configState.data || {}).trajectory || {};
+      const trajOn = traj.enabled !== false; // default on
       return `
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">General hive instance settings.</p>
         <div class="config-field">
@@ -13107,7 +13109,33 @@ function burnAreaChart() {
             <button class="btn" onclick="closeConfigDialog();openACMMDialog()" title="Open the ACMM maturity level selector">Change&hellip;</button>
           </div>
           <span style="font-size:0.65rem;color:var(--muted);margin-top:4px;display:block">Each level applies a curated agent pack. Change&hellip; opens the level selector.</span>
+        </div>
+        <div class="config-field">
+          <div class="config-toggle">
+            <div class="config-toggle-switch ${trajOn ? 'on' : ''}" onclick="toggleTrajectoryReview(this)"></div>
+            <span class="config-toggle-label">Trajectory Review <span class="config-info">i<span class="config-tooltip">A safety check that periodically reads each running agent's recent transcript and asks a second model whether the SEQUENCE of actions is still working toward the agent's assigned task. It catches goal drift — individually-harmless steps that add up to something the task never authorized (escaping the sandbox, evading a security scanner, splitting a credential to avoid detection, escalating privileges, or chasing a goal picked up from a repo file instead of the operator's instruction). On divergence it pauses the agent and alerts you. It fails open: if the review model is unreachable it never pauses a working agent. Uses the Governor's LiteLLM endpoint; no reviews run until one is configured. Set the review model/cadence in hive.yaml (governor.trajectory).</span></span></span>
+          </div>
+          <span style="font-size:0.65rem;color:var(--muted);margin-top:4px;display:block">Recommended on. Pauses agents whose action sequence drifts from their assigned task. Change takes effect on next restart.</span>
         </div>`;
+    }
+
+    async function toggleTrajectoryReview(el) {
+      const turningOn = !el.classList.contains('on');
+      el.classList.toggle('on');
+      try {
+        const res = await fetch('/api/config/governor/trajectory', {
+          method: 'PUT',
+          headers: _inceptionAuthHeaders(),
+          body: JSON.stringify({ enabled: turningOn }),
+        });
+        if (!res.ok) throw new Error(await saveErrorMessage(res));
+        if (!_configState.data.trajectory) _configState.data.trajectory = {};
+        _configState.data.trajectory.enabled = turningOn;
+        showToast('Trajectory review ' + (turningOn ? 'enabled' : 'disabled') + ' — effective on next restart');
+      } catch (err) {
+        el.classList.toggle('on'); // revert on failure
+        showToast('Failed to update trajectory review: ' + err.message, 'error');
+      }
     }
 
     async function saveHiveId() {


### PR DESCRIPTION
Follow-up to #1938 per operator feedback: the trajectory-review lane was only settable in `hive.yaml`. This surfaces it in the UI and makes it on by default.

## Changes
- **Governor Config → General tab**: a **Trajectory Review** checkbox with an info tooltip explaining what it catches (goal drift — sandbox escape, scanner evasion, credential splitting, privilege escalation, repo-derived goals) and how it behaves (pause + alert, fail-open, uses the Governor LiteLLM endpoint). Toggling persists immediately.
- **Default flipped ON**: `TrajectoryConfig.Enabled` is now `*bool` — a nil/omitted key means enabled (`IsEnabled()`), only an explicit `false` disables. The lane already no-ops when no reviewer endpoint resolves, so on-by-default adds zero cost for hives without inference configured.
- **API**: `GET /api/config/governor` gains a `trajectory` block; new `PUT /api/config/governor/trajectory` mirrors the other governor section handlers (save + refresh + audit).
- Docs and config tests updated (default-on semantics; `applyDefaults` still sets `on_divergence: pause`).

Build/vet/tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)