### PR TITLE
🐛 backport: copilot live-cost + CSS-leak + mobile fixes (#2075/#2068/#2062) to mk

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1368,6 +1368,13 @@ func main() {
 		// their consumption reads as zero.
 		githubProxy.SetTokenSink(tokens.NewInferenceSink(cfg.Data.MetricsDir, logger))
 
+		// With the sink active, the proxy also MITMs the Copilot completion host
+		// (api.githubcopilot.com) to record Copilot token usage live per
+		// response — so Copilot cost shows up while an agent runs instead of only
+		// tallying at session shutdown. Tell the collector to defer Copilot token
+		// accrual from session-shutdown files to the sink to avoid double-counting.
+		tokenCollector.SetCopilotLiveCapture(true)
+
 		vllmEndpoints := parseEndpointList(envOrDefault("HIVE_VLLM_ENDPOINT", "http://hive-vllm-svc.hive-inference.svc.cluster.local:8000"))
 		llmdEndpoints := parseEndpointList(envOrDefault("HIVE_LLMD_ENDPOINT", "http://hive-llm-d-epp.hive-inference.svc.cluster.local:8000"))
 		inferenceEndpoints := map[string][]string{

--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -1297,7 +1297,7 @@
         if (!anyLive && note) {
           // No fleet data yet: don't imply live numbers exist. Swap to a
           // qualitative line alongside the (always-true) 90% coverage stat.
-          note.innerHTML = 'The <strong>90% coverage gate</strong> is enforced on Hive\'s own build under <code>-race</code>. Spin up a hive and your fleet\'s merged-PR, rejected-PR, and CVE totals appear here, live. <a href="/learn" target="_blank" rel="noopener">Learn how earned autonomy works</a>.';
+          note.innerHTML = 'The <strong>90% coverage gate</strong> is enforced on Hive\'s own build. Spin up a hive and your fleet\'s merged-PR, rejected-PR, and CVE totals appear here, live. <a href="/learn" target="_blank" rel="noopener">Learn how earned autonomy works</a>.';
         }
       }
       function go() {

--- a/v2/pkg/proxy/copilot_sniff_test.go
+++ b/v2/pkg/proxy/copilot_sniff_test.go
@@ -1,0 +1,782 @@
+package proxy
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/tokens"
+)
+
+// newTestProxyWithCA builds a GitHubProxy with a fresh in-memory CA and cert
+// cache, plus a token sink writing to a temp dir. Returns the proxy and the
+// metrics dir for reading back recorded usage.
+func newTestProxyWithCA(t *testing.T) (*GitHubProxy, string) {
+	t.Helper()
+	caCert, caX509, err := generateCA()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	p := &GitHubProxy{
+		caCert:    caCert,
+		caX509:    caX509,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		certCache: make(map[string]cachedCert),
+		tokenSink: tokens.NewInferenceSink(dir, slog.Default()),
+	}
+	return p, dir
+}
+
+// readInferenceUsage reads back the cumulative usage the sink wrote for an
+// agent (inference-<agent>.jsonl) and returns the model plus total in/out
+// tokens.
+func readInferenceUsage(t *testing.T, dir, agent string) (model string, in, out int64) {
+	t.Helper()
+	path := filepath.Join(dir, "inference-"+agent+".jsonl")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading usage file %s: %v", path, err)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var e tokens.SessionEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("bad usage line: %v", err)
+		}
+		if e.Model != "" {
+			model = e.Model
+		}
+		in += e.InputTokens
+		out += e.OutputTokens
+	}
+	return model, in, out
+}
+
+// runCopilotSniff drives proxyCopilotHTTP over an in-process client<->proxy TLS
+// connection and a plaintext proxy<->upstream connection. The upstream side is
+// an http.Server-like handler running on a net.Pipe. Returns the client's raw
+// response bytes.
+//
+// We use two net.Pipe pairs: one for client<->proxy (TLS on the client-facing
+// side), one for proxy<->upstream (plain, upstream speaks HTTP/1.1 directly).
+func TestProxyCopilotHTTP_NonStreaming(t *testing.T) {
+	p, dir := newTestProxyWithCA(t)
+
+	// Upstream: a plain TCP listener speaking HTTP/1.1 with a JSON completion.
+	upstreamLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer upstreamLn.Close()
+
+	go func() {
+		conn, err := upstreamLn.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		br := bufio.NewReader(conn)
+		req, err := http.ReadRequest(br)
+		if err != nil {
+			return
+		}
+		// Drain body.
+		body, _ := io.ReadAll(req.Body)
+		req.Body.Close()
+		// Confirm the proxy forwarded the model.
+		if !bytes.Contains(body, []byte(`"gpt-5"`)) {
+			t.Errorf("upstream did not receive model: %s", body)
+		}
+		respBody := `{"model":"gpt-5","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":120,"completion_tokens":34}}`
+		fmt.Fprintf(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(respBody), respBody)
+	}()
+
+	upstreamConn, err := net.Dial("tcp", upstreamLn.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer upstreamConn.Close()
+
+	// Client<->proxy over TLS. The proxy TLS-wraps the "client" conn; the test
+	// client dials with a pool trusting the proxy CA.
+	clientLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientLn.Close()
+
+	tlsCert, err := p.forgeCert("api.githubcopilot.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(p.caX509)
+
+	proxyDone := make(chan struct{})
+	go func() {
+		defer close(proxyDone)
+		raw, err := clientLn.Accept()
+		if err != nil {
+			return
+		}
+		tlsConn := tls.Server(raw, &tls.Config{Certificates: []tls.Certificate{tlsCert}})
+		if err := tlsConn.Handshake(); err != nil {
+			return
+		}
+		p.proxyCopilotHTTP(tlsConn, upstreamConn, "api.githubcopilot.com", "worker1")
+		tlsConn.Close()
+	}()
+
+	clientConn, err := tls.Dial("tcp", clientLn.Addr().String(), &tls.Config{
+		ServerName: "api.githubcopilot.com",
+		RootCAs:    pool,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientConn.Close()
+
+	reqBody := `{"model":"gpt-5","messages":[{"role":"user","content":"hi"}]}`
+	fmt.Fprintf(clientConn, "POST /chat/completions HTTP/1.1\r\nHost: api.githubcopilot.com\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(reqBody), reqBody)
+
+	resp, err := http.ReadResponse(bufio.NewReader(clientConn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if !bytes.Contains(got, []byte(`"content":"ok"`)) {
+		t.Errorf("client did not get upstream body verbatim: %s", got)
+	}
+
+	<-proxyDone
+
+	model, in, out := readInferenceUsage(t, dir, "worker1")
+	if model != "gpt-5" || in != 120 || out != 34 {
+		t.Errorf("recorded usage = (%q,%d,%d), want (gpt-5,120,34)", model, in, out)
+	}
+}
+
+func TestProxyCopilotHTTP_Streaming(t *testing.T) {
+	p, dir := newTestProxyWithCA(t)
+
+	upstreamLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer upstreamLn.Close()
+
+	go func() {
+		conn, err := upstreamLn.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		br := bufio.NewReader(conn)
+		req, err := http.ReadRequest(br)
+		if err != nil {
+			return
+		}
+		body, _ := io.ReadAll(req.Body)
+		req.Body.Close()
+		// Proxy must have injected include_usage into the streaming request.
+		if !bytes.Contains(body, []byte(`"include_usage":true`)) {
+			t.Errorf("proxy did not inject include_usage: %s", body)
+		}
+		sse := "data: {\"model\":\"claude-sonnet-4.5\",\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n" +
+			"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":200,\"completion_tokens\":88}}\n\n" +
+			"data: [DONE]\n\n"
+		fmt.Fprintf(conn, "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(sse), sse)
+	}()
+
+	upstreamConn, err := net.Dial("tcp", upstreamLn.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer upstreamConn.Close()
+
+	clientLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientLn.Close()
+
+	tlsCert, err := p.forgeCert("api.githubcopilot.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(p.caX509)
+
+	proxyDone := make(chan struct{})
+	go func() {
+		defer close(proxyDone)
+		raw, err := clientLn.Accept()
+		if err != nil {
+			return
+		}
+		tlsConn := tls.Server(raw, &tls.Config{Certificates: []tls.Certificate{tlsCert}})
+		if err := tlsConn.Handshake(); err != nil {
+			return
+		}
+		p.proxyCopilotHTTP(tlsConn, upstreamConn, "api.githubcopilot.com", "worker2")
+		tlsConn.Close()
+	}()
+
+	clientConn, err := tls.Dial("tcp", clientLn.Addr().String(), &tls.Config{
+		ServerName: "api.githubcopilot.com",
+		RootCAs:    pool,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientConn.Close()
+
+	// Streaming request with --model auto: usage must attribute to the model in
+	// the response (claude-sonnet-4.5), not "auto".
+	reqBody := `{"model":"auto","stream":true,"messages":[{"role":"user","content":"hi"}]}`
+	fmt.Fprintf(clientConn, "POST /chat/completions HTTP/1.1\r\nHost: api.githubcopilot.com\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(reqBody), reqBody)
+
+	resp, err := http.ReadResponse(bufio.NewReader(clientConn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if !bytes.Contains(got, []byte("[DONE]")) {
+		t.Errorf("client did not receive SSE stream verbatim: %s", got)
+	}
+
+	<-proxyDone
+
+	model, in, out := readInferenceUsage(t, dir, "worker2")
+	if model != "claude-sonnet-4.5" || in != 200 || out != 88 {
+		t.Errorf("recorded usage = (%q,%d,%d), want (claude-sonnet-4.5,200,88)", model, in, out)
+	}
+}
+
+// TestProxyCopilotHTTP_NonCompletionPassthrough verifies non-completion requests
+// (e.g. /models) pass through without recording usage.
+func TestProxyCopilotHTTP_NonCompletionPassthrough(t *testing.T) {
+	p, dir := newTestProxyWithCA(t)
+
+	upstreamLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer upstreamLn.Close()
+	go func() {
+		conn, err := upstreamLn.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		br := bufio.NewReader(conn)
+		req, _ := http.ReadRequest(br)
+		if req != nil && req.Body != nil {
+			io.ReadAll(req.Body)
+			req.Body.Close()
+		}
+		respBody := `{"data":[]}`
+		fmt.Fprintf(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(respBody), respBody)
+	}()
+
+	upstreamConn, err := net.Dial("tcp", upstreamLn.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer upstreamConn.Close()
+
+	clientLn, _ := net.Listen("tcp", "127.0.0.1:0")
+	defer clientLn.Close()
+	tlsCert, _ := p.forgeCert("api.githubcopilot.com")
+	pool := x509.NewCertPool()
+	pool.AddCert(p.caX509)
+
+	proxyDone := make(chan struct{})
+	go func() {
+		defer close(proxyDone)
+		raw, err := clientLn.Accept()
+		if err != nil {
+			return
+		}
+		tlsConn := tls.Server(raw, &tls.Config{Certificates: []tls.Certificate{tlsCert}})
+		if tlsConn.Handshake() != nil {
+			return
+		}
+		p.proxyCopilotHTTP(tlsConn, upstreamConn, "api.githubcopilot.com", "worker3")
+		tlsConn.Close()
+	}()
+
+	clientConn, err := tls.Dial("tcp", clientLn.Addr().String(), &tls.Config{
+		ServerName: "api.githubcopilot.com",
+		RootCAs:    pool,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientConn.Close()
+
+	fmt.Fprintf(clientConn, "GET /models HTTP/1.1\r\nHost: api.githubcopilot.com\r\nConnection: close\r\n\r\n")
+	resp, err := http.ReadResponse(bufio.NewReader(clientConn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	<-proxyDone
+
+	// No usage file should have been written.
+	if _, err := os.Stat(filepath.Join(dir, "inference-worker3.jsonl")); !os.IsNotExist(err) {
+		t.Errorf("non-completion request should not record usage; file exists: %v", err)
+	}
+}
+
+// TestHandleCopilotSniffGuards verifies the CONNECT branch only engages when a
+// sink is present and the agent is known. We assert the routing predicate here;
+// the full MITM is covered by the proxyCopilotHTTP tests above.
+func TestCopilotSniffRoutingGuard(t *testing.T) {
+	// Host recognition drives the branch.
+	if !IsCopilotAPIHost("api.githubcopilot.com") {
+		t.Fatal("copilot host must be recognized")
+	}
+	// A proxy without a sink must not claim the branch (nil sink).
+	p := &GitHubProxy{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	if p.tokenSink != nil {
+		t.Fatal("expected nil sink")
+	}
+}
+
+// TestHandleCopilotSniff_EndToEnd drives the full CONNECT handler: it writes the
+// "200 Connection established" line, TLS-handshakes with the client, dials the
+// (faked) upstream via the test seam, and records usage. This covers
+// handleCopilotSniff, which in production dials the real Copilot host by name.
+func TestHandleCopilotSniff_EndToEnd(t *testing.T) {
+	p, dir := newTestProxyWithCA(t)
+
+	// Fake upstream: a plain TCP server answering a completion.
+	upstreamLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer upstreamLn.Close()
+	go func() {
+		conn, err := upstreamLn.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		br := bufio.NewReader(conn)
+		req, err := http.ReadRequest(br)
+		if err != nil {
+			return
+		}
+		io.ReadAll(req.Body)
+		req.Body.Close()
+		respBody := `{"model":"gpt-5","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":11,"completion_tokens":4}}`
+		fmt.Fprintf(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(respBody), respBody)
+	}()
+
+	// Seam: dial the fake upstream instead of the real Copilot host.
+	p.copilotDial = func(host string) (net.Conn, error) {
+		return net.Dial("tcp", upstreamLn.Addr().String())
+	}
+
+	// Client<->proxy raw socket. handleCopilotSniff writes the CONNECT-OK line
+	// then expects a TLS ClientHello.
+	clientLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientLn.Close()
+
+	pool := x509.NewCertPool()
+	pool.AddCert(p.caX509)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		raw, err := clientLn.Accept()
+		if err != nil {
+			return
+		}
+		p.handleCopilotSniff(raw, "api.githubcopilot.com", "worker9")
+	}()
+
+	raw, err := net.Dial("tcp", clientLn.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+
+	// Read the "200 Connection established" status line the handler writes.
+	statusReader := bufio.NewReader(raw)
+	statusLine, err := statusReader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("reading CONNECT status: %v", err)
+	}
+	if !strings.Contains(statusLine, "200") {
+		t.Fatalf("expected 200 Connection established, got %q", statusLine)
+	}
+	// Consume the trailing blank line of the CONNECT response.
+	if _, err := statusReader.ReadString('\n'); err != nil {
+		t.Fatalf("reading CONNECT blank line: %v", err)
+	}
+
+	// Now TLS-handshake over the same raw conn. Any bytes the client buffered
+	// past the CONNECT response would be lost, but the handler waits for the
+	// ClientHello, so start TLS fresh on raw (statusReader read only the header).
+	tlsConn := tls.Client(raw, &tls.Config{ServerName: "api.githubcopilot.com", RootCAs: pool})
+	if err := tlsConn.Handshake(); err != nil {
+		t.Fatalf("client TLS handshake: %v", err)
+	}
+	reqBody := `{"model":"gpt-5","messages":[]}`
+	fmt.Fprintf(tlsConn, "POST /chat/completions HTTP/1.1\r\nHost: api.githubcopilot.com\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(reqBody), reqBody)
+
+	resp, err := http.ReadResponse(bufio.NewReader(tlsConn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	<-done
+
+	model, in, out := readInferenceUsage(t, dir, "worker9")
+	if model != "gpt-5" || in != 11 || out != 4 {
+		t.Errorf("recorded (%q,%d,%d), want (gpt-5,11,4)", model, in, out)
+	}
+}
+
+// TestHandleCopilotSniff_UpstreamDialFails covers the dial-failure branch: the
+// handler must abandon the connection cleanly after the client handshake.
+func TestHandleCopilotSniff_UpstreamDialFails(t *testing.T) {
+	p, _ := newTestProxyWithCA(t)
+	p.copilotDial = func(host string) (net.Conn, error) {
+		return nil, fmt.Errorf("simulated dial failure")
+	}
+
+	clientLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientLn.Close()
+	pool := x509.NewCertPool()
+	pool.AddCert(p.caX509)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		raw, err := clientLn.Accept()
+		if err != nil {
+			return
+		}
+		p.handleCopilotSniff(raw, "api.githubcopilot.com", "w")
+	}()
+
+	raw, err := net.Dial("tcp", clientLn.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	sr := bufio.NewReader(raw)
+	sr.ReadString('\n') // status line
+	sr.ReadString('\n') // blank line
+	tlsConn := tls.Client(raw, &tls.Config{ServerName: "api.githubcopilot.com", RootCAs: pool})
+	// Handshake may succeed (client cert forged) but the handler returns right
+	// after dial fails, so the conn closes. Either way the handler must exit.
+	_ = tlsConn.Handshake()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handleCopilotSniff did not exit on dial failure")
+	}
+}
+
+// TestHandleCopilotSniff_ForgeCertError covers the forge-cert failure branch by
+// nil-ing the CA so cert generation fails.
+func TestHandleCopilotSniff_ForgeCertError(t *testing.T) {
+	// A proxy with an empty CA cert (no PrivateKey) makes forgeCert fail.
+	p := &GitHubProxy{
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		certCache: make(map[string]cachedCert),
+	}
+	c1, c2 := net.Pipe()
+	go func() {
+		// Drain whatever the handler writes so it doesn't block.
+		io.Copy(io.Discard, c1)
+	}()
+	done := make(chan struct{})
+	go func() {
+		// Exercise the full CONNECT entry (writes the 200 line, then fails at
+		// forgeCert).
+		p.handleCopilotSniff(c2, "api.githubcopilot.com", "w")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleCopilotSniff did not exit on forge-cert error")
+	}
+	c1.Close()
+}
+
+// TestDialCopilotUpstream_DefaultErrors exercises the default (non-seam) dial
+// path against an unresolvable host to cover the tls.Dial branch.
+func TestDialCopilotUpstream_DefaultErrors(t *testing.T) {
+	p := &GitHubProxy{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	// .invalid is guaranteed non-resolvable per RFC 6761.
+	if _, err := p.dialCopilotUpstream("nonexistent.host.invalid"); err == nil {
+		t.Fatal("expected dial error for invalid host")
+	}
+}
+
+// TestProxyCopilotHTTP_NonSuccessCompletion covers the branch where a completion
+// request gets a non-2xx response — it must pass through without recording usage.
+func TestProxyCopilotHTTP_NonSuccessCompletion(t *testing.T) {
+	p, dir := newTestProxyWithCA(t)
+
+	upstreamLn, _ := net.Listen("tcp", "127.0.0.1:0")
+	defer upstreamLn.Close()
+	go func() {
+		conn, err := upstreamLn.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		br := bufio.NewReader(conn)
+		req, _ := http.ReadRequest(br)
+		if req != nil && req.Body != nil {
+			io.ReadAll(req.Body)
+			req.Body.Close()
+		}
+		body := `{"error":"rate limited"}`
+		fmt.Fprintf(conn, "HTTP/1.1 429 Too Many Requests\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(body), body)
+	}()
+	upstreamConn, _ := net.Dial("tcp", upstreamLn.Addr().String())
+	defer upstreamConn.Close()
+
+	clientLn, _ := net.Listen("tcp", "127.0.0.1:0")
+	defer clientLn.Close()
+	tlsCert, _ := p.forgeCert("api.githubcopilot.com")
+	pool := x509.NewCertPool()
+	pool.AddCert(p.caX509)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		raw, err := clientLn.Accept()
+		if err != nil {
+			return
+		}
+		tlsConn := tls.Server(raw, &tls.Config{Certificates: []tls.Certificate{tlsCert}})
+		if tlsConn.Handshake() != nil {
+			return
+		}
+		p.proxyCopilotHTTP(tlsConn, upstreamConn, "api.githubcopilot.com", "w4")
+		tlsConn.Close()
+	}()
+
+	clientConn, err := tls.Dial("tcp", clientLn.Addr().String(), &tls.Config{
+		ServerName: "api.githubcopilot.com", RootCAs: pool,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientConn.Close()
+	reqBody := `{"model":"gpt-5","messages":[]}`
+	fmt.Fprintf(clientConn, "POST /chat/completions HTTP/1.1\r\nHost: api.githubcopilot.com\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(reqBody), reqBody)
+	resp, err := http.ReadResponse(bufio.NewReader(clientConn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != 429 {
+		t.Errorf("status = %d, want 429 passed through", resp.StatusCode)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+	<-done
+
+	if _, err := os.Stat(filepath.Join(dir, "inference-w4.jsonl")); !os.IsNotExist(err) {
+		t.Errorf("non-2xx completion must not record usage")
+	}
+}
+
+// TestProxyCopilotHTTP_KeepAliveTwoRequests covers the keep-alive loop
+// continuation (req.Close/resp.Close false) and accumulation across two
+// completions on one connection.
+func TestProxyCopilotHTTP_KeepAliveTwoRequests(t *testing.T) {
+	p, dir := newTestProxyWithCA(t)
+
+	upstreamLn, _ := net.Listen("tcp", "127.0.0.1:0")
+	defer upstreamLn.Close()
+	go func() {
+		conn, err := upstreamLn.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		br := bufio.NewReader(conn)
+		for i := 0; i < 2; i++ {
+			req, err := http.ReadRequest(br)
+			if err != nil {
+				return
+			}
+			io.ReadAll(req.Body)
+			req.Body.Close()
+			body := `{"model":"gpt-5","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":10,"completion_tokens":5}}`
+			// Keep-alive: no Connection: close, explicit Content-Length.
+			fmt.Fprintf(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: %d\r\n\r\n%s", len(body), body)
+		}
+	}()
+	upstreamConn, _ := net.Dial("tcp", upstreamLn.Addr().String())
+	defer upstreamConn.Close()
+
+	clientLn, _ := net.Listen("tcp", "127.0.0.1:0")
+	defer clientLn.Close()
+	tlsCert, _ := p.forgeCert("api.githubcopilot.com")
+	pool := x509.NewCertPool()
+	pool.AddCert(p.caX509)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		raw, err := clientLn.Accept()
+		if err != nil {
+			return
+		}
+		tlsConn := tls.Server(raw, &tls.Config{Certificates: []tls.Certificate{tlsCert}})
+		if tlsConn.Handshake() != nil {
+			return
+		}
+		p.proxyCopilotHTTP(tlsConn, upstreamConn, "api.githubcopilot.com", "w5")
+		tlsConn.Close()
+	}()
+
+	clientConn, err := tls.Dial("tcp", clientLn.Addr().String(), &tls.Config{
+		ServerName: "api.githubcopilot.com", RootCAs: pool,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientConn.Close()
+
+	cr := bufio.NewReader(clientConn)
+	for i := 0; i < 2; i++ {
+		reqBody := `{"model":"gpt-5","messages":[]}`
+		fmt.Fprintf(clientConn, "POST /chat/completions HTTP/1.1\r\nHost: api.githubcopilot.com\r\nContent-Length: %d\r\n\r\n%s", len(reqBody), reqBody)
+		resp, err := http.ReadResponse(cr, nil)
+		if err != nil {
+			t.Fatalf("request %d read response: %v", i, err)
+		}
+		io.ReadAll(resp.Body)
+		resp.Body.Close()
+	}
+	clientConn.Close()
+	<-done
+
+	_, in, out := readInferenceUsage(t, dir, "w5")
+	if in != 20 || out != 10 {
+		t.Errorf("keep-alive accumulated usage = (%d,%d), want (20,10)", in, out)
+	}
+}
+
+// TestProxyCopilotHTTP_ZeroUsageNotRecorded covers the branch where a completion
+// response carries no usage — nothing is recorded.
+func TestProxyCopilotHTTP_ZeroUsageNotRecorded(t *testing.T) {
+	p, dir := newTestProxyWithCA(t)
+	upstreamLn, _ := net.Listen("tcp", "127.0.0.1:0")
+	defer upstreamLn.Close()
+	go func() {
+		conn, err := upstreamLn.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		br := bufio.NewReader(conn)
+		req, _ := http.ReadRequest(br)
+		if req != nil && req.Body != nil {
+			io.ReadAll(req.Body)
+			req.Body.Close()
+		}
+		body := `{"model":"gpt-5","choices":[{"message":{"content":"ok"}}]}` // no usage
+		fmt.Fprintf(conn, "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(body), body)
+	}()
+	upstreamConn, _ := net.Dial("tcp", upstreamLn.Addr().String())
+	defer upstreamConn.Close()
+
+	clientLn, _ := net.Listen("tcp", "127.0.0.1:0")
+	defer clientLn.Close()
+	tlsCert, _ := p.forgeCert("api.githubcopilot.com")
+	pool := x509.NewCertPool()
+	pool.AddCert(p.caX509)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		raw, err := clientLn.Accept()
+		if err != nil {
+			return
+		}
+		tlsConn := tls.Server(raw, &tls.Config{Certificates: []tls.Certificate{tlsCert}})
+		if tlsConn.Handshake() != nil {
+			return
+		}
+		p.proxyCopilotHTTP(tlsConn, upstreamConn, "api.githubcopilot.com", "w6")
+		tlsConn.Close()
+	}()
+	clientConn, err := tls.Dial("tcp", clientLn.Addr().String(), &tls.Config{
+		ServerName: "api.githubcopilot.com", RootCAs: pool,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientConn.Close()
+	reqBody := `{"model":"gpt-5","messages":[]}`
+	fmt.Fprintf(clientConn, "POST /chat/completions HTTP/1.1\r\nHost: api.githubcopilot.com\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(reqBody), reqBody)
+	resp, _ := http.ReadResponse(bufio.NewReader(clientConn), nil)
+	if resp != nil {
+		io.ReadAll(resp.Body)
+		resp.Body.Close()
+	}
+	<-done
+	if _, err := os.Stat(filepath.Join(dir, "inference-w6.jsonl")); !os.IsNotExist(err) {
+		t.Errorf("zero-usage completion must not record")
+	}
+}
+
+// TestProxyCopilotHTTP_ClientClosesImmediately ensures the loop exits cleanly
+// when the client sends nothing.
+func TestProxyCopilotHTTP_ClientClosesImmediately(t *testing.T) {
+	p, _ := newTestProxyWithCA(t)
+	c1, c2 := net.Pipe()
+	u1, _ := net.Pipe()
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		c1.Close()
+	}()
+	done := make(chan struct{})
+	go func() {
+		p.proxyCopilotHTTP(c2, u1, "api.githubcopilot.com", "w")
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("proxyCopilotHTTP did not exit on client close")
+	}
+}

--- a/v2/pkg/proxy/copilot_usage.go
+++ b/v2/pkg/proxy/copilot_usage.go
@@ -1,0 +1,173 @@
+package proxy
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+// copilotCompletionsPathSuffix is the path suffix of the Copilot chat
+// completions endpoint. Copilot's OpenAI-compatible API serves completions at
+// /chat/completions (sometimes prefixed, e.g. /v1/chat/completions), so a
+// suffix match identifies the request whose response carries a usage block.
+const copilotCompletionsPathSuffix = "/chat/completions"
+
+// copilotAutoModelSentinel is the Copilot `--model auto` value: a request may
+// send "auto" instead of a concrete model id, letting Copilot pick per task. It
+// is not a real model row, so usage recorded against it would pollute the cost
+// table — callers resolve the concrete model from the response instead.
+const copilotAutoModelSentinel = "auto"
+
+// copilotResponseModel is the minimal view of a Copilot completion response used
+// to recover the concrete model id when the request used the "auto" sentinel.
+type copilotResponseModel struct {
+	Model string `json:"model"`
+}
+
+// copilotUsageRequest is the minimal view of a Copilot (OpenAI-shaped) chat
+// completion request the proxy needs: the resolved model id (for cost
+// attribution) and whether the response will be streamed (so the proxy can
+// ensure a terminal usage chunk is emitted).
+type copilotUsageRequest struct {
+	Model         string               `json:"model"`
+	Stream        bool                 `json:"stream,omitempty"`
+	StreamOptions *openaiStreamOptions `json:"stream_options,omitempty"`
+}
+
+// isCopilotCompletionsPath reports whether an HTTP request path targets the
+// Copilot chat completions endpoint.
+func isCopilotCompletionsPath(path string) bool {
+	return strings.HasSuffix(path, copilotCompletionsPathSuffix)
+}
+
+// parseCopilotRequest extracts the model id and streaming flag from a Copilot
+// completion request body. Returns ("", false) when the body is not a parseable
+// completion request.
+func parseCopilotRequest(body []byte) (model string, streaming bool) {
+	var req copilotUsageRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return "", false
+	}
+	return req.Model, req.Stream
+}
+
+// ensureStreamUsageRequested rewrites a streaming Copilot completion request
+// body so it carries stream_options.include_usage=true. Without this hint the
+// OpenAI-compatible endpoint omits the terminal usage chunk from the SSE
+// response, leaving streamed completions uncountable. It is a no-op (returns the
+// original bytes) when the body is not a streaming request, cannot be parsed as
+// a JSON object, or already requests usage. Only the stream_options field is
+// touched; every other field is preserved byte-for-byte via a generic map so
+// the request forwarded to Copilot stays otherwise identical.
+func ensureStreamUsageRequested(body []byte) []byte {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return body
+	}
+
+	streamRaw, ok := obj["stream"]
+	if !ok {
+		return body
+	}
+	var streaming bool
+	if json.Unmarshal(streamRaw, &streaming) != nil || !streaming {
+		return body
+	}
+
+	// Already asking for usage? Leave untouched.
+	if soRaw, ok := obj["stream_options"]; ok {
+		var so openaiStreamOptions
+		if json.Unmarshal(soRaw, &so) == nil && so.IncludeUsage {
+			return body
+		}
+	}
+
+	soBytes, err := json.Marshal(openaiStreamOptions{IncludeUsage: true})
+	if err != nil {
+		return body
+	}
+	obj["stream_options"] = soBytes
+
+	rewritten, err := json.Marshal(obj)
+	if err != nil {
+		return body
+	}
+	return rewritten
+}
+
+// extractCopilotSSEUsage scans an OpenAI-format SSE stream (already buffered in
+// full) and returns the token usage from its terminal usage chunk. Returns
+// (0, 0) when no usage chunk is present. Unlike translateOpenAISSEToAnthropic
+// this does not transform the stream — the Copilot proxy forwards SSE bytes
+// verbatim and only reads the usage out of a copy.
+func extractCopilotSSEUsage(body []byte) (inputTokens, outputTokens int64) {
+	scanner := bufio.NewScanner(bytes.NewReader(body))
+	const maxSSELine = 256 * 1024
+	scanner.Buffer(make([]byte, maxSSELine), maxSSELine)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := line[len("data: "):]
+		if data == "[DONE]" {
+			break
+		}
+		var chunk openaiSSEChunk
+		if json.Unmarshal([]byte(data), &chunk) != nil {
+			continue
+		}
+		if chunk.Usage != nil {
+			// The terminal usage chunk carries the final cumulative totals; a
+			// later chunk (if any) overwrites, which is correct.
+			inputTokens = int64(chunk.Usage.PromptTokens)
+			outputTokens = int64(chunk.Usage.CompletionTokens)
+		}
+	}
+	return inputTokens, outputTokens
+}
+
+// extractCopilotUsage reads token usage from a Copilot completion response body,
+// handling both streaming (SSE) and non-streaming (single JSON) responses.
+// contentType is the response Content-Type header. Returns (0, 0) when no usage
+// is present.
+func extractCopilotUsage(contentType string, body []byte) (inputTokens, outputTokens int64) {
+	if strings.Contains(contentType, "text/event-stream") {
+		return extractCopilotSSEUsage(body)
+	}
+	return extractOpenAIUsage(body)
+}
+
+// extractCopilotResponseModel recovers the concrete model id from a Copilot
+// completion response (streaming or not). Used when the request pinned "auto"
+// so usage is attributed to the actual model Copilot chose. Returns "" when no
+// model is present.
+func extractCopilotResponseModel(body []byte, contentType string) string {
+	if strings.Contains(contentType, "text/event-stream") {
+		scanner := bufio.NewScanner(bytes.NewReader(body))
+		const maxSSELine = 256 * 1024
+		scanner.Buffer(make([]byte, maxSSELine), maxSSELine)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			data := line[len("data: "):]
+			if data == "[DONE]" {
+				break
+			}
+			var m copilotResponseModel
+			if json.Unmarshal([]byte(data), &m) == nil && m.Model != "" {
+				return m.Model
+			}
+		}
+		return ""
+	}
+	var m copilotResponseModel
+	if json.Unmarshal(body, &m) == nil {
+		return m.Model
+	}
+	return ""
+}

--- a/v2/pkg/proxy/copilot_usage_test.go
+++ b/v2/pkg/proxy/copilot_usage_test.go
@@ -1,0 +1,197 @@
+package proxy
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestIsCopilotAPIHost(t *testing.T) {
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{"api.githubcopilot.com", true},
+		{"api.enterprise.githubcopilot.com", true},
+		{"proxy.enterprise.githubcopilot.com", true},
+		{"githubcopilot.com", true},
+		{"api.github.com", false},
+		{"github.com", false},
+		{"api.anthropic.com", false},
+		{"evilgithubcopilot.com.attacker.example", false},
+		{"", false},
+		// Not a subdomain (no leading dot before githubcopilot.com) and not the
+		// bare apex, so it must NOT match.
+		{"notgithubcopilot.com", false},
+	}
+	for _, c := range cases {
+		if got := IsCopilotAPIHost(c.host); got != c.want {
+			t.Errorf("IsCopilotAPIHost(%q) = %v, want %v", c.host, got, c.want)
+		}
+	}
+}
+
+func TestIsCopilotCompletionsPath(t *testing.T) {
+	cases := map[string]bool{
+		"/chat/completions":        true,
+		"/v1/chat/completions":     true,
+		"/models":                  false,
+		"/chat/completions/stream": false,
+		"":                         false,
+		"/completions":             false,
+	}
+	for path, want := range cases {
+		if got := isCopilotCompletionsPath(path); got != want {
+			t.Errorf("isCopilotCompletionsPath(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+func TestParseCopilotRequest(t *testing.T) {
+	model, streaming := parseCopilotRequest([]byte(`{"model":"claude-sonnet-4.5","stream":true}`))
+	if model != "claude-sonnet-4.5" || !streaming {
+		t.Errorf("got (%q,%v), want (claude-sonnet-4.5,true)", model, streaming)
+	}
+
+	model, streaming = parseCopilotRequest([]byte(`{"model":"gpt-5"}`))
+	if model != "gpt-5" || streaming {
+		t.Errorf("got (%q,%v), want (gpt-5,false)", model, streaming)
+	}
+
+	model, streaming = parseCopilotRequest([]byte(`not json`))
+	if model != "" || streaming {
+		t.Errorf("bad json should yield empty, got (%q,%v)", model, streaming)
+	}
+}
+
+func TestEnsureStreamUsageRequested(t *testing.T) {
+	// Streaming request without stream_options -> injected.
+	in := []byte(`{"model":"gpt-5","stream":true,"messages":[]}`)
+	out := ensureStreamUsageRequested(in)
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(out, &obj); err != nil {
+		t.Fatalf("output not valid json: %v", err)
+	}
+	so, ok := obj["stream_options"]
+	if !ok {
+		t.Fatal("stream_options not injected")
+	}
+	var opts openaiStreamOptions
+	if json.Unmarshal(so, &opts) != nil || !opts.IncludeUsage {
+		t.Errorf("include_usage not true, got %s", so)
+	}
+	// Other fields preserved.
+	if _, ok := obj["messages"]; !ok {
+		t.Error("messages field dropped")
+	}
+	if string(obj["model"]) != `"gpt-5"` {
+		t.Errorf("model changed: %s", obj["model"])
+	}
+}
+
+func TestEnsureStreamUsageRequested_NonStreaming(t *testing.T) {
+	in := []byte(`{"model":"gpt-5","stream":false}`)
+	out := ensureStreamUsageRequested(in)
+	if string(out) != string(in) {
+		t.Errorf("non-streaming request should be unchanged, got %s", out)
+	}
+}
+
+func TestEnsureStreamUsageRequested_NoStreamField(t *testing.T) {
+	in := []byte(`{"model":"gpt-5"}`)
+	out := ensureStreamUsageRequested(in)
+	if string(out) != string(in) {
+		t.Errorf("request without stream field should be unchanged, got %s", out)
+	}
+}
+
+func TestEnsureStreamUsageRequested_AlreadyRequested(t *testing.T) {
+	in := []byte(`{"model":"gpt-5","stream":true,"stream_options":{"include_usage":true}}`)
+	out := ensureStreamUsageRequested(in)
+	if string(out) != string(in) {
+		t.Errorf("already-requested body should be unchanged, got %s", out)
+	}
+}
+
+func TestEnsureStreamUsageRequested_BadJSON(t *testing.T) {
+	in := []byte(`not json`)
+	out := ensureStreamUsageRequested(in)
+	if string(out) != string(in) {
+		t.Errorf("bad json should be returned unchanged")
+	}
+}
+
+func TestEnsureStreamUsageRequested_StreamOptionsPresentNoUsage(t *testing.T) {
+	// stream_options present but include_usage false -> gets overwritten to true.
+	in := []byte(`{"model":"gpt-5","stream":true,"stream_options":{"include_usage":false}}`)
+	out := ensureStreamUsageRequested(in)
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(out, &obj); err != nil {
+		t.Fatalf("bad output json: %v", err)
+	}
+	var opts openaiStreamOptions
+	if json.Unmarshal(obj["stream_options"], &opts) != nil || !opts.IncludeUsage {
+		t.Errorf("include_usage should be forced true, got %s", obj["stream_options"])
+	}
+}
+
+func TestExtractCopilotSSEUsage(t *testing.T) {
+	sse := "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n" +
+		"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":100,\"completion_tokens\":42}}\n" +
+		"data: [DONE]\n"
+	in, out := extractCopilotSSEUsage([]byte(sse))
+	if in != 100 || out != 42 {
+		t.Errorf("got (%d,%d), want (100,42)", in, out)
+	}
+}
+
+func TestExtractCopilotSSEUsage_NoUsage(t *testing.T) {
+	sse := "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n" +
+		"data: [DONE]\n"
+	in, out := extractCopilotSSEUsage([]byte(sse))
+	if in != 0 || out != 0 {
+		t.Errorf("got (%d,%d), want (0,0)", in, out)
+	}
+}
+
+func TestExtractCopilotUsage_NonStreaming(t *testing.T) {
+	body := []byte(`{"model":"gpt-5","choices":[{"message":{"content":"ok"}}],"usage":{"prompt_tokens":7,"completion_tokens":3}}`)
+	in, out := extractCopilotUsage("application/json", body)
+	if in != 7 || out != 3 {
+		t.Errorf("got (%d,%d), want (7,3)", in, out)
+	}
+}
+
+func TestExtractCopilotUsage_Streaming(t *testing.T) {
+	sse := "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":9,\"completion_tokens\":5}}\n"
+	in, out := extractCopilotUsage("text/event-stream; charset=utf-8", []byte(sse))
+	if in != 9 || out != 5 {
+		t.Errorf("got (%d,%d), want (9,5)", in, out)
+	}
+}
+
+func TestExtractCopilotResponseModel_NonStreaming(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4.5","usage":{"prompt_tokens":1,"completion_tokens":1}}`)
+	if m := extractCopilotResponseModel(body, "application/json"); m != "claude-sonnet-4.5" {
+		t.Errorf("got %q, want claude-sonnet-4.5", m)
+	}
+}
+
+func TestExtractCopilotResponseModel_Streaming(t *testing.T) {
+	sse := "data: {\"model\":\"gpt-5-mini\",\"choices\":[{\"delta\":{\"content\":\"x\"}}]}\n" +
+		"data: [DONE]\n"
+	if m := extractCopilotResponseModel([]byte(sse), "text/event-stream"); m != "gpt-5-mini" {
+		t.Errorf("got %q, want gpt-5-mini", m)
+	}
+}
+
+func TestExtractCopilotResponseModel_None(t *testing.T) {
+	if m := extractCopilotResponseModel([]byte(`{}`), "application/json"); m != "" {
+		t.Errorf("got %q, want empty", m)
+	}
+	if m := extractCopilotResponseModel([]byte(`bad`), "application/json"); m != "" {
+		t.Errorf("bad json got %q, want empty", m)
+	}
+	if m := extractCopilotResponseModel([]byte("data: [DONE]\n"), "text/event-stream"); m != "" {
+		t.Errorf("sse with no model got %q, want empty", m)
+	}
+}

--- a/v2/pkg/proxy/github_proxy.go
+++ b/v2/pkg/proxy/github_proxy.go
@@ -70,6 +70,21 @@ type GitHubProxy struct {
 	// agents, whose usage the file-scanning token collector cannot see
 	// otherwise. May be nil (Record is a safe no-op on a nil sink).
 	tokenSink *tokens.InferenceSink
+
+	// copilotDial, when set, overrides how the Copilot-sniff MITM path dials the
+	// upstream Copilot host (default: tls.Dial to host:443). It exists solely as
+	// a test seam so the CONNECT handler can be driven against a local fake
+	// upstream; production leaves it nil.
+	copilotDial func(host string) (net.Conn, error)
+}
+
+// dialCopilotUpstream connects to the real Copilot host over TLS (or the test
+// seam when set).
+func (p *GitHubProxy) dialCopilotUpstream(host string) (net.Conn, error) {
+	if p.copilotDial != nil {
+		return p.copilotDial(host)
+	}
+	return tls.Dial("tcp", net.JoinHostPort(host, "443"), &tls.Config{ServerName: host})
 }
 
 // SetTokenSink wires the inference token sink so the translator can record
@@ -254,6 +269,15 @@ func (p *GitHubProxy) handleTransparentTLS(conn net.Conn, peeked []byte) {
 				agentName = p.uidMap.LookupByUID(uid)
 			}
 		}
+	}
+
+	// Copilot completion host under iptables redirection: MITM to read live
+	// token usage (same guard as the explicit-CONNECT path). The peeked
+	// ClientHello is replayed via prefixConn so the TLS handshake sees the full
+	// record.
+	if IsCopilotAPIHost(host) && p.tokenSink != nil && agentName != "" {
+		p.sniffCopilotOnTLS(&prefixConn{Conn: conn, prefix: fullBuf}, host, agentName)
+		return
 	}
 
 	if !IsGitHubHost(host) || !NeedsMITM(host) {
@@ -463,6 +487,14 @@ func (p *GitHubProxy) handleConnectDirect(conn net.Conn, r *http.Request) {
 			p.handleAnthropicReroute(conn, r, host, agentName, route)
 			return
 		}
+	}
+
+	// Copilot completion host: MITM to read live token usage. Only when a token
+	// sink is active and the agent is identified — otherwise fall through to an
+	// opaque tunnel so Copilot traffic is never broken by usage capture.
+	if IsCopilotAPIHost(host) && p.tokenSink != nil && agentName != "" {
+		p.handleCopilotSniff(conn, host, agentName)
+		return
 	}
 
 	// Non-GitHub hosts: tunnel without inspection.
@@ -1317,6 +1349,173 @@ func (p *GitHubProxy) handleInferenceRequest(conn net.Conn, req *http.Request, a
 		Body:       io.NopCloser(bytes.NewReader(translated)),
 	}
 	httpResp.Write(conn)
+}
+
+// handleCopilotSniff MITMs a GitHub Copilot completion-API connection to read
+// the OpenAI-shaped token usage out of each /chat/completions response, then
+// records it via the same token sink the inference path uses so Copilot cost
+// goes live instead of only tallying at session shutdown.
+//
+// Unlike the inference reroute, this does NOT translate or reroute: the client's
+// request is forwarded verbatim to the real Copilot host (with one exception —
+// streaming requests get stream_options.include_usage injected so the terminal
+// SSE usage chunk is emitted), and the upstream response is streamed back
+// byte-for-byte to the client. The proxy only reads a copy of the response to
+// extract usage.
+//
+// It is only invoked when a token sink is active and the agent is identified;
+// callers fall back to opaque tunneling otherwise, so a missing sink or unknown
+// agent never breaks Copilot traffic.
+func (p *GitHubProxy) handleCopilotSniff(conn net.Conn, host, agentName string) {
+	if _, err := fmt.Fprintf(conn, "HTTP/1.1 200 Connection established\r\n\r\n"); err != nil {
+		p.logger.Error("copilot sniff: CONNECT response failed", "error", err)
+		return
+	}
+	p.sniffCopilotOnTLS(conn, host, agentName)
+}
+
+// sniffCopilotOnTLS TLS-terminates a client connection (already past any CONNECT
+// handshake), dials the real Copilot upstream, and pumps requests/responses
+// through proxyCopilotHTTP so usage is recorded. Shared by the explicit-CONNECT
+// (handleCopilotSniff) and the transparent-TLS (iptables) entry points so the
+// forge/handshake/dial logic lives in one place. clientConn must be the raw
+// (pre-TLS) client socket, optionally already wrapped in a prefixConn carrying a
+// peeked ClientHello.
+func (p *GitHubProxy) sniffCopilotOnTLS(clientConn net.Conn, host, agentName string) {
+	tlsCert, err := p.forgeCert(host)
+	if err != nil {
+		p.logger.Error("copilot sniff: forge cert failed", "host", host, "error", err)
+		return
+	}
+
+	tlsClientConn := tls.Server(clientConn, &tls.Config{Certificates: []tls.Certificate{tlsCert}})
+	if err := tlsClientConn.Handshake(); err != nil {
+		p.logger.Warn("copilot sniff: client TLS handshake failed", "error", err)
+		return
+	}
+	defer tlsClientConn.Close()
+
+	upstreamConn, err := p.dialCopilotUpstream(host)
+	if err != nil {
+		p.logger.Error("copilot sniff: upstream dial failed", "host", host, "error", err)
+		return
+	}
+	defer upstreamConn.Close()
+
+	p.proxyCopilotHTTP(tlsClientConn, upstreamConn, host, agentName)
+}
+
+// copilotSniffBodyLimit caps how much of a Copilot request/response body the
+// proxy buffers in order to read the usage block. Completion payloads are well
+// under this; the limit bounds memory against a pathological body. Bodies larger
+// than the limit are still forwarded in full (streamed), only usage extraction
+// is skipped for the oversized case.
+const copilotSniffBodyLimit = 32 * 1024 * 1024 // 32 MiB
+
+// proxyCopilotHTTP reads HTTP requests from the client, forwards them to the
+// Copilot upstream, and forwards responses back — extracting token usage from
+// completion responses along the way. It keeps the connection alive across
+// multiple request/response pairs (HTTP keep-alive), exiting when either side
+// closes.
+func (p *GitHubProxy) proxyCopilotHTTP(client net.Conn, upstream net.Conn, host, agentName string) {
+	clientBuf := bufio.NewReader(client)
+	upstreamBuf := bufio.NewReader(upstream)
+
+	for {
+		req, err := http.ReadRequest(clientBuf)
+		if err != nil {
+			return // client closed
+		}
+
+		isCompletion := isCopilotCompletionsPath(req.URL.Path)
+		model := ""
+
+		// For completion requests, buffer the body so we can (a) learn the
+		// model id and (b) inject include_usage on streaming requests. Other
+		// requests (model listings, etc.) are forwarded without buffering.
+		if isCompletion && req.Body != nil {
+			body, readErr := io.ReadAll(io.LimitReader(req.Body, copilotSniffBodyLimit))
+			req.Body.Close()
+			if readErr != nil {
+				return
+			}
+			var streaming bool
+			model, streaming = parseCopilotRequest(body)
+			if streaming {
+				body = ensureStreamUsageRequested(body)
+			}
+			req.Body = io.NopCloser(bytes.NewReader(body))
+			req.ContentLength = int64(len(body))
+			req.Header.Set("Content-Length", fmt.Sprintf("%d", len(body)))
+		}
+
+		if err := req.Write(upstream); err != nil {
+			return
+		}
+
+		resp, err := http.ReadResponse(upstreamBuf, req)
+		if err != nil {
+			return
+		}
+
+		if isCompletion && resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			p.forwardCopilotResponseWithUsage(client, resp, host, agentName, model)
+		} else {
+			if err := resp.Write(client); err != nil {
+				resp.Body.Close()
+				return
+			}
+			resp.Body.Close()
+		}
+
+		if req.Close || resp.Close {
+			return
+		}
+	}
+}
+
+// forwardCopilotResponseWithUsage forwards a completion response to the client
+// while extracting token usage from a buffered copy. The full body is read into
+// memory (completion responses are small), usage is recorded, then the response
+// is rewritten to the client verbatim. resp.Body is consumed and closed here.
+func (p *GitHubProxy) forwardCopilotResponseWithUsage(client net.Conn, resp *http.Response, host, agentName, model string) {
+	body, err := io.ReadAll(io.LimitReader(resp.Body, copilotSniffBodyLimit))
+	resp.Body.Close()
+	if err != nil {
+		// Best effort: nothing to forward.
+		return
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if in, out := extractCopilotUsage(contentType, body); in > 0 || out > 0 {
+		resolvedModel := model
+		if resolvedModel == "" || resolvedModel == copilotAutoModelSentinel {
+			// Fall back to the model reported in the response when the request
+			// did not pin a concrete id (e.g. --model auto). Never record the
+			// "auto" sentinel — it is not a real model row.
+			if rm := extractCopilotResponseModel(body, contentType); rm != "" {
+				resolvedModel = rm
+			}
+		}
+		if resolvedModel != "" && resolvedModel != copilotAutoModelSentinel {
+			p.tokenSink.Record(agentName, resolvedModel, in, out)
+			p.logger.Info("copilot usage recorded",
+				"agent", agentName,
+				"host", host,
+				"model", resolvedModel,
+				"input", in,
+				"output", out,
+			)
+		}
+	}
+
+	// Rewrite the response to the client verbatim. Replace the body with the
+	// buffered copy and drop Content-Length ambiguity by setting it explicitly.
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	resp.ContentLength = int64(len(body))
+	if err := resp.Write(client); err != nil {
+		p.logger.Warn("copilot sniff: response write to client failed", "agent", agentName, "error", err)
+	}
 }
 
 func (p *GitHubProxy) writeHTTPError(conn net.Conn, status int, msg string) {

--- a/v2/pkg/proxy/rules.go
+++ b/v2/pkg/proxy/rules.go
@@ -1,10 +1,10 @@
 package proxy
 
 import (
-	"sync"
 	"encoding/json"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/kubestellar/hive/v2/pkg/agent"
 )
@@ -58,6 +58,30 @@ func IsGitHubHost(host string) bool {
 // Only api.github.com needs MITM for GraphQL/REST mutation inspection.
 func NeedsMITM(host string) bool {
 	return host == "api.github.com"
+}
+
+// copilotAPIHostSuffix matches the GitHub Copilot completion API hosts. The
+// public host is api.githubcopilot.com and enterprise plans use
+// api.enterprise.githubcopilot.com (and other per-account subdomains discovered
+// via copilot_internal/user), so a suffix match covers every variant without
+// hardcoding each subdomain.
+const copilotAPIHostSuffix = ".githubcopilot.com"
+
+// copilotAPIHostExact is the public Copilot completion host, matched exactly so
+// the bare apex (no leading dot) is also recognized.
+const copilotAPIHostExact = "githubcopilot.com"
+
+// IsCopilotAPIHost reports whether host is a GitHub Copilot completion API host
+// whose /chat/completions responses carry an OpenAI-shaped usage block. The
+// proxy MITMs these hosts (when a token sink is active) purely to read that
+// usage block for live cost attribution — request and response bodies are
+// otherwise forwarded verbatim; no content is altered beyond an optional
+// stream_options.include_usage hint on streaming completion requests.
+func IsCopilotAPIHost(host string) bool {
+	if host == "" {
+		return false
+	}
+	return host == copilotAPIHostExact || strings.HasSuffix(host, copilotAPIHostSuffix)
 }
 
 // rules defines every GitHub API operation and the minimum mode needed.

--- a/v2/pkg/tokens/claude_scanner_test.go
+++ b/v2/pkg/tokens/claude_scanner_test.go
@@ -337,7 +337,7 @@ func TestAgentFromTmuxEnv(t *testing.T) {
 
 func TestParseTimestampToUnixMilli(t *testing.T) {
 	tests := []struct {
-		input   string
+		input    string
 		wantNon0 bool
 	}{
 		{"2025-01-01T00:00:00Z", true},
@@ -379,6 +379,45 @@ func TestCollectorSetClaudeSessionsDir(t *testing.T) {
 	c.SetClaudeSessionsDir("/root/.claude/projects")
 	if c.claudeSessionsDir != "/root/.claude/projects" {
 		t.Errorf("claudeSessionsDir = %q", c.claudeSessionsDir)
+	}
+}
+
+// TestCollectorCopilotLiveCapture verifies the collector honors the live-capture
+// flag: with it set, the copilot scanner defers token accrual to the sink, so the
+// scanned copilot session contributes no tokens (but is still counted), and the
+// per-agent live usage the sink wrote is what surfaces instead.
+func TestCollectorCopilotLiveCapture(t *testing.T) {
+	metricsDir := t.TempDir()
+	copilotDir := t.TempDir()
+
+	// A live copilot usage record from the proxy sink (per-response).
+	sink := NewInferenceSink(metricsDir, testLogger())
+	sink.Record("scanner", "gpt-5", 300, 100)
+
+	// A copilot session file whose shutdown metrics would double-count if the
+	// scanner accrued them.
+	sessionDir := filepath.Join(copilotDir, "s1")
+	os.MkdirAll(sessionDir, 0o755)
+	content := strings.Join([]string{
+		`{"type":"session.start","data":{"sessionId":"abc123456789","selectedModel":"gpt-5","context":{"cwd":"/data/agents/scanner"}}}`,
+		`{"type":"user.message","timestamp":"2025-06-01T00:00:00Z","data":{"content":"go"}}`,
+		`{"type":"session.shutdown","data":{"currentModel":"gpt-5","modelMetrics":{"gpt-5":{"usage":{"inputTokens":300,"outputTokens":100}}}}}`,
+	}, "\n") + "\n"
+	os.WriteFile(filepath.Join(sessionDir, "events.jsonl"), []byte(content), 0o600)
+
+	c := NewCollector(metricsDir, testLogger())
+	c.SetCopilotSessionsDir(copilotDir)
+	c.SetCopilotLiveCapture(true)
+	c.scan()
+
+	summary := c.Summary()
+	if summary == nil {
+		t.Fatal("nil summary")
+	}
+	// scanner's tokens come ONLY from the sink (400), not doubled by the
+	// shutdown scan (which would make it 800).
+	if got := summary.ByAgent["scanner"]; got != 400 {
+		t.Fatalf("ByAgent[scanner] = %d, want 400 (live sink only, no double-count)", got)
 	}
 }
 

--- a/v2/pkg/tokens/collector.go
+++ b/v2/pkg/tokens/collector.go
@@ -75,6 +75,7 @@ type Collector struct {
 	sessionsDir        string
 	claudeSessionsDir  string
 	copilotSessionsDir string
+	copilotLiveCapture bool
 	persistPath        string
 	detector           func(string) string
 	logger             *slog.Logger
@@ -114,6 +115,25 @@ func (c *Collector) SetCopilotSessionsDir(dir string) {
 	c.copilotSessionsDir = dir
 }
 
+// SetCopilotLiveCapture tells the collector that the MITM proxy is recording
+// Copilot token usage live (per completion) into the inference sink. When set,
+// the copilot session-file scanner defers token accrual to the sink to avoid
+// double-counting; it still contributes session/message/model metadata. It is
+// mutex-guarded so it can be called after Start (the scan goroutine reads it
+// under the same lock).
+func (c *Collector) SetCopilotLiveCapture(enabled bool) {
+	c.mu.Lock()
+	c.copilotLiveCapture = enabled
+	c.mu.Unlock()
+}
+
+// copilotLiveCaptureEnabled reads the flag under the lock.
+func (c *Collector) copilotLiveCaptureEnabled() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.copilotLiveCapture
+}
+
 func (c *Collector) Start(stop <-chan struct{}) {
 	c.scan()
 	ticker := time.NewTicker(c.scanInterval)
@@ -145,7 +165,7 @@ func (c *Collector) scan() {
 	}
 
 	if c.copilotSessionsDir != "" {
-		copilotAgg, err := ScanCopilotSessions(c.copilotSessionsDir)
+		copilotAgg, err := ScanCopilotSessions(c.copilotSessionsDir, c.copilotLiveCaptureEnabled())
 		if err != nil {
 			c.logger.Warn("copilot session scan failed", "error", err)
 		} else if copilotAgg != nil && copilotAgg.SessionCount > 0 {

--- a/v2/pkg/tokens/copilot_scanner.go
+++ b/v2/pkg/tokens/copilot_scanner.go
@@ -32,7 +32,7 @@ type copilotUserMessage struct {
 }
 
 type copilotShutdown struct {
-	CurrentModel string                       `json:"currentModel"`
+	CurrentModel string                        `json:"currentModel"`
 	ModelMetrics map[string]copilotModelMetric `json:"modelMetrics"`
 }
 
@@ -41,9 +41,9 @@ type copilotModelMetric struct {
 }
 
 type copilotUsage struct {
-	InputTokens     int64 `json:"inputTokens"`
-	OutputTokens    int64 `json:"outputTokens"`
-	CacheReadTokens int64 `json:"cacheReadTokens"`
+	InputTokens      int64 `json:"inputTokens"`
+	OutputTokens     int64 `json:"outputTokens"`
+	CacheReadTokens  int64 `json:"cacheReadTokens"`
 	CacheWriteTokens int64 `json:"cacheWriteTokens"`
 }
 
@@ -54,7 +54,16 @@ type copilotToolComplete struct {
 // ScanCopilotSessions reads Copilot CLI session files from the session-state
 // directory and returns an AggregateSummary. The sessionsDir is typically
 // ~/.copilot/session-state.
-func ScanCopilotSessions(sessionsDir string) (*AggregateSummary, error) {
+//
+// When liveCapture is true, the MITM proxy is recording Copilot token usage
+// live (per completion response) into the inference sink, so this scanner MUST
+// NOT also accrue tokens from the session.shutdown ModelMetrics — doing so would
+// double-count every Copilot session (once live via the sink, once at shutdown
+// here). In that mode the scanner still contributes session presence, message
+// counts, model, and last-active timestamps (which the live sink does not
+// capture), but records zero tokens; the proxy sink is the single source of
+// Copilot token totals.
+func ScanCopilotSessions(sessionsDir string, liveCapture bool) (*AggregateSummary, error) {
 	agg := &AggregateSummary{
 		ByAgent:       make(map[string]int64),
 		ByModel:       make(map[string]int64),
@@ -85,7 +94,7 @@ func ScanCopilotSessions(sessionsDir string) (*AggregateSummary, error) {
 			continue
 		}
 
-		summary, err := parseCopilotSessionFile(eventsFile)
+		summary, err := parseCopilotSessionFile(eventsFile, liveCapture)
 		if err != nil || summary == nil || summary.TotalTokens == 0 && summary.Messages == 0 {
 			continue
 		}
@@ -129,7 +138,7 @@ func ScanCopilotSessions(sessionsDir string) (*AggregateSummary, error) {
 	return agg, nil
 }
 
-func parseCopilotSessionFile(path string) (*SessionSummary, error) {
+func parseCopilotSessionFile(path string, liveCapture bool) (*SessionSummary, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -211,11 +220,17 @@ func parseCopilotSessionFile(path string) (*SessionSummary, error) {
 				if shutdown.CurrentModel != "" {
 					summary.Model = shutdown.CurrentModel
 				}
-				for _, metrics := range shutdown.ModelMetrics {
-					summary.InputTokens += metrics.Usage.InputTokens
-					summary.OutputTokens += metrics.Usage.OutputTokens
-					summary.CacheRead += metrics.Usage.CacheReadTokens
-					summary.CacheCreate += metrics.Usage.CacheWriteTokens
+				// When the live-capture proxy is active it already recorded
+				// every completion's tokens into the inference sink; accruing
+				// the shutdown ModelMetrics here would double-count. Keep the
+				// model (set above) but skip the token totals.
+				if !liveCapture {
+					for _, metrics := range shutdown.ModelMetrics {
+						summary.InputTokens += metrics.Usage.InputTokens
+						summary.OutputTokens += metrics.Usage.OutputTokens
+						summary.CacheRead += metrics.Usage.CacheReadTokens
+						summary.CacheCreate += metrics.Usage.CacheWriteTokens
+					}
 				}
 			}
 		}
@@ -238,4 +253,3 @@ func detectAgentFromCwd(cwd string) string {
 	}
 	return ""
 }
-

--- a/v2/pkg/tokens/inference_sink.go
+++ b/v2/pkg/tokens/inference_sink.go
@@ -1,11 +1,13 @@
 package tokens
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 )
 
@@ -44,12 +46,81 @@ type inferenceAgentTotals struct {
 
 // NewInferenceSink returns a sink that writes per-agent usage files into dir.
 // dir is created if missing. A nil sink (dir == "") is a safe no-op.
+//
+// On construction the sink reloads any existing per-agent totals from the
+// inference-<agent>.jsonl files already on disk, so cumulative counts survive a
+// hive restart. Without this, an in-memory-only sink would restart every agent's
+// counter at zero and overwrite the persisted file with a lower value on the
+// next Record — silently losing all pre-restart tokens (this affected inference
+// agents and would double-hurt the Copilot live path, whose only durable record
+// is this file once the session-shutdown scanner defers to the sink).
 func NewInferenceSink(dir string, logger *slog.Logger) *InferenceSink {
-	return &InferenceSink{
+	s := &InferenceSink{
 		dir:    dir,
 		logger: logger,
 		totals: make(map[string]*inferenceAgentTotals),
 	}
+	s.restoreFromDisk()
+	return s
+}
+
+// restoreFromDisk rebuilds the in-memory per-agent totals from the persisted
+// inference-<agent>.jsonl files. Best-effort: unreadable or malformed files are
+// skipped. Safe to call before any goroutines run (only invoked from the
+// constructor).
+func (s *InferenceSink) restoreFromDisk() {
+	if s == nil || s.dir == "" {
+		return
+	}
+	matches, err := filepath.Glob(filepath.Join(s.dir, inferenceSessionFilePrefix+"*.jsonl"))
+	if err != nil {
+		return
+	}
+	for _, path := range matches {
+		base := filepath.Base(path)
+		agent := strings.TrimSuffix(strings.TrimPrefix(base, inferenceSessionFilePrefix), ".jsonl")
+		if agent == "" {
+			continue
+		}
+		t := s.parseAgentFile(path)
+		if t != nil {
+			s.totals[agent] = t
+		}
+	}
+}
+
+// parseAgentFile reads a persisted inference usage file back into totals. The
+// file holds a "user" pin line and an "assistant" line carrying the cumulative
+// InputTokens/OutputTokens/Model. Returns nil on any read/parse failure.
+func (s *InferenceSink) parseAgentFile(path string) *inferenceAgentTotals {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	t := &inferenceAgentTotals{}
+	found := false
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		var e SessionEntry
+		if json.Unmarshal(scanner.Bytes(), &e) != nil {
+			continue
+		}
+		if e.Model != "" {
+			t.Model = e.Model
+		}
+		if e.InputTokens > 0 || e.OutputTokens > 0 {
+			t.InputTokens += e.InputTokens
+			t.OutputTokens += e.OutputTokens
+			found = true
+		}
+	}
+	if !found {
+		return nil
+	}
+	return t
 }
 
 // Record adds one response's token usage for agent to the running total and

--- a/v2/pkg/tokens/inference_sink_test.go
+++ b/v2/pkg/tokens/inference_sink_test.go
@@ -61,6 +61,62 @@ func TestInferenceSinkNoOps(t *testing.T) {
 	}
 }
 
+// TestInferenceSinkRestoresAcrossRestart verifies that a new sink reloads the
+// cumulative totals already persisted on disk, so a hive restart does not reset
+// every agent's counter to zero (which would overwrite the file with a lower
+// value on the next Record and silently lose all pre-restart tokens). This is
+// load-bearing for the Copilot live path, whose only durable record is this file
+// once the session-shutdown scanner defers to the sink.
+func TestInferenceSinkRestoresAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+
+	sink1 := NewInferenceSink(dir, slog.Default())
+	sink1.Record("worker1", "gpt-5", 100, 40)
+	sink1.Record("worker1", "gpt-5", 50, 20)
+	sink1.Record("worker2", "claude-sonnet-4.5", 10, 5)
+
+	// Simulate a restart: brand-new sink over the same dir.
+	sink2 := NewInferenceSink(dir, slog.Default())
+	// One more response for worker1 must accumulate ON TOP of the restored total.
+	sink2.Record("worker1", "gpt-5", 30, 10)
+
+	agg, err := CollectFromDir(dir, DefaultAgentDetector)
+	if err != nil {
+		t.Fatalf("CollectFromDir: %v", err)
+	}
+	// worker1: (100+50+30) input + (40+20+10) output = 180 + 70 = 250.
+	if got := agg.ByAgent["worker1"]; got != 250 {
+		t.Fatalf("ByAgent[worker1] = %d, want 250 (restored 210 + 40)", got)
+	}
+	// worker2 untouched by sink2 but must still be present from disk.
+	if got := agg.ByAgent["worker2"]; got != 15 {
+		t.Fatalf("ByAgent[worker2] = %d, want 15", got)
+	}
+}
+
+// TestInferenceSinkRestoreIgnoresMalformed verifies restore skips unreadable /
+// malformed files without failing construction.
+func TestInferenceSinkRestoreIgnoresMalformed(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "inference-broken.jsonl", "not json at all\n{bad")
+	writeFile(t, dir, "inference-empty.jsonl", "")
+	// A well-formed file to confirm the good one still restores.
+	writeFile(t, dir, "inference-good.jsonl",
+		`{"role":"user","agent":"good","message":"good"}`+"\n"+
+			`{"role":"assistant","agent":"good","model":"m","input_tokens":7,"output_tokens":3}`+"\n")
+
+	sink := NewInferenceSink(dir, slog.Default())
+	sink.Record("good", "m", 1, 1) // 7+1=8 in, 3+1=4 out => 12
+
+	agg, err := CollectFromDir(dir, DefaultAgentDetector)
+	if err != nil {
+		t.Fatalf("CollectFromDir: %v", err)
+	}
+	if got := agg.ByAgent["good"]; got != 12 {
+		t.Fatalf("ByAgent[good] = %d, want 12", got)
+	}
+}
+
 // TestParseSessionFileExplicitAgent verifies the parser honors an explicit
 // per-entry agent field over keyword detection.
 func TestParseSessionFileExplicitAgent(t *testing.T) {

--- a/v2/pkg/tokens/tokens_coverage_test.go
+++ b/v2/pkg/tokens/tokens_coverage_test.go
@@ -397,7 +397,7 @@ func TestCollector_Start_StopsOnChannel(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestScanCopilotSessions_EmptyDir(t *testing.T) {
-	agg, err := ScanCopilotSessions("")
+	agg, err := ScanCopilotSessions("", false)
 	if err != nil {
 		t.Fatalf("ScanCopilotSessions error: %v", err)
 	}
@@ -407,7 +407,7 @@ func TestScanCopilotSessions_EmptyDir(t *testing.T) {
 }
 
 func TestScanCopilotSessions_NonexistentDir(t *testing.T) {
-	agg, err := ScanCopilotSessions("/nonexistent/dir")
+	agg, err := ScanCopilotSessions("/nonexistent/dir", false)
 	if err != nil {
 		t.Fatalf("ScanCopilotSessions error: %v", err)
 	}
@@ -433,7 +433,7 @@ func TestScanCopilotSessions_WithSessions(t *testing.T) {
 	}, "\n") + "\n"
 	writeFile(t, sessionDir, "events.jsonl", content)
 
-	agg, err := ScanCopilotSessions(dir)
+	agg, err := ScanCopilotSessions(dir, false)
 	if err != nil {
 		t.Fatalf("ScanCopilotSessions error: %v", err)
 	}
@@ -452,13 +452,60 @@ func TestScanCopilotSessions_WithSessions(t *testing.T) {
 	}
 }
 
+// TestScanCopilotSessions_LiveCaptureSkipsTokens verifies that when live capture
+// is on (the MITM proxy records Copilot usage per response), the session-shutdown
+// scanner does NOT accrue tokens again — otherwise every Copilot session would be
+// double-counted. It must still report the session, its messages, and the model.
+func TestScanCopilotSessions_LiveCaptureSkipsTokens(t *testing.T) {
+	dir := t.TempDir()
+	sessionDir := filepath.Join(dir, "session-live")
+	os.MkdirAll(sessionDir, 0o755)
+
+	content := strings.Join([]string{
+		`{"type":"session.start","data":{"sessionId":"live123456789","selectedModel":"gpt-5","context":{"cwd":"/data/agents/scanner"}}}`,
+		`{"type":"user.message","timestamp":"2025-06-01T00:00:00Z","data":{"content":"scan for bugs"}}`,
+		`{"type":"assistant.message","timestamp":"2025-06-01T00:01:00Z","data":{}}`,
+		`{"type":"session.shutdown","data":{"currentModel":"gpt-5","modelMetrics":{"gpt-5":{"usage":{"inputTokens":500,"outputTokens":200,"cacheReadTokens":100,"cacheWriteTokens":50}}}}}`,
+	}, "\n") + "\n"
+	writeFile(t, sessionDir, "events.jsonl", content)
+
+	// liveCapture=true: tokens must be zero, but the session is still counted
+	// (it has messages) and the model is preserved.
+	agg, err := ScanCopilotSessions(dir, true)
+	if err != nil {
+		t.Fatalf("ScanCopilotSessions error: %v", err)
+	}
+	if agg.SessionCount != 1 {
+		t.Fatalf("expected 1 session, got %d", agg.SessionCount)
+	}
+	if agg.TotalInput != 0 || agg.TotalOutput != 0 || agg.TotalCacheRead != 0 || agg.TotalCacheCreate != 0 {
+		t.Errorf("live capture must skip token accrual; got in=%d out=%d cr=%d cc=%d",
+			agg.TotalInput, agg.TotalOutput, agg.TotalCacheRead, agg.TotalCacheCreate)
+	}
+	if agg.TotalMessages != 2 {
+		t.Errorf("TotalMessages = %d, want 2 (messages still counted)", agg.TotalMessages)
+	}
+	if _, ok := agg.ByModel["gpt-5"]; !ok {
+		t.Errorf("model gpt-5 should still be present as a row, got %+v", agg.ByModel)
+	}
+
+	// Same file, liveCapture=false: tokens ARE accrued (proves the flag gates it).
+	agg2, err := ScanCopilotSessions(dir, false)
+	if err != nil {
+		t.Fatalf("ScanCopilotSessions error: %v", err)
+	}
+	if agg2.TotalInput != 500 || agg2.TotalOutput != 200 {
+		t.Errorf("non-live capture should accrue tokens; got in=%d out=%d", agg2.TotalInput, agg2.TotalOutput)
+	}
+}
+
 func TestScanCopilotSessions_SkipsNonDirectories(t *testing.T) {
 	dir := t.TempDir()
 
 	// Create a regular file (not a directory)
 	writeFile(t, dir, "not-a-dir.txt", "hello")
 
-	agg, err := ScanCopilotSessions(dir)
+	agg, err := ScanCopilotSessions(dir, false)
 	if err != nil {
 		t.Fatalf("ScanCopilotSessions error: %v", err)
 	}
@@ -480,7 +527,7 @@ func TestScanCopilotSessions_SkipsOldSessions(t *testing.T) {
 	oldTime := time.Now().Add(-60 * 24 * time.Hour)
 	os.Chtimes(path, oldTime, oldTime)
 
-	agg, err := ScanCopilotSessions(dir)
+	agg, err := ScanCopilotSessions(dir, false)
 	if err != nil {
 		t.Fatalf("ScanCopilotSessions error: %v", err)
 	}
@@ -535,7 +582,7 @@ func TestParseCopilotSessionFile_AgentFromMessage(t *testing.T) {
 	}, "\n") + "\n"
 	path := writeFile(t, dir, "events.jsonl", content)
 
-	summary, err := parseCopilotSessionFile(path)
+	summary, err := parseCopilotSessionFile(path, false)
 	if err != nil {
 		t.Fatalf("parseCopilotSessionFile error: %v", err)
 	}
@@ -553,7 +600,7 @@ func TestParseCopilotSessionFile_AgentFromCwd(t *testing.T) {
 	}, "\n") + "\n"
 	path := writeFile(t, dir, "events.jsonl", content)
 
-	summary, err := parseCopilotSessionFile(path)
+	summary, err := parseCopilotSessionFile(path, false)
 	if err != nil {
 		t.Fatalf("parseCopilotSessionFile error: %v", err)
 	}
@@ -576,7 +623,7 @@ func TestParseCopilotSessionFile_MaxAgentScan(t *testing.T) {
 	content := strings.Join(lines, "\n") + "\n"
 	path := writeFile(t, dir, "events.jsonl", content)
 
-	summary, err := parseCopilotSessionFile(path)
+	summary, err := parseCopilotSessionFile(path, false)
 	if err != nil {
 		t.Fatalf("parseCopilotSessionFile error: %v", err)
 	}
@@ -593,7 +640,7 @@ func TestParseCopilotSessionFile_NoTokens(t *testing.T) {
 	content := `{"type":"session.start","data":{"sessionId":"abc","selectedModel":"gpt-4o"}}` + "\n"
 	path := writeFile(t, dir, "events.jsonl", content)
 
-	summary, err := parseCopilotSessionFile(path)
+	summary, err := parseCopilotSessionFile(path, false)
 	if err != nil {
 		t.Fatalf("parseCopilotSessionFile error: %v", err)
 	}


### PR DESCRIPTION
Backport of three general fixes to `mk` per the all-branches-except-planning policy.

## Cherry-pick results
- **#2062** (`b362a41e`, mobile fixes + read-only banner wrap): **already present on mk** via the mk-native backports #2063 / #2066 / #2070 — cherry-pick resolved to an empty change and was skipped. No functional loss.
- **#2068** (`4d482e63`, stop CSS block leaking into snapshot as text): applied. The build-snapshot.mjs / dashboard index.html comment-wording conflicts resolved in favor of mk's existing wording (functionally identical); the real hub/index.html copy change (`under -race` removal) applied cleanly.
- **#2075** (`e4732d55`, capture Copilot token usage live via MITM): applied cleanly (all 1655 lines, new files copilot_usage.go / copilot_sniff_test.go / copilot_usage_test.go additive).

## Verification (module root `v2/`)
- `go build ./...`: clean
- `go vet ./pkg/proxy/ ./pkg/tokens/ ./pkg/dashboard/ ./pkg/hub/`: clean
- `go test -cover`: pkg/proxy **90.1%**, pkg/tokens **94.3%** (matches v3)
- `go test -race`: clean