### PR TITLE
🐛 dashboard: attribute auto-mode agents to resolved model + guard cost hourly against restore-jump discontinuity

### DIFF
--- a/v2/pkg/dashboard/resolve_agent_models_test.go
+++ b/v2/pkg/dashboard/resolve_agent_models_test.go
@@ -1,0 +1,96 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/tokens"
+)
+
+// TestResolveAgentModels_AutoConfigResolvesToRealModel is the core BUG A case:
+// an agent whose config model is "auto" runs sessions logged under a concrete
+// resolved model (e.g. copilot "auto" → gpt-5.3-codex). resolveAgentModels must
+// return the resolved model so the frontend badge lands on that row.
+func TestResolveAgentModels_AutoConfigResolvesToRealModel(t *testing.T) {
+	sessions := []tokens.SessionSummary{
+		{SessionID: "s1", Agent: "scanner", Model: "gpt-5.3-codex", LastActive: 100},
+	}
+	got := resolveAgentModels(sessions)
+	if got["scanner"] != "gpt-5.3-codex" {
+		t.Fatalf("scanner resolved model = %q, want gpt-5.3-codex", got["scanner"])
+	}
+}
+
+// TestResolveAgentModels_PicksLatestActive verifies that when an agent has
+// multiple qualifying sessions, the one with the greatest LastActive wins.
+func TestResolveAgentModels_PicksLatestActive(t *testing.T) {
+	sessions := []tokens.SessionSummary{
+		{SessionID: "old", Agent: "scanner", Model: "gpt-5.2-codex", LastActive: 50},
+		{SessionID: "new", Agent: "scanner", Model: "gpt-5.3-codex", LastActive: 200},
+		{SessionID: "mid", Agent: "scanner", Model: "claude-opus-4-8", LastActive: 120},
+	}
+	got := resolveAgentModels(sessions)
+	if got["scanner"] != "gpt-5.3-codex" {
+		t.Fatalf("scanner resolved model = %q, want gpt-5.3-codex (latest)", got["scanner"])
+	}
+}
+
+// TestResolveAgentModels_SkipsAliasAndUnknown verifies alias/placeholder models
+// never win, and that a real earlier session is chosen over a later alias one.
+func TestResolveAgentModels_SkipsAliasAndUnknown(t *testing.T) {
+	sessions := []tokens.SessionSummary{
+		{SessionID: "real", Agent: "scanner", Model: "gpt-5.3-codex", LastActive: 100},
+		{SessionID: "alias", Agent: "scanner", Model: "auto", LastActive: 300},
+		{SessionID: "def", Agent: "scanner", Model: "default", LastActive: 400},
+		{SessionID: "unk", Agent: "scanner", Model: "unknown", LastActive: 500},
+		{SessionID: "empty", Agent: "scanner", Model: "", LastActive: 600},
+		{SessionID: "ws", Agent: "scanner", Model: "  AUTO  ", LastActive: 700},
+	}
+	got := resolveAgentModels(sessions)
+	if got["scanner"] != "gpt-5.3-codex" {
+		t.Fatalf("scanner resolved model = %q, want gpt-5.3-codex (aliases skipped)", got["scanner"])
+	}
+}
+
+// TestResolveAgentModels_NoQualifyingSession verifies an agent with only alias
+// sessions is absent from the map (frontend then falls back to the config alias).
+func TestResolveAgentModels_NoQualifyingSession(t *testing.T) {
+	sessions := []tokens.SessionSummary{
+		{SessionID: "a", Agent: "scanner", Model: "auto", LastActive: 100},
+		{SessionID: "b", Agent: "scanner", Model: "", LastActive: 200},
+	}
+	got := resolveAgentModels(sessions)
+	if _, ok := got["scanner"]; ok {
+		t.Fatalf("scanner should be absent when it has no concrete-model session, got %q", got["scanner"])
+	}
+}
+
+// TestResolveAgentModels_MultipleAgents verifies independent resolution and that
+// an empty-agent session is ignored.
+func TestResolveAgentModels_MultipleAgents(t *testing.T) {
+	sessions := []tokens.SessionSummary{
+		{SessionID: "s1", Agent: "scanner", Model: "gpt-5.3-codex", LastActive: 100},
+		{SessionID: "s2", Agent: "reviewer", Model: "claude-opus-4-8", LastActive: 100},
+		{SessionID: "s3", Agent: "", Model: "gpt-5.3-codex", LastActive: 100},
+	}
+	got := resolveAgentModels(sessions)
+	if got["scanner"] != "gpt-5.3-codex" {
+		t.Errorf("scanner = %q, want gpt-5.3-codex", got["scanner"])
+	}
+	if got["reviewer"] != "claude-opus-4-8" {
+		t.Errorf("reviewer = %q, want claude-opus-4-8", got["reviewer"])
+	}
+	if len(got) != 2 {
+		t.Errorf("map size = %d, want 2 (empty-agent session ignored)", len(got))
+	}
+}
+
+// TestResolveAgentModels_Empty verifies no panic and an empty (non-nil) result.
+func TestResolveAgentModels_Empty(t *testing.T) {
+	got := resolveAgentModels(nil)
+	if got == nil {
+		t.Fatal("expected non-nil map")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected empty map, got %v", got)
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -273,6 +273,14 @@ type FrontendTokens struct {
 	Totals        FrontendTokenTotals            `json:"totals"`
 	ByAgent       map[string]FrontendTokenBucket `json:"byAgent"`
 	ByModel       map[string]FrontendTokenBucket `json:"byModel"`
+	// ByAgentModel maps an agent name to the RESOLVED model of its most
+	// recently active session. An agent whose config model is a routing alias
+	// ("auto"/"default") resolves at runtime to a concrete model (e.g. copilot
+	// "auto" → gpt-5.3-codex); the resolved id is parsed from session logs into
+	// SessionSummary.Model. The frontend uses this so an auto-mode agent's
+	// "running agents" badge lands on the resolved-model row where its tokens
+	// actually accrue, instead of showing nothing on that row.
+	ByAgentModel map[string]string `json:"byAgentModel"`
 }
 
 type FrontendTokenTotals struct {

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4086,8 +4086,12 @@
       // the actual spend from the noisy counter. (Also immune to price-table
       // shifts, which move the cumulative $ but not the token increments.)
       const rate = costPriceMap(hist);
+      // Ceiling derived once from the full history so every bucket judges a
+      // one-time re-seed jump against the same baseline (a bucket holding only
+      // the spike has no local typical of its own).
+      const ceiling = costDiscontinuityCeiling(hist, rate);
       for (const b of buckets) {
-        const s = costSpendBetween(hist, rate, b.start, b.end);
+        const s = costSpendBetween(hist, rate, b.start, b.end, ceiling);
         if (s != null) { b.spend = s; b.hasData = true; }
       }
       return buckets;
@@ -4145,39 +4149,84 @@
       return rate;
     }
 
-    // costSpendBetween: estimated $ spent in [t0, t1], summed from the POSITIVE
-    // step-to-step token increments priced at the current rate. The token
-    // "cumulative" counter is NOT truly monotonic — after a pod roll or when old
-    // sessions age out of the scanner window it drops — so a plain end−start
-    // delta goes negative and (wrongly) reads as $0. Summing only the positive
-    // increments recovers the real spend from that noisy counter.
-    function costSpendBetween(hist, rate, t0, t1) {
+    // Multiple of the median positive increment above which a single step is
+    // treated as a data correction (re-seed / regression-fix restore), not real
+    // spend. Chosen high enough that bursty-but-real hours (a few× the median)
+    // are always kept, low enough to catch a restore that dwarfs every normal
+    // step. The absolute floor below keeps a tiny median from nuking legit spend.
+    const COST_DISCONTINUITY_MULT = 20;
+    // Absolute-$ floor: an increment is only ever discarded as a discontinuity
+    // if it also exceeds this many dollars in a single step. No plausible run
+    // rate spends this within one snapshot interval (~30s–few min), so real
+    // spend never trips it, while a ~$18k all-time restore obviously does.
+    const COST_DISCONTINUITY_FLOOR_USD = 500;
+
+    // costPositiveIncrements: the list of POSITIVE step-to-step increments over
+    // [t0, t1], differenced only within a like measure (see costSpendBetween).
+    // Shared by the spend sum and the discontinuity ceiling so both judge the
+    // same series.
+    function costPositiveIncrements(hist, rate, t0, t1) {
       const pricedTok = (models) => {
         let s = 0;
         for (const k in models) { const m = models[k]; s += ((m.i || 0) + (m.o || 0)) * (rate[k] || 0); }
         return s;
       };
-      // Prefer the per-model token measure (immune to price-table shifts and to
-      // the non-monotonic cumulative counter). But snapshots recorded before the
-      // `models` field existed only carry a cumulative `usd` — those must NOT be
-      // skipped, or every hour older than the field's introduction renders blank
-      // (the "recent hours only" gap). For a legacy entry, fall back to the
-      // cumulative usd and count its positive step-to-step increases the same way.
-      // The two measures live on different scales (priced-token sum vs. cumulative
-      // usd), so a delta must never be taken ACROSS a measure change. Reset prev
-      // whenever the entry's measure type flips, so we only ever difference like
-      // with like — legacy usd runs and new models runs each contribute their own
-      // positive increments to the bucket total.
-      let spend = 0, prev = null, prevKind = null, sawWindow = false;
+      const incs = [];
+      let prev = null, prevKind = null, sawWindow = false;
       for (const e of hist) {
         if (e.timestamp < t0 || e.timestamp > t1) { if (e.timestamp > t1) break; continue; }
         const kind = e.models ? 'm' : (typeof e.usd === 'number' ? 'u' : null);
         if (kind == null) continue;
         const cur = kind === 'm' ? pricedTok(e.models) : e.usd;
         sawWindow = true;
-        if (prev != null && kind === prevKind && cur > prev) spend += (cur - prev);
+        if (prev != null && kind === prevKind && cur > prev) incs.push(cur - prev);
         prev = cur; prevKind = kind;
       }
+      return { incs, sawWindow };
+    }
+
+    // costDiscontinuityCeiling: the $ threshold above which a single positive
+    // increment is a data correction, not spend. Derived from the FULL history
+    // (not one bucket) so it's stable: a per-hour window that happens to contain
+    // ONLY the re-seed spike has no local "typical" to compare against, so the
+    // ceiling must come from the whole series. Returns Infinity (no cap) when
+    // there aren't enough normal increments to establish a median, so we never
+    // drop real spend on thin data. The median is computed over increments BELOW
+    // the absolute floor, so the outlier itself can't inflate the baseline.
+    function costDiscontinuityCeiling(hist, rate) {
+      if (!hist || hist.length < 2) return Infinity;
+      const { incs } = costPositiveIncrements(hist, rate, -Infinity, Infinity);
+      const normal = incs.filter(v => v < COST_DISCONTINUITY_FLOOR_USD).sort((a, b) => a - b);
+      if (normal.length < 2) return Infinity;
+      const mid = Math.floor(normal.length / 2);
+      const median = normal.length % 2 ? normal[mid] : (normal[mid - 1] + normal[mid]) / 2;
+      if (!(median > 0)) return Infinity;
+      // Cap at whichever bound is LARGER so an increment must beat BOTH the
+      // relative (20× median) and the absolute ($500) test to be discarded.
+      return Math.max(COST_DISCONTINUITY_MULT * median, COST_DISCONTINUITY_FLOOR_USD);
+    }
+
+    // costSpendBetween: estimated $ spent in [t0, t1], summed from the POSITIVE
+    // step-to-step token increments priced at the current rate. The token
+    // "cumulative" counter is NOT truly monotonic — after a pod roll or when old
+    // sessions age out of the scanner window it drops — so a plain end−start
+    // delta goes negative and (wrongly) reads as $0. Summing only the positive
+    // increments recovers the real spend from that noisy counter.
+    //
+    // Discontinuity guard: a positive counter can ALSO jump by a huge one-time
+    // step when the counter is re-seeded — a pod restart re-seeding per-agent
+    // totals, or a regression fix restoring an all-time count (observed: a lone
+    // ~$394 → ~$18,350 step). That single jump is a data correction, not spend,
+    // yet the positive-increment sum would bill it into one hourly bucket,
+    // producing a bogus giant bar and an inflated window-spend + run-rate. So an
+    // increment above the discontinuity ceiling (see above) is skipped. `ceiling`
+    // is derived once from the full history and passed in; omit it to disable the
+    // guard (kept optional so callers without full history stay correct).
+    function costSpendBetween(hist, rate, t0, t1, ceiling) {
+      const cap = (typeof ceiling === 'number') ? ceiling : Infinity;
+      const { incs, sawWindow } = costPositiveIncrements(hist, rate, t0, t1);
+      let spend = 0;
+      for (const inc of incs) { if (inc <= cap) spend += inc; }
       return sawWindow ? spend : null;
     }
 
@@ -4193,7 +4242,10 @@
       for (const e of hist) { if (e.models && e.timestamp >= start) { anchorTs = e.timestamp; break; } }
       if (anchorTs == null) { for (const e of hist) { if (e.models) { anchorTs = e.timestamp; break; } } }
       if (anchorTs == null || anchorTs >= latest.timestamp) return null;
-      const spend = costSpendBetween(hist, rate, anchorTs, latest.timestamp);
+      // Same discontinuity ceiling as the hourly buckets so a one-time re-seed
+      // jump can't inflate the run-rate either.
+      const ceiling = costDiscontinuityCeiling(hist, rate);
+      const spend = costSpendBetween(hist, rate, anchorTs, latest.timestamp, ceiling);
       const dMs = latest.timestamp - anchorTs;
       if (spend == null || !(dMs > 0) || !(spend > 0)) return null;
       return spend / dMs; // $ per ms
@@ -6363,6 +6415,13 @@ function burnAreaChart() {
       // matches an agent whose model reads "claude-opus-4-7". Paused/off agents
       // are excluded — this is "using now", not "assigned".
       const normModel = (s) => (s || '').toLowerCase().replace(/\./g, '-').replace(/^.*\//, '');
+      // Routing aliases: a config model that only names a concrete model at
+      // runtime. An agent set to one of these accrues its tokens under the
+      // RESOLVED model (e.g. copilot "auto" → gpt-5.3-codex), so its live badge
+      // must be keyed on the resolved model, not the alias, or it lands on no
+      // visible row. The backend supplies the resolution via tokens.byAgentModel.
+      const aliasModels = new Set(['auto', 'default', '']);
+      const byAgentModel = (window._lastStatus?.tokens?.byAgentModel) || {};
       const liveAgentCounts = (() => {
         const counts = {};
         for (const a of (window._lastAgents || [])) {
@@ -6370,7 +6429,16 @@ function burnAreaChart() {
           // Exclude agents that aren't actually running (same predicate the
           // agent cards use): paused, off-by-cadence, or stopped.
           if (a.paused === true || a.offByCadence === true || a.stopped === true) continue;
-          const k = normModel(a.model);
+          let model = a.model;
+          // When the config model is a routing alias, prefer the resolved model
+          // parsed from this agent's session logs so the badge lands on the row
+          // where the tokens actually accrued. Falls back to the alias if no
+          // resolved model is known yet (no sessions scanned).
+          if (aliasModels.has(normModel(a.model))) {
+            const resolved = byAgentModel[a.name];
+            if (resolved) model = resolved;
+          }
+          const k = normModel(model);
           if (!counts[k]) counts[k] = [];
           counts[k].push(a.displayName || a.name);
         }

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -677,6 +677,7 @@ func buildTokens(collector *tokens.Collector) FrontendTokens {
 		Sessions:      []FrontendSession{},
 		ByAgent:       make(map[string]FrontendTokenBucket),
 		ByModel:       make(map[string]FrontendTokenBucket),
+		ByAgentModel:  make(map[string]string),
 	}
 
 	if collector == nil {
@@ -729,10 +730,57 @@ func buildTokens(collector *tokens.Collector) FrontendTokens {
 		ft.ByModel[modelName] = bucket
 	}
 
+	// Per-agent RESOLVED model: the model of each agent's most recently active
+	// session. Config models that are routing aliases ("auto"/"default") only
+	// name a concrete model at runtime, and that resolved id is what the session
+	// logs record. Exposing it lets the frontend attribute an auto-mode agent's
+	// live badge to the row where its tokens actually land.
+	ft.ByAgentModel = resolveAgentModels(summary.Sessions)
+
 	// Individual sessions are omitted from the status payload to reduce size
 	// (~70% savings). Use GET /api/tokens for the full session list.
 
 	return ft
+}
+
+// aliasModels are model ids that are routing aliases, not concrete models. A
+// session logged under one of these carries no resolved-model information, so
+// it must not be used as an agent's resolved model.
+var aliasModels = map[string]bool{
+	"":        true,
+	"unknown": true,
+	"auto":    true,
+	"default": true,
+}
+
+// resolveAgentModels maps each agent to the concrete model of its most recently
+// active session. Sessions whose Model is empty/"unknown"/an alias ("auto",
+// "default") are skipped, since they carry no resolved-model signal. When two
+// qualifying sessions exist for an agent, the one with the greater LastActive
+// wins (ties keep the first seen). Agents with no qualifying session are absent
+// from the result.
+func resolveAgentModels(sessions []tokens.SessionSummary) map[string]string {
+	type pick struct {
+		model      string
+		lastActive int64
+	}
+	best := make(map[string]pick)
+	for _, s := range sessions {
+		if s.Agent == "" {
+			continue
+		}
+		if aliasModels[strings.ToLower(strings.TrimSpace(s.Model))] {
+			continue
+		}
+		if cur, ok := best[s.Agent]; !ok || s.LastActive > cur.lastActive {
+			best[s.Agent] = pick{model: s.Model, lastActive: s.LastActive}
+		}
+	}
+	out := make(map[string]string, len(best))
+	for agent, p := range best {
+		out[agent] = p.model
+	}
+	return out
 }
 
 func buildRepos(cfg *config.Config, actionable *github.ActionableResult) []FrontendRepo {


### PR DESCRIPTION
Fixes two related Cost-card bugs, both confirmed from the code and a live dashboard screenshot.

## BUG A — auto-mode agents show no "running agents" badge on their model row

In the Cost table, each model row shows a live count of running agents on that model. The frontend built `liveAgentCounts` by keying agents on `normModel(a.model)`, where `a.model` is the agent's **config** model (`status_builder.go:188` sets `model := proc.Config.Model`). An agent configured `"auto"` (e.g. the scanner on copilot, which auto-resolves to `gpt-5.3-codex`) was keyed under the alias, so its badge landed on no visible row — the resolved `gpt-5.3-codex` row showed `—` even though that agent's tokens ($8.72) accrue there.

The resolved model is already known: the token collector parses it from session logs into `SessionSummary{Agent, Model}` (`pkg/tokens/collector.go`) — that's *why* `gpt-5.3-codex` has cost. `buildTokens` simply never forwarded it.

**Fix (backend + frontend):**
- **Backend** — added `ByAgentModel map[string]string` (`json:"byAgentModel"`) to `FrontendTokens` (`server.go`). `resolveAgentModels()` (`status_builder.go`) populates it from `summary.Sessions`: per agent, the `Model` of the session with the greatest `LastActive`, skipping alias/placeholder models (`""`, `"unknown"`, `"auto"`, `"default"`). This is the smallest, most direct source — a per-agent resolved-model map — rather than shipping the full session list.
- **Frontend** (`index.html`) — in `liveAgentCounts`, when an agent's config model normalizes to a routing alias (`auto`/`default`/`""`), it now keys on `tokens.byAgentModel[name]` (the resolved model) when known, falling back to the alias otherwise. Agents with a concrete config model are unchanged.

**Result:** the scanner badge appears on the `gpt-5.3-codex` row.

## BUG B — hourly window spend + run-rate inflated by a data discontinuity

The live screenshot showed "spend this hourly window: $18,563 · run-rate ~$3,174/hr" — where $18,563 ≈ the entire all-time total ($18,350). Root cause: the all-time cumulative cost jumped in one snapshot step (~$394 → ~$18,350) when a prior regression fix restored the count and/or a pod restart re-seeded per-agent token totals. `costSpendBetween` sums **positive** step-to-step increments with **no cap**, so that single ~$18k jump was billed into one hourly bucket → one giant bar, empty neighboring hours, and a bogus window spend + run-rate.

**Fix (frontend, `index.html`):** added a discontinuity guard.
- `costDiscontinuityCeiling(hist, rate)` derives a threshold from the **full** history's positive increments. An increment is discarded only if it exceeds **both** `20× the median normal increment` **and** an absolute `$500/step` floor.
- **Why this heuristic:** the relative test (20× median) catches a jump that dwarfs every normal step regardless of scale; the absolute floor prevents a tiny median from ever nuking legitimate spend, and is itself unreachable by real spend — no plausible run rate spends $500 within one snapshot interval (~30s–few min). Requiring **both** means bursty-but-real hours (a few× the median) are always kept while a ~$18k all-time restore is obviously dropped.
- The ceiling is computed **once over all history** (a per-hour bucket that contains only the spike has no local baseline to compare against) and passed into `costSpendBetween`, which now skips over-ceiling increments. Both the hourly buckets and `costRunRate` use it. Thin history (<2 normal increments) yields `Infinity` = no cap, so real spend is never dropped on sparse data.
- **Result:** the one-time restore spike is excluded → the hourly window spend and run-rate become sane; normal per-hour bars still render with real spend.

## Coverage / verification

- **Backend:** `resolve_agent_models_test.go` covers `resolveAgentModels` (auto→resolved, latest-active wins, aliases/unknown/whitespace skipped, no-qualifying-session absent, multi-agent independence, empty input). `buildTokens` and `resolveAgentModels` both at **100%** coverage.
- **-race:** `go test ./pkg/dashboard/ ./pkg/tokens/ -race -count=1 -timeout 300s` — both **ok** (no data races; no new goroutines, no launch-path mutex).
- **Frontend:** app script validated with `node --check` (parses clean, self-contained). The discontinuity guard verified against a synthetic history (normal ramp + one huge jump): the jump is excluded, the ramp is counted, per-hour buckets still show real spend, a bursty-but-real +15× hour is kept, and thin history yields no cap.
- Gates: `go build ./...`, `go vet ./pkg/dashboard/`, `gofmt` on changed files — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)