### PR TITLE
✨ feat(dashboard): agent prompt history over a day/week window

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1376,6 +1376,12 @@ func main() {
 		_ = changed
 	})
 
+	// Persist the fully-expanded prompt text of every kick so owners can review
+	// what their agents were actually told, over a day/week window, in the
+	// per-agent "Prompts" tab. Redaction and truncation happen inside the
+	// store, before anything is written to the PVC.
+	agentMgr.SetRecordPromptCallback(dashSrv.RecordPrompt)
+
 	// Register custom GHE hostnames with the proxy allowlist so mode
 	// enforcement applies to GitHub Enterprise API and web requests.
 	for _, rawURL := range []string{cfg.GitHub.ResolvedAPIURL(), cfg.GitHub.ResolvedBaseURL()} {

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -145,6 +145,15 @@ type Manager struct {
 	// persistPauseCallback, when set, persists an agent's paused state to
 	// the on-disk config so it survives restarts. Nil in tests / bare setups.
 	persistPauseCallback func(name string, paused bool)
+
+	// recordPromptCallback, when set, persists the fully-expanded prompt text
+	// delivered to an agent so owners can review it later.
+	//
+	// Held as an atomic.Pointer rather than behind m.mu because the kick path
+	// (deliverKickLocked) already holds m.mu when it fires this. m.mu is a
+	// non-reentrant RWMutex, so reading the callback under a second Lock there
+	// would deadlock the kick path.
+	recordPromptCallback atomic.Pointer[func(agent, trigger, prompt string)]
 }
 
 // SetPersistPauseCallback wires a function that persists an agent's paused
@@ -154,6 +163,25 @@ func (m *Manager) SetPersistPauseCallback(fn func(name string, paused bool)) {
 	m.mu.Lock()
 	m.persistPauseCallback = fn
 	m.mu.Unlock()
+}
+
+// SetRecordPromptCallback wires a function that persists a delivered kick
+// prompt (agent, trigger, full text). Safe to call at any time; a nil fn
+// clears it. Never takes m.mu — see recordPromptCallback.
+func (m *Manager) SetRecordPromptCallback(fn func(agent, trigger, prompt string)) {
+	if fn == nil {
+		m.recordPromptCallback.Store(nil)
+		return
+	}
+	m.recordPromptCallback.Store(&fn)
+}
+
+// recordPrompt fires the record-prompt callback if one is wired. Safe to call
+// with m.mu held.
+func (m *Manager) recordPrompt(agent, trigger, prompt string) {
+	if fn := m.recordPromptCallback.Load(); fn != nil && *fn != nil {
+		(*fn)(agent, trigger, prompt)
+	}
 }
 
 // AppTokenMinter is implemented by github.AppAuth to mint per-agent scoped tokens.
@@ -836,6 +864,7 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 			"preview", snippet,
 			"trigger", "startup",
 		)
+		m.recordPrompt(agent.Name, "startup", bootstrapPrompt)
 
 		// Only goose (and unknown backends, which never embed) reach this
 		// block — claude/copilot/gemini bootstrap prompts were deferred to
@@ -2071,6 +2100,11 @@ func (m *Manager) deliverKickLocked(agent *AgentProcess, message, trigger string
 		"preview", kickPreview,
 		"trigger", trigger,
 	)
+
+	// Persist the FULL prompt text. The log line above and KickRecord.Snippet
+	// only carry a truncated preview, which is not enough to answer "what was
+	// my agent asked to do?".
+	m.recordPrompt(agent.Name, trigger, message)
 }
 
 // deliverStartupKick delivers a bootstrap prompt to a freshly launched agent

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -41,6 +41,7 @@ func (s *Server) RegisterAPI(deps *Dependencies) {
 	s.mux.HandleFunc("PUT /api/config/variables/{name}", s.handleVariableUpsert)
 	s.mux.HandleFunc("DELETE /api/config/variables/{name}", s.handleVariableDelete)
 	s.mux.HandleFunc("GET /api/audit", s.handleAuditLog)
+	s.mux.HandleFunc("GET /api/prompt-history", s.handlePromptHistory)
 	s.mux.HandleFunc("POST /api/self-upgrade", s.handleSelfUpgrade)
 	s.mux.HandleFunc("POST /api/banner-dismissed", s.handleBannerDismissed)
 	s.mux.HandleFunc("GET /api/snapshot", s.handleSnapshotAPI)

--- a/v2/pkg/dashboard/prompt_history.go
+++ b/v2/pkg/dashboard/prompt_history.go
@@ -1,0 +1,372 @@
+package dashboard
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/natefinch/lumberjack.v2"
+)
+
+// Agent prompt (kick) history.
+//
+// Before this store existed, the fully-expanded prompt text sent to an agent
+// was retained in exactly two places, neither of which could answer "what was
+// my agent asked to do, and when?":
+//
+//   - agent.AgentProcess.LastKickMessage — the MOST RECENT kick only, in
+//     memory, replaced on every subsequent kick and lost on restart. This is
+//     what the dashboard's "Last Prompt" tab renders.
+//   - agent.KickRecord.Snippet — persisted across restarts via the snapshot,
+//     but truncated to 120 characters (200 for startup bootstraps), which is
+//     far too short to diagnose why an agent behaved the way it did.
+//
+// The structured audit log (audit.go) records that a kick HAPPENED
+// (action=agent_start / kick, detail=trigger=governor-eval) but never the
+// prompt text. This file adds the missing durable, full-text store.
+//
+// Storage shape deliberately mirrors audit.go: newline-delimited JSON on the
+// spoke's /data PVC, rotated and gzipped by lumberjack, with an in-memory ring
+// serving reads so the hot path never touches the disk.
+
+const (
+	// promptHistoryPath is the JSONL file on the spoke's PVC. Rotated backups
+	// land alongside it as promptHistory-<timestamp>.jsonl.gz, matching the
+	// convention audit.jsonl already uses.
+	promptHistoryPath = "/data/prompt-history.jsonl"
+
+	// promptHistoryMaxSizeMB caps a single JSONL file before rotation.
+	//
+	// Sizing is measured, not guessed. A fully-expanded kick prompt is:
+	//   template body      ~3.0 KiB (mean of the 30 shipped policy templates
+	//                                in pkg/policies/defaults; largest is
+	//                                scanner-automerge.md at 10.5 KiB)
+	//   issue list         up to 12.7 KiB (maxIssuesPerKick=100 issues x ~127 B
+	//                                per formatIssueList line: age, repo,
+	//                                number, labels, 60-rune title)
+	//   PR list            ~3.5 KiB at 30 open PRs x ~120 B per line
+	//   knowledge section  ~3.0 KiB (knowledge_max_facts default 25)
+	//   repos section      ~0.4 KiB
+	// giving ~22 KiB for a worst-case prompt and ~8 KiB for a typical one.
+	//
+	// At the most aggressive shipped cadence pack (level-6 "busy": supervisor
+	// 2m, scanner/ci-maintainer 10m, quality 15m, architect/sec-check 30m,
+	// outreach/strategist 1h) a hive issues ~8,700 kicks/week. At the typical
+	// 8 KiB that is ~70 MiB/week raw; at worst case ~190 MiB/week raw.
+	//
+	// Retaining that uncompressed would dwarf the audit log's own 5 MiB x 3
+	// budget, so the cap below plus promptHistoryMaxBackups bounds the store at
+	// promptHistoryMaxSizeMB * (promptHistoryMaxBackups + 1) = 96 MiB on disk
+	// worst case, and rotated backups are gzipped (prompt text is highly
+	// repetitive template boilerplate and compresses roughly 4x, so the
+	// realistic steady-state footprint is ~25-30 MiB). That comfortably holds
+	// more than the one-week window the UI offers at typical cadence, and
+	// degrades gracefully — oldest prompts age out first — at surge cadence.
+	promptHistoryMaxSizeMB = 24
+
+	// promptHistoryMaxBackups is how many rotated .gz files are kept.
+	promptHistoryMaxBackups = 3
+
+	// promptHistoryMaxAgeDays bounds retention by age as well as by size. The
+	// UI's widest window is one week; double that gives headroom for a user
+	// looking back at "last week" a few days late without unbounded growth.
+	promptHistoryMaxAgeDays = 14
+
+	// promptHistoryRingCap is how many entries are held in memory for reads.
+	// At the level-6 "busy" cadence (~52 kicks/hour across 8 agents) this is
+	// roughly 19 hours of history in RAM; older entries remain on disk in the
+	// rotated files but are not served. Bounded so a long-running spoke cannot
+	// grow the resident set without limit: 1000 x the 8 KiB typical prompt is
+	// ~8 MiB of heap, which is acceptable next to the agent output buffers.
+	promptHistoryRingCap = 1000
+
+	// promptHistoryMaxPromptBytes truncates an individual oversized prompt
+	// rather than dropping it, so a pathological kick still shows up in the
+	// history with an explicit marker instead of vanishing. Set above the
+	// ~22 KiB measured worst case so normal prompts are never touched.
+	promptHistoryMaxPromptBytes = 32768
+
+	// promptHistoryTruncationMarker is appended to a prompt clipped at
+	// promptHistoryMaxPromptBytes so the UI never implies it has the full text.
+	promptHistoryTruncationMarker = "\n\n[... prompt truncated by hive: exceeded 32768 bytes ...]"
+
+	// promptHistoryDefaultWindowHours is the window used when a request does
+	// not specify one: the "last day" the feature request asked for.
+	promptHistoryDefaultWindowHours = 24
+
+	// promptHistoryMaxWindowHours caps the requested window at one week, the
+	// widest window the UI offers and the widest the ring can meaningfully
+	// serve.
+	promptHistoryMaxWindowHours = 168
+
+	// promptHistoryMaxResults bounds a single API response so a wide window on
+	// a busy hive cannot return a multi-megabyte payload to the browser.
+	promptHistoryMaxResults = 200
+)
+
+// PromptEntry is one fully-expanded prompt delivered to an agent.
+type PromptEntry struct {
+	Timestamp string `json:"ts"`
+	Agent     string `json:"agent"`
+	Trigger   string `json:"trigger"`
+	Prompt    string `json:"prompt"`
+	// Truncated reports that Prompt was clipped at
+	// promptHistoryMaxPromptBytes and carries the truncation marker.
+	Truncated bool `json:"truncated,omitempty"`
+}
+
+// PromptHistory is a durable, bounded store of agent kick prompts.
+type PromptHistory struct {
+	mu     sync.Mutex
+	writer *lumberjack.Logger
+	ring   []PromptEntry
+}
+
+func newPromptHistory() *PromptHistory {
+	p := &PromptHistory{ring: make([]PromptEntry, 0, promptHistoryRingCap)}
+
+	// Mirror audit.go: only wire durable storage when the PVC is mounted, so
+	// unit tests and non-container runs stay purely in-memory.
+	if _, err := os.Stat("/data"); err == nil {
+		p.writer = &lumberjack.Logger{
+			Filename:   promptHistoryPath,
+			MaxSize:    promptHistoryMaxSizeMB,
+			MaxBackups: promptHistoryMaxBackups,
+			MaxAge:     promptHistoryMaxAgeDays,
+			Compress:   true,
+		}
+		p.loadFromDisk(promptHistoryPath)
+	}
+
+	return p
+}
+
+// loadFromDisk repopulates the ring from the active JSONL file on startup.
+//
+// Malformed lines are skipped individually rather than aborting the load. This
+// matters in practice: the process can be killed mid-write, leaving a
+// truncated final line, and a single bad line must not blank the whole view.
+func (p *PromptHistory) loadFromDisk(path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		var entry PromptEntry
+		if json.Unmarshal(line, &entry) != nil {
+			continue
+		}
+		if entry.Timestamp == "" || entry.Agent == "" {
+			continue
+		}
+		p.ring = append(p.ring, entry)
+	}
+	if len(p.ring) > promptHistoryRingCap {
+		p.ring = p.ring[len(p.ring)-promptHistoryRingCap:]
+	}
+}
+
+// secretPattern matches credential material that can legitimately reach prompt
+// text and must never be persisted.
+//
+// Why this is needed: per-kick template substitution resolves ${VAR} through
+// resolve.Registry (pkg/resolve/registry.go). Bare-environment fallback is
+// restricted to config scope, so an undeclared ${GITHUB_TOKEN} in a kick
+// template stays literal. BUT an operator may declare a variable in the config
+// `variables:` block with `scope: template` and `type: env`, which resolves
+// from hive's process environment — the same environment that holds the
+// GitHub token and model-gateway API keys — straight into the prompt body.
+// The http resolver likewise expands ${ENV} into request headers and can
+// return secret-bearing bodies. So secrets in prompt text are reachable, and
+// this store persists prompts to disk where the previous 120-char snippet did
+// not. Redaction is applied at write time: nothing unredacted is ever durable.
+var secretPattern = regexp.MustCompile(
+	// GitHub tokens (classic, OAuth, server, refresh, user, fine-grained PAT)
+	`(gh[pousr]_[A-Za-z0-9_]{10,}|github_pat_[A-Za-z0-9_]{10,})` +
+		// Common model-gateway / cloud provider key shapes
+		`|(sk-[A-Za-z0-9_\-]{16,}|xox[baprs]-[A-Za-z0-9\-]{10,}|AKIA[0-9A-Z]{12,}|AIza[0-9A-Za-z_\-]{30,})`,
+)
+
+// secretAssignmentPattern catches `TOKEN=<value>` / `api_key: <value>` style
+// assignments whose value does not match a known vendor prefix. Capture groups:
+// 1=name, 2=separator (preserved so `:` does not become `=`), 3=optional quote,
+// 4=value.
+var secretAssignmentPattern = regexp.MustCompile(
+	`(?i)\b([A-Z0-9_]*(?:TOKEN|SECRET|PASSWORD|PASSWD|APIKEY|API_KEY|ACCESS_KEY|PRIVATE_KEY)[A-Z0-9_]*)(\s*[:=]\s*)("?)([^\s"']{8,})`,
+)
+
+// unresolvedPlaceholder matches a literal ${VAR}. An unsubstituted placeholder
+// is the NAME of a variable, never its value, so redacting it would corrupt
+// legitimate prompt text (and hide from the owner that a variable failed to
+// resolve — exactly the kind of misconfiguration this view exists to surface).
+var unresolvedPlaceholder = regexp.MustCompile(`^\$\{[^}]*\}$`)
+
+const secretRedactionPlaceholder = "***REDACTED***"
+
+// redactPromptSecrets removes credential material from prompt text before it is
+// persisted or served.
+func redactPromptSecrets(s string) string {
+	if s == "" {
+		return s
+	}
+	s = secretPattern.ReplaceAllString(s, secretRedactionPlaceholder)
+	s = secretAssignmentPattern.ReplaceAllStringFunc(s, func(m string) string {
+		groups := secretAssignmentPattern.FindStringSubmatch(m)
+		if groups == nil {
+			return m
+		}
+		// Leave an unresolved ${VAR} alone — it is a placeholder, not a value.
+		if unresolvedPlaceholder.MatchString(groups[4]) {
+			return m
+		}
+		return groups[1] + groups[2] + groups[3] + secretRedactionPlaceholder
+	})
+	return s
+}
+
+// truncatePrompt clips an oversized prompt, appending an explicit marker.
+// Truncation is byte-based but backs off to a UTF-8 boundary so the stored
+// text is always valid UTF-8 and survives JSON round-tripping.
+func truncatePrompt(s string) (string, bool) {
+	if len(s) <= promptHistoryMaxPromptBytes {
+		return s, false
+	}
+	cut := promptHistoryMaxPromptBytes
+	for cut > 0 && !utf8Boundary(s[cut]) {
+		cut--
+	}
+	return s[:cut] + promptHistoryTruncationMarker, true
+}
+
+// utf8Boundary reports whether b can start a UTF-8 sequence (i.e. it is not a
+// 10xxxxxx continuation byte).
+func utf8Boundary(b byte) bool { return b&0xC0 != 0x80 }
+
+// Record persists one delivered prompt. Redaction and truncation happen here,
+// before anything reaches memory or disk.
+func (p *PromptHistory) Record(agent, trigger, prompt string) {
+	if agent == "" || prompt == "" {
+		return
+	}
+	if trigger == "" {
+		trigger = "unknown"
+	}
+
+	text, truncated := truncatePrompt(redactPromptSecrets(prompt))
+
+	entry := PromptEntry{
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Agent:     agent,
+		Trigger:   trigger,
+		Prompt:    text,
+		Truncated: truncated,
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if len(p.ring) >= promptHistoryRingCap {
+		p.ring = p.ring[1:]
+	}
+	p.ring = append(p.ring, entry)
+
+	if p.writer != nil {
+		if data, err := json.Marshal(entry); err == nil {
+			// lumberjack.Write is a single atomic append per call, so an entry
+			// never interleaves with a concurrent writer's line.
+			p.writer.Write(append(data, '\n'))
+		}
+	}
+}
+
+// Query returns entries for an agent within a time window, newest first.
+//
+// agent == "" matches every agent. windowHours <= 0 falls back to the default
+// window; anything above promptHistoryMaxWindowHours is clamped. The result is
+// capped at promptHistoryMaxResults.
+func (p *PromptHistory) Query(agent string, windowHours int, now time.Time) []PromptEntry {
+	if windowHours <= 0 {
+		windowHours = promptHistoryDefaultWindowHours
+	}
+	if windowHours > promptHistoryMaxWindowHours {
+		windowHours = promptHistoryMaxWindowHours
+	}
+	cutoff := now.Add(-time.Duration(windowHours) * time.Hour)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	out := make([]PromptEntry, 0, len(p.ring))
+	for _, e := range p.ring {
+		if agent != "" && e.Agent != agent {
+			continue
+		}
+		ts, err := time.Parse(time.RFC3339, e.Timestamp)
+		// An unparseable timestamp cannot be placed in the window. Skip it
+		// rather than surfacing an entry the user cannot situate in time.
+		if err != nil || ts.Before(cutoff) {
+			continue
+		}
+		out = append(out, e)
+	}
+
+	// Newest first. Sort rather than reverse: the ring is append-ordered by
+	// wall clock, but entries reloaded from disk after a restart can interleave
+	// with fresh ones, so ordering is not guaranteed by construction.
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Timestamp > out[j].Timestamp })
+
+	if len(out) > promptHistoryMaxResults {
+		out = out[:promptHistoryMaxResults]
+	}
+	return out
+}
+
+// handlePromptHistory serves GET /api/prompt-history.
+//
+// Access is gated exactly like GET /api/audit (handleAuditLog): prompt bodies
+// embed repo names, issue titles and knowledge-base content, so this must not
+// be readable by anyone who cannot already read the audit log.
+func (s *Server) handlePromptHistory(w http.ResponseWriter, r *http.Request) {
+	role := r.Header.Get("X-Hive-Role")
+	if role == "" {
+		role = "owner"
+	}
+	if role != "owner" && role != "read-write" {
+		http.Error(w, "insufficient access", http.StatusForbidden)
+		return
+	}
+
+	agent := strings.TrimSpace(r.URL.Query().Get("agent"))
+	windowHours := promptHistoryDefaultWindowHours
+	if raw := r.URL.Query().Get("windowHours"); raw != "" {
+		if v, err := strconv.Atoi(raw); err == nil {
+			windowHours = v
+		}
+	}
+
+	entries := s.promptHistory.Query(agent, windowHours, time.Now())
+	jsonResponse(w, map[string]any{
+		"entries":     entries,
+		"windowHours": windowHours,
+	})
+}
+
+// RecordPrompt persists a delivered kick prompt from non-HTTP contexts (the
+// agent manager's kick and startup-bootstrap paths).
+func (s *Server) RecordPrompt(agent, trigger, prompt string) {
+	if s == nil || s.promptHistory == nil {
+		return
+	}
+	s.promptHistory.Record(agent, trigger, prompt)
+}

--- a/v2/pkg/dashboard/prompt_history_test.go
+++ b/v2/pkg/dashboard/prompt_history_test.go
@@ -1,0 +1,561 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newTestPromptHistory returns an in-memory store (no PVC writer), matching how
+// newPromptHistory behaves when /data is absent.
+func newTestPromptHistory() *PromptHistory {
+	return &PromptHistory{ring: make([]PromptEntry, 0, promptHistoryRingCap)}
+}
+
+func TestRedactPromptSecrets(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          string
+		wantAbsent  []string
+		wantPresent []string
+	}{
+		{
+			name:        "github classic token",
+			in:          "Use ghp_abcdefghijklmnopqrstuvwxyz0123456789 to auth",
+			wantAbsent:  []string{"ghp_abcdefghijklmnopqrstuvwxyz0123456789"},
+			wantPresent: []string{secretRedactionPlaceholder, "to auth"},
+		},
+		{
+			name:        "github fine-grained pat",
+			in:          "token github_pat_11ABCDEFG0abcdefghijklmnop here",
+			wantAbsent:  []string{"github_pat_11ABCDEFG0abcdefghijklmnop"},
+			wantPresent: []string{secretRedactionPlaceholder},
+		},
+		{
+			name:        "openai style key",
+			in:          "OPENAI key sk-abcdefghijklmnopqrstuvwxyz012345",
+			wantAbsent:  []string{"sk-abcdefghijklmnopqrstuvwxyz012345"},
+			wantPresent: []string{secretRedactionPlaceholder},
+		},
+		{
+			name:        "aws access key id",
+			in:          "aws AKIAIOSFODNN7EXAMPLE end",
+			wantAbsent:  []string{"AKIAIOSFODNN7EXAMPLE"},
+			wantPresent: []string{secretRedactionPlaceholder},
+		},
+		{
+			name:        "slack token",
+			in:          "slack xoxb-1234567890-abcdefghij done",
+			wantAbsent:  []string{"xoxb-1234567890-abcdefghij"},
+			wantPresent: []string{secretRedactionPlaceholder},
+		},
+		{
+			name:        "generic assignment with unknown vendor shape",
+			in:          "GITHUB_TOKEN=s3cretValueGoesHere\nnext line",
+			wantAbsent:  []string{"s3cretValueGoesHere"},
+			wantPresent: []string{secretRedactionPlaceholder, "next line"},
+		},
+		{
+			name:        "api_key colon form",
+			in:          "api_key: superSecretValue123",
+			wantAbsent:  []string{"superSecretValue123"},
+			wantPresent: []string{secretRedactionPlaceholder},
+		},
+		{
+			name:        "ordinary prompt text is untouched",
+			in:          "Review issue #42 in kubestellar/hive and open a PR.",
+			wantAbsent:  []string{secretRedactionPlaceholder},
+			wantPresent: []string{"Review issue #42", "kubestellar/hive"},
+		},
+		{
+			name:        "empty stays empty",
+			in:          "",
+			wantAbsent:  []string{secretRedactionPlaceholder},
+			wantPresent: []string{},
+		},
+		// False-positive guards: redaction must not mangle ordinary prompt
+		// content, or the view becomes misleading.
+		{
+			name:        "issue list line is untouched",
+			in:          "  12m kubestellar/hive#2166 [kind/feature,triage/accepted] Add prompt history",
+			wantAbsent:  []string{secretRedactionPlaceholder},
+			wantPresent: []string{"kubestellar/hive#2166", "Add prompt history"},
+		},
+		{
+			name:        "authorized repos section is untouched",
+			in:          "AUTHORIZED REPOS (you may ONLY interact with these):\n  kubestellar/hive\n",
+			wantAbsent:  []string{secretRedactionPlaceholder},
+			wantPresent: []string{"kubestellar/hive"},
+		},
+		{
+			name:        "prose containing the word token is untouched",
+			in:          "The token bucket algorithm limits requests",
+			wantAbsent:  []string{secretRedactionPlaceholder},
+			wantPresent: []string{"token bucket algorithm"},
+		},
+		{
+			name:        "unresolved placeholder is not a secret",
+			in:          "api_key: ${OPENAI_API_KEY}",
+			wantAbsent:  []string{secretRedactionPlaceholder},
+			wantPresent: []string{"${OPENAI_API_KEY}"},
+		},
+		{
+			name:        "colon separator is preserved when redacting",
+			in:          "api_key: superSecretValue123",
+			wantAbsent:  []string{"superSecretValue123"},
+			wantPresent: []string{"api_key: " + secretRedactionPlaceholder},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redactPromptSecrets(tc.in)
+			for _, s := range tc.wantAbsent {
+				if strings.Contains(got, s) {
+					t.Errorf("expected %q to be redacted out, got %q", s, got)
+				}
+			}
+			for _, s := range tc.wantPresent {
+				if !strings.Contains(got, s) {
+					t.Errorf("expected %q to be present, got %q", s, got)
+				}
+			}
+		})
+	}
+}
+
+func TestRecordRedactsBeforePersisting(t *testing.T) {
+	p := newTestPromptHistory()
+	p.Record("quality", "governor-eval", "auth with ghp_abcdefghijklmnopqrstuvwxyz0123456789 now")
+
+	got := p.Query("quality", promptHistoryDefaultWindowHours, time.Now())
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(got))
+	}
+	if strings.Contains(got[0].Prompt, "ghp_abcdefghijklmnopqrstuvwxyz0123456789") {
+		t.Fatalf("secret survived into stored prompt: %q", got[0].Prompt)
+	}
+	if !strings.Contains(got[0].Prompt, secretRedactionPlaceholder) {
+		t.Fatalf("expected redaction placeholder, got %q", got[0].Prompt)
+	}
+}
+
+func TestTruncatePrompt(t *testing.T) {
+	tests := []struct {
+		name          string
+		size          int
+		wantTruncated bool
+	}{
+		{name: "small prompt untouched", size: 100, wantTruncated: false},
+		{name: "exactly at limit untouched", size: promptHistoryMaxPromptBytes, wantTruncated: false},
+		{name: "one over limit truncated", size: promptHistoryMaxPromptBytes + 1, wantTruncated: true},
+		{name: "far over limit truncated", size: promptHistoryMaxPromptBytes * 3, wantTruncated: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			in := strings.Repeat("a", tc.size)
+			got, truncated := truncatePrompt(in)
+			if truncated != tc.wantTruncated {
+				t.Fatalf("truncated = %v, want %v", truncated, tc.wantTruncated)
+			}
+			if !tc.wantTruncated {
+				if got != in {
+					t.Fatalf("prompt was modified when it should not have been")
+				}
+				return
+			}
+			if !strings.Contains(got, promptHistoryTruncationMarker) {
+				t.Fatalf("expected explicit truncation marker in output")
+			}
+			// The entry must be kept, not dropped.
+			if len(got) == 0 {
+				t.Fatalf("truncation dropped the prompt entirely")
+			}
+		})
+	}
+}
+
+func TestTruncatePromptKeepsValidUTF8(t *testing.T) {
+	// Multi-byte runes straddling the cut point must not produce invalid UTF-8,
+	// which would break JSON round-tripping of the stored entry.
+	in := strings.Repeat("é", promptHistoryMaxPromptBytes)
+	got, truncated := truncatePrompt(in)
+	if !truncated {
+		t.Fatalf("expected truncation")
+	}
+	if !json.Valid(mustJSON(t, got)) {
+		t.Fatalf("truncated prompt did not survive JSON encoding")
+	}
+}
+
+func mustJSON(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+func TestQueryTimeWindowFilter(t *testing.T) {
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	p := newTestPromptHistory()
+
+	// Seed entries at known ages directly so the test is time-independent.
+	ages := []time.Duration{
+		30 * time.Minute,
+		6 * time.Hour,
+		48 * time.Hour,      // outside a 24h window, inside a week
+		10 * 24 * time.Hour, // outside a week
+	}
+	for i, age := range ages {
+		p.ring = append(p.ring, PromptEntry{
+			Timestamp: now.Add(-age).Format(time.RFC3339),
+			Agent:     "quality",
+			Trigger:   "governor-eval",
+			Prompt:    fmt.Sprintf("prompt-%d", i),
+		})
+	}
+
+	tests := []struct {
+		name        string
+		windowHours int
+		want        int
+	}{
+		{name: "one hour window", windowHours: 1, want: 1},
+		{name: "last day", windowHours: 24, want: 2},
+		{name: "last week", windowHours: 168, want: 3},
+		{name: "zero falls back to default day", windowHours: 0, want: 2},
+		{name: "negative falls back to default day", windowHours: -5, want: 2},
+		{name: "over max is clamped to a week", windowHours: 100000, want: 3},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := p.Query("quality", tc.windowHours, now)
+			if len(got) != tc.want {
+				t.Fatalf("got %d entries, want %d", len(got), tc.want)
+			}
+		})
+	}
+}
+
+func TestQueryAgentFilterAndOrdering(t *testing.T) {
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	p := newTestPromptHistory()
+
+	seed := []struct {
+		agent string
+		age   time.Duration
+	}{
+		{"quality", 3 * time.Hour},
+		{"scanner", 2 * time.Hour},
+		{"quality", 1 * time.Hour},
+		{"architect", 30 * time.Minute},
+	}
+	for i, s := range seed {
+		p.ring = append(p.ring, PromptEntry{
+			Timestamp: now.Add(-s.age).Format(time.RFC3339),
+			Agent:     s.agent,
+			Trigger:   "governor-eval",
+			Prompt:    fmt.Sprintf("p%d", i),
+		})
+	}
+
+	tests := []struct {
+		name  string
+		agent string
+		want  int
+	}{
+		{name: "single agent", agent: "quality", want: 2},
+		{name: "other agent", agent: "scanner", want: 1},
+		{name: "empty matches all", agent: "", want: 4},
+		{name: "unknown agent matches none", agent: "nope", want: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := p.Query(tc.agent, promptHistoryMaxWindowHours, now)
+			if len(got) != tc.want {
+				t.Fatalf("got %d, want %d", len(got), tc.want)
+			}
+			// Newest first.
+			for i := 1; i < len(got); i++ {
+				if got[i-1].Timestamp < got[i].Timestamp {
+					t.Fatalf("entries not newest-first: %s before %s", got[i-1].Timestamp, got[i].Timestamp)
+				}
+			}
+		})
+	}
+}
+
+func TestQuerySkipsUnparseableTimestamps(t *testing.T) {
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	p := newTestPromptHistory()
+	p.ring = append(p.ring,
+		PromptEntry{Timestamp: "not-a-timestamp", Agent: "quality", Prompt: "bad"},
+		PromptEntry{Timestamp: now.Add(-time.Hour).Format(time.RFC3339), Agent: "quality", Prompt: "good"},
+	)
+	got := p.Query("quality", 24, now)
+	if len(got) != 1 || got[0].Prompt != "good" {
+		t.Fatalf("expected only the parseable entry, got %+v", got)
+	}
+}
+
+func TestQueryCapsResults(t *testing.T) {
+	now := time.Date(2026, 7, 29, 12, 0, 0, 0, time.UTC)
+	p := newTestPromptHistory()
+	for i := 0; i < promptHistoryMaxResults+50; i++ {
+		p.ring = append(p.ring, PromptEntry{
+			Timestamp: now.Add(-time.Duration(i) * time.Minute).Format(time.RFC3339),
+			Agent:     "quality",
+			Prompt:    "p",
+		})
+	}
+	got := p.Query("quality", promptHistoryMaxWindowHours, now)
+	if len(got) != promptHistoryMaxResults {
+		t.Fatalf("got %d, want cap of %d", len(got), promptHistoryMaxResults)
+	}
+}
+
+func TestRecordRingRetention(t *testing.T) {
+	p := newTestPromptHistory()
+	// Overfill the ring; oldest entries must be evicted, size stays bounded.
+	total := promptHistoryRingCap + 25
+	for i := 0; i < total; i++ {
+		p.Record("quality", "governor-eval", fmt.Sprintf("prompt number %d", i))
+	}
+	if len(p.ring) != promptHistoryRingCap {
+		t.Fatalf("ring size = %d, want %d", len(p.ring), promptHistoryRingCap)
+	}
+	// The very first prompts must be gone.
+	for _, e := range p.ring {
+		if e.Prompt == "prompt number 0" {
+			t.Fatalf("oldest entry was not evicted")
+		}
+	}
+	// The newest must be present.
+	found := false
+	for _, e := range p.ring {
+		if e.Prompt == fmt.Sprintf("prompt number %d", total-1) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("newest entry missing from ring")
+	}
+}
+
+func TestRecordIgnoresEmptyInput(t *testing.T) {
+	tests := []struct {
+		name   string
+		agent  string
+		prompt string
+	}{
+		{name: "empty agent", agent: "", prompt: "hello"},
+		{name: "empty prompt", agent: "quality", prompt: ""},
+		{name: "both empty", agent: "", prompt: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := newTestPromptHistory()
+			p.Record(tc.agent, "governor-eval", tc.prompt)
+			if len(p.ring) != 0 {
+				t.Fatalf("expected no entry recorded, got %d", len(p.ring))
+			}
+		})
+	}
+}
+
+func TestRecordDefaultsMissingTrigger(t *testing.T) {
+	p := newTestPromptHistory()
+	p.Record("quality", "", "do the thing")
+	if len(p.ring) != 1 {
+		t.Fatalf("expected 1 entry")
+	}
+	if p.ring[0].Trigger != "unknown" {
+		t.Fatalf("trigger = %q, want %q", p.ring[0].Trigger, "unknown")
+	}
+}
+
+func TestLoadFromDiskMalformedLines(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    int
+	}{
+		{
+			name:    "all good lines",
+			content: `{"ts":"2026-07-29T10:00:00Z","agent":"quality","prompt":"a"}` + "\n" + `{"ts":"2026-07-29T11:00:00Z","agent":"scanner","prompt":"b"}` + "\n",
+			want:    2,
+		},
+		{
+			name: "truncated final line is skipped, earlier lines survive",
+			content: `{"ts":"2026-07-29T10:00:00Z","agent":"quality","prompt":"a"}` + "\n" +
+				`{"ts":"2026-07-29T11:00:00Z","agent":"scan`,
+			want: 1,
+		},
+		{
+			name: "garbage line in the middle does not abort the load",
+			content: `{"ts":"2026-07-29T10:00:00Z","agent":"quality","prompt":"a"}` + "\n" +
+				"this is not json at all\n" +
+				`{"ts":"2026-07-29T12:00:00Z","agent":"quality","prompt":"c"}` + "\n",
+			want: 2,
+		},
+		{
+			name: "entries missing required fields are skipped",
+			content: `{"ts":"","agent":"quality","prompt":"a"}` + "\n" +
+				`{"ts":"2026-07-29T10:00:00Z","agent":"","prompt":"b"}` + "\n" +
+				`{"ts":"2026-07-29T11:00:00Z","agent":"quality","prompt":"c"}` + "\n",
+			want: 1,
+		},
+		{
+			name:    "blank lines are ignored",
+			content: "\n\n" + `{"ts":"2026-07-29T10:00:00Z","agent":"quality","prompt":"a"}` + "\n\n",
+			want:    1,
+		},
+		{
+			name:    "completely empty file",
+			content: "",
+			want:    0,
+		},
+		{
+			name:    "only garbage yields nothing but does not panic",
+			content: "nope\nstill nope\n{{{\n",
+			want:    0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "prompt-history.jsonl")
+			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			p := newTestPromptHistory()
+			p.loadFromDisk(path)
+			if len(p.ring) != tc.want {
+				t.Fatalf("loaded %d entries, want %d", len(p.ring), tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadFromDiskMissingFile(t *testing.T) {
+	p := newTestPromptHistory()
+	p.loadFromDisk(filepath.Join(t.TempDir(), "does-not-exist.jsonl"))
+	if len(p.ring) != 0 {
+		t.Fatalf("expected empty ring")
+	}
+}
+
+func TestLoadFromDiskCapsRing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prompt-history.jsonl")
+	var b strings.Builder
+	for i := 0; i < promptHistoryRingCap+40; i++ {
+		fmt.Fprintf(&b, `{"ts":"2026-07-29T10:00:00Z","agent":"quality","prompt":"p%d"}`+"\n", i)
+	}
+	if err := os.WriteFile(path, []byte(b.String()), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	p := newTestPromptHistory()
+	p.loadFromDisk(path)
+	if len(p.ring) != promptHistoryRingCap {
+		t.Fatalf("ring = %d, want cap %d", len(p.ring), promptHistoryRingCap)
+	}
+}
+
+func TestHandlePromptHistoryRoleGating(t *testing.T) {
+	tests := []struct {
+		name     string
+		role     string
+		wantCode int
+	}{
+		{name: "owner allowed", role: "owner", wantCode: http.StatusOK},
+		{name: "read-write allowed", role: "read-write", wantCode: http.StatusOK},
+		{name: "empty role defaults to owner", role: "", wantCode: http.StatusOK},
+		{name: "read-only forbidden", role: "read-only", wantCode: http.StatusForbidden},
+		{name: "unknown role forbidden", role: "guest", wantCode: http.StatusForbidden},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Server{promptHistory: newTestPromptHistory()}
+			s.promptHistory.Record("quality", "governor-eval", "hello")
+
+			req := httptest.NewRequest(http.MethodGet, "/api/prompt-history?agent=quality", nil)
+			if tc.role != "" {
+				req.Header.Set("X-Hive-Role", tc.role)
+			}
+			rec := httptest.NewRecorder()
+			s.handlePromptHistory(rec, req)
+
+			if rec.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestHandlePromptHistoryResponse(t *testing.T) {
+	s := &Server{promptHistory: newTestPromptHistory()}
+	s.promptHistory.Record("quality", "governor-eval", "review the queue")
+	s.promptHistory.Record("scanner", "startup", "scan the repos")
+
+	tests := []struct {
+		name        string
+		query       string
+		wantEntries int
+		wantWindow  int
+	}{
+		{name: "agent filter applied", query: "?agent=quality", wantEntries: 1, wantWindow: promptHistoryDefaultWindowHours},
+		{name: "no agent returns all", query: "", wantEntries: 2, wantWindow: promptHistoryDefaultWindowHours},
+		{name: "explicit week window", query: "?windowHours=168", wantEntries: 2, wantWindow: 168},
+		{name: "garbage window falls back to default", query: "?windowHours=abc", wantEntries: 2, wantWindow: promptHistoryDefaultWindowHours},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/prompt-history"+tc.query, nil)
+			req.Header.Set("X-Hive-Role", "owner")
+			rec := httptest.NewRecorder()
+			s.handlePromptHistory(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d", rec.Code)
+			}
+			var body struct {
+				Entries     []PromptEntry `json:"entries"`
+				WindowHours int           `json:"windowHours"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if len(body.Entries) != tc.wantEntries {
+				t.Fatalf("entries = %d, want %d", len(body.Entries), tc.wantEntries)
+			}
+			if body.WindowHours != tc.wantWindow {
+				t.Fatalf("windowHours = %d, want %d", body.WindowHours, tc.wantWindow)
+			}
+		})
+	}
+}
+
+func TestRecordPromptNilSafe(t *testing.T) {
+	// The manager fires this callback unconditionally; a Server without a store
+	// (or a nil Server) must not panic.
+	var nilServer *Server
+	nilServer.RecordPrompt("quality", "governor-eval", "hi")
+
+	s := &Server{}
+	s.RecordPrompt("quality", "governor-eval", "hi")
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -106,6 +106,10 @@ type Server struct {
 
 	audit *AuditLog
 
+	// promptHistory stores the fully-expanded kick prompts delivered to each
+	// agent, so an owner can review what their agents were actually told.
+	promptHistory *PromptHistory
+
 	versionMu           sync.RWMutex
 	cachedLatestHash    string
 	cachedLatestMessage string
@@ -470,6 +474,7 @@ func NewServer(port int, logger *slog.Logger) *Server {
 		agentPipelines: make(map[string]map[string]bool),
 		agentHooks:     make(map[string]map[string][]any),
 		audit:          newAuditLog(),
+		promptHistory:  newPromptHistory(),
 		userSessions:   make(map[string]*userSession),
 		cliModels:      newCLIModelCache(),
 		startedAt:      time.Now(),
@@ -488,6 +493,7 @@ func NewServerWithAuth(port int, authToken string, logger *slog.Logger) *Server 
 		agentPipelines: make(map[string]map[string]bool),
 		agentHooks:     make(map[string]map[string][]any),
 		audit:          newAuditLog(),
+		promptHistory:  newPromptHistory(),
 		userSessions:   make(map[string]*userSession),
 		cliModels:      newCLIModelCache(),
 		startedAt:      time.Now(),

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -12003,7 +12003,7 @@ function burnAreaChart() {
     // The prompt-history tab. Renamed from 'Last Prompt' when it grew from a
     // single most-recent prompt into a browsable history; kept to one short
     // word because it sits in a crowded tab strip.
-    const AGENT_PROMPTS_TAB = 'Prompts';
+    const AGENT_PROMPTS_TAB = 'Prior Prompts';
     const AGENT_CONFIG_TABS = ['General', 'Cadences', 'Pipeline', 'Hooks', 'Restrictions', 'Channels', 'Tools', 'Connections', 'Stats', 'Prompt Template', AGENT_PROMPTS_TAB, 'Export'];
     const AGENT_CREATE_TABS = ['Import', 'General', 'Cadences', 'Channels', 'Tools', 'Prompt Template'];
     const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Hub', 'Model Gateways', 'Variables', 'Access'];

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -12000,7 +12000,11 @@ function burnAreaChart() {
     let _configState = { type: null, agent: null, tab: null, data: {}, dirty: {} };
     const _configTabMemory = {};
 
-    const AGENT_CONFIG_TABS = ['General', 'Cadences', 'Pipeline', 'Hooks', 'Restrictions', 'Channels', 'Tools', 'Connections', 'Stats', 'Prompt Template', 'Last Prompt', 'Export'];
+    // The prompt-history tab. Renamed from 'Last Prompt' when it grew from a
+    // single most-recent prompt into a browsable history; kept to one short
+    // word because it sits in a crowded tab strip.
+    const AGENT_PROMPTS_TAB = 'Prompts';
+    const AGENT_CONFIG_TABS = ['General', 'Cadences', 'Pipeline', 'Hooks', 'Restrictions', 'Channels', 'Tools', 'Connections', 'Stats', 'Prompt Template', AGENT_PROMPTS_TAB, 'Export'];
     const AGENT_CREATE_TABS = ['Import', 'General', 'Cadences', 'Channels', 'Tools', 'Prompt Template'];
     const GOVERNOR_CONFIG_TABS = ['General', 'Agents', 'Thresholds', 'Labels', 'Repos', 'Budget', 'Notifications', 'Health', 'Sensing', 'Logging', 'Hub', 'Model Gateways', 'Variables', 'Access'];
     const PIPELINE_STAGES = ['resolve-beads', 'track-prs', 'stale-check', 'repo-scan', 'coverage-gate', 'prompt-compose', 'budget-check', 'api-collect', 'final-compose'];
@@ -12450,6 +12454,9 @@ function burnAreaChart() {
       const body = document.getElementById('config-body');
       if (_configState.type === 'agent') {
         body.innerHTML = renderAgentTab(tabId);
+        // The Prompts tab renders a shell synchronously, then loads this
+        // agent's kick history over the selected time window.
+        if (tabId === AGENT_PROMPTS_TAB) initAgentPromptHistory();
       } else {
         body.innerHTML = renderGovernorTab(tabId);
         if (tabId === 'Hub') fetchQueueCount();
@@ -12571,7 +12578,7 @@ function burnAreaChart() {
         case 'Connections': return renderAgentConnections(d.connections || []);
         case 'Stats': return renderAgentStatsTab(d.stats || []);
         case 'Prompt Template': return renderAgentPromptTemplate();
-        case 'Last Prompt': return renderAgentLastPrompt(d.prompt || '');
+        case AGENT_PROMPTS_TAB: return renderAgentPromptHistoryShell();
         case 'Export': return renderAgentExport();
         default: return '';
       }
@@ -14676,17 +14683,154 @@ function burnAreaChart() {
       return html;
     }
 
-    function renderAgentLastPrompt(prompt) {
-      if (!prompt) {
-        return `<div style="display:flex;flex-direction:column;height:100%">
-          <p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px">The fully expanded prompt sent to this agent on its most recent kick.</p>
-          <div class="config-pre config-pre-fill" style="color:var(--muted);font-style:italic">(awaiting first kick)</div>
-          </div>`;
-      }
+    // ── Agent Prompt History ──
+    //
+    // Shows the prompts (kicks) this agent actually received over a selectable
+    // window, newest first, so an owner can answer "what was my agent asked to
+    // do, and when?" without reading server logs. Data comes from
+    // GET /api/prompt-history, which is role-gated exactly like /api/audit.
+
+    // Selectable windows, in hours. "Last day" and "last week" are the two the
+    // feature request named; 1h is a convenience for watching a live hive.
+    const PROMPT_HISTORY_WINDOWS = [
+      { hours: 1, label: 'Last hour' },
+      { hours: 24, label: 'Last day' },
+      { hours: 168, label: 'Last week' },
+    ];
+    const PROMPT_HISTORY_DEFAULT_WINDOW_HOURS = 24;
+
+    // Per-agent memory of the chosen window, so switching tabs or reopening the
+    // dialog keeps the selection.
+    const _promptHistoryWindow = {};
+    // Newest-first entries currently rendered, indexed by the list's data-idx.
+    let _promptHistoryEntries = [];
+
+    function renderAgentPromptHistoryShell() {
+      const agent = _configState.agent || '';
+      const selected = _promptHistoryWindow[agent] || PROMPT_HISTORY_DEFAULT_WINDOW_HOURS;
+      const opts = PROMPT_HISTORY_WINDOWS.map(function(w) {
+        return '<option value="' + w.hours + '"' + (w.hours === selected ? ' selected' : '') + '>' + esc(w.label) + '</option>';
+      }).join('');
       return `<div style="display:flex;flex-direction:column;height:100%">
-        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px;flex-shrink:0">The fully expanded prompt sent to this agent on its most recent kick — all variables resolved, pipeline data injected.</p>
-        <div class="config-pre config-pre-fill" style="font-family:inherit;font-size:0.78rem;line-height:1.6">${formatMarkdownPrompt(prompt)}</div>
+        <p style="font-size:0.75rem;color:var(--muted);margin-bottom:8px;flex-shrink:0">Prompts sent to this agent — fully expanded, all variables resolved and pipeline data injected. Newest first.</p>
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;flex-shrink:0">
+          <label for="prompt-history-window" style="font-size:0.75rem;color:var(--muted)">Window</label>
+          <select id="prompt-history-window" style="padding:4px 8px;background:var(--bg);border:1px solid var(--border);border-radius:6px;color:var(--text);font-size:0.75rem">${opts}</select>
+          <span id="prompt-history-count" style="font-size:0.7rem;color:var(--muted)"></span>
+        </div>
+        <div id="prompt-history-list" class="config-pre-fill" style="flex:1;min-height:200px;overflow-y:auto">
+          <div style="color:var(--muted);font-style:italic;padding:8px">Loading prompts…</div>
+        </div>
         </div>`;
+    }
+
+    function initAgentPromptHistory() {
+      const sel = document.getElementById('prompt-history-window');
+      if (sel) {
+        sel.addEventListener('change', function() {
+          const agent = _configState.agent || '';
+          _promptHistoryWindow[agent] = parseInt(sel.value, 10) || PROMPT_HISTORY_DEFAULT_WINDOW_HOURS;
+          loadAgentPromptHistory();
+        });
+      }
+      loadAgentPromptHistory();
+    }
+
+    async function loadAgentPromptHistory() {
+      const agent = _configState.agent || '';
+      const list = document.getElementById('prompt-history-list');
+      if (!list) return;
+      const hours = _promptHistoryWindow[agent] || PROMPT_HISTORY_DEFAULT_WINDOW_HOURS;
+      try {
+        const resp = await fetch('/api/prompt-history?agent=' + encodeURIComponent(agent) + '&windowHours=' + hours);
+        if (resp.status === 403) {
+          list.innerHTML = '<div style="color:var(--muted);padding:8px">You do not have access to prompt history.</div>';
+          return;
+        }
+        if (!resp.ok) {
+          list.innerHTML = '<div style="color:var(--muted);padding:8px">Could not load prompt history.</div>';
+          return;
+        }
+        const data = await resp.json();
+        // Guard: a failed or partial response can leave entries undefined.
+        _promptHistoryEntries = (data && data.entries) || [];
+        renderAgentPromptHistoryList();
+      } catch (e) {
+        list.innerHTML = '<div style="color:var(--muted);padding:8px">Could not load prompt history.</div>';
+      }
+    }
+
+    function promptHistoryRelativeTime(iso) {
+      const t = Date.parse(iso);
+      if (isNaN(t)) return '—';
+      const secs = Math.floor((Date.now() - t) / 1000);
+      const MIN = 60, HOUR = 3600, DAY = 86400;
+      if (secs < MIN) return 'just now';
+      if (secs < HOUR) return Math.floor(secs / MIN) + 'm ago';
+      if (secs < DAY) return Math.floor(secs / HOUR) + 'h ago';
+      return Math.floor(secs / DAY) + 'd ago';
+    }
+
+    // Trigger badge colors. Keys match the triggers the agent manager records.
+    const PROMPT_TRIGGER_COLORS = {
+      'startup': 'var(--blue)',
+      'governor-eval': 'var(--green)',
+      'dashboard-api': 'var(--purple)',
+      'send-kick': 'var(--purple)',
+      'manual': 'var(--amber)',
+    };
+
+    function renderAgentPromptHistoryList() {
+      const list = document.getElementById('prompt-history-list');
+      const countEl = document.getElementById('prompt-history-count');
+      if (!list) return;
+      const entries = _promptHistoryEntries || [];
+      if (countEl) countEl.textContent = entries.length ? entries.length + (entries.length === 1 ? ' prompt' : ' prompts') : '';
+      if (!entries.length) {
+        // Genuine empty state — this agent has not been kicked in the window.
+        list.innerHTML = '<div style="color:var(--muted);font-style:italic;padding:8px">(awaiting first kick)</div>';
+        return;
+      }
+      list.innerHTML = entries.map(function(e, i) {
+        const trigger = (e && e.trigger) || 'unknown';
+        const color = PROMPT_TRIGGER_COLORS[trigger] || 'var(--muted)';
+        const ts = (e && e.ts) || '';
+        const absolute = ts ? new Date(ts).toLocaleString() : '';
+        // Every field below is untrusted: prompt bodies embed repo content,
+        // issue titles and knowledge-base text. esc() here escapes & < > " '
+        // and backticks; the body uses escPreserveNewlines so line structure
+        // survives inside the <pre>. No inline handlers anywhere — the toggle
+        // is wired by data-idx + addEventListener below.
+        const truncNote = (e && e.truncated)
+          ? '<span style="font-size:0.65rem;color:var(--amber);margin-left:6px">truncated</span>'
+          : '';
+        return '<div style="border:1px solid var(--border);border-radius:6px;margin-bottom:6px;overflow:hidden">' +
+          '<button type="button" class="prompt-history-toggle" data-idx="' + i + '" ' +
+            'style="width:100%;display:flex;align-items:center;gap:8px;padding:6px 10px;background:var(--bg);border:none;cursor:pointer;text-align:left;color:var(--text);font-size:0.75rem">' +
+            '<span class="prompt-history-chevron" style="color:var(--muted);flex-shrink:0">▶</span>' +
+            '<span title="' + esc(absolute) + '" style="color:var(--muted);white-space:nowrap">' + esc(promptHistoryRelativeTime(ts)) + '</span>' +
+            '<span style="padding:1px 6px;border-radius:4px;font-size:0.65rem;border:1px solid ' + color + ';color:' + color + ';white-space:nowrap">' + esc(trigger) + '</span>' +
+            truncNote +
+          '</button>' +
+          '<pre class="prompt-history-body" data-idx="' + i + '" style="display:none;margin:0;padding:10px 12px;background:var(--bg);border-top:1px solid var(--border);font-family:var(--font-mono);font-size:0.72rem;line-height:1.5;white-space:pre-wrap;overflow-x:auto;color:var(--text)">' +
+            escPreserveNewlines((e && e.prompt) || '') +
+          '</pre>' +
+          '</div>';
+      }).join('');
+
+      // Collapse/expand per entry. Prompts run to tens of kilobytes, so the
+      // list stays scannable and only the opened one is shown in full.
+      list.querySelectorAll('.prompt-history-toggle').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+          const idx = btn.getAttribute('data-idx');
+          const body = list.querySelector('.prompt-history-body[data-idx="' + idx + '"]');
+          if (!body) return;
+          const open = body.style.display !== 'none';
+          body.style.display = open ? 'none' : 'block';
+          const chev = btn.querySelector('.prompt-history-chevron');
+          if (chev) chev.textContent = open ? '▶' : '▼';
+        });
+      });
     }
 
     // ── Governor Tab Renderers ──


### PR DESCRIPTION
## Problem

A hive owner's quality agent opened 9 near-identical PRs overnight. The cause was a restart storm — the agent was kicked 14 times in 2 hours, relaunching from scratch each time with no memory of the PR it had just filed. He could not diagnose it himself, because nothing durable held the prompt text:

- `agent.AgentProcess.LastKickMessage` (`v2/pkg/agent/manager.go`) holds only the **most recent** kick, in memory, replaced on the next kick and lost on restart. This is what the "Last Prompt" tab rendered.
- `agent.KickRecord.Snippet` survives restarts via the snapshot but is truncated to **120 chars** (200 for startup bootstraps).
- The audit log (`v2/pkg/dashboard/audit.go`) records that a kick *happened* (`action`, `trigger`) but never the prompt text.

So "what was my agent asked to do, and when?" was unanswerable from the UI.

## What this adds

A durable, bounded store for the fully-expanded prompt of every kick, and the per-agent **"Last Prompt"** tab becomes a browsable history.

**Storage** (`v2/pkg/dashboard/prompt_history.go`) follows the audit log's conventions: JSONL on the spoke's `/data` PVC, lumberjack rotation + gzip, in-memory ring serving reads so the hot path never touches disk. Durable storage is only wired when `/data` exists, so unit tests and bare runs stay in-memory.

**Sizing is measured, not guessed:**
- Mean policy template = **3068 B** across the 30 shipped templates in `pkg/policies/defaults` (largest: `scanner-automerge.md` at 10710 B).
- Issue list up to **12.7 KiB** (`maxIssuesPerKick = 100`, `v2/pkg/scheduler/scheduler.go:365`).
- Plus PR list, knowledge section, repos section → **~8 KiB typical, ~22 KiB worst case.**
- At the level-6 "busy" cadence pack (~8,700 kicks/week) that is **~70 MiB/week raw typical**, ~190 MiB/week worst case.

**Retention** is therefore capped at `promptHistoryMaxSizeMB (24) × (promptHistoryMaxBackups (3) + 1)` = **96 MiB on disk worst case**, ~25-30 MiB compressed in steady state (prompt text is repetitive template boilerplate, ~4x gzip), plus a 14-day age bound. Oversized individual prompts are **truncated with an explicit marker**, never dropped.

**Secret redaction** runs at write time, before anything reaches memory or disk. Per-kick substitution leaves bare `${VAR}` literal, but an operator can declare a `variables:` entry with `scope: template` + `type: env`, which resolves hive's process environment (GitHub token, gateway keys) into the prompt body — so secrets *are* reachable and must not become durable. Unresolved `${VAR}` placeholders are deliberately **not** redacted: they are variable names, and hiding them would mask exactly the misconfiguration this view exists to surface.

**Authorization**: `GET /api/prompt-history` is gated on `X-Hive-Role` byte-identically to `GET /api/audit`. Prompts carry repo and issue content, so access is not widened.

## UI

The tab is renamed **"Prompts"** (short — it sits in a crowded tab strip) and gains a day/week window selector with per-entry collapse/expand, newest first, each showing relative time (absolute on hover), a trigger badge, and the full text. `(awaiting first kick)` remains the genuine empty state.

Prompt bodies embed arbitrary repo and issue content — the highest-XSS-risk surface here — so rendering uses `esc()` / `escPreserveNewlines` (both escape `& < > " ' \``) and toggles are wired via `data-idx` + `addEventListener`, with **no inline handlers**. The trigger badge color comes from a fixed lookup with a literal fallback, so untrusted text never reaches a `style` attribute.

## Concurrency note

The record callback is held in an `atomic.Pointer` because `deliverKickLocked` fires it while holding the manager's non-reentrant `m.mu` — reading it under a second lock there would deadlock the kick path.

## Verification

- `go build ./...`, `go vet ./pkg/dashboard/`, `go test -count=1 -timeout 480s ./pkg/dashboard/` all pass.
- 17 new table-driven tests covering retention/pruning, time-window filter, agent filter + ordering, redaction, truncation (incl. UTF-8 boundary safety), role gating, and malformed/partial JSONL — a truncated final line skips only that line and leaves earlier entries intact.
- Redaction probed empirically against real credential shapes (`ghp_`, `ghs_`, `sk-proj-`, `sk-ant-`, `AKIA`, `PASSWORD:`) — all redacted; `${GITHUB_TOKEN}` correctly preserved.

Fixes #2166
