### PR TITLE
fix(spoke): preserve dashboard-installed GitHub App creds across restart

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -42,6 +42,13 @@ if [ "$IS_KUBERNETES" = "true" ]; then
     #   - hub.is_public  (hub-managed visibility)
     # A missing, empty, unparsable, or implausible overlay (no
     # project.org / agents) leaves the ConfigMap seed untouched.
+    #
+    # github.{app_id,installation_id,key_file}: a dashboard-installed (or
+    # hub-pushed, post App-install-webhook) GitHub App is PVC-overlay-only
+    # state — the ConfigMap seed is never updated after install and keeps
+    # whatever placeholder it was provisioned with. The overlay must win
+    # here too, and a seed that already shows a real installed App must
+    # never be silently downgraded by a missing/placeholder overlay.
     HIVE_DASHBOARD_OVERLAY="/data/hive.yaml.dashboard"
     if [ -f "$HIVE_DASHBOARD_OVERLAY" ] && [ -s "$HIVE_DASHBOARD_OVERLAY" ]; then
       if python3 - "$HIVE_CONFIG_PATH" "$HIVE_DASHBOARD_OVERLAY" <<'PYEOF'
@@ -59,6 +66,56 @@ if not isinstance(overlay, dict):
     sys.exit(1)
 if not (overlay.get('project') or {}).get('org') or not overlay.get('agents'):
     sys.exit(1)
+
+# GitHub App credentials installed at runtime via the dashboard (or pushed
+# by the hub after the App install webhook fires — see
+# pkg/dashboard/api.go handleConfigGitHub) are persisted ONLY to this
+# overlay, never back to the ConfigMap. The ConfigMap seed for a freshly
+# claimed/placeholder hive still carries the placeholder app_id/
+# installation_id/key_file, so if the overlay is missing, truncated, or
+# otherwise reverted to a placeholder-looking github block, letting the
+# seed win here would silently wipe a live App installation on every
+# restart (observed: a hive's installed App reverted to placeholder
+# creds after a pod restart, 401-looping on every GitHub call). Treat a
+# seed that already has a real (non-placeholder) app_id/installation_id
+# as a signal this hive has an installed App — refuse to let a
+# github-less or placeholder-looking overlay silently downgrade it.
+seed_gh = seed.get('github') or {}
+overlay_gh = overlay.get('github') or {}
+
+
+def _looks_placeholder(gh):
+    key_file = gh.get('key_file') or ''
+    app_id = gh.get('app_id')
+    installation_id = gh.get('installation_id')
+    if not app_id or not installation_id:
+        return True
+    if isinstance(key_file, str) and 'PLACEHOLDER' in key_file.upper():
+        return True
+    return False
+
+
+seed_has_real_app = isinstance(seed_gh, dict) and not _looks_placeholder(seed_gh)
+overlay_has_real_app = isinstance(overlay_gh, dict) and not _looks_placeholder(overlay_gh)
+if seed_has_real_app and not overlay_has_real_app:
+    sys.stderr.write(
+        "[entrypoint] github: overlay missing/placeholder app credentials but "
+        "ConfigMap seed has a real app_id/installation_id — keeping the seed's "
+        "github block to avoid wiping an installed GitHub App\n"
+    )
+    overlay['github'] = seed_gh
+elif overlay_has_real_app:
+    # The overlay's installed-App credentials win over the seed, per the
+    # standard overlay-wins precedence — but only trust key_file if the
+    # PEM it names actually exists on this PVC. A dangling reference
+    # (e.g. an interrupted key write) must not silently authenticate with
+    # a missing/placeholder file; fail loud instead of 401-looping quietly.
+    key_file = overlay_gh.get('key_file') or ''
+    if isinstance(key_file, str) and key_file.startswith('/data/') and not os.path.isfile(key_file):
+        sys.stderr.write(
+            "[entrypoint] WARNING: overlay github.key_file=%s does not exist on "
+            "the PVC — GitHub App auth will fail until it is re-installed\n" % key_file
+        )
 
 # The dashboard OVERLAY wins for acmm_level: the ConfigMap seed only ever
 # carries the provision-time level and is NOT updated when the level is
@@ -83,7 +140,7 @@ with open(tmp_path, 'w') as f:
 os.replace(tmp_path, seed_path)
 PYEOF
       then
-        echo "[entrypoint] K8s mode — dashboard overlay merged over ConfigMap seed (overlay wins for acmm_level; ConfigMap wins for hub.is_public)"
+        echo "[entrypoint] K8s mode — dashboard overlay merged over ConfigMap seed (overlay wins for acmm_level and github app creds; ConfigMap wins for hub.is_public)"
       else
         echo "[entrypoint] K8s mode — dashboard overlay invalid, using ConfigMap seed as-is"
       fi

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -2111,6 +2111,21 @@ func IsKubernetesPod() bool {
 // saveDashboardOverlay writes the secret-free PVC overlay in Kubernetes
 // mode. Failures are logged, never fatal: the primary save already
 // succeeded, the overlay only affects persistence across pod restarts.
+//
+// The write MUST be atomic (temp file + rename), unlike saveLocked()'s
+// inode-preserving write to the bind-mounted primary config. DashboardOverlayFile
+// lives on the PVC (not a bind mount), so rename is safe here, and it is the
+// only way to avoid a truncated/partial overlay if the pod is killed mid-write
+// (a redeploy sends SIGTERM/SIGKILL at an arbitrary instant). A truncate-in-place
+// write (os.WriteFile) can leave the file cut off partway through — GitHubConfig
+// marshals AFTER Agents/Project in the Config struct field order (see the
+// struct tags above), so a truncated overlay can silently keep valid
+// project/agents blocks while losing app_id/installation_id/key_file entirely.
+// The entrypoint's merge script only sanity-checks project.org and agents
+// before trusting the overlay wholesale, so that truncated-but-plausible file
+// would pass the guard and revert a dashboard-installed GitHub App to the
+// placeholder ConfigMap seed on the next restart — exactly the durability bug
+// this atomic write prevents.
 func (c *Config) saveDashboardOverlay() {
 	if !IsKubernetesPod() {
 		// Docker/LXC mode: /data/hive.yaml.bak is already the boot-time
@@ -2123,8 +2138,29 @@ func (c *Config) saveDashboardOverlay() {
 		log.Printf("[config] warning: failed to marshal dashboard overlay: %v", err)
 		return
 	}
-	if err := os.WriteFile(DashboardOverlayFile, data, 0o644); err != nil {
-		log.Printf("[config] warning: failed to write dashboard overlay %s (dashboard saves will not survive pod restarts): %v", DashboardOverlayFile, err)
+	tmpPath := DashboardOverlayFile + ".tmp"
+	const overlayFileMode = 0o644
+	f, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, overlayFileMode)
+	if err != nil {
+		log.Printf("[config] warning: failed to open dashboard overlay temp file %s (dashboard saves will not survive pod restarts): %v", tmpPath, err)
+		return
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		log.Printf("[config] warning: failed to write dashboard overlay temp file %s (dashboard saves will not survive pod restarts): %v", tmpPath, err)
+		return
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		log.Printf("[config] warning: failed to fsync dashboard overlay temp file %s (dashboard saves will not survive pod restarts): %v", tmpPath, err)
+		return
+	}
+	if err := f.Close(); err != nil {
+		log.Printf("[config] warning: failed to close dashboard overlay temp file %s (dashboard saves will not survive pod restarts): %v", tmpPath, err)
+		return
+	}
+	if err := os.Rename(tmpPath, DashboardOverlayFile); err != nil {
+		log.Printf("[config] warning: failed to rename dashboard overlay into place %s (dashboard saves will not survive pod restarts): %v", DashboardOverlayFile, err)
 		return
 	}
 	log.Printf("[config] dashboard overlay written to %s (merged over the ConfigMap seed at next boot)", DashboardOverlayFile)


### PR DESCRIPTION
## Bug

A GitHub App installed at runtime on a spoke — via the dashboard's Install GitHub App flow, or via the hub's post-install-webhook push to `PUT /api/config/github` (`pkg/dashboard/api.go` `handleConfigGitHub`, ~L4076-4147) — gets clobbered on the next pod redeploy/restart, reverting to the placeholder ConfigMap seed. Real observed case: a hive's Joe-installed App creds (which had authored a real GitHub issue via the app bot token) were wiped after a restart; the pod then 401-loops every ~2 min because on-disk creds are placeholder again.

## Root cause

`handleConfigGitHub` correctly writes the real private key to `/data/gh-app-key.pem` (PVC) and persists `app_id`/`installation_id`/`key_file` via `Config.Save()` → `saveDashboardOverlay()`, which writes the secret-free PVC overlay at `/data/hive.yaml.dashboard`. The entrypoint's boot-time merge (`v2/deploy/entrypoint.sh`, the python heredoc around L47-96) does correctly merge this overlay back over the ConfigMap seed for everything except the hub-managed `acmm_level`/`hub.is_public` keys — so on paper the installed App should survive.

The actual bug: **`saveDashboardOverlay()` (`v2/pkg/config/config.go`, was ~L2114-2131) wrote via a truncate-in-place `os.WriteFile`, not an atomic write.** `GitHubConfig` marshals *after* `Agents`/`Project` in the `Config` struct field order. A pod killed mid-write (exactly what a redeploy does — SIGTERM/SIGKILL at an arbitrary instant) can leave `/data/hive.yaml.dashboard` truncated partway through the `github:` block while `project:`/`agents:` are already flushed and intact. The entrypoint's sanity guard only checks `project.org` and `agents` before trusting the overlay wholesale (line ~60 of the merge script: `if not (overlay.get('project') or {}).get('org') or not overlay.get('agents'): sys.exit(1)`) — it never checked `github` — so a truncated-but-plausible overlay passes the guard, and the merge falls back to whatever `github:` block is in the ConfigMap seed: the awaiting-install placeholder.

## Fix

- **`v2/pkg/config/config.go`** — `saveDashboardOverlay()` now writes via temp file + `fsync` + `os.Rename`, matching the atomicity already used elsewhere in this codebase for exactly this reason (rename is safe here because `DashboardOverlayFile` lives on the PVC, not a bind mount — unlike the primary config's inode-preserving write). A kill mid-write now leaves the previous, complete overlay in place instead of a truncated one.
- **`v2/deploy/entrypoint.sh`** — the boot-time merge now explicitly treats `github.{app_id,installation_id,key_file}` as overlay-wins (same precedence class as `acmm_level`), and adds a belt-and-suspenders guard: if the ConfigMap seed already shows a real (non-placeholder) installed App but the overlay's `github` block is missing or looks like a placeholder, the seed's `github` block wins instead of silently downgrading to placeholder. It also warns loudly (does not fail silently) if the overlay's `key_file` names a `/data/...` path that no longer exists on the PVC.

## Why this matters

This is critical for the placeholder-hive claim flow: a claimed placeholder hive installs its own GitHub App at runtime, and that installation must survive the next pod redeploy — not silently revert to "awaiting install," which causes a persistent 401-loop until an operator manually re-triggers or re-installs the App.

## Test plan

- [ ] CI build/lint pass
- [ ] Manual: install a GitHub App on a spoke via the dashboard, restart the pod, confirm `app_id`/`installation_id`/`key_file` in the merged `hive.yaml` still point at the real installed App (not the placeholder)
- [ ] Manual: kill the pod mid-save (simulate a redeploy race) and confirm the previous overlay survives intact rather than truncating