### PR TITLE
feat(contribute): allow/deny mode toggle for title/author/label filters

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1068,16 +1068,31 @@ type DiscordConfig struct {
 }
 
 type HubConfig struct {
-	Enabled                       bool                `yaml:"enabled"`
-	URL                           string              `yaml:"url"`
-	IsPublic                      bool                `yaml:"is_public"`
-	SnapshotURL                   string              `yaml:"snapshot_url"`
-	DashboardURL                  string              `yaml:"dashboard_url"`
-	HiveType                      string              `yaml:"hive_type"`
-	ClusterID                     string              `yaml:"cluster_id"`
-	AutoSnapshot                  bool                `yaml:"auto_snapshot"`
-	AutoUpgrade                   bool                `yaml:"auto_upgrade"`
-	ContributeSuspended           bool                `yaml:"contribute_suspended"`
+	Enabled             bool   `yaml:"enabled"`
+	URL                 string `yaml:"url"`
+	IsPublic            bool   `yaml:"is_public"`
+	SnapshotURL         string `yaml:"snapshot_url"`
+	DashboardURL        string `yaml:"dashboard_url"`
+	HiveType            string `yaml:"hive_type"`
+	ClusterID           string `yaml:"cluster_id"`
+	AutoSnapshot        bool   `yaml:"auto_snapshot"`
+	AutoUpgrade         bool   `yaml:"auto_upgrade"`
+	ContributeSuspended bool   `yaml:"contribute_suspended"`
+	// Contribute title/author/label filters use a single list plus a mode:
+	//   - FilterModeAllow ("allow"): allowlist — an item passes ONLY if it
+	//     matches the list (a non-empty list is required for the filter to gate;
+	//     an empty allow list means "no items pass" is intentionally avoided —
+	//     see passesContributeFilter, where an empty allow list is treated as
+	//     "filter off" so a half-configured filter never silently blocks all).
+	//   - FilterModeDeny ("deny", default): denylist — an item is skipped if it
+	//     matches the list; everything else passes.
+	// The *DenyTitles/*DenyAuthors/*DenyLabels fields hold the LIST for each
+	// filter regardless of mode (names kept for backward compatibility with
+	// existing on-disk config; the mode decides allow vs deny). ContributeAllowLabels
+	// is retained only for one-time migration into DenyLabels+LabelsMode.
+	ContributeTitlesMode          string              `yaml:"contribute_titles_mode,omitempty"`
+	ContributeAuthorsMode         string              `yaml:"contribute_authors_mode,omitempty"`
+	ContributeLabelsMode          string              `yaml:"contribute_labels_mode,omitempty"`
 	ContributeAllowLabels         []string            `yaml:"contribute_allow_labels"`
 	ContributeDenyLabels          []string            `yaml:"contribute_deny_labels"`
 	ContributeDenyTitles          []string            `yaml:"contribute_deny_titles"`
@@ -1665,6 +1680,23 @@ func (c *Config) applyDefaults() {
 			"dependabot[bot]",
 			"mergeraptor[bot]",
 		}
+	}
+
+	// Contribute filter modes: default to deny (the pre-mode behavior — the
+	// *Deny* lists were always deny lists). Normalize any stored value.
+	c.Hub.ContributeTitlesMode = NormalizeFilterMode(c.Hub.ContributeTitlesMode)
+	c.Hub.ContributeAuthorsMode = NormalizeFilterMode(c.Hub.ContributeAuthorsMode)
+	c.Hub.ContributeLabelsMode = NormalizeFilterMode(c.Hub.ContributeLabelsMode)
+
+	// One-time migration of the old dual label lists into the single list+mode.
+	// If a legacy allow list was set (and no new label list/mode has been chosen
+	// yet), adopt it as an allow filter. Otherwise the deny list (if any) stands.
+	// After migration the allow list is cleared so it isn't re-applied.
+	if len(c.Hub.ContributeAllowLabels) > 0 && len(c.Hub.ContributeDenyLabels) == 0 &&
+		c.Hub.ContributeLabelsMode == FilterModeDeny {
+		c.Hub.ContributeDenyLabels = c.Hub.ContributeAllowLabels
+		c.Hub.ContributeLabelsMode = FilterModeAllow
+		c.Hub.ContributeAllowLabels = nil
 	}
 
 	if len(c.Hub.TierLimits) == 0 {
@@ -2354,4 +2386,76 @@ func MatchesAny(text string, patterns []string) bool {
 		}
 	}
 	return false
+}
+
+// Contribute filter modes for title/author/label gating.
+const (
+	// FilterModeDeny (the default) skips items that MATCH the list; everything
+	// else passes.
+	FilterModeDeny = "deny"
+	// FilterModeAllow passes ONLY items that MATCH the list; everything else is
+	// skipped. An EMPTY allow list is treated as "filter off" (see
+	// FilterPasses) so a half-configured allow filter never silently blocks
+	// every item.
+	FilterModeAllow = "allow"
+)
+
+// NormalizeFilterMode returns a valid mode, defaulting to deny for empty/unknown
+// values (backward compatible: existing config has no mode field, and its lists
+// were always deny lists).
+func NormalizeFilterMode(mode string) string {
+	if mode == FilterModeAllow {
+		return FilterModeAllow
+	}
+	return FilterModeDeny
+}
+
+// FilterPasses reports whether a single value (an issue/PR title, author, or one
+// of its labels) passes a mode+list filter.
+//
+//   - deny  mode: pass unless value matches the list.
+//   - allow mode: pass only if value matches the list; BUT an empty allow list
+//     means "not configured" → pass (never block everything on an empty list).
+//
+// Patterns use the same wildcard/regex syntax as MatchesAny.
+func FilterPasses(value string, list []string, mode string) bool {
+	switch NormalizeFilterMode(mode) {
+	case FilterModeAllow:
+		if len(list) == 0 {
+			return true // allow filter not configured → don't gate
+		}
+		return MatchesAny(value, list)
+	default: // deny
+		return !MatchesAny(value, list)
+	}
+}
+
+// LabelsFilterPasses applies a label filter across ALL of an item's labels.
+//
+//   - deny  mode: pass unless ANY label matches the deny list.
+//   - allow mode: pass only if AT LEAST ONE label matches the allow list; an
+//     empty allow list means "not configured" → pass.
+//
+// This is the label-specific counterpart to FilterPasses (labels are a set, not
+// a single scalar, so the allow/deny quantifiers differ).
+func LabelsFilterPasses(labels []string, list []string, mode string) bool {
+	switch NormalizeFilterMode(mode) {
+	case FilterModeAllow:
+		if len(list) == 0 {
+			return true // allow filter not configured → don't gate
+		}
+		for _, l := range labels {
+			if MatchesAny(l, list) {
+				return true
+			}
+		}
+		return false
+	default: // deny
+		for _, l := range labels {
+			if MatchesAny(l, list) {
+				return false
+			}
+		}
+		return true
+	}
 }

--- a/v2/pkg/config/contribute_filter_test.go
+++ b/v2/pkg/config/contribute_filter_test.go
@@ -1,0 +1,116 @@
+package config
+
+import "testing"
+
+func TestFilterPasses(t *testing.T) {
+	list := []string{"epic:*", "*dashboard*"}
+
+	cases := []struct {
+		name  string
+		value string
+		mode  string
+		want  bool
+	}{
+		// deny mode: match -> blocked, non-match -> pass.
+		{"deny match", "epic: rollout", FilterModeDeny, false},
+		{"deny wildcard match", "renovate dashboard", FilterModeDeny, false},
+		{"deny non-match", "fix login bug", FilterModeDeny, true},
+		{"empty mode defaults to deny (match)", "epic: x", "", false},
+		{"empty mode defaults to deny (non-match)", "hello", "", true},
+
+		// allow mode: only match passes.
+		{"allow match", "epic: rollout", FilterModeAllow, true},
+		{"allow non-match", "fix login bug", FilterModeAllow, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FilterPasses(tc.value, list, tc.mode); got != tc.want {
+				t.Errorf("FilterPasses(%q, list, %q) = %v, want %v", tc.value, tc.mode, got, tc.want)
+			}
+		})
+	}
+
+	// An empty ALLOW list means "filter off" — everything passes (never block all).
+	if !FilterPasses("anything", nil, FilterModeAllow) {
+		t.Error("empty allow list should pass (filter off), got blocked")
+	}
+	// An empty DENY list also passes everything.
+	if !FilterPasses("anything", nil, FilterModeDeny) {
+		t.Error("empty deny list should pass everything")
+	}
+}
+
+func TestLabelsFilterPasses(t *testing.T) {
+	list := []string{"good-first-issue", "help-wanted"}
+
+	cases := []struct {
+		name   string
+		labels []string
+		mode   string
+		want   bool
+	}{
+		// deny: pass unless ANY label matches.
+		{"deny no match", []string{"bug", "p1"}, FilterModeDeny, true},
+		{"deny one matches", []string{"bug", "help-wanted"}, FilterModeDeny, false},
+		{"deny empty labels", nil, FilterModeDeny, true},
+
+		// allow: pass only if AT LEAST ONE label matches.
+		{"allow one matches", []string{"bug", "good-first-issue"}, FilterModeAllow, true},
+		{"allow none match", []string{"bug", "p1"}, FilterModeAllow, false},
+		{"allow empty labels -> no match -> blocked", nil, FilterModeAllow, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := LabelsFilterPasses(tc.labels, list, tc.mode); got != tc.want {
+				t.Errorf("LabelsFilterPasses(%v, list, %q) = %v, want %v", tc.labels, tc.mode, got, tc.want)
+			}
+		})
+	}
+
+	// Empty allow list -> filter off -> everything passes even with no labels.
+	if !LabelsFilterPasses(nil, nil, FilterModeAllow) {
+		t.Error("empty allow label list should pass (filter off)")
+	}
+}
+
+func TestNormalizeFilterMode(t *testing.T) {
+	if NormalizeFilterMode("allow") != FilterModeAllow {
+		t.Error("allow should stay allow")
+	}
+	for _, m := range []string{"", "deny", "bogus", "DENY"} {
+		if NormalizeFilterMode(m) != FilterModeDeny {
+			t.Errorf("%q should normalize to deny", m)
+		}
+	}
+}
+
+// TestLegacyAllowLabelsMigration verifies a hive with the old dual label lists
+// (a populated allow list, no deny list, default mode) migrates to a single
+// allow-mode label filter on defaults application.
+func TestLegacyAllowLabelsMigration(t *testing.T) {
+	c := &Config{}
+	c.Hub.ContributeAllowLabels = []string{"good-first-issue"}
+	c.applyDefaults()
+
+	if c.Hub.ContributeLabelsMode != FilterModeAllow {
+		t.Errorf("labels mode = %q, want allow after migration", c.Hub.ContributeLabelsMode)
+	}
+	if len(c.Hub.ContributeDenyLabels) != 1 || c.Hub.ContributeDenyLabels[0] != "good-first-issue" {
+		t.Errorf("migrated list = %v, want [good-first-issue]", c.Hub.ContributeDenyLabels)
+	}
+	if len(c.Hub.ContributeAllowLabels) != 0 {
+		t.Errorf("allow list should be cleared after migration, got %v", c.Hub.ContributeAllowLabels)
+	}
+}
+
+// TestDefaultFilterModes verifies modes default to deny when unset.
+func TestDefaultFilterModes(t *testing.T) {
+	c := &Config{}
+	c.applyDefaults()
+	if c.Hub.ContributeTitlesMode != FilterModeDeny ||
+		c.Hub.ContributeAuthorsMode != FilterModeDeny ||
+		c.Hub.ContributeLabelsMode != FilterModeDeny {
+		t.Errorf("modes should default to deny: titles=%q authors=%q labels=%q",
+			c.Hub.ContributeTitlesMode, c.Hub.ContributeAuthorsMode, c.Hub.ContributeLabelsMode)
+	}
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -3290,6 +3290,9 @@ func (s *Server) handleGovernorConfigGet(w http.ResponseWriter, r *http.Request)
 			"auto_upgrade":                     cfg.Hub.AutoUpgrade,
 			"snapshot_interval_min":            cfg.Hub.SnapshotIntervalMin,
 			"contribute_suspended":             cfg.Hub.ContributeSuspended,
+			"contribute_titles_mode":           cfg.Hub.ContributeTitlesMode,
+			"contribute_authors_mode":          cfg.Hub.ContributeAuthorsMode,
+			"contribute_labels_mode":           cfg.Hub.ContributeLabelsMode,
 			"contribute_allow_labels":          cfg.Hub.ContributeAllowLabels,
 			"contribute_deny_labels":           cfg.Hub.ContributeDenyLabels,
 			"contribute_deny_titles":           cfg.Hub.ContributeDenyTitles,
@@ -3630,6 +3633,9 @@ func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 		AutoSnapshot                  *bool                      `json:"auto_snapshot"`
 		AutoUpgrade                   *bool                      `json:"auto_upgrade"`
 		ContributeSuspended           *bool                      `json:"contribute_suspended"`
+		ContributeTitlesMode          *string                    `json:"contribute_titles_mode"`
+		ContributeAuthorsMode         *string                    `json:"contribute_authors_mode"`
+		ContributeLabelsMode          *string                    `json:"contribute_labels_mode"`
 		ContributeAllowLabels         []string                   `json:"contribute_allow_labels"`
 		ContributeDenyLabels          []string                   `json:"contribute_deny_labels"`
 		ContributeDenyTitles          []string                   `json:"contribute_deny_titles"`
@@ -3667,6 +3673,15 @@ func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 	if body.ContributeSuspended != nil {
 		cfg.Hub.ContributeSuspended = *body.ContributeSuspended
 	}
+	if body.ContributeTitlesMode != nil {
+		cfg.Hub.ContributeTitlesMode = *body.ContributeTitlesMode
+	}
+	if body.ContributeAuthorsMode != nil {
+		cfg.Hub.ContributeAuthorsMode = *body.ContributeAuthorsMode
+	}
+	if body.ContributeLabelsMode != nil {
+		cfg.Hub.ContributeLabelsMode = *body.ContributeLabelsMode
+	}
 	if body.ContributeAllowLabels != nil {
 		cfg.Hub.ContributeAllowLabels = body.ContributeAllowLabels
 	}
@@ -3694,6 +3709,12 @@ func (s *Server) handleGovernorHub(w http.ResponseWriter, r *http.Request) {
 	if body.TierLimits != nil {
 		cfg.Hub.TierLimits = body.TierLimits
 	}
+	// Normalize any client-supplied filter mode to a valid value (unknown/empty
+	// -> deny), so a bad payload can't leave a mode that silently changes
+	// enforcement in an unexpected way.
+	cfg.Hub.ContributeTitlesMode = config.NormalizeFilterMode(cfg.Hub.ContributeTitlesMode)
+	cfg.Hub.ContributeAuthorsMode = config.NormalizeFilterMode(cfg.Hub.ContributeAuthorsMode)
+	cfg.Hub.ContributeLabelsMode = config.NormalizeFilterMode(cfg.Hub.ContributeLabelsMode)
 	s.auditFromRequest(r, "config_governor_hub", auditDetail("section", "hub"), "")
 	s.refreshAndPersist()
 	okResponse(w, map[string]string{"status": "updated"})

--- a/v2/pkg/dashboard/contribute_ws.go
+++ b/v2/pkg/dashboard/contribute_ws.go
@@ -41,16 +41,16 @@ var wsUpgrader = websocket.Upgrader{
 }
 
 type ContributorConnection struct {
-	ws           *websocket.Conn
-	profile      *ContributorProfile
-	cliBackend   string
-	model        string
-	role         string // empty = task-driven mode, "scanner"/"reviewer"/etc. = role mode
-	connectedAt  time.Time
-	currentTask  *WSTaskAssign
-	lastPong     time.Time
-	tmuxOutput   []string
-	mu           sync.Mutex
+	ws          *websocket.Conn
+	profile     *ContributorProfile
+	cliBackend  string
+	model       string
+	role        string // empty = task-driven mode, "scanner"/"reviewer"/etc. = role mode
+	connectedAt time.Time
+	currentTask *WSTaskAssign
+	lastPong    time.Time
+	tmuxOutput  []string
+	mu          sync.Mutex
 }
 
 type WSMessage struct {
@@ -105,12 +105,12 @@ type ActivityEntry struct {
 }
 
 type ContributeWSHub struct {
-	connections map[string]*ContributorConnection
-	mu          sync.RWMutex
-	logger      *slog.Logger
-	seq         int
-	activityMu  sync.RWMutex
-	activity    []ActivityEntry
+	connections    map[string]*ContributorConnection
+	mu             sync.RWMutex
+	logger         *slog.Logger
+	seq            int
+	activityMu     sync.RWMutex
+	activity       []ActivityEntry
 	server         *Server
 	completedTasks map[string]time.Time
 	completedMu    sync.Mutex
@@ -210,9 +210,13 @@ func (h *ContributeWSHub) loadCompletedTasks() {
 	h.completedMu.Lock()
 	defer h.completedMu.Unlock()
 	data, err := os.ReadFile(completedTasksFile)
-	if err != nil { return }
+	if err != nil {
+		return
+	}
 	var saved map[string]string
-	if json.Unmarshal(data, &saved) != nil { return }
+	if json.Unmarshal(data, &saved) != nil {
+		return
+	}
 	for k, v := range saved {
 		if t, err := time.Parse(time.RFC3339, v); err == nil {
 			if time.Since(t) < completedTaskCooldownHours*time.Hour {
@@ -226,7 +230,9 @@ func (h *ContributeWSHub) loadCompletedTasks() {
 func (h *ContributeWSHub) saveCompletedTasks() {
 	h.completedMu.Lock()
 	saved := make(map[string]string, len(h.completedTasks))
-	for k, t := range h.completedTasks { saved[k] = t.Format(time.RFC3339) }
+	for k, t := range h.completedTasks {
+		saved[k] = t.Format(time.RFC3339)
+	}
 	h.completedMu.Unlock()
 	data, err := json.Marshal(saved)
 	if err != nil {
@@ -845,14 +851,18 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 			title, _ := issue["title"].(string)
 			url, _ := issue["url"].(string)
 			author, _ := issue["author"].(string)
+			labels := stringSliceFromAny(issue["labels"])
 
-			var denyTitles, denyAuthors []string
+			// Apply the title / author / label contribute filters. Each is a
+			// single list plus a mode (allow = only matching pass; deny = matching
+			// skipped). Labels were previously not enforced at all.
 			if h.server.deps != nil && h.server.deps.Config != nil {
-				denyTitles = h.server.deps.Config.Hub.ContributeDenyTitles
-				denyAuthors = h.server.deps.Config.Hub.ContributeDenyAuthors
-			}
-			if config.MatchesAny(title, denyTitles) || config.MatchesAny(author, denyAuthors) {
-				continue
+				hub := h.server.deps.Config.Hub
+				if !config.FilterPasses(title, hub.ContributeDenyTitles, hub.ContributeTitlesMode) ||
+					!config.FilterPasses(author, hub.ContributeDenyAuthors, hub.ContributeAuthorsMode) ||
+					!config.LabelsFilterPasses(labels, hub.ContributeDenyLabels, hub.ContributeLabelsMode) {
+					continue
+				}
 			}
 
 			ghToken := ""
@@ -915,7 +925,23 @@ func (h *ContributeWSHub) selectTask(c *ContributorConnection) *WSMessage {
 	return nil
 }
 
+// stringSliceFromAny coerces a JSON-decoded value (from an issue map marshaled
+// via encoding/json) into a []string. Labels arrive as []any of strings; any
+// non-string elements are skipped. Returns nil for a missing/other-typed value.
+func stringSliceFromAny(v any) []string {
+	items, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		if s, ok := it.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
 func sendJSON(conn *websocket.Conn, msg WSMessage) error {
 	return conn.WriteJSON(msg)
 }
-

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -13490,12 +13490,15 @@ function burnAreaChart() {
         return {name: name, full: r, enabled: enabled};
       });
       const tiers = ['newcomer', 'contributor', 'trusted', 'advisor'];
-      const allowLabels = (hub.contribute_allow_labels || []);
       const denyLabels = (hub.contribute_deny_labels || []);
       const denyTitles = (hub.contribute_deny_titles || []);
       const denyAuthors = (hub.contribute_deny_authors || []);
       const allowModels = (hub.contribute_allow_models || []);
       const rejectUnknownModels = hub.contribute_reject_unknown_models || false;
+      // Filter modes: 'allow' = only matching pass; 'deny' (default) = matching skipped.
+      const titlesMode = (hub.contribute_titles_mode === 'allow') ? 'allow' : 'deny';
+      const authorsMode = (hub.contribute_authors_mode === 'allow') ? 'allow' : 'deny';
+      const labelsMode = (hub.contribute_labels_mode === 'allow') ? 'allow' : 'deny';
       return `
         <div class="config-toggle">
           <div class="config-toggle-switch ${hub.enabled ? 'on' : ''}" data-action="toggleConfigSwitch" data-section="hub" data-key="enabled"></div>
@@ -13533,17 +13536,19 @@ function burnAreaChart() {
           <span class="config-toggle-label" style="${hub.contribute_suspended ? 'color:var(--red);font-weight:600' : ''}">Suspend Contributions <span class="config-info">i<span class="config-tooltip">Temporarily stop assigning tasks to contributors. Connected contributors stay online but idle.</span></span></span>
         </div>
 
-        <div class="config-field">
-          <label>Deny Titles <span class="config-info">i<span class="config-tooltip">Issues matching these title patterns are excluded. Supports wildcards (*) and regex (/pattern/).</span></span></label>
-          <div id="hub-deny-titles" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">${denyTitles.map(function(t) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(248,81,73,0.15);color:var(--red);border:1px solid rgba(248,81,73,0.3)">' + esc(t) + ' <span onclick="removeHubFilter(\'contribute_deny_titles\',\'' + esc(t).replace(/'/g,"\\'") + '\')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('')}</div>
-          <div style="display:flex;gap:4px"><input type="text" id="hub-deny-title-input" placeholder="e.g. *dashboard*, epic:*, /renovate/i" style="flex:1" onkeydown="if(event.key==='Enter'){addHubFilter('contribute_deny_titles','hub-deny-title-input');event.preventDefault()}"><button onclick="addHubFilter('contribute_deny_titles','hub-deny-title-input')" style="padding:4px 12px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer;font-size:0.75rem">Add</button></div>
-        </div>
+        ${renderFilterWithMode({
+          label: 'Titles', noun: 'title', unit: 'issue',
+          modeKey: 'contribute_titles_mode', listKey: 'contribute_deny_titles',
+          mode: titlesMode, list: denyTitles, inputId: 'hub-deny-title-input',
+          placeholder: 'e.g. *dashboard*, epic:*, /renovate/i'
+        })}
 
-        <div class="config-field">
-          <label>Deny Authors <span class="config-info">i<span class="config-tooltip">Issues from these authors are excluded. Supports wildcards (*) and regex (/pattern/).</span></span></label>
-          <div id="hub-deny-authors" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">${denyAuthors.map(function(a) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(248,81,73,0.15);color:var(--red);border:1px solid rgba(248,81,73,0.3)">' + esc(a) + ' <span onclick="removeHubFilter(\'contribute_deny_authors\',\'' + esc(a).replace(/'/g,"\\'") + '\')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('')}</div>
-          <div style="display:flex;gap:4px"><input type="text" id="hub-deny-author-input" placeholder="e.g. renovate[bot], dependabot*" style="flex:1" onkeydown="if(event.key==='Enter'){addHubFilter('contribute_deny_authors','hub-deny-author-input');event.preventDefault()}"><button onclick="addHubFilter('contribute_deny_authors','hub-deny-author-input')" style="padding:4px 12px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer;font-size:0.75rem">Add</button></div>
-        </div>
+        ${renderFilterWithMode({
+          label: 'Authors', noun: 'author', unit: 'issue',
+          modeKey: 'contribute_authors_mode', listKey: 'contribute_deny_authors',
+          mode: authorsMode, list: denyAuthors, inputId: 'hub-deny-author-input',
+          placeholder: 'e.g. renovate[bot], dependabot*'
+        })}
 
         <hr style="border-color:var(--border);margin:16px 0">
         <h4 style="font-size:0.8rem;color:var(--muted);margin:0 0 8px">Model Filter ${allowModels.length === 0 ? '<span style="font-weight:400;color:var(--green);margin-left:8px">All models accepted</span>' : '<span style="font-weight:400;color:var(--blue);margin-left:8px">' + allowModels.length + ' pattern' + (allowModels.length > 1 ? 's' : '') + '</span>'}</h4>
@@ -13569,17 +13574,12 @@ function burnAreaChart() {
 
         <hr style="border-color:var(--border);margin:16px 0">
 
-        <div class="config-field">
-          <label>Allow Labels <span class="config-info">i<span class="config-tooltip">Only issues with these labels will be queued for contributors. Leave empty to allow all.</span></span></label>
-          <div id="hub-allow-labels" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">${allowLabels.map(function(l) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(34,197,94,0.15);color:var(--green);border:1px solid rgba(34,197,94,0.3)">' + esc(l) + ' <span onclick="removeHubLabel(\'allow\',' + "'" + esc(l) + "'" + ')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('')}</div>
-          <div style="display:flex;gap:4px"><input type="text" id="hub-allow-label-input" placeholder="e.g. good-first-issue, help-wanted" style="flex:1" onkeydown="if(event.key==='Enter'){addHubLabel('allow');event.preventDefault()}"><button onclick="addHubLabel('allow')" style="padding:4px 12px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer;font-size:0.75rem">Add</button></div>
-        </div>
-
-        <div class="config-field">
-          <label>Deny Labels <span class="config-info">i<span class="config-tooltip">Issues with these labels will never be queued for contributors.</span></span></label>
-          <div id="hub-deny-labels" style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">${denyLabels.map(function(l) { return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:rgba(248,81,73,0.15);color:var(--red);border:1px solid rgba(248,81,73,0.3)">' + esc(l) + ' <span onclick="removeHubLabel(\'deny\',' + "'" + esc(l) + "'" + ')" style="cursor:pointer;opacity:0.7">✕</span></span>'; }).join('')}</div>
-          <div style="display:flex;gap:4px"><input type="text" id="hub-deny-label-input" placeholder="e.g. hold, wontfix, duplicate" style="flex:1" onkeydown="if(event.key==='Enter'){addHubLabel('deny');event.preventDefault()}"><button onclick="addHubLabel('deny')" style="padding:4px 12px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer;font-size:0.75rem">Add</button></div>
-        </div>
+        ${renderFilterWithMode({
+          label: 'Labels', noun: 'label', unit: 'issue', perLabel: true,
+          modeKey: 'contribute_labels_mode', listKey: 'contribute_deny_labels',
+          mode: labelsMode, list: denyLabels, inputId: 'hub-deny-label-input',
+          placeholder: 'e.g. good-first-issue, help-wanted'
+        })}
 
         <div class="config-field">
           <label>Repos for Contribute <span class="config-info">i<span class="config-tooltip">Toggle which repos serve work to contributors. New repos default to on.</span></span></label>
@@ -13637,26 +13637,57 @@ function burnAreaChart() {
       }
     }
 
-    function addHubLabel(type) {
-      var input = document.getElementById('hub-' + type + '-label-input');
-      var val = (input.value || '').trim();
-      if (!val) return;
-      var key = type === 'allow' ? 'contribute_allow_labels' : 'contribute_deny_labels';
-      if (!_configState.data.hub) _configState.data.hub = {};
-      if (!_configState.data.hub[key]) _configState.data.hub[key] = [];
-      if (_configState.data.hub[key].indexOf(val) === -1) {
-        _configState.data.hub[key].push(val);
-        markDirty('hub', key, _configState.data.hub[key]);
+    // renderFilterWithMode renders one contribute filter as a mode toggle
+    // (Allow only / Deny) plus a single list of patterns — the well-known
+    // allowlist/denylist pattern. cfg: {label, noun, unit, modeKey, listKey,
+    // mode, list, inputId, placeholder, perLabel}. In allow mode the chips are
+    // green and the helper says only-these pass; in deny mode they're red and
+    // the helper says these-are-skipped. perLabel tweaks the copy for labels
+    // (a set) vs a scalar title/author.
+    function renderFilterWithMode(cfg) {
+      var isAllow = cfg.mode === 'allow';
+      var chipBg = isAllow ? 'rgba(34,197,94,0.15)' : 'rgba(248,81,73,0.15)';
+      var chipColor = isAllow ? 'var(--green)' : 'var(--red)';
+      var chipBorder = isAllow ? 'rgba(34,197,94,0.3)' : 'rgba(248,81,73,0.3)';
+      var help;
+      if (isAllow) {
+        help = cfg.perLabel
+          ? 'Only ' + cfg.unit + 's carrying one of these labels are worked; everything else is skipped.'
+          : 'Only ' + cfg.unit + 's whose ' + cfg.noun + ' matches are worked; everything else is skipped.';
+        if ((cfg.list || []).length === 0) help += ' (List is empty — filter is off until you add a pattern.)';
+      } else {
+        help = cfg.perLabel
+          ? cfg.unit.charAt(0).toUpperCase() + cfg.unit.slice(1) + 's carrying any of these labels are skipped; everything else is worked.'
+          : cfg.unit.charAt(0).toUpperCase() + cfg.unit.slice(1) + 's whose ' + cfg.noun + ' matches are skipped; everything else is worked.';
       }
-      input.value = '';
-      renderConfigTab('Hub');
+      function seg(m, text) {
+        var on = cfg.mode === m;
+        return '<button onclick="setHubFilterMode(\'' + cfg.modeKey + '\',\'' + m + '\')" ' +
+          'style="padding:3px 12px;border:1px solid var(--border);cursor:pointer;font-size:0.72rem;' +
+          (m === 'allow' ? 'border-radius:6px 0 0 6px;' : 'border-radius:0 6px 6px 0;border-left:none;') +
+          (on ? 'background:' + (m === 'allow' ? 'var(--green)' : 'var(--red)') + ';color:#fff;font-weight:600;' : 'background:var(--bg);color:var(--muted);') +
+          '">' + text + '</button>';
+      }
+      var chips = (cfg.list || []).map(function(v) {
+        return '<span style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:9999px;font-size:0.72rem;background:' + chipBg + ';color:' + chipColor + ';border:1px solid ' + chipBorder + '">' +
+          esc(v) + ' <span onclick="removeHubFilter(\'' + cfg.listKey + '\',\'' + esc(v).replace(/'/g, "\\'") + '\')" style="cursor:pointer;opacity:0.7">✕</span></span>';
+      }).join('');
+      return '<div class="config-field">' +
+        '<label>' + cfg.label + ' <span class="config-info">i<span class="config-tooltip">Choose a mode, then add patterns. Supports wildcards (*) and regex (/pattern/).</span></span></label>' +
+        '<div style="display:inline-flex;margin-bottom:6px">' + seg('allow', 'Allow only these') + seg('deny', 'Deny these') + '</div>' +
+        '<div style="font-size:0.68rem;color:var(--muted);margin-bottom:6px">' + help + '</div>' +
+        '<div style="display:flex;flex-wrap:wrap;gap:4px;margin-bottom:4px">' + chips + '</div>' +
+        '<div style="display:flex;gap:4px"><input type="text" id="' + cfg.inputId + '" placeholder="' + cfg.placeholder + '" style="flex:1" ' +
+          'onkeydown="if(event.key===\'Enter\'){addHubFilter(\'' + cfg.listKey + '\',\'' + cfg.inputId + '\');event.preventDefault()}">' +
+          '<button onclick="addHubFilter(\'' + cfg.listKey + '\',\'' + cfg.inputId + '\')" style="padding:4px 12px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--muted);cursor:pointer;font-size:0.75rem">Add</button></div>' +
+        '</div>';
     }
 
-    function removeHubLabel(type, label) {
-      var key = type === 'allow' ? 'contribute_allow_labels' : 'contribute_deny_labels';
-      if (!_configState.data.hub || !_configState.data.hub[key]) return;
-      _configState.data.hub[key] = _configState.data.hub[key].filter(function(l) { return l !== label; });
-      markDirty('hub', key, _configState.data.hub[key]);
+    // setHubFilterMode switches a filter between allow and deny mode.
+    function setHubFilterMode(modeKey, mode) {
+      if (!_configState.data.hub) _configState.data.hub = {};
+      _configState.data.hub[modeKey] = mode;
+      markDirty('hub', modeKey, mode);
       renderConfigTab('Hub');
     }
 


### PR DESCRIPTION
## Problem

The contribute work-queue filters were inconsistent and incomplete:
- **Titles / Authors** were deny-only.
- **Labels** had TWO lists (Allow + Deny) that were stored and shown in the UI but **never actually enforced** — no code applied them.

So there was no way to express the common case: **"work only issues with label X, skip everything else."**

## Solution — one well-known pattern, applied consistently

Unify all three filters on the **allowlist/denylist mode toggle** (the pattern firewalls, NetworkPolicy, and CI path filters use): a single list plus a mode.

- **allow**: an item passes ONLY if it matches. An empty allow list = "filter off" (never silently blocks everything).
- **deny** (default): an item is skipped if it matches; everything else passes.

### UI
Replaces the confusing dual allow/deny label lists (and the deny-only title/author fields) with **one reusable mode-toggle component**:
- a segmented **`Allow only these` / `Deny these`** control,
- a single chip list that's **green in allow mode, red in deny mode**,
- **dynamic helper text** spelling out exactly what the current mode does.

### Backend
- `config`: `Contribute{Titles,Authors,Labels}Mode`; `FilterPasses` (scalar) + `LabelsFilterPasses` (label set) + `NormalizeFilterMode`; **one-time migration** of any legacy allow-labels list into the single list + allow mode. Existing deny-titles/authors config keeps working (defaults to deny).
- `contribute_ws`: actually **enforce the label filter** (was ignored) and apply all three with mode in the queue selector.
- `api`: read/write the three mode fields; normalize on save.

## Tests
`FilterPasses`/`LabelsFilterPasses` across allow + deny + empty-list cases, mode normalization, and the legacy allow-labels migration. Full `pkg/config` + `pkg/dashboard` suites green.

v2 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)