### PR TITLE
🐛 fix(fleet-stats): carry ai_author over the heartbeat instead of blanking it

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1804,6 +1804,7 @@ func main() {
 			return &hub.HeartbeatPayload{
 				HiveID:      cfg.HiveID,
 				Org:         cfg.Project.Org,
+				AIAuthor:    cfg.Project.AIAuthor,
 				Repos:       cfg.Project.Repos,
 				PrimaryRepo: cfg.Project.PrimaryRepo,
 				ACMMLevel:   acmmLvl,
@@ -2102,10 +2103,12 @@ func main() {
 			// host). Track it in the already-reconciled check so a URL-only change
 			// still gets applied and persisted.
 			vanityMatched := pc.DashboardURL == "" || cfg.Hub.DashboardURL == pc.DashboardURL
+			authorMatched := pc.AIAuthor == "" || cfg.Project.AIAuthor == pc.AIAuthor
 			if cfg.Project.Org == pc.Org &&
 				sameStringSlice(cfg.Project.Repos, pc.Repos) &&
 				cfg.Project.PrimaryRepo == pc.PrimaryRepo &&
 				curACMM == pc.ACMMLevel &&
+				authorMatched &&
 				vanityMatched {
 				return // already reconciled
 			}
@@ -2121,6 +2124,13 @@ func main() {
 			cfg.Project.Org = pc.Org
 			cfg.Project.Repos = pc.Repos
 			cfg.Project.PrimaryRepo = pc.PrimaryRepo
+			// Only adopt a non-empty author. The hub echoes this struct back on
+			// every beat, so assigning unconditionally would reset a locally
+			// configured ai_author to "" each time — which is precisely what
+			// kept the fleet-stats collector disabled on every hive.
+			if pc.AIAuthor != "" {
+				cfg.Project.AIAuthor = pc.AIAuthor
+			}
 			level := pc.ACMMLevel
 			cfg.ACMMLevel = &level
 

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -151,6 +151,11 @@ type HeartbeatPayload struct {
 	Org                     string                        `json:"org"`
 	Repos                   []string                      `json:"repos"`
 	PrimaryRepo             string                        `json:"primary_repo"`
+	// AIAuthor is the GitHub account this hive's agents open PRs as. Reported
+	// so the hub can echo it back in HeartbeatProjectConfig rather than
+	// blanking it, and so the registry knows each hive's author without any
+	// spoke-side token lookup (which does not work on App-authenticated hives).
+	AIAuthor                string                        `json:"ai_author,omitempty"`
 	ACMMLevel               int                           `json:"acmm_level"`
 	Agents                  []AgentSummary                `json:"agents"`
 	Governor                GovernorSummary               `json:"governor"`
@@ -477,6 +482,14 @@ type HeartbeatProjectConfig struct {
 	Repos       []string `json:"repos"`
 	PrimaryRepo string   `json:"primary_repo,omitempty"`
 	ACMMLevel   int      `json:"acmm_level"`
+	// AIAuthor is the GitHub account the agents open PRs as. It rides the same
+	// channel as org/repos because it is part of the same project identity, and
+	// because without it the hub's echo of this struct silently reset the
+	// spoke's project.ai_author to "" on every beat — which disabled the
+	// fleet-stats collector fleet-wide (Start() returns early on an empty
+	// author) and left the public landing page's stats strip blank. Empty =
+	// leave the spoke's configured author unchanged.
+	AIAuthor string `json:"ai_author,omitempty"`
 	// DashboardURL is the claimed hive's vanity URL. The spoke adopts it as its
 	// hub.dashboard_url and reports it in subsequent heartbeats, so the hub
 	// registry's dashboardUrl becomes the vanity URL (rather than the raw

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4421,6 +4421,10 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 		PrimaryRepo:  primary,
 		ACMMLevel:    h.ACMMLevel,
 		DashboardURL: h.VanityURL,
+		// AIAuthor is deliberately left empty here. Provisioning state never
+		// knows the agents' GitHub account — the spoke owns it — and the spoke
+		// treats an empty author as "leave mine alone". Setting it from this
+		// struct would reintroduce the blanking bug.
 	}
 }
 

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -61,6 +61,11 @@ type RegistryEntry struct {
 	Name                      string             `json:"name"`
 	Org                       string             `json:"org"`
 	Repos                     []string           `json:"repos"`
+	// AIAuthor is the GitHub account this hive's agents open PRs as, as
+	// reported by the spoke. The hub needs it to echo project config back
+	// without blanking it, and it is the author the fleet-stats counts are
+	// scoped to.
+	AIAuthor                  string             `json:"aiAuthor,omitempty"`
 	PrimaryRepo               string             `json:"primaryRepo"`
 	DashboardURL              string             `json:"dashboardUrl"`
 	SnapshotURL               string             `json:"snapshotUrl,omitempty"`
@@ -506,6 +511,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			return safe
 		}(),
 		PrimaryRepo:  safePrimary,
+		AIAuthor:     sanitizeField(payload.AIAuthor),
 		DashboardURL: payload.DashboardURL,
 		SnapshotURL:  payload.SnapshotURL,
 		ACMMLevel:    clampInt(payload.ACMMLevel, 0, 6),


### PR DESCRIPTION
Ports the fleet-stats fix to `dd`. Same change as #2098 (v3, merged).

## Why a config edit can't fix this

Setting `ai_author` directly on a spoke's PVC reverts within one heartbeat — verified live on `hosted-kubestellar-console-4vkt`, twice. The hub echoes `HeartbeatProjectConfig` back and the spoke adopts it wholesale; that struct had **no `AIAuthor` field**, so `project.ai_author` was reset to `""` every beat.

With an empty author `FleetStatsCollector.Start()` returns immediately — collector never runs, `ready` stays false, heartbeat carries nil counts, hub aggregates nothing. The landing page then correctly hides the stats rather than render a fabricated zero.

## Changes

- **`HeartbeatPayload.AIAuthor`** — the spoke reports the account its agents open PRs as. No spoke-side token lookup, which never worked on App-authenticated hives (`cfg.GitHub.Token` is empty there, and an App token's login is a `…[bot]` that authors nothing).
- **`RegistryEntry.AIAuthor`** — the hub records it.
- **`HeartbeatProjectConfig.AIAuthor`** — echoed back, adopted **only when non-empty**. Empty now means "leave mine alone".
- Drift comparison includes the author so a mismatch reconciles.
- Provisioning echo leaves it empty — `SaaSHive` never knows the agents' account.

## Not doing

**Org-wide search without an author filter** — 11,329 merged for kubestellar instead of ~3,900, counting human PRs as agent work.

**Scoping by registry `owner`** — `castrojo` merged 883 PRs in projectbluefin *before* that hive registered; owner-scoped counting would credit pre-Hive human work to the fleet.

## Expected

Fleet total ≈ **3,928 merged / 859 rejected / 45 CVE** once spokes report their author.

`go build` passes; hub `Heartbeat|Project|FleetStats` tests pass on v3.