### PR TITLE
✨ planning: Phase 4 — plan a GitHub issue from the dashboard + config-driven tier keywords

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2128,6 +2128,72 @@ func (k agentKicker) Kick(agent, message string) error {
 	return k.mgr.SendKick(agent, message)
 }
 
+// planFromLabeledIssues is Phase 4 Part B: for each actionable issue carrying a
+// `plan`/`epic` label, mint an epic (idempotent) and hand it to the architect,
+// RESPECTING the architect's pause. It is a plain synchronous call on the eval
+// tick — no goroutine — and only ever touches the manager via SendKick/IsPaused,
+// exactly like every governor kick, so it never re-enters the launch-path mutex.
+// Epics are minted into the architect store (falling back to any store) so the
+// dashboard plan-review flow and replan lane find them the same way.
+//
+// A minted epic is decompose_pending (plan_status=draft). While the architect is
+// paused, the request stays queued and visible (the PLANNING tile shows it as
+// pending) — we never force-unpause. Once the architect is available, we kick it
+// each cycle until it decomposes and clears the pending marker.
+func planFromLabeledIssues(
+	actionable *github.ActionableResult,
+	beadStores map[string]*beads.Store,
+	agentMgr *agent.Manager,
+	gov *governor.Governor,
+	dashSrv *dashboard.Server,
+	logger *slog.Logger,
+) {
+	if actionable == nil || len(beadStores) == 0 {
+		return
+	}
+	store, ok := beadStores[planning.ArchitectAgentName]
+	if !ok {
+		for name := range beadStores {
+			store = beadStores[name]
+			break
+		}
+	}
+	if store == nil {
+		return
+	}
+
+	sink := labelPlanSink{gov: gov, dashSrv: dashSrv, logger: logger}
+	planning.PlanIssuesFromLabels(store, agentMgr, actionable.Issues.Items, sink,
+		func(ref string, err error) {
+			logger.Warn("plan-from-label: minting epic failed", "issue", ref, "error", err)
+		})
+}
+
+// labelPlanSink adapts the governor/dashboard/logger to planning.LabelPlanSink so
+// the label-trigger core lives (and is tested) in pkg/planning.
+type labelPlanSink struct {
+	gov     *governor.Governor
+	dashSrv *dashboard.Server
+	logger  *slog.Logger
+}
+
+func (s labelPlanSink) KickedPlan(epic *beads.Bead) {
+	s.gov.RecordKick(planning.ArchitectAgentName)
+	if s.dashSrv != nil {
+		s.dashSrv.AuditLog("planning", "plan_from_label", "epic="+epic.ID+" ref="+epic.ExternalRef, planning.ArchitectAgentName)
+	}
+	s.logger.Info("audit: plan requested from labeled issue", "epic", epic.ID, "ref", epic.ExternalRef)
+}
+
+func (s labelPlanSink) QueuedPlan(epic *beads.Bead, paused bool) {
+	if paused {
+		// Architect deliberately paused — queue, do not unpause, log once.
+		s.logger.Info("plan-from-label: architect paused, plan queued", "epic", epic.ID, "ref", epic.ExternalRef)
+		return
+	}
+	s.logger.Warn("plan-from-label: architect unavailable, plan queued", "epic", epic.ID, "ref", epic.ExternalRef)
+}
+
 // diagnoseGitHubAppWrite returns "" when the configured GitHub App
 // installation belongs to expectedOwner and grants issues:write. Otherwise it
 // returns a banner-ready diagnosis distinguishing the two write-failure causes
@@ -2372,6 +2438,17 @@ func runEvalCycle(
 		if err := store.Reload(); err != nil {
 			logger.Warn("failed to reload beads from disk", "agent", name, "error", err)
 		}
+	}
+
+	// Phase 4 Part B: `plan`/`epic` label trigger. An actionable issue carrying a
+	// plan label auto-mints an epic and requests decomposition — the same flow as
+	// the dashboard "Plan this issue" click, but triggered by the label. It runs
+	// AFTER the store reload so FindByExternalRef sees current state (idempotent:
+	// no duplicate epic if one already exists). Cheap, synchronous, adds NO
+	// goroutine, and drives the architect only via SendKick (never the launch
+	// path). Gated by config/ACMM so low-maturity hives stay advisory-only.
+	if cfg.Planning.PlanFromLabelEnabled(inferACMMLevel(cfg)) {
+		planFromLabeledIssues(actionable, beadStores, agentMgr, gov, dashSrv, logger)
 	}
 
 	// Advisory digest: build from beads (the source of truth) before status broadcast.
@@ -3159,6 +3236,11 @@ func initAgentConfigDrivenSystems(cfg *config.Config) {
 	if len(lanes) > 0 {
 		classify.SetLanes(lanes)
 	}
+	// Tier-classification keywords (config-driven, mirroring SetLanes). Empty
+	// lists leave the built-in defaults in force, so an absent classifier block
+	// keeps behavior unchanged. Always call so a reload that CLEARS the block
+	// restores defaults.
+	classify.SetTierKeywords(cfg.Classifier.SimpleKeywords, cfg.Classifier.ComplexSignals)
 	if len(detectKeywords) > 0 {
 		tokens.SetDetectKeywords(detectKeywords)
 	}

--- a/v2/docs/planning-intelligence.md
+++ b/v2/docs/planning-intelligence.md
@@ -1,0 +1,142 @@
+# Planning Intelligence
+
+**Planning intelligence** turns a big, vague GitHub issue into an ordered,
+reviewable plan of small sub-tasks — and gates that plan behind a human approval
+before any agent starts work. It is how Hive handles work that is too large for a
+single agent kick: instead of one agent thrashing on an epic, the **architect**
+lane decomposes it into a DAG of child beads, a human reviews the plan, and only
+then are the children released to the fleet.
+
+The feature has four moving parts:
+
+1. **Decompose** — the architect breaks an epic into ordered, dependency-linked,
+   execution-tagged sub-tasks (child beads).
+2. **Plan-review gate** — a decomposed plan starts as a **draft**; its children
+   are withheld from `Ready()` (no agent can claim them) until a human approves.
+3. **Stall-replan** — if an approved plan stops progressing, the governor
+   re-kicks the architect to revise the unfinished work, bounded by a replan cap.
+4. **The issue entry point** (this page's focus) — how a GitHub issue *becomes*
+   an epic to plan, by label or by a dashboard click.
+
+## Planning a GitHub issue
+
+There are two ways to ask Hive to plan an issue. **The `plan` label is the
+primary, first-class trigger** — maintainers think in labels, and it needs no
+dashboard at all. The dashboard button is a convenience for the same flow.
+
+### 1. The `plan` label (recommended)
+
+Add the label **`plan`** (or **`epic`**) to any issue in a repo Hive watches. On
+the next eval cycle Hive:
+
+- mints an **epic bead** from the issue (idempotently — labeling the same issue
+  twice never creates a second epic),
+- marks it `plan_status=draft` and `decompose_pending`, so it shows up
+  immediately in the dashboard as a queued plan, and
+- hands it to the architect to decompose.
+
+When the architect finishes, the plan appears in the plan-review view for your
+approval. Remove/re-add the label at will — the epic is keyed to the issue.
+
+The label trigger is gated so low-maturity hives stay advisory-only. By default
+it is **on at ACMM L4 and above**; you can force it on or off explicitly:
+
+```yaml
+planning:
+  plan_from_label: true   # force on regardless of ACMM level (omit to use the L4+ default)
+```
+
+### 2. The **⧉ Plan** button (dashboard)
+
+Every actionable issue pill on the dashboard has a **⧉ Plan** button. Click it to
+run the exact same flow as the label — mint the epic and request decomposition —
+without leaving the dashboard. The button is always available (it does not depend
+on ACMM level); the label path is what the ACMM gate governs.
+
+## The architect is a shared agent — and its pause is respected
+
+Decomposition is driven by the **architect** agent, which is a *general-purpose*
+lane with its own pre-existing job (RFCs, refactor and performance scans).
+Decomposition is just one more thing it does, so:
+
+> **If you have paused the architect, Hive does NOT auto-unpause it and does NOT
+> silently drop your plan request.** The epic is minted and queued
+> (`decompose_pending`), and it waits until you resume the architect.
+
+When a plan is queued because the architect is paused, Hive tells you clearly —
+in the **⧉ Plan** toast, and on the governor **PLANNING** tile:
+
+> ⏸ Architect is paused — this plan won't be built until you resume the architect agent.
+
+You paused it deliberately; this message makes sure you know that is *why*
+nothing is happening, and points you at the fix. Resume the architect (or let its
+cadence fire) and it picks up every queued plan on the next cycle, clears the
+`decompose_pending` marker as it materializes children, and the normal
+plan-review flow takes over.
+
+Everything here drives the architect through the same out-of-band kick path the
+governor already uses (`SendKick` / `IsPaused`); it never touches the
+agent-launch mutex.
+
+## Reviewing and approving a plan
+
+A decomposed epic is a **draft**: its child beads are hidden from `Ready()`, so no
+agent can start the work yet. In the plan-review view you can:
+
+- inspect the ordered children with their execution tags (`agent_suitable` /
+  `human_required`) and dependency edges,
+- **retag** or **remove** a child before approving,
+- **approve** — releasing the children through `Ready()` so the fleet can claim
+  them, or
+- **reject** — returning the plan to draft (re-gating the children) so the
+  architect can revise it.
+
+High-maturity ACMM packs may enable `plan_auto_approve`, which approves a plan at
+decomposition time (no review gate); by default the gate is on.
+
+## The PLANNING governor tile
+
+The governor's **PLANNING** metric summarizes plan state across all bead stores:
+
+- **active** — epics that have been decomposed (draft or approved),
+- **review** — drafts awaiting human approval,
+- **queued** — issue-sourced epics not yet built by the architect
+  (`decompose_pending`),
+- and a **⏸** marker plus a warning tooltip when queued work is blocked on a
+  paused architect.
+
+When there is no planning activity at all, the tile's tooltip nudges you toward
+the feature: *click ⧉ Plan on any issue, or add the `plan` label on GitHub.*
+
+## Configuration reference
+
+```yaml
+# Auto-plan issues carrying the `plan`/`epic` label. Omit to use the ACMM gate
+# (on at L4+); set explicitly to force on/off.
+planning:
+  plan_from_label: true
+
+# Tier-classification keywords (used to pick a model per issue) are config-driven
+# and shown in the dashboard governor-config view. Empty/absent keeps the
+# built-in defaults, so behavior is unchanged when unset.
+classifier:
+  simple_keywords: [typo, i18n, rename, const, label, badge, tooltip, placeholder, aria, "alt text"]
+  complex_signals: ["race condition", deadlock, "memory leak", performance, "api change"]
+
+# Stall-replan lane (Phase 3): re-kicks the architect on stalled plans.
+governor:
+  replan:
+    enabled: true
+    interval_s: 1800        # scan cadence (default 30m)
+    stall_threshold_s: 21600 # no child progress for 6h → stalled
+    max_replans: 5          # cap before escalating to a human
+```
+
+## Safety properties
+
+- **Idempotent**: an issue maps to exactly one epic (keyed by a stable issue
+  ref); the label trigger and repeated clicks never duplicate it.
+- **Respects pause**: a paused architect queues plans, it is never force-resumed.
+- **Gated**: draft-plan children are unclaimable until a human approves.
+- **No launch-path mutex**: all architect interaction is via `SendKick`/`IsPaused`
+  from the governor tick or an HTTP handler — never the agent-launch path.

--- a/v2/pkg/classify/classifier.go
+++ b/v2/pkg/classify/classifier.go
@@ -50,9 +50,68 @@ type Classification struct {
 	ClusterKey string              `json:"cluster_key,omitempty"`
 }
 
-var simpleKeywords = []string{
+// defaultSimpleKeywords are the built-in title keywords that mark an issue as
+// Tier "Simple". Kept as the fallback when no config-driven set is provided via
+// SetTierKeywords, so behavior is unchanged when the classifier block is absent
+// from hive.yaml.
+var defaultSimpleKeywords = []string{
 	"typo", "i18n", "rename", "const", "label", "badge",
 	"tooltip", "placeholder", "aria", "alt text",
+}
+
+// defaultComplexSignals are the built-in title signals that mark an issue as
+// Tier "Complex". Like defaultSimpleKeywords, this is the fallback used when
+// SetTierKeywords has not been called with a non-empty complex set.
+var defaultComplexSignals = []string{
+	"race condition", "deadlock", "memory leak", "performance", "api change",
+}
+
+var tierMu sync.RWMutex
+var configuredSimpleKeywords []string
+var configuredComplexSignals []string
+
+// SetTierKeywords replaces the tier-classification keyword sets used by
+// classifyTier, mirroring SetLanes. Empty slices leave the corresponding
+// default in force, so a partial config (only simple, only complex, or neither)
+// still classifies with the built-in list for the unset side. It is safe to
+// call concurrently with Classify.
+func SetTierKeywords(simple, complex []string) {
+	tierMu.Lock()
+	defer tierMu.Unlock()
+	configuredSimpleKeywords = simple
+	configuredComplexSignals = complex
+}
+
+// activeSimpleKeywords returns the configured Simple-tier keywords, or the
+// built-in defaults when none are configured.
+func activeSimpleKeywords() []string {
+	tierMu.RLock()
+	defer tierMu.RUnlock()
+	if len(configuredSimpleKeywords) > 0 {
+		return configuredSimpleKeywords
+	}
+	return defaultSimpleKeywords
+}
+
+// activeComplexSignals returns the configured Complex-tier signals, or the
+// built-in defaults when none are configured.
+func activeComplexSignals() []string {
+	tierMu.RLock()
+	defer tierMu.RUnlock()
+	if len(configuredComplexSignals) > 0 {
+		return configuredComplexSignals
+	}
+	return defaultComplexSignals
+}
+
+// TierKeywords returns copies of the currently-effective Simple keywords and
+// Complex signals (config-driven when set, else the built-in defaults). The
+// dashboard governor-config endpoint surfaces these so operators can see exactly
+// which lists are in force. Copies are returned so callers cannot mutate
+// classifier state.
+func TierKeywords() (simple, complex []string) {
+	return append([]string(nil), activeSimpleKeywords()...),
+		append([]string(nil), activeComplexSignals()...)
 }
 
 // defaultLanes is the built-in lane config used when no config-driven lanes are provided.
@@ -129,7 +188,7 @@ func classifyLane(titleLower, labelsStr string) Lane {
 }
 
 func classifyTier(titleLower, labelsStr string, labels []string) Tier {
-	for _, kw := range simpleKeywords {
+	for _, kw := range activeSimpleKeywords() {
 		if strings.Contains(titleLower, kw) {
 			return TierSimple
 		}
@@ -145,8 +204,7 @@ func classifyTier(titleLower, labelsStr string, labels []string) Tier {
 		return TierComplex
 	}
 
-	complexSignals := []string{"race condition", "deadlock", "memory leak", "performance", "api change"}
-	for _, sig := range complexSignals {
+	for _, sig := range activeComplexSignals() {
 		if strings.Contains(titleLower, sig) {
 			return TierComplex
 		}

--- a/v2/pkg/classify/classify_tier_keywords_test.go
+++ b/v2/pkg/classify/classify_tier_keywords_test.go
@@ -1,0 +1,117 @@
+package classify
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// resetTierKeywords restores the default (unconfigured) tier keyword state so
+// tests do not leak configuration into one another.
+func resetTierKeywords() { SetTierKeywords(nil, nil) }
+
+func TestSetTierKeywords_DefaultsWhenUnset(t *testing.T) {
+	defer resetTierKeywords()
+	resetTierKeywords()
+
+	simple, complex := TierKeywords()
+	if !reflect.DeepEqual(simple, defaultSimpleKeywords) {
+		t.Errorf("simple defaults = %v, want %v", simple, defaultSimpleKeywords)
+	}
+	if !reflect.DeepEqual(complex, defaultComplexSignals) {
+		t.Errorf("complex defaults = %v, want %v", complex, defaultComplexSignals)
+	}
+}
+
+func TestClassifyTier_DefaultsUnchanged(t *testing.T) {
+	defer resetTierKeywords()
+	resetTierKeywords()
+
+	cases := []struct {
+		title string
+		want  Tier
+	}{
+		{"Fix typo in README", TierSimple},           // default simple keyword
+		{"rename the variable", TierSimple},          // default simple keyword
+		{"race condition in scheduler", TierComplex}, // default complex signal
+		{"memory leak in cache", TierComplex},        // default complex signal
+		{"add a new dashboard card", TierMedium},     // neither
+	}
+	for _, tc := range cases {
+		got := Classify(github.Issue{Title: tc.title}).Tier
+		if got != tc.want {
+			t.Errorf("Classify(%q).Tier = %q, want %q", tc.title, got, tc.want)
+		}
+	}
+}
+
+func TestSetTierKeywords_Overrides(t *testing.T) {
+	defer resetTierKeywords()
+	SetTierKeywords([]string{"trivial"}, []string{"quantum"})
+
+	simple, complex := TierKeywords()
+	if !reflect.DeepEqual(simple, []string{"trivial"}) {
+		t.Errorf("simple override = %v", simple)
+	}
+	if !reflect.DeepEqual(complex, []string{"quantum"}) {
+		t.Errorf("complex override = %v", complex)
+	}
+
+	// The custom keywords now drive classification...
+	if got := Classify(github.Issue{Title: "a trivial change"}).Tier; got != TierSimple {
+		t.Errorf("custom simple: got %q, want Simple", got)
+	}
+	if got := Classify(github.Issue{Title: "quantum entanglement bug"}).Tier; got != TierComplex {
+		t.Errorf("custom complex: got %q, want Complex", got)
+	}
+	// ...and the OLD defaults no longer apply (they were replaced).
+	if got := Classify(github.Issue{Title: "fix typo"}).Tier; got == TierSimple {
+		t.Errorf("default 'typo' should not classify Simple after override, got %q", got)
+	}
+	if got := Classify(github.Issue{Title: "race condition"}).Tier; got == TierComplex {
+		t.Errorf("default 'race condition' should not classify Complex after override, got %q", got)
+	}
+}
+
+func TestSetTierKeywords_PartialKeepsOtherDefault(t *testing.T) {
+	defer resetTierKeywords()
+	// Configure only simple; complex must keep its default set.
+	SetTierKeywords([]string{"tweak"}, nil)
+
+	simple, complex := TierKeywords()
+	if !reflect.DeepEqual(simple, []string{"tweak"}) {
+		t.Errorf("simple = %v, want [tweak]", simple)
+	}
+	if !reflect.DeepEqual(complex, defaultComplexSignals) {
+		t.Errorf("complex = %v, want defaults", complex)
+	}
+	// Default complex signal still classifies since only simple was overridden.
+	if got := Classify(github.Issue{Title: "deadlock in queue"}).Tier; got != TierComplex {
+		t.Errorf("default complex 'deadlock' lost: got %q", got)
+	}
+}
+
+func TestTierKeywords_ReturnsCopies(t *testing.T) {
+	defer resetTierKeywords()
+	SetTierKeywords([]string{"a"}, []string{"b"})
+
+	simple, complex := TierKeywords()
+	simple[0] = "mutated"
+	complex[0] = "mutated"
+
+	// A fresh read must be unaffected by the caller's mutation.
+	simple2, complex2 := TierKeywords()
+	if simple2[0] != "a" || complex2[0] != "b" {
+		t.Errorf("TierKeywords did not return copies: %v %v", simple2, complex2)
+	}
+}
+
+func TestSetTierKeywords_EmptySliceFallsBackToDefault(t *testing.T) {
+	defer resetTierKeywords()
+	SetTierKeywords([]string{}, []string{})
+	simple, complex := TierKeywords()
+	if !reflect.DeepEqual(simple, defaultSimpleKeywords) || !reflect.DeepEqual(complex, defaultComplexSignals) {
+		t.Errorf("empty slices should fall back to defaults, got %v / %v", simple, complex)
+	}
+}

--- a/v2/pkg/config/classifier_planning_test.go
+++ b/v2/pkg/config/classifier_planning_test.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestPlanFromLabelEnabled(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  PlanningConfig
+		acmm int
+		want bool
+	}{
+		{"explicit true wins at L1", PlanningConfig{PlanFromLabel: boolPtr(true)}, 1, true},
+		{"explicit false wins at L6", PlanningConfig{PlanFromLabel: boolPtr(false)}, 6, false},
+		{"nil defaults off below L4", PlanningConfig{}, 3, false},
+		{"nil defaults on at L4", PlanningConfig{}, 4, true},
+		{"nil defaults on above L4", PlanningConfig{}, 6, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.PlanFromLabelEnabled(tc.acmm); got != tc.want {
+				t.Errorf("PlanFromLabelEnabled(%d) = %v, want %v", tc.acmm, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifierConfig_YAML(t *testing.T) {
+	src := `
+classifier:
+  simple_keywords: [tweak, nit]
+  complex_signals: [distributed-consensus]
+planning:
+  plan_from_label: true
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(src), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(cfg.Classifier.SimpleKeywords, []string{"tweak", "nit"}) {
+		t.Errorf("simple_keywords = %v", cfg.Classifier.SimpleKeywords)
+	}
+	if !reflect.DeepEqual(cfg.Classifier.ComplexSignals, []string{"distributed-consensus"}) {
+		t.Errorf("complex_signals = %v", cfg.Classifier.ComplexSignals)
+	}
+	if cfg.Planning.PlanFromLabel == nil || !*cfg.Planning.PlanFromLabel {
+		t.Errorf("plan_from_label = %v, want true", cfg.Planning.PlanFromLabel)
+	}
+}
+
+func TestClassifierConfig_AbsentIsZero(t *testing.T) {
+	var cfg Config
+	if err := yaml.Unmarshal([]byte("project: {}\n"), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Absent blocks yield empty lists (classifier keeps built-in defaults) and a
+	// nil PlanFromLabel (falls back to the ACMM gate).
+	if len(cfg.Classifier.SimpleKeywords) != 0 || len(cfg.Classifier.ComplexSignals) != 0 {
+		t.Errorf("expected empty classifier lists, got %+v", cfg.Classifier)
+	}
+	if cfg.Planning.PlanFromLabel != nil {
+		t.Errorf("expected nil PlanFromLabel, got %v", *cfg.Planning.PlanFromLabel)
+	}
+	// The ACMM gate then applies.
+	if cfg.Planning.PlanFromLabelEnabled(4) != true || cfg.Planning.PlanFromLabelEnabled(3) != false {
+		t.Errorf("ACMM gate wrong for nil PlanFromLabel")
+	}
+}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -41,8 +41,49 @@ type Config struct {
 	HiveID        string                 `yaml:"hive_id"`
 	ACMMLevel     *int                   `yaml:"acmm_level,omitempty" json:"acmm_level"`
 	Variables     VariablesConfig        `yaml:"variables,omitempty"`
+	Classifier    ClassifierConfig       `yaml:"classifier,omitempty" json:"classifier,omitempty"`
+	Planning      PlanningConfig         `yaml:"planning,omitempty" json:"planning,omitempty"`
 
 	SourcePath string `yaml:"-" json:"-"`
+}
+
+// PlanningConfig gates the Phase 4 planning entry points that fire automatically
+// (as opposed to the explicit dashboard "Plan this issue" click, which is always
+// available). Today that is the `plan`/`epic` label trigger: an actionable issue
+// carrying one of those labels auto-mints an epic and requests decomposition.
+type PlanningConfig struct {
+	// PlanFromLabel enables the label trigger. Pointer so an omitted key is
+	// distinguishable from an explicit false: when nil, the trigger falls back to
+	// an ACMM-level gate (on at L4+), so mature hives get it without extra config
+	// while low-maturity hives stay advisory-only. An explicit value overrides the
+	// ACMM gate in either direction.
+	PlanFromLabel *bool `yaml:"plan_from_label,omitempty" json:"plan_from_label,omitempty"`
+}
+
+// PlanFromLabelEnabled reports whether the label trigger should fire, given the
+// hive's ACMM level. Explicit config wins; otherwise the trigger is on at ACMM
+// L4 and above (where the hive is trusted to act, not just advise).
+func (p PlanningConfig) PlanFromLabelEnabled(acmmLevel int) bool {
+	if p.PlanFromLabel != nil {
+		return *p.PlanFromLabel
+	}
+	const planFromLabelMinACMM = 4
+	return acmmLevel >= planFromLabelMinACMM
+}
+
+// ClassifierConfig makes the tier-classification keyword lists (pkg/classify)
+// config-driven and dashboard-visible, mirroring how per-agent lane_keywords
+// drive lane routing. Both fields are optional: when a list is empty, the
+// classifier keeps its built-in default for that tier, so an absent
+// `classifier:` block is byte-for-byte the old hardcoded behavior. Wired via
+// classify.SetTierKeywords from cmd/hive.
+type ClassifierConfig struct {
+	// SimpleKeywords are title substrings that classify an issue as Tier
+	// "Simple" (→ haiku). Empty keeps the built-in default set.
+	SimpleKeywords []string `yaml:"simple_keywords,omitempty" json:"simple_keywords,omitempty"`
+	// ComplexSignals are title substrings that classify an issue as Tier
+	// "Complex" (→ opus). Empty keeps the built-in default set.
+	ComplexSignals []string `yaml:"complex_signals,omitempty" json:"complex_signals,omitempty"`
 }
 
 // VariablesConfig declares operator-defined ${VAR} substitutions and the trust

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/beads"
+	"github.com/kubestellar/hive/v2/pkg/classify"
 	"github.com/kubestellar/hive/v2/pkg/config"
 	"github.com/kubestellar/hive/v2/pkg/github"
 	"github.com/kubestellar/hive/v2/pkg/hub"
@@ -195,6 +196,9 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("POST /api/inception/import", s.handleInceptionImport)
 
 	// Plan-review gate (Phase 2 planning intelligence). Mirrors /api/inception/*.
+	// Phase 4 adds the issue entry point: mint an epic from a GitHub issue and
+	// request its decomposition (the "Plan this issue" dashboard action).
+	s.mux.HandleFunc("POST /api/plan/from-issue", s.handlePlanFromIssue)
 	s.mux.HandleFunc("GET /api/plan/{epicID}", s.handlePlanTree)
 	s.mux.HandleFunc("POST /api/plan/{epicID}/approve", s.handlePlanApprove)
 	s.mux.HandleFunc("POST /api/plan/{epicID}/reject", s.handlePlanReject)
@@ -3244,6 +3248,7 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 		},
 		"litellm":    litellmSectionResponse(&cfg.Governor.LiteLLM),
 		"trajectory": trajectorySectionResponse(&cfg.Governor),
+		"classifier": classifierSectionResponse(),
 		"hub": map[string]interface{}{
 			"enabled":                          cfg.Hub.Enabled,
 			"url":                              cfg.Hub.URL,
@@ -3834,6 +3839,21 @@ func litellmSectionResponse(lc *config.LiteLLMConfig) map[string]interface{} {
 		// redactSecret guards the pathological case of a key-like env var
 		// NAME appearing in the source string.
 		"keySource": redactSecret(lc.ResolveAPIKeySource(), key),
+	}
+}
+
+// classifierSectionResponse surfaces the effective tier-classification keyword
+// lists (Phase 4 Part C) to the dashboard governor-config view. It returns the
+// keywords actually in force — config-driven when a `classifier:` block is set,
+// else the built-in defaults — so operators can see and (via hive.yaml) edit
+// which title keywords map issues to the Simple/Complex tiers. classify.SetLanes
+// already surfaces per-agent lane_keywords per-agent; these are the analogous
+// global tier lists.
+func classifierSectionResponse() map[string]interface{} {
+	simple, complex := classify.TierKeywords()
+	return map[string]interface{}{
+		"simpleKeywords": simple,
+		"complexSignals": complex,
 	}
 }
 

--- a/v2/pkg/dashboard/plan_from_issue_test.go
+++ b/v2/pkg/dashboard/plan_from_issue_test.go
@@ -1,0 +1,525 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/agent"
+	"github.com/kubestellar/hive/v2/pkg/beads"
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/github"
+	"github.com/kubestellar/hive/v2/pkg/governor"
+	"github.com/kubestellar/hive/v2/pkg/planning"
+)
+
+// planIssueServer builds a Server with an empty "architect" bead store and no
+// AgentMgr, so handlePlanFromIssue mints the epic but records kicked=false
+// (the kick path is nil-guarded). Returns the server and store.
+func planIssueServer(t *testing.T) (*Server, *beads.Store) {
+	t.Helper()
+	store, err := beads.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	srv := NewServer(0, slog.Default())
+	srv.deps = &Dependencies{
+		Config:     &config.Config{Agents: map[string]config.AgentConfig{}},
+		Logger:     slog.Default(),
+		Ctx:        context.Background(),
+		BeadStores: map[string]*beads.Store{"architect": store},
+	}
+	srv.RegisterAPI(srv.deps)
+	return srv, store
+}
+
+func postPlanFromIssue(t *testing.T, srv *Server, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/api/plan/from-issue", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	return w
+}
+
+func TestHandlePlanFromIssue_MintsEpic(t *testing.T) {
+	srv, store := planIssueServer(t)
+
+	w := postPlanFromIssue(t, srv, `{"repo":"kubestellar/hive","number":11,"url":"https://x/11","title":"Plan me","body":"do the thing"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		OK     bool   `json:"ok"`
+		EpicID string `json:"epic_id"`
+		Kicked bool   `json:"kicked"`
+		Poll   string `json:"poll_url"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.OK || resp.EpicID == "" {
+		t.Fatalf("bad response: %+v", resp)
+	}
+	if resp.Kicked {
+		t.Error("kicked should be false with no AgentMgr")
+	}
+	if resp.Poll != "/api/plan/"+resp.EpicID {
+		t.Errorf("poll_url = %q", resp.Poll)
+	}
+	// The epic exists in the store with the right ref + body.
+	epic, err := store.Get(resp.EpicID)
+	if err != nil {
+		t.Fatalf("epic not in store: %v", err)
+	}
+	if epic.ExternalRef != "gh-kubestellar/hive#11" {
+		t.Errorf("ref = %q", epic.ExternalRef)
+	}
+	if epic.Notes != "do the thing" {
+		t.Errorf("notes = %q", epic.Notes)
+	}
+}
+
+func TestHandlePlanFromIssue_Idempotent(t *testing.T) {
+	srv, store := planIssueServer(t)
+	body := `{"repo":"org/repo","number":5,"title":"once"}`
+
+	w1 := postPlanFromIssue(t, srv, body)
+	w2 := postPlanFromIssue(t, srv, body)
+	if w1.Code != 200 || w2.Code != 200 {
+		t.Fatalf("codes %d %d", w1.Code, w2.Code)
+	}
+	var r1, r2 struct {
+		EpicID string `json:"epic_id"`
+	}
+	_ = json.Unmarshal(w1.Body.Bytes(), &r1)
+	_ = json.Unmarshal(w2.Body.Bytes(), &r2)
+	if r1.EpicID != r2.EpicID {
+		t.Fatalf("duplicate epics: %s vs %s", r1.EpicID, r2.EpicID)
+	}
+	epics := 0
+	for _, b := range store.List(beads.ListFilter{}) {
+		if b.Type == beads.TypeEpic {
+			epics++
+		}
+	}
+	if epics != 1 {
+		t.Fatalf("expected 1 epic, got %d", epics)
+	}
+}
+
+func TestHandlePlanFromIssue_BadBody(t *testing.T) {
+	srv, _ := planIssueServer(t)
+	w := postPlanFromIssue(t, srv, `not json`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", w.Code)
+	}
+}
+
+func TestHandlePlanFromIssue_NoTitleNoResolve(t *testing.T) {
+	srv, _ := planIssueServer(t)
+	// number+repo with no title and nothing in status to resolve → 400.
+	w := postPlanFromIssue(t, srv, `{"repo":"org/repo","number":9}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandlePlanFromIssue_ResolvesTitleFromStatus(t *testing.T) {
+	srv, store := planIssueServer(t)
+	// Seed the status payload with an actionable issue so a title-less request
+	// resolves the title/labels from it.
+	srv.statusMu.Lock()
+	srv.status = &StatusPayload{
+		Repos: []FrontendRepo{
+			{
+				Name: "hive",
+				Full: "kubestellar/hive",
+				ActionableIssues: []any{
+					github.Issue{Repo: "kubestellar/hive", Number: 21, Title: "resolved title", URL: "https://x/21", Labels: []string{"plan"}},
+				},
+			},
+		},
+	}
+	srv.statusMu.Unlock()
+
+	w := postPlanFromIssue(t, srv, `{"repo":"kubestellar/hive","number":21}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		EpicID string `json:"epic_id"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	epic, err := store.Get(resp.EpicID)
+	if err != nil {
+		t.Fatalf("epic: %v", err)
+	}
+	if epic.Title != "resolved title" {
+		t.Errorf("title = %q, want resolved", epic.Title)
+	}
+	if epic.Meta(planning.MetaIssueLabels) != "plan" {
+		t.Errorf("labels = %q", epic.Meta(planning.MetaIssueLabels))
+	}
+}
+
+func TestHandlePlanFromIssue_NoStores(t *testing.T) {
+	srv := NewServer(0, slog.Default())
+	srv.deps = &Dependencies{Config: &config.Config{}, Logger: slog.Default(), Ctx: context.Background()}
+	srv.RegisterAPI(srv.deps)
+	w := postPlanFromIssue(t, srv, `{"repo":"a/b","number":1,"title":"t"}`)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("want 503, got %d", w.Code)
+	}
+}
+
+func TestHandlePlanFromIssue_WithAgentMgr_KickPath(t *testing.T) {
+	store, err := beads.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	logger := slog.Default()
+	cfg := &config.Config{Agents: map[string]config.AgentConfig{"architect": {}}}
+	mgr := agent.NewManager(cfg.Agents, logger, agent.ProjectContext{})
+	gov := governor.New(cfg.Governor, cfg.Agents, logger)
+
+	srv := NewServer(0, logger)
+	srv.deps = &Dependencies{
+		Config:     cfg,
+		Logger:     logger,
+		Ctx:        context.Background(),
+		AgentMgr:   mgr,
+		Governor:   gov,
+		BeadStores: map[string]*beads.Store{"architect": store},
+	}
+	srv.RegisterAPI(srv.deps)
+
+	// The architect agent has no live tmux session, so SendKick fails and the
+	// handler records kicked=false — exercising the AgentMgr-present + kick-error
+	// branch while still minting the epic.
+	w := postPlanFromIssue(t, srv, `{"repo":"org/repo","number":88,"title":"kick me"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		OK     bool   `json:"ok"`
+		EpicID string `json:"epic_id"`
+		Kicked bool   `json:"kicked"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if !resp.OK || resp.EpicID == "" {
+		t.Fatalf("bad response: %+v", resp)
+	}
+	if _, err := store.Get(resp.EpicID); err != nil {
+		t.Fatalf("epic not minted: %v", err)
+	}
+}
+
+// stubKicker is a test DecomposeKicker with a settable paused state.
+type stubKicker struct {
+	paused bool
+	kicks  int
+}
+
+func (k *stubKicker) IsPaused(string) bool          { return k.paused }
+func (k *stubKicker) SendKick(string, string) error { k.kicks++; return nil }
+
+func TestRequestArchitectDecompose_States(t *testing.T) {
+	store, _ := beads.NewStore(t.TempDir())
+	epic, _ := store.Create("e", beads.TypeEpic, beads.PriorityMedium, "architect", "gh-a/b#1")
+	logger := slog.Default()
+	cfg := &config.Config{Agents: map[string]config.AgentConfig{"architect": {}}}
+
+	newSrv := func(k planning.DecomposeKicker) *Server {
+		srv := NewServer(0, logger)
+		srv.deps = &Dependencies{
+			Config:   cfg,
+			Logger:   logger,
+			Ctx:      context.Background(),
+			Governor: governor.New(cfg.Governor, cfg.Agents, logger),
+		}
+		srv.decomposeKickerOverride = k
+		return srv
+	}
+
+	// Available architect → kicked.
+	avail := &stubKicker{}
+	if got := newSrv(avail).requestArchitectDecompose(epic); got != planning.DecomposeKicked {
+		t.Errorf("available: got %q, want kicked", got)
+	}
+	if avail.kicks != 1 {
+		t.Errorf("expected 1 kick, got %d", avail.kicks)
+	}
+
+	// Paused architect → queued_paused, NOT kicked.
+	paused := &stubKicker{paused: true}
+	if got := newSrv(paused).requestArchitectDecompose(epic); got != planning.DecomposeQueuedPaused {
+		t.Errorf("paused: got %q, want queued_paused", got)
+	}
+	if paused.kicks != 0 {
+		t.Error("paused architect must not be kicked")
+	}
+
+	// No kicker → queued_no_agent.
+	if got := newSrv(nil).requestArchitectDecompose(epic); got != planning.DecomposeQueuedNoAgent {
+		t.Errorf("no agent: got %q, want queued_no_agent", got)
+	}
+}
+
+func TestHandlePlanFromIssue_PausedArchitectMessage(t *testing.T) {
+	store, _ := beads.NewStore(t.TempDir())
+	srv := NewServer(0, slog.Default())
+	srv.deps = &Dependencies{
+		Config:     &config.Config{Agents: map[string]config.AgentConfig{}},
+		Logger:     slog.Default(),
+		Ctx:        context.Background(),
+		BeadStores: map[string]*beads.Store{"architect": store},
+	}
+	srv.decomposeKickerOverride = &stubKicker{paused: true}
+	srv.RegisterAPI(srv.deps)
+
+	w := postPlanFromIssue(t, srv, `{"repo":"org/repo","number":77,"title":"paused plan"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		OK              bool   `json:"ok"`
+		Kicked          bool   `json:"kicked"`
+		State           string `json:"state"`
+		ArchitectPaused bool   `json:"architectPaused"`
+		Message         string `json:"message"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Kicked || !resp.ArchitectPaused {
+		t.Fatalf("expected paused/queued, got %+v", resp)
+	}
+	if resp.State != string(planning.DecomposeQueuedPaused) {
+		t.Errorf("state = %q", resp.State)
+	}
+	if resp.Message != planning.ArchitectPausedMessage {
+		t.Errorf("message = %q, want the paused message", resp.Message)
+	}
+	// The epic is still minted and pending (queued, not dropped).
+	epics := 0
+	for _, b := range store.List(beads.ListFilter{}) {
+		if b.Type == beads.TypeEpic && planning.DecomposePending(b) {
+			epics++
+		}
+	}
+	if epics != 1 {
+		t.Fatalf("expected 1 pending epic queued, got %d", epics)
+	}
+}
+
+func TestPlanEpicStore_FallbackToAnyStore(t *testing.T) {
+	store, err := beads.NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	srv := NewServer(0, slog.Default())
+	// No "architect" store — planEpicStore must fall back to the only store.
+	srv.deps = &Dependencies{
+		Config:     &config.Config{Agents: map[string]config.AgentConfig{}},
+		Logger:     slog.Default(),
+		Ctx:        context.Background(),
+		BeadStores: map[string]*beads.Store{"scanner": store},
+	}
+	srv.RegisterAPI(srv.deps)
+
+	w := postPlanFromIssue(t, srv, `{"url":"https://x/501","title":"fallback epic"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	epics := 0
+	for _, b := range store.List(beads.ListFilter{}) {
+		if b.Type == beads.TypeEpic {
+			epics++
+		}
+	}
+	if epics != 1 {
+		t.Fatalf("expected epic in fallback store, got %d", epics)
+	}
+}
+
+func TestHandlePlanFromIssue_TitleButNoRef(t *testing.T) {
+	srv, _ := planIssueServer(t)
+	// A title with no repo/number/url passes the title guard but has no stable
+	// ref, so EpicFromIssue returns an error → 400 (covers the mint-error path).
+	w := postPlanFromIssue(t, srv, `{"title":"orphan title"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandlePlanFromIssue_ResolveFillsRepoAndURL(t *testing.T) {
+	srv, store := planIssueServer(t)
+	// Request carries only a URL (no repo/number/title); resolve must fill in
+	// repo, title, and labels from the status payload.
+	srv.statusMu.Lock()
+	srv.status = &StatusPayload{
+		Repos: []FrontendRepo{{
+			Name:             "hive",
+			Full:             "kubestellar/hive",
+			ActionableIssues: []any{github.Issue{Repo: "kubestellar/hive", Number: 44, Title: "filled in", URL: "https://x/44", Labels: []string{"epic"}}},
+		}},
+	}
+	srv.statusMu.Unlock()
+
+	w := postPlanFromIssue(t, srv, `{"url":"https://x/44"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		EpicID string `json:"epic_id"`
+	}
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	epic, err := store.Get(resp.EpicID)
+	if err != nil {
+		t.Fatalf("epic: %v", err)
+	}
+	if epic.Meta(planning.MetaIssueRepo) != "kubestellar/hive" {
+		t.Errorf("repo not filled: %q", epic.Meta(planning.MetaIssueRepo))
+	}
+	if epic.Title != "filled in" {
+		t.Errorf("title = %q", epic.Title)
+	}
+}
+
+func TestResolveActionableIssue_ByURLAndMiss(t *testing.T) {
+	srv, _ := planIssueServer(t)
+	srv.statusMu.Lock()
+	srv.status = &StatusPayload{
+		Repos: []FrontendRepo{{
+			Name:             "hive",
+			Full:             "kubestellar/hive",
+			ActionableIssues: []any{github.Issue{Repo: "kubestellar/hive", Number: 33, Title: "by url", URL: "https://x/33"}},
+		}},
+	}
+	srv.statusMu.Unlock()
+
+	// URL match.
+	if iss, ok := srv.resolveActionableIssue("", 0, "https://x/33"); !ok || iss.Title != "by url" {
+		t.Errorf("URL resolve failed: %+v ok=%v", iss, ok)
+	}
+	// Miss.
+	if _, ok := srv.resolveActionableIssue("other/repo", 999, ""); ok {
+		t.Error("expected miss")
+	}
+}
+
+func TestResolveActionableIssue_NilStatus(t *testing.T) {
+	srv := NewServer(0, slog.Default())
+	srv.deps = &Dependencies{Logger: slog.Default(), Ctx: context.Background()}
+	if _, ok := srv.resolveActionableIssue("a/b", 1, ""); ok {
+		t.Error("nil status should return not-ok")
+	}
+}
+
+func TestPlanEpicStore_EmptyAndNil(t *testing.T) {
+	// Non-nil but empty BeadStores → (nil, "").
+	srv := NewServer(0, slog.Default())
+	srv.deps = &Dependencies{Logger: slog.Default(), BeadStores: map[string]*beads.Store{}}
+	if store, name := srv.planEpicStore(); store != nil || name != "" {
+		t.Errorf("empty stores: got (%v,%q), want (nil,\"\")", store, name)
+	}
+	// Nil deps → (nil, "").
+	srv2 := NewServer(0, slog.Default())
+	if store, _ := srv2.planEpicStore(); store != nil {
+		t.Error("nil deps should yield nil store")
+	}
+}
+
+func TestBuildPlanning_PendingAndPaused(t *testing.T) {
+	store, _ := beads.NewStore(t.TempDir())
+	// Two issue-sourced epics → both decompose_pending, plan_status=draft.
+	if _, err := planning.EpicFromIssue(store, github.Issue{Repo: "a/b", Number: 1, Title: "p1"}, ""); err != nil {
+		t.Fatalf("epic1: %v", err)
+	}
+	if _, err := planning.EpicFromIssue(store, github.Issue{Repo: "a/b", Number: 2, Title: "p2"}, ""); err != nil {
+		t.Fatalf("epic2: %v", err)
+	}
+
+	// Architect NOT paused → pending counted, ArchitectPaused false.
+	fp := BuildPlanning(map[string]*beads.Store{"architect": store}, false)
+	if fp.PendingDecompose != 2 {
+		t.Errorf("PendingDecompose = %d, want 2", fp.PendingDecompose)
+	}
+	if fp.AwaitingReview != 2 {
+		t.Errorf("AwaitingReview = %d, want 2 (draft epics)", fp.AwaitingReview)
+	}
+	if fp.ArchitectPaused {
+		t.Error("ArchitectPaused should be false when architect is not paused")
+	}
+
+	// Architect paused AND pending>0 → flag set.
+	fpPaused := BuildPlanning(map[string]*beads.Store{"architect": store}, true)
+	if !fpPaused.ArchitectPaused {
+		t.Error("ArchitectPaused should be true when architect paused with pending work")
+	}
+}
+
+func TestBuildPlanning_PausedButNoPendingIsQuiet(t *testing.T) {
+	store, _ := beads.NewStore(t.TempDir())
+	// A decomposed (non-pending) epic; architect paused but nothing queued.
+	epic, _ := store.Create("done", beads.TypeEpic, beads.PriorityHigh, "architect", "")
+	planning.DecomposeFromOutput(store, epic, "1. [T1] a [agent_suitable]\n", planning.Options{})
+	fp := BuildPlanning(map[string]*beads.Store{"architect": store}, true)
+	if fp.ArchitectPaused {
+		t.Error("no pending work → ArchitectPaused must stay false even if paused")
+	}
+}
+
+func TestArchitectPausedFromStatuses(t *testing.T) {
+	if architectPausedFromStatuses(nil) {
+		t.Error("nil statuses → false")
+	}
+	statuses := map[string]*agent.AgentProcess{"architect": {Paused: true}}
+	if !architectPausedFromStatuses(statuses) {
+		t.Error("paused architect status → true")
+	}
+	statuses["architect"].Paused = false
+	if architectPausedFromStatuses(statuses) {
+		t.Error("unpaused architect → false")
+	}
+}
+
+func TestClassifierSectionResponse(t *testing.T) {
+	section := classifierSectionResponse()
+	simple, ok := section["simpleKeywords"].([]string)
+	if !ok || len(simple) == 0 {
+		t.Fatalf("simpleKeywords missing/empty: %#v", section["simpleKeywords"])
+	}
+	complex, ok := section["complexSignals"].([]string)
+	if !ok || len(complex) == 0 {
+		t.Fatalf("complexSignals missing/empty: %#v", section["complexSignals"])
+	}
+}
+
+func TestGovernorConfigGet_IncludesClassifier(t *testing.T) {
+	srv, _ := planIssueServer(t)
+	// Governor config GET needs a minimal governor config; the default zero
+	// Config is sufficient for the classifier section.
+	req := httptest.NewRequest("GET", "/api/config/governor", nil)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	cls, ok := resp["classifier"].(map[string]any)
+	if !ok {
+		t.Fatalf("classifier section missing: %#v", resp["classifier"])
+	}
+	if _, ok := cls["simpleKeywords"]; !ok {
+		t.Error("simpleKeywords missing from governor config")
+	}
+	if _, ok := cls["complexSignals"]; !ok {
+		t.Error("complexSignals missing from governor config")
+	}
+}

--- a/v2/pkg/dashboard/plan_handlers.go
+++ b/v2/pkg/dashboard/plan_handlers.go
@@ -2,10 +2,184 @@ package dashboard
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/kubestellar/hive/v2/pkg/beads"
+	"github.com/kubestellar/hive/v2/pkg/github"
 	"github.com/kubestellar/hive/v2/pkg/planning"
 )
+
+// planEpicStore returns the bead store to mint issue-sourced epics into: the
+// architect store when present, else any store (deterministic pick not required
+// — findEpicStore locates the epic by ID afterward regardless of which store
+// holds it). Returns (nil, "") when no bead stores are configured.
+func (s *Server) planEpicStore() (*beads.Store, string) {
+	if s.deps == nil || s.deps.BeadStores == nil {
+		return nil, ""
+	}
+	if store, ok := s.deps.BeadStores[planning.ArchitectAgentName]; ok {
+		return store, planning.ArchitectAgentName
+	}
+	for name, store := range s.deps.BeadStores {
+		return store, name
+	}
+	return nil, ""
+}
+
+// decomposeKicker returns the manager as a planning.DecomposeKicker (nil when no
+// manager is wired). A test-only override (decomposeKickerOverride) lets tests
+// inject a fake kicker and exercise the paused / kicked / no-agent branches
+// without a live tmux Manager; production never sets it.
+func (s *Server) decomposeKicker() planning.DecomposeKicker {
+	if s.decomposeKickerOverride != nil {
+		return s.decomposeKickerOverride
+	}
+	if s.deps == nil || s.deps.AgentMgr == nil {
+		return nil
+	}
+	return s.deps.AgentMgr
+}
+
+// requestArchitectDecompose hands a freshly-minted (pending) epic to the
+// architect, RESPECTING its pause: a paused architect leaves the request queued
+// and returns DecomposeQueuedPaused so the handler can tell the user WHY nothing
+// is happening. Only SendKick/IsPaused are called — never the launch-path mutex.
+// On a successful kick it records the governor kick. The epic stays
+// decompose_pending until the architect materializes children.
+func (s *Server) requestArchitectDecompose(epic *beads.Bead) planning.DecomposeState {
+	state := planning.RequestDecompose(s.decomposeKicker(), epic)
+	switch state {
+	case planning.DecomposeKicked:
+		if s.deps != nil && s.deps.Governor != nil {
+			s.deps.Governor.RecordKick(planning.ArchitectAgentName)
+		}
+	case planning.DecomposeQueuedPaused:
+		s.logger.Info("plan-from-issue: architect paused, plan queued", "epic", epic.ID)
+	case planning.DecomposeQueuedNoAgent:
+		s.logger.Warn("plan-from-issue: architect unavailable, plan queued", "epic", epic.ID)
+	}
+	return state
+}
+
+// handlePlanFromIssue serves POST /api/plan/from-issue: the "Plan this issue"
+// dashboard action (Part A). Body: {repo, number, url, title, body}. It mints an
+// epic from the issue (idempotent via planning.EpicFromIssue) and REQUESTS
+// decomposition by kicking the architect out-of-band with the decomposition
+// prompt — the same lock-safe SendKick path every other kick uses, never the
+// agent-launch mutex. It does NOT decompose synchronously (that would block the
+// HTTP handler on a live tmux agent); instead it returns the epic id so the UI
+// polls GET /api/plan/{epicID} and the architect fills the plan in, surfaced via
+// the existing plan-review gate.
+func (s *Server) handlePlanFromIssue(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Repo   string `json:"repo"`
+		Number int    `json:"number"`
+		URL    string `json:"url"`
+		Title  string `json:"title"`
+		Body   string `json:"body"`
+	}
+	if err := decodeBody(r, &body); err != nil {
+		jsonError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	issue := github.Issue{
+		Repo:   sanitizeString(body.Repo),
+		Number: body.Number,
+		URL:    sanitizeString(body.URL),
+		Title:  sanitizeString(body.Title),
+	}
+	// When the client sent only a repo+number (no title), resolve the full issue
+	// from the last enumerated actionable set so we always mint a titled epic.
+	if issue.Title == "" {
+		if resolved, ok := s.resolveActionableIssue(issue.Repo, issue.Number, issue.URL); ok {
+			if issue.Title == "" {
+				issue.Title = resolved.Title
+			}
+			if issue.URL == "" {
+				issue.URL = resolved.URL
+			}
+			if issue.Repo == "" {
+				issue.Repo = resolved.Repo
+			}
+			issue.Labels = resolved.Labels
+		}
+	}
+	if issue.Title == "" {
+		jsonError(w, "issue title is required (or a resolvable repo+number)", http.StatusBadRequest)
+		return
+	}
+
+	store, agentName := s.planEpicStore()
+	if store == nil {
+		jsonError(w, "bead stores not initialized", http.StatusServiceUnavailable)
+		return
+	}
+
+	epic, err := planning.EpicFromIssue(store, issue, sanitizeString(body.Body))
+	if err != nil {
+		jsonError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Hand the epic to the architect out-of-band, respecting its pause. Extracted
+	// so the paused/kicked/queued bookkeeping is testable without a live tmux agent.
+	state := s.requestArchitectDecompose(epic)
+	kicked := state == planning.DecomposeKicked
+
+	// Build a user-facing message. When the architect is paused, say so clearly and
+	// point at the fix — the user paused it deliberately and must know that is why
+	// the plan is not being built yet.
+	message := "Plan queued — the architect will build it."
+	if kicked {
+		message = "Plan requested — the architect is decomposing this issue now."
+	} else if state == planning.DecomposeQueuedPaused {
+		message = planning.ArchitectPausedMessage
+	}
+
+	s.auditFromRequest(r, "plan_from_issue",
+		auditDetail("epic", epic.ID, "ref", epic.ExternalRef, "state", string(state)), agentName)
+	s.refreshAndPersist()
+
+	jsonResponse(w, map[string]interface{}{
+		"ok":              true,
+		"epic_id":         epic.ID,
+		"epic":            epic,
+		"kicked":          kicked,
+		"state":           string(state),
+		"architectPaused": state == planning.DecomposeQueuedPaused,
+		"message":         message,
+		"poll_url":        "/api/plan/" + epic.ID,
+	})
+}
+
+// resolveActionableIssue looks up an actionable issue by repo+number (or url)
+// from the last enumerated status, so a click that sends only identifiers can
+// still recover the title/labels. Returns (issue, true) on a match.
+func (s *Server) resolveActionableIssue(repo string, number int, url string) (github.Issue, bool) {
+	s.statusMu.RLock()
+	status := s.status
+	s.statusMu.RUnlock()
+	if status == nil {
+		return github.Issue{}, false
+	}
+	for _, repoStatus := range status.Repos {
+		for _, raw := range repoStatus.ActionableIssues {
+			iss, ok := raw.(github.Issue)
+			if !ok {
+				continue
+			}
+			if url != "" && iss.URL == url {
+				return iss, true
+			}
+			if number > 0 && iss.Number == number &&
+				(repo == "" || strings.EqualFold(iss.Repo, repo) || strings.HasSuffix(strings.ToLower(iss.Repo), "/"+strings.ToLower(repo))) {
+				return iss, true
+			}
+		}
+	}
+	return github.Issue{}, false
+}
 
 // Plan-review dashboard endpoints (Phase 2 planning intelligence). They mirror
 // the /api/inception/* shape: thin HTTP handlers that delegate all logic to

--- a/v2/pkg/dashboard/plan_handlers_test.go
+++ b/v2/pkg/dashboard/plan_handlers_test.go
@@ -310,7 +310,7 @@ func TestBuildPlanning(t *testing.T) {
 	// A plain epic never decomposed → not counted.
 	store.Create("plain", beads.TypeEpic, beads.PriorityHigh, "architect", "")
 
-	fp := BuildPlanning(map[string]*beads.Store{"architect": store})
+	fp := BuildPlanning(map[string]*beads.Store{"architect": store}, false)
 	if fp.ActivePlans != 2 {
 		t.Errorf("ActivePlans: want 2, got %d", fp.ActivePlans)
 	}
@@ -344,14 +344,14 @@ func TestBuildPlanning_Replans24h(t *testing.T) {
 	planning.DecomposeFromOutput(store, bad, "1. [T1] c [agent_suitable]\n", planning.Options{AutoApprove: true})
 	store.SetMetadata(bad.ID, planning.MetaLastReplanAt, "not-a-timestamp")
 
-	fp := buildPlanningAt(map[string]*beads.Store{"architect": store}, now)
+	fp := buildPlanningAt(map[string]*beads.Store{"architect": store}, false, now)
 	if fp.Replans24h != 1 {
 		t.Errorf("Replans24h: want 1 (only the 2h-ago replan), got %d", fp.Replans24h)
 	}
 }
 
 func TestBuildPlanning_Empty(t *testing.T) {
-	fp := BuildPlanning(map[string]*beads.Store{})
+	fp := BuildPlanning(map[string]*beads.Store{}, false)
 	if fp.ActivePlans != 0 || fp.AwaitingReview != 0 {
 		t.Errorf("empty stores should yield zero planning metric, got %+v", fp)
 	}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/github"
 	"github.com/kubestellar/hive/v2/pkg/hub"
 	"github.com/kubestellar/hive/v2/pkg/openrouter"
+	"github.com/kubestellar/hive/v2/pkg/planning"
 )
 
 //go:embed static
@@ -71,6 +72,10 @@ type Server struct {
 
 	advisoryMu     sync.RWMutex
 	advisoryDigest any
+
+	// decomposeKickerOverride is a test-only seam for the Phase 4 plan-from-issue
+	// decompose handoff; production leaves it nil and uses deps.AgentMgr.
+	decomposeKickerOverride planning.DecomposeKicker
 
 	deviceFlowMu    sync.Mutex
 	deviceFlowState *github.DeviceFlowState
@@ -323,6 +328,14 @@ type FrontendPlanning struct {
 	// governor stall-replan loop, derived from each epic's last_replan_at
 	// metadata.
 	Replans24h int `json:"replans_24h"`
+	// PendingDecompose counts epics minted from an issue (Phase 4) that are
+	// accepted but not yet decomposed by the architect (decompose_pending). While
+	// >0 there is planning work queued for the architect.
+	PendingDecompose int `json:"pending_decompose"`
+	// ArchitectPaused is true when >=1 plan is pending AND the architect is paused,
+	// so nothing will be built until the operator resumes it. The tile shows the
+	// "architect is paused" message when this is set.
+	ArchitectPaused bool `json:"architect_paused"`
 }
 
 type FrontendBudget struct {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -782,6 +782,12 @@
     .repo-issue-pill:hover { background: color-mix(in srgb, var(--pill-c) 24%, transparent); text-decoration: none; }
     .repo-issue-pill .pill-num { font-weight: 700; white-space: nowrap; }
     .repo-issue-pill .pill-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    /* ⧉ Plan action sits beside its issue pill; hidden until the pill row is hovered. */
+    .repo-issue-pill-wrap { display: inline-flex; align-items: center; gap: 4px; max-width: 100%; }
+    .repo-issue-plan { --pill-c: var(--purple); border: 1px solid color-mix(in srgb, var(--pill-c) 40%, transparent); background: color-mix(in srgb, var(--pill-c) 12%, transparent); color: var(--pill-c); font-size: 0.7rem; font-weight: 600; line-height: 1; padding: 3px 6px; border-radius: 999px; cursor: pointer; white-space: nowrap; opacity: 0; transition: opacity 0.15s, background 0.15s; }
+    .repo-issue-pill-wrap:hover .repo-issue-plan { opacity: 1; }
+    .repo-issue-plan:hover { background: color-mix(in srgb, var(--pill-c) 26%, transparent); }
+    .repo-issue-plan:disabled { opacity: 0.5; cursor: default; }
     .repo-pr-pill { --pill-c: var(--purple); text-decoration: none; max-width: 100%; transition: background 0.15s; }
     .repo-pr-pill:hover { background: color-mix(in srgb, var(--pill-c) 24%, transparent); text-decoration: none; }
     .repo-pr-pill.mergeable { --pill-c: var(--green); }
@@ -2473,6 +2479,7 @@
     <a id="gh-app-install-link" href="" target="_blank" rel="noopener" class="gh-app-btn">Install GitHub App</a>
   </div>
   <div id="hub-banner" style="display:none"></div>
+  <div id="planning-intro" style="display:none"></div>
   <div id="system-alerts-banner" style="display:none"></div>
   <div class="governor" id="governor"></div>
 
@@ -3120,14 +3127,23 @@
             const plan = window._lastStatus?.planning || {};
             const active = plan.active_plans || 0;
             const awaiting = plan.awaiting_review || 0;
+            const pending = plan.pending_decompose || 0;
+            const paused = !!plan.architect_paused;
             // Highlight when plans await human review — a human-action-required
             // state, surfaced amber like the "N Issues" / ON HOLD indicators.
-            const planClass = awaiting > 0 ? 'gm-alert' : '';
-            const planText = awaiting > 0 ? `${active} (${awaiting} review)` : `${active}`;
-            const planTitle = awaiting > 0
-              ? `${awaiting} plan(s) awaiting human review — decomposed epic children are withheld until approved`
-              : `${active} active plan(s)`;
-            return `<div class="gov-metric" title="${esc(planTitle)}"><span class="gm-label">planning</span><span class="gm-val ${planClass}">${esc(planText)}</span></div>`;
+            const planClass = (awaiting > 0 || paused) ? 'gm-alert' : '';
+            let planText = `${active}`;
+            if (awaiting > 0) planText = `${active} (${awaiting} review)`;
+            if (paused) planText = `⏸ ${planText}`;
+            let planTitle = active > 0 ? `${active} active plan(s)` : '';
+            if (awaiting > 0) planTitle = `${awaiting} plan(s) awaiting human review — decomposed epic children are withheld until approved`;
+            if (paused) planTitle = `⏸ Architect is paused — ${pending} queued plan(s) won't be built until you resume the architect agent.`;
+            else if (pending > 0) planTitle = `${pending} plan(s) queued for the architect to decompose`;
+            // Empty-state discoverability hint when there is no planning activity.
+            if (active === 0 && pending === 0) {
+              planTitle = 'Break a big issue into a plan → click ⧉ Plan on any issue, or add the `plan` label on GitHub.';
+            }
+            return `<div class="gov-metric" title="${esc(planTitle)}"><span class="gm-label">planning</span><span class="gm-val ${planClass}">${esc(planText)}${pending > 0 ? ` <span style="opacity:0.7;font-size:0.85em">+${pending} queued</span>` : ''}</span></div>`;
           })()}
           <div class="oc-gov-gauge">
             <div class="temp-gauge-track" style="background:linear-gradient(to right, var(--green) 0%, var(--green) ${OC_THRESH_QUIET/OC_GAUGE_MAX*100}%, var(--blue) ${OC_THRESH_QUIET/OC_GAUGE_MAX*100}%, var(--blue) ${OC_THRESH_BUSY/OC_GAUGE_MAX*100}%, var(--yellow) ${OC_THRESH_BUSY/OC_GAUGE_MAX*100}%, var(--yellow) ${OC_THRESH_SURGE/OC_GAUGE_MAX*100}%, var(--red) ${OC_THRESH_SURGE/OC_GAUGE_MAX*100}%, var(--red) 100%)">
@@ -4490,6 +4506,34 @@
       if (el) { el.style.display = 'none'; el.innerHTML = ''; }
     }
 
+    // maybePlanningIntro shows a ONE-TIME callout the first time planning is
+    // available (there is at least one repo to plan issues from), teaching the
+    // two entry points: the ⧉ Plan button and the `plan` GitHub label. Dismissed
+    // permanently via localStorage.
+    var PLANNING_INTRO_KEY = 'planning-intro-dismissed';
+    function maybePlanningIntro(data) {
+      var el = document.getElementById('planning-intro');
+      if (!el) return;
+      if (localStorage.getItem(PLANNING_INTRO_KEY)) { el.style.display = 'none'; el.innerHTML = ''; return; }
+      var hasRepos = (data && data.repos && data.repos.length > 0);
+      // Only introduce the feature once there is something to plan, and once any
+      // planning activity exists we assume the user has found it — stay quiet.
+      var plan = (data && data.planning) || {};
+      var alreadyUsed = (plan.active_plans || 0) > 0 || (plan.pending_decompose || 0) > 0;
+      if (!hasRepos || alreadyUsed) { el.style.display = 'none'; el.innerHTML = ''; return; }
+      el.style.display = 'block';
+      el.innerHTML = '<div style="background:rgba(124,58,237,0.10);border:1px solid rgba(124,58,237,0.32);border-radius:8px;padding:12px 16px;margin-bottom:8px;display:flex;align-items:center;gap:10px;font-size:0.85rem">'
+        + '<span style="font-size:1.1rem">🧭</span>'
+        + '<span style="flex:1;color:var(--text)"><strong>New: plan a GitHub issue.</strong> Add the <code>plan</code> label to any issue on GitHub — or click <strong>⧉ Plan</strong> on an issue below — and the architect breaks it into a reviewable task plan you approve before work starts.</span>'
+        + '<button onclick="dismissPlanningIntro()" style="background:none;border:none;color:var(--text);opacity:0.6;cursor:pointer;font-size:1.1rem;padding:0 4px" title="Dismiss">✕</button>'
+        + '</div>';
+    }
+    function dismissPlanningIntro() {
+      localStorage.setItem(PLANNING_INTRO_KEY, '1');
+      var el = document.getElementById('planning-intro');
+      if (el) { el.style.display = 'none'; el.innerHTML = ''; }
+    }
+
     function renderSystemAlerts(alerts) {
       var banner = document.getElementById('system-alerts-banner');
       if (!banner) return;
@@ -4845,7 +4889,11 @@
           const title = i.title && i.title.length > MAX_PILL_TITLE_LEN ? i.title.slice(0, MAX_PILL_TITLE_LEN) + '…' : (i.title || '');
           const age = pillAge(i.created_at);
           const tip = (i.title || '') + (i.author ? ' — @' + i.author : '') + (age ? ' (' + age + ')' : '');
-          return `<a class="repo-issue-pill" href="${esc(i.url)}" target="_blank" rel="noopener" title="${esc(tip)}"><span class="pill-num">#${i.number}</span><span class="pill-title">${esc(title)}</span></a>`;
+          const repoFull = r.full || r.name || '';
+          // ⧉ Plan action (Phase 4): mint an epic from this issue and request
+          // decomposition. data-action wires into the delegated click handler.
+          const planBtn = `<button class="repo-issue-plan" data-action="planIssue" data-repo="${esc(repoFull)}" data-number="${i.number}" data-url="${esc(i.url || '')}" data-title="${esc(i.title || '')}" title="Break this issue into a reviewable task plan (architect decomposes it; you approve before work starts)">⧉ Plan</button>`;
+          return `<span class="repo-issue-pill-wrap"><a class="repo-issue-pill" href="${esc(i.url)}" target="_blank" rel="noopener" title="${esc(tip)}"><span class="pill-num">#${i.number}</span><span class="pill-title">${esc(title)}</span></a>${planBtn}</span>`;
         }).join('');
         const prPills = (r.openPrs || []).map(p => {
           const title = p.title && p.title.length > MAX_PILL_TITLE_LEN ? p.title.slice(0, MAX_PILL_TITLE_LEN) + '…' : (p.title || '');
@@ -9251,6 +9299,7 @@ function burnAreaChart() {
       renderGitHubAppBanner(data);
       refreshWelcomeAutoChecks(data);
       renderHubBanner(data.hubBanner);
+      maybePlanningIntro(data);
       renderSystemAlerts(data.systemAlerts || []);
       if (!_dropdownOpen && !_configModalOpen) {
         applyPinOverrides(data.agents || []);
@@ -10333,6 +10382,7 @@ function burnAreaChart() {
         case 'toggleRestriction': { const cb = el.querySelector('input[type=checkbox]') || el; toggleRestriction(parseInt(el.dataset.index, 10), cb.checked); } break;
         case 'removeRestriction': removeRestriction(parseInt(el.dataset.index, 10)); break;
         case 'removeAgent': removeAgent(agent); break;
+        case 'planIssue': planIssue(el); break;
         default: break;
       }
     });
@@ -10441,6 +10491,39 @@ function burnAreaChart() {
       if (!data.ok) { showToast('Kick failed: ' + (data.error || 'unknown'), 'error'); return; }
       showToast(`Kicked ${agent}`, 'success');
       if (input) input.value = '';
+    }
+
+    // planIssue (Phase 4 "Plan this issue"): POST the issue to /api/plan/from-issue,
+    // which mints an epic and kicks the architect to decompose it. The response
+    // returns the epic id; decomposition is asynchronous (request-and-poll), so we
+    // surface the epic in the plan-review view once the architect fills it in.
+    async function planIssue(el) {
+      const repo = el.dataset.repo || '';
+      const number = parseInt(el.dataset.number, 10) || 0;
+      const url = el.dataset.url || '';
+      const title = el.dataset.title || '';
+      el.disabled = true;
+      const toast = showToast(`Planning ${repo}#${number || '?'}...`, 'info', true);
+      try {
+        const res = await fetch('/api/plan/from-issue', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ repo, number, url, title }),
+        });
+        const data = await res.json();
+        if (!data.ok) { dismissToast(toast, 'Plan failed: ' + (data.error || 'unknown'), 'error'); el.disabled = false; return; }
+        // The server returns a clear, state-specific message. When the architect
+        // is paused it explains THAT is why the plan is queued and points at the
+        // fix — surface it as a warning so the user notices.
+        const msg = data.message || (`Epic ${data.epic_id} created`);
+        dismissToast(toast, msg, data.architectPaused ? 'error' : 'success');
+        // Open the plan-review view for the new epic if that navigation exists;
+        // otherwise the epic surfaces via the existing "awaiting review" flow.
+        if (typeof openPlanReview === 'function' && data.epic_id) openPlanReview(data.epic_id);
+      } catch (e) {
+        dismissToast(toast, 'Plan failed: ' + e.message, 'error');
+        el.disabled = false;
+      }
     }
 
     async function toggleAgent(agent, currentlyPaused) {

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -135,7 +135,7 @@ func BuildFrontendStatus(
 		Tokens:       buildTokens(tokenCollector),
 		Repos:        buildRepos(cfg, actionable),
 		Beads:        BuildBeadsFromConfig(beadStores, cfg),
-		Planning:     BuildPlanning(beadStores),
+		Planning:     BuildPlanning(beadStores, architectPausedFromStatuses(agentStatuses)),
 		Health:       buildHealth(ghClient, ctx),
 		Budget:       buildBudget(gov, tokenCollector),
 		CadenceMatrix: buildCadenceMatrix(cfg, agentStatuses),
@@ -801,13 +801,16 @@ func buildBeads(stores map[string]*beads.Store) FrontendBeads {
 // "decomposing" (executing) when approved with at least one open child. Replans24h
 // (Phase 3) counts epics whose last_replan_at metadata falls within the last 24h,
 // so the tile reflects real governor stall-replans purely from bead state.
-func BuildPlanning(stores map[string]*beads.Store) FrontendPlanning {
-	return buildPlanningAt(stores, time.Now())
+// PendingDecompose (Phase 4) counts issue-sourced epics not yet built by the
+// architect; architectPaused says whether that queue is blocked on a paused
+// architect (so the tile can show the "resume the architect" message).
+func BuildPlanning(stores map[string]*beads.Store, architectPaused bool) FrontendPlanning {
+	return buildPlanningAt(stores, architectPaused, time.Now())
 }
 
 // buildPlanningAt is BuildPlanning with an injected `now`, so the replans_24h
 // window is unit-testable with backdated last_replan_at timestamps.
-func buildPlanningAt(stores map[string]*beads.Store, now time.Time) FrontendPlanning {
+func buildPlanningAt(stores map[string]*beads.Store, architectPaused bool, now time.Time) FrontendPlanning {
 	fp := FrontendPlanning{}
 	cutoff := now.Add(-planningReplanWindow)
 	for _, store := range stores {
@@ -841,6 +844,11 @@ func buildPlanningAt(stores map[string]*beads.Store, now time.Time) FrontendPlan
 					fp.Decomposing++
 				}
 			}
+			// Phase 4: an issue-sourced epic still marked decompose_pending is
+			// queued for the architect (children not yet materialized).
+			if planning.DecomposePending(b) {
+				fp.PendingDecompose++
+			}
 			if raw := b.Meta(planning.MetaLastReplanAt); raw != "" {
 				if t, err := time.Parse(time.RFC3339, raw); err == nil && t.After(cutoff) {
 					fp.Replans24h++
@@ -848,12 +856,25 @@ func buildPlanningAt(stores map[string]*beads.Store, now time.Time) FrontendPlan
 			}
 		}
 	}
+	// Only flag the paused-architect condition when it actually matters: there is
+	// queued work AND the architect is paused. Otherwise the tile stays quiet.
+	fp.ArchitectPaused = fp.PendingDecompose > 0 && architectPaused
 	return fp
 }
 
 // planningReplanWindow is the trailing window over which replans_24h counts
 // re-decomposed plans (matches the tile label "24h").
 const planningReplanWindow = 24 * time.Hour
+
+// architectPausedFromStatuses reads the architect's paused state from the
+// already-collected agent statuses, so the PLANNING tile can flag a queue
+// blocked on a paused architect WITHOUT taking the agent-manager lock.
+func architectPausedFromStatuses(statuses map[string]*agent.AgentProcess) bool {
+	if ap, ok := statuses[planning.ArchitectAgentName]; ok && ap != nil {
+		return ap.Paused
+	}
+	return false
+}
 
 // BuildBeadsFromConfig uses agent config bead_role to partition bead counts.
 func BuildBeadsFromConfig(stores map[string]*beads.Store, cfg *config.Config) FrontendBeads {

--- a/v2/pkg/planning/decompose.go
+++ b/v2/pkg/planning/decompose.go
@@ -257,6 +257,13 @@ func DecomposeFromOutput(store *beads.Store, epic *beads.Bead, output string, op
 		return nil, fmt.Errorf("planning: setting plan_status on epic %s: %w", epic.ID, err)
 	}
 
+	// Children now exist: clear any decompose_pending marker set when the epic was
+	// minted from an issue (Phase 4), so the queued request no longer shows as
+	// "waiting on the architect". Best-effort — the marker is advisory.
+	if epic.Meta(MetaDecomposePending) == "true" {
+		_ = ClearDecomposePending(store, epic.ID)
+	}
+
 	return &Result{Children: children, Tasks: tasks}, nil
 }
 

--- a/v2/pkg/planning/issue.go
+++ b/v2/pkg/planning/issue.go
@@ -1,0 +1,330 @@
+package planning
+
+// Phase 4 planning intelligence: the GitHub-issue entry point. This file turns
+// an actionable GitHub issue into an epic bead so it can be decomposed by the
+// same machinery Phases 1-3 use. It is the shared, idempotent core behind both
+// the dashboard "Plan this issue" click (Part A) and the `plan`-label auto-trigger
+// (Part B): both call EpicFromIssue, then request decomposition.
+//
+// EpicFromIssue creates NO children and kicks NO agent — it only mints (or finds)
+// the epic and stamps its metadata. Decomposition is driven separately (the
+// dashboard kicks the architect out-of-band, then the plan-review flow materializes
+// the children), keeping this function pure, fast, and safe to call every eval
+// cycle. It never touches the agent-manager launch path.
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/kubestellar/hive/v2/pkg/beads"
+	"github.com/kubestellar/hive/v2/pkg/classify"
+	"github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// Issue metadata keys stamped on an epic minted from a GitHub issue. They let
+// the dashboard/plan-review flow trace an epic back to its source issue and
+// render a link, and let the classifier reuse the issue's labels.
+const (
+	// MetaIssueRepo records the source issue's "owner/repo".
+	MetaIssueRepo = "issue_repo"
+	// MetaIssueNumber records the source issue's number (as a string).
+	MetaIssueNumber = "issue_number"
+	// MetaIssueURL records the source issue's HTML URL.
+	MetaIssueURL = "issue_url"
+	// MetaIssueLabels records the source issue's labels, comma-separated, so
+	// deriveActor/epicLabels can route the epic (and its children) by label.
+	MetaIssueLabels = "labels"
+	// MetaSource records how an epic was created ("github-issue" here) so the
+	// dashboard can distinguish issue-sourced epics from bd-created ones.
+	MetaSource = "source"
+	// MetaDecomposePending marks an epic that has been ACCEPTED for planning but
+	// not yet decomposed by the architect — the request is queued. It is set at
+	// mint time (alongside plan_status=draft) so the epic immediately surfaces in
+	// the plan-review flow as "waiting to be built", and it makes the label
+	// trigger idempotent (no re-kick while a decompose is already pending). The
+	// architect clears it when it materializes the children.
+	MetaDecomposePending = "decompose_pending"
+)
+
+// SourceGitHubIssue is the MetaSource value for epics minted from a GH issue.
+const SourceGitHubIssue = "github-issue"
+
+// externalRefPrefix namespaces issue-sourced epics' external refs so they never
+// collide with other external-ref conventions.
+const externalRefPrefix = "gh-"
+
+// IssueRef returns the stable external ref for a GitHub issue: "gh-<repo>#<num>"
+// when a repo and number are known, else the issue URL, else "". The ref is the
+// idempotency key EpicFromIssue uses via FindByExternalRef, so it must be stable
+// across eval cycles for the same issue.
+func IssueRef(issue github.Issue) string {
+	repo := strings.TrimSpace(issue.Repo)
+	if repo != "" && issue.Number > 0 {
+		return externalRefPrefix + repo + "#" + strconv.Itoa(issue.Number)
+	}
+	if u := strings.TrimSpace(issue.URL); u != "" {
+		return u
+	}
+	return ""
+}
+
+// EpicFromIssue mints (or returns the existing) epic bead for a GitHub issue.
+// body is the issue's description text (the github.Issue struct carries no body,
+// so the caller supplies it — the dashboard from its request payload, the label
+// trigger as ""); it is stored in the epic's Notes so BuildPrompt can plan
+// against it.
+//
+// It is IDEMPOTENT: if an epic already exists for the issue's external ref, that
+// epic is returned unchanged rather than duplicated — so it is safe to call on
+// every eval cycle (Part B's label trigger) and on repeated clicks (Part A).
+//
+// The epic carries the issue title, the body in Notes (so BuildPrompt/epicBody
+// pick it up), the issue's labels in "labels" metadata (so the classifier can
+// route it), and issue_repo/issue_number/issue_url/source metadata for tracing.
+// It creates NO children and sets NO plan_status — decomposition is a separate,
+// caller-driven step (kick architect + plan-review), keeping this pure and cheap.
+func EpicFromIssue(store *beads.Store, issue github.Issue, body string) (*beads.Bead, error) {
+	if store == nil {
+		return nil, fmt.Errorf("planning: bead store is nil")
+	}
+	title := strings.TrimSpace(issue.Title)
+	if title == "" {
+		return nil, fmt.Errorf("planning: issue has no title")
+	}
+
+	ref := IssueRef(issue)
+	if ref == "" {
+		return nil, fmt.Errorf("planning: issue has no stable ref (need repo+number or url)")
+	}
+
+	// Idempotency guard: an epic already minted for this issue wins, no dup.
+	if existing := store.FindByExternalRef(ref); existing != nil {
+		return existing, nil
+	}
+
+	// Derive the epic lane from the issue up front so the epic's actor is
+	// meaningful even before decomposition; the classifier already knows lanes.
+	c := classify.Classify(issue)
+
+	epic, err := store.Create(title, beads.TypeEpic, beads.PriorityMedium, string(c.Lane), ref)
+	if err != nil {
+		return nil, fmt.Errorf("planning: creating epic for issue %s: %w", ref, err)
+	}
+
+	// Carry the issue body so BuildPrompt has DETAILS to plan against. Notes is
+	// preferred by epicBody; set it via Update to keep a single persist.
+	if b := strings.TrimSpace(body); b != "" {
+		if err := store.Update(epic.ID, func(bd *beads.Bead) { bd.Notes = b }); err != nil {
+			return nil, fmt.Errorf("planning: setting body on epic %s: %w", epic.ID, err)
+		}
+	}
+
+	// Trace + state metadata. SetMetadata failures are underlying-persistence
+	// errors; a failure here leaves a valid epic (external ref already set), so
+	// surface it but the caller can still find the epic next cycle by ref.
+	//
+	// plan_status=draft + decompose_pending=true is the ACCEPTED-BUT-NOT-YET-BUILT
+	// state: the epic shows up immediately in the plan-review flow ("awaiting
+	// review") and the PLANNING tile ("pending"), so a queued request is visible
+	// even when the architect is paused and hasn't decomposed it yet. Ready() gates
+	// the (still non-existent) children on the draft status, so nothing is
+	// claimable until a human approves the eventual plan.
+	meta := map[string]string{
+		MetaSource:           SourceGitHubIssue,
+		MetaPlanStatus:       PlanStatusDraft,
+		MetaDecomposePending: "true",
+		MetaIssueRepo:        strings.TrimSpace(issue.Repo),
+		MetaIssueURL:         strings.TrimSpace(issue.URL),
+		MetaIssueLabels:      strings.Join(issue.Labels, ","),
+	}
+	if issue.Number > 0 {
+		meta[MetaIssueNumber] = strconv.Itoa(issue.Number)
+	}
+	for k, v := range meta {
+		if v == "" {
+			continue
+		}
+		if err := store.SetMetadata(epic.ID, k, v); err != nil {
+			return nil, fmt.Errorf("planning: tagging %s on epic %s: %w", k, epic.ID, err)
+		}
+	}
+
+	// Return the freshly-loaded epic so callers see the metadata/notes written
+	// above (Get cannot fail here — the epic was just created in this store).
+	refreshed, err := store.Get(epic.ID)
+	if err != nil {
+		return nil, fmt.Errorf("planning: reloading epic %s: %w", epic.ID, err)
+	}
+	return refreshed, nil
+}
+
+// DecomposePending reports whether an epic is accepted for planning but not yet
+// decomposed by the architect (its decompose_pending marker is set). Callers use
+// it to know a plan request is QUEUED — waiting on the architect — so the
+// dashboard can surface the "architect paused" message and the label trigger
+// knows there is still work to hand off.
+func DecomposePending(epic *beads.Bead) bool {
+	return epic != nil && epic.Meta(MetaDecomposePending) == "true"
+}
+
+// ClearDecomposePending removes the pending marker once the architect has
+// decomposed the epic (children materialized). It is a single metadata write; a
+// failure is non-fatal (the marker is advisory — the tile would just show the
+// epic as pending one cycle longer).
+func ClearDecomposePending(store *beads.Store, epicID string) error {
+	return store.UnsetMetadata(epicID, MetaDecomposePending)
+}
+
+// HasPlanLabel reports whether any of the issue's labels is a "plan" trigger
+// label (Part B). It matches the maintainer labels `plan` and `epic`
+// case-insensitively. A nil/empty label set returns false.
+func HasPlanLabel(issue github.Issue) bool {
+	for _, l := range issue.Labels {
+		switch strings.ToLower(strings.TrimSpace(l)) {
+		case "plan", "epic":
+			return true
+		}
+	}
+	return false
+}
+
+// ArchitectAgentName is the agent that decomposes epics. It is the general
+// architect lane (RFCs, refactor/perf scans) — decomposition is just one more
+// job it does — so decomposition RESPECTS the architect's pause: a request for a
+// paused architect queues (the epic stays decompose_pending) rather than
+// force-unpausing it.
+const ArchitectAgentName = "architect"
+
+// DecomposeKicker drives the architect out-of-band and reports whether it is
+// currently paused. Both methods must be safe to call from the governor tick /
+// an HTTP handler and must NOT touch the agent-launch mutex. *agent.Manager
+// satisfies this via SendKick + IsPaused (each takes the manager lock itself,
+// called off the launch path — the #1980/#2018/#2021 lesson).
+type DecomposeKicker interface {
+	SendKick(name, message string) error
+	IsPaused(name string) bool
+}
+
+// DecomposeState is the outcome of RequestDecompose, so callers can surface the
+// right message (toast / plan-review / PLANNING tile).
+type DecomposeState string
+
+const (
+	// DecomposeKicked: the architect was available and was kicked to decompose now.
+	DecomposeKicked DecomposeState = "kicked"
+	// DecomposeQueuedPaused: the architect is PAUSED, so the request is queued —
+	// the epic stays decompose_pending and will be built when the architect
+	// resumes. The user must be told the pause is why nothing is happening.
+	DecomposeQueuedPaused DecomposeState = "queued_paused"
+	// DecomposeQueuedNoAgent: no architect/manager is wired, so the request is
+	// queued for a later cycle (also covers the kick failing transiently).
+	DecomposeQueuedNoAgent DecomposeState = "queued_no_agent"
+)
+
+// ArchitectPausedMessage is the user-facing explanation shown wherever a plan is
+// queued because the architect is paused. It names the deliberate pause as the
+// cause and points at the fix.
+const ArchitectPausedMessage = "⏸ Architect is paused — this plan won't be built until you resume the architect agent."
+
+// RequestDecompose hands a pending epic off to the architect, RESPECTING its
+// pause. It is the shared core behind the dashboard click and the label trigger:
+//
+//   - architect paused        → do NOT kick, do NOT unpause; leave the epic
+//     decompose_pending and return DecomposeQueuedPaused so the caller shows the
+//     "architect is paused" message.
+//   - architect available     → kick it with the decomposition prompt and return
+//     DecomposeKicked; the pending marker stays until the architect materializes
+//     children (DecomposeFromOutput clears it).
+//   - no manager / kick failed → return DecomposeQueuedNoAgent; the epic stays
+//     pending and a later cycle retries.
+//
+// It never force-unpauses and only ever calls SendKick/IsPaused — never the
+// launch-path mutex. epic must be the (already minted) pending epic.
+func RequestDecompose(kicker DecomposeKicker, epic *beads.Bead) DecomposeState {
+	if kicker == nil {
+		return DecomposeQueuedNoAgent
+	}
+	if kicker.IsPaused(ArchitectAgentName) {
+		return DecomposeQueuedPaused
+	}
+	if err := kicker.SendKick(ArchitectAgentName, BuildPrompt(epic)); err != nil {
+		return DecomposeQueuedNoAgent
+	}
+	return DecomposeKicked
+}
+
+// LabelPlanResult summarizes one PlanIssuesFromLabels pass.
+type LabelPlanResult struct {
+	// Minted is the number of NEW epics created this pass (idempotent — an issue
+	// already turned into an epic is not counted again).
+	Minted int
+	// Kicked is the number of pending epics handed to an available architect.
+	Kicked int
+	// QueuedPaused is the number left queued because the architect is paused.
+	QueuedPaused int
+}
+
+// LabelPlanSink observes PlanIssuesFromLabels decisions (audit + logging). Both
+// callers implement it; either method may be a no-op. It keeps this function
+// free of the dashboard/logging types so it is unit-testable in pkg/planning.
+type LabelPlanSink interface {
+	// KickedPlan is called when a labeled issue's epic was handed to the architect.
+	KickedPlan(epic *beads.Bead)
+	// QueuedPlan is called when the plan is queued (architect paused or absent);
+	// paused reports which case, so the caller can log the "architect paused"
+	// message once.
+	QueuedPlan(epic *beads.Bead, paused bool)
+}
+
+// PlanIssuesFromLabels is the Phase 4 Part B core: for each issue carrying a
+// plan/epic label, mint an epic (idempotent) and, while it is still pending, hand
+// it to the architect via RequestDecompose — RESPECTING the architect's pause
+// (paused → queued, never force-unpaused). It is a pure, synchronous function
+// over the injected store/kicker/sink, so cmd/hive is a thin adapter and the
+// whole decision path is unit-tested here. mintErr (nil-safe) is called on a mint
+// failure so the caller can log it.
+func PlanIssuesFromLabels(store *beads.Store, kicker DecomposeKicker, issues []github.Issue, sink LabelPlanSink, mintErr func(ref string, err error)) LabelPlanResult {
+	var res LabelPlanResult
+	if store == nil {
+		return res
+	}
+	for _, issue := range issues {
+		if !HasPlanLabel(issue) {
+			continue
+		}
+		existing := store.FindByExternalRef(IssueRef(issue))
+		// The github.Issue carries no body; the epic plans against title + labels.
+		epic, err := EpicFromIssue(store, issue, "")
+		if err != nil {
+			if mintErr != nil {
+				mintErr(IssueRef(issue), err)
+			}
+			continue
+		}
+		if existing == nil {
+			res.Minted++
+		}
+		// Only hand off while still pending (not yet decomposed by the architect).
+		if !DecomposePending(epic) {
+			continue
+		}
+		switch RequestDecompose(kicker, epic) {
+		case DecomposeKicked:
+			res.Kicked++
+			if sink != nil {
+				sink.KickedPlan(epic)
+			}
+		case DecomposeQueuedPaused:
+			res.QueuedPaused++
+			if sink != nil {
+				sink.QueuedPlan(epic, true)
+			}
+		case DecomposeQueuedNoAgent:
+			if sink != nil {
+				sink.QueuedPlan(epic, false)
+			}
+		}
+	}
+	return res
+}

--- a/v2/pkg/planning/issue_test.go
+++ b/v2/pkg/planning/issue_test.go
@@ -1,0 +1,394 @@
+package planning
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/beads"
+	"github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// TestEpicFromIssue_CreateError exercises the persistence error path (the epic
+// create's WriteFile fails) by making the store dir read-only. Skipped as root,
+// which bypasses filesystem permission checks.
+func TestEpicFromIssue_CreateError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; filesystem permission enforcement is bypassed")
+	}
+	dir := t.TempDir()
+	store, err := beads.NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := os.Chmod(dir, 0500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+
+	_, err = EpicFromIssue(store, github.Issue{Repo: "a/b", Number: 1, Title: "t"}, "body")
+	if err == nil {
+		t.Fatal("want persistence error when store dir is read-only")
+	}
+	if !strings.Contains(err.Error(), "creating epic") {
+		t.Errorf("error = %v, want creating-epic wrap", err)
+	}
+}
+
+func TestIssueRef(t *testing.T) {
+	cases := []struct {
+		name  string
+		issue github.Issue
+		want  string
+	}{
+		{"repo+number", github.Issue{Repo: "kubestellar/hive", Number: 42}, "gh-kubestellar/hive#42"},
+		{"number zero falls to url", github.Issue{Repo: "kubestellar/hive", Number: 0, URL: "https://x/1"}, "https://x/1"},
+		{"no repo falls to url", github.Issue{Number: 42, URL: "https://x/2"}, "https://x/2"},
+		{"nothing", github.Issue{}, ""},
+		{"whitespace repo", github.Issue{Repo: "  ", Number: 5, URL: "https://x/3"}, "https://x/3"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IssueRef(tc.issue); got != tc.want {
+				t.Errorf("IssueRef = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEpicFromIssue_CreatesEpic(t *testing.T) {
+	store := newStore(t)
+	issue := github.Issue{
+		Repo:   "kubestellar/hive",
+		Number: 7,
+		Title:  "Add planning intelligence phase 4",
+		URL:    "https://github.com/kubestellar/hive/issues/7",
+		Labels: []string{"enhancement", "plan"},
+	}
+
+	epic, err := EpicFromIssue(store, issue, "Detailed body describing the work.")
+	if err != nil {
+		t.Fatalf("EpicFromIssue: %v", err)
+	}
+	if epic.Type != beads.TypeEpic {
+		t.Errorf("type = %q, want epic", epic.Type)
+	}
+	if epic.Title != issue.Title {
+		t.Errorf("title = %q", epic.Title)
+	}
+	if epic.ExternalRef != "gh-kubestellar/hive#7" {
+		t.Errorf("external ref = %q", epic.ExternalRef)
+	}
+	if epic.Notes != "Detailed body describing the work." {
+		t.Errorf("notes = %q", epic.Notes)
+	}
+	if epic.Meta(MetaSource) != SourceGitHubIssue {
+		t.Errorf("source meta = %q", epic.Meta(MetaSource))
+	}
+	if epic.Meta(MetaIssueRepo) != "kubestellar/hive" {
+		t.Errorf("issue_repo = %q", epic.Meta(MetaIssueRepo))
+	}
+	if epic.Meta(MetaIssueNumber) != "7" {
+		t.Errorf("issue_number = %q", epic.Meta(MetaIssueNumber))
+	}
+	if epic.Meta(MetaIssueURL) != issue.URL {
+		t.Errorf("issue_url = %q", epic.Meta(MetaIssueURL))
+	}
+	if epic.Meta(MetaIssueLabels) != "enhancement,plan" {
+		t.Errorf("labels = %q", epic.Meta(MetaIssueLabels))
+	}
+	// Accepted-but-not-built state: draft + decompose_pending, no children yet.
+	if epic.Meta(MetaPlanStatus) != PlanStatusDraft {
+		t.Errorf("plan_status = %q, want draft", epic.Meta(MetaPlanStatus))
+	}
+	if !DecomposePending(epic) {
+		t.Error("fresh issue-sourced epic should be decompose_pending")
+	}
+	// The epic must be decomposable by BuildPrompt (body flows through).
+	if body := epicBody(epic); body == "" {
+		t.Error("epicBody empty; BuildPrompt would lack DETAILS")
+	}
+}
+
+func TestEpicFromIssue_Idempotent(t *testing.T) {
+	store := newStore(t)
+	issue := github.Issue{Repo: "org/repo", Number: 3, Title: "Idempotent epic"}
+
+	first, err := EpicFromIssue(store, issue, "")
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	second, err := EpicFromIssue(store, issue, "different body")
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if first.ID != second.ID {
+		t.Fatalf("expected same epic id, got %s and %s (duplicate!)", first.ID, second.ID)
+	}
+	// Only ONE epic must exist for this ref.
+	all := store.List(beads.ListFilter{})
+	epics := 0
+	for _, b := range all {
+		if b.Type == beads.TypeEpic {
+			epics++
+		}
+	}
+	if epics != 1 {
+		t.Fatalf("expected exactly 1 epic, got %d", epics)
+	}
+}
+
+func TestEpicFromIssue_UrlOnlyRef(t *testing.T) {
+	store := newStore(t)
+	issue := github.Issue{Title: "no repo/number", URL: "https://example/issues/99"}
+	epic, err := EpicFromIssue(store, issue, "")
+	if err != nil {
+		t.Fatalf("EpicFromIssue: %v", err)
+	}
+	if epic.ExternalRef != "https://example/issues/99" {
+		t.Errorf("ref = %q", epic.ExternalRef)
+	}
+	if epic.Meta(MetaIssueNumber) != "" {
+		t.Errorf("issue_number should be empty when number is 0, got %q", epic.Meta(MetaIssueNumber))
+	}
+}
+
+func TestEpicFromIssue_Errors(t *testing.T) {
+	store := newStore(t)
+	cases := []struct {
+		name  string
+		store *beads.Store
+		issue github.Issue
+	}{
+		{"nil store", nil, github.Issue{Repo: "a/b", Number: 1, Title: "t"}},
+		{"empty title", store, github.Issue{Repo: "a/b", Number: 1}},
+		{"no ref", store, github.Issue{Title: "has title but no ref"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := EpicFromIssue(tc.store, tc.issue, ""); err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestHasPlanLabel(t *testing.T) {
+	cases := []struct {
+		labels []string
+		want   bool
+	}{
+		{[]string{"plan"}, true},
+		{[]string{"epic"}, true},
+		{[]string{"Plan"}, true},    // case-insensitive
+		{[]string{"  EPIC "}, true}, // trimmed + case-insensitive
+		{[]string{"bug", "epic"}, true},
+		{[]string{"enhancement"}, false},
+		{nil, false},
+		{[]string{}, false},
+	}
+	for _, tc := range cases {
+		got := HasPlanLabel(github.Issue{Labels: tc.labels})
+		if got != tc.want {
+			t.Errorf("HasPlanLabel(%v) = %v, want %v", tc.labels, got, tc.want)
+		}
+	}
+}
+
+func TestDecomposePendingAndClear(t *testing.T) {
+	store := newStore(t)
+	epic, err := EpicFromIssue(store, github.Issue{Repo: "a/b", Number: 1, Title: "t"}, "")
+	if err != nil {
+		t.Fatalf("EpicFromIssue: %v", err)
+	}
+	if !DecomposePending(epic) {
+		t.Fatal("issue-sourced epic should be pending")
+	}
+	if DecomposePending(nil) {
+		t.Error("nil epic should not be pending")
+	}
+
+	if err := ClearDecomposePending(store, epic.ID); err != nil {
+		t.Fatalf("ClearDecomposePending: %v", err)
+	}
+	got, _ := store.Get(epic.ID)
+	if DecomposePending(got) {
+		t.Error("epic should not be pending after clear")
+	}
+}
+
+func TestDecomposeFromOutput_ClearsPending(t *testing.T) {
+	store := newStore(t)
+	epic, err := EpicFromIssue(store, github.Issue{Repo: "a/b", Number: 2, Title: "t"}, "")
+	if err != nil {
+		t.Fatalf("EpicFromIssue: %v", err)
+	}
+	// Re-read so the in-memory epic carries the pending marker.
+	epic, _ = store.Get(epic.ID)
+	if _, err := DecomposeFromOutput(store, epic, "1. [T1] a [agent_suitable]\n", Options{}); err != nil {
+		t.Fatalf("DecomposeFromOutput: %v", err)
+	}
+	got, _ := store.Get(epic.ID)
+	if DecomposePending(got) {
+		t.Error("decompose_pending should be cleared once children are materialized")
+	}
+}
+
+// fakeDecomposeKicker records SendKick calls and reports a configurable paused
+// state, so RequestDecompose can be tested without a live agent.Manager.
+type fakeDecomposeKicker struct {
+	paused  bool
+	kickErr error
+	kicks   int
+	lastMsg string
+}
+
+func (f *fakeDecomposeKicker) IsPaused(string) bool { return f.paused }
+func (f *fakeDecomposeKicker) SendKick(_, message string) error {
+	f.kicks++
+	f.lastMsg = message
+	return f.kickErr
+}
+
+// recordingSink captures LabelPlanSink callbacks.
+type recordingSink struct {
+	kicked       []string
+	queuedPaused []string
+	queuedNo     []string
+}
+
+func (s *recordingSink) KickedPlan(epic *beads.Bead) { s.kicked = append(s.kicked, epic.ID) }
+func (s *recordingSink) QueuedPlan(epic *beads.Bead, paused bool) {
+	if paused {
+		s.queuedPaused = append(s.queuedPaused, epic.ID)
+	} else {
+		s.queuedNo = append(s.queuedNo, epic.ID)
+	}
+}
+
+func TestPlanIssuesFromLabels_MintsKicksAndSkips(t *testing.T) {
+	store := newStore(t)
+	issues := []github.Issue{
+		{Repo: "a/b", Number: 1, Title: "labeled plan", Labels: []string{"plan"}},
+		{Repo: "a/b", Number: 2, Title: "no label", Labels: []string{"bug"}}, // skipped
+		{Repo: "a/b", Number: 3, Title: "labeled epic", Labels: []string{"epic"}},
+	}
+	sink := &recordingSink{}
+	res := PlanIssuesFromLabels(store, &fakeDecomposeKicker{}, issues, sink, nil)
+
+	if res.Minted != 2 || res.Kicked != 2 {
+		t.Fatalf("res = %+v, want Minted=2 Kicked=2", res)
+	}
+	if len(sink.kicked) != 2 {
+		t.Errorf("expected 2 kicked plans, got %d", len(sink.kicked))
+	}
+	// Two epics exist, both pending → draft.
+	epics := 0
+	for _, b := range store.List(beads.ListFilter{}) {
+		if b.Type == beads.TypeEpic {
+			epics++
+		}
+	}
+	if epics != 2 {
+		t.Errorf("expected 2 epics, got %d", epics)
+	}
+}
+
+func TestPlanIssuesFromLabels_Idempotent(t *testing.T) {
+	store := newStore(t)
+	issues := []github.Issue{{Repo: "a/b", Number: 1, Title: "once", Labels: []string{"plan"}}}
+	sink := &recordingSink{}
+
+	first := PlanIssuesFromLabels(store, &fakeDecomposeKicker{}, issues, sink, nil)
+	if first.Minted != 1 {
+		t.Fatalf("first Minted = %d, want 1", first.Minted)
+	}
+	// Second pass: epic already exists AND is still pending (kicker did nothing
+	// real), so it is NOT minted again but IS re-kicked (still pending).
+	second := PlanIssuesFromLabels(store, &fakeDecomposeKicker{}, issues, sink, nil)
+	if second.Minted != 0 {
+		t.Errorf("second Minted = %d, want 0 (no duplicate)", second.Minted)
+	}
+}
+
+func TestPlanIssuesFromLabels_PausedQueues(t *testing.T) {
+	store := newStore(t)
+	issues := []github.Issue{{Repo: "a/b", Number: 1, Title: "plan me", Labels: []string{"plan"}}}
+	sink := &recordingSink{}
+	res := PlanIssuesFromLabels(store, &fakeDecomposeKicker{paused: true}, issues, sink, nil)
+
+	if res.Kicked != 0 || res.QueuedPaused != 1 {
+		t.Fatalf("res = %+v, want Kicked=0 QueuedPaused=1", res)
+	}
+	if len(sink.queuedPaused) != 1 {
+		t.Errorf("expected 1 paused-queued plan, got %d", len(sink.queuedPaused))
+	}
+	// The epic is minted and still pending (queued, not dropped).
+	epic := store.FindByExternalRef("gh-a/b#1")
+	if epic == nil || !DecomposePending(epic) {
+		t.Error("paused plan should be minted and left pending")
+	}
+}
+
+func TestPlanIssuesFromLabels_NilStoreAndMintErr(t *testing.T) {
+	// Nil store → no-op zero result.
+	if res := PlanIssuesFromLabels(nil, &fakeDecomposeKicker{}, nil, nil, nil); res != (LabelPlanResult{}) {
+		t.Errorf("nil store: got %+v, want zero", res)
+	}
+	// Mint error (issue with a title but no ref) → mintErr callback fires.
+	store := newStore(t)
+	called := false
+	PlanIssuesFromLabels(store,
+		&fakeDecomposeKicker{},
+		[]github.Issue{{Title: "no ref", Labels: []string{"plan"}}},
+		nil,
+		func(string, error) { called = true })
+	if !called {
+		t.Error("expected mintErr callback on unref-able labeled issue")
+	}
+}
+
+func TestPlanIssuesFromLabels_QueuedNoAgent(t *testing.T) {
+	store := newStore(t)
+	issues := []github.Issue{{Repo: "a/b", Number: 1, Title: "plan", Labels: []string{"plan"}}}
+	sink := &recordingSink{}
+	// Kick fails → queued (no agent) path + sink.QueuedPlan(paused=false).
+	PlanIssuesFromLabels(store, &fakeDecomposeKicker{kickErr: errFake}, issues, sink, nil)
+	if len(sink.queuedNo) != 1 {
+		t.Errorf("expected 1 no-agent-queued plan, got %d", len(sink.queuedNo))
+	}
+}
+
+func TestRequestDecompose(t *testing.T) {
+	store := newStore(t)
+	epic, _ := EpicFromIssue(store, github.Issue{Repo: "a/b", Number: 3, Title: "plan me"}, "body")
+
+	// nil kicker → queued (no agent).
+	if got := RequestDecompose(nil, epic); got != DecomposeQueuedNoAgent {
+		t.Errorf("nil kicker: got %q, want queued_no_agent", got)
+	}
+
+	// paused architect → queued, NOT kicked (respect the pause).
+	paused := &fakeDecomposeKicker{paused: true}
+	if got := RequestDecompose(paused, epic); got != DecomposeQueuedPaused {
+		t.Errorf("paused: got %q, want queued_paused", got)
+	}
+	if paused.kicks != 0 {
+		t.Error("paused architect must NOT be kicked")
+	}
+
+	// available architect → kicked with the decomposition prompt.
+	ok := &fakeDecomposeKicker{}
+	if got := RequestDecompose(ok, epic); got != DecomposeKicked {
+		t.Errorf("available: got %q, want kicked", got)
+	}
+	if ok.kicks != 1 || ok.lastMsg == "" {
+		t.Errorf("expected one kick with a prompt, got %d msg=%q", ok.kicks, ok.lastMsg)
+	}
+
+	// kick error → queued (no agent).
+	failing := &fakeDecomposeKicker{kickErr: errFake}
+	if got := RequestDecompose(failing, epic); got != DecomposeQueuedNoAgent {
+		t.Errorf("kick error: got %q, want queued_no_agent", got)
+	}
+}


### PR DESCRIPTION
Phase 4 of planning intelligence: the **GitHub-issue entry point**. Phases 1–3 (decompose, plan-review gate, stall-replan) are on v3; this turns a GitHub issue into an epic to plan, by **label** or by a dashboard **click**, and makes the tier-classifier keywords config-driven + dashboard-visible.

## Part A — issue → epic → decompose

- **`pkg/planning.EpicFromIssue(store, issue, body)`** — mints a `TypeEpic` bead from an issue. **Idempotent** via `FindByExternalRef` on a stable ref (`gh-<owner>/<repo>#<num>`, else the issue URL) — labeling/clicking the same issue twice never duplicates the epic. Carries the title, body (Notes), labels + trace metadata, and sets `plan_status=draft` + `decompose_pending` so the epic shows up in the plan-review flow / PLANNING tile immediately (accepted-but-not-built).
- **`POST /api/plan/from-issue`** (`handlePlanFromIssue`) — body `{repo, number|url, title, body}` (resolves title/labels from the last actionable status when only identifiers are sent). Mints the epic, then hands it to the architect.
- **Dashboard:** a labeled **⧉ Plan** button on every issue pill (`data-action="planIssue"`, delegated click handler → POST → toast), with the tooltip *"Break this issue into a reviewable task plan (architect decomposes it; you approve before work starts)."*

### Planner approach: request-and-poll (not synchronous)
The click/label **kicks the architect out-of-band** (the same `SendKick` path Phase 3 uses) and returns the epic id; the UI polls `GET /api/plan/{epicID}` and the architect fills the plan in via the existing plan-review gate. A synchronous decompose would block the HTTP handler / eval tick on a live tmux agent — so instead the epic is minted `draft`+`decompose_pending` and the architect materializes children later (`DecomposeFromOutput` clears the pending marker).

### The architect is a shared agent — its pause is RESPECTED
The architect is general-purpose (RFCs, refactor/perf scans); decomposition is one more job. `RequestDecompose(kicker, epic)` checks `IsPaused("architect")`:
- **paused → queued, NOT unpaused, NOT dropped** — the epic stays `decompose_pending` and a clear message is surfaced in the **toast**, the **plan-from-issue response** (`architectPaused:true`), and the **PLANNING tile** (⏸ + tooltip): **"⏸ Architect is paused — this plan won't be built until you resume the architect agent."**
- available → kicked; no agent / kick error → queued for a later cycle.

When the architect resumes (or its cadence fires), the next eval cycle picks up every pending epic. Only `SendKick`/`IsPaused` are ever called — **never the launch-path mutex** (#1980/#2018/#2021).

## Part B — `plan` label trigger (primary, first-class)
In `runEvalCycle`, `planning.PlanIssuesFromLabels(...)` mints an epic (idempotent) for each actionable issue carrying a **`plan`/`epic`** label and hands it off exactly like Part A — synchronous, **no goroutine**, `SendKick`/`IsPaused` only. Gated by `planning.plan_from_label` (explicit) or **ACMM ≥ L4** (default), so low-maturity hives stay advisory-only. The label is documented as the *primary* trigger; the button is the convenience.

## Part C — config-driven tier keywords
`classify.SetTierKeywords(simple, complex)` mirrors `SetLanes` (RWMutex, built-in lists as defaults when unset → **behavior unchanged when unconfigured**). Sourced from a new `classifier:` block (`simple_keywords`, `complex_signals`) wired in `initAgentConfigDrivenSystems`. Surfaced (effective values) in **`GET /api/config/governor`** under `classifier` so they're viewable in the dashboard governor-config view; edit path is hive.yaml (noted in docs).

## Discoverability
- Labeled **⧉ Plan** button + descriptive tooltip.
- **Empty-state hint** on the PLANNING tile when there's no activity: *"click ⧉ Plan on any issue, or add the `plan` label on GitHub."*
- **One-time first-run callout** teaching both entry points.
- **`v2/docs/planning-intelligence.md`** covering the whole feature (decompose, review gate, plan label, paused-architect behavior, config).

## Gates
- **Coverage (new/changed funcs):** `pkg/classify` **100%** (SetTierKeywords/active*/TierKeywords/classifyTier); `pkg/planning` pkg total **97.2%** (EpicFromIssue 90.0%, RequestDecompose/DecomposePending/ClearDecomposePending/HasPlanLabel/IssueRef 100%, PlanIssuesFromLabels 96.2%); `pkg/config` `PlanFromLabelEnabled` **100%**; new dashboard funcs — handlePlanFromIssue **97.1%**, requestArchitectDecompose/decomposeKicker/planEpicStore/classifierSectionResponse/BuildPlanning/architectPausedFromStatuses **100%**, resolveActionableIssue **93.3%**. Idempotency (no duplicate epics), missing/invalid issue, label present/absent, paused/kicked/queued states, and config defaults-vs-overrides all covered.
- **`-race` clean:** `go test ./pkg/planning/... ./pkg/classify/ ./pkg/dashboard/ ./pkg/config/ -race -count=1 -timeout 300s` → **0 DATA RACE**.
- `go build ./...`, `go vet ./...` clean; `gofmt` clean on all changed files (pre-existing gofmt-dirty files left alone).
- No new goroutine; **no launch-path mutex touch** — architect driven only via SendKick/IsPaused.

Deferred: no full inline edit UI for the tier keywords (they're read-only in the governor-config payload; edit via hive.yaml, per the docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)