### PR TITLE
chore: mk final sync — 0 behind v2

### DIFF
--- a/v2/cmd/hive/appkeyfile_test.go
+++ b/v2/cmd/hive/appkeyfile_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// testRSAKeyBits matches the smallest size GitHub Apps actually use. These keys
+// never sign anything real — they only exercise path resolution.
+const testRSAKeyBits = 2048
+
+func writeTestKey(t *testing.T, path string) string {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, testRSAKeyBits)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	pemData := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(k),
+	})
+	if err := os.WriteFile(path, pemData, spokeAppKeyFileMode); err != nil {
+		t.Fatalf("write key %s: %v", path, err)
+	}
+	fp, err := config.AppKeyFingerprint(string(pemData))
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+	return fp
+}
+
+// redirectSpokeKeyPaths points the two spoke key locations at a temp dir and
+// restores them afterwards, so the real resolution order runs against files this
+// test controls rather than against /data and /secrets.
+func redirectSpokeKeyPaths(t *testing.T) (dataPath, secretsPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	origData, origSecrets := spokeAppKeyPath, spokeProvisionedAppKeyPath
+	spokeAppKeyPath = filepath.Join(dir, "data-gh-app-key.pem")
+	spokeProvisionedAppKeyPath = filepath.Join(dir, "secrets-gh-app-key.pem")
+	t.Cleanup(func() {
+		spokeAppKeyPath, spokeProvisionedAppKeyPath = origData, origSecrets
+	})
+	return spokeAppKeyPath, spokeProvisionedAppKeyPath
+}
+
+// TestResolveAppKeyFilePrefersDeliveredKey is the test that keeps the fix from
+// being cosmetic.
+//
+// The hub can deliver a correct key and the hive can still authenticate with the
+// wrong one: the delivered key lands on the PVC at spokeAppKeyPath, but the
+// stale operator-provisioned key sits at the read-only /secrets mount that the
+// spoke cannot overwrite. If resolution fell through to /secrets whenever
+// key_file was unset — which is exactly the state of the three broken GHE hives
+// — every restart would silently resume signing with the dead key while the hub
+// kept redelivering forever. Delivered-but-unused looks fixed and is not.
+func TestResolveAppKeyFilePrefersDeliveredKey(t *testing.T) {
+	dataPath, secretsPath := redirectSpokeKeyPaths(t)
+
+	t.Run("stale secrets key present, delivered data key wins", func(t *testing.T) {
+		staleFP := writeTestKey(t, secretsPath)
+		goodFP := writeTestKey(t, dataPath)
+		if staleFP == goodFP {
+			t.Fatal("test keys collided; the two paths must hold different keys")
+		}
+
+		// key_file unset — the vllmd-01..03 state.
+		got := resolveAppKeyFile("", "")
+		if got != dataPath {
+			t.Fatalf("resolveAppKeyFile = %q, want the delivered key at %q", got, dataPath)
+		}
+
+		// And the key actually in effect must be the delivered one.
+		fp, err := config.AppKeyFingerprintFromFile(got)
+		if err != nil {
+			t.Fatalf("fingerprint resolved key: %v", err)
+		}
+		if fp != goodFP {
+			t.Fatalf("resolved key fingerprint = %q, want the delivered %q", fp, goodFP)
+		}
+
+		// The heartbeat must report that same key, or the hub compares against a
+		// key that is not signing anything.
+		if reported := reportedAppKeyFingerprint(""); reported != goodFP {
+			t.Fatalf("reportedAppKeyFingerprint = %q, want %q", reported, goodFP)
+		}
+
+		// And it must stop claiming a per-hive override, so the hub's idempotence
+		// check sees a plain match and stops pushing.
+		if hasPerHiveAppKey("") {
+			t.Error("hasPerHiveAppKey = true after taking delivery; the /secrets key is no longer in effect")
+		}
+	})
+
+	t.Run("no delivered key falls back to the provisioning mount", func(t *testing.T) {
+		dataPath, secretsPath := redirectSpokeKeyPaths(t)
+		provisionedFP := writeTestKey(t, secretsPath)
+		_ = dataPath // deliberately absent
+
+		got := resolveAppKeyFile("", "")
+		if got != secretsPath {
+			t.Fatalf("resolveAppKeyFile = %q, want the provisioned key at %q", got, secretsPath)
+		}
+		if reported := reportedAppKeyFingerprint(""); reported != provisionedFP {
+			t.Fatalf("reportedAppKeyFingerprint = %q, want %q", reported, provisionedFP)
+		}
+		// A genuine per-hive credential must still be reported as such, so the
+		// hub's protective precedence keeps working.
+		if !hasPerHiveAppKey("") {
+			t.Error("hasPerHiveAppKey = false; a provisioned key in effect is a per-hive override")
+		}
+	})
+
+	t.Run("empty data key does not shadow a good provisioned key", func(t *testing.T) {
+		dataPath, secretsPath := redirectSpokeKeyPaths(t)
+		provisionedFP := writeTestKey(t, secretsPath)
+		// An empty /data file is exactly what vllmd-06..09 had. Mere existence
+		// must not win — only a parseable key may.
+		if err := os.WriteFile(dataPath, nil, spokeAppKeyFileMode); err != nil {
+			t.Fatal(err)
+		}
+
+		if got := resolveAppKeyFile("", ""); got != secretsPath {
+			t.Fatalf("resolveAppKeyFile = %q, want %q; an empty file is not a key", got, secretsPath)
+		}
+		if reported := reportedAppKeyFingerprint(""); reported != provisionedFP {
+			t.Fatalf("reportedAppKeyFingerprint = %q, want %q", reported, provisionedFP)
+		}
+	})
+
+	t.Run("explicit key_file and env override still win outright", func(t *testing.T) {
+		dataPath, _ := redirectSpokeKeyPaths(t)
+		writeTestKey(t, dataPath)
+		explicit := filepath.Join(t.TempDir(), "operator-chosen.pem")
+
+		if got := resolveAppKeyFile(explicit, ""); got != explicit {
+			t.Errorf("configured key_file = %q, want %q; an explicit path must not be redirected", got, explicit)
+		}
+		if got := resolveAppKeyFile("", explicit); got != explicit {
+			t.Errorf("env override = %q, want %q", got, explicit)
+		}
+		// Env beats config, matching the original precedence.
+		other := filepath.Join(t.TempDir(), "from-config.pem")
+		if got := resolveAppKeyFile(other, explicit); got != explicit {
+			t.Errorf("env override = %q, want it to beat key_file %q", got, explicit)
+		}
+		// Whitespace is not a path.
+		if got := resolveAppKeyFile("  ", "  "); got != dataPath {
+			t.Errorf("blank inputs = %q, want the delivered key at %q", got, dataPath)
+		}
+	})
+}

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -64,13 +64,16 @@ var (
 //   - spokeAppKeyPath is on the PVC and is where a hub-delivered (cluster
 //     default) key lands. It is also what cfg.GitHub.KeyFile is repointed at
 //     once the hub delivers one, so it takes effect over the provisioned mount.
-const (
+// Vars rather than consts so tests can point them at a temp dir and exercise
+// the real resolution order; production never reassigns them.
+var (
 	spokeProvisionedAppKeyPath = "/secrets/gh-app-key.pem"
 	spokeAppKeyPath            = "/data/gh-app-key.pem"
-	// spokeAppKeyFileMode is rw------- : signing material must never be
-	// readable by anything else sharing the PVC or the pod.
-	spokeAppKeyFileMode = 0o600
 )
+
+// spokeAppKeyFileMode is rw------- : signing material must never be readable by
+// anything else sharing the PVC or the pod.
+const spokeAppKeyFileMode = 0o600
 
 // reportedAppKeyFingerprint returns the non-secret fingerprint of the App key
 // this spoke is ACTUALLY using, for the heartbeat payload. It fingerprints the
@@ -82,7 +85,12 @@ const (
 // cannot authenticate") and are repaired identically. The private key itself is
 // never returned, and never enters the payload.
 func reportedAppKeyFingerprint(keyFile string) string {
-	candidates := []string{keyFile, spokeAppKeyPath, spokeProvisionedAppKeyPath}
+	// Lead with the same path resolveAppKeyFile would sign with, so the hub is
+	// told about the key actually in effect and never about a shadowed one.
+	candidates := []string{
+		resolveAppKeyFile(keyFile, os.Getenv("GH_APP_KEY_FILE")),
+		keyFile, spokeAppKeyPath, spokeProvisionedAppKeyPath,
+	}
 	for _, p := range candidates {
 		if strings.TrimSpace(p) == "" {
 			continue
@@ -108,8 +116,46 @@ func hasPerHiveAppKey(keyFile string) bool {
 		return false
 	}
 	// The provisioned key exists. It is the effective credential only if the
-	// resolved key file still points at it.
-	return strings.TrimSpace(keyFile) == "" || keyFile == spokeProvisionedAppKeyPath
+	// resolved key file still points at it — resolveAppKeyFile is the single
+	// authority on that, so an unconfigured hive that has already taken delivery
+	// of a /data key correctly stops claiming a per-hive override.
+	return resolveAppKeyFile(keyFile, os.Getenv("GH_APP_KEY_FILE")) == spokeProvisionedAppKeyPath
+}
+
+// resolveAppKeyFile picks which App private key this process will actually sign
+// with, given the configured key_file and the GH_APP_KEY_FILE env override.
+//
+// WHY THE /data PREFERENCE MATTERS
+//
+// A hub-delivered key lands at spokeAppKeyPath (/data, on the PVC) and the
+// heartbeat callback repoints cfg.GitHub.KeyFile at it — but only in memory, for
+// the life of that process. A hive whose config carries NO key_file (which is
+// the state of the three live GHE hives this repairs) used to fall straight
+// through to the read-only /secrets provisioning mount. That mount holds the
+// stale, wrong key, and the spoke cannot write to it. So on every restart the
+// hive would silently go back to signing with the key that cannot work, and the
+// hub — seeing the wrong fingerprint reported again — would redeliver forever.
+// The key would be delivered and never used: a fault that reads as fixed.
+//
+// So when nothing is explicitly configured, a key already present on the PVC is
+// preferred over the provisioning mount. An EXPLICIT key_file or env override
+// still wins outright: those are deliberate, and this must not silently redirect
+// an operator who named a path.
+func resolveAppKeyFile(configured, envOverride string) string {
+	if v := strings.TrimSpace(envOverride); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(configured); v != "" {
+		return v
+	}
+	// Nothing configured. Prefer a usable hub-delivered key on the PVC; fall
+	// back to the provisioning mount only when /data has no parseable key. The
+	// fingerprint check (not mere existence) keeps an empty or truncated /data
+	// file from shadowing a good provisioned key.
+	if fp, err := config.AppKeyFingerprintFromFile(spokeAppKeyPath); err == nil && fp != "" {
+		return spokeAppKeyPath
+	}
+	return spokeProvisionedAppKeyPath
 }
 
 // processStartedAt is when this hive process began. Reported over the heartbeat
@@ -203,13 +249,7 @@ func main() {
 	var ghClient *github.Client
 	var appAuth *github.AppAuth
 	if cfg.GitHub.AppID != 0 && cfg.GitHub.InstallationID != 0 {
-		keyFile := cfg.GitHub.KeyFile
-		if envKey := os.Getenv("GH_APP_KEY_FILE"); envKey != "" {
-			keyFile = envKey
-		}
-		if keyFile == "" {
-			keyFile = "/secrets/gh-app-key.pem"
-		}
+		keyFile := resolveAppKeyFile(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"))
 		var err error
 		appAuth, err = github.NewAppAuth(cfg.GitHub.AppID, cfg.GitHub.InstallationID, keyFile, logger, cfg.GitHub.ResolvedAPIURL())
 		if err != nil {
@@ -1843,6 +1883,10 @@ func main() {
 				// nothing and a spoke holding the wrong one self-heals.
 				GitHubAppKeyFingerprint: reportedAppKeyFingerprint(cfg.GitHub.KeyFile),
 				GitHubAppKeyPerHive:     hasPerHiveAppKey(cfg.GitHub.KeyFile),
+				// Report the App this hive believes it authenticates as. The hub
+				// pairs it with the fingerprint above to tell a per-hive key that
+				// is WRONG for this App from one that is deliberately for another.
+				GitHubAppID: cfg.GitHub.AppID,
 			}
 		}, heartbeatSendInterval, logger, hub.UpgradeCallback(func(targetSHA string) {
 			const upgradeMarkerPath = "/data/upgrade-requested"
@@ -1965,6 +2009,11 @@ func main() {
 			)
 
 			keyPath := spokeAppKeyPath
+			// keyChanged gates dropping the cached installation token below: a
+			// token minted under the previous key is invalid the moment the key
+			// is replaced, but a redelivery of the SAME key must not throw away a
+			// perfectly good token every heartbeat.
+			keyChanged := false
 			if ghCfg.PrivateKey != "" {
 				// Fingerprint before and after so the key rotation is auditable
 				// from the spoke's own logs. Fingerprints only — the key itself
@@ -1982,11 +2031,19 @@ func main() {
 					logger.Warn("could not tighten github app key permissions", "path", keyPath, "error", err)
 				}
 				afterFP, _ := config.AppKeyFingerprintFromFile(keyPath)
+				keyChanged = afterFP != "" && afterFP != beforeFP
 				logger.Info("github app private key written via heartbeat",
 					"path", keyPath,
 					"from_fingerprint", beforeFP,
 					"to_fingerprint", afterFP,
+					"key_changed", keyChanged,
 				)
+				if keyChanged {
+					// Invalidate before the new client is built, so nothing can
+					// read the dead token out of the shared on-disk cache in
+					// between. Agents read that file directly.
+					appAuth.DropCachedToken()
+				}
 			}
 
 			if ghCfg.AppID != 0 {

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -30,6 +31,20 @@ const agentSkipAfterFullBroadcastS = 5 * time.Second
 const maxSSEClients = 100
 const sessionCookieName = "hive_session"
 const sessionCookieMaxAge = 30 * 24 * 60 * 60 // 30 days
+
+// proxyAuthHeader is the proof-of-proxy header the hub's auth-check injects
+// (value = this hive's dashboard token) so a hub-proxied spoke can verify a
+// request actually transited the hub nginx rather than being forged on the pod
+// network. See authenticate() (F2). Must match the hub's constant.
+const proxyAuthHeader = "X-Hive-Proxy-Auth"
+
+// proxyProofRequired controls F2 enforcement strictness. Default false =
+// fail-open rollout: a request with no proof header is still trusted on its
+// identity headers (so hosted hives aren't locked out while the hub half rolls
+// out fleet-wide). Set HIVE_PROXY_PROOF_REQUIRED=true (once every hub is
+// confirmed injecting the header) to fail closed: a missing/incorrect proof
+// header is rejected. A WRONG proof header is ALWAYS rejected regardless.
+var proxyProofRequired = os.Getenv("HIVE_PROXY_PROOF_REQUIRED") == "true"
 
 type Server struct {
 	port       int
@@ -669,13 +684,38 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 		// valid when a real token is configured.
 		trusted := s.authToken != "" && secureCompare(r.Header.Get("X-Hive-Internal"), s.authToken)
 
-		// Hub-proxied path: nginx injects both headers from the hub's
+		// Hub-proxied path: nginx injects the identity headers from the hub's
 		// per-user/per-hive auth-check. Only trust them when this spoke is NOT a
-		// direct-route spoke (see strip above). Requiring both headers prevents
-		// trivial bypass via a single forged header.
+		// direct-route spoke (see strip above).
+		//
+		// SECURITY (F2): identity headers alone are forgeable by anything on the
+		// pod network that reaches :3002 directly, bypassing the hub nginx. The
+		// hub now also emits X-Hive-Proxy-Auth = this hive's dashboard token (the
+		// same secret we hold as authToken) on the auth-check success path, which
+		// only the trusted proxy can produce. Require it as PROOF the request
+		// transited the hub.
+		//
+		// ROLLOUT SAFETY — fail open until the hub half is everywhere: if the hub
+		// has NOT sent X-Hive-Proxy-Auth (older hub image mid-rollout), fall back
+		// to the pre-F2 behavior (trust the identity headers) so no hosted hive is
+		// locked out. Once the hub half is confirmed deployed fleet-wide, a
+		// follow-up flips proxyProofRequired to make a missing/incorrect proof
+		// header fail closed.
 		if !trusted && !directRouteAuthz &&
 			r.Header.Get("X-Hive-User") != "" && r.Header.Get("X-Hive-Role") != "" {
-			trusted = true
+			proof := r.Header.Get(proxyAuthHeader)
+			switch {
+			case proof != "" && s.authToken != "" && secureCompare(proof, s.authToken):
+				// Proof present and valid — definitely came through the hub.
+				trusted = true
+			case proof == "" && !proxyProofRequired:
+				// No proof header yet (hub not upgraded) and we're not enforcing
+				// strictly — trust the identity headers as before (rollout window).
+				trusted = true
+			default:
+				// Proof header present but WRONG, or strict mode with no proof:
+				// this did not come through the trusted hub proxy — reject.
+			}
 		}
 
 		// Per-user session path (device flow): resolve the session id in the

--- a/v2/pkg/dashboard/spoke_authz_test.go
+++ b/v2/pkg/dashboard/spoke_authz_test.go
@@ -177,6 +177,54 @@ func TestMiddleware_HubProxiedHeadersStillTrusted(t *testing.T) {
 	}
 }
 
+// TestMiddleware_F2ProxyProof covers the F2 proof-of-proxy header enforcement on
+// a hub-proxied spoke: a valid proof is trusted; a WRONG proof is always
+// rejected; a MISSING proof is trusted only in the fail-open rollout default and
+// rejected once strict enforcement is enabled.
+func TestMiddleware_F2ProxyProof(t *testing.T) {
+	newReq := func(proof string) *http.Request {
+		r := httptest.NewRequest("GET", "/api/config", nil)
+		r.Header.Set("X-Hive-User", "clubanderson")
+		r.Header.Set("X-Hive-Role", "owner")
+		if proof != "" {
+			r.Header.Set(proxyAuthHeader, proof)
+		}
+		return r
+	}
+	run := func(t *testing.T, strict bool, proof string) int {
+		s := newFullServer(t)
+		s.authToken = "shared-secret-token"
+		old := proxyProofRequired
+		proxyProofRequired = strict
+		t.Cleanup(func() { proxyProofRequired = old })
+		w := httptest.NewRecorder()
+		s.authenticate(recordingHandler(nil, nil)).ServeHTTP(w, newReq(proof))
+		return w.Code
+	}
+
+	// Valid proof header (matches authToken) -> trusted, both modes.
+	if c := run(t, false, "shared-secret-token"); c != http.StatusOK {
+		t.Errorf("valid proof (fail-open) = %d, want 200", c)
+	}
+	if c := run(t, true, "shared-secret-token"); c != http.StatusOK {
+		t.Errorf("valid proof (strict) = %d, want 200", c)
+	}
+	// Wrong proof header -> ALWAYS rejected (forged proxy).
+	if c := run(t, false, "wrong-token"); c == http.StatusOK {
+		t.Error("wrong proof must be rejected even in fail-open mode")
+	}
+	if c := run(t, true, "wrong-token"); c == http.StatusOK {
+		t.Error("wrong proof must be rejected in strict mode")
+	}
+	// Missing proof: trusted in fail-open (rollout), rejected in strict.
+	if c := run(t, false, ""); c != http.StatusOK {
+		t.Errorf("missing proof (fail-open) = %d, want 200 (rollout safety)", c)
+	}
+	if c := run(t, true, ""); c == http.StatusOK {
+		t.Error("missing proof must be rejected in strict mode")
+	}
+}
+
 func TestMiddleware_SharedCookieNoLongerAuthenticates(t *testing.T) {
 	// The old vulnerability: the shared s.authToken placed in the session cookie
 	// granted access. It must no longer be accepted as a session id.

--- a/v2/pkg/github/app_discovery.go
+++ b/v2/pkg/github/app_discovery.go
@@ -190,6 +190,34 @@ func (a *AppAuth) APIURL() string { return a.apiURL }
 // not App-authenticated and must be skipped rather than treated as failing.
 func (a *AppAuth) HasKey() bool { return a != nil && a.key != nil }
 
+// DropCachedToken discards the installation token this auth is holding, in
+// memory and on disk.
+//
+// Call it when the SIGNING KEY changes. A token is minted by presenting a JWT
+// signed with the old key; once the key is replaced that token is a dead
+// credential, and it is not enough to rebuild the AppAuth in memory — the
+// on-disk cache at cachePath is read directly by agent processes, so a stale
+// token there keeps being handed out until it expires. Dropping it forces the
+// next caller to mint a fresh token under the new key.
+//
+// A missing cache file is the normal case, not an error.
+func (a *AppAuth) DropCachedToken() {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.cachedToken = ""
+	a.tokenExpiry = time.Time{}
+	if a.cachePath == "" {
+		return
+	}
+	if err := os.Remove(a.cachePath); err != nil && !os.IsNotExist(err) && a.logger != nil {
+		a.logger.Warn("failed to drop stale app token cache after key change",
+			"path", a.cachePath, "error", err)
+	}
+}
+
 // AdoptInstallationID switches this auth to a different installation and
 // drops the cached installation token (which was minted for the OLD, wrong
 // installation and would keep 403ing on writes).

--- a/v2/pkg/github/app_dropcache_test.go
+++ b/v2/pkg/github/app_dropcache_test.go
@@ -1,0 +1,92 @@
+package github
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// dropCacheTestKeyBits matches the smallest size GitHub Apps use. This key never
+// signs anything real.
+const dropCacheTestKeyBits = 2048
+
+func newTestAppAuth(t *testing.T, cachePath string) *AppAuth {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, dropCacheTestKeyBits)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	keyFile := filepath.Join(t.TempDir(), "key.pem")
+	pemData := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(k),
+	})
+	if err := os.WriteFile(keyFile, pemData, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	auth, err := NewAppAuthWithCache(1234, 5678, keyFile, cachePath, slog.New(slog.NewTextHandler(io.Discard, nil)), "")
+	if err != nil {
+		t.Fatalf("NewAppAuthWithCache: %v", err)
+	}
+	return auth
+}
+
+// TestDropCachedToken covers the invalidation that has to happen when the App
+// private key is replaced. A token was minted by presenting a JWT signed with
+// the OLD key; once the key changes that token is dead. Rebuilding the AppAuth in
+// memory is not sufficient, because agent processes read the token straight out
+// of the on-disk cache — a stale file there keeps handing out a dead credential
+// until it expires on its own.
+func TestDropCachedToken(t *testing.T) {
+	t.Run("clears in-memory token and removes the cache file", func(t *testing.T) {
+		cachePath := filepath.Join(t.TempDir(), "gh-app-token.cache")
+		if err := os.WriteFile(cachePath, []byte("ghs_stale_token_minted_under_the_old_key"), 0o640); err != nil {
+			t.Fatal(err)
+		}
+		auth := newTestAppAuth(t, cachePath)
+		auth.cachedToken = "ghs_stale_token_minted_under_the_old_key"
+		auth.tokenExpiry = time.Now().Add(time.Hour)
+
+		auth.DropCachedToken()
+
+		if auth.cachedToken != "" {
+			t.Errorf("cachedToken = %q, want empty", auth.cachedToken)
+		}
+		if !auth.tokenExpiry.IsZero() {
+			t.Errorf("tokenExpiry = %v, want zero", auth.tokenExpiry)
+		}
+		if _, err := os.Stat(cachePath); !os.IsNotExist(err) {
+			t.Errorf("cache file still present (err=%v); agents would keep reading the dead token", err)
+		}
+	})
+
+	t.Run("a missing cache file is not an error", func(t *testing.T) {
+		cachePath := filepath.Join(t.TempDir(), "absent.cache")
+		auth := newTestAppAuth(t, cachePath)
+		auth.DropCachedToken() // must not panic or fail
+		if auth.cachedToken != "" {
+			t.Error("cachedToken should be empty")
+		}
+	})
+
+	t.Run("no cache path configured is a no-op on disk", func(t *testing.T) {
+		auth := newTestAppAuth(t, "")
+		auth.cachedToken = "x"
+		auth.DropCachedToken()
+		if auth.cachedToken != "" {
+			t.Error("cachedToken should be cleared even with no cache path")
+		}
+	})
+
+	t.Run("nil receiver is safe", func(t *testing.T) {
+		var auth *AppAuth
+		auth.DropCachedToken() // the spoke may not have App auth built yet
+	})
+}

--- a/v2/pkg/hub/cluster_app_key.go
+++ b/v2/pkg/hub/cluster_app_key.go
@@ -239,6 +239,15 @@ const (
 	appKeyReasonSpokeHasNoKey   = "spoke reports no app key"
 	appKeyReasonMismatch        = "spoke key fingerprint differs from cluster key"
 	appKeyReasonMatch           = "spoke already holds the cluster key"
+	// appKeyReasonPerHiveUnusable is the one case that overrides the per-hive
+	// precedence: the hive claims the cluster's app_id but holds a key that is
+	// not the cluster's. That pair cannot sign a valid JWT for that App, so the
+	// per-hive key is not a choice being protected — it is a fault.
+	appKeyReasonPerHiveUnusable = "per-hive key cannot sign for the app_id this hive claims"
+	// appKeyReasonDifferentApp is the per-hive case that IS protected: the hive
+	// is pinned to an App other than the cluster's, so its key is presumed
+	// correct for that App and the cluster key would break it.
+	appKeyReasonDifferentApp = "hive is deliberately pinned to a different app_id"
 )
 
 // decideAppKeySync decides whether the hub should push its cluster App key to a
@@ -250,6 +259,32 @@ const (
 // overwrote it would silently undo that decision on the next beat, with no way
 // for the operator to make it stick. The cluster key is a FLOOR for hives nobody
 // has spoken for, not a ceiling over hives somebody has.
+//
+// THE ONE EXCEPTION — A WRONG PER-HIVE KEY IS NOT A CHOICE
+//
+// That precedence protects a DECISION. It must not protect a FAULT, and the two
+// are distinguishable without heuristics. A GitHub App JWT is signed by the
+// private key and presented alongside an app_id; GitHub verifies the signature
+// against the public key registered for THAT app_id. So for a hive reporting
+// app_id == cluster.AppID with a key fingerprint != cluster.Fingerprint, the
+// credential pair is provably unusable — not "probably stale", not "differently
+// configured", but arithmetically incapable of producing a token. That is
+// exactly the state three live GHE hives are in: they carry the PUBLIC
+// github.com App's key while claiming the GHE app_id, and every request dies
+// with "401 A JSON web token could not be decoded". Withholding the cluster key
+// from them protects nothing and leaves them permanently dead.
+//
+// The discriminator is therefore the app_id, and ONLY the app_id:
+//
+//	per-hive key + spoke app_id == cluster app_id + fingerprint differs
+//	    -> PUSH. The key cannot work for the App the hive claims.
+//	per-hive key + spoke app_id != cluster app_id (and non-zero)
+//	    -> DO NOT PUSH. A different App on purpose; its key is right for it.
+//	per-hive key + spoke app_id == 0 (unknown / too old to report)
+//	    -> DO NOT PUSH. Silence is not evidence of a fault; stay conservative.
+//
+// This is a proof, not an inference: it never asks whether a key LOOKS stale,
+// only whether the hive's own claimed App ID makes its own key impossible.
 //
 // IDEMPOTENCE: the hub pushes only when the fingerprints differ. Once the spoke
 // reports the cluster fingerprint the decision flips to no-push and the key stops
@@ -264,35 +299,62 @@ const (
 // that in fact has a good key is harmless — it rewrites the same App identity —
 // whereas withholding leaves a dead hive dead. Once the spoke is new enough to
 // report, the push stops on the following beat.
-func decideAppKeySync(spokeFingerprint string, hasPerHiveKey bool, cluster *clusterAppIdentity) appKeySyncDecision {
+func decideAppKeySync(spokeFingerprint string, hasPerHiveKey bool, spokeAppID int64, cluster *clusterAppIdentity) appKeySyncDecision {
 	if cluster == nil {
 		return appKeySyncDecision{Reason: appKeyReasonNoClusterKey, FromFingerprint: spokeFingerprint}
 	}
+	fp := strings.TrimSpace(spokeFingerprint)
 	if hasPerHiveKey {
+		// Idempotence first: if the per-hive key already IS the cluster key
+		// there is nothing to decide and nothing to send. Checking this ahead of
+		// the app_id logic also means a hive whose provisioned key happens to be
+		// correct never enters the exception path at all.
+		if fp != "" && fp == cluster.Fingerprint {
+			return appKeySyncDecision{
+				Reason:          appKeyReasonMatch,
+				FromFingerprint: fp,
+				ToFingerprint:   cluster.Fingerprint,
+			}
+		}
+		// The exception: the hive claims this cluster's App but cannot sign for
+		// it. Requires a POSITIVE app_id match — zero (unknown) and any other
+		// App both fall through to the protected override below.
+		if spokeAppID != 0 && spokeAppID == cluster.AppID && fp != "" && fp != cluster.Fingerprint {
+			return appKeySyncDecision{
+				Push:            true,
+				Reason:          appKeyReasonPerHiveUnusable,
+				FromFingerprint: fp,
+				ToFingerprint:   cluster.Fingerprint,
+			}
+		}
+		reason := appKeyReasonPerHiveOverride
+		if spokeAppID != 0 && spokeAppID != cluster.AppID {
+			reason = appKeyReasonDifferentApp
+		}
 		return appKeySyncDecision{
-			Reason:          appKeyReasonPerHiveOverride,
-			FromFingerprint: spokeFingerprint,
+			Reason:          reason,
+			FromFingerprint: fp,
 			ToFingerprint:   cluster.Fingerprint,
 		}
 	}
-	if strings.TrimSpace(spokeFingerprint) == "" {
+	if fp == "" {
 		return appKeySyncDecision{
 			Push:          true,
 			Reason:        appKeyReasonSpokeHasNoKey,
 			ToFingerprint: cluster.Fingerprint,
 		}
 	}
-	if spokeFingerprint != cluster.Fingerprint {
+	if fp != cluster.Fingerprint {
 		return appKeySyncDecision{
 			Push:            true,
 			Reason:          appKeyReasonMismatch,
-			FromFingerprint: spokeFingerprint,
+			FromFingerprint: fp,
 			ToFingerprint:   cluster.Fingerprint,
 		}
 	}
 	return appKeySyncDecision{
 		Reason:          appKeyReasonMatch,
-		FromFingerprint: spokeFingerprint,
+		FromFingerprint: fp,
 		ToFingerprint:   cluster.Fingerprint,
 	}
 }
@@ -306,9 +368,9 @@ func decideAppKeySync(spokeFingerprint string, hasPerHiveKey bool, cluster *clus
 // installation_id. Zero is passed through as zero — the spoke's callback only
 // rebuilds its client once app_id, installation_id and key file are all present,
 // so a key delivered ahead of an installation ID lands on disk and waits.
-func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFingerprint string, hasPerHiveKey bool, installationID int64, logger *slog.Logger) *HeartbeatGitHubAppConfig {
+func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFingerprint string, hasPerHiveKey bool, spokeAppID int64, installationID int64, logger *slog.Logger) *HeartbeatGitHubAppConfig {
 	identity := s.appIdentityForCluster(clusterID)
-	decision := decideAppKeySync(spokeFingerprint, hasPerHiveKey, identity)
+	decision := decideAppKeySync(spokeFingerprint, hasPerHiveKey, spokeAppID, identity)
 	if !decision.Push || identity == nil {
 		return nil
 	}
@@ -318,6 +380,8 @@ func (s *HubServer) appKeyConfigForHeartbeat(hiveID, clusterID string, spokeFing
 			"hive_id", hiveID,
 			"cluster_id", clusterID,
 			"app_id", identity.AppID,
+			"spoke_app_id", spokeAppID,
+			"per_hive_key", hasPerHiveKey,
 			"reason", decision.Reason,
 			"from_fingerprint", decision.FromFingerprint,
 			"to_fingerprint", decision.ToFingerprint,
@@ -528,6 +592,7 @@ func (s *HubServer) appKeySyncForHeartbeat(payload *HeartbeatPayload) *Heartbeat
 		clusterID,
 		payload.GitHubAppKeyFingerprint,
 		payload.GitHubAppKeyPerHive,
+		payload.GitHubAppID,
 		installationIDUnchanged,
 		s.logger,
 	)

--- a/v2/pkg/hub/cluster_app_key_test.go
+++ b/v2/pkg/hub/cluster_app_key_test.go
@@ -70,6 +70,7 @@ func TestDecideAppKeySync(t *testing.T) {
 		name        string
 		spokeFP     string
 		perHive     bool
+		spokeAppID  int64
 		cluster     *clusterAppIdentity
 		wantPush    bool
 		wantReason  string
@@ -133,15 +134,16 @@ func TestDecideAppKeySync(t *testing.T) {
 			description: "nothing to push means nothing happens, not an empty push",
 		},
 		{
-			name:        "per-hive key wins over cluster default even on mismatch",
+			name:        "per-hive key, spoke app_id unknown - no push",
 			spokeFP:     wrongFP,
 			perHive:     true,
+			spokeAppID:  0,
 			cluster:     identity,
 			wantPush:    false,
 			wantReason:  appKeyReasonPerHiveOverride,
 			wantFromFP:  wrongFP,
 			wantToFP:    clusterFP,
-			description: "a deliberate per-hive credential is never overwritten",
+			description: "a spoke too old to report app_id must not be assumed broken",
 		},
 		{
 			name:        "per-hive key with no key reported still wins",
@@ -151,13 +153,85 @@ func TestDecideAppKeySync(t *testing.T) {
 			wantPush:    false,
 			wantReason:  appKeyReasonPerHiveOverride,
 			wantToFP:    clusterFP,
-			description: "the override is unconditional; operator intent is respected",
+			description: "no fingerprint is no proof of a wrong key; stay conservative",
+		},
+
+		// --- THE FIX: a per-hive key that provably cannot work ---
+		{
+			name:        "per-hive key wrong for the app_id the hive claims - PUSH",
+			spokeFP:     wrongFP,
+			perHive:     true,
+			spokeAppID:  5686,
+			cluster:     identity,
+			wantPush:    true,
+			wantReason:  appKeyReasonPerHiveUnusable,
+			wantFromFP:  wrongFP,
+			wantToFP:    clusterFP,
+			description: "vllmd-01..03: claims GHE app 5686 but holds the public github.com key — cannot sign a valid JWT, so this is a fault and not a choice",
+		},
+		{
+			name:        "per-hive key for a deliberately DIFFERENT app - no push",
+			spokeFP:     wrongFP,
+			perHive:     true,
+			spokeAppID:  99999,
+			cluster:     identity,
+			wantPush:    false,
+			wantReason:  appKeyReasonDifferentApp,
+			wantFromFP:  wrongFP,
+			wantToFP:    clusterFP,
+			description: "a hive pinned to its own App keeps its own key; the cluster key would break it",
+		},
+		{
+			name:        "per-hive key already matches the cluster key - no push",
+			spokeFP:     clusterFP,
+			perHive:     true,
+			spokeAppID:  5686,
+			cluster:     identity,
+			wantPush:    false,
+			wantReason:  appKeyReasonMatch,
+			wantFromFP:  clusterFP,
+			wantToFP:    clusterFP,
+			description: "idempotence: once repaired the push must stop, per-hive flag or not",
+		},
+		{
+			name:        "per-hive, matching app_id, no fingerprint reported - no push",
+			spokeFP:     "",
+			perHive:     true,
+			spokeAppID:  5686,
+			cluster:     identity,
+			wantPush:    false,
+			wantReason:  appKeyReasonPerHiveOverride,
+			wantToFP:    clusterFP,
+			description: "the exception needs a fingerprint that provably differs, not an absent one",
+		},
+		{
+			name:        "cluster app_id unset cannot make a positive match",
+			spokeFP:     wrongFP,
+			perHive:     true,
+			spokeAppID:  5686,
+			cluster:     &clusterAppIdentity{AppID: 0, Fingerprint: clusterFP},
+			wantPush:    false,
+			wantReason:  appKeyReasonDifferentApp,
+			wantFromFP:  wrongFP,
+			wantToFP:    clusterFP,
+			description: "no cluster app_id means no proof of a conflict",
+		},
+		{
+			name:        "non-per-hive mismatch on a matching app_id still pushes",
+			spokeFP:     wrongFP,
+			spokeAppID:  5686,
+			cluster:     identity,
+			wantPush:    true,
+			wantReason:  appKeyReasonMismatch,
+			wantFromFP:  wrongFP,
+			wantToFP:    clusterFP,
+			description: "reporting app_id must not change the pre-existing non-per-hive path",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := decideAppKeySync(tc.spokeFP, tc.perHive, tc.cluster)
+			got := decideAppKeySync(tc.spokeFP, tc.perHive, tc.spokeAppID, tc.cluster)
 			if got.Push != tc.wantPush {
 				t.Errorf("Push = %v, want %v (%s)", got.Push, tc.wantPush, tc.description)
 			}
@@ -192,7 +266,7 @@ func TestDecideAppKeySyncIsIdempotent(t *testing.T) {
 	identity := &clusterAppIdentity{AppID: 5686, PrivateKey: keyPEM, Fingerprint: fp}
 
 	// Beat 1: spoke has nothing → push.
-	first := decideAppKeySync("", false, identity)
+	first := decideAppKeySync("", false, 0, identity)
 	if !first.Push {
 		t.Fatal("first beat should push to a spoke with no key")
 	}
@@ -204,7 +278,7 @@ func TestDecideAppKeySyncIsIdempotent(t *testing.T) {
 	}
 	// Beat 2: spoke now reports the delivered key → no push, forever after.
 	for beat := 2; beat <= 5; beat++ {
-		d := decideAppKeySync(delivered, false, identity)
+		d := decideAppKeySync(delivered, false, 0, identity)
 		if d.Push {
 			t.Fatalf("beat %d re-pushed a key the spoke already holds", beat)
 		}
@@ -537,7 +611,7 @@ func TestClusterKeyNeverSerializedIntoAPIPayload(t *testing.T) {
 			Fingerprint: identity.Fingerprint,
 		},
 		// The decision record that feeds every log line.
-		"appKeySyncDecision": decideAppKeySync("sha256:00000000000000000000000000000000", false, identity),
+		"appKeySyncDecision": decideAppKeySync("sha256:00000000000000000000000000000000", false, 0, identity),
 	}
 
 	for name, payload := range payloads {

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -294,6 +294,22 @@ type HeartbeatPayload struct {
 	// its cluster. The hub honours it as an override: a deliberate per-hive
 	// credential is never overwritten by the cluster default.
 	GitHubAppKeyPerHive bool `json:"github_app_key_per_hive,omitempty"`
+	// GitHubAppID is the App ID this spoke believes it is authenticating AS —
+	// cfg.GitHub.AppID, non-secret. It exists to make one specific distinction
+	// decidable on the hub: a per-hive key that is WRONG versus a per-hive key
+	// that is deliberately for a DIFFERENT App.
+	//
+	// A JWT is signed by the key and presented as app_id. If a spoke claims the
+	// cluster's app_id but holds a key whose fingerprint is not the cluster
+	// key's, that pair provably cannot authenticate — GitHub rejects it before
+	// any permission check ("A JSON web token could not be decoded"). If the
+	// spoke claims a DIFFERENT app_id, its key is presumed correct for that
+	// other App and the hub must not touch it.
+	//
+	// Zero means the spoke is too old to report, or has no App configured. Both
+	// read as "unknown": the hub falls back to the conservative per-hive
+	// override and declines to overwrite. Never infer a mismatch from silence.
+	GitHubAppID int64 `json:"github_app_id,omitempty"`
 }
 
 type StatusCollector func() *HeartbeatPayload

--- a/v2/pkg/hub/hive_access_avatars_test.go
+++ b/v2/pkg/hub/hive_access_avatars_test.go
@@ -174,13 +174,16 @@ func TestHoverPanelReusesSharedRoleColor(t *testing.T) {
 }
 
 // TestHiveTableColumnCountUnchanged asserts the inline avatars did NOT add a
-// column. They live inside the existing name cell precisely so the 17-column
+// column. They live inside the existing name cell precisely so the 16-column
 // header, the section-header colspan and the pending-expand colspan all stay
 // correct; a stale count leaves the table visibly ragged.
+//
+// 16, not 17: the standalone Public column was folded into Location, where
+// visibility now stacks beneath the location badge.
 func TestHiveTableColumnCountUnchanged(t *testing.T) {
 	for _, snippet := range []string{
-		"var TOTAL_COLUMNS = 17;",
-		"var TOTAL_COLUMNS_HEADER = 17;",
+		"var TOTAL_COLUMNS = 16;",
+		"var TOTAL_COLUMNS_HEADER = 16;",
 	} {
 		if !strings.Contains(dashboardHTML, snippet) {
 			t.Errorf("dashboardHTML is missing %q — did the hive table gain or lose a column?", snippet)

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -6536,7 +6536,7 @@ const dashboardHTML = `<!DOCTYPE html>
     }
 
     /* Faces shown inline before collapsing the rest into a "+N" chip. The hive
-       table is 17 columns and already dense; four 16px faces plus the chip fit
+       table is 16 columns and already dense; four 16px faces plus the chip fit
        beside the role badge without widening the name column, and a hive with
        a dozen members must not push the row wide. The full list stays one
        hover away on the status dot. */
@@ -9591,7 +9591,25 @@ const dashboardHTML = `<!DOCTYPE html>
             autoUpgradeCheck = ' ' + d.outerHTML;
           }
           var shaMsg = _commitMessages[sha] || _latestSHAMessages[branchName] || '';
-          versionCell = branch + '<span style="font-family:monospace;color:var(--muted)" title="' + esc(shaMsg) + '">' + esc(sha) + '</span>' + status + upgradeIcon + autoUpgradeCheck;
+          /* Three stacked lines, grouped by what each thing IS — not split
+             arbitrarily to reach three:
+               1. the branch, which the owner can CHANGE (the pill is a
+                  switcher, so it owns a line and stays a full tap target);
+               2. the SHA and its current/behind glyph, which are two views of
+                  the same immutable fact — "what commit is this hive on";
+               3. what happens NEXT: the upgrade affordance (Upgrade button /
+                  "queued · 5pm ET" / in-flight spinner) beside the
+                  auto-upgrade mode select. These are the two tallest items,
+                  so pairing them costs one line instead of two.
+             Every fragment below is embedded verbatim, so ids, onclick/onchange
+             handlers and title tooltips are all preserved exactly. */
+          var shaLine = '<span style="font-family:monospace;color:var(--muted)" title="' + esc(shaMsg) + '">' + esc(sha) + '</span>' + status;
+          var nextLine = upgradeIcon + autoUpgradeCheck;
+          versionCell = '<div style="' + STACKED_CELL_STYLE + '">' +
+            '<div style="' + STACKED_LINE_STYLE + '">' + branch + '</div>' +
+            '<div style="' + STACKED_LINE_STYLE + '">' + shaLine + '</div>' +
+            (nextLine ? '<div style="' + STACKED_LINE_STYLE + '">' + nextLine + '</div>' : '') +
+            '</div>';
         } else { versionCell = '<span style="color:var(--muted)">—</span>'; }
         var pendingBadge = (h.pendingRequestCount > 0 && (h.role === 'owner' || h.role === 'read-write'))
           ? '<span style="position:absolute;top:-2px;right:-2px;background:var(--blue);color:#fff;border-radius:50%;width:16px;height:16px;font-size:0.6rem;display:flex;align-items:center;justify-content:center;font-weight:700">' + h.pendingRequestCount + '</span>'
@@ -9600,11 +9618,62 @@ const dashboardHTML = `<!DOCTYPE html>
         if (h.pendingRequestCount > 0 && (h.role === 'owner' || h.role === 'read-write')) {
           pendingPill = '<a href="#" onclick="togglePendingRow(\'' + esc(h.id) + '\');return false" style="display:inline-flex;align-items:center;gap:4px;padding:3px 10px;background:rgba(59,130,246,0.12);color:#60a5fa;border:1px solid rgba(59,130,246,0.3);border-radius:4px;font-size:0.7rem;text-decoration:none;cursor:pointer;white-space:nowrap">&#x1F514; ' + h.pendingRequestCount + ' pending</a>';
         }
-        // 17 = the 13 original columns, plus Uptime, plus Drift, plus the
-        // bulk-select column, plus Journey. Counted against the <th> cells in
-        // the header and the <td> cells emitted below (bulkCheckboxCell
-        // contributes one).
-        var TOTAL_COLUMNS = 17;
+        // 16 = the 13 original columns, plus Uptime, plus Drift, plus the
+        // bulk-select column, plus Journey, MINUS Public — visibility now
+        // stacks under Location instead of owning a column. Counted against
+        // the <th> cells in the header and the <td> cells emitted below
+        // (bulkCheckboxCell contributes one).
+        var TOTAL_COLUMNS = 16;
+        /* Visibility moved OUT of its own column and under Location: "where
+           does this hive run" and "who can see it" are both facts about the
+           hive's placement, so they read as one cell, and folding them saves a
+           whole column in a table that had 17.
+
+           All THREE original branches survive unchanged — the owner toggle
+           (with its 'vis-<id>' element id and onchange handler), the local
+           link into Governor Config, and the read-only ✓/— for everyone else.
+           They are deliberately NOT flattened: each answers a different
+           question about who may change the setting. */
+        var visibilityCell = (function() {
+          var pub = !!h.isPublic;
+          /* escAttr, not esc: this id lands inside a quoted attribute and a
+             hive id carrying a quote would otherwise break out of it. Still
+             'vis-' + the hive id, so it stays unique per row exactly as before. */
+          var tid = 'vis-' + escAttr(h.id);
+          /* Branch 1 — hosted hive the viewer OWNS: a live toggle. The owner is
+             the only person who may change listing, so they get the control. */
+          if (isHosted && h.role === 'owner') {
+            return '<label style="position:relative;display:inline-block;width:' + VIS_SWITCH_W_PX + 'px;height:' + VIS_SWITCH_H_PX + 'px;cursor:pointer">' +
+              '<input type="checkbox" id="' + tid + '"' + (pub ? ' checked' : '') +
+              /* jsArg (not esc) for the handler argument: esc leaves an
+                 apostrophe intact, which would close the attribute quote early.
+                 jsArg supplies its own surrounding quotes. */
+              ' onchange="toggleVisibility(' + jsArg(h.id) + ',this.checked)" style="opacity:0;width:0;height:0">' +
+              '<span style="position:absolute;inset:0;background:' + (pub ? 'var(--green)' : 'var(--border)') + ';border-radius:' + VIS_SWITCH_RADIUS_PX + 'px;transition:background 0.2s"></span>' +
+              '<span style="position:absolute;top:' + VIS_KNOB_INSET_PX + 'px;left:' + (pub ? VIS_KNOB_ON_LEFT_PX : VIS_KNOB_INSET_PX) + 'px;width:' + VIS_KNOB_PX + 'px;height:' + VIS_KNOB_PX + 'px;background:#fff;border-radius:50%;transition:left 0.2s"></span>' +
+              '</label>';
+          }
+          /* Branch 2 — LOCAL hive: the hub cannot write its config, so this is
+             a signpost to where the setting actually lives (Governor → Hub),
+             not a control. Falls back to a plain badge with no dashboard URL. */
+          if (isLocal) {
+            var dh = h.dashboardUrl && !h.dashboardUrl.includes('localhost') ? h.dashboardUrl : '';
+            var badge = pub ? '<span style="color:var(--green)">Public</span>' : '<span style="color:var(--muted)">Private</span>';
+            return dh
+              ? '<a href="' + escAttr(dh) + '#config/governor/Hub" target="_blank" title="Change in Governor Config → Hub tab" style="text-decoration:none;cursor:pointer">' + badge + ' <span style="font-size:0.6rem;color:var(--muted)">↗</span></a>'
+              : badge;
+          }
+          /* Branch 3 — everyone else: read-only state, no affordance implied. */
+          return pub ? '<span style="color:var(--green)">✓</span>' : '<span style="color:var(--muted)">—</span>';
+        })();
+        var locationBadge = isLocal ? '<span style="display:inline-block;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:rgba(107,114,128,0.15);color:#9ca3af;border:1px solid rgba(107,114,128,0.3)">local</span>' : clusterBadge(h.clusterId, h.clusterName);
+        /* Location on top, visibility beneath — two stacked lines, matching the
+           three-line Version treatment. The owner toggle is a 36x20 switch and
+           keeps its own box on its own line, so it stays an easy tap target. */
+        var locationCell = '<div style="' + STACKED_CELL_STYLE + '">' +
+          '<div style="' + STACKED_LINE_STYLE + '">' + locationBadge + '</div>' +
+          '<div style="' + STACKED_LINE_STYLE + ';font-size:0.7rem">' + visibilityCell + '</div>' +
+          '</div>';
         var pendingExpandRow = '';
         if (h.pendingRequestCount > 0 && (h.role === 'owner' || h.role === 'read-write') && (h.pending_requests || []).length > 0) {
           var prItems = (h.pending_requests || []).map(function(pr) {
@@ -9627,17 +9696,20 @@ const dashboardHTML = `<!DOCTYPE html>
           bulkCheckboxCell(h, section || 'all') +
           '<td class="hive-menu-cell" style="position:relative;width:30px;text-align:center;overflow:visible">' + (h.migrationStatus === 'migrating' ? '<span style="font-size:1.1rem;color:var(--border);user-select:none;cursor:not-allowed" title="Disabled during migration">⋮</span>' : '<span style="cursor:pointer;font-size:1.1rem;color:var(--muted);user-select:none">⋮</span>' + pendingBadge + '<div class="hive-menu-dropdown" style="display:none;position:absolute;left:0;bottom:auto;background:#1c2128;border:1px solid #30363d;border-radius:8px;min-width:160px;padding:4px 0;z-index:1000;box-shadow:0 8px 24px rgba(0,0,0,0.5)">' + menuItems.join('') + '</div>') + '</td>' +
           '<td style="text-align:left;line-height:1.4">' + (function() { var isHostedRow = h.hiveType === 'hosted' || (h.id && (h.id.startsWith('hosted-') || h.id.startsWith('saas-'))); var dh = isHostedRow && h.id ? ('/api/saas/hives/' + encodeURIComponent(h.id) + '/open') : (rb ? esc(rb) : ''); /* Label derived from the PROJECT (org + primary repo), not by splitting h.name — see hiveLabel. */ var label = hiveLabel(h); var orgName = label.line1; var repoName = label.line2; var rp = h.org && h.primaryRepo ? h.org + '/' + h.primaryRepo : ''; var ghIcon = rp ? '<a href="https://github.com/' + esc(rp) + '" target="_blank" style="opacity:0.5;vertical-align:middle" title="' + esc(rp) + '"><svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" style="vertical-align:middle"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a>' : ''; var link = function(text, bold) { if (dh) { return '<a href="' + dh + '" target="_blank" class="' + (bold ? 'hive-name-link' : 'hive-sub-link') + '" title="Open dashboard">' + esc(text) + '</a>'; } var s = bold ? 'font-weight:700;color:inherit' : 'color:#6b7280;font-weight:400'; return '<span style="' + s + '">' + esc(text) + '</span>'; }; var line1 = dot + ' ' + link(orgName, true); var fcPill = h.online ? failingCheckSummary(h) : ''; /* Inline access faces sit on the name cell's second line, immediately after this row's own role badge: the badge already answers "what am I on this hive", so the co-members read as the natural continuation of the same thought, in the one cell that is left-aligned and has room to grow. It also keeps them out of the 16 dense metric columns, none of which is about people. Empty string when the viewer is the only member, so those rows are pixel-identical to today. */ var accessFaces = hiveAccessAvatars(h); /* Keyed off repoName, not orgName: line 1 now always carries SOME identity, so the presence of a second line is decided purely by whether there is a repo to put on it. Without a repo the row still shows the GitHub icon, role badge, faces and failing-check pill on the compact variant. */ var line2 = repoName ? '<div style="padding-left:18px;font-size:0.8rem">' + link(repoName, false) + ' ' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + '</div>' : '<div style="padding-left:18px">' + ghIcon + ' ' + roleBadge(h.role) + accessFaces + fcPill + '</div>'; var line3 = pendingPill ? '<div style="margin-top:4px;padding-left:18px">' + pendingPill + '</div>' : ''; return line1 + line2 + line3; })() + '</td>' +
-          '<td>' + (isLocal ? '<span style="display:inline-block;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:rgba(107,114,128,0.15);color:#9ca3af;border:1px solid rgba(107,114,128,0.3)">local</span>' : clusterBadge(h.clusterId, h.clusterName)) + '</td>' +
+          '<td>' + locationCell + '</td>' +
           '<td style="white-space:nowrap">' + uptimeCell(h) + '</td>' +
-          '<td>' + (function() { var pub = !!h.isPublic; var tid = 'vis-' + esc(h.id); if (isHosted && h.role === 'owner') { return '<label style="position:relative;display:inline-block;width:36px;height:20px;cursor:pointer"><input type="checkbox" id="' + tid + '" ' + (pub ? 'checked' : '') + ' onchange="toggleVisibility(\'' + esc(h.id) + '\',this.checked)" style="opacity:0;width:0;height:0"><span style="position:absolute;inset:0;background:' + (pub ? 'var(--green)' : 'var(--border)') + ';border-radius:10px;transition:background 0.2s"></span><span style="position:absolute;top:2px;left:' + (pub ? '18px' : '2px') + ';width:16px;height:16px;background:#fff;border-radius:50%;transition:left 0.2s"></span></label>'; } if (isLocal) { var dh = h.dashboardUrl && !h.dashboardUrl.includes('localhost') ? h.dashboardUrl : ''; var badge = pub ? '<span style="color:var(--green)">Public</span>' : '<span style="color:var(--muted)">Private</span>'; return dh ? '<a href="' + esc(dh) + '#config/governor/Hub" target="_blank" title="Change in Governor Config → Hub tab" style="text-decoration:none;cursor:pointer">' + badge + ' <span style="font-size:0.6rem;color:var(--muted)">↗</span></a>' : badge; } return pub ? '<span style="color:var(--green)">✓</span>' : '<span style="color:var(--muted)">—</span>'; })() + '</td>' +
-          '<td style="font-size:0.7rem;white-space:nowrap">' + versionCell + '</td>' +
+          /* No white-space:nowrap on the cell itself: the stacked lines each
+             carry their own nowrap, so the SHA still never breaks mid-hash,
+             but the COLUMN is no longer forced to the width of every part laid
+             end to end. That nowrap was the main reason this column was wide. */
+          '<td style="font-size:0.7rem">' + versionCell + '</td>' +
           '<td title="' + esc((h.repos || []).join('\n')) + '" style="cursor:' + (repoCount > 0 ? 'help' : 'default') + '">' + repoCount + '</td>' +
           '<td>' + acmmBadge(h.acmmLevel) + '</td>' +
           '<td>' + journeyBadge(h.journey) + '</td>' +
           /* Drift sits immediately right of Journey: both answer "how healthy
              is this hive's configuration", so they read as one pair rather
              than being separated by nine metric columns. Header index and body
-             index are both 11 of 17 — keep them in lockstep. */
+             index are both 10 of 16 — keep them in lockstep. */
           '<td style="white-space:nowrap;text-align:right">' + driftBadge(h) + '</td>' +
           '<td title="' + esc((h.agents || []).map(function(a){ var label = a.name + ' (' + a.state + ')'; if (a.mode === 'on_demand') label += ' — on demand'; return label; }).join('\n')) + '" style="cursor:' + ((h.agentCount || 0) > 0 ? 'help' : 'default') + '">' + (h.agentCount || 0) + '</td>' +
           '<td title="Cumulative tokens consumed, as of the last heartbeat" style="white-space:nowrap;cursor:help">' + fmtTokens(h.totalTokens24h || 0) + '</td>' +
@@ -9652,8 +9724,9 @@ const dashboardHTML = `<!DOCTYPE html>
       /* Count of <th> cells in the hive table header below. The section-header
          row spans all of them; a stale value would leave the separator short
          and the table visibly ragged. 15 with the Drift column, plus the
-         bulk-select column, plus the Journey column. */
-      var TOTAL_COLUMNS_HEADER = 17;
+         bulk-select column, plus the Journey column, minus Public (visibility
+         is stacked under Location). Must stay equal to TOTAL_COLUMNS. */
+      var TOTAL_COLUMNS_HEADER = 16;
       /* The header is a click target that expands/collapses its section. The
          caret mirrors aria-expanded so the affordance and the a11y state can
          never disagree. sectionKey also scopes the select-all checkbox to THIS
@@ -9788,7 +9861,7 @@ const dashboardHTML = `<!DOCTYPE html>
         /* Non-admin lists have no section headers, so the flat list's
            select-all lives in the table head instead. */
         '<th style="width:26px;text-align:center">' + (_isAdmin ? '' : bulkSectionCheckbox('all')) + '</th>' +
-        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer">Location ⇅</th><th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅</th><th>Public</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'journey\')" style="cursor:pointer" title="Where this hive is on the adoption journey: install the GitHub App, assign a method/model (or run the contributor relay), then raise the ACMM level">Journey ⇅</th><th title="Configuration drift from the fleet norm — hover a value for the specific signals">Drift</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th>' +
+        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer" title="Where this hive runs, and whether it is listed publicly">Location ⇅</th><th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'journey\')" style="cursor:pointer" title="Where this hive is on the adoption journey: install the GitHub App, assign a method/model (or run the contributor relay), then raise the ACMM level">Journey ⇅</th><th title="Configuration drift from the fleet norm — hover a value for the specific signals">Drift</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table></div>';
       /* Delegated, so binding once is enough no matter how often the table is
          re-rendered. The guard keeps repeated renders from stacking listeners. */
@@ -9916,6 +9989,56 @@ const dashboardHTML = `<!DOCTYPE html>
     var _upgradingHives = {};
     var _switchStartedAt = {}; // hiveId → ms timestamp the switch was initiated
     var SWITCH_STALE_MS = 8 * 60 * 1000; // warn if a switch hasn't landed in 8 min
+
+    /* Version and Location cells stack their contents vertically so neither
+       column is forced as wide as the sum of its parts. The Version cell used
+       to lay branch pill + SHA + status + upgrade affordance + auto-upgrade
+       select on ONE nowrap line, which made it the widest column in a table
+       that already carries 16 of them.
+
+       STACKED_LINE_HEIGHT is deliberately tighter than the table's default so
+       the stack stays as short as three lines can be. The honest arithmetic, at
+       0.7rem on a 16px root:
+         plain text line          = 0.7*16*1.15            = 12.9px
+         line 3 (Upgrade button)  = 12.9 + 3px pad*2 + 1px border*2 = 20.9px
+         three lines + 2 gaps     = 12.9 + 12.9 + 20.9 + 2*1 = 48.7px
+       The two-line name cell (1rem + 0.8rem at line-height 1.4) is 40.3px, so
+       an OWNER row — the only variant that gets all three lines, because only
+       an owner sees the Upgrade button and the auto-upgrade select — grows from
+       40.3px to ~48.7px, about 8px. Rows for non-owners keep at most two
+       stacked lines (25.8px) and are unchanged, since the name cell still sets
+       their height. That is the deliberate trade: ~8px on owner rows in
+       exchange for dropping a whole column and a much narrower Version column.
+       Loosening either constant is what would make it materially worse.
+
+       STACKED_ROW_GAP_PX separates the stacked lines without adding a full line
+       box. 1px, not more, precisely because line 3 is a button whose own padding
+       already supplies visual separation. */
+    var STACKED_LINE_HEIGHT = 1.15;
+    var STACKED_ROW_GAP_PX = 1;
+    /* Shared style for a stacked cell: a vertical flex column, centred to match
+       the table's default text-align:center for non-first cells. */
+    var STACKED_CELL_STYLE = 'display:flex;flex-direction:column;align-items:center;justify-content:center;gap:' + STACKED_ROW_GAP_PX + 'px;line-height:' + STACKED_LINE_HEIGHT;
+    /* Horizontal gap between the items that share one stacked line (e.g. the
+       SHA and its current/behind glyph). Small enough that a line stays visibly
+       one group rather than reading as separate columns. */
+    var STACKED_ITEM_GAP_PX = 4;
+    /* One line inside a stacked cell. Items within a line stay on one row (the
+       SHA must never wrap mid-hash) but the LINES themselves are what narrow
+       the column. */
+    var STACKED_LINE_STYLE = 'display:flex;align-items:center;justify-content:center;gap:' + STACKED_ITEM_GAP_PX + 'px;white-space:nowrap';
+
+    /* Visibility toggle switch geometry, used by the Location cell's owner
+       branch. A 36x20 track with a 16px knob inset 2px is the standard iOS-style
+       switch proportion: the knob travels W - knob - 2*inset = 18px, which is
+       why the "on" position is 18px from the left. Keeping these as constants
+       means the track, the knob and the travel distance can never drift apart. */
+    var VIS_SWITCH_W_PX = 36;
+    var VIS_SWITCH_H_PX = 20;
+    var VIS_KNOB_PX = 16;
+    var VIS_KNOB_INSET_PX = 2;
+    var VIS_SWITCH_RADIUS_PX = VIS_SWITCH_H_PX / 2; // fully rounded track
+    var VIS_KNOB_ON_LEFT_PX = VIS_SWITCH_W_PX - VIS_KNOB_PX - VIS_KNOB_INSET_PX;
 
     /* Prefix marking a client-side branch-switch sentinel in _upgradingHives.
        The intended target branch follows the prefix (e.g. "switch:v3") so the

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -11298,8 +11298,12 @@ const dashboardHTML = `<!DOCTYPE html>
         // title= carries the full note on hover, so it needs attribute escaping.
         bits.push('<span title="' + escAttr(u.notes) + '" style="font-size:0.7rem;color:var(--muted);font-style:italic">' + esc(preview) + '</span>');
       }
+      // align-items:flex-start + text-align:left keep the contact lines
+      // left-justified. Without them the cell inherits the users table's
+      // centred alignment, so name/slack/notes rendered ragged-centre — each
+      // line a different width, which is hard to scan down a column.
       var summary = bits.length
-        ? '<div style="display:flex;flex-direction:column;gap:1px;max-width:220px;overflow:hidden">' + bits.join('') + '</div>'
+        ? '<div style="display:flex;flex-direction:column;align-items:flex-start;text-align:left;gap:1px;max-width:220px;overflow:hidden">' + bits.join('') + '</div>'
         : '<span style="color:var(--muted);font-size:0.72rem">—</span>';
       var btn = '<button type="button" data-contact-toggle="' + escAttr(u.github_username) + '"' +
         ' style="margin-top:2px;padding:1px 7px;background:none;border:1px solid var(--border);border-radius:4px;' +
@@ -11493,7 +11497,7 @@ const dashboardHTML = `<!DOCTYPE html>
           '<td>' + nameCell + (isAdmin ? ' <span style="color:var(--accent);font-size:0.7rem">admin</span>' : '') + '</td>' +
           '<td style="font-size:0.75rem;color:var(--muted)">' + esc(fmtUserTS(u.created_at)) + '</td>' +
           '<td style="font-size:0.75rem;color:var(--muted)">' + esc(fmtUserTS(u.last_login)) + '</td>' +
-          '<td>' + renderContactCell(u) + '</td>' +
+          '<td style="text-align:left">' + renderContactCell(u) + '</td>' +
           '<td>' + blocked + '</td>' +
           '<td><input type="number" min="0" max="10" value="' + (u.saas_quota || 0) + '" style="width:50px;padding:4px;background:var(--bg);border:1px solid var(--border);border-radius:4px;color:var(--text);text-align:center" onchange="updateUser(\'' + esc(u.github_username) + '\',{saas_quota:parseInt(this.value)||0})"></td>' +
           '<td>' + (hiveCount > 0 ? '<a href="#" onclick="toggleAdminExpand(\'' + esc(u.github_username) + '\');return false" style="color:var(--blue);font-size:0.8rem">' + hiveCount + ' hive' + (hiveCount > 1 ? 's' : '') + '</a>' : '<span style="color:var(--muted)">0</span>') + '</td>' +

--- a/v2/pkg/hub/saas_dashboard_facet_tray_test.go
+++ b/v2/pkg/hub/saas_dashboard_facet_tray_test.go
@@ -340,15 +340,17 @@ func TestHiveTableColumnCountsAgree(t *testing.T) {
 		t.Errorf("header emits %d <th> cells but a row emits %d cells — "+
 			"every column right of the mismatch is shifted", thCount, tdCount)
 	}
-	const wantColumns = 17
+	// 16 since the Public column was folded into Location (visibility stacks
+	// beneath the location badge) — see the Location cell in buildRow.
+	const wantColumns = 16
 	if thCount != wantColumns {
 		t.Errorf("hive table has %d columns, want %d", thCount, wantColumns)
 	}
 	// The colspan constants span the whole table; a stale value leaves the
 	// section separators and the pending-requests row visibly short.
 	for _, decl := range []string{
-		"var TOTAL_COLUMNS = 17;",
-		"var TOTAL_COLUMNS_HEADER = 17;",
+		"var TOTAL_COLUMNS = 16;",
+		"var TOTAL_COLUMNS_HEADER = 16;",
 	} {
 		if !strings.Contains(html, decl) {
 			t.Errorf("missing or stale colspan constant: %s", decl)


### PR DESCRIPTION
Final clean top-up of mk to the current v2 tip (#2190, #2198, #2200). No conflicts. After this, `git rev-list mk..v2` = 0 and v2's tip is an ancestor of mk — mk is genuinely current.