### PR TITLE
✨ feat: OpenRouter QR funding — scan to connect a scoped OpenRouter key as a model gateway

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1871,6 +1871,19 @@ func main() {
 			if err := cfg.Save(); err != nil {
 				logger.Error("failed to save claimed project config", "error", err)
 			}
+		}), hub.GatewayConfigCallback(func(gw *hub.HeartbeatGatewayConfig) {
+			// The hub funded an OpenRouter gateway on this hive's behalf (scan-to-
+			// fund from My Hives) and delivered it over the heartbeat channel — the
+			// only path that reaches a firewalled/heartbeat-only spoke (vllm-d). We
+			// store the key in our OWN per-gateway secret-file store and create the
+			// "openrouter" gateway. The hub drains the delivery after sending, so
+			// this fires once per fund; the key value is never logged.
+			if gw == nil || gw.Key == "" {
+				return
+			}
+			if err := dashSrv.ApplyDeliveredGateway(gw.Name, gw.Kind, gw.Endpoint, gw.DefaultModel, gw.Key); err != nil {
+				logger.Error("failed to apply hub-delivered gateway", "gateway", gw.Name, "error", err)
+			}
 		}))
 
 		go hub.StartTaskStatusPush(ctx, hubURL, func() *hub.TaskStatusPayload {

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	github.com/robfig/cron/v3 v3.0.1
+	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/spf13/cobra v1.10.2
 	go.etcd.io/bbolt v1.5.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -29,6 +29,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
+github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -114,6 +114,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("DELETE /api/config/governor/gateways/{name}", s.handleGovernorGatewaysDelete)
 	s.mux.HandleFunc("POST /api/config/governor/gateways/{name}/test", s.handleGovernorGatewaysTest)
 	s.mux.HandleFunc("POST /api/config/governor/gateways/discover", s.handleGovernorGatewaysDiscover)
+	s.registerOpenRouterRoutes()
 	s.mux.HandleFunc("POST /api/config/governor/agents", s.handleGovernorAddAgent)
 	s.mux.HandleFunc("DELETE /api/config/governor/agents/{name}", s.handleGovernorRemoveAgent)
 	s.mux.HandleFunc("PUT /api/config/governor/repos", s.handleGovernorRepos)

--- a/v2/pkg/dashboard/openrouter.go
+++ b/v2/pkg/dashboard/openrouter.go
@@ -1,0 +1,327 @@
+package dashboard
+
+// OpenRouter "scan-to-fund" flow (spoke side).
+//
+// A sponsor funds THIS hive by scanning a QR (or clicking a link) that starts an
+// OpenRouter OAuth PKCE flow. On return, the hive exchanges the code for a
+// user-controlled, scoped OpenRouter API key and stores it as a model gateway
+// named "openrouter" — reusing the EXISTING per-gateway secret-file store
+// (storeGatewayAPIKey): the key VALUE is written to an owner-only file on the
+// PVC and only the PATH is recorded in hive.yaml. The key is never logged,
+// echoed, or inlined.
+//
+// The shared PKCE crypto, URL builders, key-exchange/credit HTTP calls, QR PNG
+// encoder, and the single-use TTL state store all live in pkg/openrouter; this
+// file wires them to the spoke's HTTP routes and to the gateway config.
+//
+// SECURITY:
+//   - PKCE S256; the code_verifier NEVER leaves the server.
+//   - state is single-use + short-lived; the callback binds to the stored hive.
+//   - callback_url is built server-side from an allowlisted own-origin (the
+//     hive's configured dashboard_url, else the request host) — never accepted
+//     from the client.
+//   - /openrouter/callback is a PUBLIC path (the returning browser has no
+//     session yet); the state token is the credential and is verified server-side.
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/openrouter"
+)
+
+const (
+	// openRouterGatewayName is the fixed gateway name a funded key is stored
+	// under, so re-funding replaces the same gateway rather than piling up.
+	openRouterGatewayName = "openrouter"
+
+	// openRouterCallbackPath is the PUBLIC path the sponsor's browser returns to
+	// after authorizing on openrouter.ai. Kept in one const so the route
+	// registration, the isPublicPath allowlist, and the callback_url builder
+	// agree.
+	openRouterCallbackPath = "/openrouter/callback"
+
+	// openRouterConnectedFlag is appended to the dashboard redirect after a
+	// successful connect so the UI can show a success indicator.
+	openRouterConnectedFlag = "?openrouter=connected"
+	// openRouterErrorFlag is appended when the flow fails, so the UI can show why.
+	openRouterErrorFlag = "?openrouter=error"
+)
+
+// openRouterState returns the lazily-initialized single-use PKCE state store,
+// created once per Server with the production TTL.
+func (s *Server) openRouterState() *openrouter.StateStore {
+	s.openRouterStateOnce.Do(func() {
+		s.openRouterStateStore = openrouter.NewStateStore(openrouter.StateTTL)
+	})
+	return s.openRouterStateStore
+}
+
+// registerOpenRouterRoutes registers the spoke-side OpenRouter funding routes.
+// Called from the dashboard route registration. The callback is public (added
+// to isPublicPath); start/qr/credit ride the normal authenticated mux.
+func (s *Server) registerOpenRouterRoutes() {
+	s.mux.HandleFunc("GET /api/openrouter/connect/start", s.handleOpenRouterStart)
+	s.mux.HandleFunc("GET /api/openrouter/qr", s.handleOpenRouterQR)
+	s.mux.HandleFunc("GET /api/openrouter/models", s.handleOpenRouterModels)
+	s.mux.HandleFunc("GET /api/openrouter/credit", s.handleOpenRouterCredit)
+	s.mux.HandleFunc("GET "+openRouterCallbackPath, s.handleOpenRouterCallback)
+}
+
+// openRouterCallbackURL builds THIS hive's callback URL from an allowlisted own
+// origin. It prefers the configured dashboard_url (correct for hosted/firewalled
+// hives), then falls back to the request's forwarded/host origin. It NEVER
+// accepts a callback origin supplied by the client, so a code can only be
+// redeemed back to this server.
+func (s *Server) openRouterCallbackURL(r *http.Request) string {
+	base := ""
+	if s.deps != nil && s.deps.Config != nil {
+		base = strings.TrimSpace(s.deps.Config.Hub.DashboardURL)
+	}
+	if base == "" {
+		scheme := "https"
+		if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") == "" {
+			scheme = "http"
+		}
+		if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+			scheme = proto
+		}
+		host := r.Header.Get("X-Forwarded-Host")
+		if host == "" {
+			host = r.Host
+		}
+		base = scheme + "://" + host
+	}
+	return strings.TrimRight(base, "/") + openRouterCallbackPath
+}
+
+// handleOpenRouterStart begins a PKCE funding flow for THIS hive. It generates a
+// verifier + S256 challenge, records the single-use state (with the chosen
+// model), and returns the openrouter.ai/auth URL plus the state. The spoke
+// implies "self" — the hive_id is always this hive.
+func (s *Server) handleOpenRouterStart(w http.ResponseWriter, r *http.Request) {
+	model := strings.TrimSpace(r.URL.Query().Get("model"))
+
+	verifier, challenge, err := openrouter.GeneratePKCE()
+	if err != nil {
+		jsonError(w, "failed to start flow", http.StatusInternalServerError)
+		return
+	}
+	hiveID := ""
+	if s.deps != nil && s.deps.Config != nil {
+		hiveID = s.deps.Config.HiveID
+	}
+	state, err := s.openRouterState().Create(verifier, hiveID, model)
+	if err != nil {
+		jsonError(w, "failed to start flow", http.StatusInternalServerError)
+		return
+	}
+	authURL, err := openrouter.BuildAuthorizeURL(s.openRouterCallbackURL(r), challenge, state)
+	if err != nil {
+		jsonError(w, "failed to build authorize URL", http.StatusInternalServerError)
+		return
+	}
+	s.auditFromRequest(r, "openrouter_connect_start", auditDetail("model", model), "")
+	jsonResponse(w, map[string]interface{}{"authorize_url": authURL, "state": state})
+}
+
+// handleOpenRouterQR renders a QR PNG for the ?data=<authorize_url> query param.
+// The image is same-origin (Go-generated PNG), so the dashboard CSP stays clean
+// (no vendored JS). Only openrouter.ai/auth URLs are encoded — the data param is
+// validated to that host so this cannot be turned into an open QR generator.
+func (s *Server) handleOpenRouterQR(w http.ResponseWriter, r *http.Request) {
+	data := r.URL.Query().Get("data")
+	if !strings.HasPrefix(data, openrouter.AuthURL) {
+		http.Error(w, "data must be an OpenRouter authorize URL", http.StatusBadRequest)
+		return
+	}
+	png, err := openrouter.QRPNG(data)
+	if err != nil {
+		http.Error(w, "failed to render QR", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "image/png")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Write(png)
+}
+
+// handleOpenRouterModels returns the curated suggested model list plus OpenRouter's
+// live model catalog (best-effort) so the funding screen's picker can offer
+// sensible options and manual entry. No key is needed — /v1/models is public.
+func (s *Server) handleOpenRouterModels(w http.ResponseWriter, r *http.Request) {
+	live, _ := fetchModelsFromEndpoint(openrouter.BaseURL, "")
+	jsonResponse(w, map[string]interface{}{
+		"suggested": openrouter.SuggestedModels,
+		"models":    live,
+		"default":   openrouter.DefaultModel,
+	})
+}
+
+// handleOpenRouterCredit proxies GET /api/v1/key using the stored openrouter
+// gateway key and returns {limit, limit_remaining, usage, label} so the UI can
+// show "$X remaining". It NEVER returns the key itself. hive_id is accepted for
+// symmetry with the hub route but is ignored on the spoke (always self).
+func (s *Server) handleOpenRouterCredit(w http.ResponseWriter, r *http.Request) {
+	key := s.resolveOpenRouterKey()
+	if key == "" {
+		jsonResponse(w, map[string]interface{}{"connected": false})
+		return
+	}
+	credit, err := openrouter.FetchCredit(key)
+	if err != nil {
+		jsonResponse(w, map[string]interface{}{"connected": true, "error": "could not read credit"})
+		return
+	}
+	jsonResponse(w, map[string]interface{}{
+		"connected":       true,
+		"label":           credit.Label,
+		"limit":           credit.Limit,
+		"limit_remaining": credit.LimitRemaining,
+		"usage":           credit.Usage,
+	})
+}
+
+// handleOpenRouterCallback is the PUBLIC return endpoint. It recovers the flow
+// from the single-use state, exchanges the code+verifier for the user key, and
+// stores it as the "openrouter" gateway via the existing secret-file store. On
+// success it redirects to the dashboard with ?openrouter=connected.
+func (s *Server) handleOpenRouterCallback(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	code := strings.TrimSpace(q.Get("code"))
+	state := strings.TrimSpace(q.Get("state"))
+	if code == "" || state == "" {
+		s.redirectOpenRouter(w, r, openRouterErrorFlag)
+		return
+	}
+
+	flow, ok := s.openRouterState().Consume(state)
+	if !ok {
+		// Unknown / expired / replayed state — reject.
+		s.redirectOpenRouter(w, r, openRouterErrorFlag)
+		return
+	}
+
+	// Bind to the hive the flow was started for: on the spoke this is always
+	// self, but the check makes a code un-redeemable against a different hive.
+	if s.deps != nil && s.deps.Config != nil && flow.HiveID != "" && flow.HiveID != s.deps.Config.HiveID {
+		s.logger.Warn("openrouter callback hive mismatch", "flow_hive", flow.HiveID, "self", s.deps.Config.HiveID)
+		s.redirectOpenRouter(w, r, openRouterErrorFlag)
+		return
+	}
+
+	key, err := openrouter.ExchangeCode(code, flow.Verifier)
+	if err != nil {
+		// Never echo the key material; ExchangeCode errors carry only OpenRouter
+		// status text, but log at warn without the code/verifier.
+		s.logger.Warn("openrouter key exchange failed", "error", err.Error())
+		s.redirectOpenRouter(w, r, openRouterErrorFlag)
+		return
+	}
+
+	model := flow.Model
+	if model == "" {
+		model = openrouter.DefaultModel
+	}
+	if err := s.upsertOpenRouterGateway(key, model); err != nil {
+		s.logger.Error("failed to store openrouter gateway", "error", err.Error())
+		s.redirectOpenRouter(w, r, openRouterErrorFlag)
+		return
+	}
+	s.auditFromRequest(r, "openrouter_connect_complete", auditDetail("model", model), "")
+	s.redirectOpenRouter(w, r, openRouterConnectedFlag)
+}
+
+// upsertOpenRouterGateway stores the received key VALUE via the existing
+// per-gateway secret-file store (storeGatewayAPIKey) and upserts a gateway named
+// "openrouter" (kind=openrouter, endpoint=OpenRouter base, api_key_file=<path>,
+// default_model=<model>). Only the file PATH is recorded in hive.yaml — the key
+// value never enters config, logs, or API responses. This deliberately reuses
+// the same secret-file scheme as the Model Gateways manager (no new secret path).
+func (s *Server) upsertOpenRouterGateway(key, model string) error {
+	path, err := s.storeGatewayAPIKey(openRouterGatewayName, key)
+	if err != nil {
+		return fmt.Errorf("store key: %w", err)
+	}
+
+	cfg := s.deps.Config
+	gws := append([]config.GatewayConfig(nil), cfg.Governor.Gateways...)
+	idx := -1
+	for i := range gws {
+		if strings.EqualFold(gws[i].Name, openRouterGatewayName) {
+			idx = i
+			break
+		}
+	}
+	gw := config.GatewayConfig{
+		Name:         openRouterGatewayName,
+		Kind:         config.GatewayKindOpenRouter,
+		Endpoint:     openrouter.BaseURL,
+		APIKeyFile:   path,
+		DefaultModel: model,
+	}
+	if idx >= 0 {
+		// Preserve any operator-set env/CA fields on re-fund; only the key file
+		// and default model are (re)written by the funding flow.
+		gw.APIKeyEnv = gws[idx].APIKeyEnv
+		gw.CABundle = gws[idx].CABundle
+		gws[idx] = gw
+	} else {
+		gws = append(gws, gw)
+	}
+	cfg.Governor.Gateways = gws
+
+	if err := s.saveConfig(); err != nil {
+		s.logger.Error("failed to persist config after openrouter gateway upsert", "error", err)
+	}
+	s.registerGatewayEndpoints()
+	s.refreshAndPersist()
+	return nil
+}
+
+// ApplyDeliveredGateway stores a gateway the HUB funded on this spoke's behalf
+// and delivered over the heartbeat channel. It reuses the same secret-file store
+// + gateway-upsert path as the local funding flow, so the delivered key is
+// written to an owner-only PVC file and only its path enters hive.yaml. Idempotent:
+// re-delivery of the same gateway just re-writes the file and default model.
+// Returns an error only on a store/persist failure. The key value is never logged.
+func (s *Server) ApplyDeliveredGateway(name, kind, endpoint, defaultModel, key string) error {
+	// The current funding flow only mints "openrouter" gateways; guard the name
+	// so a delivered payload cannot create an arbitrarily-named gateway.
+	if !strings.EqualFold(name, openRouterGatewayName) {
+		return fmt.Errorf("unsupported delivered gateway %q", name)
+	}
+	if strings.TrimSpace(key) == "" {
+		return fmt.Errorf("delivered gateway has no key")
+	}
+	model := strings.TrimSpace(defaultModel)
+	if model == "" {
+		model = openrouter.DefaultModel
+	}
+	if err := s.upsertOpenRouterGateway(key, model); err != nil {
+		return err
+	}
+	s.logger.Info("applied hub-delivered openrouter gateway", "default_model", model)
+	return nil
+}
+
+// resolveOpenRouterKey returns the stored openrouter gateway's key value (from
+// its secret file), or "" when no openrouter gateway is configured. Used only
+// for the credit proxy — the value is never returned to a client.
+func (s *Server) resolveOpenRouterKey() string {
+	if s.deps == nil || s.deps.Config == nil {
+		return ""
+	}
+	gw := s.deps.Config.Governor.ResolveGateway(openRouterGatewayName)
+	if gw == nil {
+		return ""
+	}
+	return gw.ResolveAPIKey()
+}
+
+// redirectOpenRouter sends the browser back to the dashboard root with a status
+// flag the UI reads to show connected/error.
+func (s *Server) redirectOpenRouter(w http.ResponseWriter, r *http.Request, flag string) {
+	http.Redirect(w, r, "/"+flag, http.StatusFound)
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/agent"
 	"github.com/kubestellar/hive/v2/pkg/github"
 	"github.com/kubestellar/hive/v2/pkg/hub"
+	"github.com/kubestellar/hive/v2/pkg/openrouter"
 )
 
 //go:embed static
@@ -84,6 +85,12 @@ type Server struct {
 	claudeOAuthFlow claudeOAuthFlow
 
 	copilotAuthFlow copilotAuthFlow
+
+	// openRouterStateStore holds in-progress OpenRouter "scan-to-fund" PKCE
+	// flows (single-use state → verifier/hive/model). Lazily initialized via
+	// openRouterState() so the zero-value Server needs no constructor change.
+	openRouterStateOnce  sync.Once
+	openRouterStateStore *openrouter.StateStore
 
 	audit *AuditLog
 
@@ -649,6 +656,12 @@ func isPublicPath(path string) bool {
 	case strings.HasPrefix(path, "/api/leaderboard"):
 		return true
 	case strings.HasPrefix(path, "/api/gh-user-auth/"):
+		return true
+	case path == openRouterCallbackPath:
+		// OpenRouter OAuth PKCE return: the sponsor's browser comes back with no
+		// session, so the path must be public. The single-use state token in the
+		// query IS the credential — the handler verifies it (unknown/expired/
+		// replayed states are rejected) before storing anything.
 		return true
 	case path == "/sso":
 		// SSO handoff exchange: the caller has no session yet, the signed hub

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -9567,6 +9567,22 @@ function burnAreaChart() {
         const chevron = document.getElementById('advisory-digest-main-chevron');
         if (chevron) chevron.classList.add('collapsed');
       }
+      /* OpenRouter scan-to-fund return: show the result and clear the flag so a
+         reload doesn't re-toast. */
+      try {
+        const p = new URLSearchParams(window.location.search);
+        const or = p.get('openrouter');
+        if (or === 'connected') {
+          showToast('OpenRouter connected — the "openrouter" gateway is now configured', 'success');
+        } else if (or === 'error') {
+          showToast('OpenRouter connection failed — please try funding again', 'error');
+        }
+        if (or) {
+          p.delete('openrouter');
+          const qs = p.toString();
+          history.replaceState(null, '', window.location.pathname + (qs ? '?' + qs : ''));
+        }
+      } catch (e) { /* non-fatal */ }
     });
 
     // ── Debug section ──
@@ -11996,11 +12012,120 @@ function burnAreaChart() {
           uses a gateway by naming it as its backend. Keys are stored privately on this
           hive — never in hive.yaml, logs, or config downloads.
         </div>
-        <div style="margin-bottom:12px">
+        <div style="margin-bottom:12px;display:flex;gap:8px;flex-wrap:wrap">
           <button onclick="openGatewayForm()" style="padding:7px 16px;border:none;border-radius:6px;background:var(--cyan);color:var(--bg);cursor:pointer;font-weight:600;font-size:0.8rem">+ Add gateway</button>
+          <button onclick="openOpenRouterFund()" style="padding:7px 16px;border:1px solid var(--cyan);border-radius:6px;background:transparent;color:var(--cyan);cursor:pointer;font-weight:600;font-size:0.8rem">⚡ Fund this hive with OpenRouter</button>
         </div>
+        <div id="openrouter-fund-host"></div>
         <div id="gateways-form-host"></div>
         <div id="gateways-list-host"><div style="color:var(--muted);font-size:0.8rem">Loading gateways…</div></div>`;
+    }
+
+    // ---- OpenRouter scan-to-fund -------------------------------------------
+    // Fund THIS hive: pick a default model, then scan a QR (or click the link)
+    // to authorize on openrouter.ai via OAuth PKCE. On return the hive stores a
+    // scoped OpenRouter key as the "openrouter" gateway. The QR image is a
+    // same-origin Go-generated PNG (CSP-clean). We poll /api/openrouter/credit
+    // to detect the connected key and show remaining credit.
+    let _openrouterPoll = null;
+
+    async function openOpenRouterFund() {
+      const host = document.getElementById('openrouter-fund-host');
+      if (!host) return;
+      // Curated + live model options for the picker.
+      let models = { suggested: [], models: [], default: '' };
+      try {
+        const r = await fetch('/api/openrouter/models');
+        if (r.ok) models = await r.json();
+      } catch (e) { /* fall back to manual entry */ }
+      const sug = (models.suggested || []);
+      const opts = sug.map(m => `<option value="${esc(m.id)}">${esc(m.label)}</option>`).join('')
+        + `<option value="__manual__">Enter a model id manually…</option>`;
+      host.innerHTML = `
+        <div style="border:1px solid var(--cyan);border-radius:8px;padding:14px;margin-bottom:12px;background:var(--surface)">
+          <div style="font-weight:600;font-size:0.9rem;margin-bottom:4px">⚡ Fund this hive with OpenRouter</div>
+          <div style="font-size:0.76rem;color:var(--muted);margin-bottom:10px">Scan the QR (or open the link) to authorize on OpenRouter. A scoped key funded from your OpenRouter credits is stored as the <code>openrouter</code> gateway — the key never leaves this hive.</div>
+          <label style="display:block;font-size:0.74rem;color:var(--muted);margin-bottom:4px">Default model for the new gateway</label>
+          <select id="or-model-select" onchange="orModelSelectChange()" style="width:100%;padding:7px;background:var(--bg);color:var(--fg);border:1px solid var(--border);border-radius:6px;margin-bottom:8px">${opts}</select>
+          <input id="or-model-manual" placeholder="e.g. anthropic/claude-opus-4.8" style="display:none;width:100%;padding:7px;background:var(--bg);color:var(--fg);border:1px solid var(--border);border-radius:6px;margin-bottom:8px;box-sizing:border-box">
+          <div style="display:flex;gap:8px;margin-top:4px">
+            <button onclick="orStartFlow()" style="padding:7px 16px;border:none;border-radius:6px;background:var(--cyan);color:var(--bg);cursor:pointer;font-weight:600;font-size:0.8rem">Generate QR</button>
+            <button onclick="closeOpenRouterFund()" style="padding:7px 16px;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--fg);cursor:pointer;font-size:0.8rem">Cancel</button>
+          </div>
+          <div id="or-qr-area" style="margin-top:12px"></div>
+          <div id="or-status" style="margin-top:8px;font-size:0.78rem"></div>
+        </div>`;
+    }
+
+    function orModelSelectChange() {
+      const sel = document.getElementById('or-model-select');
+      const man = document.getElementById('or-model-manual');
+      if (!sel || !man) return;
+      man.style.display = sel.value === '__manual__' ? 'block' : 'none';
+    }
+
+    function orChosenModel() {
+      const sel = document.getElementById('or-model-select');
+      if (!sel) return '';
+      if (sel.value === '__manual__') {
+        const man = document.getElementById('or-model-manual');
+        return (man && man.value.trim()) || '';
+      }
+      return sel.value;
+    }
+
+    async function orStartFlow() {
+      const model = orChosenModel();
+      const qrArea = document.getElementById('or-qr-area');
+      const status = document.getElementById('or-status');
+      if (qrArea) qrArea.innerHTML = '<span style="color:var(--muted);font-size:0.78rem">Preparing…</span>';
+      try {
+        const res = await fetch('/api/openrouter/connect/start?model=' + encodeURIComponent(model));
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        const data = await res.json();
+        const authURL = data.authorize_url;
+        const qrSrc = '/api/openrouter/qr?data=' + encodeURIComponent(authURL);
+        if (qrArea) qrArea.innerHTML = `
+          <div style="display:flex;gap:16px;align-items:center;flex-wrap:wrap">
+            <img src="${esc(qrSrc)}" alt="OpenRouter QR" width="180" height="180" style="border:6px solid #fff;border-radius:8px;background:#fff">
+            <div style="font-size:0.78rem">
+              <div style="margin-bottom:6px">Scan with your phone, or on this device:</div>
+              <a href="${esc(authURL)}" target="_blank" rel="noopener" style="color:var(--cyan);font-weight:600">Open OpenRouter authorization ↗</a>
+            </div>
+          </div>`;
+        if (status) status.innerHTML = '<span style="color:var(--muted)">Waiting for authorization… this panel updates when the key is connected.</span>';
+        orStartCreditPolling();
+      } catch (e) {
+        if (qrArea) qrArea.innerHTML = `<span style="color:var(--red);font-size:0.78rem">Failed to start: ${esc(e.message)}</span>`;
+      }
+    }
+
+    function orStartCreditPolling() {
+      if (_openrouterPoll) clearInterval(_openrouterPoll);
+      const OR_POLL_MS = 4000;
+      _openrouterPoll = setInterval(orCheckCredit, OR_POLL_MS);
+    }
+
+    async function orCheckCredit() {
+      const status = document.getElementById('or-status');
+      try {
+        const res = await fetch('/api/openrouter/credit');
+        if (!res.ok) return;
+        const d = await res.json();
+        if (!d.connected) return;
+        if (_openrouterPoll) { clearInterval(_openrouterPoll); _openrouterPoll = null; }
+        let creditLine = '';
+        if (d.limit_remaining != null) creditLine = ' — $' + Number(d.limit_remaining).toFixed(2) + ' remaining';
+        else if (d.limit == null) creditLine = ' — unlimited';
+        if (status) status.innerHTML = '<span style="color:var(--green);font-weight:600">✓ Connected' + esc(creditLine) + '</span>';
+        loadGateways();
+      } catch (e) { /* keep polling */ }
+    }
+
+    function closeOpenRouterFund() {
+      if (_openrouterPoll) { clearInterval(_openrouterPoll); _openrouterPoll = null; }
+      const host = document.getElementById('openrouter-fund-host');
+      if (host) host.innerHTML = '';
     }
 
     async function loadGateways() {

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -199,6 +199,7 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 	var onSwitchBranch SwitchBranchCallback
 	var onAuthorizedUsers AuthorizedUsersCallback
 	var onProjectConfig ProjectConfigCallback
+	var onGatewayConfig GatewayConfigCallback
 	for _, cb := range callbacks {
 		switch fn := cb.(type) {
 		case UpgradeCallback:
@@ -215,6 +216,8 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 			onAuthorizedUsers = fn
 		case ProjectConfigCallback:
 			onProjectConfig = fn
+		case GatewayConfigCallback:
+			onGatewayConfig = fn
 		}
 	}
 
@@ -251,6 +254,12 @@ func StartHeartbeat(ctx context.Context, hubURL string, collect StatusCollector,
 		// claimed project (placeholder assignment); nil means leave it alone.
 		if resp.ProjectConfig != nil && onProjectConfig != nil {
 			onProjectConfig(resp.ProjectConfig)
+		}
+		// A non-nil PendingGateway means the hub funded a gateway on this spoke's
+		// behalf (OpenRouter scan-to-fund). The spoke stores the key locally and
+		// creates/replaces the gateway.
+		if resp.PendingGateway != nil && onGatewayConfig != nil {
+			onGatewayConfig(resp.PendingGateway)
 		}
 	}
 
@@ -453,6 +462,30 @@ type HeartbeatProjectConfig struct {
 	ACMMLevel   int      `json:"acmm_level"`
 }
 
+// HeartbeatGatewayConfig carries an OpenRouter model gateway (funded via the
+// hub's scan-to-fund flow) from the hub to a spoke via the heartbeat response.
+// It mirrors HeartbeatProjectConfig: for a firewalled/heartbeat-only spoke
+// (vllm-d) the hub cannot POST to the spoke's dashboard over the network, so it
+// delivers the gateway in the heartbeat response and the spoke stores the key in
+// its OWN per-gateway secret-file store. The Key is a secret VALUE — it travels
+// only over the TLS heartbeat channel, is never logged, and the spoke writes it
+// to a file (never hive.yaml).
+type HeartbeatGatewayConfig struct {
+	Name         string `json:"name"`
+	Kind         string `json:"kind"`
+	Endpoint     string `json:"endpoint"`
+	DefaultModel string `json:"default_model,omitempty"`
+	// Key is the funded API key VALUE. The spoke stores it via its secret-file
+	// store and records only the file path in hive.yaml.
+	Key string `json:"key"`
+}
+
+// GatewayConfigCallback is called when the hub delivers a funded model gateway
+// (e.g. OpenRouter) via the heartbeat response so the spoke can store the key
+// and create/replace the gateway. Used for heartbeat-only clusters the hub
+// cannot reach over the network (mirrors ProjectConfigCallback).
+type GatewayConfigCallback func(cfg *HeartbeatGatewayConfig)
+
 // HeartbeatResponse is the JSON body returned by the hub's heartbeat endpoint.
 // It includes version info so the spoke can display hub version on its dashboard
 // and self-upgrade when behind.
@@ -487,6 +520,12 @@ type HeartbeatResponse struct {
 	// project config alone. This is the ONLY delivery channel for heartbeat-only
 	// clusters (vllm-d) the hub cannot reach over kubectl.
 	ProjectConfig *HeartbeatProjectConfig `json:"project_config,omitempty"`
+	// PendingGateway carries a funded model gateway (OpenRouter scan-to-fund) the
+	// hub minted on the spoke's behalf. It is the delivery channel for
+	// firewalled/heartbeat-only spokes (vllm-d) the hub cannot POST to directly.
+	// nil means "nothing to deliver". The hub sends it once (drained on delivery)
+	// rather than every beat, since it carries a secret key value.
+	PendingGateway *HeartbeatGatewayConfig `json:"pending_gateway,omitempty"`
 }
 
 // HubBanner is a message from the hub admin displayed on spoke dashboards.

--- a/v2/pkg/hub/openrouter.go
+++ b/v2/pkg/hub/openrouter.go
@@ -1,0 +1,252 @@
+package hub
+
+// OpenRouter "scan-to-fund" flow (hub side).
+//
+// From My Hives, an owner/admin funds a SPECIFIC hive: they pick a default model
+// and scan a QR (or click a link) that starts an OpenRouter OAuth PKCE flow on
+// the hub. On return, the hub exchanges the code for a user-controlled OpenRouter
+// API key and delivers it to the target hive as a model gateway named
+// "openrouter" via the heartbeat channel (the only channel that reaches
+// firewalled/heartbeat-only spokes like vllm-d uniformly). The spoke stores the
+// key in its OWN per-gateway secret-file store — the hub never persists the key.
+//
+// SECURITY:
+//   - PKCE S256; the code_verifier NEVER leaves the hub.
+//   - state is single-use + short-lived; the callback binds to the stored
+//     hive_id, so a code cannot fund a different hive.
+//   - start is gated to the owner/admin of the target hive.
+//   - callback_url is the hub's own fixed origin (never client-supplied).
+//   - the funded key travels only over the TLS heartbeat channel and is drained
+//     on delivery; it is never logged, echoed, or stored on the hub.
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/kubestellar/hive/v2/pkg/openrouter"
+)
+
+const (
+	// hubBaseURL is the hub's own public origin, used to build the OAuth
+	// callback_url server-side (never accepted from the client). Matches the
+	// hardcoded origin used elsewhere in the hub (cookies, redirect_uri).
+	hubBaseURL = "https://hive.kubestellar.io"
+	// hubOpenRouterCallbackPath is the hub's PUBLIC OAuth return path.
+	hubOpenRouterCallbackPath = "/openrouter/callback"
+	// hubOpenRouterGatewayName is the gateway name a funded key is delivered as.
+	hubOpenRouterGatewayName = "openrouter"
+	// hubOpenRouterConnected / hubOpenRouterError are the dashboard redirect
+	// flags the My Hives UI reads to show success/failure.
+	hubOpenRouterConnected = "/dashboard?openrouter=connected"
+	hubOpenRouterError     = "/dashboard?openrouter=error"
+)
+
+// registerOpenRouterRoutes registers the hub-side OpenRouter funding routes.
+// start/qr/credit are owner/admin-gated (requireAuth + per-hive role check);
+// the callback is PUBLIC (the returning browser's state token is the credential).
+func (s *HubServer) registerOpenRouterRoutes() {
+	s.mux.HandleFunc("GET /api/openrouter/connect/start", s.requireAuth(s.handleHubOpenRouterStart))
+	s.mux.HandleFunc("GET /api/openrouter/qr", s.requireAuth(s.handleHubOpenRouterQR))
+	s.mux.HandleFunc("GET /api/openrouter/models", s.requireAuth(s.handleHubOpenRouterModels))
+	s.mux.HandleFunc("GET /api/openrouter/credit", s.requireAuth(s.handleHubOpenRouterCredit))
+	s.mux.HandleFunc("GET "+hubOpenRouterCallbackPath, s.handleHubOpenRouterCallback)
+}
+
+// openRouterState returns the lazily-initialized single-use PKCE state store.
+func (s *HubServer) openRouterState() *openrouter.StateStore {
+	s.openRouterStateOnce.Do(func() {
+		s.openRouterStateStore = openrouter.NewStateStore(openrouter.StateTTL)
+	})
+	return s.openRouterStateStore
+}
+
+// ownsHiveForFunding reports whether username may fund hiveID (its owner, a
+// read-write grantee, or the hub admin). Funding stores a spend-capable key on
+// the hive, so it is restricted to those who administer the hive.
+func (s *HubServer) ownsHiveForFunding(username, hiveID string) bool {
+	if username == hubAdminUsername {
+		return true
+	}
+	h := loadSaaSHive(hiveID)
+	if h != nil && strings.EqualFold(h.Owner, username) {
+		return true
+	}
+	if u := loadSaaSUser(username); u != nil {
+		if role, ok := u.Hives[hiveID]; ok && (role == "owner" || role == "read-write") {
+			return true
+		}
+	}
+	return false
+}
+
+// handleHubOpenRouterStart begins a PKCE funding flow for ?hive_id=<id> (with an
+// optional ?model=). It is gated to the owner/admin of that hive. It records the
+// single-use state (bound to the hive + model) and returns the authorize URL.
+func (s *HubServer) handleHubOpenRouterStart(w http.ResponseWriter, r *http.Request) {
+	hiveID := strings.TrimSpace(r.URL.Query().Get("hive_id"))
+	model := strings.TrimSpace(r.URL.Query().Get("model"))
+	if hiveID == "" {
+		http.Error(w, `{"error":"hive_id is required"}`, http.StatusBadRequest)
+		return
+	}
+	username := s.getAuthUser(r)
+	if !s.ownsHiveForFunding(username, hiveID) {
+		http.Error(w, `{"error":"only the hive owner can fund it"}`, http.StatusForbidden)
+		return
+	}
+
+	verifier, challenge, err := openrouter.GeneratePKCE()
+	if err != nil {
+		http.Error(w, `{"error":"failed to start flow"}`, http.StatusInternalServerError)
+		return
+	}
+	state, err := s.openRouterState().Create(verifier, hiveID, model)
+	if err != nil {
+		http.Error(w, `{"error":"failed to start flow"}`, http.StatusInternalServerError)
+		return
+	}
+	authURL, err := openrouter.BuildAuthorizeURL(hubBaseURL+hubOpenRouterCallbackPath, challenge, state)
+	if err != nil {
+		http.Error(w, `{"error":"failed to build authorize URL"}`, http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{"authorize_url": authURL, "state": state})
+}
+
+// handleHubOpenRouterQR renders a QR PNG for ?data=<authorize_url>. Same-origin
+// PNG so the hub CSP stays clean. Only openrouter.ai/auth URLs are accepted.
+func (s *HubServer) handleHubOpenRouterQR(w http.ResponseWriter, r *http.Request) {
+	data := r.URL.Query().Get("data")
+	if !strings.HasPrefix(data, openrouter.AuthURL) {
+		http.Error(w, "data must be an OpenRouter authorize URL", http.StatusBadRequest)
+		return
+	}
+	png, err := openrouter.QRPNG(data)
+	if err != nil {
+		http.Error(w, "failed to render QR", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "image/png")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Write(png)
+}
+
+// handleHubOpenRouterModels returns the curated suggested list + OpenRouter's live
+// model catalog so the funding modal's picker can offer options and manual entry.
+func (s *HubServer) handleHubOpenRouterModels(w http.ResponseWriter, r *http.Request) {
+	live := fetchOpenRouterModels()
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"suggested": openrouter.SuggestedModels,
+		"models":    live,
+		"default":   openrouter.DefaultModel,
+	})
+}
+
+// handleHubOpenRouterCredit reports whether the hub currently holds an undelivered
+// funded gateway for ?hive_id=<id> (i.e. the fund completed but the spoke has not
+// yet drained it on a heartbeat). Once delivered, credit is shown on the spoke's
+// own dashboard against its stored key — the hub does not keep the key, so it
+// cannot proxy /v1/key here. Owner/admin gated.
+func (s *HubServer) handleHubOpenRouterCredit(w http.ResponseWriter, r *http.Request) {
+	hiveID := strings.TrimSpace(r.URL.Query().Get("hive_id"))
+	if hiveID == "" {
+		http.Error(w, `{"error":"hive_id is required"}`, http.StatusBadRequest)
+		return
+	}
+	username := s.getAuthUser(r)
+	if !s.ownsHiveForFunding(username, hiveID) {
+		http.Error(w, `{"error":"only the hive owner can view funding"}`, http.StatusForbidden)
+		return
+	}
+	pendingDelivery := s.hasPendingGateway(hiveID)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"pending_delivery": pendingDelivery,
+	})
+}
+
+// handleHubOpenRouterCallback is the PUBLIC OAuth return. It recovers the flow
+// from the single-use state, exchanges the code for the user key, and queues the
+// funded gateway for delivery to the bound hive over the next heartbeat. On
+// success it redirects to My Hives with ?openrouter=connected.
+func (s *HubServer) handleHubOpenRouterCallback(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	code := strings.TrimSpace(q.Get("code"))
+	state := strings.TrimSpace(q.Get("state"))
+	if code == "" || state == "" {
+		http.Redirect(w, r, hubOpenRouterError, http.StatusFound)
+		return
+	}
+	flow, ok := s.openRouterState().Consume(state)
+	if !ok {
+		http.Redirect(w, r, hubOpenRouterError, http.StatusFound)
+		return
+	}
+	if flow.HiveID == "" {
+		http.Redirect(w, r, hubOpenRouterError, http.StatusFound)
+		return
+	}
+
+	key, err := openrouter.ExchangeCode(code, flow.Verifier)
+	if err != nil {
+		s.logger.Warn("hub openrouter key exchange failed", "hive_id", flow.HiveID, "error", err.Error())
+		http.Redirect(w, r, hubOpenRouterError, http.StatusFound)
+		return
+	}
+	model := flow.Model
+	if model == "" {
+		model = openrouter.DefaultModel
+	}
+	s.queuePendingGateway(flow.HiveID, &HeartbeatGatewayConfig{
+		Name:         hubOpenRouterGatewayName,
+		Kind:         "openrouter",
+		Endpoint:     openrouter.BaseURL,
+		DefaultModel: model,
+		Key:          key,
+	})
+	s.logger.Info("hub openrouter fund complete; queued gateway for delivery",
+		"hive_id", flow.HiveID, "default_model", model)
+	http.Redirect(w, r, hubOpenRouterConnected, http.StatusFound)
+}
+
+// queuePendingGateway stores a funded gateway for delivery to hiveID over the
+// next heartbeat.
+func (s *HubServer) queuePendingGateway(hiveID string, gw *HeartbeatGatewayConfig) {
+	s.pendingGatewaysMu.Lock()
+	defer s.pendingGatewaysMu.Unlock()
+	s.pendingGateways[hiveID] = gw
+}
+
+// takePendingGateway returns and REMOVES the pending gateway for hiveID (drained
+// on delivery so a secret key is sent once, not re-sent every beat), or nil.
+func (s *HubServer) takePendingGateway(hiveID string) *HeartbeatGatewayConfig {
+	s.pendingGatewaysMu.Lock()
+	defer s.pendingGatewaysMu.Unlock()
+	gw, ok := s.pendingGateways[hiveID]
+	if !ok {
+		return nil
+	}
+	delete(s.pendingGateways, hiveID)
+	return gw
+}
+
+// hasPendingGateway reports whether a funded gateway is queued but not yet
+// delivered for hiveID.
+func (s *HubServer) hasPendingGateway(hiveID string) bool {
+	s.pendingGatewaysMu.Lock()
+	defer s.pendingGatewaysMu.Unlock()
+	_, ok := s.pendingGateways[hiveID]
+	return ok
+}
+
+// fetchOpenRouterModels best-effort fetches OpenRouter's public /v1/models list
+// for the funding picker. Failure returns nil (the UI falls back to the curated
+// list + manual entry).
+func fetchOpenRouterModels() []string {
+	// Reuse the shared lenient decoder path indirectly: a tiny inline GET keeps
+	// the hub free of a dashboard import. No key needed — /v1/models is public.
+	return openrouter.PublicModelIDs()
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -5338,6 +5338,7 @@ const dashboardHTML = `<!DOCTYPE html>
         if (menuItems.length > 0 && (canConvert || isHosted || isLocal)) menuItems.push('<div style="border-top:1px solid #30363d;margin:4px 0"></div>');
         if (canConvert) menuItems.push('<div onclick="openConvert(this)" data-hive-id="' + esc(h.id) + '" data-dash-url="' + esc(h.dashboardUrl||'') + '" data-org="' + esc(h.org) + '" data-repos="' + esc((h.repos||[]).join(', ')) + '" data-primary="' + esc(h.primaryRepo) + '" data-level="' + (h.acmmLevel||1) + '" data-name="' + esc(h.name||'') + '" style="' + mi + '">Convert to Hosted</div>');
         if (isHosted && (h.role === 'owner' || h.role === 'read-write')) menuItems.push('<div onclick="openAccessModal(\'' + esc(h.id) + '\')" style="' + mi + '">Permissions</div>');
+        if (h.role === 'owner' || h.role === 'read-write' || _isAdmin) menuItems.push('<div onclick="openOpenRouterFundModal(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">⚡ Fund with OpenRouter</div>');
         if (_isAdmin && isHosted) menuItems.push('<div onclick="openBannerForHive(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">Send Banner</div>');
         if (isLocal && h.role === 'owner') menuItems.push('<div onclick="removeLocalHive(\'' + esc(h.id) + '\')" style="' + mi + '">Remove</div>');
         if (isHosted && h.role === 'owner' && _clusterList && _clusterList.length > 1 && h.migrationStatus !== 'migrating') menuItems.push('<div onclick="openMigrateModal(\'' + esc(h.id) + '\',\'' + esc(h.clusterId || '') + '\')" style="' + mi + '">Move to cluster</div>');
@@ -6154,6 +6155,22 @@ const dashboardHTML = `<!DOCTYPE html>
       } catch(e) { /* cluster dropdown stays at default */ }
     }
 
+    // OpenRouter scan-to-fund return: toast the result and clear the query flag
+    // so a reload doesn't re-toast.
+    function handleOpenRouterReturn() {
+      try {
+        var p = new URLSearchParams(window.location.search);
+        var or = p.get('openrouter');
+        if (or === 'connected') hiveToast('OpenRouter funded — the key is being delivered to the hive', 'success');
+        else if (or === 'error') hiveToast('OpenRouter funding failed — please try again', 'error');
+        if (or) {
+          p.delete('openrouter');
+          var qs = p.toString();
+          history.replaceState(null, '', window.location.pathname + (qs ? '?' + qs : ''));
+        }
+      } catch (e) { /* non-fatal */ }
+    }
+
     async function init() {
       await loadUser();
       await autoRequestAccessFromUrl();
@@ -6162,6 +6179,7 @@ const dashboardHTML = `<!DOCTYPE html>
       if (!_adminLoaded) setTimeout(loadAdminUsers, 2000);
       loadClusterHealth();
       loadClusters();
+      handleOpenRouterReturn();
     }
     init();
     var POLL_INTERVAL_MS = 30000;
@@ -6504,6 +6522,100 @@ const dashboardHTML = `<!DOCTYPE html>
         hiveToast('Error: ' + e.message, 'error');
         if (submit) { submit.disabled = false; submit.textContent = 'Assign'; }
       }
+    }
+
+    // ---- OpenRouter scan-to-fund (hub side) ---------------------------------
+    // Fund a SPECIFIC hive: pick a default model, scan a QR (or open the link)
+    // to authorize on OpenRouter. The hub exchanges the code for a scoped key and
+    // delivers it to the hive as the "openrouter" gateway over the next heartbeat.
+    var _orFundPoll = null;
+    async function openOpenRouterFundModal(hiveId, hiveName) {
+      var models = { suggested: [], models: [], default: '' };
+      try {
+        var r = await fetch('/api/openrouter/models');
+        if (r.ok) models = await r.json();
+      } catch (e) { /* fall back to manual entry */ }
+      var opts = (models.suggested || []).map(function(m) {
+        return '<option value="' + esc(m.id) + '">' + esc(m.label) + '</option>';
+      }).join('') + '<option value="__manual__">Enter a model id manually…</option>';
+      var fld = 'width:100%;padding:8px;background:var(--surface);color:var(--fg);border:1px solid var(--border);border-radius:6px;box-sizing:border-box';
+      var content =
+        '<div style="font-size:0.8rem;color:var(--muted);margin-bottom:10px">Fund <strong style="color:var(--fg)">' + esc(hiveName) + '</strong> with an OpenRouter key. Scan the QR (or open the link) to authorize on OpenRouter — the scoped key is delivered to the hive as its <code>openrouter</code> gateway.</div>' +
+        '<label style="display:block;font-size:0.75rem;color:var(--muted);margin-bottom:4px">Default model</label>' +
+        '<select id="orf-model" onchange="orfModelChange()" style="' + fld + ';margin-bottom:8px">' + opts + '</select>' +
+        '<input id="orf-model-manual" placeholder="e.g. anthropic/claude-opus-4.8" style="display:none;' + fld + ';margin-bottom:8px">' +
+        '<div style="display:flex;gap:8px;margin-top:4px">' +
+        '<button onclick="orfStart(\'' + esc(hiveId) + '\')" style="padding:7px 16px;background:var(--accent,#58a6ff);color:#000;border:none;border-radius:6px;cursor:pointer;font-weight:600">Generate QR</button>' +
+        '<button onclick="closeOrFundModal()" style="padding:7px 16px;background:var(--surface);color:var(--fg);border:1px solid var(--border);border-radius:6px;cursor:pointer">Close</button>' +
+        '</div>' +
+        '<div id="orf-qr" style="margin-top:12px"></div>' +
+        '<div id="orf-status" style="margin-top:8px;font-size:0.78rem"></div>';
+      var overlay = document.createElement('div');
+      overlay.id = 'orf-overlay';
+      overlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:2000;display:flex;align-items:center;justify-content:center';
+      overlay.innerHTML = '<div style="background:var(--bg);border:1px solid var(--border);border-radius:12px;padding:24px;max-width:460px;width:90%;max-height:88vh;overflow-y:auto">' +
+        '<h3 style="margin:0 0 12px 0;font-size:1rem">⚡ Fund with OpenRouter</h3>' + content + '</div>';
+      overlay.addEventListener('click', function(e) { if (e.target === overlay) closeOrFundModal(); });
+      document.body.appendChild(overlay);
+    }
+    function orfModelChange() {
+      var sel = document.getElementById('orf-model');
+      var man = document.getElementById('orf-model-manual');
+      if (sel && man) man.style.display = sel.value === '__manual__' ? 'block' : 'none';
+    }
+    function orfChosenModel() {
+      var sel = document.getElementById('orf-model');
+      if (!sel) return '';
+      if (sel.value === '__manual__') {
+        var man = document.getElementById('orf-model-manual');
+        return (man && man.value.trim()) || '';
+      }
+      return sel.value;
+    }
+    async function orfStart(hiveId) {
+      var model = orfChosenModel();
+      var qr = document.getElementById('orf-qr');
+      var status = document.getElementById('orf-status');
+      if (qr) qr.innerHTML = '<span style="color:var(--muted);font-size:0.78rem">Preparing…</span>';
+      try {
+        var res = await fetch('/api/openrouter/connect/start?hive_id=' + encodeURIComponent(hiveId) + '&model=' + encodeURIComponent(model));
+        if (!res.ok) { var e = await res.json().catch(function(){return{};}); throw new Error(e.error || ('HTTP ' + res.status)); }
+        var data = await res.json();
+        var authURL = data.authorize_url;
+        var qrSrc = '/api/openrouter/qr?data=' + encodeURIComponent(authURL);
+        if (qr) qr.innerHTML =
+          '<div style="display:flex;gap:16px;align-items:center;flex-wrap:wrap">' +
+          '<img src="' + esc(qrSrc) + '" alt="OpenRouter QR" width="180" height="180" style="border:6px solid #fff;border-radius:8px;background:#fff">' +
+          '<div style="font-size:0.78rem"><div style="margin-bottom:6px">Scan with your phone, or on this device:</div>' +
+          '<a href="' + esc(authURL) + '" target="_blank" rel="noopener" style="color:var(--accent,#58a6ff);font-weight:600">Open OpenRouter authorization ↗</a></div></div>';
+        if (status) status.innerHTML = '<span style="color:var(--muted)">Waiting for authorization…</span>';
+        orfStartPolling(hiveId);
+      } catch (e) {
+        if (qr) qr.innerHTML = '<span style="color:#f85149;font-size:0.78rem">Failed: ' + esc(e.message) + '</span>';
+      }
+    }
+    function orfStartPolling(hiveId) {
+      if (_orFundPoll) clearInterval(_orFundPoll);
+      var ORF_POLL_MS = 4000;
+      _orFundPoll = setInterval(function() { orfCheck(hiveId); }, ORF_POLL_MS);
+    }
+    async function orfCheck(hiveId) {
+      var status = document.getElementById('orf-status');
+      try {
+        var res = await fetch('/api/openrouter/credit?hive_id=' + encodeURIComponent(hiveId));
+        if (!res.ok) return;
+        var d = await res.json();
+        // pending_delivery flips true the moment the fund completes on the hub;
+        // it then flips back to false once the hive drains it on a heartbeat.
+        if (d.pending_delivery) {
+          if (status) status.innerHTML = '<span style="color:var(--green,#3fb950);font-weight:600">✓ Funded — delivering to the hive on its next heartbeat…</span>';
+        }
+      } catch (e) { /* keep polling */ }
+    }
+    function closeOrFundModal() {
+      if (_orFundPoll) { clearInterval(_orFundPoll); _orFundPoll = null; }
+      var ov = document.getElementById('orf-overlay');
+      if (ov) ov.remove();
     }
 
     async function removeLocalHive(id) {

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/openrouter"
 )
 
 //go:embed static/*
@@ -175,6 +177,19 @@ type HubServer struct {
 	// heartbeat response. Key: hive ID → banner entry.
 	hubBanners   map[string]*HubBannerEntry
 	hubBannersMu sync.RWMutex
+
+	// pendingGateways stores OpenRouter gateways funded via the hub's
+	// scan-to-fund flow, to deliver to firewalled/heartbeat-only spokes via the
+	// heartbeat response. Key: hive ID → gateway (carries the secret key VALUE,
+	// so it is drained on delivery, never re-sent). In-memory only — an
+	// undelivered fund is retried by the sponsor, not persisted across restarts.
+	pendingGateways   map[string]*HeartbeatGatewayConfig
+	pendingGatewaysMu sync.Mutex
+
+	// openRouterState holds in-progress hub-side OpenRouter PKCE flows
+	// (single-use state → verifier/hive/model). Lazily initialized.
+	openRouterStateOnce  sync.Once
+	openRouterStateStore *openrouter.StateStore
 }
 
 // HubBannerEntry stores an admin banner targeted at a specific hive.
@@ -219,6 +234,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		heartbeatSwitchTag:      make(map[string]string),
 		pendingWebhooks:         make(map[string]*pendingWebhookEntry),
 		pendingGitHubAppConfigs: make(map[string]*HeartbeatGitHubAppConfig),
+		pendingGateways:         make(map[string]*HeartbeatGatewayConfig),
 		hubBanners:              make(map[string]*HubBannerEntry),
 	}
 
@@ -245,6 +261,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 
 	s.registerOAuth()
 	s.registerSaaSRoutes()
+	s.registerOpenRouterRoutes()
 	go s.saveLoop()
 
 	return s
@@ -630,6 +647,15 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			"primary_repo", projCfg.PrimaryRepo,
 			"acmm_level", projCfg.ACMMLevel,
 		)
+	}
+
+	// Deliver a funded OpenRouter gateway to a firewalled/heartbeat-only spoke.
+	// Drained on delivery (carries a secret key value, so it is sent once, not
+	// re-sent every beat). The key value is not logged.
+	if gw := s.takePendingGateway(payload.HiveID); gw != nil {
+		resp.PendingGateway = gw
+		s.logger.Info("heartbeat: delivering funded gateway to spoke",
+			"hive_id", payload.HiveID, "gateway", gw.Name, "default_model", gw.DefaultModel)
 	}
 
 	// Check if the hive should self-upgrade via heartbeat response.

--- a/v2/pkg/openrouter/openrouter.go
+++ b/v2/pkg/openrouter/openrouter.go
@@ -1,0 +1,403 @@
+// Package openrouter implements the OpenRouter OAuth PKCE "scan-to-fund" flow:
+// a sponsor scans a QR (or clicks a link), authorizes on openrouter.ai, and the
+// hive receives a user-controlled, scoped OpenRouter API key which it stores as
+// a model gateway named "openrouter". The key is minted by OpenRouter against
+// the sponsor's own account/credits — the hive never sees the sponsor's login.
+//
+// This package is transport-agnostic: it holds the PKCE crypto, the URL
+// builders, the key-exchange + credit HTTP calls, the QR PNG encoder, and an
+// in-memory single-use state store. The hub and the spoke dashboard both import
+// it and wire it to their own HTTP routes (see pkg/hub and pkg/dashboard).
+//
+// SECURITY MODEL:
+//   - PKCE S256. The code_verifier NEVER leaves the server.
+//   - state is single-use and short-lived (StateTTL); it binds a returning
+//     callback to the hive it was started for, so a code can't fund a
+//     different hive.
+//   - The received key is a secret VALUE — callers store it via the existing
+//     per-gateway secret-file store; it is never logged, echoed, or inlined.
+package openrouter
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"image/png"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	qrcode "github.com/skip2/go-qrcode"
+)
+
+// OpenRouter endpoint constants. All OpenRouter URLs live here as named consts
+// (no magic strings): the base API, the OAuth authorize page, the PKCE
+// key-exchange endpoint, and the key-info (credit) endpoint.
+const (
+	// BaseURL is the OpenAI-compatible base URL a created gateway routes through.
+	BaseURL = "https://openrouter.ai/api/v1"
+	// AuthURL is the OAuth authorize page the sponsor is sent to (via QR/link).
+	AuthURL = "https://openrouter.ai/auth"
+	// KeyExchangeURL trades the returned code + PKCE verifier for the user key.
+	KeyExchangeURL = "https://openrouter.ai/api/v1/auth/keys"
+	// KeyInfoURL returns the current key's credit limit/usage (Bearer-authed).
+	KeyInfoURL = "https://openrouter.ai/api/v1/key"
+)
+
+const (
+	// codeChallengeMethod is the PKCE method. S256 (SHA-256) is required; plain
+	// is never used.
+	codeChallengeMethod = "S256"
+
+	// verifierBytes is the entropy length of the PKCE code_verifier. 32 random
+	// bytes base64url-encode to a 43-char verifier, at the low end of the
+	// RFC 7636 43–128 range and matching the Claude OAuth helper elsewhere.
+	verifierBytes = 32
+
+	// stateBytes is the entropy length of the single-use OAuth state token.
+	stateBytes = 24
+
+	// StateTTL bounds how long a started flow may be completed. A returning
+	// callback after this window is rejected (the sponsor must re-scan). Short
+	// enough to limit replay, long enough for a phone scan + login.
+	StateTTL = 10 * time.Minute
+
+	// keyExchangeTimeout bounds the code→key POST.
+	keyExchangeTimeout = 30 * time.Second
+	// creditTimeout bounds the GET /key credit check.
+	creditTimeout = 15 * time.Second
+	// maxErrBody caps how much of an OpenRouter error body we read/surface.
+	maxErrBody = 4 << 10
+
+	// qrPNGSize is the QR PNG side length in pixels — large enough to scan from
+	// a screen, small enough to inline as a data-URI without bloat.
+	qrPNGSize = 320
+)
+
+// DefaultModel is the gateway default_model used when the sponsor picks none.
+// A cheap, widely-available model so a freshly-funded hive works out of the box
+// without spending on a premium model by accident.
+const DefaultModel = "deepseek/deepseek-chat"
+
+// SuggestedModel is one curated option offered on the funding screen: an id and
+// a short human label. The list is a starting point — the UI also fetches the
+// live model list and allows manual entry.
+type SuggestedModel struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+}
+
+// SuggestedModels is the curated short list shown on the funding screen. It
+// spans a premium option (Claude Opus) and cheaper ones (DeepSeek, Llama), so a
+// sponsor can pick a sensible default without fetching the full catalog. IDs are
+// OpenRouter model ids.
+var SuggestedModels = []SuggestedModel{
+	{ID: "anthropic/claude-opus-4.8", Label: "Claude Opus 4.8 (premium)"},
+	{ID: "anthropic/claude-3.5-sonnet", Label: "Claude 3.5 Sonnet"},
+	{ID: "deepseek/deepseek-chat", Label: "DeepSeek Chat (cheap)"},
+	{ID: "meta-llama/llama-3.3-70b-instruct", Label: "Llama 3.3 70B (cheap)"},
+	{ID: "google/gemini-flash-1.5", Label: "Gemini Flash 1.5 (cheap)"},
+}
+
+// GeneratePKCE creates a random code_verifier and its S256 code_challenge.
+// The verifier is a secret held server-side; only the challenge is sent to
+// OpenRouter.
+func GeneratePKCE() (verifier, challenge string, err error) {
+	buf := make([]byte, verifierBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", "", fmt.Errorf("generate PKCE verifier: %w", err)
+	}
+	verifier = base64.RawURLEncoding.EncodeToString(buf)
+	challenge = ChallengeFor(verifier)
+	return verifier, challenge, nil
+}
+
+// ChallengeFor returns the S256 code_challenge for a given verifier:
+// base64url(sha256(verifier)). Exported so tests can assert the exact
+// transform independently of GeneratePKCE's randomness.
+func ChallengeFor(verifier string) string {
+	h := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(h[:])
+}
+
+// generateState returns a random, URL-safe single-use state token.
+func generateState() (string, error) {
+	buf := make([]byte, stateBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate state: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// BuildAuthorizeURL builds the openrouter.ai/auth URL the sponsor is sent to.
+//
+// callbackURL is THIS server's callback endpoint; the state token is appended
+// to it as a query param so it round-trips even though OpenRouter's spec only
+// echoes the callback_url (it preserves any query already on callback_url). The
+// code_challenge is the S256 challenge; code_challenge_method is always S256.
+func BuildAuthorizeURL(callbackURL, codeChallenge, state string) (string, error) {
+	cb, err := url.Parse(callbackURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid callback url: %w", err)
+	}
+	// Bind state to the callback_url itself so it survives the round-trip.
+	q := cb.Query()
+	q.Set("state", state)
+	cb.RawQuery = q.Encode()
+
+	v := url.Values{
+		"callback_url":          {cb.String()},
+		"code_challenge":        {codeChallenge},
+		"code_challenge_method": {codeChallengeMethod},
+		// Also pass state as a top-level authorize param; harmless if ignored.
+		"state": {state},
+	}
+	return AuthURL + "?" + v.Encode(), nil
+}
+
+// ExchangeCode trades the returned authorization code + the stored PKCE verifier
+// for a user-controlled OpenRouter API key. On success it returns the key VALUE
+// — the caller MUST store it as a secret file and never log or echo it.
+func ExchangeCode(code, verifier string) (string, error) {
+	if code == "" || verifier == "" {
+		return "", fmt.Errorf("missing code or verifier")
+	}
+	body, err := json.Marshal(map[string]string{
+		"code":                  code,
+		"code_verifier":         verifier,
+		"code_challenge_method": codeChallengeMethod,
+	})
+	if err != nil {
+		return "", fmt.Errorf("encode key-exchange body: %w", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, KeyExchangeURL, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("build key-exchange request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: keyExchangeTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("key-exchange request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrBody))
+		return "", fmt.Errorf("openrouter key exchange returned HTTP %d: %s",
+			resp.StatusCode, strings.TrimSpace(string(msg)))
+	}
+
+	var out struct {
+		Key string `json:"key"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxErrBody)).Decode(&out); err != nil {
+		return "", fmt.Errorf("decode key-exchange response: %w", err)
+	}
+	if strings.TrimSpace(out.Key) == "" {
+		return "", fmt.Errorf("openrouter key exchange returned an empty key")
+	}
+	return strings.TrimSpace(out.Key), nil
+}
+
+// Credit is the subset of GET /api/v1/key we surface to the UI. Limit and
+// LimitRemaining are pointers because OpenRouter returns null for an unlimited
+// key; a nil value means "unlimited / not set". The raw key is NEVER included.
+type Credit struct {
+	Label          string   `json:"label,omitempty"`
+	Limit          *float64 `json:"limit"`
+	LimitRemaining *float64 `json:"limit_remaining"`
+	Usage          float64  `json:"usage"`
+}
+
+// FetchCredit calls GET /api/v1/key with the given key and returns its credit
+// limit/usage. The key is used only as a Bearer credential for this call and is
+// never returned in the result.
+func FetchCredit(key string) (*Credit, error) {
+	if strings.TrimSpace(key) == "" {
+		return nil, fmt.Errorf("no key configured")
+	}
+	req, err := http.NewRequest(http.MethodGet, KeyInfoURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build key-info request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+key)
+
+	client := &http.Client{Timeout: creditTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("key-info request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("openrouter key-info returned HTTP %d", resp.StatusCode)
+	}
+	var out struct {
+		Data Credit `json:"data"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxErrBody)).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode key-info response: %w", err)
+	}
+	return &out.Data, nil
+}
+
+// modelsListTimeout bounds the public /v1/models fetch used by the funding
+// picker. Kept short — it's a best-effort enrichment, not on the critical path.
+const modelsListTimeout = 5 * time.Second
+
+// PublicModelIDs best-effort fetches OpenRouter's public model catalog (no key
+// required) and returns the list of model ids. On any failure it returns nil, so
+// callers fall back to the curated SuggestedModels + manual entry. The response
+// is the standard OpenAI-style {data:[{id}]} shape.
+func PublicModelIDs() []string {
+	req, err := http.NewRequest(http.MethodGet, BaseURL+"/models", nil)
+	if err != nil {
+		return nil
+	}
+	client := &http.Client{Timeout: modelsListTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+	var out struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&out); err != nil {
+		return nil
+	}
+	ids := make([]string, 0, len(out.Data))
+	for _, m := range out.Data {
+		if m.ID != "" {
+			ids = append(ids, m.ID)
+		}
+	}
+	return ids
+}
+
+// QRPNG returns a scannable QR code PNG encoding the given text (an authorize
+// URL). It is a pure-Go encoder (no external service, no vendored JS), so the
+// dashboard's CSP stays clean and the image is same-origin.
+func QRPNG(text string) ([]byte, error) {
+	if strings.TrimSpace(text) == "" {
+		return nil, fmt.Errorf("no data to encode")
+	}
+	qr, err := qrcode.New(text, qrcode.Medium)
+	if err != nil {
+		return nil, fmt.Errorf("build QR: %w", err)
+	}
+	img := qr.Image(qrPNGSize)
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		return nil, fmt.Errorf("encode QR PNG: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// PendingFlow is the server-side state for one in-progress funding flow, keyed
+// by its single-use state token. It binds the flow to a specific hive so a
+// returning callback can only fund the hive the flow was started for.
+type PendingFlow struct {
+	Verifier  string
+	HiveID    string
+	Model     string
+	CreatedAt time.Time
+}
+
+// StateStore is an in-memory, single-use, TTL-bounded store of pending flows.
+// A state is created at flow start and consumed (deleted) on callback; a
+// missing, expired, or already-consumed state is rejected. Safe for concurrent
+// use. Nothing here is persisted — an in-flight flow simply doesn't survive a
+// restart, which is acceptable for a 10-minute human-in-the-loop scan.
+type StateStore struct {
+	mu      sync.Mutex
+	flows   map[string]PendingFlow
+	ttl     time.Duration
+	nowFunc func() time.Time
+}
+
+// NewStateStore returns a StateStore with the given TTL (use StateTTL in
+// production).
+func NewStateStore(ttl time.Duration) *StateStore {
+	return &StateStore{
+		flows:   make(map[string]PendingFlow),
+		ttl:     ttl,
+		nowFunc: time.Now,
+	}
+}
+
+// now returns the store's clock (overridable in tests via SetClock).
+func (s *StateStore) now() time.Time {
+	if s.nowFunc != nil {
+		return s.nowFunc()
+	}
+	return time.Now()
+}
+
+// SetClock overrides the store's clock. Test-only; production uses time.Now.
+func (s *StateStore) SetClock(f func() time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nowFunc = f
+}
+
+// Create records a new pending flow for hiveID + model and returns its random,
+// single-use state token. It also opportunistically evicts expired flows so the
+// map does not grow without bound.
+func (s *StateStore) Create(verifier, hiveID, model string) (string, error) {
+	state, err := generateState()
+	if err != nil {
+		return "", err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.evictExpiredLocked()
+	s.flows[state] = PendingFlow{
+		Verifier:  verifier,
+		HiveID:    hiveID,
+		Model:     model,
+		CreatedAt: s.now(),
+	}
+	return state, nil
+}
+
+// Consume looks up and DELETES the flow for state (single-use), returning it
+// only when present and not expired. A missing, expired, or replayed state
+// returns ok=false. Deleting before returning guarantees a code can be redeemed
+// at most once even under concurrent callbacks.
+func (s *StateStore) Consume(state string) (PendingFlow, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	f, ok := s.flows[state]
+	if !ok {
+		return PendingFlow{}, false
+	}
+	delete(s.flows, state)
+	if s.now().Sub(f.CreatedAt) > s.ttl {
+		return PendingFlow{}, false
+	}
+	return f, true
+}
+
+// evictExpiredLocked removes expired flows. Caller must hold s.mu.
+func (s *StateStore) evictExpiredLocked() {
+	cutoff := s.now().Add(-s.ttl)
+	for k, f := range s.flows {
+		if f.CreatedAt.Before(cutoff) {
+			delete(s.flows, k)
+		}
+	}
+}

--- a/v2/pkg/openrouter/openrouter_test.go
+++ b/v2/pkg/openrouter/openrouter_test.go
@@ -1,0 +1,164 @@
+package openrouter
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestChallengeForS256 asserts the exact PKCE S256 transform:
+// code_challenge == base64url-no-pad( sha256( verifier ) ).
+func TestChallengeForS256(t *testing.T) {
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	sum := sha256.Sum256([]byte(verifier))
+	want := base64.RawURLEncoding.EncodeToString(sum[:])
+	if got := ChallengeFor(verifier); got != want {
+		t.Fatalf("ChallengeFor mismatch:\n got=%s\nwant=%s", got, want)
+	}
+}
+
+// TestGeneratePKCE checks the verifier length bounds (RFC 7636: 43–128 chars)
+// and that GeneratePKCE's challenge matches ChallengeFor(verifier).
+func TestGeneratePKCE(t *testing.T) {
+	verifier, challenge, err := GeneratePKCE()
+	if err != nil {
+		t.Fatalf("GeneratePKCE: %v", err)
+	}
+	if len(verifier) < 43 || len(verifier) > 128 {
+		t.Fatalf("verifier length %d out of RFC 7636 range 43..128", len(verifier))
+	}
+	if strings.ContainsAny(verifier, "+/=") {
+		t.Fatalf("verifier is not url-safe (has +/=): %q", verifier)
+	}
+	if challenge != ChallengeFor(verifier) {
+		t.Fatalf("GeneratePKCE challenge does not match ChallengeFor(verifier)")
+	}
+	// Two calls must differ (randomness).
+	v2, _, _ := GeneratePKCE()
+	if verifier == v2 {
+		t.Fatalf("two GeneratePKCE calls produced identical verifiers")
+	}
+}
+
+// TestBuildAuthorizeURL asserts the authorize URL carries the required PKCE
+// params and that state is bound to the callback_url (round-trips).
+func TestBuildAuthorizeURL(t *testing.T) {
+	authURL, err := BuildAuthorizeURL("https://h.example.com/openrouter/callback", "CHAL", "STATE123")
+	if err != nil {
+		t.Fatalf("BuildAuthorizeURL: %v", err)
+	}
+	if !strings.HasPrefix(authURL, AuthURL+"?") {
+		t.Fatalf("authorize URL does not start with %s: %s", AuthURL, authURL)
+	}
+	u, err := url.Parse(authURL)
+	if err != nil {
+		t.Fatalf("parse authorize URL: %v", err)
+	}
+	q := u.Query()
+	if q.Get("code_challenge") != "CHAL" {
+		t.Errorf("code_challenge = %q, want CHAL", q.Get("code_challenge"))
+	}
+	if q.Get("code_challenge_method") != "S256" {
+		t.Errorf("code_challenge_method = %q, want S256", q.Get("code_challenge_method"))
+	}
+	// callback_url must embed the state so it round-trips even if OpenRouter
+	// only echoes callback_url.
+	cbRaw := q.Get("callback_url")
+	cb, err := url.Parse(cbRaw)
+	if err != nil {
+		t.Fatalf("parse callback_url: %v", err)
+	}
+	if cb.Query().Get("state") != "STATE123" {
+		t.Errorf("callback_url state = %q, want STATE123 (state not bound to callback)", cb.Query().Get("state"))
+	}
+}
+
+// TestStateStoreSingleUse verifies that a state can be consumed exactly once:
+// the first Consume succeeds and returns the bound flow; a replay fails.
+func TestStateStoreSingleUse(t *testing.T) {
+	s := NewStateStore(StateTTL)
+	state, err := s.Create("verifier-abc", "hive-1", "deepseek/deepseek-chat")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if state == "" {
+		t.Fatal("Create returned empty state")
+	}
+
+	f, ok := s.Consume(state)
+	if !ok {
+		t.Fatal("first Consume failed, want success")
+	}
+	if f.Verifier != "verifier-abc" || f.HiveID != "hive-1" || f.Model != "deepseek/deepseek-chat" {
+		t.Fatalf("consumed flow mismatch: %+v", f)
+	}
+
+	// Replay must fail — single-use.
+	if _, ok := s.Consume(state); ok {
+		t.Fatal("second Consume succeeded, want single-use rejection (replay)")
+	}
+}
+
+// TestStateStoreUnknown rejects a state that was never created.
+func TestStateStoreUnknown(t *testing.T) {
+	s := NewStateStore(StateTTL)
+	if _, ok := s.Consume("never-created"); ok {
+		t.Fatal("Consume of unknown state succeeded, want rejection")
+	}
+}
+
+// TestStateStoreExpiry verifies an expired flow is rejected, using an injected
+// clock so the test does not sleep.
+func TestStateStoreExpiry(t *testing.T) {
+	s := NewStateStore(10 * time.Minute)
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	now := base
+	s.SetClock(func() time.Time { return now })
+
+	state, err := s.Create("v", "hive-1", "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Advance past the TTL.
+	now = base.Add(11 * time.Minute)
+	if _, ok := s.Consume(state); ok {
+		t.Fatal("Consume of expired state succeeded, want expiry rejection")
+	}
+}
+
+// TestStateStoreWithinTTL confirms a flow just inside the TTL still consumes.
+func TestStateStoreWithinTTL(t *testing.T) {
+	s := NewStateStore(10 * time.Minute)
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	now := base
+	s.SetClock(func() time.Time { return now })
+
+	state, _ := s.Create("v", "hive-1", "")
+	now = base.Add(9 * time.Minute)
+	if _, ok := s.Consume(state); !ok {
+		t.Fatal("Consume within TTL failed, want success")
+	}
+}
+
+// TestQRPNG checks the QR encoder returns a valid PNG (magic header) for a URL.
+func TestQRPNG(t *testing.T) {
+	png, err := QRPNG("https://openrouter.ai/auth?callback_url=x&code_challenge=y")
+	if err != nil {
+		t.Fatalf("QRPNG: %v", err)
+	}
+	if len(png) < 8 {
+		t.Fatal("QRPNG returned too few bytes")
+	}
+	// PNG signature: 89 50 4E 47 0D 0A 1A 0A
+	sig := []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a}
+	if string(png[:8]) != string(sig) {
+		t.Fatalf("QRPNG output is not a PNG (bad signature)")
+	}
+	if _, err := QRPNG(""); err == nil {
+		t.Fatal("QRPNG(\"\") should error")
+	}
+}


### PR DESCRIPTION
## What

Adds a **scan QR → OAuth PKCE → scoped OpenRouter key → creates an \`openrouter\` model gateway** funding flow, building **on** the just-merged Model Gateways feature (#1979/#1980). A sponsor scans a QR (or clicks a same-device link), authorizes on openrouter.ai, and a user-controlled, scoped OpenRouter key funded from **their** credits is stored as a model gateway named \`openrouter\`.

Available on **both** ends:
- **Hub (My Hives):** a "⚡ Fund with OpenRouter" entry in the per-hive ⋮ menu (owner/admin-gated) — fund a *specific* hive.
- **Spoke dashboard:** a "⚡ Fund this hive with OpenRouter" panel in the Model Gateways tab — fund *this* hive.

## How

### New shared package \`pkg/openrouter\`
- **PKCE S256:** \`GeneratePKCE\` / \`ChallengeFor\` (\`base64url(sha256(verifier))\`), a 43–128-char url-safe verifier.
- **URL builders + HTTP:** authorize-URL builder, code→key exchange (\`POST /api/v1/auth/keys\`, reads \`key\`), credit check (\`GET /api/v1/key\` → \`{limit, limit_remaining, usage, label}\`), public model-list fetch.
- **QR:** pure-Go PNG encoder (\`github.com/skip2/go-qrcode\`) — no vendored JS, same-origin image, CSP stays clean.
- **State store:** in-memory, **single-use**, **TTL-bounded** (10 min) map \`state → {verifier, hiveID, model}\`.
- All OpenRouter URLs are **named consts** (base = \`https://openrouter.ai/api/v1\`, auth = \`https://openrouter.ai/auth\`, key-exchange = \`https://openrouter.ai/api/v1/auth/keys\`, key-info = \`https://openrouter.ai/api/v1/key\`).
- **Unit tests:** S256 transform correctness, verifier length bounds, authorize-URL params + state binding, and the state store (single-use, replay rejection, expiry, within-TTL).

### Spoke (\`pkg/dashboard/openrouter.go\`)
- \`GET /api/openrouter/connect/start\` (implies self), \`/qr\`, \`/models\`, \`/credit\`, and a **PUBLIC** \`GET /openrouter/callback\` (added to \`isPublicPath\`).
- Callback exchanges code+verifier for the key and stores it via the **existing per-gateway secret-file store** (\`storeGatewayAPIKey\`) — the key VALUE goes to an owner-only PVC file, only the PATH enters \`hive.yaml\`. Upserts a gateway \`openrouter\` (kind=openrouter, endpoint=base, api_key_file=<path>, default_model=<picked>).
- \`callback_url\` is built server-side from the hive's own \`dashboard_url\` (else request host) — never client-supplied.
- UI: model picker (curated short list incl. \`anthropic/claude-opus-4.8\` + cheaper deepseek/llama/gemini, live catalog, manual entry) + QR \`<img>\` + link + credit polling.

### Hub (\`pkg/hub/openrouter.go\`)
- Owner/admin-gated \`start\`/\`qr\`/\`models\`/\`credit\` + a **PUBLIC** \`/openrouter/callback\`.
- The hub runs the PKCE flow, then **delivers** the funded gateway to the target hive over the **heartbeat channel** (\`HeartbeatResponse.PendingGateway\` + \`GatewayConfigCallback\`, mirroring the existing \`ProjectConfig\` delivery) — the only channel that reaches firewalled/heartbeat-only spokes (vllm-d) uniformly. Drained on delivery; the hub never persists the key.
- Spoke applies it via \`ApplyDeliveredGateway\`, reusing the same secret-file store.
- UI: same modal from the My Hives ⋮ menu.

## Security
- PKCE **S256**; \`code_verifier\` **never leaves the server**.
- \`state\` is **single-use + short-TTL**; the callback **binds to the stored hive_id** (a code can't fund a different hive).
- Key stored **only as a secret file ref** — never inlined into \`hive.yaml\`, logged, or echoed.
- \`callback_url\` built from an **allowlisted own origin** (never from the client).
- Start endpoints **gated to the hive owner/admin**.

## Verification
- \`go build ./...\` → exit 0; \`go vet ./pkg/hub/ ./pkg/dashboard/ ./pkg/openrouter/ ./cmd/...\` → clean.
- \`go test ./pkg/openrouter/\` → PASS; targeted \`pkg/hub\` (Heartbeat/SaaS) and \`pkg/dashboard\` (Gateway/Auth/Server/PublicPath) subsets → PASS.
- \`go mod tidy\` run; \`go-qrcode\` added as a direct dependency.

## Follow-ups / notes
- **Budget-cap-tied-to-credit is a FOLLOW-UP PR** (deliberately out of scope here).
- Hub-side \`/api/openrouter/credit\` reports \`pending_delivery\` rather than proxying \`/v1/key\`: the hub intentionally does **not** retain the key after delivery, so live remaining-credit is shown on the **spoke's** own dashboard against its stored key. This is a small, deliberate deviation for a tighter security posture.
- Heartbeat delivery to vllm-d is **fully wired** (hub queue → \`HeartbeatResponse.PendingGateway\` → \`GatewayConfigCallback\` in \`cmd/hive/main.go\` → \`ApplyDeliveredGateway\`), but has **not** been exercised against a live firewalled spoke — worth a manual smoke test on vllm-d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)