### PR TITLE
🐛 fix(dashboard): self-heal stale "GitHub App not installed" banner

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1069,39 +1069,58 @@ func main() {
 		}
 	}
 
-	// Retry advisory issue creation until it succeeds. This handles two cases:
+	// Self-heal the "GitHub App not installed" banner. This handles:
 	// 1. GitHub App credentials arrived after startup (via heartbeat/webhook)
 	// 2. ReinitGitHubFunc succeeded but cleared githubAppRequired before
 	//    EnsureAdvisoryIssue could run against the new client
+	// 3. A TRANSIENT startup/runtime 4xx (rate-limit blip, brief token-refresh
+	//    window, momentary permission propagation delay) latched the banner even
+	//    though the app is really installed and can write. Previously the retry
+	//    loop exited permanently after the first advisory-issue READ succeeded,
+	//    so a later transient write failure that re-set the flag was never
+	//    re-evaluated — the banner stuck until the pod was restarted.
+	//
+	// The loop therefore runs for the lifetime of the process (it does NOT
+	// return after the first success) and, whenever the banner is currently
+	// showing, re-runs the SAME read+write verification as the manual "Re-check"
+	// button (githubAppRecheckFn, which calls diagnoseGitHubAppWrite) and clears
+	// the flag on success. When the banner is not showing there is nothing to do,
+	// so the tick is a cheap no-op that makes no GitHub API calls.
 	{
 		primaryRepo := cfg.Project.PrimaryRepo
 		if primaryRepo == "" && len(cfg.Project.Repos) > 0 {
 			primaryRepo = cfg.Project.Repos[0]
 		}
 		if primaryRepo != "" {
-			const advisoryRetryInterval = 2 * time.Minute
+			// githubAppSelfHealInterval mirrors the heartbeat cadence so a stale
+			// banner clears within one heartbeat window of the app becoming
+			// healthy, without adding meaningful GitHub API load (the check only
+			// runs while the banner is actually showing).
+			const githubAppSelfHealInterval = 2 * time.Minute
 			go func() {
-				ticker := time.NewTicker(advisoryRetryInterval)
+				ticker := time.NewTicker(githubAppSelfHealInterval)
 				defer ticker.Stop()
 				for {
 					select {
 					case <-ctx.Done():
 						return
 					case <-ticker.C:
-						if _, exists := advisoryIssues[primaryRepo]; exists {
-							return
-						}
-						num, err := ghClient.EnsureAdvisoryIssue(ctx, primaryRepo)
-						if err != nil {
-							logger.Debug("advisory issue retry: not yet accessible", "repo", primaryRepo, "error", err)
+						// Nothing to heal unless the banner is showing.
+						if !dashSrv.IsGitHubAppRequired() {
 							continue
 						}
-						advisoryIssues[primaryRepo] = num
-						os.Setenv("HIVE_ADVISORY_ISSUE", fmt.Sprintf("%d", num))
-						dashSrv.SetGitHubAppRequired(false)
-						dashSrv.ClearPendingGitHubAppInstall()
-						logger.Info("advisory issue retry: created successfully", "repo", primaryRepo, "number", num)
-						return
+						// Re-run the same read+write verification the manual
+						// Re-check button uses. It clears the flag on success
+						// (installed AND write-verified) and leaves it set on a
+						// genuine failure (not installed / insufficient perms).
+						if dashSrv.RecheckGitHubApp() {
+							if num, exists := advisoryIssues[primaryRepo]; exists {
+								os.Setenv("HIVE_ADVISORY_ISSUE", fmt.Sprintf("%d", num))
+							}
+							logger.Info("github app self-heal: banner cleared, app installed and write verified", "repo", primaryRepo)
+						} else {
+							logger.Debug("github app self-heal: still not verified, banner remains", "repo", primaryRepo)
+						}
 					}
 				}
 			}()

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -928,17 +928,35 @@ func (s *Server) SetGitHubAppRecheckFn(fn func() bool) {
 	s.githubAppRecheckFn = fn
 }
 
+// RecheckGitHubApp runs the configured GitHub App verification (read + write,
+// the same check the manual "Re-check" button performs) and, on success, clears
+// the "App not installed" banner and its related pending/permission state.
+// Returns true when the app is installed and write-verified. It is safe to call
+// from a background loop as well as the HTTP handler; returns false (a no-op) if
+// no recheck function has been wired up. This is the single place the banner is
+// cleared on a successful recheck, so the periodic self-heal loop and the manual
+// button stay in lockstep.
+func (s *Server) RecheckGitHubApp() bool {
+	if s.githubAppRecheckFn == nil {
+		return false
+	}
+	ok := s.githubAppRecheckFn()
+	if ok {
+		s.SetGitHubAppRequired(false)
+		s.SetGitHubAppPermIssue("")
+		s.ClearPendingGitHubAppInstall()
+	}
+	return ok
+}
+
 func (s *Server) handleGitHubAppRecheck(w http.ResponseWriter, r *http.Request) {
 	if s.githubAppRecheckFn == nil {
 		http.Error(w, "recheck not configured", http.StatusNotImplemented)
 		return
 	}
-	ok := s.githubAppRecheckFn()
+	ok := s.RecheckGitHubApp()
 	w.Header().Set("Content-Type", "application/json")
 	if ok {
-		s.SetGitHubAppRequired(false)
-		s.SetGitHubAppPermIssue("")
-		s.ClearPendingGitHubAppInstall()
 		w.Write([]byte(`{"status":"installed"}`))
 	} else {
 		s.githubAppMu.RLock()


### PR DESCRIPTION
## Problem

Multiple hives (kellyaa, kalantar-msb) showed a persistent **"GitHub App Not Installed"** banner even though the App was installed, the installation_id was correct in the PVC config, and a freshly-minted installation token could read AND write the target repo. Clicking **Re-check** cleared it, but it **reappeared on the next page refresh**.

### Root cause

`githubAppRequired` is set at pod startup (`main.go`) if the first advisory-issue API call hits a 4xx, and on later runtime write failures (the digest-post path). It was only ever re-cleared by:
- the manual **Re-check** button (in-memory, per-click), or
- a one-shot retry loop that **exited permanently** after the first advisory-issue *read* succeeded.

So a **transient** startup/runtime 4xx — a rate-limit blip, a brief token-refresh window, or momentary permission-propagation delay — latched the banner, and nothing ever re-evaluated it. The banner stuck until the pod was restarted. "Re-check" only fixed server memory that the next request re-derived as still-required, hence the reappear-on-refresh symptom.

Observed in the field: kellyaa hit a transient `401 Bad credentials` on the digest POST at startup (auth healthy seconds later); kalantar hit a transient `403` updating a digest comment. Both latched the banner despite healthy auth.

## Fix

Replace the one-shot retry with a **lifetime self-heal ticker**:
- Runs for the process lifetime (does **not** return after first success).
- On each tick, if the banner is **not** showing → cheap no-op, **no GitHub API calls**.
- If the banner **is** showing → re-runs the **same read+write verification** as the manual Re-check (`githubAppRecheckFn` → `diagnoseGitHubAppWrite`) and clears the flag only on success (installed **and** write-verified).
- Cadence mirrors the heartbeat interval (2 min), so a stale banner clears within one heartbeat window of the app becoming healthy.

Extracted the clear-on-success logic into `Server.RecheckGitHubApp()` so the periodic loop and the HTTP handler share one code path and can't drift.

## Testing

- `go build ./...` passes.
- Manually confirmed (kellyaa, kalantar): fresh pod starts clean (`advisory issue ready`, no 4xx), digest posts successfully, banner gone. This change makes that recovery automatic instead of requiring a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)