### PR TITLE
🐛 hub landing: fix hero spacing, slow the carousel, drop -race jargon

### DIFF
--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -160,7 +160,10 @@
     }
     .hero-slide.is-active { opacity: 1; visibility: visible; }
     .hero-slide-spacer { visibility: hidden; }
-    .hero-slide h1, .hero-slide-spacer h1 { margin: 0; }
+    /* Slides and the spacer must measure identically or the crossfade jumps —
+       but zeroing the margin let the h1's descenders (line-height .92) collide
+       with the lede below. Keep them equal, just not zero. */
+    .hero-slide h1, .hero-slide-spacer h1 { margin: 0 0 1.15rem; }
     @media (prefers-reduced-motion: reduce) {
       .hero-slide { transition: none; }
     }
@@ -1224,7 +1227,10 @@
     // build clickable dot indicators, and pause auto-rotation for users who
     // prefer reduced motion (they still get working dots to page manually). ──
     (function heroRotator() {
-      var HERO_ROTATE_MS = 6000;
+      // 6s was not enough to read a headline plus a three-line lede before the
+      // slide changed out from under you. 11s reads comfortably; the dots stay
+      // available to page manually at any time.
+      var HERO_ROTATE_MS = 11000;
       var rotator = document.getElementById('hero-rotator');
       var dotsWrap = document.getElementById('hero-dots');
       if (!rotator || !dotsWrap) return;


### PR DESCRIPTION
Three fixes to the rotating hero on the public landing page, applied to all four long-lived branches (v2/v3/mk/dd).

## 1. Hero spacing

```css
.hero-slide h1, .hero-slide-spacer h1 { margin: 0; }
```

This overrode the base `h1`'s `margin-bottom: 1.3rem`, and with `line-height: .92` the headline's descenders ran straight into the lede. Most visible on the slide whose headline wraps to "...not a **p**rom**p**t".

The zero wasn't arbitrary — slides and the spacer must measure identically or the crossfade jumps. Keeping them **equal at `1.15rem`** preserves that and restores the gap (18px measured).

## 2. Carousel 6s → 11s

Six seconds isn't enough to read a headline plus a three-line lede before the slide changes out from under you; the longest lede is 34 words. Verified by watching real transitions, which landed at 7s and 18s. The dots still page manually, and `prefers-reduced-motion` still pauses rotation.

## 3. Drop `-race`

Re-introduced by the rotating-hero backport (#2065 and its ports). It's a Go test flag — meaningless to a maintainer evaluating Hive. The claim now reads "enforced on every build".

## Note on the missing live stats

Not a bug in this page. `/api/fleet-stats` returns 200 with:

```json
{"repos_managed":30,"prs_merged":0,"prs_rejected":0,"cves_closed":0,"hives":11}
```

The strip hides any stat where `val > 0` is false, which is the correct behaviour — it refuses to render a fabricated zero. The three counts come from spokes reporting `prs_merged_90d` / `prs_rejected_90d` / `cves_closed` over heartbeat, and no spoke has reported them yet. The collector (`v2/pkg/dashboard/fleet_stats_collector.go`) exists, so this should populate once spokes pick up a build containing it. Untouched here.