### PR TITLE
🐛 fix(dashboard,pricing): 'daily' label typo + price gpt-5.3-codex

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3909,7 +3909,7 @@
 
       const totalLabel = _costRange === 'custom'
         ? 'spend in range'
-        : `spend this ${cfg.label.replace('ly','')} window`;
+        : `spend this ${cfg.label} window`;
       return `<div class="cost-trend">
         <div class="cost-trend-head">
           <div class="cost-range">${pills}</div>

--- a/v2/pkg/tokens/pricing.go
+++ b/v2/pkg/tokens/pricing.go
@@ -95,6 +95,7 @@ var modelPrices = map[string]ModelPrice{
 	"gpt-5-6-terra":       {InputPerMTok: 1.25, OutputPerMTok: 10.00, CacheReadPerMTok: 0.125, CacheWritePerMTok: 1.25},
 	"gpt-5-6-luna":        {InputPerMTok: 1.25, OutputPerMTok: 10.00, CacheReadPerMTok: 0.125, CacheWritePerMTok: 1.25},
 	"gpt-5-3-codex-spark": {InputPerMTok: 1.25, OutputPerMTok: 10.00, CacheReadPerMTok: 0.125, CacheWritePerMTok: 1.25},
+	"gpt-5-3-codex":       {InputPerMTok: 1.25, OutputPerMTok: 10.00, CacheReadPerMTok: 0.125, CacheWritePerMTok: 1.25},
 
 	// ---- DeepSeek (common LiteLLM/OpenRouter routing target) ----
 	// deepseek-chat / V3: $0.27 in / $1.10 out; cache hit $0.07.

--- a/v2/pkg/tokens/pricing_test.go
+++ b/v2/pkg/tokens/pricing_test.go
@@ -141,3 +141,13 @@ func TestEstimateFromSummary_Nil(t *testing.T) {
 		t.Fatalf("nil summary should still return initialized maps")
 	}
 }
+
+// TestGPT53CodexPriced guards the auto-mode routing target so it stops being
+// excluded from the estimated total.
+func TestGPT53CodexPriced(t *testing.T) {
+	for _, id := range []string{"gpt-5.3-codex", "gpt-5-3-codex", "openai/gpt-5.3-codex"} {
+		if _, priced := EstimateCostUSD(id, 1_000_000, 0, 0, 0); !priced {
+			t.Errorf("%q should be priced (auto-mode routes here)", id)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

1. **`spend this dai window`** — the label built `${cfg.label.replace('ly','')} window`, turning 'daily' into 'dai'. Now uses the label as-is → 'spend this daily window'.

2. **gpt-5.3-codex was unpriced** — auto-mode routes real scanner traffic to gpt-5.3-codex, but it had no price-table entry, so it showed `—` in est.$ and was excluded from the estimated total (footnote: 'Not priced… lower bound'). Per the design intent — *show estimated cost when actual isn't available* — add gpt-5.3-codex at the gpt-5.x list price (input 1.25 / output 10.00 per Mtok, matching gpt-5-3-codex-spark).

## Test plan
- Go: new `TestGPT53CodexPriced` (dots, dashes, provider-prefixed all priced)
- UI: Daily pill reads 'spend this daily window'; gpt-5.3-codex row shows a real est.$ instead of '—' once new snapshots accrue

🤖 Generated with [Claude Code](https://claude.com/claude-code)