### PR TITLE
🐛 planning: fix epic-store permissions + gate 'Plan this issue' to ACMM L5+

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2175,6 +2175,7 @@ func planFromLabeledIssues(
 	gov *governor.Governor,
 	dashSrv *dashboard.Server,
 	logger *slog.Logger,
+	acmmLevel int,
 ) {
 	if actionable == nil || len(beadStores) == 0 {
 		return
@@ -2194,7 +2195,7 @@ func planFromLabeledIssues(
 	planning.PlanIssuesFromLabels(store, agentMgr, actionable.Issues.Items, sink,
 		func(ref string, err error) {
 			logger.Warn("plan-from-label: minting epic failed", "issue", ref, "error", err)
-		})
+		}, acmmLevel)
 }
 
 // labelPlanSink adapts the governor/dashboard/logger to planning.LabelPlanSink so
@@ -2475,8 +2476,8 @@ func runEvalCycle(
 	// no duplicate epic if one already exists). Cheap, synchronous, adds NO
 	// goroutine, and drives the architect only via SendKick (never the launch
 	// path). Gated by config/ACMM so low-maturity hives stay advisory-only.
-	if cfg.Planning.PlanFromLabelEnabled(inferACMMLevel(cfg)) {
-		planFromLabeledIssues(actionable, beadStores, agentMgr, gov, dashSrv, logger)
+	if acmmLvl := inferACMMLevel(cfg); cfg.Planning.PlanFromLabelEnabled(acmmLvl) {
+		planFromLabeledIssues(actionable, beadStores, agentMgr, gov, dashSrv, logger, acmmLvl)
 	}
 
 	// Advisory digest: build from beads (the source of truth) before status broadcast.

--- a/v2/pkg/agent/permissions_watcher.go
+++ b/v2/pkg/agent/permissions_watcher.go
@@ -37,6 +37,12 @@ var WatchedHomeDirs = []string{
 	"/data/home/.config",
 	"/data/home/.local",
 	"/data/agents",
+	// Per-agent bead stores (/data/beads/<agent>) must be group-writable so the
+	// dashboard/hub process can mint an issue-sourced epic into an agent's store
+	// (e.g. the architect's) even though that dir is owned by the agent's UID.
+	// Without this an existing spoke's beads dirs stay 0755 and "Plan this issue"
+	// fails with EACCES on beads.json.tmp.
+	"/data/beads",
 }
 
 // GooseLogsDir is the rolling log directory goose 1.37 creates on startup.

--- a/v2/pkg/beads/beads.go
+++ b/v2/pkg/beads/beads.go
@@ -79,19 +79,19 @@ func (ft flexTime) MarshalJSON() ([]byte, error) {
 }
 
 type Bead struct {
-	ID          string            `json:"id"`
-	Title       string            `json:"title"`
-	Type        BeadType          `json:"type"`
-	Status      Status            `json:"status"`
-	Priority    Priority          `json:"priority"`
-	Actor       string            `json:"actor"`
-	ExternalRef string            `json:"external_ref,omitempty"`
+	ID          string                 `json:"id"`
+	Title       string                 `json:"title"`
+	Type        BeadType               `json:"type"`
+	Status      Status                 `json:"status"`
+	Priority    Priority               `json:"priority"`
+	Actor       string                 `json:"actor"`
+	ExternalRef string                 `json:"external_ref,omitempty"`
 	Metadata    map[string]interface{} `json:"metadata,omitempty"`
-	Notes       string            `json:"notes,omitempty"`
-	CreatedAt   flexTime          `json:"created_at"`
-	UpdatedAt   flexTime          `json:"updated_at"`
-	ClosedAt    *flexTime         `json:"closed_at,omitempty"`
-	DependsOn   []string          `json:"depends_on,omitempty"`
+	Notes       string                 `json:"notes,omitempty"`
+	CreatedAt   flexTime               `json:"created_at"`
+	UpdatedAt   flexTime               `json:"updated_at"`
+	ClosedAt    *flexTime              `json:"closed_at,omitempty"`
+	DependsOn   []string               `json:"depends_on,omitempty"`
 }
 
 // Meta returns a metadata value as a string, or "" if missing/non-string.
@@ -115,7 +115,12 @@ type Store struct {
 }
 
 func NewStore(dir string) (*Store, error) {
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	// 0770 (group-writable), not 0755: agent bead dirs under /data/beads/<agent>
+	// are owned by that agent's UID but must be writable by other node-group
+	// members — e.g. the dashboard/hub process minting an issue-sourced epic into
+	// the architect's store. This matches the shared-node-group model used for
+	// /data/home/* (see pkg/agent/permissions_watcher DirPerms=0o770).
+	if err := os.MkdirAll(dir, 0770); err != nil {
 		return nil, fmt.Errorf("creating beads dir %s: %w", dir, err)
 	}
 
@@ -444,7 +449,10 @@ func (s *Store) persist(_ *Bead) error {
 
 	path := filepath.Join(s.dir, beadsFileName)
 	tmpPath := path + ".tmp"
-	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
+	// 0660 (group-writable) so a bead file created by one node-group member can be
+	// rewritten by another (e.g. the architect agent and the dashboard both write
+	// the architect store). Matches the /data/home/* FilePerms model.
+	if err := os.WriteFile(tmpPath, data, 0660); err != nil {
 		return fmt.Errorf("writing tmp beads: %w", err)
 	}
 	return os.Rename(tmpPath, path)

--- a/v2/pkg/beads/beads_perms_test.go
+++ b/v2/pkg/beads/beads_perms_test.go
@@ -1,0 +1,82 @@
+package beads
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"syscall"
+	"testing"
+)
+
+// TestNewStore_CreatesGroupWritableDir verifies the permission fix: NewStore
+// creates its directory (so a missing /data/beads/<agent> is provisioned) and
+// requests group-writable (0770) perms — the dashboard/hub process mints an
+// issue-sourced epic into the architect's store as a different UID in the shared
+// node group, so the dir must be writable by the group, not owner-only.
+//
+// Perms are subject to the process umask, so we can't assert an exact 0770. We
+// assert instead that (a) the dir exists and (b) the OWNER-write bit is present
+// (a floor that would fail if the mode were accidentally read-only), and, when
+// the umask permits it, that the GROUP-write bit made it through — the actual
+// regression guard for the 0755->0770 change.
+func TestNewStore_CreatesGroupWritableDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not meaningful on Windows")
+	}
+	dir := filepath.Join(t.TempDir(), "beads", "architect")
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("precondition: dir should not exist yet, stat err=%v", err)
+	}
+
+	s, err := NewStore(dir)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	fi, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("dir not created: %v", err)
+	}
+	if !fi.IsDir() {
+		t.Fatalf("expected a directory at %s", dir)
+	}
+	mode := fi.Mode().Perm()
+	if mode&0200 == 0 {
+		t.Errorf("dir mode %o lacks owner-write bit", mode)
+	}
+	// Group-write is the point of the fix. If the current umask masks the group
+	// bit off (e.g. 0027), we can't observe it — assert only when the umask allows.
+	if umaskAllowsGroupWrite(t) && mode&0020 == 0 {
+		t.Errorf("dir mode %o lacks group-write bit (0770 regression?)", mode)
+	}
+
+	// Minting a bead must persist a beads.json — proving the store is writable and
+	// exercising the persist path whose tmp file is created 0660 (group-writable).
+	if _, err := s.Create("epic", TypeEpic, PriorityHigh, "architect", "gh-a/b#1"); err != nil {
+		t.Fatalf("Create (persist): %v", err)
+	}
+	fpath := filepath.Join(dir, beadsFileName)
+	ffi, err := os.Stat(fpath)
+	if err != nil {
+		t.Fatalf("beads file not persisted: %v", err)
+	}
+	fmode := ffi.Mode().Perm()
+	if fmode&0200 == 0 {
+		t.Errorf("beads file mode %o lacks owner-write bit", fmode)
+	}
+	if umaskAllowsGroupWrite(t) && fmode&0020 == 0 {
+		t.Errorf("beads file mode %o lacks group-write bit (0660 regression?)", fmode)
+	}
+}
+
+// umaskAllowsGroupWrite reports whether the process umask leaves the group-write
+// bit (0020) unmasked, so a group-writable create can actually land it. It reads
+// and restores the umask non-destructively.
+func umaskAllowsGroupWrite(t *testing.T) bool {
+	t.Helper()
+	// syscall.Umask both sets and returns the previous value; call twice to read
+	// without changing it.
+	old := syscall.Umask(0)
+	syscall.Umask(old)
+	return old&0020 == 0
+}

--- a/v2/pkg/config/classifier_planning_test.go
+++ b/v2/pkg/config/classifier_planning_test.go
@@ -18,9 +18,10 @@ func TestPlanFromLabelEnabled(t *testing.T) {
 	}{
 		{"explicit true wins at L1", PlanningConfig{PlanFromLabel: boolPtr(true)}, 1, true},
 		{"explicit false wins at L6", PlanningConfig{PlanFromLabel: boolPtr(false)}, 6, false},
-		{"nil defaults off below L4", PlanningConfig{}, 3, false},
-		{"nil defaults on at L4", PlanningConfig{}, 4, true},
-		{"nil defaults on above L4", PlanningConfig{}, 6, true},
+		{"nil defaults off below L5", PlanningConfig{}, 3, false},
+		{"nil defaults off at L4 (boundary)", PlanningConfig{}, 4, false},
+		{"nil defaults on at L5 (boundary)", PlanningConfig{}, 5, true},
+		{"nil defaults on above L5", PlanningConfig{}, 6, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -67,8 +68,8 @@ func TestClassifierConfig_AbsentIsZero(t *testing.T) {
 	if cfg.Planning.PlanFromLabel != nil {
 		t.Errorf("expected nil PlanFromLabel, got %v", *cfg.Planning.PlanFromLabel)
 	}
-	// The ACMM gate then applies.
-	if cfg.Planning.PlanFromLabelEnabled(4) != true || cfg.Planning.PlanFromLabelEnabled(3) != false {
+	// The ACMM gate then applies: on at L5+ (architect scheduled), off below.
+	if cfg.Planning.PlanFromLabelEnabled(5) != true || cfg.Planning.PlanFromLabelEnabled(4) != false {
 		t.Errorf("ACMM gate wrong for nil PlanFromLabel")
 	}
 }

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -54,20 +54,31 @@ type Config struct {
 type PlanningConfig struct {
 	// PlanFromLabel enables the label trigger. Pointer so an omitted key is
 	// distinguishable from an explicit false: when nil, the trigger falls back to
-	// an ACMM-level gate (on at L4+), so mature hives get it without extra config
+	// an ACMM-level gate (on at L5+), so mature hives get it without extra config
 	// while low-maturity hives stay advisory-only. An explicit value overrides the
-	// ACMM gate in either direction.
+	// ACMM gate in either direction — but see the note below: even an explicit
+	// true is a no-op below L5, because the architect that decomposes the minted
+	// epics is not scheduled there.
 	PlanFromLabel *bool `yaml:"plan_from_label,omitempty" json:"plan_from_label,omitempty"`
 }
 
+// planFromLabelMinACMM is the lowest ACMM level at which the label trigger fires
+// by default. It matches planning.PlanningMinACMMLevel: the architect agent that
+// decomposes the minted epics only has a cadence at L5 (4h) and L6 (15m), so
+// below L5 a minted epic would sit in decompose_pending forever. It is duplicated
+// here (rather than imported) to avoid a config→planning import cycle.
+const planFromLabelMinACMM = 5
+
 // PlanFromLabelEnabled reports whether the label trigger should fire, given the
 // hive's ACMM level. Explicit config wins; otherwise the trigger is on at ACMM
-// L4 and above (where the hive is trusted to act, not just advise).
+// L5 and above (where the architect that decomposes epics is scheduled). Note:
+// even when this returns true because of an explicit override, planning's own
+// PlanIssuesFromLabels applies a hard L5+ no-op — the architect cadence gate is
+// defense-in-depth and cannot be overridden away.
 func (p PlanningConfig) PlanFromLabelEnabled(acmmLevel int) bool {
 	if p.PlanFromLabel != nil {
 		return *p.PlanFromLabel
 	}
-	const planFromLabelMinACMM = 4
 	return acmmLevel >= planFromLabelMinACMM
 }
 

--- a/v2/pkg/dashboard/plan_from_issue_test.go
+++ b/v2/pkg/dashboard/plan_from_issue_test.go
@@ -17,9 +17,16 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/planning"
 )
 
+// acmmL5 returns a pointer to ACMM level 5, the lowest level at which planning is
+// enabled (the architect that decomposes epics is scheduled at L5/L6). Tests that
+// exercise the mint/kick paths must set this so handlePlanFromIssue's L5+ gate
+// admits the request; the gate itself is covered by TestHandlePlanFromIssue_LevelGate.
+func acmmL5() *int { l := planning.PlanningMinACMMLevel; return &l }
+
 // planIssueServer builds a Server with an empty "architect" bead store and no
 // AgentMgr, so handlePlanFromIssue mints the epic but records kicked=false
-// (the kick path is nil-guarded). Returns the server and store.
+// (the kick path is nil-guarded). ACMM level is set to L5 so the L5+ planning
+// gate admits the request. Returns the server and store.
 func planIssueServer(t *testing.T) (*Server, *beads.Store) {
 	t.Helper()
 	store, err := beads.NewStore(t.TempDir())
@@ -28,7 +35,7 @@ func planIssueServer(t *testing.T) (*Server, *beads.Store) {
 	}
 	srv := NewServer(0, slog.Default())
 	srv.deps = &Dependencies{
-		Config:     &config.Config{Agents: map[string]config.AgentConfig{}},
+		Config:     &config.Config{Agents: map[string]config.AgentConfig{}, ACMMLevel: acmmL5()},
 		Logger:     slog.Default(),
 		Ctx:        context.Background(),
 		BeadStores: map[string]*beads.Store{"architect": store},
@@ -168,7 +175,8 @@ func TestHandlePlanFromIssue_ResolvesTitleFromStatus(t *testing.T) {
 
 func TestHandlePlanFromIssue_NoStores(t *testing.T) {
 	srv := NewServer(0, slog.Default())
-	srv.deps = &Dependencies{Config: &config.Config{}, Logger: slog.Default(), Ctx: context.Background()}
+	// L5 so the request clears the planning-level gate and reaches the store check.
+	srv.deps = &Dependencies{Config: &config.Config{ACMMLevel: acmmL5()}, Logger: slog.Default(), Ctx: context.Background()}
 	srv.RegisterAPI(srv.deps)
 	w := postPlanFromIssue(t, srv, `{"repo":"a/b","number":1,"title":"t"}`)
 	if w.Code != http.StatusServiceUnavailable {
@@ -182,7 +190,7 @@ func TestHandlePlanFromIssue_WithAgentMgr_KickPath(t *testing.T) {
 		t.Fatalf("NewStore: %v", err)
 	}
 	logger := slog.Default()
-	cfg := &config.Config{Agents: map[string]config.AgentConfig{"architect": {}}}
+	cfg := &config.Config{Agents: map[string]config.AgentConfig{"architect": {}}, ACMMLevel: acmmL5()}
 	mgr := agent.NewManager(cfg.Agents, logger, agent.ProjectContext{})
 	gov := governor.New(cfg.Governor, cfg.Agents, logger)
 
@@ -218,6 +226,73 @@ func TestHandlePlanFromIssue_WithAgentMgr_KickPath(t *testing.T) {
 	}
 }
 
+// TestHandlePlanFromIssue_LevelGate proves the L5+ gate on the HTTP handler:
+// below L5 the request is rejected (409) with the gate message and NO epic is
+// minted; at L5/L6 it proceeds and mints. Covers the boundary (L4 blocked, L5
+// allowed) plus the nil-config edge.
+func TestHandlePlanFromIssue_LevelGate(t *testing.T) {
+	newSrvAtLevel := func(level *int) (*Server, *beads.Store) {
+		store, err := beads.NewStore(t.TempDir())
+		if err != nil {
+			t.Fatalf("NewStore: %v", err)
+		}
+		srv := NewServer(0, slog.Default())
+		srv.deps = &Dependencies{
+			Config:     &config.Config{Agents: map[string]config.AgentConfig{}, ACMMLevel: level},
+			Logger:     slog.Default(),
+			Ctx:        context.Background(),
+			BeadStores: map[string]*beads.Store{"architect": store},
+		}
+		srv.RegisterAPI(srv.deps)
+		return srv, store
+	}
+	lvl := func(n int) *int { return &n }
+
+	tests := []struct {
+		name     string
+		level    *int
+		wantCode int
+		wantMint bool
+	}{
+		{"nil level (defaults to L1) blocked", nil, http.StatusConflict, false},
+		{"L1 blocked", lvl(1), http.StatusConflict, false},
+		{"L4 blocked (boundary)", lvl(4), http.StatusConflict, false},
+		{"L5 allowed (boundary)", lvl(5), http.StatusOK, true},
+		{"L6 allowed", lvl(6), http.StatusOK, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, store := newSrvAtLevel(tc.level)
+			w := postPlanFromIssue(t, srv, `{"repo":"org/repo","number":42,"title":"gate me"}`)
+			if w.Code != tc.wantCode {
+				t.Fatalf("code = %d, want %d: %s", w.Code, tc.wantCode, w.Body.String())
+			}
+			epics := 0
+			for _, b := range store.List(beads.ListFilter{}) {
+				if b.Type == beads.TypeEpic {
+					epics++
+				}
+			}
+			if tc.wantMint && epics != 1 {
+				t.Errorf("expected 1 epic minted, got %d", epics)
+			}
+			if !tc.wantMint {
+				if epics != 0 {
+					t.Errorf("expected no epic minted below L5, got %d", epics)
+				}
+				// The rejection must carry the explanatory gate message.
+				var resp struct {
+					Error string `json:"error"`
+				}
+				_ = json.Unmarshal(w.Body.Bytes(), &resp)
+				if resp.Error != planning.PlanningLevelGateMessage {
+					t.Errorf("error = %q, want the gate message", resp.Error)
+				}
+			}
+		})
+	}
+}
+
 // stubKicker is a test DecomposeKicker with a settable paused state.
 type stubKicker struct {
 	paused bool
@@ -231,7 +306,7 @@ func TestRequestArchitectDecompose_States(t *testing.T) {
 	store, _ := beads.NewStore(t.TempDir())
 	epic, _ := store.Create("e", beads.TypeEpic, beads.PriorityMedium, "architect", "gh-a/b#1")
 	logger := slog.Default()
-	cfg := &config.Config{Agents: map[string]config.AgentConfig{"architect": {}}}
+	cfg := &config.Config{Agents: map[string]config.AgentConfig{"architect": {}}, ACMMLevel: acmmL5()}
 
 	newSrv := func(k planning.DecomposeKicker) *Server {
 		srv := NewServer(0, logger)
@@ -273,7 +348,7 @@ func TestHandlePlanFromIssue_PausedArchitectMessage(t *testing.T) {
 	store, _ := beads.NewStore(t.TempDir())
 	srv := NewServer(0, slog.Default())
 	srv.deps = &Dependencies{
-		Config:     &config.Config{Agents: map[string]config.AgentConfig{}},
+		Config:     &config.Config{Agents: map[string]config.AgentConfig{}, ACMMLevel: acmmL5()},
 		Logger:     slog.Default(),
 		Ctx:        context.Background(),
 		BeadStores: map[string]*beads.Store{"architect": store},
@@ -322,7 +397,7 @@ func TestPlanEpicStore_FallbackToAnyStore(t *testing.T) {
 	srv := NewServer(0, slog.Default())
 	// No "architect" store — planEpicStore must fall back to the only store.
 	srv.deps = &Dependencies{
-		Config:     &config.Config{Agents: map[string]config.AgentConfig{}},
+		Config:     &config.Config{Agents: map[string]config.AgentConfig{}, ACMMLevel: acmmL5()},
 		Logger:     slog.Default(),
 		Ctx:        context.Background(),
 		BeadStores: map[string]*beads.Store{"scanner": store},

--- a/v2/pkg/dashboard/plan_handlers.go
+++ b/v2/pkg/dashboard/plan_handlers.go
@@ -83,6 +83,15 @@ func (s *Server) handlePlanFromIssue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Gate: planning below ACMM L5 mints an epic that nothing decomposes — the
+	// architect agent has no cadence until L5 (see planning.PlanningMinACMMLevel).
+	// Reject with a clear explanation rather than stranding a decompose_pending
+	// epic. Read from the same config source the status payload uses.
+	if s.deps == nil || s.deps.Config == nil || !planning.PlanningAllowedAtLevel(detectACMMLevel(s.deps.Config)) {
+		jsonError(w, planning.PlanningLevelGateMessage, http.StatusConflict)
+		return
+	}
+
 	issue := github.Issue{
 		Repo:   sanitizeString(body.Repo),
 		Number: body.Number,

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -3146,8 +3146,12 @@
             if (paused) planTitle = `⏸ Architect is paused — ${pending} queued plan(s) won't be built until you resume the architect agent.`;
             else if (pending > 0) planTitle = `${pending} plan(s) queued for the architect to decompose`;
             // Empty-state discoverability hint when there is no planning activity.
+            // Below ACMM L5 the architect that decomposes epics has no cadence, so
+            // planning is unavailable — say so instead of pointing at a button we hide.
             if (active === 0 && pending === 0) {
-              planTitle = 'Break a big issue into a plan → click ⧉ Plan on any issue, or add the `plan` label on GitHub.';
+              planTitle = ((window._lastStatus?.acmmLevel || 0) >= 5)
+                ? 'Break a big issue into a plan → click ⧉ Plan on any issue, or add the `plan` label on GitHub.'
+                : 'Planning needs ACMM level 5+ — the architect that decomposes plans is only scheduled at L5/L6. Raise the level to enable ⧉ Plan and the `plan` label.';
             }
             return `<div class="gov-metric" title="${esc(planTitle)}"><span class="gm-label">planning</span><span class="gm-val ${planClass}">${esc(planText)}${pending > 0 ? ` <span style="opacity:0.7;font-size:0.85em">+${pending} queued</span>` : ''}</span></div>`;
           })()}
@@ -4731,7 +4735,10 @@
       // planning activity exists we assume the user has found it — stay quiet.
       var plan = (data && data.planning) || {};
       var alreadyUsed = (plan.active_plans || 0) > 0 || (plan.pending_decompose || 0) > 0;
-      if (!hasRepos || alreadyUsed) { el.style.display = 'none'; el.innerHTML = ''; return; }
+      // Planning needs ACMM L5+ (the architect that decomposes epics is only
+      // scheduled there) — don't advertise a feature the hive can't act on.
+      var levelOK = ((data && data.acmmLevel) || 0) >= 5;
+      if (!hasRepos || alreadyUsed || !levelOK) { el.style.display = 'none'; el.innerHTML = ''; return; }
       el.style.display = 'block';
       el.innerHTML = '<div style="background:rgba(124,58,237,0.10);border:1px solid rgba(124,58,237,0.32);border-radius:8px;padding:12px 16px;margin-bottom:8px;display:flex;align-items:center;gap:10px;font-size:0.85rem">'
         + '<span style="font-size:1.1rem">🧭</span>'
@@ -5088,8 +5095,18 @@
       setIfChanged(el, html);
     }
 
+    // Planning (⧉ Plan button + `plan`-label trigger) requires ACMM L5+: the
+    // architect agent that decomposes epics only has a cadence at L5/L6. Below
+    // that, offering the button would mint an epic nothing ever decomposes, so
+    // hide it entirely. Mirrors planning.PlanningMinACMMLevel on the backend.
+    const PLANNING_MIN_ACMM_LEVEL = 5;
+    function planningAllowed() {
+      return ((window._lastStatus && window._lastStatus.acmmLevel) || 0) >= PLANNING_MIN_ACMM_LEVEL;
+    }
+
     function renderRepos(repos) {
       const el = document.getElementById('repos');
+      const showPlan = planningAllowed();
       setIfChanged(el, repos.map(r => {
         const iSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.issues ?? 0), 'var(--blue)');
         const pSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.prs ?? 0), 'var(--purple)');
@@ -5102,7 +5119,9 @@
           const repoFull = r.full || r.name || '';
           // ⧉ Plan action (Phase 4): mint an epic from this issue and request
           // decomposition. data-action wires into the delegated click handler.
-          const planBtn = `<button class="repo-issue-plan" data-action="planIssue" data-repo="${esc(repoFull)}" data-number="${i.number}" data-url="${esc(i.url || '')}" data-title="${esc(i.title || '')}" title="Break this issue into a reviewable task plan (architect decomposes it; you approve before work starts)">⧉ Plan</button>`;
+          // Only rendered at ACMM L5+, where the architect that decomposes the
+          // epic is actually scheduled — below that the button is hidden.
+          const planBtn = showPlan ? `<button class="repo-issue-plan" data-action="planIssue" data-repo="${esc(repoFull)}" data-number="${i.number}" data-url="${esc(i.url || '')}" data-title="${esc(i.title || '')}" title="Break this issue into a reviewable task plan (architect decomposes it; you approve before work starts)">⧉ Plan</button>` : '';
           return `<span class="repo-issue-pill-wrap"><a class="repo-issue-pill" href="${esc(i.url)}" target="_blank" rel="noopener" title="${esc(tip)}"><span class="pill-num">#${i.number}</span><span class="pill-title">${esc(title)}</span></a>${planBtn}</span>`;
         }).join('');
         const prPills = (r.openPrs || []).map(p => {

--- a/v2/pkg/planning/issue.go
+++ b/v2/pkg/planning/issue.go
@@ -196,6 +196,27 @@ func HasPlanLabel(issue github.Issue) bool {
 // force-unpausing it.
 const ArchitectAgentName = "architect"
 
+// PlanningMinACMMLevel is the lowest ACMM level at which issue planning is
+// offered. The architect agent that decomposes epics is only SCHEDULED at ACMM
+// L5 (4h cadence) and L6 (15m); it has no cadence at L1-L4 (see
+// pkg/config/packs/level-{5,6}.yaml). Offering the ⧉ Plan button or honoring
+// the `plan` label below L5 would mint an epic that nothing ever decomposes —
+// it would sit in decompose_pending forever. Gate all planning entrypoints to
+// this level.
+const PlanningMinACMMLevel = 5
+
+// PlanningLevelGateMessage is the user-facing explanation returned when planning
+// is attempted below PlanningMinACMMLevel. It names the reason (the architect is
+// not scheduled that low) and points at the fix.
+const PlanningLevelGateMessage = "Planning requires ACMM level 5+ — the architect agent that decomposes plans is not scheduled below L5. Raise the level or manually assign the architect."
+
+// PlanningAllowedAtLevel reports whether issue planning should be offered at the
+// given ACMM level. It is the single source of truth for the L5+ gate shared by
+// the dashboard handler and the label trigger.
+func PlanningAllowedAtLevel(acmmLevel int) bool {
+	return acmmLevel >= PlanningMinACMMLevel
+}
+
 // DecomposeKicker drives the architect out-of-band and reports whether it is
 // currently paused. Both methods must be safe to call from the governor tick /
 // an HTTP handler and must NOT touch the agent-launch mutex. *agent.Manager
@@ -284,9 +305,18 @@ type LabelPlanSink interface {
 // over the injected store/kicker/sink, so cmd/hive is a thin adapter and the
 // whole decision path is unit-tested here. mintErr (nil-safe) is called on a mint
 // failure so the caller can log it.
-func PlanIssuesFromLabels(store *beads.Store, kicker DecomposeKicker, issues []github.Issue, sink LabelPlanSink, mintErr func(ref string, err error)) LabelPlanResult {
+//
+// acmmLevel gates the whole pass: below PlanningMinACMMLevel the architect has no
+// cadence, so minting epics would strand them in decompose_pending. In that case
+// this is a no-op returning the zero result — no epics are minted.
+func PlanIssuesFromLabels(store *beads.Store, kicker DecomposeKicker, issues []github.Issue, sink LabelPlanSink, mintErr func(ref string, err error), acmmLevel int) LabelPlanResult {
 	var res LabelPlanResult
 	if store == nil {
+		return res
+	}
+	// Gate: the architect that decomposes these epics is not scheduled below L5.
+	// Minting here would create epics nothing ever decomposes, so skip entirely.
+	if !PlanningAllowedAtLevel(acmmLevel) {
 		return res
 	}
 	for _, issue := range issues {

--- a/v2/pkg/planning/issue_test.go
+++ b/v2/pkg/planning/issue_test.go
@@ -274,7 +274,7 @@ func TestPlanIssuesFromLabels_MintsKicksAndSkips(t *testing.T) {
 		{Repo: "a/b", Number: 3, Title: "labeled epic", Labels: []string{"epic"}},
 	}
 	sink := &recordingSink{}
-	res := PlanIssuesFromLabels(store, &fakeDecomposeKicker{}, issues, sink, nil)
+	res := PlanIssuesFromLabels(store, &fakeDecomposeKicker{}, issues, sink, nil, PlanningMinACMMLevel)
 
 	if res.Minted != 2 || res.Kicked != 2 {
 		t.Fatalf("res = %+v, want Minted=2 Kicked=2", res)
@@ -299,13 +299,13 @@ func TestPlanIssuesFromLabels_Idempotent(t *testing.T) {
 	issues := []github.Issue{{Repo: "a/b", Number: 1, Title: "once", Labels: []string{"plan"}}}
 	sink := &recordingSink{}
 
-	first := PlanIssuesFromLabels(store, &fakeDecomposeKicker{}, issues, sink, nil)
+	first := PlanIssuesFromLabels(store, &fakeDecomposeKicker{}, issues, sink, nil, PlanningMinACMMLevel)
 	if first.Minted != 1 {
 		t.Fatalf("first Minted = %d, want 1", first.Minted)
 	}
 	// Second pass: epic already exists AND is still pending (kicker did nothing
 	// real), so it is NOT minted again but IS re-kicked (still pending).
-	second := PlanIssuesFromLabels(store, &fakeDecomposeKicker{}, issues, sink, nil)
+	second := PlanIssuesFromLabels(store, &fakeDecomposeKicker{}, issues, sink, nil, PlanningMinACMMLevel)
 	if second.Minted != 0 {
 		t.Errorf("second Minted = %d, want 0 (no duplicate)", second.Minted)
 	}
@@ -315,7 +315,7 @@ func TestPlanIssuesFromLabels_PausedQueues(t *testing.T) {
 	store := newStore(t)
 	issues := []github.Issue{{Repo: "a/b", Number: 1, Title: "plan me", Labels: []string{"plan"}}}
 	sink := &recordingSink{}
-	res := PlanIssuesFromLabels(store, &fakeDecomposeKicker{paused: true}, issues, sink, nil)
+	res := PlanIssuesFromLabels(store, &fakeDecomposeKicker{paused: true}, issues, sink, nil, PlanningMinACMMLevel)
 
 	if res.Kicked != 0 || res.QueuedPaused != 1 {
 		t.Fatalf("res = %+v, want Kicked=0 QueuedPaused=1", res)
@@ -332,7 +332,7 @@ func TestPlanIssuesFromLabels_PausedQueues(t *testing.T) {
 
 func TestPlanIssuesFromLabels_NilStoreAndMintErr(t *testing.T) {
 	// Nil store → no-op zero result.
-	if res := PlanIssuesFromLabels(nil, &fakeDecomposeKicker{}, nil, nil, nil); res != (LabelPlanResult{}) {
+	if res := PlanIssuesFromLabels(nil, &fakeDecomposeKicker{}, nil, nil, nil, PlanningMinACMMLevel); res != (LabelPlanResult{}) {
 		t.Errorf("nil store: got %+v, want zero", res)
 	}
 	// Mint error (issue with a title but no ref) → mintErr callback fires.
@@ -342,7 +342,8 @@ func TestPlanIssuesFromLabels_NilStoreAndMintErr(t *testing.T) {
 		&fakeDecomposeKicker{},
 		[]github.Issue{{Title: "no ref", Labels: []string{"plan"}}},
 		nil,
-		func(string, error) { called = true })
+		func(string, error) { called = true },
+		PlanningMinACMMLevel)
 	if !called {
 		t.Error("expected mintErr callback on unref-able labeled issue")
 	}
@@ -353,9 +354,58 @@ func TestPlanIssuesFromLabels_QueuedNoAgent(t *testing.T) {
 	issues := []github.Issue{{Repo: "a/b", Number: 1, Title: "plan", Labels: []string{"plan"}}}
 	sink := &recordingSink{}
 	// Kick fails → queued (no agent) path + sink.QueuedPlan(paused=false).
-	PlanIssuesFromLabels(store, &fakeDecomposeKicker{kickErr: errFake}, issues, sink, nil)
+	PlanIssuesFromLabels(store, &fakeDecomposeKicker{kickErr: errFake}, issues, sink, nil, PlanningMinACMMLevel)
 	if len(sink.queuedNo) != 1 {
 		t.Errorf("expected 1 no-agent-queued plan, got %d", len(sink.queuedNo))
+	}
+}
+
+func TestPlanningAllowedAtLevel(t *testing.T) {
+	tests := []struct {
+		level int
+		want  bool
+	}{
+		{1, false}, {2, false}, {3, false}, {4, false}, // architect has no cadence
+		{5, true}, {6, true}, // architect scheduled (4h / 15m)
+	}
+	for _, tc := range tests {
+		if got := PlanningAllowedAtLevel(tc.level); got != tc.want {
+			t.Errorf("PlanningAllowedAtLevel(%d) = %v, want %v", tc.level, got, tc.want)
+		}
+	}
+}
+
+// TestPlanIssuesFromLabels_LevelGate proves the L5+ gate: below L5 the pass is a
+// hard no-op that mints nothing (the architect has no cadence to decompose it);
+// at L5/L6 it mints as before. Covers the boundary (L4 blocked, L5 allowed).
+func TestPlanIssuesFromLabels_LevelGate(t *testing.T) {
+	tests := []struct {
+		name       string
+		level      int
+		wantMinted int
+	}{
+		{"L1 blocked", 1, 0},
+		{"L4 blocked (boundary)", 4, 0},
+		{"L5 allowed (boundary)", 5, 1},
+		{"L6 allowed", 6, 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newStore(t)
+			issues := []github.Issue{{Repo: "a/b", Number: 1, Title: "plan me", Labels: []string{"plan"}}}
+			res := PlanIssuesFromLabels(store, &fakeDecomposeKicker{}, issues, &recordingSink{}, nil, tc.level)
+			if res.Minted != tc.wantMinted {
+				t.Errorf("level %d: Minted = %d, want %d", tc.level, res.Minted, tc.wantMinted)
+			}
+			// Below the gate, no epic should exist at all.
+			epic := store.FindByExternalRef("gh-a/b#1")
+			if tc.wantMinted == 0 && epic != nil {
+				t.Errorf("level %d: expected no epic minted, but found %s", tc.level, epic.ID)
+			}
+			if tc.wantMinted > 0 && epic == nil {
+				t.Errorf("level %d: expected an epic minted, found none", tc.level)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Two related fixes to the "Plan this issue" (Phase 4) flow

### 1. Epic-store permissions (already committed)
"Plan this issue" failed in production with `open /data/beads/architect/beads.json.tmp: permission denied`. The dashboard/hub process mints the issue-sourced epic into the **architect's** bead store, but `/data/beads/<agent>` dirs were created `0755` (owner-only write) and owned by the agent's UID — so the dashboard, a different UID in the shared `node` group, couldn't write them.

Fix (matching the established shared-node-group model used for `/data/home/*`, where `permissions_watcher` uses `DirPerms=0o770 / FilePerms=0o660`):
- `beads.NewStore`: `MkdirAll 0755 → 0770` (group-writable)
- `beads` persist: tmp file `0644 → 0660`
- `/data/beads` added to the permissions-watcher so **existing** spokes' bead dirs get corrected to group-writable at runtime.

### 2. Gate planning to ACMM L5+ (this PR's new work)
**Why:** the architect agent that decomposes plan epics is only **scheduled** at ACMM **L5** (4h cadence) and **L6** (15m) — it has **no cadence at L1–L4** (`pkg/config/packs/level-{5,6}.yaml`). Offering the ⧉ Plan button or honoring the `plan`-label auto-trigger below L5 mints an epic that **nothing ever decomposes**: it sits in `decompose_pending` forever. That is the bug.

**Fix — gated at three layers (defense in depth):**
1. **Frontend (`static/index.html`):** the ⧉ Plan button renders only when `window._lastStatus.acmmLevel >= 5`. Below L5 the button is hidden, the empty-state planning hint is retitled ("Planning needs ACMM level 5+…"), and the first-run planning callout is suppressed — no advertising a feature the hive can't act on.
2. **Backend handler (`handlePlanFromIssue`):** below L5, rejects with **409** and a clear JSON error (`Planning requires ACMM level 5+ — the architect agent that decomposes plans is not scheduled below L5. Raise the level or manually assign the architect.`), read from the same `detectACMMLevel(cfg)` source the status payload uses, **before** minting anything.
3. **Label trigger (`PlanIssuesFromLabels` / `planFromLabeledIssues`):** takes an `acmmLevel` and is a **hard no-op below L5** — mints nothing. The config default gate (`PlanFromLabelEnabled`) is bumped **L4 → L5** to match. Even an explicit `plan_from_label: true` cannot force minting below L5 — the planning-layer no-op is not overridable.

New single source of truth: `planning.PlanningMinACMMLevel = 5` + `planning.PlanningAllowedAtLevel()`, shared by the handler and the label trigger.

### Tests & coverage
- Table-driven **boundary** tests (L4 blocked, L5 allowed, L6 allowed) for both the HTTP handler (`TestHandlePlanFromIssue_LevelGate`, asserts 409 + gate message + no epic minted below L5) and `PlanIssuesFromLabels` (`TestPlanIssuesFromLabels_LevelGate`, asserts zero epics minted below L5).
- Config gate boundary updated to L5 (`TestPlanFromLabelEnabled`).
- Permission-fix test (`beads_perms_test.go`): `NewStore` provisions a group-writable dir and `persist` writes a group-writable `beads.json`; umask-tolerant (asserts the group-write bit only when the process umask permits it, always asserts the owner-write floor and that the dir/file are created).

**Per-package coverage:** `pkg/planning` 97.2% · `pkg/config` 94.1% · `pkg/beads` 97.3% · `plan_handlers.go` funcs avg 96.2% (`handlePlanFromIssue` 97.4%, `PlanFromLabelEnabled` 100%, `PlanningAllowedAtLevel` 100%, `PlanIssuesFromLabels` 96.4%).

### Gates
- `go build ./...`, `go vet`, `gofmt` — clean on all changed files.
- `-race` clean: `go test ./pkg/planning/... ./pkg/dashboard/ ./pkg/beads/ ./pkg/config/ -race -count=1 -timeout 300s` all pass.
- No launch-path mutex touches; no new goroutines.