### PR TITLE
🐛 fix(hub+spoke): stop the SSO handoff redirect loop on hosted spokes

### DIFF
--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html"
 	"io"
 	"log/slog"
 	"net/http"
@@ -1490,17 +1491,38 @@ func (s *Server) handleGHUserAuthPoll(w http.ResponseWriter, r *http.Request) {
 // authorized_users allowlist. On success it mints the same kind of session the
 // device flow does and redirects to the dashboard root.
 func (s *Server) handleSSO(w http.ResponseWriter, r *http.Request) {
+	// Loop breaker. An authentication failure must never present as an infinite
+	// redirect: if this navigation has already been through the handoff
+	// maxSSOHops times, something between here and "/" is bouncing us and no
+	// further hop will help. Stop and say so.
+	hop, _ := strconv.Atoi(r.URL.Query().Get(ssoHopParam))
+	if hop >= maxSSOHops {
+		if s.deps != nil && s.deps.Logger != nil {
+			s.deps.Logger.Warn("sso handoff loop detected", "hops", hop)
+		}
+		writeSSOError(w, r, http.StatusLoopDetected, ssoErrLoopDetected,
+			"Signing in to this hive redirected in a circle, so it was stopped before your browser gave up.",
+			"Sign in directly with GitHub below. If that also fails, the hive's access settings likely disagree with the hub's — ask the hive operator to check that your account is on this hive's authorized-users list.")
+		return
+	}
+
 	secret := os.Getenv("HIVE_HUB_SECRET")
 	if secret == "" {
-		// No shared secret → SSO cannot be verified. Send the user to the normal
-		// login rather than silently trusting anything.
-		http.Redirect(w, r, "/", http.StatusSeeOther)
+		// No shared secret → SSO cannot be verified. Terminate with an
+		// explanation. Redirecting to "/" here is what produced the historical
+		// infinite bounce: "/" is auth-gated, sends the user back to the hub
+		// login, the hub sees a valid session and hands off to /sso again.
+		writeSSOError(w, r, http.StatusServiceUnavailable, ssoErrNoSecret,
+			"This hive has no hub shared secret configured, so single sign-on from the hub cannot be verified.",
+			"Ask the hive operator to set HIVE_HUB_SECRET on this hive. In the meantime you can sign in directly with GitHub using the button below.")
 		return
 	}
 
 	token := r.URL.Query().Get("token")
 	if token == "" {
-		http.Error(w, "sso: missing token", http.StatusBadRequest)
+		writeSSOError(w, r, http.StatusBadRequest, ssoErrMissingToken,
+			"This single sign-on link is missing its handoff token.",
+			"Open the hive from the hub dashboard rather than pasting the /sso URL directly.")
 		return
 	}
 
@@ -1514,10 +1536,11 @@ func (s *Server) handleSSO(w http.ResponseWriter, r *http.Request) {
 		if s.deps != nil && s.deps.Logger != nil {
 			s.deps.Logger.Warn("sso handoff rejected", "error", err.Error())
 		}
-		// Don't leak which check failed; bounce to the normal login page.
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.WriteHeader(http.StatusUnauthorized)
-		w.Write([]byte(loginPage))
+		// Don't leak which check failed, but DO terminate here with an
+		// explanation rather than serving anything that re-enters the handoff.
+		writeSSOError(w, r, http.StatusUnauthorized, ssoErrBadToken,
+			"The single sign-on handoff token was rejected — it is expired, malformed, or was issued for a different hive.",
+			"Go back to the hub dashboard and open this hive again to get a fresh link. Handoff links are short-lived by design.")
 		return
 	}
 
@@ -1536,9 +1559,9 @@ func (s *Server) handleSSO(w http.ResponseWriter, r *http.Request) {
 			if s.deps.Logger != nil {
 				s.deps.Logger.Warn("sso handoff: user not authorized for this hive", "username", username)
 			}
-			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			w.WriteHeader(http.StatusForbidden)
-			w.Write([]byte(loginPage))
+			writeSSOError(w, r, http.StatusForbidden, ssoErrNotAuthorized,
+				"You are signed in to the hub, but this hive's own authorized-users list does not include your account.",
+				"Ask the hive owner to grant you access to this hive, then open it again from the hub dashboard.")
 			return
 		}
 	}
@@ -1546,20 +1569,106 @@ func (s *Server) handleSSO(w http.ResponseWriter, r *http.Request) {
 		role = config.RoleRead
 	}
 
-	if s.authToken != "" {
-		sid := s.createUserSession(username, role)
-		if sid == "" {
-			http.Error(w, "sso: failed to create session", http.StatusInternalServerError)
-			return
-		}
-		setSessionCookie(w, r, sid)
+	// Always mint the session. This used to be gated on s.authToken != "", which
+	// meant a spoke with no dashboard token logged "authenticated via SSO",
+	// redirected to "/", and set NO cookie at all — so "/" rejected the request
+	// and the browser bounced forever. The session store is the authority on
+	// identity here and does not depend on a shared token existing.
+	sid := s.createUserSession(username, role)
+	if sid == "" {
+		writeSSOError(w, r, http.StatusInternalServerError, ssoErrSessionFailed,
+			"The hive could not create a login session for you.",
+			"This is a problem on the hive itself. Retry in a moment; if it persists, ask the hive operator to check the dashboard logs.")
+		return
 	}
+	setSessionCookie(w, r, sid)
 	s.audit.Log(username, "login", auditDetail("method", "hub sso handoff", "role", role), "")
 	if s.deps != nil && s.deps.Logger != nil {
 		s.deps.Logger.Info("user authenticated via hub SSO handoff", "username", username, "role", role)
 	}
-	http.Redirect(w, r, "/", http.StatusSeeOther)
+	// Land on the dashboard root, carrying a hop counter. If something upstream
+	// bounces us back into /sso anyway, the counter lets the NEXT handoff detect
+	// the cycle and stop with an error instead of spinning (see the ssoHopParam
+	// check at the top of this handler).
+	http.Redirect(w, r, "/?"+ssoHopParam+"="+strconv.Itoa(hop+1), http.StatusSeeOther)
 }
+
+// SSO handoff failure identifiers, surfaced on the terminal error page so a
+// user can quote one to an operator and an operator can grep for it.
+const (
+	ssoErrNoSecret      = "SSO_NO_HUB_SECRET"
+	ssoErrMissingToken  = "SSO_MISSING_TOKEN"
+	ssoErrBadToken      = "SSO_TOKEN_REJECTED"
+	ssoErrNotAuthorized = "SSO_NOT_AUTHORIZED"
+	ssoErrSessionFailed = "SSO_SESSION_FAILED"
+	ssoErrLoopDetected  = "SSO_REDIRECT_LOOP"
+)
+
+// ssoHopParam is the query parameter carrying how many times this browser has
+// been through the SSO handoff for this navigation. The hub's handoff link
+// carries no hop, so a normal first visit is hop 0; each success redirect
+// increments it. Anything that bounces the browser back into /sso preserves the
+// query string, so a genuine cycle counts upward and trips maxSSOHops.
+const ssoHopParam = "sso_hop"
+
+// maxSSOHops is how many SSO handoffs are allowed for one navigation before we
+// declare a redirect loop and stop. A healthy handoff takes exactly one hop; a
+// small allowance absorbs a legitimate re-handoff (e.g. a racing session
+// expiry) without letting a true cycle run away. Browsers give up around 20
+// redirects with an opaque error, so we must terminate well before that to be
+// the one that explains what happened.
+const maxSSOHops = 3
+
+// writeSSOError terminates an SSO handoff with a self-contained HTML page that
+// says what failed and what to do about it. It exists because the alternative —
+// redirecting a failed handoff back toward login — is what produces an infinite
+// browser bounce, the single worst failure mode here: it tells the user nothing
+// and is indistinguishable from an outage. Any non-success exit from handleSSO
+// must come through this function.
+//
+// It also clears any stale session cookie, so a half-established session cannot
+// keep re-triggering the same failure on reload.
+func writeSSOError(w http.ResponseWriter, r *http.Request, status int, code, what, action string) {
+	clearSessionCookie(w)
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	// A failed handoff must never be cached; a cached 401/403 would make the
+	// hive look permanently broken even after access is granted.
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	fmt.Fprintf(w, ssoErrorPage, html.EscapeString(code), html.EscapeString(what), html.EscapeString(action))
+}
+
+// ssoErrorPage is the terminal error shell for a failed SSO handoff. Format
+// verbs in order: %[1]s error code, %[2]s what happened, %[3]s what to do. It
+// deliberately offers "/" (which serves the device-flow login page when
+// unauthenticated) as an escape hatch and a link back to the hub, so the user
+// is never stranded.
+const ssoErrorPage = `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Sign-in failed — Hive</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#0d1117;color:#e6edf3;display:flex;justify-content:center;align-items:center;min-height:100vh;padding:24px}
+.card{background:#161b22;border:1px solid #30363d;border-radius:12px;padding:40px;max-width:560px}
+.bee{font-size:2.5rem;margin-bottom:12px}
+h1{font-size:1.5rem;margin-bottom:16px}
+p{color:#8b949e;line-height:1.6;margin-bottom:16px}
+.action{color:#e6edf3}
+code{background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:2px 8px;font-size:0.8rem;color:#f0883e}
+.btn{display:inline-block;padding:10px 20px;border-radius:8px;text-decoration:none;font-weight:600;font-size:0.9rem;margin:16px 8px 0 0}
+.btn-primary{background:#238636;color:#fff}
+.btn-secondary{background:transparent;color:#58a6ff;border:1px solid #30363d}
+</style></head>
+<div class="card">
+<div class="bee">&#128029;</div>
+<h1>Sign-in didn't complete</h1>
+<p>%[2]s</p>
+<p class="action">%[3]s</p>
+<p>Error code: <code>%[1]s</code></p>
+<a class="btn btn-primary" href="/">Sign in with GitHub</a>
+<a class="btn btn-secondary" href="https://hive.kubestellar.io/dashboard">Back to the hub</a>
+</div>
+</html>`
 
 func (s *Server) handleGHUserAuthLogout(w http.ResponseWriter, r *http.Request) {
 	// Clear only THIS request's session so logging out affects one user, not

--- a/v2/pkg/dashboard/api_misc_coverage_test.go
+++ b/v2/pkg/dashboard/api_misc_coverage_test.go
@@ -71,11 +71,15 @@ func TestCovG_BuildSnapshot(t *testing.T) {
 func TestCovG_HandleSSO(t *testing.T) {
 	s := covMiscServer(t)
 
-	// No shared secret → redirect to /.
+	// No shared secret → terminal error page, NOT a redirect. Redirecting to
+	// "/" here is what produced the infinite browser bounce.
 	rec := httptest.NewRecorder()
 	s.handleSSO(rec, httptest.NewRequest(http.MethodGet, "/sso", nil))
-	if rec.Code != http.StatusSeeOther {
-		t.Fatalf("no-secret: expected 303, got %d", rec.Code)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("no-secret: expected 503, got %d", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "" {
+		t.Fatalf("no-secret must not redirect, got Location %q", loc)
 	}
 
 	// Secret set but no token → 400.

--- a/v2/pkg/dashboard/auth_deviceflow_coverage_test.go
+++ b/v2/pkg/dashboard/auth_deviceflow_coverage_test.go
@@ -283,8 +283,13 @@ func TestCovDF_SSO_NoSecret(t *testing.T) {
 	t.Setenv("HIVE_HUB_SECRET", "")
 	s, _, _ := dfServer(t, "complete", "octocat")
 	rec := doGet(s, "/sso?token=x")
-	if rec.Code != http.StatusSeeOther {
-		t.Fatalf("no secret: want 303, got %d", rec.Code)
+	// Terminates with an explanation instead of redirecting to "/", which
+	// bounced the browser in a loop.
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("no secret: want 503, got %d", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "" {
+		t.Fatalf("no secret must not redirect, got Location %q", loc)
 	}
 }
 

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -662,6 +662,16 @@ func (s *Server) authenticate(next http.Handler) http.Handler {
 			return
 		}
 		if s.authToken == "" && !directRouteAuthz {
+			// Open by design — but still resolve a session if the caller has one,
+			// so an SSO handoff on a token-less spoke yields a request that KNOWS
+			// who the user is. Without this the handoff sets a cookie, the next
+			// request is let through anonymously, the UI sees no identity and
+			// sends the user back to log in — a bounce. This grants no extra
+			// access: everyone is already admitted on this branch.
+			if sess := s.sessionFromRequest(r); sess != nil {
+				r.Header.Set("X-Hive-User", sess.Username)
+				r.Header.Set("X-Hive-Role", sess.Role)
+			}
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/v2/pkg/dashboard/sso_handoff_test.go
+++ b/v2/pkg/dashboard/sso_handoff_test.go
@@ -1,0 +1,382 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/hub"
+)
+
+// testHubSecret is the shared hub secret used to mint/verify handoff tokens in
+// these tests. It only has to be non-empty and stable within a test.
+const testHubSecret = "test-hub-shared-secret"
+
+// testHiveID is the hive the minted handoff tokens are scoped to.
+const testHiveID = "hosted-test-hive-0001"
+
+// newSSOServer builds a spoke Server wired for SSO handoff tests.
+//
+// hubProxied mirrors production shape: a hub-proxied spoke (hive-oke, nginx in
+// front) has NO authorized_users allowlist, so IsDirectRouteAuthzEnabled() is
+// false; a direct-route spoke (vllm-d, no proxy) carries the allowlist and is
+// the authority on who may enter.
+func newSSOServer(t *testing.T, hubProxied bool, authToken string, authorized ...string) *Server {
+	t.Helper()
+	s := newFullServer(t)
+	s.authToken = authToken
+	s.deps.Config.HiveID = testHiveID
+	if hubProxied {
+		s.deps.Config.Dashboard.AuthorizedUsers = nil
+	} else {
+		s.deps.Config.Dashboard.AuthorizedUsers = authorized
+	}
+	t.Setenv("HIVE_HUB_SECRET", testHubSecret)
+	return s
+}
+
+// ssoGet drives handleSSO once and returns the recorder.
+func ssoGet(t *testing.T, s *Server, rawQuery string) *httptest.ResponseRecorder {
+	t.Helper()
+	r := httptest.NewRequest("GET", "/sso?"+rawQuery, nil)
+	// Production traffic arrives at the spoke over plain HTTP behind a
+	// TLS-terminating nginx, which is what makes the cookie Secure.
+	r.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+	s.handleSSO(w, r)
+	return w
+}
+
+// sessionCookie returns the hive_session cookie the response set, or nil.
+func sessionCookie(w *httptest.ResponseRecorder) *http.Cookie {
+	for _, c := range (&http.Response{Header: w.Header()}).Cookies() {
+		if c.Name == sessionCookieName {
+			return c
+		}
+	}
+	return nil
+}
+
+// TestSSOHandoff_ValidTokenLandsOnRootWithSession is the happy path on BOTH the
+// hub-proxied and the direct-route shapes: a valid handoff mints a session,
+// sets the cookie, and redirects exactly once to the dashboard root — no
+// further bounce.
+func TestSSOHandoff_ValidTokenLandsOnRootWithSession(t *testing.T) {
+	tests := []struct {
+		name       string
+		hubProxied bool
+		authToken  string
+		authorized []string
+		wantRole   string
+	}{
+		{
+			name:       "hub-proxied spoke with dashboard token",
+			hubProxied: true,
+			authToken:  "shared-secret-token",
+			wantRole:   config.RoleOwner,
+		},
+		{
+			// Regression: setSessionCookie used to be gated on authToken != "",
+			// so a spoke provisioned without a dashboard token redirected to "/"
+			// having set NO cookie — an infinite bounce.
+			name:       "hub-proxied spoke with EMPTY dashboard token still sets a cookie",
+			hubProxied: true,
+			authToken:  "",
+			wantRole:   config.RoleOwner,
+		},
+		{
+			name:       "direct-route spoke, user on the allowlist",
+			hubProxied: false,
+			authToken:  "shared-secret-token",
+			authorized: []string{"clubanderson"},
+			wantRole:   config.RoleOwner,
+		},
+		{
+			// The allowlist is authoritative for the role: the hub asked for
+			// owner, the allowlist says read, read wins (no hub escalation).
+			name:       "direct-route allowlist role overrides the token role",
+			hubProxied: false,
+			authToken:  "shared-secret-token",
+			authorized: []string{"someoneelse", "clubanderson"},
+			wantRole:   config.RoleRead,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newSSOServer(t, tc.hubProxied, tc.authToken, tc.authorized...)
+			tok := hub.MintSSOToken(testHubSecret, "clubanderson", config.RoleOwner, testHiveID, time.Now())
+			if tok == "" {
+				t.Fatal("failed to mint handoff token")
+			}
+
+			w := ssoGet(t, s, "token="+tok)
+
+			if w.Code != http.StatusSeeOther {
+				t.Fatalf("status = %d, want 303 (single redirect to root); body=%q", w.Code, w.Body.String())
+			}
+			loc := w.Header().Get("Location")
+			if !strings.HasPrefix(loc, "/?") && loc != "/" {
+				t.Fatalf("Location = %q, want the dashboard root", loc)
+			}
+			// The landing URL must NOT re-enter /sso — that is the loop.
+			if strings.Contains(loc, "/sso") {
+				t.Fatalf("Location = %q must not redirect back into the SSO handoff", loc)
+			}
+
+			c := sessionCookie(w)
+			if c == nil {
+				t.Fatal("no hive_session cookie set — the browser would bounce forever")
+			}
+			if c.Value == "" {
+				t.Fatal("hive_session cookie set to an empty value")
+			}
+			if !c.HttpOnly {
+				t.Error("session cookie must be HttpOnly")
+			}
+			if !c.Secure {
+				t.Error("session cookie must be Secure behind TLS-terminating nginx")
+			}
+			if c.Path != "/" {
+				t.Errorf("cookie Path = %q, want / so it is returned on the root request", c.Path)
+			}
+			if c.SameSite != http.SameSiteLaxMode {
+				t.Errorf("cookie SameSite = %v, want Lax so it survives the cross-site handoff redirect", c.SameSite)
+			}
+
+			// The minted session must actually resolve to the right identity,
+			// otherwise "/" rejects the very next request.
+			sess := s.lookupSession(c.Value)
+			if sess == nil {
+				t.Fatal("session cookie does not resolve to a session")
+			}
+			if sess.Username != "clubanderson" {
+				t.Errorf("session username = %q, want clubanderson", sess.Username)
+			}
+			if sess.Role != tc.wantRole {
+				t.Errorf("session role = %q, want %q", sess.Role, tc.wantRole)
+			}
+		})
+	}
+}
+
+// TestSSOHandoff_LandingRequestIsAuthenticated proves the loop is actually
+// closed end to end: the cookie handleSSO set is accepted by authenticate() on
+// the follow-up request to the landing URL, on both spoke shapes. If this fails,
+// the browser bounces.
+func TestSSOHandoff_LandingRequestIsAuthenticated(t *testing.T) {
+	tests := []struct {
+		name       string
+		hubProxied bool
+		authToken  string
+		authorized []string
+	}{
+		{"hub-proxied", true, "shared-secret-token", nil},
+		{"hub-proxied, no dashboard token", true, "", nil},
+		{"direct-route", false, "shared-secret-token", []string{"clubanderson"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newSSOServer(t, tc.hubProxied, tc.authToken, tc.authorized...)
+			tok := hub.MintSSOToken(testHubSecret, "clubanderson", config.RoleOwner, testHiveID, time.Now())
+			w := ssoGet(t, s, "token="+tok)
+			c := sessionCookie(w)
+			if c == nil {
+				t.Fatal("handoff set no session cookie")
+			}
+			loc := w.Header().Get("Location")
+
+			// Replay the browser's next request: GET the landing URL carrying
+			// the cookie, through the real auth middleware.
+			var sawUser string
+			next := httptest.NewRequest("GET", loc, nil)
+			next.AddCookie(&http.Cookie{Name: sessionCookieName, Value: c.Value})
+			w2 := httptest.NewRecorder()
+			s.authenticate(recordingHandler(&sawUser, nil)).ServeHTTP(w2, next)
+
+			if w2.Code != http.StatusOK {
+				t.Fatalf("landing request after handoff = %d, want 200 (a non-200 here IS the redirect loop)", w2.Code)
+			}
+			if sawUser != "clubanderson" {
+				t.Errorf("landing request identity = %q, want clubanderson", sawUser)
+			}
+		})
+	}
+}
+
+// TestSSOHandoff_FailuresTerminateWithoutRedirecting is the core anti-loop
+// contract: every failure mode ends on an error page that explains itself. None
+// of them may emit a redirect, because a redirect is what spins the browser.
+func TestSSOHandoff_FailuresTerminateWithoutRedirecting(t *testing.T) {
+	validTok := func() string {
+		return hub.MintSSOToken(testHubSecret, "clubanderson", config.RoleOwner, testHiveID, time.Now())
+	}
+
+	tests := []struct {
+		name       string
+		hubProxied bool
+		authorized []string
+		hubSecret  string // "" means unset HIVE_HUB_SECRET
+		query      func() string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "missing token",
+			hubProxied: true,
+			hubSecret:  testHubSecret,
+			query:      func() string { return "" },
+			wantStatus: http.StatusBadRequest,
+			wantCode:   ssoErrMissingToken,
+		},
+		{
+			name:       "garbage token",
+			hubProxied: true,
+			hubSecret:  testHubSecret,
+			query:      func() string { return "token=not-a-real-token" },
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   ssoErrBadToken,
+		},
+		{
+			name:       "token signed with the wrong secret",
+			hubProxied: true,
+			hubSecret:  testHubSecret,
+			query: func() string {
+				return "token=" + hub.MintSSOToken("a-different-secret", "clubanderson", config.RoleOwner, testHiveID, time.Now())
+			},
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   ssoErrBadToken,
+		},
+		{
+			name:       "token scoped to a different hive",
+			hubProxied: true,
+			hubSecret:  testHubSecret,
+			query: func() string {
+				return "token=" + hub.MintSSOToken(testHubSecret, "clubanderson", config.RoleOwner, "some-other-hive", time.Now())
+			},
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   ssoErrBadToken,
+		},
+		{
+			name:       "expired token",
+			hubProxied: true,
+			hubSecret:  testHubSecret,
+			query: func() string {
+				// Minted far enough in the past that any sane TTL has lapsed.
+				const wellPastAnyTTL = -24 * time.Hour
+				return "token=" + hub.MintSSOToken(testHubSecret, "clubanderson", config.RoleOwner, testHiveID, time.Now().Add(wellPastAnyTTL))
+			},
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   ssoErrBadToken,
+		},
+		{
+			name:       "no hub secret configured on the spoke",
+			hubProxied: true,
+			hubSecret:  "",
+			query:      func() string { return "token=anything" },
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   ssoErrNoSecret,
+		},
+		{
+			name:       "direct-route: valid token, user NOT on the allowlist",
+			hubProxied: false,
+			authorized: []string{"someoneelse"},
+			hubSecret:  testHubSecret,
+			query:      func() string { return "token=" + validTok() },
+			wantStatus: http.StatusForbidden,
+			wantCode:   ssoErrNotAuthorized,
+		},
+		{
+			name:       "hop counter at the limit trips the loop breaker",
+			hubProxied: true,
+			hubSecret:  testHubSecret,
+			query: func() string {
+				return "token=" + validTok() + "&" + ssoHopParam + "=" + strconv.Itoa(maxSSOHops)
+			},
+			wantStatus: http.StatusLoopDetected,
+			wantCode:   ssoErrLoopDetected,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newSSOServer(t, tc.hubProxied, "shared-secret-token", tc.authorized...)
+			// newSSOServer sets the secret; override per case.
+			t.Setenv("HIVE_HUB_SECRET", tc.hubSecret)
+
+			w := ssoGet(t, s, tc.query())
+
+			if w.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tc.wantStatus)
+			}
+			// THE contract: a failed handoff must never redirect.
+			if loc := w.Header().Get("Location"); loc != "" {
+				t.Fatalf("failed handoff emitted a redirect to %q — this is the infinite-loop bug", loc)
+			}
+			if w.Code >= 300 && w.Code < 400 {
+				t.Fatalf("failed handoff returned 3xx status %d — must terminate, not redirect", w.Code)
+			}
+
+			body := w.Body.String()
+			if !strings.Contains(body, tc.wantCode) {
+				t.Errorf("error page missing code %q; body=%q", tc.wantCode, body)
+			}
+			// The page must actually tell the user something actionable.
+			if !strings.Contains(body, "Sign in with GitHub") {
+				t.Error("error page must offer a direct sign-in escape hatch")
+			}
+			if !strings.Contains(body, "Back to the hub") {
+				t.Error("error page must offer a way back to the hub")
+			}
+			if w.Header().Get("Cache-Control") != "no-store" {
+				t.Error("error page must not be cached, or the hive looks permanently broken")
+			}
+			// No session may be established on a failed handoff.
+			if c := sessionCookie(w); c != nil && c.Value != "" && c.MaxAge >= 0 {
+				t.Errorf("failed handoff established a session cookie %q", c.Value)
+			}
+		})
+	}
+}
+
+// TestSSOHandoff_HopCounterAdvances checks the loop breaker actually counts:
+// below the limit the handoff proceeds and increments, at the limit it stops.
+func TestSSOHandoff_HopCounterAdvances(t *testing.T) {
+	for hop := 0; hop < maxSSOHops; hop++ {
+		s := newSSOServer(t, true, "shared-secret-token")
+		tok := hub.MintSSOToken(testHubSecret, "clubanderson", config.RoleOwner, testHiveID, time.Now())
+		w := ssoGet(t, s, "token="+tok+"&"+ssoHopParam+"="+strconv.Itoa(hop))
+		if w.Code != http.StatusSeeOther {
+			t.Fatalf("hop=%d: status = %d, want 303 (still under the limit)", hop, w.Code)
+		}
+		want := ssoHopParam + "=" + strconv.Itoa(hop+1)
+		if loc := w.Header().Get("Location"); !strings.Contains(loc, want) {
+			t.Errorf("hop=%d: Location = %q, want it to carry %q", hop, loc, want)
+		}
+	}
+}
+
+// TestSSOErrorPage_NoLiteralBodyTag guards the snapshot builder, which does a
+// naive indexOf("<body>") over the dashboard markup. A literal body tag
+// introduced here corrupts the build.
+func TestSSOErrorPage_NoLiteralBodyTag(t *testing.T) {
+	if strings.Contains(ssoErrorPage, "<body>") {
+		t.Error("ssoErrorPage must not contain a literal <body> tag — it corrupts the snapshot builder")
+	}
+}
+
+// TestSSOErrorPage_EscapesInterpolatedText ensures the error page cannot be
+// turned into an injection vector by any future caller.
+func TestSSOErrorPage_EscapesInterpolatedText(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/sso", nil)
+	writeSSOError(w, r, http.StatusForbidden, "CODE", `<script>alert(1)</script>`, "do a thing")
+	if strings.Contains(w.Body.String(), "<script>alert(1)</script>") {
+		t.Error("interpolated text must be HTML-escaped")
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -5547,7 +5547,26 @@ func (s *HubServer) handleUserToken(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]string{"token": token})
 }
 
-var publicPaths = []string{"/snapshot", "/leaderboard", "/contribute", "/api/leaderboard", "/api/contribute"}
+var publicPaths = []string{"/snapshot", "/leaderboard", "/contribute", "/api/leaderboard", "/api/contribute", ssoHandoffPath}
+
+// ssoHandoffPath is the spoke's SSO handoff endpoint. It MUST bypass the hub's
+// nginx auth_request gate.
+//
+// Why: the auth-check subrequest authorizes a user against THIS hive's grant
+// list (user.Hives[hiveID]). The whole point of the handoff is to admit a user
+// who is authenticated on the hub but has no hub-side grant row for the hive —
+// the spoke's own authorized_users allowlist is the authority. Gating /sso on
+// the hub check therefore 401s exactly the requests the handoff exists to
+// serve, and nginx turns that 401 into an auth-signin redirect back to the hub
+// login, which (the user already having a valid hub cookie) immediately
+// redirects to /sso again — an infinite bounce the browser eventually aborts.
+//
+// This does NOT weaken authentication: the signed, hive-scoped, short-lived
+// HMAC token in the query IS the credential, and dashboard.handleSSO verifies
+// it against HIVE_HUB_SECRET plus the spoke's own allowlist before minting any
+// session. It is the same reasoning that already makes /sso a public path on
+// the spoke half (see dashboard.isPublicPath).
+const ssoHandoffPath = "/sso"
 
 // proxyAuthHeader is the response header the hub sets on a successful
 // auth-check subrequest to PROVE to the spoke that the request was

--- a/v2/pkg/hub/sso_authcheck_test.go
+++ b/v2/pkg/hub/sso_authcheck_test.go
@@ -1,0 +1,85 @@
+package hub
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestAuthCheck_SSOHandoffBypassesGate is the hub half of the redirect-loop fix.
+//
+// The spoke ingress puts every path behind nginx auth_request ->
+// /api/saas/auth-check. That check authorizes against the hub's per-user grant
+// list for the hive. The SSO handoff exists precisely to admit a hub-
+// authenticated user who has no such grant row, so gating /sso on it 401s the
+// requests the handoff exists to serve — and nginx converts that 401 into an
+// auth-signin redirect to the hub login, which (with a valid hub cookie
+// already present) immediately redirects back to /sso. Infinite bounce.
+//
+// /sso must therefore reach the spoke unauthenticated, exactly like the other
+// public paths. This does NOT weaken auth: the signed, hive-scoped,
+// short-lived HMAC token in the query is the credential, and the spoke
+// verifies it plus its own allowlist before minting any session.
+func TestAuthCheck_SSOHandoffBypassesGate(t *testing.T) {
+	tests := []struct {
+		name        string
+		originalURI string
+		wantStatus  int
+	}{
+		{
+			name:        "bare sso path",
+			originalURI: ssoHandoffPath,
+			wantStatus:  http.StatusOK,
+		},
+		{
+			name:        "sso path carrying the handoff token",
+			originalURI: ssoHandoffPath + "?token=eyJ2IjoiaGl2ZS1zc28tdjEifQ.sig",
+			wantStatus:  http.StatusOK,
+		},
+		{
+			// Everything else stays gated — the bypass is scoped to the handoff.
+			name:        "dashboard root is still gated",
+			originalURI: "/",
+			wantStatus:  http.StatusUnauthorized,
+		},
+		{
+			name:        "api is still gated",
+			originalURI: "/api/status",
+			wantStatus:  http.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := NewHubServer(0, slog.Default(), "test", "v2")
+			req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test-hive", nil)
+			req.Header.Set("X-Original-URI", tc.originalURI)
+			w := httptest.NewRecorder()
+			srv.mux.ServeHTTP(w, req)
+
+			if w.Code != tc.wantStatus {
+				t.Errorf("auth-check for %q = %d, want %d", tc.originalURI, w.Code, tc.wantStatus)
+			}
+		})
+	}
+}
+
+// TestAuthCheck_SSOBypassSetsNoProxyProof guards the F2 contract: the
+// proof-of-proxy header is set ONLY on the authenticated success path, never on
+// a public-path bypass. If the /sso bypass leaked the hive's dashboard token,
+// anyone could fetch it by hitting the auth-check with X-Original-URI=/sso.
+func TestAuthCheck_SSOBypassSetsNoProxyProof(t *testing.T) {
+	srv := NewHubServer(0, slog.Default(), "test", "v2")
+	req := httptest.NewRequest("GET", "/api/saas/auth-check?hive=test-hive", nil)
+	req.Header.Set("X-Original-URI", ssoHandoffPath)
+	w := httptest.NewRecorder()
+	srv.mux.ServeHTTP(w, req)
+
+	if got := w.Header().Get(proxyAuthHeader); got != "" {
+		t.Errorf("public-path bypass leaked %s = %q; it must only be set on the authenticated success path", proxyAuthHeader, got)
+	}
+	if got := w.Header().Get("X-Hive-User"); got != "" {
+		t.Errorf("public-path bypass set X-Hive-User = %q; it must assert no identity", got)
+	}
+}


### PR DESCRIPTION
Fixes the live "Too many redirects" failure opening a hosted spoke from the hub (reproduced in Safari on `hosted-available-oke-05-placeholder-6q84` and `hosted-available-oke-02-placeholder-7zus`, both on `hive-oke`).

## The observed cycle

Verified live with `curl -v`, not inferred. The spoke's `/sso` handler **never runs** — nginx intercepts first:

```
1. GET https://hosted-...-6q84.hive.kubestellar.io/sso?token=eyJ2...
   -> HTTP/2 302
      location: https://hive.kubestellar.io/login?redirect=https://hosted-...-6q84.hive.kubestellar.io/sso?token=...

2. GET https://hive.kubestellar.io/api/saas/auth-check?hive=hosted-...-6q84&uri=/sso   (nginx auth_request subrequest)
   -> HTTP/2 401   "not authenticated"

3. GET https://hive.kubestellar.io/login?redirect=...%2Fsso%3Ftoken%3D...
   -> HTTP/2 307   (user HAS a valid hive_hub_user cookie, so this resolves immediately)
      location: -> OAuth callback -> 307 back to the /sso URL from `state`

4. GOTO 1.
```

No `Set-Cookie` from the spoke ever appears, because the spoke is never reached.

## Root cause — this is **not** #2195

`v2/pkg/hub/saas.go:5550` — `/sso` was missing from `publicPaths`:

```go
var publicPaths = []string{"/snapshot", "/leaderboard", "/contribute", "/api/leaderboard", "/api/contribute"}
```

The spoke ingress (`v2/pkg/hub/saas_provision.go:1556-1559`) puts **every** path behind `auth-url` -> `/api/saas/auth-check`, with `auth-signin` pointing at the hub login. `handleSaaSAuthCheck` (`v2/pkg/hub/saas.go:5666`) authorizes against the hub's per-user grant list:

```go
role, ok := user.Hives[hiveID]
if !ok { http.Error(w, "no access to this hive", http.StatusForbidden) }
```

That 401/403s exactly the user the handoff exists to serve — someone authenticated on the hub whose authority to enter lives in the **spoke's** `authorized_users` allowlist, not the hub's grant map. nginx converts it to the auth-signin redirect, the hub cookie is valid, so `/login` immediately redirects back to `/sso`. Infinite bounce.

I read #2195 carefully and it is **not** implicated: it fails open by default (`proxyProofRequired` is false unless `HIVE_PROXY_PROOF_REQUIRED=true`), and more decisively, `authenticate()` never emits a redirect at all — it serves the login page with a 401. It cannot produce a loop. Cookie attributes were also checked and are correct (`Secure` via `X-Forwarded-Proto`, `SameSite=Lax` survives the cross-site top-level GET, `Path=/`).

## The fix

**Hub half** — add `/sso` to `publicPaths` as a named constant with the rationale. This is server-side in the auth-check handler, so it applies to every existing hive immediately, with no ingress re-provisioning.

This does **not** weaken authentication. The signed, hive-scoped, short-lived HMAC token in the query IS the credential, and `dashboard.handleSSO` verifies it against `HIVE_HUB_SECRET` plus the spoke's own allowlist before minting any session — the same reasoning that already makes `/sso` public on the spoke half (`dashboard.isPublicPath`). A test asserts the bypass is scoped to `/sso` only and leaks neither `X-Hive-Proxy-Auth` nor `X-Hive-User`, preserving the F2 contract from #2195/#2189.

**Spoke half** — an auth failure must never present as an infinite redirect, independently of the above:

- Every non-success exit from `handleSSO` now terminates on a self-contained error page: what failed, what to do, an error code to quote, a direct GitHub sign-in escape hatch, and a link back to the hub. `Cache-Control: no-store` so a hive doesn't look permanently broken after access is granted. Previously the no-secret case `303`'d to `/` (itself a loop) and the reject cases served the login page.
- A hop counter (`sso_hop`, limit `maxSSOHops = 3`) breaks any residual cycle and terminates with `SSO_REDIRECT_LOOP` well before the browser's ~20-redirect opaque failure.
- **`setSessionCookie` is no longer gated on `authToken != ""`.** This is the known prior bug shape and it was still live: a spoke with no dashboard token logged "authenticated via SSO", redirected to `/`, and set no cookie at all.
- `authenticate()` now resolves a session on the open-by-design branch (no token AND no allowlist) so a handoff there produces a request that knows who the user is. Grants no extra access — everyone is already admitted on that branch.

## Both paths

- **Hub-proxied** (hive-oke, nginx in front): fixed by the `publicPaths` change; this is the path that was broken in production.
- **Direct-route** (vllm-d, no proxy): never hit the nginx gate, so it was not looping — but it gains the terminal error page, the hop breaker, and the empty-token cookie fix. Both shapes are covered in tests.

## Terminal error state

Dark-themed card matching the hub's access-denied page: 🐝, "Sign-in didn't complete", what happened, what to do, `Error code: SSO_TOKEN_REJECTED` (or `SSO_NOT_AUTHORIZED` / `SSO_NO_HUB_SECRET` / `SSO_MISSING_TOKEN` / `SSO_SESSION_FAILED` / `SSO_REDIRECT_LOOP`), plus "Sign in with GitHub" and "Back to the hub" buttons. No literal `<body>` tag, per the snapshot-builder convention.

## Verification

- `go build ./...`, `go vet ./...` clean.
- `go test ./pkg/dashboard/` — **ok**.
- `go test ./pkg/hub/` — only `TestFailingCheckSummaryEscapes/filter_chip_label_escaped` and `TestFilterComposition/clear_button_accounts_for_check_filter` fail; confirmed identical on a clean detached `origin/v2` worktree, so pre-existing and unrelated.
- Two existing tests (`TestCovG_HandleSSO`, `TestCovDF_SSO_NoSecret`) asserted the old `303`-to-`/` behavior and were updated to the terminal-error contract — that redirect was the bug.

New table-driven tests cover: a valid handoff sets a resolvable session and lands on `/` with no further redirect (hub-proxied, direct-route, and a token-less spoke); the cookie is actually accepted by `authenticate()` on the follow-up request (closing the loop end to end); every failure mode terminates with **no** `Location` header; the hop counter advances and trips; and the hub bypass is correctly scoped.

## Verified vs assumed

**Verified:** the live redirect chain via `curl -v` against both affected hostnames; that the hub auth-check 401s for `uri=/sso`; that `/sso` was absent from `publicPaths`; that `authenticate()` returns 401-with-login-page and never redirects (so #2195 cannot loop); cookie attributes; the pre-existing `pkg/hub` failures against a clean worktree.

**Assumed (not directly observed):** that the product owner's hub account lacks a `user.Hives[hiveID]` grant row for these two specific hives — I did not read the hub's on-disk user records. The loop reproduces from an unauthenticated client regardless, and the fix removes the gate entirely for `/sso`, so the conclusion does not depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)