### PR TITLE
✨ feat(dashboard): bee-to-hive loader for ACMM apply (replaces gear spinner)

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2418,24 +2418,9 @@
       <h2 class="config-title">🐝 Getting Started<span id="welcome-progress" class="welcome-progress"></span></h2>
       <button class="config-close" onclick="closeWelcomeDialog()">&times;</button>
     </div>
-    <div class="wb-stage" aria-hidden="true">
-      <svg class="wb-hive" viewBox="0 0 80 92" width="42" height="48">
-        <path d="M40 2 v8" stroke="#8a5a30" stroke-width="3" fill="none"/>
-        <g class="wb-coils">
-          <rect x="30" y="10" width="20" height="9"  rx="4.5"/>
-          <rect x="24" y="18" width="32" height="10" rx="5"/>
-          <rect x="18" y="27" width="44" height="11" rx="5.5"/>
-          <rect x="13" y="37" width="54" height="12" rx="6"/>
-          <rect x="11" y="48" width="58" height="12" rx="6"/>
-          <rect x="13" y="59" width="54" height="12" rx="6"/>
-          <rect x="18" y="70" width="44" height="11" rx="5.5"/>
-          <rect x="26" y="80" width="28" height="10" rx="5"/>
-        </g>
-        <ellipse cx="40" cy="64" rx="7.5" ry="9" fill="#2a1a06"/>
-        <ellipse cx="40" cy="62" rx="7.5" ry="7" fill="#120c04"/>
-      </svg>
-      <div class="wb-flyer"><div class="wb-facing"><div class="wb-trail"><i></i><i></i><i></i></div><div class="wb-bob"><span class="wb-bee">&#x1F41D;</span></div></div></div>
-    </div>
+    <!-- Bee-to-hive banner. Markup is injected from beeStageHtml() on dialog
+         open so this and the ACMM "Applying Level…" overlay stay in sync. -->
+    <div class="wb-stage" id="welcome-bee-stage" aria-hidden="true"></div>
     <div class="config-body welcome-body" id="welcome-body"></div>
     <div class="config-footer welcome-footer">
       <button class="hive-dialog-btn" onclick="closeWelcomeDialog()" title="Close for now — the checklist opens again on the next dashboard load">Remind me next time</button>
@@ -12025,6 +12010,30 @@ function burnAreaChart() {
       document.getElementById('acmm-overlay').classList.add('hidden');
     }
 
+    // Shared bee-to-hive animation markup (the .wb-* stage from the Getting
+    // Started banner). Returned as a string so the welcome dialog and the ACMM
+    // "Applying Level…" overlay render the identical animation and stay in sync.
+    // All CSS lives in the .wb-* rules in <head>; this only emits the DOM.
+    function beeStageHtml() {
+      return '' +
+        '<svg class="wb-hive" viewBox="0 0 80 92" width="42" height="48">' +
+          '<path d="M40 2 v8" stroke="#8a5a30" stroke-width="3" fill="none"/>' +
+          '<g class="wb-coils">' +
+            '<rect x="30" y="10" width="20" height="9"  rx="4.5"/>' +
+            '<rect x="24" y="18" width="32" height="10" rx="5"/>' +
+            '<rect x="18" y="27" width="44" height="11" rx="5.5"/>' +
+            '<rect x="13" y="37" width="54" height="12" rx="6"/>' +
+            '<rect x="11" y="48" width="58" height="12" rx="6"/>' +
+            '<rect x="13" y="59" width="54" height="12" rx="6"/>' +
+            '<rect x="18" y="70" width="44" height="11" rx="5.5"/>' +
+            '<rect x="26" y="80" width="28" height="10" rx="5"/>' +
+          '</g>' +
+          '<ellipse cx="40" cy="64" rx="7.5" ry="9" fill="#2a1a06"/>' +
+          '<ellipse cx="40" cy="62" rx="7.5" ry="7" fill="#120c04"/>' +
+        '</svg>' +
+        '<div class="wb-flyer"><div class="wb-facing"><div class="wb-trail"><i></i><i></i><i></i></div><div class="wb-bob"><span class="wb-bee">&#x1F41D;</span></div></div></div>';
+    }
+
     function showACMMLoading(message) {
       let el = document.getElementById('acmm-loading-overlay');
       if (!el) {
@@ -12033,11 +12042,12 @@ function burnAreaChart() {
         el.style.cssText = 'position:absolute;inset:0;z-index:100;background:rgba(0,0,0,0.7);display:flex;align-items:center;justify-content:center;border-radius:12px';
         const inner = document.createElement('div');
         inner.style.cssText = 'text-align:center;color:#fff';
-        inner.innerHTML = '<div style="font-size:2rem;margin-bottom:12px;animation:spin 1s linear infinite">&#9881;</div><div id="acmm-loading-text" style="font-size:0.9rem;font-weight:600"></div>';
+        // Bee-to-hive animation (shared with the Getting Started banner) above
+        // the level label. The .wb-stage sets width/height so the bee's flight
+        // bounds are defined; slightly narrower than the welcome banner to suit
+        // the compact overlay.
+        inner.innerHTML = '<div class="wb-stage" aria-hidden="true" style="width:220px;height:64px;margin:0 auto 12px">' + beeStageHtml() + '</div><div id="acmm-loading-text" style="font-size:0.9rem;font-weight:600"></div>';
         el.appendChild(inner);
-        const style = document.createElement('style');
-        style.textContent = '@keyframes spin{to{transform:rotate(360deg)}}';
-        el.appendChild(style);
         document.querySelector('#acmm-overlay .config-modal').style.position = 'relative';
         document.querySelector('#acmm-overlay .config-modal').appendChild(el);
       }
@@ -16214,6 +16224,11 @@ function burnAreaChart() {
     }
 
     function openWelcomeDialog() {
+      // Populate the bee-to-hive banner from the shared helper (idempotent — the
+      // ACMM overlay reuses the same markup). Only inject once to avoid
+      // restarting the CSS animations on every open.
+      const beeStage = document.getElementById('welcome-bee-stage');
+      if (beeStage && !beeStage.firstChild) beeStage.innerHTML = beeStageHtml();
       // Refresh the primary-repo signal: window._primaryRepo is set by the
       // /api/config fetch at boot, so a repo saved through the config dialog
       // would otherwise stay stale until a full page reload.


### PR DESCRIPTION
## What

Replaces the plain spinning-gear (⚙) indicator shown while an ACMM level is being applied ("Applying Level N…") with the bee-to-hive animation that already exists in the Getting Started (welcome) dialog banner.

## Why

The gear spinner was a generic placeholder. The dashboard already has a charming, on-brand bee-flies-to-the-skep-hive animation in the welcome banner. Reusing it makes the "Applying Level…" overlay consistent with the rest of the UI.

## How

- Extracted the welcome banner's `.wb-*` markup (the SVG skep hive + animated bee flyer) into a small reusable helper `beeStageHtml()` that returns the DOM as a string. All CSS keyframes already live in the shared `.wb-*` rules in `<head>` and are untouched.
- The ACMM `showACMMLoading()` overlay now renders `beeStageHtml()` inside a compact `.wb-stage` (220×64) above the unchanged "Applying Level N…" label, instead of the gear glyph + local `@keyframes spin`.
- The welcome dialog's banner is now populated from the same `beeStageHtml()` on open (injected once, idempotent) so both stay in sync from a single source.

No changes to `ApplyPack` / level-set logic or timing — purely the visual indicator.

## Verify

- The three changed JS functions (`beeStageHtml`, `showACMMLoading`, `openWelcomeDialog`) were extracted and validated with `new Function(...)`.
- The old gear glyph (`&#9881;`) and the local overlay-scoped `@keyframes spin` are gone; the global `spin` keyframe used by other spinners is untouched.
- HTML/JS only — no `.go` files touched.