### PR TITLE
♻️ refactor(dashboard): unify sparkline history behind a generic TimeSeries store

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -67,6 +67,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("GET /api/cost", s.handleCost)
 	s.mux.HandleFunc("GET /api/cost/history", s.handleCostHistory)
 	s.mux.HandleFunc("GET /api/trend/history", s.handleTrendHistory)
+	s.mux.HandleFunc("GET /api/timeseries", s.handleTimeSeries)
 	s.mux.HandleFunc("GET /api/issue-costs", s.handleIssueCosts)
 	s.mux.HandleFunc("GET /api/model-advisor", s.handleModelAdvisor)
 	s.mux.HandleFunc("GET /api/budget-ignore", s.handleBudgetIgnoreGet)
@@ -4903,6 +4904,24 @@ func (s *Server) handleCostHistory(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleTrendHistory(w http.ResponseWriter, r *http.Request) {
 	jsonResponse(w, s.TrendHistory())
+}
+
+// handleTimeSeries is the unified read endpoint over the sparkline histories.
+// GET /api/timeseries?series=<name> returns the same JSON the dedicated
+// endpoint returns (token → /api/tokens history, fact → /api/knowledge/
+// fact-history, cost → /api/cost/history), so it's an additive alias rather
+// than a replacement — the existing endpoints stay for back-compat.
+func (s *Server) handleTimeSeries(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Query().Get("series") {
+	case "token", "tokens":
+		jsonResponse(w, s.TokenSparklineHistory())
+	case "fact", "facts":
+		jsonResponse(w, s.FactHistory())
+	case "cost":
+		jsonResponse(w, s.CostHistory())
+	default:
+		http.Error(w, `{"error":"unknown series; valid: token, fact, cost"}`, http.StatusBadRequest)
+	}
 }
 
 func (s *Server) handleKnowledgeGraph(w http.ResponseWriter, r *http.Request) {

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -59,16 +59,21 @@ type Server struct {
 	acmmEvalCache    *ACMMEvaluation
 	acmmEvalCachedAt time.Time
 
-	tokenHistoryMu    sync.RWMutex
-	tokenHistory      []TokenSparklineEntry
+	// Sparkline histories, all backed by the generic timeSeries ring buffer
+	// (see timeseries.go). Lazily constructed via the tokenSeries()/factSeries()
+	// /costSeries() accessors so the zero-value Server needs no constructor
+	// change. Each keeps its own typed entry struct and JSON contract, so the
+	// unification is internal — on-disk files and /api/* endpoints are unchanged.
+	histOnce  sync.Once
+	tokenHist *timeSeries[TokenSparklineEntry]
+	factHist  *timeSeries[FactHistoryEntry]
+	costHist  *timeSeries[CostHistoryEntry]
+
+	// lastFullBroadcast is guarded by statusMu (set/read alongside s.status).
 	lastFullBroadcast time.Time
 
-	factHistoryMu sync.RWMutex
-	factHistory   []FactHistoryEntry
-
-	costHistoryMu sync.RWMutex
-	costHistory   []CostHistoryEntry
-
+	// fact/cost histories were migrated to the generic timeSeries store (#2041);
+	// the trend history (#2039) remains a dedicated buffer for now.
 	trendHistoryMu sync.RWMutex
 	trendHistory   []TrendHistoryEntry
 
@@ -1523,15 +1528,47 @@ func (s *Server) broadcastFrame(frame string) {
 	}
 }
 
+// initHistories lazily builds the three sparkline ring buffers. Called (once)
+// by each history accessor so a zero-value Server — as used in tests that do
+// `&Server{}` — works without a constructor. Token history has no throttle
+// (append every broadcast); fact/cost throttle to ~5 min. Each buffer's cap and
+// interval match the previous bespoke implementation exactly, so behavior and
+// on-disk shape are preserved.
+func (s *Server) initHistories() {
+	s.histOnce.Do(func() {
+		s.tokenHist = newTimeSeries(tokenSparklineMaxEntries, 0,
+			func(e TokenSparklineEntry) int64 { return e.Timestamp })
+		s.factHist = newTimeSeries(factHistoryMaxEntries, factHistoryMinIntervalMs,
+			func(e FactHistoryEntry) int64 { return e.Timestamp })
+		s.costHist = newTimeSeries(costHistoryMaxEntries, costHistoryMinIntervalMs,
+			func(e CostHistoryEntry) int64 { return e.Timestamp })
+	})
+}
+
+func (s *Server) tokenSeries() *timeSeries[TokenSparklineEntry] {
+	s.initHistories()
+	return s.tokenHist
+}
+
+func (s *Server) factSeries() *timeSeries[FactHistoryEntry] {
+	s.initHistories()
+	return s.factHist
+}
+
+func (s *Server) costSeries() *timeSeries[CostHistoryEntry] {
+	s.initHistories()
+	return s.costHist
+}
+
 // AppendTokenSparkline extracts token metrics from the current status and
-// appends a timestamped entry to the in-memory token sparkline history.
+// appends a timestamped entry to the token sparkline history (no throttle).
 func (s *Server) AppendTokenSparkline(status *StatusPayload) {
 	if status == nil {
 		return
 	}
 
 	entry := TokenSparklineEntry{
-		Timestamp:   time.Now().UnixMilli(),
+		Timestamp:   nowMillis(),
 		Input:       status.Tokens.Totals.Input,
 		Output:      status.Tokens.Totals.Output,
 		CacheRead:   status.Tokens.Totals.CacheRead,
@@ -1548,73 +1585,35 @@ func (s *Server) AppendTokenSparkline(status *StatusPayload) {
 		entry.ByModel[name] = bucket.Input + bucket.Output + bucket.CacheRead
 	}
 
-	s.tokenHistoryMu.Lock()
-	s.tokenHistory = append(s.tokenHistory, entry)
-	if len(s.tokenHistory) > tokenSparklineMaxEntries {
-		s.tokenHistory = s.tokenHistory[len(s.tokenHistory)-tokenSparklineMaxEntries:]
-	}
-	s.tokenHistoryMu.Unlock()
+	s.tokenSeries().append(entry)
 }
 
 // TokenSparklineHistory returns a copy of the current token sparkline history.
 func (s *Server) TokenSparklineHistory() []TokenSparklineEntry {
-	s.tokenHistoryMu.RLock()
-	defer s.tokenHistoryMu.RUnlock()
-	out := make([]TokenSparklineEntry, len(s.tokenHistory))
-	copy(out, s.tokenHistory)
-	return out
+	return s.tokenSeries().snapshot()
 }
 
 // SeedTokenSparklineHistory restores persisted token history on startup.
 func (s *Server) SeedTokenSparklineHistory(entries []TokenSparklineEntry) {
-	s.tokenHistoryMu.Lock()
-	defer s.tokenHistoryMu.Unlock()
-	if len(entries) > tokenSparklineMaxEntries {
-		entries = entries[len(entries)-tokenSparklineMaxEntries:]
-	}
-	s.tokenHistory = entries
+	s.tokenSeries().seed(entries)
 }
 
 // AppendFactHistory records a total-facts count if enough time has passed.
 func (s *Server) AppendFactHistory(count int) {
-	now := time.Now().UnixMilli()
-
-	s.factHistoryMu.Lock()
-	defer s.factHistoryMu.Unlock()
-
-	if len(s.factHistory) > 0 {
-		last := s.factHistory[len(s.factHistory)-1]
-		if now-last.Timestamp < factHistoryMinIntervalMs {
-			return
-		}
-	}
-
-	s.factHistory = append(s.factHistory, FactHistoryEntry{
-		Timestamp: now,
+	s.factSeries().append(FactHistoryEntry{
+		Timestamp: nowMillis(),
 		Count:     count,
 	})
-	if len(s.factHistory) > factHistoryMaxEntries {
-		s.factHistory = s.factHistory[len(s.factHistory)-factHistoryMaxEntries:]
-	}
 }
 
 // FactHistory returns a copy of the fact count history.
 func (s *Server) FactHistory() []FactHistoryEntry {
-	s.factHistoryMu.RLock()
-	defer s.factHistoryMu.RUnlock()
-	out := make([]FactHistoryEntry, len(s.factHistory))
-	copy(out, s.factHistory)
-	return out
+	return s.factSeries().snapshot()
 }
 
 // SeedFactHistory restores persisted fact history on startup.
 func (s *Server) SeedFactHistory(entries []FactHistoryEntry) {
-	s.factHistoryMu.Lock()
-	defer s.factHistoryMu.Unlock()
-	if len(entries) > factHistoryMaxEntries {
-		entries = entries[len(entries)-factHistoryMaxEntries:]
-	}
-	s.factHistory = entries
+	s.factSeries().seed(entries)
 }
 
 // AppendCostHistory records an estimated-cost ($) snapshot if enough time has
@@ -1633,20 +1632,8 @@ func (s *Server) AppendCostHistory(usd float64, agents ...map[string]float64) {
 // AppendCostHistoryFull is AppendCostHistory plus the per-model snapshot map
 // that feeds the cost table's mini sparklines.
 func (s *Server) AppendCostHistoryFull(usd float64, agents map[string]float64, models map[string]CostModelSnap) {
-	now := time.Now().UnixMilli()
-
-	s.costHistoryMu.Lock()
-	defer s.costHistoryMu.Unlock()
-
-	if len(s.costHistory) > 0 {
-		last := s.costHistory[len(s.costHistory)-1]
-		if now-last.Timestamp < costHistoryMinIntervalMs {
-			return
-		}
-	}
-
 	entry := CostHistoryEntry{
-		Timestamp: now,
+		Timestamp: nowMillis(),
 		USD:       usd,
 	}
 	if len(agents) > 0 {
@@ -1655,29 +1642,17 @@ func (s *Server) AppendCostHistoryFull(usd float64, agents map[string]float64, m
 	if len(models) > 0 {
 		entry.Models = models
 	}
-	s.costHistory = append(s.costHistory, entry)
-	if len(s.costHistory) > costHistoryMaxEntries {
-		s.costHistory = s.costHistory[len(s.costHistory)-costHistoryMaxEntries:]
-	}
+	s.costSeries().append(entry)
 }
 
 // CostHistory returns a copy of the estimated-cost history.
 func (s *Server) CostHistory() []CostHistoryEntry {
-	s.costHistoryMu.RLock()
-	defer s.costHistoryMu.RUnlock()
-	out := make([]CostHistoryEntry, len(s.costHistory))
-	copy(out, s.costHistory)
-	return out
+	return s.costSeries().snapshot()
 }
 
 // SeedCostHistory restores persisted cost history on startup.
 func (s *Server) SeedCostHistory(entries []CostHistoryEntry) {
-	s.costHistoryMu.Lock()
-	defer s.costHistoryMu.Unlock()
-	if len(entries) > costHistoryMaxEntries {
-		entries = entries[len(entries)-costHistoryMaxEntries:]
-	}
-	s.costHistory = entries
+	s.costSeries().seed(entries)
 }
 
 // AppendTrendHistory samples the governor / per-repo / beads / system-gauge

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3660,6 +3660,32 @@
       });
     }
 
+    // Default stroke colors for the named series historyData carries. Keeps the
+    // sparkline() helper below a single source of truth for each series' color
+    // so the scattered render fns don't each repeat the getHistorySeries +
+    // sparkSvg + color triple.
+    const SPARKLINE_COLORS = {
+      govIssues: 'var(--blue)',
+      govPrs: 'var(--purple)',
+      govTotal: 'var(--green)',
+      govHold: 'var(--muted)', // sparkline tint only — the count itself is neutral
+      beadsWorkers: 'var(--cyan)',
+      beadsSupervisor: 'var(--yellow)',
+      tokenTotal: 'var(--cyan)',
+      tokenInput: 'var(--blue)',
+      tokenOutput: 'var(--purple)',
+      tokenCacheRead: 'var(--green)',
+      tokenCacheCreate: 'var(--yellow)',
+      tokenMessages: 'var(--muted)',
+    };
+    // sparkline(name, color?) renders the named historyData series as an SVG
+    // sparkline. color defaults to SPARKLINE_COLORS[name] (falling back to
+    // muted). One helper routes every historyData-backed sparkline through the
+    // same getHistorySeries + sparkSvg path.
+    function sparkline(name, color) {
+      return sparkSvg(getHistorySeries(name), color || SPARKLINE_COLORS[name] || 'var(--muted)');
+    }
+
     function restartSparkSvg(agentName) {
       const series = historyData
         .map(s => s.agents?.[agentName]?.restarts)
@@ -4762,9 +4788,9 @@
       const isStarting = !gov.active && !gov.mode;
       const cls = gov.active ? 'active' : (isStarting ? 'starting' : 'dead');
       el.className = `governor ${cls}`;
-      const issuesSpark = sparkSvg(getHistorySeries('govIssues'), 'var(--blue)');
-      const prsSpark = sparkSvg(getHistorySeries('govPrs'), 'var(--purple)');
-      const totalSpark = sparkSvg(getHistorySeries('govTotal'), 'var(--green)');
+      const issuesSpark = sparkline('govIssues');
+      const prsSpark = sparkline('govPrs');
+      const totalSpark = sparkline('govTotal');
       const issueCount = gov.issues || 0;
       const currentMode = gov.mode || 'idle';
       const modes = ['idle', 'quiet', 'busy', 'surge'];
@@ -4799,9 +4825,8 @@
       const holdData = data.hold || {};
       const holdTotal = holdData.total || 0;
       const holdItems = holdData.items || [];
-      const HOLD_COLOR = 'var(--muted)'; /* sparkline tint only — the count itself is neutral */
       const holdTooltip = holdItems.length > 0 ? escapeHtml(holdItems.map(h => `${h.type === 'pr' ? 'PR' : 'Issue'} ${h.repo}#${h.number}: ${h.title}`).join('\n')) : 'No items on hold';
-      const holdSpark = sparkSvg(getHistorySeries('govHold'), HOLD_COLOR);
+      const holdSpark = sparkline('govHold');
 
       el.innerHTML = `
         <div class="gov-title">Governor <button class="config-gear" onclick="openConfigDialog('governor')" title="Open Governor configuration — manage agents, thresholds, budget, notifications, health checks, and sensing patterns">⚙️</button></div>
@@ -5039,8 +5064,8 @@
           'Counts appear here as soon as agents start filing beads — kick an agent, or let the governor cadence run, and check back.'));
         return;
       }
-      const wSpark = sparkSvg(getHistorySeries('beadsWorkers'), 'var(--cyan)');
-      const sSpark = sparkSvg(getHistorySeries('beadsSupervisor'), 'var(--yellow)');
+      const wSpark = sparkline('beadsWorkers');
+      const sSpark = sparkline('beadsSupervisor');
       setIfChanged(el, `
         <div class="bead-stat"><div class="spark-row"><span class="num">${workers}</span>${wSpark}</div><div class="label">workers</div></div>
         <div class="bead-stat"><div class="spark-row"><span class="num">${supervisor}</span>${sSpark}</div><div class="label">supervisor</div></div>`);
@@ -5965,7 +5990,7 @@ function burnAreaChart() {
 
       const advisorHtml = buildCadenceAdvisor(tokens.byAgent || {});
 
-      const totalSpark = sparkSvg(getHistorySeries('tokenTotal'), 'var(--cyan)');
+      const totalSpark = sparkline('tokenTotal');
       const ba = tokens.byAgent || {};
       const agentNames = Object.keys(ba).sort((a, b) => {
         const aOrder = _getAgentSortOrder(a);
@@ -5988,11 +6013,11 @@ function burnAreaChart() {
         </div>
         <div class="token-grid">
           <div class="token-stat"><div class="spark-row"><span class="tval">${fmtTokens(totalTokens)}</span>${totalSpark}</div><div class="tlabel">total tokens</div></div>
-          <div class="token-stat"><div class="spark-row"><span class="tval">${fmtTokens(t.input)}</span>${sparkSvg(getHistorySeries('tokenInput'), 'var(--blue)')}</div><div class="tlabel">input</div></div>
-          <div class="token-stat"><div class="spark-row"><span class="tval">${fmtTokens(t.output)}</span>${sparkSvg(getHistorySeries('tokenOutput'), 'var(--purple)')}</div><div class="tlabel">output</div></div>
-          <div class="token-stat"><div class="spark-row"><span class="tval">${fmtTokens(t.cacheRead)}</span>${sparkSvg(getHistorySeries('tokenCacheRead'), 'var(--green)')}</div><div class="tlabel">cache read</div></div>
-          <div class="token-stat"><div class="spark-row"><span class="tval">${fmtTokens(t.cacheCreate)}</span>${sparkSvg(getHistorySeries('tokenCacheCreate'), 'var(--yellow)')}</div><div class="tlabel">cache create</div></div>
-          <div class="token-stat"><div class="spark-row"><span class="tval">${t.messages}</span>${sparkSvg(getHistorySeries('tokenMessages'), 'var(--muted)')}</div><div class="tlabel">messages</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval">${fmtTokens(t.input)}</span>${sparkline('tokenInput')}</div><div class="tlabel">input</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval">${fmtTokens(t.output)}</span>${sparkline('tokenOutput')}</div><div class="tlabel">output</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval">${fmtTokens(t.cacheRead)}</span>${sparkline('tokenCacheRead')}</div><div class="tlabel">cache read</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval">${fmtTokens(t.cacheCreate)}</span>${sparkline('tokenCacheCreate')}</div><div class="tlabel">cache create</div></div>
+          <div class="token-stat"><div class="spark-row"><span class="tval">${t.messages}</span>${sparkline('tokenMessages')}</div><div class="tlabel">messages</div></div>
         </div>
         ${agentSparkRows ? `<div class="token-grid" style="margin-top:4px">${agentSparkRows}</div>` : ''}
         ${advisorHtml}

--- a/v2/pkg/dashboard/timeseries.go
+++ b/v2/pkg/dashboard/timeseries.go
@@ -1,0 +1,91 @@
+package dashboard
+
+import (
+	"sync"
+	"time"
+)
+
+// timeSeries is a generic, concurrency-safe ring buffer of timestamped entries.
+// It is the single mechanism behind every persisted sparkline history (token,
+// fact, cost, trend): a bounded, most-recent-tail buffer with an optional
+// minimum-interval throttle and copy-on-read semantics.
+//
+// It deliberately owns ONLY the storage mechanics (cap, throttle, mutex, copy).
+// Each concrete history keeps its own typed entry struct and its own JSON
+// contract, so migrating a bespoke buffer onto timeSeries is a behavior- and
+// wire-preserving refactor: the on-disk files and /api/* endpoints are
+// unchanged.
+//
+// T is the entry type. tsOf extracts an entry's timestamp (unix millis) so the
+// buffer can enforce the min-interval throttle without T needing an interface.
+type timeSeries[T any] struct {
+	mu          sync.RWMutex
+	entries     []T
+	cap         int   // maximum retained entries (most-recent tail kept)
+	minInterval int64 // minimum ms between appends; 0 disables throttling
+	tsOf        func(T) int64
+}
+
+// newTimeSeries builds a ring buffer with the given cap and min-interval (ms;
+// 0 disables the throttle). tsOf returns an entry's timestamp in unix millis.
+func newTimeSeries[T any](capacity int, minIntervalMs int64, tsOf func(T) int64) *timeSeries[T] {
+	return &timeSeries[T]{
+		cap:         capacity,
+		minInterval: minIntervalMs,
+		tsOf:        tsOf,
+	}
+}
+
+// append adds entry unless the throttle suppresses it (the entry's timestamp is
+// less than minInterval after the last retained entry's). It reports whether the
+// entry was stored. Callers that need the current wall clock should stamp the
+// entry before calling; append uses tsOf(entry) for the throttle comparison.
+func (ts *timeSeries[T]) append(entry T) bool {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	if ts.minInterval > 0 && len(ts.entries) > 0 {
+		last := ts.entries[len(ts.entries)-1]
+		if ts.tsOf(entry)-ts.tsOf(last) < ts.minInterval {
+			return false
+		}
+	}
+
+	ts.entries = append(ts.entries, entry)
+	if ts.cap > 0 && len(ts.entries) > ts.cap {
+		ts.entries = ts.entries[len(ts.entries)-ts.cap:]
+	}
+	return true
+}
+
+// snapshot returns a copy of the retained entries so callers can't mutate the
+// buffer's backing array.
+func (ts *timeSeries[T]) snapshot() []T {
+	ts.mu.RLock()
+	defer ts.mu.RUnlock()
+	out := make([]T, len(ts.entries))
+	copy(out, ts.entries)
+	return out
+}
+
+// seed replaces the buffer contents (trimming to the most-recent cap tail),
+// used to restore persisted history on startup.
+func (ts *timeSeries[T]) seed(entries []T) {
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+	if ts.cap > 0 && len(entries) > ts.cap {
+		entries = entries[len(entries)-ts.cap:]
+	}
+	ts.entries = entries
+}
+
+// len reports the current number of retained entries.
+func (ts *timeSeries[T]) len() int {
+	ts.mu.RLock()
+	defer ts.mu.RUnlock()
+	return len(ts.entries)
+}
+
+// nowMillis is the wall clock used when stamping entries; a package var so
+// tests could override it if needed.
+func nowMillis() int64 { return time.Now().UnixMilli() }

--- a/v2/pkg/dashboard/timeseries_test.go
+++ b/v2/pkg/dashboard/timeseries_test.go
@@ -1,0 +1,108 @@
+package dashboard
+
+import "testing"
+
+// tsEntry is a minimal entry type for exercising the generic timeSeries.
+type tsEntry struct {
+	T   int64
+	Val int
+}
+
+func tsTsOf(e tsEntry) int64 { return e.T }
+
+// TestTimeSeriesAppendAndSnapshot verifies appends land and snapshot copies.
+func TestTimeSeriesAppendAndSnapshot(t *testing.T) {
+	ts := newTimeSeries(10, 0, tsTsOf)
+	if ts.len() != 0 {
+		t.Fatalf("fresh len = %d, want 0", ts.len())
+	}
+	if !ts.append(tsEntry{T: 1, Val: 100}) {
+		t.Fatal("first append should store")
+	}
+	got := ts.snapshot()
+	if len(got) != 1 || got[0].Val != 100 {
+		t.Fatalf("snapshot = %+v, want one entry val=100", got)
+	}
+	// Mutating the returned copy must not leak into the buffer.
+	got[0].Val = 999
+	if again := ts.snapshot(); again[0].Val != 100 {
+		t.Errorf("snapshot is not a copy: got %d", again[0].Val)
+	}
+}
+
+// TestTimeSeriesThrottle verifies the min-interval throttle suppresses a rapid
+// second append and admits one past the interval.
+func TestTimeSeriesThrottle(t *testing.T) {
+	const interval = 300_000
+	ts := newTimeSeries(10, interval, tsTsOf)
+
+	if !ts.append(tsEntry{T: 1000}) {
+		t.Fatal("first append should store")
+	}
+	// Within the interval → suppressed.
+	if ts.append(tsEntry{T: 1000 + interval - 1}) {
+		t.Error("append within interval should be suppressed")
+	}
+	if ts.len() != 1 {
+		t.Fatalf("len = %d, want 1 after throttled append", ts.len())
+	}
+	// At/after the interval → admitted.
+	if !ts.append(tsEntry{T: 1000 + interval}) {
+		t.Error("append at interval boundary should be admitted")
+	}
+	if ts.len() != 2 {
+		t.Fatalf("len = %d, want 2", ts.len())
+	}
+}
+
+// TestTimeSeriesNoThrottle verifies a 0 interval admits every append (token
+// history behavior).
+func TestTimeSeriesNoThrottle(t *testing.T) {
+	ts := newTimeSeries(10, 0, tsTsOf)
+	for i := 0; i < 5; i++ {
+		if !ts.append(tsEntry{T: int64(i)}) {
+			t.Fatalf("append %d suppressed with no throttle", i)
+		}
+	}
+	if ts.len() != 5 {
+		t.Fatalf("len = %d, want 5", ts.len())
+	}
+}
+
+// TestTimeSeriesCap verifies the ring buffer keeps only the most-recent tail.
+func TestTimeSeriesCap(t *testing.T) {
+	const capacity = 3
+	ts := newTimeSeries(capacity, 0, tsTsOf)
+	for i := 0; i < 6; i++ {
+		ts.append(tsEntry{T: int64(i), Val: i})
+	}
+	got := ts.snapshot()
+	if len(got) != capacity {
+		t.Fatalf("len = %d, want cap %d", len(got), capacity)
+	}
+	// Oldest dropped: should hold the last 3 (Val 3,4,5).
+	if got[0].Val != 3 || got[2].Val != 5 {
+		t.Errorf("tail = %d..%d, want 3..5", got[0].Val, got[2].Val)
+	}
+}
+
+// TestTimeSeriesSeedTrimsToTail verifies seed trims an over-cap slice to the
+// most-recent tail and preserves ordering.
+func TestTimeSeriesSeedTrimsToTail(t *testing.T) {
+	const capacity = 4
+	ts := newTimeSeries(capacity, 0, tsTsOf)
+
+	over := make([]tsEntry, 10)
+	for i := range over {
+		over[i] = tsEntry{T: int64(i), Val: i}
+	}
+	ts.seed(over)
+
+	got := ts.snapshot()
+	if len(got) != capacity {
+		t.Fatalf("seeded len = %d, want cap %d", len(got), capacity)
+	}
+	if got[0].Val != 6 || got[len(got)-1].Val != 9 {
+		t.Errorf("kept tail = %d..%d, want 6..9", got[0].Val, got[len(got)-1].Val)
+	}
+}


### PR DESCRIPTION
## Motivation

The token, fact, and cost sparkline histories each hand-rolled the **same** ring buffer: a mutex, a slice, manual cap trimming, a min-interval throttle, and copy-on-read. This PR introduces one generic `timeSeries[T]` store and routes the three existing buffers through it.

## Behavior- and wire-preserving

The migration is entirely internal:

- Each history keeps its **own typed entry struct and JSON contract**. The on-disk files (`/data/token-sparkline-history.json`, `fact-history.json`, `cost-history.json`) and the existing endpoints (`/api/tokens`, `/api/knowledge/fact-history`, `/api/cost/history`) are **unchanged**.
- Caps and throttle intervals match the previous code exactly: token cap 288 / no throttle; fact & cost cap 8640 / 5-min throttle.
- Buffers are lazily built (`initHistories()` + `tokenSeries()`/`factSeries()`/`costSeries()`) so a zero-value `&Server{}` (used across tests) needs no constructor change.
- `lastFullBroadcast` — which previously sat in the token history's mutex field block but was actually guarded by `statusMu` — keeps its real guard. No behavior change.

## New (additive) endpoint

`GET /api/timeseries?series=<token|fact|cost>` dispatches to the same typed getters — an alias, not a replacement. The dedicated endpoints remain for back-compat.

## Client

Adds one `sparkline(name, color?)` helper backed by a `SPARKLINE_COLORS` map (single source of truth per series color), and routes the scattered `sparkSvg(getHistorySeries(...), color)` call sites (governor issues/prs/total/hold, beads workers/supervisor, token input/output/cache/messages/total) through it. Colors are preserved exactly, including govHold's muted tint.

## Scope note

This lands as **one** PR — the diff is a mechanical mutex/slice → generic-store swap plus a client helper, and the full existing suite exercises it. The PR-2 trend-history buffer (separate PR, not yet merged) can adopt `timeSeries[TrendHistoryEntry]` in a trivial follow-up once both land.

## Verification

- `go build ./...` passes.
- `go test ./pkg/dashboard/ ./pkg/hub/ -count=1` passes, including new `timeseries_test.go` (append, throttle boundary, no-throttle, cap tail, seed trim, copy-on-read) and the **existing** `cost_history_test.go`, which now runs against the generic backing.
- `gofmt -l` clean on all changed Go files.
- Extracted `sparkline` + `SPARKLINE_COLORS` and validated via `new Function`: color resolution matches the original per-site colors, unknown series falls back to muted, override arg honored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)