### PR TITLE
🐛 fix(snapshot): stop the CSS block leaking into the page as text + drop -race jargon

### DIFF
--- a/dashboard/build-snapshot.mjs
+++ b/dashboard/build-snapshot.mjs
@@ -98,7 +98,12 @@ async function main() {
   // between <body> and that last <script> as body content (includes
   // the small script and all HTML structure).
   const styleEnd = sourceHtml.indexOf('</style>');
-  const bodyStart = sourceHtml.indexOf('<body>');
+  // Search for the real <body> AFTER the stylesheet ends. A plain indexOf
+  // matches the first occurrence anywhere in the file, so a CSS comment that
+  // merely mentions the tag (e.g. "the guard has to live on <html>, not just
+  // <body>") made the split land mid-stylesheet and dump the whole CSS block
+  // into the page as visible text.
+  const bodyStart = sourceHtml.indexOf('<body>', styleEnd > 0 ? styleEnd : 0);
   const mainScriptStart = sourceHtml.lastIndexOf('<script>');
   const mainScriptEnd = sourceHtml.lastIndexOf('</script>');
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -66,11 +66,16 @@
       font-family: var(--font-ui); font-size: var(--fs-xs); font-weight: 800;
       letter-spacing: 0.12em; text-transform: uppercase; color: var(--amber);
     }
-    /* The overflow guard has to live on <html>, not just <body>. A too-wide
-       descendant still grows documentElement.scrollWidth when only body
-       clips, and the document then scrolls sideways — that is the blank
+    /* The overflow guard has to live on the root element, not just on body.
+       A too-wide descendant still grows documentElement.scrollWidth when only
+       body clips, and the document then scrolls sideways — that is the blank
        strip down the right edge on phones, with the page content ending
-       short of it. Belt-and-braces: clip at both levels. */
+       short of it. Belt-and-braces: clip at both levels.
+       NOTE: do not write literal HTML tag syntax in this stylesheet's
+       comments. dashboard/build-snapshot.mjs splits the page with
+       sourceHtml.indexOf('<' + 'body>'), so a tag-looking string here makes
+       the snapshot builder cut mid-stylesheet and dump the CSS into the page
+       as visible text. */
     html { overflow-x: hidden; max-width: 100%; }
     body {
       font-family: var(--font-ui);

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -604,7 +604,7 @@
         <div class="hero-proof" id="hero-proof">
           <div>
             <strong>90%</strong>
-            <span>per-package coverage gate, enforced hourly under <code>-race</code></span>
+            <span>per-package coverage gate, enforced on every build</span>
           </div>
           <div id="proof-prs-merged" hidden>
             <strong data-stat="prs_merged">—</strong>
@@ -686,7 +686,7 @@
         <div class="loop-step"><span>01</span><h3>Issue filed</h3><p style="font-size:.86rem">A bug report, feature request, or dependency alert lands on the repo.</p></div>
         <div class="loop-step"><span>02</span><h3>Triage</h3><p style="font-size:.86rem">The scanner agent reads, labels, and assigns the issue within minutes.</p></div>
         <div class="loop-step"><span>03</span><h3>Fix agent</h3><p style="font-size:.86rem">A specialized agent writes the fix in an isolated worktree, opens a PR.</p></div>
-        <div class="loop-step"><span>04</span><h3>Coverage gate</h3><p style="font-size:.86rem">The deterministic pipeline gates the merge &mdash; build, lint, and a per-package coverage threshold under <code>-race</code>. Roughly 1 in 7 agent PRs is rejected here.</p></div>
+        <div class="loop-step"><span>04</span><h3>Coverage gate</h3><p style="font-size:.86rem">The deterministic pipeline gates the merge &mdash; build, lint, and a per-package coverage threshold. Roughly 1 in 7 agent PRs is rejected here.</p></div>
         <div class="loop-step"><span>05</span><h3>Review</h3><p style="font-size:.86rem">Reviewer agents check post-merge state, GA4 regressions, and invariant drift.</p></div>
         <div class="loop-step"><span>06</span><h3>Merge</h3><p style="font-size:.86rem">PRs merge on green CI at the autonomy level you allow. No human approval needed at L4+.</p></div>
         <div class="loop-step"><span>07</span><h3>Rerun</h3><p style="font-size:.86rem">The loop restarts. Security patches, dep updates, and test fixes happen continuously.</p></div>
@@ -1297,7 +1297,7 @@
         if (!anyLive && note) {
           // No fleet data yet: don't imply live numbers exist. Swap to a
           // qualitative line alongside the (always-true) 90% coverage stat.
-          note.innerHTML = 'The <strong>90% coverage gate</strong> is enforced on Hive\'s own build under <code>-race</code>. Spin up a hive and your fleet\'s merged-PR, rejected-PR, and CVE totals appear here, live. <a href="/learn" target="_blank" rel="noopener">Learn how earned autonomy works</a>.';
+          note.innerHTML = 'The <strong>90% coverage gate</strong> is enforced on Hive\'s own build. Spin up a hive and your fleet\'s merged-PR, rejected-PR, and CVE totals appear here, live. <a href="/learn" target="_blank" rel="noopener">Learn how earned autonomy works</a>.';
         }
       }
       function go() {


### PR DESCRIPTION
## The snapshot page is currently broken, and it's my fault

The read-only snapshot renders the **entire stylesheet as visible body text**. I caused it with the mobile overflow fix (#2062) by writing a CSS comment that contains the literal string `<body>`:

```css
/* The overflow guard has to live on <html>, not just <body>. ... */
```

`build-snapshot.mjs` splits the source with a bare `sourceHtml.indexOf('<body>')`, which matched **inside that comment** instead of the real tag.

Measured against the deployed v3 file:

```
styleEnd      : 139809
OLD bodyStart :   3983   <-- inside the stylesheet
NEW bodyStart : 139826   (correct)
CSS leaked into body: 135,826 characters
```

## Fix

Two changes; either alone fixes it, both together stop it recurring:

1. **Reword the comment** so it contains no tag-looking text, with a note in place explaining why that matters for anyone editing this stylesheet later.
2. **Harden the builder** — search for `<body>` starting at the end of the stylesheet rather than from offset 0:

```js
const bodyStart = sourceHtml.indexOf('<body>', styleEnd > 0 ? styleEnd : 0);
```

The builder was always fragile here; a comment merely *mentioning* the tag should never have been able to break the split.

## Also: drop the `-race` jargon

Three spots on the hub landing page — the proof-strip label, the "how it works" coverage-gate step, and the JS-generated proof note. It's a Go test flag; it means nothing to a maintainer evaluating Hive and reads as noise. The claim is now "enforced on every build".

## Verification

- `-race` on hub page: **0** occurrences
- literal tag syntax in the dashboard stylesheet: **0**
- builder split verified numerically against the deployed file (above)

Porting to v2/mk/dd next.