### PR TITLE
🔧 fix(agent): per-agent CODEX_HOME to fix Codex app-server EPERM for non-root agents

### DIFF
--- a/bin/agent-launch.sh
+++ b/bin/agent-launch.sh
@@ -92,6 +92,26 @@ if [[ ${#EXTRA_ARGS[@]} -gt 0 ]]; then
   FULL_CMD+=("${EXTRA_ARGS[@]}")
 fi
 
+# Codex CLI: give each agent its OWN CODEX_HOME rather than the shared
+# $HOME/.codex. Codex 0.144.1's "in-process app-server client" performs
+# owner-gated operations on files/dirs under CODEX_HOME (helper-binary "PATH
+# alias" symlinks under tmp/arg0, sqlite state). A shared CODEX_HOME owned by
+# a DIFFERENT uid (the entrypoint chowns /data/home/.codex to dev:node) makes
+# every non-owner agent uid fail with:
+#   Error: failed to initialize in-process app-server client:
+#          Operation not permitted (os error 1)
+# even though the dir is group-writable and the agent is in the node group —
+# group-write is NOT sufficient, the app-server needs ownership. Claude/Copilot
+# tolerate group-write; Codex does not. Verified live: a per-agent CODEX_HOME
+# the agent owns launches Codex cleanly. The dir lives on the persistent
+# /data/home volume (group-writable, setgid node) so the agent uid can create
+# it and owns everything it writes inside.
+if [[ "$BACKEND" == "codex" ]]; then
+  CODEX_HOME="${CODEX_HOME:-/data/home/.codex-${HIVE_AGENT_ID}}"
+  export CODEX_HOME
+  mkdir -p "$CODEX_HOME" 2>/dev/null || true
+fi
+
 # Copilot CLI: use a fine-grained PAT via env var to bypass /login entirely.
 # The PAT file lives on the persistent /data volume, never in source control.
 if [[ "$BACKEND" == "copilot" ]]; then


### PR DESCRIPTION
## Problem (LIVE blocker)

Codex CLI 0.144.1 (`/opt/hive/codex/bin/codex`) fails for **any non-root agent uid** (e.g. `hive-scanner` uid 2007) but works as root:

```
WARNING: proceeding, even though we could not create PATH aliases: Operation not permitted (os error 1)
Error: failed to initialize in-process app-server client: Operation not permitted (os error 1)
```

This blocks David Diaz from using the `codex` backend in his spoke pod.

## Root cause (isolated live, with evidence)

It is **ownership of `CODEX_HOME`**, not sandbox / `$HOME` perms / `TMPDIR` / NFS / a capability.

| Test (as `hive-scanner`) | CODEX_HOME | Result |
|---|---|---|
| Baseline | `/data/home/.codex` (shared, `dev:node`, group-writable+setgid) | ❌ app-server EPERM |
| `TMPDIR=/tmp XDG_RUNTIME_DIR=/tmp` | shared `.codex` | ❌ app-server EPERM (rules out socket/tmp dir) |
| Fresh dir on **same NFS volume**, scanner-owned | `/data/home/cxtest-nfs` | ✅ full banner (rules out NFS) |
| **Scanner-owned copy of the exact same populated `.codex`** | `/data/home/cxcopy` | ✅ full banner |
| **Per-agent home** | `/data/home/.codex-<agent>` | ✅ full banner, reaches API |

Codex 0.144.1's *in-process app-server client* init (and the "PATH alias" helper-binary symlinks it creates under `CODEX_HOME/tmp/arg0`) perform **owner-gated** operations on `CODEX_HOME`. The entrypoint chowns the shared `/data/home/.codex` to `dev:node` (uid 1001) and makes it group-writable+setgid so all agents can share it — which is fine for Claude/Copilot (they tolerate group ownership) but **Codex's app-server requires the current uid to OWN the contents**. Group membership in `node` + group-write is not enough, so every agent uid other than the creator EPERMs.

The `codex-code-mode-host` binary and network path were verified fine; the PATH-alias warning is a secondary symptom, not the app-server cause.

## Fix

For the `codex` backend, `agent-launch.sh` (which runs **as the agent uid**) points `CODEX_HOME` at a per-agent dir `/data/home/.codex-<agent>` and creates it. The dir and everything Codex writes inside are owned by that uid, so the app-server initializes cleanly. Mirrors the existing per-agent-HOME pattern used for inference backends.

## Canary proving it works (as the agent user, through the launcher)

```
$ su-exec hive-scanner .../agent-launch.sh --backend codex exec --skip-git-repo-check
OpenAI Codex v0.144.1
session id: 019f9076-...
# (only a 401 Unauthorized remains — missing OpenAI auth, a separate config step, NOT this blocker)
$ ls -ld /data/home/.codex-scanner
drwxrws---. hive-scanner node ...   # auto-created, agent-owned
```

Before the fix the same invocation produced the app-server EPERM.

## Live hotfix

The equivalent change was hot-applied to David's running pod (`/usr/local/bin/agent-launch.sh`, backup at `.pre-codexfix.bak`) so he is unblocked now; this PR bakes it into the image.

## Note

Codex auth (`OPENAI_API_KEY` / `auth.json`) is passed through env or dropped into the per-agent `CODEX_HOME` by the user — unchanged by this fix. No shared codex auth existed to migrate.