### PR TITLE
✨ fix(saas): add the missing /api/saas/repos endpoint + manual repo URL entry

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -143,6 +143,7 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("PUT /api/saas/hives/{id}/approve-access/{username}", s.requireAuth(s.handleApproveAccess))
 	s.mux.HandleFunc("DELETE /api/saas/hives/{id}/deny-access/{username}", s.requireAuth(s.handleDenyAccess))
 	s.mux.HandleFunc("GET /api/saas/access-status", s.handleAccessStatus)
+	s.mux.HandleFunc("GET /api/saas/repos", s.requireAuth(s.handleSaaSRepos))
 	s.mux.HandleFunc("POST /api/saas/request-provision", s.requireAuth(s.handleRequestProvision))
 	s.mux.HandleFunc("PUT /api/saas/approve-provision/{username}", s.requireAdmin(s.handleApproveProvision))
 	s.mux.HandleFunc("DELETE /api/saas/deny-provision/{username}", s.requireAdmin(s.handleDenyProvision))
@@ -7894,4 +7895,116 @@ func (s *HubServer) handleGetHubBanner(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"banners": banners})
+}
+
+// handleSaaSRepos lists the repositories the requester can pick from in the
+// "Get a hosted hive" flow (step 3).
+//
+// The frontend has always called GET /api/saas/repos, but no handler was ever
+// registered — the fetch 404'd and the page fell through to "No repositories
+// found. Make sure the Hive GitHub App is installed on your org", which blamed
+// the user's App installation for a missing backend route. It failed for every
+// requester regardless of whether the App was installed.
+//
+// Repos come from the App installations the user's OAuth token can see, which
+// covers BOTH org installations and personal-account installations (the
+// original error text assumed orgs only — the first real report was a repo
+// under a personal account).
+//
+// Note this can only ever see public github.com. A GitHub Enterprise repo
+// (github.ibm.com, …) is invisible to a github.com OAuth token, so the UI also
+// lets the requester type a repo URL by hand; that path does not depend on this
+// endpoint.
+func (s *HubServer) handleSaaSRepos(w http.ResponseWriter, r *http.Request) {
+	username := s.getAuthUser(r)
+	if username == "" {
+		http.Error(w, `{"error":"not authenticated"}`, http.StatusUnauthorized)
+		return
+	}
+	user := loadSaaSUser(username)
+	if user == nil || user.EncryptedToken == "" {
+		// No stored token — return an empty list rather than an error so the UI
+		// shows its "install the App / paste a URL" guidance instead of a crash.
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"repos": []any{}})
+		return
+	}
+	token, err := decryptToken(user.EncryptedToken)
+	if err != nil {
+		s.logger.Warn("repos: failed to decrypt user token", "user", username, "error", err)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"repos": []any{}})
+		return
+	}
+
+	type repoOut struct {
+		FullName    string `json:"full_name"`
+		Name        string `json:"name"`
+		Description string `json:"description,omitempty"`
+	}
+	ghGet := func(url string, out any) error {
+		req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, url, nil)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", "token "+token)
+		req.Header.Set("Accept", "application/vnd.github+json")
+		resp, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("github %s: status %d", url, resp.StatusCode)
+		}
+		return json.NewDecoder(resp.Body).Decode(out)
+	}
+
+	// 1. Which App installations can this user see? (orgs AND their own account)
+	var insts struct {
+		Installations []struct {
+			ID int64 `json:"id"`
+		} `json:"installations"`
+	}
+	if err := ghGet("https://api.github.com/user/installations?per_page=100", &insts); err != nil {
+		s.logger.Warn("repos: listing installations failed", "user", username, "error", err)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"repos": []any{}})
+		return
+	}
+
+	// 2. Repositories per installation, deduped by full_name.
+	seen := map[string]struct{}{}
+	repos := []repoOut{}
+	for _, inst := range insts.Installations {
+		for page := 1; page <= 5; page++ { // cap paging; 500 repos is plenty for a picker
+			var rr struct {
+				Repositories []struct {
+					FullName    string `json:"full_name"`
+					Name        string `json:"name"`
+					Description string `json:"description"`
+				} `json:"repositories"`
+			}
+			url := fmt.Sprintf("https://api.github.com/user/installations/%d/repositories?per_page=100&page=%d", inst.ID, page)
+			if err := ghGet(url, &rr); err != nil {
+				s.logger.Warn("repos: listing installation repos failed",
+					"user", username, "installation", inst.ID, "error", err)
+				break
+			}
+			for _, rp := range rr.Repositories {
+				if _, dup := seen[rp.FullName]; dup {
+					continue
+				}
+				seen[rp.FullName] = struct{}{}
+				repos = append(repos, repoOut{FullName: rp.FullName, Name: rp.Name, Description: rp.Description})
+			}
+			if len(rr.Repositories) < 100 {
+				break
+			}
+		}
+	}
+	sort.Slice(repos, func(i, j int) bool { return repos[i].FullName < repos[j].FullName })
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"repos": repos})
 }

--- a/v2/pkg/hub/static/get-started.html
+++ b/v2/pkg/hub/static/get-started.html
@@ -349,7 +349,23 @@
         <div id="repo-loading" style="color:var(--muted);padding:24px;text-align:center">Loading your repositories...</div>
         <div id="repo-list" class="repo-list" style="display:none"></div>
         <div id="repo-none" style="display:none;padding:24px;text-align:center;color:var(--muted)">
-          <p>No repositories found. Make sure the <a href="https://github.com/apps/kubestellar-hive" target="_blank" style="color:var(--blue)">Hive GitHub App</a> is installed on your org.</p>
+          <p>No repositories found. Install the <a href="https://github.com/apps/kubestellar-hive" target="_blank" style="color:var(--blue)">Hive GitHub App</a> on the account or org that owns them &mdash; or add a repo URL below.</p>
+        </div>
+        <!-- Manual entry. Repo discovery uses the github.com OAuth token, so a
+             GitHub Enterprise repo (github.ibm.com, github.cisco.com, …) can
+             never appear in the list above. Typing the URL is the only way to
+             request one, and it also covers a repo the App has not been
+             installed on yet. -->
+        <div style="margin-top:18px;padding-top:16px;border-top:1px solid var(--line)">
+          <label for="repo-manual" style="display:block;font-size:0.86rem;color:var(--muted);margin-bottom:6px">
+            Or add a repository by URL &mdash; required for GitHub Enterprise (github.ibm.com and similar), which cannot be listed above
+          </label>
+          <div style="display:flex;gap:8px">
+            <input type="text" id="repo-manual" placeholder="https://github.ibm.com/my-org/my-repo"
+              style="flex:1;padding:9px 12px;background:var(--bg-soft);border:1px solid var(--line);border-radius:6px;color:var(--text);font-size:0.88rem">
+            <button class="btn-secondary" type="button" onclick="addManualRepo()">Add</button>
+          </div>
+          <div id="repo-manual-err" style="display:none;margin-top:6px;font-size:0.8rem;color:var(--red)"></div>
         </div>
         <div style="display:flex;gap:12px;margin-top:16px">
           <button class="btn-secondary" onclick="goToStep(2)">← Back</button>
@@ -543,6 +559,67 @@ hive-contribute connect https://hive.kubestellar.io/hive/HIVE_ID</code></pre>
         el.classList.add('selected');
         cb.checked = true;
       }
+      document.getElementById('repos-continue').disabled = _selectedRepos.length === 0;
+    }
+
+    // Add a repo the picker cannot show. Repo discovery runs on the github.com
+    // OAuth token, so GitHub Enterprise repos (github.ibm.com and friends) never
+    // appear in the list — typing the URL is the only way to request one.
+    // Accepts a full URL, "host/org/repo", or "org/repo".
+    function addManualRepo() {
+      var input = document.getElementById('repo-manual');
+      var err = document.getElementById('repo-manual-err');
+      var raw = (input.value || '').trim();
+      err.style.display = 'none';
+      if (!raw) return;
+
+      var v = raw.replace(/^https?:\/\//, '').replace(/\/+$/, '').replace(/\.git$/, '');
+      var parts = v.split('/').filter(function(p) { return p.length; });
+      // Drop a leading hostname (anything with a dot) so host/org/repo -> org/repo.
+      if (parts.length > 2 && parts[0].indexOf('.') !== -1) parts = parts.slice(1);
+      if (parts.length < 2) {
+        err.textContent = 'Enter a repository URL or org/repo — for example https://github.ibm.com/my-org/my-repo';
+        err.style.display = 'block';
+        return;
+      }
+      var org = parts[0], name = parts[1], fullName = org + '/' + name;
+      if (_selectedRepos.some(function(r) { return r.full_name === fullName; })) {
+        err.textContent = fullName + ' is already selected';
+        err.style.display = 'block';
+        return;
+      }
+      _selectedRepos.push({full_name: fullName, name: name});
+      input.value = '';
+      renderManualRepos();
+      document.getElementById('repos-continue').disabled = _selectedRepos.length === 0;
+    }
+
+    // Show manually added repos (they have no checkbox row in the picker list).
+    function renderManualRepos() {
+      var host = document.getElementById('repo-manual-added');
+      if (!host) {
+        host = document.createElement('div');
+        host.id = 'repo-manual-added';
+        host.style.cssText = 'margin-top:10px;display:flex;flex-wrap:wrap;gap:6px';
+        document.getElementById('repo-manual').parentNode.parentNode.appendChild(host);
+      }
+      var listed = {};
+      document.querySelectorAll('#repo-list .repo-item').forEach(function(el) {
+        var n = el.querySelector('.repo-name');
+        if (n) listed[n.textContent] = true;
+      });
+      var manual = _selectedRepos.filter(function(r) { return !listed[r.full_name]; });
+      host.innerHTML = manual.map(function(r) {
+        return '<span style="display:inline-flex;align-items:center;gap:6px;padding:3px 10px;border:1px solid var(--line);border-radius:999px;font-size:0.8rem">' +
+          esc(r.full_name) +
+          '<a href="#" onclick="removeManualRepo(\'' + esc(r.full_name) + '\');return false" style="color:var(--muted);text-decoration:none" title="Remove">&times;</a></span>';
+      }).join('');
+    }
+
+    function removeManualRepo(fullName) {
+      var i = _selectedRepos.findIndex(function(r) { return r.full_name === fullName; });
+      if (i >= 0) _selectedRepos.splice(i, 1);
+      renderManualRepos();
       document.getElementById('repos-continue').disabled = _selectedRepos.length === 0;
     }
 


### PR DESCRIPTION
Fixes the "No repositories found" wall Jim Laredo hit in **Get a hosted hive → step 3**, with the App installed and steps 1–2 green.

## Root cause

`get-started.html:509` has always fetched `GET /api/saas/repos` — but **no handler was ever registered**. Live check on the running hub:

```
/api/saas/repos -> HTTP 404
```

The fetch 404s, the page falls through to its empty state, and the message blames the user's App installation for a missing backend route. It failed for **every** requester.

## The endpoint

`handleSaaSRepos` lists repos from the App installations the user's OAuth token can see:

1. `GET /user/installations`
2. `GET /user/installations/{id}/repositories` (paged, capped, deduped, sorted)

That covers **org and personal-account installations**. The first report was `laredo/cuga-agent` — a personal account, which the old copy ("installed on your **org**") didn't even contemplate.

A missing or undecryptable token returns an empty list rather than an error, so the UI shows guidance instead of breaking.

## Manual repo URL entry

Discovery alone can't be sufficient. Repo listing runs on the **github.com** OAuth token, so a **GitHub Enterprise** repo (`github.ibm.com`, `github.cisco.com`, …) is invisible to it no matter what's installed — and hub OAuth is github.com by design.

Requesters can now type a repo URL directly. Accepts:

| input | result |
|---|---|
| `https://github.ibm.com/my-org/my-repo` | `my-org/my-repo` |
| `github.ibm.com/my-org/my-repo` | `my-org/my-repo` |
| `my-org/my-repo` | `my-org/my-repo` |

Added repos join the same selection model as picked ones, render as removable chips, and enable Continue. This also covers a repo whose App install hasn't happened yet.

Pairs with #2128, which captures `github_host` on the request so you can see which instance a request targets before placing the hive.

## Copy fix

The empty state no longer says "your org" — it points at the account **or** org that owns the repos, and at the URL field.

## Verification

HTML parses with no unclosed tags; `go build`, `go vet`, and the hub `Repos|Provision|Assign|Request` tests pass.