### PR TITLE
👷 coverage gate: documented 78% floor for dashboard [#1896]

### DIFF
--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -35,13 +35,26 @@ jobs:
           FAILED=""
           REPORT=""
 
+          # Per-package threshold overrides. A handful of packages are heavily
+          # coupled to the live runtime (fixed /data,/proc,/var/run paths, real
+          # github.com/platform.claude.com device-flow, a live tmux agent buffer,
+          # an in-cluster k8s serviceaccount) and cannot be exercised hermetically
+          # in CI without invasive production seams. They get a documented lower
+          # floor so the gate still catches regressions below their real ceiling,
+          # rather than blocking forever on untestable code. Raise these toward 90
+          # as seams are added; do not add new entries without justification here.
+          declare -A PKG_THRESHOLD=(
+            [dashboard]=78   # ~20% is inception tmux watcher + copilot/claude device-flow + /data file I/O + k8s
+          )
+
           while IFS= read -r line; do
             pkg=$(echo "$line" | awk '{print $2}' | sed 's/.*\///')
             pct=$(echo "$line" | grep -o '[0-9]*\.[0-9]*%' | tr -d '%')
             if [ -z "$pct" ]; then continue; fi
             int_pct=$(echo "$pct" | cut -d. -f1)
-            if [ "$int_pct" -lt "$THRESHOLD" ]; then
-              FAILED="${FAILED}${pkg}: ${pct}%\n"
+            pkg_threshold=${PKG_THRESHOLD[$pkg]:-$THRESHOLD}
+            if [ "$int_pct" -lt "$pkg_threshold" ]; then
+              FAILED="${FAILED}${pkg}: ${pct}% (floor ${pkg_threshold}%)\n"
             fi
             REPORT="${REPORT}${pkg}: ${pct}%\n"
           done < <(go test -cover ./pkg/... -short -count=1 -timeout 600s 2>&1 | grep '^ok')


### PR DESCRIPTION
Per your decision on the #1896 coverage sweep: merge dashboard's coverage work at 80% and give the gate a **documented per-package floor** so it goes green honestly, rather than forcing invasive production seams for untestable code.

## Why dashboard can't hit 90% hermetically
~20% of `pkg/dashboard` is coupled to the live runtime and cannot run in a hermetic CI test without invasive seams:
- `inception_watcher.go` — blocking ticker loops + question/fact interception needing a **live tmux agent buffer**
- `copilot_auth.go` / `claude_auth.go` — real **github.com / platform.claude.com device-flow** + fixed `/data` credential paths
- `api.go` / `contribute_ws.go` — success paths reading/writing fixed `/data`·`/proc`·`/var/run` files, calling **live GitHub**, or shelling out to `node`
- `litellm_key_store.go` — needs an **in-cluster k8s serviceaccount**

## What changes
A `PKG_THRESHOLD` override map in the gate: `dashboard=78` (it's at 80%, small headroom). Everything else stays at the global 90%. Dashboard regressions **below 78% still fail the gate**, so it can't silently rot. Comment tells future maintainers to raise the floor toward 90 as seams are added.

Pairs with #2012 (the dashboard coverage tests, 60.6% → 80.0%).

Refs #1896