### PR TITLE
fix(hub): clear Upgrading badge with prefix-tolerant SHA compare

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4275,6 +4275,16 @@ const dashboardHTML = `<!DOCTYPE html>
   <script>
     function esc(s) { var d = document.createElement('div'); d.textContent = s || ''; return d.innerHTML; }
 
+    // sameShaJS: two git SHAs are the same commit even if one is a short
+    // prefix of the other. The hub stores 7-char short SHAs while a spoke may
+    // report a longer one; a raw === left the "Upgrading" badge spinning
+    // forever on a hive already at the target. Mirrors hub sameCommit().
+    function sameShaJS(a, b) {
+      if (!a || !b) return false;
+      var n = Math.min(a.length, b.length);
+      return a.slice(0, n).toLowerCase() === b.slice(0, n).toLowerCase();
+    }
+
     function dismissBanner(key, btn) {
       var dismissed = JSON.parse(localStorage.getItem('hive-dismissed-banners') || '{}');
       dismissed[key] = Date.now();
@@ -4547,7 +4557,7 @@ const dashboardHTML = `<!DOCTYPE html>
           if (el) {
             var hubBranchLatest = _latestSHAs[hubBranch] || _latestSHA;
             var hubLatestUnknown = !hubBranchLatest;
-            var isCurrent = hubBranchLatest && hubHash === hubBranchLatest;
+            var isCurrent = hubBranchLatest && sameShaJS(hubHash, hubBranchLatest);
             var hubUpgradeBtn = '';
             var hubIsUpgrading = _hubUpgrading || (!isCurrent && hubBranchLatest && _hubAutoUpgrade);
             if (!isCurrent && hubBranchLatest && _isAdmin && !hubIsUpgrading) {
@@ -4765,7 +4775,7 @@ const dashboardHTML = `<!DOCTYPE html>
             ? '<span id="branch-pill-' + esc(h.id) + '" style="display:inline-block;position:relative;padding:1px 6px;border-radius:9999px;font-size:0.6rem;background:rgba(59,130,246,0.15);color:#60a5fa;border:1px solid rgba(59,130,246,0.3);margin-right:4px;cursor:pointer" onclick="toggleBranchMenu(\'' + esc(h.id) + '\')" title="Click to switch branch">' + esc(branchName) + ' ▾<div id="branch-menu-' + esc(h.id) + '" style="display:none;position:absolute;top:100%;left:0;margin-top:4px;background:#1c2128;border:1px solid #30363d;border-radius:6px;padding:4px 0;z-index:1000;min-width:60px;box-shadow:0 4px 12px rgba(0,0,0,0.4)">' + branchOptions + '</div></span>'
             : '<span style="display:inline-block;padding:1px 6px;border-radius:9999px;font-size:0.6rem;background:rgba(59,130,246,0.15);color:#60a5fa;border:1px solid rgba(59,130,246,0.3);margin-right:4px">' + esc(branchName) + '</span>';
           var latestUnknown = !branchLatest;
-          var isCurrent = branchLatest && sha === branchLatest;
+          var isCurrent = branchLatest && sameShaJS(sha, branchLatest);
           /* Branch switch in flight: the hive still reports the OLD branch
              (often current on it) until the new pod heartbeats — without
              this, isCurrent suppresses every progress indicator. */

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -475,10 +475,13 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 				branchForLatest = "v2"
 			}
 			registryLatestSHA := getLatestSHAForBranch(branchForLatest)
-			if h.Upgrading && !payload.Upgrading && (payload.GitHash == h.UpgradeTarget || (registryLatestSHA != "" && payload.GitHash == registryLatestSHA)) {
+			if h.Upgrading && !payload.Upgrading && (sameCommit(payload.GitHash, h.UpgradeTarget) || (registryLatestSHA != "" && sameCommit(payload.GitHash, registryLatestSHA))) {
 				// Non-upgrading heartbeat at the target SHA or at latest —
 				// upgrade completed (image may have advanced past the
-				// original target before the spoke pulled it).
+				// original target before the spoke pulled it). sameCommit
+				// tolerates short/full SHA length mismatch — a raw == left the
+				// Upgrading badge spinning forever when the spoke reported a
+				// full SHA and the target/latest was the 7-char short form.
 				entry.Upgrading = false
 				entry.UpgradeTarget = ""
 			} else if h.Upgrading && !payload.Upgrading && h.UpgradeTarget == "" {


### PR DESCRIPTION
Follow-up to #1942, which added `sameCommit()` for the upgrade *decision* but missed three SHA comparisons that drive the **Upgrading badge** — so a hive already at the target keeps spinning "Upgrading" forever when it reports a full SHA and the hub target/latest is the 7-char short form:

- `server.go:478` — heartbeat Upgrading-clear (`payload.GitHash == UpgradeTarget/latest`)
- `saas.go` per-hive row `isCurrent` (`sha === branchLatest`)
- `saas.go` hub-self `isCurrent` (`hubHash === hubBranchLatest`)

Uses `sameCommit()` (Go) and a new `sameShaJS()` (frontend, mirrors it).

Observed live on daviddiaz0317: pod healthy on the correct `03c0fc4b` image, 0 restarts, hive idle and working — but the badge never cleared. Pure display bug now that the crash-loop itself (#1942) is fixed. Build/tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)