### PR TITLE
🐛 fix(hub): migrateHive goroutine race in tests (#2043)

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1978,7 +1978,14 @@ func (s *HubServer) handleMigrateHive(w http.ResponseWriter, r *http.Request) {
 	s.logger.Info("audit: hive migration initiated",
 		"hive_id", id, "from", currentClusterID, "to", req.TargetClusterID, "by", username)
 
-	go s.migrateHive(h, &fromCluster, &toCluster)
+	// Register with provisionWG so tests can drain this goroutine before
+	// mutating the shared package-level path vars; migrateHive reads them
+	// (via provisionHive) and would otherwise outlive the request/test.
+	provisionWG.Add(1)
+	go func() {
+		defer provisionWG.Done()
+		s.migrateHive(h, &fromCluster, &toCluster)
+	}()
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{


### PR DESCRIPTION
## Problem

`pkg/hub` tests intermittently fail under `-race` with a DATA RACE, tracked as #2043 (e.g. `--- FAIL: TestStartLatestSHAPollerPreLoop`). This is a **different** leak than the one fixed in #2026 (the SHA poller); it reproduces on `7760ce3`/current `v2`, which postdates #2026.

## Root cause

`handleMigrateHive` (`saas.go`) launched the migration worker with a bare `go s.migrateHive(...)` and **never registered it with `provisionWG`**. `migrateHive` → `provisionHive` reads the package-level `saas*Dir` path variables. When the spawning test returns, that goroutine can still be running; a later test's `helperSetupTempDirs` `t.Cleanup` (`hub_filesystem_test.go:42-43`) then **rewrites** those path vars — read vs. write with no synchronization.

`TestHandleMigrateHiveSuccess` already calls `provisionWG.Wait()`, but `provisionWG` only ever covered the async **provision** goroutine (`saas.go:1734`), not the **migrate** goroutine — so the join was a no-op and the goroutine leaked past the test.

The failing test in any given run is just whichever test happened to be executing when the leaked goroutine finally raced — the fault is the leaked `migrateHive` goroutine, not that test.

## Fix

Register the migrate goroutine with `provisionWG` (mirroring the provision path), so the existing `provisionWG.Wait()` in the migrate test deterministically drains it before shared state is mutated. `provisionWG` is only ever `Wait()`ed from tests, so **production behavior is unchanged** — this is a test-synchronization fix, not a behavioral change.

## Verification

- Reproduced the DATA RACE before the fix (`go test ./pkg/hub/ -run 'TestHandleMigrate|TestStartLatestSHAPoller' -race -count=50` → FAIL).
- After the fix: `go test ./pkg/hub/ -race -count=50` (whole package) passes with no data races; targeted `-run 'TestHandleMigrate|TestStartLatestSHAPoller' -race -count=50` passes.
- `go build ./...` clean; `gofmt -l` clean on changed file.

Fixes #2043