### PR TITLE
fix(acmm): correct the ACMM ladder (names, merge level, L3 testing focus)

### DIFF
--- a/v2/docs/architecture.md
+++ b/v2/docs/architecture.md
@@ -242,8 +242,8 @@ flowchart LR
 |-------|------|------------------|
 | L1 | Assisted | Advisory beads + project inception only |
 | L2 | Instructed | Observe and report findings as beads; no GitHub writes |
-| L3 | Measured | `quality` opens hold-gated PRs; others advisory |
-| L4 | Adaptive | Several agents file issues; a few open hold-gated PRs |
+| L3 | Measured | `quality` opens hold-gated PRs about testing gaps, coverage, and CI health; others advisory. This measurement foundation is what earns automation at higher levels |
+| L4 | Adaptive | All agents file issues (bugs, docs, workflows, vulns); still no PRs |
 | L5 | Semi-Automated | All agents open PRs — every PR carries a `hold` label for human review |
 | L6 | Fully Autonomous | Agents open PRs and **auto-merge on green CI**; no hold required |
 

--- a/v2/pkg/hub/static/learn.html
+++ b/v2/pkg/hub/static/learn.html
@@ -295,15 +295,15 @@
       <div class="section-heading">
         <p class="section-label">Autonomy framework</p>
         <h2>The ACMM ladder</h2>
-        <p>The <strong style="color:var(--text)">AI-native Codebase Maturity Model (ACMM)</strong> defines six levels of AI agent autonomy, from advisory-only to fully autonomous. Each level controls which agents are active and what actions they can take. Start conservative, climb when you&rsquo;re ready.</p>
+        <p>The <strong style="color:var(--text)">AI-native Capability Maturity Model (ACMM)</strong> defines six levels of AI agent autonomy, from advisory-only to fully autonomous. Each level controls which agents are active and what actions they can take. Start conservative, climb when you&rsquo;re ready &mdash; raising the level is always a human decision.</p>
       </div>
       <div class="acmm-grid">
-        <div class="acmm-card"><span class="level lv-1">L1 &mdash; Idea</span><h3>Advisory only</h3><p>Agents analyze but don&rsquo;t act. Beads and heartbeat logs only.</p></div>
-        <div class="acmm-card"><span class="level lv-2">L2 &mdash; Measured</span><h3>Issues, no PRs</h3><p>Agents can open issues. Quality gates begin.</p></div>
-        <div class="acmm-card"><span class="level lv-3">L3 &mdash; CI/CD</span><h3>Hold-gated PRs</h3><p>Agents open hold-gated PRs. CI must pass. Human approval required.</p></div>
-        <div class="acmm-card"><span class="level lv-4">L4 &mdash; Autonomous PR</span><h3>Merge on green</h3><p>Agents open and merge PRs on green CI. Hold labels for safety.</p></div>
-        <div class="acmm-card"><span class="level lv-5">L5 &mdash; Self-Governing</span><h3>Budget-aware</h3><p>Full autonomy with budget controls. Governor manages pace and cost.</p></div>
-        <div class="acmm-card"><span class="level lv-6">L6 &mdash; Fully Autonomous</span><h3>Multi-loop</h3><p>Multi-loop orchestration. Outreach, community engagement. Highest trust.</p></div>
+        <div class="acmm-card"><span class="level lv-1">L1 &mdash; Assisted</span><h3>Inception &amp; advisory</h3><p>An interactive brainstorm agent turns ideas into project scaffolding; a guide agent audits docs. Every action needs human approval. No feedback loops.</p></div>
+        <div class="acmm-card"><span class="level lv-2">L2 &mdash; Instructed</span><h3>Observe &amp; report</h3><p>Agents produce advisory findings on the dashboard and a tracking issue. No GitHub issues or PRs. They observe and report; humans decide what to act on.</p></div>
+        <div class="acmm-card"><span class="level lv-3">L3 &mdash; Measured</span><h3>Quality &amp; test coverage</h3><p>The quality agent opens issues and hold-gated PRs about testing gaps, coverage, and CI health. Every PR keeps a <code>hold</code> label &mdash; no agent merges. This measurement foundation is what earns automation in the levels above.</p></div>
+        <div class="acmm-card"><span class="level lv-4">L4 &mdash; Adaptive</span><h3>Closed-loop, issues</h3><p>All agents now file issues &mdash; bugs, doc gaps, workflow failures, vulnerabilities. Security agent joins. Still no PRs; the loop is closing.</p></div>
+        <div class="acmm-card"><span class="level lv-5">L5 &mdash; Semi-Automated</span><h3>Hold-gated PRs</h3><p>All agents open PRs, each auto-labeled <code>hold</code> for human batch-review. Architect (RFCs) and strategist join. The system proposes; it does not merge on its own.</p></div>
+        <div class="acmm-card"><span class="level lv-6">L6 &mdash; Fully Autonomous</span><h3>Merge on green CI</h3><p>Agents open PRs and auto-merge on green CI &mdash; no <code>hold</code> label. Outreach agent handles community engagement. Highest trust; governor at fastest cadence.</p></div>
       </div>
     </section>
 


### PR DESCRIPTION
## What

The ACMM ladder on the **/learn** page (hive.kubestellar.io) and in `docs/architecture.md` had the wrong level names and wrong behaviors. Corrected both against the source of truth (`pkg/config/packs/level-*.yaml` + `docs/acmm-policy-matrix.md`).

| Level | Was (wrong) | Now (canonical) |
|---|---|---|
| L1 | Idea | **Assisted** — inception & advisory |
| L2 | Measured | **Instructed** — observe & report |
| L3 | CI/CD | **Measured** — quality/testing, hold-gated PRs |
| L4 | Autonomous PR · *merge on green* | **Adaptive** — all agents file **issues** (no PRs yet) |
| L5 | Self-Governing | **Semi-Automated** — all agents open **hold-gated PRs** |
| L6 | Multi-loop | **Fully Autonomous** — **auto-merge on green** |

### Key corrections
- **Auto-merge moved from L4 → L6.** All PRs are hold-gated below L6; only L6 auto-merges.
- **L4 is issues-only.** Hold-gated PRs start at L5, not L4.
- **ACMM expansion fixed:** 'AI-native ~~Codebase~~ **Capability** Maturity Model'.
- **L3 sharpened:** the quality agent opens hold-gated PRs about testing gaps, coverage, and CI health — the measurement foundation that earns automation at higher levels.

No behavior change — public-facing copy only. Hub package builds.