### PR TITLE
🐛 dashboard: show PLANNING count in the Governor header (was missing at L6)

### DIFF
--- a/v2/pkg/dashboard/plan_from_issue_test.go
+++ b/v2/pkg/dashboard/plan_from_issue_test.go
@@ -518,7 +518,7 @@ func TestBuildPlanning_PendingAndPaused(t *testing.T) {
 	}
 
 	// Architect NOT paused → pending counted, ArchitectPaused false.
-	fp := BuildPlanning(map[string]*beads.Store{"architect": store}, false)
+	fp := BuildPlanning(map[string]*beads.Store{"architect": store}, false, 6)
 	if fp.PendingDecompose != 2 {
 		t.Errorf("PendingDecompose = %d, want 2", fp.PendingDecompose)
 	}
@@ -530,7 +530,7 @@ func TestBuildPlanning_PendingAndPaused(t *testing.T) {
 	}
 
 	// Architect paused AND pending>0 → flag set.
-	fpPaused := BuildPlanning(map[string]*beads.Store{"architect": store}, true)
+	fpPaused := BuildPlanning(map[string]*beads.Store{"architect": store}, true, 6)
 	if !fpPaused.ArchitectPaused {
 		t.Error("ArchitectPaused should be true when architect paused with pending work")
 	}
@@ -541,7 +541,7 @@ func TestBuildPlanning_PausedButNoPendingIsQuiet(t *testing.T) {
 	// A decomposed (non-pending) epic; architect paused but nothing queued.
 	epic, _ := store.Create("done", beads.TypeEpic, beads.PriorityHigh, "architect", "")
 	planning.DecomposeFromOutput(store, epic, "1. [T1] a [agent_suitable]\n", planning.Options{})
-	fp := BuildPlanning(map[string]*beads.Store{"architect": store}, true)
+	fp := BuildPlanning(map[string]*beads.Store{"architect": store}, true, 6)
 	if fp.ArchitectPaused {
 		t.Error("no pending work → ArchitectPaused must stay false even if paused")
 	}

--- a/v2/pkg/dashboard/plan_handlers_test.go
+++ b/v2/pkg/dashboard/plan_handlers_test.go
@@ -310,7 +310,7 @@ func TestBuildPlanning(t *testing.T) {
 	// A plain epic never decomposed → not counted.
 	store.Create("plain", beads.TypeEpic, beads.PriorityHigh, "architect", "")
 
-	fp := BuildPlanning(map[string]*beads.Store{"architect": store}, false)
+	fp := BuildPlanning(map[string]*beads.Store{"architect": store}, false, 6)
 	if fp.ActivePlans != 2 {
 		t.Errorf("ActivePlans: want 2, got %d", fp.ActivePlans)
 	}
@@ -344,14 +344,29 @@ func TestBuildPlanning_Replans24h(t *testing.T) {
 	planning.DecomposeFromOutput(store, bad, "1. [T1] c [agent_suitable]\n", planning.Options{AutoApprove: true})
 	store.SetMetadata(bad.ID, planning.MetaLastReplanAt, "not-a-timestamp")
 
-	fp := buildPlanningAt(map[string]*beads.Store{"architect": store}, false, now)
+	fp := buildPlanningAt(map[string]*beads.Store{"architect": store}, false, 6, now)
 	if fp.Replans24h != 1 {
 		t.Errorf("Replans24h: want 1 (only the 2h-ago replan), got %d", fp.Replans24h)
 	}
 }
 
+func TestBuildPlanning_AvailableGate(t *testing.T) {
+	store, _ := beads.NewStore(t.TempDir())
+	// L4: planning not available (architect not scheduled) -> Available false.
+	if fp := BuildPlanning(map[string]*beads.Store{"architect": store}, false, 4); fp.Available {
+		t.Errorf("Available should be false at ACMM L4")
+	}
+	// L5 and L6: available.
+	if fp := BuildPlanning(map[string]*beads.Store{"architect": store}, false, 5); !fp.Available {
+		t.Errorf("Available should be true at ACMM L5")
+	}
+	if fp := BuildPlanning(map[string]*beads.Store{"architect": store}, false, 6); !fp.Available {
+		t.Errorf("Available should be true at ACMM L6")
+	}
+}
+
 func TestBuildPlanning_Empty(t *testing.T) {
-	fp := BuildPlanning(map[string]*beads.Store{}, false)
+	fp := BuildPlanning(map[string]*beads.Store{}, false, 6)
 	if fp.ActivePlans != 0 || fp.AwaitingReview != 0 {
 		t.Errorf("empty stores should yield zero planning metric, got %+v", fp)
 	}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -323,6 +323,11 @@ type FrontendBeads struct {
 // planning intelligence). It is computed from bead metadata (parent_epic +
 // plan_status) across all bead stores.
 type FrontendPlanning struct {
+	// Available is true only when planning is usable at the current ACMM level
+	// (>= 5, where the architect that decomposes plans is scheduled). The
+	// governor PLANNING tile renders only when this is true, so it never shows a
+	// misleading "0 plans" at levels where planning can't run at all.
+	Available bool `json:"available"`
 	// ActivePlans counts epics that have been decomposed (carry a plan_status),
 	// i.e. plans currently in flight (draft or approved).
 	ActivePlans int `json:"active_plans"`

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -838,6 +838,9 @@
     .gov-stat .val.active { color: var(--green); }
     .gov-stat .val.dead { color: var(--red); }
     .gov-stat .val.starting { color: var(--yellow); }
+    /* planning-alert: plans awaiting human review — amber, to draw the eye like
+       the "N Issues" / on-hold indicators. */
+    .gov-stat .val.planning-alert { color: var(--yellow); }
 
     /* Repos */
     .repos { margin-bottom: 24px; }
@@ -3241,6 +3244,9 @@
           <div class="gov-metric" title="${esc((window._lastStatus?.hold?.items || []).map(h => (h.type === 'pr' ? 'PR' : 'Issue') + ' ' + h.repo + '#' + h.number + ': ' + h.title).join('\n') || 'No items on hold')}"><span class="gm-label">on hold</span><span class="gm-val">${window._lastStatus?.hold?.total || 0}</span></div>
           ${(() => {
             const plan = window._lastStatus?.planning || {};
+            // Planning only runs at ACMM >= 5 (architect scheduled); hide the tile
+            // entirely below that so it never shows a misleading empty state.
+            if (!plan.available) return '';
             const active = plan.active_plans || 0;
             const awaiting = plan.awaiting_review || 0;
             const pending = plan.pending_decompose || 0;
@@ -5045,6 +5051,23 @@
           <div class="gov-stat" title="Number of open pull requests across all monitored repositories."><div class="label">PRs</div><div class="spark-row"><span class="val">${gov.prs}</span>${prsSpark}</div></div>
           <div class="gov-stat" title="${itmTitle}"><div class="label">MTTR</div><div class="spark-row"><span class="val">${formatFixTime(itmMedian)}</span>${itmSpark}</div></div>
           <div class="gov-stat" title="${holdTooltip}"><div class="label">on hold</div><div class="spark-row"><span class="val">${holdTotal}</span>${holdSpark}</div></div>
+          ${(() => {
+            // Planning tile: active plan-trees, with plans-awaiting-review highlighted
+            // amber (human-action-required, like on-hold). Reads /api/status planning
+            // block. Hidden entirely when planning is unavailable (ACMM < 5, where the
+            // architect isn't scheduled) so it never shows a misleading 0.
+            const plan = (data && data.planning) || {};
+            if (!plan.available) return '';
+            const active = plan.active_plans || 0;
+            const awaiting = plan.awaiting_review || 0;
+            const pending = plan.decomposing || 0;
+            const alertCls = awaiting > 0 ? ' planning-alert' : '';
+            const tip = awaiting > 0
+              ? `${awaiting} plan(s) awaiting your review — approve them in the plan view before agents start the work`
+              : `${active} active plan-tree(s)` + (pending ? `, ${pending} decomposing` : '');
+            const valTxt = awaiting > 0 ? `${awaiting} to review` : String(active);
+            return `<div class="gov-stat" title="${escapeHtml(tip)}"><div class="label">planning</div><div class="val${alertCls}">${escapeHtml(valTxt)}${pending > 0 ? ` <span style="opacity:.6;font-size:.7em">+${pending}</span>` : ''}</div></div>`;
+          })()}
           <div class="gov-stat" title="When the governor will next evaluate mode and kick agents based on cadence schedules."><div class="label">next run</div><div class="val">${escapeHtml(gov.nextKick || '—')}</div></div>
         </div>
         <div class="temp-gauge" style="cursor:pointer" onclick="openConfigDialog('governor',null,'Thresholds')" title="Click to adjust governor thresholds">

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -128,21 +128,21 @@ func BuildFrontendStatus(
 	issueToMerge := buildIssueToMerge(metricsCollector)
 
 	payload := &StatusPayload{
-		Timestamp:    time.Now().UTC().Format(time.RFC3339),
-		HiveID:       cfg.HiveID,
-		Agents:       buildAgents(agentStatuses, cfg, govState),
-		Governor:     buildGovernor(govState, cfg),
-		Tokens:       buildTokens(tokenCollector),
-		Repos:        buildRepos(cfg, actionable),
-		Beads:        BuildBeadsFromConfig(beadStores, cfg),
-		Planning:     BuildPlanning(beadStores, architectPausedFromStatuses(agentStatuses)),
-		Health:       buildHealth(ghClient, ctx),
-		Budget:       buildBudget(gov, tokenCollector),
-		CadenceMatrix: buildCadenceMatrix(cfg, agentStatuses),
-		GHRateLimits: buildGHRateLimits(ghClient, ctx, cfg),
-		AgentMetrics: agentMetrics,
-		Hold:         buildHold(actionable),
-		IssueToMerge: issueToMerge,
+		Timestamp:       time.Now().UTC().Format(time.RFC3339),
+		HiveID:          cfg.HiveID,
+		Agents:          buildAgents(agentStatuses, cfg, govState),
+		Governor:        buildGovernor(govState, cfg),
+		Tokens:          buildTokens(tokenCollector),
+		Repos:           buildRepos(cfg, actionable),
+		Beads:           BuildBeadsFromConfig(beadStores, cfg),
+		Planning:        BuildPlanning(beadStores, architectPausedFromStatuses(agentStatuses), detectACMMLevel(cfg)),
+		Health:          buildHealth(ghClient, ctx),
+		Budget:          buildBudget(gov, tokenCollector),
+		CadenceMatrix:   buildCadenceMatrix(cfg, agentStatuses),
+		GHRateLimits:    buildGHRateLimits(ghClient, ctx, cfg),
+		AgentMetrics:    agentMetrics,
+		Hold:            buildHold(actionable),
+		IssueToMerge:    issueToMerge,
 		ACMMLevel:       detectACMMLevel(cfg),
 		ACMMPackAgents:  buildACMMPackAgents(cfg),
 		SystemResources: collectSystemResources(),
@@ -698,12 +698,12 @@ func buildTokens(collector *tokens.Collector) FrontendTokens {
 	// Per-agent breakdown with full detail
 	for agentName, detail := range summary.ByAgentDetail {
 		bucket := FrontendTokenBucket{
-			Input:     detail.Input,
-			Output:    detail.Output,
-			CacheRead: detail.CacheRead,
+			Input:       detail.Input,
+			Output:      detail.Output,
+			CacheRead:   detail.CacheRead,
 			CacheCreate: detail.CacheCreate,
-			Messages:  detail.Messages,
-			Sessions:  detail.Sessions,
+			Messages:    detail.Messages,
+			Sessions:    detail.Sessions,
 		}
 		if detail.Sessions > 0 {
 			totalForAgent := detail.Input + detail.Output + detail.CacheRead + detail.CacheCreate
@@ -715,12 +715,12 @@ func buildTokens(collector *tokens.Collector) FrontendTokens {
 	// Per-model breakdown with full detail
 	for modelName, detail := range summary.ByModelDetail {
 		bucket := FrontendTokenBucket{
-			Input:     detail.Input,
-			Output:    detail.Output,
-			CacheRead: detail.CacheRead,
+			Input:       detail.Input,
+			Output:      detail.Output,
+			CacheRead:   detail.CacheRead,
 			CacheCreate: detail.CacheCreate,
-			Messages:  detail.Messages,
-			Sessions:  detail.Sessions,
+			Messages:    detail.Messages,
+			Sessions:    detail.Sessions,
 		}
 		if detail.Sessions > 0 {
 			totalForModel := detail.Input + detail.Output + detail.CacheRead + detail.CacheCreate
@@ -804,14 +804,14 @@ func buildBeads(stores map[string]*beads.Store) FrontendBeads {
 // PendingDecompose (Phase 4) counts issue-sourced epics not yet built by the
 // architect; architectPaused says whether that queue is blocked on a paused
 // architect (so the tile can show the "resume the architect" message).
-func BuildPlanning(stores map[string]*beads.Store, architectPaused bool) FrontendPlanning {
-	return buildPlanningAt(stores, architectPaused, time.Now())
+func BuildPlanning(stores map[string]*beads.Store, architectPaused bool, acmmLevel int) FrontendPlanning {
+	return buildPlanningAt(stores, architectPaused, acmmLevel, time.Now())
 }
 
 // buildPlanningAt is BuildPlanning with an injected `now`, so the replans_24h
 // window is unit-testable with backdated last_replan_at timestamps.
-func buildPlanningAt(stores map[string]*beads.Store, architectPaused bool, now time.Time) FrontendPlanning {
-	fp := FrontendPlanning{}
+func buildPlanningAt(stores map[string]*beads.Store, architectPaused bool, acmmLevel int, now time.Time) FrontendPlanning {
+	fp := FrontendPlanning{Available: planning.PlanningAllowedAtLevel(acmmLevel)}
 	cutoff := now.Add(-planningReplanWindow)
 	for _, store := range stores {
 		all := store.List(beads.ListFilter{})


### PR DESCRIPTION
**Reported:** at ACMM L6, there's no PLANNING count anywhere in the Governor.

**Root cause:** the Phase 2 PLANNING tile only rendered in the compact `.oc-gov-strip`, not the main Governor-page header (the big timer/mode/actionable/on-hold/next-run tiles). And both tiles gated on `plan.available`, a field that **didn't exist** on `FrontendPlanning` — so it was always falsy and never rendered.

**Fix:**
1. Add `Available bool` to the planning payload, true only at ACMM ≥ 5 (where the architect is scheduled), wired from `detectACMMLevel` → `BuildPlanning`.
2. Add a **PLANNING tile to the big Governor header** (after on-hold): shows active plan-trees; highlights `N to review` in amber when plans await approval; hidden below L5 so it never shows a misleading 0.

At L6 (available), the tile now appears in the Governor header. `TestBuildPlanning_AvailableGate` covers the gate. Build/vet/tests clean; dashboard 80.5% (floor 78%).

Planning is v3-only, so this is v3-only.