### PR TITLE
✨ feat(banner): safe markdown (links + bold) + compose toolbar & live preview

### DIFF
--- a/v2/pkg/dashboard/history_endpoints_coverage_test.go
+++ b/v2/pkg/dashboard/history_endpoints_coverage_test.go
@@ -1,0 +1,82 @@
+package dashboard
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/tokens"
+)
+
+// TestHandleTrendHistory covers the trend-history read endpoint (#2039).
+func TestHandleTrendHistory(t *testing.T) {
+	s := covApiServer(t)
+	rec := doGet(s, "/api/trend/history")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("trend history: want 200, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct == "" {
+		t.Errorf("expected a Content-Type header")
+	}
+}
+
+// TestHandleTimeSeries covers the unified sparkline-history alias (#2041),
+// including every valid series and the unknown-series 400 path.
+func TestHandleTimeSeries(t *testing.T) {
+	s := covApiServer(t)
+
+	for _, series := range []string{"token", "tokens", "fact", "facts", "cost"} {
+		rec := doGet(s, "/api/timeseries?series="+series)
+		if rec.Code != http.StatusOK {
+			t.Errorf("series=%s: want 200, got %d", series, rec.Code)
+		}
+	}
+
+	// Unknown / missing series → 400.
+	for _, bad := range []string{"", "bogus"} {
+		rec := doGet(s, "/api/timeseries?series="+bad)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("series=%q: want 400, got %d", bad, rec.Code)
+		}
+	}
+}
+
+// TestHandleMetricsWithCollector exercises handleMetrics with a token collector
+// wired in so estimatedCost() returns populated by_model / by_agent slices,
+// covering the exposition loops (not just the empty-data path).
+func TestHandleMetricsWithCollector(t *testing.T) {
+	s, deps := apiServer(t)
+	deps.Config.HiveID = "cov-hive"
+	deps.Tokens = tokens.NewCollector(t.TempDir(),
+		slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+
+	rec := httptest.NewRecorder()
+	s.handleMetrics(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if rec.Code != http.StatusOK && rec.Code != 0 {
+		t.Fatalf("metrics status = %d", rec.Code)
+	}
+	// The exposition always emits the fixed HELP/TYPE headers and the total,
+	// regardless of whether any model data exists.
+	if body := rec.Body.String(); body == "" ||
+		!containsAll(body, "hive_estimated_cost_usd_total", "cov-hive") {
+		t.Errorf("exposition missing fixed series/label:\n%s", rec.Body.String())
+	}
+}
+
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		found := false
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if s[i:i+len(sub)] == sub {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4643,6 +4643,23 @@
       gray:  {bg: 'rgba(107,114,128,0.12)', border: 'rgba(107,114,128,0.3)', color: 'var(--text)'}
     };
 
+    // bannerMarkdown renders a SAFE, minimal markdown subset for hub banners:
+    // links [text](http(s)://url) and **bold**. Everything is HTML-escaped
+    // FIRST (XSS-safe), then only these two constructs are re-introduced, and
+    // link hrefs are restricted to http/https. No other markdown/HTML passes.
+    function bannerMarkdown(text, linkColor) {
+      var esc = String(text || '')
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+      // Links: [label](url) — url must be http(s) and contain no quotes/spaces.
+      esc = esc.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)"']+)\)/g, function (_, label, url) {
+        return '<a href="' + url + '" target="_blank" rel="noopener noreferrer" style="color:'
+          + (linkColor || 'inherit') + ';text-decoration:underline">' + label + '</a>';
+      });
+      // Bold: **text**
+      esc = esc.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+      return esc;
+    }
+
     function renderHubBanner(banner) {
       var el = document.getElementById('hub-banner');
       if (!el) return;
@@ -4653,7 +4670,7 @@
       el.style.display = 'block';
       el.innerHTML = '<div style="background:' + s.bg + ';border:1px solid ' + s.border + ';border-radius:8px;padding:12px 16px;margin-bottom:8px;display:flex;align-items:center;gap:10px;font-size:0.85rem">'
         + '<span style="font-size:1.1rem">📢</span>'
-        + '<span style="flex:1;color:' + s.color + '">' + (banner.message || '').replace(/</g, '&lt;') + '</span>'
+        + '<span style="flex:1;color:' + s.color + '">' + bannerMarkdown(banner.message, s.color) + '</span>'
         + '<button onclick="dismissHubBanner(\'' + (banner.id || '').replace(/'/g, "\\'") + '\')" style="background:none;border:none;color:' + s.color + ';opacity:0.6;cursor:pointer;font-size:1.1rem;padding:0 4px" title="Dismiss">✕</button>'
         + '</div>';
     }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -6878,8 +6878,14 @@ const dashboardHTML = `<!DOCTYPE html>
       <div style="flex:1;overflow-y:auto;padding:0 32px">
         <div style="margin-bottom:12px">
           <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:4px">Message *</label>
-          <textarea id="banner-message" rows="3" maxlength="500" placeholder="Announce a new capability..." style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem;resize:vertical;font-family:inherit"></textarea>
-          <div style="font-size:0.7rem;color:var(--muted);text-align:right;margin-top:2px"><span id="banner-char-count">0</span>/500</div>
+          <div style="display:flex;gap:6px;margin-bottom:6px">
+            <button type="button" onclick="bannerFmtBold()" title="Bold (**text**)" style="padding:3px 10px;background:var(--bg);border:1px solid var(--border);border-radius:5px;color:var(--text);cursor:pointer;font-weight:700;font-size:0.8rem">B</button>
+            <button type="button" onclick="bannerFmtLink()" title="Insert link ([text](url))" style="padding:3px 10px;background:var(--bg);border:1px solid var(--border);border-radius:5px;color:var(--text);cursor:pointer;font-size:0.8rem">🔗 Link</button>
+          </div>
+          <textarea id="banner-message" rows="3" maxlength="500" oninput="updateBannerPreview()" placeholder="Announce a new capability... — use the buttons above for bold and links" style="width:100%;padding:8px 12px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.85rem;resize:vertical;font-family:inherit"></textarea>
+          <div style="font-size:0.7rem;color:var(--muted);display:flex;justify-content:space-between;margin-top:2px"><span>Markdown: <code>**bold**</code>, <code>[text](https://url)</code></span><span><span id="banner-char-count">0</span>/500</span></div>
+          <div style="font-size:0.7rem;color:var(--muted);margin:8px 0 3px">Preview</div>
+          <div id="banner-preview" style="padding:10px 14px;border:1px dashed var(--border);border-radius:6px;font-size:0.85rem;min-height:1.4em;color:var(--text)"></div>
         </div>
         <div style="margin-bottom:16px">
           <label style="display:block;font-size:0.8rem;color:var(--muted);margin-bottom:8px">Color</label>
@@ -7291,6 +7297,19 @@ const dashboardHTML = `<!DOCTYPE html>
       radios.forEach(function(r) { r.addEventListener('change', updateBannerPreview); });
     })();
 
+    // Same safe minimal-markdown as the spoke's renderHubBanner: escape first,
+    // then re-introduce only **bold** and [text](http(s)://url) links. Keep this
+    // in sync with bannerMarkdown() in the spoke dashboard.
+    function bannerMarkdown(text, linkColor) {
+      var out = String(text || '')
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+      out = out.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)"']+)\)/g, function(_, label, url) {
+        return '<a href="' + url + '" target="_blank" rel="noopener noreferrer" style="color:'
+          + (linkColor || 'inherit') + ';text-decoration:underline">' + label + '</a>';
+      });
+      return out.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+    }
+
     function updateBannerPreview() {
       var msg = (document.getElementById('banner-message').value || '').trim();
       var color = (document.querySelector('input[name="banner-color"]:checked') || {}).value || 'green';
@@ -7299,8 +7318,25 @@ const dashboardHTML = `<!DOCTYPE html>
       preview.style.background = s.bg;
       preview.style.border = s.border;
       preview.style.color = s.color;
-      preview.innerHTML = msg ? esc(msg) : '<em style="opacity:0.6">Type a message above to preview...</em>';
+      preview.innerHTML = msg ? ('📢 ' + bannerMarkdown(msg, s.color)) : '<em style="opacity:0.6">Type a message above to preview...</em>';
     }
+
+    // Toolbar helpers: wrap the current selection (or insert a template) at the
+    // cursor, then refresh the char count + preview.
+    function bannerInsert(before, after, placeholder) {
+      var el = document.getElementById('banner-message');
+      var start = el.selectionStart, end = el.selectionEnd;
+      var sel = el.value.slice(start, end) || placeholder;
+      el.value = el.value.slice(0, start) + before + sel + after + el.value.slice(end);
+      // Re-select the inserted content so the user can type over the placeholder.
+      el.focus();
+      el.selectionStart = start + before.length;
+      el.selectionEnd = start + before.length + sel.length;
+      document.getElementById('banner-char-count').textContent = el.value.length;
+      updateBannerPreview();
+    }
+    function bannerFmtBold() { bannerInsert('**', '**', 'bold text'); }
+    function bannerFmtLink() { bannerInsert('[', '](https://)', 'link text'); }
 
     function loadBannerHiveList() {
       var container = document.getElementById('banner-hive-list');


### PR DESCRIPTION
## Summary

Hub banners were plain escaped text — a URL wasn't clickable and `[text](url)` showed literally. Now banners support a **safe minimal-markdown subset** and the composer has a small WYSIWYG toolbar + live preview.

### Markdown
- `**bold**` → bold
- `[text](https://url)` → link (http/https only)
- Rendered identically on the spoke (`renderHubBanner`) and in the hub composer preview (shared `bannerMarkdown`).

### Security (no engine, no deps)
Escape everything FIRST, then re-introduce only bold + links. Link hrefs restricted to `http(s)://` (so `[x](javascript:...)` is **not** linkified); quotes inside a URL are escaped so they can't break out of the `href`. Verified against `<script>`, `javascript:`, and quote-injection cases.

### Composer WYSIWYG
- **B** and **🔗 Link** toolbar buttons wrap the current selection (or insert a placeholder) at the cursor.
- **Live preview** below the textarea renders the banner exactly as it'll appear on the spoke, in the selected color.
- Placeholder + hint text updated.

## Test plan
- Send a banner with `Check the [new dashboard](https://…) — it's **live**` → spoke shows a clickable bold-containing banner
- `[x](javascript:alert(1))` stays inert text; `<script>` escaped
- Toolbar buttons insert at cursor; preview matches spoke rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)