### PR TITLE
🐛 fix(saas,dashboard): stop the crash loop from a pasted repo URL

### DIFF
--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -797,7 +797,15 @@ func buildRepos(cfg *config.Config, actionable *github.ActionableResult) []Front
 	}
 
 	for _, repoName := range cfg.Project.Repos {
-		full := cfg.Project.Org + "/" + repoName
+		// A repo entry may be a bare name ("cuga-agent") or an explicit
+		// cross-org reference ("laredo/cuga-agent") — both are supported config.
+		// Prefixing the org unconditionally turned the latter into
+		// "laredo/laredo/cuga-agent" in the REPOSITORIES card and in every
+		// GitHub link built from it.
+		full := repoName
+		if !strings.Contains(repoName, "/") {
+			full = cfg.Project.Org + "/" + repoName
+		}
 
 		issueCount := 0
 		prCount := 0

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4450,10 +4450,31 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 	if !needClaimPush && !needURLPush {
 		return nil // nothing left to push
 	}
+	// Sanitize before pushing. A repo pasted as a URL
+	// ("github.ibm.com/enricom-ibm/jackrabbit") has two slashes, which
+	// isValidRepoRef rejects — so the hub 400s the spoke's every heartbeat
+	// ("invalid repo name"), /api/livez then fails on the stale heartbeat, and
+	// the kubelet restarts the pod in a loop. Normalizing here repairs an
+	// already-broken hive over the heartbeat, which is the only channel that
+	// reaches a firewalled cluster (vllm-d).
+	pushRepos := make([]string, 0, len(h.Repos))
+	for _, r := range h.Repos {
+		if rr := sanitizeRepoEntry(r); rr != "" {
+			pushRepos = append(pushRepos, rr)
+		}
+	}
+	if len(pushRepos) == 0 {
+		pushRepos = h.Repos
+	}
+	pushPrimary := sanitizeRepoEntry(primary)
+	if pushPrimary == "" {
+		pushPrimary = primary
+	}
+
 	return &HeartbeatProjectConfig{
 		Org:          h.Org,
-		Repos:        h.Repos,
-		PrimaryRepo:  primary,
+		Repos:        pushRepos,
+		PrimaryRepo:  pushPrimary,
 		ACMMLevel:    h.ACMMLevel,
 		DashboardURL: h.VanityURL,
 		// AIAuthor is deliberately left empty here. Provisioning state never

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1485,3 +1485,34 @@ func sanitizeHeartbeatField(s string) string {
 	}
 	return b.String()
 }
+
+// sanitizeRepoEntry makes a repo entry satisfy isValidRepoRef.
+//
+// A repo may legitimately be a bare name ("cuga-agent") or a cross-org
+// reference ("laredo/cuga-agent") — both are supported config. What is NOT
+// valid is a pasted URL ("github.ibm.com/enricom-ibm/jackrabbit"), which has
+// two slashes: the hub rejects the spoke's heartbeat with "invalid repo name",
+// /api/livez then fails on the stale heartbeat, and the pod crash-loops.
+//
+// Strip the scheme and a leading hostname (a first segment containing a dot),
+// then keep at most the last two segments so a valid cross-org ref survives.
+func sanitizeRepoEntry(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "http://")
+	s = strings.Trim(s, "/")
+	s = strings.TrimSuffix(s, ".git")
+	if s == "" {
+		return ""
+	}
+	parts := strings.Split(s, "/")
+	// Drop a leading hostname: "github.ibm.com/org/repo" -> "org/repo".
+	if len(parts) > 2 && strings.Contains(parts[0], ".") {
+		parts = parts[1:]
+	}
+	// Anything still deeper than owner/repo keeps only its last two segments.
+	if len(parts) > 2 {
+		parts = parts[len(parts)-2:]
+	}
+	return strings.Join(parts, "/")
+}


### PR DESCRIPTION
## The crash loop

Two hives are crash-looping right now with a repo stored as a pasted URL:

| Hive | stored repo | restarts |
|---|---|---|
| `vllmd-03` (enricom8) | `github.ibm.com/enricom-ibm/jackrabbit` | 5 |
| `vllmd-04` (zacburns) | `GitHub.ibm.com/zacburns/mlz-manager` | 8 |

`isValidRepoRef` allows at most **one** slash — a bare `repo` or a cross-org `owner/repo`. A URL has two. The chain, verified end to end:

```
pasted URL in repo field
  -> hub rejects every heartbeat: 400 "invalid repo name"
  -> /api/livez 503s on the stale heartbeat (livezHeartbeatStaleMax)
  -> "Container hive failed liveness probe, will be restarted"
  -> each 0/1 window serves 503 on the route; gray dot in the hub
```

## Fix — over the heartbeat

vllm-d is unreachable by kubectl, so the repair has to travel the heartbeat channel:

- **`sanitizeRepoEntry`** strips the scheme and a leading hostname, keeping at most `owner/repo`. A valid cross-org ref survives untouched.
- **`projectConfigForHiveID`** sanitizes `Repos`/`PrimaryRepo` before pushing, so an already-broken hive repairs itself on its next beat — no per-spoke edit.

Verified against both live values:

| input | output | valid? |
|---|---|---|
| `github.ibm.com/enricom-ibm/jackrabbit` | `enricom-ibm/jackrabbit` | ✓ |
| `GitHub.ibm.com/zacburns/mlz-manager` | `zacburns/mlz-manager` | ✓ |
| `laredo/cuga-agent` | unchanged | ✓ |
| `osscar-application` | unchanged | ✓ |

## Also: the `laredo/laredo/cuga-agent` display bug

`status_builder.go` prefixed the org onto every repo unconditionally, so a cross-org entry rendered doubled in the REPOSITORIES card and in every GitHub link built from it. Jim was right that his config was fine — only the display was wrong.

## This is not a GHE gap

`hosted-open-source-osscar` (jjs-world) runs happily against **github.ibm.com** with a bare `primary_repo` and `github.api_url: https://github.ibm.com/api/v3`. The host belongs in `api_url`, not in the repo field. GHE auth (enterprise `app_id`/installation) is deliberately out of scope here.

## Verification

`go build`, `go vet`, hub `Project|Assign|Heartbeat|Provision` and dashboard `Status|Repo` tests all pass.