### PR TITLE
🐛 fix(spoke): stop liveness probe from crash-looping healthy pods on hub outages

### DIFF
--- a/v2/deploy/k8s/deployment.yaml
+++ b/v2/deploy/k8s/deployment.yaml
@@ -65,17 +65,29 @@ spec:
               readOnly: true
             - name: data
               mountPath: /data
+          # startupProbe holds the liveness clock off until the process has
+          # finished booting, so a slow start can never race the liveness
+          # timer into a restart loop. failureThreshold x periodSeconds
+          # (30 x 5s = 150s) is the boot budget.
+          startupProbe:
+            httpGet:
+              path: /api/health
+              port: api
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            failureThreshold: 30
           livenessProbe:
-            # /api/livez includes a heartbeat-staleness check (in addition to
-            # everything /api/health checks) so a heartbeat goroutine that
-            # dies silently while the HTTP server stays up gets caught and
-            # the pod restarted, instead of staying 1/1 Running forever with
-            # the hub showing it offline. See pkg/dashboard/server.go
-            # handleLivez. Hives with no hub configured are unaffected.
+            # /api/livez checks that the HTTP server responds AND that the
+            # heartbeat loop is still *attempting* sends — i.e. it only fails
+            # when the process is genuinely wedged, which a restart fixes.
+            # It deliberately does NOT fail on a stale heartbeat: an
+            # unreachable hub is a connectivity problem no restart can fix,
+            # and gating liveness on it crash-loops healthy pods on
+            # firewalled clusters. That signal lives in /api/health/deep.
+            # See pkg/dashboard/server.go handleLivez.
             httpGet:
               path: /api/livez
               port: api
-            initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 5
           readinessProbe:

--- a/v2/docs/manual-provisioning.md
+++ b/v2/docs/manual-provisioning.md
@@ -400,9 +400,18 @@ spec:
         # OFFLINE forever (see the gotcha below). HIVE_HUB_URL points at the hub.
         - { name: HIVE_HUB_SECRET, value: "${HUB_SECRET}" }
         - { name: HIVE_HUB_URL,    value: "https://hive.kubestellar.io" }
+        # startupProbe keeps the liveness clock from starting until boot
+        # finishes, so a slow start can't race liveness into a restart loop.
+        startupProbe:
+          httpGet: { path: /api/health, port: 3002 }
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          failureThreshold: 30
         livenessProbe:
-          # /api/livez (NOT /api/health) — it also fails on a stale heartbeat,
-          # so a wedged/dead heartbeat goroutine gets the pod auto-restarted.
+          # /api/livez (NOT /api/health) — it also fails when the heartbeat
+          # loop stops *attempting* sends, so a wedged/dead heartbeat
+          # goroutine gets the pod auto-restarted. It does NOT fail merely
+          # because the hub is unreachable (see the gotcha below).
           httpGet: { path: /api/livez, port: 3002 }
           periodSeconds: 30
           failureThreshold: 3
@@ -447,11 +456,21 @@ YAML
 > `/api/health` only checks the HTTP server is up, so a pod whose heartbeat
 > goroutine has silently died still passes it and is never restarted — the hive
 > shows a persistent "offline" dot while `1/1 Running`. `/api/livez` additionally
-> fails (503) when the last successful heartbeat is stale, so the kubelet
+> fails (503) when the heartbeat loop stops *attempting* to send, so the kubelet
 > restarts the pod and the heartbeat revives. It returns 200 unauthenticated
 > once healthy. Existing deployments provisioned before this note still point at
 > `/api/health` — migrate them:
 > `kubectl -n <ns> patch deploy hive --type json -p '[{"op":"replace","path":"/spec/template/spec/containers/0/livenessProbe/httpGet/path","value":"/api/livez"}]'`
+
+> **Note — `/api/livez` does not fail on an unreachable hub.** It keys off
+> heartbeat *attempts*, not successes. A hub that is down, firewalled, or
+> rejecting beats leaves the process perfectly healthy, and restarting it
+> cannot fix a network partition — an earlier version gated liveness on
+> heartbeat freshness and crash-looped healthy spokes on firewalled clusters
+> (vllm-d). Heartbeat freshness is reported by `/api/health/deep` under the
+> `hub_heartbeat` check, and the hub greys the hive's dot on its own.
+> Spokes deployed before this fix need a redeploy (or a probe patch) to stop
+> restarting on hub outages.
 
 > **Gotcha — some clusters enforce an `owner` label.** A `ValidatingAdmissionPolicy`
 > on vllm-d requires an `owner` label on `PersistentVolumeClaim`, `ConfigMap`,
@@ -649,6 +668,7 @@ kubectl --context hive-oke -n hive-hub exec "$HUB_POD" -- \
 | `Config save failed ... open /etc/hive/hive.yaml: read-only file system` (ACMM/App-auth lost on restart) | ConfigMap mounted DIRECTLY at `/etc/hive` (read-only) | Mount ConfigMap at `/etc/hive-seed` + a writable emptyDir at `/etc/hive` + the `copy-config` init container (see B.8) |
 | Pod `1/1 Running` but hive shows **offline**; spoke logs `hub heartbeat rejected status=401` | No `HIVE_HUB_SECRET` in the deployment env | Add `HIVE_HUB_SECRET` (+ `HIVE_HUB_URL`) env from a working hive; the pod rolls and heartbeats |
 | Pod `1/1 Running` but hive shows **offline**; no 401, heartbeat just stopped | Heartbeat goroutine died; liveness probe on `/api/health` can't detect it | Point livenessProbe at `/api/livez`; restart to revive now |
+| Pod restarting repeatedly (`RESTARTS` climbing) while the app looks fine; hub unreachable/firewalled | Old liveness probe failed on stale *heartbeat success* — a connectivity condition a restart can't fix | Redeploy to pick up the attempt-based `/api/livez` (+ `startupProbe`); check `/api/health/deep` → `hub_heartbeat` for the real connectivity state |
 | Pod `CrashLoopBackOff` exit 255, SCC `restricted-v2` | `hive-anyuid` RoleBinding subject points at the wrong namespace | Set `subjects[].namespace` to the hive's own `$NS`, delete the pod |
 | Pod won't boot: `github.token or github.app_id is required` | `github.app_id` empty in the seed | Set a placeholder `app_id` (e.g. `999999999`) |
 | Dashboard sign-in redirect loop (vllm-d) | `hub_proxied: true` on a cluster with no hub auth proxy | Set `hub_proxied: false` on the PVC overlay |

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -1217,39 +1217,58 @@ const (
 	// isn't exported. If that interval ever changes, update both.
 	heartbeatSendInterval = 2 * time.Minute
 
-	// livezHeartbeatStaleMax is how old the last successful heartbeat may be
+	// livezHeartbeatStallMax is how old the last heartbeat *attempt* may be
 	// before /api/livez reports unhealthy. Set to 3x the send interval (6
-	// minutes): generous enough to absorb one or two transient hub-side
-	// failures (network blip, hub restart, rate limit) without flapping the
-	// pod, but tight enough that a genuinely dead heartbeat goroutine gets
-	// caught and the pod restarted well within a single human-observable
-	// "gray dot" investigation window.
-	livezHeartbeatStaleMax = 3 * heartbeatSendInterval
+	// minutes): long enough to absorb a couple of missed ticks under CPU
+	// starvation or a slow hub round trip without flapping the pod, but tight
+	// enough that a genuinely wedged loop is caught within a single
+	// human-observable "gray dot" investigation window.
+	//
+	// Deliberately measured against attempts, not successes: a hub that is
+	// down or unreachable leaves successes arbitrarily stale while the loop
+	// keeps beating happily, and restarting the pod cannot fix a network
+	// partition. See handleLivez.
+	livezHeartbeatStallMax = 3 * heartbeatSendInterval
 
 	// livezStartupGrace bounds how long a freshly started process is treated
-	// as healthy before it has sent its first successful heartbeat. Covers
+	// as healthy before the heartbeat loop has made its first attempt. Covers
 	// waitForReady's own up-to-3-minute wait for the dashboard to come up
-	// plus one heartbeat send attempt and hub round trip. Without this, a
-	// pod would fail liveness during normal startup, before the heartbeat
-	// loop ever got a chance to succeed.
+	// plus one heartbeat send attempt. Without this, a pod would fail
+	// liveness during normal startup, before the heartbeat loop ever got a
+	// chance to run.
 	livezStartupGrace = 4 * time.Minute
 )
 
 // handleLivez is the liveness-only counterpart to /api/health. It includes
 // everything /api/health checks (the HTTP server itself is responsive) PLUS,
 // for hub-connected hives, a check that the heartbeat goroutine is actually
-// still beating. The heartbeat goroutine can silently die (panic recovered
-// upstream, deadlock, stuck HTTP call) while this HTTP server keeps serving
-// fine — that's the bug this endpoint exists to catch: before this endpoint
-// existed, /api/health stayed green in that case and kubelet had no reason
-// to ever restart the pod, so the hub kept showing the hive as offline
-// (gray dot) indefinitely even though the pod was 1/1 Running.
+// still running its loop. The heartbeat goroutine can silently die (panic
+// recovered upstream, deadlock, stuck HTTP call) while this HTTP server keeps
+// serving fine — that's the bug this endpoint exists to catch: /api/health
+// stays green in that case and kubelet has no reason to ever restart the pod,
+// so the hub keeps showing the hive as offline (gray dot) indefinitely even
+// though the pod is 1/1 Running.
+//
+// Crucially, "still running its loop" is measured by heartbeat *attempts*,
+// not *successes*. Those are very different conditions:
+//
+//   - Attempts stalled  => the goroutine is wedged. A restart revives it, so
+//     failing liveness is the correct and only remedy.
+//   - Successes stalled but attempts advancing => the hub is unreachable or
+//     rejecting. The process is perfectly healthy; restarting it cannot fix
+//     a network partition, and killing the pod every failureThreshold window
+//     just produces a crash-loop that outlives the outage. Routine on
+//     firewalled clusters that reach the hub only intermittently.
+//
+// Gating liveness on success staleness (as this endpoint originally did) made
+// every hub outage or firewall hiccup look like a dead process and got
+// healthy pods killed in a loop. Heartbeat *freshness* is a connectivity
+// signal, so it is reported via /api/health/deep and the hub's own
+// staleness marking (which already greys the dot) rather than via liveness.
 //
 // Only the livenessProbe should point here. Readiness stays on /api/health:
 // a transient hub outage would otherwise pull a perfectly-serving pod out of
-// the Service's endpoints for no benefit (restarting won't fix a hub that's
-// down). Liveness failing here IS the intended remedy for a dead heartbeat
-// goroutine, since a restart revives it.
+// the Service's endpoints for no benefit.
 func (s *Server) handleLivez(w http.ResponseWriter, r *http.Request) {
 	s.statusMu.RLock()
 	ready := s.ready
@@ -1264,25 +1283,30 @@ func (s *Server) handleLivez(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Hives with no hub configured never run a heartbeat loop at all, so
-	// there is nothing to go stale — never gate their liveness on this.
+	// there is nothing to stall — never gate their liveness on this.
 	if hub.HeartbeatEnabled() {
-		lastSuccess, hasSucceededOnce := hub.LastHeartbeatSuccess()
+		lastAttempt, hasAttemptedOnce := hub.LastHeartbeatAttempt()
 		switch {
-		case !hasSucceededOnce:
+		case !hasAttemptedOnce:
+			// The loop has not reached its first send yet. Healthy during the
+			// startup grace (waitForReady legitimately holds it off for
+			// minutes); past that, the goroutine never got going.
 			if age := time.Since(s.startedAt); age > livezStartupGrace {
 				w.WriteHeader(http.StatusServiceUnavailable)
 				json.NewEncoder(w).Encode(map[string]string{
 					"status": "unhealthy",
-					"detail": "no successful heartbeat since startup",
+					"detail": "heartbeat loop never started sending",
 				})
 				return
 			}
-		case time.Since(lastSuccess) > livezHeartbeatStaleMax:
+		case time.Since(lastAttempt) > livezHeartbeatStallMax:
+			// Attempts have stopped advancing entirely — the loop is wedged,
+			// not merely unable to reach the hub. A restart is the remedy.
 			w.WriteHeader(http.StatusServiceUnavailable)
 			json.NewEncoder(w).Encode(map[string]string{
-				"status":            "unhealthy",
-				"detail":            "heartbeat stale",
-				"last_heartbeat_at": lastSuccess.UTC().Format(time.RFC3339),
+				"status":                    "unhealthy",
+				"detail":                    "heartbeat loop stalled",
+				"last_heartbeat_attempt_at": lastAttempt.UTC().Format(time.RFC3339),
 			})
 			return
 		}
@@ -1466,7 +1490,37 @@ func (s *Server) handleHealthDeep(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// 10. Queue trend (is work being processed?)
+	// 10. Hub heartbeat (connectivity signal).
+	//
+	// Deliberately reported here rather than via /api/livez: a stale
+	// heartbeat means the hub is unreachable or rejecting, which a pod
+	// restart cannot fix. It surfaces as "warn" so operators (and the hub
+	// dashboard's gray dot) still see the connectivity problem without the
+	// kubelet killing an otherwise-healthy pod. See handleLivez.
+	if hub.HeartbeatEnabled() {
+		hbCheck := map[string]any{"status": "pass"}
+		if lastSuccess, ok := hub.LastHeartbeatSuccess(); ok {
+			hbCheck["last_success"] = lastSuccess.UTC().Format(time.RFC3339)
+			hbCheck["last_success_age"] = time.Since(lastSuccess).Round(time.Second).String()
+			if time.Since(lastSuccess) > livezHeartbeatStallMax {
+				hbCheck["status"] = "warn"
+				hbCheck["detail"] = "hub has not accepted a heartbeat recently — check hub reachability"
+			}
+		} else {
+			hbCheck["status"] = "warn"
+			hbCheck["detail"] = "no heartbeat accepted by the hub since startup"
+		}
+		if lastAttempt, ok := hub.LastHeartbeatAttempt(); ok {
+			hbCheck["last_attempt"] = lastAttempt.UTC().Format(time.RFC3339)
+			hbCheck["last_attempt_age"] = time.Since(lastAttempt).Round(time.Second).String()
+		}
+		if hbCheck["status"] == "warn" && overall == "ok" {
+			overall = "degraded"
+		}
+		checks["hub_heartbeat"] = hbCheck
+	}
+
+	// 11. Queue trend (is work being processed?)
 	s.statusMu.RLock()
 	if s.status != nil {
 		totalActionable := 0

--- a/v2/pkg/dashboard/server_livez_heartbeat_test.go
+++ b/v2/pkg/dashboard/server_livez_heartbeat_test.go
@@ -1,0 +1,154 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/hub"
+)
+
+// getLivez drives a ready server's /api/livez and returns the recorder.
+func getLivez(t *testing.T, s *Server) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/livez", nil))
+	return rec
+}
+
+// TestLivez_StaleHeartbeatSuccessStaysAlive is the regression test for the
+// self-inflicted crash loop: a spoke that cannot reach the hub (firewalled
+// cluster, hub outage) has an arbitrarily old last *success*, but its loop is
+// still beating. Liveness must stay 200 — restarting the pod cannot fix a
+// network partition, and failing here crash-loops a healthy process.
+func TestLivez_StaleHeartbeatSuccessStaysAlive(t *testing.T) {
+	defer hub.ResetHeartbeatStateForTest()
+	s := healthServer(t)
+	s.MarkReady()
+
+	// Loop is beating right now, but the hub last accepted a beat an hour ago.
+	hub.SetHeartbeatStateForTest(true, time.Now(), time.Now().Add(-time.Hour))
+
+	if rec := getLivez(t, s); rec.Code != http.StatusOK {
+		t.Fatalf("stale heartbeat success must NOT fail liveness: got %d, body %s",
+			rec.Code, rec.Body.String())
+	}
+}
+
+// TestLivez_NeverSucceededButAttemptingStaysAlive covers a spoke that has
+// never once reached the hub (misconfigured secret, hub down since boot) well
+// past the startup grace. The loop is attempting, so the process is healthy
+// and must not be restarted — the hub already greys its dot.
+func TestLivez_NeverSucceededButAttemptingStaysAlive(t *testing.T) {
+	defer hub.ResetHeartbeatStateForTest()
+	s := healthServer(t)
+	s.MarkReady()
+	s.startedAt = time.Now().Add(-24 * time.Hour) // long past startup grace
+
+	hub.SetHeartbeatStateForTest(true, time.Now(), time.Time{})
+
+	if rec := getLivez(t, s); rec.Code != http.StatusOK {
+		t.Fatalf("never-successful but attempting must stay alive: got %d, body %s",
+			rec.Code, rec.Body.String())
+	}
+}
+
+// TestLivez_StalledAttemptsFail is the other half of the contract: when the
+// loop stops attempting entirely it is genuinely wedged, and a restart is the
+// only remedy. This is the condition /api/livez exists to catch.
+func TestLivez_StalledAttemptsFail(t *testing.T) {
+	defer hub.ResetHeartbeatStateForTest()
+	s := healthServer(t)
+	s.MarkReady()
+
+	stalled := time.Now().Add(-livezHeartbeatStallMax - time.Minute)
+	// Successes are fresh-ish relative to attempts; only attempts matter here.
+	hub.SetHeartbeatStateForTest(true, stalled, stalled)
+
+	rec := getLivez(t, s)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("stalled heartbeat loop must fail liveness: got %d", rec.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode livez body: %v", err)
+	}
+	if body["detail"] != "heartbeat loop stalled" {
+		t.Fatalf("unexpected detail: %q", body["detail"])
+	}
+}
+
+// TestLivez_NoAttemptWithinStartupGrace verifies a booting pod is healthy
+// before the loop's first send (waitForReady legitimately delays it for
+// minutes), and unhealthy once the grace has elapsed with no attempt at all.
+func TestLivez_NoAttemptWithinStartupGrace(t *testing.T) {
+	defer hub.ResetHeartbeatStateForTest()
+
+	t.Run("within grace is alive", func(t *testing.T) {
+		s := healthServer(t)
+		s.MarkReady()
+		s.startedAt = time.Now()
+		hub.SetHeartbeatStateForTest(true, time.Time{}, time.Time{})
+
+		if rec := getLivez(t, s); rec.Code != http.StatusOK {
+			t.Fatalf("booting pod must pass liveness: got %d", rec.Code)
+		}
+	})
+
+	t.Run("past grace fails", func(t *testing.T) {
+		s := healthServer(t)
+		s.MarkReady()
+		s.startedAt = time.Now().Add(-livezStartupGrace - time.Minute)
+		hub.SetHeartbeatStateForTest(true, time.Time{}, time.Time{})
+
+		rec := getLivez(t, s)
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("loop that never started must fail liveness: got %d", rec.Code)
+		}
+	})
+}
+
+// TestLivez_NoHubConfiguredIgnoresHeartbeat guards the hub-less case: such a
+// hive never runs a loop, so it must never be gated on heartbeat state.
+func TestLivez_NoHubConfiguredIgnoresHeartbeat(t *testing.T) {
+	defer hub.ResetHeartbeatStateForTest()
+	s := healthServer(t)
+	s.MarkReady()
+	s.startedAt = time.Now().Add(-24 * time.Hour)
+
+	// Disabled loop, no attempts, no successes — still alive.
+	hub.SetHeartbeatStateForTest(false, time.Time{}, time.Time{})
+
+	if rec := getLivez(t, s); rec.Code != http.StatusOK {
+		t.Fatalf("hub-less hive must ignore heartbeat state: got %d", rec.Code)
+	}
+}
+
+// TestHealthDeep_ReportsHeartbeatStaleness confirms the connectivity signal
+// removed from liveness is still surfaced — as a warning, not a pod kill.
+func TestHealthDeep_ReportsHeartbeatStaleness(t *testing.T) {
+	defer hub.ResetHeartbeatStateForTest()
+	s := healthServer(t)
+	s.MarkReady()
+
+	hub.SetHeartbeatStateForTest(true, time.Now(), time.Now().Add(-time.Hour))
+
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/health/deep", nil))
+
+	var body struct {
+		Checks map[string]any `json:"checks"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode health/deep: %v", err)
+	}
+	hb, ok := body.Checks["hub_heartbeat"].(map[string]any)
+	if !ok {
+		t.Fatalf("health/deep missing hub_heartbeat check: %s", rec.Body.String())
+	}
+	if hb["status"] != "warn" {
+		t.Fatalf("stale heartbeat should warn in health/deep, got %v", hb["status"])
+	}
+}

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -38,8 +38,58 @@ var lastHeartbeatSuccessUnix atomic.Int64
 // liveness forever. Set once at startup; read from the HTTP handler.
 var heartbeatLoopStarted atomic.Bool
 
+// lastHeartbeatAttemptUnix holds the unix-seconds timestamp of the most
+// recent heartbeat the loop *tried* to send, regardless of whether the hub
+// accepted it, rejected it (4xx/5xx), or was unreachable entirely.
+//
+// This is the signal that separates the two failure modes a stale
+// lastHeartbeatSuccessUnix otherwise conflates:
+//
+//   - Attempts advancing but successes not: the goroutine is alive and doing
+//     its job; the *hub* is unreachable or rejecting. Restarting the pod
+//     cannot fix a network partition or a hub outage, so liveness must not
+//     fail — this is routine on firewalled clusters that can only reach the
+//     hub intermittently.
+//   - Attempts themselves not advancing: the loop is genuinely wedged (dead
+//     goroutine, deadlock, permanently stuck HTTP call). A restart is the
+//     only remedy, so this is what liveness should catch.
+//
+// Same atomic rationale as lastHeartbeatSuccessUnix: written by the heartbeat
+// goroutine, read by the dashboard's HTTP handler goroutine.
+var lastHeartbeatAttemptUnix atomic.Int64
+
+// storeUnixOrZero stores t as unix seconds, or 0 for the zero time so it
+// reads back as "never happened" through the Last* accessors.
+func storeUnixOrZero(dst *atomic.Int64, t time.Time) {
+	if t.IsZero() {
+		dst.Store(0)
+		return
+	}
+	dst.Store(t.Unix())
+}
+
 func recordHeartbeatSuccess() {
 	lastHeartbeatSuccessUnix.Store(time.Now().Unix())
+}
+
+// recordHeartbeatAttempt marks that the heartbeat loop reached the top of a
+// send. Called unconditionally before each attempt so a hub that is down,
+// unreachable, or rejecting every beat still counts as "the loop is alive".
+func recordHeartbeatAttempt() {
+	lastHeartbeatAttemptUnix.Store(time.Now().Unix())
+}
+
+// LastHeartbeatAttempt returns the time the heartbeat loop last tried to
+// send, and whether it has ever tried. Unlike LastHeartbeatSuccess this
+// advances even while the hub is unreachable, so liveness checks can tell a
+// wedged goroutine (no attempts) from a partitioned network (attempts, no
+// successes).
+func LastHeartbeatAttempt() (t time.Time, ok bool) {
+	sec := lastHeartbeatAttemptUnix.Load()
+	if sec == 0 {
+		return time.Time{}, false
+	}
+	return time.Unix(sec, 0), true
 }
 
 // LastHeartbeatSuccess returns the time of the last heartbeat the hub
@@ -335,6 +385,12 @@ func waitForReady(ctx context.Context, logger *slog.Logger) {
 var validNamePattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
 func sendHeartbeat(ctx context.Context, hubURL string, collect StatusCollector, logger *slog.Logger) *HeartbeatResponse {
+	// Record the attempt before anything that can bail out early (including a
+	// nil payload from collect): reaching this point proves the loop goroutine
+	// is still running its schedule, which is exactly what liveness needs to
+	// know. Success is tracked separately, further down, on hub acceptance.
+	recordHeartbeatAttempt()
+
 	payload := collect()
 	if payload == nil {
 		return nil

--- a/v2/pkg/hub/heartbeat_testhooks.go
+++ b/v2/pkg/hub/heartbeat_testhooks.go
@@ -1,0 +1,29 @@
+package hub
+
+import "time"
+
+// This file exposes write access to the process-global heartbeat atomics so
+// tests in *other* packages (notably pkg/dashboard, which owns the /api/livez
+// handler) can simulate heartbeat states without standing up a real hub and
+// heartbeat loop. The production paths that set these live in heartbeat.go.
+//
+// These are deliberately exported rather than kept in an _test.go file: Go
+// only compiles _test.go files into their own package's test binary, so a
+// helper defined in hub's tests would be invisible to dashboard's tests.
+// Nothing in the production code calls them.
+
+// SetHeartbeatStateForTest overrides the heartbeat loop state used by liveness
+// and health reporting. A zero attempt or success time clears that timestamp,
+// making it read as "never happened".
+func SetHeartbeatStateForTest(enabled bool, lastAttempt, lastSuccess time.Time) {
+	heartbeatLoopStarted.Store(enabled)
+	storeUnixOrZero(&lastHeartbeatAttemptUnix, lastAttempt)
+	storeUnixOrZero(&lastHeartbeatSuccessUnix, lastSuccess)
+}
+
+// ResetHeartbeatStateForTest returns the heartbeat atomics to their
+// process-start values (no loop, no attempts, no successes). Tests that mutate
+// this global state should defer it so they don't leak into other tests.
+func ResetHeartbeatStateForTest() {
+	SetHeartbeatStateForTest(false, time.Time{}, time.Time{})
+}

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -1285,13 +1285,18 @@ spec:
           # /api/livez (not /api/health) so a heartbeat goroutine that dies
           # silently while the HTTP server stays up still gets caught and the
           # pod restarted. /api/health only proves the dashboard's HTTP
-          # server is responsive; it does not check heartbeat freshness, so
-          # a hive with a dead heartbeat goroutine but a live server would
-          # otherwise stay 1/1 Running forever while the hub shows it
-          # offline (gray dot) with nothing to recover it. See
-          # pkg/dashboard/server.go handleLivez for the staleness threshold
-          # and startup-grace handling; hives without a hub configured are
-          # exempt (guarded by hub.HeartbeatEnabled()).
+          # server is responsive; it does not check that the heartbeat loop is
+          # still running, so a hive with a wedged loop but a live server
+          # would otherwise stay 1/1 Running forever while the hub shows it
+          # offline (gray dot) with nothing to recover it.
+          #
+          # /api/livez keys off heartbeat *attempts*, not successes, so an
+          # unreachable or rejecting hub never kills the pod — a restart
+          # cannot fix a network partition, and gating on it crash-looped
+          # healthy spokes on firewalled clusters. Heartbeat freshness is
+          # reported via /api/health/deep instead. See
+          # pkg/dashboard/server.go handleLivez; hives without a hub
+          # configured are exempt (guarded by hub.HeartbeatEnabled()).
           httpGet:
             path: /api/livez
             port: {{.DashboardPort}}


### PR DESCRIPTION
## The bug

Spoke deployments wire the kubelet **liveness** probe to `/api/livez`, and that endpoint returned **503 whenever the last successful hub heartbeat went stale**.

Heartbeat staleness is a *connectivity* condition, not a *"the process is dead"* condition. When a spoke can't reach the hub — routine on firewalled clusters like vllm-d — kubelet killed a perfectly healthy pod. Restarting a process cannot repair a network partition, so with `periodSeconds: 30, failureThreshold: 3` a ~90s heartbeat stall killed the pod, and the restart loop lasted as long as the outage did.

This was self-inflicted: the staleness check was added deliberately (to catch a heartbeat goroutine that dies silently while the HTTP server keeps serving). That goal is valid — the implementation just used a signal that can't tell the two causes apart.

## The fix

Liveness now keys off heartbeat **attempts** rather than **successes**, which separates the two conditions the old check conflated:

| condition | meaning | liveness |
|---|---|---|
| attempts stalled | loop genuinely wedged (dead goroutine, deadlock, stuck call) | **fails** — a restart is the only remedy |
| successes stale, attempts advancing | hub unreachable/rejecting | **stays green** — process is healthy |

`pkg/hub/heartbeat.go` gains `lastHeartbeatAttemptUnix`, recorded at the top of `sendHeartbeat` *before* any early return (including a nil payload from `collect()`), so reaching the send proves the goroutine is still running its schedule. Exposed via a new `LastHeartbeatAttempt()` accessor, same atomic rationale as the existing success timestamp.

The original "dead heartbeat goroutine" detection is fully preserved — it just now triggers on the signal that actually implies a wedged process.

## The connectivity signal is not lost

`/api/health/deep` gains a `hub_heartbeat` check reporting last success/attempt timestamps and ages, degrading to `warn` when the hub hasn't accepted a beat. The hub's own staleness marking still greys the dot. So operators keep full visibility into hub reachability — it just no longer kills pods.

## Startup probe

`deploy/k8s/deployment.yaml` had **no `startupProbe`**, so the liveness clock started at boot and a slow start raced it. Added one (`failureThreshold: 30` x `periodSeconds: 5` = 150s boot budget) and dropped the now-redundant liveness `initialDelaySeconds`. `saas_provision.go` already had a `startupProbe`; the live spoke observed without one predates it.

## Provisioning templates

Yes — `pkg/hub/saas_provision.go` (the hosted-hive template) and `deploy/k8s/deployment.yaml` are both updated, so **newly provisioned hives get the corrected probes automatically**. `docs/manual-provisioning.md` is updated too, since it actively instructed operators to rely on the old semantics.

⚠️ **Existing running hives need a redeploy** to pick up the new probe config and image. No live clusters were patched by this PR.

## Tests

No existing test needed its assertions changed. All three files that touch `/api/livez` (`server_health_coverage_test.go`, `server_more_coverage_test.go`, `server_state_coverage_test.go`) only exercise the `ready` flag and never enable a heartbeat loop, so `hub.HeartbeatEnabled()` is false and they take the unchanged code path. Their existing "livez 503 when not ready" assertions remain correct — not-ready is still a genuine liveness failure; only the *heartbeat* gate changed.

Added `server_livez_heartbeat_test.go` covering the semantics that had no coverage before:

- **stale success + fresh attempts → 200** (the regression test for this bug)
- never-succeeded but attempting, past startup grace → 200
- stalled attempts → 503 with `heartbeat loop stalled`
- no attempt within/past startup grace → 200 / 503
- hub-less hive ignores heartbeat state entirely
- `/api/health/deep` reports stale heartbeat as `warn`

Driving these from `pkg/dashboard` required writing the process-global atomics in `pkg/hub`, so `heartbeat_testhooks.go` adds exported `SetHeartbeatStateForTest`/`ResetHeartbeatStateForTest`. They're in a regular file rather than `_test.go` because Go only compiles `_test.go` into its own package's test binary; no production code calls them, and every test defers a reset.

## Verified

- `go build ./...`, `go vet ./pkg/dashboard/ ./pkg/hub/` — clean
- `go test -timeout 480s ./pkg/dashboard/` — ok (13.2s)
- `go test -timeout 480s ./pkg/hub/` — ok (65.9s)
- Rendered the real `k8sManifestTemplate` through `text/template` with a production-shaped data map: parses to 11 valid YAML docs, with `startupProbe`→`/api/health`, `livenessProbe`→`/api/livez`, `readinessProbe`→`/api/health`. `deploy/k8s/deployment.yaml` validated the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)