### PR TITLE
✨ feat(dashboard): per-model mini sparklines in cost table + zero-spend baseline

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -4833,7 +4833,8 @@ func (s *Server) handleKnowledgeStats(w http.ResponseWriter, r *http.Request) {
 	// cost sparkline shares the fact sparkline's timer (both throttled to
 	// ~5-min intervals). The figure is the same all-time cumulative estimated
 	// total that GET /api/cost returns; the per-agent map feeds the agent
-	// cards' spend-over-window display.
+	// cards' spend-over-window display and the per-model map feeds the cost
+	// table's mini sparklines (unpriced models included — tokens still trend).
 	est := s.estimatedCost()
 	perAgent := make(map[string]float64, len(est.ByAgent))
 	for _, row := range est.ByAgent {
@@ -4841,7 +4842,13 @@ func (s *Server) handleKnowledgeStats(w http.ResponseWriter, r *http.Request) {
 			perAgent[row.Name] = row.USD
 		}
 	}
-	s.AppendCostHistory(est.TotalUSD, perAgent)
+	perModel := make(map[string]CostModelSnap, len(est.ByModel))
+	for _, row := range est.ByModel {
+		if row.Input > 0 || row.Output > 0 || row.USD > 0 {
+			perModel[row.Name] = CostModelSnap{Input: row.Input, Output: row.Output, USD: row.USD}
+		}
+	}
+	s.AppendCostHistoryFull(est.TotalUSD, perAgent, perModel)
 
 	jsonResponse(w, stats)
 }

--- a/v2/pkg/dashboard/cost_history_test.go
+++ b/v2/pkg/dashboard/cost_history_test.go
@@ -99,3 +99,23 @@ func TestAppendCostHistoryPerAgent(t *testing.T) {
 		t.Errorf("empty agents map should be nil on the entry, got %v", got[0].Agents)
 	}
 }
+
+// TestAppendCostHistoryFullModels verifies per-model snapshots land on the entry.
+func TestAppendCostHistoryFullModels(t *testing.T) {
+	s := &Server{}
+	s.AppendCostHistoryFull(5.0,
+		map[string]float64{"scanner": 5.0},
+		map[string]CostModelSnap{"claude-opus-4.7": {Input: 100, Output: 10, USD: 5.0}})
+
+	got := s.CostHistory()
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	snap, ok := got[0].Models["claude-opus-4.7"]
+	if !ok || snap.Input != 100 || snap.Output != 10 || snap.USD != 5.0 {
+		t.Errorf("model snap = %+v ok=%v, want {100 10 5}", snap, ok)
+	}
+	if got[0].Agents["scanner"] != 5.0 {
+		t.Errorf("agents map lost alongside models: %v", got[0].Agents)
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -378,6 +378,16 @@ type CostHistoryEntry struct {
 	// enabling per-agent spend-over-window on the client. Omitted on entries
 	// recorded before this field existed.
 	Agents map[string]float64 `json:"agents,omitempty"`
+	// Models maps model name → cumulative token/cost snapshot, feeding the
+	// per-model mini sparklines in the cost table. Omitted on older entries.
+	Models map[string]CostModelSnap `json:"models,omitempty"`
+}
+
+// CostModelSnap is one model's cumulative counters at a history snapshot.
+type CostModelSnap struct {
+	Input  int64   `json:"i"`
+	Output int64   `json:"o"`
+	USD    float64 `json:"usd"`
 }
 
 // costHistoryMaxEntries caps the cost sparkline to ~30 days at 5-min intervals,
@@ -1555,6 +1565,16 @@ func (s *Server) SeedFactHistory(entries []FactHistoryEntry) {
 // agents map carries per-agent cumulative $ so the UI can derive per-agent
 // spend over a time window (agent cards); variadic to keep old callers valid.
 func (s *Server) AppendCostHistory(usd float64, agents ...map[string]float64) {
+	var a map[string]float64
+	if len(agents) > 0 {
+		a = agents[0]
+	}
+	s.AppendCostHistoryFull(usd, a, nil)
+}
+
+// AppendCostHistoryFull is AppendCostHistory plus the per-model snapshot map
+// that feeds the cost table's mini sparklines.
+func (s *Server) AppendCostHistoryFull(usd float64, agents map[string]float64, models map[string]CostModelSnap) {
 	now := time.Now().UnixMilli()
 
 	s.costHistoryMu.Lock()
@@ -1571,8 +1591,11 @@ func (s *Server) AppendCostHistory(usd float64, agents ...map[string]float64) {
 		Timestamp: now,
 		USD:       usd,
 	}
-	if len(agents) > 0 && len(agents[0]) > 0 {
-		entry.Agents = agents[0]
+	if len(agents) > 0 {
+		entry.Agents = agents
+	}
+	if len(models) > 0 {
+		entry.Models = models
 	}
 	s.costHistory = append(s.costHistory, entry)
 	if len(s.costHistory) > costHistoryMaxEntries {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -1033,6 +1033,7 @@
     .cost-custom-range { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); font-size: 0.7rem; }
     .cost-custom-range input { background: var(--bg-soft); border: 1px solid var(--line); border-radius: 5px; color: var(--text); font-size: 0.7rem; padding: 2px 6px; font-family: var(--font-ui); }
     .agent-spend-chip { display: inline-block; margin-left: 6px; padding: 0 6px; border: 1px solid var(--line); border-radius: 8px; font-size: 0.66rem; font-weight: 600; color: var(--muted); vertical-align: middle; }
+    .cell-spark { vertical-align: middle; margin-left: 6px; opacity: 0.75; }
     .cost-range button { border: none; background: none; color: var(--muted); font-size: 0.66rem; font-weight: 600; padding: 3px 9px; border-radius: 5px; cursor: pointer; text-transform: capitalize; }
     .cost-range button:hover { color: var(--text); }
     .cost-range button.active { background: var(--panel); color: var(--green); box-shadow: 0 1px 2px rgba(0,0,0,0.15); }
@@ -3770,8 +3771,34 @@
     // is absent on entries recorded before per-agent snapshots existed.
     function costHist() {
       return (_costHistory || [])
-        .map(e => e && { usd: e.usd, timestamp: e.t ?? e.timestamp, agents: e.agents })
+        .map(e => e && { usd: e.usd, timestamp: e.t ?? e.timestamp, agents: e.agents, models: e.models })
         .filter(e => e && typeof e.usd === 'number' && typeof e.timestamp === 'number');
+    }
+
+    // Tiny inline sparkline for cost-table cells. Same min/max scaling as the
+    // big sparkline, sized to sit beside a number.
+    function miniSparkSvg(values, color) {
+      if (!values || values.length < 2) return '';
+      const W = 56, H = 14;
+      const max = Math.max(...values), min = Math.min(...values);
+      const range = (max - min) || max || 1;
+      const pts = values.map((v, i) =>
+        `${(i / (values.length - 1) * W).toFixed(1)},${(H - ((v - min) / range) * (H - 2) - 1).toFixed(1)}`);
+      return `<svg class="cell-spark" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}"><polyline points="${pts.join(' ')}" fill="none" stroke="${color}" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
+    }
+
+    // Cumulative series for one model's field ('i' input, 'o' output, 'usd')
+    // across the active cost window — the table sparklines follow the same
+    // timeframe selector as everything else.
+    function modelSeries(name, field) {
+      const win = costWindow();
+      const out = [];
+      for (const e of costHist()) {
+        if (e.timestamp < win.start || e.timestamp > win.end) continue;
+        const m = e.models && e.models[name];
+        if (m && typeof m[field] === 'number') out.push(m[field]);
+      }
+      return out;
     }
 
     // Last cumulative value at-or-before t via pick(e); null if history starts
@@ -3867,7 +3894,9 @@
         body = `<div class="cost-trend-empty">No cost history yet for this range — data accrues as agents run.</div>`;
       } else {
         const bars = buckets.map(b => {
-          const h = max > 0 ? Math.max(1, (b.spend / max) * 100) : 0;
+          // All-zero windows still draw a 2% baseline so the chart reads as
+          // "flat at zero" rather than missing (only axis labels visible).
+          const h = max > 0 ? Math.max(1, (b.spend / max) * 100) : (b.hasData ? 2 : 0);
           const cls = b.spend > 0 ? 'cost-bar' : 'cost-bar zero';
           const tip = `${new Date(b.start).toLocaleString()} → ${new Date(b.end).toLocaleString()}: ${fmtUSD(b.spend)}`;
           return `<div class="${cls}" style="height:${h.toFixed(1)}%" title="${esc(tip)}"></div>`;
@@ -5878,9 +5907,9 @@ function burnAreaChart() {
           : fmtUSD(m.usd);
         return `<tr>
           <td class="cmodel">${esc(m.name || 'unknown')}</td>
-          <td class="cnum">${fmtTokens(m.input)}</td>
-          <td class="cnum">${fmtTokens(m.output)}</td>
-          <td class="cnum">${usdCell}</td>
+          <td class="cnum">${fmtTokens(m.input)}${miniSparkSvg(modelSeries(m.name, 'i'), 'var(--blue)')}</td>
+          <td class="cnum">${fmtTokens(m.output)}${miniSparkSvg(modelSeries(m.name, 'o'), 'var(--purple)')}</td>
+          <td class="cnum">${usdCell}${miniSparkSvg(modelSeries(m.name, 'usd'), 'var(--green)')}</td>
         </tr>`;
       }).join('');
 


### PR DESCRIPTION
## Summary

From operating the console hive (screenshot showed only `13 / 01 / 12` axis labels with no chart):

1. **Mini sparklines on every model row** — the cost table's input, output, and est.$ cells each get a small inline sparkline of that model's cumulative counters, scoped to the **same hourly/daily/weekly/monthly/custom selector** the spend chart and agent chips use.
2. **Zero-spend windows draw a baseline** — when every bucket's spend is $0 (e.g. all traffic on unpriced models), the chart previously rendered nothing but its axis labels, which read as a bug. Now a flat 2% baseline row renders with tooltips.

## How

- `CostHistoryEntry` gains `models` (name → {i, o, usd} cumulative snapshot), sampled from `estimatedCost().ByModel` on the existing ~5-min throttle. New `AppendCostHistoryFull(usd, agents, models)`; `AppendCostHistory` delegates, keeping its signature for existing callers/tests.
- Unpriced models (currently `gpt-5.3-codex`, `auto`) are included in snapshots — token trends render even where est.$ is '—'. (Separately: pricing gpt-5.3-codex would fix the estimated total undercounting now that auto-mode routes there.)
- Client: `miniSparkSvg` + `modelSeries` helpers; series filtered to `costWindow()` bounds.

## Test plan
- Go: `TestAppendCostHistoryFullModels`; existing history tests unchanged
- UI: model rows show three sparklines once ≥2 snapshots accrue post-deploy; switching timeframe re-scopes them; all-zero hourly window shows flat baseline instead of blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)