### PR TITLE
✨ planning: Phase 3 — governor stall-detection + bounded replanning

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/knowledge"
 	"github.com/kubestellar/hive/v2/pkg/logscrub"
 	"github.com/kubestellar/hive/v2/pkg/notify"
+	"github.com/kubestellar/hive/v2/pkg/planning"
 	"github.com/kubestellar/hive/v2/pkg/policies"
 	"github.com/kubestellar/hive/v2/pkg/promptsrc"
 	"github.com/kubestellar/hive/v2/pkg/proxy"
@@ -1960,6 +1961,34 @@ func main() {
 	// enabled AND no reviewer resolves; clears when off or configured).
 	dashSrv.ReconcileTrajectoryAlert(&cfg.Governor)
 
+	// Stall-replan lane (Phase 3 planning intelligence): periodically detects
+	// approved plans whose sub-tasks have stopped progressing and re-kicks the
+	// architect to revise them, bounded by a per-plan replan cap. It runs off the
+	// governor tick, gated by its own Due() cadence (no goroutine of its own), and
+	// drives the architect only through SendKick (agentKicker) from this tick —
+	// never from the agent-launch path — so it cannot touch the manager lock
+	// unsafely. On by default; a no-op when there are no approved plans.
+	var replanLane *planning.ReplanLane
+	if cfg.Governor.Replan.IsEnabled() {
+		rc := cfg.Governor.Replan
+		replanLane = planning.NewReplanLane(
+			beadStores,
+			agentKicker{mgr: agentMgr},
+			gov,
+			dashboard.NewReplanSink(dashSrv, notifier),
+			planning.ReplanLaneConfig{
+				IntervalS: rc.IntervalS,
+				Stall: planning.StallConfig{
+					StallThreshold: time.Duration(rc.StallThresholdS) * time.Second,
+					MaxReplans:     rc.MaxReplans,
+				},
+			}, logger)
+		logger.Info("stall-replan lane enabled",
+			"interval_s", rc.IntervalS,
+			"stall_threshold_s", rc.StallThresholdS,
+			"max_replans", rc.MaxReplans)
+	}
+
 	logger.Info("entering governor loop", "interval_seconds", cfg.Governor.EvalIntervalS)
 	lastEvalInterval := cfg.Governor.EvalIntervalS
 	ticker := time.NewTicker(time.Duration(cfg.Governor.EvalIntervalS) * time.Second)
@@ -2030,6 +2059,14 @@ func main() {
 			if trajLane != nil && trajLane.Due(time.Now()) {
 				trajLane.Run(ctx)
 			}
+			// Stall-replan runs on the same tick, gated by its own Due() cadence.
+			// It is synchronous and adds no goroutine; kicks go through the same
+			// out-of-band SendKick path as the eval cycle above.
+			if replanLane != nil && replanLane.Due(time.Now()) {
+				if n := replanLane.Run(ctx); n > 0 {
+					logger.Info("stall-replan lane re-kicked stalled plans", "replans", n)
+				}
+			}
 			persistState(agentMgr, gov, cfg, tokenCollector, statePath, logger, dashSrv)
 			if cfg.Governor.EvalIntervalS != lastEvalInterval && cfg.Governor.EvalIntervalS > 0 {
 				logger.Info("eval interval changed, resetting ticker",
@@ -2078,6 +2115,17 @@ func applyBudgetAlerts(gov *governor.Governor, trans governor.BudgetTransitions,
 		dashSrv.AddSystemAlert(budgetExhaustedAlertID, "error", msg)
 		notifier.Send("Budget exhausted", msg, notify.PriorityHigh)
 	}
+}
+
+// agentKicker adapts *agent.Manager to planning.Kicker for the Phase 3
+// stall-replan lane. Kick delegates to SendKick, which takes the manager lock
+// ITSELF and is only ever called here from the governor tick (never from the
+// agent-launch path), so it cannot re-enter a held manager lock. This is the
+// same out-of-band kick path the eval loop already uses for governor kicks.
+type agentKicker struct{ mgr *agent.Manager }
+
+func (k agentKicker) Kick(agent, message string) error {
+	return k.mgr.SendKick(agent, message)
 }
 
 // diagnoseGitHubAppWrite returns "" when the configured GitHub App

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -514,6 +514,7 @@ type GovernorConfig struct {
 	VLLM          InferenceAuthConfig   `yaml:"vllm"`
 	LLMD          InferenceAuthConfig   `yaml:"llm-d"`
 	Trajectory    TrajectoryConfig      `yaml:"trajectory"`
+	Replan        ReplanConfig          `yaml:"replan"`
 	// Gateways is the list of named model gateways (OpenAI-compatible endpoints
 	// like OpenRouter, a LiteLLM proxy, vLLM, or llm-d). An agent routes through
 	// a gateway by naming it as its backend. When empty, a single implicit
@@ -672,6 +673,33 @@ type TrajectoryConfig struct {
 	// ExemptAgents are never reviewed (e.g. advisory-only agents that open no
 	// PRs and touch no infrastructure).
 	ExemptAgents []string `yaml:"exempt_agents"`
+}
+
+// ReplanConfig governs the Phase 3 stall-replan lane: a periodic check that
+// finds approved plans whose sub-tasks have stopped progressing and re-kicks the
+// architect to revise them, bounded by a per-plan replan cap. It runs off the
+// governor tick on its own cadence (like the trajectory lane). On by default; it
+// is a no-op when there are no approved plans, so "on" is always safe.
+type ReplanConfig struct {
+	// Enabled turns the stall-replan lane on. Pointer so an omitted key defaults
+	// to enabled, while an explicit "false" disables it.
+	Enabled *bool `yaml:"enabled"`
+	// IntervalS is how often (seconds) the lane scans for stalled plans. It runs
+	// off the governor tick, so the effective floor is the governor eval
+	// interval. 0 → default (30m).
+	IntervalS int `yaml:"interval_s"`
+	// StallThresholdS is how long (seconds) a plan may go without any child
+	// progressing before it is considered stalled. 0 → default (6h).
+	StallThresholdS int `yaml:"stall_threshold_s"`
+	// MaxReplans caps replans per plan before the lane stops and escalates to a
+	// human. 0 → default (5).
+	MaxReplans int `yaml:"max_replans"`
+}
+
+// IsEnabled reports whether the stall-replan lane is on. Default is ON: a nil
+// Enabled (key omitted) counts as enabled, only an explicit false disables it.
+func (r ReplanConfig) IsEnabled() bool {
+	return r.Enabled == nil || *r.Enabled
 }
 
 // IsEnabled reports whether the trajectory-review lane is on. Default is ON:

--- a/v2/pkg/config/replan_default_test.go
+++ b/v2/pkg/config/replan_default_test.go
@@ -1,0 +1,23 @@
+package config
+
+import "testing"
+
+func TestReplanDefaultOn(t *testing.T) {
+	// nil Enabled (key omitted) → enabled
+	var rc ReplanConfig
+	if !rc.IsEnabled() {
+		t.Error("omitted replan.enabled must default to on")
+	}
+	// explicit false → disabled
+	f := false
+	rc.Enabled = &f
+	if rc.IsEnabled() {
+		t.Error("explicit replan.enabled=false must disable")
+	}
+	// explicit true → enabled
+	tr := true
+	rc.Enabled = &tr
+	if !rc.IsEnabled() {
+		t.Error("explicit replan.enabled=true must enable")
+	}
+}

--- a/v2/pkg/dashboard/plan_handlers_test.go
+++ b/v2/pkg/dashboard/plan_handlers_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/agentparse"
 	"github.com/kubestellar/hive/v2/pkg/beads"
@@ -321,6 +322,31 @@ func TestBuildPlanning(t *testing.T) {
 	}
 	if fp.Replans24h != 0 {
 		t.Errorf("Replans24h: want 0, got %d", fp.Replans24h)
+	}
+}
+
+func TestBuildPlanning_Replans24h(t *testing.T) {
+	store, _ := beads.NewStore(t.TempDir())
+	now := time.Now()
+
+	// Approved epic replanned 2h ago → counted.
+	recent, _ := store.Create("recent", beads.TypeEpic, beads.PriorityHigh, "architect", "")
+	planning.DecomposeFromOutput(store, recent, "1. [T1] a [agent_suitable]\n", planning.Options{AutoApprove: true})
+	store.SetMetadata(recent.ID, planning.MetaLastReplanAt, now.Add(-2*time.Hour).Format(time.RFC3339))
+
+	// Approved epic replanned 30h ago → outside the 24h window, not counted.
+	old, _ := store.Create("old", beads.TypeEpic, beads.PriorityHigh, "architect", "")
+	planning.DecomposeFromOutput(store, old, "1. [T1] b [agent_suitable]\n", planning.Options{AutoApprove: true})
+	store.SetMetadata(old.ID, planning.MetaLastReplanAt, now.Add(-30*time.Hour).Format(time.RFC3339))
+
+	// Approved epic with a malformed timestamp → ignored, not counted.
+	bad, _ := store.Create("bad", beads.TypeEpic, beads.PriorityHigh, "architect", "")
+	planning.DecomposeFromOutput(store, bad, "1. [T1] c [agent_suitable]\n", planning.Options{AutoApprove: true})
+	store.SetMetadata(bad.ID, planning.MetaLastReplanAt, "not-a-timestamp")
+
+	fp := buildPlanningAt(map[string]*beads.Store{"architect": store}, now)
+	if fp.Replans24h != 1 {
+		t.Errorf("Replans24h: want 1 (only the 2h-ago replan), got %d", fp.Replans24h)
 	}
 }
 

--- a/v2/pkg/dashboard/replan_sink.go
+++ b/v2/pkg/dashboard/replan_sink.go
@@ -1,0 +1,34 @@
+package dashboard
+
+import "github.com/kubestellar/hive/v2/pkg/notify"
+
+// ReplanSink adapts the dashboard Server (+ notifier) to planning.Sink, so the
+// Phase 3 stall-replan lane records audit entries, raises system alerts, and
+// pushes notifications through the same channels the trajectory and budget
+// alerts use. The notifier may be nil (notifications are then skipped).
+type ReplanSink struct {
+	srv      *Server
+	notifier *notify.Notifier
+}
+
+// NewReplanSink builds the adapter.
+func NewReplanSink(srv *Server, notifier *notify.Notifier) *ReplanSink {
+	return &ReplanSink{srv: srv, notifier: notifier}
+}
+
+// Audit records a replan decision in the audit log.
+func (r *ReplanSink) Audit(actor, action, detail, agent string) {
+	r.srv.AuditLog(actor, action, detail, agent)
+}
+
+// Alert raises (or updates) a dashboard system alert.
+func (r *ReplanSink) Alert(id, severity, message string) {
+	r.srv.AddSystemAlert(id, severity, message)
+}
+
+// Notify sends a high-priority notification when a notifier is configured.
+func (r *ReplanSink) Notify(title, message string) {
+	if r.notifier != nil {
+		r.notifier.Send(title, message, notify.PriorityHigh)
+	}
+}

--- a/v2/pkg/dashboard/replan_sink_test.go
+++ b/v2/pkg/dashboard/replan_sink_test.go
@@ -1,0 +1,39 @@
+package dashboard
+
+import (
+	"log/slog"
+	"testing"
+)
+
+func TestReplanSink(t *testing.T) {
+	srv := NewServer(0, slog.Default())
+	// nil notifier → Notify is a safe no-op.
+	sink := NewReplanSink(srv, nil)
+
+	sink.Audit("planning", "replan", "epic e1 replanned", "architect")
+	sink.Alert("plan-stall-e1", "warning", "e1 stalled")
+	sink.Notify("Plan replan", "e1 replanned") // must not panic with nil notifier
+
+	entries := srv.GetAudit().Recent(10)
+	found := false
+	for _, e := range entries {
+		if e.Action == "replan" && e.Agent == "architect" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("replan audit entry not recorded: %+v", entries)
+	}
+
+	srv.systemAlertsMu.RLock()
+	defer srv.systemAlertsMu.RUnlock()
+	var alerted bool
+	for _, a := range srv.systemAlerts {
+		if a.ID == "plan-stall-e1" && a.Severity == "warning" {
+			alerted = true
+		}
+	}
+	if !alerted {
+		t.Errorf("replan alert not raised: %+v", srv.systemAlerts)
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -319,8 +319,9 @@ type FrontendPlanning struct {
 	// Decomposing counts approved plans that still have open (unfinished)
 	// children — plans actively being executed by agents.
 	Decomposing int `json:"decomposing"`
-	// Replans24h counts plans re-decomposed in the last 24h. Phase 3 (governor
-	// stall-replan) populates this; it is 0 for now.
+	// Replans24h counts plans re-decomposed in the last 24h by the Phase 3
+	// governor stall-replan loop, derived from each epic's last_replan_at
+	// metadata.
 	Replans24h int `json:"replans_24h"`
 }
 

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -798,10 +798,18 @@ func buildBeads(stores map[string]*beads.Store) FrontendBeads {
 // BuildPlanning computes the governor PLANNING metric block from bead metadata
 // across all stores (Phase 2 planning intelligence). An epic is "active" once it
 // carries a plan_status; "awaiting review" while that status is draft; and
-// "decomposing" (executing) when approved with at least one open child.
-// Replans24h is Phase 3 territory and stays 0.
+// "decomposing" (executing) when approved with at least one open child. Replans24h
+// (Phase 3) counts epics whose last_replan_at metadata falls within the last 24h,
+// so the tile reflects real governor stall-replans purely from bead state.
 func BuildPlanning(stores map[string]*beads.Store) FrontendPlanning {
+	return buildPlanningAt(stores, time.Now())
+}
+
+// buildPlanningAt is BuildPlanning with an injected `now`, so the replans_24h
+// window is unit-testable with backdated last_replan_at timestamps.
+func buildPlanningAt(stores map[string]*beads.Store, now time.Time) FrontendPlanning {
 	fp := FrontendPlanning{}
+	cutoff := now.Add(-planningReplanWindow)
 	for _, store := range stores {
 		all := store.List(beads.ListFilter{})
 
@@ -833,10 +841,19 @@ func BuildPlanning(stores map[string]*beads.Store) FrontendPlanning {
 					fp.Decomposing++
 				}
 			}
+			if raw := b.Meta(planning.MetaLastReplanAt); raw != "" {
+				if t, err := time.Parse(time.RFC3339, raw); err == nil && t.After(cutoff) {
+					fp.Replans24h++
+				}
+			}
 		}
 	}
 	return fp
 }
+
+// planningReplanWindow is the trailing window over which replans_24h counts
+// re-decomposed plans (matches the tile label "24h").
+const planningReplanWindow = 24 * time.Hour
 
 // BuildBeadsFromConfig uses agent config bead_role to partition bead counts.
 func BuildBeadsFromConfig(stores map[string]*beads.Store, cfg *config.Config) FrontendBeads {

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -696,7 +696,7 @@
             </tr>
             <tr>
               <td class="cap">Auto plan decomposition + plan review</td>
-              <td class="hive-col"><span class="c-part">Partial</span><span class="c-note">Ideation only &mdash; on the roadmap</span></td>
+              <td class="hive-col"><span class="c-yes">&#10003;</span><span class="c-note">Decompose &rarr; review gate &rarr; stall-replan</span></td>
               <td><span class="c-part">Spec/plan</span></td>
               <td><span class="c-yes">&#10003;</span><span class="c-note">Interactive Planning</span></td>
               <td><span class="c-yes">&#10003;</span><span class="c-note">Work breakdown</span></td>
@@ -705,7 +705,7 @@
         </table>
       </div>
       <p class="compare-legend"><span class="c-yes">&#10003;</span> yes &nbsp;&middot;&nbsp; <span class="c-part">partial</span> &nbsp;&middot;&nbsp; <span class="c-no">&#10007;</span> no. Competitor rows reflect each vendor&rsquo;s public documentation as of 2026; comparisons are our own.</p>
-      <p class="compare-foot">Being honest about the one gap: general-purpose <strong>plan decomposition with a review-before-execution gate</strong> is where the field &mdash; Devin, Planner, and others &mdash; is ahead today. Hive already does it for project ideation and has the ledger to generalize it. Everywhere else, Hive is the option you own outright.</p>
+      <p class="compare-foot">Hive now closes what used to be the one gap: general-purpose <strong>plan decomposition with a review-before-execution gate</strong>. It breaks an epic into an ordered sub-task DAG, holds it behind a human plan-review gate, and &mdash; when an approved plan stalls &mdash; detects the stall and re-kicks the architect to revise it, bounded by a per-plan replan cap. Devin, Planner, and others plan; Hive plans, reviews, and self-corrects &mdash; and it&rsquo;s the option you own outright.</p>
     </section>
 
     <!-- ── Get started ── -->

--- a/v2/pkg/planning/replan.go
+++ b/v2/pkg/planning/replan.go
@@ -1,0 +1,237 @@
+package planning
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/beads"
+)
+
+// This file implements Phase 3 bounded replanning and the eval-loop lane that
+// drives it. The pure stall detector lives in stall.go; here we turn a detected
+// stall into a bounded, reversible action:
+//
+//   - under the cap: re-kick the architect to revise the stalled plan, record
+//     the replan (replan_count++, last_replan_at=now), and audit/alert/notify;
+//   - at the cap: stop replanning and raise a "needs human" escalation.
+//
+// SAFETY (launch-path mutex): this lane runs on the governor eval tick, exactly
+// like the existing kick machinery. It NEVER touches agent.Manager's internal
+// mutex — it drives the architect only through the Kicker interface (backed by
+// the manager's already-lock-safe SendKick, the same call runEvalCycle uses).
+// Run takes a context.Context; the caller gates it with Due() so it is a plain
+// synchronous call on the tick, adding NO new goroutine.
+
+// architectAgent is the agent name the planner/replanner drives. It matches the
+// architect lane used by Phase 1 decomposition.
+const architectAgent = "architect"
+
+// Kicker drives an agent out-of-band. The agent manager satisfies it via
+// SendKick, which takes the manager lock ITSELF and is called from the governor
+// tick — never from the agent-launch path — so no re-entrant lock is possible.
+// Keeping this an interface also keeps pkg/planning free of an import cycle and
+// unit-testable with a fake.
+type Kicker interface {
+	// Kick delivers message to the named agent. It must be safe to call from
+	// the governor goroutine.
+	Kick(agent, message string) error
+}
+
+// KickRecorder records that an agent was kicked (for governor kick history /
+// cadence accounting). The governor satisfies it via RecordKick.
+type KickRecorder interface {
+	RecordKick(agent string)
+}
+
+// Sink records the replan lane's decisions through the same channels the
+// trajectory/budget alerts use (audit log, system alert, notification). The
+// dashboard implements it. All methods must be safe to call from the governor
+// goroutine, and any may be a no-op if the underlying sink is absent.
+type Sink interface {
+	Audit(actor, action, detail, agent string)
+	Alert(id, severity, message string)
+	Notify(title, message string)
+}
+
+// ReplanLaneConfig configures the replan lane.
+type ReplanLaneConfig struct {
+	// IntervalS is the minimum seconds between lane runs. The governor tick
+	// gates on Due(), so this floors the cadence at (but never below) the tick.
+	// Zero means DefaultReplanIntervalS.
+	IntervalS int
+	// Stall tunes the stall detector (threshold + replan cap).
+	Stall StallConfig
+}
+
+// DefaultReplanIntervalS is the default replan-lane cadence: 30 minutes. Stall
+// detection is expensive-ish (it re-kicks agents) and stalls evolve slowly, so
+// it runs far less often than the governor tick.
+const DefaultReplanIntervalS = 30 * 60
+
+// replanAlertPrefix namespaces the lane's dashboard system alerts by epic.
+const replanAlertPrefix = "plan-stall-"
+
+// ReplanLane runs periodic stall detection + bounded replanning over every bead
+// store. It mirrors trajectory.Lane's shape: a Due()-gated, synchronous Run the
+// governor tick calls; no goroutine of its own.
+type ReplanLane struct {
+	stores   map[string]*beads.Store
+	kicker   Kicker
+	recorder KickRecorder
+	sink     Sink
+	logger   *slog.Logger
+	interval time.Duration
+	stallCfg StallConfig
+	lastRun  time.Time
+}
+
+// NewReplanLane builds the lane. stores is the same per-agent store map the
+// dashboard/governor use. kicker and recorder drive/record the architect
+// re-kick; either may be nil (the lane then only detects + accounts + alerts,
+// without kicking — useful in tests and safe by construction). sink may be nil
+// (decisions are then only logged).
+func NewReplanLane(stores map[string]*beads.Store, kicker Kicker, recorder KickRecorder, sink Sink, cfg ReplanLaneConfig, logger *slog.Logger) *ReplanLane {
+	intervalS := cfg.IntervalS
+	if intervalS <= 0 {
+		intervalS = DefaultReplanIntervalS
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &ReplanLane{
+		stores:   stores,
+		kicker:   kicker,
+		recorder: recorder,
+		sink:     sink,
+		logger:   logger,
+		interval: time.Duration(intervalS) * time.Second,
+		stallCfg: cfg.Stall,
+	}
+}
+
+// Due reports whether enough time has elapsed since the last run for the lane to
+// run again at time now. The governor tick gates on this so the lane's cadence
+// is independent of, but floored by, the governor interval — exactly like
+// trajectory.Lane.Due.
+func (l *ReplanLane) Due(now time.Time) bool {
+	return l.lastRun.IsZero() || now.Sub(l.lastRun) >= l.interval
+}
+
+// Run detects stalled plans across every store once and acts on each, bounded by
+// the replan cap. It is synchronous and adds no goroutine; the caller runs it
+// from the governor tick after Due() returns true. Returns the number of replans
+// performed (for logging/tests).
+func (l *ReplanLane) Run(ctx context.Context) int {
+	l.lastRun = time.Now()
+	now := l.lastRun
+	replans := 0
+	for storeName, store := range l.stores {
+		snap := SnapshotFromStore(store)
+		stalled := DetectStalledPlans(snap, now, l.stallCfg)
+		for _, sp := range stalled {
+			if ctx.Err() != nil {
+				return replans // shutting down; stop cleanly
+			}
+			if l.handleStall(store, storeName, sp, now) {
+				replans++
+			}
+		}
+	}
+	return replans
+}
+
+// handleStall applies the bounded-replan decision to one stalled plan. Returns
+// true when a replan was performed (as opposed to a cap escalation or a
+// bookkeeping failure).
+func (l *ReplanLane) handleStall(store *beads.Store, storeName string, sp StalledPlan, now time.Time) bool {
+	alertID := replanAlertPrefix + sp.EpicID
+
+	if sp.CapReached {
+		// Cap exhausted — stop replanning, escalate to a human. Reversible: a
+		// human can edit the plan and RejectPlan/ApprovePlan to reset the loop;
+		// the cap does not touch bead state.
+		msg := fmt.Sprintf("plan %q stalled for %s and hit the replan cap (%d) — needs human review",
+			sp.EpicTitle, roundDur(sp.StalledFor), l.stallCfg.maxReplans())
+		l.emit(alertID, "error", "replan-cap", msg, sp.EpicID)
+		l.logger.Warn("audit: plan replan cap reached",
+			"store", storeName, "epic", sp.EpicID, "replan_count", sp.ReplanCount, "stalled_for", sp.StalledFor.String())
+		return false
+	}
+
+	// Under the cap — record the replan first (increment count + stamp time) so
+	// the accounting is durable even if the kick fails. This is the minimal,
+	// reversible mutation: two metadata writes on the epic.
+	next := sp.ReplanCount + 1
+	if err := store.SetMetadata(sp.EpicID, MetaReplanCount, strconv.Itoa(next)); err != nil {
+		l.logger.Warn("replan: bumping replan_count failed", "epic", sp.EpicID, "err", err.Error())
+		return false
+	}
+	if err := store.SetMetadata(sp.EpicID, MetaLastReplanAt, now.UTC().Format(time.RFC3339)); err != nil {
+		l.logger.Warn("replan: stamping last_replan_at failed", "epic", sp.EpicID, "err", err.Error())
+		// Non-fatal: the count is already bumped; continue to kick + audit.
+	}
+
+	// Re-kick the architect to revise the stalled plan. This is the safe,
+	// minimal first cut: a stateless kick with a "this plan stalled, revise the
+	// approach" prompt naming the unfinished children, reusing the existing kick
+	// machinery. It does NOT synchronously drive tmux and never touches the
+	// manager lock from the launch path — SendKick (behind Kicker) takes its own
+	// lock from this governor-tick call, exactly like every other kick.
+	if l.kicker != nil {
+		if err := l.kicker.Kick(architectAgent, buildReplanPrompt(sp)); err != nil {
+			l.logger.Warn("replan: architect kick failed", "epic", sp.EpicID, "err", err.Error())
+			// Count is already bumped (avoids thrashing a failing kick); surface
+			// the failure but still treat this cycle as a replan attempt.
+		} else if l.recorder != nil {
+			l.recorder.RecordKick(architectAgent)
+		}
+	}
+
+	msg := fmt.Sprintf("plan %q stalled for %s with %d unfinished task(s) — re-kicked architect to revise (replan %d/%d)",
+		sp.EpicTitle, roundDur(sp.StalledFor), len(sp.Remaining), next, l.stallCfg.maxReplans())
+	l.emit(alertID, "warning", "replan", msg, sp.EpicID)
+	l.logger.Info("audit: plan replanned",
+		"store", storeName, "epic", sp.EpicID, "replan_count", next, "remaining", len(sp.Remaining))
+	return true
+}
+
+// emit fans a decision out to audit log, system alert, and notification through
+// the sink (if configured).
+func (l *ReplanLane) emit(alertID, severity, action, message, epicID string) {
+	if l.sink == nil {
+		return
+	}
+	l.sink.Audit("planning", action, message, architectAgent)
+	l.sink.Alert(alertID, severity, message)
+	l.sink.Notify("Plan "+action, message)
+	_ = epicID
+}
+
+// buildReplanPrompt renders the "revise the stalled approach" prompt for the
+// architect, naming the unfinished children so it can re-plan the remaining
+// work rather than starting over.
+func buildReplanPrompt(sp StalledPlan) string {
+	msg := "[agent:architect]\n" +
+		"A plan you decomposed has STALLED — its sub-tasks have not progressed for " +
+		roundDur(sp.StalledFor).String() + ".\n\n" +
+		"EPIC: " + sp.EpicTitle + " (" + sp.EpicID + ")\n" +
+		"UNFINISHED SUB-TASKS:\n"
+	for _, c := range sp.Remaining {
+		msg += "  - [" + string(c.Status) + "] " + c.Title + "\n"
+	}
+	msg += "\nRevise the approach for the UNFINISHED work only: identify the blocker, " +
+		"and either break the stuck task(s) down further or propose an alternative path. " +
+		"Do NOT re-plan the completed sub-tasks. Output only the revised plan.\n"
+	return msg
+}
+
+// roundDur rounds a duration to the minute for human-readable messages.
+func roundDur(d time.Duration) time.Duration {
+	if d < time.Minute {
+		return d.Round(time.Second)
+	}
+	return d.Round(time.Minute)
+}

--- a/v2/pkg/planning/replan_test.go
+++ b/v2/pkg/planning/replan_test.go
@@ -1,0 +1,329 @@
+package planning
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/beads"
+)
+
+// fakeKicker records kicks and can be made to fail.
+type fakeKicker struct {
+	kicks []struct{ agent, msg string }
+	fail  bool
+}
+
+func (f *fakeKicker) Kick(agent, message string) error {
+	f.kicks = append(f.kicks, struct{ agent, msg string }{agent, message})
+	if f.fail {
+		return errFake
+	}
+	return nil
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+const errFake = errString("kick failed")
+
+// fakeRecorder records RecordKick calls.
+type fakeRecorder struct{ kicked []string }
+
+func (f *fakeRecorder) RecordKick(agent string) { f.kicked = append(f.kicked, agent) }
+
+// fakeSink captures sink calls.
+type fakeSink struct {
+	audits  []string
+	alerts  []struct{ id, sev, msg string }
+	notifys int
+}
+
+func (f *fakeSink) Audit(actor, action, detail, agent string) {
+	f.audits = append(f.audits, action)
+}
+func (f *fakeSink) Alert(id, severity, message string) {
+	f.alerts = append(f.alerts, struct{ id, sev, msg string }{id, severity, message})
+}
+func (f *fakeSink) Notify(title, message string) { f.notifys++ }
+
+// setupStalledPlan creates an approved epic with one open child whose activity
+// is backdated so the plan reads as stalled. Returns the epic ID.
+func setupStalledPlan(t *testing.T, store *beads.Store, replans string) string {
+	t.Helper()
+	epic := mustEpic(t, store, "Stalled epic")
+	if err := store.SetMetadata(epic.ID, MetaPlanStatus, PlanStatusApproved); err != nil {
+		t.Fatal(err)
+	}
+	if replans != "" {
+		if err := store.SetMetadata(epic.ID, MetaReplanCount, replans); err != nil {
+			t.Fatal(err)
+		}
+	}
+	child, err := store.Create("stuck task", beads.TypeTask, beads.PriorityMedium, "worker", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(child.ID, MetaParentEpic, epic.ID); err != nil {
+		t.Fatal(err)
+	}
+	return epic.ID
+}
+
+// oldStall is a threshold small enough that any real store timestamp (now)
+// counts as stalled when we detect at a time far in the future.
+func farFuture() time.Time { return time.Now().Add(48 * time.Hour) }
+
+func newTestLane(store *beads.Store, k Kicker, r KickRecorder, s Sink) *ReplanLane {
+	return NewReplanLane(
+		map[string]*beads.Store{"main": store},
+		k, r, s,
+		ReplanLaneConfig{IntervalS: 1, Stall: StallConfig{StallThreshold: time.Hour, MaxReplans: 3}},
+		nil,
+	)
+}
+
+func TestReplanLane_UnderCap_KicksAndAccounts(t *testing.T) {
+	store := newStore(t)
+	epicID := setupStalledPlan(t, store, "1")
+	k, r, s := &fakeKicker{}, &fakeRecorder{}, &fakeSink{}
+	lane := newTestLane(store, k, r, s)
+	lane.lastRun = farFuture().Add(-48 * time.Hour) // ensure Due
+
+	// Force detection to see the plan as stalled by running "now" in the future.
+	// Run() uses time.Now(); the store child was just created (now), threshold 1h,
+	// so it is NOT yet stalled. Drive the pure path directly to assert the mutation
+	// deterministically, then also exercise Run for the no-op branch.
+	snap := SnapshotFromStore(store)
+	stalled := DetectStalledPlans(snap, farFuture(), lane.stallCfg)
+	if len(stalled) != 1 {
+		t.Fatalf("expected 1 stalled plan, got %d", len(stalled))
+	}
+	if !lane.handleStall(store, "main", stalled[0], farFuture()) {
+		t.Fatal("handleStall should report a replan under cap")
+	}
+
+	// replan_count bumped 1 → 2, last_replan_at stamped.
+	got, _ := store.Get(epicID)
+	if got.Meta(MetaReplanCount) != "2" {
+		t.Errorf("replan_count = %q, want 2", got.Meta(MetaReplanCount))
+	}
+	if got.Meta(MetaLastReplanAt) == "" {
+		t.Error("last_replan_at not stamped")
+	}
+	if len(k.kicks) != 1 || k.kicks[0].agent != architectAgent {
+		t.Errorf("architect not kicked: %+v", k.kicks)
+	}
+	if !strings.Contains(k.kicks[0].msg, "STALLED") {
+		t.Errorf("kick prompt missing stall framing: %q", k.kicks[0].msg)
+	}
+	if len(r.kicked) != 1 {
+		t.Errorf("RecordKick not called: %+v", r.kicked)
+	}
+	if s.notifys != 1 || len(s.alerts) != 1 || s.alerts[0].sev != "warning" {
+		t.Errorf("sink not driven correctly: alerts=%+v notifys=%d", s.alerts, s.notifys)
+	}
+}
+
+func TestReplanLane_AtCap_EscalatesNoKick(t *testing.T) {
+	store := newStore(t)
+	epicID := setupStalledPlan(t, store, "3") // == MaxReplans
+	k, r, s := &fakeKicker{}, &fakeRecorder{}, &fakeSink{}
+	lane := newTestLane(store, k, r, s)
+
+	snap := SnapshotFromStore(store)
+	stalled := DetectStalledPlans(snap, farFuture(), lane.stallCfg)
+	if len(stalled) != 1 || !stalled[0].CapReached {
+		t.Fatalf("expected cap-reached stall, got %+v", stalled)
+	}
+	if lane.handleStall(store, "main", stalled[0], farFuture()) {
+		t.Fatal("handleStall should NOT report a replan at cap")
+	}
+	// No kick, no count bump.
+	if len(k.kicks) != 0 {
+		t.Errorf("should not kick at cap, got %+v", k.kicks)
+	}
+	got, _ := store.Get(epicID)
+	if got.Meta(MetaReplanCount) != "3" {
+		t.Errorf("replan_count changed at cap: %q", got.Meta(MetaReplanCount))
+	}
+	if len(s.alerts) != 1 || s.alerts[0].sev != "error" {
+		t.Errorf("cap escalation should raise an error alert: %+v", s.alerts)
+	}
+	if !strings.Contains(s.alerts[0].msg, "replan cap") {
+		t.Errorf("cap alert message unexpected: %q", s.alerts[0].msg)
+	}
+}
+
+func TestReplanLane_KickFailure_StillAccounts(t *testing.T) {
+	store := newStore(t)
+	epicID := setupStalledPlan(t, store, "0")
+	k, r, s := &fakeKicker{fail: true}, &fakeRecorder{}, &fakeSink{}
+	lane := newTestLane(store, k, r, s)
+
+	snap := SnapshotFromStore(store)
+	stalled := DetectStalledPlans(snap, farFuture(), lane.stallCfg)
+	if !lane.handleStall(store, "main", stalled[0], farFuture()) {
+		t.Fatal("a failed kick still counts as a replan attempt")
+	}
+	got, _ := store.Get(epicID)
+	if got.Meta(MetaReplanCount) != "1" {
+		t.Errorf("replan_count should bump even on kick failure: %q", got.Meta(MetaReplanCount))
+	}
+	// RecordKick is NOT called when the kick itself failed.
+	if len(r.kicked) != 0 {
+		t.Errorf("RecordKick should be skipped on kick failure: %+v", r.kicked)
+	}
+}
+
+func TestReplanLane_NilKickerAndSink(t *testing.T) {
+	store := newStore(t)
+	epicID := setupStalledPlan(t, store, "0")
+	lane := NewReplanLane(map[string]*beads.Store{"m": store}, nil, nil, nil,
+		ReplanLaneConfig{IntervalS: 1, Stall: StallConfig{StallThreshold: time.Hour, MaxReplans: 3}}, nil)
+
+	snap := SnapshotFromStore(store)
+	stalled := DetectStalledPlans(snap, farFuture(), lane.stallCfg)
+	if !lane.handleStall(store, "m", stalled[0], farFuture()) {
+		t.Fatal("handleStall should still account with nil kicker/sink")
+	}
+	got, _ := store.Get(epicID)
+	if got.Meta(MetaReplanCount) != "1" {
+		t.Errorf("accounting must happen without a kicker: %q", got.Meta(MetaReplanCount))
+	}
+}
+
+func TestReplanLane_Run_NoStalls(t *testing.T) {
+	store := newStore(t)
+	setupStalledPlan(t, store, "0") // child just created → within threshold → not stalled
+	k := &fakeKicker{}
+	lane := newTestLane(store, k, &fakeRecorder{}, &fakeSink{})
+	if n := lane.Run(context.Background()); n != 0 {
+		t.Errorf("fresh plan should not replan, got %d", n)
+	}
+	if len(k.kicks) != 0 {
+		t.Errorf("no kicks expected: %+v", k.kicks)
+	}
+}
+
+func TestReplanLane_Run_CancelledContext(t *testing.T) {
+	store := newStore(t)
+	// Backdate is impossible via store, so make it stalled by shrinking threshold
+	// to 0 so a just-created child is already "stale".
+	setupStalledPlan(t, store, "0")
+	k := &fakeKicker{}
+	lane := NewReplanLane(map[string]*beads.Store{"m": store}, k, &fakeRecorder{}, &fakeSink{},
+		ReplanLaneConfig{IntervalS: 1, Stall: StallConfig{StallThreshold: time.Nanosecond, MaxReplans: 3}}, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled
+	if n := lane.Run(ctx); n != 0 {
+		t.Errorf("cancelled context should short-circuit, got %d replans", n)
+	}
+}
+
+func TestReplanLane_Run_PerformsReplan(t *testing.T) {
+	store := newStore(t)
+	setupStalledPlan(t, store, "0")
+	k, r, s := &fakeKicker{}, &fakeRecorder{}, &fakeSink{}
+	// Threshold of 0/nanosecond so the just-created child reads as stalled at now.
+	lane := NewReplanLane(map[string]*beads.Store{"m": store}, k, r, s,
+		ReplanLaneConfig{IntervalS: 1, Stall: StallConfig{StallThreshold: time.Nanosecond, MaxReplans: 3}}, nil)
+	time.Sleep(2 * time.Millisecond) // ensure now-updatedAt > threshold
+	if n := lane.Run(context.Background()); n != 1 {
+		t.Fatalf("expected 1 replan, got %d", n)
+	}
+	if len(k.kicks) != 1 {
+		t.Errorf("architect should be kicked once: %+v", k.kicks)
+	}
+}
+
+func TestReplanLane_Due(t *testing.T) {
+	lane := NewReplanLane(nil, nil, nil, nil, ReplanLaneConfig{IntervalS: 3600}, nil)
+	if !lane.Due(time.Now()) {
+		t.Error("zero lastRun should be Due")
+	}
+	lane.lastRun = time.Now()
+	if lane.Due(time.Now()) {
+		t.Error("just-ran lane should not be Due")
+	}
+	if !lane.Due(time.Now().Add(2 * time.Hour)) {
+		t.Error("lane should be Due after the interval elapses")
+	}
+}
+
+func TestNewReplanLane_Defaults(t *testing.T) {
+	lane := NewReplanLane(nil, nil, nil, nil, ReplanLaneConfig{}, nil)
+	if lane.interval != DefaultReplanIntervalS*time.Second {
+		t.Errorf("default interval = %v, want %v", lane.interval, DefaultReplanIntervalS*time.Second)
+	}
+	if lane.logger == nil {
+		t.Error("nil logger should default to slog.Default()")
+	}
+}
+
+func TestBuildReplanPrompt_ListsRemaining(t *testing.T) {
+	sp := StalledPlan{
+		EpicID:     "e1",
+		EpicTitle:  "My Epic",
+		StalledFor: 3 * time.Hour,
+		Remaining: []SnapBead{
+			{Title: "task one", Status: beads.StatusOpen},
+			{Title: "task two", Status: beads.StatusBlocked},
+		},
+	}
+	p := buildReplanPrompt(sp)
+	for _, want := range []string{"My Epic", "e1", "task one", "task two", "[open]", "[blocked]", "UNFINISHED"} {
+		if !strings.Contains(p, want) {
+			t.Errorf("prompt missing %q:\n%s", want, p)
+		}
+	}
+}
+
+// TestReplanLane_AccountingWriteFails exercises the replan_count SetMetadata
+// error path (a persistence failure), where handleStall must NOT kick and must
+// report no replan. Skipped as root (root bypasses filesystem permissions).
+func TestReplanLane_AccountingWriteFails(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; filesystem permission enforcement is bypassed")
+	}
+	dir := t.TempDir()
+	store, err := beads.NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	epicID := setupStalledPlan(t, store, "0")
+	_ = epicID
+	k := &fakeKicker{}
+	lane := newTestLane(store, k, &fakeRecorder{}, &fakeSink{})
+
+	snap := SnapshotFromStore(store)
+	stalled := DetectStalledPlans(snap, farFuture(), lane.stallCfg)
+	if len(stalled) != 1 {
+		t.Fatalf("want 1 stalled, got %d", len(stalled))
+	}
+
+	// Make the store dir read-only so the replan_count persist fails.
+	if err := os.Chmod(dir, 0500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+
+	if lane.handleStall(store, "main", stalled[0], farFuture()) {
+		t.Error("handleStall should report no replan when accounting write fails")
+	}
+	if len(k.kicks) != 0 {
+		t.Errorf("must not kick when accounting failed: %+v", k.kicks)
+	}
+}
+
+func TestRoundDur(t *testing.T) {
+	if got := roundDur(90 * time.Second); got != 2*time.Minute {
+		t.Errorf("roundDur(90s) = %v, want 2m", got)
+	}
+	if got := roundDur(45 * time.Second); got != 45*time.Second {
+		t.Errorf("sub-minute should round to seconds, got %v", got)
+	}
+}

--- a/v2/pkg/planning/stall.go
+++ b/v2/pkg/planning/stall.go
@@ -1,0 +1,250 @@
+package planning
+
+import (
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/beads"
+)
+
+// This file implements Phase 3 stall detection: the PURE, unit-testable core
+// that finds approved plans whose execution has stalled. It has NO goroutines,
+// NO agent/tmux dependency, and NO governor coupling — it operates entirely on a
+// point-in-time snapshot of beads plus an injected `now`, so it can be tested
+// with backdated timestamps. The eval-loop wiring (cadence, kicks, alerts) lives
+// in replan.go / the ReplanLane and in cmd/hive/main.go.
+
+// MetaReplanCount on an epic records how many times its plan has been
+// re-decomposed / re-kicked by the stall-replan loop. It is a decimal string
+// ("0", "1", ...). Absent means zero. It is capped by MaxReplans.
+const MetaReplanCount = "replan_count"
+
+// MetaLastReplanAt on an epic records the RFC3339 timestamp of the most recent
+// replan. BuildPlanning reads it to compute replans_24h purely from bead
+// metadata (no in-memory governor state needed).
+const MetaLastReplanAt = "last_replan_at"
+
+// MaxReplans caps how many times a single plan may be replanned before the loop
+// stops and escalates to a human. It mirrors inception's maxKickRetries=5 so a
+// stalled plan cannot thrash the architect indefinitely.
+const MaxReplans = 5
+
+// DefaultStallThreshold is the default age (since a plan last made progress)
+// beyond which an approved plan with unfinished children is considered stalled.
+// It is deliberately generous: a plan must be quiet for a while before we spend
+// tokens re-kicking the architect.
+const DefaultStallThreshold = 6 * time.Hour
+
+// StallConfig tunes stall detection. The zero value is valid: it falls back to
+// DefaultStallThreshold and MaxReplans.
+type StallConfig struct {
+	// StallThreshold is how long a plan may go without progress (no child
+	// closing and no child update) before it is reported stalled. Zero means
+	// DefaultStallThreshold.
+	StallThreshold time.Duration
+	// MaxReplans caps replans per epic. Zero means MaxReplans (the package
+	// default). A plan already at or past the cap is still reported (so the
+	// caller can escalate), with CapReached=true.
+	MaxReplans int
+}
+
+func (c StallConfig) threshold() time.Duration {
+	if c.StallThreshold > 0 {
+		return c.StallThreshold
+	}
+	return DefaultStallThreshold
+}
+
+func (c StallConfig) maxReplans() int {
+	if c.MaxReplans > 0 {
+		return c.MaxReplans
+	}
+	return MaxReplans
+}
+
+// SnapBead is one bead in a stall-detection snapshot. It carries only the fields
+// stall detection reads, with EXPORTED time fields so tests can construct
+// snapshots with arbitrary (backdated) timestamps without touching the beads
+// package's unexported time wrapper. SnapshotFromStore builds these from a live
+// store in production.
+type SnapBead struct {
+	ID          string
+	Title       string
+	Type        beads.BeadType
+	Status      beads.Status
+	ParentEpic  string // parent_epic metadata ("" for non-children)
+	PlanStatus  string // plan_status metadata (epics only)
+	ReplanCount int    // replan_count metadata parsed to int (epics only)
+	// UpdatedAt is the bead's last-update time.
+	UpdatedAt time.Time
+	// ClosedAt is the bead's close time, or the zero Time if still open.
+	ClosedAt time.Time
+}
+
+// StalledPlan describes one approved plan whose execution has stalled. Remaining
+// holds the still-open (or blocked) children — the unfinished work the caller
+// may re-decompose or re-kick.
+type StalledPlan struct {
+	// EpicID is the stalled epic's bead ID.
+	EpicID string
+	// EpicTitle is the stalled epic's title.
+	EpicTitle string
+	// Remaining are the epic's children that are still open, in-progress, or
+	// blocked (the unfinished work).
+	Remaining []SnapBead
+	// ReplanCount is the epic's replan_count BEFORE this detection cycle.
+	ReplanCount int
+	// CapReached is true when ReplanCount has already reached the configured
+	// cap; the caller must escalate rather than replan again.
+	CapReached bool
+	// StalledFor is how long the plan has gone without progress at detection
+	// time (now minus the most recent child activity).
+	StalledFor time.Duration
+}
+
+// SnapshotFromStore extracts a stall-detection snapshot from a live beads store.
+// It reads only the fields DetectStalledPlans needs. This is the ONLY place that
+// touches the store; DetectStalledPlans itself stays pure over the snapshot.
+func SnapshotFromStore(store *beads.Store) []SnapBead {
+	if store == nil {
+		return nil
+	}
+	all := store.List(beads.ListFilter{})
+	out := make([]SnapBead, 0, len(all))
+	for _, b := range all {
+		sb := SnapBead{
+			ID:         b.ID,
+			Title:      b.Title,
+			Type:       b.Type,
+			Status:     b.Status,
+			ParentEpic: b.Meta(MetaParentEpic),
+			PlanStatus: b.Meta(MetaPlanStatus),
+			UpdatedAt:  b.UpdatedAt.Time,
+		}
+		if b.ClosedAt != nil {
+			sb.ClosedAt = b.ClosedAt.Time
+		}
+		sb.ReplanCount = parseReplanCount(b.Meta(MetaReplanCount))
+		out = append(out, sb)
+	}
+	return out
+}
+
+// childActive reports whether a child bead still represents unfinished work
+// (open, in-progress, or blocked). Done/closed children are finished.
+func childActive(s beads.Status) bool {
+	switch s {
+	case beads.StatusOpen, beads.StatusInProgress, beads.StatusBlocked:
+		return true
+	default:
+		return false
+	}
+}
+
+// DetectStalledPlans finds approved plans whose execution has stalled as of
+// `now`. A plan is stalled when ALL of:
+//
+//  1. the epic's plan_status is approved (a draft plan is gated, not stalled);
+//  2. at least one child is still active (open/in_progress/blocked) — a fully
+//     completed plan is done, not stalled;
+//  3. no child has made progress within cfg.StallThreshold — "progress" is the
+//     most recent child ClosedAt (a child finishing) or UpdatedAt (a child being
+//     worked). If the whole child set has been quiet longer than the threshold,
+//     the plan is stalled.
+//
+// It is a PURE function: no I/O, no goroutines, no store access. Callers pass a
+// snapshot (SnapshotFromStore) and the current time. Determinism makes it fully
+// table-testable with backdated timestamps.
+func DetectStalledPlans(snap []SnapBead, now time.Time, cfg StallConfig) []StalledPlan {
+	threshold := cfg.threshold()
+	cap := cfg.maxReplans()
+
+	// Index approved epics and bucket active children by parent.
+	approvedEpics := make(map[string]SnapBead)
+	for _, b := range snap {
+		if b.Type == beads.TypeEpic && b.PlanStatus == PlanStatusApproved {
+			approvedEpics[b.ID] = b
+		}
+	}
+	if len(approvedEpics) == 0 {
+		return nil
+	}
+
+	type acc struct {
+		active     []SnapBead
+		lastActive time.Time // most recent activity across ALL children
+	}
+	byEpic := make(map[string]*acc, len(approvedEpics))
+	for _, b := range snap {
+		if b.ParentEpic == "" {
+			continue
+		}
+		if _, ok := approvedEpics[b.ParentEpic]; !ok {
+			continue // child of a non-approved (or missing) epic
+		}
+		a := byEpic[b.ParentEpic]
+		if a == nil {
+			a = &acc{}
+			byEpic[b.ParentEpic] = a
+		}
+		// Track the most recent activity of ANY child (closed or updated).
+		if b.ClosedAt.After(a.lastActive) {
+			a.lastActive = b.ClosedAt
+		}
+		if b.UpdatedAt.After(a.lastActive) {
+			a.lastActive = b.UpdatedAt
+		}
+		if childActive(b.Status) {
+			a.active = append(a.active, b)
+		}
+	}
+
+	var out []StalledPlan
+	for epicID, epic := range approvedEpics {
+		a := byEpic[epicID]
+		if a == nil || len(a.active) == 0 {
+			continue // no children at all, or all children finished
+		}
+		// A plan with no recorded activity (lastActive zero) but active children
+		// is treated as stalled from the epic's own update time is not available
+		// here; the child snapshot always carries an UpdatedAt, so lastActive is
+		// non-zero whenever children exist.
+		stalledFor := now.Sub(a.lastActive)
+		if stalledFor < threshold {
+			continue // still making progress within the window
+		}
+		out = append(out, StalledPlan{
+			EpicID:      epicID,
+			EpicTitle:   epic.Title,
+			Remaining:   a.active,
+			ReplanCount: epic.ReplanCount,
+			CapReached:  epic.ReplanCount >= cap,
+			StalledFor:  stalledFor,
+		})
+	}
+
+	// Deterministic order (by epic ID) so callers and tests see a stable list.
+	sortStalledByID(out)
+	return out
+}
+
+// sortStalledByID sorts stalled plans by epic ID for deterministic output.
+func sortStalledByID(sp []StalledPlan) {
+	for i := 1; i < len(sp); i++ {
+		for j := i; j > 0 && sp[j-1].EpicID > sp[j].EpicID; j-- {
+			sp[j-1], sp[j] = sp[j], sp[j-1]
+		}
+	}
+}
+
+// parseReplanCount parses a replan_count metadata string to an int. A missing,
+// empty, or malformed value is zero.
+func parseReplanCount(s string) int {
+	n := 0
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0 // any non-digit → treat as unset/malformed
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n
+}

--- a/v2/pkg/planning/stall_test.go
+++ b/v2/pkg/planning/stall_test.go
@@ -1,0 +1,246 @@
+package planning
+
+import (
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/beads"
+)
+
+// baseTime is a fixed reference "now" for deterministic stall tests.
+var baseTime = time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+
+// epicSnap builds an approved (or draft) epic SnapBead.
+func epicSnap(id, title, planStatus string, replans int) SnapBead {
+	return SnapBead{
+		ID:          id,
+		Title:       title,
+		Type:        beads.TypeEpic,
+		Status:      beads.StatusInProgress,
+		PlanStatus:  planStatus,
+		ReplanCount: replans,
+		UpdatedAt:   baseTime.Add(-100 * time.Hour),
+	}
+}
+
+// childSnap builds a child SnapBead with an explicit last-activity time.
+func childSnap(id, parent string, status beads.Status, updated, closed time.Time) SnapBead {
+	return SnapBead{
+		ID:         id,
+		Title:      "child " + id,
+		Type:       beads.TypeTask,
+		Status:     status,
+		ParentEpic: parent,
+		UpdatedAt:  updated,
+		ClosedAt:   closed,
+	}
+}
+
+func TestDetectStalledPlans(t *testing.T) {
+	cfg := StallConfig{StallThreshold: 6 * time.Hour, MaxReplans: 5}
+	stale := baseTime.Add(-10 * time.Hour) // older than threshold
+	fresh := baseTime.Add(-1 * time.Hour)  // within threshold
+	var zero time.Time
+
+	tests := []struct {
+		name       string
+		snap       []SnapBead
+		wantEpics  []string // stalled epic IDs, in returned order
+		wantRemain map[string]int
+		wantCap    map[string]bool
+	}{
+		{
+			name:      "no approved epics — draft epic never stalls",
+			snap:      []SnapBead{epicSnap("e1", "E1", PlanStatusDraft, 0), childSnap("c1", "e1", beads.StatusOpen, stale, zero)},
+			wantEpics: nil,
+		},
+		{
+			name:      "empty snapshot",
+			snap:      nil,
+			wantEpics: nil,
+		},
+		{
+			name: "stalled under cap",
+			snap: []SnapBead{
+				epicSnap("e1", "E1", PlanStatusApproved, 1),
+				childSnap("c1", "e1", beads.StatusDone, stale, stale),
+				childSnap("c2", "e1", beads.StatusOpen, stale, zero),
+			},
+			wantEpics:  []string{"e1"},
+			wantRemain: map[string]int{"e1": 1},
+			wantCap:    map[string]bool{"e1": false},
+		},
+		{
+			name: "stalled at cap → CapReached",
+			snap: []SnapBead{
+				epicSnap("e1", "E1", PlanStatusApproved, 5),
+				childSnap("c1", "e1", beads.StatusBlocked, stale, zero),
+			},
+			wantEpics:  []string{"e1"},
+			wantRemain: map[string]int{"e1": 1},
+			wantCap:    map[string]bool{"e1": true},
+		},
+		{
+			name: "not stalled — recent child activity within window",
+			snap: []SnapBead{
+				epicSnap("e1", "E1", PlanStatusApproved, 0),
+				childSnap("c1", "e1", beads.StatusOpen, fresh, zero),
+			},
+			wantEpics: nil,
+		},
+		{
+			name: "not stalled — all children finished (no active child)",
+			snap: []SnapBead{
+				epicSnap("e1", "E1", PlanStatusApproved, 0),
+				childSnap("c1", "e1", beads.StatusDone, stale, stale),
+				childSnap("c2", "e1", beads.StatusClosed, stale, stale),
+			},
+			wantEpics: nil,
+		},
+		{
+			name:      "approved epic with no children at all",
+			snap:      []SnapBead{epicSnap("e1", "E1", PlanStatusApproved, 0)},
+			wantEpics: nil,
+		},
+		{
+			name: "child of a missing/non-approved parent is ignored",
+			snap: []SnapBead{
+				epicSnap("e1", "E1", PlanStatusApproved, 0),
+				childSnap("c1", "ghost", beads.StatusOpen, stale, zero), // parent not in snap
+				childSnap("c2", "e1", beads.StatusDone, stale, stale),   // e1 fully done
+			},
+			wantEpics: nil,
+		},
+		{
+			name: "one child recent keeps whole plan fresh",
+			snap: []SnapBead{
+				epicSnap("e1", "E1", PlanStatusApproved, 0),
+				childSnap("c1", "e1", beads.StatusOpen, stale, zero),
+				childSnap("c2", "e1", beads.StatusInProgress, fresh, zero), // recent activity
+			},
+			wantEpics: nil,
+		},
+		{
+			name: "two stalled epics returned sorted by ID",
+			snap: []SnapBead{
+				epicSnap("e2", "E2", PlanStatusApproved, 0),
+				childSnap("c2", "e2", beads.StatusOpen, stale, zero),
+				epicSnap("e1", "E1", PlanStatusApproved, 0),
+				childSnap("c1", "e1", beads.StatusOpen, stale, zero),
+			},
+			wantEpics:  []string{"e1", "e2"},
+			wantRemain: map[string]int{"e1": 1, "e2": 1},
+			wantCap:    map[string]bool{"e1": false, "e2": false},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DetectStalledPlans(tc.snap, baseTime, cfg)
+			if len(got) != len(tc.wantEpics) {
+				t.Fatalf("got %d stalled, want %d: %+v", len(got), len(tc.wantEpics), got)
+			}
+			for i, sp := range got {
+				if sp.EpicID != tc.wantEpics[i] {
+					t.Errorf("stalled[%d] epic = %q, want %q", i, sp.EpicID, tc.wantEpics[i])
+				}
+				if want, ok := tc.wantRemain[sp.EpicID]; ok && len(sp.Remaining) != want {
+					t.Errorf("%s remaining = %d, want %d", sp.EpicID, len(sp.Remaining), want)
+				}
+				if want, ok := tc.wantCap[sp.EpicID]; ok && sp.CapReached != want {
+					t.Errorf("%s CapReached = %v, want %v", sp.EpicID, sp.CapReached, want)
+				}
+				if sp.StalledFor <= 0 {
+					t.Errorf("%s StalledFor = %v, want > 0", sp.EpicID, sp.StalledFor)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectStalledPlans_DefaultsFromZeroConfig(t *testing.T) {
+	// Zero StallConfig → DefaultStallThreshold (6h) and MaxReplans (5).
+	stale := baseTime.Add(-(DefaultStallThreshold + time.Hour))
+	snap := []SnapBead{
+		epicSnap("e1", "E1", PlanStatusApproved, MaxReplans),
+		childSnap("c1", "e1", beads.StatusOpen, stale, time.Time{}),
+	}
+	got := DetectStalledPlans(snap, baseTime, StallConfig{})
+	if len(got) != 1 {
+		t.Fatalf("want 1 stalled with default config, got %d", len(got))
+	}
+	if !got[0].CapReached {
+		t.Errorf("replan_count==MaxReplans should be CapReached under default cap")
+	}
+}
+
+func TestSnapshotFromStore(t *testing.T) {
+	store := newStore(t)
+	epic := mustEpic(t, store, "Epic A")
+	if err := store.SetMetadata(epic.ID, MetaPlanStatus, PlanStatusApproved); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(epic.ID, MetaReplanCount, "3"); err != nil {
+		t.Fatal(err)
+	}
+	child, err := store.Create("child", beads.TypeTask, beads.PriorityMedium, "architect", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMetadata(child.ID, MetaParentEpic, epic.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	snap := SnapshotFromStore(store)
+	if len(snap) != 2 {
+		t.Fatalf("want 2 snap beads, got %d", len(snap))
+	}
+	var gotEpic *SnapBead
+	for i := range snap {
+		if snap[i].ID == epic.ID {
+			gotEpic = &snap[i]
+		}
+	}
+	if gotEpic == nil {
+		t.Fatal("epic missing from snapshot")
+	}
+	if gotEpic.PlanStatus != PlanStatusApproved {
+		t.Errorf("PlanStatus = %q", gotEpic.PlanStatus)
+	}
+	if gotEpic.ReplanCount != 3 {
+		t.Errorf("ReplanCount = %d, want 3", gotEpic.ReplanCount)
+	}
+	if gotEpic.UpdatedAt.IsZero() {
+		t.Errorf("UpdatedAt not populated")
+	}
+}
+
+func TestSnapshotFromStore_ClosedAtPopulated(t *testing.T) {
+	store := newStore(t)
+	b, err := store.Create("done", beads.TypeTask, beads.PriorityMedium, "a", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Close(b.ID); err != nil {
+		t.Fatal(err)
+	}
+	snap := SnapshotFromStore(store)
+	if len(snap) != 1 || snap[0].ClosedAt.IsZero() {
+		t.Fatalf("closed bead should carry a non-zero ClosedAt: %+v", snap)
+	}
+}
+
+func TestSnapshotFromStore_NilStore(t *testing.T) {
+	if got := SnapshotFromStore(nil); got != nil {
+		t.Errorf("nil store → nil snapshot, got %+v", got)
+	}
+}
+
+func TestParseReplanCount(t *testing.T) {
+	cases := map[string]int{"": 0, "0": 0, "1": 1, "42": 42, "abc": 0, "1x": 0, "-3": 0}
+	for in, want := range cases {
+		if got := parseReplanCount(in); got != want {
+			t.Errorf("parseReplanCount(%q) = %d, want %d", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Phase 3 (final) — governor stall-detection + bounded replanning

Completes the planning-intelligence feature. Phase 1 decomposed epics into a bead DAG; Phase 2 added the plan-review gate (`plan_status=draft/approved`) and the governor PLANNING tile. Phase 3 makes the loop self-correcting: it detects **approved plans whose execution has stalled** and re-kicks the architect to revise them, **bounded** so it can never thrash.

> **Stacked on Phase 2.** This branch was cut from `feat/planning-phase2-review`, which is not yet in `v3`. Against `v3` the diff currently shows the 4 Phase 2 commits **plus** the 5 Phase 3 commits below; once Phase 2 merges to `v3` this PR reduces to the Phase 3 commits only. Review the Phase 3 commits (`da70ebb9..0b84f133`).

### Stall detector (Part A — pure)
`pkg/planning/stall.go`: `DetectStalledPlans(snap, now, cfg) []StalledPlan` is a **pure** function over a bead snapshot (`SnapshotFromStore`) plus an injected `now`. A plan is stalled when its epic is `plan_status=approved`, ≥1 child is still active (open/in_progress/blocked), and no child has made progress (max child `ClosedAt`/`UpdatedAt`) within `StallThreshold` (default 6h). No goroutines, no store access, no agent coupling — fully table-testable with backdated timestamps. `SnapBead` uses exported time fields so tests build snapshots without the beads package's unexported time wrapper.

### Bounded replan (Part B)
`pkg/planning/replan.go`: for each stalled plan, under the per-epic cap it bumps `replan_count`, stamps `last_replan_at`, and re-kicks the architect with a "this plan stalled, revise the unfinished work" prompt (the **safer first cut**: re-kick via existing machinery, not synchronous re-decomposition). The cap (`MaxReplans`, default 5) mirrors inception's `maxKickRetries`; past it the lane **stops and escalates** ("replan cap reached — needs human") instead of thrashing. Accounting is written before the kick so it's durable even if the kick fails. Every replan and cap-exhaustion flows through audit-log + dashboard system-alert + notification via `ReplanSink`, reusing the trajectory/budget sinks.

### Real `replans_24h`
`BuildPlanning` now derives `replans_24h` purely from each epic's `last_replan_at` metadata over a 24h window, replacing the Phase 2 hardcoded `0`.

### Eval-loop wiring (Part C)
`ReplanLane` is modeled on `trajectory.Lane`: constructed next to it in `cmd/hive/main.go`, run on the governor tick **gated by its own `Due()` cadence** (default 30m), after the eval cycle. New `governor.replan` config block (`enabled`/`interval_s`/`stall_threshold_s`/`max_replans`), on by default (no-op with no approved plans).

**Live-planner wiring — what I did and why:** I took the **record-kick + injectable-planner** path the task allows as the safe first cut, not a full out-of-band tmux launcher. The lane drives the architect exclusively through a `Kicker` interface backed by `agentKicker{mgr}.Kick → Manager.SendKick`, plus `Governor.RecordKick`. That's the exact out-of-band kick path `runEvalCycle` already uses. The `PlannerFunc`/decompose seam from Phase 1 stays injectable; a full re-decompose-and-materialize replanner can layer on later without touching the eval loop. This keeps the risky part (touching the eval loop + the agent manager) minimal and reversible.

### ⚠️ Mutex safety (this area caused #1980/#2018/#2021)
- **No `agent.Manager.m.mu` on the launch path.** My code never touches the manager mutex directly. It calls `SendKick`, which acquires `m.mu` **itself**, and only ever from the governor tick — never from `Start`/`launchInTmux`/the kick path — so no re-entrant `RWMutex` deadlock is possible.
- **No uncancellable goroutine.** `ReplanLane.Run` is synchronous (zero goroutines), takes a `context.Context`, and returns early on `ctx.Err()`. Cadence is `Due()`-gated exactly like the trajectory lane.
- I did **not** modify `pkg/agent`.

### Part D — comparison chart
`pkg/hub/static/index.html`: the Hive "Auto plan decomposition + plan review" row flips **partial → ✓** ("Decompose → review gate → stall-replan"); the closing note now reflects decomposition + review + self-correcting replan.

### Gates
- **Coverage** (new/changed): `pkg/planning` **97.8%** (`stall.go`/`replan.go` functions 100% except `handleStall` 95.2% — sole gap is a non-fatal `last_replan_at`-stamp error branch); new `pkg/dashboard` code (`replan_sink.go`, `buildPlanningAt`) **100%** (`ReplanSink.Notify` real-notifier branch aside, matching the trajectory sink); `pkg/config` new block covered. Table-driven cases include: not-stalled, stalled-under-cap, stalled-at-cap, no-approved-epics, missing/ghost parent, all-children-done, replan-count increment, kick-failure-still-accounts, cancelled-context.
- **`-race` clean**: `go test ./pkg/planning/... ./pkg/governor/ ./pkg/beads/ ./pkg/dashboard/ ./pkg/config/ -race -count=1 -timeout 300s` — all pass.
- `go build ./...`, `go vet ./...` clean; `gofmt` on changed files clean (left pre-existing `status_builder.go` alignment untouched per convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
