### PR TITLE
🐛 fix(saas): repair a wedged spoke even after the claim was delivered

### DIFF
--- a/v2/pkg/hub/project_config_repair_test.go
+++ b/v2/pkg/hub/project_config_repair_test.go
@@ -1,0 +1,36 @@
+package hub
+import "testing"
+// A wedged spoke (invalid repo, claim already delivered) must still get a
+// corrected project pushed — otherwise it crash-loops forever.
+func TestProjectConfigRepairsWedgedSpoke(t *testing.T) {
+	dir := t.TempDir()
+	oldDir := saasHivesDir
+	saasHivesDir = dir
+	defer func() { saasHivesDir = oldDir }()
+
+	h := &SaaSHive{
+		ID: "hosted-wedged", Owner: "someone", Org: "enricom-ibm",
+		Repos: []string{"enricom-ibm/jackrabbit"}, PrimaryRepo: "enricom-ibm/jackrabbit",
+		ACMMLevel: 2, ClaimDelivered: true,
+	}
+	if err := saveSaaSHive(h); err != nil { t.Fatal(err) }
+
+	// Spoke reports the malformed value it is stuck on.
+	bad := "github.ibm.com/enricom-ibm/jackrabbit"
+	pc := projectConfigForHiveID("hosted-wedged", "enricom-ibm", []string{bad}, bad, 2, "")
+	if pc == nil {
+		t.Fatal("expected a repair push for a spoke reporting an invalid repo, got nil")
+	}
+	if !isValidRepoRef(pc.PrimaryRepo) {
+		t.Errorf("pushed primary_repo %q is still invalid", pc.PrimaryRepo)
+	}
+	for _, r := range pc.Repos {
+		if !isValidRepoRef(r) { t.Errorf("pushed repo %q is still invalid", r) }
+	}
+
+	// A healthy delivered claim must stay quiet (no churn every beat).
+	if pc2 := projectConfigForHiveID("hosted-wedged", "enricom-ibm",
+		[]string{"enricom-ibm/jackrabbit"}, "enricom-ibm/jackrabbit", 2, ""); pc2 != nil {
+		t.Errorf("expected nil for a healthy delivered claim, got %+v", pc2)
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4447,7 +4447,20 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 			sameStringSliceFold(curRepos, h.Repos) &&
 			strings.EqualFold(curPrimary, primary))
 	needURLPush := h.VanityURL != "" && curURL != h.VanityURL
-	if !needClaimPush && !needURLPush {
+	// A spoke reporting a repo that fails isValidRepoRef is wedged: the hub 400s
+	// its every heartbeat ("invalid repo name"), /api/livez then fails on the
+	// stale heartbeat and the kubelet crash-loops the pod. Push a corrected
+	// project even when the claim was already delivered — otherwise the guard
+	// above ("nothing left to push") leaves the hive broken forever, since a
+	// wedged spoke can never report anything the hub will accept.
+	needRepoRepair := false
+	for _, r := range append(append([]string{}, curRepos...), curPrimary) {
+		if r != "" && !isValidRepoRef(r) {
+			needRepoRepair = true
+			break
+		}
+	}
+	if !needClaimPush && !needURLPush && !needRepoRepair {
 		return nil // nothing left to push
 	}
 	// Sanitize before pushing. A repo pasted as a URL


### PR DESCRIPTION
## #2130 didn't reach the hives it was meant to rescue

It sanitized the repo before pushing — but the guard above it returns first:

```go
needClaimPush := !h.ClaimDelivered && ...
if !needClaimPush && !needURLPush { return nil }   // nothing left to push
```

Both hives have `claim_delivered: true`, so the sanitization was **unreachable**.

Verified after `c80ed9d` deployed to the hub:

| hive | spoke still has | restarts |
|---|---|---|
| vllmd-03 | `github.ibm.com/enricom-ibm/jackrabbit` | 15 |
| vllmd-04 | `GitHub.ibm.com/zacburns/mlz-manager` | 19 |

Heartbeats still rejected, restarts still climbing. My fix shipped and changed nothing.

## The deadlock

A spoke whose repo fails `isValidRepoRef` has **every** heartbeat 400'd. It can therefore never report anything the hub accepts, so the claim-delivered gate never reopens — the hive stays broken **forever**. Nothing in the normal flow can rescue it.

## Fix

Add `needRepoRepair`: if the spoke *reports* a repo that fails `isValidRepoRef`, push a corrected project **regardless of `ClaimDelivered`**.

A healthy delivered claim still pushes nothing, so there's no per-beat churn — which was the original reason for that gate (the spyre bug, where pushing every beat reverted operator edits).

## Test

`project_config_repair_test.go` covers both halves:
- wedged spoke (invalid repo + `ClaimDelivered: true`) → non-nil push, and every pushed repo satisfies `isValidRepoRef`
- healthy delivered claim → `nil`

`go build`, `go vet`, and the hub `Project|Assign|Heartbeat|Repair` tests pass.