### PR TITLE
🐛 fix(dashboard): persist model + CLI pin from the agent config dialog

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -2266,6 +2266,25 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 			agentCfg.CLIPinned = b
 		}
 	}
+	// model / cliPinValue: the dialog's Model and CLI-Pin selects. These were
+	// historically dropped here (the handler only read a fixed allowlist), so
+	// changes made in the config dialog silently never persisted. Track whether
+	// they changed so we can apply them live after the config write, the same
+	// way the card dropdowns do (SetModelOverride + restart) — otherwise a stale
+	// live override would mask the freshly-saved value and it still wouldn't stick.
+	modelChanged, backendChanged := false, false
+	if v, ok := body["model"]; ok {
+		if str, ok := v.(string); ok {
+			agentCfg.Model = sanitizeString(str)
+			modelChanged = true
+		}
+	}
+	if v, ok := body["cliPinValue"]; ok {
+		if str, ok := v.(string); ok && str != "" {
+			agentCfg.Backend = sanitizeString(str)
+			backendChanged = true
+		}
+	}
 	if v, ok := body["emoji"]; ok {
 		if s, ok := v.(string); ok {
 			agentCfg.Emoji = sanitizeString(s)
@@ -2432,6 +2451,26 @@ func (s *Server) handleAgentConfigGeneral(w http.ResponseWriter, r *http.Request
 			s.logger.Error("failed to persist agent overlay after update", "agent", name, "error", err)
 		}
 	}
+	// Apply model/backend live so the change takes effect immediately and isn't
+	// masked by a pre-existing override from a card dropdown. SetModelOverride
+	// with the saved value (or "" to clear back to the launch-command default)
+	// keeps the dialog and the card in sync; a single restart applies both.
+	if modelChanged {
+		if err := s.deps.AgentMgr.SetModelOverride(name, agentCfg.Model); err != nil {
+			s.logger.Warn("failed to apply model from config dialog", "agent", name, "error", err)
+		}
+	}
+	if backendChanged {
+		if err := s.deps.AgentMgr.SetBackendOverride(name, agentCfg.Backend); err != nil {
+			s.logger.Warn("failed to apply backend from config dialog", "agent", name, "error", err)
+		}
+	}
+	if modelChanged || backendChanged {
+		if err := s.deps.AgentMgr.Restart(s.deps.Ctx, name); err != nil {
+			s.logger.Warn("restart after config-dialog model/backend change failed", "agent", name, "error", err)
+		}
+	}
+
 	s.auditFromRequest(r, "config_agent_general", auditDetail("section", "general"), name)
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated", "agent": name})

--- a/v2/pkg/dashboard/api_agentcfg_coverage_test.go
+++ b/v2/pkg/dashboard/api_agentcfg_coverage_test.go
@@ -162,3 +162,40 @@ func TestCovACfg_Export(t *testing.T) {
 		t.Fatalf("export ghost: %d", rec.Code)
 	}
 }
+
+// TestCovACfg_General_ModelPersists guards the fix for the config-dialog model
+// save bug: the general handler historically dropped the "model" and
+// "cliPinValue" keys, so a model chosen in the dialog silently never stuck.
+func TestCovACfg_General_ModelPersists(t *testing.T) {
+	s := acfgServer(t)
+	rec := doPut(s, "/api/config/agent/scanner/general", map[string]any{
+		"model":       "claude-opus-4-8",
+		"cliPinValue": "claude",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	cfg := s.deps.Config.Agents["scanner"]
+	if cfg.Model != "claude-opus-4-8" {
+		t.Errorf("model not persisted: got %q, want claude-opus-4-8", cfg.Model)
+	}
+	if cfg.Backend != "claude" {
+		t.Errorf("backend not persisted: got %q, want claude", cfg.Backend)
+	}
+	// Empty cliPinValue must NOT blank the backend (dialog sends "" when the
+	// pin toggle is off); model="" IS a valid clear-to-launch-default.
+	rec2 := doPut(s, "/api/config/agent/scanner/general", map[string]any{
+		"model":       "",
+		"cliPinValue": "",
+	})
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("clear: want 200, got %d", rec2.Code)
+	}
+	cfg2 := s.deps.Config.Agents["scanner"]
+	if cfg2.Model != "" {
+		t.Errorf("model should clear to launch default, got %q", cfg2.Model)
+	}
+	if cfg2.Backend != "claude" {
+		t.Errorf("empty cliPinValue must not blank backend, got %q", cfg2.Backend)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the reported bug where changing an agent's **model in the config dialog doesn't stick**, while changing it from the small agent cards does.

## Root cause (not what it looked like)

It's not a top-vs-bottom / `_configState.agent` bug — the dialog fails from **every** entry point. The general PUT handler (`handleAgentConfigGeneral`) copied a fixed allowlist of keys and **never read `model` or `cliPinValue`**, yet returned `200 {status:updated}` so the client toasted 'saved'. The GET *does* return `model`, so the dialog rendered the current value — an asymmetric API that masked the drop.

Users' 'works from the small cards' path is a **different control**: the inline `model ▾` dropdown on the cards → `POST /api/model/{agent}/{model}` (`handleModelSet`), which sets an override and restarts. Same ⚙ gear opens the dialog; the dialog's own Model select was the broken one.

## Fix

`handleAgentConfigGeneral` now:
- parses `model` (empty = clear to launch-command default) and `cliPinValue` (empty ignored, so toggling the pin off doesn't blank the backend) into the persisted agent config, and
- applies them live via `SetModelOverride`/`SetBackendOverride` + a single `Restart`, matching the card path so the change is immediate and isn't masked by a pre-existing override.

Also fixes the previously-silent `cliPinValue` drop (secondary issue in the same handler).

## Test plan
- Go: new `TestCovACfg_General_ModelPersists` (model + backend persist; empty cliPinValue doesn't blank backend; empty model clears)
- UI: change model in the dialog from the top-nav gear → save → reopen shows the new model, agent restarts on it

🤖 Generated with [Claude Code](https://claude.com/claude-code)