### PR TITLE
🐛 dashboard: fix cost hourly/daily charts showing only recent hours

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4151,13 +4151,26 @@
         for (const k in models) { const m = models[k]; s += ((m.i || 0) + (m.o || 0)) * (rate[k] || 0); }
         return s;
       };
-      let spend = 0, prev = null, sawWindow = false;
+      // Prefer the per-model token measure (immune to price-table shifts and to
+      // the non-monotonic cumulative counter). But snapshots recorded before the
+      // `models` field existed only carry a cumulative `usd` — those must NOT be
+      // skipped, or every hour older than the field's introduction renders blank
+      // (the "recent hours only" gap). For a legacy entry, fall back to the
+      // cumulative usd and count its positive step-to-step increases the same way.
+      // The two measures live on different scales (priced-token sum vs. cumulative
+      // usd), so a delta must never be taken ACROSS a measure change. Reset prev
+      // whenever the entry's measure type flips, so we only ever difference like
+      // with like — legacy usd runs and new models runs each contribute their own
+      // positive increments to the bucket total.
+      let spend = 0, prev = null, prevKind = null, sawWindow = false;
       for (const e of hist) {
-        if (!e.models || e.timestamp < t0 || e.timestamp > t1) { if (e.models && e.timestamp > t1) break; continue; }
+        if (e.timestamp < t0 || e.timestamp > t1) { if (e.timestamp > t1) break; continue; }
+        const kind = e.models ? 'm' : (typeof e.usd === 'number' ? 'u' : null);
+        if (kind == null) continue;
+        const cur = kind === 'm' ? pricedTok(e.models) : e.usd;
         sawWindow = true;
-        const cur = pricedTok(e.models);
-        if (prev != null && cur > prev) spend += (cur - prev); // count only increases
-        prev = cur;
+        if (prev != null && kind === prevKind && cur > prev) spend += (cur - prev);
+        prev = cur; prevKind = kind;
       }
       return sawWindow ? spend : null;
     }


### PR DESCRIPTION
**Reported:** the Cost → Hourly view shows bars only for the last hour or two; every earlier bucket is blank (present on all branches).

**Root cause:** `costSpendBetween` (the per-bucket spend calc) required every history snapshot to carry the per-model `models` field and `continue`d past any entry lacking it. But `CostHistoryEntry.Models` is `omitempty` and documented "omitted on older entries" — it was added recently, so the ring buffer up to that point holds `usd`-only snapshots. Those got skipped → every bucket older than the field's introduction rendered empty.

**Fix:** fall back to the cumulative `usd` for legacy entries and count its positive step-to-step increases. Since priced-token-sum and cumulative-usd are different scales, the delta is only taken **like-with-like** — `prevKind` tracks the measure type and resets the baseline on a flip, so a legacy→new boundary never yields a garbage delta.

Frontend-only (`index.html`); `go build ./pkg/dashboard/` passes. Separately investigating an auto-mode agent showing no cost row.