### PR TITLE
🚑 fix(dashboard): make /api/livez public so the liveness probe actually works

### DIFF
--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -604,6 +604,12 @@ func isPublicPath(path string) bool {
 	switch {
 	case strings.HasPrefix(path, "/api/health"):
 		return true
+	case path == "/api/livez":
+		// The kubelet liveness probe hits this UNAUTHENTICATED — it must be
+		// public like /api/health, or every probe 401s, the probe never fails
+		// on a stale heartbeat (it fails on auth instead), and a dead-heartbeat
+		// pod is never restarted (the exact bug this endpoint was added to fix).
+		return true
 	case path == "/api/auth/token":
 		return true
 	case path == "/snapshot" || strings.HasPrefix(path, "/snapshot/"):


### PR DESCRIPTION
The heartbeat-liveness endpoint added in #1955 (`/api/livez`) was **not** in `isPublicPath`'s auth-bypass whitelist, unlike `/api/health`. So on a hive with `DASHBOARD_AUTH_TOKEN` set, the kubelet's unauthenticated liveness probe gets **401 on every check** — the probe fails on *auth*, never on heartbeat staleness, and if actually pointed at `/api/livez` it would **restart-loop the pod forever**.

**Net effect:** the auto-restart-on-dead-heartbeat mechanism #1955 was built for **never fired** — dead-heartbeat pods (David's, kalantar's) kept showing `1/1 Running` while offline, exactly the bug #1955 meant to eliminate.

**Fix:** add `/api/livez` to `isPublicPath` so the probe reaches the real heartbeat-staleness check unauthenticated, like `/api/health`.

⚠️ **Follow-up:** existing deployments still have `livenessProbe.path=/api/health` (the #1955 template change only affects new provisions). Their probes must be migrated to `/api/livez` separately for auto-restart to engage — I'll handle that operationally.