### PR TITLE
📝 hub landing: lead the hero with the human, and with the fast-loop argument

### DIFF
--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -573,15 +573,15 @@
                so the rotator reserves its height and nothing jumps on crossfade. -->
           <div class="hero-slide-spacer" aria-hidden="true">
             <h1>You earn automation with test coverage</h1>
-            <p class="hero-lede">Six autonomy levels, from advisory to auto-merge. Strong test coverage is what earns the confidence to raise a level &mdash; and you, the admin, decide when to raise it. Your tests tell you when it's safe; the choice is always yours.</p>
+            <p class="hero-lede">Give a mediocre model good tests and enough turns around the loop, and it will get there. The tests do the reasoning &mdash; so coverage, not model choice, is what earns the next of six autonomy levels. You decide when to raise it.</p>
           </div>
           <div class="hero-slide is-active">
             <h1>Put your repo on autopilot</h1>
-            <p class="hero-lede">A fleet of AI agents triages your issues, writes the fixes, opens the PRs, and merges them on green &mdash; so maintainers get their time back for the work that actually needs a human.</p>
+            <p class="hero-lede">Spend your time on the work you actually love &mdash; and put a fleet of AI agents on the rest: triaging issues, writing the fixes, opening the PRs, and merging them on green.</p>
           </div>
           <div class="hero-slide">
             <h1>You earn automation with test coverage</h1>
-            <p class="hero-lede">Six autonomy levels, from advisory to auto-merge. Strong test coverage is what earns the confidence to raise a level &mdash; and you, the admin, decide when to raise it. Your tests tell you when it's safe; the choice is always yours.</p>
+            <p class="hero-lede">Give a mediocre model good tests and enough turns around the loop, and it will get there. The tests do the reasoning &mdash; so coverage, not model choice, is what earns the next of six autonomy levels. You decide when to raise it.</p>
           </div>
           <div class="hero-slide">
             <h1>A deterministic pipeline, not a prompt</h1>


### PR DESCRIPTION
Two copy changes from Jorge's (bfin) feedback on the live page. Applied to all four long-lived branches.

## 1. Autopilot lede — human first

**Before:** "A fleet of AI agents triages your issues, writes the fixes…"

Jorge's note: *"bottom para, start with the human first. Everyone says 'a fleet of ai agents…'"* — and that "Put your repo on autopilot" is a strong hook that needs the left-hook combo behind it.

**After:** "Spend your time on the work you actually love — and put a fleet of AI agents on the rest: triaging issues, writing the fixes, opening the PRs, and merging them on green."

Same claims, reordered so the maintainer's benefit lands first.

## 2. Coverage slide — make the actual argument

The slide stated the six-levels mechanic but never said *why* coverage is the thing that earns autonomy. Jorge pointed at the version of this you've said out loud:

> *"you can give the stupidest LLM good tests and loop it enough and it will work."*

**After:** "Give a mediocre model good tests and enough turns around the loop, and it will get there. The tests do the reasoning — so coverage, not model choice, is what earns the next of six autonomy levels. You decide when to raise it."

That reframes coverage from a gate you satisfy into the mechanism that buys the autonomy, which is the whole ACMM thesis. It also implicitly answers "which model do you use?" — the differentiator is the loop, not the model.

## Note on the diff

The coverage lede is replaced in **two** places. The rotator has a hidden spacer slide duplicating the tallest slide so the block reserves its height and the crossfade doesn't jump — the spacer must carry identical copy or the sizing breaks.