### PR TITLE
🐛 fix(fleet-stats): derive the author from the bot token when ai_author is unset

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -663,7 +663,35 @@ func main() {
 	// (merged/rejected PRs, CVE-referencing PRs) across its org on a slow timer
 	// and caches them, so each heartbeat can attach a fresh-but-cheap snapshot
 	// the hub aggregates into the public landing page's live fleet-stats strip.
-	fleetStatsCollector := dashboard.NewFleetStatsCollector(ghClient, cfg.Project.AIAuthor, cfg.Project.Org, logger)
+	// ai_author is optional config and hosted hives are provisioned without it,
+	// so most spokes had an empty author — which silently disabled the collector
+	// entirely (Start() returns early) and left the public fleet-stats strip
+	// blank. Fall back to the bot token's own GitHub login: that IS the account
+	// the agents open PRs as, so it is the correct author to count. Never fall
+	// back to an org-wide search with no author filter — that would sweep in
+	// human PRs and overstate what the fleet's agents actually did.
+	fleetStatsAuthor := cfg.Project.AIAuthor
+	fleetStatsToken := cfg.GitHub.Token
+	if fleetStatsToken == "" {
+		fleetStatsToken = os.Getenv("HIVE_GITHUB_TOKEN")
+	}
+	if fleetStatsAuthor == "" && fleetStatsToken != "" {
+		if botUser, err := github.ValidateToken(fleetStatsToken, cfg.GitHub.ResolvedAPIURL()); err == nil && botUser.Login != "" {
+			fleetStatsAuthor = botUser.Login
+			logger.Info("fleet stats: ai_author unset, using bot token identity",
+				"author", fleetStatsAuthor)
+		} else if err != nil {
+			logger.Warn("fleet stats: ai_author unset and bot identity lookup failed; "+
+				"this hive will not contribute to the public fleet-stats total",
+				"error", err)
+		}
+	}
+	if fleetStatsAuthor == "" || cfg.Project.Org == "" {
+		logger.Warn("fleet stats collector disabled: author or org is empty; "+
+			"set project.ai_author in hive.yaml so this hive contributes to the fleet total",
+			"author", fleetStatsAuthor, "org", cfg.Project.Org)
+	}
+	fleetStatsCollector := dashboard.NewFleetStatsCollector(ghClient, fleetStatsAuthor, cfg.Project.Org, logger)
 	go fleetStatsCollector.Start(ctx)
 
 	var lastActionable atomic.Pointer[github.ActionableResult]

--- a/v2/pkg/dashboard/fleet_stats_collector.go
+++ b/v2/pkg/dashboard/fleet_stats_collector.go
@@ -73,7 +73,12 @@ func (fc *FleetStatsCollector) collect(ctx context.Context) {
 	counts, err := fc.ghClient.ComputeFleetContribCounts(ctx, fc.author, fc.org)
 	if err != nil {
 		if fc.logger != nil {
-			fc.logger.Debug("fleet stats collect failed", "error", err)
+			// Warn, not Debug: a failure here means this hive silently drops out
+			// of the public fleet-stats total, and the only symptom is a blank
+			// strip on the landing page. That is not something to hide at a log
+			// level nobody enables.
+			fc.logger.Warn("fleet stats collect failed; this hive will not contribute to the fleet total",
+				"error", err, "author", fc.author, "org", fc.org)
 		}
 		return
 	}


### PR DESCRIPTION
Ports the fleet-stats fix to `mk`. Same change as #2085 (v3).

## The bug

**8 of 11 hives run builds containing the collector. Zero were actually collecting.**

`FleetStatsCollector.Start()` returns early when `author` is empty, and `project.ai_author` is optional config that hosted provisioning never sets. `hosted-kubestellar-console-4vkt` reports `"ai_author": ""` — so the collector never ran, `ready` stayed false, the heartbeat sent nil, and the hub aggregated nothing. The landing page then correctly hid all three stats rather than render a fabricated zero.

## Fix

Fall back to the bot token's own GitHub login via the existing `github.ValidateToken`. That account **is** the one the agents open PRs as.

**Not** dropping the author filter to count the whole org — for `kubestellar` that reports 11,329 merged PRs instead of 3,900, sweeping in human PRs and overstating what the agents did.

Collect-failure logging also goes `Debug` → `Warn`, plus an explicit warning when the collector is disabled. A hive silently dropping out of the public total should not be invisible.

## Expected fleet total

merged **3,928** · rejected **859** · CVE **45** (verified by running the collector's own queries directly).

`go build` and `go vet` pass.