### PR TITLE
✨ hub landing: live fleet stats + rotating hero + ACMM copy fix (backport of #2065)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -659,6 +659,13 @@ func main() {
 	metricsCollector := dashboard.NewMetricsCollector(ghClient, cfg.Project.Org, primaryRepo, badgeURL, cfg.Project.AIAuthor, cfg.Project.Name, logger)
 	go metricsCollector.Start(ctx)
 
+	// Fleet-stats collector: computes this hive's AI-author contribution counts
+	// (merged/rejected PRs, CVE-referencing PRs) across its org on a slow timer
+	// and caches them, so each heartbeat can attach a fresh-but-cheap snapshot
+	// the hub aggregates into the public landing page's live fleet-stats strip.
+	fleetStatsCollector := dashboard.NewFleetStatsCollector(ghClient, cfg.Project.AIAuthor, cfg.Project.Org, logger)
+	go fleetStatsCollector.Start(ctx)
+
 	var lastActionable atomic.Pointer[github.ActionableResult]
 	refreshDashboard := func() {
 		actionable := lastActionable.Load()
@@ -1599,6 +1606,14 @@ func main() {
 			if cfg.ACMMLevel != nil {
 				acmmLvl = *cfg.ACMMLevel
 			}
+			// Attach cached fleet-stat counts only once the collector has done a
+			// successful compute — nil pointers until then, so the hub never
+			// aggregates a not-yet-computed zero into the public fleet total.
+			var prsMerged, prsRejected, cvesClosed *int
+			if fc, ok := fleetStatsCollector.Snapshot(); ok {
+				m, rj, cv := fc.PRsMerged, fc.PRsRejected, fc.CVEsClosed
+				prsMerged, prsRejected, cvesClosed = &m, &rj, &cv
+			}
 			return &hub.HeartbeatPayload{
 				HiveID:      cfg.HiveID,
 				Org:         cfg.Project.Org,
@@ -1684,6 +1699,9 @@ func main() {
 					}
 					return hub.CollectClusterHealth(logger)
 				}(),
+				PRsMerged90d:   prsMerged,
+				PRsRejected90d: prsRejected,
+				CVEsClosed:     cvesClosed,
 			}
 		}, heartbeatSendInterval, logger, hub.UpgradeCallback(func(targetSHA string) {
 			const upgradeMarkerPath = "/data/upgrade-requested"

--- a/v2/pkg/dashboard/fleet_stats_collector.go
+++ b/v2/pkg/dashboard/fleet_stats_collector.go
@@ -1,0 +1,103 @@
+package dashboard
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// fleetStatsCollectInterval is how often the spoke recomputes its fleet-stat
+// contribution counts. Each collect is three GitHub search requests, so this
+// is deliberately much slower than the heartbeat cadence — the heartbeat reads
+// the cached snapshot, never triggers a fresh GitHub call. Cheap and steady.
+// A var (not a const) so tests can drive the ticker branch quickly; production
+// keeps the default.
+var fleetStatsCollectInterval = 30 * time.Minute
+
+// FleetStatsCollector periodically computes this hive's AI-author contribution
+// counts (PRs merged, PRs rejected, CVE-referencing PRs) across its org and
+// caches them, so the heartbeat sender can attach a fresh-but-cheap snapshot to
+// every beat. The hub aggregates these across all spokes into the public
+// landing page's live fleet-stats strip.
+type FleetStatsCollector struct {
+	ghClient *ghpkg.Client
+	author   string
+	org      string
+	logger   *slog.Logger
+
+	mu     sync.RWMutex
+	counts ghpkg.FleetContribCounts
+	// ready is false until the first successful collect, so the heartbeat can
+	// omit zero counts that merely mean "not computed yet" rather than "truly
+	// zero" — the hub then hides the stat instead of showing a fake number.
+	ready bool
+}
+
+// NewFleetStatsCollector builds a collector for the given AI author and org.
+// A nil ghClient, or empty author/org, yields a collector that never reports
+// counts (Snapshot returns ready=false) — the hive simply contributes nothing
+// to the fleet total rather than erroring.
+func NewFleetStatsCollector(ghClient *ghpkg.Client, author, org string, logger *slog.Logger) *FleetStatsCollector {
+	return &FleetStatsCollector{
+		ghClient: ghClient,
+		author:   author,
+		org:      org,
+		logger:   logger,
+	}
+}
+
+// Start runs the collect loop until ctx is cancelled. It computes once up
+// front, then on fleetStatsCollectInterval. The ticker takes ctx and is
+// stopped on return, so there is no uncancellable timer leak.
+func (fc *FleetStatsCollector) Start(ctx context.Context) {
+	if fc == nil || fc.ghClient == nil || fc.author == "" || fc.org == "" {
+		return
+	}
+	fc.collect(ctx)
+	ticker := time.NewTicker(fleetStatsCollectInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			fc.collect(ctx)
+		}
+	}
+}
+
+func (fc *FleetStatsCollector) collect(ctx context.Context) {
+	counts, err := fc.ghClient.ComputeFleetContribCounts(ctx, fc.author, fc.org)
+	if err != nil {
+		if fc.logger != nil {
+			fc.logger.Debug("fleet stats collect failed", "error", err)
+		}
+		return
+	}
+	fc.mu.Lock()
+	fc.counts = counts
+	fc.ready = true
+	fc.mu.Unlock()
+	if fc.logger != nil {
+		fc.logger.Info("fleet stats collected",
+			"prs_merged", counts.PRsMerged,
+			"prs_rejected", counts.PRsRejected,
+			"cves_closed", counts.CVEsClosed,
+		)
+	}
+}
+
+// Snapshot returns the last computed counts and whether a successful collect
+// has ever completed. When ready is false the caller should omit the counts
+// from the heartbeat so the hub does not treat "not computed yet" as zero.
+func (fc *FleetStatsCollector) Snapshot() (ghpkg.FleetContribCounts, bool) {
+	if fc == nil {
+		return ghpkg.FleetContribCounts{}, false
+	}
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
+	return fc.counts, fc.ready
+}

--- a/v2/pkg/dashboard/fleet_stats_collector_test.go
+++ b/v2/pkg/dashboard/fleet_stats_collector_test.go
@@ -1,0 +1,173 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	ghpkg "github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// newFleetTestClient builds a github.Client pointed at a test server that
+// answers /search/issues with a total keyed by qualifier substrings.
+func newFleetTestClient(t *testing.T, byQualifier map[string]int) *ghpkg.Client {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		total := 0
+		for sub, n := range byQualifier {
+			if strings.Contains(q, sub) {
+				total = n
+				break
+			}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"total_count": total, "items": []any{}})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	c := ghpkg.NewClient("fake", "org", []string{"repo"}, slog.Default(), "")
+	base, err := url.Parse(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	c.GoGitHub().BaseURL = base
+	return c
+}
+
+func TestFleetStatsCollector_SnapshotBeforeCollect(t *testing.T) {
+	fc := NewFleetStatsCollector(newFleetTestClient(t, nil), "bot", "org", slog.Default())
+	_, ready := fc.Snapshot()
+	if ready {
+		t.Error("ready should be false before first collect")
+	}
+}
+
+func TestFleetStatsCollector_Collect(t *testing.T) {
+	c := newFleetTestClient(t, map[string]int{
+		"is:merged merged:>=":             20,
+		"is:closed is:unmerged closed:>=": 3,
+		`"CVE-"`:                          6,
+	})
+	fc := NewFleetStatsCollector(c, "bot", "org", slog.Default())
+	fc.collect(context.Background())
+
+	snap, ready := fc.Snapshot()
+	if !ready {
+		t.Fatal("ready should be true after collect")
+	}
+	want := ghpkg.FleetContribCounts{PRsMerged: 20, PRsRejected: 3, CVEsClosed: 6}
+	if snap != want {
+		t.Errorf("got %+v, want %+v", snap, want)
+	}
+}
+
+func TestFleetStatsCollector_NilAndEmpty(t *testing.T) {
+	// nil collector
+	var nilFc *FleetStatsCollector
+	if _, ready := nilFc.Snapshot(); ready {
+		t.Error("nil collector Snapshot ready should be false")
+	}
+	nilFc.Start(context.Background()) // must not panic
+
+	// empty author/org: Start returns immediately, stays not-ready
+	fc := NewFleetStatsCollector(newFleetTestClient(t, nil), "", "", slog.Default())
+	fc.Start(context.Background())
+	if _, ready := fc.Snapshot(); ready {
+		t.Error("empty-config collector should never be ready")
+	}
+}
+
+func TestFleetStatsCollector_StartCancels(t *testing.T) {
+	c := newFleetTestClient(t, map[string]int{"is:merged merged:>=": 1})
+	fc := NewFleetStatsCollector(c, "bot", "org", slog.Default())
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { fc.Start(ctx); close(done) }()
+
+	// Wait until the up-front collect has completed (ready flips true) before
+	// cancelling, so the assertion isn't racing the initial GitHub call.
+	deadline := time.After(5 * time.Second)
+	for {
+		if _, ready := fc.Snapshot(); ready {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("initial collect never completed")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// Cancel and confirm the loop exits promptly.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after context cancel")
+	}
+}
+
+func TestFleetStatsCollector_TickerReCollects(t *testing.T) {
+	// Shrink the interval so the ticker branch fires within the test.
+	orig := fleetStatsCollectInterval
+	fleetStatsCollectInterval = 20 * time.Millisecond
+	defer func() { fleetStatsCollectInterval = orig }()
+
+	var hits int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		_ = json.NewEncoder(w).Encode(map[string]any{"total_count": 1, "items": []any{}})
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	c := ghpkg.NewClient("fake", "org", []string{"repo"}, slog.Default(), "")
+	base, _ := url.Parse(srv.URL + "/")
+	c.GoGitHub().BaseURL = base
+
+	fc := NewFleetStatsCollector(c, "bot", "org", slog.Default())
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { fc.Start(ctx); close(done) }()
+
+	// Wait for at least two collect rounds (initial + one ticker fire); each
+	// round is 3 search requests, so >3 hits proves the ticker branch ran.
+	deadline := time.After(3 * time.Second)
+	for atomic.LoadInt32(&hits) <= 3 {
+		select {
+		case <-deadline:
+			t.Fatalf("ticker branch never re-collected (hits=%d)", atomic.LoadInt32(&hits))
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	cancel()
+	<-done
+}
+
+func TestFleetStatsCollector_CollectError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	c := ghpkg.NewClient("fake", "org", []string{"repo"}, slog.Default(), "")
+	base, _ := url.Parse(srv.URL + "/")
+	c.GoGitHub().BaseURL = base
+
+	fc := NewFleetStatsCollector(c, "bot", "org", slog.Default())
+	fc.collect(context.Background())
+	// A failed collect must leave the collector not-ready (never a fake zero).
+	if _, ready := fc.Snapshot(); ready {
+		t.Error("collector should stay not-ready after a failed collect")
+	}
+}

--- a/v2/pkg/github/fleet_stats.go
+++ b/v2/pkg/github/fleet_stats.go
@@ -1,0 +1,108 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+// FleetContribCounts holds the spoke-computed contribution totals a hive
+// reports to the hub for the public landing-page "live fleet stats" strip.
+// These are counts of the AI author's PRs across the hive's own org, so the
+// hub can aggregate a true fleet total across every registered spoke.
+type FleetContribCounts struct {
+	// PRsMerged is the number of PRs the AI author has merged in the window.
+	PRsMerged int `json:"prs_merged"`
+	// PRsRejected is the number of PRs the AI author opened that were closed
+	// without merging in the window — the pipeline (build/lint/test/policy)
+	// rejected them. This is the honest "the gate caught something" signal.
+	PRsRejected int `json:"prs_rejected"`
+	// CVEsClosed is the number of merged PRs by the AI author whose title or
+	// body references a CVE id (matched server-side by GitHub search). It is
+	// all-time rather than windowed, since CVE fixes are a cumulative claim.
+	CVEsClosed int `json:"cves_closed"`
+}
+
+// fleetStatsWindowDays is the trailing window (in days) over which merged and
+// rejected PR counts are measured. Ninety days keeps the number current
+// ("what has the fleet done lately") without being a lifetime figure that only
+// ever grows and stops meaning anything.
+const fleetStatsWindowDays = 90
+
+// searchIssueTotal runs a GitHub issue/PR search and returns only the total
+// match count (PerPage 1 — we never page, GitHub returns the total in the
+// first response). Shared by the fleet-stat counters below.
+func (c *Client) searchIssueTotal(ctx context.Context, qualifier string) (int, error) {
+	result, _, err := c.client.Search.Issues(ctx, qualifier, &gh.SearchOptions{
+		ListOptions: gh.ListOptions{PerPage: 1},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("searching %q: %w", qualifier, err)
+	}
+	return result.GetTotal(), nil
+}
+
+// SearchMergedPRCountSince counts PRs by author within org merged on or after
+// the given cutoff date. Used for the fleet "PRs merged" stat.
+func (c *Client) SearchMergedPRCountSince(ctx context.Context, author, org string, since time.Time) (int, error) {
+	q := fmt.Sprintf("type:pr author:%s org:%s is:merged merged:>=%s",
+		author, org, since.UTC().Format("2006-01-02"))
+	return c.searchIssueTotal(ctx, q)
+}
+
+// SearchRejectedPRCountSince counts PRs by author within org that were closed
+// WITHOUT merging on or after the cutoff date — i.e. the pipeline rejected
+// them. Used for the fleet "PRs rejected" stat.
+func (c *Client) SearchRejectedPRCountSince(ctx context.Context, author, org string, since time.Time) (int, error) {
+	q := fmt.Sprintf("type:pr author:%s org:%s is:closed is:unmerged closed:>=%s",
+		author, org, since.UTC().Format("2006-01-02"))
+	return c.searchIssueTotal(ctx, q)
+}
+
+// SearchCVEPRCount counts merged PRs by author within org whose title or body
+// references a CVE id. GitHub's search treats "CVE" as a term match, so the
+// count is an upper bound the hub reports honestly as "PRs referencing a CVE".
+func (c *Client) SearchCVEPRCount(ctx context.Context, author, org string) (int, error) {
+	// The quoted "CVE-" term biases the free-text match toward real CVE ids
+	// (CVE-YYYY-N…) rather than incidental uses of the word "cve".
+	q := fmt.Sprintf("type:pr author:%s org:%s is:merged \"CVE-\"", author, org)
+	return c.searchIssueTotal(ctx, q)
+}
+
+// ComputeFleetContribCounts computes the three fleet-stat contribution counts
+// for this hive's AI author across its org. It is a read-only aggregation over
+// GitHub search; callers should invoke it on a timer and cache the result
+// rather than per-heartbeat, since each call is three search API requests.
+//
+// An empty author or org yields a zero-value result and no error — a
+// misconfigured hive simply contributes nothing to the fleet total rather than
+// failing the heartbeat.
+func (c *Client) ComputeFleetContribCounts(ctx context.Context, author, org string) (FleetContribCounts, error) {
+	var out FleetContribCounts
+	if c == nil || author == "" || org == "" {
+		return out, nil
+	}
+	since := time.Now().AddDate(0, 0, -fleetStatsWindowDays)
+
+	merged, err := c.SearchMergedPRCountSince(ctx, author, org, since)
+	if err != nil {
+		return out, fmt.Errorf("fleet merged count: %w", err)
+	}
+	out.PRsMerged = merged
+
+	rejected, err := c.SearchRejectedPRCountSince(ctx, author, org, since)
+	if err != nil {
+		return out, fmt.Errorf("fleet rejected count: %w", err)
+	}
+	out.PRsRejected = rejected
+
+	cves, err := c.SearchCVEPRCount(ctx, author, org)
+	if err != nil {
+		return out, fmt.Errorf("fleet cve count: %w", err)
+	}
+	out.CVEsClosed = cves
+
+	return out, nil
+}

--- a/v2/pkg/github/fleet_stats_test.go
+++ b/v2/pkg/github/fleet_stats_test.go
@@ -1,0 +1,165 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fleetSearchServer returns an httptest server that answers /search/issues with
+// a total keyed by which qualifier substrings appear in the "q" query param, so
+// each of the three fleet-stat searches can return a distinct count.
+func fleetSearchServer(t *testing.T, byQualifier map[string]int) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		total := 0
+		for sub, n := range byQualifier {
+			if strings.Contains(q, sub) {
+				total = n
+				break
+			}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"total_count": total, "items": []any{}})
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestSearchMergedPRCountSince(t *testing.T) {
+	srv := fleetSearchServer(t, map[string]int{"is:merged merged:>=": 12})
+	defer srv.Close()
+	c := newTestClient(t, srv, "org", []string{"repo"})
+	got, err := c.SearchMergedPRCountSince(context.Background(), "bot", "org", time.Now().AddDate(0, 0, -90))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != 12 {
+		t.Errorf("got %d, want 12", got)
+	}
+}
+
+func TestSearchRejectedPRCountSince(t *testing.T) {
+	srv := fleetSearchServer(t, map[string]int{"is:closed is:unmerged closed:>=": 4})
+	defer srv.Close()
+	c := newTestClient(t, srv, "org", []string{"repo"})
+	got, err := c.SearchRejectedPRCountSince(context.Background(), "bot", "org", time.Now().AddDate(0, 0, -90))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != 4 {
+		t.Errorf("got %d, want 4", got)
+	}
+}
+
+func TestSearchCVEPRCount(t *testing.T) {
+	srv := fleetSearchServer(t, map[string]int{`"CVE-"`: 7})
+	defer srv.Close()
+	c := newTestClient(t, srv, "org", []string{"repo"})
+	got, err := c.SearchCVEPRCount(context.Background(), "bot", "org")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != 7 {
+		t.Errorf("got %d, want 7", got)
+	}
+}
+
+func TestComputeFleetContribCounts(t *testing.T) {
+	tests := []struct {
+		name      string
+		author    string
+		org       string
+		byQual    map[string]int
+		nilClient bool
+		want      FleetContribCounts
+		wantErr   bool
+	}{
+		{
+			name:   "all three counts",
+			author: "bot",
+			org:    "org",
+			byQual: map[string]int{
+				"is:merged merged:>=":             30,
+				"is:closed is:unmerged closed:>=": 5,
+				`"CVE-"`:                          9,
+			},
+			want: FleetContribCounts{PRsMerged: 30, PRsRejected: 5, CVEsClosed: 9},
+		},
+		{
+			name:   "empty author yields zero, no error",
+			author: "",
+			org:    "org",
+			want:   FleetContribCounts{},
+		},
+		{
+			name:   "empty org yields zero, no error",
+			author: "bot",
+			org:    "",
+			want:   FleetContribCounts{},
+		},
+		{
+			name:      "nil client yields zero, no error",
+			author:    "bot",
+			org:       "org",
+			nilClient: true,
+			want:      FleetContribCounts{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c *Client
+			if !tt.nilClient {
+				srv := fleetSearchServer(t, tt.byQual)
+				defer srv.Close()
+				c = newTestClient(t, srv, tt.org, []string{"repo"})
+			}
+			got, err := c.ComputeFleetContribCounts(context.Background(), tt.author, tt.org)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// failOnServer returns a search server that 500s only when the query contains
+// failSub, and otherwise returns okTotal. Lets us exercise each of the three
+// sequential error returns in ComputeFleetContribCounts independently.
+func failOnServer(t *testing.T, failSub string, okTotal int) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/search/issues", func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Query().Get("q"), failSub) {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"total_count": okTotal, "items": []any{}})
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestComputeFleetContribCounts_SearchError(t *testing.T) {
+	cases := []struct{ name, failSub string }{
+		{"merged fails", "is:merged merged:>="},
+		{"rejected fails", "is:unmerged"},
+		{"cve fails", `"CVE-"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := failOnServer(t, tc.failSub, 1)
+			defer srv.Close()
+			c := newTestClient(t, srv, "org", []string{"repo"})
+			_, err := c.ComputeFleetContribCounts(context.Background(), "bot", "org")
+			if err == nil {
+				t.Fatal("expected error on search failure")
+			}
+		})
+	}
+}

--- a/v2/pkg/hub/fleet_stats_test.go
+++ b/v2/pkg/hub/fleet_stats_test.go
@@ -1,0 +1,144 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func ptrInt(v int) *int { return &v }
+
+func freshHeartbeat() string { return time.Now().UTC().Format(time.RFC3339) }
+func staleHeartbeat() string {
+	return time.Now().Add(-maxHeartbeatAge - time.Minute).UTC().Format(time.RFC3339)
+}
+
+func TestClampFleetCount(t *testing.T) {
+	tests := []struct {
+		name string
+		in   *int
+		want *int
+	}{
+		{"nil stays nil", nil, nil},
+		{"negative becomes nil", ptrInt(-5), nil},
+		{"zero preserved", ptrInt(0), ptrInt(0)},
+		{"normal preserved", ptrInt(42), ptrInt(42)},
+		{"over max clamped", ptrInt(maxFleetCount + 1), ptrInt(maxFleetCount)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := clampFleetCount(tt.in)
+			if (got == nil) != (tt.want == nil) {
+				t.Fatalf("nil mismatch: got %v want %v", got, tt.want)
+			}
+			if got != nil && *got != *tt.want {
+				t.Errorf("got %d want %d", *got, *tt.want)
+			}
+			// Must not alias the caller's pointer.
+			if got != nil && got == tt.in {
+				t.Error("clampFleetCount returned aliased pointer")
+			}
+		})
+	}
+}
+
+func TestComputeFleetStats(t *testing.T) {
+	tests := []struct {
+		name  string
+		hives []RegistryEntry
+		want  FleetStats
+	}{
+		{
+			name: "aggregates public online hives, dedupes repos",
+			hives: []RegistryEntry{
+				{IsPublic: true, Online: true, Org: "a", Repos: []string{"r1", "r2"},
+					PRsMerged90d: ptrInt(10), PRsRejected90d: ptrInt(2), CVEsClosed: ptrInt(1)},
+				{IsPublic: true, Online: true, Org: "a", Repos: []string{"r2", "a/r3"},
+					PRsMerged90d: ptrInt(5), PRsRejected90d: ptrInt(1), CVEsClosed: ptrInt(3)},
+			},
+			// repos: a/r1, a/r2, a/r3 = 3 distinct; a/r2 reported twice + as "r2".
+			want: FleetStats{ReposManaged: 3, PRsMerged: 15, PRsRejected: 3, CVEsClosed: 4, Hives: 2},
+		},
+		{
+			name: "skips private and offline hives",
+			hives: []RegistryEntry{
+				{IsPublic: false, Online: true, Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(99)},
+				{IsPublic: true, Online: false, Org: "a", Repos: []string{"r2"}, PRsMerged90d: ptrInt(99)},
+				{IsPublic: true, Online: true, Org: "a", Repos: []string{"r3"}, PRsMerged90d: ptrInt(7)},
+			},
+			want: FleetStats{ReposManaged: 1, PRsMerged: 7, Hives: 1},
+		},
+		{
+			name: "nil counts are not aggregated as zero",
+			hives: []RegistryEntry{
+				{IsPublic: true, Online: true, Org: "a", Repos: []string{"r1"}}, // all nil
+				{IsPublic: true, Online: true, Org: "a", Repos: []string{"r2"}, PRsMerged90d: ptrInt(4)},
+			},
+			want: FleetStats{ReposManaged: 2, PRsMerged: 4, Hives: 2},
+		},
+		{
+			name: "empty repo strings are skipped",
+			hives: []RegistryEntry{
+				{IsPublic: true, Online: true, Org: "a", Repos: []string{"", "r1", ""},
+					PRsMerged90d: ptrInt(2)},
+			},
+			want: FleetStats{ReposManaged: 1, PRsMerged: 2, Hives: 1},
+		},
+		{
+			name:  "no hives yields empty",
+			hives: nil,
+			want:  FleetStats{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &HubServer{logger: slog.Default()}
+			s.registry.Hives = tt.hives
+			got := s.computeFleetStats()
+			if got != tt.want {
+				t.Errorf("got %+v\nwant %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHandleFleetStats(t *testing.T) {
+	s := &HubServer{logger: slog.Default()}
+	s.registry.Hives = []RegistryEntry{
+		{ID: "h1", IsPublic: true, Online: true, LastHeartbeat: freshHeartbeat(),
+			Org: "a", Repos: []string{"r1"}, PRsMerged90d: ptrInt(8), CVEsClosed: ptrInt(2)},
+		// Stale (old heartbeat) — markStaleHives flips it offline, so excluded.
+		{ID: "h2", IsPublic: true, Online: true, LastHeartbeat: staleHeartbeat(),
+			Org: "a", Repos: []string{"r2"}, PRsMerged90d: ptrInt(100)},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/fleet-stats", nil)
+	s.handleFleetStats(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d", rec.Code)
+	}
+	var fs FleetStats
+	if err := json.Unmarshal(rec.Body.Bytes(), &fs); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if fs.PRsMerged != 8 {
+		t.Errorf("PRsMerged = %d, want 8 (stale hive must be excluded)", fs.PRsMerged)
+	}
+	if fs.CVEsClosed != 2 {
+		t.Errorf("CVEsClosed = %d, want 2", fs.CVEsClosed)
+	}
+	if fs.Hives != 1 {
+		t.Errorf("Hives = %d, want 1", fs.Hives)
+	}
+	if fs.ReposManaged != 1 {
+		t.Errorf("ReposManaged = %d, want 1", fs.ReposManaged)
+	}
+	if fs.UpdatedAt == "" {
+		t.Error("UpdatedAt empty")
+	}
+}

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -175,6 +175,16 @@ type HeartbeatPayload struct {
 	UpgradeTargetSHA        string                        `json:"upgrade_target_sha,omitempty"`
 	PendingGitHubAppInstall bool                          `json:"pending_github_app_install,omitempty"`
 	ClusterHealth           *HeartbeatClusterHealthReport `json:"cluster_health,omitempty"`
+	// Fleet contribution counts — the spoke's AI-author PR activity across its
+	// org, computed on a timer and cached (never per-heartbeat). The hub sums
+	// these across all public, non-stale hives for the landing page's live
+	// fleet-stats strip. Pointers so a spoke that hasn't computed them yet
+	// (old spoke, or first-collect still pending) is distinguishable from a
+	// genuine zero — nil means "no data, don't count me" so the hub never
+	// aggregates a not-yet-computed zero into a fabricated fleet total.
+	PRsMerged90d   *int `json:"prs_merged_90d,omitempty"`
+	PRsRejected90d *int `json:"prs_rejected_90d,omitempty"`
+	CVEsClosed     *int `json:"cves_closed,omitempty"`
 }
 
 type StatusCollector func() *HeartbeatPayload

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -82,6 +82,13 @@ type RegistryEntry struct {
 	GitHubAppPermIssue        string             `json:"githubAppPermIssue,omitempty"`
 	PendingGitHubAppInstall   bool               `json:"pendingGitHubAppInstall,omitempty"`
 	PendingGitHubAppInstallAt time.Time          `json:"pendingGitHubAppInstallAt,omitempty"`
+	// Fleet contribution counts reported by the spoke (nil = not reported /
+	// not yet computed). Aggregated across public, non-stale hives into the
+	// /api/fleet-stats total. Pointers preserve the nil-vs-zero distinction so
+	// a hive that never reported is never counted as a zero.
+	PRsMerged90d   *int `json:"prsMerged90d,omitempty"`
+	PRsRejected90d *int `json:"prsRejected90d,omitempty"`
+	CVEsClosed     *int `json:"cvesClosed,omitempty"`
 }
 
 type SparkPoint struct {
@@ -252,6 +259,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 	s.mux.HandleFunc("GET /api/registry", s.handleRegistry)
 	s.mux.HandleFunc("GET /api/hub/leaderboard", s.handleLeaderboard)
 	s.mux.HandleFunc("GET /api/hub/stats", s.handleStats)
+	s.mux.HandleFunc("GET /api/fleet-stats", s.handleFleetStats)
 	s.mux.HandleFunc("GET /api/hub/version", s.handleHubVersion)
 	s.mux.HandleFunc("DELETE /api/hub/registry/{id}", s.handleRegistryDelete)
 	s.mux.HandleFunc("POST /api/contribute/register", s.handleContributeProxy)
@@ -466,6 +474,9 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			}
 			return time.Time{}
 		}(),
+		PRsMerged90d:   clampFleetCount(payload.PRsMerged90d),
+		PRsRejected90d: clampFleetCount(payload.PRsRejected90d),
+		CVEsClosed:     clampFleetCount(payload.CVEsClosed),
 	}
 
 	// Populate ClusterID from SaaS hive record, heartbeat payload, or default.
@@ -917,6 +928,77 @@ func (s *HubServer) handleStats(w http.ResponseWriter, r *http.Request) {
 	w.Write(data)
 }
 
+// FleetStats is the aggregated, fleet-wide contribution total exposed at
+// GET /api/fleet-stats and rendered by the public landing page's hero-proof
+// strip. It sums the spoke-reported counts across every PUBLIC, non-stale
+// hive, so the numbers are a true fleet total (every managed repo of every
+// live spoke) rather than a single org's figures.
+type FleetStats struct {
+	ReposManaged int    `json:"repos_managed"`
+	PRsMerged    int    `json:"prs_merged"`
+	PRsRejected  int    `json:"prs_rejected"`
+	CVEsClosed   int    `json:"cves_closed"`
+	Hives        int    `json:"hives"`
+	UpdatedAt    string `json:"updated_at"`
+}
+
+// computeFleetStats aggregates fleet-wide contribution counts across public,
+// non-stale hives. A hive that never reported a given count (nil pointer) is
+// skipped for that count — the aggregate reflects only hives with real data,
+// so a not-yet-computed zero is never fabricated into the total. Distinct
+// repos are counted across hives (deduplicated by org/repo reference) so two
+// hives on the same repo don't double-count it.
+//
+// Caller must hold s.mu (read or write).
+func (s *HubServer) computeFleetStats() FleetStats {
+	var fs FleetStats
+	repoSet := make(map[string]struct{})
+	for _, h := range s.registry.Hives {
+		if !h.IsPublic || !h.Online {
+			continue
+		}
+		fs.Hives++
+		for _, r := range h.Repos {
+			if r == "" {
+				continue
+			}
+			// Normalize a bare "repo" to "org/repo" so the same repo reported
+			// with and without an org prefix isn't counted twice.
+			key := r
+			if !strings.Contains(r, "/") && h.Org != "" {
+				key = h.Org + "/" + r
+			}
+			repoSet[key] = struct{}{}
+		}
+		if h.PRsMerged90d != nil {
+			fs.PRsMerged += *h.PRsMerged90d
+		}
+		if h.PRsRejected90d != nil {
+			fs.PRsRejected += *h.PRsRejected90d
+		}
+		if h.CVEsClosed != nil {
+			fs.CVEsClosed += *h.CVEsClosed
+		}
+	}
+	fs.ReposManaged = len(repoSet)
+	return fs
+}
+
+func (s *HubServer) handleFleetStats(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	s.markStaleHives()
+	s.mu.Unlock()
+
+	s.mu.RLock()
+	fs := s.computeFleetStats()
+	s.mu.RUnlock()
+	fs.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+
+	data, _ := json.Marshal(fs)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(data)
+}
+
 // removeRegistryEntry removes a hive from the in-memory registry by ID.
 func (s *HubServer) removeRegistryEntry(id, by string) {
 	s.mu.Lock()
@@ -1207,6 +1289,24 @@ func clampInt(v, min, max int) int {
 		return max
 	}
 	return v
+}
+
+// maxFleetCount bounds a single hive's reported fleet contribution count, so a
+// malicious or buggy spoke can't inflate the public fleet total with an absurd
+// value. Ten million PRs from one hive is already far beyond plausible.
+const maxFleetCount = 10_000_000
+
+// clampFleetCount validates a spoke-reported fleet count pointer. nil stays nil
+// (the hive reported nothing — it must NOT be aggregated as a zero). A negative
+// value is treated as nil (garbage → don't count). Otherwise it is clamped to
+// [0, maxFleetCount] and returned as a fresh pointer (never aliasing the
+// caller's payload).
+func clampFleetCount(v *int) *int {
+	if v == nil || *v < 0 {
+		return nil
+	}
+	c := clampInt(*v, 0, maxFleetCount)
+	return &c
 }
 
 func clampInt64(v, min, max int64) int64 {

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -6,10 +6,10 @@
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🍯</text></svg>">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta property="og:title" content="Hive — AI agents that maintain your repo">
-  <meta property="og:description" content="You earn automation with test coverage. Hive runs a fleet of AI agents on your backlog behind six autonomy levels — raise coverage, then raise how much the agents are allowed to do.">
+  <meta property="og:description" content="Put your repo on autopilot. Hive runs a fleet of AI agents on your backlog behind six autonomy levels — test coverage earns the confidence to raise a level, and you (the admin) choose when to raise it.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://hive.kubestellar.io">
-  <meta name="description" content="Hive — you earn automation with test coverage. AI agents triage issues, write fixes, and patch CVEs behind six autonomy levels, from advisory to auto-merge. Raise coverage, then raise autonomy.">
+  <meta name="description" content="Hive — the AI maintainer you own outright. AI agents triage issues, write fixes, patch CVEs, and merge on green behind six autonomy levels. Coverage earns the confidence to level up; the admin decides when to raise it.">
   <title>Hive — AI agents that maintain your repo</title>
   <style>
     :root {
@@ -148,8 +148,39 @@
     .hero-sub-links a { color: var(--blue); }
     .hero-sub-links a:hover { text-decoration: underline; }
 
-    /* ── Hero proof strip: the receipts behind the coverage claim. Every figure
-       here is checkable via the public GitHub API on the kubestellar org. ── */
+    /* ── Hero rotator: crossfading value statements. Slides are absolutely
+       stacked so the block height stays stable while they fade; a spacer sizes
+       it to the tallest slide. Auto-rotation is JS-driven and disabled under
+       prefers-reduced-motion (handled in JS, not just CSS). ── */
+    .hero-rotator { position: relative; }
+    .hero-slide {
+      position: absolute; inset: 0;
+      opacity: 0; visibility: hidden;
+      transition: opacity .6s ease;
+    }
+    .hero-slide.is-active { opacity: 1; visibility: visible; }
+    .hero-slide-spacer { visibility: hidden; }
+    .hero-slide h1, .hero-slide-spacer h1 { margin: 0; }
+    @media (prefers-reduced-motion: reduce) {
+      .hero-slide { transition: none; }
+    }
+    .hero-dots {
+      display: flex; gap: .55rem; margin-top: 1.4rem;
+    }
+    .hero-dot {
+      width: .55rem; height: .55rem; border-radius: 999px;
+      border: 0; padding: 0; cursor: pointer;
+      background: #ffffff2e;
+      transition: background .2s, transform .2s;
+    }
+    .hero-dot:hover { background: #ffffff5c; }
+    .hero-dot.is-active { background: var(--amber); transform: scale(1.15); }
+    .hero-dot:focus-visible { outline: 2px solid var(--amber); outline-offset: 3px; }
+
+    /* ── Hero proof strip: the live fleet-stats receipts. Numbers are fetched
+       from /api/fleet-stats — a fleet-wide total across every repo Hive manages
+       (all registered public spokes), NOT a single org. A stat is hidden when
+       unavailable rather than showing a fabricated number. ── */
     .hero-proof {
       display: flex;
       flex-wrap: wrap;
@@ -530,32 +561,65 @@
     <section class="hero section-pad" id="product">
       <div>
         <p class="section-label">Earned Autonomy for AI Agents</p>
-        <h1>You earn automation with test coverage</h1>
-        <p class="hero-lede">Hive runs a fleet of AI agents against your backlog &mdash; triaging issues, writing fixes, and patching CVEs. What makes that safe is the sequencing: raise your test coverage, and only then raise how much the agents are allowed to do. Six autonomy levels, from advisory to auto-merge. You move up when your tests justify it, not when you feel optimistic.</p>
+
+        <!-- ── Rotating hero: 5 value statements, auto-crossfading (JS). The
+             spacer sizes the block to the tallest slide so nothing jumps as
+             slides fade. Auto-rotation is disabled under prefers-reduced-motion. -->
+        <div class="hero-rotator" id="hero-rotator" aria-live="polite">
+          <!-- Spacer (aria-hidden, non-interactive): duplicates the tallest slide
+               so the rotator reserves its height and nothing jumps on crossfade. -->
+          <div class="hero-slide-spacer" aria-hidden="true">
+            <h1>You earn automation with test coverage</h1>
+            <p class="hero-lede">Six autonomy levels, from advisory to auto-merge. Strong test coverage is what earns the confidence to raise a level &mdash; and you, the admin, decide when to raise it. Your tests tell you when it's safe; the choice is always yours.</p>
+          </div>
+          <div class="hero-slide is-active">
+            <h1>Put your repo on autopilot</h1>
+            <p class="hero-lede">A fleet of AI agents triages your issues, writes the fixes, opens the PRs, and merges them on green &mdash; so maintainers get their time back for the work that actually needs a human.</p>
+          </div>
+          <div class="hero-slide">
+            <h1>You earn automation with test coverage</h1>
+            <p class="hero-lede">Six autonomy levels, from advisory to auto-merge. Strong test coverage is what earns the confidence to raise a level &mdash; and you, the admin, decide when to raise it. Your tests tell you when it's safe; the choice is always yours.</p>
+          </div>
+          <div class="hero-slide">
+            <h1>A deterministic pipeline, not a prompt</h1>
+            <p class="hero-lede">Every fix runs the gauntlet &mdash; build, lint, test, and policy checks &mdash; before anything merges. Autonomy comes from a repeatable pipeline you can audit, not from trusting a model's good mood.</p>
+          </div>
+          <div class="hero-slide">
+            <h1>From a big issue to a reviewed plan</h1>
+            <p class="hero-lede">Click Plan and the architect breaks an epic into a task DAG for you to approve before any work begins. You review the plan; the fleet executes it (ACMM L5&ndash;L6).</p>
+          </div>
+          <div class="hero-slide">
+            <h1>The AI maintainer you own outright</h1>
+            <p class="hero-lede">Free, open-source, and self-hosted. Point it at your repo, bring your own model, and run the whole fleet on your own terms &mdash; no per-seat license, no data leaving your cluster.</p>
+          </div>
+        </div>
+
+        <div class="hero-dots" id="hero-dots" role="tablist" aria-label="Hero highlights"></div>
+
         <div class="hero-actions">
           <a class="button primary" href="/get-started">Request a Hive</a>
           <a class="button secondary" href="#how-it-works">See how it works</a>
           <a class="button tertiary" href="https://arxiv.org/abs/2604.09388" target="_blank">Read the ACMM paper</a>
         </div>
-        <div class="hero-proof">
+        <div class="hero-proof" id="hero-proof">
           <div>
             <strong>90%</strong>
             <span>per-package coverage gate, enforced on every build</span>
           </div>
-          <div>
-            <strong>~14%</strong>
-            <span>of agent PRs rejected by the pipeline</span>
+          <div id="proof-prs-merged" hidden>
+            <strong data-stat="prs_merged">—</strong>
+            <span>PRs merged in the last 90 days, fleet-wide</span>
           </div>
-          <div>
-            <strong>42</strong>
-            <span>merged PRs closing named CVEs</span>
+          <div id="proof-prs-rejected" hidden>
+            <strong data-stat="prs_rejected">—</strong>
+            <span>agent PRs the pipeline rejected before merge (90d)</span>
           </div>
-          <div>
-            <strong>~4,000</strong>
-            <span>PRs merged last quarter across six repos</span>
+          <div id="proof-cves" hidden>
+            <strong data-stat="cves_closed">—</strong>
+            <span>merged PRs referencing a named CVE</span>
           </div>
         </div>
-        <p class="hero-proof-note">Measured on our own repos &mdash; Hive maintains Hive. Every figure is checkable in the <a href="https://github.com/kubestellar" target="_blank" rel="noopener">kubestellar org</a>, including the reverts where our test suite caught an agent regression and the fleet backed itself out.</p>
+        <p class="hero-proof-note" id="hero-proof-note">The <strong>90% coverage gate</strong> is enforced on Hive's own build. The other figures are <span id="proof-live-label">live</span> across every repo Hive manages &mdash; the fleet of <a href="#hives">public hives</a> below &mdash; aggregated over their spokes' contributions. <a href="/learn" target="_blank" rel="noopener">Learn how earned autonomy works</a>.</p>
         <p class="hero-sub-links">Already running a hive? <a href="/dashboard">Open your dashboard</a> &middot; <a href="/learn">Learn the concepts</a></p>
       </div>
 
@@ -616,7 +680,7 @@
       <div class="section-heading">
         <p class="section-label">How it works</p>
         <h2>Coverage first, then autonomy</h2>
-        <p>Point a hive at your repository and start at L1, where agents only advise. As your coverage climbs, you raise the autonomy level and agents take on more &mdash; filing issues, opening hold-gated PRs, and eventually merging on green. A governor decides minute by minute how hard they work based on your queue depth. Hive doesn&rsquo;t replace maintainers; it earns its way into the work.</p>
+        <p>Point a hive at your repository and start at L1, where agents only advise. Strong test coverage is what earns the confidence to go further &mdash; but the autonomy level never rises on its own. You (the admin) choose to raise it, and only then do agents take on more: filing issues, opening hold-gated PRs, and eventually merging on green. Coverage tells you when it's safe to level up; the decision is always yours. A governor decides minute by minute how hard they work based on your queue depth. Hive doesn&rsquo;t replace maintainers; it earns its way into the work.</p>
       </div>
       <div class="loop-rail">
         <div class="loop-step"><span>01</span><h3>Issue filed</h3><p style="font-size:.86rem">A bug report, feature request, or dependency alert lands on the repo.</p></div>
@@ -1155,6 +1219,97 @@
       if (!document.hidden) { loadRegistry(); loadLeaderboard(); }
     });
     window.addEventListener('focus', function() { loadRegistry(); loadLeaderboard(); });
+
+    // ── Rotating hero: crossfade through the value-statement slides on a timer,
+    // build clickable dot indicators, and pause auto-rotation for users who
+    // prefer reduced motion (they still get working dots to page manually). ──
+    (function heroRotator() {
+      var HERO_ROTATE_MS = 6000;
+      var rotator = document.getElementById('hero-rotator');
+      var dotsWrap = document.getElementById('hero-dots');
+      if (!rotator || !dotsWrap) return;
+      var slides = Array.prototype.slice.call(rotator.querySelectorAll('.hero-slide'));
+      if (slides.length < 2) return;
+      var idx = 0;
+      var dots = slides.map(function(_, i) {
+        var b = document.createElement('button');
+        b.className = 'hero-dot' + (i === 0 ? ' is-active' : '');
+        b.type = 'button';
+        b.setAttribute('role', 'tab');
+        b.setAttribute('aria-label', 'Show highlight ' + (i + 1));
+        b.setAttribute('aria-selected', i === 0 ? 'true' : 'false');
+        b.addEventListener('click', function() { show(i); restart(); });
+        dotsWrap.appendChild(b);
+        return b;
+      });
+      function show(n) {
+        idx = (n + slides.length) % slides.length;
+        slides.forEach(function(s, i) { s.classList.toggle('is-active', i === idx); });
+        dots.forEach(function(d, i) {
+          var on = i === idx;
+          d.classList.toggle('is-active', on);
+          d.setAttribute('aria-selected', on ? 'true' : 'false');
+        });
+      }
+      var timer = null;
+      var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      function restart() {
+        if (reduce) return;
+        if (timer) clearInterval(timer);
+        timer = setInterval(function() { show(idx + 1); }, HERO_ROTATE_MS);
+      }
+      restart();
+      // Pause while the tab is hidden so slides don't silently churn offscreen.
+      document.addEventListener('visibilitychange', function() {
+        if (document.hidden) { if (timer) { clearInterval(timer); timer = null; } }
+        else { restart(); }
+      });
+    })();
+
+    // ── Live fleet stats: fetch /api/fleet-stats and fill the hero-proof strip.
+    // Only reveal a stat when the fleet actually reports a positive number — a
+    // zero or missing value keeps the stat HIDDEN rather than showing a fake or
+    // misleading figure. If no live data at all, the strip falls back to just
+    // the static 90% coverage stat plus a qualitative line. ──
+    (function loadFleetStats() {
+      var FLEET_POLL_MS = 60000;
+      var LIVE_STATS = [
+        { key: 'prs_merged', box: 'proof-prs-merged' },
+        { key: 'prs_rejected', box: 'proof-prs-rejected' },
+        { key: 'cves_closed', box: 'proof-cves' }
+      ];
+      function fmt(n) { return n.toLocaleString('en-US'); }
+      function apply(data) {
+        var anyLive = false;
+        LIVE_STATS.forEach(function(s) {
+          var box = document.getElementById(s.box);
+          if (!box) return;
+          var val = data && typeof data[s.key] === 'number' ? data[s.key] : 0;
+          if (val > 0) {
+            box.querySelector('[data-stat]').textContent = fmt(val);
+            box.hidden = false;
+            anyLive = true;
+          } else {
+            box.hidden = true;
+          }
+        });
+        var note = document.getElementById('hero-proof-note');
+        if (!anyLive && note) {
+          // No fleet data yet: don't imply live numbers exist. Swap to a
+          // qualitative line alongside the (always-true) 90% coverage stat.
+          note.innerHTML = 'The <strong>90% coverage gate</strong> is enforced on Hive\'s own build under <code>-race</code>. Spin up a hive and your fleet\'s merged-PR, rejected-PR, and CVE totals appear here, live. <a href="/learn" target="_blank" rel="noopener">Learn how earned autonomy works</a>.';
+        }
+      }
+      function go() {
+        fetch('/api/fleet-stats')
+          .then(function(r) { return r.json(); })
+          .then(apply)
+          .catch(function() { apply(null); });
+      }
+      go();
+      setInterval(go, FLEET_POLL_MS);
+      window.addEventListener('focus', go);
+    })();
 
     var _userAccessStatus = {};
 


### PR DESCRIPTION
Backport of #2065 (landing overhaul) to `mk` per the all-branches policy.

Cherry-pick applied cleanly (`git cherry-pick -x f0b56677`); git auto-merged the divergent files (server.go, main.go, index.html) with no manual conflict resolution needed. New additive files (fleet_stats*.go, fleet_stats_collector*.go) applied as-is. Only the fleet-stats/landing changes were added; mk's branch-specific content is preserved.

Verification:
- `go build ./...` clean
- `go vet ./pkg/hub/ ./pkg/dashboard/ ./pkg/github/` clean
- Tests: hub 90.0%, github 95.9%, dashboard 80.2% coverage
- `-race` clean on pkg/hub and pkg/github
- gofmt clean on touched files

Do not merge until CI is green.