### PR TITLE
🐛 fix(visual-hive): hot-activate runtime after setup

### DIFF
--- a/v2/cmd/hive/integrated_dashboard_lifecycle.go
+++ b/v2/cmd/hive/integrated_dashboard_lifecycle.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -249,7 +250,11 @@ func runDashboardIntegratedControl(ctx context.Context, stateDir string, request
 			}
 			args := []string{"uninstall", "--state-dir", stateDir, "--json", "--github-token-env", "HIVE_GITHUB_TOKEN"}
 			if request.Action != "uninstall-cancel" {
-				for _, dir := range dashboardLifecycleNormalBeadsDirs {
+				beadDirs := append([]string(nil), dashboardLifecycleNormalBeadsDirs...)
+				if normalVisualRuntime := dashboardNormalVisualRuntime.Load(); normalVisualRuntime != nil {
+					beadDirs = normalVisualRuntime.BeadDirs()
+				}
+				for _, dir := range beadDirs {
 					if strings.TrimSpace(dir) != "" {
 						args = append(args, "--beads-dir", dir)
 					}
@@ -262,6 +267,14 @@ func runDashboardIntegratedControl(ctx context.Context, stateDir string, request
 				args = append(args, "--cancel")
 			}
 			result, _, runErr := dashboardLifecycleCLIRunner(ctx, args, token, false)
+			if normalVisualRuntime := dashboardNormalVisualRuntime.Load(); runErr != nil && normalVisualRuntime != nil {
+				if _, resumeErr := normalVisualRuntime.ResumeReconciliation(ctx); resumeErr != nil {
+					slog.Default().Warn("restore normal Visual Hive runtime after failed uninstall mutation", "error", resumeErr)
+				}
+			}
+			if runErr == nil && request.Action == "uninstall-cancel" {
+				result = reconcileDashboardSetupRuntime(ctx, result)
+			}
 			return result, runErr
 		default:
 			return nil, fmt.Errorf("unsupported integrated control action %q", request.Action)
@@ -296,12 +309,13 @@ func runDashboardBaselineApproval(ctx context.Context, stateDir string, request 
 }
 
 func triggerDashboardVisualCycle(ctx context.Context) error {
-	if normalVisualWorkRunner == nil {
+	normalVisualRuntime := dashboardNormalVisualRuntime.Load()
+	if normalVisualRuntime == nil {
 		return errors.New("normal Visual Hive service is not running in this dashboard process")
 	}
 	triggerCtx, cancel := context.WithTimeout(ctx, 2*time.Hour)
 	defer cancel()
-	return normalVisualWorkRunner.Trigger(triggerCtx)
+	return normalVisualRuntime.Trigger(triggerCtx)
 }
 
 func isBoundedDashboardTriggerOutcome(err error) bool {

--- a/v2/cmd/hive/integrated_dashboard_setup.go
+++ b/v2/cmd/hive/integrated_dashboard_setup.go
@@ -40,10 +40,17 @@ func runDashboardIntegratedSetup(ctx context.Context, request dashboard.Integrat
 			stateDir, request.RequestID, "setup", request.ExpectedPlanSHA256,
 		)
 		if replayErr != nil || terminal {
+			if replayErr == nil {
+				replay = reconcileDashboardSetupRuntime(ctx, replay)
+			}
 			return replay, replayErr
 		}
 		if recoverStale {
-			return runDashboardSetupMutation(ctx, stateDir, request, baseArgs, token)
+			result, mutationErr := runDashboardSetupMutation(ctx, stateDir, request, baseArgs, token)
+			if mutationErr == nil {
+				result = reconcileDashboardSetupRuntime(ctx, result)
+			}
+			return result, mutationErr
 		}
 	}
 	plan, planBytes, err := dashboardSetupCLIRunner(ctx, append(append([]string(nil), baseArgs...), "--plan"), token)
@@ -65,7 +72,40 @@ func runDashboardIntegratedSetup(ctx context.Context, request dashboard.Integrat
 	if request.ExpectedPlanSHA256 != planSHA256 {
 		return nil, fmt.Errorf("integrated setup plan changed: expected %s, current %s", request.ExpectedPlanSHA256, planSHA256)
 	}
-	return runDashboardSetupMutation(ctx, stateDir, request, baseArgs, token)
+	result, mutationErr := runDashboardSetupMutation(ctx, stateDir, request, baseArgs, token)
+	if mutationErr == nil {
+		result = reconcileDashboardSetupRuntime(ctx, result)
+	}
+	return result, mutationErr
+}
+
+func reconcileDashboardSetupRuntime(ctx context.Context, result map[string]any) map[string]any {
+	if result == nil {
+		result = map[string]any{}
+	}
+	activation := map[string]any{"state": "pending"}
+	normalVisualRuntime := dashboardNormalVisualRuntime.Load()
+	if normalVisualRuntime == nil {
+		activation["error_reference"] = dashboardSetupErrorDigest(errors.New("normal Visual Hive runtime manager is unavailable"))
+		result["visual_runtime_activation"] = activation
+		return result
+	}
+	active, err := normalVisualRuntime.ResumeReconciliation(ctx)
+	switch {
+	case err != nil:
+		activation["error_reference"] = dashboardSetupErrorDigest(err)
+	case active:
+		activation["state"] = "ready"
+	default:
+		activation["error_reference"] = dashboardSetupErrorDigest(errors.New("authoritative Visual Hive contract is not yet available"))
+	}
+	result["visual_runtime_activation"] = activation
+	return result
+}
+
+func dashboardSetupErrorDigest(err error) string {
+	sum := sha256.Sum256([]byte(fmt.Sprint(err)))
+	return hex.EncodeToString(sum[:])
 }
 
 func dashboardSetupPlanDigest(request dashboard.IntegratedSetupRequest, planBytes []byte) (string, error) {

--- a/v2/cmd/hive/integrated_dashboard_setup_test.go
+++ b/v2/cmd/hive/integrated_dashboard_setup_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -46,6 +47,13 @@ func TestDashboardIntegratedSetupBindsApplyToFreshPlan(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("HIVE_STATE_DIR", stateDir)
+	contract := &testNormalVisualContract{config: testInstalledNormalVisualContract(t, stateDir), exists: true}
+	runtimeManager, factoryCalls, _ := newTestNormalVisualRuntimeManager(t, contract, func(binding normalVisualRuntimeBinding) *fakeNormalVisualRuntime {
+		return &fakeNormalVisualRuntime{binding: binding}
+	})
+	originalRuntime := dashboardNormalVisualRuntime.Load()
+	dashboardNormalVisualRuntime.Store(runtimeManager)
+	t.Cleanup(func() { dashboardNormalVisualRuntime.Store(originalRuntime) })
 	planBytes := []byte("{\"applied\":false}\n")
 	var calls [][]string
 	dashboardSetupCLIRunner = func(_ context.Context, args []string, token string) (map[string]any, []byte, error) {
@@ -73,7 +81,8 @@ func TestDashboardIntegratedSetupBindsApplyToFreshPlan(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result["plan_sha256"] != planDigest || len(calls) != 2 {
+	activation, _ := result["visual_runtime_activation"].(map[string]any)
+	if result["plan_sha256"] != planDigest || activation["state"] != "ready" || len(calls) != 2 {
 		t.Fatalf("result=%v calls=%v", result, calls)
 	}
 	wantBase := []string{
@@ -86,7 +95,9 @@ func TestDashboardIntegratedSetupBindsApplyToFreshPlan(t *testing.T) {
 		t.Fatalf("unexpected setup arguments: %v", calls)
 	}
 	replay, err := runDashboardIntegratedSetup(context.Background(), request, "owner-token")
-	if err != nil || replay["idempotent_replay"] != true || len(calls) != 2 {
+	replayActivation, _ := replay["visual_runtime_activation"].(map[string]any)
+	if err != nil || replay["idempotent_replay"] != true || replayActivation["state"] != "ready" ||
+		len(calls) != 2 || factoryCalls.Load() != 1 {
 		t.Fatalf("replay=%v err=%v calls=%v", replay, err, calls)
 	}
 }
@@ -155,6 +166,13 @@ func TestDashboardIntegratedSetupRejectsPlanDriftBeforeApply(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("HIVE_STATE_DIR", stateDir)
+	contract := &testNormalVisualContract{config: testInstalledNormalVisualContract(t, stateDir), exists: true}
+	runtimeManager, factoryCalls, _ := newTestNormalVisualRuntimeManager(t, contract, func(binding normalVisualRuntimeBinding) *fakeNormalVisualRuntime {
+		return &fakeNormalVisualRuntime{binding: binding}
+	})
+	originalRuntime := dashboardNormalVisualRuntime.Load()
+	dashboardNormalVisualRuntime.Store(runtimeManager)
+	t.Cleanup(func() { dashboardNormalVisualRuntime.Store(originalRuntime) })
 	calls := 0
 	dashboardSetupCLIRunner = func(context.Context, []string, string) (map[string]any, []byte, error) {
 		calls++
@@ -165,7 +183,67 @@ func TestDashboardIntegratedSetupRejectsPlanDriftBeforeApply(t *testing.T) {
 		Repository: "owner/repository", Coverage: "essential", Automation: "repair-pr",
 		Provider: "codex", VisualHiveRef: strings.Repeat("a", 40), ExpectedPlanSHA256: strings.Repeat("0", 64),
 	}, "owner-token")
-	if err == nil || !strings.Contains(err.Error(), "plan changed") || calls != 1 {
-		t.Fatalf("err=%v calls=%d", err, calls)
+	if err == nil || !strings.Contains(err.Error(), "plan changed") || calls != 1 || factoryCalls.Load() != 0 {
+		t.Fatalf("err=%v calls=%d factory=%d", err, calls, factoryCalls.Load())
+	}
+}
+
+func TestDashboardIntegratedSetupPersistsSuccessAndRetriesOnlyRuntimeActivation(t *testing.T) {
+	originalRunner := dashboardSetupCLIRunner
+	t.Cleanup(func() { dashboardSetupCLIRunner = originalRunner })
+	stateDir := filepath.Join(t.TempDir(), "repository-state")
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HIVE_STATE_DIR", stateDir)
+	contract := &testNormalVisualContract{config: testInstalledNormalVisualContract(t, stateDir), exists: true}
+	var runtimeAttempts int
+	runtimeManager, factoryCalls, _ := newTestNormalVisualRuntimeManager(t, contract, func(binding normalVisualRuntimeBinding) *fakeNormalVisualRuntime {
+		runtimeAttempts++
+		instance := &fakeNormalVisualRuntime{binding: binding}
+		if runtimeAttempts == 1 {
+			instance.startErr = errors.New("dashboard readiness is not yet available")
+		}
+		return instance
+	})
+	originalRuntime := dashboardNormalVisualRuntime.Load()
+	dashboardNormalVisualRuntime.Store(runtimeManager)
+	t.Cleanup(func() { dashboardNormalVisualRuntime.Store(originalRuntime) })
+
+	planBytes := []byte("{\"applied\":false}\n")
+	calls := 0
+	dashboardSetupCLIRunner = func(_ context.Context, args []string, _ string) (map[string]any, []byte, error) {
+		calls++
+		if args[len(args)-1] == "--plan" {
+			return map[string]any{"applied": false}, planBytes, nil
+		}
+		return map[string]any{"applied": true}, []byte("{\"applied\":true}\n"), nil
+	}
+	request := dashboard.IntegratedSetupRequest{
+		RequestID: "setup-runtime-retry-001", Repository: "owner/repository",
+		Coverage: "essential", Automation: "repair-pr", Provider: "codex",
+		VisualHiveRef: strings.Repeat("a", 40),
+	}
+	planDigest, err := dashboardSetupPlanDigest(request, planBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.ExpectedPlanSHA256 = planDigest
+	first, err := runDashboardIntegratedSetup(context.Background(), request, "owner-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstActivation, _ := first["visual_runtime_activation"].(map[string]any)
+	if firstActivation["state"] != "pending" || firstActivation["error_reference"] == "" {
+		t.Fatalf("first activation=%v", firstActivation)
+	}
+	replay, err := runDashboardIntegratedSetup(context.Background(), request, "owner-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	replayActivation, _ := replay["visual_runtime_activation"].(map[string]any)
+	if replay["idempotent_replay"] != true || replayActivation["state"] != "ready" ||
+		calls != 2 || factoryCalls.Load() != 2 {
+		t.Fatalf("replay=%v calls=%d factory=%d", replay, calls, factoryCalls.Load())
 	}
 }

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -38,7 +38,6 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/github"
 	"github.com/kubestellar/hive/v2/pkg/governor"
 	"github.com/kubestellar/hive/v2/pkg/hub"
-	"github.com/kubestellar/hive/v2/pkg/integrated"
 	"github.com/kubestellar/hive/v2/pkg/knowledge"
 	"github.com/kubestellar/hive/v2/pkg/logscrub"
 	"github.com/kubestellar/hive/v2/pkg/notify"
@@ -50,7 +49,6 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/snapshot"
 	"github.com/kubestellar/hive/v2/pkg/tokens"
 	"github.com/kubestellar/hive/v2/pkg/trajectory"
-	visualcontroller "github.com/kubestellar/hive/v2/pkg/visualhive/controller"
 )
 
 var (
@@ -411,17 +409,6 @@ func main() {
 		PolicyDir:  policyDir,
 	}
 	agentMgr := agent.NewManager(cfg.EnabledAgents(), logger, projectCtx)
-	var normalVisualWorkOwnership *os.File
-	var normalVisualDashboardReadiness *normalVisualDashboardGate
-	defer func() { dashboardLifecycleStopNormalVisual = nil }()
-	defer shutdownOrdinaryVisualRuntime(cancel, agentMgr, func() {
-		if normalVisualDashboardReadiness != nil {
-			if err := normalVisualDashboardReadiness.Stop(); err != nil {
-				logger.Warn("remove normal Visual Hive dashboard readiness", "error", err)
-			}
-		}
-		releaseDaemonLease(normalVisualWorkOwnership)
-	}, logger)
 	configCoordinator := dashboard.NewConfigCoordinator(cfg, gov, agentMgr)
 	if appAuth != nil {
 		agentMgr.SetAppAuth(appAuth)
@@ -667,18 +654,6 @@ func main() {
 			logger.Info("orphan beads store loaded from disk", "agent", name, "count", store.Count())
 		}
 	}
-	installedVisualContract, visualContractExists, visualContractErr := loadCurrentVisualWorkContract(cfg)
-	if visualContractErr == nil && visualContractExists {
-		initialized, initErr := ensureVisualSpecialistBeadStores(beadStores, lifecycleBeadsDirs, beadsRootDir, cfg.HiveID)
-		if initErr != nil {
-			visualContractErr = fmt.Errorf("initialize fixed Visual Hive specialist bead stores: %w", initErr)
-		} else {
-			for _, role := range initialized {
-				logger.Info("Visual Hive specialist beads store initialized", "agent", role, "count", beadStores[role].Count())
-			}
-		}
-	}
-
 	lifecycleBeadRoles := make([]string, 0, len(lifecycleBeadsDirs))
 	for role := range lifecycleBeadsDirs {
 		lifecycleBeadRoles = append(lifecycleBeadRoles, role)
@@ -689,62 +664,23 @@ func main() {
 		dashboardLifecycleNormalBeadsDirs = append(dashboardLifecycleNormalBeadsDirs, strings.TrimSpace(lifecycleBeadsDirs[role]))
 	}
 
-	if visualContractErr != nil {
-		logger.Warn("normal Visual Hive contract unavailable", "error", visualContractErr)
-	} else if visualContractExists {
-		lifecycle, lifecycleErr := visualLifecycleForInstalledContract(installedVisualContract)
-		if lifecycleErr != nil {
-			logger.Warn("normal Visual Hive lifecycle unavailable", "error", lifecycleErr)
-		} else if service, serviceErr := visualcontroller.New(gov, lifecycle, beadStores, agentMgr, ghClient, installedVisualContract, inferACMMLevel(cfg)); serviceErr != nil {
-			logger.Warn("normal Visual Hive intake unavailable", "error", serviceErr)
-		} else {
-			service.SetAuditSink(dashboardVisualWorkAudit{server: dashSrv})
-			service.SetRuntimeConfigLoader(func() (integrated.Config, int, error) {
-				current, currentExists, currentErr := loadAuthoritativeVisualWorkContract()
-				if currentErr != nil {
-					return integrated.Config{}, 0, currentErr
-				}
-				if !currentExists {
-					return integrated.Config{}, 0, fmt.Errorf("authoritative installed Visual Hive contract is unavailable")
-				}
-				return current, agentMgr.GetACMMLevel(), nil
-			})
-			if configuredRuntimeOwnerIntent(installedVisualContract) != runtimeOwnerNormalHive {
-				normalVisualWorkService = service
-				logger.Info("normal Visual Hive intake initialized", "repository", installedVisualContract.Repository)
-				logger.Info("normal Visual Hive intake does not own repair polling for the current installed config", "repository", installedVisualContract.Repository, "runtime_owner", configuredRuntimeOwnerIntent(installedVisualContract))
-			} else {
-				candidateDashboardReadiness, readinessErr := newNormalVisualDashboardGate(dashSrv, installedVisualContract.StateDir, installedVisualContract.Repository)
-				if readinessErr != nil {
-					logger.Warn("normal Visual Hive dashboard readiness unavailable", "error", readinessErr)
-				} else {
-					ownership, runnerErr := claimNormalVisualWorkOwnership(installedVisualContract.StateDir, agentMgr, func(ordinaryManager *agent.Manager) (bool, error) {
-						runner, health, configureErr := configureNormalVisualWorkRunner(installedVisualContract, service, lifecycle, sched, ordinaryManager, ghClient, normalGitTransportToken, candidateDashboardReadiness.Ready, logger)
-						if configureErr != nil || runner == nil {
-							return false, configureErr
-						}
-						normalVisualWorkRunner = runner
-						normalVisualWorkHealthWriter = health
-						return true, nil
-					})
-					if runnerErr != nil {
-						if errors.Is(runnerErr, errDaemonLeaseHeld) {
-							logger.Warn("normal Visual Hive governed repair service held because the legacy scheduler owns this repository; stop it and restart normal Hive for a controlled transition", "repository", installedVisualContract.Repository)
-						} else {
-							logger.Warn("normal Visual Hive governed repair service unavailable", "error", runnerErr)
-						}
-					} else if ownership != nil {
-						normalVisualWorkService = service
-						normalVisualWorkOwnership = ownership
-						normalVisualDashboardReadiness = candidateDashboardReadiness
-						dashboardLifecycleStopNormalVisual = func(context.Context) error {
-							return errors.New("normal Visual Hive runtime initialization is not complete")
-						}
-						logger.Info("normal Visual Hive intake and governed repair service initialized with exclusive ordinary-Manager ownership", "repository", installedVisualContract.Repository)
-					}
-				}
-			}
-		}
+	normalVisualRuntime, runtimeManagerErr := newNormalVisualRuntimeManager(normalVisualRuntimeDependencies{
+		ProcessContext: ctx, NormalConfig: cfg, Governor: gov,
+		BeadStores: beadStores, LifecycleBeadDirs: lifecycleBeadsDirs,
+		BeadsRoot: beadsRootDir, HiveID: cfg.HiveID,
+		AgentManager: agentMgr, GitHub: ghClient, Scheduler: sched,
+		GitTransportToken: normalGitTransportToken, Dashboard: dashSrv, Logger: logger,
+	})
+	if runtimeManagerErr != nil {
+		logger.Error("normal Visual Hive runtime manager unavailable", "error", runtimeManagerErr)
+	} else {
+		dashboardNormalVisualRuntime.Store(normalVisualRuntime)
+		dashboardLifecycleStopNormalVisual = normalVisualRuntime.Stop
+		defer func() {
+			dashboardLifecycleStopNormalVisual = nil
+			dashboardNormalVisualRuntime.Store(nil)
+		}()
+		defer shutdownOrdinaryVisualRuntime(cancel, agentMgr, normalVisualRuntime.ReleaseOnProcessExit, logger)
 	}
 
 	initAgentConfigDrivenSystems(cfg)
@@ -1625,8 +1561,8 @@ func main() {
 
 	go func() {
 		err := dashSrv.Start()
-		if normalVisualDashboardReadiness != nil {
-			if stopErr := normalVisualDashboardReadiness.Stop(); stopErr != nil {
+		if normalVisualRuntime := dashboardNormalVisualRuntime.Load(); normalVisualRuntime != nil {
+			if stopErr := normalVisualRuntime.ClearDashboardReadiness(); stopErr != nil {
 				logger.Warn("remove stopped normal Visual Hive dashboard readiness", "error", stopErr)
 			}
 		}
@@ -2177,44 +2113,18 @@ func main() {
 		dashboardHTTPReady = true
 	}
 	cancelDashboardReady()
-	if normalVisualWorkRunner != nil {
+	if normalVisualRuntime := dashboardNormalVisualRuntime.Load(); normalVisualRuntime != nil {
 		if !dashboardHTTPReady {
 			logger.Error("normal Visual Hive service will not start without the existing dashboard HTTP listener")
-		} else if normalVisualDashboardReadiness == nil {
-			logger.Error("normal Visual Hive service will not start without dashboard readiness binding")
-		} else if err := normalVisualDashboardReadiness.Activate(time.Now().UTC()); err != nil {
-			logger.Error("normal Visual Hive service will not start without generation-bound dashboard readiness", "error", err)
-		} else if normalVisualWorkHealthWriter == nil {
-			logger.Error("normal Visual Hive service will not start without its health writer")
-		} else if err := normalVisualWorkHealthWriter.Initialize(); err != nil {
-			logger.Error("normal Visual Hive service will not start without a generation-bound health record", "error", err)
 		} else {
-			runner := normalVisualWorkRunner
-			runnerContext, cancelRunner := context.WithCancel(ctx)
-			runnerDone := make(chan struct{})
-			stopper := &normalVisualRuntimeStopper{
-				cancel:  cancelRunner,
-				done:    runnerDone,
-				manager: agentMgr,
-				logger:  logger,
-				releaseOwnership: func() {
-					if normalVisualDashboardReadiness != nil {
-						if err := normalVisualDashboardReadiness.Stop(); err != nil {
-							logger.Warn("remove normal Visual Hive dashboard readiness during uninstall", "error", err)
-						}
-						normalVisualDashboardReadiness = nil
-					}
-					releaseDaemonLease(normalVisualWorkOwnership)
-					normalVisualWorkOwnership = nil
-					normalVisualWorkRunner = nil
-					normalVisualWorkHealthWriter = nil
-				},
+			if _, err := normalVisualRuntime.Ensure(ctx); err != nil {
+				if errors.Is(err, errDaemonLeaseHeld) {
+					logger.Warn("normal Visual Hive governed repair service held because another runtime owns this repository", "error", err)
+				} else {
+					logger.Warn("normal Visual Hive runtime activation is pending", "error", err)
+				}
 			}
-			dashboardLifecycleStopNormalVisual = stopper.Stop
-			go func() {
-				defer close(runnerDone)
-				runner.Run(runnerContext)
-			}()
+			go normalVisualRuntime.Observe(ctx, normalVisualRuntimeReconcileInterval)
 		}
 	}
 

--- a/v2/cmd/hive/normal_visual_runtime_control.go
+++ b/v2/cmd/hive/normal_visual_runtime_control.go
@@ -17,6 +17,7 @@ type normalVisualRuntimeStopper struct {
 	cancel           context.CancelFunc
 	done             <-chan struct{}
 	manager          specialistChildShutdowner
+	resetSpecialists func() error
 	releaseOwnership func()
 	logger           *slog.Logger
 	cancelRequested  bool
@@ -53,6 +54,11 @@ func (stopper *normalVisualRuntimeStopper) Stop(ctx context.Context) error {
 	}
 	if err := shutdownOrdinarySpecialistChildren(stopper.manager, stopper.logger); err != nil {
 		return err
+	}
+	if stopper.resetSpecialists != nil {
+		if err := stopper.resetSpecialists(); err != nil {
+			return err
+		}
 	}
 
 	stopper.mu.Lock()

--- a/v2/cmd/hive/normal_visual_runtime_control_test.go
+++ b/v2/cmd/hive/normal_visual_runtime_control_test.go
@@ -26,11 +26,15 @@ func TestNormalVisualRuntimeStopperStopsBeforeReleasingAndIsIdempotent(t *testin
 		<-runContext.Done()
 	}()
 	manager := &runtimeStopTestManager{}
-	releases := 0
+	releases, resets := 0, 0
 	stopper := &normalVisualRuntimeStopper{
 		cancel:  cancelRun,
 		done:    done,
 		manager: manager,
+		resetSpecialists: func() error {
+			resets++
+			return nil
+		},
 		releaseOwnership: func() {
 			select {
 			case <-done:
@@ -49,7 +53,7 @@ func TestNormalVisualRuntimeStopperStopsBeforeReleasingAndIsIdempotent(t *testin
 	manager.mu.Lock()
 	shutdownCalls := manager.calls
 	manager.mu.Unlock()
-	if shutdownCalls != 1 || releases != 1 {
-		t.Fatalf("shutdownCalls=%d releases=%d", shutdownCalls, releases)
+	if shutdownCalls != 1 || resets != 1 || releases != 1 {
+		t.Fatalf("shutdownCalls=%d resets=%d releases=%d", shutdownCalls, resets, releases)
 	}
 }

--- a/v2/cmd/hive/normal_visual_runtime_manager.go
+++ b/v2/cmd/hive/normal_visual_runtime_manager.go
@@ -1,0 +1,649 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/agent"
+	"github.com/kubestellar/hive/v2/pkg/beads"
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/dashboard"
+	hivegithub "github.com/kubestellar/hive/v2/pkg/github"
+	"github.com/kubestellar/hive/v2/pkg/governor"
+	"github.com/kubestellar/hive/v2/pkg/integrated"
+	"github.com/kubestellar/hive/v2/pkg/scheduler"
+	visualcontroller "github.com/kubestellar/hive/v2/pkg/visualhive/controller"
+	"github.com/kubestellar/hive/v2/pkg/visualhive/normalservice"
+)
+
+var (
+	dashboardNormalVisualRuntime         atomic.Pointer[normalVisualRuntimeManager]
+	normalVisualRuntimeReconcileInterval = 5 * time.Second
+)
+
+type normalVisualRuntimeBinding struct {
+	Digest     string
+	Repository string
+	StateDir   string
+}
+
+type normalVisualRuntimeInstance interface {
+	Binding() normalVisualRuntimeBinding
+	Start(context.Context) error
+	Trigger(context.Context) error
+	Import(context.Context, hivegithub.VerifiedVisualHiveArtifact) (visualcontroller.Result, error)
+	Stop(context.Context) error
+	ClearDashboardReadiness() error
+	ReleaseOnProcessExit()
+	BeadDirs() []string
+}
+
+type normalVisualRuntimeFactory func(integrated.Config) (normalVisualRuntimeInstance, error)
+
+// normalVisualRuntimeManager is the single in-process owner of the additive
+// Visual Hive controller. It observes only Hive's authoritative installed
+// contract and never creates a second ordinary Manager or scheduler.
+type normalVisualRuntimeManager struct {
+	mu         sync.Mutex
+	process    context.Context
+	normal     *config.Config
+	load       func(*config.Config) (integrated.Config, bool, error)
+	factory    normalVisualRuntimeFactory
+	logger     *slog.Logger
+	active     normalVisualRuntimeInstance
+	beadDirs   []string
+	suppressed bool
+}
+
+type normalVisualRuntimeDependencies struct {
+	ProcessContext    context.Context
+	NormalConfig      *config.Config
+	Governor          *governor.Governor
+	BeadStores        map[string]*beads.Store
+	LifecycleBeadDirs map[string]string
+	BeadsRoot         string
+	HiveID            string
+	AgentManager      *agent.Manager
+	GitHub            *hivegithub.Client
+	Scheduler         *scheduler.Scheduler
+	GitTransportToken func(context.Context) (string, error)
+	Dashboard         *dashboard.Server
+	Logger            *slog.Logger
+}
+
+func newNormalVisualRuntimeManager(deps normalVisualRuntimeDependencies) (*normalVisualRuntimeManager, error) {
+	if deps.ProcessContext == nil || deps.NormalConfig == nil || deps.Governor == nil ||
+		deps.AgentManager == nil || deps.GitHub == nil || deps.Scheduler == nil ||
+		deps.GitTransportToken == nil || deps.Dashboard == nil {
+		return nil, errors.New("normal Visual Hive runtime manager dependencies are incomplete")
+	}
+	if deps.Logger == nil {
+		deps.Logger = slog.Default()
+	}
+	baseDirs := sortedNormalVisualBeadDirs(deps.LifecycleBeadDirs)
+	manager := &normalVisualRuntimeManager{
+		process:  deps.ProcessContext,
+		normal:   deps.NormalConfig,
+		load:     loadCurrentVisualWorkContract,
+		logger:   deps.Logger,
+		beadDirs: baseDirs,
+	}
+	manager.factory = func(installed integrated.Config) (normalVisualRuntimeInstance, error) {
+		return buildNormalVisualRuntime(deps, installed)
+	}
+	return manager, nil
+}
+
+// Ensure activates the exact authoritative contract once. Repeated calls for
+// the same binding are no-ops; a changed live binding fails closed and must use
+// the supported stop/rebind lifecycle.
+func (manager *normalVisualRuntimeManager) Ensure(_ context.Context) (bool, error) {
+	if manager == nil {
+		return false, errors.New("normal Visual Hive runtime manager is unavailable")
+	}
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.suppressed {
+		return false, nil
+	}
+
+	installed, exists, err := manager.load(manager.normal)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		if manager.active != nil {
+			return false, errors.New("authoritative Visual Hive contract disappeared while its runtime is active; use supported uninstall")
+		}
+		return false, nil
+	}
+	binding, err := normalVisualBinding(installed)
+	if err != nil {
+		return false, err
+	}
+	if manager.active != nil {
+		current := manager.active.Binding()
+		if current.Digest == binding.Digest {
+			return true, nil
+		}
+		return false, fmt.Errorf(
+			"installed Visual Hive contract changed from %s to %s while the runtime is active; use the managed stop/rebind lifecycle",
+			current.Repository, binding.Repository,
+		)
+	}
+
+	instance, err := manager.factory(installed)
+	if err != nil {
+		return false, err
+	}
+	if instance == nil {
+		return false, errors.New("normal Visual Hive runtime factory returned no instance")
+	}
+	if instance.Binding().Digest != binding.Digest {
+		instance.ReleaseOnProcessExit()
+		return false, errors.New("normal Visual Hive runtime factory returned a mismatched contract binding")
+	}
+	if err := instance.Start(manager.process); err != nil {
+		instance.ReleaseOnProcessExit()
+		return false, err
+	}
+	manager.active = instance
+	manager.beadDirs = instance.BeadDirs()
+	manager.logger.Info("normal Visual Hive runtime reconciled in-process",
+		"repository", binding.Repository,
+		"binding", binding.Digest,
+	)
+	return true, nil
+}
+
+func (manager *normalVisualRuntimeManager) Trigger(ctx context.Context) error {
+	active, err := manager.Ensure(ctx)
+	if err != nil {
+		return err
+	}
+	if !active {
+		return errors.New("normal Visual Hive service is not running in this dashboard process")
+	}
+	manager.mu.Lock()
+	instance := manager.active
+	manager.mu.Unlock()
+	if instance == nil {
+		return errors.New("normal Visual Hive service is not running in this dashboard process")
+	}
+	return instance.Trigger(ctx)
+}
+
+func (manager *normalVisualRuntimeManager) Import(ctx context.Context, source hivegithub.VerifiedVisualHiveArtifact) (visualcontroller.Result, error) {
+	active, err := manager.Ensure(ctx)
+	if err != nil {
+		return visualcontroller.Result{}, err
+	}
+	if !active {
+		return visualcontroller.Result{}, errors.New("normal Visual Hive work service is not configured")
+	}
+	manager.mu.Lock()
+	instance := manager.active
+	manager.mu.Unlock()
+	if instance == nil {
+		return visualcontroller.Result{}, errors.New("normal Visual Hive work service is not configured")
+	}
+	return instance.Import(ctx, source)
+}
+
+func (manager *normalVisualRuntimeManager) Stop(ctx context.Context) error {
+	if manager == nil {
+		return nil
+	}
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	manager.suppressed = true
+	if manager.active == nil {
+		return nil
+	}
+	if err := manager.active.Stop(ctx); err != nil {
+		return err
+	}
+	manager.active = nil
+	return nil
+}
+
+// ResumeReconciliation is used only after an exact managed setup/cancel or a
+// failed uninstall mutation. It prevents the background observer from
+// recreating a runtime while uninstall is between its stop and durable CLI
+// transaction.
+func (manager *normalVisualRuntimeManager) ResumeReconciliation(ctx context.Context) (bool, error) {
+	if manager == nil {
+		return false, errors.New("normal Visual Hive runtime manager is unavailable")
+	}
+	manager.mu.Lock()
+	manager.suppressed = false
+	manager.mu.Unlock()
+	return manager.Ensure(ctx)
+}
+
+func (manager *normalVisualRuntimeManager) ClearDashboardReadiness() error {
+	if manager == nil {
+		return nil
+	}
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.active == nil {
+		return nil
+	}
+	return manager.active.ClearDashboardReadiness()
+}
+
+func (manager *normalVisualRuntimeManager) ReleaseOnProcessExit() {
+	if manager == nil {
+		return
+	}
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	if manager.active != nil {
+		manager.active.ReleaseOnProcessExit()
+		manager.active = nil
+	}
+}
+
+func (manager *normalVisualRuntimeManager) BeadDirs() []string {
+	if manager == nil {
+		return nil
+	}
+	manager.mu.Lock()
+	defer manager.mu.Unlock()
+	return append([]string(nil), manager.beadDirs...)
+}
+
+func (manager *normalVisualRuntimeManager) Observe(ctx context.Context, interval time.Duration) {
+	if manager == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = normalVisualRuntimeReconcileInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	lastFailure := ""
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			_, err := manager.Ensure(ctx)
+			failure := ""
+			if err != nil {
+				sum := sha256.Sum256([]byte(err.Error()))
+				failure = hex.EncodeToString(sum[:])
+			}
+			if failure == lastFailure {
+				continue
+			}
+			lastFailure = failure
+			if err != nil {
+				manager.logger.Warn("normal Visual Hive runtime reconciliation is pending", "error", err)
+			} else {
+				manager.logger.Info("normal Visual Hive runtime reconciliation recovered")
+			}
+		}
+	}
+}
+
+type concreteNormalVisualRuntime struct {
+	mu         sync.Mutex
+	binding    normalVisualRuntimeBinding
+	controller *visualcontroller.Controller
+	runner     *normalservice.Service
+	health     *normalVisualServiceHealthReporter
+	readiness  *normalVisualDashboardGate
+	ownership  *os.File
+	manager    *agent.Manager
+	logger     *slog.Logger
+	beadDirs   []string
+	stopper    *normalVisualRuntimeStopper
+	started    bool
+}
+
+func buildNormalVisualRuntime(deps normalVisualRuntimeDependencies, installed integrated.Config) (normalVisualRuntimeInstance, error) {
+	binding, err := normalVisualBinding(installed)
+	if err != nil {
+		return nil, err
+	}
+	stores := cloneNormalVisualBeadStores(deps.BeadStores)
+	dirs := cloneNormalVisualBeadDirs(deps.LifecycleBeadDirs)
+	initialized, err := ensureVisualSpecialistBeadStores(stores, dirs, deps.BeadsRoot, deps.HiveID)
+	if err != nil {
+		return nil, fmt.Errorf("initialize fixed Visual Hive specialist bead stores: %w", err)
+	}
+	for _, role := range initialized {
+		deps.Logger.Info("Visual Hive specialist beads store initialized", "agent", role, "count", stores[role].Count())
+	}
+	lifecycle, err := visualLifecycleForInstalledContract(installed)
+	if err != nil {
+		return nil, fmt.Errorf("initialize normal Visual Hive lifecycle: %w", err)
+	}
+	controller, err := visualcontroller.New(
+		deps.Governor, lifecycle, stores, deps.AgentManager, deps.GitHub,
+		installed, inferACMMLevel(deps.NormalConfig),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("initialize normal Visual Hive intake: %w", err)
+	}
+	controller.SetAuditSink(dashboardVisualWorkAudit{server: deps.Dashboard})
+	controller.SetRuntimeConfigLoader(func() (integrated.Config, int, error) {
+		current, exists, loadErr := loadAuthoritativeVisualWorkContract()
+		if loadErr != nil {
+			return integrated.Config{}, 0, loadErr
+		}
+		if !exists {
+			return integrated.Config{}, 0, errors.New("authoritative installed Visual Hive contract is unavailable")
+		}
+		return current, deps.AgentManager.GetACMMLevel(), nil
+	})
+	instance := &concreteNormalVisualRuntime{
+		binding:    binding,
+		controller: controller,
+		manager:    deps.AgentManager,
+		logger:     deps.Logger,
+		beadDirs:   sortedNormalVisualBeadDirs(dirs),
+	}
+	if configuredRuntimeOwnerIntent(installed) != runtimeOwnerNormalHive {
+		deps.Logger.Info("normal Visual Hive intake does not own repair polling for the current installed config",
+			"repository", installed.Repository,
+			"runtime_owner", configuredRuntimeOwnerIntent(installed),
+		)
+		return instance, nil
+	}
+
+	readiness, err := newNormalVisualDashboardGate(deps.Dashboard, installed.StateDir, installed.Repository)
+	if err != nil {
+		return nil, err
+	}
+	ownership, err := claimNormalVisualWorkOwnership(installed.StateDir, deps.AgentManager, func(ordinaryManager *agent.Manager) (bool, error) {
+		runner, health, configureErr := configureNormalVisualWorkRunner(
+			installed, controller, lifecycle, deps.Scheduler, ordinaryManager,
+			deps.GitHub, deps.GitTransportToken, readiness.Ready, deps.Logger,
+		)
+		if configureErr != nil || runner == nil {
+			return false, configureErr
+		}
+		instance.runner = runner
+		instance.health = health
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if ownership == nil {
+		return nil, errors.New("normal Visual Hive runtime did not acquire ordinary-Manager ownership")
+	}
+	instance.readiness = readiness
+	instance.ownership = ownership
+	return instance, nil
+}
+
+func (runtime *concreteNormalVisualRuntime) Binding() normalVisualRuntimeBinding {
+	if runtime == nil {
+		return normalVisualRuntimeBinding{}
+	}
+	return runtime.binding
+}
+
+func (runtime *concreteNormalVisualRuntime) Start(parent context.Context) error {
+	if runtime == nil {
+		return errors.New("normal Visual Hive runtime is unavailable")
+	}
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	if runtime.started {
+		return nil
+	}
+	if runtime.runner == nil {
+		runtime.started = true
+		return nil
+	}
+	if parent == nil {
+		return errors.New("normal Visual Hive runtime requires the ordinary Hive process context")
+	}
+	if runtime.readiness == nil || runtime.health == nil || runtime.ownership == nil {
+		return errors.New("normal Visual Hive runtime start bindings are incomplete")
+	}
+	if err := runtime.readiness.Activate(time.Now().UTC()); err != nil {
+		runtime.cleanupUnstarted()
+		return fmt.Errorf("activate normal Visual Hive dashboard readiness: %w", err)
+	}
+	if err := runtime.health.Initialize(); err != nil {
+		runtime.cleanupUnstarted()
+		return fmt.Errorf("initialize normal Visual Hive health: %w", err)
+	}
+	runnerContext, cancelRunner := context.WithCancel(parent)
+	runnerDone := make(chan struct{})
+	runtime.stopper = &normalVisualRuntimeStopper{
+		cancel:  cancelRunner,
+		done:    runnerDone,
+		manager: runtime.manager,
+		resetSpecialists: func() error {
+			return runtime.manager.ResetSpecialistChildDispatcher(filepath.Join(runtime.binding.StateDir, "repair"))
+		},
+		logger: runtime.logger,
+		releaseOwnership: func() {
+			if runtime.readiness != nil {
+				if err := runtime.readiness.Stop(); err != nil {
+					runtime.logger.Warn("remove normal Visual Hive dashboard readiness during uninstall", "error", err)
+				}
+			}
+			releaseDaemonLease(runtime.ownership)
+			runtime.ownership = nil
+		},
+	}
+	runner := runtime.runner
+	go func() {
+		defer close(runnerDone)
+		runner.Run(runnerContext)
+	}()
+	runtime.started = true
+	return nil
+}
+
+func (runtime *concreteNormalVisualRuntime) Trigger(ctx context.Context) error {
+	runtime.mu.Lock()
+	runner, started := runtime.runner, runtime.started
+	runtime.mu.Unlock()
+	if !started || runner == nil {
+		return errors.New("normal Visual Hive service is not running in this dashboard process")
+	}
+	return runner.Trigger(ctx)
+}
+
+func (runtime *concreteNormalVisualRuntime) Import(ctx context.Context, source hivegithub.VerifiedVisualHiveArtifact) (visualcontroller.Result, error) {
+	if runtime == nil || runtime.controller == nil {
+		return visualcontroller.Result{}, errors.New("normal Visual Hive work service is not configured")
+	}
+	return runtime.controller.Import(ctx, source)
+}
+
+func (runtime *concreteNormalVisualRuntime) Stop(ctx context.Context) error {
+	if runtime == nil {
+		return nil
+	}
+	runtime.mu.Lock()
+	stopper, runner := runtime.stopper, runtime.runner
+	runtime.mu.Unlock()
+	if runner != nil {
+		if stopper == nil {
+			return errors.New("normal Visual Hive runtime stop bindings are incomplete")
+		}
+		if err := stopper.Stop(ctx); err != nil {
+			return err
+		}
+	}
+	runtime.mu.Lock()
+	runtime.started = false
+	runtime.stopper = nil
+	runtime.runner = nil
+	runtime.controller = nil
+	runtime.mu.Unlock()
+	return nil
+}
+
+func (runtime *concreteNormalVisualRuntime) ClearDashboardReadiness() error {
+	if runtime == nil || runtime.readiness == nil {
+		return nil
+	}
+	return runtime.readiness.Stop()
+}
+
+func (runtime *concreteNormalVisualRuntime) ReleaseOnProcessExit() {
+	if runtime == nil {
+		return
+	}
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	if runtime.stopper != nil && runtime.stopper.cancel != nil {
+		runtime.stopper.cancel()
+	}
+	if runtime.readiness != nil {
+		if err := runtime.readiness.Stop(); err != nil && runtime.logger != nil {
+			runtime.logger.Warn("remove normal Visual Hive dashboard readiness on process exit", "error", err)
+		}
+	}
+	releaseDaemonLease(runtime.ownership)
+	runtime.ownership = nil
+	runtime.started = false
+}
+
+func (runtime *concreteNormalVisualRuntime) BeadDirs() []string {
+	if runtime == nil {
+		return nil
+	}
+	return append([]string(nil), runtime.beadDirs...)
+}
+
+func (runtime *concreteNormalVisualRuntime) cleanupUnstarted() {
+	if runtime.readiness != nil {
+		_ = runtime.readiness.Stop()
+	}
+	if runtime.manager != nil {
+		_ = runtime.manager.ResetSpecialistChildDispatcher(filepath.Join(runtime.binding.StateDir, "repair"))
+	}
+	releaseDaemonLease(runtime.ownership)
+	runtime.ownership = nil
+}
+
+func normalVisualBinding(installed integrated.Config) (normalVisualRuntimeBinding, error) {
+	stateDir, err := canonicalNormalVisualPath(installed.StateDir)
+	if err != nil {
+		return normalVisualRuntimeBinding{}, fmt.Errorf("bind normal Visual Hive state directory: %w", err)
+	}
+	checkoutDir, err := canonicalNormalVisualPath(installed.CheckoutDir)
+	if err != nil {
+		return normalVisualRuntimeBinding{}, fmt.Errorf("bind normal Visual Hive checkout directory: %w", err)
+	}
+	repository := strings.ToLower(strings.TrimSpace(installed.Repository))
+	if repository == "" {
+		return normalVisualRuntimeBinding{}, errors.New("bind normal Visual Hive runtime: repository is empty")
+	}
+	binding := struct {
+		Repository         string                   `json:"repository"`
+		RepositoryID       string                   `json:"repository_id"`
+		DefaultBranch      string                   `json:"default_branch"`
+		StateDir           string                   `json:"state_dir"`
+		CheckoutDir        string                   `json:"checkout_dir"`
+		RuntimeOwner       runtimeOwnerIntent       `json:"runtime_owner"`
+		Coverage           integrated.Coverage      `json:"coverage"`
+		Automation         integrated.Automation    `json:"automation"`
+		ExecutionMode      integrated.ExecutionMode `json:"execution_mode"`
+		ACMMLevel          int                      `json:"acmm_level"`
+		ProviderCommand    string                   `json:"provider_command"`
+		ProviderArgs       []string                 `json:"provider_args"`
+		RunIntervalSeconds int64                    `json:"run_interval_seconds"`
+		VisualHiveRef      string                   `json:"visual_hive_ref"`
+		VisualHiveCommand  string                   `json:"visual_hive_command"`
+		VisualHiveArgs     []string                 `json:"visual_hive_args"`
+		VisualConfigDigest string                   `json:"visual_config_digest"`
+		TestCommands       [][]string               `json:"test_commands"`
+		AllowedRepairPaths []string                 `json:"allowed_repair_paths"`
+	}{
+		Repository: repository, RepositoryID: strings.TrimSpace(installed.RepositoryID),
+		DefaultBranch: strings.TrimSpace(installed.DefaultBranch), StateDir: stateDir, CheckoutDir: checkoutDir,
+		RuntimeOwner: configuredRuntimeOwnerIntent(installed), Coverage: installed.Coverage,
+		Automation: installed.Automation, ExecutionMode: installed.ExecutionMode, ACMMLevel: installed.ACMMLevel,
+		ProviderCommand: strings.TrimSpace(installed.ProviderCommand), ProviderArgs: append([]string(nil), installed.ProviderArgs...),
+		RunIntervalSeconds: installed.RunIntervalSeconds, VisualHiveRef: strings.TrimSpace(installed.VisualHiveRef),
+		VisualHiveCommand: strings.TrimSpace(installed.VisualHiveCommand), VisualHiveArgs: append([]string(nil), installed.VisualHiveArgs...),
+		VisualConfigDigest: strings.TrimSpace(installed.VisualHiveConfigDigest),
+		TestCommands:       cloneNormalVisualCommands(installed.TestCommands),
+		AllowedRepairPaths: append([]string(nil), installed.AllowedRepairPaths...),
+	}
+	data, err := json.Marshal(binding)
+	if err != nil {
+		return normalVisualRuntimeBinding{}, err
+	}
+	sum := sha256.Sum256(data)
+	return normalVisualRuntimeBinding{
+		Digest: hex.EncodeToString(sum[:]), Repository: repository, StateDir: stateDir,
+	}, nil
+}
+
+func cloneNormalVisualCommands(source [][]string) [][]string {
+	result := make([][]string, len(source))
+	for index, command := range source {
+		result[index] = append([]string(nil), command...)
+	}
+	return result
+}
+
+func canonicalNormalVisualPath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", errors.New("path is empty")
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	absolute = filepath.Clean(absolute)
+	if runtime.GOOS == "windows" {
+		absolute = strings.ToLower(absolute)
+	}
+	return absolute, nil
+}
+
+func cloneNormalVisualBeadStores(source map[string]*beads.Store) map[string]*beads.Store {
+	result := make(map[string]*beads.Store, len(source))
+	for role, store := range source {
+		result[role] = store
+	}
+	return result
+}
+
+func cloneNormalVisualBeadDirs(source map[string]string) map[string]string {
+	result := make(map[string]string, len(source))
+	for role, dir := range source {
+		result[role] = dir
+	}
+	return result
+}
+
+func sortedNormalVisualBeadDirs(source map[string]string) []string {
+	dirs := make([]string, 0, len(source))
+	for _, dir := range source {
+		if trimmed := strings.TrimSpace(dir); trimmed != "" {
+			dirs = append(dirs, trimmed)
+		}
+	}
+	sort.Strings(dirs)
+	return dirs
+}

--- a/v2/cmd/hive/normal_visual_runtime_manager_test.go
+++ b/v2/cmd/hive/normal_visual_runtime_manager_test.go
@@ -1,0 +1,313 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	hivegithub "github.com/kubestellar/hive/v2/pkg/github"
+	"github.com/kubestellar/hive/v2/pkg/integrated"
+	visualcontroller "github.com/kubestellar/hive/v2/pkg/visualhive/controller"
+)
+
+type fakeNormalVisualRuntime struct {
+	binding   normalVisualRuntimeBinding
+	startErr  error
+	starts    atomic.Int32
+	triggers  atomic.Int32
+	stops     atomic.Int32
+	releases  atomic.Int32
+	readiness atomic.Int32
+}
+
+func (runtime *fakeNormalVisualRuntime) Binding() normalVisualRuntimeBinding {
+	return runtime.binding
+}
+
+func (runtime *fakeNormalVisualRuntime) Start(context.Context) error {
+	runtime.starts.Add(1)
+	return runtime.startErr
+}
+
+func (runtime *fakeNormalVisualRuntime) Trigger(context.Context) error {
+	runtime.triggers.Add(1)
+	return nil
+}
+
+func (runtime *fakeNormalVisualRuntime) Import(context.Context, hivegithub.VerifiedVisualHiveArtifact) (visualcontroller.Result, error) {
+	return visualcontroller.Result{}, nil
+}
+
+func (runtime *fakeNormalVisualRuntime) Stop(context.Context) error {
+	runtime.stops.Add(1)
+	return nil
+}
+
+func (runtime *fakeNormalVisualRuntime) ClearDashboardReadiness() error {
+	runtime.readiness.Add(1)
+	return nil
+}
+
+func (runtime *fakeNormalVisualRuntime) ReleaseOnProcessExit() {
+	runtime.releases.Add(1)
+}
+
+func (runtime *fakeNormalVisualRuntime) BeadDirs() []string {
+	return []string{"/data/beads/quality", "/data/beads/security"}
+}
+
+type testNormalVisualContract struct {
+	mu     sync.Mutex
+	config integrated.Config
+	exists bool
+	err    error
+}
+
+func (contract *testNormalVisualContract) load(*config.Config) (integrated.Config, bool, error) {
+	contract.mu.Lock()
+	defer contract.mu.Unlock()
+	return contract.config, contract.exists, contract.err
+}
+
+func (contract *testNormalVisualContract) set(config integrated.Config, exists bool, err error) {
+	contract.mu.Lock()
+	contract.config, contract.exists, contract.err = config, exists, err
+	contract.mu.Unlock()
+}
+
+func testInstalledNormalVisualContract(t *testing.T, stateDir string) integrated.Config {
+	t.Helper()
+	checkoutDir := t.TempDir()
+	return integrated.Config{
+		Repository: "owner/repository", RepositoryID: "123", DefaultBranch: "main",
+		Automation: integrated.AutomationRepairPR, ExecutionMode: integrated.ExecutionLocal,
+		ProviderCommand: "codex", ProviderArgs: []string{"exec"},
+		RunIntervalSeconds: 60, VisualHive: true, VisualHiveRef: strings.Repeat("a", 40),
+		VisualHiveCommand: "node", VisualHiveArgs: []string{"visual-hive.js"},
+		StateDir: stateDir, CheckoutDir: checkoutDir,
+	}
+}
+
+func newTestNormalVisualRuntimeManager(
+	t *testing.T,
+	contract *testNormalVisualContract,
+	factory func(normalVisualRuntimeBinding) *fakeNormalVisualRuntime,
+) (*normalVisualRuntimeManager, *atomic.Int32, *[]*fakeNormalVisualRuntime) {
+	t.Helper()
+	var factoryCalls atomic.Int32
+	var instancesMu sync.Mutex
+	instances := []*fakeNormalVisualRuntime{}
+	manager := &normalVisualRuntimeManager{
+		process: context.Background(), normal: &config.Config{}, load: contract.load,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)), beadDirs: []string{"/data/beads/ordinary"},
+	}
+	manager.factory = func(installed integrated.Config) (normalVisualRuntimeInstance, error) {
+		factoryCalls.Add(1)
+		binding, err := normalVisualBinding(installed)
+		if err != nil {
+			return nil, err
+		}
+		instance := factory(binding)
+		instancesMu.Lock()
+		instances = append(instances, instance)
+		instancesMu.Unlock()
+		return instance, nil
+	}
+	return manager, &factoryCalls, &instances
+}
+
+func TestNormalVisualRuntimeManagerHotActivatesExactlyOnce(t *testing.T) {
+	stateDir := t.TempDir()
+	contract := &testNormalVisualContract{}
+	manager, factoryCalls, instances := newTestNormalVisualRuntimeManager(t, contract, func(binding normalVisualRuntimeBinding) *fakeNormalVisualRuntime {
+		return &fakeNormalVisualRuntime{binding: binding}
+	})
+	if active, err := manager.Ensure(context.Background()); err != nil || active {
+		t.Fatalf("dormant ensure active=%t err=%v", active, err)
+	}
+	contract.set(testInstalledNormalVisualContract(t, stateDir), true, nil)
+
+	const callers = 32
+	var wait sync.WaitGroup
+	errs := make(chan error, callers)
+	for range callers {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			active, err := manager.Ensure(context.Background())
+			if err != nil {
+				errs <- err
+			} else if !active {
+				errs <- errors.New("runtime did not become active")
+			}
+		}()
+	}
+	wait.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+	if factoryCalls.Load() != 1 || len(*instances) != 1 || (*instances)[0].starts.Load() != 1 {
+		t.Fatalf("factory=%d instances=%d starts=%d", factoryCalls.Load(), len(*instances), (*instances)[0].starts.Load())
+	}
+	if err := manager.Trigger(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if (*instances)[0].triggers.Load() != 1 {
+		t.Fatalf("triggers=%d", (*instances)[0].triggers.Load())
+	}
+}
+
+func TestNormalVisualRuntimeManagerFailsClosedOnBindingDrift(t *testing.T) {
+	stateDir := t.TempDir()
+	installed := testInstalledNormalVisualContract(t, stateDir)
+	contract := &testNormalVisualContract{config: installed, exists: true}
+	manager, factoryCalls, instances := newTestNormalVisualRuntimeManager(t, contract, func(binding normalVisualRuntimeBinding) *fakeNormalVisualRuntime {
+		return &fakeNormalVisualRuntime{binding: binding}
+	})
+	if active, err := manager.Ensure(context.Background()); err != nil || !active {
+		t.Fatalf("initial ensure active=%t err=%v", active, err)
+	}
+	installed.VisualHiveRef = strings.Repeat("b", 40)
+	contract.set(installed, true, nil)
+	if active, err := manager.Ensure(context.Background()); err == nil || active || !strings.Contains(err.Error(), "managed stop/rebind") {
+		t.Fatalf("drift ensure active=%t err=%v", active, err)
+	}
+	if factoryCalls.Load() != 1 || len(*instances) != 1 {
+		t.Fatalf("factory=%d instances=%d", factoryCalls.Load(), len(*instances))
+	}
+}
+
+func TestNormalVisualRuntimeBindingIgnoresLifecycleOnlyChanges(t *testing.T) {
+	installed := testInstalledNormalVisualContract(t, t.TempDir())
+	first, err := normalVisualBinding(installed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	installed.Paused = true
+	installed.UpdatedAt = time.Now().UTC()
+	installed.SetupPRNumber = 42
+	second, err := normalVisualBinding(installed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Digest != second.Digest {
+		t.Fatalf("lifecycle-only state changed runtime binding: first=%s second=%s", first.Digest, second.Digest)
+	}
+	installed.TestCommands = [][]string{{"go", "test", "./..."}}
+	third, err := normalVisualBinding(installed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if third.Digest == second.Digest {
+		t.Fatal("static runtime command change did not change the binding")
+	}
+}
+
+func TestNormalVisualRuntimeManagerStopAllowsManagedReinstall(t *testing.T) {
+	stateDir := t.TempDir()
+	contract := &testNormalVisualContract{config: testInstalledNormalVisualContract(t, stateDir), exists: true}
+	manager, factoryCalls, instances := newTestNormalVisualRuntimeManager(t, contract, func(binding normalVisualRuntimeBinding) *fakeNormalVisualRuntime {
+		return &fakeNormalVisualRuntime{binding: binding}
+	})
+	if active, err := manager.Ensure(context.Background()); err != nil || !active {
+		t.Fatalf("initial ensure active=%t err=%v", active, err)
+	}
+	if err := manager.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if active, err := manager.ResumeReconciliation(context.Background()); err != nil || !active {
+		t.Fatalf("reinstall ensure active=%t err=%v", active, err)
+	}
+	if factoryCalls.Load() != 2 || len(*instances) != 2 ||
+		(*instances)[0].stops.Load() != 1 || (*instances)[1].starts.Load() != 1 {
+		t.Fatalf("factory=%d instances=%d first_stops=%d second_starts=%d",
+			factoryCalls.Load(), len(*instances), (*instances)[0].stops.Load(), (*instances)[1].starts.Load())
+	}
+}
+
+func TestNormalVisualRuntimeManagerStopSuppressesObserverUntilManagedResume(t *testing.T) {
+	stateDir := t.TempDir()
+	contract := &testNormalVisualContract{config: testInstalledNormalVisualContract(t, stateDir), exists: true}
+	manager, factoryCalls, _ := newTestNormalVisualRuntimeManager(t, contract, func(binding normalVisualRuntimeBinding) *fakeNormalVisualRuntime {
+		return &fakeNormalVisualRuntime{binding: binding}
+	})
+	if active, err := manager.Ensure(context.Background()); err != nil || !active {
+		t.Fatalf("initial ensure active=%t err=%v", active, err)
+	}
+	if err := manager.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go manager.Observe(ctx, time.Millisecond)
+	time.Sleep(25 * time.Millisecond)
+	cancel()
+	if factoryCalls.Load() != 1 {
+		t.Fatalf("observer restarted a lifecycle-suppressed runtime: factory=%d", factoryCalls.Load())
+	}
+	if active, err := manager.ResumeReconciliation(context.Background()); err != nil || !active {
+		t.Fatalf("managed resume active=%t err=%v", active, err)
+	}
+	if factoryCalls.Load() != 2 {
+		t.Fatalf("managed resume factory=%d", factoryCalls.Load())
+	}
+}
+
+func TestNormalVisualRuntimeManagerActivationFailureLeavesNoActiveRuntime(t *testing.T) {
+	stateDir := t.TempDir()
+	contract := &testNormalVisualContract{config: testInstalledNormalVisualContract(t, stateDir), exists: true}
+	manager, factoryCalls, instances := newTestNormalVisualRuntimeManager(t, contract, func(binding normalVisualRuntimeBinding) *fakeNormalVisualRuntime {
+		return &fakeNormalVisualRuntime{binding: binding, startErr: errors.New("readiness unavailable")}
+	})
+	if active, err := manager.Ensure(context.Background()); err == nil || active {
+		t.Fatalf("failed ensure active=%t err=%v", active, err)
+	}
+	if manager.active != nil || factoryCalls.Load() != 1 || (*instances)[0].releases.Load() != 1 {
+		t.Fatalf("active=%v factory=%d releases=%d", manager.active, factoryCalls.Load(), (*instances)[0].releases.Load())
+	}
+}
+
+func TestNormalVisualRuntimeManagerObserverActivatesLateContract(t *testing.T) {
+	stateDir := t.TempDir()
+	contract := &testNormalVisualContract{}
+	manager, factoryCalls, _ := newTestNormalVisualRuntimeManager(t, contract, func(binding normalVisualRuntimeBinding) *fakeNormalVisualRuntime {
+		return &fakeNormalVisualRuntime{binding: binding}
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go manager.Observe(ctx, time.Millisecond)
+	contract.set(testInstalledNormalVisualContract(t, stateDir), true, nil)
+	deadline := time.Now().Add(2 * time.Second)
+	for factoryCalls.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if factoryCalls.Load() != 1 {
+		t.Fatalf("observer factory calls=%d", factoryCalls.Load())
+	}
+}
+
+func TestDashboardTriggerLazilyReconcilesNormalVisualRuntime(t *testing.T) {
+	stateDir := t.TempDir()
+	contract := &testNormalVisualContract{config: testInstalledNormalVisualContract(t, stateDir), exists: true}
+	manager, factoryCalls, instances := newTestNormalVisualRuntimeManager(t, contract, func(binding normalVisualRuntimeBinding) *fakeNormalVisualRuntime {
+		return &fakeNormalVisualRuntime{binding: binding}
+	})
+	original := dashboardNormalVisualRuntime.Load()
+	dashboardNormalVisualRuntime.Store(manager)
+	t.Cleanup(func() { dashboardNormalVisualRuntime.Store(original) })
+	if err := triggerDashboardVisualCycle(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if factoryCalls.Load() != 1 || len(*instances) != 1 ||
+		(*instances)[0].starts.Load() != 1 || (*instances)[0].triggers.Load() != 1 {
+		t.Fatalf("factory=%d instances=%d starts=%d triggers=%d",
+			factoryCalls.Load(), len(*instances), (*instances)[0].starts.Load(), (*instances)[0].triggers.Load())
+	}
+}

--- a/v2/cmd/hive/visual_work_controller.go
+++ b/v2/cmd/hive/visual_work_controller.go
@@ -16,8 +16,6 @@ import (
 	visualcontroller "github.com/kubestellar/hive/v2/pkg/visualhive/controller"
 )
 
-var normalVisualWorkService *visualcontroller.Controller
-
 type dashboardVisualWorkAudit struct{ server *dashboard.Server }
 
 func (sink dashboardVisualWorkAudit) RecordVisualWorkAudit(_ context.Context, event visualcontroller.AuditEvent) error {
@@ -101,10 +99,11 @@ func normalProjectContainsRepository(project config.ProjectConfig, repository st
 }
 
 func importNormalVisualWork(ctx context.Context, source hivegithub.VerifiedVisualHiveArtifact) (visualcontroller.Result, error) {
-	if normalVisualWorkService == nil {
+	normalVisualRuntime := dashboardNormalVisualRuntime.Load()
+	if normalVisualRuntime == nil {
 		return visualcontroller.Result{}, errors.New("normal Visual Hive work service is not configured")
 	}
-	return normalVisualWorkService.Import(ctx, source)
+	return normalVisualRuntime.Import(ctx, source)
 }
 
 func visualLifecycleForInstalledContract(installed integrated.Config) (*visualhive.LifecycleStore, error) {

--- a/v2/cmd/hive/visual_work_service.go
+++ b/v2/cmd/hive/visual_work_service.go
@@ -23,11 +23,6 @@ import (
 	"github.com/kubestellar/hive/v2/pkg/visualhive/normalservice"
 )
 
-var (
-	normalVisualWorkRunner       *normalservice.Service
-	normalVisualWorkHealthWriter *normalVisualServiceHealthReporter
-)
-
 const (
 	normalVisualArtifactFetchTimeout = 45 * time.Minute
 	normalVisualRepairModelTimeout   = 20 * time.Minute
@@ -286,11 +281,6 @@ func configureNormalVisualWorkRunner(
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := manager.ConfigureSpecialistChildDispatcher(agent.SpecialistChildDispatcherOptions{
-		RepairStateRoot: filepath.Join(installed.StateDir, "repair"), Executor: executor,
-	}); err != nil {
-		return nil, nil, err
-	}
 	loader := func() (integrated.Config, int, error) {
 		current, exists, err := loadAuthoritativeVisualWorkContract()
 		if err != nil {
@@ -352,6 +342,14 @@ func configureNormalVisualWorkRunner(
 		Verdict: verdict, Logger: logger, OnCycleStart: health.StartCycle, OnCycle: health.RecordCycle, OnInactive: health.RecordInactive,
 	})
 	if err != nil {
+		return nil, nil, err
+	}
+	// Configure the ordinary Manager only after every other fallible runtime
+	// dependency has been constructed. A failed hot activation must not leave
+	// a half-installed specialist dispatcher behind.
+	if err := manager.ConfigureSpecialistChildDispatcher(agent.SpecialistChildDispatcherOptions{
+		RepairStateRoot: filepath.Join(installed.StateDir, "repair"), Executor: executor,
+	}); err != nil {
 		return nil, nil, err
 	}
 	return service, health, nil

--- a/v2/pkg/agent/specialist_child_dispatch.go
+++ b/v2/pkg/agent/specialist_child_dispatch.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -172,6 +173,36 @@ func (m *Manager) ConfigureSpecialistChildDispatcher(options SpecialistChildDisp
 	}
 	m.specialistChildExecutor = options.Executor
 	m.specialistChildRoot = childRoot
+	return nil
+}
+
+// ResetSpecialistChildDispatcher clears only the one-shot specialist transport
+// after the runtime that owned it has proven every child stopped. It leaves the
+// ordinary persistent agents untouched and permits a later managed Visual Hive
+// install to bind a fresh state root without restarting ordinary Hive.
+func (m *Manager) ResetSpecialistChildDispatcher(repairStateRoot string) error {
+	if m == nil {
+		return nil
+	}
+	repairStateRoot = filepath.Clean(strings.TrimSpace(repairStateRoot))
+	if repairStateRoot == "." || !filepath.IsAbs(repairStateRoot) {
+		return errors.New("specialist child dispatcher reset requires the exact absolute repair state root")
+	}
+	expectedChildRoot := filepath.Join(repairStateRoot, "specialist-children")
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.specialistChildren) != 0 {
+		return errors.New("cannot reset specialist child dispatcher while children are active")
+	}
+	if m.specialistChildRoot != "" {
+		configuredRoot, expectedRoot := filepath.Clean(m.specialistChildRoot), filepath.Clean(expectedChildRoot)
+		if configuredRoot != expectedRoot && !(runtime.GOOS == "windows" && strings.EqualFold(configuredRoot, expectedRoot)) {
+			return errors.New("refuse to reset specialist child dispatcher for a different repair state root")
+		}
+	}
+	m.specialistChildExecutor = nil
+	m.specialistChildRoot = ""
+	m.specialistsDown = false
 	return nil
 }
 

--- a/v2/pkg/agent/specialist_child_dispatch_test.go
+++ b/v2/pkg/agent/specialist_child_dispatch_test.go
@@ -277,6 +277,32 @@ func configureTestSpecialistChild(t *testing.T, manager *Manager, executor Speci
 	return state
 }
 
+func TestResetSpecialistChildDispatcherRequiresNoActiveChildrenAndAllowsRebind(t *testing.T) {
+	manager := &Manager{specialistChildren: make(map[SpecialistRole]*specialistChildSession)}
+	first := &fakeSpecialistChildExecutor{identity: testSpecialistChildIdentity("codex")}
+	firstState := configureTestSpecialistChild(t, manager, first)
+	manager.specialistChildren[SpecialistQuality] = &specialistChildSession{}
+	if err := manager.ResetSpecialistChildDispatcher(firstState); err == nil || !strings.Contains(err.Error(), "children are active") {
+		t.Fatalf("active reset error=%v", err)
+	}
+	delete(manager.specialistChildren, SpecialistQuality)
+	manager.specialistsDown = true
+	if err := manager.ResetSpecialistChildDispatcher(filepath.Join(t.TempDir(), "different")); err == nil || !strings.Contains(err.Error(), "different repair state root") {
+		t.Fatalf("mismatched reset error=%v", err)
+	}
+	if err := manager.ResetSpecialistChildDispatcher(firstState); err != nil {
+		t.Fatal(err)
+	}
+	if manager.specialistChildExecutor != nil || manager.specialistChildRoot != "" || manager.specialistsDown {
+		t.Fatal("specialist dispatcher reset left runtime bindings behind")
+	}
+	second := &fakeSpecialistChildExecutor{identity: testSpecialistChildIdentity("codex")}
+	configureTestSpecialistChild(t, manager, second)
+	if manager.specialistChildExecutor != second || manager.specialistChildRoot == "" {
+		t.Fatal("specialist dispatcher did not accept managed rebind")
+	}
+}
+
 func testSpecialistChildDispatchRequest(t *testing.T, identity SpecialistSessionIdentity, kind string) SpecialistDispatchRequest {
 	profile := &SpecialistProposalExecutorProfile{
 		Backend: "codex", ProviderSHA256: identity.ProviderSHA256, Model: identity.ExecutorModel,


### PR DESCRIPTION
## Summary

Hot-activate the existing Visual Hive controller after a managed installation without restarting the Hive dashboard process.

The dashboard previously constructed the Visual Hive controller only during process startup. A setup transaction could install a valid contract while Hive was already running, but the same process would continue reporting no active Visual Hive service until the pod restarted.

This change:

- extracts the existing controller/service startup into one mutex-protected in-process runtime manager;
- reconciles after dashboard readiness, successful setup apply, successful setup replay, dashboard trigger, and a lightweight contract observer;
- binds the live runtime to the authoritative repository, state, owner, configuration, command, and repair-policy identity;
- treats the same binding as an idempotent no-op and rejects active binding drift until managed uninstall/rebind;
- reuses the existing ordinary Manager, Scheduler, controller, lease, readiness gate, health writer, and shutdown path;
- suppresses observer reactivation during uninstall and permits a fresh managed install only after specialist children are quiescent;
- preserves a successfully completed setup transaction when activation is temporarily pending, returning a separate hashed activation status that can be retried;
- leaves ordinary Hive unchanged and Visual Hive dormant when no installed contract exists.

No new scheduler, dashboard button, state owner, arbitrary command endpoint, or GitHub writer is introduced. Visual Hive remains evidence-only, and its embedded pin remains `1de3765924043ba87d46f200e8883b9233d94a18`.

## Safety properties

- Concurrent startup, setup, replay, observer, status, and trigger paths cannot create duplicate controllers or leases.
- Partial initialization releases readiness, specialist-dispatch, and ownership resources.
- Pending setup/baseline state can initialize the runtime but remains held by the existing production gates.
- Managed uninstall stops only Visual Hive; ordinary Hive continues.
- Repository, state, owner, contract, and factory-binding mismatches fail closed.
- Repeated setup replay does not rerun or duplicate the completed setup mutation.

## Validation

Validated on the exact candidate `e62911091d6136e19886c6ce8108c10d0e5cec0d`, rebased on `dd@e4319b3df0911f970e62e3f521608d9506ea08b1`:

- `go build ./...`
- `go vet ./...`
- complete Linux package suite
- canonical race suite across Hive startup, agent, config, dashboard, trajectory, integrated, and Visual Hive packages
- focused hot-activation, setup/replay, trigger, ownership, baseline, pause/resume, and uninstall regressions
- two identical production-shaped lifecycle repetitions with unchanged source
- repository credential-literal guard and credential-isolation tests
- actionlint for production workflows and generated hosted-controller workflow validation
- `govulncheck` with Go 1.26.5: no called vulnerabilities
- dashboard proxy tests
- Docker build and entrypoint/dormant boot smoke

The immutable local qualification image is `sha256:3b98e704eeefb59dd884c2a808a553659fab4b220e4be6f966040054eccfa0df`; it reports Hive commit `e62911091d6136e19886c6ce8108c10d0e5cec0d` and embeds the exact Visual Hive pin above. A network-isolated ordinary-Hive boot reached `{"status":"ok"}` with no installed Visual Hive state.

Three unrelated tests were excluded from aggregate runner gates only after reproducing identically on the untouched `34f4af9d` parent: one tmux menu interaction test and two GitHub device-flow scope expectation tests. Two credential-inventory tests were also excluded from the read-only Docker worktree mount because its Windows `.git` indirection is not valid inside Linux; both pass on the exact candidate in a valid Git worktree.
