### PR TITLE
✨ feat: Auto model mode for Copilot agents (copilot --model auto)

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -750,6 +750,11 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 					" --disallowed-tools 'mcp__github__merge_pull_request'"
 			}
 		case "copilot":
+			// model is passed verbatim to `copilot --model %s`. It may be a
+			// concrete id OR the auto-selection sentinel "auto" (copilotAutoModel
+			// in cli_models.go), which lets the Copilot CLI pick/adjust the model
+			// per task. Nothing here assumes a concrete id, so the sentinel flows
+			// through unchanged.
 			switch {
 			case mode >= ModeIssuesAndPRs:
 				launchCmd = fmt.Sprintf("%s --model %s --no-auto-update --allow-all --enable-all-github-mcp-tools",

--- a/v2/pkg/dashboard/cli_models.go
+++ b/v2/pkg/dashboard/cli_models.go
@@ -86,6 +86,13 @@ const (
 	// require a plausible editor identifier.
 	copilotEditorVersion = "vscode/1.99.0"
 
+	// copilotAutoModel is the Copilot auto-selection sentinel: `copilot --model
+	// auto` lets the Copilot CLI pick/adjust the optimal model per task instead
+	// of pinning a concrete id. It is a valid --model VALUE (confirmed against
+	// copilot CLI v1.0.59), not a discoverable catalog id, so it is always
+	// offered (copilotAlwaysIncludeModels) and exempt from model auto-heal.
+	copilotAutoModel = "auto"
+
 	// --- Gemini ---
 
 	// geminiModelsURL lists models available to a Gemini API key.
@@ -149,6 +156,9 @@ var copilotStaticModels = []string{
 // copilot list so agents can be pinned to them safely.
 var copilotAlwaysIncludeModels = []string{
 	"mai-code-1-flash-picker",
+	// Auto-select sentinel — never returned by the /models catalog, but a valid
+	// launch value, so it must always be offered and must survive auto-heal.
+	copilotAutoModel,
 }
 
 // codexStaticModels is the maintained list for the OpenAI Codex CLI. Codex only

--- a/v2/pkg/dashboard/cli_models_test.go
+++ b/v2/pkg/dashboard/cli_models_test.go
@@ -131,6 +131,19 @@ func TestQueryCLIModels_CopilotAlwaysIncludePinned(t *testing.T) {
 	}
 }
 
+// TestQueryCLIModels_CopilotAutoSentinelServed verifies the Copilot auto-select
+// sentinel ("auto") is always offered in the served copilot list, so an agent
+// can be launched with `copilot --model auto` and the selection survives model
+// auto-heal (the sentinel is not in the discovered catalog by design).
+func TestQueryCLIModels_CopilotAutoSentinelServed(t *testing.T) {
+	t.Setenv("COPILOT_GITHUB_TOKEN", "")
+	s := &Server{cliModels: newCLIModelCache(), logger: testLogger()}
+	r := s.queryCLIModels("copilot")
+	if !contains(r.models, copilotAutoModel) {
+		t.Fatalf("copilot auto sentinel %q missing from served list: %v", copilotAutoModel, r.models)
+	}
+}
+
 // TestQueryCLIModels_GeminiFallbackNoKey verifies gemini falls back when no
 // API key is configured.
 func TestQueryCLIModels_GeminiFallbackNoKey(t *testing.T) {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4668,6 +4668,10 @@
       { value: 'claude-fable-5', label: 'Fable 5' },
     ];
     const COPILOT_CLI_MODELS = [
+      // Auto sentinel: `copilot --model auto` lets the Copilot CLI pick/adjust
+      // the optimal model per task. Not a concrete model id — treated as an
+      // always-valid selection that reconcileModelsAfterDiscovery never heals.
+      { value: 'auto', label: 'Auto (Copilot picks)' },
       { value: 'mai-code-1-flash-picker', label: 'MAI Code 1 Flash' },
       { value: 'claude-opus-4.6', label: 'Opus 4.6' },
       { value: 'claude-sonnet-4.6', label: 'Sonnet 4.6' },
@@ -4712,6 +4716,14 @@
     function backendLabel(b) {
       if (INFERENCE_BACKENDS.includes(b)) return b + ' ⚡';
       return b;
+    }
+    // Auto-select sentinels: special --model VALUES that tell a CLI to pick the
+    // model itself rather than pin a concrete id. They flow verbatim through the
+    // launch path's `--model <value>` but are never in a discovered model
+    // catalog, so they must be exempted from model auto-heal. Copilot: `auto`.
+    const AUTO_MODEL_SENTINELS = { copilot: ['auto'] };
+    function isAutoModelSentinel(backend, model) {
+      return (AUTO_MODEL_SENTINELS[backend] || []).includes(model);
     }
     function modelsForBackend(backend) {
       const discovered = BACKEND_MODELS[backend];
@@ -4909,6 +4921,7 @@
       (window._lastAgents || []).forEach(a => {
         if (a.cli !== backend) return;
         if (!a.model) return;                 // no explicit model — nothing to heal
+        if (isAutoModelSentinel(backend, a.model)) return; // auto-select value — never a concrete id, never healed
         const key = `${backend}|${a.name}`;
         if (isAvailable(a.model)) { _markAvailable(key, a.model); return; } // still valid — leave untouched (idempotent)
         if (!_confirmAbsent(key, a.model)) return; // unconfirmed or already healed — no switch


### PR DESCRIPTION
## What

Adds an **"Auto (Copilot picks)"** model option for the **Copilot** CLI backend, so an agent can run in auto-mode — the Copilot CLI picks/adjusts the optimal model per task — instead of being pinned to a concrete model id.

## How it works

This is fundamentally **one dropdown entry + making sure the value isn't rejected or healed away**. Auto mode is just a special value passed to Copilot's existing `--model` flag:

- **Copilot:** `copilot --model auto` — the Copilot CLI selects the optimal model per task. Value is the literal string `auto` (confirmed against copilot CLI **v1.0.59**).

`auto` is a special `--model` **VALUE** that flows through hive's **existing** `--model <value>` launch path. No new flag, mechanism, or config field.

### Why Copilot-only

The Claude CLI has **no equivalent true per-task auto-selection mode**, so this is intentionally Copilot-only. `CLAUDE_CLI_MODELS` and `CODEX_CLI_MODELS` are left exactly as they were.

## Changes

- **Frontend** (`v2/pkg/dashboard/static/index.html`): add `{ value: 'auto', label: 'Auto (Copilot picks)' }` at the **top** of `COPILOT_CLI_MODELS` (natural default choice). `reconcileModelsAfterDiscovery` now treats `auto` as an always-valid copilot sentinel via `isAutoModelSentinel()`, so it is **never healed away** just for not appearing in the live-discovered model catalog.
- **Backend** (`v2/pkg/dashboard/cli_models.go`): new named const `copilotAutoModel = "auto"`, added to `copilotAlwaysIncludeModels` so it is **always served** in the copilot dropdown whether the list came from live discovery or the static fallback (same mechanism as `mai-code-1-flash-picker`).
- **Launch path** (`v2/pkg/agent/manager.go`): `auto` passes verbatim to `copilot --model %s`; comment added noting nothing there assumes a concrete model id.
- **Test** (`cli_models_test.go`): asserts the `auto` sentinel is always present in the served copilot list. Also automatically covered by the existing `TestQueryCLIModels_CopilotAlwaysIncludePinned`.

## Validation notes

- **Model-value validation:** Per-agent model values are **not** validated against a known-model list on config save — they are passed free-form to `--model`. The only allowlist path (`checkModelAllowed` / `contribute_reject_unknown_models` in `contribute_ws.go`) is an admin-configured allowlist for **external contributors connecting to a hive**, off by default and orthogonal to this feature. So beyond serving the option, no acceptance/save change was needed.
- **Auto-heal:** `reconcileModelsAfterDiscovery` will not clobber an `auto` selection — the new sentinel guard exempts it, and it is also always present in the served list, so both the frontend guard and backend always-include cover it.

## Testing

- `go build ./...` — exit 0
- `go vet ./pkg/dashboard/ ./pkg/agent/` — clean
- `go test ./pkg/dashboard/ -run TestQueryCLIModels_Copilot` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)