### PR TITLE
🧪 promptsrc + trajectory: raise coverage to ≥90% [#1896]

### DIFF
--- a/v2/pkg/promptsrc/promptsrc_test.go
+++ b/v2/pkg/promptsrc/promptsrc_test.go
@@ -199,6 +199,70 @@ func TestFetchOnce_Gating(t *testing.T) {
 	}
 }
 
+// TestResolve_NilFetcherServesCache: when the fetcher is nil but a prior
+// success left a cached body (e.g. the client was swapped out after a
+// successful boot), Resolve should still serve the cache instead of missing.
+func TestResolve_NilFetcherServesCache(t *testing.T) {
+	f := &stubFetcher{body: "cached prompt"}
+	r := NewResolver(f, allowAll, nil)
+	first := r.Resolve(context.Background(), fullSource())
+	if !first.Ok {
+		t.Fatalf("priming fetch should succeed, got %+v", first)
+	}
+
+	// Simulate the client going away (e.g. token-less rewire) while the cache
+	// entry from the earlier successful fetch remains.
+	r.fetcher = nil
+
+	res := r.Resolve(context.Background(), fullSource())
+	if !res.Ok || res.Body != "cached prompt" {
+		t.Fatalf("nil fetcher with warm cache should hit, got %+v", res)
+	}
+	if !strings.HasPrefix(res.Source, "github-cache:") {
+		t.Errorf("source = %q, want github-cache:*", res.Source)
+	}
+}
+
+// TestResolve_DefaultRefProvenance: an empty Ref reports "default" in the
+// provenance string rather than an empty ref segment.
+func TestResolve_DefaultRefProvenance(t *testing.T) {
+	f := &stubFetcher{body: "on default branch"}
+	r := NewResolver(f, allowAll, nil)
+	src := Source{Owner: "kubestellar", Repo: "hive", Path: "prompts/scanner.md"} // Ref unset
+	res := r.Resolve(context.Background(), src)
+	if !res.Ok {
+		t.Fatalf("resolve should succeed, got %+v", res)
+	}
+	if res.Source != "github:kubestellar/hive@default" {
+		t.Errorf("source = %q, want github:kubestellar/hive@default", res.Source)
+	}
+}
+
+// TestFetchOnce_NilContext: a nil context must not panic and should behave
+// like context.Background().
+func TestFetchOnce_NilContext(t *testing.T) {
+	f := &stubFetcher{body: "baked"}
+	//nolint:staticcheck // deliberately passing nil ctx to exercise the guard
+	body, err := FetchOnce(nil, f, allowAll, fullSource())
+	if err != nil || body != "baked" {
+		t.Errorf("nil ctx should be tolerated, got body=%q err=%v", body, err)
+	}
+}
+
+// TestFetchOnce_TruncatesOversizeBody: FetchOnce enforces the same size cap
+// as Resolve, truncating rather than erroring.
+func TestFetchOnce_TruncatesOversizeBody(t *testing.T) {
+	huge := strings.Repeat("b", maxPromptBytes+50)
+	f := &stubFetcher{body: huge}
+	body, err := FetchOnce(context.Background(), f, allowAll, fullSource())
+	if err != nil {
+		t.Fatalf("oversize body should not error, got %v", err)
+	}
+	if len(body) != maxPromptBytes {
+		t.Errorf("body len = %d, want %d (truncated to cap)", len(body), maxPromptBytes)
+	}
+}
+
 // TestSource_Helpers exercises Slug/valid/key edge cases.
 func TestSource_Helpers(t *testing.T) {
 	if (Source{}).Slug() != "" {

--- a/v2/pkg/trajectory/lane_test.go
+++ b/v2/pkg/trajectory/lane_test.go
@@ -3,6 +3,7 @@ package trajectory
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -129,6 +130,92 @@ func TestLaneSkipsNonDivergentAndExemptAndPaused(t *testing.T) {
 	}
 	if len(sink.audits) != 0 {
 		t.Errorf("no audits expected, got %v", sink.audits)
+	}
+}
+
+// TestLaneReviewErrorFailsOpen: a reviewer transport error must be logged and
+// skipped, never pausing the agent (fail-open on outage).
+func TestLaneReviewErrorFailsOpen(t *testing.T) {
+	src := &fakeSource{agents: []AgentView{
+		{Name: "scanner", Running: true, Intent: "fix the bug", Transcript: "splitting token"},
+	}}
+	sink := &fakeSink{}
+	// Point the reviewer at an endpoint with no listener so the HTTP call
+	// itself fails (transport error), exercising Run's error branch.
+	reviewer, err := NewReviewer(Config{Endpoint: "http://127.0.0.1:1", Model: "m"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lane := NewLane(reviewer, src, sink, LaneConfig{OnDivergence: "pause"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	lane.Run(context.Background())
+
+	if len(src.paused) != 0 {
+		t.Errorf("reviewer outage must not pause, got %v", src.paused)
+	}
+	if len(sink.audits) != 0 {
+		t.Errorf("reviewer outage must not audit, got %v", sink.audits)
+	}
+}
+
+// TestLanePauseFailureFallsThroughToAlert: when Pause itself errors, the
+// divergence must still be surfaced via audit/alert/notify.
+func TestLanePauseFailureFallsThroughToAlert(t *testing.T) {
+	srv := verdictServer(t, true)
+	defer srv.Close()
+	src := &pauseFailSource{fakeSource: fakeSource{agents: []AgentView{
+		{Name: "scanner", Running: true, Intent: "fix the bug", Transcript: "splitting token"},
+	}}}
+	sink := &fakeSink{}
+	lane := newTestLane(t, src, sink, srv.URL, LaneConfig{OnDivergence: "pause"})
+	lane.Run(context.Background())
+
+	if len(sink.audits) != 1 || !strings.HasPrefix(sink.audits[0], "scanner/trajectory-pause") {
+		t.Errorf("expected pause audit despite Pause error, got %v", sink.audits)
+	}
+	if len(sink.alerts) != 1 {
+		t.Errorf("expected alert despite Pause error, got %v", sink.alerts)
+	}
+	if len(sink.notifs) != 1 {
+		t.Errorf("expected notify despite Pause error, got %v", sink.notifs)
+	}
+}
+
+type pauseFailSource struct {
+	fakeSource
+}
+
+func (p *pauseFailSource) Pause(name, trigger, reason string) error {
+	return errPauseBoom
+}
+
+var errPauseBoom = errors.New("pause boom")
+
+// TestItoa covers zero, positive, negative, and multi-digit paths.
+func TestItoa(t *testing.T) {
+	cases := map[int]string{
+		0:     "0",
+		5:     "5",
+		42:    "42",
+		-7:    "-7",
+		-1234: "-1234",
+		999:   "999",
+	}
+	for in, want := range cases {
+		if got := itoa(in); got != want {
+			t.Errorf("itoa(%d) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestSanitize collapses newlines, carriage returns, and tabs to spaces.
+func TestSanitize(t *testing.T) {
+	in := "line one\nline two\r\nwith\ttab"
+	want := "line one line two  with tab"
+	if got := sanitize(in); got != want {
+		t.Errorf("sanitize = %q, want %q", got, want)
+	}
+	if got := sanitize("no special chars"); got != "no special chars" {
+		t.Errorf("sanitize should be identity when nothing to strip, got %q", got)
 	}
 }
 

--- a/v2/pkg/trajectory/trajectory_test.go
+++ b/v2/pkg/trajectory/trajectory_test.go
@@ -132,6 +132,66 @@ func TestReviewEmptyTranscriptSkips(t *testing.T) {
 	}
 }
 
+// TestReviewNoChoicesErrors: a 200 response with an empty choices array must
+// error rather than panic on index access.
+func TestReviewNoChoicesErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(chatResponse{Choices: nil})
+	}))
+	defer srv.Close()
+	r, err := NewReviewer(Config{Endpoint: srv.URL, Model: "m"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, err := r.Review(context.Background(), "a", "intent", "some work")
+	if err == nil {
+		t.Error("expected error on empty choices")
+	}
+	if v.Divergent {
+		t.Error("verdict must be non-divergent on error")
+	}
+}
+
+// TestReviewMalformedJSONBody: a 200 response whose body is not valid JSON
+// must surface a decode error, not a panic.
+func TestReviewMalformedJSONBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json at all"))
+	}))
+	defer srv.Close()
+	r, err := NewReviewer(Config{Endpoint: srv.URL, Model: "m"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Review(context.Background(), "a", "intent", "some work"); err == nil {
+		t.Error("expected decode error on malformed body")
+	}
+}
+
+// TestReviewTransportError: an unreachable endpoint (nothing listening)
+// surfaces a transport error from http.Client.Do.
+func TestReviewTransportError(t *testing.T) {
+	r, err := NewReviewer(Config{Endpoint: "http://127.0.0.1:1", Model: "m"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Review(context.Background(), "a", "intent", "some work"); err == nil {
+		t.Error("expected transport error against unreachable endpoint")
+	}
+}
+
+// TestReviewBuildRequestError: a malformed endpoint URL (control characters
+// in the scheme/host) makes http.NewRequestWithContext itself fail.
+func TestReviewBuildRequestError(t *testing.T) {
+	r, err := NewReviewer(Config{Endpoint: "http://\x7f", Model: "m"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.Review(context.Background(), "a", "intent", "some work"); err == nil {
+		t.Error("expected request-build error on malformed endpoint")
+	}
+}
+
 func TestReviewFailsOpenOnServerError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
## Summary
Raises Go test coverage for two small packages, per #1896.

| Package | Before | After |
|---|---|---|
| `v2/pkg/promptsrc` | 87.9% | 93.9% |
| `v2/pkg/trajectory` | 87.4% | 97.6% |

Both verified with `-short` and without `-short`.

### promptsrc — new coverage
- `Resolve`: nil-fetcher-with-warm-cache hit path (fetcher goes away after a prior successful fetch, cache still served), empty-`Ref` provenance defaulting to `@default`
- `FetchOnce`: nil-context tolerance, oversize-body truncation (same cap as `Resolve`)

### trajectory — new coverage
- `Lane.Run`: reviewer transport-error path fails open — agent is not paused or audited when the reviewer endpoint is unreachable
- `Lane.act`: when `Pause()` itself returns an error, the divergence still falls through to audit/alert/notify
- `itoa`: zero, positive, negative, multi-digit
- `sanitize`: newline/CR/tab collapsing plus the no-op identity case
- `Reviewer.Review`: empty-`choices` response error, malformed (non-JSON) response body, HTTP transport error against an unreachable endpoint, request-build error from a malformed endpoint URL

## Production code changes
None — only `*_test.go` files were touched (`promptsrc_test.go`, `lane_test.go`, `trajectory_test.go`).

## Test plan
- [x] `go test ./pkg/promptsrc/ ./pkg/trajectory/ -short -count=1 -cover`
- [x] `go test ./pkg/promptsrc/ ./pkg/trajectory/ -count=1 -cover` (no `-short`)
- [x] `go vet ./pkg/promptsrc/... ./pkg/trajectory/...`
- [x] `gofmt -l` clean on touched files

Refs #1896