### PR TITLE
🐛 fix(hub): "Assigning to <org>" no longer shows on hives that are just upgrading

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1340,11 +1340,21 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 
 		// Assigning transient state: after a placeholder is assigned, the meta
 		// records the real project but the spoke still reports the old placeholder
-		// identity until it reconciles via heartbeat. projectConfigForHiveID
-		// returns non-nil in exactly that window (complete claim, meta != what the
-		// spoke reports) and nil once matched — so it is the authoritative signal.
-		// The RegistryEntry fields here are the live heartbeat-reported values.
-		if projectConfigForHiveID(entry.ID, entry.Org, entry.Repos, entry.PrimaryRepo, entry.ACMMLevel) != nil {
+		// identity until it reconciles via heartbeat.
+		//
+		// projectConfigForHiveID returns non-nil whenever meta != what the spoke
+		// reports — but that ALSO happens transiently during an UPGRADE (the spoke
+		// pod restarts and its heartbeat momentarily reports an empty/stale org),
+		// which falsely lit "Assigning to <org>" on already-claimed hives that were
+		// merely upgrading. Guard against that:
+		//   - never show Assigning while the hive is Upgrading (an upgrade is not
+		//     an assignment), and
+		//   - only show it when the spoke is genuinely reporting a DIFFERENT,
+		//     non-empty project (an empty reported org means the spoke just
+		//     restarted / hasn't beaten yet — not a fresh assignment).
+		spokeReportsDifferentProject := entry.Org != "" && !strings.EqualFold(entry.Org, sh.Org)
+		if !entry.Upgrading && spokeReportsDifferentProject &&
+			projectConfigForHiveID(entry.ID, entry.Org, entry.Repos, entry.PrimaryRepo, entry.ACMMLevel) != nil {
 			entry.Assigning = true
 			entry.AssigningTo = sh.Org
 		}


### PR DESCRIPTION
## Problem
Already-claimed, running hives (kellyaa, ibm, open-source, llm-d) showed **"Assigning to <org>"** with a spinner in the MODE column while they were merely **upgrading** to a new image.

## Root cause
#1974's assigning state keyed off `projectConfigForHiveID(...) != nil` — i.e. "meta project != what the spoke reports." That mismatch is the correct signal for a fresh placeholder assignment, but it ALSO occurs **transiently during an upgrade**: the spoke pod restarts and its heartbeat momentarily reports an empty/stale org, so the meta (real project) != the spoke's (empty/stale) → false "Assigning."

## Fix
Only show Assigning for a genuine placeholder→project transition:
- **never** while `entry.Upgrading` (an upgrade is not an assignment), and
- only when the spoke reports a genuinely **different, non-empty** project (empty reported org = spoke just restarted / hasn't beaten yet, not a fresh assignment).

A real assignment — where the spoke still reports its old placeholder org (e.g. `available-vllmd-03`) — still lights the spinner correctly.

`go build ./pkg/hub/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)