### PR TITLE
🐛 fix(fleet-stats): carry ai_author over the heartbeat instead of blanking it

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1656,6 +1656,7 @@ func main() {
 			return &hub.HeartbeatPayload{
 				HiveID:      cfg.HiveID,
 				Org:         cfg.Project.Org,
+				AIAuthor:    cfg.Project.AIAuthor,
 				Repos:       cfg.Project.Repos,
 				PrimaryRepo: cfg.Project.PrimaryRepo,
 				ACMMLevel:   acmmLvl,
@@ -1941,10 +1942,12 @@ func main() {
 			// host). Track it in the already-reconciled check so a URL-only change
 			// still gets applied and persisted.
 			vanityMatched := pc.DashboardURL == "" || cfg.Hub.DashboardURL == pc.DashboardURL
+			authorMatched := pc.AIAuthor == "" || cfg.Project.AIAuthor == pc.AIAuthor
 			if cfg.Project.Org == pc.Org &&
 				sameStringSlice(cfg.Project.Repos, pc.Repos) &&
 				cfg.Project.PrimaryRepo == pc.PrimaryRepo &&
 				curACMM == pc.ACMMLevel &&
+				authorMatched &&
 				vanityMatched {
 				return // already reconciled
 			}
@@ -1960,6 +1963,13 @@ func main() {
 			cfg.Project.Org = pc.Org
 			cfg.Project.Repos = pc.Repos
 			cfg.Project.PrimaryRepo = pc.PrimaryRepo
+			// Only adopt a non-empty author. The hub echoes this struct back on
+			// every beat, so assigning unconditionally would reset a locally
+			// configured ai_author to "" each time — which is precisely what
+			// kept the fleet-stats collector disabled on every hive.
+			if pc.AIAuthor != "" {
+				cfg.Project.AIAuthor = pc.AIAuthor
+			}
 			level := pc.ACMMLevel
 			cfg.ACMMLevel = &level
 

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -151,6 +151,11 @@ type HeartbeatPayload struct {
 	Org                     string                        `json:"org"`
 	Repos                   []string                      `json:"repos"`
 	PrimaryRepo             string                        `json:"primary_repo"`
+	// AIAuthor is the GitHub account this hive's agents open PRs as. Reported
+	// so the hub can echo it back in HeartbeatProjectConfig rather than
+	// blanking it, and so the registry knows each hive's author without any
+	// spoke-side token lookup (which does not work on App-authenticated hives).
+	AIAuthor                string                        `json:"ai_author,omitempty"`
 	ACMMLevel               int                           `json:"acmm_level"`
 	Agents                  []AgentSummary                `json:"agents"`
 	Governor                GovernorSummary               `json:"governor"`
@@ -470,6 +475,14 @@ type HeartbeatProjectConfig struct {
 	Repos       []string `json:"repos"`
 	PrimaryRepo string   `json:"primary_repo,omitempty"`
 	ACMMLevel   int      `json:"acmm_level"`
+	// AIAuthor is the GitHub account the agents open PRs as. It rides the same
+	// channel as org/repos because it is part of the same project identity, and
+	// because without it the hub's echo of this struct silently reset the
+	// spoke's project.ai_author to "" on every beat — which disabled the
+	// fleet-stats collector fleet-wide (Start() returns early on an empty
+	// author) and left the public landing page's stats strip blank. Empty =
+	// leave the spoke's configured author unchanged.
+	AIAuthor string `json:"ai_author,omitempty"`
 	// DashboardURL is the claimed hive's vanity URL. The spoke adopts it as its
 	// hub.dashboard_url and reports it in subsequent heartbeats, so the hub
 	// registry's dashboardUrl becomes the vanity URL (rather than the raw

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4411,6 +4411,10 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 		PrimaryRepo:  primary,
 		ACMMLevel:    h.ACMMLevel,
 		DashboardURL: h.VanityURL,
+		// AIAuthor is deliberately left empty here. Provisioning state never
+		// knows the agents' GitHub account — the spoke owns it — and the spoke
+		// treats an empty author as "leave mine alone". Setting it from this
+		// struct would reintroduce the blanking bug.
 	}
 }
 

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -61,6 +61,11 @@ type RegistryEntry struct {
 	Name                      string             `json:"name"`
 	Org                       string             `json:"org"`
 	Repos                     []string           `json:"repos"`
+	// AIAuthor is the GitHub account this hive's agents open PRs as, as
+	// reported by the spoke. The hub needs it to echo project config back
+	// without blanking it, and it is the author the fleet-stats counts are
+	// scoped to.
+	AIAuthor                  string             `json:"aiAuthor,omitempty"`
 	PrimaryRepo               string             `json:"primaryRepo"`
 	DashboardURL              string             `json:"dashboardUrl"`
 	SnapshotURL               string             `json:"snapshotUrl,omitempty"`
@@ -506,6 +511,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			return safe
 		}(),
 		PrimaryRepo:  safePrimary,
+		AIAuthor:     sanitizeField(payload.AIAuthor),
 		DashboardURL: payload.DashboardURL,
 		SnapshotURL:  payload.SnapshotURL,
 		ACMMLevel:    clampInt(payload.ACMMLevel, 0, 6),


### PR DESCRIPTION
## Why a config edit can't fix this

I set `ai_author: clubanderson` directly on `hosted-kubestellar-console-4vkt`'s PVC — both `/data/hive.yaml` and the `/data/hive.yaml.dashboard` overlay — and restarted. It reverted within one heartbeat, twice.

The hub echoes `HeartbeatProjectConfig` back to the spoke and the spoke adopts it wholesale. That struct had **no `AIAuthor` field**, so the adoption path reset `project.ai_author` to `""` on every beat. The pod's own log, after the edit:

```
WARN "fleet stats collector disabled: author or org is empty" author:"" org:"kubestellar"
```

With an empty author `FleetStatsCollector.Start()` returns immediately — collector never runs, `ready` stays false, heartbeat carries nil counts, hub aggregates nothing. The landing page then correctly hides the stats rather than render a fabricated zero.

*(The hive has been restored to its original state; no config change remains.)*

## Changes

- **`HeartbeatPayload.AIAuthor`** — the spoke reports the account its agents open PRs as. No spoke-side token lookup, which never worked on App-authenticated hives: `cfg.GitHub.Token` is empty there, and an App installation token's login is a `…[bot]` that authors nothing.
- **`RegistryEntry.AIAuthor`** — the hub records it.
- **`HeartbeatProjectConfig.AIAuthor`** — echoed back, and the spoke adopts it **only when non-empty**. Empty now means "leave mine alone" rather than "blank it".
- **Drift comparison** includes the author, so a mismatch reconciles instead of silently persisting.
- The provisioning echo deliberately leaves it empty — `SaaSHive` is provisioning state and never knows the agents' account.

## Two things I deliberately did not do

**Org-wide search with no author filter.** For `kubestellar` that reports **11,329** merged PRs instead of ~3,900 — it counts human PRs as agent work.

**Scope counts by the registry `owner` field.** `castrojo` merged **883 PRs in projectbluefin before that hive ever registered**, plus 1,903 in the window. Owner-scoped counting would credit pre-Hive human work to the fleet.

## Expected result

Once spokes report their author, the fleet total should be roughly **3,928 merged / 859 rejected / 45 CVE** — verified by running the collector's own queries directly.

## Verification

`go build`, `go vet`, and the hub `Heartbeat|Project|FleetStats` tests all pass.

Supersedes #2092 (the `/data/gh-user-token` fallback), which I'll close — this is the cleaner fix and doesn't depend on an interactive login having happened. Porting to v2/mk/dd next.