### PR TITLE
✨ feat(dashboard): add Codex (OpenAI) models to the model dropdown

### DIFF
--- a/v2/pkg/dashboard/cli_models.go
+++ b/v2/pkg/dashboard/cli_models.go
@@ -151,6 +151,21 @@ var copilotAlwaysIncludeModels = []string{
 	"mai-code-1-flash-picker",
 }
 
+// codexStaticModels is the maintained list for the OpenAI Codex CLI. Codex only
+// accepts OpenAI models — Claude ids are rejected with a ChatGPT account
+// ("model is not supported when using Codex with a ChatGPT account"), so codex
+// must never fall through to the copilot list. Order mirrors `codex /model`
+// (sol is the default). Keep CURRENT with the Codex CLI's model set.
+var codexStaticModels = []string{
+	"gpt-5.6-sol",
+	"gpt-5.6-terra",
+	"gpt-5.6-luna",
+	"gpt-5.5",
+	"gpt-5.4",
+	"gpt-5.4-mini",
+	"gpt-5.3-codex-spark",
+}
+
 // geminiStaticModels is the fallback when no Gemini API key is configured (or
 // discovery fails). Keep CURRENT.
 var geminiStaticModels = []string{
@@ -287,6 +302,10 @@ func (s *Server) queryCLIModels(backend string) cliModelResult {
 	case "claude":
 		// No live source exists; the maintained static list is authoritative.
 		r = cliModelResult{models: dedupeModels(claudeStaticModels), fallback: false}
+	case "codex":
+		// No probe wired yet; the maintained static list is authoritative and
+		// OpenAI-only (Claude ids are rejected by Codex with a ChatGPT account).
+		r = cliModelResult{models: dedupeModels(codexStaticModels), fallback: false}
 	default:
 		r = cliModelResult{models: nil, fallback: true}
 	}
@@ -321,6 +340,8 @@ func cliStaticFallback(backend string) []string {
 		return geminiStaticModels
 	case "claude":
 		return claudeStaticModels
+	case "codex":
+		return codexStaticModels
 	case "goose":
 		return []string{"default"}
 	default:

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4677,8 +4677,21 @@
       { value: 'gpt-5.4', label: 'GPT-5.4' },
       { value: 'gpt-5.2', label: 'GPT-5.2' },
     ];
+    // Codex (OpenAI CLI) exposes its own OpenAI-only models. Claude models are
+    // rejected by Codex with a ChatGPT account ("model is not supported when
+    // using Codex with a ChatGPT account"), so codex must NOT fall through to
+    // the copilot list. Order mirrors `codex /model` (sol is the default).
+    const CODEX_CLI_MODELS = [
+      { value: 'gpt-5.6-sol', label: 'GPT-5.6 Sol' },
+      { value: 'gpt-5.6-terra', label: 'GPT-5.6 Terra' },
+      { value: 'gpt-5.6-luna', label: 'GPT-5.6 Luna' },
+      { value: 'gpt-5.5', label: 'GPT-5.5' },
+      { value: 'gpt-5.4', label: 'GPT-5.4' },
+      { value: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
+      { value: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' },
+    ];
     const KNOWN_MODELS = COPILOT_CLI_MODELS;
-    const CLI_BACKENDS = ['claude', 'copilot', 'gemini', 'goose'];
+    const CLI_BACKENDS = ['claude', 'copilot', 'gemini', 'goose', 'codex'];
     // BACKEND_MODELS holds the live-discovered model list for every backend
     // (inference AND cli), keyed by backend id. INFERENCE_MODELS is kept as
     // an alias to the same object for backward compatibility with existing
@@ -4694,6 +4707,7 @@
       copilot: COPILOT_CLI_MODELS,
       gemini: COPILOT_CLI_MODELS,
       goose: COPILOT_CLI_MODELS,
+      codex: CODEX_CLI_MODELS,
     };
     function backendLabel(b) {
       if (INFERENCE_BACKENDS.includes(b)) return b + ' ⚡';


### PR DESCRIPTION
The **codex** backend had no model list, so the dropdown fell through to the **copilot** list (Claude models). Selecting `claude-opus-4.7` for a codex agent fails:

> The 'claude-opus-4.7' model is not supported when using Codex with a ChatGPT account.

(David's codex agent was stuck on an unusable model.)

**Fix:** add codex's OpenAI-only model set (from `codex /model`) in both places that feed the dropdown:
- `static/index.html`: `CODEX_CLI_MODELS` + `codex` in `CLI_BACKENDS` / `CLI_FALLBACK_MODELS`
- `cli_models.go`: `codexStaticModels` + `codex` cases in the discovery switch and `cliStaticFallback`

Models: `gpt-5.6-sol` (default), `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex-spark`. `go build`/`vet`/`test` pass.