### PR TITLE
🐛 fix(hub): show correct ACMM level + Assign menu for heartbeating placeholders

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1281,8 +1281,41 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 	var result []MyHiveEntry
 
 	autoUpgradeMap := make(map[string]bool)
+	saasByID := make(map[string]*SaaSHive)
 	for _, sh := range listSaaSHives() {
+		shCopy := sh
 		autoUpgradeMap[sh.ID] = sh.AutoUpgrade
+		saasByID[sh.ID] = &shCopy
+	}
+
+	// enrichFromSaaSMeta overlays the authoritative SaaS meta.json fields
+	// (ProvStatus, ACMMLevel, provisioning/error/migration state) onto an entry
+	// built from a live registry hive. Registry entries come from spoke
+	// heartbeats and carry the spoke's live-reported ACMM level and NO
+	// provStatus — so a hosted placeholder that is actively heartbeating (e.g. a
+	// firewalled vllm-d spoke) would otherwise render at its live level (L0)
+	// with an empty provStatus, hiding the "Assign" menu and showing the wrong
+	// level. Placeholders that are scaled to zero never heartbeat, so they fall
+	// through to the SaaS-meta loop below and already render correctly; this
+	// closes that asymmetry for heartbeating spokes. meta.json is authoritative
+	// for status/level per the SaaS provisioning model.
+	enrichFromSaaSMeta := func(entry *MyHiveEntry) {
+		sh := saasByID[entry.ID]
+		if sh == nil {
+			return
+		}
+		entry.ProvStatus = sh.Status
+		entry.ACMMLevel = sh.ACMMLevel
+		switch sh.Status {
+		case "provisioning":
+			entry.GovernorMode = "PROVISIONING"
+		case "error":
+			entry.GovernorMode = "ERROR"
+			entry.ProvError = sh.Error
+		}
+		entry.MigrationStatus = sh.MigrationStatus
+		entry.MigrationFrom = sh.MigrationFrom
+		entry.MigrationTo = sh.MigrationTo
 	}
 
 	isAdmin := username == hubAdminUsername
@@ -1291,16 +1324,22 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 			if isAdmin && role != "owner" {
 				role = "owner"
 			}
-			result = append(result, MyHiveEntry{RegistryEntry: h, Role: role, AutoUpgrade: autoUpgradeMap[h.ID]})
+			entry := MyHiveEntry{RegistryEntry: h, Role: role, AutoUpgrade: autoUpgradeMap[h.ID]}
+			enrichFromSaaSMeta(&entry)
+			result = append(result, entry)
 			continue
 		}
 		if strings.EqualFold(h.Owner, username) {
-			result = append(result, MyHiveEntry{RegistryEntry: h, Role: "owner", AutoUpgrade: autoUpgradeMap[h.ID]})
+			entry := MyHiveEntry{RegistryEntry: h, Role: "owner", AutoUpgrade: autoUpgradeMap[h.ID]}
+			enrichFromSaaSMeta(&entry)
+			result = append(result, entry)
 			user.Hives[h.ID] = "owner"
 			continue
 		}
 		if isAdmin {
-			result = append(result, MyHiveEntry{RegistryEntry: h, Role: "owner", AutoUpgrade: autoUpgradeMap[h.ID]})
+			entry := MyHiveEntry{RegistryEntry: h, Role: "owner", AutoUpgrade: autoUpgradeMap[h.ID]}
+			enrichFromSaaSMeta(&entry)
+			result = append(result, entry)
 		}
 	}
 


### PR DESCRIPTION
## Problem

Two symptoms on **vllm-d** hosted placeholders in **My Hives**, both absent on **hive-oke** placeholders:
1. The **"Assign / Claim"** menu item (added in #1964) did **not** appear.
2. The rows showed **L0 + perpetual "Upgrading"** instead of the intended **L2 Instructed** (meta.json says `acmm_level: 2`).

### Root cause

`handleMyHives` builds entries from the **live registry** (`s.registry.Hives`, populated by spoke heartbeats) *first*, then marks them `seen` so the later SaaS-meta loop skips them. Registry entries carry the spoke's **live-reported ACMM level** and **no `provStatus`**.

- **vllm-d placeholders** are firewalled spokes the hub can't kubectl to, so they report via **heartbeat** and ARE in the registry → their row got `provStatus=""` and `acmmLevel=0`. The Assign item is gated on `provStatus === 'available'`, so it never rendered, and the level showed L0/Upgrading.
- **hive-oke placeholders** are scaled to zero, never heartbeat, so they're NOT in the registry → they fell through to the SaaS-meta loop that correctly sets `provStatus=available` + `acmm=2`.

That asymmetry is exactly why Assign appeared on hive-oke placeholders but not vllm-d ones.

## Fix

Add `enrichFromSaaSMeta()` and call it for every registry-sourced entry. It overlays the authoritative `meta.json` fields — `ProvStatus`, `ACMMLevel`, and provisioning/error/migration state — onto the entry. `meta.json` is authoritative for status/level per the SaaS provisioning model, so a heartbeating placeholder now renders **"L2 Instructed"** and shows its **Assign** menu, identical to a scaled-down placeholder.

## Testing

- `go build ./...` passes.
- Verified against live meta.json: both oke and vllm-d placeholders have `status: available`, `acmm_level: 2`; only the vllm-d ones were being clobbered by registry data. This change makes both render from meta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)