### PR TITLE
🐛 fix(hive): prefer App auth for advisory digest so user-token failures don't false-flag the App

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2299,12 +2299,26 @@ func runEvalCycle(
 			md := advisory.FormatDigestMarkdown(digest, org, repoName)
 			if md != "" {
 				if issueNum, ok := advisoryIssues[primaryRepo]; ok && issueNum > 0 {
-					postClient := ghClient
-					if uc := userGHClient.Load(); uc != nil {
-						postClient = uc
-					}
-					if err := postClient.PostAdvisoryDigest(ctx, primaryRepo, issueNum, md); err != nil {
-						logger.Warn("failed to post advisory digest", "repo", primaryRepo, "issue", issueNum, "error", err)
+					// Prefer the App client as the PRIMARY poster. The App
+					// authored the advisory-digest comment and always holds
+					// issues:write, so it is the correct identity to edit it.
+					// The App banner must be driven ONLY by the App's own
+					// error — never by a user-token failure. Otherwise a
+					// user-token problem (kellyaa: expired token → 401;
+					// kalantar: valid token but not repo-admin → 403 editing
+					// the bot's own comment) would false-flag the App as "Not
+					// Installed" even though the App itself works fine.
+					if err := ghClient.PostAdvisoryDigest(ctx, primaryRepo, issueNum, md); err != nil {
+						// App failed. Try the user client as a FALLBACK ONLY so
+						// the digest still gets posted. A user-fallback success
+						// does NOT clear the App banner — the App error below is
+						// what decides the banner state.
+						if uc := userGHClient.Load(); uc != nil {
+							if uerr := uc.PostAdvisoryDigest(ctx, primaryRepo, issueNum, md); uerr == nil {
+								logger.Info("posted advisory digest", "repo", primaryRepo, "issue", issueNum, "findings", digest.TotalCount, "via", "user-fallback")
+							}
+						}
+						logger.Warn("failed to post advisory digest via app", "repo", primaryRepo, "issue", issueNum, "error", err)
 						if strings.Contains(err.Error(), "403") && strings.Contains(err.Error(), "Resource not accessible by integration") {
 							// App is installed (we found the issue) but can't write.
 							// Resolve the actual cause — pending permission approval
@@ -2323,7 +2337,7 @@ func runEvalCycle(
 							dashSrv.SetGitHubAppRequired(true)
 						}
 					} else {
-						logger.Info("posted advisory digest", "repo", primaryRepo, "issue", issueNum, "findings", digest.TotalCount)
+						logger.Info("posted advisory digest", "repo", primaryRepo, "issue", issueNum, "findings", digest.TotalCount, "via", "app")
 						// A successful write proves the app is installed AND has
 						// write access — clear BOTH the perm issue and the
 						// app-required banner flag. Previously only the perm


### PR DESCRIPTION
## Problem

The advisory-digest poster preferred the **user token** when one was loaded, and drove the **"GitHub App Not Installed"** banner off whatever client happened to post. A user-token failure could therefore false-flag a perfectly healthy App:

- **kellyaa** — the user token had **expired**, so the post failed with `401`. The App was installed and working, but the 401 tripped `SetGitHubAppRequired(true)` and raised the banner.
- **kalantar** — the user token was valid but the user was **not a repo admin**, so editing the bot's *own* comment returned `403`. Again the App was fine, but the 403 raised the banner.

## Fix

The GitHub App **authored** the advisory-digest comment and **always holds `issues:write`**, so it is the correct primary identity to edit it. This PR flips the order:

1. The **App client posts first**.
2. On App success, the banner state is cleared exactly as before (`SetGitHubAppPermIssue("")`, `SetGitHubAppRequired(false)`, `ClearPendingGitHubAppInstall()`), now logged with `via=app`.
3. On App failure, the **user client is tried as a strict fallback** only so the digest still gets posted (`via=user-fallback`). Crucially, a user-fallback success does **not** clear the App banner, and a user-token failure never raises it.
4. The three App-error banner branches (`Resource not accessible by integration` 403 → `diagnoseGitHubAppWrite` + perm issue, `rate limit`, generic `403||401`) are kept verbatim but now keyed off the **App's own error**.

### Key invariant

`SetGitHubAppRequired` / `SetGitHubAppPermIssue` are driven **only** by the App's own error — never by the user client's. The user client is strictly a fallback poster.

Only `v2/cmd/hive/main.go` is touched. `go build ./...` and `go vet ./cmd/hive/` both pass clean.