### PR TITLE
fix(config): preserve frozen payload in dashboard overlay

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -2368,7 +2368,7 @@ func (c *Config) savePersistenceBytes(data []byte) error {
 		log.Printf("[config] PVC backup written to %s (recovery copy, not primary config)", backupFile)
 	}
 
-	c.saveDashboardOverlay()
+	c.saveDashboardOverlay(data)
 	return nil
 }
 
@@ -2400,26 +2400,6 @@ func IsKubernetesPod() bool {
 	return err == nil
 }
 
-// dashboardOverlayBytes marshals a secret-free copy of the config for the PVC
-// overlay: env-substituted secrets are re-templated / cleared so the persisted
-// overlay never contains real credentials.
-func (c *Config) dashboardOverlayBytes() ([]byte, error) {
-	// Shallow copy: top-level fields are struct values, so mutating the
-	// copy's GitHub/Dashboard sections leaves the live config untouched
-	// (the shared Agents map is not modified).
-	cp := *c
-	if tok := os.Getenv("HIVE_GITHUB_TOKEN"); tok != "" && cp.GitHub.Token == tok {
-		cp.GitHub.Token = "${HIVE_GITHUB_TOKEN}"
-	}
-	for _, env := range []string{"DASHBOARD_AUTH_TOKEN", "HIVE_DASHBOARD_TOKEN"} {
-		if v := os.Getenv(env); v != "" && cp.Dashboard.AuthToken == v {
-			cp.Dashboard.AuthToken = ""
-			break
-		}
-	}
-	return yaml.Marshal(&cp)
-}
-
 // saveDashboardOverlay writes the secret-free PVC overlay in Kubernetes
 // mode. Failures are logged, never fatal: the primary save already
 // succeeded, the overlay only affects persistence across pod restarts.
@@ -2438,16 +2418,11 @@ func (c *Config) dashboardOverlayBytes() ([]byte, error) {
 // would pass the guard and revert a dashboard-installed GitHub App to the
 // placeholder ConfigMap seed on the next restart — exactly the durability bug
 // this atomic write prevents.
-func (c *Config) saveDashboardOverlay() {
+func (c *Config) saveDashboardOverlay(data []byte) {
 	if !IsKubernetesPod() {
 		// Docker/LXC mode: /data/hive.yaml.bak is already the boot-time
 		// source of truth there, so dashboard saves persist without an
 		// overlay.
-		return
-	}
-	data, err := c.dashboardOverlayBytes()
-	if err != nil {
-		log.Printf("[config] warning: failed to marshal dashboard overlay: %v", err)
 		return
 	}
 	tmpPath := DashboardOverlayFile + ".tmp"

--- a/v2/pkg/config/config_save_test.go
+++ b/v2/pkg/config/config_save_test.go
@@ -596,6 +596,9 @@ func TestSaveWritesDashboardOverlayInK8sMode(t *testing.T) {
 	if !strings.Contains(content, "testorg") {
 		t.Error("overlay missing project org")
 	}
+	if _, err := os.Stat(DashboardOverlayFile + ".tmp"); !os.IsNotExist(err) {
+		t.Fatalf("temporary overlay should be removed after atomic rename (stat err: %v)", err)
+	}
 	// The live config is untouched by the scrub.
 	if cfg.GitHub.Token != "ghp_secrettoken12345" {
 		t.Errorf("Save mutated the live config token: %q", cfg.GitHub.Token)


### PR DESCRIPTION
## Summary

Fix the `dd` merge of transactional config persistence with the Kubernetes dashboard-overlay durability change.

The merge kept `persistencePayload()` for the primary config and backup, but re-marshaled the live `Config` separately for the dashboard overlay. That broke the established exact-byte contract and could persist expanded environment secrets instead of the load-proven templates.

This change:
- passes the already-frozen, provenance-restored payload to the atomic overlay writer;
- removes the duplicate serializer;
- keeps the temp-file + fsync + atomic rename durability behavior;
- verifies the temporary file is gone after a successful rename.

The Codex per-agent `CODEX_HOME` fix already merged in `de8f1ac5` is unchanged.

## Validation

- `go build ./...`
- `go vet ./pkg/config`
- Linux: `go test ./pkg/config -count=1`
- `git diff --check`

Before this patch, exact `dd@c13fce9c` failed `TestSaveRestoresAllEnvironmentTemplatesAndWritesExactBytes` and `TestSavePersistenceBytesWritesOneFrozenPayload`. Both pass with this patch.

Signed-off-by: DavidDiaz0317 <DAVIDDIAZ031706@GMAIL.COM>
