### PR TITLE
🐛 fix(dashboard): Config → Access tab stuck on "Loading…" forever

### DIFF
--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -12734,10 +12734,17 @@ function burnAreaChart() {
     }
 
     async function loadAuthorizedUsers() {
-      const listEl = document.getElementById('access-users-list');
-      const statusEl = document.getElementById('access-users-status');
+      // Resolve the targets AFTER the first await, never before. The caller does
+      // `body.innerHTML = renderGovernorTab(tab)`, so renderGovAccess() — and this
+      // function with it — runs while the PREVIOUS tab is still mounted. Looking
+      // the elements up synchronously captured null every time, so both the success
+      // and the catch branch wrote into nothing and the panel sat on "Loading…"
+      // forever regardless of what the API returned.
+      let listEl = null, statusEl = null;
       try {
         const r = await fetch('/api/config/authorized-users');
+        listEl = document.getElementById('access-users-list');
+        statusEl = document.getElementById('access-users-status');
         if (!r.ok) throw new Error('HTTP ' + r.status);
         const d = await r.json();
         if (statusEl) {
@@ -12759,7 +12766,11 @@ function burnAreaChart() {
             '</div>';
         }).join('');
       } catch (e) {
-        if (listEl) listEl.innerHTML = '<div style="color:var(--muted);font-size:0.75rem">Could not load authorized users.</div>';
+        // fetch() itself can reject before the lookups above ran, so re-resolve
+        // here rather than trusting listEl to be set — otherwise a network failure
+        // is indistinguishable from a hang.
+        const el = listEl || document.getElementById('access-users-list');
+        if (el) el.innerHTML = '<div style="color:var(--muted);font-size:0.75rem">Could not load authorized users.</div>';
       }
     }
 
@@ -12852,10 +12863,13 @@ function burnAreaChart() {
     }
 
     async function loadVariables() {
-      const listEl = document.getElementById('variables-list');
-      const statusEl = document.getElementById('variables-status');
+      // Same ordering hazard as loadAuthorizedUsers(): renderGovVariables() calls
+      // this before its markup is assigned into the DOM, so resolve after the await.
+      let listEl = null, statusEl = null;
       try {
         const r = await fetch('/api/config/variables');
+        listEl = document.getElementById('variables-list');
+        statusEl = document.getElementById('variables-status');
         if (!r.ok) throw new Error('HTTP ' + r.status);
         const d = await r.json();
         if (statusEl) {


### PR DESCRIPTION
## Problem

The spoke dashboard's **Config → Access** tab never loads — it sits on "Loading…" indefinitely, and shows no error either.

`renderGovAccess()` calls `loadAuthorizedUsers()`, which resolved its target elements synchronously:

```js
async function loadAuthorizedUsers() {
  const listEl = document.getElementById('access-users-list');   // ← null
  const statusEl = document.getElementById('access-users-status'); // ← null
```

But the caller does `body.innerHTML = renderGovernorTab(tab)` — the returned markup is not in the DOM until that assignment completes. So those lookups ran against the *previous* tab and captured `null` every time.

Every subsequent write was a silent no-op, **including the `catch` branch**, which is why there was no error message either.

This is a pure display bug — `/api/config/authorized-users` and the allowlist itself were working correctly.

## Fix

Resolve both elements after the first `await`, once the markup is mounted.

The `catch` block re-resolves rather than trusting the outer binding, since `fetch()` can reject before the lookups run — otherwise a genuine network failure would still be indistinguishable from a hang.

`loadVariables()` had the identical ordering hazard (same shape, same cause) and is fixed the same way.

## Follow-up

Still needs porting to **mk**, **dd**, and **v3**. Note ks/console's hive runs **v3**, so it won't be fixed there until that port lands.