### PR TITLE
✨ feat(hub): consolidate activity timeline and relay status into My Hives hover

### DIFF
--- a/v2/pkg/hub/health_check_detail_test.go
+++ b/v2/pkg/hub/health_check_detail_test.go
@@ -97,8 +97,16 @@ func TestSingleHoverPanelInvariant(t *testing.T) {
 	}
 	// The panel is built as one concatenated return expression; scan to the end
 	// of that statement.
+	//
+	// The end is anchored on the statement TERMINATOR rather than on whichever
+	// variable happens to be rendered last. An earlier version matched
+	// "accessRows + '</span></span>';", so appending another section to the
+	// panel (recent activity) silently moved the marker and the guard stopped
+	// finding the expression at all. Matching the closing tags + ';' keeps this
+	// test working as the panel gains sections — which is exactly when the
+	// title-attribute regression is most likely to be reintroduced.
 	rest := dashboardHTML[idx:]
-	end := strings.Index(rest, "accessRows + '</span></span>';")
+	end := strings.Index(rest, "'</span></span>';")
 	if end < 0 {
 		t.Fatalf("could not find the end of the consolidated hover panel expression")
 	}

--- a/v2/pkg/hub/hover_timeline_relay_test.go
+++ b/v2/pkg/hub/hover_timeline_relay_test.go
@@ -1,0 +1,232 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The consolidated status hover (health + relay + access + recent activity)
+// is built in the inline dashboardHTML JS, so most of what can break here is
+// invisible to the Go compiler. These tests pin the pieces that matter.
+
+// TestHoverPanelRendersConsolidatedSections asserts the panel composes every
+// section. A rebase that drops one leaves the hover silently missing a surface
+// rather than failing anywhere else.
+func TestHoverPanelRendersConsolidatedSections(t *testing.T) {
+	cases := []struct {
+		name    string
+		snippet string
+	}{
+		{"relay line is composed into the panel", "relayLine(h) +"},
+		{"recent activity is composed into the panel", "hoverEventRows(h) + '</span></span>';"},
+		{"relay helper exists", "function relayLine(h)"},
+		{"recent activity helper exists", "function hoverEventRows(h)"},
+		// The events must come from the payload, never a per-hover fetch.
+		{"events read from the payload", "(h.recentEvents || [])"},
+		// Relay state is read from the SAME field the Journey column uses.
+		{"relay reads journey.viaRelay", "if (!j.viaRelay) return '';"},
+		{"contributor count is shown", "registered + ' contributors'"},
+		// "View all" must reach the existing modal.
+		{"view-all opens the timeline modal", "openTimelineModal(btn.getAttribute('data-hive-id')"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(dashboardHTML, tc.snippet) {
+				t.Errorf("dashboardHTML is missing %q", tc.snippet)
+			}
+		})
+	}
+}
+
+// TestHoverPanelDoesNotFetchOnHover guards the design decision: recent activity
+// rides the My Hives payload, so hovering rows must never issue a request. A
+// fetch inside the hover helpers would be a request storm at fleet scale.
+func TestHoverPanelDoesNotFetchOnHover(t *testing.T) {
+	start := strings.Index(dashboardHTML, "function hoverEventRows(h)")
+	if start < 0 {
+		t.Fatal("hoverEventRows not found in dashboardHTML")
+	}
+	end := strings.Index(dashboardHTML[start:], "\n    function healthBadge(h)")
+	if end < 0 {
+		t.Fatal("could not bound hoverEventRows")
+	}
+	body := dashboardHTML[start : start+end]
+	for _, bad := range []string{"fetch(", "XMLHttpRequest"} {
+		if strings.Contains(body, bad) {
+			t.Errorf("hoverEventRows performs %q — recent activity must come from "+
+				"the My Hives payload, not a per-hover request", bad)
+		}
+	}
+}
+
+// TestHoverViewAllUsesDelegationNotInlineHandler guards against building an
+// inline onclick from the hive name. esc() does not escape apostrophes, so a
+// name containing one would break out of the handler string.
+func TestHoverViewAllUsesDelegationNotInlineHandler(t *testing.T) {
+	if !strings.Contains(dashboardHTML, `class="hover-view-timeline" `) {
+		t.Error("view-all button is missing its delegation class")
+	}
+	// Scoped to hoverEventRows: the row's kebab menu legitimately builds an
+	// inline openTimelineModal handler elsewhere, so a whole-file search would
+	// match that instead of the button under test.
+	start := strings.Index(dashboardHTML, "function hoverEventRows(h)")
+	if start < 0 {
+		t.Fatal("hoverEventRows not found in dashboardHTML")
+	}
+	end := strings.Index(dashboardHTML[start:], "\n    function healthBadge(h)")
+	if end < 0 {
+		t.Fatal("could not bound hoverEventRows")
+	}
+	if body := dashboardHTML[start : start+end]; strings.Contains(body, "onclick=") {
+		t.Error("hover view-all button builds an inline handler; the hive name is " +
+			"user-controlled and esc() does not escape apostrophes")
+	}
+	if !strings.Contains(dashboardHTML, "e.target.closest('.hover-view-timeline')") {
+		t.Error("no delegated listener for the view-all button")
+	}
+}
+
+// TestHoverViewAllEscapesAttributes guards the attribute-injection vector on
+// the view-all button. The hive id and name are spoke-reported and land inside
+// double-quoted data attributes. esc() goes through textContent -> innerHTML,
+// which escapes & < > but NOT quotes, so esc() alone would let a name
+// containing a '"' close the attribute and inject an event handler. The values
+// must go through escAttr().
+func TestHoverViewAllEscapesAttributes(t *testing.T) {
+	if !strings.Contains(dashboardHTML, "function escAttr(s)") {
+		t.Fatal("escAttr helper is missing; attribute contexts have no quote-safe escaper")
+	}
+	for _, want := range []string{
+		`'data-hive-id="' + escAttr(h.id) + '"`,
+		`data-hive-name="' + escAttr(h.name || h.id) + '"`,
+	} {
+		if !strings.Contains(dashboardHTML, want) {
+			t.Errorf("view-all button does not escape its attribute with escAttr: missing %q", want)
+		}
+	}
+	// escAttr must actually neutralise both quote characters.
+	for _, want := range []string{`replace(/"/g, '&quot;')`, `replace(/'/g, '&#39;')`} {
+		if !strings.Contains(dashboardHTML, want) {
+			t.Errorf("escAttr does not neutralise a quote character: missing %q", want)
+		}
+	}
+}
+
+// TestRelayRenderingIsConsistentWithJourneyColumn asserts the hover and the
+// Journey column are driven by the same signal and the same colour, so one
+// hive can never appear to say two different things in two places.
+func TestRelayRenderingIsConsistentWithJourneyColumn(t *testing.T) {
+	// Both surfaces key off journey.viaRelay.
+	if !strings.Contains(dashboardHTML, "if (j.viaRelay) {") {
+		t.Error("Journey column no longer keys off j.viaRelay")
+	}
+	if !strings.Contains(dashboardHTML, "if (!j.viaRelay) return '';") {
+		t.Error("hover relay line no longer keys off j.viaRelay")
+	}
+	// The hover uses the same teal as the .journey-relay badge.
+	if !strings.Contains(dashboardHTML, "var RELAY_COLOR = '#2dd4bf';") {
+		t.Error("hover relay colour constant missing")
+	}
+	if !strings.Contains(dashboardHTML, "color: #2dd4bf;") {
+		t.Error(".journey-relay badge colour changed; the hover's RELAY_COLOR must track it")
+	}
+	// The relay must read as its own state, not folded into "assigned"/"OK".
+	if !strings.Contains(dashboardHTML, "satisfies the method/model requirement") {
+		t.Error("hover does not explain that the relay satisfies the method/model requirement")
+	}
+}
+
+// TestRelayInUseDrivesHoverSignal is a table-driven check of the shared
+// relayInUse() helper this feature reuses from journey.go, covering the
+// registered / active / in-flight-task paths the hover copy branches on.
+func TestRelayInUseDrivesHoverSignal(t *testing.T) {
+	cases := []struct {
+		name string
+		h    *RegistryEntry
+		want bool
+	}{
+		{"nil entry", nil, false},
+		{"no contributors at all", &RegistryEntry{}, false},
+		{"registered contributors", &RegistryEntry{ContributorCount: 3}, true},
+		{"only live contributors", &RegistryEntry{ActiveContributors: 1}, true},
+		{"leaderboard task in flight", &RegistryEntry{
+			Leaderboard: []LeaderboardEntry{{CurrentTask: "fix-123"}},
+		}, true},
+		{"leaderboard with blank tasks only", &RegistryEntry{
+			Leaderboard: []LeaderboardEntry{{CurrentTask: "   "}},
+		}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := relayInUse(tc.h); got != tc.want {
+				t.Errorf("relayInUse() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMyHivesEmbedsRecentEvents asserts the payload carries the hover's events
+// under the same owner/admin rule as the access list, and trims to the
+// documented count.
+func TestMyHivesEmbedsRecentEvents(t *testing.T) {
+	const owner = "hover-events-owner"
+	const hiveID = "hosted-relaytest"
+	const token = "ghp_hover_events"
+
+	dir := t.TempDir()
+	origUsers, origTimeline := saasUsersDir, timelineDir
+	saasUsersDir = dir + "/users"
+	timelineDir = dir + "/timeline"
+	t.Cleanup(func() { saasUsersDir, timelineDir = origUsers, origTimeline })
+
+	cleanup := helperSetupAuthUser(t, token, owner)
+	defer cleanup()
+
+	s := NewHubServer(0, slog.Default(), "test", "v2")
+	s.mu.Lock()
+	s.registry.Hives = []RegistryEntry{{
+		ID:            hiveID,
+		Name:          "acme/widget",
+		Owner:         owner,
+		Online:        true,
+		LastHeartbeat: time.Now().UTC().Format(time.RFC3339),
+	}}
+	s.mu.Unlock()
+
+	// More events than the hover shows, so the trim is exercised.
+	for i := 0; i < myHivesRecentEventCount+4; i++ {
+		s.timeline.append(hiveID, TimelineHealthChanged, "health flipped", "")
+	}
+
+	req := httptest.NewRequest("GET", "/api/saas/my-hives", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	s.handleMyHives(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("handleMyHives = %d, want 200 (body %s)", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Hives []MyHiveEntry `json:"hives"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var got *MyHiveEntry
+	for i := range resp.Hives {
+		if resp.Hives[i].ID == hiveID {
+			got = &resp.Hives[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("hive %s missing from my-hives response", hiveID)
+	}
+	if len(got.RecentEvents) != myHivesRecentEventCount {
+		t.Errorf("RecentEvents = %d events, want %d (the hover's cap)",
+			len(got.RecentEvents), myHivesRecentEventCount)
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1326,7 +1326,38 @@ type MyHiveEntry struct {
 	// so the My Hives table can render the badge and the fleet-exceptions
 	// summary from data it already has.
 	Drift DriftReport `json:"drift"`
+
+	// RecentEvents carries the newest few timeline events so the My Hives
+	// status hover can show recent activity WITHOUT a per-row fetch.
+	//
+	// Embedding rather than lazy-fetching is deliberate. The hover is a
+	// transient, high-frequency interaction: sweeping the pointer down a
+	// 42-row table would fire 42 requests, each of which hits the filesystem
+	// via loadSaaSHive in handleHiveTimeline. No debounce or TTL cache removes
+	// that — scanning the list IS the normal way the table is read, so the
+	// requests are the common case, not the edge case.
+	//
+	// The cost of embedding was measured rather than guessed: at
+	// myHivesRecentEventCount events per row a typical fleet of 42 hives adds
+	// ~14 KB, and ~50 KB in the pathological case where every event carries a
+	// maxed-out timelineMaxDetailRunes detail. That is small beside what a row
+	// already ships (health map, drift report, access list, agents,
+	// leaderboard and the issue/PR spark histories), and the events are
+	// already in memory hub-side, so serving them costs no extra I/O.
+	//
+	// Populated under the SAME authorization as Access — owner or admin only —
+	// because it is the same per-hive operational detail handleHiveTimeline
+	// guards. The full 200-event history stays behind that endpoint and its
+	// modal; this is only the hover preview.
+	RecentEvents []TimelineEvent `json:"recentEvents,omitempty"`
 }
+
+// myHivesRecentEventCount is how many timeline events ride the My Hives
+// payload for the status hover. The hover panel already carries a status word,
+// the per-check health lines, the relay line and the user list; three events
+// is enough to answer "what just happened to this hive?" without turning a
+// transient tooltip into a scrolling log. "See all" opens the full modal.
+const myHivesRecentEventCount = 3
 
 func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 	username := s.getAuthUser(r)
@@ -1536,6 +1567,13 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		// told who else shares the hive.
 		if h.Role == "owner" || isAdmin {
 			result[i].Access = accessForHive(h.ID, allSaaSUsers)
+			// Recent activity for the status hover, same owner/admin rule as
+			// the access list and as handleHiveTimeline itself. s.timeline is
+			// nil in tests that construct a bare HubServer, and recent() is a
+			// read under the store's own leaf mutex — no s.mu is held here.
+			if s.timeline != nil {
+				result[i].RecentEvents = s.timeline.recent(h.ID, myHivesRecentEventCount)
+			}
 		}
 		if h.Role == "owner" || h.Role == "read-write" || isAdmin {
 			reqs := loadAccessRequests(h.ID)
@@ -5515,6 +5553,16 @@ const dashboardHTML = `<!DOCTYPE html>
       .hive-access-wrap:hover .hive-access-pop,
       .hive-access-wrap:focus-within .hive-access-pop { display: block !important; }
     }
+    /* The panel is offset 6px below the dot. That gap is outside both the dot
+       and the panel, so travelling to the panel's "View all activity" button
+       would drop :hover and close it mid-move. This pseudo-element bridges the
+       gap with a transparent strip so the pointer never leaves the wrapper.
+       Height matches the 6px offset in the panel's inline top. */
+    .hive-access-pop::before { content: ''; position: absolute; left: 0; right: 0; top: -6px; height: 6px; }
+    /* The wrapper is cursor:help; the one thing inside that is genuinely
+       clickable says so. */
+    .hover-view-timeline { cursor: pointer; }
+    .hover-view-timeline:hover { color: #79c0ff !important; }
     .repo-link { color: var(--blue); font-size: 0.8rem; }
     .hive-name-link { color: #58a6ff; font-weight: 700; text-decoration: none; }
     .hive-name-link:hover { color: #79c0ff; text-decoration: underline; }
@@ -5690,6 +5738,15 @@ const dashboardHTML = `<!DOCTYPE html>
         .replace(/\n/g, '\\n') + "'";
       return esc(lit);
     }
+
+    // escAttr escapes for a QUOTED ATTRIBUTE value. esc() goes through
+    // textContent -> innerHTML, which per spec escapes & < > but NOT quotes, so
+    // esc() alone is unsafe between double quotes: a hive name containing a '"'
+    // closes the attribute and everything after it is parsed as markup, which
+    // is enough to inject an event handler. Hive names and org/repo strings are
+    // spoke-reported, i.e. untrusted. Use escAttr for anything interpolated
+    // into an attribute; esc() remains correct for text nodes.
+    function escAttr(s) { return esc(s).replace(/"/g, '&quot;').replace(/'/g, '&#39;'); }
 
     // sameShaJS: two git SHAs are the same commit even if one is a short
     // prefix of the other. The hub stores 7-char short SHAs while a spoke may
@@ -6011,6 +6068,95 @@ const dashboardHTML = `<!DOCTYPE html>
         esc(label) + '</span>';
     }
 
+    /* ---- Contributor relay (hover panel) ------------------------------
+       The relay is a first-class SUBSTITUTE for assigning a method/model:
+       when humans are picking up this hive's tasks through /contribute, the
+       "tokens for an agent" requirement is satisfied. The product rule is
+       that this must read as its OWN state — never silently folded into
+       "assigned"/"OK" — so an operator can see the requirement is being met
+       *via the relay*.
+
+       The signal is h.journey.viaRelay, computed on the hub by relayInUse()
+       (pkg/hub/journey.go) and already shipped on every My Hives row for the
+       Journey column's "relay" badge. Reading the SAME field here is what
+       keeps the two surfaces from ever disagreeing about one hive — there is
+       no second, browser-side relay rule to drift out of sync. */
+
+    /* Teal, matching the .journey-relay badge, so "relay" reads as the same
+       thing in the Journey column and in this panel. */
+    var RELAY_COLOR = '#2dd4bf';
+
+    /* relayLine renders the relay state plus how many contributors are behind
+       it. ContributorCount is the durable registered-profile count; active is
+       the live-WebSocket count, which legitimately drops to zero when nobody
+       is connected right now — so the registered count is what's headlined and
+       the active count is only added when it is non-zero. */
+    function relayLine(h) {
+      var j = h.journey || {};
+      if (!j.viaRelay) return '';
+      var registered = h.contributorCount || 0;
+      var active = h.activeContributors || 0;
+      var who;
+      if (registered > 0) {
+        who = registered === 1 ? '1 contributor' : registered + ' contributors';
+        if (active > 0) who += ', ' + active + ' active';
+      } else if (active > 0) {
+        who = active === 1 ? '1 active contributor' : active + ' active contributors';
+      } else {
+        /* viaRelay with no counts means the signal came from a leaderboard
+           entry with a task in flight; say so rather than printing "0". */
+        who = 'task in progress';
+      }
+      return '<div style="padding:1px 0;color:' + RELAY_COLOR + '">' +
+        esc('◆ Contributor relay · ' + who) + '</div>' +
+        '<div style="padding:0 0 1px 12px;color:var(--muted);font-size:0.65rem">' +
+        esc('satisfies the method/model requirement') + '</div>';
+    }
+
+    /* ---- Recent activity (hover panel) --------------------------------
+       Events ride the My Hives payload as h.recentEvents (owner/admin only,
+       see MyHiveEntry.RecentEvents) rather than being fetched on hover, so
+       sweeping the pointer down the table costs zero requests. The full
+       history stays in the timeline modal. */
+
+    /* How many events the panel renders. The server already trims to
+       myHivesRecentEventCount; this is the browser-side guard so an older or
+       hand-crafted payload can never stretch the panel. */
+    var HOVER_EVENT_COUNT = 3;
+
+    /* An event detail is a full sentence; the panel is 300px wide at most, so
+       long details are clipped to keep one event on one line. */
+    var HOVER_EVENT_DETAIL_MAXLEN = 48;
+
+    function hoverEventRows(h) {
+      var events = (h.recentEvents || []).slice(0, HOVER_EVENT_COUNT);
+      if (!events.length) return '';
+      var rows = events.map(function(ev) {
+        var kind = TIMELINE_KINDS[ev.kind] || { label: ev.kind || 'Event', color: '#8b949e' };
+        var detail = ev.detail || '';
+        if (detail.length > HOVER_EVENT_DETAIL_MAXLEN) {
+          detail = detail.substring(0, HOVER_EVENT_DETAIL_MAXLEN - 1) + '…';
+        }
+        return '<div style="display:flex;gap:6px;align-items:baseline;padding:1px 0">' +
+          '<span style="flex:0 0 auto;color:' + kind.color + ';font-size:0.6rem;font-weight:600">' + esc(kind.label) + '</span>' +
+          '<span style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--muted)">' + esc(detail) + '</span>' +
+          '<span style="flex:0 0 auto;color:var(--muted);font-size:0.6rem">' + esc(timelineAgo(ev.ts)) + '</span>' +
+          '</div>';
+      }).join('');
+      /* "View all" opens the existing 200-event modal. It is a data-attribute
+         button read by a delegated listener, NOT an inline onclick: a hive name
+         is spoke-reported and esc() escapes neither quotes nor apostrophes, so
+         building a handler string from it would be an injection. The values
+         land in quoted attributes, so they go through escAttr(), not esc(). */
+      var viewAll = '<div style="padding:3px 0 0"><button type="button" class="hover-view-timeline" ' +
+        'data-hive-id="' + escAttr(h.id) + '" data-hive-name="' + escAttr(h.name || h.id) + '" ' +
+        'style="background:none;border:none;padding:0;color:var(--blue);font-size:0.62rem;cursor:pointer;text-decoration:underline">' +
+        'View all activity</button></div>';
+      return '<span style="display:block;border-top:1px solid var(--border);margin:6px 0 4px"></span>' +
+        '<span style="display:block;color:var(--muted);font-size:0.62rem;text-transform:uppercase;letter-spacing:0.04em;margin-bottom:4px">Recent activity</span>' +
+        rows + viewAll;
+    }
+
     function healthBadge(h) {
       var hp = h.health || {};
       var st = hp.status || 'unknown';
@@ -6065,8 +6211,18 @@ const dashboardHTML = `<!DOCTYPE html>
 
       // No access list (not an owner of this row): nothing to render beyond the
       // health lines, so the native title tooltip is enough and cheapest.
+      //
+      // recentEvents is populated under the SAME owner/admin rule as access, so
+      // a row without an access list has no events either — there is nothing to
+      // consolidate here and this branch stays a plain title. The relay state is
+      // carried as a text line so this branch still reports it, rather than the
+      // relay being visible only to owners.
       if (!access.length) {
-        return '<span title="' + esc(lines.join('\n')) + '" style="display:inline-flex;align-items:center;gap:4px;cursor:help;white-space:pre-line">' + dotMarkup + '</span>';
+        var plainLines = lines.slice();
+        if ((h.journey || {}).viaRelay) {
+          plainLines.push('◆ Contributor relay in use — satisfies the method/model requirement');
+        }
+        return '<span title="' + esc(plainLines.join('\n')) + '" style="display:inline-flex;align-items:center;gap:4px;cursor:help;white-space:pre-line">' + dotMarkup + '</span>';
       }
 
       // ONE panel holding health AND access. Setting a title attribute here too
@@ -6105,9 +6261,11 @@ const dashboardHTML = `<!DOCTYPE html>
         'min-width:210px;max-width:300px;padding:8px 10px;border-radius:8px;border:1px solid var(--border);' +
         'background:var(--surface);box-shadow:0 6px 20px rgba(0,0,0,0.35);font-size:0.72rem;text-align:left;font-weight:400;white-space:normal">' +
         healthRows +
+        relayLine(h) +
         '<span style="display:block;border-top:1px solid var(--border);margin:6px 0 4px"></span>' +
         '<span style="display:block;color:var(--muted);font-size:0.62rem;text-transform:uppercase;letter-spacing:0.04em;margin-bottom:4px">' + esc(heading) + '</span>' +
-        accessRows + '</span></span>';
+        accessRows +
+        hoverEventRows(h) + '</span></span>';
     }
     /* ---- Config drift -------------------------------------------------
        The server computes drift signals per hive (pkg/hub/drift.go) and ships
@@ -9589,6 +9747,17 @@ const dashboardHTML = `<!DOCTYPE html>
       if (!e.target.closest('[id^="hive-menu-"]') && !e.target.closest('[onclick*="toggleHiveMenu"]')) {
         document.querySelectorAll('[id^="hive-menu-"]').forEach(function(m) { m.style.display = 'none'; });
       }
+    });
+
+    /* "View all activity" in the status hover panel. Delegated rather than an
+       inline onclick because the hive name is user-controlled and esc() does
+       not escape apostrophes — a name containing one would break out of an
+       inline handler string. The values are read back from data attributes,
+       where esc() IS sufficient. */
+    document.addEventListener('click', function(e) {
+      var btn = e.target.closest ? e.target.closest('.hover-view-timeline') : null;
+      if (!btn) return;
+      openTimelineModal(btn.getAttribute('data-hive-id') || '', btn.getAttribute('data-hive-name') || '');
     });
 
     function openMigrateModal(hiveId, currentClusterId) {


### PR DESCRIPTION
## What

The My Hives status hover already carried status, config-drift signals, per-check health lines and the user access list. Recent activity lived in a separate modal, and contributor-relay state was only visible as a badge in the Journey column — so answering "what is going on with this hive?" meant reading three surfaces. This folds both into the one panel.

## Fetch vs embed — measured, not guessed

Recent activity **rides the my-hives payload** (`MyHiveEntry.RecentEvents`) rather than being fetched on hover.

Hovering is a high-frequency interaction: sweeping the pointer down a 42-row table would fire 42 requests, each hitting the filesystem via `loadSaaSHive` in `handleHiveTimeline`. Neither a debounce nor a TTL cache removes that, because scanning the list *is* how the table is read — the requests are the common case, not the edge case.

Cost was measured by marshalling representative events:

| case | bytes/row (3 events) | x42 hives |
|---|---|---|
| typical details | 335 B | **13.7 KB** |
| every detail maxed to `timelineMaxDetailRunes` (300) | 1216 B | **49.9 KB** |

Small beside what a row already ships (health map, drift report, access list, agents, leaderboard, issue/PR spark histories). The events are already in memory hub-side, so serving them costs **no extra I/O**.

Events are populated under the **same owner/admin rule as the access list** — the rule `handleHiveTimeline` itself enforces.

## Modal kept

Yes. The full 200-event modal is untouched (`#timeline-modal`, `#timeline-list`, `#timeline-hive-label`, route and handler all intact). The hover shows `myHivesRecentEventCount = 3` events, newest first, plus a **"View all activity"** affordance that opens the existing modal. A hover panel is the wrong place for 200 events.

## Relay status

Reads `h.journey.viaRelay` — the field already computed by the shared **`relayInUse()`** from `journey.go` (#2161) and already used by the Journey column's badge. Reusing the same field means there is **no second browser-side relay rule** that could drift out of sync, and one hive can never say two different things in two places. The hover uses the same teal (`#2dd4bf`) as `.journey-relay`.

Per the product rule the relay renders as its **own distinct state** naming what it does — "Contributor relay · 3 contributors" over "satisfies the method/model requirement" — never folded into "assigned" or "OK". The registered `contributorCount` is headlined with `activeContributors` appended only when non-zero, since the live count legitimately drops to zero when nobody is connected.

## Single-hover-panel invariant

Holds. `TestSingleHoverPanelInvariant` passes; no `title` attribute appears on the custom-panel branch, and the rows without an access list still get a plain `title` and no panel.

The test itself is **re-anchored on the statement terminator** (`'</span></span>';`) instead of `accessRows + '</span></span>';`. Appending a section to the panel moved the old marker, so the guard stopped finding the expression and silently stopped guarding anything. Verified by dumping the matched region: it still spans the complete panel expression.

## Security fix

Adds an `escAttr()` helper. `esc()` goes through `textContent -> innerHTML`, which escapes `& < >` but **not quotes** — so it is unsafe between double quotes. A spoke-reported hive name containing a `"` would close a data attribute and inject an event handler (confirmed reproducible against `esc()` semantics). The view-all button's data attributes use `escAttr`, and the button is a **delegated listener**, not an inline `onclick`.

## Verified vs assumed

**Verified by running:** `go build ./...`, `go vet ./pkg/hub/`, `go test -count=1 -timeout 480s ./pkg/hub/` (all green, post-rebase); all 4 inline `<script>` bodies extracted from `dashboardHTML` and passed `node --check`; the payload sizes in the table above; `relayInUse()` signature and `viaRelay` JSON wiring; `ContributorCount`/`ActiveContributors` reaching the payload via the embedded `RegistryEntry`; `recent()` returning newest-first; the modal, route and handler still present; the invariant test's matched region.

**Assumed (not verified):** rendered visual appearance in a real browser — no hub instance was exercised, so panel width/wrapping at 300px and the hover-gap bridge are reasoned from the CSS, not observed.

## Note on base

Rebased onto current `v2`; resolved one conflict where #2163's `jsArg()` helper landed at the same spot as `escAttr()`. They serve different contexts (JS-literal vs quoted-attribute) and both are kept.