### PR TITLE
🧪 beads + config: raise coverage to ≥90% [#1896]

### DIFF
--- a/v2/pkg/beads/beads_archive_coverage_test.go
+++ b/v2/pkg/beads/beads_archive_coverage_test.go
@@ -1,0 +1,400 @@
+package beads
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestArchive_MovesBeadToArchiveLog verifies that Archive writes a compact
+// summary to archive.jsonl and removes the bead from the live store.
+func TestArchive_MovesBeadToArchiveLog(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	b, err := s.Create("archive me", TypeTask, PriorityLow, "alice", "ref-1")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := s.Close(b.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if err := s.Archive(b.ID); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	if _, err := s.Get(b.ID); err == nil {
+		t.Fatalf("expected bead to be removed from store after archive")
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, archiveFileName))
+	if err != nil {
+		t.Fatalf("reading archive file: %v", err)
+	}
+	if !strings.Contains(string(data), b.ID) {
+		t.Fatalf("archive file missing bead ID: %s", string(data))
+	}
+	if !strings.Contains(string(data), "archive me") {
+		t.Fatalf("archive file missing title: %s", string(data))
+	}
+}
+
+// TestArchive_NotFound verifies Archive returns an error for an unknown ID.
+func TestArchive_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	if err := s.Archive("does-not-exist"); err == nil {
+		t.Fatalf("expected error archiving missing bead")
+	}
+}
+
+// TestArchive_AppendsMultipleEntries verifies successive archive calls append
+// rather than overwrite the archive log, and that ClosedAt is carried through
+// when set.
+func TestArchive_AppendsMultipleEntries(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	b1, _ := s.Create("first", TypeBug, PriorityHigh, "alice", "")
+	b2, _ := s.Create("second", TypeChore, PriorityMinor, "bob", "")
+
+	if err := s.Close(b1.ID); err != nil {
+		t.Fatalf("Close b1: %v", err)
+	}
+
+	if err := s.Archive(b1.ID); err != nil {
+		t.Fatalf("Archive b1: %v", err)
+	}
+	if err := s.Archive(b2.ID); err != nil {
+		t.Fatalf("Archive b2: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, archiveFileName))
+	if err != nil {
+		t.Fatalf("reading archive file: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 archive lines, got %d: %v", len(lines), lines)
+	}
+}
+
+// TestArchive_OpenFileError verifies Archive surfaces an error when the
+// archive file path cannot be opened (e.g. a directory occupies the path).
+func TestArchive_OpenFileError(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	b, _ := s.Create("blocked", TypeTask, PriorityMedium, "alice", "")
+
+	// Make archive.jsonl a directory so OpenFile fails.
+	if err := os.MkdirAll(filepath.Join(dir, archiveFileName), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if err := s.Archive(b.ID); err == nil {
+		t.Fatalf("expected error when archive path is a directory")
+	}
+}
+
+// TestAllClosed_ReturnsDoneAndClosedOnly verifies AllClosed filters to
+// StatusDone and StatusClosed beads, excluding others.
+func TestAllClosed_ReturnsDoneAndClosedOnly(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	open, _ := s.Create("open one", TypeTask, PriorityMedium, "alice", "")
+	closed, _ := s.Create("closed one", TypeTask, PriorityMedium, "alice", "")
+	done, _ := s.Create("done one", TypeTask, PriorityMedium, "alice", "")
+	_ = open
+
+	if err := s.Close(closed.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := s.Update(done.ID, func(b *Bead) { b.Status = StatusDone }); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	result := s.AllClosed()
+	if len(result) != 2 {
+		t.Fatalf("expected 2 closed/done beads, got %d", len(result))
+	}
+	ids := map[string]bool{}
+	for _, b := range result {
+		ids[b.ID] = true
+	}
+	if !ids[closed.ID] || !ids[done.ID] {
+		t.Fatalf("expected closed and done beads present, got %v", ids)
+	}
+	if ids[open.ID] {
+		t.Fatalf("open bead should not be in AllClosed result")
+	}
+}
+
+// TestAllClosed_EmptyStore verifies AllClosed returns an empty slice when
+// there are no beads at all.
+func TestAllClosed_EmptyStore(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	if result := s.AllClosed(); len(result) != 0 {
+		t.Fatalf("expected empty result, got %d", len(result))
+	}
+}
+
+// TestHasOpenBead_Variants covers found+open, found+closed, and not-found cases.
+func TestHasOpenBead_Variants(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	open, _ := s.Create("open", TypeTask, PriorityMedium, "alice", "")
+	closed, _ := s.Create("closed", TypeTask, PriorityMedium, "alice", "")
+	if err := s.Close(closed.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if !s.HasOpenBead(open.ID) {
+		t.Fatalf("expected open bead to be reported as open")
+	}
+	if s.HasOpenBead(closed.ID) {
+		t.Fatalf("expected closed bead to be reported as not open")
+	}
+	if s.HasOpenBead("missing-id") {
+		t.Fatalf("expected missing bead to be reported as not open")
+	}
+}
+
+// TestUnsynthesized_FiltersCorrectly verifies that Unsynthesized returns only
+// done/closed beads lacking the synthesized_at metadata key, sorted by
+// CreatedAt.
+func TestUnsynthesized_FiltersCorrectly(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	openBead, _ := s.Create("still open", TypeTask, PriorityMedium, "alice", "")
+	closedUnsynth, _ := s.Create("closed unsynth", TypeTask, PriorityMedium, "alice", "")
+	closedSynth, _ := s.Create("closed synth", TypeTask, PriorityMedium, "alice", "")
+
+	if err := s.Close(closedUnsynth.ID); err != nil {
+		t.Fatalf("Close closedUnsynth: %v", err)
+	}
+	if err := s.Close(closedSynth.ID); err != nil {
+		t.Fatalf("Close closedSynth: %v", err)
+	}
+	if err := s.SetMetadata(closedSynth.ID, "synthesized_at", "2024-01-01T00:00:00Z"); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+
+	result := s.Unsynthesized()
+	if len(result) != 1 {
+		t.Fatalf("expected 1 unsynthesized bead, got %d", len(result))
+	}
+	if result[0].ID != closedUnsynth.ID {
+		t.Fatalf("expected %s, got %s", closedUnsynth.ID, result[0].ID)
+	}
+	_ = openBead
+}
+
+// TestUnsynthesized_EmptyWhenNoneClosed verifies Unsynthesized returns an
+// empty slice when no beads are done/closed.
+func TestUnsynthesized_EmptyWhenNoneClosed(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	if _, err := s.Create("still open", TypeTask, PriorityMedium, "alice", ""); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if result := s.Unsynthesized(); len(result) != 0 {
+		t.Fatalf("expected empty result, got %d", len(result))
+	}
+}
+
+// TestCreate_InvalidBeadType verifies Create rejects unknown bead types.
+func TestCreate_InvalidBeadType(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	if _, err := s.Create("bad type", BeadType("not-a-type"), PriorityMedium, "alice", ""); err == nil {
+		t.Fatalf("expected error for invalid bead type")
+	}
+}
+
+// TestCreate_StampsHiveIDMetadata verifies that when a hive ID is configured,
+// new beads are stamped with it in metadata.
+func TestCreate_StampsHiveIDMetadata(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	s.SetHiveID("hive-42")
+
+	b, err := s.Create("stamped", TypeTask, PriorityMedium, "alice", "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if b.Metadata[hiveIDMetadataKey] != "hive-42" {
+		t.Fatalf("expected hive_id metadata to be stamped, got %v", b.Metadata)
+	}
+}
+
+// TestCloseAll_NoOpenBeadsSkipsPersist verifies CloseAll returns 0 without
+// error when there is nothing open/in_progress/blocked to close.
+func TestCloseAll_NoOpenBeadsSkipsPersist(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	b, _ := s.Create("already done", TypeTask, PriorityMedium, "alice", "")
+	if err := s.Update(b.ID, func(bead *Bead) { bead.Status = StatusDone }); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	closed, err := s.CloseAll("shutdown")
+	if err != nil {
+		t.Fatalf("CloseAll: %v", err)
+	}
+	if closed != 0 {
+		t.Fatalf("expected 0 closed, got %d", closed)
+	}
+}
+
+// TestCloseAll_ClosesOpenInProgressAndBlocked verifies CloseAll transitions
+// every open/in_progress/blocked bead to closed and records the reason.
+func TestCloseAll_ClosesOpenInProgressAndBlocked(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	open, _ := s.Create("open", TypeTask, PriorityMedium, "alice", "")
+	inProgress, _ := s.Create("in progress", TypeTask, PriorityMedium, "alice", "")
+	blocked, _ := s.Create("blocked", TypeTask, PriorityMedium, "alice", "")
+
+	if err := s.Claim(inProgress.ID); err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if err := s.Update(blocked.ID, func(b *Bead) { b.Status = StatusBlocked }); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	closed, err := s.CloseAll("bulk shutdown")
+	if err != nil {
+		t.Fatalf("CloseAll: %v", err)
+	}
+	if closed != 3 {
+		t.Fatalf("expected 3 closed, got %d", closed)
+	}
+
+	for _, id := range []string{open.ID, inProgress.ID, blocked.ID} {
+		b, err := s.Get(id)
+		if err != nil {
+			t.Fatalf("Get %s: %v", id, err)
+		}
+		if b.Status != StatusClosed {
+			t.Fatalf("expected %s to be closed, got %s", id, b.Status)
+		}
+		if b.Meta("close_reason") != "bulk shutdown" {
+			t.Fatalf("expected close_reason metadata, got %v", b.Metadata)
+		}
+	}
+}
+
+// TestSetMetadata_InitializesNilMap verifies SetMetadata lazily creates the
+// metadata map on a bead that has none.
+func TestSetMetadata_InitializesNilMap(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	b, err := s.Create("no metadata", TypeTask, PriorityMedium, "alice", "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Force metadata to nil directly to exercise the lazy-init branch.
+	if err := s.Update(b.ID, func(bead *Bead) { bead.Metadata = nil }); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if err := s.SetMetadata(b.ID, "foo", "bar"); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+
+	got, err := s.Get(b.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Metadata["foo"] != "bar" {
+		t.Fatalf("expected metadata foo=bar, got %v", got.Metadata)
+	}
+}
+
+// TestMeta_NonStringValueFormatted verifies Meta stringifies non-string
+// metadata values via fmt.Sprintf rather than returning "".
+func TestMeta_NonStringValueFormatted(t *testing.T) {
+	b := &Bead{Metadata: map[string]interface{}{"count": 42}}
+	if got := b.Meta("count"); got != "42" {
+		t.Fatalf("expected \"42\", got %q", got)
+	}
+}
+
+// TestPersist_WriteError verifies persist surfaces an error when the target
+// directory has been removed out from under the store.
+func TestPersist_WriteError(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	if _, err := s.Create("first", TypeTask, PriorityMedium, "alice", ""); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+
+	if _, err := s.Create("second", TypeTask, PriorityMedium, "alice", ""); err == nil {
+		t.Fatalf("expected error persisting to removed directory")
+	}
+}

--- a/v2/pkg/config/config_uncovered_coverage_test.go
+++ b/v2/pkg/config/config_uncovered_coverage_test.go
@@ -1,0 +1,929 @@
+package config
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// BeadSynthesizerConfig.IsEnabled / ChannelConfig.IsEnabled
+// ---------------------------------------------------------------------------
+
+func TestBeadSynthesizerConfig_IsEnabled(t *testing.T) {
+	trueVal := true
+	falseVal := false
+	tests := []struct {
+		name string
+		cfg  BeadSynthesizerConfig
+		want bool
+	}{
+		{"nil defaults to enabled", BeadSynthesizerConfig{}, true},
+		{"explicit true", BeadSynthesizerConfig{Enabled: &trueVal}, true},
+		{"explicit false", BeadSynthesizerConfig{Enabled: &falseVal}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.IsEnabled(); got != tt.want {
+				t.Errorf("IsEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestChannelConfig_IsEnabled(t *testing.T) {
+	trueVal := true
+	falseVal := false
+	tests := []struct {
+		name string
+		cfg  ChannelConfig
+		want bool
+	}{
+		{"nil defaults to enabled", ChannelConfig{Type: "kick"}, true},
+		{"explicit true", ChannelConfig{Type: "kick", Enabled: &trueVal}, true},
+		{"explicit false", ChannelConfig{Type: "kick", Enabled: &falseVal}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.IsEnabled(); got != tt.want {
+				t.Errorf("IsEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AgentConfig.HasChannel / ChannelsOfType / UsesGovernorKick
+// ---------------------------------------------------------------------------
+
+func TestAgentConfig_HasChannel(t *testing.T) {
+	a := AgentConfig{Channels: []ChannelConfig{
+		{Type: "kick"},
+		{Type: "webhook"},
+	}}
+	if !a.HasChannel("kick") {
+		t.Error("expected HasChannel(kick) to be true")
+	}
+	if !a.HasChannel("webhook") {
+		t.Error("expected HasChannel(webhook) to be true")
+	}
+	if a.HasChannel("discord") {
+		t.Error("expected HasChannel(discord) to be false")
+	}
+}
+
+func TestAgentConfig_ChannelsOfType(t *testing.T) {
+	a := AgentConfig{Channels: []ChannelConfig{
+		{Type: "webhook", Events: []string{"push"}},
+		{Type: "webhook", Events: []string{"pr"}},
+		{Type: "kick"},
+	}}
+	webhooks := a.ChannelsOfType("webhook")
+	if len(webhooks) != 2 {
+		t.Fatalf("expected 2 webhook channels, got %d", len(webhooks))
+	}
+	if len(a.ChannelsOfType("discord")) != 0 {
+		t.Error("expected 0 discord channels")
+	}
+}
+
+func TestAgentConfig_UsesGovernorKick(t *testing.T) {
+	tests := []struct {
+		name string
+		a    AgentConfig
+		want bool
+	}{
+		{"no channels implies kick", AgentConfig{}, true},
+		{"explicit kick channel", AgentConfig{Channels: []ChannelConfig{{Type: "kick"}}}, true},
+		{"only webhook channel, no kick", AgentConfig{Channels: []ChannelConfig{{Type: "webhook", Events: []string{"push"}}}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.a.UsesGovernorKick(); got != tt.want {
+				t.Errorf("UsesGovernorKick() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GatewayConfig.ResolveAPIKey
+// ---------------------------------------------------------------------------
+
+func TestGatewayConfig_ResolveAPIKey(t *testing.T) {
+	t.Run("from env var", func(t *testing.T) {
+		t.Setenv("GW_TEST_KEY", "env-key-value")
+		gw := GatewayConfig{APIKeyEnv: "GW_TEST_KEY"}
+		if got := gw.ResolveAPIKey(); got != "env-key-value" {
+			t.Errorf("got %q, want env-key-value", got)
+		}
+	})
+
+	t.Run("from file when env unset", func(t *testing.T) {
+		dir := t.TempDir()
+		keyPath := filepath.Join(dir, "key.txt")
+		if err := os.WriteFile(keyPath, []byte("  file-key-value  \n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		gw := GatewayConfig{APIKeyFile: keyPath}
+		if got := gw.ResolveAPIKey(); got != "file-key-value" {
+			t.Errorf("got %q, want file-key-value", got)
+		}
+	})
+
+	t.Run("env takes priority over file", func(t *testing.T) {
+		t.Setenv("GW_TEST_KEY2", "env-wins")
+		dir := t.TempDir()
+		keyPath := filepath.Join(dir, "key.txt")
+		os.WriteFile(keyPath, []byte("file-loses"), 0o600)
+		gw := GatewayConfig{APIKeyEnv: "GW_TEST_KEY2", APIKeyFile: keyPath}
+		if got := gw.ResolveAPIKey(); got != "env-wins" {
+			t.Errorf("got %q, want env-wins", got)
+		}
+	})
+
+	t.Run("unset returns empty", func(t *testing.T) {
+		gw := GatewayConfig{}
+		if got := gw.ResolveAPIKey(); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("file path missing falls through to empty", func(t *testing.T) {
+		gw := GatewayConfig{APIKeyFile: "/nonexistent/path/to/key"}
+		if got := gw.ResolveAPIKey(); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// InferenceAuthConfig.ResolveAPIKey
+// ---------------------------------------------------------------------------
+
+func TestInferenceAuthConfig_ResolveAPIKey(t *testing.T) {
+	t.Run("from file", func(t *testing.T) {
+		dir := t.TempDir()
+		keyPath := filepath.Join(dir, "key.txt")
+		os.WriteFile(keyPath, []byte("file-key"), 0o600)
+		c := &InferenceAuthConfig{APIKeyFile: keyPath}
+		if got := c.ResolveAPIKey("DEFAULT_ENV_UNUSED"); got != "file-key" {
+			t.Errorf("got %q, want file-key", got)
+		}
+	})
+
+	t.Run("from named env when file unset", func(t *testing.T) {
+		t.Setenv("INF_TEST_KEY", "named-env-key")
+		c := &InferenceAuthConfig{APIKeyEnv: "INF_TEST_KEY"}
+		if got := c.ResolveAPIKey("DEFAULT_ENV_UNUSED"); got != "named-env-key" {
+			t.Errorf("got %q, want named-env-key", got)
+		}
+	})
+
+	t.Run("from default env when nothing else set", func(t *testing.T) {
+		t.Setenv("INF_DEFAULT_KEY", "default-env-key")
+		c := &InferenceAuthConfig{}
+		if got := c.ResolveAPIKey("INF_DEFAULT_KEY"); got != "default-env-key" {
+			t.Errorf("got %q, want default-env-key", got)
+		}
+	})
+
+	t.Run("nothing configured returns empty", func(t *testing.T) {
+		c := &InferenceAuthConfig{}
+		if got := c.ResolveAPIKey(""); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+
+	t.Run("empty file falls through to env", func(t *testing.T) {
+		dir := t.TempDir()
+		keyPath := filepath.Join(dir, "key.txt")
+		os.WriteFile(keyPath, []byte(""), 0o600)
+		t.Setenv("INF_TEST_KEY2", "fallback-env")
+		c := &InferenceAuthConfig{APIKeyFile: keyPath, APIKeyEnv: "INF_TEST_KEY2"}
+		if got := c.ResolveAPIKey(""); got != "fallback-env" {
+			t.Errorf("got %q, want fallback-env", got)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// LiteLLMConfig.ResolveAPIKeySource
+// ---------------------------------------------------------------------------
+
+func TestLiteLLMConfig_ResolveAPIKeySource(t *testing.T) {
+	t.Run("from configured file", func(t *testing.T) {
+		dir := t.TempDir()
+		keyPath := filepath.Join(dir, "key.txt")
+		os.WriteFile(keyPath, []byte("secretvalue"), 0o600)
+		c := &LiteLLMConfig{APIKeyFile: keyPath}
+		src := c.ResolveAPIKeySource()
+		if src != "file:"+keyPath {
+			t.Errorf("got %q, want file:%s", src, keyPath)
+		}
+	})
+
+	t.Run("from named env", func(t *testing.T) {
+		t.Setenv("LITELLM_TEST_KEY", "envval")
+		c := &LiteLLMConfig{APIKeyEnv: "LITELLM_TEST_KEY"}
+		src := c.ResolveAPIKeySource()
+		if src != "env:LITELLM_TEST_KEY" {
+			t.Errorf("got %q, want env:LITELLM_TEST_KEY", src)
+		}
+	})
+
+	t.Run("nothing configured returns empty source", func(t *testing.T) {
+		c := &LiteLLMConfig{}
+		if src := c.ResolveAPIKeySource(); src != "" {
+			t.Errorf("got %q, want empty", src)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// GitHubConfig.IsGHE / ResolvedAppSlug / AppInstallURL
+// ---------------------------------------------------------------------------
+
+func TestGitHubConfig_IsGHE(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		want    bool
+	}{
+		{"empty base url is not GHE", "", false},
+		{"default github.com is not GHE", DefaultGitHubBaseURL, false},
+		{"custom base url is GHE", "https://github.mycorp.com", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := GitHubConfig{BaseURL: tt.baseURL}
+			if got := g.IsGHE(); got != tt.want {
+				t.Errorf("IsGHE() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGitHubConfig_ResolvedAppSlug(t *testing.T) {
+	g := GitHubConfig{}
+	if got := g.ResolvedAppSlug(); got != DefaultGitHubAppSlug {
+		t.Errorf("got %q, want default %q", got, DefaultGitHubAppSlug)
+	}
+	g.AppSlug = "custom-slug"
+	if got := g.ResolvedAppSlug(); got != "custom-slug" {
+		t.Errorf("got %q, want custom-slug", got)
+	}
+}
+
+func TestGitHubConfig_AppInstallURL(t *testing.T) {
+	t.Run("github.com uses /apps/ path", func(t *testing.T) {
+		g := GitHubConfig{}
+		want := "https://github.com/apps/" + DefaultGitHubAppSlug + "/installations/new"
+		if got := g.AppInstallURL(); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("GHE uses /github-apps/ path", func(t *testing.T) {
+		g := GitHubConfig{BaseURL: "https://github.mycorp.com/", AppSlug: "corp-hive"}
+		want := "https://github.mycorp.com/github-apps/corp-hive/installations/new"
+		if got := g.AppInstallURL(); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// DashboardConfig.AuthorizedRole / splitAuthorizedEntry
+// ---------------------------------------------------------------------------
+
+func TestDashboardConfig_AuthorizedRole(t *testing.T) {
+	d := DashboardConfig{AuthorizedUsers: []string{
+		"owner-user",
+		"reader-user",
+		"explicit-owner:owner",
+		"explicit-reader:read",
+		"weird:banana",
+	}}
+
+	tests := []struct {
+		name     string
+		username string
+		wantRole string
+		wantOK   bool
+	}{
+		{"empty username", "", "", false},
+		{"first entry defaults to owner", "owner-user", RoleOwner, true},
+		{"later bare entry defaults to read", "reader-user", RoleRead, true},
+		{"case-insensitive match", "OWNER-USER", RoleOwner, true},
+		{"explicit owner suffix", "explicit-owner", RoleOwner, true},
+		{"explicit read suffix", "explicit-reader", RoleRead, true},
+		{"unknown role suffix downgrades to bare-name match", "weird:banana", RoleRead, true},
+		{"not found", "someone-else", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			role, ok := d.AuthorizedRole(tt.username)
+			if role != tt.wantRole || ok != tt.wantOK {
+				t.Errorf("AuthorizedRole(%q) = (%q, %v), want (%q, %v)", tt.username, role, ok, tt.wantRole, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestDashboardConfig_AuthorizedRole_WeirdSuffixMatchesWholeEntry(t *testing.T) {
+	// An unknown role suffix causes splitAuthorizedEntry to treat the WHOLE
+	// string (including the colon) as the username, per the safety comment
+	// in splitAuthorizedEntry. Confirm that a lookup for the literal whole
+	// string succeeds since it's now the only-entry position (position 0),
+	// hence defaults to owner.
+	d := DashboardConfig{AuthorizedUsers: []string{"weird:banana"}}
+	role, ok := d.AuthorizedRole("weird:banana")
+	if !ok || role != RoleOwner {
+		t.Errorf("AuthorizedRole(weird:banana) = (%q, %v), want (%q, true)", role, ok, RoleOwner)
+	}
+}
+
+func TestSplitAuthorizedEntry(t *testing.T) {
+	tests := []struct {
+		entry    string
+		wantName string
+		wantRole string
+	}{
+		{"alice", "alice", ""},
+		{"alice:owner", "alice", RoleOwner},
+		{"alice:read", "alice", RoleRead},
+		{"alice:READ", "alice", RoleRead},
+		{"alice:bogus", "alice:bogus", ""},
+		{"  alice  :  owner  ", "alice", RoleOwner},
+		{"", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.entry, func(t *testing.T) {
+			name, role := splitAuthorizedEntry(tt.entry)
+			if name != tt.wantName || role != tt.wantRole {
+				t.Errorf("splitAuthorizedEntry(%q) = (%q, %q), want (%q, %q)", tt.entry, name, role, tt.wantName, tt.wantRole)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// validateChannels / validateTools / validateConnections
+// ---------------------------------------------------------------------------
+
+func TestValidateChannels(t *testing.T) {
+	tests := []struct {
+		name    string
+		ch      []ChannelConfig
+		wantErr bool
+	}{
+		{"empty is valid", nil, false},
+		{"valid kick", []ChannelConfig{{Type: "kick"}}, false},
+		{"invalid type", []ChannelConfig{{Type: "carrier-pigeon"}}, true},
+		{"webhook missing events", []ChannelConfig{{Type: "webhook"}}, true},
+		{"webhook with events", []ChannelConfig{{Type: "webhook", Events: []string{"push"}}}, false},
+		{"discord missing patterns", []ChannelConfig{{Type: "discord"}}, true},
+		{"discord with patterns", []ChannelConfig{{Type: "discord", Patterns: []string{"*.go"}}}, false},
+		{"schedule missing cron", []ChannelConfig{{Type: "schedule"}}, true},
+		{"schedule with cron", []ChannelConfig{{Type: "schedule", Schedule: "0 * * * *"}}, false},
+		{"bead missing match", []ChannelConfig{{Type: "bead"}}, true},
+		{"bead with match", []ChannelConfig{{Type: "bead", Match: map[string]string{"status": "open"}}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateChannels("agent1", tt.ch)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateChannels() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateTools(t *testing.T) {
+	tests := []struct {
+		name    string
+		tools   *ToolsConfig
+		wantErr bool
+	}{
+		{"nil tools valid", nil, false},
+		{"empty preset valid", &ToolsConfig{}, false},
+		{"valid preset advisory", &ToolsConfig{Preset: "advisory"}, false},
+		{"valid preset full", &ToolsConfig{Preset: "full"}, false},
+		{"invalid preset", &ToolsConfig{Preset: "bogus"}, true},
+		{"rule missing pattern", &ToolsConfig{Rules: []ToolRule{{Action: "allow"}}}, true},
+		{"rule invalid action", &ToolsConfig{Rules: []ToolRule{{Pattern: "foo", Action: "maybe"}}}, true},
+		{"rule valid allow", &ToolsConfig{Rules: []ToolRule{{Pattern: "foo", Action: "allow"}}}, false},
+		{"rule valid deny", &ToolsConfig{Rules: []ToolRule{{Pattern: "foo", Action: "deny"}}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTools("agent1", tt.tools)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateTools() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateConnections(t *testing.T) {
+	tests := []struct {
+		name    string
+		conns   []ConnectionConfig
+		wantErr bool
+	}{
+		{"empty valid", nil, false},
+		{"missing name", []ConnectionConfig{{Type: "mcp", URI: "http://x"}}, true},
+		{"duplicate name", []ConnectionConfig{
+			{Name: "a", Type: "mcp", URI: "http://x"},
+			{Name: "a", Type: "api", URI: "http://y"},
+		}, true},
+		{"invalid type", []ConnectionConfig{{Name: "a", Type: "carrier-pigeon"}}, true},
+		{"mcp missing uri", []ConnectionConfig{{Name: "a", Type: "mcp"}}, true},
+		{"api missing uri", []ConnectionConfig{{Name: "a", Type: "api"}}, true},
+		{"knowledge without uri is fine", []ConnectionConfig{{Name: "a", Type: "knowledge"}}, false},
+		{"mcp with uri valid", []ConnectionConfig{{Name: "a", Type: "mcp", URI: "http://x"}}, false},
+		{"auth invalid type", []ConnectionConfig{{Name: "a", Type: "mcp", URI: "http://x", Auth: &ConnectionAuth{Type: "bogus"}}}, true},
+		{"auth env missing env_var", []ConnectionConfig{{Name: "a", Type: "mcp", URI: "http://x", Auth: &ConnectionAuth{Type: "env"}}}, true},
+		{"auth env valid", []ConnectionConfig{{Name: "a", Type: "mcp", URI: "http://x", Auth: &ConnectionAuth{Type: "env", EnvVar: "TOK"}}}, false},
+		{"auth file missing file", []ConnectionConfig{{Name: "a", Type: "mcp", URI: "http://x", Auth: &ConnectionAuth{Type: "file"}}}, true},
+		{"auth file valid", []ConnectionConfig{{Name: "a", Type: "mcp", URI: "http://x", Auth: &ConnectionAuth{Type: "file", File: "/x"}}}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConnections("agent1", tt.conns)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateConnections() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidate_ChannelsToolsConnectionsPropagate ensures Config.validate()
+// actually calls through to validateChannels/validateTools/validateConnections
+// for each agent (rather than these only being reachable in isolation).
+func TestValidate_ChannelsToolsConnectionsPropagate(t *testing.T) {
+	base := func() *Config {
+		return &Config{
+			Project: ProjectConfig{Org: "acme"},
+			GitHub:  GitHubConfig{Token: "x"},
+			Agents: map[string]AgentConfig{
+				"scanner": {Backend: "claude"},
+			},
+		}
+	}
+
+	c := base()
+	c.Agents["scanner"] = AgentConfig{Backend: "claude", Channels: []ChannelConfig{{Type: "bogus"}}}
+	if err := c.validate(); err == nil {
+		t.Error("expected channel validation error to propagate")
+	}
+
+	c = base()
+	c.Agents["scanner"] = AgentConfig{Backend: "claude", Tools: &ToolsConfig{Preset: "bogus"}}
+	if err := c.validate(); err == nil {
+		t.Error("expected tools validation error to propagate")
+	}
+
+	c = base()
+	c.Agents["scanner"] = AgentConfig{Backend: "claude", Connections: []ConnectionConfig{{Type: "bogus", Name: "a"}}}
+	if err := c.validate(); err == nil {
+		t.Error("expected connections validation error to propagate")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// saveLocked: create-fallback path when OpenFile fails (e.g. path is a dir)
+// ---------------------------------------------------------------------------
+
+func TestSaveLocked_CreateFallbackWhenOpenFails(t *testing.T) {
+	dir := t.TempDir()
+	// SourcePath points at a path that is itself a directory, so
+	// os.OpenFile(O_WRONLY|O_TRUNC) fails and saveLocked falls back to
+	// os.WriteFile — which will ALSO fail because you cannot write a file
+	// over an existing directory. This exercises the fallback branch's
+	// error path.
+	asDir := filepath.Join(dir, "hive.yaml")
+	if err := os.MkdirAll(asDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{
+		SourcePath: asDir,
+		Project:    ProjectConfig{Org: "acme"},
+		Agents:     map[string]AgentConfig{"scanner": {Role: "scanner"}},
+	}
+	if err := cfg.Save(); err == nil {
+		t.Fatal("expected error writing config over a directory path")
+	}
+}
+
+// TestSaveLocked_FileDoesNotExistYet exercises the "file may not exist yet"
+// fallback-to-create branch on the happy path (no file present at all).
+func TestSaveLocked_FileDoesNotExistYet(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "hive.yaml")
+	// Note: parent dir "nested" does not exist either, but os.WriteFile
+	// (the fallback) does not create parent dirs, so this should still fail
+	// cleanly rather than panic; assert we get a graceful error rather than
+	// a crash. This exercises the create-fallback branch's own error path
+	// (distinct from the directory-collision case above).
+	cfg := &Config{
+		SourcePath: path,
+		Project:    ProjectConfig{Org: "acme"},
+		Agents:     map[string]AgentConfig{"scanner": {Role: "scanner"}},
+	}
+	if err := cfg.Save(); err == nil {
+		t.Fatal("expected error writing config to a path whose parent dir does not exist")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// dashboardOverlayBytes: DASHBOARD_AUTH_TOKEN / HIVE_DASHBOARD_TOKEN scrubbing
+// ---------------------------------------------------------------------------
+
+func TestDashboardOverlayBytes_ScrubsAuthToken(t *testing.T) {
+	tests := []struct {
+		name   string
+		envVar string
+	}{
+		{"DASHBOARD_AUTH_TOKEN", "DASHBOARD_AUTH_TOKEN"},
+		{"HIVE_DASHBOARD_TOKEN", "HIVE_DASHBOARD_TOKEN"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(tt.envVar, "super-secret-token")
+			c := &Config{
+				Project:   ProjectConfig{Org: "acme"},
+				Agents:    map[string]AgentConfig{"scanner": {Role: "scanner"}},
+				Dashboard: DashboardConfig{AuthToken: "super-secret-token"},
+			}
+			data, err := c.dashboardOverlayBytes()
+			if err != nil {
+				t.Fatalf("dashboardOverlayBytes: %v", err)
+			}
+			if containsString(string(data), "super-secret-token") {
+				t.Error("overlay bytes should not contain the raw auth token")
+			}
+			// Live config unaffected.
+			if c.Dashboard.AuthToken != "super-secret-token" {
+				t.Errorf("live config mutated: %q", c.Dashboard.AuthToken)
+			}
+		})
+	}
+}
+
+func TestDashboardOverlayBytes_NoScrubWhenTokenDiffers(t *testing.T) {
+	t.Setenv("DASHBOARD_AUTH_TOKEN", "env-token")
+	c := &Config{
+		Project:   ProjectConfig{Org: "acme"},
+		Agents:    map[string]AgentConfig{"scanner": {Role: "scanner"}},
+		Dashboard: DashboardConfig{AuthToken: "different-token-not-from-env"},
+	}
+	data, err := c.dashboardOverlayBytes()
+	if err != nil {
+		t.Fatalf("dashboardOverlayBytes: %v", err)
+	}
+	if !containsString(string(data), "different-token-not-from-env") {
+		t.Error("overlay should keep a token that does not match the env var value")
+	}
+}
+
+func containsString(haystack, needle string) bool {
+	return len(needle) == 0 || (len(haystack) >= len(needle) && indexOf(haystack, needle) >= 0)
+}
+
+func indexOf(haystack, needle string) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}
+
+// ---------------------------------------------------------------------------
+// tool_presets.go: EffectiveRules / DenyPatterns / EffectiveMode
+// ---------------------------------------------------------------------------
+
+func TestToolsConfig_EffectiveRules(t *testing.T) {
+	t.Run("nil receiver returns nil", func(t *testing.T) {
+		var tc *ToolsConfig
+		if got := tc.EffectiveRules(); got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("no preset, no rules", func(t *testing.T) {
+		tc := &ToolsConfig{}
+		if got := tc.EffectiveRules(); len(got) != 0 {
+			t.Errorf("expected empty, got %v", got)
+		}
+	})
+
+	t.Run("preset only", func(t *testing.T) {
+		tc := &ToolsConfig{Preset: "advisory"}
+		got := tc.EffectiveRules()
+		if len(got) != len(ToolPresets["advisory"]) {
+			t.Errorf("expected %d preset rules, got %d", len(ToolPresets["advisory"]), len(got))
+		}
+	})
+
+	t.Run("unknown preset yields no preset rules", func(t *testing.T) {
+		tc := &ToolsConfig{Preset: "totally-bogus"}
+		if got := tc.EffectiveRules(); len(got) != 0 {
+			t.Errorf("expected empty, got %v", got)
+		}
+	})
+
+	t.Run("override replaces matching preset rule via wildcard", func(t *testing.T) {
+		tc := &ToolsConfig{
+			Preset: "advisory",
+			Rules: []ToolRule{
+				{Pattern: "mcp__github__create_pull_request", Action: "allow"},
+			},
+		}
+		got := tc.EffectiveRules()
+		found := false
+		for _, r := range got {
+			if r.Pattern == "mcp__github__create_pull_request" {
+				found = true
+				if r.Action != "allow" {
+					t.Errorf("expected override to allow, got %q", r.Action)
+				}
+			}
+		}
+		if !found {
+			t.Error("expected overridden rule to be present")
+		}
+		// Should not have duplicated the pattern.
+		count := 0
+		for _, r := range got {
+			if r.Pattern == "mcp__github__create_pull_request" {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Errorf("expected exactly 1 rule for the pattern, got %d", count)
+		}
+	})
+
+	t.Run("override with new pattern appends", func(t *testing.T) {
+		tc := &ToolsConfig{
+			Preset: "issues-only",
+			Rules: []ToolRule{
+				{Pattern: "mcp__custom__thing", Action: "deny"},
+			},
+		}
+		got := tc.EffectiveRules()
+		found := false
+		for _, r := range got {
+			if r.Pattern == "mcp__custom__thing" {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("expected new rule to be appended")
+		}
+	})
+}
+
+func TestToolsConfig_DenyPatterns(t *testing.T) {
+	tc := &ToolsConfig{Preset: "advisory"}
+	patterns := tc.DenyPatterns()
+	if len(patterns) == 0 {
+		t.Error("expected advisory preset to have deny patterns")
+	}
+	for _, p := range patterns {
+		if p == "" {
+			t.Error("unexpected empty pattern")
+		}
+	}
+
+	tc2 := &ToolsConfig{Preset: "issues-prs"}
+	if got := tc2.DenyPatterns(); len(got) != 0 {
+		t.Errorf("expected no deny patterns for issues-prs, got %v", got)
+	}
+}
+
+func TestToolsConfig_EffectiveMode(t *testing.T) {
+	tests := []struct {
+		name string
+		tc   *ToolsConfig
+		want string
+	}{
+		{"nil receiver", nil, ""},
+		{"preset advisory maps directly", &ToolsConfig{Preset: "advisory"}, "ADVISORY"},
+		{"preset full maps directly", &ToolsConfig{Preset: "full"}, "ISSUES_PRS_MERGE"},
+		{"preset issues-only maps directly", &ToolsConfig{Preset: "issues-only"}, "ISSUES_ONLY"},
+		{"preset issues-prs maps directly", &ToolsConfig{Preset: "issues-prs"}, "ISSUES_AND_PRS"},
+		{"no preset, no denies", &ToolsConfig{}, "ISSUES_PRS_MERGE"},
+		{
+			"no preset, deny create_issue implies advisory",
+			&ToolsConfig{Rules: []ToolRule{{Pattern: "mcp__github__create_issue", Action: "deny"}}},
+			"ADVISORY",
+		},
+		{
+			"no preset, deny create_pull_request implies issues-only",
+			&ToolsConfig{Rules: []ToolRule{{Pattern: "mcp__github__create_pull_request", Action: "deny"}}},
+			"ISSUES_ONLY",
+		},
+		{
+			"no preset, deny unrelated pattern implies issues-and-prs",
+			&ToolsConfig{Rules: []ToolRule{{Pattern: "mcp__something__else", Action: "deny"}}},
+			"ISSUES_AND_PRS",
+		},
+		{
+			"unknown preset falls through to deny-based derivation",
+			&ToolsConfig{Preset: "totally-bogus"},
+			"ISSUES_PRS_MERGE",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.tc.EffectiveMode(); got != tt.want {
+				t.Errorf("EffectiveMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// watcher.go: error paths not covered by watcher_test.go
+// ---------------------------------------------------------------------------
+
+// TestWatcher_AddNonExistentPathLogsAndReturns exercises the fsw.Add error
+// branch in Start: watching a path in a directory that does not exist fails
+// at Add() time, so Start should log and return promptly rather than block.
+func TestWatcher_AddNonExistentPathLogsAndReturns(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	w := NewWatcher("/definitely/does/not/exist/hive.yaml", func(cfg *Config) {}, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		w.Start(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Start returned promptly because fsw.Add failed — expected.
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after Add failure on nonexistent path")
+	}
+}
+
+// TestWatcher_ScheduleReloadNoopAfterStopped verifies scheduleReload becomes
+// a no-op once cancelTimer has set stopped=true (covers the early-return
+// branch in scheduleReload).
+func TestWatcher_ScheduleReloadNoopAfterStopped(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	w := NewWatcher("/tmp/unused.yaml", func(cfg *Config) {}, logger)
+
+	w.cancelTimer() // sets stopped = true directly, no fsnotify involved
+	w.scheduleReload()
+
+	w.mu.Lock()
+	timerIsNil := w.timer == nil
+	w.mu.Unlock()
+	if !timerIsNil {
+		t.Error("expected scheduleReload to no-op (no timer set) once stopped")
+	}
+}
+
+// TestWatcher_ReloadSkipsWhenSkipNextSet verifies SkipNext causes exactly one
+// reload to be swallowed without invoking onChange.
+func TestWatcher_ReloadSkipsWhenSkipNextSet(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hive.yaml")
+	if err := os.WriteFile(path, []byte(minimalValidYAML("o", "ghp_tok")), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var called bool
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	w := NewWatcher(path, func(cfg *Config) { called = true }, logger)
+
+	w.SkipNext()
+	w.reload() // direct call, bypasses fsnotify plumbing entirely
+
+	if called {
+		t.Error("onChange should not be invoked when SkipNext was set")
+	}
+
+	// skipNext should now be cleared, so the fields are back to the initial
+	// zero-ish state ready for a real reload.
+	w.mu.Lock()
+	skip := w.skipNext
+	w.mu.Unlock()
+	if skip {
+		t.Error("expected skipNext to be cleared after one skipped reload")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// resolveKeyFromFileThenEnv (exercised indirectly via ResolveReviewer, since
+// it is unexported and only reachable that way).
+// ---------------------------------------------------------------------------
+
+func TestResolveReviewer_KeyFromTrajectoryFile(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "reviewer-key.txt")
+	if err := os.WriteFile(keyPath, []byte("  reviewer-file-key  \n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	g := &GovernorConfig{
+		Trajectory: TrajectoryConfig{
+			Endpoint:   "https://reviewer.example.com",
+			Model:      "reviewer-model",
+			APIKeyFile: keyPath,
+		},
+	}
+	_, apiKey, _ := g.ResolveReviewer()
+	if apiKey != "reviewer-file-key" {
+		t.Errorf("got %q, want reviewer-file-key", apiKey)
+	}
+}
+
+func TestResolveReviewer_KeyFromTrajectoryEnvWhenFileEmpty(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "empty-key.txt")
+	if err := os.WriteFile(keyPath, []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("REVIEWER_TEST_ENV_KEY", "reviewer-env-key")
+	g := &GovernorConfig{
+		Trajectory: TrajectoryConfig{
+			Endpoint:   "https://reviewer.example.com",
+			Model:      "reviewer-model",
+			APIKeyFile: keyPath,
+			APIKeyEnv:  "REVIEWER_TEST_ENV_KEY",
+		},
+	}
+	_, apiKey, _ := g.ResolveReviewer()
+	if apiKey != "reviewer-env-key" {
+		t.Errorf("got %q, want reviewer-env-key", apiKey)
+	}
+}
+
+func TestResolveReviewer_KeyFallsBackToLiteLLMWhenTrajectoryUnset(t *testing.T) {
+	g := &GovernorConfig{
+		LiteLLM: LiteLLMConfig{
+			Endpoint:  "https://litellm.example.com",
+			APIKeyEnv: "LITELLM_FALLBACK_KEY_TEST",
+		},
+	}
+	t.Setenv("LITELLM_FALLBACK_KEY_TEST", "litellm-fallback-key")
+	_, apiKey, _ := g.ResolveReviewer()
+	if apiKey != "litellm-fallback-key" {
+		t.Errorf("got %q, want litellm-fallback-key", apiKey)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// saveDashboardOverlay: failure branches when the overlay path is unwritable.
+// ---------------------------------------------------------------------------
+
+func TestSaveDashboardOverlay_OpenTempFileFails(t *testing.T) {
+	origOverlay := DashboardOverlayFile
+	// Point the overlay at a path inside a directory that does not exist,
+	// so OpenFile(tmpPath) fails. saveDashboardOverlay must log and return
+	// without panicking (Save() itself must still succeed).
+	DashboardOverlayFile = "/nonexistent/deeply/nested/dir/hive.yaml.dashboard"
+	t.Cleanup(func() { DashboardOverlayFile = origOverlay })
+	t.Setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+
+	dir := t.TempDir()
+	cfg := &Config{
+		SourcePath: filepath.Join(dir, "hive.yaml"),
+		Project:    ProjectConfig{Org: "acme"},
+		Agents:     map[string]AgentConfig{"scanner": {Role: "scanner"}},
+	}
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save should succeed even when the dashboard overlay write fails: %v", err)
+	}
+}
+
+// TestWatcher_ReloadHandlesLoadFailure verifies reload logs and returns
+// (without calling onChange) when LoadWithDashboardOverlay fails, e.g.
+// because the watched file was deleted out from under it.
+func TestWatcher_ReloadHandlesLoadFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hive.yaml")
+	// Never create the file at all, so Load() inside reload() fails.
+	var called bool
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	w := NewWatcher(path, func(cfg *Config) { called = true }, logger)
+
+	w.reload()
+
+	if called {
+		t.Error("onChange should not be invoked when the config file cannot be loaded")
+	}
+}


### PR DESCRIPTION
Raises two packages over the coverage-hourly 90% gate. Test-only — no production code changed.

| Package | Before | After |
|---|---|---|
| `pkg/beads` | 74.5% | 97.0% |
| `pkg/config` | 74.4% | 94.0% |

**config** covers the previously-0% accessors (IsGHE / ResolvedAppSlug / AppInstallURL, AuthorizedRole / splitAuthorizedEntry, channel helpers, gateway/inference/LiteLLM key resolution, tool-preset EffectiveRules / DenyPatterns / EffectiveMode), the `validate{Channels,Tools,Connections}` error branches, `resolveKeyFromFileThenEnv` (via ResolveReviewer), and `saveDashboardOverlay`'s temp-file-open failure branch.
**beads** covers archive/serialization and CRUD error paths (Archive, AllClosed, HasOpenBead, Unsynthesized, CloseAll edge cases, persist write-failure).

Remaining sub-90% functions and why they're hard to close further without touching production code:
- `ACMMPacks` (76.5%): the ReadDir/ReadFile/Unmarshal error branches and dir/non-yaml skip only trigger on a malformed embedded FS — all 6 embedded pack YAMLs are valid, so those paths are unreachable without a seam in production code.
- `watcher.go Start` (65.2%): the `fsnotify.NewWatcher()` failure branch is effectively unreachable in a normal test environment (would require exhausting OS file-watch resources).
- `saveLocked`/`saveDashboardOverlay` remaining branches: PVC backup permission-retry path and the write/sync/rename-after-open failure branches require injecting mid-operation I/O errors that aren't reachable via a real filesystem without fault injection.

Both packages pass with and without `-short` (94.0% / 97.0% either way — no `testing.Short()` gating in either package).

Refs #1896