### PR TITLE
🐛 fix(github): send GitHub Enterprise users to their own GHE host to install the App

### DIFF
--- a/v2/pkg/config/config_uncovered_coverage_test.go
+++ b/v2/pkg/config/config_uncovered_coverage_test.go
@@ -296,6 +296,79 @@ func TestGitHubConfig_AppInstallURL(t *testing.T) {
 	})
 }
 
+// TestGitHubConfig_AppInstallURL_Table locks the exact install URL for every
+// host/slug shape the hub and spoke can hand this function. The regression it
+// guards: a GitHub Enterprise user sent to public github.com never reaches
+// their own org's install flow, so the request silently disappears and their
+// GHE admin sees nothing pending.
+func TestGitHubConfig_AppInstallURL_Table(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		appSlug string
+		want    string
+	}{
+		{
+			name: "public github.com with default slug",
+			want: "https://github.com/apps/" + DefaultGitHubAppSlug + "/installations/new",
+		},
+		{
+			name:    "explicit public base url is not treated as GHE",
+			baseURL: DefaultGitHubBaseURL,
+			want:    "https://github.com/apps/" + DefaultGitHubAppSlug + "/installations/new",
+		},
+		{
+			name:    "public github.com with a custom slug",
+			appSlug: "acme-hive",
+			want:    "https://github.com/apps/acme-hive/installations/new",
+		},
+		{
+			name:    "GHE host uses the enterprise /github-apps/ path",
+			baseURL: "https://github.ibm.com",
+			want:    "https://github.ibm.com/github-apps/" + DefaultGitHubAppSlug + "/installations/new",
+		},
+		{
+			name:    "GHE host with a trailing slash does not double up",
+			baseURL: "https://github.cisco.com/",
+			want:    "https://github.cisco.com/github-apps/" + DefaultGitHubAppSlug + "/installations/new",
+		},
+		{
+			name:    "GHE host with multiple trailing slashes",
+			baseURL: "https://github.cisco.com///",
+			want:    "https://github.cisco.com/github-apps/" + DefaultGitHubAppSlug + "/installations/new",
+		},
+		{
+			name:    "GHE host honours a per-instance app slug",
+			baseURL: "https://github.ibm.com",
+			appSlug: "katamari-hive",
+			want:    "https://github.ibm.com/github-apps/katamari-hive/installations/new",
+		},
+		{
+			name:    "empty base url falls back to public github.com",
+			baseURL: "",
+			appSlug: "acme-hive",
+			want:    "https://github.com/apps/acme-hive/installations/new",
+		},
+		{
+			// A malformed base URL is echoed back rather than silently
+			// rewritten to github.com: sending a GHE user to public GitHub is
+			// the exact failure this function exists to prevent, so a visibly
+			// broken link is the safer outcome than a plausible wrong one.
+			name:    "malformed base url is not rewritten to github.com",
+			baseURL: "not a url",
+			want:    "not a url/github-apps/" + DefaultGitHubAppSlug + "/installations/new",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := GitHubConfig{BaseURL: tt.baseURL, AppSlug: tt.appSlug}
+			if got := g.AppInstallURL(); got != tt.want {
+				t.Errorf("AppInstallURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // DashboardConfig.AuthorizedRole / splitAuthorizedEntry
 // ---------------------------------------------------------------------------

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/kubestellar/hive/v2/pkg/agent"
+	"github.com/kubestellar/hive/v2/pkg/config"
 	"github.com/kubestellar/hive/v2/pkg/github"
 	"github.com/kubestellar/hive/v2/pkg/hub"
 	"github.com/kubestellar/hive/v2/pkg/openrouter"
@@ -1061,7 +1062,10 @@ func (s *Server) SetGitHubAppRequired(required bool) {
 	if required && s.deps != nil && s.deps.Config != nil {
 		s.githubAppInstallURL = s.deps.Config.GitHub.AppInstallURL()
 	} else if required {
-		s.githubAppInstallURL = "https://github.com/apps/kubestellar-hive/installations/new"
+		// No config loaded (tests, early boot): fall back to the zero-value
+		// GitHubConfig, which resolves to the public github.com install URL.
+		// Derive it rather than hardcoding so the two paths can never drift.
+		s.githubAppInstallURL = config.GitHubConfig{}.AppInstallURL()
 	} else {
 		s.githubAppInstallURL = ""
 		s.githubAppPermIssue = ""

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -4768,7 +4768,24 @@
           banner.classList.add('perm-issue');
           if (title) title.textContent = 'GitHub App — Insufficient Permissions';
           if (desc) desc.textContent = 'The app is installed but cannot write to this repository.';
-          if (link) { link.textContent = 'View App Settings'; link.href = data.githubAppInstallURL || 'https://github.com/apps/kubestellar-hive'; }
+          // Never fall back to a public github.com URL: on GitHub Enterprise
+          // that sends the user to the wrong GitHub entirely and their org
+          // admin never sees the request. Prefer the server-computed install
+          // URL; otherwise send them to this hive's own GitHub host root and
+          // say so, rather than guessing an app path/slug the client does not
+          // know.
+          if (link) {
+            link.textContent = 'View App Settings';
+            if (data.githubAppInstallURL) {
+              link.href = data.githubAppInstallURL;
+            } else if (data.githubBaseURL) {
+              link.href = data.githubBaseURL;
+              link.textContent = 'Open ' + String(data.githubBaseURL).replace(/^https?:\/\//, '');
+            } else {
+              link.removeAttribute('href');
+              link.textContent = 'Install URL unavailable';
+            }
+          }
           var details = existingDetails;
           if (!details) {
             details = document.createElement('div');

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
 )
 
 var saasUsersDir = "/data/saas/users"
@@ -528,16 +530,52 @@ type ClusterListEntry struct {
 	Name   string `json:"name"`
 	HasGPU bool   `json:"has_gpu"`
 	Arch   string `json:"arch"`
+	// GitHubHost is the bare hostname of the GitHub instance hives on this
+	// cluster default to ("github.com" for public GitHub). Shown in the
+	// create-hive modal so an admin can see which GitHub a hive will target.
+	GitHubHost string `json:"github_host,omitempty"`
+	// AppInstallURL is the GitHub App install link for THIS cluster's GitHub
+	// host and app slug. A GitHub Enterprise cluster must never be handed a
+	// public github.com link: the install request would land on the wrong
+	// GitHub and the GHE org admin would never see it.
+	AppInstallURL string `json:"app_install_url,omitempty"`
+}
+
+// clusterGitHubConfig projects a cluster's GitHub settings onto the
+// config.GitHubConfig that owns URL construction, so the hub and the spoke
+// build install links from exactly one implementation.
+func clusterGitHubConfig(c *ClusterConfig) config.GitHubConfig {
+	if c == nil {
+		return config.GitHubConfig{}
+	}
+	base := c.GitHubBaseURL
+	// The cluster stores "" for public GitHub; config.GitHubConfig uses the
+	// same convention, so pass it through untouched.
+	return config.GitHubConfig{BaseURL: base, AppSlug: c.GitHubAppSlug}
+}
+
+// githubHostLabel renders a GitHub base URL as a bare hostname for display.
+// Empty (public GitHub) becomes "github.com" rather than an empty chip.
+func githubHostLabel(baseURL string) string {
+	h := strings.TrimSpace(baseURL)
+	if h == "" {
+		return "github.com"
+	}
+	h = strings.TrimPrefix(strings.TrimPrefix(h, "https://"), "http://")
+	return strings.TrimRight(h, "/")
 }
 
 func (s *HubServer) handleListClusters(w http.ResponseWriter, r *http.Request) {
 	var entries []ClusterListEntry
 	for _, c := range s.clusters {
+		gh := clusterGitHubConfig(&c)
 		entries = append(entries, ClusterListEntry{
-			ID:     c.ID,
-			Name:   c.Name,
-			HasGPU: c.HasGPU,
-			Arch:   c.Arch,
+			ID:            c.ID,
+			Name:          c.Name,
+			HasGPU:        c.HasGPU,
+			Arch:          c.Arch,
+			GitHubHost:    githubHostLabel(c.GitHubBaseURL),
+			AppInstallURL: gh.AppInstallURL(),
 		})
 	}
 	// Sort for deterministic API output.
@@ -9531,11 +9569,83 @@ const dashboardHTML = `<!DOCTYPE html>
           var caps = [];
           if (c.has_gpu) caps.push('GPU');
           if (c.arch) caps.push(c.arch);
+          /* Surface the GitHub host: on a GitHub Enterprise cluster the App
+             lives on that GHE instance, and picking the wrong cluster is the
+             difference between an install request the org admin can see and
+             one that silently lands on public github.com. */
+          if (c.github_host && c.github_host !== PUBLIC_GITHUB_HOST) caps.push(c.github_host);
           var label = c.name || c.id;
           if (caps.length) label += ' (' + caps.join(', ') + ')';
           return '<option value="' + esc(c.id) + '">' + esc(label) + '</option>';
         }).join('');
+        sel.removeEventListener('change', syncCreateModalInstallLinks);
+        sel.addEventListener('change', syncCreateModalInstallLinks);
+        syncCreateModalInstallLinks();
       } catch(e) { /* cluster dropdown stays at default */ }
+    }
+
+    /* PUBLIC_GITHUB_HOST is the bare hostname the hub reports for a cluster
+       with no GitHub Enterprise override. Anything else is a GHE instance. */
+    var PUBLIC_GITHUB_HOST = 'github.com';
+
+    /* selectedClusterEntry returns the ClusterListEntry for the cluster chosen
+       in the create-hive modal, or null when the list has not loaded. */
+    function selectedClusterEntry() {
+      var sel = document.getElementById('f-cluster');
+      if (!sel || !sel.value) return null;
+      var list = _clusterList || [];
+      for (var i = 0; i < list.length; i++) {
+        if (list[i] && list[i].id === sel.value) return list[i];
+      }
+      return null;
+    }
+
+    /* syncCreateModalInstallLinks points every "install the app" link in the
+       create-hive modal at the SELECTED cluster's GitHub host. The hub serves
+       one page to admins provisioning onto both public GitHub and GitHub
+       Enterprise clusters, so a static github.com anchor is wrong for half of
+       them: a GHE user following it lands on public github.com and their org
+       admin never sees the pending install request.
+
+       The URL comes from the server (config.GitHubConfig.AppInstallURL), which
+       also honours a per-cluster app slug — a GHE instance hosts its own App
+       registration and it is rarely named "kubestellar-hive". */
+    function syncCreateModalInstallLinks() {
+      var c = selectedClusterEntry();
+      var url = (c && c.app_install_url) || '';
+      var host = (c && c.github_host) || PUBLIC_GITHUB_HOST;
+      var isGHE = host !== PUBLIC_GITHUB_HOST;
+      var ids = ['auth-info-app-link', 'auth-info-later-link', 'auth-later-install-link'];
+      for (var i = 0; i < ids.length; i++) {
+        var el = document.getElementById(ids[i]);
+        if (!el) continue;
+        if (url) {
+          el.href = url;
+          el.removeAttribute('aria-disabled');
+        } else {
+          /* No URL yet (clusters still loading). Do not fall back to a
+             github.com guess — a dead link is safer than one that sends a
+             GHE admin to the wrong GitHub. */
+          el.removeAttribute('href');
+          el.setAttribute('aria-disabled', 'true');
+        }
+      }
+      var appLink = document.getElementById('auth-info-later-link');
+      if (appLink) appLink.textContent = '→ Install app on ' + host + ' now';
+      var btn = document.getElementById('auth-later-install-link');
+      if (btn) btn.textContent = 'Install app on your ' + (isGHE ? host + ' ' : '') + 'org';
+      var note = document.getElementById('auth-later-ghe-note');
+      if (note) {
+        if (isGHE) {
+          note.textContent = 'This cluster targets ' + host + '. The GitHub App must be registered and'
+            + ' installed on that GitHub Enterprise instance — a public github.com install will not'
+            + ' reach it, and the ' + host + ' org admin will see no pending request.';
+          note.style.display = '';
+        } else {
+          note.textContent = '';
+          note.style.display = 'none';
+        }
+      }
     }
 
     // OpenRouter scan-to-fund return: toast the result and clear the query flag
@@ -10311,11 +10421,11 @@ const dashboardHTML = `<!DOCTYPE html>
           The hive uses this token for all GitHub API calls — creating issues, posting advisory comments, reading repos, pushing code, and merging PRs. All actions appear as the token owner. Permissions cannot be scoped per agent trust tier.
         </div>
         <div id="auth-info-app" style="display:none;font-size:0.7rem;color:var(--muted);margin-top:8px;line-height:1.5;padding:8px 10px;background:rgba(255,255,255,0.03);border-radius:6px;border:1px solid var(--border)">
-          The hive generates short-lived installation tokens scoped to each agent's trust tier — newcomers get issues-only access, contributors get code + PR access, and trusted agents can merge. Actions appear as the app, not a personal account. Requires a <a href="https://github.com/apps/kubestellar-hive" target="_blank" style="color:var(--accent)">GitHub App</a> installed on the target org/repo.
+          The hive generates short-lived installation tokens scoped to each agent's trust tier — newcomers get issues-only access, contributors get code + PR access, and trusted agents can merge. Actions appear as the app, not a personal account. Requires a <a id="auth-info-app-link" href="" target="_blank" rel="noopener" style="color:var(--accent)">GitHub App</a> installed on the target org/repo.
         </div>
         <div id="auth-info-later" style="display:none;font-size:0.7rem;color:var(--muted);margin-top:8px;line-height:1.5;padding:8px 10px;background:rgba(255,255,255,0.03);border-radius:6px;border:1px solid var(--border)">
           The hive will be provisioned with the <strong>kubestellar-hive</strong> GitHub App pre-configured (App ID: 3568013). Agents will be unable to access GitHub until the app is installed on the target org and the installation ID is supplied via the hive config.<br><br>
-          <a href="https://github.com/apps/kubestellar-hive/installations/new" target="_blank" style="color:var(--accent);font-weight:600">→ Install kubestellar-hive app now</a>
+          <a id="auth-info-later-link" href="" target="_blank" rel="noopener" style="color:var(--accent);font-weight:600">→ Install app now</a>
         </div>
       </div>
       <div id="auth-pat">
@@ -10347,7 +10457,8 @@ const dashboardHTML = `<!DOCTYPE html>
         <div style="margin-bottom:12px;padding:12px;background:rgba(59,130,246,0.08);border:1px solid rgba(59,130,246,0.2);border-radius:8px">
           <div style="font-size:0.85rem;font-weight:600;color:var(--text);margin-bottom:8px">Hive App: kubestellar-hive</div>
           <div style="font-size:0.75rem;color:var(--muted);line-height:1.5">App ID: <code>3568013</code> (pre-configured)<br>The hive will start without GitHub access. Install the app on the target org, then supply the Installation ID and Private Key via the hive config.</div>
-          <a href="https://github.com/apps/kubestellar-hive/installations/new" target="_blank" style="display:inline-block;margin-top:8px;padding:6px 14px;background:var(--accent);color:#fff;border-radius:6px;font-size:0.8rem;font-weight:600;text-decoration:none">Install kubestellar-hive on your org</a>
+          <div id="auth-later-ghe-note" style="display:none;font-size:0.75rem;color:var(--muted);line-height:1.5;margin-top:8px"></div>
+          <a id="auth-later-install-link" href="" target="_blank" rel="noopener" style="display:inline-block;margin-top:8px;padding:6px 14px;background:var(--accent);color:#fff;border-radius:6px;font-size:0.8rem;font-weight:600;text-decoration:none">Install app on your org</a>
         </div>
       </div>
       </div>

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -139,7 +139,13 @@ type ClusterConfig struct {
 	InferenceEndpoint           string `json:"inference_endpoint,omitempty" yaml:"inference_endpoint,omitempty"`
 	GitHubBaseURL               string `json:"github_base_url,omitempty" yaml:"github_base_url,omitempty"`
 	GitHubAPIURL                string `json:"github_api_url,omitempty" yaml:"github_api_url,omitempty"`
-	OAuthClientID               string `json:"oauth_client_id,omitempty" yaml:"oauth_client_id,omitempty"`
+	// GitHubAppSlug is the GitHub App's URL slug on THIS cluster's GitHub
+	// host. A GitHub Enterprise instance hosts its own App registration,
+	// which is rarely named "kubestellar-hive" — without this the spoke's
+	// install link points at an app that does not exist on that GHE host.
+	// Empty falls back to config.DefaultGitHubAppSlug.
+	GitHubAppSlug string `json:"github_app_slug,omitempty" yaml:"github_app_slug,omitempty"`
+	OAuthClientID string `json:"oauth_client_id,omitempty" yaml:"oauth_client_id,omitempty"`
 	ClusterHealthTimeoutSeconds int    `json:"cluster_health_timeout_seconds,omitempty" yaml:"cluster_health_timeout_seconds,omitempty"`
 }
 
@@ -625,6 +631,10 @@ func provisionHive(h *SaaSHive, req *CreateHiveRequest, cluster *ClusterConfig, 
 		"HasGHE":            effectiveGitHubBaseURL(h, cluster) != "",
 		"GitHubBaseURL":     effectiveGitHubBaseURL(h, cluster),
 		"GitHubAPIURL":      effectiveGitHubAPIURL(h, cluster),
+		// Only emit app_slug when the cluster names one. Leaving it out lets
+		// config.ResolvedAppSlug() supply the public default, so public-GitHub
+		// hives are unaffected.
+		"GitHubAppSlug": cluster.GitHubAppSlug,
 		"OAuthClientID": func() string {
 			// Follow the hive's EFFECTIVE GitHub host, not the cluster
 			// default — a public-GitHub hive on a GHE-defaulted cluster
@@ -1089,6 +1099,9 @@ data:
 {{- if .HasGHE}}
       base_url: {{.GitHubBaseURL}}
       api_url: {{.GitHubAPIURL}}
+{{- end}}
+{{- if .GitHubAppSlug}}
+      app_slug: {{.GitHubAppSlug}}
 {{- end}}
 {{- if .OAuthClientID}}
       oauth_client_id: {{.OAuthClientID}}

--- a/v2/pkg/hub/static/get-started.html
+++ b/v2/pkg/hub/static/get-started.html
@@ -329,13 +329,35 @@
       <div class="wizard-panel" id="panel-2">
         <h2>Install the Hive GitHub App</h2>
         <p>The Hive GitHub App lets our agents read issues, open PRs, and respond to CI on your repos. Install it on the org or repos you want to manage.</p>
+        <!-- This button is correct ONLY for public github.com. This page signs
+             you in with the public github.com OAuth app and no hive exists yet,
+             so we genuinely do not know which GitHub instance your repos live
+             on — we must not fake a per-user link here. GitHub Enterprise users
+             get the explicit note below instead of a link that would send their
+             install request to the wrong GitHub entirely. -->
         <div style="margin:20px 0">
-          <a href="https://github.com/apps/kubestellar-hive" target="_blank" class="btn-github" id="install-app-btn">
+          <a href="https://github.com/apps/kubestellar-hive" target="_blank" rel="noopener" class="btn-github" id="install-app-btn">
             <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
             Install Hive GitHub App
           </a>
         </div>
         <p style="font-size:0.82rem;color:var(--muted)">Already installed? Click continue.</p>
+        <div style="margin-top:18px;padding:12px 14px;background:var(--bg-soft);border:1px solid var(--line);border-radius:.7rem">
+          <p style="margin:0 0 6px;font-size:0.86rem;font-weight:700">Using GitHub Enterprise?</p>
+          <p style="margin:0;font-size:0.82rem;color:var(--muted);line-height:1.55">
+            The button above installs on <strong>public github.com</strong>. If your repos live on a
+            GitHub Enterprise instance (<code>github.example.com</code>, and similar), that link will
+            not work &mdash; the install request lands on public GitHub and your Enterprise org admin
+            will never see it.
+            <br><br>
+            Instead: continue to step&nbsp;3 and add your repository by <strong>URL</strong>. We record
+            which Enterprise instance it lives on, and provision your hive against a GitHub App
+            registered on <em>that</em> instance. Your org admin approves the installation from your own
+            Enterprise host &mdash; your hive's dashboard will show the correct install link once it is
+            provisioned. If no App is registered on your Enterprise instance yet, we will set that up
+            with your admin as part of provisioning.
+          </p>
+        </div>
         <div style="display:flex;gap:12px;margin-top:16px">
           <button class="btn-secondary" onclick="goToStep(1)">← Back</button>
           <button class="btn-primary" onclick="goToStep(3)">Continue →</button>
@@ -349,7 +371,8 @@
         <div id="repo-loading" style="color:var(--muted);padding:24px;text-align:center">Loading your repositories...</div>
         <div id="repo-list" class="repo-list" style="display:none"></div>
         <div id="repo-none" style="display:none;padding:24px;text-align:center;color:var(--muted)">
-          <p>No repositories found. Install the <a href="https://github.com/apps/kubestellar-hive" target="_blank" style="color:var(--blue)">Hive GitHub App</a> on the account or org that owns them &mdash; or add a repo URL below.</p>
+          <p>No repositories found. Install the <a href="https://github.com/apps/kubestellar-hive" target="_blank" rel="noopener" style="color:var(--blue)">Hive GitHub App</a> on the account or org that owns them &mdash; or add a repo URL below.</p>
+          <p style="font-size:0.82rem">That link is public github.com. <strong>GitHub Enterprise repos will never appear in this list</strong> and cannot be installed from there &mdash; add the repo by URL below and we will provision against your Enterprise instance.</p>
         </div>
         <!-- Manual entry. Repo discovery uses the github.com OAuth token, so a
              GitHub Enterprise repo (github.ibm.com, github.cisco.com, …) can


### PR DESCRIPTION
## The incident

A user maintaining a repo on a **GitHub Enterprise** instance clicked "Install app" in his hive. It sent him to `https://github.com/apps/kubestellar-hive/installations/select_target` — **public github.com**. His GHE org admin then found no pending request, because the request had landed on an entirely different GitHub.

> "I'm not sure where to trigger the install to \<our GHE host\>. When I launch the install app it sends me to https://github.com/apps/... which is public GitHub."

This silently blocks **every** GHE user at Stage 1 of the adoption journey — the failure is invisible to both the user and their admin.

## Root cause

`config.GitHubConfig.AppInstallURL()` already builds the correct URL for both cases:

| Host | Path |
| --- | --- |
| public github.com | `/apps/{slug}/installations/new` |
| GitHub Enterprise | `/github-apps/{slug}/installations/new` |

**It simply was not being called.** Several link sites hardcoded github.com instead. (`select_target` is GitHub's own redirect from `/apps/{slug}` when signed in — that anchor is what produced the reported URL.)

## Resolution per call site

The spoke knows its own GitHub host, so its links can be made *correct*. The hub serves one page to many users across different GitHub instances, so each hub site was resolved according to what host context it actually has.

### Spoke — link made correct

- **`pkg/dashboard/server.go`** — the fallback used when no config is loaded hardcoded a github.com literal. Now derived from a zero-value `GitHubConfig`, so the two paths cannot drift. (The primary path already called `AppInstallURL()` correctly.)
- **`pkg/dashboard/static/index.html`** — the *Insufficient Permissions* banner fell back to a public github.com app URL whenever no install URL was available. It now prefers the server-computed URL, then this hive's own GitHub host, and finally reports the URL as unavailable. It never guesses github.com.

### Hub create-hive modal — link made per-cluster

A static anchor cannot be right for an admin who provisions onto both public-GitHub and GHE clusters. The host **is** reachable at render time (per cluster), so the link is now built per-cluster:

- `ClusterListEntry` carries `github_host` and `app_install_url`, computed **server-side** through `config.GitHubConfig` so the hub and spoke share exactly one URL implementation.
- The modal's three install links follow the **selected** cluster.
- The cluster dropdown labels GHE clusters with their host, so an admin can see which GitHub a hive will target.
- A GHE cluster shows an explicit note that a public github.com install will not reach that instance.
- Before the cluster list loads the links are **disabled**, not defaulted to github.com — a dead link is safer than a plausible wrong one.

### Hub get-started wizard — copy made honest

This page authenticates with the **public github.com OAuth app** and runs **before any hive exists**, so the user's GitHub instance is genuinely unknowable. Per the brief, no link is faked here. Instead:

- Step 2 states plainly that the button is public github.com only, that a GHE install request will never reach the user's Enterprise admin, and directs GHE users to the **existing add-repo-by-URL path** — which already records the Enterprise host and forwards it as `github_host` on the provision request.
- Step 3's empty-state carries the same warning (GHE repos can never appear in that list, since discovery runs on the github.com OAuth token).

## App slug

A GHE deployment hosts its **own** App registration, rarely named `kubestellar-hive`. `github.app_slug` existed in config and `ResolvedAppSlug()` honoured it — but it was **never plumbed from provisioning**, so a hosted GHE spoke always built a link for the public slug even when its GitHub host was correct.

Clusters now carry `github_app_slug`, and the provisioning template emits `github.app_slug` when set. Public-GitHub hives are unaffected: the field is omitted and `ResolvedAppSlug()` supplies the default.

## Tests

Table-driven `AppInstallURL()` coverage added: public github.com, explicit public base URL, custom slug, a GHE host, GHE with trailing slash(es), GHE with a per-instance slug, empty base URL, and a malformed base URL — which is echoed rather than silently rewritten to github.com, since a visibly broken link beats one that plausibly sends a GHE admin to the wrong GitHub.

```
go build ./...                                                    PASS
go vet ./pkg/hub/ ./pkg/dashboard/ ./pkg/config/                  PASS
go test -count=1 -timeout 480s ./pkg/hub/ ./pkg/dashboard/ ./pkg/config/   PASS
```

No GHE hostname is hardcoded anywhere; every path derives from configuration.

## Does this unblock a GHE user end-to-end?

**Partly — and the remaining gap is now visible instead of silent.**

- ✅ A GHE user whose hive is **already provisioned** with `github.base_url` set now gets a correct install link on their own Enterprise host, honouring a per-instance app slug.
- ✅ A GHE user on the **get-started wizard** is no longer sent to the wrong GitHub; they are told what to do instead.
- ⚠️ Still outside this fix: **a GitHub App must actually be registered on that Enterprise instance.** The public `kubestellar-hive` App does not exist on a customer's GHE host, so a correct link only resolves once an admin registers one there and the cluster's `github_app_slug` / `github_base_url` are set. This PR makes that a visible, actionable setup step rather than a silent dead end — but it is an operator action, not something code can do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)