### PR TITLE
🐛 fix(hub): unstick "Loading your hives..." and trim the my-hives payload 92%

### DIFF
--- a/v2/pkg/hub/dashboard_js_structure_test.go
+++ b/v2/pkg/hub/dashboard_js_structure_test.go
@@ -1,0 +1,186 @@
+package hub
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The "Loading your hives..." outage was NOT a syntax error — every <script>
+// block in dashboardHTML parsed cleanly with `node --check`. A dropped closing
+// brace on renderAlertRows silently swallowed ~13 KB of code (including
+// _dashSearchQuery, _dashFacets and applyDashFilters) into that function's
+// body. The file still parsed; those declarations simply became function-local,
+// so renderHives() threw ReferenceError at runtime and the spinner never left.
+//
+// A brace-balance check over each script block catches that whole class of
+// defect, which node --check cannot: nesting is legal JavaScript.
+func TestDashboardScriptBracesAreBalanced(t *testing.T) {
+	for i, block := range dashboardScriptBlocks(t) {
+		if depth := braceDepth(block); depth != 0 {
+			t.Errorf("script block %d ends at brace depth %d, want 0 — "+
+				"an unbalanced brace nests later top-level declarations inside "+
+				"an earlier function and breaks the dashboard at runtime", i, depth)
+		}
+	}
+}
+
+// Declarations the render path depends on must be reachable as top-level
+// statements. Anchoring on column 4 ("    var x") is how the file is
+// formatted for genuinely top-level inline-script declarations; anything
+// swallowed into a function body is indented further.
+func TestDashboardRenderStateIsTopLevel(t *testing.T) {
+	names := []string{
+		"_dashSearchQuery",
+		"_dashFacets",
+		"_dashFacetCollapsed",
+		"_dashSectionCollapsed",
+		"_allDashHives",
+	}
+	for _, n := range names {
+		t.Run(n, func(t *testing.T) {
+			re := regexp.MustCompile(`(?m)^ {4}var ` + regexp.QuoteMeta(n) + `\b`)
+			if !re.MatchString(dashboardHTML) {
+				t.Errorf("var %s is not declared at top level of the inline script; "+
+					"renderHives() will throw ReferenceError at runtime", n)
+			}
+		})
+	}
+}
+
+func TestDashboardRenderFunctionsAreTopLevel(t *testing.T) {
+	names := []string{
+		"renderAlertRows",
+		"applyDashFilters",
+		"renderFacetRail",
+		"renderHives",
+		"renderHivesError",
+		"paintCachedHives",
+	}
+	for _, n := range names {
+		t.Run(n, func(t *testing.T) {
+			re := regexp.MustCompile(`(?m)^ {4}function ` + regexp.QuoteMeta(n) + `\(`)
+			if !re.MatchString(dashboardHTML) {
+				t.Errorf("function %s is not declared at top level of the inline script", n)
+			}
+		})
+	}
+}
+
+// dashboardScriptBlocks returns the body of every <script> element in
+// dashboardHTML. Built without a literal closing-script tag in source.
+func dashboardScriptBlocks(t *testing.T) []string {
+	t.Helper()
+	open := regexp.MustCompile(`(?s)<script[^>]*>`)
+	closeTag := "</" + "script>"
+	var out []string
+	rest := dashboardHTML
+	for {
+		loc := open.FindStringIndex(rest)
+		if loc == nil {
+			break
+		}
+		rest = rest[loc[1]:]
+		end := strings.Index(rest, closeTag)
+		if end < 0 {
+			t.Fatalf("unterminated script element in dashboardHTML")
+		}
+		out = append(out, rest[:end])
+		rest = rest[end+len(closeTag):]
+	}
+	if len(out) == 0 {
+		t.Fatal("no script blocks found in dashboardHTML")
+	}
+	return out
+}
+
+// braceDepth counts { and } outside string literals, comments and regex
+// literals. It is deliberately conservative: it only needs to be exact enough
+// that a genuinely balanced block returns 0.
+func braceDepth(src string) int {
+	depth := 0
+	var inStr byte    // quote char when inside a string
+	inLineComment := false
+	inBlockComment := false
+	inRegex := false
+	// prev is the last significant character, used to tell a regex literal
+	// from a division operator.
+	var prev byte
+	for i := 0; i < len(src); i++ {
+		c := src[i]
+		switch {
+		case inLineComment:
+			if c == '\n' {
+				inLineComment = false
+			}
+			continue
+		case inBlockComment:
+			if c == '*' && i+1 < len(src) && src[i+1] == '/' {
+				inBlockComment = false
+				i++
+			}
+			continue
+		case inStr != 0:
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == inStr {
+				inStr = 0
+			}
+			continue
+		case inRegex:
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == '[' {
+				// Character class: a '/' inside it does not close the regex.
+				for i++; i < len(src); i++ {
+					if src[i] == '\\' {
+						i++
+						continue
+					}
+					if src[i] == ']' {
+						break
+					}
+				}
+				continue
+			}
+			if c == '/' {
+				inRegex = false
+			}
+			continue
+		}
+		switch c {
+		case '/':
+			if i+1 < len(src) && src[i+1] == '/' {
+				inLineComment = true
+				i++
+				continue
+			}
+			if i+1 < len(src) && src[i+1] == '*' {
+				inBlockComment = true
+				i++
+				continue
+			}
+			// A '/' starting a regex can only follow an operator or opening
+			// bracket — never a value-producing token.
+			if prev == 0 || strings.IndexByte("(,=:[!&|?{};+-*~^%<>", prev) >= 0 {
+				inRegex = true
+				continue
+			}
+		case '\'', '"', '`':
+			inStr = c
+			continue
+		case '{':
+			depth++
+		case '}':
+			depth--
+		}
+		if c != ' ' && c != '\t' && c != '\n' && c != '\r' {
+			prev = c
+		}
+	}
+	return depth
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1730,6 +1730,14 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		st := s.journey.get(result[i].ID)
 		status := JourneyStatusFor(&result[i].RegistryEntry, st, journeyNow)
 		result[i].Journey = &status
+
+		// Sparkline history dominated this payload: at 42 hives the two series
+		// were ~755 KB of an 818 KB response (92%), yet they are drawn into a
+		// 50 px-wide SVG. Downsample on the WIRE only — the registry keeps the
+		// full 7-day series, so nothing is lost server-side and a future
+		// full-resolution view can still fetch it per hive.
+		result[i].IssueHistory = downsampleSpark(result[i].IssueHistory, sparkWirePoints)
+		result[i].PRHistory = downsampleSpark(result[i].PRHistory, sparkWirePoints)
 	}
 
 	resp := map[string]any{
@@ -6743,6 +6751,82 @@ const dashboardHTML = `<!DOCTYPE html>
     var _lastHivesJSON = '';
     var _lastUsersJSON = '';
 
+    /* ── Instant-paint cache for the hive list ──
+       A returning operator used to stare at "Loading your hives..." for the
+       whole round-trip. We persist the last good list and paint it on load,
+       then reconcile when the fresh payload lands.
+
+       Bounded and versioned on purpose:
+       - HIVES_CACHE_TTL_MS keeps a stale fleet from being presented as current.
+       - HIVES_CACHE_VERSION is bumped whenever the row shape changes, so an
+         old-shaped cache can never be rendered by new code (that would
+         reintroduce exactly the class of render crash this fixes).
+       Reads NEVER throw: storage can be disabled, full, or hold junk, and none
+       of that may block the network path. */
+    var LS_HIVES_CACHE = 'hive-my-hives-cache';
+    /* Bump on ANY change to the hive row shape consumed by renderHives(). */
+    var HIVES_CACHE_VERSION = 1;
+    /* 10 minutes: long enough to cover a reload or a tab restore, short enough
+       that a cached fleet is never wildly out of date before the poll lands. */
+    var HIVES_CACHE_TTL_MS = 10 * 60 * 1000;
+    /* Cap what we persist. Only the fields renderHives() needs for the first
+       paint are stored, but a huge fleet could still overflow the ~5 MB quota
+       and make every write fail. */
+    var HIVES_CACHE_MAX_ROWS = 200;
+
+    function readHivesCache() {
+      try {
+        var raw = window.localStorage.getItem(LS_HIVES_CACHE);
+        if (!raw) return null;
+        var c = JSON.parse(raw);
+        if (!c || c.version !== HIVES_CACHE_VERSION) return null;
+        if (!c.savedAt || (Date.now() - c.savedAt) > HIVES_CACHE_TTL_MS) return null;
+        if (!Array.isArray(c.hives) || !c.hives.length) return null;
+        return c;
+      } catch (e) {
+        /* Disabled/!full/corrupt storage must never break the load path. */
+        console.warn('[hive] hive cache read failed, using network only:', e);
+        return null;
+      }
+    }
+
+    function writeHivesCache(hives) {
+      try {
+        var rows = (hives || []).slice(0, HIVES_CACHE_MAX_ROWS);
+        window.localStorage.setItem(LS_HIVES_CACHE, JSON.stringify({
+          version: HIVES_CACHE_VERSION,
+          savedAt: Date.now(),
+          hives: rows
+        }));
+      } catch (e) {
+        /* Quota errors are expected on large fleets — caching is best-effort. */
+        console.warn('[hive] hive cache write failed:', e);
+      }
+    }
+
+    /* Paint the cached fleet before the first request returns. Guarded so any
+       failure (including a stale-shaped row slipping past the version check)
+       falls back to the normal spinner + network path rather than killing
+       init(). */
+    function paintCachedHives() {
+      var c = readHivesCache();
+      if (!c) return false;
+      try {
+        _allDashHives = c.hives;
+        _hiveRegistry = c.hives;
+        renderHives(sortedDashHives(), true);
+        return true;
+      } catch (e) {
+        console.error('[hive] cached render failed, falling back to network:', e);
+        _allDashHives = [];
+        _hiveRegistry = [];
+        _lastHivesJSON = '';
+        var container = document.getElementById('hives-container');
+        if (container) container.innerHTML = '<div class="loading">Loading your hives...</div>';
+        return false;
+      }
+    }
+
     /* Active status filters, keyed by HIVE_FILTER_*. Multi-select: several may
        be on at once and a hive matches if it satisfies ANY active one (OR), so
        turning on more chips widens the list rather than narrowing it to nothing
@@ -7480,6 +7564,7 @@ const dashboardHTML = `<!DOCTYPE html>
           (rows.length - ALERT_ROWS_SHOWN) + ' more</div>'
         : '';
       return '<div class="alert-rows">' + html + more + '</div>';
+    }
 
     /* ── Free-text search over the hive list ──
        OR semantics: whitespace-separated terms, a hive matches if ANY term is a
@@ -7712,7 +7797,6 @@ const dashboardHTML = `<!DOCTYPE html>
         return hiveMatchesFilters(h) && hiveMatchesAlertFilter(h) &&
           hiveMatchesSearch(h) && hiveMatchesFacets(h);
       });
-    }
     }
 
     /* toggleStatusFilter flips one chip and re-renders from the unfiltered
@@ -8216,6 +8300,10 @@ const dashboardHTML = `<!DOCTYPE html>
            back to server order every REFRESH cycle. With no sort key set this
            returns _allDashHives unchanged, i.e. the previous behaviour. */
         renderHives(sortedDashHives());
+        /* Persist AFTER a successful render: a payload we could not render must
+           never be cached, or the next page load would replay the same crash
+           from localStorage before the network could correct it. */
+        writeHivesCache(data.hives || []);
         renderPendingBanner(data.hives || []);
         renderUserAccessBanner();
         renderProvisionRequestBanner(data.my_provision_request || null);
@@ -8224,12 +8312,65 @@ const dashboardHTML = `<!DOCTYPE html>
         loadPublicHives(data.hives || []);
         loadUsage();
       } catch(e) {
-        if (!_allDashHives.length) {
-          document.getElementById('hives-container').innerHTML = '<div class="loading">Failed to load hives</div>';
-        }
+        /* Surface EVERY failure in the load→render path, not just fetch errors.
+           The old guard only painted a message when _allDashHives was empty —
+           but _allDashHives is assigned from the payload BEFORE renderHives()
+           runs, so a throw inside rendering left the container showing
+           "Loading your hives..." forever with nothing in the console. That is
+           how an unbalanced brace in the inline JS (which silently nested a
+           third of the dashboard's top-level declarations inside
+           renderAlertRows) reached production unnoticed. Never swallow: log the
+           real error AND give the operator a way to retry. */
+        console.error('[hive] my-hives load/render failed:', e);
+        renderHivesError(e);
       } finally {
         _hivesLoading = false;
       }
+    }
+
+    /* renderHivesError replaces the eternal spinner with an actionable message.
+       Written with DOM APIs + addEventListener rather than innerHTML with an
+       inline handler so the error text can never be interpreted as markup. */
+    function renderHivesError(err) {
+      var container = document.getElementById('hives-container');
+      if (!container) return;
+      /* Keep a good list on screen if we already have one — a failed refresh
+         should not blank out the fleet the operator is looking at. */
+      if (_allDashHives.length && !/Loading your hives/.test(container.innerHTML) &&
+          !container.querySelector('.hives-load-error')) {
+        return;
+      }
+      var box = document.createElement('div');
+      box.className = 'empty-state hives-load-error';
+      var title = document.createElement('p');
+      title.style.cssText = 'font-size:1.1rem;margin-bottom:8px;color:var(--red)';
+      title.textContent = 'Could not load your hives';
+      var detail = document.createElement('p');
+      detail.style.cssText = 'font-size:0.8rem;color:var(--muted);word-break:break-word';
+      detail.textContent = (err && (err.message || String(err))) || 'Unknown error';
+      var hint = document.createElement('p');
+      hint.style.cssText = 'font-size:0.75rem;color:var(--muted);opacity:0.8;margin-top:6px';
+      hint.textContent = 'Details were logged to the browser console.';
+      var wrap = document.createElement('p');
+      wrap.style.marginTop = '12px';
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'filter-chip filter-chip-clear';
+      btn.textContent = 'Retry';
+      btn.addEventListener('click', function() {
+        container.innerHTML = '<div class="loading">Loading your hives...</div>';
+        /* Force the next render past the signature short-circuit — the cached
+           signature may still match the payload that failed to render. */
+        _lastHivesJSON = '';
+        loadHives();
+      });
+      wrap.appendChild(btn);
+      box.appendChild(title);
+      box.appendChild(detail);
+      box.appendChild(hint);
+      box.appendChild(wrap);
+      container.innerHTML = '';
+      container.appendChild(box);
     }
 
     async function loadPublicHives(myHives) {
@@ -10111,6 +10252,12 @@ const dashboardHTML = `<!DOCTYPE html>
          already reflects the operator's view rather than flashing the ungrouped
          list and then rearranging. */
       loadDashViewPrefs();
+      /* Progressive paint: put the last known fleet on screen immediately so a
+         returning operator sees their hives instead of a spinner. The network
+         path below still runs unconditionally and reconciles the list; this
+         only changes what fills the gap while it is in flight. Must come after
+         loadDashViewPrefs() so the cached rows honour the active view. */
+      paintCachedHives();
       await loadUser();
       await autoRequestAccessFromUrl();
       await loadHives();

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -10,6 +10,7 @@ import (
 	"html"
 	"io"
 	"log/slog"
+	"math"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -133,6 +134,43 @@ type RegistryEntry struct {
 type SparkPoint struct {
 	T int64 `json:"t"`
 	V int   `json:"v"`
+}
+
+// sparkWirePoints is how many history points /api/saas/my-hives ships per
+// series. The registry keeps the full 7-day, 15-minute series (sparkMaxPoints
+// = 672), but the dashboard renders it into a 50x14 px SVG polyline — at 672
+// points that is ~13 points per horizontal pixel, so all but a handful are
+// invisible. 48 points keeps the shape of the trend at roughly one point per
+// pixel while cutting the two history arrays from ~755 KB to ~54 KB across a
+// 42-hive fleet (they were 92% of an 818 KB payload).
+const sparkWirePoints = 48
+
+// downsampleSpark reduces a stored series to at most sparkWirePoints for the
+// wire. It keeps the FIRST and LAST samples exactly (the sparkline's endpoints
+// are what the eye anchors on, and the last point is the current value shown
+// next to it) and picks evenly spaced samples in between. Series already at or
+// under the cap are returned unchanged, so short histories keep full detail.
+//
+// Returning a fresh slice matters: the input aliases the registry's stored
+// history, and callers marshal the result while other goroutines may append.
+func downsampleSpark(points []SparkPoint, max int) []SparkPoint {
+	if max <= 0 {
+		return nil
+	}
+	if len(points) <= max {
+		return points
+	}
+	out := make([]SparkPoint, 0, max)
+	// Spread max samples across the series, inclusive of both endpoints.
+	step := float64(len(points)-1) / float64(max-1)
+	for i := 0; i < max; i++ {
+		idx := int(math.Round(float64(i) * step))
+		if idx >= len(points) {
+			idx = len(points) - 1
+		}
+		out = append(out, points[idx])
+	}
+	return out
 }
 
 var safeNamePattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)

--- a/v2/pkg/hub/spark_downsample_test.go
+++ b/v2/pkg/hub/spark_downsample_test.go
@@ -1,0 +1,166 @@
+package hub
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// mkSpark builds a synthetic series of n points at the real 15-minute sampling
+// interval, with a value that varies per index so downsampling is observable.
+func mkSpark(n int) []SparkPoint {
+	now := time.Now().Unix()
+	s := make([]SparkPoint, n)
+	for i := range s {
+		s[i] = SparkPoint{T: now - int64((n-i)*900), V: i}
+	}
+	return s
+}
+
+func TestDownsampleSpark(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      []SparkPoint
+		max     int
+		wantLen int
+	}{
+		{"nil series stays nil", nil, sparkWirePoints, 0},
+		{"empty series stays empty", []SparkPoint{}, sparkWirePoints, 0},
+		{"single point is untouched", mkSpark(1), sparkWirePoints, 1},
+		{"under the cap is untouched", mkSpark(10), sparkWirePoints, 10},
+		{"exactly at the cap is untouched", mkSpark(sparkWirePoints), sparkWirePoints, sparkWirePoints},
+		{"one over the cap is reduced", mkSpark(sparkWirePoints + 1), sparkWirePoints, sparkWirePoints},
+		{"full 7-day series is reduced", mkSpark(672), sparkWirePoints, sparkWirePoints},
+		{"max of zero yields nothing", mkSpark(672), 0, 0},
+		{"negative max yields nothing", mkSpark(672), -1, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := downsampleSpark(tc.in, tc.max)
+			if len(got) != tc.wantLen {
+				t.Fatalf("len = %d, want %d", len(got), tc.wantLen)
+			}
+			if len(got) == 0 {
+				return
+			}
+			// Endpoints must be preserved exactly: the sparkline's first and
+			// last points anchor the trend, and the last value is the one
+			// rendered as a number beside the chart.
+			if got[0] != tc.in[0] {
+				t.Errorf("first point = %+v, want %+v", got[0], tc.in[0])
+			}
+			last := tc.in[len(tc.in)-1]
+			if got[len(got)-1] != last {
+				t.Errorf("last point = %+v, want %+v", got[len(got)-1], last)
+			}
+			// Order must be preserved — a scrambled series would draw a
+			// meaningless zig-zag.
+			for i := 1; i < len(got); i++ {
+				if got[i].T < got[i-1].T {
+					t.Fatalf("series not monotonic at %d: %d < %d", i, got[i].T, got[i-1].T)
+				}
+			}
+		})
+	}
+}
+
+// The caller marshals the result while the registry may still be appending to
+// the stored series, so a downsampled series must not alias its input.
+func TestDownsampleSparkDoesNotAliasInput(t *testing.T) {
+	in := mkSpark(672)
+	got := downsampleSpark(in, sparkWirePoints)
+	got[0].V = 999999
+	if in[0].V == 999999 {
+		t.Fatal("downsampleSpark returned a slice aliasing the caller's series")
+	}
+}
+
+// Guards the reason this exists: sparkline history was 92% of the my-hives
+// payload. If someone raises sparkWirePoints back toward sparkMaxPoints this
+// fails loudly rather than silently restoring an 800 KB response.
+func TestDownsampleSparkShrinksPayload(t *testing.T) {
+	const fleet = 42
+	full := mkSpark(672)
+	var before, after int
+	for i := 0; i < fleet; i++ {
+		b, err := json.Marshal(map[string]any{"issueHistory": full, "prHistory": full})
+		if err != nil {
+			t.Fatalf("marshal full: %v", err)
+		}
+		before += len(b)
+		a, err := json.Marshal(map[string]any{
+			"issueHistory": downsampleSpark(full, sparkWirePoints),
+			"prHistory":    downsampleSpark(full, sparkWirePoints),
+		})
+		if err != nil {
+			t.Fatalf("marshal downsampled: %v", err)
+		}
+		after += len(a)
+	}
+	reduction := 100 * (1 - float64(after)/float64(before))
+	t.Logf("history bytes across %d hives: before=%d after=%d (%.1f%% smaller)", fleet, before, after, reduction)
+	if reduction < 80 {
+		t.Errorf("history downsampling only saved %.1f%%, want >=80%% — sparkWirePoints (%d) may have crept up", reduction, sparkWirePoints)
+	}
+}
+
+// sparkWirePoints must stay well under what the registry stores, otherwise the
+// wire trim is a no-op.
+func TestSparkWirePointsBelowStoredMax(t *testing.T) {
+	const storedMax = 672 // sparkMaxPoints in handleHeartbeat
+	if sparkWirePoints >= storedMax {
+		t.Fatalf("sparkWirePoints = %d must be < stored max %d", sparkWirePoints, storedMax)
+	}
+}
+
+// The eternal-spinner regression: renderHives() threw, but loadHives' catch
+// only painted a message when _allDashHives was empty — and it is assigned
+// before the render. These assert the surfaced-error path stays wired up.
+func TestDashboardSurfacesRenderFailures(t *testing.T) {
+	tests := []struct {
+		name    string
+		snippet string
+	}{
+		{"logs the real error", "console.error('[hive] my-hives load/render failed:', e);"},
+		{"calls the error renderer", "renderHivesError(e);"},
+		{"error renderer exists", "function renderHivesError(err) {"},
+		{"offers a retry affordance", "btn.textContent = 'Retry';"},
+		{"retry clears the render signature", "_lastHivesJSON = '';"},
+		{"no longer gates on an empty list", "if (_allDashHives.length && !/Loading your hives/.test(container.innerHTML)"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(dashboardHTML, tc.snippet) {
+				t.Errorf("dashboardHTML is missing %q", tc.snippet)
+			}
+		})
+	}
+}
+
+// Instant-paint cache: must be bounded, versioned, and never throw.
+func TestDashboardHivesCacheIsBoundedAndVersioned(t *testing.T) {
+	tests := []struct {
+		name    string
+		snippet string
+	}{
+		{"cache key", "var LS_HIVES_CACHE = 'hive-my-hives-cache';"},
+		{"schema version", "var HIVES_CACHE_VERSION = 1;"},
+		{"named TTL constant", "var HIVES_CACHE_TTL_MS = 10 * 60 * 1000;"},
+		{"named row cap", "var HIVES_CACHE_MAX_ROWS = 200;"},
+		{"version is enforced on read", "if (!c || c.version !== HIVES_CACHE_VERSION) return null;"},
+		{"TTL is enforced on read", "if (!c.savedAt || (Date.now() - c.savedAt) > HIVES_CACHE_TTL_MS) return null;"},
+		{"reads cannot throw", "console.warn('[hive] hive cache read failed, using network only:', e);"},
+		{"writes cannot throw", "console.warn('[hive] hive cache write failed:', e);"},
+		{"cached render is guarded", "console.error('[hive] cached render failed, falling back to network:', e);"},
+		{"painted before the network resolves", "paintCachedHives();"},
+		{"only successful renders are cached", "writeHivesCache(data.hives || []);"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(dashboardHTML, tc.snippet) {
+				t.Errorf("dashboardHTML is missing %q", tc.snippet)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The bug

The hub dashboard was stuck on `Loading your hives...` and never rendered the list.

It was **not** a syntax error — all four `<script>` blocks in `dashboardHTML` pass `node --check`.

**Root cause:** `renderAlertRows()` was missing its closing brace (`v2/pkg/hub/saas.go:7481`), with the orphaned `}` left further down just after `applyDashFilters`. The script still parsed as valid JavaScript, but ~13 KB of code that was meant to be top-level got silently nested **inside `renderAlertRows`** — including `_dashSearchQuery`, `_dashFacets`, `_dashFacetCollapsed`, `_dashSectionCollapsed` and `applyDashFilters`.

`renderHives()` builds its cache signature from `_dashSearchQuery`, so it threw:

```
ReferenceError: _dashSearchQuery is not defined
    at renderHives (...:2560:15)
    at loadHives (...:2190:9)
```

Introduced by `2419e4c8` (#2154, search/facets/collapsible sections) — **not** by any of the more recently merged commits that were initially suspected.

## How it was reproduced

Extracted the real `dashboardHTML` and loaded it in jsdom with a production-shaped payload: 42 hives, mixed placeholders and claimed hives, rows missing `journey` / `drift` / `access` / `health` / `recentEvents`.

- Before: `#hives-container` stayed on `Loading your hives...`, **0 rows**, error swallowed.
- After: **43 rows** render.

Confirmed structurally with an AST parse — `applyDashFilters` and `_dashSearchQuery` were not top-level declarations before the fix, and are after.

## Why nobody noticed

`loadHives`' catch only painted a message when `_allDashHives` was empty — but `_allDashHives` is assigned from the payload **before** `renderHives()` runs. So any render throw left an eternal spinner *and* an empty console.

Now it logs the real error **and** surfaces an actionable message with a working **Retry** (built with DOM APIs + `addEventListener`, so error text can never be interpreted as markup). Verified end-to-end: injected a render crash, saw the message, clicked Retry, list recovered.

## Payload: 92.8% smaller

`issueHistory`/`prHistory` were ~755 KB of the 818 KB response (92%) — yet they render into a **50x14 px** SVG. At 672 stored points that is ~13 points per horizontal pixel.

The registry still stores the full 7-day / 672-point series; only the **wire** is downsampled to `sparkWirePoints = 48`, preserving both endpoints exactly (the last point is the value shown beside the chart).

| | history bytes across 42 hives |
|---|---|
| before | 1292 KB |
| after | 94 KB |
| **reduction** | **92.8%** |

## Progressive + cached

- **Progressive:** the cached fleet is painted immediately on load, before the request resolves, so a returning operator sees their hives instead of a spinner; the network path still runs and reconciles.
- **Cached:** last successful list persisted to `localStorage`. Bounded (`HIVES_CACHE_TTL_MS` = 10 min, `HIVES_CACHE_MAX_ROWS` = 200), versioned (`HIVES_CACHE_VERSION`) so a schema change can never render stale-shaped rows, and every read/write is wrapped so disabled/full/corrupt storage falls back to the network path. Only *successfully rendered* payloads are cached, so a bad payload can't replay its own crash from storage.

Verified all four cache paths in jsdom — fresh cache paints 6 rows with the network hung; stale (>TTL), old-version and corrupt-JSON each fall back cleanly to the spinner without throwing.

## Regression guards

`node --check` cannot catch this class of bug, because nesting is legal JavaScript. Added structural tests over the inline script:

- brace-balance per `<script>` block
- top-level-declaration assertions for the render state and render functions

**Verified these are not vacuous:** reintroducing the original dropped brace makes `TestDashboardScriptBracesAreBalanced` fail with `script block 2 ends at brace depth 1, want 0`.

Plus table-driven tests for the downsampler (endpoints preserved, ordering monotonic, no aliasing of the registry's slice, and a floor on the payload reduction so `sparkWirePoints` can't silently creep back up).

## Verification

- `go build ./...` — pass
- `go vet ./pkg/hub/` — pass
- `go test -count=1 -timeout 480s ./pkg/hub/` — pass (123s)
- `node --check` on all 4 extracted script blocks — pass
- jsdom render, error-path, retry, and 4 cache scenarios — pass

**Assumed, not verified:** the 818 KB / field-level byte breakdown for the live 42-hive fleet was taken from the report rather than re-measured against production; the before/after figures above are measured from a synthetic 672-point series at the same fleet size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)