### PR TITLE
fix(hub): prefix-tolerant SHA compare stops self-upgrade crash-loop (+ trajectory alert reconcile, toggle contrast)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1585,6 +1585,23 @@ func main() {
 		}, heartbeatSendInterval, logger, hub.UpgradeCallback(func(targetSHA string) {
 			const upgradeMarkerPath = "/data/upgrade-requested"
 
+			// Never self-upgrade to the commit we are already running. The hub
+			// may instruct an upgrade to a short SHA that is a prefix of our
+			// full gitShort (or vice-versa); treating that as "behind" caused a
+			// crash-loop (patch → 403 → os.Exit → repeat) on hives sitting
+			// exactly at HEAD. Prefix-compare so same-commit is a no-op.
+			if sha1, sha2 := targetSHA, gitShort; sha1 != "" && sha2 != "" {
+				n := len(sha1)
+				if len(sha2) < n {
+					n = len(sha2)
+				}
+				if strings.EqualFold(sha1[:n], sha2[:n]) {
+					logger.Info("self-upgrade skipped: target is the running commit",
+						"target", targetSHA, "current", gitShort)
+					return
+				}
+			}
+
 			// If a previous process already attempted an upgrade and we booted
 			// with the same git hash, the image tag didn't actually change.
 			// Skip to avoid an infinite restart loop.
@@ -1785,11 +1802,9 @@ func main() {
 		if terr != nil {
 			// Enabled but not runnable — surface it as a dashboard alert, not
 			// just a log line, so a safety control is never silently inert.
+			// (Reconciled below so it also clears when the lane is disabled.)
 			logger.Warn("trajectory-review lane enabled but not running", "reason", terr.Error())
-			dashSrv.AddSystemAlert("trajectory-not-configured", "warning",
-				"Trajectory review is ON but has no reviewer endpoint configured — no agents are being reviewed. Set a reviewer endpoint (LiteLLM, vLLM, or llm-d) in Governor Config.")
 		} else {
-			dashSrv.ClearSystemAlert("trajectory-not-configured")
 			trajLane = trajectory.NewLane(reviewer, agentMgr,
 				dashboard.NewTrajectorySink(dashSrv, notifier),
 				trajectory.LaneConfig{
@@ -1803,6 +1818,9 @@ func main() {
 				"on_divergence", cfg.Governor.Trajectory.OnDivergence)
 		}
 	}
+	// Reconcile the not-configured alert from actual state (raises only when
+	// enabled AND no reviewer resolves; clears when off or configured).
+	dashSrv.ReconcileTrajectoryAlert(&cfg.Governor)
 
 	logger.Info("entering governor loop", "interval_seconds", cfg.Governor.EvalIntervalS)
 	lastEvalInterval := cfg.Governor.EvalIntervalS

--- a/v2/pkg/dashboard/api_trajectory.go
+++ b/v2/pkg/dashboard/api_trajectory.go
@@ -49,9 +49,30 @@ func (s *Server) handleGovernorTrajectory(w http.ResponseWriter, r *http.Request
 	if err := s.saveConfig(); err != nil {
 		s.logger.Error("failed to persist config after trajectory update", "error", err)
 	}
+	// Reconcile the "enabled but no reviewer endpoint" alert against the new
+	// state: it must clear when the lane is turned off or an endpoint is set,
+	// not linger from a stale startup evaluation.
+	s.ReconcileTrajectoryAlert(&s.deps.Config.Governor)
 	s.auditFromRequest(r, "config_governor_trajectory", auditDetail("section", "trajectory"), "")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})
+}
+
+// TrajectoryNotConfiguredAlertID is the dashboard system-alert id for
+// "trajectory review is enabled but has no reviewer endpoint."
+const TrajectoryNotConfiguredAlertID = "trajectory-not-configured"
+
+// ReconcileTrajectoryAlert raises the "enabled but no reviewer endpoint" alert
+// only when the lane is BOTH enabled AND not runnable, and clears it in every
+// other case (disabled, or an endpoint now resolves). Safe to call from
+// startup and from the config PUT handler.
+func (s *Server) ReconcileTrajectoryAlert(g *config.GovernorConfig) {
+	if g.Trajectory.IsEnabled() && !g.ReviewerReady() {
+		s.AddSystemAlert(TrajectoryNotConfiguredAlertID, "warning",
+			"Trajectory review is ON but has no reviewer endpoint configured — no agents are being reviewed. Set a reviewer endpoint (LiteLLM, vLLM, or llm-d) in Governor Config.")
+		return
+	}
+	s.ClearSystemAlert(TrajectoryNotConfiguredAlertID)
 }
 
 // trajectorySectionResponse builds the trajectory config payload for the

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1216,15 +1216,26 @@
       display: flex; align-items: center; gap: 10px; margin-bottom: 10px;
     }
     .config-toggle-switch {
-      position: relative; width: 36px; height: 20px;
-      background: var(--border); border-radius: 10px; cursor: pointer;
-      transition: background 0.2s;
+      position: relative; width: 38px; height: 22px;
+      /* Off state: a visible muted track with a border, so the control reads
+         as a switch in both themes (previously var(--border), a near-invisible
+         hairline that made the thumb look like a lone dot). */
+      background: color-mix(in srgb, var(--muted) 45%, transparent);
+      border: 1px solid color-mix(in srgb, var(--muted) 60%, transparent);
+      border-radius: 999px; cursor: pointer;
+      transition: background 0.2s, border-color 0.2s;
     }
-    .config-toggle-switch.on { background: var(--green); }
+    .config-toggle-switch.on {
+      background: var(--green);
+      border-color: var(--green);
+    }
     .config-toggle-switch::before {
       content: ''; position: absolute; top: 2px; left: 2px;
       width: 16px; height: 16px; border-radius: 50%;
-      background: var(--text); transition: transform 0.2s;
+      /* Thumb is a white knob with a soft shadow — a physical-switch cue that
+         stays visible whether the track is muted-gray or green, in both themes. */
+      background: #ffffff; box-shadow: 0 1px 2px rgba(0,0,0,0.35);
+      transition: transform 0.2s;
     }
     .config-toggle-switch.on::before { transform: translateX(16px); }
     .config-toggle-label { font-size: 0.8rem; color: var(--text); }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2223,7 +2223,7 @@ func (s *HubServer) handleToggleAutoUpgrade(w http.ResponseWriter, r *http.Reque
 			branch = "v2"
 		}
 		latestSHA := getLatestSHAForBranch(branch)
-		if latestSHA != "" && currentSHA != "" && currentSHA != latestSHA {
+		if latestSHA != "" && currentSHA != "" && !sameCommit(currentSHA, latestSHA) {
 			s.logger.Info("audit: auto-upgrade initial trigger", "hive_id", id, "from", currentSHA, "to", latestSHA)
 			s.mu.Lock()
 			for i := range s.registry.Hives {

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -25,12 +25,12 @@ import (
 var staticFS embed.FS
 
 const (
-	registryPath           = "/data/hub-registry.json"
-	maxHeartbeatAge        = 5 * time.Minute
-	staleRemoveAge         = 24 * time.Hour
-	registrySaveDelay      = 5 * time.Second
-	maxPayloadBytes        = 1 << 20 // 1MB
-	staleUpgradeTimeout    = 10 * time.Minute
+	registryPath        = "/data/hub-registry.json"
+	maxHeartbeatAge     = 5 * time.Minute
+	staleRemoveAge      = 24 * time.Hour
+	registrySaveDelay   = 5 * time.Second
+	maxPayloadBytes     = 1 << 20 // 1MB
+	staleUpgradeTimeout = 10 * time.Minute
 )
 
 type Registry struct {
@@ -39,44 +39,44 @@ type Registry struct {
 }
 
 type RegistryEntry struct {
-	ID                 string         `json:"id"`
-	Name               string         `json:"name"`
-	Org                string         `json:"org"`
-	Repos              []string       `json:"repos"`
-	PrimaryRepo        string         `json:"primaryRepo"`
-	DashboardURL       string         `json:"dashboardUrl"`
-	SnapshotURL        string         `json:"snapshotUrl,omitempty"`
-	ACMMLevel          int            `json:"acmmLevel"`
-	AgentCount         int            `json:"agentCount"`
-	GovernorMode       string         `json:"governorMode"`
-	TotalTokens24h     int64          `json:"totalTokens24h"`
-	ActionableIssues   int            `json:"actionableIssues"`
-	ActionablePRs      int            `json:"actionablePRs"`
-	ContributorCount   int            `json:"contributorCount"`
-	ActiveContributors int            `json:"activeContributors"`
-	Owner              string         `json:"owner,omitempty"`
-	ClusterID          string         `json:"clusterId,omitempty"`
-	ClusterName        string         `json:"clusterName,omitempty"`
-	HiveType           string         `json:"hiveType,omitempty"`
-	IsPublic           bool           `json:"isPublic"`
-	RegisteredAt       string         `json:"registeredAt"`
-	LastHeartbeat      string         `json:"lastHeartbeat"`
-	Health             map[string]any `json:"health"`
-	Version            string         `json:"version"`
-	GitHash            string         `json:"gitHash,omitempty"`
-	GitBranch          string         `json:"gitBranch,omitempty"`
-	Agents             []AgentSummary `json:"agents,omitempty"`
-	Leaderboard        []LeaderboardEntry `json:"leaderboard,omitempty"`
-	Online             bool           `json:"online"`
-	Upgrading          bool           `json:"upgrading,omitempty"`
-	UpgradeTarget      string         `json:"upgradeTarget,omitempty"`
-	UpgradeStartedAt   time.Time      `json:"upgradeStartedAt,omitempty"`
-	IssueHistory       []SparkPoint   `json:"issueHistory,omitempty"`
-	PRHistory          []SparkPoint   `json:"prHistory,omitempty"`
-	GitHubAppRequired       bool           `json:"githubAppRequired,omitempty"`
-	GitHubAppPermIssue      string         `json:"githubAppPermIssue,omitempty"`
-	PendingGitHubAppInstall bool           `json:"pendingGitHubAppInstall,omitempty"`
-	PendingGitHubAppInstallAt time.Time    `json:"pendingGitHubAppInstallAt,omitempty"`
+	ID                        string             `json:"id"`
+	Name                      string             `json:"name"`
+	Org                       string             `json:"org"`
+	Repos                     []string           `json:"repos"`
+	PrimaryRepo               string             `json:"primaryRepo"`
+	DashboardURL              string             `json:"dashboardUrl"`
+	SnapshotURL               string             `json:"snapshotUrl,omitempty"`
+	ACMMLevel                 int                `json:"acmmLevel"`
+	AgentCount                int                `json:"agentCount"`
+	GovernorMode              string             `json:"governorMode"`
+	TotalTokens24h            int64              `json:"totalTokens24h"`
+	ActionableIssues          int                `json:"actionableIssues"`
+	ActionablePRs             int                `json:"actionablePRs"`
+	ContributorCount          int                `json:"contributorCount"`
+	ActiveContributors        int                `json:"activeContributors"`
+	Owner                     string             `json:"owner,omitempty"`
+	ClusterID                 string             `json:"clusterId,omitempty"`
+	ClusterName               string             `json:"clusterName,omitempty"`
+	HiveType                  string             `json:"hiveType,omitempty"`
+	IsPublic                  bool               `json:"isPublic"`
+	RegisteredAt              string             `json:"registeredAt"`
+	LastHeartbeat             string             `json:"lastHeartbeat"`
+	Health                    map[string]any     `json:"health"`
+	Version                   string             `json:"version"`
+	GitHash                   string             `json:"gitHash,omitempty"`
+	GitBranch                 string             `json:"gitBranch,omitempty"`
+	Agents                    []AgentSummary     `json:"agents,omitempty"`
+	Leaderboard               []LeaderboardEntry `json:"leaderboard,omitempty"`
+	Online                    bool               `json:"online"`
+	Upgrading                 bool               `json:"upgrading,omitempty"`
+	UpgradeTarget             string             `json:"upgradeTarget,omitempty"`
+	UpgradeStartedAt          time.Time          `json:"upgradeStartedAt,omitempty"`
+	IssueHistory              []SparkPoint       `json:"issueHistory,omitempty"`
+	PRHistory                 []SparkPoint       `json:"prHistory,omitempty"`
+	GitHubAppRequired         bool               `json:"githubAppRequired,omitempty"`
+	GitHubAppPermIssue        string             `json:"githubAppPermIssue,omitempty"`
+	PendingGitHubAppInstall   bool               `json:"pendingGitHubAppInstall,omitempty"`
+	PendingGitHubAppInstallAt time.Time          `json:"pendingGitHubAppInstallAt,omitempty"`
 }
 
 type SparkPoint struct {
@@ -137,17 +137,17 @@ type HeartbeatHealthEntry struct {
 }
 
 type HubServer struct {
-	mux            *http.ServeMux
-	registry       Registry
-	mu             sync.RWMutex
-	logger         *slog.Logger
-	saveCh         chan struct{}
-	hubGitHash     string
-	hubGitBranch   string
-	hubSecret      string
-	httpServer     *http.Server
-	httpMu         sync.Mutex // guards httpServer (Start runs in a goroutine; Shutdown races it)
-	clusters       map[string]ClusterConfig
+	mux               *http.ServeMux
+	registry          Registry
+	mu                sync.RWMutex
+	logger            *slog.Logger
+	saveCh            chan struct{}
+	hubGitHash        string
+	hubGitBranch      string
+	hubSecret         string
+	httpServer        *http.Server
+	httpMu            sync.Mutex // guards httpServer (Start runs in a goroutine; Shutdown races it)
+	clusters          map[string]ClusterConfig
 	heartbeatHealth   map[string]*HeartbeatHealthEntry // cluster ID → latest health from spoke heartbeat
 	heartbeatHealthMu sync.RWMutex
 
@@ -207,16 +207,16 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		logger.Info("generated hub secret", "path", "/data/saas/hub-secret.key")
 	}
 	s := &HubServer{
-		mux:              http.NewServeMux(),
-		logger:           logger,
-		saveCh:           make(chan struct{}, 1),
-		hubGitHash:       gitHash,
-		hubGitBranch:     gitBranch,
-		hubSecret:        secret,
-		clusters:         loadClusters(logger),
-		heartbeatHealth:  make(map[string]*HeartbeatHealthEntry),
-		heartbeatUpgrade:   make(map[string]string),
-		heartbeatSwitchTag: make(map[string]string),
+		mux:                     http.NewServeMux(),
+		logger:                  logger,
+		saveCh:                  make(chan struct{}, 1),
+		hubGitHash:              gitHash,
+		hubGitBranch:            gitBranch,
+		hubSecret:               secret,
+		clusters:                loadClusters(logger),
+		heartbeatHealth:         make(map[string]*HeartbeatHealthEntry),
+		heartbeatUpgrade:        make(map[string]string),
+		heartbeatSwitchTag:      make(map[string]string),
 		pendingWebhooks:         make(map[string]*pendingWebhookEntry),
 		pendingGitHubAppConfigs: make(map[string]*HeartbeatGitHubAppConfig),
 		hubBanners:              make(map[string]*HubBannerEntry),
@@ -359,9 +359,9 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	safePrimary := payload.PrimaryRepo
 
 	entry := RegistryEntry{
-		ID:                 payload.HiveID,
-		Name:               safeOrg + "/" + safePrimary,
-		Org:                safeOrg,
+		ID:   payload.HiveID,
+		Name: safeOrg + "/" + safePrimary,
+		Org:  safeOrg,
 		Repos: func() []string {
 			safe := make([]string, len(payload.Repos))
 			for i, r := range payload.Repos {
@@ -369,10 +369,10 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			}
 			return safe
 		}(),
-		PrimaryRepo:        safePrimary,
-		DashboardURL:       payload.DashboardURL,
-		SnapshotURL:        payload.SnapshotURL,
-		ACMMLevel:          clampInt(payload.ACMMLevel, 0, 6),
+		PrimaryRepo:  safePrimary,
+		DashboardURL: payload.DashboardURL,
+		SnapshotURL:  payload.SnapshotURL,
+		ACMMLevel:    clampInt(payload.ACMMLevel, 0, 6),
 		AgentCount: func() int {
 			count := 0
 			for _, a := range payload.Agents {
@@ -398,12 +398,12 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			}
 			return "local"
 		}(),
-		IsPublic: payload.IsPublic,
-		LastHeartbeat:      time.Now().UTC().Format(time.RFC3339),
-		Health:             payload.Health,
-		Version:            sanitizeHeartbeatField(payload.Version),
-		GitHash:            sanitizeHeartbeatField(payload.GitHash),
-		GitBranch:          sanitizeHeartbeatField(payload.GitBranch),
+		IsPublic:      payload.IsPublic,
+		LastHeartbeat: time.Now().UTC().Format(time.RFC3339),
+		Health:        payload.Health,
+		Version:       sanitizeHeartbeatField(payload.Version),
+		GitHash:       sanitizeHeartbeatField(payload.GitHash),
+		GitBranch:     sanitizeHeartbeatField(payload.GitBranch),
 		Agents: func() []AgentSummary {
 			for i := range payload.Agents {
 				payload.Agents[i].Name = sanitizeHeartbeatField(payload.Agents[i].Name)
@@ -425,7 +425,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			}
 			return payload.Leaderboard
 		}(),
-		Online:            true,
+		Online:                  true,
 		GitHubAppRequired:       payload.GitHubAppRequired,
 		GitHubAppPermIssue:      sanitizeHeartbeatField(payload.GitHubAppPermIssue),
 		PendingGitHubAppInstall: payload.PendingGitHubAppInstall,
@@ -651,22 +651,25 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				"hive_id", payload.HiveID, "tag", switchTag)
 		}
 	}
-	if hbTarget != "" && (payload.GitHash == hbTarget || (latestSHA != "" && payload.GitHash == latestSHA)) {
+	if hbTarget != "" && (sameCommit(payload.GitHash, hbTarget) || (latestSHA != "" && sameCommit(payload.GitHash, latestSHA))) {
 		// Spoke already at the target or at latest — clear the fallback entry.
+		// sameCommit tolerates short/full SHA length mismatch (hub stores a
+		// 7-char short SHA; a spoke may report a longer one) so a hive already
+		// at HEAD is not told to upgrade forever.
 		s.mu.Lock()
 		delete(s.heartbeatUpgrade, payload.HiveID)
 		s.mu.Unlock()
 		hbTarget = ""
 	}
 
-	if spokeManaged && latestSHA != "" && payload.GitHash != "" && payload.GitHash != latestSHA {
+	if spokeManaged && latestSHA != "" && payload.GitHash != "" && !sameCommit(payload.GitHash, latestSHA) {
 		resp.UpgradeTo = latestSHA
 		s.logger.Info("heartbeat: instructing spoke-managed hive to upgrade",
 			"hive_id", payload.HiveID,
 			"from", payload.GitHash,
 			"to", latestSHA,
 		)
-	} else if hbTarget != "" && payload.GitHash != hbTarget {
+	} else if hbTarget != "" && !sameCommit(payload.GitHash, hbTarget) {
 		resp.UpgradeTo = hbTarget
 		s.logger.Info("heartbeat: instructing hub-managed hive to upgrade (kubectl fallback)",
 			"hive_id", payload.HiveID,
@@ -769,8 +772,8 @@ func (s *HubServer) handleTaskStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var payload struct {
-		HiveID      string           `json:"hive_id"`
-		Leaderboard []LeaderboardEntry `json:"leaderboard"`
+		HiveID       string             `json:"hive_id"`
+		Leaderboard  []LeaderboardEntry `json:"leaderboard"`
 		Contributors ContributorSummary `json:"contributors"`
 	}
 	if err := json.Unmarshal(body, &payload); err != nil {
@@ -888,10 +891,10 @@ func (s *HubServer) handleRegistryDelete(w http.ResponseWriter, r *http.Request)
 
 func (s *HubServer) handleHubVersion(w http.ResponseWriter, r *http.Request) {
 	resp := map[string]any{
-		"git_hash":       s.hubGitHash,
-		"git_branch":     s.hubGitBranch,
-		"latest_sha":     getLatestSHA(),
-		"latest_shas":    getLatestSHAs(),
+		"git_hash":    s.hubGitHash,
+		"git_branch":  s.hubGitBranch,
+		"latest_sha":  getLatestSHA(),
+		"latest_shas": getLatestSHAs(),
 	}
 	cookie, _ := r.Cookie("hive_hub_user")
 	if cookie != nil && cookie.Value == hubAdminUsername {
@@ -1129,14 +1132,22 @@ func isPrivateURL(ctx context.Context, rawURL string) bool {
 }
 
 func clampInt(v, min, max int) int {
-	if v < min { return min }
-	if v > max { return max }
+	if v < min {
+		return min
+	}
+	if v > max {
+		return max
+	}
 	return v
 }
 
 func clampInt64(v, min, max int64) int64 {
-	if v < min { return min }
-	if v > max { return max }
+	if v < min {
+		return min
+	}
+	if v > max {
+		return max
+	}
 	return v
 }
 

--- a/v2/pkg/hub/sha_compare.go
+++ b/v2/pkg/hub/sha_compare.go
@@ -1,0 +1,23 @@
+package hub
+
+import "strings"
+
+// sameCommit reports whether two git SHAs refer to the same commit even when
+// one is a short (e.g. 7-char) prefix of the other. The hub stores 7-char
+// short SHAs (candidateSHA[:shortSHALen]) while a spoke may report a longer
+// gitShort — a raw != comparison then loops the spoke through endless
+// "upgrade" instructions to a version it is already running. Comparing on the
+// shorter length fixes that. Empty inputs are never equal (unknown state must
+// not be treated as up-to-date).
+func sameCommit(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if a == "" || b == "" {
+		return false
+	}
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	return strings.EqualFold(a[:n], b[:n])
+}

--- a/v2/pkg/hub/sha_compare_test.go
+++ b/v2/pkg/hub/sha_compare_test.go
@@ -1,0 +1,25 @@
+package hub
+
+import "testing"
+
+func TestSameCommit(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"39a095b9455f", "39a095b", true}, // full vs short prefix — the David bug
+		{"39a095b", "39a095b9455f", true}, // short vs full
+		{"39a095b9455f", "39a095b9455f", true},
+		{"39a095b", "39a095b", true},
+		{"39A095B", "39a095b9455f", true}, // case-insensitive
+		{"abc1234", "def5678", false},
+		{"39a095b", "39a0000", false}, // same length, differ
+		{"", "39a095b", false},        // empty never equal
+		{"39a095b", "", false},
+	}
+	for _, c := range cases {
+		if got := sameCommit(c.a, c.b); got != c.want {
+			t.Errorf("sameCommit(%q,%q)=%v want %v", c.a, c.b, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## 1. Self-upgrade crash-loop — the urgent one
A hosted hive (daviddiaz0317) was crash-looping and 503-ing. Root cause: the hub stores a **7-char short SHA** (`candidateSHA[:shortSHALen]`), but a spoke reports a longer `gitShort`. A raw `!=` compare told a hive **already at HEAD** to upgrade forever:

```
hub: upgrade to 39a095b   (short)
hive current: 39a095b9455f (full)  → "!=" → try upgrade
hive patches own Deployment → HTTP 403 (SA can't patch) → os.Exit(0)
kubelet restarts → hub says upgrade again → loop
```

The pod never stayed ready → the hive subdomain 503'd → the hub's hive link fell back to `/dashboard`.

**Fix:** `sameCommit(a,b)` — prefix-tolerant, case-insensitive, empty-never-equal — applied at every heartbeat / auto-upgrade comparison in `pkg/hub` (server.go ×3, saas.go), plus a same-commit **no-op guard in the hive's own upgrade callback** so a spoke never exits for a commit it already runs. Table test included.

## 2. Trajectory 'not configured' alert lingered
The "ON but no reviewer endpoint" banner was raised once at startup and **never cleared when the lane was toggled off** — so kubestellar/console showed the banner while trajectory review was OFF. Extracted `ReconcileTrajectoryAlert()`, called from both startup and the config PUT, so the alert tracks actual state (enabled **and** not-ready).

## 3. Toggle contrast (light + dark)
Off-state track was `var(--border)` (near-invisible) with a `var(--text)` thumb (black in light / white in dark), so every toggle read as a lone dot. Now: visible muted track + border in the off state, white knob with a shadow. Verified both themes.

Build/vet/tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)