### PR TITLE
✨ feat(dashboard): cost panel — all-time label, comma formatting, cost-over-time sparkline

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -291,6 +291,15 @@ func main() {
 		}
 	}
 
+	// Restore estimated-cost history from disk so the cost sparkline survives restarts
+	const costHistoryPath = "/data/cost-history.json"
+	var pendingCostSeed []dashboard.CostHistoryEntry
+	if costData, err := os.ReadFile(costHistoryPath); err == nil {
+		if err := json.Unmarshal(costData, &pendingCostSeed); err == nil && len(pendingCostSeed) > 0 {
+			logger.Info("cost history loaded", "entries", len(pendingCostSeed))
+		}
+	}
+
 	if cfg.Knowledge.Enabled {
 		layers := convertKnowledgeLayers(cfg.Knowledge.Layers)
 		primerCfg := knowledge.PrimerConfig{
@@ -556,6 +565,11 @@ func main() {
 	if len(pendingFactSeed) > 0 {
 		dashSrv.SeedFactHistory(pendingFactSeed)
 		logger.Info("fact history restored", "entries", len(pendingFactSeed))
+	}
+
+	if len(pendingCostSeed) > 0 {
+		dashSrv.SeedCostHistory(pendingCostSeed)
+		logger.Info("cost history restored", "entries", len(pendingCostSeed))
 	}
 
 	beadStores := make(map[string]*beads.Store)
@@ -2740,6 +2754,14 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 			factData, err := json.Marshal(factHist)
 			if err == nil {
 				atomicWrite("/data/fact-history.json", factData)
+			}
+		}
+
+		costHist := dashSrv.CostHistory()
+		if len(costHist) > 0 {
+			costData, err := json.Marshal(costHist)
+			if err == nil {
+				atomicWrite("/data/cost-history.json", costData)
 			}
 		}
 	}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -65,6 +65,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/token-access", s.handleTokenAccess)
 	s.mux.HandleFunc("GET /api/tokens", s.handleTokens)
 	s.mux.HandleFunc("GET /api/cost", s.handleCost)
+	s.mux.HandleFunc("GET /api/cost/history", s.handleCostHistory)
 	s.mux.HandleFunc("GET /api/issue-costs", s.handleIssueCosts)
 	s.mux.HandleFunc("GET /api/model-advisor", s.handleModelAdvisor)
 	s.mux.HandleFunc("GET /api/budget-ignore", s.handleBudgetIgnoreGet)
@@ -4828,11 +4829,21 @@ func (s *Server) handleKnowledgeStats(w http.ResponseWriter, r *http.Request) {
 		s.AppendFactHistory(total)
 	}
 
+	// Sample the estimated cost on the same cadence as the fact history so the
+	// cost sparkline shares the fact sparkline's timer (both throttled to
+	// ~5-min intervals). The figure is the same all-time cumulative estimated
+	// total that GET /api/cost returns.
+	s.AppendCostHistory(s.estimatedCost().TotalUSD)
+
 	jsonResponse(w, stats)
 }
 
 func (s *Server) handleFactHistory(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, s.FactHistory())
+}
+
+func (s *Server) handleCostHistory(w http.ResponseWriter, r *http.Request) {
+	jsonResponse(w, s.CostHistory())
 }
 
 func (s *Server) handleKnowledgeGraph(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/cost.go
+++ b/v2/pkg/dashboard/cost.go
@@ -118,21 +118,7 @@ func (s *Server) handleCost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// --- Estimated cost from token counts ---
-	if s.deps != nil && s.deps.Tokens != nil {
-		if summary := s.deps.Tokens.Summary(); summary != nil {
-			est := tokens.EstimateFromSummary(summary)
-			resp.Estimated = flattenEstimated(est)
-		}
-	}
-	if resp.Estimated.ByModel == nil {
-		resp.Estimated.ByModel = []costModelEntry{}
-	}
-	if resp.Estimated.ByAgent == nil {
-		resp.Estimated.ByAgent = []costModelEntry{}
-	}
-	if resp.Estimated.UnpricedModels == nil {
-		resp.Estimated.UnpricedModels = []string{}
-	}
+	resp.Estimated = s.estimatedCost()
 
 	// --- Native cost per metered gateway ---
 	if s.deps != nil && s.deps.Config != nil {
@@ -148,6 +134,30 @@ func (s *Server) handleCost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	jsonResponse(w, resp)
+}
+
+// estimatedCost computes the estimated per-model / per-agent breakdown (and the
+// all-time cumulative total) from the current token summary. Factored out so
+// both the /api/cost handler and the cost-history sampler produce the exact same
+// figure. Returns a zero-value costEstimated (with non-nil slices) when no token
+// data is available.
+func (s *Server) estimatedCost() costEstimated {
+	var est costEstimated
+	if s.deps != nil && s.deps.Tokens != nil {
+		if summary := s.deps.Tokens.Summary(); summary != nil {
+			est = flattenEstimated(tokens.EstimateFromSummary(summary))
+		}
+	}
+	if est.ByModel == nil {
+		est.ByModel = []costModelEntry{}
+	}
+	if est.ByAgent == nil {
+		est.ByAgent = []costModelEntry{}
+	}
+	if est.UnpricedModels == nil {
+		est.UnpricedModels = []string{}
+	}
+	return est
 }
 
 // flattenEstimated converts the map-keyed EstimatedCost into sorted-agnostic

--- a/v2/pkg/dashboard/cost_history_test.go
+++ b/v2/pkg/dashboard/cost_history_test.go
@@ -1,0 +1,79 @@
+package dashboard
+
+import "testing"
+
+// TestAppendCostHistory verifies a single append lands and the throttle
+// suppresses a rapid second append (same 5-min cadence as fact history).
+func TestAppendCostHistory(t *testing.T) {
+	s := newTestServer()
+
+	if got := s.CostHistory(); len(got) != 0 {
+		t.Fatalf("fresh server cost history len = %d, want 0", len(got))
+	}
+
+	s.AppendCostHistory(100.50)
+	got := s.CostHistory()
+	if len(got) != 1 {
+		t.Fatalf("after one append len = %d, want 1", len(got))
+	}
+	if got[0].USD != 100.50 {
+		t.Errorf("entry USD = %v, want 100.50", got[0].USD)
+	}
+	if got[0].Timestamp == 0 {
+		t.Error("entry Timestamp not set")
+	}
+
+	// A second immediate append is throttled (< costHistoryMinIntervalMs apart).
+	s.AppendCostHistory(200.75)
+	if got := s.CostHistory(); len(got) != 1 {
+		t.Fatalf("after throttled append len = %d, want 1 (throttle should suppress)", len(got))
+	}
+}
+
+// TestCostHistoryReturnsCopy verifies CostHistory hands back a copy so callers
+// can't mutate the server's slice.
+func TestCostHistoryReturnsCopy(t *testing.T) {
+	s := newTestServer()
+	s.AppendCostHistory(42.0)
+
+	got := s.CostHistory()
+	got[0].USD = 999.0
+
+	again := s.CostHistory()
+	if again[0].USD != 42.0 {
+		t.Errorf("mutating returned slice leaked into server state: got %v", again[0].USD)
+	}
+}
+
+// TestSeedCostHistoryCapAndOrdering verifies the seed path trims to the cap
+// (keeping the most-recent tail) and preserves ordering.
+func TestSeedCostHistoryCapAndOrdering(t *testing.T) {
+	s := newTestServer()
+
+	// Build an over-cap ordered slice.
+	over := costHistoryMaxEntries + 10
+	entries := make([]CostHistoryEntry, over)
+	for i := range entries {
+		entries[i] = CostHistoryEntry{Timestamp: int64(i), USD: float64(i)}
+	}
+	s.SeedCostHistory(entries)
+
+	got := s.CostHistory()
+	if len(got) != costHistoryMaxEntries {
+		t.Fatalf("seeded len = %d, want cap %d", len(got), costHistoryMaxEntries)
+	}
+	// The oldest (over - cap) entries should have been dropped; the tail kept.
+	wantFirst := int64(over - costHistoryMaxEntries)
+	if got[0].Timestamp != wantFirst {
+		t.Errorf("first kept timestamp = %d, want %d (tail should be retained)", got[0].Timestamp, wantFirst)
+	}
+	if got[len(got)-1].Timestamp != int64(over-1) {
+		t.Errorf("last timestamp = %d, want %d", got[len(got)-1].Timestamp, over-1)
+	}
+	// Ordering preserved (monotonic).
+	for i := 1; i < len(got); i++ {
+		if got[i].Timestamp <= got[i-1].Timestamp {
+			t.Fatalf("ordering broken at %d: %d <= %d", i, got[i].Timestamp, got[i-1].Timestamp)
+		}
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -66,6 +66,9 @@ type Server struct {
 	factHistoryMu sync.RWMutex
 	factHistory   []FactHistoryEntry
 
+	costHistoryMu sync.RWMutex
+	costHistory   []CostHistoryEntry
+
 	advisoryMu     sync.RWMutex
 	advisoryDigest any
 
@@ -364,6 +367,22 @@ const factHistoryMaxEntries = 8640
 
 // factHistoryMinIntervalMs prevents recording more than once per 5 minutes (ms).
 const factHistoryMinIntervalMs = 300_000
+
+// CostHistoryEntry records an estimated-cost ($) snapshot at a point in time.
+// USD is the all-time cumulative estimated total (token counts × list prices),
+// the same figure GET /api/cost returns.
+type CostHistoryEntry struct {
+	Timestamp int64   `json:"t"`
+	USD       float64 `json:"usd"`
+}
+
+// costHistoryMaxEntries caps the cost sparkline to ~30 days at 5-min intervals,
+// mirroring factHistoryMaxEntries.
+const costHistoryMaxEntries = 8640
+
+// costHistoryMinIntervalMs prevents recording more than once per 5 minutes (ms),
+// mirroring factHistoryMinIntervalMs.
+const costHistoryMinIntervalMs = 300_000
 
 const sseRetryMs = 3000
 
@@ -1524,6 +1543,50 @@ func (s *Server) SeedFactHistory(entries []FactHistoryEntry) {
 		entries = entries[len(entries)-factHistoryMaxEntries:]
 	}
 	s.factHistory = entries
+}
+
+// AppendCostHistory records an estimated-cost ($) snapshot if enough time has
+// passed since the last one. Mirrors AppendFactHistory: same cadence throttle
+// and same ring-buffer cap so the two histories stay aligned.
+func (s *Server) AppendCostHistory(usd float64) {
+	now := time.Now().UnixMilli()
+
+	s.costHistoryMu.Lock()
+	defer s.costHistoryMu.Unlock()
+
+	if len(s.costHistory) > 0 {
+		last := s.costHistory[len(s.costHistory)-1]
+		if now-last.Timestamp < costHistoryMinIntervalMs {
+			return
+		}
+	}
+
+	s.costHistory = append(s.costHistory, CostHistoryEntry{
+		Timestamp: now,
+		USD:       usd,
+	})
+	if len(s.costHistory) > costHistoryMaxEntries {
+		s.costHistory = s.costHistory[len(s.costHistory)-costHistoryMaxEntries:]
+	}
+}
+
+// CostHistory returns a copy of the estimated-cost history.
+func (s *Server) CostHistory() []CostHistoryEntry {
+	s.costHistoryMu.RLock()
+	defer s.costHistoryMu.RUnlock()
+	out := make([]CostHistoryEntry, len(s.costHistory))
+	copy(out, s.costHistory)
+	return out
+}
+
+// SeedCostHistory restores persisted cost history on startup.
+func (s *Server) SeedCostHistory(entries []CostHistoryEntry) {
+	s.costHistoryMu.Lock()
+	defer s.costHistoryMu.Unlock()
+	if len(entries) > costHistoryMaxEntries {
+		entries = entries[len(entries)-costHistoryMaxEntries:]
+	}
+	s.costHistory = entries
 }
 
 // SetAdvisoryDigest stores the latest advisory digest for SSE broadcast.

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3673,6 +3673,36 @@
     }
     // fetchFactHistory() — deferred to _deferredInit
 
+    // ── Estimated-cost sparkline (30-day server-side history) ──
+    // Mirrors the fact sparkline: same dimensions, same min/max scaling,
+    // reads /api/cost/history which parallels /api/knowledge/fact-history.
+    let _costHistory = [];
+    const COST_SPARKLINE_W = FACT_SPARKLINE_W, COST_SPARKLINE_H = FACT_SPARKLINE_H;
+    async function fetchCostHistory() {
+      try {
+        const r = await fetch('/api/cost/history');
+        _costHistory = await r.json();
+      } catch { /* non-critical */ }
+    }
+    function costSparkSvg() {
+      if (!_costHistory || _costHistory.length < 2) return '';
+      const values = _costHistory.map(e => e.usd);
+      const max = Math.max(...values);
+      const min = Math.min(...values);
+      const range = (max - min) || max || 1;
+      const pts = values.map((v, i) => {
+        const x = (i / (values.length - 1)) * COST_SPARKLINE_W;
+        const y = COST_SPARKLINE_H - ((v - min) / range) * (COST_SPARKLINE_H - 2) - 1;
+        return `${x.toFixed(1)},${y.toFixed(1)}`;
+      });
+      const lastPt = pts[pts.length - 1].split(',');
+      return `<span class="sparkline" style="margin-left:0;margin-top:4px" title="Estimated cost over time (last 30d)"><svg width="${COST_SPARKLINE_W}" height="${COST_SPARKLINE_H}" viewBox="0 0 ${COST_SPARKLINE_W} ${COST_SPARKLINE_H}">` +
+        `<polyline points="${pts.join(' ')}" fill="none" stroke="var(--green)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>` +
+        `<circle cx="${lastPt[0]}" cy="${lastPt[1]}" r="2" fill="var(--green)"/>` +
+        `</svg></span>`;
+    }
+    // fetchCostHistory() is invoked alongside fetchCost() (see below).
+
     async function fetchHistory() {
       try {
         const r = await fetch('/api/history');
@@ -5535,13 +5565,15 @@ function burnAreaChart() {
     // spend reported by OpenRouter / LiteLLM gateways). Estimates are always
     // labeled "est." so they never masquerade as actual billing.
     const COST_POLL_MS = 60000;
+    // Format a dollar amount with thousands separators (commas). Small amounts
+    // keep 2-decimal cents; amounts >= $100 are shown as whole dollars but still
+    // comma-grouped (e.g. $20,849). Sentinels for null / sub-cent are preserved.
     function fmtUSD(n) {
       if (n == null || isNaN(n)) return '—';
       if (n === 0) return '$0.00';
       if (n < 0.01) return '<$0.01';
-      if (n < 100) return '$' + n.toFixed(2);
-      if (n < 100000) return '$' + n.toFixed(0);
-      return '$' + (n / 1000).toFixed(1) + 'k';
+      const frac = n < 100 ? 2 : 0;
+      return '$' + n.toLocaleString('en-US', { minimumFractionDigits: frac, maximumFractionDigits: frac });
     }
 
     function renderCost(cost) {
@@ -5604,7 +5636,7 @@ function burnAreaChart() {
         <div class="cost-title">Cost <span class="cost-badge est" title="Estimated from token counts × list prices; subscription/self-hosted billing may differ">est.</span></div>
         <div class="cost-subtitle">List prices as of ${esc(cost.price_table_date || '')}. Metered gateways (OpenRouter, LiteLLM) show ACTUAL spend; everything else is ESTIMATED.</div>
         <div class="cost-grid">
-          <div class="cost-stat"><div class="cval">${fmtUSD(est.total_usd)}<span class="cost-badge est">est.</span></div><div class="clabel">estimated total (token × list price)</div></div>
+          <div class="cost-stat"><div class="cval">${fmtUSD(est.total_usd)}<span class="cost-badge est">est.</span></div><div class="clabel">estimated total — all-time cumulative (token × list price)</div>${costSparkSvg()}</div>
         </div>
         ${gwCards ? `<div class="cost-gateways">${gwCards}</div>` : ''}
         <table class="cost-table">
@@ -5618,7 +5650,7 @@ function burnAreaChart() {
 
     async function fetchCost() {
       try {
-        const resp = await fetch('/api/cost');
+        const [resp] = await Promise.all([fetch('/api/cost'), fetchCostHistory()]);
         if (!resp.ok) return;
         const cost = await resp.json();
         renderCost(cost);


### PR DESCRIPTION
## Summary
Improves the dashboard **Cost** panel (from the merged cost-tracking feature) in three ways:

1. **Period label** — the estimated total is an *all-time cumulative* figure (`Tokens.Summary()` is a lifetime aggregate scanned from all session files), not per-day/week/month. The sublabel now reads **"estimated total — all-time cumulative (token × list price)"** so the reader can't misread it as a daily number. EST. badges and disclaimers are unchanged.

2. **Thousands separators (commas)** — `fmtUSD` now comma-groups every dollar amount via `toLocaleString('en-US')` (e.g. `$20,849`, `$10,201`), keeping 2-decimal cents for amounts under $100 and preserving the `—` / `<$0.01` / `$0.00` sentinels. Applies to the big total, the per-model `est. $` column, and gateway native `spent`/`limit`/`remaining`.

3. **Cost-over-time sparkline with server-side history** — mirrors the existing 30-day fact-history mechanism exactly:
   - `CostHistoryEntry{T,USD}` + `costHistory` slice/mutex, `costHistoryMaxEntries` (~30d @ 5min) + `costHistoryMinIntervalMs`, and `AppendCostHistory`/`CostHistory`/`SeedCostHistory`.
   - Sampled on the **same timer** as `AppendFactHistory` (`handleKnowledgeStats`), via a factored `estimatedCost()` so `/api/cost` and the sampler return the identical all-time total.
   - New route `GET /api/cost/history` mirroring `handleFactHistory`.
   - Persisted to `/data/cost-history.json` (load / seed / atomic save) like fact history, so it survives restarts.
   - Frontend SVG polyline sparkline (min/max scaling, `<2` points → renders nothing), reusing the `.sparkline` CSS class, tinted `--green`, tooltip "Estimated cost over time (last 30d)".

## Tests
`go test ./pkg/dashboard/` passes. Added `cost_history_test.go`: append throttle, `CostHistory()` copy semantics, and seed cap + ordering.

## Verification
- `go build ./...` — exit 0
- `go vet ./pkg/dashboard/` — clean
- `go test ./pkg/dashboard/` — pass