### PR TITLE
fix(proxy): scan /proc/net/tcp6 for agent UID attribution (spyre quality PR block)

### DIFF
--- a/v2/pkg/proxy/procnet.go
+++ b/v2/pkg/proxy/procnet.go
@@ -8,20 +8,34 @@ import (
 	"strings"
 )
 
-const procNetTCPPath = "/proc/net/tcp"
+// procNetTCPPath / procNetTCP6Path are the kernel socket tables scanned for UID
+// attribution. Vars (not consts) so tests can redirect them at temp files.
+var (
+	procNetTCPPath  = "/proc/net/tcp"
+	procNetTCP6Path = "/proc/net/tcp6"
+)
 
-// LookupUIDByLocalPort reads /proc/net/tcp and returns the UID of the
-// process owning the socket bound to the given local port. Returns -1
-// if no match is found.
+// LookupUIDByLocalPort returns the UID of the process owning the socket bound to
+// the given local port, checking BOTH /proc/net/tcp (IPv4) and /proc/net/tcp6
+// (IPv6). Returns -1 if no match is found.
 //
-// Each line in /proc/net/tcp (after the header) has this layout:
-//
-//	sl  local_address rem_address   st tx_queue:rx_queue ... uid ...
-//	0:  0100007F:4803 0100007F:0050 01 00000000:00000000 ... 1001 ...
-//
-// local_address is hex IP:port. UID is field index 7 (0-based).
+// Both tables must be scanned: an agent connecting to a "127.0.0.1"/"localhost"
+// proxy can land its socket in the IPv6 table (as ::1 or an IPv4-mapped ::ffff:
+// address), so an IPv4-only lookup silently misses those connections and returns
+// no UID — which the proxy treats as an unidentified agent (advisory mode),
+// wrongly blocking a write-capable agent's GitHub API calls (e.g. POST /pulls).
 func LookupUIDByLocalPort(port int) (int, error) {
-	return lookupUIDByLocalPortFrom(procNetTCPPath, port)
+	uid, err := lookupUIDByLocalPortFrom(procNetTCPPath, port)
+	if err == nil {
+		return uid, nil
+	}
+	// Fall back to the IPv6 table — the socket may be there instead.
+	uid6, err6 := lookupUIDByLocalPortFrom(procNetTCP6Path, port)
+	if err6 == nil {
+		return uid6, nil
+	}
+	// Neither table had it; return the original (IPv4) error for context.
+	return -1, err
 }
 
 func lookupUIDByLocalPortFrom(path string, port int) (int, error) {

--- a/v2/pkg/proxy/procnet_test.go
+++ b/v2/pkg/proxy/procnet_test.go
@@ -71,3 +71,52 @@ func TestLookupUID_MissingFile(t *testing.T) {
 		t.Error("expected error for missing file")
 	}
 }
+
+// Sample /proc/net/tcp6 content: same column layout as /proc/net/tcp but the
+// local_address is a 32-hex IPv6 address. This is where a "127.0.0.1"/localhost
+// proxy connection can land (as ::1 or ::ffff:127.0.0.1), so the UID lookup must
+// scan it too.
+const sampleProcNetTCP6 = `  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 00000000000000000000000001000000:0BBA 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000  2006        0 99999 1 0000000000000000 100 0 0 10 0
+`
+
+// TestLookupUIDByLocalPort_TCP6Fallback verifies a socket that appears ONLY in
+// /proc/net/tcp6 (not the IPv4 table) is still resolved. This is the spyre bug:
+// an agent's GitHub API connection over IPv6 loopback was missed, so the proxy
+// saw no UID, treated the agent as unidentified (advisory), and blocked its
+// POST /pulls even though the agent was in ISSUES_AND_PRS mode.
+func TestLookupUIDByLocalPort_TCP6Fallback(t *testing.T) {
+	dir := t.TempDir()
+	tcp4 := filepath.Join(dir, "tcp")
+	tcp6 := filepath.Join(dir, "tcp6")
+	// IPv4 table has only an UNRELATED socket, so the target port is absent there.
+	if err := os.WriteFile(tcp4, []byte(sampleProcNetTCP), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tcp6, []byte(sampleProcNetTCP6), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldTCP, oldTCP6 := procNetTCPPath, procNetTCP6Path
+	procNetTCPPath, procNetTCP6Path = tcp4, tcp6
+	t.Cleanup(func() { procNetTCPPath, procNetTCP6Path = oldTCP, oldTCP6 })
+
+	// Port 0x0BBA=3002 exists only in the tcp6 table -> must be found via fallback.
+	uid, err := LookupUIDByLocalPort(0x0BBA)
+	if err != nil {
+		t.Fatalf("tcp6 socket should be found via fallback: %v", err)
+	}
+	if uid != 2006 {
+		t.Errorf("got uid=%d, want 2006 (from tcp6 table)", uid)
+	}
+
+	// A port in neither table still errors.
+	if _, err := LookupUIDByLocalPort(0x9999); err == nil {
+		t.Error("expected error for port in neither table")
+	}
+
+	// A port in the IPv4 table is still found (no regression).
+	if uid, err := LookupUIDByLocalPort(0x4803); err != nil || uid != 1001 {
+		t.Errorf("IPv4 lookup regressed: uid=%d err=%v, want 1001", uid, err)
+	}
+}


### PR DESCRIPTION
## Problem (Joe Runde / spyre)

At ACMM **L3**, the `quality` agent is `ISSUES_AND_PRS` mode — the one agent allowed to open hold-gated PRs. But on spyre (`hosted-torch-spyre-spyre-infer-94c2`) its PR creation was blocked:
```
proxy request blocked  agent:""  method:POST  path:/repos/torch-spyre/spyre-inference/pulls
```

**Not a permissions problem, and not an intentional L3 restriction.** I verified the config is correct end-to-end: pack mode `ISSUES_AND_PRS`, `/tmp/.hive-mode-quality` = `ISSUES_AND_PRS`, and the proxy rule for `POST /pulls` requires exactly that. The block was a **UID-attribution miss**: the `agent` field is empty.

## Root cause

The proxy identifies the calling agent by the UID of the socket connected to it, read from **`/proc/net/tcp`** (IPv4 only). An agent reaching a `127.0.0.1`/localhost `HTTPS_PROXY` over **IPv6 loopback** (`::1` or `::ffff:127.0.0.1`) lands its socket in **`/proc/net/tcp6`**, which was never scanned. So the lookup found no UID → the proxy treated the request as an unidentified agent → fell back to `ADVISORY` → blocked the write.

Proof it's attribution, not policy: at the same time, quality's `git push` (same `ISSUES_AND_PRS` tier) succeeded and its inference calls were correctly tagged `agent:"quality"` — those used IPv4 sockets; the `POST /pulls` used IPv6.

## Fix

`LookupUIDByLocalPort` now scans `/proc/net/tcp` then falls back to `/proc/net/tcp6` (identical column layout; UID at field index 7). Paths are vars so the fallback is unit-testable.

## Tests
- New `TestLookupUIDByLocalPort_TCP6Fallback`: a socket present only in the tcp6 table is resolved; IPv4 lookups don't regress; a port in neither table still errors.
- Full `pkg/proxy` suite green with `-race`.

v2 only (per request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)