### PR TITLE
fix(hub): harden session cookie integrity; drop hub secret from version endpoint

### DIFF
--- a/v2/pkg/hub/access2_coverage_test.go
+++ b/v2/pkg/hub/access2_coverage_test.go
@@ -14,7 +14,7 @@ import (
 func TestHandleApproveAccessFlow(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	saveSaaSUser(&SaaSUser{GitHubUsername: "owner", Hives: map[string]string{"h1": "owner"}})
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "owner"})
@@ -52,7 +52,7 @@ func TestHandleApproveAccessFlow(t *testing.T) {
 func TestHandleDenyAccessFlow(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	saveSaaSUser(&SaaSUser{GitHubUsername: "owner", Hives: map[string]string{"h1": "owner"}})
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "owner"})
@@ -69,7 +69,7 @@ func TestHandleDenyAccessFlow(t *testing.T) {
 func TestHandleAccessStatus(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "owner"})
 	mkUser(t, "viewer")

--- a/v2/pkg/hub/access_coverage_test.go
+++ b/v2/pkg/hub/access_coverage_test.go
@@ -22,7 +22,7 @@ func setPathValues(r *http.Request, kv map[string]string) *http.Request {
 func TestAccessRequestLifecycle(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	// Owner + hive.
 	saveSaaSUser(&SaaSUser{GitHubUsername: "owner", Hives: map[string]string{"h1": "owner"}})
@@ -98,7 +98,7 @@ func TestAccessRequestLifecycle(t *testing.T) {
 func TestHandleApproveRequestRoleGuard(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	// read-write approver cannot grant owner.
 	saveSaaSUser(&SaaSUser{GitHubUsername: "rw", Hives: map[string]string{"h1": "read-write"}})
@@ -116,7 +116,7 @@ func TestHandleApproveRequestRoleGuard(t *testing.T) {
 func TestHandleDenyRequest(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	saveSaaSUser(&SaaSUser{GitHubUsername: "owner", Hives: map[string]string{"h1": "owner"}})
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "owner"})
@@ -133,7 +133,7 @@ func TestHandleDenyRequest(t *testing.T) {
 func TestHandleAccessAddListRemove(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	saveSaaSUser(&SaaSUser{GitHubUsername: "owner", Hives: map[string]string{"h1": "owner"}})
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "owner"})
@@ -191,6 +191,7 @@ func TestHandleToggleAutoUpgradeSuccess(t *testing.T) {
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice"})
 
 	s := &HubServer{
+		hubSecret:        testHubSecret,
 		logger:           slog.Default(),
 		heartbeatUpgrade: make(map[string]string),
 	}

--- a/v2/pkg/hub/cluster_health_coverage_test.go
+++ b/v2/pkg/hub/cluster_health_coverage_test.go
@@ -77,6 +77,7 @@ func TestBuildClusterHealthWithScriptedKubectl(t *testing.T) {
 	clusterHealthCacheMu.Unlock()
 
 	s := &HubServer{
+		hubSecret:       testHubSecret,
 		logger:          slog.Default(),
 		clusters:        map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", InCluster: true, Name: "OKE"}},
 		heartbeatHealth: make(map[string]*HeartbeatHealthEntry),
@@ -105,8 +106,9 @@ func TestHandleUpgradeHiveSuccess(t *testing.T) {
 	mkUser(t, "alice")
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", ClusterID: "hive-oke"})
 	s := &HubServer{
-		logger:   slog.Default(),
-		clusters: map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", InCluster: true}},
+		hubSecret: testHubSecret,
+		logger:    slog.Default(),
+		clusters:  map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", InCluster: true}},
 	}
 	s.registry.Hives = []RegistryEntry{{ID: "h1", GitBranch: "v2"}}
 

--- a/v2/pkg/hub/final2_coverage_test.go
+++ b/v2/pkg/hub/final2_coverage_test.go
@@ -27,7 +27,7 @@ func TestTriggerAutoUpgradesRemoteStale(t *testing.T) {
 	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "newsha7"}
 	latestSHAMu.Unlock()
 
-	s := &HubServer{logger: slog.Default(), heartbeatUpgrade: make(map[string]string), clusters: map[string]ClusterConfig{"remote": remote}}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string), clusters: map[string]ClusterConfig{"remote": remote}}
 	s.registry.Hives = []RegistryEntry{{
 		ID: "h1", GitBranch: "v2", GitHash: "old", Upgrading: true,
 		UpgradeTarget: "oldtarget", UpgradeStartedAt: time.Now().Add(-2 * time.Hour),
@@ -42,7 +42,7 @@ func TestTriggerAutoUpgradesRemoteNotStale(t *testing.T) {
 	remote := ClusterConfig{ID: "remote", InCluster: false, KubeconfigPath: "/tmp/kc", Context: "ctx"}
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", AutoUpgrade: true, Status: "running", ClusterID: "remote"})
 
-	s := &HubServer{logger: slog.Default(), heartbeatUpgrade: make(map[string]string), clusters: map[string]ClusterConfig{"remote": remote}}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string), clusters: map[string]ClusterConfig{"remote": remote}}
 	// Upgrading, recent timestamp -> not stale -> re-arm heartbeat target.
 	s.registry.Hives = []RegistryEntry{{
 		ID: "h1", GitBranch: "v2", GitHash: "old", Upgrading: true,
@@ -68,7 +68,7 @@ func TestTriggerAutoUpgradesNoClusterSkip(t *testing.T) {
 	latestSHAMu.Unlock()
 
 	// Not upgrading, behind latest, but no cluster config -> skip branch.
-	s := &HubServer{logger: slog.Default(), heartbeatUpgrade: make(map[string]string), clusters: map[string]ClusterConfig{}}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string), clusters: map[string]ClusterConfig{}}
 	s.registry.Hives = []RegistryEntry{{ID: "h1", GitBranch: "v2", GitHash: "old"}}
 	s.triggerAutoUpgrades()
 }
@@ -109,7 +109,7 @@ func TestHandleHubOpenRouterStartOwner(t *testing.T) {
 	saveSaaSUser(&SaaSUser{GitHubUsername: "alice", Hives: map[string]string{}})
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice"})
 
-	s := &HubServer{logger: slog.Default(), pendingGateways: make(map[string]*HeartbeatGatewayConfig)}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, pendingGateways: make(map[string]*HeartbeatGatewayConfig)}
 	rec := httptest.NewRecorder()
 	req := reqWithUser(http.MethodGet, "/api/openrouter/connect/start?hive_id=h1", "", "alice")
 	s.handleHubOpenRouterStart(rec, req)

--- a/v2/pkg/hub/final3_coverage_test.go
+++ b/v2/pkg/hub/final3_coverage_test.go
@@ -62,7 +62,7 @@ func TestHandleSwitchBranchUnknownBranch(t *testing.T) {
 	})
 	resetSHACaches(t)
 
-	s := &HubServer{logger: slog.Default(), clusters: map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", InCluster: true}}}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, clusters: map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", InCluster: true}}}
 	rec := httptest.NewRecorder()
 	req := setPathValue(reqWithUser(http.MethodPost, "/sw", `{"branch":"nonexistent-branch"}`, "alice"), "id", "h1")
 	s.handleSwitchBranch(rec, req)
@@ -78,7 +78,7 @@ func TestHandleSwitchBranchUnknownBranch(t *testing.T) {
 func TestHandleDenyRequestBranches(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	// Hive not found -> 404.
 	rec := httptest.NewRecorder()
@@ -102,7 +102,7 @@ func TestHandleDenyRequestBranches(t *testing.T) {
 func TestHandleDenyAccessNotOwner(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	saveSaaSUser(&SaaSUser{GitHubUsername: "notowner", Hives: map[string]string{}})
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "someone"})
@@ -120,7 +120,7 @@ func TestHandleDenyAccessNotOwner(t *testing.T) {
 // ============================================================
 
 func TestHandleHubOpenRouterQRLongData(t *testing.T) {
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	// Valid prefix but an absurdly long payload -> QR encoder returns an error.
 	longData := "https://openrouter.ai/auth?x=" + strings.Repeat("a", 5000)
 	// Ensure the prefix matches the accepted authorize URL.

--- a/v2/pkg/hub/final4_coverage_test.go
+++ b/v2/pkg/hub/final4_coverage_test.go
@@ -13,7 +13,7 @@ import (
 // ============================================================
 
 func TestMergeLeaderboards_Cov4(t *testing.T) {
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	s.registry.Hives = []RegistryEntry{
 		{ID: "priv", IsPublic: false, Leaderboard: []LeaderboardEntry{{GitHubUsername: "hidden", TasksCompleted: 5}}},
 		{ID: "pub1", IsPublic: true, Leaderboard: []LeaderboardEntry{
@@ -56,7 +56,7 @@ func TestHandleApproveProvisionExplicitPlaceholder(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 	mkUser(t, hubAdminUsername)
-	s := &HubServer{logger: slog.Default(), saveCh: make(chan struct{}, 1), clusters: map[string]ClusterConfig{"hive-oke": *dynamicCluster()}}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, saveCh: make(chan struct{}, 1), clusters: map[string]ClusterConfig{"hive-oke": *dynamicCluster()}}
 
 	saveProvisionRequest(&ProvisionRequest{
 		Username: "bob", Org: "acme", Repos: "repo", PrimaryRepo: "repo", ACMMLevel: 2,

--- a/v2/pkg/hub/final6_coverage_test.go
+++ b/v2/pkg/hub/final6_coverage_test.go
@@ -14,7 +14,7 @@ import (
 func TestHandleHiveStatusBranches(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	// Missing hive -> 404.
 	rec := httptest.NewRecorder()
@@ -47,7 +47,7 @@ func TestHandleHiveStatusBranches(t *testing.T) {
 func TestHandleAccessAddBadBody_Cov6(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	saveSaaSUser(&SaaSUser{GitHubUsername: "owner", Hives: map[string]string{"h1": "owner"}})
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "owner"})
 
@@ -71,7 +71,7 @@ func TestHandleAccessAddBadBody_Cov6(t *testing.T) {
 func TestHandleRequestAccessAlreadyHas(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "owner"})
 	// User already has access to h1.
@@ -88,7 +88,7 @@ func TestHandleRequestAccessAlreadyHas(t *testing.T) {
 func TestHandleAccessRemoveUserNotFound(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	saveSaaSUser(&SaaSUser{GitHubUsername: "owner", Hives: map[string]string{"h1": "owner"}})
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "owner"})
 

--- a/v2/pkg/hub/hub_cookie.go
+++ b/v2/pkg/hub/hub_cookie.go
@@ -1,0 +1,74 @@
+package hub
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+)
+
+// Hub session cookie integrity.
+//
+// The `hive_hub_user` cookie carries the logged-in GitHub username that the hub
+// trusts for browser-originated API calls. Historically it stored the raw
+// username, which meant anyone could hand-craft the cookie and impersonate any
+// user — including the hub admin. To make the cookie tamper-evident it is now
+// bound to the hub secret with an HMAC:
+//
+//	value = <username>.<base64url(HMAC-SHA256(username, hubSecret))>
+//
+// The username stays in the clear (it is not a secret and callers already know
+// their own login); the appended signature is what proves the hub itself minted
+// the value. Verification recomputes the HMAC and compares in constant time, so
+// a forged or edited cookie fails closed.
+//
+// Legacy transition: existing sessions carry an UNSIGNED cookie (no "." + sig).
+// Those fail verification and are treated as logged out, so the user simply
+// re-authenticates through the normal login flow, which re-mints the new signed
+// cookie. No stored data changes and nobody is permanently locked out.
+
+// hubCookieB64 encodes the signature URL-safe and unpadded so the cookie value
+// stays within the RFC 6265 cookie-octet set.
+var hubCookieB64 = base64.RawURLEncoding
+
+// mintHubUserCookieValue returns the signed, tamper-evident cookie value for
+// username. It returns "" when no secret is configured or the username is empty
+// — callers must treat that as "cannot establish a session" rather than emitting
+// an unsigned (trusted-by-default) cookie.
+func mintHubUserCookieValue(secret, username string) string {
+	if secret == "" || username == "" {
+		return ""
+	}
+	return username + "." + hubCookieSign(secret, username)
+}
+
+// verifyHubUserCookieValue parses a cookie value, recomputes its HMAC over the
+// carried username, and constant-time-compares it against the presented
+// signature. It returns (username, true) only when the signature verifies; on a
+// legacy unsigned cookie, a forged value, or a missing secret it returns
+// ("", false) so the caller treats the request as unauthenticated.
+func verifyHubUserCookieValue(secret, value string) (string, bool) {
+	if secret == "" || value == "" {
+		return "", false
+	}
+	// SplitN from the right: usernames are validated to exclude ".", but be
+	// defensive and treat the final segment as the signature regardless.
+	idx := strings.LastIndex(value, ".")
+	if idx <= 0 || idx == len(value)-1 {
+		return "", false
+	}
+	username, sig := value[:idx], value[idx+1:]
+	expected := hubCookieSign(secret, username)
+	if !hmac.Equal([]byte(sig), []byte(expected)) {
+		return "", false
+	}
+	return username, true
+}
+
+// hubCookieSign returns the URL-safe base64 HMAC-SHA256 of username under
+// secret.
+func hubCookieSign(secret, username string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(username))
+	return hubCookieB64.EncodeToString(mac.Sum(nil))
+}

--- a/v2/pkg/hub/hub_cookie_test.go
+++ b/v2/pkg/hub/hub_cookie_test.go
@@ -1,0 +1,98 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestSignedHubCookieRoundTrip confirms a value minted by the hub verifies back
+// to the same username under the same secret.
+func TestSignedHubCookieRoundTrip(t *testing.T) {
+	const user = "octocat"
+	value := mintHubUserCookieValue(testHubSecret, user)
+	if value == "" {
+		t.Fatal("mint returned empty value")
+	}
+	if value == user {
+		t.Fatal("cookie value must not be the raw username")
+	}
+	got, ok := verifyHubUserCookieValue(testHubSecret, value)
+	if !ok || got != user {
+		t.Fatalf("verify = (%q, %v), want (%q, true)", got, ok, user)
+	}
+}
+
+// TestForgedHubCookieRejected pins the core F4 guarantee: a hand-crafted
+// (unsigned) cookie value or one signed with the wrong secret does NOT
+// authenticate. getAuthUser must return "" so the request is unauthenticated.
+func TestForgedHubCookieRejected(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, hubAdminUsername)
+
+	srv := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{"raw unsigned username (legacy/forged)", hubAdminUsername},
+		{"empty signature", hubAdminUsername + "."},
+		{"garbage signature", hubAdminUsername + ".not-a-real-hmac"},
+		{"signed with wrong secret", mintHubUserCookieValue("attacker-secret", hubAdminUsername)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/x", nil)
+			req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: tc.value})
+			if got := srv.getAuthUser(req); got != "" {
+				t.Errorf("forged cookie authenticated as %q, want unauthenticated", got)
+			}
+		})
+	}
+}
+
+// TestSignedHubCookieAuthenticates confirms a properly-signed cookie for a
+// known user does authenticate through getAuthUser.
+func TestSignedHubCookieAuthenticates(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, "alice")
+
+	srv := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+
+	req := httptest.NewRequest("GET", "/x", nil)
+	req.AddCookie(testAuthCookie("alice"))
+	if got := srv.getAuthUser(req); got != "alice" {
+		t.Errorf("getAuthUser = %q, want alice", got)
+	}
+}
+
+// TestHandleHubVersionNeverLeaksSecret confirms the version endpoint never
+// returns the hub secret, even to a request carrying a valid admin cookie.
+func TestHandleHubVersionNeverLeaksSecret(t *testing.T) {
+	srv := &HubServer{logger: slog.Default(), hubSecret: "super-secret-value"}
+
+	req := httptest.NewRequest("GET", "/api/hub/version", nil)
+	req.AddCookie(testAuthCookie(hubAdminUsername))
+	w := httptest.NewRecorder()
+	srv.handleHubVersion(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, present := resp["hub_secret"]; present {
+		t.Error("version response must never include hub_secret")
+	}
+	if got := w.Body.String(); strings.Contains(got, "super-secret-value") {
+		t.Errorf("version body leaked the raw secret: %s", got)
+	}
+}

--- a/v2/pkg/hub/hub_coverage_boost_test.go
+++ b/v2/pkg/hub/hub_coverage_boost_test.go
@@ -901,6 +901,12 @@ func TestHandleRegistryDeleteNoAdmin(t *testing.T) {
 }
 
 func TestHandleRegistryDeleteAsAdmin(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	// Admin authorization is resolved through getAuthUser, which requires a real
+	// user record and a signed session cookie.
+	ensureSaaSUser(hubAdminUsername)
+
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -912,7 +918,7 @@ func TestHandleRegistryDeleteAsAdmin(t *testing.T) {
 	mux.HandleFunc("DELETE /api/hub/registry/{id}", srv.handleRegistryDelete)
 
 	req := httptest.NewRequest("DELETE", "/api/hub/registry/delete-me", nil)
-	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: hubAdminUsername})
+	req.AddCookie(testAuthCookie(hubAdminUsername))
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
@@ -928,13 +934,17 @@ func TestHandleRegistryDeleteAsAdmin(t *testing.T) {
 }
 
 func TestHandleRegistryDeleteNotFound(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	ensureSaaSUser(hubAdminUsername)
+
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/hub/registry/{id}", srv.handleRegistryDelete)
 
 	req := httptest.NewRequest("DELETE", "/api/hub/registry/nonexistent", nil)
-	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: hubAdminUsername})
+	req.AddCookie(testAuthCookie(hubAdminUsername))
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
@@ -951,7 +961,7 @@ func TestHandleHubVersionAsAdmin(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "admin-hash", "v2")
 
 	req := httptest.NewRequest("GET", "/api/hub/version", nil)
-	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: hubAdminUsername})
+	req.AddCookie(testAuthCookie(hubAdminUsername))
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
 
@@ -962,8 +972,9 @@ func TestHandleHubVersionAsAdmin(t *testing.T) {
 	if !strings.Contains(body, "admin-hash") {
 		t.Error("should contain git hash")
 	}
-	if !strings.Contains(body, "hub_secret") {
-		t.Error("admin should see hub_secret")
+	// The hub secret must never be exposed over this endpoint, even to an admin.
+	if strings.Contains(body, "hub_secret") {
+		t.Error("version response must not include hub_secret")
 	}
 }
 

--- a/v2/pkg/hub/hub_filesystem_extra_test.go
+++ b/v2/pkg/hub/hub_filesystem_extra_test.go
@@ -613,7 +613,7 @@ func TestHandleAuthUserWithFileUser(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/auth-user", nil)
-	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "file-auth-user"})
+	req.AddCookie(testAuthCookie("file-auth-user"))
 	w := httptest.NewRecorder()
 	srv.handleAuthUser(w, req)
 
@@ -636,7 +636,7 @@ func TestHandleAuthUserAdmin(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/auth-user", nil)
-	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: hubAdminUsername})
+	req.AddCookie(testAuthCookie(hubAdminUsername))
 	w := httptest.NewRecorder()
 	srv.handleAuthUser(w, req)
 
@@ -656,7 +656,7 @@ func TestGetAuthUserWithCookieAndFile(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/test", nil)
-	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "cookie-user"})
+	req.AddCookie(testAuthCookie("cookie-user"))
 	user := srv.getAuthUser(req)
 
 	if user != "cookie-user" {

--- a/v2/pkg/hub/hub_filesystem_test.go
+++ b/v2/pkg/hub/hub_filesystem_test.go
@@ -17,6 +17,10 @@ func helperSetupTempDirs(t *testing.T) func() {
 	t.Helper()
 	dir := t.TempDir()
 
+	// Pin a known hub secret so NewHubServer signs/verifies session cookies with
+	// a value the tests can reproduce (see testHubSecret / testAuthCookie).
+	t.Setenv("HIVE_HUB_SECRET", testHubSecret)
+
 	// Async provisioning goroutines from previously-run tests read the
 	// package-level path variables swapped below; drain them first.
 	provisionWG.Wait()

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -251,10 +251,18 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 
 	s.logger.Info("audit: hub OAuth login", "user", user.Login)
 
-	// Set cookie with user info (simple JSON cookie for now)
+	// Set the session cookie to a signed, tamper-evident value so it cannot be
+	// forged. If the hub has no secret to sign with, fail the login rather than
+	// emit an unsigned (trusted-by-default) cookie.
+	cookieValue := mintHubUserCookieValue(s.hubSecret, user.Login)
+	if cookieValue == "" {
+		s.logger.Warn("OAuth: cannot mint signed session cookie", "user", user.Login)
+		http.Error(w, "session unavailable", http.StatusInternalServerError)
+		return
+	}
 	cookie := &http.Cookie{
 		Name:     "hive_hub_user",
-		Value:    user.Login,
+		Value:    cookieValue,
 		Path:     "/",
 		Domain:   ".hive.kubestellar.io",
 		MaxAge:   86400 * cookieMaxAgeDays,
@@ -288,16 +296,19 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{"authenticated":false}`))
 		return
 	}
-	if loadSaaSUser(cookie.Value) == nil {
+	// Trust the carried username only when its signature verifies; a legacy
+	// unsigned or forged cookie reports unauthenticated, prompting a re-login.
+	username, ok := verifyHubUserCookieValue(s.hubSecret, cookie.Value)
+	if !ok || loadSaaSUser(username) == nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"authenticated":false}`))
 		return
 	}
-	isAdmin := cookie.Value == hubAdminUsername
+	isAdmin := username == hubAdminUsername
 	data, err := json.Marshal(map[string]any{
 		"authenticated": true,
-		"login":         cookie.Value,
-		"avatar_url":    fmt.Sprintf("https://github.com/%s.png", cookie.Value),
+		"login":         username,
+		"avatar_url":    fmt.Sprintf("https://github.com/%s.png", username),
 		"hub_admin":     isAdmin,
 	})
 	if err != nil {

--- a/v2/pkg/hub/oauth_provision_coverage_test.go
+++ b/v2/pkg/hub/oauth_provision_coverage_test.go
@@ -76,7 +76,8 @@ func TestHandleOAuthCallbackSuccess(t *testing.T) {
 	defaultGHUserURL = usr.URL
 	defer func() { defaultGHTokenURL, defaultGHUserURL = oldTok, oldUsr }()
 
-	s := &HubServer{logger: slog.Default()}
+	// A configured secret lets the login path mint a signed session cookie.
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	rec := httptest.NewRecorder()
 	// A safe relative redirect state should be honored.
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=abc&state=%2Fmy-hives", nil)
@@ -90,6 +91,23 @@ func TestHandleOAuthCallbackSuccess(t *testing.T) {
 	// User should have been created.
 	if loadSaaSUser("octocat") == nil {
 		t.Error("expected octocat user created")
+	}
+	// The login path must re-mint the NEW signed cookie so returning users get a
+	// verifiable session (this is what lets legacy unsigned-cookie users recover).
+	var sessionCookie *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hive_hub_user" {
+			sessionCookie = c
+		}
+	}
+	if sessionCookie == nil {
+		t.Fatal("expected a hive_hub_user session cookie to be set")
+	}
+	if sessionCookie.Value == "octocat" {
+		t.Error("session cookie must be signed, not the raw username")
+	}
+	if user, ok := verifyHubUserCookieValue(testHubSecret, sessionCookie.Value); !ok || user != "octocat" {
+		t.Errorf("minted cookie did not verify: (%q, %v)", user, ok)
 	}
 }
 

--- a/v2/pkg/hub/openrouter_coverage_test.go
+++ b/v2/pkg/hub/openrouter_coverage_test.go
@@ -18,13 +18,15 @@ import (
 func newORHub() *HubServer {
 	return &HubServer{
 		logger:          slog.Default(),
+		hubSecret:       testHubSecret,
 		pendingGateways: make(map[string]*HeartbeatGatewayConfig),
 	}
 }
 
-// withCookieUser sets the hive_hub_user cookie to a user that exists on disk.
+// withCookieUser sets a signed hive_hub_user cookie for a user that exists on
+// disk.
 func withCookieUser(req *http.Request, username string) {
-	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: username})
+	req.AddCookie(testAuthCookie(username))
 }
 
 func TestPendingGatewayLifecycle(t *testing.T) {

--- a/v2/pkg/hub/provision_approve_coverage_test.go
+++ b/v2/pkg/hub/provision_approve_coverage_test.go
@@ -23,13 +23,13 @@ func TestLoadRegistry(t *testing.T) {
 	old := registryPath
 	registryPath = filepath.Join(dir, "missing.json")
 	defer func() { registryPath = old }()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	s.loadRegistry()
 
 	// Valid file -> loads hives.
 	registryPath = filepath.Join(dir, "reg.json")
 	os.WriteFile(registryPath, []byte(`{"hives":[{"id":"h1"},{"id":"h2"}]}`), 0o644)
-	s2 := &HubServer{logger: slog.Default()}
+	s2 := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	s2.loadRegistry()
 	if len(s2.registry.Hives) != 2 {
 		t.Errorf("expected 2 hives loaded, got %d", len(s2.registry.Hives))
@@ -37,7 +37,7 @@ func TestLoadRegistry(t *testing.T) {
 
 	// Bad JSON -> logged, registry left empty.
 	os.WriteFile(registryPath, []byte(`{not json`), 0o644)
-	s3 := &HubServer{logger: slog.Default()}
+	s3 := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	s3.loadRegistry()
 	if len(s3.registry.Hives) != 0 {
 		t.Errorf("bad JSON should leave registry empty, got %d", len(s3.registry.Hives))
@@ -48,7 +48,7 @@ func TestHandleApproveProvision(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 	mkUser(t, hubAdminUsername)
-	s := &HubServer{logger: slog.Default(), saveCh: make(chan struct{}, 1), clusters: map[string]ClusterConfig{"hive-oke": *dynamicCluster()}}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, saveCh: make(chan struct{}, 1), clusters: map[string]ClusterConfig{"hive-oke": *dynamicCluster()}}
 
 	// No pending request -> 404.
 	rec := httptest.NewRecorder()
@@ -86,7 +86,7 @@ func TestHandleToggleAutoUpgradeHeartbeatOnly(t *testing.T) {
 	mkUser(t, "alice")
 
 	// No SaaS record; only a registry entry (heartbeat-connected hive behind latest).
-	s := &HubServer{logger: slog.Default(), heartbeatUpgrade: make(map[string]string)}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string)}
 	s.registry.Hives = []RegistryEntry{{ID: "hb1", Owner: "alice", GitBranch: "v2", GitHash: "behind0"}}
 	resetSHACaches(t)
 	latestSHAMu.Lock()
@@ -109,7 +109,7 @@ func TestHandleToggleAutoUpgradeUnknownHive(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 	mkUser(t, "alice")
-	s := &HubServer{logger: slog.Default(), heartbeatUpgrade: make(map[string]string)}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string)}
 
 	rec := httptest.NewRecorder()
 	req := setPathValue(reqWithUser(http.MethodPut, "/au", `{"auto_upgrade":true}`, "alice"), "id", "nope")
@@ -127,7 +127,7 @@ func TestHandleMyHives(t *testing.T) {
 	saveSaaSUser(&SaaSUser{GitHubUsername: "alice", Hives: map[string]string{"h1": "owner"}})
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", Org: "acme", Status: "running"})
 
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	// A registry entry for the same hive to exercise the merge path.
 	s.registry.Hives = []RegistryEntry{{ID: "h1", Owner: "alice", Org: "acme", GitHash: "abc", Online: true}}
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -318,8 +318,14 @@ func isTrustedOrigin(raw string) bool {
 func (s *HubServer) getAuthUser(r *http.Request) string {
 	cookie, err := r.Cookie("hive_hub_user")
 	if err == nil && cookie.Value != "" {
-		if loadSaaSUser(cookie.Value) != nil {
-			return cookie.Value
+		// The cookie value is only trusted when its HMAC signature verifies
+		// against the hub secret. A legacy unsigned cookie or a forged value
+		// fails here and is treated as logged out, so the user re-authenticates
+		// through the normal login flow (which re-mints a signed cookie).
+		if username, ok := verifyHubUserCookieValue(s.hubSecret, cookie.Value); ok {
+			if loadSaaSUser(username) != nil {
+				return username
+			}
 		}
 	}
 

--- a/v2/pkg/hub/saas_bulk_test.go
+++ b/v2/pkg/hub/saas_bulk_test.go
@@ -51,7 +51,7 @@ func bulkPost(t *testing.T, srv *HubServer, user string, body any) (*httptest.Re
 	req := httptest.NewRequest("POST", "/api/saas/hives/bulk", bytes.NewReader(raw))
 	req.Header.Set("Content-Type", "application/json")
 	if user != "" {
-		req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: user})
+		req.AddCookie(testAuthCookie(user))
 	}
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)

--- a/v2/pkg/hub/saas_edge_coverage_test.go
+++ b/v2/pkg/hub/saas_edge_coverage_test.go
@@ -15,6 +15,7 @@ import (
 // nil and the "no cluster config" error branches run.
 func noClusterHub() *HubServer {
 	return &HubServer{
+		hubSecret:          testHubSecret,
 		logger:             slog.Default(),
 		saveCh:             make(chan struct{}, 1),
 		heartbeatUpgrade:   make(map[string]string),
@@ -45,7 +46,7 @@ func TestHandleUpgradeHiveRegistryUpdate(t *testing.T) {
 	mkUser(t, "alice")
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", ClusterID: "hive-oke"})
 
-	s := &HubServer{logger: slog.Default(), clusters: map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", InCluster: true}}}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, clusters: map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", InCluster: true}}}
 	// A matching registry entry so the post-upgrade registry-update loop runs.
 	s.registry.Hives = []RegistryEntry{{ID: "h1", GitBranch: "v2"}}
 	resetSHACaches(t)
@@ -94,6 +95,7 @@ func TestHandleHubAutoUpgradeSuccess(t *testing.T) {
 	latestSHAMu.Unlock()
 
 	s := &HubServer{
+		hubSecret:  testHubSecret,
 		logger:     slog.Default(),
 		hubGitHash: "oldhubsha",
 		clusters:   map[string]ClusterConfig{defaultClusterID: {ID: defaultClusterID, InCluster: true}},
@@ -127,7 +129,7 @@ func TestHandleHubSelfUpgrade_Edge(t *testing.T) {
 	t.Cleanup(func() { hubImageExists = oldImgCheck })
 
 	// Failure path: fail-fast fake kubectl (exit 1) -> 500.
-	s := &HubServer{logger: slog.Default(), hubGitBranch: "v2", clusters: map[string]ClusterConfig{defaultClusterID: {ID: defaultClusterID, InCluster: true}}}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, hubGitBranch: "v2", clusters: map[string]ClusterConfig{defaultClusterID: {ID: defaultClusterID, InCluster: true}}}
 	rec := httptest.NewRecorder()
 	req := reqWithUser(http.MethodPost, "/hub-self", "", "admin")
 	s.handleHubSelfUpgrade(rec, req)
@@ -162,6 +164,7 @@ func TestHandleClusterHealthBuildError(t *testing.T) {
 	clusterHealthCacheMu.Unlock()
 
 	s := &HubServer{
+		hubSecret:       testHubSecret,
 		logger:          slog.Default(),
 		clusters:        map[string]ClusterConfig{},
 		heartbeatHealth: make(map[string]*HeartbeatHealthEntry),

--- a/v2/pkg/hub/saas_handlers2_coverage_test.go
+++ b/v2/pkg/hub/saas_handlers2_coverage_test.go
@@ -14,6 +14,7 @@ import (
 
 func newHandlerHub2() *HubServer {
 	return &HubServer{
+		hubSecret:               testHubSecret,
 		logger:                  slog.Default(),
 		saveCh:                  make(chan struct{}, 1),
 		hubBanners:              make(map[string]*HubBannerEntry),

--- a/v2/pkg/hub/saas_handlers_coverage_test.go
+++ b/v2/pkg/hub/saas_handlers_coverage_test.go
@@ -16,6 +16,20 @@ import (
 // kubectl, exercising the request-handling body without a real cluster.
 // ============================================================
 
+// testHubSecret is the shared hub secret every test signs its session cookie
+// with. Tests that build a HubServer relying on cookie auth set
+// hubSecret: testHubSecret (or arrange for NewHubServer to load it via
+// HIVE_HUB_SECRET, e.g. through helperSetupTempDirs) so the signature the
+// server recomputes matches the one baked into the cookie.
+const testHubSecret = "test-hub-secret-f4"
+
+// testAuthCookie mints a signed hive_hub_user cookie for username using
+// testHubSecret, matching the production cookie format so getAuthUser /
+// handleAuthUser accept it.
+func testAuthCookie(username string) *http.Cookie {
+	return &http.Cookie{Name: "hive_hub_user", Value: mintHubUserCookieValue(testHubSecret, username)}
+}
+
 // mkUser writes a SaaS user to the temp dir so getAuthUser resolves the cookie.
 func mkUser(t *testing.T, username string) {
 	t.Helper()
@@ -32,7 +46,7 @@ func reqWithUser(method, target, body, username string) *http.Request {
 	} else {
 		r = httptest.NewRequest(method, target, nil)
 	}
-	r.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: username})
+	r.AddCookie(testAuthCookie(username))
 	return r
 }
 
@@ -45,6 +59,7 @@ func setPathValue(r *http.Request, key, val string) *http.Request {
 func newHandlerHub() *HubServer {
 	return &HubServer{
 		logger:             slog.Default(),
+		hubSecret:          testHubSecret,
 		hubBanners:         make(map[string]*HubBannerEntry),
 		heartbeatSwitchTag: make(map[string]string),
 		heartbeatUpgrade:   make(map[string]string),
@@ -105,7 +120,9 @@ func TestHandleOpenHive(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 	s := newHandlerHub()
-	s.hubSecret = "test-secret"
+	// newHandlerHub already sets hubSecret to testHubSecret, which is what
+	// reqWithUser signs its session cookie with — keep them in sync so the
+	// authenticated open paths below verify.
 
 	// Invalid id.
 	rec := httptest.NewRecorder()

--- a/v2/pkg/hub/saas_user_contact_test.go
+++ b/v2/pkg/hub/saas_user_contact_test.go
@@ -24,7 +24,7 @@ func contactPutRequest(username, body, asUser string) *http.Request {
 	req := httptest.NewRequest("PUT", "/api/saas/admin/users/"+username, strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	if asUser != "" {
-		req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: asUser})
+		req.AddCookie(testAuthCookie(asUser))
 	}
 	return req
 }

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1348,8 +1348,7 @@ func (s *HubServer) removeRegistryEntry(id, by string) {
 }
 
 func (s *HubServer) handleRegistryDelete(w http.ResponseWriter, r *http.Request) {
-	cookie, err := r.Cookie("hive_hub_user")
-	if err != nil || cookie.Value != hubAdminUsername {
+	if s.getAuthUser(r) != hubAdminUsername {
 		http.Error(w, "admin access required", http.StatusForbidden)
 		return
 	}
@@ -1366,23 +1365,21 @@ func (s *HubServer) handleRegistryDelete(w http.ResponseWriter, r *http.Request)
 	s.mu.Unlock()
 	if removed {
 		s.requestSave()
-		s.logger.Info("audit: admin removed registry entry", "id", id, "admin", cookie.Value)
+		s.logger.Info("audit: admin removed registry entry", "id", id, "admin", hubAdminUsername)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"removed": removed, "id": id})
 }
 
 func (s *HubServer) handleHubVersion(w http.ResponseWriter, r *http.Request) {
+	// The hub secret is never returned from this browser-reachable endpoint; the
+	// raw shared secret has no legitimate consumer over HTTP.
 	resp := map[string]any{
 		"git_hash":      s.hubGitHash,
 		"git_branch":    s.hubGitBranch,
 		"latest_sha":    getLatestSHA(),
 		"latest_shas":   getLatestSHAs(),
 		"upgrade_state": s.hubUpgradeState(),
-	}
-	cookie, _ := r.Cookie("hive_hub_user")
-	if cookie != nil && cookie.Value == hubAdminUsername {
-		resp["hub_secret"] = s.hubSecret
 	}
 	data, _ := json.Marshal(resp)
 	w.Header().Set("Content-Type", "application/json")

--- a/v2/pkg/hub/small_gaps_coverage_test.go
+++ b/v2/pkg/hub/small_gaps_coverage_test.go
@@ -148,7 +148,7 @@ func TestVerifySSOTokenBranches(t *testing.T) {
 func TestHandleAuthUserAndLogout(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	// No cookie -> not authenticated.
 	rec := httptest.NewRecorder()
@@ -162,7 +162,7 @@ func TestHandleAuthUserAndLogout(t *testing.T) {
 	mkUser(t, "octocat")
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/auth/user", nil)
-	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "octocat"})
+	req.AddCookie(testAuthCookie("octocat"))
 	s.handleAuthUser(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Errorf("auth user status = %d, want 200", rec.Code)

--- a/v2/pkg/hub/timeline_test.go
+++ b/v2/pkg/hub/timeline_test.go
@@ -539,8 +539,9 @@ func TestHandleHiveTimelineAuthorization(t *testing.T) {
 	}
 
 	s := &HubServer{
-		logger:   slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
-		timeline: newTimelineStore(),
+		logger:    slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		hubSecret: testHubSecret,
+		timeline:  newTimelineStore(),
 	}
 	s.timeline.append(hiveID, TimelineRestarted, "process restarted", "")
 
@@ -563,7 +564,7 @@ func TestHandleHiveTimelineAuthorization(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/api/saas/hives/"+tc.hiveID+"/timeline", nil)
 			req.SetPathValue("id", tc.hiveID)
 			if tc.user != "" {
-				req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: tc.user})
+				req.AddCookie(testAuthCookie(tc.user))
 			}
 			rec := httptest.NewRecorder()
 			s.handleHiveTimeline(rec, req)
@@ -598,8 +599,9 @@ func TestRecordHeartbeatTransitionsNilStore(t *testing.T) {
 
 func TestMarkStaleHivesReportsOfflineOnce(t *testing.T) {
 	s := &HubServer{
-		logger:   slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
-		timeline: newTimelineStore(),
+		logger:    slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		hubSecret: testHubSecret,
+		timeline:  newTimelineStore(),
 	}
 	stale := time.Now().Add(-maxHeartbeatAge - time.Minute).UTC().Format(time.RFC3339)
 	s.registry.Hives = []RegistryEntry{

--- a/v2/pkg/hub/upgrade_schedule_test.go
+++ b/v2/pkg/hub/upgrade_schedule_test.go
@@ -308,7 +308,7 @@ func TestHandleToggleAutoUpgradeModePersistence(t *testing.T) {
 			defer cleanup()
 			mkUser(t, "alice")
 			saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice"})
-			s := &HubServer{logger: slog.Default(), heartbeatUpgrade: make(map[string]string)}
+			s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string)}
 
 			rec := httptest.NewRecorder()
 			req := setPathValue(reqWithUser(http.MethodPut, "/au", tc.body, "alice"), "id", "h1")
@@ -351,7 +351,7 @@ func TestHandleToggleAutoUpgradeClearsLastFired(t *testing.T) {
 		AutoUpgradeMode:      AutoUpgradeModeDaily,
 		AutoUpgradeLastFired: "2026-07-15",
 	})
-	s := &HubServer{logger: slog.Default(), heartbeatUpgrade: make(map[string]string)}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string)}
 
 	rec := httptest.NewRecorder()
 	req := setPathValue(reqWithUser(http.MethodPut,
@@ -385,7 +385,7 @@ func TestManualUpgradeUnaffectedByMode(t *testing.T) {
 		AutoUpgrade:     true,
 		AutoUpgradeMode: AutoUpgradeModeDaily,
 	})
-	s := &HubServer{logger: slog.Default(), heartbeatUpgrade: make(map[string]string)}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string)}
 
 	rec := httptest.NewRecorder()
 	req := setPathValue(reqWithUser(http.MethodPost, "/upgrade", `{}`, "alice"), "id", "h1")


### PR DESCRIPTION
Hardens the hub's session cookie and removes a secret from the version endpoint.

- The `hive_hub_user` session cookie is now HMAC-signed (`<username>.<base64url(HMAC-SHA256(username, hubSecret))>`) and verified with a constant-time compare before the username is trusted. Identity resolution (`getAuthUser`, `handleAuthUser`, admin checks) goes through verification.
- `/api/hub/version` no longer returns the hub secret (no other consumer found).

**No lockout:** existing unsigned cookies are treated as logged-out; users re-authenticate via the normal GitHub login, which mints the new signed cookie. No stored data changes. Verified the login path re-mints a verifiable cookie.

Tests: new `hub_cookie_test.go` (forged/unsigned/wrong-secret rejected; signed accepted; version endpoint clean) + existing auth/cookie/version/oauth tests updated to mint signed cookies — focused gate green. Two unrelated `health_check_detail_test.go` failures are pre-existing on origin/v2 (verified against a clean checkout), not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)