### PR TITLE
✨ feat(hub): bulk multi-select actions for the My Hives list

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -176,6 +176,7 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("POST /api/saas/admin/hub-banner", s.requireAdmin(s.handleSendHubBanner))
 	s.mux.HandleFunc("DELETE /api/saas/admin/hub-banner", s.requireAdmin(s.handleClearHubBanner))
 	s.mux.HandleFunc("GET /api/saas/admin/hub-banner", s.requireAdmin(s.handleGetHubBanner))
+	s.registerBulkRoutes()
 
 	// Under `go test` these long-lived pollers leak across test cases: they
 	// immediately hit the GitHub API and read the package-level saas path
@@ -5509,6 +5510,7 @@ const dashboardHTML = `<!DOCTYPE html>
     <div id="hive-drift-summary" style="display:none"></div>
     <div id="hive-filter-bar" style="display:none"></div>
     <div id="usage-panel" style="display:none;margin-bottom:24px"></div>
+    <div id="bulk-action-bar" style="display:none"></div>
     <div id="hives-container"><div class="loading">Loading your hives...</div></div>
 
     <div id="public-hives-section" style="display:none;margin-top:48px">
@@ -6742,6 +6744,233 @@ const dashboardHTML = `<!DOCTYPE html>
       return h.provStatus === 'available' || (!!h.org && h.org.indexOf('available-') === 0);
     }
 
+    /* ---------- Bulk multi-select actions ----------
+       _bulkSelected is the authoritative selection, keyed by hive id, so it
+       survives re-render, re-sort and filter changes: the checkbox state is
+       derived from this map on every render rather than read back out of the
+       DOM. Ids that are no longer visible are pruned in syncBulkSelection so a
+       hidden hive can never be swept into a bulk action the user cannot see. */
+    var _bulkSelected = {};
+
+    /* Client-side mirror of the server's maxBulkHivesPerRequest. The server is
+       the enforcing authority; this only gives a better message than a 400. */
+    var BULK_MAX_HIVES = 100;
+
+    /* Actions that disrupt a running hive and therefore require confirmation
+       naming the count. Auto-upgrade toggles only change a stored preference,
+       so they are not in this set. */
+    var BULK_DISRUPTIVE_ACTIONS = {'restart': 1, 'upgrade': 1, 'switch-branch': 1};
+
+    /* Only hosted hives the user owns (or any hosted hive, for the hub admin)
+       can be targeted — the same predicate the single-hive buttons use. Local
+       hives have no hub-managed deployment to restart, and unassigned
+       placeholders have nothing running yet. */
+    function isBulkEligible(h) {
+      if (!h || !h.id) return false;
+      if (isPlaceholderHive(h)) return false;
+      var isHosted = h.hiveType === 'hosted' || (h.id.indexOf('hosted-') === 0 || h.id.indexOf('saas-') === 0);
+      if (!isHosted) return false;
+      return h.role === 'owner' || _isAdmin;
+    }
+
+    function bulkSelectedIds() {
+      var out = [];
+      for (var k in _bulkSelected) { if (_bulkSelected[k]) out.push(k); }
+      return out;
+    }
+
+    /* Drop selections for hives that are no longer present/eligible in the
+       current view. Called at the top of every render so the count in the bulk
+       bar always matches what is actually on screen. */
+    function syncBulkSelection(visibleHives) {
+      var live = {};
+      var list = visibleHives || [];
+      for (var i = 0; i < list.length; i++) {
+        if (isBulkEligible(list[i])) live[list[i].id] = true;
+      }
+      for (var k in _bulkSelected) {
+        if (!live[k]) delete _bulkSelected[k];
+      }
+    }
+
+    function toggleBulkHive(id, checked) {
+      if (checked) _bulkSelected[id] = true; else delete _bulkSelected[id];
+      renderBulkBar();
+      syncBulkSectionHeaderBoxes();
+    }
+
+    /* Select-all is per section (Assigned / Unassigned) so an admin cannot
+       accidentally sweep the whole page from one box. section is the key used
+       by the header checkbox id. */
+    function toggleBulkSection(section, checked) {
+      var boxes = document.querySelectorAll('input[type=checkbox][data-bulk-section="' + section + '"]');
+      for (var i = 0; i < boxes.length; i++) {
+        var id = boxes[i].getAttribute('data-bulk-id');
+        if (!id) continue;
+        boxes[i].checked = checked;
+        if (checked) _bulkSelected[id] = true; else delete _bulkSelected[id];
+      }
+      renderBulkBar();
+    }
+
+    /* Put each section header box into checked / indeterminate / unchecked to
+       match its rows. */
+    function syncBulkSectionHeaderBoxes() {
+      var heads = document.querySelectorAll('input[type=checkbox][data-bulk-section-head]');
+      for (var i = 0; i < heads.length; i++) {
+        var section = heads[i].getAttribute('data-bulk-section-head');
+        var boxes = document.querySelectorAll('input[type=checkbox][data-bulk-section="' + section + '"]');
+        var total = boxes.length, sel = 0;
+        for (var j = 0; j < boxes.length; j++) {
+          if (_bulkSelected[boxes[j].getAttribute('data-bulk-id')]) sel++;
+        }
+        heads[i].checked = total > 0 && sel === total;
+        heads[i].indeterminate = sel > 0 && sel < total;
+      }
+    }
+
+    function clearBulkSelection() {
+      _bulkSelected = {};
+      var boxes = document.querySelectorAll('input[type=checkbox][data-bulk-id]');
+      for (var i = 0; i < boxes.length; i++) { boxes[i].checked = false; }
+      renderBulkBar();
+      syncBulkSectionHeaderBoxes();
+    }
+
+    /* Row checkbox markup. section scopes it to a select-all group. */
+    function bulkCheckboxCell(h, section) {
+      if (!isBulkEligible(h)) {
+        return '<td style="width:26px;text-align:center"></td>';
+      }
+      var checked = _bulkSelected[h.id] ? ' checked' : '';
+      return '<td style="width:26px;text-align:center">' +
+        '<input type="checkbox" data-bulk-id="' + esc(h.id) + '" data-bulk-section="' + esc(section) + '"' + checked +
+        ' onclick="event.stopPropagation()" onchange="toggleBulkHive(\'' + esc(h.id) + '\',this.checked)"' +
+        ' title="Select for bulk actions" style="cursor:pointer"></td>';
+    }
+
+    function bulkSectionCheckbox(section) {
+      return '<input type="checkbox" data-bulk-section-head="' + esc(section) + '"' +
+        ' onchange="toggleBulkSection(\'' + esc(section) + '\',this.checked)"' +
+        ' title="Select all in this section" style="cursor:pointer;margin-right:8px;vertical-align:middle">';
+    }
+
+    function renderBulkBar() {
+      var bar = document.getElementById('bulk-action-bar');
+      if (!bar) return;
+      var ids = bulkSelectedIds();
+      if (!ids.length) { bar.style.display = 'none'; bar.innerHTML = ''; return; }
+      var btn = 'padding:5px 12px;border-radius:4px;cursor:pointer;font-size:0.72rem;white-space:nowrap;border:1px solid var(--border);background:var(--surface);color:var(--text)';
+      var over = ids.length > BULK_MAX_HIVES;
+      var branchOpts = '';
+      var branches = _trackedBranchesList.length > 0 ? _trackedBranchesList : Object.keys(_latestSHAs);
+      for (var bi = 0; bi < branches.length; bi++) {
+        branchOpts += '<option value="' + esc(branches[bi]) + '">' + esc(branches[bi]) + '</option>';
+      }
+      var branchPicker = branches.length > 0
+        ? '<select id="bulk-branch-select" style="' + btn + ';padding:4px 8px"><option value="">Switch branch…</option>' + branchOpts + '</select>'
+        : '';
+      bar.innerHTML =
+        '<div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:14px;padding:10px 14px;' +
+        'background:rgba(59,130,246,0.08);border:1px solid rgba(59,130,246,0.3);border-radius:8px">' +
+        '<strong style="font-size:0.8rem;color:#60a5fa">' + ids.length + (ids.length === 1 ? ' hive' : ' hives') + ' selected</strong>' +
+        (over ? '<span style="font-size:0.72rem;color:var(--red)">Over the ' + BULK_MAX_HIVES + '-hive limit — deselect some.</span>' : '') +
+        '<span style="flex:1"></span>' +
+        '<button type="button" onclick="runBulkAction(\'restart\')" style="' + btn + '">Restart</button>' +
+        '<button type="button" onclick="runBulkAction(\'upgrade\')" style="' + btn + '">Upgrade to latest</button>' +
+        '<button type="button" onclick="runBulkAction(\'enable-auto-upgrade\')" style="' + btn + '">Auto-upgrade on</button>' +
+        '<button type="button" onclick="runBulkAction(\'disable-auto-upgrade\')" style="' + btn + '">Auto-upgrade off</button>' +
+        branchPicker +
+        '<button type="button" onclick="clearBulkSelection()" style="' + btn + ';color:var(--muted)">Clear</button>' +
+        '</div>';
+      bar.style.display = '';
+      var sel = document.getElementById('bulk-branch-select');
+      if (sel) {
+        sel.onchange = function() {
+          var b = sel.value;
+          sel.value = '';
+          if (b) runBulkAction('switch-branch', b);
+        };
+      }
+    }
+
+    var BULK_ACTION_LABELS = {
+      'restart': 'Restart',
+      'upgrade': 'Upgrade to latest',
+      'enable-auto-upgrade': 'Enable auto-upgrade on',
+      'disable-auto-upgrade': 'Disable auto-upgrade on',
+      'switch-branch': 'Switch branch for'
+    };
+
+    async function runBulkAction(action, branch) {
+      var ids = bulkSelectedIds();
+      if (!ids.length) { hiveToast('No hives selected', 'error'); return; }
+      if (ids.length > BULK_MAX_HIVES) {
+        hiveToast('Select at most ' + BULK_MAX_HIVES + ' hives per bulk action', 'error');
+        return;
+      }
+      var label = BULK_ACTION_LABELS[action] || action;
+      var noun = ids.length === 1 ? 'hive' : 'hives';
+      /* Confirmation names BOTH the action and the count — restarting a batch
+         of live hives must never be one misclick. Disruptive actions also list
+         the hives so the user can see exactly what is in the batch. */
+      if (BULK_DISRUPTIVE_ACTIONS[action]) {
+        var names = ids.slice(0, 10).map(function(i) { return esc(i); }).join('<br>');
+        if (ids.length > 10) names += '<br>… and ' + (ids.length - 10) + ' more';
+        var msg = '<strong>' + esc(label) + (branch ? ' ' + esc(branch) : '') + '</strong> on <strong>' +
+          ids.length + ' ' + noun + '</strong>?<br><br>' +
+          '<div style="font-family:monospace;font-size:0.75rem;color:var(--muted);text-align:left;max-height:180px;overflow:auto">' + names + '</div>';
+        if (!await hiveConfirm(msg, true)) return;
+      }
+      hiveToast(label + ' — ' + ids.length + ' ' + noun + '…', 'info');
+      try {
+        var resp = await fetch('/api/saas/hives/bulk', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({action: action, hive_ids: ids, branch: branch || ''})
+        });
+        var data = await resp.json();
+        if (!resp.ok) { hiveToast((data && data.error) || 'Bulk action failed', 'error'); return; }
+        showBulkResults(label, data);
+        clearBulkSelection();
+        loadHives();
+        setTimeout(loadHives, 10000);
+        setTimeout(loadHives, 30000);
+        setTimeout(loadHives, 60000);
+      } catch(e) {
+        hiveToast('Error: ' + e.message, 'error');
+      }
+    }
+
+    /* Partial failure is the normal case, so always show the per-hive
+       breakdown rather than a single success toast: the user needs to know
+       WHICH hives failed and why. */
+    function showBulkResults(label, data) {
+      var results = (data && data.results) || [];
+      var ok = data.succeeded || 0, failed = data.failed || 0;
+      var failedRows = '';
+      var heartbeatCount = 0;
+      for (var i = 0; i < results.length; i++) {
+        var r = results[i] || {};
+        if (r.ok) { if (r.via === 'heartbeat') heartbeatCount++; continue; }
+        failedRows += '<div style="display:flex;gap:8px;padding:3px 0;font-size:0.72rem">' +
+          '<span style="font-family:monospace;color:var(--red);flex:none">' + esc(r.hive_id || '?') + '</span>' +
+          '<span style="color:var(--muted)">' + esc(r.error || 'failed') + '</span></div>';
+      }
+      if (!failed) {
+        var extra = heartbeatCount
+          ? ' (' + heartbeatCount + ' queued for delivery on next check-in)'
+          : '';
+        hiveToast(label + ': ' + ok + ' succeeded' + extra, 'success');
+        return;
+      }
+      hiveConfirm('<strong>' + esc(label) + '</strong><br><br>' +
+        '<span style="color:var(--green)">' + ok + ' succeeded</span>' +
+        (heartbeatCount ? ' <span style="color:var(--muted);font-size:0.75rem">(' + heartbeatCount + ' via heartbeat)</span>' : '') +
+        ' &nbsp; <span style="color:var(--red)">' + failed + ' failed</span>' +
+        '<div style="margin-top:10px;text-align:left;max-height:220px;overflow:auto">' + failedRows + '</div>', true);
+    }
+
     function renderHives(allHives, force) {
       allHives = allHives || [];
       /* The signature must include the active filters, otherwise toggling a
@@ -6762,6 +6991,12 @@ const dashboardHTML = `<!DOCTYPE html>
       var hives = applyDashFilters(assignedAll).concat(unassignedAll);
       var filterBar = document.getElementById('hive-filter-bar');
       if (filterBar) filterBar.style.display = allHives.length ? '' : 'none';
+      /* Nothing renderable below means no rows to act on — drop the selection
+         so the bulk bar can't linger over an empty or fully-filtered table. */
+      if (!allHives.length || !hives.length) {
+        _bulkSelected = {};
+        renderBulkBar();
+      }
       /* Counts are over the assigned set only, matching what the chips filter. */
       renderStatusFilterBar(assignedAll, hives.length - unassignedAll.length);
       /* Drift exceptions are scoped to assigned hives for the same reason: a
@@ -6789,8 +7024,11 @@ const dashboardHTML = `<!DOCTYPE html>
           '</div>';
         return;
       }
+      /* Prune selections for hives that are no longer visible BEFORE building
+         rows, so the checkbox state and the bulk bar's count agree. */
+      syncBulkSelection(hives);
       var repoPath = function(h) { return h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : h.primaryRepo || ''; };
-      var buildRow = function(h, i) {
+      var buildRow = function(h, i, section) {
         var dot = h.online ? healthBadge(h) : '<span class="online-dot off"></span>';
         var rp = repoPath(h);
         var repoLink = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" class="repo-link">' + esc(h.primaryRepo) + '</a>' : '';
@@ -6916,8 +7154,10 @@ const dashboardHTML = `<!DOCTYPE html>
         if (h.pendingRequestCount > 0 && (h.role === 'owner' || h.role === 'read-write')) {
           pendingPill = '<a href="#" onclick="togglePendingRow(\'' + esc(h.id) + '\');return false" style="display:inline-flex;align-items:center;gap:4px;padding:3px 10px;background:rgba(59,130,246,0.12);color:#60a5fa;border:1px solid rgba(59,130,246,0.3);border-radius:4px;font-size:0.7rem;text-decoration:none;cursor:pointer;white-space:nowrap">&#x1F514; ' + h.pendingRequestCount + ' pending</a>';
         }
-        // 14 = the 13 original columns plus Uptime.
-        var TOTAL_COLUMNS = 15;
+        // 16 = the 13 original columns, plus Uptime, plus Drift, plus the
+        // bulk-select column. Counted against the <th> cells in the header and
+        // the <td> cells emitted below (bulkCheckboxCell contributes one).
+        var TOTAL_COLUMNS = 16;
         var pendingExpandRow = '';
         if (h.pendingRequestCount > 0 && (h.role === 'owner' || h.role === 'read-write') && (h.pending_requests || []).length > 0) {
           var prItems = (h.pending_requests || []).map(function(pr) {
@@ -6937,6 +7177,7 @@ const dashboardHTML = `<!DOCTYPE html>
           pendingExpandRow = '<tr id="pending-row-' + esc(h.id) + '" style="display:none"><td colspan="' + TOTAL_COLUMNS + '"><div style="padding:8px 16px;background:rgba(59,130,246,0.05);border-radius:6px;margin:4px 0">' + prItems + '</div></td></tr>';
         }
         return '<tr>' +
+          bulkCheckboxCell(h, section || 'all') +
           '<td class="hive-menu-cell" style="position:relative;width:30px;text-align:center;overflow:visible">' + (h.migrationStatus === 'migrating' ? '<span style="font-size:1.1rem;color:var(--border);user-select:none;cursor:not-allowed" title="Disabled during migration">⋮</span>' : '<span style="cursor:pointer;font-size:1.1rem;color:var(--muted);user-select:none">⋮</span>' + pendingBadge + '<div class="hive-menu-dropdown" style="display:none;position:absolute;left:0;bottom:auto;background:#1c2128;border:1px solid #30363d;border-radius:8px;min-width:160px;padding:4px 0;z-index:1000;box-shadow:0 8px 24px rgba(0,0,0,0.5)">' + menuItems.join('') + '</div>') + '</td>' +
           '<td style="text-align:left;line-height:1.4">' + (function() { var isHostedRow = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'))); var dh = isHostedRow && h.id ? ('/api/saas/hives/' + encodeURIComponent(h.id) + '/open') : (rb ? esc(rb) : ''); var displayName = h.name || h.id; var parts = displayName.split('/'); var orgName = parts.length > 1 ? parts[0] : ''; var repoName = parts.length > 1 ? parts.slice(1).join('/') : displayName; var rp = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : ''; var ghIcon = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>' : ''; var link = function(text, bold) { if (dh) { return '<a href="' + dh + '" target="_blank" class="' + (bold ? 'hive-name-link' : 'hive-sub-link') + '" title="Open dashboard">' + esc(text) + '</a>'; } var s = bold ? 'font-weight:700;color:inherit' : 'color:#6b7280;font-weight:400'; return '<span style="' + s + '">' + esc(text) + '</span>'; }; var line1 = dot + ' ' + link(orgName || repoName, true); var fcPill = h.online ? failingCheckSummary(h) : ''; var line2 = orgName ? '<div style="padding-left:18px;font-size:0.8rem">' + link(repoName, false) + ' ' + ghIcon + ' ' + roleBadge(h.role) + fcPill + '</div>' : '<div style="padding-left:18px">' + ghIcon + ' ' + roleBadge(h.role) + fcPill + '</div>'; var line3 = pendingPill ? '<div style="margin-top:4px;padding-left:18px">' + pendingPill + '</div>' : ''; return line1 + line2 + line3; })() + '</td>' +
           '<td>' + (isLocal ? '<span style="display:inline-block;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:rgba(107,114,128,0.15);color:#9ca3af;border:1px solid rgba(107,114,128,0.3)">local</span>' : clusterBadge(h.clusterId, h.clusterName)) + '</td>' +
@@ -6958,13 +7199,16 @@ const dashboardHTML = `<!DOCTYPE html>
          match the table's muted uppercase heading treatment (see .hive-table th). */
       /* Count of <th> cells in the hive table header below. The section-header
          row spans all of them; a stale value would leave the separator short
-         and the table visibly ragged. Bumped from 14 when the Drift column
-         was added. */
-      var TOTAL_COLUMNS_HEADER = 15;
-      var sectionHeader = function(label, count) {
+         and the table visibly ragged. 15 with the Drift column, plus one more
+         for the bulk-select column added here. */
+      var TOTAL_COLUMNS_HEADER = 16;
+      /* section, when given, adds a select-all checkbox scoped to THIS
+         section's rows only (Assigned and Unassigned select independently). */
+      var sectionHeader = function(label, count, section) {
         return '<tr class="hive-section-head"><td colspan="' + TOTAL_COLUMNS_HEADER + '" ' +
           'style="padding:14px 12px 6px;color:var(--muted);font-weight:600;font-size:0.75rem;' +
           'text-transform:uppercase;letter-spacing:0.5px;text-align:left">' +
+          (section ? bulkSectionCheckbox(section) : '') +
           esc(label) + ' (' + count + ')</td></tr>';
       };
       var rows;
@@ -6984,22 +7228,31 @@ const dashboardHTML = `<!DOCTYPE html>
         var _idx = 0;
         rows = '';
         if (assigned.length > 0) {
-          rows += sectionHeader('Assigned hives', assigned.length);
-          for (var _ai = 0; _ai < assigned.length; _ai++) { rows += buildRow(assigned[_ai], _idx++); }
+          rows += sectionHeader('Assigned hives', assigned.length, 'assigned');
+          for (var _ai = 0; _ai < assigned.length; _ai++) { rows += buildRow(assigned[_ai], _idx++, 'assigned'); }
         }
         if (unassigned.length > 0) {
+          /* Unassigned placeholders are never bulk-eligible (nothing is
+             running yet), so the section gets no select-all box. */
           rows += sectionHeader('Unassigned hives', unassigned.length);
-          for (var _ui = 0; _ui < unassigned.length; _ui++) { rows += buildRow(unassigned[_ui], _idx++); }
+          for (var _ui = 0; _ui < unassigned.length; _ui++) { rows += buildRow(unassigned[_ui], _idx++, 'unassigned'); }
         }
       } else {
         /* Non-admin: single flat list, exactly as before. */
-        rows = hives.map(buildRow).join('');
+        rows = hives.map(function(h, i) { return buildRow(h, i, 'all'); }).join('');
       }
       document.getElementById('hives-container').innerHTML =
         '<div class="table-wrap"><table class="hive-table"><thead><tr>' +
+        /* Non-admin lists have no section headers, so the flat list's
+           select-all lives in the table head instead. */
+        '<th style="width:26px;text-align:center">' + (_isAdmin ? '' : bulkSectionCheckbox('all')) + '</th>' +
         '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer">Location ⇅</th><th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅</th><th>Public</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th>' +
         '<th title="Configuration drift from the fleet norm — hover a value for the specific signals">Drift</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table></div>';
+      /* Re-derive the bar and the select-all tri-state from _bulkSelected now
+         that the fresh checkboxes exist in the DOM. */
+      renderBulkBar();
+      syncBulkSectionHeaderBoxes();
       setTimeout(function() {
         var tw = document.querySelector('.table-wrap');
         if (tw && tw.scrollWidth > tw.clientWidth) tw.classList.add('has-scroll');

--- a/v2/pkg/hub/saas_bulk.go
+++ b/v2/pkg/hub/saas_bulk.go
@@ -1,0 +1,448 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Bulk fleet operations for the hub dashboard's "My Hives" list.
+//
+// Every bulk action is a thin fan-out over the SAME logic the single-hive
+// handlers use (handleUpgradeHive, handleToggleAutoUpgrade, handleSwitchBranch,
+// rolloutRestartHive). The rules that make this safe to expose:
+//
+//  1. Authorization is re-derived PER HIVE from the hub's own store. The
+//     client-supplied ID list is treated as untrusted input: every ID is
+//     loaded with loadSaaSHive and checked against the same
+//     "owner or hub admin" predicate the single-hive handlers apply. A hive
+//     the caller may not touch is reported as a per-hive error, never applied.
+//  2. Partial failure is the normal case (a hive may be offline, unclaimed,
+//     or on a firewalled cluster), so the response is a per-hive result list
+//     rather than a single boolean.
+//  3. Blast radius is bounded by maxBulkHivesPerRequest and the work is run
+//     through a fixed-size worker pool (bulkActionConcurrency) so a 42-hive
+//     fleet never becomes 42 simultaneous kubectl processes.
+
+// maxBulkHivesPerRequest caps how many hives a single bulk request may target.
+// The fleet is ~42 hives across 2 clusters, so this comfortably covers
+// "select all" today while keeping a malicious or buggy client from asking the
+// hub to shell out to kubectl an unbounded number of times.
+const maxBulkHivesPerRequest = 100
+
+// bulkActionConcurrency bounds how many hives are acted on at once. Each unit
+// of work can shell out to kubectl (up to upgradeKubectlTimeout each), so this
+// trades wall-clock time for a predictable ceiling on concurrent subprocesses
+// and API-server load. 4 keeps a 100-hive worst case well inside
+// bulkRequestBudget while never stampeding a single cluster's API server.
+const bulkActionConcurrency = 4
+
+// bulkRequestBudget bounds the total wall-clock time of one bulk request so a
+// batch of unreachable clusters can never hold an HTTP handler open forever.
+// Worst case per hive is upgradeKubectlTimeout (15s); with the concurrency
+// above, 100 hives need ~100/4*15s = 375s, so this leaves headroom without
+// being unbounded.
+const bulkRequestBudget = 8 * time.Minute
+
+// maxBulkRequestBodyBytes caps the bulk request body. A request is a short JSON
+// object plus at most maxBulkHivesPerRequest hive IDs, so 64KiB is generous.
+const maxBulkRequestBodyBytes = 64 * 1024
+
+// Bulk action names accepted by handleBulkHiveAction.
+const (
+	bulkActionRestart            = "restart"
+	bulkActionUpgrade            = "upgrade"
+	bulkActionEnableAutoUpgrade  = "enable-auto-upgrade"
+	bulkActionDisableAutoUpgrade = "disable-auto-upgrade"
+	bulkActionSwitchBranch       = "switch-branch"
+)
+
+// BulkHiveRequest is the body of POST /api/saas/hives/bulk.
+type BulkHiveRequest struct {
+	Action  string   `json:"action"`
+	HiveIDs []string `json:"hive_ids"`
+	// Branch is only read by the switch-branch action.
+	Branch string `json:"branch"`
+}
+
+// BulkHiveResult is the outcome for ONE hive in a bulk request. Ok=false always
+// carries a human-readable Error; Via records the delivery path actually used
+// ("kubectl" or "heartbeat") so the UI can explain why a firewalled cluster's
+// hive reports success without an immediate rollout.
+type BulkHiveResult struct {
+	HiveID string `json:"hive_id"`
+	Ok     bool   `json:"ok"`
+	Error  string `json:"error,omitempty"`
+	Via    string `json:"via,omitempty"`
+}
+
+// Delivery paths reported in BulkHiveResult.Via.
+const (
+	bulkViaKubectl   = "kubectl"
+	bulkViaHeartbeat = "heartbeat"
+	bulkViaStore     = "store"
+)
+
+// bulkDefaultBranch is the branch assumed when a hive has never reported one.
+// Matches the same "" -> "v2" default the single-hive upgrade paths apply.
+const bulkDefaultBranch = "v2"
+
+// bulkHiveImageRepo is the container image repository the hosted hives run,
+// matching the image handleSwitchBranch sets and docker.yml publishes.
+const bulkHiveImageRepo = "ghcr.io/kubestellar/hive"
+
+// registerBulkRoutes wires the bulk endpoint. Kept separate from
+// registerSaaSRoutes so this feature's diff does not collide with the
+// concurrently-edited route table.
+func (s *HubServer) registerBulkRoutes() {
+	s.mux.HandleFunc("POST /api/saas/hives/bulk", s.requireAuth(s.handleBulkHiveAction))
+}
+
+// authorizeBulkHive re-derives authorization for one hive from the hub's own
+// store, mirroring the owner check every single-hive handler performs
+// (h.Owner != username && username != hubAdminUsername). It returns the loaded
+// hive on success, or a reason string on refusal. The client's list is never
+// trusted: an ID that does not resolve, or resolves to someone else's hive, is
+// refused here rather than acted on.
+func authorizeBulkHive(id, username string) (*SaaSHive, string) {
+	if username == "" {
+		return nil, "not authenticated"
+	}
+	h := loadSaaSHive(id)
+	if h == nil {
+		return nil, "hive not found"
+	}
+	if h.Owner != username && username != hubAdminUsername {
+		return nil, "not authorized for this hive"
+	}
+	return h, ""
+}
+
+func (s *HubServer) handleBulkHiveAction(w http.ResponseWriter, r *http.Request) {
+	origin := r.Header.Get("Origin")
+	if isTrustedOrigin(origin) {
+		w.Header().Set("Access-Control-Allow-Origin", origin)
+		w.Header().Set("Access-Control-Allow-Credentials", "true")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	}
+	if r.Method == "OPTIONS" {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	username := s.getAuthUser(r)
+	if username == "" {
+		writeBulkError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxBulkRequestBodyBytes)
+	var body BulkHiveRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeBulkError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	switch body.Action {
+	case bulkActionRestart, bulkActionUpgrade, bulkActionEnableAutoUpgrade,
+		bulkActionDisableAutoUpgrade, bulkActionSwitchBranch:
+	default:
+		writeBulkError(w, http.StatusBadRequest, "unknown bulk action")
+		return
+	}
+
+	// De-duplicate while preserving the client's order: a repeated ID would
+	// otherwise restart the same hive twice within one request.
+	ids := make([]string, 0, len(body.HiveIDs))
+	seen := map[string]bool{}
+	for _, id := range body.HiveIDs {
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		writeBulkError(w, http.StatusBadRequest, "no hives selected")
+		return
+	}
+	if len(ids) > maxBulkHivesPerRequest {
+		writeBulkError(w, http.StatusBadRequest,
+			fmt.Sprintf("too many hives in one request (%d, max %d)", len(ids), maxBulkHivesPerRequest))
+		return
+	}
+
+	if body.Action == bulkActionSwitchBranch {
+		if body.Branch == "" {
+			writeBulkError(w, http.StatusBadRequest, "branch is required for switch-branch")
+			return
+		}
+		// Validate ONCE for the whole batch rather than per hive — the target
+		// branch is the same for every selected hive, and the fallback check
+		// hits the GitHub API.
+		if !s.validateBulkBranch(body.Branch) {
+			writeBulkError(w, http.StatusBadRequest,
+				"unknown branch (does not exist on the hive repo)")
+			return
+		}
+	}
+
+	s.logger.Info("audit: bulk hive action requested",
+		"action", body.Action, "by", username, "count", len(ids), "hives", ids, "branch", body.Branch)
+
+	results := s.runBulkAction(body.Action, body.Branch, ids, username)
+
+	okCount := 0
+	for _, res := range results {
+		if res.Ok {
+			okCount++
+		}
+	}
+	s.logger.Info("audit: bulk hive action completed",
+		"action", body.Action, "by", username, "requested", len(ids),
+		"succeeded", okCount, "failed", len(ids)-okCount)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"action":    body.Action,
+		"requested": len(ids),
+		"succeeded": okCount,
+		"failed":    len(ids) - okCount,
+		"results":   results,
+	})
+}
+
+// runBulkAction fans the action out over a bounded worker pool and returns one
+// result per requested ID, in the order the IDs were given.
+func (s *HubServer) runBulkAction(action, branch string, ids []string, username string) []BulkHiveResult {
+	results := make([]BulkHiveResult, len(ids))
+	deadline := time.Now().Add(bulkRequestBudget)
+
+	workers := bulkActionConcurrency
+	if len(ids) < workers {
+		workers = len(ids)
+	}
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for idx := range jobs {
+				id := ids[idx]
+				if time.Now().After(deadline) {
+					// The request budget is spent — report the remainder
+					// honestly rather than holding the connection open.
+					results[idx] = BulkHiveResult{HiveID: id, Ok: false,
+						Error: "skipped — bulk request time budget exhausted"}
+					continue
+				}
+				results[idx] = s.applyBulkAction(action, branch, id, username)
+			}
+		}()
+	}
+	for i := range ids {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+	return results
+}
+
+// applyBulkAction authorizes ONE hive and applies the action, reusing the exact
+// mechanics of the corresponding single-hive handler.
+func (s *HubServer) applyBulkAction(action, branch, id, username string) BulkHiveResult {
+	h, reason := authorizeBulkHive(id, username)
+	if h == nil {
+		return BulkHiveResult{HiveID: id, Ok: false, Error: reason}
+	}
+	switch action {
+	case bulkActionRestart, bulkActionUpgrade:
+		return s.bulkRestartOrUpgrade(h, id, username, action)
+	case bulkActionEnableAutoUpgrade:
+		return s.bulkSetAutoUpgrade(h, id, username, true)
+	case bulkActionDisableAutoUpgrade:
+		return s.bulkSetAutoUpgrade(h, id, username, false)
+	case bulkActionSwitchBranch:
+		return s.bulkSwitchBranch(h, id, username, branch)
+	}
+	return BulkHiveResult{HiveID: id, Ok: false, Error: "unknown bulk action"}
+}
+
+// bulkRestartOrUpgrade restarts one hive's deployment. This is the same
+// operation handleUpgradeHive performs (`kubectl rollout restart
+// deployment/hive`), but routed through rolloutRestartHive so it inherits the
+// bounded timeout and the unreachable-cluster cache — without that, a batch
+// containing hives on a firewalled cluster (vllm-d) would stall for the full
+// kubectl timeout per hive.
+//
+// When kubectl cannot deliver (firewalled cluster, or one already known
+// unreachable), the heartbeat fallback is armed exactly as the single-hive
+// paths do: s.heartbeatUpgrade[id] is set to the branch's latest SHA and the
+// registry is marked Upgrading, so the spoke self-restarts on its next
+// check-in. That is the ONLY delivery path for unreachable clusters, so it is
+// reported as success with Via="heartbeat", not as an error.
+func (s *HubServer) bulkRestartOrUpgrade(h *SaaSHive, id, username, action string) BulkHiveResult {
+	cluster := s.clusterForHive(h)
+	if cluster == nil {
+		return BulkHiveResult{HiveID: id, Ok: false, Error: "no cluster config for this hive"}
+	}
+
+	// The branch a hive actually runs is reported by heartbeat into the
+	// registry, not stored on the SaaS record — same lookup
+	// handleToggleAutoUpgrade performs before computing an upgrade target.
+	s.mu.RLock()
+	branch := ""
+	for _, reg := range s.registry.Hives {
+		if reg.ID == id {
+			branch = reg.GitBranch
+			break
+		}
+	}
+	s.mu.RUnlock()
+	if branch == "" {
+		branch = bulkDefaultBranch
+	}
+	latestSHA := getLatestSHAForBranch(branch)
+
+	delivered := s.rolloutRestartHive(cluster, id)
+
+	s.mu.Lock()
+	for i := range s.registry.Hives {
+		if s.registry.Hives[i].ID != id {
+			continue
+		}
+		// Only an upgrade advances the target; a plain restart re-pulls the
+		// same tag and must not make the dashboard claim a version change.
+		if action == bulkActionUpgrade && latestSHA != "" {
+			s.registry.Hives[i].Upgrading = true
+			s.registry.Hives[i].UpgradeTarget = latestSHA
+			s.registry.Hives[i].UpgradeStartedAt = time.Now()
+		}
+		break
+	}
+	if !delivered && action == bulkActionUpgrade && latestSHA != "" {
+		s.heartbeatUpgrade[id] = latestSHA
+	}
+	s.mu.Unlock()
+
+	if !delivered && action == bulkActionRestart {
+		// A restart has no SHA to hand the spoke, so there is nothing the
+		// heartbeat path can carry — say so instead of reporting success.
+		s.logger.Warn("bulk restart could not reach cluster", "hive", id, "cluster", cluster.ID)
+		return BulkHiveResult{HiveID: id, Ok: false,
+			Error: "cluster unreachable from the hub — restart could not be delivered"}
+	}
+	if !delivered {
+		s.logger.Info("audit: bulk upgrade queued via heartbeat",
+			"hive_id", id, "by", username, "target", latestSHA, "cluster", cluster.ID)
+		return BulkHiveResult{HiveID: id, Ok: true, Via: bulkViaHeartbeat}
+	}
+	s.logger.Info("audit: bulk hive "+action, "hive_id", id, "by", username, "cluster", cluster.ID)
+	return BulkHiveResult{HiveID: id, Ok: true, Via: bulkViaKubectl}
+}
+
+// bulkSetAutoUpgrade mirrors handleToggleAutoUpgrade's persistence: the SaaS
+// store and the registry are the source of truth for the dashboard, and the
+// preference reaches the spoke on its next heartbeat. No kubectl is involved,
+// so this works identically for firewalled clusters.
+func (s *HubServer) bulkSetAutoUpgrade(h *SaaSHive, id, username string, enabled bool) BulkHiveResult {
+	h.AutoUpgrade = enabled
+	if err := saveSaaSHive(h); err != nil {
+		return BulkHiveResult{HiveID: id, Ok: false, Error: "failed to save"}
+	}
+	s.logger.Info("audit: bulk auto-upgrade toggled",
+		"hive_id", id, "auto_upgrade", enabled, "by", username)
+	return BulkHiveResult{HiveID: id, Ok: true, Via: bulkViaStore}
+}
+
+// bulkSwitchBranch points one hive at another branch's image. It reuses
+// branchToTag (the same sanitization handleSwitchBranch and docker.yml apply)
+// and the same heartbeat fallback: when kubectl cannot set the image,
+// s.heartbeatSwitchTag[id] is recorded and the spoke — which holds the
+// hive-self-upgrade RBAC to patch its own deployment — applies it on its next
+// check-in. Branch validity is checked ONCE by the caller, not per hive.
+func (s *HubServer) bulkSwitchBranch(h *SaaSHive, id, username, branch string) BulkHiveResult {
+	cluster := s.clusterForHive(h)
+	if cluster == nil {
+		return BulkHiveResult{HiveID: id, Ok: false, Error: "no cluster config for this hive"}
+	}
+	imageTag := branchToTag(branch) + "-latest"
+	image := bulkHiveImageRepo + ":" + imageTag
+
+	delivered := false
+	if !s.clusterRecentlyUnreachable(cluster.ID) {
+		ns := hiveHostedNamespacePrefix + id
+		cmd := kubectlForCluster(cluster, "set", "image", "deployment/hive", "*="+image, "-n", ns)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			s.markClusterUnreachable(cluster.ID)
+			s.logger.Warn("bulk branch switch kubectl failed, using heartbeat fallback",
+				"hive", id, "branch", branch, "output", string(out))
+		} else {
+			s.markClusterReachable(cluster.ID)
+			delivered = true
+			// Restart so the new image is pulled — same as the single-hive path.
+			s.rolloutRestartHive(cluster, id)
+		}
+	}
+
+	s.mu.Lock()
+	if !delivered {
+		s.heartbeatSwitchTag[id] = imageTag
+	}
+	for i := range s.registry.Hives {
+		if s.registry.Hives[i].ID == id {
+			s.registry.Hives[i].Upgrading = true
+			s.registry.Hives[i].UpgradeTarget = imageTag
+			s.registry.Hives[i].UpgradeStartedAt = time.Now()
+			break
+		}
+	}
+	s.mu.Unlock()
+
+	via := bulkViaKubectl
+	if !delivered {
+		via = bulkViaHeartbeat
+	}
+	s.logger.Info("audit: bulk hive branch switched",
+		"hive_id", id, "branch", branch, "image", image, "by", username, "via", via)
+	return BulkHiveResult{HiveID: id, Ok: true, Via: via}
+}
+
+// validateBulkBranch resolves whether a branch is a legitimate switch target,
+// using the same two-step rule as handleSwitchBranch: prefer the tracked branch
+// list, then fall back to a live existence check against the hive repo (which
+// also populates the SHA cache, so the branch is tracked from then on).
+func (s *HubServer) validateBulkBranch(branch string) bool {
+	for _, b := range s.trackedBranchList() {
+		if b == branch {
+			return true
+		}
+	}
+	fetchBranchSHA(s.logger, branch)
+	return getLatestSHAForBranch(branch) != ""
+}
+
+// sortedBulkResults returns results ordered failures-first then by hive ID, for
+// callers that want a stable, most-actionable-first presentation.
+func sortedBulkResults(results []BulkHiveResult) []BulkHiveResult {
+	out := make([]BulkHiveResult, len(results))
+	copy(out, results)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Ok != out[j].Ok {
+			return !out[i].Ok
+		}
+		return out[i].HiveID < out[j].HiveID
+	})
+	return out
+}
+
+func writeBulkError(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/v2/pkg/hub/saas_bulk_test.go
+++ b/v2/pkg/hub/saas_bulk_test.go
@@ -1,0 +1,371 @@
+package hub
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// bulkTestHub returns a hub with the bulk route registered and the SaaS store
+// pointed at a temp dir, plus a cleanup func.
+func bulkTestHub(t *testing.T) *HubServer {
+	t.Helper()
+	cleanup := helperSetupTempDirs(t)
+	t.Cleanup(cleanup)
+	// NewHubServer -> registerSaaSRoutes already wires the bulk route.
+	return NewHubServer(0, slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)), "test", "v2")
+}
+
+// bulkSeedHive writes a hosted hive owned by owner into the temp SaaS store,
+// along with the owner's user record — getAuthUser only honours a session
+// cookie for a user that actually exists.
+func bulkSeedHive(t *testing.T, id, owner string) {
+	t.Helper()
+	bulkSeedUser(t, owner)
+	if err := saveSaaSHive(&SaaSHive{ID: id, Owner: owner}); err != nil {
+		t.Fatalf("seed hive %s: %v", id, err)
+	}
+}
+
+func bulkSeedUser(t *testing.T, username string) {
+	t.Helper()
+	if username == "" || loadSaaSUser(username) != nil {
+		return
+	}
+	if err := saveSaaSUser(&SaaSUser{GitHubUsername: username}); err != nil {
+		t.Fatalf("seed user %s: %v", username, err)
+	}
+}
+
+func bulkPost(t *testing.T, srv *HubServer, user string, body any) (*httptest.ResponseRecorder, map[string]any) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req := httptest.NewRequest("POST", "/api/saas/hives/bulk", bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	if user != "" {
+		req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: user})
+	}
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+	var out map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &out)
+	return w, out
+}
+
+// TestAuthorizeBulkHivePerHive covers the core security property: authorization
+// is re-derived per hive from the hub's own store, never from the client list.
+func TestAuthorizeBulkHivePerHive(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	bulkSeedHive(t, "hosted-alice", "alice")
+	bulkSeedHive(t, "hosted-bob", "bob")
+	bulkSeedUser(t, hubAdminUsername)
+
+	tests := []struct {
+		name    string
+		hiveID  string
+		caller  string
+		wantOK  bool
+		wantWhy string
+	}{
+		{"owner may act on own hive", "hosted-alice", "alice", true, ""},
+		{"owner may not act on another user's hive", "hosted-bob", "alice", false, "not authorized for this hive"},
+		{"hub admin may act on any hive", "hosted-bob", hubAdminUsername, true, ""},
+		{"unknown hive is refused", "hosted-ghost", "alice", false, "hive not found"},
+		{"unauthenticated caller is refused", "hosted-alice", "", false, "not authenticated"},
+		{"path traversal id is refused", "../../etc", "alice", false, "hive not found"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h, why := authorizeBulkHive(tc.hiveID, tc.caller)
+			gotOK := h != nil
+			if gotOK != tc.wantOK {
+				t.Fatalf("authorizeBulkHive(%q,%q) ok=%v, want %v (reason %q)",
+					tc.hiveID, tc.caller, gotOK, tc.wantOK, why)
+			}
+			if !tc.wantOK && why != tc.wantWhy {
+				t.Errorf("reason = %q, want %q", why, tc.wantWhy)
+			}
+		})
+	}
+}
+
+// TestBulkHandlerRejectsNonOwnerPerHive proves an attacker cannot widen their
+// blast radius by putting someone else's hive IDs in the list: the request as a
+// whole succeeds, but each unauthorized hive comes back as a per-hive error and
+// is never acted on.
+func TestBulkHandlerRejectsNonOwnerPerHive(t *testing.T) {
+	srv := bulkTestHub(t)
+	bulkSeedHive(t, "hosted-mine", "mallory")
+	bulkSeedHive(t, "hosted-yours", "victim")
+
+	w, out := bulkPost(t, srv, "mallory", BulkHiveRequest{
+		Action:  bulkActionDisableAutoUpgrade,
+		HiveIDs: []string{"hosted-mine", "hosted-yours"},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	results := bulkResults(t, out)
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+	byID := map[string]BulkHiveResult{}
+	for _, r := range results {
+		byID[r.HiveID] = r
+	}
+	if !byID["hosted-mine"].Ok {
+		t.Errorf("own hive should succeed, got %+v", byID["hosted-mine"])
+	}
+	if byID["hosted-yours"].Ok {
+		t.Error("another user's hive must NOT be acted on")
+	}
+	if !strings.Contains(byID["hosted-yours"].Error, "not authorized") {
+		t.Errorf("want authorization error, got %q", byID["hosted-yours"].Error)
+	}
+	// The victim's stored preference must be untouched.
+	victim := loadSaaSHive("hosted-yours")
+	if victim == nil || victim.AutoUpgrade {
+		t.Error("victim hive was mutated by an unauthorized bulk request")
+	}
+}
+
+// TestBulkHandlerUnauthenticated confirms a caller with no session is rejected
+// outright rather than reaching the per-hive fan-out.
+func TestBulkHandlerUnauthenticated(t *testing.T) {
+	srv := bulkTestHub(t)
+	bulkSeedHive(t, "hosted-a", "alice")
+
+	w, _ := bulkPost(t, srv, "", BulkHiveRequest{
+		Action:  bulkActionEnableAutoUpgrade,
+		HiveIDs: []string{"hosted-a"},
+	})
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+	h := loadSaaSHive("hosted-a")
+	if h == nil || h.AutoUpgrade {
+		t.Error("unauthenticated request must not mutate any hive")
+	}
+}
+
+// TestBulkPartialFailureAggregation checks that a mixed batch reports an
+// accurate per-hive breakdown plus correct succeeded/failed counts, rather
+// than collapsing to a single boolean.
+func TestBulkPartialFailureAggregation(t *testing.T) {
+	srv := bulkTestHub(t)
+	bulkSeedHive(t, "hosted-ok1", "alice")
+	bulkSeedHive(t, "hosted-ok2", "alice")
+	bulkSeedHive(t, "hosted-other", "bob")
+
+	tests := []struct {
+		name          string
+		ids           []string
+		wantSucceeded int
+		wantFailed    int
+	}{
+		{"all succeed", []string{"hosted-ok1", "hosted-ok2"}, 2, 0},
+		{"one unauthorized", []string{"hosted-ok1", "hosted-other"}, 1, 1},
+		{"one missing", []string{"hosted-ok1", "hosted-nope"}, 1, 1},
+		{"all fail", []string{"hosted-other", "hosted-nope"}, 0, 2},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w, out := bulkPost(t, srv, "alice", BulkHiveRequest{
+				Action:  bulkActionEnableAutoUpgrade,
+				HiveIDs: tc.ids,
+			})
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", w.Code)
+			}
+			if got := int(out["succeeded"].(float64)); got != tc.wantSucceeded {
+				t.Errorf("succeeded = %d, want %d", got, tc.wantSucceeded)
+			}
+			if got := int(out["failed"].(float64)); got != tc.wantFailed {
+				t.Errorf("failed = %d, want %d", got, tc.wantFailed)
+			}
+			results := bulkResults(t, out)
+			if len(results) != len(tc.ids) {
+				t.Fatalf("got %d results, want one per requested id (%d)", len(results), len(tc.ids))
+			}
+			// Every failure must carry a reason the UI can display.
+			for _, r := range results {
+				if !r.Ok && r.Error == "" {
+					t.Errorf("hive %s failed with no reason", r.HiveID)
+				}
+			}
+		})
+	}
+}
+
+// TestBulkRequestCap covers the blast-radius bound.
+func TestBulkRequestCap(t *testing.T) {
+	srv := bulkTestHub(t)
+	bulkSeedHive(t, "hosted-a", "alice")
+
+	tooMany := make([]string, maxBulkHivesPerRequest+1)
+	for i := range tooMany {
+		tooMany[i] = fmt.Sprintf("hosted-%d", i)
+	}
+	atCap := make([]string, maxBulkHivesPerRequest)
+	for i := range atCap {
+		atCap[i] = fmt.Sprintf("hosted-%d", i)
+	}
+
+	tests := []struct {
+		name     string
+		ids      []string
+		wantCode int
+	}{
+		{"empty selection rejected", nil, http.StatusBadRequest},
+		{"single hive accepted", []string{"hosted-a"}, http.StatusOK},
+		{"exactly at the cap accepted", atCap, http.StatusOK},
+		{"one over the cap rejected", tooMany, http.StatusBadRequest},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w, _ := bulkPost(t, srv, "alice", BulkHiveRequest{
+				Action:  bulkActionDisableAutoUpgrade,
+				HiveIDs: tc.ids,
+			})
+			if w.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d; body=%s", w.Code, tc.wantCode, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestBulkDeduplicatesIDs ensures a repeated id is acted on once, so a buggy
+// client cannot restart the same hive N times in one request — and cannot use
+// duplicates to slip past the cap.
+func TestBulkDeduplicatesIDs(t *testing.T) {
+	srv := bulkTestHub(t)
+	bulkSeedHive(t, "hosted-dup", "alice")
+
+	w, out := bulkPost(t, srv, "alice", BulkHiveRequest{
+		Action:  bulkActionEnableAutoUpgrade,
+		HiveIDs: []string{"hosted-dup", "hosted-dup", "hosted-dup"},
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if got := int(out["requested"].(float64)); got != 1 {
+		t.Errorf("requested = %d, want 1 after de-duplication", got)
+	}
+	if got := len(bulkResults(t, out)); got != 1 {
+		t.Errorf("got %d results, want 1", got)
+	}
+}
+
+// TestBulkActionValidation rejects unknown actions and a branch switch with no
+// branch before any hive is touched.
+func TestBulkActionValidation(t *testing.T) {
+	srv := bulkTestHub(t)
+	bulkSeedHive(t, "hosted-a", "alice")
+
+	tests := []struct {
+		name     string
+		action   string
+		branch   string
+		wantCode int
+	}{
+		{"unknown action rejected", "delete-everything", "", http.StatusBadRequest},
+		{"empty action rejected", "", "", http.StatusBadRequest},
+		{"switch-branch without branch rejected", bulkActionSwitchBranch, "", http.StatusBadRequest},
+		{"known action accepted", bulkActionDisableAutoUpgrade, "", http.StatusOK},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w, _ := bulkPost(t, srv, "alice", BulkHiveRequest{
+				Action:  tc.action,
+				Branch:  tc.branch,
+				HiveIDs: []string{"hosted-a"},
+			})
+			if w.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d; body=%s", w.Code, tc.wantCode, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestBulkAutoUpgradePersists confirms the enable/disable actions actually
+// write through to the SaaS store — the same persistence handleToggleAutoUpgrade
+// relies on, which is what the spoke reads on its next heartbeat.
+func TestBulkAutoUpgradePersists(t *testing.T) {
+	srv := bulkTestHub(t)
+	bulkSeedHive(t, "hosted-p1", "alice")
+	bulkSeedHive(t, "hosted-p2", "alice")
+	ids := []string{"hosted-p1", "hosted-p2"}
+
+	for _, tc := range []struct {
+		action string
+		want   bool
+	}{
+		{bulkActionEnableAutoUpgrade, true},
+		{bulkActionDisableAutoUpgrade, false},
+	} {
+		t.Run(tc.action, func(t *testing.T) {
+			w, _ := bulkPost(t, srv, "alice", BulkHiveRequest{Action: tc.action, HiveIDs: ids})
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", w.Code)
+			}
+			for _, id := range ids {
+				h := loadSaaSHive(id)
+				if h == nil {
+					t.Fatalf("hive %s disappeared", id)
+				}
+				if h.AutoUpgrade != tc.want {
+					t.Errorf("%s AutoUpgrade = %v, want %v", id, h.AutoUpgrade, tc.want)
+				}
+			}
+		})
+	}
+}
+
+// TestSortedBulkResults verifies failures sort first so the UI can lead with
+// the actionable rows.
+func TestSortedBulkResults(t *testing.T) {
+	in := []BulkHiveResult{
+		{HiveID: "b", Ok: true},
+		{HiveID: "c", Ok: false, Error: "boom"},
+		{HiveID: "a", Ok: true},
+		{HiveID: "a2", Ok: false, Error: "boom"},
+	}
+	got := sortedBulkResults(in)
+	wantOrder := []string{"a2", "c", "a", "b"}
+	for i, want := range wantOrder {
+		if got[i].HiveID != want {
+			t.Errorf("position %d = %q, want %q (full: %+v)", i, got[i].HiveID, want, got)
+		}
+	}
+	// Input must not be mutated.
+	if in[0].HiveID != "b" {
+		t.Error("sortedBulkResults mutated its input")
+	}
+}
+
+func bulkResults(t *testing.T, out map[string]any) []BulkHiveResult {
+	t.Helper()
+	raw, err := json.Marshal(out["results"])
+	if err != nil {
+		t.Fatalf("marshal results: %v", err)
+	}
+	var results []BulkHiveResult
+	if err := json.Unmarshal(raw, &results); err != nil {
+		t.Fatalf("unmarshal results: %v", err)
+	}
+	return results
+}


### PR DESCRIPTION
## Why

The fleet is 42 hives across 2 clusters and growing. Routine operations — restart ten hives, upgrade a batch, flip auto-upgrade — currently take one action per hive, or a drop to `kubectl`. That does not scale.

## What

**UI (`dashboardHTML` in `v2/pkg/hub/saas.go`)**
- Row checkboxes on every bulk-eligible hive, plus a select-all per section. Assigned and Unassigned select **independently** so an admin cannot sweep the whole page from one box. Non-admin flat lists get their select-all in the table head.
- Selection lives in `_bulkSelected` (keyed by hive id), not in the DOM, so it survives re-render, re-sort and filter changes. `syncBulkSelection` prunes ids that are no longer visible before each render, so a hidden hive can never be swept into an action the user cannot see, and the bar's count always matches the screen.
- A bulk action bar appears at ≥1 selection showing the count and the available actions.

**Server (`v2/pkg/hub/saas_bulk.go`, new file)**
- One endpoint, `POST /api/saas/hives/bulk`, fanning out over the existing single-hive logic.

## Reused single-hive endpoints — no parallel logic

| Bulk action | Reuses |
|---|---|
| restart / upgrade | `rolloutRestartHive` (`saas.go:3164`) — same call `handleUpgradeHive` (`saas.go:2169`) makes, but routed through the helper so it inherits the bounded `upgradeKubectlTimeout` and the unreachable-cluster cache |
| enable/disable auto-upgrade | `handleToggleAutoUpgrade`'s persistence (`saas.go:2441`) — `saveSaaSHive`, read by the spoke on its next heartbeat |
| switch branch | `branchToTag` + `heartbeatSwitchTag`, matching `handleSwitchBranch` (`saas.go:2231`) |
| authorization | `getAuthUser` (`saas.go:253`) and the `h.Owner != username && username != hubAdminUsername` predicate every single-hive handler applies |

**Skipped: set ACMM level.** There is no standalone single-hive ACMM endpoint to reuse — ACMM is set at provision/assign time (`handleAssignHive`) and otherwise adopted from spoke heartbeats via `reconcileProjectConfig`. Writing parallel ACMM logic inside a bulk handler would be the wrong place to introduce it, so this PR leaves it out.

## Safety properties

- **Per-hive authorization.** The client's ID list is untrusted input. `authorizeBulkHive` re-loads every id with `loadSaaSHive` and re-checks ownership against the hub's own store. An unauthorized hive is refused individually and never acted on — the request as a whole still succeeds, so an attacker learns nothing and changes nothing. Covered by a test that asserts the victim's stored record is unmutated.
- **Partial failure is normal.** The response is a per-hive `{hive_id, ok, error, via}` list plus `succeeded`/`failed` counts, never a single boolean. The UI leads with the failures and their reasons.
- **Bounded blast radius.** `maxBulkHivesPerRequest` (100) caps a request; `bulkActionConcurrency` (4) bounds the worker pool; `bulkRequestBudget` (8m) bounds total wall clock. 42 hives never become 42 simultaneous kubectl processes. IDs are de-duplicated so duplicates cannot double-restart a hive or slip past the cap.
- **Firewalled clusters.** For hives on a cluster the hub cannot reach (vllm-d), `rolloutRestartHive` returns false and the heartbeat fallback is armed exactly as the single-hive path does — `heartbeatUpgrade[id]` for upgrade, `heartbeatSwitchTag[id]` for branch switch. That is the only delivery path there, so it is reported as success with `via: "heartbeat"`, and the UI says how many were queued for next check-in. A bare restart has no SHA for the spoke to carry, so it is honestly reported as a failure rather than a false success.
- **Confirmation.** Restart, upgrade and switch-branch confirm first, naming the action and the count and listing the hives. Restarting 20 live hives is not one misclick. Auto-upgrade toggles only change a stored preference, so they do not prompt.
- **Audit logging.** Request and completion are logged with actor, action and hive list; each per-hive effect logs its own `audit:` line, matching the existing convention.

## Tests

Table-driven, in `v2/pkg/hub/saas_bulk_test.go`: per-hive authorization (owner, cross-owner, hub admin, missing hive, unauthenticated, path traversal), a non-admin attempting to act on another user's hive through the handler, partial-failure aggregation across four mixes, the per-request cap (empty / one / exactly at cap / one over), de-duplication, action validation, auto-upgrade write-through, and result ordering.

## Verification

- `go build ./...` — pass
- `go vet ./pkg/hub/` — pass
- `go test -timeout 480s ./pkg/hub/` — pass (72s, full package)
- Dashboard JS extracted from the `dashboardHTML` raw string and checked with `node --check` — parses clean

Not verified: no live hub deploy, so the UI was not exercised against a real fleet, and the heartbeat fallback path was reasoned from the existing single-hive code rather than observed end-to-end against vllm-d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)