### PR TITLE
✨ feat(dashboard): per-agent spend on agent cards + custom cost date range

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -4832,8 +4832,16 @@ func (s *Server) handleKnowledgeStats(w http.ResponseWriter, r *http.Request) {
 	// Sample the estimated cost on the same cadence as the fact history so the
 	// cost sparkline shares the fact sparkline's timer (both throttled to
 	// ~5-min intervals). The figure is the same all-time cumulative estimated
-	// total that GET /api/cost returns.
-	s.AppendCostHistory(s.estimatedCost().TotalUSD)
+	// total that GET /api/cost returns; the per-agent map feeds the agent
+	// cards' spend-over-window display.
+	est := s.estimatedCost()
+	perAgent := make(map[string]float64, len(est.ByAgent))
+	for _, row := range est.ByAgent {
+		if row.USD > 0 {
+			perAgent[row.Name] = row.USD
+		}
+	}
+	s.AppendCostHistory(est.TotalUSD, perAgent)
 
 	jsonResponse(w, stats)
 }

--- a/v2/pkg/dashboard/cost_history_test.go
+++ b/v2/pkg/dashboard/cost_history_test.go
@@ -77,3 +77,25 @@ func TestSeedCostHistoryCapAndOrdering(t *testing.T) {
 		}
 	}
 }
+
+// TestAppendCostHistoryPerAgent verifies the optional per-agent map is stored
+// on the entry and omitted when empty.
+func TestAppendCostHistoryPerAgent(t *testing.T) {
+	s := &Server{}
+	s.AppendCostHistory(10.0, map[string]float64{"scanner": 7.5, "quality": 2.5})
+
+	got := s.CostHistory()
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].Agents["scanner"] != 7.5 || got[0].Agents["quality"] != 2.5 {
+		t.Errorf("agents map = %v, want scanner=7.5 quality=2.5", got[0].Agents)
+	}
+
+	// Empty map should be dropped, not stored as {}.
+	s2 := &Server{}
+	s2.AppendCostHistory(1.0, map[string]float64{})
+	if got := s2.CostHistory(); len(got) != 1 || got[0].Agents != nil {
+		t.Errorf("empty agents map should be nil on the entry, got %v", got[0].Agents)
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -374,6 +374,10 @@ const factHistoryMinIntervalMs = 300_000
 type CostHistoryEntry struct {
 	Timestamp int64   `json:"t"`
 	USD       float64 `json:"usd"`
+	// Agents maps agent name → cumulative estimated $ at this snapshot,
+	// enabling per-agent spend-over-window on the client. Omitted on entries
+	// recorded before this field existed.
+	Agents map[string]float64 `json:"agents,omitempty"`
 }
 
 // costHistoryMaxEntries caps the cost sparkline to ~30 days at 5-min intervals,
@@ -1547,8 +1551,10 @@ func (s *Server) SeedFactHistory(entries []FactHistoryEntry) {
 
 // AppendCostHistory records an estimated-cost ($) snapshot if enough time has
 // passed since the last one. Mirrors AppendFactHistory: same cadence throttle
-// and same ring-buffer cap so the two histories stay aligned.
-func (s *Server) AppendCostHistory(usd float64) {
+// and same ring-buffer cap so the two histories stay aligned. The optional
+// agents map carries per-agent cumulative $ so the UI can derive per-agent
+// spend over a time window (agent cards); variadic to keep old callers valid.
+func (s *Server) AppendCostHistory(usd float64, agents ...map[string]float64) {
 	now := time.Now().UnixMilli()
 
 	s.costHistoryMu.Lock()
@@ -1561,10 +1567,14 @@ func (s *Server) AppendCostHistory(usd float64) {
 		}
 	}
 
-	s.costHistory = append(s.costHistory, CostHistoryEntry{
+	entry := CostHistoryEntry{
 		Timestamp: now,
 		USD:       usd,
-	})
+	}
+	if len(agents) > 0 && len(agents[0]) > 0 {
+		entry.Agents = agents[0]
+	}
+	s.costHistory = append(s.costHistory, entry)
 	if len(s.costHistory) > costHistoryMaxEntries {
 		s.costHistory = s.costHistory[len(s.costHistory)-costHistoryMaxEntries:]
 	}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1030,6 +1030,9 @@
     .cost-trend { margin: 6px 0 14px; }
     .cost-trend-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; flex-wrap: wrap; margin-bottom: 6px; }
     .cost-range { display: inline-flex; gap: 2px; background: rgba(128,128,128,0.12); border-radius: 7px; padding: 2px; }
+    .cost-custom-range { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); font-size: 0.7rem; }
+    .cost-custom-range input { background: var(--bg-soft); border: 1px solid var(--line); border-radius: 5px; color: var(--text); font-size: 0.7rem; padding: 2px 6px; font-family: var(--font-ui); }
+    .agent-spend-chip { display: inline-block; margin-left: 6px; padding: 0 6px; border: 1px solid var(--line); border-radius: 8px; font-size: 0.66rem; font-weight: 600; color: var(--muted); vertical-align: middle; }
     .cost-range button { border: none; background: none; color: var(--muted); font-size: 0.66rem; font-weight: 600; padding: 3px 9px; border-radius: 5px; cursor: pointer; text-transform: capitalize; }
     .cost-range button:hover { color: var(--text); }
     .cost-range button.active { background: var(--panel); color: var(--green); box-shadow: 0 1px 2px rgba(0,0,0,0.15); }
@@ -3726,46 +3729,80 @@
     // delta of the cumulative value across each bucket boundary — no backend
     // change needed. Selected range persists across re-renders and page loads.
     const COST_RANGES = {
-      // key: { label, bucketMs, windowMs, buckets, axisFmt }
+      // key: { label, bucketMs, windowMs, buckets }
       hourly:  { label: 'hourly',  bucketMs: 3600e3,        windowMs: 24 * 3600e3,      buckets: 24 },
       daily:   { label: 'daily',   bucketMs: 24 * 3600e3,   windowMs: 30 * 24 * 3600e3, buckets: 30 },
       weekly:  { label: 'weekly',  bucketMs: 7 * 24 * 3600e3, windowMs: 12 * 7 * 24 * 3600e3, buckets: 12 },
       monthly: { label: 'monthly', bucketMs: 30 * 24 * 3600e3, windowMs: 12 * 30 * 24 * 3600e3, buckets: 12 },
+      custom:  { label: 'custom' }, // bounds come from _costCustom; slices derived
     };
     let _costRange = (() => {
       try { const s = localStorage.getItem('hiveCostRange'); if (s && COST_RANGES[s]) return s; } catch {}
       return 'daily';
     })();
+    // Custom range bounds (ms since epoch), persisted like the range key.
+    let _costCustom = (() => {
+      try {
+        const s = JSON.parse(localStorage.getItem('hiveCostCustom') || 'null');
+        if (s && typeof s.start === 'number' && typeof s.end === 'number' && s.end > s.start) return s;
+      } catch {}
+      const now = Date.now();
+      return { start: now - 24 * 3600e3, end: now };
+    })();
+    const COST_CUSTOM_BUCKETS = 24; // bar-chart slices for a custom range
+
+    // costWindow: {start, end, bucketMs, count} for the active range. Preset
+    // ranges anchor to now and walk backwards; custom uses the picked bounds.
+    function costWindow() {
+      if (_costRange === 'custom') {
+        const span = Math.max(_costCustom.end - _costCustom.start, 60e3);
+        return { start: _costCustom.start, end: _costCustom.end,
+                 bucketMs: span / COST_CUSTOM_BUCKETS, count: COST_CUSTOM_BUCKETS };
+      }
+      const cfg = COST_RANGES[_costRange];
+      const now = Date.now();
+      return { start: now - cfg.windowMs, end: now, bucketMs: cfg.bucketMs, count: cfg.buckets };
+    }
+
+    // Normalized history [{usd, timestamp, agents}]. The server serializes the
+    // timestamp as `t` (CostHistoryEntry json:"t"); accept `timestamp` too so a
+    // future rename can't zero the card again. `agents` (name → cumulative $)
+    // is absent on entries recorded before per-agent snapshots existed.
+    function costHist() {
+      return (_costHistory || [])
+        .map(e => e && { usd: e.usd, timestamp: e.t ?? e.timestamp, agents: e.agents })
+        .filter(e => e && typeof e.usd === 'number' && typeof e.timestamp === 'number');
+    }
+
+    // Last cumulative value at-or-before t via pick(e); null if history starts
+    // after t (or pick never yields a number up to t).
+    function costValueAt(hist, t, pick) {
+      let v = null;
+      for (const e of hist) {
+        if (e.timestamp > t) break;
+        const x = pick(e);
+        if (typeof x === 'number') v = x;
+      }
+      return v;
+    }
 
     // costBuckets: returns [{start, end, spend}] for the active range. spend is the
     // cumulative-$ delta over the bucket; 30d of history means longer ranges are
     // truncated to whatever the ring buffer holds (labeled in the UI).
     function costBuckets() {
-      const cfg = COST_RANGES[_costRange];
-      // The server serializes the timestamp as `t` (CostHistoryEntry json:"t");
-      // accept `timestamp` too so a future rename can't zero the card again.
-      const hist = (_costHistory || [])
-        .map(e => e && { usd: e.usd, timestamp: e.t ?? e.timestamp })
-        .filter(e => e && typeof e.usd === 'number' && typeof e.timestamp === 'number');
-      const now = Date.now();
-      const windowStart = now - cfg.windowMs;
-      // Snap the last bucket edge to now, walk backwards by bucketMs.
+      const win = costWindow();
+      const hist = costHist();
       const buckets = [];
-      for (let i = cfg.buckets - 1; i >= 0; i--) {
-        const end = now - i * cfg.bucketMs;
-        const start = end - cfg.bucketMs;
-        if (end <= windowStart) continue;
+      for (let i = win.count - 1; i >= 0; i--) {
+        const end = win.end - i * win.bucketMs;
+        const start = end - win.bucketMs;
+        if (end <= win.start) continue;
         buckets.push({ start, end, spend: 0, hasData: false });
       }
       if (hist.length < 2) return buckets;
       // For each bucket, spend = usd at last snapshot in bucket − usd at last
       // snapshot before bucket start (the cumulative baseline entering the bucket).
-      const at = (t) => {
-        // last cumulative value at-or-before time t; null if history starts after t.
-        let v = null;
-        for (const e of hist) { if (e.timestamp <= t) v = e.usd; else break; }
-        return v;
-      };
+      const at = (t) => costValueAt(hist, t, e => e.usd);
       for (const b of buckets) {
         const before = at(b.start);
         const end = at(b.end);
@@ -3781,11 +3818,27 @@
       return buckets;
     }
 
+    // agentWindowSpend: estimated $ spent by one agent inside the active cost
+    // window, derived from per-agent cumulative snapshots. null = no per-agent
+    // data covering this window (e.g. history predates the feature).
+    function agentWindowSpend(name) {
+      const win = costWindow();
+      const hist = costHist().filter(e => e.agents && typeof e.agents[name] === 'number');
+      if (!hist.length || hist[0].timestamp > win.end) return null;
+      const pick = e => e.agents[name];
+      const endV = costValueAt(hist, win.end, pick);
+      if (endV == null) return null;
+      let startV = costValueAt(hist, win.start, pick);
+      if (startV == null) startV = hist[0].agents[name]; // history begins inside window
+      return Math.max(0, endV - startV);
+    }
+
     function costBucketAxisLabel(b) {
       const d = new Date(b.end);
       if (_costRange === 'hourly') return String(d.getHours()).padStart(2, '0');
       if (_costRange === 'daily')  return `${d.getMonth() + 1}/${d.getDate()}`;
       if (_costRange === 'weekly') return `${d.getMonth() + 1}/${d.getDate()}`;
+      if (_costRange === 'custom') return `${d.getMonth() + 1}/${d.getDate()} ${String(d.getHours()).padStart(2, '0')}h`;
       return d.toLocaleString('en-US', { month: 'short' });
     }
 
@@ -3794,6 +3847,16 @@
       const pills = Object.keys(COST_RANGES).map(k =>
         `<button data-cost-range="${k}" class="${k === _costRange ? 'active' : ''}">${COST_RANGES[k].label}</button>`
       ).join('');
+      let customControls = '';
+      if (_costRange === 'custom') {
+        // datetime-local wants local wall-clock time without zone suffix.
+        const toLocal = (ms) => new Date(ms - new Date().getTimezoneOffset() * 60000).toISOString().slice(0, 16);
+        customControls = `<div class="cost-custom-range">
+          <input type="datetime-local" id="cost-custom-start" value="${toLocal(_costCustom.start)}" onchange="costCustomChanged()" title="Custom range start">
+          <span>→</span>
+          <input type="datetime-local" id="cost-custom-end" value="${toLocal(_costCustom.end)}" onchange="costCustomChanged()" title="Custom range end">
+        </div>`;
+      }
       const buckets = costBuckets();
       const withData = buckets.filter(b => b.hasData);
       const total = withData.reduce((s, b) => s + b.spend, 0);
@@ -3815,13 +3878,30 @@
           <div class="cost-bars-axis"><span>${esc(costBucketAxisLabel(first))}</span><span>${esc(costBucketAxisLabel(mid))}</span><span>${esc(costBucketAxisLabel(last))}</span></div>`;
       }
 
+      const totalLabel = _costRange === 'custom'
+        ? 'spend in range'
+        : `spend this ${cfg.label.replace('ly','')} window`;
       return `<div class="cost-trend">
         <div class="cost-trend-head">
           <div class="cost-range">${pills}</div>
-          <div class="cost-trend-total">spend this ${cfg.label.replace('ly','')} window: <b>${fmtUSD(total)}</b></div>
+          ${customControls}
+          <div class="cost-trend-total">${totalLabel}: <b>${fmtUSD(total)}</b></div>
         </div>
         ${body}
       </div>`;
+    }
+
+    function costCustomChanged() {
+      const s = document.getElementById('cost-custom-start');
+      const e = document.getElementById('cost-custom-end');
+      if (!s || !e || !s.value || !e.value) return;
+      const start = new Date(s.value).getTime();
+      const end = new Date(e.value).getTime();
+      if (!(end > start)) { hiveToast('Custom range: end must be after start', 'error'); return; }
+      _costCustom = { start, end };
+      try { localStorage.setItem('hiveCostCustom', JSON.stringify(_costCustom)); } catch {}
+      if (_lastCost) renderCost(_lastCost);
+      if (window._lastAgents) renderAgents(window._lastAgents);
     }
 
     async function fetchHistory() {
@@ -4111,6 +4191,23 @@
       return 0;
     }
 
+    // Per-agent estimated spend over the Cost section's active timeframe.
+    // The chip shows on the card header (visible in compact and expanded);
+    // the row adds detail inside the expanded card. Both return '' when the
+    // history has no per-agent data covering the window.
+    function agentSpendChip(name) {
+      const usd = agentWindowSpend(name);
+      if (usd == null) return '';
+      const lbl = _costRange === 'custom' ? 'custom range' : `${COST_RANGES[_costRange].label} window`;
+      return `<span class="agent-spend-chip" title="Estimated spend over the ${lbl} — follows the Cost section's timeframe selector (token × list price)">${fmtUSD(usd)}</span>`;
+    }
+    function agentSpendRow(name) {
+      const usd = agentWindowSpend(name);
+      if (usd == null) return '';
+      const lbl = _costRange === 'custom' ? 'custom range' : COST_RANGES[_costRange].label;
+      return `<div class="agent-field"><span class="label" title="Estimated cost attributed to this agent over the timeframe selected in the Cost section (token × list price)">spend (${lbl})</span><span class="value">${fmtUSD(usd)}</span></div>`;
+    }
+
     function agentTokenRow(name, cadence) {
       const byAgent = window._tokensByAgent || {};
       const t = byAgent[name];
@@ -4206,7 +4303,7 @@
             if (a.structuredStatus === 'DONE') return '<span class="status-badge done">done</span>';
             if (isStale) return '<span class="status-badge needs-context">stale</span>';
             return '';
-          })()}</div>
+          })()}${agentSpendChip(a.name)}</div>
           <div class="agent-card-details">
           <div class="agent-field"><span class="label" title="${INFERENCE_BACKENDS.includes(a.cli) ? 'Inference backend (self-hosted model server)' : 'The CLI backend running this agent (e.g. claude, copilot). Pin to prevent governor from switching it.'}">${INFERENCE_BACKENDS.includes(a.cli) ? 'method' : 'cli'}</span><span class="value">${cliChip(a.cli, a.pinnedBoth || a.pinnedCli, a.name)}${(a.pinnedBoth || a.pinnedCli) ? '' : ` <button class="pin-toggle" data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="cli" data-unpin="false" title="Pin CLI — lock current backend" style="opacity:0.4;cursor:pointer;border:none;background:none">📌</button>`}</span></div>
           <div class="agent-field"><span class="label" title="The LLM model powering this agent. Governor may change it based on budget or mode. Pin to lock.">model</span><span class="value">${modelChip(a.model, a.govReason, a.pinnedBoth || a.pinnedModel, a.name)}${(a.pinnedBoth || a.pinnedModel) ? '' : ` <button class="pin-toggle" data-action="togglePin" data-agent="${esc(a.name)}" data-pin-type="model" data-unpin="false" title="Pin model — lock current model" style="opacity:0.4;cursor:pointer;border:none;background:none">📌</button>`}</span></div>
@@ -4216,6 +4313,7 @@
           <div class="agent-field"><span class="label" title="When the governor last kicked (started a work pass for) this agent.">last run</span><span class="value">${a.lastKick || '—'}</span></div>
           <div class="agent-field"><span class="label" title="When the governor will next kick this agent based on its cadence interval.">next run</span><span class="value">${isOnDemand ? 'on demand' : isPaused ? 'paused' : isOff ? 'off' : (a.nextKick || '—')}</span></div>
           ${agentTokenRow(a.name, a.cadence)}
+          ${agentSpendRow(a.name)}
           <div class="agent-field"><span class="label" title="Number of times this agent has been restarted in the last 24 hours. High counts may indicate instability or rate limiting.">restarts</span><span class="value${(a.restarts || 0) > 5 ? ' restart-high' : (a.restarts || 0) > 0 ? ' restart-warn' : ''}">${a.restarts || 0}<span class="restart-label">24h</span>${(a.restarts || 0) > 0 ? `<button class="restart-reset" data-action="resetRestarts" data-agent="${esc(a.name)}" title="Reset the restart counter to zero — does not affect the agent">✕</button>` : ''}<span class="restart-spark">${restartSparkSvg(a.name)}</span></span></div>
           <div class="agent-field"><span class="label" title="CLI authentication status — log in to authenticate the agent's CLI tool">auth</span><span class="value">${(() => {
             const isClaude = a.cli === 'claude';
@@ -5828,6 +5926,8 @@ function burnAreaChart() {
       _costRange = r;
       try { localStorage.setItem('hiveCostRange', r); } catch {}
       if (_lastCost) renderCost(_lastCost);
+      // Agent cards' spend chips follow this selector as their global filter.
+      if (window._lastAgents) renderAgents(window._lastAgents);
     });
 
     // GitHub auth health — sticky banner when 401


### PR DESCRIPTION
## Summary

Two requests from operating the console hive:

1. **Cost on the agent cards (small and big)** — each card now shows the agent's estimated spend over the window selected in the Cost section. The hourly/daily/weekly/monthly pills act as the **global filter**: a chip on the card header (visible in compact mode) and a `spend (<range>)` detail row in the expanded card, both re-rendered when the selector changes.

2. **Custom date range** — the Cost section's timeframe pills gain a `custom` option with start/end `datetime-local` inputs (persisted in localStorage, 24 bar-chart slices across the span). Agent chips follow it too.

## How

- `CostHistoryEntry` gains an optional `agents` map (name → cumulative estimated $), sampled from `estimatedCost().ByAgent` on the existing ~5-min history throttle. `AppendCostHistory` takes it as a variadic arg — existing callers and tests compile unchanged.
- Client derives per-agent window spend the same way bucket spend works: cumulative delta across the window bounds. Entries recorded before this feature lack the map, so cards show nothing until new snapshots accrue (graceful).
- New shared helpers (`costWindow`, `costHist`, `costValueAt`) replace the duplicated bucketing logic.

## Test plan
- Go: new `TestAppendCostHistoryPerAgent` (map stored; empty map dropped); existing history tests unchanged
- UI: switch pills → card chips update; custom range with end ≤ start → toast error; agents without per-agent data → no chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)