### PR TITLE
🐛 fix(hub): hub upgrade target was gated on the SPOKE image, not the hub image

### DIFF
--- a/v2/pkg/hub/hub_upgrade_state_test.go
+++ b/v2/pkg/hub/hub_upgrade_state_test.go
@@ -10,15 +10,38 @@ import (
 )
 
 // setV2Latest seeds the verified latest SHA for v2 and restores it afterward.
+// Both the spoke and hub caches are seeded: the spoke cache drives hive upgrade
+// targets, the hub cache drives the hub's own. They are separate because the two
+// images are separate builds, but tests that don't care about that distinction
+// want them in agreement — see setV2HubLatest for the divergent case.
 func setV2Latest(t *testing.T, sha string) {
 	t.Helper()
 	latestSHAMu.Lock()
 	old := latestSHAByBranch["v2"]
+	oldHub := latestHubSHAByBranch["v2"]
 	latestSHAByBranch["v2"] = branchSHAInfo{SHA: sha}
+	latestHubSHAByBranch["v2"] = branchSHAInfo{SHA: sha}
 	latestSHAMu.Unlock()
 	t.Cleanup(func() {
 		latestSHAMu.Lock()
 		latestSHAByBranch["v2"] = old
+		latestHubSHAByBranch["v2"] = oldHub
+		latestSHAMu.Unlock()
+	})
+}
+
+// setV2HubLatest seeds ONLY the hub-image cache for v2, leaving the spoke cache
+// untouched, so a test can reproduce the case this split exists for: the hub
+// image published for a SHA whose spoke image did not.
+func setV2HubLatest(t *testing.T, sha string) {
+	t.Helper()
+	latestSHAMu.Lock()
+	old := latestHubSHAByBranch["v2"]
+	latestHubSHAByBranch["v2"] = branchSHAInfo{SHA: sha}
+	latestSHAMu.Unlock()
+	t.Cleanup(func() {
+		latestSHAMu.Lock()
+		latestHubSHAByBranch["v2"] = old
 		latestSHAMu.Unlock()
 	})
 }
@@ -131,5 +154,33 @@ func TestRolloutHubToSHAContainerName(t *testing.T) {
 	}
 	if strings.Contains(args, hubDeploymentName+"=ghcr.io/") {
 		t.Errorf("set image wrongly used the DEPLOYMENT name as the container: %q", strings.TrimSpace(args))
+	}
+}
+
+// TestHubUpgradeStateUsesHubImageNotSpokeImage pins the split between the two
+// GHCR repos. The hub and spoke images are separate builds that can succeed
+// independently for the same commit; gating the hub's upgrade target on the
+// SPOKE image meant a SHA whose spoke build failed was invisible to the hub,
+// which then reported "current" against a stale target and never rolled.
+func TestHubUpgradeStateUsesHubImageNotSpokeImage(t *testing.T) {
+	setAutoUpgrade(t, false)
+
+	// Spoke image stuck on an older SHA (its build failed for the newer one),
+	// hub image already published for the newer SHA.
+	setV2Latest(t, "aaaaaaa")
+	setV2HubLatest(t, "bbbbbbb")
+
+	// Hub is running the older SHA. It must see itself as behind the SHA whose
+	// HUB image exists, not "current" against the stale spoke-gated value.
+	s := &HubServer{logger: slog.Default(), hubGitBranch: "v2", hubGitHash: "aaaaaaa"}
+	if got := s.hubUpgradeState(); got != "behind" {
+		t.Errorf("hub behind on hub-image SHA -> %q, want behind", got)
+	}
+
+	// And once it is running that SHA, it is current — even though the spoke
+	// cache still trails.
+	s.hubGitHash = "bbbbbbb"
+	if got := s.hubUpgradeState(); got != "current" {
+		t.Errorf("hub at hub-image SHA -> %q, want current", got)
 	}
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -2024,7 +2024,7 @@ func (s *HubServer) handleHubAutoUpgrade(w http.ResponseWriter, r *http.Request)
 
 	// If enabling and hub is behind, trigger immediately
 	if body.AutoUpgrade {
-		latestSHA := getLatestSHAForBranch(s.hubGitBranch)
+		latestSHA := getLatestHubSHAForBranch(s.hubGitBranch)
 		if latestSHA != "" && !sameCommit(latestSHA, s.hubGitHash) {
 			s.logger.Info("audit: hub auto-upgrade initial trigger", "from", s.hubGitHash, "to", latestSHA)
 			// Route through rolloutHubToSHA so this shares the hub-image gate and
@@ -2082,7 +2082,10 @@ func (s *HubServer) rolloutHubToSHA(sha string) error {
 // admin-clicked rollout ("upgrading") from everything else ("queued"), so an
 // AUTO rollout in progress showed a misleading "queued".
 func (s *HubServer) hubUpgradeState() string {
-	latest := getLatestSHAForBranch(s.hubGitBranch)
+	// Gate the badge on the HUB image, matching what rolloutHubToSHA can
+	// actually roll to — otherwise the UI shows "behind"/"queued" against a
+	// target the hub is incapable of reaching.
+	latest := getLatestHubSHAForBranch(s.hubGitBranch)
 	if latest == "" {
 		return "unknown"
 	}
@@ -2104,7 +2107,7 @@ func (s *HubServer) hubUpgradeState() string {
 
 func (s *HubServer) handleHubSelfUpgrade(w http.ResponseWriter, r *http.Request) {
 	username := s.getAuthUser(r)
-	target := getLatestSHAForBranch(s.hubGitBranch)
+	target := getLatestHubSHAForBranch(s.hubGitBranch)
 	s.logger.Info("audit: hub self-upgrade triggered", "by", username, "to", target)
 	if err := s.rolloutHubToSHA(target); err != nil {
 		s.logger.Warn("hub self-upgrade failed", "error", err)
@@ -2560,6 +2563,14 @@ var (
 	// latestSHAByBranch only ever advances to SHAs whose container image is
 	// verified pullable on GHCR — it drives upgrade targets.
 	latestSHAByBranch = map[string]branchSHAInfo{}
+	// latestHubSHAByBranch is the same idea for the HUB's own image, which is a
+	// separate build from the spoke's (ghcrRepoHub vs ghcrRepoSpoke) and can
+	// succeed or fail independently for the same commit. Tracking one shared
+	// value meant the hub's upgrade target was gated on the SPOKE image: when a
+	// spoke build failed but the hub build succeeded, that SHA never entered
+	// latestSHAByBranch, so the hub could never roll to it and reported
+	// "current" against a stale target.
+	latestHubSHAByBranch = map[string]branchSHAInfo{}
 	// headSHAByBranch advances to the branch HEAD immediately so the
 	// dashboard can show the newest commit with a build-status indicator.
 	headSHAByBranch = map[string]branchHeadInfo{}
@@ -2797,6 +2808,16 @@ func getLatestSHAForBranch(branch string) string {
 	return latestSHAByBranch[branch].SHA
 }
 
+// getLatestHubSHAForBranch returns the newest SHA on this branch whose HUB
+// image is verified pullable. Use this — never getLatestSHAForBranch — for the
+// hub's own upgrade target, since the hub and spoke images are separate builds
+// that can fail independently for the same commit.
+func getLatestHubSHAForBranch(branch string) string {
+	latestSHAMu.RLock()
+	defer latestSHAMu.RUnlock()
+	return latestHubSHAByBranch[branch].SHA
+}
+
 // getLatestSHAs returns a branch→SHA map (backward-compatible string values).
 func getLatestSHAs() map[string]string {
 	latestSHAMu.RLock()
@@ -3031,7 +3052,10 @@ func (s *HubServer) StartLatestSHAPoller(ctx context.Context) {
 		// a rollout restart. A debounce prevents re-restarting every 2min while a
 		// restart is already rolling out (the new pod reports the new hash, which
 		// clears the condition, but the poll can fire before the rollout lands).
-		hubBranchSHA := getLatestSHAForBranch("v2")
+		// Use the hub's OWN branch, not a hardcoded "v2": hubUpgradeState() and
+		// handleHubSelfUpgrade() both read s.hubGitBranch, so hardcoding here
+		// made the badge and the poller disagree the moment a hub ran on v3.
+		hubBranchSHA := getLatestHubSHAForBranch(s.hubGitBranch)
 		s.hubUpgradeMu.Lock()
 		debounced := time.Since(s.lastHubUpgradeTrigger) > hubUpgradeDebounce
 		s.hubUpgradeMu.Unlock()
@@ -3247,6 +3271,17 @@ func fetchBranchSHA(logger *slog.Logger, branch string) {
 	// dashboard can show the new commit while its image builds.
 	prevHead := getBranchHead(branch)
 	headChanged := prevHead.SHA != candidateSHA
+
+	// The hub image is a SEPARATE build from the spoke image and can land in
+	// either order (or fail independently). Probe it on its own so the hub's
+	// upgrade target is never gated on the spoke build, and vice versa.
+	if candidateSHA != getLatestHubSHAForBranch(branch) &&
+		ghcrTagExists(client, ghcrRepoHub, candidateSHA, logger) {
+		latestSHAMu.Lock()
+		latestHubSHAByBranch[branch] = branchSHAInfo{SHA: candidateSHA, Message: commitMsg}
+		latestSHAMu.Unlock()
+		logger.Info("SHA poll: hub image verified on GHCR", "branch", branch, "sha", candidateSHA)
+	}
 
 	if candidateSHA == getLatestSHAForBranch(branch) {
 		// Head unchanged since its image was verified — nothing to re-check.


### PR DESCRIPTION
## Problem

The hub and spoke ship as **two separate GHCR images** — `kubestellar/hive-hub` and `kubestellar/hive` — built by separate jobs that can succeed or fail independently for the same commit.

`latestSHAByBranch` only advanced once the **spoke** image was verified pullable (`saas.go:3257`), but `rolloutHubToSHA` requires the **hub** image (`saas.go:2055`). So a SHA whose spoke build failed while its hub build succeeded never entered the cache, and the hub could never roll to it — while `hubUpgradeState()` compared against that same stale value and reported `"current"`.

The manual **Upgrade** button was broken identically, since `handleHubSelfUpgrade` also reads `getLatestSHAForBranch`.

Confirmed live on GHCR:

```
kubestellar/hive      3d30475 -> 404   (spoke build missing)
kubestellar/hive-hub  3d30475 -> 200   (hub build succeeded)
```

The existing comment at `saas.go:2532` already warned about this hazard, but the guard was only ever applied to the rollout side.

## Fix

Track the two independently:

- New `latestHubSHAByBranch`, advanced by its own GHCR probe against `ghcrRepoHub` in the same poll.
- New `getLatestHubSHAForBranch()` feeds **every** hub-upgrade consumer: the auto-upgrade poller, the enable-auto-upgrade trigger, `handleHubSelfUpgrade`, and the dashboard badge.
- Spoke upgrade targets keep using the spoke cache, unchanged.

Also fixed: the poller hardcoded `getLatestSHAForBranch("v2")` for the hub's own branch, while `hubUpgradeState()` and `handleHubSelfUpgrade()` both read `s.hubGitBranch`. Those diverge the moment a hub runs on v3 — the badge would read v3's SHA while the poller rolled to v2's.

## Notes

- The hub cache is deliberately **not** persisted to `/data/saas/latest-shas.json`. It repopulates on the first poll, and leaving that file's schema alone avoids a migration for a value that's cheap to recompute. The only cost is the badge reading `"unknown"` for one poll interval after a hub restart.

## Tests

- `setV2Latest` now seeds both caches (tests that don't care about the split want them in agreement).
- New `setV2HubLatest` seeds only the hub cache, for the divergent case.
- New `TestHubUpgradeStateUsesHubImageNotSpokeImage` pins the regression: spoke cache trailing at one SHA, hub image published at a newer one — the hub must report `behind`, not `current`.

## Relationship to #2137

Independent bugs, both blocking hub upgrades. #2137 fixes the loop being starved by per-hive kubectl timeouts; this fixes the target being wrong even when the loop does run. Both are needed.

## Follow-up

Still needs porting to **mk**, **dd**, and **v3**.