### PR TITLE
✨ feat(hub): vanity dashboard URL on placeholder assignment (PR-1)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1873,11 +1873,23 @@ func main() {
 			if cfg.ACMMLevel != nil {
 				curACMM = *cfg.ACMMLevel
 			}
+			// Adopt the vanity dashboard URL delivered on claim, if any. We
+			// report cfg.Hub.DashboardURL in our heartbeats, so once set the hub
+			// registry's dashboardUrl becomes the vanity URL (not the placeholder
+			// host). Track it in the already-reconciled check so a URL-only change
+			// still gets applied and persisted.
+			vanityMatched := pc.DashboardURL == "" || cfg.Hub.DashboardURL == pc.DashboardURL
 			if cfg.Project.Org == pc.Org &&
 				sameStringSlice(cfg.Project.Repos, pc.Repos) &&
 				cfg.Project.PrimaryRepo == pc.PrimaryRepo &&
-				curACMM == pc.ACMMLevel {
+				curACMM == pc.ACMMLevel &&
+				vanityMatched {
 				return // already reconciled
+			}
+			if pc.DashboardURL != "" && cfg.Hub.DashboardURL != pc.DashboardURL {
+				logger.Info("adopting vanity dashboard URL from hub heartbeat",
+					"was", cfg.Hub.DashboardURL, "now", pc.DashboardURL)
+				cfg.Hub.DashboardURL = pc.DashboardURL
 			}
 			logger.Info("project config updated from hub heartbeat (placeholder claimed)",
 				"was_org", cfg.Project.Org, "now_org", pc.Org,

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -460,6 +460,12 @@ type HeartbeatProjectConfig struct {
 	Repos       []string `json:"repos"`
 	PrimaryRepo string   `json:"primary_repo,omitempty"`
 	ACMMLevel   int      `json:"acmm_level"`
+	// DashboardURL is the claimed hive's vanity URL. The spoke adopts it as its
+	// hub.dashboard_url and reports it in subsequent heartbeats, so the hub
+	// registry's dashboardUrl becomes the vanity URL (rather than the raw
+	// placeholder subdomain) — and stays that way, since it's now the value the
+	// heartbeat carries. Empty = leave the spoke's dashboard URL unchanged.
+	DashboardURL string `json:"dashboard_url,omitempty"`
 }
 
 // HeartbeatGatewayConfig carries an OpenRouter model gateway (funded via the

--- a/v2/pkg/hub/hub_filesystem_test.go
+++ b/v2/pkg/hub/hub_filesystem_test.go
@@ -1127,13 +1127,26 @@ func TestHandleAssignHiveWithFilesystem(t *testing.T) {
 		t.Errorf("assign wrote wrong meta: %+v", h)
 	}
 
+	// Assign derives a vanity URL from the claimed project (present because the
+	// test cluster has a domain). It's the marker that the placeholder is claimed.
+	if h.VanityURL == "" {
+		t.Error("expected assign to set a vanity URL")
+	}
+
 	// projectConfigForHiveID keeps returning the real project until the spoke
-	// reports it back, then goes quiet.
-	if pc := projectConfigForHiveID("hosted-assign-fs", "oldorg", []string{"old"}, "old", 2); pc == nil {
+	// reports BOTH the project AND the vanity URL back, then goes quiet.
+	if pc := projectConfigForHiveID("hosted-assign-fs", "oldorg", []string{"old"}, "old", 2, ""); pc == nil {
 		t.Error("expected non-nil project config while spoke reports stale project")
 	}
-	if pc := projectConfigForHiveID("hosted-assign-fs", "neworg", []string{"repoa", "repob"}, "repoa", 3); pc != nil {
-		t.Errorf("expected nil project config once spoke matches, got %+v", pc)
+	// Project matches but the spoke hasn't adopted the vanity URL yet -> still sending.
+	if pc := projectConfigForHiveID("hosted-assign-fs", "neworg", []string{"repoa", "repob"}, "repoa", 3, ""); pc == nil {
+		t.Error("expected non-nil config while spoke has not yet adopted the vanity URL")
+	} else if pc.DashboardURL != h.VanityURL {
+		t.Errorf("project config DashboardURL = %q, want the vanity URL %q", pc.DashboardURL, h.VanityURL)
+	}
+	// Spoke now reports the vanity URL too -> goes quiet.
+	if pc := projectConfigForHiveID("hosted-assign-fs", "neworg", []string{"repoa", "repob"}, "repoa", 3, h.VanityURL); pc != nil {
+		t.Errorf("expected nil project config once spoke matches project + vanity URL, got %+v", pc)
 	}
 
 	// Assigning an already-claimed (non-available) hive is rejected.

--- a/v2/pkg/hub/misc_coverage_test.go
+++ b/v2/pkg/hub/misc_coverage_test.go
@@ -136,32 +136,44 @@ func TestProjectConfigForHiveID(t *testing.T) {
 	defer cleanup()
 
 	// No such hive -> nil.
-	if got := projectConfigForHiveID("missing", "", nil, "", 0); got != nil {
+	if got := projectConfigForHiveID("missing", "", nil, "", 0, ""); got != nil {
 		t.Errorf("missing hive -> %+v, want nil", got)
 	}
 
 	// Available placeholder -> nil (not yet claimed).
 	saveSaaSHive(&SaaSHive{ID: "ph", Status: statusAvailable})
-	if got := projectConfigForHiveID("ph", "", nil, "", 0); got != nil {
+	if got := projectConfigForHiveID("ph", "", nil, "", 0, ""); got != nil {
 		t.Errorf("placeholder -> %+v, want nil", got)
 	}
 
 	// Incomplete claim (no ACMM) -> nil.
 	saveSaaSHive(&SaaSHive{ID: "inc", Status: "running", Org: "acme", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 0})
-	if got := projectConfigForHiveID("inc", "", nil, "", 0); got != nil {
+	if got := projectConfigForHiveID("inc", "", nil, "", 0, ""); got != nil {
 		t.Errorf("incomplete claim -> %+v, want nil", got)
 	}
 
 	// Complete claim, spoke not yet matching -> returns config.
 	saveSaaSHive(&SaaSHive{ID: "full", Status: "running", Org: "acme", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 3})
-	got := projectConfigForHiveID("full", "", nil, "", 0)
+	got := projectConfigForHiveID("full", "", nil, "", 0, "")
 	if got == nil || got.Org != "acme" || got.ACMMLevel != 3 {
 		t.Errorf("complete claim -> %+v, want org=acme acmm=3", got)
 	}
 
 	// Spoke already matches -> nil (stop sending).
-	if got := projectConfigForHiveID("full", "acme", []string{"r"}, "r", 3); got != nil {
+	if got := projectConfigForHiveID("full", "acme", []string{"r"}, "r", 3, ""); got != nil {
 		t.Errorf("matched spoke -> %+v, want nil", got)
+	}
+
+	// Vanity URL set but spoke hasn't adopted it -> keep sending (with the URL),
+	// even though org/repos/acmm already match.
+	saveSaaSHive(&SaaSHive{ID: "van", Status: "running", Org: "acme", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 3, VanityURL: "https://vanity.example/"})
+	got = projectConfigForHiveID("van", "acme", []string{"r"}, "r", 3, "")
+	if got == nil || got.DashboardURL != "https://vanity.example/" {
+		t.Errorf("vanity not yet adopted -> %+v, want DashboardURL set", got)
+	}
+	// Spoke has now adopted the vanity URL -> stop sending.
+	if got := projectConfigForHiveID("van", "acme", []string{"r"}, "r", 3, "https://vanity.example/"); got != nil {
+		t.Errorf("vanity adopted -> %+v, want nil", got)
 	}
 }
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1367,7 +1367,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		//     restarted / hasn't beaten yet — not a fresh assignment).
 		spokeReportsDifferentProject := entry.Org != "" && !strings.EqualFold(entry.Org, sh.Org)
 		if !entry.Upgrading && spokeReportsDifferentProject &&
-			projectConfigForHiveID(entry.ID, entry.Org, entry.Repos, entry.PrimaryRepo, entry.ACMMLevel) != nil {
+			projectConfigForHiveID(entry.ID, entry.Org, entry.Repos, entry.PrimaryRepo, entry.ACMMLevel, entry.DashboardURL) != nil {
 			entry.Assigning = true
 			entry.AssigningTo = sh.Org
 		}
@@ -4180,7 +4180,7 @@ func (s *HubServer) handleAvailablePlaceholders(w http.ResponseWriter, r *http.R
 // record, is still an unclaimed placeholder (statusAvailable), or the spoke
 // already reports the recorded project. The spoke's currently-reported values
 // (curOrg/curRepos/curPrimary/curACMM) let the hub stop sending once matched.
-func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary string, curACMM int) *HeartbeatProjectConfig {
+func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary string, curACMM int, curURL string) *HeartbeatProjectConfig {
 	h := loadSaaSHive(hiveID)
 	if h == nil {
 		return nil
@@ -4207,18 +4207,22 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 		return nil
 	}
 	// Already matching — stop sending (mirrors AuthorizedUsers "leave alone"
-	// semantics once the spoke has caught up).
+	// semantics once the spoke has caught up). Include the vanity URL: if it's
+	// set but the spoke hasn't adopted it yet, keep sending so the URL propagates.
+	urlMatched := h.VanityURL == "" || curURL == h.VanityURL
 	if strings.EqualFold(curOrg, h.Org) &&
 		sameStringSliceFold(curRepos, h.Repos) &&
 		strings.EqualFold(curPrimary, primary) &&
-		curACMM == h.ACMMLevel {
+		curACMM == h.ACMMLevel &&
+		urlMatched {
 		return nil
 	}
 	return &HeartbeatProjectConfig{
-		Org:         h.Org,
-		Repos:       h.Repos,
-		PrimaryRepo: primary,
-		ACMMLevel:   h.ACMMLevel,
+		Org:          h.Org,
+		Repos:        h.Repos,
+		PrimaryRepo:  primary,
+		ACMMLevel:    h.ACMMLevel,
+		DashboardURL: h.VanityURL, // empty until assign sets it
 	}
 }
 
@@ -4345,6 +4349,17 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	h.IsPublic = body.IsPublic
 	h.Status = ""
 	h.Error = ""
+	// Derive a stable, friendly vanity URL from the claimed project so the user
+	// sees hosted-<org>-<repo>-*.<domain> instead of the raw placeholder host.
+	// Compute once (idempotent re-assign keeps the same URL) and only when the
+	// hive's cluster domain is known. The spoke adopts this via the heartbeat
+	// (HeartbeatProjectConfig.DashboardURL) and reports it back, so the hub
+	// registry's dashboardUrl becomes the vanity URL and stays that way.
+	if h.VanityURL == "" {
+		if cluster := s.clusterForHive(h); cluster != nil && cluster.Domain != "" {
+			h.VanityURL = "https://" + generateHiveID(body.Org, primaryRepo) + "." + cluster.Domain
+		}
+	}
 	if err := saveSaaSHive(h); err != nil {
 		http.Error(w, `{"error":"failed to save hive assignment"}`, http.StatusInternalServerError)
 		return

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -245,16 +245,23 @@ type PendingAccessRequest struct {
 }
 
 type SaaSHive struct {
-	ID              string                 `json:"id"`
-	Owner           string                 `json:"owner"`
-	ProjectName     string                 `json:"project_name"`
-	Org             string                 `json:"org"`
-	Repos           []string               `json:"repos"`
-	PrimaryRepo     string                 `json:"primary_repo"`
-	ACMMLevel       int                    `json:"acmm_level"`
-	Status          string                 `json:"status"`
-	CreatedAt       string                 `json:"created_at"`
-	Subdomain       string                 `json:"subdomain"`
+	ID          string   `json:"id"`
+	Owner       string   `json:"owner"`
+	ProjectName string   `json:"project_name"`
+	Org         string   `json:"org"`
+	Repos       []string `json:"repos"`
+	PrimaryRepo string   `json:"primary_repo"`
+	ACMMLevel   int      `json:"acmm_level"`
+	Status      string   `json:"status"`
+	CreatedAt   string   `json:"created_at"`
+	Subdomain   string   `json:"subdomain"`
+	// VanityURL is the friendly dashboard URL derived from the claimed project
+	// (e.g. hosted-<org>-<repo>-*.hive.kubestellar.io), set at ASSIGN time. Its
+	// presence is the explicit marker that a placeholder has been claimed —
+	// callers prefer it over the raw placeholder Subdomain and must NOT infer
+	// "claimed" by pattern-matching the placeholder name. Empty = unclaimed
+	// placeholder (or a pre-vanity hive).
+	VanityURL       string                 `json:"vanity_url,omitempty"`
 	Error           string                 `json:"error,omitempty"`
 	AutoUpgrade     bool                   `json:"auto_upgrade"`
 	IsPublic        bool                   `json:"is_public"`

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -646,7 +646,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	// that reaches heartbeat-only clusters (vllm-d) — the hub cannot push
 	// config there over kubectl. A nil return means "spoke already matches, or
 	// no SaaS record / still a placeholder" — send nothing.
-	if projCfg := projectConfigForHiveID(payload.HiveID, payload.Org, payload.Repos, payload.PrimaryRepo, payload.ACMMLevel); projCfg != nil {
+	if projCfg := projectConfigForHiveID(payload.HiveID, payload.Org, payload.Repos, payload.PrimaryRepo, payload.ACMMLevel, payload.DashboardURL); projCfg != nil {
 		resp.ProjectConfig = projCfg
 		s.logger.Info("heartbeat: delivering claimed project config to spoke",
 			"hive_id", payload.HiveID,


### PR DESCRIPTION
## Summary

When a placeholder is claimed, the user still saw the raw `hosted-available-*-placeholder-*` URL. This makes assignment derive a **friendly vanity URL** (`hosted-<org>-<repo>-*.<cluster-domain>`) and deliver it so **My Hives shows the vanity URL instead of the placeholder**.

This is **PR-1 of 2**: identity + delivery (no cluster mutation). PR-2 will auto-create the vanity Route/Ingress.

## How
- **`SaaSHive.VanityURL`** (meta.json) — set once at assign time from the claimed project. Its **presence is the explicit 'claimed' marker** (no pattern-matching the placeholder name — answers 'how do we tell the difference').
- **`HeartbeatProjectConfig.DashboardURL`** — delivers it over the same heartbeat channel as the claimed org/repos/ACMM, so it works on heartbeat-only clusters (vllm-d) with no kubectl push.
- **Spoke** (`cmd/hive`) adopts it into `cfg.Hub.DashboardURL`, persists to the PVC overlay, and reports it in heartbeats → hub registry `dashboardUrl` becomes the vanity URL and **stays** that way (heartbeat is source of truth; hand-edits get overwritten — the gotcha we hit today).
- **`projectConfigForHiveID`** gains a `curURL` arg so the hub keeps sending until the spoke adopts the URL, then goes quiet.
- **My Hives**: no change needed — it already renders `RegistryEntry.DashboardURL`.

## Test plan
- Go: `TestProjectConfigForHiveID` (URL set but unadopted → keep sending with DashboardURL; adopted → nil); `TestHandleAssignHiveWithFilesystem` updated to assert the vanity URL is set and drives the reconcile loop. Full `pkg/hub` suite passes; build + gofmt clean.

## Follow-up (PR-2)
Auto-create the vanity Route (hive-oke: hub `kubectl apply`; vllm-d: spoke self-applies on heartbeat). Until then the vanity host is shown but must be pointed at the service manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)