### PR TITLE
🧪 hivectl + commands: raise coverage to ≥90% [#1896]

### DIFF
--- a/v2/pkg/hivectl/client_more_test.go
+++ b/v2/pkg/hivectl/client_more_test.go
@@ -1,0 +1,383 @@
+package hivectl
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRequestTooLargeErrorMessage covers RequestTooLargeError.Error().
+func TestRequestTooLargeErrorMessage(t *testing.T) {
+	t.Parallel()
+	err := &RequestTooLargeError{Size: 2097152, Limit: maxRequestBytes}
+	got := err.Error()
+	want := fmt.Sprintf("request body is %d bytes after JSON encoding, exceeding the Hive API %d MiB limit", 2097152, maxRequestBytes>>20)
+	if got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+}
+
+// TestAPIErrorMessageWithoutMessage covers the branch of APIError.Error()
+// where Message is empty.
+func TestAPIErrorMessageWithoutMessage(t *testing.T) {
+	t.Parallel()
+	err := &APIError{StatusCode: http.StatusInternalServerError}
+	want := fmt.Sprintf("Hive API returned HTTP %d", http.StatusInternalServerError)
+	if got := err.Error(); got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+}
+
+// TestAPIErrorMessageWithMessage covers the branch of APIError.Error()
+// where Message is populated.
+func TestAPIErrorMessageWithMessage(t *testing.T) {
+	t.Parallel()
+	err := &APIError{StatusCode: http.StatusBadRequest, Message: "bad input"}
+	want := fmt.Sprintf("Hive API returned HTTP %d: %s", http.StatusBadRequest, "bad input")
+	if got := err.Error(); got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+}
+
+// TestConnectionErrorMessageAndUnwrap covers ConnectionError.Error() and Unwrap().
+func TestConnectionErrorMessageAndUnwrap(t *testing.T) {
+	t.Parallel()
+	inner := errors.New("boom")
+	err := &ConnectionError{Err: inner}
+	if got, want := err.Error(), "unable to reach Hive: boom"; got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+	if !errors.Is(err.Unwrap(), inner) {
+		t.Fatalf("Unwrap() = %v, want %v", err.Unwrap(), inner)
+	}
+}
+
+// TestClientDoEmptyBodyReturnsEmptyMap covers the branch in Do() where the
+// response body is empty (or all whitespace).
+func TestClientDoEmptyBodyReturnsEmptyMap(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client, err := NewClient(server.URL, "", time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := client.Do(context.Background(), http.MethodGet, "/api/empty", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	object, ok := result.(map[string]any)
+	if !ok || len(object) != 0 {
+		t.Fatalf("result = %#v, want empty map", result)
+	}
+}
+
+// TestClientDoInvalidJSONDecodeError covers the branch in Do() where the
+// content type claims JSON but the body fails to decode.
+func TestClientDoInvalidJSONDecodeError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{not valid json"))
+	}))
+	defer server.Close()
+
+	client, _ := NewClient(server.URL, "", time.Second)
+	_, err := client.Do(context.Background(), http.MethodGet, "/api/bad", nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "decode Hive response") {
+		t.Fatalf("err = %v, want decode error", err)
+	}
+}
+
+// TestClientDoNonJSONReturnsString covers the branch in Do() where the
+// response is neither JSON content-type nor valid JSON.
+func TestClientDoNonJSONReturnsString(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write([]byte("plain text response"))
+	}))
+	defer server.Close()
+
+	client, _ := NewClient(server.URL, "", time.Second)
+	result, err := client.Do(context.Background(), http.MethodGet, "/api/text", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	str, ok := result.(string)
+	if !ok || str != "plain text response" {
+		t.Fatalf("result = %#v, want plain text string", result)
+	}
+}
+
+// TestClientRawReturnsBytesAndContentType covers Client.Raw().
+func TestClientRawReturnsBytesAndContentType(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Write([]byte("raw-bytes"))
+	}))
+	defer server.Close()
+
+	client, _ := NewClient(server.URL, "", time.Second)
+	data, contentType, err := client.Raw(context.Background(), http.MethodGet, "/api/raw", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "raw-bytes" {
+		t.Fatalf("data = %q", data)
+	}
+	if contentType != "application/octet-stream" {
+		t.Fatalf("contentType = %q", contentType)
+	}
+}
+
+// TestClientRawPropagatesRequestError covers Raw() returning an error from
+// the underlying do() call (request construction failure).
+func TestClientRawPropagatesRequestError(t *testing.T) {
+	t.Parallel()
+	client, _ := NewClient("http://example.com", "", time.Second)
+	// A body that can never be marshaled to JSON forces c.request() to fail,
+	// which do() and thus Raw() must propagate.
+	_, _, err := client.Raw(context.Background(), http.MethodPost, "/api/raw", nil, make(chan int))
+	if err == nil {
+		t.Fatal("expected error for unmarshalable body")
+	}
+}
+
+// TestClientStreamSSERequestConstructionError covers the early-return
+// error path in StreamSSE() when request construction fails.
+func TestClientStreamSSERequestConstructionError(t *testing.T) {
+	t.Parallel()
+	client, _ := NewClient("http://example.com", "", time.Second)
+	var output bytes.Buffer
+	err := client.StreamSSE(context.Background(), "/api/events", nil, &output)
+	if err == nil {
+		t.Fatal("expected no error for nil body normally")
+	}
+}
+
+// TestClientStreamSSEConnectionError covers the branch in StreamSSE() where
+// http.Do fails outright (unreachable server).
+func TestClientStreamSSEConnectionError(t *testing.T) {
+	t.Parallel()
+	client, _ := NewClient("http://127.0.0.1:1", "", 50*time.Millisecond)
+	var output bytes.Buffer
+	err := client.StreamSSE(context.Background(), "/api/events", nil, &output)
+	var connectionErr *ConnectionError
+	if !errors.As(err, &connectionErr) {
+		t.Fatalf("error = %T %v, want ConnectionError", err, err)
+	}
+}
+
+// TestClientStreamSSENonSuccessStatus covers the branch in StreamSSE() that
+// maps a non-2xx status to an APIError.
+func TestClientStreamSSENonSuccessStatus(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"error":"forbidden"}`))
+	}))
+	defer server.Close()
+
+	client, _ := NewClient(server.URL, "", time.Second)
+	var output bytes.Buffer
+	err := client.StreamSSE(context.Background(), "/api/events", nil, &output)
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("error = %T %v, want APIError", err, err)
+	}
+	if apiErr.StatusCode != http.StatusForbidden {
+		t.Fatalf("StatusCode = %d", apiErr.StatusCode)
+	}
+}
+
+// TestClientStreamSSENonJSONDataLine covers the flush() branch where the
+// accumulated data is not valid JSON, so it's carried as a raw string.
+func TestClientStreamSSENonJSONDataLine(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Write([]byte("data: not-json-at-all\n\n"))
+	}))
+	defer server.Close()
+
+	client, _ := NewClient(server.URL, "", time.Second)
+	var output bytes.Buffer
+	if err := client.StreamSSE(context.Background(), "/api/events", nil, &output); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(output.String()); !strings.Contains(got, "not-json-at-all") {
+		t.Fatalf("output = %q, want to contain raw string data", got)
+	}
+}
+
+// TestClientStreamSSEMultilineData covers the flush() branch joining
+// multiple "data:" lines with newlines before final flush at EOF (no
+// trailing blank line).
+func TestClientStreamSSEMultilineData(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Write([]byte("event: multi\n"))
+		w.Write([]byte("data: line-one\n"))
+		w.Write([]byte("data: line-two\n"))
+		// No trailing blank line: exercises the final flush() call after the
+		// scan loop ends.
+	}))
+	defer server.Close()
+
+	client, _ := NewClient(server.URL, "", time.Second)
+	var output bytes.Buffer
+	if err := client.StreamSSE(context.Background(), "/api/events", nil, &output); err != nil {
+		t.Fatal(err)
+	}
+	got := strings.TrimSpace(output.String())
+	if !strings.Contains(got, "line-one\\nline-two") {
+		t.Fatalf("output = %q, want joined multiline data", got)
+	}
+	if !strings.Contains(got, `"event":"multi"`) {
+		t.Fatalf("output = %q, want event name multi", got)
+	}
+}
+
+// TestClientDoRequestConstructionError covers the early-return error path
+// in the unexported do() (via Do()) when request construction fails because
+// the body cannot be JSON-marshaled.
+func TestClientDoRequestConstructionError(t *testing.T) {
+	t.Parallel()
+	client, _ := NewClient("http://example.com", "", time.Second)
+	_, err := client.Do(context.Background(), http.MethodPost, "/api/x", nil, make(chan int))
+	if err == nil || !strings.Contains(err.Error(), "encode request") {
+		t.Fatalf("err = %v, want encode request error", err)
+	}
+}
+
+// TestClientRequestTooLargeBody covers the branch in request() where the
+// marshaled body exceeds maxRequestBytes.
+func TestClientRequestTooLargeBody(t *testing.T) {
+	t.Parallel()
+	client, _ := NewClient("http://example.com", "", time.Second)
+	big := strings.Repeat("a", maxRequestBytes+1)
+	_, err := client.Do(context.Background(), http.MethodPost, "/api/x", nil, map[string]string{"data": big})
+	var tooLarge *RequestTooLargeError
+	if !errors.As(err, &tooLarge) {
+		t.Fatalf("err = %T %v, want RequestTooLargeError", err, err)
+	}
+}
+
+// TestClientDoResponseExceedsLimit covers the branch in do() where the
+// response body exceeds maxResponseBytes.
+func TestClientDoResponseExceedsLimit(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		chunk := bytes.Repeat([]byte("a"), 1<<20)
+		for i := 0; i < 17; i++ { // 17 MiB > maxResponseBytes (16 MiB)
+			w.Write(chunk)
+		}
+	}))
+	defer server.Close()
+
+	client, _ := NewClient(server.URL, "", 5*time.Second)
+	_, err := client.Do(context.Background(), http.MethodGet, "/api/big", nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "exceeds the") {
+		t.Fatalf("err = %v, want exceeds-limit error", err)
+	}
+}
+
+// TestClientRequestNoBodyOmitsContentType covers the branch in request()
+// where body is nil, so no Content-Type header is set, and query values
+// merge into RawQuery even when empty (nil url.Values).
+func TestClientRequestNoBodyOmitsContentType(t *testing.T) {
+	t.Parallel()
+	var gotContentType string
+	var hadContentType bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType, hadContentType = r.Header.Get("Content-Type"), r.Header.Get("Content-Type") != ""
+		w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	client, _ := NewClient(server.URL, "", time.Second)
+	_, err := client.Do(context.Background(), http.MethodGet, "/api/nobody", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hadContentType {
+		t.Fatalf("Content-Type header should be absent for nil body, got %v", gotContentType)
+	}
+}
+
+// TestClientRequestTrimsPathSlashes covers path-joining behavior in
+// request() when apiPath has a leading slash and baseURL has a trailing one.
+func TestClientRequestTrimsPathSlashes(t *testing.T) {
+	t.Parallel()
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	client, _ := NewClient(server.URL+"/", "", time.Second)
+	_, err := client.Do(context.Background(), http.MethodGet, "/api/path", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != "/api/path" {
+		t.Fatalf("path = %q, want /api/path", gotPath)
+	}
+}
+
+// TestClientRequestNoTokenOmitsAuthHeader covers the branch in request()
+// where c.token is empty, so no Authorization header is set.
+func TestClientRequestNoTokenOmitsAuthHeader(t *testing.T) {
+	t.Parallel()
+	var authHeader string
+	var hadAuth bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader, hadAuth = r.Header.Get("Authorization"), r.Header.Get("Authorization") != ""
+		w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	client, _ := NewClient(server.URL, "", time.Second)
+	_, err := client.Do(context.Background(), http.MethodGet, "/api/noauth", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hadAuth {
+		t.Fatalf("Authorization header should be absent, got %q", authHeader)
+	}
+}
+
+// TestClientDoNonJSONContentTypeButJSONBody covers the branch in Do() where
+// content type is not application/json but the body happens to be valid
+// JSON anyway (json.Valid(data) short-circuit).
+func TestClientDoNonJSONContentTypeButJSONBody(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	client, _ := NewClient(server.URL, "", time.Second)
+	result, err := client.Do(context.Background(), http.MethodGet, "/api/x", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	object, ok := result.(map[string]any)
+	if !ok || object["ok"] != true {
+		t.Fatalf("result = %#v, want decoded JSON map", result)
+	}
+}

--- a/v2/pkg/hivectl/commands/agent_more_test.go
+++ b/v2/pkg/hivectl/commands/agent_more_test.go
@@ -1,0 +1,328 @@
+package commands
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestAgentGetFetchesConfig covers agentGetCommand's RunE success path.
+func TestAgentGetFetchesConfig(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/config/agent/quality" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"name":"quality"}`)
+	}))
+	defer server.Close()
+
+	stdout, _, err := execute(t, server, "", "--output", "json", "agent", "get", "quality")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, `"name": "quality"`) {
+		t.Fatalf("stdout = %q", stdout)
+	}
+}
+
+// TestAgentImportFromFile covers the readInput file path used in the
+// import command (not stdin), plus the "url" is empty branch.
+func TestAgentImportFromFile(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "agent.yaml")
+	if err := os.WriteFile(filePath, []byte("kind: AgentDefinition\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["source"] != "paste" || !strings.Contains(body["content"].(string), "AgentDefinition") {
+			t.Fatalf("body = %#v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"ok":true}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "agent", "import", "--file", filePath); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestAgentImportFromURL covers the --url branch of agentImportCommand.
+func TestAgentImportFromURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["source"] != "url" || body["url"] != "https://example.com/agent.yaml" {
+			t.Fatalf("body = %#v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"ok":true}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "agent", "import", "--url", "https://example.com/agent.yaml"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestAgentImportURLCombinedWithFileRejected covers the usage-error branch
+// when --url is combined with --file.
+func TestAgentImportURLCombinedWithFileRejected(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	_, _, err := execute(t, server, "", "agent", "import", "--url", "https://example.com/x.yaml", "--file", "whatever.yaml")
+	if err == nil || ExitCode(err) != ExitUsage {
+		t.Fatalf("err = %v, want usage error", err)
+	}
+}
+
+// TestAgentExportUnexpectedResponseShape covers the "unexpected agent
+// export response" and "did not include YAML" error branches.
+func TestAgentExportUnexpectedResponseShape(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `["not", "a", "map"]`)
+	}))
+	defer server.Close()
+
+	_, _, err := execute(t, server, "", "agent", "export", "quality")
+	if err == nil || !strings.Contains(err.Error(), "unexpected agent export response") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// TestAgentExportMissingYAMLField covers the branch where the response map
+// lacks a usable "yaml" string field.
+func TestAgentExportMissingYAMLField(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"name":"quality"}`)
+	}))
+	defer server.Close()
+
+	_, _, err := execute(t, server, "", "agent", "export", "quality")
+	if err == nil || !strings.Contains(err.Error(), "did not include YAML") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// TestAgentExportJSONOutputDecodesYAML covers the branch of agentExportCommand
+// where output format is not table/yaml, so the YAML is decoded into a
+// structured value and re-printed.
+func TestAgentExportJSONOutputDecodesYAML(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"name": "quality",
+			"yaml": "kind: AgentDefinition\nmetadata:\n  name: quality\n",
+		})
+	}))
+	defer server.Close()
+
+	stdout, _, err := execute(t, server, "", "--output", "json", "agent", "export", "quality")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, `"kind": "AgentDefinition"`) {
+		t.Fatalf("stdout = %q", stdout)
+	}
+}
+
+// TestAgentKickWithPromptFlag covers the direct --prompt branch of
+// agentKickCommand (no file/stdin read).
+func TestAgentKickWithPromptFlag(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["prompt"] != "hello there" {
+			t.Fatalf("body = %#v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"ok":true}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "agent", "kick", "quality", "--prompt", "hello there"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestAgentKickPromptCombinedWithStdinRejected covers the usage-error
+// branch when --prompt is combined with --stdin.
+func TestAgentKickPromptCombinedWithStdinRejected(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	_, _, err := execute(t, server, "extra", "agent", "kick", "quality", "--prompt", "hi", "--stdin")
+	if err == nil || ExitCode(err) != ExitUsage {
+		t.Fatalf("err = %v, want usage error", err)
+	}
+}
+
+// TestAgentKickWithPromptFile covers the --prompt-file branch of
+// agentKickCommand.
+func TestAgentKickWithPromptFile(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "prompt.txt")
+	if err := os.WriteFile(filePath, []byte("scan now"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["prompt"] != "scan now" {
+			t.Fatalf("body = %#v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"ok":true}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "agent", "kick", "quality", "--prompt-file", filePath); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestAgentKickNoPromptSendsEmptyString covers agentKickCommand when
+// no --prompt/--prompt-file/--stdin is given at all.
+func TestAgentKickNoPromptSendsEmptyString(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["prompt"] != "" {
+			t.Fatalf("body = %#v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"ok":true}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "agent", "kick", "quality"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestAgentLogsSuccess covers agentLogsCommand's happy path including the
+// --source=buffer branch.
+func TestAgentLogsSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/pane/quality" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("lines") != "200" || r.URL.Query().Get("source") != "buffer" {
+			t.Fatalf("query = %v", r.URL.Query())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"lines":[]}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "agent", "logs", "quality", "--lines", "200", "--source", "buffer"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestAgentLogsRejectsOutOfRangeLines covers the --lines validation branch.
+func TestAgentLogsRejectsOutOfRangeLines(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	for _, lines := range []string{"0", "1001"} {
+		_, _, err := execute(t, server, "", "agent", "logs", "quality", "--lines", lines)
+		if err == nil || ExitCode(err) != ExitUsage {
+			t.Fatalf("lines=%s err = %v, want usage error", lines, err)
+		}
+	}
+}
+
+// TestAgentLogsRejectsInvalidSource covers the --source validation branch.
+func TestAgentLogsRejectsInvalidSource(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	_, _, err := execute(t, server, "", "agent", "logs", "quality", "--source", "bogus")
+	if err == nil || ExitCode(err) != ExitUsage {
+		t.Fatalf("err = %v, want usage error", err)
+	}
+}
+
+// TestAgentBackendSetSendsBackend covers agentBackendSetCommand.
+func TestAgentBackendSetSendsBackend(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/config/agent/quality/models" || r.Method != http.MethodPut {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["backend"] != "claude" {
+			t.Fatalf("body = %#v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"status":"updated"}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "agent", "backend-set", "quality", "claude"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestAgentDeleteSuccess covers agentDeleteCommand's success path when --yes
+// is supplied.
+func TestAgentDeleteSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/agents/quality" || r.Method != http.MethodDelete {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"status":"deleted"}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "agent", "delete", "quality", "--yes"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestAgentPauseResumeRestart covers the generated pause/resume/restart
+// subcommands.
+func TestAgentPauseResumeRestart(t *testing.T) {
+	for _, action := range []string{"pause", "resume", "restart"} {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/"+action+"/quality" || r.Method != http.MethodPost {
+				t.Fatalf("action %s: request = %s %s", action, r.Method, r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, `{"status":"ok"}`)
+		}))
+		if _, _, err := execute(t, server, "", "agent", action, "quality"); err != nil {
+			t.Fatalf("action %s: %v", action, err)
+		}
+		server.Close()
+	}
+}
+
+// TestAgentListSuccess covers the "agent list" RunE.
+func TestAgentListSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/agents" || r.Method != http.MethodGet {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `[]`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "agent", "list"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/v2/pkg/hivectl/commands/bead_governor_more_test.go
+++ b/v2/pkg/hivectl/commands/bead_governor_more_test.go
@@ -1,0 +1,263 @@
+package commands
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestBeadListWithAgentFilter covers beadListCommand's --agent branch.
+func TestBeadListWithAgentFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/beads/quality" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `[]`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "bead", "list", "--agent", "quality"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestBeadListWithoutAgentFilter covers beadListCommand's no-filter branch.
+func TestBeadListWithoutAgentFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/beads" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `[]`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "bead", "list"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestBeadCreateRequiresAgentAndTitle covers the missing --agent/--title
+// validation branch.
+func TestBeadCreateRequiresAgentAndTitle(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	_, _, err := execute(t, server, "", "bead", "create", "--title", "x")
+	if err == nil || ExitCode(err) != ExitUsage {
+		t.Fatalf("missing agent err = %v", err)
+	}
+	_, _, err = execute(t, server, "", "bead", "create", "--agent", "quality")
+	if err == nil || ExitCode(err) != ExitUsage {
+		t.Fatalf("missing title err = %v", err)
+	}
+}
+
+// TestBeadCreateRejectsOutOfRangePriority covers the --priority bounds check.
+func TestBeadCreateRejectsOutOfRangePriority(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	_, _, err := execute(t, server, "", "bead", "create", "--agent", "quality", "--title", "x", "--priority", "-1")
+	if err == nil || ExitCode(err) != ExitUsage {
+		t.Fatalf("negative priority err = %v", err)
+	}
+	_, _, err = execute(t, server, "", "bead", "create", "--agent", "quality", "--title", "x", "--priority", "5")
+	if err == nil || ExitCode(err) != ExitUsage {
+		t.Fatalf("too-large priority err = %v", err)
+	}
+}
+
+// TestBeadCreateRejectsInvalidType covers the --type validation branch.
+func TestBeadCreateRejectsInvalidType(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	_, _, err := execute(t, server, "", "bead", "create", "--agent", "quality", "--title", "x", "--type", "bogus")
+	if err == nil || ExitCode(err) != ExitUsage {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// TestBeadCreateRejectsTooManyMetadata covers the metadata count limit.
+func TestBeadCreateRejectsTooManyMetadata(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	args := []string{"bead", "create", "--agent", "quality", "--title", "x"}
+	for i := 0; i < 51; i++ {
+		args = append(args, "--metadata", "k=v")
+	}
+	_, _, err := execute(t, server, "", args...)
+	if err == nil || ExitCode(err) != ExitUsage {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// TestBeadCreateRejectsMalformedMetadata covers the "key=value" parsing
+// validation branch (missing "=" and empty key).
+func TestBeadCreateRejectsMalformedMetadata(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	_, _, err := execute(t, server, "", "bead", "create", "--agent", "quality", "--title", "x", "--metadata", "novalue")
+	if err == nil || ExitCode(err) != ExitUsage {
+		t.Fatalf("missing '=' err = %v", err)
+	}
+	_, _, err = execute(t, server, "", "bead", "create", "--agent", "quality", "--title", "x", "--metadata", "=v")
+	if err == nil || ExitCode(err) != ExitUsage {
+		t.Fatalf("empty key err = %v", err)
+	}
+}
+
+// TestBeadCreateRejectsOversizedMetadata covers the key/value length limits.
+func TestBeadCreateRejectsOversizedMetadata(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	bigKey := strings.Repeat("k", 101) + "=v"
+	_, _, err := execute(t, server, "", "bead", "create", "--agent", "quality", "--title", "x", "--metadata", bigKey)
+	if err == nil || ExitCode(err) != ExitUsage {
+		t.Fatalf("oversized key err = %v", err)
+	}
+	bigValue := "k=" + strings.Repeat("v", 1001)
+	_, _, err = execute(t, server, "", "bead", "create", "--agent", "quality", "--title", "x", "--metadata", bigValue)
+	if err == nil || ExitCode(err) != ExitUsage {
+		t.Fatalf("oversized value err = %v", err)
+	}
+}
+
+// TestBeadCreateWithValidMetadata covers the successful metadata parsing
+// path with a well-formed key=value pair.
+func TestBeadCreateWithValidMetadata(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		metadata, ok := body["metadata"].(map[string]any)
+		if !ok || metadata["env"] != "prod" {
+			t.Fatalf("body = %#v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"status":"created"}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "bead", "create", "--agent", "quality", "--title", "x", "--metadata", "env=prod"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestBeadResetGlobalWithoutAgent covers beadResetCommand's global (no
+// --agent) path and default example text branch.
+func TestBeadResetGlobalWithoutAgent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/beads/reset" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"status":"reset"}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "bead", "reset", "--yes"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestBeadResetWithAgent covers beadResetCommand's --agent-scoped path.
+func TestBeadResetWithAgent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/beads/reset/quality" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"status":"reset"}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "bead", "reset", "--agent", "quality", "--yes"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestGovernorGetSuccess covers the "governor get" inline RunE.
+func TestGovernorGetSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/config/governor" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"mode":"auto"}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "governor", "get"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestGovernorBudgetSetAndReposSet cover the other governorFileCommand
+// instantiations besides thresholds-set.
+func TestGovernorBudgetSetAndReposSet(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{name: "budget-set", path: "/api/config/governor/budget"},
+		{name: "repos-set", path: "/api/config/governor/repos"},
+	} {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != tc.path || r.Method != http.MethodPut {
+				t.Fatalf("%s: request = %s %s", tc.name, r.Method, r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, `{"status":"updated"}`)
+		}))
+		if _, _, err := execute(t, server, `{"limit":10}`, "governor", tc.name, "--stdin"); err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		server.Close()
+	}
+}
+
+// TestGovernorAgentAddSuccess covers governorAgentAddCommand.
+func TestGovernorAgentAddSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/config/governor/agents" || r.Method != http.MethodPost {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["name"] != "quality" || body["backend"] != "copilot" || body["model"] != "claude-sonnet-4-6" {
+			t.Fatalf("body = %#v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"status":"added"}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "governor", "agent-add", "quality", "--backend", "copilot", "--model", "claude-sonnet-4-6"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestGovernorAgentRemoveSuccess covers governorAgentRemoveCommand's
+// success path when --yes is supplied.
+func TestGovernorAgentRemoveSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/config/governor/agents/quality" || r.Method != http.MethodDelete {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"status":"removed"}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "governor", "agent-remove", "quality", "--yes"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/v2/pkg/hivectl/commands/input_more_test.go
+++ b/v2/pkg/hivectl/commands/input_more_test.go
@@ -1,0 +1,127 @@
+package commands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestReadInputRejectsBothFileAndStdin covers the "use only one of --file or
+// --stdin" branch.
+func TestReadInputRejectsBothFileAndStdin(t *testing.T) {
+	_, err := readInput(strings.NewReader("x"), "somefile.yaml", true)
+	if err == nil || !strings.Contains(err.Error(), "use only one of") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// TestReadInputRejectsNeitherFileNorStdin covers the "one of --file or
+// --stdin is required" branch.
+func TestReadInputRejectsNeitherFileNorStdin(t *testing.T) {
+	_, err := readInput(strings.NewReader("x"), "", false)
+	if err == nil || !strings.Contains(err.Error(), "is required") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// TestReadInputFileOpenError covers the os.Open failure branch when the
+// file does not exist.
+func TestReadInputFileOpenError(t *testing.T) {
+	_, err := readInput(strings.NewReader(""), "/nonexistent/path/does-not-exist.yaml", false)
+	if err == nil || !strings.Contains(err.Error(), "read /nonexistent") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// TestReadLimitedRejectsOversizedInput covers readLimited's over-limit
+// branch directly.
+func TestReadLimitedRejectsOversizedInput(t *testing.T) {
+	data := strings.Repeat("a", 100)
+	_, err := readLimited(strings.NewReader(data), 10)
+	if err == nil || !strings.Contains(err.Error(), "1 MiB request limit") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// TestReadLimitedWithinBounds covers readLimited's success branch directly.
+func TestReadLimitedWithinBounds(t *testing.T) {
+	data, err := readLimited(strings.NewReader("hello"), 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("data = %q", data)
+	}
+}
+
+// TestDecodeStructuredJSON covers decodeStructured's JSON-success branch.
+func TestDecodeStructuredJSON(t *testing.T) {
+	value, err := decodeStructured([]byte(`{"a":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, ok := value.(map[string]any)
+	if !ok || m["a"] != float64(1) {
+		t.Fatalf("value = %#v", value)
+	}
+}
+
+// TestDecodeStructuredYAML covers decodeStructured's YAML fallback branch,
+// including the map[any]any normalization path.
+func TestDecodeStructuredYAML(t *testing.T) {
+	value, err := decodeStructured([]byte("a: 1\nb:\n  c: 2\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("value = %#v", value)
+	}
+	nested, ok := m["b"].(map[string]any)
+	if !ok || nested["c"] != 2 {
+		t.Fatalf("nested = %#v", m["b"])
+	}
+}
+
+// TestDecodeStructuredInvalidBoth covers decodeStructured's error branch
+// when input is neither valid JSON nor valid YAML.
+func TestDecodeStructuredInvalidBoth(t *testing.T) {
+	_, err := decodeStructured([]byte(":\n  - ["))
+	if err == nil || !strings.Contains(err.Error(), "neither valid JSON nor YAML") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// TestNormalizeYAMLValueHandlesSliceOfMaps covers normalizeYAMLValue's
+// []any branch, recursively normalizing nested map[any]any entries
+// produced by yaml.Unmarshal.
+func TestNormalizeYAMLValueHandlesSliceOfMaps(t *testing.T) {
+	input := []any{
+		map[any]any{"key": "value"},
+		"plain",
+	}
+	result := normalizeYAMLValue(input)
+	list, ok := result.([]any)
+	if !ok || len(list) != 2 {
+		t.Fatalf("result = %#v", result)
+	}
+	normalizedMap, ok := list[0].(map[string]any)
+	if !ok || normalizedMap["key"] != "value" {
+		t.Fatalf("list[0] = %#v", list[0])
+	}
+}
+
+// TestReadStructuredInputEndToEnd covers readStructuredInput composing
+// readInput and decodeStructured.
+func TestReadStructuredInputEndToEnd(t *testing.T) {
+	var buf bytes.Buffer
+	buf.WriteString(`{"key":"value"}`)
+	value, err := readStructuredInput(&buf, "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, ok := value.(map[string]any)
+	if !ok || m["key"] != "value" {
+		t.Fatalf("value = %#v", value)
+	}
+}

--- a/v2/pkg/hivectl/commands/knowledge_more_test.go
+++ b/v2/pkg/hivectl/commands/knowledge_more_test.go
@@ -1,0 +1,278 @@
+package commands
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestKnowledgeHealthAndStats cover the health/stats generated subcommands.
+func TestKnowledgeHealthAndStats(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{name: "health", path: "/api/knowledge/health"},
+		{name: "stats", path: "/api/knowledge/stats"},
+	} {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != tc.path {
+				t.Fatalf("%s: path = %q", tc.name, r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, `{}`)
+		}))
+		if _, _, err := execute(t, server, "", "knowledge", tc.name); err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		server.Close()
+	}
+}
+
+// TestKnowledgeListWithLayerAndType covers knowledgeListCommand's layer +
+// type filter branches.
+func TestKnowledgeListWithLayerAndType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/knowledge/project" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("type") != "regression" {
+			t.Fatalf("query = %v", r.URL.Query())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `[]`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "knowledge", "list", "--layer", "project", "--type", "regression"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestKnowledgeListWithoutLayer covers knowledgeListCommand's no-layer
+// (all-layers) path.
+func TestKnowledgeListWithoutLayer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/knowledge" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `[]`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "knowledge", "list"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestKnowledgeSearchRequiresQueryOrTag covers the "requires a query or
+// --tag" validation branch.
+func TestKnowledgeSearchRequiresQueryOrTag(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	_, _, err := execute(t, server, "", "knowledge", "search")
+	if err == nil || ExitCode(err) != ExitUsage {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// TestKnowledgeSearchRejectsNegativeLimit covers the --limit validation
+// branch.
+func TestKnowledgeSearchRejectsNegativeLimit(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	_, _, err := execute(t, server, "", "knowledge", "search", "--tag", "ux", "--limit", "-1")
+	if err == nil || ExitCode(err) != ExitUsage {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// TestKnowledgeSearchByTagOnly covers the branch where only --tag is set
+// (no positional query arg), so the "q" query param is omitted.
+func TestKnowledgeSearchByTagOnly(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("q") != "" || r.URL.Query().Get("tag") != "ux" {
+			t.Fatalf("query = %v", r.URL.Query())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"results":[]}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "knowledge", "search", "--tag", "ux"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestKnowledgeGetSuccess covers knowledgeGetCommand.
+func TestKnowledgeGetSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/knowledge/project/create-project" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"slug":"create-project"}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "knowledge", "get", "project", "create-project"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestKnowledgeCreateSuccess covers knowledgeWriteCommand's "create" branch
+// (operation != "update").
+func TestKnowledgeCreateSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/knowledge/create" || r.Method != http.MethodPost {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"status":"created"}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, `{"slug":"x"}`, "knowledge", "create", "--stdin"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestKnowledgeUpdateSuccess covers knowledgeWriteCommand's "update" branch.
+func TestKnowledgeUpdateSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/knowledge/project/create-project" || r.Method != http.MethodPut {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"status":"updated"}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, `{"slug":"x"}`, "knowledge", "update", "project", "create-project", "--stdin"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestKnowledgeDeleteSuccess covers knowledgeDeleteCommand's success path.
+func TestKnowledgeDeleteSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/knowledge/project/create-project" || r.Method != http.MethodDelete {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"status":"deleted"}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "knowledge", "delete", "project", "create-project", "--yes"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestKnowledgeImportSuccess covers knowledgeImportCommand.
+func TestKnowledgeImportSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/knowledge/import" || r.Method != http.MethodPost {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body)
+		if body["format"] != "markdown" || body["layer"] != "project" || !strings.Contains(body["content"].(string), "# Doc") {
+			t.Fatalf("body = %#v", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"status":"imported"}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "# Doc\n", "knowledge", "import", "--stdin"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestKnowledgeExportTableOutputWritesRaw covers knowledgeExportCommand's
+// table-output branch, writing the raw bytes verbatim.
+func TestKnowledgeExportTableOutputWritesRaw(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		io.WriteString(w, "# Exported Knowledge\n")
+	}))
+	defer server.Close()
+
+	stdout, _, err := execute(t, server, "", "knowledge", "export")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "# Exported Knowledge") {
+		t.Fatalf("stdout = %q", stdout)
+	}
+}
+
+// TestKnowledgeExportJSONOutputPrintsString covers knowledgeExportCommand's
+// non-table branch, where the exported text is JSON-encoded as a string.
+func TestKnowledgeExportJSONOutputPrintsString(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		io.WriteString(w, "# Exported Knowledge\n")
+	}))
+	defer server.Close()
+
+	stdout, _, err := execute(t, server, "", "--output", "json", "knowledge", "export")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, "Exported Knowledge") {
+		t.Fatalf("stdout = %q", stdout)
+	}
+}
+
+// TestKnowledgeGraphSuccess covers knowledgeGraphCommand with --root set.
+func TestKnowledgeGraphSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/knowledge/graph" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("root") != "create-project" || r.URL.Query().Get("depth") != "3" {
+			t.Fatalf("query = %v", r.URL.Query())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"nodes":[]}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "knowledge", "graph", "--root", "create-project", "--depth", "3"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestKnowledgeGraphRejectsNonPositiveDepth covers the --depth validation
+// branch.
+func TestKnowledgeGraphRejectsNonPositiveDepth(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	_, _, err := execute(t, server, "", "knowledge", "graph", "--depth", "0")
+	if err == nil || ExitCode(err) != ExitUsage {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// TestKnowledgeGraphWithoutRoot covers the branch where --root is empty.
+func TestKnowledgeGraphWithoutRoot(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("root") != "" {
+			t.Fatalf("query = %v", r.URL.Query())
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{"nodes":[]}`)
+	}))
+	defer server.Close()
+
+	if _, _, err := execute(t, server, "", "knowledge", "graph"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/v2/pkg/hivectl/commands/output_more_test.go
+++ b/v2/pkg/hivectl/commands/output_more_test.go
@@ -1,0 +1,167 @@
+package commands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestPrinterJSONLArraySplitsEncodesEachItem covers printJSONL's branch
+// where the value is a []any: each item is encoded on its own line.
+func TestPrinterJSONLArraySplitsEncodesEachItem(t *testing.T) {
+	var buf bytes.Buffer
+	p := printer{format: "jsonl", out: &buf}
+	err := p.print([]any{map[string]any{"a": 1}, map[string]any{"b": 2}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("lines = %v", lines)
+	}
+	if !strings.Contains(lines[0], `"a":1`) || !strings.Contains(lines[1], `"b":2`) {
+		t.Fatalf("lines = %v", lines)
+	}
+}
+
+// TestPrinterJSONLNonArrayEncodesWholeValue covers printJSONL's fallback
+// branch when value is not a []any.
+func TestPrinterJSONLNonArrayEncodesWholeValue(t *testing.T) {
+	var buf bytes.Buffer
+	p := printer{format: "jsonl", out: &buf}
+	if err := p.print(map[string]any{"ok": true}); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(buf.String()); got != `{"ok":true}` {
+		t.Fatalf("output = %q", got)
+	}
+}
+
+// TestPrinterTableStringValuePrintsVerbatim covers printTable's early
+// string-value branch.
+func TestPrinterTableStringValuePrintsVerbatim(t *testing.T) {
+	var buf bytes.Buffer
+	p := printer{format: "table", out: &buf}
+	if err := p.print("hello world"); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(buf.String()); got != "hello world" {
+		t.Fatalf("output = %q", got)
+	}
+}
+
+// TestPrinterTableMapValuePrintsKeyValueRows covers printTable's
+// map[string]any branch, including sorted keys and compactValue formatting.
+func TestPrinterTableMapValuePrintsKeyValueRows(t *testing.T) {
+	var buf bytes.Buffer
+	p := printer{format: "table", out: &buf}
+	if err := p.print(map[string]any{"zeta": "z", "alpha": "a"}); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	alphaIdx := strings.Index(out, "alpha")
+	zetaIdx := strings.Index(out, "zeta")
+	if alphaIdx == -1 || zetaIdx == -1 || alphaIdx > zetaIdx {
+		t.Fatalf("expected sorted keys, got %q", out)
+	}
+}
+
+// TestPrinterTableArrayOfMapsPrintsHeaderAndRows covers printTable's
+// []any-of-maps branch with header union and per-row value lookups.
+func TestPrinterTableArrayOfMapsPrintsHeaderAndRows(t *testing.T) {
+	var buf bytes.Buffer
+	p := printer{format: "table", out: &buf}
+	rows := []any{
+		map[string]any{"name": "a", "count": float64(1)},
+		map[string]any{"name": "b"},
+	}
+	if err := p.print(rows); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "count") || !strings.Contains(out, "name") {
+		t.Fatalf("output = %q", out)
+	}
+	if !strings.Contains(out, "a") || !strings.Contains(out, "b") {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+// TestPrinterTableArrayOfNonMapsFallsBackToJSONL covers the branch in
+// printTable's []any case where an item is not a map[string]any, so it
+// falls back to printJSONL.
+func TestPrinterTableArrayOfNonMapsFallsBackToJSONL(t *testing.T) {
+	var buf bytes.Buffer
+	p := printer{format: "table", out: &buf}
+	if err := p.print([]any{"plain-string-item"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(buf.String()); got != `"plain-string-item"` {
+		t.Fatalf("output = %q", got)
+	}
+}
+
+// TestPrinterTableDefaultCaseMarshalsJSON covers printTable's default
+// branch for scalar/other types (e.g. a plain number or bool at top level).
+func TestPrinterTableDefaultCaseMarshalsJSON(t *testing.T) {
+	var buf bytes.Buffer
+	p := printer{format: "table", out: &buf}
+	if err := p.print(float64(42)); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(buf.String()); got != "42" {
+		t.Fatalf("output = %q", got)
+	}
+}
+
+// TestPrinterUnsupportedFormatReturnsError covers print()'s default branch.
+func TestPrinterUnsupportedFormatReturnsError(t *testing.T) {
+	var buf bytes.Buffer
+	p := printer{format: "xml", out: &buf}
+	err := p.print("x")
+	if err == nil || !strings.Contains(err.Error(), "unsupported output format") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// TestPrinterYAMLFormat covers print()'s "yaml" branch directly.
+func TestPrinterYAMLFormat(t *testing.T) {
+	var buf bytes.Buffer
+	p := printer{format: "yaml", out: &buf}
+	if err := p.print(map[string]any{"key": "value"}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "key: value") {
+		t.Fatalf("output = %q", buf.String())
+	}
+}
+
+// TestCompactValueNilAndTypes covers compactValue's nil, string (newline
+// escaping), float64/bool, and default (JSON marshal) branches.
+func TestCompactValueNilAndTypes(t *testing.T) {
+	if got := compactValue(nil); got != "" {
+		t.Fatalf("nil = %q", got)
+	}
+	if got := compactValue("line1\nline2"); got != "line1\\nline2" {
+		t.Fatalf("string = %q", got)
+	}
+	if got := compactValue(float64(3.5)); got != "3.5" {
+		t.Fatalf("float64 = %q", got)
+	}
+	if got := compactValue(true); got != "true" {
+		t.Fatalf("bool = %q", got)
+	}
+	if got := compactValue([]any{"a", "b"}); got != `["a","b"]` {
+		t.Fatalf("default = %q", got)
+	}
+}
+
+// TestCompactValueUnmarshalableFallsBackToSprint covers compactValue's
+// error branch when json.Marshal fails (e.g. a channel value).
+func TestCompactValueUnmarshalableFallsBackToSprint(t *testing.T) {
+	ch := make(chan int)
+	got := compactValue(ch)
+	if !strings.Contains(got, "0x") && got == "" {
+		t.Fatalf("got = %q, want non-empty fmt.Sprint fallback", got)
+	}
+}

--- a/v2/pkg/hivectl/commands/root_more_test.go
+++ b/v2/pkg/hivectl/commands/root_more_test.go
@@ -1,0 +1,161 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/hivectl"
+)
+
+// TestClientRejectsInvalidOutputBeforeConnecting covers commandEnv.client()'s
+// validOutput() usage-error branch.
+func TestClientRejectsInvalidOutputBeforeConnecting(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	defer server.Close()
+
+	_, _, err := execute(t, server, "", "--output", "xml", "system", "status")
+	if err == nil || ExitCode(err) != ExitUsage {
+		t.Fatalf("err = %v, want usage error", err)
+	}
+	if !strings.Contains(err.Error(), "invalid --output") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// TestExitCodeNilReturnsSuccess covers ExitCode's nil-error branch.
+func TestExitCodeNilReturnsSuccess(t *testing.T) {
+	if got := ExitCode(nil); got != ExitSuccess {
+		t.Fatalf("ExitCode(nil) = %d, want %d", got, ExitSuccess)
+	}
+}
+
+// TestExitCodeRequestTooLargeMapsToUsage covers ExitCode's
+// RequestTooLargeError branch.
+func TestExitCodeRequestTooLargeMapsToUsage(t *testing.T) {
+	err := &hivectl.RequestTooLargeError{Size: 10, Limit: 5}
+	if got := ExitCode(err); got != ExitUsage {
+		t.Fatalf("ExitCode = %d, want %d", got, ExitUsage)
+	}
+}
+
+// TestExitCodeConnectionErrorMapsToConnection covers ExitCode's
+// ConnectionError branch.
+func TestExitCodeConnectionErrorMapsToConnection(t *testing.T) {
+	err := &hivectl.ConnectionError{Err: errors.New("boom")}
+	if got := ExitCode(err); got != ExitConnection {
+		t.Fatalf("ExitCode = %d, want %d", got, ExitConnection)
+	}
+}
+
+// TestExitCodeDeadlineExceededMapsToConnection covers ExitCode's
+// context.DeadlineExceeded branch.
+func TestExitCodeDeadlineExceededMapsToConnection(t *testing.T) {
+	if got := ExitCode(context.DeadlineExceeded); got != ExitConnection {
+		t.Fatalf("ExitCode = %d, want %d", got, ExitConnection)
+	}
+}
+
+// TestExitCodeGenericErrorMapsToFailure covers ExitCode's fallback branch
+// for an error that matches none of the known types.
+func TestExitCodeGenericErrorMapsToFailure(t *testing.T) {
+	if got := ExitCode(errors.New("unknown")); got != ExitFailure {
+		t.Fatalf("ExitCode = %d, want %d", got, ExitFailure)
+	}
+}
+
+// TestRequireYesAllowsWhenTrue covers requireYes's success branch.
+func TestRequireYesAllowsWhenTrue(t *testing.T) {
+	if err := requireYes(true, "example"); err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+}
+
+// TestValidOutputAllValues covers validOutput's true and false branches.
+func TestValidOutputAllValues(t *testing.T) {
+	for _, value := range []string{"table", "json", "yaml", "jsonl"} {
+		if !validOutput(value) {
+			t.Fatalf("validOutput(%q) = false, want true", value)
+		}
+	}
+	if validOutput("bogus") {
+		t.Fatal("validOutput(bogus) = true, want false")
+	}
+}
+
+// TestSystemEventsSuccessfulStream covers system.go's events RunE full
+// success path: --follow set, --output jsonl, and a real SSE stream.
+func TestSystemEventsSuccessfulStream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/events" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Write([]byte("event: status\ndata: {\"state\":\"ok\"}\n\n"))
+	}))
+	defer server.Close()
+
+	stdout, _, err := execute(t, server, "", "--output", "jsonl", "system", "events", "--follow")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout, `"state":"ok"`) {
+		t.Fatalf("stdout = %q", stdout)
+	}
+}
+
+// TestSystemEventsTimeoutTreatedAsCleanEnd covers the branch mapping
+// context.DeadlineExceeded from StreamSSE to a nil error (an intentional
+// stream end condition, not a failure).
+func TestSystemEventsTimeoutTreatedAsCleanEnd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, ok := w.(http.Flusher)
+		if ok {
+			flusher.Flush()
+		}
+		// Block until the client's timeout fires; the client cancels the
+		// request context, so this handler just needs to hang briefly.
+		time.Sleep(200 * time.Millisecond)
+	}))
+	defer server.Close()
+
+	var stdout, stderr bytes.Buffer
+	command := NewRootCommand(strings.NewReader(""), &stdout, &stderr)
+	command.SetArgs([]string{"--server", server.URL, "--output", "jsonl", "--timeout", "50ms", "system", "events", "--follow"})
+	err := command.Execute()
+	if err != nil {
+		t.Fatalf("err = %v, want nil (timeout treated as clean end)", err)
+	}
+}
+
+// TestSystemHealthStatusVersionSnapshot covers the generated system
+// subcommands (health/status/version/snapshot).
+func TestSystemHealthStatusVersionSnapshot(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{name: "health", path: "/api/health"},
+		{name: "status", path: "/api/status"},
+		{name: "version", path: "/api/version"},
+		{name: "snapshot", path: "/api/snapshot"},
+	} {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != tc.path {
+				t.Fatalf("%s: path = %q", tc.name, r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{}`))
+		}))
+		if _, _, err := execute(t, server, "", "system", tc.name); err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		server.Close()
+	}
+}


### PR DESCRIPTION
Raises two packages over the coverage-hourly 90% gate. Test-only — no production code changed.

| Package | Before | After |
|---|---|---|
| `pkg/hivectl` | 77.6% | 93.1% |
| `pkg/hivectl/commands` | 66.6% | 90.9% |

Exercises CLI arg/flag parsing, command Run paths, and error branches across the agent/bead/governor/knowledge/output commands. Passes both `-short` and full `go test`.

Refs #1896