### PR TITLE
🔗 fix(hub): correct GitHub App slug on get-started page (hive-hub → kubestellar-hive)

### DIFF
--- a/v2/pkg/hub/static/get-started.html
+++ b/v2/pkg/hub/static/get-started.html
@@ -330,7 +330,7 @@
         <h2>Install the Hive GitHub App</h2>
         <p>The Hive GitHub App lets our agents read issues, open PRs, and respond to CI on your repos. Install it on the org or repos you want to manage.</p>
         <div style="margin:20px 0">
-          <a href="https://github.com/apps/hive-hub" target="_blank" class="btn-github" id="install-app-btn">
+          <a href="https://github.com/apps/kubestellar-hive" target="_blank" class="btn-github" id="install-app-btn">
             <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
             Install Hive GitHub App
           </a>
@@ -349,7 +349,7 @@
         <div id="repo-loading" style="color:var(--muted);padding:24px;text-align:center">Loading your repositories...</div>
         <div id="repo-list" class="repo-list" style="display:none"></div>
         <div id="repo-none" style="display:none;padding:24px;text-align:center;color:var(--muted)">
-          <p>No repositories found. Make sure the <a href="https://github.com/apps/hive-hub" target="_blank" style="color:var(--blue)">Hive GitHub App</a> is installed on your org.</p>
+          <p>No repositories found. Make sure the <a href="https://github.com/apps/kubestellar-hive" target="_blank" style="color:var(--blue)">Hive GitHub App</a> is installed on your org.</p>
         </div>
         <div style="display:flex;gap:12px;margin-top:16px">
           <button class="btn-secondary" onclick="goToStep(2)">← Back</button>


### PR DESCRIPTION
The **Install Hive GitHub App** button on `https://hive.kubestellar.io/get-started` (and the no-repos hint below it) linked to `https://github.com/apps/hive-hub`, which **404s**. The published app slug is `kubestellar-hive`.

Both links now point at `https://github.com/apps/kubestellar-hive` — verified **HTTP 200** (old slug verified 404).

Two-line change, static hrefs only.