### PR TITLE
fix(dashboard): require X-Hive-Proxy-Auth on hub-proxied path (F2 spoke half, fail-open) — v2

### DIFF
--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -30,6 +31,20 @@ const agentSkipAfterFullBroadcastS = 5 * time.Second
 const maxSSEClients = 100
 const sessionCookieName = "hive_session"
 const sessionCookieMaxAge = 30 * 24 * 60 * 60 // 30 days
+
+// proxyAuthHeader is the proof-of-proxy header the hub's auth-check injects
+// (value = this hive's dashboard token) so a hub-proxied spoke can verify a
+// request actually transited the hub nginx rather than being forged on the pod
+// network. See authenticate() (F2). Must match the hub's constant.
+const proxyAuthHeader = "X-Hive-Proxy-Auth"
+
+// proxyProofRequired controls F2 enforcement strictness. Default false =
+// fail-open rollout: a request with no proof header is still trusted on its
+// identity headers (so hosted hives aren't locked out while the hub half rolls
+// out fleet-wide). Set HIVE_PROXY_PROOF_REQUIRED=true (once every hub is
+// confirmed injecting the header) to fail closed: a missing/incorrect proof
+// header is rejected. A WRONG proof header is ALWAYS rejected regardless.
+var proxyProofRequired = os.Getenv("HIVE_PROXY_PROOF_REQUIRED") == "true"
 
 type Server struct {
 	port       int
@@ -669,13 +684,38 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		// valid when a real token is configured.
 		trusted := s.authToken != "" && secureCompare(r.Header.Get("X-Hive-Internal"), s.authToken)
 
-		// Hub-proxied path: nginx injects both headers from the hub's
+		// Hub-proxied path: nginx injects the identity headers from the hub's
 		// per-user/per-hive auth-check. Only trust them when this spoke is NOT a
-		// direct-route spoke (see strip above). Requiring both headers prevents
-		// trivial bypass via a single forged header.
+		// direct-route spoke (see strip above).
+		//
+		// SECURITY (F2): identity headers alone are forgeable by anything on the
+		// pod network that reaches :3002 directly, bypassing the hub nginx. The
+		// hub now also emits X-Hive-Proxy-Auth = this hive's dashboard token (the
+		// same secret we hold as authToken) on the auth-check success path, which
+		// only the trusted proxy can produce. Require it as PROOF the request
+		// transited the hub.
+		//
+		// ROLLOUT SAFETY — fail open until the hub half is everywhere: if the hub
+		// has NOT sent X-Hive-Proxy-Auth (older hub image mid-rollout), fall back
+		// to the pre-F2 behavior (trust the identity headers) so no hosted hive is
+		// locked out. Once the hub half is confirmed deployed fleet-wide, a
+		// follow-up flips proxyProofRequired to make a missing/incorrect proof
+		// header fail closed.
 		if !trusted && !directRouteAuthz &&
 			r.Header.Get("X-Hive-User") != "" && r.Header.Get("X-Hive-Role") != "" {
-			trusted = true
+			proof := r.Header.Get(proxyAuthHeader)
+			switch {
+			case proof != "" && s.authToken != "" && secureCompare(proof, s.authToken):
+				// Proof present and valid — definitely came through the hub.
+				trusted = true
+			case proof == "" && !proxyProofRequired:
+				// No proof header yet (hub not upgraded) and we're not enforcing
+				// strictly — trust the identity headers as before (rollout window).
+				trusted = true
+			default:
+				// Proof header present but WRONG, or strict mode with no proof:
+				// this did not come through the trusted hub proxy — reject.
+			}
 		}
 
 		// Per-user session path (device flow): resolve the session id in the

--- a/v2/pkg/dashboard/spoke_authz_test.go
+++ b/v2/pkg/dashboard/spoke_authz_test.go
@@ -177,6 +177,54 @@ func TestMiddleware_HubProxiedHeadersStillTrusted(t *testing.T) {
 	}
 }
 
+// TestMiddleware_F2ProxyProof covers the F2 proof-of-proxy header enforcement on
+// a hub-proxied spoke: a valid proof is trusted; a WRONG proof is always
+// rejected; a MISSING proof is trusted only in the fail-open rollout default and
+// rejected once strict enforcement is enabled.
+func TestMiddleware_F2ProxyProof(t *testing.T) {
+	newReq := func(proof string) *http.Request {
+		r := httptest.NewRequest("GET", "/api/config", nil)
+		r.Header.Set("X-Hive-User", "clubanderson")
+		r.Header.Set("X-Hive-Role", "owner")
+		if proof != "" {
+			r.Header.Set(proxyAuthHeader, proof)
+		}
+		return r
+	}
+	run := func(t *testing.T, strict bool, proof string) int {
+		s := newFullServer(t)
+		s.authToken = "shared-secret-token"
+		old := proxyProofRequired
+		proxyProofRequired = strict
+		t.Cleanup(func() { proxyProofRequired = old })
+		w := httptest.NewRecorder()
+		s.authenticate(recordingHandler(nil, nil)).ServeHTTP(w, newReq(proof))
+		return w.Code
+	}
+
+	// Valid proof header (matches authToken) -> trusted, both modes.
+	if c := run(t, false, "shared-secret-token"); c != http.StatusOK {
+		t.Errorf("valid proof (fail-open) = %d, want 200", c)
+	}
+	if c := run(t, true, "shared-secret-token"); c != http.StatusOK {
+		t.Errorf("valid proof (strict) = %d, want 200", c)
+	}
+	// Wrong proof header -> ALWAYS rejected (forged proxy).
+	if c := run(t, false, "wrong-token"); c == http.StatusOK {
+		t.Error("wrong proof must be rejected even in fail-open mode")
+	}
+	if c := run(t, true, "wrong-token"); c == http.StatusOK {
+		t.Error("wrong proof must be rejected in strict mode")
+	}
+	// Missing proof: trusted in fail-open (rollout), rejected in strict.
+	if c := run(t, false, ""); c != http.StatusOK {
+		t.Errorf("missing proof (fail-open) = %d, want 200 (rollout safety)", c)
+	}
+	if c := run(t, true, ""); c == http.StatusOK {
+		t.Error("missing proof must be rejected in strict mode")
+	}
+}
+
 func TestMiddleware_SharedCookieNoLongerAuthenticates(t *testing.T) {
 	// The old vulnerability: the shared s.authToken placed in the session cookie
 	// granted access. It must no longer be accepted as a session id.


### PR DESCRIPTION
**v2 port of the F2 spoke half** (v3 = #2192; hub half = #2189, deployed). Needed so hub-proxied **v2** hives also get the proof-header enforcement.

Same change as #2192: on a hub-proxied spoke, `authenticate()` requires `X-Hive-Proxy-Auth` (= this hive's dashboard token, constant-time compared) as proof the request transited the hub nginx. Applies only to the `!directRouteAuthz` (push/hub-proxied) path — vllm-d/pull spokes (per-user session) untouched.

**Fails OPEN by default** (missing proof still trusted on identity headers → no lockout); wrong proof always rejected; `HIVE_PROXY_PROOF_REQUIRED=true` flips to strict after ingress annotations are updated fleet-wide.

Tests: `TestMiddleware_F2ProxyProof` + existing hub-proxied test green.

cc @jonpspri

🤖 Generated with [Claude Code](https://claude.com/claude-code)