### PR TITLE
🐛 fix(hub,spoke): PVC session persistence + stop heartbeat reverting dashboard ACMM level

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -563,9 +563,14 @@ func main() {
 
 	dashSrv := dashboard.NewServerWithAuth(cfg.Dashboard.Port, cfg.Dashboard.AuthToken, logger)
 
-	// Persist per-user dashboard sessions next to the config (the PVC in
-	// hosted mode) so direct-route users aren't logged out by pod restarts.
-	dashSrv.EnableSessionPersistence(filepath.Join(filepath.Dir(*configPath), "dashboard-sessions.json"))
+	// Persist per-user dashboard sessions on the PVC (/data) so direct-route
+	// users aren't logged out by pod restarts. NOTE: use /data explicitly, NOT
+	// filepath.Dir(configPath) — the config lives at /etc/hive/hive.yaml, which
+	// is an ephemeral emptyDir (the ConfigMap seed mount), so a sessions file
+	// there is wiped on every pod roll. That was the "re-login on every visit"
+	// bug on direct-route spokes. /data is the CephFS PVC (same place cost/fact
+	// history persist).
+	dashSrv.EnableSessionPersistence("/data/dashboard-sessions.json")
 
 	// Seed token sparkline history now that the dashboard server exists
 	if len(pendingTokenSeed) > 0 {

--- a/v2/pkg/hub/misc_coverage_test.go
+++ b/v2/pkg/hub/misc_coverage_test.go
@@ -216,3 +216,30 @@ func TestHandleClusterHealth(t *testing.T) {
 	clusterHealthCacheTime = time.Time{}
 	clusterHealthCacheMu.Unlock()
 }
+
+// TestAdoptSpokeACMMLevel verifies the hub adopts a dashboard-set ACMM level
+// reported by a claimed spoke (the Joe Runde / spyre revert bug), and leaves
+// unclaimed placeholders and no-op cases alone.
+func TestAdoptSpokeACMMLevel(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	s := &HubServer{logger: slog.Default()}
+
+	// Claimed hive at level 2; spoke reports 3 (operator bumped it) -> adopt.
+	saveSaaSHive(&SaaSHive{ID: "claimed", Status: "running", Org: "o", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 2})
+	s.adoptSpokeACMMLevel("claimed", 3)
+	if h := loadSaaSHive("claimed"); h == nil || h.ACMMLevel != 3 {
+		t.Errorf("claimed hive: meta ACMM = %v, want 3 (adopted)", h)
+	}
+
+	// Unclaimed placeholder: assign owns the level -> NOT adopted.
+	saveSaaSHive(&SaaSHive{ID: "ph", Status: statusAvailable, ACMMLevel: 2})
+	s.adoptSpokeACMMLevel("ph", 5)
+	if h := loadSaaSHive("ph"); h == nil || h.ACMMLevel != 2 {
+		t.Errorf("placeholder: meta ACMM = %v, want 2 (unchanged)", h)
+	}
+
+	// No record -> no panic, no-op.
+	s.adoptSpokeACMMLevel("missing", 4)
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4180,6 +4180,43 @@ func (s *HubServer) handleAvailablePlaceholders(w http.ResponseWriter, r *http.R
 // record, is still an unclaimed placeholder (statusAvailable), or the spoke
 // already reports the recorded project. The spoke's currently-reported values
 // (curOrg/curRepos/curPrimary/curACMM) let the hub stop sending once matched.
+// adoptSpokeACMMLevel updates the hub's stored ACMM level for a CLAIMED hive to
+// match the level the spoke just reported, when they differ. It is called only
+// once the project is already reconciled (projectConfigForHiveID == nil), so a
+// difference here means the operator changed the level on the dashboard — the
+// dashboard is the source of truth for a running hive. Without this the hub
+// would re-push its stale meta level every beat and silently revert the change.
+//
+// No-op for unclaimed placeholders (assign owns their level) and when unchanged.
+func (s *HubServer) adoptSpokeACMMLevel(hiveID string, spokeLevel int) {
+	h := loadSaaSHive(hiveID)
+	if h == nil || h.Status == statusAvailable {
+		return // no record, or an unclaimed placeholder — assign controls it
+	}
+	if h.ACMMLevel == spokeLevel {
+		return // already in sync
+	}
+	prev := h.ACMMLevel
+	h.ACMMLevel = spokeLevel
+	if err := saveSaaSHive(h); err != nil {
+		s.logger.Warn("failed to persist spoke-reported ACMM level to meta",
+			"hive_id", hiveID, "level", spokeLevel, "error", err)
+		return
+	}
+	// Keep the in-memory registry consistent so the UI and the next
+	// projectConfigForHiveID comparison see the adopted level immediately.
+	s.mu.Lock()
+	for i := range s.registry.Hives {
+		if s.registry.Hives[i].ID == hiveID {
+			s.registry.Hives[i].ACMMLevel = spokeLevel
+			break
+		}
+	}
+	s.mu.Unlock()
+	s.logger.Info("adopted dashboard-set ACMM level from spoke heartbeat",
+		"hive_id", hiveID, "was", prev, "now", spokeLevel)
+}
+
 func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary string, curACMM int, curURL string) *HeartbeatProjectConfig {
 	h := loadSaaSHive(hiveID)
 	if h == nil {

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -654,6 +654,15 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			"primary_repo", projCfg.PrimaryRepo,
 			"acmm_level", projCfg.ACMMLevel,
 		)
+	} else {
+		// Already reconciled (projCfg == nil): the spoke's project matches meta,
+		// so the hub is no longer pushing. In THIS state a difference in the
+		// spoke-reported ACMM level means the operator changed it on the
+		// dashboard — adopt it into meta instead of fighting it next beat.
+		// Without this, a dashboard level bump is silently reverted: the spoke
+		// reports the new level, the hub sees level != meta and re-pushes the
+		// old meta level, and the spoke drops back (the Joe Runde / spyre bug).
+		s.adoptSpokeACMMLevel(payload.HiveID, clampInt(payload.ACMMLevel, 0, 6))
 	}
 
 	// Deliver a funded OpenRouter gateway to a firewalled/heartbeat-only spoke.


### PR DESCRIPTION
## Summary

Two bugs reported by a direct-route (vllm-d) spoke owner after today's upgrades (torch-spyre / Joe Runde). Both are regressions/misconfigurations of existing mechanisms, root-caused on the live spoke.

### 1. Re-login on every page visit
`EnableSessionPersistence` wrote the sessions file to `filepath.Dir(configPath)` = **`/etc/hive`** — but that's the **ephemeral emptyDir** (the ConfigMap seed mount), not the PVC. Confirmed on the live pod: `/etc/hive/dashboard-sessions.json` exists but `/etc/hive` is `xfs` on `/dev/vda4` while `/data` is the CephFS PVC. So sessions were wiped on every pod roll, and today's many upgrades re-prompted device-flow login each time. **Fix:** persist to `/data/dashboard-sessions.json` (same place cost/fact history persist).

### 2. Dashboard ACMM level reverts to the old value
The claimed-project heartbeat only pushes DOWN (hub meta → spoke); nothing carries the spoke's dashboard-set level back up. Confirmed in hub logs: spoke reports `acmm_level:3`, hub responds "delivering … acmm_level:2", spoke drops to 2. **Fix:** once the project is already reconciled (`projectConfigForHiveID == nil` — the hub isn't mid-assign), a differing spoke-reported ACMM level is **adopted into meta** (`adoptSpokeACMMLevel`). The dashboard is the source of truth for a running hive; unclaimed placeholders are untouched (assign still owns their level).

## Test plan
- Go: `TestAdoptSpokeACMMLevel` (claimed hive adopts spoke level; placeholder untouched; missing = no-op). Full `pkg/hub` suite passes; build + gofmt + vet clean.
- Live-verifiable: set ACMM on the spyre dashboard → it stays (no revert on next heartbeat); pod roll → no re-login prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)