### PR TITLE
fix(spoke): detect dead heartbeat goroutine via new /api/livez liveness check

### DIFF
--- a/v2/deploy/k8s/deployment.yaml
+++ b/v2/deploy/k8s/deployment.yaml
@@ -66,8 +66,14 @@ spec:
             - name: data
               mountPath: /data
           livenessProbe:
+            # /api/livez includes a heartbeat-staleness check (in addition to
+            # everything /api/health checks) so a heartbeat goroutine that
+            # dies silently while the HTTP server stays up gets caught and
+            # the pod restarted, instead of staying 1/1 Running forever with
+            # the hub showing it offline. See pkg/dashboard/server.go
+            # handleLivez. Hives with no hub configured are unaffected.
             httpGet:
-              path: /api/health
+              path: /api/livez
               port: api
             initialDelaySeconds: 30
             periodSeconds: 30

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kubestellar/hive/v2/pkg/agent"
 	"github.com/kubestellar/hive/v2/pkg/github"
+	"github.com/kubestellar/hive/v2/pkg/hub"
 )
 
 //go:embed static
@@ -40,6 +41,10 @@ type Server struct {
 	deps       *Dependencies
 	sidebar    interface{}
 	sidebarMu  sync.RWMutex
+
+	// startedAt marks process start, used by /api/livez to bound the
+	// startup-grace window before the first heartbeat has to have succeeded.
+	startedAt time.Time
 
 	agentPipelines map[string]map[string]bool
 	agentHooks     map[string]map[string][]any
@@ -366,6 +371,7 @@ func NewServer(port int, logger *slog.Logger) *Server {
 		audit:          newAuditLog(),
 		userSessions:   make(map[string]*userSession),
 		cliModels:      newCLIModelCache(),
+		startedAt:      time.Now(),
 	}
 	s.registerCoreRoutes()
 	return s
@@ -383,6 +389,7 @@ func NewServerWithAuth(port int, authToken string, logger *slog.Logger) *Server 
 		audit:          newAuditLog(),
 		userSessions:   make(map[string]*userSession),
 		cliModels:      newCLIModelCache(),
+		startedAt:      time.Now(),
 	}
 	s.registerCoreRoutes()
 	return s
@@ -454,6 +461,7 @@ func (s *Server) SetSkipReloadFunc(fn func()) {
 func (s *Server) registerCoreRoutes() {
 	s.mux.HandleFunc("GET /api/health", s.handleHealth)
 	s.mux.HandleFunc("GET /api/health/deep", s.handleHealthDeep)
+	s.mux.HandleFunc("GET /api/livez", s.handleLivez)
 	s.mux.HandleFunc("GET /api/status", s.handleStatus)
 	s.mux.HandleFunc("GET /api/events", s.handleSSE)
 	s.mux.HandleFunc("POST /api/github-app/recheck", s.handleGitHubAppRecheck)
@@ -970,6 +978,92 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]string{"status": "starting"})
 		return
 	}
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+const (
+	// heartbeatSendInterval mirrors the fixed 2-minute cadence StartHeartbeat
+	// is launched with in cmd/hive/main.go (see the comment there — it's
+	// deliberately independent of the governor eval interval so every hive,
+	// regardless of ACMM level, beats comfortably under the hub's 5-minute
+	// staleness window). Duplicated as a constant here rather than plumbed
+	// through from main.go because the value is a cross-package contract
+	// (hub-side staleness marking, spoke-side send cadence, and now this
+	// liveness threshold all need to agree on it) and hub.heartbeatSendInterval
+	// isn't exported. If that interval ever changes, update both.
+	heartbeatSendInterval = 2 * time.Minute
+
+	// livezHeartbeatStaleMax is how old the last successful heartbeat may be
+	// before /api/livez reports unhealthy. Set to 3x the send interval (6
+	// minutes): generous enough to absorb one or two transient hub-side
+	// failures (network blip, hub restart, rate limit) without flapping the
+	// pod, but tight enough that a genuinely dead heartbeat goroutine gets
+	// caught and the pod restarted well within a single human-observable
+	// "gray dot" investigation window.
+	livezHeartbeatStaleMax = 3 * heartbeatSendInterval
+
+	// livezStartupGrace bounds how long a freshly started process is treated
+	// as healthy before it has sent its first successful heartbeat. Covers
+	// waitForReady's own up-to-3-minute wait for the dashboard to come up
+	// plus one heartbeat send attempt and hub round trip. Without this, a
+	// pod would fail liveness during normal startup, before the heartbeat
+	// loop ever got a chance to succeed.
+	livezStartupGrace = 4 * time.Minute
+)
+
+// handleLivez is the liveness-only counterpart to /api/health. It includes
+// everything /api/health checks (the HTTP server itself is responsive) PLUS,
+// for hub-connected hives, a check that the heartbeat goroutine is actually
+// still beating. The heartbeat goroutine can silently die (panic recovered
+// upstream, deadlock, stuck HTTP call) while this HTTP server keeps serving
+// fine — that's the bug this endpoint exists to catch: before this endpoint
+// existed, /api/health stayed green in that case and kubelet had no reason
+// to ever restart the pod, so the hub kept showing the hive as offline
+// (gray dot) indefinitely even though the pod was 1/1 Running.
+//
+// Only the livenessProbe should point here. Readiness stays on /api/health:
+// a transient hub outage would otherwise pull a perfectly-serving pod out of
+// the Service's endpoints for no benefit (restarting won't fix a hub that's
+// down). Liveness failing here IS the intended remedy for a dead heartbeat
+// goroutine, since a restart revives it.
+func (s *Server) handleLivez(w http.ResponseWriter, r *http.Request) {
+	s.statusMu.RLock()
+	ready := s.ready
+	s.statusMu.RUnlock()
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if !ready {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		json.NewEncoder(w).Encode(map[string]string{"status": "starting"})
+		return
+	}
+
+	// Hives with no hub configured never run a heartbeat loop at all, so
+	// there is nothing to go stale — never gate their liveness on this.
+	if hub.HeartbeatEnabled() {
+		lastSuccess, hasSucceededOnce := hub.LastHeartbeatSuccess()
+		switch {
+		case !hasSucceededOnce:
+			if age := time.Since(s.startedAt); age > livezStartupGrace {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				json.NewEncoder(w).Encode(map[string]string{
+					"status": "unhealthy",
+					"detail": "no successful heartbeat since startup",
+				})
+				return
+			}
+		case time.Since(lastSuccess) > livezHeartbeatStaleMax:
+			w.WriteHeader(http.StatusServiceUnavailable)
+			json.NewEncoder(w).Encode(map[string]string{
+				"status":            "unhealthy",
+				"detail":            "heartbeat stale",
+				"last_heartbeat_at": lastSuccess.UTC().Format(time.RFC3339),
+			})
+			return
+		}
+	}
+
 	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"sync/atomic"
 	"time"
 )
 
@@ -16,6 +17,51 @@ const (
 	heartbeatTimeout = 10 * time.Second
 	staleThreshold   = 15 * time.Minute
 )
+
+// lastHeartbeatSuccessUnix holds the unix-seconds timestamp of the most
+// recent heartbeat the hub accepted (HTTP < 300 from either the regular
+// StartHeartbeat loop or SendUpgradingHeartbeat). It is process-global
+// because a hive runs at most one heartbeat loop, and it needs to be read
+// from the dashboard's HTTP handler goroutine (the liveness endpoint) while
+// being written from the heartbeat goroutine — hence atomic rather than a
+// mutex-guarded field, so the health handler never blocks on the sender.
+//
+// Zero means "no successful heartbeat yet" (process just started, or the
+// hive doesn't run a heartbeat loop at all). Callers distinguish those two
+// cases via HeartbeatEnabled, not via this timestamp alone.
+var lastHeartbeatSuccessUnix atomic.Int64
+
+// heartbeatLoopStarted records whether StartHeartbeat actually launched a
+// loop for this process (i.e. hubURL was non-empty). A hive with no hub
+// configured never sends heartbeats, so its liveness check must not gate on
+// heartbeat freshness at all — otherwise every hub-less hive would fail
+// liveness forever. Set once at startup; read from the HTTP handler.
+var heartbeatLoopStarted atomic.Bool
+
+func recordHeartbeatSuccess() {
+	lastHeartbeatSuccessUnix.Store(time.Now().Unix())
+}
+
+// LastHeartbeatSuccess returns the time of the last heartbeat the hub
+// accepted, and whether one has ever succeeded. A zero ok means either no
+// heartbeat has succeeded yet (e.g. still within startup grace, or the hub
+// has been down since boot) or this process never runs a heartbeat loop —
+// callers should check HeartbeatEnabled() to tell those apart.
+func LastHeartbeatSuccess() (t time.Time, ok bool) {
+	sec := lastHeartbeatSuccessUnix.Load()
+	if sec == 0 {
+		return time.Time{}, false
+	}
+	return time.Unix(sec, 0), true
+}
+
+// HeartbeatEnabled reports whether this process launched a hub heartbeat
+// loop (StartHeartbeat was called with a non-empty hubURL). Hives with no
+// hub configured never send heartbeats, so liveness checks must skip the
+// staleness gate entirely for them.
+func HeartbeatEnabled() bool {
+	return heartbeatLoopStarted.Load()
+}
 
 type AgentSummary struct {
 	Name  string `json:"name"`
@@ -142,6 +188,10 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 		logger.Info("hub heartbeat disabled (no HIVE_HUB_URL)")
 		return
 	}
+	// Mark the loop as active before the first send so /api/livez can tell
+	// "hub-connected, awaiting first beat" (healthy during startup grace)
+	// apart from "no hub configured" (never gated on heartbeat freshness).
+	heartbeatLoopStarted.Store(true)
 	var onUpgrade UpgradeCallback
 	var onGitHubAppConfig GitHubAppConfigCallback
 	var onHubBanner HubBannerCallback
@@ -302,6 +352,11 @@ func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, 
 		return nil
 	}
 
+	// The hub accepted the beat (status < 300) — this is what /api/livez
+	// treats as "the heartbeat goroutine is alive and doing its job", so
+	// record it even if the response body below fails to decode.
+	recordHeartbeatSuccess()
+
 	var hbResp HeartbeatResponse
 	if err := json.NewDecoder(resp.Body).Decode(&hbResp); err == nil {
 		if hbResp.HubGitHash != "" {
@@ -355,7 +410,13 @@ func SendUpgradingHeartbeat(hubURL string, collect StatusCollector, targetSHA st
 		logger.Debug("upgrading heartbeat failed", "error", err)
 		return
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
+	if resp.StatusCode < 300 {
+		// Counts as a successful beat for liveness purposes: the process is
+		// seconds from a self-initiated restart anyway, so this mainly keeps
+		// LastHeartbeatSuccess fresh in case the upgrade is aborted/delayed.
+		recordHeartbeatSuccess()
+	}
 	logger.Info("upgrading heartbeat sent to hub", "target", targetSHA)
 }
 

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1226,8 +1226,18 @@ spec:
           periodSeconds: 5
           failureThreshold: 30
         livenessProbe:
+          # /api/livez (not /api/health) so a heartbeat goroutine that dies
+          # silently while the HTTP server stays up still gets caught and the
+          # pod restarted. /api/health only proves the dashboard's HTTP
+          # server is responsive; it does not check heartbeat freshness, so
+          # a hive with a dead heartbeat goroutine but a live server would
+          # otherwise stay 1/1 Running forever while the hub shows it
+          # offline (gray dot) with nothing to recover it. See
+          # pkg/dashboard/server.go handleLivez for the staleness threshold
+          # and startup-grace handling; hives without a hub configured are
+          # exempt (guarded by hub.HeartbeatEnabled()).
           httpGet:
-            path: /api/health
+            path: /api/livez
             port: {{.DashboardPort}}
           periodSeconds: 30
           failureThreshold: 3


### PR DESCRIPTION
## Problem

The hub heartbeat runs as an in-process goroutine (`hub.StartHeartbeat`, launched from `cmd/hive/main.go:1488`). When that goroutine dies silently (panic recovered upstream, deadlock, stuck HTTP call) while the dashboard's HTTP server keeps serving fine, nothing catches it:

- The existing `livenessProbe` hits `GET /api/health`, which only checks that the dashboard's HTTP server is responsive — it has no idea whether heartbeats are still going out.
- The pod stays `1/1 Running` forever.
- The hub marks the hive offline (gray dot) because it stops receiving heartbeats, but has no mechanism to restart the spoke pod itself.

This has happened repeatedly in production (David's and kalantar's hives).

## Fix

1. **Track last successful heartbeat** (`v2/pkg/hub/heartbeat.go`): a package-level `atomic.Int64` (`lastHeartbeatSuccessUnix`) is updated whenever a heartbeat gets an HTTP response `< 300` from the hub — both in the normal `StartHeartbeat`/`sendHeartbeat` loop and in `SendUpgradingHeartbeat`. A separate `atomic.Bool` (`heartbeatLoopStarted`) records whether `StartHeartbeat` actually launched a loop for this process (i.e. `hubURL` was non-empty). Exposed via:
   - `hub.LastHeartbeatSuccess() (time.Time, bool)`
   - `hub.HeartbeatEnabled() bool`

   Atomics (not a mutex) so the HTTP handler reading this on every liveness probe never blocks on the heartbeat sender.

2. **New `/api/livez` endpoint** (`v2/pkg/dashboard/server.go`): does everything `/api/health` does (readiness check) PLUS, only when `hub.HeartbeatEnabled()` is true, fails with `503` if the last successful heartbeat is older than a threshold. Hives with no hub configured (`HeartbeatEnabled() == false`) are completely unaffected — never gated on heartbeat freshness.

   Named constants (no magic numbers):
   - `heartbeatSendInterval = 2 * time.Minute` — mirrors the actual interval `cmd/hive/main.go` launches `StartHeartbeat` with (see the comment there re: why it's fixed independent of ACMM level).
   - `livezHeartbeatStaleMax = 3 * heartbeatSendInterval` (6 min) — generous enough to absorb one or two transient hub-side hiccups (network blip, hub restart, rate limit) without flapping the pod, tight enough to catch a genuinely dead heartbeat well within a normal "why is this hive gray" investigation window.
   - `livezStartupGrace = 4 * time.Minute` — covers `waitForReady`'s own up-to-3-minute wait for the dashboard to come up, plus one heartbeat send/round-trip, so a freshly started pod isn't killed before its first heartbeat ever gets a chance to succeed.

3. **Only the liveness probe points at the new endpoint.** Updated in both places that define it:
   - `v2/pkg/hub/saas_provision.go` (the SaaS provisioning Deployment template)
   - `v2/deploy/k8s/deployment.yaml` (manual/example deployment manifest)

   `readinessProbe` is left on `/api/health` in both. Rationale: pulling a perfectly-serving pod out of the Service during a transient hub outage has no upside (a restart can't fix a hub that's down), whereas failing *liveness* on heartbeat staleness IS the correct remedy — restarting the pod revives the heartbeat goroutine. Splitting the endpoints avoids the tradeoff of a shared `/api/health` also flipping readiness on every heartbeat hiccup.

`v2/docs/manual-provisioning.md` was checked — it doesn't reference the probe paths, so no doc update was needed there.

## Before / after

- **Before**: heartbeat goroutine dies -> `/api/health` stays green (HTTP server unaffected) -> pod stays `1/1 Running` indefinitely -> hub shows the hive as offline (gray dot) with no automatic recovery path.
- **After**: heartbeat goroutine dies -> no successful heartbeat recorded -> once `time.Since(lastSuccess) > livezHeartbeatStaleMax` (6 min), `/api/livez` starts returning 503 -> kubelet's livenessProbe (`periodSeconds: 30`, `failureThreshold: 3`, i.e. ~90s after crossing the threshold) restarts the pod -> heartbeat goroutine restarts with the process -> hive reappears on the hub automatically.

## Testing

- `go build ./pkg/hub/... ./pkg/dashboard/... ./cmd/...` — clean.
- `go vet ./pkg/hub/... ./pkg/dashboard/...` — clean.
- `go test ./pkg/dashboard/... ./pkg/hub/...` — all existing tests pass (no new tests added in this PR; happy to add a table test for `handleLivez` covering: hub-disabled/never-gated, startup-grace, fresh success, and stale-success-503 if reviewers want it inline rather than as a fast-follow).

Not merging — opening for review per repo convention.