### PR TITLE
🐛 fix(spoke): SHA-pinned hives restart-looped forever instead of upgrading

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1838,11 +1838,24 @@ func main() {
 				}
 			}, targetSHA, logger)
 
-			if err := hub.RolloutRestartSelf(logger); err != nil {
-				logger.Warn("rolling restart failed, falling back to os.Exit",
-					"error", err,
-				)
-				os.Exit(0)
+			// A plain rollout restart only advances a deployment tracking a
+			// MUTABLE tag. On a SHA-pinned deployment it relaunches the very
+			// same image, so the hive reports the old hash and the hub re-sends
+			// this upgrade every heartbeat — a restart loop that never lands.
+			// UpgradeSelfToSHA patches the image instead when we are pinned.
+			needsRestart, err := hub.UpgradeSelfToSHA(logger, targetSHA)
+			if err != nil {
+				logger.Warn("pinned-image upgrade failed, falling back to rolling restart",
+					"target", targetSHA, "error", err)
+				needsRestart = true
+			}
+			if needsRestart {
+				if err := hub.RolloutRestartSelf(logger); err != nil {
+					logger.Warn("rolling restart failed, falling back to os.Exit",
+						"error", err,
+					)
+					os.Exit(0)
+				}
 			}
 			// Rolling restart initiated — K8s will start a new pod and
 			// send SIGTERM to this one once the replacement is Ready.

--- a/v2/pkg/hub/pinned_upgrade_test.go
+++ b/v2/pkg/hub/pinned_upgrade_test.go
@@ -1,0 +1,34 @@
+package hub
+
+import "testing"
+
+// TestImageTagIsMutable pins which image references a rollout restart can
+// actually advance. Getting this wrong in the "mutable" direction is the
+// expensive one: a SHA-pinned hive would restart forever without ever changing
+// image (the torch-spyre failure), so anything uncertain must classify as
+// immutable and take the image-patch path.
+func TestImageTagIsMutable(t *testing.T) {
+	cases := []struct {
+		image string
+		want  bool
+		why   string
+	}{
+		{"ghcr.io/kubestellar/hive:v2-latest", true, "mutable branch tag"},
+		{"ghcr.io/kubestellar/hive:v3-latest", true, "mutable branch tag"},
+		{"ghcr.io/kubestellar/hive:mk-latest", true, "personal branch tag is republished too"},
+		{"ghcr.io/kubestellar/hive:63d8902", false, "SHA pin — restart is a no-op"},
+		{"ghcr.io/kubestellar/hive:v2.1.0", false, "release tag is immutable"},
+		{"ghcr.io/kubestellar/hive@sha256:abc123", false, "digest pin"},
+		{"ghcr.io/kubestellar/hive", false, "no tag — do not guess"},
+		{"", false, "empty"},
+		// Registry ports must not be mistaken for tags.
+		{"registry.internal:5000/kubestellar/hive", false, "port, not a tag"},
+		{"registry.internal:5000/kubestellar/hive:v2-latest", true, "port plus mutable tag"},
+		{"registry.internal:5000/kubestellar/hive:63d8902", false, "port plus SHA pin"},
+	}
+	for _, c := range cases {
+		if got := imageTagIsMutable(c.image); got != c.want {
+			t.Errorf("imageTagIsMutable(%q) = %v, want %v (%s)", c.image, got, c.want, c.why)
+		}
+	}
+}

--- a/v2/pkg/hub/self_upgrade.go
+++ b/v2/pkg/hub/self_upgrade.go
@@ -103,6 +103,107 @@ func SwitchImageSelf(logger *slog.Logger, image string) error {
 	return nil
 }
 
+// mutableTagSuffix marks image tags that CI republishes in place (v2-latest,
+// v3-latest, mk-latest, ...). A restart re-pulls those and lands on the new
+// build; any other tag is an immutable SHA pin where a restart is a no-op.
+const mutableTagSuffix = "-latest"
+
+// imageTagIsMutable reports whether restarting the pod can pick up new code for
+// this image reference. Digest pins (@sha256:...) and SHA tags never can.
+func imageTagIsMutable(image string) bool {
+	if image == "" || strings.Contains(image, "@") {
+		return false
+	}
+	// Only the part after the LAST colon is a tag, and only if it has no slash
+	// after it — otherwise it's a registry port (host:5000/repo).
+	idx := strings.LastIndex(image, ":")
+	if idx < 0 || strings.Contains(image[idx+1:], "/") {
+		return false // no tag at all — implicitly :latest, but don't guess
+	}
+	return strings.HasSuffix(image[idx+1:], mutableTagSuffix)
+}
+
+// UpgradeSelfToSHA moves this pod onto targetSHA and returns whether a restart
+// still has to be triggered by the caller.
+//
+// A `rollout restart` only picks up new code when the deployment tracks a
+// MUTABLE tag (v2-latest and friends), because the restart re-pulls the same
+// tag. A hive pinned to an immutable SHA tag restarts straight back onto the
+// identical image, reports the same git hash, and gets told to upgrade again on
+// the next heartbeat — an endless restart loop that never advances. torch-spyre
+// sat on 63d8902 cycling pods this way while the hub re-sent e4506c4 every beat.
+//
+// So: patch the image when pinned, restart when mutable. Returns needsRestart
+// false when the image patch itself rolls the deployment.
+func UpgradeSelfToSHA(logger *slog.Logger, targetSHA string) (needsRestart bool, err error) {
+	current, err := selfDeploymentImage()
+	if err != nil {
+		// Can't tell which kind of tag we're on. A restart is the safe default:
+		// it is correct for mutable tags (the common case) and merely useless —
+		// never harmful — on a pin.
+		logger.Warn("could not read own deployment image, defaulting to rollout restart",
+			"error", err)
+		return true, nil
+	}
+	if imageTagIsMutable(current) {
+		return true, nil
+	}
+	// Pinned. Rewrite the tag in place so the registry/repo (which may be a
+	// mirror or a private registry) is preserved — only the tag changes.
+	idx := strings.LastIndex(current, ":")
+	if idx < 0 {
+		return true, nil
+	}
+	newImage := current[:idx+1] + targetSHA
+	if newImage == current {
+		return false, nil // already there; nothing to do
+	}
+	logger.Info("upgrading a SHA-pinned deployment by image patch, not restart",
+		"from", current, "to", newImage)
+	if err := SwitchImageSelf(logger, newImage); err != nil {
+		return false, fmt.Errorf("patching pinned image to %s: %w", newImage, err)
+	}
+	// SwitchImageSelf's patch changes the pod template, which rolls the
+	// deployment on its own — a restart on top would be redundant.
+	return false, nil
+}
+
+// selfDeploymentImage returns the image of this pod's own Deployment's first
+// container, via the in-cluster API.
+func selfDeploymentImage() (string, error) {
+	ns, err := os.ReadFile(k8sNamespacePath)
+	if err != nil {
+		return "", fmt.Errorf("reading namespace: %w", err)
+	}
+	namespace := strings.TrimSpace(string(ns))
+	if namespace == "" {
+		return "", fmt.Errorf("empty namespace from %s", k8sNamespacePath)
+	}
+	path := fmt.Sprintf("/apis/apps/v1/namespaces/%s/deployments/%s", namespace, selfUpgradeDeployName)
+	body, err := k8sAPIGet(path)
+	if err != nil {
+		return "", err
+	}
+	var dep struct {
+		Spec struct {
+			Template struct {
+				Spec struct {
+					Containers []struct {
+						Image string `json:"image"`
+					} `json:"containers"`
+				} `json:"spec"`
+			} `json:"template"`
+		} `json:"spec"`
+	}
+	if err := json.Unmarshal(body, &dep); err != nil {
+		return "", err
+	}
+	if len(dep.Spec.Template.Spec.Containers) == 0 {
+		return "", fmt.Errorf("deployment %s/%s has no containers", namespace, selfUpgradeDeployName)
+	}
+	return dep.Spec.Template.Spec.Containers[0].Image, nil
+}
+
 type deploymentContainerNames struct {
 	containers     []string
 	initContainers []string


### PR DESCRIPTION
## Problem

The heartbeat upgrade path called `RolloutRestartSelf()` unconditionally.

A `rollout restart` only picks up new code when the deployment tracks a **mutable** tag (`v2-latest` and friends) — the restart re-pulls the same tag and lands on the new build.

On a deployment pinned to an **immutable SHA tag**, the restart relaunches the very same image. The hive comes back reporting the old git hash, the hub sees it still behind and re-sends `UpgradeTo` on the next heartbeat, and the pod cycles again. Forever, without ever advancing.

**torch-spyre hit exactly this.** Pinned to `ghcr.io/kubestellar/hive:63d8902`, three pods cycled in six minutes while the hub re-sent `e4506c4` every beat:

```
22:06:30  heartbeat: instructing hub-managed hive to upgrade  from=63d8902 to=e4506c4
22:07:40  heartbeat: instructing hub-managed hive to upgrade  from=63d8902 to=e4506c4
22:08:57  heartbeat: instructing hub-managed hive to upgrade  from=63d8902 to=e4506c4
```

…and the deployment image never moved. `rollout status` even reported *"successfully rolled out"* each time, because the restart genuinely succeeded — it just accomplished nothing.

It was the only SHA-pinned hive on vllm-d, which is why it was the only one visibly stuck. Every other hive there rides a `*-latest` tag.

## Fix

Add `UpgradeSelfToSHA`: read the deployment's own image, and **patch the tag** via the existing `SwitchImageSelf` when pinned, rather than restarting. Mutable-tag hives keep the existing restart behaviour.

The registry and repo are preserved (only the tag is rewritten), so mirrors and private registries keep working.

## Safety

Failure modes deliberately favour the old path:

- If the deployment image can't be read → rolling restart. Correct for mutable tags (the common case), merely useless — never harmful — on a pin.
- If the reference has no tag to rewrite → rolling restart.
- If the image patch fails → rolling restart.

`imageTagIsMutable` treats digest pins, release tags, and untagged references as **immutable**, and is careful not to read a registry port (`host:5000/repo`) as a tag. Anything uncertain classifies as immutable, since the costly direction of a wrong answer is the restart loop above.

## Tests

`TestImageTagIsMutable` covers branch tags, SHA pins, release tags, digest pins, untagged refs, and the registry-port cases. Full `./pkg/hub/` suite passes.

## Note

This does not by itself unstick torch-spyre — the running pod has to reach a build containing this fix. Its deployment likely needs a one-time manual bump to `e4506c4`, after which the mechanism is self-sustaining.

## Follow-up

Still needs porting to **mk**, **dd**, and **v3**.