### PR TITLE
🐛 hub: fix data race in saas_provision (fixes #2021)

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -165,7 +165,7 @@ func (s *HubServer) registerSaaSRoutes() {
 	// that need poller logic call the functions directly.
 	if !testing.Testing() {
 		go s.startProvisionWatcher(context.Background())
-		go s.StartLatestSHAPoller()
+		go s.StartLatestSHAPoller(context.Background())
 		// Periodically probe every spoke's unauthenticated /api/status and alert
 		// on any that answer 200 (wide open) — catches auth drift automatically.
 		go s.StartAuthAudit(context.Background())
@@ -2880,7 +2880,12 @@ func persistLatestSHAs(logger *slog.Logger) {
 	}
 }
 
-func (s *HubServer) StartLatestSHAPoller() {
+// StartLatestSHAPoller polls GitHub/GHCR for the latest branch SHAs until ctx
+// is cancelled. It takes a context so the loop can be stopped for a clean
+// shutdown (and so tests can stop the goroutine rather than leaking it past the
+// test, which otherwise races the package-level saas path state that per-test
+// temp-dir setup rewrites — same class as startProvisionWatcher).
+func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 	// Serve last-known-good SHAs immediately; live fetches below refresh them.
 	loadPersistedSHAs(s.logger, s.trackedBranchList())
 	prevInfos := snapshotBranchSHAs()
@@ -2892,7 +2897,12 @@ func (s *HubServer) StartLatestSHAPoller() {
 	s.triggerAutoUpgrades()
 	ticker := time.NewTicker(latestSHAPollInterval)
 	defer ticker.Stop()
-	for range ticker.C {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
 		oldSHAs := getLatestSHAs()
 		oldInfos := snapshotBranchSHAs()
 		// Re-resolve each tick so branches from newly registered hives are

--- a/v2/pkg/hub/sha_poller_coverage_test.go
+++ b/v2/pkg/hub/sha_poller_coverage_test.go
@@ -1,6 +1,7 @@
 package hub
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -43,11 +44,19 @@ func TestStartLatestSHAPollerPreLoop(t *testing.T) {
 	// A registered hive contributes a tracked branch so the fetch loop runs.
 	s.registry.Hives = []RegistryEntry{{ID: "h1", GitBranch: "v2"}}
 
+	// Run the poller under a cancellable context and JOIN the goroutine before
+	// returning. Otherwise the daemon keeps reading the package-level saas path
+	// vars (via triggerAutoUpgrades -> listSaaSHives) after the test ends,
+	// racing the next test's per-test temp-dir teardown. This defer runs before
+	// helperSetupTempDirs' t.Cleanup, so the goroutine is stopped while the
+	// temp dirs still exist.
+	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {
-		s.StartLatestSHAPoller() // blocks on the 2-min ticker after the first pass
-		close(done)
+		defer close(done)
+		s.StartLatestSHAPoller(ctx) // blocks on the 2-min ticker after the first pass
 	}()
+	defer func() { cancel(); <-done }()
 
 	// Give the synchronous pre-loop pass time to finish its fetch.
 	deadline := time.After(3 * time.Second)
@@ -62,6 +71,5 @@ func TestStartLatestSHAPollerPreLoop(t *testing.T) {
 		case <-time.After(50 * time.Millisecond):
 		}
 	}
-	// The poller goroutine is intentionally left blocking on its long ticker;
-	// it makes no further network calls until the 2-minute tick, well past test end.
+	// The poller goroutine is cancelled and joined via the deferred cancel above.
 }


### PR DESCRIPTION
## The race

The scheduled v2 `go test ./pkg/... -short -race` run flagged a data race in `pkg/hub` — distinct from the `:433`/`:896` race already fixed in #2018, but the same class.

`StartLatestSHAPoller` ran an **uncancellable** ticker loop. `TestStartLatestSHAPollerPreLoop` launched it in a goroutine that outlived the test; that goroutine kept calling `triggerAutoUpgrades()` → `listSaaSHives()`, **reading** the package-level `saasHivesDir` path var, while the *next* test's `helperSetupTempDirs` cleanup **wrote** that same var. The race detector correctly flagged the write-vs-read:

```
Write at ... hub.helperSetupTempDirs.func1()  hub_filesystem_test.go:43
Previous read at ... hub.listSaaSHives()       saas_provision.go
                     hub.(*HubServer).triggerAutoUpgrades()  saas.go
                     hub.(*HubServer).StartLatestSHAPoller()  saas.go
                     TestStartLatestSHAPollerPreLoop.func2()  sha_poller_coverage_test.go
```

## The fix

Mirrors #2018's `startProvisionWatcher` pattern (const/context additions only, no logic change):

- `StartLatestSHAPoller` now takes a `context.Context` and `select`s on `ctx.Done()` in its ticker loop. Behavior-preserving: production passes `context.Background()`, so the daemon still runs forever in prod.
- The production caller in `StartServer` passes `context.Background()`.
- `TestStartLatestSHAPollerPreLoop` runs the poller under a cancellable context and cancels+joins the goroutine (the `defer` runs before the temp-dir `t.Cleanup`), so the daemon is stopped while its temp dirs still exist.

## Verification

- `go test ./pkg/hub/ -race -count=1 -timeout 300s` → clean, **0 DATA RACE** (`ok ... 40.2s`)
- `go vet ./pkg/hub/` passes
- `gofmt -w` on both touched files

No security or launch-path logic is touched.

Fixes #2021