### PR TITLE
🐛 fix(hub): key the Usage "by org" rollup on org/repo

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -6910,7 +6910,9 @@ const dashboardHTML = `<!DOCTYPE html>
             ' <span style="color:var(--muted);font-size:0.72rem">across ' + (Number(d.hiveCount) || 0) + ' hive' + ((Number(d.hiveCount) || 0) === 1 ? '' : 's') + '</span></span>' +
           '</div>' +
           '<div style="display:flex;gap:20px;flex-wrap:wrap">' +
-            renderUsageSection('By org', d.byOrg, 'org') +
+            /* byOrg buckets on org/repo (usageOrgRepoKey in usage.go), so the
+               label says so; the JSON field keeps its original name. */
+            renderUsageSection('By org / repo', d.byOrg, 'org') +
             renderUsageSection('By owner', d.byOwner, 'owner') +
             renderUsageSection('By cluster', d.byCluster, 'cluster') +
           '</div>' +

--- a/v2/pkg/hub/usage.go
+++ b/v2/pkg/hub/usage.go
@@ -58,6 +58,11 @@ const (
 	// deliberate: silently dropping them would make the rollup shares fail to
 	// sum to the fleet total, which is worse than an honest "unattributed".
 	usageUnattributed = "(unattributed)"
+
+	// usageOrgRepoSep joins the org and repo halves of an org/repo bucket key.
+	// GitHub's own "owner/name" convention, so the key reads exactly like the
+	// repository slug an operator would paste into a browser.
+	usageOrgRepoSep = "/"
 )
 
 // usageCurrencyNote is shown wherever a reader might expect a dollar figure.
@@ -106,11 +111,17 @@ type UsageSnapshot struct {
 
 // UsageRollup is the full attribution report.
 type UsageRollup struct {
-	TotalTokens int64         `json:"totalTokens"`
-	HiveCount   int           `json:"hiveCount"`
-	ByOrg       []UsageBucket `json:"byOrg"`
-	ByOwner     []UsageBucket `json:"byOwner"`
-	ByCluster   []UsageBucket `json:"byCluster"`
+	TotalTokens int64 `json:"totalTokens"`
+	HiveCount   int   `json:"hiveCount"`
+	// ByOrg buckets on "org/repo" (see usageOrgRepoKey), NOT on org alone —
+	// two hives in the same org need to be distinguishable. The Go field and
+	// the "byOrg" JSON key are deliberately left unrenamed: the wire contract
+	// is consumed by the dashboard and potentially by external readers, and
+	// churning the name buys nothing that the key values do not already say.
+	// The UI label changed instead.
+	ByOrg     []UsageBucket `json:"byOrg"`
+	ByOwner   []UsageBucket `json:"byOwner"`
+	ByCluster []UsageBucket `json:"byCluster"`
 	// ZeroConsumption lists claimed hives reporting no tokens. Unassigned
 	// placeholders are excluded by the caller — a pool slot with nothing
 	// assigned to it is SUPPOSED to consume nothing, so flagging it would be
@@ -177,6 +188,40 @@ func buildUsageBuckets(hives []RegistryEntry, keyOf func(RegistryEntry) string, 
 	return out
 }
 
+// usageOrgRepoKey builds the org/repo grouping key for a hive.
+//
+// WHY org/repo AND NOT org ALONE: two hives in the same org are indistinguishable
+// in an org-only rollup, so a heavy repo hides behind a quiet sibling. Keying on
+// the slug separates them while still sorting neighbours together.
+//
+// WHY PrimaryRepo AND NOT the whole Repos slice: a hive may watch several repos,
+// but it has exactly one primary. Joining the slice would produce a different key
+// for every combination and mint one-hive buckets that never aggregate; the
+// primary is the single stable identity the hive already declares.
+//
+// Edge cases, all deliberate:
+//   - org + primary repo → "org/repo".
+//   - org, no primary repo → "org" (never "org/", which reads as a truncated
+//     slug and looks like a rendering bug).
+//   - no org, primary repo  → "repo". Attributing it to a fabricated org would be
+//     worse than a bare repo name, and dropping the hive would break the sum.
+//   - neither → "" so usageGroupKey folds it into usageUnattributed, preserving
+//     the existing placeholder handling (see isUnassignedPlaceholder) and keeping
+//     the shares summing to the fleet total.
+func usageOrgRepoKey(h RegistryEntry) string {
+	org := strings.TrimSpace(h.Org)
+	repo := strings.TrimSpace(h.PrimaryRepo)
+	switch {
+	case org != "" && repo != "":
+		return org + usageOrgRepoSep + repo
+	case org != "":
+		return org
+	default:
+		// repo alone, or "" which usageGroupKey turns into usageUnattributed.
+		return repo
+	}
+}
+
 // isUnassignedPlaceholder mirrors the dashboard's isPlaceholderHive() helper
 // (saas.go) server-side: provStatus "available" is authoritative, with an
 // "available-" org prefix as the fallback for placeholders that have not yet
@@ -227,7 +272,7 @@ func buildUsageRollup(hives []RegistryEntry, placeholderOf func(RegistryEntry) b
 	}
 	out.HiveCount = len(claimed)
 
-	out.ByOrg = buildUsageBuckets(claimed, func(h RegistryEntry) string { return h.Org }, out.TotalTokens)
+	out.ByOrg = buildUsageBuckets(claimed, usageOrgRepoKey, out.TotalTokens)
 	out.ByOwner = buildUsageBuckets(claimed, func(h RegistryEntry) string { return h.Owner }, out.TotalTokens)
 	out.ByCluster = buildUsageBuckets(claimed, func(h RegistryEntry) string {
 		// Prefer the human-readable cluster name, fall back to the ID.

--- a/v2/pkg/hub/usage_test.go
+++ b/v2/pkg/hub/usage_test.go
@@ -4,12 +4,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
 
 // TestBuildUsageBuckets covers the rollup math: grouping, share percentages,
-// descending sort, deterministic tie-breaking, and the empty fleet.
+// descending sort, deterministic tie-breaking, and the empty fleet. Keyed with
+// usageOrgRepoKey, the same func the org rollup uses in production.
 func TestBuildUsageBuckets(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -27,10 +29,10 @@ func TestBuildUsageBuckets(t *testing.T) {
 			wantKeys: []string{},
 		},
 		{
-			name:      "single hive",
-			hives:     []RegistryEntry{{Org: "acme", TotalTokens24h: 100}},
+			name:      "single hive keys on org/repo",
+			hives:     []RegistryEntry{{Org: "acme", PrimaryRepo: "widgets", TotalTokens24h: 100}},
 			total:     100,
-			wantKeys:  []string{"acme"},
+			wantKeys:  []string{"acme/widgets"},
 			wantToks:  []int64{100},
 			wantHives: []int{1},
 			wantShare: []float64{100},
@@ -38,63 +40,114 @@ func TestBuildUsageBuckets(t *testing.T) {
 		{
 			name: "sorted by consumption descending",
 			hives: []RegistryEntry{
-				{Org: "small", TotalTokens24h: 10},
-				{Org: "big", TotalTokens24h: 70},
-				{Org: "mid", TotalTokens24h: 20},
+				{Org: "acme", PrimaryRepo: "small", TotalTokens24h: 10},
+				{Org: "acme", PrimaryRepo: "big", TotalTokens24h: 70},
+				{Org: "acme", PrimaryRepo: "mid", TotalTokens24h: 20},
 			},
 			total:     100,
-			wantKeys:  []string{"big", "mid", "small"},
+			wantKeys:  []string{"acme/big", "acme/mid", "acme/small"},
 			wantToks:  []int64{70, 20, 10},
 			wantHives: []int{1, 1, 1},
 			wantShare: []float64{70, 20, 10},
 		},
 		{
-			name: "groups multiple hives into one bucket",
+			// THE CASE THAT MOTIVATED THE FIX: same org, different repos. Under
+			// the old org-only key these collapsed into one "acme" bucket worth
+			// 50 tokens across 2 hives; they must now be separate rows.
+			name: "same org different repos are separate buckets",
 			hives: []RegistryEntry{
-				{Org: "acme", TotalTokens24h: 30},
-				{Org: "acme", TotalTokens24h: 20},
-				{Org: "other", TotalTokens24h: 50},
+				{Org: "acme", PrimaryRepo: "widgets", TotalTokens24h: 30},
+				{Org: "acme", PrimaryRepo: "gadgets", TotalTokens24h: 20},
+				{Org: "other", PrimaryRepo: "thing", TotalTokens24h: 50},
+			},
+			total:     100,
+			wantKeys:  []string{"other/thing", "acme/widgets", "acme/gadgets"},
+			wantToks:  []int64{50, 30, 20},
+			wantHives: []int{1, 1, 1},
+			wantShare: []float64{50, 30, 20},
+		},
+		{
+			name: "same org same repo still aggregates into one bucket",
+			hives: []RegistryEntry{
+				{Org: "acme", PrimaryRepo: "widgets", TotalTokens24h: 30},
+				{Org: "acme", PrimaryRepo: "widgets", TotalTokens24h: 20},
+				{Org: "other", PrimaryRepo: "thing", TotalTokens24h: 50},
 			},
 			total: 100,
-			// 50/50 tie → tie-break on Key ascending: "acme" < "other".
-			wantKeys:  []string{"acme", "other"},
+			// 50/50 tie → tie-break on Key ascending: "acme/..." < "other/...".
+			wantKeys:  []string{"acme/widgets", "other/thing"},
 			wantToks:  []int64{50, 50},
 			wantHives: []int{2, 1},
 			wantShare: []float64{50, 50},
 		},
 		{
+			// Multi-repo hive: PrimaryRepo alone decides the key. Joining the
+			// whole Repos slice would mint a bucket per repo combination.
+			name: "multi-repo hive keys on the primary repo only",
+			hives: []RegistryEntry{
+				{Org: "acme", PrimaryRepo: "widgets", Repos: []string{"widgets", "gadgets", "sprockets"}, TotalTokens24h: 100},
+			},
+			total:     100,
+			wantKeys:  []string{"acme/widgets"},
+			wantToks:  []int64{100},
+			wantHives: []int{1},
+		},
+		{
+			name: "org with no primary repo renders as bare org, never a trailing slash",
+			hives: []RegistryEntry{
+				{Org: "acme", TotalTokens24h: 60},
+				{Org: "acme", PrimaryRepo: "   ", TotalTokens24h: 40},
+			},
+			total: 100,
+			// Both fold to the same bare-org bucket; whitespace is not a repo.
+			wantKeys:  []string{"acme"},
+			wantToks:  []int64{100},
+			wantHives: []int{2},
+			wantShare: []float64{100},
+		},
+		{
+			name: "repo with no org keys on the bare repo",
+			hives: []RegistryEntry{
+				{PrimaryRepo: "orphan", TotalTokens24h: 100},
+			},
+			total:     100,
+			wantKeys:  []string{"orphan"},
+			wantToks:  []int64{100},
+			wantHives: []int{1},
+		},
+		{
 			name: "ties break on key ascending for stable ordering",
 			hives: []RegistryEntry{
-				{Org: "zebra", TotalTokens24h: 5},
-				{Org: "alpha", TotalTokens24h: 5},
-				{Org: "mango", TotalTokens24h: 5},
+				{Org: "zebra", PrimaryRepo: "r", TotalTokens24h: 5},
+				{Org: "alpha", PrimaryRepo: "r", TotalTokens24h: 5},
+				{Org: "mango", PrimaryRepo: "r", TotalTokens24h: 5},
 			},
 			total:     15,
-			wantKeys:  []string{"alpha", "mango", "zebra"},
+			wantKeys:  []string{"alpha/r", "mango/r", "zebra/r"},
 			wantToks:  []int64{5, 5, 5},
 			wantHives: []int{1, 1, 1},
 		},
 		{
-			name: "blank org folds into the unattributed bucket, not dropped",
+			name: "neither org nor repo folds into the unattributed bucket, not dropped",
 			hives: []RegistryEntry{
-				{Org: "", TotalTokens24h: 40},
-				{Org: "   ", TotalTokens24h: 10},
-				{Org: "acme", TotalTokens24h: 50},
+				{Org: "", PrimaryRepo: "", TotalTokens24h: 40},
+				{Org: "   ", PrimaryRepo: "  ", TotalTokens24h: 10},
+				{Org: "acme", PrimaryRepo: "widgets", TotalTokens24h: 50},
 			},
 			total: 100,
 			// 50/50 tie → Key ascending; "(" sorts before letters.
-			wantKeys:  []string{usageUnattributed, "acme"},
+			wantKeys:  []string{usageUnattributed, "acme/widgets"},
 			wantToks:  []int64{50, 50},
 			wantHives: []int{2, 1},
 		},
 		{
 			name: "zero fleet total yields zero shares, never NaN",
 			hives: []RegistryEntry{
-				{Org: "idle-a", TotalTokens24h: 0},
-				{Org: "idle-b", TotalTokens24h: 0},
+				{Org: "idle", PrimaryRepo: "a", TotalTokens24h: 0},
+				{Org: "idle", PrimaryRepo: "b", TotalTokens24h: 0},
 			},
 			total:     0,
-			wantKeys:  []string{"idle-a", "idle-b"},
+			wantKeys:  []string{"idle/a", "idle/b"},
 			wantToks:  []int64{0, 0},
 			wantHives: []int{1, 1},
 			wantShare: []float64{0, 0},
@@ -102,11 +155,11 @@ func TestBuildUsageBuckets(t *testing.T) {
 		{
 			name: "negative tokens clamped to zero",
 			hives: []RegistryEntry{
-				{Org: "corrupt", TotalTokens24h: -500},
-				{Org: "good", TotalTokens24h: 100},
+				{Org: "acme", PrimaryRepo: "corrupt", TotalTokens24h: -500},
+				{Org: "acme", PrimaryRepo: "good", TotalTokens24h: 100},
 			},
 			total:     100,
-			wantKeys:  []string{"good", "corrupt"},
+			wantKeys:  []string{"acme/good", "acme/corrupt"},
 			wantToks:  []int64{100, 0},
 			wantHives: []int{1, 1},
 		},
@@ -114,7 +167,7 @@ func TestBuildUsageBuckets(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildUsageBuckets(tc.hives, func(h RegistryEntry) string { return h.Org }, tc.total)
+			got := buildUsageBuckets(tc.hives, usageOrgRepoKey, tc.total)
 			if len(got) != len(tc.wantKeys) {
 				t.Fatalf("bucket count = %d, want %d (%+v)", len(got), len(tc.wantKeys), got)
 			}
@@ -209,8 +262,8 @@ func TestBuildUsageRollup(t *testing.T) {
 			t.Errorf("placeholders were flagged as zero-consumption: %+v", got.ZeroConsumption)
 		}
 		for _, b := range got.ByOrg {
-			if b.Key == "available-pool" {
-				t.Error("placeholder org leaked into the org rollup")
+			if strings.HasPrefix(b.Key, "available-pool") {
+				t.Error("placeholder org leaked into the org/repo rollup")
 			}
 		}
 	})
@@ -257,9 +310,9 @@ func TestBuildUsageRollup(t *testing.T) {
 
 	t.Run("shares sum to 100 across a rollup", func(t *testing.T) {
 		hives := []RegistryEntry{
-			{Org: "a", TotalTokens24h: 33},
-			{Org: "b", TotalTokens24h: 33},
-			{Org: "c", TotalTokens24h: 34},
+			{Org: "a", PrimaryRepo: "r", TotalTokens24h: 33},
+			{Org: "b", PrimaryRepo: "r", TotalTokens24h: 33},
+			{Org: "c", PrimaryRepo: "r", TotalTokens24h: 34},
 		}
 		got := buildUsageRollup(hives, placeholderOf, nil, "fleet")
 		var sum float64
@@ -270,6 +323,80 @@ func TestBuildUsageRollup(t *testing.T) {
 			t.Errorf("shares sum to %v, want ~100", sum)
 		}
 	})
+
+	// The motivating regression, exercised end-to-end through the rollup rather
+	// than the bucket builder: splitting one org into per-repo rows must not
+	// lose or double-count tokens.
+	t.Run("two hives in one org split by repo and still sum to the fleet total", func(t *testing.T) {
+		hives := []RegistryEntry{
+			{ID: "1", Org: "kubestellar", PrimaryRepo: "console", TotalTokens24h: 70},
+			{ID: "2", Org: "kubestellar", PrimaryRepo: "docs", TotalTokens24h: 30},
+			// No primary repo: must appear as the bare org, not "kubestellar/".
+			{ID: "3", Org: "kubestellar", TotalTokens24h: 0},
+		}
+		got := buildUsageRollup(hives, placeholderOf, nil, "fleet")
+		if got.TotalTokens != 100 {
+			t.Fatalf("TotalTokens = %d, want 100", got.TotalTokens)
+		}
+		wantKeys := []string{"kubestellar/console", "kubestellar/docs", "kubestellar"}
+		if len(got.ByOrg) != len(wantKeys) {
+			t.Fatalf("ByOrg = %+v, want %d buckets %v", got.ByOrg, len(wantKeys), wantKeys)
+		}
+		var sumTokens int64
+		var sumHives int
+		for i, b := range got.ByOrg {
+			if b.Key != wantKeys[i] {
+				t.Errorf("ByOrg[%d].Key = %q, want %q", i, b.Key, wantKeys[i])
+			}
+			if strings.HasSuffix(b.Key, usageOrgRepoSep) {
+				t.Errorf("ByOrg[%d].Key = %q has a trailing separator", i, b.Key)
+			}
+			sumTokens += b.Tokens
+			sumHives += b.Hives
+		}
+		if sumTokens != got.TotalTokens {
+			t.Errorf("bucket tokens sum to %d, want the fleet total %d", sumTokens, got.TotalTokens)
+		}
+		if sumHives != got.HiveCount {
+			t.Errorf("bucket hives sum to %d, want HiveCount %d", sumHives, got.HiveCount)
+		}
+	})
+}
+
+// TestUsageOrgRepoKey pins the four org/repo edge cases directly.
+func TestUsageOrgRepoKey(t *testing.T) {
+	tests := []struct {
+		name string
+		in   RegistryEntry
+		want string
+	}{
+		{"org and primary repo", RegistryEntry{Org: "acme", PrimaryRepo: "widgets"}, "acme/widgets"},
+		{"org only renders bare, no trailing slash", RegistryEntry{Org: "acme"}, "acme"},
+		{"whitespace repo is not a repo", RegistryEntry{Org: "acme", PrimaryRepo: "  "}, "acme"},
+		{"repo only renders bare, no leading slash", RegistryEntry{PrimaryRepo: "orphan"}, "orphan"},
+		{"neither yields empty for usageGroupKey to fold", RegistryEntry{}, ""},
+		{"whitespace both yields empty", RegistryEntry{Org: " ", PrimaryRepo: " "}, ""},
+		{"values are trimmed", RegistryEntry{Org: " acme ", PrimaryRepo: " widgets "}, "acme/widgets"},
+		{
+			"Repos slice is ignored in favor of PrimaryRepo",
+			RegistryEntry{Org: "acme", PrimaryRepo: "widgets", Repos: []string{"a", "b", "c"}},
+			"acme/widgets",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := usageOrgRepoKey(tc.in); got != tc.want {
+				t.Errorf("usageOrgRepoKey(%+v) = %q, want %q", tc.in, got, tc.want)
+			}
+			// Whatever the key, the rendered bucket label must never be blank
+			// and must never be a bare or dangling separator.
+			label := usageGroupKey(usageOrgRepoKey(tc.in))
+			if label == "" || label == usageOrgRepoSep ||
+				strings.HasPrefix(label, usageOrgRepoSep) || strings.HasSuffix(label, usageOrgRepoSep) {
+				t.Errorf("bucket label %q is blank or a dangling separator", label)
+			}
+		})
+	}
 }
 
 // TestIsUnassignedPlaceholder mirrors the dashboard's isPlaceholderHive().


### PR DESCRIPTION
## Problem

The Usage panel (#2158) rendered its "BY ORG" list as bare org names — `kubestellar`, `torch-spyre`, `llm-d-incubation`, `projectbluefin`, `kellyaa`. Two hives in the same org collapsed into one row, so an operator looking at `kubestellar` could not tell whether the console hive or the docs hive was burning the tokens.

`v2/pkg/hub/usage.go` bucketed on `func(h RegistryEntry) string { return h.Org }`.

## Change

Bucket on `org/repo` via a new `usageOrgRepoKey`, using `PrimaryRepo` as the repo component.

`PrimaryRepo` and **not** the whole `Repos` slice: a hive may watch several repos but declares exactly one primary. Joining the slice would produce a different key for every repo combination and mint one-hive buckets that never aggregate.

### Edge cases, handled explicitly

| Input | Key | Rendered |
|---|---|---|
| org + primary repo | `acme/widgets` | `acme/widgets` |
| org, no primary repo | `acme` | `acme` — never `acme/` |
| primary repo, no org | `orphan` | `orphan` — never `/orphan` |
| neither | `""` | folds through `usageGroupKey` into `(unattributed)` |

Whitespace-only values are trimmed first, so `PrimaryRepo: "  "` is treated as absent rather than producing `acme/`. The empty case deliberately returns `""` rather than its own label, so the existing `usageUnattributed` / `isUnassignedPlaceholder` handling keeps working unchanged and the bucket shares still sum to the fleet total.

## JSON field: renamed the label, kept the wire name

`UsageRollup.ByOrg` and its `json:"byOrg"` tag are **left unrenamed**. The wire shape of `/api/saas/usage` is consumed by the dashboard and potentially by external readers; renaming it would break them in order to say something the key values already say for themselves. The *key* and the *label* change; the contract does not. Documented on the field so the next reader does not "fix" the apparent mismatch.

The only frontend change is the section label, `'By org'` → `'By org / repo'` — one line in the `dashboardHTML` raw-string const in `saas.go`. Kept short for the narrow panel.

`grep` for `ByOrg` found no other consumers; the other hits are `findHiveByOrgRepos` in `webhook.go`, which is unrelated.

## Tests

The table-driven cases in `usage_test.go` keyed on bare org names had to change — they now key with `usageOrgRepoKey` (the production func, not a test-local lambda) and carry `PrimaryRepo`.

Updated: `single hive`, `sorted by consumption descending`, `groups multiple hives into one bucket` (now `same org same repo still aggregates`), `ties break on key ascending`, `blank org folds into the unattributed bucket` (now `neither org nor repo`), `zero fleet total yields zero shares`, `negative tokens clamped to zero`, `shares sum to 100 across a rollup`, and the placeholder-leak assertion (now a prefix check).

Added:
- `same org different repos are separate buckets` — the case that motivated the fix
- `multi-repo hive keys on the primary repo only`
- `org with no primary repo renders as bare org, never a trailing slash`
- `repo with no org keys on the bare repo`
- rollup-level `two hives in one org split by repo and still sum to the fleet total` — asserts bucket tokens sum to `TotalTokens` and bucket hives sum to `HiveCount` after the split
- `TestUsageOrgRepoKey` — pins each edge case and asserts no rendered label is ever blank or a dangling separator

## Verified

- `go build ./...` — clean
- `go vet ./pkg/hub/` — clean
- `go test -count=1 -timeout 480s ./pkg/hub/` — `ok ... 127.995s`
- Extracted all 4 `<script>` bodies from `dashboardHTML` and `node --check`'d each — all parse; confirmed the edited label lands in one of them

Bucket keys continue to flow through the existing `esc()` call sites in `renderUsageSection` (both the `title` attribute and the cell text); no new interpolation point was introduced, and no inline handler takes the key.