### PR TITLE
✨ feat(cost): opt-in Prometheus /metrics endpoint for estimated LLM cost

### DIFF
--- a/v2/pkg/dashboard/metrics_prometheus.go
+++ b/v2/pkg/dashboard/metrics_prometheus.go
@@ -1,0 +1,101 @@
+package dashboard
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+)
+
+// metricsEnabled reports whether the /metrics Prometheus endpoint is turned on.
+// Off by default (the endpoint exposes cost data unauthenticated); an operator
+// opts in with HIVE_METRICS_ENABLED=1|true|yes so a scraper on the pod network
+// can collect it.
+func metricsEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("HIVE_METRICS_ENABLED"))) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}
+
+// Prometheus text-exposition endpoint for hive's ESTIMATED LLM cost.
+//
+// This is deliberately dependency-free (no prometheus/client_golang): it writes
+// the stable text exposition format directly, reusing estimatedCost() so the
+// numbers are identical to the dashboard's Cost card and GET /api/cost.
+//
+// The whole surface is an ESTIMATE (token counts × list price) — the metric
+// names carry `estimated` and the HELP text says so, so a downstream FinOps
+// tool (e.g. OpenCost's FOCUS custom-cost plugin) never mistakes it for billed
+// spend. Values are all-time cumulative counters; scrapers derive rates via
+// increase()/rate() the usual way.
+//
+// Exposed series (labels: hive_id, plus model or agent):
+//
+//	hive_estimated_cost_usd{hive_id,model}          — per-model cumulative $
+//	hive_estimated_cost_usd_by_agent{hive_id,agent} — per-agent cumulative $
+//	hive_estimated_cost_usd_total{hive_id}          — grand total $
+//	hive_model_input_tokens_total{hive_id,model}    — per-model input tokens
+//	hive_model_output_tokens_total{hive_id,model}   — per-model output tokens
+func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
+	est := s.estimatedCost()
+
+	hiveID := ""
+	if s.deps != nil && s.deps.Config != nil {
+		hiveID = s.deps.Config.HiveID
+	}
+
+	var b strings.Builder
+
+	writeHeader := func(name, help, typ string) {
+		fmt.Fprintf(&b, "# HELP %s %s\n# TYPE %s %s\n", name, help, name, typ)
+	}
+
+	// Grand total.
+	writeHeader("hive_estimated_cost_usd_total",
+		"All-time cumulative ESTIMATED cost in USD (token counts x list price; not a bill).", "counter")
+	fmt.Fprintf(&b, "hive_estimated_cost_usd_total{hive_id=%q} %g\n", hiveID, est.TotalUSD)
+
+	// Per-model cost.
+	writeHeader("hive_estimated_cost_usd",
+		"All-time cumulative ESTIMATED cost in USD per model (token counts x list price; not a bill).", "counter")
+	for _, m := range sortedByName(est.ByModel) {
+		fmt.Fprintf(&b, "hive_estimated_cost_usd{hive_id=%q,model=%q,source=%q} %g\n",
+			hiveID, m.Name, m.Source, m.USD)
+	}
+
+	// Per-agent cost.
+	writeHeader("hive_estimated_cost_usd_by_agent",
+		"All-time cumulative ESTIMATED cost in USD per agent (token counts x list price; not a bill).", "counter")
+	for _, a := range sortedByName(est.ByAgent) {
+		fmt.Fprintf(&b, "hive_estimated_cost_usd_by_agent{hive_id=%q,agent=%q} %g\n",
+			hiveID, a.Name, a.USD)
+	}
+
+	// Per-model token counters (the price-independent basis of the estimate).
+	writeHeader("hive_model_input_tokens_total",
+		"All-time cumulative input tokens per model.", "counter")
+	for _, m := range sortedByName(est.ByModel) {
+		fmt.Fprintf(&b, "hive_model_input_tokens_total{hive_id=%q,model=%q} %d\n", hiveID, m.Name, m.Input)
+	}
+	writeHeader("hive_model_output_tokens_total",
+		"All-time cumulative output tokens per model.", "counter")
+	for _, m := range sortedByName(est.ByModel) {
+		fmt.Fprintf(&b, "hive_model_output_tokens_total{hive_id=%q,model=%q} %d\n", hiveID, m.Name, m.Output)
+	}
+
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	_, _ = w.Write([]byte(b.String()))
+}
+
+// sortedByName returns the entries sorted by Name so the exposition output is
+// stable across scrapes (Prometheus doesn't require order, but stable output
+// makes diffs and tests deterministic).
+func sortedByName(in []costModelEntry) []costModelEntry {
+	out := make([]costModelEntry, len(in))
+	copy(out, in)
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}

--- a/v2/pkg/dashboard/metrics_prometheus_test.go
+++ b/v2/pkg/dashboard/metrics_prometheus_test.go
@@ -1,0 +1,45 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestMetricsEnabledToggle(t *testing.T) {
+	for _, v := range []string{"1", "true", "TRUE", "yes", "on"} {
+		t.Setenv("HIVE_METRICS_ENABLED", v)
+		if !metricsEnabled() {
+			t.Errorf("HIVE_METRICS_ENABLED=%q should enable metrics", v)
+		}
+	}
+	for _, v := range []string{"", "0", "false", "no", "off", "garbage"} {
+		t.Setenv("HIVE_METRICS_ENABLED", v)
+		if metricsEnabled() {
+			t.Errorf("HIVE_METRICS_ENABLED=%q should NOT enable metrics", v)
+		}
+	}
+}
+
+func TestHandleMetricsExposition(t *testing.T) {
+	s := covApiServer(t)
+	s.deps.Config.HiveID = "test-hive"
+	// The route is only registered when metrics are enabled, so exercise the
+	// handler directly — the exposition format is what's under test.
+	rec := httptest.NewRecorder()
+	s.handleMetrics(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := rec.Body.String()
+	for _, want := range []string{
+		"# TYPE hive_estimated_cost_usd_total counter",
+		"hive_estimated_cost_usd_total{hive_id=\"test-hive\"}",
+		"# HELP hive_model_input_tokens_total",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("exposition missing %q\n---\n%s", want, body)
+		}
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("Content-Type = %q, want text/plain exposition", ct)
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -502,6 +502,12 @@ func (s *Server) registerCoreRoutes() {
 	s.mux.HandleFunc("GET /api/health", s.handleHealth)
 	s.mux.HandleFunc("GET /api/health/deep", s.handleHealthDeep)
 	s.mux.HandleFunc("GET /api/livez", s.handleLivez)
+	// Prometheus scrape endpoint for estimated LLM cost — opt-in, since it
+	// exposes cost data unauthenticated (Prometheus can't do device-flow auth).
+	// Enabled only when HIVE_METRICS_ENABLED is truthy; see isPublicPath.
+	if metricsEnabled() {
+		s.mux.HandleFunc("GET /metrics", s.handleMetrics)
+	}
 	s.mux.HandleFunc("GET /api/status", s.handleStatus)
 	s.mux.HandleFunc("GET /api/events", s.handleSSE)
 	s.mux.HandleFunc("POST /api/github-app/recheck", s.handleGitHubAppRecheck)
@@ -675,6 +681,10 @@ func isPublicPath(path string) bool {
 		// pod is never restarted (the exact bug this endpoint was added to fix).
 		return true
 	case path == "/api/auth/token":
+		return true
+	case path == "/metrics" && metricsEnabled():
+		// Prometheus scrape target — public only when explicitly enabled via
+		// HIVE_METRICS_ENABLED. Prometheus cannot authenticate via device flow.
 		return true
 	case path == "/snapshot" || strings.HasPrefix(path, "/snapshot/"):
 		return true


### PR DESCRIPTION
## Summary

A dependency-free Prometheus `/metrics` endpoint exposing hive's **estimated** LLM cost, as the first concrete step toward FinOps integration (OpenCost's FOCUS custom-cost plugin already tracks LLM token cost; once our data is scrapable it's portable to any FinOps/observability stack).

Reuses `estimatedCost()`, so the numbers are identical to the Cost card and `GET /api/cost`. Series (labels `hive_id` + model/agent):
- `hive_estimated_cost_usd{model,source}` / `_by_agent{agent}` / `_total`
- `hive_model_input_tokens_total{model}` / `hive_model_output_tokens_total{model}`

## Off by default (security)
The endpoint exposes cost data **unauthenticated** (Prometheus can't do device-flow login), so it's registered and made public **only** when `HIVE_METRICS_ENABLED` is truthy. The gate is an **env var, not dashboard config**, on purpose: enabling an auth-exposure endpoint must be deterministic at process start and live next to the scrape/ServiceMonitor config — not routed through the runtime dashboard overlay (the same overlay path whose boot-only application caused today's Certus access issue). Metric names + HELP text carry `estimated` so nothing downstream mistakes a list-price estimate for billed spend.

## Test plan
- `TestMetricsEnabledToggle` — truthy values enable, everything else (incl. unset) disables
- `TestHandleMetricsExposition` — exposition format, `hive_id` label, HELP/TYPE lines, text/plain content-type
- `go build` + `go test ./pkg/dashboard/` pass; gofmt clean

Dependency-free (writes the text format directly; no client_golang).

🤖 Generated with [Claude Code](https://claude.com/claude-code)