### PR TITLE
✨ feat(hub): config-drift detection for the fleet

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1728,13 +1728,19 @@ func main() {
 					}
 					return fmt.Sprintf("http://localhost:%d", cfg.Dashboard.Port)
 				}(),
-				SnapshotURL:             cfg.Hub.SnapshotURL,
-				HiveType:                cfg.Hub.HiveType,
-				ClusterID:               cfg.Hub.ClusterID,
-				IsPublic:                cfg.Hub.IsPublic,
-				Version:                 "3.0.0",
-				GitHash:                 gitShort,
-				GitBranch:               gitBranch,
+				SnapshotURL: cfg.Hub.SnapshotURL,
+				HiveType:    cfg.Hub.HiveType,
+				ClusterID:   cfg.Hub.ClusterID,
+				IsPublic:    cfg.Hub.IsPublic,
+				Version:     "3.0.0",
+				GitHash:     gitShort,
+				GitBranch:   gitBranch,
+				// The image ref the Deployment tracks, read in-cluster and
+				// cached. The hub cannot see it for firewalled spokes, and it
+				// is the only way to distinguish a hive pinned to an immutable
+				// SHA tag (which can never receive a rolling upgrade) from one
+				// riding <branch>-latest. Empty off-cluster — never guessed.
+				ImageRef:                hub.SelfDeploymentImage(),
 				GitHubAppRequired:       dashSrv.IsGitHubAppRequired(),
 				GitHubAppPermIssue:      dashSrv.GetGitHubAppPermIssue(),
 				PendingGitHubAppInstall: dashSrv.IsPendingGitHubAppInstall(),

--- a/v2/pkg/hub/drift.go
+++ b/v2/pkg/hub/drift.go
@@ -1,0 +1,504 @@
+package hub
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Config-drift detection.
+//
+// Every incident this exists for was silent: the hub already RECEIVED the data
+// that would have flagged it (a spoke reporting a branch nobody else runs, a
+// GitHub App that was never installed, a health check failing for hours, an
+// upgrade wedged since last week) but nothing in the UI ever compared a hive
+// against its fleet or against itself a minute ago. Drift signals do that
+// comparison server-side, once per My Hives request, and ride back on the same
+// payload so the table can render them without a second call.
+//
+// Two rules shape the whole model:
+//
+//  1. Derive the norm, don't hardcode it. "Behind" and "wrong branch" are
+//     relative to what the rest of the fleet is actually running (the modal
+//     branch/version across online hives), so the model stays correct when the
+//     fleet moves to a new branch without anyone editing this file.
+//  2. Never flag a placeholder for a claimed-hive concern. An unassigned pool
+//     slot legitimately has no GitHub App, no tokens, no agents and ACMM 0;
+//     flagging those would bury the real signals under pool noise.
+
+// DriftSeverity ranks a signal so a row can show its worst one and the fleet
+// summary can sort by urgency.
+type DriftSeverity string
+
+const (
+	// DriftInfo is a difference worth knowing but not acting on today
+	// (e.g. a hive a couple of commits behind the fleet).
+	DriftInfo DriftSeverity = "info"
+	// DriftWarn is a real misconfiguration that degrades the hive but has not
+	// stopped it (e.g. ACMM unset, no agents, a warning-level health check).
+	DriftWarn DriftSeverity = "warn"
+	// DriftCritical is a condition that makes the hive not work as configured
+	// (e.g. offline while it should be up, App required but not installed,
+	// pinned to an immutable tag so it can never upgrade).
+	DriftCritical DriftSeverity = "critical"
+)
+
+// driftSeverityRank orders severities for "worst wins" comparisons. Higher is
+// worse. Unknown severities rank lowest so an unrecognized value can never
+// masquerade as critical.
+var driftSeverityRank = map[DriftSeverity]int{
+	DriftInfo:     1,
+	DriftWarn:     2,
+	DriftCritical: 3,
+}
+
+// Drift signal kinds. These are stable identifiers: the frontend groups the
+// fleet-exceptions summary by them and uses them as filter keys, so renaming
+// one is a breaking UI change.
+const (
+	DriftKindVersionBehind  = "version-behind"
+	DriftKindBranchMismatch = "branch-mismatch"
+	DriftKindPinnedImage    = "pinned-image"
+	DriftKindHeartbeatStale = "heartbeat-stale"
+	DriftKindAppMissing     = "app-missing"
+	DriftKindAppPermIssue   = "app-perm-issue"
+	DriftKindHealthDegraded = "health-degraded"
+	DriftKindUpgradeStuck   = "upgrade-stuck"
+	DriftKindACMMUnset      = "acmm-unset"
+	DriftKindNoAgents       = "no-agents"
+)
+
+// DriftSignal is one detected deviation. Reason is a complete, human-readable
+// sentence — the UI renders it verbatim, so it must carry the specifics (which
+// branch, which check, how long) rather than deferring to a lookup table.
+type DriftSignal struct {
+	Kind     string        `json:"kind"`
+	Severity DriftSeverity `json:"severity"`
+	Reason   string        `json:"reason"`
+}
+
+// DriftReport is the per-hive drift result attached to a My Hives row.
+// WorstSeverity is empty exactly when Signals is empty.
+type DriftReport struct {
+	Signals       []DriftSignal `json:"signals,omitempty"`
+	Count         int           `json:"count"`
+	WorstSeverity DriftSeverity `json:"worstSeverity,omitempty"`
+}
+
+// fleetNorm is the derived "what the fleet is running" baseline that relative
+// signals compare against. Empty fields mean "no norm could be established"
+// (too few online hives, or no clear majority) — in which case the relative
+// signals are skipped entirely rather than guessed at.
+type fleetNorm struct {
+	// Branch is the modal git branch across eligible hives.
+	Branch string
+	// SHA is the modal git hash among hives ON the norm branch. Scoped to the
+	// branch because a v3 hive's SHA is not evidence about v2's norm.
+	SHA string
+	// Eligible is how many hives contributed to the norm. Reported so callers
+	// can require a minimum sample before trusting it.
+	Eligible int
+}
+
+// minFleetNormSample is the smallest number of eligible hives from which a
+// fleet norm is derived. With fewer than this, "the majority" is not a
+// meaningful statement — a two-hive fleet where the hives disagree would flag
+// one of them arbitrarily — so relative signals (branch/version drift) are
+// suppressed instead of guessed.
+const minFleetNormSample = 3
+
+// driftHeartbeatStaleAfter is how old the last heartbeat may be before the hub
+// treats the hive as not reporting. It matches maxHeartbeatAge, which is the
+// same threshold markStaleHives uses to clear Online — deriving it keeps the
+// drift signal and the online dot from ever disagreeing.
+const driftHeartbeatStaleAfter = maxHeartbeatAge
+
+// driftACMMUnsetLevel is the ACMM level value meaning "never configured". A
+// claimed hive at this level is running with no maturity target set.
+const driftACMMUnsetLevel = 0
+
+// driftNoAgentsCount is the agent count meaning "nothing is running". A claimed
+// hive here consumes a slot and does no work.
+const driftNoAgentsCount = 0
+
+// modalString returns the most common non-empty value in vals and how many
+// hives held it. Ties break on the lexically smaller value so the norm is
+// deterministic across requests (a norm that flickered between two equally
+// popular branches would flag half the fleet on alternating page loads).
+func modalString(vals []string) (string, int) {
+	counts := make(map[string]int, len(vals))
+	for _, v := range vals {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		counts[v]++
+	}
+	if len(counts) == 0 {
+		return "", 0
+	}
+	keys := make([]string, 0, len(counts))
+	for k := range counts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	best, bestN := "", 0
+	for _, k := range keys {
+		if counts[k] > bestN {
+			best, bestN = k, counts[k]
+		}
+	}
+	return best, bestN
+}
+
+// driftEligibleForNorm reports whether a hive's self-reported version should
+// count toward the fleet norm. Only ONLINE, non-placeholder hives vote: an
+// offline hive's last-known branch may be months stale, and a placeholder runs
+// whatever the pool image happens to be, so neither is evidence about what the
+// fleet is meant to be running.
+func driftEligibleForNorm(h MyHiveEntry) bool {
+	return h.Online && !isPlaceholderEntry(h)
+}
+
+// isPlaceholderEntry mirrors the frontend's isPlaceholderHive: provStatus
+// "available" is authoritative, with an "available-" org prefix as the fallback
+// for placeholders that have not reported provStatus yet. Kept in lockstep with
+// the JS so server-computed drift and client-rendered sections can never
+// disagree about what counts as a claimed hive.
+func isPlaceholderEntry(h MyHiveEntry) bool {
+	if h.ProvStatus == statusAvailable {
+		return true
+	}
+	return strings.HasPrefix(h.Org, "available-")
+}
+
+// computeFleetNorm derives the baseline from the hives the caller can see.
+// Returns a zero norm when the eligible sample is too small to be meaningful.
+func computeFleetNorm(hives []MyHiveEntry) fleetNorm {
+	branches := make([]string, 0, len(hives))
+	for _, h := range hives {
+		if !driftEligibleForNorm(h) {
+			continue
+		}
+		branches = append(branches, h.GitBranch)
+	}
+	if len(branches) < minFleetNormSample {
+		return fleetNorm{}
+	}
+	branch, _ := modalString(branches)
+	if branch == "" {
+		return fleetNorm{}
+	}
+	// Scope the SHA norm to hives on the norm branch — a hive on another
+	// branch has a legitimately different SHA and must not drag the modal.
+	shas := make([]string, 0, len(hives))
+	for _, h := range hives {
+		if !driftEligibleForNorm(h) || !strings.EqualFold(h.GitBranch, branch) {
+			continue
+		}
+		shas = append(shas, shortSHA(h.GitHash))
+	}
+	sha, _ := modalString(shas)
+	return fleetNorm{Branch: branch, SHA: sha, Eligible: len(branches)}
+}
+
+// driftHumanDuration renders a duration for a reason string at the coarsest
+// unit that still reads precisely ("3 min", "4 hours", "2 days"). Sub-minute
+// durations round up to "1 min" — no drift reason is ever about seconds.
+func driftHumanDuration(d time.Duration) string {
+	const hoursPerDay = 24
+	if d < time.Hour {
+		mins := int(d.Minutes())
+		if mins < 1 {
+			mins = 1
+		}
+		return pluralize(mins, "min", "min")
+	}
+	if d < hoursPerDay*time.Hour {
+		return pluralize(int(d.Hours()), "hour", "hours")
+	}
+	return pluralize(int(d.Hours())/hoursPerDay, "day", "days")
+}
+
+func pluralize(n int, one, many string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, one)
+	}
+	return fmt.Sprintf("%d %s", n, many)
+}
+
+// parseRFC3339 parses a timestamp, reporting ok=false for empty or malformed
+// input so callers skip the signal rather than computing an age from the zero
+// time (which would make every hive look decades stale).
+func parseRFC3339(s string) (time.Time, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// imageTagOf extracts the tag from an image reference
+// ("ghcr.io/kubestellar/hive:v2-latest" → "v2-latest"). Returns "" when the ref
+// carries no tag or is a digest pin, since neither is a tag-drift question.
+// The registry host may itself contain a ':' port, so only a colon AFTER the
+// last '/' delimits a tag.
+func imageTagOf(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ""
+	}
+	// A digest pin ("...@sha256:...") has no mutable tag to speak of.
+	if at := strings.LastIndex(ref, "@"); at >= 0 {
+		ref = ref[:at]
+	}
+	slash := strings.LastIndex(ref, "/")
+	colon := strings.LastIndex(ref, ":")
+	if colon <= slash {
+		return ""
+	}
+	return ref[colon+1:]
+}
+
+// healthFailingChecks returns the names of checks that are not passing, with
+// their status, in the order the spoke reported them. Every access is guarded:
+// Health is a free-form map[string]any decoded from spoke JSON, so any level of
+// it can be a different type (or missing) on an old or misbehaving spoke, and a
+// type assertion that panicked here would take down the whole My Hives request.
+func healthFailingChecks(health map[string]any) []string {
+	if health == nil {
+		return nil
+	}
+	raw, ok := health["checks"].([]any)
+	if !ok {
+		return nil
+	}
+	var out []string
+	for _, item := range raw {
+		ck, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		status, _ := ck["status"].(string)
+		if status == "" || status == "pass" || status == "skip" {
+			continue
+		}
+		name, _ := ck["name"].(string)
+		if name == "" {
+			name = "unnamed check"
+		}
+		detail, _ := ck["detail"].(string)
+		if detail != "" {
+			out = append(out, fmt.Sprintf("%s (%s: %s)", name, status, detail))
+			continue
+		}
+		out = append(out, fmt.Sprintf("%s (%s)", name, status))
+	}
+	return out
+}
+
+// healthStatusOf reads health.status, defaulting to "unknown".
+func healthStatusOf(health map[string]any) string {
+	if health == nil {
+		return "unknown"
+	}
+	st, ok := health["status"].(string)
+	if !ok || st == "" {
+		return "unknown"
+	}
+	return st
+}
+
+// maxFailingChecksInReason bounds how many failing check names a single reason
+// string names before summarizing the rest. A hive with a dozen failures would
+// otherwise produce a reason too long to read in a hover panel.
+const maxFailingChecksInReason = 3
+
+// computeDrift builds the drift report for one hive against a fleet norm and a
+// branch→latest-SHA map (the same map the My Hives payload already ships as
+// latest_shas, so no new data source is introduced).
+//
+// now is passed in rather than read from the clock so every hive in one request
+// is evaluated against the same instant and tests are deterministic.
+func computeDrift(h MyHiveEntry, norm fleetNorm, latestSHAs map[string]string, now time.Time) DriftReport {
+	var signals []DriftSignal
+	add := func(kind string, sev DriftSeverity, reason string) {
+		signals = append(signals, DriftSignal{Kind: kind, Severity: sev, Reason: reason})
+	}
+
+	placeholder := isPlaceholderEntry(h)
+
+	// --- Signals that apply to every hive, claimed or placeholder ----------
+
+	// Heartbeat stale / offline. Only meaningful once the hive has beaten at
+	// least once: a slot that has never reported is being provisioned, not
+	// drifting.
+	if last, ok := parseRFC3339(h.LastHeartbeat); ok {
+		if age := now.Sub(last); age > driftHeartbeatStaleAfter {
+			add(DriftKindHeartbeatStale, DriftCritical,
+				fmt.Sprintf("No heartbeat for %s — the hub has no live reading for this hive", driftHumanDuration(age)))
+		}
+	}
+
+	// Upgrade wedged. Reuses staleUpgradeTimeout, the same bound the hub's own
+	// upgrade-state machine uses to call an in-flight upgrade stuck, so the
+	// drift badge and the row's upgrade spinner agree on when to give up.
+	if h.Upgrading {
+		started, ok := parseRFC3339OrTime(h.UpgradeStartedAt, "")
+		if !ok || started.IsZero() {
+			add(DriftKindUpgradeStuck, DriftWarn,
+				"Upgrade in flight with no recorded start time — the hub cannot tell how long it has been running")
+		} else if age := now.Sub(started); age > staleUpgradeTimeout {
+			target := h.UpgradeTarget
+			if target == "" {
+				target = "an unrecorded target"
+			}
+			add(DriftKindUpgradeStuck, DriftCritical,
+				fmt.Sprintf("Upgrade to %s has been in flight for %s (limit %s) — it is stuck, not progressing",
+					target, driftHumanDuration(age), driftHumanDuration(staleUpgradeTimeout)))
+		}
+	}
+
+	// Image pinned to an immutable tag. The spoke reports its own Deployment's
+	// image over the heartbeat; a tag that is not "<branch>-latest" can never
+	// receive a rolling upgrade, which is how one spoke sat on hive:63d8902
+	// restart-looping while the fleet moved on. Reuses imageTagIsMutable — the
+	// SAME predicate UpgradeSelfToSHA uses to decide a restart is a no-op, so
+	// the badge can never disagree with the upgrade path about what is pinned.
+	//
+	// Guarded on a non-empty ref: "unknown image" (old spoke, or not running
+	// in-cluster) must never render as "pinned".
+	if h.ImageRef != "" && !imageTagIsMutable(h.ImageRef) {
+		label := imageTagOf(h.ImageRef)
+		if label == "" {
+			label = h.ImageRef
+		}
+		add(DriftKindPinnedImage, DriftCritical,
+			fmt.Sprintf("Image %q is not a rolling tag — this hive can never receive a rolling upgrade (expected a *%s tag)",
+				label, mutableTagSuffix))
+	}
+
+	// Health. Placeholders run a real spoke process and can genuinely be
+	// degraded, so this is not claimed-only.
+	switch st := healthStatusOf(h.Health); st {
+	case "degraded", "critical":
+		failing := healthFailingChecks(h.Health)
+		sev := DriftWarn
+		if st == "critical" {
+			sev = DriftCritical
+		}
+		if len(failing) == 0 {
+			add(DriftKindHealthDegraded, sev,
+				fmt.Sprintf("Health is %s but the spoke reported no failing check — the reason is not visible to the hub", st))
+			break
+		}
+		named := failing
+		suffix := ""
+		if len(named) > maxFailingChecksInReason {
+			extra := len(named) - maxFailingChecksInReason
+			named = named[:maxFailingChecksInReason]
+			noun := "checks"
+			if extra == 1 {
+				noun = "check"
+			}
+			suffix = fmt.Sprintf(" and %d more %s", extra, noun)
+		}
+		add(DriftKindHealthDegraded, sev,
+			fmt.Sprintf("Health is %s: %s%s", st, strings.Join(named, ", "), suffix))
+	}
+
+	// --- Claimed-hive-only signals ---------------------------------------
+	//
+	// A placeholder legitimately has no App, no agents and ACMM 0. Flagging it
+	// for those would make the pool dominate the exceptions summary and hide
+	// the hives a human can actually fix.
+	if !placeholder {
+		if h.GitHubAppRequired {
+			if h.GitHubAppPermIssue != "" {
+				add(DriftKindAppPermIssue, DriftCritical,
+					fmt.Sprintf("GitHub App is installed but its permissions are insufficient: %s", h.GitHubAppPermIssue))
+			} else {
+				add(DriftKindAppMissing, DriftCritical,
+					"GitHub App is required by this hive but is not installed — agents cannot act on the repo")
+			}
+		}
+		if h.ACMMLevel <= driftACMMUnsetLevel {
+			add(DriftKindACMMUnset, DriftWarn,
+				"ACMM level is unset (0) on a claimed hive — the governor has no maturity target to work toward")
+		}
+		if h.AgentCount <= driftNoAgentsCount {
+			add(DriftKindNoAgents, DriftWarn,
+				"No agents are running on this claimed hive — it holds a slot but does no work")
+		}
+	}
+
+	// --- Fleet-relative signals ------------------------------------------
+	//
+	// Skipped entirely when no norm could be derived, and skipped for offline
+	// hives (whose last-reported version is not evidence of current state) and
+	// placeholders (which track the pool image, not the fleet).
+	if norm.Branch != "" && h.Online && !placeholder {
+		hiveBranch := strings.TrimSpace(h.GitBranch)
+		if hiveBranch != "" && !strings.EqualFold(hiveBranch, norm.Branch) {
+			add(DriftKindBranchMismatch, DriftWarn,
+				fmt.Sprintf("Running branch %s while %d of the fleet's online hives run %s",
+					hiveBranch, norm.Eligible, norm.Branch))
+		}
+
+		// Version drift is only asked WITHIN a branch: a hive on another
+		// branch is already flagged above, and "behind" across branches is
+		// not a defined relation.
+		if hiveBranch == "" || strings.EqualFold(hiveBranch, norm.Branch) {
+			hiveSHA := shortSHA(h.GitHash)
+			// Prefer the branch's true latest build (what the hive SHOULD be
+			// on); fall back to the fleet's modal SHA when the hub has not
+			// resolved a latest for this branch.
+			target := shortSHA(latestSHAs[norm.Branch])
+			targetLabel := "the latest build on " + norm.Branch
+			if target == "" {
+				target = norm.SHA
+				targetLabel = "the version most of the fleet runs"
+			}
+			if hiveSHA != "" && target != "" && !sameCommit(hiveSHA, target) {
+				add(DriftKindVersionBehind, DriftInfo,
+					fmt.Sprintf("Running %s, which differs from %s (%s)", hiveSHA, targetLabel, target))
+			}
+		}
+	}
+
+	report := DriftReport{Signals: signals, Count: len(signals)}
+	for _, s := range signals {
+		if driftSeverityRank[s.Severity] > driftSeverityRank[report.WorstSeverity] {
+			report.WorstSeverity = s.Severity
+		}
+	}
+	return report
+}
+
+// parseRFC3339OrTime accepts an already-parsed time.Time (the registry stores
+// UpgradeStartedAt as one) and falls back to parsing a string form. ok is false
+// only when neither yields a usable instant.
+func parseRFC3339OrTime(t time.Time, s string) (time.Time, bool) {
+	if !t.IsZero() {
+		return t, true
+	}
+	return parseRFC3339(s)
+}
+
+// annotateDrift computes the fleet norm across the caller's hives once and
+// attaches a drift report to each. Mutating in place (rather than returning a
+// parallel map) keeps the report on the row the frontend already renders.
+func annotateDrift(hives []MyHiveEntry, latestSHAs map[string]string, now time.Time) {
+	if len(hives) == 0 {
+		return
+	}
+	norm := computeFleetNorm(hives)
+	for i := range hives {
+		hives[i].Drift = computeDrift(hives[i], norm, latestSHAs, now)
+	}
+}

--- a/v2/pkg/hub/drift_test.go
+++ b/v2/pkg/hub/drift_test.go
@@ -1,0 +1,698 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// driftNow is the fixed instant every table-driven case is evaluated at, so
+// "3 hours ago" in a fixture means the same thing on every run.
+var driftNow = time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+
+func rfc(t time.Time) string { return t.UTC().Format(time.RFC3339) }
+
+// healthyEntry is a claimed hive with NOTHING wrong: online, fresh heartbeat,
+// on the fleet's branch and SHA, App installed, agents running, ACMM set,
+// riding a rolling tag. Every case below starts from this and breaks exactly
+// one thing, so a signal firing can only be attributed to that change.
+func healthyEntry(id string) MyHiveEntry {
+	return MyHiveEntry{
+		RegistryEntry: RegistryEntry{
+			ID:            id,
+			Org:           "kubestellar",
+			ACMMLevel:     2,
+			AgentCount:    3,
+			LastHeartbeat: rfc(driftNow.Add(-1 * time.Minute)),
+			Online:        true,
+			GitHash:       "abc1234",
+			GitBranch:     "v2",
+			ImageRef:      "ghcr.io/kubestellar/hive:v2-latest",
+			Health:        map[string]any{"status": "ok"},
+		},
+		Role:       "owner",
+		ProvStatus: "claimed",
+	}
+}
+
+// normFleet is an eligible-sized fleet all on v2/abc1234, so computeFleetNorm
+// yields a real norm and relative signals are actually exercised.
+func normFleet() []MyHiveEntry {
+	return []MyHiveEntry{healthyEntry("a"), healthyEntry("b"), healthyEntry("c")}
+}
+
+func driftKindsOf(r DriftReport) map[string]DriftSignal {
+	out := make(map[string]DriftSignal, len(r.Signals))
+	for _, s := range r.Signals {
+		out[s.Kind] = s
+	}
+	return out
+}
+
+func TestComputeDriftSignals(t *testing.T) {
+	norm := computeFleetNorm(normFleet())
+	if norm.Branch != "v2" {
+		t.Fatalf("test setup: expected norm branch v2, got %q", norm.Branch)
+	}
+	latest := map[string]string{"v2": "abc1234"}
+
+	tests := []struct {
+		name string
+		// mutate breaks exactly one thing on a healthy hive.
+		mutate func(*MyHiveEntry)
+		// wantKind is the signal expected to fire ("" = expect no drift).
+		wantKind string
+		wantSev  DriftSeverity
+		// wantReasonHas is a substring the reason must carry, so the test
+		// pins the SPECIFICS (which branch, which check) not just the kind.
+		wantReasonHas string
+	}{
+		{
+			name:   "no drift on a healthy claimed hive",
+			mutate: func(h *MyHiveEntry) {},
+		},
+		{
+			name: "heartbeat stale",
+			mutate: func(h *MyHiveEntry) {
+				h.LastHeartbeat = rfc(driftNow.Add(-3 * time.Hour))
+			},
+			wantKind:      DriftKindHeartbeatStale,
+			wantSev:       DriftCritical,
+			wantReasonHas: "3 hours",
+		},
+		{
+			name: "heartbeat never sent yields no stale signal",
+			mutate: func(h *MyHiveEntry) {
+				h.LastHeartbeat = ""
+			},
+		},
+		{
+			name: "malformed heartbeat timestamp yields no stale signal",
+			mutate: func(h *MyHiveEntry) {
+				h.LastHeartbeat = "not-a-time"
+			},
+		},
+		{
+			name: "pinned immutable sha tag",
+			mutate: func(h *MyHiveEntry) {
+				h.ImageRef = "ghcr.io/kubestellar/hive:63d8902"
+			},
+			wantKind:      DriftKindPinnedImage,
+			wantSev:       DriftCritical,
+			wantReasonHas: "63d8902",
+		},
+		{
+			name: "digest pin is also not a rolling tag",
+			mutate: func(h *MyHiveEntry) {
+				h.ImageRef = "ghcr.io/kubestellar/hive@sha256:" + strings.Repeat("d", 64)
+			},
+			wantKind: DriftKindPinnedImage,
+			wantSev:  DriftCritical,
+		},
+		{
+			name: "unknown image ref is not reported as pinned",
+			mutate: func(h *MyHiveEntry) {
+				h.ImageRef = ""
+			},
+		},
+		{
+			name: "registry port is not mistaken for a tag",
+			mutate: func(h *MyHiveEntry) {
+				h.ImageRef = "registry.internal:5000/kubestellar/hive:v2-latest"
+			},
+		},
+		{
+			name: "github app required but not installed",
+			mutate: func(h *MyHiveEntry) {
+				h.GitHubAppRequired = true
+			},
+			wantKind:      DriftKindAppMissing,
+			wantSev:       DriftCritical,
+			wantReasonHas: "not installed",
+		},
+		{
+			name: "github app installed with insufficient permissions",
+			mutate: func(h *MyHiveEntry) {
+				h.GitHubAppRequired = true
+				h.GitHubAppPermIssue = "missing contents:write"
+			},
+			wantKind:      DriftKindAppPermIssue,
+			wantSev:       DriftCritical,
+			wantReasonHas: "missing contents:write",
+		},
+		{
+			name: "health degraded names the failing check",
+			mutate: func(h *MyHiveEntry) {
+				h.Health = map[string]any{
+					"status": "degraded",
+					"checks": []any{
+						map[string]any{"name": "ready", "status": "pass"},
+						map[string]any{"name": "github_auth", "status": "fail", "detail": "token error"},
+					},
+				}
+			},
+			wantKind:      DriftKindHealthDegraded,
+			wantSev:       DriftWarn,
+			wantReasonHas: "github_auth (fail: token error)",
+		},
+		{
+			name: "health critical escalates severity",
+			mutate: func(h *MyHiveEntry) {
+				h.Health = map[string]any{
+					"status": "critical",
+					"checks": []any{map[string]any{"name": "agents", "status": "fail"}},
+				}
+			},
+			wantKind:      DriftKindHealthDegraded,
+			wantSev:       DriftCritical,
+			wantReasonHas: "agents (fail)",
+		},
+		{
+			name: "health degraded with no check data still explains itself",
+			mutate: func(h *MyHiveEntry) {
+				h.Health = map[string]any{"status": "degraded"}
+			},
+			wantKind:      DriftKindHealthDegraded,
+			wantSev:       DriftWarn,
+			wantReasonHas: "no failing check",
+		},
+		{
+			name: "malformed health checks do not panic and yield no names",
+			mutate: func(h *MyHiveEntry) {
+				h.Health = map[string]any{
+					"status": "degraded",
+					"checks": "not-an-array",
+				}
+			},
+			wantKind:      DriftKindHealthDegraded,
+			wantSev:       DriftWarn,
+			wantReasonHas: "no failing check",
+		},
+		{
+			name: "upgrade stuck past the stale timeout",
+			mutate: func(h *MyHiveEntry) {
+				h.Upgrading = true
+				h.UpgradeTarget = "v2-latest"
+				h.UpgradeStartedAt = driftNow.Add(-2 * time.Hour)
+			},
+			wantKind:      DriftKindUpgradeStuck,
+			wantSev:       DriftCritical,
+			wantReasonHas: "v2-latest",
+		},
+		{
+			name: "upgrade in flight but still within the timeout is not drift",
+			mutate: func(h *MyHiveEntry) {
+				h.Upgrading = true
+				h.UpgradeTarget = "v2-latest"
+				h.UpgradeStartedAt = driftNow.Add(-1 * time.Minute)
+			},
+		},
+		{
+			name: "upgrade with no recorded start time is a warning",
+			mutate: func(h *MyHiveEntry) {
+				h.Upgrading = true
+			},
+			wantKind:      DriftKindUpgradeStuck,
+			wantSev:       DriftWarn,
+			wantReasonHas: "no recorded start time",
+		},
+		{
+			name: "acmm unset on a claimed hive",
+			mutate: func(h *MyHiveEntry) {
+				h.ACMMLevel = 0
+			},
+			wantKind:      DriftKindACMMUnset,
+			wantSev:       DriftWarn,
+			wantReasonHas: "ACMM level is unset",
+		},
+		{
+			name: "zero agents on a claimed hive",
+			mutate: func(h *MyHiveEntry) {
+				h.AgentCount = 0
+			},
+			wantKind:      DriftKindNoAgents,
+			wantSev:       DriftWarn,
+			wantReasonHas: "No agents",
+		},
+		{
+			name: "branch differs from the fleet norm",
+			mutate: func(h *MyHiveEntry) {
+				h.GitBranch = "v3"
+			},
+			wantKind:      DriftKindBranchMismatch,
+			wantSev:       DriftWarn,
+			wantReasonHas: "Running branch v3",
+		},
+		{
+			name: "version behind the branch latest",
+			mutate: func(h *MyHiveEntry) {
+				h.GitHash = "0000fff"
+			},
+			wantKind:      DriftKindVersionBehind,
+			wantSev:       DriftInfo,
+			wantReasonHas: "abc1234",
+		},
+		{
+			name: "long git hash matching the short latest is not behind",
+			mutate: func(h *MyHiveEntry) {
+				h.GitHash = "abc1234deadbeef"
+			},
+		},
+		{
+			name: "offline hive is not judged on version",
+			mutate: func(h *MyHiveEntry) {
+				h.Online = false
+				h.GitHash = "0000fff"
+				h.GitBranch = "v3"
+				// Heartbeat is still fresh, so the stale signal stays quiet and
+				// the case isolates the relative-signal suppression.
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := healthyEntry("subject")
+			tc.mutate(&h)
+			got := computeDrift(h, norm, latest, driftNow)
+
+			if tc.wantKind == "" {
+				if got.Count != 0 || len(got.Signals) != 0 {
+					t.Fatalf("expected no drift, got %d signals: %+v", got.Count, got.Signals)
+				}
+				if got.WorstSeverity != "" {
+					t.Fatalf("expected empty WorstSeverity with no signals, got %q", got.WorstSeverity)
+				}
+				return
+			}
+
+			byKind := driftKindsOf(got)
+			sig, ok := byKind[tc.wantKind]
+			if !ok {
+				t.Fatalf("expected signal %q, got %+v", tc.wantKind, got.Signals)
+			}
+			if sig.Severity != tc.wantSev {
+				t.Errorf("severity: want %q, got %q", tc.wantSev, sig.Severity)
+			}
+			if tc.wantReasonHas != "" && !strings.Contains(sig.Reason, tc.wantReasonHas) {
+				t.Errorf("reason %q does not contain %q", sig.Reason, tc.wantReasonHas)
+			}
+			if got.Count != len(got.Signals) {
+				t.Errorf("Count %d != len(Signals) %d", got.Count, len(got.Signals))
+			}
+			// Exactly one thing was broken, so exactly one signal must fire —
+			// this is what catches a new signal accidentally double-flagging.
+			if len(got.Signals) != 1 {
+				t.Errorf("expected exactly 1 signal for a single-fault fixture, got %+v", got.Signals)
+			}
+		})
+	}
+}
+
+// Placeholders legitimately have no App, no agents and ACMM 0. Flagging them
+// would bury real signals under pool noise — the reason the model scopes those
+// three signals to claimed hives.
+func TestComputeDriftSkipsClaimedOnlySignalsForPlaceholders(t *testing.T) {
+	norm := computeFleetNorm(normFleet())
+	latest := map[string]string{"v2": "abc1234"}
+
+	for _, tc := range []struct {
+		name  string
+		setup func(*MyHiveEntry)
+	}{
+		{"provStatus available", func(h *MyHiveEntry) { h.ProvStatus = statusAvailable }},
+		{"available- org prefix", func(h *MyHiveEntry) { h.ProvStatus = ""; h.Org = "available-pool-7" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := healthyEntry("slot")
+			h.GitHubAppRequired = true
+			h.ACMMLevel = 0
+			h.AgentCount = 0
+			h.GitBranch = "v3"
+			h.GitHash = "0000fff"
+			tc.setup(&h)
+
+			got := computeDrift(h, norm, latest, driftNow)
+			for _, s := range got.Signals {
+				switch s.Kind {
+				case DriftKindAppMissing, DriftKindAppPermIssue, DriftKindACMMUnset,
+					DriftKindNoAgents, DriftKindBranchMismatch, DriftKindVersionBehind:
+					t.Errorf("placeholder was flagged with claimed-only signal %q: %s", s.Kind, s.Reason)
+				}
+			}
+		})
+	}
+}
+
+// A placeholder still runs a real spoke, so universal signals must still fire.
+func TestComputeDriftStillFlagsPlaceholderUniversalSignals(t *testing.T) {
+	h := healthyEntry("slot")
+	h.ProvStatus = statusAvailable
+	h.LastHeartbeat = rfc(driftNow.Add(-2 * time.Hour))
+	h.ImageRef = "ghcr.io/kubestellar/hive:63d8902"
+
+	got := computeDrift(h, fleetNorm{}, nil, driftNow)
+	byKind := driftKindsOf(got)
+	if _, ok := byKind[DriftKindHeartbeatStale]; !ok {
+		t.Errorf("stale heartbeat must be flagged on placeholders too: %+v", got.Signals)
+	}
+	if _, ok := byKind[DriftKindPinnedImage]; !ok {
+		t.Errorf("pinned image must be flagged on placeholders too: %+v", got.Signals)
+	}
+}
+
+func TestComputeDriftWorstSeverityWins(t *testing.T) {
+	h := healthyEntry("mixed")
+	h.ACMMLevel = 0                                 // warn
+	h.AgentCount = 0                                // warn
+	h.ImageRef = "ghcr.io/kubestellar/hive:63d8902" // critical
+
+	got := computeDrift(h, fleetNorm{}, nil, driftNow)
+	if got.WorstSeverity != DriftCritical {
+		t.Errorf("want critical, got %q from %+v", got.WorstSeverity, got.Signals)
+	}
+	if got.Count != 3 {
+		t.Errorf("want 3 signals, got %d: %+v", got.Count, got.Signals)
+	}
+}
+
+func TestComputeFleetNorm(t *testing.T) {
+	tests := []struct {
+		name       string
+		hives      []MyHiveEntry
+		wantBranch string
+		wantSHA    string
+	}{
+		{
+			name:  "empty fleet has no norm",
+			hives: nil,
+		},
+		{
+			name:  "below the minimum sample has no norm",
+			hives: []MyHiveEntry{healthyEntry("a"), healthyEntry("b")},
+		},
+		{
+			name:       "modal branch and sha",
+			hives:      normFleet(),
+			wantBranch: "v2",
+			wantSHA:    "abc1234",
+		},
+		{
+			name: "minority branch does not become the norm",
+			hives: func() []MyHiveEntry {
+				f := normFleet()
+				f[0].GitBranch = "v3"
+				f[0].GitHash = "9999999"
+				return f
+			}(),
+			wantBranch: "v2",
+			wantSHA:    "abc1234",
+		},
+		{
+			name: "offline hives do not vote",
+			hives: func() []MyHiveEntry {
+				// Three v3 hives, all offline, plus three online v2 hives.
+				var f []MyHiveEntry
+				for _, id := range []string{"x", "y", "z"} {
+					h := healthyEntry(id)
+					h.Online = false
+					h.GitBranch = "v3"
+					f = append(f, h)
+				}
+				return append(f, normFleet()...)
+			}(),
+			wantBranch: "v2",
+			wantSHA:    "abc1234",
+		},
+		{
+			name: "placeholders do not vote",
+			hives: func() []MyHiveEntry {
+				var f []MyHiveEntry
+				for _, id := range []string{"p1", "p2", "p3", "p4"} {
+					h := healthyEntry(id)
+					h.ProvStatus = statusAvailable
+					h.GitBranch = "pool"
+					f = append(f, h)
+				}
+				return append(f, normFleet()...)
+			}(),
+			wantBranch: "v2",
+			wantSHA:    "abc1234",
+		},
+		{
+			name: "sha norm is scoped to the norm branch",
+			hives: func() []MyHiveEntry {
+				f := normFleet()
+				// A v3 hive with a different SHA must not drag the v2 SHA norm.
+				odd := healthyEntry("odd")
+				odd.GitBranch = "v3"
+				odd.GitHash = "fffffff"
+				return append(f, odd)
+			}(),
+			wantBranch: "v2",
+			wantSHA:    "abc1234",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeFleetNorm(tc.hives)
+			if got.Branch != tc.wantBranch {
+				t.Errorf("branch: want %q, got %q", tc.wantBranch, got.Branch)
+			}
+			if got.SHA != tc.wantSHA {
+				t.Errorf("sha: want %q, got %q", tc.wantSHA, got.SHA)
+			}
+		})
+	}
+}
+
+// A tie must resolve the same way every request; a norm that flickered would
+// flag half the fleet on alternating page loads.
+func TestComputeFleetNormTieIsDeterministic(t *testing.T) {
+	build := func() []MyHiveEntry {
+		var f []MyHiveEntry
+		for i, br := range []string{"v2", "v2", "v3", "v3"} {
+			h := healthyEntry(string(rune('a' + i)))
+			h.GitBranch = br
+			f = append(f, h)
+		}
+		return f
+	}
+	first := computeFleetNorm(build()).Branch
+	for i := 0; i < 20; i++ {
+		if got := computeFleetNorm(build()).Branch; got != first {
+			t.Fatalf("tie-break not deterministic: %q then %q", first, got)
+		}
+	}
+	if first != "v2" {
+		t.Errorf("tie should break to the lexically smaller branch, got %q", first)
+	}
+}
+
+func TestAnnotateDrift(t *testing.T) {
+	hives := normFleet()
+	hives = append(hives, func() MyHiveEntry {
+		h := healthyEntry("bad")
+		h.GitHubAppRequired = true
+		return h
+	}())
+
+	annotateDrift(hives, map[string]string{"v2": "abc1234"}, driftNow)
+
+	for _, h := range hives[:3] {
+		if h.Drift.Count != 0 {
+			t.Errorf("healthy hive %s got drift: %+v", h.ID, h.Drift.Signals)
+		}
+	}
+	last := hives[len(hives)-1]
+	if last.Drift.Count != 1 || last.Drift.WorstSeverity != DriftCritical {
+		t.Errorf("bad hive: want 1 critical signal, got %+v", last.Drift)
+	}
+
+	// Nil/empty input must not panic.
+	annotateDrift(nil, nil, driftNow)
+	annotateDrift([]MyHiveEntry{}, nil, driftNow)
+}
+
+// When the hub has not resolved a latest SHA for the branch, version drift
+// falls back to the fleet's modal SHA rather than going silent.
+func TestComputeDriftVersionFallsBackToFleetModalSHA(t *testing.T) {
+	norm := computeFleetNorm(normFleet())
+	h := healthyEntry("behind")
+	h.GitHash = "0000fff"
+
+	got := computeDrift(h, norm, nil /* no latest_shas */, driftNow)
+	sig, ok := driftKindsOf(got)[DriftKindVersionBehind]
+	if !ok {
+		t.Fatalf("expected version drift, got %+v", got.Signals)
+	}
+	if !strings.Contains(sig.Reason, "most of the fleet") {
+		t.Errorf("expected fleet-modal wording, got %q", sig.Reason)
+	}
+}
+
+// With no derivable norm, relative signals must be silent rather than guessed.
+func TestComputeDriftSkipsRelativeSignalsWithoutNorm(t *testing.T) {
+	h := healthyEntry("lonely")
+	h.GitBranch = "some-feature-branch"
+	h.GitHash = "0000fff"
+
+	got := computeDrift(h, fleetNorm{}, map[string]string{"v2": "abc1234"}, driftNow)
+	for _, s := range got.Signals {
+		if s.Kind == DriftKindBranchMismatch || s.Kind == DriftKindVersionBehind {
+			t.Errorf("relative signal %q fired with no fleet norm: %s", s.Kind, s.Reason)
+		}
+	}
+}
+
+func TestImageTagOf(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"", ""},
+		{"ghcr.io/kubestellar/hive:v2-latest", "v2-latest"},
+		{"ghcr.io/kubestellar/hive:63d8902", "63d8902"},
+		{"ghcr.io/kubestellar/hive", ""},
+		{"registry.internal:5000/kubestellar/hive", ""},
+		{"registry.internal:5000/kubestellar/hive:v2-latest", "v2-latest"},
+		{"ghcr.io/kubestellar/hive@sha256:" + strings.Repeat("a", 64), ""},
+		{"ghcr.io/kubestellar/hive:v2-latest@sha256:" + strings.Repeat("a", 64), "v2-latest"},
+	}
+	for _, tc := range tests {
+		if got := imageTagOf(tc.in); got != tc.want {
+			t.Errorf("imageTagOf(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestHealthFailingChecks(t *testing.T) {
+	tests := []struct {
+		name   string
+		health map[string]any
+		want   []string
+	}{
+		{"nil health", nil, nil},
+		{"no checks key", map[string]any{"status": "ok"}, nil},
+		{"checks wrong type", map[string]any{"checks": 42}, nil},
+		{"checks entry wrong type", map[string]any{"checks": []any{"oops"}}, nil},
+		{
+			name: "passing and skipped are not failures",
+			health: map[string]any{"checks": []any{
+				map[string]any{"name": "a", "status": "pass"},
+				map[string]any{"name": "b", "status": "skip"},
+			}},
+			want: nil,
+		},
+		{
+			name: "fail and warn are reported with detail",
+			health: map[string]any{"checks": []any{
+				map[string]any{"name": "a", "status": "fail", "detail": "boom"},
+				map[string]any{"name": "b", "status": "warn"},
+			}},
+			want: []string{"a (fail: boom)", "b (warn)"},
+		},
+		{
+			name: "missing name is labelled not dropped",
+			health: map[string]any{"checks": []any{
+				map[string]any{"status": "fail"},
+			}},
+			want: []string{"unnamed check (fail)"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := healthFailingChecks(tc.health)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("[%d] got %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// Many failing checks must summarize rather than produce an unreadable reason.
+func TestComputeDriftTruncatesLongCheckLists(t *testing.T) {
+	var checks []any
+	for _, n := range []string{"c1", "c2", "c3", "c4", "c5"} {
+		checks = append(checks, map[string]any{"name": n, "status": "fail"})
+	}
+	h := healthyEntry("noisy")
+	h.Health = map[string]any{"status": "degraded", "checks": checks}
+
+	got := computeDrift(h, fleetNorm{}, nil, driftNow)
+	sig := driftKindsOf(got)[DriftKindHealthDegraded]
+	if !strings.Contains(sig.Reason, "and 2 more checks") {
+		t.Errorf("expected a truncation summary, got %q", sig.Reason)
+	}
+	if strings.Contains(sig.Reason, "c4") {
+		t.Errorf("reason should not name checks past the cap: %q", sig.Reason)
+	}
+}
+
+func TestDriftHumanDuration(t *testing.T) {
+	tests := []struct {
+		in   time.Duration
+		want string
+	}{
+		{10 * time.Second, "1 min"},
+		{1 * time.Minute, "1 min"},
+		{45 * time.Minute, "45 min"},
+		{1 * time.Hour, "1 hour"},
+		{5 * time.Hour, "5 hours"},
+		{25 * time.Hour, "1 day"},
+		{72 * time.Hour, "3 days"},
+	}
+	for _, tc := range tests {
+		if got := driftHumanDuration(tc.in); got != tc.want {
+			t.Errorf("driftHumanDuration(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestModalString(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    []string
+		want  string
+		wantN int
+	}{
+		{"nil", nil, "", 0},
+		{"all empty", []string{"", "  "}, "", 0},
+		{"clear winner", []string{"v2", "v2", "v3"}, "v2", 2},
+		{"empties are ignored", []string{"", "v3", "v3"}, "v3", 2},
+		{"tie breaks lexically", []string{"v3", "v2"}, "v2", 1},
+		{"whitespace is trimmed together", []string{" v2 ", "v2"}, "v2", 2},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, n := modalString(tc.in)
+			if got != tc.want || n != tc.wantN {
+				t.Errorf("modalString(%v) = (%q, %d), want (%q, %d)", tc.in, got, n, tc.want, tc.wantN)
+			}
+		})
+	}
+}
+
+func TestIsPlaceholderEntry(t *testing.T) {
+	tests := []struct {
+		name string
+		in   MyHiveEntry
+		want bool
+	}{
+		{"claimed", MyHiveEntry{ProvStatus: "claimed", RegistryEntry: RegistryEntry{Org: "kubestellar"}}, false},
+		{"available status", MyHiveEntry{ProvStatus: statusAvailable}, true},
+		{"available org prefix", MyHiveEntry{RegistryEntry: RegistryEntry{Org: "available-7"}}, true},
+		{"empty entry", MyHiveEntry{}, false},
+		{"org merely containing available", MyHiveEntry{RegistryEntry: RegistryEntry{Org: "not-available-here"}}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isPlaceholderEntry(tc.in); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/v2/pkg/hub/health_check_detail_test.go
+++ b/v2/pkg/hub/health_check_detail_test.go
@@ -118,7 +118,10 @@ func TestFilterComposition(t *testing.T) {
 	}{
 		// The render signature must include the check filter or toggling it on
 		// unchanged data is treated as a no-op and nothing re-renders.
-		{"render signature includes check filter", "+ '|' + _dashFailingCheckFilter;"},
+		// Matched without a trailing ';' so that later filters appending their
+		// own state to the signature do not trip this guard — the invariant is
+		// that the check filter is PART of the signature, not that it is last.
+		{"render signature includes check filter", "+ '|' + _dashFailingCheckFilter"},
 		// Clearing must clear both filter kinds, else "Clear filters" leaves the
 		// list mysteriously short.
 		{"clear resets check filter", "_dashFailingCheckFilter = '';"},
@@ -126,7 +129,10 @@ func TestFilterComposition(t *testing.T) {
 		{"placeholder split retained", "(isPlaceholderHive(allHives[_si]) ? unassignedAll : assignedAll)"},
 		{"filters applied to assigned only", "applyDashFilters(assignedAll).concat(unassignedAll)"},
 		// Any-active must account for the check filter so the Clear button shows.
-		{"clear button accounts for check filter", "|| !!_dashFailingCheckFilter;"},
+		// Trailing ';' omitted so additional filters can be OR'd into anyActive
+		// without tripping this guard; the invariant is that the check filter
+		// participates, not that it terminates the expression.
+		{"clear button accounts for check filter", "|| !!_dashFailingCheckFilter"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -197,36 +197,45 @@ type HeartbeatGPUSummary struct {
 }
 
 type HeartbeatPayload struct {
-	HiveID                  string                        `json:"hive_id"`
-	Org                     string                        `json:"org"`
-	Repos                   []string                      `json:"repos"`
-	PrimaryRepo             string                        `json:"primary_repo"`
+	HiveID      string   `json:"hive_id"`
+	Org         string   `json:"org"`
+	Repos       []string `json:"repos"`
+	PrimaryRepo string   `json:"primary_repo"`
 	// AIAuthor is the GitHub account this hive's agents open PRs as. Reported
 	// so the hub can echo it back in HeartbeatProjectConfig rather than
 	// blanking it, and so the registry knows each hive's author without any
 	// spoke-side token lookup (which does not work on App-authenticated hives).
-	AIAuthor                string                        `json:"ai_author,omitempty"`
-	ACMMLevel               int                           `json:"acmm_level"`
-	Agents                  []AgentSummary                `json:"agents"`
-	Governor                GovernorSummary               `json:"governor"`
-	Tokens24h               int64                         `json:"tokens_24h"`
-	Contributors            ContributorSummary            `json:"contributors"`
-	Leaderboard             []LeaderboardEntry            `json:"leaderboard"`
+	AIAuthor     string             `json:"ai_author,omitempty"`
+	ACMMLevel    int                `json:"acmm_level"`
+	Agents       []AgentSummary     `json:"agents"`
+	Governor     GovernorSummary    `json:"governor"`
+	Tokens24h    int64              `json:"tokens_24h"`
+	Contributors ContributorSummary `json:"contributors"`
+	Leaderboard  []LeaderboardEntry `json:"leaderboard"`
 	// StartedAt is the spoke process start time (RFC3339). The hub renders it
 	// as an uptime pill so a hive that is quietly crash-looping — 1/1 Running
 	// but restarted 35 times — is visible in My Hives instead of looking
 	// healthy. A short uptime that keeps resetting is the tell.
-	StartedAt               string                        `json:"started_at,omitempty"`
-	Health                  map[string]any                `json:"health"`
-	DashboardURL            string                        `json:"dashboard_url"`
-	SnapshotURL             string                        `json:"snapshot_url"`
-	Owner                   string                        `json:"owner,omitempty"`
-	HiveType                string                        `json:"hive_type,omitempty"`
-	ClusterID               string                        `json:"cluster_id,omitempty"`
-	IsPublic                bool                          `json:"is_public"`
-	Version                 string                        `json:"version"`
-	GitHash                 string                        `json:"git_hash"`
-	GitBranch               string                        `json:"git_branch,omitempty"`
+	StartedAt    string         `json:"started_at,omitempty"`
+	Health       map[string]any `json:"health"`
+	DashboardURL string         `json:"dashboard_url"`
+	SnapshotURL  string         `json:"snapshot_url"`
+	Owner        string         `json:"owner,omitempty"`
+	HiveType     string         `json:"hive_type,omitempty"`
+	ClusterID    string         `json:"cluster_id,omitempty"`
+	IsPublic     bool           `json:"is_public"`
+	Version      string         `json:"version"`
+	GitHash      string         `json:"git_hash"`
+	GitBranch    string         `json:"git_branch,omitempty"`
+	// ImageRef is the container image this spoke's own Deployment runs, read
+	// in-cluster from the Deployment spec. GitHash says which commit the
+	// BINARY was built from; ImageRef says which TAG the deployment tracks —
+	// and only the tag reveals a hive pinned to an immutable
+	// ghcr.io/kubestellar/hive:<sha> that can never receive a rolling upgrade.
+	// The hub cannot read this itself for firewalled spokes it reaches only by
+	// heartbeat, which is why it rides the payload. Empty when the spoke is
+	// not running in-cluster or the read failed — never a guess.
+	ImageRef                string                        `json:"image_ref,omitempty"`
 	Timestamp               string                        `json:"timestamp"`
 	GitHubAppRequired       bool                          `json:"github_app_required,omitempty"`
 	GitHubAppPermIssue      string                        `json:"github_app_perm_issue,omitempty"`

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1310,6 +1310,12 @@ type MyHiveEntry struct {
 	MigrationStatus string `json:"migrationStatus,omitempty"`
 	MigrationFrom   string `json:"migrationFrom,omitempty"`
 	MigrationTo     string `json:"migrationTo,omitempty"`
+
+	// Drift holds config-drift signals computed server-side against the fleet
+	// norm (see drift.go). It rides this payload rather than a per-row API call
+	// so the My Hives table can render the badge and the fleet-exceptions
+	// summary from data it already has.
+	Drift DriftReport `json:"drift"`
 }
 
 func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
@@ -1537,6 +1543,12 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 			result[i].PendingRequests = pending
 		}
 	}
+
+	// Config drift, computed once over the caller's full visible set — the
+	// fleet norm is derived from that set, so this must run AFTER every row has
+	// been collected and enriched (a row still missing its provStatus would be
+	// misread as a claimed hive and flagged for having no App).
+	annotateDrift(result, getDisplaySHAs(), time.Now())
 
 	resp := map[string]any{
 		"hives":                   result,
@@ -5321,6 +5333,7 @@ const dashboardHTML = `<!DOCTYPE html>
     /* Status filter chips above the My Hives table. --chip-color is set inline
        per chip so one rule serves every state colour. */
     #hive-filter-bar { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; margin-bottom: 14px; }
+    #hive-drift-summary { margin-bottom: 12px; padding: 10px 12px; border: 1px solid var(--border); border-radius: 8px; background: rgba(248,81,73,0.04); }
     .filter-chips { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
     .filter-chip { display: inline-flex; align-items: center; gap: 6px; padding: 5px 12px; background: var(--surface); color: var(--muted); border: 1px solid var(--border); border-radius: 9999px; font-size: 0.72rem; font-weight: 600; cursor: pointer; font-family: inherit; transition: all .15s; }
     .filter-chip:hover { border-color: var(--chip-color, var(--muted)); color: var(--text); }
@@ -5489,6 +5502,7 @@ const dashboardHTML = `<!DOCTYPE html>
       <div id="past-requests-body" style="display:none;overflow-x:auto"><div id="admin-request-history"></div></div>
     </div>
 
+    <div id="hive-drift-summary" style="display:none"></div>
     <div id="hive-filter-bar" style="display:none"></div>
     <div id="hives-container"><div class="loading">Loading your hives...</div></div>
 
@@ -5907,6 +5921,92 @@ const dashboardHTML = `<!DOCTYPE html>
         '<span style="display:block;color:var(--muted);font-size:0.62rem;text-transform:uppercase;letter-spacing:0.04em;margin-bottom:4px">' + esc(heading) + '</span>' +
         accessRows + '</span></span>';
     }
+    /* ---- Config drift -------------------------------------------------
+       The server computes drift signals per hive (pkg/hub/drift.go) and ships
+       them on the My Hives payload as h.drift = {signals, count, worstSeverity}.
+       Everything below only RENDERS that; no drift rule lives in the browser,
+       so the badge, the summary and any future consumer can never disagree
+       about what counts as drift. */
+
+    /* Palette reused from healthBadge() so a critical drift signal reads as the
+       same red as a critical health dot. */
+    var DRIFT_SEVERITY_COLORS = {info: '#58a6ff', warn: '#d29922', critical: '#f85149'};
+    var DRIFT_SEVERITY_LABELS = {info: 'Info', warn: 'Warning', critical: 'Critical'};
+    /* Display order, worst first, for the fleet-exceptions breakdown. */
+    var DRIFT_SEVERITY_ORDER = ['critical', 'warn', 'info'];
+
+    /* Human labels for the server's stable drift kind identifiers. A kind with
+       no entry here falls back to its raw identifier rather than rendering
+       blank, so a new server-side signal is still legible before the UI
+       catches up. */
+    var DRIFT_KIND_LABELS = {
+      'version-behind':  'Version differs from fleet',
+      'branch-mismatch': 'Branch differs from fleet',
+      'pinned-image':    'Pinned to an immutable image',
+      'heartbeat-stale': 'Heartbeat stale',
+      'app-missing':     'GitHub App not installed',
+      'app-perm-issue':  'GitHub App permissions',
+      'health-degraded': 'Health degraded',
+      'upgrade-stuck':   'Upgrade stuck',
+      'acmm-unset':      'ACMM level unset',
+      'no-agents':       'No agents running'
+    };
+
+    function driftKindLabel(kind) { return DRIFT_KIND_LABELS[kind] || kind || 'Unknown'; }
+
+    /* driftOf normalizes the server's report so every caller can treat signals
+       as an array and count as a number, even for a row the server predates
+       (h.drift undefined) or a payload that arrived malformed. */
+    function driftOf(h) {
+      var d = (h && h.drift) || {};
+      var signals = Array.isArray(d.signals) ? d.signals : [];
+      return {
+        signals: signals,
+        count: typeof d.count === 'number' ? d.count : signals.length,
+        worstSeverity: d.worstSeverity || ''
+      };
+    }
+
+    /* driftBadge renders the Drift column: the signal count coloured by the
+       worst severity, with a hover panel listing every reason.
+
+       It follows healthBadge()'s ONE-panel rule exactly: a custom hover panel
+       and NO title attribute on the same element. Setting both makes the
+       browser draw its native tooltip on top of the panel — two overlapping
+       boxes saying different things. */
+    function driftBadge(h) {
+      var d = driftOf(h);
+      if (!d.count) {
+        return '<span title="No configuration drift detected" style="color:var(--muted);font-size:0.72rem;cursor:help">—</span>';
+      }
+      var c = DRIFT_SEVERITY_COLORS[d.worstSeverity] || DRIFT_SEVERITY_COLORS.info;
+
+      var rows = (d.signals || []).map(function(s) {
+        s = s || {};
+        var sc = DRIFT_SEVERITY_COLORS[s.severity] || DRIFT_SEVERITY_COLORS.info;
+        var sevLabel = DRIFT_SEVERITY_LABELS[s.severity] || s.severity || 'Info';
+        return '<div style="padding:4px 0;border-top:1px solid var(--border)">' +
+          '<div style="display:flex;align-items:center;gap:6px;margin-bottom:2px">' +
+          '<span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:' + sc + ';flex:0 0 auto"></span>' +
+          '<span style="color:' + sc + ';font-weight:600">' + esc(driftKindLabel(s.kind)) + '</span>' +
+          '<span style="margin-left:auto;color:var(--muted);font-size:0.6rem;text-transform:uppercase;letter-spacing:0.04em">' + esc(sevLabel) + '</span>' +
+          '</div>' +
+          '<div style="color:var(--muted);line-height:1.4">' + esc(s.reason || '') + '</div>' +
+          '</div>';
+      }).join('');
+
+      var heading = d.count === 1 ? '1 drift signal' : d.count + ' drift signals';
+
+      return '<span class="hive-access-wrap" style="position:relative;display:inline-flex;align-items:center;gap:4px;cursor:help">' +
+        '<span style="display:inline-block;min-width:18px;padding:1px 6px;border-radius:9999px;font-size:0.65rem;font-weight:700;' +
+        'color:' + c + ';background:rgba(255,255,255,0.04);border:1px solid ' + c + '">' + d.count + '</span>' +
+        '<span class="hive-access-pop" style="display:none;position:absolute;right:0;top:calc(100% + 6px);z-index:60;' +
+        'min-width:260px;max-width:380px;padding:8px 10px;border-radius:8px;border:1px solid var(--border);' +
+        'background:var(--surface);box-shadow:0 6px 20px rgba(0,0,0,0.35);font-size:0.72rem;text-align:left;font-weight:400;white-space:normal">' +
+        '<span style="display:block;color:' + c + ';font-weight:600;margin-bottom:2px">' + esc(heading) + '</span>' +
+        rows + '</span></span>';
+    }
+
     function dashboardLink(h) {
       var isHosted = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-')));
       // Open hosted spokes via the hub's SSO handoff endpoint so the user's hub
@@ -6030,12 +6130,32 @@ const dashboardHTML = `<!DOCTYPE html>
       renderHives(_allDashHives, true);
     }
 
+    /* The drift-kind currently selected in the fleet-exceptions summary, or ''
+       for none. Single-select (unlike the multi-select status chips): the
+       summary's purpose is "show me the hives with THIS problem", and an
+       OR across several problem types is what the status chips already do.
+       It composes with the status chips by AND — the chips answer "which
+       states", this answers "which specific misconfiguration". */
+    var _dashDriftFilter = '';
+
+    /* hiveMatchesDriftFilter answers whether a hive carries the selected drift
+       kind. Guarded so a row with no drift report never throws. */
+    function hiveMatchesDriftFilter(h) {
+      if (!_dashDriftFilter) return true;
+      var signals = driftOf(h).signals;
+      for (var i = 0; i < signals.length; i++) {
+        if (signals[i] && signals[i].kind === _dashDriftFilter) return true;
+      }
+      return false;
+    }
+
     /* hiveMatchesFilters answers whether a hive survives the active chips. */
     function hiveMatchesFilters(h) {
       if (_dashFailingCheckFilter) {
         var hit = failingChecks(h).some(function(ck) { return ck.name === _dashFailingCheckFilter; });
         if (!hit) return false;
       }
+      if (!hiveMatchesDriftFilter(h)) return false;
       var active = Object.keys(_dashStatusFilters || {}).filter(function(k) { return _dashStatusFilters[k]; });
       if (!active.length) return true;
       var f = hiveStatusFlags(h);
@@ -6065,8 +6185,104 @@ const dashboardHTML = `<!DOCTYPE html>
 
     function clearStatusFilters() {
       _dashStatusFilters = {};
+      /* "Clear filters" is offered from the empty state, so it must clear
+         EVERY filter — leaving one on would keep the list empty and make the
+         button look broken. */
       _dashFailingCheckFilter = '';
+      _dashDriftFilter = '';
       renderHives(_allDashHives, true);
+    }
+
+    /* toggleDriftFilter selects (or deselects) one drift kind in the fleet
+       exceptions summary. */
+    function toggleDriftFilter(kind) {
+      _dashDriftFilter = (_dashDriftFilter === kind) ? '' : kind;
+      renderHives(_allDashHives, true);
+    }
+
+    /* renderDriftSummary draws the "N hives need attention" strip above the
+       table, broken down by drift kind and clickable to filter.
+
+       Counts are computed over the ASSIGNED set the caller passes, matching
+       the status chips: an unassigned placeholder is never flagged for the
+       claimed-hive concerns (no App, ACMM 0, no agents) server-side, and
+       scoping the summary the same way keeps the headline count equal to the
+       number of rows a human can actually act on. */
+    function renderDriftSummary(assignedHives) {
+      var el = document.getElementById('hive-drift-summary');
+      if (!el) return;
+      var hives = assignedHives || [];
+
+      var hivesWithDrift = 0;
+      var worstOverall = '';
+      var kindCounts = {};   // kind -> number of HIVES carrying it
+      var kindWorst = {};    // kind -> worst severity seen for that kind
+      for (var i = 0; i < hives.length; i++) {
+        var d = driftOf(hives[i]);
+        if (!d.count) continue;
+        hivesWithDrift++;
+        if (DRIFT_SEVERITY_ORDER.indexOf(d.worstSeverity) >= 0 &&
+            (worstOverall === '' || DRIFT_SEVERITY_ORDER.indexOf(d.worstSeverity) < DRIFT_SEVERITY_ORDER.indexOf(worstOverall))) {
+          worstOverall = d.worstSeverity;
+        }
+        /* A hive can legitimately report the same kind once only, but count
+           distinct kinds per hive defensively so a duplicated signal cannot
+           inflate the breakdown past the headline. */
+        var seenKinds = {};
+        for (var j = 0; j < d.signals.length; j++) {
+          var s = d.signals[j] || {};
+          if (!s.kind || seenKinds[s.kind]) continue;
+          seenKinds[s.kind] = true;
+          kindCounts[s.kind] = (kindCounts[s.kind] || 0) + 1;
+          var prev = kindWorst[s.kind];
+          if (!prev || DRIFT_SEVERITY_ORDER.indexOf(s.severity) < DRIFT_SEVERITY_ORDER.indexOf(prev)) {
+            kindWorst[s.kind] = s.severity;
+          }
+        }
+      }
+
+      if (!hivesWithDrift) {
+        el.style.display = 'none';
+        el.innerHTML = '';
+        return;
+      }
+      el.style.display = '';
+
+      /* Sort the breakdown worst-severity-first, then by how many hives are
+         affected, then by label — so the most urgent, most widespread problem
+         is always the first thing read. */
+      var kinds = Object.keys(kindCounts).sort(function(a, b) {
+        var sa = DRIFT_SEVERITY_ORDER.indexOf(kindWorst[a]);
+        var sb = DRIFT_SEVERITY_ORDER.indexOf(kindWorst[b]);
+        if (sa !== sb) return sa - sb;
+        if (kindCounts[b] !== kindCounts[a]) return kindCounts[b] - kindCounts[a];
+        return driftKindLabel(a).localeCompare(driftKindLabel(b));
+      });
+
+      var chips = kinds.map(function(k) {
+        var color = DRIFT_SEVERITY_COLORS[kindWorst[k]] || DRIFT_SEVERITY_COLORS.info;
+        var on = _dashDriftFilter === k;
+        var cls = on ? 'filter-chip on' : 'filter-chip';
+        return '<button type="button" class="' + cls + '" aria-pressed="' + (on ? 'true' : 'false') +
+          '" onclick="toggleDriftFilter(\'' + esc(k) + '\')" style="--chip-color:' + color + '">' +
+          '<span class="filter-chip-dot" style="background:' + color + '"></span>' +
+          esc(driftKindLabel(k)) + '<span class="filter-chip-count">' + kindCounts[k] + '</span></button>';
+      }).join('');
+
+      var headColor = DRIFT_SEVERITY_COLORS[worstOverall] || DRIFT_SEVERITY_COLORS.info;
+      var headline = hivesWithDrift === 1
+        ? '1 hive needs attention'
+        : hivesWithDrift + ' hives need attention';
+      var clearBtn = _dashDriftFilter
+        ? '<button type="button" class="filter-chip filter-chip-clear" onclick="toggleDriftFilter(\'' + esc(_dashDriftFilter) + '\')">Show all</button>'
+        : '';
+
+      el.innerHTML =
+        '<div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">' +
+        '<span style="color:' + headColor + ';font-weight:600;font-size:0.8rem">⚠ ' + esc(headline) + '</span>' +
+        '<span style="color:var(--muted);font-size:0.7rem">configuration drift detected from the fleet norm</span>' +
+        '</div>' +
+        '<div class="filter-chips" style="margin-top:8px">' + chips + clearBtn + '</div>';
     }
 
     /* renderStatusFilterBar draws the chip row plus the match count. Counts are
@@ -6123,7 +6339,11 @@ const dashboardHTML = `<!DOCTYPE html>
               esc(nm) + '<span class="filter-chip-count">' + n + '</span></button>';
           }).join('') + '</div>';
       }
-      var anyActive = Object.keys(_dashStatusFilters || {}).length > 0 || !!_dashFailingCheckFilter;
+      /* Every filter that narrows the list must be counted here: it drives both
+         the "Showing X of Y" summary and the Clear button, and clearStatusFilters()
+         resets all of them. Omitting one hides the Clear button while the list is
+         still filtered, which reads as hives having disappeared. */
+      var anyActive = Object.keys(_dashStatusFilters || {}).length > 0 || !!_dashFailingCheckFilter || !!_dashDriftFilter;
       /* allHives here is the ASSIGNED set — the caller scopes it, because the
          chips never filter unassigned placeholders. Say "assigned" so the count
          is not read as the whole fleet. */
@@ -6373,7 +6593,7 @@ const dashboardHTML = `<!DOCTYPE html>
       allHives = allHives || [];
       /* The signature must include the active filters, otherwise toggling a
          chip while the hive data is unchanged would be treated as a no-op. */
-      var sig = JSON.stringify(allHives) + '|' + JSON.stringify(_dashStatusFilters) + '|' + _dashFailingCheckFilter;
+      var sig = JSON.stringify(allHives) + '|' + JSON.stringify(_dashStatusFilters) + '|' + _dashFailingCheckFilter + '|' + _dashDriftFilter;
       if (!force && sig === _lastHivesJSON) return;
       _lastHivesJSON = sig;
       /* Status filters describe ASSIGNED hives only. An unassigned placeholder
@@ -6391,7 +6611,12 @@ const dashboardHTML = `<!DOCTYPE html>
       if (filterBar) filterBar.style.display = allHives.length ? '' : 'none';
       /* Counts are over the assigned set only, matching what the chips filter. */
       renderStatusFilterBar(assignedAll, hives.length - unassignedAll.length);
+      /* Drift exceptions are scoped to assigned hives for the same reason: a
+         placeholder is never flagged for claimed-hive concerns server-side. */
+      renderDriftSummary(assignedAll);
       if (!allHives.length) {
+        var driftEl0 = document.getElementById('hive-drift-summary');
+        if (driftEl0) driftEl0.style.display = 'none';
         document.getElementById('hives-container').innerHTML =
           '<div class="empty-state">' +
           '<p style="font-size:1.2rem;margin-bottom:8px">No hives yet</p>' +
@@ -6539,7 +6764,7 @@ const dashboardHTML = `<!DOCTYPE html>
           pendingPill = '<a href="#" onclick="togglePendingRow(\'' + esc(h.id) + '\');return false" style="display:inline-flex;align-items:center;gap:4px;padding:3px 10px;background:rgba(59,130,246,0.12);color:#60a5fa;border:1px solid rgba(59,130,246,0.3);border-radius:4px;font-size:0.7rem;text-decoration:none;cursor:pointer;white-space:nowrap">&#x1F514; ' + h.pendingRequestCount + ' pending</a>';
         }
         // 14 = the 13 original columns plus Uptime.
-        var TOTAL_COLUMNS = 14;
+        var TOTAL_COLUMNS = 15;
         var pendingExpandRow = '';
         if (h.pendingRequestCount > 0 && (h.role === 'owner' || h.role === 'read-write') && (h.pending_requests || []).length > 0) {
           var prItems = (h.pending_requests || []).map(function(pr) {
@@ -6573,11 +6798,16 @@ const dashboardHTML = `<!DOCTYPE html>
           '<td>' + sparkline(h.issueHistory, '#f59e0b', 50, 14) + (h.actionableIssues || 0) + '</td>' +
           '<td>' + sparkline(h.prHistory, '#3b82f6', 50, 14) + (h.actionablePRs || 0) + '</td>' +
           '<td>' + (h.activeContributors || 0) + '</td>' +
+          '<td style="white-space:nowrap;text-align:right">' + driftBadge(h) + '</td>' +
           '</tr>' + pendingExpandRow;
       };
       /* Section-header row: a labeled separator spanning all columns, styled to
          match the table's muted uppercase heading treatment (see .hive-table th). */
-      var TOTAL_COLUMNS_HEADER = 14;
+      /* Count of <th> cells in the hive table header below. The section-header
+         row spans all of them; a stale value would leave the separator short
+         and the table visibly ragged. Bumped from 14 when the Drift column
+         was added. */
+      var TOTAL_COLUMNS_HEADER = 15;
       var sectionHeader = function(label, count) {
         return '<tr class="hive-section-head"><td colspan="' + TOTAL_COLUMNS_HEADER + '" ' +
           'style="padding:14px 12px 6px;color:var(--muted);font-weight:600;font-size:0.75rem;' +
@@ -6615,6 +6845,7 @@ const dashboardHTML = `<!DOCTYPE html>
       document.getElementById('hives-container').innerHTML =
         '<div class="table-wrap"><table class="hive-table"><thead><tr>' +
         '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer">Location ⇅</th><th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅</th><th>Public</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th>' +
+        '<th title="Configuration drift from the fleet norm — hover a value for the specific signals">Drift</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table></div>';
       setTimeout(function() {
         var tw = document.querySelector('.table-wrap');

--- a/v2/pkg/hub/self_upgrade.go
+++ b/v2/pkg/hub/self_upgrade.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -284,4 +285,51 @@ func k8sAPIPatch(path string, body []byte) error {
 		return fmt.Errorf("k8s API PATCH %s: HTTP %d: %s", path, resp.StatusCode, string(respBody))
 	}
 	return nil
+}
+
+// selfImageCacheTTL bounds how long SelfDeploymentImage reuses a cached read.
+// The image only changes on an upgrade (which rolls the pod and restarts this
+// process, clearing the cache anyway), so a long TTL is safe — and necessary:
+// the heartbeat runs on a short interval and an uncached read would hit the
+// in-cluster API server on every beat, from every spoke in the fleet.
+const selfImageCacheTTL = 10 * time.Minute
+
+var (
+	selfImageMu        sync.RWMutex
+	selfImageCached    string
+	selfImageFetched   time.Time
+	selfImageAttempted bool
+)
+
+// SelfDeploymentImage returns this pod's own Deployment image, cached.
+//
+// It is exported for the SPOKE's heartbeat collector: the hub cannot read a
+// firewalled spoke's Deployment over kubectl, so the spoke must report its own
+// image ref for the hub's pinned-image drift detection to work at all.
+//
+// Returns "" (never an error) when the read fails or this process is not
+// running in-cluster — an absent image ref means "unknown", and drift
+// detection skips the pinned-image signal rather than inventing one. A failed
+// read is cached the same as a successful one so a non-cluster process does
+// not retry an API call it can never satisfy on every heartbeat.
+func SelfDeploymentImage() string {
+	selfImageMu.RLock()
+	if selfImageAttempted && time.Since(selfImageFetched) < selfImageCacheTTL {
+		img := selfImageCached
+		selfImageMu.RUnlock()
+		return img
+	}
+	selfImageMu.RUnlock()
+
+	img, err := selfDeploymentImage()
+	if err != nil {
+		img = ""
+	}
+
+	selfImageMu.Lock()
+	selfImageCached = img
+	selfImageFetched = time.Now()
+	selfImageAttempted = true
+	selfImageMu.Unlock()
+	return img
 }

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -57,40 +57,49 @@ type Registry struct {
 }
 
 type RegistryEntry struct {
-	ID                        string             `json:"id"`
-	Name                      string             `json:"name"`
-	Org                       string             `json:"org"`
-	Repos                     []string           `json:"repos"`
+	ID    string   `json:"id"`
+	Name  string   `json:"name"`
+	Org   string   `json:"org"`
+	Repos []string `json:"repos"`
 	// AIAuthor is the GitHub account this hive's agents open PRs as, as
 	// reported by the spoke. The hub needs it to echo project config back
 	// without blanking it, and it is the author the fleet-stats counts are
 	// scoped to.
-	AIAuthor                  string             `json:"aiAuthor,omitempty"`
+	AIAuthor string `json:"aiAuthor,omitempty"`
 	// StartedAt is the spoke process start time, reported over the heartbeat.
 	// Rendered as an uptime pill in My Hives so a crash-looping hive is visible.
-	StartedAt                 string             `json:"startedAt,omitempty"`
-	PrimaryRepo               string             `json:"primaryRepo"`
-	DashboardURL              string             `json:"dashboardUrl"`
-	SnapshotURL               string             `json:"snapshotUrl,omitempty"`
-	ACMMLevel                 int                `json:"acmmLevel"`
-	AgentCount                int                `json:"agentCount"`
-	GovernorMode              string             `json:"governorMode"`
-	TotalTokens24h            int64              `json:"totalTokens24h"`
-	ActionableIssues          int                `json:"actionableIssues"`
-	ActionablePRs             int                `json:"actionablePRs"`
-	ContributorCount          int                `json:"contributorCount"`
-	ActiveContributors        int                `json:"activeContributors"`
-	Owner                     string             `json:"owner,omitempty"`
-	ClusterID                 string             `json:"clusterId,omitempty"`
-	ClusterName               string             `json:"clusterName,omitempty"`
-	HiveType                  string             `json:"hiveType,omitempty"`
-	IsPublic                  bool               `json:"isPublic"`
-	RegisteredAt              string             `json:"registeredAt"`
-	LastHeartbeat             string             `json:"lastHeartbeat"`
-	Health                    map[string]any     `json:"health"`
-	Version                   string             `json:"version"`
-	GitHash                   string             `json:"gitHash,omitempty"`
-	GitBranch                 string             `json:"gitBranch,omitempty"`
+	StartedAt          string         `json:"startedAt,omitempty"`
+	PrimaryRepo        string         `json:"primaryRepo"`
+	DashboardURL       string         `json:"dashboardUrl"`
+	SnapshotURL        string         `json:"snapshotUrl,omitempty"`
+	ACMMLevel          int            `json:"acmmLevel"`
+	AgentCount         int            `json:"agentCount"`
+	GovernorMode       string         `json:"governorMode"`
+	TotalTokens24h     int64          `json:"totalTokens24h"`
+	ActionableIssues   int            `json:"actionableIssues"`
+	ActionablePRs      int            `json:"actionablePRs"`
+	ContributorCount   int            `json:"contributorCount"`
+	ActiveContributors int            `json:"activeContributors"`
+	Owner              string         `json:"owner,omitempty"`
+	ClusterID          string         `json:"clusterId,omitempty"`
+	ClusterName        string         `json:"clusterName,omitempty"`
+	HiveType           string         `json:"hiveType,omitempty"`
+	IsPublic           bool           `json:"isPublic"`
+	RegisteredAt       string         `json:"registeredAt"`
+	LastHeartbeat      string         `json:"lastHeartbeat"`
+	Health             map[string]any `json:"health"`
+	Version            string         `json:"version"`
+	GitHash            string         `json:"gitHash,omitempty"`
+	GitBranch          string         `json:"gitBranch,omitempty"`
+	// ImageRef is the container image this spoke's own Deployment runs, as
+	// read in-cluster by the spoke and reported over the heartbeat. The hub
+	// cannot see it any other way for firewalled/heartbeat-only spokes, and
+	// without it there is no way to tell a hive pinned to an immutable
+	// ghcr.io/kubestellar/hive:<sha> tag — which can never receive a rolling
+	// upgrade — from one riding <branch>-latest. Empty on spokes that are not
+	// in-cluster or predate this field; drift detection skips the signal
+	// rather than guessing.
+	ImageRef                  string             `json:"imageRef,omitempty"`
 	Agents                    []AgentSummary     `json:"agents,omitempty"`
 	Leaderboard               []LeaderboardEntry `json:"leaderboard,omitempty"`
 	Online                    bool               `json:"online"`
@@ -628,6 +637,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		Version:       sanitizeHeartbeatField(payload.Version),
 		GitHash:       shortSHA(sanitizeHeartbeatField(payload.GitHash)),
 		GitBranch:     sanitizeHeartbeatField(payload.GitBranch),
+		ImageRef:      sanitizeHeartbeatField(payload.ImageRef),
 		Agents: func() []AgentSummary {
 			for i := range payload.Agents {
 				payload.Agents[i].Name = sanitizeHeartbeatField(payload.Agents[i].Name)


### PR DESCRIPTION
## Why

Four config-drift incidents in one night, all silent until a user complained. In each case **the hub already received the data that would have flagged it** — nothing ever compared a hive against its fleet, or against itself a minute ago.

- A spoke pinned to an immutable SHA tag (`hive:63d8902`) restart-looped forever while the fleet rode `v2-latest`.
- Hives sat at ACMM 0 / zero agents, holding a slot and doing no work.
- A GitHub App was required but never installed — agents silently could not act.
- An upgrade wedged in flight with nothing surfacing it.

## What

### Server-side drift model — `v2/pkg/hub/drift.go`

Computed once per My Hives request and returned **on the existing payload** (`hive.drift = {signals, count, worstSeverity}`), so the table renders without a second call.

**The norm is derived, not hardcoded.** "Behind" and "wrong branch" are relative to the modal `gitBranch` across *online, non-placeholder* hives, with the SHA norm scoped to that branch. The model therefore stays correct when the fleet moves to a new branch without anyone editing this file. Two guards:

- Suppressed below a **3-hive** eligible sample — with fewer, "the majority" is not a meaningful statement and a 2-hive disagreement would flag one arbitrarily.
- Ties break lexically, so the norm cannot flicker between requests and flag half the fleet on alternating page loads.

| Signal | Severity | Notes |
|---|---|---|
| `heartbeat-stale` | critical | Reuses `maxHeartbeatAge` — the same threshold `markStaleHives` uses to clear `Online`, so the badge and the online dot can never disagree |
| `upgrade-stuck` | critical / warn | Reuses the existing `staleUpgradeTimeout`; warn when no start time was recorded |
| `pinned-image` | critical | Reuses `imageTagIsMutable` — the *same* predicate `UpgradeSelfToSHA` uses to decide a restart is a no-op |
| `health-degraded` | critical / warn | Names the **specific failing check** and its detail; caps at 3 then summarizes |
| `app-missing` / `app-perm-issue` | critical | Mirrors `healthBadge`'s installed-vs-insufficient split |
| `acmm-unset` | warn | Claimed hives only |
| `no-agents` | warn | Claimed hives only |
| `branch-mismatch` | warn | Names the branch and how many hives run the norm |
| `version-behind` | info | Prefers the branch's true latest build; falls back to the fleet's modal SHA |

**Placeholder scoping:** an unassigned pool slot legitimately has no App, no agents and ACMM 0. Those three are claimed-only — flagging them would let the pool dominate the exceptions summary and bury the rows a human can actually fix. Universal signals (stale heartbeat, pinned image, degraded health) still fire on placeholders, because a placeholder runs a real spoke. `isPlaceholderEntry` is kept in lockstep with the frontend's `isPlaceholderHive`.

### One heartbeat field added: `image_ref`

This was the one signal that was **not** computable from existing data, so it is the one thing added — and it is real, not faked. `GitHash` says which commit the *binary* came from; only the Deployment's *tag* reveals a hive that can never receive a rolling upgrade. The hub cannot read it for firewalled/heartbeat-only spokes, so the spoke reports it using the in-cluster read that **already existed** (`selfDeploymentImage`), newly exposed as a cached `SelfDeploymentImage()` — cached because the heartbeat is hot and an uncached read would hit the API server on every beat from every spoke. Empty when the spoke is off-cluster or the read fails; drift detection then **skips** the signal rather than guessing.

### UI

- **Drift column**: count badge coloured by worst severity, expanding to a hover panel listing every signal's kind, severity and reason. Follows `healthBadge`'s one-panel rule — custom panel, **no** `title` attribute on the same element (the double-tooltip bug that was just fixed).
- **Fleet exceptions strip**: "N hives need attention", broken down by drift kind, sorted worst-severity-then-prevalence, each chip clickable to filter. Composes with the existing status chips by AND, scoped to assigned hives exactly as the chips already are, and `clearStatusFilters()` clears it too so the empty-state button is never a no-op.
- Unknown drift kinds fall back to their raw identifier, so a future server-side signal is legible before the UI catches up.

## Verified, not assumed

- `go build ./...`, `go vet ./pkg/hub/`, `go test -timeout 480s ./pkg/hub/` — all pass (full suite, 71s).
- Drift JS extracted from `dashboardHTML` and `node --check`'d, then exercised in a harness: HTML escaping of user-controlled reasons (a `<script>` payload in a reason renders escaped), no `title` attribute alongside the custom panel, undefined/malformed `h.drift` handled, filter match/exclude/pass-through, summary hidden when empty, critical-first ordering, and a duplicated kind not inflating the breakdown.
- Health map handling is guarded at every level — it is free-form JSON from the spoke, and an unguarded type assertion would panic the entire My Hives request. Covered by tests for wrong-typed `checks`, wrong-typed entries and missing names.
- Confirmed the hub did **not** previously receive any image reference (checked before adding the field).

## Not merging

Per repo convention, leaving this for review.