### PR TITLE
🐝 feat(hub): animated bee banner on the landing-page fleet panel

### DIFF
--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -170,6 +170,52 @@
       width: .72rem; height: .72rem;
       box-shadow: 0 0 0 .38rem #74df9a24;
     }
+
+    /* ── Bee banner: a bee buzzes to an SVG skep hive and back, atop the live
+       fleet panel. .wb-* scoped; flight bounds are % so it fits the panel. ── */
+    .wb-stage{ position:relative; width:100%; height:56px; margin:-.25rem 0 1rem;
+      border-radius:.7rem; overflow:hidden;
+      background:linear-gradient(180deg, #f4c75f14, transparent 72%); }
+    .wb-stage::before{ content:""; position:absolute; inset:0; opacity:.07; pointer-events:none;
+      background-image:radial-gradient(circle at 50% 50%, transparent 0, transparent 7px, var(--amber) 7px, var(--amber) 8px, transparent 8px);
+      background-size:28px 24px; }
+    .wb-hive{ position:absolute; right:14px; top:50%; filter:drop-shadow(0 3px 4px rgba(0,0,0,.4));
+      animation:wb-sway 6s ease-in-out infinite; transform-origin:50% 3px; }
+    .wb-hive .wb-coils rect{ fill:#e0a52a; stroke:#b9791f; stroke-width:1.1; }
+    .wb-hive .wb-coils rect:nth-child(even){ fill:#f0b429; }
+    @keyframes wb-sway{ 0%,100%{ transform:translateY(-50%) rotate(-3deg); } 50%{ transform:translateY(-50%) rotate(3deg); } }
+    .wb-flyer{ position:absolute; top:50%; left:0; width:100%; will-change:transform; animation:wb-fly 20s ease-in-out infinite; }
+    .wb-facing{ display:inline-block; animation:wb-bank 20s ease-in-out infinite; }
+    .wb-bob{ display:inline-block; animation:wb-bob 3.6s ease-in-out infinite; }
+    .wb-bee{ display:inline-block; font-size:23px; line-height:1; filter:drop-shadow(0 2px 3px rgba(0,0,0,.35));
+      animation:wb-flutter .13s ease-in-out infinite alternate; transform-origin:50% 65%; }
+    @keyframes wb-fly{
+      0%,6%    { transform:translateX(12px); }
+      46%,54%  { transform:translateX(calc(100% - 64px)); }
+      94%,100% { transform:translateX(12px); }
+    }
+    @keyframes wb-bob{ 0%,100%{ transform:translateY(-7px); } 50%{ transform:translateY(7px); } }
+    @keyframes wb-flutter{ 0%{ transform:rotate(-5deg) scaleY(1); } 100%{ transform:rotate(5deg) scaleY(.94); } }
+    @keyframes wb-bank{
+      0%      { transform:scaleX(0); }
+      6%,46%  { transform:scaleX(-1); }
+      50%     { transform:scaleX(0); }
+      54%,94% { transform:scaleX(1); }
+      100%    { transform:scaleX(0); }
+    }
+    .wb-trail{ position:absolute; top:0; left:0; pointer-events:none;
+      animation:wb-bob 3.6s ease-in-out infinite; animation-delay:-0.22s; }
+    .wb-trail i{ position:absolute; top:9px; width:4px; height:2px; border-radius:2px; background:var(--amber);
+      opacity:0; animation:wb-puff 3.6s ease-out infinite; }
+    .wb-trail i:nth-child(1){ left:28px; animation-delay:0s; }
+    .wb-trail i:nth-child(2){ left:36px; animation-delay:.18s; }
+    .wb-trail i:nth-child(3){ left:44px; animation-delay:.36s; }
+    @keyframes wb-puff{ 0%{ opacity:.4; transform:translateY(0) scale(1);} 100%{ opacity:0; transform:translateY(5px) scale(.4);} }
+    @media (prefers-reduced-motion: reduce){
+      .wb-flyer,.wb-facing,.wb-bob,.wb-bee,.wb-trail,.wb-trail i,.wb-hive{ animation:none !important; }
+      .wb-flyer{ transform:translateX(calc(50% - 28px)); }
+      .wb-hive{ transform:translateY(-50%); }
+    }
     .verdict-card {
       background: #f4c75f17;
       border: 1px solid #f4c75f42;
@@ -441,6 +487,24 @@
       </div>
 
       <div class="hero-panel">
+        <div class="wb-stage" aria-hidden="true">
+          <svg class="wb-hive" viewBox="0 0 80 92" width="38" height="44">
+            <path d="M40 2 v8" stroke="#8a5a30" stroke-width="3" fill="none"/>
+            <g class="wb-coils">
+              <rect x="30" y="10" width="20" height="9"  rx="4.5"/>
+              <rect x="24" y="18" width="32" height="10" rx="5"/>
+              <rect x="18" y="27" width="44" height="11" rx="5.5"/>
+              <rect x="13" y="37" width="54" height="12" rx="6"/>
+              <rect x="11" y="48" width="58" height="12" rx="6"/>
+              <rect x="13" y="59" width="54" height="12" rx="6"/>
+              <rect x="18" y="70" width="44" height="11" rx="5.5"/>
+              <rect x="26" y="80" width="28" height="10" rx="5"/>
+            </g>
+            <ellipse cx="40" cy="64" rx="7.5" ry="9" fill="#2a1a06"/>
+            <ellipse cx="40" cy="62" rx="7.5" ry="7" fill="#120c04"/>
+          </svg>
+          <div class="wb-flyer"><div class="wb-facing"><div class="wb-trail"><i></i><i></i><i></i></div><div class="wb-bob"><span class="wb-bee">&#x1F41D;</span></div></div></div>
+        </div>
         <div class="panel-header"><span class="signal"></span> Live fleet status</div>
         <div class="verdict-card">
           <span>Hives online</span>


### PR DESCRIPTION
Adds the flying-bee + inline-SVG skep hive banner to the top of the hero's **Live fleet status** panel on `hive.kubestellar.io` — a bee drifts to the hive and back, above the live stats.

- `.wb-*` scoped selectors; theme-aware via the page's `--amber` token.
- **Slow, ambient timings** (fly 20s, sway 6s, bob 3.6s) so it reads as calm atmosphere, not an attention-grabbing loop.
- Percentage-based flight bounds fit the panel; inline SVG hive (no beehive emoji exists in Unicode) with coil bands + entrance hole.
- Respects `prefers-reduced-motion`.

Matches the dashboard bee shipped in #1947, placed for the public landing page.