### PR TITLE
fix(hub): stop reverting operator dashboard edits (ACMM, org/repos, thresholds)

### DIFF
--- a/v2/pkg/dashboard/acmm_roster_reconcile_test.go
+++ b/v2/pkg/dashboard/acmm_roster_reconcile_test.go
@@ -196,3 +196,51 @@ func TestApplyPackReconcilesStalePackFields(t *testing.T) {
 		t.Error("scanner still on stale advisory template after L5 apply")
 	}
 }
+
+// TestApplyPackPreservesOperatorThreshold guards the fix for the governor
+// threshold revert (Joe Runde / spyre): a pure re-apply of the SAME level (a
+// merge, not an expansion) must NOT overwrite an operator-set threshold — even
+// when that threshold is 0, which the old `mode.Threshold == 0` clause wrongly
+// treated as "unset".
+func TestApplyPackPreservesOperatorThreshold(t *testing.T) {
+	srv := newFullServer(t)
+
+	// First apply at L2 seeds the pack's thresholds + roster.
+	if _, err := srv.ApplyPack(2); err != nil {
+		t.Fatalf("ApplyPack(2): %v", err)
+	}
+
+	// Operator tunes QUIET to 0 (a legitimate low bound) via the dashboard.
+	const mode = "quiet"
+	m := srv.deps.Config.Governor.Modes[mode]
+	m.Threshold = 0
+	srv.deps.Config.Governor.Modes[mode] = m
+
+	// Re-apply the SAME level — a pure merge (no agents created). The operator's
+	// 0 must survive; the old code reset it to the pack default.
+	if _, err := srv.ApplyPack(2); err != nil {
+		t.Fatalf("ApplyPack(2) re-apply: %v", err)
+	}
+	if got := srv.deps.Config.Governor.Modes[mode].Threshold; got != 0 {
+		t.Errorf("operator threshold clobbered on merge: quiet = %d, want 0 (preserved)", got)
+	}
+
+	// A brand-new mode with no existing entry IS still seeded on merge.
+	pack, err := config.ACMMPackByLevel(2)
+	if err != nil {
+		t.Fatalf("ACMMPackByLevel(2): %v", err)
+	}
+	for modeName, want := range pack.Governor.Thresholds {
+		if modeName == mode {
+			continue // operator-overridden above
+		}
+		delete(srv.deps.Config.Governor.Modes, modeName)
+		if _, err := srv.ApplyPack(2); err != nil {
+			t.Fatalf("ApplyPack(2) after deleting %q: %v", modeName, err)
+		}
+		if got := srv.deps.Config.Governor.Modes[modeName].Threshold; got != want {
+			t.Errorf("absent mode %q not seeded on merge: got %d, want %d", modeName, got, want)
+		}
+		break
+	}
+}

--- a/v2/pkg/dashboard/api_packs.go
+++ b/v2/pkg/dashboard/api_packs.go
@@ -221,11 +221,18 @@ func (s *Server) ApplyPack(level int) (*ApplyPackResult, error) {
 			s.deps.Config.Governor.Modes[modeName] = mode
 		}
 		for modeName, threshold := range pack.Governor.Thresholds {
-			mode := s.deps.Config.Governor.Modes[modeName]
-			if isFirstApplyOrExpansion || mode.Threshold == 0 {
+			// On first apply / level expansion, seed the pack's threshold. On a
+			// pure merge, only fill a mode that has NO existing entry — never
+			// overwrite an operator-set value. The old `|| mode.Threshold == 0`
+			// clause broke this: threshold 0 is a legitimate operator setting
+			// (e.g. a low QUIET bound), not "unset", so re-applying a pack —
+			// including the apply triggered by an ACMM level bounce — reset the
+			// operator's tuning.
+			mode, present := s.deps.Config.Governor.Modes[modeName]
+			if isFirstApplyOrExpansion || !present {
 				mode.Threshold = threshold
+				s.deps.Config.Governor.Modes[modeName] = mode
 			}
-			s.deps.Config.Governor.Modes[modeName] = mode
 		}
 	}
 

--- a/v2/pkg/hub/hub_filesystem_test.go
+++ b/v2/pkg/hub/hub_filesystem_test.go
@@ -1133,20 +1133,18 @@ func TestHandleAssignHiveWithFilesystem(t *testing.T) {
 		t.Error("expected assign to set a vanity URL")
 	}
 
-	// projectConfigForHiveID keeps returning the real project until the spoke
-	// reports BOTH the project AND the vanity URL back, then goes quiet.
-	if pc := projectConfigForHiveID("hosted-assign-fs", "oldorg", []string{"old"}, "old", 2, ""); pc == nil {
-		t.Error("expected non-nil project config while spoke reports stale project")
-	}
-	// Project matches but the spoke hasn't adopted the vanity URL yet -> still sending.
+	// After a claim, org/repos/ACMM are operator-controlled and adopted (not
+	// pushed), so the ONLY thing projectConfigForHiveID still delivers is the
+	// vanity URL — until the spoke reports it back, then it goes quiet.
+	// URL not yet adopted -> still delivering (carries the vanity URL).
 	if pc := projectConfigForHiveID("hosted-assign-fs", "neworg", []string{"repoa", "repob"}, "repoa", 3, ""); pc == nil {
 		t.Error("expected non-nil config while spoke has not yet adopted the vanity URL")
 	} else if pc.DashboardURL != h.VanityURL {
 		t.Errorf("project config DashboardURL = %q, want the vanity URL %q", pc.DashboardURL, h.VanityURL)
 	}
-	// Spoke now reports the vanity URL too -> goes quiet.
+	// Spoke now reports the vanity URL -> nothing left to push -> nil.
 	if pc := projectConfigForHiveID("hosted-assign-fs", "neworg", []string{"repoa", "repob"}, "repoa", 3, h.VanityURL); pc != nil {
-		t.Errorf("expected nil project config once spoke matches project + vanity URL, got %+v", pc)
+		t.Errorf("expected nil project config once spoke reports the vanity URL, got %+v", pc)
 	}
 
 	// Assigning an already-claimed (non-available) hive is rejected.

--- a/v2/pkg/hub/misc_coverage_test.go
+++ b/v2/pkg/hub/misc_coverage_test.go
@@ -152,22 +152,29 @@ func TestProjectConfigForHiveID(t *testing.T) {
 		t.Errorf("incomplete claim -> %+v, want nil", got)
 	}
 
-	// Complete claim, spoke not yet matching -> returns config.
-	saveSaaSHive(&SaaSHive{ID: "full", Status: "running", Org: "acme", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 3})
-	got := projectConfigForHiveID("full", "", nil, "", 0, "")
-	if got == nil || got.Org != "acme" || got.ACMMLevel != 3 {
-		t.Errorf("complete claim -> %+v, want org=acme acmm=3", got)
+	// Freshly-claimed hive (ClaimDelivered=false), spoke still reporting a stale
+	// placeholder project -> hub PUSHES the real claim until the spoke reports it.
+	saveSaaSHive(&SaaSHive{ID: "fresh", Status: "running", Org: "acme", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 3})
+	if got := projectConfigForHiveID("fresh", "placeholder", nil, "old", 0, ""); got == nil || got.Org != "acme" {
+		t.Errorf("undelivered claim, stale spoke -> %+v, want claim pushed (org=acme)", got)
 	}
 
-	// Spoke already matches -> nil (stop sending).
+	// Delivered claim (ClaimDelivered=true): org/repos/ACMM are now operator-owned
+	// and adopted by the caller, not pushed here — so projectConfigForHiveID
+	// returns nil regardless of what the spoke reports (nothing to push).
+	saveSaaSHive(&SaaSHive{ID: "full", Status: "running", Org: "acme", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 3, ClaimDelivered: true})
 	if got := projectConfigForHiveID("full", "acme", []string{"r"}, "r", 3, ""); got != nil {
-		t.Errorf("matched spoke -> %+v, want nil", got)
+		t.Errorf("delivered claim -> %+v, want nil (org/repos/ACMM are adopted, not pushed)", got)
+	}
+	// Even a spoke reporting a different level -> still nil (no push; adopt path handles it).
+	if got := projectConfigForHiveID("full", "acme", []string{"r"}, "r", 2, ""); got != nil {
+		t.Errorf("differing ACMM -> %+v, want nil (adopted, not pushed)", got)
 	}
 
 	// Vanity URL set but spoke hasn't adopted it -> keep sending (with the URL),
-	// even though org/repos/acmm already match.
-	saveSaaSHive(&SaaSHive{ID: "van", Status: "running", Org: "acme", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 3, VanityURL: "https://vanity.example/"})
-	got = projectConfigForHiveID("van", "acme", []string{"r"}, "r", 3, "")
+	// even though the claim is delivered and org/repos/acmm already match.
+	saveSaaSHive(&SaaSHive{ID: "van", Status: "running", Org: "acme", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 3, ClaimDelivered: true, VanityURL: "https://vanity.example/"})
+	got := projectConfigForHiveID("van", "acme", []string{"r"}, "r", 3, "")
 	if got == nil || got.DashboardURL != "https://vanity.example/" {
 		t.Errorf("vanity not yet adopted -> %+v, want DashboardURL set", got)
 	}
@@ -217,29 +224,60 @@ func TestHandleClusterHealth(t *testing.T) {
 	clusterHealthCacheMu.Unlock()
 }
 
-// TestAdoptSpokeACMMLevel verifies the hub adopts a dashboard-set ACMM level
-// reported by a claimed spoke (the Joe Runde / spyre revert bug), and leaves
-// unclaimed placeholders and no-op cases alone.
-func TestAdoptSpokeACMMLevel(t *testing.T) {
+// TestAdoptSpokeProjectConfig verifies the hub's adopt path:
+//   - ACMM level is operator-owned from the start and always adopted (the Joe
+//     Runde / spyre revert bug);
+//   - org/repos/primary follow the ClaimDelivered handshake: before the spoke
+//     first reports the claimed project, hub-pushed values are authoritative and
+//     spoke reports do NOT adopt (a stale placeholder must not win); the first
+//     matching report flips ClaimDelivered, and only afterwards do dashboard
+//     edits to org/repos get adopted.
+//
+// It also leaves unclaimed placeholders and empty/no-op reports alone.
+func TestAdoptSpokeProjectConfig(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 
 	s := &HubServer{logger: slog.Default()}
 
-	// Claimed hive at level 2; spoke reports 3 (operator bumped it) -> adopt.
+	// Freshly-claimed hive (ClaimDelivered=false). ACMM is adopted immediately,
+	// but org/repos edits reported before delivery are IGNORED (could be a stale
+	// placeholder still reporting old values). A report that MATCHES the claim
+	// flips ClaimDelivered.
 	saveSaaSHive(&SaaSHive{ID: "claimed", Status: "running", Org: "o", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 2})
-	s.adoptSpokeACMMLevel("claimed", 3)
-	if h := loadSaaSHive("claimed"); h == nil || h.ACMMLevel != 3 {
-		t.Errorf("claimed hive: meta ACMM = %v, want 3 (adopted)", h)
+
+	// Pre-delivery: spoke reports a DIFFERENT org/repos (stale) but a new level.
+	// -> adopt the level (3) only; org/repos stay as the claim; not yet delivered.
+	s.adoptSpokeProjectConfig("claimed", "stale", []string{"old"}, "old", 3)
+	if h := loadSaaSHive("claimed"); h == nil || h.ACMMLevel != 3 || h.Org != "o" || len(h.Repos) != 1 || h.ClaimDelivered {
+		t.Errorf("pre-delivery stale report: meta = %+v, want acmm=3 org=o repos=[r] ClaimDelivered=false", h)
 	}
 
-	// Unclaimed placeholder: assign owns the level -> NOT adopted.
-	saveSaaSHive(&SaaSHive{ID: "ph", Status: statusAvailable, ACMMLevel: 2})
-	s.adoptSpokeACMMLevel("ph", 5)
-	if h := loadSaaSHive("ph"); h == nil || h.ACMMLevel != 2 {
-		t.Errorf("placeholder: meta ACMM = %v, want 2 (unchanged)", h)
+	// Spoke now reports the actual claimed project -> flips ClaimDelivered.
+	s.adoptSpokeProjectConfig("claimed", "o", []string{"r"}, "r", 3)
+	if h := loadSaaSHive("claimed"); h == nil || !h.ClaimDelivered {
+		t.Errorf("matching report should mark ClaimDelivered: %+v", h)
+	}
+
+	// Post-delivery: operator changes repos on the dashboard -> adopted.
+	s.adoptSpokeProjectConfig("claimed", "o", []string{"r", "r2"}, "r2", 4)
+	if h := loadSaaSHive("claimed"); h == nil || h.ACMMLevel != 4 || len(h.Repos) != 2 || h.PrimaryRepo != "r2" {
+		t.Errorf("post-delivery edit: meta = %+v, want acmm=4 repos=[r r2] primary=r2 (adopted)", h)
+	}
+
+	// EMPTY/zero reported values must NOT wipe or downgrade meta (mid-boot spoke).
+	s.adoptSpokeProjectConfig("claimed", "", nil, "", 0)
+	if h := loadSaaSHive("claimed"); h == nil || h.ACMMLevel != 4 || len(h.Repos) != 2 || h.Org != "o" {
+		t.Errorf("empty report clobbered meta: %+v, want unchanged", h)
+	}
+
+	// Unclaimed placeholder: assign owns it -> NOT adopted.
+	saveSaaSHive(&SaaSHive{ID: "ph", Status: statusAvailable, ACMMLevel: 2, Org: "orig"})
+	s.adoptSpokeProjectConfig("ph", "hijack", []string{"x"}, "x", 5)
+	if h := loadSaaSHive("ph"); h == nil || h.ACMMLevel != 2 || h.Org != "orig" {
+		t.Errorf("placeholder: meta = %+v, want unchanged (assign owns it)", h)
 	}
 
 	// No record -> no panic, no-op.
-	s.adoptSpokeACMMLevel("missing", 4)
+	s.adoptSpokeProjectConfig("missing", "o", []string{"r"}, "r", 4)
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4180,41 +4180,86 @@ func (s *HubServer) handleAvailablePlaceholders(w http.ResponseWriter, r *http.R
 // record, is still an unclaimed placeholder (statusAvailable), or the spoke
 // already reports the recorded project. The spoke's currently-reported values
 // (curOrg/curRepos/curPrimary/curACMM) let the hub stop sending once matched.
-// adoptSpokeACMMLevel updates the hub's stored ACMM level for a CLAIMED hive to
-// match the level the spoke just reported, when they differ. It is called only
-// once the project is already reconciled (projectConfigForHiveID == nil), so a
-// difference here means the operator changed the level on the dashboard — the
-// dashboard is the source of truth for a running hive. Without this the hub
-// would re-push its stale meta level every beat and silently revert the change.
+// adoptSpokeProjectConfig makes the hub's meta.json track what a CLAIMED hive's
+// spoke reports for its OPERATOR-CONTROLLED runtime settings: org, repos,
+// primary_repo, and ACMM level. Once a placeholder is claimed, the spoke
+// dashboard is the source of truth for these — an operator can re-point repos or
+// change the level there. Without adopting them, the reconcile in
+// projectConfigForHiveID keeps re-pushing meta's old values and silently reverts
+// the operator's edit every heartbeat (the spyre / Joe Runde bug — originally
+// just ACMM, but org/repos have the identical failure mode).
 //
-// No-op for unclaimed placeholders (assign owns their level) and when unchanged.
-func (s *HubServer) adoptSpokeACMMLevel(hiveID string, spokeLevel int) {
+// Guardrails:
+//   - No-op for a hive with no SaaS record or an unclaimed placeholder
+//     (statusAvailable) — assign owns those until claimed.
+//   - Never adopt EMPTY/zero values: a spoke reporting empty org/repos or level 0
+//     (e.g. mid-boot, before its config loads) must not wipe/downgrade meta.
+//   - Only writes when something actually changed.
+func (s *HubServer) adoptSpokeProjectConfig(hiveID, org string, repos []string, primary string, level int) {
 	h := loadSaaSHive(hiveID)
 	if h == nil || h.Status == statusAvailable {
 		return // no record, or an unclaimed placeholder — assign controls it
 	}
-	if h.ACMMLevel == spokeLevel {
-		return // already in sync
+	changed := false
+	prevLevel := h.ACMMLevel
+
+	// ACMM is operator-owned from the start — always adopt a non-zero level.
+	if level > 0 && level != h.ACMMLevel {
+		h.ACMMLevel = level
+		changed = true
 	}
-	prev := h.ACMMLevel
-	h.ACMMLevel = spokeLevel
+
+	// Org/repos: while the claim hasn't been delivered yet, the hub is still
+	// PUSHING them down and the spoke may report its OLD placeholder project —
+	// do NOT adopt that (it would clobber the real claim). Mark the claim
+	// delivered once the spoke reports the matching org/repos, and only AFTER
+	// delivery treat the spoke as the source of truth for repo edits.
+	orgMatches := org != "" && strings.EqualFold(org, h.Org)
+	reposMatch := len(repos) > 0 && sameStringSliceFold(repos, h.Repos)
+	primaryMatches := primary == "" || strings.EqualFold(primary, h.PrimaryRepo)
+	if !h.ClaimDelivered {
+		if orgMatches && reposMatch && primaryMatches {
+			h.ClaimDelivered = true
+			changed = true
+		}
+	} else {
+		if org != "" && !strings.EqualFold(org, h.Org) {
+			h.Org = org
+			changed = true
+		}
+		if len(repos) > 0 && !sameStringSliceFold(repos, h.Repos) {
+			h.Repos = repos
+			changed = true
+		}
+		if primary != "" && !strings.EqualFold(primary, h.PrimaryRepo) {
+			h.PrimaryRepo = primary
+			changed = true
+		}
+	}
+	if !changed {
+		return
+	}
 	if err := saveSaaSHive(h); err != nil {
-		s.logger.Warn("failed to persist spoke-reported ACMM level to meta",
-			"hive_id", hiveID, "level", spokeLevel, "error", err)
+		s.logger.Warn("failed to persist spoke-reported project config to meta",
+			"hive_id", hiveID, "error", err)
 		return
 	}
 	// Keep the in-memory registry consistent so the UI and the next
-	// projectConfigForHiveID comparison see the adopted level immediately.
+	// projectConfigForHiveID comparison see the adopted values immediately.
 	s.mu.Lock()
 	for i := range s.registry.Hives {
 		if s.registry.Hives[i].ID == hiveID {
-			s.registry.Hives[i].ACMMLevel = spokeLevel
+			s.registry.Hives[i].Org = h.Org
+			s.registry.Hives[i].Repos = h.Repos
+			s.registry.Hives[i].PrimaryRepo = h.PrimaryRepo
+			s.registry.Hives[i].ACMMLevel = h.ACMMLevel
 			break
 		}
 	}
 	s.mu.Unlock()
-	s.logger.Info("adopted dashboard-set ACMM level from spoke heartbeat",
-		"hive_id", hiveID, "was", prev, "now", spokeLevel)
+	s.logger.Info("adopted dashboard-set project config from spoke heartbeat",
+		"hive_id", hiveID, "org", h.Org, "primary_repo", h.PrimaryRepo,
+		"acmm_was", prevLevel, "acmm_now", h.ACMMLevel)
 }
 
 func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary string, curACMM int, curURL string) *HeartbeatProjectConfig {
@@ -4243,23 +4288,30 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 		// Incomplete/stale record (a pre-claim hive) — leave the spoke alone.
 		return nil
 	}
-	// Already matching — stop sending (mirrors AuthorizedUsers "leave alone"
-	// semantics once the spoke has caught up). Include the vanity URL: if it's
-	// set but the spoke hasn't adopted it yet, keep sending so the URL propagates.
-	urlMatched := h.VanityURL == "" || curURL == h.VanityURL
-	if strings.EqualFold(curOrg, h.Org) &&
-		sameStringSliceFold(curRepos, h.Repos) &&
-		strings.EqualFold(curPrimary, primary) &&
-		curACMM == h.ACMMLevel &&
-		urlMatched {
-		return nil
+	// What the hub still PUSHES to the spoke, and until when:
+	//   - org/repos/primary_repo: pushed only until the claim is DELIVERED (the
+	//     spoke first reports the assigned project). After delivery the spoke's
+	//     dashboard owns them and the caller adopts operator edits instead.
+	//   - vanity URL: pushed until the spoke first reports it back.
+	//   - ACMM level: NEVER pushed — operator-owned from the start, always
+	//     adopted by the caller. Including it here (as the old code did) made any
+	//     dashboard level change get reverted every beat (the spyre bug).
+	// curACMM is unused for the push decision (kept for signature/back-compat).
+	_ = curACMM
+	needClaimPush := !h.ClaimDelivered &&
+		!(strings.EqualFold(curOrg, h.Org) &&
+			sameStringSliceFold(curRepos, h.Repos) &&
+			strings.EqualFold(curPrimary, primary))
+	needURLPush := h.VanityURL != "" && curURL != h.VanityURL
+	if !needClaimPush && !needURLPush {
+		return nil // nothing left to push
 	}
 	return &HeartbeatProjectConfig{
 		Org:          h.Org,
 		Repos:        h.Repos,
 		PrimaryRepo:  primary,
 		ACMMLevel:    h.ACMMLevel,
-		DashboardURL: h.VanityURL, // empty until assign sets it
+		DashboardURL: h.VanityURL,
 	}
 }
 
@@ -4386,6 +4438,10 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	h.IsPublic = body.IsPublic
 	h.Status = ""
 	h.Error = ""
+	// A (re)assignment is a new claim payload: reset delivery so the hub pushes
+	// this project to the spoke until it reports the new org/repos back, before
+	// letting the spoke's dashboard own them.
+	h.ClaimDelivered = false
 	// Derive a stable, friendly vanity URL from the claimed project so the user
 	// sees hosted-<org>-<repo>-*.<domain> instead of the raw placeholder host.
 	// Compute once (idempotent re-assign keeps the same URL) and only when the

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -261,7 +261,14 @@ type SaaSHive struct {
 	// callers prefer it over the raw placeholder Subdomain and must NOT infer
 	// "claimed" by pattern-matching the placeholder name. Empty = unclaimed
 	// placeholder (or a pre-vanity hive).
-	VanityURL       string                 `json:"vanity_url,omitempty"`
+	VanityURL string `json:"vanity_url,omitempty"`
+	// ClaimDelivered flips true once a claimed spoke first reports back the
+	// assigned org/repos, i.e. the claim payload reached it. Before that the hub
+	// PUSHES org/repos to the spoke (it may still report its old placeholder
+	// project); after that the spoke's dashboard becomes the source of truth and
+	// the hub ADOPTS operator edits instead of pushing. (ACMM is operator-owned
+	// from the start and always adopted, independent of this flag.)
+	ClaimDelivered  bool                   `json:"claim_delivered,omitempty"`
 	Error           string                 `json:"error,omitempty"`
 	AutoUpgrade     bool                   `json:"auto_upgrade"`
 	IsPublic        bool                   `json:"is_public"`

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -646,6 +646,14 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	// that reaches heartbeat-only clusters (vllm-d) — the hub cannot push
 	// config there over kubectl. A nil return means "spoke already matches, or
 	// no SaaS record / still a placeholder" — send nothing.
+	// Org/repos/primary_repo/ACMM are operator-controlled on the spoke dashboard
+	// once a hive is claimed, so the spoke's reported values are authoritative:
+	// adopt them into meta every beat. This runs BEFORE the reconcile below,
+	// which now only delivers the vanity URL. Without it, an operator's dashboard
+	// edit (repos or level) is reverted every heartbeat — the spyre / Joe Runde
+	// bug. (No-op for unclaimed placeholders and for empty/zero reported values.)
+	s.adoptSpokeProjectConfig(payload.HiveID, payload.Org, payload.Repos, payload.PrimaryRepo, clampInt(payload.ACMMLevel, 0, 6))
+
 	if projCfg := projectConfigForHiveID(payload.HiveID, payload.Org, payload.Repos, payload.PrimaryRepo, payload.ACMMLevel, payload.DashboardURL); projCfg != nil {
 		resp.ProjectConfig = projCfg
 		s.logger.Info("heartbeat: delivering claimed project config to spoke",
@@ -654,15 +662,6 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			"primary_repo", projCfg.PrimaryRepo,
 			"acmm_level", projCfg.ACMMLevel,
 		)
-	} else {
-		// Already reconciled (projCfg == nil): the spoke's project matches meta,
-		// so the hub is no longer pushing. In THIS state a difference in the
-		// spoke-reported ACMM level means the operator changed it on the
-		// dashboard — adopt it into meta instead of fighting it next beat.
-		// Without this, a dashboard level bump is silently reverted: the spoke
-		// reports the new level, the hub sees level != meta and re-pushes the
-		// old meta level, and the spoke drops back (the Joe Runde / spyre bug).
-		s.adoptSpokeACMMLevel(payload.HiveID, clampInt(payload.ACMMLevel, 0, 6))
 	}
 
 	// Deliver a funded OpenRouter gateway to a firewalled/heartbeat-only spoke.


### PR DESCRIPTION
## Problem (spyre / Joe Runde)

A claimed spoke's operator-controlled settings were silently reverted on **every heartbeat**:

- **ACMM level** — setting L3 on the dashboard bounced back to L2. `adoptSpokeACMMLevel` ran only in the `else` branch of the reconcile, which never fired when the level differed (`projectConfigForHiveID` returned non-nil in exactly that case), so the old meta level was re-pushed each beat.
- **org / repos / primary_repo** — re-pointing repos on the dashboard reverted the same way (reconcile kept re-pushing the claim payload forever).
- **governor thresholds** — `ApplyPack` overwrote an operator-set threshold whenever it was `0`, treating a legitimate low bound as "unset".

## Fix

- Rename `adoptSpokeACMMLevel` → `adoptSpokeProjectConfig`; run it **before** the reconcile so it always adopts spoke-reported values into meta.
- **ACMM is operator-owned from the start** — always adopt a non-zero reported level, never push it.
- **org/repos follow a `ClaimDelivered` handshake**: the hub pushes the claim until the spoke first reports it back (so a stale placeholder can't clobber a fresh claim), then the spoke dashboard owns them and operator edits are adopted. A (re)assignment resets `ClaimDelivered` so the new claim is pushed.
- `projectConfigForHiveID` now pushes only the unadopted claim and the vanity URL; **never ACMM**.
- Empty/zero reported values never wipe or downgrade meta (mid-boot spoke).
- `ApplyPack` fills a threshold only on first apply/expansion or when the mode has no entry.

## Tests

- `TestAdoptSpokeProjectConfig` — ACMM always adopted; org/repos gated by ClaimDelivered (stale pre-delivery report ignored, matching report flips the flag, post-delivery edits adopted); empty-report and placeholder no-ops.
- `TestProjectConfigForHiveID` — undelivered claim pushed; delivered claim adopted-not-pushed; vanity URL push/stop.
- `TestApplyPackPreservesOperatorThreshold` — re-apply never resets an operator threshold.
- Full `pkg/hub` suite green with `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)