### PR TITLE
feat(github): auto-discover the App installation for a hive's own org

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -160,6 +160,10 @@ func main() {
 			os.Exit(1)
 		}
 		logger.Info("using GitHub App authentication", "app_id", cfg.GitHub.AppID)
+		// Correct a stale/wrong installation_id BEFORE building the client, so
+		// the very first token this process mints is scoped to the right org
+		// rather than 403ing on every write until the self-heal tick runs.
+		healGitHubAppInstallation(ctx, appAuth, cfg, logger)
 		ghClient = github.NewClientFromApp(appAuth, cfg.Project.Org, cfg.Project.Repos, logger)
 
 		if cfg.GitHub.DocsInstallationID != 0 {
@@ -1133,6 +1137,10 @@ func main() {
 				// wrong installation). Verify write capability before letting
 				// the handler clear the banner, so Re-check can't produce a
 				// clears-then-returns flip-flop.
+				// Before reporting a wrong-account installation, try to fix it:
+				// this is the exact case rediscovery exists for. Cached by TTL,
+				// so a repeated re-check does not re-hit the API.
+				healGitHubAppInstallation(ctx, ghClient.AppAuth(), cfg, logger)
 				if diag := diagnoseGitHubAppWrite(ctx, ghClient.AppAuth(), cfg.Project.Org); diag != "" {
 					dashSrv.SetGitHubAppPermIssue(diag)
 					logger.Warn("github app recheck: app detected but write not verified", "repo", recheckRepo, "detail", diag)
@@ -1904,6 +1912,10 @@ func main() {
 					logger.Error("github app auth init via heartbeat failed", "error", err)
 					return
 				}
+				// Hub-delivered creds can carry a wrong installation_id just as
+				// easily as a hand-edited config; correct (and persist) it
+				// before building a client that would 403 on every write.
+				healGitHubAppInstallation(ctx, newAppAuth, cfg, logger)
 				newClient := github.NewClientFromApp(newAppAuth, cfg.Project.Org, cfg.Project.Repos, logger)
 				if len(cfg.Governor.Labels.Exempt) > 0 {
 					newClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
@@ -2228,6 +2240,50 @@ func applyBudgetAlerts(gov *governor.Governor, trans governor.BudgetTransitions,
 // that produce identical 403s: an installation_id pointing at a different
 // org's installation, and a permission update the org owner hasn't approved
 // yet. A nil appAuth (token-authenticated hive) yields "" — nothing to check.
+// healGitHubAppInstallation self-heals a hive whose github.installation_id
+// points at the WRONG account — the failure mode diagnoseGitHubAppWrite
+// already detects and reports ("installation N belongs to 'X', not 'Y'"). It
+// asks pkg/github to rediscover the installation covering cfg.Project.Org via
+// the App JWT and, only on an unambiguous match, adopts it in place and
+// persists it so the fix survives a pod restart.
+//
+// Every failure path is soft and silent-ish: a hive with no App key is not
+// App-authenticated (skip), an API error or an ambiguous/absent discovery
+// result leaves installation_id exactly as configured so the existing
+// "check github.installation_id" banner still stands. It never returns an
+// error to the caller and never blocks startup or a heartbeat.
+//
+// Rediscovery is rate-limited by pkg/github's discovery cache
+// (github.InstallationDiscoveryTTL), so calling this from the self-heal tick
+// is cheap even when the App is genuinely not installed on the org.
+func healGitHubAppInstallation(ctx context.Context, appAuth *github.AppAuth, cfg *config.Config, logger *slog.Logger) {
+	if appAuth == nil || !appAuth.HasKey() || cfg == nil {
+		return
+	}
+	org := cfg.Project.Org
+	if org == "" {
+		return
+	}
+	newID, err := appAuth.RediscoverAndAdopt(ctx, org, logger)
+	if err != nil {
+		logger.Debug("github app installation rediscovery did not adopt a new id",
+			"org", org, "error", err)
+		return
+	}
+	if newID == 0 {
+		return // already correct, or nothing safe to adopt
+	}
+	cfg.GitHub.InstallationID = newID
+	if err := cfg.Save(); err != nil {
+		logger.Error("adopted rediscovered installation_id but failed to persist it — "+
+			"it will revert on the next pod restart",
+			"installation_id", newID, "error", err)
+		return
+	}
+	logger.Info("persisted rediscovered github app installation_id",
+		"installation_id", newID, "org", org)
+}
+
 func diagnoseGitHubAppWrite(ctx context.Context, appAuth *github.AppAuth, expectedOwner string) string {
 	if appAuth == nil {
 		return ""

--- a/v2/pkg/github/app_discovery.go
+++ b/v2/pkg/github/app_discovery.go
@@ -1,0 +1,257 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+const (
+	// InstallationDiscoveryTTL bounds how often a hive may re-query GitHub for
+	// the installation covering its org. Discovery is only ever triggered from
+	// slow paths (startup, and the self-heal tick that already runs at the
+	// heartbeat cadence while the App banner is showing), but the self-heal
+	// tick would otherwise re-discover on EVERY beat for a hive whose App is
+	// genuinely not installed on the org — burning App-JWT rate limit forever.
+	// One hour is far shorter than any realistic "admin installs the App"
+	// turnaround and far longer than the heartbeat.
+	InstallationDiscoveryTTL = 1 * time.Hour
+
+	// discoveryListPerPage is the page size used when falling back to
+	// GET /app/installations. GitHub caps per_page at 100.
+	discoveryListPerPage = 100
+
+	// discoveryMaxPages bounds the fallback listing walk. An App installed on
+	// more than 100*discoveryMaxPages accounts is not a hive App; stopping
+	// keeps a pathological listing from stalling startup or the heartbeat.
+	discoveryMaxPages = 10
+
+	// discoveryTimeout bounds a whole discovery attempt (direct lookup plus
+	// any fallback listing) so a hung GHE instance can never wedge startup or
+	// a heartbeat tick.
+	discoveryTimeout = 30 * time.Second
+)
+
+// discoveryCache memoises the outcome of DiscoverInstallationID per
+// (apiURL, appID, org) so repeated calls from the self-heal loop do not hit
+// the API. Negative results are cached too — "the App is not installed on
+// this org" is the expensive-to-recheck case that motivates the TTL.
+var (
+	discoveryCacheMu sync.Mutex
+	discoveryCache   = map[string]discoveryCacheEntry{}
+)
+
+type discoveryCacheEntry struct {
+	id       int64
+	err      error
+	cachedAt time.Time
+}
+
+func discoveryCacheKey(apiURL string, appID int64, org string) string {
+	return fmt.Sprintf("%s|%d|%s", apiURL, appID, strings.ToLower(org))
+}
+
+// ResetInstallationDiscoveryCache clears the memoised discovery results.
+// Exported for tests; never called in production.
+func ResetInstallationDiscoveryCache() {
+	discoveryCacheMu.Lock()
+	defer discoveryCacheMu.Unlock()
+	discoveryCache = map[string]discoveryCacheEntry{}
+}
+
+// ErrNoInstallationForOrg means the App JWT authenticated fine but no
+// installation of this App covers the target org. This is NOT a transient
+// failure and NOT something the caller can fix by retrying: the App has to be
+// installed on the org. Callers must leave the configured installation_id
+// untouched when they see it.
+var ErrNoInstallationForOrg = fmt.Errorf("no installation of this app covers the target org")
+
+// DiscoverInstallationID resolves the installation ID of this App on org.
+//
+// It prefers GET /orgs/{org}/installation — a single App-JWT-authenticated
+// call that answers the exact question and is correct by construction (GitHub
+// resolves the org, so there is no login-matching for us to get wrong). When
+// that endpoint is unavailable (older GHE, or the target is a user account
+// rather than an org) it falls back to walking GET /app/installations and
+// matching the installation account login case-insensitively.
+//
+// Both endpoints are authenticated with the App JWT, not an installation
+// token, so this works even when the CONFIGURED installation_id is wrong —
+// which is the whole point.
+//
+// It never returns an installation belonging to a different account: a
+// plausible-but-wrong ID produces exactly the confusing 403s this is meant to
+// cure. Ambiguity or absence yields ErrNoInstallationForOrg and the caller
+// must leave the config alone.
+func (a *AppAuth) DiscoverInstallationID(ctx context.Context, org string) (int64, error) {
+	if a == nil {
+		return 0, fmt.Errorf("no app auth configured")
+	}
+	if a.key == nil {
+		// A hive with no App private key simply is not App-authenticated.
+		// This is not a discovery failure — callers skip silently.
+		return 0, fmt.Errorf("app private key not loaded")
+	}
+	org = strings.TrimSpace(org)
+	if org == "" {
+		return 0, fmt.Errorf("target org is empty")
+	}
+
+	key := discoveryCacheKey(a.apiURL, a.appID, org)
+	discoveryCacheMu.Lock()
+	if entry, ok := discoveryCache[key]; ok && time.Since(entry.cachedAt) < InstallationDiscoveryTTL {
+		discoveryCacheMu.Unlock()
+		return entry.id, entry.err
+	}
+	discoveryCacheMu.Unlock()
+
+	id, err := a.discoverInstallationUncached(ctx, org)
+
+	discoveryCacheMu.Lock()
+	discoveryCache[key] = discoveryCacheEntry{id: id, err: err, cachedAt: time.Now()}
+	discoveryCacheMu.Unlock()
+
+	return id, err
+}
+
+func (a *AppAuth) discoverInstallationUncached(ctx context.Context, org string) (int64, error) {
+	ctx, cancel := context.WithTimeout(ctx, discoveryTimeout)
+	defer cancel()
+
+	jwtToken, err := a.generateJWT()
+	if err != nil {
+		return 0, fmt.Errorf("generating JWT: %w", err)
+	}
+	jwtClient := gh.NewClient(nil).WithAuthToken(jwtToken)
+	setBaseURL(jwtClient, a.apiURL)
+
+	// Preferred: direct per-org lookup.
+	inst, resp, err := jwtClient.Apps.FindOrganizationInstallation(ctx, org)
+	if err == nil && inst != nil && inst.GetID() != 0 {
+		// Defensive: only adopt when the returned account really is the org.
+		// The endpoint is authoritative, but adopting an ID whose account we
+		// have not confirmed is exactly the failure mode being fixed.
+		if acct := inst.GetAccount().GetLogin(); acct != "" && !strings.EqualFold(acct, org) {
+			return 0, fmt.Errorf("%w: direct lookup for %q returned an installation owned by %q", ErrNoInstallationForOrg, org, acct)
+		}
+		return inst.GetID(), nil
+	}
+	// A 404 means "this App is not installed on that org" — authoritative and
+	// final. Anything else (405 on old GHE, 5xx, network) falls through to the
+	// listing walk, which also covers user-account targets.
+	directErr := err
+	if resp != nil && resp.StatusCode == 404 {
+		// Still try the listing: on some GHE versions the org endpoint 404s for
+		// user-account targets that DO have a listable installation.
+		directErr = fmt.Errorf("direct org lookup: not found")
+	}
+
+	opts := &gh.ListOptions{PerPage: discoveryListPerPage}
+	for page := 0; page < discoveryMaxPages; page++ {
+		installs, listResp, listErr := jwtClient.Apps.ListInstallations(ctx, opts)
+		if listErr != nil {
+			return 0, fmt.Errorf("listing app installations (direct lookup: %v): %w", directErr, listErr)
+		}
+		for _, in := range installs {
+			if in == nil {
+				continue
+			}
+			if strings.EqualFold(in.GetAccount().GetLogin(), org) {
+				if id := in.GetID(); id != 0 {
+					return id, nil
+				}
+			}
+		}
+		if listResp == nil || listResp.NextPage == 0 {
+			break
+		}
+		opts.Page = listResp.NextPage
+	}
+
+	return 0, fmt.Errorf("%w: app %d has no installation for %q (direct lookup: %v)", ErrNoInstallationForOrg, a.appID, org, directErr)
+}
+
+// AppID returns the configured GitHub App ID.
+func (a *AppAuth) AppID() int64 { return a.appID }
+
+// InstallationID returns the installation ID this auth currently uses.
+func (a *AppAuth) InstallationID() int64 { return a.installationID }
+
+// APIURL returns the GitHub API base URL this auth targets ("" = public).
+func (a *AppAuth) APIURL() string { return a.apiURL }
+
+// HasKey reports whether an App private key was loaded. A hive without one is
+// not App-authenticated and must be skipped rather than treated as failing.
+func (a *AppAuth) HasKey() bool { return a != nil && a.key != nil }
+
+// AdoptInstallationID switches this auth to a different installation and
+// drops the cached installation token (which was minted for the OLD, wrong
+// installation and would keep 403ing on writes).
+func (a *AppAuth) AdoptInstallationID(id int64) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.installationID = id
+	a.cachedToken = ""
+	a.tokenExpiry = time.Time{}
+	// The on-disk cache holds the same stale token; agents read it directly.
+	if a.cachePath != "" {
+		if err := os.Remove(a.cachePath); err != nil && !os.IsNotExist(err) {
+			a.logger.Warn("failed to drop stale app token cache after adopting new installation",
+				"path", a.cachePath, "error", err)
+		}
+	}
+}
+
+// RediscoverAndAdopt is the self-heal entry point. It verifies the configured
+// installation and, ONLY when that installation belongs to an account other
+// than org, discovers the correct installation for org and adopts it in place.
+//
+// It returns the newly adopted installation ID, or 0 when nothing changed.
+// Every failure mode is soft: a nil auth, a missing key, an API error, or an
+// ambiguous/absent discovery result all return (0, err-or-nil) with the
+// configured ID left exactly as it was, so the existing "check your
+// installation_id" diagnosis still stands and startup/heartbeat proceed.
+func (a *AppAuth) RediscoverAndAdopt(ctx context.Context, org string, logger *slog.Logger) (int64, error) {
+	if a == nil || !a.HasKey() {
+		return 0, nil // not App-authenticated — nothing to heal, not an error
+	}
+	if strings.TrimSpace(org) == "" {
+		return 0, nil
+	}
+	if logger == nil {
+		logger = a.logger
+	}
+
+	info, err := a.VerifyInstallation(ctx)
+	if err != nil {
+		// Cannot prove the current installation is wrong — never guess.
+		return 0, fmt.Errorf("verifying installation before rediscovery: %w", err)
+	}
+	if strings.EqualFold(info.Account, org) {
+		return 0, nil // installation already belongs to the right account
+	}
+
+	logger.Warn("github app installation belongs to the wrong account — attempting rediscovery",
+		"installation_id", info.InstallationID, "account", info.Account, "expected_org", org)
+
+	newID, err := a.DiscoverInstallationID(ctx, org)
+	if err != nil {
+		logger.Warn("github app installation rediscovery failed — leaving installation_id untouched",
+			"expected_org", org, "error", err)
+		return 0, err
+	}
+	if newID == 0 || newID == info.InstallationID {
+		return 0, nil
+	}
+
+	a.AdoptInstallationID(newID)
+	logger.Info("adopted rediscovered github app installation",
+		"was", info.InstallationID, "now", newID, "org", org)
+	return newID, nil
+}

--- a/v2/pkg/github/app_discovery_test.go
+++ b/v2/pkg/github/app_discovery_test.go
@@ -1,0 +1,500 @@
+package github
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func discoveryTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func discoveryTestKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+	return key
+}
+
+// discoveryServer builds an httptest server that answers the two App-level
+// endpoints discovery uses. orgInstall maps an org login to the installation
+// GET /orgs/{org}/installation should return (0 = 404). listInstalls is what
+// GET /app/installations returns.
+type discoveryServerOpts struct {
+	orgInstall     map[string]int64
+	orgInstallCode int // status for a miss; 0 => 404
+	listInstalls   []map[string]any
+	listStatus     int // non-zero => fail the listing with this status
+	// getInstallation answers GET /app/installations/{id} (VerifyInstallation).
+	getInstallation map[string]any
+}
+
+func newDiscoveryServer(t *testing.T, opts discoveryServerOpts, hits *int64) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hits != nil {
+			atomic.AddInt64(hits, 1)
+		}
+		path := r.URL.Path
+		switch {
+		case strings.HasPrefix(path, "/orgs/") && strings.HasSuffix(path, "/installation"):
+			org := strings.TrimSuffix(strings.TrimPrefix(path, "/orgs/"), "/installation")
+			if id, ok := opts.orgInstall[org]; ok && id != 0 {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(map[string]any{
+					"id":      id,
+					"account": map[string]any{"login": org},
+				})
+				return
+			}
+			code := opts.orgInstallCode
+			if code == 0 {
+				code = http.StatusNotFound
+			}
+			w.WriteHeader(code)
+			w.Write([]byte(`{"message":"Not Found"}`))
+		case path == "/app/installations":
+			if opts.listStatus != 0 {
+				w.WriteHeader(opts.listStatus)
+				w.Write([]byte(`{"message":"boom"}`))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			list := opts.listInstalls
+			if list == nil {
+				list = []map[string]any{}
+			}
+			json.NewEncoder(w).Encode(list)
+		case strings.HasPrefix(path, "/app/installations/"):
+			if opts.getInstallation == nil {
+				w.WriteHeader(http.StatusNotFound)
+				w.Write([]byte(`{"message":"Not Found"}`))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(opts.getInstallation)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"message":"unexpected path ` + path + `"}`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func installEntry(id int64, login string) map[string]any {
+	return map[string]any{"id": id, "account": map[string]any{"login": login}}
+}
+
+func TestDiscoverInstallationID(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    discoveryServerOpts
+		org     string
+		wantID  int64
+		wantErr bool
+		// wantNoInstall asserts the error is the authoritative
+		// "not installed" sentinel, not a transient failure.
+		wantNoInstall bool
+	}{
+		{
+			name: "direct org lookup succeeds",
+			opts: discoveryServerOpts{
+				orgInstall: map[string]int64{"open-source": 99887},
+			},
+			org:    "open-source",
+			wantID: 99887,
+		},
+		{
+			name: "falls back to listing when direct lookup 404s",
+			opts: discoveryServerOpts{
+				listInstalls: []map[string]any{
+					installEntry(41414, "Andrew-Anderson"),
+					installEntry(55555, "open-source"),
+				},
+			},
+			org:    "open-source",
+			wantID: 55555,
+		},
+		{
+			name: "listing match is case-insensitive",
+			opts: discoveryServerOpts{
+				listInstalls: []map[string]any{installEntry(77777, "Open-Source")},
+			},
+			org:    "open-source",
+			wantID: 77777,
+		},
+		{
+			name: "falls back to listing when direct lookup 405s (old GHE)",
+			opts: discoveryServerOpts{
+				orgInstallCode: http.StatusMethodNotAllowed,
+				listInstalls:   []map[string]any{installEntry(31337, "katamari")},
+			},
+			org:    "katamari",
+			wantID: 31337,
+		},
+		{
+			name: "no matching installation leaves nothing to adopt",
+			opts: discoveryServerOpts{
+				listInstalls: []map[string]any{
+					installEntry(41414, "Andrew-Anderson"),
+					installEntry(1, "someone-else"),
+				},
+			},
+			org:           "open-source",
+			wantErr:       true,
+			wantNoInstall: true,
+		},
+		{
+			name: "empty installation list is not a match",
+			opts: discoveryServerOpts{
+				listInstalls: []map[string]any{},
+			},
+			org:           "open-source",
+			wantErr:       true,
+			wantNoInstall: true,
+		},
+		{
+			name: "nil entries in the listing are skipped, not dereferenced",
+			opts: discoveryServerOpts{
+				listInstalls: []map[string]any{
+					nil,
+					installEntry(4242, "open-source"),
+				},
+			},
+			org:    "open-source",
+			wantID: 4242,
+		},
+		{
+			name: "api failure fails soft with an error and no id",
+			opts: discoveryServerOpts{
+				listStatus: http.StatusInternalServerError,
+			},
+			org:     "open-source",
+			wantErr: true,
+			// A 500 is transient — it must NOT be reported as
+			// authoritative "not installed".
+			wantNoInstall: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ResetInstallationDiscoveryCache()
+			srv := newDiscoveryServer(t, tc.opts, nil)
+			auth := &AppAuth{
+				appID: 5686, installationID: 41414,
+				key: discoveryTestKey(t), logger: discoveryTestLogger(),
+				apiURL: srv.URL,
+			}
+			id, err := auth.DiscoverInstallationID(context.Background(), tc.org)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got id %d", id)
+				}
+				if id != 0 {
+					t.Errorf("id = %d on error, want 0 so the caller leaves config untouched", id)
+				}
+				if got := errors.Is(err, ErrNoInstallationForOrg); got != tc.wantNoInstall {
+					t.Errorf("errors.Is(ErrNoInstallationForOrg) = %v, want %v (err: %v)", got, tc.wantNoInstall, err)
+				}
+				// The configured (wrong) ID must be untouched.
+				if auth.InstallationID() != 41414 {
+					t.Errorf("installationID mutated to %d on a failed discovery", auth.InstallationID())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("DiscoverInstallationID: %v", err)
+			}
+			if id != tc.wantID {
+				t.Errorf("id = %d, want %d", id, tc.wantID)
+			}
+		})
+	}
+}
+
+// A direct lookup that somehow answers with a different account must be
+// rejected: adopting a plausible-but-wrong ID reproduces the exact 403 this
+// feature exists to cure.
+func TestDiscoverInstallationID_RejectsMismatchedAccount(t *testing.T) {
+	ResetInstallationDiscoveryCache()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":      41414,
+			"account": map[string]any{"login": "Andrew-Anderson"},
+		})
+	}))
+	defer srv.Close()
+
+	auth := &AppAuth{
+		appID: 5686, installationID: 41414,
+		key: discoveryTestKey(t), logger: discoveryTestLogger(), apiURL: srv.URL,
+	}
+	id, err := auth.DiscoverInstallationID(context.Background(), "open-source")
+	if err == nil {
+		t.Fatalf("expected rejection, got id %d", id)
+	}
+	if !errors.Is(err, ErrNoInstallationForOrg) {
+		t.Errorf("err = %v, want ErrNoInstallationForOrg", err)
+	}
+	if id != 0 {
+		t.Errorf("id = %d, want 0", id)
+	}
+}
+
+// A missing private key is not a discovery failure — the hive simply is not
+// App-authenticated and callers must skip it.
+func TestDiscoverInstallationID_MissingKeyIsSkipped(t *testing.T) {
+	ResetInstallationDiscoveryCache()
+	auth := &AppAuth{appID: 1, logger: discoveryTestLogger()}
+	if auth.HasKey() {
+		t.Fatal("HasKey() = true with no key")
+	}
+	id, err := auth.DiscoverInstallationID(context.Background(), "open-source")
+	if err == nil {
+		t.Fatal("expected an error explaining the key is absent")
+	}
+	if id != 0 {
+		t.Errorf("id = %d, want 0", id)
+	}
+
+	// The self-heal entry point must treat it as a silent no-op, NOT an error.
+	newID, err := auth.RediscoverAndAdopt(context.Background(), "open-source", discoveryTestLogger())
+	if err != nil {
+		t.Errorf("RediscoverAndAdopt with no key returned error %v, want nil (skip silently)", err)
+	}
+	if newID != 0 {
+		t.Errorf("newID = %d, want 0", newID)
+	}
+
+	var nilAuth *AppAuth
+	if _, err := nilAuth.RediscoverAndAdopt(context.Background(), "open-source", discoveryTestLogger()); err != nil {
+		t.Errorf("nil AppAuth RediscoverAndAdopt returned %v, want nil", err)
+	}
+}
+
+// The result is cached so the self-heal loop cannot hammer the API on every
+// beat — including the negative "not installed on this org" result.
+func TestDiscoverInstallationID_CachesResult(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opts discoveryServerOpts
+	}{
+		{"positive", discoveryServerOpts{orgInstall: map[string]int64{"open-source": 900}}},
+		{"negative", discoveryServerOpts{listInstalls: []map[string]any{installEntry(1, "nope")}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ResetInstallationDiscoveryCache()
+			var hits int64
+			srv := newDiscoveryServer(t, tc.opts, &hits)
+			auth := &AppAuth{
+				appID: 5686, installationID: 41414,
+				key: discoveryTestKey(t), logger: discoveryTestLogger(), apiURL: srv.URL,
+			}
+			for i := 0; i < 5; i++ {
+				auth.DiscoverInstallationID(context.Background(), "open-source")
+			}
+			first := atomic.LoadInt64(&hits)
+			if first == 0 {
+				t.Fatal("no API calls at all — server never exercised")
+			}
+			// Whatever the first attempt cost (1 direct, or 1 direct + 1 list),
+			// it must not scale with the number of calls.
+			if first > 2 {
+				t.Errorf("hit the API %d times for 5 calls, want <= 2 (TTL cache)", first)
+			}
+		})
+	}
+}
+
+// GHE base URLs must be honoured — discovery must never touch api.github.com.
+func TestDiscoverInstallationID_HonoursGHEBaseURL(t *testing.T) {
+	ResetInstallationDiscoveryCache()
+	var gotPaths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPaths = append(gotPaths, r.URL.Path)
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":      777,
+			"account": map[string]any{"login": "open-source"},
+		})
+	}))
+	defer srv.Close()
+
+	// Mirror the osscar hive: a GHE API URL with the /api/v3 path prefix.
+	auth := &AppAuth{
+		appID: 5686, installationID: 41414,
+		key: discoveryTestKey(t), logger: discoveryTestLogger(),
+		apiURL: srv.URL + "/api/v3",
+	}
+	id, err := auth.DiscoverInstallationID(context.Background(), "open-source")
+	if err != nil {
+		t.Fatalf("DiscoverInstallationID: %v", err)
+	}
+	if id != 777 {
+		t.Errorf("id = %d, want 777", id)
+	}
+	if len(gotPaths) == 0 {
+		t.Fatal("no request reached the GHE test server")
+	}
+	if !strings.HasPrefix(gotPaths[0], "/api/v3/") {
+		t.Errorf("request path = %q, want the GHE /api/v3 prefix (base URL not honoured)", gotPaths[0])
+	}
+}
+
+// The live osscar case end to end: installation 41414 belongs to
+// "Andrew-Anderson", the App IS installed on "open-source" as 55555, so the
+// hive must adopt 55555.
+func TestRediscoverAndAdopt_WrongAccountIsCorrected(t *testing.T) {
+	ResetInstallationDiscoveryCache()
+	srv := newDiscoveryServer(t, discoveryServerOpts{
+		getInstallation: map[string]any{
+			"id":          41414,
+			"account":     map[string]any{"login": "Andrew-Anderson"},
+			"permissions": map[string]any{"issues": "write"},
+		},
+		orgInstall: map[string]int64{"open-source": 55555},
+	}, nil)
+
+	dir := t.TempDir()
+	cachePath := filepath.Join(dir, "token.cache")
+	if err := os.WriteFile(cachePath, []byte("stale-token"), 0o600); err != nil {
+		t.Fatalf("seeding token cache: %v", err)
+	}
+
+	auth := &AppAuth{
+		appID: 5686, installationID: 41414,
+		key: discoveryTestKey(t), logger: discoveryTestLogger(),
+		apiURL: srv.URL, cachePath: cachePath,
+		cachedToken: "stale-token",
+	}
+
+	newID, err := auth.RediscoverAndAdopt(context.Background(), "open-source", discoveryTestLogger())
+	if err != nil {
+		t.Fatalf("RediscoverAndAdopt: %v", err)
+	}
+	if newID != 55555 {
+		t.Fatalf("newID = %d, want 55555", newID)
+	}
+	if auth.InstallationID() != 55555 {
+		t.Errorf("installationID = %d, want 55555 adopted in place", auth.InstallationID())
+	}
+	// The cached token was minted for the WRONG installation and would keep
+	// 403ing on writes — it must be dropped, in memory and on disk.
+	if auth.cachedToken != "" {
+		t.Errorf("cachedToken = %q, want cleared after adopting a new installation", auth.cachedToken)
+	}
+	if _, err := os.Stat(cachePath); !os.IsNotExist(err) {
+		t.Errorf("stale on-disk token cache still present (stat err %v)", err)
+	}
+}
+
+// When the installation already belongs to the right account, nothing changes
+// and no discovery call is made.
+func TestRediscoverAndAdopt_CorrectAccountIsLeftAlone(t *testing.T) {
+	ResetInstallationDiscoveryCache()
+	srv := newDiscoveryServer(t, discoveryServerOpts{
+		getInstallation: map[string]any{
+			"id":          55555,
+			"account":     map[string]any{"login": "open-source"},
+			"permissions": map[string]any{"issues": "write"},
+		},
+		// A direct lookup would answer with a DIFFERENT id; if it is ever
+		// consulted here, the assertion below catches it.
+		orgInstall: map[string]int64{"open-source": 12345},
+	}, nil)
+
+	auth := &AppAuth{
+		appID: 5686, installationID: 55555,
+		key: discoveryTestKey(t), logger: discoveryTestLogger(), apiURL: srv.URL,
+	}
+	newID, err := auth.RediscoverAndAdopt(context.Background(), "open-source", discoveryTestLogger())
+	if err != nil {
+		t.Fatalf("RediscoverAndAdopt: %v", err)
+	}
+	if newID != 0 {
+		t.Errorf("newID = %d, want 0 (no change)", newID)
+	}
+	if auth.InstallationID() != 55555 {
+		t.Errorf("installationID = %d, want 55555 unchanged", auth.InstallationID())
+	}
+}
+
+// Wrong account, but the App is genuinely not installed on the target org:
+// leave the config untouched so the existing "check your installation_id"
+// banner stands.
+func TestRediscoverAndAdopt_NoInstallationLeavesConfigUntouched(t *testing.T) {
+	ResetInstallationDiscoveryCache()
+	srv := newDiscoveryServer(t, discoveryServerOpts{
+		getInstallation: map[string]any{
+			"id":      41414,
+			"account": map[string]any{"login": "Andrew-Anderson"},
+		},
+		listInstalls: []map[string]any{installEntry(41414, "Andrew-Anderson")},
+	}, nil)
+
+	auth := &AppAuth{
+		appID: 5686, installationID: 41414,
+		key: discoveryTestKey(t), logger: discoveryTestLogger(), apiURL: srv.URL,
+	}
+	newID, err := auth.RediscoverAndAdopt(context.Background(), "open-source", discoveryTestLogger())
+	if err == nil {
+		t.Fatal("expected an error reporting the app is not installed on the org")
+	}
+	if !errors.Is(err, ErrNoInstallationForOrg) {
+		t.Errorf("err = %v, want ErrNoInstallationForOrg", err)
+	}
+	if newID != 0 {
+		t.Errorf("newID = %d, want 0", newID)
+	}
+	if auth.InstallationID() != 41414 {
+		t.Errorf("installationID = %d, want the configured 41414 left untouched", auth.InstallationID())
+	}
+}
+
+// A verification failure (API down) must never cause a guess.
+func TestRediscoverAndAdopt_VerifyFailureNeverGuesses(t *testing.T) {
+	ResetInstallationDiscoveryCache()
+	auth := &AppAuth{
+		appID: 5686, installationID: 41414,
+		key: discoveryTestKey(t), logger: discoveryTestLogger(),
+		apiURL: "http://127.0.0.1:1", // connection refused
+	}
+	newID, err := auth.RediscoverAndAdopt(context.Background(), "open-source", discoveryTestLogger())
+	if err == nil {
+		t.Fatal("expected a verification error")
+	}
+	if newID != 0 || auth.InstallationID() != 41414 {
+		t.Errorf("newID = %d, installationID = %d — must not change when verification fails",
+			newID, auth.InstallationID())
+	}
+}
+
+// An empty org means we have nothing to match against — never guess.
+func TestRediscoverAndAdopt_EmptyOrgIsNoOp(t *testing.T) {
+	ResetInstallationDiscoveryCache()
+	auth := &AppAuth{
+		appID: 1, installationID: 2,
+		key: discoveryTestKey(t), logger: discoveryTestLogger(),
+	}
+	newID, err := auth.RediscoverAndAdopt(context.Background(), "  ", discoveryTestLogger())
+	if err != nil || newID != 0 {
+		t.Errorf("newID = %d, err = %v — want a silent no-op", newID, err)
+	}
+	if _, err := auth.DiscoverInstallationID(context.Background(), ""); err == nil {
+		t.Error("expected an error for an empty target org")
+	}
+}

--- a/v2/pkg/hub/github_host_backfill_test.go
+++ b/v2/pkg/hub/github_host_backfill_test.go
@@ -1,0 +1,86 @@
+package hub
+
+import "testing"
+
+// The vllm-d gap: placeholders provisioned before their cluster gained GHE
+// settings never inherit them, so the heartbeat pushes an empty API URL and
+// the spoke keeps api.github.com plus the public app_id.
+func TestBackfillGitHubHostFromCluster(t *testing.T) {
+	gheCluster := &ClusterConfig{
+		GitHubBaseURL: "https://github.ibm.com",
+		GitHubAPIURL:  "https://github.ibm.com/api/v3",
+	}
+	publicCluster := &ClusterConfig{}
+
+	tests := []struct {
+		name    string
+		hive    *SaaSHive
+		cluster *ClusterConfig
+		want    string
+	}{
+		{
+			name:    "blank host on a GHE cluster is backfilled",
+			hive:    &SaaSHive{},
+			cluster: gheCluster,
+			want:    "github.ibm.com",
+		},
+		{
+			name:    "existing host is never overwritten",
+			hive:    &SaaSHive{GitHubHost: "github.example.com"},
+			cluster: gheCluster,
+			want:    "",
+		},
+		{
+			name:    "explicit public override stays public",
+			hive:    &SaaSHive{GitHubBaseURL: githubHostPublic},
+			cluster: gheCluster,
+			want:    "",
+		},
+		{
+			name:    "hive-level GHE override wins over the cluster default",
+			hive:    &SaaSHive{GitHubBaseURL: "https://ghe.other.com"},
+			cluster: gheCluster,
+			want:    "ghe.other.com",
+		},
+		{
+			name:    "public cluster has nothing to backfill",
+			hive:    &SaaSHive{},
+			cluster: publicCluster,
+			want:    "",
+		},
+		{
+			name:    "nil cluster is a no-op",
+			hive:    &SaaSHive{},
+			cluster: nil,
+			want:    "",
+		},
+		{
+			name:    "nil hive is a no-op",
+			hive:    nil,
+			cluster: gheCluster,
+			want:    "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := backfillGitHubHostFromCluster(tc.hive, tc.cluster); got != tc.want {
+				t.Errorf("backfillGitHubHostFromCluster = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The backfilled host must be what actually drives the heartbeat's API URL.
+func TestBackfilledHostProducesGHEAPIURL(t *testing.T) {
+	host := backfillGitHubHostFromCluster(&SaaSHive{}, &ClusterConfig{
+		GitHubBaseURL: "https://github.ibm.com",
+	})
+	if got := gheAPIURLForHost(host); got != "https://github.ibm.com/api/v3" {
+		t.Errorf("gheAPIURLForHost(%q) = %q, want https://github.ibm.com/api/v3", host, got)
+	}
+	// And a public hive must still push nothing.
+	if got := gheAPIURLForHost(backfillGitHubHostFromCluster(&SaaSHive{}, &ClusterConfig{})); got != "" {
+		t.Errorf("public hive pushed API URL %q, want empty", got)
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -5283,6 +5283,20 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	if body.GitHubHost != "" {
 		h.GitHubHost = body.GitHubHost
 	}
+	// Backfill the host from the hive's cluster when neither the request nor
+	// the placeholder carries one. Placeholders provisioned BEFORE their
+	// cluster gained github_base_url/github_api_url have GitHubHost == "", and
+	// nothing else ever fills it in: projectConfigForHiveID pushes
+	// gheAPIURLForHost(h.GitHubHost), which is empty for those hives, so the
+	// spoke keeps api.github.com and the public app_id even though the cluster
+	// is a GHE cluster (observed on vllm-d: hosted-available-vllmd-01 has
+	// base_url: "" / api_url: "" against a github.ibm.com cluster). The hive's
+	// own value always wins; this only fills a blank.
+	if host := backfillGitHubHostFromCluster(h, s.clusterForHive(h)); host != "" {
+		h.GitHubHost = host
+		s.logger.Info("backfilled hive github host from cluster defaults",
+			"hive", hiveID, "github_host", host)
+	}
 	h.Repos = repos
 	h.PrimaryRepo = primaryRepo
 	if body.ProjectName != "" {

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -385,6 +385,32 @@ func effectiveGitHubAPIURL(h *SaaSHive, cluster *ClusterConfig) string {
 	}
 }
 
+// backfillGitHubHostFromCluster returns the GitHub host a hive should inherit
+// from its cluster, or "" when there is nothing to fill in.
+//
+// A hive's GitHubHost is otherwise only ever set from an explicitly pasted
+// org URL at assign time. Placeholders provisioned BEFORE their cluster gained
+// github_base_url/github_api_url therefore keep GitHubHost == "" forever, and
+// projectConfigForHiveID pushes gheAPIURLForHost("") == "" on every heartbeat
+// — which the spoke reads as "leave mine alone". The result is a hive on a GHE
+// cluster still pointing at api.github.com with the public app_id (observed on
+// vllm-d: hosted-available-vllmd-01 in org "katamari" has base_url: "",
+// api_url: "", app_id: 3568013 against a github.ibm.com cluster).
+//
+// This only ever fills a blank: a hive that already carries a host — including
+// an explicit "public" override, which effectiveGitHubBaseURL resolves to ""
+// — is returned unchanged.
+func backfillGitHubHostFromCluster(h *SaaSHive, cluster *ClusterConfig) string {
+	if h == nil || h.GitHubHost != "" || cluster == nil {
+		return ""
+	}
+	base := effectiveGitHubBaseURL(h, cluster)
+	if base == "" {
+		return "" // public github.com — nothing to record
+	}
+	return githubHostLabel(base)
+}
+
 func generateHiveID(org, repo string) string {
 	short := repo
 	if len(short) > 12 {


### PR DESCRIPTION
## The bug this fixes

`hosted-open-source-osscar-appli-rc57` (org `open-source`, repo `osscar-application`, on GHE `github.ibm.com`) fails **every** write. Its own logs already say exactly why:

> `github app recheck: app detected but write not verified` — *"This hive is authenticating as GitHub App installation 41414, which belongs to 'Andrew-Anderson' — not 'open-source'. Check github.installation_id in the hive config."*

The App (`app_id: 5686`) and the host are correct; only `installation_id: 41414` points at a personal-account installation. The resulting `403 Resource not accessible by integration` **reads** like a permissions problem but is not — adding permissions would not fix it. Until now the only remedy was hand-editing the config.

## What this adds

`pkg/github/app_discovery.go` — `DiscoverInstallationID(ctx, org)`, which resolves the installation covering a target org using the **App JWT** (so it works even when the configured installation is the wrong one):

| endpoint | role |
|---|---|
| `GET /orgs/{org}/installation` | **preferred.** One call, authoritative — GitHub resolves the org, so there is no login-matching for us to get wrong. |
| `GET /app/installations` | fallback. Walks the list and matches the account login case-insensitively. Covers older GHE (405 on the org endpoint) and user-account targets. |

Both go through the existing `setBaseURL(client, a.apiURL)` pattern, so **GitHub Enterprise is honoured** and `api.github.com` is never assumed.

### It refuses to guess

A plausible-but-wrong ID reproduces exactly the confusing 403 this exists to cure, so:

- an installation whose account is not the target org is **rejected**, even when the direct lookup returned it;
- ambiguity or absence yields `ErrNoInstallationForOrg`, the config is left **untouched**, and the existing "check `github.installation_id`" banner still stands;
- a verification failure (API down) never triggers an adoption.

### It fails soft and stays cheap

- Results — **including negative ones** — are memoised for `InstallationDiscoveryTTL` (**1 hour**). The negative case is the one that matters: without it, a hive whose App genuinely is not installed on its org would re-discover on every self-heal tick forever.
- Bounded by `discoveryTimeout` (30s) and `discoveryMaxPages` (10 × 100).
- **A missing private key is not a failure** — that hive simply is not App-authenticated, so it is skipped silently.
- No discovery failure can break agent startup or a heartbeat.

### Self-heal and persistence

`RediscoverAndAdopt` **reuses the existing `VerifyInstallation`** to confirm the wrong-account case before acting (no duplicated detection), adopts the correct ID in place, and drops the cached installation token — in memory *and* on disk — because that token was minted for the wrong installation and would keep 403ing.

`cmd/hive` wires it via `healGitHubAppInstallation`, which persists the corrected ID through `cfg.Save()` → the `/data/hive.yaml.dashboard` PVC overlay, the same path the heartbeat project-config adoption already uses, so the fix survives a pod restart. It runs in three places:

1. **at App-auth startup**, before the client is built, so the first token minted is already correctly scoped;
2. **on hub-delivered App creds** over the heartbeat (those can carry a wrong ID just as easily as a hand-edited config);
3. **before the recheck path reports a wrong-account diagnosis** — the exact moment the problem is detected.

## Also: the vllm-d cluster-settings inheritance gap

Investigated as requested, and included because the fix is one small, clearly-correct block.

A hive's `GitHubHost` is only ever set from an **explicitly pasted org URL** at assign time. A placeholder provisioned *before* its cluster gained `github_base_url`/`github_api_url` therefore keeps `GitHubHost == ""` forever — nothing backfills it. `projectConfigForHiveID` then pushes `gheAPIURLForHost("") == ""` on every heartbeat, which the spoke correctly reads as *"leave mine alone"*.

That is precisely why `hosted-available-vllmd-01` (org `katamari`) still runs with `base_url: ""`, `api_url: ""` and the **public** `app_id: 3568013` against a `github.ibm.com` cluster. `effectiveGitHubBaseURL`/`effectiveGitHubAPIURL` already implement the intended hive→cluster→public precedence; `handleAssignHive` just never consulted them for the host.

`backfillGitHubHostFromCluster` fills the blank at assign time. It **only ever fills a blank** — an existing host wins, and an explicit `public` override stays public.

## Tests

Table-driven against `httptest` servers, never the real API:

- direct org lookup succeeds
- falls back to listing on 404 and on 405 (old GHE)
- listing match is case-insensitive
- nil entries in the listing are skipped, not dereferenced
- no matching installation → config untouched, `ErrNoInstallationForOrg`
- direct lookup returning a mismatched account → rejected
- API 500 → fails soft, and is *not* reported as authoritative "not installed"
- missing private key → skipped (and `RediscoverAndAdopt` returns nil, not an error)
- result is cached — 5 calls cost ≤ 2 API hits, for positive *and* negative outcomes
- GHE `/api/v3` base URL honoured
- the osscar case end to end: 41414/`Andrew-Anderson` → 55555/`open-source` adopted, stale token cache dropped
- correct account → left alone, no discovery call
- verification failure → never guesses
- GitHub-host backfill precedence table

`go build ./...`, `go vet ./...`, and the full `./pkg/github/` and `./pkg/hub/` suites pass. `./pkg/agent/` was not touched, so it was not run.

## Does osscar self-heal?

**Only if the App is actually installed on the `open-source` org.**

- If it is: yes. On the next start (or the next re-check tick) the hive verifies installation 41414, sees it belongs to `Andrew-Anderson` and not `open-source`, discovers the real `open-source` installation, adopts it, drops the stale token, and persists the corrected ID to the PVC overlay.
- If it is not: the hive **deliberately changes nothing**. Discovery returns `ErrNoInstallationForOrg`, `installation_id` stays as configured, and the existing "installation 41414 belongs to 'Andrew-Anderson' — not 'open-source'" banner keeps telling the operator what to fix. Someone must install App 5686 on the `open-source` org on `github.ibm.com` first.

I could not verify which of those two is true — that requires the GHE App JWT, which I do not have.

## Verified vs assumed

**Verified:** the code paths and their wiring; that `cfg.Save()` writes the PVC overlay and that the overlay includes `app_id`/`installation_id`; that `GitHubHost` has no backfill path today; that `projectConfigForHiveID` derives the pushed API URL solely from `h.GitHubHost`; all behaviour covered by the tests above, against `httptest`.

**Assumed (not exercised against real infrastructure):** that `github.ibm.com` implements `GET /orgs/{org}/installation` — this is why the listing fallback exists and is tested; and the current live state of the osscar and vllm-d hives, which is taken from the incident report rather than re-derived.

Not merged, per instructions.