### PR TITLE
chore: mk sync tip (#2202, #2206)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -504,6 +504,23 @@ func main() {
 		PolicyDir:  policyDir,
 	}
 	agentMgr := agent.NewManager(cfg.EnabledAgents(), logger, projectCtx)
+	// Resolve the bob API key at LAUNCH time, not here: cfg is the live config
+	// pointer (the config watcher swaps its contents in place on reload), so a
+	// key added via the Secret mount, the PVC file, or a config edit takes
+	// effect on the next agent launch with no hive restart. Only the key's
+	// LOCATION is ever in cfg; the value is read from file/env on each call and
+	// is never logged.
+	agentMgr.SetBobAPIKeyResolver(func() string {
+		return cfg.Governor.Bob.ResolveAPIKey()
+	})
+	// Log only WHERE the key came from (or that none is set) so a misconfigured
+	// hive is diagnosable without the value ever reaching the logs.
+	if src := cfg.Governor.Bob.ResolveAPIKeySource(); src != "" {
+		logger.Info("bob api key detected", "source", src)
+	} else {
+		logger.Info("no bob api key configured; agents with backend \"bob\" will not launch",
+			"remedy", "set governor.bob.api_key_file or the "+config.DefaultBobAPIKeyEnv+" env var")
+	}
 	if appAuth != nil {
 		agentMgr.SetAppAuth(appAuth)
 		go agentMgr.StartAgentTokenRefresh(ctx)

--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -226,6 +226,16 @@ if [ "$(id -u)" = "0" ]; then
   # a different UID with mode 600, making them unreadable by dev/UID 1001)
   chown dev:node /secrets/*.pem 2>/dev/null || true
   chmod 644 /secrets/*.pem 2>/dev/null || true
+  # API-key files are not .pem, so they need the same treatment. Without this
+  # a host-side mode-600 file owned by a foreign UID reads as EACCES from the
+  # Go binary (uid 1001), and every key-file read swallows the error — the key
+  # silently resolves to "" and the backend looks unconfigured. Mode 400:
+  # owner-read only (stricter than the .pem files, which ttyd/git also read).
+  for key_file in /secrets/bob_api_key /secrets/litellm_api_key; do
+    [ -f "$key_file" ] || continue
+    chown dev:node "$key_file" 2>/dev/null || true
+    chmod 400 "$key_file" 2>/dev/null || true
+  done
 
   # Copy read-only mounted secrets so dev user can read them
   if [ -f /etc/hive/gh-app-key.pem ]; then

--- a/v2/deploy/k8s/secret.yaml
+++ b/v2/deploy/k8s/secret.yaml
@@ -18,3 +18,10 @@ stringData:
 
   # Dashboard auth token (for mutation endpoints via proxy)
   # HIVE_DASHBOARD_TOKEN: your-dashboard-token-here
+
+  # IBM bobshell API key — REQUIRED for agents with backend "bob".
+  # bob's default auth opens a browser and polls a localhost callback, which
+  # cannot work in a pod, so without a key those agents refuse to launch.
+  # This surfaces at /secrets/bob_api_key (the default api_key_file path), so
+  # no hive.yaml change is needed. Never put the key value in hive.yaml.
+  # bob_api_key: your-bobshell-api-key-here

--- a/v2/hive.yaml.example
+++ b/v2/hive.yaml.example
@@ -178,6 +178,18 @@ governor:
   #   local_proxy: false                      # run the bundled litellm binary locally
   #                                           # (config at /data/litellm/config.yaml)
 
+  # IBM bobshell ("bob") backend credentials. REQUIRED for agents with
+  # backend: bob — bob's default IBMid/W3ID auth opens a browser and waits on a
+  # localhost callback, which no pod can satisfy, so it fails after a 3-minute
+  # timeout. With a key, hive launches bob with --auth-method api-key and it
+  # authenticates headlessly (interactive tmux use still works).
+  # SECURITY: store only the env var NAME or a key file path, never the value.
+  # Both defaults below are consulted automatically, so if you mount the key at
+  # /secrets/bob_api_key or set HIVE_BOB_API_KEY, this block can stay commented.
+  # bob:
+  #   api_key_env: HIVE_BOB_API_KEY       # env var NAME holding the key (default)
+  #   api_key_file: /secrets/bob_api_key  # or a mounted key file (default path)
+
 # GitHub authentication — use ONE of these methods
 github:
   # Option 1: Personal access token (simplest)

--- a/v2/pkg/agent/bob_test.go
+++ b/v2/pkg/agent/bob_test.go
@@ -1,0 +1,344 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// TestWatchedHomeDirsIncludesBob pins the fix for bob's startup failure:
+//
+//	EACCES: permission denied, mkdir '/data/home/.bob'
+//
+// bob derives its state dir as path.join(os.homedir(), ".bob") and agents run
+// with HOME=/data/home, which is root-created — so the watcher must own it.
+func TestWatchedHomeDirsIncludesBob(t *testing.T) {
+	const bobStateDir = "/data/home/.bob"
+	for _, dir := range WatchedHomeDirs {
+		if dir == bobStateDir {
+			return
+		}
+	}
+	t.Fatalf("WatchedHomeDirs must contain %q so bob can create its state dir; got %v",
+		bobStateDir, WatchedHomeDirs)
+}
+
+// TestPermissionsWatcher_BobNestedTree covers the nested case explicitly: bob
+// writes .bob/tmp/<uuid>/chats, so a fix that only handled the top level would
+// leave the chat-recording service broken. ensureWatchedDirs must create the
+// root, and fixPermissions must walk (and correct) arbitrarily deep children.
+func TestPermissionsWatcher_BobNestedTree(t *testing.T) {
+	tests := []struct {
+		name string
+		// nested is created before the watcher runs, relative to the .bob root.
+		nested string
+		// file, when set, is created inside nested with restrictive perms.
+		file string
+	}{
+		{name: "top level only", nested: ""},
+		{name: "tmp subdir", nested: "tmp"},
+		{name: "chats tree", nested: filepath.Join("tmp", "abc-123", "chats")},
+		{name: "chats tree with file", nested: filepath.Join("tmp", "def-456", "chats"), file: "session.json"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			bobRoot := filepath.Join(dir, ".bob")
+
+			target := bobRoot
+			if tc.nested != "" {
+				target = filepath.Join(bobRoot, tc.nested)
+			}
+			// 0o700 is what bob's mkdirSync default would leave behind: unusable
+			// by other agent UIDs in the shared node group.
+			if err := os.MkdirAll(target, 0o700); err != nil {
+				t.Fatal(err)
+			}
+			if tc.file != "" {
+				if err := os.WriteFile(filepath.Join(target, tc.file), []byte("{}"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			origW, origG := WatchedHomeDirs, GooseLogsDir
+			WatchedHomeDirs = []string{bobRoot}
+			GooseLogsDir = filepath.Join(dir, "goose", "logs")
+			t.Cleanup(func() { WatchedHomeDirs = origW; GooseLogsDir = origG })
+
+			// Record every path the walk should visit, so we can assert the walk
+			// actually reaches the full depth of bob's tree.
+			var walked []string
+			if err := filepath.Walk(bobRoot, func(p string, fi os.FileInfo, err error) error {
+				if err == nil {
+					walked = append(walked, p)
+				}
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+
+			ensureWatchedDirs(discardLogger())
+			fixPermissions(discardLogger())
+
+			// The root must exist: ensureWatchedDirs creates it (MkdirAll) with
+			// group bits, which is what fixes bob's "EACCES: mkdir '/data/home/.bob'".
+			info, err := os.Stat(bobRoot)
+			if err != nil {
+				t.Fatalf("bob state dir should exist: %v", err)
+			}
+			if !info.IsDir() {
+				t.Fatal("bob state dir should be a directory")
+			}
+
+			// fixPermissions must WALK the whole nested tree, not just the root.
+			// This is the property that makes .bob/tmp/<uuid>/chats recoverable:
+			// anything created root-owned underneath is chowned on the next tick.
+			//
+			// The mode assertions that would normally follow are deliberately
+			// omitted: fixEntry only chmods entries owned by DevUID (1001) — see
+			// the "Only fix permissions on files we own or just chowned" guard —
+			// and an unprivileged test process owns these files as its own UID,
+			// so production behavior here is correctly a no-op. Asserting modes
+			// would require running as uid 1001 or as root.
+			if tc.nested != "" {
+				if _, err := os.Stat(target); err != nil {
+					t.Fatalf("nested dir %q should exist: %v", tc.nested, err)
+				}
+				wantDepth := len(strings.Split(tc.nested, string(filepath.Separator)))
+				// root + one entry per nested level (+1 more when a file exists).
+				minWalked := 1 + wantDepth
+				if tc.file != "" {
+					minWalked++
+				}
+				if len(walked) < minWalked {
+					t.Errorf("walk visited %d paths (%v), want at least %d — the nested "+
+						"tree must be traversed, not just the root", len(walked), walked, minWalked)
+				}
+			}
+			if tc.file != "" {
+				if _, err := os.Stat(filepath.Join(target, tc.file)); err != nil {
+					t.Fatalf("nested file should exist: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestBobAPIKeyResolver covers the resolver seam: absent when never injected,
+// absent when the resolver reports no key, present when it does.
+func TestBobAPIKeyResolver(t *testing.T) {
+	tests := []struct {
+		name     string
+		inject   bool
+		resolver func() string
+		want     string
+	}{
+		{name: "no resolver injected", inject: false, want: ""},
+		{name: "nil resolver injected", inject: true, resolver: nil, want: ""},
+		{name: "resolver returns empty", inject: true, resolver: func() string { return "" }, want: ""},
+		{name: "resolver returns key", inject: true, resolver: func() string { return "bob-key-abc" }, want: "bob-key-abc"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Manager{logger: discardLogger()}
+			if tc.inject {
+				m.SetBobAPIKeyResolver(tc.resolver)
+			}
+			if got := m.bobAPIKey(); got != tc.want {
+				t.Errorf("bobAPIKey() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBobEnvPairInjection verifies the key is plumbed into the agent env under
+// the name bob actually reads, marked Secret so it never reaches the command
+// line, and is confined to the bob backend.
+func TestBobEnvPairInjection(t *testing.T) {
+	tests := []struct {
+		name       string
+		backend    string
+		key        string
+		wantPair   bool
+		wantSecret bool
+	}{
+		{name: "bob with key", backend: "bob", key: "bob-key-abc", wantPair: true, wantSecret: true},
+		{name: "bob without key", backend: "bob", key: "", wantPair: false},
+		{name: "claude never gets bob key", backend: "claude", key: "bob-key-abc", wantPair: false},
+		{name: "copilot never gets bob key", backend: "copilot", key: "bob-key-abc", wantPair: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Manager{logger: discardLogger()}
+			key := tc.key
+			m.SetBobAPIKeyResolver(func() string { return key })
+
+			agent := &AgentProcess{
+				Name:   "tester",
+				Config: config.AgentConfig{Backend: tc.backend},
+			}
+
+			var found *agentEnvPair
+			for _, p := range m.agentEnvPairs(agent) {
+				if p.Key == config.BobAPIKeyEnvVar {
+					pair := p
+					found = &pair
+				}
+			}
+
+			if tc.wantPair != (found != nil) {
+				t.Fatalf("%s pair present = %v, want %v", config.BobAPIKeyEnvVar, found != nil, tc.wantPair)
+			}
+			if found == nil {
+				return
+			}
+			if found.Value != tc.key {
+				t.Errorf("pair value = %q, want %q", found.Value, tc.key)
+			}
+			if found.Secret != tc.wantSecret {
+				t.Errorf("pair Secret = %v, want %v (a key must never reach the command line)",
+					found.Secret, tc.wantSecret)
+			}
+		})
+	}
+}
+
+// TestBobKeyNotInEnvPrefix is the regression guard for leaking the key onto the
+// shell command line, where it would show up in `ps` and pane scrollback.
+func TestBobKeyNotInEnvPrefix(t *testing.T) {
+	const secretKey = "bob-key-must-not-leak"
+	m := &Manager{logger: discardLogger()}
+	m.SetBobAPIKeyResolver(func() string { return secretKey })
+
+	agent := &AgentProcess{
+		Name:   "tester",
+		Config: config.AgentConfig{Backend: "bob"},
+	}
+	prefix := m.buildEnvPrefix(agent)
+	if strings.Contains(prefix, secretKey) {
+		t.Errorf("env prefix must not contain the API key value; got %q", prefix)
+	}
+	if strings.Contains(prefix, config.BobAPIKeyEnvVar) {
+		t.Errorf("env prefix must not mention %s at all; got %q", config.BobAPIKeyEnvVar, prefix)
+	}
+}
+
+// TestBobLaunchCmd pins the flags that make headless auth work while keeping
+// the session interactive.
+func TestBobLaunchCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		model       string
+		wantContain []string
+		wantAbsent  []string
+	}{
+		{
+			name:  "no model",
+			model: "",
+			// --auth-method api-key is what stops bob choosing the browser SSO
+			// flow in interactive mode; --accept-license clears the license gate
+			// that would otherwise hard-error with no human to answer it.
+			wantContain: []string{"bob", "--auth-method api-key", "--accept-license"},
+			// No -p/--prompt: interactive mode must be preserved.
+			wantAbsent: []string{"--model", " -p ", "--prompt"},
+		},
+		{
+			name:        "with model",
+			model:       "granite-3",
+			wantContain: []string{"--auth-method api-key", "--accept-license", "--model granite-3"},
+			wantAbsent:  []string{" -p ", "--prompt"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := bobLaunchCmd("bob", tc.model)
+			for _, want := range tc.wantContain {
+				if !strings.Contains(got, want) {
+					t.Errorf("bobLaunchCmd(...) = %q, want it to contain %q", got, want)
+				}
+			}
+			for _, absent := range tc.wantAbsent {
+				if strings.Contains(got, absent) {
+					t.Errorf("bobLaunchCmd(...) = %q, want it NOT to contain %q", got, absent)
+				}
+			}
+		})
+	}
+}
+
+// TestBobLaunchRefusedWithoutKey verifies the fail-fast: with no key
+// configured, launchInTmux must mark the agent failed and return rather than
+// starting bob, which would otherwise hang for 3 minutes on a browser flow
+// that cannot complete in a pod.
+func TestBobLaunchRefusedWithoutKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       string
+		wantState ProcessState
+	}{
+		{name: "no key refuses launch", key: "", wantState: StateFailed},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := os.Stat("/usr/local/bin/bob"); err == nil {
+				t.Skip("bob binary present; this test covers the no-key path only")
+			}
+			m := &Manager{logger: discardLogger()}
+			key := tc.key
+			m.SetBobAPIKeyResolver(func() string { return key })
+
+			agent := &AgentProcess{
+				Name:   "tester",
+				Config: config.AgentConfig{Backend: "bob"},
+			}
+			// launchInTmux returns nil for both the missing-binary and missing-key
+			// paths (one bad agent must never abort the fleet); StateFailed is the
+			// observable signal in either case.
+			if err := m.launchInTmux(t.Context(), agent); err != nil {
+				t.Fatalf("launchInTmux should return nil, got %v", err)
+			}
+			if agent.State != tc.wantState {
+				t.Errorf("agent.State = %v, want %v", agent.State, tc.wantState)
+			}
+			if agent.HasLaunched {
+				t.Error("agent must not be marked launched when auth cannot succeed")
+			}
+		})
+	}
+}
+
+// TestBobBackendAuthAvailable verifies the dashboard sees honest auth state for
+// bob (previously "unknown", like every non-claude/copilot backend).
+func TestBobBackendAuthAvailable(t *testing.T) {
+	tests := []struct {
+		name          string
+		key           string
+		wantAvailable bool
+		wantKnown     bool
+	}{
+		{name: "key configured", key: "bob-key-abc", wantAvailable: true, wantKnown: true},
+		{name: "no key configured", key: "", wantAvailable: false, wantKnown: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Manager{logger: discardLogger()}
+			key := tc.key
+			m.SetBobAPIKeyResolver(func() string { return key })
+
+			available, known := m.BackendAuthAvailable("bob")
+			if available != tc.wantAvailable || known != tc.wantKnown {
+				t.Errorf("BackendAuthAvailable(bob) = (%v, %v), want (%v, %v)",
+					available, known, tc.wantAvailable, tc.wantKnown)
+			}
+		})
+	}
+}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -124,6 +124,17 @@ type Manager struct {
 	uidMap           *UIDMap
 	appAuth          AppTokenMinter
 
+	// bobAPIKeyResolver resolves the IBM bobshell API key at LAUNCH time (not
+	// boot), so a key an operator adds via a Secret/PVC file or the config UI
+	// takes effect without restarting the hive. Returns "" when unconfigured.
+	//
+	// Stored as an atomic.Pointer, NOT under m.mu, for the same reason as
+	// isGatewayBackend above: it is read from launchInTmux/agentEnvPairs, which
+	// already hold m.mu.Lock(). Re-locking a non-reentrant RWMutex on the same
+	// goroutine would deadlock startup before MarkReady and crash-loop every
+	// spoke. An atomic read is lock-free and safe from any lock context.
+	bobAPIKeyResolver atomic.Pointer[func() string]
+
 	inferenceRouteCallback      func(agentName, backend, model string)
 	clearInferenceRouteCallback func(agentName string)
 
@@ -241,6 +252,10 @@ func (m *Manager) BackendAuthAvailable(backend string) (available, known bool) {
 			return true, true
 		}
 		return configHasTokens(), true
+	case bobBackend:
+		// bob has exactly one usable credential in a pod: the API key. Its
+		// presence is therefore a complete answer, so report it as known.
+		return m.bobAPIKey() != "", true
 	default:
 		return false, false
 	}
@@ -266,6 +281,27 @@ func (m *Manager) SetGatewayBackendChecker(fn func(backend string) bool) {
 	// Atomic store — no m.mu — so routableBackend can read it lock-free from the
 	// lock-holding launch path without deadlocking (see isGatewayBackend docs).
 	m.isGatewayBackend.Store(&fn)
+}
+
+// SetBobAPIKeyResolver injects the resolver for the IBM bobshell API key.
+// Called from main.go with a closure over the live config, so a key added
+// after boot is picked up on the next agent launch. The resolver must return
+// the key VALUE or "" — the value is never logged.
+func (m *Manager) SetBobAPIKeyResolver(fn func() string) {
+	// Atomic store — no m.mu — so bobAPIKey can be read lock-free from the
+	// lock-holding launch path (see bobAPIKeyResolver docs).
+	m.bobAPIKeyResolver.Store(&fn)
+}
+
+// bobAPIKey returns the configured bobshell API key, or "" when none is
+// configured (or no resolver was injected, as in tests/bare setups).
+// Safe to call while holding m.mu.
+func (m *Manager) bobAPIKey() string {
+	fnp := m.bobAPIKeyResolver.Load()
+	if fnp == nil || *fnp == nil {
+		return ""
+	}
+	return (*fnp)()
 }
 
 // routableBackend reports whether a backend should be routed through the
@@ -714,6 +750,27 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		return nil
 	}
 
+	// bob cannot authenticate without an API key in a pod: its default W3ID SSO
+	// flow opens a browser and polls a localhost callback port, then fails with
+	// "Authentication timeout (3 minutes)". Refuse to launch instead of burning
+	// three minutes per attempt on a flow that cannot succeed here. Mirrors the
+	// missing-binary handling above: mark the agent failed, log actionably, and
+	// return nil so one misconfigured agent never aborts the fleet.
+	// The key VALUE is not bound to a local here — only its presence is checked.
+	// It is delivered to the CLI via tmux set-environment in agentEnvPairs.
+	if backend == bobBackend {
+		if m.bobAPIKey() == "" {
+			agent.State = StateFailed
+			m.logger.Warn("bob requires "+config.BobAPIKeyEnvVar+" for headless operation; ask your hub admin to configure it",
+				"name", agent.Name,
+				"backend", backend,
+				"remedy", "set governor.bob.api_key_file (e.g. "+config.DefaultBobAPIKeyFile+
+					") or the "+config.DefaultBobAPIKeyEnv+" env var on the hive pod",
+			)
+			return nil
+		}
+	}
+
 	launchCmd := binary
 	model := agent.Config.Model
 	if agent.ModelOverride != "" {
@@ -816,8 +873,8 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 			if model != "" {
 				launchCmd = fmt.Sprintf("%s --model %s", launchCmd, model)
 			}
-		case "bob":
-			launchCmd = binary
+		case bobBackend:
+			launchCmd = bobLaunchCmd(binary, model)
 		default:
 			launchCmd = binary
 		}
@@ -927,6 +984,17 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	}
 
 	m.fixSharedConfigPerms(agent)
+
+	// Re-apply SECRET env vars before every launch. ensureTmuxSession sets the
+	// full env via tmux set-environment, but it returns early when the session
+	// already exists, so on a relaunch (restart, model change, crash recovery)
+	// those values are never refreshed. Non-secret vars survive that because
+	// buildEnvPrefix re-types them on the command line each launch, and
+	// COPILOT_GITHUB_TOKEN survives because it is also in the hive process env
+	// and inherited — but a key resolved from a Secret/PVC FILE is in neither,
+	// so without this it would reach the CLI on a session's first launch only.
+	// set-environment is idempotent and never appears in the pane.
+	m.applySecretEnv(agent)
 
 	envCmd := m.buildEnvPrefix(agent)
 	fullCmd := envCmd + launchCmd
@@ -1418,6 +1486,23 @@ func (m *Manager) readCoveragePreamble() string {
 func shellEnvVar(key, value string) string {
 	quoted := strings.ReplaceAll(value, "'", "'\"'\"'")
 	return fmt.Sprintf("%s='%s'", key, quoted)
+}
+
+// applySecretEnv pushes only the Secret pairs into the agent's tmux session via
+// set-environment. Values are passed as exec args (never through a shell), so
+// they are not word-split and never land in the pane or in bash history.
+// Failures are ignored for the same reason ensureTmuxSession ignores them: a
+// missing session is handled by the launch path, not here.
+func (m *Manager) applySecretEnv(agent *AgentProcess) {
+	if agent == nil || agent.tmuxSession == "" {
+		return
+	}
+	for _, p := range m.agentEnvPairs(agent) {
+		if !p.Secret {
+			continue
+		}
+		_ = m.tmuxCmd(agent, "set-environment", "-t", agent.tmuxSession, p.Key, p.Value).Run()
+	}
 }
 
 func (m *Manager) buildEnvPrefix(agent *AgentProcess) string {
@@ -3227,6 +3312,51 @@ func inferenceHomePath(agentName string) string {
 // codexBackend is the backend name for the OpenAI Codex CLI.
 const codexBackend = "codex"
 
+// bobBackend is the backend name for the IBM bobshell ("bob") CLI.
+const bobBackend = "bob"
+
+// bobLaunchCmd builds bob's interactive launch command.
+//
+// The launch stays INTERACTIVE — no -p/--prompt — so the agent drives bob in a
+// tmux pane exactly like every other CLI backend and a human can attach to it.
+// Two flags make that work in a headless pod. Both were verified against the
+// installed bundle (bobshell 1.0.6 bundle/bob.js), not assumed:
+//
+//   - --auth-method api-key: bob computes its default auth type as "if
+//     BOBSHELL_API_KEY is set AND the session is non-interactive then api-key,
+//     else W3ID_SSO". So in interactive mode the env var ALONE is not enough —
+//     bob still selects SSO, opens a browser, and dies on the 3-minute
+//     callback timeout; it merely prints 'Existing API key detected
+//     (BOBSHELL_API_KEY). Select "Bob-Shell API Key" option to use it.' This
+//     flag sets globalThis.authMethodByCliArg, which takes precedence over both
+//     the computed default and the persisted security.auth.selectedType, so an
+//     interactive session authenticates with the key and never reaches the
+//     browser flow. The value is bob's own enum constant USE_BOBSHELL="api-key".
+//     This is why interactive mode remains available rather than being
+//     hard-switched to -p.
+//
+//   - --accept-license: bob hard-errors ("A license agreement is required.
+//     Please accept the license terms before proceeding.") before doing any
+//     work unless licenseConsent is already persisted in its settings. That
+//     consent is normally collected from a human at an interactive prompt that
+//     nobody can answer in an unattended pod, and it is stored under
+//     $HOME/.bob, so it is lost whenever the PVC is reset. Passing it on every
+//     launch is idempotent (it only sets licenseConsent=true) and is the
+//     vendor-documented non-interactive path. An operator configuring an API
+//     key for unattended use is the act of acceptance; the text stays
+//     reviewable via `bob --show-license`.
+//
+// The API key itself is NOT a flag — it is delivered out-of-band via
+// tmux set-environment (see agentEnvPairs) so it never lands in the command
+// line, `ps` output, or pane scrollback.
+func bobLaunchCmd(binary, model string) string {
+	cmd := fmt.Sprintf("%s --auth-method %s --accept-license", binary, config.BobAuthMethodAPIKey)
+	if model != "" {
+		cmd = fmt.Sprintf("%s --model %s", cmd, model)
+	}
+	return cmd
+}
+
 // codexHomePrefix is the per-agent CODEX_HOME directory prefix. Each agent gets
 // its own dir so Codex's owner-gated app-server sees a directory the agent UID
 // actually owns (a shared, merely group-writable dir is not sufficient for
@@ -3754,6 +3884,15 @@ func (m *Manager) agentEnvPairs(agent *AgentProcess) []agentEnvPair {
 	}
 	if m.claudeAuthToken != "" && backend == "claude" {
 		vars = append(vars, agentEnvPair{"CLAUDE_CODE_OAUTH_TOKEN", m.claudeAuthToken, true})
+	}
+	// bob reads its key from BOBSHELL_API_KEY. Secret: true keeps the value off
+	// the shell command line (out of `ps`, bash history, and pane scrollback);
+	// it reaches the CLI via tmux set-environment only. Gated on the backend so
+	// no other CLI's environment carries an IBM credential it has no use for.
+	if backend == bobBackend {
+		if key := m.bobAPIKey(); key != "" {
+			vars = append(vars, agentEnvPair{config.BobAPIKeyEnvVar, key, true})
+		}
 	}
 	// BD_DIR tells the `bd` CLI where to read/write beads. Without this,
 	// bd falls back to cwd (/data/agents/<name>) instead of the configured

--- a/v2/pkg/agent/permissions_watcher.go
+++ b/v2/pkg/agent/permissions_watcher.go
@@ -36,6 +36,19 @@ var WatchedHomeDirs = []string{
 	"/data/home/.cache",
 	"/data/home/.config",
 	"/data/home/.local",
+	// bobshell writes its installation-id file and chat-recording tree under
+	// $HOME/.bob (verified in bobshell 1.0.6 bundle/bob.js: the state dir is
+	// path.join(os.homedir(), ".bob")). Agents run with HOME=/data/home, which
+	// the entrypoint creates as root, so without this entry every launch logs
+	// "EACCES: permission denied, mkdir '/data/home/.bob'" and bob falls back
+	// to an ephemeral installation ID with chat recording disabled.
+	//
+	// The nested tree (.bob/tmp/<uuid>/chats) needs no separate entries: bob
+	// creates those with mkdirSync({recursive:true}) as the AGENT's own uid
+	// once .bob itself is traversable+writable by the node group, and
+	// fixPermissions walks each root recursively (filepath.Walk) so anything
+	// created root-owned underneath is corrected on the next tick anyway.
+	"/data/home/.bob",
 	"/data/agents",
 }
 

--- a/v2/pkg/config/bob_test.go
+++ b/v2/pkg/config/bob_test.go
@@ -1,0 +1,146 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestBobConfigResolveAPIKey covers the resolution order — configured file,
+// then the k8s Secret mount default, then the PVC default, then api_key_env,
+// then DefaultBobAPIKeyEnv — and confirms that a nil/empty config resolves to
+// "" rather than panicking.
+func TestBobConfigResolveAPIKey(t *testing.T) {
+	tests := []struct {
+		name string
+		// fileContents is written to a temp file whose path is put in APIKeyFile.
+		fileContents string
+		// envName/envValue is set for the duration of the case.
+		envName  string
+		envValue string
+		// apiKeyEnv is the configured api_key_env value.
+		apiKeyEnv  string
+		want       string
+		wantSource string
+	}{
+		{
+			name: "unconfigured resolves empty",
+			want: "", wantSource: "",
+		},
+		{
+			name:         "key file wins",
+			fileContents: "key-from-file",
+			apiKeyEnv:    "HIVE_BOB_TEST_KEY",
+			envName:      "HIVE_BOB_TEST_KEY",
+			envValue:     "key-from-env",
+			want:         "key-from-file",
+			wantSource:   "file:", // prefix check; the path is a temp dir
+		},
+		{
+			name:      "configured env var used when no file",
+			apiKeyEnv: "HIVE_BOB_TEST_KEY",
+			envName:   "HIVE_BOB_TEST_KEY",
+			envValue:  "key-from-env",
+			want:      "key-from-env", wantSource: "env:HIVE_BOB_TEST_KEY",
+		},
+		{
+			name:     "default env var used when nothing configured",
+			envName:  DefaultBobAPIKeyEnv,
+			envValue: "key-from-default-env",
+			want:     "key-from-default-env", wantSource: "env:" + DefaultBobAPIKeyEnv,
+		},
+		{
+			name:         "whitespace is trimmed",
+			fileContents: "  key-with-space\n",
+			want:         "key-with-space", wantSource: "file:",
+		},
+		{
+			name:         "empty file falls through to env",
+			fileContents: "   \n",
+			envName:      DefaultBobAPIKeyEnv,
+			envValue:     "key-from-default-env",
+			want:         "key-from-default-env", wantSource: "env:" + DefaultBobAPIKeyEnv,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Clear the default env var unless the case sets it, so an inherited
+			// value in the developer's shell cannot make a case pass or fail.
+			t.Setenv(DefaultBobAPIKeyEnv, "")
+			if tc.envName != "" {
+				t.Setenv(tc.envName, tc.envValue)
+			}
+
+			c := &BobConfig{APIKeyEnv: tc.apiKeyEnv}
+			if tc.fileContents != "" {
+				path := filepath.Join(t.TempDir(), "bob_api_key")
+				if err := os.WriteFile(path, []byte(tc.fileContents), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				c.APIKeyFile = path
+			}
+
+			if got := c.ResolveAPIKey(); got != tc.want {
+				t.Errorf("ResolveAPIKey() = %q, want %q", got, tc.want)
+			}
+
+			source := c.ResolveAPIKeySource()
+			switch {
+			case tc.wantSource == "":
+				if source != "" {
+					t.Errorf("ResolveAPIKeySource() = %q, want empty", source)
+				}
+			case tc.wantSource == "file:":
+				if len(source) < len("file:") || source[:len("file:")] != "file:" {
+					t.Errorf("ResolveAPIKeySource() = %q, want a file: source", source)
+				}
+			default:
+				if source != tc.wantSource {
+					t.Errorf("ResolveAPIKeySource() = %q, want %q", source, tc.wantSource)
+				}
+			}
+
+			// The source must never contain the key value itself — it is logged.
+			if tc.want != "" && source != "" && source == tc.want {
+				t.Error("ResolveAPIKeySource() must not expose the key value")
+			}
+		})
+	}
+}
+
+// TestBobConfigNilReceiver guards the nil path: callers hold *BobConfig and a
+// nil receiver must resolve to "" rather than panic.
+func TestBobConfigNilReceiver(t *testing.T) {
+	var c *BobConfig
+	if got := c.ResolveAPIKey(); got != "" {
+		t.Errorf("nil BobConfig ResolveAPIKey() = %q, want empty", got)
+	}
+	if got := c.ResolveAPIKeySource(); got != "" {
+		t.Errorf("nil BobConfig ResolveAPIKeySource() = %q, want empty", got)
+	}
+}
+
+// TestBobConstants pins the externally-defined names. BobAPIKeyEnvVar and
+// BobAuthMethodAPIKey are dictated by the bobshell bundle, not by us: changing
+// them silently breaks headless auth, so they are asserted rather than assumed.
+func TestBobConstants(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"bob's own env var name", BobAPIKeyEnvVar, "BOBSHELL_API_KEY"},
+		{"bob's api-key auth method value", BobAuthMethodAPIKey, "api-key"},
+		{"hive-side default env var", DefaultBobAPIKeyEnv, "HIVE_BOB_API_KEY"},
+		{"k8s Secret mount default path", DefaultBobAPIKeyFile, "/secrets/bob_api_key"},
+		{"PVC default path", WritableBobAPIKeyFile, "/data/secrets/bob_api_key"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Errorf("got %q, want %q", tc.got, tc.want)
+			}
+		})
+	}
+}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -513,6 +513,10 @@ type GovernorConfig struct {
 	LiteLLM       LiteLLMConfig         `yaml:"litellm"`
 	VLLM          InferenceAuthConfig   `yaml:"vllm"`
 	LLMD          InferenceAuthConfig   `yaml:"llm-d"`
+	// Bob holds the IBM bobshell CLI backend's API-key location. Required for
+	// agents with backend "bob": bobshell's browser SSO flow cannot complete in
+	// a headless pod.
+	Bob BobConfig `yaml:"bob"`
 	Trajectory    TrajectoryConfig      `yaml:"trajectory"`
 	// Gateways is the list of named model gateways (OpenAI-compatible endpoints
 	// like OpenRouter, a LiteLLM proxy, vLLM, or llm-d). An agent routes through
@@ -813,6 +817,95 @@ const (
 	// (mirrors HIVE_VLLM_ENDPOINT / HIVE_LLMD_ENDPOINT).
 	LiteLLMEndpointEnv = "HIVE_LITELLM_ENDPOINT"
 )
+
+// Bob (IBM bobshell) API-key resolution. bobshell cannot authenticate in a pod
+// any other way: its default flow (W3ID SSO) opens a browser and polls a
+// localhost callback port, which in a headless container cannot succeed and
+// instead burns a 3-minute timeout per launch. IBM's documented remedy for
+// non-interactive sessions is API-key auth. As with LiteLLM, hive.yaml stores
+// only the env var NAME and/or key FILE PATH — never the key value, because
+// Config.Save() round-trips the config back to disk.
+const (
+	// BobAPIKeyEnvVar is the env var name bobshell itself reads the key from.
+	// Verified against the installed bundle (bobshell 1.0.6 bundle/bob.js):
+	// `process.env.BOBSHELL_API_KEY`. This is the name injected INTO the
+	// agent's environment, distinct from the hive-side variable below that
+	// an operator sets on the hive pod.
+	BobAPIKeyEnvVar = "BOBSHELL_API_KEY"
+
+	// DefaultBobAPIKeyEnv is the hive-side env var consulted for the bob API
+	// key when governor.bob.api_key_env is not set in hive.yaml.
+	DefaultBobAPIKeyEnv = "HIVE_BOB_API_KEY"
+
+	// DefaultBobAPIKeyFile is the key file consulted when api_key_file is not
+	// set. Matches the read-only /secrets volume used for k8s Secret mounts.
+	DefaultBobAPIKeyFile = "/secrets/bob_api_key"
+
+	// WritableBobAPIKeyFile is the PVC-backed location a hosted operator can
+	// write the key to without cluster access, mirroring
+	// WritableLiteLLMAPIKeyFile. Referenced by path only; never by value.
+	WritableBobAPIKeyFile = WritableSecretsDir + "/bob_api_key"
+
+	// BobAuthMethodAPIKey is the value bobshell's `--auth-method` flag expects
+	// to select API-key auth. Verified in bundle/bob.js, where the auth-type
+	// enum is defined as `USE_BOBSHELL="api-key"`.
+	BobAuthMethodAPIKey = "api-key"
+)
+
+// BobConfig configures the IBM bobshell ("bob") CLI backend. Only the
+// key's LOCATION is stored — never the key itself.
+type BobConfig struct {
+	APIKeyEnv  string `yaml:"api_key_env" json:"api_key_env,omitempty"`   // env var NAME holding the key; default HIVE_BOB_API_KEY
+	APIKeyFile string `yaml:"api_key_file" json:"api_key_file,omitempty"` // path to a file holding the key; default /secrets/bob_api_key
+}
+
+// ResolveAPIKey returns the bob API key, or "" when none is configured.
+// Key FILES are consulted in priority order — the configured api_key_file,
+// then the k8s Secret mount (DefaultBobAPIKeyFile), then the PVC file
+// (WritableBobAPIKeyFile) — followed by the env var named by api_key_env and
+// finally DefaultBobAPIKeyEnv. This mirrors LiteLLMConfig.ResolveAPIKey so a
+// key stays working if hive.yaml is re-seeded and the api_key_file pointer is
+// lost, or if the PVC copy is wiped but an admin Secret exists.
+func (c *BobConfig) ResolveAPIKey() string {
+	key, _ := c.resolveAPIKeyWithSource()
+	return key
+}
+
+// ResolveAPIKeySource reports WHERE the key was found without exposing the
+// value: "file:<path>", "env:<NAME>", or "" when unconfigured. Safe to log
+// and safe to return from APIs.
+func (c *BobConfig) ResolveAPIKeySource() string {
+	_, source := c.resolveAPIKeyWithSource()
+	return source
+}
+
+func (c *BobConfig) resolveAPIKeyWithSource() (string, string) {
+	if c == nil {
+		return "", ""
+	}
+	files := []string{c.APIKeyFile, DefaultBobAPIKeyFile, WritableBobAPIKeyFile}
+	seen := map[string]bool{"": true}
+	for _, f := range files {
+		if seen[f] {
+			continue
+		}
+		seen[f] = true
+		if data, err := os.ReadFile(f); err == nil {
+			if key := strings.TrimSpace(string(data)); key != "" {
+				return key, "file:" + f
+			}
+		}
+	}
+	if c.APIKeyEnv != "" {
+		if key := os.Getenv(c.APIKeyEnv); key != "" {
+			return key, "env:" + c.APIKeyEnv
+		}
+	}
+	if key := os.Getenv(DefaultBobAPIKeyEnv); key != "" {
+		return key, "env:" + DefaultBobAPIKeyEnv
+	}
+	return "", ""
+}
 
 // LiteLLMConfig configures the litellm inference backend: an OpenAI-compatible
 // LiteLLM proxy (remote or local) that agents reach through the hive's

--- a/v2/pkg/hub/access2_coverage_test.go
+++ b/v2/pkg/hub/access2_coverage_test.go
@@ -14,7 +14,7 @@ import (
 func TestHandleApproveAccessFlow(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	saveSaaSUser(&SaaSUser{GitHubUsername: "owner", Hives: map[string]string{"h1": "owner"}})
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "owner"})
@@ -52,7 +52,7 @@ func TestHandleApproveAccessFlow(t *testing.T) {
 func TestHandleDenyAccessFlow(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	saveSaaSUser(&SaaSUser{GitHubUsername: "owner", Hives: map[string]string{"h1": "owner"}})
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "owner"})
@@ -69,7 +69,7 @@ func TestHandleDenyAccessFlow(t *testing.T) {
 func TestHandleAccessStatus(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "owner"})
 	mkUser(t, "viewer")

--- a/v2/pkg/hub/access_coverage_test.go
+++ b/v2/pkg/hub/access_coverage_test.go
@@ -22,7 +22,7 @@ func setPathValues(r *http.Request, kv map[string]string) *http.Request {
 func TestAccessRequestLifecycle(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	// Owner + hive.
 	saveSaaSUser(&SaaSUser{GitHubUsername: "owner", Hives: map[string]string{"h1": "owner"}})
@@ -98,7 +98,7 @@ func TestAccessRequestLifecycle(t *testing.T) {
 func TestHandleApproveRequestRoleGuard(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	// read-write approver cannot grant owner.
 	saveSaaSUser(&SaaSUser{GitHubUsername: "rw", Hives: map[string]string{"h1": "read-write"}})
@@ -116,7 +116,7 @@ func TestHandleApproveRequestRoleGuard(t *testing.T) {
 func TestHandleDenyRequest(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	saveSaaSUser(&SaaSUser{GitHubUsername: "owner", Hives: map[string]string{"h1": "owner"}})
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "owner"})
@@ -133,7 +133,7 @@ func TestHandleDenyRequest(t *testing.T) {
 func TestHandleAccessAddListRemove(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	saveSaaSUser(&SaaSUser{GitHubUsername: "owner", Hives: map[string]string{"h1": "owner"}})
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "owner"})
@@ -191,6 +191,7 @@ func TestHandleToggleAutoUpgradeSuccess(t *testing.T) {
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice"})
 
 	s := &HubServer{
+		hubSecret:        testHubSecret,
 		logger:           slog.Default(),
 		heartbeatUpgrade: make(map[string]string),
 	}

--- a/v2/pkg/hub/cluster_health_coverage_test.go
+++ b/v2/pkg/hub/cluster_health_coverage_test.go
@@ -77,6 +77,7 @@ func TestBuildClusterHealthWithScriptedKubectl(t *testing.T) {
 	clusterHealthCacheMu.Unlock()
 
 	s := &HubServer{
+		hubSecret:       testHubSecret,
 		logger:          slog.Default(),
 		clusters:        map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", InCluster: true, Name: "OKE"}},
 		heartbeatHealth: make(map[string]*HeartbeatHealthEntry),
@@ -105,8 +106,9 @@ func TestHandleUpgradeHiveSuccess(t *testing.T) {
 	mkUser(t, "alice")
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", ClusterID: "hive-oke"})
 	s := &HubServer{
-		logger:   slog.Default(),
-		clusters: map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", InCluster: true}},
+		hubSecret: testHubSecret,
+		logger:    slog.Default(),
+		clusters:  map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", InCluster: true}},
 	}
 	s.registry.Hives = []RegistryEntry{{ID: "h1", GitBranch: "v2"}}
 

--- a/v2/pkg/hub/final2_coverage_test.go
+++ b/v2/pkg/hub/final2_coverage_test.go
@@ -27,7 +27,7 @@ func TestTriggerAutoUpgradesRemoteStale(t *testing.T) {
 	latestSHAByBranch["v2"] = branchSHAInfo{SHA: "newsha7"}
 	latestSHAMu.Unlock()
 
-	s := &HubServer{logger: slog.Default(), heartbeatUpgrade: make(map[string]string), clusters: map[string]ClusterConfig{"remote": remote}}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string), clusters: map[string]ClusterConfig{"remote": remote}}
 	s.registry.Hives = []RegistryEntry{{
 		ID: "h1", GitBranch: "v2", GitHash: "old", Upgrading: true,
 		UpgradeTarget: "oldtarget", UpgradeStartedAt: time.Now().Add(-2 * time.Hour),
@@ -42,7 +42,7 @@ func TestTriggerAutoUpgradesRemoteNotStale(t *testing.T) {
 	remote := ClusterConfig{ID: "remote", InCluster: false, KubeconfigPath: "/tmp/kc", Context: "ctx"}
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", AutoUpgrade: true, Status: "running", ClusterID: "remote"})
 
-	s := &HubServer{logger: slog.Default(), heartbeatUpgrade: make(map[string]string), clusters: map[string]ClusterConfig{"remote": remote}}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string), clusters: map[string]ClusterConfig{"remote": remote}}
 	// Upgrading, recent timestamp -> not stale -> re-arm heartbeat target.
 	s.registry.Hives = []RegistryEntry{{
 		ID: "h1", GitBranch: "v2", GitHash: "old", Upgrading: true,
@@ -68,7 +68,7 @@ func TestTriggerAutoUpgradesNoClusterSkip(t *testing.T) {
 	latestSHAMu.Unlock()
 
 	// Not upgrading, behind latest, but no cluster config -> skip branch.
-	s := &HubServer{logger: slog.Default(), heartbeatUpgrade: make(map[string]string), clusters: map[string]ClusterConfig{}}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string), clusters: map[string]ClusterConfig{}}
 	s.registry.Hives = []RegistryEntry{{ID: "h1", GitBranch: "v2", GitHash: "old"}}
 	s.triggerAutoUpgrades()
 }
@@ -109,7 +109,7 @@ func TestHandleHubOpenRouterStartOwner(t *testing.T) {
 	saveSaaSUser(&SaaSUser{GitHubUsername: "alice", Hives: map[string]string{}})
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice"})
 
-	s := &HubServer{logger: slog.Default(), pendingGateways: make(map[string]*HeartbeatGatewayConfig)}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, pendingGateways: make(map[string]*HeartbeatGatewayConfig)}
 	rec := httptest.NewRecorder()
 	req := reqWithUser(http.MethodGet, "/api/openrouter/connect/start?hive_id=h1", "", "alice")
 	s.handleHubOpenRouterStart(rec, req)

--- a/v2/pkg/hub/final3_coverage_test.go
+++ b/v2/pkg/hub/final3_coverage_test.go
@@ -62,7 +62,7 @@ func TestHandleSwitchBranchUnknownBranch(t *testing.T) {
 	})
 	resetSHACaches(t)
 
-	s := &HubServer{logger: slog.Default(), clusters: map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", InCluster: true}}}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, clusters: map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", InCluster: true}}}
 	rec := httptest.NewRecorder()
 	req := setPathValue(reqWithUser(http.MethodPost, "/sw", `{"branch":"nonexistent-branch"}`, "alice"), "id", "h1")
 	s.handleSwitchBranch(rec, req)
@@ -78,7 +78,7 @@ func TestHandleSwitchBranchUnknownBranch(t *testing.T) {
 func TestHandleDenyRequestBranches(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	// Hive not found -> 404.
 	rec := httptest.NewRecorder()
@@ -102,7 +102,7 @@ func TestHandleDenyRequestBranches(t *testing.T) {
 func TestHandleDenyAccessNotOwner(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	saveSaaSUser(&SaaSUser{GitHubUsername: "notowner", Hives: map[string]string{}})
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "someone"})
@@ -120,7 +120,7 @@ func TestHandleDenyAccessNotOwner(t *testing.T) {
 // ============================================================
 
 func TestHandleHubOpenRouterQRLongData(t *testing.T) {
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	// Valid prefix but an absurdly long payload -> QR encoder returns an error.
 	longData := "https://openrouter.ai/auth?x=" + strings.Repeat("a", 5000)
 	// Ensure the prefix matches the accepted authorize URL.

--- a/v2/pkg/hub/final4_coverage_test.go
+++ b/v2/pkg/hub/final4_coverage_test.go
@@ -13,7 +13,7 @@ import (
 // ============================================================
 
 func TestMergeLeaderboards_Cov4(t *testing.T) {
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	s.registry.Hives = []RegistryEntry{
 		{ID: "priv", IsPublic: false, Leaderboard: []LeaderboardEntry{{GitHubUsername: "hidden", TasksCompleted: 5}}},
 		{ID: "pub1", IsPublic: true, Leaderboard: []LeaderboardEntry{
@@ -56,7 +56,7 @@ func TestHandleApproveProvisionExplicitPlaceholder(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 	mkUser(t, hubAdminUsername)
-	s := &HubServer{logger: slog.Default(), saveCh: make(chan struct{}, 1), clusters: map[string]ClusterConfig{"hive-oke": *dynamicCluster()}}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, saveCh: make(chan struct{}, 1), clusters: map[string]ClusterConfig{"hive-oke": *dynamicCluster()}}
 
 	saveProvisionRequest(&ProvisionRequest{
 		Username: "bob", Org: "acme", Repos: "repo", PrimaryRepo: "repo", ACMMLevel: 2,

--- a/v2/pkg/hub/final6_coverage_test.go
+++ b/v2/pkg/hub/final6_coverage_test.go
@@ -14,7 +14,7 @@ import (
 func TestHandleHiveStatusBranches(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	// Missing hive -> 404.
 	rec := httptest.NewRecorder()
@@ -47,7 +47,7 @@ func TestHandleHiveStatusBranches(t *testing.T) {
 func TestHandleAccessAddBadBody_Cov6(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	saveSaaSUser(&SaaSUser{GitHubUsername: "owner", Hives: map[string]string{"h1": "owner"}})
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "owner"})
 
@@ -71,7 +71,7 @@ func TestHandleAccessAddBadBody_Cov6(t *testing.T) {
 func TestHandleRequestAccessAlreadyHas(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "owner"})
 	// User already has access to h1.
@@ -88,7 +88,7 @@ func TestHandleRequestAccessAlreadyHas(t *testing.T) {
 func TestHandleAccessRemoveUserNotFound(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	saveSaaSUser(&SaaSUser{GitHubUsername: "owner", Hives: map[string]string{"h1": "owner"}})
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "owner"})
 

--- a/v2/pkg/hub/hub_cookie.go
+++ b/v2/pkg/hub/hub_cookie.go
@@ -1,0 +1,74 @@
+package hub
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+)
+
+// Hub session cookie integrity.
+//
+// The `hive_hub_user` cookie carries the logged-in GitHub username that the hub
+// trusts for browser-originated API calls. Historically it stored the raw
+// username, which meant anyone could hand-craft the cookie and impersonate any
+// user — including the hub admin. To make the cookie tamper-evident it is now
+// bound to the hub secret with an HMAC:
+//
+//	value = <username>.<base64url(HMAC-SHA256(username, hubSecret))>
+//
+// The username stays in the clear (it is not a secret and callers already know
+// their own login); the appended signature is what proves the hub itself minted
+// the value. Verification recomputes the HMAC and compares in constant time, so
+// a forged or edited cookie fails closed.
+//
+// Legacy transition: existing sessions carry an UNSIGNED cookie (no "." + sig).
+// Those fail verification and are treated as logged out, so the user simply
+// re-authenticates through the normal login flow, which re-mints the new signed
+// cookie. No stored data changes and nobody is permanently locked out.
+
+// hubCookieB64 encodes the signature URL-safe and unpadded so the cookie value
+// stays within the RFC 6265 cookie-octet set.
+var hubCookieB64 = base64.RawURLEncoding
+
+// mintHubUserCookieValue returns the signed, tamper-evident cookie value for
+// username. It returns "" when no secret is configured or the username is empty
+// — callers must treat that as "cannot establish a session" rather than emitting
+// an unsigned (trusted-by-default) cookie.
+func mintHubUserCookieValue(secret, username string) string {
+	if secret == "" || username == "" {
+		return ""
+	}
+	return username + "." + hubCookieSign(secret, username)
+}
+
+// verifyHubUserCookieValue parses a cookie value, recomputes its HMAC over the
+// carried username, and constant-time-compares it against the presented
+// signature. It returns (username, true) only when the signature verifies; on a
+// legacy unsigned cookie, a forged value, or a missing secret it returns
+// ("", false) so the caller treats the request as unauthenticated.
+func verifyHubUserCookieValue(secret, value string) (string, bool) {
+	if secret == "" || value == "" {
+		return "", false
+	}
+	// SplitN from the right: usernames are validated to exclude ".", but be
+	// defensive and treat the final segment as the signature regardless.
+	idx := strings.LastIndex(value, ".")
+	if idx <= 0 || idx == len(value)-1 {
+		return "", false
+	}
+	username, sig := value[:idx], value[idx+1:]
+	expected := hubCookieSign(secret, username)
+	if !hmac.Equal([]byte(sig), []byte(expected)) {
+		return "", false
+	}
+	return username, true
+}
+
+// hubCookieSign returns the URL-safe base64 HMAC-SHA256 of username under
+// secret.
+func hubCookieSign(secret, username string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(username))
+	return hubCookieB64.EncodeToString(mac.Sum(nil))
+}

--- a/v2/pkg/hub/hub_cookie_test.go
+++ b/v2/pkg/hub/hub_cookie_test.go
@@ -1,0 +1,98 @@
+package hub
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestSignedHubCookieRoundTrip confirms a value minted by the hub verifies back
+// to the same username under the same secret.
+func TestSignedHubCookieRoundTrip(t *testing.T) {
+	const user = "octocat"
+	value := mintHubUserCookieValue(testHubSecret, user)
+	if value == "" {
+		t.Fatal("mint returned empty value")
+	}
+	if value == user {
+		t.Fatal("cookie value must not be the raw username")
+	}
+	got, ok := verifyHubUserCookieValue(testHubSecret, value)
+	if !ok || got != user {
+		t.Fatalf("verify = (%q, %v), want (%q, true)", got, ok, user)
+	}
+}
+
+// TestForgedHubCookieRejected pins the core F4 guarantee: a hand-crafted
+// (unsigned) cookie value or one signed with the wrong secret does NOT
+// authenticate. getAuthUser must return "" so the request is unauthenticated.
+func TestForgedHubCookieRejected(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, hubAdminUsername)
+
+	srv := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{"raw unsigned username (legacy/forged)", hubAdminUsername},
+		{"empty signature", hubAdminUsername + "."},
+		{"garbage signature", hubAdminUsername + ".not-a-real-hmac"},
+		{"signed with wrong secret", mintHubUserCookieValue("attacker-secret", hubAdminUsername)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/x", nil)
+			req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: tc.value})
+			if got := srv.getAuthUser(req); got != "" {
+				t.Errorf("forged cookie authenticated as %q, want unauthenticated", got)
+			}
+		})
+	}
+}
+
+// TestSignedHubCookieAuthenticates confirms a properly-signed cookie for a
+// known user does authenticate through getAuthUser.
+func TestSignedHubCookieAuthenticates(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	mkUser(t, "alice")
+
+	srv := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
+
+	req := httptest.NewRequest("GET", "/x", nil)
+	req.AddCookie(testAuthCookie("alice"))
+	if got := srv.getAuthUser(req); got != "alice" {
+		t.Errorf("getAuthUser = %q, want alice", got)
+	}
+}
+
+// TestHandleHubVersionNeverLeaksSecret confirms the version endpoint never
+// returns the hub secret, even to a request carrying a valid admin cookie.
+func TestHandleHubVersionNeverLeaksSecret(t *testing.T) {
+	srv := &HubServer{logger: slog.Default(), hubSecret: "super-secret-value"}
+
+	req := httptest.NewRequest("GET", "/api/hub/version", nil)
+	req.AddCookie(testAuthCookie(hubAdminUsername))
+	w := httptest.NewRecorder()
+	srv.handleHubVersion(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, present := resp["hub_secret"]; present {
+		t.Error("version response must never include hub_secret")
+	}
+	if got := w.Body.String(); strings.Contains(got, "super-secret-value") {
+		t.Errorf("version body leaked the raw secret: %s", got)
+	}
+}

--- a/v2/pkg/hub/hub_coverage_boost_test.go
+++ b/v2/pkg/hub/hub_coverage_boost_test.go
@@ -901,6 +901,12 @@ func TestHandleRegistryDeleteNoAdmin(t *testing.T) {
 }
 
 func TestHandleRegistryDeleteAsAdmin(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	// Admin authorization is resolved through getAuthUser, which requires a real
+	// user record and a signed session cookie.
+	ensureSaaSUser(hubAdminUsername)
+
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 	srv.mu.Lock()
 	srv.registry.Hives = []RegistryEntry{
@@ -912,7 +918,7 @@ func TestHandleRegistryDeleteAsAdmin(t *testing.T) {
 	mux.HandleFunc("DELETE /api/hub/registry/{id}", srv.handleRegistryDelete)
 
 	req := httptest.NewRequest("DELETE", "/api/hub/registry/delete-me", nil)
-	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: hubAdminUsername})
+	req.AddCookie(testAuthCookie(hubAdminUsername))
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
@@ -928,13 +934,17 @@ func TestHandleRegistryDeleteAsAdmin(t *testing.T) {
 }
 
 func TestHandleRegistryDeleteNotFound(t *testing.T) {
+	cleanup := helperSetupTempDirs(t)
+	defer cleanup()
+	ensureSaaSUser(hubAdminUsername)
+
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("DELETE /api/hub/registry/{id}", srv.handleRegistryDelete)
 
 	req := httptest.NewRequest("DELETE", "/api/hub/registry/nonexistent", nil)
-	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: hubAdminUsername})
+	req.AddCookie(testAuthCookie(hubAdminUsername))
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
@@ -951,7 +961,7 @@ func TestHandleHubVersionAsAdmin(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "admin-hash", "v2")
 
 	req := httptest.NewRequest("GET", "/api/hub/version", nil)
-	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: hubAdminUsername})
+	req.AddCookie(testAuthCookie(hubAdminUsername))
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)
 
@@ -962,8 +972,9 @@ func TestHandleHubVersionAsAdmin(t *testing.T) {
 	if !strings.Contains(body, "admin-hash") {
 		t.Error("should contain git hash")
 	}
-	if !strings.Contains(body, "hub_secret") {
-		t.Error("admin should see hub_secret")
+	// The hub secret must never be exposed over this endpoint, even to an admin.
+	if strings.Contains(body, "hub_secret") {
+		t.Error("version response must not include hub_secret")
 	}
 }
 

--- a/v2/pkg/hub/hub_filesystem_extra_test.go
+++ b/v2/pkg/hub/hub_filesystem_extra_test.go
@@ -613,7 +613,7 @@ func TestHandleAuthUserWithFileUser(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/auth-user", nil)
-	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "file-auth-user"})
+	req.AddCookie(testAuthCookie("file-auth-user"))
 	w := httptest.NewRecorder()
 	srv.handleAuthUser(w, req)
 
@@ -636,7 +636,7 @@ func TestHandleAuthUserAdmin(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/auth-user", nil)
-	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: hubAdminUsername})
+	req.AddCookie(testAuthCookie(hubAdminUsername))
 	w := httptest.NewRecorder()
 	srv.handleAuthUser(w, req)
 
@@ -656,7 +656,7 @@ func TestGetAuthUserWithCookieAndFile(t *testing.T) {
 	srv := NewHubServer(0, slog.Default(), "test", "v2")
 
 	req := httptest.NewRequest("GET", "/test", nil)
-	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "cookie-user"})
+	req.AddCookie(testAuthCookie("cookie-user"))
 	user := srv.getAuthUser(req)
 
 	if user != "cookie-user" {

--- a/v2/pkg/hub/hub_filesystem_test.go
+++ b/v2/pkg/hub/hub_filesystem_test.go
@@ -17,6 +17,10 @@ func helperSetupTempDirs(t *testing.T) func() {
 	t.Helper()
 	dir := t.TempDir()
 
+	// Pin a known hub secret so NewHubServer signs/verifies session cookies with
+	// a value the tests can reproduce (see testHubSecret / testAuthCookie).
+	t.Setenv("HIVE_HUB_SECRET", testHubSecret)
+
 	// Async provisioning goroutines from previously-run tests read the
 	// package-level path variables swapped below; drain them first.
 	provisionWG.Wait()

--- a/v2/pkg/hub/oauth.go
+++ b/v2/pkg/hub/oauth.go
@@ -251,10 +251,18 @@ func (s *HubServer) handleOAuthCallback(w http.ResponseWriter, r *http.Request) 
 
 	s.logger.Info("audit: hub OAuth login", "user", user.Login)
 
-	// Set cookie with user info (simple JSON cookie for now)
+	// Set the session cookie to a signed, tamper-evident value so it cannot be
+	// forged. If the hub has no secret to sign with, fail the login rather than
+	// emit an unsigned (trusted-by-default) cookie.
+	cookieValue := mintHubUserCookieValue(s.hubSecret, user.Login)
+	if cookieValue == "" {
+		s.logger.Warn("OAuth: cannot mint signed session cookie", "user", user.Login)
+		http.Error(w, "session unavailable", http.StatusInternalServerError)
+		return
+	}
 	cookie := &http.Cookie{
 		Name:     "hive_hub_user",
-		Value:    user.Login,
+		Value:    cookieValue,
 		Path:     "/",
 		Domain:   ".hive.kubestellar.io",
 		MaxAge:   86400 * cookieMaxAgeDays,
@@ -288,16 +296,19 @@ func (s *HubServer) handleAuthUser(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`{"authenticated":false}`))
 		return
 	}
-	if loadSaaSUser(cookie.Value) == nil {
+	// Trust the carried username only when its signature verifies; a legacy
+	// unsigned or forged cookie reports unauthenticated, prompting a re-login.
+	username, ok := verifyHubUserCookieValue(s.hubSecret, cookie.Value)
+	if !ok || loadSaaSUser(username) == nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`{"authenticated":false}`))
 		return
 	}
-	isAdmin := cookie.Value == hubAdminUsername
+	isAdmin := username == hubAdminUsername
 	data, err := json.Marshal(map[string]any{
 		"authenticated": true,
-		"login":         cookie.Value,
-		"avatar_url":    fmt.Sprintf("https://github.com/%s.png", cookie.Value),
+		"login":         username,
+		"avatar_url":    fmt.Sprintf("https://github.com/%s.png", username),
 		"hub_admin":     isAdmin,
 	})
 	if err != nil {

--- a/v2/pkg/hub/oauth_provision_coverage_test.go
+++ b/v2/pkg/hub/oauth_provision_coverage_test.go
@@ -76,7 +76,8 @@ func TestHandleOAuthCallbackSuccess(t *testing.T) {
 	defaultGHUserURL = usr.URL
 	defer func() { defaultGHTokenURL, defaultGHUserURL = oldTok, oldUsr }()
 
-	s := &HubServer{logger: slog.Default()}
+	// A configured secret lets the login path mint a signed session cookie.
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	rec := httptest.NewRecorder()
 	// A safe relative redirect state should be honored.
 	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=abc&state=%2Fmy-hives", nil)
@@ -90,6 +91,23 @@ func TestHandleOAuthCallbackSuccess(t *testing.T) {
 	// User should have been created.
 	if loadSaaSUser("octocat") == nil {
 		t.Error("expected octocat user created")
+	}
+	// The login path must re-mint the NEW signed cookie so returning users get a
+	// verifiable session (this is what lets legacy unsigned-cookie users recover).
+	var sessionCookie *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == "hive_hub_user" {
+			sessionCookie = c
+		}
+	}
+	if sessionCookie == nil {
+		t.Fatal("expected a hive_hub_user session cookie to be set")
+	}
+	if sessionCookie.Value == "octocat" {
+		t.Error("session cookie must be signed, not the raw username")
+	}
+	if user, ok := verifyHubUserCookieValue(testHubSecret, sessionCookie.Value); !ok || user != "octocat" {
+		t.Errorf("minted cookie did not verify: (%q, %v)", user, ok)
 	}
 }
 

--- a/v2/pkg/hub/openrouter_coverage_test.go
+++ b/v2/pkg/hub/openrouter_coverage_test.go
@@ -18,13 +18,15 @@ import (
 func newORHub() *HubServer {
 	return &HubServer{
 		logger:          slog.Default(),
+		hubSecret:       testHubSecret,
 		pendingGateways: make(map[string]*HeartbeatGatewayConfig),
 	}
 }
 
-// withCookieUser sets the hive_hub_user cookie to a user that exists on disk.
+// withCookieUser sets a signed hive_hub_user cookie for a user that exists on
+// disk.
 func withCookieUser(req *http.Request, username string) {
-	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: username})
+	req.AddCookie(testAuthCookie(username))
 }
 
 func TestPendingGatewayLifecycle(t *testing.T) {

--- a/v2/pkg/hub/provision_approve_coverage_test.go
+++ b/v2/pkg/hub/provision_approve_coverage_test.go
@@ -23,13 +23,13 @@ func TestLoadRegistry(t *testing.T) {
 	old := registryPath
 	registryPath = filepath.Join(dir, "missing.json")
 	defer func() { registryPath = old }()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	s.loadRegistry()
 
 	// Valid file -> loads hives.
 	registryPath = filepath.Join(dir, "reg.json")
 	os.WriteFile(registryPath, []byte(`{"hives":[{"id":"h1"},{"id":"h2"}]}`), 0o644)
-	s2 := &HubServer{logger: slog.Default()}
+	s2 := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	s2.loadRegistry()
 	if len(s2.registry.Hives) != 2 {
 		t.Errorf("expected 2 hives loaded, got %d", len(s2.registry.Hives))
@@ -37,7 +37,7 @@ func TestLoadRegistry(t *testing.T) {
 
 	// Bad JSON -> logged, registry left empty.
 	os.WriteFile(registryPath, []byte(`{not json`), 0o644)
-	s3 := &HubServer{logger: slog.Default()}
+	s3 := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	s3.loadRegistry()
 	if len(s3.registry.Hives) != 0 {
 		t.Errorf("bad JSON should leave registry empty, got %d", len(s3.registry.Hives))
@@ -48,7 +48,7 @@ func TestHandleApproveProvision(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 	mkUser(t, hubAdminUsername)
-	s := &HubServer{logger: slog.Default(), saveCh: make(chan struct{}, 1), clusters: map[string]ClusterConfig{"hive-oke": *dynamicCluster()}}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, saveCh: make(chan struct{}, 1), clusters: map[string]ClusterConfig{"hive-oke": *dynamicCluster()}}
 
 	// No pending request -> 404.
 	rec := httptest.NewRecorder()
@@ -86,7 +86,7 @@ func TestHandleToggleAutoUpgradeHeartbeatOnly(t *testing.T) {
 	mkUser(t, "alice")
 
 	// No SaaS record; only a registry entry (heartbeat-connected hive behind latest).
-	s := &HubServer{logger: slog.Default(), heartbeatUpgrade: make(map[string]string)}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string)}
 	s.registry.Hives = []RegistryEntry{{ID: "hb1", Owner: "alice", GitBranch: "v2", GitHash: "behind0"}}
 	resetSHACaches(t)
 	latestSHAMu.Lock()
@@ -109,7 +109,7 @@ func TestHandleToggleAutoUpgradeUnknownHive(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 	mkUser(t, "alice")
-	s := &HubServer{logger: slog.Default(), heartbeatUpgrade: make(map[string]string)}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string)}
 
 	rec := httptest.NewRecorder()
 	req := setPathValue(reqWithUser(http.MethodPut, "/au", `{"auto_upgrade":true}`, "alice"), "id", "nope")
@@ -127,7 +127,7 @@ func TestHandleMyHives(t *testing.T) {
 	saveSaaSUser(&SaaSUser{GitHubUsername: "alice", Hives: map[string]string{"h1": "owner"}})
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", Org: "acme", Status: "running"})
 
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 	// A registry entry for the same hive to exercise the merge path.
 	s.registry.Hives = []RegistryEntry{{ID: "h1", Owner: "alice", Org: "acme", GitHash: "abc", Online: true}}
 

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -318,8 +318,14 @@ func isTrustedOrigin(raw string) bool {
 func (s *HubServer) getAuthUser(r *http.Request) string {
 	cookie, err := r.Cookie("hive_hub_user")
 	if err == nil && cookie.Value != "" {
-		if loadSaaSUser(cookie.Value) != nil {
-			return cookie.Value
+		// The cookie value is only trusted when its HMAC signature verifies
+		// against the hub secret. A legacy unsigned cookie or a forged value
+		// fails here and is treated as logged out, so the user re-authenticates
+		// through the normal login flow (which re-mints a signed cookie).
+		if username, ok := verifyHubUserCookieValue(s.hubSecret, cookie.Value); ok {
+			if loadSaaSUser(username) != nil {
+				return username
+			}
 		}
 	}
 

--- a/v2/pkg/hub/saas_bulk_test.go
+++ b/v2/pkg/hub/saas_bulk_test.go
@@ -51,7 +51,7 @@ func bulkPost(t *testing.T, srv *HubServer, user string, body any) (*httptest.Re
 	req := httptest.NewRequest("POST", "/api/saas/hives/bulk", bytes.NewReader(raw))
 	req.Header.Set("Content-Type", "application/json")
 	if user != "" {
-		req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: user})
+		req.AddCookie(testAuthCookie(user))
 	}
 	w := httptest.NewRecorder()
 	srv.mux.ServeHTTP(w, req)

--- a/v2/pkg/hub/saas_edge_coverage_test.go
+++ b/v2/pkg/hub/saas_edge_coverage_test.go
@@ -15,6 +15,7 @@ import (
 // nil and the "no cluster config" error branches run.
 func noClusterHub() *HubServer {
 	return &HubServer{
+		hubSecret:          testHubSecret,
 		logger:             slog.Default(),
 		saveCh:             make(chan struct{}, 1),
 		heartbeatUpgrade:   make(map[string]string),
@@ -45,7 +46,7 @@ func TestHandleUpgradeHiveRegistryUpdate(t *testing.T) {
 	mkUser(t, "alice")
 	saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice", ClusterID: "hive-oke"})
 
-	s := &HubServer{logger: slog.Default(), clusters: map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", InCluster: true}}}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, clusters: map[string]ClusterConfig{"hive-oke": {ID: "hive-oke", InCluster: true}}}
 	// A matching registry entry so the post-upgrade registry-update loop runs.
 	s.registry.Hives = []RegistryEntry{{ID: "h1", GitBranch: "v2"}}
 	resetSHACaches(t)
@@ -94,6 +95,7 @@ func TestHandleHubAutoUpgradeSuccess(t *testing.T) {
 	latestSHAMu.Unlock()
 
 	s := &HubServer{
+		hubSecret:  testHubSecret,
 		logger:     slog.Default(),
 		hubGitHash: "oldhubsha",
 		clusters:   map[string]ClusterConfig{defaultClusterID: {ID: defaultClusterID, InCluster: true}},
@@ -127,7 +129,7 @@ func TestHandleHubSelfUpgrade_Edge(t *testing.T) {
 	t.Cleanup(func() { hubImageExists = oldImgCheck })
 
 	// Failure path: fail-fast fake kubectl (exit 1) -> 500.
-	s := &HubServer{logger: slog.Default(), hubGitBranch: "v2", clusters: map[string]ClusterConfig{defaultClusterID: {ID: defaultClusterID, InCluster: true}}}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, hubGitBranch: "v2", clusters: map[string]ClusterConfig{defaultClusterID: {ID: defaultClusterID, InCluster: true}}}
 	rec := httptest.NewRecorder()
 	req := reqWithUser(http.MethodPost, "/hub-self", "", "admin")
 	s.handleHubSelfUpgrade(rec, req)
@@ -162,6 +164,7 @@ func TestHandleClusterHealthBuildError(t *testing.T) {
 	clusterHealthCacheMu.Unlock()
 
 	s := &HubServer{
+		hubSecret:       testHubSecret,
 		logger:          slog.Default(),
 		clusters:        map[string]ClusterConfig{},
 		heartbeatHealth: make(map[string]*HeartbeatHealthEntry),

--- a/v2/pkg/hub/saas_handlers2_coverage_test.go
+++ b/v2/pkg/hub/saas_handlers2_coverage_test.go
@@ -14,6 +14,7 @@ import (
 
 func newHandlerHub2() *HubServer {
 	return &HubServer{
+		hubSecret:               testHubSecret,
 		logger:                  slog.Default(),
 		saveCh:                  make(chan struct{}, 1),
 		hubBanners:              make(map[string]*HubBannerEntry),

--- a/v2/pkg/hub/saas_handlers_coverage_test.go
+++ b/v2/pkg/hub/saas_handlers_coverage_test.go
@@ -16,6 +16,20 @@ import (
 // kubectl, exercising the request-handling body without a real cluster.
 // ============================================================
 
+// testHubSecret is the shared hub secret every test signs its session cookie
+// with. Tests that build a HubServer relying on cookie auth set
+// hubSecret: testHubSecret (or arrange for NewHubServer to load it via
+// HIVE_HUB_SECRET, e.g. through helperSetupTempDirs) so the signature the
+// server recomputes matches the one baked into the cookie.
+const testHubSecret = "test-hub-secret-f4"
+
+// testAuthCookie mints a signed hive_hub_user cookie for username using
+// testHubSecret, matching the production cookie format so getAuthUser /
+// handleAuthUser accept it.
+func testAuthCookie(username string) *http.Cookie {
+	return &http.Cookie{Name: "hive_hub_user", Value: mintHubUserCookieValue(testHubSecret, username)}
+}
+
 // mkUser writes a SaaS user to the temp dir so getAuthUser resolves the cookie.
 func mkUser(t *testing.T, username string) {
 	t.Helper()
@@ -32,7 +46,7 @@ func reqWithUser(method, target, body, username string) *http.Request {
 	} else {
 		r = httptest.NewRequest(method, target, nil)
 	}
-	r.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: username})
+	r.AddCookie(testAuthCookie(username))
 	return r
 }
 
@@ -45,6 +59,7 @@ func setPathValue(r *http.Request, key, val string) *http.Request {
 func newHandlerHub() *HubServer {
 	return &HubServer{
 		logger:             slog.Default(),
+		hubSecret:          testHubSecret,
 		hubBanners:         make(map[string]*HubBannerEntry),
 		heartbeatSwitchTag: make(map[string]string),
 		heartbeatUpgrade:   make(map[string]string),
@@ -105,7 +120,9 @@ func TestHandleOpenHive(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
 	s := newHandlerHub()
-	s.hubSecret = "test-secret"
+	// newHandlerHub already sets hubSecret to testHubSecret, which is what
+	// reqWithUser signs its session cookie with — keep them in sync so the
+	// authenticated open paths below verify.
 
 	// Invalid id.
 	rec := httptest.NewRecorder()

--- a/v2/pkg/hub/saas_user_contact_test.go
+++ b/v2/pkg/hub/saas_user_contact_test.go
@@ -24,7 +24,7 @@ func contactPutRequest(username, body, asUser string) *http.Request {
 	req := httptest.NewRequest("PUT", "/api/saas/admin/users/"+username, strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	if asUser != "" {
-		req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: asUser})
+		req.AddCookie(testAuthCookie(asUser))
 	}
 	return req
 }

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -1348,8 +1348,7 @@ func (s *HubServer) removeRegistryEntry(id, by string) {
 }
 
 func (s *HubServer) handleRegistryDelete(w http.ResponseWriter, r *http.Request) {
-	cookie, err := r.Cookie("hive_hub_user")
-	if err != nil || cookie.Value != hubAdminUsername {
+	if s.getAuthUser(r) != hubAdminUsername {
 		http.Error(w, "admin access required", http.StatusForbidden)
 		return
 	}
@@ -1366,23 +1365,21 @@ func (s *HubServer) handleRegistryDelete(w http.ResponseWriter, r *http.Request)
 	s.mu.Unlock()
 	if removed {
 		s.requestSave()
-		s.logger.Info("audit: admin removed registry entry", "id", id, "admin", cookie.Value)
+		s.logger.Info("audit: admin removed registry entry", "id", id, "admin", hubAdminUsername)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"removed": removed, "id": id})
 }
 
 func (s *HubServer) handleHubVersion(w http.ResponseWriter, r *http.Request) {
+	// The hub secret is never returned from this browser-reachable endpoint; the
+	// raw shared secret has no legitimate consumer over HTTP.
 	resp := map[string]any{
 		"git_hash":      s.hubGitHash,
 		"git_branch":    s.hubGitBranch,
 		"latest_sha":    getLatestSHA(),
 		"latest_shas":   getLatestSHAs(),
 		"upgrade_state": s.hubUpgradeState(),
-	}
-	cookie, _ := r.Cookie("hive_hub_user")
-	if cookie != nil && cookie.Value == hubAdminUsername {
-		resp["hub_secret"] = s.hubSecret
 	}
 	data, _ := json.Marshal(resp)
 	w.Header().Set("Content-Type", "application/json")

--- a/v2/pkg/hub/small_gaps_coverage_test.go
+++ b/v2/pkg/hub/small_gaps_coverage_test.go
@@ -148,7 +148,7 @@ func TestVerifySSOTokenBranches(t *testing.T) {
 func TestHandleAuthUserAndLogout(t *testing.T) {
 	cleanup := helperSetupTempDirs(t)
 	defer cleanup()
-	s := &HubServer{logger: slog.Default()}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret}
 
 	// No cookie -> not authenticated.
 	rec := httptest.NewRecorder()
@@ -162,7 +162,7 @@ func TestHandleAuthUserAndLogout(t *testing.T) {
 	mkUser(t, "octocat")
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/auth/user", nil)
-	req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: "octocat"})
+	req.AddCookie(testAuthCookie("octocat"))
 	s.handleAuthUser(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Errorf("auth user status = %d, want 200", rec.Code)

--- a/v2/pkg/hub/timeline_test.go
+++ b/v2/pkg/hub/timeline_test.go
@@ -539,8 +539,9 @@ func TestHandleHiveTimelineAuthorization(t *testing.T) {
 	}
 
 	s := &HubServer{
-		logger:   slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
-		timeline: newTimelineStore(),
+		logger:    slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		hubSecret: testHubSecret,
+		timeline:  newTimelineStore(),
 	}
 	s.timeline.append(hiveID, TimelineRestarted, "process restarted", "")
 
@@ -563,7 +564,7 @@ func TestHandleHiveTimelineAuthorization(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/api/saas/hives/"+tc.hiveID+"/timeline", nil)
 			req.SetPathValue("id", tc.hiveID)
 			if tc.user != "" {
-				req.AddCookie(&http.Cookie{Name: "hive_hub_user", Value: tc.user})
+				req.AddCookie(testAuthCookie(tc.user))
 			}
 			rec := httptest.NewRecorder()
 			s.handleHiveTimeline(rec, req)
@@ -598,8 +599,9 @@ func TestRecordHeartbeatTransitionsNilStore(t *testing.T) {
 
 func TestMarkStaleHivesReportsOfflineOnce(t *testing.T) {
 	s := &HubServer{
-		logger:   slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
-		timeline: newTimelineStore(),
+		logger:    slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})),
+		hubSecret: testHubSecret,
+		timeline:  newTimelineStore(),
 	}
 	stale := time.Now().Add(-maxHeartbeatAge - time.Minute).UTC().Format(time.RFC3339)
 	s.registry.Hives = []RegistryEntry{

--- a/v2/pkg/hub/upgrade_schedule_test.go
+++ b/v2/pkg/hub/upgrade_schedule_test.go
@@ -308,7 +308,7 @@ func TestHandleToggleAutoUpgradeModePersistence(t *testing.T) {
 			defer cleanup()
 			mkUser(t, "alice")
 			saveSaaSHive(&SaaSHive{ID: "h1", Owner: "alice"})
-			s := &HubServer{logger: slog.Default(), heartbeatUpgrade: make(map[string]string)}
+			s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string)}
 
 			rec := httptest.NewRecorder()
 			req := setPathValue(reqWithUser(http.MethodPut, "/au", tc.body, "alice"), "id", "h1")
@@ -351,7 +351,7 @@ func TestHandleToggleAutoUpgradeClearsLastFired(t *testing.T) {
 		AutoUpgradeMode:      AutoUpgradeModeDaily,
 		AutoUpgradeLastFired: "2026-07-15",
 	})
-	s := &HubServer{logger: slog.Default(), heartbeatUpgrade: make(map[string]string)}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string)}
 
 	rec := httptest.NewRecorder()
 	req := setPathValue(reqWithUser(http.MethodPut,
@@ -385,7 +385,7 @@ func TestManualUpgradeUnaffectedByMode(t *testing.T) {
 		AutoUpgrade:     true,
 		AutoUpgradeMode: AutoUpgradeModeDaily,
 	})
-	s := &HubServer{logger: slog.Default(), heartbeatUpgrade: make(map[string]string)}
+	s := &HubServer{logger: slog.Default(), hubSecret: testHubSecret, heartbeatUpgrade: make(map[string]string)}
 
 	rec := httptest.NewRecorder()
 	req := setPathValue(reqWithUser(http.MethodPost, "/upgrade", `{}`, "alice"), "id", "h1")


### PR DESCRIPTION
Top up mk with the two newest v2 commits (#2202 bob-on-spokes, #2206 session-cookie hardening). Clean merge, 0 behind, v2 tip is ancestor. **Merge, not squash.**