### PR TITLE
✨ feat(ui): move Drift beside Journey; fold status filters into a collapsible facet tray

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -5827,15 +5827,51 @@ const dashboardHTML = `<!DOCTYPE html>
     .alert-panel-more { margin-top: 8px; font-size: 0.7rem; color: var(--muted); background: none; border: none; font-family: inherit; cursor: pointer; text-decoration: underline; padding: 0; }
 
     /* ── Hive search + facets ──
-       The My Hives area is a two-column shell: a narrow facet rail on the left
-       and the search box + table on the right. Both collapse to a single stacked
-       column at the 900px breakpoint used elsewhere in this sheet. */
+       The facet panel is a CLICK-TOGGLED left tray, collapsed by default so the
+       dashboard is uncluttered until the operator asks for filters. Collapsed it
+       is a narrow rail (--facet-rail-w) carrying a filter glyph and, whenever
+       anything is narrowing the list, an active-filter count badge. Clicking the
+       rail expands the tray; clicking again collapses it. The state persists in
+       localStorage (LS_FACET_TRAY_OPEN).
+
+       No hover-reveal: a pointer-only affordance is unreachable on touch and
+       flickers across the gap between rail and panel. A real <button> with
+       aria-expanded works identically with mouse, touch and keyboard.
+
+       Why overlay rather than push: pushing would re-flow the table on every
+       toggle, which re-triggers .table-wrap's horizontal-scroll measurement.
+       Overlaying leaves the scroll container completely untouched.
+
+       Layering: the tray sits at z-index 40, deliberately BELOW the row hover
+       panels (.hive-access-pop / healthBadge's custom panel, z-index 60), so a
+       row's panel always draws above the tray rather than behind it. */
     #hive-search-row { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; }
     #hive-search { flex: 1; min-width: 0; padding: 8px 14px; background: var(--surface); border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-size: 0.85rem; font-family: inherit; }
     #hive-search:focus { outline: none; border-color: var(--accent); }
     #hive-search-clear { flex: none; }
-    .hive-layout { display: grid; grid-template-columns: 220px minmax(0, 1fr); gap: 20px; align-items: start; }
-    .facet-rail { min-width: 0; }
+    /* Collapsed rail width and expanded tray width. The layout grid reserves
+       only the rail; the tray overhangs it. */
+    :root { --facet-rail-w: 34px; --facet-tray-w: 240px; }
+    .hive-layout { display: grid; grid-template-columns: var(--facet-rail-w) minmax(0, 1fr); gap: 12px; align-items: start; }
+    /* The tray's positioning context. position:relative only — no overflow
+       clipping, so the table's own hover panels are never cut off by it. */
+    .facet-shell { position: relative; min-width: 0; }
+    /* Always-visible collapsed affordance. .has-active turns it accent-coloured
+       and reveals the badge, so a filtered list always has a visible cause even
+       with the tray shut. */
+    .facet-rail-tab { display: flex; flex-direction: column; align-items: center; gap: 6px; width: var(--facet-rail-w); padding: 8px 0; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; color: var(--muted); font: inherit; font-size: 0.8rem; cursor: pointer; }
+    .facet-rail-tab:hover, .facet-rail-tab:focus-visible { color: var(--text); border-color: var(--muted); }
+    .facet-rail-tab.has-active { border-color: var(--accent); color: var(--accent); }
+    .facet-rail-word { writing-mode: vertical-rl; letter-spacing: 0.08em; font-size: 0.6rem; text-transform: uppercase; }
+    .facet-active-badge { display: inline-flex; align-items: center; justify-content: center; min-width: 18px; height: 18px; padding: 0 4px; border-radius: 9999px; background: var(--accent); color: #000; font-size: 0.62rem; font-weight: 800; font-variant-numeric: tabular-nums; }
+    /* Closed by default; .facet-open (driven entirely by JS from the persisted
+       flag) is the only thing that reveals it. display:none while closed keeps
+       every control inside it out of the tab order. */
+    .facet-tray { display: none; position: absolute; top: 0; left: 0; z-index: 40; width: var(--facet-tray-w); max-height: 70vh; overflow-y: auto; padding: 10px; background: var(--bg-soft, var(--surface)); border: 1px solid var(--border); border-radius: 10px; box-shadow: 0 12px 32px rgba(0,0,0,0.5); }
+    .facet-shell.facet-open .facet-tray { display: block; }
+    .facet-tray-head { display: flex; align-items: center; justify-content: space-between; gap: 6px; margin-bottom: 8px; color: var(--muted); font-size: 0.66rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; }
+    .facet-tray-close { background: none; border: none; color: var(--muted); font: inherit; font-size: 0.9rem; line-height: 1; cursor: pointer; padding: 2px 4px; }
+    .facet-tray-close:hover { color: var(--text); }
     .facet-group { margin-bottom: 14px; border: 1px solid var(--border); border-radius: 8px; background: var(--surface); overflow: hidden; }
     .facet-group-head { display: flex; align-items: center; justify-content: space-between; gap: 6px; width: 100%; padding: 8px 10px; background: none; border: none; color: var(--muted); font: inherit; font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px; cursor: pointer; text-align: left; }
     .facet-group-head:hover { color: var(--text); }
@@ -5982,10 +6018,15 @@ const dashboardHTML = `<!DOCTYPE html>
       .site-header { grid-template-columns: 1fr; position: static; }
       .site-header nav { flex-wrap: wrap; gap: .85rem; }
       .header-link { justify-self: start; }
-      /* Stack the facet rail above the table instead of squeezing the grid. */
+      /* Narrow screens stack the tray above the table instead of squeezing the
+         grid. The tray stops being an overlay and becomes an in-flow
+         disclosure, driven by the same .facet-open class and the same toggle
+         button, so behaviour is identical — only the placement differs. */
       .hive-layout { grid-template-columns: minmax(0, 1fr); }
-      .facet-rail { display: flex; flex-wrap: wrap; gap: 10px; }
-      .facet-group { flex: 1 1 160px; margin-bottom: 0; }
+      .facet-rail-tab { flex-direction: row; width: auto; justify-content: center; gap: 8px; padding: 8px 12px; }
+      .facet-rail-word { writing-mode: horizontal-tb; }
+      .facet-tray { position: static; width: auto; max-height: none; box-shadow: none; margin-top: 8px; }
+      .facet-group { margin-bottom: 10px; }
     }
     @media (max-width: 600px) {
       .content { padding: 1.5rem 12px 32px; }
@@ -6066,7 +6107,23 @@ const dashboardHTML = `<!DOCTYPE html>
     <div id="usage-panel" style="display:none;margin-bottom:24px"></div>
     <div id="bulk-action-bar" style="display:none"></div>
     <div class="hive-layout">
-      <div class="facet-rail" id="hive-facet-rail"></div>
+      <div class="facet-shell" id="hive-facet-shell">
+        <button type="button" class="facet-rail-tab" id="hive-facet-toggle"
+                aria-expanded="false" aria-controls="hive-facet-tray"
+                title="Show filters">
+          <span aria-hidden="true">&#9776;</span>
+          <span class="facet-rail-word">Filters</span>
+          <span class="facet-active-badge" id="hive-facet-active-badge" style="display:none"></span>
+        </button>
+        <div class="facet-tray" id="hive-facet-tray">
+          <div class="facet-tray-head">
+            <span>Filters</span>
+            <button type="button" class="facet-tray-close" id="hive-facet-close"
+                    title="Hide filters" aria-label="Hide filters">&#10005;</button>
+          </div>
+          <div id="hive-facet-rail"></div>
+        </div>
+      </div>
       <div>
         <div id="hive-search-row" style="display:none">
           <input type="text" id="hive-search" placeholder="Search hives — org, repo, cluster, branch, user… (space = OR)" oninput="onHiveSearchInput()" autocomplete="off">
@@ -7952,6 +8009,14 @@ const dashboardHTML = `<!DOCTYPE html>
        reachable instead of silently dropping out of every facet count. */
     var FACET_UNKNOWN = '—';
 
+    /* Group keys for the two filters moved into the tray from the old chip bar.
+       They are NOT in HIVE_FACET_GROUPS — those are derived from hive fields via
+       hiveFacetValues, whereas these keep their own pre-existing state
+       (_dashStatusFilters / _dashFailingCheckFilter) and matching semantics.
+       They share _dashFacetCollapsed only for the collapse chrome. */
+    var FACET_GROUP_HEALTH = 'health';
+    var FACET_GROUP_FAILING_CHECK = 'failing-check';
+
     var HIVE_FACET_GROUPS = [
       {key: FACET_CLUSTER, label: 'Location'},
       {key: FACET_ACMM, label: 'ACMM level'},
@@ -7964,6 +8029,103 @@ const dashboardHTML = `<!DOCTYPE html>
     var _dashFacets = {};
     /* Collapsed facet GROUPS (chrome only, not a filter): {facetKey: true}. */
     var _dashFacetCollapsed = {};
+
+    /* ── Facet tray open/closed ──
+       Click-toggled, persisted, and COLLAPSED BY DEFAULT so the dashboard is
+       uncluttered until filters are asked for. Key follows the same 'hive-*'
+       localStorage convention as hive-section-assigned-collapsed and
+       hive-cluster-health-collapsed. Open only when explicitly stored 'true',
+       so a first visit and a corrupted value both fall back to closed. */
+    var LS_FACET_TRAY_OPEN = 'hive-facet-tray-open';
+    var _dashFacetTrayOpen = false;
+    try {
+      _dashFacetTrayOpen = localStorage.getItem(LS_FACET_TRAY_OPEN) === 'true';
+    } catch (e) { _dashFacetTrayOpen = false; } /* storage disabled */
+
+    /* applyFacetTrayState paints the DOM from _dashFacetTrayOpen. Split out so
+       the initial paint and every toggle go through exactly one code path and
+       can never disagree about aria-expanded. */
+    function applyFacetTrayState() {
+      var shell = document.getElementById('hive-facet-shell');
+      var toggle = document.getElementById('hive-facet-toggle');
+      if (shell) shell.classList.toggle('facet-open', _dashFacetTrayOpen);
+      if (toggle) {
+        toggle.setAttribute('aria-expanded', _dashFacetTrayOpen ? 'true' : 'false');
+        toggle.title = _dashFacetTrayOpen ? 'Hide filters' : 'Show filters';
+      }
+    }
+
+    function setFacetTrayOpen(open) {
+      _dashFacetTrayOpen = !!open;
+      try {
+        localStorage.setItem(LS_FACET_TRAY_OPEN, _dashFacetTrayOpen ? 'true' : 'false');
+      } catch (e) {} /* private-browsing quota — the toggle still works in-session */
+      applyFacetTrayState();
+    }
+
+    function toggleFacetTray() { setFacetTrayOpen(!_dashFacetTrayOpen); }
+
+    /* activeFilterCount is what the collapsed rail's badge shows. EVERY control
+       that can narrow the list is counted, because the badge is the only thing
+       telling the operator why the table is short while the tray is shut. Each
+       selected facet value counts individually — "3" must mean three choices,
+       not three groups. */
+    function activeFilterCount() {
+      var n = 0;
+      n += Object.keys(_dashStatusFilters || {}).length;
+      if (_dashFailingCheckFilter) n++;
+      if (_dashDriftFilter) n++;
+      if (_alertTypeFilter) n++;
+      if (_dashSearchQuery) n++;
+      var groups = Object.keys(_dashFacets || {});
+      for (var i = 0; i < groups.length; i++) {
+        n += Object.keys(_dashFacets[groups[i]] || {}).length;
+      }
+      return n;
+    }
+
+    /* renderFacetTrayAffordance keeps the collapsed rail honest: accent border
+       plus a count badge whenever anything is filtering. */
+    function renderFacetTrayAffordance() {
+      var toggle = document.getElementById('hive-facet-toggle');
+      var badge = document.getElementById('hive-facet-active-badge');
+      var n = activeFilterCount();
+      if (toggle) toggle.classList.toggle('has-active', n > 0);
+      if (badge) {
+        badge.style.display = n > 0 ? '' : 'none';
+        badge.textContent = n > 0 ? String(n) : '';
+        badge.title = n === 1 ? '1 active filter' : n + ' active filters';
+      }
+      if (toggle) {
+        var base = _dashFacetTrayOpen ? 'Hide filters' : 'Show filters';
+        toggle.title = n > 0 ? base + ' — ' + (n === 1 ? '1 filter active' : n + ' filters active') : base;
+        toggle.setAttribute('aria-label', toggle.title);
+      }
+    }
+
+    /* Bound once at parse time via delegation on document, so the handlers
+       survive every re-render of the tray's contents and no inline onclick has
+       to interpolate anything. */
+    document.addEventListener('click', function(ev) {
+      var t = ev.target;
+      if (!t || !t.closest) return;
+      if (t.closest('#hive-facet-toggle')) { toggleFacetTray(); return; }
+      if (t.closest('#hive-facet-close')) { setFacetTrayOpen(false); return; }
+    });
+    /* Escape closes the tray when focus is inside it, and returns focus to the
+       toggle so the keyboard user is not stranded on a hidden control. */
+    document.addEventListener('keydown', function(ev) {
+      if (ev.key !== 'Escape' || !_dashFacetTrayOpen) return;
+      var tray = document.getElementById('hive-facet-tray');
+      if (!tray || !tray.contains(document.activeElement)) return;
+      setFacetTrayOpen(false);
+      var toggle = document.getElementById('hive-facet-toggle');
+      if (toggle) toggle.focus();
+    });
+    /* Paint the persisted state immediately. This script runs after the tray
+       markup, so the elements already exist and there is no open-then-snap-shut
+       flash on a reload with the tray remembered open. */
+    applyFacetTrayState();
 
     /* hiveFacetValues returns the facet values a single hive belongs to. A hive
        contributes at most one value per group. */
@@ -8012,16 +8174,112 @@ const dashboardHTML = `<!DOCTYPE html>
       renderHives(_allDashHives, true);
     }
 
-    /* renderFacetRail draws the left rail. Counts are computed over the assigned
-       hives after the chips and the search box, but BEFORE the facets in the
-       same group are applied — so a group keeps showing its alternatives once
-       you pick one, rather than collapsing to the single value you chose. */
+    /* facetGroupShell wraps one collapsible group so the status/failing-check
+       groups moved in from the old chip bar are visually and behaviourally
+       identical to the derived facet groups. */
+    function facetGroupShell(key, label, collapsed, bodyHTML) {
+      return '<div class="facet-group">' +
+        '<button type="button" class="facet-group-head" aria-expanded="' + (collapsed ? 'false' : 'true') +
+        '" onclick="toggleFacetGroup(\'' + esc(key) + '\')">' +
+        '<span>' + esc(label) + '</span><span>' + (collapsed ? '▸' : '▾') + '</span></button>' +
+        (collapsed ? '' : bodyHTML) + '</div>';
+    }
+
+    /* renderStatusFacetGroup renders the four health chips — GitHub App not
+       installed / No tokens used / Degraded / OK — as a facet group inside the
+       tray, replacing the old standalone chip row. Semantics are UNCHANGED:
+       these still OR among themselves via _dashStatusFilters and
+       hiveMatchesFilters, exactly like a facet group ORs within itself.
+       Counts are over the FULL assigned set (placeholders already excluded by
+       the caller), matching what the old bar advertised. */
+    function renderStatusFacetGroup(assignedNoPlaceholders) {
+      var counts = {};
+      counts[HIVE_FILTER_APP_MISSING] = 0;
+      counts[HIVE_FILTER_NO_TOKENS] = 0;
+      counts[HIVE_FILTER_DEGRADED] = 0;
+      counts[HIVE_FILTER_OK] = 0;
+      (assignedNoPlaceholders || []).forEach(function(h) {
+        var f = hiveStatusFlags(h);
+        if (f.appMissing) counts[HIVE_FILTER_APP_MISSING]++;
+        if (f.noTokens) counts[HIVE_FILTER_NO_TOKENS]++;
+        if (f.degraded) counts[HIVE_FILTER_DEGRADED]++;
+        if (f.ok) counts[HIVE_FILTER_OK]++;
+      });
+      var body = '<div class="facet-values">' + (HIVE_FILTER_CHIPS || []).map(function(c) {
+        var on = !!_dashStatusFilters[c.key];
+        return '<button type="button" class="facet-value' + (on ? ' on' : '') +
+          '" aria-pressed="' + (on ? 'true' : 'false') +
+          '" onclick="toggleStatusFilter(\'' + esc(c.key) + '\')" title="' + esc(c.label) + '">' +
+          '<span class="facet-value-label">' + esc(c.label) + '</span>' +
+          '<span class="facet-value-count">' + counts[c.key] + '</span></button>';
+      }).join('') +
+      /* Group-scoped reset for the health + failing-check pair, so a user can
+         undo just these without also dropping their search term and facets. */
+      (Object.keys(_dashStatusFilters || {}).length || _dashFailingCheckFilter || _dashDriftFilter
+        ? '<button type="button" class="facet-value" onclick="clearStatusFilters()" title="Clear the health, failing-check and drift filters">' +
+          '<span class="facet-value-label">Clear health filters</span></button>'
+        : '') + '</div>';
+      return facetGroupShell(FACET_GROUP_HEALTH, 'Health',
+        !!_dashFacetCollapsed[FACET_GROUP_HEALTH], body);
+    }
+
+    /* renderFailingCheckFacetGroup renders the failing-check picker as a facet
+       group. Semantics are UNCHANGED: still SINGLE-select and still ANDed
+       against the health chips by hiveMatchesFilters. That is deliberately not
+       the OR-within-group rule the derived facets use — "degraded hives" and
+       "github_auth is failing" are different questions whose useful answer is
+       the intersection — so the group head says so, rather than silently
+       looking like the others. Returns '' on a healthy fleet. */
+    function renderFailingCheckFacetGroup(assignedNoPlaceholders) {
+      var fcCounts = failingCheckCounts(assignedNoPlaceholders);
+      var fcNames = Object.keys(fcCounts).sort(function(a, b) {
+        return fcCounts[b] - fcCounts[a] || a.localeCompare(b);
+      }).slice(0, MAX_FAILING_CHECK_FILTER_OPTIONS);
+      if (!fcNames.length && !_dashFailingCheckFilter) return '';
+      /* Keep a selected check listed even at count 0 so it can be clicked off. */
+      if (_dashFailingCheckFilter && fcNames.indexOf(_dashFailingCheckFilter) === -1) {
+        fcNames.unshift(_dashFailingCheckFilter);
+        if (fcCounts[_dashFailingCheckFilter] == null) fcCounts[_dashFailingCheckFilter] = 0;
+      }
+      var body = '<div class="facet-values">' + fcNames.map(function(nm) {
+        var on = _dashFailingCheckFilter === nm;
+        var n = fcCounts[nm] || 0;
+        var tip = n >= FLEET_CHECK_SIGNAL_MIN_HIVES
+          ? nm + ' failing on ' + n + ' hives — likely fleet-wide'
+          : nm + ' failing on ' + n + (n === 1 ? ' hive' : ' hives');
+        return '<button type="button" class="facet-value' + (on ? ' on' : '') +
+          '" aria-pressed="' + (on ? 'true' : 'false') + '" title="' + esc(tip) + '"' +
+          ' onclick="setFailingCheckFilter(' + (on ? "''" : "'" + esc(nm).replace(/'/g, '&#39;') + "'") + ')">' +
+          '<span class="facet-value-label">' + esc(nm) + '</span>' +
+          '<span class="facet-value-count">' + n + '</span></button>';
+      }).join('') + '</div>';
+      return facetGroupShell(FACET_GROUP_FAILING_CHECK, 'Failing check (one at a time)',
+        !!_dashFacetCollapsed[FACET_GROUP_FAILING_CHECK], body);
+    }
+
+    /* renderFacetRail draws the tray's body: the health chips and failing-check
+       picker moved in from the old standalone bar, then the derived facet
+       groups. Derived-group counts are computed over the assigned hives after
+       the chips and the search box, but BEFORE the facets in the same group are
+       applied — so a group keeps showing its alternatives once you pick one,
+       rather than collapsing to the single value you chose. */
     function renderFacetRail(assignedAll) {
       var rail = document.getElementById('hive-facet-rail');
+      /* The rail's affordance reflects filter state even when the rail body
+         itself has nothing to draw, so update it before any early return. */
+      renderFacetTrayAffordance();
       if (!rail) return;
+      /* The health and failing-check groups filter ASSIGNED hives only — the
+         unassigned pool is inventory. The caller already scopes to assigned;
+         strip any placeholder defensively so the counts match the old bar. */
+      var assignedReal = (assignedAll || []).filter(function(h) { return !isPlaceholderHive(h); });
       var base = (assignedAll || []).filter(hiveMatchesFilters).filter(hiveMatchesSearch);
-      if (!base.length && !Object.keys(_dashFacets || {}).length) { rail.innerHTML = ''; return; }
-      var html = '';
+      var head = renderStatusFacetGroup(assignedReal) + renderFailingCheckFacetGroup(assignedReal);
+      if (!base.length && !Object.keys(_dashFacets || {}).length) {
+        rail.innerHTML = head + clearFacetsButton();
+        return;
+      }
+      var html = head;
       (HIVE_FACET_GROUPS || []).forEach(function(grp) {
         /* Count within this group ignoring this group's own selections. */
         var others = {};
@@ -8052,16 +8310,19 @@ const dashboardHTML = `<!DOCTYPE html>
               '<span class="facet-value-count">' + counts[v] + '</span></button>';
           }).join('') + '</div>';
         }
-        html += '<div class="facet-group">' +
-          '<button type="button" class="facet-group-head" aria-expanded="' + (collapsed ? 'false' : 'true') +
-          '" onclick="toggleFacetGroup(\'' + esc(grp.key) + '\')">' +
-          '<span>' + esc(grp.label) + '</span><span>' + (collapsed ? '▸' : '▾') + '</span></button>' + valuesHTML +
-          '</div>';
+        html += facetGroupShell(grp.key, grp.label, collapsed, valuesHTML);
       });
-      if (Object.keys(_dashFacets || {}).length) {
-        html += '<button type="button" class="filter-chip filter-chip-clear" onclick="clearHiveFacets()">Clear facets</button>';
-      }
-      rail.innerHTML = html;
+      rail.innerHTML = html + clearFacetsButton();
+    }
+
+    /* One Clear button for the whole tray. It calls clearAllHiveFilters(), not
+       clearHiveFacets(), because the health chips and the failing-check picker
+       now live in the same tray: a button labelled "Clear" that left two of the
+       three groups still filtering would be a lie. */
+    function clearFacetsButton() {
+      return activeFilterCount() > 0
+        ? '<button type="button" class="filter-chip filter-chip-clear" onclick="clearAllHiveFilters()">Clear all filters</button>'
+        : '';
     }
 
     /* applyDashFilters filters the hives the caller wants rendered.
@@ -8189,81 +8450,39 @@ const dashboardHTML = `<!DOCTYPE html>
         '<div class="filter-chips" style="margin-top:8px">' + chips + clearBtn + '</div>';
     }
 
-    /* renderStatusFilterBar draws the chip row plus the match count. Counts are
-       computed over the FULL assigned hive list (not the filtered one) so each
-       chip always advertises how many hives it would show. Unassigned
-       placeholders are excluded — they are inventory, and a pool of dozens of
-       "no tokens used" slots would drown the real signal. */
+    /* renderStatusFilterBar draws the "Showing X of Y" summary and the Clear
+       button. The health chips and the failing-check picker used to live here as
+       standalone chip rows; they now render inside the facet tray
+       (renderStatusFacetGroup / renderFailingCheckFacetGroup). What stays is the
+       one thing that must NOT be hidden behind a collapsed tray: the statement
+       that the list is currently narrowed, and the way back out.
+
+       Unassigned placeholders are excluded from the totals — they are
+       inventory, never filtered by these controls. */
     function renderStatusFilterBar(allHivesIn, shownCount) {
       var bar = document.getElementById('hive-filter-bar');
       if (!bar) return;
       var allHives = (allHivesIn || []).filter(function(h) { return !isPlaceholderHive(h); });
-      var counts = {};
-      counts[HIVE_FILTER_APP_MISSING] = 0;
-      counts[HIVE_FILTER_NO_TOKENS] = 0;
-      counts[HIVE_FILTER_DEGRADED] = 0;
-      counts[HIVE_FILTER_OK] = 0;
-      (allHives || []).forEach(function(h) {
-        var f = hiveStatusFlags(h);
-        if (f.appMissing) counts[HIVE_FILTER_APP_MISSING]++;
-        if (f.noTokens) counts[HIVE_FILTER_NO_TOKENS]++;
-        if (f.degraded) counts[HIVE_FILTER_DEGRADED]++;
-        if (f.ok) counts[HIVE_FILTER_OK]++;
-      });
-      var chips = (HIVE_FILTER_CHIPS || []).map(function(c) {
-        var on = !!_dashStatusFilters[c.key];
-        var cls = on ? 'filter-chip on' : 'filter-chip';
-        return '<button type="button" class="' + cls + '" aria-pressed="' + (on ? 'true' : 'false') +
-          '" onclick="toggleStatusFilter(\'' + esc(c.key) + '\')" style="--chip-color:' + c.color + '">' +
-          '<span class="filter-chip-dot" style="background:' + c.color + '"></span>' +
-          esc(c.label) + '<span class="filter-chip-count">' + counts[c.key] + '</span></button>';
-      }).join('');
-      /* Failing-check chips, most-affected first. Each doubles as the fleet
-         signal: the count IS "github_auth failing on 6 hives". Only names
-         actually failing somewhere in the assigned set appear, so the row is
-         empty (and takes no space) on a healthy fleet. */
-      var fcCounts = failingCheckCounts(allHives);
-      var fcNames = Object.keys(fcCounts).sort(function(a, b) {
-        return fcCounts[b] - fcCounts[a] || a.localeCompare(b);
-      }).slice(0, MAX_FAILING_CHECK_FILTER_OPTIONS);
-      var checkChips = '';
-      if (fcNames.length) {
-        checkChips = '<div class="filter-chips" style="margin-top:6px">' +
-          '<span style="align-self:center;color:var(--muted);font-size:0.62rem;text-transform:uppercase;letter-spacing:0.04em;margin-right:2px">Failing check</span>' +
-          fcNames.map(function(nm) {
-            var on = _dashFailingCheckFilter === nm;
-            var n = fcCounts[nm];
-            /* A check failing across several hives is a fleet problem, not a
-               hive problem — say so in the tooltip. */
-            var tip = n >= FLEET_CHECK_SIGNAL_MIN_HIVES
-              ? nm + ' failing on ' + n + ' hives — likely fleet-wide'
-              : nm + ' failing on 1 hive';
-            return '<button type="button" class="' + (on ? 'filter-chip on' : 'filter-chip') + '"' +
-              ' aria-pressed="' + (on ? 'true' : 'false') + '" title="' + esc(tip) + '"' +
-              ' onclick="setFailingCheckFilter(' + (on ? "''" : "'" + esc(nm).replace(/'/g, '&#39;') + "'") + ')"' +
-              ' style="--chip-color:#f85149">' +
-              '<span class="filter-chip-dot" style="background:#f85149"></span>' +
-              esc(nm) + '<span class="filter-chip-count">' + n + '</span></button>';
-          }).join('') + '</div>';
-      }
-      /* Every filter that narrows the list must be counted here: it drives both
-         the "Showing X of Y" summary and the Clear button, and clearStatusFilters()
-         resets all of them. Omitting one hides the Clear button while the list is
-         still filtered, which reads as hives having disappeared. */
-      var anyActive = Object.keys(_dashStatusFilters || {}).length > 0 || !!_dashFailingCheckFilter || !!_dashDriftFilter;
-      /* allHives here is the ASSIGNED set — the caller scopes it, because the
-         chips never filter unassigned placeholders. Say "assigned" so the count
-         is not read as the whole fleet. */
+      /* activeFilterCount covers EVERY narrowing control — the health chips,
+         the failing-check picker, drift, the alert drill-down, the search box
+         and the facets. Omitting one would hide the Clear button while the list
+         is still filtered, which reads as hives having disappeared. */
+      var activeN = activeFilterCount();
+      var anyActive = activeN > 0;
       var total = (allHives || []).length;
       var summary = anyActive
-        ? 'Showing ' + shownCount + ' of ' + total + ' assigned hives'
+        ? 'Showing ' + shownCount + ' of ' + total + ' assigned hives' +
+          ' &middot; ' + activeN + (activeN === 1 ? ' filter active' : ' filters active')
         : total + (total === 1 ? ' assigned hive' : ' assigned hives');
       var clearBtn = anyActive
-        ? '<button type="button" class="filter-chip filter-chip-clear" onclick="clearStatusFilters()">Clear filters</button>'
+        ? '<button type="button" class="filter-chip filter-chip-clear" onclick="clearAllHiveFilters()">Clear filters</button>'
         : '';
-      bar.innerHTML = '<div class="filter-chips">' + chips + clearBtn + '</div>' +
-        checkChips +
-        '<span class="filter-summary">' + summary + '</span>';
+      bar.innerHTML = '<span class="filter-summary">' + summary + '</span>' + clearBtn;
+      /* The bar no longer carries chip rows, so on a fleet with no assigned
+         hives it would render as an empty flex box still claiming its
+         margin-bottom. Collapse it outright in that case rather than leaving a
+         gap above the table. */
+      bar.style.display = total ? '' : 'none';
     }
 
     /* renderViewBar draws the group-by <select> and the saved-view controls.
@@ -9064,7 +9283,8 @@ const dashboardHTML = `<!DOCTYPE html>
         '|' + _dashSearchQuery + '|' + JSON.stringify(_dashFacets) +
         '|' + JSON.stringify(_dashFacetCollapsed) + '|' + JSON.stringify(_dashSectionCollapsed) +
         '|' + _dashGroupBy + '|' + JSON.stringify(_dashGroupCollapsed) +
-        '|' + _dashActiveView + '|' + _dashDefaultView + '|' + JSON.stringify(_dashSavedViews);
+        '|' + _dashActiveView + '|' + _dashDefaultView + '|' + JSON.stringify(_dashSavedViews) +
+        '|' + _dashFacetTrayOpen;
       if (!force && sig === _lastHivesJSON) return;
       _lastHivesJSON = sig;
       /* Status filters describe ASSIGNED hives only. An unassigned placeholder
@@ -9327,13 +9547,17 @@ const dashboardHTML = `<!DOCTYPE html>
           '<td title="' + esc((h.repos || []).join('\n')) + '" style="cursor:' + (repoCount > 0 ? 'help' : 'default') + '">' + repoCount + '</td>' +
           '<td>' + acmmBadge(h.acmmLevel) + '</td>' +
           '<td>' + journeyBadge(h.journey) + '</td>' +
+          /* Drift sits immediately right of Journey: both answer "how healthy
+             is this hive's configuration", so they read as one pair rather
+             than being separated by nine metric columns. Header index and body
+             index are both 11 of 17 — keep them in lockstep. */
+          '<td style="white-space:nowrap;text-align:right">' + driftBadge(h) + '</td>' +
           '<td title="' + esc((h.agents || []).map(function(a){ var label = a.name + ' (' + a.state + ')'; if (a.mode === 'on_demand') label += ' — on demand'; return label; }).join('\n')) + '" style="cursor:' + ((h.agentCount || 0) > 0 ? 'help' : 'default') + '">' + (h.agentCount || 0) + '</td>' +
           '<td title="Cumulative tokens consumed, as of the last heartbeat" style="white-space:nowrap;cursor:help">' + fmtTokens(h.totalTokens24h || 0) + '</td>' +
           '<td>' + modeCell + '</td>' +
           '<td>' + sparkline(h.issueHistory, '#f59e0b', 50, 14) + (h.actionableIssues || 0) + '</td>' +
           '<td>' + sparkline(h.prHistory, '#3b82f6', 50, 14) + (h.actionablePRs || 0) + '</td>' +
           '<td>' + (h.activeContributors || 0) + '</td>' +
-          '<td style="white-space:nowrap;text-align:right">' + driftBadge(h) + '</td>' +
           '</tr>' + pendingExpandRow;
       };
       /* Section-header row: a labeled separator spanning all columns, styled to
@@ -9477,8 +9701,7 @@ const dashboardHTML = `<!DOCTYPE html>
         /* Non-admin lists have no section headers, so the flat list's
            select-all lives in the table head instead. */
         '<th style="width:26px;text-align:center">' + (_isAdmin ? '' : bulkSectionCheckbox('all')) + '</th>' +
-        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer">Location ⇅</th><th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅</th><th>Public</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'journey\')" style="cursor:pointer" title="Where this hive is on the adoption journey: install the GitHub App, assign a method/model (or run the contributor relay), then raise the ACMM level">Journey ⇅</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th>' +
-        '<th title="Configuration drift from the fleet norm — hover a value for the specific signals">Drift</th>' +
+        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer">Location ⇅</th><th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅</th><th>Public</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'journey\')" style="cursor:pointer" title="Where this hive is on the adoption journey: install the GitHub App, assign a method/model (or run the contributor relay), then raise the ACMM level">Journey ⇅</th><th title="Configuration drift from the fleet norm — hover a value for the specific signals">Drift</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table></div>';
       /* Delegated, so binding once is enough no matter how often the table is
          re-rendered. The guard keeps repeated renders from stacking listeners. */

--- a/v2/pkg/hub/saas_dashboard_facet_tray_test.go
+++ b/v2/pkg/hub/saas_dashboard_facet_tray_test.go
@@ -1,0 +1,418 @@
+package hub
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The My Hives facet panel is a click-toggled left tray, collapsed by default,
+// with the health chips and the failing-check picker moved into it from the old
+// standalone chip bar. All of it lives inside the dashboardHTML raw string, so
+// these tests guard the wiring the Go compiler cannot see.
+
+// TestFacetTrayMarkup asserts the tray's structural elements exist. Every one of
+// them is reached by getElementById at runtime, where a missing id is a silent
+// no-op rather than an error.
+func TestFacetTrayMarkup(t *testing.T) {
+	html := dashScript(t)
+	for _, id := range []string{
+		`id="hive-facet-shell"`,
+		`id="hive-facet-toggle"`,
+		`id="hive-facet-tray"`,
+		`id="hive-facet-close"`,
+		`id="hive-facet-active-badge"`,
+		`id="hive-facet-rail"`,
+	} {
+		if !strings.Contains(html, id) {
+			t.Errorf("dashboardHTML is missing tray element %s", id)
+		}
+	}
+	// The toggle must be a real focusable control with the disclosure
+	// semantics, not a div with a click handler — keyboard users reach the
+	// tray through it and nothing else.
+	if !strings.Contains(html, `<button type="button" class="facet-rail-tab" id="hive-facet-toggle"`) {
+		t.Error("the facet tray toggle must be a real <button>")
+	}
+	for _, attr := range []string{`aria-expanded="false"`, `aria-controls="hive-facet-tray"`} {
+		if !strings.Contains(html, attr) {
+			t.Errorf("the facet tray toggle is missing %s", attr)
+		}
+	}
+}
+
+// TestFacetTrayDefaultsCollapsedAndPersists pins the two behaviours the product
+// decision rests on: the tray is CLOSED on a first visit (so the dashboard is
+// uncluttered), and the open/closed choice survives a reload under the shared
+// 'hive-*' localStorage convention. The comparison operator encodes the default,
+// so an accidental flip is a one-character change — exactly what a test is for.
+func TestFacetTrayDefaultsCollapsedAndPersists(t *testing.T) {
+	html := dashScript(t)
+	if !strings.Contains(html, `var LS_FACET_TRAY_OPEN = 'hive-facet-tray-open';`) {
+		t.Error("the facet tray's localStorage key must be a named constant following the hive-* convention")
+	}
+	// Open only when explicitly stored 'true' => default collapsed, and a
+	// corrupted value falls back to collapsed rather than to open.
+	if !strings.Contains(html, `localStorage.getItem(LS_FACET_TRAY_OPEN) === 'true'`) {
+		t.Error("the facet tray must default to COLLAPSED (=== 'true')")
+	}
+	if !strings.Contains(html, `localStorage.setItem(LS_FACET_TRAY_OPEN,`) {
+		t.Error("toggling the facet tray must persist the new state")
+	}
+	// CSS alone must never reveal the tray: a :hover rule would be unreachable
+	// on touch and would flicker across the rail/tray gap. .facet-open, set by
+	// JS from the persisted flag, is the only thing that opens it.
+	if !strings.Contains(html, `.facet-shell.facet-open .facet-tray { display: block; }`) {
+		t.Error("the tray must be revealed by the JS-driven .facet-open class")
+	}
+	if regexp.MustCompile(`\.facet-shell:hover`).MatchString(html) {
+		t.Error("the facet tray must not be hover-revealed — it is unreachable on touch")
+	}
+}
+
+// TestFacetTraySymbols asserts every function the tray's handlers call is also
+// defined. These are wired by delegation and by inline onclick; a typo in either
+// is invisible to the Go compiler and surfaces only as a dead control.
+func TestFacetTraySymbols(t *testing.T) {
+	html := dashScript(t)
+	for _, fn := range []string{
+		"applyFacetTrayState",
+		"setFacetTrayOpen",
+		"toggleFacetTray",
+		"activeFilterCount",
+		"renderFacetTrayAffordance",
+		"facetGroupShell",
+		"renderStatusFacetGroup",
+		"renderFailingCheckFacetGroup",
+		"clearFacetsButton",
+	} {
+		if !strings.Contains(html, "function "+fn+"(") {
+			t.Errorf("dashboardHTML is missing a definition for %s()", fn)
+		}
+		if strings.Count(html, fn+"(") < 2 {
+			t.Errorf("dashboardHTML defines %s() but never calls it", fn)
+		}
+	}
+}
+
+// TestStatusFiltersMovedIntoTray asserts the health chips and the failing-check
+// picker now render inside the tray rather than as a standalone chip row, and —
+// crucially — that moving them did NOT change how they combine. The state
+// variables and the matching predicate are untouched; only the markup moved.
+func TestStatusFiltersMovedIntoTray(t *testing.T) {
+	html := dashScript(t)
+	// Rendered as facet groups inside the tray.
+	for _, want := range []string{
+		"function renderStatusFacetGroup(assignedNoPlaceholders)",
+		"function renderFailingCheckFacetGroup(assignedNoPlaceholders)",
+		`facetGroupShell(FACET_GROUP_HEALTH, 'Health'`,
+		`facetGroupShell(FACET_GROUP_FAILING_CHECK, 'Failing check (one at a time)'`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("the moved filters must render as tray groups; missing: %s", want)
+		}
+	}
+	// Semantics unchanged: same state, same predicate, same handlers.
+	for _, want := range []string{
+		"_dashStatusFilters",       // health chips still OR among themselves
+		"_dashFailingCheckFilter",  // failing check still single-select, ANDed
+		"toggleStatusFilter(",
+		"setFailingCheckFilter(",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("moving the filters must not change their semantics; missing: %s", want)
+		}
+	}
+	// The old standalone chip row is gone: renderStatusFilterBar must no longer
+	// emit filter-chip buttons, only the summary and the way out of it.
+	i := strings.Index(html, "function renderStatusFilterBar(allHivesIn, shownCount)")
+	if i < 0 {
+		t.Fatal("renderStatusFilterBar not found")
+	}
+	body := html[i:]
+	if end := strings.Index(body, "\n    /* renderViewBar"); end >= 0 {
+		body = body[:end]
+	}
+	if strings.Contains(body, `class="filter-chip on"`) || strings.Contains(body, "filter-chip-dot") {
+		t.Error("renderStatusFilterBar must no longer draw the status chip row — it moved into the tray")
+	}
+	if !strings.Contains(body, `class="filter-summary"`) {
+		t.Error("renderStatusFilterBar must still show the Showing X of Y summary")
+	}
+	// An empty bar must not reserve vertical space now that its chips are gone.
+	if !strings.Contains(body, "bar.style.display = total ? '' : 'none';") {
+		t.Error("the filter bar must collapse when it has no summary to show")
+	}
+}
+
+// TestActiveFilterCountCoversEveryFilter is the anti-invisible-filter guard.
+// With the tray collapsed by default, the rail's badge is the ONLY thing telling
+// an operator why the table is short. Every control that can narrow the list
+// must therefore be counted; omitting one produces a filtered list with no
+// visible cause, which is worse than no filtering at all.
+func TestActiveFilterCountCoversEveryFilter(t *testing.T) {
+	html := dashScript(t)
+	i := strings.Index(html, "function activeFilterCount()")
+	if i < 0 {
+		t.Fatal("activeFilterCount not found")
+	}
+	body := html[i:]
+	if end := strings.Index(body, "\n    /* renderFacetTrayAffordance"); end >= 0 {
+		body = body[:end]
+	}
+	for _, state := range []string{
+		"_dashStatusFilters",
+		"_dashFailingCheckFilter",
+		"_dashDriftFilter",
+		"_alertTypeFilter",
+		"_dashSearchQuery",
+		"_dashFacets",
+	} {
+		if !strings.Contains(body, state) {
+			t.Errorf("activeFilterCount omits %s — that filter would narrow the list "+
+				"with nothing on screen explaining why", state)
+		}
+	}
+	// The collapsed rail must actually surface the count.
+	for _, want := range []string{
+		`toggle.classList.toggle('has-active', n > 0)`,
+		"badge.textContent = n > 0 ? String(n) : '';",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("the collapsed rail must indicate active filters; missing: %s", want)
+		}
+	}
+}
+
+// TestRenderCacheSignatureIncludesTrayState extends the existing signature guard
+// to the tray. renderHives short-circuits on an unchanged signature, so any view
+// state left out of it makes the corresponding control a silent no-op.
+func TestRenderCacheSignatureIncludesTrayState(t *testing.T) {
+	html := dashScript(t)
+	i := strings.Index(html, "var sig = JSON.stringify(allHives) + '|' + JSON.stringify(_dashStatusFilters)")
+	if i < 0 {
+		t.Fatal("could not find the renderHives cache signature")
+	}
+	sig := html[i:]
+	if end := strings.Index(sig, "if (!force"); end >= 0 {
+		sig = sig[:end]
+	}
+	// Everything that was already in the signature must stay in it — a move
+	// must never quietly drop a filter's state.
+	for _, state := range []string{
+		"_dashStatusFilters",
+		"_dashFailingCheckFilter",
+		"_dashDriftFilter",
+		"_alertTypeFilter",
+		"_alertShowAcked",
+		"_dashSearchQuery",
+		"_dashFacets",
+		"_dashFacetCollapsed",
+		"_dashSectionCollapsed",
+		"_dashGroupBy",
+		"_dashGroupCollapsed",
+		"_dashActiveView",
+		"_dashDefaultView",
+		"_dashSavedViews",
+		"_dashFacetTrayOpen",
+	} {
+		if !strings.Contains(sig, state) {
+			t.Errorf("renderHives cache signature omits %s — changes to it would be a silent no-op", state)
+		}
+	}
+}
+
+// TestClearAllHiveFiltersStillClearsEverything pins the escape hatch. It is now
+// reachable from three places (the empty state, the summary bar and the tray),
+// so a filter it forgets would leave the operator looking at an empty table with
+// a Clear button that does nothing.
+func TestClearAllHiveFiltersStillClearsEverything(t *testing.T) {
+	html := dashScript(t)
+	i := strings.Index(html, "function clearAllHiveFilters()")
+	if i < 0 {
+		t.Fatal("clearAllHiveFilters not found")
+	}
+	body := html[i:]
+	if end := strings.Index(body, "\n    function toggleAlertAcked"); end >= 0 {
+		body = body[:end]
+	}
+	for _, reset := range []string{
+		"_dashStatusFilters = {};",
+		"_dashFailingCheckFilter = '';",
+		"_dashDriftFilter = '';",
+		"_alertTypeFilter = '';",
+		"_dashFacets = {};",
+		"_dashSearchQuery = '';",
+	} {
+		if !strings.Contains(body, reset) {
+			t.Errorf("clearAllHiveFilters must reset %s", reset)
+		}
+	}
+	// clearStatusFilters remains the group-scoped reset for the health and
+	// failing-check groups, and must still clear all three of its own filters.
+	j := strings.Index(html, "function clearStatusFilters()")
+	if j < 0 {
+		t.Fatal("clearStatusFilters not found")
+	}
+	sub := html[j:]
+	if end := strings.Index(sub, "\n    /* toggleDriftFilter"); end >= 0 {
+		sub = sub[:end]
+	}
+	for _, reset := range []string{
+		"_dashStatusFilters = {};",
+		"_dashFailingCheckFilter = '';",
+		"_dashDriftFilter = '';",
+	} {
+		if !strings.Contains(sub, reset) {
+			t.Errorf("clearStatusFilters must reset %s", reset)
+		}
+	}
+}
+
+// TestFacetTrayLayersBelowRowHoverPanels pins the stacking decision. The row
+// hover panels (.hive-access-pop and healthBadge's custom panel) sit at
+// z-index 60; the tray must stay strictly below them, or a panel on a row the
+// tray overlaps would render behind it and be unreadable.
+func TestFacetTrayLayersBelowRowHoverPanels(t *testing.T) {
+	html := dashScript(t)
+	if !strings.Contains(html, "z-index: 40;") {
+		t.Error("the facet tray must declare an explicit z-index")
+	}
+	trayZ := regexp.MustCompile(`\.facet-tray \{[^}]*z-index: (\d+)`).FindStringSubmatch(html)
+	if trayZ == nil {
+		t.Fatal("could not read the .facet-tray z-index")
+	}
+	if trayZ[1] != "40" {
+		t.Errorf(".facet-tray z-index is %s, want 40 — it must stay below the "+
+			"z-index:60 row hover panels", trayZ[1])
+	}
+	// The panels' own layer must not have drifted either, or "below 60" is a
+	// claim about a number that no longer exists.
+	if !strings.Contains(html, "z-index:60;") {
+		t.Error("the row hover panels are expected at z-index:60")
+	}
+}
+
+// TestHiveTableColumnCountsAgree is the column-discipline guard. The header and
+// every row must emit the same number of cells, and the colspan constants that
+// span the table must match that number. A past bug moved a <th> without moving
+// its <td>, which silently shifted every column right of it.
+func TestHiveTableColumnCountsAgree(t *testing.T) {
+	html := dashScript(t)
+
+	// --- header: count <th> cells between the table open and </tr></thead>.
+	start := strings.Index(html, `'<div class="table-wrap"><table class="hive-table"><thead><tr>'`)
+	if start < 0 {
+		t.Fatal("could not find the hive table header")
+	}
+	end := strings.Index(html[start:], `</tr></thead><tbody>' + rows`)
+	if end < 0 {
+		t.Fatal("could not find the end of the hive table header")
+	}
+	header := html[start : start+end]
+	// "<th" only — "<thead" is excluded by requiring the next char to be '>' or
+	// whitespace, which is what makes this a count of cells and not of tags.
+	thCount := len(regexp.MustCompile(`<th[\s>]`).FindAllString(header, -1))
+
+	// --- body: count the <td> cells buildRow emits, plus the one contributed
+	// by the bulkCheckboxCell() helper, which emits no literal tag here.
+	bStart := strings.Index(html, "var buildRow = function(h, i, section) {")
+	if bStart < 0 {
+		t.Fatal("could not find buildRow")
+	}
+	retIdx := strings.Index(html[bStart:], "return '<tr>' +")
+	if retIdx < 0 {
+		t.Fatal("could not find buildRow's return")
+	}
+	rStart := bStart + retIdx
+	rEnd := strings.Index(html[rStart:], "'</tr>' + pendingExpandRow;")
+	if rEnd < 0 {
+		t.Fatal("could not find the end of buildRow's return")
+	}
+	rowExpr := html[rStart : rStart+rEnd]
+	tdCount := len(regexp.MustCompile(`'<td[\s>]`).FindAllString(rowExpr, -1))
+	if !strings.Contains(rowExpr, "bulkCheckboxCell(h, section || 'all')") {
+		t.Fatal("buildRow no longer emits bulkCheckboxCell — the body count below is wrong")
+	}
+	tdCount++ // bulkCheckboxCell contributes exactly one cell
+
+	if thCount != tdCount {
+		t.Errorf("header emits %d <th> cells but a row emits %d cells — "+
+			"every column right of the mismatch is shifted", thCount, tdCount)
+	}
+	const wantColumns = 17
+	if thCount != wantColumns {
+		t.Errorf("hive table has %d columns, want %d", thCount, wantColumns)
+	}
+	// The colspan constants span the whole table; a stale value leaves the
+	// section separators and the pending-requests row visibly short.
+	for _, decl := range []string{
+		"var TOTAL_COLUMNS = 17;",
+		"var TOTAL_COLUMNS_HEADER = 17;",
+	} {
+		if !strings.Contains(html, decl) {
+			t.Errorf("missing or stale colspan constant: %s", decl)
+		}
+	}
+}
+
+// TestDriftColumnSitsRightOfJourney pins the column ORDER, in both the header
+// and the body, at the same index. Asserting only the header is how the last
+// column-move bug shipped.
+func TestDriftColumnSitsRightOfJourney(t *testing.T) {
+	html := dashScript(t)
+
+	// --- header order.
+	start := strings.Index(html, `'<div class="table-wrap"><table class="hive-table"><thead><tr>'`)
+	end := strings.Index(html[start:], `</tr></thead><tbody>' + rows`)
+	if start < 0 || end < 0 {
+		t.Fatal("could not isolate the hive table header")
+	}
+	header := html[start : start+end]
+	journeyTh := strings.Index(header, ">Journey ")
+	driftTh := strings.Index(header, ">Drift<")
+	if journeyTh < 0 || driftTh < 0 {
+		t.Fatal("could not find the Journey and Drift header cells")
+	}
+	if driftTh < journeyTh {
+		t.Fatal("Drift header cell comes before Journey")
+	}
+	// Nothing but the closing tag of Journey's own cell may sit between them:
+	// any other <th> would mean Drift is not IMMEDIATELY right of Journey.
+	between := header[journeyTh:driftTh]
+	if n := len(regexp.MustCompile(`<th[\s>]`).FindAllString(between, -1)); n != 1 {
+		t.Errorf("found %d header cells between Journey and Drift, want exactly 1 "+
+			"(Drift's own <th>) — Drift must sit immediately right of Journey", n)
+	}
+
+	// --- body order, over the same expression the row is built from.
+	bStart := strings.Index(html, "var buildRow = function(h, i, section) {")
+	retIdx := strings.Index(html[bStart:], "return '<tr>' +")
+	rStart := bStart + retIdx
+	rEnd := strings.Index(html[rStart:], "'</tr>' + pendingExpandRow;")
+	if bStart < 0 || retIdx < 0 || rEnd < 0 {
+		t.Fatal("could not isolate buildRow's return expression")
+	}
+	rowExpr := html[rStart : rStart+rEnd]
+	journeyTd := strings.Index(rowExpr, "journeyBadge(h.journey)")
+	driftTd := strings.Index(rowExpr, "driftBadge(h)")
+	if journeyTd < 0 || driftTd < 0 {
+		t.Fatal("could not find the Journey and Drift body cells")
+	}
+	if driftTd < journeyTd {
+		t.Fatal("the Drift body cell comes before the Journey body cell")
+	}
+	between = rowExpr[journeyTd:driftTd]
+	if n := len(regexp.MustCompile(`'<td[\s>]`).FindAllString(between, -1)); n != 1 {
+		t.Errorf("found %d body cells between Journey and Drift, want exactly 1 "+
+			"(Drift's own <td>) — the body must match the header order", n)
+	}
+	// Drift must appear exactly once in each, i.e. the move did not leave a copy
+	// behind at the old position.
+	if n := strings.Count(header, ">Drift<"); n != 1 {
+		t.Errorf("Drift appears %d times in the header, want 1", n)
+	}
+	if n := strings.Count(rowExpr, "driftBadge(h)"); n != 1 {
+		t.Errorf("driftBadge appears %d times in a row, want 1", n)
+	}
+}


### PR DESCRIPTION
Two UI changes to the hub's **My Hives** view, plus the follow-up ask to fold the status filters into the tray.

All of this lives in the inline Go raw-string `dashboardHTML` in `v2/pkg/hub/saas.go`.

---

## 1. Drift moves to the right of Journey

Drift sat at the far right of the table, nine columns away from Journey — which asks the same question about the same hive. It now sits immediately right of Journey.

**Verified column order (17 columns, before → after):**

| # | Before | After |
|---|--------|-------|
| 1 | bulk-select | bulk-select |
| 2 | (menu) | (menu) |
| 3 | Hive | Hive |
| 4 | Location | Location |
| 5 | Uptime | Uptime |
| 6 | Public | Public |
| 7 | Version | Version |
| 8 | Repos | Repos |
| 9 | ACMM | ACMM |
| 10 | Journey | Journey |
| 11 | Agents | **Drift** |
| 12 | Tokens | Agents |
| 13 | Mode | Tokens |
| 14 | Issues | Mode |
| 15 | PRs | Issues |
| 16 | Contributors | PRs |
| 17 | **Drift** | Contributors |

**How it was enumerated** — counting tags is wrong in both directions here, so cells were counted, not tags:

- `grep -c '<th'` false-matches `<thead>`, so the header was matched on `<th[\s>]` between the table open and `</tr></thead>`.
- One body cell — the bulk-select column — is emitted by the `bulkCheckboxCell()` helper with no literal `<td>` in `buildRow`, so a literal-tag count of the body undercounts by exactly one.
- Header and body were then confirmed against a **live DOM**: 17 `<th>`, 17 `<td>`, `Journey@10`, `Drift@11`, and the body cell at index 11 is the right-aligned `driftBadge` cell.

**Nothing indexes columns positionally.** The sort handlers are keyed by field name (`sortDashHives('journey')`), not by column index; there are no `nth-child` rules anywhere in the file; and the only positional dependency is the two colspan constants, both still `17` — a move changes order, not count. Both are asserted by a new test, along with header/body agreement.

## 2. Facet panel becomes a collapsible left tray

Per the correction: **click-toggled, not hover-revealed.**

- A rail on the left margin with a real `<button>` toggle carrying `aria-expanded` and `aria-controls`. Click to expand, click to collapse. Enter/Space work because it is a button, not a div.
- **Collapsed by default**, so the dashboard is uncluttered until filters are asked for.
- **State persists** under `hive-facet-tray-open`, following the same `hive-*` localStorage convention as the section- and group-collapse flags. Open only when explicitly stored `'true'`, so a first visit and a corrupted value both fall back to closed.
- **Escape** closes the tray when focus is inside it and returns focus to the toggle, so a keyboard user is never stranded on a hidden control.
- **Touch** works naturally — it is a tap target. There is no `@media (hover: hover)` guard because there is no hover behaviour to guard.
- **Overlay, not push.** Pushing would re-flow the table on every toggle and re-trigger `.table-wrap`'s horizontal-scroll measurement. Overlaying leaves the scroll container untouched. Below 900px the tray becomes an in-flow disclosure above the table instead, driven by the same class and the same button.
- **Layering:** the tray is `z-index: 40`, deliberately below the `z-index: 60` row hover panels (`.hive-access-pop` / `healthBadge`'s custom panel), so a row's panel always draws *above* the tray. `.facet-shell` is `position: relative` with no overflow clipping, so nothing is cut off. Pinned by a test that reads both z-indexes.

## 3. Status chips and failing-check filter move into the tray

The standalone chip rows are gone; both now render as groups inside the tray.

**Semantics are unchanged** — only the markup moved. The health chips still OR among themselves via `_dashStatusFilters`; the failing-check filter is still single-select and still ANDed against them by `hiveMatchesFilters`. That AND is *not* the OR-within-group rule the derived facets use, so rather than let it silently look like the others, its group head says **"Failing check (one at a time)"**.

**Counts are preserved** and still computed over the assigned set only, with placeholders excluded — the same scoping the old bar used, now consistent with the derived facet groups' counts.

**What was found and deliberately not moved:** the drift and alert-type filters are *not* standalone chip rows. Drift chips live inside `#hive-drift-summary`'s "⚠ N hives need attention" callout, and alert-type chips inside `#fleet-alerts-panel`'s drill-down. Both are contextual panels that only appear when there is something to say, and moving their chips into the tray would strip the headline that gives them meaning. They stay where they are — but both are counted in the tray's active-filter badge and cleared by Clear.

## Active filters stay visible

This mattered most, since the tray is closed by default:

- The collapsed rail turns accent-coloured and shows a **count badge** whenever anything is narrowing the list.
- `activeFilterCount()` counts **every** control — health chips, failing check, drift, the alert drill-down, the search box, and each selected facet value *individually* (so "3" means three choices, not three groups). A test asserts every one of those six state variables is read.
- The summary bar keeps "Showing X of Y assigned hives" and now appends the active filter count, and collapses entirely rather than reserving space when there is nothing to say.

`clearAllHiveFilters()` still resets all six; `clearStatusFilters()` remains the group-scoped reset for the health/failing-check/drift trio. Both are pinned by tests.

The **render-cache signature** gains `_dashFacetTrayOpen` and keeps all fifteen pieces it already carried — asserted by name, so a future move cannot quietly drop one and turn a control into a silent no-op.

## Verification

`node --check` is not sufficient for this file — a missing brace produces valid-but-wrongly-scoped JS that parses fine and breaks the dashboard at runtime (#2177). So:

- Script bodies were extracted **fresh** (old copies deleted first) and the extraction proven non-stale by grepping the extracted file for the 13 identifiers introduced here — 48 hits on symbols that did not exist before this change. `node --check` passes on both blocks.
- Better: the real `dashboardHTML` was **driven in jsdom** — **47 runtime assertions, all passing**, covering the toggle and its ARIA state, localStorage persistence across open/close, the close button, Escape-with-focus-inside, the chips rendering inside the tray, OR-among-chips (a second chip *widens*: 1 → 2 rows), failing-check AND (strictly narrows: 1 → 0), the badge count tracking each filter type, the tray staying collapsed while filters are active, the cache signature not short-circuiting, and the full 17-column header/body order. Zero console errors on load.

`go build ./...` and `go vet ./pkg/hub/` pass. `TestSingleHoverPanelInvariant`, `TestInlineAvatarsCarryNoCustomPanel`, `TestDashboardScriptBracesAreBalanced`, `TestDashboardRenderStateIsTopLevel`, `TestDashboardRenderFunctionsAreTopLevel` and the existing My Hives UX tests all still pass (see the local-test caveat at the bottom).

New test file `saas_dashboard_facet_tray_test.go` adds 9 tests covering the tray markup and ARIA, the collapsed-by-default and persistence rules, an assertion that no `:hover` rule reveals the tray, the moved filters keeping their semantics, `activeFilterCount` coverage, the extended cache signature, both clear functions, the z-index ordering, and the column count/order in header *and* body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Rebased onto v2 after #2182 merged** (`hiveLabel(h)` / `hiveNameSortValue`). Clean rebase, no conflicts — #2182 rewrote the name cell's inner expression while this moves a sibling `<td>`; both are present and all tests pass on the rebased tree.

**Local test caveat:** `go build ./...` and `go vet ./pkg/hub/` pass, and every dashboard/table test named above passes when run by name. The *full* `./pkg/hub/` suite does not complete in this sandbox — it hangs with no output and needs a writable `/data` and network. Confirmed environmental, not caused by this change: a pristine `origin/v2` worktree hangs identically under the same command. CI's `build-and-test` is the authoritative gate.
