### PR TITLE
fix(hub): target container 'hub' (not 'hive-hub') in self-upgrade set-image

### DIFF
--- a/v2/pkg/hub/hub_upgrade_state_test.go
+++ b/v2/pkg/hub/hub_upgrade_state_test.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -91,5 +92,44 @@ func TestRolloutHubToSHAEmpty(t *testing.T) {
 	s := &HubServer{logger: slog.Default(), hubGitBranch: "v2"}
 	if err := s.rolloutHubToSHA(""); err == nil {
 		t.Error("empty SHA should error")
+	}
+}
+
+// TestRolloutHubToSHAContainerName verifies `kubectl set image` targets the
+// hub's ACTUAL container name ("hub"), not the deployment name ("hive-hub").
+// Naming the wrong container makes set image a no-op/error, so a regression here
+// silently breaks every hub self-upgrade.
+func TestRolloutHubToSHAContainerName(t *testing.T) {
+	// Fake kubectl that records its args, so we can assert the container= arg.
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "args.txt")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> " + argsFile + "\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(dir, "kubectl"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// Stub the GHCR check so the roll proceeds to kubectl.
+	oldImg := hubImageExists
+	hubImageExists = func(string, *slog.Logger) bool { return true }
+	t.Cleanup(func() { hubImageExists = oldImg })
+
+	s := &HubServer{logger: slog.Default(), hubGitBranch: "v2",
+		clusters: map[string]ClusterConfig{defaultClusterID: {ID: defaultClusterID, InCluster: true}}}
+	if err := s.rolloutHubToSHA("abc1234"); err != nil {
+		t.Fatalf("rolloutHubToSHA: %v", err)
+	}
+
+	got, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("kubectl not invoked: %v", err)
+	}
+	args := string(got)
+	wantContainer := hubContainerName + "=ghcr.io/" + ghcrRepoHub + ":abc1234"
+	if !strings.Contains(args, wantContainer) {
+		t.Errorf("set image args = %q, want container arg %q", strings.TrimSpace(args), wantContainer)
+	}
+	if strings.Contains(args, hubDeploymentName+"=ghcr.io/") {
+		t.Errorf("set image wrongly used the DEPLOYMENT name as the container: %q", strings.TrimSpace(args))
 	}
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2023,12 +2023,13 @@ func (s *HubServer) handleHubAutoUpgrade(w http.ResponseWriter, r *http.Request)
 
 	// If enabling and hub is behind, trigger immediately
 	if body.AutoUpgrade {
-		latestSHA := getLatestSHA()
-		if latestSHA != "" && latestSHA != s.hubGitHash {
+		latestSHA := getLatestSHAForBranch(s.hubGitBranch)
+		if latestSHA != "" && !sameCommit(latestSHA, s.hubGitHash) {
 			s.logger.Info("audit: hub auto-upgrade initial trigger", "from", s.hubGitHash, "to", latestSHA)
-			cmd := kubectlForCluster(s.hubCluster(), "rollout", "restart", "deployment/hive-hub", "-n", "hive-hub")
-			if out, err := cmd.CombinedOutput(); err != nil {
-				s.logger.Warn("hub auto-upgrade failed", "output", string(out))
+			// Route through rolloutHubToSHA so this shares the hub-image gate and
+			// the SHA-pin (avoids a stale cached v2-latest) with the poller path.
+			if err := s.rolloutHubToSHA(latestSHA); err != nil {
+				s.logger.Warn("hub auto-upgrade skipped", "to", latestSHA, "reason", err)
 			}
 		}
 	}
@@ -2056,7 +2057,7 @@ func (s *HubServer) rolloutHubToSHA(sha string) error {
 	}
 	image := fmt.Sprintf("ghcr.io/%s:%s", ghcrRepoHub, sha)
 	cmd := kubectlForCluster(s.hubCluster(), "set", "image",
-		"deployment/hive-hub", "hive-hub="+image, "-n", "hive-hub")
+		"deployment/"+hubDeploymentName, hubContainerName+"="+image, "-n", hubNamespace)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("kubectl set image failed: %s", strings.TrimSpace(string(out)))
 	}
@@ -2535,6 +2536,14 @@ var (
 const (
 	ghcrRepoSpoke = "kubestellar/hive"
 	ghcrRepoHub   = "kubestellar/hive-hub"
+
+	// hubDeploymentName / hubContainerName / hubNamespace identify the hub's own
+	// Kubernetes objects for self-upgrade. NOTE the container is named "hub", not
+	// "hive-hub" — a `kubectl set image` that names the wrong container silently
+	// no-ops the target (or errors), so pin the image against hubContainerName.
+	hubDeploymentName = "hive-hub"
+	hubContainerName  = "hub"
+	hubNamespace      = "hive-hub"
 )
 
 // hubImageExists reports whether the hub's own container image is published on


### PR DESCRIPTION
## Problem

Follow-up to #2090. `rolloutHubToSHA` ran:
```
kubectl set image deployment/hive-hub hive-hub=<img> -n hive-hub
```
But the hub **container** is named `hub` — only the **deployment** is `hive-hub`. `kubectl set image` naming a non-existent container fails (`unable to find container named "hive-hub"`), so **every hub self-upgrade would error out**. Caught while manually rolling the live hub.

## Fix
- Add `hubDeploymentName` / `hubContainerName` (`hub`) / `hubNamespace` constants; pin the image against the **container** name.
- Route the auto-upgrade **enable** path through `rolloutHubToSHA` too, so it shares the hub-image gate and the SHA-pin (previously a bare `rollout restart` of the mutable tag).
- Test asserts the set-image arg is `hub=ghcr.io/kubestellar/hive-hub:<sha>` and never uses the deployment name as the container.

Full `pkg/hub` suite green. Ports to mk/dd/v3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)