### PR TITLE
🐛 fix(hub): don't downgrade running hives to L0 from stale meta ACMM

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1288,24 +1288,32 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		saasByID[sh.ID] = &shCopy
 	}
 
-	// enrichFromSaaSMeta overlays the authoritative SaaS meta.json fields
-	// (ProvStatus, ACMMLevel, provisioning/error/migration state) onto an entry
-	// built from a live registry hive. Registry entries come from spoke
-	// heartbeats and carry the spoke's live-reported ACMM level and NO
-	// provStatus — so a hosted placeholder that is actively heartbeating (e.g. a
-	// firewalled vllm-d spoke) would otherwise render at its live level (L0)
-	// with an empty provStatus, hiding the "Assign" menu and showing the wrong
-	// level. Placeholders that are scaled to zero never heartbeat, so they fall
-	// through to the SaaS-meta loop below and already render correctly; this
-	// closes that asymmetry for heartbeating spokes. meta.json is authoritative
-	// for status/level per the SaaS provisioning model.
+	// enrichFromSaaSMeta overlays SaaS meta.json fields onto an entry built from
+	// a live registry hive (registry entries come from spoke heartbeats and carry
+	// NO provStatus, so provStatus/migration/error must come from meta).
+	//
+	// ACMM level is the subtle case, and getting it wrong caused a regression:
+	//   - For a CLAIMED / running hive, the spoke's LIVE heartbeat level is
+	//     authoritative — it's what the hive is actually running. Many pre-claim
+	//     meta.json records still carry a stale acmm_level: 0 even though the
+	//     spoke runs at a real level, so unconditionally taking the meta level
+	//     downgraded live hives to L0 on the dashboard.
+	//   - For an unclaimed PLACEHOLDER (status: available), there is no
+	//     meaningful live level (the slot reports L0), so the INTENDED level from
+	//     meta ("L2 Instructed") is what should show, and it also gates the
+	//     "Assign" menu (provStatus === 'available').
+	// Rule: take the meta level only for placeholders, or as a fallback when the
+	// live registry level is 0 (unknown) but meta has a real one. Otherwise the
+	// live registry level wins.
 	enrichFromSaaSMeta := func(entry *MyHiveEntry) {
 		sh := saasByID[entry.ID]
 		if sh == nil {
 			return
 		}
 		entry.ProvStatus = sh.Status
-		entry.ACMMLevel = sh.ACMMLevel
+		if sh.Status == statusAvailable || (entry.ACMMLevel == 0 && sh.ACMMLevel > 0) {
+			entry.ACMMLevel = sh.ACMMLevel
+		}
 		switch sh.Status {
 		case "provisioning":
 			entry.GovernorMode = "PROVISIONING"


### PR DESCRIPTION
## Problem (regression from #1966)

Since #1966, active claimed hives (kalantar, daviddiaz, torch-spyre, llm-d, llm-d-incubation) render **L0** on My Hives even though they run at **L2/L3**. Placeholders render correctly.

### Root cause

#1966's `enrichFromSaaSMeta` overlays SaaS meta.json onto registry-sourced entries and **unconditionally** set `entry.ACMMLevel = sh.ACMMLevel`. That was needed so heartbeating **placeholders** (meta `acmm_level: 2`) show "L2 Instructed" and expose the Assign menu.

But many **pre-claim** meta.json records still carry a stale `acmm_level: 0` even though the spoke actually runs at a real level. Unconditionally taking the meta level therefore **downgraded live hives to L0**. Confirmed against the live heartbeat registry (`acmmLevel`): kalantar=2, daviddiaz=2, torch-spyre=2, llm-d=2, llm-d-incubation=2 — all reported correctly by the spoke, all shown as L0 because meta said 0.

## Fix

The **live heartbeat level is authoritative for a running hive**; the **meta level is authoritative only for an unclaimed placeholder** (which reports L0 live but should show its intended level, and whose `provStatus: available` gates the Assign menu).

`enrichFromSaaSMeta` now takes the meta ACMM level only when `status == available`, or as a fallback when the live level is `0` (unknown) but meta has a real one. Otherwise the live registry level wins. `provStatus`/migration/error still always come from meta.

## Testing

- `go build ./...` passes.
- Verified against `/data/hub-registry.json`: the affected hives report correct live levels (2/3) that this change now preserves, while placeholders (live 0, meta 2) still show their intended "L2 Instructed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)