### PR TITLE
🔧 fix(entrypoint): provision /data/home/.codex group-writable for agent UIDs

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -214,11 +214,17 @@ if [ "$(id -u)" = "0" ]; then
   # Shared CLI auth/cache lives in /data/home (persistent volume).
   # Make it group-writable so all agent UIDs (node group) can use it.
   # The manager sets HOME=/data/home for agent tmux sessions.
-  mkdir -p /data/home/.config /data/home/.copilot /data/home/.claude/session-env /data/config/github-copilot /home/dev/.config
+  mkdir -p /data/home/.config /data/home/.copilot /data/home/.claude/session-env /data/home/.codex /data/config/github-copilot /home/dev/.config
   chmod 2770 /data/home/.copilot 2>/dev/null || true
   chown dev:node /data/home/.copilot 2>/dev/null || true
   chmod 2775 /data/home/.claude /data/home/.claude/session-env 2>/dev/null || true
   chown -R dev:node /data/home/.claude 2>/dev/null || true
+  # Codex (newer method) writes a local sqlite state db under $HOME/.codex —
+  # pre-create it group-writable + setgid so every agent UID (node group) can
+  # init it, matching .claude/.copilot. Without this, switching an agent to the
+  # codex backend fails with "Permission denied" initializing state_N.sqlite.
+  chmod 2775 /data/home/.codex 2>/dev/null || true
+  chown -R dev:node /data/home/.codex 2>/dev/null || true
   ln -sfn /data/config/github-copilot /home/dev/.config/github-copilot
   ln -sfn /data/config/github-copilot /data/home/.config/github-copilot
   ln -sfn /data/home/.copilot /home/dev/.copilot
@@ -272,7 +278,14 @@ if [ "$(id -u)" = "0" ]; then
         chown -R dev:node /data/home/.claude 2>/dev/null
       done
     ) &
-    echo "[entrypoint] inotify perm guard active (copilot + claude)"
+    (
+      while inotifywait -qq -e close_write,moved_to,create /data/home/.codex/ 2>/dev/null; do
+        chmod -R g+rwX /data/home/.codex 2>/dev/null
+        find /data/home/.codex -type d -exec chmod g+s {} + 2>/dev/null
+        chown -R dev:node /data/home/.codex 2>/dev/null
+      done
+    ) &
+    echo "[entrypoint] inotify perm guard active (copilot + claude + codex)"
   fi
   (
     CYCLE=0
@@ -283,8 +296,8 @@ if [ "$(id -u)" = "0" ]; then
       # Slow cycle: fix entire /data/home tree every 5 min (new dirs from agents)
       CYCLE=$((CYCLE + 1))
       if [ "$CYCLE" -ge 60 ]; then
-        chmod -R g+rwX /data/home/.cache /data/home/.copilot /data/home/.claude 2>/dev/null
-        find /data/home/.cache /data/home/.claude -type d -exec chmod g+s {} + 2>/dev/null
+        chmod -R g+rwX /data/home/.cache /data/home/.copilot /data/home/.claude /data/home/.codex 2>/dev/null
+        find /data/home/.cache /data/home/.claude /data/home/.codex -type d -exec chmod g+s {} + 2>/dev/null
         CYCLE=0
       fi
       sleep 5


### PR DESCRIPTION
## Problem

Switching an agent to the **codex** backend fails immediately:

```
ERROR: failed to initialize sqlite local db at /data/home/.codex/state_N.sqlite:
       failed to initialize state runtime at /data/home/.codex: Permission denied (os error 13)
WARNING: proceeding, even though we could not create PATH aliases: Permission denied
```

## Root cause

The entrypoint pre-creates `.claude` and `.copilot` under `/data/home` with group-write + setgid (`2775`/`2770`, group `node`) so every per-agent UID (`hive-<name>`, group `node`) can write them. **Codex is a newer method whose `$HOME/.codex` state dir was never added to that provisioning** — so a non-root agent UID cannot create it under the `755` root-owned `/data/home`.

`claude` and `copilot` work precisely *because* they get this treatment; codex was the one method missing from it.

## Fix (purely additive — parity with .claude/.copilot)

Add `.codex` to the three places `.claude`/`.copilot` are already handled:

1. **Pre-provision** — `mkdir -p … /data/home/.codex`, then `chmod 2775` + `chown -R dev:node`.
2. **inotify perm guard** — a third watcher that chowns fresh sqlite writes promptly (parity with the claude guard).
3. **5-minute slow-cycle** — self-heals `.codex` on already-provisioned PVCs, where the one-time `NEED_PERM_FIX` block is skipped (this is why David's existing hive couldn't create the dir on its own).

## Blast radius

**None to other methods.** Every change *appends* `/data/home/.codex` to a list that already contained `.claude`/`.copilot`; no existing path, permission, or flag is modified. Permissions are byte-identical to `.claude` (`2775`, `dev:node`, setgid). All commands are idempotent (`mkdir -p`, `2>/dev/null || true`). On hives that never use codex the dir sits empty. `gemini` shares the CLI-auth model (already covered); `vllm`/`llm-d`/`litellm` are endpoints that write no local state.

## Live hotfix already applied

David's running hive (`hosted-daviddiaz0317-visual-hive--1jos`) had `.codex` created manually with matching perms, so codex works there now; this PR makes it permanent for all hives on the next image build.