### PR TITLE
🐛 dashboard: make openrouter a first-class agent method (always in picker)

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4714,9 +4714,12 @@
     }
 
     // ── Centralized backend/model config (mirrors backends.conf) ──────────
-    const KNOWN_BACKENDS = ['claude', 'copilot', 'bob', 'gemini', 'codex', 'amazonq', 'goose', 'aider', 'vllm', 'llm-d', 'litellm'];
+    // 'openrouter' is a first-class inference method (an OpenAI-compatible gateway
+    // preset), so it appears in every backend/method picker even before a matching
+    // Model Gateway is configured — the user picks it, then funds/configures it.
+    const KNOWN_BACKENDS = ['claude', 'copilot', 'bob', 'gemini', 'codex', 'amazonq', 'goose', 'aider', 'vllm', 'llm-d', 'litellm', 'openrouter'];
     const FREE_BACKENDS = ['copilot', 'goose'];
-    const INFERENCE_BACKENDS = ['vllm', 'llm-d', 'litellm'];
+    const INFERENCE_BACKENDS = ['vllm', 'llm-d', 'litellm', 'openrouter'];
     // Names of Model Gateways configured under Governor Config → Model Gateways
     // (e.g. 'openrouter'). Agent routing already resolves a gateway name, but
     // the backend pickers only listed KNOWN_BACKENDS — so a configured gateway


### PR DESCRIPTION
**Fixes the follow-up to #1996** — openrouter still wasn't showing in the agent method dropdown.

## Root cause
#1996 only surfaced `openrouter` in the backend/method dropdowns when a Model Gateway literally **named** `openrouter` was already configured (via `_configuredGateways`, populated from `/api/gateways`). But the user needs to **pick** openrouter *first*, then fund/configure it — so it has to be a static method option like `vllm`/`llm-d`/`litellm`, present before any gateway exists.

## Fix
Add `openrouter` to `KNOWN_BACKENDS` and `INFERENCE_BACKENDS`, so it:
- always renders in every agent method picker (Overview cards, detail drawer, gateway CLI-pin),
- carries the ⚡ inference-backend treatment,
- returns an empty model catalog until a live gateway provides one — identical to how `vllm`/`llm-d` already behave.

The contributor relay picker already lists openrouter/vllm/llm-d/litellm (#1996), so this only touches the agent-side dropdowns in `index.html`.