### PR TITLE
🐛 fix(dashboard): populate restart sparkline series

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -11444,7 +11444,7 @@ function burnAreaChart() {
             agents: {},
           };
           for (const r of (data.repos || [])) snap.repos[r.name] = { issues: r.issues || 0, prs: r.prs || 0 };
-          for (const a of (data.agents || [])) snap.agents[a.name] = { busy: a.busy === 'working' ? 1 : 0 };
+          for (const a of (data.agents || [])) snap.agents[a.name] = { busy: a.busy === 'working' ? 1 : 0, restarts: a.restarts || 0 };
           // Token sparkline data
           snap.tokens = {};
           snap.tokenTotal = 0;


### PR DESCRIPTION
## Problem

`restartSparkSvg(agentName)` reads `historyData[].agents[name].restarts`, but the per-SSE snapshot appended to `historyData` only wrote `agents[name] = { busy: ... }` — never `.restarts`. The series was therefore always empty and the function returned `''`, so the restart sparkline **never rendered**.

## Fix

Include each agent's restart count in the snapshot object:

```js
snap.agents[a.name] = { busy: a.busy === 'working' ? 1 : 0, restarts: a.restarts || 0 };
```

Now `restartSparkSvg` has data to draw.

## Verification

- `go build ./...` passes (index.html is embedded).
- Extracted `restartSparkSvg` + validated it parses via `new Function`; simulated snapshots produce a non-empty series (`[0,2,3]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)