### PR TITLE
✨ feat(agent): opt-in App-bot PR authorship + surface AI author in UI

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -497,11 +497,12 @@ func main() {
 	}
 
 	projectCtx := agent.ProjectContext{
-		Org:        cfg.Project.Org,
-		Repos:      cfg.Project.Repos,
-		ACMMLevel:  acmmLevel,
-		PRsAllowed: cfg.Project.PRsAllowed(),
-		PolicyDir:  policyDir,
+		Org:            cfg.Project.Org,
+		Repos:          cfg.Project.Repos,
+		ACMMLevel:      acmmLevel,
+		PRsAllowed:     cfg.Project.PRsAllowed(),
+		PolicyDir:      policyDir,
+		AppAuthoredPRs: cfg.GitHub.AppAuthoredPRs,
 	}
 	agentMgr := agent.NewManager(cfg.EnabledAgents(), logger, projectCtx)
 	// Resolve the bob API key at LAUNCH time, not here: cfg is the live config
@@ -1796,8 +1797,9 @@ func main() {
 				AgentsWithModel: &agentsWithModel,
 				HiveID:          cfg.HiveID,
 				Org:             cfg.Project.Org,
-				AIAuthor:        cfg.Project.AIAuthor,
-				StartedAt:       processStartedAt.UTC().Format(time.RFC3339),
+				AIAuthor:          cfg.Project.AIAuthor,
+				AIAuthorEffective: cfg.EffectiveAIAuthor(),
+				StartedAt:         processStartedAt.UTC().Format(time.RFC3339),
 				Repos:           cfg.Project.Repos,
 				PrimaryRepo:     cfg.Project.PrimaryRepo,
 				ACMMLevel:       acmmLvl,

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -110,6 +110,11 @@ type ProjectContext struct {
 	ACMMLevel  int
 	PRsAllowed bool
 	PolicyDir  string
+	// AppAuthoredPRs mirrors config github.app_authored_prs: when true, push-
+	// capable agents get the App installation token as GITHUB_TOKEN so the GitHub
+	// MCP server authors PRs/commits as the App bot. Default false → no token is
+	// injected and behavior is unchanged (opt-in per hive).
+	AppAuthoredPRs bool
 }
 
 type Manager struct {
@@ -361,6 +366,25 @@ func (m *Manager) refreshAgentTokens(ctx context.Context) {
 		tier := m.agentMode(a).TokenTier()
 		if err := auth.WriteAgentToken(ctx, a.Name, tier, a.UID); err != nil {
 			m.logger.Warn("agent token refresh failed", "agent", a.Name, "error", err)
+			continue
+		}
+		// Re-inject the freshly-minted App token into the running session so the
+		// GitHub MCP server keeps authenticating as the App bot. The scoped token
+		// expires hourly; WriteAgentToken above rewrites the cache FILE (which the
+		// git credential helper re-reads per call), but the Copilot CLI reads
+		// GITHUB_TOKEN once from its env at startup — so without this push the MCP
+		// token would go stale an hour after launch and GitHub writes would start
+		// 401ing. tmux set-environment only affects processes started AFTER it,
+		// which is fine: the Copilot CLI is (re)spawned per agent turn, so each new
+		// turn picks up the current token. Gated on the opt-in flag + CanPush() to
+		// match the launch injection — advisory agents stay GITHUB_TOKEN-less, and
+		// hives that have not opted in get nothing injected.
+		if m.project.AppAuthoredPRs && a.tmuxSession != "" && m.agentMode(a).CanPush() {
+			if data, err := os.ReadFile(ghpkg.AgentTokenCachePath(a.Name)); err == nil {
+				if tok := strings.TrimSpace(string(data)); tok != "" {
+					_ = m.tmuxCmd(a, "set-environment", "-t", a.tmuxSession, "GITHUB_TOKEN", tok).Run()
+				}
+			}
 		}
 	}
 }
@@ -3981,6 +4005,30 @@ func (m *Manager) agentEnvPairs(agent *AgentProcess) []agentEnvPair {
 	}
 	if m.copilotAuthToken != "" {
 		vars = append(vars, agentEnvPair{"COPILOT_GITHUB_TOKEN", m.copilotAuthToken, true})
+	}
+	// Point the GitHub MCP server at the App installation token so PRs, issue
+	// comments, and merges are authored by the App bot ("<slug>[bot]") — NOT by
+	// the Copilot login user. COPILOT_GITHUB_TOKEN above stays as the Copilot
+	// OAuth token because it authenticates the AI model (a separate concern from
+	// GitHub write identity); leaving it untouched keeps the Copilot CLI login
+	// working. The Copilot CLI reads GH_TOKEN / GITHUB_TOKEN for GitHub API auth
+	// (per its README: GH_TOKEN or GITHUB_TOKEN, in that precedence), so setting
+	// GITHUB_TOKEN here makes the built-in GitHub MCP server act as the App bot.
+	//
+	// Gated on the opt-in flag first (default OFF → no behavior change on any
+	// hive that has not explicitly enabled App-bot authorship), then on CanPush():
+	// advisory agents are deliberately kept GITHUB_TOKEN-less (see the -u
+	// GITHUB_TOKEN strip after the env loop) so they cannot write; only push-
+	// capable tiers — the ones that legitimately open/merge PRs — get the App
+	// token. m.appAuth != nil means an App is configured. The value is the
+	// per-agent tier-SCOPED App token, and refreshAgentTokens re-pushes it hourly
+	// so it never goes stale.
+	if m.project.AppAuthoredPRs && m.appAuth != nil && agent.UID > 0 && m.agentMode(agent).CanPush() {
+		if data, err := os.ReadFile(ghpkg.AgentTokenCachePath(agent.Name)); err == nil {
+			if tok := strings.TrimSpace(string(data)); tok != "" {
+				vars = append(vars, agentEnvPair{"GITHUB_TOKEN", tok, true})
+			}
+		}
 	}
 	if m.claudeAuthToken != "" && backend == "claude" {
 		vars = append(vars, agentEnvPair{"CLAUDE_CODE_OAUTH_TOKEN", m.claudeAuthToken, true})

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1087,6 +1087,13 @@ type GitHubConfig struct {
 	// BaseURL is the GitHub web base URL. Defaults to DefaultGitHubBaseURL.
 	// For GitHub Enterprise, set to e.g. "https://github.ibm.com".
 	BaseURL string `yaml:"base_url"`
+	// AppAuthoredPRs opts a hive into App-bot authorship: when true AND ai_author
+	// is empty, agents author PRs/commits as the GitHub App bot ("<slug>[bot]")
+	// via the App installation token, instead of the Copilot-login user. Default
+	// false — a hive with this unset behaves exactly as before (author = whatever
+	// the Copilot login / ai_author already produced), so enabling App-bot mode is
+	// strictly opt-in per hive and never changes an existing hive on upgrade.
+	AppAuthoredPRs bool `yaml:"app_authored_prs"`
 }
 
 const (
@@ -1125,6 +1132,35 @@ func (g GitHubConfig) ResolvedAppSlug() string {
 		return g.AppSlug
 	}
 	return DefaultGitHubAppSlug
+}
+
+// BotLogin returns the GitHub App bot login ("<app-slug>[bot]") when a GitHub
+// App is configured (AppID set), or "" otherwise. This is the account that
+// actually authors PRs and commits when the hive authenticates as an
+// installation rather than a personal token.
+func (g GitHubConfig) BotLogin() string {
+	if g.AppID == 0 {
+		return ""
+	}
+	return g.ResolvedAppSlug() + "[bot]"
+}
+
+// EffectiveAIAuthor returns the GitHub identity agents should author PRs and
+// commits as. An explicitly configured project.ai_author always wins. When
+// ai_author is empty, the result depends on the opt-in github.app_authored_prs
+// flag: if set, agents author as the GitHub App bot ("<slug>[bot]") — deriving
+// the bot login here rather than persisting it into ai_author keeps App-bot mode
+// durable across restarts (clearing ai_author is enough; nothing writes the bot
+// name back into config). If the flag is NOT set, this returns "" exactly as
+// before, so a hive that has not opted in behaves identically on upgrade.
+func (c *Config) EffectiveAIAuthor() string {
+	if c.Project.AIAuthor != "" {
+		return c.Project.AIAuthor
+	}
+	if c.GitHub.AppAuthoredPRs {
+		return c.GitHub.BotLogin()
+	}
+	return ""
 }
 
 // AppInstallURL returns the full URL to install the GitHub App.

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -575,15 +575,19 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 		githubBaseURL = "https://github.com"
 	}
 	jsonResponse(w, map[string]interface{}{
-		"org":             cfg.Project.Org,
-		"repos":           cfg.Project.Repos,
-		"ai_author":       cfg.Project.AIAuthor,
-		"agents":          len(cfg.EnabledAgents()),
-		"eval_interval_s": cfg.Governor.EvalIntervalS,
-		"primaryRepo":     primaryRepo,
-		"hub_url":         cfg.Hub.URL,
-		"hive_id":         cfg.HiveID,
-		"github_base_url": githubBaseURL,
+		"org":       cfg.Project.Org,
+		"repos":     cfg.Project.Repos,
+		"ai_author": cfg.Project.AIAuthor,
+		// ai_author_effective is who agents actually author PRs/commits as: the
+		// configured ai_author, or the GitHub App bot login ("<slug>[bot]") when
+		// ai_author is empty and the hive authenticates as an App installation.
+		"ai_author_effective": cfg.EffectiveAIAuthor(),
+		"agents":              len(cfg.EnabledAgents()),
+		"eval_interval_s":     cfg.Governor.EvalIntervalS,
+		"primaryRepo":         primaryRepo,
+		"hub_url":             cfg.Hub.URL,
+		"hive_id":             cfg.HiveID,
+		"github_base_url":     githubBaseURL,
 	})
 }
 
@@ -2191,7 +2195,7 @@ func (s *Server) substituteTemplateVars(template, agentName string) string {
 		"PROJECT_NAME":         lit(cfg.Project.Name),
 		"PROJECT_ORG":          lit(org),
 		"PROJECT_PRIMARY_REPO": lit(fullPrimaryRepo),
-		"PROJECT_AI_AUTHOR":    lit(cfg.Project.AIAuthor),
+		"PROJECT_AI_AUTHOR":    lit(cfg.EffectiveAIAuthor()),
 		"PROJECT_REPOS_LIST":   lit(reposList),
 		"HIVE_REPO":            lit(fmt.Sprintf("%s/hive", org)),
 		"HIVE_ID":              lit(cfg.HiveID),

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -5080,6 +5080,7 @@
           <div class="gov-stat" title="${itmTitle}"><div class="label">MTTR</div><div class="spark-row"><span class="val">${formatFixTime(itmMedian)}</span>${itmSpark}</div></div>
           <div class="gov-stat" title="${holdTooltip}"><div class="label">on hold</div><div class="spark-row"><span class="val">${holdTotal}</span>${holdSpark}</div></div>
           <div class="gov-stat" title="NEXT RUN — when the governor next wakes up.&#10;&#10;WHAT: The next scheduled moment the governor will re-evaluate mode and kick any agents that are due.&#10;&#10;HOW: Computed from the current mode's cadence schedule — the governor adds the mode's interval to the last run time. Faster modes (busy/surge) produce a nearer next run than idle/quiet."><div class="label">next run</div><div class="val">${escapeHtml(gov.nextKick || '—')}</div></div>
+          <div class="gov-stat" title="PR AUTHOR — the GitHub identity this hive's agents open PRs and push commits as.&#10;&#10;WHAT: Either the configured project.ai_author, or the GitHub App bot ('<slug>[bot]') when the hive runs in App-authored mode.&#10;&#10;HOW: Reported by the spoke as ai_author_effective. A '[bot]' value means PRs are authored by the App installation, not a personal account."><div class="label">PR author</div><div class="val">${escapeHtml(window._aiAuthor || '—')}</div></div>
         </div>
         <div class="temp-gauge" style="cursor:pointer" onclick="openConfigDialog('governor',null,'Thresholds')" title="Click to adjust governor thresholds">
           <div class="temp-gauge-label"><span>Issues: ${issueCount}</span><span>max ${maxQ}</span></div>
@@ -12056,6 +12057,10 @@ function burnAreaChart() {
     fetch("/api/config").then(r => r.json()).then(cfg => {
       const ghBase = cfg.github_base_url || 'https://github.com';
       window._githubBaseUrl = ghBase;
+      // Who agents author PRs/commits as — the App bot ("<slug>[bot]") when this
+      // hive runs App-authored mode, else the configured ai_author. Surfaced on
+      // the governor card so operators can see the write identity at a glance.
+      window._aiAuthor = cfg.ai_author_effective || cfg.ai_author || '';
       const repoDisplay = cfg.org && cfg.primaryRepo && !cfg.primaryRepo.includes('/')
         ? cfg.org + '/' + cfg.primaryRepo
         : (cfg.primaryRepo || '');

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -206,6 +206,13 @@ type HeartbeatPayload struct {
 	// blanking it, and so the registry knows each hive's author without any
 	// spoke-side token lookup (which does not work on App-authenticated hives).
 	AIAuthor string `json:"ai_author,omitempty"`
+	// AIAuthorEffective is who agents ACTUALLY author PRs/commits as: the
+	// configured ai_author, or the GitHub App bot login ("<slug>[bot]") when
+	// ai_author is empty and the hive authenticates as an App installation.
+	// Display-only — the hub shows it in the spokes table but NEVER echoes it
+	// back into project config, so an App-bot hive keeps ai_author empty and
+	// stays bot-authored across restarts.
+	AIAuthorEffective string `json:"ai_author_effective,omitempty"`
 	// GitHubAPIURL is the GitHub API base URL this spoke is CURRENTLY running
 	// against (its resolved value, so a public-GitHub spoke reports
 	// https://api.github.com rather than ""). Reported so the hub can tell

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -9655,7 +9655,7 @@ const dashboardHTML = `<!DOCTYPE html>
         // stacks under Location instead of owning a column. Counted against
         // the <th> cells in the header and the <td> cells emitted below
         // (bulkCheckboxCell contributes one).
-        var TOTAL_COLUMNS = 16;
+        var TOTAL_COLUMNS = 17;
         /* Visibility moved OUT of its own column and under Location: "where
            does this hive run" and "who can see it" are both facts about the
            hive's placement, so they read as one cell, and folding them saves a
@@ -9737,6 +9737,11 @@ const dashboardHTML = `<!DOCTYPE html>
           '<td style="font-size:0.7rem">' + versionCell + '</td>' +
           '<td title="' + esc((h.repos || []).join('\n')) + '" style="cursor:' + (repoCount > 0 ? 'help' : 'default') + '">' + repoCount + '</td>' +
           '<td>' + acmmBadge(h.acmmLevel) + '</td>' +
+          /* AI Author: who this hive authors PRs as. aiAuthorEffective is the
+             App bot ("<slug>[bot]") in App-authored mode, else the configured
+             ai_author (falls back to aiAuthor for spokes too old to report the
+             effective value). A "[bot]" value is the informative case. */
+          '<td style="white-space:nowrap;font-size:0.75rem" title="GitHub identity for this hive\'s PRs/commits">' + esc(h.aiAuthorEffective || h.aiAuthor || '—') + '</td>' +
           '<td>' + journeyBadge(h.journey) + '</td>' +
           /* Drift sits immediately right of Journey: both answer "how healthy
              is this hive's configuration", so they read as one pair rather
@@ -9758,7 +9763,7 @@ const dashboardHTML = `<!DOCTYPE html>
          and the table visibly ragged. 15 with the Drift column, plus the
          bulk-select column, plus the Journey column, minus Public (visibility
          is stacked under Location). Must stay equal to TOTAL_COLUMNS. */
-      var TOTAL_COLUMNS_HEADER = 16;
+      var TOTAL_COLUMNS_HEADER = 17;
       /* The header is a click target that expands/collapses its section. The
          caret mirrors aria-expanded so the affordance and the a11y state can
          never disagree. sectionKey also scopes the select-all checkbox to THIS
@@ -9893,7 +9898,7 @@ const dashboardHTML = `<!DOCTYPE html>
         /* Non-admin lists have no section headers, so the flat list's
            select-all lives in the table head instead. */
         '<th style="width:26px;text-align:center">' + (_isAdmin ? '' : bulkSectionCheckbox('all')) + '</th>' +
-        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer" title="Where this hive runs, and whether it is listed publicly">Location / Public ⇅</th><th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'journey\')" style="cursor:pointer" title="Where this hive is on the adoption journey: install the GitHub App, assign a method/model (or run the contributor relay), then raise the ACMM level">Journey ⇅</th><th title="Configuration drift from the fleet norm — hover a value for the specific signals">Drift</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th>' +
+        '<th></th><th onclick="sortDashHives(\'name\')" style="cursor:pointer">Hive ⇅</th><th onclick="sortDashHives(\'clusterId\')" style="cursor:pointer" title="Where this hive runs, and whether it is listed publicly">Location / Public ⇅</th><th onclick="sortDashHives(\'startedAt\')" style="cursor:pointer" title="Process uptime since the last restart — a short value that keeps resetting means the pod is restarting">Uptime ⇅</th><th>Version</th><th>Repos</th><th onclick="sortDashHives(\'acmmLevel\')" style="cursor:pointer">ACMM ⇅</th><th onclick="sortDashHives(\'aiAuthor\')" style="cursor:pointer" title="The GitHub identity this hive\'s agents open PRs as — the configured ai_author, or the App bot (&lt;slug&gt;[bot]) in App-authored mode">AI Author ⇅</th><th onclick="sortDashHives(\'journey\')" style="cursor:pointer" title="Where this hive is on the adoption journey: install the GitHub App, assign a method/model (or run the contributor relay), then raise the ACMM level">Journey ⇅</th><th title="Configuration drift from the fleet norm — hover a value for the specific signals">Drift</th><th onclick="sortDashHives(\'agentCount\')" style="cursor:pointer">Agents ⇅</th><th onclick="sortDashHives(\'totalTokens24h\')" style="cursor:pointer" title="Cumulative tokens consumed, as of the last heartbeat">Tokens ⇅</th><th onclick="sortDashHives(\'governorMode\')" style="cursor:pointer">Mode ⇅</th><th onclick="sortDashHives(\'actionableIssues\')" style="cursor:pointer">Issues ⇅</th><th onclick="sortDashHives(\'actionablePRs\')" style="cursor:pointer">PRs ⇅</th><th onclick="sortDashHives(\'activeContributors\')" style="cursor:pointer">Contributors ⇅</th>' +
         '</tr></thead><tbody>' + rows + '</tbody></table></div>';
       /* Delegated, so binding once is enough no matter how often the table is
          re-rendered. The guard keeps repeated renders from stacking listeners. */

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -67,6 +67,10 @@ type RegistryEntry struct {
 	// without blanking it, and it is the author the fleet-stats counts are
 	// scoped to.
 	AIAuthor string `json:"aiAuthor,omitempty"`
+	// AIAuthorEffective is who the spoke's agents actually author PRs/commits
+	// as — ai_author when set, else the GitHub App bot login ("<slug>[bot]").
+	// Display-only in the spokes table; never echoed back into project config.
+	AIAuthorEffective string `json:"aiAuthorEffective,omitempty"`
 	// StartedAt is the spoke process start time, reported over the heartbeat.
 	// Rendered as an uptime pill in My Hives so a crash-looping hive is visible.
 	StartedAt          string         `json:"startedAt,omitempty"`
@@ -682,12 +686,13 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 			}
 			return safe
 		}(),
-		PrimaryRepo:  safePrimary,
-		AIAuthor:     sanitizeField(payload.AIAuthor),
-		StartedAt:    sanitizeField(payload.StartedAt),
-		DashboardURL: payload.DashboardURL,
-		SnapshotURL:  payload.SnapshotURL,
-		ACMMLevel:    clampInt(payload.ACMMLevel, 0, 6),
+		PrimaryRepo:       safePrimary,
+		AIAuthor:          sanitizeField(payload.AIAuthor),
+		AIAuthorEffective: sanitizeField(payload.AIAuthorEffective),
+		StartedAt:         sanitizeField(payload.StartedAt),
+		DashboardURL:      payload.DashboardURL,
+		SnapshotURL:       payload.SnapshotURL,
+		ACMMLevel:         clampInt(payload.ACMMLevel, 0, 6),
 		AgentCount: func() int {
 			count := 0
 			for _, a := range payload.Agents {

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -214,7 +214,7 @@ func (s *Scheduler) substituteTemplate(template string, actionable *github.Actio
 		"PROJECT_ORG":           lit(s.cfg.Project.Org),
 		"PROJECT_NAME":          lit(s.cfg.Project.Name),
 		"PROJECT_PRIMARY_REPO":  lit(fullPrimaryRepo),
-		"PROJECT_AI_AUTHOR":     lit(s.cfg.Project.AIAuthor),
+		"PROJECT_AI_AUTHOR":     lit(s.cfg.EffectiveAIAuthor()),
 		"PROJECT_REPOS_LIST":    lit(reposList),
 		"PROJECT_HOMEBREW_REPO": lit(fmt.Sprintf("%s/homebrew-tap", s.cfg.Project.Org)),
 		"HIVE_REPO":             lit(fmt.Sprintf("%s/hive", s.cfg.Project.Org)),
@@ -500,7 +500,7 @@ func (s *Scheduler) buildScannerMessage(issues []github.Issue, actionable *githu
 
 	b.WriteString("\nWORKFLOW:\n")
 	b.WriteString("  1. Check beads (`bd list --status open`) for context from previous cycles\n")
-	b.WriteString("  2. Quick merges + cleanup (10 min cap) — merge green PRs with `--squash --admin`. Ensure `Fixes #<issue>` in body. Close stale drafts (>48h, needs-rebase + dco-no, or fix already merged). `@dependabot rebase` stale ones. Move on after 10 min.\n")
+	b.WriteString("  2. Quick merges + cleanup (10 min cap) — merge PRs whose required checks are GREEN using a squash merge via your App token (MCP `merge_pull_request` with `merge_method: \"squash\"`, or `gh pr merge --squash`). Do NOT use `--admin` — never force-merge past pending or failing CI; wait for the required checks to pass. Ensure `Fixes #<issue>` in body. Close stale drafts (>48h, needs-rebase + dco-no, or fix already merged). `@dependabot rebase` stale ones. Move on after 10 min.\n")
 	b.WriteString("  3. Fix blockers — find the ONE fix that unblocks the most PRs/issues. Clone, fix, push, merge.\n")
 	b.WriteString("  4. Crank quick fixes — launch background agents using the Agent tool (run_in_background: true) to fix remaining issues in parallel. One PR per issue, move fast.\n")
 


### PR DESCRIPTION
## Summary

Adds an **opt-in, default-off** flag `github.app_authored_prs` that makes a hive's push-capable agents author PRs/commits as the **GitHub App bot** (`<slug>[bot]`) instead of the Copilot-login user.

### Root cause this fixes
Agents author PRs via the Copilot GitHub MCP server, which authenticates with the **Copilot login's user token** (e.g. `clubanderson`) — so PRs are attributed to a personal account, not the App. Setting `ai_author` / git config does **not** change this, because the MCP server's token decides PR authorship.

### The fix
When `github.app_authored_prs: true` **and** `ai_author` is empty, push-capable agents get the per-agent tier-scoped **App installation token** injected as `GITHUB_TOKEN`, which the Copilot CLI's GitHub MCP server uses for GitHub API calls → PRs/merges author as `<slug>[bot]`.

- `COPILOT_GITHUB_TOKEN` (AI-model auth) is **left untouched** — the Copilot CLI login is unaffected.
- Advisory (non-push) agents stay `GITHUB_TOKEN`-less (existing `CanPush()` gate + `-u GITHUB_TOKEN` strip).
- `refreshAgentTokens` re-pushes the token hourly via `tmux set-environment`, so the MCP token never goes stale.

### Blast radius — none by default
`app_authored_prs` defaults **false**. `EffectiveAIAuthor()` returns `""` (prior behavior) and no `GITHUB_TOKEN` is injected unless a hive explicitly opts in. **Every existing spoke is unchanged on upgrade.** App-bot mode is enabled per-hive.

### Also in this PR
- `Config.EffectiveAIAuthor()` / `GitHubConfig.BotLogin()` — resolve the effective author; wired into `PROJECT_AI_AUTHOR`.
- Merge guidance drops `--admin`: wait for required checks green, squash-merge via the App token (the App is not a repo admin and must not force-merge past CI).
- Surface the effective author: `ai_author_effective` on `GET /api/config` + a **"PR author"** stat on the governor card; `AIAuthorEffective` on the heartbeat + registry + an **"AI Author"** column in the hub spokes table.

## Notes for reviewers
- gofmt: `main.go`, `manager.go`, `config.go`, `scheduler.go` had **pre-existing** gofmt drift at the `v2` baseline; this PR does not touch that drift (additions only). A CI gofmt check may flag the whole file — the drift predates this change.
- GHE spokes: `BotLogin()` uses `ResolvedAppSlug()` (defaults `kubestellar-hive`); a GHE spoke opting in should set `app_slug` to its App's real slug so `EffectiveAIAuthor()`/claim-matching reflects the correct bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)