### PR TITLE
🐛 dashboard: prevent Plan button from overflowing the repo card on long titles

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -784,8 +784,11 @@
     .repo-issue-pill .pill-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     /* ⧉ Plan action sits beside its issue pill. Always visible (so the feature is
        discoverable) but visually secondary; brightens to full on row hover. */
-    .repo-issue-pill-wrap { display: inline-flex; align-items: center; gap: 4px; max-width: 100%; }
-    .repo-issue-plan { --pill-c: var(--purple); border: 1px solid color-mix(in srgb, var(--pill-c) 40%, transparent); background: color-mix(in srgb, var(--pill-c) 12%, transparent); color: var(--pill-c); font-size: 0.7rem; font-weight: 600; line-height: 1; padding: 3px 6px; border-radius: 999px; cursor: pointer; white-space: nowrap; opacity: 0.75; transition: opacity 0.15s, background 0.15s; }
+    .repo-issue-pill-wrap { display: inline-flex; align-items: center; gap: 4px; max-width: 100%; min-width: 0; }
+    /* The pill shrinks (its title ellipsis-truncates) so a long title + the
+       always-visible Plan button never overflow the fixed-width repo card. */
+    .repo-issue-pill-wrap .repo-issue-pill { min-width: 0; flex: 0 1 auto; overflow: hidden; }
+    .repo-issue-plan { --pill-c: var(--purple); flex: 0 0 auto; border: 1px solid color-mix(in srgb, var(--pill-c) 40%, transparent); background: color-mix(in srgb, var(--pill-c) 12%, transparent); color: var(--pill-c); font-size: 0.7rem; font-weight: 600; line-height: 1; padding: 3px 6px; border-radius: 999px; cursor: pointer; white-space: nowrap; opacity: 0.75; transition: opacity 0.15s, background 0.15s; }
     .repo-issue-pill-wrap:hover .repo-issue-plan { opacity: 1; }
     .repo-issue-plan:hover { background: color-mix(in srgb, var(--pill-c) 26%, transparent); }
     .repo-issue-plan:disabled { opacity: 0.5; cursor: default; }


### PR DESCRIPTION
Follow-up to #2054 (Plan button made always-visible). Now that the button is no longer collapsed, a long issue title + the button could push the pill wider than the fixed-width repo card — the pill lacked `min-width:0`, so its title never ellipsis-truncated inside the flex wrap.

Fix: pill gets `min-width:0; flex:0 1 auto; overflow:hidden` (shrinks, title truncates); button gets `flex:0 0 auto` (fixed size, never squished).

**Answer to 'does this widen the column?'** — No. `.repo-issues` is `flex-wrap: wrap` inside the fixed-width `.repo-card`; pills just wrap to more lines. This PR ensures they *wrap* cleanly instead of *overflowing* on long titles.

CSS-only; `go build ./pkg/dashboard/` passes.