### PR TITLE
dashboard: explain every Governor header tile (what + how it's calculated) [v3]

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5106,21 +5106,23 @@
       const FIX_TIME_SPARK_COLOR = 'var(--muted)'; /* sparkline tint only — the value itself is neutral */
       const itmHistory = (itm.history || []).map(h => h.median || h.avg);
       const itmSpark = sparkSvg(itmHistory, FIX_TIME_SPARK_COLOR);
-      const itmTitle = itmCount > 0 ? `MTTR (Mean Time to Resolution) — median: ${formatFixTime(itmMedian)} | avg: ${formatFixTime(itmAvg)} | p90: ${formatFixTime(itm.p90_minutes)} | fastest: ${formatFixTime(itm.fastest_minutes)} | slowest: ${formatFixTime(itm.slowest_minutes)} | ${itmCount} fixes in last 30d` : 'MTTR — no data yet';
+      const itmExplain = 'MTTR — how fast issues get resolved.\n\nWHAT: The headline figure is the MEDIAN time from an issue being opened to the fixing PR being merged. Lower is better; the sparkline shows the recent trend.\n\nHOW: For every issue closed by a merged PR in the last 30 days, we measure (merge time − open time). The tile shows the median of those durations; the breakdown below lists avg / p90 / fastest / slowest and the sample size.\n\n';
+      const itmTitle = itmCount > 0 ? itmExplain + `median: ${formatFixTime(itmMedian)} | avg: ${formatFixTime(itmAvg)} | p90: ${formatFixTime(itm.p90_minutes)} | fastest: ${formatFixTime(itm.fastest_minutes)} | slowest: ${formatFixTime(itm.slowest_minutes)} | ${itmCount} fixes in last 30d` : itmExplain + 'No fixes recorded in the last 30 days yet.';
 
       const holdData = data.hold || {};
       const holdTotal = holdData.total || 0;
       const holdItems = holdData.items || [];
-      const holdTooltip = holdItems.length > 0 ? escapeHtml(holdItems.map(h => `${h.type === 'pr' ? 'PR' : 'Issue'} ${h.repo}#${h.number}: ${h.title}`).join('\n')) : 'No items on hold';
+      const holdExplain = 'ON HOLD — work intentionally paused, awaiting a human.\n\nWHAT: Issues and PRs that agents will NOT act on until a maintainer clears them. Excluded from the actionable-issue count that drives the mode.\n\nHOW: Count of open issues/PRs carrying a hold label (hold / do-not-merge / blocked). The list below names each held item; the sparkline shows how the backlog of held work is trending.\n\n';
+      const holdTooltip = holdItems.length > 0 ? escapeHtml(holdExplain + holdItems.map(h => `${h.type === 'pr' ? 'PR' : 'Issue'} ${h.repo}#${h.number}: ${h.title}`).join('\n')) : escapeHtml(holdExplain + 'Nothing is currently on hold.');
       const holdSpark = sparkline('govHold');
 
       el.innerHTML = `
         <div class="gov-title">Governor <button class="config-gear" onclick="openConfigDialog('governor')" title="Open Governor configuration — manage agents, thresholds, budget, notifications, health checks, and sensing patterns">⚙️</button></div>
         <div class="gov-grid">
-          <div class="gov-stat" title="Whether the governor's periodic evaluation timer is running. If dead, agents will not be kicked automatically."><div class="label">timer</div><div class="val ${cls}">${gov.active ? '● active' : (isStarting ? '⏳ starting' : '⚠ DEAD')}</div></div>
-          <div class="gov-stat" title="Current governor mode based on actionable issue count. Modes: idle (few issues), quiet (normal), busy (high load), surge (critical). Each mode has different agent cadences."><div class="label">mode</div><div class="val" style="color:${modeColor}">${escapeHtml(gov.mode)}</div></div>
-          <div class="gov-stat" title="Number of open GitHub issues that are actionable (not labeled as hold, wontfix, etc.). This count determines the governor mode."><div class="label">actionable issues</div><div class="spark-row"><span class="val">${issueCount}</span>${issuesSpark}</div></div>
-          <div class="gov-stat" title="Number of open pull requests across all monitored repositories."><div class="label">PRs</div><div class="spark-row"><span class="val">${gov.prs}</span>${prsSpark}</div></div>
+          <div class="gov-stat" title="TIMER — is the governor's evaluation loop alive?&#10;&#10;WHAT: The governor re-evaluates mode and kicks due agents on a fixed cadence. This shows whether that loop is running.&#10;&#10;HOW: 'active' if the governor reported a heartbeat within its expected interval; 'starting' during boot before the first tick; 'DEAD' if no heartbeat has arrived — agents will NOT be kicked automatically until it recovers."><div class="label">timer</div><div class="val ${cls}">${gov.active ? '● active' : (isStarting ? '⏳ starting' : '⚠ DEAD')}</div></div>
+          <div class="gov-stat" title="MODE — the governor's current activity level.&#10;&#10;WHAT: Sets how aggressively agents are scheduled. idle → quiet → busy → surge, each with faster cadences.&#10;&#10;HOW: Derived purely from the actionable-issue count against the thresholds shown on the gauge below: 0–${CLASSIC_THRESH_QUIET-1}=idle, ${CLASSIC_THRESH_QUIET}–${CLASSIC_THRESH_BUSY-1}=quiet, ${CLASSIC_THRESH_BUSY}–${CLASSIC_THRESH_SURGE-1}=busy, ≥${CLASSIC_THRESH_SURGE}=surge. Thresholds are configurable in Governor settings."><div class="label">mode</div><div class="val" style="color:${modeColor}">${escapeHtml(gov.mode)}</div></div>
+          <div class="gov-stat" title="ACTIONABLE ISSUES — open work the agents can pick up.&#10;&#10;WHAT: The queue depth that drives the governor mode. The sparkline shows its recent trend.&#10;&#10;HOW: Count of open GitHub issues across all monitored KubeStellar repos, MINUS any labeled hold / do-not-merge / wontfix / blocked. This is the exact number the mode gauge below reads."><div class="label">actionable issues</div><div class="spark-row"><span class="val">${issueCount}</span>${issuesSpark}</div></div>
+          <div class="gov-stat" title="PRS — open pull requests in flight.&#10;&#10;WHAT: How many PRs are currently open across the fleet. The sparkline shows the recent trend.&#10;&#10;HOW: Count of open pull requests across all monitored KubeStellar repos at the last scan (includes both agent-authored and human PRs; does not subtract held PRs)."><div class="label">PRs</div><div class="spark-row"><span class="val">${gov.prs}</span>${prsSpark}</div></div>
           <div class="gov-stat" title="${itmTitle}"><div class="label">MTTR</div><div class="spark-row"><span class="val">${formatFixTime(itmMedian)}</span>${itmSpark}</div></div>
           <div class="gov-stat" title="${holdTooltip}"><div class="label">on hold</div><div class="spark-row"><span class="val">${holdTotal}</span>${holdSpark}</div></div>
           ${(() => {
@@ -5134,13 +5136,14 @@
             const awaiting = plan.awaiting_review || 0;
             const pending = plan.decomposing || 0;
             const alertCls = awaiting > 0 ? ' planning-alert' : '';
-            const tip = awaiting > 0
+            const planExplain = 'PLANNING — goals being decomposed into work.\n\nWHAT: The architect agent breaks high-level goals (epics) into a tree of child issues before other agents execute them. Available only at ACMM level 5–6, where the architect is scheduled.\n\nHOW: Counts plan-trees by state from the planning ledger — active (approved, in progress), awaiting review (need your approval before work starts), and decomposing (being broken down now). Amber means human action is required.\n\n';
+            const tip = planExplain + (awaiting > 0
               ? `${awaiting} plan(s) awaiting your review — approve them in the plan view before agents start the work`
-              : `${active} active plan-tree(s)` + (pending ? `, ${pending} decomposing` : '');
+              : `${active} active plan-tree(s)` + (pending ? `, ${pending} decomposing` : ''));
             const valTxt = awaiting > 0 ? `${awaiting} to review` : String(active);
             return `<div class="gov-stat" title="${escapeHtml(tip)}"><div class="label">planning</div><div class="val${alertCls}">${escapeHtml(valTxt)}${pending > 0 ? ` <span style="opacity:.6;font-size:.7em">+${pending}</span>` : ''}</div></div>`;
           })()}
-          <div class="gov-stat" title="When the governor will next evaluate mode and kick agents based on cadence schedules."><div class="label">next run</div><div class="val">${escapeHtml(gov.nextKick || '—')}</div></div>
+          <div class="gov-stat" title="NEXT RUN — when the governor next wakes up.&#10;&#10;WHAT: The next scheduled moment the governor will re-evaluate mode and kick any agents that are due.&#10;&#10;HOW: Computed from the current mode's cadence schedule — the governor adds the mode's interval to the last run time. Faster modes (busy/surge) produce a nearer next run than idle/quiet."><div class="label">next run</div><div class="val">${escapeHtml(gov.nextKick || '—')}</div></div>
         </div>
         <div class="temp-gauge" style="cursor:pointer" onclick="openConfigDialog('governor',null,'Thresholds')" title="Click to adjust governor thresholds">
           <div class="temp-gauge-label"><span>Issues: ${issueCount}</span><span>max ${maxQ}</span></div>


### PR DESCRIPTION
## What

Every tile in the **Governor page header** now has a hover tooltip explaining **both what the metric represents and how it is calculated** — replacing the previous one-line "what" blurb.

Tiles covered: **timer, mode, actionable issues, PRs, MTTR, on hold, next run**, **planning**.

Each tooltip is structured as:
- **WHAT** — the plain-English meaning of the number
- **HOW** — how it is derived (e.g. mode = actionable-issue count vs. the threshold gauge; MTTR = median of `merge_time − open_time` over merged fixes in the last 30d; on-hold = count of items carrying hold/do-not-merge/blocked labels)

The MTTR and on-hold tooltips keep their existing live per-item breakdown; the WHAT/HOW explanation is prepended.

## Scope

Tooltip-only change (`title=` attributes / the `itmTitle`, `holdTooltip`, planning `tip` strings). No behavior change, no new data dependencies. Inline JS validated with `node`.

Per branch policy this UI improvement lands on all four branches (v2, v3, mk, dd); the **planning** tile only exists on v3, so its tooltip is enhanced there only.