### PR TITLE
✨ feat(agent): route agents through named model gateways (follow-up to #1979)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1343,8 +1343,40 @@ func main() {
 			inferenceEndpoints["litellm"] = parseEndpointList(litellmEndpoint)
 		}
 		dashSrv.SetInferenceEndpoints(inferenceEndpoints)
+		// Treat any configured gateway name as an inference-routable backend so
+		// an agent with backend: <gateway> routes through it. Resolution is live
+		// (reads cfg on each call) so gateways added from the Model Gateways tab
+		// take effect without a restart.
+		agentMgr.SetGatewayBackendChecker(func(backend string) bool {
+			return cfg.Governor.ResolveGateway(backend) != nil &&
+				!strings.EqualFold(backend, "") // empty is the default, not a named backend
+		})
 		agentMgr.SetInferenceCallbacks(
 			func(agentName, backend, model string) {
+				// Named model gateway (OpenRouter, a second LiteLLM, etc.): resolve
+				// endpoint/key/model from the gateway and route through it. Built-in
+				// backend names (litellm/vllm/llm-d) are handled below; a gateway
+				// literally named "litellm" resolves here to the same legacy block
+				// via ResolvedGateways, so behavior is identical.
+				if gw := cfg.Governor.ResolveGateway(backend); gw != nil && !config.IsInferenceBackend(backend) {
+					endpoint := gw.Endpoint
+					if endpoint == "" {
+						logger.Warn("gateway backend selected but no endpoint configured",
+							"agent", agentName, "gateway", backend, "model", model)
+						return
+					}
+					if model == "" {
+						model = gw.DefaultModel
+					}
+					githubProxy.SetInferenceRoute(agentName, &proxy.InferenceRoute{
+						Backend:  backend,
+						Endpoint: endpoint,
+						Model:    model,
+						APIKey:   gw.ResolveAPIKey(),
+						CABundle: gw.CABundle,
+					})
+					return
+				}
 				if backend == "litellm" {
 					// Resolve endpoint/key at call time so a URL saved from
 					// the governor LiteLLM tab (or a rotated key) takes

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -126,6 +126,13 @@ type Manager struct {
 	inferenceRouteCallback      func(agentName, backend, model string)
 	clearInferenceRouteCallback func(agentName string)
 
+	// isGatewayBackend reports whether a backend string names a configured model
+	// gateway (in addition to the built-in inference backends vllm/llm-d/litellm).
+	// Injected from config so an agent whose backend is a gateway name (e.g.
+	// "openrouter") is treated as inference-routable and its route resolved.
+	// Nil in tests/bare setups → only built-in inference backends route.
+	isGatewayBackend func(backend string) bool
+
 	// persistPauseCallback, when set, persists an agent's paused state to
 	// the on-disk config so it survives restarts. Nil in tests / bare setups.
 	persistPauseCallback func(name string, paused bool)
@@ -212,6 +219,29 @@ func (m *Manager) SetInferenceCallbacks(
 	defer m.mu.Unlock()
 	m.inferenceRouteCallback = setRoute
 	m.clearInferenceRouteCallback = clearRoute
+}
+
+// SetGatewayBackendChecker injects a predicate that reports whether a backend
+// string names a configured model gateway. This makes an agent whose backend is
+// a gateway name inference-routable, so its route is resolved via the inference
+// callback exactly like the built-in litellm/vllm/llm-d backends.
+func (m *Manager) SetGatewayBackendChecker(fn func(backend string) bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.isGatewayBackend = fn
+}
+
+// routableBackend reports whether a backend should be routed through the
+// inference proxy: either a built-in inference backend, or a configured gateway
+// name. Callers must NOT hold m.mu (isGatewayBackend is read under RLock).
+func (m *Manager) routableBackend(backend string) bool {
+	if IsInferenceBackend(backend) {
+		return true
+	}
+	m.mu.RLock()
+	fn := m.isGatewayBackend
+	m.mu.RUnlock()
+	return fn != nil && fn(backend)
 }
 
 // SetAppAuth injects the GitHub App auth provider for per-agent scoped tokens.
@@ -669,7 +699,7 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 
 	// Inference backends (vllm, llm-d) use Claude Code as the CLI tool
 	// and route API traffic through the proxy to the self-hosted endpoint.
-	isInference := IsInferenceBackend(backend)
+	isInference := m.routableBackend(backend)
 	if isInference {
 		binary = "claude"
 		m.ensureClaudeSettings(agent.Name, agent.UID)
@@ -4182,7 +4212,7 @@ func (m *Manager) SetModelOverride(name, model string) error {
 	if agent.BackendOverride != "" {
 		effectiveBackend = agent.BackendOverride
 	}
-	if IsInferenceBackend(effectiveBackend) && m.inferenceRouteCallback != nil {
+	if m.routableBackend(effectiveBackend) && m.inferenceRouteCallback != nil {
 		m.inferenceRouteCallback(name, effectiveBackend, model)
 	}
 	return nil
@@ -4200,7 +4230,7 @@ func (m *Manager) SetBackendOverride(name, backend string) error {
 	agent.BackendOverride = backend
 	m.logger.Info("agent backend override set", "name", name, "backend", backend)
 
-	if IsInferenceBackend(backend) && m.inferenceRouteCallback != nil {
+	if m.routableBackend(backend) && m.inferenceRouteCallback != nil {
 		model := agent.ModelOverride
 		if model == "" {
 			model = agent.Config.Model
@@ -4219,7 +4249,7 @@ func (m *Manager) SetBackendOverride(name, backend string) error {
 func (m *Manager) RefreshInferenceRoutes(backend string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.inferenceRouteCallback == nil || !IsInferenceBackend(backend) {
+	if m.inferenceRouteCallback == nil || !m.routableBackend(backend) {
 		return
 	}
 	for name, agent := range m.agents {

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -514,6 +514,114 @@ type GovernorConfig struct {
 	VLLM          InferenceAuthConfig   `yaml:"vllm"`
 	LLMD          InferenceAuthConfig   `yaml:"llm-d"`
 	Trajectory    TrajectoryConfig      `yaml:"trajectory"`
+	// Gateways is the list of named model gateways (OpenAI-compatible endpoints
+	// like OpenRouter, a LiteLLM proxy, vLLM, or llm-d). An agent routes through
+	// a gateway by naming it as its backend. When empty, a single implicit
+	// gateway named "litellm" is synthesized from the legacy LiteLLM block above
+	// so existing hives keep working with zero config change. See ResolveGateway.
+	Gateways []GatewayConfig `yaml:"gateways"`
+}
+
+// GatewayConfig is one named, OpenAI-compatible model gateway. A hive may
+// configure several at once (e.g. OpenRouter for public models plus a private
+// LiteLLM proxy for internal ones); each agent picks one by naming it as its
+// backend. Secrets are referenced by env-var NAME or file PATH only — never
+// inlined — matching the LiteLLM/inference key-handling rule elsewhere.
+type GatewayConfig struct {
+	// Name is the unique gateway id an agent names as its backend (e.g.
+	// "openrouter", "corp-litellm"). Must be non-empty and unique per hive.
+	Name string `yaml:"name" json:"name"`
+	// Kind drives preset defaults + labeling: openrouter | litellm | vllm |
+	// llm-d | custom. Purely descriptive at runtime (all are OpenAI-compatible);
+	// the endpoint is what actually routes.
+	Kind string `yaml:"kind" json:"kind,omitempty"`
+	// Endpoint is the OpenAI-compatible base URL, e.g. https://openrouter.ai/api/v1.
+	Endpoint string `yaml:"endpoint" json:"endpoint"`
+	// APIKeyEnv / APIKeyFile resolve this gateway's key (env var NAME and/or file
+	// PATH — never the value). Empty is allowed for keyless endpoints (some vLLM).
+	APIKeyEnv  string `yaml:"api_key_env" json:"api_key_env,omitempty"`
+	APIKeyFile string `yaml:"api_key_file" json:"api_key_file,omitempty"`
+	// DefaultModel is used when an agent routed through this gateway selects none.
+	DefaultModel string `yaml:"default_model" json:"default_model,omitempty"`
+	// CABundle is an optional PEM path for a private CA (never disables verify).
+	CABundle string `yaml:"ca_bundle" json:"ca_bundle,omitempty"`
+}
+
+// gatewayKind values.
+const (
+	GatewayKindOpenRouter = "openrouter"
+	GatewayKindLiteLLM    = "litellm"
+	GatewayKindVLLM       = "vllm"
+	GatewayKindLLMD       = "llm-d"
+	GatewayKindCustom     = "custom"
+
+	// legacyLiteLLMGatewayName is the name of the implicit gateway synthesized
+	// from the legacy Governor.LiteLLM block when no gateways are configured. It
+	// matches the historical "litellm" agent backend so existing agents route
+	// unchanged.
+	legacyLiteLLMGatewayName = "litellm"
+)
+
+// ResolvedGateways returns the effective gateway list: the explicitly-configured
+// Gateways when present, otherwise a single implicit gateway synthesized from the
+// legacy LiteLLM block (only if that block has an endpoint). This is what lets a
+// hive with no `gateways:` and a classic `litellm:` block keep working, while a
+// hive that lists gateways gets exactly those.
+func (g GovernorConfig) ResolvedGateways() []GatewayConfig {
+	if len(g.Gateways) > 0 {
+		return g.Gateways
+	}
+	if g.LiteLLM.Endpoint == "" {
+		return nil
+	}
+	return []GatewayConfig{{
+		Name:         legacyLiteLLMGatewayName,
+		Kind:         GatewayKindLiteLLM,
+		Endpoint:     g.LiteLLM.Endpoint,
+		APIKeyEnv:    g.LiteLLM.APIKeyEnv,
+		APIKeyFile:   g.LiteLLM.APIKeyFile,
+		DefaultModel: g.LiteLLM.DefaultModel,
+		CABundle:     g.LiteLLM.CABundle,
+	}}
+}
+
+// ResolveGateway looks up a gateway by name in the resolved list. An empty name
+// returns the FIRST resolved gateway (the default), so an inference agent that
+// names no specific gateway routes through the default one. Returns nil if no
+// gateway matches (or none are configured).
+func (g GovernorConfig) ResolveGateway(name string) *GatewayConfig {
+	gws := g.ResolvedGateways()
+	if len(gws) == 0 {
+		return nil
+	}
+	if name == "" {
+		gw := gws[0]
+		return &gw
+	}
+	for i := range gws {
+		if strings.EqualFold(gws[i].Name, name) {
+			gw := gws[i]
+			return &gw
+		}
+	}
+	return nil
+}
+
+// ResolveAPIKey returns this gateway's key value, preferring the env var when
+// set and falling back to the file. Returns "" when neither yields a value
+// (a keyless endpoint). Mirrors LiteLLMConfig key resolution.
+func (gw GatewayConfig) ResolveAPIKey() string {
+	if gw.APIKeyEnv != "" {
+		if v := os.Getenv(gw.APIKeyEnv); v != "" {
+			return v
+		}
+	}
+	if gw.APIKeyFile != "" {
+		if b, err := os.ReadFile(gw.APIKeyFile); err == nil {
+			return strings.TrimSpace(string(b))
+		}
+	}
+	return ""
 }
 
 // TrajectoryConfig governs the trajectory-review lane: a periodic,
@@ -1813,6 +1921,15 @@ func (c *Config) validate() error {
 	if err := c.Governor.LiteLLM.Validate(); err != nil {
 		return err
 	}
+	// A configured gateway name is a valid agent backend: naming a gateway as
+	// the backend routes that agent through it. Names are matched
+	// case-insensitively to mirror ResolveGateway.
+	gatewayNames := map[string]bool{}
+	for _, gw := range c.Governor.ResolvedGateways() {
+		if gw.Name != "" {
+			gatewayNames[strings.ToLower(gw.Name)] = true
+		}
+	}
 	for name, agent := range c.Agents {
 		validBackends := map[string]bool{"claude": true, "copilot": true, "goose": true, "codex": true, "pi": true, "bob": true, "aider": true}
 		// Inference backends (vllm, llm-d, litellm) are valid persisted
@@ -1821,8 +1938,8 @@ func (c *Config) validate() error {
 		for _, b := range InferenceBackends {
 			validBackends[b] = true
 		}
-		if agent.Backend != "" && !validBackends[agent.Backend] {
-			return fmt.Errorf("agent %s: invalid backend %q (must be claude, copilot, goose, codex, pi, bob, aider, or an inference backend: %s)", name, agent.Backend, strings.Join(InferenceBackends, ", "))
+		if agent.Backend != "" && !validBackends[agent.Backend] && !gatewayNames[strings.ToLower(agent.Backend)] {
+			return fmt.Errorf("agent %s: invalid backend %q (must be claude, copilot, goose, codex, pi, bob, aider, an inference backend: %s, or a configured gateway name)", name, agent.Backend, strings.Join(InferenceBackends, ", "))
 		}
 		validCavemanModes := map[string]bool{"": true, "lite": true, "full": true, "ultra": true, "wenyan": true}
 		if !validCavemanModes[agent.CavemanMode] {

--- a/v2/pkg/config/gateways_test.go
+++ b/v2/pkg/config/gateways_test.go
@@ -1,0 +1,92 @@
+package config
+
+import "testing"
+
+// A hive with only the legacy litellm block (no gateways:) must resolve to a
+// single implicit gateway named "litellm" so existing agents route unchanged.
+func TestResolvedGatewaysBackCompat(t *testing.T) {
+	g := GovernorConfig{
+		LiteLLM: LiteLLMConfig{
+			Endpoint:     "https://litellm.example.com",
+			APIKeyEnv:    "HIVE_LITELLM_API_KEY",
+			DefaultModel: "gpt-4o",
+		},
+	}
+	gws := g.ResolvedGateways()
+	if len(gws) != 1 {
+		t.Fatalf("expected 1 synthesized gateway, got %d", len(gws))
+	}
+	if gws[0].Name != legacyLiteLLMGatewayName {
+		t.Fatalf("synthesized gateway name = %q, want %q", gws[0].Name, legacyLiteLLMGatewayName)
+	}
+	if gws[0].Endpoint != "https://litellm.example.com" || gws[0].DefaultModel != "gpt-4o" {
+		t.Fatalf("synthesized gateway did not carry legacy fields: %+v", gws[0])
+	}
+	// Resolving by the legacy name AND by empty (default) both hit it.
+	if g.ResolveGateway("") == nil || g.ResolveGateway("litellm") == nil {
+		t.Fatal("default and legacy-name resolution must both find the gateway")
+	}
+}
+
+// No litellm endpoint and no gateways → nothing resolves (a hive that never
+// configured inference). Must not panic or synthesize a bogus gateway.
+func TestResolvedGatewaysEmpty(t *testing.T) {
+	g := GovernorConfig{}
+	if len(g.ResolvedGateways()) != 0 {
+		t.Fatal("empty config must resolve to no gateways")
+	}
+	if g.ResolveGateway("") != nil || g.ResolveGateway("anything") != nil {
+		t.Fatal("no gateways → resolution returns nil")
+	}
+}
+
+// Explicit gateways take precedence over the legacy block, and lookup is
+// case-insensitive; empty name returns the first (default).
+func TestResolveGatewayExplicit(t *testing.T) {
+	g := GovernorConfig{
+		LiteLLM: LiteLLMConfig{Endpoint: "https://legacy.example.com"}, // must be IGNORED when gateways present
+		Gateways: []GatewayConfig{
+			{Name: "openrouter", Kind: GatewayKindOpenRouter, Endpoint: "https://openrouter.ai/api/v1", DefaultModel: "anthropic/claude-opus-4.8"},
+			{Name: "corp", Kind: GatewayKindLiteLLM, Endpoint: "https://litellm.internal:4000"},
+		},
+	}
+	if got := g.ResolveGateway(""); got == nil || got.Name != "openrouter" {
+		t.Fatalf("empty name must return first gateway (openrouter), got %+v", got)
+	}
+	if got := g.ResolveGateway("CORP"); got == nil || got.Endpoint != "https://litellm.internal:4000" {
+		t.Fatalf("case-insensitive lookup failed: %+v", got)
+	}
+	if g.ResolveGateway("nope") != nil {
+		t.Fatal("unknown gateway must resolve to nil")
+	}
+	// Legacy block must NOT leak in when explicit gateways are set.
+	for _, gw := range g.ResolvedGateways() {
+		if gw.Endpoint == "https://legacy.example.com" {
+			t.Fatal("legacy litellm endpoint leaked despite explicit gateways")
+		}
+	}
+}
+
+// A gateway name is accepted as a valid agent backend by validate().
+func TestGatewayNameValidAsBackend(t *testing.T) {
+	c := &Config{
+		Project: ProjectConfig{Org: "acme"},
+		GitHub:  GitHubConfig{Token: "x"},
+		Agents: map[string]AgentConfig{
+			"scanner": {Backend: "openrouter"},
+		},
+		Governor: GovernorConfig{
+			Gateways: []GatewayConfig{
+				{Name: "openrouter", Endpoint: "https://openrouter.ai/api/v1"},
+			},
+		},
+	}
+	if err := c.validate(); err != nil {
+		t.Fatalf("gateway name should be a valid backend, got: %v", err)
+	}
+	// A backend that is neither a known CLI/inference backend nor a gateway fails.
+	c.Agents["scanner"] = AgentConfig{Backend: "not-a-thing"}
+	if err := c.validate(); err == nil {
+		t.Fatal("unknown backend must be rejected")
+	}
+}


### PR DESCRIPTION
## Completes multi-gateway support (stacks on #1979)

#1979 adds the Model Gateways schema + UI (configure OpenRouter, a LiteLLM proxy, etc.). This PR makes an agent actually **route through a named gateway** when its backend is that gateway's name (e.g. `backend: openrouter`).

**⚠️ Depends on #1979** (needs `GovernorConfig.ResolveGateway`). Merge #1979 first; this rebases onto v2 cleanly after.

## Changes
- **Manager:** `SetGatewayBackendChecker` + `routableBackend()` — a backend is inference-routable if it's a built-in inference backend (litellm/vllm/llm-d) OR a configured gateway name. The four `inferenceRouteCallback` gates (launch path + model/backend overrides) now use `routableBackend`, so a gateway-named agent launches the claude CLI and gets an inference route.
- **main.go route callback:** resolves a gateway by name (`cfg.Governor.ResolveGateway`) → routes through its endpoint / key / model / CA. Built-in names keep their existing paths; a gateway literally named `litellm` resolves to the same legacy block, so behavior is identical. Live resolution (reads `cfg` per call) → gateways added from the Model Gateways tab take effect without a restart.

## Testing
`go build ./...` exit 0; `go vet ./pkg/agent/ ./cmd/hive/` clean; `go test ./pkg/config/ -run Gateway` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)