### PR TITLE
🐛 fix(cost): drop 'auto'/'default' routing aliases from the model table

### DIFF
--- a/v2/pkg/tokens/pricing.go
+++ b/v2/pkg/tokens/pricing.go
@@ -126,6 +126,18 @@ var modelPrices = map[string]ModelPrice{
 // It strips a leading provider prefix ("anthropic/", "openai/", …), lowercases,
 // unifies '.' and '_' separators to '-', and collapses repeated dashes. The
 // result is a table-lookup key, not a display string.
+// isRoutingAlias reports whether a NORMALIZED model id is a routing/selection
+// mode ("auto", "default") rather than a real model. Tokens are attributed to
+// the resolved model, so these carry ~no usage and should not appear as cost
+// rows. Pass the output of normalizeModelID.
+func isRoutingAlias(normalizedID string) bool {
+	switch normalizedID {
+	case "", "auto", "default":
+		return true
+	}
+	return false
+}
+
 func normalizeModelID(model string) string {
 	id := strings.TrimSpace(strings.ToLower(model))
 	if id == "" {
@@ -275,6 +287,12 @@ func EstimateFromSummary(agg *AggregateSummary) EstimatedCost {
 			continue
 		}
 		key := normalizeModelID(model)
+		// Skip routing aliases — "auto"/"default" are selection MODES, not
+		// models. The tokens are attributed to the resolved model, so these
+		// buckets are always ~empty and just add a noise row to the cost table.
+		if isRoutingAlias(key) {
+			continue
+		}
 		m := merged[key]
 		if m == nil {
 			m = &mergedBucket{display: model}

--- a/v2/pkg/tokens/pricing_test.go
+++ b/v2/pkg/tokens/pricing_test.go
@@ -200,3 +200,33 @@ func TestEstimateFromSummary_ModelDedup(t *testing.T) {
 		t.Errorf("merged cost = $%.4f, want $30 (opus 1M in + 1M out)", mc.USD)
 	}
 }
+
+// TestEstimateFromSummary_DropsRoutingAliases verifies "auto"/"default" are
+// excluded from the cost table (they're selection modes, not models).
+func TestEstimateFromSummary_DropsRoutingAliases(t *testing.T) {
+	agg := &AggregateSummary{
+		ByModelDetail: map[string]*AgentModelBucket{
+			"auto":            {Input: 0, Output: 0},
+			"default":         {Input: 0, Output: 0},
+			"claude-opus-4-8": {Input: 1_000_000, Output: 0},
+		},
+	}
+	est := EstimateFromSummary(agg)
+	if _, ok := est.ByModel["auto"]; ok {
+		t.Error("'auto' must not appear as a cost row")
+	}
+	if _, ok := est.ByModel["default"]; ok {
+		t.Error("'default' must not appear as a cost row")
+	}
+	if _, ok := est.ByModel["claude-opus-4-8"]; !ok {
+		t.Error("real model dropped")
+	}
+	if len(est.ByModel) != 1 {
+		t.Errorf("expected only the real model, got %d rows: %v", len(est.ByModel), est.ByModel)
+	}
+	for _, m := range est.UnpricedModels {
+		if m == "auto" || m == "default" {
+			t.Errorf("routing alias %q leaked into UnpricedModels", m)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`auto` was showing as a row in the cost model table (0 tokens, ~$0.00). It's a **selection mode, not a model** — the tokens land on the resolved model, so the `auto` bucket is always empty and just noise. `EstimateFromSummary` now skips routing aliases (`auto`, `default`, empty) when building `by_model`.

## Test plan
- Go: `TestEstimateFromSummary_DropsRoutingAliases` (auto/default excluded, real model kept, no alias in UnpricedModels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)