### PR TITLE
🐛 tokens: fix Copilot cost collapse ($18k regression) — backport to v2

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1400,8 +1400,11 @@ func main() {
 		// (api.githubcopilot.com) to record Copilot token usage live per
 		// response — so Copilot cost shows up while an agent runs instead of only
 		// tallying at session shutdown. Tell the collector to defer Copilot token
-		// accrual from session-shutdown files to the sink to avoid double-counting.
-		tokenCollector.SetCopilotLiveCapture(true)
+		// accrual to the sink ONLY for sessions active from NOW on (the moment
+		// live capture starts). Sessions that ended earlier were never sniffed by
+		// the proxy, so the scanner keeps counting their shutdown tokens —
+		// otherwise all pre-existing Copilot spend would vanish.
+		tokenCollector.SetCopilotLiveCapture(time.Now().UnixMilli())
 
 		vllmEndpoints := parseEndpointList(envOrDefault("HIVE_VLLM_ENDPOINT", "http://hive-vllm-svc.hive-inference.svc.cluster.local:8000"))
 		llmdEndpoints := parseEndpointList(envOrDefault("HIVE_LLMD_ENDPOINT", "http://hive-llm-d-epp.hive-inference.svc.cluster.local:8000"))

--- a/v2/pkg/tokens/claude_scanner_test.go
+++ b/v2/pkg/tokens/claude_scanner_test.go
@@ -407,7 +407,7 @@ func TestCollectorCopilotLiveCapture(t *testing.T) {
 
 	c := NewCollector(metricsDir, testLogger())
 	c.SetCopilotSessionsDir(copilotDir)
-	c.SetCopilotLiveCapture(true)
+	c.SetCopilotLiveCapture(1)
 	c.scan()
 
 	summary := c.Summary()

--- a/v2/pkg/tokens/collector.go
+++ b/v2/pkg/tokens/collector.go
@@ -72,20 +72,20 @@ const (
 )
 
 type Collector struct {
-	sessionsDir        string
-	claudeSessionsDir  string
-	copilotSessionsDir string
-	copilotLiveCapture bool
-	persistPath        string
-	detector           func(string) string
-	logger             *slog.Logger
-	mu                 sync.RWMutex
-	latest             *AggregateSummary
-	issueCosts         map[string]int64
-	scanInterval       time.Duration
-	prevSessionCount   int
-	prevTotalTokens    int64
-	prevByAgent        map[string]int64
+	sessionsDir               string
+	claudeSessionsDir         string
+	copilotSessionsDir        string
+	copilotLiveCaptureSinceMs int64
+	persistPath               string
+	detector                  func(string) string
+	logger                    *slog.Logger
+	mu                        sync.RWMutex
+	latest                    *AggregateSummary
+	issueCosts                map[string]int64
+	scanInterval              time.Duration
+	prevSessionCount          int
+	prevTotalTokens           int64
+	prevByAgent               map[string]int64
 }
 
 func NewCollector(sessionsDir string, logger *slog.Logger) *Collector {
@@ -115,23 +115,29 @@ func (c *Collector) SetCopilotSessionsDir(dir string) {
 	c.copilotSessionsDir = dir
 }
 
-// SetCopilotLiveCapture tells the collector that the MITM proxy is recording
-// Copilot token usage live (per completion) into the inference sink. When set,
-// the copilot session-file scanner defers token accrual to the sink to avoid
-// double-counting; it still contributes session/message/model metadata. It is
-// mutex-guarded so it can be called after Start (the scan goroutine reads it
+// SetCopilotLiveCapture tells the collector that the MITM proxy began recording
+// Copilot token usage live (per completion) into the inference sink at
+// sinceUnixMs. The copilot session-file scanner then defers token accrual to the
+// sink ONLY for sessions that were still active at/after that moment (i.e. ones
+// the proxy could actually have sniffed). Sessions that ended BEFORE live
+// capture started were never seen by the sink, so the scanner must still count
+// their session.shutdown ModelMetrics — otherwise all historical Copilot spend
+// vanishes (the $18k→$394 regression). A sinceUnixMs of 0 disables the deferral
+// entirely (always count shutdown tokens).
+//
+// Mutex-guarded so it can be called after Start (the scan goroutine reads it
 // under the same lock).
-func (c *Collector) SetCopilotLiveCapture(enabled bool) {
+func (c *Collector) SetCopilotLiveCapture(sinceUnixMs int64) {
 	c.mu.Lock()
-	c.copilotLiveCapture = enabled
+	c.copilotLiveCaptureSinceMs = sinceUnixMs
 	c.mu.Unlock()
 }
 
-// copilotLiveCaptureEnabled reads the flag under the lock.
-func (c *Collector) copilotLiveCaptureEnabled() bool {
+// copilotLiveCaptureSince reads the live-capture start timestamp (ms), 0 if off.
+func (c *Collector) copilotLiveCaptureSince() int64 {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.copilotLiveCapture
+	return c.copilotLiveCaptureSinceMs
 }
 
 func (c *Collector) Start(stop <-chan struct{}) {
@@ -165,7 +171,7 @@ func (c *Collector) scan() {
 	}
 
 	if c.copilotSessionsDir != "" {
-		copilotAgg, err := ScanCopilotSessions(c.copilotSessionsDir, c.copilotLiveCaptureEnabled())
+		copilotAgg, err := ScanCopilotSessions(c.copilotSessionsDir, c.copilotLiveCaptureSince())
 		if err != nil {
 			c.logger.Warn("copilot session scan failed", "error", err)
 		} else if copilotAgg != nil && copilotAgg.SessionCount > 0 {

--- a/v2/pkg/tokens/copilot_scanner.go
+++ b/v2/pkg/tokens/copilot_scanner.go
@@ -55,15 +55,17 @@ type copilotToolComplete struct {
 // directory and returns an AggregateSummary. The sessionsDir is typically
 // ~/.copilot/session-state.
 //
-// When liveCapture is true, the MITM proxy is recording Copilot token usage
-// live (per completion response) into the inference sink, so this scanner MUST
-// NOT also accrue tokens from the session.shutdown ModelMetrics — doing so would
-// double-count every Copilot session (once live via the sink, once at shutdown
-// here). In that mode the scanner still contributes session presence, message
-// counts, model, and last-active timestamps (which the live sink does not
-// capture), but records zero tokens; the proxy sink is the single source of
-// Copilot token totals.
-func ScanCopilotSessions(sessionsDir string, liveCapture bool) (*AggregateSummary, error) {
+// liveCaptureSinceMs, when > 0, is the Unix-ms moment the MITM proxy began
+// recording Copilot token usage live into the inference sink. For any session
+// still active AT OR AFTER that moment, the proxy already counted its tokens, so
+// this scanner MUST NOT also accrue them from session.shutdown ModelMetrics
+// (that would double-count). But sessions that ended BEFORE liveCaptureSinceMs
+// were never seen by the sink, so their shutdown tokens MUST still be counted —
+// otherwise all pre-live-capture Copilot spend disappears. A value of 0 disables
+// the deferral entirely (always count shutdown tokens). Either way the scanner
+// always contributes session presence, message counts, model, and last-active
+// timestamps (which the live sink does not capture).
+func ScanCopilotSessions(sessionsDir string, liveCaptureSinceMs int64) (*AggregateSummary, error) {
 	agg := &AggregateSummary{
 		ByAgent:       make(map[string]int64),
 		ByModel:       make(map[string]int64),
@@ -94,8 +96,24 @@ func ScanCopilotSessions(sessionsDir string, liveCapture bool) (*AggregateSummar
 			continue
 		}
 
-		summary, err := parseCopilotSessionFile(eventsFile, liveCapture)
-		if err != nil || summary == nil || summary.TotalTokens == 0 && summary.Messages == 0 {
+		// Always parse the full shutdown usage; decide per-session below whether
+		// to keep it (older than live capture → keep) or defer it to the proxy
+		// sink (active at/after live capture → zero the tokens to avoid
+		// double-counting). Deciding here — not inside the parser — means we can
+		// use the session's own LastActive, which is only known after parsing.
+		summary, err := parseCopilotSessionFile(eventsFile)
+		if err != nil || summary == nil {
+			continue
+		}
+		if liveCaptureSinceMs > 0 && summary.LastActive >= liveCaptureSinceMs {
+			// Proxy captured this session's tokens live; keep metadata, drop tokens.
+			summary.InputTokens = 0
+			summary.OutputTokens = 0
+			summary.CacheRead = 0
+			summary.CacheCreate = 0
+			summary.TotalTokens = 0
+		}
+		if summary.TotalTokens == 0 && summary.Messages == 0 {
 			continue
 		}
 
@@ -138,7 +156,7 @@ func ScanCopilotSessions(sessionsDir string, liveCapture bool) (*AggregateSummar
 	return agg, nil
 }
 
-func parseCopilotSessionFile(path string, liveCapture bool) (*SessionSummary, error) {
+func parseCopilotSessionFile(path string) (*SessionSummary, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -220,17 +238,16 @@ func parseCopilotSessionFile(path string, liveCapture bool) (*SessionSummary, er
 				if shutdown.CurrentModel != "" {
 					summary.Model = shutdown.CurrentModel
 				}
-				// When the live-capture proxy is active it already recorded
-				// every completion's tokens into the inference sink; accruing
-				// the shutdown ModelMetrics here would double-count. Keep the
-				// model (set above) but skip the token totals.
-				if !liveCapture {
-					for _, metrics := range shutdown.ModelMetrics {
-						summary.InputTokens += metrics.Usage.InputTokens
-						summary.OutputTokens += metrics.Usage.OutputTokens
-						summary.CacheRead += metrics.Usage.CacheReadTokens
-						summary.CacheCreate += metrics.Usage.CacheWriteTokens
-					}
+				// Always accrue the shutdown token totals here. The caller
+				// (ScanCopilotSessions) decides per-session whether to keep them
+				// or zero them out for double-count avoidance, based on whether
+				// the session was active after live capture started — a decision
+				// that needs the fully-parsed LastActive timestamp.
+				for _, metrics := range shutdown.ModelMetrics {
+					summary.InputTokens += metrics.Usage.InputTokens
+					summary.OutputTokens += metrics.Usage.OutputTokens
+					summary.CacheRead += metrics.Usage.CacheReadTokens
+					summary.CacheCreate += metrics.Usage.CacheWriteTokens
 				}
 			}
 		}

--- a/v2/pkg/tokens/tokens_coverage_test.go
+++ b/v2/pkg/tokens/tokens_coverage_test.go
@@ -397,7 +397,7 @@ func TestCollector_Start_StopsOnChannel(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestScanCopilotSessions_EmptyDir(t *testing.T) {
-	agg, err := ScanCopilotSessions("", false)
+	agg, err := ScanCopilotSessions("", 0)
 	if err != nil {
 		t.Fatalf("ScanCopilotSessions error: %v", err)
 	}
@@ -407,7 +407,7 @@ func TestScanCopilotSessions_EmptyDir(t *testing.T) {
 }
 
 func TestScanCopilotSessions_NonexistentDir(t *testing.T) {
-	agg, err := ScanCopilotSessions("/nonexistent/dir", false)
+	agg, err := ScanCopilotSessions("/nonexistent/dir", 0)
 	if err != nil {
 		t.Fatalf("ScanCopilotSessions error: %v", err)
 	}
@@ -433,7 +433,7 @@ func TestScanCopilotSessions_WithSessions(t *testing.T) {
 	}, "\n") + "\n"
 	writeFile(t, sessionDir, "events.jsonl", content)
 
-	agg, err := ScanCopilotSessions(dir, false)
+	agg, err := ScanCopilotSessions(dir, 0)
 	if err != nil {
 		t.Fatalf("ScanCopilotSessions error: %v", err)
 	}
@@ -449,6 +449,37 @@ func TestScanCopilotSessions_WithSessions(t *testing.T) {
 	}
 	if agg.TotalCacheRead != 100 {
 		t.Errorf("TotalCacheRead = %d, want 100", agg.TotalCacheRead)
+	}
+}
+
+// TestScanCopilotSessions_PreCaptureSessionStillCounts is the regression guard
+// for the $18k->$394 bug: a Copilot session that ENDED BEFORE live capture
+// started was never sniffed by the proxy sink, so its session.shutdown tokens
+// MUST still be counted even though live capture is enabled. Only sessions
+// active at/after the capture start are deferred to the sink.
+func TestScanCopilotSessions_PreCaptureSessionStillCounts(t *testing.T) {
+	dir := t.TempDir()
+	sessionDir := filepath.Join(dir, "session-old")
+	os.MkdirAll(sessionDir, 0o755)
+
+	// Session activity is 2025-06-01 (well in the past).
+	content := strings.Join([]string{
+		`{"type":"session.start","data":{"sessionId":"old123456789","selectedModel":"gpt-4o","context":{"cwd":"/data/agents/scanner"}}}`,
+		`{"type":"user.message","timestamp":"2025-06-01T00:00:00Z","data":{"content":"scan"}}`,
+		`{"type":"assistant.message","timestamp":"2025-06-01T00:01:00Z","data":{}}`,
+		`{"type":"session.shutdown","data":{"currentModel":"gpt-4o","modelMetrics":{"gpt-4o":{"usage":{"inputTokens":500,"outputTokens":200,"cacheReadTokens":100,"cacheWriteTokens":50}}}}}`,
+	}, "\n") + "\n"
+	writeFile(t, sessionDir, "events.jsonl", content)
+
+	// Live capture "started" in 2026 — AFTER this session ended. Its tokens
+	// must NOT be dropped.
+	sinceMs := int64(1767225600000) // 2026-01-01
+	agg, err := ScanCopilotSessions(dir, sinceMs)
+	if err != nil {
+		t.Fatalf("ScanCopilotSessions error: %v", err)
+	}
+	if agg.TotalInput != 500 || agg.TotalOutput != 200 {
+		t.Fatalf("pre-capture session tokens were dropped: input=%d output=%d, want 500/200 (the $18k->$394 regression)", agg.TotalInput, agg.TotalOutput)
 	}
 }
 
@@ -471,7 +502,7 @@ func TestScanCopilotSessions_LiveCaptureSkipsTokens(t *testing.T) {
 
 	// liveCapture=true: tokens must be zero, but the session is still counted
 	// (it has messages) and the model is preserved.
-	agg, err := ScanCopilotSessions(dir, true)
+	agg, err := ScanCopilotSessions(dir, 1)
 	if err != nil {
 		t.Fatalf("ScanCopilotSessions error: %v", err)
 	}
@@ -490,7 +521,7 @@ func TestScanCopilotSessions_LiveCaptureSkipsTokens(t *testing.T) {
 	}
 
 	// Same file, liveCapture=false: tokens ARE accrued (proves the flag gates it).
-	agg2, err := ScanCopilotSessions(dir, false)
+	agg2, err := ScanCopilotSessions(dir, 0)
 	if err != nil {
 		t.Fatalf("ScanCopilotSessions error: %v", err)
 	}
@@ -505,7 +536,7 @@ func TestScanCopilotSessions_SkipsNonDirectories(t *testing.T) {
 	// Create a regular file (not a directory)
 	writeFile(t, dir, "not-a-dir.txt", "hello")
 
-	agg, err := ScanCopilotSessions(dir, false)
+	agg, err := ScanCopilotSessions(dir, 0)
 	if err != nil {
 		t.Fatalf("ScanCopilotSessions error: %v", err)
 	}
@@ -527,7 +558,7 @@ func TestScanCopilotSessions_SkipsOldSessions(t *testing.T) {
 	oldTime := time.Now().Add(-60 * 24 * time.Hour)
 	os.Chtimes(path, oldTime, oldTime)
 
-	agg, err := ScanCopilotSessions(dir, false)
+	agg, err := ScanCopilotSessions(dir, 0)
 	if err != nil {
 		t.Fatalf("ScanCopilotSessions error: %v", err)
 	}
@@ -582,7 +613,7 @@ func TestParseCopilotSessionFile_AgentFromMessage(t *testing.T) {
 	}, "\n") + "\n"
 	path := writeFile(t, dir, "events.jsonl", content)
 
-	summary, err := parseCopilotSessionFile(path, false)
+	summary, err := parseCopilotSessionFile(path)
 	if err != nil {
 		t.Fatalf("parseCopilotSessionFile error: %v", err)
 	}
@@ -600,7 +631,7 @@ func TestParseCopilotSessionFile_AgentFromCwd(t *testing.T) {
 	}, "\n") + "\n"
 	path := writeFile(t, dir, "events.jsonl", content)
 
-	summary, err := parseCopilotSessionFile(path, false)
+	summary, err := parseCopilotSessionFile(path)
 	if err != nil {
 		t.Fatalf("parseCopilotSessionFile error: %v", err)
 	}
@@ -623,7 +654,7 @@ func TestParseCopilotSessionFile_MaxAgentScan(t *testing.T) {
 	content := strings.Join(lines, "\n") + "\n"
 	path := writeFile(t, dir, "events.jsonl", content)
 
-	summary, err := parseCopilotSessionFile(path, false)
+	summary, err := parseCopilotSessionFile(path)
 	if err != nil {
 		t.Fatalf("parseCopilotSessionFile error: %v", err)
 	}
@@ -640,7 +671,7 @@ func TestParseCopilotSessionFile_NoTokens(t *testing.T) {
 	content := `{"type":"session.start","data":{"sessionId":"abc","selectedModel":"gpt-4o"}}` + "\n"
 	path := writeFile(t, dir, "events.jsonl", content)
 
-	summary, err := parseCopilotSessionFile(path, false)
+	summary, err := parseCopilotSessionFile(path)
 	if err != nil {
 		t.Fatalf("parseCopilotSessionFile error: %v", err)
 	}


### PR DESCRIPTION
Backport of #2089 (cost-regression fix) to v2. The buggy live-capture dedup from #2075 is on this branch too, so the $18k→$394 copilot-cost collapse is present here — this fixes it with the per-session time-gated dedup (sessions active before live-capture keep their shutdown tokens). Clean cherry-pick; build + tokens tests pass.