### PR TITLE
✨ feat(cost): always estimate spend — tier fallback pricing, no more $0 windows

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3827,18 +3827,37 @@
         buckets.push({ start, end, spend: 0, hasData: false });
       }
       if (hist.length < 2) return buckets;
-      // For each bucket, spend = usd at last snapshot in bucket − usd at last
-      // snapshot before bucket start (the cumulative baseline entering the bucket).
-      const at = (t) => costValueAt(hist, t, e => e.usd);
+      // Per-bucket spend = cumulative-$ at the last snapshot in the bucket minus
+      // the last snapshot before it. We estimate — exactness isn't the goal —
+      // and prefer the SUM OF PER-MODEL $ deltas over the single total-$ delta:
+      // the per-model figures capture activity the coarse rounded total can drop
+      // to ~0 at short (hourly) windows, and cover models added mid-window.
+      const totalAt = (t) => costValueAt(hist, t, e => e.usd);
+      // Sum of per-model cumulative $ at-or-before t (models present at that
+      // snapshot). null only if NO snapshot carries a models map up to t.
+      const modelSumAt = (t) => {
+        let sum = null;
+        for (const e of hist) {
+          if (e.timestamp > t) break;
+          if (e.models) {
+            let s = 0;
+            for (const k in e.models) { const u = e.models[k] && e.models[k].usd; if (typeof u === 'number') s += u; }
+            sum = s;
+          }
+        }
+        return sum;
+      };
+      const firstModelSum = () => { for (const e of hist) { if (e.models) { let s = 0; for (const k in e.models) { const u = e.models[k] && e.models[k].usd; if (typeof u === 'number') s += u; } return s; } } return null; };
       for (const b of buckets) {
-        const before = at(b.start);
-        const end = at(b.end);
+        // Try per-model deltas first, fall back to the total-$ delta.
+        let before = modelSumAt(b.start), end = modelSumAt(b.end), baseline = firstModelSum();
+        if (end == null) { before = totalAt(b.start); end = totalAt(b.end); baseline = hist[0].usd; }
         if (before != null && end != null) {
           b.spend = Math.max(0, end - before);
           b.hasData = true;
         } else if (end != null && before == null && hist[0].timestamp <= b.end) {
-          // History begins inside this bucket — spend since first snapshot.
-          b.spend = Math.max(0, end - hist[0].usd);
+          // History begins inside this bucket — spend since the first snapshot.
+          b.spend = Math.max(0, end - (baseline ?? 0));
           b.hasData = true;
         }
       }
@@ -5899,11 +5918,13 @@ function burnAreaChart() {
         </div>`;
       }).join('');
 
-      // Per-model estimated cost table. Unpriced models render "—".
+      // Per-model estimated cost table. Every model shows a $ estimate now —
+      // exact list price where known, a coarse tier estimate (~) otherwise.
       const models = (est.by_model || []).slice().sort((a, b) => b.usd - a.usd);
       const modelRows = models.map(m => {
-        const usdCell = m.source === 'unpriced'
-          ? `<span title="no list price known for this model">—</span>`
+        const approx = m.source === 'unpriced';
+        const usdCell = approx
+          ? `<span title="tier estimate — no exact list price for this model">~${fmtUSD(m.usd)}</span>`
           : fmtUSD(m.usd);
         return `<tr>
           <td class="cmodel">${esc(m.name || 'unknown')}</td>
@@ -5914,12 +5935,12 @@ function burnAreaChart() {
       }).join('');
 
       const unpricedNote = (est.unpriced_models && est.unpriced_models.length)
-        ? `<div class="cost-disclaimer">Not priced (excluded from estimated total): ${est.unpriced_models.map(esc).join(', ')}. Estimated total is a lower bound.</div>`
+        ? `<div class="cost-disclaimer">Tier-estimated (no exact list price, marked ~ and included in the total): ${est.unpriced_models.map(esc).join(', ')}.</div>`
         : '';
 
       el.innerHTML = `<div class="cost-panel">
         <div class="cost-title">Cost <span class="cost-badge est" title="Estimated from token counts × list prices; subscription/self-hosted billing may differ">est.</span></div>
-        <div class="cost-subtitle">List prices as of ${esc(cost.price_table_date || '')}. Metered gateways (OpenRouter, LiteLLM) show ACTUAL spend; everything else is ESTIMATED.</div>
+        <div class="cost-subtitle">Estimated from token counts × list prices (as of ${esc(cost.price_table_date || '')}); models without an exact price use a coarse tier estimate (~). Where a metered gateway reports actual spend it refines the estimate, but the figure is always an estimate.</div>
         <div class="cost-grid">
           <div class="cost-stat"><div class="cval">${fmtUSD(est.total_usd)}<span class="cost-badge est">est.</span></div><div class="clabel">estimated total — all-time cumulative (token × list price)</div>${costSparkSvg()}</div>
         </div>

--- a/v2/pkg/tokens/pricing.go
+++ b/v2/pkg/tokens/pricing.go
@@ -158,20 +158,55 @@ func LookupPrice(model string) (ModelPrice, bool) {
 	return p, ok
 }
 
-// EstimateCostUSD computes the estimated dollar cost for the given token counts
-// at the model's list price. priced is false when the model is not in the price
-// table (unknown model) — in that case usd is 0 and the UI should render "—"
-// rather than "$0.00" so an unknown model is never mistaken for a free one.
-func EstimateCostUSD(model string, inputTok, outputTok, cacheReadTok, cacheWriteTok int64) (usd float64, priced bool) {
+// Tier fallback prices (USD per MTok). Deliberately coarse — used only when a
+// model is not in the exact table, so the cost estimate reflects activity
+// instead of showing $0. The heuristic follows the obvious ordering: smaller /
+// older / lighter models cost less than bigger / newer / flagship ones.
+var (
+	tierCheap = ModelPrice{InputPerMTok: 0.25, OutputPerMTok: 2.00, CacheReadPerMTok: 0.025, CacheWritePerMTok: 0.25}  // mini / flash / haiku / lite
+	tierMid   = ModelPrice{InputPerMTok: 1.25, OutputPerMTok: 10.00, CacheReadPerMTok: 0.125, CacheWritePerMTok: 1.25} // gpt-5.x / sonnet / codex class
+	tierBig   = ModelPrice{InputPerMTok: 5.00, OutputPerMTok: 25.00, CacheReadPerMTok: 0.50, CacheWritePerMTok: 6.25}  // opus / pro / fable / flagship
+)
+
+// FallbackPrice returns a tier-based estimate for a model absent from the exact
+// table, plus false to signal it's a fallback (callers may still flag the row
+// as approximate). It never returns a zero price, so no active model shows $0.
+func FallbackPrice(model string) (ModelPrice, bool) {
+	id := normalizeModelID(model)
+	switch {
+	case id == "":
+		return tierMid, false
+	case strings.Contains(id, "mini") || strings.Contains(id, "flash") ||
+		strings.Contains(id, "haiku") || strings.Contains(id, "lite") ||
+		strings.Contains(id, "small") || strings.Contains(id, "nano"):
+		return tierCheap, false
+	case strings.Contains(id, "opus") || strings.Contains(id, "-pro") ||
+		strings.Contains(id, "fable") || strings.Contains(id, "ultra") ||
+		strings.Contains(id, "-max"):
+		return tierBig, false
+	default:
+		// Unknown mid-size (most GPT-5.x/codex/sonnet-class ids land here).
+		return tierMid, false
+	}
+}
+
+// EstimateCostUSD computes the estimated dollar cost for the given token counts.
+// It ALWAYS returns a dollar estimate: exact list price when the model is in the
+// table, otherwise a coarse tier fallback (see FallbackPrice) so an active model
+// never contributes $0 to the total. The `exact` return reports which was used —
+// true = exact list price, false = tier estimate — so the UI can mark a row as
+// approximate, but the number is real either way. (This whole card is an
+// estimate; we do not depend on unavailable "actual" gateway spend.)
+func EstimateCostUSD(model string, inputTok, outputTok, cacheReadTok, cacheWriteTok int64) (usd float64, exact bool) {
 	p, ok := LookupPrice(model)
 	if !ok {
-		return 0, false
+		p, _ = FallbackPrice(model)
 	}
 	usd = float64(inputTok)/tokensPerMillion*p.InputPerMTok +
 		float64(outputTok)/tokensPerMillion*p.OutputPerMTok +
 		float64(cacheReadTok)/tokensPerMillion*p.CacheReadPerMTok +
 		float64(cacheWriteTok)/tokensPerMillion*p.CacheWritePerMTok
-	return usd, true
+	return usd, ok
 }
 
 // ModelCost is the estimated dollar cost for one model or agent, plus whether
@@ -227,18 +262,20 @@ func EstimateFromSummary(agg *AggregateSummary) EstimatedCost {
 		if b == nil {
 			continue
 		}
-		usd, priced := EstimateCostUSD(model, b.Input, b.Output, b.CacheRead, b.CacheCreate)
+		usd, exact := EstimateCostUSD(model, b.Input, b.Output, b.CacheRead, b.CacheCreate)
 		out.ByModel[model] = ModelCost{
 			USD:         usd,
-			Priced:      priced,
+			Priced:      exact,
 			Input:       b.Input,
 			Output:      b.Output,
 			CacheRead:   b.CacheRead,
 			CacheCreate: b.CacheCreate,
 		}
-		if priced {
-			out.TotalUSD += usd
-		} else if model != "" && !unpricedSeen[model] {
+		// Every model contributes to the total now — exact where we have a list
+		// price, tier estimate otherwise. UnpricedModels lists the estimated
+		// ones so the UI can mark them ~approximate (not exclude them).
+		out.TotalUSD += usd
+		if !exact && model != "" && !unpricedSeen[model] {
 			unpricedSeen[model] = true
 			out.UnpricedModels = append(out.UnpricedModels, model)
 		}
@@ -254,10 +291,10 @@ func EstimateFromSummary(agg *AggregateSummary) EstimatedCost {
 			continue
 		}
 		model := agentModel[agent]
-		usd, priced := EstimateCostUSD(model, b.Input, b.Output, b.CacheRead, b.CacheCreate)
+		usd, exact := EstimateCostUSD(model, b.Input, b.Output, b.CacheRead, b.CacheCreate)
 		out.ByAgent[agent] = ModelCost{
 			USD:         usd,
-			Priced:      priced,
+			Priced:      exact,
 			Input:       b.Input,
 			Output:      b.Output,
 			CacheRead:   b.CacheRead,

--- a/v2/pkg/tokens/pricing_test.go
+++ b/v2/pkg/tokens/pricing_test.go
@@ -28,12 +28,28 @@ func TestEstimateCostUSD_KnownModel(t *testing.T) {
 }
 
 func TestEstimateCostUSD_UnknownModel(t *testing.T) {
-	usd, priced := EstimateCostUSD("some-unknown-model-9000", 1_000_000, 1_000_000, 0, 0)
-	if priced {
-		t.Fatalf("expected unknown model to be unpriced")
+	// Unknown models are now tier-estimated, never $0: exact=false but usd>0.
+	usd, exact := EstimateCostUSD("some-unknown-model-9000", 1_000_000, 1_000_000, 0, 0)
+	if exact {
+		t.Fatalf("expected unknown model to be a tier estimate (exact=false)")
 	}
-	if usd != 0 {
-		t.Fatalf("expected $0 for unknown model, got $%.6f", usd)
+	if usd <= 0 {
+		t.Fatalf("expected a non-zero tier estimate for an unknown model, got $%.6f", usd)
+	}
+}
+
+// TestFallbackTierOrdering guards the "smaller/older cheaper, bigger/newer
+// pricier" heuristic: a mini/flash model must estimate cheaper than an
+// opus/flagship one for identical token counts.
+func TestFallbackTierOrdering(t *testing.T) {
+	cheap, _ := EstimateCostUSD("mystery-flash-mini", 1_000_000, 1_000_000, 0, 0)
+	big, _ := EstimateCostUSD("mystery-opus-max", 1_000_000, 1_000_000, 0, 0)
+	mid, _ := EstimateCostUSD("mystery-model-x", 1_000_000, 1_000_000, 0, 0)
+	if !(cheap < mid && mid < big) {
+		t.Fatalf("tier ordering broken: cheap=%.4f mid=%.4f big=%.4f (want cheap<mid<big)", cheap, mid, big)
+	}
+	if cheap <= 0 {
+		t.Fatalf("cheap tier must still be non-zero, got %.6f", cheap)
 	}
 }
 
@@ -99,19 +115,22 @@ func TestEstimateFromSummary(t *testing.T) {
 
 	est := EstimateFromSummary(agg)
 
-	// Only the priced model contributes: opus-4-8 1M+1M = $30.
-	if !approxEqual(est.TotalUSD, 30.0) {
-		t.Fatalf("expected total $30.00, got $%.6f", est.TotalUSD)
+	// Both models contribute now: opus-4-8 1M+1M = $30 (exact) plus
+	// mystery-model 1M+1M at the mid tier ($1.25 in + $10 out = $11.25).
+	if !approxEqual(est.TotalUSD, 41.25) {
+		t.Fatalf("expected total $41.25 (exact + tier estimate), got $%.6f", est.TotalUSD)
 	}
 
 	if mc := est.ByModel["claude-opus-4-8"]; !mc.Priced || !approxEqual(mc.USD, 30.0) {
 		t.Fatalf("claude-opus-4-8 model cost wrong: %+v", mc)
 	}
-	if mc := est.ByModel["mystery-model"]; mc.Priced || mc.USD != 0 {
-		t.Fatalf("mystery-model should be unpriced with $0, got %+v", mc)
+	// mystery-model: tier-estimated (Priced=false) but non-zero and included.
+	if mc := est.ByModel["mystery-model"]; mc.Priced || !approxEqual(mc.USD, 11.25) {
+		t.Fatalf("mystery-model should be tier-estimated ~$11.25, got %+v", mc)
 	}
 
-	// Unpriced list must contain the mystery model.
+	// UnpricedModels now means "tier-estimated" (still surfaced so the UI can
+	// mark it ~approximate), not "excluded".
 	foundUnpriced := false
 	for _, m := range est.UnpricedModels {
 		if m == "mystery-model" {
@@ -119,7 +138,7 @@ func TestEstimateFromSummary(t *testing.T) {
 		}
 	}
 	if !foundUnpriced {
-		t.Fatalf("expected mystery-model in UnpricedModels, got %v", est.UnpricedModels)
+		t.Fatalf("expected mystery-model in UnpricedModels (tier-estimated list), got %v", est.UnpricedModels)
 	}
 
 	// Per-agent: scanner used opus-4-8 (1M input) -> $5.


### PR DESCRIPTION
## Summary

Addresses two related asks: (1) *switch to estimated spend for a time period; exactness isn't needed*, and (2) *use exact price where available but never gate on unavailable actual spend*.

### Problem
Models without an exact list-price entry (`gpt-5.3-codex`, `auto`) were priced at $0 **and excluded from the total** (footnote: 'lower bound'). Since auto-mode routes real traffic to those, the per-window spend rounded to **$0.00** and rows showed **—**.

### Fix
- **Tier fallback pricing** (`FallbackPrice`): any model missing from the exact table gets a coarse estimate by tier — cheaper for `mini/flash/haiku/lite/nano`, pricier for `opus/pro/fable/ultra/max`, mid otherwise (matches 'older/smaller cheaper, newer/bigger pricier'). `EstimateCostUSD` never returns $0 for active tokens.
- **Everything counts toward the total.** The bool return is renamed `priced`→`exact` (exact list price vs tier estimate); tier-estimated models are still listed so the UI marks them `~approximate`, but they're included, not excluded.
- **Window spend from per-model $ deltas.** `costBuckets` now sums per-model cumulative-$ deltas across the window (falling back to the coarse total delta), so hourly/short windows reflect activity instead of rounding to $0.
- **UI**: `~$X` for estimated rows (was `—`); note reads 'tier-estimated … included in the total'; subtitle reframed so the card is unambiguously an estimate.

## Test plan
- Go: unknown model → non-zero tier estimate (exact=false); `TestFallbackTierOrdering` (cheap<mid<big); `TestEstimateFromSummary` total now $41.25 (exact + tier)
- UI: gpt-5.3-codex/auto show `~$…`; hourly window shows non-zero spend once snapshots accrue

🤖 Generated with [Claude Code](https://claude.com/claude-code)