### PR TITLE
🐛 fix(hub): stop spoke kubectl timeouts from starving the hub's own auto-upgrade

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -33,6 +33,18 @@ const hubAdminUsername = "clubanderson"
 // reports the new hash. One cycle plus rollout headroom.
 const hubUpgradeDebounce = 4 * time.Minute
 
+// upgradeKubectlTimeout bounds a single auto-upgrade kubectl call. kubectl's own
+// default retries an unreachable API server for ~2 minutes before giving up;
+// paying that per hive serialized the upgrade loop and starved the hub's own
+// upgrade check that runs after it. The heartbeat fallback is the real delivery
+// path for unreachable clusters, so failing fast costs nothing.
+const upgradeKubectlTimeout = 15 * time.Second
+
+// clusterUnreachableTTL is how long the hub skips kubectl for a cluster after a
+// dial failure. Long enough that one poll cycle probes a firewalled cluster at
+// most once, short enough that a cluster coming back online is picked up soon.
+const clusterUnreachableTTL = 10 * time.Minute
+
 type SaaSUser struct {
 	GitHubUsername string            `json:"github_username"`
 	CreatedAt      string            `json:"created_at"`
@@ -3048,6 +3060,69 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 	}
 }
 
+// clusterRecentlyUnreachable reports whether the hub failed to reach this
+// cluster recently enough that another kubectl attempt would just burn the
+// timeout again. Callers should go straight to the heartbeat fallback instead.
+func (s *HubServer) clusterRecentlyUnreachable(clusterID string) bool {
+	if clusterID == "" {
+		return false
+	}
+	s.clusterUnreachableMu.Lock()
+	defer s.clusterUnreachableMu.Unlock()
+	until, ok := s.clusterUnreachableUntil[clusterID]
+	return ok && time.Now().Before(until)
+}
+
+// markClusterUnreachable starts (or extends) the kubectl suppression window for
+// a cluster the hub just failed to dial.
+func (s *HubServer) markClusterUnreachable(clusterID string) {
+	if clusterID == "" {
+		return
+	}
+	s.clusterUnreachableMu.Lock()
+	defer s.clusterUnreachableMu.Unlock()
+	s.clusterUnreachableUntil[clusterID] = time.Now().Add(clusterUnreachableTTL)
+}
+
+// markClusterReachable clears any suppression after a kubectl call succeeds, so
+// a cluster that recovers is used immediately rather than waiting out the TTL.
+func (s *HubServer) markClusterReachable(clusterID string) {
+	if clusterID == "" {
+		return
+	}
+	s.clusterUnreachableMu.Lock()
+	defer s.clusterUnreachableMu.Unlock()
+	delete(s.clusterUnreachableUntil, clusterID)
+}
+
+// rolloutRestartHive issues the auto-upgrade `kubectl rollout restart` for one
+// hive under a bounded timeout, honouring and maintaining the unreachable-cluster
+// cache. It returns false when kubectl did not deliver the restart — the caller
+// must then arm the heartbeat fallback, which is the ONLY path that works for
+// firewalled clusters. Skipping is reported as a plain failure (not an error) so
+// callers treat "known unreachable" and "just failed" identically.
+func (s *HubServer) rolloutRestartHive(cluster *ClusterConfig, hiveID string) bool {
+	if s.clusterRecentlyUnreachable(cluster.ID) {
+		s.logger.Debug("auto-upgrade kubectl skipped — cluster known unreachable, using heartbeat",
+			"hive", hiveID, "cluster", cluster.ID)
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), upgradeKubectlTimeout)
+	defer cancel()
+	ns := "hive-hosted-" + hiveID
+	cmd := kubectlForClusterContext(ctx, cluster, "rollout", "restart", "deployment/hive", "-n", ns)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		s.markClusterUnreachable(cluster.ID)
+		s.logger.Warn("auto-upgrade kubectl failed, falling back to heartbeat",
+			"hive", hiveID, "cluster", cluster.ID,
+			"timeout", upgradeKubectlTimeout, "output", strings.TrimSpace(string(out)))
+		return false
+	}
+	s.markClusterReachable(cluster.ID)
+	return true
+}
+
 func (s *HubServer) triggerAutoUpgrades() {
 	hives := listSaaSHives()
 	for _, h := range hives {
@@ -3124,14 +3199,13 @@ func (s *HubServer) triggerAutoUpgrades() {
 					s.mu.Unlock()
 					hiveCluster := s.clusterForHive(&h)
 					if hiveCluster != nil && !hiveCluster.InCluster {
-						ns := "hive-hosted-" + h.ID
-						cmd := kubectlForCluster(hiveCluster, "rollout", "restart", "deployment/hive", "-n", ns)
-						if out, err := cmd.CombinedOutput(); err != nil {
-							// Expected when the hub can't reach the hive's
-							// cluster — the heartbeat fallback above handles it.
-							s.logger.Warn("stale upgrade kubectl restart failed (heartbeat fallback armed)",
-								"hive", h.ID, "output", string(out))
-						}
+						// Failure here is expected when the hub can't reach the
+						// hive's cluster; the heartbeat fallback armed above is
+						// what actually delivers the upgrade. rolloutRestartHive
+						// bounds the attempt and skips it entirely for clusters
+						// already known unreachable, so this recovery path can't
+						// re-introduce the per-hive timeout stall either.
+						s.rolloutRestartHive(hiveCluster, h.ID)
 					}
 					continue
 				}
@@ -3177,11 +3251,7 @@ func (s *HubServer) triggerAutoUpgrades() {
 			}
 		}
 		s.mu.Unlock()
-		ns := "hive-hosted-" + h.ID
-		cmd := kubectlForCluster(hiveCluster, "rollout", "restart", "deployment/hive", "-n", ns)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			s.logger.Warn("auto-upgrade kubectl failed, falling back to heartbeat",
-				"hive", h.ID, "cluster", hiveCluster.ID, "target", latestSHA, "output", string(out))
+		if !s.rolloutRestartHive(hiveCluster, h.ID) {
 			// kubectl can't reach the cluster — fall back to heartbeat-based
 			// upgrade (path 3). The next heartbeat from this hive will include
 			// UpgradeTo, causing the spoke to self-restart.

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -252,6 +252,16 @@ type HubServer struct {
 	// Key: hive ID, value: target SHA.  Cleared when the spoke reports the
 	// target SHA, proving the upgrade completed.
 	heartbeatUpgrade map[string]string
+
+	// clusterUnreachableUntil suppresses kubectl against clusters the hub has
+	// just proven it cannot route to (firewalled GPU clusters like vllm-d).
+	// Without this, triggerAutoUpgrades() paid a full dial timeout PER HIVE PER
+	// CYCLE — 15 vllm-d hives serialized into ~30 minutes of blocking, which
+	// starved the hub's own auto-upgrade check at the end of the same loop and
+	// left the hub pinned to an old SHA indefinitely. Key: cluster ID, value:
+	// the time after which kubectl may be retried.
+	clusterUnreachableUntil map[string]time.Time
+	clusterUnreachableMu    sync.Mutex
 	// heartbeatSwitchTag tracks hives that should switch their deployment
 	// image to a specific tag (branch switch) via heartbeat, for clusters
 	// the hub can't reach over kubectl. Cleared once the spoke reports it.
@@ -403,6 +413,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		heartbeatHealth:         make(map[string]*HeartbeatHealthEntry),
 		heartbeatUpgrade:        make(map[string]string),
 		heartbeatSwitchTag:      make(map[string]string),
+		clusterUnreachableUntil: make(map[string]time.Time),
 		pendingWebhooks:         make(map[string]*pendingWebhookEntry),
 		pendingGitHubAppConfigs: make(map[string]*HeartbeatGitHubAppConfig),
 		pendingGateways:         make(map[string]*HeartbeatGatewayConfig),


### PR DESCRIPTION
## Problem

The hub was not upgrading itself when a new v2 image was available. It sat on `11ab742` while `e4506c4` had already been verified pullable on GHCR at 21:22.

Root cause is **starvation, not a config or image problem**. `triggerAutoUpgrades()` runs before the hub's own self-upgrade check in the same poll cycle. For each hive on a firewalled cluster (vllm-d), it shelled out to `kubectl rollout restart` against an API server the hub cannot route to, and kubectl's default retry burned ~2 minutes per hive before failing over to the heartbeat path.

With 15 vllm-d hives, one cycle took ~30 minutes of blocking, so `rolloutHubToSHA()` at the end of the loop was reached only rarely.

The hub logs show it plainly — `audit: auto-upgrade triggered` marching in exact 2-minute steps, one hive per step:

```
21:26:24  auto-upgrade triggered   hosted-available-vllmd-02
21:28:24  kubectl failed, falling back to heartbeat   (dial tcp 169.63.181.35:6443: i/o timeout)
21:28:24  auto-upgrade triggered   hosted-available-vllmd-03
21:30:25  kubectl failed, falling back to heartbeat
21:30:25  auto-upgrade triggered   hosted-available-vllmd-04
...
```

## Fix

Two changes, both confined to the auto-upgrade poll loop:

- **Bound each attempt** with `upgradeKubectlTimeout` (15s) via `kubectlForClusterContext`, rather than inheriting kubectl's ~2 minute retry.
- **Cache dial failures per cluster** for `clusterUnreachableTTL` (10m), so a firewalled cluster is probed at most once per window instead of once per hive. A success clears the entry immediately, so a recovering cluster is not delayed.

## Notes

- Behaviour is otherwise unchanged. kubectl failure still arms the heartbeat fallback, which remains the **only** delivery path for unreachable clusters.
- A skipped attempt is reported identically to a failed one, so callers cannot mistake "known unreachable" for success.
- The stale-upgrade recovery path routes through the same helper, so it cannot reintroduce the stall.
- User-triggered handlers (manual upgrade, branch switch, provisioning) are deliberately left unbounded — they are not on the poll loop and a caller is waiting on them.

## Verification

`go build`, `go vet`, and `go test ./pkg/hub/` all pass locally (85s).

## Follow-up (not in this PR)

Still needs porting to **mk**, **dd**, and **v3**.

Separately, there is a real latent bug worth its own fix: the SHA-advance gate checks `kubestellar/hive` (spoke) while `rolloutHubToSHA` requires `kubestellar/hive-hub`. A SHA where the spoke build fails but the hub build succeeds can never be rolled to. Confirmed live for `3d30475` (spoke 404, hub 200). Not what caused this incident, but it will bite.