### PR TITLE
🚑 fix(ci): bump prune-ghcr to v3.1.0 — stop deleting multi-arch children

### DIFF
--- a/.github/workflows/prune-ghcr.yml
+++ b/.github/workflows/prune-ghcr.yml
@@ -25,7 +25,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Prune untagged hive images
-        uses: snok/container-retention-policy@v3.0.0
+        # v3.1.0+ AUTOMATICALLY protects per-architecture child manifests that
+        # are referenced by a tagged multi-arch manifest list (fail-closed: if
+        # it can't read a tag's manifest it skips deletion entirely). v3.0.0 did
+        # NOT — with tag-selection: untagged it deleted the arm64/amd64 children
+        # of live tagged images (only the manifest LIST is tagged; its per-arch
+        # children are untagged), which left every -latest / SHA tag dangling and
+        # made fresh multi-arch pulls fail with "manifest unknown" (404) on the
+        # child. Cached images kept running, which masked it, but any new node /
+        # fresh pull broke daily right after this 04:17 UTC prune. Do NOT pin
+        # back below v3.1.0.
+        uses: snok/container-retention-policy@v3.1.0
         with:
           account: kubestellar
           token: ${{ secrets.GHCR_PRUNE_TOKEN }}
@@ -34,7 +44,8 @@ jobs:
           cut-off: 3h              # untagged digests are unreachable by name; only
                                   # spare the last few hours so an in-flight build's
                                   # per-arch children aren't deleted before their
-                                  # manifest list is created.
+                                  # manifest list is created. (Belt-and-suspenders
+                                  # on top of the v3.1.0 multi-arch protection.)
           dry-run: ${{ github.event_name == 'schedule' && 'false' || inputs.dry_run }}
 
   # Prune <branch>-latest tags whose branch no longer exists. The docker


### PR DESCRIPTION
## The recurring root cause ("started yesterday and keeps happening")

The daily GHCR prune workflow has been **deleting the per-architecture child manifests of live tagged hive images**, breaking every fresh multi-arch pull.

### Mechanism
- Multi-arch images = a tagged **manifest list** + several **untagged** per-arch child manifests (arm64, amd64).
- `snok/container-retention-policy@v3.0.0` with `tag-selection: untagged` deletes untagged digests past the cut-off — **including the live arch-children**. v3.0.0 has **no** protection for children referenced by a tagged list.
- With `cut-off: 3h` and a daily 04:17 UTC schedule, any image built >3h before the prune loses its children → the tagged manifest list dangles → **fresh pulls 404 with `manifest unknown`** on the child.
- Already-cached images keep running (masking it); **new nodes / fresh pulls break** — recurring every day.

### Proof
- hive-oke is all **arm64**. Placeholder pods stuck `Init:ImagePullBackOff`; the kubelet was reading arm64 child `sha256:43e0aa12…` for `v2-latest`/`6e66211`, which returns **HTTP 404** even authenticated, while the manifest **list** returns 200.
- The arm64 child is 404 for **every** tag checked (`6e66211`, `64ff4a1`, `ed08b15`, `c9d9c06`) — not just recent ones.
- Timeline: `6e66211` built 02:03–02:08 UTC 2026-07-24; prune ran 05:23 UTC (~3h later, matching `cut-off: 3h`) and deleted the children.

## Fix

Bump to `snok/container-retention-policy@v3.1.0`, which **automatically protects child manifests referenced by tagged manifest lists** (added in 3.1.0, fail-closed — skips deletion if it can't read a tag's manifest). Config unchanged otherwise.

## Follow-up (operational, not in this PR)

The children the old prune already deleted must be **republished by rebuilding** the affected images. I've triggered fresh `docker.yml` builds for v2/mk/dd to restore them; any other tag needed on a fresh arm64 pull must be rebuilt too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)