### PR TITLE
✨ feat(dashboard): persist governor/repo/beads trend history across restarts

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -300,6 +300,17 @@ func main() {
 		}
 	}
 
+	// Restore governor/repo/beads/system trend history from disk so those
+	// sparklines survive restarts and render for any viewer (previously kept
+	// only in the browser's localStorage).
+	const trendHistoryPath = "/data/trend-history.json"
+	var pendingTrendSeed []dashboard.TrendHistoryEntry
+	if trendData, err := os.ReadFile(trendHistoryPath); err == nil {
+		if err := json.Unmarshal(trendData, &pendingTrendSeed); err == nil && len(pendingTrendSeed) > 0 {
+			logger.Info("trend history loaded", "entries", len(pendingTrendSeed))
+		}
+	}
+
 	if cfg.Knowledge.Enabled {
 		layers := convertKnowledgeLayers(cfg.Knowledge.Layers)
 		primerCfg := knowledge.PrimerConfig{
@@ -570,6 +581,11 @@ func main() {
 	if len(pendingCostSeed) > 0 {
 		dashSrv.SeedCostHistory(pendingCostSeed)
 		logger.Info("cost history restored", "entries", len(pendingCostSeed))
+	}
+
+	if len(pendingTrendSeed) > 0 {
+		dashSrv.SeedTrendHistory(pendingTrendSeed)
+		logger.Info("trend history restored", "entries", len(pendingTrendSeed))
 	}
 
 	beadStores := make(map[string]*beads.Store)
@@ -2762,6 +2778,14 @@ func persistState(agentMgr *agent.Manager, gov *governor.Governor, cfg *config.C
 			costData, err := json.Marshal(costHist)
 			if err == nil {
 				atomicWrite("/data/cost-history.json", costData)
+			}
+		}
+
+		trendHist := dashSrv.TrendHistory()
+		if len(trendHist) > 0 {
+			trendData, err := json.Marshal(trendHist)
+			if err == nil {
+				atomicWrite("/data/trend-history.json", trendData)
 			}
 		}
 	}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -66,6 +66,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/tokens", s.handleTokens)
 	s.mux.HandleFunc("GET /api/cost", s.handleCost)
 	s.mux.HandleFunc("GET /api/cost/history", s.handleCostHistory)
+	s.mux.HandleFunc("GET /api/trend/history", s.handleTrendHistory)
 	s.mux.HandleFunc("GET /api/issue-costs", s.handleIssueCosts)
 	s.mux.HandleFunc("GET /api/model-advisor", s.handleModelAdvisor)
 	s.mux.HandleFunc("GET /api/budget-ignore", s.handleBudgetIgnoreGet)
@@ -4898,6 +4899,10 @@ func (s *Server) handleFactHistory(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleCostHistory(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, s.CostHistory())
+}
+
+func (s *Server) handleTrendHistory(w http.ResponseWriter, r *http.Request) {
+	jsonResponse(w, s.TrendHistory())
 }
 
 func (s *Server) handleKnowledgeGraph(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -69,6 +69,9 @@ type Server struct {
 	costHistoryMu sync.RWMutex
 	costHistory   []CostHistoryEntry
 
+	trendHistoryMu sync.RWMutex
+	trendHistory   []TrendHistoryEntry
+
 	advisoryMu     sync.RWMutex
 	advisoryDigest any
 
@@ -397,6 +400,50 @@ const costHistoryMaxEntries = 8640
 // costHistoryMinIntervalMs prevents recording more than once per 5 minutes (ms),
 // mirroring factHistoryMinIntervalMs.
 const costHistoryMinIntervalMs = 300_000
+
+// TrendHistoryEntry records a point-in-time snapshot of the governor / per-repo
+// / beads / system-gauge trends that were previously kept only in the browser's
+// localStorage (hive_sparkline_history) and thus lost on a pod restart or a new
+// viewer. Persisting these server-side (same ring-buffer + PVC-seed treatment
+// as the fact/cost histories) makes the corresponding sparklines survive
+// restarts and render immediately for any viewer.
+type TrendHistoryEntry struct {
+	Timestamp int64 `json:"t"`
+	// Governor actionable counts.
+	GovIssues int `json:"govIssues"`
+	GovPrs    int `json:"govPrs"`
+	GovTotal  int `json:"govTotal"`
+	GovHold   int `json:"govHold"`
+	// Beads worker/supervisor counts.
+	BeadsWorkers    int `json:"beadsWorkers"`
+	BeadsSupervisor int `json:"beadsSupervisor"`
+	// Repos maps repo name → issues/prs at this snapshot. Omitted when empty.
+	Repos map[string]TrendRepoSnap `json:"repos,omitempty"`
+	// System gauges (disk/mem/cpu percent). Pointer so an entry recorded when
+	// systemResources was unavailable omits the field rather than reporting 0.
+	System *TrendSystemSnap `json:"system,omitempty"`
+}
+
+// TrendRepoSnap is one repo's actionable issue/PR counts at a snapshot.
+type TrendRepoSnap struct {
+	Issues int `json:"issues"`
+	PRs    int `json:"prs"`
+}
+
+// TrendSystemSnap is the disk/mem/cpu percentages at a snapshot.
+type TrendSystemSnap struct {
+	DiskPct float64 `json:"diskPct"`
+	MemPct  float64 `json:"memPct"`
+	CpuPct  float64 `json:"cpuPct"`
+}
+
+// trendHistoryMaxEntries caps the trend sparklines to ~30 days at 5-min
+// intervals, mirroring factHistoryMaxEntries / costHistoryMaxEntries.
+const trendHistoryMaxEntries = 8640
+
+// trendHistoryMinIntervalMs prevents recording more than once per 5 minutes (ms),
+// mirroring factHistoryMinIntervalMs / costHistoryMinIntervalMs.
+const trendHistoryMinIntervalMs = 300_000
 
 const sseRetryMs = 3000
 
@@ -880,6 +927,7 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 	s.statusMu.Unlock()
 
 	s.AppendTokenSparkline(status)
+	s.AppendTrendHistory(status)
 
 	data, err := json.Marshal(status)
 	if err != nil {
@@ -1620,6 +1668,76 @@ func (s *Server) SeedCostHistory(entries []CostHistoryEntry) {
 		entries = entries[len(entries)-costHistoryMaxEntries:]
 	}
 	s.costHistory = entries
+}
+
+// AppendTrendHistory samples the governor / per-repo / beads / system-gauge
+// trends from the current status and records a timestamped entry if enough time
+// has passed since the last one. Mirrors AppendFactHistory / AppendCostHistory:
+// same 5-min cadence throttle and same ring-buffer cap so all the persisted
+// histories stay aligned. No-op on a nil status.
+func (s *Server) AppendTrendHistory(status *StatusPayload) {
+	if status == nil {
+		return
+	}
+	now := time.Now().UnixMilli()
+
+	s.trendHistoryMu.Lock()
+	defer s.trendHistoryMu.Unlock()
+
+	if len(s.trendHistory) > 0 {
+		last := s.trendHistory[len(s.trendHistory)-1]
+		if now-last.Timestamp < trendHistoryMinIntervalMs {
+			return
+		}
+	}
+
+	entry := TrendHistoryEntry{
+		Timestamp:       now,
+		GovIssues:       status.Governor.Issues,
+		GovPrs:          status.Governor.PRs,
+		GovTotal:        status.Governor.Issues + status.Governor.PRs,
+		GovHold:         status.Hold.Total,
+		BeadsWorkers:    status.Beads.Workers,
+		BeadsSupervisor: status.Beads.Supervisor,
+	}
+	if len(status.Repos) > 0 {
+		repos := make(map[string]TrendRepoSnap, len(status.Repos))
+		for _, r := range status.Repos {
+			repos[r.Name] = TrendRepoSnap{Issues: r.Issues, PRs: r.PRs}
+		}
+		entry.Repos = repos
+	}
+	if status.SystemResources != nil {
+		entry.System = &TrendSystemSnap{
+			DiskPct: status.SystemResources.DiskPct,
+			MemPct:  status.SystemResources.MemPct,
+			CpuPct:  status.SystemResources.CpuPct,
+		}
+	}
+
+	s.trendHistory = append(s.trendHistory, entry)
+	if len(s.trendHistory) > trendHistoryMaxEntries {
+		s.trendHistory = s.trendHistory[len(s.trendHistory)-trendHistoryMaxEntries:]
+	}
+}
+
+// TrendHistory returns a copy of the trend history.
+func (s *Server) TrendHistory() []TrendHistoryEntry {
+	s.trendHistoryMu.RLock()
+	defer s.trendHistoryMu.RUnlock()
+	out := make([]TrendHistoryEntry, len(s.trendHistory))
+	copy(out, s.trendHistory)
+	return out
+}
+
+// SeedTrendHistory restores persisted trend history on startup.
+func (s *Server) SeedTrendHistory(entries []TrendHistoryEntry) {
+	s.trendHistoryMu.Lock()
+	defer s.trendHistoryMu.Unlock()
+	if len(entries) > trendHistoryMaxEntries {
+		entries = entries[len(entries)-trendHistoryMaxEntries:]
+	}
+	s.trendHistory = entries
 }
 
 // SetAdvisoryDigest stores the latest advisory digest for SSE broadcast.

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3724,6 +3724,70 @@
     }
     // fetchCostHistory() is invoked alongside fetchCost() (see below).
 
+    // ── Governor / repo / beads / system trend history (server-persisted) ──
+    // These trends used to live only in the browser's localStorage
+    // (hive_sparkline_history), so they were blank after a pod restart or for a
+    // brand-new viewer. The server now persists ~30 days of snapshots to
+    // /data/trend-history.json (same ring-buffer treatment as fact/cost). We
+    // fetch them and merge into historyData by timestamp so the governor / repo
+    // / beads / system-gauge sparklines render immediately instead of blank.
+    // Field names in the server entry mirror the client snapshot shape
+    // (govIssues, govPrs, govTotal, govHold, beadsWorkers, beadsSupervisor,
+    // repos[name].{issues,prs}) so no per-field translation is needed.
+    let _serverTrendHistory = [];
+    const TREND_MERGE_DELTA_MS = 60000;
+    async function fetchTrendHistory() {
+      try {
+        const r = await fetch('/api/trend/history');
+        const data = await r.json();
+        _serverTrendHistory = Array.isArray(data) ? data : [];
+        mergeTrendHistory();
+      } catch { /* non-critical */ }
+    }
+    // mergeTrendHistory folds cached server trend snapshots into historyData,
+    // matching each to the nearest live snapshot within TREND_MERGE_DELTA_MS and
+    // injecting any that have no live counterpart. Idempotent-ish: injected
+    // entries carry _fromTrend so a re-merge (after fetchHistory reassigns
+    // historyData) doesn't double-count against already-present live points.
+    function mergeTrendHistory() {
+      if (!_serverTrendHistory.length) return;
+      const matched = new Set();
+      for (const live of historyData) {
+        const lt = live.t || 0;
+        let bestIdx = -1, bestDelta = Infinity;
+        for (let i = 0; i < _serverTrendHistory.length; i++) {
+          const d = Math.abs((_serverTrendHistory[i].t || 0) - lt);
+          if (d < bestDelta) { bestDelta = d; bestIdx = i; }
+        }
+        if (bestIdx >= 0 && bestDelta < TREND_MERGE_DELTA_MS) matched.add(bestIdx);
+      }
+      const injected = [];
+      for (let i = 0; i < _serverTrendHistory.length; i++) {
+        if (matched.has(i)) continue;
+        const e = _serverTrendHistory[i];
+        const repos = {};
+        for (const [name, rs] of Object.entries(e.repos || {})) {
+          repos[name] = { issues: rs.issues || 0, prs: rs.prs || 0 };
+        }
+        injected.push({
+          t: e.t,
+          govIssues: e.govIssues || 0,
+          govPrs: e.govPrs || 0,
+          govTotal: e.govTotal || 0,
+          govHold: e.govHold || 0,
+          beadsWorkers: e.beadsWorkers || 0,
+          beadsSupervisor: e.beadsSupervisor || 0,
+          repos,
+          agents: {},
+          _fromTrend: true,
+        });
+      }
+      if (injected.length) {
+        historyData = historyData.concat(injected);
+        historyData.sort((a, b) => (a.t || 0) - (b.t || 0));
+      }
+    }
+
     // ── Cost spend-over-time (hourly / daily / weekly / monthly) ──
     // The server keeps 30 days of CUMULATIVE all-time estimated-$ snapshots at
     // ~5-min resolution. We derive per-bucket SPEND on the client by taking the
@@ -4013,6 +4077,9 @@
           evalEntries.sort((a, b) => (a.t || 0) - (b.t || 0));
         }
         historyData = evalEntries || [];
+        // Re-fold persisted governor/repo/beads trends into the freshly
+        // reassigned historyData so those sparklines survive the 30s refresh.
+        mergeTrendHistory();
       } catch (e) { /* ignore */ }
     }
     // fetchHistory() — deferred to _deferredInit
@@ -9041,6 +9108,12 @@ function burnAreaChart() {
     // fetchContributors() + fetchLeaderboard() — deferred to _deferredInit
 
     // ── System resource gauge history for sparklines ──
+    // NOTE: these mini-sparklines still read this in-memory array, which resets
+    // on reload. The disk/mem/cpu percentages ARE now persisted server-side in
+    // the trend history (/api/trend/history, entry.system) alongside the
+    // governor/repo/beads trends, so the data survives restarts; wiring these
+    // gauge sparklines to that persisted series is a follow-up (kept client-only
+    // here to avoid reworking renderSystemGauges in this change).
     const SYS_GAUGE_HISTORY_MAX = 60;
     const _sysGaugeHistory = { disk: [], mem: [], cpu: [] };
 
@@ -16257,7 +16330,7 @@ function burnAreaChart() {
       setTimeout(() => {
         const deferred = [
           () => fetchFactHistory(),
-          () => fetchHistory().then(() => { setInterval(fetchHistory, HISTORY_REFRESH_MS); }),
+          () => fetchTrendHistory().then(() => fetchHistory()).then(() => { setInterval(fetchHistory, HISTORY_REFRESH_MS); }),
           () => fetchIssueCosts().then(() => { setInterval(fetchIssueCosts, ISSUE_COSTS_REFRESH_MS); }),
           () => fetch('/api/budget-ignore').then(r => r.json()).then(d => { budgetIgnored = d.ignored; }).catch(() => {}),
           () => fetchNousStatus().then(() => { setInterval(fetchNousStatus, NOUS_POLL_MS); }),

--- a/v2/pkg/dashboard/trend_history_test.go
+++ b/v2/pkg/dashboard/trend_history_test.go
@@ -1,0 +1,127 @@
+package dashboard
+
+import "testing"
+
+// TestAppendTrendHistory verifies a single append lands and the throttle
+// suppresses a rapid second append (same 5-min cadence as fact/cost history).
+func TestAppendTrendHistory(t *testing.T) {
+	s := newTestServer()
+
+	if got := s.TrendHistory(); len(got) != 0 {
+		t.Fatalf("fresh server trend history len = %d, want 0", len(got))
+	}
+
+	status := &StatusPayload{
+		Governor: FrontendGovernor{Issues: 3, PRs: 2},
+		Hold:     FrontendHold{Total: 4},
+		Beads:    FrontendBeads{Workers: 5, Supervisor: 1},
+		Repos: []FrontendRepo{
+			{Name: "console", Issues: 2, PRs: 1},
+		},
+		SystemResources: &SystemResources{DiskPct: 40, MemPct: 55, CpuPct: 12},
+	}
+	s.AppendTrendHistory(status)
+
+	got := s.TrendHistory()
+	if len(got) != 1 {
+		t.Fatalf("after one append len = %d, want 1", len(got))
+	}
+	e := got[0]
+	if e.GovIssues != 3 || e.GovPrs != 2 || e.GovTotal != 5 {
+		t.Errorf("governor counts = %d/%d/%d, want 3/2/5", e.GovIssues, e.GovPrs, e.GovTotal)
+	}
+	if e.GovHold != 4 {
+		t.Errorf("hold = %d, want 4", e.GovHold)
+	}
+	if e.BeadsWorkers != 5 || e.BeadsSupervisor != 1 {
+		t.Errorf("beads = %d/%d, want 5/1", e.BeadsWorkers, e.BeadsSupervisor)
+	}
+	if e.Repos["console"].Issues != 2 || e.Repos["console"].PRs != 1 {
+		t.Errorf("repo snap = %+v, want {2 1}", e.Repos["console"])
+	}
+	if e.System == nil || e.System.DiskPct != 40 || e.System.MemPct != 55 || e.System.CpuPct != 12 {
+		t.Errorf("system snap = %+v, want {40 55 12}", e.System)
+	}
+	if e.Timestamp == 0 {
+		t.Error("entry Timestamp not set")
+	}
+
+	// A second immediate append is throttled (< trendHistoryMinIntervalMs apart).
+	s.AppendTrendHistory(status)
+	if got := s.TrendHistory(); len(got) != 1 {
+		t.Fatalf("after throttled append len = %d, want 1 (throttle should suppress)", len(got))
+	}
+}
+
+// TestAppendTrendHistoryNilStatus verifies a nil status is a no-op.
+func TestAppendTrendHistoryNilStatus(t *testing.T) {
+	s := newTestServer()
+	s.AppendTrendHistory(nil)
+	if got := s.TrendHistory(); len(got) != 0 {
+		t.Fatalf("nil status appended an entry: len = %d, want 0", len(got))
+	}
+}
+
+// TestAppendTrendHistoryOmitsEmptyOptionals verifies the repos map and system
+// pointer are omitted (nil) when the status carries no repos / no resources.
+func TestAppendTrendHistoryOmitsEmptyOptionals(t *testing.T) {
+	s := &Server{}
+	s.AppendTrendHistory(&StatusPayload{
+		Governor: FrontendGovernor{Issues: 1},
+	})
+	got := s.TrendHistory()
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].Repos != nil {
+		t.Errorf("empty repos should be nil, got %v", got[0].Repos)
+	}
+	if got[0].System != nil {
+		t.Errorf("absent system resources should be nil, got %v", got[0].System)
+	}
+}
+
+// TestTrendHistoryReturnsCopy verifies TrendHistory hands back a copy so callers
+// can't mutate the server's slice.
+func TestTrendHistoryReturnsCopy(t *testing.T) {
+	s := &Server{}
+	s.AppendTrendHistory(&StatusPayload{Governor: FrontendGovernor{Issues: 7}})
+
+	got := s.TrendHistory()
+	got[0].GovIssues = 999
+
+	again := s.TrendHistory()
+	if again[0].GovIssues != 7 {
+		t.Errorf("mutating returned slice leaked into server state: got %d", again[0].GovIssues)
+	}
+}
+
+// TestSeedTrendHistoryCapAndOrdering verifies the seed path trims to the cap
+// (keeping the most-recent tail) and preserves ordering.
+func TestSeedTrendHistoryCapAndOrdering(t *testing.T) {
+	s := newTestServer()
+
+	over := trendHistoryMaxEntries + 10
+	entries := make([]TrendHistoryEntry, over)
+	for i := range entries {
+		entries[i] = TrendHistoryEntry{Timestamp: int64(i), GovTotal: i}
+	}
+	s.SeedTrendHistory(entries)
+
+	got := s.TrendHistory()
+	if len(got) != trendHistoryMaxEntries {
+		t.Fatalf("seeded len = %d, want cap %d", len(got), trendHistoryMaxEntries)
+	}
+	wantFirst := int64(over - trendHistoryMaxEntries)
+	if got[0].Timestamp != wantFirst {
+		t.Errorf("first kept timestamp = %d, want %d (tail should be retained)", got[0].Timestamp, wantFirst)
+	}
+	if got[len(got)-1].Timestamp != int64(over-1) {
+		t.Errorf("last timestamp = %d, want %d", got[len(got)-1].Timestamp, over-1)
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i].Timestamp <= got[i-1].Timestamp {
+			t.Fatalf("ordering broken at %d: %d <= %d", i, got[i].Timestamp, got[i-1].Timestamp)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The governor (actionable issues/prs/total/on-hold), per-repo issues/prs, and beads workers/supervisor trends lived **only** in the browser's `localStorage` (`hive_sparkline_history`). They were blank after a pod restart and for any brand-new viewer — unlike the token/fact/cost histories, which are already persisted server-side.

## Change

Give these trends the same server ring-buffer + PVC-seed treatment as the fact/cost histories:

- **server.go**: new `TrendHistoryEntry` carrying governor counts, per-repo `{issues,prs}`, beads workers/supervisor, and system disk/mem/cpu gauges, with `AppendTrendHistory` / `TrendHistory` / `SeedTrendHistory`. Sampled in `UpdateStatus` right after `AppendTokenSparkline`, throttled to ~5 min with a ~30-day (8640-entry) cap — mirroring fact/cost.
- **api.go**: new `GET /api/trend/history` endpoint.
- **cmd/hive/main.go**: seed from `/data/trend-history.json` on boot, `atomicWrite` it in `persistState` — mirroring the cost/fact wiring.
- **index.html**: `fetchTrendHistory()` + `mergeTrendHistory()` fold the persisted snapshots into `historyData` by timestamp (re-merged after each 30s `fetchHistory` refresh) so the governor/repo/beads sparklines render immediately after a deploy instead of blank. Server entry field names mirror the client snapshot shape, so no per-field translation is needed.

**System gauges**: disk/mem/cpu are now captured server-side in the same buffer. Their mini-sparklines still read the in-memory `_sysGaugeHistory` (documented in a comment) — wiring them to the persisted series is a small follow-up, left out here to avoid reworking `renderSystemGauges`.

## Verification

- `go build ./...` passes.
- `go test ./pkg/dashboard/ ./pkg/hub/ -count=1` passes, including new `trend_history_test.go` (mirrors `cost_history_test.go`: append + throttle, nil-status no-op, empty-optional omission, copy-on-read, seed cap/ordering).
- `gofmt -l` clean on all changed Go files.
- Extracted `mergeTrendHistory` + validated it parses via `new Function`; simulated a merge — matched entries dedupe against live points, unmatched inject with the correct `repos`/governor shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)