### PR TITLE
✨ feat(saas): point GHE hives at their enterprise API over the heartbeat

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1942,11 +1942,13 @@ func main() {
 			// still gets applied and persisted.
 			vanityMatched := pc.DashboardURL == "" || cfg.Hub.DashboardURL == pc.DashboardURL
 			authorMatched := pc.AIAuthor == "" || cfg.Project.AIAuthor == pc.AIAuthor
+			apiURLMatched := pc.GitHubAPIURL == "" || cfg.GitHub.APIURL == pc.GitHubAPIURL
 			if cfg.Project.Org == pc.Org &&
 				sameStringSlice(cfg.Project.Repos, pc.Repos) &&
 				cfg.Project.PrimaryRepo == pc.PrimaryRepo &&
 				curACMM == pc.ACMMLevel &&
 				authorMatched &&
+				apiURLMatched &&
 				vanityMatched {
 				return // already reconciled
 			}
@@ -1968,6 +1970,14 @@ func main() {
 			// kept the fleet-stats collector disabled on every hive.
 			if pc.AIAuthor != "" {
 				cfg.Project.AIAuthor = pc.AIAuthor
+			}
+			// Adopt a GitHub Enterprise API URL when the hub sends one. Empty
+			// means "leave mine alone" — the spoke's own default is already
+			// api.github.com, so this never clobbers a working config.
+			if pc.GitHubAPIURL != "" && cfg.GitHub.APIURL != pc.GitHubAPIURL {
+				logger.Info("adopting GitHub API URL from hub heartbeat",
+					"was", cfg.GitHub.APIURL, "now", pc.GitHubAPIURL)
+				cfg.GitHub.APIURL = pc.GitHubAPIURL
 			}
 			level := pc.ACMMLevel
 			cfg.ACMMLevel = &level

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -489,6 +489,15 @@ type HeartbeatProjectConfig struct {
 	// placeholder subdomain) — and stays that way, since it's now the value the
 	// heartbeat carries. Empty = leave the spoke's dashboard URL unchanged.
 	DashboardURL string `json:"dashboard_url,omitempty"`
+	// GitHubAPIURL points the spoke at a GitHub Enterprise API when the request
+	// named a GHE org (github.ibm.com/my-org). Without it a GHE hive silently
+	// talks to api.github.com and 404s on every repo call, which is what drove
+	// users to paste the host into the repo field instead — the malformed value
+	// then failed heartbeat validation and crash-looped the pod.
+	//
+	// Empty = leave the spoke's github.api_url unchanged (public github.com is
+	// the spoke's own default), so this never blanks a working config.
+	GitHubAPIURL string `json:"github_api_url,omitempty"`
 }
 
 // HeartbeatGatewayConfig carries an OpenRouter model gateway (funded via the

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4477,6 +4477,11 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 		PrimaryRepo:  pushPrimary,
 		ACMMLevel:    h.ACMMLevel,
 		DashboardURL: h.VanityURL,
+		// Point a GHE hive at its enterprise API. jjs-world
+		// (hosted-open-source-osscar) is the working reference: a bare
+		// primary_repo plus github.api_url = https://<host>/api/v3. Empty host
+		// pushes nothing, so a github.com hive keeps the spoke's own default.
+		GitHubAPIURL: gheAPIURLForHost(h.GitHubHost),
 		// AIAuthor is deliberately left empty here. Provisioning state never
 		// knows the agents' GitHub account — the spoke owns it — and the spoke
 		// treats an empty author as "leave mine alone". Setting it from this
@@ -4626,6 +4631,11 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	// (and any stale error) alone makes it show under the new owner in My Hives.
 	h.Owner = body.Owner
 	h.Org = body.Org
+	// Record the GHE host (if any) so the heartbeat can point this spoke at the
+	// right GitHub API. Never blank an existing value with an empty one.
+	if body.GitHubHost != "" {
+		h.GitHubHost = body.GitHubHost
+	}
 	h.Repos = repos
 	h.PrimaryRepo = primaryRepo
 	if body.ProjectName != "" {

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -249,6 +249,11 @@ type SaaSHive struct {
 	Owner       string   `json:"owner"`
 	ProjectName string   `json:"project_name"`
 	Org         string   `json:"org"`
+	// GitHubHost is the GitHub instance this project lives on — empty means
+	// public github.com, otherwise a GitHub Enterprise host (github.ibm.com,
+	// github.cisco.com, …). Recorded at assign time from the requested org so
+	// the spoke can be pointed at the right API over the heartbeat.
+	GitHubHost  string   `json:"github_host,omitempty"`
 	Repos       []string `json:"repos"`
 	PrimaryRepo string   `json:"primary_repo"`
 	ACMMLevel   int      `json:"acmm_level"`

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1516,3 +1516,19 @@ func sanitizeRepoEntry(s string) string {
 	}
 	return strings.Join(parts, "/")
 }
+
+// gheAPIURLForHost turns a GitHub host into the API base URL the spoke should
+// use. GitHub Enterprise serves its v3 API at https://<host>/api/v3 — the
+// working reference is hosted-open-source-osscar, which runs against
+// github.ibm.com with exactly that value.
+//
+// Public github.com (and an empty host) return "", meaning "leave the spoke's
+// github.api_url alone" — its own default is already https://api.github.com,
+// and pushing a value here would overwrite a hand-tuned config.
+func gheAPIURLForHost(host string) string {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if host == "" || host == "github.com" || host == "api.github.com" {
+		return ""
+	}
+	return "https://" + host + "/api/v3"
+}


### PR DESCRIPTION
Completes the GHE path. #2128 captures `github_host` from a pasted org URL; this carries it to the spoke so a GHE hive actually talks to the right API.

## The gap

A request could name `github.ibm.com/my-org` and the host was recorded — but nothing set `github.api_url` on the spoke, so the hive still called `api.github.com` and 404'd on every repo. That is precisely what drove users to paste the host into the **repo** field instead, and a three-segment repo fails heartbeat validation and crash-loops the pod (#2130).

## Wiring

- **`SaaSHive.GitHubHost`** — recorded at assign time; an empty value never blanks an existing one.
- **`gheAPIURLForHost`** — `<host>` → `https://<host>/api/v3`. Public github.com returns `""`, so nothing is pushed and the spoke keeps its own default.
- **`HeartbeatProjectConfig.GitHubAPIURL`** — the only channel that reaches a firewalled cluster (vllm-d).
- **Spoke adoption** — a non-empty value is written to `cfg.GitHub.APIURL` and logged; empty means "leave mine alone".
- **Drift check** — includes the API URL, so a mismatch reconciles instead of persisting silently.

## Matches the working reference

`hosted-open-source-osscar` (jjs-world) already runs against github.ibm.com:

```yaml
org: open-source
primary_repo: osscar-application            # bare name
github:
  api_url: https://github.ibm.com/api/v3    # host lives here, not in the repo
```

`gheAPIURLForHost` produces exactly that value.

| input | output |
|---|---|
| `github.ibm.com` | `https://github.ibm.com/api/v3` |
| `GitHub.IBM.com` | `https://github.ibm.com/api/v3` |
| `github.cisco.com` | `https://github.cisco.com/api/v3` |
| `github.com` / empty | `""` (no-op) |

## Still required, and out of scope

The **enterprise App credential**. jjs-world uses `app_id: 5686`; a hive assigned from the github.com App (`3568013`) will now reach the right API and then **401**. This change fixes the endpoint, not the credential — flagging it so a GHE assignment isn't expected to work end-to-end without it.

`go build`, `go vet`, and the hub `Project|Assign|Heartbeat|Provision` tests pass.