### PR TITLE
chore: top up dd to current v2, preserve Visual Hive

### DIFF
--- a/v2/Dockerfile
+++ b/v2/Dockerfile
@@ -137,6 +137,31 @@ RUN ARCH=$(uname -m) && \
     chmod +x /usr/local/bin/goose || \
     echo "WARN: Goose CLI install failed — skipping"
 
+# --- Layer 9: Bob CLI (IBM bobshell — backend: bob) ---
+# bobshell is NOT published to the public npm registry; it is distributed as a
+# tarball from IBM Cloud Object Storage. The vendor's documented host install is
+# `curl https://bob.ibm.com/download/bobshell.sh | bash`, but that script merely
+# resolves the latest version and npm-installs the same tarball. We install the
+# tarball directly at a pinned version instead: piping a remote script into the
+# build would be unpinned and unauditable, and inconsistent with the copilot /
+# claude / goose layers above.
+# The package is pure JavaScript (no native .node/.so payloads, no os/cpu
+# fields), so a single layer serves both linux/amd64 and linux/arm64.
+# package.json declares "bin": {"bob": "bundle/bob.js"} — npm therefore creates
+# /usr/local/bin/bob directly, matching the binary name the agent launcher
+# invokes (manager.go maps "bob" -> "bob"). No symlink is required.
+ARG BOBSHELL_VERSION=1.0.6
+ARG BOBSHELL_BASE_URL=https://s3.us-south.cloud-object-storage.appdomain.cloud/bob-shell
+# Deliberately NOT tolerant of failure, unlike the copilot/goose layers above.
+# A hive configured with backend "bob" passes config validation (validBackends
+# in pkg/config) and then fails at launch with "agent scanner not running" —
+# a silent trap that cost real debugging time. If this download breaks, the
+# build must break loudly rather than ship an image that reproduces that bug.
+# The `which bob` check turns a partial install into a build failure too.
+RUN npm install -g "${BOBSHELL_BASE_URL}/bobshell-${BOBSHELL_VERSION}.tgz" && \
+    npm cache clean --force && \
+    which bob
+
 # --- Application layers ---
 ENV HOME=/home/dev
 

--- a/v2/docs/architecture.md
+++ b/v2/docs/architecture.md
@@ -242,8 +242,8 @@ flowchart LR
 |-------|------|------------------|
 | L1 | Assisted | Advisory beads + project inception only |
 | L2 | Instructed | Observe and report findings as beads; no GitHub writes |
-| L3 | Measured | `quality` opens hold-gated PRs; others advisory |
-| L4 | Adaptive | Several agents file issues; a few open hold-gated PRs |
+| L3 | Measured | `quality` opens hold-gated PRs about testing gaps, coverage, and CI health; others advisory. This measurement foundation is what earns automation at higher levels |
+| L4 | Adaptive | All agents file issues (bugs, docs, workflows, vulns); still no PRs |
 | L5 | Semi-Automated | All agents open PRs — every PR carries a `hold` label for human review |
 | L6 | Fully Autonomous | Agents open PRs and **auto-merge on green CI**; no hold required |
 

--- a/v2/docs/cncf-reference-architecture.md
+++ b/v2/docs/cncf-reference-architecture.md
@@ -1,0 +1,279 @@
+---
+title: Hive — an autonomous cloud-native maintenance platform for open source
+date: 2026-07-29
+org_name: Hive
+org_team: Hive maintainers
+org_url: https://hive.kubestellar.io/
+org_logo_filename: images/hive.svg
+contact: Andy Anderson
+email: # optional — add if you want it listed publicly
+org_description: |
+  Hive is an open-source, self-hostable system that runs a fleet of AI coding
+  agents to autonomously maintain software repositories — triaging issues,
+  writing fixes, opening pull requests, and merging on green CI, all under
+  human-controlled, technically-enforced guardrails. It runs as a cloud-native
+  workload on Kubernetes with a hub-and-spoke model: a hosted hub coordinates a
+  fleet of self-hosted spoke hives. End users today include the KubeStellar
+  Console team (kubestellar/console) and Project Bluefin (projectbluefin), each
+  running a hive against their own repositories.
+org_size: Open-source community project
+user_size: The maintainers and contributors of every repository a hive maintains
+industries:
+  - Open Source
+  - Software
+tags:
+  - kubestellar
+  - hive
+  - ai-agents
+  - autonomous-maintenance
+  - platform-engineering
+  - multi-cluster
+  - security
+reference_architectures:
+  - CI/CD
+  - Platform Engineering
+  - AI/ML
+---
+
+## Relevant CNCF projects
+
+{{< cardpane >}}
+  {{< card header="Kubernetes" >}}
+  [![kubernetes logo](https://raw.githubusercontent.com/cncf/artwork/main/projects/kubernetes/icon/color/kubernetes-icon-color.svg)](https://www.cncf.io/projects/kubernetes/)
+  - **Using since:** 2024
+  - **Current version:** 1.24+
+
+  A hive is a single-replica Kubernetes Deployment with a PVC, Service, and Ingress. The hub provisions new spoke hives onto member clusters as native Kubernetes objects.
+  {{< /card >}}
+
+  {{< card header="cert-manager" >}}
+  [![cert-manager logo](https://raw.githubusercontent.com/cncf/artwork/main/projects/cert-manager/icon/color/cert-manager-icon-color.svg)](https://www.cncf.io/projects/cert-manager/)
+  - **Using since:** 2024
+  - **Current version:** v1.x
+
+  Issues and renews the TLS certificates that terminate every hive dashboard and the hosted hub, via a `ClusterIssuer` (Let's Encrypt in production).
+  {{< /card >}}
+
+  {{< card header="KubeStellar" >}}
+  [![kubestellar logo](https://raw.githubusercontent.com/kubestellar/kubestellar/main/docs/overrides/images/KubeStellar-with-Logo.png)](https://kubestellar.io/)
+  - **Using since:** 2024 (CNCF Sandbox)
+  - **Current version:** 0.2x
+
+  KubeStellar provides an optional multi-cluster substrate: the hub can reason about a fleet of clusters (cloud and edge) and place spoke hives onto them. Hive's own hub-and-spoke model is directly inspired by KubeStellar's placement design.
+  {{< /card >}}
+{{< /cardpane >}}
+
+{{< cardpane >}}
+  {{< card header="containerd" >}}
+  [![containerd logo](https://raw.githubusercontent.com/cncf/artwork/main/projects/containerd/icon/color/containerd-icon-color.svg)](https://www.cncf.io/projects/containerd/)
+  - **Using since:** 2024
+  - **Current version:** (cluster default)
+
+  The container runtime that runs the single hive image on every node. Each hive is one OCI image bundling the Go orchestrator, agent CLIs, and the dashboard.
+  {{< /card >}}
+
+  {{< card header="OpenTelemetry / Prometheus" >}}
+  [![prometheus logo](https://raw.githubusercontent.com/cncf/artwork/main/projects/prometheus/icon/color/prometheus-icon-color.svg)](https://www.cncf.io/projects/prometheus/)
+  - **Using since:** 2025
+  - **Current version:** exposition format
+
+  Each hive exposes `/metrics` in Prometheus format (governor mode, queue depth, per-agent token spend, fleet health) for scraping, alongside a live SSE stream to the dashboard.
+  {{< /card >}}
+
+  {{< card header="Helm / Kustomize" >}}
+  [![helm logo](https://raw.githubusercontent.com/cncf/artwork/main/projects/helm/icon/color/helm-icon-color.svg)](https://www.cncf.io/projects/helm/)
+  - **Using since:** 2024
+  - **Current version:** v3.x / kubectl-native
+
+  Hive ships a Kustomize base (namespace, Deployment, Service, PVC, ConfigMap, Secret) so an operator applies one overlay per environment.
+  {{< /card >}}
+{{< /cardpane >}}
+
+## Describe your organisation
+
+**Hive** is an open-source, self-hostable platform that keeps software
+repositories maintained by running a fleet of AI coding agents — triaging issues,
+writing fixes, opening pull requests, and merging on green CI — under a
+human-controlled autonomy dial and permissions enforced in depth. It is built as
+a cloud-native workload: each hive is a Kubernetes deployment, and a hosted hub
+coordinates a fleet of self-hosted spoke hives.
+
+Hive is used in production today by more than one open-source community:
+
+- The **KubeStellar Console** team ([`kubestellar/console`](https://github.com/kubestellar/console)) runs a hive against the console's repositories — the flagship end user, where Hive is dogfooded daily.
+- **Project Bluefin** ([`projectbluefin`](https://github.com/ublue-os)) runs its own hive (`projectbluefin/knuckle` and related repos) at a measured ACMM level.
+
+This is the point of the hub-and-spoke design: independent teams each self-host a
+spoke hive against their own repositories, while a shared hub gives them a
+registry, a cross-hive leaderboard, and — where reachable — provisioning.
+
+## Describe your entity and/or team
+
+Hive is built and operated by an open-source community as a standalone project.
+There is no separate commercial entity: the maintainers run production hives
+against their own repositories (the project dogfoods its own tool) and operate a
+hosted hub ([hive.kubestellar.io](https://hive.kubestellar.io)) so other
+open-source projects and individual contributors can register a spoke hive or
+donate compute to an existing one.
+
+## Brief overview of your architecture and any potential goals you are trying to achieve with it?
+
+**The goal:** let a fleet of AI coding agents maintain a repository
+autonomously — triage issues, write fixes, open PRs, merge on green CI — while
+keeping a human firmly in control of *how much* autonomy is granted, and enforcing
+those limits with technical controls rather than trust.
+
+A hive runs as a **single container** on Kubernetes with three long-lived
+processes:
+
+- a **Go orchestrator** (the brain) — runs the governor eval loop, the agent
+  manager, the dashboard API, an in-process man-in-the-middle GitHub proxy, and
+  the hub heartbeat;
+- a **Node.js proxy** — the public front door (auth, path-rewrite, SSE/WebSocket);
+- **ttyd** — a web terminal onto the agents' `tmux` sessions.
+
+Two ideas define the architecture:
+
+1. **Deterministic before judgment.** A pipeline of Go and shell steps
+   enumerates GitHub work, classifies it, gates which PRs are mergeable, and
+   enforces permissions *before* any model sees a task. Agents only make the
+   judgment calls (read code, reason about a fix, write a PR).
+
+2. **Autonomy is a dial, enforced in depth.** An **AI-native Capability Maturity
+   Model (ACMM)** with six levels (advisory → fully autonomous) is the single
+   control a human turns. Each level maps deterministically to a per-agent
+   permission mode, and that mode is enforced at three independent layers: CLI
+   tool denial, least-privilege scoped GitHub App tokens, and a network-level
+   MITM proxy that gates every GitHub write by `(method, path) → minimum mode`
+   plus a repo allowlist. A bug in one layer is caught by the next.
+
+```mermaid
+flowchart LR
+    github["GitHub<br/>issues · PRs"] --> gov["Governor<br/>queue depth → mode → kick"]
+    gov --> pipe["Deterministic pipeline<br/>classify · merge-gate · enforce"]
+    pipe --> agents["AI agents (tmux)<br/>Claude · Copilot · Gemini · Goose"]
+    agents --> guard["Guardrails<br/>tool deny · scoped token · MITM proxy"]
+    guard -->|"gated writes"| github
+    agents -.-> beads["Beads ledger<br/>git-backed work items"]
+    gov -.->|"heartbeat / 2 min"| hub["Hive Hub<br/>registry · leaderboard · provisioning"]
+```
+
+The **hub** is where the cloud-native, multi-cluster story shows: it holds a
+registry of all spoke hives, a cross-hive leaderboard, and — for clusters it can
+reach — provisions new spokes onto them with `kubectl`. Firewalled spokes it
+cannot reach directly are still fully managed over the 2-minute heartbeat, whose
+response carries callbacks (self-upgrade to a pinned image SHA, GitHub App
+credential delivery, visibility changes). It is this heartbeat-driven control
+plane that lets independent teams — the KubeStellar Console team and Project
+Bluefin among them — each run a spoke against their own repositories while a
+single hub keeps the fleet coherent.
+
+A fuller technical walkthrough (process model, the governor loop, the guardrail
+layers, the beads ledger, and an end-to-end "issue → merged PR" trace) lives in
+the project's [reference architecture](architecture.md).
+
+## Can you expand on why you are using those projects/services?
+
+- **Kubernetes** is the deployment substrate because a hive needs to be
+  self-hostable anywhere, survive restarts, and be provisioned programmatically.
+  Modeling each hive as a Deployment + PVC + Service + Ingress means the hub can
+  create, upgrade, and delete a spoke with plain Kubernetes API calls.
+- **KubeStellar** (optional) gives the hub a coherent way to reason about *many*
+  clusters — cloud and edge — as placement targets for spokes when a hive is run
+  across a multi-cluster fleet.
+- **cert-manager** removes TLS toil: every dashboard and the hub get automatic,
+  renewing certificates, which matters because agent dashboards stream over
+  long-lived SSE connections that must be secured.
+- **containerd** runs the single, self-contained hive image — the Go binary, the
+  agent CLIs, and the dashboard travel together so a hive is one artifact.
+- **Prometheus exposition / OpenTelemetry** make the fleet observable: the
+  governor's mode, queue depth, and per-agent token cost are all scrapeable, so a
+  runaway agent or a stalled eval loop is visible before it does harm.
+- **Kustomize/Helm** keep per-environment deployment declarative.
+
+## What has worked well?
+
+- **The three-layer guardrail model.** Because the MITM proxy enforces
+  permissions at the network boundary — independent of what the agent's CLI or
+  prompt does — we can grant real write access with confidence. An agent that
+  tries to merge a PR while in `ISSUES_ONLY` mode simply gets a `403` from its own
+  egress proxy. This is the feature that made higher ACMM levels safe to run.
+- **A durable, git-backed work ledger ("beads").** Giving each agent a typed,
+  dependency-aware work ledger on disk (rather than an in-memory queue) means
+  agents coordinate without stepping on each other, and state survives restarts,
+  crashes, and upgrades.
+- **Queue-depth governance.** Driving agent cadence from the actionable-issue
+  count (idle → quiet → busy → surge) keeps a quiet repository nearly free and
+  gives a flooded one the full fleet — without a human tuning schedules.
+- **Hub-and-spoke over heartbeat.** Managing spokes we can't reach directly
+  (firewalled clusters) purely through the heartbeat response has been robust —
+  and it is what lets separate end users (KubeStellar Console, Project Bluefin)
+  each self-host a spoke under one shared hub.
+
+## What has not worked well?
+
+- **Cost attribution across model backends.** Agents run against several
+  inference backends (Anthropic, GitHub Copilot, and OpenAI-compatible gateways
+  like vLLM/llm-d/LiteLLM). Reconciling token spend across their differing session
+  formats — especially "auto" model selection and one-time cost restores — took
+  several iterations to get accurate on the dashboard.
+- **Non-reentrant locks on the startup path.** Early versions risked a startup
+  deadlock when a mutex was re-taken from the launch path; CI's race detector did
+  not catch it, and it manifested as spokes crash-looping before readiness. We
+  moved hot startup state to lock-free atomics.
+- **Config precedence.** The authoritative runtime config lives on the PVC, while
+  a ConfigMap seeds only the first boot. It took clear conventions (and
+  documentation) before this stopped being a source of "why didn't my change take
+  effect" confusion.
+
+## What sort of "glue" have you had to develop to enable usage of your architecture?
+
+Quite a bit, and it is most of the interesting engineering:
+
+- A **deterministic shell/Go pipeline** (`run-pipeline.sh` + `pkg/classify`) that
+  enumerates, classifies, clusters, and merge-gates GitHub work before agents run.
+- A **`gh` wrapper** installed at `/usr/local/bin/gh` that injects scoped tokens
+  and blocks writes exceeding an agent's tier — the shell-level twin of the MITM
+  proxy.
+- An **in-process MITM proxy** (with `iptables` redirection of agent egress and a
+  self-signed CA installed into the container trust store) that inspects
+  `api.github.com` traffic and gates it by agent mode and repo allowlist. Agent
+  identity is resolved from the connection's owning UID via `/proc/net/tcp`.
+- An **inference translator** that reroutes Anthropic-shaped calls to
+  OpenAI-shaped gateway endpoints so the same agent CLI works across backends.
+- A **trajectory reviewer** — a periodic second-model check that reads an agent's
+  recent transcript against its assigned intent and pauses it on drift (a defense
+  against prompt-injection-style goal hijacking that per-action gating can't see).
+- Agents run inside **`tmux`** sessions under per-agent OS users for UID
+  isolation; a "kick" is literally a work order typed into the agent's CLI prompt.
+
+## Has your architecture evolved? What lessons did you learn from previous iterations?
+
+Yes — the central lesson was **enforce, don't trust**. Early designs relied on
+prompting and CLI tool-deny lists to keep agents in bounds; that is necessary but
+not sufficient, because a capable agent can find paths the prompt did not
+anticipate. Moving enforcement to the *network boundary* (the MITM proxy) and to
+*credential scope* (least-privilege, per-agent, short-lived GitHub App tokens)
+changed the trust model: we no longer have to believe the agent will behave, we
+constrain what it *can do* regardless.
+
+A second lesson was **make autonomy a graded, human-owned dial**. Rather than
+"agents on / agents off", the ACMM ladder lets an operator start advisory-only and
+climb one rung at a time as trust is earned — and every rung is a concrete,
+enforced permission change, not a vibe.
+
+A third: **durable state beats clever runtime state**. The git-backed beads
+ledger and PVC-authoritative config both came from painful episodes where
+in-memory coordination lost work across restarts.
+
+## What's next for your architecture? What are you looking to do next?
+
+- **Planning intelligence** (already incubating on a development branch):
+  automatic decomposition of a high-level goal into a tree of child work items,
+  with a human "approve the plan" gate before agents execute, and stall-triggered
+  re-planning when progress stops.
+- **Richer fleet observability** — first-class OpenTelemetry traces across the
+  governor → pipeline → agent → PR lifecycle so an operator can see exactly why a
+  given change was (or wasn't) made.
+- **Broadening the guardrail model** with an optional content/prompt-injection
+  classifier and a proxy-level request-rate limiter for defense in depth.

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -429,11 +429,11 @@ func newManagerWithUIDMap(agents map[string]config.AgentConfig, logger *slog.Log
 			}
 		}
 		m.agents[name] = &AgentProcess{
-			Name:         name,
-			ID:           agentID,
-			Config:       cfg,
-			State:        StateStopped,
-			UID:          agentUID,
+			Name:   name,
+			ID:     agentID,
+			Config: cfg,
+			State:  StateStopped,
+			UID:    agentUID,
 			// Restore a persisted operator pause so a restart/upgrade
 			// doesn't silently un-pause the agent.
 			Paused:       cfg.Paused,

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -363,7 +363,7 @@ code{background:#0d1117;padding:2px 8px;border-radius:4px;font-size:.9rem}
 <option value="openrouter" data-install="" data-host-install="npm i -g @anthropic-ai/claude-code" data-model-flag="--model" data-default-model="" data-env="# OpenRouter — Claude Code routed through OpenRouter\nexport HIVE_LITELLM_ENDPOINT=https://openrouter.ai/api/v1\nexport HIVE_LITELLM_API_KEY=sk-or-...  # your OpenRouter key">OpenRouter (Claude Code + your key)</option>
 <option value="vllm" data-install="" data-host-install="npm i -g @anthropic-ai/claude-code" data-model-flag="--model" data-default-model="" data-env="# vLLM — self-hosted OpenAI-compatible server\nexport HIVE_LITELLM_ENDPOINT=http://your-vllm-host:8000/v1\nexport HIVE_LITELLM_API_KEY=sk-your-vllm-key  # only if your server needs one">vLLM (self-hosted)</option>
 <option value="llm-d" data-install="" data-host-install="npm i -g @anthropic-ai/claude-code" data-model-flag="--model" data-default-model="" data-env="# llm-d — self-hosted OpenAI-compatible endpoint\nexport HIVE_LITELLM_ENDPOINT=http://your-llm-d-host:8000/v1\nexport HIVE_LITELLM_API_KEY=sk-your-llm-d-key  # only if your endpoint needs one">llm-d (self-hosted)</option>
-<option value="bob" data-install="" data-host-install="npm i -g bobshell" data-model-flag="" data-default-model="">Bob</option>
+<option value="bob" data-install="" data-host-install="curl -fsSL https://bob.ibm.com/download/bobshell.sh | bash" data-model-flag="" data-default-model="">Bob</option>
 <option value="other" data-install="" data-host-install="# Install your CLI tool" data-model-flag="" data-default-model="">Other (host only)</option>
 </select>
 </span>

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -33,6 +34,20 @@ const agentSkipAfterFullBroadcastS = 5 * time.Second
 const maxSSEClients = 100
 const sessionCookieName = "hive_session"
 const sessionCookieMaxAge = 30 * 24 * 60 * 60 // 30 days
+
+// proxyAuthHeader is the proof-of-proxy header the hub's auth-check injects
+// (value = this hive's dashboard token) so a hub-proxied spoke can verify a
+// request actually transited the hub nginx rather than being forged on the pod
+// network. See authenticate() (F2). Must match the hub's constant.
+const proxyAuthHeader = "X-Hive-Proxy-Auth"
+
+// proxyProofRequired controls F2 enforcement strictness. Default false =
+// fail-open rollout: a request with no proof header is still trusted on its
+// identity headers (so hosted hives aren't locked out while the hub half rolls
+// out fleet-wide). Set HIVE_PROXY_PROOF_REQUIRED=true (once every hub is
+// confirmed injecting the header) to fail closed: a missing/incorrect proof
+// header is rejected. A WRONG proof header is ALWAYS rejected regardless.
+var proxyProofRequired = os.Getenv("HIVE_PROXY_PROOF_REQUIRED") == "true"
 
 type Server struct {
 	port       int
@@ -859,13 +874,38 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		// valid when a real token is configured.
 		trusted := s.authToken != "" && secureCompare(r.Header.Get("X-Hive-Internal"), s.authToken)
 
-		// Hub-proxied path: nginx injects both headers from the hub's
+		// Hub-proxied path: nginx injects the identity headers from the hub's
 		// per-user/per-hive auth-check. Only trust them when this spoke is NOT a
-		// direct-route spoke (see strip above). Requiring both headers prevents
-		// trivial bypass via a single forged header.
+		// direct-route spoke (see strip above).
+		//
+		// SECURITY (F2): identity headers alone are forgeable by anything on the
+		// pod network that reaches :3002 directly, bypassing the hub nginx. The
+		// hub now also emits X-Hive-Proxy-Auth = this hive's dashboard token (the
+		// same secret we hold as authToken) on the auth-check success path, which
+		// only the trusted proxy can produce. Require it as PROOF the request
+		// transited the hub.
+		//
+		// ROLLOUT SAFETY — fail open until the hub half is everywhere: if the hub
+		// has NOT sent X-Hive-Proxy-Auth (older hub image mid-rollout), fall back
+		// to the pre-F2 behavior (trust the identity headers) so no hosted hive is
+		// locked out. Once the hub half is confirmed deployed fleet-wide, a
+		// follow-up flips proxyProofRequired to make a missing/incorrect proof
+		// header fail closed.
 		if !trusted && !directRouteAuthz &&
 			r.Header.Get("X-Hive-User") != "" && r.Header.Get("X-Hive-Role") != "" {
-			trusted = true
+			proof := r.Header.Get(proxyAuthHeader)
+			switch {
+			case proof != "" && s.authToken != "" && secureCompare(proof, s.authToken):
+				// Proof present and valid — definitely came through the hub.
+				trusted = true
+			case proof == "" && !proxyProofRequired:
+				// No proof header yet (hub not upgraded) and we're not enforcing
+				// strictly — trust the identity headers as before (rollout window).
+				trusted = true
+			default:
+				// Proof header present but WRONG, or strict mode with no proof:
+				// this did not come through the trusted hub proxy — reject.
+			}
 		}
 
 		// Per-user session path (device flow): resolve the session id in the

--- a/v2/pkg/dashboard/spoke_authz_test.go
+++ b/v2/pkg/dashboard/spoke_authz_test.go
@@ -177,6 +177,54 @@ func TestMiddleware_HubProxiedHeadersStillTrusted(t *testing.T) {
 	}
 }
 
+// TestMiddleware_F2ProxyProof covers the F2 proof-of-proxy header enforcement on
+// a hub-proxied spoke: a valid proof is trusted; a WRONG proof is always
+// rejected; a MISSING proof is trusted only in the fail-open rollout default and
+// rejected once strict enforcement is enabled.
+func TestMiddleware_F2ProxyProof(t *testing.T) {
+	newReq := func(proof string) *http.Request {
+		r := httptest.NewRequest("GET", "/api/config", nil)
+		r.Header.Set("X-Hive-User", "clubanderson")
+		r.Header.Set("X-Hive-Role", "owner")
+		if proof != "" {
+			r.Header.Set(proxyAuthHeader, proof)
+		}
+		return r
+	}
+	run := func(t *testing.T, strict bool, proof string) int {
+		s := newFullServer(t)
+		s.authToken = "shared-secret-token"
+		old := proxyProofRequired
+		proxyProofRequired = strict
+		t.Cleanup(func() { proxyProofRequired = old })
+		w := httptest.NewRecorder()
+		s.authenticate(recordingHandler(nil, nil)).ServeHTTP(w, newReq(proof))
+		return w.Code
+	}
+
+	// Valid proof header (matches authToken) -> trusted, both modes.
+	if c := run(t, false, "shared-secret-token"); c != http.StatusOK {
+		t.Errorf("valid proof (fail-open) = %d, want 200", c)
+	}
+	if c := run(t, true, "shared-secret-token"); c != http.StatusOK {
+		t.Errorf("valid proof (strict) = %d, want 200", c)
+	}
+	// Wrong proof header -> ALWAYS rejected (forged proxy).
+	if c := run(t, false, "wrong-token"); c == http.StatusOK {
+		t.Error("wrong proof must be rejected even in fail-open mode")
+	}
+	if c := run(t, true, "wrong-token"); c == http.StatusOK {
+		t.Error("wrong proof must be rejected in strict mode")
+	}
+	// Missing proof: trusted in fail-open (rollout), rejected in strict.
+	if c := run(t, false, ""); c != http.StatusOK {
+		t.Errorf("missing proof (fail-open) = %d, want 200 (rollout safety)", c)
+	}
+	if c := run(t, true, ""); c == http.StatusOK {
+		t.Error("missing proof must be rejected in strict mode")
+	}
+}
+
 func TestMiddleware_SharedCookieNoLongerAuthenticates(t *testing.T) {
 	// The old vulnerability: the shared s.authToken placed in the session cookie
 	// granted access. It must no longer be accepted as a session id.

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -247,7 +247,7 @@ type HeartbeatPayload struct {
 	// The hub cannot read this itself for firewalled spokes it reaches only by
 	// heartbeat, which is why it rides the payload. Empty when the spoke is
 	// not running in-cluster or the read failed — never a guess.
-	ImageRef     string         `json:"image_ref,omitempty"`
+	ImageRef                string                        `json:"image_ref,omitempty"`
 	Timestamp               string                        `json:"timestamp"`
 	GitHubAppRequired       bool                          `json:"github_app_required,omitempty"`
 	GitHubAppPermIssue      string                        `json:"github_app_perm_issue,omitempty"`

--- a/v2/pkg/hub/hub_filesystem_test.go
+++ b/v2/pkg/hub/hub_filesystem_test.go
@@ -1333,6 +1333,57 @@ func TestHandleSaaSAuthCheckWithFilesystem(t *testing.T) {
 	}
 }
 
+// TestHandleSaaSAuthCheckProxyAuthHeader asserts the F2 hub-half proof header:
+// on the authenticated SUCCESS path the hub sets X-Hive-Proxy-Auth to the
+// hive's dashboard token (the spoke's own authToken), and it is NEVER set on
+// the unauthenticated (401) path.
+func TestHandleSaaSAuthCheckProxyAuthHeader(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+
+	// Fake kubectl so loadSpokeAuthToken resolves the dashboard token.
+	const wantToken = "proxy-auth-dash-token"
+	installSecretKubectl(t, "-----BEGIN X-----", wantToken)
+
+	authCleanup := helperSetupAuthUser(t, "ghp_proxyauth", "proxyauth-user")
+	defer authCleanup()
+
+	u := ensureSaaSUser("proxyauth-user")
+	u.Hives["proxy-hive"] = "admin"
+	saveSaaSUser(u)
+
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	// The hive must be in the registry with a known cluster so the hub can
+	// resolve its dashboard token in the auth-check handler.
+	srv.registry.Hives = []RegistryEntry{{ID: "proxy-hive", ClusterID: "hive-oke"}}
+	srv.clusters = map[string]ClusterConfig{"hive-oke": {ID: "hive-oke"}}
+
+	// SUCCESS path: header set to the dashboard token.
+	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=proxy-hive", nil)
+	req.Header.Set("Authorization", "Bearer ghp_proxyauth")
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("X-Hive-Proxy-Auth"); got != wantToken {
+		t.Errorf("X-Hive-Proxy-Auth = %q, want %q", got, wantToken)
+	}
+
+	// FAILURE path: no credentials → 401 and NO proof header.
+	reqNoAuth := httptest.NewRequest("GET", "/api/saas/auth-check?hive=proxy-hive", nil)
+	wNoAuth := httptest.NewRecorder()
+	srv.mux.ServeHTTP(wNoAuth, reqNoAuth)
+
+	if wNoAuth.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", wNoAuth.Code)
+	}
+	if got := wNoAuth.Header().Get("X-Hive-Proxy-Auth"); got != "" {
+		t.Errorf("X-Hive-Proxy-Auth set on 401 path = %q, want empty", got)
+	}
+}
+
 func TestHandleSaaSAuthCheckNoAccess(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4418,8 +4418,8 @@ type ProvisionRequest struct {
 	// github.com, otherwise a GitHub Enterprise host (github.ibm.com,
 	// github.cisco.com, …). Captured so an admin can see which instance a
 	// request targets before deciding where to place the hive.
-	GitHubHost string `json:"github_host,omitempty"`
-	Org        string `json:"org"`
+	GitHubHost  string `json:"github_host,omitempty"`
+	Org         string `json:"org"`
 	Repos       string `json:"repos"`
 	PrimaryRepo string `json:"primary_repo"`
 	ACMMLevel   int    `json:"acmm_level"`
@@ -5232,8 +5232,8 @@ func sameStringSliceFold(a, b []string) bool {
 // the real project the placeholder is being claimed for, plus optional GitHub
 // App credentials to deliver to the spoke via the heartbeat channel.
 type AssignHiveRequest struct {
-	Owner          string `json:"owner"`
-	Org            string `json:"org"`
+	Owner string `json:"owner"`
+	Org   string `json:"org"`
 	// GitHubHost is the GitHub instance the org lives on ("" = public
 	// github.com, otherwise a GHE host). Parsed from a pasted org URL when the
 	// caller does not send it explicitly.
@@ -5553,6 +5553,79 @@ func (s *HubServer) handleUserToken(w http.ResponseWriter, r *http.Request) {
 
 var publicPaths = []string{"/snapshot", "/leaderboard", "/contribute", "/api/leaderboard", "/api/contribute"}
 
+// proxyAuthHeader is the response header the hub sets on a successful
+// auth-check subrequest to PROVE to the spoke that the request was
+// authenticated by the hub's nginx auth-proxy (not spoofed by a client that
+// merely supplied X-Hive-User/X-Hive-Role directly). nginx is configured to
+// copy this header onto the upstream request via the auth-response-headers
+// annotation (see saas_provision.go). Its value is the spoke's own dashboard
+// token, so the spoke can constant-time-compare it against its authToken.
+//
+// CONTRACT (spoke half, separate v3 PR must verify EXACTLY this):
+//   - Header name: "X-Hive-Proxy-Auth"
+//   - Value: the hive's dashboard token — the raw value stored in the spoke's
+//     "hive-secrets" k8s secret under key "dashboard-token", i.e. the same
+//     string the spoke reads from DASHBOARD_AUTH_TOKEN into its authToken.
+//   - Set ONLY on the authenticated success path; NEVER on public-path,
+//     unfurl-bot, unauthenticated (401), or no-access (403) responses.
+const proxyAuthHeader = "X-Hive-Proxy-Auth"
+
+// spokeProxyAuthCacheTTL bounds how long a hive's dashboard token is memoized
+// so the per-request auth-check subrequest avoids a kubectl exec on every call
+// while still picking up a re-provisioned token within a bounded window.
+const spokeProxyAuthCacheTTL = 5 * time.Minute
+
+// spokeProxyAuthEntry is a cached dashboard token with its expiry.
+type spokeProxyAuthEntry struct {
+	token   string
+	expires time.Time
+}
+
+// spokeProxyAuthToken returns the given hive's dashboard token — the shared
+// secret the spoke holds as its authToken (DASHBOARD_AUTH_TOKEN / the
+// "dashboard-token" key of the "hive-secrets" k8s secret). It memoizes the
+// value for spokeProxyAuthCacheTTL so the hot auth-check path does not exec
+// kubectl on every proxied request. Returns "" if the token cannot be
+// resolved (e.g. the hive isn't in the registry or its cluster is unreachable);
+// callers must then omit the proof header rather than send an empty one.
+func (s *HubServer) spokeProxyAuthToken(hiveID string) string {
+	now := time.Now()
+
+	s.spokeProxyAuthMu.Lock()
+	if entry, ok := s.spokeProxyAuthCache[hiveID]; ok && now.Before(entry.expires) {
+		tok := entry.token
+		s.spokeProxyAuthMu.Unlock()
+		return tok
+	}
+	s.spokeProxyAuthMu.Unlock()
+
+	// Resolve the registry entry (ID + ClusterID) that loadSpokeAuthToken needs.
+	var hive *RegistryEntry
+	s.mu.RLock()
+	for i := range s.registry.Hives {
+		if s.registry.Hives[i].ID == hiveID {
+			h := s.registry.Hives[i]
+			hive = &h
+			break
+		}
+	}
+	s.mu.RUnlock()
+	if hive == nil {
+		return ""
+	}
+
+	token := s.loadSpokeAuthToken(hive)
+	if token == "" {
+		return ""
+	}
+
+	s.spokeProxyAuthMu.Lock()
+	s.spokeProxyAuthCache[hiveID] = spokeProxyAuthEntry{token: token, expires: now.Add(spokeProxyAuthCacheTTL)}
+	s.spokeProxyAuthMu.Unlock()
+
+	return token
+}
+
 func (s *HubServer) handleSaaSAuthCheck(w http.ResponseWriter, r *http.Request) {
 	hiveID := r.URL.Query().Get("hive")
 	if hiveID == "" {
@@ -5603,6 +5676,16 @@ func (s *HubServer) handleSaaSAuthCheck(w http.ResponseWriter, r *http.Request) 
 
 	w.Header().Set("X-Hive-User", username)
 	w.Header().Set("X-Hive-Role", role)
+	// Prove to the spoke that this request really passed through the hub's
+	// auth-proxy: set X-Hive-Proxy-Auth to the hive's own dashboard token so
+	// the spoke can constant-time-compare it against its authToken. Only set on
+	// this authenticated success path; a client hitting the spoke directly
+	// cannot forge it because it never learns the token. If the token can't be
+	// resolved, omit the header (backward-compatible: the spoke half must fail
+	// open only until it is deployed — see the v3 spoke PR).
+	if proxyAuth := s.spokeProxyAuthToken(hiveID); proxyAuth != "" {
+		w.Header().Set(proxyAuthHeader, proxyAuth)
+	}
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/v2/pkg/hub/saas_provision.go
+++ b/v2/pkg/hub/saas_provision.go
@@ -113,32 +113,32 @@ var clustersConfigPath = "/data/saas/clusters.json"
 // hive spokes onto. Each cluster has its own kubeconfig, storage backend,
 // ingress style, and optional platform-specific settings (OCI, OpenShift).
 type ClusterConfig struct {
-	ID                          string `json:"id" yaml:"id"`
-	Name                        string `json:"name" yaml:"name"`
-	KubeconfigPath              string `json:"kubeconfig_path,omitempty" yaml:"kubeconfig_path,omitempty"`
-	Context                     string `json:"context" yaml:"context"`
-	InCluster                   bool   `json:"in_cluster" yaml:"in_cluster"`
-	StorageClass                string `json:"storage_class" yaml:"storage_class"`
-	StorageType                 string `json:"storage_type" yaml:"storage_type"`
-	NFSMountIP                  string `json:"nfs_mount_ip,omitempty" yaml:"nfs_mount_ip,omitempty"`
-	IngressType                 string `json:"ingress_type" yaml:"ingress_type"`
-	IngressClass                string `json:"ingress_class,omitempty" yaml:"ingress_class,omitempty"`
-	CertIssuer                  string `json:"cert_issuer,omitempty" yaml:"cert_issuer,omitempty"`
-	Domain                      string `json:"domain" yaml:"domain"`
-	DomainPrefix                string `json:"domain_prefix,omitempty" yaml:"domain_prefix,omitempty"`
-	OCICompartment              string `json:"oci_compartment,omitempty" yaml:"oci_compartment,omitempty"`
-	OCIAvailDomain              string `json:"oci_avail_domain,omitempty" yaml:"oci_avail_domain,omitempty"`
-	OCIMountTarget              string `json:"oci_mount_target,omitempty" yaml:"oci_mount_target,omitempty"`
-	OCIExportSet                string `json:"oci_export_set,omitempty" yaml:"oci_export_set,omitempty"`
-	RequiresSCC                 bool   `json:"requires_scc" yaml:"requires_scc"`
-	SCCName                     string `json:"scc_name,omitempty" yaml:"scc_name,omitempty"`
-	HasGPU                      bool   `json:"has_gpu" yaml:"has_gpu"`
-	Arch                        string `json:"arch" yaml:"arch"`
-	ImageTag                    string `json:"image_tag" yaml:"image_tag"`
-	ImagePullPolicy             string `json:"image_pull_policy,omitempty" yaml:"image_pull_policy,omitempty"`
-	InferenceEndpoint           string `json:"inference_endpoint,omitempty" yaml:"inference_endpoint,omitempty"`
-	GitHubBaseURL               string `json:"github_base_url,omitempty" yaml:"github_base_url,omitempty"`
-	GitHubAPIURL                string `json:"github_api_url,omitempty" yaml:"github_api_url,omitempty"`
+	ID                string `json:"id" yaml:"id"`
+	Name              string `json:"name" yaml:"name"`
+	KubeconfigPath    string `json:"kubeconfig_path,omitempty" yaml:"kubeconfig_path,omitempty"`
+	Context           string `json:"context" yaml:"context"`
+	InCluster         bool   `json:"in_cluster" yaml:"in_cluster"`
+	StorageClass      string `json:"storage_class" yaml:"storage_class"`
+	StorageType       string `json:"storage_type" yaml:"storage_type"`
+	NFSMountIP        string `json:"nfs_mount_ip,omitempty" yaml:"nfs_mount_ip,omitempty"`
+	IngressType       string `json:"ingress_type" yaml:"ingress_type"`
+	IngressClass      string `json:"ingress_class,omitempty" yaml:"ingress_class,omitempty"`
+	CertIssuer        string `json:"cert_issuer,omitempty" yaml:"cert_issuer,omitempty"`
+	Domain            string `json:"domain" yaml:"domain"`
+	DomainPrefix      string `json:"domain_prefix,omitempty" yaml:"domain_prefix,omitempty"`
+	OCICompartment    string `json:"oci_compartment,omitempty" yaml:"oci_compartment,omitempty"`
+	OCIAvailDomain    string `json:"oci_avail_domain,omitempty" yaml:"oci_avail_domain,omitempty"`
+	OCIMountTarget    string `json:"oci_mount_target,omitempty" yaml:"oci_mount_target,omitempty"`
+	OCIExportSet      string `json:"oci_export_set,omitempty" yaml:"oci_export_set,omitempty"`
+	RequiresSCC       bool   `json:"requires_scc" yaml:"requires_scc"`
+	SCCName           string `json:"scc_name,omitempty" yaml:"scc_name,omitempty"`
+	HasGPU            bool   `json:"has_gpu" yaml:"has_gpu"`
+	Arch              string `json:"arch" yaml:"arch"`
+	ImageTag          string `json:"image_tag" yaml:"image_tag"`
+	ImagePullPolicy   string `json:"image_pull_policy,omitempty" yaml:"image_pull_policy,omitempty"`
+	InferenceEndpoint string `json:"inference_endpoint,omitempty" yaml:"inference_endpoint,omitempty"`
+	GitHubBaseURL     string `json:"github_base_url,omitempty" yaml:"github_base_url,omitempty"`
+	GitHubAPIURL      string `json:"github_api_url,omitempty" yaml:"github_api_url,omitempty"`
 	// GitHubAppSlug is the GitHub App's URL slug on THIS cluster's GitHub
 	// host. A GitHub Enterprise instance hosts its own App registration,
 	// which is rarely named "kubestellar-hive" — without this the spoke's
@@ -155,8 +155,8 @@ type ClusterConfig struct {
 	//
 	// Zero means "this cluster has no hub-managed App identity" — the hub then
 	// changes nothing about its spokes' credentials.
-	GitHubAppID   int64  `json:"github_app_id,omitempty" yaml:"github_app_id,omitempty"`
-	OAuthClientID string `json:"oauth_client_id,omitempty" yaml:"oauth_client_id,omitempty"`
+	GitHubAppID                 int64  `json:"github_app_id,omitempty" yaml:"github_app_id,omitempty"`
+	OAuthClientID               string `json:"oauth_client_id,omitempty" yaml:"oauth_client_id,omitempty"`
 	ClusterHealthTimeoutSeconds int    `json:"cluster_health_timeout_seconds,omitempty" yaml:"cluster_health_timeout_seconds,omitempty"`
 }
 
@@ -262,10 +262,10 @@ type PendingAccessRequest struct {
 }
 
 type SaaSHive struct {
-	ID          string   `json:"id"`
-	Owner       string   `json:"owner"`
-	ProjectName string   `json:"project_name"`
-	Org         string   `json:"org"`
+	ID          string `json:"id"`
+	Owner       string `json:"owner"`
+	ProjectName string `json:"project_name"`
+	Org         string `json:"org"`
 	// GitHubHost is the GitHub instance this project lives on — empty means
 	// public github.com, otherwise a GitHub Enterprise host (github.ibm.com,
 	// github.cisco.com, …). Recorded at assign time from the requested org so
@@ -1557,7 +1557,7 @@ metadata:
     nginx.ingress.kubernetes.io/custom-http-errors: "502,503"
     nginx.ingress.kubernetes.io/default-backend: hive-error-pages
     nginx.ingress.kubernetes.io/auth-signin: "https://hive.kubestellar.io/login?redirect=$scheme://$http_host$request_uri"
-    nginx.ingress.kubernetes.io/auth-response-headers: "X-Hive-User,X-Hive-Role"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Hive-User,X-Hive-Role,X-Hive-Proxy-Auth"
 spec:
   ingressClassName: {{.IngressClass}}
   rules:

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -100,7 +100,7 @@ type RegistryEntry struct {
 	// upgrade — from one riding <branch>-latest. Empty on spokes that are not
 	// in-cluster or predate this field; drift detection skips the signal
 	// rather than guessing.
-	ImageRef           string         `json:"imageRef,omitempty"`
+	ImageRef                  string             `json:"imageRef,omitempty"`
 	Agents                    []AgentSummary     `json:"agents,omitempty"`
 	Leaderboard               []LeaderboardEntry `json:"leaderboard,omitempty"`
 	Online                    bool               `json:"online"`
@@ -346,6 +346,14 @@ type HubServer struct {
 	hubBanners   map[string]*HubBannerEntry
 	hubBannersMu sync.RWMutex
 
+	// spokeProxyAuthCache memoizes each hive's dashboard token (the shared
+	// secret the spoke holds as DASHBOARD_AUTH_TOKEN) so the auth-check
+	// subrequest — which fires on EVERY hub-proxied request — does not pay a
+	// kubectl exec per call. Key: hive ID → cached token + expiry. Guarded by
+	// spokeProxyAuthMu. See handleSaaSAuthCheck / spokeProxyAuthToken.
+	spokeProxyAuthCache map[string]spokeProxyAuthEntry
+	spokeProxyAuthMu    sync.Mutex
+
 	// pendingGateways stores OpenRouter gateways funded via the hub's
 	// scan-to-fund flow, to deliver to firewalled/heartbeat-only spokes via the
 	// heartbeat response. Key: hive ID → gateway (carries the secret key VALUE,
@@ -499,6 +507,7 @@ func NewHubServer(port int, logger *slog.Logger, gitHash, gitBranch string) *Hub
 		pendingGitHubAppConfigs: make(map[string]*HeartbeatGitHubAppConfig),
 		pendingGateways:         make(map[string]*HeartbeatGatewayConfig),
 		hubBanners:              make(map[string]*HubBannerEntry),
+		spokeProxyAuthCache:     make(map[string]spokeProxyAuthEntry),
 		timeline:                newTimelineStore(),
 		journey:                 newJourneyStore(),
 		alerts:                  newAlertState(),

--- a/v2/pkg/hub/static/learn.html
+++ b/v2/pkg/hub/static/learn.html
@@ -295,15 +295,15 @@
       <div class="section-heading">
         <p class="section-label">Autonomy framework</p>
         <h2>The ACMM ladder</h2>
-        <p>The <strong style="color:var(--text)">AI-native Codebase Maturity Model (ACMM)</strong> defines six levels of AI agent autonomy, from advisory-only to fully autonomous. Each level controls which agents are active and what actions they can take. Start conservative, climb when you&rsquo;re ready.</p>
+        <p>The <strong style="color:var(--text)">AI-native Capability Maturity Model (ACMM)</strong> defines six levels of AI agent autonomy, from advisory-only to fully autonomous. Each level controls which agents are active and what actions they can take. Start conservative, climb when you&rsquo;re ready &mdash; raising the level is always a human decision.</p>
       </div>
       <div class="acmm-grid">
-        <div class="acmm-card"><span class="level lv-1">L1 &mdash; Idea</span><h3>Advisory only</h3><p>Agents analyze but don&rsquo;t act. Beads and heartbeat logs only.</p></div>
-        <div class="acmm-card"><span class="level lv-2">L2 &mdash; Measured</span><h3>Issues, no PRs</h3><p>Agents can open issues. Quality gates begin.</p></div>
-        <div class="acmm-card"><span class="level lv-3">L3 &mdash; CI/CD</span><h3>Hold-gated PRs</h3><p>Agents open hold-gated PRs. CI must pass. Human approval required.</p></div>
-        <div class="acmm-card"><span class="level lv-4">L4 &mdash; Autonomous PR</span><h3>Merge on green</h3><p>Agents open and merge PRs on green CI. Hold labels for safety.</p></div>
-        <div class="acmm-card"><span class="level lv-5">L5 &mdash; Self-Governing</span><h3>Budget-aware</h3><p>Full autonomy with budget controls. Governor manages pace and cost.</p></div>
-        <div class="acmm-card"><span class="level lv-6">L6 &mdash; Fully Autonomous</span><h3>Multi-loop</h3><p>Multi-loop orchestration. Outreach, community engagement. Highest trust.</p></div>
+        <div class="acmm-card"><span class="level lv-1">L1 &mdash; Assisted</span><h3>Inception &amp; advisory</h3><p>An interactive brainstorm agent turns ideas into project scaffolding; a guide agent audits docs. Every action needs human approval. No feedback loops.</p></div>
+        <div class="acmm-card"><span class="level lv-2">L2 &mdash; Instructed</span><h3>Observe &amp; report</h3><p>Agents produce advisory findings on the dashboard and a tracking issue. No GitHub issues or PRs. They observe and report; humans decide what to act on.</p></div>
+        <div class="acmm-card"><span class="level lv-3">L3 &mdash; Measured</span><h3>Quality &amp; test coverage</h3><p>The quality agent opens issues and hold-gated PRs about testing gaps, coverage, and CI health. Every PR keeps a <code>hold</code> label &mdash; no agent merges. This measurement foundation is what earns automation in the levels above.</p></div>
+        <div class="acmm-card"><span class="level lv-4">L4 &mdash; Adaptive</span><h3>Closed-loop, issues</h3><p>All agents now file issues &mdash; bugs, doc gaps, workflow failures, vulnerabilities. Security agent joins. Still no PRs; the loop is closing.</p></div>
+        <div class="acmm-card"><span class="level lv-5">L5 &mdash; Semi-Automated</span><h3>Hold-gated PRs</h3><p>All agents open PRs, each auto-labeled <code>hold</code> for human batch-review. Architect (RFCs) and strategist join. The system proposes; it does not merge on its own.</p></div>
+        <div class="acmm-card"><span class="level lv-6">L6 &mdash; Fully Autonomous</span><h3>Merge on green CI</h3><p>Agents open PRs and auto-merge on green CI &mdash; no <code>hold</code> label. Outreach agent handles community engagement. Highest trust; governor at fastest cadence.</p></div>
       </div>
     </section>
 


### PR DESCRIPTION
## What

Follow-up to the dd sync (#2196), which merged against a slightly stale v2 base. This brings dd's remaining v2 commits — #2185 (GH-App key self-correct), #2187 (Bob CLI), #2189/#2195 (proxy-auth), #2190 (CONTACT UI), #2193 (ACMM fix), #2194 (CNCF docs) — while **preserving all of dd's Visual Hive work**.

## Conflicts (10, combined — not picked)
Mostly gofmt-alignment on the hub superset structs. Substantive:
- `dashboard/server.go`: kept **both** dd's `listenerReady`/`listenerStopped` and v2's `promptHistory`.
- `dashboard/api.go`: kept dd's `mutateConfig` wrapper.
- `cmd/hive/main.go`: kept dd's `configCoordinator` persistence + Visual Hive; v2's `healGitHubAppInstallation`/GHE APIURL already integrated.
- `agent/manager.go`: kept dd's `backendAllowsInterruptBeforeKick` (Visual Hive interrupt logic).
- `hub/server.go`: took v2's `spokeProxyAuthCache` (#2189).

## Verification
- Visual Hive preserved: `listenerReady` ×7, `v2/skills/`, `v2/pkg/internal/visualhivepr/` all intact.
- `go build ./...` clean.
- Test failures pre-existing (OAuth device-flow, hub HTML-substring drift shared with v2, Visual Hive /var-symlink) — not merge-caused.

Note: one newer v2 commit (#2198, WRONG-key replacement) landed after this merge's base and will come in a small follow-up — dd's history diverged enough that chaining a second merge re-conflicts, so it's cleaner as a targeted follow-up.