### PR TITLE
🐛 fix(setup): keep Visual Hive integration deterministic

### DIFF
--- a/v2/pkg/integrated/inspect.go
+++ b/v2/pkg/integrated/inspect.go
@@ -305,7 +305,7 @@ func packageScriptCommands(packagePath, runner string, scripts map[string]string
 
 func safeAutomationScript(name, body string) bool {
 	name, body = strings.ToLower(strings.TrimSpace(name)), strings.ToLower(strings.TrimSpace(body))
-	if name == "" || name == "vh:plan" || name == "vh:run" {
+	if name == "" || name == "vh:plan" || name == "vh:run" || name == "vh:build-source" {
 		return false
 	}
 	// Every selected script runs as an isolated, non-interactive job. Exclude

--- a/v2/pkg/integrated/inspect_test.go
+++ b/v2/pkg/integrated/inspect_test.go
@@ -279,7 +279,7 @@ func TestInspectCheckoutDetectsPlaywrightAndVisualHiveReviewedBaselines(t *testi
 
 func TestInspectCheckoutKeepsOnlyBoundedNonInteractiveAutomation(t *testing.T) {
 	root := t.TempDir()
-	writeFixture(t, root, "package.json", `{"scripts":{"vh:test-creation":"node test-creation.js","vh:suite":"node suite.js","vh:mutation-proof":"node proof.js","vh:mutate":"node mutate.js","vh:run":"node run.js","vh:plan":"node plan.js","typecheck":"tsc --noEmit","build":"vite build"}}`)
+	writeFixture(t, root, "package.json", `{"scripts":{"vh:test-creation":"node test-creation.js","vh:suite":"node suite.js","vh:mutation-proof":"node proof.js","vh:mutate":"node mutate.js","vh:run":"node run.js","vh:plan":"node plan.js","vh:build-source":"node build-visual-hive-source.mjs","typecheck":"tsc --noEmit","build":"vite build"}}`)
 	writeFixture(t, root, "package-lock.json", `{}`)
 
 	inspection, err := InspectCheckout(root, "main")

--- a/v2/pkg/integrated/setup.go
+++ b/v2/pkg/integrated/setup.go
@@ -2048,6 +2048,10 @@ func mergeVisualHiveRecommendation(checkout, expectedProfile string) error {
 			delete(current, key)
 		}
 	}
+	// Coverage-owned recommendations may replace the visual section wholesale.
+	// Reapply the integration-owned invariants after that replacement so a
+	// merged setup remains byte-for-byte idempotent on the next setup run.
+	enableVisualHiveIntegration(current)
 	if recommendedCost, exists := report.RecommendedConfig["costPolicy"]; exists {
 		current["costPolicy"] = recommendedCost
 	}

--- a/v2/pkg/integrated/setup.go
+++ b/v2/pkg/integrated/setup.go
@@ -2096,6 +2096,12 @@ func enableVisualHiveIntegration(config map[string]any) {
 	integrations := ensureStringMap(config, "integrations")
 	hive := ensureStringMap(integrations, "hive")
 	hive["enabled"] = true
+	// Hive's accountable baseline lifecycle accepts only this canonical,
+	// repository-local namespace. Preserve the repository's visual policy,
+	// but route every integrated baseline candidate through the path that the
+	// hosted verifier, approval plan, and merge authority bind exactly.
+	visual := ensureStringMap(config, "visual")
+	visual["snapshotDir"] = ".visual-hive/snapshots"
 }
 
 func anyStringMap(value any) map[string]any {

--- a/v2/pkg/integrated/setup_visual_migration_test.go
+++ b/v2/pkg/integrated/setup_visual_migration_test.go
@@ -33,6 +33,9 @@ integrations:
     enabled: false
     mode: guarded_repair
     defaultActor: repository-quality
+visual:
+  snapshotDir: visual-hive.baselines
+  maxDiffPixelRatio: 0.01
 `
 	writeFixture(t, root, "visual-hive.config.yaml", original)
 	if err := mergeVisualHiveRecommendation(root, "complex-app"); err != nil {
@@ -48,10 +51,12 @@ integrations:
 	}
 	project := anyStringMap(value["project"])
 	hive := anyStringMap(anyStringMap(value["integrations"])["hive"])
+	visual := anyStringMap(value["visual"])
 	if project["name"] != "proof" || project["setupProfile"] != "complex-app" || len(anyStringMap(value["targets"])) != 1 ||
 		fmt.Sprint(anyStringMap(anySlice(value["contracts"])[0])["id"]) != "domain-contract" ||
 		!reflect.DeepEqual(anySlice(anyStringMap(value["mutation"])["operators"]), []any{"api-500"}) ||
-		hive["enabled"] != true || hive["mode"] != "guarded_repair" || hive["defaultActor"] != "repository-quality" {
+		hive["enabled"] != true || hive["mode"] != "guarded_repair" || hive["defaultActor"] != "repository-quality" ||
+		visual["snapshotDir"] != ".visual-hive/snapshots" || visual["maxDiffPixelRatio"] != 0.01 {
 		t.Fatalf("same-profile integration enablement replaced repository-owned configuration: %+v", value)
 	}
 	if err := mergeVisualHiveRecommendation(root, "complex-app"); err != nil {


### PR DESCRIPTION
## Problem

The end-to-end Visual Hive setup rehearsal exposed two repository-integration ambiguities and one idempotency edge case on `dd`:

1. A target repository's `vh:build-source` helper could be selected as an ordinary repository test even though it bootstraps the Visual Hive producer itself.
2. An existing Visual Hive plan could retain a noncanonical snapshot directory even though Hive's accountable baseline lifecycle binds `.visual-hive/snapshots`.
3. For generated plans, coverage recommendation reconciliation could replace the canonical `visual` section on the next setup run. That made an otherwise identical rerun appear substantive and correctly tripped the existing cross-user setup-authorizer guard.

## Fix

- Exclude only `vh:build-source` from bounded target-repository test selection. Existing `vh:test-creation`, suite, and mutation-proof commands remain eligible.
- Preserve repository-owned visual policy while binding integrated baseline candidates to `.visual-hive/snapshots`.
- Reapply integration-owned invariants after coverage-owned recommendation replacement so a merged setup is byte-for-byte idempotent.
- Extend the focused inspection/config regression coverage. The existing installed-bundle acceptance test now also proves the generated-plan rerun remains a cross-user no-op.

## Safety and compatibility

- Ordinary Hive behavior is unchanged when a repository has no installed Visual Hive contract.
- No dashboard, CLI, MCP, authentication, Governor, Scheduler, agent, or repair-policy interface changes.
- The setup-authorizer check remains fail-closed; this fixes the false substantive diff instead of weakening identity enforcement.
- No Visual Hive source, Console source, workflow, deployment, or persistent state is changed by this PR.

## Validation

Base: `kubestellar/hive:dd@9feb88e0bafe54110797665d3d2728e05fad41a4`

Visual Hive producer used by the rehearsal: `DavidDiaz0317/visual-hive@9fb0eebf4ec4c3f6653092c1fd53795d4d80523e`

Local gates:

- `go test ./pkg/integrated -run '^TestInstalledVisualHiveBundleSetupApplyAndMergedRerunIsIdempotent$' -count=1 -timeout=10m` — pass
- focused selector/config tests — pass
- `go test ./pkg/integrated -count=1 -timeout=12m` — pass (`478.748s`)
- `go vet ./pkg/integrated` — pass
- `go build ./...` — pass
- `git diff --check` — pass

The first two commits also completed the full isolated demo lifecycle: setup, hosted baseline, accountable PNG approval, `production_ready=true`, one unseeded scan, and duplicate-free restart/replay. Relevant runs: [setup](https://github.com/DavidDiaz0317/visual-hive-demo-site/actions/runs/30070773506), [baseline/current-head verification](https://github.com/DavidDiaz0317/visual-hive-demo-site/actions/runs/30071425988), and [restart replay](https://github.com/DavidDiaz0317/visual-hive-demo-site/actions/runs/30071901197). The final commit is limited to the generated-plan no-op ordering fix and is covered by the acceptance test above.