### PR TITLE
📖 docs: drop incorrect "(v3 feature)" labels from v2 agent example (#1928)

### DIFF
--- a/v2/examples/agents/customized-agent.yaml
+++ b/v2/examples/agents/customized-agent.yaml
@@ -27,7 +27,7 @@ spec:
     - customized
   aliases:
     - cu
-  # Channels — declare how this agent gets triggered (v3 feature)
+  # Channels — declare how this agent gets triggered
   # Uncomment to use explicit channels instead of governor-only kicks:
   # channels:
   #   - type: kick
@@ -36,7 +36,7 @@ spec:
   #   - type: schedule
   #     schedule: "0 */4 * * *"
 
-  # Tools — declarative tool permissions (v3 feature)
+  # Tools — declarative tool permissions
   # Uncomment to use instead of the mode field above:
   # tools:
   #   preset: advisory
@@ -45,7 +45,7 @@ spec:
   #       action: allow
   #       reason: "allow creating advisory issues"
 
-  # Connections — external service integrations (v3 feature)
+  # Connections — external service integrations
   # connections:
   #   - name: github-mcp
   #     type: mcp


### PR DESCRIPTION
The v2 example customized-agent.yaml labeled Channels/Tools/Connections as "(v3 feature)", but all three are implemented in v2. Removed the misleading labels. Fixes #1928.