### PR TITLE
📝 dashboard: link + agent import overlay to the AgentDefinition docs (fixes #1929)

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -11828,8 +11828,11 @@ function burnAreaChart() {
     function renderAgentImport() {
       var exampleURL = 'https://github.com/kubestellar/hive/blob/v2/v2/examples/agents/customized-agent.yaml';
       var rawURL = 'https://raw.githubusercontent.com/kubestellar/hive/v2/v2/examples/agents/customized-agent.yaml';
+      // Field-by-field reference on the docs site (documents the same v2 schema
+      // as the example, and explains the doubled "v2/v2" path). See #1929/#1930.
+      var docsURL = 'https://docs.kubestellar.io/hive/agent-definition-yaml';
       return '<div style="max-width:600px;margin:0 auto">' +
-        '<p style="font-size:0.82rem;color:var(--muted);margin-bottom:16px">Import an agent from a YAML definition file. <a href="' + exampleURL + '" target="_blank" rel="noopener" style="color:var(--accent)">See example agent definition ↗</a></p>' +
+        '<p style="font-size:0.82rem;color:var(--muted);margin-bottom:16px">Import an agent from a YAML definition file. <a href="' + docsURL + '" target="_blank" rel="noopener" style="color:var(--accent)">Field reference ↗</a> · <a href="' + exampleURL + '" target="_blank" rel="noopener" style="color:var(--accent)">example definition ↗</a></p>' +
         '<div class="config-field" style="margin-bottom:12px">' +
           '<label>Import from URL</label>' +
           '<div style="display:flex;gap:8px"><input type="text" id="import-url-input" placeholder="' + rawURL + '" style="flex:1"><button onclick="previewImportFromURL()" style="padding:6px 16px;border-radius:6px;cursor:pointer;font-weight:600;border:none;background:var(--cyan);color:var(--bg);white-space:nowrap">Preview</button></div>' +


### PR DESCRIPTION
## Problem (#1929)
The **+ agent → Import from URL** overlay only linked to the raw example YAML (`blob/v2/v2/...`). The reporter went looking for **documentation of the file format** on the docs site and couldn't find it — and was also thrown by the doubled `v2/v2` in the path and the site offering only `main (Latest)` with no `v2` in the version selector.

## Fix
The field-by-field reference now exists at **[docs.kubestellar.io/hive/agent-definition-yaml](https://docs.kubestellar.io/hive/agent-definition-yaml)** (docs #6424, fixes #1930). That page documents every AgentDefinition field **and** explicitly explains that `v2/v2` is *branch `v2`* + *in-repo path `v2/examples/...`*, not a typo.

This PR surfaces that page directly in the overlay:

> Import an agent from a YAML definition file. **Field reference ↗** · **example definition ↗**

So the documentation the user was hunting for is one click from where they actually needed it.

`go build ./pkg/dashboard/` passes.

Fixes #1929