### PR TITLE
✨ feat(hub): derive My Hives display name from org / primary repo

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -8315,10 +8315,66 @@ const dashboardHTML = `<!DOCTYPE html>
           var jb = journeySortValue(b && b.journey);
           return _dashSortAsc ? ja - jb : jb - ja;
         }
-        var va = (a && a[key]) || '', vb = (b && b[key]) || '';
+        var va = key === 'name' ? hiveNameSortValue(a) : ((a && a[key]) || '');
+        var vb = key === 'name' ? hiveNameSortValue(b) : ((b && b[key]) || '');
         if (typeof va === 'number' && typeof vb === 'number') return _dashSortAsc ? va - vb : vb - va;
         return _dashSortAsc ? String(va).localeCompare(String(vb)) : String(vb).localeCompare(String(va));
       });
+    }
+
+    /* hiveLabel derives the two-line name-cell label from the hive's PROJECT
+       (org + primary repo) rather than by splitting h.name.
+
+       Why not h.name: the hub synthesises name as org + "/" + primaryRepo on
+       every heartbeat (see RegistryEntry construction in server.go), so
+       splitting it back apart is a lossy round-trip of the two fields we
+       already have on the row — and it breaks whenever either field itself
+       contains a slash. Live fleet evidence: a URL-parsing bug put a HOST in
+       the org position, so the listing showed 'github.ibm.com / forthehive'.
+       Reading org/primaryRepo directly makes the label reflect the project.
+
+       Precedence, most specific first:
+         1. org + primaryRepo  — the real project, the whole point
+         2. h.name             — a hive that reported a name but no project
+         3. h.id               — last resort, never blank
+
+       Returns {line1, line2}. line2 is '' whenever there is no SECOND thing
+       worth saying, so the caller never renders an empty link or a stray '/'.
+       An unassigned placeholder (org 'available-*' or 'placeholder', no
+       primaryRepo) therefore keeps showing its org on line 1 with no empty
+       second line — the same headline it shows today.
+
+       primaryRepo is rendered VERBATIM, including any embedded slash
+       ('enricom-ibm/jackrabbit' is a real live value produced by the same
+       corruption). Taking only the last segment would silently hide half of
+       a legitimate value, and the repo path is what the adjacent GitHub link
+       resolves to — the label and the link must agree. */
+    function hiveLabel(h) {
+      if (!h) return { line1: '', line2: '' };
+      var org = h.org || '';
+      var repo = h.primaryRepo || '';
+      if (org && repo) return { line1: org, line2: repo };
+      /* Exactly one half of the project is known — show it alone, on the
+         bold line, rather than emitting 'org/' or '/repo'. */
+      if (org || repo) return { line1: org || repo, line2: '' };
+      /* No project at all. Fall back to whatever identity the row carries. */
+      return { line1: h.name || h.id || '', line2: '' };
+    }
+
+    /* hiveNameSortValue is the value the Hive column SORTS on. It must track
+       the label the name cell DISPLAYS, so it delegates to hiveLabel —
+       otherwise clicking "Hive ⇅" orders rows by text nobody can see.
+
+       Sorting on the raw h.name is what diverges: the hub synthesises name as
+       org + "/" + primaryRepo, so a hive with no org sorts under "/repo" (the
+       leading slash collates before every letter) and a hive with neither
+       sorts under "" (always first), while both DISPLAY an ordinary word. This
+       reproduces hiveLabel's precedence and joins the two lines with a space,
+       so the sort reads top line first, then second line — exactly how the
+       cell is read. */
+    function hiveNameSortValue(h) {
+      var label = hiveLabel(h);
+      return label.line2 ? label.line1 + ' ' + label.line2 : label.line1;
     }
 
     function sortDashHives(key) {
@@ -9263,7 +9319,7 @@ const dashboardHTML = `<!DOCTYPE html>
         return '<tr>' +
           bulkCheckboxCell(h, section || 'all') +
           '<td class="hive-menu-cell" style="position:relative;width:30px;text-align:center;overflow:visible">' + (h.migrationStatus === 'migrating' ? '<span style="font-size:1.1rem;color:var(--border);user-select:none;cursor:not-allowed" title="Disabled during migration">⋮</span>' : '<span style="cursor:pointer;font-size:1.1rem;color:var(--muted);user-select:none">⋮</span>' + pendingBadge + '<div class="hive-menu-dropdown" style="display:none;position:absolute;left:0;bottom:auto;background:#1c2128;border:1px solid #30363d;border-radius:8px;min-width:160px;padding:4px 0;z-index:1000;box-shadow:0 8px 24px rgba(0,0,0,0.5)">' + menuItems.join('') + '</div>') + '</td>' +
-          '<td style="text-align:left;line-height:1.4">' + (function() { var isHostedRow = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'))); var dh = isHostedRow && h.id ? ('/api/saas/hives/' + encodeURIComponent(h.id) + '/open') : (rb ? esc(rb) : ''); var displayName = h.name || h.id; var parts = displayName.split('/'); var orgName = parts.length > 1 ? parts[0] : ''; var repoName = parts.length > 1 ? parts.slice(1).join('/') : displayName; var rp = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : ''; var ghIcon = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>' : ''; var link = function(text, bold) { if (dh) { return '<a href="' + dh + '" target="_blank" class="' + (bold ? 'hive-name-link' : 'hive-sub-link') + '" title="Open dashboard">' + esc(text) + '</a>'; } var s = bold ? 'font-weight:700;color:inherit' : 'color:#6b7280;font-weight:400'; return '<span style="' + s + '">' + esc(text) + '</span>'; }; var line1 = dot + ' ' + link(orgName || repoName, true); var fcPill = h.online ? failingCheckSummary(h) : ''; /* Inline access faces sit on the name cell's second line, immediately after this row's own role badge: the badge already answers "what am I on this hive", so the co-members read as the natural continuation of the same thought, in the one cell that is left-aligned and has room to grow. It also keeps them out of the 16 dense metric columns, none of which is about people. Empty string when the viewer is the only member, so those rows are pixel-identical to today. */ var accessFaces = hiveAccessAvatars(h); var line2 = orgName ? '<div style="padding-left:18px;font-size:0.8rem">' + link(repoName, false) + ' ' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + '</div>' : '<div style="padding-left:18px">' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + '</div>'; var line3 = pendingPill ? '<div style="margin-top:4px;padding-left:18px">' + pendingPill + '</div>' : ''; return line1 + line2 + line3; })() + '</td>' +
+          '<td style="text-align:left;line-height:1.4">' + (function() { var isHostedRow = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'))); var dh = isHostedRow && h.id ? ('/api/saas/hives/' + encodeURIComponent(h.id) + '/open') : (rb ? esc(rb) : ''); /* Label derived from the PROJECT (org + primary repo), not by splitting h.name — see hiveLabel. */ var label = hiveLabel(h); var orgName = label.line1; var repoName = label.line2; var rp = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : ''; var ghIcon = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>' : ''; var link = function(text, bold) { if (dh) { return '<a href="' + dh + '" target="_blank" class="' + (bold ? 'hive-name-link' : 'hive-sub-link') + '" title="Open dashboard">' + esc(text) + '</a>'; } var s = bold ? 'font-weight:700;color:inherit' : 'color:#6b7280;font-weight:400'; return '<span style="' + s + '">' + esc(text) + '</span>'; }; var line1 = dot + ' ' + link(orgName, true); var fcPill = h.online ? failingCheckSummary(h) : ''; /* Inline access faces sit on the name cell's second line, immediately after this row's own role badge: the badge already answers "what am I on this hive", so the co-members read as the natural continuation of the same thought, in the one cell that is left-aligned and has room to grow. It also keeps them out of the 16 dense metric columns, none of which is about people. Empty string when the viewer is the only member, so those rows are pixel-identical to today. */ var accessFaces = hiveAccessAvatars(h); /* Keyed off repoName, not orgName: line 1 now always carries SOME identity, so the presence of a second line is decided purely by whether there is a repo to put on it. Without a repo the row still shows the GitHub icon, role badge, faces and failing-check pill on the compact variant. */ var line2 = repoName ? '<div style="padding-left:18px;font-size:0.8rem">' + link(repoName, false) + ' ' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + '</div>' : '<div style="padding-left:18px">' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + '</div>'; var line3 = pendingPill ? '<div style="margin-top:4px;padding-left:18px">' + pendingPill + '</div>' : ''; return line1 + line2 + line3; })() + '</td>' +
           '<td>' + (isLocal ? '<span style="display:inline-block;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:rgba(107,114,128,0.15);color:#9ca3af;border:1px solid rgba(107,114,128,0.3)">local</span>' : clusterBadge(h.clusterId, h.clusterName)) + '</td>' +
           '<td style="white-space:nowrap">' + uptimeCell(h) + '</td>' +
           '<td>' + (function() { var pub = !!h.isPublic; var tid = 'vis-' + esc(h.id); if (isHosted && h.role === 'owner') { return '<label style="position:relative;display:inline-block;width:36px;height:20px;cursor:pointer"><input type="checkbox" id="' + tid + '" ' + (pub ? 'checked' : '') + ' onchange="toggleVisibility(\'' + esc(h.id) + '\',this.checked)" style="opacity:0;width:0;height:0"><span style="position:absolute;inset:0;background:' + (pub ? 'var(--green)' : 'var(--border)') + ';border-radius:10px;transition:background 0.2s"></span><span style="position:absolute;top:2px;left:' + (pub ? '18px' : '2px') + ';width:16px;height:16px;background:#fff;border-radius:50%;transition:left 0.2s"></span></label>'; } if (isLocal) { var dh = h.dashboardUrl && !h.dashboardUrl.includes('localhost') ? h.dashboardUrl : ''; var badge = pub ? '<span style="color:var(--green)">Public</span>' : '<span style="color:var(--muted)">Private</span>'; return dh ? '<a href="' + esc(dh) + '#config/governor/Hub" target="_blank" title="Change in Governor Config → Hub tab" style="text-decoration:none;cursor:pointer">' + badge + ' <span style="font-size:0.6rem;color:var(--muted)">↗</span></a>' : badge; } return pub ? '<span style="color:var(--green)">✓</span>' : '<span style="color:var(--muted)">—</span>'; })() + '</td>' +


### PR DESCRIPTION
## What

The hub's **My Hives** listing built each hive's two-line name label by string-splitting `h.name` on `/`:

```js
var displayName = h.name || h.id;
var parts = displayName.split('/');
var orgName  = parts.length > 1 ? parts[0] : '';
var repoName = parts.length > 1 ? parts.slice(1).join('/') : displayName;
```

But the hub **synthesises** `name` as `org + "/" + primaryRepo` on every heartbeat (`RegistryEntry` construction in `server.go`). So the split was a lossy round-trip of two fields that were already on the row — and already used a few characters later to build the adjacent GitHub icon link.

This changes the label to read `h.org` / `h.primaryRepo` directly.

## Why

That round-trip breaks whenever either field contains a slash. A URL-parsing bug put a **host** into the org position on several live hives, so the listing currently shows

- `github.ibm.com / forthehive`
- `github-ibm-com_enricom-ibm / enricom-ibm/jackrabbit`

as the hive's *name*. Deriving from `org`/`primaryRepo` makes the listing reflect the actual project.

## Fallback precedence

`org + primaryRepo` → `h.name` → `h.id`

A row can never render blank or `undefined`. `line2` is emitted **only when there is a repo to put on it**, which also fixes a pre-existing defect: a hive with an org but no primary repo (`name: "someorg/"` → `repoName: ""`) rendered an **empty second-line link**. There is never a stray `/`.

**Placeholders are unchanged in headline.** An unassigned placeholder (org `available-*` or `placeholder`, no primaryRepo) keeps showing its org on line 1 exactly as today — now without the empty line 2.

## `primaryRepo` containing a slash

Rendered **verbatim**. `enricom-ibm/jackrabbit` is a real live value from the same corruption. Truncating to the last segment would silently hide half of a legitimate repo path, and the label must agree with the GitHub link built from the same value.

## Search / sort consistency

- **Search** already indexed `org`, `primaryRepo`, `name` and `id` in `hiveSearchText`, so every displayed label was — and remains — searchable. No change needed; verified rather than assumed.
- **Sort** did diverge. The `name` sort key sorted on raw `h.name`, so a project-less hive sorted under `"/repo"` (leading slash collates before every letter) or `""` (always first) while it *displayed* an ordinary word. The comparator now uses `hiveNameSortValue`, which delegates to the same `hiveLabel`, so the column can no longer order rows by text nobody can see.

## Scope

Content change within one existing cell. No column-count change (`TOTAL_COLUMNS`/`TOTAL_COLUMNS_HEADER` stay 17). The cell's structure, links, badges, access avatars and failing-check pill are untouched. 58 insertions / 2 deletions in one file.

## Verification

`go build ./...` and `go vet ./pkg/hub/` pass. `TestSingleHoverPanelInvariant`, `TestInlineAvatarsCarryNoCustomPanel` and the `TestDashboard*` structure/brace-balance tests (#2177) pass.

Beyond `node --check`, the `<script>` bodies were extracted and driven in **jsdom through the real `renderHives()`**, asserting the rendered DOM. The extraction is re-run on every invocation and a marker is grepped from it to prove it is fresh, not stale. Rows exercised:

| row | line 1 | line 2 |
|---|---|---|
| normal | `kubestellar` | `console` |
| host-in-org corruption | `github.ibm.com` | `forthehive` |
| slash in primaryRepo | `github-ibm-com_enricom-ibm` | `enricom-ibm/jackrabbit` |
| org, no repo | `someorg` | *(none — was an empty link)* |
| repo, no org | `lonelyrepo` | *(none)* |
| name, no project | `legacy-name` | *(none)* |
| neither | `hosted-bare-1` (id) | *(none)* |
| placeholder `available-oke` | `available-oke` | *(none)* |
| placeholder `placeholder` | `placeholder` | *(none)* |

Also asserted: `null`/`undefined`/`{}`/all-null-fields inputs return `{line1:'',line2:''}` without throwing; searching each row's displayed label matches that row; and markup injected via `org`/`primaryRepo` renders as inert text (0 injected elements, no handler fired) since `link()` applies `esc()`.

The full `go test ./pkg/hub/` suite could not be completed in this sandbox — it dies with `signal: killed` needing a writable `/data` and network. **This reproduces identically on unmodified `origin/v2` with my changes stashed**, so it is an environment limit, not a regression. CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)