### PR TITLE
✨ planning: Phase 1 — epic→bead-DAG decomposition (architect lane)

### DIFF
--- a/v2/cmd/bd/decompose.go
+++ b/v2/cmd/bd/decompose.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/kubestellar/hive/v2/pkg/beads"
+	"github.com/kubestellar/hive/v2/pkg/planning"
+)
+
+// cmdDecompose is the MANUAL Phase-1 entry point for planning intelligence.
+// It decomposes an existing epic bead into a DAG of child task beads.
+//
+// Phase 1 does NOT launch a live agent: the planner's task breakdown is read
+// from a file (--plan) or stdin. This keeps the trigger fully manual and the
+// planning package free of any agent/tmux dependency. Phase 2/3 will wire the
+// architect lane's live output in place of the file/stdin source.
+//
+// Usage:
+//
+//	bd decompose <epic-id> --plan plan.txt [--actor <lane>]
+//	cat plan.txt | bd decompose <epic-id>
+func cmdDecompose(args []string) {
+	if len(args) < 1 {
+		fmt.Fprintln(os.Stderr, "bd decompose: requires an epic bead ID")
+		os.Exit(1)
+	}
+
+	epicID := args[0]
+	fs := flag.NewFlagSet("decompose", flag.ExitOnError)
+	planFile := fs.String("plan", "", "File containing the planner's task list (default: stdin)")
+	actor := fs.String("actor", "", "Override child bead actor/lane (default: classifier/architect)")
+	printPrompt := fs.Bool("print-prompt", false, "Print the architect decomposition prompt for this epic and exit")
+	_ = fs.Parse(args[1:])
+
+	store := openStore()
+	epic, err := store.Get(epicID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bd decompose: %v\n", err)
+		os.Exit(1)
+	}
+
+	if *printPrompt {
+		fmt.Print(decomposePromptFor(epic))
+		return
+	}
+
+	output, err := readPlan(*planFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bd decompose: reading plan: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Phase 1 planner is a passthrough of the file/stdin content; the prompt is
+	// still built (and could be printed for the operator) but no agent runs.
+	planner := func(_ context.Context, _ string) (string, error) { return output, nil }
+
+	result, err := planning.Decompose(context.Background(), store, epic, planner, planning.Options{Actor: *actor})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bd decompose: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Decomposed epic %s into %d child bead(s):\n", epic.ID, len(result.Children))
+	for i, child := range result.Children {
+		fmt.Printf("  %s  [%s]  %s\n", child.ID, child.Meta(planning.MetaExecution), result.Tasks[i].Title)
+	}
+	fmt.Printf("Epic %s marked plan_status=%s\n", epic.ID, planning.PlanStatusDraft)
+}
+
+// readPlan returns the plan text from path, or from stdin when path is empty.
+func readPlan(path string) (string, error) {
+	if path == "" {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return "", err
+		}
+		return string(data), nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// decomposePromptFor is exposed so an operator can preview the architect prompt
+// that the planner should be given (e.g. to paste into a live agent). It is a
+// thin wrapper over planning.BuildPrompt.
+func decomposePromptFor(epic *beads.Bead) string {
+	return planning.BuildPrompt(epic)
+}

--- a/v2/cmd/bd/main.go
+++ b/v2/cmd/bd/main.go
@@ -69,6 +69,8 @@ func main() {
 		cmdUpdate(os.Args[2:])
 	case "close":
 		cmdClose(os.Args[2:])
+	case "decompose":
+		cmdDecompose(os.Args[2:])
 	case "reset":
 		cmdReset(os.Args[2:])
 	case "remember":
@@ -106,6 +108,9 @@ Commands:
   kb       list-docs                      List imported documents
   remember "<fact>"                        Quick-add an advisory bead
   close  <id>                              Close a bead
+  decompose <epic-id> [--plan <file>] [--actor <lane>]
+                                           Decompose an epic into a DAG of child task beads
+                                           (Phase 1: reads the planner's task list from --plan or stdin)
   reset  [--reason "..."]                  Close all open/in_progress/blocked beads
   dolt   push                              No-op (data already on disk)
   init                                     No-op (store auto-creates)

--- a/v2/pkg/agentparse/agentparse.go
+++ b/v2/pkg/agentparse/agentparse.go
@@ -1,0 +1,361 @@
+// Package agentparse provides generic, reusable parsers that turn an agent's
+// structured text output (tables, numbered/bulleted lists, and `bd create`
+// command lines) into typed items.
+//
+// These parsers were lifted out of the inception (Level-1 ideation) watcher so
+// that other subsystems — notably planning intelligence (epic -> bead-DAG
+// decomposition) — can reuse the exact same battle-tested extraction logic
+// instead of re-implementing it. Inception continues to use these via thin,
+// behavior-preserving adapters.
+//
+// An Item carries a Title plus optional Default and Category metadata; callers
+// map Items into their own domain types (questions, sub-tasks, ...).
+package agentparse
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Item is a generic parsed list entry. Title is the primary text (a question,
+// a sub-task, ...); Default and Category are optional metadata that some
+// parsers populate. Callers translate Items into their own domain types.
+type Item struct {
+	// Category is a coarse classification label. For the table/numbered parsers
+	// it is derived from the caller-supplied categories; empty when none match
+	// and no fallback is configured.
+	Category string
+	// Title is the primary extracted text.
+	Title string
+	// Default is an optional default/answer column (table parser) — empty when
+	// the source has none.
+	Default string
+}
+
+// ParseTable extracts items from an agent's │-delimited table output.
+//
+// Each row is split on │. The parser finds the column whose (lower-cased) value
+// is present in categories, treats the next column as the Title and the one
+// after as the Default. Rows with no category column are treated as
+// continuations that append their non-empty columns to the current item's
+// Title/Default. Items are de-duplicated by category+title.
+//
+// This is the generic form of inception's parseQuestionTable.
+func ParseTable(lines []string, categories map[string]bool) []Item {
+	var items []Item
+	seen := make(map[string]bool)
+
+	var currentCat, currentTitle, currentDefault string
+
+	flush := func() {
+		if currentCat == "" || currentTitle == "" {
+			return
+		}
+		key := currentCat + ":" + currentTitle
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		items = append(items, Item{
+			Category: currentCat,
+			Title:    strings.TrimSpace(currentTitle),
+			Default:  strings.TrimSpace(currentDefault),
+		})
+	}
+
+	for _, line := range lines {
+		if !strings.Contains(line, "│") {
+			continue
+		}
+
+		cols := strings.Split(line, "│")
+		cleaned := make([]string, 0, len(cols))
+		for _, c := range cols {
+			cleaned = append(cleaned, strings.TrimSpace(c))
+		}
+
+		catIdx := -1
+		for i, c := range cleaned {
+			if categories[strings.ToLower(c)] {
+				catIdx = i
+				break
+			}
+		}
+
+		if catIdx >= 0 && catIdx+1 < len(cleaned) {
+			flush()
+			currentCat = strings.ToLower(cleaned[catIdx])
+			currentTitle = cleaned[catIdx+1]
+			if catIdx+2 < len(cleaned) {
+				currentDefault = cleaned[catIdx+2]
+			} else {
+				currentDefault = ""
+			}
+		} else if currentCat != "" {
+			// Continuation row — append non-empty columns to title/default.
+			nonEmpty := 0
+			for _, c := range cleaned {
+				if c != "" {
+					nonEmpty++
+					if nonEmpty == 1 {
+						currentTitle += " " + c
+					} else if nonEmpty == 2 {
+						currentDefault += " " + c
+					}
+				}
+			}
+		}
+	}
+
+	flush()
+	return items
+}
+
+// numberedListRe matches lines like "1. Primary users — who will use this?"
+// or "1. **Primary users** — who?" or "- Primary users: ...". Group 1 is the
+// label (word chars, spaces and slashes), group 2 the remaining text.
+var numberedListRe = regexp.MustCompile(`^\s*(?:\d+[\.\)]\s*|[-*]\s+)(?:\*\*)?(\w[\w/\s]*?)(?:\*\*)?\s*[-—:]+\s*(.+)`)
+
+// NumberedListRe exposes the numbered/bulleted-list matcher so callers that
+// need to strip list decoration from a single line (rather than a whole slice)
+// can reuse the exact same pattern.
+func NumberedListRe() *regexp.Regexp { return numberedListRe }
+
+// ParseNumberedList extracts items from numbered or bulleted lists such as:
+//
+//  1. Primary users — who will use this and how?
+//  2. Must-have features — the 2-3 things it must do
+//     - Language: what language?
+//
+// The captured label is matched against categories (substring match); when
+// none match, fallbackCategory is used. The remaining text becomes the Title.
+// Items are de-duplicated by category+title. This is the generic form of
+// inception's parseNumberedQuestions.
+func ParseNumberedList(lines []string, categories map[string]bool, fallbackCategory string) []Item {
+	var items []Item
+	seen := make(map[string]bool)
+
+	for _, line := range lines {
+		m := numberedListRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+
+		label := strings.TrimSpace(strings.ToLower(m[1]))
+		title := strings.TrimSpace(m[2])
+		if title == "" {
+			continue
+		}
+
+		cat := ""
+		for kw := range categories {
+			if strings.Contains(label, kw) {
+				cat = kw
+				break
+			}
+		}
+		if cat == "" {
+			cat = fallbackCategory
+		}
+
+		key := cat + ":" + title
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		items = append(items, Item{Category: cat, Title: title, Default: ""})
+	}
+
+	return items
+}
+
+// bdCreateTitleRe extracts the --title value from a `bd create` command line.
+var bdCreateTitleRe = regexp.MustCompile(`--title\s+"([^"]+)"`)
+
+// defaultPlaceholders are placeholder titles the agent emits when showing a
+// command template before filling in real values.
+var defaultPlaceholders = []string{
+	"<fact title>", "<question title>", "<title>",
+	"<your question>", "<description>", "<bead title>",
+	"fact_title", "question_title", "your question here",
+}
+
+// IsTemplatePlaceholder reports whether title is a template placeholder rather
+// than a real value. Any "<...>" angle-bracketed string is a placeholder, as is
+// any exact match against defaultPlaceholders. This is the generic form of
+// inception's isTemplatePlaceholder.
+func IsTemplatePlaceholder(title string) bool {
+	lower := strings.ToLower(title)
+	if strings.HasPrefix(lower, "<") && strings.HasSuffix(lower, ">") {
+		return true
+	}
+	for _, p := range defaultPlaceholders {
+		if lower == p {
+			return true
+		}
+	}
+	return false
+}
+
+// TitleFromBdCreate extracts the --title value from a `bd create` command line,
+// returning ("", false) when there is no title, the title is empty, or it is a
+// template placeholder. This is the generic core of inception's
+// parseQuestionFromBdCreate (category inference and prefix handling stay with
+// the caller).
+func TitleFromBdCreate(line string) (string, bool) {
+	m := bdCreateTitleRe.FindStringSubmatch(line)
+	// len(m) < 2 is defensive: the regex has one capture group, so a non-nil
+	// match always has len 2. It cannot be exercised in a test.
+	if m == nil || len(m) < 2 {
+		return "", false
+	}
+	title := strings.TrimSpace(m[1])
+	if title == "" {
+		return "", false
+	}
+	if IsTemplatePlaceholder(title) {
+		return "", false
+	}
+	return title, true
+}
+
+// taskListRe matches an ordered/bulleted task line, optionally prefixed with a
+// task identifier the decomposer references for dependencies, e.g.:
+//
+//  1. [T1] Scaffold the module skeleton
+//     - [T2] Wire config loading (depends: T1)
+//
+// Group 1 (optional) is the task ID token; group 2 is the task text.
+var taskListRe = regexp.MustCompile(`^\s*(?:\d+[\.\)]\s*|[-*]\s+)(?:\[([^\]]+)\]\s*)?(.+)$`)
+
+// depsRe extracts a trailing "(depends: A, B)" / "(deps: A)" clause.
+var depsRe = regexp.MustCompile(`(?i)\(\s*depends?(?:\s+on)?\s*:\s*([^)]*)\)`)
+
+// executionRe extracts a trailing execution tag written as a parenthetical:
+// "(execution: agent_suitable)", "(exec: human required)", or the bare
+// "(agent_suitable)" / "(human_required)" form. The bracketed "[agent_suitable]"
+// form is handled separately in ParseTaskList.
+var executionRe = regexp.MustCompile(`(?i)\(\s*(?:(?:execution|exec)\s*:\s*)?(agent[_ ]suitable|human[_ ]required)\s*\)`)
+
+// Task is a parsed sub-task emitted by ParseTaskList. Ref is the task's local
+// identifier (e.g. "T1") used to resolve DependsOn references; it is empty when
+// the line carried no [ID] token. DependsOn holds the referenced local ids.
+// Execution is the normalized execution tag ("agent_suitable" or
+// "human_required"), or "" when the line carried none.
+type Task struct {
+	Ref       string
+	Title     string
+	Execution string
+	DependsOn []string
+}
+
+// Normalized execution tag values.
+const (
+	ExecutionAgentSuitable = "agent_suitable"
+	ExecutionHumanRequired = "human_required"
+)
+
+// normalizeExecution maps loose forms ("agent suitable", "human-required") onto
+// the canonical constants, returning "" for anything unrecognized.
+func normalizeExecution(s string) string {
+	switch strings.ReplaceAll(strings.ToLower(strings.TrimSpace(s)), " ", "_") {
+	case ExecutionAgentSuitable:
+		return ExecutionAgentSuitable
+	case ExecutionHumanRequired:
+		return ExecutionHumanRequired
+	default:
+		return ""
+	}
+}
+
+// ParseTaskList parses an agent's ordered sub-task breakdown into Tasks. Each
+// task line may carry an optional [ID] token, a trailing "(depends: ...)"
+// clause referencing other ids, and a trailing execution tag. Lines that are
+// not list items are ignored. Tasks are de-duplicated by title.
+//
+// Example input:
+//
+//  1. [T1] Design the data model [agent_suitable]
+//  2. [T2] Get legal sign-off (human_required)
+//  3. [T3] Implement persistence (depends: T1) [agent_suitable]
+func ParseTaskList(lines []string) []Task {
+	var tasks []Task
+	seen := make(map[string]bool)
+
+	for _, line := range lines {
+		m := taskListRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		ref := strings.TrimSpace(m[1])
+		rest := strings.TrimSpace(m[2])
+		// Defensive: taskListRe's group 2 is `(.+)`, so a matched line always has
+		// non-empty rest before trimming. This guard covers the whitespace-only
+		// edge and cannot be exercised via the regex.
+		if rest == "" {
+			continue
+		}
+
+		var deps []string
+		if dm := depsRe.FindStringSubmatch(rest); dm != nil {
+			for _, d := range strings.Split(dm[1], ",") {
+				if d = strings.TrimSpace(d); d != "" {
+					deps = append(deps, d)
+				}
+			}
+			rest = strings.TrimSpace(depsRe.ReplaceAllString(rest, ""))
+		}
+
+		execution := ""
+		if em := executionRe.FindStringSubmatch(rest); em != nil {
+			execution = normalizeExecution(em[1])
+			rest = strings.TrimSpace(executionRe.ReplaceAllString(rest, ""))
+		} else {
+			// Also accept a bare bracketed [agent_suitable]/[human_required] tag.
+			for _, tag := range []string{ExecutionAgentSuitable, ExecutionHumanRequired} {
+				bracket := "[" + tag + "]"
+				if idx := strings.Index(strings.ToLower(rest), bracket); idx >= 0 {
+					execution = tag
+					rest = strings.TrimSpace(rest[:idx] + rest[idx+len(bracket):])
+					break
+				}
+			}
+		}
+
+		title := strings.TrimSpace(rest)
+		if title == "" {
+			continue
+		}
+		if seen[title] {
+			continue
+		}
+		seen[title] = true
+
+		tasks = append(tasks, Task{
+			Ref:       ref,
+			Title:     title,
+			Execution: execution,
+			DependsOn: deps,
+		})
+	}
+
+	return tasks
+}
+
+// SplitLines splits raw agent output into trimmed-right lines, dropping the
+// trailing empty element from a final newline. Provided so callers do not each
+// re-implement the same normalization before calling the line-based parsers.
+func SplitLines(raw string) []string {
+	raw = strings.ReplaceAll(raw, "\r\n", "\n")
+	parts := strings.Split(raw, "\n")
+	// Drop a single trailing empty line from a terminal newline.
+	if n := len(parts); n > 0 && parts[n-1] == "" {
+		parts = parts[:n-1]
+	}
+	out := make([]string, len(parts))
+	for i, p := range parts {
+		out[i] = strings.TrimRight(p, " \t")
+	}
+	return out
+}

--- a/v2/pkg/agentparse/agentparse_test.go
+++ b/v2/pkg/agentparse/agentparse_test.go
@@ -1,0 +1,401 @@
+package agentparse
+
+import (
+	"reflect"
+	"testing"
+)
+
+var testCategories = map[string]bool{
+	"users": true, "features": true, "constraints": true,
+	"testing": true, "deployment": true, "storage": true,
+	"language": true, "general": true,
+}
+
+func TestParseTable(t *testing.T) {
+	tests := []struct {
+		name  string
+		lines []string
+		want  []Item
+	}{
+		{
+			name:  "nil",
+			lines: nil,
+			want:  nil,
+		},
+		{
+			name:  "no pipes",
+			lines: []string{"just text", "no table here"},
+			want:  nil,
+		},
+		{
+			name: "basic three rows",
+			lines: []string{
+				"│ language │ What language? │ Go         │",
+				"│ users    │ Who uses it?   │ developers │",
+				"│ features │ What must do?  │            │",
+			},
+			want: []Item{
+				{Category: "language", Title: "What language?", Default: "Go"},
+				{Category: "users", Title: "Who uses it?", Default: "developers"},
+				{Category: "features", Title: "What must do?", Default: ""},
+			},
+		},
+		{
+			name: "category not first column",
+			lines: []string{
+				"│ 1 │ storage │ Where to persist? │ disk │",
+			},
+			want: []Item{
+				{Category: "storage", Title: "Where to persist?", Default: "disk"},
+			},
+		},
+		{
+			name: "missing default column",
+			lines: []string{
+				"│ testing │ How to verify?",
+			},
+			want: []Item{
+				{Category: "testing", Title: "How to verify?", Default: ""},
+			},
+		},
+		{
+			name: "continuation row merges",
+			lines: []string{
+				"│ features │ What must it │ nothing │",
+				"│          │ absolutely do │ special │",
+			},
+			want: []Item{
+				{Category: "features", Title: "What must it absolutely do", Default: "nothing special"},
+			},
+		},
+		{
+			name: "dedup identical",
+			lines: []string{
+				"│ users │ Who? │ devs │",
+				"│ users │ Who? │ devs │",
+			},
+			want: []Item{
+				{Category: "users", Title: "Who?", Default: "devs"},
+			},
+		},
+		{
+			name: "continuation before any category is ignored",
+			lines: []string{
+				"│ some │ stray │ row │",
+				"│ users │ Who? │ devs │",
+			},
+			want: []Item{
+				{Category: "users", Title: "Who?", Default: "devs"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseTable(tt.lines, testCategories)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseTable() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseNumberedList(t *testing.T) {
+	tests := []struct {
+		name     string
+		lines    []string
+		fallback string
+		want     []Item
+	}{
+		{name: "nil", lines: nil, fallback: "general", want: nil},
+		{
+			name: "numbered",
+			lines: []string{
+				"1. Primary users — who will use this?",
+				"not a list item",
+				"3. Language — which language?",
+			},
+			fallback: "general",
+			want: []Item{
+				{Category: "users", Title: "who will use this?"},
+				{Category: "language", Title: "which language?"},
+			},
+		},
+		{
+			name:     "bullets",
+			lines:    []string{"- Users: who?", "* Language: what?"},
+			fallback: "general",
+			want: []Item{
+				{Category: "users", Title: "who?"},
+				{Category: "language", Title: "what?"},
+			},
+		},
+		{
+			name:     "bold labels",
+			lines:    []string{"1. **Features** — what must it do?"},
+			fallback: "general",
+			want: []Item{
+				{Category: "features", Title: "what must it do?"},
+			},
+		},
+		{
+			name:     "unknown label uses fallback",
+			lines:    []string{"1. Timeline — when to ship?"},
+			fallback: "general",
+			want: []Item{
+				{Category: "general", Title: "when to ship?"},
+			},
+		},
+		{
+			name:     "empty question skipped",
+			lines:    []string{"1. Users — "},
+			fallback: "general",
+			want:     nil,
+		},
+		{
+			name:     "dedup",
+			lines:    []string{"1. Users — who?", "2. Users — who?"},
+			fallback: "general",
+			want: []Item{
+				{Category: "users", Title: "who?"},
+			},
+		},
+		{
+			name:     "empty fallback stays empty",
+			lines:    []string{"1. Timeline — when?"},
+			fallback: "",
+			want: []Item{
+				{Category: "", Title: "when?"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseNumberedList(tt.lines, testCategories, tt.fallback)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseNumberedList() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNumberedListRe(t *testing.T) {
+	re := NumberedListRe()
+	if re == nil {
+		t.Fatal("NumberedListRe returned nil")
+	}
+	m := re.FindStringSubmatch("1. Users — who?")
+	if m == nil || m[2] != "who?" {
+		t.Errorf("unexpected match: %v", m)
+	}
+}
+
+func TestIsTemplatePlaceholder(t *testing.T) {
+	tests := map[string]bool{
+		"<fact title>":       true,
+		"<question title>":   true,
+		"<anything>":         true,
+		"<>":                 true,
+		"your question here": true,
+		"fact_title":         true,
+		"QUESTION_TITLE":     true, // case-insensitive
+		"real title":         false,
+		"Primary users":      false,
+		"":                   false,
+	}
+	for in, want := range tests {
+		if got := IsTemplatePlaceholder(in); got != want {
+			t.Errorf("IsTemplatePlaceholder(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestTitleFromBdCreate(t *testing.T) {
+	tests := []struct {
+		name   string
+		line   string
+		want   string
+		wantOK bool
+	}{
+		{"basic", `bd create --title "What db?" --type advisory`, "What db?", true},
+		{"no title flag", `bd create --type advisory`, "", false},
+		{"empty title", `bd create --title ""`, "", false},
+		{"placeholder", `bd create --title "<fact title>"`, "", false},
+		{"trims whitespace", `bd create --title "  spaced  "`, "spaced", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := TitleFromBdCreate(tt.line)
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("TitleFromBdCreate(%q) = (%q,%v), want (%q,%v)", tt.line, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestParseTaskList(t *testing.T) {
+	tests := []struct {
+		name  string
+		lines []string
+		want  []Task
+	}{
+		{name: "nil", lines: nil, want: nil},
+		{name: "no list items", lines: []string{"prose", "more prose"}, want: nil},
+		{
+			name: "ids deps and execution tags",
+			lines: []string{
+				"1. [T1] Design data model [agent_suitable]",
+				"2. [T2] Get legal sign-off (human_required)",
+				"3. [T3] Implement persistence (depends: T1) [agent_suitable]",
+			},
+			want: []Task{
+				{Ref: "T1", Title: "Design data model", Execution: "agent_suitable"},
+				{Ref: "T2", Title: "Get legal sign-off", Execution: "human_required"},
+				{Ref: "T3", Title: "Implement persistence", Execution: "agent_suitable", DependsOn: []string{"T1"}},
+			},
+		},
+		{
+			name: "multiple deps and depends on phrasing",
+			lines: []string{
+				"1. [A] first",
+				"2. [B] second (depends on: A)",
+				"3. [C] third (depends: A, B)",
+			},
+			want: []Task{
+				{Ref: "A", Title: "first"},
+				{Ref: "B", Title: "second", DependsOn: []string{"A"}},
+				{Ref: "C", Title: "third", DependsOn: []string{"A", "B"}},
+			},
+		},
+		{
+			name: "execution parenthetical variant with space",
+			lines: []string{
+				"- [X] do a thing (execution: agent suitable)",
+			},
+			want: []Task{
+				{Ref: "X", Title: "do a thing", Execution: "agent_suitable"},
+			},
+		},
+		{
+			name: "unknown execution tag dropped",
+			lines: []string{
+				"1. [T1] task (execution: maybe)",
+			},
+			want: []Task{
+				// "(execution: maybe)" does not match the execution regex, so it
+				// remains part of the title.
+				{Ref: "T1", Title: "task (execution: maybe)"},
+			},
+		},
+		{
+			name: "no id token",
+			lines: []string{
+				"1. plain task without id [human_required]",
+			},
+			want: []Task{
+				{Ref: "", Title: "plain task without id", Execution: "human_required"},
+			},
+		},
+		{
+			name: "bracketed agent_suitable tag",
+			lines: []string{
+				"1. [T1] build the thing [agent_suitable]",
+			},
+			want: []Task{
+				{Ref: "T1", Title: "build the thing", Execution: "agent_suitable"},
+			},
+		},
+		{
+			name: "dedup by title",
+			lines: []string{
+				"1. [T1] same task",
+				"2. [T2] same task",
+			},
+			want: []Task{
+				{Ref: "T1", Title: "same task"},
+			},
+		},
+		{
+			name: "empty remainder skipped",
+			lines: []string{
+				"1. [T1] (depends: T0)",
+			},
+			want: nil,
+		},
+		{
+			name: "empty deps clause yields no deps",
+			lines: []string{
+				"1. [T1] task (depends: )",
+			},
+			want: []Task{
+				{Ref: "T1", Title: "task"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseTaskList(tt.lines)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseTaskList() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSplitLines(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"single line no newline", "hello", []string{"hello"}},
+		{"trailing newline dropped", "a\nb\n", []string{"a", "b"}},
+		{"crlf normalized", "a\r\nb", []string{"a", "b"}},
+		{"trailing spaces trimmed", "a   \nb\t", []string{"a", "b"}},
+		{"internal blank preserved", "a\n\nb\n", []string{"a", "", "b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SplitLines(tt.in)
+			// SplitLines never returns nil for non-empty input; normalize the
+			// empty case where a single "" element is expected to drop out.
+			if tt.in == "" {
+				if len(got) != 1 || got[0] != "" {
+					// "" -> Split gives [""], trailing-empty rule drops it -> [].
+					if len(got) != 0 {
+						t.Errorf("SplitLines(%q) = %+v, want empty", tt.in, got)
+					}
+					return
+				}
+			}
+			if tt.want == nil {
+				if len(got) != 0 {
+					t.Errorf("SplitLines(%q) = %+v, want empty", tt.in, got)
+				}
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SplitLines(%q) = %+v, want %+v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeExecution(t *testing.T) {
+	tests := map[string]string{
+		"agent_suitable": ExecutionAgentSuitable,
+		"agent suitable": ExecutionAgentSuitable,
+		"HUMAN_REQUIRED": ExecutionHumanRequired,
+		"human required": ExecutionHumanRequired,
+		"unknown":        "",
+		"":               "",
+	}
+	for in, want := range tests {
+		if got := normalizeExecution(in); got != want {
+			t.Errorf("normalizeExecution(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/v2/pkg/dashboard/inception_parser_pin_test.go
+++ b/v2/pkg/dashboard/inception_parser_pin_test.go
@@ -1,0 +1,223 @@
+package dashboard
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/knowledge"
+)
+
+// This file "pins" the current behavior of the inception output parsers
+// (parseQuestionTable, parseNumberedQuestions, parseQuestionFromBdCreate, and
+// isTemplatePlaceholder) BEFORE they are lifted into the shared pkg/agentparse
+// package. The lift-and-generalize refactor must keep every assertion below
+// green, guaranteeing Level-1 ideation parsing is unchanged.
+
+func TestPin_ParseQuestionTable_FullTable(t *testing.T) {
+	lines := []string{
+		"┌──────────┬──────────────────────────────┬─────────────┐",
+		"│ Category │ Question                     │ Default     │",
+		"├──────────┼──────────────────────────────┼─────────────┤",
+		"│ language │ What language will you use?   │ Go          │",
+		"│ users    │ Who are the primary users?    │ developers  │",
+		"│ features │ What must it do?              │             │",
+		"└──────────┴──────────────────────────────┴─────────────┘",
+	}
+	got := parseQuestionTable(lines)
+	if len(got) != 3 {
+		t.Fatalf("want 3 questions, got %d: %+v", len(got), got)
+	}
+	want := []knowledge.Question{
+		{ID: "language", Text: "What language will you use?", Default: "Go", Category: "language"},
+		{ID: "users", Text: "Who are the primary users?", Default: "developers", Category: "users"},
+		{ID: "features", Text: "What must it do?", Default: "", Category: "features"},
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("q[%d] = %+v, want %+v", i, got[i], w)
+		}
+	}
+}
+
+func TestPin_ParseQuestionTable_BeadColumnLayout(t *testing.T) {
+	// The category is found dynamically regardless of the leading column.
+	lines := []string{
+		"│ 1 │ storage │ Where do we persist state? │ local disk │",
+		"│ 2 │ testing │ How do we verify?          │ unit tests │",
+	}
+	got := parseQuestionTable(lines)
+	if len(got) != 2 {
+		t.Fatalf("want 2, got %d: %+v", len(got), got)
+	}
+	if got[0].Category != "storage" || got[0].Text != "Where do we persist state?" || got[0].Default != "local disk" {
+		t.Errorf("q0 = %+v", got[0])
+	}
+	if got[1].Category != "testing" {
+		t.Errorf("q1 category = %q", got[1].Category)
+	}
+}
+
+func TestPin_ParseQuestionTable_ContinuationRow(t *testing.T) {
+	lines := []string{
+		"│ features │ What must it            │ nothing │",
+		"│          │ absolutely do          │ special │",
+	}
+	got := parseQuestionTable(lines)
+	if len(got) != 1 {
+		t.Fatalf("want 1 merged question, got %d: %+v", len(got), got)
+	}
+	if got[0].Text != "What must it absolutely do" {
+		t.Errorf("continuation text = %q", got[0].Text)
+	}
+	if got[0].Default != "nothing special" {
+		t.Errorf("continuation default = %q", got[0].Default)
+	}
+}
+
+func TestPin_ParseQuestionTable_EmptyAndNoPipes(t *testing.T) {
+	if got := parseQuestionTable(nil); len(got) != 0 {
+		t.Errorf("nil -> %d", len(got))
+	}
+	if got := parseQuestionTable([]string{"regular text", "no table"}); len(got) != 0 {
+		t.Errorf("no-pipes -> %d", len(got))
+	}
+}
+
+func TestPin_ParseQuestionTable_Dedup(t *testing.T) {
+	lines := []string{
+		"│ language │ What language? │ Go │",
+		"│ language │ What language? │ Go │",
+	}
+	if got := parseQuestionTable(lines); len(got) != 1 {
+		t.Errorf("dedup -> %d", len(got))
+	}
+}
+
+func TestPin_ParseNumberedQuestions_Numbered(t *testing.T) {
+	lines := []string{
+		"1. Primary users — who will use this and how?",
+		"2. Must-have features — the 2-3 things it must do",
+		"3. Language — what programming language?",
+		"This is not a question",
+		"4. Testing — how should we verify it works?",
+	}
+	got := parseNumberedQuestions(lines)
+	if len(got) != 4 {
+		t.Fatalf("want 4, got %d: %+v", len(got), got)
+	}
+	// Category inference from the captured label. Note the regex captures the
+	// label up to the first non-\w/\s char, so "Must-have features" captures
+	// only "must" (-> general) and the question text keeps "have features ...".
+	if got[0].Category != "users" {
+		t.Errorf("q0 category = %q, want users", got[0].Category)
+	}
+	if got[0].Text != "who will use this and how?" {
+		t.Errorf("q0 text = %q", got[0].Text)
+	}
+	if got[1].Category != "general" {
+		t.Errorf("q1 category = %q, want general (label captured as 'must')", got[1].Category)
+	}
+	if got[1].Text != "have features — the 2-3 things it must do" {
+		t.Errorf("q1 text = %q", got[1].Text)
+	}
+	if got[2].Category != "language" {
+		t.Errorf("q2 category = %q, want language", got[2].Category)
+	}
+	if got[3].Category != "testing" {
+		t.Errorf("q3 category = %q, want testing", got[3].Category)
+	}
+}
+
+func TestPin_ParseNumberedQuestions_Bullets(t *testing.T) {
+	lines := []string{
+		"- Primary users: who will use this?",
+		"* Language: what language?",
+	}
+	got := parseNumberedQuestions(lines)
+	if len(got) != 2 {
+		t.Fatalf("want 2, got %d: %+v", len(got), got)
+	}
+}
+
+func TestPin_ParseNumberedQuestions_Bold(t *testing.T) {
+	lines := []string{
+		"1. **Primary users** — who will use this?",
+		"2. **Features** — what must it do?",
+	}
+	got := parseNumberedQuestions(lines)
+	if len(got) != 2 {
+		t.Fatalf("want 2, got %d: %+v", len(got), got)
+	}
+	if got[0].Category != "users" {
+		t.Errorf("q0 category = %q", got[0].Category)
+	}
+}
+
+func TestPin_ParseNumberedQuestions_UnknownLabelGeneral(t *testing.T) {
+	lines := []string{"1. Timeline — when must it ship?"}
+	got := parseNumberedQuestions(lines)
+	if len(got) != 1 || got[0].Category != "general" {
+		t.Fatalf("unknown label -> %+v", got)
+	}
+}
+
+func TestPin_ParseNumberedQuestions_EmptyAndDedup(t *testing.T) {
+	if got := parseNumberedQuestions(nil); len(got) != 0 {
+		t.Errorf("nil -> %d", len(got))
+	}
+	dup := []string{"1. Users — who uses this?", "2. Users — who uses this?"}
+	if got := parseNumberedQuestions(dup); len(got) != 1 {
+		t.Errorf("dedup -> %d", len(got))
+	}
+}
+
+func TestPin_ParseQuestionFromBdCreate(t *testing.T) {
+	w := &InceptionWatcher{logger: slog.Default()}
+
+	q := w.parseQuestionFromBdCreate(`bd create --title "What database should we use?" --type advisory`)
+	if q == nil || q.Text != "What database should we use?" {
+		t.Fatalf("basic -> %+v", q)
+	}
+
+	q = w.parseQuestionFromBdCreate(`bd create --title "Who are the primary users?" --actor brainstorm`)
+	if q == nil || q.Category != "users" {
+		t.Fatalf("users category -> %+v", q)
+	}
+
+	q = w.parseQuestionFromBdCreate(`bd create --title "Clarification: What language?"`)
+	if q == nil || q.Text != "What language?" {
+		t.Fatalf("clarification strip -> %+v", q)
+	}
+	if q.Category != "language" {
+		t.Errorf("language category -> %q", q.Category)
+	}
+	if q.Default != "Yes, use best practices" {
+		t.Errorf("default -> %q", q.Default)
+	}
+
+	if got := w.parseQuestionFromBdCreate(`bd create --type advisory`); got != nil {
+		t.Errorf("no title -> %+v", got)
+	}
+	if got := w.parseQuestionFromBdCreate(`bd create --title "<fact title>"`); got != nil {
+		t.Errorf("placeholder -> %+v", got)
+	}
+	if got := w.parseQuestionFromBdCreate(`bd create --title ""`); got != nil {
+		t.Errorf("empty title -> %+v", got)
+	}
+}
+
+func TestPin_IsTemplatePlaceholder(t *testing.T) {
+	cases := map[string]bool{
+		"<fact title>":         true,
+		"<question title>":     true,
+		"<anything angled>":    true,
+		"your question here":   true,
+		"What database to use?": false,
+		"Primary users":        false,
+	}
+	for in, want := range cases {
+		if got := isTemplatePlaceholder(in); got != want {
+			t.Errorf("isTemplatePlaceholder(%q) = %v, want %v", in, got, want)
+		}
+	}
+}

--- a/v2/pkg/dashboard/inception_watcher.go
+++ b/v2/pkg/dashboard/inception_watcher.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/agent"
+	"github.com/kubestellar/hive/v2/pkg/agentparse"
 	"github.com/kubestellar/hive/v2/pkg/beads"
 	"github.com/kubestellar/hive/v2/pkg/governor"
 	"github.com/kubestellar/hive/v2/pkg/knowledge"
@@ -20,15 +20,15 @@ import (
 )
 
 const (
-	inceptionWatchIntervalS  = 5 * time.Second
-	inceptionBeadRefPrefix   = "inception/"
-	minQuestionsForAdvance   = 5
-	minFactsForAdvance           = 3
-	targetFactCount              = 8
-	factEnrichmentGracePeriod    = 15 * time.Second
-	autoFactFallbackTimeout      = 60 * time.Second  // minimum time before fact fallback can fire
-	autoQuestionFallbackTimeout  = 60 * time.Second  // minimum time before fallback can fire
-	agentIdleThreshold           = 30 * time.Second  // agent must be idle this long before fallback
+	inceptionWatchIntervalS     = 5 * time.Second
+	inceptionBeadRefPrefix      = "inception/"
+	minQuestionsForAdvance      = 5
+	minFactsForAdvance          = 3
+	targetFactCount             = 8
+	factEnrichmentGracePeriod   = 15 * time.Second
+	autoFactFallbackTimeout     = 60 * time.Second // minimum time before fact fallback can fire
+	autoQuestionFallbackTimeout = 60 * time.Second // minimum time before fallback can fire
+	agentIdleThreshold          = 30 * time.Second // agent must be idle this long before fallback
 )
 
 // InceptionWatcher polls brainstorm beads and bridges them into the inception
@@ -391,11 +391,11 @@ func (w *InceptionWatcher) checkForQuestions(inceptionBeads []*beads.Bead) {
 }
 
 const (
-	outputParseLineCount       = 100
-	interceptBufferLineCount   = 500
-	kickRetryDelayS        = 20 * time.Second
-	kickRetryGracePeriodS  = 15 * time.Second
-	maxKickRetries         = 5
+	outputParseLineCount     = 100
+	interceptBufferLineCount = 500
+	kickRetryDelayS          = 20 * time.Second
+	kickRetryGracePeriodS    = 15 * time.Second
+	maxKickRetries           = 5
 )
 
 // retryKickIfStale re-sends the inception prompt via SendKick when the
@@ -788,154 +788,51 @@ func (w *InceptionWatcher) checkForQuestionsInOutput() {
 	)
 }
 
-// parseQuestionTable extracts questions from the agent's formatted table output.
-// The table uses │ as column delimiters with columns: #/Bead, Category, Question, Default.
-// categoryKeywords are the valid question categories the agent produces.
+// categoryKeywords are the valid question categories the agent produces during
+// Level-1 ideation. They are passed to the shared agentparse list-parsers.
 var categoryKeywords = map[string]bool{
 	"users": true, "features": true, "constraints": true,
 	"testing": true, "deployment": true, "storage": true,
 	"language": true, "general": true,
 }
 
-// parseQuestionTable extracts questions from the agent's formatted table output.
-// Scans each │-delimited row for a column matching a known category keyword,
-// then takes the next column as the question and the one after as the default.
-// Handles variable column layouts (# | Category | Question | Default) and
-// (Bead | Category | Question | Default) by finding the category dynamically.
+// parseQuestionTable extracts questions from the agent's │-delimited table
+// output. It is a thin, behavior-preserving adapter over agentparse.ParseTable:
+// the generic parser finds the category column and extracts title/default, and
+// this adapter maps each Item into a knowledge.Question (ID == Category, as
+// before).
 func parseQuestionTable(lines []string) []knowledge.Question {
-	var questions []knowledge.Question
-	seen := make(map[string]bool)
-
-	var currentCat, currentQuestion, currentDefault string
-
-	for _, line := range lines {
-		if !strings.Contains(line, "│") {
-			continue
-		}
-
-		// Split by │ delimiter
-		cols := strings.Split(line, "│")
-		var cleaned []string
-		for _, c := range cols {
-			cleaned = append(cleaned, strings.TrimSpace(c))
-		}
-
-		// Find category column by matching known keywords
-		catIdx := -1
-		for i, c := range cleaned {
-			if categoryKeywords[strings.ToLower(c)] {
-				catIdx = i
-				break
-			}
-		}
-
-		if catIdx >= 0 && catIdx+1 < len(cleaned) {
-			// Flush previous question
-			if currentCat != "" && currentQuestion != "" {
-				key := currentCat + ":" + currentQuestion
-				if !seen[key] {
-					seen[key] = true
-					questions = append(questions, knowledge.Question{
-						ID:       currentCat,
-						Text:     strings.TrimSpace(currentQuestion),
-						Default:  strings.TrimSpace(currentDefault),
-						Category: currentCat,
-					})
-				}
-			}
-
-			// Start new question
-			currentCat = strings.ToLower(cleaned[catIdx])
-			currentQuestion = cleaned[catIdx+1]
-			if catIdx+2 < len(cleaned) {
-				currentDefault = cleaned[catIdx+2]
-			} else {
-				currentDefault = ""
-			}
-		} else if currentCat != "" {
-			// Continuation row — append non-empty columns to question/default
-			nonEmpty := 0
-			for _, c := range cleaned {
-				if c != "" {
-					nonEmpty++
-					if nonEmpty == 1 {
-						currentQuestion += " " + c
-					} else if nonEmpty == 2 {
-						currentDefault += " " + c
-					}
-				}
-			}
-		}
+	items := agentparse.ParseTable(lines, categoryKeywords)
+	questions := make([]knowledge.Question, 0, len(items))
+	for _, it := range items {
+		questions = append(questions, knowledge.Question{
+			ID:       it.Category,
+			Text:     it.Title,
+			Default:  it.Default,
+			Category: it.Category,
+		})
 	}
-
-	// Flush last question
-	if currentCat != "" && currentQuestion != "" {
-		key := currentCat + ":" + currentQuestion
-		if !seen[key] {
-			seen[key] = true
-			questions = append(questions, knowledge.Question{
-				ID:       currentCat,
-				Text:     strings.TrimSpace(currentQuestion),
-				Default:  strings.TrimSpace(currentDefault),
-				Category: currentCat,
-			})
-		}
-	}
-
 	return questions
 }
 
-// numberedQuestionRe matches lines like "1. Primary users — who will use this?"
-// or "1. **Primary users** — who will use this?" or "- Primary users: ..."
-var numberedQuestionRe = regexp.MustCompile(`^\s*(?:\d+[\.\)]\s*|[-*]\s+)(?:\*\*)?(\w[\w/\s]*?)(?:\*\*)?\s*[-—:]+\s*(.+)`)
+// numberedQuestionRe is retained for callers in this file that strip list
+// decoration from a single line; it is the same matcher agentparse uses.
+var numberedQuestionRe = agentparse.NumberedListRe()
 
 // parseNumberedQuestions extracts questions from numbered or bulleted lists.
-// Catches the case where the agent outputs questions as:
-//   1. Primary users — who will use this and how?
-//   2. Must-have features — the 2-3 things it must do
-// instead of a │-delimited table.
+// Thin, behavior-preserving adapter over agentparse.ParseNumberedList with the
+// "general" fallback category, mapping each Item into a knowledge.Question.
 func parseNumberedQuestions(lines []string) []knowledge.Question {
-	var questions []knowledge.Question
-	seen := make(map[string]bool)
-
-	for _, line := range lines {
-		m := numberedQuestionRe.FindStringSubmatch(line)
-		if m == nil {
-			continue
-		}
-
-		label := strings.TrimSpace(strings.ToLower(m[1]))
-		question := strings.TrimSpace(m[2])
-		if question == "" {
-			continue
-		}
-
-		// Map label to category
-		cat := ""
-		for kw := range categoryKeywords {
-			if strings.Contains(label, kw) {
-				cat = kw
-				break
-			}
-		}
-		if cat == "" {
-			cat = "general"
-		}
-
-		key := cat + ":" + question
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
-
+	items := agentparse.ParseNumberedList(lines, categoryKeywords, "general")
+	questions := make([]knowledge.Question, 0, len(items))
+	for _, it := range items {
 		questions = append(questions, knowledge.Question{
-			ID:       cat,
-			Text:     question,
+			ID:       it.Category,
+			Text:     it.Title,
 			Default:  "",
-			Category: cat,
+			Category: it.Category,
 		})
 	}
-
 	return questions
 }
 
@@ -1404,42 +1301,21 @@ func (w *InceptionWatcher) interceptQuestionsFromBuffer(state *knowledge.Incepti
 	}
 }
 
-// bdCreateTitleRe extracts the --title value from a bd create command line.
-var bdCreateTitleRe = regexp.MustCompile(`--title\s+"([^"]+)"`)
-
 // isTemplatePlaceholder rejects placeholder titles that the agent outputs
 // as part of showing a command template before filling in actual values.
+// Thin, behavior-preserving adapter over agentparse.IsTemplatePlaceholder.
 func isTemplatePlaceholder(title string) bool {
-	lower := strings.ToLower(title)
-	if strings.HasPrefix(lower, "<") && strings.HasSuffix(lower, ">") {
-		return true
-	}
-	placeholders := []string{
-		"<fact title>", "<question title>", "<title>",
-		"<your question>", "<description>", "<bead title>",
-		"fact_title", "question_title", "your question here",
-	}
-	for _, p := range placeholders {
-		if lower == p {
-			return true
-		}
-	}
-	return false
+	return agentparse.IsTemplatePlaceholder(title)
 }
 
 // parseQuestionFromBdCreate extracts a question from a bd create command
 // in the agent's raw output. Works regardless of --type, --actor, or
-// --external-ref values — the title IS the question.
+// --external-ref values — the title IS the question. Title extraction and
+// placeholder rejection are delegated to agentparse.TitleFromBdCreate; category
+// inference and prefix handling stay here (inception-specific).
 func (w *InceptionWatcher) parseQuestionFromBdCreate(line string) *knowledge.Question {
-	m := bdCreateTitleRe.FindStringSubmatch(line)
-	if m == nil || len(m) < 2 {
-		return nil
-	}
-	title := strings.TrimSpace(m[1])
-	if title == "" {
-		return nil
-	}
-	if isTemplatePlaceholder(title) {
+	title, ok := agentparse.TitleFromBdCreate(line)
+	if !ok {
 		return nil
 	}
 

--- a/v2/pkg/planning/decompose.go
+++ b/v2/pkg/planning/decompose.go
@@ -1,0 +1,291 @@
+// Package planning implements "planning intelligence" for Hive: turning a
+// high-level epic bead into an ordered DAG of child sub-task beads.
+//
+// Phase 1 (this package) covers epic -> bead-DAG decomposition with a MANUAL
+// trigger. It asks the architect lane to break an epic's goal into ordered,
+// mostly-independent sub-tasks, parses that plan with the shared agentparse
+// task-list parser, and materializes the result as child beads linked by
+// dependencies and tagged with parent/execution metadata.
+//
+// Phase 1 deliberately does NOT touch the governor, the main eval loop, or the
+// live agent-launch path. The planner's output is provided to Decompose via an
+// injected PlannerFunc (or as raw text via DecomposeFromOutput), keeping the
+// whole package unit-testable without spawning a real agent.
+//
+// The readiness gate that hides draft-epic children from Ready() is Phase 2;
+// this package only lays the metadata convention (plan_status=draft on the
+// epic, parent_epic + execution on each child) that Phase 2 will filter on.
+package planning
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kubestellar/hive/v2/pkg/agentparse"
+	"github.com/kubestellar/hive/v2/pkg/beads"
+	"github.com/kubestellar/hive/v2/pkg/classify"
+	"github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// Metadata keys written by Decompose. These form the convention Phase 2's
+// Ready()-filtering will read.
+const (
+	// MetaParentEpic on a child bead holds the ID of the epic it decomposes.
+	MetaParentEpic = "parent_epic"
+	// MetaExecution on a child bead records whether it is agent-suitable or
+	// human-required (agentparse.ExecutionAgentSuitable / ExecutionHumanRequired).
+	MetaExecution = "execution"
+	// MetaPlanStatus on the epic records decomposition state. Phase 1 only ever
+	// sets it to PlanStatusDraft. Phase 2 will transition it (e.g. to
+	// "approved") to release the children through Ready().
+	MetaPlanStatus = "plan_status"
+	// MetaPlanRef on a child records the planner's local task reference (e.g.
+	// "T1") so a plan can be re-derived / audited.
+	MetaPlanRef = "plan_ref"
+)
+
+// PlanStatusDraft marks an epic whose plan has been drafted but not yet
+// approved. TODO(planning phase 2): Store.Ready() must exclude children whose
+// parent epic still carries plan_status=draft; that gating is intentionally not
+// implemented here.
+const PlanStatusDraft = "draft"
+
+// defaultChildPriority is the priority assigned to generated child beads when
+// the epic carries none distinguishable. Children inherit the epic's priority
+// (see Options.ChildPriority) but default to Medium.
+const defaultChildPriority = beads.PriorityMedium
+
+// PlannerFunc produces the raw planner output for an epic prompt. It is the
+// single injection seam that keeps Decompose free of any live agent/tmux
+// dependency in Phase 1. Implementations must honor ctx cancellation.
+type PlannerFunc func(ctx context.Context, prompt string) (string, error)
+
+// Options tune a decomposition. The zero value is valid.
+type Options struct {
+	// Actor overrides the child beads' actor/lane. When empty, Decompose
+	// derives the lane from the epic title via the classifier, falling back to
+	// the architect lane (the planner role for Phase 1).
+	Actor string
+	// ChildPriority overrides the child beads' priority. When nil, children
+	// inherit the epic's priority.
+	ChildPriority *beads.Priority
+}
+
+// Result summarizes a decomposition.
+type Result struct {
+	// Children are the newly created child beads, in plan order.
+	Children []*beads.Bead
+	// Tasks are the parsed planner tasks aligned 1:1 with Children.
+	Tasks []agentparse.Task
+}
+
+// BuildPrompt renders the architect-style decomposition prompt for an epic. It
+// reuses the architect lane's framing ([agent:architect]) so the planner role
+// is the existing architect, not a new role. The prompt asks for an ordered,
+// dependency-annotated, execution-tagged task list in the exact shape
+// agentparse.ParseTaskList consumes.
+func BuildPrompt(epic *beads.Bead) string {
+	var b strings.Builder
+	b.WriteString("[agent:architect]\n")
+	b.WriteString("Decompose the following EPIC into an ordered plan of sub-tasks.\n\n")
+
+	b.WriteString("EPIC: ")
+	b.WriteString(epic.Title)
+	b.WriteString("\n")
+	if body := epicBody(epic); body != "" {
+		b.WriteString("DETAILS:\n")
+		b.WriteString(body)
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+
+	b.WriteString("INSTRUCTIONS:\n")
+	b.WriteString("  1. Break the goal into ordered, independent-where-possible sub-tasks.\n")
+	b.WriteString("  2. Give each sub-task a local id in [brackets] (T1, T2, ...).\n")
+	b.WriteString("  3. Note dependencies with a trailing \"(depends: T1, T2)\" clause.\n")
+	b.WriteString("  4. Mark each sub-task \"[agent_suitable]\" or \"[human_required]\".\n")
+	b.WriteString("  5. Do NOT open PRs or create beads — output only the plan.\n\n")
+
+	b.WriteString("FORMAT (one task per line):\n")
+	b.WriteString("  1. [T1] <task> [agent_suitable]\n")
+	b.WriteString("  2. [T2] <task> (depends: T1) [human_required]\n")
+
+	return b.String()
+}
+
+// epicBody returns the most descriptive text available for an epic: its Notes,
+// else a "body"/"description" metadata value, else "".
+func epicBody(epic *beads.Bead) string {
+	if strings.TrimSpace(epic.Notes) != "" {
+		return strings.TrimSpace(epic.Notes)
+	}
+	for _, k := range []string{"body", "description"} {
+		if v := epic.Meta(k); strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+// Decompose runs a full manual decomposition: it builds the architect prompt,
+// invokes planner to get the plan text, then materializes child beads via
+// DecomposeFromOutput. planner must not be nil.
+func Decompose(ctx context.Context, store *beads.Store, epic *beads.Bead, planner PlannerFunc, opts Options) (*Result, error) {
+	if planner == nil {
+		return nil, fmt.Errorf("planning: planner func is nil")
+	}
+	if err := validateEpic(store, epic); err != nil {
+		return nil, err
+	}
+
+	prompt := BuildPrompt(epic)
+	output, err := planner(ctx, prompt)
+	if err != nil {
+		return nil, fmt.Errorf("planning: planner failed: %w", err)
+	}
+	return DecomposeFromOutput(store, epic, output, opts)
+}
+
+// DecomposeFromOutput materializes child beads from an already-obtained planner
+// output. It is the unit-testable core: no agent, no context needed. Steps:
+//
+//  1. parse the output into tasks (agentparse.ParseTaskList),
+//  2. create one child bead per task,
+//  3. link dependencies by resolving each task's local refs to child ids,
+//  4. tag children with parent_epic + execution (+ plan_ref),
+//  5. mark the epic plan_status=draft (Phase 2 readiness convention).
+//
+// It returns an error if the epic is invalid or the output yields no tasks.
+func DecomposeFromOutput(store *beads.Store, epic *beads.Bead, output string, opts Options) (*Result, error) {
+	if err := validateEpic(store, epic); err != nil {
+		return nil, err
+	}
+
+	tasks := agentparse.ParseTaskList(agentparse.SplitLines(output))
+	if len(tasks) == 0 {
+		return nil, fmt.Errorf("planning: planner output produced no tasks")
+	}
+
+	actor := opts.Actor
+	if actor == "" {
+		actor = deriveActor(epic)
+	}
+	priority := epic.Priority
+	if opts.ChildPriority != nil {
+		priority = *opts.ChildPriority
+	} else if priority < beads.PriorityCritical || priority > beads.PriorityMinor {
+		priority = defaultChildPriority
+	}
+
+	children := make([]*beads.Bead, 0, len(tasks))
+	// refToID maps a task's local ref (e.g. "T1") to the created child bead id,
+	// so dependency clauses can be resolved after all children exist.
+	refToID := make(map[string]string, len(tasks))
+
+	// NOTE: the store.Create / SetMetadata / AddDependency error branches below
+	// only fire on underlying persistence (disk I/O) failures — the inputs are
+	// always valid (TypeTask, string metadata, known ids). They are covered
+	// representatively by TestDecomposeFromOutput_CreateChildError (read-only
+	// store dir); the remaining sibling branches are defensive I/O guards.
+	for _, task := range tasks {
+		child, err := store.Create(task.Title, beads.TypeTask, priority, actor, "")
+		if err != nil {
+			return nil, fmt.Errorf("planning: creating child bead for %q: %w", task.Title, err)
+		}
+		children = append(children, child)
+		if task.Ref != "" {
+			refToID[task.Ref] = child.ID
+		}
+
+		if err := store.SetMetadata(child.ID, MetaParentEpic, epic.ID); err != nil {
+			return nil, fmt.Errorf("planning: tagging parent_epic on %s: %w", child.ID, err)
+		}
+		execution := task.Execution
+		if execution == "" {
+			// Default unmarked tasks to agent-suitable; a human can re-tag later.
+			execution = agentparse.ExecutionAgentSuitable
+		}
+		if err := store.SetMetadata(child.ID, MetaExecution, execution); err != nil {
+			return nil, fmt.Errorf("planning: tagging execution on %s: %w", child.ID, err)
+		}
+		if task.Ref != "" {
+			if err := store.SetMetadata(child.ID, MetaPlanRef, task.Ref); err != nil {
+				return nil, fmt.Errorf("planning: tagging plan_ref on %s: %w", child.ID, err)
+			}
+		}
+	}
+
+	// Second pass: wire dependencies now that every ref is known. Unknown refs
+	// (a task depending on an id the planner never defined) are skipped rather
+	// than erroring, so a partially-malformed plan still produces a usable DAG.
+	for i, task := range tasks {
+		for _, ref := range task.DependsOn {
+			depID, ok := refToID[ref]
+			if !ok || depID == children[i].ID {
+				// Unknown ref or self-dependency — skip.
+				continue
+			}
+			if err := store.AddDependency(children[i].ID, depID); err != nil {
+				return nil, fmt.Errorf("planning: linking %s -> %s: %w", children[i].ID, depID, err)
+			}
+		}
+	}
+
+	// Lay the Phase 2 readiness convention: mark the epic's plan as draft.
+	if err := store.SetMetadata(epic.ID, MetaPlanStatus, PlanStatusDraft); err != nil {
+		return nil, fmt.Errorf("planning: setting plan_status on epic %s: %w", epic.ID, err)
+	}
+
+	return &Result{Children: children, Tasks: tasks}, nil
+}
+
+// validateEpic ensures epic is non-nil, of type epic, and (when store is
+// provided) still exists in the store.
+func validateEpic(store *beads.Store, epic *beads.Bead) error {
+	if epic == nil {
+		return fmt.Errorf("planning: epic is nil")
+	}
+	if epic.Type != beads.TypeEpic {
+		return fmt.Errorf("planning: bead %s is type %q, only %q may be decomposed", epic.ID, epic.Type, beads.TypeEpic)
+	}
+	if store != nil {
+		if _, err := store.Get(epic.ID); err != nil {
+			return fmt.Errorf("planning: epic %s not found in store: %w", epic.ID, err)
+		}
+	}
+	return nil
+}
+
+// architectActor is the actor/lane for the planner role in Phase 1. It matches
+// classify.LaneArchitect and is the fallback when the classifier does not route
+// the epic elsewhere.
+const architectActor = string(classify.LaneArchitect)
+
+// deriveActor picks the child beads' actor/lane. It runs the epic title through
+// the classifier; a non-default lane wins, otherwise it falls back to the
+// architect lane (the Phase 1 planner role).
+func deriveActor(epic *beads.Bead) string {
+	c := classify.Classify(github.Issue{Title: epic.Title, Labels: epicLabels(epic)})
+	if lane := string(c.Lane); lane != "" && lane != classify.DefaultLane {
+		return lane
+	}
+	return architectActor
+}
+
+// epicLabels extracts comma-separated labels from an epic's "labels" metadata,
+// if present, so the classifier can use them.
+func epicLabels(epic *beads.Bead) []string {
+	raw := epic.Meta("labels")
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/v2/pkg/planning/decompose_test.go
+++ b/v2/pkg/planning/decompose_test.go
@@ -1,0 +1,480 @@
+package planning
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/agentparse"
+	"github.com/kubestellar/hive/v2/pkg/beads"
+	"github.com/kubestellar/hive/v2/pkg/classify"
+)
+
+// newStore returns a beads.Store rooted at a fresh temp dir.
+func newStore(t *testing.T) *beads.Store {
+	t.Helper()
+	store, err := beads.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	return store
+}
+
+// mustEpic creates and returns an epic bead.
+func mustEpic(t *testing.T, store *beads.Store, title string) *beads.Bead {
+	t.Helper()
+	b, err := store.Create(title, beads.TypeEpic, beads.PriorityHigh, "architect", "")
+	if err != nil {
+		t.Fatalf("create epic: %v", err)
+	}
+	return b
+}
+
+const samplePlan = `Here is the plan:
+1. [T1] Design the data model [agent_suitable]
+2. [T2] Get security review sign-off (human_required)
+3. [T3] Implement persistence (depends: T1) [agent_suitable]
+4. [T4] Wire it together (depends: T1, T3) [agent_suitable]
+`
+
+func TestDecomposeFromOutput_HappyPath(t *testing.T) {
+	store := newStore(t)
+	epic := mustEpic(t, store, "Build the widget subsystem")
+
+	res, err := DecomposeFromOutput(store, epic, samplePlan, Options{})
+	if err != nil {
+		t.Fatalf("DecomposeFromOutput: %v", err)
+	}
+	if len(res.Children) != 4 {
+		t.Fatalf("want 4 children, got %d", len(res.Children))
+	}
+
+	// Titles preserved and in order.
+	wantTitles := []string{
+		"Design the data model",
+		"Get security review sign-off",
+		"Implement persistence",
+		"Wire it together",
+	}
+	for i, want := range wantTitles {
+		if res.Children[i].Title != want {
+			t.Errorf("child[%d] title = %q, want %q", i, res.Children[i].Title, want)
+		}
+		if res.Children[i].Type != beads.TypeTask {
+			t.Errorf("child[%d] type = %q, want task", i, res.Children[i].Type)
+		}
+	}
+
+	// Metadata: parent_epic on every child, execution tags correct.
+	for _, c := range res.Children {
+		got, err := store.Get(c.ID)
+		if err != nil {
+			t.Fatalf("get child: %v", err)
+		}
+		if got.Meta(MetaParentEpic) != epic.ID {
+			t.Errorf("child %s parent_epic = %q, want %q", c.ID, got.Meta(MetaParentEpic), epic.ID)
+		}
+	}
+
+	// Execution: T2 is human_required; the rest agent_suitable.
+	if got := mustGet(t, store, res.Children[1].ID).Meta(MetaExecution); got != agentparse.ExecutionHumanRequired {
+		t.Errorf("T2 execution = %q, want human_required", got)
+	}
+	for _, idx := range []int{0, 2, 3} {
+		if got := mustGet(t, store, res.Children[idx].ID).Meta(MetaExecution); got != agentparse.ExecutionAgentSuitable {
+			t.Errorf("child[%d] execution = %q, want agent_suitable", idx, got)
+		}
+	}
+
+	// plan_ref recorded.
+	if got := mustGet(t, store, res.Children[0].ID).Meta(MetaPlanRef); got != "T1" {
+		t.Errorf("child[0] plan_ref = %q, want T1", got)
+	}
+
+	// Dependencies: T3 depends on T1; T4 depends on T1 and T3.
+	t1, t3, t4 := res.Children[0].ID, res.Children[2].ID, res.Children[3].ID
+	assertDeps(t, store, t3, []string{t1})
+	assertDeps(t, store, t4, []string{t1, t3})
+
+	// Epic marked plan_status=draft.
+	if got := mustGet(t, store, epic.ID).Meta(MetaPlanStatus); got != PlanStatusDraft {
+		t.Errorf("epic plan_status = %q, want draft", got)
+	}
+}
+
+func TestDecomposeFromOutput_UnmarkedTaskDefaultsAgentSuitable(t *testing.T) {
+	store := newStore(t)
+	epic := mustEpic(t, store, "Some epic")
+	res, err := DecomposeFromOutput(store, epic, "1. [T1] a task with no execution tag", Options{})
+	if err != nil {
+		t.Fatalf("DecomposeFromOutput: %v", err)
+	}
+	if got := mustGet(t, store, res.Children[0].ID).Meta(MetaExecution); got != agentparse.ExecutionAgentSuitable {
+		t.Errorf("execution = %q, want agent_suitable default", got)
+	}
+}
+
+func TestDecomposeFromOutput_UnknownDepSkipped(t *testing.T) {
+	store := newStore(t)
+	epic := mustEpic(t, store, "Epic")
+	// T1 depends on a ref (T9) that is never defined — must be skipped, not error.
+	res, err := DecomposeFromOutput(store, epic, "1. [T1] only task (depends: T9)", Options{})
+	if err != nil {
+		t.Fatalf("DecomposeFromOutput: %v", err)
+	}
+	assertDeps(t, store, res.Children[0].ID, nil)
+}
+
+func TestDecomposeFromOutput_SelfDepSkipped(t *testing.T) {
+	store := newStore(t)
+	epic := mustEpic(t, store, "Epic")
+	res, err := DecomposeFromOutput(store, epic, "1. [T1] recursive (depends: T1)", Options{})
+	if err != nil {
+		t.Fatalf("DecomposeFromOutput: %v", err)
+	}
+	assertDeps(t, store, res.Children[0].ID, nil)
+}
+
+func TestDecomposeFromOutput_NoTasks(t *testing.T) {
+	store := newStore(t)
+	epic := mustEpic(t, store, "Epic")
+	_, err := DecomposeFromOutput(store, epic, "just prose, no list items here", Options{})
+	if err == nil || !strings.Contains(err.Error(), "no tasks") {
+		t.Fatalf("want no-tasks error, got %v", err)
+	}
+}
+
+func TestDecomposeFromOutput_NonEpicRejected(t *testing.T) {
+	store := newStore(t)
+	task, err := store.Create("not an epic", beads.TypeTask, beads.PriorityMedium, "scanner", "")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	_, err = DecomposeFromOutput(store, task, samplePlan, Options{})
+	if err == nil || !strings.Contains(err.Error(), "only") {
+		t.Fatalf("want non-epic rejection, got %v", err)
+	}
+}
+
+func TestDecomposeFromOutput_NilEpic(t *testing.T) {
+	store := newStore(t)
+	if _, err := DecomposeFromOutput(store, nil, samplePlan, Options{}); err == nil {
+		t.Fatal("want error for nil epic")
+	}
+}
+
+func TestDecomposeFromOutput_EpicNotInStore(t *testing.T) {
+	store := newStore(t)
+	// An epic-typed bead that was never persisted to this store.
+	ghost := &beads.Bead{ID: "ghost1234567", Title: "ghost", Type: beads.TypeEpic}
+	if _, err := DecomposeFromOutput(store, ghost, samplePlan, Options{}); err == nil {
+		t.Fatal("want error for epic not in store")
+	}
+}
+
+func TestDecomposeFromOutput_ActorOverride(t *testing.T) {
+	store := newStore(t)
+	epic := mustEpic(t, store, "Epic")
+	res, err := DecomposeFromOutput(store, epic, "1. [T1] task", Options{Actor: "quality"})
+	if err != nil {
+		t.Fatalf("DecomposeFromOutput: %v", err)
+	}
+	if res.Children[0].Actor != "quality" {
+		t.Errorf("actor = %q, want quality (override)", res.Children[0].Actor)
+	}
+}
+
+func TestDecomposeFromOutput_ChildPriorityOverride(t *testing.T) {
+	store := newStore(t)
+	epic := mustEpic(t, store, "Epic")
+	pri := beads.PriorityCritical
+	res, err := DecomposeFromOutput(store, epic, "1. [T1] task", Options{ChildPriority: &pri})
+	if err != nil {
+		t.Fatalf("DecomposeFromOutput: %v", err)
+	}
+	if res.Children[0].Priority != beads.PriorityCritical {
+		t.Errorf("priority = %d, want critical", res.Children[0].Priority)
+	}
+}
+
+func TestDecomposeFromOutput_InheritsEpicPriority(t *testing.T) {
+	store := newStore(t)
+	epic := mustEpic(t, store, "Epic") // created with PriorityHigh
+	res, err := DecomposeFromOutput(store, epic, "1. [T1] task", Options{})
+	if err != nil {
+		t.Fatalf("DecomposeFromOutput: %v", err)
+	}
+	if res.Children[0].Priority != beads.PriorityHigh {
+		t.Errorf("priority = %d, want inherited High", res.Children[0].Priority)
+	}
+}
+
+func TestDecomposeFromOutput_OutOfRangePriorityDefaults(t *testing.T) {
+	store := newStore(t)
+	epic := mustEpic(t, store, "Epic")
+	// Force an out-of-range priority on the epic to exercise the default clamp.
+	if err := store.Update(epic.ID, func(b *beads.Bead) { b.Priority = beads.Priority(99) }); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	epic = mustGet(t, store, epic.ID)
+	res, err := DecomposeFromOutput(store, epic, "1. [T1] task", Options{})
+	if err != nil {
+		t.Fatalf("DecomposeFromOutput: %v", err)
+	}
+	if res.Children[0].Priority != defaultChildPriority {
+		t.Errorf("priority = %d, want default %d", res.Children[0].Priority, defaultChildPriority)
+	}
+}
+
+func TestDeriveActor_ClassifierRoutesArchitect(t *testing.T) {
+	store := newStore(t)
+	// "refactor" routes to the architect lane via the classifier.
+	epic := mustEpic(t, store, "Large refactor of the scheduler")
+	res, err := DecomposeFromOutput(store, epic, "1. [T1] task", Options{})
+	if err != nil {
+		t.Fatalf("DecomposeFromOutput: %v", err)
+	}
+	if res.Children[0].Actor != string(classify.LaneArchitect) {
+		t.Errorf("actor = %q, want architect", res.Children[0].Actor)
+	}
+}
+
+func TestDeriveActor_FallsBackToArchitect(t *testing.T) {
+	// A title with no lane keywords classifies to the default (scanner) lane,
+	// so deriveActor falls back to the architect planner role.
+	epic := &beads.Bead{ID: "x", Title: "plain unremarkable title", Type: beads.TypeEpic}
+	if got := deriveActor(epic); got != architectActor {
+		t.Errorf("deriveActor = %q, want architect fallback", got)
+	}
+}
+
+func TestDeriveActor_UsesLabelsMetadata(t *testing.T) {
+	epic := &beads.Bead{
+		ID:    "x",
+		Title: "unremarkable",
+		Type:  beads.TypeEpic,
+		Metadata: map[string]interface{}{
+			"labels": "outreach, community",
+		},
+	}
+	if got := deriveActor(epic); got != string(classify.LaneOutreach) {
+		t.Errorf("deriveActor = %q, want outreach (from labels)", got)
+	}
+}
+
+func TestEpicLabels(t *testing.T) {
+	tests := []struct {
+		name string
+		meta map[string]interface{}
+		want []string
+	}{
+		{"none", nil, nil},
+		{"empty string", map[string]interface{}{"labels": "  "}, nil},
+		{"csv", map[string]interface{}{"labels": "a, b ,,c"}, []string{"a", "b", "c"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			epic := &beads.Bead{Metadata: tt.meta}
+			got := epicLabels(epic)
+			if len(got) != len(tt.want) {
+				t.Fatalf("epicLabels = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("epicLabels[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBuildPrompt(t *testing.T) {
+	epic := &beads.Bead{
+		ID:    "e1",
+		Title: "Ship the reporting pipeline",
+		Type:  beads.TypeEpic,
+		Notes: "Must handle 1M events/day.",
+	}
+	p := BuildPrompt(epic)
+	for _, want := range []string{
+		"[agent:architect]",
+		"Ship the reporting pipeline",
+		"Must handle 1M events/day.",
+		"agent_suitable",
+		"human_required",
+		"depends:",
+	} {
+		if !strings.Contains(p, want) {
+			t.Errorf("prompt missing %q\n---\n%s", want, p)
+		}
+	}
+}
+
+func TestBuildPrompt_BodyFromMetadata(t *testing.T) {
+	epic := &beads.Bead{
+		ID:    "e1",
+		Title: "Epic",
+		Type:  beads.TypeEpic,
+		Metadata: map[string]interface{}{
+			"description": "described in metadata",
+		},
+	}
+	if !strings.Contains(BuildPrompt(epic), "described in metadata") {
+		t.Error("prompt should include description metadata as body")
+	}
+}
+
+func TestBuildPrompt_NoBody(t *testing.T) {
+	epic := &beads.Bead{ID: "e1", Title: "Epic", Type: beads.TypeEpic}
+	p := BuildPrompt(epic)
+	if strings.Contains(p, "DETAILS:") {
+		t.Error("prompt should omit DETAILS when there is no body")
+	}
+}
+
+func TestEpicBody_Precedence(t *testing.T) {
+	// Notes wins over metadata.
+	epic := &beads.Bead{
+		Notes:    "from notes",
+		Metadata: map[string]interface{}{"body": "from body"},
+	}
+	if got := epicBody(epic); got != "from notes" {
+		t.Errorf("epicBody = %q, want notes precedence", got)
+	}
+	// body metadata wins over description.
+	epic2 := &beads.Bead{Metadata: map[string]interface{}{"body": "b", "description": "d"}}
+	if got := epicBody(epic2); got != "b" {
+		t.Errorf("epicBody = %q, want body", got)
+	}
+	// nothing -> empty.
+	if got := epicBody(&beads.Bead{}); got != "" {
+		t.Errorf("epicBody = %q, want empty", got)
+	}
+}
+
+func TestDecompose_WithPlanner(t *testing.T) {
+	store := newStore(t)
+	epic := mustEpic(t, store, "Epic")
+
+	var gotPrompt string
+	planner := func(_ context.Context, prompt string) (string, error) {
+		gotPrompt = prompt
+		return samplePlan, nil
+	}
+	res, err := Decompose(context.Background(), store, epic, planner, Options{})
+	if err != nil {
+		t.Fatalf("Decompose: %v", err)
+	}
+	if len(res.Children) != 4 {
+		t.Fatalf("want 4 children, got %d", len(res.Children))
+	}
+	if !strings.Contains(gotPrompt, "[agent:architect]") {
+		t.Error("planner was not given the architect prompt")
+	}
+}
+
+func TestDecompose_NilPlanner(t *testing.T) {
+	store := newStore(t)
+	epic := mustEpic(t, store, "Epic")
+	if _, err := Decompose(context.Background(), store, epic, nil, Options{}); err == nil {
+		t.Fatal("want error for nil planner")
+	}
+}
+
+func TestDecompose_PlannerError(t *testing.T) {
+	store := newStore(t)
+	epic := mustEpic(t, store, "Epic")
+	boom := errors.New("boom")
+	planner := func(_ context.Context, _ string) (string, error) { return "", boom }
+	_, err := Decompose(context.Background(), store, epic, planner, Options{})
+	if err == nil || !errors.Is(err, boom) {
+		t.Fatalf("want wrapped planner error, got %v", err)
+	}
+}
+
+func TestDecompose_ValidatesEpicBeforePlanner(t *testing.T) {
+	store := newStore(t)
+	task, _ := store.Create("task", beads.TypeTask, beads.PriorityMedium, "scanner", "")
+	called := false
+	planner := func(_ context.Context, _ string) (string, error) { called = true; return samplePlan, nil }
+	if _, err := Decompose(context.Background(), store, task, planner, Options{}); err == nil {
+		t.Fatal("want error for non-epic")
+	}
+	if called {
+		t.Error("planner must not be called when epic is invalid")
+	}
+}
+
+func TestDecompose_HonorsContextCancellation(t *testing.T) {
+	store := newStore(t)
+	epic := mustEpic(t, store, "Epic")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	planner := func(ctx context.Context, _ string) (string, error) {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		return samplePlan, nil
+	}
+	if _, err := Decompose(ctx, store, epic, planner, Options{}); err == nil {
+		t.Fatal("want context-cancelled error")
+	}
+}
+
+// TestDecomposeFromOutput_CreateChildError exercises the child-bead persistence
+// error path by making the store directory read-only after the epic exists, so
+// the first child create's WriteFile fails. Skipped when running as root (root
+// bypasses filesystem permission checks).
+func TestDecomposeFromOutput_CreateChildError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; filesystem permission enforcement is bypassed")
+	}
+	dir := t.TempDir()
+	store, err := beads.NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	epic := mustEpic(t, store, "Epic")
+
+	if err := os.Chmod(dir, 0500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	// Restore permissions so t.TempDir cleanup can remove the directory.
+	t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+
+	if _, err := DecomposeFromOutput(store, epic, "1. [T1] task", Options{}); err == nil {
+		t.Fatal("want persistence error when store dir is read-only")
+	} else if !strings.Contains(err.Error(), "creating child bead") {
+		t.Errorf("error = %v, want creating-child-bead wrap", err)
+	}
+}
+
+// ---- helpers ----
+
+func mustGet(t *testing.T, store *beads.Store, id string) *beads.Bead {
+	t.Helper()
+	b, err := store.Get(id)
+	if err != nil {
+		t.Fatalf("get %s: %v", id, err)
+	}
+	return b
+}
+
+func assertDeps(t *testing.T, store *beads.Store, id string, want []string) {
+	t.Helper()
+	b := mustGet(t, store, id)
+	if len(b.DependsOn) != len(want) {
+		t.Fatalf("%s deps = %v, want %v", id, b.DependsOn, want)
+	}
+	set := make(map[string]bool, len(b.DependsOn))
+	for _, d := range b.DependsOn {
+		set[d] = true
+	}
+	for _, w := range want {
+		if !set[w] {
+			t.Errorf("%s missing dep %s (have %v)", id, w, b.DependsOn)
+		}
+	}
+}


### PR DESCRIPTION
## Planning intelligence — Phase 1: epic → bead-DAG decomposition (architect lane)

This is **Phase 1** of the planning-intelligence feature: given an explicit
`TypeEpic` bead, produce a DAG of child task beads by having the **architect**
lane break the goal into ordered, dependency-annotated sub-tasks. **Manual
trigger only** — no governor, eval-loop, or agent-launch changes.

### Design

- **Trigger:** only `beads.TypeEpic` beads may be decomposed; invocation is manual.
- **Planner role:** reuses the existing **architect** lane. `BuildPrompt` emits
  an `[agent:architect]` kick-message asking for an ordered, `[Tn]`-tagged task
  list with `(depends: ...)` clauses and `[agent_suitable]`/`[human_required]`
  execution tags — no new role, no `brainstorm` overload.
- **Reuse, don't rebuild:** inception's structured-output parsers were **lifted**
  into a new shared, importable `pkg/agentparse` package as generic list-parsers
  emitting generic `Item`s:
  - `ParseTable` ← `parseQuestionTable`
  - `ParseNumberedList` ← `parseNumberedQuestions`
  - `TitleFromBdCreate` / `IsTemplatePlaceholder` ← `parseQuestionFromBdCreate` core
  - **new** `ParseTaskList` — ordered sub-tasks with ids/deps/execution tags
  - `SplitLines` helper

  Inception's parsers are now **thin, behavior-preserving adapters** over the
  shared package. **Pin-tests were added first** (commit 1) to lock the exact
  current behavior of all four functions, then the lift was performed and the
  pin-tests re-run green — Level-1 ideation parsing is unchanged.
- **`pkg/planning`:**
  - `Decompose(ctx, store, epic, planner, opts)` — builds the prompt, invokes an
    injected `PlannerFunc`, then materializes beads.
  - `DecomposeFromOutput(store, epic, output, opts)` — the unit-testable core:
    parses the plan, `beads.Create`s one child per task, links them via
    `AddDependency` (resolving local `[Tn]` refs; unknown/self refs skipped),
    and tags each child `parent_epic` + `execution` (+ `plan_ref`). Child
    actor/lane comes from the classifier (falling back to the architect lane).
  - Phase 1 keeps the planner output **injected** (func/string) — no live
    tmux/agent launch — so the whole package is deterministic and unit-testable.
- **Readiness gate (metadata only):** on success the epic is tagged
  `plan_status=draft`. The actual `Ready()` filtering of draft-epic children is
  **Phase 2** — a `TODO(planning phase 2)` marks the convention.
- **Manual entry point:** a `bd decompose <epic-id> [--plan <file>] [--actor <lane>]`
  subcommand (plan read from `--plan`/stdin; `--print-prompt` previews the
  architect prompt).

### Quality gates

- **Coverage:** `pkg/planning` **94.9%**, `pkg/agentparse` **98.4%** (both ≥90%
  gate). Remaining uncovered lines are genuinely-unreachable defensive I/O-error
  and regex guards, each documented inline; the representative persistence-error
  path is covered via a read-only-store-dir fault-injection test.
- **`-race` clean (0 data races):** `go test ./pkg/planning/... ./pkg/dashboard/ ./pkg/knowledge/ -race -count=1 -timeout 300s` passes. Any goroutine seam (`PlannerFunc`) takes a `context.Context`; no uncancellable loops added.
- `go vet` clean; `gofmt` clean on all touched files; full `go build ./...` passes.

### Scope / deferred

- **Deferred to Phase 2:** `Ready()` filtering that hides children of a
  `plan_status=draft` epic; a plan-approval transition; dashboard panel.
- **Deferred to Phase 3:** governor/eval-loop wiring and live architect-agent
  launch to replace the injected planner output.

Only existing-file edits are the behavior-preserving parser lift + re-point
(covered by the pin-tests) and the `bd` subcommand registration; everything else
is new code + tests.
