### PR TITLE
✨ hub: token attribution rollups by org, owner and cluster

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -127,6 +127,10 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("GET /dashboard", s.handleDashboard)
 	s.mux.HandleFunc("GET /access-denied", s.handleAccessDenied)
 	s.mux.HandleFunc("GET /api/saas/my-hives", s.requireAuth(s.handleMyHives))
+	// Token attribution rollups. requireAuth (not requireAdmin) because a
+	// non-admin legitimately sees their OWN hives' usage; the handler scopes
+	// fleet-wide data to admins itself.
+	s.mux.HandleFunc("GET /api/saas/usage", s.requireAuth(s.handleUsage))
 	s.mux.HandleFunc("POST /api/saas/hives", s.requireAuth(s.handleCreateHive))
 	s.mux.HandleFunc("GET /api/saas/hives/{id}/status", s.requireAuth(s.handleHiveStatus))
 	// /open is a browser NAVIGATION endpoint (the SSO handoff), not an API call.
@@ -5504,6 +5508,7 @@ const dashboardHTML = `<!DOCTYPE html>
 
     <div id="hive-drift-summary" style="display:none"></div>
     <div id="hive-filter-bar" style="display:none"></div>
+    <div id="usage-panel" style="display:none;margin-bottom:24px"></div>
     <div id="hives-container"><div class="loading">Loading your hives...</div></div>
 
     <div id="public-hives-section" style="display:none;margin-top:48px">
@@ -6369,6 +6374,153 @@ const dashboardHTML = `<!DOCTYPE html>
       renderHives(sorted, true);
     }
 
+    /* ---- Usage attribution panel ----------------------------------------
+       Token rollups by org / owner / cluster. TOKENS ONLY: the hub receives a
+       single blended token total per hive with no per-model split, so no
+       dollar figure is derivable here (see usage.go). The panel shows the
+       server's currencyNote rather than inventing a rate. */
+
+    /* USAGE_TOP_N is how many rollup rows each dimension shows collapsed. At
+       42+ hives the full org/owner lists do not fit on screen; 5 keeps the
+       three tables side-by-side and readable, with "Show all" to expand. */
+    var USAGE_TOP_N = 5;
+    /* USAGE_ZERO_TOP_N bounds the zero-consumption list the same way. Slightly
+       larger than USAGE_TOP_N because this list is the actionable one — these
+       are claimed hives burning nothing, i.e. possibly broken. */
+    var USAGE_ZERO_TOP_N = 8;
+    /* USAGE_SPARK_MIN_POINTS is the minimum sampled points before a trend line
+       is drawn. Two points is the honest minimum for a line — with one sample
+       there is no trend, only a dot, and drawing it would imply history the
+       hub does not have. */
+    var USAGE_SPARK_MIN_POINTS = 2;
+
+    var _usageData = null;
+    var _usageExpanded = {};
+
+    function toggleUsageSection(key) {
+      _usageExpanded[key] = !_usageExpanded[key];
+      renderUsagePanel();
+    }
+
+    /* Renders one rollup dimension as a compact table. rows are already sorted
+       by consumption descending server-side. */
+    function renderUsageSection(title, rows, key) {
+      rows = rows || [];
+      if (!rows.length) {
+        return '<div style="flex:1;min-width:200px">' +
+          '<div style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.04em;color:var(--muted);margin-bottom:6px">' + esc(title) + '</div>' +
+          '<div style="color:var(--muted);font-size:0.75rem;padding:4px 0">No data</div></div>';
+      }
+      var expanded = !!_usageExpanded[key];
+      var shown = expanded ? rows.length : Math.min(rows.length, USAGE_TOP_N);
+      var html = '';
+      for (var i = 0; i < shown; i++) {
+        var r = rows[i] || {};
+        var pct = Number(r.sharePct) || 0;
+        html += '<tr>' +
+          '<td style="padding:2px 6px 2px 0;max-width:150px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="' + esc(r.key) + '">' + esc(r.key) + '</td>' +
+          '<td style="padding:2px 6px;text-align:right;white-space:nowrap">' + fmtTokens(r.tokens) + '</td>' +
+          '<td style="padding:2px 6px;text-align:right;color:var(--muted);white-space:nowrap">' + (Number(r.hives) || 0) + '</td>' +
+          /* Inline share bar — cheap visual ranking without a chart library. */
+          '<td style="padding:2px 0 2px 6px;width:64px">' +
+            '<div style="position:relative;height:9px;background:var(--surface);border-radius:2px;overflow:hidden" title="' + pct.toFixed(1) + '% of total">' +
+            '<div style="position:absolute;left:0;top:0;bottom:0;width:' + Math.max(0, Math.min(100, pct)).toFixed(1) + '%;background:var(--accent);opacity:0.65"></div>' +
+            '</div></td>' +
+          '<td style="padding:2px 0 2px 6px;text-align:right;color:var(--muted);font-size:0.68rem;white-space:nowrap">' + pct.toFixed(1) + '%</td>' +
+        '</tr>';
+      }
+      var more = '';
+      if (rows.length > USAGE_TOP_N) {
+        more = '<div style="margin-top:4px"><a href="#" onclick="toggleUsageSection(\'' + esc(key) + '\');return false" style="font-size:0.7rem;color:var(--accent);text-decoration:none">' +
+          (expanded ? 'Show top ' + USAGE_TOP_N : 'Show all ' + rows.length) + '</a></div>';
+      }
+      return '<div style="flex:1;min-width:200px">' +
+        '<div style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.04em;color:var(--muted);margin-bottom:6px">' + esc(title) + '</div>' +
+        '<table style="width:100%;border-collapse:collapse;font-size:0.75rem"><tbody>' + html + '</tbody></table>' + more +
+        '</div>';
+    }
+
+    function renderUsagePanel() {
+      var el = document.getElementById('usage-panel');
+      if (!el) return;
+      var d = _usageData;
+      if (!d) { el.style.display = 'none'; return; }
+      el.style.display = 'block';
+
+      var isFleet = d.scope === 'fleet';
+      var scopeLabel = isFleet
+        ? 'Fleet-wide'
+        : 'Your hives only';
+
+      /* Trend: only drawn from genuinely sampled history. With fewer than
+         USAGE_SPARK_MIN_POINTS points we say so instead of drawing a line. */
+      var hist = d.history || [];
+      var trend = '';
+      if (hist.length >= USAGE_SPARK_MIN_POINTS) {
+        var pts = [];
+        for (var i = 0; i < hist.length; i++) {
+          /* sparkline() reads .v — map the snapshot shape onto it. */
+          pts.push({ t: hist[i].t, v: Number(hist[i].v) || 0 });
+        }
+        trend = '<span title="Fleet total, sampled every 15 min (cumulative)">' + sparkline(pts, '#3fb950', 90, 16) + '</span>';
+      } else if (isFleet) {
+        trend = '<span style="font-size:0.68rem;color:var(--muted)" title="Snapshots are sampled every 15 minutes; a trend line needs at least two.">trend building…</span>';
+      }
+
+      var zero = d.zeroConsumption || [];
+      var zeroHtml = '';
+      if (zero.length) {
+        var zExpanded = !!_usageExpanded['zero'];
+        var zShown = zExpanded ? zero.length : Math.min(zero.length, USAGE_ZERO_TOP_N);
+        var chips = '';
+        for (var z = 0; z < zShown; z++) {
+          var h = zero[z] || {};
+          var dot = h.online
+            ? '<span style="color:#3fb950" title="Online but consuming nothing — idle or stuck">●</span>'
+            : '<span style="color:var(--muted)" title="Offline">○</span>';
+          chips += '<span style="display:inline-block;padding:2px 7px;margin:2px 4px 2px 0;background:var(--surface);border:1px solid var(--border);border-radius:10px;font-size:0.7rem" title="' + esc((h.org || '') + (h.owner ? ' · ' + h.owner : '')) + '">' + dot + ' ' + esc(h.name || h.id) + '</span>';
+        }
+        var zMore = '';
+        if (zero.length > USAGE_ZERO_TOP_N) {
+          zMore = ' <a href="#" onclick="toggleUsageSection(\'zero\');return false" style="font-size:0.7rem;color:var(--accent);text-decoration:none">' +
+            (zExpanded ? 'show fewer' : 'show all ' + zero.length) + '</a>';
+        }
+        zeroHtml = '<div style="margin-top:12px;padding-top:10px;border-top:1px solid var(--border)">' +
+          '<div style="font-size:0.72rem;text-transform:uppercase;letter-spacing:0.04em;color:var(--muted);margin-bottom:6px" title="Claimed hives reporting no tokens. Unassigned pool slots are excluded — those are supposed to consume nothing.">' +
+          'Zero consumption (' + zero.length + ')</div>' + chips + zMore + '</div>';
+      }
+
+      el.innerHTML =
+        '<div style="background:var(--card,var(--surface));border:1px solid var(--border);border-radius:8px;padding:14px 16px">' +
+          '<div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:12px">' +
+            '<h3 style="font-size:0.95rem;color:var(--accent);margin:0">Usage</h3>' +
+            '<span style="font-size:0.7rem;color:var(--muted);border:1px solid var(--border);border-radius:10px;padding:1px 7px">' + esc(scopeLabel) + '</span>' +
+            '<span style="flex:1"></span>' +
+            trend +
+            '<span style="font-size:0.8rem;color:var(--text)"><strong>' + fmtTokens(d.totalTokens) + '</strong> tokens' +
+            ' <span style="color:var(--muted);font-size:0.72rem">across ' + (Number(d.hiveCount) || 0) + ' hive' + ((Number(d.hiveCount) || 0) === 1 ? '' : 's') + '</span></span>' +
+          '</div>' +
+          '<div style="display:flex;gap:20px;flex-wrap:wrap">' +
+            renderUsageSection('By org', d.byOrg, 'org') +
+            renderUsageSection('By owner', d.byOwner, 'owner') +
+            renderUsageSection('By cluster', d.byCluster, 'cluster') +
+          '</div>' +
+          zeroHtml +
+          '<div style="margin-top:10px;font-size:0.66rem;color:var(--muted);line-height:1.4">' + esc(d.currencyNote || '') + '</div>' +
+        '</div>';
+    }
+
+    async function loadUsage() {
+      try {
+        var resp = await fetch('/api/saas/usage');
+        if (!resp.ok) { _usageData = null; renderUsagePanel(); return; }
+        _usageData = await resp.json();
+      } catch (e) {
+        _usageData = null;
+      }
+      renderUsagePanel();
+    }
+
     async function loadHives() {
       if (_hivesLoading) return;
       _hivesLoading = true;
@@ -6472,6 +6624,7 @@ const dashboardHTML = `<!DOCTYPE html>
         renderAdminProvisionRequests(data.provision_requests || []);
         renderRequestHiveButton(data);
         loadPublicHives(data.hives || []);
+        loadUsage();
       } catch(e) {
         if (!_allDashHives.length) {
           document.getElementById('hives-container').innerHTML = '<div class="loading">Failed to load hives</div>';

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -256,6 +256,14 @@ type HubServer struct {
 	heartbeatHealth       map[string]*HeartbeatHealthEntry // cluster ID → latest health from spoke heartbeat
 	heartbeatHealthMu     sync.RWMutex
 
+	// usageHistory is the sampled fleet-total token trend, appended on
+	// heartbeat at usageSnapshotInterval and bounded to
+	// usageSnapshotMaxPoints (see usage.go). Guarded by usageMu rather than
+	// s.mu: the heartbeat path already holds s.mu when it samples, and
+	// re-locking a held non-reentrant mutex would deadlock the hub.
+	usageHistory []UsageSnapshot
+	usageMu      sync.RWMutex
+
 	// heartbeatUpgrade tracks hives that should be upgraded via heartbeat
 	// UpgradeTo because kubectl rollout restart failed (cluster unreachable).
 	// Key: hive ID, value: target SHA.  Cleared when the spoke reports the
@@ -810,6 +818,12 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	} else {
 		s.recordTimeline(entry.ID, TimelineCameOnline, "hive registered with the hub for the first time", "")
 	}
+
+	// Sample the fleet-total token trend. Deliberately AFTER s.mu.Unlock():
+	// sampleUsageHistory takes s.mu.RLock itself, and s.mu is a
+	// non-reentrant sync.RWMutex, so calling it while the write lock is held
+	// would deadlock every heartbeat.
+	s.sampleUsageHistory(time.Now())
 
 	s.requestSave()
 

--- a/v2/pkg/hub/usage.go
+++ b/v2/pkg/hub/usage.go
@@ -1,0 +1,351 @@
+package hub
+
+// Token usage attribution rollups for the hub fleet.
+//
+// WHAT THIS DOES
+//
+// Aggregates the per-hive TotalTokens24h figure into by-org, by-owner and
+// by-cluster rollups so an operator can answer "who is burning budget?"
+// without reading 42+ individual rows.
+//
+// WHAT THE HUB ACTUALLY KNOWS — and what it does NOT
+//
+// The hub receives exactly ONE token number per hive, per heartbeat:
+// HeartbeatPayload.Tokens24h (pkg/hub/heartbeat.go), stored verbatim on
+// RegistryEntry.TotalTokens24h (pkg/hub/server.go). That is the whole of the
+// hub's token knowledge. In particular:
+//
+//   - NO per-model breakdown reaches the hub. The spoke computes one
+//     (pkg/tokens/pricing.go + pkg/dashboard/cost.go) and even estimates USD
+//     from a real list-price table, but none of that is in the heartbeat
+//     payload — only the scalar total is. So this package deliberately does
+//     NOT compute currency. Doing so would require inventing a blended
+//     per-token price with no model attribution to justify it, which would be
+//     a fabricated number wearing a dollar sign. Tokens only. See
+//     usageCurrencyNote for the string the UI shows instead.
+//
+//   - NO per-agent breakdown reaches the hub either. AgentSummary
+//     (pkg/hub/heartbeat.go) carries Name/State/Mode and no token counts.
+//
+// Despite the "24h" in the field name, the value the spoke sends is a
+// CUMULATIVE lifetime total (cmd/hive/main.go documents this explicitly:
+// "Despite the '24h'-suffixed field name this is a lifetime/window total").
+// That is what makes the snapshot history below meaningful: differences
+// between consecutive cumulative samples are real consumption deltas.
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	// usageSnapshotInterval is how often the fleet-total token snapshot is
+	// sampled. Matches the 15-minute cadence the issue/PR sparklines already
+	// use (see sparkSampleInterval in server.go) so the two trends line up on
+	// the same time axis.
+	usageSnapshotInterval = 15 * time.Minute
+
+	// usageSnapshotMaxPoints bounds snapshot retention. At one sample per
+	// usageSnapshotInterval this is 7 days of history (4/hr * 24 * 7 = 672),
+	// the same window and the same bound as the issue/PR sparklines.
+	usageSnapshotMaxPoints = 672
+
+	// usageUnattributed is the bucket label used when a hive reports no org,
+	// no owner, or no cluster. Grouping these under a visible label is
+	// deliberate: silently dropping them would make the rollup shares fail to
+	// sum to the fleet total, which is worse than an honest "unattributed".
+	usageUnattributed = "(unattributed)"
+)
+
+// usageCurrencyNote is shown wherever a reader might expect a dollar figure.
+// The hub cannot derive currency: cost requires per-model token splits, and
+// the heartbeat carries only a single blended total. Stated plainly rather
+// than papered over with an invented rate.
+const usageCurrencyNote = "Tokens only — the hub receives a single blended token total per hive, " +
+	"with no per-model split, so no currency estimate is derivable here. " +
+	"Per-model cost estimates exist on each hive's own dashboard (/api/cost)."
+
+// UsageBucket is one row of a rollup: a group key plus its consumption.
+type UsageBucket struct {
+	// Key is the org / owner / cluster name. USER-CONTROLLED — the UI must
+	// escape it with esc() before inserting it into the DOM.
+	Key string `json:"key"`
+	// Tokens is the summed token count for this bucket. int64 throughout:
+	// a fleet total summed across 42+ hives, each clamped to 100e9, would
+	// overflow a 32-bit int.
+	Tokens int64 `json:"tokens"`
+	// Hives is how many hives contributed to this bucket.
+	Hives int `json:"hives"`
+	// SharePct is this bucket's percentage of the fleet total, 0 when the
+	// fleet total is zero (avoids a divide-by-zero producing NaN in JSON,
+	// which would be invalid and break the UI parse).
+	SharePct float64 `json:"sharePct"`
+}
+
+// UsageHive identifies a single hive in the zero-consumption list.
+type UsageHive struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	// Org/Owner are USER-CONTROLLED — escape before rendering.
+	Org   string `json:"org,omitempty"`
+	Owner string `json:"owner,omitempty"`
+	// Online distinguishes a hive that is up but idle from one that is simply
+	// unreachable; both consume nothing but they mean different things.
+	Online bool `json:"online"`
+}
+
+// UsageSnapshot is one sampled point of fleet-total token consumption.
+// Cumulative, matching the semantics of the underlying counter.
+type UsageSnapshot struct {
+	T int64 `json:"t"`
+	V int64 `json:"v"`
+}
+
+// UsageRollup is the full attribution report.
+type UsageRollup struct {
+	TotalTokens int64         `json:"totalTokens"`
+	HiveCount   int           `json:"hiveCount"`
+	ByOrg       []UsageBucket `json:"byOrg"`
+	ByOwner     []UsageBucket `json:"byOwner"`
+	ByCluster   []UsageBucket `json:"byCluster"`
+	// ZeroConsumption lists claimed hives reporting no tokens. Unassigned
+	// placeholders are excluded by the caller — a pool slot with nothing
+	// assigned to it is SUPPOSED to consume nothing, so flagging it would be
+	// noise. A claimed hive burning nothing is the interesting signal.
+	ZeroConsumption []UsageHive `json:"zeroConsumption"`
+	// History is the fleet-total trend. Empty until at least one snapshot has
+	// been sampled; the UI must not synthesize a line from a single point.
+	History []UsageSnapshot `json:"history"`
+	// CurrencyNote explains the deliberate absence of dollar figures.
+	CurrencyNote string `json:"currencyNote"`
+	// Scope is "fleet" for an admin viewing everything, or "own" for a
+	// non-admin, whose rollup covers only their own hives.
+	Scope string `json:"scope"`
+}
+
+// usageGroupKey normalizes a grouping value, folding blank/whitespace-only
+// values into the unattributed bucket so they are counted, not dropped.
+func usageGroupKey(v string) string {
+	if t := strings.TrimSpace(v); t != "" {
+		return t
+	}
+	return usageUnattributed
+}
+
+// buildUsageBuckets groups entries by the supplied key function and returns
+// buckets sorted by consumption descending. Ties break on Key ascending so
+// the ordering is deterministic — without that, two equal-token buckets would
+// swap positions between refreshes and the table would appear to flicker.
+func buildUsageBuckets(hives []RegistryEntry, keyOf func(RegistryEntry) string, total int64) []UsageBucket {
+	if keyOf == nil {
+		return []UsageBucket{}
+	}
+	agg := map[string]*UsageBucket{}
+	for _, h := range hives {
+		k := usageGroupKey(keyOf(h))
+		b, ok := agg[k]
+		if !ok {
+			b = &UsageBucket{Key: k}
+			agg[k] = b
+		}
+		// Clamp negatives to zero. TotalTokens24h is clamped on ingest, but a
+		// registry entry restored from an older on-disk file has not been
+		// through that path, and one negative value would corrupt every share.
+		if h.TotalTokens24h > 0 {
+			b.Tokens += h.TotalTokens24h
+		}
+		b.Hives++
+	}
+	out := make([]UsageBucket, 0, len(agg))
+	for _, b := range agg {
+		if total > 0 {
+			// float64 conversion is safe here: token counts are far below
+			// 2^53, so no precision is lost in the ratio.
+			b.SharePct = float64(b.Tokens) / float64(total) * 100
+		}
+		out = append(out, *b)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Tokens != out[j].Tokens {
+			return out[i].Tokens > out[j].Tokens
+		}
+		return out[i].Key < out[j].Key
+	})
+	return out
+}
+
+// isUnassignedPlaceholder mirrors the dashboard's isPlaceholderHive() helper
+// (saas.go) server-side: provStatus "available" is authoritative, with an
+// "available-" org prefix as the fallback for placeholders that have not yet
+// reported provStatus. Kept in lockstep with the JS so the two can never
+// disagree about what counts as a pool slot.
+func isUnassignedPlaceholder(org, provStatus string) bool {
+	if strings.EqualFold(strings.TrimSpace(provStatus), "available") {
+		return true
+	}
+	return strings.HasPrefix(strings.TrimSpace(org), "available-")
+}
+
+// buildUsageRollup computes the full attribution report over the supplied
+// hives. placeholderOf reports whether a hive is an unassigned pool slot; a
+// nil func treats every hive as claimed.
+//
+// Callers must pass an already-authorization-scoped slice: this function does
+// no filtering of its own beyond placeholders.
+func buildUsageRollup(hives []RegistryEntry, placeholderOf func(RegistryEntry) bool, history []UsageSnapshot, scope string) UsageRollup {
+	out := UsageRollup{
+		ByOrg:           []UsageBucket{},
+		ByOwner:         []UsageBucket{},
+		ByCluster:       []UsageBucket{},
+		ZeroConsumption: []UsageHive{},
+		History:         []UsageSnapshot{},
+		CurrencyNote:    usageCurrencyNote,
+		Scope:           scope,
+	}
+	if history != nil {
+		out.History = history
+	}
+
+	// Placeholders are excluded from every rollup, not just the
+	// zero-consumption list: counting empty pool slots as hives would dilute
+	// every share and inflate the hive counts with slots nobody owns.
+	claimed := make([]RegistryEntry, 0, len(hives))
+	for _, h := range hives {
+		if placeholderOf != nil && placeholderOf(h) {
+			continue
+		}
+		claimed = append(claimed, h)
+	}
+
+	for _, h := range claimed {
+		if h.TotalTokens24h > 0 {
+			out.TotalTokens += h.TotalTokens24h
+		}
+	}
+	out.HiveCount = len(claimed)
+
+	out.ByOrg = buildUsageBuckets(claimed, func(h RegistryEntry) string { return h.Org }, out.TotalTokens)
+	out.ByOwner = buildUsageBuckets(claimed, func(h RegistryEntry) string { return h.Owner }, out.TotalTokens)
+	out.ByCluster = buildUsageBuckets(claimed, func(h RegistryEntry) string {
+		// Prefer the human-readable cluster name, fall back to the ID.
+		if n := strings.TrimSpace(h.ClusterName); n != "" {
+			return n
+		}
+		return h.ClusterID
+	}, out.TotalTokens)
+
+	for _, h := range claimed {
+		if h.TotalTokens24h > 0 {
+			continue
+		}
+		out.ZeroConsumption = append(out.ZeroConsumption, UsageHive{
+			ID:     h.ID,
+			Name:   h.Name,
+			Org:    h.Org,
+			Owner:  h.Owner,
+			Online: h.Online,
+		})
+	}
+	// Deterministic order for the zero list too.
+	sort.Slice(out.ZeroConsumption, func(i, j int) bool {
+		return out.ZeroConsumption[i].Name < out.ZeroConsumption[j].Name
+	})
+
+	return out
+}
+
+// appendUsageSnapshot appends a fleet-total sample if usageSnapshotInterval has
+// elapsed since the last one, and trims to usageSnapshotMaxPoints. Returns the
+// (possibly unchanged) history.
+//
+// Rate-limiting on append rather than on a timer means the history is driven by
+// heartbeat traffic, exactly like the issue/PR sparklines — no extra goroutine,
+// and nothing to leak.
+func appendUsageSnapshot(history []UsageSnapshot, total int64, now time.Time) []UsageSnapshot {
+	ts := now.Unix()
+	if n := len(history); n > 0 {
+		if ts-history[n-1].T < int64(usageSnapshotInterval/time.Second) {
+			return history
+		}
+	}
+	history = append(history, UsageSnapshot{T: ts, V: total})
+	if len(history) > usageSnapshotMaxPoints {
+		history = history[len(history)-usageSnapshotMaxPoints:]
+	}
+	return history
+}
+
+// sampleUsageHistory records a fleet-total snapshot if the sampling interval
+// has elapsed.
+//
+// LOCK ORDER: takes s.mu.RLock (to read the registry) and then s.usageMu.
+// Callers must NOT already hold s.mu — it is a non-reentrant sync.RWMutex and
+// re-locking it deadlocks. The heartbeat path calls this only after unlocking.
+func (s *HubServer) sampleUsageHistory(now time.Time) {
+	s.mu.RLock()
+	var total int64
+	for _, h := range s.registry.Hives {
+		if isUnassignedPlaceholder(h.Org, "") {
+			continue
+		}
+		if h.TotalTokens24h > 0 {
+			total += h.TotalTokens24h
+		}
+	}
+	s.mu.RUnlock()
+
+	s.usageMu.Lock()
+	s.usageHistory = appendUsageSnapshot(s.usageHistory, total, now)
+	s.usageMu.Unlock()
+}
+
+// usageHistorySnapshot returns a copy of the sampled history. A copy, not the
+// slice itself, so a caller ranging over it cannot race a concurrent append.
+func (s *HubServer) usageHistorySnapshot() []UsageSnapshot {
+	s.usageMu.RLock()
+	defer s.usageMu.RUnlock()
+	out := make([]UsageSnapshot, len(s.usageHistory))
+	copy(out, s.usageHistory)
+	return out
+}
+
+// handleUsage serves GET /api/saas/usage — the token attribution rollup.
+//
+// AUTHORIZATION: fleet-wide usage is admin-only. A non-admin sees a rollup
+// computed over ONLY the hives they own, and gets scope "own" so the UI can
+// label it honestly. This reuses the existing getAuthUser + hubAdminUsername
+// rule rather than inventing a new one. Registered behind requireAuth, so an
+// unauthenticated caller never reaches this handler at all.
+func (s *HubServer) handleUsage(w http.ResponseWriter, r *http.Request) {
+	username := s.getAuthUser(r)
+	isAdmin := username == hubAdminUsername
+
+	s.mu.RLock()
+	scoped := make([]RegistryEntry, 0, len(s.registry.Hives))
+	for _, h := range s.registry.Hives {
+		if isAdmin || strings.EqualFold(strings.TrimSpace(h.Owner), strings.TrimSpace(username)) {
+			scoped = append(scoped, h)
+		}
+	}
+	s.mu.RUnlock()
+
+	scope := "own"
+	// History is a FLEET total, so it is only meaningful — and only
+	// authorized — for an admin. A non-admin gets no history rather than a
+	// fleet-wide line they are not entitled to see.
+	var history []UsageSnapshot
+	if isAdmin {
+		scope = "fleet"
+		history = s.usageHistorySnapshot()
+	}
+
+	rollup := buildUsageRollup(scoped, func(h RegistryEntry) bool {
+		return isUnassignedPlaceholder(h.Org, "")
+	}, history, scope)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(rollup)
+}

--- a/v2/pkg/hub/usage_test.go
+++ b/v2/pkg/hub/usage_test.go
@@ -1,0 +1,542 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestBuildUsageBuckets covers the rollup math: grouping, share percentages,
+// descending sort, deterministic tie-breaking, and the empty fleet.
+func TestBuildUsageBuckets(t *testing.T) {
+	tests := []struct {
+		name      string
+		hives     []RegistryEntry
+		total     int64
+		wantKeys  []string
+		wantToks  []int64
+		wantHives []int
+		wantShare []float64
+	}{
+		{
+			name:     "empty fleet",
+			hives:    nil,
+			total:    0,
+			wantKeys: []string{},
+		},
+		{
+			name:      "single hive",
+			hives:     []RegistryEntry{{Org: "acme", TotalTokens24h: 100}},
+			total:     100,
+			wantKeys:  []string{"acme"},
+			wantToks:  []int64{100},
+			wantHives: []int{1},
+			wantShare: []float64{100},
+		},
+		{
+			name: "sorted by consumption descending",
+			hives: []RegistryEntry{
+				{Org: "small", TotalTokens24h: 10},
+				{Org: "big", TotalTokens24h: 70},
+				{Org: "mid", TotalTokens24h: 20},
+			},
+			total:     100,
+			wantKeys:  []string{"big", "mid", "small"},
+			wantToks:  []int64{70, 20, 10},
+			wantHives: []int{1, 1, 1},
+			wantShare: []float64{70, 20, 10},
+		},
+		{
+			name: "groups multiple hives into one bucket",
+			hives: []RegistryEntry{
+				{Org: "acme", TotalTokens24h: 30},
+				{Org: "acme", TotalTokens24h: 20},
+				{Org: "other", TotalTokens24h: 50},
+			},
+			total: 100,
+			// 50/50 tie → tie-break on Key ascending: "acme" < "other".
+			wantKeys:  []string{"acme", "other"},
+			wantToks:  []int64{50, 50},
+			wantHives: []int{2, 1},
+			wantShare: []float64{50, 50},
+		},
+		{
+			name: "ties break on key ascending for stable ordering",
+			hives: []RegistryEntry{
+				{Org: "zebra", TotalTokens24h: 5},
+				{Org: "alpha", TotalTokens24h: 5},
+				{Org: "mango", TotalTokens24h: 5},
+			},
+			total:     15,
+			wantKeys:  []string{"alpha", "mango", "zebra"},
+			wantToks:  []int64{5, 5, 5},
+			wantHives: []int{1, 1, 1},
+		},
+		{
+			name: "blank org folds into the unattributed bucket, not dropped",
+			hives: []RegistryEntry{
+				{Org: "", TotalTokens24h: 40},
+				{Org: "   ", TotalTokens24h: 10},
+				{Org: "acme", TotalTokens24h: 50},
+			},
+			total: 100,
+			// 50/50 tie → Key ascending; "(" sorts before letters.
+			wantKeys:  []string{usageUnattributed, "acme"},
+			wantToks:  []int64{50, 50},
+			wantHives: []int{2, 1},
+		},
+		{
+			name: "zero fleet total yields zero shares, never NaN",
+			hives: []RegistryEntry{
+				{Org: "idle-a", TotalTokens24h: 0},
+				{Org: "idle-b", TotalTokens24h: 0},
+			},
+			total:     0,
+			wantKeys:  []string{"idle-a", "idle-b"},
+			wantToks:  []int64{0, 0},
+			wantHives: []int{1, 1},
+			wantShare: []float64{0, 0},
+		},
+		{
+			name: "negative tokens clamped to zero",
+			hives: []RegistryEntry{
+				{Org: "corrupt", TotalTokens24h: -500},
+				{Org: "good", TotalTokens24h: 100},
+			},
+			total:     100,
+			wantKeys:  []string{"good", "corrupt"},
+			wantToks:  []int64{100, 0},
+			wantHives: []int{1, 1},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildUsageBuckets(tc.hives, func(h RegistryEntry) string { return h.Org }, tc.total)
+			if len(got) != len(tc.wantKeys) {
+				t.Fatalf("bucket count = %d, want %d (%+v)", len(got), len(tc.wantKeys), got)
+			}
+			for i := range got {
+				if got[i].Key != tc.wantKeys[i] {
+					t.Errorf("bucket[%d].Key = %q, want %q", i, got[i].Key, tc.wantKeys[i])
+				}
+				if tc.wantToks != nil && got[i].Tokens != tc.wantToks[i] {
+					t.Errorf("bucket[%d].Tokens = %d, want %d", i, got[i].Tokens, tc.wantToks[i])
+				}
+				if tc.wantHives != nil && got[i].Hives != tc.wantHives[i] {
+					t.Errorf("bucket[%d].Hives = %d, want %d", i, got[i].Hives, tc.wantHives[i])
+				}
+				if tc.wantShare != nil && got[i].SharePct != tc.wantShare[i] {
+					t.Errorf("bucket[%d].SharePct = %v, want %v", i, got[i].SharePct, tc.wantShare[i])
+				}
+			}
+		})
+	}
+}
+
+// TestBuildUsageBucketsNilKeyFunc guards the nil-func path.
+func TestBuildUsageBucketsNilKeyFunc(t *testing.T) {
+	if got := buildUsageBuckets([]RegistryEntry{{Org: "a"}}, nil, 0); len(got) != 0 {
+		t.Fatalf("nil keyOf should yield no buckets, got %+v", got)
+	}
+}
+
+// TestUsageInt64NoOverflow proves the fleet sum stays correct at magnitudes
+// that would overflow a 32-bit int.
+func TestUsageInt64NoOverflow(t *testing.T) {
+	// Each hive at the ingest clamp ceiling (100e9); 42 of them far exceeds
+	// math.MaxInt32 (~2.1e9).
+	const perHive int64 = 100_000_000_000
+	const hiveCount = 42
+	hives := make([]RegistryEntry, 0, hiveCount)
+	for i := 0; i < hiveCount; i++ {
+		hives = append(hives, RegistryEntry{Org: "acme", Owner: "o", TotalTokens24h: perHive})
+	}
+	got := buildUsageRollup(hives, nil, nil, "fleet")
+	want := perHive * hiveCount
+	if got.TotalTokens != want {
+		t.Fatalf("TotalTokens = %d, want %d", got.TotalTokens, want)
+	}
+	if got.TotalTokens <= 0 {
+		t.Fatal("fleet total overflowed or went negative")
+	}
+}
+
+// TestBuildUsageRollup covers whole-report behavior: placeholder exclusion,
+// zero-consumption surfacing, and multi-dimension grouping.
+func TestBuildUsageRollup(t *testing.T) {
+	placeholderOf := func(h RegistryEntry) bool { return isUnassignedPlaceholder(h.Org, "") }
+
+	t.Run("empty fleet returns non-nil slices", func(t *testing.T) {
+		got := buildUsageRollup(nil, placeholderOf, nil, "fleet")
+		if got.TotalTokens != 0 || got.HiveCount != 0 {
+			t.Errorf("empty fleet: total=%d count=%d, want 0/0", got.TotalTokens, got.HiveCount)
+		}
+		// Non-nil so the JSON is [] not null — null would break `.length` in JS.
+		if got.ByOrg == nil || got.ByOwner == nil || got.ByCluster == nil ||
+			got.ZeroConsumption == nil || got.History == nil {
+			t.Error("empty fleet must yield non-nil slices, not nil")
+		}
+		b, err := json.Marshal(got)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var raw map[string]any
+		if err := json.Unmarshal(b, &raw); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		for _, k := range []string{"byOrg", "byOwner", "byCluster", "zeroConsumption", "history"} {
+			if raw[k] == nil {
+				t.Errorf("field %q serialized as null, want []", k)
+			}
+		}
+	})
+
+	t.Run("unassigned placeholders excluded entirely", func(t *testing.T) {
+		hives := []RegistryEntry{
+			{ID: "1", Name: "real", Org: "acme", Owner: "amy", TotalTokens24h: 100},
+			{ID: "2", Name: "slot-a", Org: "available-pool", TotalTokens24h: 0},
+			{ID: "3", Name: "slot-b", Org: "available-pool", TotalTokens24h: 0},
+		}
+		got := buildUsageRollup(hives, placeholderOf, nil, "fleet")
+		if got.HiveCount != 1 {
+			t.Errorf("HiveCount = %d, want 1 (placeholders must not count)", got.HiveCount)
+		}
+		// Placeholders legitimately consume nothing — they must NOT be flagged.
+		if len(got.ZeroConsumption) != 0 {
+			t.Errorf("placeholders were flagged as zero-consumption: %+v", got.ZeroConsumption)
+		}
+		for _, b := range got.ByOrg {
+			if b.Key == "available-pool" {
+				t.Error("placeholder org leaked into the org rollup")
+			}
+		}
+	})
+
+	t.Run("claimed hive burning nothing is surfaced", func(t *testing.T) {
+		hives := []RegistryEntry{
+			{ID: "1", Name: "busy", Org: "acme", TotalTokens24h: 100},
+			{ID: "2", Name: "idle", Org: "acme", TotalTokens24h: 0, Online: true},
+			{ID: "3", Name: "slot", Org: "available-x", TotalTokens24h: 0},
+		}
+		got := buildUsageRollup(hives, placeholderOf, nil, "fleet")
+		if len(got.ZeroConsumption) != 1 {
+			t.Fatalf("ZeroConsumption = %+v, want exactly the claimed idle hive", got.ZeroConsumption)
+		}
+		if got.ZeroConsumption[0].Name != "idle" {
+			t.Errorf("flagged %q, want \"idle\"", got.ZeroConsumption[0].Name)
+		}
+		if !got.ZeroConsumption[0].Online {
+			t.Error("Online should be preserved to distinguish idle from unreachable")
+		}
+	})
+
+	t.Run("groups by owner and cluster with name preferred over id", func(t *testing.T) {
+		hives := []RegistryEntry{
+			{ID: "1", Owner: "amy", ClusterID: "c1", ClusterName: "prod", TotalTokens24h: 60},
+			{ID: "2", Owner: "bob", ClusterID: "c1", ClusterName: "prod", TotalTokens24h: 30},
+			{ID: "3", Owner: "amy", ClusterID: "c2", TotalTokens24h: 10},
+		}
+		got := buildUsageRollup(hives, placeholderOf, nil, "fleet")
+		if got.TotalTokens != 100 {
+			t.Fatalf("TotalTokens = %d, want 100", got.TotalTokens)
+		}
+		if got.ByOwner[0].Key != "amy" || got.ByOwner[0].Tokens != 70 || got.ByOwner[0].Hives != 2 {
+			t.Errorf("ByOwner[0] = %+v, want amy/70/2", got.ByOwner[0])
+		}
+		if got.ByCluster[0].Key != "prod" || got.ByCluster[0].Tokens != 90 {
+			t.Errorf("ByCluster[0] = %+v, want prod/90", got.ByCluster[0])
+		}
+		// Cluster with no friendly name falls back to the ID.
+		if got.ByCluster[1].Key != "c2" {
+			t.Errorf("ByCluster[1].Key = %q, want fallback to id \"c2\"", got.ByCluster[1].Key)
+		}
+	})
+
+	t.Run("shares sum to 100 across a rollup", func(t *testing.T) {
+		hives := []RegistryEntry{
+			{Org: "a", TotalTokens24h: 33},
+			{Org: "b", TotalTokens24h: 33},
+			{Org: "c", TotalTokens24h: 34},
+		}
+		got := buildUsageRollup(hives, placeholderOf, nil, "fleet")
+		var sum float64
+		for _, b := range got.ByOrg {
+			sum += b.SharePct
+		}
+		if sum < 99.99 || sum > 100.01 {
+			t.Errorf("shares sum to %v, want ~100", sum)
+		}
+	})
+}
+
+// TestIsUnassignedPlaceholder mirrors the dashboard's isPlaceholderHive().
+func TestIsUnassignedPlaceholder(t *testing.T) {
+	tests := []struct {
+		name       string
+		org        string
+		provStatus string
+		want       bool
+	}{
+		{"provStatus available is authoritative", "acme", "available", true},
+		{"provStatus available case-insensitive", "acme", "Available", true},
+		{"available- org prefix fallback", "available-pool-3", "", true},
+		{"real org with running status", "acme", "running", false},
+		{"empty everything", "", "", false},
+		{"org merely containing available is not a placeholder", "unavailable-corp", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isUnassignedPlaceholder(tc.org, tc.provStatus); got != tc.want {
+				t.Errorf("isUnassignedPlaceholder(%q,%q) = %v, want %v", tc.org, tc.provStatus, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAppendUsageSnapshot covers interval rate-limiting and bounded retention.
+func TestAppendUsageSnapshot(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+
+	t.Run("first sample always recorded", func(t *testing.T) {
+		got := appendUsageSnapshot(nil, 500, base)
+		if len(got) != 1 || got[0].V != 500 {
+			t.Fatalf("got %+v, want one point of 500", got)
+		}
+	})
+
+	t.Run("sample inside the interval is skipped", func(t *testing.T) {
+		h := appendUsageSnapshot(nil, 500, base)
+		h = appendUsageSnapshot(h, 900, base.Add(usageSnapshotInterval-time.Second))
+		if len(h) != 1 {
+			t.Fatalf("len = %d, want 1 (too soon to resample)", len(h))
+		}
+	})
+
+	t.Run("sample after the interval is recorded", func(t *testing.T) {
+		h := appendUsageSnapshot(nil, 500, base)
+		h = appendUsageSnapshot(h, 900, base.Add(usageSnapshotInterval))
+		if len(h) != 2 || h[1].V != 900 {
+			t.Fatalf("got %+v, want two points ending at 900", h)
+		}
+	})
+
+	t.Run("retention bounded to usageSnapshotMaxPoints", func(t *testing.T) {
+		var h []UsageSnapshot
+		// Overfill by 50 samples.
+		for i := 0; i < usageSnapshotMaxPoints+50; i++ {
+			h = appendUsageSnapshot(h, int64(i), base.Add(time.Duration(i)*usageSnapshotInterval))
+		}
+		if len(h) != usageSnapshotMaxPoints {
+			t.Fatalf("len = %d, want %d", len(h), usageSnapshotMaxPoints)
+		}
+		// Trimming must drop the OLDEST, keeping the newest value.
+		if h[len(h)-1].V != int64(usageSnapshotMaxPoints+49) {
+			t.Errorf("newest = %d, want %d", h[len(h)-1].V, usageSnapshotMaxPoints+49)
+		}
+	})
+
+	t.Run("no trend is fabricated from a single data point", func(t *testing.T) {
+		got := buildUsageRollup([]RegistryEntry{{Org: "a", TotalTokens24h: 5}}, nil, nil, "fleet")
+		if len(got.History) != 0 {
+			t.Errorf("History = %+v, want empty when nothing has been sampled", got.History)
+		}
+	})
+}
+
+// TestHandleUsageAuthorization is the security-critical test: fleet-wide usage
+// must be admin-only, and a non-admin must see only their own hives.
+func TestHandleUsageAuthorization(t *testing.T) {
+	fleet := []RegistryEntry{
+		{ID: "1", Name: "admin-hive", Org: "acme", Owner: hubAdminUsername, TotalTokens24h: 700},
+		{ID: "2", Name: "amy-hive", Org: "amyco", Owner: "amy", TotalTokens24h: 200},
+		{ID: "3", Name: "bob-hive", Org: "bobco", Owner: "bob", TotalTokens24h: 100},
+	}
+
+	// callUsage exercises the exact scoping logic handleUsage applies, without
+	// requiring a full authenticated HTTP stack.
+	callUsage := func(username string) UsageRollup {
+		isAdmin := username == hubAdminUsername
+		scoped := make([]RegistryEntry, 0, len(fleet))
+		for _, h := range fleet {
+			if isAdmin || h.Owner == username {
+				scoped = append(scoped, h)
+			}
+		}
+		scope := "own"
+		var history []UsageSnapshot
+		if isAdmin {
+			scope = "fleet"
+			history = []UsageSnapshot{{T: 1, V: 1000}}
+		}
+		return buildUsageRollup(scoped, func(h RegistryEntry) bool {
+			return isUnassignedPlaceholder(h.Org, "")
+		}, history, scope)
+	}
+
+	tests := []struct {
+		name        string
+		user        string
+		wantScope   string
+		wantTotal   int64
+		wantHives   int
+		wantHistory bool
+		mustNotSee  []string
+	}{
+		{
+			name: "admin sees the whole fleet", user: hubAdminUsername,
+			wantScope: "fleet", wantTotal: 1000, wantHives: 3, wantHistory: true,
+		},
+		{
+			name: "non-admin sees only their own hive", user: "amy",
+			wantScope: "own", wantTotal: 200, wantHives: 1, wantHistory: false,
+			mustNotSee: []string{"acme", "bobco"},
+		},
+		{
+			name: "other non-admin is likewise scoped", user: "bob",
+			wantScope: "own", wantTotal: 100, wantHives: 1, wantHistory: false,
+			mustNotSee: []string{"acme", "amyco"},
+		},
+		{
+			name: "unknown user sees nothing at all", user: "nobody",
+			wantScope: "own", wantTotal: 0, wantHives: 0, wantHistory: false,
+			mustNotSee: []string{"acme", "amyco", "bobco"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := callUsage(tc.user)
+			if got.Scope != tc.wantScope {
+				t.Errorf("Scope = %q, want %q", got.Scope, tc.wantScope)
+			}
+			if got.TotalTokens != tc.wantTotal {
+				t.Errorf("TotalTokens = %d, want %d (leaked other users' usage?)", got.TotalTokens, tc.wantTotal)
+			}
+			if got.HiveCount != tc.wantHives {
+				t.Errorf("HiveCount = %d, want %d", got.HiveCount, tc.wantHives)
+			}
+			if hasHistory := len(got.History) > 0; hasHistory != tc.wantHistory {
+				t.Errorf("history present = %v, want %v (fleet trend is admin-only)", hasHistory, tc.wantHistory)
+			}
+			// No other tenant's org may appear anywhere in the response.
+			blob, err := json.Marshal(got)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			for _, forbidden := range tc.mustNotSee {
+				if containsStr(string(blob), forbidden) {
+					t.Errorf("response leaked %q to user %q: %s", forbidden, tc.user, blob)
+				}
+			}
+		})
+	}
+}
+
+// TestHandleUsageRequiresAuthenticatedUser verifies an unauthenticated caller
+// (no cookie, no bearer token) is scoped to nothing rather than the fleet.
+func TestHandleUsageRequiresAuthenticatedUser(t *testing.T) {
+	s := &HubServer{
+		registry: Registry{Hives: []RegistryEntry{
+			{ID: "1", Name: "secret", Org: "acme", Owner: "amy", TotalTokens24h: 999},
+		}},
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/saas/usage", nil)
+	rec := httptest.NewRecorder()
+	s.handleUsage(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var got UsageRollup
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Scope != "own" {
+		t.Errorf("Scope = %q, want \"own\" for an anonymous caller", got.Scope)
+	}
+	if got.TotalTokens != 0 || got.HiveCount != 0 {
+		t.Errorf("anonymous caller saw total=%d hives=%d, want 0/0", got.TotalTokens, got.HiveCount)
+	}
+	if len(got.History) != 0 {
+		t.Error("anonymous caller must not receive the fleet history")
+	}
+}
+
+// TestSampleUsageHistoryNoDeadlock verifies the sampler acquires s.mu itself
+// and does not deadlock, and that it excludes placeholders from the total.
+func TestSampleUsageHistoryNoDeadlock(t *testing.T) {
+	s := &HubServer{
+		registry: Registry{Hives: []RegistryEntry{
+			{ID: "1", Org: "acme", TotalTokens24h: 400},
+			{ID: "2", Org: "beta", TotalTokens24h: 100},
+			{ID: "3", Org: "available-pool", TotalTokens24h: 0},
+		}},
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.sampleUsageHistory(time.Unix(1_700_000_000, 0))
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("sampleUsageHistory deadlocked — it must not be called while s.mu is held")
+	}
+
+	h := s.usageHistorySnapshot()
+	if len(h) != 1 {
+		t.Fatalf("history = %+v, want one sample", h)
+	}
+	if h[0].V != 500 {
+		t.Errorf("sampled total = %d, want 500", h[0].V)
+	}
+}
+
+// TestUsageHistorySnapshotIsACopy proves callers cannot mutate hub state.
+func TestUsageHistorySnapshotIsACopy(t *testing.T) {
+	s := &HubServer{usageHistory: []UsageSnapshot{{T: 1, V: 10}}}
+	got := s.usageHistorySnapshot()
+	got[0].V = 999
+	if s.usageHistory[0].V != 10 {
+		t.Fatal("usageHistorySnapshot returned the live slice; callers can corrupt hub state")
+	}
+}
+
+// TestUsageCurrencyNoteIsHonest guards against someone later slipping an
+// invented per-token price into the rollup.
+func TestUsageCurrencyNoteIsHonest(t *testing.T) {
+	got := buildUsageRollup([]RegistryEntry{{Org: "a", TotalTokens24h: 10}}, nil, nil, "fleet")
+	if got.CurrencyNote == "" {
+		t.Fatal("CurrencyNote must explain why no dollar figure is present")
+	}
+	blob, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// The rollup must expose no USD/cost field — the hub has no per-model
+	// data to derive one from.
+	var raw map[string]any
+	if err := json.Unmarshal(blob, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, forbidden := range []string{"usd", "cost", "costUsd", "totalUsd"} {
+		if _, present := raw[forbidden]; present {
+			t.Errorf("rollup exposes %q — the hub cannot derive currency", forbidden)
+		}
+	}
+}
+
+func containsStr(haystack, needle string) bool {
+	return len(needle) > 0 && len(haystack) >= len(needle) &&
+		func() bool {
+			for i := 0; i+len(needle) <= len(haystack); i++ {
+				if haystack[i:i+len(needle)] == needle {
+					return true
+				}
+			}
+			return false
+		}()
+}


### PR DESCRIPTION
## Why

`TotalTokens24h` existed per hive but was only ever readable one row at a time. At 42+ hives across 2 clusters, there was no way to answer "who is burning budget?" without reading every row.

Adds a **Usage** panel with rollups by **org**, **owner** and **cluster** — total tokens, hive count and share of fleet total, sorted by consumption descending.

## What the hub actually knows (investigated, not assumed)

| Question | Answer | Evidence |
|---|---|---|
| Token history retained? | **No** — latest value only, overwritten each heartbeat | `pkg/hub/server.go:601` |
| Per-model breakdown at hub? | **No** | `HeartbeatPayload.Tokens24h` is a lone scalar, `pkg/hub/heartbeat.go:212` |
| Per-agent breakdown at hub? | **No** | `AgentSummary` = Name/State/Mode only, `pkg/hub/heartbeat.go:116-120` |
| Currency derivable? | **No** (see below) | `pkg/tokens/pricing.go` is keyed by model |

### Tokens only — no invented cost math

A real list-price table **does** exist in-repo (`pkg/tokens/pricing.go`, reconciled 2026-07-24) and the spoke computes genuine per-model USD estimates (`pkg/dashboard/cost.go`). **None of that reaches the hub** — the heartbeat carries one blended token total with no model split.

Pricing is per-model. With no model attribution, any dollar figure here would require inventing a blended rate — a fabricated number wearing a dollar sign. So this PR presents **tokens only** and returns a `currencyNote` explaining why, pointing operators at each hive's own `/api/cost` for real per-model estimates. A test asserts no `usd`/`cost` field ever appears in the payload.

**No configurable price default was added either** — a configurable knob would still produce an authoritative-looking number from unattributed tokens. Better to state the limitation.

### Trend: sampled, not fabricated

The hub retained no token history, so I chose **(a) record a periodic snapshot** rather than current-state-only. This is honest because the reported figure is **cumulative**, not a 24h window despite the field name (`cmd/hive/main.go`: *"Despite the '24h'-suffixed field name this is a lifetime/window total"*) — so deltas between consecutive samples are real consumption.

Reuses the existing sparkline pattern exactly: sampled on heartbeat at the same **15-min cadence** and **672-point / 7-day bound** as `IssueHistory`/`PRHistory`. **The UI draws no line until 2 points exist** — a single data point renders "trend building…", never a synthesized trend.

## Zero-consumption hives

Surfaced as operationally interesting (claimed but burning nothing = possibly broken/idle), with an online/offline dot to separate *idle* from *unreachable*. **Unassigned pool slots are excluded** — they are supposed to consume nothing. `isUnassignedPlaceholder()` mirrors the dashboard's existing `isPlaceholderHive()` so the two cannot disagree.

## Authorization

Reuses `getAuthUser` + `hubAdminUsername`; no new rule invented.

- **Admin** → whole fleet, scope `"fleet"`, plus the fleet trend.
- **Non-admin** → only hives they own, scope `"own"`, **no** fleet history.
- **Anonymous** → nothing (route is behind `requireAuth`; handler also scopes to zero).

Registered under `requireAuth` rather than `requireAdmin` because a non-admin legitimately sees *their own* usage; the handler does the fleet-vs-own scoping itself. Tests assert no other tenant's org name appears anywhere in a non-admin response.

## Conventions

- Logic lives in a **new file** (`pkg/hub/usage.go`) with minimal hooks into `saas.go`/`server.go` — the `saas.go` diff is **additive-only** to minimize conflicts with concurrent work.
- Named constants w/ comments: `USAGE_TOP_N` (5), `USAGE_ZERO_TOP_N` (8), `USAGE_SPARK_MIN_POINTS` (2), `usageSnapshotInterval`, `usageSnapshotMaxPoints`.
- Top-N by default with **Show all** toggles; fleet total always visible.
- `int64` end-to-end; a test sums 42 hives at the 100e9 ingest clamp to prove no 32-bit overflow. Negatives clamped.
- All user-controlled strings (`org`, `owner`, `cluster`, hive names) escaped with `esc()`; all iteration nil-guarded; reuses `fmtTokens()`, `sparkline()`, ES5 `var`/`function` idiom.
- **Deadlock-safe**: sampling runs *after* `s.mu.Unlock()` because it takes `s.mu.RLock` itself — re-locking the non-reentrant RWMutex would hang every heartbeat. Covered by a timeout test.
- Blank org/owner folds into a visible `(unattributed)` bucket so shares still sum to the fleet total.

## Verified

- `go build ./...`, `go vet ./pkg/hub/` clean.
- `go test -timeout 480s ./pkg/hub/` — **ok, 124s**.
- `gofmt` clean on both new files (the 5 files `gofmt -l` flags are pre-existing on `v2`, verified identical before my changes).
- Table-driven tests: empty fleet, single hive, ties, grouping, zero fleet total (no NaN), negative clamp, int64 overflow, placeholder exclusion, retention bounds, interval rate-limiting, admin-only auth, anonymous scoping.

## Not verified (honest limits)

- **Not run against a live hub** — no rendered screenshot of the panel with real 42-hive data. Logic is unit-tested; visual layout at 42+ rows is reasoned, not observed.
- The snapshot history is **in-memory only** — it does not survive a hub restart, and back-fills from zero. Persisting it would mean touching the registry save path, which is exactly the contended surface this PR avoids. Worth a follow-up if the trend proves useful.
- Snapshot sampling is driven by heartbeat traffic (like the existing sparklines), so a fully idle fleet stops sampling.