### PR TITLE
Route Visual Hive beads to owning Hive agents

### DIFF
--- a/v2/cmd/hive/visual.go
+++ b/v2/cmd/hive/visual.go
@@ -56,6 +56,7 @@ func runVisualCommand(args []string) int {
 	flags.SetOutput(os.Stderr)
 	bundlePath := flags.String("bundle", "", "path to a Visual Hive bundle manifest")
 	beadsDir := flags.String("beads-dir", "/data/beads/quality", "target Hive beads directory")
+	beadsRoot := flags.String("beads-root", "", "route imported beads by actor under this Hive beads root")
 	maxACMM := flags.Int("max-acmm", 3, "maximum ACMM level this Hive permits")
 	allowLocal := flags.Bool("allow-local", false, "allow explicit local proof bundles (never use for an untrusted artifact)")
 	flags.Bool("json", false, "emit machine-readable JSON")
@@ -73,12 +74,17 @@ func runVisualCommand(args []string) int {
 	}
 	output := visualImportOutput{Validation: bundle.Validation}
 	if action == "apply" {
-		store, err := beads.NewStore(*beadsDir)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "open beads store:", err)
-			return 1
+		var result beads.BatchResult
+		var err error
+		if strings.TrimSpace(*beadsRoot) != "" {
+			result, err = bundle.ImportByActor(*beadsRoot)
+		} else {
+			var store *beads.Store
+			store, err = beads.NewStore(*beadsDir)
+			if err == nil {
+				result, err = bundle.Import(store)
+			}
 		}
-		result, err := bundle.Import(store)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, "import visual evidence:", err)
 			return 1

--- a/v2/pkg/channels/bead.go
+++ b/v2/pkg/channels/bead.go
@@ -15,11 +15,11 @@ const beadPollIntervalS = 30
 
 // BeadWatcher polls bead stores and triggers agents based on match criteria.
 type BeadWatcher struct {
-	mgr     *Manager
-	mu      sync.Mutex
-	agents  map[string]config.AgentConfig
-	seen    map[string]bool
-	cancel  context.CancelFunc
+	mgr    *Manager
+	mu     sync.Mutex
+	agents map[string]config.AgentConfig
+	seen   map[string]bool
+	cancel context.CancelFunc
 }
 
 // NewBeadWatcher creates a new bead watcher.
@@ -134,9 +134,13 @@ func (b *BeadWatcher) matchesBead(path string, match map[string]string) bool {
 	if err := json.Unmarshal(data, &metadata); err != nil {
 		return false
 	}
+	fields := metadata
+	if nested, ok := metadata["metadata"].(map[string]interface{}); ok {
+		fields = nested
+	}
 
 	for key, expected := range match {
-		val, ok := metadata[key]
+		val, ok := fields[key]
 		if !ok {
 			return false
 		}

--- a/v2/pkg/channels/bead_test.go
+++ b/v2/pkg/channels/bead_test.go
@@ -1,0 +1,64 @@
+package channels
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+func TestMatchesBeadReadsVisualHiveAgentMetadata(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ux-scout.json")
+	data := []byte(`{"title":"UX review","metadata":{"visual_hive_agent":"ux-scout"}}`)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	watcher := NewBeadWatcher(nil)
+	if !watcher.matchesBead(path, map[string]string{"visual_hive_agent": "ux-scout"}) {
+		t.Fatal("expected Visual Hive agent metadata to match")
+	}
+	if watcher.matchesBead(path, map[string]string{"visual_hive_agent": "quality"}) {
+		t.Fatal("unexpected match for a different agent")
+	}
+}
+
+func TestVisualHiveBeadTriggersMatchingAgentKick(t *testing.T) {
+	beadsDir := t.TempDir()
+	beadPath := filepath.Join(beadsDir, "vh-ux-review.json")
+	if err := os.WriteFile(beadPath, []byte(`{
+		"title": "Review API error flow",
+		"metadata": {"visual_hive_agent": "ux-scout"}
+	}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	kicked := make(chan string, 1)
+	manager := NewManager(
+		map[string]config.AgentConfig{
+			"ux-scout": {BeadsDir: beadsDir},
+		},
+		func(agent, _ string) error {
+			kicked <- agent
+			return nil
+		},
+		nil,
+		nil,
+	)
+	watcher := manager.bead
+	watcher.checkBeadsForAgent("ux-scout", config.AgentConfig{BeadsDir: beadsDir}, config.ChannelConfig{
+		Type:  "bead",
+		Match: map[string]string{"visual_hive_agent": "ux-scout"},
+	})
+
+	select {
+	case agent := <-kicked:
+		if agent != "ux-scout" {
+			t.Fatalf("kick sent to %q, want ux-scout", agent)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("matching Visual Hive bead did not trigger an agent kick")
+	}
+}

--- a/v2/pkg/visualhive/bundle.go
+++ b/v2/pkg/visualhive/bundle.go
@@ -387,6 +387,72 @@ func (bundle *ValidatedBundle) Import(store *beads.Store) (beads.BatchResult, er
 	return store.ImportBatch(items)
 }
 
+// ImportByActor routes each validated Visual Hive projection to the Hive bead
+// store named by its actor. This preserves agent ownership so channel-based
+// agents, such as ux-scout, receive only their intended work items.
+func (bundle *ValidatedBundle) ImportByActor(beadsRoot string) (beads.BatchResult, error) {
+	if strings.TrimSpace(beadsRoot) == "" {
+		return beads.BatchResult{}, fmt.Errorf("beads root is required")
+	}
+	result := beads.BatchResult{}
+	byActor := make(map[string][]Projection)
+	for _, projection := range bundle.Beads {
+		actor, err := actorStoreName(projection.Actor)
+		if err != nil {
+			return result, err
+		}
+		byActor[actor] = append(byActor[actor], projection)
+	}
+	for actor, projections := range byActor {
+		store, err := beads.NewStore(filepath.Join(beadsRoot, actor))
+		if err != nil {
+			return result, fmt.Errorf("open beads store for %s: %w", actor, err)
+		}
+		imported, err := importProjections(bundle, projections, store)
+		if err != nil {
+			return result, fmt.Errorf("import beads for %s: %w", actor, err)
+		}
+		result.Created += imported.Created
+		result.Skipped += imported.Skipped
+	}
+	return result, nil
+}
+
+func importProjections(bundle *ValidatedBundle, projections []Projection, store *beads.Store) (beads.BatchResult, error) {
+	if bundle == nil || bundle.validationProfile == bundleValidationPullRequestLocal {
+		return beads.BatchResult{}, fmt.Errorf("pull_request bundle parsing never grants bead import authority")
+	}
+	if store == nil {
+		return beads.BatchResult{}, fmt.Errorf("persistent Hive bead store is required")
+	}
+	items := make([]beads.BatchInput, 0, len(projections))
+	for _, projection := range projections {
+		metadata := make(map[string]interface{}, len(projection.Metadata)+4)
+		for key, value := range projection.Metadata {
+			metadata[key] = value
+		}
+		metadata["visual_hive_bundle_id"] = bundle.Manifest.BundleID
+		metadata["visual_hive_digest"] = bundle.Manifest.OverallDigest
+		metadata["visual_hive_repository"] = bundle.Manifest.Source.Repository
+		metadata["visual_hive_commit"] = bundle.Manifest.Source.CommitSHA
+		items = append(items, beads.BatchInput{
+			SourceID: projection.ID, Title: projection.Title, Type: beadType(projection.Type),
+			Status: beadStatus(projection.Status), Priority: beadPriority(projection.Priority), Actor: projection.Actor,
+			ExternalRef: projection.ExternalRef, Metadata: metadata, Notes: projection.Notes, DependsOn: projection.DependsOn,
+		})
+	}
+	return store.ImportBatch(items)
+}
+
+func actorStoreName(actor string) (string, error) {
+	name := strings.TrimSpace(actor)
+	name = strings.TrimPrefix(name, "hive/")
+	if name == "" || !safeID.MatchString(name) {
+		return "", fmt.Errorf("Visual Hive bead actor %q is not a safe Hive agent name", actor)
+	}
+	return name, nil
+}
+
 func validateManifest(m Manifest, options ValidationOptions) error {
 	now := options.Now
 	if now.IsZero() {

--- a/v2/pkg/visualhive/bundle_test.go
+++ b/v2/pkg/visualhive/bundle_test.go
@@ -36,6 +36,32 @@ func TestValidateAndImportBundle(t *testing.T) {
 	}
 }
 
+func TestImportByActorRoutesValidatedProjectionsToAgentStores(t *testing.T) {
+	root := t.TempDir()
+	manifestPath := writeTestBundle(t, root, false)
+	bundle, err := ValidateBundle(manifestPath, ValidationOptions{
+		Now: time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC), MaxACMM: 3, AllowLocal: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle.Beads[0].Actor = "ux-scout"
+	result, err := bundle.ImportByActor(filepath.Join(root, "beads"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Created != 1 || result.Skipped != 0 {
+		t.Fatalf("unexpected routed import result: %+v", result)
+	}
+	uxStore, err := beads.NewStore(filepath.Join(root, "beads", "ux-scout"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uxStore.Count() != 1 {
+		t.Fatalf("expected one projection in the owning agent store, got %d", uxStore.Count())
+	}
+}
+
 func TestValidateBundleRejectsTampering(t *testing.T) {
 	root := t.TempDir()
 	manifestPath := writeTestBundle(t, root, false)


### PR DESCRIPTION
This PR adds the missing runtime bridge for Visual Hive advisory agents such as UX Scout. It preserves the existing default import path, adds optional actor-aware routing under the Hive beads root, and lets bead channels match Visual Hive agent identity in nested metadata. As a result, a Visual Hive bead with actor=ux-scout is written to /data/beads/ux-scout and can trigger the imported UX Scout agent. Includes focused routing and trigger tests. No Visual Hive verdict logic or existing default behavior is changed; the new path is only used when --beads-root is explicitly configured.