### PR TITLE
🐛 fix(dashboard): cost spend buckets read the server's 't' timestamp field

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3742,7 +3742,11 @@
     // truncated to whatever the ring buffer holds (labeled in the UI).
     function costBuckets() {
       const cfg = COST_RANGES[_costRange];
-      const hist = (_costHistory || []).filter(e => e && typeof e.usd === 'number' && e.timestamp);
+      // The server serializes the timestamp as `t` (CostHistoryEntry json:"t");
+      // accept `timestamp` too so a future rename can't zero the card again.
+      const hist = (_costHistory || [])
+        .map(e => e && { usd: e.usd, timestamp: e.t ?? e.timestamp })
+        .filter(e => e && typeof e.usd === 'number' && typeof e.timestamp === 'number');
       const now = Date.now();
       const windowStart = now - cfg.windowMs;
       // Snap the last bucket edge to now, walk backwards by bucketMs.


### PR DESCRIPTION
## Summary

The Cost card's hourly/daily/weekly/monthly spend was **always $0.00** with *"No cost history yet for this range"*, even though the all-time total and its sparkline rendered fine.

Root cause: `CostHistoryEntry` serializes its timestamp as `json:"t"` (UnixMilli), but `costBuckets()` filtered on `e.timestamp` — `undefined` on every entry — so the whole history was discarded before bucketing. The sparkline only reads `.usd`, which is why it kept working and masked the bug.

## Fix

Normalize history entries to `{usd, timestamp}` on the client, accepting `t` or `timestamp`, so a future server-side rename can't silently zero the card again.

## Test plan
- Cost card with existing history: each range pill shows non-zero per-bucket bars and a real "spend this … window" total
- Sparkline unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)