### PR TITLE
🐛 fix(hub): register migrateHive goroutine with provisionWG (fixes v2 Tests flake)

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1978,7 +1978,14 @@ func (s *HubServer) handleMigrateHive(w http.ResponseWriter, r *http.Request) {
 	s.logger.Info("audit: hive migration initiated",
 		"hive_id", id, "from", currentClusterID, "to", req.TargetClusterID, "by", username)
 
-	go s.migrateHive(h, &fromCluster, &toCluster)
+	// Registered with provisionWG so tests can drain this goroutine before
+	// swapping the package-level saas*Dir vars. Without it, migrateHive's
+	// saveSaaSHive call races the next test's temp-dir teardown.
+	provisionWG.Add(1)
+	go func() {
+		defer provisionWG.Done()
+		s.migrateHive(h, &fromCluster, &toCluster)
+	}()
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{


### PR DESCRIPTION
## The flake

`v2 Tests` has been red intermittently all day across unrelated commits. It most recently failed on the `v2` merge commit blaming `TestStartLatestSHAPollerPreLoop`, with `race detected during execution of test`.

That attribution is misleading, which is why this read as noise. The race is reported against whichever test happens to be running when an **orphaned goroutine** fires — locally it surfaced as `TestPushVisibilityToSpoke` and `TestHandleUpgradeHiveKubectlFails` instead.

## Root cause

`handleMigrateHive` launched the migration without registering it:

```go
go s.migrateHive(h, &fromCluster, &toCluster)
```

`provisionWG` exists precisely for this, and its doc comment spells out the contract:

> `provisionWG` tracks async hive-provisioning goroutines so tests (which swap the package-level `saas*Dir` path variables) can wait for them to drain before mutating shared state.

The provisioning path at `saas.go:1734` opts in; the migrate path never did. So `TestHandleMigrateHiveSuccess` calls `provisionWG.Wait()` (line 168) and it returns immediately — the goroutine escapes, then calls `saveSaaSHive` and reads the package-level path vars while a *later* test's `helperSetupTempDirs` cleanup writes them.

Race trace from CI:
- **Write** — `helperSetupTempDirs.func1()` at `hub_filesystem_test.go:43` (a test's deferred cleanup)
- **Previous read** — `saveSaaSHive()` at `saas_provision.go:418`, via `migrateHive()` ← `handleMigrateHive.gowrap1()` at `saas.go:1981`

## Fix

Wrap the goroutine in `provisionWG.Add(1)` / `defer provisionWG.Done()`, matching the existing pattern at `saas.go:1734`.

I audited the other goroutine launches in `saas.go` (lines 167-171, 724, 2288). None touch the `saas*Dir` vars — line 724's is awaited via channel, and `pushVisibilityToSpoke` doesn't hit that state. `migrateHive` was the only leak.

## Verification

Full `pkg/hub` package under `-race`:

| | Result |
|---|---|
| before (stashed fix) | `3x WARNING: DATA RACE`, `--- FAIL: TestPushVisibilityToSpoke`, `--- FAIL: TestHandleUpgradeHiveKubectlFails` |
| after | `ok github.com/kubestellar/hive/v2/pkg/hub 91.803s` |

`go build` and `go vet` clean.

Found while verifying an unrelated landing-page deploy (#2040) — that PR touched only `index.html` and did not cause this.