### PR TITLE
✨ feat(hub): surface per-check health detail in My Hives

### DIFF
--- a/v2/pkg/hub/health_check_detail_test.go
+++ b/v2/pkg/hub/health_check_detail_test.go
@@ -1,0 +1,149 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+)
+
+// The per-check health detail lives in the inline dashboardHTML JS. These tests
+// pin the invariants that are easy to break during a rebase (nine agents are
+// editing this same file) and impossible to catch with a Go compile.
+
+// TestHealthCheckHelpersPresent asserts the shared per-check helpers exist, so a
+// merge that drops one fails here rather than at runtime with a blank table.
+func TestHealthCheckHelpersPresent(t *testing.T) {
+	cases := []struct {
+		name    string
+		snippet string
+	}{
+		{"healthChecks normaliser", "function healthChecks(h)"},
+		{"failingChecks selector", "function failingChecks(h)"},
+		{"inline row summary", "function failingCheckSummary(h)"},
+		{"fleet tally", "function failingCheckCounts(hives)"},
+		{"check-name filter setter", "function setFailingCheckFilter(name)"},
+		{"failing status set", "var FAILING_CHECK_STATUSES"},
+		{"named inline-name budget", "var INLINE_FAILING_CHECK_NAMES"},
+		{"named name-length budget", "var INLINE_CHECK_NAME_MAXLEN"},
+		{"named filter-option cap", "var MAX_FAILING_CHECK_FILTER_OPTIONS"},
+		{"named fleet-signal threshold", "var FLEET_CHECK_SIGNAL_MIN_HIVES"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(dashboardHTML, tc.snippet) {
+				t.Errorf("dashboardHTML is missing %q", tc.snippet)
+			}
+		})
+	}
+}
+
+// TestHealthChecksDefensiveAccess asserts every read of a spoke-supplied check
+// field is guarded. Health is map[string]any off the wire, so checks may be
+// absent, null, empty, or hold entries missing fields; one malformed spoke must
+// not blank the whole My Hives table.
+func TestHealthChecksDefensiveAccess(t *testing.T) {
+	cases := []struct {
+		name    string
+		snippet string
+	}{
+		{"health object guarded", "var hp = (h && h.health) || {};"},
+		{"absent/empty checks short-circuit", "if (!raw || !raw.length) return [];"},
+		{"non-object entries skipped", "if (!ck || typeof ck !== 'object') continue;"},
+		{"name type-checked", "typeof ck.name === 'string' ? ck.name : ''"},
+		{"status type-checked with fallback", "typeof ck.status === 'string' ? ck.status : 'unknown'"},
+		{"detail type-checked with fallback", "typeof ck.detail === 'string' ? ck.detail : ''"},
+		{"unnamed checks dropped", "if (!nm) continue;"},
+		{"filter iterates guarded list", "failingChecks(h).some(function(ck)"},
+		{"tally iterates guarded list", "failingChecks(h).forEach(function(ck)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(dashboardHTML, tc.snippet) {
+				t.Errorf("dashboardHTML is missing defensive guard %q", tc.snippet)
+			}
+		})
+	}
+}
+
+// TestFailingCheckSummaryEscapes asserts the spoke-supplied check name and
+// detail are escaped everywhere they reach the DOM. Both are user-influenced.
+func TestFailingCheckSummaryEscapes(t *testing.T) {
+	cases := []struct {
+		name    string
+		snippet string
+	}{
+		{"inline pill tooltip escaped", "'<span title=\"' + esc(full) + '\""},
+		{"inline pill label escaped", "esc(label) + '</span>';"},
+		{"filter chip tooltip escaped", "title=\"' + esc(tip) + '\""},
+		{"filter chip label escaped", "esc(nm) + '<span class=\"filter-chip-count\">'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(dashboardHTML, tc.snippet) {
+				t.Errorf("dashboardHTML is missing escaping %q", tc.snippet)
+			}
+		})
+	}
+}
+
+// TestSingleHoverPanelInvariant guards the regression that was just fixed: a
+// native title attribute AND a custom panel on the same element make the browser
+// draw its own tooltip on top of the panel — two overlapping boxes. The custom
+// panel branch must never carry a title.
+func TestSingleHoverPanelInvariant(t *testing.T) {
+	const panelMarker = `'<span class="hive-access-wrap"`
+	idx := strings.Index(dashboardHTML, panelMarker)
+	if idx < 0 {
+		t.Fatalf("consolidated hover panel markup not found in dashboardHTML")
+	}
+	// The panel is built as one concatenated return expression; scan to the end
+	// of that statement.
+	rest := dashboardHTML[idx:]
+	end := strings.Index(rest, "accessRows + '</span></span>';")
+	if end < 0 {
+		t.Fatalf("could not find the end of the consolidated hover panel expression")
+	}
+	panel := rest[:end]
+	if strings.Contains(panel, "title=") {
+		t.Errorf("consolidated hover panel carries a native title attribute; "+
+			"that stacks a browser tooltip on top of the custom panel. Panel markup:\n%s", panel)
+	}
+}
+
+// TestFilterComposition asserts the new check-name filter composes with the
+// existing status chips and stays scoped away from unassigned placeholders.
+func TestFilterComposition(t *testing.T) {
+	cases := []struct {
+		name    string
+		snippet string
+	}{
+		// The render signature must include the check filter or toggling it on
+		// unchanged data is treated as a no-op and nothing re-renders.
+		{"render signature includes check filter", "+ '|' + _dashFailingCheckFilter;"},
+		// Clearing must clear both filter kinds, else "Clear filters" leaves the
+		// list mysteriously short.
+		{"clear resets check filter", "_dashFailingCheckFilter = '';"},
+		// Placeholder scoping is unchanged and still splits before filtering.
+		{"placeholder split retained", "(isPlaceholderHive(allHives[_si]) ? unassignedAll : assignedAll)"},
+		{"filters applied to assigned only", "applyDashFilters(assignedAll).concat(unassignedAll)"},
+		// Any-active must account for the check filter so the Clear button shows.
+		{"clear button accounts for check filter", "|| !!_dashFailingCheckFilter;"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(dashboardHTML, tc.snippet) {
+				t.Errorf("dashboardHTML is missing %q", tc.snippet)
+			}
+		})
+	}
+}
+
+// TestHoverGroupsFailuresFirst asserts the hover panel sorts failing checks
+// ahead of passing ones so the reason for a bad status reads first.
+func TestHoverGroupsFailuresFirst(t *testing.T) {
+	if !strings.Contains(dashboardHTML, "var fa = FAILING_CHECK_STATUSES[a.status] ? 0 : 1;") {
+		t.Error("hover panel does not sort failing checks first")
+	}
+	if !strings.Contains(dashboardHTML, "healthChecks(h).slice().sort(") {
+		t.Error("hover panel should sort a COPY of the normalised checks, not the raw payload")
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -5704,6 +5704,85 @@ const dashboardHTML = `<!DOCTYPE html>
         : 'Process uptime since the last restart';
       return '<span title="' + esc(title) + '" style="font-size:0.72rem;color:' + c + ';cursor:help">' + esc(label) + '</span>';
     }
+    /* ---- Per-check health detail -------------------------------------------
+       Health.checks[] arrives over the heartbeat as free-form JSON decoded into
+       map[string]any on the hub (RegistryEntry.Health, server.go). It may be
+       absent, null, an empty array, or hold entries missing name/status/detail.
+       Every accessor below therefore guards each field individually: one
+       malformed spoke payload must never blank the whole table. */
+
+    /* Check statuses that count as a FAILURE for the inline row summary, the
+       hover grouping and the per-check filter. 'warn' is included because an
+       operator scanning for "what is wrong here" wants warnings surfaced too;
+       'skip' is not a problem and 'pass' obviously is not. */
+    var FAILING_CHECK_STATUSES = {fail: true, warn: true, critical: true, error: true};
+
+    /* How many failing check NAMES to spell out inline in the row before
+       collapsing to a bare count. The name column is already three lines deep,
+       so one name is all that fits without pushing the row taller. */
+    var INLINE_FAILING_CHECK_NAMES = 1;
+
+    /* Longest failing-check name rendered inline before it is ellipsised.
+       Check names are spoke-supplied and unbounded. */
+    var INLINE_CHECK_NAME_MAXLEN = 22;
+
+    /* healthChecks returns the hive's checks as a clean array of
+       {name, status, detail} strings — never null, never holding non-objects. */
+    function healthChecks(h) {
+      var hp = (h && h.health) || {};
+      var raw = hp.checks;
+      if (!raw || !raw.length) return [];
+      var out = [];
+      for (var i = 0; i < raw.length; i++) {
+        var ck = raw[i];
+        if (!ck || typeof ck !== 'object') continue;
+        var nm = typeof ck.name === 'string' ? ck.name : '';
+        if (!nm) continue;   /* an unnamed check cannot be shown or filtered on */
+        out.push({
+          name: nm,
+          status: typeof ck.status === 'string' ? ck.status : 'unknown',
+          detail: typeof ck.detail === 'string' ? ck.detail : ''
+        });
+      }
+      return out;
+    }
+
+    /* failingChecks returns only the checks in a failing/warning state. */
+    function failingChecks(h) {
+      return healthChecks(h).filter(function(ck) { return !!FAILING_CHECK_STATUSES[ck.status]; });
+    }
+
+    /* failingCheckSummary renders the compact in-row failure summary: the name
+       of the single failing check, or "N checks failing" when there are more.
+       Returns '' when nothing is failing, so healthy rows stay exactly as
+       dense as they are today. */
+    function failingCheckSummary(h) {
+      var bad = failingChecks(h);
+      if (!bad.length) return '';
+      var label;
+      if (bad.length <= INLINE_FAILING_CHECK_NAMES) {
+        var nm = bad[0].name;
+        if (nm.length > INLINE_CHECK_NAME_MAXLEN) nm = nm.substring(0, INLINE_CHECK_NAME_MAXLEN - 1) + '…';
+        label = nm;
+      } else {
+        label = bad.length + ' checks failing';
+      }
+      /* Any 'fail'-class check is red; a row that is only warning stays amber so
+         the pill colour agrees with the row dot. */
+      var anyHard = bad.some(function(ck) { return ck.status !== 'warn'; });
+      var col = anyHard ? '#f85149' : '#d29922';
+      var full = bad.map(function(ck) {
+        return ck.name + (ck.detail ? ': ' + ck.detail : '');
+      }).join('\n');
+      /* One element, one tooltip source: this pill owns a plain title and never
+         also carries a custom panel (that is healthBadge()'s job). */
+      return '<span title="' + esc(full) + '" style="display:inline-block;margin-left:6px;padding:0 6px;' +
+        'border-radius:9999px;font-size:0.62rem;font-weight:600;line-height:1.5;cursor:help;white-space:nowrap;' +
+        'color:' + col + ';background:' + (anyHard ? 'rgba(248,81,73,0.12)' : 'rgba(210,153,34,0.12)') + ';' +
+        'border:1px solid ' + (anyHard ? 'rgba(248,81,73,0.35)' : 'rgba(210,153,34,0.35)') + '">' +
+        esc(label) + '</span>';
+    }
+
     function healthBadge(h) {
       var hp = h.health || {};
       var st = hp.status || 'unknown';
@@ -5714,7 +5793,13 @@ const dashboardHTML = `<!DOCTYPE html>
       var ic = icons[st] || '?';
       var isUpgrading = _upgradingHives[h.id];
       var statusLabel = isUpgrading ? 'Starting up after upgrade' : st.charAt(0).toUpperCase() + st.slice(1);
-      var checks = hp.checks || [];
+      /* Checks, failures first, so the reason for a bad status reads before the
+         wall of passing checks. Stable within each group (spoke report order). */
+      var checks = healthChecks(h).slice().sort(function(a, b) {
+        var fa = FAILING_CHECK_STATUSES[a.status] ? 0 : 1;
+        var fb = FAILING_CHECK_STATUSES[b.status] ? 0 : 1;
+        return fa - fb;
+      });
       var lines = [statusLabel];
       for (var i = 0; i < checks.length; i++) {
         var ck = checks[i];
@@ -5766,7 +5851,13 @@ const dashboardHTML = `<!DOCTYPE html>
         if (i === 0) {
           return '<span style="display:block;color:' + c + ';font-weight:600;margin-bottom:4px">' + esc(l) + '</span>';
         }
-        return '<div style="padding:1px 0;color:var(--muted)">' + esc(l) + '</div>';
+        /* Failing check lines (built above with ✕/⚠ icons) are lifted out of the
+           muted grey so the reason for the status is the first thing read. The
+           lines are already sorted failures-first. */
+        var lc = 'var(--muted)';
+        if (l.indexOf('✕') === 0) lc = '#f85149';
+        else if (l.indexOf('⚠') === 0) lc = '#d29922';
+        return '<div style="padding:1px 0;color:' + lc + '">' + esc(l) + '</div>';
       }).join('');
 
       var accessRows = access.map(function(a) {
@@ -5876,8 +5967,49 @@ const dashboardHTML = `<!DOCTYPE html>
       {key: HIVE_FILTER_OK, label: 'OK', color: '#3fb950'}
     ];
 
+    /* Active failing-check-name filter: '' = off, otherwise a check name that a
+       hive must be FAILING for it to be shown. This is an AND against the status
+       chips (chips OR among themselves), because "degraded hives" and
+       "github_auth is failing" are two different questions and the useful answer
+       is their intersection. */
+    var _dashFailingCheckFilter = '';
+
+    /* Max distinct failing check names offered in the picker. Names come from
+       spokes, so an unbounded fleet could otherwise produce a huge menu. */
+    var MAX_FAILING_CHECK_FILTER_OPTIONS = 12;
+
+    /* If a single check is failing on at least this many hives, it is called out
+       as a fleet-wide signal rather than reading as per-hive noise. */
+    var FLEET_CHECK_SIGNAL_MIN_HIVES = 2;
+
+    /* failingCheckCounts tallies, over the hives given, how many have each check
+       in a failing state — {name: hiveCount}. Callers pass the ASSIGNED set so
+       placeholders never contribute. */
+    function failingCheckCounts(hives) {
+      var counts = {};
+      (hives || []).forEach(function(h) {
+        var seen = {};
+        failingChecks(h).forEach(function(ck) {
+          if (seen[ck.name]) return;   /* count each hive once per check name */
+          seen[ck.name] = true;
+          counts[ck.name] = (counts[ck.name] || 0) + 1;
+        });
+      });
+      return counts;
+    }
+
+    /* setFailingCheckFilter selects (or clears, with '') the check-name filter. */
+    function setFailingCheckFilter(name) {
+      _dashFailingCheckFilter = name || '';
+      renderHives(_allDashHives, true);
+    }
+
     /* hiveMatchesFilters answers whether a hive survives the active chips. */
     function hiveMatchesFilters(h) {
+      if (_dashFailingCheckFilter) {
+        var hit = failingChecks(h).some(function(ck) { return ck.name === _dashFailingCheckFilter; });
+        if (!hit) return false;
+      }
       var active = Object.keys(_dashStatusFilters || {}).filter(function(k) { return _dashStatusFilters[k]; });
       if (!active.length) return true;
       var f = hiveStatusFlags(h);
@@ -5907,6 +6039,7 @@ const dashboardHTML = `<!DOCTYPE html>
 
     function clearStatusFilters() {
       _dashStatusFilters = {};
+      _dashFailingCheckFilter = '';
       renderHives(_allDashHives, true);
     }
 
@@ -5936,7 +6069,35 @@ const dashboardHTML = `<!DOCTYPE html>
           '<span class="filter-chip-dot" style="background:' + c.color + '"></span>' +
           esc(c.label) + '<span class="filter-chip-count">' + counts[c.key] + '</span></button>';
       }).join('');
-      var anyActive = Object.keys(_dashStatusFilters || {}).length > 0;
+      /* Failing-check chips, most-affected first. Each doubles as the fleet
+         signal: the count IS "github_auth failing on 6 hives". Only names
+         actually failing somewhere in the assigned set appear, so the row is
+         empty (and takes no space) on a healthy fleet. */
+      var fcCounts = failingCheckCounts(allHives);
+      var fcNames = Object.keys(fcCounts).sort(function(a, b) {
+        return fcCounts[b] - fcCounts[a] || a.localeCompare(b);
+      }).slice(0, MAX_FAILING_CHECK_FILTER_OPTIONS);
+      var checkChips = '';
+      if (fcNames.length) {
+        checkChips = '<div class="filter-chips" style="margin-top:6px">' +
+          '<span style="align-self:center;color:var(--muted);font-size:0.62rem;text-transform:uppercase;letter-spacing:0.04em;margin-right:2px">Failing check</span>' +
+          fcNames.map(function(nm) {
+            var on = _dashFailingCheckFilter === nm;
+            var n = fcCounts[nm];
+            /* A check failing across several hives is a fleet problem, not a
+               hive problem — say so in the tooltip. */
+            var tip = n >= FLEET_CHECK_SIGNAL_MIN_HIVES
+              ? nm + ' failing on ' + n + ' hives — likely fleet-wide'
+              : nm + ' failing on 1 hive';
+            return '<button type="button" class="' + (on ? 'filter-chip on' : 'filter-chip') + '"' +
+              ' aria-pressed="' + (on ? 'true' : 'false') + '" title="' + esc(tip) + '"' +
+              ' onclick="setFailingCheckFilter(' + (on ? "''" : "'" + esc(nm).replace(/'/g, '&#39;') + "'") + ')"' +
+              ' style="--chip-color:#f85149">' +
+              '<span class="filter-chip-dot" style="background:#f85149"></span>' +
+              esc(nm) + '<span class="filter-chip-count">' + n + '</span></button>';
+          }).join('') + '</div>';
+      }
+      var anyActive = Object.keys(_dashStatusFilters || {}).length > 0 || !!_dashFailingCheckFilter;
       /* allHives here is the ASSIGNED set — the caller scopes it, because the
          chips never filter unassigned placeholders. Say "assigned" so the count
          is not read as the whole fleet. */
@@ -5948,6 +6109,7 @@ const dashboardHTML = `<!DOCTYPE html>
         ? '<button type="button" class="filter-chip filter-chip-clear" onclick="clearStatusFilters()">Clear filters</button>'
         : '';
       bar.innerHTML = '<div class="filter-chips">' + chips + clearBtn + '</div>' +
+        checkChips +
         '<span class="filter-summary">' + summary + '</span>';
     }
 
@@ -6185,7 +6347,7 @@ const dashboardHTML = `<!DOCTYPE html>
       allHives = allHives || [];
       /* The signature must include the active filters, otherwise toggling a
          chip while the hive data is unchanged would be treated as a no-op. */
-      var sig = JSON.stringify(allHives) + '|' + JSON.stringify(_dashStatusFilters);
+      var sig = JSON.stringify(allHives) + '|' + JSON.stringify(_dashStatusFilters) + '|' + _dashFailingCheckFilter;
       if (!force && sig === _lastHivesJSON) return;
       _lastHivesJSON = sig;
       /* Status filters describe ASSIGNED hives only. An unassigned placeholder
@@ -6370,7 +6532,7 @@ const dashboardHTML = `<!DOCTYPE html>
         }
         return '<tr>' +
           '<td class="hive-menu-cell" style="position:relative;width:30px;text-align:center;overflow:visible">' + (h.migrationStatus === 'migrating' ? '<span style="font-size:1.1rem;color:var(--border);user-select:none;cursor:not-allowed" title="Disabled during migration">⋮</span>' : '<span style="cursor:pointer;font-size:1.1rem;color:var(--muted);user-select:none">⋮</span>' + pendingBadge + '<div class="hive-menu-dropdown" style="display:none;position:absolute;left:0;bottom:auto;background:#1c2128;border:1px solid #30363d;border-radius:8px;min-width:160px;padding:4px 0;z-index:1000;box-shadow:0 8px 24px rgba(0,0,0,0.5)">' + menuItems.join('') + '</div>') + '</td>' +
-          '<td style="text-align:left;line-height:1.4">' + (function() { var isHostedRow = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'))); var dh = isHostedRow && h.id ? ('/api/saas/hives/' + encodeURIComponent(h.id) + '/open') : (rb ? esc(rb) : ''); var displayName = h.name || h.id; var parts = displayName.split('/'); var orgName = parts.length > 1 ? parts[0] : ''; var repoName = parts.length > 1 ? parts.slice(1).join('/') : displayName; var rp = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : ''; var ghIcon = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>' : ''; var link = function(text, bold) { if (dh) { return '<a href="' + dh + '" target="_blank" class="' + (bold ? 'hive-name-link' : 'hive-sub-link') + '" title="Open dashboard">' + esc(text) + '</a>'; } var s = bold ? 'font-weight:700;color:inherit' : 'color:#6b7280;font-weight:400'; return '<span style="' + s + '">' + esc(text) + '</span>'; }; var line1 = dot + ' ' + link(orgName || repoName, true); var line2 = orgName ? '<div style="padding-left:18px;font-size:0.8rem">' + link(repoName, false) + ' ' + ghIcon + ' ' + roleBadge(h.role) + '</div>' : '<div style="padding-left:18px">' + ghIcon + ' ' + roleBadge(h.role) + '</div>'; var line3 = pendingPill ? '<div style="margin-top:4px;padding-left:18px">' + pendingPill + '</div>' : ''; return line1 + line2 + line3; })() + '</td>' +
+          '<td style="text-align:left;line-height:1.4">' + (function() { var isHostedRow = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'))); var dh = isHostedRow && h.id ? ('/api/saas/hives/' + encodeURIComponent(h.id) + '/open') : (rb ? esc(rb) : ''); var displayName = h.name || h.id; var parts = displayName.split('/'); var orgName = parts.length > 1 ? parts[0] : ''; var repoName = parts.length > 1 ? parts.slice(1).join('/') : displayName; var rp = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : ''; var ghIcon = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>' : ''; var link = function(text, bold) { if (dh) { return '<a href="' + dh + '" target="_blank" class="' + (bold ? 'hive-name-link' : 'hive-sub-link') + '" title="Open dashboard">' + esc(text) + '</a>'; } var s = bold ? 'font-weight:700;color:inherit' : 'color:#6b7280;font-weight:400'; return '<span style="' + s + '">' + esc(text) + '</span>'; }; var line1 = dot + ' ' + link(orgName || repoName, true); var fcPill = h.online ? failingCheckSummary(h) : ''; var line2 = orgName ? '<div style="padding-left:18px;font-size:0.8rem">' + link(repoName, false) + ' ' + ghIcon + ' ' + roleBadge(h.role) + fcPill + '</div>' : '<div style="padding-left:18px">' + ghIcon + ' ' + roleBadge(h.role) + fcPill + '</div>'; var line3 = pendingPill ? '<div style="margin-top:4px;padding-left:18px">' + pendingPill + '</div>' : ''; return line1 + line2 + line3; })() + '</td>' +
           '<td>' + (isLocal ? '<span style="display:inline-block;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:rgba(107,114,128,0.15);color:#9ca3af;border:1px solid rgba(107,114,128,0.3)">local</span>' : clusterBadge(h.clusterId, h.clusterName)) + '</td>' +
           '<td style="white-space:nowrap">' + uptimeCell(h) + '</td>' +
           '<td>' + (function() { var pub = !!h.isPublic; var tid = 'vis-' + esc(h.id); if (isHosted && h.role === 'owner') { return '<label style="position:relative;display:inline-block;width:36px;height:20px;cursor:pointer"><input type="checkbox" id="' + tid + '" ' + (pub ? 'checked' : '') + ' onchange="toggleVisibility(\'' + esc(h.id) + '\',this.checked)" style="opacity:0;width:0;height:0"><span style="position:absolute;inset:0;background:' + (pub ? 'var(--green)' : 'var(--border)') + ';border-radius:10px;transition:background 0.2s"></span><span style="position:absolute;top:2px;left:' + (pub ? '18px' : '2px') + ';width:16px;height:16px;background:#fff;border-radius:50%;transition:left 0.2s"></span></label>'; } if (isLocal) { var dh = h.dashboardUrl && !h.dashboardUrl.includes('localhost') ? h.dashboardUrl : ''; var badge = pub ? '<span style="color:var(--green)">Public</span>' : '<span style="color:var(--muted)">Private</span>'; return dh ? '<a href="' + esc(dh) + '#config/governor/Hub" target="_blank" title="Change in Governor Config → Hub tab" style="text-decoration:none;cursor:pointer">' + badge + ' <span style="font-size:0.6rem;color:var(--muted)">↗</span></a>' : badge; } return pub ? '<span style="color:var(--green)">✓</span>' : '<span style="color:var(--muted)">—</span>'; })() + '</td>' +


### PR DESCRIPTION
## Problem

A hive row in **My Hives** shows a coloured dot and a status word. An operator who sees "Degraded" cannot tell **which** check is failing without opening the spoke — even though the hub already receives `Health.checks[]` with per-check `name` / `status` / `detail` on every heartbeat. The data was there; it just was not scannable.

## What this adds

**1. Inline failing-check summary in the row.** A compact pill sits next to the role badge on the name cell's second line — no new column, no extra row height. It names the failing check, collapsing to `N checks failing` past one name. Red for a hard failure, amber when only warnings, so the pill can never disagree with the row dot. When nothing is failing it renders the empty string, so healthy rows are byte-for-byte unchanged. Hovering it gives the full `name: detail` list.

**2. Richer, grouped hover panel.** Checks are now sorted **failures first** and failing lines are lifted out of the muted grey (red for `✕`, amber for `⚠`), so the reason for a bad status reads before the wall of passing checks.

**3. Filterable by failing check name.** A `Failing check` chip row appears under the existing status chips, most-affected first. One click answers "show me everything where `github_auth` is failing". It **ANDs** with the status chips (they OR among themselves) because "degraded hives" and "`github_auth` is failing" are different questions and the useful answer is their intersection. It reuses the existing `isPlaceholderHive()` scoping unchanged, so unassigned pool slots are never swept in. `Clear filters` clears both filter kinds, and the render signature includes the check filter so toggling it on unchanged data is not a no-op.

**4. Fleet signal.** Folded into the chips rather than added as a separate widget: the count on each chip *is* the fleet signal — `github_auth 6` means it is failing on six hives — and the tooltip says so explicitly (`github_auth failing on 6 hives — likely fleet-wide`) once it crosses `FLEET_CHECK_SIGNAL_MIN_HIVES`. This keeps it out of the way of the other in-flight work on this row.

## Single-hover-panel invariant — preserved

The consolidated panel branch still carries **no** native `title` attribute; the plain-`title` branch (rows with no access list) still renders **no** panel. The new pill is a **separate element** that owns a plain `title` and no panel of its own, so the two never stack. `TestSingleHoverPanelInvariant` slices out the panel expression and fails if a `title=` ever reappears inside it.

## Malformed payloads

`Health` is `map[string]any` decoded from the wire, so `checks` may be absent, `null`, empty, a non-array, or hold entries missing fields. A new `healthChecks()` normaliser is the single entry point for all four features: it guards the health object, short-circuits on absent/empty, skips non-object entries, type-checks `name`/`status`/`detail` individually with fallbacks, and drops unnamed checks (they cannot be shown or filtered on anyway). A malformed payload from one spoke degrades to "no checks" **for that row only** — it can never blank the table.

Check names and detail strings originate on the spoke and are user-influenced, so every path to the DOM goes through `esc()` — pill label, pill tooltip, chip label, chip tooltip, and the chip's inline `onclick` argument.

## Conventions

- Edited the inline `dashboardHTML` raw-string const in `v2/pkg/hub/saas.go`, ES5 `var`/`function` idiom throughout.
- No magic numbers: `INLINE_FAILING_CHECK_NAMES`, `INLINE_CHECK_NAME_MAXLEN`, `MAX_FAILING_CHECK_FILTER_OPTIONS`, `FLEET_CHECK_SIGNAL_MIN_HIVES`, `FAILING_CHECK_STATUSES` are all named and commented.
- Diff is deliberately minimal and scoped to health-check rendering — 167 insertions, 5 deletions, one file — since several agents are concurrently editing this same row.

## Verified

- `go build ./...`, `go vet ./pkg/hub/` clean.
- `go test -timeout 480s ./pkg/hub/` — full package green (70s).
- Extracted the complete dashboard JS and ran `node --check` on it — parses.
- **Executed** the new helpers under node against 17 payload shapes (no health, null health, absent/null/empty/non-array `checks`, null and scalar entries, entries missing name/status/detail, non-string detail, over-long name, and an XSS-shaped name). None throw; `failingCheckCounts` handles a null hive list and null hives. Confirmed truncation (`a_really_extremely_lo…`), the `2 checks failing` collapse, and that `"><img src=x onerror=alert(1)>` comes out fully escaped in both label and tooltip.
- New table-driven tests pin the defensive guards, the escaping, the filter composition and placeholder scoping, the failures-first sort, and the single-panel invariant.

**Assumed, not verified:** visual appearance in a live browser against a real degraded fleet — this was verified structurally (markup, escaping, helper behaviour) rather than by rendering the hub dashboard with real heartbeat data.