### PR TITLE
feat(hub): assign pre-provisioned placeholder hives via heartbeat delivery

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1767,6 +1767,49 @@ func main() {
 					"was", len(cfg.Dashboard.AuthorizedUsers), "now", len(users))
 				cfg.Dashboard.AuthorizedUsers = users
 			}
+		}), hub.ProjectConfigCallback(func(pc *hub.HeartbeatProjectConfig) {
+			// The hub assigned this (previously placeholder) hive a real project.
+			// Reconcile our running project config so agents work the claimed
+			// org/repos at the claimed maturity level. This is the ONLY delivery
+			// channel on heartbeat-only clusters (vllm-d) — no kubectl push is
+			// possible. The hub keeps sending this every beat until we report the
+			// matching project back, so an idempotent no-op when already matched
+			// is expected and cheap.
+			if pc == nil || pc.Org == "" {
+				return
+			}
+			curACMM := 0
+			if cfg.ACMMLevel != nil {
+				curACMM = *cfg.ACMMLevel
+			}
+			if cfg.Project.Org == pc.Org &&
+				sameStringSlice(cfg.Project.Repos, pc.Repos) &&
+				cfg.Project.PrimaryRepo == pc.PrimaryRepo &&
+				curACMM == pc.ACMMLevel {
+				return // already reconciled
+			}
+			logger.Info("project config updated from hub heartbeat (placeholder claimed)",
+				"was_org", cfg.Project.Org, "now_org", pc.Org,
+				"repos", pc.Repos, "primary_repo", pc.PrimaryRepo,
+				"acmm_level", pc.ACMMLevel)
+			cfg.Project.Org = pc.Org
+			cfg.Project.Repos = pc.Repos
+			cfg.Project.PrimaryRepo = pc.PrimaryRepo
+			level := pc.ACMMLevel
+			cfg.ACMMLevel = &level
+
+			// Re-sync the GitHub clients that cache the repo list (mirrors the
+			// config-watcher reload path).
+			ghClient.SetRepos(cfg.Project.Repos)
+			if uc := userGHClient.Load(); uc != nil {
+				uc.SetRepos(cfg.Project.Repos)
+			}
+
+			// Persist to the PVC overlay so the claim survives a pod restart
+			// (config save writes the overlay hive.yaml, same as level switches).
+			if err := cfg.Save(); err != nil {
+				logger.Error("failed to save claimed project config", "error", err)
+			}
 		}))
 
 		go hub.StartTaskStatusPush(ctx, hubURL, func() *hub.TaskStatusPayload {

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -198,6 +198,7 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 	var onVisibility VisibilityCallback
 	var onSwitchBranch SwitchBranchCallback
 	var onAuthorizedUsers AuthorizedUsersCallback
+	var onProjectConfig ProjectConfigCallback
 	for _, cb := range callbacks {
 		switch fn := cb.(type) {
 		case UpgradeCallback:
@@ -212,6 +213,8 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 			onSwitchBranch = fn
 		case AuthorizedUsersCallback:
 			onAuthorizedUsers = fn
+		case ProjectConfigCallback:
+			onProjectConfig = fn
 		}
 	}
 
@@ -243,6 +246,11 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 		// spoke's allowlist; nil means the hub sent nothing, leave it alone.
 		if resp.AuthorizedUsers != nil && onAuthorizedUsers != nil {
 			onAuthorizedUsers(resp.AuthorizedUsers)
+		}
+		// A non-nil ProjectConfig means the hub wants the spoke to adopt a newly
+		// claimed project (placeholder assignment); nil means leave it alone.
+		if resp.ProjectConfig != nil && onProjectConfig != nil {
+			onProjectConfig(resp.ProjectConfig)
 		}
 	}
 
@@ -429,6 +437,22 @@ type HeartbeatGitHubAppConfig struct {
 	PrivateKey     string `json:"private_key,omitempty"`
 }
 
+// HeartbeatProjectConfig carries a claimed project's real org/repos/ACMM from
+// the hub to a spoke via the heartbeat response. It mirrors the AuthorizedUsers
+// mechanism: when an admin assigns a pre-provisioned "placeholder" hive to a
+// requesting user, the hub cannot push the new project config to a
+// heartbeat-only spoke (e.g. vllm-d) over kubectl. Delivering it in the
+// heartbeat response lets the spoke reconcile its running config
+// (cfg.Project.Org/Repos/PrimaryRepo and ACMM level) every beat until it
+// matches what the hub recorded — the only channel that works uniformly for
+// both reachable (hive-oke) and heartbeat-only (vllm-d) clusters.
+type HeartbeatProjectConfig struct {
+	Org         string   `json:"org"`
+	Repos       []string `json:"repos"`
+	PrimaryRepo string   `json:"primary_repo,omitempty"`
+	ACMMLevel   int      `json:"acmm_level"`
+}
+
 // HeartbeatResponse is the JSON body returned by the hub's heartbeat endpoint.
 // It includes version info so the spoke can display hub version on its dashboard
 // and self-upgrade when behind.
@@ -455,6 +479,14 @@ type HeartbeatResponse struct {
 	// changes propagate automatically. nil means "hub sent nothing" (leave the
 	// spoke's list unchanged); a non-nil (possibly empty) slice replaces it.
 	AuthorizedUsers []string `json:"authorized_users,omitempty"`
+	// ProjectConfig is the claimed project's real org/repos/ACMM. The hub sets
+	// it (mirroring AuthorizedUsers) when a placeholder hive has been assigned
+	// to a user and the spoke is still reporting its old (placeholder) project.
+	// The hub keeps sending it every beat until the spoke reconciles and reports
+	// the matching project. nil means "no reconcile needed" — leave the spoke's
+	// project config alone. This is the ONLY delivery channel for heartbeat-only
+	// clusters (vllm-d) the hub cannot reach over kubectl.
+	ProjectConfig *HeartbeatProjectConfig `json:"project_config,omitempty"`
 }
 
 // HubBanner is a message from the hub admin displayed on spoke dashboards.
@@ -485,6 +517,12 @@ type AuthorizedUsersCallback func(users []string)
 // GitHubAppConfigCallback is called when the hub delivers GitHub App config
 // via the heartbeat response (app ID, installation ID, private key).
 type GitHubAppConfigCallback func(cfg *HeartbeatGitHubAppConfig)
+
+// ProjectConfigCallback is called when the hub delivers a claimed project's
+// real org/repos/ACMM via the heartbeat response so the spoke can reconcile
+// its running project config. Used for heartbeat-only clusters where the hub
+// cannot push config over kubectl (mirrors AuthorizedUsersCallback).
+type ProjectConfigCallback func(cfg *HeartbeatProjectConfig)
 
 const taskPushInterval = 30 * time.Second
 

--- a/v2/pkg/hub/hub_filesystem_test.go
+++ b/v2/pkg/hub/hub_filesystem_test.go
@@ -1009,6 +1009,18 @@ func TestHandleApproveProvisionWithFilesystem(t *testing.T) {
 		Status:   provisionStatusPending,
 	})
 
+	// Approving now ASSIGNS an available placeholder from the correct pool. Seed
+	// an available placeholder owned by the admin on the public (hive-oke) pool.
+	if err := saveSaaSHive(&SaaSHive{
+		ID:        "hosted-placeholder-fs",
+		Owner:     hubAdminUsername,
+		Status:    statusAvailable,
+		ACMMLevel: defaultAssignACMMLevel,
+		ClusterID: defaultClusterID,
+	}); err != nil {
+		t.Fatalf("seed placeholder: %v", err)
+	}
+
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	mux := http.NewServeMux()
 	mux.HandleFunc("PUT /api/saas/approve-provision/{username}", srv.handleApproveProvision)
@@ -1026,6 +1038,112 @@ func TestHandleApproveProvisionWithFilesystem(t *testing.T) {
 	u := loadSaaSUser("prov-target")
 	if u.SaaSQuota != 1 {
 		t.Errorf("quota = %d, want 1", u.SaaSQuota)
+	}
+
+	// Verify the placeholder was assigned to the requesting user with the
+	// request's project, and its "available" status was cleared.
+	h := loadSaaSHive("hosted-placeholder-fs")
+	if h == nil {
+		t.Fatal("placeholder hive missing after assignment")
+	}
+	if h.Owner != "prov-target" {
+		t.Errorf("owner = %q, want prov-target", h.Owner)
+	}
+	if h.Org != "org" {
+		t.Errorf("org = %q, want org", h.Org)
+	}
+	if h.Status != "" {
+		t.Errorf("status = %q, want empty (cleared)", h.Status)
+	}
+}
+
+func TestHandleApproveProvisionNoPlaceholderWithFilesystem(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	authCleanup := helperSetupAuthUser(t, "ghp_appprov_none_fs", hubAdminUsername)
+	defer authCleanup()
+
+	ensureSaaSUser("prov-target-none")
+	saveProvisionRequest(&ProvisionRequest{
+		Username: "prov-target-none",
+		Org:      "org",
+		Repos:    "repo",
+		Status:   provisionStatusPending,
+	})
+
+	// No available placeholder seeded -> the admin must be told to provision more.
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /api/saas/approve-provision/{username}", srv.handleApproveProvision)
+
+	req := httptest.NewRequest("PUT", "/api/saas/approve-provision/prov-target-none", nil)
+	req.Header.Set("Authorization", "Bearer ghp_appprov_none_fs")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409 (no placeholder), got %d (body: %s)", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleAssignHiveWithFilesystem(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	authCleanup := helperSetupAuthUser(t, "ghp_assign_fs", hubAdminUsername)
+	defer authCleanup()
+
+	if err := saveSaaSHive(&SaaSHive{
+		ID:        "hosted-assign-fs",
+		Owner:     hubAdminUsername,
+		Status:    statusAvailable,
+		ACMMLevel: defaultAssignACMMLevel,
+		ClusterID: gpuClusterID,
+	}); err != nil {
+		t.Fatalf("seed placeholder: %v", err)
+	}
+
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/saas/hives/{id}/assign", srv.handleAssignHive)
+
+	bodyJSON := `{"owner":"newowner","org":"neworg","repos":"repoa,repob","primary_repo":"repoa","acmm_level":3}`
+	req := httptest.NewRequest("POST", "/api/saas/hives/hosted-assign-fs/assign", strings.NewReader(bodyJSON))
+	req.Header.Set("Authorization", "Bearer ghp_assign_fs")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	h := loadSaaSHive("hosted-assign-fs")
+	if h == nil {
+		t.Fatal("hive missing after assign")
+	}
+	if h.Owner != "newowner" || h.Org != "neworg" || h.PrimaryRepo != "repoa" || h.ACMMLevel != 3 || h.Status != "" {
+		t.Errorf("assign wrote wrong meta: %+v", h)
+	}
+
+	// projectConfigForHiveID keeps returning the real project until the spoke
+	// reports it back, then goes quiet.
+	if pc := projectConfigForHiveID("hosted-assign-fs", "oldorg", []string{"old"}, "old", 2); pc == nil {
+		t.Error("expected non-nil project config while spoke reports stale project")
+	}
+	if pc := projectConfigForHiveID("hosted-assign-fs", "neworg", []string{"repoa", "repob"}, "repoa", 3); pc != nil {
+		t.Errorf("expected nil project config once spoke matches, got %+v", pc)
+	}
+
+	// Assigning an already-claimed (non-available) hive is rejected.
+	req2 := httptest.NewRequest("POST", "/api/saas/hives/hosted-assign-fs/assign", strings.NewReader(bodyJSON))
+	req2.Header.Set("Authorization", "Bearer ghp_assign_fs")
+	req2.Header.Set("Content-Type", "application/json")
+	w2 := httptest.NewRecorder()
+	mux.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusConflict {
+		t.Errorf("expected 409 assigning a non-placeholder, got %d", w2.Code)
 	}
 }
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -138,6 +138,7 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("GET /api/saas/admin/users", s.requireAdmin(s.handleAdminUsers))
 	s.mux.HandleFunc("PUT /api/saas/admin/users/{username}", s.requireAdmin(s.handleAdminUpdateUser))
 	s.mux.HandleFunc("DELETE /api/saas/admin/users/{username}", s.requireAdmin(s.handleAdminDeleteUser))
+	s.mux.HandleFunc("POST /api/saas/hives/{id}/assign", s.requireAuth(s.handleAssignHive))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/migrate", s.requireAuth(s.handleMigrateHive))
 	s.mux.HandleFunc("GET /api/saas/cluster-health", s.requireAdmin(s.handleClusterHealth))
 	s.mux.HandleFunc("GET /api/hub/clusters", s.requireAuth(s.handleListClusters))
@@ -3743,27 +3744,83 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Increment user quota so they can have a hive provisioned
+	// Approving now ASSIGNS an available placeholder instead of just bumping
+	// quota for a manual provision. Pick the pool from the request's auth_method
+	// (private → vllm-d/GPU pool, otherwise → hive-oke/public pool). If no
+	// placeholder is available in that pool, tell the admin to provision more.
+	pool := poolClusterForAuthMethod(pr.AuthMethod)
+	hiveID := findAvailablePlaceholder(pool)
+	if hiveID == "" {
+		http.Error(w, fmt.Sprintf(`{"error":"no available placeholder hive in pool %q — provision more placeholders"}`, pool), http.StatusConflict)
+		return
+	}
+
+	h := loadSaaSHive(hiveID)
+	if h == nil || h.Status != statusAvailable {
+		// Raced with another assignment between selection and load.
+		http.Error(w, `{"error":"selected placeholder became unavailable — retry"}`, http.StatusConflict)
+		return
+	}
+
+	// Reuse the request's org/repos/primary_repo/acmm as the assignment inputs.
+	var repos []string
+	for _, repo := range strings.Split(pr.Repos, ",") {
+		if repo = strings.TrimSpace(repo); repo != "" {
+			repos = append(repos, repo)
+		}
+	}
+	primaryRepo := pr.PrimaryRepo
+	if primaryRepo == "" && len(repos) > 0 {
+		primaryRepo = repos[0]
+	}
+	acmm := pr.ACMMLevel
+	if acmm == 0 {
+		acmm = defaultAssignACMMLevel
+	}
+	if acmm < minAssignACMMLevel || acmm > maxAssignACMMLevel {
+		acmm = defaultAssignACMMLevel
+	}
+
+	// Rewrite the placeholder's meta.json to the requesting user's real project.
+	// Clearing status makes it show under the new owner in My Hives; the project
+	// config reaches the spoke via the heartbeat channel (projectConfigForHiveID).
+	h.Owner = targetUsername
+	h.Org = pr.Org
+	h.Repos = repos
+	h.PrimaryRepo = primaryRepo
+	h.ACMMLevel = acmm
+	h.Status = ""
+	h.Error = ""
+	if err := saveSaaSHive(h); err != nil {
+		http.Error(w, `{"error":"failed to assign placeholder hive"}`, http.StatusInternalServerError)
+		return
+	}
+
+	// Ensure the user record exists and count this owned hive against a quota.
 	user := loadSaaSUser(targetUsername)
 	if user == nil {
 		user = ensureSaaSUser(targetUsername)
 	}
 	user.SaaSQuota++
 	if err := saveSaaSUser(user); err != nil {
-		http.Error(w, `{"error":"failed to update user quota"}`, http.StatusInternalServerError)
-		return
+		s.logger.Warn("assigned placeholder but failed to update user quota", "user", targetUsername, "error", err)
 	}
 
-	// Mark the request as approved — admin provisions separately via "+ Add Hosted Hive"
+	// Mark the request fulfilled.
 	pr.Status = provisionStatusApproved
 	if err := saveProvisionRequest(pr); err != nil {
-		http.Error(w, `{"error":"failed to update provision request"}`, http.StatusInternalServerError)
-		return
+		s.logger.Warn("assigned placeholder but failed to update provision request", "user", targetUsername, "error", err)
 	}
 
-	s.logger.Info("audit: provision request approved", "target", targetUsername, "by", approver, "org", pr.Org, "repos", pr.Repos)
+	s.logger.Info("audit: provision request approved via placeholder assignment",
+		"target", targetUsername, "by", approver, "org", pr.Org, "repos", pr.Repos,
+		"hive_id", hiveID, "cluster", clusterIDForHive(h))
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"ok": true, "status": provisionStatusApproved})
+	json.NewEncoder(w).Encode(map[string]any{
+		"ok":      true,
+		"status":  provisionStatusApproved,
+		"hive_id": hiveID,
+	})
 }
 
 func (s *HubServer) handleDenyProvision(w http.ResponseWriter, r *http.Request) {
@@ -3781,6 +3838,270 @@ func (s *HubServer) handleDenyProvision(w http.ResponseWriter, r *http.Request) 
 	s.logger.Info("audit: provision request denied", "target", targetUsername, "by", denier)
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"ok": true})
+}
+
+// authMethodPrivate is the request auth_method value that routes a provision
+// request to the private/GPU placeholder pool (vllm-d). Any other value (the
+// default) routes to the public pool (hive-oke).
+const authMethodPrivate = "private"
+
+// poolClusterForAuthMethod maps a provision request's auth_method to the
+// placeholder pool it should draw from: private methods → the GPU pool
+// (vllm-d, heartbeat-only); everything else → the public pool (hive-oke).
+func poolClusterForAuthMethod(authMethod string) string {
+	if strings.EqualFold(authMethod, authMethodPrivate) || strings.EqualFold(authMethod, gpuClusterID) {
+		return gpuClusterID
+	}
+	return defaultClusterID
+}
+
+// clusterIDForHive returns the effective cluster ID of a SaaS hive, treating an
+// empty cluster_id as the default (hive-oke) — matching clusterForHive's own
+// fallback so pool matching agrees with cluster resolution.
+func clusterIDForHive(h *SaaSHive) string {
+	if h.ClusterID == "" {
+		return defaultClusterID
+	}
+	return h.ClusterID
+}
+
+// findAvailablePlaceholder returns the ID of an available placeholder hive in
+// the given pool (cluster), or "" if none exists. A placeholder is a SaaS hive
+// owned by the hub admin, sitting at statusAvailable, on the target cluster.
+func findAvailablePlaceholder(clusterID string) string {
+	for _, h := range listSaaSHives() {
+		if h.Status != statusAvailable {
+			continue
+		}
+		if h.Owner != hubAdminUsername {
+			continue
+		}
+		if clusterIDForHive(&h) != clusterID {
+			continue
+		}
+		return h.ID
+	}
+	return ""
+}
+
+// projectConfigForHiveID returns the claimed project's real org/repos/ACMM for
+// delivery to the spoke in its heartbeat response, or nil when no reconcile is
+// needed. It mirrors authorizedUsersForHiveID: nil when the hive has no SaaS
+// record, is still an unclaimed placeholder (statusAvailable), or the spoke
+// already reports the recorded project. The spoke's currently-reported values
+// (curOrg/curRepos/curPrimary/curACMM) let the hub stop sending once matched.
+func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary string, curACMM int) *HeartbeatProjectConfig {
+	h := loadSaaSHive(hiveID)
+	if h == nil {
+		return nil
+	}
+	// An unclaimed placeholder has nothing real to reconcile yet.
+	if h.Status == statusAvailable {
+		return nil
+	}
+	// A record with no org recorded (never assigned a real project) is left
+	// alone — reconciling to an empty project would break the spoke.
+	if h.Org == "" {
+		return nil
+	}
+	primary := h.PrimaryRepo
+	if primary == "" && len(h.Repos) > 0 {
+		primary = h.Repos[0]
+	}
+	// Already matching — stop sending (mirrors the AuthorizedUsers "leave alone"
+	// semantics once the spoke has caught up).
+	if strings.EqualFold(curOrg, h.Org) &&
+		sameStringSliceFold(curRepos, h.Repos) &&
+		strings.EqualFold(curPrimary, primary) &&
+		curACMM == h.ACMMLevel {
+		return nil
+	}
+	return &HeartbeatProjectConfig{
+		Org:         h.Org,
+		Repos:       h.Repos,
+		PrimaryRepo: primary,
+		ACMMLevel:   h.ACMMLevel,
+	}
+}
+
+// sameStringSliceFold reports whether two string slices contain the same
+// entries in the same order, case-insensitively (org/repo names are compared
+// case-insensitively throughout the hub).
+func sameStringSliceFold(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !strings.EqualFold(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// AssignHiveRequest is the body of POST /api/saas/hives/{id}/assign. It carries
+// the real project the placeholder is being claimed for, plus optional GitHub
+// App credentials to deliver to the spoke via the heartbeat channel.
+type AssignHiveRequest struct {
+	Owner         string `json:"owner"`
+	Org           string `json:"org"`
+	Repos         string `json:"repos"`
+	PrimaryRepo   string `json:"primary_repo"`
+	ProjectName   string `json:"project_name"`
+	ACMMLevel     int    `json:"acmm_level"`
+	IsPublic      bool   `json:"is_public"`
+	AppID         string `json:"app_id"`
+	InstallationID string `json:"installation_id"`
+	AppPrivateKey string `json:"app_private_key"`
+}
+
+// handleAssignHive assigns an available placeholder hive to a real owner/project
+// (admin-only). It rewrites the hive's meta.json to the real project and clears
+// its "available" status, then delivers the new project config — and any GitHub
+// App creds — to the spoke via the heartbeat response. This works uniformly for
+// both reachable (hive-oke) and heartbeat-only (vllm-d) clusters: NO hub→spoke
+// push or kubectl is used, so a vllm-d claim is delivered entirely by heartbeat.
+func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
+	if s.getAuthUser(r) != hubAdminUsername {
+		http.Error(w, `{"error":"admin access required"}`, http.StatusForbidden)
+		return
+	}
+	hiveID := r.PathValue("id")
+
+	// A GitHub App private key PEM can be a few KB, so allow more headroom than
+	// the provision-request body limit.
+	const maxAssignRequestBodyBytes = 16 * 1024
+	r.Body = http.MaxBytesReader(w, r.Body, maxAssignRequestBodyBytes)
+	var body AssignHiveRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, `{"error":"invalid JSON"}`, http.StatusBadRequest)
+		return
+	}
+
+	h := loadSaaSHive(hiveID)
+	if h == nil {
+		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
+		return
+	}
+	if h.Status != statusAvailable {
+		http.Error(w, `{"error":"hive is not an available placeholder"}`, http.StatusConflict)
+		return
+	}
+
+	// Validate the claimed project inputs (reuse the shared validators).
+	if body.Owner == "" || !isValidName(body.Owner) {
+		http.Error(w, `{"error":"invalid owner"}`, http.StatusBadRequest)
+		return
+	}
+	if body.Org == "" || !isValidName(body.Org) {
+		http.Error(w, `{"error":"invalid org name"}`, http.StatusBadRequest)
+		return
+	}
+	if body.Repos == "" {
+		http.Error(w, `{"error":"repos are required"}`, http.StatusBadRequest)
+		return
+	}
+	var repos []string
+	for _, repo := range strings.Split(body.Repos, ",") {
+		repo = strings.TrimSpace(repo)
+		if repo == "" {
+			continue
+		}
+		if !isValidRepoRef(repo) {
+			http.Error(w, `{"error":"invalid repo name"}`, http.StatusBadRequest)
+			return
+		}
+		repos = append(repos, repo)
+	}
+	if len(repos) == 0 {
+		http.Error(w, `{"error":"repos are required"}`, http.StatusBadRequest)
+		return
+	}
+	primaryRepo := strings.TrimSpace(body.PrimaryRepo)
+	if primaryRepo == "" {
+		primaryRepo = repos[0]
+	} else if !isValidRepoRef(primaryRepo) {
+		http.Error(w, `{"error":"invalid primary repo"}`, http.StatusBadRequest)
+		return
+	}
+
+	acmm := body.ACMMLevel
+	if acmm == 0 {
+		acmm = defaultAssignACMMLevel
+	}
+	if acmm < minAssignACMMLevel || acmm > maxAssignACMMLevel {
+		http.Error(w, `{"error":"acmm_level must be between 0 and 6"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Rewrite the placeholder's meta.json to the real project. Clearing status
+	// (and any stale error) alone makes it show under the new owner in My Hives.
+	h.Owner = body.Owner
+	h.Org = body.Org
+	h.Repos = repos
+	h.PrimaryRepo = primaryRepo
+	if body.ProjectName != "" {
+		h.ProjectName = body.ProjectName
+	}
+	h.ACMMLevel = acmm
+	h.IsPublic = body.IsPublic
+	h.Status = ""
+	h.Error = ""
+	if err := saveSaaSHive(h); err != nil {
+		http.Error(w, `{"error":"failed to save hive assignment"}`, http.StatusInternalServerError)
+		return
+	}
+
+	// Deliver GitHub App creds (if supplied) via the SAME heartbeat channel the
+	// webhook path uses — storePendingGitHubAppConfig queues them for the next
+	// heartbeat response (consumePendingGitHubAppConfig in handleHeartbeat). We
+	// deliberately do NOT call pushGitHubConfigToSpoke here: it requires a
+	// reachable dashboardURL and would fail for vllm-d. The heartbeat path
+	// covers both clusters uniformly.
+	appDelivered := false
+	if body.AppID != "" && body.InstallationID != "" && strings.TrimSpace(body.AppPrivateKey) != "" {
+		appID, err1 := strconv.ParseInt(strings.TrimSpace(body.AppID), 10, 64)
+		installID, err2 := strconv.ParseInt(strings.TrimSpace(body.InstallationID), 10, 64)
+		if err1 != nil || err2 != nil {
+			http.Error(w, `{"error":"app_id and installation_id must be numeric"}`, http.StatusBadRequest)
+			return
+		}
+		if !strings.HasPrefix(strings.TrimSpace(body.AppPrivateKey), "-----BEGIN") {
+			http.Error(w, `{"error":"app_private_key must be a PEM private key"}`, http.StatusBadRequest)
+			return
+		}
+		s.storePendingGitHubAppConfig(hiveID, &HeartbeatGitHubAppConfig{
+			AppID:          appID,
+			InstallationID: installID,
+			PrivateKey:     strings.TrimSpace(body.AppPrivateKey),
+		})
+		appDelivered = true
+	}
+
+	// The project config itself is delivered by handleHeartbeat via
+	// projectConfigForHiveID on the next beat — it keeps sending until the spoke
+	// reports the matching project. No hub→spoke push or kubectl is needed, so
+	// this works for the heartbeat-only vllm-d pool as well as hive-oke.
+
+	s.logger.Info("audit: placeholder hive assigned",
+		"hive_id", hiveID,
+		"owner", h.Owner,
+		"org", h.Org,
+		"primary_repo", h.PrimaryRepo,
+		"acmm_level", h.ACMMLevel,
+		"cluster", clusterIDForHive(h),
+		"app_creds_delivered", appDelivered,
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"status":       "assigned",
+		"id":           hiveID,
+		"owner":        h.Owner,
+		"org":          h.Org,
+		"primary_repo": h.PrimaryRepo,
+		"acmm_level":   h.ACMMLevel,
+	})
 }
 
 func (s *HubServer) handleUserToken(w http.ResponseWriter, r *http.Request) {
@@ -5256,12 +5577,15 @@ const dashboardHTML = `<!DOCTYPE html>
 
     async function approveProvision(username, btn) {
       btn.disabled = true;
-      btn.textContent = 'Approving...';
+      btn.textContent = 'Assigning...';
       try {
+        // Approving assigns an available placeholder hive from the correct pool
+        // (public request -> hive-oke, private -> vllm-d) and marks the request
+        // fulfilled. The assigned hive id comes back in the response.
         var resp = await fetch('/api/saas/approve-provision/' + encodeURIComponent(username), {method: 'PUT'});
         var data = await resp.json();
-        if (!resp.ok) { hiveToast(data.error || 'Approve failed', 'error'); btn.disabled = false; btn.textContent = 'Approve'; return; }
-        hiveToast('Provision approved for ' + username, 'success');
+        if (!resp.ok) { hiveToast(data.error || 'Assign failed', 'error'); btn.disabled = false; btn.textContent = 'Approve'; return; }
+        hiveToast('Assigned ' + (data.hive_id || 'a hive') + ' to ' + username, 'success');
         loadHives();
       } catch(e) { hiveToast('Error: ' + e.message, 'error'); btn.disabled = false; btn.textContent = 'Approve'; }
     }

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -77,6 +77,29 @@ const (
 // multi-cluster support.
 const defaultClusterID = "hive-oke"
 
+// gpuClusterID is the cluster ID of the GPU pool. It is heartbeat-only: the
+// hub cannot reach it over kubectl, so all config for its hives (access lists,
+// GitHub App creds, claimed project config) is delivered via the heartbeat
+// response rather than pushed.
+const gpuClusterID = "vllm-d"
+
+// Placeholder-hive lifecycle status values. A pre-provisioned placeholder sits
+// at statusAvailable until an admin assigns it to a requesting user, at which
+// point its status is cleared (empty) and it behaves like any owned hive.
+const (
+	// statusAvailable marks a pre-provisioned placeholder hive that is idle and
+	// waiting to be claimed. Only such a hive may be assigned.
+	statusAvailable = "available"
+)
+
+// ACMM level bounds for a claimed/assigned hive. The maturity model spans
+// levels 0-6; a placeholder assignment defaults to level 2 when unspecified.
+const (
+	minAssignACMMLevel     = 0
+	maxAssignACMMLevel     = 6
+	defaultAssignACMMLevel = 2
+)
+
 // clustersConfigPath is the on-disk location where the hub reads cluster
 // definitions. It is a JSON array of ClusterConfig objects.
 const clustersConfigPath = "/data/saas/clusters.json"

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -613,6 +613,23 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		resp.AuthorizedUsers = authUsers
 	}
 
+	// Deliver the claimed project's real org/repos/ACMM so a spoke that was
+	// assigned a pre-provisioned placeholder reconciles its running project
+	// config. Mirrors AuthorizedUsers: the hub keeps sending it every beat
+	// until the spoke reports the matching project. This is the ONLY channel
+	// that reaches heartbeat-only clusters (vllm-d) — the hub cannot push
+	// config there over kubectl. A nil return means "spoke already matches, or
+	// no SaaS record / still a placeholder" — send nothing.
+	if projCfg := projectConfigForHiveID(payload.HiveID, payload.Org, payload.Repos, payload.PrimaryRepo, payload.ACMMLevel); projCfg != nil {
+		resp.ProjectConfig = projCfg
+		s.logger.Info("heartbeat: delivering claimed project config to spoke",
+			"hive_id", payload.HiveID,
+			"org", projCfg.Org,
+			"primary_repo", projCfg.PrimaryRepo,
+			"acmm_level", projCfg.ACMMLevel,
+		)
+	}
+
 	// Check if the hive should self-upgrade via heartbeat response.
 	//
 	// Three upgrade paths, all controlled by a single toggle:


### PR DESCRIPTION
## Summary

Adds the **placeholder hive claim/assign** feature. The operator pre-provisions idle "placeholder" hives (`status: "available"`, `owner: <admin>`) in two pools — **hive-oke** (public, hub-reachable) and **vllm-d** (private/GPU, **heartbeat-only**). This lets a request for access be fulfilled in seconds by assigning an existing hive instead of provisioning fresh.

## What changed

### 1. Approve → assign a placeholder (repurposed)
`handleApproveProvision` (`PUT /api/saas/approve-provision/{username}`) no longer just bumps quota for a manual provision. It now:
- Picks the pool from the request's `auth_method` — **private → vllm-d**, otherwise **→ hive-oke** (`poolClusterForAuthMethod`).
- Auto-selects an available placeholder in that pool (`findAvailablePlaceholder`).
- Rewrites its `meta.json` to the request's org/repos/primary_repo/acmm and clears `status`.
- Returns the assigned `hive_id`; the admin UI toast reports it.
- Returns a clear **409** ("provision more placeholders") when the pool is empty.

### 2. New assign endpoint
`POST /api/saas/hives/{id}/assign` → `handleAssignHive` (admin-only; hive must be `available`). Validates owner/org/repos via `isValidName`/`isValidRepoRef`, clamps ACMM to 0–6 (default 2), rewrites `meta.json` via `saveSaaSHive`, and accepts optional GitHub App creds.

### 3. Config delivery via heartbeat (the key part)
vllm-d is heartbeat-only — the hub **cannot push config or kubectl-scale it**. Mirroring the existing `AuthorizedUsers` mechanism:
- New `ProjectConfig *HeartbeatProjectConfig` field on `HeartbeatResponse` (org/repos/primary_repo/acmm_level) + `ProjectConfigCallback`.
- The hub sets `resp.ProjectConfig` in `handleHeartbeat` (`projectConfigForHiveID`) **every beat until the spoke reports the matching project**, then goes quiet — exactly like AuthorizedUsers.
- The spoke reconciles `cfg.Project.Org/Repos/PrimaryRepo` and the ACMM level, re-syncs its GitHub clients (`SetRepos`), and **saves to the PVC overlay** so the claim survives restarts.
- **GitHub App creds** ride the existing `GitHubAppConfig` heartbeat path via `storePendingGitHubAppConfig` — **not** `pushGitHubConfigToSpoke` (which needs a reachable dashboardURL and would fail for vllm-d).

**No hub→spoke push or kubectl is used anywhere in the claim path, so vllm-d assignment is delivered entirely by the heartbeat response** — the critical design constraint.

## Constants / style
Named constants for `statusAvailable`, `gpuClusterID`, ACMM min/max/default (0/6/2), and pool→cluster mapping. Reuses `loadSaaSHive`, `saveSaaSHive`, `isValidName`, `isValidRepoRef`, `clusterForHive`, `hubAdminUsername`, and the existing GitHubAppConfig heartbeat path.

## Tests
- Updated `TestHandleApproveProvisionWithFilesystem` for the assign behavior; added `TestHandleApproveProvisionNoPlaceholderWithFilesystem` (409 path) and `TestHandleAssignHiveWithFilesystem` (assign + reconcile quiet-once-matched + already-claimed 409).
- `go build ./...`, `go vet ./pkg/hub/... ./cmd/...`, and `go test ./pkg/hub/...` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)