### PR TITLE
🐛 fix(hub): retry hub self-upgrade every cycle (stops "queued" hub from getting stuck)

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -27,6 +27,12 @@ var saasUsersDir = "/data/saas/users"
 
 const hubAdminUsername = "clubanderson"
 
+// hubUpgradeDebounce is the minimum gap between hub self-upgrade rollout
+// restarts. The behind-latest check runs every SHA-poll cycle, so without this
+// the hub could re-trigger a restart before the previous rollout's new pod
+// reports the new hash. One cycle plus rollout headroom.
+const hubUpgradeDebounce = 4 * time.Minute
+
 type SaaSUser struct {
 	GitHubUsername string            `json:"github_username"`
 	CreatedAt      string            `json:"created_at"`
@@ -2875,15 +2881,24 @@ func (s *HubServer) StartLatestSHAPoller() {
 				break
 			}
 		}
-		if changed {
-			// Hub auto-upgrade (hub runs on v2)
-			hubBranchSHA := getLatestSHAForBranch("v2")
-			if isHubAutoUpgrade() && hubBranchSHA != "" && hubBranchSHA != s.hubGitHash {
-				s.logger.Info("audit: hub auto-upgrade triggered", "from", s.hubGitHash, "to", hubBranchSHA)
-				cmd := kubectlForCluster(s.hubCluster(), "rollout", "restart", "deployment/hive-hub", "-n", "hive-hub")
-				if out, err := cmd.CombinedOutput(); err != nil {
-					s.logger.Warn("hub auto-upgrade failed", "output", string(out))
-				}
+		_ = changed
+		// Hub auto-upgrade — checked EVERY cycle, not only when the SHA just
+		// changed. Previously this lived inside `if changed {}`, so if the hub
+		// missed the one poll where v2's SHA flipped (busy, mid-restart, or the
+		// SHA moved between polls), it stayed "queued" forever and never retried,
+		// while spokes retry every cycle via triggerAutoUpgrades() above. Mirror
+		// that: whenever auto-upgrade is on and the hub is behind latest v2, trigger
+		// a rollout restart. A debounce prevents re-restarting every 2min while a
+		// restart is already rolling out (the new pod reports the new hash, which
+		// clears the condition, but the poll can fire before the rollout lands).
+		hubBranchSHA := getLatestSHAForBranch("v2")
+		if isHubAutoUpgrade() && hubBranchSHA != "" && !sameCommit(hubBranchSHA, s.hubGitHash) &&
+			time.Since(s.lastHubUpgradeTrigger) > hubUpgradeDebounce {
+			s.lastHubUpgradeTrigger = time.Now()
+			s.logger.Info("audit: hub auto-upgrade triggered", "from", s.hubGitHash, "to", hubBranchSHA)
+			cmd := kubectlForCluster(s.hubCluster(), "rollout", "restart", "deployment/hive-hub", "-n", "hive-hub")
+			if out, err := cmd.CombinedOutput(); err != nil {
+				s.logger.Warn("hub auto-upgrade failed", "output", string(out))
 			}
 		}
 	}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -145,6 +145,10 @@ type HubServer struct {
 	hubGitHash        string
 	hubGitBranch      string
 	hubSecret         string
+	// lastHubUpgradeTrigger debounces the hub self-upgrade rollout restart so the
+	// every-cycle behind-latest check doesn't re-restart while a rollout is still
+	// in flight. See the auto-upgrade block in the SHA-poll loop.
+	lastHubUpgradeTrigger time.Time
 	httpServer        *http.Server
 	httpMu            sync.Mutex // guards httpServer (Start runs in a goroutine; Shutdown races it)
 	clusters          map[string]ClusterConfig


### PR DESCRIPTION
## Problem
The hub showed **"queued"** (behind latest v2, auto-upgrade ON) but never actually upgraded itself.

## Root cause
The hub's self-upgrade rollout-restart was inside `if changed {}` — it only fired in the **exact SHA-poll cycle where v2's latest SHA changed**. If the hub missed that single window (busy pushing spoke upgrades, mid-restart, or the SHA moved between polls), `changed` was false on every subsequent poll, so the self-upgrade block was skipped — the hub stayed queued **forever with no retry**. Spokes don't have this problem: `triggerAutoUpgrades()` runs unconditionally every cycle.

Observed live: hub stuck at `281508c` while latest v2 was `177757f`+, queued badge showing, never rolling. (Fixed manually with a rollout restart; this prevents recurrence.)

## Fix
Move the hub behind-latest check **out of `if changed`** so it runs every SHA-poll cycle (mirroring the spoke retry). Add a 4-min debounce (`hubUpgradeDebounce`) so the every-cycle check doesn't re-trigger a restart while a rollout is still in flight before the new pod reports the new hash. Use `sameCommit` for prefix-tolerant SHA comparison.

## Testing
`go build ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)