### PR TITLE
🐛 fix data races + timeouts from -race coverage tests (fixes #2014)

### DIFF
--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -26,7 +26,7 @@ jobs:
           cache-dependency-path: v2/go.sum
 
       - name: Test with coverage
-        run: go test ./pkg/... -short -race -coverprofile=coverage.out -count=1 -timeout 300s
+        run: go test ./pkg/... -short -race -coverprofile=coverage.out -count=1 -timeout 600s
 
       - name: Check per-package coverage
         id: coverage
@@ -44,7 +44,7 @@ jobs:
               FAILED="${FAILED}${pkg}: ${pct}%\n"
             fi
             REPORT="${REPORT}${pkg}: ${pct}%\n"
-          done < <(go test -cover ./pkg/... -short -count=1 -timeout 300s 2>&1 | grep '^ok')
+          done < <(go test -cover ./pkg/... -short -count=1 -timeout 600s 2>&1 | grep '^ok')
 
           TOTAL=$(go tool cover -func=coverage.out | grep '^total:' | awk '{print $3}')
           echo "Total coverage: ${TOTAL}"

--- a/v2/pkg/hub/final_gaps_coverage_test.go
+++ b/v2/pkg/hub/final_gaps_coverage_test.go
@@ -86,10 +86,13 @@ func TestPushGitHubConfigToSpokeRetryThenSucceed(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	// Shorten the retry delay so the test is fast.
-	oldDelay := webhookRetryDelay
+	// Shorten the retry delay AND the per-attempt timeout so the test is fast:
+	// the forced connection failure would otherwise hang each attempt for the
+	// full 30s push timeout (minutes across all retries).
+	oldDelay, oldTimeout := webhookRetryDelay, webhookPushTimeout
 	webhookRetryDelay = time.Millisecond
-	defer func() { webhookRetryDelay = oldDelay }()
+	webhookPushTimeout = 2 * time.Second
+	defer func() { webhookRetryDelay = oldDelay; webhookPushTimeout = oldTimeout }()
 
 	s := &HubServer{logger: slog.Default(), clusters: map[string]ClusterConfig{"hive-oke": {ID: "hive-oke"}}}
 	hive := &RegistryEntry{ID: "h1", ClusterID: "hive-oke", DashboardURL: srv.URL}

--- a/v2/pkg/hub/hub_coverage_boost_test.go
+++ b/v2/pkg/hub/hub_coverage_boost_test.go
@@ -503,12 +503,12 @@ func TestHandleHeartbeatValidPayload(t *testing.T) {
 	srv.hubSecret = "test-secret"
 
 	payload := HeartbeatPayload{
-		HiveID:      "test-hive",
-		Org:         "myorg",
-		PrimaryRepo: "myrepo",
-		Repos:       []string{"repo1", "repo2"},
+		HiveID:       "test-hive",
+		Org:          "myorg",
+		PrimaryRepo:  "myrepo",
+		Repos:        []string{"repo1", "repo2"},
 		DashboardURL: "https://example.com",
-		SnapshotURL: "https://snapshot.example.com",
+		SnapshotURL:  "https://snapshot.example.com",
 		Agents: []AgentSummary{
 			{Name: "scanner", State: "running"},
 			{Name: "fixer", State: "idle"},

--- a/v2/pkg/hub/hub_coverage_extra_test.go
+++ b/v2/pkg/hub/hub_coverage_extra_test.go
@@ -666,13 +666,13 @@ func TestHandleHeartbeatUpdateExistingWithSparkline(t *testing.T) {
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
 		{
-			ID:               "spark-hive",
-			Online:           true,
-			RegisteredAt:     "2024-01-01T00:00:00Z",
-			GitHash:          "old123",
-			IssueHistory:     []SparkPoint{{T: oldTime, V: 3}},
-			PRHistory:        []SparkPoint{{T: oldTime, V: 2}},
-			LastHeartbeat:    time.Now().Format(time.RFC3339),
+			ID:            "spark-hive",
+			Online:        true,
+			RegisteredAt:  "2024-01-01T00:00:00Z",
+			GitHash:       "old123",
+			IssueHistory:  []SparkPoint{{T: oldTime, V: 3}},
+			PRHistory:     []SparkPoint{{T: oldTime, V: 2}},
+			LastHeartbeat: time.Now().Format(time.RFC3339),
 		},
 	}
 	srv.mu.Unlock()

--- a/v2/pkg/hub/hub_saas_handlers_test.go
+++ b/v2/pkg/hub/hub_saas_handlers_test.go
@@ -1091,4 +1091,3 @@ func TestIsCSRFSafeGetAlwaysPasses(t *testing.T) {
 		}
 	}
 }
-

--- a/v2/pkg/hub/provision_watcher_coverage_test.go
+++ b/v2/pkg/hub/provision_watcher_coverage_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -50,7 +51,16 @@ func TestStartProvisionWatcher(t *testing.T) {
 	})
 
 	s := &HubServer{logger: slog.Default(), clusters: map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", InCluster: true}}}
-	go s.startProvisionWatcher()
+
+	// Run the watcher under a cancellable context and JOIN the goroutine before
+	// returning. Otherwise the daemon keeps polling listSaaSHives() (which reads
+	// the package-level saas path vars) after the test ends, racing the next
+	// test's per-test temp-dir teardown. This defer runs before helperSetupTempDirs'
+	// t.Cleanup, so the goroutine is stopped while the temp dirs still exist.
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); s.startProvisionWatcher(ctx) }()
+	defer func() { cancel(); <-done }()
 
 	// Wait for the watcher to process at least one poll.
 	deadline := time.After(3 * time.Second)

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -164,7 +164,7 @@ func (s *HubServer) registerSaaSRoutes() {
 	// race detector rightly flags. Production behavior is unchanged; tests
 	// that need poller logic call the functions directly.
 	if !testing.Testing() {
-		go s.startProvisionWatcher()
+		go s.startProvisionWatcher(context.Background())
 		go s.StartLatestSHAPoller()
 		// Periodically probe every spoke's unauthenticated /api/status and alert
 		// on any that answer 200 (wide open) — catches auth drift automatically.

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -888,11 +888,20 @@ func extractYAMLValue(yamlStr, key string) string {
 	return ""
 }
 
-func (s *HubServer) startProvisionWatcher() {
+// startProvisionWatcher polls provisioning hives until ctx is cancelled. It
+// takes a context so the loop can be stopped for a clean shutdown (and so tests
+// can stop the goroutine rather than leaking it past the test, which otherwise
+// races the package-level state that per-test temp-dir setup rewrites).
+func (s *HubServer) startProvisionWatcher(ctx context.Context) {
 	ticker := time.NewTicker(provisionPollInterval)
 	defer ticker.Stop()
 
-	for range ticker.C {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
 		hives := listSaaSHives()
 		for _, h := range hives {
 			if h.Status != "provisioning" {

--- a/v2/pkg/hub/webhook.go
+++ b/v2/pkg/hub/webhook.go
@@ -18,13 +18,18 @@ const (
 	webhookSecretEnvVar = "GITHUB_WEBHOOK_SECRET"
 	webhookSecretPath   = "/data/saas/webhook-secret.key"
 	webhookMaxBodyBytes = 256 * 1024
-	webhookPushTimeout  = 30 * time.Second
 	webhookPushRetries  = 3
 )
 
-// webhookRetryDelay is the backoff between spoke config-push retries. A var (not
-// a const) so tests can shorten it; production keeps the default.
-var webhookRetryDelay = 5 * time.Second
+// webhookRetryDelay is the backoff between spoke config-push retries, and
+// webhookPushTimeout bounds each push attempt. Both are vars (not consts) so
+// tests can shorten them — a test that forces a connection-level failure would
+// otherwise wait the full 30s timeout per retry (minutes total). Production
+// keeps the defaults.
+var (
+	webhookRetryDelay  = 5 * time.Second
+	webhookPushTimeout = 30 * time.Second
+)
 
 type installationEvent struct {
 	Action       string `json:"action"`

--- a/v2/pkg/proxy/inference_route.go
+++ b/v2/pkg/proxy/inference_route.go
@@ -147,6 +147,13 @@ func (ir *inferenceRouter) Get(agentName string) *InferenceRoute {
 // (asynchronous) query was issued for. This prevents a slow probe from an old
 // model switch from clobbering a route the user changed again in the meantime.
 // Returns true if the update was applied.
+//
+// The update is copy-on-write: it stores a NEW *InferenceRoute rather than
+// mutating the existing struct in place. Get() hands its caller a bare pointer
+// and releases the lock, so any concurrent reader of route.MaxContextLen (e.g.
+// the token-capping path in the inference request handlers) would otherwise
+// race this write. Replacing the map entry means existing readers keep a
+// consistent snapshot and only subsequent Get() calls observe the new value.
 func (ir *inferenceRouter) UpdateMaxContextLen(agentName, endpoint, model string, maxLen int) bool {
 	ir.mu.Lock()
 	defer ir.mu.Unlock()
@@ -154,7 +161,9 @@ func (ir *inferenceRouter) UpdateMaxContextLen(agentName, endpoint, model string
 	if !ok || route.Endpoint != endpoint || route.Model != model {
 		return false
 	}
-	route.MaxContextLen = maxLen
+	updated := *route // shallow copy; InferenceRoute has no reference-type fields that alias mutably
+	updated.MaxContextLen = maxLen
+	ir.routes[agentName] = &updated
 	return true
 }
 


### PR DESCRIPTION
The #1896 coverage tests, run under `go test ./pkg/... -short -race`, exposed **two real data races** and **two slow-test timeouts** that failed the scheduled v2 test run and the coverage-hourly gate — this is what filed **#2014**.

## Races (real production bugs, now fixed)
**proxy** — `inferenceRouter.UpdateMaxContextLen` mutated `route.MaxContextLen` in place while `Get()` hands callers a bare pointer and releases the lock. So the token-capping read path (`translateAnthropicToOpenAI(..., route.MaxContextLen, ...)`) raced the async max-context probe goroutine. Fixed with **copy-on-write** — store a new `*InferenceRoute` rather than mutating the shared struct. `InferenceRoute` is all value types, so the shallow copy is safe.

**hub** — `startProvisionWatcher` ran an uncancellable ticker loop; the coverage test launched it in a goroutine that outlived the test and kept reading package-level saas path vars while the *next* test's temp-dir teardown rewrote them. `startProvisionWatcher` now takes a `context.Context`; the test cancels and **joins** the goroutine before returning. (Production already guards these daemons behind `testing.Testing()`.)

## Timeouts
- **hub** — `TestPushGitHubConfigToSpokeRetryThenSucceed` forced a connection failure that hung each attempt for the full 30s push timeout (minutes across retries). Made `webhookPushTimeout` a var seam; the test shortens it (mirroring `webhookRetryDelay`).
- **coverage-hourly** — raised the `-race` run's `-timeout 300s → 600s`. The agent package's real-tmux integration tests are legitimately slow under `-race` and were tipping over the 300s package limit (agent FAILed at exactly 300.03s = timeout, not a race).

## Safety
All changes are behavior-preserving: the `const`→`var` / `context` additions keep production defaults, and **no security or launch-path mutex logic is touched**. Verified locally: the proxy race is gone (`-race` clean), and the hub races are eliminated (0 `DATA RACE` markers). Full `-short -race` validation across agent's tmux suite happens in CI (needs Linux + tmux).

Fixes #2014