### PR TITLE
👷 ci: gate v2-ci build-and-test on the v3 branch

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -2,10 +2,10 @@ name: v2 CI
 
 on:
   push:
-    branches: [v2]
+    branches: [v2, v3]
     paths: ['v2/**']
   pull_request:
-    branches: [v2]
+    branches: [v2, v3]
     paths: ['v2/**']
 
 permissions:


### PR DESCRIPTION
**Step 0 of the planning-intelligence work** (which builds/tests on `v3`).

`v2-ci.yml` — the per-PR gate (Go build + `-race` tests + proxy npm test) — only triggered on `branches: [v2]`, so a PR into `v3` would merge with **no CI**. This adds `v3` to both the `push` and `pull_request` branch lists.

**Images already handled** — no change needed: `docker.yml` builds on every branch and its push allowlist already includes v3 (`LONG_LIVED="v2 v3 mk dd"`), so pushes to `v3` publish `hive:v3-latest`, `hive-hub:v3-latest`, `hive-contributor:v3-latest` for deployment. `nightly-release` stays gated on `refs/heads/v2`, so v3 never touches the v2 `nightly` tag.

This PR itself is the verification that CI now runs on v3 PRs.