### PR TITLE
fix(agent): deliver bob's bootstrap prompt so it does not idle after launch

### DIFF
--- a/v2/pkg/agent/bob_startup_kick_test.go
+++ b/v2/pkg/agent/bob_startup_kick_test.go
@@ -1,0 +1,304 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// TestBackendDefersStartupKick pins WHICH backends get their bootstrap prompt
+// delivered by deliverStartupKick versus embedded in the launch command.
+//
+// bob is the fix: it was in neither group, so its bootstrap prompt was written
+// to /tmp/.hive-bootstrap-<name>.txt and never read, leaving it idle.
+//
+// The other rows are regression guards. goose in particular MUST stay false —
+// `goose run` needs the embedded --text prompt to stay interactive and exits on
+// the ^C that readiness-gated delivery sends.
+func TestBackendDefersStartupKick(t *testing.T) {
+	tests := []struct {
+		name    string
+		backend string
+		want    bool
+		why     string
+	}{
+		{"bob defers (the fix)", bobBackend, true,
+			"bob is an interactive TUI with no embedded-prompt mechanism"},
+		{"claude unchanged", "claude", true,
+			"pre-existing deferred backend"},
+		{"copilot unchanged", "copilot", true,
+			"pre-existing deferred backend"},
+		{"gemini unchanged", "gemini", true,
+			"pre-existing deferred backend"},
+		{"goose still embeds", "goose", false,
+			"goose run needs --text and exits on the ^C a deferred kick sends"},
+		{"codex still embeds", codexBackend, false,
+			"not a deferred backend; must not change"},
+		{"aider still embeds", "aider", false,
+			"not a deferred backend; must not change"},
+		{"unknown backend does not defer", "totally-made-up", false,
+			"no verified readiness signal for unknown CLIs"},
+		{"empty backend does not defer", "", false,
+			"guard against a zero-value backend silently deferring"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := backendDefersStartupKick(tc.backend); got != tc.want {
+				t.Errorf("backendDefersStartupKick(%q) = %v, want %v (%s)",
+					tc.backend, got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+// TestBobPaneMarkers pins the literals copied from the installed bobshell
+// bundle (1.0.6, bundle/bob.js). They are vendor-defined, not ours: if a bob
+// upgrade changes them, bob's readiness detection breaks silently (its startup
+// kick is dropped after cliReadyTimeout) and this test is the tripwire.
+func TestBobPaneMarkers(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"input placeholder (primary readiness signal)", bobInputPlaceholder,
+			"Type your message or @path/to/file"},
+		{"product marker (coarse CLI presence only)", bobProductMarker, "Bob-Shell"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Errorf("marker = %q, want %q", tc.got, tc.want)
+			}
+		})
+	}
+
+	// Both markers must be reachable through the shared CLI-presence check,
+	// otherwise waitForCLIReadyForAgent can never see a booted bob.
+	for _, marker := range []string{bobInputPlaceholder, bobProductMarker} {
+		if !paneHasCLIMarker("some pane text " + marker + " trailing") {
+			t.Errorf("paneHasCLIMarker must recognise bob marker %q", marker)
+		}
+	}
+}
+
+// TestPaneShowsInputPrompt covers the readiness gate that decides whether a
+// startup kick is typed or dropped.
+//
+// The claude/copilot/gemini/goose rows assert the pre-existing markers still
+// match EXACTLY as before — this is the test that proves adding bob did not
+// change the other backends' readiness behaviour.
+func TestPaneShowsInputPrompt(t *testing.T) {
+	tests := []struct {
+		name string
+		pane string
+		want bool
+	}{
+		// --- bob: the new behaviour ---
+		{"bob idle input box", "  " + bobInputPlaceholder, true},
+		{"bob placeholder amid other output", "booting\n  " + bobInputPlaceholder + "\n", true},
+
+		// --- pre-existing markers: must be unchanged ---
+		{"claude/copilot/gemini arrow prompt", "some output\n❯ ", true},
+		{"goose ready banner", "goose is ready", true},
+		{"enter-to-send prompt", "> Enter to send", true},
+		{"bare newline-gt-newline prompt", "text\n>\nmore", true},
+
+		// --- negatives ---
+		{"empty pane", "", false},
+		{"bare bash prompt", "user@host:~$ ", false},
+		{"bob product name alone is NOT input-ready", bobProductMarker, false},
+		{"bob license dialog is NOT input-ready",
+			bobProductMarker + " API Key Notice\nBy using the " + bobProductMarker + " API", false},
+		{"unrelated prose", "the build finished successfully", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := paneShowsInputPrompt(tc.pane); got != tc.want {
+				t.Errorf("paneShowsInputPrompt(%q) = %v, want %v", tc.pane, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBobConsentScreenNoFalsePositive guards the OTHER half of the readiness
+// chain. paneShowsConsentScreen makes waitForInputPromptForAgent skip a pane,
+// and its markers are Claude-specific ("Enter to confirm", "Bypass Permissions
+// mode"). Verified against bobshell 1.0.6: the bundle contains none of them, so
+// a bob pane must never be mistaken for a consent screen — if it were, bob's
+// kick would be dropped exactly as it was before this fix.
+func TestBobConsentScreenNoFalsePositive(t *testing.T) {
+	tests := []struct {
+		name string
+		pane string
+	}{
+		{"bob idle prompt", "  " + bobInputPlaceholder},
+		{"bob banner", bobProductMarker + " 1.0.6"},
+		{"bob trust dialog text",
+			"Trusting a folder allows " + bobProductMarker + " to read and perform auto-edits"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if paneShowsConsentScreen(tc.pane) {
+				t.Errorf("paneShowsConsentScreen(%q) = true; a bob pane must never "+
+					"be treated as a consent screen or its startup kick is dropped", tc.pane)
+			}
+		})
+	}
+}
+
+// TestBobInputHandlerSettleDelay pins the bob-only settle window and asserts it
+// is genuinely distinct from the generic tmux pacing constants. bob's Ink
+// reconciler paints the input box before attaching its stdin handler, so text
+// typed too early is painted but never reaches component state.
+func TestBobInputHandlerSettleDelay(t *testing.T) {
+	if bobInputHandlerSettleDelay <= 0 {
+		t.Fatalf("bobInputHandlerSettleDelay must be positive, got %v", bobInputHandlerSettleDelay)
+	}
+	// It must not silently collapse into a value that "happens to work" and is
+	// really just tmux keystroke pacing.
+	for _, other := range []struct {
+		name string
+		d    time.Duration
+	}{
+		{"textToEnterDelay", textToEnterDelay},
+		{"staleCheckDelay", staleCheckDelay},
+	} {
+		if bobInputHandlerSettleDelay == other.d {
+			t.Errorf("bobInputHandlerSettleDelay (%v) must be a deliberate, distinct "+
+				"value, not a reuse of %s (%v)", bobInputHandlerSettleDelay, other.name, other.d)
+		}
+	}
+	// The settle window must fit comfortably inside the gate that precedes it,
+	// or a slow bob would blow the overall startup-kick budget.
+	if bobInputHandlerSettleDelay >= inputPromptTimeout {
+		t.Errorf("bobInputHandlerSettleDelay (%v) must be far below inputPromptTimeout (%v)",
+			bobInputHandlerSettleDelay, inputPromptTimeout)
+	}
+}
+
+// TestBobStartupKickNotWrittenToDeadTempFile documents that bob no longer takes
+// the write-a-file-and-never-read-it path. Only backends that actually consume
+// the file (goose, via --text "$(cat ...)") should be writing it.
+//
+// Asserted through the launch-command builder: bob's command must contain no
+// reference to the bootstrap temp file and no embedded prompt argument.
+func TestBobStartupKickNotWrittenToDeadTempFile(t *testing.T) {
+	cmd := bobLaunchCmd("bob", "some-model")
+	for _, forbidden := range []string{".hive-bootstrap", "--text", "$(cat", "-p ", "--prompt"} {
+		if strings.Contains(cmd, forbidden) {
+			t.Errorf("bobLaunchCmd() = %q must not contain %q: bob's prompt is delivered "+
+				"by deliverStartupKick, not embedded or read from a temp file", cmd, forbidden)
+		}
+	}
+}
+
+// TestDeliverStartupKick_BobReceivesKick is the end-to-end proof that the
+// prompt actually reaches bob, rather than merely that a function was called.
+//
+// It drives the real deliverStartupKick against a real tmux pane rendering
+// bob's real idle placeholder, and asserts the kick was delivered: LastKick
+// set, the exact prompt text recorded, and history appended. Before this fix
+// the pane would never satisfy waitForCLIReadyForAgent (bob renders none of
+// the pre-existing markers) and the kick would be dropped.
+func TestDeliverStartupKick_BobReceivesKick(t *testing.T) {
+	if !tmuxAvailable() {
+		t.Skip("tmux not available")
+	}
+	const session = "hive-bobkick1"
+	newRawTmuxSession(t, session)
+
+	m := NewManager(map[string]config.AgentConfig{
+		session: {Backend: bobBackend},
+	}, discardLogger(), ProjectContext{})
+
+	m.mu.RLock()
+	agent := m.agents[session]
+	m.mu.RUnlock()
+	if agent == nil {
+		t.Fatalf("agent %q not registered", session)
+	}
+	agent.tmuxSession = session
+	agent.State = StateRunning
+	agent.launchGen = 1
+
+	// Render EXACTLY what a booted, idle bob shows — no "❯", no goose banner.
+	paneInject(t, session, bobInputPlaceholder)
+
+	const prompt = "bootstrap: go find work"
+	m.deliverStartupKick(agent, prompt, 1)
+
+	if agent.LastKick == nil {
+		t.Fatal("bob must receive its startup kick; LastKick is nil " +
+			"(the prompt was dropped, which is the bug this change fixes)")
+	}
+	if agent.LastKickMessage != prompt {
+		t.Errorf("LastKickMessage = %q, want %q", agent.LastKickMessage, prompt)
+	}
+	if len(agent.KickHistory) == 0 {
+		t.Error("bob's startup kick must be recorded in KickHistory")
+	}
+}
+
+// TestDeliverStartupKick_PausedAgentNotKicked covers the paused-agent case.
+//
+// An agent restored as paused never reaches launchInTmux at all (Start returns
+// early with State=StatePaused), so no startup kick is ever spawned. This test
+// pins the second line of defence: even if a kick goroutine is somehow in
+// flight, deliverStartupKick's state check must refuse to deliver to an agent
+// that is not StateRunning.
+func TestDeliverStartupKick_PausedAgentNotKicked(t *testing.T) {
+	if !tmuxAvailable() {
+		t.Skip("tmux not available")
+	}
+
+	tests := []struct {
+		name    string
+		session string
+		backend string
+	}{
+		{"paused bob is not kicked", "hive-bobpause1", bobBackend},
+		{"paused claude is not kicked", "hive-bobpause2", "claude"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			newRawTmuxSession(t, tc.session)
+			name := tc.session
+			m := NewManager(map[string]config.AgentConfig{
+				name: {Backend: tc.backend},
+			}, discardLogger(), ProjectContext{})
+
+			m.mu.RLock()
+			agent := m.agents[name]
+			m.mu.RUnlock()
+			if agent == nil {
+				t.Fatalf("agent %q not registered", name)
+			}
+			agent.tmuxSession = tc.session
+			agent.Paused = true
+			agent.State = StatePaused
+			agent.launchGen = 1
+
+			// Render a ready prompt so the readiness gates pass fast and the
+			// state check — not a timeout — is what stops delivery.
+			paneInject(t, tc.session, "goose is ready")
+
+			m.deliverStartupKick(agent, "bootstrap prompt", 1)
+
+			if agent.LastKick != nil {
+				t.Error("a paused agent must not receive a startup kick")
+			}
+			if len(agent.KickHistory) != 0 {
+				t.Errorf("a paused agent must record no kick history, got %d entries",
+					len(agent.KickHistory))
+			}
+		})
+	}
+}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -654,7 +654,32 @@ var cliPaneMarkers = []string{
 	"Copilot",
 	"Gemini",
 	"goose",
+	// bob's markers. NONE of the entries above match a running bob: verified
+	// against the installed bundle (bobshell 1.0.6 bundle/bob.js), which
+	// contains zero "❯" characters and no "esc cancel" / "/ commands" /
+	// "? help" / "goose" strings. ("Claude"/"Gemini" occur only as model-name
+	// data, never as UI chrome.) Without these two entries
+	// waitForCLIReadyForAgent can never see a booted bob, so its startup kick
+	// would be dropped after cliReadyTimeout even though bob is healthy.
+	bobInputPlaceholder,
+	bobProductMarker,
 }
+
+const (
+	// bobInputPlaceholder is the placeholder bob renders inside its input box
+	// when it is idle and accepting input. This is bob's equivalent of the "❯"
+	// prompt for the other TUIs and is the PRIMARY readiness signal: the
+	// bundle renders it on the same component whose presence is gated by
+	// `isInputActive`, so seeing it means the input is live, not merely
+	// painted. Copied verbatim from bobshell 1.0.6 — see TestBobPaneMarkers.
+	bobInputPlaceholder = "Type your message or @path/to/file"
+	// bobProductMarker is bob's product name, which appears in its banner and
+	// dialogs. It is a weaker, secondary signal than bobInputPlaceholder — it
+	// also shows on trust/auth/license dialogs, which are NOT ready states —
+	// so it is used only for coarse CLI-presence detection (is anything other
+	// than bash in this pane?), never as the input-ready gate.
+	bobProductMarker = "Bob-Shell"
+)
 
 // paneHasCLIMarker reports whether the given pane content contains any known
 // CLI UI marker.
@@ -736,6 +761,37 @@ func paneShowsConsentScreen(pane string) bool {
 	return false
 }
 
+
+// backendDefersStartupKick reports whether a backend's bootstrap prompt is
+// delivered AFTER the CLI is ready (deliverStartupKick) instead of being
+// embedded in the launch command.
+//
+// Embedding raced the CLI boot: the prompt-bearing launch line was typed into
+// the pane in the same second as the (re)start (observed live: `audit: agent
+// kicked trigger=startup` 60ms after `audit: agent restarting`), before the
+// CLI — or even bash — was ready to consume it, so the kick text landed in
+// bash and an unbalanced quote left the shell in PS2 continuation.
+//
+// goose is deliberately NOT in this set: `goose run` needs the embedded --text
+// prompt to stay interactive at all, and it exits on the ^C that
+// readiness-gated delivery sends (see deliverKickLocked). Unknown backends are
+// likewise excluded — they never embed and have no verified readiness signal.
+//
+// bob belongs in this set, not the goose set. It is a long-lived interactive
+// TUI (launched WITHOUT -p, see bobLaunchCmd) that sits at its prompt with no
+// prompt argument at all, so it has no goose-style reason to embed — and
+// embedding would expose it to exactly the PS2 race above. Before this it was
+// in NEITHER group: it fell through to the write-a-file branch in launchInTmux,
+// so its bootstrap prompt was serialized to /tmp/.hive-bootstrap-<name>.txt and
+// then never read, leaving bob idle at its prompt after every launch.
+func backendDefersStartupKick(backend string) bool {
+	switch backend {
+	case "claude", "copilot", "gemini", bobBackend:
+		return true
+	default:
+		return false
+	}
+}
 
 func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	backend := agent.Config.Backend
@@ -888,23 +944,11 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		bootstrapPrompt = "You are an AI agent. Await further instructions."
 	}
 
-	// Interactive backends get the bootstrap prompt delivered AFTER the CLI
-	// is ready (deliverStartupKick, spawned below) instead of embedding it in
-	// the launch command. Embedding raced the CLI boot: the prompt-bearing
-	// launch line was typed into the pane in the same second as the (re)start
-	// (observed live: `audit: agent kicked trigger=startup` 60ms after
-	// `audit: agent restarting`), before the CLI — or even bash — was ready
-	// to consume it, so the kick text landed in bash and an unbalanced quote
-	// left the shell in PS2 continuation. Goose keeps the embedded --text
-	// prompt: goose run needs it to stay interactive and exits on the ^C that
-	// readiness-gated delivery sends.
+	// See backendDefersStartupKick for why each backend is or is not deferred.
 	deferredStartupKick := ""
-	if bootstrapPrompt != "" {
-		switch backend {
-		case "claude", "copilot", "gemini":
-			deferredStartupKick = bootstrapPrompt
-			bootstrapPrompt = ""
-		}
+	if bootstrapPrompt != "" && backendDefersStartupKick(backend) {
+		deferredStartupKick = bootstrapPrompt
+		bootstrapPrompt = ""
 	}
 
 	if bootstrapPrompt != "" {
@@ -924,8 +968,10 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 		m.recordPrompt(agent.Name, "startup", bootstrapPrompt)
 
 		// Only goose (and unknown backends, which never embed) reach this
-		// block — claude/copilot/gemini bootstrap prompts were deferred to
-		// deliverStartupKick above.
+		// block — claude/copilot/gemini/bob bootstrap prompts were deferred to
+		// deliverStartupKick above, so no /tmp/.hive-bootstrap-<name>.txt is
+		// written for them. bob used to land here and get a file nothing ever
+		// read; that dead write is gone with the deferral above.
 		promptFile := fmt.Sprintf("/tmp/.hive-bootstrap-%s.txt", agent.Name)
 		if err := os.WriteFile(promptFile, []byte(bootstrapPrompt), 0o644); err != nil {
 			m.logger.Warn("failed to write bootstrap prompt", "name", agent.Name, "error", err)
@@ -1683,6 +1729,27 @@ func findOverlap(prev, curr []string) int {
 }
 
 
+// paneShowsInputPrompt reports whether the pane content shows a CLI input
+// prompt that is ready to accept a kick.
+//
+// The first four markers are the pre-existing set, preserved verbatim so
+// claude/copilot/gemini/goose readiness is bit-for-bit unchanged. The bob
+// placeholder is additive: bob's TUI renders none of the other four (verified
+// against bobshell 1.0.6 — the bundle contains no "❯" at all), so without it a
+// healthy bob never registers as ready and its startup kick is dropped.
+//
+// Callers pass captured pane text; empty input is not a prompt.
+func paneShowsInputPrompt(output string) bool {
+	if output == "" {
+		return false
+	}
+	return strings.Contains(output, "❯") ||
+		strings.Contains(output, "goose is ready") ||
+		strings.Contains(output, "> Enter to send") ||
+		strings.Contains(output, "\n>\n") ||
+		strings.Contains(output, bobInputPlaceholder)
+}
+
 // waitForCLIReady polls the tmux pane until the CLI shows its ready prompt
 // or the timeout expires. Returns true if the CLI became ready.
 func (m *Manager) waitForCLIReady(session string) bool {
@@ -1758,6 +1825,7 @@ func (m *Manager) waitForInputPromptForAgent(agent *AgentProcess) bool {
 				"has_goose_ready", strings.Contains(output, "goose is ready"),
 				"has_enter", strings.Contains(output, "> Enter to send"),
 				"has_arrow", strings.Contains(output, "❯"),
+				"has_bob_placeholder", strings.Contains(output, bobInputPlaceholder),
 				"head_500", truncateHead(output, 500), "tail_500", truncateTail(output, 500))
 			return false
 		case <-ticker.C:
@@ -1769,7 +1837,7 @@ func (m *Manager) waitForInputPromptForAgent(agent *AgentProcess) bool {
 				continue
 			}
 			output := m.captureTmuxPaneForAgent(agent)
-			if strings.Contains(output, "❯") || strings.Contains(output, "goose is ready") || strings.Contains(output, "> Enter to send") || strings.Contains(output, "\n>\n") {
+			if paneShowsInputPrompt(output) {
 				return true
 			}
 		}
@@ -1790,7 +1858,7 @@ func (m *Manager) waitForInputPrompt(session string) bool {
 			return false
 		case <-ticker.C:
 			output := m.captureTmuxPane(session)
-			if strings.Contains(output, "❯") || strings.Contains(output, "goose is ready") || strings.Contains(output, "> Enter to send") || strings.Contains(output, "\n>\n") {
+			if paneShowsInputPrompt(output) {
 				return true
 			}
 		}
@@ -2213,6 +2281,24 @@ func (m *Manager) deliverStartupKick(agent *AgentProcess, prompt string, gen int
 		m.logger.Warn("startup kick dropped: CLI never reached input prompt",
 			"name", agent.Name, "session", agent.tmuxSession, "trigger", "startup")
 		return
+	}
+
+	// bob needs an extra settle window that the other TUIs do not. Its UI is a
+	// React/Ink app (its crashes surface as React reconciler stack traces), and
+	// Ink paints the input box on an early render pass — so the placeholder
+	// that waitForInputPromptForAgent matches can be visible before the
+	// reconciler has finished mounting the input component and attached its
+	// stdin handler. Text typed in that window is painted into the pane but
+	// never reaches component state, so the kick is silently swallowed and bob
+	// stays idle — the exact failure this change exists to fix. claude/copilot/
+	// gemini do not need this: their input handlers are live as soon as the
+	// prompt renders, which is why the delay is bob-only rather than a new
+	// universal pause in the shared path.
+	//
+	// Read outside m.mu: effectiveBackend is a pure field read and this path
+	// must not hold the lock while sleeping.
+	if effectiveBackend(agent) == bobBackend {
+		time.Sleep(bobInputHandlerSettleDelay)
 	}
 
 	m.mu.Lock()
@@ -2673,6 +2759,20 @@ const (
 	// clears stale PS2 quote-continuation state before the launch command
 	// is typed into the pane.
 	preLaunchShellClearDelay = 500 * time.Millisecond
+	// bobInputHandlerSettleDelay is an extra pause applied ONLY to the bob
+	// backend after its input prompt becomes visible, before its startup kick
+	// is typed. bob's TUI is React/Ink: Ink paints the input box on an early
+	// render pass, so the placeholder can be on screen before the reconciler
+	// finishes mounting the input component and attaching its stdin handler.
+	// Typing in that gap paints characters that never reach component state —
+	// the kick is swallowed and bob sits idle. It is deliberately NOT reused
+	// from textToEnterDelay/staleCheckDelay (1s each): those cover tmux
+	// keystroke pacing, a different concern, and a value that merely happens
+	// to work is what this constant exists to avoid. 3s is a conservative
+	// multiple of the observed 1s pacing unit, chosen because over-waiting
+	// costs one agent a few seconds once per launch while under-waiting
+	// silently loses the bootstrap prompt entirely.
+	bobInputHandlerSettleDelay = 3 * time.Second
 	// cliBootGraceSeconds is how long after StartedAt a bare pane (no CLI
 	// marker) is tolerated before CheckAndRestartCrashedAgents treats it as a
 	// crash. It matches cliReadyTimeout (60s) so a still-booting CLI is never


### PR DESCRIPTION
## Problem

bob installs (#2187) and authenticates (#2202) but **never receives its bootstrap prompt** — it launches, authenticates, and then sits idle until something else kicks it.

Two independent defects. **Either one alone leaves bob idle**, so both had to be fixed.

## Defect 1 — bob was in neither delivery group

`launchInTmux` has two prompt-delivery mechanisms:

1. **`deferredStartupKick`** — typed into the pane once the CLI is ready
2. **goose's embedded `--text`** argument

bob was in neither, so it fell through to the branch that writes `/tmp/.hive-bootstrap-<name>.txt` and then only appends `--text` for goose. The file was written and never read.

**Chosen mechanism: `deferredStartupKick`.** bob is a long-lived interactive TUI (launched without `-p`; interactive mode retained per #2202) that sits at its prompt with no prompt argument at all — so it has no goose-style reason to embed, and embedding would expose it to the documented PS2 quote-continuation race. goose stays embedded: `goose run` needs `--text` to remain interactive and exits on the `^C` a deferred kick sends.

The switch is extracted to `backendDefersStartupKick` so the policy is testable directly rather than only through a launch.

## Defect 2 — bob could never satisfy the readiness gate

Adding bob to the switch alone does **not** fix the bug. `deliverStartupKick` gates on `waitForCLIReadyForAgent` + `waitForInputPromptForAgent`, and neither can ever match a running bob.

Verified against the installed bundle (`bobshell 1.0.6 bundle/bob.js`) rather than assumed — it contains **zero `❯` characters** and none of `esc cancel`, `/ commands`, `? help`, `goose`. (`Claude`/`Gemini` appear only as model-name data, never as UI chrome.) The kick would have been dropped after `cliReadyTimeout` with bob perfectly healthy.

bob's real idle signal is the placeholder rendered inside its input box, `Type your message or @path/to/file`, emitted by the component gated on `isInputActive` — so seeing it means the input **exists**, not merely that something is on screen. Added as the primary readiness marker, plus `Bob-Shell` as a **coarse CLI-presence marker only** (it also appears on trust/auth/license dialogs, which are not ready states, so it is deliberately excluded from the input-ready gate).

The duplicated four-marker input-prompt condition is extracted to `paneShowsInputPrompt` with the existing markers **preserved verbatim**; bob's placeholder is purely additive. The prompt-timeout diagnostic now also reports `has_bob_placeholder`, otherwise a bob timeout is undebuggable.

## Readiness / delay handling

bob gets one bob-only pause, `bobInputHandlerSettleDelay` (3s, named constant with rationale). bob's UI is React/Ink; Ink paints the input box on an early render pass, so the placeholder can be visible **before** the reconciler has mounted the input component and attached its stdin handler. Text typed in that gap is painted but never reaches component state — the kick is swallowed.

claude/copilot/gemini need no such pause, so this is **not** a new universal delay in the shared path. It is deliberately not a reuse of `textToEnterDelay`/`staleCheckDelay` (1s tmux keystroke pacing — a different concern); a test asserts it stays distinct from both.

## Concurrency

The settle sleep and the `effectiveBackend` read happen **before** `m.mu` is taken. `effectiveBackend` is a pure field read, and the lock is never held across the sleep — respecting the non-reentrant `RWMutex` and the documented startup-deadlock class.

## Paused agents — unchanged and preserved

An agent restored as paused returns from `Start` with `StatePaused` before reaching `launchInTmux`, so no kick goroutine is ever spawned. `deliverStartupKick`'s existing `State != StateRunning` check is the second line of defence. Both are covered by tests.

## Dead temp file

bob no longer writes `/tmp/.hive-bootstrap-<name>.txt`. The file remains for goose, which actually reads it via `--text "$(cat ...)"`.

## Tests (table-driven)

- `backendDefersStartupKick` pinned per backend — goose/codex/aider stay embedded, empty/unknown backends do not defer
- `paneShowsInputPrompt` — bob's placeholder matches; **all four pre-existing markers still match exactly** (this is the test proving other backends are unaffected); bob's product name and license dialog explicitly NOT input-ready
- bob's markers pinned to the vendor literals (tripwire for a bob upgrade) and asserted reachable via `paneHasCLIMarker`
- `paneShowsConsentScreen` must never fire on a bob pane (its markers are Claude-specific; confirmed absent from the bundle)
- **end-to-end**: `deliverStartupKick` against a real tmux pane rendering only bob's real placeholder actually sets `LastKick`/`LastKickMessage`/`KickHistory`. Confirmed to **FAIL** (kick dropped after timeout) when the bob marker is removed — it guards the regression rather than merely passing
- a paused bob and a paused claude receive no kick

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test -count=1 -timeout 900s ./pkg/agent/` — **passes in full, 430s**, no `signal: killed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)