### PR TITLE
✨ feat(ui): make user avatars clickable links to GitHub profiles

### DIFF
--- a/v2/pkg/dashboard/clickable_avatars_test.go
+++ b/v2/pkg/dashboard/clickable_avatars_test.go
@@ -1,0 +1,166 @@
+package dashboard
+
+import (
+	"strings"
+	"testing"
+)
+
+// indexHTML returns the spoke dashboard's single-page markup from the embedded
+// FS. The avatar markup is JS inside that file, invisible to the Go compiler, so
+// these tests are the only automated check that the faces stay linked, safe and
+// layout-neutral.
+func indexHTML(t *testing.T) string {
+	t.Helper()
+	b, err := staticFS.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatalf("reading embedded static/index.html: %v", err)
+	}
+	return string(b)
+}
+
+// TestAvatarSitesUseSharedHelper asserts each avatar-rendering site goes through
+// the shared helper rather than hand-rolling an <img>. A site with its own
+// markup is a site that will silently miss the anchor, the onerror fallback, or
+// the escaping.
+func TestAvatarSitesUseSharedHelper(t *testing.T) {
+	html := indexHTML(t)
+	cases := []struct {
+		name    string
+		snippet string
+	}{
+		{"contributor cards", "const avatarHtml = linkedAvatar(c.github_username, CONTRIBUTOR_AVATAR_PX,"},
+		{"leaderboard rows", "? linkedAvatar(e.github_username, CONTRIBUTOR_AVATAR_PX, `@${e.github_username}`, e.avatar_url)"},
+		{"access tab allowlist", "linkedAvatar(u.username, ACCESS_LIST_AVATAR_PX,"},
+		{"audit log actor", "? linkedAvatar(actor, AUDIT_AVATAR_PX, actor, '', 'margin-right:4px')"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(html, tc.snippet) {
+				t.Errorf("index.html is missing %q — did an avatar site stop using the shared helper?", tc.snippet)
+			}
+		})
+	}
+}
+
+// TestAvatarHelpersPresent asserts the shared helpers and their named sizes
+// exist. A merge that drops one leaves faces unlinked or reintroduces a magic
+// number, and nothing else in the build would notice.
+func TestAvatarHelpersPresent(t *testing.T) {
+	html := indexHTML(t)
+	for _, snippet := range []string{
+		"function ghProfileURL(username)",
+		"function avatarProfileLink(username, label, avatarHTML)",
+		"function avatarImg(src, px, extraStyle)",
+		"function linkedAvatar(username, px, label, avatarURL, extraStyle)",
+		"const CONTRIBUTOR_AVATAR_PX = 28;",
+		"const ACCESS_LIST_AVATAR_PX = 20;",
+		"const AUDIT_AVATAR_PX = 16;",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("index.html is missing %q", snippet)
+		}
+	}
+}
+
+// TestAvatarAnchorSafety asserts the profile anchor opens a new tab without
+// leaking the opener, and carries an accessible name so the link's purpose is
+// clear without seeing the picture.
+func TestAvatarAnchorSafety(t *testing.T) {
+	html := indexHTML(t)
+	for _, snippet := range []string{
+		"`<a href=\"${esc(ghProfileURL(uname))}\" target=\"_blank\" rel=\"noopener noreferrer\" ` +",
+		"`title=\"${name}\" aria-label=\"${name}\" ` +",
+		"`style=\"display:inline-block;line-height:0;text-decoration:none\">${avatarHTML}</a>`",
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Errorf("avatarProfileLink is missing %q", snippet)
+		}
+	}
+}
+
+// TestAvatarLinkDegradesWithoutUsername asserts a record with no username
+// renders the bare avatar rather than an anchor to https://github.com/.
+func TestAvatarLinkDegradesWithoutUsername(t *testing.T) {
+	if !strings.Contains(indexHTML(t), "if (!uname) return avatarHTML;") {
+		t.Error("avatarProfileLink no longer returns the unwrapped avatar for a blank username")
+	}
+}
+
+// TestAvatarOnErrorFallbackKept asserts the 404-avatar fallback survived the
+// move into an anchor: a broken-image glyph inside a link reads as a dead
+// control.
+func TestAvatarOnErrorFallbackKept(t *testing.T) {
+	if !strings.Contains(indexHTML(t), `onerror="this.style.display='none'">`) {
+		t.Error("avatarImg no longer hides a broken avatar image")
+	}
+}
+
+// TestProfileLinksAlwaysGithubCom asserts profile links are built from
+// github.com and never from a per-hive Enterprise host. The account that
+// authenticated is a github.com account even on a hive whose org lives on GHE.
+func TestProfileLinksAlwaysGithubCom(t *testing.T) {
+	if !strings.Contains(indexHTML(t), "return `https://github.com/${encodeURIComponent(String(username || ''))}`;") {
+		t.Error("ghProfileURL no longer builds a github.com profile URL from an encoded username")
+	}
+}
+
+// TestRedundantProfileAffordancesRemoved asserts the second anchors that pointed
+// at the profile the avatar now links to are gone — the contributor card's
+// @username link and the leaderboard row's @username link — while the links that
+// go SOMEWHERE ELSE (task issue links) survive.
+func TestRedundantProfileAffordancesRemoved(t *testing.T) {
+	html := indexHTML(t)
+	for _, gone := range []string{
+		"<a href=\"${ghLink}\" target=\"_blank\" rel=\"noopener\" style=\"color:var(--blue);text-decoration:none;font-weight:600\">@${esc(c.github_username)}</a>",
+		"<a href=\"${ghLink}\" target=\"_blank\" rel=\"noopener\" style=\"color:var(--blue);text-decoration:none\">@${esc(e.github_username)}</a>",
+	} {
+		if strings.Contains(html, gone) {
+			t.Errorf("a redundant @username profile anchor survives; the avatar replaces it: %q", gone)
+		}
+	}
+	// Task links point at an issue, not a profile — they must NOT be removed.
+	if !strings.Contains(html, "https://github.com/${esc(t.repo)}/issues/${t.number}") {
+		t.Error("the contributor card's task issue link was removed; it is a different destination")
+	}
+}
+
+// TestAnonymousAuditActorIsNotLinked asserts the audit log's placeholder face
+// for an entry with no actor is rendered UNLINKED. 'ghost' is a real github.com
+// account; linking the placeholder would send the reader to a stranger's
+// profile and imply they performed the action.
+func TestAnonymousAuditActorIsNotLinked(t *testing.T) {
+	html := indexHTML(t)
+	if !strings.Contains(html, ": avatarImg(ghProfileURL('ghost') + '.png', AUDIT_AVATAR_PX, 'margin-right:4px');") {
+		t.Error("the audit log's actorless placeholder face is no longer rendered unlinked")
+	}
+	if strings.Contains(html, "linkedAvatar(e.user||'ghost'") {
+		t.Error("the audit log links its 'ghost' placeholder to a real github.com account")
+	}
+}
+
+// TestNavAvatarKeepsItsMenu asserts the top-bar avatar still opens the user menu
+// rather than being repurposed into a profile link — the menu is a different
+// destination — and that the profile is reachable from a menu entry instead.
+func TestNavAvatarKeepsItsMenu(t *testing.T) {
+	html := indexHTML(t)
+	if !strings.Contains(html, `id="oc-gh-avatar"`) || !strings.Contains(html, `onclick="toggleGHUserMenu()"`) {
+		t.Error("the top-bar avatar no longer opens the user menu")
+	}
+	if !strings.Contains(html, `id="oc-gh-menu-profile"`) {
+		t.Error("the user menu has no GitHub profile entry")
+	}
+	if !strings.Contains(html, "profEl.href = ghProfileURL(username);") {
+		t.Error("the user menu's profile entry is not pointed at the signed-in account")
+	}
+}
+
+// TestNoLiteralBodyTagInComments guards the snapshot builder, which locates the
+// document body with indexOf("<body>"). A literal opening body tag inside any
+// comment or string in this file corrupts that build.
+func TestNoLiteralBodyTagInComments(t *testing.T) {
+	const openBody = "<" + "body>"
+	if got := strings.Count(indexHTML(t), openBody); got != 1 {
+		t.Errorf("found %d occurrences of the opening body tag, want exactly 1 (the real one) — "+
+			"a copy inside a comment or string corrupts the snapshot builder", got)
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2540,6 +2540,11 @@
         <div id="oc-gh-user-menu" style="display:none;position:absolute;right:0;top:34px;background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:4px 0;min-width:160px;z-index:9999;box-shadow:0 8px 24px rgba(0,0,0,0.4)">
           <div style="padding:8px 16px;border-bottom:1px solid var(--line);color:var(--text);font-weight:600;font-size:0.85rem" id="oc-gh-menu-user"></div>
           <div id="oc-gh-menu-role" style="display:none;padding:2px 16px 6px;border-bottom:1px solid var(--line);font-size:0.72rem;color:var(--muted)"></div>
+          <!-- This nav avatar is NOT a profile link: its click already opens
+               this menu, a different destination, so it keeps that job. The
+               profile gets a menu entry instead, populated by showGHAuthState()
+               once the signed-in login is known. -->
+          <a href="#" id="oc-gh-menu-profile" target="_blank" rel="noopener noreferrer" style="display:none;padding:8px 16px;color:var(--text);text-decoration:none;font-size:0.82rem">GitHub profile ↗</a>
           <a href="/api/config/download" id="oc-gh-menu-download" style="display:none;padding:8px 16px;color:var(--text);text-decoration:none;font-size:0.82rem">Download hive.yaml</a>
           <a href="/api/docs" target="_blank" style="display:block;padding:8px 16px;color:var(--text);text-decoration:none;font-size:0.82rem">API Docs ↗</a>
           <button onclick="ghLogout()" style="display:block;width:100%;text-align:left;padding:8px 16px;background:none;border:none;color:var(--text);cursor:pointer;font-size:0.82rem">Sign out</button>
@@ -9080,13 +9085,24 @@ function burnAreaChart() {
     const AUDIT_POLL_MS = 30000;
     var _auditEntries = [];
 
+    /* Rendered size of the audit log's actor face, in CSS pixels — the log is
+       the densest table on the dashboard, so its faces are the smallest. */
+    const AUDIT_AVATAR_PX = 16;
+
     function renderAuditRow(e) {
       var t = e.ts ? new Date(e.ts) : null;
       var timeStr = t ? t.toLocaleString() : '—';
-      var user = esc(e.user||'ghost');
+      /* An entry with no actor is attributed to 'ghost', which is a real
+         github.com account and not this person — so the placeholder face is
+         rendered UNLINKED by passing no username, rather than sending the
+         reader to a stranger's profile. */
+      var actor = String(e.user || '');
+      var face = actor
+        ? linkedAvatar(actor, AUDIT_AVATAR_PX, actor, '', 'margin-right:4px')
+        : avatarImg(ghProfileURL('ghost') + '.png', AUDIT_AVATAR_PX, 'margin-right:4px');
       return '<tr style="border-bottom:1px solid var(--terminal-line)">' +
         '<td style="padding:4px 8px;white-space:nowrap;color:var(--terminal-muted)">' + timeStr + '</td>' +
-        '<td style="padding:4px 8px"><img src="https://github.com/' + user + '.png?s=32" style="width:16px;height:16px;border-radius:50%;vertical-align:middle;margin-right:4px">' + esc(e.user||'—') + '</td>' +
+        '<td style="padding:4px 8px">' + face + esc(e.user||'—') + '</td>' +
         '<td style="padding:4px 8px;font-weight:600">' + esc(e.action||'—') + '</td>' +
         '<td style="padding:4px 8px">' + esc(e.agent||'—') + '</td>' +
         '<td style="padding:4px 8px;color:var(--terminal-muted)">' + esc(e.detail||'') + '</td>' +
@@ -9189,6 +9205,64 @@ function burnAreaChart() {
     function trustTierBadge(tier) {
       return `<span style="display:inline-block;padding:2px 8px;border-radius:4px;font-size:0.7rem;color:var(--muted);border:1px solid var(--line)">${esc(tier || 'unknown')}</span>`;
     }
+
+    /* ---- Clickable user avatars ---------------------------------------
+       Every face on this dashboard links to that person's GitHub profile, so
+       the avatar itself is the affordance rather than a separate glyph or a
+       second anchor on the username beside it.
+
+       ALWAYS github.com. Contributors, leaderboard entries and allowlisted
+       users are identified by the github.com account that authenticated, even
+       on a hive whose ORG lives on a GitHub Enterprise host — repo links are
+       built from a host field, profile links are not.
+
+       encodeURIComponent for the URL path segment; esc() for the quoted
+       attribute values (this file's esc() does escape " ' and backtick, unlike
+       the hub's, so it is safe in attributes here). */
+    function ghProfileURL(username) {
+      return `https://github.com/${encodeURIComponent(String(username || ''))}`;
+    }
+
+    /* Wrap avatar markup in a profile anchor.
+
+       display:inline-block with line-height:0 stops the anchor contributing a
+       text baseline's worth of height to the table row or flex line that holds
+       it; the avatars are 20-28px inline images that keep their own sizing.
+
+       Returns the markup unwrapped when there is no username — an anchor to a
+       profile that cannot exist is worse than no anchor at all. */
+    function avatarProfileLink(username, label, avatarHTML) {
+      const uname = String(username || '');
+      if (!uname) return avatarHTML;
+      const name = esc(label || uname);
+      return `<a href="${esc(ghProfileURL(uname))}" target="_blank" rel="noopener noreferrer" ` +
+        `title="${name}" aria-label="${name}" ` +
+        `style="display:inline-block;line-height:0;text-decoration:none">${avatarHTML}</a>`;
+    }
+
+    /* Round avatar <img>, at the given rendered size in CSS pixels. src may be
+       an explicit avatar_url from the API (GitHub's CDN URL, not derivable from
+       the login) or, when that is absent, github.com/<login>.png. onerror hides
+       a 404 rather than leaving a broken-image glyph — which would read as a
+       dead control now that the image is inside a link. */
+    function avatarImg(src, px, extraStyle) {
+      return `<img src="${esc(src)}" alt="" width="${px}" height="${px}" ` +
+        `style="width:${px}px;height:${px}px;border-radius:50%;vertical-align:middle;` +
+        `${extraStyle || ''}" onerror="this.style.display='none'">`;
+    }
+
+    /* The common case: a linked, round avatar for a github.com login. avatarURL
+       is optional and wins when present. */
+    function linkedAvatar(username, px, label, avatarURL, extraStyle) {
+      const src = avatarURL || `${ghProfileURL(username)}.png`;
+      return avatarProfileLink(username, label, avatarImg(src, px, extraStyle));
+    }
+
+    /* Rendered avatar sizes, in CSS pixels. The contributor cards and the
+       leaderboard rows share a size because they are the same kind of roster;
+       the Access tab's allowlist is a denser config list. */
+    const CONTRIBUTOR_AVATAR_PX = 28;
+    const ACCESS_LIST_AVATAR_PX = 20;
 
     // Active contributor filter set — empty means "all"
     let _contributorFilters = new Set();
@@ -9310,8 +9384,11 @@ function burnAreaChart() {
         const cards = nonRevoked.map(c => {
           const dotColor = c.active ? 'var(--green)' : 'var(--muted)';
           const dotTitle = c.active ? 'Online' : 'Offline';
-          const ghLink = `https://github.com/${esc(c.github_username)}`;
-          const avatar = c.avatar_url || `https://github.com/${esc(c.github_username)}.png`;
+          // The face is the profile link. The @username beside it used to be a
+          // second anchor to that same profile; it stays as plain text so there
+          // is one control per destination.
+          const avatarHtml = linkedAvatar(c.github_username, CONTRIBUTOR_AVATAR_PX,
+            `@${c.github_username}`, c.avatar_url, 'flex-shrink:0');
           const cliLine = c.cli_backend ? `${esc(c.cli_backend)}${c.model ? ' · ' + esc(c.model) : ''}` : '';
           const roleLine = c.preferred_role ? `role: ${esc(c.preferred_role)}` : '';
           const tierOptions = Object.keys(TRUST_TIER_COLORS).filter(t => t !== 'revoked').map(t =>
@@ -9320,8 +9397,8 @@ function burnAreaChart() {
           return `<div style="background:var(--card-bg);border:1px solid var(--border);border-radius:8px;padding:16px">
             <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;flex-wrap:wrap">
               <span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${dotColor};flex-shrink:0" title="${dotTitle}"></span>
-              <img src="${avatar}" alt="" style="width:28px;height:28px;border-radius:50%;flex-shrink:0" onerror="this.style.display='none'">
-              <a href="${ghLink}" target="_blank" rel="noopener" style="color:var(--blue);text-decoration:none;font-weight:600">@${esc(c.github_username)}</a>
+              ${avatarHtml}
+              <span style="font-weight:600">@${esc(c.github_username)}</span>
               <span style="flex-shrink:0">${trustTierBadge(c.trust_tier)}</span>
             </div>
             ${cliLine ? `<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">${cliLine}${roleLine ? ' · ' + roleLine : ''}</div>` : (roleLine ? `<div style="font-size:0.75rem;color:var(--muted);margin-bottom:6px">${roleLine}</div>` : '')}
@@ -9408,16 +9485,20 @@ function burnAreaChart() {
         setIfChanged(panel, '<div style="color:var(--muted);padding:24px;text-align:center;background:var(--card-bg);border:1px solid var(--border);border-radius:8px">No leaderboard data yet.</div>');
         return;
       }
-      const AVATAR_SIZE_PX = 28;
       const rows = entries.map(e => {
-        const avatarHtml = e.avatar_url
-          ? `<img src="${esc(e.avatar_url)}" width="${AVATAR_SIZE_PX}" height="${AVATAR_SIZE_PX}" style="border-radius:50%;vertical-align:middle" alt="">`
-          : `<span style="display:inline-block;width:${AVATAR_SIZE_PX}px;height:${AVATAR_SIZE_PX}px;border-radius:50%;background:var(--border)"></span>`;
-        const ghLink = `https://github.com/${esc(e.github_username)}`;
+        /* The face links to the profile; the @username beside it is plain text
+           now that the avatar carries the same destination. An entry with no
+           avatar_url still falls back to github.com/<login>.png, so the grey
+           circle is only for entries with no username at all — and that one is
+           deliberately NOT wrapped in an anchor, since there is no profile to
+           point at. */
+        const avatarHtml = e.github_username
+          ? linkedAvatar(e.github_username, CONTRIBUTOR_AVATAR_PX, `@${e.github_username}`, e.avatar_url)
+          : `<span style="display:inline-block;width:${CONTRIBUTOR_AVATAR_PX}px;height:${CONTRIBUTOR_AVATAR_PX}px;border-radius:50%;background:var(--border)"></span>`;
         return `<tr style="border-bottom:1px solid var(--border)">
           <td style="padding:8px 12px;font-weight:600;color:var(--muted)">${e.rank}</td>
           <td style="padding:8px 12px">${avatarHtml}</td>
-          <td style="padding:8px 12px"><a href="${ghLink}" target="_blank" rel="noopener" style="color:var(--blue);text-decoration:none">@${esc(e.github_username)}</a></td>
+          <td style="padding:8px 12px">@${esc(e.github_username)}</td>
           <td style="padding:8px 12px">${trustTierBadge(e.trust_tier)}</td>
           <td style="padding:8px 12px;text-align:right">${e.tasks_completed || 0}</td>
           <td style="padding:8px 12px;text-align:right;color:${(e.tasks_failed || 0) > 0 ? 'var(--red)' : 'var(--muted)'}">${e.tasks_failed || 0}</td>
@@ -12784,7 +12865,8 @@ function burnAreaChart() {
         listEl.innerHTML = users.map(function(u) {
           var roleCls = u.role === 'owner' ? 'role-owner' : u.role === 'read-write' ? 'role-read-write' : 'role-read';
           return '<div class="config-list-item" style="align-items:center;gap:8px">' +
-            '<img src="https://github.com/' + esc(u.username) + '.png" style="width:20px;height:20px;border-radius:50%;vertical-align:middle" onerror="this.style.display=\'none\'">' +
+            linkedAvatar(u.username, ACCESS_LIST_AVATAR_PX,
+              String(u.username || '') + (u.role ? ' — ' + u.role : ''), '', '') +
             '<span style="flex:1;font-size:0.85rem">' + esc(u.username) + '</span>' +
             '<span class="role-badge ' + roleCls + '" style="font-size:0.7rem">' + esc(u.role) + '</span>' +
             '</div>';
@@ -16143,6 +16225,19 @@ function burnAreaChart() {
             img.alt = username;
           }
           document.getElementById('oc-gh-menu-user').textContent = username;
+          /* Point the menu's profile entry at the signed-in account, and show it
+             only once there is a login to point at. href is assigned as a
+             property (not interpolated into markup), so encodeURIComponent on
+             the path segment is the whole escaping story here. */
+          const profEl = document.getElementById('oc-gh-menu-profile');
+          if (profEl) {
+            if (username) {
+              profEl.href = ghProfileURL(username);
+              profEl.style.display = 'block';
+            } else {
+              profEl.style.display = 'none';
+            }
+          }
           const roleEl = document.getElementById('oc-gh-menu-role');
           if (roleEl && role) {
             roleEl.style.display = '';

--- a/v2/pkg/hub/clickable_avatars_test.go
+++ b/v2/pkg/hub/clickable_avatars_test.go
@@ -1,0 +1,161 @@
+package hub
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// Every user avatar in the hub dashboard is a link to that person's GitHub
+// profile. The markup lives in the inline dashboardHTML JS, invisible to the Go
+// compiler, so these tests pin the properties that would otherwise only surface
+// as a broken, unsafe, or unreachable control in a browser.
+
+// TestAvatarSitesUseSharedHelper asserts every avatar-rendering site goes
+// through the shared helpers rather than hand-rolling an <img>. A site that
+// builds its own markup is a site that will silently miss the anchor, the
+// onerror fallback, or the escaping.
+func TestAvatarSitesUseSharedHelper(t *testing.T) {
+	cases := []struct {
+		name    string
+		snippet string
+	}{
+		{"inline per-hive faces", "return linkedAvatar(uname, INLINE_ACCESS_AVATAR_PX,"},
+		{"status-dot hover panel rows", "linkedAvatar(a.username, PANEL_ACCESS_AVATAR_PX,"},
+		{"per-hive pending request rows", "var avatar = linkedAvatar(pr.username, LIST_AVATAR_PX, pr.username, 'margin-right:6px');"},
+		{"past requests table", "linkedAvatar(uname, PANEL_ACCESS_AVATAR_PX, uname, 'margin-right:6px')"},
+		{"pending provision cards", "var avatar = linkedAvatar(pr.username, TABLE_AVATAR_PX, pr.username, 'margin-right:8px');"},
+		{"admin users table", "var avatar = linkedAvatar(u.github_username, TABLE_AVATAR_PX,"},
+		{"access modal pending requests", "var avatar = linkedAvatar(r.username, LIST_AVATAR_PX, r.username, 'margin-right:6px');"},
+		{"access modal access list", "var avatar = linkedAvatar(u.username, LIST_AVATAR_PX,"},
+		{"nav bar viewer avatar", "avatarProfileLink(data.login, String(data.login || '') + ' — ' + roleText,"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(dashboardHTML, tc.snippet) {
+				t.Errorf("dashboardHTML is missing %q — did an avatar site stop using the shared helper?", tc.snippet)
+			}
+		})
+	}
+}
+
+// TestNoHandRolledAvatarImages asserts no site builds a github.com avatar <img>
+// outside the shared helper. Exactly one occurrence of the ".png?size=" pattern
+// is expected: the one inside avatarImg().
+func TestNoHandRolledAvatarImages(t *testing.T) {
+	const marker = ".png?size="
+	if got := strings.Count(dashboardHTML, marker); got != 1 {
+		t.Errorf("found %d occurrences of %q in dashboardHTML, want exactly 1 (only avatarImg may build an avatar URL)", got, marker)
+	}
+	// The other hand-rolled shape: 'https://github.com/' + <expr> + '.png'.
+	if strings.Contains(dashboardHTML, `+ '.png"`) {
+		t.Error("dashboardHTML still builds an avatar <img> src inline; use avatarImg()/linkedAvatar()")
+	}
+}
+
+// TestAvatarAnchorSafety asserts the profile anchor carries the attributes that
+// make a new-tab link safe and legible: rel="noopener noreferrer" so the opened
+// tab cannot reach back through window.opener, and an accessible name so the
+// link's purpose is clear without seeing the picture.
+func TestAvatarAnchorSafety(t *testing.T) {
+	cases := []struct {
+		name    string
+		snippet string
+	}{
+		{"opens in a new tab", `target="_blank"`},
+		{"blocks opener and referrer", `rel="noopener noreferrer"`},
+		{"names the link for assistive tech", `aria-label="' + escAttr(label || uname) + '"`},
+		{"native tooltip names the user too", `title="' + escAttr(label || uname) + '"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !strings.Contains(dashboardHTML, tc.snippet) {
+				t.Errorf("avatarProfileLink is missing %q", tc.snippet)
+			}
+		})
+	}
+}
+
+// TestAvatarLinkDegradesWithoutUsername asserts a record with no username
+// renders the bare avatar rather than an anchor to https://github.com/ — a link
+// to a profile that cannot exist is worse than no link.
+func TestAvatarLinkDegradesWithoutUsername(t *testing.T) {
+	if !strings.Contains(dashboardHTML, "if (!uname) return avatarHTML;") {
+		t.Error("avatarProfileLink no longer returns the unwrapped avatar for a blank username")
+	}
+}
+
+// TestAvatarOnErrorFallbackKept asserts the 404-avatar fallback survived the
+// move into an anchor. A broken-image glyph inside a link reads as a dead
+// control, which is worse than the gap it replaced.
+func TestAvatarOnErrorFallbackKept(t *testing.T) {
+	if !strings.Contains(dashboardHTML, `onerror="this.style.visibility=\'hidden\'"`) {
+		t.Error("avatarImg no longer hides a broken avatar image")
+	}
+}
+
+// TestAvatarAnchorDoesNotDisturbRowHeight asserts the anchor is laid out so it
+// cannot add a text baseline's worth of height to a dense table row. A bare
+// inline anchor inherits its parent's line-height and would shift rows.
+func TestAvatarAnchorDoesNotDisturbRowHeight(t *testing.T) {
+	for _, snippet := range []string{"display:inline-block", "line-height:0"} {
+		if !strings.Contains(dashboardHTML, "style=\"display:inline-block;line-height:0;text-decoration:none\"") {
+			t.Fatalf("avatarProfileLink is missing the layout-neutral anchor style (looking for %q)", snippet)
+		}
+	}
+}
+
+// TestProfileLinksAlwaysGithubCom asserts profile links are built from
+// github.com and never from a per-record github_host. The account that signs in
+// to the hub is a github.com account even when the ORG it works on lives on a
+// GitHub Enterprise host; only REPO links take their origin from the record.
+func TestProfileLinksAlwaysGithubCom(t *testing.T) {
+	if !strings.Contains(dashboardHTML, `return 'https://github.com/' + encodeURIComponent(String(username || ''));`) {
+		t.Error("ghProfileURL no longer builds a github.com profile URL from an encoded username")
+	}
+	// ghRepoURL is the one that must consult github_host; assert the split is
+	// still real so a future edit cannot quietly merge the two.
+	if !strings.Contains(dashboardHTML, "function ghRepoURL(") {
+		t.Error("ghRepoURL is gone; repo links must still be built from the record's github_host")
+	}
+	if strings.Contains(dashboardHTML, "ghProfileURL(username, host)") {
+		t.Error("ghProfileURL took on a host argument; profile links must stay on github.com")
+	}
+}
+
+// TestRedundantProfileAffordancesRemoved asserts the separate link affordances
+// that pointed at the profile the avatar now links to are gone: the admin Users
+// table's ↗ glyph and the Past Requests table's second anchor on the username.
+func TestRedundantProfileAffordancesRemoved(t *testing.T) {
+	if strings.Contains(dashboardHTML, `title="GitHub profile" style="color:var(--muted);font-size:0.65rem;margin-right:4px">↗</a>`) {
+		t.Error("the admin Users table still renders the ↗ profile glyph; the avatar replaces it")
+	}
+	if strings.Contains(dashboardHTML, `'<a href="https://github.com/' + encodeURIComponent(uname) + '" target="_blank" rel="noopener noreferrer" style="color:inherit">' + esc(uname) + '</a>'`) {
+		t.Error("the Past Requests table still links the username separately; the avatar replaces it")
+	}
+	// The assign-flow anchor on the username must SURVIVE: it goes somewhere
+	// else (the assign modal), so it is not redundant with the profile link.
+	if !strings.Contains(dashboardHTML, `onclick="openAssignForUser(\'`) {
+		t.Error("the admin Users table lost its assign-flow link, which is a different destination")
+	}
+}
+
+// TestAvatarSizesAreNamedConstants asserts no avatar site hardcodes a pixel
+// size at the call site.
+func TestAvatarSizesAreNamedConstants(t *testing.T) {
+	for _, decl := range []string{
+		"var PANEL_ACCESS_AVATAR_PX = 18;",
+		"var LIST_AVATAR_PX = 20;",
+		"var TABLE_AVATAR_PX = 24;",
+		"var AVATAR_HIDPI_SCALE = 2;",
+	} {
+		if !strings.Contains(dashboardHTML, decl) {
+			t.Errorf("dashboardHTML is missing the named size constant %q", decl)
+		}
+	}
+	// No call site may pass a bare number as the size argument.
+	numericSize := regexp.MustCompile(`linkedAvatar\([^,]+,\s*\d`)
+	if m := numericSize.FindString(dashboardHTML); m != "" {
+		t.Errorf("a linkedAvatar call passes a magic pixel size: %q", m)
+	}
+}

--- a/v2/pkg/hub/hive_access_avatars_test.go
+++ b/v2/pkg/hub/hive_access_avatars_test.go
@@ -24,7 +24,10 @@ func TestInlineAccessAvatarHelpersPresent(t *testing.T) {
 		{"shared role colour helper", "function accessRoleColor(role)"},
 		{"named face cap", "var INLINE_ACCESS_AVATAR_MAX"},
 		{"named rendered size", "var INLINE_ACCESS_AVATAR_PX"},
-		{"named fetch size", "var INLINE_ACCESS_AVATAR_FETCH_PX"},
+		{"named HiDPI fetch scale", "var AVATAR_HIDPI_SCALE"},
+		{"shared profile url helper", "function ghProfileURL(username)"},
+		{"shared profile anchor helper", "function avatarProfileLink(username, label, avatarHTML)"},
+		{"shared linked-avatar helper", "function linkedAvatar(username, px, label, extraStyle)"},
 		{"named role colour map", "var ACCESS_ROLE_COLORS"},
 		{"named role colour fallback", "var ACCESS_ROLE_COLOR_DEFAULT"},
 		{"viewer identity state", "var _currentUser"},
@@ -71,10 +74,15 @@ func TestInlineAccessAvatarEscaping(t *testing.T) {
 		name    string
 		snippet string
 	}{
-		// URL path segment.
-		{"avatar url encodes the username", `'<img src="https://github.com/' + encodeURIComponent(uname) + '.png?size=' + INLINE_ACCESS_AVATAR_FETCH_PX`},
+		// URL path segment. The inline faces now render through the shared
+		// avatar helpers, so the escaping lives there — assert it at the source.
+		{"profile url encodes the username", `return 'https://github.com/' + encodeURIComponent(String(username || ''));`},
+		{"avatar url built from the encoded profile url", `'<img src="' + escAttr(ghProfileURL(username)) + '.png?size='`},
 		// Quoted attribute values.
-		{"title uses escAttr", `'alt="" title="' + escAttr(uname + (role ? ' — ' + role : '')) + '" '`},
+		{"anchor href uses escAttr", `'<a href="' + escAttr(ghProfileURL(uname)) + '" target="_blank" rel="noopener noreferrer" '`},
+		{"anchor title and aria-label use escAttr", `'title="' + escAttr(label || uname) + '" aria-label="' + escAttr(label || uname) + '" '`},
+		// The inline face still carries the role in its tooltip, via the helper.
+		{"inline face labels username and role", `return linkedAvatar(uname, INLINE_ACCESS_AVATAR_PX, uname + (role ? ' — ' + role : ''),`},
 		{"overflow chip title uses escAttr", `'<span title="' + escAttr(hiddenNames.join(', ')) + '" '`},
 		{"aria-label uses escAttr", `'<span class="hive-access-faces" aria-label="' + escAttr(label) + '" '`},
 	}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -6067,6 +6067,76 @@ const dashboardHTML = `<!DOCTYPE html>
     // into an attribute; esc() remains correct for text nodes.
     function escAttr(s) { return esc(s).replace(/"/g, '&quot;').replace(/'/g, '&#39;'); }
 
+    /* ---- Clickable user avatars ---------------------------------------
+       Every face in this dashboard is a link to that person's GitHub profile.
+       The avatar IS the affordance: a separate ↗ glyph or a separately-linked
+       username next to it was two controls for one destination, so those are
+       gone and the picture carries the click.
+
+       ALWAYS github.com, never a github_host. The account that signs in to the
+       hub is a github.com account even when the ORG it works on lives on a
+       GitHub Enterprise host — the same reasoning that kept the Past Requests
+       user link on github.com while its REPO link is built from the request's
+       github_host (see ghRepoURL). A profile link is about the person; the
+       repo link is about the instance.
+
+       The username lands in two hostile contexts and gets a different helper in
+       each: encodeURIComponent for the URL path segment, escAttr for quoted
+       attribute values (esc() leaves quotes intact and a crafted login could
+       close the attribute). */
+    function ghProfileURL(username) {
+      return 'https://github.com/' + encodeURIComponent(String(username || ''));
+    }
+
+    /* Wrap avatar markup in a profile anchor.
+
+       display:inline-block with line-height:0 keeps the anchor from adding a
+       text baseline's worth of height to whatever row or cell holds it: a bare
+       inline anchor inherits the line-height of its parent and can push a dense
+       table row taller than its neighbours. The avatars themselves are 16-28px
+       inline images and keep their own vertical-align.
+
+       Returns the avatar unwrapped when there is no username to link to (a
+       placeholder or a malformed record) — an anchor to a profile that does not
+       exist is worse than no anchor.
+
+       label is the accessible name; it also becomes the native tooltip, so any
+       role information the caller already showed there is preserved. */
+    function avatarProfileLink(username, label, avatarHTML) {
+      var uname = String(username || '');
+      if (!uname) return avatarHTML;
+      return '<a href="' + escAttr(ghProfileURL(uname)) + '" target="_blank" rel="noopener noreferrer" ' +
+        'title="' + escAttr(label || uname) + '" aria-label="' + escAttr(label || uname) + '" ' +
+        'style="display:inline-block;line-height:0;text-decoration:none">' + avatarHTML + '</a>';
+    }
+
+    /* Round avatar <img> for a github.com login, at the given rendered size in
+       CSS pixels. Requests 2x from GitHub so the face stays sharp on HiDPI.
+       onerror hides a 404 avatar rather than leaving a broken-image glyph — an
+       especially important detail now that the image sits inside a link, where
+       a broken icon would read as a dead control. extraStyle appends to the
+       inline style (borders, flex sizing) and defaults to nothing. */
+    var AVATAR_HIDPI_SCALE = 2;
+    function avatarImg(username, px, extraStyle) {
+      return '<img src="' + escAttr(ghProfileURL(username)) + '.png?size=' + (px * AVATAR_HIDPI_SCALE) + '" alt="" ' +
+        'style="width:' + px + 'px;height:' + px + 'px;border-radius:50%;vertical-align:middle;' +
+        (extraStyle || '') + '" ' +
+        'onerror="this.style.visibility=\'hidden\'">';
+    }
+
+    /* The common case: a linked, round avatar for a github.com login. */
+    function linkedAvatar(username, px, label, extraStyle) {
+      return avatarProfileLink(username, label, avatarImg(username, px, extraStyle));
+    }
+
+    /* Rendered avatar sizes, in CSS pixels, one per surface. They differ because
+       the surfaces differ in density, not arbitrarily: the status-dot hover
+       panel and the compact request/access lists are tight vertical lists; the
+       admin Users table row and the pending provision cards have more room. */
+    var PANEL_ACCESS_AVATAR_PX = 18;   /* rows inside the status-dot hover panel */
+    var LIST_AVATAR_PX = 20;           /* compact request/access lists */
+    var TABLE_AVATAR_PX = 24;          /* admin Users table + provision cards */
+
     // ghRepoURL builds the URL for an org/repo on the RIGHT GitHub instance.
     // Hives are not all on public github.com: a provision request carries a
     // github_host ('' = public github.com, otherwise a GitHub Enterprise host
@@ -6248,9 +6318,9 @@ const dashboardHTML = `<!DOCTYPE html>
     /* Rendered size of an inline face, in CSS pixels — small enough to sit on
        the name cell's second line beside the role badge. */
     var INLINE_ACCESS_AVATAR_PX = 16;
-    /* Pixel size requested from GitHub. 2x the rendered size so the faces stay
-       sharp on HiDPI displays. */
-    var INLINE_ACCESS_AVATAR_FETCH_PX = INLINE_ACCESS_AVATAR_PX * 2;
+    /* The pixel size requested from GitHub is INLINE_ACCESS_AVATAR_PX *
+       AVATAR_HIDPI_SCALE, applied by the shared avatarImg() helper so every
+       face in the dashboard stays sharp on HiDPI by the same rule. */
 
     /* Everyone with access to h EXCEPT the signed-in viewer. Their own
        membership is implied by the row being visible to them, so showing their
@@ -6276,26 +6346,21 @@ const dashboardHTML = `<!DOCTYPE html>
       return out;
     }
 
-    /* One inline face. Carries a native title ONLY — deliberately no custom
-       hover panel on this element. The status dot owns the one custom panel in
-       this row (see healthBadge and TestSingleHoverPanelInvariant); an element
-       with both draws the browser tooltip on top of the panel, which is the
-       overlap bug that was fixed once already.
+    /* One inline face, linked to that user's GitHub profile. Carries a native
+       title ONLY — deliberately no custom hover panel on this element. The
+       status dot owns the one custom panel in this row (see healthBadge and
+       TestSingleHoverPanelInvariant); an element with both draws the browser
+       tooltip on top of the panel, which is the overlap bug that was fixed once
+       already. The title moves to the anchor, which is still a plain native
+       tooltip, not a panel.
 
-       The username lands in two hostile contexts: a URL path segment
-       (encodeURIComponent) and a quoted attribute value (escAttr — esc() alone
-       leaves quotes intact and would let a crafted login close the attribute).
-       onerror hides the image rather than leaving a broken-image glyph, the
-       same pattern the hover panel and the provision tables use. */
+       The role stays in the tooltip so the face still answers "who and at what
+       permission" on hover, exactly as before it became a link. */
     function inlineAccessAvatar(a) {
       var uname = String(a.username || '');
       var role = String(a.role || '');
-      var px = INLINE_ACCESS_AVATAR_PX;
-      return '<img src="https://github.com/' + encodeURIComponent(uname) + '.png?size=' + INLINE_ACCESS_AVATAR_FETCH_PX + '" ' +
-        'alt="" title="' + escAttr(uname + (role ? ' — ' + role : '')) + '" ' +
-        'style="width:' + px + 'px;height:' + px + 'px;border-radius:50%;vertical-align:middle;' +
-        'border:1px solid ' + accessRoleColor(role) + ';background:var(--surface);flex:0 0 auto" ' +
-        'onerror="this.style.visibility=\'hidden\'">';
+      return linkedAvatar(uname, INLINE_ACCESS_AVATAR_PX, uname + (role ? ' — ' + role : ''),
+        'border:1px solid ' + accessRoleColor(role) + ';background:var(--surface);flex:0 0 auto');
     }
 
     /* Inline summary of the OTHER users on this hive, or '' when there are
@@ -6685,10 +6750,14 @@ const dashboardHTML = `<!DOCTYPE html>
         /* Shared with the inline row faces (accessRoleColor) so a face in the
            name cell and its line in this panel read as the same role. */
         var rc = accessRoleColor(a.role);
+        /* The face links to the profile. The title lives on the ANCHOR, which is
+           a plain native tooltip inside the panel — the invariant that matters
+           is that no title sits on the panel's own root element (see
+           TestSingleHoverPanelInvariant), not that the panel's contents are
+           tooltip-free. */
         return '<div style="display:flex;align-items:center;gap:6px;padding:2px 0">' +
-          '<img src="https://github.com/' + esc(a.username) + '.png?size=40" alt="" ' +
-          'style="width:18px;height:18px;border-radius:50%;flex:0 0 auto" ' +
-          'onerror="this.style.visibility=\'hidden\'">' +
+          linkedAvatar(a.username, PANEL_ACCESS_AVATAR_PX,
+            String(a.username || '') + (a.role ? ' — ' + a.role : ''), 'flex:0 0 auto') +
           '<span style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' + esc(a.username) + '</span>' +
           '<span style="color:' + rc + ';font-size:0.62rem;font-weight:600;white-space:nowrap">' + esc(a.role) + '</span>' +
           '</div>';
@@ -6846,8 +6915,15 @@ const dashboardHTML = `<!DOCTYPE html>
              roster and the auth payload can disagree on casing. */
           _currentUser = String(data.login || '').toLowerCase();
           var roleText = data.hub_admin ? 'Hub Admin' : 'User';
+          /* The viewer's own face links to their own profile, like every other
+             face in the dashboard. avatar_url comes from the auth payload (it is
+             GitHub's CDN URL, not derivable from the login), so this one builds
+             its <img> directly rather than via avatarImg — but the anchor and
+             the role tooltip are the shared ones. */
           document.getElementById('nav-user').innerHTML =
-            '<img src="' + esc(data.avatar_url) + '" class="nav-avatar" title="' + esc(data.login) + ' — ' + roleText + '">' +
+            avatarProfileLink(data.login, String(data.login || '') + ' — ' + roleText,
+              '<img src="' + escAttr(data.avatar_url) + '" class="nav-avatar" alt="" ' +
+              'onerror="this.style.visibility=\'hidden\'">') +
             '<span style="font-size:0.85rem">' + esc(data.login) + '</span>' +
             '<span style="font-size:0.65rem;color:var(--muted);margin-left:6px">' + roleText + '</span>';
         }
@@ -8954,7 +9030,7 @@ const dashboardHTML = `<!DOCTYPE html>
         var pendingExpandRow = '';
         if (h.pendingRequestCount > 0 && (h.role === 'owner' || h.role === 'read-write') && (h.pending_requests || []).length > 0) {
           var prItems = (h.pending_requests || []).map(function(pr) {
-            var avatar = '<img src="https://github.com/' + esc(pr.username) + '.png" style="width:20px;height:20px;border-radius:50%;vertical-align:middle;margin-right:6px">';
+            var avatar = linkedAvatar(pr.username, LIST_AVATAR_PX, pr.username, 'margin-right:6px');
             var note = (pr.note || '').trim();
             var noteHtml = note
               ? '<div style="margin-top:4px;font-size:0.75rem;color:var(--text);white-space:pre-wrap;word-break:break-word;background:rgba(0,0,0,0.15);border-left:2px solid var(--accent);padding:4px 8px;border-radius:2px">' + esc(note) + '</div>'
@@ -9700,10 +9776,14 @@ const dashboardHTML = `<!DOCTYPE html>
         // profile link is about the person, and the account that signed in to
         // the hub is a github.com account even when the ORG they asked for
         // lives on an Enterprise host.
+        //
+        // The AVATAR carries that link now. The username used to be a second
+        // anchor to the same profile; two controls for one destination is noise,
+        // so the name is plain text and the face is the affordance.
         var userCell =
-          '<img src="https://github.com/' + encodeURIComponent(uname) + '.png?size=40" alt="" style="width:18px;height:18px;border-radius:50%;vertical-align:middle;margin-right:6px" onerror="this.style.visibility=\'hidden\'">' +
+          linkedAvatar(uname, PANEL_ACCESS_AVATAR_PX, uname, 'margin-right:6px') +
           (uname
-            ? '<a href="https://github.com/' + encodeURIComponent(uname) + '" target="_blank" rel="noopener noreferrer" style="color:inherit">' + esc(uname) + '</a>'
+            ? '<span>' + esc(uname) + '</span>'
             : '<span style="color:var(--muted)">—</span>');
         // Repo link, built by the shared provisionRepoLabel(): github_host is
         // empty for public github.com and otherwise a GitHub Enterprise host
@@ -9790,7 +9870,7 @@ const dashboardHTML = `<!DOCTYPE html>
       _provisionRequestsByUser = {};
       pending.forEach(function(pr) { _provisionRequestsByUser[pr.username] = pr; });
       var rows = pending.map(function(pr) {
-        var avatar = '<img src="https://github.com/' + esc(pr.username) + '.png" style="width:24px;height:24px;border-radius:50%;vertical-align:middle;margin-right:8px">';
+        var avatar = linkedAvatar(pr.username, TABLE_AVATAR_PX, pr.username, 'margin-right:8px');
         return '<div style="display:flex;align-items:center;justify-content:space-between;padding:10px 14px;background:var(--surface);border:1px solid var(--border);border-radius:8px;margin-bottom:8px">' +
           '<div style="display:flex;align-items:center;gap:8px">' +
           avatar +
@@ -10494,7 +10574,8 @@ const dashboardHTML = `<!DOCTYPE html>
       if (!users.length) { document.getElementById('users-container').innerHTML = '<div class="loading">No users found</div>'; return; }
       var rows = users.map(function(u) {
         var blocked = u.blocked ? '<span style="color:var(--red);font-weight:600">BLOCKED</span>' : '<span style="color:var(--green)">active</span>';
-        var avatar = '<img src="https://github.com/' + esc(u.github_username) + '.png" style="width:24px;height:24px;border-radius:50%;vertical-align:middle;margin-right:6px">';
+        var avatar = linkedAvatar(u.github_username, TABLE_AVATAR_PX,
+          u.github_username + ' — GitHub profile', 'margin-right:6px');
         var isAdmin = u.github_username === 'clubanderson';
         var hivesObj = u.hives || {};
         var registryIds = new Set((_hiveRegistry || []).map(function(h) { return h.id; }));
@@ -10527,13 +10608,14 @@ const dashboardHTML = `<!DOCTYPE html>
 
         /* Clicking the name opens the assign flow for this user (admin-only, and
            the underlying endpoints re-check that server-side). The GitHub
-           profile stays reachable via the avatar, so one click is not overloaded
-           with two destinations. A pending provision request is called out
-           because the click then approves it rather than assigning a bare
-           placeholder. */
+           profile is reachable via the avatar, so one click is not overloaded
+           with two destinations. The separate ↗ glyph that used to sit between
+           them is gone: it went to the same profile the face now links to, and
+           a 0.65rem arrow was a far smaller click target than the picture. A
+           pending provision request is called out because the click then
+           approves it rather than assigning a bare placeholder. */
         var hasPendingReq = !!_provisionRequestsByUser[u.github_username];
         var nameCell = avatar +
-          '<a href="https://github.com/' + esc(u.github_username) + '" target="_blank" title="GitHub profile" style="color:var(--muted);font-size:0.65rem;margin-right:4px">↗</a>' +
           '<a href="#" onclick="openAssignForUser(\'' + esc(u.github_username) + '\');return false" ' +
           'title="' + (hasPendingReq ? 'Approve this user&#39;s pending request and assign a hive' : 'Assign an available hive to this user') + '" ' +
           'style="color:var(--blue);cursor:pointer">' + esc(u.github_username) + '</a>' +
@@ -11416,7 +11498,7 @@ const dashboardHTML = `<!DOCTYPE html>
         if (!el) return;
         if (!reqs.length) { el.innerHTML = '<span style="color:var(--muted);font-size:0.8rem">No pending requests</span>'; return; }
         el.innerHTML = reqs.map(function(r) {
-          var avatar = '<img src="https://github.com/' + esc(r.username) + '.png" style="width:20px;height:20px;border-radius:50%;vertical-align:middle;margin-right:6px">';
+          var avatar = linkedAvatar(r.username, LIST_AVATAR_PX, r.username, 'margin-right:6px');
           var note = (r.note || '').trim();
           var noteHtml = note
             ? '<div style="margin-top:4px;font-size:0.75rem;color:var(--text);white-space:pre-wrap;word-break:break-word;background:var(--bg);border-left:2px solid var(--accent);padding:4px 8px;border-radius:2px">' + esc(note) + '</div>'
@@ -11487,7 +11569,8 @@ const dashboardHTML = `<!DOCTYPE html>
         }
         var ownerCount = users.filter(function(u) { return u.role === 'owner'; }).length;
         var rows = users.map(function(u) {
-          var avatar = '<img src="https://github.com/' + esc(u.username) + '.png" style="width:20px;height:20px;border-radius:50%;vertical-align:middle;margin-right:6px">';
+          var avatar = linkedAvatar(u.username, LIST_AVATAR_PX,
+            String(u.username || '') + (u.role ? ' — ' + u.role : ''), 'margin-right:6px');
           // The last owner can be neither removed nor demoted — doing so would
           // orphan the hive with no one able to manage access.
           var isLastOwner = (u.role === 'owner' && ownerCount <= 1);


### PR DESCRIPTION
## What

Every user avatar in the hub dashboard and the spoke dashboard is now a link to that person's GitHub profile. The avatar itself is the affordance, so separate link indicators that existed only to reach the same profile are removed.

## Avatar sites changed (11)

**Hub — `v2/pkg/hub/saas.go`** (inline `dashboardHTML`)

| Site | Function |
|---|---|
| Inline per-hive access faces | `inlineAccessAvatar` |
| Status-dot hover panel access rows | `healthBadge` |
| Per-hive pending-request expand rows | hive row renderer |
| Past Requests table | decided-requests renderer |
| Pending provision cards | pending-provision renderer |
| Admin Users table | `renderUsers` |
| Access modal — pending requests | `loadPendingRequests` |
| Access modal — access list | `loadAccessList` |
| Nav bar viewer avatar | `loadUser` |

**Spoke — `v2/pkg/dashboard/static/index.html`**

| Site | Function |
|---|---|
| Contributor cards | `renderContributors` |
| Leaderboard rows | `renderLeaderboard` |
| Access tab allowlist | authorized-users renderer |
| Audit log actor | `renderAuditRow` |

The audit log site was **not** in the expected list — it uses `.png?s=32` rather than `.png?size=`, and had no `onerror`, so it did not match the initial greps. It had no link and no broken-image fallback; it now has both.

## Redundant affordances removed

- **Admin Users table** — the 0.65rem `↗` glyph between the face and the name. Same destination as the avatar, and a far smaller click target.
- **Past Requests table** — the second anchor on the username.
- **Contributor cards / leaderboard rows** — the `@username` anchor. The name is plain text now.

## Links deliberately KEPT (different destinations)

- Users table name → opens the **assign flow** modal, not a profile.
- Contributor task chips → link to the **issue**.
- Revoked-contributors table username → that row has **no avatar** to carry the link.
- Spoke top-bar avatar → its click already opens the **user menu**. Rather than hijack it, the profile got a new `GitHub profile ↗` menu entry.

## GHE vs github.com

**Profile links are always github.com**, following the precedent from #2167. The account that signs in to the hub is a github.com account even when the org it works on lives on a GitHub Enterprise host; only **repo** links take their origin from the record's `github_host` (via `ghRepoURL` / `provisionRepoLabel`, untouched here). No site was found where the username is demonstrably a GHE account. `TestProfileLinksAlwaysGithubCom` asserts the two URL builders stay separate.

## Implementation

One helper set per file — `ghProfileURL` / `avatarProfileLink` / `avatarImg` / `linkedAvatar` — so the anchor, escaping, HiDPI fetch size and `onerror` fallback cannot drift between sites. All sizes are named constants (`PANEL_ACCESS_AVATAR_PX`, `LIST_AVATAR_PX`, `TABLE_AVATAR_PX`, `AVATAR_HIDPI_SCALE`, `CONTRIBUTOR_AVATAR_PX`, `ACCESS_LIST_AVATAR_PX`, `AUDIT_AVATAR_PX`). The now-redundant `INLINE_ACCESS_AVATAR_FETCH_PX` folded into the shared `AVATAR_HIDPI_SCALE`.

Safety and layout:
- `encodeURIComponent` on the URL path segment; `escAttr` (hub) / `esc` (spoke) on quoted attribute values — usernames are user-controlled.
- `rel="noopener noreferrer"` on every new-tab profile link.
- `title` + `aria-label` name the user, preserving the role text the inline faces and access rows already showed on hover.
- The `onerror` fallback is kept — a broken-image glyph inside a link reads as a dead control.
- The anchor is `display:inline-block;line-height:0` so it cannot add a baseline's worth of height to a dense table row.
- A record with **no** username renders the avatar unwrapped rather than linking to `https://github.com/`. The audit log's `ghost` placeholder is deliberately unlinked — `ghost` is a real account, and linking it would imply that person acted.

## Hover-panel invariant

Preserved. No `title` attribute was added to `healthBadge`'s panel root; the access rows' titles sit on the anchors *inside* the panel. Both guard tests pass:

```
--- PASS: TestSingleHoverPanelInvariant (0.00s)
--- PASS: TestInlineAvatarsCarryNoCustomPanel (0.00s)
```

## Verification

- `go build ./...`, `go vet ./pkg/hub/ ./pkg/dashboard/` — clean
- `go test -count=1 -timeout 480s ./pkg/hub/ ./pkg/dashboard/` — both `ok`
- New table-driven tests: `v2/pkg/hub/clickable_avatars_test.go` (9 tests) and `v2/pkg/dashboard/clickable_avatars_test.go` (10 tests), covering helper usage at every site, anchor safety, blank-username degradation, the `onerror` fallback, layout neutrality, github.com-only profile links, removal of the redundant affordances, survival of the different-destination links, and named sizes. `TestNoHandRolledAvatarImages` asserts exactly one place builds an avatar URL.
- `node --check` on the extracted `<script>` bodies of both files — **and the extraction was re-run after the final edit and verified to contain the new code** (`AUDIT_AVATAR_PX` present) before trusting the pass.
- Column discipline: no table gained or lost a cell. The diff touches exactly two `<td>`s, each replaced in place; `TOTAL_COLUMNS`/`TOTAL_COLUMNS_HEADER` stay 17 and `TestHiveTableColumnCountUnchanged` passes.
- No literal opening `body` tag added to `index.html`; `TestNoLiteralBodyTagInComments` asserts exactly one occurrence remains.

**Not verified:** rendering in a live browser. The row-height risk is mitigated structurally (`line-height:0` on an `inline-block` anchor wrapping an image that keeps its own `vertical-align`) and asserted by test, but it was not visually confirmed against a running hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)