### PR TITLE
🐛 fix(saas): serve vanity hosts, accept pasted URLs, record the GitHub instance

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -3899,8 +3899,13 @@ const (
 const maxProvisionRequestBodyBytes = 4 * 1024
 
 type ProvisionRequest struct {
-	Username    string `json:"username"`
-	Org         string `json:"org"`
+	Username string `json:"username"`
+	// GitHubHost is the GitHub instance the org lives on — empty means public
+	// github.com, otherwise a GitHub Enterprise host (github.ibm.com,
+	// github.cisco.com, …). Captured so an admin can see which instance a
+	// request targets before deciding where to place the hive.
+	GitHubHost string `json:"github_host,omitempty"`
+	Org        string `json:"org"`
 	Repos       string `json:"repos"`
 	PrimaryRepo string `json:"primary_repo"`
 	ACMMLevel   int    `json:"acmm_level"`
@@ -3982,6 +3987,7 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 	r.Body = http.MaxBytesReader(w, r.Body, maxProvisionRequestBodyBytes)
 	var body struct {
 		Org         string `json:"org"`
+		GitHubHost  string `json:"github_host"`
 		Repos       string `json:"repos"`
 		PrimaryRepo string `json:"primary_repo"`
 		ACMMLevel   int    `json:"acmm_level"`
@@ -3995,8 +4001,32 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 		http.Error(w, `{"error":"org and repos are required"}`, http.StatusBadRequest)
 		return
 	}
+	// Accept a pasted org/repo URL, not just a bare name. Users read
+	// "GitHub Organization" and paste the org's URL; the old validator rejected
+	// ":" and "/" and returned a bare "invalid org name" that explained nothing.
+	// The host is kept so the admin can see whether a request is for github.com
+	// or a GitHub Enterprise instance before placing the hive.
+	ghHost, orgName := normalizeOrgRef(body.Org)
+	body.Org = orgName
+	if ghHost != "" {
+		body.GitHubHost = ghHost
+	}
+	{
+		var cleaned []string
+		for _, repo := range strings.Split(body.Repos, ",") {
+			if r := normalizeRepoRef(repo); r != "" {
+				cleaned = append(cleaned, r)
+			}
+		}
+		body.Repos = strings.Join(cleaned, ",")
+		body.PrimaryRepo = normalizeRepoRef(body.PrimaryRepo)
+	}
 	if !isValidName(body.Org) {
-		http.Error(w, `{"error":"invalid org name"}`, http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf(`{"error":"invalid org name %q — use the org name or its URL (e.g. github.ibm.com/my-org)"}`, body.Org), http.StatusBadRequest)
+		return
+	}
+	if body.GitHubHost != "" && !isValidName(body.GitHubHost) {
+		http.Error(w, `{"error":"invalid github host"}`, http.StatusBadRequest)
 		return
 	}
 	for _, repo := range strings.Split(body.Repos, ",") {
@@ -4023,6 +4053,7 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 
 	pr := &ProvisionRequest{
 		Username:    username,
+		GitHubHost:  body.GitHubHost,
 		Org:         body.Org,
 		Repos:       body.Repos,
 		PrimaryRepo: primaryRepo,
@@ -4452,6 +4483,10 @@ func sameStringSliceFold(a, b []string) bool {
 type AssignHiveRequest struct {
 	Owner          string `json:"owner"`
 	Org            string `json:"org"`
+	// GitHubHost is the GitHub instance the org lives on ("" = public
+	// github.com, otherwise a GHE host). Parsed from a pasted org URL when the
+	// caller does not send it explicitly.
+	GitHubHost     string `json:"github_host,omitempty"`
 	Repos          string `json:"repos"`
 	PrimaryRepo    string `json:"primary_repo"`
 	ProjectName    string `json:"project_name"`
@@ -4500,13 +4535,37 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, `{"error":"invalid owner"}`, http.StatusBadRequest)
 		return
 	}
+	// Accept a pasted org/repo URL here too — an admin assigning a hive reaches
+	// for the same paste the requester did.
+	if h, o := normalizeOrgRef(body.Org); o != "" {
+		body.Org = o
+		if h != "" && body.GitHubHost == "" {
+			body.GitHubHost = h
+		}
+	}
 	if body.Org == "" || !isValidName(body.Org) {
-		http.Error(w, `{"error":"invalid org name"}`, http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf(`{"error":"invalid org name %q — use the org name or its URL (e.g. github.ibm.com/my-org)"}`, body.Org), http.StatusBadRequest)
+		return
+	}
+	if body.GitHubHost != "" && !isValidName(body.GitHubHost) {
+		http.Error(w, `{"error":"invalid github host"}`, http.StatusBadRequest)
 		return
 	}
 	if body.Repos == "" {
 		http.Error(w, `{"error":"repos are required"}`, http.StatusBadRequest)
 		return
+	}
+	{
+		var cleaned []string
+		for _, r := range strings.Split(body.Repos, ",") {
+			if rr := normalizeRepoRef(r); rr != "" {
+				cleaned = append(cleaned, rr)
+			}
+		}
+		body.Repos = strings.Join(cleaned, ",")
+		if body.PrimaryRepo != "" {
+			body.PrimaryRepo = normalizeRepoRef(body.PrimaryRepo)
+		}
 	}
 	var repos []string
 	for _, repo := range strings.Split(body.Repos, ",") {
@@ -4566,7 +4625,23 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	// registry's dashboardUrl becomes the vanity URL and stays that way.
 	if h.VanityURL == "" {
 		if cluster := s.clusterForHive(h); cluster != nil && cluster.Domain != "" {
-			h.VanityURL = "https://" + generateHiveID(body.Org, primaryRepo) + "." + cluster.Domain
+			vanityHost := generateHiveID(body.Org, primaryRepo) + "." + cluster.Domain
+			// Only adopt the vanity hostname once the spoke's Ingress actually
+			// serves it. Nothing else creates a route for this host: provisioning
+			// templates a single DashboardHost, so a vanity URL minted here
+			// resolves to no backend and every hub link to it — including the SSO
+			// handoff — returns 503, while the raw placeholder host works fine.
+			// Create the route FIRST, then adopt the URL. VanityURL doubles as
+			// the "placeholder is claimed" marker (projectConfigForHiveID keeps
+			// pushing until the spoke reports it back), so it is always set —
+			// but a failed route is logged at Warn rather than swallowed, since
+			// the symptom is a 503 on every hub link to this hive.
+			if err := s.addVanityHostToIngress(hiveID, vanityHost, cluster); err != nil {
+				s.logger.Warn("vanity host is not served: could not add it to the spoke ingress/route — "+
+					"hub links to this hive will 503 until it is added by hand",
+					"hive", hiveID, "host", vanityHost, "error", err)
+			}
+			h.VanityURL = "https://" + vanityHost
 		}
 	}
 	if err := saveSaaSHive(h); err != nil {
@@ -6187,6 +6262,10 @@ const dashboardHTML = `<!DOCTYPE html>
           '<div>' +
           '<span style="font-size:0.85rem;font-weight:600">' + esc(pr.username) + '</span>' +
           '<span style="font-size:0.75rem;color:var(--muted);margin-left:8px">' + esc(pr.org) + '/' + esc(pr.primary_repo || pr.repos) + '</span>' +
+          // Show which GitHub instance the request targets. Blank github_host
+          // means public github.com; a GHE host (github.ibm.com, …) is called
+          // out so the admin can place the hive on a cluster that can reach it.
+          ' <span style="font-size:0.68rem;padding:1px 7px;border-radius:999px;border:1px solid ' + (pr.github_host ? 'var(--accent);color:var(--accent)' : 'var(--border);color:var(--muted)') + '">' + esc(pr.github_host || 'github.com') + '</span>' +
           ' ' + acmmBadge(pr.acmm_level) +
           '<div style="font-size:0.7rem;color:var(--muted)">' + esc((pr.requested_at || '').substring(0, 10)) + '</div>' +
           '</div></div>' +

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1499,3 +1499,125 @@ spec:
     insecureEdgeTerminationPolicy: Redirect
 {{- end}}
 `
+
+// addVanityHostToIngress makes the spoke actually serve a second, friendlier
+// hostname. Provisioning templates exactly one DashboardHost, so a vanity URL
+// derived from the claimed org/repo has no backend until something creates a
+// route for it — and every hub link to that host (including the /open SSO
+// handoff) returns 503 while the raw placeholder host works fine.
+//
+// nginx clusters: patch the existing Ingresses, appending the vanity host as an
+// extra rule (copied from the placeholder rule) and adding it to the TLS block
+// so cert-manager issues for it.
+// OpenShift clusters: a Route carries a single host, so add parallel
+// "<name>-vanity" Routes instead.
+//
+// Returns an error when the host could not be made servable; the caller then
+// leaves VanityURL empty so the hive keeps its working placeholder host.
+func (s *HubServer) addVanityHostToIngress(hiveID, vanityHost string, cluster *ClusterConfig) error {
+	if cluster == nil || vanityHost == "" {
+		return fmt.Errorf("no cluster or vanity host")
+	}
+	ns := "hive-hosted-" + hiveID
+	placeholderHost := hiveID + "." + cluster.Domain
+
+	if cluster.IngressType == ingressTypeOpenShiftRoute {
+		for _, base := range []string{"hive-dashboard", "hive-terminal"} {
+			out, err := kubectlForCluster(cluster, "-n", ns, "get", "route", base,
+				"-o", "jsonpath={.spec.port.targetPort}|{.spec.path}").Output()
+			if err != nil {
+				continue // route absent on this spoke — nothing to mirror
+			}
+			parts := strings.SplitN(string(out), "|", 2)
+			targetPort := parts[0]
+			path := "/"
+			if len(parts) == 2 && parts[1] != "" {
+				path = parts[1]
+			}
+			manifest := fmt.Sprintf(`apiVersion: route.openshift.io/v1
+kind: Route
+metadata: { name: %s-vanity, namespace: %s, labels: { app: hive } }
+spec:
+  host: %s
+  path: %s
+  port: { targetPort: %s }
+  tls: { termination: edge, insecureEdgeTerminationPolicy: Redirect }
+  to: { kind: Service, name: hive, weight: 100 }
+  wildcardPolicy: None
+`, base, ns, vanityHost, path, targetPort)
+			cmd := kubectlForCluster(cluster, "apply", "-f", "-")
+			cmd.Stdin = strings.NewReader(manifest)
+			if err := cmd.Run(); err != nil {
+				return fmt.Errorf("applying %s-vanity route: %w", base, err)
+			}
+		}
+		return nil
+	}
+
+	// nginx: append a rule + TLS host to each existing Ingress via a JSON patch.
+	patched := 0
+	for _, ing := range []string{"hive", "hive-contribute", "hive-terminal"} {
+		raw, err := kubectlForCluster(cluster, "-n", ns, "get", "ingress", ing, "-o", "json").Output()
+		if err != nil {
+			continue // not every spoke has all three
+		}
+		var obj map[string]any
+		if err := json.Unmarshal(raw, &obj); err != nil {
+			continue
+		}
+		spec, _ := obj["spec"].(map[string]any)
+		if spec == nil {
+			continue
+		}
+		rules, _ := spec["rules"].([]any)
+		var base map[string]any
+		for _, r := range rules {
+			rm, _ := r.(map[string]any)
+			if rm == nil {
+				continue
+			}
+			if h, _ := rm["host"].(string); h == vanityHost {
+				base = nil // already present
+				goto tls
+			} else if h == placeholderHost {
+				base = rm
+			}
+		}
+		if base != nil {
+			clone := map[string]any{"host": vanityHost, "http": base["http"]}
+			spec["rules"] = append(rules, clone)
+		}
+	tls:
+		if tlsList, ok := spec["tls"].([]any); ok {
+			for _, t := range tlsList {
+				tm, _ := t.(map[string]any)
+				if tm == nil {
+					continue
+				}
+				hosts, _ := tm["hosts"].([]any)
+				found := false
+				for _, h := range hosts {
+					if hs, _ := h.(string); hs == vanityHost {
+						found = true
+					}
+				}
+				if !found {
+					tm["hosts"] = append(hosts, vanityHost)
+				}
+			}
+		}
+		patchBody, err := json.Marshal(map[string]any{"spec": spec})
+		if err != nil {
+			continue
+		}
+		cmd := kubectlForCluster(cluster, "-n", ns, "patch", "ingress", ing, "--type", "merge", "-p", string(patchBody))
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("patching ingress %s: %w", ing, err)
+		}
+		patched++
+	}
+	if patched == 0 {
+		return fmt.Errorf("no ingress found in %s to add %s to", ns, vanityHost)
+	}
+	return nil
+}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -129,6 +129,59 @@ func isValidName(s string) bool {
 	return safeNamePattern.MatchString(s) && len(s) <= 100
 }
 
+// normalizeOrgRef accepts what a user actually pastes into an "org" field and
+// splits it into a GitHub host and a bare org name.
+//
+// The field is labelled "GitHub Organization", but pasting the org's URL is the
+// obvious reading, and safeNamePattern rejects ":" and "/" — so a paste like
+// "https://github.ibm.com/z-aiops-unite" failed with a bare "invalid org name"
+// that named neither the problem nor the fix.
+//
+// Any GitHub Enterprise host is accepted (github.ibm.com, github.cisco.com, …),
+// not a fixed allow-list. Returns (host, org); host is "" when the input was a
+// bare org name, which callers should read as public github.com.
+//
+//	https://github.ibm.com/z-aiops-unite  -> ("github.ibm.com", "z-aiops-unite")
+//	github.ibm.com/z-aiops-unite          -> ("github.ibm.com", "z-aiops-unite")
+//	z-aiops-unite                         -> ("",               "z-aiops-unite")
+func normalizeOrgRef(s string) (host, org string) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "http://")
+	s = strings.Trim(s, "/")
+	if s == "" {
+		return "", ""
+	}
+	parts := strings.Split(s, "/")
+	// A leading segment containing a dot is a hostname (github.com,
+	// github.ibm.com). A bare org can also contain dots, so only treat the
+	// first segment as a host when something follows it.
+	if len(parts) > 1 && strings.Contains(parts[0], ".") {
+		return parts[0], parts[1]
+	}
+	return "", parts[0]
+}
+
+// normalizeRepoRef strips a GitHub URL or "org/repo" prefix down to the bare
+// repo name, so users can paste a repo URL into the repos field. Returns the
+// repo name; the org is already carried separately.
+//
+//	https://github.ibm.com/z-aiops-unite/ui -> "ui"
+//	z-aiops-unite/ui                        -> "ui"
+//	ui                                      -> "ui"
+func normalizeRepoRef(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "http://")
+	s = strings.Trim(s, "/")
+	s = strings.TrimSuffix(s, ".git")
+	if s == "" {
+		return ""
+	}
+	parts := strings.Split(s, "/")
+	return parts[len(parts)-1]
+}
+
 // isValidRepoRef validates a repo entry, which may be a bare name ("repo")
 // or a cross-org "owner/repo" reference. Both segments must be safe names
 // (no path traversal); at most one slash is allowed. Cross-org repos are a


### PR DESCRIPTION
Three related failures in the request → assign path, all reported today.

## 1. Vanity URLs returned 503

Assignment mints a vanity hostname from the claimed org/repo (`saas.go:4569`), but **nothing ever created a route for it** — provisioning templates exactly one `DashboardHost`. The spoke adopts the unroutable URL over heartbeat, so every hub link to it (including the `/open` SSO handoff) 503s while the raw placeholder host works fine.

Three live hives hit this: `ibmmcp` (oke-03), `hashicorp` (oke-04), `zacburns` (vllmd-04). All three are now serving after a manual route fix.

`addVanityHostToIngress` makes the host servable:
- **nginx** — appends a rule to each Ingress (copied from the placeholder rule) plus the TLS host, so cert-manager issues for it
- **OpenShift** — a Route carries a single host, so it creates parallel `<name>-vanity` Routes

`VanityURL` is still always set (it doubles as the "claimed" marker `projectConfigForHiveID` pushes until the spoke echoes it back), but a failed route now logs at **Warn** instead of silently producing a dead link.

## 2. "Invalid org name" on a pasted URL

The field says **GitHub Organization**, so users paste the org's URL. `safeNamePattern` rejects `:` and `/`, and the error named neither the value nor the fix:

```
https://github.ibm.com/z-aiops-unite  ->  invalid org name
```

`normalizeOrgRef` / `normalizeRepoRef` now accept a full URL, a `host/org` pair, or a bare name — in **both** the request and assign handlers. The error quotes the offending value and shows the accepted form.

## 3. No record of which GitHub instance was requested

`ProvisionRequest` carried no host, so you couldn't tell github.com from github.ibm.com before placing a hive:

```json
{"username":"wlchan3","org":"VPC-Migration-Factory","auth_method":"",...}
```

The host is now parsed from the paste, persisted as `github_host` (empty = public github.com), and rendered as a badge on each **Pending Provision Requests** row. Any GHE host is accepted (`github.ibm.com`, `github.cisco.com`, …) rather than an allow-list.

## Verification

`normalizeOrgRef` tested against the real reports:

| input | host | org |
|---|---|---|
| `https://github.ibm.com/z-aiops-unite` | github.ibm.com | z-aiops-unite |
| `github.cisco.com/some-org` | github.cisco.com | some-org |
| `https://github.com/kubestellar` | github.com | kubestellar |
| `VPC-Migration-Factory` | — | VPC-Migration-Factory |

`go build`, `go vet`, and the hub `Provision|Assign|Request` tests pass.

## Not in this PR

The **"No repositories found"** bug in Get Started step 3 is separate: `get-started.html:509` calls `/api/saas/repos`, which **returns 404 — no Go handler registers that route**. It needs a new endpoint listing repos from the user's App installations, which is a feature rather than a fix. Flagging it here since it blocks every requester, not just Jim.