### PR TITLE
✨ feat(hub): auto-upgrade scheduling mode — Instant or daily 5pm ET

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1290,10 +1290,14 @@ func parseInt(s string) int {
 
 type MyHiveEntry struct {
 	RegistryEntry
-	Role                string                 `json:"role"`
-	ProvError           string                 `json:"provError,omitempty"`
-	ProvStatus          string                 `json:"provStatus,omitempty"`
-	AutoUpgrade         bool                   `json:"autoUpgrade"`
+	Role        string `json:"role"`
+	ProvError   string `json:"provError,omitempty"`
+	ProvStatus  string `json:"provStatus,omitempty"`
+	AutoUpgrade bool   `json:"autoUpgrade"`
+	// AutoUpgradeMode is always sent NORMALIZED (never empty when autoUpgrade is
+	// on) so the dashboard can render the effective mode without re-deriving the
+	// legacy empty-means-instant rule in JavaScript.
+	AutoUpgradeMode     string                 `json:"autoUpgradeMode,omitempty"`
 	PendingRequestCount int                    `json:"pendingRequestCount,omitempty"`
 	PendingRequests     []PendingAccessRequest `json:"pending_requests,omitempty"`
 
@@ -1347,10 +1351,14 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 	var result []MyHiveEntry
 
 	autoUpgradeMap := make(map[string]bool)
+	// Normalized here (empty → instant) so every consumer sees the effective
+	// mode rather than the raw legacy blank.
+	autoUpgradeModeMap := make(map[string]string)
 	saasByID := make(map[string]*SaaSHive)
 	for _, sh := range listSaaSHives() {
 		shCopy := sh
 		autoUpgradeMap[sh.ID] = sh.AutoUpgrade
+		autoUpgradeModeMap[sh.ID] = normalizeAutoUpgradeMode(sh.AutoUpgradeMode)
 		saasByID[sh.ID] = &shCopy
 	}
 
@@ -1419,20 +1427,20 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 			if isAdmin && role != "owner" {
 				role = "owner"
 			}
-			entry := MyHiveEntry{RegistryEntry: h, Role: role, AutoUpgrade: autoUpgradeMap[h.ID]}
+			entry := MyHiveEntry{RegistryEntry: h, Role: role, AutoUpgrade: autoUpgradeMap[h.ID], AutoUpgradeMode: autoUpgradeModeMap[h.ID]}
 			enrichFromSaaSMeta(&entry)
 			result = append(result, entry)
 			continue
 		}
 		if strings.EqualFold(h.Owner, username) {
-			entry := MyHiveEntry{RegistryEntry: h, Role: "owner", AutoUpgrade: autoUpgradeMap[h.ID]}
+			entry := MyHiveEntry{RegistryEntry: h, Role: "owner", AutoUpgrade: autoUpgradeMap[h.ID], AutoUpgradeMode: autoUpgradeModeMap[h.ID]}
 			enrichFromSaaSMeta(&entry)
 			result = append(result, entry)
 			user.Hives[h.ID] = "owner"
 			continue
 		}
 		if isAdmin {
-			entry := MyHiveEntry{RegistryEntry: h, Role: "owner", AutoUpgrade: autoUpgradeMap[h.ID]}
+			entry := MyHiveEntry{RegistryEntry: h, Role: "owner", AutoUpgrade: autoUpgradeMap[h.ID], AutoUpgradeMode: autoUpgradeModeMap[h.ID]}
 			enrichFromSaaSMeta(&entry)
 			result = append(result, entry)
 		}
@@ -2087,6 +2095,23 @@ func (s *HubServer) handleMigrateHive(w http.ResponseWriter, r *http.Request) {
 
 var hubAutoUpgradePath = "/data/saas/hub-auto-upgrade"
 
+// The hub's own auto-upgrade is deliberately NOT given the daily schedule that
+// per-hive auto-upgrade has. The two look symmetric but carry opposite risk:
+//
+//   - A spoke hive is a workload. Restarting it interrupts running agents, so
+//     deferring to an after-hours window is a clear win — that is exactly the
+//     "don't disturb a working hive" motivation for the daily mode.
+//   - The hub is the control plane. It is what DELIVERS every spoke upgrade,
+//     serves the dashboard, and receives every heartbeat. Holding a hub fix for
+//     up to 24 hours means holding back fixes to the upgrade machinery itself,
+//     including any fix to this scheduler. A hub restart is also cheap: it is a
+//     single stateless pod whose state lives on the PVC, and spokes tolerate a
+//     missed heartbeat cycle by design.
+//
+// Deferring hub upgrades would therefore add real risk (a known-bad hub stays
+// up all day) to avoid a disruption the hub does not really suffer. It stays a
+// plain on/off toggle. Revisit only if hub restarts are ever shown to disrupt
+// in-flight spoke work.
 func isHubAutoUpgrade() bool {
 	data, err := os.ReadFile(hubAutoUpgradePath)
 	if err != nil {
@@ -2528,8 +2553,15 @@ func (s *HubServer) handleToggleAutoUpgrade(w http.ResponseWriter, r *http.Reque
 		fmt.Fprint(w, `{"error":"only the owner can change auto-upgrade"}`)
 		return
 	}
+	// The mode rides on the EXISTING endpoint rather than a second one: it is
+	// the same preference, the same owner-or-admin authorization checked above,
+	// and the same persistence. A separate endpoint would let the two settings
+	// drift apart across two requests. Older clients that send only
+	// auto_upgrade omit the field, which reads as "" = instant, preserving
+	// their behaviour exactly.
 	var body struct {
-		AutoUpgrade bool `json:"auto_upgrade"`
+		AutoUpgrade bool   `json:"auto_upgrade"`
+		Mode        string `json:"auto_upgrade_mode"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		w.Header().Set("Content-Type", "application/json")
@@ -2537,19 +2569,37 @@ func (s *HubServer) handleToggleAutoUpgrade(w http.ResponseWriter, r *http.Reque
 		fmt.Fprint(w, `{"error":"invalid request body"}`)
 		return
 	}
+	// Reject unknown modes instead of defaulting — a typo must not silently
+	// change how often a hive restarts.
+	if !isValidAutoUpgradeMode(body.Mode) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"error":"invalid auto_upgrade_mode (expected \"instant\" or \"daily\")"}`)
+		return
+	}
 	h.AutoUpgrade = body.AutoUpgrade
+	h.AutoUpgradeMode = body.Mode
+	// Switching modes clears the day's fire record. Otherwise a hive flipped to
+	// daily after an instant upgrade earlier today would inherit a stale date
+	// and skip tonight's window.
+	h.AutoUpgradeLastFired = ""
 	if err := saveSaaSHive(h); err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprint(w, `{"error":"failed to save"}`)
 		return
 	}
-	s.logger.Info("audit: auto-upgrade toggled", "hive_id", id, "auto_upgrade", body.AutoUpgrade, "by", username)
+	s.logger.Info("audit: auto-upgrade toggled", "hive_id", id, "auto_upgrade", body.AutoUpgrade, "mode", normalizeAutoUpgradeMode(body.Mode), "by", username)
 
 	// If enabling auto-upgrade and hive is behind, trigger immediately via kubectl
 	// for hosted hives. For heartbeat-connected hives, the upgrade instruction
 	// is delivered via the heartbeat response.
-	if body.AutoUpgrade {
+	// Daily mode deliberately does NOT kick an upgrade here: the whole point of
+	// choosing it is that turning auto-upgrade on should not immediately
+	// restart a working hive. It will roll at the next 17:00 ET window. The
+	// operator who wants it now still has the explicit Upgrade button, which
+	// goes through handleUpgradeHive and is never gated by mode.
+	if body.AutoUpgrade && normalizeAutoUpgradeMode(body.Mode) == AutoUpgradeModeInstant {
 		s.mu.RLock()
 		var currentSHA, branch string
 		for _, reg := range s.registry.Hives {
@@ -2588,7 +2638,7 @@ func (s *HubServer) handleToggleAutoUpgrade(w http.ResponseWriter, r *http.Reque
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintf(w, `{"ok":true,"auto_upgrade":%t}`, body.AutoUpgrade)
+	fmt.Fprintf(w, `{"ok":true,"auto_upgrade":%t,"auto_upgrade_mode":%q}`, body.AutoUpgrade, normalizeAutoUpgradeMode(body.Mode))
 }
 
 // branchSHAInfo holds a short SHA and the first line of its commit message.
@@ -3232,6 +3282,17 @@ func (s *HubServer) triggerAutoUpgrades() {
 		if !h.AutoUpgrade {
 			continue
 		}
+		// Scheduling gate. Instant-mode hives (and every legacy record, whose
+		// mode is empty) pass straight through, so this changes nothing for the
+		// existing fleet. Daily-mode hives are held until the first cycle at or
+		// after autoUpgradeDailyHour ET and released only once per ET day.
+		// Evaluated BEFORE any of the work below so a held hive costs nothing.
+		decision := shouldAutoUpgradeNow(h.AutoUpgradeMode, h.AutoUpgradeLastFired, time.Now())
+		if !decision.Allowed {
+			s.logger.Debug("auto-upgrade held by schedule",
+				"hive_id", h.ID, "mode", h.AutoUpgradeMode, "reason", decision.Reason)
+			continue
+		}
 		// Skip hives that are actively provisioning or in error state.
 		// Empty status means the hive predates the provisioning system — treat as eligible.
 		if h.Status == "provisioning" || h.Status == "error" {
@@ -3343,7 +3404,25 @@ func (s *HubServer) triggerAutoUpgrades() {
 			s.logger.Warn("auto-upgrade skipped — no cluster config", "hive_id", h.ID, "cluster_id", h.ClusterID)
 			continue
 		}
-		s.logger.Info("audit: auto-upgrade triggered", "hive_id", h.ID, "branch", branch, "from", currentSHA, "to", latestSHA, "cluster", hiveCluster.ID)
+		// Record the day's fire BEFORE kicking the rollout. Persisting first
+		// means a hub crash between here and the restart cannot cause a second
+		// upgrade for the same ET day; at worst the hive waits for tomorrow's
+		// window, which is the conservative direction for a "don't disturb it"
+		// mode. Only daily-mode hives carry a fire date (decision.FireDate is
+		// empty for instant), and a save failure is logged but not fatal — the
+		// upgrade itself still proceeds.
+		if decision.FireDate != "" {
+			stored := loadSaaSHive(h.ID)
+			if stored == nil {
+				stored = &h
+			}
+			stored.AutoUpgradeLastFired = decision.FireDate
+			if err := saveSaaSHive(stored); err != nil {
+				s.logger.Warn("failed to persist auto-upgrade fire date — a hub restart today could re-fire",
+					"hive_id", h.ID, "date", decision.FireDate, "error", err)
+			}
+		}
+		s.logger.Info("audit: auto-upgrade triggered", "hive_id", h.ID, "branch", branch, "from", currentSHA, "to", latestSHA, "cluster", hiveCluster.ID, "mode", normalizeAutoUpgradeMode(h.AutoUpgradeMode))
 		s.recordTimeline(h.ID, TimelineUpgradeStarted,
 			fmt.Sprintf("auto-upgrade triggered on %s: %s → %s", branch, orDash(currentSHA), latestSHA), "auto-upgrade")
 		s.mu.Lock()
@@ -8000,7 +8079,8 @@ const dashboardHTML = `<!DOCTYPE html>
         '<span style="flex:1"></span>' +
         '<button type="button" onclick="runBulkAction(\'restart\')" style="' + btn + '">Restart</button>' +
         '<button type="button" onclick="runBulkAction(\'upgrade\')" style="' + btn + '">Upgrade to latest</button>' +
-        '<button type="button" onclick="runBulkAction(\'enable-auto-upgrade\')" style="' + btn + '">Auto-upgrade on</button>' +
+        '<button type="button" onclick="runBulkAction(\'enable-auto-upgrade\')" style="' + btn + '">Auto: instant</button>' +
+        '<button type="button" onclick="runBulkAction(\'daily-auto-upgrade\')" style="' + btn + '" title="Upgrade at most once a day, after hours — keeps a stable hive from being restarted mid-work">Auto: daily 5pm ET</button>' +
         '<button type="button" onclick="runBulkAction(\'disable-auto-upgrade\')" style="' + btn + '">Auto-upgrade off</button>' +
         branchPicker +
         '<button type="button" onclick="clearBulkSelection()" style="' + btn + ';color:var(--muted)">Clear</button>' +
@@ -8019,7 +8099,8 @@ const dashboardHTML = `<!DOCTYPE html>
     var BULK_ACTION_LABELS = {
       'restart': 'Restart',
       'upgrade': 'Upgrade to latest',
-      'enable-auto-upgrade': 'Enable auto-upgrade on',
+      'enable-auto-upgrade': 'Enable instant auto-upgrade on',
+      'daily-auto-upgrade': 'Enable daily 5pm ET auto-upgrade on',
       'disable-auto-upgrade': 'Disable auto-upgrade on',
       'switch-branch': 'Switch branch for'
     };
@@ -8285,15 +8366,46 @@ const dashboardHTML = `<!DOCTYPE html>
             var progressTitle = isSwitching ? (switchStale ? 'The hive has not reported branch ' + esc(targetBranch) + ' yet — it may be offline or its build predates in-cluster switch support. It will apply on its next successful check-in.' : 'Rolling out ' + esc(h.upgradeTarget || '') + ' — the pill updates when the hive reports the new branch') : 'Upgrading to ' + esc(branchLatest || h.upgradeTarget || '?');
             upgradeIcon = ' <span title="' + progressTitle + '" style="display:inline-block;padding:3px 10px;background:var(--surface);border:1px solid var(--border);border-radius:4px;font-size:0.7rem;margin-left:6px;white-space:nowrap;opacity:0.8"><span style="display:inline-block;width:12px;height:12px;border:2px solid rgba(255,255,255,0.3);border-top-color:#fff;border-radius:50%;animation:spin 1s linear infinite;vertical-align:middle;margin-right:4px"></span>' + progressLabel + '</span>';
           } else if (!isCurrent && !latestUnknown && isHosted && h.role === 'owner' && h.autoUpgrade) {
-            upgradeIcon = ' <span id="upgrade-' + esc(h.id) + '" onclick="upgradeHive(\'' + esc(h.id) + '\',\'' + esc(sha) + '\',\'' + esc(branchName) + '\')" title="Auto-upgrade will apply ' + esc(branchLatest) + ' shortly — click to upgrade now' + esc(buildingHint) + '" style="display:inline-block;padding:3px 10px;background:var(--surface);color:var(--muted);border:1px dashed var(--border);border-radius:4px;cursor:pointer;font-size:0.7rem;margin-left:6px;white-space:nowrap">queued</span>';
+            /* A daily-mode hive is NOT upgrading "shortly" — saying so would be
+               a lie the operator would notice hours later. Name the window and
+               keep the click-to-upgrade-now escape hatch, which is the manual
+               path and is never gated by the schedule. */
+            var queuedDaily = h.autoUpgradeMode === AUTO_UPGRADE_DAILY;
+            var queuedLabel = queuedDaily ? 'queued · 5pm ET' : 'queued';
+            var queuedTitle = queuedDaily
+              ? 'Auto-upgrade will apply ' + esc(branchLatest) + ' at the next 5pm ET window — click to upgrade now' + esc(buildingHint)
+              : 'Auto-upgrade will apply ' + esc(branchLatest) + ' shortly — click to upgrade now' + esc(buildingHint);
+            upgradeIcon = ' <span id="upgrade-' + esc(h.id) + '" onclick="upgradeHive(\'' + esc(h.id) + '\',\'' + esc(sha) + '\',\'' + esc(branchName) + '\')" title="' + queuedTitle + '" style="display:inline-block;padding:3px 10px;background:var(--surface);color:var(--muted);border:1px dashed var(--border);border-radius:4px;cursor:pointer;font-size:0.7rem;margin-left:6px;white-space:nowrap">' + queuedLabel + '</span>';
           } else if (!isCurrent && !latestUnknown && isHosted && h.role === 'owner') {
             upgradeIcon = ' <button id="upgrade-' + esc(h.id) + '" onclick="upgradeHive(\'' + esc(h.id) + '\',\'' + esc(sha) + '\',\'' + esc(branchName) + '\')" title="Current: ' + esc(sha) + ' → Latest: ' + esc(branchLatest) + esc(buildingHint) + '" style="padding:3px 10px;background:var(--green);color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.7rem;margin-left:6px;white-space:nowrap">Upgrade</button>';
           } else if (latestUnknown && isHosted && h.role === 'owner') {
             upgradeIcon = ' <button disabled title="Waiting for latest version…" style="padding:3px 10px;background:var(--surface);color:var(--muted);border:1px solid var(--border);border-radius:4px;font-size:0.7rem;margin-left:6px;white-space:nowrap;cursor:not-allowed;opacity:0.5">Upgrade</button>';
           }
+          /* Auto-upgrade control: a single select replaces the old checkbox.
+             The dense table has no room for a checkbox PLUS a mode dropdown,
+             and two controls for one setting invites the illegal-looking
+             "off but daily" state. One select shows the effective mode at a
+             glance — no dialog, no hover needed — which is the whole point:
+             an operator scanning the fleet must be able to see which hives
+             restart on sight of a new commit and which wait for the evening.
+             The id travels in a data-* attribute and the handler is bound by
+             delegation (see bindAutoUpgradeSelects) because esc() does NOT
+             escape quotes and is unsafe to interpolate into an attribute. */
           var autoUpgradeCheck = '';
           if (isHosted && h.role === 'owner') {
-            autoUpgradeCheck = ' <label style="margin-left:8px;font-size:0.65rem;color:var(--muted);cursor:pointer;white-space:nowrap" title="Automatically upgrade when a new version is available"><input type="checkbox" ' + (h.autoUpgrade ? 'checked' : '') + ' onchange="toggleAutoUpgrade(\'' + esc(h.id) + '\',this.checked)" style="vertical-align:middle;margin-right:2px;cursor:pointer">auto</label>';
+            var mode = h.autoUpgrade ? (h.autoUpgradeMode === AUTO_UPGRADE_DAILY ? AUTO_UPGRADE_DAILY : AUTO_UPGRADE_INSTANT) : AUTO_UPGRADE_OFF;
+            var opts = '';
+            for (var oi = 0; oi < AUTO_UPGRADE_OPTIONS.length; oi++) {
+              var opt = AUTO_UPGRADE_OPTIONS[oi];
+              opts += '<option value="' + esc(opt.value) + '"' + (mode === opt.value ? ' selected' : '') + '>' + esc(opt.label) + '</option>';
+            }
+            var d = document.createElement('select');
+            d.className = 'auto-upgrade-select';
+            d.setAttribute('data-hive-id', h.id);
+            d.title = AUTO_UPGRADE_TITLE;
+            d.setAttribute('style', 'margin-left:8px;font-size:0.65rem;color:var(--muted);background:var(--surface);border:1px solid var(--border);border-radius:4px;padding:1px 3px;cursor:pointer;vertical-align:middle');
+            d.innerHTML = opts;
+            autoUpgradeCheck = ' ' + d.outerHTML;
           }
           var shaMsg = _commitMessages[sha] || _latestSHAMessages[branchName] || '';
           versionCell = branch + '<span style="font-family:monospace;color:var(--muted)" title="' + esc(shaMsg) + '">' + esc(sha) + '</span>' + status + upgradeIcon + autoUpgradeCheck;
@@ -8492,6 +8604,9 @@ const dashboardHTML = `<!DOCTYPE html>
         '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer">Location ⇅</th><th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅</th><th>Public</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'journey\')" style="cursor:pointer" title="Where this hive is on the adoption journey: install the GitHub App, assign a method/model (or run the contributor relay), then raise the ACMM level">Journey ⇅</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th>' +
         '<th title="Configuration drift from the fleet norm — hover a value for the specific signals">Drift</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table></div>';
+      /* Delegated, so binding once is enough no matter how often the table is
+         re-rendered. The guard keeps repeated renders from stacking listeners. */
+      if (!_autoUpgradeSelectsBound) { bindAutoUpgradeSelects(); _autoUpgradeSelectsBound = true; }
       /* Re-derive the bar and the select-all tri-state from _bulkSelected now
          that the fresh checkboxes exist in the DOM. */
       renderBulkBar();
@@ -8514,6 +8629,59 @@ const dashboardHTML = `<!DOCTYPE html>
         hiveToast(id + ' is now ' + (isPublic ? 'public' : 'private'), 'success');
         loadHives();
       } catch(e) { hiveToast('Error: ' + e.message, 'error'); loadHives(); }
+    }
+
+    /* Auto-upgrade select values. AUTO_UPGRADE_OFF is a UI-only sentinel: on
+       the wire "off" is auto_upgrade:false, and the two real modes match the
+       server's allowlist ("instant" / "daily"). */
+    var _autoUpgradeSelectsBound = false;
+    var AUTO_UPGRADE_OFF = 'off';
+    var AUTO_UPGRADE_INSTANT = 'instant';
+    var AUTO_UPGRADE_DAILY = 'daily';
+    /* Copy is framed around DISRUPTION, not cron mechanics: the operator is
+       choosing when it is acceptable to interrupt a hive that is working. */
+    var AUTO_UPGRADE_TITLE = 'When to apply new versions. Instant restarts the hive as soon as a new version lands; Daily restarts it at most once a day, after hours, so a stable hive is not disturbed mid-work.';
+    var AUTO_UPGRADE_OPTIONS = [
+      {value: AUTO_UPGRADE_OFF, label: 'Auto: off'},
+      {value: AUTO_UPGRADE_INSTANT, label: 'Auto: instant'},
+      {value: AUTO_UPGRADE_DAILY, label: 'Auto: daily 5pm ET'}
+    ];
+
+    /* One delegated listener on the container, bound once at startup, so every
+       re-render of the table keeps working without rebinding per row. */
+    function bindAutoUpgradeSelects() {
+      var container = document.getElementById('hives-container');
+      if (!container) return;
+      container.addEventListener('change', function(e) {
+        var el = e.target;
+        if (!el || !el.classList || !el.classList.contains('auto-upgrade-select')) return;
+        var id = el.getAttribute('data-hive-id');
+        if (!id) return;
+        setAutoUpgradeMode(id, el.value);
+      });
+    }
+
+    /* Maps the select's value onto the existing endpoint's two fields. "off"
+       sends auto_upgrade:false; the mode is still sent so the server records a
+       concrete preference rather than leaving a blank to be re-interpreted. */
+    async function setAutoUpgradeMode(id, value) {
+      var enabled = value !== AUTO_UPGRADE_OFF;
+      var mode = (value === AUTO_UPGRADE_DAILY) ? AUTO_UPGRADE_DAILY : AUTO_UPGRADE_INSTANT;
+      try {
+        var resp = await fetch('/api/saas/hives/' + encodeURIComponent(id) + '/auto-upgrade', {
+          method: 'PUT',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({auto_upgrade: enabled, auto_upgrade_mode: mode})
+        });
+        if (!resp.ok) { hiveToast('Failed to update auto-upgrade', 'error'); loadHives(); return; }
+        var label = !enabled ? 'off'
+          : (mode === AUTO_UPGRADE_DAILY ? 'daily at 5pm ET' : 'instant');
+        hiveToast(id + ' auto-upgrade: ' + label, 'success');
+        loadHives();
+      } catch(e) {
+        hiveToast('Error: ' + e.message, 'error');
+        loadHives();
+      }
     }
 
     async function toggleAutoUpgrade(id, enabled) {

--- a/v2/pkg/hub/saas_bulk.go
+++ b/v2/pkg/hub/saas_bulk.go
@@ -57,7 +57,11 @@ const (
 	bulkActionUpgrade            = "upgrade"
 	bulkActionEnableAutoUpgrade  = "enable-auto-upgrade"
 	bulkActionDisableAutoUpgrade = "disable-auto-upgrade"
-	bulkActionSwitchBranch       = "switch-branch"
+	// bulkActionDailyAutoUpgrade enables auto-upgrade in daily mode. The plain
+	// enable action keeps meaning INSTANT so existing muscle memory and any
+	// existing API callers are unchanged.
+	bulkActionDailyAutoUpgrade = "daily-auto-upgrade"
+	bulkActionSwitchBranch     = "switch-branch"
 )
 
 // BulkHiveRequest is the body of POST /api/saas/hives/bulk.
@@ -149,7 +153,7 @@ func (s *HubServer) handleBulkHiveAction(w http.ResponseWriter, r *http.Request)
 
 	switch body.Action {
 	case bulkActionRestart, bulkActionUpgrade, bulkActionEnableAutoUpgrade,
-		bulkActionDisableAutoUpgrade, bulkActionSwitchBranch:
+		bulkActionDisableAutoUpgrade, bulkActionDailyAutoUpgrade, bulkActionSwitchBranch:
 	default:
 		writeBulkError(w, http.StatusBadRequest, "unknown bulk action")
 		return
@@ -264,9 +268,11 @@ func (s *HubServer) applyBulkAction(action, branch, id, username string) BulkHiv
 	case bulkActionRestart, bulkActionUpgrade:
 		return s.bulkRestartOrUpgrade(h, id, username, action)
 	case bulkActionEnableAutoUpgrade:
-		return s.bulkSetAutoUpgrade(h, id, username, true)
+		return s.bulkSetAutoUpgrade(h, id, username, true, AutoUpgradeModeInstant)
+	case bulkActionDailyAutoUpgrade:
+		return s.bulkSetAutoUpgrade(h, id, username, true, AutoUpgradeModeDaily)
 	case bulkActionDisableAutoUpgrade:
-		return s.bulkSetAutoUpgrade(h, id, username, false)
+		return s.bulkSetAutoUpgrade(h, id, username, false, AutoUpgradeModeInstant)
 	case bulkActionSwitchBranch:
 		return s.bulkSwitchBranch(h, id, username, branch)
 	}
@@ -350,13 +356,17 @@ func (s *HubServer) bulkRestartOrUpgrade(h *SaaSHive, id, username, action strin
 // store and the registry are the source of truth for the dashboard, and the
 // preference reaches the spoke on its next heartbeat. No kubectl is involved,
 // so this works identically for firewalled clusters.
-func (s *HubServer) bulkSetAutoUpgrade(h *SaaSHive, id, username string, enabled bool) BulkHiveResult {
+func (s *HubServer) bulkSetAutoUpgrade(h *SaaSHive, id, username string, enabled bool, mode string) BulkHiveResult {
 	h.AutoUpgrade = enabled
+	h.AutoUpgradeMode = mode
+	// Mode changes clear the day's fire record for the same reason the
+	// single-hive handler does — see handleToggleAutoUpgrade.
+	h.AutoUpgradeLastFired = ""
 	if err := saveSaaSHive(h); err != nil {
 		return BulkHiveResult{HiveID: id, Ok: false, Error: "failed to save"}
 	}
 	s.logger.Info("audit: bulk auto-upgrade toggled",
-		"hive_id", id, "auto_upgrade", enabled, "by", username)
+		"hive_id", id, "auto_upgrade", enabled, "mode", normalizeAutoUpgradeMode(mode), "by", username)
 	return BulkHiveResult{HiveID: id, Ok: true, Via: bulkViaStore}
 }
 

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -282,6 +282,23 @@ type SaaSHive struct {
 	OCIExportID     string                 `json:"oci_export_id,omitempty"`
 	ClusterID       string                 `json:"cluster_id,omitempty"`
 
+	// AutoUpgradeMode gates WHEN an enabled auto-upgrade may fire:
+	// AutoUpgradeModeInstant (or empty) upgrades as soon as the hive is seen
+	// behind latest; AutoUpgradeModeDaily upgrades at most once per ET calendar
+	// day, at or after autoUpgradeDailyHour. omitempty keeps existing meta.json
+	// records byte-identical until the operator actually picks a mode, and an
+	// absent field reads as instant — so the ~42 records already on the PVC keep
+	// today's behaviour exactly.
+	AutoUpgradeMode string `json:"auto_upgrade_mode,omitempty"`
+	// AutoUpgradeLastFired is the ET calendar day (autoUpgradeDateFormat) on
+	// which the daily schedule last triggered an upgrade for this hive. It lives
+	// here, in the hive's own meta.json on the PVC, for two reasons: it is
+	// per-hive state that belongs with the rest of the hive's upgrade
+	// preferences, and persisting it means a hub restart at 17:03 cannot re-fire
+	// an upgrade that already went out at 17:01. Empty for instant-mode hives,
+	// which are never gated and never record a date.
+	AutoUpgradeLastFired string `json:"auto_upgrade_last_fired,omitempty"`
+
 	// GitHubBaseURL / GitHubAPIURL pin this hive's GitHub host. The GitHub
 	// host is a property of the HIVE (where its org/repos live), not the
 	// cluster: a cluster-level GHE default silently breaks hives for

--- a/v2/pkg/hub/upgrade_schedule.go
+++ b/v2/pkg/hub/upgrade_schedule.go
@@ -1,0 +1,145 @@
+package hub
+
+import (
+	"sync"
+	"time"
+
+	// tzdata embeds the IANA timezone database into the binary. The hub image is
+	// built FROM alpine:3.21, which does NOT install the tzdata package (see
+	// Dockerfile.hub — only ca-certificates and curl are added), so
+	// time.LoadLocation("America/New_York") would fail at runtime with
+	// "unknown time zone" and the daily schedule would never fire. Embedding
+	// costs ~450KB in the binary and removes the dependency on the base image.
+	_ "time/tzdata"
+)
+
+// Auto-upgrade scheduling modes. AutoUpgrade (bool) remains the on/off master
+// switch; the mode only decides WHEN an enabled auto-upgrade is allowed to fire.
+//
+// The product intent is disruption minimisation: a stable, working hive should
+// not be restarted at an arbitrary moment just because a new commit landed.
+// "daily" confines the restart to one predictable after-hours moment per day.
+const (
+	// AutoUpgradeModeInstant upgrades as soon as the hive is seen behind latest.
+	// This is the historical behaviour and the meaning of an EMPTY mode, so the
+	// ~42 existing PVC records that carry only `auto_upgrade: true` keep
+	// behaving exactly as they do today.
+	AutoUpgradeModeInstant = "instant"
+
+	// AutoUpgradeModeDaily upgrades at most once per calendar day, during the
+	// first poll cycle at or after autoUpgradeDailyHour local time in
+	// autoUpgradeTimezone.
+	AutoUpgradeModeDaily = "daily"
+)
+
+// autoUpgradeDailyHour is the hour (24h clock, in autoUpgradeTimezone) at or
+// after which a "daily" hive becomes eligible to upgrade. 17 = 5pm ET, chosen
+// as an after-hours moment for the maintainers this hub serves.
+const autoUpgradeDailyHour = 17
+
+// autoUpgradeTimezone is the IANA zone the daily window is expressed in. It is
+// deliberately a ZONE NAME and not a fixed UTC offset: America/New_York is
+// UTC-5 (EST) for part of the year and UTC-4 (EDT) for the rest, so a
+// hardcoded offset would fire an hour early or late for roughly half of every
+// year and would drift across the DST transitions in March and November.
+const autoUpgradeTimezone = "America/New_York"
+
+// autoUpgradeDateFormat is the calendar-day key stored per hive. Day identity
+// is evaluated in autoUpgradeTimezone, not UTC, so "at most once per day" means
+// once per ET day as the operator experiences it.
+const autoUpgradeDateFormat = "2006-01-02"
+
+// validAutoUpgradeModes is the allowlist the API validates against. Unknown
+// values are rejected with 400 rather than silently falling back, so a typo in
+// an API client never quietly changes a hive's upgrade cadence.
+var validAutoUpgradeModes = map[string]bool{
+	AutoUpgradeModeInstant: true,
+	AutoUpgradeModeDaily:   true,
+}
+
+// isValidAutoUpgradeMode reports whether mode is acceptable on the API. The
+// empty string is allowed and means "instant" (see normalizeAutoUpgradeMode) so
+// that older clients which send only auto_upgrade keep working unchanged.
+func isValidAutoUpgradeMode(mode string) bool {
+	return mode == "" || validAutoUpgradeModes[mode]
+}
+
+// normalizeAutoUpgradeMode maps a stored/legacy value onto a concrete mode.
+// Empty (a legacy record, or a client that never sent the field) is instant.
+func normalizeAutoUpgradeMode(mode string) string {
+	if mode == AutoUpgradeModeDaily {
+		return AutoUpgradeModeDaily
+	}
+	return AutoUpgradeModeInstant
+}
+
+// autoUpgradeLocation resolves autoUpgradeTimezone once and caches the result.
+// If the zone cannot be loaded the error is cached too, and callers fail SAFE
+// by treating the hive as instant: a hive that upgrades sooner than the
+// operator asked is a far better failure than one that silently never upgrades
+// again. With the embedded tzdata import above this path should be
+// unreachable, but it is kept because failing closed here would be invisible.
+var (
+	autoUpgradeLocOnce sync.Once
+	autoUpgradeLoc     *time.Location
+	autoUpgradeLocErr  error
+)
+
+func autoUpgradeLocation() (*time.Location, error) {
+	autoUpgradeLocOnce.Do(func() {
+		autoUpgradeLoc, autoUpgradeLocErr = time.LoadLocation(autoUpgradeTimezone)
+	})
+	return autoUpgradeLoc, autoUpgradeLocErr
+}
+
+// autoUpgradeDecision is the result of evaluating one hive's schedule for one
+// poll cycle. FireDate is the calendar-day key to persist once the upgrade has
+// actually been triggered; it is empty when Allowed is false.
+type autoUpgradeDecision struct {
+	Allowed bool
+	// FireDate is the ET calendar day the upgrade is being attributed to.
+	// Persisting it is what makes a 17:02 cycle and a 17:04 cycle collapse
+	// into a single upgrade for the day.
+	FireDate string
+	// Reason is a short, log-friendly explanation. Always populated.
+	Reason string
+}
+
+// shouldAutoUpgradeNow decides whether an auto-upgrade-enabled hive may fire on
+// this poll cycle.
+//
+// mode is the hive's stored AutoUpgradeMode (empty = instant, i.e. legacy).
+// lastFiredDate is the hive's stored AutoUpgradeLastFired, an ET calendar day
+// in autoUpgradeDateFormat, or empty if it has never fired on a schedule.
+// now is injected so the behaviour is testable without touching the wall clock.
+//
+// Missed windows deliberately do NOT accumulate. If the hub is down across
+// 17:00 and comes back at 21:30, the hive upgrades on the next cycle it sees
+// (it is still behind, and the day's window has passed) and then resumes the
+// normal daily cadence. The alternative — waiting a further ~20 hours for the
+// next 17:00 — would leave a hive knowingly behind for a full extra day, which
+// defeats the point of having auto-upgrade enabled at all. Only ONE upgrade is
+// ever owed, because the gate is "have we fired today", not a queue of windows.
+func shouldAutoUpgradeNow(mode, lastFiredDate string, now time.Time) autoUpgradeDecision {
+	if normalizeAutoUpgradeMode(mode) == AutoUpgradeModeInstant {
+		// Instant hives are ungated and never record a fire date.
+		return autoUpgradeDecision{Allowed: true, Reason: "instant mode"}
+	}
+
+	loc, err := autoUpgradeLocation()
+	if err != nil {
+		// Fail safe: behave as instant rather than never upgrading.
+		return autoUpgradeDecision{Allowed: true, Reason: "timezone unavailable — falling back to instant"}
+	}
+
+	local := now.In(loc)
+	today := local.Format(autoUpgradeDateFormat)
+
+	if lastFiredDate == today {
+		return autoUpgradeDecision{Reason: "already upgraded today"}
+	}
+	if local.Hour() < autoUpgradeDailyHour {
+		return autoUpgradeDecision{Reason: "before the daily window"}
+	}
+	return autoUpgradeDecision{Allowed: true, FireDate: today, Reason: "daily window open"}
+}

--- a/v2/pkg/hub/upgrade_schedule_test.go
+++ b/v2/pkg/hub/upgrade_schedule_test.go
@@ -1,0 +1,404 @@
+package hub
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// mustET returns a time in America/New_York. The clock is INJECTED into
+// shouldAutoUpgradeNow, so none of these tests read the real wall clock and
+// they behave identically regardless of the machine's TZ.
+func mustET(t *testing.T, y int, mo time.Month, d, h, m int) time.Time {
+	t.Helper()
+	loc, err := time.LoadLocation(autoUpgradeTimezone)
+	if err != nil {
+		t.Fatalf("LoadLocation(%s): %v — tzdata should be embedded via time/tzdata", autoUpgradeTimezone, err)
+	}
+	return time.Date(y, mo, d, h, m, 0, 0, loc)
+}
+
+// TestTzdataIsEmbedded guards the Dockerfile.hub gap directly: alpine:3.21 does
+// not ship the tzdata package, so without the `_ "time/tzdata"` import in
+// upgrade_schedule.go this lookup fails in the container and every daily hive
+// silently stops upgrading.
+func TestTzdataIsEmbedded(t *testing.T) {
+	loc, err := autoUpgradeLocation()
+	if err != nil {
+		t.Fatalf("autoUpgradeLocation() failed: %v", err)
+	}
+	if loc == nil || loc.String() != autoUpgradeTimezone {
+		t.Fatalf("got location %v, want %s", loc, autoUpgradeTimezone)
+	}
+}
+
+func TestShouldAutoUpgradeNow(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        string
+		lastFired   string
+		now         time.Time
+		wantAllowed bool
+		wantFire    string
+	}{
+		{
+			name:        "legacy record with empty mode behaves as instant",
+			mode:        "",
+			now:         mustET(t, 2026, time.July, 15, 3, 0),
+			wantAllowed: true,
+		},
+		{
+			name:        "explicit instant is never gated, even at 3am",
+			mode:        AutoUpgradeModeInstant,
+			now:         mustET(t, 2026, time.July, 15, 3, 0),
+			wantAllowed: true,
+		},
+		{
+			name:        "instant ignores a stale fire date",
+			mode:        AutoUpgradeModeInstant,
+			lastFired:   "2026-07-15",
+			now:         mustET(t, 2026, time.July, 15, 18, 0),
+			wantAllowed: true,
+		},
+		{
+			name:        "daily before the window does not fire",
+			mode:        AutoUpgradeModeDaily,
+			now:         mustET(t, 2026, time.July, 15, 16, 59),
+			wantAllowed: false,
+		},
+		{
+			name:        "daily exactly at 17:00 fires",
+			mode:        AutoUpgradeModeDaily,
+			now:         mustET(t, 2026, time.July, 15, autoUpgradeDailyHour, 0),
+			wantAllowed: true,
+			wantFire:    "2026-07-15",
+		},
+		{
+			name:        "daily after the window fires",
+			mode:        AutoUpgradeModeDaily,
+			now:         mustET(t, 2026, time.July, 15, 17, 2),
+			wantAllowed: true,
+			wantFire:    "2026-07-15",
+		},
+		{
+			name:        "daily already fired today does not fire again at 17:04",
+			mode:        AutoUpgradeModeDaily,
+			lastFired:   "2026-07-15",
+			now:         mustET(t, 2026, time.July, 15, 17, 4),
+			wantAllowed: false,
+		},
+		{
+			name:        "daily already fired today stays held late at night",
+			mode:        AutoUpgradeModeDaily,
+			lastFired:   "2026-07-15",
+			now:         mustET(t, 2026, time.July, 15, 23, 59),
+			wantAllowed: false,
+		},
+		{
+			name:        "daily fires again the next day",
+			mode:        AutoUpgradeModeDaily,
+			lastFired:   "2026-07-15",
+			now:         mustET(t, 2026, time.July, 16, 17, 0),
+			wantAllowed: true,
+			wantFire:    "2026-07-16",
+		},
+		{
+			name:        "next day before the window still does not fire",
+			mode:        AutoUpgradeModeDaily,
+			lastFired:   "2026-07-15",
+			now:         mustET(t, 2026, time.July, 16, 9, 0),
+			wantAllowed: false,
+		},
+		{
+			name:        "missed window does not accumulate — fires on the next cycle seen",
+			mode:        AutoUpgradeModeDaily,
+			lastFired:   "2026-07-13",
+			now:         mustET(t, 2026, time.July, 15, 21, 30),
+			wantAllowed: true,
+			wantFire:    "2026-07-15",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldAutoUpgradeNow(tc.mode, tc.lastFired, tc.now)
+			if got.Allowed != tc.wantAllowed {
+				t.Fatalf("Allowed = %v, want %v (reason: %s)", got.Allowed, tc.wantAllowed, got.Reason)
+			}
+			if got.FireDate != tc.wantFire {
+				t.Errorf("FireDate = %q, want %q", got.FireDate, tc.wantFire)
+			}
+			if got.Reason == "" {
+				t.Error("Reason should always be populated")
+			}
+		})
+	}
+}
+
+// TestShouldAutoUpgradeNowDST is the reason autoUpgradeTimezone is a ZONE NAME
+// and not a fixed offset. On these dates a hardcoded UTC-5 or UTC-4 would put
+// the 17:00 boundary an hour off, firing early or holding a hive an extra day.
+// Each case asserts on a wall-clock ET time that is only correct if the offset
+// is resolved from tzdata.
+func TestShouldAutoUpgradeNowDST(t *testing.T) {
+	tests := []struct {
+		name        string
+		now         time.Time
+		wantOffset  int // seconds east of UTC, proving which side of DST we are on
+		wantAllowed bool
+	}{
+		{
+			// Spring forward 2026: DST begins Sunday March 8. The day before is
+			// still EST (UTC-5).
+			name:        "day before spring forward is EST, 16:59 holds",
+			now:         mustET(t, 2026, time.March, 7, 16, 59),
+			wantOffset:  -5 * 60 * 60,
+			wantAllowed: false,
+		},
+		{
+			name:        "day before spring forward is EST, 17:00 fires",
+			now:         mustET(t, 2026, time.March, 7, autoUpgradeDailyHour, 0),
+			wantOffset:  -5 * 60 * 60,
+			wantAllowed: true,
+		},
+		{
+			// After the transition the same wall-clock 17:00 is EDT (UTC-4).
+			// A hardcoded -5 offset would treat this instant as 16:00 and hold.
+			name:        "day after spring forward is EDT, 17:00 still fires",
+			now:         mustET(t, 2026, time.March, 9, autoUpgradeDailyHour, 0),
+			wantOffset:  -4 * 60 * 60,
+			wantAllowed: true,
+		},
+		{
+			name:        "day after spring forward is EDT, 16:59 still holds",
+			now:         mustET(t, 2026, time.March, 9, 16, 59),
+			wantOffset:  -4 * 60 * 60,
+			wantAllowed: false,
+		},
+		{
+			// Fall back 2026: DST ends Sunday November 1. The day before is EDT.
+			name:        "day before fall back is EDT, 17:00 fires",
+			now:         mustET(t, 2026, time.October, 31, autoUpgradeDailyHour, 0),
+			wantOffset:  -4 * 60 * 60,
+			wantAllowed: true,
+		},
+		{
+			// After the transition 17:00 is EST again. A hardcoded -4 offset
+			// would treat this as 18:00 — still firing, but the 16:59 case
+			// below is what a wrong offset actually breaks.
+			name:        "day after fall back is EST, 17:00 fires",
+			now:         mustET(t, 2026, time.November, 2, autoUpgradeDailyHour, 0),
+			wantOffset:  -5 * 60 * 60,
+			wantAllowed: true,
+		},
+		{
+			name:        "day after fall back is EST, 16:59 holds",
+			now:         mustET(t, 2026, time.November, 2, 16, 59),
+			wantOffset:  -5 * 60 * 60,
+			wantAllowed: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, off := tc.now.Zone(); off != tc.wantOffset {
+				t.Fatalf("zone offset = %d, want %d — tzdata disagrees about DST on this date", off, tc.wantOffset)
+			}
+			got := shouldAutoUpgradeNow(AutoUpgradeModeDaily, "", tc.now)
+			if got.Allowed != tc.wantAllowed {
+				t.Errorf("Allowed = %v, want %v (reason: %s)", got.Allowed, tc.wantAllowed, got.Reason)
+			}
+		})
+	}
+}
+
+// TestShouldAutoUpgradeNowDayIdentityIsET pins day identity to ET rather than
+// UTC. At 22:00 ET the UTC date has already rolled over to the next day; if the
+// day key were computed in UTC, a hive that fired at 18:00 ET would be allowed
+// to fire again four hours later.
+func TestShouldAutoUpgradeNowDayIdentityIsET(t *testing.T) {
+	now := mustET(t, 2026, time.July, 15, 22, 0)
+	if now.UTC().Format(autoUpgradeDateFormat) == now.Format(autoUpgradeDateFormat) {
+		t.Fatal("test precondition: expected the UTC date to differ from the ET date at 22:00 ET")
+	}
+	got := shouldAutoUpgradeNow(AutoUpgradeModeDaily, "2026-07-15", now)
+	if got.Allowed {
+		t.Errorf("Allowed = true, want false — day identity must be evaluated in ET, not UTC")
+	}
+}
+
+func TestAutoUpgradeModeValidation(t *testing.T) {
+	tests := []struct {
+		mode      string
+		wantValid bool
+		wantNorm  string
+	}{
+		{mode: "", wantValid: true, wantNorm: AutoUpgradeModeInstant},
+		{mode: AutoUpgradeModeInstant, wantValid: true, wantNorm: AutoUpgradeModeInstant},
+		{mode: AutoUpgradeModeDaily, wantValid: true, wantNorm: AutoUpgradeModeDaily},
+		{mode: "Daily", wantValid: false, wantNorm: AutoUpgradeModeInstant},
+		{mode: "hourly", wantValid: false, wantNorm: AutoUpgradeModeInstant},
+		{mode: "instant ", wantValid: false, wantNorm: AutoUpgradeModeInstant},
+		{mode: "off", wantValid: false, wantNorm: AutoUpgradeModeInstant},
+	}
+	for _, tc := range tests {
+		t.Run("mode="+tc.mode, func(t *testing.T) {
+			if got := isValidAutoUpgradeMode(tc.mode); got != tc.wantValid {
+				t.Errorf("isValidAutoUpgradeMode(%q) = %v, want %v", tc.mode, got, tc.wantValid)
+			}
+			if got := normalizeAutoUpgradeMode(tc.mode); got != tc.wantNorm {
+				t.Errorf("normalizeAutoUpgradeMode(%q) = %q, want %q", tc.mode, got, tc.wantNorm)
+			}
+		})
+	}
+}
+
+// TestHandleToggleAutoUpgradeModePersistence covers the API end of the feature:
+// a valid mode is stored, an unknown one is rejected with 400 and changes
+// nothing, and a request that omits the field (an older client) lands as
+// instant.
+func TestHandleToggleAutoUpgradeModePersistence(t *testing.T) {
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+		wantMode   string
+		wantOn     bool
+	}{
+		{
+			name:       "daily mode is stored",
+			body:       `{"auto_upgrade":true,"auto_upgrade_mode":"daily"}`,
+			wantStatus: http.StatusOK,
+			wantMode:   AutoUpgradeModeDaily,
+			wantOn:     true,
+		},
+		{
+			name:       "instant mode is stored",
+			body:       `{"auto_upgrade":true,"auto_upgrade_mode":"instant"}`,
+			wantStatus: http.StatusOK,
+			wantMode:   AutoUpgradeModeInstant,
+			wantOn:     true,
+		},
+		{
+			name:       "omitted mode from an older client reads as instant",
+			body:       `{"auto_upgrade":true}`,
+			wantStatus: http.StatusOK,
+			wantMode:   "",
+			wantOn:     true,
+		},
+		{
+			name:       "unknown mode is rejected with 400",
+			body:       `{"auto_upgrade":true,"auto_upgrade_mode":"weekly"}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "off with a mode still stores the mode",
+			body:       `{"auto_upgrade":false,"auto_upgrade_mode":"daily"}`,
+			wantStatus: http.StatusOK,
+			wantMode:   AutoUpgradeModeDaily,
+			wantOn:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cleanup := helperSetupTempDirs(t)
+			defer cleanup()
+			mkUser(t, "alice")
+			saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice"})
+			s := &HubServer{logger: slog.Default(), heartbeatUpgrade: make(map[string]string)}
+
+			rec := httptest.NewRecorder()
+			req := setPathValue(reqWithUser(http.MethodPut, "/au", tc.body, "alice"), "id", "h1")
+			s.handleToggleAutoUpgrade(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d (body: %s)", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			got := loadSaaSHive("h1")
+			if got == nil {
+				t.Fatal("hive record disappeared")
+			}
+			if tc.wantStatus != http.StatusOK {
+				// A rejected request must not have mutated anything.
+				if got.AutoUpgrade || got.AutoUpgradeMode != "" {
+					t.Errorf("rejected request mutated the record: %+v", got)
+				}
+				return
+			}
+			if got.AutoUpgrade != tc.wantOn {
+				t.Errorf("AutoUpgrade = %v, want %v", got.AutoUpgrade, tc.wantOn)
+			}
+			if got.AutoUpgradeMode != tc.wantMode {
+				t.Errorf("AutoUpgradeMode = %q, want %q", got.AutoUpgradeMode, tc.wantMode)
+			}
+		})
+	}
+}
+
+// TestHandleToggleAutoUpgradeClearsLastFired verifies that changing mode resets
+// the day's fire record, so a hive switched to daily after an instant upgrade
+// earlier the same day is not held until tomorrow.
+func TestHandleToggleAutoUpgradeClearsLastFired(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, "alice")
+	saveSaaSHive(&SaaSHive{
+		ID: "h1", Owner: "alice",
+		AutoUpgrade:          true,
+		AutoUpgradeMode:      AutoUpgradeModeDaily,
+		AutoUpgradeLastFired: "2026-07-15",
+	})
+	s := &HubServer{logger: slog.Default(), heartbeatUpgrade: make(map[string]string)}
+
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPut,
+		"/au", `{"auto_upgrade":true,"auto_upgrade_mode":"daily"}`, "alice"), "id", "h1")
+	s.handleToggleAutoUpgrade(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := loadSaaSHive("h1"); got == nil || got.AutoUpgradeLastFired != "" {
+		t.Errorf("AutoUpgradeLastFired not cleared: %+v", got)
+	}
+}
+
+// TestManualUpgradeUnaffectedByMode pins the rule that the schedule gates ONLY
+// the automatic path. handleUpgradeHive is the manual button's handler; it must
+// never consult AutoUpgradeMode. A daily-mode hive that is being held by the
+// scheduler must still be manually upgradable at any hour.
+func TestManualUpgradeUnaffectedByMode(t *testing.T) {
+	// The scheduler holds this hive: daily mode, 09:00 ET, before the window.
+	held := shouldAutoUpgradeNow(AutoUpgradeModeDaily, "", mustET(t, 2026, time.July, 15, 9, 0))
+	if held.Allowed {
+		t.Fatal("test precondition: expected the scheduler to hold this hive")
+	}
+
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, "alice")
+	saveSaaSHive(&SaaSHive{
+		ID: "h1", Owner: "alice", Status: "running",
+		AutoUpgrade:     true,
+		AutoUpgradeMode: AutoUpgradeModeDaily,
+	})
+	s := &HubServer{logger: slog.Default(), heartbeatUpgrade: make(map[string]string)}
+
+	rec := httptest.NewRecorder()
+	req := setPathValue(reqWithUser(http.MethodPost, "/upgrade", `{}`, "alice"), "id", "h1")
+	s.handleUpgradeHive(rec, req)
+
+	// The manual path may fail for environmental reasons in a unit test (no
+	// cluster to kubectl against), but it must NOT be refused on account of the
+	// hive's schedule: a 403/409-style "not allowed" is the failure this guards.
+	if rec.Code == http.StatusForbidden || rec.Code == http.StatusConflict {
+		t.Errorf("manual upgrade was refused for a daily-mode hive: %d %s", rec.Code, rec.Body.String())
+	}
+	// The stored mode must be untouched by a manual upgrade.
+	if got := loadSaaSHive("h1"); got == nil || got.AutoUpgradeMode != AutoUpgradeModeDaily {
+		t.Errorf("manual upgrade changed the schedule: %+v", got)
+	}
+}


### PR DESCRIPTION
## Why

> "when a hive is stable and working, i dont want to disturb it all the time with upgrades"

Auto-upgrade is currently all-or-nothing: leave it on and a working hive restarts the moment a commit lands; turn it off and the hive drifts behind. This adds a middle option so upgrades keep flowing without interrupting a hive mid-work.

Per hive: **Off / Instant / Daily 5pm ET**.

## Model & migration

- `AutoUpgrade bool` stays the on/off master. `AutoUpgradeMode string` is a **separate** field (`"instant"` / `"daily"`) — neither field is overloaded.
- Both new fields are `omitempty`, so existing `meta.json` records stay byte-identical until an operator picks a mode.
- **Migration rule honoured:** a record with `auto_upgrade: true` and no mode normalizes to instant and behaves exactly as today. The ~42 records on the PVC are unaffected — no migration step, no backfill.

## Scheduling semantics

- Daily fires on the **first poll cycle at or after 17:00 America/New_York**, at most **once per ET calendar day**.
- Day identity is evaluated in ET, not UTC (there is a test for this — at 22:00 ET the UTC date has already rolled over, which would otherwise allow a second fire).
- `AutoUpgradeLastFired` (an ET day key) is persisted **before** the rollout is kicked, so a 17:02 cycle and a 17:04 cycle collapse into one upgrade, and a hub restart cannot re-fire the same day.
- **Missed windows do not accumulate.** Only one upgrade is ever owed, because the gate is "have we fired today", not a queue of windows. If the hub is down across 17:00 and returns at 21:30, the hive upgrades on the next cycle it sees, then resumes the daily cadence — waiting another ~20h would leave a hive knowingly behind for an extra day, defeating the point of having auto-upgrade on.
- **Manual upgrade is never gated.** `handleUpgradeHive` is a separate handler that does not consult the mode; it is unchanged and covered by a test.
- Turning auto-upgrade on in daily mode deliberately does **not** kick an immediate upgrade — that would be the exact disruption the mode exists to avoid.

## DST and tzdata

The window uses `time.LoadLocation("America/New_York")`, **not** a fixed offset — ET is UTC-5 (EST) or UTC-4 (EDT) depending on the date, so a hardcoded offset is wrong for roughly half the year.

`Dockerfile.hub` builds `FROM alpine:3.21` and installs only `ca-certificates` and `curl` — **it does not ship tzdata**. Verified by reading the Dockerfile, not assumed. So `upgrade_schedule.go` imports `_ "time/tzdata"` to embed the database in the binary (~450KB). `TestTzdataIsEmbedded` guards this directly, so removing the import fails CI rather than silently breaking the schedule in production.

If the zone somehow still fails to load, the code **fails safe to instant** and logs it — a hive upgrading sooner than asked is a far better failure than one that silently never upgrades again.

DST is covered by tests on both transitions in both directions (spring forward Mar 2026, fall back Nov 2026), each asserting the actual zone offset so a wrong offset fails loudly.

## API

The mode rides on the **existing** `PUT /api/saas/hives/{id}/auto-upgrade` rather than a second endpoint — same preference, same persistence, and a separate endpoint would let the two settings drift apart across two requests. Authorization is **unchanged**: the existing owner-or-admin check is reused verbatim, no new rule.

Unknown modes are rejected with **400** against an allowlist rather than silently defaulting, so a typo cannot quietly change how often a hive restarts. Clients sending only `auto_upgrade` still work (absent field → instant).

## UI

The per-row checkbox becomes a **single select** (Off / Instant / Daily 5pm ET), rendered inside the existing Version cell.

One select rather than a toggle plus a mode dropdown, because: the table is dense; two controls for one setting invites a nonsensical "off but daily" state; and one control shows the effective mode at a glance — an operator scanning the fleet can see which hives restart on sight and which wait for the evening, without opening anything.

- Copy is framed around **disruption**, not cron mechanics: *"Daily restarts it at most once a day, after hours, so a stable hive is not disturbed mid-work."*
- The `queued` pill now reads `queued · 5pm ET` for daily hives instead of falsely promising "shortly", and keeps its click-to-upgrade-now escape hatch.
- Bulk actions gain **Auto: daily 5pm ET**; the existing enable action keeps meaning instant so existing callers are unchanged.
- The hive id travels in a `data-*` attribute with a **delegated** listener (bound once, survives re-renders), because `esc()` escapes only `& < >` and is unsafe interpolated into an attribute. The element is built with `createElement`/`setAttribute` so the DOM does the escaping.

**Column count: unchanged.** The control lives inside the existing Version `<td>`, so no column was added. Verified by counting: **17 real `<th>` cells** — a naive `grep -c '<th'` returns 18 because it also matches `<thead>`. `TOTAL_COLUMNS` and `TOTAL_COLUMNS_HEADER` both remain 17.

## Hub-level toggle: schedule NOT applied (reasoning)

The brief's instinct was "yes for consistency". I concluded **no**, and recorded why in a comment at `isHubAutoUpgrade`. The two cases look symmetric but carry opposite risk:

- A **spoke hive is a workload** — restarting it interrupts running agents, so an after-hours window is a clear win.
- The **hub is the control plane** — it delivers every spoke upgrade, serves the dashboard, and receives every heartbeat. Holding a hub fix for up to 24h means holding back fixes to the upgrade machinery itself, *including any fix to this scheduler*. A hub restart is also cheap: a single stateless pod whose state lives on the PVC, and spokes tolerate a missed heartbeat by design.

Deferring hub upgrades would add real risk (a known-bad hub stays up all day) to avoid a disruption the hub does not meaningfully suffer. It stays a plain on/off toggle.

## New-hive default: flagged, not changed

Investigated `handleCreateHive` (`saas.go:1784`): provisioning **never sets `AutoUpgrade`**, so new hives start with auto-upgrade **off** and the operator opts in explicitly. There is therefore no "default mode" to change — the question of instant-vs-daily only arises at the moment the operator turns it on, and at that point they are choosing from the select anyway.

Making daily the *recommended* default would mean auto-enabling auto-upgrade on new hives, which is a materially bigger product change than this PR. **Flagging as a follow-up decision for the owner** rather than smuggling it in. If wanted, the cheap version is pre-selecting Daily in the select's ordering — the plumbing is already here.

## Verified vs assumed

**Verified:**
- `go build ./...`, `go vet ./pkg/hub/` clean.
- `go test -count=1 -timeout 480s ./pkg/hub/` — full package green (109s).
- All 4 `dashboardHTML` `<script>` bodies extracted and `node --check`ed (the main block is 264KB and contains these changes).
- Column count by actual cell count, excluding the `<thead>` false positive.
- `Dockerfile.hub` read directly to confirm tzdata is absent.
- `gofmt`: introduced **zero** new formatting drift. `saas.go`/`saas_provision.go` are already unformatted on clean `origin/v2` (confirmed by stashing); the remaining hunks are byte-identical to baseline, only line-shifted. Deliberately did not reformat unrelated regions.
- No literal `<body>` added inside any string or comment.

**Assumed (not exercised end-to-end):**
- Live behaviour against the real fleet — the scheduler is unit-tested with an injected clock, but no hive has actually rolled through a 17:00 window in a cluster yet.
- The "~42 existing records" figure comes from the brief; I verified the *decode* path is backward-compatible rather than counting PVC files.

## Tests

Table-driven with an **injected clock** — no wall-clock reads: before 17:00 (no fire), at exactly 17:00 and after (fires), already fired today (no second fire at 17:04 or 23:59), next day (fires again), missed window (fires next cycle, no accumulation), both DST boundaries in both directions with offset assertions, ET-vs-UTC day identity, legacy empty mode behaving as instant, unknown mode rejected with 400 leaving the record unmutated, mode change clearing the fire date, and manual upgrade unaffected by mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)