### PR TITLE
fix(integrated): keep setup plans out of durable state

### DIFF
--- a/v2/cmd/hive/integrated.go
+++ b/v2/cmd/hive/integrated.go
@@ -2364,7 +2364,50 @@ func repositoryIntegratedStateDir(repository string) (string, error) {
 		short = "repository"
 	}
 	digest := fmt.Sprintf("%x", sha256.Sum256([]byte(canonical)))
-	return filepath.Join(integratedStateRoot(), "repos", short+"-"+digest[:16]), nil
+	selected := filepath.Join(integratedStateRoot(), "repos", short+"-"+digest[:16])
+	if prior, exists, err := loadExistingSetupConfig(selected); err != nil {
+		return "", fmt.Errorf("inspect existing repository state at %s: %w", selected, err)
+	} else if exists {
+		if !strings.EqualFold(strings.TrimSpace(prior.Repository), strings.TrimSpace(repository)) {
+			return "", fmt.Errorf("repository state at %s belongs to %s, not %s", selected, prior.Repository, repository)
+		}
+		if prior.StateDir != "" && !strings.EqualFold(filepath.Clean(prior.StateDir), filepath.Clean(selected)) {
+			return "", fmt.Errorf("repository state at %s embeds a different state path %s; use the original exact --state-dir so Hive can verify it", selected, prior.StateDir)
+		}
+		return selected, nil
+	}
+	entries, readErr := os.ReadDir(selected)
+	if os.IsNotExist(readErr) || (readErr == nil && len(entries) == 0) {
+		return selected, nil
+	}
+	if readErr != nil {
+		return "", fmt.Errorf("inspect unowned repository state at %s: %w", selected, readErr)
+	}
+
+	// Older read-only setup plans cloned into the auto-selected durable path
+	// before a repository ID was available, leaving a markerless state root
+	// that a later apply must never adopt. Preserve that directory untouched
+	// and select one deterministic sibling for the real managed installation.
+	recovery := selected + "-managed"
+	if prior, exists, err := loadExistingSetupConfig(recovery); err != nil {
+		return "", fmt.Errorf("inspect recovered repository state at %s: %w", recovery, err)
+	} else if exists {
+		if !strings.EqualFold(strings.TrimSpace(prior.Repository), strings.TrimSpace(repository)) {
+			return "", fmt.Errorf("recovered repository state at %s belongs to %s, not %s", recovery, prior.Repository, repository)
+		}
+		if prior.StateDir != "" && !strings.EqualFold(filepath.Clean(prior.StateDir), filepath.Clean(recovery)) {
+			return "", fmt.Errorf("recovered repository state at %s embeds a different state path %s; use the original exact --state-dir so Hive can verify it", recovery, prior.StateDir)
+		}
+		return recovery, nil
+	}
+	recoveryEntries, recoveryErr := os.ReadDir(recovery)
+	if os.IsNotExist(recoveryErr) || (recoveryErr == nil && len(recoveryEntries) == 0) {
+		return recovery, nil
+	}
+	if recoveryErr != nil {
+		return "", fmt.Errorf("inspect recovered repository state at %s: %w", recovery, recoveryErr)
+	}
+	return "", fmt.Errorf("both auto-selected repository state paths are nonempty and unowned; preserve them and rerun with an explicitly reviewed dedicated --state-dir")
 }
 
 func legacyRepositoryIntegratedStateDir(repository string) string {

--- a/v2/cmd/hive/state_path_test.go
+++ b/v2/cmd/hive/state_path_test.go
@@ -95,6 +95,27 @@ func TestDefaultRepositoryStatePathIgnoresUnownedPartialLegacyDirectory(t *testi
 	}
 }
 
+func TestDefaultRepositoryStatePathPreservesReadOnlyPlanResidue(t *testing.T) {
+	useTemporaryHiveHome(t)
+	selected, err := repositoryIntegratedStateDir(longSetupProofRepository)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureTestDirectory(filepath.Join(selected, "integrated", "checkout")); err != nil {
+		t.Fatal(err)
+	}
+	recovered, err := repositoryIntegratedStateDir(longSetupProofRepository)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered == selected || recovered != selected+"-managed" {
+		t.Fatalf("markerless read-only plan residue was reused: initial=%q recovered=%q", selected, recovered)
+	}
+	if _, err := os.Stat(selected); err != nil {
+		t.Fatalf("read-only plan residue was not preserved: %v", err)
+	}
+}
+
 func ensureTestDirectory(path string) error {
 	return os.MkdirAll(path, 0o700)
 }

--- a/v2/pkg/integrated/setup.go
+++ b/v2/pkg/integrated/setup.go
@@ -137,6 +137,21 @@ func RunSetup(ctx context.Context, options SetupOptions) (SetupResult, error) {
 	if err := validateSetupOptions(options); err != nil {
 		return SetupResult{}, err
 	}
+	requestedStateDir := options.StateDir
+	var readOnlyPlanRoot string
+	if !options.Apply {
+		configPath := filepath.Join(options.StateDir, "integrated", "config.json")
+		if _, statErr := os.Lstat(configPath); os.IsNotExist(statErr) {
+			readOnlyPlanRoot, err = os.MkdirTemp("", "hive-setup-plan-")
+			if err != nil {
+				return SetupResult{}, fmt.Errorf("create ephemeral read-only setup workspace: %w", err)
+			}
+			defer os.RemoveAll(readOnlyPlanRoot)
+			options.StateDir = filepath.Join(readOnlyPlanRoot, "state")
+		} else if statErr != nil {
+			return SetupResult{}, fmt.Errorf("inspect existing setup state before read-only planning: %w", statErr)
+		}
+	}
 	if err := validateSetupStateRoot(options.StateDir, options.Repository); err != nil {
 		return SetupResult{}, err
 	}
@@ -241,7 +256,9 @@ func RunSetup(ctx context.Context, options SetupOptions) (SetupResult, error) {
 		}
 	}
 	options = effectiveSetupAutoMergePolicy(options, prior, hasPrior)
-	plan := buildSetupPlan(options, inspection)
+	planOptions := options
+	planOptions.StateDir = requestedStateDir
+	plan := buildSetupPlan(planOptions, inspection)
 	result := SetupResult{Plan: plan, ProtectionActivationPending: options.Automation == AutomationAutoMerge, ActivationMessage: setupActivationMessage(options.Automation, options.Start, true)}
 	if !options.Apply {
 		return result, nil

--- a/v2/pkg/integrated/setup_plan_readonly_test.go
+++ b/v2/pkg/integrated/setup_plan_readonly_test.go
@@ -1,0 +1,50 @@
+package integrated
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReadOnlySetupPlanLeavesRequestedStateUntouched(t *testing.T) {
+	const repository = "owner/read-only-plan"
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote.git")
+	seed := filepath.Join(root, "seed")
+	runCheckoutFixtureGit(t, root, "init", "--bare", remote)
+	runCheckoutFixtureGit(t, root, "init", "-b", "main", seed)
+	if err := os.WriteFile(filepath.Join(seed, "package.json"), []byte(`{"scripts":{"test":"node --test"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runCheckoutFixtureGit(t, seed, "add", "package.json")
+	runCheckoutFixtureGit(t, seed, "-c", "user.name=Hive Test", "-c", "user.email=hive@example.invalid", "commit", "-m", "seed")
+	runCheckoutFixtureGit(t, seed, "remote", "add", "origin", remote)
+	runCheckoutFixtureGit(t, seed, "push", "-u", "origin", "main")
+	runCheckoutFixtureGit(t, remote, "symbolic-ref", "HEAD", "refs/heads/main")
+
+	previousCloneURL := setupRepositoryCloneURL
+	setupRepositoryCloneURL = func(string) string { return remote }
+	t.Cleanup(func() { setupRepositoryCloneURL = previousCloneURL })
+
+	stateDir := filepath.Join(root, "hive-read-only-state")
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	result, err := RunSetup(ctx, SetupOptions{
+		Repository: repository, Coverage: CoverageEssential, Automation: AutomationRepairPR,
+		Provider: "codex", StateDir: stateDir, MaxActiveIssues: 5, MaxRepairAttempts: 4,
+		ExecutionMode: ExecutionLocal, VisualHive: true, VisualHiveRepo: "owner/visual-hive",
+		VisualHiveRef: strings.Repeat("a", 40),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Plan.ReadOnly || result.Plan.Repository != repository {
+		t.Fatalf("unexpected read-only plan: %+v", result.Plan)
+	}
+	if _, err := os.Lstat(stateDir); !os.IsNotExist(err) {
+		t.Fatalf("read-only setup plan changed requested durable state: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- keep a fresh `hive setup --plan` clone in an ephemeral workspace instead of the requested durable state directory
- preserve the requested durable path in the returned plan and clean the ephemeral workspace on every return path
- when an older read-only plan already left a markerless auto-selected state root, preserve it untouched and select one deterministic `-managed` sibling for the real installation
- add regressions for both read-only state isolation and safe auto-state recovery

## Root cause

A fresh unauthenticated `hive setup --plan --json` cloned the repository under the auto-selected durable state directory before an immutable repository ID was available. The command returned `read_only=true`, but a second identical plan failed closed with:

```text
nonempty state directory has no exact Hive ownership marker or ordinary legacy config
```

The clone itself was correctly checkout-owned; the state root could not be durably owned without the repository ID. The fix avoids writing there during fresh planning and never adopts the old residue.

## Impact

This restores repeatable read-only planning and lets the subsequent managed setup choose safe durable state without deleting, rewriting, or trusting files left by an older plan.

## Validation

- `go build ./...`
- `go vet ./...`
- `go test ./pkg/integrated -run '^TestReadOnlySetupPlanLeavesRequestedStateUntouched$' -count=1 -v`
- `go test ./cmd/hive -run '^TestDefaultRepositoryStatePath' -count=1 -v`
- Linux/Node runner parity: `go test ./pkg/integrated ./cmd/hive -timeout 8m`
- `git diff --check`

The broad Windows suite still reproduces unrelated existing concurrent file-lock and Git-process timeout failures; affected Linux packages and focused Windows regressions are green.