### PR TITLE
fix(hub): inject X-Hive-Proxy-Auth proof header on auth-check (F2 hub half)

### DIFF
--- a/v2/pkg/hub/hub_filesystem_test.go
+++ b/v2/pkg/hub/hub_filesystem_test.go
@@ -1310,6 +1310,57 @@ func TestHandleSaaSAuthCheckWithFilesystem(t *testing.T) {
 	}
 }
 
+// TestHandleSaaSAuthCheckProxyAuthHeader asserts the F2 hub-half proof header:
+// on the authenticated SUCCESS path the hub sets X-Hive-Proxy-Auth to the
+// hive's dashboard token (the spoke's own authToken), and it is NEVER set on
+// the unauthenticated (401) path.
+func TestHandleSaaSAuthCheckProxyAuthHeader(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	// Fake kubectl so loadSpokeAuthToken resolves the dashboard token.
+	const wantToken = "proxy-auth-dash-token"
+	installSecretKubectl(t, "-----BEGIN X-----", wantToken)
+
+	authCleanup := helperSetupAuthUser(t, "ghp_proxyauth", "proxyauth-user")
+	defer authCleanup()
+
+	u := ensureSaaSUser("proxyauth-user")
+	u.Hives["proxy-hive"] = "admin"
+	saveSaaSUser(u)
+
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	// The hive must be in the registry with a known cluster so the hub can
+	// resolve its dashboard token in the auth-check handler.
+	srv.registry.Hives = []RegistryEntry{{ID: "proxy-hive", ClusterID: "hive-oke"}}
+	srv.clusters = map[string]ClusterConfig{"hive-oke": {ID: "hive-oke"}}
+
+	// SUCCESS path: header set to the dashboard token.
+	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=proxy-hive", nil)
+	req.Header.Set("Authorization", "Bearer ghp_proxyauth")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("X-Hive-Proxy-Auth"); got != wantToken {
+		t.Errorf("X-Hive-Proxy-Auth = %q, want %q", got, wantToken)
+	}
+
+	// FAILURE path: no credentials → 401 and NO proof header.
+	reqNoAuth := httptest.NewRequest("GET", "/api/saas/auth-check?hive=proxy-hive", nil)
+	wNoAuth := httptest.NewRecorder()
+	srv.mux.ServeHTTP(wNoAuth, reqNoAuth)
+
+	if wNoAuth.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", wNoAuth.Code)
+	}
+	if got := wNoAuth.Header().Get("X-Hive-Proxy-Auth"); got != "" {
+		t.Errorf("X-Hive-Proxy-Auth set on 401 path = %q, want empty", got)
+	}
+}
+
 func TestHandleSaaSAuthCheckNoAccess(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4408,8 +4408,8 @@ type ProvisionRequest struct {
 	// github.com, otherwise a GitHub Enterprise host (github.ibm.com,
 	// github.cisco.com, …). Captured so an admin can see which instance a
 	// request targets before deciding where to place the hive.
-	GitHubHost string `json:"github_host,omitempty"`
-	Org        string `json:"org"`
+	GitHubHost  string `json:"github_host,omitempty"`
+	Org         string `json:"org"`
 	Repos       string `json:"repos"`
 	PrimaryRepo string `json:"primary_repo"`
 	ACMMLevel   int    `json:"acmm_level"`
@@ -5222,8 +5222,8 @@ func sameStringSliceFold(a, b []string) bool {
 // the real project the placeholder is being claimed for, plus optional GitHub
 // App credentials to deliver to the spoke via the heartbeat channel.
 type AssignHiveRequest struct {
-	Owner          string `json:"owner"`
-	Org            string `json:"org"`
+	Owner string `json:"owner"`
+	Org   string `json:"org"`
 	// GitHubHost is the GitHub instance the org lives on ("" = public
 	// github.com, otherwise a GHE host). Parsed from a pasted org URL when the
 	// caller does not send it explicitly.
@@ -5543,6 +5543,79 @@ func (s *HubServer) handleUserToken(w http.ResponseWriter, r *http.Request) {
 
 var publicPaths = []string{"/snapshot", "/leaderboard", "/contribute", "/api/leaderboard", "/api/contribute"}
 
+// proxyAuthHeader is the response header the hub sets on a successful
+// auth-check subrequest to PROVE to the spoke that the request was
+// authenticated by the hub's nginx auth-proxy (not spoofed by a client that
+// merely supplied X-Hive-User/X-Hive-Role directly). nginx is configured to
+// copy this header onto the upstream request via the auth-response-headers
+// annotation (see saas_provision.go). Its value is the spoke's own dashboard
+// token, so the spoke can constant-time-compare it against its authToken.
+//
+// CONTRACT (spoke half, separate v3 PR must verify EXACTLY this):
+//   - Header name: "X-Hive-Proxy-Auth"
+//   - Value: the hive's dashboard token — the raw value stored in the spoke's
+//     "hive-secrets" k8s secret under key "dashboard-token", i.e. the same
+//     string the spoke reads from DASHBOARD_AUTH_TOKEN into its authToken.
+//   - Set ONLY on the authenticated success path; NEVER on public-path,
+//     unfurl-bot, unauthenticated (401), or no-access (403) responses.
+const proxyAuthHeader = "X-Hive-Proxy-Auth"
+
+// spokeProxyAuthCacheTTL bounds how long a hive's dashboard token is memoized
+// so the per-request auth-check subrequest avoids a kubectl exec on every call
+// while still picking up a re-provisioned token within a bounded window.
+const spokeProxyAuthCacheTTL = 5 * time.Minute
+
+// spokeProxyAuthEntry is a cached dashboard token with its expiry.
+type spokeProxyAuthEntry struct {
+	token   string
+	expires time.Time
+}
+
+// spokeProxyAuthToken returns the given hive's dashboard token — the shared
+// secret the spoke holds as its authToken (DASHBOARD_AUTH_TOKEN / the
+// "dashboard-token" key of the "hive-secrets" k8s secret). It memoizes the
+// value for spokeProxyAuthCacheTTL so the hot auth-check path does not exec
+// kubectl on every proxied request. Returns "" if the token cannot be
+// resolved (e.g. the hive isn't in the registry or its cluster is unreachable);
+// callers must then omit the proof header rather than send an empty one.
+func (s *HubServer) spokeProxyAuthToken(hiveID string) string {
+	now := time.Now()
+
+	s.spokeProxyAuthMu.Lock()
+	if entry, ok := s.spokeProxyAuthCache[hiveID]; ok && now.Before(entry.expires) {
+		tok := entry.token
+		s.spokeProxyAuthMu.Unlock()
+		return tok
+	}
+	s.spokeProxyAuthMu.Unlock()
+
+	// Resolve the registry entry (ID + ClusterID) that loadSpokeAuthToken needs.
+	var hive *RegistryEntry
+	s.mu.RLock()
+	for i := range s.registry.Hives {
+		if s.registry.Hives[i].ID == hiveID {
+			h := s.registry.Hives[i]
+			hive = &h
+			break
+		}
+	}
+	s.mu.RUnlock()
+	if hive == nil {
+		return ""
+	}
+
+	token := s.loadSpokeAuthToken(hive)
+	if token == "" {
+		return ""
+	}
+
+	s.spokeProxyAuthMu.Lock()
+	s.spokeProxyAuthCache[hiveID] = spokeProxyAuthEntry{token: token, expires: now.Add(spokeProxyAuthCacheTTL)}
+	s.spokeProxyAuthMu.Unlock()
+
+	return token
+}
+
 func (s *HubServer) handleSaaSAuthCheck(w http.ResponseWriter, r *http.Request) {
 	hiveID := r.URL.Query().Get("hive")
 	if hiveID == "" {
@@ -5593,6 +5666,16 @@ func (s *HubServer) handleSaaSAuthCheck(w http.ResponseWriter, r *http.Request) 
 
 	w.Header().Set("X-Hive-User", username)
 	w.Header().Set("X-Hive-Role", role)
+	// Prove to the spoke that this request really passed through the hub's
+	// auth-proxy: set X-Hive-Proxy-Auth to the hive's own dashboard token so
+	// the spoke can constant-time-compare it against its authToken. Only set on
+	// this authenticated success path; a client hitting the spoke directly
+	// cannot forge it because it never learns the token. If the token can't be
+	// resolved, omit the header (backward-compatible: the spoke half must fail
+	// open only until it is deployed — see the v3 spoke PR).
+	if proxyAuth := s.spokeProxyAuthToken(hiveID); proxyAuth != "" {
+		w.Header().Set(proxyAuthHeader, proxyAuth)
+	}
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -113,32 +113,32 @@ var clustersConfigPath = "/data/saas/clusters.json"
 // hive spokes onto. Each cluster has its own kubeconfig, storage backend,
 // ingress style, and optional platform-specific settings (OCI, OpenShift).
 type ClusterConfig struct {
-	ID                          string `json:"id" yaml:"id"`
-	Name                        string `json:"name" yaml:"name"`
-	KubeconfigPath              string `json:"kubeconfig_path,omitempty" yaml:"kubeconfig_path,omitempty"`
-	Context                     string `json:"context" yaml:"context"`
-	InCluster                   bool   `json:"in_cluster" yaml:"in_cluster"`
-	StorageClass                string `json:"storage_class" yaml:"storage_class"`
-	StorageType                 string `json:"storage_type" yaml:"storage_type"`
-	NFSMountIP                  string `json:"nfs_mount_ip,omitempty" yaml:"nfs_mount_ip,omitempty"`
-	IngressType                 string `json:"ingress_type" yaml:"ingress_type"`
-	IngressClass                string `json:"ingress_class,omitempty" yaml:"ingress_class,omitempty"`
-	CertIssuer                  string `json:"cert_issuer,omitempty" yaml:"cert_issuer,omitempty"`
-	Domain                      string `json:"domain" yaml:"domain"`
-	DomainPrefix                string `json:"domain_prefix,omitempty" yaml:"domain_prefix,omitempty"`
-	OCICompartment              string `json:"oci_compartment,omitempty" yaml:"oci_compartment,omitempty"`
-	OCIAvailDomain              string `json:"oci_avail_domain,omitempty" yaml:"oci_avail_domain,omitempty"`
-	OCIMountTarget              string `json:"oci_mount_target,omitempty" yaml:"oci_mount_target,omitempty"`
-	OCIExportSet                string `json:"oci_export_set,omitempty" yaml:"oci_export_set,omitempty"`
-	RequiresSCC                 bool   `json:"requires_scc" yaml:"requires_scc"`
-	SCCName                     string `json:"scc_name,omitempty" yaml:"scc_name,omitempty"`
-	HasGPU                      bool   `json:"has_gpu" yaml:"has_gpu"`
-	Arch                        string `json:"arch" yaml:"arch"`
-	ImageTag                    string `json:"image_tag" yaml:"image_tag"`
-	ImagePullPolicy             string `json:"image_pull_policy,omitempty" yaml:"image_pull_policy,omitempty"`
-	InferenceEndpoint           string `json:"inference_endpoint,omitempty" yaml:"inference_endpoint,omitempty"`
-	GitHubBaseURL               string `json:"github_base_url,omitempty" yaml:"github_base_url,omitempty"`
-	GitHubAPIURL                string `json:"github_api_url,omitempty" yaml:"github_api_url,omitempty"`
+	ID                string `json:"id" yaml:"id"`
+	Name              string `json:"name" yaml:"name"`
+	KubeconfigPath    string `json:"kubeconfig_path,omitempty" yaml:"kubeconfig_path,omitempty"`
+	Context           string `json:"context" yaml:"context"`
+	InCluster         bool   `json:"in_cluster" yaml:"in_cluster"`
+	StorageClass      string `json:"storage_class" yaml:"storage_class"`
+	StorageType       string `json:"storage_type" yaml:"storage_type"`
+	NFSMountIP        string `json:"nfs_mount_ip,omitempty" yaml:"nfs_mount_ip,omitempty"`
+	IngressType       string `json:"ingress_type" yaml:"ingress_type"`
+	IngressClass      string `json:"ingress_class,omitempty" yaml:"ingress_class,omitempty"`
+	CertIssuer        string `json:"cert_issuer,omitempty" yaml:"cert_issuer,omitempty"`
+	Domain            string `json:"domain" yaml:"domain"`
+	DomainPrefix      string `json:"domain_prefix,omitempty" yaml:"domain_prefix,omitempty"`
+	OCICompartment    string `json:"oci_compartment,omitempty" yaml:"oci_compartment,omitempty"`
+	OCIAvailDomain    string `json:"oci_avail_domain,omitempty" yaml:"oci_avail_domain,omitempty"`
+	OCIMountTarget    string `json:"oci_mount_target,omitempty" yaml:"oci_mount_target,omitempty"`
+	OCIExportSet      string `json:"oci_export_set,omitempty" yaml:"oci_export_set,omitempty"`
+	RequiresSCC       bool   `json:"requires_scc" yaml:"requires_scc"`
+	SCCName           string `json:"scc_name,omitempty" yaml:"scc_name,omitempty"`
+	HasGPU            bool   `json:"has_gpu" yaml:"has_gpu"`
+	Arch              string `json:"arch" yaml:"arch"`
+	ImageTag          string `json:"image_tag" yaml:"image_tag"`
+	ImagePullPolicy   string `json:"image_pull_policy,omitempty" yaml:"image_pull_policy,omitempty"`
+	InferenceEndpoint string `json:"inference_endpoint,omitempty" yaml:"inference_endpoint,omitempty"`
+	GitHubBaseURL     string `json:"github_base_url,omitempty" yaml:"github_base_url,omitempty"`
+	GitHubAPIURL      string `json:"github_api_url,omitempty" yaml:"github_api_url,omitempty"`
 	// GitHubAppSlug is the GitHub App's URL slug on THIS cluster's GitHub
 	// host. A GitHub Enterprise instance hosts its own App registration,
 	// which is rarely named "kubestellar-hive" — without this the spoke's
@@ -155,8 +155,8 @@ type ClusterConfig struct {
 	//
 	// Zero means "this cluster has no hub-managed App identity" — the hub then
 	// changes nothing about its spokes' credentials.
-	GitHubAppID   int64  `json:"github_app_id,omitempty" yaml:"github_app_id,omitempty"`
-	OAuthClientID string `json:"oauth_client_id,omitempty" yaml:"oauth_client_id,omitempty"`
+	GitHubAppID                 int64  `json:"github_app_id,omitempty" yaml:"github_app_id,omitempty"`
+	OAuthClientID               string `json:"oauth_client_id,omitempty" yaml:"oauth_client_id,omitempty"`
 	ClusterHealthTimeoutSeconds int    `json:"cluster_health_timeout_seconds,omitempty" yaml:"cluster_health_timeout_seconds,omitempty"`
 }
 
@@ -262,10 +262,10 @@ type PendingAccessRequest struct {
 }
 
 type SaaSHive struct {
-	ID          string   `json:"id"`
-	Owner       string   `json:"owner"`
-	ProjectName string   `json:"project_name"`
-	Org         string   `json:"org"`
+	ID          string `json:"id"`
+	Owner       string `json:"owner"`
+	ProjectName string `json:"project_name"`
+	Org         string `json:"org"`
 	// GitHubHost is the GitHub instance this project lives on — empty means
 	// public github.com, otherwise a GitHub Enterprise host (github.ibm.com,
 	// github.cisco.com, …). Recorded at assign time from the requested org so
@@ -1557,7 +1557,7 @@ metadata:
     nginx.ingress.kubernetes.io/custom-http-errors: "502,503"
     nginx.ingress.kubernetes.io/default-backend: hive-error-pages
     nginx.ingress.kubernetes.io/auth-signin: "https://hive.kubestellar.io/login?redirect=$scheme://$http_host$request_uri"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Hive-User,X-Hive-Role"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Hive-User,X-Hive-Role,X-Hive-Proxy-Auth"
 spec:
   ingressClassName: {{.IngressClass}}
   rules:

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -346,6 +346,14 @@ type HubServer struct {
 	hubBanners   map[string]*HubBannerEntry
 	hubBannersMu sync.RWMutex
 
+	// spokeProxyAuthCache memoizes each hive's dashboard token (the shared
+	// secret the spoke holds as DASHBOARD_AUTH_TOKEN) so the auth-check
+	// subrequest — which fires on EVERY hub-proxied request — does not pay a
+	// kubectl exec per call. Key: hive ID → cached token + expiry. Guarded by
+	// spokeProxyAuthMu. See handleSaaSAuthCheck / spokeProxyAuthToken.
+	spokeProxyAuthCache map[string]spokeProxyAuthEntry
+	spokeProxyAuthMu    sync.Mutex
+
 	// pendingGateways stores OpenRouter gateways funded via the hub's
 	// scan-to-fund flow, to deliver to firewalled/heartbeat-only spokes via the
 	// heartbeat response. Key: hive ID → gateway (carries the secret key VALUE,
@@ -499,6 +507,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		pendingGitHubAppConfigs: make(map[string]*HeartbeatGitHubAppConfig),
 		pendingGateways:         make(map[string]*HeartbeatGatewayConfig),
 		hubBanners:              make(map[string]*HubBannerEntry),
+		spokeProxyAuthCache:     make(map[string]spokeProxyAuthEntry),
 		timeline:                newTimelineStore(),
 		journey:                 newJourneyStore(),
 		alerts:                  newAlertState(),


### PR DESCRIPTION
**Hub half of F2** (tracking #2172, review by @jonpspri). Deploy-first step of a coordinated hub→spoke change.

## What
The hub's nginx-ingress `auth_request` (`/api/saas/auth-check`) currently sets only `X-Hive-User`/`X-Hive-Role` for the spoke — with no proof the request actually transited the hub proxy. This PR has the hub additionally emit a **proof-of-proxy header** on authenticated success, so the spoke (in a follow-up v3 PR) can require it and stop trusting bare identity headers from the pod network.

- `handleSaaSAuthCheck` sets **`X-Hive-Proxy-Auth`** = the hive's dashboard token (the same per-hive secret the spoke already holds as its `authToken`, read from the `dashboard-token` k8s secret). Set only on the auth-success path; never on public/401/403 paths.
- Token is resolved via the existing `loadSpokeAuthToken` and **memoized 5 min** so the per-request auth subrequest never execs `kubectl` in the hot path.
- `auth-response-headers` annotation extended to copy the new header.

## Safety — pure no-op until the spoke half ships
This only **adds** one response header that current spokes ignore. Existing `authenticate()` never reads `X-Hive-Proxy-Auth`, so nothing changes for any of the ~41 live hosted hives until the v3 spoke enforcement lands. This must deploy to the hub **first**; the v3 spoke half fails open during the rollout window, then enforces.

## Contract for the v3 spoke half
Header `X-Hive-Proxy-Auth`, value = raw dashboard token (no prefix/encoding/HMAC), constant-time compared against the spoke's `authToken`; present only on success.

## Tests
New `TestHandleSaaSAuthCheckProxyAuthHeader` (set on 200, absent on 401). `go build ./...` + `go test ./pkg/hub/ -run 'AuthCheck|Assign'` green.

cc @jonpspri

🤖 Generated with [Claude Code](https://claude.com/claude-code)