### PR TITLE
🐛 fix(hub): owners could not add users — Manage Access dropdown was admin-only

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -134,6 +134,7 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("GET /api/saas/auth-check", s.handleSaaSAuthCheck)
 	s.mux.HandleFunc("POST /api/saas/user-token", s.requireAuth(s.handleUserToken))
 	s.mux.HandleFunc("GET /api/saas/hives/{id}/access", s.requireAuth(s.handleAccessList))
+	s.mux.HandleFunc("GET /api/saas/grantable-users", s.requireAuth(s.handleGrantableUsers))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/access", s.requireAuth(s.handleAccessAdd))
 	s.mux.HandleFunc("DELETE /api/saas/hives/{id}/access/{username}", s.requireAuth(s.handleAccessRemove))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/request-access", s.requireAuth(s.handleRequestAccess))
@@ -3508,6 +3509,41 @@ func (s *HubServer) handleAccessList(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"access": access})
+}
+
+// handleGrantableUsers lists the usernames a hive owner may grant access to.
+// The Manage Access dropdown used to read /api/saas/admin/users, which is
+// requireAdmin — so for every owner who is not the hub admin it 403'd and the
+// dropdown silently rendered empty, making it look as though known users simply
+// "weren't there". Owners legitimately need the roster to grant access, so this
+// exposes exactly that and nothing else: usernames only, no emails, quotas, or
+// hive assignments (which would leak the shape of other people's fleets).
+func (s *HubServer) handleGrantableUsers(w http.ResponseWriter, r *http.Request) {
+	username := s.getAuthUser(r)
+	// Any user who owns at least one hive may see the roster; that is the same
+	// bar as being able to open Manage Access at all. Admin always qualifies.
+	owns := username == hubAdminUsername
+	if !owns {
+		for _, h := range listSaaSHives() {
+			if h.Owner == username {
+				owns = true
+				break
+			}
+		}
+	}
+	if !owns {
+		http.Error(w, `{"error":"only hive owners can list users"}`, http.StatusForbidden)
+		return
+	}
+	names := make([]string, 0)
+	for _, u := range listAllSaaSUsers() {
+		if u.GitHubUsername != "" {
+			names = append(names, u.GitHubUsername)
+		}
+	}
+	sort.Strings(names)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"users": names})
 }
 
 func (s *HubServer) handleAccessAdd(w http.ResponseWriter, r *http.Request) {
@@ -7573,16 +7609,28 @@ const dashboardHTML = `<!DOCTYPE html>
     }
 
     async function loadAccessUserDropdown() {
+      var sel = document.getElementById('access-username');
+      if (!sel) return;
       try {
-        var resp = await fetch('/api/saas/admin/users');
-        if (resp.status === 403) return;
+        // grantable-users, NOT admin/users: the latter is admin-only, so every
+        // non-admin owner got a 403 and an empty dropdown with no explanation.
+        var resp = await fetch('/api/saas/grantable-users');
+        if (!resp.ok) throw new Error('HTTP ' + resp.status);
         var data = await resp.json();
-        var users = (data.users || []).map(function(u) { return u.github_username; });
-        var sel = document.getElementById('access-username');
+        var users = (data.users || []);
+        if (!users.length) {
+          sel.innerHTML = '<option value="">No users yet — they must sign in to the hub once</option>';
+          return;
+        }
         sel.innerHTML = '<option value="">Select user...</option>' + users.map(function(u) {
           return '<option value="' + esc(u) + '">' + esc(u) + '</option>';
         }).join('');
-      } catch(e) {}
+      } catch(e) {
+        // Never leave the control looking merely empty — an empty dropdown is
+        // indistinguishable from "no such users", which is what made this
+        // confusing in the first place.
+        sel.innerHTML = '<option value="">Could not load users</option>';
+      }
     }
 
     async function loadAccessList() {


### PR DESCRIPTION
## Problem

Reported from the field: a hive owner opens **Manage Access**, and the **Add User** dropdown is empty — no users to pick, with no explanation.

The dropdown populated itself from `/api/saas/admin/users`, which is registered behind `requireAdmin` (`saas.go:151`). For every hive owner who is **not** the hub admin, that request 403'd — and the handler did a bare `return` on 403, leaving the dropdown with only its placeholder.

```js
var resp = await fetch('/api/saas/admin/users');
if (resp.status === 403) return;   // ← silent, indistinguishable from "no users"
```

The failure was invisible and read as *"those users don't exist"* rather than *"you aren't allowed to see them"*. Owners could see their hive and open Manage Access, but could never grant anyone access.

Worth noting: the usual advice — *"they have to sign in to the hub once first"* — is true but was **not** the cause here. Even users who had already signed in would never have appeared for a non-admin owner.

## Fix

Add `GET /api/saas/grantable-users`, authorized for any user who owns at least one hive (the same bar as being able to open Manage Access at all), plus the admin.

It returns **usernames only** — deliberately not the admin user records, which carry emails, quotas, and per-user hive assignments that would leak the shape of other people's fleets to any owner.

The dropdown now reads that endpoint and no longer swallows failures: an empty roster and a failed load each get their own message instead of both rendering as an empty control.

## Follow-up

Still needs porting to **mk**, **dd**, and **v3**.