### PR TITLE
🔐 feat(hub): self-correct GitHub App private keys across the fleet

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -55,6 +55,63 @@ var (
 	gitBranch = "unknown"
 )
 
+// GitHub App private-key locations on a spoke, and how the two differ.
+//
+//   - spokeProvisionedAppKeyPath is a read-only Kubernetes Secret mount, written
+//     at PROVISIONING time from a key an operator supplied for THIS hive
+//     specifically. Its presence is the marker of a deliberate per-hive
+//     credential, which the hub's cluster-wide reconcile must never overwrite.
+//   - spokeAppKeyPath is on the PVC and is where a hub-delivered (cluster
+//     default) key lands. It is also what cfg.GitHub.KeyFile is repointed at
+//     once the hub delivers one, so it takes effect over the provisioned mount.
+const (
+	spokeProvisionedAppKeyPath = "/secrets/gh-app-key.pem"
+	spokeAppKeyPath            = "/data/gh-app-key.pem"
+	// spokeAppKeyFileMode is rw------- : signing material must never be
+	// readable by anything else sharing the PVC or the pod.
+	spokeAppKeyFileMode = 0o600
+)
+
+// reportedAppKeyFingerprint returns the non-secret fingerprint of the App key
+// this spoke is ACTUALLY using, for the heartbeat payload. It fingerprints the
+// resolved key file rather than a hard-coded path so the hub compares against
+// the key that would really sign a JWT.
+//
+// Returns "" whenever there is no usable key — no file, empty file, or
+// unparseable contents. All three mean the same thing to the hub ("this spoke
+// cannot authenticate") and are repaired identically. The private key itself is
+// never returned, and never enters the payload.
+func reportedAppKeyFingerprint(keyFile string) string {
+	candidates := []string{keyFile, spokeAppKeyPath, spokeProvisionedAppKeyPath}
+	for _, p := range candidates {
+		if strings.TrimSpace(p) == "" {
+			continue
+		}
+		if fp, err := config.AppKeyFingerprintFromFile(p); err == nil && fp != "" {
+			return fp
+		}
+	}
+	return ""
+}
+
+// hasPerHiveAppKey reports whether this spoke's key came from a per-hive
+// provisioning secret rather than the cluster default. The provisioned mount is
+// read-only, so its mere existence with real PEM content is the signal — a
+// hub-delivered key can never create or alter it.
+//
+// When BOTH exist the hub-delivered PVC key is the one in effect (the callback
+// repoints cfg.GitHub.KeyFile at it), so this only claims an override while the
+// provisioned key is genuinely the one being used.
+func hasPerHiveAppKey(keyFile string) bool {
+	fp, err := config.AppKeyFingerprintFromFile(spokeProvisionedAppKeyPath)
+	if err != nil || fp == "" {
+		return false
+	}
+	// The provisioned key exists. It is the effective credential only if the
+	// resolved key file still points at it.
+	return strings.TrimSpace(keyFile) == "" || keyFile == spokeProvisionedAppKeyPath
+}
+
 // processStartedAt is when this hive process began. Reported over the heartbeat
 // so the hub can show an uptime pill — a hive that is 1/1 Running but restarting
 // every couple of minutes looks healthy in a pod listing and in My Hives, and a
@@ -1780,6 +1837,12 @@ func main() {
 				PRsMerged90d:   prsMerged,
 				PRsRejected90d: prsRejected,
 				CVEsClosed:     cvesClosed,
+				// Report WHICH App key we hold, never the key. The hub compares
+				// this against its per-cluster key and pushes a correction only
+				// on a mismatch, so a spoke already holding the right key costs
+				// nothing and a spoke holding the wrong one self-heals.
+				GitHubAppKeyFingerprint: reportedAppKeyFingerprint(cfg.GitHub.KeyFile),
+				GitHubAppKeyPerHive:     hasPerHiveAppKey(cfg.GitHub.KeyFile),
 			}
 		}, heartbeatSendInterval, logger, hub.UpgradeCallback(func(targetSHA string) {
 			const upgradeMarkerPath = "/data/upgrade-requested"
@@ -1901,20 +1964,51 @@ func main() {
 				"has_key", ghCfg.PrivateKey != "",
 			)
 
-			keyPath := "/data/gh-app-key.pem"
+			keyPath := spokeAppKeyPath
 			if ghCfg.PrivateKey != "" {
-				const keyFileMode = 0o600
-				if err := os.WriteFile(keyPath, []byte(ghCfg.PrivateKey), keyFileMode); err != nil {
+				// Fingerprint before and after so the key rotation is auditable
+				// from the spoke's own logs. Fingerprints only — the key itself
+				// is never logged.
+				beforeFP, _ := config.AppKeyFingerprintFromFile(keyPath)
+				if err := os.WriteFile(keyPath, []byte(ghCfg.PrivateKey), spokeAppKeyFileMode); err != nil {
 					logger.Error("failed to write github app key from heartbeat", "error", err)
 					return
 				}
-				logger.Info("github app private key written via heartbeat", "path", keyPath)
+				// os.WriteFile does NOT re-apply the mode to a file that already
+				// exists, so a key written by an older build (or restored from a
+				// looser-moded source) would keep its old permissions forever.
+				// Chmod unconditionally so every path converges on 0600.
+				if err := os.Chmod(keyPath, spokeAppKeyFileMode); err != nil {
+					logger.Warn("could not tighten github app key permissions", "path", keyPath, "error", err)
+				}
+				afterFP, _ := config.AppKeyFingerprintFromFile(keyPath)
+				logger.Info("github app private key written via heartbeat",
+					"path", keyPath,
+					"from_fingerprint", beforeFP,
+					"to_fingerprint", afterFP,
+				)
 			}
 
-			cfg.GitHub.AppID = ghCfg.AppID
-			cfg.GitHub.InstallationID = ghCfg.InstallationID
+			if ghCfg.AppID != 0 {
+				cfg.GitHub.AppID = ghCfg.AppID
+			}
+			// A zero installation_id means "the hub is not speaking to this
+			// field", not "clear it". The cluster-wide key reconcile repairs the
+			// KEY on hives whose installation_id is already correct (and which
+			// the hub does not track); assigning zero here would blank a working
+			// value and turn a key-only fault into a total auth outage.
+			if ghCfg.InstallationID != 0 {
+				cfg.GitHub.InstallationID = ghCfg.InstallationID
+			}
 			if ghCfg.PrivateKey != "" {
 				cfg.GitHub.KeyFile = keyPath
+			}
+			// Same "empty means unchanged" contract as installation_id: adopting
+			// an empty slug would blank a working install link.
+			if ghCfg.AppSlug != "" && cfg.GitHub.AppSlug != ghCfg.AppSlug {
+				logger.Info("adopting github app slug from hub",
+					"was", cfg.GitHub.AppSlug, "now", ghCfg.AppSlug)
+				cfg.GitHub.AppSlug = ghCfg.AppSlug
 			}
 
 			if cfg.GitHub.AppID != 0 && cfg.GitHub.InstallationID != 0 && cfg.GitHub.KeyFile != "" {

--- a/v2/pkg/config/appkey.go
+++ b/v2/pkg/config/appkey.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"crypto"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/pem"
+	"errors"
+	"os"
+	"strings"
+)
+
+// GitHub App private-key fingerprinting.
+//
+// A spoke must be able to tell the hub WHICH App key it is running without ever
+// sending the key itself. The fingerprint below is derived from the PUBLIC half
+// of the key, so it is safe to put in a heartbeat payload, a log line, or an
+// operator-facing API response — it reveals nothing that GitHub does not already
+// publish, and it cannot be inverted back into signing material.
+//
+// The digest is taken over the DER-encoded PKIX *public* key rather than over
+// the PEM file bytes, so two byte-different encodings of the SAME key
+// (PKCS#1 "BEGIN RSA PRIVATE KEY" vs PKCS#8 "BEGIN PRIVATE KEY", CRLF vs LF,
+// trailing newline present or absent) produce the SAME fingerprint. A file-bytes
+// digest would report a spurious mismatch on all of those and make the hub
+// re-push a key that was already correct on every single heartbeat.
+
+// AppKeyFingerprintLen is the number of hex characters kept from the SHA-256
+// digest of the public key. 32 hex chars = 128 bits, far beyond what is needed
+// to distinguish the handful of App keys in a fleet while keeping log lines and
+// JSON payloads readable. Never truncate below this: shorter prefixes invite
+// accidental collisions that would suppress a needed key push.
+const AppKeyFingerprintLen = 32
+
+// appKeyFingerprintPrefix labels the digest with its scheme so a future change
+// of algorithm is self-describing on the wire and in logs, and so an old
+// fingerprint can never be silently compared against a new-scheme one.
+const appKeyFingerprintPrefix = "sha256:"
+
+// ErrNoAppKey is returned when there is no key material to fingerprint at all
+// (empty string, or a key file that does not exist). Callers treat this as
+// "spoke has no key", which is a legitimate, expected state — not an error to
+// log loudly.
+var ErrNoAppKey = errors.New("no github app private key")
+
+// AppKeyFingerprint returns a non-secret, stable identifier for a GitHub App
+// private key in PEM form. The returned value is "sha256:<hex>" and NEVER
+// contains key material.
+//
+// It returns ErrNoAppKey for empty input so callers can distinguish "no key" from
+// "malformed key" — the two demand different operator responses.
+func AppKeyFingerprint(pemData string) (string, error) {
+	trimmed := strings.TrimSpace(pemData)
+	if trimmed == "" {
+		return "", ErrNoAppKey
+	}
+
+	block, _ := pem.Decode([]byte(trimmed))
+	if block == nil {
+		return "", errors.New("github app key is not valid PEM")
+	}
+
+	pub, err := publicKeyFromPrivateDER(block.Bytes)
+	if err != nil {
+		return "", err
+	}
+
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return "", err
+	}
+
+	sum := sha256.Sum256(der)
+	full := hex.EncodeToString(sum[:])
+	return appKeyFingerprintPrefix + full[:AppKeyFingerprintLen], nil
+}
+
+// publicKeyFromPrivateDER extracts the public half of a private key from DER
+// bytes, accepting every encoding GitHub and GitHub Enterprise hand out:
+// PKCS#1 (the classic "BEGIN RSA PRIVATE KEY" download), PKCS#8, and SEC1 EC.
+// Trying each in turn is deliberate — rejecting a valid key because it arrived
+// in the other standard encoding would make the hub re-push forever.
+func publicKeyFromPrivateDER(der []byte) (any, error) {
+	if k, err := x509.ParsePKCS1PrivateKey(der); err == nil {
+		return &k.PublicKey, nil
+	}
+	if k, err := x509.ParsePKCS8PrivateKey(der); err == nil {
+		if pk, ok := k.(interface{ Public() crypto.PublicKey }); ok {
+			return pk.Public(), nil
+		}
+		return nil, errors.New("github app key has no derivable public key")
+	}
+	if k, err := x509.ParseECPrivateKey(der); err == nil {
+		return &k.PublicKey, nil
+	}
+	return nil, errors.New("github app key is not a recognized private key encoding")
+}
+
+// AppKeyFingerprintFromFile fingerprints the key stored at path. A missing or
+// empty file yields ErrNoAppKey — the normal "this hive was provisioned without
+// a key" state, which the hub repairs rather than reports as a failure.
+func AppKeyFingerprintFromFile(path string) (string, error) {
+	if strings.TrimSpace(path) == "" {
+		return "", ErrNoAppKey
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", ErrNoAppKey
+		}
+		return "", err
+	}
+	return AppKeyFingerprint(string(data))
+}

--- a/v2/pkg/config/appkey_test.go
+++ b/v2/pkg/config/appkey_test.go
@@ -1,0 +1,220 @@
+package config
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// testRSAKeyBits is deliberately the smallest size Go will generate quickly.
+// These keys are never used for real signing — only to exercise fingerprinting.
+const testRSAKeyBits = 2048
+
+func mustRSAPEMs(t *testing.T) (pkcs1 string, pkcs8 string) {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, testRSAKeyBits)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+	p1 := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(k),
+	})
+	der, err := x509.MarshalPKCS8PrivateKey(k)
+	if err != nil {
+		t.Fatalf("marshal pkcs8: %v", err)
+	}
+	p8 := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	return string(p1), string(p8)
+}
+
+// TestAppKeyFingerprintStableAcrossEncodings is the property the whole
+// self-correction loop rests on: the SAME key must fingerprint identically no
+// matter how it was encoded or whitespace-mangled. If it did not, the hub would
+// see a permanent mismatch and re-push a credential on every heartbeat forever.
+func TestAppKeyFingerprintStableAcrossEncodings(t *testing.T) {
+	pkcs1, pkcs8 := mustRSAPEMs(t)
+
+	base, err := AppKeyFingerprint(pkcs1)
+	if err != nil {
+		t.Fatalf("fingerprint pkcs1: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{"pkcs1 identical", pkcs1},
+		{"pkcs8 same key", pkcs8},
+		{"leading and trailing whitespace", "\n\t " + pkcs1 + "\n\n"},
+		{"no trailing newline", strings.TrimRight(pkcs1, "\n")},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := AppKeyFingerprint(tc.in)
+			if err != nil {
+				t.Fatalf("AppKeyFingerprint: %v", err)
+			}
+			if got != base {
+				t.Errorf("fingerprint = %q, want %q (same key, different encoding)", got, base)
+			}
+		})
+	}
+}
+
+func TestAppKeyFingerprintDistinguishesKeys(t *testing.T) {
+	a, _ := mustRSAPEMs(t)
+	b, _ := mustRSAPEMs(t)
+
+	fpA, err := AppKeyFingerprint(a)
+	if err != nil {
+		t.Fatalf("fingerprint a: %v", err)
+	}
+	fpB, err := AppKeyFingerprint(b)
+	if err != nil {
+		t.Fatalf("fingerprint b: %v", err)
+	}
+	if fpA == fpB {
+		t.Fatal("two distinct keys produced the same fingerprint")
+	}
+}
+
+// TestAppKeyFingerprintLeaksNoKeyMaterial guards the security property directly:
+// nothing recognizable from the private key may appear in its fingerprint.
+func TestAppKeyFingerprintLeaksNoKeyMaterial(t *testing.T) {
+	pkcs1, _ := mustRSAPEMs(t)
+	fp, err := AppKeyFingerprint(pkcs1)
+	if err != nil {
+		t.Fatalf("AppKeyFingerprint: %v", err)
+	}
+	if strings.Contains(fp, "BEGIN") || strings.Contains(fp, "PRIVATE") {
+		t.Fatalf("fingerprint %q looks like it contains PEM material", fp)
+	}
+	// Every base64 body line of the PEM must be absent from the fingerprint.
+	for _, line := range strings.Split(pkcs1, "\n") {
+		line = strings.TrimSpace(line)
+		if len(line) < 20 || strings.HasPrefix(line, "-----") {
+			continue
+		}
+		if strings.Contains(fp, line) {
+			t.Fatalf("fingerprint contains a line of the private key")
+		}
+	}
+	if !strings.HasPrefix(fp, "sha256:") {
+		t.Errorf("fingerprint %q missing scheme prefix", fp)
+	}
+	if len(fp) != len("sha256:")+AppKeyFingerprintLen {
+		t.Errorf("fingerprint %q has unexpected length %d", fp, len(fp))
+	}
+}
+
+func TestAppKeyFingerprintErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		wantErr error // nil means "any error"
+		wantAny bool
+	}{
+		{name: "empty", in: "", wantErr: ErrNoAppKey},
+		{name: "whitespace only", in: "   \n\t ", wantErr: ErrNoAppKey},
+		{name: "not pem", in: "hello world", wantAny: true},
+		{
+			name:    "pem envelope with garbage body",
+			in:      "-----BEGIN RSA PRIVATE KEY-----\nZ m9v\n-----END RSA PRIVATE KEY-----\n",
+			wantAny: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := AppKeyFingerprint(tc.in)
+			if err == nil {
+				t.Fatalf("expected an error, got fingerprint %q", got)
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Errorf("error = %v, want %v", err, tc.wantErr)
+			}
+			if got != "" {
+				t.Errorf("expected empty fingerprint on error, got %q", got)
+			}
+		})
+	}
+}
+
+func TestAppKeyFingerprintECKey(t *testing.T) {
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate ec key: %v", err)
+	}
+	der, err := x509.MarshalECPrivateKey(k)
+	if err != nil {
+		t.Fatalf("marshal ec: %v", err)
+	}
+	sec1 := string(pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der}))
+
+	fp, err := AppKeyFingerprint(sec1)
+	if err != nil {
+		t.Fatalf("AppKeyFingerprint(EC): %v", err)
+	}
+	if !strings.HasPrefix(fp, "sha256:") {
+		t.Errorf("EC fingerprint %q missing prefix", fp)
+	}
+}
+
+func TestAppKeyFingerprintFromFile(t *testing.T) {
+	dir := t.TempDir()
+	pkcs1, _ := mustRSAPEMs(t)
+
+	good := filepath.Join(dir, "good.pem")
+	if err := os.WriteFile(good, []byte(pkcs1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	empty := filepath.Join(dir, "empty.pem")
+	if err := os.WriteFile(empty, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	wantGood, err := AppKeyFingerprint(pkcs1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		want    string
+		wantErr error
+	}{
+		{name: "existing key", path: good, want: wantGood},
+		{name: "missing file", path: filepath.Join(dir, "nope.pem"), wantErr: ErrNoAppKey},
+		{name: "empty path", path: "", wantErr: ErrNoAppKey},
+		// The four live hives with NO key have exactly this: a zero-byte file.
+		{name: "empty file", path: empty, wantErr: ErrNoAppKey},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := AppKeyFingerprintFromFile(tc.path)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("error = %v, want %v", err, tc.wantErr)
+				}
+				if got != "" {
+					t.Errorf("got %q, want empty on error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/v2/pkg/hub/cluster_app_key.go
+++ b/v2/pkg/hub/cluster_app_key.go
@@ -1,0 +1,534 @@
+package hub
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// Per-cluster GitHub App private-key store.
+//
+// WHY THIS EXISTS
+//
+// Every cluster the hub provisions onto talks to its OWN GitHub instance, and
+// each of those instances hosts its own GitHub App registration with its own
+// app_id and its own private key. Before this store the hub only ever knew a key
+// that an operator pasted into a SINGLE hive's provisioning request. A hive
+// provisioned without one — or provisioned against the wrong GitHub — had no
+// path back to a correct key, and the only working copy of a GitHub Enterprise
+// key in the fleet lived on one spoke's PVC. Reprovisioning that spoke would
+// have destroyed it.
+//
+// The store makes the HUB the authority: one key per cluster, from which every
+// spoke on that cluster is continuously reconciled over the existing heartbeat
+// channel.
+//
+// WHY THE KEY IS NOT IN clusters.json
+//
+// clusters.json is read, parsed and rendered along operator-facing paths (the
+// cluster list, the create-hive modal, provisioning templates). Putting signing
+// material in it would put that material one careless marshal away from an HTTP
+// response. The key therefore lives in its own file, referenced only by cluster
+// ID, and ClusterConfig carries nothing but the non-secret app_id.
+
+// clusterAppKeyDir is the directory holding one PEM per cluster, named
+// <clusterID>.pem. A var (not a const) so tests can redirect it at a temp dir;
+// production never reassigns it. It sits beside the hub's other secrets
+// (hmac.key, hub-secret.key) on the same PVC, so it survives hub restarts and
+// is backed up by whatever backs up /data.
+var clusterAppKeyDir = "/data/saas/app-keys"
+
+// File modes for the key store. The directory is owner-only too: the filenames
+// alone (cluster IDs) are harmless, but there is no reason for anything else on
+// the pod to enumerate or traverse it.
+const (
+	// clusterAppKeyDirMode is rwx------ — only the hub process may traverse.
+	clusterAppKeyDirMode = 0o700
+	// clusterAppKeyFileMode is rw------- — the key is readable only by the hub.
+	clusterAppKeyFileMode = 0o600
+)
+
+// clusterAppKeyPath returns the on-disk path of a cluster's App key.
+//
+// The cluster ID is sanitized before it reaches the filesystem: IDs arrive from
+// clusters.json and from heartbeat payloads, and a value like "../../etc/x"
+// would otherwise escape the key directory. Only characters that appear in real
+// cluster IDs survive; anything else makes the path invalid and the caller
+// treats the cluster as having no key.
+func clusterAppKeyPath(clusterID string) (string, bool) {
+	id := strings.TrimSpace(clusterID)
+	if id == "" {
+		return "", false
+	}
+	for _, r := range id {
+		ok := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.'
+		if !ok {
+			return "", false
+		}
+	}
+	// Reject "." and ".." outright: both pass the character filter above but
+	// name a directory rather than a key file.
+	if id == "." || id == ".." {
+		return "", false
+	}
+	return filepath.Join(clusterAppKeyDir, id+".pem"), true
+}
+
+// loadClusterAppKey returns the PEM private key stored for a cluster, or "" when
+// the cluster has none. A missing key is an ordinary state — most clusters use
+// the public GitHub App whose key is supplied per hive at provisioning time — so
+// it is never an error and never logged as one.
+func loadClusterAppKey(clusterID string) string {
+	path, ok := clusterAppKeyPath(clusterID)
+	if !ok {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	pem := strings.TrimSpace(string(data))
+	if !strings.HasPrefix(pem, "-----BEGIN") {
+		// A truncated or garbage file must not be pushed to spokes: it would
+		// replace a working key with a broken one across the whole cluster.
+		return ""
+	}
+	return pem
+}
+
+// storeClusterAppKey writes a cluster's App private key to the store.
+//
+// The write is atomic (temp file in the same directory, then rename) so a hub
+// restart or a full disk can never leave a half-written PEM that would be
+// distributed to every spoke on the cluster. The temp file is created with the
+// final restrictive mode from the outset — never world-readable for even the
+// instant between create and chmod.
+func storeClusterAppKey(clusterID, pemData string) error {
+	path, ok := clusterAppKeyPath(clusterID)
+	if !ok {
+		return fmt.Errorf("invalid cluster id for app key store: %q", clusterID)
+	}
+	trimmed := strings.TrimSpace(pemData)
+	if !strings.HasPrefix(trimmed, "-----BEGIN") {
+		return fmt.Errorf("app key for cluster %s is not PEM", clusterID)
+	}
+	// Validate before persisting: a key we cannot fingerprint is a key we could
+	// never compare against a spoke's report, so it would be pushed forever.
+	if _, err := config.AppKeyFingerprint(trimmed); err != nil {
+		return fmt.Errorf("app key for cluster %s is unusable: %w", clusterID, err)
+	}
+
+	if err := os.MkdirAll(clusterAppKeyDir, clusterAppKeyDirMode); err != nil {
+		return fmt.Errorf("create app key dir: %w", err)
+	}
+
+	tmp, err := os.CreateTemp(clusterAppKeyDir, "."+filepath.Base(path)+".tmp*")
+	if err != nil {
+		return fmt.Errorf("create temp app key file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName) // no-op once the rename below succeeds
+
+	if err := tmp.Chmod(clusterAppKeyFileMode); err != nil {
+		tmp.Close()
+		return fmt.Errorf("chmod temp app key file: %w", err)
+	}
+	if _, err := tmp.WriteString(trimmed + "\n"); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp app key file: %w", err)
+	}
+	// Sync before rename so the rename cannot publish an empty file after a
+	// crash — the key is distributed fleet-wide, so a partial write is worse
+	// than no write.
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("sync temp app key file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp app key file: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename app key into place: %w", err)
+	}
+	return nil
+}
+
+// clusterAppKeyFingerprint returns the non-secret fingerprint of a cluster's
+// stored key, or "" when the cluster has no usable key.
+func clusterAppKeyFingerprint(clusterID string) string {
+	pem := loadClusterAppKey(clusterID)
+	if pem == "" {
+		return ""
+	}
+	fp, err := config.AppKeyFingerprint(pem)
+	if err != nil {
+		return ""
+	}
+	return fp
+}
+
+// clusterAppIdentity is what the hub believes a given cluster's spokes should be
+// authenticating as. Assembled from the cluster config (app_id, non-secret) and
+// the key store (the key itself, never in any config file).
+type clusterAppIdentity struct {
+	AppID       int64
+	AppSlug     string
+	PrivateKey  string
+	Fingerprint string
+}
+
+// appIdentityForCluster resolves the App identity the hub should enforce on a
+// cluster. It returns nil when the cluster is unknown, has no configured app_id,
+// or has no stored key — all of which mean "this hub has nothing authoritative
+// to say about this cluster's App credentials, so change nothing".
+func (s *HubServer) appIdentityForCluster(clusterID string) *clusterAppIdentity {
+	if s == nil || s.clusters == nil {
+		return nil
+	}
+	c, ok := s.clusters[clusterID]
+	if !ok {
+		return nil
+	}
+	if c.GitHubAppID == 0 {
+		return nil
+	}
+	pem := loadClusterAppKey(clusterID)
+	if pem == "" {
+		return nil
+	}
+	fp, err := config.AppKeyFingerprint(pem)
+	if err != nil {
+		return nil
+	}
+	return &clusterAppIdentity{
+		AppID:       c.GitHubAppID,
+		AppSlug:     c.GitHubAppSlug,
+		PrivateKey:  pem,
+		Fingerprint: fp,
+	}
+}
+
+// appKeySyncDecision is the outcome of comparing a spoke's reported App identity
+// against its cluster's authoritative one. Returned rather than acted on inline
+// so the decision is table-testable without a filesystem or an HTTP server.
+type appKeySyncDecision struct {
+	// Push is true when the hub should deliver the cluster key to this spoke.
+	Push bool
+	// Reason is a short, log-safe explanation. Never contains key material.
+	Reason string
+	// FromFingerprint is what the spoke reported ("" = spoke reported none).
+	FromFingerprint string
+	// ToFingerprint is the cluster key's fingerprint the spoke should end up at.
+	ToFingerprint string
+}
+
+// Reasons a sync decision was taken, as named constants so log queries and
+// tests never depend on a literal typed twice.
+const (
+	appKeyReasonNoClusterKey    = "cluster has no app key configured"
+	appKeyReasonPerHiveOverride = "hive has an explicitly provisioned per-hive key"
+	appKeyReasonSpokeHasNoKey   = "spoke reports no app key"
+	appKeyReasonMismatch        = "spoke key fingerprint differs from cluster key"
+	appKeyReasonMatch           = "spoke already holds the cluster key"
+)
+
+// decideAppKeySync decides whether the hub should push its cluster App key to a
+// spoke on this heartbeat.
+//
+// PRECEDENCE: an explicitly per-hive-provisioned key WINS over the cluster
+// default. A per-hive key is a deliberate operator act — a hive pointed at a
+// different App, or a hive mid-migration — and a cluster-wide reconcile that
+// overwrote it would silently undo that decision on the next beat, with no way
+// for the operator to make it stick. The cluster key is a FLOOR for hives nobody
+// has spoken for, not a ceiling over hives somebody has.
+//
+// IDEMPOTENCE: the hub pushes only when the fingerprints differ. Once the spoke
+// reports the cluster fingerprint the decision flips to no-push and the key stops
+// travelling. Re-sending a credential every 30 seconds to a spoke that already
+// has it is pure exposure for no benefit.
+//
+// UNKNOWN IS NOT MISMATCH — with one deliberate exception. A spoke too old to
+// report a fingerprint sends "". For most reconciles that must be read as
+// "unknown, do nothing" (see GitHubAPIURL on HeartbeatPayload). Here the opposite
+// is correct: a hive with NO key cannot authenticate at all, and the empty
+// fingerprint is exactly what four live hives report. Pushing to an old spoke
+// that in fact has a good key is harmless — it rewrites the same App identity —
+// whereas withholding leaves a dead hive dead. Once the spoke is new enough to
+// report, the push stops on the following beat.
+func decideAppKeySync(spokeFingerprint string, hasPerHiveKey bool, cluster *clusterAppIdentity) appKeySyncDecision {
+	if cluster == nil {
+		return appKeySyncDecision{Reason: appKeyReasonNoClusterKey, FromFingerprint: spokeFingerprint}
+	}
+	if hasPerHiveKey {
+		return appKeySyncDecision{
+			Reason:          appKeyReasonPerHiveOverride,
+			FromFingerprint: spokeFingerprint,
+			ToFingerprint:   cluster.Fingerprint,
+		}
+	}
+	if strings.TrimSpace(spokeFingerprint) == "" {
+		return appKeySyncDecision{
+			Push:          true,
+			Reason:        appKeyReasonSpokeHasNoKey,
+			ToFingerprint: cluster.Fingerprint,
+		}
+	}
+	if spokeFingerprint != cluster.Fingerprint {
+		return appKeySyncDecision{
+			Push:            true,
+			Reason:          appKeyReasonMismatch,
+			FromFingerprint: spokeFingerprint,
+			ToFingerprint:   cluster.Fingerprint,
+		}
+	}
+	return appKeySyncDecision{
+		Reason:          appKeyReasonMatch,
+		FromFingerprint: spokeFingerprint,
+		ToFingerprint:   cluster.Fingerprint,
+	}
+}
+
+// appKeyConfigForHeartbeat returns the GitHub App config to attach to a spoke's
+// heartbeat response so it self-corrects onto its cluster's key, or nil when
+// nothing needs to change.
+//
+// installationID is echoed back unchanged from what the hub already knows for
+// this hive: this reconcile fixes the KEY, and must never disturb a correct
+// installation_id. Zero is passed through as zero — the spoke's callback only
+// rebuilds its client once app_id, installation_id and key file are all present,
+// so a key delivered ahead of an installation ID lands on disk and waits.
+func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFingerprint string, hasPerHiveKey bool, installationID int64, logger *slog.Logger) *HeartbeatGitHubAppConfig {
+	identity := s.appIdentityForCluster(clusterID)
+	decision := decideAppKeySync(spokeFingerprint, hasPerHiveKey, identity)
+	if !decision.Push || identity == nil {
+		return nil
+	}
+	if logger != nil {
+		// Fingerprints only. The key itself is never logged, at any level.
+		logger.Info("heartbeat: pushing cluster github app key to spoke",
+			"hive_id", hiveID,
+			"cluster_id", clusterID,
+			"app_id", identity.AppID,
+			"reason", decision.Reason,
+			"from_fingerprint", decision.FromFingerprint,
+			"to_fingerprint", decision.ToFingerprint,
+		)
+	}
+	return &HeartbeatGitHubAppConfig{
+		AppID:          identity.AppID,
+		InstallationID: installationID,
+		PrivateKey:     identity.PrivateKey,
+		AppSlug:        identity.AppSlug,
+	}
+}
+
+// --- Operator API ---
+
+// clusterAppKeyRequest is the admin upload body for a cluster's App key.
+type clusterAppKeyRequest struct {
+	// AppID is the numeric GitHub App ID on that cluster's GitHub host. Optional
+	// on upload: when omitted the cluster's configured github_app_id stands.
+	AppID int64 `json:"app_id,omitempty"`
+	// PrivateKey is the PEM private key. It is WRITE-ONLY: it is stored to the
+	// 0600 key file and is never returned by any endpoint, in any form.
+	PrivateKey string `json:"private_key"`
+}
+
+// clusterAppKeyStatus is the read side. It carries the fingerprint and NEVER the
+// key — this shape is what any operator UI renders, and the omission is the
+// point, not an oversight.
+type clusterAppKeyStatus struct {
+	ClusterID   string `json:"cluster_id"`
+	AppID       int64  `json:"app_id,omitempty"`
+	HasKey      bool   `json:"has_key"`
+	Fingerprint string `json:"fingerprint,omitempty"`
+}
+
+// handleGetClusterAppKeys reports, per cluster, whether a hub-held App key
+// exists and which key it is — by fingerprint only. An operator uses this to
+// confirm an upload landed and that the fleet is converging, without the key
+// ever being retrievable once stored.
+func (s *HubServer) handleGetClusterAppKeys(w http.ResponseWriter, r *http.Request) {
+	statuses := make([]clusterAppKeyStatus, 0, len(s.clusters))
+	for id, c := range s.clusters {
+		fp := clusterAppKeyFingerprint(id)
+		statuses = append(statuses, clusterAppKeyStatus{
+			ClusterID:   id,
+			AppID:       c.GitHubAppID,
+			HasKey:      fp != "",
+			Fingerprint: fp,
+		})
+	}
+	sort.Slice(statuses, func(i, j int) bool { return statuses[i].ClusterID < statuses[j].ClusterID })
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(statuses)
+}
+
+// handlePutClusterAppKey stores (or replaces) a cluster's App private key.
+//
+// This is the ONLY way key material enters the hub. It is admin-gated, the key
+// is validated before it is persisted, and the response echoes back only the
+// resulting fingerprint so the operator can verify the right key landed without
+// the endpoint ever becoming a way to read a key back out.
+func (s *HubServer) handlePutClusterAppKey(w http.ResponseWriter, r *http.Request) {
+	clusterID := r.PathValue("clusterID")
+	if _, ok := s.clusters[clusterID]; !ok {
+		http.Error(w, `{"error":"unknown cluster"}`, http.StatusNotFound)
+		return
+	}
+
+	var body clusterAppKeyRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, maxClusterAppKeyBytes)).Decode(&body); err != nil {
+		http.Error(w, `{"error":"invalid JSON body"}`, http.StatusBadRequest)
+		return
+	}
+	key := strings.TrimSpace(body.PrivateKey)
+	if !strings.HasPrefix(key, "-----BEGIN") {
+		http.Error(w, `{"error":"private_key must be a PEM private key"}`, http.StatusBadRequest)
+		return
+	}
+	fp, err := config.AppKeyFingerprint(key)
+	if err != nil {
+		// Report only that parsing failed. The error must not quote the input.
+		http.Error(w, `{"error":"private_key is not a usable RSA/EC private key"}`, http.StatusBadRequest)
+		return
+	}
+	if err := storeClusterAppKey(clusterID, key); err != nil {
+		s.logger.Error("failed to store cluster app key", "cluster_id", clusterID, "error", err)
+		http.Error(w, `{"error":"failed to store key"}`, http.StatusInternalServerError)
+		return
+	}
+
+	// Persist the app_id alongside so the cluster has a complete identity. The
+	// ID is not secret and belongs in clusters.json.
+	appID := s.clusters[clusterID].GitHubAppID
+	if body.AppID != 0 && body.AppID != appID {
+		if err := s.setClusterAppID(clusterID, body.AppID); err != nil {
+			s.logger.Warn("stored cluster app key but failed to persist app_id",
+				"cluster_id", clusterID, "error", err)
+		} else {
+			appID = body.AppID
+		}
+	}
+
+	s.logger.Info("audit: cluster github app key stored",
+		"cluster_id", clusterID,
+		"app_id", appID,
+		"fingerprint", fp, // fingerprint only — never the key
+		"by", s.getAuthUser(r),
+	)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(clusterAppKeyStatus{
+		ClusterID:   clusterID,
+		AppID:       appID,
+		HasKey:      true,
+		Fingerprint: fp,
+	})
+}
+
+// maxClusterAppKeyBytes caps the upload body. A 4096-bit RSA PEM is well under
+// 4 KiB; 16 KiB leaves generous headroom while refusing to buffer an arbitrary
+// payload into memory.
+const maxClusterAppKeyBytes = 16 << 10
+
+// setClusterAppID records a cluster's non-secret App ID in both the in-memory
+// map and clusters.json, so it survives a hub restart.
+func (s *HubServer) setClusterAppID(clusterID string, appID int64) error {
+	c, ok := s.clusters[clusterID]
+	if !ok {
+		return fmt.Errorf("unknown cluster %q", clusterID)
+	}
+	c.GitHubAppID = appID
+	s.clusters[clusterID] = c
+
+	// Rewrite clusters.json preserving every other cluster untouched. Read the
+	// file fresh rather than re-serializing the in-memory map: loadClusters
+	// silently drops entries that fail validation, and writing the map back
+	// would delete them from disk permanently.
+	data, err := os.ReadFile(clustersConfigPath)
+	if err != nil {
+		return fmt.Errorf("read clusters config: %w", err)
+	}
+	var configs []ClusterConfig
+	if err := json.Unmarshal(data, &configs); err != nil {
+		return fmt.Errorf("parse clusters config: %w", err)
+	}
+	found := false
+	for i := range configs {
+		if configs[i].ID == clusterID {
+			configs[i].GitHubAppID = appID
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("cluster %q not present in %s", clusterID, clustersConfigPath)
+	}
+	out, err := json.MarshalIndent(configs, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal clusters config: %w", err)
+	}
+	// Atomic replace, same reasoning as the key store: a truncated clusters.json
+	// would leave the hub unable to reach any cluster on its next restart.
+	tmp := clustersConfigPath + ".tmp"
+	if err := os.WriteFile(tmp, out, clustersConfigFileMode); err != nil {
+		return fmt.Errorf("write clusters config: %w", err)
+	}
+	if err := os.Rename(tmp, clustersConfigPath); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("rename clusters config: %w", err)
+	}
+	return nil
+}
+
+// clustersConfigFileMode is rw-r----- : clusters.json holds no secrets (that is
+// the whole point of keeping the App key out of it) but it does describe
+// kubeconfig locations, so it is not world-readable.
+const clustersConfigFileMode = 0o640
+
+// appKeySyncForHeartbeat is the heartbeat-handler entry point for the standing
+// per-cluster App key reconcile. It resolves which cluster the beating spoke
+// belongs to and defers to appKeyConfigForHeartbeat for the decision.
+//
+// Returns nil — meaning "attach nothing, change nothing" — for every hive whose
+// cluster has no hub-managed App identity, which is the overwhelming majority.
+// The reconcile is strictly opt-in per cluster.
+func (s *HubServer) appKeySyncForHeartbeat(payload *HeartbeatPayload) *HeartbeatGitHubAppConfig {
+	if s == nil || payload == nil {
+		return nil
+	}
+	clusterID := payload.ClusterID
+	if clusterID == "" {
+		// The spoke did not report a cluster. Fall back to the hub's own record
+		// for this hive rather than guessing the default cluster: guessing would
+		// aim a GitHub Enterprise key at a public-GitHub hive.
+		if sh := loadSaaSHive(payload.HiveID); sh != nil {
+			clusterID = sh.ClusterID
+		}
+	}
+	if clusterID == "" {
+		return nil
+	}
+	// The hub does not track installation IDs, and this reconcile is about the
+	// KEY. Sending 0 tells the spoke to leave its (already correct) installation
+	// ID alone — see the callback in cmd/hive.
+	const installationIDUnchanged = 0
+	return s.appKeyConfigForHeartbeat(
+		payload.HiveID,
+		clusterID,
+		payload.GitHubAppKeyFingerprint,
+		payload.GitHubAppKeyPerHive,
+		installationIDUnchanged,
+		s.logger,
+	)
+}

--- a/v2/pkg/hub/cluster_app_key_test.go
+++ b/v2/pkg/hub/cluster_app_key_test.go
@@ -1,0 +1,744 @@
+package hub
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// testRSAKeyBits matches the smallest size GitHub Apps actually use. These keys
+// never sign anything real — they only exercise fingerprint comparison.
+const testRSAKeyBits = 2048
+
+func testAppKeyPEM(t *testing.T) string {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, testRSAKeyBits)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(k),
+	}))
+}
+
+// withTempAppKeyDir redirects the cluster key store at a temp dir for the
+// duration of a test and restores it afterwards.
+func withTempAppKeyDir(t *testing.T) string {
+	t.Helper()
+	orig := clusterAppKeyDir
+	dir := t.TempDir()
+	clusterAppKeyDir = dir
+	t.Cleanup(func() { clusterAppKeyDir = orig })
+	return dir
+}
+
+func appKeyTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// --- decideAppKeySync: the core state machine ---
+
+// TestDecideAppKeySync is the table the incident maps onto directly:
+// vllmd-01..03 report a WRONG fingerprint, vllmd-06..09 report NONE, and osscar
+// reports the MATCHING one. Only the first two groups may receive a push.
+func TestDecideAppKeySync(t *testing.T) {
+	const (
+		clusterFP = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		wrongFP   = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+	identity := &clusterAppIdentity{
+		AppID:       5686,
+		PrivateKey:  "-----BEGIN RSA PRIVATE KEY-----\nx\n-----END RSA PRIVATE KEY-----",
+		Fingerprint: clusterFP,
+	}
+
+	tests := []struct {
+		name        string
+		spokeFP     string
+		perHive     bool
+		cluster     *clusterAppIdentity
+		wantPush    bool
+		wantReason  string
+		wantFromFP  string
+		wantToFP    string
+		description string
+	}{
+		{
+			name:        "fingerprint matches - no push",
+			spokeFP:     clusterFP,
+			cluster:     identity,
+			wantPush:    false,
+			wantReason:  appKeyReasonMatch,
+			wantFromFP:  clusterFP,
+			wantToFP:    clusterFP,
+			description: "osscar: already correct, must not re-send the credential",
+		},
+		{
+			name:        "fingerprint differs - push",
+			spokeFP:     wrongFP,
+			cluster:     identity,
+			wantPush:    true,
+			wantReason:  appKeyReasonMismatch,
+			wantFromFP:  wrongFP,
+			wantToFP:    clusterFP,
+			description: "vllmd-01..03: carrying the public github.com key",
+		},
+		{
+			name:        "spoke reports no key - push",
+			spokeFP:     "",
+			cluster:     identity,
+			wantPush:    true,
+			wantReason:  appKeyReasonSpokeHasNoKey,
+			wantToFP:    clusterFP,
+			description: "vllmd-06..09: provisioned with no key at all",
+		},
+		{
+			name:        "whitespace-only fingerprint counts as absent",
+			spokeFP:     "   ",
+			cluster:     identity,
+			wantPush:    true,
+			wantReason:  appKeyReasonSpokeHasNoKey,
+			wantToFP:    clusterFP,
+			description: "a blank report must never be read as a real fingerprint",
+		},
+		{
+			name:        "cluster has no key - no-op",
+			spokeFP:     wrongFP,
+			cluster:     nil,
+			wantPush:    false,
+			wantReason:  appKeyReasonNoClusterKey,
+			wantFromFP:  wrongFP,
+			description: "a cluster the hub holds no key for must be left entirely alone",
+		},
+		{
+			name:        "cluster has no key and spoke has none either - still no-op",
+			spokeFP:     "",
+			cluster:     nil,
+			wantPush:    false,
+			wantReason:  appKeyReasonNoClusterKey,
+			description: "nothing to push means nothing happens, not an empty push",
+		},
+		{
+			name:        "per-hive key wins over cluster default even on mismatch",
+			spokeFP:     wrongFP,
+			perHive:     true,
+			cluster:     identity,
+			wantPush:    false,
+			wantReason:  appKeyReasonPerHiveOverride,
+			wantFromFP:  wrongFP,
+			wantToFP:    clusterFP,
+			description: "a deliberate per-hive credential is never overwritten",
+		},
+		{
+			name:        "per-hive key with no key reported still wins",
+			spokeFP:     "",
+			perHive:     true,
+			cluster:     identity,
+			wantPush:    false,
+			wantReason:  appKeyReasonPerHiveOverride,
+			wantToFP:    clusterFP,
+			description: "the override is unconditional; operator intent is respected",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decideAppKeySync(tc.spokeFP, tc.perHive, tc.cluster)
+			if got.Push != tc.wantPush {
+				t.Errorf("Push = %v, want %v (%s)", got.Push, tc.wantPush, tc.description)
+			}
+			if got.Reason != tc.wantReason {
+				t.Errorf("Reason = %q, want %q", got.Reason, tc.wantReason)
+			}
+			if got.FromFingerprint != tc.wantFromFP {
+				t.Errorf("FromFingerprint = %q, want %q", got.FromFingerprint, tc.wantFromFP)
+			}
+			if got.ToFingerprint != tc.wantToFP {
+				t.Errorf("ToFingerprint = %q, want %q", got.ToFingerprint, tc.wantToFP)
+			}
+			// No decision may ever carry key material, regardless of outcome.
+			for _, field := range []string{got.Reason, got.FromFingerprint, got.ToFingerprint} {
+				if strings.Contains(field, "BEGIN") || strings.Contains(field, "PRIVATE KEY") {
+					t.Errorf("decision field %q contains key material", field)
+				}
+			}
+		})
+	}
+}
+
+// TestDecideAppKeySyncIsIdempotent asserts convergence: once the spoke reports
+// the fingerprint it was pushed, the next decision is no-push. Without this the
+// hub would put a private key on the wire on every single heartbeat.
+func TestDecideAppKeySyncIsIdempotent(t *testing.T) {
+	keyPEM := testAppKeyPEM(t)
+	fp, err := config.AppKeyFingerprint(keyPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := &clusterAppIdentity{AppID: 5686, PrivateKey: keyPEM, Fingerprint: fp}
+
+	// Beat 1: spoke has nothing → push.
+	first := decideAppKeySync("", false, identity)
+	if !first.Push {
+		t.Fatal("first beat should push to a spoke with no key")
+	}
+	// The spoke writes the key; its next report is the fingerprint of what it
+	// was given. Compute it the way the spoke would, from the delivered PEM.
+	delivered, err := config.AppKeyFingerprint(first.ToFingerprintKeySource(identity))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Beat 2: spoke now reports the delivered key → no push, forever after.
+	for beat := 2; beat <= 5; beat++ {
+		d := decideAppKeySync(delivered, false, identity)
+		if d.Push {
+			t.Fatalf("beat %d re-pushed a key the spoke already holds", beat)
+		}
+	}
+}
+
+// ToFingerprintKeySource returns the PEM the decision would deliver. Test-only
+// helper kept next to its single use so production code carries no accessor
+// that hands back key material.
+func (d appKeySyncDecision) ToFingerprintKeySource(c *clusterAppIdentity) string {
+	return c.PrivateKey
+}
+
+// --- Key store on disk ---
+
+func TestStoreAndLoadClusterAppKey(t *testing.T) {
+	withTempAppKeyDir(t)
+	keyPEM := testAppKeyPEM(t)
+
+	if err := storeClusterAppKey("vllm-d", keyPEM); err != nil {
+		t.Fatalf("storeClusterAppKey: %v", err)
+	}
+	got := loadClusterAppKey("vllm-d")
+	if strings.TrimSpace(got) != strings.TrimSpace(keyPEM) {
+		t.Error("loaded key does not round-trip the stored key")
+	}
+
+	wantFP, err := config.AppKeyFingerprint(keyPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotFP := clusterAppKeyFingerprint("vllm-d"); gotFP != wantFP {
+		t.Errorf("clusterAppKeyFingerprint = %q, want %q", gotFP, wantFP)
+	}
+}
+
+// TestClusterAppKeyFileMode is a hard security requirement: signing material on
+// the hub PVC must be readable by nothing but the hub.
+func TestClusterAppKeyFileMode(t *testing.T) {
+	dir := withTempAppKeyDir(t)
+	if err := storeClusterAppKey("hive-oke", testAppKeyPEM(t)); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(filepath.Join(dir, "hive-oke.pem"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != fs.FileMode(clusterAppKeyFileMode) {
+		t.Errorf("key file mode = %#o, want %#o", perm, clusterAppKeyFileMode)
+	}
+}
+
+func TestStoreClusterAppKeyRejectsBadInput(t *testing.T) {
+	withTempAppKeyDir(t)
+	tests := []struct {
+		name      string
+		clusterID string
+		key       string
+	}{
+		{name: "empty cluster id", clusterID: "", key: testAppKeyPEM(t)},
+		{name: "path traversal cluster id", clusterID: "../../etc/shadow", key: testAppKeyPEM(t)},
+		{name: "dot cluster id", clusterID: ".", key: testAppKeyPEM(t)},
+		{name: "dotdot cluster id", clusterID: "..", key: testAppKeyPEM(t)},
+		{name: "slash in cluster id", clusterID: "a/b", key: testAppKeyPEM(t)},
+		{name: "not a pem key", clusterID: "ok", key: "just a string"},
+		{name: "pem envelope with garbage", clusterID: "ok", key: "-----BEGIN RSA PRIVATE KEY-----\nZZZ\n-----END RSA PRIVATE KEY-----"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := storeClusterAppKey(tc.clusterID, tc.key); err == nil {
+				t.Fatal("expected storeClusterAppKey to reject this input")
+			}
+		})
+	}
+}
+
+func TestLoadClusterAppKeyMissingOrCorrupt(t *testing.T) {
+	dir := withTempAppKeyDir(t)
+
+	if got := loadClusterAppKey("never-stored"); got != "" {
+		t.Errorf("missing key returned %q, want empty", got)
+	}
+	if got := loadClusterAppKey("../escape"); got != "" {
+		t.Errorf("traversal id returned %q, want empty", got)
+	}
+	// A truncated file must not be distributed: it would replace working keys
+	// across an entire cluster with a broken one.
+	if err := os.WriteFile(filepath.Join(dir, "trunc.pem"), []byte("garbage"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := loadClusterAppKey("trunc"); got != "" {
+		t.Errorf("corrupt key returned %q, want empty", got)
+	}
+	if got := clusterAppKeyFingerprint("trunc"); got != "" {
+		t.Errorf("corrupt key fingerprint = %q, want empty", got)
+	}
+}
+
+// --- appIdentityForCluster wiring ---
+
+func TestAppIdentityForCluster(t *testing.T) {
+	withTempAppKeyDir(t)
+	keyPEM := testAppKeyPEM(t)
+	if err := storeClusterAppKey("vllm-d", keyPEM); err != nil {
+		t.Fatal(err)
+	}
+	// A cluster with a key on disk but no app_id configured, to prove both
+	// halves are required.
+	if err := storeClusterAppKey("keyonly", keyPEM); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &HubServer{clusters: map[string]ClusterConfig{
+		"vllm-d":   {ID: "vllm-d", GitHubAppID: 5686, GitHubAppSlug: "ibm-hive"},
+		"keyonly":  {ID: "keyonly"},
+		"hive-oke": {ID: "hive-oke", GitHubAppID: 12345},
+	}}
+
+	tests := []struct {
+		name      string
+		clusterID string
+		wantNil   bool
+		wantAppID int64
+		wantSlug  string
+		reason    string
+	}{
+		{name: "app id and key present", clusterID: "vllm-d", wantAppID: 5686, wantSlug: "ibm-hive"},
+		{name: "key but no app id", clusterID: "keyonly", wantNil: true, reason: "an app_id-less cluster has no identity to enforce"},
+		{name: "app id but no key", clusterID: "hive-oke", wantNil: true, reason: "nothing to push without key material"},
+		{name: "unknown cluster", clusterID: "nope", wantNil: true, reason: "never invent an identity for an unknown cluster"},
+		{name: "empty cluster id", clusterID: "", wantNil: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := s.appIdentityForCluster(tc.clusterID)
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("got identity %+v, want nil (%s)", got.AppID, tc.reason)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("got nil identity, want one")
+			}
+			if got.AppID != tc.wantAppID {
+				t.Errorf("AppID = %d, want %d", got.AppID, tc.wantAppID)
+			}
+			if got.AppSlug != tc.wantSlug {
+				t.Errorf("AppSlug = %q, want %q", got.AppSlug, tc.wantSlug)
+			}
+			if got.Fingerprint == "" {
+				t.Error("identity has no fingerprint")
+			}
+		})
+	}
+}
+
+func TestAppIdentityForClusterNilSafe(t *testing.T) {
+	var nilServer *HubServer
+	if got := nilServer.appIdentityForCluster("x"); got != nil {
+		t.Error("nil server should yield nil identity")
+	}
+	empty := &HubServer{}
+	if got := empty.appIdentityForCluster("x"); got != nil {
+		t.Error("server with nil cluster map should yield nil identity")
+	}
+}
+
+// --- Heartbeat integration ---
+
+func TestAppKeySyncForHeartbeat(t *testing.T) {
+	withTempAppKeyDir(t)
+	keyPEM := testAppKeyPEM(t)
+	if err := storeClusterAppKey("vllm-d", keyPEM); err != nil {
+		t.Fatal(err)
+	}
+	clusterFP, err := config.AppKeyFingerprint(keyPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := &HubServer{
+		logger:   appKeyTestLogger(),
+		clusters: map[string]ClusterConfig{"vllm-d": {ID: "vllm-d", GitHubAppID: 5686, GitHubAppSlug: "ibm-hive"}},
+	}
+
+	tests := []struct {
+		name     string
+		payload  *HeartbeatPayload
+		wantCfg  bool
+		wantSlug string
+		reason   string
+	}{
+		{
+			name:     "spoke with no key gets the cluster key",
+			payload:  &HeartbeatPayload{HiveID: "vllmd-06", ClusterID: "vllm-d"},
+			wantCfg:  true,
+			wantSlug: "ibm-hive",
+			reason:   "the four keyless hives",
+		},
+		{
+			name:     "spoke with the wrong key gets corrected",
+			payload:  &HeartbeatPayload{HiveID: "vllmd-01", ClusterID: "vllm-d", GitHubAppKeyFingerprint: "sha256:deadbeefdeadbeefdeadbeefdeadbeef"},
+			wantCfg:  true,
+			wantSlug: "ibm-hive",
+			reason:   "the three hives carrying the public github.com key",
+		},
+		{
+			name:    "spoke already correct is left alone",
+			payload: &HeartbeatPayload{HiveID: "osscar", ClusterID: "vllm-d", GitHubAppKeyFingerprint: clusterFP},
+			wantCfg: false,
+			reason:  "no credential on the wire once it matches",
+		},
+		{
+			name:    "per-hive key is not overwritten",
+			payload: &HeartbeatPayload{HiveID: "special", ClusterID: "vllm-d", GitHubAppKeyPerHive: true},
+			wantCfg: false,
+			reason:  "per-hive beats cluster default",
+		},
+		{
+			name:    "cluster the hub holds no key for",
+			payload: &HeartbeatPayload{HiveID: "h", ClusterID: "hive-oke"},
+			wantCfg: false,
+			reason:  "unknown cluster: change nothing",
+		},
+		{
+			name:    "no cluster reported and no hub record",
+			payload: &HeartbeatPayload{HiveID: "orphan"},
+			wantCfg: false,
+			reason:  "never guess a cluster; guessing aims a GHE key at a public hive",
+		},
+		{
+			name:    "nil payload",
+			payload: nil,
+			wantCfg: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := s.appKeySyncForHeartbeat(tc.payload)
+			if !tc.wantCfg {
+				if got != nil {
+					t.Fatalf("got a config, want nil (%s)", tc.reason)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("got nil, want a config (%s)", tc.reason)
+			}
+			if got.AppID != 5686 {
+				t.Errorf("AppID = %d, want 5686", got.AppID)
+			}
+			// The reconcile must never disturb a correct installation_id, which
+			// the hub does not track. Zero is the "leave it alone" signal.
+			if got.InstallationID != 0 {
+				t.Errorf("InstallationID = %d, want 0 (unchanged)", got.InstallationID)
+			}
+			if strings.TrimSpace(got.PrivateKey) != strings.TrimSpace(keyPEM) {
+				t.Error("delivered key is not the cluster key")
+			}
+			if got.AppSlug != tc.wantSlug {
+				t.Errorf("AppSlug = %q, want %q", got.AppSlug, tc.wantSlug)
+			}
+		})
+	}
+}
+
+func TestAppKeySyncForHeartbeatNilServer(t *testing.T) {
+	var s *HubServer
+	if got := s.appKeySyncForHeartbeat(&HeartbeatPayload{HiveID: "x"}); got != nil {
+		t.Error("nil server must yield no config")
+	}
+}
+
+// --- The key must never leave the hub through an API ---
+
+// TestClusterKeyNeverSerializedIntoAPIPayload is the standing guarantee that a
+// cluster's App private key cannot reach an operator UI or any HTTP client. It
+// marshals every cluster-shaped payload the hub hands out and asserts the key
+// appears in none of them.
+func TestClusterKeyNeverSerializedIntoAPIPayload(t *testing.T) {
+	withTempAppKeyDir(t)
+	keyPEM := testAppKeyPEM(t)
+	if err := storeClusterAppKey("vllm-d", keyPEM); err != nil {
+		t.Fatal(err)
+	}
+	// A distinctive slice of the key body to search for. Using the middle of the
+	// PEM (not the BEGIN header) makes an accidental substring match implausible.
+	bodyLines := []string{}
+	for _, line := range strings.Split(strings.TrimSpace(keyPEM), "\n") {
+		if !strings.HasPrefix(line, "-----") && len(strings.TrimSpace(line)) > 20 {
+			bodyLines = append(bodyLines, strings.TrimSpace(line))
+		}
+	}
+	if len(bodyLines) == 0 {
+		t.Fatal("generated key had no body lines to search for")
+	}
+
+	cluster := ClusterConfig{
+		ID:            "vllm-d",
+		Name:          "GPU pool",
+		Domain:        "hive.example.com",
+		GitHubAppID:   5686,
+		GitHubAppSlug: "ibm-hive",
+	}
+	identity := (&HubServer{clusters: map[string]ClusterConfig{"vllm-d": cluster}}).appIdentityForCluster("vllm-d")
+	if identity == nil {
+		t.Fatal("expected an identity for the seeded cluster")
+	}
+
+	gh := clusterGitHubConfig(&cluster)
+	payloads := map[string]any{
+		// The struct parsed from and written back to clusters.json.
+		"ClusterConfig": cluster,
+		// What the clusters list endpoint returns to the dashboard.
+		"ClusterListEntry": ClusterListEntry{
+			ID:            cluster.ID,
+			Name:          cluster.Name,
+			HasGPU:        cluster.HasGPU,
+			Arch:          cluster.Arch,
+			GitHubHost:    githubHostLabel(cluster.GitHubBaseURL),
+			AppInstallURL: gh.AppInstallURL(),
+		},
+		// The key-store status endpoint: fingerprint only, by construction.
+		"clusterAppKeyStatus": clusterAppKeyStatus{
+			ClusterID:   cluster.ID,
+			AppID:       cluster.GitHubAppID,
+			HasKey:      true,
+			Fingerprint: identity.Fingerprint,
+		},
+		// The decision record that feeds every log line.
+		"appKeySyncDecision": decideAppKeySync("sha256:00000000000000000000000000000000", false, identity),
+	}
+
+	for name, payload := range payloads {
+		t.Run(name, func(t *testing.T) {
+			data, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatalf("marshal %s: %v", name, err)
+			}
+			s := string(data)
+			if strings.Contains(s, "BEGIN RSA PRIVATE KEY") || strings.Contains(s, "PRIVATE KEY") {
+				t.Fatalf("%s serialization contains a PEM header:\n%s", name, s)
+			}
+			for _, line := range bodyLines {
+				if strings.Contains(s, line) {
+					t.Fatalf("%s serialization contains private key material", name)
+				}
+			}
+		})
+	}
+}
+
+// TestClusterConfigHasNoPrivateKeyField locks the design decision in: if someone
+// later adds a key field to ClusterConfig it lands in clusters.json and one
+// marshal away from an HTTP response. Fail loudly rather than silently.
+func TestClusterConfigHasNoPrivateKeyField(t *testing.T) {
+	data, err := json.Marshal(ClusterConfig{ID: "x", GitHubAppID: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(data, &fields); err != nil {
+		t.Fatal(err)
+	}
+	for name := range fields {
+		lower := strings.ToLower(name)
+		if strings.Contains(lower, "private") || strings.Contains(lower, "app_key") || lower == "key" {
+			t.Errorf("ClusterConfig exposes a key-shaped JSON field %q — the private key must stay out of clusters.json", name)
+		}
+	}
+}
+
+// TestHeartbeatPayloadCarriesNoPrivateKey asserts the upward direction: a spoke
+// reports only a fingerprint, never key material. The hub is the only holder.
+func TestHeartbeatPayloadCarriesNoPrivateKey(t *testing.T) {
+	data, err := json.Marshal(HeartbeatPayload{
+		HiveID:                  "vllmd-01",
+		GitHubAppKeyFingerprint: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		GitHubAppKeyPerHive:     true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fields map[string]any
+	if err := json.Unmarshal(data, &fields); err != nil {
+		t.Fatal(err)
+	}
+	for name := range fields {
+		lower := strings.ToLower(name)
+		if strings.Contains(lower, "private_key") || lower == "app_key" {
+			t.Errorf("HeartbeatPayload has upward key field %q — spoke must never send the key to the hub", name)
+		}
+	}
+	if _, ok := fields["github_app_key_fingerprint"]; !ok {
+		t.Error("heartbeat payload is missing the fingerprint field the hub compares against")
+	}
+}
+
+// --- HTTP handlers ---
+
+func TestHandleGetClusterAppKeysFingerprintsOnly(t *testing.T) {
+	withTempAppKeyDir(t)
+	keyPEM := testAppKeyPEM(t)
+	if err := storeClusterAppKey("vllm-d", keyPEM); err != nil {
+		t.Fatal(err)
+	}
+	wantFP, err := config.AppKeyFingerprint(keyPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := &HubServer{logger: appKeyTestLogger(), clusters: map[string]ClusterConfig{
+		"vllm-d":   {ID: "vllm-d", GitHubAppID: 5686},
+		"hive-oke": {ID: "hive-oke"},
+	}}
+
+	rec := httptest.NewRecorder()
+	s.handleGetClusterAppKeys(rec, httptest.NewRequest(http.MethodGet, "/api/saas/admin/cluster-app-keys", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "PRIVATE KEY") {
+		t.Fatal("status endpoint leaked key material")
+	}
+
+	var got []clusterAppKeyStatus
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d statuses, want 2", len(got))
+	}
+	// Sorted by cluster ID: hive-oke then vllm-d.
+	if got[0].ClusterID != "hive-oke" || got[0].HasKey {
+		t.Errorf("hive-oke status wrong: %+v", got[0])
+	}
+	if got[1].ClusterID != "vllm-d" || !got[1].HasKey || got[1].Fingerprint != wantFP {
+		t.Errorf("vllm-d status wrong: %+v", got[1])
+	}
+}
+
+func TestHandlePutClusterAppKey(t *testing.T) {
+	keyPEM := testAppKeyPEM(t)
+	wantFP, err := config.AppKeyFingerprint(keyPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		clusterID  string
+		body       string
+		wantStatus int
+		wantStored bool
+	}{
+		{
+			name:       "valid key stored",
+			clusterID:  "vllm-d",
+			body:       mustJSON(t, clusterAppKeyRequest{AppID: 5686, PrivateKey: keyPEM}),
+			wantStatus: http.StatusOK,
+			wantStored: true,
+		},
+		{
+			name:       "unknown cluster rejected",
+			clusterID:  "nope",
+			body:       mustJSON(t, clusterAppKeyRequest{PrivateKey: keyPEM}),
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "non-pem body rejected",
+			clusterID:  "vllm-d",
+			body:       mustJSON(t, clusterAppKeyRequest{PrivateKey: "not a key"}),
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "pem envelope with garbage rejected",
+			clusterID:  "vllm-d",
+			body:       mustJSON(t, clusterAppKeyRequest{PrivateKey: "-----BEGIN RSA PRIVATE KEY-----\nZZZ\n-----END RSA PRIVATE KEY-----"}),
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "malformed json rejected",
+			clusterID:  "vllm-d",
+			body:       "{not json",
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withTempAppKeyDir(t)
+			s := &HubServer{logger: appKeyTestLogger(), clusters: map[string]ClusterConfig{
+				"vllm-d": {ID: "vllm-d", GitHubAppID: 5686},
+			}}
+
+			req := httptest.NewRequest(http.MethodPut,
+				"/api/saas/admin/cluster-app-keys/"+tc.clusterID, strings.NewReader(tc.body))
+			req.SetPathValue("clusterID", tc.clusterID)
+			rec := httptest.NewRecorder()
+			s.handlePutClusterAppKey(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d (body %s)", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			// No response, success or error, may echo key material back.
+			if strings.Contains(rec.Body.String(), "PRIVATE KEY") {
+				t.Fatal("response echoed key material")
+			}
+			stored := loadClusterAppKey(tc.clusterID) != ""
+			if stored != tc.wantStored {
+				t.Errorf("stored = %v, want %v", stored, tc.wantStored)
+			}
+			if tc.wantStored {
+				var got clusterAppKeyStatus
+				if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+					t.Fatalf("unmarshal response: %v", err)
+				}
+				if got.Fingerprint != wantFP {
+					t.Errorf("response fingerprint = %q, want %q", got.Fingerprint, wantFP)
+				}
+			}
+		})
+	}
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -277,6 +277,23 @@ type HeartbeatPayload struct {
 	// nudge", NOT as a genuine zero. Never threaten a hive over a signal that
 	// was never sent.
 	AgentsWithModel *int `json:"agents_with_model,omitempty"`
+	// GitHubAppKeyFingerprint is a NON-SECRET identifier for the GitHub App
+	// private key this spoke currently holds — "sha256:<hex>" over the DER
+	// public key derived from it (config.AppKeyFingerprint). It exists so the
+	// hub can tell a spoke carrying the WRONG key apart from one carrying the
+	// right one, without the private key ever travelling spoke → hub. The
+	// private key is never placed in this payload, in any field, ever.
+	//
+	// Empty means the spoke has no key, could not parse the one it has, or is
+	// too old to report this. All three are repaired the same way: the hub
+	// pushes its cluster key, and the spoke starts reporting a fingerprint that
+	// matches, at which point pushing stops.
+	GitHubAppKeyFingerprint string `json:"github_app_key_fingerprint,omitempty"`
+	// GitHubAppKeyPerHive is true when this spoke's key was supplied
+	// specifically for THIS hive at provisioning time, rather than adopted from
+	// its cluster. The hub honours it as an override: a deliberate per-hive
+	// credential is never overwritten by the cluster default.
+	GitHubAppKeyPerHive bool `json:"github_app_key_per_hive,omitempty"`
 }
 
 type StatusCollector func() *HeartbeatPayload
@@ -552,6 +569,15 @@ type HeartbeatGitHubAppConfig struct {
 	AppID          int64  `json:"app_id"`
 	InstallationID int64  `json:"installation_id"`
 	PrivateKey     string `json:"private_key,omitempty"`
+	// AppSlug is the App's URL slug on this cluster's GitHub host. It is only
+	// set at PROVISIONING time today, so a hive provisioned before its cluster's
+	// slug was configured shows an install link pointing at an app that does not
+	// exist on that GitHub Enterprise host — and no code path ever corrects it.
+	// Riding it alongside the key lets the same reconcile repair both.
+	//
+	// Empty means "leave the spoke's slug unchanged" — never a way to blank a
+	// working value.
+	AppSlug string `json:"app_slug,omitempty"`
 }
 
 // HeartbeatProjectConfig carries a claimed project's real org/repos/ACMM from

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -226,6 +226,10 @@ func (s *HubServer) registerSaaSRoutes() {
 	// view, so it is admin-only (see alerts.go).
 	s.mux.HandleFunc("POST /api/saas/admin/alert-ack", s.requireAdmin(s.handleAlertAck))
 	s.mux.HandleFunc("GET /api/hub/clusters", s.requireAuth(s.handleListClusters))
+	// Per-cluster GitHub App key store. The GET is fingerprints only (never key
+	// material); the PUT is the single write-only entry point for a key.
+	s.mux.HandleFunc("GET /api/saas/admin/cluster-app-keys", s.requireAdmin(s.handleGetClusterAppKeys))
+	s.mux.HandleFunc("PUT /api/saas/admin/cluster-app-keys/{clusterID}", s.requireAdmin(s.handlePutClusterAppKey))
 	s.mux.HandleFunc("POST /api/saas/admin/hub-banner", s.requireAdmin(s.handleSendHubBanner))
 	s.mux.HandleFunc("DELETE /api/saas/admin/hub-banner", s.requireAdmin(s.handleClearHubBanner))
 	s.mux.HandleFunc("GET /api/saas/admin/hub-banner", s.requireAdmin(s.handleGetHubBanner))

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -145,6 +145,17 @@ type ClusterConfig struct {
 	// install link points at an app that does not exist on that GHE host.
 	// Empty falls back to config.DefaultGitHubAppSlug.
 	GitHubAppSlug string `json:"github_app_slug,omitempty" yaml:"github_app_slug,omitempty"`
+	// GitHubAppID is the numeric App ID registered on THIS cluster's GitHub
+	// host. It is the non-secret half of the cluster's App identity — the
+	// matching PRIVATE KEY is deliberately NOT a field here, because this struct
+	// is parsed from clusters.json and flows along operator-facing paths. The
+	// key lives in its own 0600 file keyed by cluster ID (see
+	// cluster_app_key.go); this field is what tells the hub such a key is
+	// expected and which App it belongs to.
+	//
+	// Zero means "this cluster has no hub-managed App identity" — the hub then
+	// changes nothing about its spokes' credentials.
+	GitHubAppID   int64  `json:"github_app_id,omitempty" yaml:"github_app_id,omitempty"`
 	OAuthClientID string `json:"oauth_client_id,omitempty" yaml:"oauth_client_id,omitempty"`
 	ClusterHealthTimeoutSeconds int    `json:"cluster_health_timeout_seconds,omitempty" yaml:"cluster_health_timeout_seconds,omitempty"`
 }

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1068,6 +1068,14 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			"app_id", ghCfg.AppID,
 			"installation_id", ghCfg.InstallationID,
 		)
+	} else if keyCfg := s.appKeySyncForHeartbeat(&payload); keyCfg != nil {
+		// No one-shot config queued (webhook install, manual push), so fall
+		// through to the standing per-cluster reconcile: a spoke holding the
+		// wrong App key — or none — is corrected onto its cluster's key. This is
+		// deliberately the LOWER-priority branch: a config queued for a specific
+		// hive is a targeted operator/webhook action and must not be displaced
+		// by the fleet-wide default.
+		resp.GitHubAppConfig = keyCfg
 	}
 
 	s.hubBannersMu.RLock()


### PR DESCRIPTION
## The incident

Seven GHE hives on the `vllm-d` cluster cannot authenticate as the GitHub App:

| Hive | State |
|---|---|
| vllmd-01, 02, 03 | **wrong key** — the PUBLIC github.com app's key, while claiming `app_id: 5686` |
| vllmd-06, 07, 08, 09 | **no key at all** (MD5 `d41d8cd9…` is the digest of an empty file) |
| osscar | **correct** — mints a valid JWT against app 5686 |

vllmd-01 has a correct `installation_id: 42980` and a correctly-installed App, yet GHE returns:

```
401 A JSON web token could not be decoded
  POST https://github.ibm.com/api/v3/app/installations/42980/access_tokens
```

GHE is rejecting the signature because the private key does not match app_id 5686.

## Why it did not self-correct

The **spoke** side of delivery already worked: `GitHubAppConfigCallback` receives `app_id`/`installation_id`/`PrivateKey` over the heartbeat and writes the key to `/data/gh-app-key.pem`.

The **hub** side was the gap. It only ever pushed a key supplied per-hive through the provisioning API (`AppPrivateKey` in the request body). There was no per-cluster key store — `/data/saas/` held only `hmac.key`, `hub-secret.key`, `webhook-secret.key` and the proxy CA — and `ClusterConfig` had no key field. The heartbeat would gladly distribute a key; nobody ever gave the hub one for GHE. The only working copy in the fleet lived on one spoke's PVC and would have been lost on reprovision.

## What this adds

### 1. Per-cluster App credentials on the hub

`ClusterConfig` gains `github_app_id` (non-secret). The **private key is deliberately not a field** — `clusters.json` is parsed and rendered along operator-facing paths, and putting signing material in it would leave it one careless marshal from an HTTP response.

The key lives in its own store at `/data/saas/app-keys/<clusterID>.pem`, mode `0600`, written atomically (temp file created with the final restrictive mode, `Sync`, then rename), on the same PVC as `hmac.key` / `hub-secret.key` and following that pattern. Cluster IDs are sanitized before touching the filesystem so a value like `../../etc/x` cannot escape the directory.

### 2. Pushed over the existing heartbeat path

No parallel delivery mechanism — the existing `HeartbeatGitHubAppConfig` / `GitHubAppConfigCallback` pair. The reconcile is the **lower-priority** branch in the heartbeat handler: a one-shot config queued for a specific hive (webhook install, manual push) still wins, so a targeted operator action is never displaced by the fleet-wide default.

### 3. Fingerprints, so the hub can tell *wrong* from *absent*

`HeartbeatPayload` gains `github_app_key_fingerprint`: `sha256:<32 hex>` over the **DER-encoded PKIX public key** derived from the private key.

Digesting the public key rather than the PEM file bytes matters — PKCS#1 (`BEGIN RSA PRIVATE KEY`) vs PKCS#8 (`BEGIN PRIVATE KEY`), CRLF vs LF, and a trailing newline are all byte-different encodings of the *same* key. A file-bytes digest would report a mismatch on every one of them and make the hub re-push a correct key on every single heartbeat.

**The private key never travels spoke → hub, in any field.** `TestHeartbeatPayloadCarriesNoPrivateKey` asserts it.

### 4. Idempotent self-correction

- Push only when the fingerprint differs or is absent. Once the spoke reports a match the decision flips to no-push and stays there — no credential on the wire for a spoke that already has it.
- Every push logs hive, cluster, reason, and before/after **fingerprints only**. The key is never logged at any level.
- A cluster with no configured key (or no `github_app_id`) is a complete no-op.

An empty fingerprint is treated as **push**, not as "unknown, do nothing" — the opposite of the `GitHubAPIURL` reconcile's convention, and deliberately so. A hive with no key cannot authenticate at all, and empty is exactly what the four keyless hives report. Pushing to a spoke too old to report is harmless (it rewrites the same App identity); withholding leaves a dead hive dead. The push stops once the spoke is new enough to report back.

### 5. Precedence: per-hive beats cluster

An explicitly per-hive-provisioned key — the read-only `/secrets/gh-app-key.pem` Secret mount, written at provisioning time from a key an operator supplied for *that hive* — wins over the cluster default. A per-hive key is a deliberate act (a hive pointed at a different App, or one mid-migration), and a cluster-wide reconcile that overwrote it would silently undo that decision on the next beat with no way to make it stick. **The cluster key is a floor for hives nobody has spoken for, not a ceiling over hives somebody has.**

The spoke reports this as `github_app_key_per_hive`, derived from the provisioned mount existing *and* still being the effective key file (a hub-delivered key repoints `cfg.GitHub.KeyFile` at the PVC, so it takes precedence once delivered).

### 6. `github_app_slug`, repaired over the same channel

`GitHubAppSlug` already existed on `ClusterConfig` but was only ever consumed at **provisioning** time. A hive provisioned before its cluster's slug was configured shows an install link pointing at an app that does not exist on that GHE host, and no code path ever corrected it. It now rides alongside the key. Empty means "leave unchanged", never "blank it".

## Two correctness fixes on the spoke callback

- `cfg.GitHub.InstallationID = ghCfg.InstallationID` was unconditional. The hub does not track installation IDs, and this key-only reconcile sends `0` — which would have **blanked vllmd-01's correct `installation_id: 42980`**, turning a key fault into a total auth outage. Zero now means "unchanged" for both `app_id` and `installation_id`.
- `os.WriteFile` does **not** re-apply its mode argument to a file that already exists, so a key written by an older build kept its old permissions forever. The key file is now `chmod`'d unconditionally on every write so all paths converge on `0600`.

## Security properties

- Key material is never logged — fingerprints only, everywhere.
- Hub key file `0600`, directory `0700`; spoke `/data/gh-app-key.pem` `0600` and now enforced on rewrite.
- No API returns the key. `PUT /api/saas/admin/cluster-app-keys/{clusterID}` is write-only and echoes back only the resulting fingerprint; `GET /api/saas/admin/cluster-app-keys` returns `has_key` + fingerprint. Both admin-gated.
- `TestClusterKeyNeverSerializedIntoAPIPayload` marshals `ClusterConfig`, `ClusterListEntry`, `clusterAppKeyStatus` and the decision record and asserts no PEM header and no key body line appears in any of them.
- `TestClusterConfigHasNoPrivateKeyField` fails loudly if anyone later adds a key-shaped field to `ClusterConfig`, since that would land it in `clusters.json`.
- The key never reaches `meta.json` or any operator-rendered file.

## Do the seven hives self-repair on deploy?

**No — an operator must supply the GHE key to the hub first.** This change builds the distribution mechanism; it cannot invent key material the hub has never held. Until `vllm-d` has a stored key, `appIdentityForCluster` returns nil and every hive on it is left exactly as it is.

The exact step, once deployed:

```bash
# The GHE app 5686 private key. The only working copy currently in the fleet
# is on the osscar spoke's PVC (fingerprint a394401d…), so pull it from there
# or re-download it from the App settings page on github.ibm.com.
curl -X PUT https://<hub>/api/saas/admin/cluster-app-keys/vllm-d \
  -H 'Content-Type: application/json' \
  -b 'hive_hub_user=<admin>' \
  -d "$(jq -n --arg k "$(cat gh-app-key.pem)" '{app_id: 5686, private_key: $k}')"
```

The response returns the stored fingerprint for verification. `github_app_id: 5686` is persisted into `clusters.json` by the same call.

Alternatively the file can be placed directly: write the PEM to `/data/saas/app-keys/vllm-d.pem` (mode `0600`) on the hub PVC and set `"github_app_id": 5686` on the `vllm-d` entry in `clusters.json`. Both halves are required — a key with no `github_app_id`, or an ID with no key, is a deliberate no-op.

After that all seven repair themselves within one heartbeat each: the four keyless hives report an empty fingerprint and the three wrong-key hives report a mismatching one, so all seven receive a push, write the key, rebuild their App auth, and report the matching fingerprint on the following beat — at which point the hub stops sending.

`vllm-d`'s empty `github_app_slug` should be filled in at the same time; it is the separate live gap the slug plumbing above addresses.

## Verified vs assumed

**Verified:**
- `d41d8cd98f00b204e9800998ecf8427e` is the MD5 of empty input (`printf '' | openssl md5`), confirming the four hives have genuinely empty key files — which `AppKeyFingerprintFromFile` reports as `ErrNoAppKey` → empty fingerprint → push.
- `GitHubAppConfigCallback` (`v2/cmd/hive/main.go`) already writes the delivered key and rebuilds App auth — delivery was solved, only the hub-side source was missing.
- The hub had no per-cluster key store: `ClusterConfig` had `GitHubAppSlug` but no key or app-ID field, and the only key source was `loadAppPrivateKey` reading a per-hive or shared *Kubernetes* secret via kubectl — unavailable for the heartbeat-only `vllm-d` pool.
- `GitHubAppSlug` is consumed only in the provisioning template, never post-provision.
- `ClusterListEntry` is a separate projection from `ClusterConfig`, so the clusters list endpoint could not have leaked a key field — the test pins that.
- `go build ./...`, `go vet ./...`, and the full `./pkg/hub/` and `./pkg/config/` suites pass.

**Assumed (not reachable from here):**
- That the GHE key currently on the osscar spoke is the correct key for app 5686 fleet-wide — taken from the incident report's verified `HTTP 200 on GET /api/v3/app`.
- That the three wrong-key hives' `installation_id`s are correct (stated as verified for vllmd-01; assumed for 02/03). If any are wrong, `healGitHubAppInstallation` on the spoke already corrects them once the key is valid enough to mint a JWT.
- Behaviour against a live GHE instance — no cluster access from this environment. The reconcile logic is covered by table tests rather than an integration run.

## Tests

`./pkg/config/` — fingerprint stability across PKCS#1/PKCS#8/whitespace, distinctness across keys, EC keys, no key material in the output, and the empty-file case the four hives exhibit.

`./pkg/hub/` — the decision table (match → no push; mismatch → push; absent → push; cluster with no key → no-op; per-hive precedence), multi-beat idempotence, key-store round-trip and `0600` mode, path-traversal and corrupt-input rejection, heartbeat integration mapped onto the seven live hives by name, handler tests, and the serialization leak tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
