### PR TITLE
✨ feat(hub): per-hive activity timeline

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -151,6 +151,7 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("DELETE /api/saas/hives/{id}/access/{username}", s.requireAuth(s.handleAccessRemove))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/request-access", s.requireAuth(s.handleRequestAccess))
 	s.mux.HandleFunc("GET /api/saas/hives/{id}/requests", s.requireAuth(s.handleGetRequests))
+	s.mux.HandleFunc("GET /api/saas/hives/{id}/timeline", s.requireAuth(s.handleHiveTimeline))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/requests/{username}/approve", s.requireAuth(s.handleApproveRequest))
 	s.mux.HandleFunc("POST /api/saas/hives/{id}/requests/{username}/deny", s.requireAuth(s.handleDenyRequest))
 	s.mux.HandleFunc("PUT /api/saas/hives/{id}/approve-access/{username}", s.requireAuth(s.handleApproveAccess))
@@ -1321,10 +1322,11 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 	user := ensureSaaSUser(username)
 
 	s.mu.Lock()
-	s.markStaleHives()
+	offlineEvents := s.markStaleHives()
 	allHives := make([]RegistryEntry, len(s.registry.Hives))
 	copy(allHives, s.registry.Hives)
 	s.mu.Unlock()
+	s.flushOfflineEvents(offlineEvents)
 
 	var result []MyHiveEntry
 
@@ -1590,10 +1592,11 @@ func (s *HubServer) handleAccessStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.mu.Lock()
-	s.markStaleHives()
+	offlineEvents := s.markStaleHives()
 	allHives := make([]RegistryEntry, len(s.registry.Hives))
 	copy(allHives, s.registry.Hives)
 	s.mu.Unlock()
+	s.flushOfflineEvents(offlineEvents)
 
 	type hiveAccessInfo struct {
 		Role   string `json:"role"`
@@ -2203,6 +2206,7 @@ func (s *HubServer) handleUpgradeHive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.logger.Info("audit: hosted hive upgraded", "hive_id", id, "by", username, "cluster", cluster.ID)
+	s.recordTimeline(id, TimelineUpgradeStarted, "upgrade requested from the hub dashboard", username)
 	s.mu.Lock()
 	for i := range s.registry.Hives {
 		if s.registry.Hives[i].ID == id {
@@ -2326,6 +2330,8 @@ func (s *HubServer) handleSwitchBranch(w http.ResponseWriter, r *http.Request) {
 		s.logger.Warn("rollout restart after branch switch failed", "hive", id, "output", string(restartOut))
 	}
 	s.logger.Info("audit: hive branch switched", "hive_id", id, "branch", body.Branch, "image", image, "by", username)
+	s.recordTimeline(id, TimelineBranchChanged,
+		fmt.Sprintf("branch switch to %s requested (image %s)", body.Branch, image), username)
 	s.mu.Lock()
 	for i := range s.registry.Hives {
 		if s.registry.Hives[i].ID == id {
@@ -3301,6 +3307,8 @@ func (s *HubServer) triggerAutoUpgrades() {
 			continue
 		}
 		s.logger.Info("audit: auto-upgrade triggered", "hive_id", h.ID, "branch", branch, "from", currentSHA, "to", latestSHA, "cluster", hiveCluster.ID)
+		s.recordTimeline(h.ID, TimelineUpgradeStarted,
+			fmt.Sprintf("auto-upgrade triggered on %s: %s → %s", branch, orDash(currentSHA), latestSHA), "auto-upgrade")
 		s.mu.Lock()
 		for i := range s.registry.Hives {
 			if s.registry.Hives[i].ID == h.ID {
@@ -3737,6 +3745,8 @@ func (s *HubServer) handleAccessAdd(w http.ResponseWriter, r *http.Request) {
 	target.Hives[hiveID] = body.Role
 	saveSaaSUser(target)
 	s.logger.Info("audit: access granted", "hive", hiveID, "target", body.Username, "role", body.Role, "by", username)
+	s.recordTimeline(hiveID, TimelineAccess,
+		fmt.Sprintf("access granted to %s as %s", body.Username, body.Role), username)
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "granted"})
 }
@@ -3774,6 +3784,8 @@ func (s *HubServer) handleAccessRemove(w http.ResponseWriter, r *http.Request) {
 	delete(target.Hives, hiveID)
 	saveSaaSUser(target)
 	s.logger.Info("audit: access revoked", "hive", hiveID, "target", targetUsername, "by", username)
+	s.recordTimeline(hiveID, TimelineAccess,
+		fmt.Sprintf("access revoked from %s", targetUsername), username)
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "revoked"})
 }
@@ -3968,6 +3980,8 @@ func (s *HubServer) handleApproveRequest(w http.ResponseWriter, r *http.Request)
 	saveAccessRequests(hiveID, reqs)
 
 	s.logger.Info("audit: access request approved", "hive", hiveID, "target", targetUsername, "role", body.Role, "by", approver)
+	s.recordTimeline(hiveID, TimelineAccess,
+		fmt.Sprintf("access request from %s approved as %s", targetUsername, body.Role), approver)
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "approved"})
 }
@@ -4003,6 +4017,8 @@ func (s *HubServer) handleDenyRequest(w http.ResponseWriter, r *http.Request) {
 	saveAccessRequests(hiveID, reqs)
 
 	s.logger.Info("audit: access request denied", "hive", hiveID, "target", targetUsername, "by", denier)
+	s.recordTimeline(hiveID, TimelineAccess,
+		fmt.Sprintf("access request from %s denied", targetUsername), denier)
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "denied"})
 }
@@ -4992,6 +5008,9 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 		"cluster", clusterIDForHive(h),
 		"app_creds_delivered", appDelivered,
 	)
+	s.recordTimeline(hiveID, TimelineOwnership,
+		fmt.Sprintf("hive assigned to %s (%s/%s, ACMM %d)", h.Owner, h.Org, h.PrimaryRepo, h.ACMMLevel),
+		s.getAuthUser(r))
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{
@@ -5574,6 +5593,8 @@ const dashboardHTML = `<!DOCTYPE html>
       if (requestModal && requestModal.style.display === 'flex') { requestModal.style.display = 'none'; return; }
       var accessOverlay = document.querySelector('.hive-confirm-overlay');
       if (accessOverlay) { accessOverlay.remove(); return; }
+      var timelineModal = document.getElementById('timeline-modal');
+      if (timelineModal && timelineModal.style.display === 'flex') { timelineModal.style.display = 'none'; return; }
       var accessModal = document.getElementById('access-modal');
       if (accessModal && accessModal.style.display === 'flex') { accessModal.style.display = 'none'; }
     });
@@ -6271,6 +6292,8 @@ const dashboardHTML = `<!DOCTYPE html>
         if (menuItems.length > 0 && (canConvert || isHosted || isLocal)) menuItems.push('<div style="border-top:1px solid #30363d;margin:4px 0"></div>');
         if (canConvert) menuItems.push('<div onclick="openConvert(this)" data-hive-id="' + esc(h.id) + '" data-dash-url="' + esc(h.dashboardUrl||'') + '" data-org="' + esc(h.org) + '" data-repos="' + esc((h.repos||[]).join(', ')) + '" data-primary="' + esc(h.primaryRepo) + '" data-level="' + (h.acmmLevel||1) + '" data-name="' + esc(h.name||'') + '" style="' + mi + '">Convert to Hosted</div>');
         if (isHosted && (h.role === 'owner' || h.role === 'read-write')) menuItems.push('<div onclick="openAccessModal(\'' + esc(h.id) + '\',\'' + esc(h.dashboardUrl || '') + '\')" style="' + mi + '">Permissions</div>');
+        /* Timeline is owner-or-admin, matching the API's authorization. */
+        if (isHosted && (h.role === 'owner' || _isAdmin)) menuItems.push('<div onclick="openTimelineModal(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">Activity Timeline</div>');
         if (h.role === 'owner' || h.role === 'read-write' || _isAdmin) menuItems.push('<div onclick="openOpenRouterFundModal(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">⚡ Fund with OpenRouter</div>');
         if (_isAdmin && isHosted) menuItems.push('<div onclick="openBannerForHive(\'' + esc(h.id) + '\',\'' + esc(h.name || h.id) + '\')" style="' + mi + '">Send Banner</div>');
         if (isLocal && h.role === 'owner') menuItems.push('<div onclick="removeLocalHive(\'' + esc(h.id) + '\')" style="' + mi + '">Remove</div>');
@@ -8004,6 +8027,19 @@ const dashboardHTML = `<!DOCTYPE html>
     </div>
   </div>
 
+  <div id="timeline-modal" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:100;align-items:center;justify-content:center">
+    <div style="background:var(--surface);border:1px solid var(--border);border-radius:12px;max-width:640px;width:92%;max-height:82vh;display:flex;flex-direction:column">
+      <h2 style="font-size:1.3rem;padding:32px 32px 8px;margin:0;color:var(--accent);flex-shrink:0">Activity Timeline</h2>
+      <p style="font-size:0.8rem;color:var(--muted);margin:0;padding:0 32px 16px;flex-shrink:0" id="timeline-hive-label"></p>
+      <div style="flex:1;overflow-y:auto;padding:0 32px 24px">
+        <div id="timeline-list"><div class="loading">Loading...</div></div>
+      </div>
+      <div style="display:flex;justify-content:flex-end;padding:16px 32px;border-top:1px solid var(--border);flex-shrink:0">
+        <button onclick="document.getElementById('timeline-modal').style.display='none'" style="padding:8px 20px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--muted);cursor:pointer">Close</button>
+      </div>
+    </div>
+  </div>
+
   <div id="request-access-modal" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.6);z-index:100;align-items:center;justify-content:center">
     <div style="background:var(--surface);border:1px solid var(--border);border-radius:12px;max-width:480px;width:90%;display:flex;flex-direction:column">
       <h2 style="font-size:1.3rem;padding:32px 32px 8px;margin:0;color:var(--accent)">Request Access</h2>
@@ -8057,6 +8093,85 @@ const dashboardHTML = `<!DOCTYPE html>
 
   <script>
     var _accessHiveId = '';
+    var _timelineHiveId = '';
+
+    /* Per-event presentation: a colour and a short label per event kind, so the
+       timeline is scannable rather than a wall of text. Kinds come from the
+       Timeline* constants in timeline.go; unknown kinds fall through to a
+       neutral default so an older dashboard never renders a blank row. */
+    var TIMELINE_KINDS = {
+      version_changed:   { label: 'Version',    color: '#3fb950' },
+      branch_changed:    { label: 'Branch',     color: '#60a5fa' },
+      went_offline:      { label: 'Offline',    color: '#f85149' },
+      came_online:       { label: 'Online',     color: '#3fb950' },
+      health_changed:    { label: 'Health',     color: '#f59e0b' },
+      upgrade_started:   { label: 'Upgrade',    color: '#60a5fa' },
+      upgrade_completed: { label: 'Upgraded',   color: '#3fb950' },
+      upgrade_stale:     { label: 'Stuck',      color: '#f85149' },
+      restarted:         { label: 'Restart',    color: '#f59e0b' },
+      acmm_changed:      { label: 'ACMM',       color: '#a371f7' },
+      agents_changed:    { label: 'Agents',     color: '#a371f7' },
+      github_app_changed:{ label: 'GitHub App', color: '#f59e0b' },
+      access:            { label: 'Access',     color: '#60a5fa' },
+      ownership:         { label: 'Ownership',  color: '#60a5fa' },
+      admin:             { label: 'Admin',      color: '#8b949e' }
+    };
+
+    /* Relative time, coarse on purpose: "what happened to this hive" is
+       answered by ordering and rough age, not by seconds. */
+    var TIMELINE_MS_PER_MIN = 60000;
+    var TIMELINE_MIN_PER_HOUR = 60;
+    var TIMELINE_HOURS_PER_DAY = 24;
+    function timelineAgo(ts) {
+      var t = Date.parse(ts);
+      if (isNaN(t)) return '';
+      var mins = Math.floor((Date.now() - t) / TIMELINE_MS_PER_MIN);
+      if (mins < 1) return 'just now';
+      if (mins < TIMELINE_MIN_PER_HOUR) return mins + 'm ago';
+      var hours = Math.floor(mins / TIMELINE_MIN_PER_HOUR);
+      if (hours < TIMELINE_HOURS_PER_DAY) return hours + 'h ago';
+      return Math.floor(hours / TIMELINE_HOURS_PER_DAY) + 'd ago';
+    }
+
+    async function openTimelineModal(hiveId, hiveName) {
+      _timelineHiveId = hiveId;
+      document.getElementById('timeline-hive-label').textContent = hiveName || hiveId;
+      document.getElementById('timeline-list').innerHTML = '<div class="loading">Loading...</div>';
+      document.getElementById('timeline-modal').style.display = 'flex';
+      await loadTimeline();
+    }
+
+    async function loadTimeline() {
+      var el = document.getElementById('timeline-list');
+      try {
+        var resp = await fetch('/api/saas/hives/' + encodeURIComponent(_timelineHiveId) + '/timeline');
+        if (!resp.ok) {
+          el.innerHTML = '<div style="color:var(--red);font-size:0.85rem">Could not load this hive\'s timeline.</div>';
+          return;
+        }
+        var data = await resp.json();
+        var events = (data && data.events) || [];
+        if (events.length === 0) {
+          el.innerHTML = '<div style="color:var(--muted);font-size:0.85rem">No recorded activity yet. Events appear here when something actually changes — a version lands, health flips, the hive restarts or goes offline.</div>';
+          return;
+        }
+        /* Server returns newest first; render in that order. */
+        el.innerHTML = events.map(function(ev) {
+          var kind = TIMELINE_KINDS[ev.kind] || { label: ev.kind || 'Event', color: '#8b949e' };
+          var actor = ev.actor
+            ? '<span style="color:var(--muted);font-size:0.7rem;margin-left:6px">by ' + esc(ev.actor) + '</span>'
+            : '';
+          return '<div style="display:flex;gap:10px;padding:9px 0;border-bottom:1px solid var(--border)">' +
+            '<div style="flex-shrink:0;width:84px"><span style="display:inline-block;padding:2px 7px;border-radius:9999px;font-size:0.62rem;font-weight:600;white-space:nowrap;background:' + kind.color + '22;color:' + kind.color + ';border:1px solid ' + kind.color + '55">' + esc(kind.label) + '</span></div>' +
+            '<div style="flex:1;min-width:0">' +
+              '<div style="font-size:0.82rem;color:var(--text);word-break:break-word">' + esc(ev.detail || '') + actor + '</div>' +
+              '<div style="font-size:0.68rem;color:var(--muted);margin-top:2px" title="' + esc(ev.ts || '') + '">' + esc(timelineAgo(ev.ts)) + '</div>' +
+            '</div></div>';
+        }).join('');
+      } catch(e) {
+        el.innerHTML = '<div style="color:var(--red);font-size:0.85rem">Failed to load timeline: ' + esc(e.message) + '</div>';
+      }
+    }
 
     async function openAccessModal(hiveId, dashUrl) {
       _accessHiveId = hiveId;

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -294,6 +294,13 @@ type HubServer struct {
 	// (single-use state → verifier/hive/model). Lazily initialized.
 	openRouterStateOnce  sync.Once
 	openRouterStateStore *openrouter.StateStore
+
+	// timeline is the append-only per-hive activity event store. It records
+	// state TRANSITIONS observed on the heartbeat (version, health, upgrade,
+	// restart, …) plus human-initiated actions, so "why is hive X stuck?" is
+	// answerable from the hub instead of `kubectl logs`. It carries its own
+	// leaf mutex and is never guarded by s.mu. See timeline.go.
+	timeline *timelineStore
 }
 
 // HubBannerEntry stores an admin banner targeted at a specific hive.
@@ -418,10 +425,12 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		pendingGitHubAppConfigs: make(map[string]*HeartbeatGitHubAppConfig),
 		pendingGateways:         make(map[string]*HeartbeatGatewayConfig),
 		hubBanners:              make(map[string]*HubBannerEntry),
+		timeline:                newTimelineStore(),
 	}
 
 	s.loadRegistry()
 	s.loadHubBanners()
+	s.timeline.load()
 
 	s.mux.HandleFunc("POST /api/heartbeat", s.handleHeartbeat)
 	s.mux.HandleFunc("POST /api/task-status", s.handleTaskStatus)
@@ -675,10 +684,21 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		entry.Upgrading = true
 	}
 
+	// Timeline: capture the pre-heartbeat entry inside the lock (it is the only
+	// place old and new coexist), but diff and persist AFTER unlocking —
+	// s.mu is a write lock held across the whole registry scan, so a file
+	// write under it would serialize every heartbeat in the fleet.
+	var prevEntry RegistryEntry
+	hadPrev := false
+
 	s.mu.Lock()
 	found := false
 	for i, h := range s.registry.Hives {
 		if h.ID == payload.HiveID {
+			// `h` is a value copy from the range, so it already snapshots the
+			// scalar fields the timeline compares. Health is a map that the
+			// new entry never mutates in place, so aliasing it is safe here.
+			prevEntry, hadPrev = h, true
 			entry.RegisteredAt = h.RegisteredAt
 			if entry.SnapshotURL == "" {
 				entry.SnapshotURL = h.SnapshotURL
@@ -771,6 +791,15 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	}
 	s.registry.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 	s.mu.Unlock()
+
+	// Timeline: record whatever changed on this beat. Nothing is written when
+	// nothing changed, which is the common case — at ~2 min per beat and 42
+	// hives, an event per beat would be pure noise.
+	if hadPrev {
+		s.recordHeartbeatTransitions(&prevEntry, &entry)
+	} else {
+		s.recordTimeline(entry.ID, TimelineCameOnline, "hive registered with the hub for the first time", "")
+	}
 
 	s.requestSave()
 
@@ -976,8 +1005,9 @@ func (s *HubServer) consumePendingGitHubAppConfig(hiveID string) *HeartbeatGitHu
 
 func (s *HubServer) handleRegistry(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
-	s.markStaleHives()
+	offlineEvents := s.markStaleHives()
 	s.mu.Unlock()
+	s.flushOfflineEvents(offlineEvents)
 	s.mu.RLock()
 	hostedNames := make(map[string]bool)
 	for _, h := range s.registry.Hives {
@@ -1162,8 +1192,9 @@ func (s *HubServer) computeFleetStats() FleetStats {
 
 func (s *HubServer) handleFleetStats(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
-	s.markStaleHives()
+	offlineEvents := s.markStaleHives()
 	s.mu.Unlock()
+	s.flushOfflineEvents(offlineEvents)
 
 	s.mu.RLock()
 	fs := s.computeFleetStats()
@@ -1232,8 +1263,16 @@ func (s *HubServer) handleHubVersion(w http.ResponseWriter, r *http.Request) {
 	w.Write(data)
 }
 
-func (s *HubServer) markStaleHives() {
+// markStaleHives flips Online off for hives that stopped beating and evicts
+// ones silent past staleRemoveAge.
+//
+// It runs with s.mu held, so it does no I/O: online→offline transitions are
+// COLLECTED and returned, and the caller appends them to the timeline after
+// unlocking (see flushOfflineEvents). This is the only place a hive going
+// offline can be observed — a silent hive by definition sends no heartbeat.
+func (s *HubServer) markStaleHives() []offlineSweepEvent {
 	now := time.Now()
+	var offline []offlineSweepEvent
 	kept := s.registry.Hives[:0]
 	for i := range s.registry.Hives {
 		if s.registry.Hives[i].LastHeartbeat == "" {
@@ -1252,10 +1291,15 @@ func (s *HubServer) markStaleHives() {
 			s.logger.Info("removing stale hive", "id", s.registry.Hives[i].ID, "last_heartbeat", s.registry.Hives[i].LastHeartbeat)
 			continue
 		}
+		wasOnline := s.registry.Hives[i].Online
 		s.registry.Hives[i].Online = age <= maxHeartbeatAge
+		if wasOnline && !s.registry.Hives[i].Online {
+			offline = append(offline, offlineEventFor(&s.registry.Hives[i], age))
+		}
 		kept = append(kept, s.registry.Hives[i])
 	}
 	s.registry.Hives = kept
+	return offline
 }
 
 func (s *HubServer) mergeLeaderboards() []LeaderboardEntry {

--- a/v2/pkg/hub/timeline.go
+++ b/v2/pkg/hub/timeline.go
@@ -1,0 +1,573 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Per-hive activity timeline.
+//
+// Debugging "why is hive X stuck?" used to mean shelling into a cluster and
+// reading `kubectl logs`. A hive restart-looped for hours because it was
+// pinned to an immutable image tag; another sat "upgrading" forever because
+// the hub could not reach its cluster; a third silently rejected a user.
+// Every one of those had a signal the hub ALREADY receives on the heartbeat —
+// it was just never recorded.
+//
+// This is an append-only, bounded, per-hive event store. It records state
+// TRANSITIONS, not heartbeats: at ~2 min per beat and 42 hives, writing an
+// event per beat would be 30k events/day of pure noise. An event is emitted
+// only when a watched field actually changes.
+
+// timelineMaxEvents caps the number of events retained per hive. Oldest are
+// pruned first. This store lives on the hub PVC, so it must not grow without
+// limit: 200 events is deep enough to cover several weeks of a normally quiet
+// hive (these are transitions, not heartbeats), and a fully-saturated hive
+// file measures ~37 KB — so the whole 42-hive fleet is bounded at ~1.5 MB
+// even in the worst case where every hive is maxed out.
+const timelineMaxEvents = 200
+
+// timelineMaxDetailRunes bounds a single event's human-readable detail
+// string. Details are built from spoke-reported (i.e. untrusted) values such
+// as SHAs, branch names and health check names, so they are both length- and
+// content-bounded before they are ever persisted.
+const timelineMaxDetailRunes = 300
+
+// timelineAgentCountDelta is the minimum change in running agent count that
+// is considered material enough to record. Agent counts oscillate by one as
+// tasks start and finish; recording every ±1 would drown the timeline. A
+// jump of this size or more indicates a real capacity change (scale-up, mass
+// crash, governor mode flip).
+const timelineAgentCountDelta = 3
+
+// timelineRestartSlack absorbs clock skew and RFC3339 second-truncation when
+// comparing a spoke's reported StartedAt across heartbeats. A StartedAt that
+// moves forward by more than this means the process actually restarted.
+const timelineRestartSlack = 30 * time.Second
+
+// timelineUpgradeStaleAfter is how long a hive may sit with Upgrading=true
+// before the timeline records that the upgrade went stale. It matches the
+// hub's own staleUpgradeTimeout so the timeline and the recovery logic agree
+// on what "stuck" means.
+const timelineUpgradeStaleAfter = staleUpgradeTimeout
+
+// Event kinds. Stable strings — they are persisted and rendered in the UI.
+const (
+	TimelineVersionChanged   = "version_changed"
+	TimelineBranchChanged    = "branch_changed"
+	TimelineWentOffline      = "went_offline"
+	TimelineCameOnline       = "came_online"
+	TimelineHealthChanged    = "health_changed"
+	TimelineUpgradeStarted   = "upgrade_started"
+	TimelineUpgradeCompleted = "upgrade_completed"
+	TimelineUpgradeStale     = "upgrade_stale"
+	TimelineRestarted        = "restarted"
+	TimelineACMMChanged      = "acmm_changed"
+	TimelineAgentsChanged    = "agents_changed"
+	TimelineGitHubAppChanged = "github_app_changed"
+	TimelineAccess           = "access"
+	TimelineOwnership        = "ownership"
+	TimelineAdmin            = "admin"
+)
+
+// timelineDir is the directory holding one JSON file per hive. It follows the
+// existing /data/saas conventions (PVC-backed, atomic tmp+rename writes).
+// var, not const, so tests can redirect it.
+var timelineDir = "/data/saas/timeline"
+
+// TimelineEvent is one recorded state transition.
+type TimelineEvent struct {
+	TS     string `json:"ts"`              // RFC3339 UTC
+	Kind   string `json:"kind"`            // one of the Timeline* constants
+	Detail string `json:"detail"`          // human-readable, pre-sanitized
+	Actor  string `json:"actor,omitempty"` // GitHub username for human-initiated events
+}
+
+// hiveTimeline is the on-disk shape: an append-only, capped event list.
+type hiveTimeline struct {
+	HiveID string          `json:"hiveId"`
+	Events []TimelineEvent `json:"events"`
+}
+
+// timelineStore holds every hive's timeline in memory and mirrors it to disk.
+//
+// It owns its OWN mutex, and that mutex is a LEAF: nothing acquired under it
+// ever reaches back for HubServer.mu. Callers likewise append only after
+// releasing s.mu — re-locking a non-reentrant mutex from the heartbeat path
+// has deadlocked hub startup before, and persist() does file I/O that would
+// otherwise serialize every heartbeat in the fleet behind one disk write.
+type timelineStore struct {
+	mu   sync.RWMutex
+	byID map[string][]TimelineEvent
+}
+
+func newTimelineStore() *timelineStore {
+	return &timelineStore{byID: make(map[string][]TimelineEvent)}
+}
+
+// timelinePath returns the on-disk path for a hive, or "" if the hive ID is
+// not a safe filename. Hive IDs arrive over the heartbeat, so a traversal
+// attempt must never reach the filesystem.
+func timelinePath(hiveID string) string {
+	if hiveID == "" || !isValidName(hiveID) ||
+		strings.Contains(hiveID, "..") || strings.ContainsAny(hiveID, `/\`) {
+		return ""
+	}
+	return filepath.Join(timelineDir, hiveID+".json")
+}
+
+// truncateDetail bounds a detail string so a hostile spoke cannot inflate the
+// store. Values are already sanitized upstream by sanitizeHeartbeatField;
+// this is the belt to that suspenders.
+func truncateDetail(s string) string {
+	s = strings.TrimSpace(s)
+	if r := []rune(s); len(r) > timelineMaxDetailRunes {
+		return string(r[:timelineMaxDetailRunes]) + "…"
+	}
+	return s
+}
+
+// append records one event for a hive, prunes to the retention cap
+// (oldest-first) and persists. Safe to call from many goroutines.
+func (t *timelineStore) append(hiveID, kind, detail, actor string) {
+	if hiveID == "" || kind == "" {
+		return
+	}
+	ev := TimelineEvent{
+		TS:     time.Now().UTC().Format(time.RFC3339),
+		Kind:   kind,
+		Detail: truncateDetail(detail),
+		Actor:  truncateDetail(actor),
+	}
+
+	t.mu.Lock()
+	events := append(t.byID[hiveID], ev)
+	if len(events) > timelineMaxEvents {
+		// Prune oldest first. Copy into a fresh slice so the pruned prefix is
+		// not retained by the backing array.
+		trimmed := make([]TimelineEvent, timelineMaxEvents)
+		copy(trimmed, events[len(events)-timelineMaxEvents:])
+		events = trimmed
+	}
+	t.byID[hiveID] = events
+	snapshot := make([]TimelineEvent, len(events))
+	copy(snapshot, events)
+	t.mu.Unlock()
+
+	t.persist(hiveID, snapshot)
+}
+
+// appendAll records a batch of events under a single lock acquisition. Used
+// by the heartbeat hook, which frequently produces several transitions at
+// once (e.g. came online + version changed + upgrade completed).
+func (t *timelineStore) appendAll(hiveID string, evs []TimelineEvent) {
+	if hiveID == "" || len(evs) == 0 {
+		return
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	t.mu.Lock()
+	events := t.byID[hiveID]
+	for _, ev := range evs {
+		if ev.Kind == "" {
+			continue
+		}
+		ev.TS = now
+		ev.Detail = truncateDetail(ev.Detail)
+		ev.Actor = truncateDetail(ev.Actor)
+		events = append(events, ev)
+	}
+	if len(events) > timelineMaxEvents {
+		trimmed := make([]TimelineEvent, timelineMaxEvents)
+		copy(trimmed, events[len(events)-timelineMaxEvents:])
+		events = trimmed
+	}
+	t.byID[hiveID] = events
+	snapshot := make([]TimelineEvent, len(events))
+	copy(snapshot, events)
+	t.mu.Unlock()
+
+	t.persist(hiveID, snapshot)
+}
+
+// recent returns up to n events for a hive, newest first. Never returns nil.
+func (t *timelineStore) recent(hiveID string, n int) []TimelineEvent {
+	t.mu.RLock()
+	events := t.byID[hiveID]
+	t.mu.RUnlock()
+
+	if n <= 0 || n > len(events) {
+		n = len(events)
+	}
+	out := make([]TimelineEvent, 0, n)
+	for i := len(events) - 1; i >= len(events)-n; i-- {
+		out = append(out, events[i])
+	}
+	return out
+}
+
+// persist writes a hive's timeline atomically (tmp+rename), matching the
+// other /data/saas state files. Failures are logged by the caller's absence
+// of a return value only — a timeline write must never fail a heartbeat.
+func (t *timelineStore) persist(hiveID string, events []TimelineEvent) {
+	path := timelinePath(hiveID)
+	if path == "" {
+		return
+	}
+	if err := os.MkdirAll(timelineDir, 0o755); err != nil {
+		return
+	}
+	data, err := json.MarshalIndent(hiveTimeline{HiveID: hiveID, Events: events}, "", "  ")
+	if err != nil {
+		return
+	}
+	tmpPath := path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+	}
+}
+
+// load reads every persisted timeline back into memory at hub startup, so a
+// hub restart does not blank the history users are trying to debug with.
+func (t *timelineStore) load() {
+	entries, err := os.ReadDir(timelineDir)
+	if err != nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(timelineDir, name))
+		if err != nil {
+			continue
+		}
+		var tl hiveTimeline
+		if json.Unmarshal(data, &tl) != nil || tl.HiveID == "" {
+			continue
+		}
+		events := tl.Events
+		if len(events) > timelineMaxEvents {
+			events = events[len(events)-timelineMaxEvents:]
+		}
+		t.byID[tl.HiveID] = events
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Transition detection
+// ---------------------------------------------------------------------------
+
+// healthStatus extracts the coarse status string from a heartbeat health map.
+// The spoke reports health as a free-form map; "status" is the field the
+// dashboard already keys on.
+func healthStatus(h map[string]any) string {
+	if h == nil {
+		return ""
+	}
+	if v, ok := h["status"].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// flippedHealthChecks names the individual checks whose boolean/string value
+// differs between two health maps. Returned sorted so the detail string is
+// deterministic (map iteration order is not).
+func flippedHealthChecks(oldH, newH map[string]any) []string {
+	if oldH == nil || newH == nil {
+		return nil
+	}
+	var flipped []string
+	for k, nv := range newH {
+		if k == "status" {
+			continue
+		}
+		ov, present := oldH[k]
+		if !present {
+			continue
+		}
+		// Only compare scalars; nested structures are noisy and change shape.
+		switch nv.(type) {
+		case bool, string, float64:
+			if fmt.Sprintf("%v", ov) != fmt.Sprintf("%v", nv) {
+				flipped = append(flipped, k)
+			}
+		}
+	}
+	sort.Strings(flipped)
+	return flipped
+}
+
+// absInt returns the absolute value of an int.
+func absInt(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
+}
+
+// detectTransitions compares the previously-registered entry against the one
+// just built from a heartbeat and returns the events worth recording.
+//
+// It is a PURE function: no locks, no I/O, no clock beyond `now`. That is
+// what makes it callable from inside the heartbeat's existing s.mu critical
+// section without any risk of lock re-entrancy, and what makes it directly
+// table-testable.
+func detectTransitions(old, new *RegistryEntry, now time.Time) []TimelineEvent {
+	if old == nil || new == nil {
+		return nil
+	}
+	var evs []TimelineEvent
+	add := func(kind, detail string) {
+		evs = append(evs, TimelineEvent{Kind: kind, Detail: detail})
+	}
+
+	// Offline → online. The registry marks Online=false from markStaleHives;
+	// a heartbeat arriving at all means the hive is back.
+	if !old.Online && new.Online {
+		add(TimelineCameOnline, "hive resumed reporting to the hub")
+	}
+
+	// Restart: the spoke's own reported process start time moved forward.
+	// This is the tell for a crash-looping hive that otherwise reads healthy.
+	if old.StartedAt != "" && new.StartedAt != "" && old.StartedAt != new.StartedAt {
+		oldT, errOld := time.Parse(time.RFC3339, old.StartedAt)
+		newT, errNew := time.Parse(time.RFC3339, new.StartedAt)
+		if errOld == nil && errNew == nil && newT.Sub(oldT) > timelineRestartSlack {
+			add(TimelineRestarted, fmt.Sprintf("process restarted (up %s, previously started %s)",
+				shortDur(now.Sub(newT)), old.StartedAt))
+		}
+	}
+
+	// Version / SHA.
+	if old.GitHash != "" && new.GitHash != "" && !sameCommit(old.GitHash, new.GitHash) {
+		detail := fmt.Sprintf("version %s → %s", old.GitHash, new.GitHash)
+		if old.Version != new.Version && new.Version != "" {
+			detail += fmt.Sprintf(" (%s → %s)", old.Version, new.Version)
+		}
+		add(TimelineVersionChanged, detail)
+	}
+
+	// Branch.
+	if old.GitBranch != "" && new.GitBranch != "" && old.GitBranch != new.GitBranch {
+		add(TimelineBranchChanged, fmt.Sprintf("branch %s → %s", old.GitBranch, new.GitBranch))
+	}
+
+	// Upgrade lifecycle. new.Upgrading is already reconciled by the heartbeat
+	// handler against the target SHA before this runs.
+	switch {
+	case !old.Upgrading && new.Upgrading:
+		target := new.UpgradeTarget
+		if target == "" {
+			target = "latest"
+		}
+		add(TimelineUpgradeStarted, fmt.Sprintf("upgrade started → %s", target))
+	case old.Upgrading && !new.Upgrading:
+		if new.GitHash != "" && !sameCommit(old.GitHash, new.GitHash) {
+			add(TimelineUpgradeCompleted, fmt.Sprintf("upgrade completed at %s", new.GitHash))
+		} else {
+			add(TimelineUpgradeCompleted, "upgrade cleared")
+		}
+	case old.Upgrading && new.Upgrading && !old.UpgradeStartedAt.IsZero():
+		// Still upgrading. Record staleness EXACTLY once, at the crossing:
+		// the previous heartbeat was inside the window and this one is not.
+		elapsed := now.Sub(old.UpgradeStartedAt)
+		if elapsed > timelineUpgradeStaleAfter {
+			prev := now.Sub(old.UpgradeStartedAt) - heartbeatStalePollWindow
+			if prev <= timelineUpgradeStaleAfter {
+				target := new.UpgradeTarget
+				if target == "" {
+					target = "latest"
+				}
+				add(TimelineUpgradeStale, fmt.Sprintf(
+					"upgrade to %s has been in flight for %s with no version change — the hive may be unreachable or pinned to an immutable tag",
+					target, shortDur(elapsed)))
+			}
+		}
+	}
+
+	// Health status, plus which individual check flipped.
+	oldStatus, newStatus := healthStatus(old.Health), healthStatus(new.Health)
+	if oldStatus != newStatus && (oldStatus != "" || newStatus != "") {
+		detail := fmt.Sprintf("health %s → %s", orDash(oldStatus), orDash(newStatus))
+		if flipped := flippedHealthChecks(old.Health, new.Health); len(flipped) > 0 {
+			detail += " (changed: " + strings.Join(flipped, ", ") + ")"
+		}
+		add(TimelineHealthChanged, detail)
+	}
+
+	// ACMM level.
+	if old.ACMMLevel != new.ACMMLevel {
+		add(TimelineACMMChanged, fmt.Sprintf("ACMM level %d → %d", old.ACMMLevel, new.ACMMLevel))
+	}
+
+	// Agent count — only material moves.
+	if absInt(new.AgentCount-old.AgentCount) >= timelineAgentCountDelta {
+		add(TimelineAgentsChanged, fmt.Sprintf("running agents %d → %d", old.AgentCount, new.AgentCount))
+	}
+
+	// GitHub App: permission issue appeared or cleared, install completed.
+	if old.GitHubAppPermIssue != new.GitHubAppPermIssue {
+		if new.GitHubAppPermIssue == "" {
+			add(TimelineGitHubAppChanged, "GitHub App permission issue cleared")
+		} else {
+			add(TimelineGitHubAppChanged, "GitHub App permission issue: "+new.GitHubAppPermIssue)
+		}
+	}
+	if old.PendingGitHubAppInstall && !new.PendingGitHubAppInstall {
+		add(TimelineGitHubAppChanged, "GitHub App install completed")
+	} else if !old.PendingGitHubAppInstall && new.PendingGitHubAppInstall {
+		add(TimelineGitHubAppChanged, "GitHub App install pending — the App is not yet installed on the org")
+	}
+	if old.GitHubAppRequired != new.GitHubAppRequired {
+		if new.GitHubAppRequired {
+			add(TimelineGitHubAppChanged, "hive now requires a GitHub App install")
+		} else {
+			add(TimelineGitHubAppChanged, "GitHub App requirement satisfied")
+		}
+	}
+
+	return evs
+}
+
+// heartbeatStalePollWindow is the assumed spacing between two consecutive
+// heartbeats from the same hive. It is used only to fire the "upgrade went
+// stale" event once, on the beat that first crosses the threshold, instead of
+// on every beat thereafter. Spokes beat every ~2 min; maxHeartbeatAge is the
+// hub's own tolerance for that spacing and is reused here so the two never
+// disagree.
+const heartbeatStalePollWindow = maxHeartbeatAge
+
+// orDash renders an empty string as an em dash for readability.
+func orDash(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
+}
+
+// shortDur renders a duration as a compact human string ("3m", "2h", "4d").
+func shortDur(d time.Duration) string {
+	if d < 0 {
+		d = -d
+	}
+	const hoursPerDay = 24
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < hoursPerDay*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours())/hoursPerDay)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HubServer hooks
+// ---------------------------------------------------------------------------
+
+// recordTimeline appends a single human-initiated event. Call it alongside
+// the existing `audit:` log lines — the log answers "what did the hub do",
+// the timeline answers "what happened to this hive".
+//
+// Never call this while holding s.mu: it performs a file write. The timeline
+// store has its own leaf lock, but the I/O would serialize whatever s.mu is
+// protecting.
+func (s *HubServer) recordTimeline(hiveID, kind, detail, actor string) {
+	if s == nil || s.timeline == nil {
+		return
+	}
+	s.timeline.append(hiveID, kind, detail, actor)
+}
+
+// recordHeartbeatTransitions is the heartbeat hook. `old` is the registry
+// entry as it stood before this beat, `new` is the entry that replaced it.
+//
+// Call it AFTER s.mu.Unlock(): detectTransitions is pure, but the append that
+// follows writes a file, and s.mu is a write lock held across the entire
+// registry scan — doing I/O under it would serialize every heartbeat in the
+// fleet behind one disk write.
+func (s *HubServer) recordHeartbeatTransitions(old, new *RegistryEntry) {
+	if s == nil || s.timeline == nil {
+		return
+	}
+	evs := detectTransitions(old, new, time.Now())
+	if len(evs) == 0 {
+		return
+	}
+	s.timeline.appendAll(new.ID, evs)
+}
+
+// recordOfflineTransitions is the sweep hook. markStaleHives flips Online to
+// false for hives that stopped beating; that transition can only be observed
+// there, because a hive that has gone silent by definition sends no
+// heartbeat to observe it on.
+//
+// markStaleHives runs with s.mu held, so this only COLLECTS the events; the
+// caller drains and appends them after unlocking. See offlineSweepEvent.
+type offlineSweepEvent struct {
+	HiveID string
+	Detail string
+}
+
+// offlineEventFor builds the went-offline event for a hive whose heartbeat
+// just aged past maxHeartbeatAge. Pure — safe to call under s.mu.
+func offlineEventFor(h *RegistryEntry, age time.Duration) offlineSweepEvent {
+	return offlineSweepEvent{
+		HiveID: h.ID,
+		Detail: fmt.Sprintf("no heartbeat for %s — last seen %s", shortDur(age), orDash(h.LastHeartbeat)),
+	}
+}
+
+// flushOfflineEvents appends collected went-offline events. Call AFTER
+// releasing s.mu.
+func (s *HubServer) flushOfflineEvents(evs []offlineSweepEvent) {
+	if s == nil || s.timeline == nil {
+		return
+	}
+	for _, e := range evs {
+		s.timeline.append(e.HiveID, TimelineWentOffline, e.Detail, "")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// API
+// ---------------------------------------------------------------------------
+
+// handleHiveTimeline serves GET /api/saas/hives/{id}/timeline.
+//
+// Authorization is deliberately IDENTICAL to the existing per-hive endpoints
+// (handleAccessList et al): the hive's owner, or the hub admin. No new
+// authorization rule is introduced here.
+func (s *HubServer) handleHiveTimeline(w http.ResponseWriter, r *http.Request) {
+	hiveID := r.PathValue("id")
+	username := s.getAuthUser(r)
+	h := loadSaaSHive(hiveID)
+	if h == nil {
+		http.Error(w, `{"error":"hive not found"}`, http.StatusNotFound)
+		return
+	}
+	if h.Owner != username && username != hubAdminUsername {
+		http.Error(w, `{"error":"only the owner can view this hive's timeline"}`, http.StatusForbidden)
+		return
+	}
+	events := s.timeline.recent(hiveID, timelineMaxEvents)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"events": events})
+}

--- a/v2/pkg/hub/timeline_test.go
+++ b/v2/pkg/hub/timeline_test.go
@@ -1,0 +1,637 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// hasKind reports whether evs contains an event of the given kind.
+func hasKind(evs []TimelineEvent, kind string) bool {
+	for _, e := range evs {
+		if e.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func kindsOf(evs []TimelineEvent) []string {
+	out := make([]string, 0, len(evs))
+	for _, e := range evs {
+		out = append(out, e.Kind)
+	}
+	return out
+}
+
+func TestDetectTransitions(t *testing.T) {
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+
+	// A baseline "steady state" entry. Cases mutate a copy of it.
+	base := func() RegistryEntry {
+		return RegistryEntry{
+			ID:         "hosted-demo",
+			Online:     true,
+			GitHash:    "aaaaaaa",
+			GitBranch:  "v2",
+			Version:    "1.0.0",
+			ACMMLevel:  3,
+			AgentCount: 4,
+			StartedAt:  now.Add(-2 * time.Hour).Format(time.RFC3339),
+			Health:     map[string]any{"status": "ok", "disk": true},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		mutate    func(old, new *RegistryEntry)
+		wantKinds []string
+		wantNone  bool
+		detailHas string
+	}{
+		{
+			name:     "identical entries emit nothing",
+			mutate:   func(old, new *RegistryEntry) {},
+			wantNone: true,
+		},
+		{
+			name: "unchanged SHA with new heartbeat emits nothing",
+			mutate: func(old, new *RegistryEntry) {
+				new.LastHeartbeat = now.Format(time.RFC3339)
+				new.TotalTokens24h = 12345 // noisy field, deliberately not watched
+			},
+			wantNone: true,
+		},
+		{
+			name: "version change",
+			mutate: func(old, new *RegistryEntry) {
+				new.GitHash = "bbbbbbb"
+				new.Version = "1.1.0"
+			},
+			wantKinds: []string{TimelineVersionChanged},
+			detailHas: "aaaaaaa → bbbbbbb",
+		},
+		{
+			name: "same commit at different SHA lengths is not a change",
+			mutate: func(old, new *RegistryEntry) {
+				new.GitHash = "aaaaaaa1234567"
+			},
+			wantNone: true,
+		},
+		{
+			name: "branch switch",
+			mutate: func(old, new *RegistryEntry) {
+				new.GitBranch = "v3"
+			},
+			wantKinds: []string{TimelineBranchChanged},
+			detailHas: "v2 → v3",
+		},
+		{
+			name: "came back online",
+			mutate: func(old, new *RegistryEntry) {
+				old.Online = false
+			},
+			wantKinds: []string{TimelineCameOnline},
+		},
+		{
+			name: "health degraded names the flipped check",
+			mutate: func(old, new *RegistryEntry) {
+				new.Health = map[string]any{"status": "degraded", "disk": false}
+			},
+			wantKinds: []string{TimelineHealthChanged},
+			detailHas: "changed: disk",
+		},
+		{
+			name: "health check flip without status change emits nothing",
+			mutate: func(old, new *RegistryEntry) {
+				new.Health = map[string]any{"status": "ok", "disk": false}
+			},
+			wantNone: true,
+		},
+		{
+			name: "upgrade started",
+			mutate: func(old, new *RegistryEntry) {
+				new.Upgrading = true
+				new.UpgradeTarget = "ccccccc"
+			},
+			wantKinds: []string{TimelineUpgradeStarted},
+			detailHas: "ccccccc",
+		},
+		{
+			name: "upgrade completed at new SHA",
+			mutate: func(old, new *RegistryEntry) {
+				old.Upgrading = true
+				old.UpgradeTarget = "ccccccc"
+				new.GitHash = "ccccccc"
+			},
+			wantKinds: []string{TimelineVersionChanged, TimelineUpgradeCompleted},
+			detailHas: "upgrade completed at ccccccc",
+		},
+		{
+			name: "upgrade stale fires once at the crossing",
+			mutate: func(old, new *RegistryEntry) {
+				old.Upgrading = true
+				old.UpgradeTarget = "ccccccc"
+				old.UpgradeStartedAt = now.Add(-timelineUpgradeStaleAfter - time.Minute)
+				new.Upgrading = true
+				new.UpgradeTarget = "ccccccc"
+			},
+			wantKinds: []string{TimelineUpgradeStale},
+			detailHas: "in flight",
+		},
+		{
+			name: "upgrade long past stale does not re-fire",
+			mutate: func(old, new *RegistryEntry) {
+				old.Upgrading = true
+				old.UpgradeTarget = "ccccccc"
+				// Well past the crossing window — already reported.
+				old.UpgradeStartedAt = now.Add(-timelineUpgradeStaleAfter - 10*heartbeatStalePollWindow)
+				new.Upgrading = true
+				new.UpgradeTarget = "ccccccc"
+			},
+			wantNone: true,
+		},
+		{
+			name: "upgrade in flight but not yet stale",
+			mutate: func(old, new *RegistryEntry) {
+				old.Upgrading = true
+				old.UpgradeTarget = "ccccccc"
+				old.UpgradeStartedAt = now.Add(-time.Minute)
+				new.Upgrading = true
+				new.UpgradeTarget = "ccccccc"
+			},
+			wantNone: true,
+		},
+		{
+			name: "restart detected when StartedAt moves forward",
+			mutate: func(old, new *RegistryEntry) {
+				new.StartedAt = now.Add(-1 * time.Minute).Format(time.RFC3339)
+			},
+			wantKinds: []string{TimelineRestarted},
+			detailHas: "process restarted",
+		},
+		{
+			name: "StartedAt jitter within slack is not a restart",
+			mutate: func(old, new *RegistryEntry) {
+				oldT, _ := time.Parse(time.RFC3339, old.StartedAt)
+				new.StartedAt = oldT.Add(timelineRestartSlack / 2).Format(time.RFC3339)
+			},
+			wantNone: true,
+		},
+		{
+			name: "ACMM level change",
+			mutate: func(old, new *RegistryEntry) {
+				new.ACMMLevel = 4
+			},
+			wantKinds: []string{TimelineACMMChanged},
+			detailHas: "3 → 4",
+		},
+		{
+			name: "agent count moves materially",
+			mutate: func(old, new *RegistryEntry) {
+				new.AgentCount = old.AgentCount + timelineAgentCountDelta
+			},
+			wantKinds: []string{TimelineAgentsChanged},
+		},
+		{
+			name: "agent count jitter below threshold is ignored",
+			mutate: func(old, new *RegistryEntry) {
+				new.AgentCount = old.AgentCount + timelineAgentCountDelta - 1
+			},
+			wantNone: true,
+		},
+		{
+			name: "github app permission issue appears",
+			mutate: func(old, new *RegistryEntry) {
+				new.GitHubAppPermIssue = "missing contents:write"
+			},
+			wantKinds: []string{TimelineGitHubAppChanged},
+			detailHas: "missing contents:write",
+		},
+		{
+			name: "github app permission issue clears",
+			mutate: func(old, new *RegistryEntry) {
+				old.GitHubAppPermIssue = "missing contents:write"
+			},
+			wantKinds: []string{TimelineGitHubAppChanged},
+			detailHas: "cleared",
+		},
+		{
+			name: "github app install completes",
+			mutate: func(old, new *RegistryEntry) {
+				old.PendingGitHubAppInstall = true
+			},
+			wantKinds: []string{TimelineGitHubAppChanged},
+			detailHas: "install completed",
+		},
+		{
+			name: "several transitions on one beat",
+			mutate: func(old, new *RegistryEntry) {
+				old.Online = false
+				new.GitHash = "ddddddd"
+				new.ACMMLevel = 5
+			},
+			wantKinds: []string{TimelineCameOnline, TimelineVersionChanged, TimelineACMMChanged},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			old, new := base(), base()
+			tc.mutate(&old, &new)
+			got := detectTransitions(&old, &new, now)
+
+			if tc.wantNone {
+				if len(got) != 0 {
+					t.Fatalf("expected no events, got %v", kindsOf(got))
+				}
+				return
+			}
+			for _, want := range tc.wantKinds {
+				if !hasKind(got, want) {
+					t.Errorf("missing event kind %q; got %v", want, kindsOf(got))
+				}
+			}
+			if tc.detailHas != "" {
+				found := false
+				for _, e := range got {
+					if strings.Contains(e.Detail, tc.detailHas) {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("no event detail contained %q; got %+v", tc.detailHas, got)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectTransitionsNilSafe(t *testing.T) {
+	e := &RegistryEntry{ID: "x"}
+	if got := detectTransitions(nil, e, time.Now()); got != nil {
+		t.Errorf("nil old should yield nil, got %v", kindsOf(got))
+	}
+	if got := detectTransitions(e, nil, time.Now()); got != nil {
+		t.Errorf("nil new should yield nil, got %v", kindsOf(got))
+	}
+	if got := detectTransitions(nil, nil, time.Now()); got != nil {
+		t.Errorf("both nil should yield nil, got %v", kindsOf(got))
+	}
+}
+
+func TestFlippedHealthChecksNilSafe(t *testing.T) {
+	if got := flippedHealthChecks(nil, map[string]any{"a": true}); got != nil {
+		t.Errorf("nil old health should yield nil, got %v", got)
+	}
+	if got := flippedHealthChecks(map[string]any{"a": true}, nil); got != nil {
+		t.Errorf("nil new health should yield nil, got %v", got)
+	}
+	// Deterministic ordering: map iteration order must not leak into details.
+	oldH := map[string]any{"status": "ok", "zeta": true, "alpha": true, "mid": "up"}
+	newH := map[string]any{"status": "bad", "zeta": false, "alpha": false, "mid": "down"}
+	got := flippedHealthChecks(oldH, newH)
+	want := []string{"alpha", "mid", "zeta"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v (sorted)", got, want)
+		}
+	}
+}
+
+func TestTimelineRetentionPruning(t *testing.T) {
+	tests := []struct {
+		name       string
+		appendN    int
+		wantStored int
+		// wantOldest is the detail of the oldest surviving event.
+		wantOldest string
+		wantNewest string
+	}{
+		{
+			name:       "under the cap keeps everything",
+			appendN:    10,
+			wantStored: 10,
+			wantOldest: "event-0",
+			wantNewest: "event-9",
+		},
+		{
+			name:       "exactly at the cap keeps everything",
+			appendN:    timelineMaxEvents,
+			wantStored: timelineMaxEvents,
+			wantOldest: "event-0",
+			wantNewest: fmt.Sprintf("event-%d", timelineMaxEvents-1),
+		},
+		{
+			name:       "over the cap prunes oldest first",
+			appendN:    timelineMaxEvents + 50,
+			wantStored: timelineMaxEvents,
+			wantOldest: "event-50",
+			wantNewest: fmt.Sprintf("event-%d", timelineMaxEvents+49),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			origDir := timelineDir
+			timelineDir = dir
+			defer func() { timelineDir = origDir }()
+
+			ts := newTimelineStore()
+			for i := 0; i < tc.appendN; i++ {
+				ts.append("hosted-prune", TimelineVersionChanged, fmt.Sprintf("event-%d", i), "")
+			}
+
+			// recent() returns newest first.
+			got := ts.recent("hosted-prune", timelineMaxEvents*2)
+			if len(got) != tc.wantStored {
+				t.Fatalf("stored %d events, want %d", len(got), tc.wantStored)
+			}
+			if got[0].Detail != tc.wantNewest {
+				t.Errorf("newest = %q, want %q", got[0].Detail, tc.wantNewest)
+			}
+			if got[len(got)-1].Detail != tc.wantOldest {
+				t.Errorf("oldest = %q, want %q", got[len(got)-1].Detail, tc.wantOldest)
+			}
+
+			// The persisted file must respect the same cap — this is the PVC
+			// growth bound, not just an in-memory one.
+			data, err := os.ReadFile(filepath.Join(dir, "hosted-prune.json"))
+			if err != nil {
+				t.Fatalf("timeline not persisted: %v", err)
+			}
+			var tl hiveTimeline
+			if err := json.Unmarshal(data, &tl); err != nil {
+				t.Fatalf("persisted timeline is not valid JSON: %v", err)
+			}
+			if len(tl.Events) != tc.wantStored {
+				t.Errorf("persisted %d events, want %d", len(tl.Events), tc.wantStored)
+			}
+		})
+	}
+}
+
+func TestTimelineAppendAllPrunes(t *testing.T) {
+	dir := t.TempDir()
+	origDir := timelineDir
+	timelineDir = dir
+	defer func() { timelineDir = origDir }()
+
+	ts := newTimelineStore()
+	batch := make([]TimelineEvent, 0, timelineMaxEvents+20)
+	for i := 0; i < timelineMaxEvents+20; i++ {
+		batch = append(batch, TimelineEvent{Kind: TimelineACMMChanged, Detail: fmt.Sprintf("e-%d", i)})
+	}
+	ts.appendAll("hosted-batch", batch)
+
+	got := ts.recent("hosted-batch", timelineMaxEvents*2)
+	if len(got) != timelineMaxEvents {
+		t.Fatalf("stored %d, want cap %d", len(got), timelineMaxEvents)
+	}
+	if got[len(got)-1].Detail != "e-20" {
+		t.Errorf("oldest surviving = %q, want e-20", got[len(got)-1].Detail)
+	}
+	// Empty kinds must be skipped, not stored blank.
+	ts.appendAll("hosted-batch2", []TimelineEvent{{Kind: "", Detail: "ignored"}})
+	if n := len(ts.recent("hosted-batch2", 10)); n != 0 {
+		t.Errorf("empty-kind event was stored (%d events)", n)
+	}
+}
+
+func TestTimelinePersistRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	origDir := timelineDir
+	timelineDir = dir
+	defer func() { timelineDir = origDir }()
+
+	ts := newTimelineStore()
+	ts.append("hosted-rt", TimelineRestarted, "process restarted", "")
+	ts.append("hosted-rt", TimelineHealthChanged, "health ok → degraded", "")
+
+	// A fresh store loading from the same directory must see both events.
+	ts2 := newTimelineStore()
+	ts2.load()
+	got := ts2.recent("hosted-rt", timelineMaxEvents)
+	if len(got) != 2 {
+		t.Fatalf("reloaded %d events, want 2", len(got))
+	}
+	if got[0].Kind != TimelineHealthChanged {
+		t.Errorf("newest reloaded = %q, want %q", got[0].Kind, TimelineHealthChanged)
+	}
+	// No .tmp files should survive an atomic write.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("leftover temp file %s", e.Name())
+		}
+	}
+}
+
+func TestTimelinePathRejectsTraversal(t *testing.T) {
+	tests := []struct {
+		name   string
+		hiveID string
+		want   bool // want a non-empty path
+	}{
+		{"valid id", "hosted-demo-01", true},
+		{"valid with dots", "hosted.demo.01", true},
+		{"empty", "", false},
+		{"parent traversal", "..", false},
+		{"embedded traversal", "../../etc/passwd", false},
+		{"forward slash", "a/b", false},
+		{"backslash", `a\b`, false},
+		{"null-ish junk", "a\x00b", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := timelinePath(tc.hiveID)
+			if (got != "") != tc.want {
+				t.Errorf("timelinePath(%q) = %q, want non-empty=%v", tc.hiveID, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTimelineTruncatesDetail(t *testing.T) {
+	dir := t.TempDir()
+	origDir := timelineDir
+	timelineDir = dir
+	defer func() { timelineDir = origDir }()
+
+	ts := newTimelineStore()
+	long := strings.Repeat("x", timelineMaxDetailRunes*3)
+	ts.append("hosted-long", TimelineHealthChanged, long, long)
+
+	got := ts.recent("hosted-long", 1)
+	if len(got) != 1 {
+		t.Fatal("expected one event")
+	}
+	if r := []rune(got[0].Detail); len(r) > timelineMaxDetailRunes+1 {
+		t.Errorf("detail not truncated: %d runes", len(r))
+	}
+	if r := []rune(got[0].Actor); len(r) > timelineMaxDetailRunes+1 {
+		t.Errorf("actor not truncated: %d runes", len(r))
+	}
+}
+
+func TestTimelineConcurrentAppends(t *testing.T) {
+	dir := t.TempDir()
+	origDir := timelineDir
+	timelineDir = dir
+	defer func() { timelineDir = origDir }()
+
+	ts := newTimelineStore()
+	const goroutines = 16
+	const perGoroutine = 20
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				ts.append("hosted-race", TimelineVersionChanged, fmt.Sprintf("g%d-%d", g, i), "")
+				ts.recent("hosted-race", 10)
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	got := ts.recent("hosted-race", timelineMaxEvents*2)
+	if len(got) != timelineMaxEvents {
+		t.Errorf("got %d events, want cap %d", len(got), timelineMaxEvents)
+	}
+}
+
+func TestHandleHiveTimelineAuthorization(t *testing.T) {
+	dir := t.TempDir()
+	origTimelineDir, origHivesDir, origUsersDir := timelineDir, saasHivesDir, saasUsersDir
+	timelineDir = filepath.Join(dir, "timeline")
+	saasHivesDir = filepath.Join(dir, "hives")
+	saasUsersDir = filepath.Join(dir, "users")
+	defer func() {
+		timelineDir, saasHivesDir, saasUsersDir = origTimelineDir, origHivesDir, origUsersDir
+	}()
+
+	const hiveID = "hosted-authz"
+	const owner = "alice"
+	if err := saveSaaSHive(&SaaSHive{ID: hiveID, Owner: owner, Status: "running"}); err != nil {
+		t.Fatalf("saveSaaSHive: %v", err)
+	}
+	// getAuthUser only trusts the session cookie when a SaaS user record
+	// exists, so the identities under test must be real users.
+	for _, u := range []string{owner, hubAdminUsername, "mallory"} {
+		if err := saveSaaSUser(&SaaSUser{GitHubUsername: u, Hives: map[string]string{}}); err != nil {
+			t.Fatalf("saveSaaSUser(%s): %v", u, err)
+		}
+	}
+
+	s := &HubServer{
+		logger:   slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		timeline: newTimelineStore(),
+	}
+	s.timeline.append(hiveID, TimelineRestarted, "process restarted", "")
+
+	tests := []struct {
+		name     string
+		hiveID   string
+		user     string
+		wantCode int
+	}{
+		{"owner may read", hiveID, owner, http.StatusOK},
+		{"hub admin may read", hiveID, hubAdminUsername, http.StatusOK},
+		{"unrelated user is forbidden", hiveID, "mallory", http.StatusForbidden},
+		{"anonymous is forbidden", hiveID, "", http.StatusForbidden},
+		{"unknown hive is not found", "hosted-nope", owner, http.StatusNotFound},
+		{"unknown hive for admin is not found", "hosted-nope", hubAdminUsername, http.StatusNotFound},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/saas/hives/"+tc.hiveID+"/timeline", nil)
+			req.SetPathValue("id", tc.hiveID)
+			if tc.user != "" {
+				req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: tc.user})
+			}
+			rec := httptest.NewRecorder()
+			s.handleHiveTimeline(rec, req)
+
+			if rec.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d (body %s)", rec.Code, tc.wantCode, rec.Body.String())
+			}
+			if tc.wantCode != http.StatusOK {
+				return
+			}
+			var body struct {
+				Events []TimelineEvent `json:"events"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("bad JSON: %v", err)
+			}
+			if len(body.Events) != 1 || body.Events[0].Kind != TimelineRestarted {
+				t.Errorf("unexpected events: %+v", body.Events)
+			}
+		})
+	}
+}
+
+func TestRecordHeartbeatTransitionsNilStore(t *testing.T) {
+	// A HubServer without a timeline store (older constructor paths, tests)
+	// must not panic — the timeline is strictly additive.
+	s := &HubServer{}
+	s.recordHeartbeatTransitions(&RegistryEntry{ID: "x"}, &RegistryEntry{ID: "x", GitHash: "b"})
+	s.recordTimeline("x", TimelineAccess, "detail", "actor")
+	s.flushOfflineEvents([]offlineSweepEvent{{HiveID: "x", Detail: "d"}})
+}
+
+func TestMarkStaleHivesReportsOfflineOnce(t *testing.T) {
+	s := &HubServer{
+		logger:   slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		timeline: newTimelineStore(),
+	}
+	stale := time.Now().Add(-maxHeartbeatAge - time.Minute).UTC().Format(time.RFC3339)
+	s.registry.Hives = []RegistryEntry{
+		{ID: "hosted-a", Online: true, LastHeartbeat: stale},
+		{ID: "hosted-b", Online: true, LastHeartbeat: time.Now().UTC().Format(time.RFC3339)},
+	}
+
+	got := s.markStaleHives()
+	if len(got) != 1 || got[0].HiveID != "hosted-a" {
+		t.Fatalf("expected one offline event for hosted-a, got %+v", got)
+	}
+
+	// A second sweep must NOT re-report: the hive is already Online=false.
+	if got2 := s.markStaleHives(); len(got2) != 0 {
+		t.Errorf("offline re-reported on second sweep: %+v", got2)
+	}
+}
+
+func TestShortDur(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{5 * time.Second, "5s"},
+		{90 * time.Second, "1m"},
+		{3 * time.Hour, "3h"},
+		{50 * time.Hour, "2d"},
+		{-3 * time.Hour, "3h"},
+	}
+	for _, tc := range tests {
+		if got := shortDur(tc.d); got != tc.want {
+			t.Errorf("shortDur(%v) = %q, want %q", tc.d, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Debugging "why is hive X stuck?" currently means shelling into a cluster and reading `kubectl logs`. Real examples from one night: a hive restart-looped for hours because it was pinned to an immutable image tag; another sat "upgrading" forever because the hub couldn't reach its cluster; a third was silently rejecting a user. **Every one of those had signals the hub ALREADY receives on the heartbeat** — they were just never recorded or surfaced.

## What

An append-only, bounded, per-hive event store on the hub that records state **transitions**, not heartbeats. At ~2 min per beat across 42 hives, writing an event per beat would be ~30k events/day of pure noise. An event is written only when a watched field actually changes.

### Event types

| Kind | Fires when |
|---|---|
| `version_changed` | GitHash moves (upgrade landed) |
| `branch_changed` | GitBranch switches |
| `went_offline` / `came_online` | heartbeat goes stale / resumes |
| `health_changed` | health status flips — **names which check changed** |
| `upgrade_started` / `upgrade_completed` / `upgrade_stale` | upgrade lifecycle |
| `restarted` | StartedAt moved forward (the crash-loop tell) |
| `acmm_changed` | ACMM level moves |
| `agents_changed` | running agent count moves materially (±3) |
| `github_app_changed` | install completed/pending, permission issue appeared/cleared |
| `access` / `ownership` | grants, denials, revocations, assignment |

Deliberate **non**-events (all covered by tests): same commit reported at different SHA lengths, sub-threshold agent-count jitter, `StartedAt` clock skew within slack, individual health checks flipping without a status change, and an already-reported stale upgrade re-firing on every subsequent beat.

## Where it hooks

`handleHeartbeat` (`server.go`) snapshots the previous registry entry **inside** the existing `s.mu` critical section — the only place old and new coexist — but diffs and persists **after** unlocking. `s.mu` is a write lock held across the whole registry scan; file I/O under it would serialize every heartbeat in the fleet behind one disk write.

`detectTransitions` is a **pure function** (no locks, no I/O, injected clock). That's what makes the above safe and what makes it directly table-testable.

Offline transitions are *collected* (not written) inside `markStaleHives`, which runs under `s.mu`, and flushed by its four callers after unlocking. A hive going offline can only be observed there — a silent hive by definition sends no heartbeat to observe it on.

The timeline store's mutex is a **leaf**: nothing acquired under it ever reaches back for `s.mu`.

## Retention & storage

- `timelineMaxEvents = 200` per hive, pruned oldest-first, enforced both in memory and on disk.
- Persisted atomically (tmp+rename) under `/data/saas/timeline/<hiveID>.json`, matching the surrounding `/data/saas` conventions. Hive IDs are traversal-guarded before touching the filesystem.
- **Measured, not estimated**: a fully-saturated hive file is 37,450 bytes → **~1.5 MB for all 42 hives** in the worst case where every hive is maxed.
- Timelines reload at hub startup, so a hub restart doesn't blank the history you're trying to debug with.

## API & UI

`GET /api/saas/hives/{id}/timeline` — authorization is **identical** to the existing per-hive endpoints (`handleAccessList` et al): hive owner, or hub admin. No new authorization rule is introduced.

UI is an "Activity Timeline" item on the existing `⋮` row menu, opening a chronological newest-first panel with per-kind colour coding, human-readable descriptions and relative times. All user-controlled strings go through `esc()`; all iteration is nil-guarded.

## On the existing per-spoke audit log

Checked as asked. `pkg/dashboard/audit.go` is **entirely spoke-local** — it writes `/data/audit.jsonl` on the *spoke's* PVC and is served by the *spoke's* own dashboard at `GET /api/audit`, gated on the `X-Hive-Role` header. **The hub never receives any of it.** There is zero overlap with this store, and nothing here duplicates it.

## Verified vs assumed

**Verified:** `go build ./...`, `go vet ./pkg/hub/`, and the full `go test -timeout 480s ./pkg/hub/` suite all pass. The timeline + heartbeat tests also pass under `-race`. The 37 KB/1.5 MB storage figure was measured by saturating a real store and stat-ing the file, not estimated. `gofmt` clean on both new files (`saas.go`/`server.go` were already unformatted on v2 and were left that way rather than reformatted into a conflict).

**Assumed:** that `health["status"]` is the right coarse key to diff on — it's what the dashboard already keys on, but the spoke reports health as a free-form map, so an unusual spoke could carry its status elsewhere. Nested/non-scalar health values are deliberately not diffed (they change shape and would be noisy). The `±3` agent-count threshold and 200-event cap are judgement calls tuned for readability, not derived from production data — both are named constants and trivial to retune.

**Not verified:** no live-cluster run. Behaviour under a real 42-hive heartbeat load is reasoned about (and race-tested) rather than observed.

## Concurrency note

Diff is deliberately tight given the five other agents in `saas.go`: 164 lines across the two shared files, everything else in new `timeline.go` / `timeline_test.go`. Expect to rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)