### PR TITLE
🐛 fix(snapshot): stop the CSS block leaking into the page as text + drop -race jargon

### DIFF
--- a/dashboard/build-snapshot.mjs
+++ b/dashboard/build-snapshot.mjs
@@ -98,7 +98,11 @@ async function main() {
   // between <body> and that last <script> as body content (includes
   // the small script and all HTML structure).
   const styleEnd = sourceHtml.indexOf('</style>');
-  const bodyStart = sourceHtml.indexOf('<body>');
+  // Search for the real <body> AFTER the stylesheet ends. A plain indexOf
+  // matches the first occurrence anywhere in the file, so a CSS comment that
+  // merely mentions the tag made the split land mid-stylesheet and dump the
+  // whole CSS block into the page as visible text.
+  const bodyStart = sourceHtml.indexOf('<body>', styleEnd > 0 ? styleEnd : 0);
   const mainScriptStart = sourceHtml.lastIndexOf('<script>');
   const mainScriptEnd = sourceHtml.lastIndexOf('</script>');
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -66,11 +66,16 @@
       font-family: var(--font-ui); font-size: var(--fs-xs); font-weight: 800;
       letter-spacing: 0.12em; text-transform: uppercase; color: var(--amber);
     }
-    /* The overflow guard has to live on <html>, not just <body>. A too-wide
-       descendant still grows documentElement.scrollWidth when only body
-       clips, and the document then scrolls sideways — that is the blank
+    /* The overflow guard has to live on the root element, not just on body.
+       A too-wide descendant still grows documentElement.scrollWidth when only
+       body clips, and the document then scrolls sideways — that is the blank
        strip down the right edge on phones, with the page content ending
-       short of it. Belt-and-braces: clip at both levels. */
+       short of it. Belt-and-braces: clip at both levels.
+       NOTE: do not write literal HTML tag syntax in this stylesheet's
+       comments. dashboard/build-snapshot.mjs splits the page with
+       sourceHtml.indexOf('<' + 'body>'), so a tag-looking string here makes
+       the snapshot builder cut mid-stylesheet and dump the CSS into the page
+       as visible text. */
     html { overflow-x: hidden; max-width: 100%; }
     body {
       font-family: var(--font-ui);

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -540,7 +540,7 @@
         <div class="hero-proof">
           <div>
             <strong>90%</strong>
-            <span>per-package coverage gate, enforced hourly under <code>-race</code></span>
+            <span>per-package coverage gate, enforced on every build</span>
           </div>
           <div>
             <strong>~14%</strong>
@@ -622,7 +622,7 @@
         <div class="loop-step"><span>01</span><h3>Issue filed</h3><p style="font-size:.86rem">A bug report, feature request, or dependency alert lands on the repo.</p></div>
         <div class="loop-step"><span>02</span><h3>Triage</h3><p style="font-size:.86rem">The scanner agent reads, labels, and assigns the issue within minutes.</p></div>
         <div class="loop-step"><span>03</span><h3>Fix agent</h3><p style="font-size:.86rem">A specialized agent writes the fix in an isolated worktree, opens a PR.</p></div>
-        <div class="loop-step"><span>04</span><h3>Coverage gate</h3><p style="font-size:.86rem">The deterministic pipeline gates the merge &mdash; build, lint, and a per-package coverage threshold under <code>-race</code>. Roughly 1 in 7 agent PRs is rejected here.</p></div>
+        <div class="loop-step"><span>04</span><h3>Coverage gate</h3><p style="font-size:.86rem">The deterministic pipeline gates the merge &mdash; build, lint, and a per-package coverage threshold. Roughly 1 in 7 agent PRs is rejected here.</p></div>
         <div class="loop-step"><span>05</span><h3>Review</h3><p style="font-size:.86rem">Reviewer agents check post-merge state, GA4 regressions, and invariant drift.</p></div>
         <div class="loop-step"><span>06</span><h3>Merge</h3><p style="font-size:.86rem">PRs merge on green CI at the autonomy level you allow. No human approval needed at L4+.</p></div>
         <div class="loop-step"><span>07</span><h3>Rerun</h3><p style="font-size:.86rem">The loop restarts. Security patches, dep updates, and test fixes happen continuously.</p></div>


### PR DESCRIPTION
Ports the snapshot fix to `dd`. Same change as #2068 (v3).

## The bug

The read-only snapshot renders the **entire stylesheet as visible body text**. A CSS comment added by the mobile overflow fix contains the literal string `<body>`, and `build-snapshot.mjs` splits the source with a bare `sourceHtml.indexOf('<body>')` — which matches **inside the comment** instead of the real tag.

Measured on the deployed v3 file: `bodyStart` resolved to offset **3983** instead of **139826**, leaking **135,826 characters** of CSS into the page.

## Fix

1. Reword the comment so it contains no tag-looking text, with a note explaining why that matters for future edits to this stylesheet.
2. Harden the builder — search for `<body>` starting at the end of the stylesheet:
   ```js
   const bodyStart = sourceHtml.indexOf('<body>', styleEnd > 0 ? styleEnd : 0);
   ```

Either alone fixes it; both together stop it recurring.

## Also: drop `-race`

Three spots on the hub landing page. It's a Go test flag and means nothing to a maintainer evaluating Hive; the claim now reads "enforced on every build".

## Verified on this branch

- `-race` on hub page: **0**
- split check: `styleEnd=138732 bodyStart=138749` — body now resolves after the stylesheet