### PR TITLE
🔐 fix(hub): replace a WRONG per-hive GitHub App key, not just a missing one

### DIFF
--- a/v2/cmd/hive/appkeyfile_test.go
+++ b/v2/cmd/hive/appkeyfile_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// testRSAKeyBits matches the smallest size GitHub Apps actually use. These keys
+// never sign anything real — they only exercise path resolution.
+const testRSAKeyBits = 2048
+
+func writeTestKey(t *testing.T, path string) string {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, testRSAKeyBits)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pemData := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(k),
+	})
+	if err := os.WriteFile(path, pemData, spokeAppKeyFileMode); err != nil {
+		t.Fatalf("write key %s: %v", path, err)
+	}
+	fp, err := config.AppKeyFingerprint(string(pemData))
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+	return fp
+}
+
+// redirectSpokeKeyPaths points the two spoke key locations at a temp dir and
+// restores them afterwards, so the real resolution order runs against files this
+// test controls rather than against /data and /secrets.
+func redirectSpokeKeyPaths(t *testing.T) (dataPath, secretsPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	origData, origSecrets := spokeAppKeyPath, spokeProvisionedAppKeyPath
+	spokeAppKeyPath = filepath.Join(dir, "data-gh-app-key.pem")
+	spokeProvisionedAppKeyPath = filepath.Join(dir, "secrets-gh-app-key.pem")
+	t.Cleanup(func() {
+		spokeAppKeyPath, spokeProvisionedAppKeyPath = origData, origSecrets
+	})
+	return spokeAppKeyPath, spokeProvisionedAppKeyPath
+}
+
+// TestResolveAppKeyFilePrefersDeliveredKey is the test that keeps the fix from
+// being cosmetic.
+//
+// The hub can deliver a correct key and the hive can still authenticate with the
+// wrong one: the delivered key lands on the PVC at spokeAppKeyPath, but the
+// stale operator-provisioned key sits at the read-only /secrets mount that the
+// spoke cannot overwrite. If resolution fell through to /secrets whenever
+// key_file was unset — which is exactly the state of the three broken GHE hives
+// — every restart would silently resume signing with the dead key while the hub
+// kept redelivering forever. Delivered-but-unused looks fixed and is not.
+func TestResolveAppKeyFilePrefersDeliveredKey(t *testing.T) {
+	dataPath, secretsPath := redirectSpokeKeyPaths(t)
+
+	t.Run("stale secrets key present, delivered data key wins", func(t *testing.T) {
+		staleFP := writeTestKey(t, secretsPath)
+		goodFP := writeTestKey(t, dataPath)
+		if staleFP == goodFP {
+			t.Fatal("test keys collided; the two paths must hold different keys")
+		}
+
+		// key_file unset — the vllmd-01..03 state.
+		got := resolveAppKeyFile("", "")
+		if got != dataPath {
+			t.Fatalf("resolveAppKeyFile = %q, want the delivered key at %q", got, dataPath)
+		}
+
+		// And the key actually in effect must be the delivered one.
+		fp, err := config.AppKeyFingerprintFromFile(got)
+		if err != nil {
+			t.Fatalf("fingerprint resolved key: %v", err)
+		}
+		if fp != goodFP {
+			t.Fatalf("resolved key fingerprint = %q, want the delivered %q", fp, goodFP)
+		}
+
+		// The heartbeat must report that same key, or the hub compares against a
+		// key that is not signing anything.
+		if reported := reportedAppKeyFingerprint(""); reported != goodFP {
+			t.Fatalf("reportedAppKeyFingerprint = %q, want %q", reported, goodFP)
+		}
+
+		// And it must stop claiming a per-hive override, so the hub's idempotence
+		// check sees a plain match and stops pushing.
+		if hasPerHiveAppKey("") {
+			t.Error("hasPerHiveAppKey = true after taking delivery; the /secrets key is no longer in effect")
+		}
+	})
+
+	t.Run("no delivered key falls back to the provisioning mount", func(t *testing.T) {
+		dataPath, secretsPath := redirectSpokeKeyPaths(t)
+		provisionedFP := writeTestKey(t, secretsPath)
+		_ = dataPath // deliberately absent
+
+		got := resolveAppKeyFile("", "")
+		if got != secretsPath {
+			t.Fatalf("resolveAppKeyFile = %q, want the provisioned key at %q", got, secretsPath)
+		}
+		if reported := reportedAppKeyFingerprint(""); reported != provisionedFP {
+			t.Fatalf("reportedAppKeyFingerprint = %q, want %q", reported, provisionedFP)
+		}
+		// A genuine per-hive credential must still be reported as such, so the
+		// hub's protective precedence keeps working.
+		if !hasPerHiveAppKey("") {
+			t.Error("hasPerHiveAppKey = false; a provisioned key in effect is a per-hive override")
+		}
+	})
+
+	t.Run("empty data key does not shadow a good provisioned key", func(t *testing.T) {
+		dataPath, secretsPath := redirectSpokeKeyPaths(t)
+		provisionedFP := writeTestKey(t, secretsPath)
+		// An empty /data file is exactly what vllmd-06..09 had. Mere existence
+		// must not win — only a parseable key may.
+		if err := os.WriteFile(dataPath, nil, spokeAppKeyFileMode); err != nil {
+			t.Fatal(err)
+		}
+
+		if got := resolveAppKeyFile("", ""); got != secretsPath {
+			t.Fatalf("resolveAppKeyFile = %q, want %q; an empty file is not a key", got, secretsPath)
+		}
+		if reported := reportedAppKeyFingerprint(""); reported != provisionedFP {
+			t.Fatalf("reportedAppKeyFingerprint = %q, want %q", reported, provisionedFP)
+		}
+	})
+
+	t.Run("explicit key_file and env override still win outright", func(t *testing.T) {
+		dataPath, _ := redirectSpokeKeyPaths(t)
+		writeTestKey(t, dataPath)
+		explicit := filepath.Join(t.TempDir(), "operator-chosen.pem")
+
+		if got := resolveAppKeyFile(explicit, ""); got != explicit {
+			t.Errorf("configured key_file = %q, want %q; an explicit path must not be redirected", got, explicit)
+		}
+		if got := resolveAppKeyFile("", explicit); got != explicit {
+			t.Errorf("env override = %q, want %q", got, explicit)
+		}
+		// Env beats config, matching the original precedence.
+		other := filepath.Join(t.TempDir(), "from-config.pem")
+		if got := resolveAppKeyFile(other, explicit); got != explicit {
+			t.Errorf("env override = %q, want it to beat key_file %q", got, explicit)
+		}
+		// Whitespace is not a path.
+		if got := resolveAppKeyFile("  ", "  "); got != dataPath {
+			t.Errorf("blank inputs = %q, want the delivered key at %q", got, dataPath)
+		}
+	})
+}

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -64,13 +64,16 @@ var (
 //   - spokeAppKeyPath is on the PVC and is where a hub-delivered (cluster
 //     default) key lands. It is also what cfg.GitHub.KeyFile is repointed at
 //     once the hub delivers one, so it takes effect over the provisioned mount.
-const (
+// Vars rather than consts so tests can point them at a temp dir and exercise
+// the real resolution order; production never reassigns them.
+var (
 	spokeProvisionedAppKeyPath = "/secrets/gh-app-key.pem"
 	spokeAppKeyPath            = "/data/gh-app-key.pem"
-	// spokeAppKeyFileMode is rw------- : signing material must never be
-	// readable by anything else sharing the PVC or the pod.
-	spokeAppKeyFileMode = 0o600
 )
+
+// spokeAppKeyFileMode is rw------- : signing material must never be readable by
+// anything else sharing the PVC or the pod.
+const spokeAppKeyFileMode = 0o600
 
 // reportedAppKeyFingerprint returns the non-secret fingerprint of the App key
 // this spoke is ACTUALLY using, for the heartbeat payload. It fingerprints the
@@ -82,7 +85,12 @@ const (
 // cannot authenticate") and are repaired identically. The private key itself is
 // never returned, and never enters the payload.
 func reportedAppKeyFingerprint(keyFile string) string {
-	candidates := []string{keyFile, spokeAppKeyPath, spokeProvisionedAppKeyPath}
+	// Lead with the same path resolveAppKeyFile would sign with, so the hub is
+	// told about the key actually in effect and never about a shadowed one.
+	candidates := []string{
+		resolveAppKeyFile(keyFile, os.Getenv("GH_APP_KEY_FILE")),
+		keyFile, spokeAppKeyPath, spokeProvisionedAppKeyPath,
+	}
 	for _, p := range candidates {
 		if strings.TrimSpace(p) == "" {
 			continue
@@ -108,8 +116,46 @@ func hasPerHiveAppKey(keyFile string) bool {
 		return false
 	}
 	// The provisioned key exists. It is the effective credential only if the
-	// resolved key file still points at it.
-	return strings.TrimSpace(keyFile) == "" || keyFile == spokeProvisionedAppKeyPath
+	// resolved key file still points at it — resolveAppKeyFile is the single
+	// authority on that, so an unconfigured hive that has already taken delivery
+	// of a /data key correctly stops claiming a per-hive override.
+	return resolveAppKeyFile(keyFile, os.Getenv("GH_APP_KEY_FILE")) == spokeProvisionedAppKeyPath
+}
+
+// resolveAppKeyFile picks which App private key this process will actually sign
+// with, given the configured key_file and the GH_APP_KEY_FILE env override.
+//
+// WHY THE /data PREFERENCE MATTERS
+//
+// A hub-delivered key lands at spokeAppKeyPath (/data, on the PVC) and the
+// heartbeat callback repoints cfg.GitHub.KeyFile at it — but only in memory, for
+// the life of that process. A hive whose config carries NO key_file (which is
+// the state of the three live GHE hives this repairs) used to fall straight
+// through to the read-only /secrets provisioning mount. That mount holds the
+// stale, wrong key, and the spoke cannot write to it. So on every restart the
+// hive would silently go back to signing with the key that cannot work, and the
+// hub — seeing the wrong fingerprint reported again — would redeliver forever.
+// The key would be delivered and never used: a fault that reads as fixed.
+//
+// So when nothing is explicitly configured, a key already present on the PVC is
+// preferred over the provisioning mount. An EXPLICIT key_file or env override
+// still wins outright: those are deliberate, and this must not silently redirect
+// an operator who named a path.
+func resolveAppKeyFile(configured, envOverride string) string {
+	if v := strings.TrimSpace(envOverride); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(configured); v != "" {
+		return v
+	}
+	// Nothing configured. Prefer a usable hub-delivered key on the PVC; fall
+	// back to the provisioning mount only when /data has no parseable key. The
+	// fingerprint check (not mere existence) keeps an empty or truncated /data
+	// file from shadowing a good provisioned key.
+	if fp, err := config.AppKeyFingerprintFromFile(spokeAppKeyPath); err == nil && fp != "" {
+		return spokeAppKeyPath
+	}
+	return spokeProvisionedAppKeyPath
 }
 
 // processStartedAt is when this hive process began. Reported over the heartbeat
@@ -203,13 +249,7 @@ func main() {
 	var ghClient *github.Client
 	var appAuth *github.AppAuth
 	if cfg.GitHub.AppID != 0 && cfg.GitHub.InstallationID != 0 {
-		keyFile := cfg.GitHub.KeyFile
-		if envKey := os.Getenv("GH_APP_KEY_FILE"); envKey != "" {
-			keyFile = envKey
-		}
-		if keyFile == "" {
-			keyFile = "/secrets/gh-app-key.pem"
-		}
+		keyFile := resolveAppKeyFile(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"))
 		var err error
 		appAuth, err = github.NewAppAuth(cfg.GitHub.AppID, cfg.GitHub.InstallationID, keyFile, logger, cfg.GitHub.ResolvedAPIURL())
 		if err != nil {
@@ -1843,6 +1883,10 @@ func main() {
 				// nothing and a spoke holding the wrong one self-heals.
 				GitHubAppKeyFingerprint: reportedAppKeyFingerprint(cfg.GitHub.KeyFile),
 				GitHubAppKeyPerHive:     hasPerHiveAppKey(cfg.GitHub.KeyFile),
+				// Report the App this hive believes it authenticates as. The hub
+				// pairs it with the fingerprint above to tell a per-hive key that
+				// is WRONG for this App from one that is deliberately for another.
+				GitHubAppID: cfg.GitHub.AppID,
 			}
 		}, heartbeatSendInterval, logger, hub.UpgradeCallback(func(targetSHA string) {
 			const upgradeMarkerPath = "/data/upgrade-requested"
@@ -1965,6 +2009,11 @@ func main() {
 			)
 
 			keyPath := spokeAppKeyPath
+			// keyChanged gates dropping the cached installation token below: a
+			// token minted under the previous key is invalid the moment the key
+			// is replaced, but a redelivery of the SAME key must not throw away a
+			// perfectly good token every heartbeat.
+			keyChanged := false
 			if ghCfg.PrivateKey != "" {
 				// Fingerprint before and after so the key rotation is auditable
 				// from the spoke's own logs. Fingerprints only — the key itself
@@ -1982,11 +2031,19 @@ func main() {
 					logger.Warn("could not tighten github app key permissions", "path", keyPath, "error", err)
 				}
 				afterFP, _ := config.AppKeyFingerprintFromFile(keyPath)
+				keyChanged = afterFP != "" && afterFP != beforeFP
 				logger.Info("github app private key written via heartbeat",
 					"path", keyPath,
 					"from_fingerprint", beforeFP,
 					"to_fingerprint", afterFP,
+					"key_changed", keyChanged,
 				)
+				if keyChanged {
+					// Invalidate before the new client is built, so nothing can
+					// read the dead token out of the shared on-disk cache in
+					// between. Agents read that file directly.
+					appAuth.DropCachedToken()
+				}
 			}
 
 			if ghCfg.AppID != 0 {

--- a/v2/pkg/github/app_discovery.go
+++ b/v2/pkg/github/app_discovery.go
@@ -190,6 +190,34 @@ func (a *AppAuth) APIURL() string { return a.apiURL }
 // not App-authenticated and must be skipped rather than treated as failing.
 func (a *AppAuth) HasKey() bool { return a != nil && a.key != nil }
 
+// DropCachedToken discards the installation token this auth is holding, in
+// memory and on disk.
+//
+// Call it when the SIGNING KEY changes. A token is minted by presenting a JWT
+// signed with the old key; once the key is replaced that token is a dead
+// credential, and it is not enough to rebuild the AppAuth in memory — the
+// on-disk cache at cachePath is read directly by agent processes, so a stale
+// token there keeps being handed out until it expires. Dropping it forces the
+// next caller to mint a fresh token under the new key.
+//
+// A missing cache file is the normal case, not an error.
+func (a *AppAuth) DropCachedToken() {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.cachedToken = ""
+	a.tokenExpiry = time.Time{}
+	if a.cachePath == "" {
+		return
+	}
+	if err := os.Remove(a.cachePath); err != nil && !os.IsNotExist(err) && a.logger != nil {
+		a.logger.Warn("failed to drop stale app token cache after key change",
+			"path", a.cachePath, "error", err)
+	}
+}
+
 // AdoptInstallationID switches this auth to a different installation and
 // drops the cached installation token (which was minted for the OLD, wrong
 // installation and would keep 403ing on writes).

--- a/v2/pkg/github/app_dropcache_test.go
+++ b/v2/pkg/github/app_dropcache_test.go
@@ -1,0 +1,92 @@
+package github
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// dropCacheTestKeyBits matches the smallest size GitHub Apps use. This key never
+// signs anything real.
+const dropCacheTestKeyBits = 2048
+
+func newTestAppAuth(t *testing.T, cachePath string) *AppAuth {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, dropCacheTestKeyBits)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	keyFile := filepath.Join(t.TempDir(), "key.pem")
+	pemData := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(k),
+	})
+	if err := os.WriteFile(keyFile, pemData, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	auth, err := NewAppAuthWithCache(1234, 5678, keyFile, cachePath, slog.New(slog.NewTextHandler(io.Discard, nil)), "")
+	if err != nil {
+		t.Fatalf("NewAppAuthWithCache: %v", err)
+	}
+	return auth
+}
+
+// TestDropCachedToken covers the invalidation that has to happen when the App
+// private key is replaced. A token was minted by presenting a JWT signed with
+// the OLD key; once the key changes that token is dead. Rebuilding the AppAuth in
+// memory is not sufficient, because agent processes read the token straight out
+// of the on-disk cache — a stale file there keeps handing out a dead credential
+// until it expires on its own.
+func TestDropCachedToken(t *testing.T) {
+	t.Run("clears in-memory token and removes the cache file", func(t *testing.T) {
+		cachePath := filepath.Join(t.TempDir(), "gh-app-token.cache")
+		if err := os.WriteFile(cachePath, []byte("ghs_stale_token_minted_under_the_old_key"), 0o640); err != nil {
+			t.Fatal(err)
+		}
+		auth := newTestAppAuth(t, cachePath)
+		auth.cachedToken = "ghs_stale_token_minted_under_the_old_key"
+		auth.tokenExpiry = time.Now().Add(time.Hour)
+
+		auth.DropCachedToken()
+
+		if auth.cachedToken != "" {
+			t.Errorf("cachedToken = %q, want empty", auth.cachedToken)
+		}
+		if !auth.tokenExpiry.IsZero() {
+			t.Errorf("tokenExpiry = %v, want zero", auth.tokenExpiry)
+		}
+		if _, err := os.Stat(cachePath); !os.IsNotExist(err) {
+			t.Errorf("cache file still present (err=%v); agents would keep reading the dead token", err)
+		}
+	})
+
+	t.Run("a missing cache file is not an error", func(t *testing.T) {
+		cachePath := filepath.Join(t.TempDir(), "absent.cache")
+		auth := newTestAppAuth(t, cachePath)
+		auth.DropCachedToken() // must not panic or fail
+		if auth.cachedToken != "" {
+			t.Error("cachedToken should be empty")
+		}
+	})
+
+	t.Run("no cache path configured is a no-op on disk", func(t *testing.T) {
+		auth := newTestAppAuth(t, "")
+		auth.cachedToken = "x"
+		auth.DropCachedToken()
+		if auth.cachedToken != "" {
+			t.Error("cachedToken should be cleared even with no cache path")
+		}
+	})
+
+	t.Run("nil receiver is safe", func(t *testing.T) {
+		var auth *AppAuth
+		auth.DropCachedToken() // the spoke may not have App auth built yet
+	})
+}

--- a/v2/pkg/hub/cluster_app_key.go
+++ b/v2/pkg/hub/cluster_app_key.go
@@ -239,6 +239,15 @@ const (
 	appKeyReasonSpokeHasNoKey   = "spoke reports no app key"
 	appKeyReasonMismatch        = "spoke key fingerprint differs from cluster key"
 	appKeyReasonMatch           = "spoke already holds the cluster key"
+	// appKeyReasonPerHiveUnusable is the one case that overrides the per-hive
+	// precedence: the hive claims the cluster's app_id but holds a key that is
+	// not the cluster's. That pair cannot sign a valid JWT for that App, so the
+	// per-hive key is not a choice being protected — it is a fault.
+	appKeyReasonPerHiveUnusable = "per-hive key cannot sign for the app_id this hive claims"
+	// appKeyReasonDifferentApp is the per-hive case that IS protected: the hive
+	// is pinned to an App other than the cluster's, so its key is presumed
+	// correct for that App and the cluster key would break it.
+	appKeyReasonDifferentApp = "hive is deliberately pinned to a different app_id"
 )
 
 // decideAppKeySync decides whether the hub should push its cluster App key to a
@@ -250,6 +259,32 @@ const (
 // overwrote it would silently undo that decision on the next beat, with no way
 // for the operator to make it stick. The cluster key is a FLOOR for hives nobody
 // has spoken for, not a ceiling over hives somebody has.
+//
+// THE ONE EXCEPTION — A WRONG PER-HIVE KEY IS NOT A CHOICE
+//
+// That precedence protects a DECISION. It must not protect a FAULT, and the two
+// are distinguishable without heuristics. A GitHub App JWT is signed by the
+// private key and presented alongside an app_id; GitHub verifies the signature
+// against the public key registered for THAT app_id. So for a hive reporting
+// app_id == cluster.AppID with a key fingerprint != cluster.Fingerprint, the
+// credential pair is provably unusable — not "probably stale", not "differently
+// configured", but arithmetically incapable of producing a token. That is
+// exactly the state three live GHE hives are in: they carry the PUBLIC
+// github.com App's key while claiming the GHE app_id, and every request dies
+// with "401 A JSON web token could not be decoded". Withholding the cluster key
+// from them protects nothing and leaves them permanently dead.
+//
+// The discriminator is therefore the app_id, and ONLY the app_id:
+//
+//	per-hive key + spoke app_id == cluster app_id + fingerprint differs
+//	    -> PUSH. The key cannot work for the App the hive claims.
+//	per-hive key + spoke app_id != cluster app_id (and non-zero)
+//	    -> DO NOT PUSH. A different App on purpose; its key is right for it.
+//	per-hive key + spoke app_id == 0 (unknown / too old to report)
+//	    -> DO NOT PUSH. Silence is not evidence of a fault; stay conservative.
+//
+// This is a proof, not an inference: it never asks whether a key LOOKS stale,
+// only whether the hive's own claimed App ID makes its own key impossible.
 //
 // IDEMPOTENCE: the hub pushes only when the fingerprints differ. Once the spoke
 // reports the cluster fingerprint the decision flips to no-push and the key stops
@@ -264,35 +299,62 @@ const (
 // that in fact has a good key is harmless — it rewrites the same App identity —
 // whereas withholding leaves a dead hive dead. Once the spoke is new enough to
 // report, the push stops on the following beat.
-func decideAppKeySync(spokeFingerprint string, hasPerHiveKey bool, cluster *clusterAppIdentity) appKeySyncDecision {
+func decideAppKeySync(spokeFingerprint string, hasPerHiveKey bool, spokeAppID int64, cluster *clusterAppIdentity) appKeySyncDecision {
 	if cluster == nil {
 		return appKeySyncDecision{Reason: appKeyReasonNoClusterKey, FromFingerprint: spokeFingerprint}
 	}
+	fp := strings.TrimSpace(spokeFingerprint)
 	if hasPerHiveKey {
+		// Idempotence first: if the per-hive key already IS the cluster key
+		// there is nothing to decide and nothing to send. Checking this ahead of
+		// the app_id logic also means a hive whose provisioned key happens to be
+		// correct never enters the exception path at all.
+		if fp != "" && fp == cluster.Fingerprint {
+			return appKeySyncDecision{
+				Reason:          appKeyReasonMatch,
+				FromFingerprint: fp,
+				ToFingerprint:   cluster.Fingerprint,
+			}
+		}
+		// The exception: the hive claims this cluster's App but cannot sign for
+		// it. Requires a POSITIVE app_id match — zero (unknown) and any other
+		// App both fall through to the protected override below.
+		if spokeAppID != 0 && spokeAppID == cluster.AppID && fp != "" && fp != cluster.Fingerprint {
+			return appKeySyncDecision{
+				Push:            true,
+				Reason:          appKeyReasonPerHiveUnusable,
+				FromFingerprint: fp,
+				ToFingerprint:   cluster.Fingerprint,
+			}
+		}
+		reason := appKeyReasonPerHiveOverride
+		if spokeAppID != 0 && spokeAppID != cluster.AppID {
+			reason = appKeyReasonDifferentApp
+		}
 		return appKeySyncDecision{
-			Reason:          appKeyReasonPerHiveOverride,
-			FromFingerprint: spokeFingerprint,
+			Reason:          reason,
+			FromFingerprint: fp,
 			ToFingerprint:   cluster.Fingerprint,
 		}
 	}
-	if strings.TrimSpace(spokeFingerprint) == "" {
+	if fp == "" {
 		return appKeySyncDecision{
 			Push:          true,
 			Reason:        appKeyReasonSpokeHasNoKey,
 			ToFingerprint: cluster.Fingerprint,
 		}
 	}
-	if spokeFingerprint != cluster.Fingerprint {
+	if fp != cluster.Fingerprint {
 		return appKeySyncDecision{
 			Push:            true,
 			Reason:          appKeyReasonMismatch,
-			FromFingerprint: spokeFingerprint,
+			FromFingerprint: fp,
 			ToFingerprint:   cluster.Fingerprint,
 		}
 	}
 	return appKeySyncDecision{
 		Reason:          appKeyReasonMatch,
-		FromFingerprint: spokeFingerprint,
+		FromFingerprint: fp,
 		ToFingerprint:   cluster.Fingerprint,
 	}
 }
@@ -306,9 +368,9 @@ func decideAppKeySync(spokeFingerprint string, hasPerHiveKey bool, cluster *clus
 // installation_id. Zero is passed through as zero — the spoke's callback only
 // rebuilds its client once app_id, installation_id and key file are all present,
 // so a key delivered ahead of an installation ID lands on disk and waits.
-func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFingerprint string, hasPerHiveKey bool, installationID int64, logger *slog.Logger) *HeartbeatGitHubAppConfig {
+func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFingerprint string, hasPerHiveKey bool, spokeAppID int64, installationID int64, logger *slog.Logger) *HeartbeatGitHubAppConfig {
 	identity := s.appIdentityForCluster(clusterID)
-	decision := decideAppKeySync(spokeFingerprint, hasPerHiveKey, identity)
+	decision := decideAppKeySync(spokeFingerprint, hasPerHiveKey, spokeAppID, identity)
 	if !decision.Push || identity == nil {
 		return nil
 	}
@@ -318,6 +380,8 @@ func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFing
 			"hive_id", hiveID,
 			"cluster_id", clusterID,
 			"app_id", identity.AppID,
+			"spoke_app_id", spokeAppID,
+			"per_hive_key", hasPerHiveKey,
 			"reason", decision.Reason,
 			"from_fingerprint", decision.FromFingerprint,
 			"to_fingerprint", decision.ToFingerprint,
@@ -528,6 +592,7 @@ func (s *HubServer) appKeySyncForHeartbeat(payload *HeartbeatPayload) *Heartbeat
 		clusterID,
 		payload.GitHubAppKeyFingerprint,
 		payload.GitHubAppKeyPerHive,
+		payload.GitHubAppID,
 		installationIDUnchanged,
 		s.logger,
 	)

--- a/v2/pkg/hub/cluster_app_key_test.go
+++ b/v2/pkg/hub/cluster_app_key_test.go
@@ -70,6 +70,7 @@ func TestDecideAppKeySync(t *testing.T) {
 		name        string
 		spokeFP     string
 		perHive     bool
+		spokeAppID  int64
 		cluster     *clusterAppIdentity
 		wantPush    bool
 		wantReason  string
@@ -133,15 +134,16 @@ func TestDecideAppKeySync(t *testing.T) {
 			description: "nothing to push means nothing happens, not an empty push",
 		},
 		{
-			name:        "per-hive key wins over cluster default even on mismatch",
+			name:        "per-hive key, spoke app_id unknown - no push",
 			spokeFP:     wrongFP,
 			perHive:     true,
+			spokeAppID:  0,
 			cluster:     identity,
 			wantPush:    false,
 			wantReason:  appKeyReasonPerHiveOverride,
 			wantFromFP:  wrongFP,
 			wantToFP:    clusterFP,
-			description: "a deliberate per-hive credential is never overwritten",
+			description: "a spoke too old to report app_id must not be assumed broken",
 		},
 		{
 			name:        "per-hive key with no key reported still wins",
@@ -151,13 +153,85 @@ func TestDecideAppKeySync(t *testing.T) {
 			wantPush:    false,
 			wantReason:  appKeyReasonPerHiveOverride,
 			wantToFP:    clusterFP,
-			description: "the override is unconditional; operator intent is respected",
+			description: "no fingerprint is no proof of a wrong key; stay conservative",
+		},
+
+		// --- THE FIX: a per-hive key that provably cannot work ---
+		{
+			name:        "per-hive key wrong for the app_id the hive claims - PUSH",
+			spokeFP:     wrongFP,
+			perHive:     true,
+			spokeAppID:  5686,
+			cluster:     identity,
+			wantPush:    true,
+			wantReason:  appKeyReasonPerHiveUnusable,
+			wantFromFP:  wrongFP,
+			wantToFP:    clusterFP,
+			description: "vllmd-01..03: claims GHE app 5686 but holds the public github.com key — cannot sign a valid JWT, so this is a fault and not a choice",
+		},
+		{
+			name:        "per-hive key for a deliberately DIFFERENT app - no push",
+			spokeFP:     wrongFP,
+			perHive:     true,
+			spokeAppID:  99999,
+			cluster:     identity,
+			wantPush:    false,
+			wantReason:  appKeyReasonDifferentApp,
+			wantFromFP:  wrongFP,
+			wantToFP:    clusterFP,
+			description: "a hive pinned to its own App keeps its own key; the cluster key would break it",
+		},
+		{
+			name:        "per-hive key already matches the cluster key - no push",
+			spokeFP:     clusterFP,
+			perHive:     true,
+			spokeAppID:  5686,
+			cluster:     identity,
+			wantPush:    false,
+			wantReason:  appKeyReasonMatch,
+			wantFromFP:  clusterFP,
+			wantToFP:    clusterFP,
+			description: "idempotence: once repaired the push must stop, per-hive flag or not",
+		},
+		{
+			name:        "per-hive, matching app_id, no fingerprint reported - no push",
+			spokeFP:     "",
+			perHive:     true,
+			spokeAppID:  5686,
+			cluster:     identity,
+			wantPush:    false,
+			wantReason:  appKeyReasonPerHiveOverride,
+			wantToFP:    clusterFP,
+			description: "the exception needs a fingerprint that provably differs, not an absent one",
+		},
+		{
+			name:        "cluster app_id unset cannot make a positive match",
+			spokeFP:     wrongFP,
+			perHive:     true,
+			spokeAppID:  5686,
+			cluster:     &clusterAppIdentity{AppID: 0, Fingerprint: clusterFP},
+			wantPush:    false,
+			wantReason:  appKeyReasonDifferentApp,
+			wantFromFP:  wrongFP,
+			wantToFP:    clusterFP,
+			description: "no cluster app_id means no proof of a conflict",
+		},
+		{
+			name:        "non-per-hive mismatch on a matching app_id still pushes",
+			spokeFP:     wrongFP,
+			spokeAppID:  5686,
+			cluster:     identity,
+			wantPush:    true,
+			wantReason:  appKeyReasonMismatch,
+			wantFromFP:  wrongFP,
+			wantToFP:    clusterFP,
+			description: "reporting app_id must not change the pre-existing non-per-hive path",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := decideAppKeySync(tc.spokeFP, tc.perHive, tc.cluster)
+			got := decideAppKeySync(tc.spokeFP, tc.perHive, tc.spokeAppID, tc.cluster)
 			if got.Push != tc.wantPush {
 				t.Errorf("Push = %v, want %v (%s)", got.Push, tc.wantPush, tc.description)
 			}
@@ -192,7 +266,7 @@ func TestDecideAppKeySyncIsIdempotent(t *testing.T) {
 	identity := &clusterAppIdentity{AppID: 5686, PrivateKey: keyPEM, Fingerprint: fp}
 
 	// Beat 1: spoke has nothing → push.
-	first := decideAppKeySync("", false, identity)
+	first := decideAppKeySync("", false, 0, identity)
 	if !first.Push {
 		t.Fatal("first beat should push to a spoke with no key")
 	}
@@ -204,7 +278,7 @@ func TestDecideAppKeySyncIsIdempotent(t *testing.T) {
 	}
 	// Beat 2: spoke now reports the delivered key → no push, forever after.
 	for beat := 2; beat <= 5; beat++ {
-		d := decideAppKeySync(delivered, false, identity)
+		d := decideAppKeySync(delivered, false, 0, identity)
 		if d.Push {
 			t.Fatalf("beat %d re-pushed a key the spoke already holds", beat)
 		}
@@ -537,7 +611,7 @@ func TestClusterKeyNeverSerializedIntoAPIPayload(t *testing.T) {
 			Fingerprint: identity.Fingerprint,
 		},
 		// The decision record that feeds every log line.
-		"appKeySyncDecision": decideAppKeySync("sha256:00000000000000000000000000000000", false, identity),
+		"appKeySyncDecision": decideAppKeySync("sha256:00000000000000000000000000000000", false, 0, identity),
 	}
 
 	for name, payload := range payloads {

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -294,6 +294,22 @@ type HeartbeatPayload struct {
 	// its cluster. The hub honours it as an override: a deliberate per-hive
 	// credential is never overwritten by the cluster default.
 	GitHubAppKeyPerHive bool `json:"github_app_key_per_hive,omitempty"`
+	// GitHubAppID is the App ID this spoke believes it is authenticating AS —
+	// cfg.GitHub.AppID, non-secret. It exists to make one specific distinction
+	// decidable on the hub: a per-hive key that is WRONG versus a per-hive key
+	// that is deliberately for a DIFFERENT App.
+	//
+	// A JWT is signed by the key and presented as app_id. If a spoke claims the
+	// cluster's app_id but holds a key whose fingerprint is not the cluster
+	// key's, that pair provably cannot authenticate — GitHub rejects it before
+	// any permission check ("A JSON web token could not be decoded"). If the
+	// spoke claims a DIFFERENT app_id, its key is presumed correct for that
+	// other App and the hub must not touch it.
+	//
+	// Zero means the spoke is too old to report, or has no App configured. Both
+	// read as "unknown": the hub falls back to the conservative per-hive
+	// override and declines to overwrite. Never infer a mismatch from silence.
+	GitHubAppID int64 `json:"github_app_id,omitempty"`
 }
 
 type StatusCollector func() *HeartbeatPayload


### PR DESCRIPTION
## The gap

#2185 made the hub authoritative for cluster GitHub App keys and repaired the four `vllm-d` spokes that had **no key at all**. It left the three that had a **wrong** key exactly as broken.

| Spoke | State before the seed | Synced by #2185? |
|---|---|---|
| vllmd-06/07/08/09 | no key (empty file) | ✅ all four correct now |
| vllmd-01/02/03 | wrong key — the PUBLIC github.com App's, while claiming `app_id: 5686` (GHE) | ❌ nothing delivered |

`hosted-available-vllmd-01` (`taylormgeorge91`, org `katamari` on GitHub Enterprise) cannot authenticate at all, despite a correct App install and a correct `installation_id: 42980`:

```
401 A JSON web token could not be decoded
  POST https://github.ibm.com/api/v3/app/installations/42980/access_tokens
```

## Which side was declining: the hub

The **hub never sent**. The spoke's write path is fine and was never reached.

Those three hives have no `github.key_file` configured, so:

- `hasPerHiveAppKey("")` — [`v2/cmd/hive/main.go:105-113`](https://github.com/kubestellar/hive/blob/559bbeb2/v2/cmd/hive/main.go#L105-L113) — finds real PEM at the read-only `/secrets/gh-app-key.pem` mount and, because `keyFile == ""`, returns **true**.
- `decideAppKeySync(...)` — [`v2/pkg/hub/cluster_app_key.go:271-277`](https://github.com/kubestellar/hive/blob/559bbeb2/v2/pkg/hub/cluster_app_key.go#L271-L277) — takes the `hasPerHiveKey` branch **before** any fingerprint comparison and returns `Push: false`.

So the wrong fingerprint was reported correctly and then discarded unread.

## The discriminator

#2185's precedence protects a **decision** — a hive pinned to its own App must keep its own key. It must not protect a **fault**, and the two are separable *provably*, not heuristically.

A GitHub App JWT is signed by the private key and presented alongside an `app_id`; GitHub verifies the signature against the key registered for **that** `app_id`. So a hive reporting the cluster's `app_id` with a fingerprint that is not the cluster key's is **arithmetically incapable** of minting a token — not "probably stale".

The discriminator is the `app_id`, and only the `app_id`:

| per-hive key | spoke `app_id` | fingerprint | decision |
|---|---|---|---|
| yes | `== cluster` | differs | **PUSH** (`per-hive key cannot sign for the app_id this hive claims`) |
| yes | `!= cluster`, non-zero | differs | hold (`hive is deliberately pinned to a different app_id`) |
| yes | `0` (too old / no App) | differs | hold (`per-hive override`) |
| yes | any | matches | hold (`match`) |

Silence is never read as a fault: `app_id == 0` keeps the old conservative behaviour. A cluster with `app_id` unset likewise cannot produce a positive match. Spokes now report `cfg.GitHub.AppID` (non-secret) so the comparison is possible at all.

## Making sure the delivered key is actually *used*

A delivered-but-unused key looks fixed and is not. The callback repoints `cfg.GitHub.KeyFile` at `/data/gh-app-key.pem` **in memory only**; on restart, a hive with no configured `key_file` fell straight through to `keyFile = "/secrets/gh-app-key.pem"` (old `main.go:210-212`) — the mount it cannot write — resumed signing with the dead key, and the hub would redeliver forever.

`resolveAppKeyFile()` is now the single authority:

1. `GH_APP_KEY_FILE` env override wins outright
2. an explicit configured `key_file` wins outright
3. otherwise prefer a **parseable** `/data/gh-app-key.pem`
4. else fall back to `/secrets/gh-app-key.pem`

Step 3 fingerprints rather than stat-ing, so an empty or truncated `/data` file cannot shadow a good provisioned key. `reportedAppKeyFingerprint` and `hasPerHiveAppKey` both delegate to it, so the hub is always told about the key really in effect — and a hive that has taken delivery correctly stops claiming a per-hive override, which is what makes the push stop.

## Also

- **Idempotent.** The fingerprint-match check runs *ahead* of the `app_id` logic, so once the spoke reports a match the decision is `match` and pushing stops regardless of the per-hive flag. No credential on the wire for a spoke that already has it.
- **Stale token dropped.** `AppAuth.DropCachedToken()` clears the installation token in memory and removes the on-disk cache when the fingerprint *actually changes* — a token minted under the old key is dead, and agents read that cache file directly. A redelivery of the same key does not discard a good token.
- **`installation_id` untouched.** The reconcile still sends `0` for "unchanged", preserving vllmd-01's correct `42980` — the bug #2185 fixed stays fixed.
- **No key material logged or serialized.** Fingerprints only, everywhere.

## Verification

`go build ./...` and `go vet ./...` clean. Tests pass for every package touched (`pkg/hub`, `pkg/github`, `cmd/hive`).

New/updated tables:
- full decision table — wrong-key-for-claimed-app **pushes**, deliberately-different-app holds, unknown-`app_id` holds, match holds, no-cluster-key no-ops, and the pre-existing empty-fingerprint push is preserved
- `TestResolveAppKeyFilePrefersDeliveredKey` — the delivered `/data` key beats a stale `/secrets` key, an empty `/data` file does not shadow a good provisioned key, explicit paths still win
- `TestDropCachedToken` — in-memory + on-disk clearing, missing file, no cache path, nil receiver

**Pre-existing failures, not from this change:** `TestFailingCheckSummaryEscapes/filter_chip_label_escaped` and `TestFilterComposition/clear_button_accounts_for_check_filter` in `pkg/hub` (filter-chip UI, unrelated). Both reproduce identically on unmodified `origin/v2` — verified in a clean worktree.

## Will vllmd-01/02/03 self-repair?

**Yes, provided the spokes are running this build**, which is the one thing to be aware of. The `app_id` field is *reported by the spoke*, so the hub cannot apply the new discriminator until a spoke reports it. Sequence per hive: spoke upgrades → reports `github_app_id: 5686` plus the wrong fingerprint `d5bead6a…` → hub sees `app_id` match with fingerprint mismatch → pushes → spoke writes `/data/gh-app-key.pem` (`a394401d…`), drops the stale token, rebuilds its client → next beat reports the matching fingerprint → pushing stops. No operator action, and no reprovision.

Until a given spoke is on this build it reports `app_id: 0` and is deliberately left alone — old spokes are held, not broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)