### PR TITLE
🧪 openrouter: cover error branches (89.7% → 94.8%) [#1896]

### DIFF
--- a/v2/pkg/openrouter/openrouter_http_test.go
+++ b/v2/pkg/openrouter/openrouter_http_test.go
@@ -261,3 +261,53 @@ func TestGeneratePKCE_Success(t *testing.T) {
 		t.Fatal("challenge must equal ChallengeFor(verifier)")
 	}
 }
+
+// badURL contains a control char that makes http.NewRequest fail to parse,
+// exercising the request-build error branches.
+const badURL = "http://\x7f\x00-invalid"
+
+// closedURL points at a port nothing listens on so client.Do fails fast,
+// exercising the network-error branches.
+const closedURL = "http://127.0.0.1:1"
+
+func TestExchangeCode_RequestBuildError(t *testing.T) {
+	withURLs(t, BaseURL, badURL, KeyInfoURL)
+	if _, err := ExchangeCode("c", "v"); err == nil {
+		t.Fatal("unparseable KeyExchangeURL must error")
+	}
+}
+
+func TestExchangeCode_NetworkError(t *testing.T) {
+	withURLs(t, BaseURL, closedURL, KeyInfoURL)
+	if _, err := ExchangeCode("c", "v"); err == nil {
+		t.Fatal("connection failure must error")
+	}
+}
+
+func TestFetchCredit_RequestBuildError(t *testing.T) {
+	withURLs(t, BaseURL, KeyExchangeURL, badURL)
+	if _, err := FetchCredit("k"); err == nil {
+		t.Fatal("unparseable KeyInfoURL must error")
+	}
+}
+
+func TestFetchCredit_NetworkError(t *testing.T) {
+	withURLs(t, BaseURL, KeyExchangeURL, closedURL)
+	if _, err := FetchCredit("k"); err == nil {
+		t.Fatal("connection failure must error")
+	}
+}
+
+func TestPublicModelIDs_RequestBuildErrorReturnsNil(t *testing.T) {
+	withURLs(t, badURL, KeyExchangeURL, KeyInfoURL)
+	if ids := PublicModelIDs(); ids != nil {
+		t.Fatalf("unparseable BaseURL must return nil, got %v", ids)
+	}
+}
+
+func TestPublicModelIDs_NetworkErrorReturnsNil(t *testing.T) {
+	withURLs(t, closedURL, KeyExchangeURL, KeyInfoURL)
+	if ids := PublicModelIDs(); ids != nil {
+		t.Fatalf("connection failure must return nil, got %v", ids)
+	}
+}


### PR DESCRIPTION
Pushes `pkg/openrouter` over the 90% gate by covering the reachable failure paths in `ExchangeCode`/`FetchCredit`/`PublicModelIDs`: request-build error (unparseable endpoint URL) and network error (`client.Do` against a closed port).

Remaining uncovered lines are the `crypto/rand` fatal-panic guards, unreachable on Go 1.25+ ([go.dev/issue/66821](https://go.dev/issue/66821)) — documented inline.

Refs #1896