### PR TITLE
🐛 fix(saas): grant the assignee owner access on hive assignment

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4138,14 +4138,27 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Ensure the user record exists and count this owned hive against a quota.
+	// Ensure the user record exists, grant them owner access, and count this
+	// owned hive against a quota.
+	//
+	// Granting Hives[hiveID] is what actually puts the requester on the hive's
+	// permissions: handleAccessList builds the access list by scanning every
+	// user record for Hives[hiveID], NOT from h.Owner. Without this the
+	// assignment set h.Owner correctly but the new owner never appeared under
+	// Manage Access — only the admin who provisioned the placeholder did — and
+	// on a heartbeat-only cluster (vllm-d) that stale list is what gets
+	// delivered to the spoke.
 	user := loadSaaSUser(targetUsername)
 	if user == nil {
 		user = ensureSaaSUser(targetUsername)
 	}
+	if user.Hives == nil {
+		user.Hives = map[string]string{}
+	}
+	user.Hives[hiveID] = "owner"
 	user.SaaSQuota++
 	if err := saveSaaSUser(user); err != nil {
-		s.logger.Warn("assigned placeholder but failed to update user quota", "user", targetUsername, "error", err)
+		s.logger.Warn("assigned placeholder but failed to grant owner access", "user", targetUsername, "hive", hiveID, "error", err)
 	}
 
 	// Mark the request fulfilled.
@@ -4559,6 +4572,26 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	if err := saveSaaSHive(h); err != nil {
 		http.Error(w, `{"error":"failed to save hive assignment"}`, http.StatusInternalServerError)
 		return
+	}
+
+	// Grant the assignee owner access. handleAccessList builds a hive's access
+	// list by scanning every user record for Hives[hiveID], NOT from h.Owner —
+	// so without this the assignment set h.Owner correctly while Manage Access
+	// still showed only the admin who provisioned the placeholder. On a
+	// heartbeat-only cluster (vllm-d) that stale list is what reaches the spoke.
+	assignee := loadSaaSUser(body.Owner)
+	if assignee == nil {
+		assignee = ensureSaaSUser(body.Owner)
+	}
+	if assignee.Hives == nil {
+		assignee.Hives = map[string]string{}
+	}
+	if assignee.Hives[hiveID] != "owner" {
+		assignee.Hives[hiveID] = "owner"
+		assignee.SaaSQuota++
+		if err := saveSaaSUser(assignee); err != nil {
+			s.logger.Warn("assigned hive but failed to grant owner access", "user", body.Owner, "hive", hiveID, "error", err)
+		}
 	}
 
 	// Deliver GitHub App creds (if supplied) via the SAME heartbeat channel the


### PR DESCRIPTION
## The bug

Assigning a hive set `h.Owner` and bumped the user's quota but **never set `user.Hives[hiveID]`**.

`handleAccessList` builds a hive's access list by scanning every user record for `Hives[hiveID]` — **not** from `h.Owner`. So the hive knew its owner while the permissions system didn't, and Manage Access showed only the admin who provisioned the placeholder.

## Reproduced live

After approving `joewxboy` for `hosted-available-oke-02-placeholder-7zus`:

```json
{ "github_username": "joewxboy", "hives": {}, "saas_quota": 1 }
```

The quota incremented on the line right next to the grant that never happened.

An audit of all nine assigned hives found **every code-path assignment broken** — the ones that looked healthy had been repaired by hand.

## Fix

- **`handleApproveProvision`** — adds the `Hives[hiveID]` grant beside the existing quota bump.
- **`handleAssignHive`** — didn't touch the user record at all. Now loads/creates the assignee and grants owner, guarded so a re-assign doesn't double-count quota.

## Not a heartbeat bug

The corruption is hub-side, in the hub's own PVC user records. The heartbeat only *delivers* that list — which is why the symptom looked worst on vllm-d: a heartbeat-only cluster has no other channel, so a stale access list is all the spoke ever sees.

`go build` and `go vet` pass.