### PR TITLE
✨ feat(hub): user-journey nudge system with escalating banners

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1658,7 +1658,13 @@ func main() {
 				m, rj, cv := fc.PRsMerged, fc.PRsRejected, fc.CVEsClosed
 				prsMerged, prsRejected, cvesClosed = &m, &rj, &cv
 			}
+			// Count agents with a method/model assigned for the hub's
+			// user-journey stage detection. Always a non-nil pointer from a
+			// spoke new enough to compute it, so the hub can distinguish
+			// "genuinely zero agents configured" from "old spoke, unknown".
+			agentsWithModel := agentMgr.CountAgentsWithModel()
 			return &hub.HeartbeatPayload{
+				AgentsWithModel: &agentsWithModel,
 				HiveID:      cfg.HiveID,
 				Org:         cfg.Project.Org,
 				AIAuthor:    cfg.Project.AIAuthor,

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -2593,6 +2593,42 @@ func (m *Manager) GetStatus(name string) (*AgentProcess, error) {
 	return &snap, nil
 }
 
+// CountAgentsWithModel returns how many agents have an effective method
+// (backend) or model assigned, resolving overrides ahead of config exactly as
+// the launcher does. Reported to the hub so it can tell whether this hive has
+// completed the "assign a method/model to an agent" adoption step.
+//
+// An agent counts if EITHER a backend or a model is set: "claude with the
+// default model" and "the governor's default backend pinned to a specific
+// model" are both real assignments. Values like "auto" and "default" are
+// deliberate routing selections, not absences, so they count too — only a
+// wholly empty backend AND model reads as unassigned.
+func (m *Manager) CountAgentsWithModel() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	count := 0
+	for _, a := range m.agents {
+		if a == nil {
+			continue
+		}
+		backend := a.Config.Backend
+		if a.BackendOverride != "" {
+			backend = a.BackendOverride
+		}
+		model := a.Config.Model
+		if a.ModelOverride != "" {
+			model = a.ModelOverride
+		} else if a.PinnedModel != "" {
+			model = a.PinnedModel
+		}
+		if strings.TrimSpace(backend) != "" || strings.TrimSpace(model) != "" {
+			count++
+		}
+	}
+	return count
+}
+
 func (m *Manager) AllStatuses() map[string]*AgentProcess {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -254,6 +254,17 @@ type HeartbeatPayload struct {
 	PRsMerged90d   *int `json:"prs_merged_90d,omitempty"`
 	PRsRejected90d *int `json:"prs_rejected_90d,omitempty"`
 	CVEsClosed     *int `json:"cves_closed,omitempty"`
+	// AgentsWithModel counts this hive's agents that have an effective method
+	// (backend) or model assigned — override first, then agent config, exactly
+	// as the launcher resolves it. The hub uses it for user-journey stage
+	// detection: a hive with zero configured agents has not yet completed the
+	// "assign a method/model to an agent" step.
+	//
+	// A pointer for the same reason as the fleet counts above: a spoke too old
+	// to report this sends nil, which the hub must read as "unknown, do not
+	// nudge", NOT as a genuine zero. Never threaten a hive over a signal that
+	// was never sent.
+	AgentsWithModel *int `json:"agents_with_model,omitempty"`
 }
 
 type StatusCollector func() *HeartbeatPayload

--- a/v2/pkg/hub/journey.go
+++ b/v2/pkg/hub/journey.go
@@ -1,0 +1,606 @@
+package hub
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// User-journey nudges.
+//
+// Every hive owner walks the same adoption path:
+//
+//	Stage 1  Install the GitHub App          URGENT   — days, not weeks
+//	Stage 2  Assign a method/model, OR run   MEDIUM   — a few weeks
+//	         the contributor relay
+//	Stage 3  Raise the ACMM level            SLOW     — months, never forced
+//
+// This file computes, server-side, which stage each hive is stalled on and
+// turns that into an escalating banner delivered over the existing per-hive
+// hub-banner channel (see hubBanners in server.go and the heartbeat response
+// assembly in handleHeartbeat). It NEVER de-provisions anything: the strongest
+// action it takes is warning that a human may de-provision the spoke.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ── Tunable thresholds ──────────────────────────────────────────────────────
+//
+// Every duration the journey nudger uses lives in this block so the whole
+// escalation policy can be retuned in one place. Nothing below this comment
+// hard-codes a bare duration.
+
+const (
+	// Stage 1 (GitHub App) is urgent: the spoke cannot open issues or PRs
+	// without it, so an uninstalled App means the hive is burning cluster
+	// capacity while producing nothing. The product policy is "immediately,
+	// and never outstanding more than 1-2 weeks", so the escalation runs
+	// gentle → firm → de-provision warning inside a two-week envelope.
+
+	// stage1GentleAfter is how long after registration the first, friendly
+	// "don't forget to install the App" nudge goes out.
+	stage1GentleAfter = 2 * 24 * time.Hour // 2 days
+
+	// stage1FirmAfter is when the tone hardens — the hive has now been idle
+	// for a full week with nothing to show for it.
+	stage1FirmAfter = 7 * 24 * time.Hour // 1 week
+
+	// stage1WarnAfter is when the spoke is told, explicitly, that it is a
+	// candidate for de-provisioning. Set at the far end of the product's
+	// "1-2 weeks" window.
+	stage1WarnAfter = 14 * 24 * time.Hour // 2 weeks
+
+	// stage2GraceAfter is how long a hive may sit with the App installed but
+	// no method/model assigned and no contributor relay activity before it is
+	// warned. The product allows ~2-3 weeks after stage 1 is satisfied; this
+	// is the gentle end of that window.
+	stage2GraceAfter = 14 * 24 * time.Hour // 2 weeks
+
+	// stage2WarnAfter is the far end of the same 2-3 week window, at which
+	// point a de-provision warning is permitted — but ONLY when neither a
+	// method/model nor the relay is in use.
+	stage2WarnAfter = 21 * 24 * time.Hour // 3 weeks
+
+	// stage3SuggestAfter is how long a hive rests at a given ACMM level before
+	// it is invited (never pushed) to consider the next one. ACMM movement is
+	// measured in months, so this is deliberately slow and never escalates.
+	stage3SuggestAfter = 30 * 24 * time.Hour // ~1 month
+)
+
+// Re-send intervals. A banner is re-delivered only after its stage's interval
+// has elapsed since the last send, so a hive stalled for months sees a steady
+// drumbeat rather than one banner per heartbeat.
+const (
+	// stage1ResendInterval is short because stage 1 is urgent and the whole
+	// window is only two weeks — a weekly reminder would fire twice total.
+	stage1ResendInterval = 3 * 24 * time.Hour // every 3 days
+
+	// stage2ResendInterval is weekly: medium urgency over a 2-3 week window.
+	stage2ResendInterval = 7 * 24 * time.Hour // weekly
+
+	// stage3ResendInterval is monthly, matching the "gentle reminder about
+	// once a month" policy for ACMM graduation.
+	stage3ResendInterval = 30 * 24 * time.Hour // monthly
+)
+
+// journeyBannerIDPrefix namespaces journey banner IDs so they are visually
+// distinct from admin-sent banners (bannerIDPrefix, "hub-banner-") in logs and
+// in the spoke's banner-dismiss state. The spoke keys dismissal off the banner
+// ID, so an ID that changes per stage+severity means each escalation step
+// re-appears even if the owner dismissed the previous one.
+const journeyBannerIDPrefix = "journey-"
+
+// journeyStatePath is the on-disk file holding per-hive nudge state (what was
+// last sent, when) and admin snoozes. A var, not a const, so tests can point it
+// at a temp file — same pattern as hubBannersPath.
+var journeyStatePath = "/data/saas/journey-state.json"
+
+// maxJourneySnoozeDuration bounds how far in the future an admin may snooze a
+// hive's nudges. Long enough to cover a quarter of legitimate exemption
+// (vendor pilots, hives parked for a conference), short enough that a snooze
+// set and forgotten eventually lapses back into the normal cadence.
+const maxJourneySnoozeDuration = 90 * 24 * time.Hour
+
+// JourneyStage identifies a step on the adoption path. The zero value means
+// "no stage outstanding" — every stage is satisfied.
+type JourneyStage int
+
+const (
+	// StageNone means the hive has satisfied every stage we track. Stage 3 is
+	// never fully "done" (there is always a next ACMM level until L6), so this
+	// is reached only by a hive at the maximum level.
+	StageNone JourneyStage = iota
+	// StageGitHubApp — the GitHub App is not installed yet.
+	StageGitHubApp
+	// StageMethodModel — no agent has a method/model, and the contributor
+	// relay is not carrying the load either.
+	StageMethodModel
+	// StageACMMLevel — the hive works, but has been resting at its current
+	// ACMM level long enough to be worth a graduation suggestion.
+	StageACMMLevel
+)
+
+// String renders a stage as a short stable token used in the registry JSON and
+// in the My Hives table.
+func (s JourneyStage) String() string {
+	switch s {
+	case StageGitHubApp:
+		return "github-app"
+	case StageMethodModel:
+		return "method-model"
+	case StageACMMLevel:
+		return "acmm-level"
+	default:
+		return "none"
+	}
+}
+
+// JourneySeverity describes how hard a nudge pushes. It maps onto the banner
+// colors the spoke already understands (validBannerColors in saas.go).
+type JourneySeverity int
+
+const (
+	// SeverityNone — nothing to say yet.
+	SeverityNone JourneySeverity = iota
+	// SeverityGentle — a friendly, informational reminder.
+	SeverityGentle
+	// SeverityFirm — this is overdue and needs attention.
+	SeverityFirm
+	// SeverityDeprovisionWarning — the owner is told a human may reclaim the
+	// spoke. NEVER produced for StageACMMLevel; see nextNudge.
+	SeverityDeprovisionWarning
+)
+
+// String renders a severity as a stable token for the API and the UI.
+func (s JourneySeverity) String() string {
+	switch s {
+	case SeverityGentle:
+		return "gentle"
+	case SeverityFirm:
+		return "firm"
+	case SeverityDeprovisionWarning:
+		return "deprovision-warning"
+	default:
+		return "none"
+	}
+}
+
+// bannerColor maps a severity onto one of the four colors the spoke dashboard
+// accepts. Anything unknown degrades to the calmest color rather than to an
+// invalid one the spoke would refuse to render.
+func (s JourneySeverity) bannerColor() string {
+	switch s {
+	case SeverityFirm:
+		return "amber"
+	case SeverityDeprovisionWarning:
+		return "amber"
+	case SeverityGentle:
+		return "blue"
+	default:
+		return "gray"
+	}
+}
+
+// acmmLevelInfo describes one ACMM level for nudge copy. Names and summaries
+// are taken from the authoritative pack definitions in
+// v2/pkg/config/packs/level-*.yaml so a suggestion always names the real next
+// level and what adopting it actually changes.
+type acmmLevelInfo struct {
+	Name    string
+	Summary string
+}
+
+// acmmLevels maps a level number to its name and a one-line summary of what
+// moving there entails. Kept in sync with v2/pkg/config/packs/level-*.yaml.
+var acmmLevels = map[int]acmmLevelInfo{
+	1: {"Assisted", "an interactive brainstorm agent turns ideas into structured facts and scaffolding, with every action human-approved"},
+	2: {"Instructed", "five agents (supervisor, scanner, quality, guide, brainstorm) publish advisory findings to your dashboard and a tracking issue — still no GitHub writes"},
+	3: {"Measured", "the quality agent starts opening issues and hold-gated PRs about testing gaps, and ci-maintainer joins to watch build health — nothing merges without you"},
+	4: {"Adaptive", "every agent files GitHub issues in its lane (bugs, docs gaps, workflow breakage) and a sec-check agent joins for vulnerabilities — issues only, still no PRs"},
+	5: {"Semi-Automated", "agents open pull requests as well as issues, all carrying a 'hold' label for you to batch-review, and architect plus strategist join — the system proposes, you dispose"},
+	6: {"Fully Autonomous", "agents open issues, raise PRs, and auto-merge them on green CI with no hold label, plus an outreach agent for community work — the highest trust setting"},
+}
+
+// maxACMMLevel is the top of the 6-level model. A hive here has nowhere to
+// graduate to, so it gets no ACMM nudge at all.
+const maxACMMLevel = 6
+
+// acmmLevelLabel renders a level as "L3 Measured", falling back to a bare
+// "L3" for any level outside the known table so copy never reads "L9 <nil>".
+func acmmLevelLabel(level int) string {
+	if info, ok := acmmLevels[level]; ok {
+		return fmt.Sprintf("L%d %s", level, info.Name)
+	}
+	return fmt.Sprintf("L%d", level)
+}
+
+// JourneyState is the per-hive record of what we last told this owner. It is
+// persisted so a hub restart does not restart the whole escalation ladder and
+// re-spam every hive.
+type JourneyState struct {
+	// LastStage / LastSeverity are the stage+severity of the most recent
+	// banner actually delivered. A change in either forces an immediate
+	// re-send regardless of the interval — an escalation should not wait.
+	LastStage    string `json:"last_stage,omitempty"`
+	LastSeverity string `json:"last_severity,omitempty"`
+	// LastSentAt is when that banner was queued (RFC3339).
+	LastSentAt string `json:"last_sent_at,omitempty"`
+	// LastACMMLevel is the level the hive sat at when the last ACMM nudge
+	// went out. If the owner graduates, the level changes and the next
+	// suggestion is allowed immediately rather than a month later.
+	LastACMMLevel int `json:"last_acmm_level,omitempty"`
+	// SnoozedUntil (RFC3339) suppresses ALL journey nudges for this hive
+	// until the given time. Set by an admin for legitimately exempt hives.
+	SnoozedUntil string `json:"snoozed_until,omitempty"`
+	// SnoozedBy / SnoozeReason record who granted the exemption and why, so a
+	// silent hive is explainable months later.
+	SnoozedBy    string `json:"snoozed_by,omitempty"`
+	SnoozeReason string `json:"snooze_reason,omitempty"`
+}
+
+// snoozeActive reports whether an admin snooze is currently suppressing nudges.
+// An unparseable timestamp is treated as "not snoozed" so corrupt state fails
+// toward nudging rather than toward permanent silence.
+func (js *JourneyState) snoozeActive(now time.Time) bool {
+	if js == nil || js.SnoozedUntil == "" {
+		return false
+	}
+	until, err := time.Parse(time.RFC3339, js.SnoozedUntil)
+	if err != nil {
+		return false
+	}
+	return now.Before(until)
+}
+
+// JourneyStatus is the computed, read-only view of where a hive stands. It is
+// attached to each registry entry for the My Hives table and the admin API.
+type JourneyStatus struct {
+	// Stage is the first unsatisfied stage, as a stable token.
+	Stage string `json:"stage"`
+	// StageNum is the same thing numerically, for sorting in the UI.
+	StageNum int `json:"stageNum"`
+	// Severity is how hard the current nudge pushes.
+	Severity string `json:"severity"`
+	// Message is the banner copy that would be (or was) delivered.
+	Message string `json:"message,omitempty"`
+	// StalledFor is a human-readable age of the current stall ("9 days").
+	StalledFor string `json:"stalledFor,omitempty"`
+	// ViaRelay marks a hive that satisfies stage 2 through the contributor
+	// relay rather than by assigning a method/model. The UI shows this as a
+	// distinct badge — such a hive is NOT silently reported as "assigned".
+	ViaRelay bool `json:"viaRelay,omitempty"`
+	// Snoozed is true while an admin exemption is in force.
+	Snoozed bool `json:"snoozed,omitempty"`
+	// SnoozedUntil echoes the exemption expiry for the UI tooltip.
+	SnoozedUntil string `json:"snoozedUntil,omitempty"`
+}
+
+// ── Stage detection ─────────────────────────────────────────────────────────
+
+// githubAppInstalled reports whether stage 1 is satisfied.
+//
+// Two spoke-reported signals feed this (both on RegistryEntry, populated in
+// handleHeartbeat):
+//
+//   - PendingGitHubAppInstall — the spoke is actively waiting for an install to
+//     complete, so the App is definitively not usable yet.
+//   - GitHubAppRequired — the spoke's config demands App auth. Combined with a
+//     recorded permission problem (GitHubAppPermIssue) this means the install
+//     is missing or broken.
+//
+// A hive that never asked for App auth (GitHubAppRequired false) is treated as
+// satisfied: it authenticates some other way and stage 1 does not apply.
+func githubAppInstalled(h *RegistryEntry) bool {
+	if h == nil {
+		return true
+	}
+	if h.PendingGitHubAppInstall {
+		return false
+	}
+	if h.GitHubAppRequired && strings.TrimSpace(h.GitHubAppPermIssue) != "" {
+		return false
+	}
+	return true
+}
+
+// methodModelAssigned reports whether any agent on this hive has a method
+// (backend) or model assigned.
+//
+// AgentsWithModel is a pointer so that a spoke too old to report it (nil) is
+// distinguishable from a spoke reporting a genuine zero. A nil value means "we
+// cannot tell", and the caller must not treat that as an unsatisfied stage —
+// we never threaten a hive over a signal we did not receive.
+func methodModelAssigned(h *RegistryEntry) (assigned bool, known bool) {
+	if h == nil || h.AgentsWithModel == nil {
+		return false, false
+	}
+	return *h.AgentsWithModel > 0, true
+}
+
+// relayInUse reports whether the contributor relay is carrying this hive's
+// work, which the product accepts as a full substitute for a method/model.
+//
+// Two signals, strongest first:
+//
+//   - A leaderboard entry with a non-empty CurrentTask means a human
+//     contributor is actively working a task right now — the relay is
+//     unambiguously in use.
+//   - ContributorCount (registered profiles on the spoke's disk) > 0 means
+//     people have signed up to this hive's relay. This is durable across the
+//     gaps when nobody happens to be connected, which matters because a nudge
+//     must not fire just because the relay is idle at 3am.
+//
+// ActiveContributors alone is deliberately NOT sufficient on its own — it is a
+// live-WebSocket count that drops to zero whenever contributors disconnect —
+// but a non-zero value does confirm use.
+func relayInUse(h *RegistryEntry) bool {
+	if h == nil {
+		return false
+	}
+	if h.ContributorCount > 0 || h.ActiveContributors > 0 {
+		return true
+	}
+	for _, e := range h.Leaderboard {
+		if strings.TrimSpace(e.CurrentTask) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// stageSatisfiedAt returns the timestamp from which the current stage's clock
+// runs, plus whether it is usable. Stage 1 measures from registration. Stages 2
+// and 3 have no per-stage "satisfied at" timestamp in the registry, so they
+// also measure from registration — which is conservative: it can only make a
+// nudge fire later relative to when the previous stage was actually cleared,
+// never earlier.
+func stageSatisfiedAt(h *RegistryEntry) (time.Time, bool) {
+	if h == nil {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, h.RegisteredAt)
+	if err != nil || t.IsZero() {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// humanDuration renders a stall age for the UI, in the coarsest unit that is
+// still informative.
+func humanDuration(d time.Duration) string {
+	const hoursPerDay = 24
+	days := int(d.Hours() / hoursPerDay)
+	switch {
+	case days >= 2:
+		return fmt.Sprintf("%d days", days)
+	case days == 1:
+		return "1 day"
+	default:
+		hours := int(d.Hours())
+		if hours <= 1 {
+			return "under an hour"
+		}
+		return fmt.Sprintf("%d hours", hours)
+	}
+}
+
+// nudge is a fully-formed decision: which stage, how hard, and exactly what to
+// say. A zero Stage means "say nothing".
+type nudge struct {
+	Stage    JourneyStage
+	Severity JourneySeverity
+	Message  string
+	// Resend is the minimum gap before this same stage+severity is sent again.
+	Resend time.Duration
+	// ViaRelay records that stage 2 was satisfied through the contributor
+	// relay, for display purposes.
+	ViaRelay bool
+	// StalledFor is the age of the stall, for display.
+	StalledFor time.Duration
+}
+
+// nextNudge computes the current journey decision for one hive.
+//
+// The stage is the FIRST unsatisfied stage, checked in order. Severity is a
+// function of how long the stall has run, against the tunable thresholds at the
+// top of this file.
+//
+// Invariant enforced here and asserted by tests: a StageACMMLevel nudge is
+// never returned with SeverityDeprovisionWarning, and its copy never mentions
+// de-provisioning. ACMM movement is an invitation, not a demand.
+func nextNudge(h *RegistryEntry, now time.Time) nudge {
+	if h == nil {
+		return nudge{}
+	}
+
+	since, ok := stageSatisfiedAt(h)
+	if !ok {
+		// No trustworthy clock — never escalate against a timestamp we could
+		// not parse.
+		return nudge{}
+	}
+	age := now.Sub(since)
+	if age < 0 {
+		age = 0
+	}
+
+	// ── Stage 1: GitHub App ────────────────────────────────────────────────
+	if !githubAppInstalled(h) {
+		n := nudge{Stage: StageGitHubApp, Resend: stage1ResendInterval, StalledFor: age}
+		switch {
+		case age >= stage1WarnAfter:
+			n.Severity = SeverityDeprovisionWarning
+			n.Message = fmt.Sprintf(
+				"Action required: the KubeStellar Hive GitHub App is still not installed on %s, %s after this hive registered. "+
+					"Without it your agents cannot read issues or open pull requests, so this spoke is consuming cluster capacity and producing nothing. "+
+					"Install it from your hive dashboard (Settings → GitHub App) to start work immediately. "+
+					"Spokes left in this state are candidates for de-provisioning by an administrator.",
+				orgLabel(h), humanDuration(age))
+		case age >= stage1FirmAfter:
+			n.Severity = SeverityFirm
+			n.Message = fmt.Sprintf(
+				"Your hive still has no GitHub App installed after %s. Until it is installed, no agent can open an issue or a pull request — "+
+					"the hive is running but cannot do any work. Install the KubeStellar Hive GitHub App on %s from Settings → GitHub App on your dashboard.",
+				humanDuration(age), orgLabel(h))
+		case age >= stage1GentleAfter:
+			n.Severity = SeverityGentle
+			n.Message = fmt.Sprintf(
+				"Welcome aboard! One step left before your agents can work: install the KubeStellar Hive GitHub App on %s. "+
+					"It grants the scoped, short-lived tokens agents use to read issues and raise pull requests. "+
+					"You can do it from Settings → GitHub App on your dashboard.",
+				orgLabel(h))
+		default:
+			return nudge{}
+		}
+		return n
+	}
+
+	// ── Stage 2: method/model, or the contributor relay ────────────────────
+	//
+	// The relay is a first-class substitute: a hive whose humans are picking up
+	// tasks through /contribute has satisfied this stage as completely as one
+	// that pointed an agent at a model.
+	viaRelay := relayInUse(h)
+	assigned, known := methodModelAssigned(h)
+	if !viaRelay && !assigned {
+		// `known == false` means the spoke is too old to report the signal. We
+		// do not nudge — let alone threaten — on the basis of a value that was
+		// never sent.
+		if !known {
+			return nudge{}
+		}
+		n := nudge{Stage: StageMethodModel, Resend: stage2ResendInterval, StalledFor: age}
+		switch {
+		case age >= stage2WarnAfter:
+			n.Severity = SeverityDeprovisionWarning
+			n.Message = fmt.Sprintf(
+				"Action required: after %s, none of your agents has a method or model assigned, and no one is picking up tasks through your contributor relay. "+
+					"Assign a backend and model to at least one agent (Agents → pick an agent → Model), or open your hive's /contribute page to your community — "+
+					"either one counts. Spokes that stay idle past this point are candidates for de-provisioning by an administrator.",
+				humanDuration(age))
+		case age >= stage2GraceAfter:
+			n.Severity = SeverityFirm
+			n.Message = fmt.Sprintf(
+				"Your hive has been up for %s but no agent has a method or model assigned yet, so nothing is running. "+
+					"Pick a backend and model for an agent under Agents → Model. Prefer humans in the loop? "+
+					"Running the contributor relay from your hive's /contribute page satisfies this step just as well.",
+				humanDuration(age))
+		default:
+			return nudge{}
+		}
+		return n
+	}
+
+	// ── Stage 3: ACMM graduation — gentle, monthly, never a threat ─────────
+	level := h.ACMMLevel
+	if level >= maxACMMLevel {
+		// Already at the top; there is nothing to graduate to.
+		return nudge{ViaRelay: viaRelay}
+	}
+	if age < stage3SuggestAfter {
+		return nudge{ViaRelay: viaRelay}
+	}
+	next, ok := acmmLevels[level+1]
+	if !ok {
+		// Unknown next level — say nothing rather than invent one.
+		return nudge{ViaRelay: viaRelay}
+	}
+	return nudge{
+		Stage:      StageACMMLevel,
+		Severity:   SeverityGentle,
+		Resend:     stage3ResendInterval,
+		ViaRelay:   viaRelay,
+		StalledFor: age,
+		Message: fmt.Sprintf(
+			"Your hive has been running at %s for a while now. When it feels right, consider graduating to L%d %s: %s. "+
+				"There is no deadline and no obligation — move up only when your team is ready. You can review and apply the level from Config → ACMM Level.",
+			acmmLevelLabel(level), level+1, next.Name, next.Summary),
+	}
+}
+
+// orgLabel renders the hive's org (or its name as a fallback) for banner copy,
+// so a message names the actual GitHub org the owner must install the App on.
+func orgLabel(h *RegistryEntry) string {
+	if h == nil {
+		return "your organization"
+	}
+	if org := strings.TrimSpace(h.Org); org != "" {
+		return org
+	}
+	if name := strings.TrimSpace(h.Name); name != "" {
+		return name
+	}
+	return "your organization"
+}
+
+// shouldSend decides whether a computed nudge is due, given what was last sent.
+//
+// It fires when any of the following holds:
+//   - nothing was ever sent for this hive;
+//   - the stage or the severity changed (an escalation must not wait out the
+//     interval — that is the whole point of escalating);
+//   - the ACMM level changed since the last ACMM nudge (the owner graduated,
+//     so the old suggestion is stale and the new one is immediately relevant);
+//   - the stage's re-send interval has elapsed.
+//
+// An unparseable LastSentAt is treated as "never sent", which re-sends once and
+// then repairs the state.
+func shouldSend(n nudge, st *JourneyState, now time.Time) bool {
+	if n.Stage == StageNone || n.Severity == SeverityNone {
+		return false
+	}
+	if st == nil || st.LastSentAt == "" {
+		return true
+	}
+	if st.LastStage != n.Stage.String() || st.LastSeverity != n.Severity.String() {
+		return true
+	}
+	last, err := time.Parse(time.RFC3339, st.LastSentAt)
+	if err != nil {
+		return true
+	}
+	return !now.Before(last.Add(n.Resend))
+}
+
+// journeyBannerID builds the banner ID for a nudge. It embeds the stage and
+// severity so that each escalation step is a NEW banner from the spoke's point
+// of view — an owner who dismissed the gentle reminder still sees the firm one.
+// For ACMM it also embeds the level, so a suggestion to move to L4 reappears
+// after the owner reaches L3 even though stage and severity are unchanged.
+func journeyBannerID(n nudge, level int) string {
+	if n.Stage == StageACMMLevel {
+		return fmt.Sprintf("%s%s-%s-l%d", journeyBannerIDPrefix, n.Stage, n.Severity, level)
+	}
+	return fmt.Sprintf("%s%s-%s", journeyBannerIDPrefix, n.Stage, n.Severity)
+}
+
+// isJourneyBanner reports whether a banner ID was generated by this subsystem.
+// Used so journey nudges never overwrite a banner an admin sent by hand.
+func isJourneyBanner(id string) bool {
+	return strings.HasPrefix(id, journeyBannerIDPrefix)
+}
+
+// JourneyStatusFor computes the display-facing status for one hive. It is pure
+// and side-effect free, so both the registry projection and the tests can call
+// it freely.
+func JourneyStatusFor(h *RegistryEntry, st *JourneyState, now time.Time) JourneyStatus {
+	n := nextNudge(h, now)
+	status := JourneyStatus{
+		Stage:    n.Stage.String(),
+		StageNum: int(n.Stage),
+		Severity: n.Severity.String(),
+		Message:  n.Message,
+		ViaRelay: n.ViaRelay,
+	}
+	if n.Stage == StageMethodModel {
+		// A hive being nudged for stage 2 is by definition not on the relay.
+		status.ViaRelay = false
+	}
+	if n.StalledFor > 0 && n.Stage != StageNone {
+		status.StalledFor = humanDuration(n.StalledFor)
+	}
+	if st.snoozeActive(now) {
+		status.Snoozed = true
+		status.SnoozedUntil = st.SnoozedUntil
+	}
+	return status
+}

--- a/v2/pkg/hub/journey_dispatch.go
+++ b/v2/pkg/hub/journey_dispatch.go
@@ -1,0 +1,201 @@
+package hub
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// journeyBannerFor decides whether this hive is due a journey nudge right now
+// and, if so, returns the banner to deliver on the heartbeat response.
+//
+// It returns nil when: the hive is snoozed by an admin, no stage is
+// outstanding, the required signal was never reported, or the nudge was
+// already sent recently enough that re-sending would be spam.
+//
+// Callers must NOT hold hubBannersMu.
+func (s *HubServer) journeyBannerFor(hiveID string, now time.Time) *HubBanner {
+	if s == nil || s.journey == nil {
+		return nil
+	}
+
+	entry := s.registryEntryCopy(hiveID)
+	if entry == nil {
+		return nil
+	}
+
+	st := s.journey.get(hiveID)
+	// An admin exemption suppresses every journey nudge for this hive. Admin
+	// banners sent by hand are unaffected — this only gates journey traffic.
+	if st.snoozeActive(now) {
+		return nil
+	}
+
+	n := nextNudge(entry, now)
+	if !shouldSend(n, st, now) {
+		return nil
+	}
+	// Defence in depth for the product's hardest rule: ACMM is a suggestion,
+	// never a threat. Even if a future edit to nextNudge got this wrong, no
+	// de-provision warning can leave the hub on an ACMM nudge.
+	if n.Stage == StageACMMLevel && n.Severity == SeverityDeprovisionWarning {
+		s.logger.Error("journey: refusing to send a de-provision warning for ACMM level",
+			"hive_id", hiveID)
+		return nil
+	}
+
+	s.journey.recordSent(hiveID, n, entry.ACMMLevel, now)
+	if err := s.journey.save(); err != nil {
+		// A failed save means the nudge may repeat after a restart. That is
+		// strictly better than dropping the nudge, so continue.
+		s.logger.Error("failed to persist journey nudge state", "error", err, "hive_id", hiveID)
+	}
+
+	s.logger.Info("journey: sending nudge",
+		"hive_id", hiveID,
+		"stage", n.Stage.String(),
+		"severity", n.Severity.String(),
+		"stalled_for", n.StalledFor.String(),
+	)
+
+	return &HubBanner{
+		ID:      journeyBannerID(n, entry.ACMMLevel),
+		Message: n.Message,
+		Color:   n.Severity.bannerColor(),
+	}
+}
+
+// registryEntryCopy returns a copy of one registry entry under the registry
+// lock, so journey computation never races with a concurrent heartbeat write.
+func (s *HubServer) registryEntryCopy(hiveID string) *RegistryEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for i := range s.registry.Hives {
+		if s.registry.Hives[i].ID == hiveID {
+			cp := s.registry.Hives[i]
+			return &cp
+		}
+	}
+	return nil
+}
+
+// attachJourneyStatus fills in the Journey field on each entry of a hive slice
+// so the My Hives table can show where every hive is stalled. Computed on read
+// — journey status is derived data and is never persisted on the registry.
+func (s *HubServer) attachJourneyStatus(hives []RegistryEntry, now time.Time) {
+	if s == nil || s.journey == nil {
+		return
+	}
+	for i := range hives {
+		st := s.journey.get(hives[i].ID)
+		status := JourneyStatusFor(&hives[i], st, now)
+		hives[i].Journey = &status
+	}
+}
+
+// ── Admin snooze API ────────────────────────────────────────────────────────
+
+// handleJourneySnooze sets or clears an admin exemption for one hive. Some
+// hives are legitimately exempt (vendor pilots, demo spokes, hives parked
+// between events) and must not be nagged or threatened.
+//
+// POST /api/saas/admin/journey-snooze
+//
+//	{"hive_id": "...", "duration": "720h", "reason": "vendor pilot"}
+//
+// An empty or zero duration clears the snooze.
+func (s *HubServer) handleJourneySnooze(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		HiveID   string `json:"hive_id"`
+		Duration string `json:"duration"`
+		Reason   string `json:"reason"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return
+	}
+	hiveID := strings.TrimSpace(body.HiveID)
+	if hiveID == "" {
+		http.Error(w, `{"error":"hive_id is required"}`, http.StatusBadRequest)
+		return
+	}
+	// maxSnoozeReasonLen keeps an audit note readable and bounds what is
+	// written to the PVC; the reason is operator-facing prose, not data.
+	const maxSnoozeReasonLen = 200
+	reason := strings.TrimSpace(body.Reason)
+	if runes := []rune(reason); len(runes) > maxSnoozeReasonLen {
+		reason = string(runes[:maxSnoozeReasonLen])
+	}
+
+	now := time.Now()
+	until, err := parseSnoozeUntil(body.Duration, now)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	username := s.getAuthUser(r)
+	s.journey.setSnooze(hiveID, until, username, reason)
+	if err := s.journey.save(); err != nil {
+		s.logger.Error("failed to persist journey snooze", "error", err, "hive_id", hiveID)
+		writeJSONError(w, http.StatusInternalServerError, "failed to persist snooze")
+		return
+	}
+
+	if until.IsZero() {
+		s.logger.Info("journey: snooze cleared", "hive_id", hiveID, "by", username)
+	} else {
+		s.logger.Info("journey: snooze set",
+			"hive_id", hiveID, "until", until.UTC().Format(time.RFC3339),
+			"reason", reason, "by", username)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	resp := map[string]any{"ok": true, "hive_id": hiveID}
+	if until.IsZero() {
+		resp["snoozed"] = false
+	} else {
+		resp["snoozed"] = true
+		resp["snoozed_until"] = until.UTC().Format(time.RFC3339)
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// handleJourneyStatus returns the journey status of every hive, for the admin
+// view of who is stalled where.
+func (s *HubServer) handleJourneyStatus(w http.ResponseWriter, r *http.Request) {
+	now := time.Now()
+	s.mu.RLock()
+	hives := make([]RegistryEntry, len(s.registry.Hives))
+	copy(hives, s.registry.Hives)
+	s.mu.RUnlock()
+
+	s.attachJourneyStatus(hives, now)
+
+	type row struct {
+		HiveID string         `json:"hive_id"`
+		Name   string         `json:"name"`
+		Owner  string         `json:"owner,omitempty"`
+		Status *JourneyStatus `json:"status"`
+	}
+	rows := make([]row, 0, len(hives))
+	for i := range hives {
+		rows = append(rows, row{
+			HiveID: hives[i].ID,
+			Name:   hives[i].Name,
+			Owner:  hives[i].Owner,
+			Status: hives[i].Journey,
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"hives": rows})
+}
+
+// writeJSONError emits a JSON error body with the given status code.
+func writeJSONError(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/v2/pkg/hub/journey_store.go
+++ b/v2/pkg/hub/journey_store.go
@@ -1,0 +1,188 @@
+package hub
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// journeyStore holds per-hive nudge state (what was last sent, and any admin
+// snooze) and persists it to the PVC so a hub restart neither restarts every
+// escalation ladder from scratch nor forgets an admin's exemption.
+//
+// It is deliberately a separate file from hub-banners.json: banners are
+// ephemeral delivery state an admin can clear wholesale, whereas journey state
+// is a record of what each owner has already been told.
+type journeyStore struct {
+	mu     sync.RWMutex
+	states map[string]*JourneyState
+	// dirty tracks whether anything changed since the last save, so a
+	// heartbeat storm that produces no nudges does not rewrite the file.
+	dirty bool
+}
+
+func newJourneyStore() *journeyStore {
+	return &journeyStore{states: make(map[string]*JourneyState)}
+}
+
+// get returns a copy of the state for a hive, or nil when none is recorded.
+// A copy so callers cannot mutate shared state without the lock.
+//
+// Nil-receiver safe: a HubServer built directly (as tests and some internal
+// paths do) has no store, and a missing store simply means "nothing was ever
+// sent" rather than a crash on a read path.
+func (js *journeyStore) get(hiveID string) *JourneyState {
+	if js == nil {
+		return nil
+	}
+	js.mu.RLock()
+	defer js.mu.RUnlock()
+	st, ok := js.states[hiveID]
+	if !ok || st == nil {
+		return nil
+	}
+	cp := *st
+	return &cp
+}
+
+// recordSent stores that a banner for this stage/severity was delivered now.
+func (js *journeyStore) recordSent(hiveID string, n nudge, acmmLevel int, now time.Time) {
+	if js == nil {
+		return
+	}
+	js.mu.Lock()
+	defer js.mu.Unlock()
+	st, ok := js.states[hiveID]
+	if !ok || st == nil {
+		st = &JourneyState{}
+		js.states[hiveID] = st
+	}
+	st.LastStage = n.Stage.String()
+	st.LastSeverity = n.Severity.String()
+	st.LastSentAt = now.UTC().Format(time.RFC3339)
+	if n.Stage == StageACMMLevel {
+		st.LastACMMLevel = acmmLevel
+	}
+	js.dirty = true
+}
+
+// setSnooze records (or clears, when until is zero) an admin exemption.
+func (js *journeyStore) setSnooze(hiveID string, until time.Time, by, reason string) {
+	if js == nil {
+		return
+	}
+	js.mu.Lock()
+	defer js.mu.Unlock()
+	st, ok := js.states[hiveID]
+	if !ok || st == nil {
+		st = &JourneyState{}
+		js.states[hiveID] = st
+	}
+	if until.IsZero() {
+		st.SnoozedUntil = ""
+		st.SnoozedBy = ""
+		st.SnoozeReason = ""
+	} else {
+		st.SnoozedUntil = until.UTC().Format(time.RFC3339)
+		st.SnoozedBy = by
+		st.SnoozeReason = reason
+	}
+	js.dirty = true
+}
+
+// save writes the store to disk atomically (tmp + rename) so a crash mid-write
+// never leaves a half-parsed file. A no-op when nothing changed.
+func (js *journeyStore) save() error {
+	if js == nil {
+		return nil
+	}
+	js.mu.Lock()
+	if !js.dirty {
+		js.mu.Unlock()
+		return nil
+	}
+	snapshot := make(map[string]*JourneyState, len(js.states))
+	for id, st := range js.states {
+		snapshot[id] = st
+	}
+	js.dirty = false
+	js.mu.Unlock()
+
+	data, err := json.MarshalIndent(snapshot, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal journey state: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(journeyStatePath), 0o755); err != nil {
+		return fmt.Errorf("create journey state dir: %w", err)
+	}
+	tmpPath := journeyStatePath + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+		return fmt.Errorf("write journey state: %w", err)
+	}
+	if err := os.Rename(tmpPath, journeyStatePath); err != nil {
+		return fmt.Errorf("rename journey state: %w", err)
+	}
+	return nil
+}
+
+// load reads persisted state from the PVC. A missing file is normal (no nudges
+// sent yet) and is not an error. Expired snoozes are dropped on load so a stale
+// exemption does not silently outlive its window.
+func (js *journeyStore) load(now time.Time) error {
+	if js == nil {
+		return nil
+	}
+	data, err := os.ReadFile(journeyStatePath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("read journey state: %w", err)
+	}
+	var stored map[string]*JourneyState
+	if err := json.Unmarshal(data, &stored); err != nil {
+		return fmt.Errorf("parse journey state: %w", err)
+	}
+	js.mu.Lock()
+	defer js.mu.Unlock()
+	for id, st := range stored {
+		if st == nil {
+			continue
+		}
+		if st.SnoozedUntil != "" && !st.snoozeActive(now) {
+			st.SnoozedUntil = ""
+			st.SnoozedBy = ""
+			st.SnoozeReason = ""
+		}
+		js.states[id] = st
+	}
+	return nil
+}
+
+// parseSnoozeUntil validates an admin-supplied snooze duration and converts it
+// to an absolute expiry. An empty/zero duration means "clear the snooze".
+// Durations beyond maxJourneySnoozeDuration are rejected rather than silently
+// clamped, so an admin who typed the wrong unit finds out.
+func parseSnoozeUntil(raw string, now time.Time) (time.Time, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "0" {
+		return time.Time{}, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid duration %q: use a Go duration such as 720h", raw)
+	}
+	if d <= 0 {
+		return time.Time{}, nil
+	}
+	if d > maxJourneySnoozeDuration {
+		return time.Time{}, fmt.Errorf("snooze %s exceeds the maximum of %s", d, maxJourneySnoozeDuration)
+	}
+	return now.Add(d), nil
+}

--- a/v2/pkg/hub/journey_test.go
+++ b/v2/pkg/hub/journey_test.go
@@ -1,0 +1,884 @@
+package hub
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// baseTime is a fixed reference so every time-window test is deterministic.
+var baseTime = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// intPtr is a helper for the *int heartbeat signals.
+func intPtr(v int) *int { return &v }
+
+// hive builds a RegistryEntry registered `age` before baseTime, with every
+// stage satisfied by default. Individual tests then break one thing.
+func hive(age time.Duration, mut ...func(*RegistryEntry)) *RegistryEntry {
+	h := &RegistryEntry{
+		ID:              "hive-1",
+		Name:            "acme/widget",
+		Org:             "acme",
+		RegisteredAt:    baseTime.Add(-age).Format(time.RFC3339),
+		ACMMLevel:       maxACMMLevel, // top level → no ACMM nudge unless a test lowers it
+		AgentsWithModel: intPtr(1),    // stage 2 satisfied by assignment
+	}
+	for _, m := range mut {
+		m(h)
+	}
+	return h
+}
+
+// ── Stage detection ─────────────────────────────────────────────────────────
+
+func TestGitHubAppInstalled(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry *RegistryEntry
+		want  bool
+	}{
+		{"nil entry is treated as satisfied", nil, true},
+		{"clean hive", &RegistryEntry{}, true},
+		{"pending install is not satisfied", &RegistryEntry{PendingGitHubAppInstall: true}, false},
+		{"app required with a permission issue is not satisfied",
+			&RegistryEntry{GitHubAppRequired: true, GitHubAppPermIssue: "missing contents:write"}, false},
+		{"app required with no permission issue is satisfied",
+			&RegistryEntry{GitHubAppRequired: true}, true},
+		{"permission issue without app required is satisfied (app auth not in use)",
+			&RegistryEntry{GitHubAppPermIssue: "stale"}, true},
+		{"whitespace-only permission issue does not count as a problem",
+			&RegistryEntry{GitHubAppRequired: true, GitHubAppPermIssue: "   "}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := githubAppInstalled(tc.entry); got != tc.want {
+				t.Errorf("githubAppInstalled() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMethodModelAssigned(t *testing.T) {
+	tests := []struct {
+		name         string
+		entry        *RegistryEntry
+		wantAssigned bool
+		wantKnown    bool
+	}{
+		{"nil entry is unknown", nil, false, false},
+		{"nil pointer means an old spoke, so unknown", &RegistryEntry{}, false, false},
+		{"zero agents with a model is a known negative",
+			&RegistryEntry{AgentsWithModel: intPtr(0)}, false, true},
+		{"one agent with a model is assigned",
+			&RegistryEntry{AgentsWithModel: intPtr(1)}, true, true},
+		{"many agents with a model is assigned",
+			&RegistryEntry{AgentsWithModel: intPtr(9)}, true, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assigned, known := methodModelAssigned(tc.entry)
+			if assigned != tc.wantAssigned || known != tc.wantKnown {
+				t.Errorf("methodModelAssigned() = (%v,%v), want (%v,%v)",
+					assigned, known, tc.wantAssigned, tc.wantKnown)
+			}
+		})
+	}
+}
+
+func TestRelayInUse(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry *RegistryEntry
+		want  bool
+	}{
+		{"nil entry", nil, false},
+		{"no contributors at all", &RegistryEntry{}, false},
+		{"registered contributors count as in use (durable across idle gaps)",
+			&RegistryEntry{ContributorCount: 3}, true},
+		{"live contributors count as in use",
+			&RegistryEntry{ActiveContributors: 1}, true},
+		{"a contributor working a task counts even with no counters",
+			&RegistryEntry{Leaderboard: []LeaderboardEntry{{CurrentTask: "fix #12"}}}, true},
+		{"leaderboard entries with no current task do not count",
+			&RegistryEntry{Leaderboard: []LeaderboardEntry{{GitHubUsername: "ada"}}}, false},
+		{"whitespace current task does not count",
+			&RegistryEntry{Leaderboard: []LeaderboardEntry{{CurrentTask: "  "}}}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := relayInUse(tc.entry); got != tc.want {
+				t.Errorf("relayInUse() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNextNudgeStageOrdering verifies the current stage is the FIRST
+// unsatisfied one — an earlier unsatisfied stage always wins.
+func TestNextNudgeStageOrdering(t *testing.T) {
+	// Old enough that all three stages would otherwise have something to say.
+	const age = 60 * 24 * time.Hour
+	tests := []struct {
+		name  string
+		entry *RegistryEntry
+		want  JourneyStage
+	}{
+		{
+			"all stages unsatisfied yields stage 1",
+			hive(age, func(h *RegistryEntry) {
+				h.PendingGitHubAppInstall = true
+				h.AgentsWithModel = intPtr(0)
+				h.ACMMLevel = 2
+			}),
+			StageGitHubApp,
+		},
+		{
+			"app installed, no method/model yields stage 2",
+			hive(age, func(h *RegistryEntry) {
+				h.AgentsWithModel = intPtr(0)
+				h.ACMMLevel = 2
+			}),
+			StageMethodModel,
+		},
+		{
+			"stages 1 and 2 satisfied yields stage 3",
+			hive(age, func(h *RegistryEntry) { h.ACMMLevel = 2 }),
+			StageACMMLevel,
+		},
+		{
+			"everything satisfied at max ACMM yields no stage",
+			hive(age),
+			StageNone,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := nextNudge(tc.entry, baseTime)
+			if got.Stage != tc.want {
+				t.Errorf("stage = %v, want %v", got.Stage, tc.want)
+			}
+		})
+	}
+}
+
+// ── Escalation timing — boundaries of every window ─────────────────────────
+
+// TestStage1EscalationBoundaries walks the urgent GitHub App ladder, checking
+// the exact instant each threshold takes effect and the instant before it.
+func TestStage1EscalationBoundaries(t *testing.T) {
+	tests := []struct {
+		name string
+		age  time.Duration
+		want JourneySeverity
+	}{
+		{"brand new hive says nothing", 0, SeverityNone},
+		{"just before the gentle threshold", stage1GentleAfter - time.Second, SeverityNone},
+		{"exactly at the gentle threshold", stage1GentleAfter, SeverityGentle},
+		{"just before firm", stage1FirmAfter - time.Second, SeverityGentle},
+		{"exactly at firm", stage1FirmAfter, SeverityFirm},
+		{"just before the de-provision warning", stage1WarnAfter - time.Second, SeverityFirm},
+		{"exactly at the de-provision warning", stage1WarnAfter, SeverityDeprovisionWarning},
+		{"well past the warning stays at the warning", stage1WarnAfter * 3, SeverityDeprovisionWarning},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := hive(tc.age, func(h *RegistryEntry) { h.PendingGitHubAppInstall = true })
+			got := nextNudge(h, baseTime)
+			if got.Severity != tc.want {
+				t.Errorf("severity at %s = %v, want %v", tc.age, got.Severity, tc.want)
+			}
+			if tc.want != SeverityNone && got.Stage != StageGitHubApp {
+				t.Errorf("stage = %v, want %v", got.Stage, StageGitHubApp)
+			}
+		})
+	}
+}
+
+// TestStage2EscalationBoundaries walks the medium-urgency method/model window.
+func TestStage2EscalationBoundaries(t *testing.T) {
+	tests := []struct {
+		name string
+		age  time.Duration
+		want JourneySeverity
+	}{
+		{"inside the grace period says nothing", stage2GraceAfter - time.Second, SeverityNone},
+		{"exactly at the grace threshold becomes firm", stage2GraceAfter, SeverityFirm},
+		{"just before the warning threshold", stage2WarnAfter - time.Second, SeverityFirm},
+		{"exactly at the warning threshold", stage2WarnAfter, SeverityDeprovisionWarning},
+		{"long past the warning stays at the warning", stage2WarnAfter * 2, SeverityDeprovisionWarning},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := hive(tc.age, func(h *RegistryEntry) { h.AgentsWithModel = intPtr(0) })
+			got := nextNudge(h, baseTime)
+			if got.Severity != tc.want {
+				t.Errorf("severity at %s = %v, want %v", tc.age, got.Severity, tc.want)
+			}
+		})
+	}
+}
+
+// TestStage3SuggestBoundary checks the monthly ACMM suggestion boundary.
+func TestStage3SuggestBoundary(t *testing.T) {
+	tests := []struct {
+		name string
+		age  time.Duration
+		want JourneyStage
+	}{
+		{"just before the monthly mark says nothing", stage3SuggestAfter - time.Second, StageNone},
+		{"exactly at the monthly mark suggests", stage3SuggestAfter, StageACMMLevel},
+		{"months later still suggests", stage3SuggestAfter * 5, StageACMMLevel},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := hive(tc.age, func(h *RegistryEntry) { h.ACMMLevel = 3 })
+			got := nextNudge(h, baseTime)
+			if got.Stage != tc.want {
+				t.Errorf("stage at %s = %v, want %v", tc.age, got.Stage, tc.want)
+			}
+		})
+	}
+}
+
+// ── The relay substitution ─────────────────────────────────────────────────
+
+// TestRelaySubstitutesForMethodModel is the product's key stage-2 rule: the
+// contributor relay fully satisfies the stage, and a hive on the relay is
+// never nudged or threatened for lacking a method/model — at any age.
+func TestRelaySubstitutesForMethodModel(t *testing.T) {
+	// Far past even the de-provision threshold, to prove age cannot override
+	// the substitution.
+	const age = stage2WarnAfter * 4
+
+	tests := []struct {
+		name         string
+		mut          func(*RegistryEntry)
+		wantStage    JourneyStage
+		wantViaRelay bool
+	}{
+		{
+			"no model and no relay is nudged to a de-provision warning",
+			func(h *RegistryEntry) { h.AgentsWithModel = intPtr(0) },
+			StageMethodModel, false,
+		},
+		{
+			"registered contributors satisfy the stage instead",
+			func(h *RegistryEntry) { h.AgentsWithModel = intPtr(0); h.ContributorCount = 2 },
+			StageNone, true,
+		},
+		{
+			"an active contributor satisfies the stage",
+			func(h *RegistryEntry) { h.AgentsWithModel = intPtr(0); h.ActiveContributors = 1 },
+			StageNone, true,
+		},
+		{
+			"a contributor working a task satisfies the stage",
+			func(h *RegistryEntry) {
+				h.AgentsWithModel = intPtr(0)
+				h.Leaderboard = []LeaderboardEntry{{CurrentTask: "triage #7"}}
+			},
+			StageNone, true,
+		},
+		{
+			"an assigned model satisfies the stage without the relay",
+			func(h *RegistryEntry) { h.AgentsWithModel = intPtr(1) },
+			StageNone, false,
+		},
+		{
+			"both a model and the relay still reports the relay flag",
+			func(h *RegistryEntry) { h.AgentsWithModel = intPtr(1); h.ContributorCount = 5 },
+			StageNone, true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := hive(age, tc.mut)
+			got := nextNudge(h, baseTime)
+			if got.Stage != tc.wantStage {
+				t.Errorf("stage = %v, want %v", got.Stage, tc.wantStage)
+			}
+			if got.ViaRelay != tc.wantViaRelay {
+				t.Errorf("viaRelay = %v, want %v", got.ViaRelay, tc.wantViaRelay)
+			}
+			// The relay must never be threatened out of existence.
+			if tc.wantViaRelay && got.Severity == SeverityDeprovisionWarning {
+				t.Error("a hive satisfying stage 2 via the relay must never get a de-provision warning")
+			}
+		})
+	}
+}
+
+// TestRelayHiveIsNotReportedAsAssigned guards the product's display rule: a
+// hive on the relay must be visibly distinct, not silently folded into
+// "assigned".
+func TestRelayHiveIsNotReportedAsAssigned(t *testing.T) {
+	h := hive(stage2WarnAfter*2, func(h *RegistryEntry) {
+		h.AgentsWithModel = intPtr(0)
+		h.ContributorCount = 4
+	})
+	st := JourneyStatusFor(h, nil, baseTime)
+	if !st.ViaRelay {
+		t.Fatal("a relay-satisfied hive must carry the viaRelay indicator")
+	}
+	if st.Stage != StageNone.String() {
+		t.Errorf("stage = %q, want %q", st.Stage, StageNone.String())
+	}
+}
+
+// ── "Never threaten ACMM" ──────────────────────────────────────────────────
+
+// TestACMMNeverThreatensDeprovision is the strongest product rule: no matter
+// how long a hive rests at a level, an ACMM nudge is always a gentle
+// suggestion and never mentions de-provisioning.
+func TestACMMNeverThreatensDeprovision(t *testing.T) {
+	// Every level below the top, at ages spanning years.
+	ages := []time.Duration{
+		stage3SuggestAfter,
+		stage3SuggestAfter * 2,
+		stage3SuggestAfter * 12,
+		stage3SuggestAfter * 60,
+		365 * 24 * time.Hour * 5,
+	}
+	for level := 1; level < maxACMMLevel; level++ {
+		for _, age := range ages {
+			h := hive(age, func(h *RegistryEntry) { h.ACMMLevel = level })
+			got := nextNudge(h, baseTime)
+			if got.Stage != StageACMMLevel {
+				t.Fatalf("level %d age %s: stage = %v, want %v", level, age, got.Stage, StageACMMLevel)
+			}
+			if got.Severity != SeverityGentle {
+				t.Errorf("level %d age %s: severity = %v, want gentle — ACMM must never escalate",
+					level, age, got.Severity)
+			}
+			lower := strings.ToLower(got.Message)
+			for _, banned := range []string{"de-provision", "deprovision", "reclaim", "shut down", "removed"} {
+				if strings.Contains(lower, banned) {
+					t.Errorf("level %d age %s: ACMM copy must never threaten; found %q in: %s",
+						level, age, banned, got.Message)
+				}
+			}
+		}
+	}
+}
+
+// TestACMMSuggestionIsLevelSpecific checks the copy names the hive's ACTUAL
+// next level and what it entails, rather than nagging generically.
+func TestACMMSuggestionIsLevelSpecific(t *testing.T) {
+	tests := []struct {
+		level       int
+		wantCurrent string
+		wantNext    string
+		wantEntails string
+	}{
+		{1, "L1 Assisted", "L2 Instructed", "advisory"},
+		{2, "L2 Instructed", "L3 Measured", "hold-gated"},
+		{3, "L3 Measured", "L4 Adaptive", "issues"},
+		{4, "L4 Adaptive", "L5 Semi-Automated", "pull requests"},
+		{5, "L5 Semi-Automated", "L6 Fully Autonomous", "auto-merge"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.wantCurrent, func(t *testing.T) {
+			h := hive(stage3SuggestAfter, func(h *RegistryEntry) { h.ACMMLevel = tc.level })
+			msg := nextNudge(h, baseTime).Message
+			if !strings.Contains(msg, tc.wantCurrent) {
+				t.Errorf("copy should name the current level %q: %s", tc.wantCurrent, msg)
+			}
+			if !strings.Contains(msg, tc.wantNext) {
+				t.Errorf("copy should name the next level %q: %s", tc.wantNext, msg)
+			}
+			if !strings.Contains(strings.ToLower(msg), tc.wantEntails) {
+				t.Errorf("copy should say what the next level entails (%q): %s", tc.wantEntails, msg)
+			}
+		})
+	}
+}
+
+// TestMaxACMMLevelGetsNoNudge — a hive at the top has nowhere to graduate to.
+func TestMaxACMMLevelGetsNoNudge(t *testing.T) {
+	h := hive(stage3SuggestAfter*10, func(h *RegistryEntry) { h.ACMMLevel = maxACMMLevel })
+	if got := nextNudge(h, baseTime); got.Stage != StageNone {
+		t.Errorf("stage = %v, want %v for a hive at the maximum level", got.Stage, StageNone)
+	}
+}
+
+// ── De-provision copy is present exactly where it should be ────────────────
+
+func TestDeprovisionWarningCopy(t *testing.T) {
+	tests := []struct {
+		name        string
+		entry       *RegistryEntry
+		wantWarning bool
+	}{
+		{"stage 1 past the window warns",
+			hive(stage1WarnAfter, func(h *RegistryEntry) { h.PendingGitHubAppInstall = true }), true},
+		{"stage 2 past the window warns",
+			hive(stage2WarnAfter, func(h *RegistryEntry) { h.AgentsWithModel = intPtr(0) }), true},
+		{"stage 1 before the window does not warn",
+			hive(stage1FirmAfter, func(h *RegistryEntry) { h.PendingGitHubAppInstall = true }), false},
+		{"stage 3 never warns",
+			hive(stage3SuggestAfter*10, func(h *RegistryEntry) { h.ACMMLevel = 2 }), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := nextNudge(tc.entry, baseTime)
+			mentions := strings.Contains(strings.ToLower(got.Message), "de-provision")
+			if mentions != tc.wantWarning {
+				t.Errorf("de-provision mentioned = %v, want %v; copy: %s",
+					mentions, tc.wantWarning, got.Message)
+			}
+			isWarn := got.Severity == SeverityDeprovisionWarning
+			if isWarn != tc.wantWarning {
+				t.Errorf("severity warning = %v, want %v", isWarn, tc.wantWarning)
+			}
+		})
+	}
+}
+
+// TestNudgeCopyIsActionable checks every generated message says what to do,
+// not merely that something is wrong.
+func TestNudgeCopyIsActionable(t *testing.T) {
+	cases := []*RegistryEntry{
+		hive(stage1GentleAfter, func(h *RegistryEntry) { h.PendingGitHubAppInstall = true }),
+		hive(stage1FirmAfter, func(h *RegistryEntry) { h.PendingGitHubAppInstall = true }),
+		hive(stage1WarnAfter, func(h *RegistryEntry) { h.PendingGitHubAppInstall = true }),
+		hive(stage2GraceAfter, func(h *RegistryEntry) { h.AgentsWithModel = intPtr(0) }),
+		hive(stage2WarnAfter, func(h *RegistryEntry) { h.AgentsWithModel = intPtr(0) }),
+		hive(stage3SuggestAfter, func(h *RegistryEntry) { h.ACMMLevel = 2 }),
+	}
+	// minActionableCopyLen is a floor that a bare "please fix this" cannot meet.
+	const minActionableCopyLen = 80
+	for i, h := range cases {
+		got := nextNudge(h, baseTime)
+		if len(got.Message) < minActionableCopyLen {
+			t.Errorf("case %d: copy too terse to be actionable: %q", i, got.Message)
+		}
+		// Each message must point at a concrete place to go.
+		lower := strings.ToLower(got.Message)
+		if !strings.Contains(lower, "settings") && !strings.Contains(lower, "agents") &&
+			!strings.Contains(lower, "config") && !strings.Contains(lower, "/contribute") {
+			t.Errorf("case %d: copy names no destination: %s", i, got.Message)
+		}
+	}
+}
+
+// ── Unknown / missing signals never produce a nudge ────────────────────────
+
+func TestUnknownSignalsNeverNudge(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry *RegistryEntry
+	}{
+		{"nil entry", nil},
+		{"unparseable registration timestamp",
+			&RegistryEntry{RegisteredAt: "not-a-time", PendingGitHubAppInstall: true}},
+		{"empty registration timestamp",
+			&RegistryEntry{PendingGitHubAppInstall: true}},
+		{"old spoke that never reported the model signal",
+			hive(stage2WarnAfter*3, func(h *RegistryEntry) { h.AgentsWithModel = nil })},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nextNudge(tc.entry, baseTime); got.Stage != StageNone {
+				t.Errorf("stage = %v, want %v — never nudge on a signal we do not have",
+					got.Stage, StageNone)
+			}
+		})
+	}
+}
+
+// TestFutureRegistrationClampsToZero guards against a clock skew producing a
+// negative age and a nonsense escalation.
+func TestFutureRegistrationClampsToZero(t *testing.T) {
+	h := &RegistryEntry{
+		RegisteredAt:            baseTime.Add(48 * time.Hour).Format(time.RFC3339),
+		PendingGitHubAppInstall: true,
+		AgentsWithModel:         intPtr(1),
+	}
+	if got := nextNudge(h, baseTime); got.Severity != SeverityNone {
+		t.Errorf("severity = %v, want none for a hive registered in the future", got.Severity)
+	}
+}
+
+// ── Idempotence / re-send intervals ────────────────────────────────────────
+
+func TestShouldSendRespectsResendInterval(t *testing.T) {
+	n := nudge{Stage: StageGitHubApp, Severity: SeverityGentle, Resend: stage1ResendInterval}
+	sentAt := baseTime.Add(-stage1ResendInterval)
+	state := func(offset time.Duration) *JourneyState {
+		return &JourneyState{
+			LastStage:    StageGitHubApp.String(),
+			LastSeverity: SeverityGentle.String(),
+			LastSentAt:   baseTime.Add(offset).Format(time.RFC3339),
+		}
+	}
+
+	tests := []struct {
+		name  string
+		nudge nudge
+		state *JourneyState
+		want  bool
+	}{
+		{"no state means never sent, so send", n, nil, true},
+		{"empty timestamp means never sent, so send", n, &JourneyState{}, true},
+		{"just sent, do not repeat", n, state(-time.Minute), false},
+		{"one second before the interval elapses, do not repeat",
+			n, state(-stage1ResendInterval + time.Second), false},
+		{"exactly at the interval, send again", n, state(-stage1ResendInterval), true},
+		{"long past the interval, send again", n, state(-stage1ResendInterval * 5), true},
+		{
+			"an escalation sends immediately, ignoring the interval",
+			nudge{Stage: StageGitHubApp, Severity: SeverityFirm, Resend: stage1ResendInterval},
+			state(-time.Minute),
+			true,
+		},
+		{
+			"a stage change sends immediately",
+			nudge{Stage: StageMethodModel, Severity: SeverityGentle, Resend: stage2ResendInterval},
+			state(-time.Minute),
+			true,
+		},
+		{
+			"an unparseable timestamp re-sends once rather than going silent",
+			n,
+			&JourneyState{LastStage: StageGitHubApp.String(), LastSeverity: SeverityGentle.String(), LastSentAt: "bogus"},
+			true,
+		},
+		{"nothing to say is never sent", nudge{}, nil, false},
+		{
+			"a stage with no severity is never sent",
+			nudge{Stage: StageGitHubApp, Severity: SeverityNone},
+			nil,
+			false,
+		},
+	}
+	_ = sentAt
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldSend(tc.nudge, tc.state, baseTime); got != tc.want {
+				t.Errorf("shouldSend() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResendIntervalsMatchUrgency locks in the product's cadence ordering:
+// urgent nudges repeat more often than the monthly ACMM suggestion.
+func TestResendIntervalsMatchUrgency(t *testing.T) {
+	if !(stage1ResendInterval < stage2ResendInterval && stage2ResendInterval < stage3ResendInterval) {
+		t.Errorf("re-send intervals must increase with decreasing urgency: %s, %s, %s",
+			stage1ResendInterval, stage2ResendInterval, stage3ResendInterval)
+	}
+	if stage3ResendInterval < 28*24*time.Hour {
+		t.Errorf("the ACMM suggestion must be about monthly, got %s", stage3ResendInterval)
+	}
+}
+
+// TestJourneyBannerIDChangesOnEscalation ensures each escalation step is a NEW
+// banner, so an owner who dismissed the gentle one still sees the firm one.
+func TestJourneyBannerIDChangesOnEscalation(t *testing.T) {
+	gentle := journeyBannerID(nudge{Stage: StageGitHubApp, Severity: SeverityGentle}, 0)
+	firm := journeyBannerID(nudge{Stage: StageGitHubApp, Severity: SeverityFirm}, 0)
+	warn := journeyBannerID(nudge{Stage: StageGitHubApp, Severity: SeverityDeprovisionWarning}, 0)
+	ids := map[string]bool{gentle: true, firm: true, warn: true}
+	if len(ids) != 3 {
+		t.Errorf("each escalation step needs a distinct banner ID, got %v", ids)
+	}
+	for _, id := range []string{gentle, firm, warn} {
+		if !isJourneyBanner(id) {
+			t.Errorf("%q should be recognised as a journey banner", id)
+		}
+	}
+	// ACMM IDs embed the level so a new suggestion appears after graduating.
+	l2 := journeyBannerID(nudge{Stage: StageACMMLevel, Severity: SeverityGentle}, 2)
+	l3 := journeyBannerID(nudge{Stage: StageACMMLevel, Severity: SeverityGentle}, 3)
+	if l2 == l3 {
+		t.Error("ACMM banner IDs must differ per level so a graduated hive gets a fresh suggestion")
+	}
+	if isJourneyBanner(bannerIDPrefix + "123") {
+		t.Error("an admin banner must not be mistaken for a journey banner")
+	}
+}
+
+// ── Snooze ─────────────────────────────────────────────────────────────────
+
+func TestSnoozeActive(t *testing.T) {
+	tests := []struct {
+		name  string
+		state *JourneyState
+		want  bool
+	}{
+		{"nil state", nil, false},
+		{"no snooze set", &JourneyState{}, false},
+		{"snoozed into the future",
+			&JourneyState{SnoozedUntil: baseTime.Add(time.Hour).Format(time.RFC3339)}, true},
+		{"snooze expired",
+			&JourneyState{SnoozedUntil: baseTime.Add(-time.Hour).Format(time.RFC3339)}, false},
+		{"snooze expiring exactly now is no longer active",
+			&JourneyState{SnoozedUntil: baseTime.Format(time.RFC3339)}, false},
+		{"corrupt timestamp fails toward nudging, not toward silence",
+			&JourneyState{SnoozedUntil: "nonsense"}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.state.snoozeActive(baseTime); got != tc.want {
+				t.Errorf("snoozeActive() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseSnoozeUntil(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		wantZero bool
+		wantErr  bool
+	}{
+		{"empty clears the snooze", "", true, false},
+		{"zero clears the snooze", "0", true, false},
+		{"negative clears the snooze", "-5h", true, false},
+		{"a week is fine", "168h", false, false},
+		{"the maximum is accepted", maxJourneySnoozeDuration.String(), false, false},
+		{"beyond the maximum is rejected", (maxJourneySnoozeDuration + time.Hour).String(), true, true},
+		{"garbage is rejected", "soon", true, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseSnoozeUntil(tc.raw, baseTime)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err = %v, wantErr %v", err, tc.wantErr)
+			}
+			if got.IsZero() != tc.wantZero {
+				t.Errorf("zero = %v, want %v", got.IsZero(), tc.wantZero)
+			}
+		})
+	}
+}
+
+// TestSnoozeSuppressesStatus verifies a snoozed hive is displayed as snoozed
+// even while a stage is genuinely outstanding.
+func TestSnoozeSuppressesStatus(t *testing.T) {
+	h := hive(stage1WarnAfter*2, func(h *RegistryEntry) { h.PendingGitHubAppInstall = true })
+	st := &JourneyState{SnoozedUntil: baseTime.Add(24 * time.Hour).Format(time.RFC3339)}
+	got := JourneyStatusFor(h, st, baseTime)
+	if !got.Snoozed {
+		t.Error("a snoozed hive must report Snoozed")
+	}
+	if got.SnoozedUntil != st.SnoozedUntil {
+		t.Errorf("SnoozedUntil = %q, want %q", got.SnoozedUntil, st.SnoozedUntil)
+	}
+	// The underlying stage is still reported so an admin can see what is
+	// being suppressed.
+	if got.Stage != StageGitHubApp.String() {
+		t.Errorf("stage = %q, want %q", got.Stage, StageGitHubApp.String())
+	}
+}
+
+// ── Store persistence ──────────────────────────────────────────────────────
+
+// withTempStatePath redirects journeyStatePath at a temp file for the duration
+// of a test.
+func withTempStatePath(t *testing.T) {
+	t.Helper()
+	orig := journeyStatePath
+	journeyStatePath = filepath.Join(t.TempDir(), "journey-state.json")
+	t.Cleanup(func() { journeyStatePath = orig })
+}
+
+func TestJourneyStoreRoundTrip(t *testing.T) {
+	withTempStatePath(t)
+
+	store := newJourneyStore()
+	n := nudge{Stage: StageGitHubApp, Severity: SeverityFirm}
+	store.recordSent("hive-1", n, 0, baseTime)
+	store.setSnooze("hive-2", baseTime.Add(24*time.Hour), "admin", "vendor pilot")
+	if err := store.save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	reloaded := newJourneyStore()
+	if err := reloaded.load(baseTime); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	got := reloaded.get("hive-1")
+	if got == nil || got.LastStage != StageGitHubApp.String() || got.LastSeverity != SeverityFirm.String() {
+		t.Errorf("hive-1 state did not survive the round trip: %+v", got)
+	}
+	sn := reloaded.get("hive-2")
+	if sn == nil || !sn.snoozeActive(baseTime) {
+		t.Errorf("hive-2 snooze did not survive the round trip: %+v", sn)
+	}
+	if sn.SnoozedBy != "admin" || sn.SnoozeReason != "vendor pilot" {
+		t.Errorf("snooze audit fields lost: %+v", sn)
+	}
+}
+
+// TestJourneyStoreDropsExpiredSnoozeOnLoad — a forgotten exemption must lapse.
+func TestJourneyStoreDropsExpiredSnoozeOnLoad(t *testing.T) {
+	withTempStatePath(t)
+
+	store := newJourneyStore()
+	store.setSnooze("hive-1", baseTime.Add(time.Hour), "admin", "short pilot")
+	if err := store.save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	reloaded := newJourneyStore()
+	// Load well after the snooze expired.
+	if err := reloaded.load(baseTime.Add(48 * time.Hour)); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	got := reloaded.get("hive-1")
+	if got == nil {
+		t.Fatal("state should still exist")
+	}
+	if got.SnoozedUntil != "" {
+		t.Errorf("expired snooze should be cleared on load, got %q", got.SnoozedUntil)
+	}
+}
+
+func TestJourneyStoreMissingFileIsNotAnError(t *testing.T) {
+	withTempStatePath(t)
+	store := newJourneyStore()
+	if err := store.load(baseTime); err != nil {
+		t.Errorf("a missing state file must not be an error, got %v", err)
+	}
+}
+
+func TestJourneyStoreGetReturnsACopy(t *testing.T) {
+	withTempStatePath(t)
+	store := newJourneyStore()
+	store.recordSent("hive-1", nudge{Stage: StageGitHubApp, Severity: SeverityGentle}, 0, baseTime)
+	got := store.get("hive-1")
+	got.LastStage = "tampered"
+	if again := store.get("hive-1"); again.LastStage != StageGitHubApp.String() {
+		t.Error("get() must return a copy so callers cannot mutate shared state")
+	}
+	if store.get("missing") != nil {
+		t.Error("get() on an unknown hive should return nil")
+	}
+}
+
+func TestJourneyStoreSaveIsSkippedWhenClean(t *testing.T) {
+	withTempStatePath(t)
+	store := newJourneyStore()
+	// Nothing recorded → nothing to write.
+	if err := store.save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if _, err := os.Stat(journeyStatePath); !os.IsNotExist(err) {
+		t.Error("a clean store must not write a file")
+	}
+}
+
+// TestRecordSentTracksACMMLevel verifies the ACMM level is remembered so a
+// graduated hive gets a fresh suggestion.
+func TestRecordSentTracksACMMLevel(t *testing.T) {
+	withTempStatePath(t)
+	store := newJourneyStore()
+	store.recordSent("hive-1", nudge{Stage: StageACMMLevel, Severity: SeverityGentle}, 3, baseTime)
+	if got := store.get("hive-1"); got.LastACMMLevel != 3 {
+		t.Errorf("LastACMMLevel = %d, want 3", got.LastACMMLevel)
+	}
+	// A non-ACMM nudge must not overwrite the recorded level.
+	store.recordSent("hive-1", nudge{Stage: StageGitHubApp, Severity: SeverityFirm}, 5, baseTime)
+	if got := store.get("hive-1"); got.LastACMMLevel != 3 {
+		t.Errorf("LastACMMLevel = %d, want it unchanged at 3", got.LastACMMLevel)
+	}
+}
+
+// ── Presentation helpers ───────────────────────────────────────────────────
+
+func TestSeverityBannerColorIsAlwaysValid(t *testing.T) {
+	for _, s := range []JourneySeverity{SeverityNone, SeverityGentle, SeverityFirm, SeverityDeprovisionWarning} {
+		if !validBannerColors[s.bannerColor()] {
+			t.Errorf("severity %v maps to invalid banner color %q", s, s.bannerColor())
+		}
+	}
+}
+
+func TestStageAndSeverityStrings(t *testing.T) {
+	if StageNone.String() != "none" || StageGitHubApp.String() != "github-app" ||
+		StageMethodModel.String() != "method-model" || StageACMMLevel.String() != "acmm-level" {
+		t.Error("stage tokens must stay stable — the UI keys off them")
+	}
+	if SeverityNone.String() != "none" || SeverityGentle.String() != "gentle" ||
+		SeverityFirm.String() != "firm" || SeverityDeprovisionWarning.String() != "deprovision-warning" {
+		t.Error("severity tokens must stay stable — the UI keys off them")
+	}
+}
+
+func TestACMMLevelLabel(t *testing.T) {
+	tests := []struct {
+		level int
+		want  string
+	}{
+		{1, "L1 Assisted"},
+		{6, "L6 Fully Autonomous"},
+		{99, "L99"}, // unknown levels degrade gracefully, never "L99 <nil>"
+	}
+	for _, tc := range tests {
+		if got := acmmLevelLabel(tc.level); got != tc.want {
+			t.Errorf("acmmLevelLabel(%d) = %q, want %q", tc.level, got, tc.want)
+		}
+	}
+}
+
+func TestHumanDuration(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Minute, "under an hour"},
+		{time.Hour, "under an hour"},
+		{5 * time.Hour, "5 hours"},
+		{25 * time.Hour, "1 day"},
+		{72 * time.Hour, "3 days"},
+	}
+	for _, tc := range tests {
+		if got := humanDuration(tc.d); got != tc.want {
+			t.Errorf("humanDuration(%s) = %q, want %q", tc.d, got, tc.want)
+		}
+	}
+}
+
+func TestOrgLabelFallbacks(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry *RegistryEntry
+		want  string
+	}{
+		{"nil", nil, "your organization"},
+		{"org wins", &RegistryEntry{Org: "acme", Name: "acme/widget"}, "acme"},
+		{"name is the fallback", &RegistryEntry{Name: "acme/widget"}, "acme/widget"},
+		{"blank falls back to generic copy", &RegistryEntry{Org: "  "}, "your organization"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := orgLabel(tc.entry); got != tc.want {
+				t.Errorf("orgLabel() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestJourneyStatusForNilState covers the common path where a hive has never
+// been nudged.
+func TestJourneyStatusForNilState(t *testing.T) {
+	h := hive(stage1FirmAfter, func(h *RegistryEntry) { h.PendingGitHubAppInstall = true })
+	got := JourneyStatusFor(h, nil, baseTime)
+	if got.Stage != StageGitHubApp.String() || got.Severity != SeverityFirm.String() {
+		t.Errorf("unexpected status: %+v", got)
+	}
+	if got.StageNum != int(StageGitHubApp) {
+		t.Errorf("StageNum = %d, want %d", got.StageNum, int(StageGitHubApp))
+	}
+	if got.StalledFor == "" {
+		t.Error("a stalled hive should report how long it has been stalled")
+	}
+	if got.Snoozed {
+		t.Error("a hive with no state must not report as snoozed")
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -177,6 +177,8 @@ func (s *HubServer) registerSaaSRoutes() {
 	s.mux.HandleFunc("DELETE /api/saas/admin/hub-banner", s.requireAdmin(s.handleClearHubBanner))
 	s.mux.HandleFunc("GET /api/saas/admin/hub-banner", s.requireAdmin(s.handleGetHubBanner))
 	s.registerBulkRoutes()
+	s.mux.HandleFunc("POST /api/saas/admin/journey-snooze", s.requireAdmin(s.handleJourneySnooze))
+	s.mux.HandleFunc("GET /api/saas/admin/journey-status", s.requireAdmin(s.handleJourneyStatus))
 
 	// Under `go test` these long-lived pollers leak across test cases: they
 	// immediately hit the GitHub API and read the package-level saas path
@@ -1554,6 +1556,15 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 	// been collected and enriched (a row still missing its provStatus would be
 	// misread as a claimed hive and flagged for having no App).
 	annotateDrift(result, getDisplaySHAs(), time.Now())
+
+	// Attach the user-journey stage to every row so the table can show who is
+	// stalled where. Derived on read; never persisted on the registry entry.
+	journeyNow := time.Now()
+	for i := range result {
+		st := s.journey.get(result[i].ID)
+		status := JourneyStatusFor(&result[i].RegistryEntry, st, journeyNow)
+		result[i].Journey = &status
+	}
 
 	resp := map[string]any{
 		"hives":                   result,
@@ -5391,6 +5402,21 @@ const dashboardHTML = `<!DOCTYPE html>
     .acmm-5 { background: rgba(255,126,126,0.15); color: #ff7e7e; border: 1px solid rgba(255,126,126,0.3); }
     .acmm-6 { background: rgba(180,130,255,0.15); color: #b482ff; border: 1px solid rgba(180,130,255,0.3); }
 
+    /* ── User-journey stage badges ──
+       Severity drives the color so a stalled hive is scannable at a glance:
+       green = nothing outstanding, blue = a gentle nudge, amber = overdue,
+       red = a de-provision warning has been sent. */
+    .journey-badge { display: inline-block; padding: 3px 9px; border-radius: 9999px; font-size: 0.65rem; font-weight: 700; white-space: nowrap; cursor: help; }
+    .journey-none { background: rgba(116,223,154,0.12); color: #74df9a; border: 1px solid rgba(116,223,154,0.28); }
+    .journey-gentle { background: rgba(128,191,255,0.15); color: #80bfff; border: 1px solid rgba(128,191,255,0.3); }
+    .journey-firm { background: rgba(244,199,95,0.15); color: #f4c75f; border: 1px solid rgba(244,199,95,0.3); }
+    .journey-deprovision-warning { background: rgba(255,126,126,0.18); color: #ff7e7e; border: 1px solid rgba(255,126,126,0.4); }
+    .journey-snoozed { background: rgba(107,114,128,0.15); color: #9ca3af; border: 1px solid rgba(107,114,128,0.3); }
+    /* The relay badge marks a hive satisfying stage 2 through human
+       contributors rather than an assigned method/model — deliberately its own
+       label so such a hive is never silently reported as "assigned". */
+    .journey-relay { display: inline-block; margin-left: 4px; padding: 3px 8px; border-radius: 9999px; font-size: 0.62rem; font-weight: 700; white-space: nowrap; cursor: help; background: rgba(45,212,191,0.15); color: #2dd4bf; border: 1px solid rgba(45,212,191,0.3); }
+
     /* ── Buttons ── */
     .btn-primary { display: inline-flex; align-items: center; justify-content: center; padding: .72rem 1.2rem; background: var(--amber); color: #17110a; font-weight: 800; border-radius: .55rem; border: none; cursor: pointer; font-size: 0.85rem; transition: all .2s; }
     .btn-primary:hover { background: #f8d87a; text-decoration: none; }
@@ -5645,6 +5671,58 @@ const dashboardHTML = `<!DOCTYPE html>
       var l = level || 0;
       var tips = {1:'L1 Assisted — Advisory only.',2:'L2 Instructed — Advisory beads, no GitHub writes.',3:'L3 Measured — Hold-gated PRs, CI gates.',4:'L4 Adaptive — Agents open issues, sec-check.',5:'L5 Semi-Automated — PRs with hold label, batch review.',6:'L6 Autonomous — Auto-merge on green CI.'};
       return '<span class="acmm-badge acmm-' + l + '" title="' + esc(tips[l] || '') + '">' + (ACMM_LABELS[l] || 'L' + l) + '</span>';
+    }
+    /* Labels for each journey stage, matching JourneyStage.String() on the hub. */
+    var JOURNEY_STAGE_LABELS = {
+      'none': 'On track',
+      'github-app': 'GitHub App',
+      'method-model': 'Method/model',
+      'acmm-level': 'ACMM',
+    };
+    /* What each stage means, for the hover tooltip. */
+    var JOURNEY_STAGE_TIPS = {
+      'none': 'No outstanding adoption steps.',
+      'github-app': 'Stage 1 — the GitHub App is not installed, so no agent can open issues or PRs.',
+      'method-model': 'Stage 2 — no agent has a method/model assigned and the contributor relay is not in use.',
+      'acmm-level': 'Stage 3 — running steadily; due a gentle suggestion to consider the next ACMM level. Never a de-provision risk.',
+    };
+    /* Rank a journey status for sorting. Snoozed hives rank lowest — an admin
+       has already dealt with them — then on-track, then by escalation. */
+    var JOURNEY_SEVERITY_RANK = {'none': 0, 'gentle': 1, 'firm': 2, 'deprovision-warning': 3};
+    function journeySortValue(j) {
+      if (!j) return -1;
+      if (j.snoozed) return -1;
+      var sev = JOURNEY_SEVERITY_RANK[j.severity || 'none'] || 0;
+      /* SEVERITY_SPAN spaces the stage ranks apart so severity orders within a
+         stage without ever bleeding into the next stage's band. */
+      var SEVERITY_SPAN = 10;
+      return (j.stageNum || 0) * SEVERITY_SPAN + sev;
+    }
+    function journeyBadge(j) {
+      if (!j) return '<span style="color:var(--muted)">—</span>';
+      var stage = j.stage || 'none';
+      var label = JOURNEY_STAGE_LABELS[stage] || stage;
+      var tip = JOURNEY_STAGE_TIPS[stage] || '';
+      if (j.stalledFor && stage !== 'none') tip += ' Stalled for ' + j.stalledFor + '.';
+      /* A snoozed hive shows as snoozed regardless of stage — an admin has
+         exempted it, so it must not read as an active problem. */
+      var cls, text;
+      if (j.snoozed) {
+        cls = 'journey-snoozed';
+        text = label + ' (snoozed)';
+        tip = 'Nudges snoozed by an admin' + (j.snoozedUntil ? ' until ' + j.snoozedUntil : '') + '. ' + tip;
+      } else {
+        var sev = j.severity || 'none';
+        cls = 'journey-' + (sev === 'none' ? 'none' : sev);
+        text = label;
+        if (sev === 'deprovision-warning') text = label + ' ⚠';
+      }
+      var html = '<span class="journey-badge ' + cls + '" title="' + esc(tip) + '">' + esc(text) + '</span>';
+      /* Stage 2 satisfied via the contributor relay gets its own visible badge. */
+      if (j.viaRelay) {
+        html += '<span class="journey-relay" title="' + esc('Stage 2 is satisfied through the contributor relay (human contributors picking up tasks), not by an assigned method/model.') + '">relay</span>';
+      }
+      return html;
     }
     function roleBadge(role) {
       var cls = role === 'owner' ? 'role-owner' : role === 'read-write' ? 'role-read-write' : 'role-read';
@@ -6369,7 +6447,17 @@ const dashboardHTML = `<!DOCTYPE html>
     function sortDashHives(key) {
       if (_dashSortKey === key) { _dashSortAsc = !_dashSortAsc; } else { _dashSortKey = key; _dashSortAsc = true; }
       var sorted = _allDashHives.slice().sort(function(a, b) {
-        var va = a[key] || '', vb = b[key] || '';
+        var va, vb;
+        if (key === 'journey') {
+          /* journey is an object, so sort by how urgent it is rather than by
+             stringifying it. Higher = needs attention sooner, so the default
+             ascending sort puts on-track hives first and the most-escalated
+             last; click again to bring the problems to the top. */
+          va = journeySortValue(a.journey);
+          vb = journeySortValue(b.journey);
+          return _dashSortAsc ? va - vb : vb - va;
+        }
+        va = a[key] || ''; vb = b[key] || '';
         if (typeof va === 'number' && typeof vb === 'number') return _dashSortAsc ? va - vb : vb - va;
         return _dashSortAsc ? String(va).localeCompare(String(vb)) : String(vb).localeCompare(String(va));
       });
@@ -7154,10 +7242,11 @@ const dashboardHTML = `<!DOCTYPE html>
         if (h.pendingRequestCount > 0 && (h.role === 'owner' || h.role === 'read-write')) {
           pendingPill = '<a href="#" onclick="togglePendingRow(\'' + esc(h.id) + '\');return false" style="display:inline-flex;align-items:center;gap:4px;padding:3px 10px;background:rgba(59,130,246,0.12);color:#60a5fa;border:1px solid rgba(59,130,246,0.3);border-radius:4px;font-size:0.7rem;text-decoration:none;cursor:pointer;white-space:nowrap">&#x1F514; ' + h.pendingRequestCount + ' pending</a>';
         }
-        // 16 = the 13 original columns, plus Uptime, plus Drift, plus the
-        // bulk-select column. Counted against the <th> cells in the header and
-        // the <td> cells emitted below (bulkCheckboxCell contributes one).
-        var TOTAL_COLUMNS = 16;
+        // 17 = the 13 original columns, plus Uptime, plus Drift, plus the
+        // bulk-select column, plus Journey. Counted against the <th> cells in
+        // the header and the <td> cells emitted below (bulkCheckboxCell
+        // contributes one).
+        var TOTAL_COLUMNS = 17;
         var pendingExpandRow = '';
         if (h.pendingRequestCount > 0 && (h.role === 'owner' || h.role === 'read-write') && (h.pending_requests || []).length > 0) {
           var prItems = (h.pending_requests || []).map(function(pr) {
@@ -7186,6 +7275,7 @@ const dashboardHTML = `<!DOCTYPE html>
           '<td style="font-size:0.7rem;white-space:nowrap">' + versionCell + '</td>' +
           '<td title="' + esc((h.repos || []).join('\n')) + '" style="cursor:' + (repoCount > 0 ? 'help' : 'default') + '">' + repoCount + '</td>' +
           '<td>' + acmmBadge(h.acmmLevel) + '</td>' +
+          '<td>' + journeyBadge(h.journey) + '</td>' +
           '<td title="' + esc((h.agents || []).map(function(a){ var label = a.name + ' (' + a.state + ')'; if (a.mode === 'on_demand') label += ' — on demand'; return label; }).join('\n')) + '" style="cursor:' + ((h.agentCount || 0) > 0 ? 'help' : 'default') + '">' + (h.agentCount || 0) + '</td>' +
           '<td title="Cumulative tokens consumed, as of the last heartbeat" style="white-space:nowrap;cursor:help">' + fmtTokens(h.totalTokens24h || 0) + '</td>' +
           '<td>' + modeCell + '</td>' +
@@ -7199,9 +7289,9 @@ const dashboardHTML = `<!DOCTYPE html>
          match the table's muted uppercase heading treatment (see .hive-table th). */
       /* Count of <th> cells in the hive table header below. The section-header
          row spans all of them; a stale value would leave the separator short
-         and the table visibly ragged. 15 with the Drift column, plus one more
-         for the bulk-select column added here. */
-      var TOTAL_COLUMNS_HEADER = 16;
+         and the table visibly ragged. 15 with the Drift column, plus the
+         bulk-select column, plus the Journey column added here. */
+      var TOTAL_COLUMNS_HEADER = 17;
       /* section, when given, adds a select-all checkbox scoped to THIS
          section's rows only (Assigned and Unassigned select independently). */
       var sectionHeader = function(label, count, section) {
@@ -7246,7 +7336,7 @@ const dashboardHTML = `<!DOCTYPE html>
         /* Non-admin lists have no section headers, so the flat list's
            select-all lives in the table head instead. */
         '<th style="width:26px;text-align:center">' + (_isAdmin ? '' : bulkSectionCheckbox('all')) + '</th>' +
-        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer">Location ⇅</th><th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅</th><th>Public</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th>' +
+        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer">Location ⇅</th><th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅</th><th>Public</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'journey\')" style="cursor:pointer" title="Where this hive is on the adoption journey: install the GitHub App, assign a method/model (or run the contributor relay), then raise the ACMM level">Journey ⇅</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th>' +
         '<th title="Configuration drift from the fleet norm — hover a value for the specific signals">Drift</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table></div>';
       /* Re-derive the bar and the select-all tri-state from _bulkSelected now

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -119,6 +119,15 @@ type RegistryEntry struct {
 	PRsMerged90d   *int `json:"prsMerged90d,omitempty"`
 	PRsRejected90d *int `json:"prsRejected90d,omitempty"`
 	CVEsClosed     *int `json:"cvesClosed,omitempty"`
+	// AgentsWithModel is the spoke-reported count of agents that have a method
+	// (backend) or model assigned. nil = the spoke is too old to report it, so
+	// journey stage 2 is treated as unknown rather than unsatisfied.
+	AgentsWithModel *int `json:"agentsWithModel,omitempty"`
+	// Journey is the computed user-journey status (which adoption stage this
+	// hive is stalled on, how hard it is being nudged, and whether stage 2 is
+	// satisfied via the contributor relay). Computed on read from the journey
+	// state store — never persisted on the registry entry itself.
+	Journey *JourneyStatus `json:"journey,omitempty"`
 }
 
 type SparkPoint struct {
@@ -318,6 +327,10 @@ type HubServer struct {
 	// answerable from the hub instead of `kubectl logs`. It carries its own
 	// leaf mutex and is never guarded by s.mu. See timeline.go.
 	timeline *timelineStore
+
+	// journey holds per-hive user-journey nudge state: which banner each owner
+	// was last sent and when, plus admin snoozes. Persisted to the PVC.
+	journey *journeyStore
 }
 
 // HubBannerEntry stores an admin banner targeted at a specific hive.
@@ -443,11 +456,17 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		pendingGateways:         make(map[string]*HeartbeatGatewayConfig),
 		hubBanners:              make(map[string]*HubBannerEntry),
 		timeline:                newTimelineStore(),
+		journey:                 newJourneyStore(),
 	}
 
 	s.loadRegistry()
 	s.loadHubBanners()
 	s.timeline.load()
+	if err := s.journey.load(time.Now()); err != nil {
+		// Losing journey state is a soft failure: the worst case is that a few
+		// owners get one duplicate nudge. Never block hub startup on it.
+		logger.Error("failed to load journey nudge state", "error", err)
+	}
 
 	s.mux.HandleFunc("POST /api/heartbeat", s.handleHeartbeat)
 	s.mux.HandleFunc("POST /api/task-status", s.handleTaskStatus)
@@ -680,6 +699,9 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		PRsMerged90d:   clampFleetCount(payload.PRsMerged90d),
 		PRsRejected90d: clampFleetCount(payload.PRsRejected90d),
 		CVEsClosed:     clampFleetCount(payload.CVEsClosed),
+		// Preserve nil (old spoke, unknown) vs a real count — journey stage
+		// detection depends on telling those two apart.
+		AgentsWithModel: clampFleetCount(payload.AgentsWithModel),
 	}
 
 	// Populate ClusterID from SaaS hive record, heartbeat payload, or default.
@@ -1004,6 +1026,16 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	s.hubBannersMu.RUnlock()
+
+	// User-journey nudge. An admin-sent banner always wins: a human took the
+	// trouble to target this hive, so an automated reminder must not displace
+	// it. Journey nudges therefore only fill an empty slot (or replace a
+	// previous journey banner, which is this subsystem's own to update).
+	if resp.HubBanner == nil || isJourneyBanner(resp.HubBanner.ID) {
+		if jb := s.journeyBannerFor(payload.HiveID, time.Now()); jb != nil {
+			resp.HubBanner = jb
+		}
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	data, _ := json.Marshal(resp)


### PR DESCRIPTION
## What

Detects where each hive owner is stalled on the adoption journey and sends escalating banner reminders, with de-provisioning warnings where the product policy allows them.

**This system only warns. It never de-provisions anything.** No code path here deletes, scales down, or reclaims a spoke — the strongest action it takes is putting a warning banner on the owner's dashboard. Actually de-provisioning a hive remains a human decision made outside this system.

## The three stages

Stage detection is server-side and derived from data the hub already holds (plus one new heartbeat field, below). A hive's current stage is the **first unsatisfied one**.

### Stage 1 — Install the GitHub App (URGENT)

The only stage that escalates this fast, per the product policy of "immediately, and never outstanding more than 1-2 weeks":

| Age since registration | Severity | Copy |
|---|---|---|
| 2 days | gentle | friendly "one step left before your agents can work" |
| 7 days | firm | "no agent can open an issue or a PR — the hive is running but cannot do any work" |
| 14 days | **de-provision warning** | names the consequence explicitly |

**Detected from** `RegistryEntry.PendingGitHubAppInstall`, or `GitHubAppRequired` combined with a non-empty `GitHubAppPermIssue` (`v2/pkg/hub/server.go:102-105`, populated at `server.go:644-652`). A hive that never asked for App auth is treated as satisfied — stage 1 does not apply to it.

### Stage 2 — Assign a method/model to an agent (MEDIUM)

Firm at 2 weeks, de-provision warning at 3 weeks, matching the "~2-3 weeks after stage 1" window.

**The contributor relay is a full substitute.** A hive satisfying this stage through the relay is never nudged and never threatened for it, at any age — and it is shown with its own distinct `relay` badge in My Hives rather than being silently reported as "assigned".

A de-provision warning fires only when **neither** a method/model **nor** the relay is in use.

### Stage 3 — Raise the ACMM level (SLOW, never threatened)

A gentle suggestion about once a month, and nothing else. **Never threatens de-provisioning at any age or level** — enforced in `nextNudge`, guarded a second time in the dispatch path (which refuses to emit an ACMM de-provision warning and logs an error if one were ever constructed), and asserted by a test that sweeps every level below the maximum across ages up to five years, scanning the copy for "de-provision", "reclaim", "shut down", and "removed".

Suggestions are specific to the hive's actual level, using the real names and behavior from the authoritative pack definitions in `v2/pkg/config/packs/level-*.yaml`:

> Your hive has been running at **L2 Instructed** for a while now. When it feels right, consider graduating to **L3 Measured**: the quality agent starts opening issues and hold-gated PRs about testing gaps, and ci-maintainer joins to watch build health — nothing merges without you. There is no deadline and no obligation — move up only when your team is ready.

A hive already at L6 gets no ACMM nudge — there is nowhere to graduate to.

## Heartbeat extension — and why it was necessary

Two of the three stages needed no new data. One did.

**No extension needed for the relay.** `ContributorCount` and `ActiveContributors` already reach the hub (`v2/pkg/hub/heartbeat.go:213`, stored at `server.go:604-605`), as does `Leaderboard[].CurrentTask` — the genuine "a human is working a task right now" signal.

**Extension required for method/model.** `AgentSummary` (`v2/pkg/hub/heartbeat.go:116-120`) carries only `Name`, `State`, and `Mode`; `Mode` is only ever `"on_demand"`. Neither backend nor model was reported anywhere, on any payload. The hub had **zero** signal for this stage.

Added `HeartbeatPayload.AgentsWithModel *int`, counted spoke-side by the new `Manager.CountAgentsWithModel()`, which resolves `BackendOverride`/`ModelOverride`/`PinnedModel` ahead of `Config.Backend`/`Config.Model` exactly as the launcher does.

It is a **pointer**, following the existing `PRsMerged90d` precedent: a spoke too old to report it sends `nil`, which the hub reads as *"unknown — do not nudge"*, never as a genuine zero. We never threaten a hive over a signal that was never sent. A per-agent `omitempty` string would have made an old spoke indistinguishable from a genuinely unassigned agent.

An agent counts as assigned if **either** a backend or a model is set — "claude with the default model" and "default backend pinned to a model" are both real assignments. `"auto"` and `"default"` are deliberate routing selections and count as assigned; only a wholly empty backend *and* model reads as unassigned.

## Thresholds — all in one place

Every duration is a named constant with a comment, in a single tunable block at the top of `v2/pkg/hub/journey.go`. Nothing below that block hard-codes a bare duration.

```go
stage1GentleAfter  =  2 * 24h    stage1ResendInterval =  3 * 24h
stage1FirmAfter    =  7 * 24h    stage2ResendInterval =  7 * 24h
stage1WarnAfter    = 14 * 24h    stage3ResendInterval = 30 * 24h
stage2GraceAfter   = 14 * 24h
stage2WarnAfter    = 21 * 24h    maxJourneySnoozeDuration = 90 * 24h
stage3SuggestAfter = 30 * 24h
```

Escalation is keyed off `RegisteredAt`. Stages 2 and 3 have no per-stage "satisfied at" timestamp in the registry, so they measure from registration too — conservative, since it can only make a nudge fire *later* than the moment the previous stage actually cleared, never earlier.

## Reuses the existing banner path

Banners were already **per-hive** (`hubBanners map[hiveID]*HubBannerEntry`, `server.go:280-283`) and persisted, delivered on the heartbeat response at `server.go:945-953` and rendered by the spoke via `SetHubBanner`. No parallel delivery path was built.

**Admin-sent banners always win.** A journey nudge only fills an empty slot or replaces a previous *journey* banner — a human who targeted a hive by hand is never displaced by an automated reminder.

## Idempotent, not spammy

Per-hive state (last stage, last severity, last sent time, last ACMM level) persists to `/data/saas/journey-state.json`, so a hub restart neither replays every ladder nor forgets an exemption.

A banner re-sends only when the re-send interval has elapsed — **except** that a stage or severity change sends immediately, because an escalation should not have to wait out an interval. Banner IDs embed stage + severity (and the level, for ACMM), so each escalation step is a *new* banner: an owner who dismissed the gentle reminder still sees the firm one, and a hive that graduates L2→L3 gets a fresh suggestion rather than a suppressed stale one.

## Hub-side visibility

A sortable **Journey** column in My Hives, colored by severity (green on-track → blue gentle → amber firm → red warning), showing the stage, how long it has been stalled, the `relay` badge, and a snooze indicator. Sorting ranks by urgency rather than stringifying the object. Journey status is derived on read and never persisted onto the registry entry. It is deliberately **not** added to the public hives table.

## Admin override

Some hives are legitimately exempt (vendor pilots, demo spokes, hives parked between events).

```
POST /api/saas/admin/journey-snooze  {"hive_id":"...","duration":"720h","reason":"vendor pilot"}
GET  /api/saas/admin/journey-status
```

Persisted with who set it and why, admin-gated, capped at 90 days, and expired snoozes lapse on load so a forgotten exemption cannot silence a hive forever. A snoozed hive still displays its underlying stage, so an admin can see what is being suppressed.

## Tests

Table-driven, in `v2/pkg/hub/journey_test.go`, covering all four required areas:

- **Stage detection** — each signal in isolation, plus stage ordering proving the first unsatisfied stage always wins.
- **Escalation timing** — every window boundary tested at `threshold-1s`, exactly `threshold`, and well past it.
- **Relay substitution** — each relay signal, at 4× the de-provision threshold, asserting stage-satisfied, the `viaRelay` flag, and that no warning is ever produced.
- **Never threaten ACMM** — every level below the maximum × ages up to five years, asserting gentle severity and scanning copy for threatening language.

Plus: unknown/missing signals never nudge (nil pointer, unparseable and empty timestamps), future-dated registration clamps instead of escalating, re-send interval boundaries, escalation bypassing the interval, banner ID uniqueness, snooze expiry boundaries, store round-trip and atomic persistence, and copy assertions that every message names a concrete destination.

## Verification

- `go build ./...` — passes
- `go vet ./pkg/hub/` — passes
- `go test -timeout 480s ./pkg/hub/` — passes (full package, 111s)

Fixing a nil-pointer panic surfaced by the existing `TestHandleMyHives`: the store is now nil-receiver safe, since `HubServer` is constructed directly in several places without going through the constructor.

## Not detected / assumed

- **`Hub.ContributeSuspended` never reaches the hub** (`v2/pkg/config/config.go:1080`; it is enforced only spoke-side in `contribute_ws.go:778`). A hive with the relay suspended but registered contributors still reads as "relay in use". Fixing this needs another heartbeat field; called out rather than guessed at.
- **`ContributorCount` counts registered profiles on disk, including revoked ones**, and never decays. Chosen deliberately over `ActiveContributors` alone, which is a 90-second WebSocket liveness window that would drop to zero overnight and fire a spurious nudge at 3am.
- **Stages 2 and 3 measure from `RegisteredAt`**, not from when the previous stage was actually satisfied — the registry stores no per-stage completion timestamp. Conservative in the safe direction, as noted above.
- ACMM level names/behavior are taken from `v2/pkg/config/packs/level-*.yaml` (Assisted / Instructed / Measured / Adaptive / Semi-Automated / Fully Autonomous). Note `v2/pkg/agent/manager.go:1225` holds a **different, stale** set of names (Idea / Development / CI-CD / Managed / …) that disagrees with both the packs and the hub UI; the packs were used as authoritative. Worth reconciling separately.

## Follow-ups worth considering

- A UI control for the snooze endpoint (the API is admin-gated and usable today, but there is no button yet).
- Reporting `ContributeSuspended` so a suspended relay stops counting as satisfying stage 2.
- Reconciling the stale `acmmLevelNames` map in `pkg/agent/manager.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
