### PR TITLE
🐛 fix(image): install Bob CLI so backend: bob actually works

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -101,6 +101,25 @@ RUN ARCH=$(uname -m) && \
     chmod +x /usr/local/bin/goose || \
     echo "WARN: Goose CLI install failed — skipping"
 
+# --- Layer 9: Bob CLI (IBM bobshell — backend: bob) ---
+# bobshell is NOT published to the public npm registry; it is distributed as a
+# tarball from IBM Cloud Object Storage. The vendor's documented host install is
+# `curl https://bob.ibm.com/download/bobshell.sh | bash`, but that script merely
+# resolves the latest version and npm-installs the same tarball. We install the
+# tarball directly at a pinned version instead: piping a remote script into the
+# build would be unpinned and unauditable, and inconsistent with the copilot /
+# claude / goose layers above.
+# The package is pure JavaScript (no native .node/.so payloads, no os/cpu
+# fields), so a single layer serves both linux/amd64 and linux/arm64.
+# package.json declares "bin": {"bob": "bundle/bob.js"} — npm therefore creates
+# /usr/local/bin/bob directly, matching the binary name the agent launcher
+# invokes (manager.go maps "bob" -> "bob"). No symlink is required.
+ARG BOBSHELL_VERSION=1.0.6
+ARG BOBSHELL_BASE_URL=https://s3.us-south.cloud-object-storage.appdomain.cloud/bob-shell
+RUN npm install -g "${BOBSHELL_BASE_URL}/bobshell-${BOBSHELL_VERSION}.tgz" && \
+    npm cache clean --force || \
+    echo "WARN: Bob CLI install failed — skipping"
+
 # --- Application layers ---
 ENV HOME=/home/dev
 

--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -116,9 +116,15 @@ RUN ARCH=$(uname -m) && \
 # invokes (manager.go maps "bob" -> "bob"). No symlink is required.
 ARG BOBSHELL_VERSION=1.0.6
 ARG BOBSHELL_BASE_URL=https://s3.us-south.cloud-object-storage.appdomain.cloud/bob-shell
+# Deliberately NOT tolerant of failure, unlike the copilot/goose layers above.
+# A hive configured with backend "bob" passes config validation (validBackends
+# in pkg/config) and then fails at launch with "agent scanner not running" —
+# a silent trap that cost real debugging time. If this download breaks, the
+# build must break loudly rather than ship an image that reproduces that bug.
+# The `which bob` check turns a partial install into a build failure too.
 RUN npm install -g "${BOBSHELL_BASE_URL}/bobshell-${BOBSHELL_VERSION}.tgz" && \
-    npm cache clean --force || \
-    echo "WARN: Bob CLI install failed — skipping"
+    npm cache clean --force && \
+    which bob
 
 # --- Application layers ---
 ENV HOME=/home/dev

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -363,7 +363,7 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 <option value="openrouter" data-install="" data-host-install="npm i -g @anthropic-ai/claude-code" data-model-flag="--model" data-default-model="" data-env="# OpenRouter — Claude Code routed through OpenRouter\nexport HIVE_LITELLM_ENDPOINT=https://openrouter.ai/api/v1\nexport HIVE_LITELLM_API_KEY=sk-or-...  # your OpenRouter key">OpenRouter (Claude Code + your key)</option>
 <option value="vllm" data-install="" data-host-install="npm i -g @anthropic-ai/claude-code" data-model-flag="--model" data-default-model="" data-env="# vLLM — self-hosted OpenAI-compatible server\nexport HIVE_LITELLM_ENDPOINT=http://your-vllm-host:8000/v1\nexport HIVE_LITELLM_API_KEY=sk-your-vllm-key  # only if your server needs one">vLLM (self-hosted)</option>
 <option value="llm-d" data-install="" data-host-install="npm i -g @anthropic-ai/claude-code" data-model-flag="--model" data-default-model="" data-env="# llm-d — self-hosted OpenAI-compatible endpoint\nexport HIVE_LITELLM_ENDPOINT=http://your-llm-d-host:8000/v1\nexport HIVE_LITELLM_API_KEY=sk-your-llm-d-key  # only if your endpoint needs one">llm-d (self-hosted)</option>
-<option value="bob" data-install="" data-host-install="npm i -g bobshell" data-model-flag="" data-default-model="">Bob</option>
+<option value="bob" data-install="" data-host-install="curl -fsSL https://bob.ibm.com/download/bobshell.sh | bash" data-model-flag="" data-default-model="">Bob</option>
 <option value="other" data-install="" data-host-install="# Install your CLI tool" data-model-flag="" data-default-model="">Other (host only)</option>
 </select>
 </span>


### PR DESCRIPTION
## Problem

`bob` is a fully supported backend **everywhere except the image**:

| Location | Status |
|---|---|
| `v2/pkg/config/config.go:1974` — `validBackends` includes `"bob"` | ✅ config validates |
| `v2/pkg/agent/manager.go:791` — `case "bob": launchCmd = binary` | ✅ launcher handles it |
| `v2/pkg/agent/manager.go:2829` — binary map `"bob": "bob"` | ✅ mapped |
| `README.md:276`, `v2/AGENT-DEFINITION.md:38` | ✅ documented as supported |
| `v2/Dockerfile` | ❌ **never installs it** |

Observed live on a spoke (`hosted-available-vllmd-01`, org `katamari`, scanner agent `cli: bob`): dashboard shows **"Kick failed: agent scanner not running"**, 0 actionable items, empty activity summary. On the spoke, `which bob` returns nothing while `claude` and `copilot` are both present. The tmux session is created and shows attached, but capturing the pane returns nothing — an empty shell where bob should be.

## Fix

A pinned Dockerfile layer beside the existing copilot/claude/goose CLI layers.

`bobshell` is **not on the public npm registry** (`registry.npmjs.org/bobshell` → 404). It ships as a tarball from IBM Cloud Object Storage. The vendor installer at `bob.ibm.com/download/bobshell.sh` does not carry a binary — it resolves a version and npm-installs that same tarball. So this installs the tarball directly at a pinned version rather than piping a remote script into the build: piping would be unpinned, unauditable, and inconsistent with the layers above it.

## Verified, not assumed

- **`bin` mapping** — extracted from the 1.0.6 tarball: `"bin": {"bob": "bundle/bob.js"}`. The package is named `bobshell` but the bin entry is literally `bob`.
- **A real `npm install -g` of the tarball** produced `bin/bob -> ../lib/node_modules/bobshell/bundle/bob.js` — same shape as the existing `claude`/`copilot` symlinks on the spoke. **No symlink layer needed**; `which bob` will resolve.
- **Multi-arch** — pure JavaScript. No `.node`/`.so`/`.wasm` payloads in the tarball, no `os`/`cpu` fields in package.json. One layer covers linux/amd64 and linux/arm64.
- **Tarball URL** — HTTP 200, 4,503,786 bytes, public, no credentials.
- `go build ./...` and `go vet ./...` — both clean.
- `docker buildx build --check` — "Check complete, no warnings found."
- **Not verified: the full image build.** It is large and I did not build it. CI's `docker` job is the real gate here.

## Contributor page was broken

`v2/pkg/dashboard/api_contribute.go:366` advertised `data-host-install="npm i -g bobshell"`. Since the package is not on npm, that instruction **could never have worked** for a contributor installing on their own machine. Changed to the vendor's documented host installer:

```
curl -fsSL https://bob.ibm.com/download/bobshell.sh | bash
```

The `curl | bash` form is appropriate for a developer's own machine (and matches how `pi` is already advertised on that page) even though it is the wrong choice for the image.

## Same gap in other backends — reported, not fixed

`validBackends` accepts seven CLIs. Only three are in the image:

| Backend | In image? |
|---|---|
| `claude` | ✅ Layer 7 |
| `copilot` | ✅ Layer 3 |
| `goose` | ✅ Layer 8 |
| `bob` | ✅ **this PR** |
| `codex` | ❌ would fail identically |
| `pi` | ❌ would fail identically |
| `aider` | ❌ would fail identically |

`codex`, `pi`, and `aider` pass config validation and will produce the same silent "agent not running" symptom. Left out of scope deliberately — each needs its own install-source decision (and `aider` is Python, so it would want the venv pattern, not npm). Worth a follow-up issue.

## Constraints respected

- Copilot's deliberate 1.0.59 pin and the MITM proxy CA setup are **untouched**.
- Layer placed beside the other CLI layers; nothing below it is invalidated, so pull-time churn across the fleet is minimal.
- Version lives in `ARG BOBSHELL_VERSION` with an explanatory comment — no magic strings. Base URL is likewise an `ARG`.