### PR TITLE
🐛 dashboard: make the ⧉ Plan button always visible on issue pills

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -782,9 +782,10 @@
     .repo-issue-pill:hover { background: color-mix(in srgb, var(--pill-c) 24%, transparent); text-decoration: none; }
     .repo-issue-pill .pill-num { font-weight: 700; white-space: nowrap; }
     .repo-issue-pill .pill-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    /* ⧉ Plan action sits beside its issue pill; hidden until the pill row is hovered. */
+    /* ⧉ Plan action sits beside its issue pill. Always visible (so the feature is
+       discoverable) but visually secondary; brightens to full on row hover. */
     .repo-issue-pill-wrap { display: inline-flex; align-items: center; gap: 4px; max-width: 100%; }
-    .repo-issue-plan { --pill-c: var(--purple); border: 1px solid color-mix(in srgb, var(--pill-c) 40%, transparent); background: color-mix(in srgb, var(--pill-c) 12%, transparent); color: var(--pill-c); font-size: 0.7rem; font-weight: 600; line-height: 1; padding: 3px 6px; border-radius: 999px; cursor: pointer; white-space: nowrap; opacity: 0; transition: opacity 0.15s, background 0.15s; }
+    .repo-issue-plan { --pill-c: var(--purple); border: 1px solid color-mix(in srgb, var(--pill-c) 40%, transparent); background: color-mix(in srgb, var(--pill-c) 12%, transparent); color: var(--pill-c); font-size: 0.7rem; font-weight: 600; line-height: 1; padding: 3px 6px; border-radius: 999px; cursor: pointer; white-space: nowrap; opacity: 0.75; transition: opacity 0.15s, background 0.15s; }
     .repo-issue-pill-wrap:hover .repo-issue-plan { opacity: 1; }
     .repo-issue-plan:hover { background: color-mix(in srgb, var(--pill-c) 26%, transparent); }
     .repo-issue-plan:disabled { opacity: 0.5; cursor: default; }


### PR DESCRIPTION
**Fixes a discoverability regression in Phase 4** (reported on v3: the Plan action is hidden).

Phase 4 (#2049) added the `⧉ Plan` button to each issue pill but styled it `opacity: 0`, visible only when you hover that exact pill row. That undercuts the whole discoverability effort (tooltip, empty-state hint, first-run callout all assume the button is visible) — an operator looking at their issue list can't see the feature exists.

Change: default `opacity: 0` → `opacity: 0.75` (still visually secondary to the pill), retaining the brighten-to-`1.0`-on-row-hover. The button is now discoverable at a glance.

One-line CSS change in `v2/pkg/dashboard/static/index.html`. `go build ./pkg/dashboard/` passes.