### PR TITLE
✨ planning: Phase 2 — plan-review gate + governor PLANNING metric

### DIFF
--- a/v2/cmd/bd/decompose.go
+++ b/v2/cmd/bd/decompose.go
@@ -33,6 +33,7 @@ func cmdDecompose(args []string) {
 	fs := flag.NewFlagSet("decompose", flag.ExitOnError)
 	planFile := fs.String("plan", "", "File containing the planner's task list (default: stdin)")
 	actor := fs.String("actor", "", "Override child bead actor/lane (default: classifier/architect)")
+	autoApprove := fs.Bool("auto-approve", false, "Approve the plan immediately (children claimable now, no review gate)")
 	printPrompt := fs.Bool("print-prompt", false, "Print the architect decomposition prompt for this epic and exit")
 	_ = fs.Parse(args[1:])
 
@@ -58,17 +59,21 @@ func cmdDecompose(args []string) {
 	// still built (and could be printed for the operator) but no agent runs.
 	planner := func(_ context.Context, _ string) (string, error) { return output, nil }
 
-	result, err := planning.Decompose(context.Background(), store, epic, planner, planning.Options{Actor: *actor})
+	result, err := planning.Decompose(context.Background(), store, epic, planner, planning.Options{Actor: *actor, AutoApprove: *autoApprove})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "bd decompose: %v\n", err)
 		os.Exit(1)
 	}
 
+	planStatus := planning.PlanStatusDraft
+	if *autoApprove {
+		planStatus = planning.PlanStatusApproved
+	}
 	fmt.Printf("Decomposed epic %s into %d child bead(s):\n", epic.ID, len(result.Children))
 	for i, child := range result.Children {
 		fmt.Printf("  %s  [%s]  %s\n", child.ID, child.Meta(planning.MetaExecution), result.Tasks[i].Title)
 	}
-	fmt.Printf("Epic %s marked plan_status=%s\n", epic.ID, planning.PlanStatusDraft)
+	fmt.Printf("Epic %s marked plan_status=%s\n", epic.ID, planStatus)
 }
 
 // readPlan returns the plan text from path, or from stdin when path is empty.

--- a/v2/pkg/beads/beads.go
+++ b/v2/pkg/beads/beads.go
@@ -269,13 +269,90 @@ func (s *Store) List(filter ListFilter) []*Bead {
 	return result
 }
 
+// Plan-review metadata keys. These mirror the convention written by
+// pkg/planning (planning.MetaParentEpic / planning.MetaPlanStatus /
+// planning.PlanStatusApproved); they are duplicated here as plain strings so
+// the low-level beads package can honor the plan-review gate WITHOUT importing
+// planning (which would create an import cycle: planning already imports beads).
+// Keep these values in sync with pkg/planning.
+const (
+	// metaParentEpic on a child bead holds the ID of the epic it decomposes.
+	// A bead without this key is a normal bead and is never gated.
+	metaParentEpic = "parent_epic"
+	// metaPlanStatus on an epic records its plan-review state.
+	metaPlanStatus = "plan_status"
+	// planStatusApproved is the only plan_status that releases an epic's
+	// children through Ready(). Any other value (e.g. "draft"), or the parent
+	// being missing, keeps the children hidden.
+	planStatusApproved = "approved"
+)
+
+// Ready returns the open beads a claimant may work on now, honoring the
+// plan-review gate (Phase 2 planning intelligence): a child bead of a
+// decomposed epic (one carrying a parent_epic metadata key) is EXCLUDED unless
+// that parent epic's plan_status metadata is "approved". Normal beads — those
+// with no parent_epic — are never affected by the gate.
+//
+// This is the readiness hook that feeds `bd ready` and governor claim
+// selection, so gating here transparently prevents an agent from claiming a
+// not-yet-reviewed plan's sub-tasks. Approval is a human action performed via
+// planning.ApprovePlan / the /api/plan/{epic}/approve endpoint.
 func (s *Store) Ready(actor string) []*Bead {
 	status := StatusOpen
 	filter := ListFilter{Status: &status}
 	if actor != "" {
 		filter.Actor = &actor
 	}
-	return s.List(filter)
+	candidates := s.List(filter)
+
+	// Resolve plan gating under a read lock so the parent lookups are
+	// consistent with the snapshot returned by List.
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := candidates[:0:0] // fresh slice, don't alias List's return
+	for _, b := range candidates {
+		if s.planGated(b) {
+			continue
+		}
+		result = append(result, b)
+	}
+	return result
+}
+
+// planGated reports whether bead b must be withheld from Ready() because it is a
+// child of an epic whose plan has not been approved. It reads only string
+// metadata by convention (no planning import). A bead with no parent_epic key is
+// never gated. A child whose parent cannot be found is gated (fail-closed): the
+// plan record is incomplete, so the child is not yet safe to claim.
+//
+// Caller must hold s.mu (at least RLock).
+func (s *Store) planGated(b *Bead) bool {
+	parentID := metaString(b, metaParentEpic)
+	if parentID == "" {
+		return false // normal bead, not a decomposed child
+	}
+	parent, ok := s.beads[parentID]
+	if !ok {
+		return true // fail-closed: parent epic missing
+	}
+	return metaString(parent, metaPlanStatus) != planStatusApproved
+}
+
+// metaString reads a string metadata value from a bead without locking. It
+// mirrors Bead.Meta but is used internally where the store lock is already held
+// and where only genuine string values should count (a non-string value is
+// treated as absent for gating purposes).
+func metaString(b *Bead, key string) string {
+	if b == nil || b.Metadata == nil {
+		return ""
+	}
+	if v, ok := b.Metadata[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
 }
 
 func (s *Store) FindByExternalRef(ref string) *Bead {

--- a/v2/pkg/beads/beads_plangate_test.go
+++ b/v2/pkg/beads/beads_plangate_test.go
@@ -1,0 +1,157 @@
+package beads
+
+import "testing"
+
+// setPlanMeta is a test helper mirroring the pkg/planning metadata convention
+// without importing planning (which would be a cycle). The key strings match
+// planning.MetaParentEpic / planning.MetaPlanStatus.
+func setPlanMeta(t *testing.T, s *Store, id, key, val string) {
+	t.Helper()
+	if err := s.SetMetadata(id, key, val); err != nil {
+		t.Fatalf("SetMetadata(%s,%s): %v", id, key, err)
+	}
+}
+
+// TestReady_PlanGate_DraftHidesChildren verifies a child of a draft epic is
+// withheld from Ready, while a child of an approved epic is released, and a
+// normal (parentless) bead is unaffected.
+func TestReady_PlanGate_DraftHidesChildren(t *testing.T) {
+	s, _ := NewStore(t.TempDir())
+
+	normal, _ := s.Create("normal", TypeTask, PriorityLow, "worker", "")
+
+	draftEpic, _ := s.Create("draft epic", TypeEpic, PriorityHigh, "architect", "")
+	setPlanMeta(t, s, draftEpic.ID, metaPlanStatus, "draft")
+	draftChild, _ := s.Create("draft child", TypeTask, PriorityLow, "worker", "")
+	setPlanMeta(t, s, draftChild.ID, metaParentEpic, draftEpic.ID)
+
+	approvedEpic, _ := s.Create("approved epic", TypeEpic, PriorityHigh, "architect", "")
+	setPlanMeta(t, s, approvedEpic.ID, metaPlanStatus, planStatusApproved)
+	approvedChild, _ := s.Create("approved child", TypeTask, PriorityLow, "worker", "")
+	setPlanMeta(t, s, approvedChild.ID, metaParentEpic, approvedEpic.ID)
+
+	ready := s.Ready("")
+	got := map[string]bool{}
+	for _, b := range ready {
+		got[b.ID] = true
+	}
+
+	if !got[normal.ID] {
+		t.Error("normal parentless bead should be ready")
+	}
+	if got[draftChild.ID] {
+		t.Error("child of draft epic must be withheld")
+	}
+	if !got[approvedChild.ID] {
+		t.Error("child of approved epic must be ready")
+	}
+	// The epics themselves are open beads with no parent_epic → not gated.
+	if !got[draftEpic.ID] || !got[approvedEpic.ID] {
+		t.Error("epic beads themselves should not be gated")
+	}
+}
+
+// TestReady_PlanGate_ApprovalReleases verifies flipping the epic's plan_status
+// from draft to approved releases the previously-hidden child.
+func TestReady_PlanGate_ApprovalReleases(t *testing.T) {
+	s, _ := NewStore(t.TempDir())
+
+	epic, _ := s.Create("epic", TypeEpic, PriorityHigh, "architect", "")
+	setPlanMeta(t, s, epic.ID, metaPlanStatus, "draft")
+	child, _ := s.Create("child", TypeTask, PriorityLow, "worker", "")
+	setPlanMeta(t, s, child.ID, metaParentEpic, epic.ID)
+
+	if inReady(s.Ready(""), child.ID) {
+		t.Fatal("child should be gated while draft")
+	}
+
+	setPlanMeta(t, s, epic.ID, metaPlanStatus, planStatusApproved)
+	if !inReady(s.Ready(""), child.ID) {
+		t.Fatal("child should be released after approval")
+	}
+}
+
+// TestReady_PlanGate_MissingParentFailsClosed verifies a child pointing at a
+// non-existent epic is withheld (fail-closed).
+func TestReady_PlanGate_MissingParentFailsClosed(t *testing.T) {
+	s, _ := NewStore(t.TempDir())
+	child, _ := s.Create("orphan child", TypeTask, PriorityLow, "worker", "")
+	setPlanMeta(t, s, child.ID, metaParentEpic, "no-such-epic")
+
+	if inReady(s.Ready(""), child.ID) {
+		t.Fatal("child with missing parent must be withheld (fail-closed)")
+	}
+}
+
+// TestReady_PlanGate_ActorFilter verifies the gate composes with the actor
+// filter: an actor-scoped Ready still hides draft children.
+func TestReady_PlanGate_ActorFilter(t *testing.T) {
+	s, _ := NewStore(t.TempDir())
+
+	epic, _ := s.Create("epic", TypeEpic, PriorityHigh, "architect", "")
+	setPlanMeta(t, s, epic.ID, metaPlanStatus, "draft")
+	child, _ := s.Create("child", TypeTask, PriorityLow, "alice", "")
+	setPlanMeta(t, s, child.ID, metaParentEpic, epic.ID)
+	s.Create("alice normal", TypeTask, PriorityLow, "alice", "")
+
+	ready := s.Ready("alice")
+	if inReady(ready, child.ID) {
+		t.Error("draft child should be hidden even in actor-scoped Ready")
+	}
+	if len(ready) != 1 {
+		t.Errorf("expected only the normal alice bead, got %d", len(ready))
+	}
+}
+
+// TestReady_PlanGate_MalformedMetadata verifies a non-string plan_status is
+// treated as absent (not "approved"), so the child stays gated.
+func TestReady_PlanGate_MalformedMetadata(t *testing.T) {
+	s, _ := NewStore(t.TempDir())
+
+	epic, _ := s.Create("epic", TypeEpic, PriorityHigh, "architect", "")
+	// Inject a non-string metadata value directly.
+	if err := s.Update(epic.ID, func(b *Bead) {
+		if b.Metadata == nil {
+			b.Metadata = map[string]interface{}{}
+		}
+		b.Metadata[metaPlanStatus] = 42 // not a string
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	child, _ := s.Create("child", TypeTask, PriorityLow, "worker", "")
+	setPlanMeta(t, s, child.ID, metaParentEpic, epic.ID)
+
+	if inReady(s.Ready(""), child.ID) {
+		t.Fatal("child of epic with malformed plan_status must be gated")
+	}
+}
+
+// TestMetaString covers the internal metaString helper's branches.
+func TestMetaString(t *testing.T) {
+	if metaString(nil, "k") != "" {
+		t.Error("nil bead should return empty")
+	}
+	b := &Bead{}
+	if metaString(b, "k") != "" {
+		t.Error("nil metadata should return empty")
+	}
+	b.Metadata = map[string]interface{}{"s": "v", "n": 7}
+	if metaString(b, "s") != "v" {
+		t.Error("string value should be returned")
+	}
+	if metaString(b, "n") != "" {
+		t.Error("non-string value should return empty")
+	}
+	if metaString(b, "missing") != "" {
+		t.Error("missing key should return empty")
+	}
+}
+
+func inReady(beads []*Bead, id string) bool {
+	for _, b := range beads {
+		if b.ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/v2/pkg/config/acmm_packs.go
+++ b/v2/pkg/config/acmm_packs.go
@@ -52,6 +52,26 @@ type PackGovernor struct {
 	EvalIntervalS int                          `json:"evalIntervalS,omitempty" yaml:"eval_interval_s,omitempty"`
 	Cadences      map[string]map[string]string `json:"cadences,omitempty" yaml:"cadences,omitempty"`
 	Thresholds    map[string]int               `json:"thresholds,omitempty" yaml:"thresholds,omitempty"`
+	// PlanAutoApprove controls the Phase 2 plan-review gate for this maturity
+	// level. When false (default, low levels), a decomposed epic's plan stays
+	// plan_status=draft and its children are withheld from Ready() until a human
+	// approves it. When true (high-trust levels L5/L6), decomposition sets
+	// plan_status=approved immediately, releasing the children without a manual
+	// review step.
+	PlanAutoApprove bool `json:"planAutoApprove,omitempty" yaml:"plan_auto_approve,omitempty"`
+}
+
+// PlanAutoApproveForLevel reports whether the ACMM pack at the given level
+// enables automatic plan approval (plan_auto_approve). It is the single lookup
+// the decomposition path uses to decide whether a fresh plan is drafted (human
+// review required) or approved immediately. Unknown levels return false so the
+// safe default (require review) always wins.
+func PlanAutoApproveForLevel(level int) bool {
+	p, err := ACMMPackByLevel(level)
+	if err != nil {
+		return false
+	}
+	return p.Governor.PlanAutoApprove
 }
 
 // ACMMPacks returns the built-in ACMM level pack definitions loaded from

--- a/v2/pkg/config/acmm_packs_planapprove_test.go
+++ b/v2/pkg/config/acmm_packs_planapprove_test.go
@@ -1,0 +1,45 @@
+package config
+
+import "testing"
+
+// TestPlanAutoApproveForLevel checks the plan_auto_approve knob resolves from
+// the embedded pack YAML: true for high-trust levels (L5/L6), false for the
+// lower levels, and false for unknown levels.
+func TestPlanAutoApproveForLevel(t *testing.T) {
+	cases := []struct {
+		level int
+		want  bool
+	}{
+		{1, false},
+		{2, false},
+		{3, false},
+		{4, false},
+		{5, true},
+		{6, true},
+		{99, false}, // unknown level → safe default
+	}
+	for _, c := range cases {
+		if got := PlanAutoApproveForLevel(c.level); got != c.want {
+			t.Errorf("PlanAutoApproveForLevel(%d) = %v, want %v", c.level, got, c.want)
+		}
+	}
+}
+
+// TestPackGovernorPlanAutoApproveField verifies the field is parsed onto
+// PackGovernor for the levels that set it.
+func TestPackGovernorPlanAutoApproveField(t *testing.T) {
+	p5, err := ACMMPackByLevel(5)
+	if err != nil {
+		t.Fatalf("level 5: %v", err)
+	}
+	if !p5.Governor.PlanAutoApprove {
+		t.Error("level 5 pack should have plan_auto_approve=true")
+	}
+	p1, err := ACMMPackByLevel(1)
+	if err != nil {
+		t.Fatalf("level 1: %v", err)
+	}
+	if p1.Governor.PlanAutoApprove {
+		t.Error("level 1 pack should have plan_auto_approve=false")
+	}
+}

--- a/v2/pkg/config/packs/level-5.yaml
+++ b/v2/pkg/config/packs/level-5.yaml
@@ -8,6 +8,9 @@ description: 'Multi-loop feedback. Agents open issues AND pull requests. All age
   '
 governor:
   modes: SURGE, BUSY, QUIET, IDLE
+  # High-trust level: decomposed epic plans are approved automatically, so their
+  # child sub-tasks become claimable without a human plan-review step.
+  plan_auto_approve: true
   merge_policy: 'Hold-gated — all agent PRs get ''hold'' label. Human batch-approves.
 
     '

--- a/v2/pkg/config/packs/level-6.yaml
+++ b/v2/pkg/config/packs/level-6.yaml
@@ -8,6 +8,9 @@ description: 'Multi-loop with external orchestration. Agents open issues, create
   '
 governor:
   modes: SURGE, BUSY, QUIET, IDLE
+  # High-trust level: decomposed epic plans are approved automatically, so their
+  # child sub-tasks become claimable without a human plan-review step.
+  plan_auto_approve: true
   merge_policy: 'Auto-merge on green CI. No hold label.
 
     '

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -194,6 +194,12 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("PUT /api/inception/wiki-name", s.handleInceptionRenameWiki)
 	s.mux.HandleFunc("POST /api/inception/import", s.handleInceptionImport)
 
+	// Plan-review gate (Phase 2 planning intelligence). Mirrors /api/inception/*.
+	s.mux.HandleFunc("GET /api/plan/{epicID}", s.handlePlanTree)
+	s.mux.HandleFunc("POST /api/plan/{epicID}/approve", s.handlePlanApprove)
+	s.mux.HandleFunc("POST /api/plan/{epicID}/reject", s.handlePlanReject)
+	s.mux.HandleFunc("POST /api/plan/{epicID}/child/{childID}", s.handlePlanChild)
+
 	s.mux.HandleFunc("POST /api/chat", s.handleChat)
 
 	s.mux.HandleFunc("GET /api/nous/status", s.handleNousStatus)

--- a/v2/pkg/dashboard/plan_handlers.go
+++ b/v2/pkg/dashboard/plan_handlers.go
@@ -1,0 +1,128 @@
+package dashboard
+
+import (
+	"net/http"
+
+	"github.com/kubestellar/hive/v2/pkg/beads"
+	"github.com/kubestellar/hive/v2/pkg/planning"
+)
+
+// Plan-review dashboard endpoints (Phase 2 planning intelligence). They mirror
+// the /api/inception/* shape: thin HTTP handlers that delegate all logic to
+// pkg/planning. Beads live in per-agent stores, so each handler locates the
+// store that actually holds the target epic (findEpicStore) before acting.
+
+// findEpicStore returns the bead store that contains an epic bead with epicID,
+// or (nil, "") if no store holds it. Planning children live in the same store
+// as their epic (Decompose creates them there), so the located store is where
+// the whole plan lives.
+func (s *Server) findEpicStore(epicID string) (*beads.Store, string) {
+	if s.deps == nil || s.deps.BeadStores == nil {
+		return nil, ""
+	}
+	for name, store := range s.deps.BeadStores {
+		if b, err := store.Get(epicID); err == nil && b.Type == beads.TypeEpic {
+			return store, name
+		}
+	}
+	return nil, ""
+}
+
+// handlePlanTree serves GET /api/plan/{epicID}: the review view of a decomposed
+// epic (the epic + its children with execution tags and dependency edges).
+func (s *Server) handlePlanTree(w http.ResponseWriter, r *http.Request) {
+	epicID := r.PathValue("epicID")
+	store, _ := s.findEpicStore(epicID)
+	if store == nil {
+		jsonError(w, "epic not found in any bead store", http.StatusNotFound)
+		return
+	}
+	tree, err := planning.GetPlanTree(store, epicID)
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusNotFound)
+		return
+	}
+	jsonResponse(w, map[string]interface{}{"ok": true, "plan": tree})
+}
+
+// handlePlanApprove serves POST /api/plan/{epicID}/approve: approve the plan,
+// releasing its children through Ready().
+func (s *Server) handlePlanApprove(w http.ResponseWriter, r *http.Request) {
+	epicID := r.PathValue("epicID")
+	store, agentName := s.findEpicStore(epicID)
+	if store == nil {
+		jsonError(w, "epic not found in any bead store", http.StatusNotFound)
+		return
+	}
+	if err := planning.ApprovePlan(store, epicID); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.auditFromRequest(r, "plan_approve", auditDetail("epic", epicID), agentName)
+	s.refreshAndPersist()
+	tree, _ := planning.GetPlanTree(store, epicID)
+	jsonResponse(w, map[string]interface{}{"ok": true, "status": "approved", "plan": tree})
+}
+
+// handlePlanReject serves POST /api/plan/{epicID}/reject: return an approved (or
+// draft) plan to draft state, re-gating its children.
+func (s *Server) handlePlanReject(w http.ResponseWriter, r *http.Request) {
+	epicID := r.PathValue("epicID")
+	store, agentName := s.findEpicStore(epicID)
+	if store == nil {
+		jsonError(w, "epic not found in any bead store", http.StatusNotFound)
+		return
+	}
+	if err := planning.RejectPlan(store, epicID); err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.auditFromRequest(r, "plan_reject", auditDetail("epic", epicID), agentName)
+	s.refreshAndPersist()
+	tree, _ := planning.GetPlanTree(store, epicID)
+	jsonResponse(w, map[string]interface{}{"ok": true, "status": "draft", "plan": tree})
+}
+
+// handlePlanChild serves POST /api/plan/{epicID}/child/{childID}: edit a child
+// before approval. Body {"action":"retag","execution":"agent_suitable"} retags;
+// {"action":"remove"} removes (closes) the child.
+func (s *Server) handlePlanChild(w http.ResponseWriter, r *http.Request) {
+	epicID := r.PathValue("epicID")
+	childID := r.PathValue("childID")
+	store, agentName := s.findEpicStore(epicID)
+	if store == nil {
+		jsonError(w, "epic not found in any bead store", http.StatusNotFound)
+		return
+	}
+
+	var body struct {
+		Action    string `json:"action"`
+		Execution string `json:"execution"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	switch body.Action {
+	case "retag":
+		if err := planning.RetagChild(store, epicID, childID, sanitizeString(body.Execution)); err != nil {
+			jsonError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		s.auditFromRequest(r, "plan_child_retag", auditDetail("epic", epicID, "child", childID, "execution", body.Execution), agentName)
+	case "remove":
+		if err := planning.RemoveChild(store, epicID, childID); err != nil {
+			jsonError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		s.auditFromRequest(r, "plan_child_remove", auditDetail("epic", epicID, "child", childID), agentName)
+	default:
+		jsonError(w, "action must be 'retag' or 'remove'", http.StatusBadRequest)
+		return
+	}
+
+	s.refreshAndPersist()
+	tree, _ := planning.GetPlanTree(store, epicID)
+	jsonResponse(w, map[string]interface{}{"ok": true, "plan": tree})
+}

--- a/v2/pkg/dashboard/plan_handlers_test.go
+++ b/v2/pkg/dashboard/plan_handlers_test.go
@@ -1,0 +1,332 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/agentparse"
+	"github.com/kubestellar/hive/v2/pkg/beads"
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/planning"
+)
+
+// planServer builds a Server with a single "architect" bead store and an epic
+// decomposed into children. It returns the server, store, and epic.
+func planServer(t *testing.T) (*Server, *beads.Store, *beads.Bead) {
+	t.Helper()
+	store, err := beads.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	epic, err := store.Create("plan epic", beads.TypeEpic, beads.PriorityHigh, "architect", "")
+	if err != nil {
+		t.Fatalf("create epic: %v", err)
+	}
+	plan := "1. [T1] design [agent_suitable]\n2. [T2] review (depends: T1) [human_required]\n"
+	if _, err := planning.DecomposeFromOutput(store, epic, plan, planning.Options{}); err != nil {
+		t.Fatalf("decompose: %v", err)
+	}
+
+	srv := NewServer(0, slog.Default())
+	srv.deps = &Dependencies{
+		Config:     &config.Config{Agents: map[string]config.AgentConfig{}},
+		Logger:     slog.Default(),
+		Ctx:        context.Background(),
+		BeadStores: map[string]*beads.Store{"architect": store},
+	}
+	srv.RegisterAPI(srv.deps)
+	return srv, store, epic
+}
+
+func TestHandlePlanTree(t *testing.T) {
+	srv, _, epic := planServer(t)
+
+	req := httptest.NewRequest("GET", "/api/plan/"+epic.ID, nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		OK   bool              `json:"ok"`
+		Plan planning.PlanTree `json:"plan"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.OK || resp.Plan.EpicID != epic.ID || len(resp.Plan.Children) != 2 {
+		t.Fatalf("unexpected plan: %+v", resp.Plan)
+	}
+	if resp.Plan.PlanStatus != planning.PlanStatusDraft {
+		t.Fatalf("want draft, got %q", resp.Plan.PlanStatus)
+	}
+}
+
+func TestHandlePlanTree_NotFound(t *testing.T) {
+	srv, _, _ := planServer(t)
+	req := httptest.NewRequest("GET", "/api/plan/does-not-exist", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", w.Code)
+	}
+}
+
+func TestHandlePlanApprove(t *testing.T) {
+	srv, store, epic := planServer(t)
+
+	req := httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/approve", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	got, _ := store.Get(epic.ID)
+	if got.Meta(planning.MetaPlanStatus) != planning.PlanStatusApproved {
+		t.Fatalf("epic not approved: %q", got.Meta(planning.MetaPlanStatus))
+	}
+
+	// Double-approve → 400.
+	w2 := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w2, httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/approve", nil))
+	if w2.Code != http.StatusBadRequest {
+		t.Fatalf("double approve want 400, got %d", w2.Code)
+	}
+}
+
+func TestHandlePlanApprove_NotFound(t *testing.T) {
+	srv, _, _ := planServer(t)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, httptest.NewRequest("POST", "/api/plan/missing/approve", nil))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", w.Code)
+	}
+}
+
+func TestHandlePlanReject(t *testing.T) {
+	srv, store, epic := planServer(t)
+	if err := planning.ApprovePlan(store, epic.ID); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/reject", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	got, _ := store.Get(epic.ID)
+	if got.Meta(planning.MetaPlanStatus) != planning.PlanStatusDraft {
+		t.Fatalf("want draft after reject, got %q", got.Meta(planning.MetaPlanStatus))
+	}
+}
+
+func TestHandlePlanChild_Retag(t *testing.T) {
+	srv, store, epic := planServer(t)
+	children := store.List(beads.ListFilter{})
+	var child *beads.Bead
+	for _, b := range children {
+		if b.Meta(planning.MetaParentEpic) == epic.ID {
+			child = b
+			break
+		}
+	}
+	if child == nil {
+		t.Fatal("no child found")
+	}
+
+	body := strings.NewReader(`{"action":"retag","execution":"human_required"}`)
+	req := httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/child/"+child.ID, body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	got, _ := store.Get(child.ID)
+	if got.Meta(planning.MetaExecution) != agentparse.ExecutionHumanRequired {
+		t.Fatalf("retag failed: %q", got.Meta(planning.MetaExecution))
+	}
+}
+
+func TestHandlePlanChild_Remove(t *testing.T) {
+	srv, store, epic := planServer(t)
+	var child *beads.Bead
+	for _, b := range store.List(beads.ListFilter{}) {
+		if b.Meta(planning.MetaParentEpic) == epic.ID {
+			child = b
+			break
+		}
+	}
+	body := strings.NewReader(`{"action":"remove"}`)
+	req := httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/child/"+child.ID, body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	got, _ := store.Get(child.ID)
+	if got.Status != beads.StatusClosed {
+		t.Fatalf("want closed, got %q", got.Status)
+	}
+}
+
+func TestHandlePlanChild_BadAction(t *testing.T) {
+	srv, store, epic := planServer(t)
+	var child *beads.Bead
+	for _, b := range store.List(beads.ListFilter{}) {
+		if b.Meta(planning.MetaParentEpic) == epic.ID {
+			child = b
+			break
+		}
+	}
+	body := strings.NewReader(`{"action":"bogus"}`)
+	req := httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/child/"+child.ID, body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 for bad action, got %d", w.Code)
+	}
+}
+
+func TestHandlePlanReject_BadState(t *testing.T) {
+	// Reject an undecomposed epic → planning.RejectPlan errors → 400.
+	store, _ := beads.NewStore(t.TempDir())
+	epic, _ := store.Create("undecomposed", beads.TypeEpic, beads.PriorityHigh, "architect", "")
+	srv := NewServer(0, slog.Default())
+	srv.deps = &Dependencies{
+		Config:     &config.Config{Agents: map[string]config.AgentConfig{}},
+		Logger:     slog.Default(),
+		Ctx:        context.Background(),
+		BeadStores: map[string]*beads.Store{"architect": store},
+	}
+	srv.RegisterAPI(srv.deps)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/reject", nil))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+}
+
+func TestHandlePlanReject_NotFound(t *testing.T) {
+	srv, _, _ := planServer(t)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, httptest.NewRequest("POST", "/api/plan/missing/reject", nil))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", w.Code)
+	}
+}
+
+func TestHandlePlanChild_NotFound(t *testing.T) {
+	srv, _, _ := planServer(t)
+	body := strings.NewReader(`{"action":"remove"}`)
+	req := httptest.NewRequest("POST", "/api/plan/missing/child/x", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", w.Code)
+	}
+}
+
+func TestHandlePlanChild_BadBody(t *testing.T) {
+	srv, _, epic := planServer(t)
+	req := httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/child/x", strings.NewReader("{not json"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 for bad body, got %d", w.Code)
+	}
+}
+
+func TestHandlePlanChild_RetagError(t *testing.T) {
+	srv, store, epic := planServer(t)
+	var child *beads.Bead
+	for _, b := range store.List(beads.ListFilter{}) {
+		if b.Meta(planning.MetaParentEpic) == epic.ID {
+			child = b
+			break
+		}
+	}
+	// Invalid execution value → RetagChild errors → 400.
+	body := strings.NewReader(`{"action":"retag","execution":"bogus"}`)
+	req := httptest.NewRequest("POST", "/api/plan/"+epic.ID+"/child/"+child.ID, body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 for invalid execution, got %d", w.Code)
+	}
+}
+
+func TestHandlePlanTree_NonEpicBead(t *testing.T) {
+	// A task bead ID resolves to no epic store → 404.
+	store, _ := beads.NewStore(t.TempDir())
+	task, _ := store.Create("task", beads.TypeTask, beads.PriorityLow, "worker", "")
+	srv := NewServer(0, slog.Default())
+	srv.deps = &Dependencies{
+		Config:     &config.Config{Agents: map[string]config.AgentConfig{}},
+		Logger:     slog.Default(),
+		Ctx:        context.Background(),
+		BeadStores: map[string]*beads.Store{"architect": store},
+	}
+	srv.RegisterAPI(srv.deps)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, httptest.NewRequest("GET", "/api/plan/"+task.ID, nil))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404 for non-epic bead, got %d", w.Code)
+	}
+}
+
+func TestHandlePlan_NoStores(t *testing.T) {
+	srv := NewServer(0, slog.Default())
+	srv.deps = &Dependencies{Logger: slog.Default(), Ctx: context.Background()}
+	srv.RegisterAPI(srv.deps)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, httptest.NewRequest("GET", "/api/plan/x", nil))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("want 404 with no stores, got %d", w.Code)
+	}
+}
+
+func TestBuildPlanning(t *testing.T) {
+	store, _ := beads.NewStore(t.TempDir())
+
+	// Draft epic with children.
+	draft, _ := store.Create("draft", beads.TypeEpic, beads.PriorityHigh, "architect", "")
+	planning.DecomposeFromOutput(store, draft, "1. [T1] a [agent_suitable]\n", planning.Options{})
+
+	// Approved epic with an open child → decomposing.
+	appr, _ := store.Create("appr", beads.TypeEpic, beads.PriorityHigh, "architect", "")
+	planning.DecomposeFromOutput(store, appr, "1. [T1] b [agent_suitable]\n", planning.Options{AutoApprove: true})
+
+	// A plain epic never decomposed → not counted.
+	store.Create("plain", beads.TypeEpic, beads.PriorityHigh, "architect", "")
+
+	fp := BuildPlanning(map[string]*beads.Store{"architect": store})
+	if fp.ActivePlans != 2 {
+		t.Errorf("ActivePlans: want 2, got %d", fp.ActivePlans)
+	}
+	if fp.AwaitingReview != 1 {
+		t.Errorf("AwaitingReview: want 1, got %d", fp.AwaitingReview)
+	}
+	if fp.Decomposing != 1 {
+		t.Errorf("Decomposing: want 1, got %d", fp.Decomposing)
+	}
+	if fp.Replans24h != 0 {
+		t.Errorf("Replans24h: want 0, got %d", fp.Replans24h)
+	}
+}
+
+func TestBuildPlanning_Empty(t *testing.T) {
+	fp := BuildPlanning(map[string]*beads.Store{})
+	if fp.ActivePlans != 0 || fp.AwaitingReview != 0 {
+		t.Errorf("empty stores should yield zero planning metric, got %+v", fp)
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -140,6 +140,7 @@ type StatusPayload struct {
 	Tokens              FrontendTokens         `json:"tokens"`
 	Repos               []FrontendRepo         `json:"repos"`
 	Beads               FrontendBeads          `json:"beads"`
+	Planning            FrontendPlanning       `json:"planning"`
 	Health              map[string]any         `json:"health"`
 	Budget              FrontendBudget         `json:"budget"`
 	CadenceMatrix       []FrontendCadence      `json:"cadenceMatrix"`
@@ -303,6 +304,24 @@ type FrontendRepo struct {
 type FrontendBeads struct {
 	Workers    int `json:"workers"`
 	Supervisor int `json:"supervisor"`
+}
+
+// FrontendPlanning is the governor-facing PLANNING metric block (Phase 2
+// planning intelligence). It is computed from bead metadata (parent_epic +
+// plan_status) across all bead stores.
+type FrontendPlanning struct {
+	// ActivePlans counts epics that have been decomposed (carry a plan_status),
+	// i.e. plans currently in flight (draft or approved).
+	ActivePlans int `json:"active_plans"`
+	// AwaitingReview counts epics whose plan_status is draft — the
+	// human-action-required state the governor tile highlights.
+	AwaitingReview int `json:"awaiting_review"`
+	// Decomposing counts approved plans that still have open (unfinished)
+	// children — plans actively being executed by agents.
+	Decomposing int `json:"decomposing"`
+	// Replans24h counts plans re-decomposed in the last 24h. Phase 3 (governor
+	// stall-replan) populates this; it is 0 for now.
+	Replans24h int `json:"replans_24h"`
 }
 
 type FrontendBudget struct {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -342,6 +342,9 @@
     .oc-gov-strip .gov-metric .gm-val.mode-quiet { color: var(--blue); }
     .oc-gov-strip .gov-metric .gm-val.mode-busy { color: var(--yellow); }
     .oc-gov-strip .gov-metric .gm-val.mode-surge { color: var(--red); }
+    /* gm-alert: human-action-required highlight (plans awaiting review), amber
+       to draw the eye like the "N Issues" / ON HOLD indicators. */
+    .oc-gov-strip .gov-metric .gm-val.gm-alert { color: var(--yellow); font-weight: 800; }
     .oc-gov-gauge { flex-basis: 100%; margin-top: 4px; }
     .oc-gov-gauge .temp-gauge-track { height: 14px; }
     .oc-gov-gauge .temp-gauge-labels { font-size: 0.55rem; }
@@ -3113,6 +3116,19 @@
           <div class="gov-metric"><span class="gm-label">PRs</span><span class="gm-val">${govPrs}</span></div>
           <div class="gov-metric"><span class="gm-label">MTTR</span><span class="gm-val">${formatFixTime(itmMedian)}</span></div>
           <div class="gov-metric" title="${esc((window._lastStatus?.hold?.items || []).map(h => (h.type === 'pr' ? 'PR' : 'Issue') + ' ' + h.repo + '#' + h.number + ': ' + h.title).join('\n') || 'No items on hold')}"><span class="gm-label">on hold</span><span class="gm-val">${window._lastStatus?.hold?.total || 0}</span></div>
+          ${(() => {
+            const plan = window._lastStatus?.planning || {};
+            const active = plan.active_plans || 0;
+            const awaiting = plan.awaiting_review || 0;
+            // Highlight when plans await human review — a human-action-required
+            // state, surfaced amber like the "N Issues" / ON HOLD indicators.
+            const planClass = awaiting > 0 ? 'gm-alert' : '';
+            const planText = awaiting > 0 ? `${active} (${awaiting} review)` : `${active}`;
+            const planTitle = awaiting > 0
+              ? `${awaiting} plan(s) awaiting human review — decomposed epic children are withheld until approved`
+              : `${active} active plan(s)`;
+            return `<div class="gov-metric" title="${esc(planTitle)}"><span class="gm-label">planning</span><span class="gm-val ${planClass}">${esc(planText)}</span></div>`;
+          })()}
           <div class="oc-gov-gauge">
             <div class="temp-gauge-track" style="background:linear-gradient(to right, var(--green) 0%, var(--green) ${OC_THRESH_QUIET/OC_GAUGE_MAX*100}%, var(--blue) ${OC_THRESH_QUIET/OC_GAUGE_MAX*100}%, var(--blue) ${OC_THRESH_BUSY/OC_GAUGE_MAX*100}%, var(--yellow) ${OC_THRESH_BUSY/OC_GAUGE_MAX*100}%, var(--yellow) ${OC_THRESH_SURGE/OC_GAUGE_MAX*100}%, var(--red) ${OC_THRESH_SURGE/OC_GAUGE_MAX*100}%, var(--red) 100%)">
               <div class="temp-gauge-glow" style="width:100%"></div>

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/config"
 	"github.com/kubestellar/hive/v2/pkg/github"
 	"github.com/kubestellar/hive/v2/pkg/governor"
+	"github.com/kubestellar/hive/v2/pkg/planning"
 	"github.com/kubestellar/hive/v2/pkg/resolve"
 	"github.com/kubestellar/hive/v2/pkg/tokens"
 )
@@ -134,6 +135,7 @@ func BuildFrontendStatus(
 		Tokens:       buildTokens(tokenCollector),
 		Repos:        buildRepos(cfg, actionable),
 		Beads:        BuildBeadsFromConfig(beadStores, cfg),
+		Planning:     BuildPlanning(beadStores),
 		Health:       buildHealth(ghClient, ctx),
 		Budget:       buildBudget(gov, tokenCollector),
 		CadenceMatrix: buildCadenceMatrix(cfg, agentStatuses),
@@ -791,6 +793,49 @@ func buildBeads(stores map[string]*beads.Store) FrontendBeads {
 		}
 	}
 	return fb
+}
+
+// BuildPlanning computes the governor PLANNING metric block from bead metadata
+// across all stores (Phase 2 planning intelligence). An epic is "active" once it
+// carries a plan_status; "awaiting review" while that status is draft; and
+// "decomposing" (executing) when approved with at least one open child.
+// Replans24h is Phase 3 territory and stays 0.
+func BuildPlanning(stores map[string]*beads.Store) FrontendPlanning {
+	fp := FrontendPlanning{}
+	for _, store := range stores {
+		all := store.List(beads.ListFilter{})
+
+		// Count open children per epic so we can tell executing plans apart from
+		// fully-completed ones.
+		openChildrenByEpic := make(map[string]int)
+		for _, b := range all {
+			if epicID := b.Meta(planning.MetaParentEpic); epicID != "" {
+				if b.Status == beads.StatusOpen || b.Status == beads.StatusInProgress {
+					openChildrenByEpic[epicID]++
+				}
+			}
+		}
+
+		for _, b := range all {
+			if b.Type != beads.TypeEpic {
+				continue
+			}
+			status := b.Meta(planning.MetaPlanStatus)
+			if status == "" {
+				continue // never decomposed
+			}
+			fp.ActivePlans++
+			switch status {
+			case planning.PlanStatusDraft:
+				fp.AwaitingReview++
+			case planning.PlanStatusApproved:
+				if openChildrenByEpic[b.ID] > 0 {
+					fp.Decomposing++
+				}
+			}
+		}
+	}
+	return fp
 }
 
 // BuildBeadsFromConfig uses agent config bead_role to partition bead counts.

--- a/v2/pkg/planning/decompose.go
+++ b/v2/pkg/planning/decompose.go
@@ -45,11 +45,18 @@ const (
 	MetaPlanRef = "plan_ref"
 )
 
-// PlanStatusDraft marks an epic whose plan has been drafted but not yet
-// approved. TODO(planning phase 2): Store.Ready() must exclude children whose
-// parent epic still carries plan_status=draft; that gating is intentionally not
-// implemented here.
-const PlanStatusDraft = "draft"
+const (
+	// PlanStatusDraft marks an epic whose plan has been drafted but not yet
+	// approved. While an epic carries plan_status=draft, beads.Store.Ready()
+	// (Phase 2) excludes its children, so no agent can claim the sub-tasks
+	// until a human approves the plan.
+	PlanStatusDraft = "draft"
+	// PlanStatusApproved marks an epic whose plan a human has approved. Only
+	// this value releases the epic's children through beads.Store.Ready().
+	// It is set by ApprovePlan (or immediately at decomposition time when the
+	// active ACMM pack enables plan_auto_approve).
+	PlanStatusApproved = "approved"
+)
 
 // defaultChildPriority is the priority assigned to generated child beads when
 // the epic carries none distinguishable. Children inherit the epic's priority
@@ -70,6 +77,13 @@ type Options struct {
 	// ChildPriority overrides the child beads' priority. When nil, children
 	// inherit the epic's priority.
 	ChildPriority *beads.Priority
+	// AutoApprove, when true, sets the epic's plan_status to approved (instead
+	// of draft) immediately at decomposition time, releasing the children
+	// through Ready() without a human approval step. It is driven by the active
+	// ACMM pack's plan_auto_approve knob — high maturity levels (L5/L6) trust
+	// the planner enough to skip the review gate; lower levels leave it false so
+	// the plan stays draft pending human approval. Default false.
+	AutoApprove bool
 }
 
 // Result summarizes a decomposition.
@@ -232,8 +246,14 @@ func DecomposeFromOutput(store *beads.Store, epic *beads.Bead, output string, op
 		}
 	}
 
-	// Lay the Phase 2 readiness convention: mark the epic's plan as draft.
-	if err := store.SetMetadata(epic.ID, MetaPlanStatus, PlanStatusDraft); err != nil {
+	// Set the epic's plan_status. Normally draft (children stay gated until a
+	// human approves via ApprovePlan); when the active pack enables
+	// plan_auto_approve, approved (children released immediately).
+	planStatus := PlanStatusDraft
+	if opts.AutoApprove {
+		planStatus = PlanStatusApproved
+	}
+	if err := store.SetMetadata(epic.ID, MetaPlanStatus, planStatus); err != nil {
 		return nil, fmt.Errorf("planning: setting plan_status on epic %s: %w", epic.ID, err)
 	}
 

--- a/v2/pkg/planning/plan_review.go
+++ b/v2/pkg/planning/plan_review.go
@@ -1,0 +1,194 @@
+package planning
+
+import (
+	"fmt"
+
+	"github.com/kubestellar/hive/v2/pkg/agentparse"
+	"github.com/kubestellar/hive/v2/pkg/beads"
+)
+
+// This file implements the Phase 2 plan-review gate transitions and readers.
+// Phase 1 (decompose.go) drafts a plan (epic plan_status=draft, children tagged
+// parent_epic + execution). beads.Store.Ready() withholds a draft epic's
+// children. The functions here let a human inspect the plan (PlanTree), edit it
+// before approval (RetagChild / RemoveChild), and approve or reject it
+// (ApprovePlan / RejectPlan). Approval flips the epic to plan_status=approved,
+// which releases the children through Ready().
+
+// PlanChild summarizes one child bead of a plan for the review UI.
+type PlanChild struct {
+	// ID is the child bead's ID.
+	ID string `json:"id"`
+	// Title is the child bead's title.
+	Title string `json:"title"`
+	// Execution is the child's execution tag (agent_suitable / human_required).
+	Execution string `json:"execution"`
+	// PlanRef is the planner's local task ref (e.g. "T1"), if any.
+	PlanRef string `json:"planRef,omitempty"`
+	// Status is the child bead's current status.
+	Status beads.Status `json:"status"`
+	// DependsOn holds the child bead IDs this child depends on. These are the
+	// intra-plan dependency edges for the review DAG.
+	DependsOn []string `json:"dependsOn,omitempty"`
+}
+
+// PlanTree is the review view of a decomposed epic: the epic plus its children
+// (in creation order) with their execution tags and dependency edges.
+type PlanTree struct {
+	// EpicID is the epic bead's ID.
+	EpicID string `json:"epicId"`
+	// EpicTitle is the epic bead's title.
+	EpicTitle string `json:"epicTitle"`
+	// PlanStatus is the epic's current plan_status ("draft" / "approved"), or
+	// "" if the epic was never decomposed.
+	PlanStatus string `json:"planStatus"`
+	// Approved is true when PlanStatus == PlanStatusApproved.
+	Approved bool `json:"approved"`
+	// Children are the epic's child beads, in creation order.
+	Children []PlanChild `json:"children"`
+}
+
+// loadEpic fetches an epic bead and verifies it is of type epic. It is the
+// shared guard for the review transitions below.
+func loadEpic(store *beads.Store, epicID string) (*beads.Bead, error) {
+	if store == nil {
+		return nil, fmt.Errorf("planning: store is nil")
+	}
+	epic, err := store.Get(epicID)
+	if err != nil {
+		return nil, fmt.Errorf("planning: epic %s not found: %w", epicID, err)
+	}
+	if epic.Type != beads.TypeEpic {
+		return nil, fmt.Errorf("planning: bead %s is type %q, not an epic", epicID, epic.Type)
+	}
+	return epic, nil
+}
+
+// childrenOf returns the child beads of epicID (those tagged parent_epic ==
+// epicID), in creation order.
+func childrenOf(store *beads.Store, epicID string) []*beads.Bead {
+	var out []*beads.Bead
+	for _, b := range store.List(beads.ListFilter{}) {
+		if b.Meta(MetaParentEpic) == epicID {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// PlanTree returns the review view of a decomposed epic. It errors if the epic
+// does not exist or is not of type epic. An epic that was never decomposed
+// returns an empty PlanStatus and no children (not an error).
+func GetPlanTree(store *beads.Store, epicID string) (*PlanTree, error) {
+	epic, err := loadEpic(store, epicID)
+	if err != nil {
+		return nil, err
+	}
+	status := epic.Meta(MetaPlanStatus)
+	tree := &PlanTree{
+		EpicID:     epic.ID,
+		EpicTitle:  epic.Title,
+		PlanStatus: status,
+		Approved:   status == PlanStatusApproved,
+	}
+	for _, c := range childrenOf(store, epicID) {
+		tree.Children = append(tree.Children, PlanChild{
+			ID:        c.ID,
+			Title:     c.Title,
+			Execution: c.Meta(MetaExecution),
+			PlanRef:   c.Meta(MetaPlanRef),
+			Status:    c.Status,
+			DependsOn: c.DependsOn,
+		})
+	}
+	return tree, nil
+}
+
+// ApprovePlan approves a decomposed epic's plan by setting its plan_status to
+// approved, which releases the epic's children through beads.Store.Ready(). It
+// errors if the epic does not exist, is not an epic, was never decomposed
+// (plan_status unset), or is already approved (so a double-approve is surfaced
+// rather than silently succeeding).
+func ApprovePlan(store *beads.Store, epicID string) error {
+	epic, err := loadEpic(store, epicID)
+	if err != nil {
+		return err
+	}
+	switch epic.Meta(MetaPlanStatus) {
+	case "":
+		return fmt.Errorf("planning: epic %s has no plan to approve (not decomposed)", epicID)
+	case PlanStatusApproved:
+		return fmt.Errorf("planning: epic %s plan is already approved", epicID)
+	}
+	if err := store.SetMetadata(epicID, MetaPlanStatus, PlanStatusApproved); err != nil {
+		return fmt.Errorf("planning: approving plan for epic %s: %w", epicID, err)
+	}
+	return nil
+}
+
+// RejectPlan returns a plan to draft state (plan_status=draft), re-gating the
+// epic's children. It is the inverse of ApprovePlan — used when a reviewer
+// approved by mistake or wants to force re-review after editing. It errors if
+// the epic does not exist, is not an epic, or was never decomposed.
+func RejectPlan(store *beads.Store, epicID string) error {
+	epic, err := loadEpic(store, epicID)
+	if err != nil {
+		return err
+	}
+	if epic.Meta(MetaPlanStatus) == "" {
+		return fmt.Errorf("planning: epic %s has no plan to reject (not decomposed)", epicID)
+	}
+	if err := store.SetMetadata(epicID, MetaPlanStatus, PlanStatusDraft); err != nil {
+		return fmt.Errorf("planning: rejecting plan for epic %s: %w", epicID, err)
+	}
+	return nil
+}
+
+// RetagChild changes a child bead's execution tag before approval. execution
+// must be agent_suitable or human_required. It errors if the child does not
+// exist, is not a child of epicID, or the execution value is invalid.
+func RetagChild(store *beads.Store, epicID, childID, execution string) error {
+	switch execution {
+	case agentparse.ExecutionAgentSuitable, agentparse.ExecutionHumanRequired:
+		// ok
+	default:
+		return fmt.Errorf("planning: invalid execution %q (want %q or %q)",
+			execution, agentparse.ExecutionAgentSuitable, agentparse.ExecutionHumanRequired)
+	}
+	if err := verifyChild(store, epicID, childID); err != nil {
+		return err
+	}
+	if err := store.SetMetadata(childID, MetaExecution, execution); err != nil {
+		return fmt.Errorf("planning: retagging child %s: %w", childID, err)
+	}
+	return nil
+}
+
+// RemoveChild removes a child bead from a plan before approval by closing it.
+// The bead is closed rather than deleted so the audit trail (and any dependency
+// references from siblings) is preserved. It errors if the child does not exist
+// or is not a child of epicID.
+func RemoveChild(store *beads.Store, epicID, childID string) error {
+	if err := verifyChild(store, epicID, childID); err != nil {
+		return err
+	}
+	if err := store.Close(childID); err != nil {
+		return fmt.Errorf("planning: removing child %s: %w", childID, err)
+	}
+	return nil
+}
+
+// verifyChild confirms childID exists and is tagged parent_epic == epicID.
+func verifyChild(store *beads.Store, epicID, childID string) error {
+	if store == nil {
+		return fmt.Errorf("planning: store is nil")
+	}
+	child, err := store.Get(childID)
+	if err != nil {
+		return fmt.Errorf("planning: child %s not found: %w", childID, err)
+	}
+	if child.Meta(MetaParentEpic) != epicID {
+		return fmt.Errorf("planning: bead %s is not a child of epic %s", childID, epicID)
+	}
+	return nil
+}

--- a/v2/pkg/planning/plan_review_test.go
+++ b/v2/pkg/planning/plan_review_test.go
@@ -1,0 +1,286 @@
+package planning
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/agentparse"
+	"github.com/kubestellar/hive/v2/pkg/beads"
+)
+
+// mustTask creates a plain task bead (used for negative "not a child" cases).
+func mustTask(t *testing.T, store *beads.Store, title string) *beads.Bead {
+	t.Helper()
+	b, err := store.Create(title, beads.TypeTask, beads.PriorityMedium, "worker", "")
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	return b
+}
+
+// decomposeEpic is a helper that decomposes an epic with the given options and
+// returns the epic + result.
+func decomposeEpic(t *testing.T, store *beads.Store, title string, opts Options) (*beads.Bead, *Result) {
+	t.Helper()
+	epic := mustEpic(t, store, title)
+	res, err := DecomposeFromOutput(store, epic, samplePlan, opts)
+	if err != nil {
+		t.Fatalf("DecomposeFromOutput: %v", err)
+	}
+	return epic, res
+}
+
+func TestApprovePlan_HappyPath(t *testing.T) {
+	store := newStore(t)
+	epic, _ := decomposeEpic(t, store, "Epic to approve", Options{})
+
+	// Freshly decomposed → draft.
+	got, _ := store.Get(epic.ID)
+	if s := got.Meta(MetaPlanStatus); s != PlanStatusDraft {
+		t.Fatalf("want draft after decompose, got %q", s)
+	}
+
+	if err := ApprovePlan(store, epic.ID); err != nil {
+		t.Fatalf("ApprovePlan: %v", err)
+	}
+	got, _ = store.Get(epic.ID)
+	if s := got.Meta(MetaPlanStatus); s != PlanStatusApproved {
+		t.Fatalf("want approved, got %q", s)
+	}
+}
+
+func TestApprovePlan_Errors(t *testing.T) {
+	store := newStore(t)
+
+	// Non-existent epic.
+	if err := ApprovePlan(store, "nope"); err == nil {
+		t.Fatal("want error for missing epic")
+	}
+
+	// Non-epic bead.
+	task := mustTask(t, store, "a task")
+	if err := ApprovePlan(store, task.ID); err == nil || !strings.Contains(err.Error(), "not an epic") {
+		t.Fatalf("want non-epic error, got %v", err)
+	}
+
+	// Epic never decomposed (no plan_status).
+	epic := mustEpic(t, store, "undecomposed")
+	if err := ApprovePlan(store, epic.ID); err == nil || !strings.Contains(err.Error(), "no plan") {
+		t.Fatalf("want no-plan error, got %v", err)
+	}
+
+	// Already approved.
+	epic2, _ := decomposeEpic(t, store, "already approved", Options{})
+	if err := ApprovePlan(store, epic2.ID); err != nil {
+		t.Fatalf("first approve: %v", err)
+	}
+	if err := ApprovePlan(store, epic2.ID); err == nil || !strings.Contains(err.Error(), "already approved") {
+		t.Fatalf("want already-approved error, got %v", err)
+	}
+
+	// Nil store.
+	if err := ApprovePlan(nil, "x"); err == nil {
+		t.Fatal("want error for nil store")
+	}
+}
+
+func TestRejectPlan(t *testing.T) {
+	store := newStore(t)
+	epic, _ := decomposeEpic(t, store, "reject me", Options{})
+	if err := ApprovePlan(store, epic.ID); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	if err := RejectPlan(store, epic.ID); err != nil {
+		t.Fatalf("RejectPlan: %v", err)
+	}
+	got, _ := store.Get(epic.ID)
+	if s := got.Meta(MetaPlanStatus); s != PlanStatusDraft {
+		t.Fatalf("want draft after reject, got %q", s)
+	}
+
+	// Errors: missing, non-epic, undecomposed.
+	if err := RejectPlan(store, "missing"); err == nil {
+		t.Fatal("want error for missing epic")
+	}
+	task := mustTask(t, store, "task")
+	if err := RejectPlan(store, task.ID); err == nil {
+		t.Fatal("want error for non-epic")
+	}
+	undec := mustEpic(t, store, "undecomposed")
+	if err := RejectPlan(store, undec.ID); err == nil {
+		t.Fatal("want error for undecomposed epic")
+	}
+}
+
+func TestGetPlanTree(t *testing.T) {
+	store := newStore(t)
+	epic, res := decomposeEpic(t, store, "tree epic", Options{})
+
+	tree, err := GetPlanTree(store, epic.ID)
+	if err != nil {
+		t.Fatalf("GetPlanTree: %v", err)
+	}
+	if tree.EpicID != epic.ID || tree.EpicTitle != "tree epic" {
+		t.Fatalf("epic identity wrong: %+v", tree)
+	}
+	if tree.PlanStatus != PlanStatusDraft || tree.Approved {
+		t.Fatalf("want draft/not-approved, got status=%q approved=%v", tree.PlanStatus, tree.Approved)
+	}
+	if len(tree.Children) != len(res.Children) {
+		t.Fatalf("want %d children, got %d", len(res.Children), len(tree.Children))
+	}
+	// Execution tags carried; the human_required task from samplePlan present.
+	var sawHuman, sawDeps bool
+	for _, c := range tree.Children {
+		if c.Execution == agentparse.ExecutionHumanRequired {
+			sawHuman = true
+		}
+		if len(c.DependsOn) > 0 {
+			sawDeps = true
+		}
+		if c.PlanRef == "" {
+			t.Errorf("child %s missing plan ref", c.ID)
+		}
+	}
+	if !sawHuman {
+		t.Error("expected a human_required child")
+	}
+	if !sawDeps {
+		t.Error("expected at least one dependency edge")
+	}
+
+	// After approve, tree reflects it.
+	if err := ApprovePlan(store, epic.ID); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	tree, _ = GetPlanTree(store, epic.ID)
+	if !tree.Approved || tree.PlanStatus != PlanStatusApproved {
+		t.Fatalf("want approved tree, got %+v", tree)
+	}
+}
+
+func TestGetPlanTree_Errors(t *testing.T) {
+	store := newStore(t)
+	if _, err := GetPlanTree(store, "missing"); err == nil {
+		t.Fatal("want error for missing epic")
+	}
+	task := mustTask(t, store, "task")
+	if _, err := GetPlanTree(store, task.ID); err == nil {
+		t.Fatal("want error for non-epic")
+	}
+	// Undecomposed epic → empty status, no children, no error.
+	epic := mustEpic(t, store, "undecomposed")
+	tree, err := GetPlanTree(store, epic.ID)
+	if err != nil {
+		t.Fatalf("undecomposed epic should not error: %v", err)
+	}
+	if tree.PlanStatus != "" || len(tree.Children) != 0 {
+		t.Fatalf("want empty tree, got %+v", tree)
+	}
+}
+
+func TestRetagChild(t *testing.T) {
+	store := newStore(t)
+	epic, res := decomposeEpic(t, store, "retag epic", Options{})
+	child := res.Children[0]
+
+	if err := RetagChild(store, epic.ID, child.ID, agentparse.ExecutionHumanRequired); err != nil {
+		t.Fatalf("RetagChild: %v", err)
+	}
+	got, _ := store.Get(child.ID)
+	if e := got.Meta(MetaExecution); e != agentparse.ExecutionHumanRequired {
+		t.Fatalf("want human_required, got %q", e)
+	}
+
+	// Invalid execution value.
+	if err := RetagChild(store, epic.ID, child.ID, "bogus"); err == nil {
+		t.Fatal("want error for invalid execution")
+	}
+	// Missing child.
+	if err := RetagChild(store, epic.ID, "missing", agentparse.ExecutionAgentSuitable); err == nil {
+		t.Fatal("want error for missing child")
+	}
+	// Bead that is not a child of this epic.
+	other := mustTask(t, store, "orphan")
+	if err := RetagChild(store, epic.ID, other.ID, agentparse.ExecutionAgentSuitable); err == nil {
+		t.Fatal("want error for non-child bead")
+	}
+}
+
+func TestRemoveChild(t *testing.T) {
+	store := newStore(t)
+	epic, res := decomposeEpic(t, store, "remove epic", Options{})
+	child := res.Children[0]
+
+	if err := RemoveChild(store, epic.ID, child.ID); err != nil {
+		t.Fatalf("RemoveChild: %v", err)
+	}
+	got, _ := store.Get(child.ID)
+	if got.Status != beads.StatusClosed {
+		t.Fatalf("want closed after remove, got %q", got.Status)
+	}
+
+	// Missing child + non-child bead.
+	if err := RemoveChild(store, epic.ID, "missing"); err == nil {
+		t.Fatal("want error for missing child")
+	}
+	other := mustTask(t, store, "orphan")
+	if err := RemoveChild(store, epic.ID, other.ID); err == nil {
+		t.Fatal("want error for non-child bead")
+	}
+	// Nil store guards.
+	if err := verifyChild(nil, epic.ID, child.ID); err == nil {
+		t.Fatal("want error for nil store in verifyChild")
+	}
+}
+
+// TestPlanReview_PersistErrors exercises the SetMetadata/Close persistence
+// error branches of the review transitions by making the store dir read-only
+// after the plan exists in memory. Skipped as root (perms bypassed).
+func TestPlanReview_PersistErrors(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; filesystem permission enforcement is bypassed")
+	}
+	dir := t.TempDir()
+	store, err := beads.NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	epic := mustEpic(t, store, "persist epic")
+	res, err := DecomposeFromOutput(store, epic, samplePlan, Options{})
+	if err != nil {
+		t.Fatalf("decompose: %v", err)
+	}
+	child := res.Children[0]
+
+	if err := os.Chmod(dir, 0500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+
+	if err := ApprovePlan(store, epic.ID); err == nil {
+		t.Error("ApprovePlan: want persist error")
+	}
+	// After a failed approve the status may have flipped in memory; force draft
+	// so RejectPlan reaches its SetMetadata call.
+	_ = store.Update(epic.ID, func(b *beads.Bead) { b.Metadata[MetaPlanStatus] = PlanStatusDraft })
+	if err := RejectPlan(store, epic.ID); err == nil {
+		t.Error("RejectPlan: want persist error")
+	}
+	if err := RetagChild(store, epic.ID, child.ID, agentparse.ExecutionHumanRequired); err == nil {
+		t.Error("RetagChild: want persist error")
+	}
+	if err := RemoveChild(store, epic.ID, child.ID); err == nil {
+		t.Error("RemoveChild: want persist error")
+	}
+}
+
+func TestDecompose_AutoApprove(t *testing.T) {
+	store := newStore(t)
+	epic, _ := decomposeEpic(t, store, "auto approved", Options{AutoApprove: true})
+	got, _ := store.Get(epic.ID)
+	if s := got.Meta(MetaPlanStatus); s != PlanStatusApproved {
+		t.Fatalf("want approved with AutoApprove, got %q", s)
+	}
+}


### PR DESCRIPTION
## Phase 2 — plan-review gate + governor PLANNING metric

Builds on Phase 1 (#2031, epic→bead-DAG decomposition in `pkg/planning`). Phase 1 laid the metadata convention (epic `plan_status=draft`; children `parent_epic`/`execution`); this PR adds the review gate that consumes it.

### Part A — Readiness gating (core)
`beads.Store.Ready(actor)` now **excludes a child bead of a decomposed epic** (one carrying a `parent_epic` metadata key) unless that epic's `plan_status` is `approved`. This is the hook feeding `bd ready` and governor claim selection, so a not-yet-reviewed plan's sub-tasks are unclaimable.

- Kept `beads` generic: it reads `parent_epic`/`plan_status` as **plain strings** by convention — no import of `planning`, **no import cycle** (`planning` already imports `beads`). Local unexported consts mirror the planning keys with a "keep in sync" doc comment.
- **Normal (parentless) beads are unaffected** — only decomposed children gate.
- Missing parent epic → **fail-closed** (child withheld). Malformed (non-string) `plan_status` treated as not-approved.

### Part B — Approve transition + API
- `pkg/planning`: `PlanStatusApproved`, `ApprovePlan` (draft→approved), `RejectPlan` (approved→draft), `GetPlanTree` (epic + children with execution tags + dep edges for the review UI), and `RetagChild`/`RemoveChild` to edit a plan before approval.
- Dashboard `/api/plan/*` (mirrors `/api/inception/*`, thin handlers, logic in `pkg/planning`): `GET /api/plan/{epicID}`, `POST /api/plan/{epicID}/approve`, `POST /api/plan/{epicID}/reject`, `POST /api/plan/{epicID}/child/{childID}` (`{"action":"retag"|"remove"}`).
- **`plan_auto_approve` knob**: `PackGovernor.PlanAutoApprove` + `config.PlanAutoApproveForLevel(level)`; set **true for L5/L6** packs, false (default) elsewhere. `Options.AutoApprove` makes `Decompose` set `plan_status=approved` immediately at high-trust levels; low levels stay draft pending human approval. `bd decompose --auto-approve` added.

### Part C — Governor PLANNING metric
- `planning` block on `/api/status`: `{active_plans, awaiting_review, decomposing, replans_24h}` computed from bead metadata. `awaiting_review` = epics with `plan_status=draft`; `replans_24h` = 0 (Phase 3 fills it).
- Governor metric-strip **`planning` tile** shows the active-plans count and **highlights `awaiting_review`>0 amber** (new `.gm-alert` class) — a human-action-required state surfaced like the "N Issues" / ON HOLD indicators.
- **Status/dashboard only — the governor eval loop and `main.go` stall logic are untouched** (Phase 3).

### Quality gates
- **Coverage** (new/changed code): `pkg/planning` **96.9%** (new `plan_review.go` 100%), `pkg/beads` **97.3%** (new `Ready`/`planGated`/`metaString` 100%), `pkg/config` **94.0%** (`PlanAutoApproveForLevel` 100%), new dashboard code (`plan_handlers.go` + `BuildPlanning`) **~95%**. Tests are table-driven and cover error branches: missing epic, non-epic id, child of draft vs approved, already-approved, missing/malformed metadata, persistence-error paths.
- **`-race` clean**: `go test ./pkg/planning/... ./pkg/beads/ ./pkg/dashboard/ ./pkg/config/ -race -count=1 -timeout 300s` → 0 DATA RACE.
- `go build ./...`, `go vet`, existing Ready + inception tests all green — **no regressions**.

### Next
Phase 3 (governor stall-replan) will populate `replans_24h` and wire replanning into the eval loop.
