### PR TITLE
🔢 fix(hub): raise heartbeat token clamp 100M → 100B so real usage isn't capped

### DIFF
--- a/v2/pkg/hub/hub_heartbeat_tokens_test.go
+++ b/v2/pkg/hub/hub_heartbeat_tokens_test.go
@@ -76,8 +76,10 @@ func TestHeartbeatTokenTotalClamped(t *testing.T) {
 	}
 	srv.mu.RUnlock()
 
-	// clampInt64(payload.Tokens24h, 0, 100_000_000)
-	const maxTokens = int64(100_000_000)
+	// clampInt64(payload.Tokens24h, 0, 100_000_000_000) — 100B ceiling is a
+	// sanity guard against a corrupt/hostile spoke; real hives legitimately
+	// exceed 100M/day so the cap must be far above realistic usage.
+	const maxTokens = int64(100_000_000_000)
 	if got != maxTokens {
 		t.Fatalf("clamped TotalTokens24h = %d, want %d", got, maxTokens)
 	}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -388,7 +388,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			return count
 		}(),
 		GovernorMode:       sanitizeHeartbeatField(payload.Governor.Mode),
-		TotalTokens24h:     clampInt64(payload.Tokens24h, 0, 100_000_000),
+		TotalTokens24h:     clampInt64(payload.Tokens24h, 0, 100_000_000_000),
 		ActionableIssues:   clampInt(payload.Governor.Issues, 0, 10_000),
 		ActionablePRs:      clampInt(payload.Governor.PRs, 0, 10_000),
 		ContributorCount:   clampInt(payload.Contributors.Registered, 0, 10_000),


### PR DESCRIPTION
The fleet **Tokens** column capped every hive at exactly `100M` because the heartbeat sanitizer clamped `Tokens24h` to `100_000_000` (`server.go:391`). Real hives burn well over 100M tokens/day, so many rows showed a flat, inaccurate `100M` with the true value thrown away — which is why the count never appeared higher than 100M.

Raise the ceiling to **100B** — still a sanity guard against a corrupt/hostile spoke injecting an absurd value, but far above realistic usage. `fmtTokens()` already renders a `B` suffix, so no display change needed. Clamp test updated.