### PR TITLE
🐛 fix(config): read-write grants were rejected — role suffix not recognized

### DIFF
--- a/v2/pkg/config/authorized_role_rw_test.go
+++ b/v2/pkg/config/authorized_role_rw_test.go
@@ -1,0 +1,56 @@
+package config
+
+import "testing"
+
+// TestAuthorizedRoleReadWrite pins the parse of a "user:read-write" allowlist
+// entry. The hub's Manage Access screen grants exactly three roles — read,
+// read-write, owner — but read-write was missing from the spoke's accepted
+// suffixes, so splitAuthorizedEntry took its "unknown suffix" branch and folded
+// the whole entry into the username. The allowlist then held a user literally
+// named "cbrooker27:read-write", every lookup missed, and a correctly granted
+// user was rejected from their own hive.
+func TestAuthorizedRoleReadWrite(t *testing.T) {
+	d := DashboardConfig{AuthorizedUsers: []string{
+		"zacburns:owner",
+		"cbrooker27:read-write",
+		"clubanderson:owner",
+	}}
+
+	role, ok := d.AuthorizedRole("cbrooker27")
+	if !ok {
+		t.Fatal("cbrooker27 not authorized — read-write entry failed to parse")
+	}
+	if role != RoleReadWrite {
+		t.Errorf("role = %q, want %q", role, RoleReadWrite)
+	}
+
+	// Case-insensitive on the username, as for the other roles.
+	if role, ok := d.AuthorizedRole("CBrooker27"); !ok || role != RoleReadWrite {
+		t.Errorf("case-insensitive lookup = (%q,%v), want (%q,true)", role, ok, RoleReadWrite)
+	}
+
+	// The other roles must be unaffected.
+	if role, ok := d.AuthorizedRole("zacburns"); !ok || role != RoleOwner {
+		t.Errorf("owner = (%q,%v), want (owner,true)", role, ok)
+	}
+
+	// A genuinely unknown suffix must still fall back to treating the whole
+	// entry as a username, so a stray colon cannot silently grant access.
+	d2 := DashboardConfig{AuthorizedUsers: []string{"someone:bogusrole"}}
+	if _, ok := d2.AuthorizedRole("someone"); ok {
+		t.Error("unknown role suffix should NOT resolve to a bare username match")
+	}
+
+	// Not on the list at all.
+	if _, ok := d.AuthorizedRole("stranger"); ok {
+		t.Error("unlisted user must not be authorized")
+	}
+}
+
+// TestSplitAuthorizedEntryReadWrite checks the parser directly.
+func TestSplitAuthorizedEntryReadWrite(t *testing.T) {
+	name, role := splitAuthorizedEntry("cbrooker27:read-write")
+	if name != "cbrooker27" || role != RoleReadWrite {
+		t.Errorf("splitAuthorizedEntry = (%q,%q), want (cbrooker27,read-write)", name, role)
+	}
+}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1146,6 +1146,14 @@ type DashboardConfig struct {
 const (
 	RoleOwner = "owner"
 	RoleRead  = "read"
+	// RoleReadWrite is granted by the hub's Manage Access screen (see the role
+	// validation in hub.handleAccessAdd, which accepts read / read-write /
+	// owner). It was missing here, so splitAuthorizedEntry treated
+	// "user:read-write" as an unknown suffix and folded the whole string into
+	// the username — the allowlist then contained a user literally named
+	// "cbrooker27:read-write", no lookup could ever match, and every login was
+	// rejected as unauthorized despite the grant being present and correct.
+	RoleReadWrite = "read-write"
 )
 
 // AuthorizedRole resolves a GitHub username against the spoke's authorized-users
@@ -1204,7 +1212,7 @@ func splitAuthorizedEntry(entry string) (name, role string) {
 	if idx := strings.LastIndex(entry, ":"); idx >= 0 {
 		name = strings.TrimSpace(entry[:idx])
 		role = strings.ToLower(strings.TrimSpace(entry[idx+1:]))
-		if role != RoleOwner && role != RoleRead {
+		if role != RoleOwner && role != RoleRead && role != RoleReadWrite {
 			// Unknown role suffix — treat the whole thing as a bare username so
 			// a stray colon can never silently downgrade or escalate access.
 			return strings.TrimSpace(entry), ""


### PR DESCRIPTION
## Problem

A user granted **read-write** on a direct-route spoke could never sign in. They saw:

> your GitHub account (cbrooker27) is not authorized to access this hive. Contact the hive owner to request access.

…despite being present and correct in `authorized_users`:

```yaml
authorized_users:
    - zacburns:owner
    - cbrooker27:read-write     # ← rejected
    - clubanderson:owner
```

## Cause

The hub's Manage Access screen grants **three** roles — `read`, `read-write`, `owner` (validated in `handleAccessAdd`, `saas.go:3533`). But the spoke's `splitAuthorizedEntry` only accepted `owner` and `read`; there was no `RoleReadWrite` constant.

So `read-write` hit the unknown-suffix branch, which deliberately folds the entire entry into the username so a stray colon cannot silently escalate access. That guard is right in principle — but `read-write` is a real hub-issued role, so a legitimate grant was treated as a typo:

```
"cbrooker27:read-write"  →  name = "cbrooker27:read-write", role = ""
```

The allowlist then held a user literally named `cbrooker27:read-write`. `AuthorizedRole("cbrooker27")` could never match, and every device-flow login was rejected.

**The hub was granting a role the spoke could not parse.** This is also why the config file looked perfectly correct while logins kept failing — and why `owner` users on the same hive were unaffected.

## Fix

Add `RoleReadWrite` and accept it as a valid suffix.

The unknown-suffix fallback is **unchanged**: a genuinely bogus role (`someone:bogusrole`) still cannot resolve to a bare username match — covered by an explicit test assertion.

No downstream change needed: write actions gate on `role == "read"` (`server.go:906`, `server.go:1046`), so `read-write` correctly carries write access once it parses.

## Tests

`TestAuthorizedRoleReadWrite` covers the read-write grant, case-insensitive lookup, the other roles still working, the bogus-suffix guard, and an unlisted user. `TestSplitAuthorizedEntryReadWrite` checks the parser directly. `pkg/config` and `pkg/dashboard` suites pass.

## Deployment note

Affected spokes need to pick up this build before the grant takes effect. As an immediate unblock without waiting, changing the entry to `cbrooker27:owner` (or bare `cbrooker27`, which grants read) works on the current code.

## Follow-up

Still needs porting to **mk**, **dd**, and **v3**.