### PR TITLE
✨ feat(hub): explicit GitHub host on assign + retroactive host repair

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1737,7 +1737,12 @@ func main() {
 					}
 					return ""
 				}(),
-				Health: dashSrv.HealthSummary(),
+				// Report the API URL we are actually running against so the hub
+				// can see whether a GitHub Enterprise API URL it delivered has
+				// landed. Resolved (never empty) so the hub can distinguish
+				// "public github.com" from "spoke too old to report this".
+				GitHubAPIURL: cfg.GitHub.ResolvedAPIURL(),
+				Health:       dashSrv.HealthSummary(),
 				DashboardURL: func() string {
 					if cfg.Hub.DashboardURL != "" {
 						return cfg.Hub.DashboardURL

--- a/v2/pkg/hub/github_host_assignment_test.go
+++ b/v2/pkg/hub/github_host_assignment_test.go
@@ -1,0 +1,309 @@
+package hub
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+)
+
+// gheTestHost is the GitHub Enterprise instance used throughout these tests —
+// the same one the live vllm-d cluster is configured with.
+const gheTestHost = "github.ibm.com"
+
+// gheTestBaseURL / gheTestAPIURL are that host's cluster-level settings.
+const (
+	gheTestBaseURL = "https://" + gheTestHost
+	gheTestAPIURL  = "https://" + gheTestHost + "/api/v3"
+)
+
+// newGHETestHub returns a hub whose default cluster is a GHE cluster, plus a
+// discard logger so the repair's audit logging does not spam test output.
+func newGHETestHub() *HubServer {
+	return &HubServer{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		clusters: map[string]ClusterConfig{
+			defaultClusterID: {
+				ID:            defaultClusterID,
+				Name:          "ghe-cluster",
+				GitHubBaseURL: gheTestBaseURL,
+				GitHubAPIURL:  gheTestAPIURL,
+			},
+			"public-cluster": {ID: "public-cluster", Name: "public"},
+		},
+	}
+}
+
+// useTempHiveDir points the on-disk SaaS hive store at a temp dir for the
+// duration of a test.
+func useTempHiveDir(t *testing.T) {
+	t.Helper()
+	old := saasHivesDir
+	saasHivesDir = t.TempDir()
+	t.Cleanup(func() { saasHivesDir = old })
+}
+
+// applyAssignHostChoice mirrors the host-resolution the assign/approve handlers
+// perform: an explicit "public" becomes a blank host plus the sentinel base
+// URL, any other explicit host is recorded verbatim, and only a still-blank
+// host inherits the cluster default. Keeping it in one place lets the table
+// below exercise the exact precedence both handlers implement.
+func applyAssignHostChoice(s *HubServer, h *SaaSHive, requested string) {
+	if requested == githubHostPublic {
+		h.GitHubHost = ""
+		h.GitHubBaseURL = githubHostPublic
+	} else if requested != "" {
+		h.GitHubHost = requested
+	}
+	if host := backfillGitHubHostFromCluster(h, s.clusterForHive(h)); host != "" {
+		h.GitHubHost = host
+	}
+}
+
+// TestAssignmentGitHubHostPrecedence covers the three assignment cases the GHE
+// gap turns on: an explicit host is kept, a blank host on a GHE cluster is
+// backfilled, and an explicit "public" override on a GHE cluster stays public.
+func TestAssignmentGitHubHostPrecedence(t *testing.T) {
+	s := newGHETestHub()
+
+	tests := []struct {
+		name          string
+		clusterID     string
+		requestedHost string
+		wantHost      string
+		wantAPIURL    string
+	}{
+		{
+			name:          "explicit host is recorded verbatim",
+			clusterID:     defaultClusterID,
+			requestedHost: "github.other.com",
+			wantHost:      "github.other.com",
+			wantAPIURL:    "https://github.other.com/api/v3",
+		},
+		{
+			name:          "blank host on a GHE cluster is backfilled",
+			clusterID:     defaultClusterID,
+			requestedHost: "",
+			wantHost:      gheTestHost,
+			wantAPIURL:    gheTestAPIURL,
+		},
+		{
+			name:          "explicit public override on a GHE cluster stays public",
+			clusterID:     defaultClusterID,
+			requestedHost: githubHostPublic,
+			wantHost:      "",
+			wantAPIURL:    "",
+		},
+		{
+			name:          "blank host on a public cluster records nothing",
+			clusterID:     "public-cluster",
+			requestedHost: "",
+			wantHost:      "",
+			wantAPIURL:    "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &SaaSHive{ID: "hosted-x", ClusterID: tc.clusterID}
+			applyAssignHostChoice(s, h, tc.requestedHost)
+			if h.GitHubHost != tc.wantHost {
+				t.Errorf("GitHubHost = %q, want %q", h.GitHubHost, tc.wantHost)
+			}
+			// The host only matters because of what it makes the heartbeat push.
+			if got := gheAPIURLForHost(h.GitHubHost); got != tc.wantAPIURL {
+				t.Errorf("pushed github_api_url = %q, want %q", got, tc.wantAPIURL)
+			}
+		})
+	}
+}
+
+// TestApprovePrefersRequestGitHubHost: approving a provision request must honour
+// the host the REQUESTER supplied (parsed from the org URL they pasted) rather
+// than dropping it, and an admin's explicit choice in the approve modal must
+// win over the request.
+func TestApprovePrefersRequestGitHubHost(t *testing.T) {
+	s := newGHETestHub()
+
+	tests := []struct {
+		name        string
+		requestHost string
+		adminHost   string
+		wantHost    string
+	}{
+		{
+			name:        "request host is used when the admin picks the default",
+			requestHost: "github.requested.com",
+			adminHost:   "",
+			wantHost:    "github.requested.com",
+		},
+		{
+			name:        "admin override wins over the request",
+			requestHost: "github.requested.com",
+			adminHost:   "github.admin.com",
+			wantHost:    "github.admin.com",
+		},
+		{
+			name:        "admin public override beats a GHE request and the GHE cluster",
+			requestHost: "github.requested.com",
+			adminHost:   githubHostPublic,
+			wantHost:    "",
+		},
+		{
+			name:        "no request host and no admin choice falls back to the cluster",
+			requestHost: "",
+			adminHost:   "",
+			wantHost:    gheTestHost,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &SaaSHive{ID: "hosted-approve", ClusterID: defaultClusterID}
+			// Mirrors handleApproveProvision's resolution order.
+			if tc.adminHost == githubHostPublic {
+				h.GitHubHost = ""
+				h.GitHubBaseURL = githubHostPublic
+			} else if tc.adminHost != "" {
+				h.GitHubHost = tc.adminHost
+			} else if tc.requestHost != "" {
+				h.GitHubHost = tc.requestHost
+			}
+			if host := backfillGitHubHostFromCluster(h, s.clusterForHive(h)); host != "" {
+				h.GitHubHost = host
+			}
+			if h.GitHubHost != tc.wantHost {
+				t.Errorf("GitHubHost = %q, want %q", h.GitHubHost, tc.wantHost)
+			}
+		})
+	}
+}
+
+// TestRepairGitHubHostsFromClusters covers the retroactive repair: it fixes an
+// already-assigned hive with a blank host on a GHE cluster, refuses to touch an
+// explicit host, an explicit public override, a public cluster, or an unclaimed
+// placeholder — and is idempotent on a second run.
+func TestRepairGitHubHostsFromClusters(t *testing.T) {
+	useTempHiveDir(t)
+	s := newGHETestHub()
+
+	seed := []*SaaSHive{
+		// The vllm-d case: assigned, blank host, GHE cluster.
+		{ID: "hosted-blank-ghe", Owner: "taylormgeorge91", Org: "katamari",
+			Repos: []string{"ibm-aiops-orchestrator"}, PrimaryRepo: "ibm-aiops-orchestrator",
+			ACMMLevel: 2, ClusterID: defaultClusterID},
+		// Explicitly set to a DIFFERENT host — must never be clobbered.
+		{ID: "hosted-explicit", Owner: "a", Org: "o", GitHubHost: "github.explicit.com",
+			Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 1, ClusterID: defaultClusterID},
+		// Explicit public override on a GHE cluster — must stay public.
+		{ID: "hosted-public-override", Owner: "a", Org: "o", GitHubBaseURL: githubHostPublic,
+			Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 1, ClusterID: defaultClusterID},
+		// Public cluster — nothing to record.
+		{ID: "hosted-public-cluster", Owner: "a", Org: "o",
+			Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 1, ClusterID: "public-cluster"},
+		// Unclaimed placeholder — assign owns it, repair must skip it.
+		{ID: "hosted-available-x", Owner: hubAdminUsername, Status: statusAvailable,
+			ClusterID: defaultClusterID},
+	}
+	for _, h := range seed {
+		if err := saveSaaSHive(h); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const wantRepaired = 1 // only hosted-blank-ghe qualifies
+	if got := s.repairGitHubHostsFromClusters(); got != wantRepaired {
+		t.Errorf("repairGitHubHostsFromClusters() = %d, want %d", got, wantRepaired)
+	}
+
+	want := map[string]string{
+		"hosted-blank-ghe":       gheTestHost,
+		"hosted-explicit":        "github.explicit.com",
+		"hosted-public-override": "",
+		"hosted-public-cluster":  "",
+		"hosted-available-x":     "",
+	}
+	for id, wantHost := range want {
+		h := loadSaaSHive(id)
+		if h == nil {
+			t.Fatalf("hive %s disappeared", id)
+		}
+		if h.GitHubHost != wantHost {
+			t.Errorf("%s: GitHubHost = %q, want %q", id, h.GitHubHost, wantHost)
+		}
+	}
+
+	// Idempotent: a second sweep over an already-repaired fleet changes nothing.
+	if got := s.repairGitHubHostsFromClusters(); got != 0 {
+		t.Errorf("second repair sweep changed %d hives, want 0", got)
+	}
+	if h := loadSaaSHive("hosted-blank-ghe"); h == nil || h.GitHubHost != gheTestHost {
+		t.Errorf("repaired host did not survive a second sweep: %+v", h)
+	}
+}
+
+// TestRepairedHostReachesSpokeViaHeartbeat is the end-to-end trace that makes
+// the repair worth anything: filling GitHubHost on an ALREADY-DELIVERED claim
+// must actually cause projectConfigForHiveID to push the GHE API URL.
+//
+// Before the needGHEAPIPush gate this failed: ClaimDelivered == true and a
+// matching vanity URL made every push condition false, so the reconcile
+// returned nil forever and the repaired host never left the hub.
+func TestRepairedHostReachesSpokeViaHeartbeat(t *testing.T) {
+	useTempHiveDir(t)
+	s := newGHETestHub()
+
+	h := &SaaSHive{
+		ID: "hosted-delivered", Owner: "taylormgeorge91", Org: "katamari",
+		Repos: []string{"ibm-aiops-orchestrator"}, PrimaryRepo: "ibm-aiops-orchestrator",
+		ACMMLevel: 2, ClusterID: defaultClusterID,
+		// The claim already landed — this is the state every pre-existing
+		// misconfigured hive is in.
+		ClaimDelivered: true,
+	}
+	if err := saveSaaSHive(h); err != nil {
+		t.Fatal(err)
+	}
+
+	// publicAPIURL is what a misconfigured GHE spoke reports today.
+	const publicAPIURL = "https://api.github.com"
+
+	// Before the repair the hub has nothing to say.
+	if pc := projectConfigForHiveID(h.ID, h.Org, h.Repos, h.PrimaryRepo, h.ACMMLevel, "", publicAPIURL); pc != nil {
+		t.Fatalf("expected no push before repair, got %+v", pc)
+	}
+
+	// This is the entry point the heartbeat handler calls, per hive, per beat.
+	if !s.repairGitHubHostForHive(h.ID) {
+		t.Fatal("per-hive repair reported no change for a blank host on a GHE cluster")
+	}
+	// Idempotent on the next beat — the heartbeat calls this every time.
+	if s.repairGitHubHostForHive(h.ID) {
+		t.Error("per-hive repair changed an already-repaired hive on a second beat")
+	}
+
+	// After the repair the very next heartbeat must carry the GHE API URL.
+	pc := projectConfigForHiveID(h.ID, h.Org, h.Repos, h.PrimaryRepo, h.ACMMLevel, "", publicAPIURL)
+	if pc == nil {
+		t.Fatal("repaired host produced no heartbeat push — the spoke would never learn its GHE API URL")
+	}
+	if pc.GitHubAPIURL != gheTestAPIURL {
+		t.Errorf("pushed github_api_url = %q, want %q", pc.GitHubAPIURL, gheTestAPIURL)
+	}
+	// The push must not disturb the project the spoke already runs.
+	if pc.Org != h.Org || pc.PrimaryRepo != h.PrimaryRepo {
+		t.Errorf("push altered the delivered project: org=%q primary=%q", pc.Org, pc.PrimaryRepo)
+	}
+
+	// Once the spoke reports the new API URL, the hub goes quiet again — no
+	// per-beat churn.
+	if pc2 := projectConfigForHiveID(h.ID, h.Org, h.Repos, h.PrimaryRepo, h.ACMMLevel, "", gheTestAPIURL); pc2 != nil {
+		t.Errorf("expected silence once the spoke reports the GHE API URL, got %+v", pc2)
+	}
+
+	// A spoke too old to report its API URL sends "". That is UNKNOWN, not a
+	// mismatch — pushing on it would re-send every beat with no read-back to
+	// ever stop it.
+	if pc3 := projectConfigForHiveID(h.ID, h.Org, h.Repos, h.PrimaryRepo, h.ACMMLevel, "", ""); pc3 != nil {
+		t.Errorf("expected no push for a spoke that does not report its API URL, got %+v", pc3)
+	}
+}

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -205,7 +205,19 @@ type HeartbeatPayload struct {
 	// so the hub can echo it back in HeartbeatProjectConfig rather than
 	// blanking it, and so the registry knows each hive's author without any
 	// spoke-side token lookup (which does not work on App-authenticated hives).
-	AIAuthor     string             `json:"ai_author,omitempty"`
+	AIAuthor string `json:"ai_author,omitempty"`
+	// GitHubAPIURL is the GitHub API base URL this spoke is CURRENTLY running
+	// against (its resolved value, so a public-GitHub spoke reports
+	// https://api.github.com rather than ""). Reported so the hub can tell
+	// whether a GitHub Enterprise API URL it wants to deliver has actually
+	// landed. Without it the hub has no read-back for this field: the claim
+	// reconcile in projectConfigForHiveID stops sending anything once
+	// ClaimDelivered is set, so a hive whose GitHubHost is filled in AFTER
+	// assignment (the retroactive repair) would never receive its GHE API URL.
+	//
+	// Empty means "spoke too old to report it" — the hub must treat that as
+	// UNKNOWN, never as a genuine mismatch, or it would re-push forever.
+	GitHubAPIURL string             `json:"github_api_url,omitempty"`
 	ACMMLevel    int                `json:"acmm_level"`
 	Agents       []AgentSummary     `json:"agents"`
 	Governor     GovernorSummary    `json:"governor"`

--- a/v2/pkg/hub/hub_filesystem_test.go
+++ b/v2/pkg/hub/hub_filesystem_test.go
@@ -1137,13 +1137,13 @@ func TestHandleAssignHiveWithFilesystem(t *testing.T) {
 	// pushed), so the ONLY thing projectConfigForHiveID still delivers is the
 	// vanity URL — until the spoke reports it back, then it goes quiet.
 	// URL not yet adopted -> still delivering (carries the vanity URL).
-	if pc := projectConfigForHiveID("hosted-assign-fs", "neworg", []string{"repoa", "repob"}, "repoa", 3, ""); pc == nil {
+	if pc := projectConfigForHiveID("hosted-assign-fs", "neworg", []string{"repoa", "repob"}, "repoa", 3, "", ""); pc == nil {
 		t.Error("expected non-nil config while spoke has not yet adopted the vanity URL")
 	} else if pc.DashboardURL != h.VanityURL {
 		t.Errorf("project config DashboardURL = %q, want the vanity URL %q", pc.DashboardURL, h.VanityURL)
 	}
 	// Spoke now reports the vanity URL -> nothing left to push -> nil.
-	if pc := projectConfigForHiveID("hosted-assign-fs", "neworg", []string{"repoa", "repob"}, "repoa", 3, h.VanityURL); pc != nil {
+	if pc := projectConfigForHiveID("hosted-assign-fs", "neworg", []string{"repoa", "repob"}, "repoa", 3, h.VanityURL, ""); pc != nil {
 		t.Errorf("expected nil project config once spoke reports the vanity URL, got %+v", pc)
 	}
 

--- a/v2/pkg/hub/misc_coverage_test.go
+++ b/v2/pkg/hub/misc_coverage_test.go
@@ -136,26 +136,26 @@ func TestProjectConfigForHiveID(t *testing.T) {
 	defer cleanup()
 
 	// No such hive -> nil.
-	if got := projectConfigForHiveID("missing", "", nil, "", 0, ""); got != nil {
+	if got := projectConfigForHiveID("missing", "", nil, "", 0, "", ""); got != nil {
 		t.Errorf("missing hive -> %+v, want nil", got)
 	}
 
 	// Available placeholder -> nil (not yet claimed).
 	saveSaaSHive(&SaaSHive{ID: "ph", Status: statusAvailable})
-	if got := projectConfigForHiveID("ph", "", nil, "", 0, ""); got != nil {
+	if got := projectConfigForHiveID("ph", "", nil, "", 0, "", ""); got != nil {
 		t.Errorf("placeholder -> %+v, want nil", got)
 	}
 
 	// Incomplete claim (no ACMM) -> nil.
 	saveSaaSHive(&SaaSHive{ID: "inc", Status: "running", Org: "acme", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 0})
-	if got := projectConfigForHiveID("inc", "", nil, "", 0, ""); got != nil {
+	if got := projectConfigForHiveID("inc", "", nil, "", 0, "", ""); got != nil {
 		t.Errorf("incomplete claim -> %+v, want nil", got)
 	}
 
 	// Freshly-claimed hive (ClaimDelivered=false), spoke still reporting a stale
 	// placeholder project -> hub PUSHES the real claim until the spoke reports it.
 	saveSaaSHive(&SaaSHive{ID: "fresh", Status: "running", Org: "acme", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 3})
-	if got := projectConfigForHiveID("fresh", "placeholder", nil, "old", 0, ""); got == nil || got.Org != "acme" {
+	if got := projectConfigForHiveID("fresh", "placeholder", nil, "old", 0, "", ""); got == nil || got.Org != "acme" {
 		t.Errorf("undelivered claim, stale spoke -> %+v, want claim pushed (org=acme)", got)
 	}
 
@@ -163,23 +163,23 @@ func TestProjectConfigForHiveID(t *testing.T) {
 	// and adopted by the caller, not pushed here — so projectConfigForHiveID
 	// returns nil regardless of what the spoke reports (nothing to push).
 	saveSaaSHive(&SaaSHive{ID: "full", Status: "running", Org: "acme", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 3, ClaimDelivered: true})
-	if got := projectConfigForHiveID("full", "acme", []string{"r"}, "r", 3, ""); got != nil {
+	if got := projectConfigForHiveID("full", "acme", []string{"r"}, "r", 3, "", ""); got != nil {
 		t.Errorf("delivered claim -> %+v, want nil (org/repos/ACMM are adopted, not pushed)", got)
 	}
 	// Even a spoke reporting a different level -> still nil (no push; adopt path handles it).
-	if got := projectConfigForHiveID("full", "acme", []string{"r"}, "r", 2, ""); got != nil {
+	if got := projectConfigForHiveID("full", "acme", []string{"r"}, "r", 2, "", ""); got != nil {
 		t.Errorf("differing ACMM -> %+v, want nil (adopted, not pushed)", got)
 	}
 
 	// Vanity URL set but spoke hasn't adopted it -> keep sending (with the URL),
 	// even though the claim is delivered and org/repos/acmm already match.
 	saveSaaSHive(&SaaSHive{ID: "van", Status: "running", Org: "acme", Repos: []string{"r"}, PrimaryRepo: "r", ACMMLevel: 3, ClaimDelivered: true, VanityURL: "https://vanity.example/"})
-	got := projectConfigForHiveID("van", "acme", []string{"r"}, "r", 3, "")
+	got := projectConfigForHiveID("van", "acme", []string{"r"}, "r", 3, "", "")
 	if got == nil || got.DashboardURL != "https://vanity.example/" {
 		t.Errorf("vanity not yet adopted -> %+v, want DashboardURL set", got)
 	}
 	// Spoke has now adopted the vanity URL -> stop sending.
-	if got := projectConfigForHiveID("van", "acme", []string{"r"}, "r", 3, "https://vanity.example/"); got != nil {
+	if got := projectConfigForHiveID("van", "acme", []string{"r"}, "r", 3, "https://vanity.example/", ""); got != nil {
 		t.Errorf("vanity adopted -> %+v, want nil", got)
 	}
 }

--- a/v2/pkg/hub/project_config_repair_test.go
+++ b/v2/pkg/hub/project_config_repair_test.go
@@ -17,7 +17,7 @@ func TestProjectConfigRepairsWedgedSpoke(t *testing.T) {
 
 	// Spoke reports the malformed value it is stuck on.
 	bad := "github.ibm.com/enricom-ibm/jackrabbit"
-	pc := projectConfigForHiveID("hosted-wedged", "enricom-ibm", []string{bad}, bad, 2, "")
+	pc := projectConfigForHiveID("hosted-wedged", "enricom-ibm", []string{bad}, bad, 2, "", "")
 	if pc == nil {
 		t.Fatal("expected a repair push for a spoke reporting an invalid repo, got nil")
 	}
@@ -30,7 +30,7 @@ func TestProjectConfigRepairsWedgedSpoke(t *testing.T) {
 
 	// A healthy delivered claim must stay quiet (no churn every beat).
 	if pc2 := projectConfigForHiveID("hosted-wedged", "enricom-ibm",
-		[]string{"enricom-ibm/jackrabbit"}, "enricom-ibm/jackrabbit", 2, ""); pc2 != nil {
+		[]string{"enricom-ibm/jackrabbit"}, "enricom-ibm/jackrabbit", 2, "", ""); pc2 != nil {
 		t.Errorf("expected nil for a healthy delivered claim, got %+v", pc2)
 	}
 }

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -1563,7 +1563,9 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		//     restarted / hasn't beaten yet — not a fresh assignment).
 		spokeReportsDifferentProject := entry.Org != "" && !strings.EqualFold(entry.Org, sh.Org)
 		if !entry.Upgrading && spokeReportsDifferentProject &&
-			projectConfigForHiveID(entry.ID, entry.Org, entry.Repos, entry.PrimaryRepo, entry.ACMMLevel, entry.DashboardURL) != nil {
+			// Empty curAPIURL deliberately: a GHE API-URL-only push is a config
+			// repair, not an assignment, and must never light "Assigning to <org>".
+			projectConfigForHiveID(entry.ID, entry.Org, entry.Repos, entry.PrimaryRepo, entry.ACMMLevel, entry.DashboardURL, "") != nil {
 			entry.Assigning = true
 			entry.AssigningTo = sh.Org
 		}
@@ -4689,6 +4691,11 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 // absent HiveID preserves the historical auto-pick behavior.
 type ApproveProvisionRequest struct {
 	HiveID string `json:"hive_id"`
+	// GitHubHost is the admin's explicit choice of GitHub instance for this
+	// hive, overriding the one on the provision request. "public" forces public
+	// github.com even on a GitHub Enterprise cluster; empty means "use the
+	// request's host, else the cluster default".
+	GitHubHost string `json:"github_host,omitempty"`
 }
 
 func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Request) {
@@ -4775,6 +4782,38 @@ func (s *HubServer) handleApproveProvision(w http.ResponseWriter, r *http.Reques
 	h.ACMMLevel = acmm
 	h.Status = ""
 	h.Error = ""
+	// The requester already told us which GitHub their org lives on (parsed
+	// from the org URL they pasted, or picked explicitly), so honour it. Before
+	// this, approve dropped github_host entirely — only the manual assign path
+	// ever set it — and a GHE request approved through this path produced a
+	// hive with a blank host talking to api.github.com. An override the admin
+	// chose in the approve modal arrives on the request body below and wins.
+	if host := strings.TrimSpace(approveBody.GitHubHost); host != "" {
+		if !isValidName(host) && !strings.EqualFold(host, githubHostPublic) {
+			http.Error(w, `{"error":"invalid github host"}`, http.StatusBadRequest)
+			return
+		}
+		// An explicit "public" choice means public github.com. Record it as a
+		// blank host so gheAPIURLForHost pushes nothing and the spoke keeps its
+		// own api.github.com default — and so the cluster backfill below, which
+		// only ever fills a blank, does not silently re-GHE it.
+		if strings.EqualFold(host, githubHostPublic) {
+			h.GitHubHost = ""
+			h.GitHubBaseURL = githubHostPublic
+		} else {
+			h.GitHubHost = host
+		}
+	} else if pr.GitHubHost != "" {
+		h.GitHubHost = pr.GitHubHost
+	}
+	// Same cluster backfill the manual assign path does: when neither the admin
+	// nor the request named a host, inherit the cluster's GHE default rather
+	// than leaving a blank that pushes an empty API URL forever.
+	if host := backfillGitHubHostFromCluster(h, s.clusterForHive(h)); host != "" {
+		h.GitHubHost = host
+		s.logger.Info("backfilled hive github host from cluster defaults",
+			"hive", hiveID, "github_host", host)
+	}
 	if err := saveSaaSHive(h); err != nil {
 		http.Error(w, `{"error":"failed to assign placeholder hive"}`, http.StatusInternalServerError)
 		return
@@ -5040,7 +5079,10 @@ func (s *HubServer) adoptSpokeProjectConfig(hiveID, org string, repos []string, 
 		"acmm_was", prevLevel, "acmm_now", h.ACMMLevel)
 }
 
-func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary string, curACMM int, curURL string) *HeartbeatProjectConfig {
+// curAPIURL is the GitHub API base URL the spoke reports it is CURRENTLY using
+// (HeartbeatPayload.GitHubAPIURL). Empty means the spoke is too old to report
+// it — treated as UNKNOWN, never as a mismatch.
+func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary string, curACMM int, curURL, curAPIURL string) *HeartbeatProjectConfig {
 	h := loadSaaSHive(hiveID)
 	if h == nil {
 		return nil
@@ -5094,7 +5136,20 @@ func projectConfigForHiveID(hiveID, curOrg string, curRepos []string, curPrimary
 			break
 		}
 	}
-	if !needClaimPush && !needURLPush && !needRepoRepair {
+	// A hive whose GitHubHost was filled in AFTER its claim was delivered —
+	// the retroactive repair, or an admin editing the host later — has
+	// ClaimDelivered == true and a matching vanity URL, so every gate above is
+	// false and the reconcile returns nil forever. The spoke would then keep
+	// talking to api.github.com against a GitHub Enterprise org (the vllm-d /
+	// hosted-available-vllmd-01 failure). Push whenever we have a GHE API URL
+	// to deliver and the spoke reports a DIFFERENT one.
+	//
+	// Deliberately conservative: an empty curAPIURL means the spoke is too old
+	// to report its API URL, which is UNKNOWN, not a mismatch — pushing on it
+	// would re-send on every beat with no read-back to ever stop it.
+	wantAPIURL := gheAPIURLForHost(h.GitHubHost)
+	needGHEAPIPush := wantAPIURL != "" && curAPIURL != "" && curAPIURL != wantAPIURL
+	if !needClaimPush && !needURLPush && !needRepoRepair && !needGHEAPIPush {
 		return nil // nothing left to push
 	}
 	// Sanitize before pushing. A repo pasted as a URL
@@ -5221,7 +5276,9 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf(`{"error":"invalid org name %q — use the org name or its URL (e.g. github.ibm.com/my-org)"}`, body.Org), http.StatusBadRequest)
 		return
 	}
-	if body.GitHubHost != "" && !isValidName(body.GitHubHost) {
+	// "public" is the sentinel that forces public github.com even on a GHE
+	// cluster; it is not a hostname, so exempt it from the hostname validator.
+	if body.GitHubHost != "" && !isValidName(body.GitHubHost) && !strings.EqualFold(body.GitHubHost, githubHostPublic) {
 		http.Error(w, `{"error":"invalid github host"}`, http.StatusBadRequest)
 		return
 	}
@@ -5280,7 +5337,18 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	h.Org = body.Org
 	// Record the GHE host (if any) so the heartbeat can point this spoke at the
 	// right GitHub API. Never blank an existing value with an empty one.
-	if body.GitHubHost != "" {
+	//
+	// "public" is an explicit choice of public github.com on a cluster whose
+	// defaults point at GHE. Record it as a blank host (so gheAPIURLForHost
+	// pushes nothing and the spoke keeps api.github.com) PLUS the
+	// GitHubBaseURL sentinel, which is what makes effectiveGitHubBaseURL
+	// resolve to "" and therefore makes the cluster backfill below decline to
+	// re-GHE the hive. Without the sentinel a blank host would simply be
+	// refilled from the cluster on the very next line.
+	if strings.EqualFold(body.GitHubHost, githubHostPublic) {
+		h.GitHubHost = ""
+		h.GitHubBaseURL = githubHostPublic
+	} else if body.GitHubHost != "" {
 		h.GitHubHost = body.GitHubHost
 	}
 	// Backfill the host from the hive's cluster when neither the request nor
@@ -9853,12 +9921,20 @@ const dashboardHTML = `<!DOCTYPE html>
         '<div><span style="color:var(--muted)">Repos:</span> ' + esc(pr.repos || '') + '</div>' +
         '<div><span style="color:var(--muted)">Primary:</span> ' + esc(pr.primary_repo || '') + '</div>' +
         '<div><span style="color:var(--muted)">ACMM:</span> ' + (pr.acmm_level != null ? pr.acmm_level : '—') + '</div>' +
+        '<div><span style="color:var(--muted)">GitHub:</span> ' + esc(pr.github_host || PUBLIC_GITHUB_HOST) + '</div>' +
         '</div>';
+      /* The requester's own github_host pre-fills the picker — they already
+         told us which GitHub their org lives on. It is only the cluster
+         default when the request carries none. The cluster is unknown until a
+         placeholder is picked (auto-pick resolves it server-side), so the
+         picker opens on "Cluster default" and the note fills in on selection. */
+      var approveRequestHost = pr.github_host || '';
       var content =
         summary +
         '<label style="' + lbl + '">Placeholder to assign</label>' +
         '<select id="approve-hive" style="' + fld + '"><option value="">Loading placeholders…</option></select>' +
         '<div style="font-size:0.72rem;color:var(--muted);margin-top:6px">Auto-pick chooses an available placeholder from the request&#39;s pool.</div>' +
+        githubHostChoiceMarkup('approve', '', approveRequestHost, fld, lbl) +
         '<div style="display:flex;gap:8px;justify-content:flex-end;margin-top:16px">' +
         '<button onclick="closeApproveModal()" style="padding:6px 16px;background:var(--surface);color:var(--fg);border:1px solid var(--border);border-radius:6px;cursor:pointer">Cancel</button>' +
         '<button id="approve-submit" onclick="confirmApprove(\'' + esc(username) + '\')" style="padding:6px 16px;background:#3fb950;color:#000;border:none;border-radius:6px;cursor:pointer;font-weight:600">Approve</button>' +
@@ -9870,17 +9946,35 @@ const dashboardHTML = `<!DOCTYPE html>
         '<h3 style="margin:0 0 12px 0;font-size:1rem">Approve &amp; assign placeholder</h3>' + content + '</div>';
       overlay.addEventListener('click', function(e) { if (e.target === overlay) closeApproveModal(); });
       document.body.appendChild(overlay);
+      /* No cluster is known yet (auto-pick is the default selection), so the
+         "Cluster default" note stays generic until a placeholder is chosen. */
+      wireGitHubHostChoice('approve', '');
       // Populate the dropdown with available placeholders (auto-pick default).
+      var _approvePlaceholders = [];
       try {
         var resp = await fetch('/api/saas/admin/available-placeholders');
         var data = await resp.json();
         var sel = document.getElementById('approve-hive');
         if (!sel) return;
+        _approvePlaceholders = data.placeholders || [];
         var opts = '<option value="">Auto-pick</option>';
-        (data.placeholders || []).forEach(function(p) {
+        _approvePlaceholders.forEach(function(p) {
           opts += '<option value="' + esc(p.id) + '">' + esc(p.id) + '  (' + esc(p.cluster_id || 'default') + ')</option>';
         });
         sel.innerHTML = opts;
+        /* Picking a concrete placeholder reveals its cluster, so the "Cluster
+           default" option can finally name the GitHub instance the hive will
+           land on. Auto-pick ('') leaves it unnamed — the server resolves the
+           cluster and backfills the host itself. */
+        sel.addEventListener('change', function() {
+          var ph = (_approvePlaceholders || []).reduce(function(m, p) { return (p && p.id === sel.value) ? p : m; }, null);
+          var host = ph ? clusterGitHubHost(ph.cluster_id || '') : '';
+          var hostSel = document.getElementById('approve-ghhost');
+          if (hostSel && hostSel.options && hostSel.options.length) {
+            hostSel.options[0].textContent = host ? 'Cluster default — ' + host : 'Cluster default';
+          }
+          wireGitHubHostChoice('approve', host);
+        });
       } catch(e) {
         var sel2 = document.getElementById('approve-hive');
         if (sel2) sel2.innerHTML = '<option value="">Auto-pick</option>';
@@ -9901,7 +9995,9 @@ const dashboardHTML = `<!DOCTYPE html>
         var resp = await fetch('/api/saas/approve-provision/' + encodeURIComponent(username), {
           method: 'PUT',
           headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({hive_id: hiveId})
+          /* github_host: '' = use the request's host, else the cluster
+             default (server-side); 'public' = force public github.com. */
+          body: JSON.stringify({hive_id: hiveId, github_host: githubHostChoiceValue('approve')})
         });
         var data = await resp.json();
         if (!resp.ok) { hiveToast(data.error || 'Assign failed', 'error'); if (submit) { submit.disabled = false; submit.textContent = 'Approve'; } return; }
@@ -10169,6 +10265,123 @@ const dashboardHTML = `<!DOCTYPE html>
         if (list[i] && list[i].id === sel.value) return list[i];
       }
       return null;
+    }
+
+    /* PUBLIC_GITHUB_SENTINEL is the value the assign/approve APIs accept to
+       FORCE public github.com on a cluster whose defaults point at a GitHub
+       Enterprise instance. It mirrors githubHostPublic on the server, where
+       effectiveGitHubBaseURL resolves it to "" (public). It is deliberately
+       NOT a hostname — the server exempts it from the hostname validator. */
+    var PUBLIC_GITHUB_SENTINEL = 'public';
+
+    /* clusterEntryById returns the ClusterListEntry for a cluster id, or null
+       when the cluster list has not loaded (or the id is unknown). An empty id
+       is how the hub records "the default cluster", so fall through to a
+       lookup rather than guessing a host. */
+    function clusterEntryById(clusterId) {
+      if (!clusterId) return null;
+      var list = _clusterList || [];
+      for (var i = 0; i < list.length; i++) {
+        if (list[i] && list[i].id === clusterId) return list[i];
+      }
+      return null;
+    }
+
+    /* clusterGitHubHost returns the bare GitHub host a cluster's hives default
+       to ('github.com' for public GitHub), or '' when the cluster is unknown /
+       the list has not loaded yet. Never guess github.com for an unknown
+       cluster: silently claiming "public" is the exact bug this control
+       exists to surface. */
+    function clusterGitHubHost(clusterId) {
+      var c = clusterEntryById(clusterId);
+      return (c && c.github_host) || '';
+    }
+
+    /* githubHostChoiceMarkup renders the GitHub-instance picker shared by the
+       assign and approve modals.
+
+       Options are: the cluster's own host (the default, and the right answer
+       in almost every case), explicit public github.com, and a free-text host
+       for the rare cross-instance assignment. clusterHost may be '' when the
+       cluster list has not loaded — the control then opens on "Use cluster
+       default", which submits nothing and lets the SERVER's cluster backfill
+       decide, exactly as if the control did not exist. */
+    function githubHostChoiceMarkup(idPrefix, clusterHost, requestHost, fld, lbl) {
+      var isGHE = clusterHost && clusterHost !== PUBLIC_GITHUB_HOST;
+      var defaultLabel = clusterHost
+        ? 'Cluster default — ' + esc(clusterHost)
+        : 'Cluster default';
+      /* A provision request's github_host, when present, is what the REQUESTER
+         told us their org lives on. Prefer it over the cluster default: they
+         know which GitHub their org is on and we should not silently override
+         them. */
+      var preselectCustom = !!(requestHost && requestHost !== clusterHost && requestHost !== PUBLIC_GITHUB_HOST);
+      var opts =
+        '<option value="">' + defaultLabel + '</option>' +
+        '<option value="' + esc(PUBLIC_GITHUB_SENTINEL) + '">Public github.com' + (isGHE ? ' (override)' : '') + '</option>' +
+        '<option value="__custom__"' + (preselectCustom ? ' selected' : '') + '>Other GitHub Enterprise host…</option>';
+      return '<label style="' + lbl + '">GitHub instance</label>' +
+        '<select id="' + esc(idPrefix) + '-ghhost" style="' + fld + '">' + opts + '</select>' +
+        '<input id="' + esc(idPrefix) + '-ghhost-custom" style="' + fld + ';margin-top:6px;display:' + (preselectCustom ? 'block' : 'none') + '" ' +
+          'placeholder="github.example.com" value="' + esc(preselectCustom ? requestHost : '') + '">' +
+        '<div id="' + esc(idPrefix) + '-ghhost-note" style="font-size:0.72rem;color:var(--muted);margin-top:6px"></div>';
+    }
+
+    /* wireGitHubHostChoice attaches the behaviour for a picker rendered by
+       githubHostChoiceMarkup: show the free-text box only for "Other", and
+       keep a live note of exactly which GitHub instance the hive will target.
+       Uses addEventListener rather than inline handlers because the values
+       involved (hosts, org names) are user-controlled. */
+    function wireGitHubHostChoice(idPrefix, clusterHost) {
+      var sel = document.getElementById(idPrefix + '-ghhost');
+      var custom = document.getElementById(idPrefix + '-ghhost-custom');
+      var note = document.getElementById(idPrefix + '-ghhost-note');
+      if (!sel) return;
+      function render() {
+        var isCustom = sel.value === '__custom__';
+        if (custom) custom.style.display = isCustom ? 'block' : 'none';
+        if (!note) return;
+        var target;
+        if (isCustom) {
+          target = (custom && custom.value.trim()) || '';
+        } else if (sel.value === PUBLIC_GITHUB_SENTINEL) {
+          target = PUBLIC_GITHUB_HOST;
+        } else {
+          target = clusterHost || '';
+        }
+        if (!target) {
+          note.textContent = 'This hive will use its cluster’s GitHub instance.';
+          note.style.color = 'var(--muted)';
+          return;
+        }
+        var ghe = target !== PUBLIC_GITHUB_HOST;
+        note.textContent = 'This hive will target ' + target + '.' +
+          (ghe ? ' The GitHub App must be installed on the org on ' + target + ' — a public github.com App will not authenticate there.' : '');
+        note.style.color = ghe ? 'var(--accent, #58a6ff)' : 'var(--muted)';
+      }
+      /* Idempotent: this is re-invoked when the assign modal's placeholder
+         picker changes the cluster, and binding a second listener each time
+         would leave a stale closure (holding the OLD clusterHost) racing the
+         new one. Store the current renderer and swap it out. */
+      if (sel._ghHostRender) {
+        sel.removeEventListener('change', sel._ghHostRender);
+        if (custom) custom.removeEventListener('input', sel._ghHostRender);
+      }
+      sel._ghHostRender = render;
+      sel.addEventListener('change', render);
+      if (custom) custom.addEventListener('input', render);
+      render();
+    }
+
+    /* githubHostChoiceValue returns what to send as github_host: '' for
+       "cluster default" (the server backfills), the 'public' sentinel, or a
+       typed GHE hostname. */
+    function githubHostChoiceValue(idPrefix) {
+      var sel = document.getElementById(idPrefix + '-ghhost');
+      if (!sel) return '';
+      if (sel.value !== '__custom__') return sel.value;
+      var custom = document.getElementById(idPrefix + '-ghhost-custom');
+      return (custom && custom.value.trim()) || '';
     }
 
     /* syncCreateModalInstallLinks points every "install the app" link in the
@@ -10709,12 +10922,23 @@ const dashboardHTML = `<!DOCTYPE html>
       } else {
         hiveField = '<div style="margin-bottom:4px;font-size:0.8rem;color:var(--muted)">Claim placeholder <strong style="color:var(--fg)">' + esc(hiveId) + '</strong> for a real project.</div>';
       }
+      /* The GitHub instance defaults to the SELECTED placeholder's cluster.
+         With a picker the selection can change, so resolve the cluster of the
+         initially-selected placeholder and re-resolve on change below. */
+      function clusterIdForSelection(id) {
+        var fromList = (placeholders || []).reduce(function(m, p) { return (p && p.id === id) ? p : m; }, null);
+        if (fromList) return fromList.cluster_id || '';
+        var fromDash = (_allDashHives || []).reduce(function(m, x) { return (x && x.id === id) ? x : m; }, null);
+        return (fromDash && fromDash.clusterId) || '';
+      }
+      var assignClusterHost = clusterGitHubHost(clusterIdForSelection(hiveId));
       var content =
         hiveField +
         '<label style="' + lbl + '">Owner (GitHub login) *</label>' +
         '<input id="assign-owner" style="' + fld + '" value="' + esc(prefillOwner || '') + '" placeholder="octocat">' +
         '<label style="' + lbl + '">Org *</label>' +
         '<input id="assign-org" style="' + fld + '" value="' + orgVal + '" placeholder="my-org">' +
+        githubHostChoiceMarkup('assign', assignClusterHost, '', fld, lbl) +
         '<label style="' + lbl + '">Repos * (comma-separated)</label>' +
         '<input id="assign-repos" style="' + fld + '" value="' + reposVal + '" placeholder="repo-a, repo-b">' +
         '<label style="' + lbl + '">Primary repo (optional, defaults to first)</label>' +
@@ -10745,6 +10969,25 @@ const dashboardHTML = `<!DOCTYPE html>
         '<h3 style="margin:0 0 12px 0;font-size:1rem">Assign placeholder hive</h3>' + content + '</div>';
       overlay.addEventListener('click', function(e) { if (e.target === overlay) closeAssignModal(); });
       document.body.appendChild(overlay);
+      wireGitHubHostChoice('assign', assignClusterHost);
+      /* Retargeting the placeholder can change the cluster, and with it the
+         default GitHub instance. Re-resolve so the note never claims the
+         previous cluster's host. An explicit override the admin already made
+         (public / a typed host) is left alone — only the "cluster default"
+         label and note follow the selection. */
+      var phPick = document.getElementById('assign-hive-pick');
+      if (phPick) {
+        phPick.addEventListener('change', function() {
+          assignClusterHost = clusterGitHubHost(clusterIdForSelection(phPick.value));
+          var sel = document.getElementById('assign-ghhost');
+          if (sel && sel.options && sel.options.length) {
+            sel.options[0].textContent = assignClusterHost
+              ? 'Cluster default — ' + assignClusterHost
+              : 'Cluster default';
+          }
+          wireGitHubHostChoice('assign', assignClusterHost);
+        });
+      }
     }
     function toggleAssignAdvanced() {
       var adv = document.getElementById('assign-adv');
@@ -10782,7 +11025,9 @@ const dashboardHTML = `<!DOCTYPE html>
         var resp = await fetch('/api/saas/hives/' + encodeURIComponent(hiveId) + '/assign', {
           method: 'POST',
           headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({owner: owner, org: org, repos: repos, primary_repo: primary, project_name: name, acmm_level: acmm, is_public: isPublic, app_id: appId, installation_id: installId, app_private_key: appKey})
+          /* github_host: '' = let the server backfill from the cluster,
+             'public' = force public github.com, otherwise a GHE hostname. */
+          body: JSON.stringify({owner: owner, org: org, github_host: githubHostChoiceValue('assign'), repos: repos, primary_repo: primary, project_name: name, acmm_level: acmm, is_public: isPublic, app_id: appId, installation_id: installId, app_private_key: appKey})
         });
         var data = await resp.json();
         if (!resp.ok) { hiveToast(data.error || 'Assignment failed', 'error'); if (submit) { submit.disabled = false; submit.textContent = 'Assign'; } return; }

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -411,6 +411,99 @@ func backfillGitHubHostFromCluster(h *SaaSHive, cluster *ClusterConfig) string {
 	return githubHostLabel(base)
 }
 
+// repairGitHubHostsFromClusters retroactively fills in a blank GitHubHost on
+// hives that were ALREADY assigned, using their cluster's GHE defaults.
+//
+// backfillGitHubHostFromCluster only runs at assign time, so every hive claimed
+// before that fix keeps GitHubHost == "" forever — and with it an empty
+// github_api_url pushed on every heartbeat, which the spoke reads as "leave
+// mine alone". Those hives sit on a github.ibm.com cluster while talking to
+// api.github.com (hosted-available-vllmd-01 in org "katamari" is the live
+// example). Nothing else ever repairs them.
+//
+// It is deliberately conservative and idempotent:
+//   - It only ever fills a BLANK GitHubHost. An explicitly set host is never
+//     overwritten, and neither is an explicit "public" override — that resolves
+//     to an empty effective base URL, which backfillGitHubHostFromCluster
+//     already refuses to record.
+//   - It changes nothing when the hive's cluster has no GHE host configured.
+//   - Unclaimed placeholders are skipped: assign owns those, and it now
+//     backfills the host itself.
+//   - Every change is logged with before/after.
+//
+// Returns the number of hives changed.
+//
+// It runs LAZILY, per hive, from the heartbeat path (repairGitHubHostForHive)
+// rather than as a startup sweep. A goroutine at hub start would walk the hive
+// directory concurrently with the first heartbeats already writing to it, for
+// no benefit: a hive that never beats does not need repairing, and one that
+// does gets repaired on its very next beat.
+//
+// NOTE: this repairs the HOST only. A hive that also carries the public
+// app_id/installation_id is NOT fixed by this — the GitHub App still has to be
+// installed on the target org before installation auto-discovery can self-heal
+// it. See gitHubAppStillRequiredNote.
+func (s *HubServer) repairGitHubHostsFromClusters() int {
+	repaired := 0
+	for _, h := range listSaaSHives() {
+		if s.repairGitHubHostForHive(h.ID) {
+			repaired++
+		}
+	}
+	if repaired > 0 {
+		s.logger.Info("github host repair: complete", "hives_repaired", repaired,
+			"note", gitHubAppStillRequiredNote)
+	}
+	return repaired
+}
+
+// repairGitHubHostForHive applies the retroactive host repair to a SINGLE hive,
+// reporting whether it changed anything. Called on each heartbeat, so it must
+// be cheap and silent in the overwhelmingly common no-op case — every guard
+// below returns before any write.
+func (s *HubServer) repairGitHubHostForHive(hiveID string) bool {
+	h := loadSaaSHive(hiveID)
+	if h == nil {
+		return false
+	}
+	if h.Status == statusAvailable {
+		return false // unclaimed placeholder — assign backfills it at claim time
+	}
+	if h.GitHubHost != "" {
+		return false // explicitly set — never clobber
+	}
+	// backfillGitHubHostFromCluster also returns "" for an explicit "public"
+	// override (effectiveGitHubBaseURL resolves the sentinel to public) and for
+	// a cluster with no GHE host, so both are covered by this one check.
+	host := backfillGitHubHostFromCluster(h, s.clusterForHive(h))
+	if host == "" {
+		return false
+	}
+	h.GitHubHost = host
+	if err := saveSaaSHive(h); err != nil {
+		s.logger.Error("github host repair: failed to save hive",
+			"hive", hiveID, "error", err)
+		return false
+	}
+	s.logger.Info("github host repair: filled blank github_host from cluster defaults",
+		"hive", hiveID,
+		"cluster", clusterIDForHive(h),
+		"org", h.Org,
+		"github_host_before", "",
+		"github_host_after", host,
+		"github_api_url_after", gheAPIURLForHost(host),
+		"note", gitHubAppStillRequiredNote)
+	return true
+}
+
+// gitHubAppStillRequiredNote is the operator-facing caveat attached to a host
+// repair. Filling in the host points the spoke at the right GitHub API, but it
+// does NOT change the hive's app_id/installation_id: a hive provisioned with
+// the PUBLIC App credentials still needs the GitHub Enterprise App installed on
+// its org before installation auto-discovery can find an installation to adopt.
+// Until a human does that, the hive authenticates as nothing on its GHE host.
+const gitHubAppStillRequiredNote = "github_host repaired; a hive still carrying the public app_id also needs the GitHub Enterprise App installed on its org before its installation can be auto-discovered"
+
 func generateHiveID(org, repo string) string {
 	short := repo
 	if len(short) > 12 {

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -924,7 +924,14 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 	// bug. (No-op for unclaimed placeholders and for empty/zero reported values.)
 	s.adoptSpokeProjectConfig(payload.HiveID, payload.Org, payload.Repos, payload.PrimaryRepo, clampInt(payload.ACMMLevel, 0, 6))
 
-	if projCfg := projectConfigForHiveID(payload.HiveID, payload.Org, payload.Repos, payload.PrimaryRepo, payload.ACMMLevel, payload.DashboardURL); projCfg != nil {
+	// Retroactively fill a blank github_host from this hive's cluster BEFORE
+	// building the project config, so a hive assigned before assign-time
+	// backfill existed starts receiving its GitHub Enterprise API URL on this
+	// very beat. No-op (and silent) for every hive that already has a host, is
+	// an unclaimed placeholder, or sits on a non-GHE cluster.
+	s.repairGitHubHostForHive(payload.HiveID)
+
+	if projCfg := projectConfigForHiveID(payload.HiveID, payload.Org, payload.Repos, payload.PrimaryRepo, payload.ACMMLevel, payload.DashboardURL, payload.GitHubAPIURL); projCfg != nil {
 		resp.ProjectConfig = projCfg
 		s.logger.Info("heartbeat: delivering claimed project config to spoke",
 			"hive_id", payload.HiveID,


### PR DESCRIPTION
## Problem

A hive assigned onto a GitHub Enterprise cluster can end up believing it is on **public github.com** — blank `base_url`/`api_url` and the public `app_id: 3568013`.

Live example: `hosted-available-vllmd-01` (owner `taylormgeorge91`, org `katamari`, repo `ibm-aiops-orchestrator`) sits on the `vllm-d` cluster, which HAS `github_base_url: https://github.ibm.com` and `github_api_url: https://github.ibm.com/api/v3` — yet the hive runs with both blank.

PR #2176 fixed the cluster backfill at assign time. Two gaps remained; this PR closes both.

## Gap 1 — the assign flow never collected a host

`body.GitHubHost` was populated only as a side effect of an admin pasting a *full org URL* (`https://github.ibm.com/katamari`), which `normalizeOrgRef` splits. Typing a bare org name left it empty, and there was no UI field for it at all.

Adds an explicit **GitHub instance** picker to the assign modal *and* the approve-provision modal:

- **Defaults to the selected cluster's host**, so the common case needs no thought. Reuses `ClusterListEntry.github_host` (added in #2171) — no parallel data path. Re-resolves when the placeholder picker changes the cluster.
- **Public github.com stays available as an explicit override** on a GHE cluster. The server records it as the `githubHostPublic` sentinel in `GitHubBaseURL` so the cluster backfill on the very next line does not immediately re-GHE the hive.
- Free-text host for the rare cross-instance assignment.
- **Shows which GitHub instance the hive will target** in a live note — the information the admin currently has no way to see — and warns that a GHE target needs the App installed on that instance.

**Approve pre-fills from the request.** A provision request already carries `github_host`; the requester told us. `handleApproveProvision` previously dropped it entirely — only the manual assign path ever set a host — so every GHE request approved through that path produced a hive with a blank host. It now honours the request's host, lets an admin override it, and falls back to the cluster default only when neither names one.

## Gap 2 — retroactive repair of existing hives

Backfill only ran at assignment, so already-assigned hives stayed broken; `vllmd-01` would still have empty URLs after #2176.

`repairGitHubHostForHive` runs **from the heartbeat path**, per hive, per beat. It fills a blank `github_host` from the hive's cluster and logs every change with before/after.

It refuses to touch:
- an explicitly-set host,
- an explicit `public` override (`effectiveGitHubBaseURL` resolves the sentinel to public, so `backfillGitHubHostFromCluster` already returns `""`),
- a hive whose cluster has no GHE host,
- unclaimed placeholders (assign owns those).

Lazy and per-hive rather than a startup sweep: a goroutine walking the hive directory at boot **raced the first heartbeats already writing to it** — caught under `-race`, and reverted to this design.

## Traced: does filling the host actually reach the spoke?

**Not on its own — it did not, and that is fixed here.**

`projectConfigForHiveID` returns `nil` once `ClaimDelivered` is `true` and the vanity URL matches. Every existing misconfigured hive is in exactly that state, so a repaired host would have been written to `meta.json` and **never left the hub**.

The full chain now:

1. `repairGitHubHostForHive` fills `h.GitHubHost` on the heartbeat.
2. `projectConfigForHiveID` gains a `needGHEAPIPush` gate: push when `gheAPIURLForHost(h.GitHubHost)` is non-empty and differs from what the spoke reports.
3. The spoke reports its current API URL (new `HeartbeatPayload.GitHubAPIURL`, `cfg.GitHub.ResolvedAPIURL()` — never empty, so "public github.com" is distinguishable from "spoke too old to report it").
4. `HeartbeatProjectConfig.GitHubAPIURL` carries the value; `cmd/hive/main.go` already adopts a non-empty one and persists it to the PVC overlay.
5. Once the spoke reports the new URL back, the gate closes — no per-beat churn.

An empty reported URL is treated as **UNKNOWN, never a mismatch**: pushing on it would re-send every beat with no read-back to ever stop it. `TestRepairedHostReachesSpokeViaHeartbeat` asserts each step, including the silence-after-convergence and old-spoke cases.

## What this does NOT fix

Fixing the host does **not** fix a hive's `app_id`/`installation_id`. #2176's installation auto-discovery self-heals the installation only when the App is installed on the target org. Confirmed live: the GHE App `kubestellar-hive-ghe` (app_id 5686) has exactly ONE installation — `41414` on the personal account `Andrew-Anderson`; `GET /orgs/open-source/installation` returns 404.

No attempt is made to auto-fix `app_id`. The repair's log line carries `gitHubAppStillRequiredNote`, which states plainly that a hive still carrying the public app_id needs a human to install the GHE App on its org.

## Tests

Table-driven, in `pkg/hub/github_host_assignment_test.go`:
- assignment with an explicit host / blank host on a GHE cluster (backfills) / explicit `public` override on a GHE cluster (stays public) / blank host on a public cluster
- approve pre-filling from the request's `github_host`, admin override winning, admin `public` beating both a GHE request and a GHE cluster
- the retroactive repair across a seeded fleet, asserting each refusal case, and idempotent on a second sweep and a second beat
- the full heartbeat trace above

## Verification

- `go build ./...`, `go vet ./...`, `go test -count=1 -timeout 480s ./pkg/hub/` — all pass
- `go test -race` on the hub-construction and filesystem tests — clean (this is what caught the startup-goroutine race)
- Both `dashboardHTML` `<script>` bodies extracted and `node --check`ed. Extraction freshness confirmed by grepping the extracted file for the new identifiers (24 hits) before trusting the pass
- No table cells changed, so `TOTAL_COLUMNS`/`TOTAL_COLUMNS_HEADER` are untouched
- New UI uses `esc()` on all interpolated values and `addEventListener` rather than inline handlers, since hosts and org names are user-controlled