### PR TITLE
📝 hub landing: fix typo in the Watch heading

### DIFF
--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -663,7 +663,7 @@
     <section class="section-pad video-section" id="watch">
       <div class="section-heading" style="margin-left:auto;margin-right:auto">
         <p class="section-label">Watch</p>
-        <h2>How Hive works &mdash; and why not to build your own</h2>
+        <h2>How Hive works &mdash; and why not build your own</h2>
         <p>A walkthrough of the agents, the governor, and the guardrails that make Hive safe to leave running &mdash; and why standing up your own agent loop means re-solving problems Hive already handles.</p>
       </div>
       <div class="video-frame">


### PR DESCRIPTION
`How Hive works — and why not **to** build your own` → `…and why not build your own`.

The extra "to" made the heading read as advice against building anything, rather than the intended "why you wouldn't build your own" — which is what the body copy directly underneath already says:

> …and why standing up your own agent loop means re-solving problems Hive already handles.

One line, applied to all four long-lived branches.