### PR TITLE
🐛 fix(agent): per-agent npm cache so caveman install stops EACCESing

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1009,7 +1009,12 @@ func (m *Manager) installCavemanForAgent(agent *AgentProcess, backend string) {
 	}
 
 	cmd.Dir = filepath.Join("/data/agents", agent.Name)
-	cmd.Env = append(os.Environ(), "HOME="+home)
+	// The shared npm cache under /data/home accumulates content-addressed
+	// entries owned by whichever agent UID wrote them first; npx run as the
+	// hive user then fails with EACCES on those shards and the agent launches
+	// without its proxy. A per-agent cache can never collide across UIDs.
+	npmCache := filepath.Join("/data/agents", agent.Name, ".npm-caveman-cache")
+	cmd.Env = append(os.Environ(), "HOME="+home, "npm_config_cache="+npmCache)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		m.logger.Warn("caveman install failed", "agent", agent.Name, "error", err, "output", string(out))
 	}


### PR DESCRIPTION
## Summary

`installCavemanForAgent` runs npx as the hive user with `HOME=/data/home`. That shared home's npm cache (`/data/home/.npm/_cacache`) accumulates content-addressed shards owned by whichever agent UID touched them first, so the server-run npx eventually hits one it can't write:

```
npm error EACCES: permission denied, mkdir '/data/home/.npm/_cacache/content-v2/sha512/1b/cc'
```

…and the agent launches **without its MITM proxy**. Observed on the kubestellar-console hive: every scanner resume since 2026-07-25 logged `caveman install failed` with this error, leaving the scanner running unproxied.

## Fix

Set `npm_config_cache` to a per-agent directory (`/data/agents/<name>/.npm-caveman-cache`) for the installer invocation. Per-agent caches can never collide across UIDs. First install per agent re-downloads once; subsequent installs reuse the agent's own cache.

## Test plan
- CI (existing `installCavemanForAgent` fast-branch coverage unaffected — env change only)
- After deploy: resume any copilot-backend agent and confirm `installing caveman` is followed by no `caveman install failed` warning, and the proxy is active from message one

🤖 Generated with [Claude Code](https://claude.com/claude-code)