### PR TITLE
feat(hub,dashboard): persistent banners across upgrades + display/dismiss audit

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -42,6 +42,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("DELETE /api/config/variables/{name}", s.handleVariableDelete)
 	s.mux.HandleFunc("GET /api/audit", s.handleAuditLog)
 	s.mux.HandleFunc("POST /api/self-upgrade", s.handleSelfUpgrade)
+	s.mux.HandleFunc("POST /api/banner-dismissed", s.handleBannerDismissed)
 	s.mux.HandleFunc("GET /api/snapshot", s.handleSnapshotAPI)
 	s.mux.HandleFunc("GET /snapshot", s.handleSnapshotPage)
 	s.mux.HandleFunc("GET /api/history", s.handleHistory)

--- a/v2/pkg/dashboard/banner_dismiss_test.go
+++ b/v2/pkg/dashboard/banner_dismiss_test.go
@@ -1,0 +1,124 @@
+package dashboard
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func dismissLogger() *slog.Logger { return slog.Default() }
+
+// TestHandleBannerDismissedRequiresAuth verifies an unauthenticated request
+// (no session cookie, no proxy-injected identity) is rejected: only signed-in
+// users may dismiss a banner.
+func TestHandleBannerDismissedRequiresAuth(t *testing.T) {
+	s := NewServer(0, dismissLogger())
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/banner-dismissed", strings.NewReader(`{"id":"b-1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	s.handleBannerDismissed(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("unauthenticated dismiss status = %d, want 403 (body=%s)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleBannerDismissedRejectsReadOnly verifies a read-only viewer (role
+// "read", the value nginx injects for preview users) cannot dismiss.
+func TestHandleBannerDismissedRejectsReadOnly(t *testing.T) {
+	s := NewServer(0, dismissLogger())
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/banner-dismissed", strings.NewReader(`{"id":"b-1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-User", "viewer")
+	req.Header.Set("X-Hive-Role", "read")
+	s.handleBannerDismissed(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("read-only dismiss status = %d, want 403 (body=%s)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleBannerDismissedProxiedWriteUser verifies a hub-proxied write/owner
+// user (identity injected via X-Hive-User/X-Hive-Role) is allowed.
+func TestHandleBannerDismissedProxiedWriteUser(t *testing.T) {
+	s := NewServer(0, dismissLogger())
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/banner-dismissed", strings.NewReader(`{"id":"b-2"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-User", "owner-user")
+	req.Header.Set("X-Hive-Role", "owner")
+	s.handleBannerDismissed(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("owner dismiss status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleBannerDismissedSessionUser verifies a direct-route user with a valid
+// per-user session cookie is allowed to dismiss.
+func TestHandleBannerDismissedSessionUser(t *testing.T) {
+	s := NewServer(0, dismissLogger())
+	id := s.createUserSession("alice", "owner")
+	if id == "" {
+		t.Fatal("could not create session")
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/banner-dismissed", strings.NewReader(`{"id":"b-3"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: sessionCookieName, Value: id})
+	s.handleBannerDismissed(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("session-user dismiss status = %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleBannerDismissedBadBody verifies a missing/blank banner id is a 400.
+func TestHandleBannerDismissedBadBody(t *testing.T) {
+	s := NewServer(0, dismissLogger())
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/banner-dismissed", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Hive-User", "owner-user")
+	req.Header.Set("X-Hive-Role", "owner")
+	s.handleBannerDismissed(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("empty id status = %d, want 400", rec.Code)
+	}
+}
+
+// TestSetHubBannerLogsFirstDisplayOnce is a light guard that SetHubBanner is
+// idempotent on the stored state for the same id and updates it for a new id
+// (the first-display log fires on the transition, which we exercise here for
+// coverage of the id-change branch).
+func TestSetHubBannerFirstDisplayTransition(t *testing.T) {
+	s := NewServer(0, dismissLogger())
+
+	s.SetHubBanner("b-1", "hello", "green")
+	s.hubBannerMu.RLock()
+	first := s.hubBanner
+	s.hubBannerMu.RUnlock()
+	if first == nil || first.ID != "b-1" {
+		t.Fatalf("banner not set, got %+v", first)
+	}
+
+	// Same id again — state stays consistent.
+	s.SetHubBanner("b-1", "hello", "green")
+	// New id — banner is replaced.
+	s.SetHubBanner("b-2", "world", "amber")
+	s.hubBannerMu.RLock()
+	got := s.hubBanner
+	s.hubBannerMu.RUnlock()
+	if got == nil || got.ID != "b-2" || got.Message != "world" {
+		t.Errorf("banner not updated to new id, got %+v", got)
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -979,11 +979,18 @@ func (s *Server) ClearSystemAlert(id string) {
 	}
 }
 
-// SetHubBanner sets the hub admin banner displayed on the spoke dashboard.
+// SetHubBanner sets the hub admin banner displayed on the spoke dashboard. It is
+// called on every heartbeat that carries a banner, so it logs the first display
+// only when the banner ID actually changes (a new banner became active), not on
+// every re-delivery of the same one.
 func (s *Server) SetHubBanner(id, message, color string) {
 	s.hubBannerMu.Lock()
-	defer s.hubBannerMu.Unlock()
+	isNew := s.hubBanner == nil || s.hubBanner.ID != id
 	s.hubBanner = &HubBannerState{ID: id, Message: message, Color: color}
+	s.hubBannerMu.Unlock()
+	if isNew && s.logger != nil {
+		s.logger.Info("hub banner displayed", "banner_id", id, "message", message, "color", color)
+	}
 }
 
 // ClearHubBanner removes the hub admin banner.
@@ -991,6 +998,52 @@ func (s *Server) ClearHubBanner() {
 	s.hubBannerMu.Lock()
 	defer s.hubBannerMu.Unlock()
 	s.hubBanner = nil
+}
+
+// handleBannerDismissed records that an authenticated user dismissed the hub
+// banner. Dismissal remains a client-side action (the banner stays in the hub
+// and re-appears for other viewers) — this endpoint only produces an audit line
+// attributing the dismissal to a specific user, so an admin can tell who acted
+// on a banner and when.
+//
+// Only authenticated users with write/owner permissions may dismiss: the
+// roleEnforcement middleware already rejects a "read"-role viewer's POST with
+// 403, and this handler additionally 403s any request it cannot attribute to a
+// signed-in user (no session, no proxy-injected identity). The frontend keeps
+// the banner visible on a non-2xx so a rejected dismissal does not hide it.
+func (s *Server) handleBannerDismissed(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		ID string `json:"id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.ID == "" {
+		jsonError(w, "missing banner id", http.StatusBadRequest)
+		return
+	}
+
+	// Resolve the acting user: a direct-route spoke has a per-user session
+	// cookie; a hub-proxied spoke gets identity injected as X-Hive-User /
+	// X-Hive-Role by nginx. Either establishes an authenticated user.
+	username, role := "", ""
+	if sess := s.sessionFromRequest(r); sess != nil {
+		username, role = sess.Username, sess.Role
+	} else if hubUser := r.Header.Get("X-Hive-User"); hubUser != "" {
+		username, role = hubUser, r.Header.Get("X-Hive-Role")
+	}
+	if username == "" {
+		jsonError(w, "you must be signed in to dismiss this banner", http.StatusForbidden)
+		return
+	}
+	// Defense in depth: reject a read-only user even if the middleware let this
+	// through (e.g. no X-Hive-Role header on a direct-route read session).
+	if role == "read" {
+		jsonError(w, "read-only users cannot dismiss banners", http.StatusForbidden)
+		return
+	}
+
+	if s.logger != nil {
+		s.logger.Info("hub banner dismissed", "banner_id", body.ID, "by", username, "role", role)
+	}
+	jsonResponse(w, map[string]bool{"ok": true})
 }
 
 func (s *Server) SetGitHubAppRequired(required bool) {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4799,9 +4799,29 @@
     }
 
     function dismissHubBanner(id) {
-      localStorage.setItem('hub-banner-dismissed-' + id, '1');
-      var el = document.getElementById('hub-banner');
-      if (el) { el.style.display = 'none'; el.innerHTML = ''; }
+      // Record the dismissal server-side so it is attributed to the signed-in
+      // user in the spoke's audit log. The server authorizes: only an
+      // authenticated write/owner user gets a 2xx. We hide the banner ONLY on
+      // success — a read-only or signed-out viewer gets a 403 and the banner
+      // stays visible (their dismissal isn't honored). Dismissal remains
+      // per-browser (localStorage) for the view; the POST is just the audit
+      // trail, so a network failure still lets the user hide it locally.
+      fetch('/api/banner-dismissed', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: id })
+      }).then(function(resp) {
+        if (!resp.ok) return; // not authorized to dismiss — leave banner up
+        localStorage.setItem('hub-banner-dismissed-' + id, '1');
+        var el = document.getElementById('hub-banner');
+        if (el) { el.style.display = 'none'; el.innerHTML = ''; }
+      }).catch(function() {
+        // Network/API failure: fall back to a local-only hide so the user is
+        // never stuck with an undismissable banner (no audit line in this case).
+        localStorage.setItem('hub-banner-dismissed-' + id, '1');
+        var el = document.getElementById('hub-banner');
+        if (el) { el.style.display = 'none'; el.innerHTML = ''; }
+      });
     }
 
     function renderSystemAlerts(alerts) {

--- a/v2/pkg/hub/banner_persistence_test.go
+++ b/v2/pkg/hub/banner_persistence_test.go
@@ -1,0 +1,122 @@
+package hub
+
+import (
+	"log/slog"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// withTempBannersPath points hubBannersPath at a temp file for the duration of a
+// test and restores it afterward.
+func withTempBannersPath(t *testing.T) {
+	t.Helper()
+	orig := hubBannersPath
+	hubBannersPath = filepath.Join(t.TempDir(), "hub-banners.json")
+	t.Cleanup(func() { hubBannersPath = orig })
+}
+
+// TestHubBannerPersistenceRoundTrip verifies a sent banner survives a hub
+// restart: save to disk, then a fresh server loads it back and still delivers it
+// (the spyre/upgrade "banner vanished after a pod roll" bug).
+func TestHubBannerPersistenceRoundTrip(t *testing.T) {
+	withTempBannersPath(t)
+
+	s1 := &HubServer{logger: slog.Default(), hubBanners: make(map[string]*HubBannerEntry)}
+	s1.hubBanners["hive-a"] = &HubBannerEntry{
+		ID: "b-1", Message: "maintenance tonight", Color: "amber",
+		SentAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	s1.saveHubBanners()
+
+	// A brand-new server (simulating the restarted/upgraded pod) loads it back.
+	s2 := &HubServer{logger: slog.Default(), hubBanners: make(map[string]*HubBannerEntry)}
+	s2.loadHubBanners()
+
+	got, ok := s2.hubBanners["hive-a"]
+	if !ok {
+		t.Fatalf("banner not restored after restart; map = %+v", s2.hubBanners)
+	}
+	if got.ID != "b-1" || got.Message != "maintenance tonight" || got.Color != "amber" {
+		t.Errorf("restored banner = %+v, want id=b-1 message/color preserved", got)
+	}
+}
+
+// TestHubBannerPersistenceDropsStale verifies banners older than hubBannerMaxAge
+// are pruned on load (so a long-forgotten banner does not resurrect across an
+// upgrade), while fresh banners are kept, and the pruned set is rewritten.
+func TestHubBannerPersistenceDropsStale(t *testing.T) {
+	withTempBannersPath(t)
+
+	s1 := &HubServer{logger: slog.Default(), hubBanners: make(map[string]*HubBannerEntry)}
+	fresh := time.Now().UTC()
+	stale := fresh.Add(-hubBannerMaxAge - time.Hour)
+	s1.hubBanners["fresh"] = &HubBannerEntry{ID: "f", Message: "new", SentAt: fresh.Format(time.RFC3339)}
+	s1.hubBanners["stale"] = &HubBannerEntry{ID: "s", Message: "old", SentAt: stale.Format(time.RFC3339)}
+	s1.saveHubBanners()
+
+	s2 := &HubServer{logger: slog.Default(), hubBanners: make(map[string]*HubBannerEntry)}
+	s2.loadHubBanners()
+
+	if _, ok := s2.hubBanners["fresh"]; !ok {
+		t.Errorf("fresh banner should survive load, map = %+v", s2.hubBanners)
+	}
+	if _, ok := s2.hubBanners["stale"]; ok {
+		t.Errorf("stale banner should be dropped on load, map = %+v", s2.hubBanners)
+	}
+
+	// The pruned state should have been rewritten to disk: a third load sees only
+	// the fresh banner.
+	s3 := &HubServer{logger: slog.Default(), hubBanners: make(map[string]*HubBannerEntry)}
+	s3.loadHubBanners()
+	if len(s3.hubBanners) != 1 {
+		t.Errorf("expected pruned file to hold 1 banner, got %d", len(s3.hubBanners))
+	}
+}
+
+// TestHubBannerPersistenceMissingFile verifies loadHubBanners is a no-op (no
+// error, empty map) when no banners have ever been persisted.
+func TestHubBannerPersistenceMissingFile(t *testing.T) {
+	withTempBannersPath(t)
+	// Ensure the file does not exist.
+	_ = os.Remove(hubBannersPath)
+
+	s := &HubServer{logger: slog.Default(), hubBanners: make(map[string]*HubBannerEntry)}
+	s.loadHubBanners()
+	if len(s.hubBanners) != 0 {
+		t.Errorf("expected empty banners for missing file, got %d", len(s.hubBanners))
+	}
+}
+
+// TestHubBannerPersistedOnSendAndClear verifies the send and clear handlers write
+// through to disk so the state survives a restart.
+func TestHubBannerPersistedOnSendAndClear(t *testing.T) {
+	withTempBannersPath(t)
+	s := &HubServer{logger: slog.Default(), hubBanners: make(map[string]*HubBannerEntry)}
+
+	rec := httptest.NewRecorder()
+	s.handleSendHubBanner(rec, postJSON("/api/hub/banner", `{"message":"hi","hive_ids":["h1"]}`))
+	if rec.Code != 200 {
+		t.Fatalf("send status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	// A fresh server loads the persisted banner.
+	s2 := &HubServer{logger: slog.Default(), hubBanners: make(map[string]*HubBannerEntry)}
+	s2.loadHubBanners()
+	if _, ok := s2.hubBanners["h1"]; !ok {
+		t.Fatalf("send did not persist banner; map = %+v", s2.hubBanners)
+	}
+
+	// Clear on the original, then a fresh load sees nothing.
+	rec = httptest.NewRecorder()
+	s.handleClearHubBanner(rec, postJSON("/api/hub/banner/clear", ``))
+	if rec.Code != 200 {
+		t.Fatalf("clear status = %d", rec.Code)
+	}
+	s3 := &HubServer{logger: slog.Default(), hubBanners: make(map[string]*HubBannerEntry)}
+	s3.loadHubBanners()
+	if len(s3.hubBanners) != 0 {
+		t.Errorf("clear did not persist empty state; %d banners remain", len(s3.hubBanners))
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -7022,12 +7022,6 @@ const dashboardHTML = `<!DOCTYPE html>
           </div>
           <div id="banner-hive-list" style="max-height:200px;overflow-y:auto;border:1px solid var(--border);border-radius:6px;background:var(--bg);padding:4px"></div>
         </div>
-        <div style="margin-bottom:12px">
-          <label style="font-size:0.8rem;color:var(--muted);margin-bottom:4px;display:block">Preview</label>
-          <div id="banner-preview" style="padding:12px 16px;border-radius:6px;font-size:0.85rem;background:rgba(22,163,74,0.12);border:1px solid rgba(22,163,74,0.3);color:var(--text)">
-            <em style="opacity:0.6">Type a message above to preview...</em>
-          </div>
-        </div>
       </div>
       <div style="display:flex;justify-content:flex-end;gap:8px;padding:16px 32px 32px;flex-shrink:0">
         <button onclick="document.getElementById('banner-modal').style.display='none'" style="padding:8px 20px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--muted);cursor:pointer">Cancel</button>
@@ -7621,6 +7615,9 @@ func (s *HubServer) handleSendHubBanner(w http.ResponseWriter, r *http.Request) 
 		s.hubBanners[hiveID] = entry
 	}
 	s.hubBannersMu.Unlock()
+	// Persist so the banner survives a hub restart/upgrade (the pod roll would
+	// otherwise wipe the in-memory map and silently drop it).
+	s.saveHubBanners()
 
 	username := s.getAuthUser(r)
 	s.logger.Info("hub banner sent",
@@ -7640,6 +7637,8 @@ func (s *HubServer) handleClearHubBanner(w http.ResponseWriter, r *http.Request)
 	count := len(s.hubBanners)
 	s.hubBanners = make(map[string]*HubBannerEntry)
 	s.hubBannersMu.Unlock()
+	// Persist the cleared (empty) state so banners stay gone across a restart.
+	s.saveHubBanners()
 
 	username := s.getAuthUser(r)
 	s.logger.Info("hub banners cleared", "cleared_count", count, "by", username)

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -15,6 +15,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -29,6 +30,18 @@ var staticFS embed.FS
 // registryPath is the on-disk hub registry file. A var (not a const) so tests
 // can redirect it at a temp file; production keeps the default.
 var registryPath = "/data/hub-registry.json"
+
+// hubBannersPath is the on-disk file where admin-sent banners are persisted so
+// they survive hub restarts and upgrades (an in-place upgrade rolls the pod,
+// which would otherwise wipe the in-memory map and silently drop every active
+// banner). A var (not a const) so tests can redirect it at a temp file.
+var hubBannersPath = "/data/saas/hub-banners.json"
+
+// hubBannerMaxAge bounds how long a persisted banner is honored after it was
+// sent. On load, entries older than this are dropped so a long-forgotten banner
+// does not resurrect across an upgrade months later. Admins still clear banners
+// explicitly; this is only a backstop for stale on-disk state.
+const hubBannerMaxAge = 30 * 24 * time.Hour
 
 const (
 	maxHeartbeatAge     = 5 * time.Minute
@@ -207,6 +220,83 @@ type HubBannerEntry struct {
 	SentAt  string `json:"sent_at"`
 }
 
+// saveHubBanners persists the in-memory banner map to the PVC so banners survive
+// hub restarts and upgrades. Caller must NOT hold hubBannersMu — this takes an
+// RLock itself. Writes atomically (tmp + rename) so a crash mid-write never
+// leaves a half-written file. A persistence failure is logged, not fatal: a lost
+// banner is a soft failure, and the admin can resend.
+func (s *HubServer) saveHubBanners() {
+	s.hubBannersMu.RLock()
+	snapshot := make(map[string]*HubBannerEntry, len(s.hubBanners))
+	for id, entry := range s.hubBanners {
+		snapshot[id] = entry
+	}
+	s.hubBannersMu.RUnlock()
+
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		s.logger.Error("failed to marshal hub banners for persistence", "error", err)
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(hubBannersPath), 0o755); err != nil {
+		s.logger.Error("failed to create hub banners dir", "error", err)
+		return
+	}
+	tmpPath := hubBannersPath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		s.logger.Error("failed to write hub banners tmp file", "error", err)
+		return
+	}
+	if err := os.Rename(tmpPath, hubBannersPath); err != nil {
+		s.logger.Error("failed to rename hub banners file", "error", err)
+	}
+}
+
+// loadHubBanners reads persisted banners from the PVC into the in-memory map on
+// startup. Entries older than hubBannerMaxAge (by SentAt) are dropped so stale
+// banners do not resurrect long after they were relevant; if any are dropped the
+// pruned set is written back. A missing file is normal (no banners yet).
+func (s *HubServer) loadHubBanners() {
+	data, err := os.ReadFile(hubBannersPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			s.logger.Error("failed to read persisted hub banners", "error", err)
+		}
+		return
+	}
+	var stored map[string]*HubBannerEntry
+	if err := json.Unmarshal(data, &stored); err != nil {
+		s.logger.Error("failed to parse persisted hub banners", "error", err)
+		return
+	}
+
+	pruned := false
+	s.hubBannersMu.Lock()
+	for id, entry := range stored {
+		if entry == nil {
+			pruned = true
+			continue
+		}
+		if sent, perr := time.Parse(time.RFC3339, entry.SentAt); perr == nil {
+			if time.Since(sent) > hubBannerMaxAge {
+				pruned = true
+				continue // drop stale banner
+			}
+		}
+		s.hubBanners[id] = entry
+	}
+	loaded := len(s.hubBanners)
+	s.hubBannersMu.Unlock()
+
+	if loaded > 0 {
+		s.logger.Info("loaded persisted hub banners", "count", loaded)
+	}
+	if pruned {
+		// Rewrite the file without the dropped/stale entries.
+		s.saveHubBanners()
+	}
+}
+
 func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *HubServer {
 	if gitBranch == "" || gitBranch == "unknown" {
 		gitBranch = "v2"
@@ -246,6 +336,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 	}
 
 	s.loadRegistry()
+	s.loadHubBanners()
 
 	s.mux.HandleFunc("POST /api/heartbeat", s.handleHeartbeat)
 	s.mux.HandleFunc("POST /api/task-status", s.handleTaskStatus)


### PR DESCRIPTION
## Problem

Hub admin banners were **in-memory only** on the hub, so any hub restart or upgrade (the pod roll) **silently dropped every active banner**. And when a recipient dismissed a banner, there was **no server-side trace at all** — no way to tell who acted on it.

## Changes

### 1. Persistence — banners survive upgrades/restarts
- Persist to `/data/saas/hub-banners.json` (atomic tmp+rename), loaded on startup in `NewHubServer`. Send and clear both write through.
- On load, drop entries older than **30 days** (backstop so a long-forgotten banner can't resurrect across an upgrade) and rewrite the pruned set.

### 2. First-display log (spoke)
- `SetHubBanner` logs `hub banner displayed` **once**, only when the banner ID changes — not on every heartbeat re-delivery.

### 3. Dismissal log with authenticated user (spoke)
- New `POST /api/banner-dismissed` resolves the user from the per-user session (direct route) or `X-Hive-User`/`X-Hive-Role` (hub-proxied) and logs `hub banner dismissed by=<user> role=<role>`.
- **Only authenticated write/owner users may dismiss**: `roleEnforcement` already 403s a read-only POST, and the handler additionally 403s any request it can't attribute to a signed-in user.
- Frontend posts the beacon and hides the banner **only on a 2xx** (a rejected dismissal stays visible), with a local-only fallback on network error so a user is never stuck with an undismissable banner.
- Dismissal remains per-browser (localStorage) for the view — the POST is purely the audit trail; **no hub involvement**, as requested.

### 4. UI fix
- Removed a duplicate `id="banner-preview"` in the Send Hub Banner modal (a leftover second block after Target Hives showed a stuck "Type a message above to preview…" because `getElementById` only updates the first match).

## Tests
- Hub: round-trip survives restart; stale-TTL prune; missing-file no-op; send+clear write-through.
- Spoke: dismissal auth (anon 403, read-only 403, proxied owner 200, session user 200, bad body 400); first-display transition.
- Full `pkg/hub` and `pkg/dashboard` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)