### PR TITLE
fix(agent): persist pause state outside manager lock

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -4077,10 +4077,10 @@ func (m *Manager) KillSession(name string) error {
 
 func (m *Manager) Pause(name, trigger, reason string) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	agent, ok := m.agents[name]
 	if !ok {
+		m.mu.Unlock()
 		return fmt.Errorf("agent %s not found", name)
 	}
 
@@ -4093,8 +4093,13 @@ func (m *Manager) Pause(name, trigger, reason string) error {
 	}
 	agent.State = StatePaused
 	agent.Config.Paused = true
-	if m.persistPauseCallback != nil {
-		m.persistPauseCallback(name, true)
+	persistPause := m.persistPauseCallback
+	m.mu.Unlock()
+
+	// Persistence republishes the complete runtime config and re-enters the
+	// manager to update agent snapshots. Never invoke it while holding m.mu.
+	if persistPause != nil {
+		persistPause(name, true)
 	}
 	m.logger.Info("audit: agent paused",
 		"name", name,
@@ -4131,9 +4136,7 @@ func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) erro
 	prevReason := agent.PausedReason
 	agent.Paused = false
 	agent.Config.Paused = false
-	if m.persistPauseCallback != nil {
-		m.persistPauseCallback(name, false)
-	}
+	persistPause := m.persistPauseCallback
 	agent.PausedAt = time.Time{}
 	agent.PausedReason = ""
 	agent.PausedTrigger = ""
@@ -4147,6 +4150,11 @@ func (m *Manager) Resume(ctx context.Context, name, trigger, reason string) erro
 	// instead of serializing on the mutex.
 	m.mu.Unlock()
 
+	// Persistence republishes the complete runtime config and re-enters the
+	// manager to update agent snapshots. Never invoke it while holding m.mu.
+	if persistPause != nil {
+		persistPause(name, false)
+	}
 	m.logger.Info("audit: agent resumed",
 		"name", name,
 		"trigger", trigger,

--- a/v2/pkg/agent/manager_test.go
+++ b/v2/pkg/agent/manager_test.go
@@ -469,6 +469,41 @@ func TestPause_SetsPausedFlag(t *testing.T) {
 	}
 }
 
+func TestPause_PersistenceCallbackCanReenterManager(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{
+		"worker": makeAgentConfig("claude", "sonnet"),
+	}, discardLogger(), ProjectContext{})
+
+	callbackCalled := make(chan struct{}, 1)
+	m.SetPersistPauseCallback(func(name string, paused bool) {
+		if name != "worker" || !paused {
+			t.Errorf("persist callback = (%q, %v), want (worker, true)", name, paused)
+		}
+		_ = m.AllStatuses()
+		callbackCalled <- struct{}{}
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- m.Pause("worker", "test", "test pause")
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Pause() error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Pause() deadlocked while persistence callback re-entered manager")
+	}
+
+	select {
+	case <-callbackCalled:
+	default:
+		t.Fatal("pause persistence callback was not called")
+	}
+}
+
 func TestResume_ClearsPausedFlag(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("legacy tmux/su-exec agent runtime is Linux-only")
@@ -491,6 +526,43 @@ func TestResume_ClearsPausedFlag(t *testing.T) {
 	ap, _ := m.GetStatus("worker")
 	if ap.Paused {
 		t.Error("expected agent to not be paused after Resume()")
+	}
+}
+
+func TestResume_PersistenceCallbackCanReenterManager(t *testing.T) {
+	m := NewManager(map[string]config.AgentConfig{
+		"worker": makeAgentConfig("claude", "sonnet"),
+	}, discardLogger(), ProjectContext{})
+	m.agents["worker"].Paused = true
+	m.agents["worker"].Config.Paused = true
+
+	callbackCalled := make(chan struct{}, 1)
+	m.SetPersistPauseCallback(func(name string, paused bool) {
+		if name != "worker" || paused {
+			t.Errorf("persist callback = (%q, %v), want (worker, false)", name, paused)
+		}
+		_ = m.AllStatuses()
+		callbackCalled <- struct{}{}
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- m.Resume(context.Background(), "worker", "test", "test resume")
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Resume() error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Resume() deadlocked while persistence callback re-entered manager")
+	}
+
+	select {
+	case <-callbackCalled:
+	default:
+		t.Fatal("resume persistence callback was not called")
 	}
 }
 


### PR DESCRIPTION
## Summary

Move pause-state persistence outside `Manager.mu` for both `Pause` and `Resume`, and add regressions where the persistence callback re-enters the manager.

## Root cause

The `dd` pause-persistence callback uses `ConfigCoordinator.Mutate`. Publishing that transaction calls `Manager.AllStatuses`/`UpdateConfig`. `Pause` and `Resume` invoked the callback while holding the manager's non-reentrant mutex, so a dashboard pause/resume deadlocked the request and blocked subsequent manager-backed status/config endpoints.

This was reproduced on the hosted `dd@00e75f2d61928776fb1892656c5629e2f79e722a` demo: resuming the Quality agent stayed indefinitely at “Resuming quality…”, no resume audit entry was written, and later agent configuration requests remained at “Loading…”. The exact source path confirms the callback re-enters the manager under the held lock.

## Change

- capture the configured persistence callback while mutating in-memory state
- release `Manager.mu`
- persist the complete config transaction
- retain synchronous durability before the remaining resume launch work
- cover both pause and resume with callbacks that call `AllStatuses`

No policy, cadence, agent mode, GitHub permission, workflow, or Visual Hive behavior changes.

## Validation

- `go test ./pkg/agent -count=1 -timeout=90s`
- `go test ./pkg/dashboard -run 'Test(HandlePause|HandleResume|ConfigCoordinator)' -count=1 -timeout=90s`
- `go vet ./pkg/agent`
- `go build ./cmd/hive`
- focused pause/resume regressions pass

A local Windows `-race` attempt was not available because CGO is disabled; the PR's Linux race lane should provide the authoritative race result.