### PR TITLE
🐛 fix(hub): stop stripping the colon from spoke image refs (false pinned-image criticals)

### DIFF
--- a/v2/pkg/hub/drift.go
+++ b/v2/pkg/hub/drift.go
@@ -265,6 +265,42 @@ func imageTagOf(ref string) string {
 	return ref[colon+1:]
 }
 
+// imageRefIsPinned reports whether an image reference is DEFINITIVELY pinned to
+// something a rolling upgrade can never advance.
+//
+// This is deliberately not the same question as imageTagIsMutable. That
+// predicate asks "can a restart pick up new code?", and its safe answer for
+// anything it cannot parse is false — the caller then takes the harmless
+// image-patch path. The drift rule asks something stronger: "do I have positive
+// evidence this hive is pinned, enough to page a human with a CRITICAL badge?"
+// An unparseable ref is not that evidence.
+//
+// The distinction is not academic. A ref that lost its tag separator in transit
+// (the sanitizer used to strip ':') is a MALFORMED value, not a legitimate SHA
+// pin — yet the old rule, built directly on !imageTagIsMutable, read eleven
+// healthy "-latest" hives as critically pinned. So parse failure degrades to
+// silence here, exactly as an empty ref already did. A future mangling of this
+// field can then only ever cost the hub a signal, never invent a false one.
+//
+// Returns false (no signal) for: an empty ref, and a ref with no tag separator
+// at all — both are "unknown", not "pinned".
+func imageRefIsPinned(ref string) bool {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return false // unknown image: old spoke, or not running in-cluster
+	}
+	// A digest pin ("...@sha256:...") is unambiguous positive evidence.
+	if strings.Contains(ref, "@") {
+		return true
+	}
+	// Otherwise a tag must be parseable before any claim can be made. Only a
+	// colon AFTER the last '/' is a tag; an earlier one is a registry port.
+	if imageTagOf(ref) == "" {
+		return false // malformed or untagged — unknown, so stay silent
+	}
+	return !imageTagIsMutable(ref)
+}
+
 // healthFailingChecks returns the names of checks that are not passing, with
 // their status, in the order the spoke reported them. Every access is guarded:
 // Health is a free-form map[string]any decoded from spoke JSON, so any level of
@@ -367,13 +403,15 @@ func computeDrift(h MyHiveEntry, norm fleetNorm, latestSHAs map[string]string, n
 	// Image pinned to an immutable tag. The spoke reports its own Deployment's
 	// image over the heartbeat; a tag that is not "<branch>-latest" can never
 	// receive a rolling upgrade, which is how one spoke sat on hive:63d8902
-	// restart-looping while the fleet moved on. Reuses imageTagIsMutable — the
-	// SAME predicate UpgradeSelfToSHA uses to decide a restart is a no-op, so
-	// the badge can never disagree with the upgrade path about what is pinned.
+	// restart-looping while the fleet moved on.
 	//
-	// Guarded on a non-empty ref: "unknown image" (old spoke, or not running
-	// in-cluster) must never render as "pinned".
-	if h.ImageRef != "" && !imageTagIsMutable(h.ImageRef) {
+	// imageRefIsPinned — not a bare !imageTagIsMutable — because raising a
+	// CRITICAL badge demands positive evidence of a pin. An empty or
+	// unparseable ref is "unknown", and unknown must be silent: that is the
+	// difference between reporting a real pin and telling an operator eleven
+	// healthy rolling hives can never be upgraded. A genuine pin (SHA tag,
+	// release tag, or digest) still fires, and still fires critical.
+	if imageRefIsPinned(h.ImageRef) {
 		label := imageTagOf(h.ImageRef)
 		if label == "" {
 			label = h.ImageRef

--- a/v2/pkg/hub/imageref_sanitize_test.go
+++ b/v2/pkg/hub/imageref_sanitize_test.go
@@ -1,0 +1,169 @@
+package hub
+
+import "testing"
+
+// TestSanitizeImageRefRoundTrip pins the bug that made 11 healthy hives render
+// a CRITICAL "pinned-image" badge: the shared heartbeat sanitizer's allowlist
+// omitted the colon, so "ghcr.io/kubestellar/hive:v2-latest" arrived at the
+// drift rule as "ghcr.io/kubestellar/hivev2-latest". With no tag separator left
+// imageTagIsMutable said "not mutable", and the hub told the operator a rolling
+// hive could never be upgraded.
+//
+// An image ref must survive the hub verbatim, while still being sanitized: a
+// hostile spoke must not be able to smuggle markup into a hub-rendered string.
+func TestSanitizeImageRefRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+		why  string
+	}{
+		{
+			name: "mutable branch tag survives verbatim",
+			in:   "ghcr.io/kubestellar/hive:v2-latest",
+			want: "ghcr.io/kubestellar/hive:v2-latest",
+			why:  "the live ref on every vllm-d and hive-oke deployment",
+		},
+		{
+			name: "digest pin survives verbatim",
+			in:   "ghcr.io/kubestellar/hive@sha256:9f2c1ab34de5",
+			want: "ghcr.io/kubestellar/hive@sha256:9f2c1ab34de5",
+			why:  "both @ and : are legal in an OCI digest reference",
+		},
+		{
+			name: "sha tag pin survives verbatim",
+			in:   "ghcr.io/kubestellar/hive:63d8902",
+			want: "ghcr.io/kubestellar/hive:63d8902",
+			why:  "a genuine pin must reach the drift rule intact so it is still flagged",
+		},
+		{
+			name: "registry port survives verbatim",
+			in:   "registry.internal:5000/kubestellar/hive:v2-latest",
+			want: "registry.internal:5000/kubestellar/hive:v2-latest",
+			why:  "a port colon must not be confused with a tag colon",
+		},
+		{
+			name: "markup is still stripped",
+			in:   "ghcr.io/x/hive:<script>alert(1)</script>",
+			want: "ghcr.io/x/hive:scriptalert1/script",
+			why:  "sanitization must keep working — a hostile spoke cannot inject markup",
+		},
+		{
+			name: "quotes and spaces are stripped",
+			in:   `ghcr.io/x/hive:v2-latest" onload="x`,
+			want: "ghcr.io/x/hive:v2-latestonloadx",
+			why:  "attribute-breaking characters have no place in an image ref",
+		},
+		{
+			name: "empty stays empty",
+			in:   "",
+			want: "",
+			why:  "unknown image must stay unknown, not become a bogus value",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := sanitizeImageRef(c.in); got != c.want {
+				t.Errorf("sanitizeImageRef(%q) = %q, want %q (%s)", c.in, got, c.want, c.why)
+			}
+		})
+	}
+}
+
+// TestSanitizeHeartbeatFieldStillRejectsColon guards the scope decision: the
+// colon was added to a DEDICATED image-ref sanitizer, not to the shared one.
+// sanitizeHeartbeatField is applied to ~12 fields (hive IDs, agent names,
+// governor mode, owner, leaderboard usernames); none of those may contain a
+// colon, and widening the shared allowlist would have loosened all of them.
+func TestSanitizeHeartbeatFieldStillRejectsColon(t *testing.T) {
+	if got := sanitizeHeartbeatField("agent:evil"); got != "agentevil" {
+		t.Errorf("sanitizeHeartbeatField must still strip ':' from non-image fields; got %q", got)
+	}
+}
+
+// TestImageRefTagParseFailureIsSilent is the defence-in-depth half of the fix.
+//
+// A ref with no tag separator at all is a MALFORMED value, not a legitimate
+// immutable pin — exactly what the mangling produced. imageTagIsMutable
+// answers "is a restart useful?" and correctly says false there (the caller
+// must take the safe image-patch path). The drift rule asks a different
+// question — "is this hive definitively pinned?" — and an unparseable ref is
+// not evidence of a pin. It must degrade to silence, as an empty ref already
+// does, so a future mangling can never again produce a critical alert about a
+// healthy hive.
+func TestImageRefTagParseFailureIsSilent(t *testing.T) {
+	cases := []struct {
+		name   string
+		ref    string
+		pinned bool
+		why    string
+	}{
+		{"mutable tag", "ghcr.io/kubestellar/hive:v2-latest", false, "rolling tag, no signal"},
+		{"mangled colonless ref", "ghcr.io/kubestellar/hivev2-latest", false, "unparseable — unknown, not pinned"},
+		{"bare repo, no tag", "ghcr.io/kubestellar/hive", false, "implicit :latest — do not guess"},
+		{"registry port but no tag", "registry.internal:5000/kubestellar/hive", false, "port is not a tag"},
+		{"empty", "", false, "unknown image"},
+		{"sha tag pin", "ghcr.io/kubestellar/hive:63d8902", true, "genuine pin — MUST still be flagged"},
+		{"release tag pin", "ghcr.io/kubestellar/hive:v2.1.0", true, "immutable release tag is a real pin"},
+		{"digest pin", "ghcr.io/kubestellar/hive@sha256:abc123", true, "digest pin is a real pin"},
+		{"port plus sha pin", "registry.internal:5000/kubestellar/hive:63d8902", true, "genuine pin behind a port"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := imageRefIsPinned(c.ref); got != c.pinned {
+				t.Errorf("imageRefIsPinned(%q) = %v, want %v (%s)", c.ref, got, c.pinned, c.why)
+			}
+		})
+	}
+}
+
+// TestComputeDriftNoPinnedSignalForMangledRef is the end-to-end regression: a
+// healthy rolling hive whose ref lost its colon in transit must produce NO
+// pinned-image signal at all, let alone a critical one.
+func TestComputeDriftNoPinnedSignalForMangledRef(t *testing.T) {
+	norm := computeFleetNorm(normFleet())
+	latest := map[string]string{"v2": "abc1234"}
+
+	cases := []struct {
+		name       string
+		ref        string
+		wantSignal bool
+	}{
+		{"healthy rolling tag", "ghcr.io/kubestellar/hive:v2-latest", false},
+		{"mangled colonless ref", "ghcr.io/kubestellar/hivev2-latest", false},
+		{"genuine sha pin", "ghcr.io/kubestellar/hive:63d8902", true},
+		{"genuine digest pin", "ghcr.io/kubestellar/hive@sha256:abc123", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h := healthyEntry("h1")
+			h.ImageRef = c.ref
+			kinds := driftKindsOf(computeDrift(h, norm, latest, driftNow))
+			sig, got := kinds[DriftKindPinnedImage]
+			if got != c.wantSignal {
+				t.Fatalf("ref %q: pinned-image signal present = %v, want %v (signals: %+v)",
+					c.ref, got, c.wantSignal, kinds)
+			}
+			if got && sig.Severity != DriftCritical {
+				t.Errorf("ref %q: a genuine pin should stay critical, got %q", c.ref, sig.Severity)
+			}
+		})
+	}
+}
+
+// TestHeartbeatImageRefSurvivesIngest proves the fix at the boundary the bug
+// actually lived at: the ref written into the registry entry by the heartbeat
+// handler's sanitization must still parse as a rolling tag.
+func TestHeartbeatImageRefSurvivesIngest(t *testing.T) {
+	const live = "ghcr.io/kubestellar/hive:v2-latest"
+	stored := sanitizeImageRef(live)
+	if stored != live {
+		t.Fatalf("ingest mangled the ref: %q -> %q", live, stored)
+	}
+	if imageRefIsPinned(stored) {
+		t.Errorf("stored ref %q must not read as pinned", stored)
+	}
+	if !imageTagIsMutable(stored) {
+		t.Errorf("stored ref %q must still read as mutable for the upgrade path", stored)
+	}
+}

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -672,7 +672,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		Version:       sanitizeHeartbeatField(payload.Version),
 		GitHash:       shortSHA(sanitizeHeartbeatField(payload.GitHash)),
 		GitBranch:     sanitizeHeartbeatField(payload.GitBranch),
-		ImageRef:      sanitizeHeartbeatField(payload.ImageRef),
+		ImageRef:      sanitizeImageRef(payload.ImageRef),
 		Agents: func() []AgentSummary {
 			for i := range payload.Agents {
 				payload.Agents[i].Name = sanitizeHeartbeatField(payload.Agents[i].Name)
@@ -1608,6 +1608,39 @@ func sanitizeHeartbeatField(s string) string {
 	var b strings.Builder
 	for _, c := range s {
 		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.' || c == '/' {
+			b.WriteRune(c)
+		}
+	}
+	return b.String()
+}
+
+// sanitizeImageRef sanitizes a container image reference reported by a spoke.
+//
+// This is DELIBERATELY separate from sanitizeHeartbeatField rather than a
+// widening of it. That allowlist is applied to roughly a dozen fields — hive
+// IDs, versions, branches, governor mode, owner, agent names and states,
+// leaderboard usernames — none of which may legally contain a colon, so
+// admitting one globally would loosen all of them at once to fix a single
+// field.
+//
+// An image ref is the one heartbeat field where a colon is structural: it
+// separates repo from tag ("hive:v2-latest"), introduces a digest algorithm
+// ("@sha256:..."), and delimits a registry port ("registry:5000/..."). The
+// shared sanitizer stripped it, turning "ghcr.io/kubestellar/hive:v2-latest"
+// into "ghcr.io/kubestellar/hivev2-latest" — a ref with no tag separator,
+// which the pinned-image drift rule then reported as a CRITICAL pin on eleven
+// perfectly healthy rolling hives.
+//
+// The allowlist is exactly the character set legal in an OCI reference:
+// alphanumerics plus the "-_./" of a repository path, ":" for tag/port/digest
+// algorithm, and "@" for a digest. Everything else — quotes, angle brackets,
+// whitespace, control characters — is still dropped, so a hostile spoke cannot
+// inject markup into a hub-rendered string.
+func sanitizeImageRef(s string) string {
+	var b strings.Builder
+	for _, c := range s {
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+			c == '-' || c == '_' || c == '.' || c == '/' || c == ':' || c == '@' {
 			b.WriteRune(c)
 		}
 	}


### PR DESCRIPTION
## The bug

`sanitizeHeartbeatField`'s allowlist (`[a-zA-Z0-9-_./]`) omits the colon, so every spoke's image reference is mangled in transit:

```
ghcr.io/kubestellar/hive:v2-latest   →   ghcr.io/kubestellar/hivev2-latest
```

With the tag separator gone, `imageTagIsMutable()` concludes "no tag → immutable" and the drift rule raises a **critical** `pinned-image` signal.

**Live impact:** 11 healthy hives flagged critical across `vllm-d` and `hive-oke`. Zero hives are actually pinned — every Deployment on both clusters runs a `*-latest` tag:

```
$ kubectl --context vllm-d -n hive-hosted-hosted-available-vllmd-01 \
    get deploy hive -o jsonpath='{.spec.template.spec.containers[0].image}'
ghcr.io/kubestellar/hive:v2-latest
```

## The fix

Two parts, because the sanitizer bug alone was only half the defect.

### 1. Dedicated `sanitizeImageRef`, not a widened shared allowlist

`sanitizeHeartbeatField` is applied to ~12 fields — hive IDs, versions, branches, governor mode, owner, agent names/states, leaderboard usernames. None of those may legally contain a colon, so admitting one globally would loosen all of them to fix a single field.

An image ref is the one heartbeat field where `:` is *structural*: it separates repo from tag, introduces a digest algorithm (`@sha256:`), and delimits a registry port (`registry:5000/`). So it gets its own allowlist — alphanumerics, `-_./`, plus `:` and `@`, exactly the OCI reference character set. Markup, quotes, whitespace and control characters are still dropped, so a hostile spoke still cannot inject into a hub-rendered string. Sanitization is **not** disabled.

### 2. A parsing failure can no longer produce a critical alert

This is the deeper defect. The drift rule was built on `!imageTagIsMutable`, but that predicate answers a *different question* — "can a restart pick up new code?" — and its safe answer for anything unparseable is `false`, which is correct there (the caller takes the harmless image-patch path).

Raising a CRITICAL badge demands the stronger question: *do I have positive evidence of a pin?* A ref with no colon at all is a **malformed** value, not a legitimate SHA pin. New `imageRefIsPinned` treats "no tag separator" as **unknown → no signal**, exactly as an empty ref already was.

So even after the sanitizer fix, a future mangling of this field degrades to silence rather than to a false critical about a healthy hive. Genuine pins — SHA tags, release tags, digest pins — still fire, and still fire critical.

## Audit of the other new drift signals

Checked all of `version-behind` (12 live), `branch-mismatch` (3), `no-agents` (3), `app-missing` (5) for the same class of bug:

| Signal | Field read | Corruptible? |
|---|---|---|
| `no-agents` | `AgentCount` (int) | No — never reaches the sanitizer |
| `app-missing` | `GitHubAppRequired` (bool) | No — never reaches the sanitizer |
| `version-behind` | `GitHash` (hex SHA) | No — hex is fully inside the allowlist |
| `branch-mismatch` | `GitBranch` (git refname) | No — git's `check-ref-format` forbids `:` in branch names |

`ImageRef` was the only field where the allowlist mangles a legitimate value. **No other fix made** — those signals are reporting real conditions.

## Stored values

`RegistryEntry.ImageRef` values already on the hub's PVC are corrupted, but **self-heal on the next heartbeat** — the handler overwrites the field unconditionally on every beat, so the fleet corrects within one heartbeat interval of rollout. **No migration needed.**

## Tests

Table-driven, written failing first (`v2/pkg/hub/imageref_sanitize_test.go`):

- round-trip of the real live ref `ghcr.io/kubestellar/hive:v2-latest`
- digest-pinned ref `repo@sha256:...`
- a genuinely pinned SHA tag — **must still be flagged critical** (guards against over-correcting into silencing the real signal)
- a malformed no-colon ref — **must be silent, not critical**
- registry-port refs, markup-injection and quote-breaking inputs
- a guard that `sanitizeHeartbeatField` *still* strips `:` from non-image fields (pins the shared-vs-dedicated scope decision)
- an end-to-end `computeDrift` regression asserting no `pinned-image` signal for a mangled ref

## Verification

- `go build ./...` — pass
- `go vet ./pkg/hub/` — pass
- `go test -count=1 -timeout 480s ./pkg/hub/` — pass (full package, 119s)
- Mangling reproduced directly before the fix, and confirmed gone after.