### PR TITLE
🐛 fix(agent): adapt caveman installer to new CLI flags and pin the ref

### DIFF
--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -989,14 +989,24 @@ func (m *Manager) installCavemanForAgent(agent *AgentProcess, backend string) {
 
 	m.logger.Info("installing caveman", "agent", agent.Name, "backend", backend, "mode", mode)
 
+	// Pinned: unpinned HEAD broke every install on 2026-07-27 when upstream
+	// removed the --mode flag. Bump deliberately, after checking `--help`.
+	const cavemanRef = "github:JuliusBrussee/caveman#0d95a81d35a9"
+	// Upstream replaced `--mode full|minimal` with `--all` / `--minimal`
+	// (--all = hooks + init).
+	modeFlag := "--all"
+	if mode == "minimal" {
+		modeFlag = "--minimal"
+	}
+
 	var cmd *exec.Cmd
 	switch backend {
 	case "claude":
-		cmd = exec.Command("npx", "-y", "github:JuliusBrussee/caveman", "--", "--only", "claude", "--mode", mode)
+		cmd = exec.Command("npx", "-y", cavemanRef, "--", "--only", "claude", modeFlag)
 	case "copilot":
-		cmd = exec.Command("npx", "-y", "github:JuliusBrussee/caveman", "--", "--only", "copilot", "--with-init", "--mode", mode)
+		cmd = exec.Command("npx", "-y", cavemanRef, "--", "--only", "copilot", "--with-init", modeFlag)
 	case "gemini":
-		cmd = exec.Command("npx", "-y", "github:JuliusBrussee/caveman", "--", "--only", "gemini", "--mode", mode)
+		cmd = exec.Command("npx", "-y", cavemanRef, "--", "--only", "gemini", modeFlag)
 	case "goose":
 		cmd = exec.Command("npx", "-y", "skills", "add", "JuliusBrussee/caveman", "-a", "goose")
 	case "codex":


### PR DESCRIPTION
## Summary

Follow-up to #2019. With the npm-cache EACCES fixed, installs got far enough to reveal the next breakage: upstream caveman **removed the `--mode` flag** (its CLI now uses `--all` / `--minimal`), so every install fails with:

```
error: unknown flag: --mode
```

…and agents still launch without their MITM proxy (observed on the kubestellar-console hive scanner, 2026-07-27 11:41 ET).

## Fix

- Map `CavemanMode` → new flags: `full` → `--all` (hooks + init), `minimal` → `--minimal`.
- **Pin the npx ref** to `github:JuliusBrussee/caveman#0d95a81d35a9` (current HEAD, verified working against these flags in the live pod). Unpinned HEAD is how this broke silently; future bumps should be deliberate, after checking `--help`. Same philosophy as the pinned Copilot CLI.

## Test plan
- Verified in the live console hive pod: `npx -y github:JuliusBrussee/caveman -- --help` at this ref accepts `--all`/`--minimal`/`--only`/`--with-init`
- After deploy: restart a copilot agent → `installing caveman` with no `caveman install failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)