### PR TITLE
fix(hub): standardize on 7-char short SHA across spoke, hub, and comparisons

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -13,7 +13,7 @@ COPY v2/ .
 ARG GIT_HASH=unknown
 ARG GIT_BRANCH=unknown
 RUN GIT_HASH=$(git -C /repo rev-parse HEAD 2>/dev/null || echo "unknown") && \
-    GIT_SHORT=$(git -C /repo rev-parse --short HEAD 2>/dev/null || echo "unknown") && \
+    GIT_SHORT=$(git -C /repo rev-parse --short=7 HEAD 2>/dev/null || echo "unknown") && \
     if [ "$GIT_BRANCH" = "unknown" ] || [ -z "$GIT_BRANCH" ]; then GIT_BRANCH=$(git -C /repo rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown"); fi && \
     GOCACHE=/tmp/gobuild CGO_ENABLED=0 go build -ldflags "-X main.gitHash=${GIT_HASH} -X main.gitShort=${GIT_SHORT} -X main.gitBranch=${GIT_BRANCH}" -o /hive ./cmd/hive && \
     GOCACHE=/tmp/gobuild CGO_ENABLED=0 go build -o /bd ./cmd/bd

--- a/v2/Dockerfile.hub
+++ b/v2/Dockerfile.hub
@@ -5,7 +5,7 @@ WORKDIR /src
 COPY .git /repo/.git
 COPY v2/ .
 RUN GIT_HASH=$(git -C /repo rev-parse HEAD 2>/dev/null || echo "unknown") && \
-    GIT_SHORT=$(git -C /repo rev-parse --short HEAD 2>/dev/null || echo "unknown") && \
+    GIT_SHORT=$(git -C /repo rev-parse --short=7 HEAD 2>/dev/null || echo "unknown") && \
     CGO_ENABLED=0 go build -ldflags "-X main.gitHash=${GIT_HASH} -X main.gitShort=${GIT_SHORT}" -o /hive ./cmd/hive
 
 FROM alpine:3.21

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -62,6 +62,13 @@ func main() {
 	}
 	configPath := flag.String("config", defaultConfig, "path to hive.yaml config file")
 	flag.Parse()
+	// Canonicalize gitShort to the standard 7-char short SHA the hub stores and
+	// compares against. The Dockerfile builds it with `--short=7`, but git can
+	// still return more chars when 7 isn't unique; trim so what we report to the
+	// hub is always the same length it stores (no short-vs-full mismatch).
+	if len(gitShort) > 7 {
+		gitShort = gitShort[:7]
+	}
 	dashboard.SetGitVersion(gitHash, gitShort)
 	dashboard.SetGitBranch(gitBranch)
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2852,7 +2852,7 @@ func (s *HubServer) triggerAutoUpgrades() {
 			continue
 		}
 		latestSHA := getLatestSHAForBranch(branch)
-		if latestSHA == "" || currentSHA == latestSHA {
+		if latestSHA == "" || sameCommit(currentSHA, latestSHA) {
 			continue
 		}
 		hiveCluster := s.clusterForHive(&h)
@@ -2924,12 +2924,11 @@ func fetchBranchSHA(logger *slog.Logger, branch string) {
 		logger.Warn("SHA poll: branch decode failed", "branch", branch, "error", err)
 		return
 	}
-	const shortSHALen = 7
-	if len(branchResult.Commit.SHA) < shortSHALen {
+	if len(branchResult.Commit.SHA) < StandardSHALen {
 		logger.Warn("SHA poll: branch SHA too short", "branch", branch, "sha", branchResult.Commit.SHA)
 		return
 	}
-	candidateSHA := branchResult.Commit.SHA[:shortSHALen]
+	candidateSHA := shortSHA(branchResult.Commit.SHA)
 	// Extract only the first line of the commit message for tooltip display.
 	commitMsg := branchResult.Commit.Commit.Message
 	if idx := strings.Index(commitMsg, "\n"); idx >= 0 {

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -310,6 +310,11 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "hive_id required", http.StatusBadRequest)
 		return
 	}
+	// Normalize the reported SHA to the canonical short length up front so every
+	// downstream comparison is same-length against the hub's 7-char stored SHAs.
+	// (Spokes now build gitShort with `--short=7`; this covers any that predate
+	// that or report a longer value.)
+	payload.GitHash = shortSHA(payload.GitHash)
 	if !isValidName(payload.HiveID) {
 		http.Error(w, "invalid hive_id", http.StatusBadRequest)
 		return
@@ -402,7 +407,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		LastHeartbeat: time.Now().UTC().Format(time.RFC3339),
 		Health:        payload.Health,
 		Version:       sanitizeHeartbeatField(payload.Version),
-		GitHash:       sanitizeHeartbeatField(payload.GitHash),
+		GitHash:       shortSHA(sanitizeHeartbeatField(payload.GitHash)),
 		GitBranch:     sanitizeHeartbeatField(payload.GitBranch),
 		Agents: func() []AgentSummary {
 			for i := range payload.Agents {

--- a/v2/pkg/hub/sha_compare.go
+++ b/v2/pkg/hub/sha_compare.go
@@ -2,6 +2,24 @@ package hub
 
 import "strings"
 
+// StandardSHALen is the canonical short-SHA length used across hive: the hub
+// stores branch SHAs as Commit.SHA[:StandardSHALen], spoke and hub binaries
+// build gitShort with `git rev-parse --short=7`, and the hub normalizes any
+// SHA a spoke reports to this length on ingest. Standardizing the length is
+// what removes short-vs-full mismatch at the source (sameCommit remains a
+// defensive backstop for any SHA that slips through un-normalized).
+const StandardSHALen = 7
+
+// shortSHA normalizes a git SHA to the canonical short length. A shorter or
+// empty value is returned unchanged (never padded); a longer one is truncated.
+func shortSHA(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= StandardSHALen {
+		return s
+	}
+	return s[:StandardSHALen]
+}
+
 // sameCommit reports whether two git SHAs refer to the same commit even when
 // one is a short (e.g. 7-char) prefix of the other. The hub stores 7-char
 // short SHAs (candidateSHA[:shortSHALen]) while a spoke may report a longer

--- a/v2/pkg/hub/sha_compare_test.go
+++ b/v2/pkg/hub/sha_compare_test.go
@@ -23,3 +23,19 @@ func TestSameCommit(t *testing.T) {
 		}
 	}
 }
+
+func TestShortSHA(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"03c0fc4b671a", "03c0fc4b"[:7]}, // 12 → 7
+		{"03c0fc4b671a", "03c0fc4"},      // explicit
+		{"39a095b", "39a095b"},           // already 7
+		{"abc", "abc"},                   // shorter, unchanged
+		{"", ""},                         // empty
+		{"  03c0fc4b671a  ", "03c0fc4"},  // trimmed then truncated
+	}
+	for _, c := range cases {
+		if got := shortSHA(c.in); got != c.want {
+			t.Errorf("shortSHA(%q)=%q want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Root cause
The self-upgrade churn on David's hive (and the "queued"/"Upgrading" badges that wouldn't clear) all trace to **one length mismatch**: the hive reported a variable-length `gitShort` (`git rev-parse --short` auto-sizes to 8–12+ chars) while the hub stores branch SHAs truncated to exactly 7 (`Commit.SHA[:7]`). Same commit, different string lengths → comparisons mismatched → a hive already at HEAD was told to upgrade forever.

#1942 and #1943 added `sameCommit`/`sameShaJS` to *tolerate* the mismatch. This PR **removes it at the source** — one canonical short length (7) end to end, per operator direction to standardize rather than defend:

- **Dockerfile + Dockerfile.hub**: `git rev-parse --short=7` (was bare `--short`)
- **cmd/hive/main.go**: trim `gitShort` to 7 at startup (git can still exceed 7 when it's not unique)
- **pkg/hub**: `StandardSHALen` const + `shortSHA()` helper; normalize `payload.GitHash` on heartbeat ingest; store `candidateSHA` via `shortSHA`; point the poller's local `shortSHALen` at the shared const
- fix the last raw `==` upgrade-skip compare (`saas.go`) to `sameCommit`

`sameCommit`/`sameShaJS` stay as a **defensive backstop** for any SHA that reaches a comparison un-normalized (e.g. an old spoke build reporting a long SHA before it upgrades).

## Testing
`shortSHA` + `sameCommit` table tests; build/vet/tests green.

Note: existing spokes keep reporting their old long SHA until they rebuild on this image; the hub-side ingest-normalization covers them in the meantime, so the churn stops as soon as the **hub** ships this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)