### PR TITLE
feat(trajectory): generalize reviewer endpoint (LiteLLM/vLLM/llm-d) + surface readiness in UI

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1775,19 +1775,21 @@ func main() {
 	// with a single warning rather than erroring every tick.
 	var trajLane *trajectory.Lane
 	if cfg.Governor.Trajectory.IsEnabled() {
-		reviewModel := cfg.Governor.Trajectory.Model
-		if reviewModel == "" {
-			reviewModel = cfg.Governor.LiteLLM.DefaultModel
-		}
+		reviewEndpoint, reviewKey, reviewModel := cfg.Governor.ResolveReviewer()
 		reviewer, terr := trajectory.NewReviewer(trajectory.Config{
-			Endpoint:        cfg.Governor.LiteLLM.ResolveEndpoint(),
-			APIKey:          cfg.Governor.LiteLLM.ResolveAPIKey(),
+			Endpoint:        reviewEndpoint,
+			APIKey:          reviewKey,
 			Model:           reviewModel,
 			TranscriptLines: cfg.Governor.Trajectory.TranscriptLines,
 		})
 		if terr != nil {
-			logger.Warn("trajectory-review lane disabled", "reason", terr.Error())
+			// Enabled but not runnable — surface it as a dashboard alert, not
+			// just a log line, so a safety control is never silently inert.
+			logger.Warn("trajectory-review lane enabled but not running", "reason", terr.Error())
+			dashSrv.AddSystemAlert("trajectory-not-configured", "warning",
+				"Trajectory review is ON but has no reviewer endpoint configured — no agents are being reviewed. Set a reviewer endpoint (LiteLLM, vLLM, or llm-d) in Governor Config.")
 		} else {
+			dashSrv.ClearSystemAlert("trajectory-not-configured")
 			trajLane = trajectory.NewLane(reviewer, agentMgr,
 				dashboard.NewTrajectorySink(dashSrv, notifier),
 				trajectory.LaneConfig{

--- a/v2/docs/trajectory-review.md
+++ b/v2/docs/trajectory-review.md
@@ -47,10 +47,13 @@ model is appropriate — this is a divergence classifier, not a coding model.
 
 ## Configuration
 
-**Dashboard:** Governor Config → **General** tab has a **Trajectory Review**
-toggle (on by default) with an info tooltip explaining the check. Toggling it
-persists immediately and takes effect on the next hive restart. The review
-model, cadence, and exemptions are set in `hive.yaml` (below).
+**Dashboard:** Governor Config → **General** tab has a full **Trajectory Review**
+panel: an on/off toggle (on by default), a status chip that distinguishes
+*On — active* from *On — no reviewer endpoint (not running)* so the control is
+never silently inert, an explanation of why it exists and what it requires, and
+inline fields for the reviewer model, review interval, reviewer endpoint, and
+the pause/alert-only choice. Changes persist immediately and take effect on the
+next restart. Exemptions remain in `hive.yaml`.
 
 **hive.yaml** — under `governor.trajectory`:
 
@@ -62,6 +65,8 @@ governor:
     default_model: claude-haiku-4-5
   trajectory:
     enabled: true                 # ON by default; set false to disable
+    endpoint: ""                  # reviewer /v1 base URL (LiteLLM/vLLM/llm-d); empty → inherit litellm.endpoint
+    api_key_env: ""               # env var NAME for the reviewer key; empty → inherit litellm key
     interval_s: 600               # review cadence (floored by eval_interval_s)
     model: claude-haiku-4-5       # reviewer model; empty → litellm.default_model
     transcript_lines: 120         # trailing lines sent per agent
@@ -79,8 +84,19 @@ governor:
 | `on_divergence` | `pause` | `pause` stops the agent + alerts; `alert` only notifies. |
 | `exempt_agents` | `[]` | Agents never reviewed. |
 
-The reviewer uses the hive's existing `governor.litellm` endpoint and key
-(same resolution as inference), so no new secret is introduced.
+### Reviewer endpoint
+
+The reviewer needs any **OpenAI-compatible `/v1/chat/completions`** endpoint —
+a **LiteLLM** gateway, a **vLLM** server, or an **llm-d** front. Set
+`governor.trajectory.endpoint` (with `api_key_env`/`api_key_file` if the
+endpoint needs a key; a bare vLLM server needs none). When left empty, the
+reviewer inherits the `governor.litellm` endpoint and key, so no new secret is
+introduced for hives that already run LiteLLM. Pointing the reviewer at a cheap
+local vLLM model is a good way to run oversight without spending gateway tokens.
+
+Protocol compatibility is all that's required — but model *capability* still
+matters: a tiny local model emits weaker verdicts. Because the lane fails open,
+a weak reviewer degrades toward "catches less," not "false-pauses everything."
 
 ## Backend and model coverage
 

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -522,18 +522,36 @@ type GovernorConfig struct {
 // assigned intent (its last kick), pausing the agent when it diverges. This
 // is defense against trajectory-level goal drift — individually-innocuous
 // steps that assemble toward an unauthorized outcome — which action-level
-// gating cannot see. On by default; the lane no-ops when no LiteLLM reviewer
-// endpoint is configured, so "on" is safe even without inference set up.
+// gating cannot see. On by default; the lane no-ops when no reviewer endpoint
+// resolves, so "on" is safe even without inference set up.
+//
+// The reviewer needs any OpenAI-compatible /v1/chat/completions endpoint — a
+// LiteLLM gateway, a vLLM server, or an llm-d front. It does NOT drive an
+// interactive CLI: it makes one stateless request per agent per cycle and
+// reads back a strict-JSON verdict, which the CLIs (stateful tmux sessions)
+// cannot provide.
 type TrajectoryConfig struct {
 	// Enabled turns the review lane on. Pointer so an omitted key defaults to
 	// enabled (applyDefaults sets it), while an explicit "false" disables it.
 	Enabled *bool `yaml:"enabled"`
+	// Endpoint is the reviewer's OpenAI-compatible base URL (LiteLLM, vLLM, or
+	// llm-d — anything serving /v1/chat/completions). Empty → fall back to the
+	// governor LiteLLM endpoint. Storing it here lets the reviewer target a
+	// cheap local model independent of the agents' inference config.
+	Endpoint string `yaml:"endpoint"`
+	// APIKeyEnv / APIKeyFile resolve the reviewer endpoint's key (env var NAME
+	// or file PATH; never the value). Empty → fall back to the LiteLLM key.
+	// A bare vLLM server needs no key; a gateway usually does.
+	APIKeyEnv  string `yaml:"api_key_env"`
+	APIKeyFile string `yaml:"api_key_file"`
 	// IntervalS is how often (seconds) the lane evaluates running agents.
 	// It runs off the governor tick, so the effective floor is the governor
 	// eval interval; a value below that reviews every tick. 0 → default.
 	IntervalS int `yaml:"interval_s"`
-	// Model is the reviewer model id (sent to the LiteLLM endpoint). Empty →
-	// the governor LiteLLM default_model. A cheap model is appropriate.
+	// Model is the reviewer model id. Empty → the governor LiteLLM
+	// default_model. A cheap-but-capable model is appropriate; a tiny model
+	// will emit weaker verdicts (the lane fails open, so it degrades toward
+	// "catches less," not "false-pauses").
 	Model string `yaml:"model"`
 	// TranscriptLines caps how many trailing transcript lines are sent to the
 	// reviewer. 0 → default. Bounds token cost and keeps the review focused
@@ -554,6 +572,57 @@ type TrajectoryConfig struct {
 // defaulting on is safe even for hives without inference configured.
 func (t TrajectoryConfig) IsEnabled() bool {
 	return t.Enabled == nil || *t.Enabled
+}
+
+// ResolveReviewer returns the reviewer endpoint, API key, and model, falling
+// back to the governor LiteLLM block for any field the trajectory block leaves
+// empty. This is what lets the reviewer target a LiteLLM gateway, a vLLM
+// server, or an llm-d front interchangeably: it only needs an
+// OpenAI-compatible /v1/chat/completions URL. The key value is resolved from
+// a file or env var and is never stored in hive.yaml.
+func (g *GovernorConfig) ResolveReviewer() (endpoint, apiKey, model string) {
+	t := g.Trajectory
+	endpoint = strings.TrimRight(strings.TrimSpace(t.Endpoint), "/")
+	if endpoint == "" {
+		endpoint = g.LiteLLM.ResolveEndpoint()
+	}
+	apiKey = resolveKeyFromFileThenEnv(t.APIKeyFile, t.APIKeyEnv)
+	if apiKey == "" {
+		apiKey = g.LiteLLM.ResolveAPIKey()
+	}
+	model = strings.TrimSpace(t.Model)
+	if model == "" {
+		model = g.LiteLLM.DefaultModel
+	}
+	return endpoint, apiKey, model
+}
+
+// ReviewerReady reports whether the reviewer has both an endpoint and a model
+// resolved — i.e. whether enabling the lane will actually run reviews. The UI
+// uses this to distinguish "on and running" from "on but not configured", so
+// a safety control never silently no-ops while showing as enabled.
+func (g *GovernorConfig) ReviewerReady() bool {
+	endpoint, _, model := g.ResolveReviewer()
+	return endpoint != "" && model != ""
+}
+
+// resolveKeyFromFileThenEnv reads a secret from a file path, then an env var
+// NAME, returning "" if neither yields a value. Mirrors the LiteLLM/inference
+// resolution order without pulling in defaults.
+func resolveKeyFromFileThenEnv(file, env string) string {
+	if file != "" {
+		if data, err := os.ReadFile(file); err == nil {
+			if k := strings.TrimSpace(string(data)); k != "" {
+				return k
+			}
+		}
+	}
+	if env != "" {
+		if k := os.Getenv(env); k != "" {
+			return k
+		}
+	}
+	return ""
 }
 
 // Discovery-auth defaults for the self-hosted inference backends. Like

--- a/v2/pkg/config/trajectory_default_test.go
+++ b/v2/pkg/config/trajectory_default_test.go
@@ -29,3 +29,34 @@ func TestTrajectoryDefaultsApplied(t *testing.T) {
 		t.Errorf("on_divergence default = %q, want pause", c.Governor.Trajectory.OnDivergence)
 	}
 }
+
+func TestResolveReviewerAndReady(t *testing.T) {
+	// Falls back to LiteLLM block when trajectory endpoint/model are empty.
+	g := &GovernorConfig{}
+	g.LiteLLM.Endpoint = "https://litellm.example.com"
+	g.LiteLLM.DefaultModel = "claude-haiku-4-5"
+	ep, _, model := g.ResolveReviewer()
+	if ep != "https://litellm.example.com" || model != "claude-haiku-4-5" {
+		t.Fatalf("fallback resolve wrong: ep=%q model=%q", ep, model)
+	}
+	if !g.ReviewerReady() {
+		t.Error("reviewer should be ready with litellm endpoint+model")
+	}
+
+	// Trajectory endpoint/model override the LiteLLM block (e.g. point at vLLM).
+	g.Trajectory.Endpoint = "http://vllm.hive-inference.svc:8000/"
+	g.Trajectory.Model = "deepseek-r1-14b"
+	ep, _, model = g.ResolveReviewer()
+	if ep != "http://vllm.hive-inference.svc:8000" { // trailing slash trimmed
+		t.Errorf("trajectory endpoint should win and be trimmed: %q", ep)
+	}
+	if model != "deepseek-r1-14b" {
+		t.Errorf("trajectory model should win: %q", model)
+	}
+
+	// Not ready when nothing resolves.
+	empty := &GovernorConfig{}
+	if empty.ReviewerReady() {
+		t.Error("reviewer must not be ready with no endpoint/model")
+	}
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3148,15 +3148,8 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			"compress":   cfg.Governor.Logging.Compress,
 			"level":      cfg.Governor.Logging.Level,
 		},
-		"litellm": litellmSectionResponse(&cfg.Governor.LiteLLM),
-		"trajectory": map[string]interface{}{
-			"enabled":         cfg.Governor.Trajectory.IsEnabled(),
-			"intervalS":       cfg.Governor.Trajectory.IntervalS,
-			"model":           cfg.Governor.Trajectory.Model,
-			"transcriptLines": cfg.Governor.Trajectory.TranscriptLines,
-			"onDivergence":    cfg.Governor.Trajectory.OnDivergence,
-			"exemptAgents":    cfg.Governor.Trajectory.ExemptAgents,
-		},
+		"litellm":    litellmSectionResponse(&cfg.Governor.LiteLLM),
+		"trajectory": trajectorySectionResponse(&cfg.Governor),
 		"hub": map[string]interface{}{
 			"enabled":                          cfg.Hub.Enabled,
 			"url":                              cfg.Hub.URL,

--- a/v2/pkg/dashboard/api_trajectory.go
+++ b/v2/pkg/dashboard/api_trajectory.go
@@ -1,22 +1,50 @@
 package dashboard
 
-import "net/http"
+import (
+	"net/http"
+	"strings"
 
-// handleGovernorTrajectory updates the trajectory-review lane config. The
-// General tab sends only the enabled toggle; the other fields are optional and
-// left untouched when omitted (they're edited via hive.yaml for now). Takes
-// effect on the next hive restart, like other governor.trajectory changes.
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// handleGovernorTrajectory updates the trajectory-review lane config. Fields
+// are optional; only those present in the body are changed. Takes effect on
+// the next hive restart, like other governor config changes.
 func (s *Server) handleGovernorTrajectory(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		Enabled *bool `json:"enabled"`
+		Enabled         *bool   `json:"enabled"`
+		IntervalS       *int    `json:"intervalS"`
+		Model           *string `json:"model"`
+		Endpoint        *string `json:"endpoint"`
+		TranscriptLines *int    `json:"transcriptLines"`
+		OnDivergence    *string `json:"onDivergence"`
 	}
 	if err := decodeBody(r, &body); err != nil {
 		jsonError(w, "invalid body", http.StatusBadRequest)
 		return
 	}
+	t := &s.deps.Config.Governor.Trajectory
 	if body.Enabled != nil {
 		v := *body.Enabled
-		s.deps.Config.Governor.Trajectory.Enabled = &v
+		t.Enabled = &v
+	}
+	if body.IntervalS != nil && *body.IntervalS >= 0 {
+		t.IntervalS = *body.IntervalS
+	}
+	if body.Model != nil {
+		t.Model = strings.TrimSpace(*body.Model)
+	}
+	if body.Endpoint != nil {
+		t.Endpoint = strings.TrimSpace(*body.Endpoint)
+	}
+	if body.TranscriptLines != nil && *body.TranscriptLines >= 0 {
+		t.TranscriptLines = *body.TranscriptLines
+	}
+	if body.OnDivergence != nil {
+		v := strings.TrimSpace(*body.OnDivergence)
+		if v == "pause" || v == "alert" {
+			t.OnDivergence = v
+		}
 	}
 	if err := s.saveConfig(); err != nil {
 		s.logger.Error("failed to persist config after trajectory update", "error", err)
@@ -24,4 +52,35 @@ func (s *Server) handleGovernorTrajectory(w http.ResponseWriter, r *http.Request
 	s.auditFromRequest(r, "config_governor_trajectory", auditDetail("section", "trajectory"), "")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})
+}
+
+// trajectorySectionResponse builds the trajectory config payload for the
+// governor config GET. It exposes reviewerReady (endpoint AND model resolve)
+// and the effective/source of the endpoint so the UI can distinguish
+// "on and running" from "on but no reviewer". The API key value is never
+// returned — only whether one resolved.
+func trajectorySectionResponse(g *config.GovernorConfig) map[string]interface{} {
+	endpoint, key, model := g.ResolveReviewer()
+	// Where did the endpoint come from — the trajectory block or the inherited
+	// LiteLLM block? Helps the UI point the operator at the right field.
+	endpointSource := "none"
+	if strings.TrimSpace(g.Trajectory.Endpoint) != "" {
+		endpointSource = "trajectory"
+	} else if endpoint != "" {
+		endpointSource = "litellm"
+	}
+	return map[string]interface{}{
+		"enabled":           g.Trajectory.IsEnabled(),
+		"intervalS":         g.Trajectory.IntervalS,
+		"model":             g.Trajectory.Model,
+		"effectiveModel":    model,
+		"transcriptLines":   g.Trajectory.TranscriptLines,
+		"onDivergence":      g.Trajectory.OnDivergence,
+		"exemptAgents":      g.Trajectory.ExemptAgents,
+		"endpoint":          g.Trajectory.Endpoint,
+		"effectiveEndpoint": endpoint,
+		"endpointSource":    endpointSource,
+		"hasKey":            key != "",
+		"reviewerReady":     endpoint != "" && model != "",
+	}
 }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -13092,6 +13092,16 @@ function burnAreaChart() {
       const currentACMMLevel = (window._lastStatus || {}).acmmLevel || 0;
       const traj = (_configState.data || {}).trajectory || {};
       const trajOn = traj.enabled !== false; // default on
+      const trajReady = traj.reviewerReady === true;
+      const trajEndpoint = traj.effectiveEndpoint || '';
+      const trajModel = traj.effectiveModel || '';
+      const trajInterval = traj.intervalS || 0;
+      const trajDiv = traj.onDivergence || 'pause';
+      // Status line: distinguish ON+running from ON+not-configured from OFF.
+      let trajStatus, trajStatusColor;
+      if (!trajOn) { trajStatus = 'Off'; trajStatusColor = 'var(--muted)'; }
+      else if (trajReady) { trajStatus = 'On — active'; trajStatusColor = 'var(--green)'; }
+      else { trajStatus = 'On — no reviewer endpoint (not running)'; trajStatusColor = 'var(--amber)'; }
       return `
         <p style="font-size:0.75rem;color:var(--muted);margin-bottom:14px">General hive instance settings.</p>
         <div class="config-field">
@@ -13110,12 +13120,45 @@ function burnAreaChart() {
           </div>
           <span style="font-size:0.65rem;color:var(--muted);margin-top:4px;display:block">Each level applies a curated agent pack. Change&hellip; opens the level selector.</span>
         </div>
-        <div class="config-field">
-          <div class="config-toggle">
-            <div class="config-toggle-switch ${trajOn ? 'on' : ''}" onclick="toggleTrajectoryReview(this)"></div>
-            <span class="config-toggle-label">Trajectory Review <span class="config-info">i<span class="config-tooltip">A safety check that periodically reads each running agent's recent transcript and asks a second model whether the SEQUENCE of actions is still working toward the agent's assigned task. It catches goal drift — individually-harmless steps that add up to something the task never authorized (escaping the sandbox, evading a security scanner, splitting a credential to avoid detection, escalating privileges, or chasing a goal picked up from a repo file instead of the operator's instruction). On divergence it pauses the agent and alerts you. It fails open: if the review model is unreachable it never pauses a working agent. Uses the Governor's LiteLLM endpoint; no reviews run until one is configured. Set the review model/cadence in hive.yaml (governor.trajectory).</span></span></span>
+        <div class="config-field" style="border-top:1px solid var(--border);margin-top:18px;padding-top:16px">
+          <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap">
+            <div class="config-toggle" style="margin:0">
+              <div class="config-toggle-switch ${trajOn ? 'on' : ''}" onclick="toggleTrajectoryReview(this)"></div>
+              <span class="config-toggle-label" style="font-weight:600">Trajectory Review</span>
+            </div>
+            <span style="font-family:monospace;font-size:0.72rem;padding:2px 10px;border-radius:999px;background:color-mix(in srgb, ${trajStatusColor} 14%, transparent);border:1px solid color-mix(in srgb, ${trajStatusColor} 45%, transparent);color:${trajStatusColor}">${esc(trajStatus)}</span>
           </div>
-          <span style="font-size:0.65rem;color:var(--muted);margin-top:4px;display:block">Recommended on. Pauses agents whose action sequence drifts from their assigned task. Change takes effect on next restart.</span>
+
+          <div style="font-size:0.75rem;color:var(--muted);line-height:1.6;margin-top:10px">
+            <p style="margin:0 0 8px"><strong style="color:var(--text)">Why it exists.</strong> An agent running for a long time can take a series of individually-harmless steps that add up to something its task never authorized — escaping the sandbox, evading a security scanner, splitting a credential so a scanner won't see it, escalating privileges, or chasing a goal it picked up from a repo file instead of your instruction. A per-action allow/deny check can't catch this, because no single step breaks a rule; only the <em>direction</em> of the sequence does.</p>
+            <p style="margin:0 0 8px"><strong style="color:var(--text)">What it does.</strong> On a fixed cadence it reads each running agent's recent transcript, compares it against the task the agent was actually assigned (its last kick), and judges whether the agent is still working toward that task. If the sequence has drifted, it <strong>pauses the agent and alerts you</strong> (or, in alert-only mode, just alerts). Alerts appear in the dashboard banner, the audit log, and ntfy.</p>
+            <p style="margin:0 0 8px"><strong style="color:var(--text)">How it works.</strong> A second, cheap model gets the assigned task plus a bounded tail of the transcript and returns a one-line JSON verdict (<code>divergent / confidence / reason</code>). It judges direction, not any single line, and defaults to "not divergent" when unsure, so ordinary work never trips it. It reads the transcript every CLI writes to, so it covers Claude, Copilot, Gemini, Goose, and inference backends alike. It <strong>fails open</strong>: if the reviewer is unreachable it returns "not divergent," so a broken reviewer never pauses a working agent.</p>
+            <p style="margin:0"><strong style="color:var(--text)">What it requires.</strong> One OpenAI-compatible <code>/v1/chat/completions</code> endpoint for the reviewer model — a LiteLLM gateway, a vLLM server, or an llm-d front. It uses the Governor's LiteLLM endpoint by default; set a different one below to point at a cheap local model. <strong>Until an endpoint resolves, the lane is inert even when this is on</strong> — the status chip above tells you which state you're in.</p>
+          </div>
+
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-top:14px">
+            <div>
+              <label style="font-size:0.7rem;color:var(--muted);display:block;margin-bottom:3px">Reviewer model <span class="config-info">i<span class="config-tooltip">Model id sent to the reviewer endpoint. Empty = the Governor's LiteLLM default model. A cheap-but-capable model is right; a tiny model gives weaker verdicts (fails open, so it catches less rather than false-pausing).</span></span></label>
+              <input type="text" value="${esc(traj.model || '')}" placeholder="${esc(trajModel || 'litellm default')}" onchange="saveTrajectoryField('model', this.value)" style="width:100%">
+            </div>
+            <div>
+              <label style="font-size:0.7rem;color:var(--muted);display:block;margin-bottom:3px">Review interval (sec) <span class="config-info">i<span class="config-tooltip">How often the lane reviews running agents. Floored by the Governor eval interval. Empty/0 = default (600s).</span></span></label>
+              <input type="number" min="0" value="${trajInterval || ''}" placeholder="600" onchange="saveTrajectoryField('intervalS', this.value === '' ? 0 : parseInt(this.value,10))" style="width:100%">
+            </div>
+            <div style="grid-column:1 / -1">
+              <label style="font-size:0.7rem;color:var(--muted);display:block;margin-bottom:3px">Reviewer endpoint <span class="config-info">i<span class="config-tooltip">OpenAI-compatible base URL for the reviewer (LiteLLM / vLLM / llm-d). Empty = inherit the Governor's LiteLLM endpoint. The API key is inherited from LiteLLM or set in hive.yaml (governor.trajectory.api_key_env/api_key_file); a bare vLLM server needs none.</span></span></label>
+              <input type="text" value="${esc(traj.endpoint || '')}" placeholder="${trajEndpoint ? esc(trajEndpoint) + '  (inherited from LiteLLM)' : 'https://litellm-or-vllm-or-llmd:port'}" onchange="saveTrajectoryField('endpoint', this.value)" style="width:100%">
+              <span style="font-size:0.62rem;color:var(--muted);margin-top:3px;display:block">Resolved: ${trajEndpoint ? esc(trajEndpoint) + ' (' + esc(traj.endpointSource || '') + (traj.hasKey ? ', key set' : ', no key') + ')' : 'none — reviewer will not run'}</span>
+            </div>
+            <div style="grid-column:1 / -1">
+              <label style="font-size:0.7rem;color:var(--muted);display:block;margin-bottom:3px">On divergence</label>
+              <div style="display:flex;gap:14px;font-size:0.8rem">
+                <label style="display:flex;align-items:center;gap:5px;cursor:pointer"><input type="radio" name="traj-div" ${trajDiv === 'pause' ? 'checked' : ''} onchange="saveTrajectoryField('onDivergence','pause')"> Pause the agent &amp; alert</label>
+                <label style="display:flex;align-items:center;gap:5px;cursor:pointer"><input type="radio" name="traj-div" ${trajDiv === 'alert' ? 'checked' : ''} onchange="saveTrajectoryField('onDivergence','alert')"> Alert only (don't pause)</label>
+              </div>
+              <span style="font-size:0.62rem;color:var(--muted);margin-top:3px;display:block">Start in alert-only to calibrate on your agents, then switch to pause. Changes take effect on next restart.</span>
+            </div>
+          </div>
         </div>`;
     }
 
@@ -13134,6 +13177,25 @@ function burnAreaChart() {
         showToast('Trajectory review ' + (turningOn ? 'enabled' : 'disabled') + ' — effective on next restart');
       } catch (err) {
         el.classList.toggle('on'); // revert on failure
+        showToast('Failed to update trajectory review: ' + err.message, 'error');
+      }
+    }
+
+    async function saveTrajectoryField(field, value) {
+      try {
+        const body = {}; body[field] = value;
+        const res = await fetch('/api/config/governor/trajectory', {
+          method: 'PUT',
+          headers: _inceptionAuthHeaders(),
+          body: JSON.stringify(body),
+        });
+        if (!res.ok) throw new Error(await saveErrorMessage(res));
+        if (!_configState.data.trajectory) _configState.data.trajectory = {};
+        _configState.data.trajectory[field] = value;
+        // Re-render so the status chip / resolved-endpoint line reflect the change.
+        renderConfigTab('General');
+        showToast('Trajectory review updated — effective on next restart');
+      } catch (err) {
         showToast('Failed to update trajectory review: ' + err.message, 'error');
       }
     }

--- a/v2/pkg/trajectory/trajectory.go
+++ b/v2/pkg/trajectory/trajectory.go
@@ -87,7 +87,7 @@ type Config struct {
 func NewReviewer(c Config) (*Reviewer, error) {
 	endpoint := strings.TrimRight(strings.TrimSpace(c.Endpoint), "/")
 	if endpoint == "" {
-		return nil, fmt.Errorf("trajectory review: no LiteLLM endpoint resolved")
+		return nil, fmt.Errorf("trajectory review: no reviewer endpoint resolved (set governor.trajectory.endpoint or governor.litellm.endpoint)")
 	}
 	if strings.TrimSpace(c.Model) == "" {
 		return nil, fmt.Errorf("trajectory review: no reviewer model resolved")


### PR DESCRIPTION
Follow-ups to the trajectory-review lane, prompted by two operator questions: *"if the LiteLLM endpoint isn't configured, how is that reflected?"* and *"would vLLM/llm-d work?"*

## 1. The reviewer endpoint is now generic
`governor.trajectory` gains `endpoint` / `api_key_env` / `api_key_file`, and `GovernorConfig.ResolveReviewer()` prefers them, falling back to the `governor.litellm` block. The reviewer only ever needed an **OpenAI-compatible `/v1/chat/completions`** endpoint — so a **LiteLLM gateway, a vLLM server, or an llm-d front all work**. A hive can now point oversight at a cheap local model instead of a metered gateway. Copy that said "LiteLLM" where it meant "reviewer endpoint" is fixed. (Protocol is all that's required; a tiny model gives weaker verdicts, but the lane fails open so it degrades toward "catches less," not "false-pauses.")

## 2. Readiness is now visible (was a silent failure)
Before: *enabled but no endpoint* failed silently — the toggle showed ON while the lane was inert, with only a server-log line. Now:
- `GET /api/config/governor` exposes `reviewerReady` (endpoint **and** model resolve) plus `effectiveEndpoint`/`effectiveModel`/`endpointSource`/`hasKey`.
- `main.go` raises a dashboard **system alert** when enabled-but-not-runnable, cleared once a reviewer resolves.
- The Governor → General section is now a **full panel**: a status chip (**On — active** / **On — no reviewer endpoint (not running)** / **Off**), a why/what/how/requires explanation of the feature, and inline **model / interval / endpoint / pause-vs-alert** controls. `PUT /api/config/governor/trajectory` accepts all of them.

## Testing
- `ResolveReviewer` fallback+override and `ReviewerReady` covered by a config test; `go build/vet` clean; config/dashboard/trajectory package tests pass.
- Rendered the new panel in both states (active / not-configured) to verify layout and the status chip.

Docs updated (`v2/docs/trajectory-review.md`) for the generalized endpoint and the panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)