### PR TITLE
✨ hub landing: add "How Hive compares" comparison chart

### DIFF
--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -230,6 +230,24 @@
       font-size: clamp(1.8rem, 3vw, 2.8rem);
       line-height: 1;
     }
+    /* ── Comparison table ── */
+    .compare-wrap { overflow-x: auto; margin-top: 2rem; border: 1px solid var(--line); border-radius: .8rem; background: linear-gradient(#17212deb, #0c1219eb); }
+    .compare-table { width: 100%; border-collapse: collapse; font-size: 0.86rem; min-width: 720px; }
+    .compare-table th { text-align: center; padding: 14px 14px; color: var(--muted); font-weight: 600; border-bottom: 2px solid var(--line); font-size: 0.72rem; text-transform: uppercase; letter-spacing: .05em; }
+    .compare-table th.cap { text-align: left; }
+    .compare-table th.hive-col { color: var(--amber); }
+    .compare-table td { padding: 12px 14px; border-bottom: 1px solid #ffffff0a; text-align: center; vertical-align: middle; color: var(--muted); }
+    .compare-table td.cap { text-align: left; color: var(--text); font-weight: 600; }
+    .compare-table td.hive-col { background: rgba(244,199,95,0.05); color: var(--text); font-weight: 600; }
+    .compare-table tr:hover td { background: rgba(244,199,95,0.03); }
+    .compare-table tr:hover td.hive-col { background: rgba(244,199,95,0.08); }
+    .compare-table thead th.hive-col { background: rgba(244,199,95,0.08); border-top-left-radius: .5rem; border-top-right-radius: .5rem; }
+    .c-yes { color: var(--green); font-weight: 800; }
+    .c-no { color: #ff7e7e; opacity: .7; }
+    .c-part { color: var(--amber); }
+    .c-note { display: block; font-size: 0.68rem; color: var(--muted); margin-top: 2px; font-weight: 400; }
+    .compare-legend { font-size: 0.72rem; color: var(--muted); margin-top: .8rem; text-align: center; }
+    .compare-foot { font-size: 0.78rem; color: var(--muted); margin-top: 1.2rem; line-height: 1.5; }
     .metric-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
       gap: .85rem;
@@ -585,6 +603,109 @@
           <div style="margin-top:1rem"><a class="button tertiary" href="/learn">Learn the architecture</a></div>
         </div>
       </div>
+    </section>
+
+    <!-- ── How Hive compares ── -->
+    <section class="section-pad" id="compare">
+      <div class="section-heading">
+        <p class="section-label">How Hive compares</p>
+        <h2>The only open-source one in the room</h2>
+        <p>AI teammates that break down work, run in the background, and open pull requests are everywhere now &mdash; from GitHub&rsquo;s own coding agent to Devin to Microsoft Planner. Nearly all of them are paid, proprietary, and cloud-only. Hive is the free, open-source, self-hosted alternative &mdash; and it enforces what agents can do at the network layer, not on the honor system.</p>
+      </div>
+      <div class="compare-wrap">
+        <table class="compare-table">
+          <thead>
+            <tr>
+              <th class="cap">Capability</th>
+              <th class="hive-col">Hive</th>
+              <th>GitHub Copilot<br>coding agent</th>
+              <th>Devin</th>
+              <th>MS Planner /<br>Jira Rovo</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="cap">Free &amp; open source</td>
+              <td class="hive-col"><span class="c-yes">&#10003;</span><span class="c-note">Apache&#8209;2.0 &middot; CNCF/KubeStellar</span></td>
+              <td><span class="c-no">&#10007;</span><span class="c-note">Paid subscription</span></td>
+              <td><span class="c-no">&#10007;</span><span class="c-note">Paid / enterprise</span></td>
+              <td><span class="c-no">&#10007;</span><span class="c-note">M365 / Atlassian license</span></td>
+            </tr>
+            <tr>
+              <td class="cap">Self-hosted / your infra</td>
+              <td class="hive-col"><span class="c-yes">&#10003;</span><span class="c-note">K8s, LXC, Compose</span></td>
+              <td><span class="c-no">&#10007;</span><span class="c-note">GitHub cloud</span></td>
+              <td><span class="c-part">Hybrid</span><span class="c-note">Planning stays in cloud</span></td>
+              <td><span class="c-no">&#10007;</span><span class="c-note">Vendor cloud</span></td>
+            </tr>
+            <tr>
+              <td class="cap">Bring your own AI &amp; model</td>
+              <td class="hive-col"><span class="c-yes">&#10003;</span><span class="c-note">Any OpenAI-compatible; self-host vLLM/llm-d</span></td>
+              <td><span class="c-no">&#10007;</span><span class="c-note">Locked to provider</span></td>
+              <td><span class="c-no">&#10007;</span></td>
+              <td><span class="c-part">Vendor models</span></td>
+            </tr>
+            <tr>
+              <td class="cap">Multi-agent, specialized roles</td>
+              <td class="hive-col"><span class="c-yes">&#10003;</span><span class="c-note">Scanner, quality, architect, &hellip;</span></td>
+              <td><span class="c-no">&#10007;</span><span class="c-note">Single agent</span></td>
+              <td><span class="c-part">Subagents</span><span class="c-note">Delegation, not peers</span></td>
+              <td><span class="c-part">Assignable agents</span></td>
+            </tr>
+            <tr>
+              <td class="cap">Enforced permissions at network layer</td>
+              <td class="hive-col"><span class="c-yes">&#10003;</span><span class="c-note">MITM proxy + scoped tokens</span></td>
+              <td><span class="c-part">Branch rules</span></td>
+              <td><span class="c-part">Rule engine</span><span class="c-note">Agent-layer</span></td>
+              <td><span class="c-part">Graph ACL inherit</span></td>
+            </tr>
+            <tr>
+              <td class="cap">Graduated autonomy levels</td>
+              <td class="hive-col"><span class="c-yes">&#10003;</span><span class="c-note">ACMM L1&ndash;L6, advisory&rarr;auto-merge</span></td>
+              <td><span class="c-no">&#10007;</span></td>
+              <td><span class="c-part">Allow/Ask/Deny</span></td>
+              <td><span class="c-no">&#10007;</span></td>
+            </tr>
+            <tr>
+              <td class="cap">Transparent AI cost &amp; budget controls</td>
+              <td class="hive-col"><span class="c-yes">&#10003;</span><span class="c-note">Per-model cost + weekly token budget</span></td>
+              <td><span class="c-no">&#10007;</span><span class="c-note">Opaque in license</span></td>
+              <td><span class="c-no">&#10007;</span></td>
+              <td><span class="c-no">&#10007;</span></td>
+            </tr>
+            <tr>
+              <td class="cap">Trajectory / goal-drift review</td>
+              <td class="hive-col"><span class="c-yes">&#10003;</span><span class="c-note">Intent-vs-transcript, injection-aware</span></td>
+              <td><span class="c-no">&#10007;</span></td>
+              <td><span class="c-no">&#10007;</span></td>
+              <td><span class="c-no">&#10007;</span></td>
+            </tr>
+            <tr>
+              <td class="cap">Durable work ledger (DAG)</td>
+              <td class="hive-col"><span class="c-yes">&#10003;</span><span class="c-note">Git-backed beads w/ dependencies</span></td>
+              <td><span class="c-no">&#10007;</span></td>
+              <td><span class="c-part">In-run</span></td>
+              <td><span class="c-part">Task lists</span></td>
+            </tr>
+            <tr>
+              <td class="cap">Human-in-the-loop &amp; audit trail</td>
+              <td class="hive-col"><span class="c-yes">&#10003;</span><span class="c-note">PR holds, pause/resume, full audit</span></td>
+              <td><span class="c-yes">&#10003;</span><span class="c-note">Draft-PR review</span></td>
+              <td><span class="c-yes">&#10003;</span></td>
+              <td><span class="c-yes">&#10003;</span></td>
+            </tr>
+            <tr>
+              <td class="cap">Auto plan decomposition + plan review</td>
+              <td class="hive-col"><span class="c-part">Partial</span><span class="c-note">Ideation only &mdash; on the roadmap</span></td>
+              <td><span class="c-part">Spec/plan</span></td>
+              <td><span class="c-yes">&#10003;</span><span class="c-note">Interactive Planning</span></td>
+              <td><span class="c-yes">&#10003;</span><span class="c-note">Work breakdown</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="compare-legend"><span class="c-yes">&#10003;</span> yes &nbsp;&middot;&nbsp; <span class="c-part">partial</span> &nbsp;&middot;&nbsp; <span class="c-no">&#10007;</span> no. Competitor rows reflect each vendor&rsquo;s public documentation as of 2026; comparisons are our own.</p>
+      <p class="compare-foot">Being honest about the one gap: general-purpose <strong>plan decomposition with a review-before-execution gate</strong> is where the field &mdash; Devin, Planner, and others &mdash; is ahead today. Hive already does it for project ideation and has the ledger to generalize it. Everywhere else, Hive is the option you own outright.</p>
     </section>
 
     <!-- ── Get started ── -->


### PR DESCRIPTION
Adds a **comparison section** to the hub landing page (`hive.kubestellar.io`, served from `v2/pkg/hub/static/index.html`), positioning Hive against the field of AI work-orchestration / autonomous coding agents.

### What it shows
A 10-row table — **Hive** (highlighted) vs. **GitHub Copilot coding agent**, **Devin**, and **MS Planner / Jira Rovo** — across the axes where Hive is differentiated:
- **Free & open source** (Apache-2.0 — the only OSS option in the set)
- Self-hosted / your infra · bring-your-own AI & model
- Multi-agent specialized roles
- **Permissions enforced at the network layer** (MITM proxy + scoped tokens)
- Graduated autonomy (ACMM L1–L6)
- **Transparent AI cost + weekly token budget** (the AI CLIs cost money; Hive makes that spend visible and governed)
- Trajectory / goal-drift review · durable DAG work ledger (beads) · HITL + audit

### Honesty
The chart marks Hive **"partial"** on general-purpose *plan decomposition + review-before-execution* — the one area the field (Devin, Planner) leads today — with a closing note owning that gap, so the comparison reads as credible rather than overclaiming. Competitor cells reflect each vendor's public docs (2026) and are labeled as our own comparison.

### Implementation
Reuses the existing dark theme + a small amount of scoped CSS (`.compare-*`). Placed after "Why Hive", before "Get started". `go build ./pkg/hub/` passes; verified rendering locally.

Preview of the section: rendered in the site's own theme during review.