### PR TITLE
🐛 fix(github-app): stop blaming users for operator-side App credential failures

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -398,6 +398,11 @@ func main() {
 	notifier.SetHiveID(cfg.HiveID)
 	acmmLevel := inferACMMLevel(cfg)
 	githubAppRequired := false
+	// githubAppDiag/githubAppState carry the classified reason App auth failed,
+	// so the banner can name the true cause (and the hub can avoid escalating
+	// against a hive whose credentials the operator never delivered).
+	githubAppDiag := ""
+	githubAppState := github.AppStateUnknown
 
 	// Find or create the pinned advisory issue. Any level can have advisory
 	// agents whose findings should be posted to this issue.
@@ -418,7 +423,17 @@ func main() {
 					logger.Warn("GitHub API rate limit hit during advisory issue ensure", "repo", primaryRepo)
 				} else if strings.Contains(err.Error(), "403") || strings.Contains(err.Error(), "401") {
 					githubAppRequired = true
-					logger.Warn("GitHub App not installed or credentials invalid — setting githubAppRequired flag", "error", err)
+					// Classify WHY before the banner renders. A bare 401/403
+					// here used to become "GitHub App Not Installed", which is
+					// wrong — and actively misleading — when the real cause is
+					// a key the operator has not delivered. Classification is
+					// on the live API response, and a missing key file
+					// short-circuits without any API call.
+					githubAppDiag, githubAppState = diagnoseGitHubApp(ctx, ghClient.AppAuth(), cfg.Project.Org)
+					logger.Warn("GitHub App authentication failed at startup",
+						"state", githubAppState.String(),
+						"operator_actionable", githubAppState.OperatorActionable(),
+						"error", err)
 				}
 			} else {
 				advisoryIssues[primaryRepo] = num
@@ -1172,6 +1187,15 @@ func main() {
 	})
 
 	dashSrv.SetGitHubAppRequired(githubAppRequired)
+	// Order matters: SetGitHubAppRequired(false) clears both fields, so the
+	// classified state is applied only after it, and only when a failure was
+	// actually detected.
+	if githubAppRequired {
+		dashSrv.SetGitHubAppState(githubAppState.String())
+		if githubAppDiag != "" {
+			dashSrv.SetGitHubAppPermIssue(githubAppDiag)
+		}
+	}
 
 	// Wire up the manual re-check callback for the dashboard button.
 	{
@@ -1198,9 +1222,12 @@ func main() {
 				// this is the exact case rediscovery exists for. Cached by TTL,
 				// so a repeated re-check does not re-hit the API.
 				healGitHubAppInstallation(ctx, ghClient.AppAuth(), cfg, logger)
-				if diag := diagnoseGitHubAppWrite(ctx, ghClient.AppAuth(), cfg.Project.Org); diag != "" {
+				if diag, state := diagnoseGitHubApp(ctx, ghClient.AppAuth(), cfg.Project.Org); diag != "" {
 					dashSrv.SetGitHubAppPermIssue(diag)
-					logger.Warn("github app recheck: app detected but write not verified", "repo", recheckRepo, "detail", diag)
+					dashSrv.SetGitHubAppState(state.String())
+					logger.Warn("github app recheck: app detected but write not verified",
+						"repo", recheckRepo, "state", state.String(),
+						"operator_actionable", state.OperatorActionable(), "detail", diag)
 					dashSrv.AuditLog("system", "github_app_check", "result=installed but write NOT verified: "+diag, "")
 					return false
 				}
@@ -1826,6 +1853,7 @@ func main() {
 				ImageRef:                hub.SelfDeploymentImage(),
 				GitHubAppRequired:       dashSrv.IsGitHubAppRequired(),
 				GitHubAppPermIssue:      dashSrv.GetGitHubAppPermIssue(),
+				GitHubAppState:          dashSrv.GetGitHubAppState(),
 				PendingGitHubAppInstall: dashSrv.IsPendingGitHubAppInstall(),
 				AutoUpgrade:             cfg.Hub.AutoUpgrade,
 				ClusterHealth: func() *hub.HeartbeatClusterHealthReport {
@@ -2389,27 +2417,36 @@ func healGitHubAppInstallation(ctx context.Context, appAuth *github.AppAuth, cfg
 		"installation_id", newID, "org", org)
 }
 
-func diagnoseGitHubAppWrite(ctx context.Context, appAuth *github.AppAuth, expectedOwner string) string {
+// diagnoseGitHubApp classifies this hive's GitHub App credential state and
+// returns both the machine-readable state and banner-ready copy.
+//
+// It supersedes a substring match on the formatted error ("403"/"401"), which
+// could not tell a user-side failure from an operator-side one and so showed
+// every hive the same "GitHub App Not Installed" banner. The most damaging
+// case that fixes: a spoke holding the WRONG private key (the hub's key push
+// has not landed, or delivered a public github.com key to a GitHub Enterprise
+// hive) gets `401 A JSON web token could not be decoded`. The user cannot see,
+// supply, or correct that key — telling them to install the App or check
+// github.installation_id sends them to redo work they already did correctly.
+//
+// The candidate key paths are passed so a MISSING key is detected without any
+// API round-trip at all.
+//
+// Returns ("", AppStateOK) when App auth is healthy, and ("", state) for a nil
+// appAuth (a token-authenticated hive has nothing to check).
+func diagnoseGitHubApp(ctx context.Context, appAuth *github.AppAuth, expectedOwner string) (string, github.AppAuthState) {
 	if appAuth == nil {
-		return ""
+		return "", github.AppStateOK
 	}
-	info, err := appAuth.VerifyInstallation(ctx)
-	if err != nil {
-		return fmt.Sprintf("Could not verify the GitHub App installation: %v", err)
-	}
-	if expectedOwner != "" && !strings.EqualFold(info.Account, expectedOwner) {
-		return fmt.Sprintf("This hive is authenticating as GitHub App installation %d, which belongs to '%s' — not '%s'. Check github.installation_id in the hive config.",
-			info.InstallationID, info.Account, expectedOwner)
-	}
-	if info.IssuesPerm != "write" {
-		granted := info.IssuesPerm
-		if granted == "" {
-			granted = "none"
-		}
-		return fmt.Sprintf("The GitHub App is installed for '%s' but granted Issues: %s (Issues: Read & Write required). The org owner must approve the updated permissions at the app installation settings page.",
-			info.Account, granted)
-	}
-	return ""
+	d := appAuth.DiagnoseAppAuth(ctx, expectedOwner, spokeAppKeyPath, spokeProvisionedAppKeyPath)
+	return d.Message(), d.State
+}
+
+// diagnoseGitHubAppWrite is the string-only wrapper retained for callers that
+// only need banner copy.
+func diagnoseGitHubAppWrite(ctx context.Context, appAuth *github.AppAuth, expectedOwner string) string {
+	msg, _ := diagnoseGitHubApp(ctx, appAuth, expectedOwner)
+	return msg
 }
 
 func runEvalCycle(
@@ -2704,17 +2741,32 @@ func runEvalCycle(
 							// Resolve the actual cause — pending permission approval
 							// vs. an installation_id pointing at the wrong org — so
 							// the banner tells the user what to actually fix.
-							msg := diagnoseGitHubAppWrite(ctx, ghClient.AppAuth(), cfg.Project.Org)
+							msg, state := diagnoseGitHubApp(ctx, ghClient.AppAuth(), cfg.Project.Org)
 							if msg == "" {
 								msg = "The GitHub App is installed but lacks Issues: Read & Write permission. The org owner must approve updated permissions at the app installation settings page."
+								state = github.AppStateInsufficientPerms
 							}
-							dashSrv.SetGitHubAppPermIssue(msg)
 							dashSrv.SetGitHubAppRequired(true)
-							logger.Warn("GitHub App installed but insufficient permissions — cannot write issue comments", "repo", primaryRepo, "detail", msg)
+							dashSrv.SetGitHubAppPermIssue(msg)
+							dashSrv.SetGitHubAppState(state.String())
+							logger.Warn("GitHub App write failed — cannot write issue comments",
+								"repo", primaryRepo, "state", state.String(),
+								"operator_actionable", state.OperatorActionable(), "detail", msg)
 						} else if strings.Contains(err.Error(), "rate limit") {
 							logger.Warn("GitHub API rate limit hit, skipping advisory digest post", "repo", primaryRepo)
 						} else if strings.Contains(err.Error(), "403") || strings.Contains(err.Error(), "401") {
+							// Same reasoning as the startup path: classify
+							// before raising a banner, so an operator-side key
+							// failure is never rendered as "not installed".
+							msg, state := diagnoseGitHubApp(ctx, ghClient.AppAuth(), cfg.Project.Org)
 							dashSrv.SetGitHubAppRequired(true)
+							if msg != "" {
+								dashSrv.SetGitHubAppPermIssue(msg)
+							}
+							dashSrv.SetGitHubAppState(state.String())
+							logger.Warn("GitHub App authentication failed posting advisory digest",
+								"repo", primaryRepo, "state", state.String(),
+								"operator_actionable", state.OperatorActionable())
 						}
 					} else {
 						logger.Info("posted advisory digest", "repo", primaryRepo, "issue", issueNum, "findings", digest.TotalCount, "via", "app")

--- a/v2/pkg/dashboard/gh_app_banner_test.go
+++ b/v2/pkg/dashboard/gh_app_banner_test.go
@@ -1,0 +1,119 @@
+package dashboard
+
+import (
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// spokeIndexHTML loads the real spoke dashboard file the server serves.
+func spokeIndexHTML(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile("static/index.html")
+	if err != nil {
+		t.Fatalf("reading static/index.html: %v", err)
+	}
+	return string(b)
+}
+
+// TestGitHubAppBannerHandlesOperatorSideStates locks the banner contract: the
+// spoke dashboard must branch on the classified state and must not send a user
+// to an install page when the failure is the operator's to fix.
+func TestGitHubAppBannerHandlesOperatorSideStates(t *testing.T) {
+	html := spokeIndexHTML(t)
+
+	required := []struct {
+		snippet string
+		why     string
+	}{
+		{"ghAppIsOperatorSide", "the operator-side predicate must exist"},
+		{"GH_APP_STATE_KEY_MISSING = 'key-missing'", "the key-missing wire token must match github.AppStateKeyMissing.String()"},
+		{"GH_APP_STATE_KEY_INVALID = 'key-invalid'", "the key-invalid wire token must match github.AppStateKeyInvalid.String()"},
+		{"data.githubAppState", "the banner must read the classified state from the status payload"},
+		{"operator-issue", "operator-side failures need their own non-alarming styling"},
+		{"no action needed from you", "the operator-side banner must tell the user they need do nothing"},
+	}
+	for _, r := range required {
+		if !strings.Contains(html, r.snippet) {
+			t.Errorf("static/index.html is missing %q — %s", r.snippet, r.why)
+		}
+	}
+}
+
+// TestGitHubAppBannerOperatorBranchOffersNoInstallLink is the specific
+// regression for the reported bug: a user whose App is installed correctly but
+// whose spoke holds the wrong key was shown "Install the GitHub App". The
+// operator-side branch must hide the action link instead.
+func TestGitHubAppBannerOperatorBranchOffersNoInstallLink(t *testing.T) {
+	html := spokeIndexHTML(t)
+
+	const branchStart = "if (isOperatorSide) {"
+	i := strings.Index(html, branchStart)
+	if i < 0 {
+		t.Fatal("static/index.html has no operator-side banner branch")
+	}
+	// Bound the branch at its early return, which is where it ends.
+	rest := html[i:]
+	end := strings.Index(rest, "return;")
+	if end < 0 {
+		t.Fatal("operator-side branch does not return early")
+	}
+	branch := rest[:end]
+
+	if !strings.Contains(branch, "oLink.removeAttribute('href')") {
+		t.Error("the operator-side branch must remove the install link href")
+	}
+	// The forbidden strings are the exact misdirection the fix removes.
+	for _, forbidden := range []string{"githubAppInstallURL", "Install GitHub App"} {
+		if strings.Contains(branch, forbidden) {
+			t.Errorf("the operator-side branch must not reference %q — the user cannot fix this by installing", forbidden)
+		}
+	}
+	if !strings.Contains(branch, "hub administrator") && !strings.Contains(branch, "githubAppPermIssue") {
+		t.Error("the operator-side branch must point the reader at the hub administrator")
+	}
+}
+
+// TestWelcomeChecklistDoesNotBlameUserForOperatorFailure guards the journey
+// nudge on the spoke: an operator-side block is not an unfinished user step.
+func TestWelcomeChecklistDoesNotBlameUserForOperatorFailure(t *testing.T) {
+	html := spokeIndexHTML(t)
+
+	const marker = "if (ghAppIsOperatorSide(data.githubAppState)) return null;"
+	if !strings.Contains(html, marker) {
+		t.Error("the github-app welcome step must return null (unknown), not false, for an operator-side block")
+	}
+	if !strings.Contains(html, "installing the App again will not help") {
+		t.Error("welcomeInstallGitHubApp must refuse to open an install page for an operator-side block")
+	}
+}
+
+// TestGitHubAppStatusFieldIsExposed proves the classified state actually
+// reaches the browser — the banner logic above is dead code without it.
+func TestGitHubAppStatusFieldIsExposed(t *testing.T) {
+	f, ok := reflect.TypeOf(StatusPayload{}).FieldByName("GitHubAppState")
+	if !ok {
+		t.Fatal("StatusPayload has no GitHubAppState field — the banner logic would be dead code")
+	}
+	// The JSON tag is the name the dashboard actually reads.
+	if got := f.Tag.Get("json"); !strings.HasPrefix(got, "githubAppState") {
+		t.Errorf("GitHubAppState json tag = %q, want it to serialise as githubAppState", got)
+	}
+}
+
+// TestSetGitHubAppStateRoundTrips covers the setter/getter and the clearing
+// contract: turning the requirement off must also clear the classified state,
+// or a stale operator-side token would suppress future genuine nudges.
+func TestSetGitHubAppStateRoundTrips(t *testing.T) {
+	s := &Server{}
+	s.SetGitHubAppRequired(true)
+	s.SetGitHubAppState("key-invalid")
+	if got := s.GetGitHubAppState(); got != "key-invalid" {
+		t.Fatalf("GetGitHubAppState() = %q, want key-invalid", got)
+	}
+	s.SetGitHubAppRequired(false)
+	if got := s.GetGitHubAppState(); got != "" {
+		t.Errorf("GetGitHubAppState() = %q after clearing the requirement, want empty", got)
+	}
+}

--- a/v2/pkg/dashboard/server.go
+++ b/v2/pkg/dashboard/server.go
@@ -128,10 +128,18 @@ type Server struct {
 	ready   bool
 	readyAt time.Time
 
-	githubAppMu               sync.RWMutex
-	githubAppRequired         bool
-	githubAppInstallURL       string
-	githubAppPermIssue        string // non-empty when app is installed but lacks required permissions
+	githubAppMu         sync.RWMutex
+	githubAppRequired   bool
+	githubAppInstallURL string
+	githubAppPermIssue  string // non-empty when app is installed but lacks required permissions
+	// githubAppState is the classified reason App auth is failing (a
+	// github.AppAuthState wire token: "key-missing", "not-installed", …).
+	// It exists so the UI can tell an OPERATOR-side failure (the hive's key
+	// was never delivered, or belongs to a different App) apart from a
+	// USER-side one (App not installed, wrong installation_id) and stop
+	// blaming users for problems only an admin can fix. Empty means the
+	// state was never classified.
+	githubAppState            string
 	pendingGitHubAppInstall   bool
 	pendingGitHubAppInstallAt time.Time
 
@@ -168,6 +176,7 @@ type StatusPayload struct {
 	GitHubAppRequired   bool                   `json:"githubAppRequired,omitempty"`
 	GitHubAppInstallURL string                 `json:"githubAppInstallURL,omitempty"`
 	GitHubAppPermIssue  string                 `json:"githubAppPermIssue,omitempty"`
+	GitHubAppState      string                 `json:"githubAppState,omitempty"`
 	GitHubBaseURL       string                 `json:"githubBaseURL,omitempty"`
 	InferenceBackends   []InferenceBackend     `json:"inferenceBackends,omitempty"`
 	SystemAlerts        []SystemAlert          `json:"systemAlerts,omitempty"`
@@ -932,6 +941,7 @@ func (s *Server) UpdateStatus(status *StatusPayload) {
 	status.GitHubAppRequired = s.githubAppRequired
 	status.GitHubAppInstallURL = s.githubAppInstallURL
 	status.GitHubAppPermIssue = s.githubAppPermIssue
+	status.GitHubAppState = s.githubAppState
 	s.githubAppMu.RUnlock()
 
 	status.InferenceBackends = s.buildInferenceBackends()
@@ -1075,7 +1085,25 @@ func (s *Server) SetGitHubAppRequired(required bool) {
 	} else {
 		s.githubAppInstallURL = ""
 		s.githubAppPermIssue = ""
+		s.githubAppState = ""
 	}
+}
+
+// SetGitHubAppState records the classified reason App auth is failing, as a
+// github.AppAuthState wire token. The banner and the hub both branch on this
+// to decide whether the failure is the user's to fix or the operator's, so it
+// must be set alongside every SetGitHubAppPermIssue call. Pass "" to clear.
+func (s *Server) SetGitHubAppState(state string) {
+	s.githubAppMu.Lock()
+	defer s.githubAppMu.Unlock()
+	s.githubAppState = state
+}
+
+// GetGitHubAppState returns the classified App auth state ("" when unknown).
+func (s *Server) GetGitHubAppState() string {
+	s.githubAppMu.RLock()
+	defer s.githubAppMu.RUnlock()
+	return s.githubAppState
 }
 
 // SetGitHubAppPermIssue records that the app IS installed but lacks a specific

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -683,6 +683,11 @@
     .gh-app-install-banner .gh-app-btn { display: inline-block; text-decoration: none; white-space: nowrap; }
     .gh-app-install-banner.perm-issue { background: color-mix(in srgb, var(--yellow) 12%, var(--panel)); border-color: var(--yellow); }
     .gh-app-install-banner.perm-issue .gh-app-desc { color: var(--text); }
+    /* Operator-side failure: informational, not alarming, and not the user's
+       fault. Deliberately neutral rather than the red "you must act" styling —
+       there is nothing for the reader to do. */
+    .gh-app-install-banner.operator-issue { background: color-mix(in srgb, var(--accent) 10%, var(--panel)); border-color: color-mix(in srgb, var(--accent) 45%, transparent); }
+    .gh-app-install-banner.operator-issue .gh-app-desc { color: var(--text); }
     .gh-app-perm-details { font-size: 0.8rem; margin-top: 6px; color: var(--text); }
     .gh-app-perm-details .perm-ok { color: var(--green); }
     .gh-app-perm-details .perm-missing { color: var(--red); font-weight: 600; }
@@ -4760,9 +4765,70 @@
       }
     }
 
+    /* Classified GitHub App auth states, matching github.AppAuthState.String()
+       on the spoke. Only the two OPERATOR_* states describe a failure the hive
+       owner cannot fix: the App private key is distributed by the hub, so a
+       missing or mismatched key is never the user's doing. Warnings for those
+       states must not tell the user to install anything or edit config. */
+    var GH_APP_STATE_KEY_MISSING = 'key-missing';
+    var GH_APP_STATE_KEY_INVALID = 'key-invalid';
+    var GH_APP_OPERATOR_STATES = {};
+    GH_APP_OPERATOR_STATES[GH_APP_STATE_KEY_MISSING] = true;
+    GH_APP_OPERATOR_STATES[GH_APP_STATE_KEY_INVALID] = true;
+
+    /* True when the App failure is the operator's to fix. An unreported or
+       unrecognised state is deliberately NOT operator-side: a spoke too old to
+       classify must keep the existing user-facing guidance rather than silently
+       telling everyone to contact an admin. */
+    function ghAppIsOperatorSide(state) {
+      return GH_APP_OPERATOR_STATES[String(state || '').trim()] === true;
+    }
+
     function renderGitHubAppBanner(data) {
       var banner = document.getElementById('gh-app-install-banner');
       if (!banner) return;
+      var appState = data ? String(data.githubAppState || '').trim() : '';
+      var isOperatorSide = data && data.githubAppRequired && ghAppIsOperatorSide(appState);
+
+      /* Operator-side failure: the hive's App credentials were never delivered,
+         or the key it holds belongs to a different App. The user did nothing
+         wrong and has nothing to fix, so this banner states the cause, names
+         who fixes it, and offers NO install link or config instruction. */
+      if (isOperatorSide) {
+        banner.classList.remove('perm-issue');
+        banner.classList.add('operator-issue');
+        var oTitle = document.querySelector('#gh-app-install-banner .gh-app-title');
+        var oDesc = document.querySelector('#gh-app-install-banner .gh-app-desc');
+        var oLink = document.getElementById('gh-app-install-link');
+        if (oTitle) oTitle.textContent = 'GitHub App credentials pending — no action needed from you';
+        if (oDesc) {
+          /* Prefer the server-composed diagnosis; it already carries the
+             accurate, non-blaming copy. textContent keeps any org name or API
+             text safe to render verbatim. */
+          oDesc.textContent = (typeof data.githubAppPermIssue === 'string' && data.githubAppPermIssue)
+            ? data.githubAppPermIssue
+            : (appState === GH_APP_STATE_KEY_INVALID
+                ? 'This hive’s GitHub App private key does not match the App it authenticates as, so GitHub rejects its token. The key is supplied by the hub operator and cannot be corrected by you — your App installation and installation ID are not at fault. Please contact your hub administrator.'
+                : 'This hive’s GitHub App credentials have not been provisioned yet. The private key is supplied by the hub operator, not by you. Agents will start working automatically once it arrives; contact your hub administrator if this persists.');
+        }
+        /* No install link: sending the user to an install page for a key
+           problem is exactly the misdirection this banner exists to stop. */
+        if (oLink) {
+          oLink.removeAttribute('href');
+          oLink.textContent = '';
+          oLink.style.display = 'none';
+        }
+        var staleDetails = document.getElementById('gh-app-perm-details');
+        if (staleDetails) staleDetails.remove();
+        banner.removeAttribute('hidden');
+        banner.style.cssText = 'display:flex !important';
+        return;
+      }
+      /* Not operator-side — restore the action link the branch above hides. */
+      var resetLink = document.getElementById('gh-app-install-link');
+      if (resetLink) resetLink.style.display = '';
+      banner.classList.remove('operator-issue');
+
       var isPermIssue = data.githubAppRequired && data.githubAppPermIssue;
       if (data.githubAppRequired && (data.githubAppInstallURL || isPermIssue)) {
         var link = document.getElementById('gh-app-install-link');
@@ -16763,7 +16829,15 @@ function burnAreaChart() {
       {
         id: 'github-app',
         title: 'Install the GitHub App',
-        auto: (data) => data ? data.githubAppRequired !== true : null,
+        // An operator-side credential failure is not an unfinished user step.
+        // Return null ("cannot tell") rather than false, so the checklist does
+        // not mark the user as having something left to do when the missing
+        // piece is a key the hub operator supplies.
+        auto: (data) => {
+          if (!data) return null;
+          if (ghAppIsOperatorSide(data.githubAppState)) return null;
+          return data.githubAppRequired !== true;
+        },
         body: 'The GitHub App unlocks issues, advisory reports, and PRs on your primary repo — without it the hive can only observe.',
         autoNote: 'Checks itself once the app is detected on your repository.',
         actions: [
@@ -16960,6 +17034,12 @@ function burnAreaChart() {
     }
     /** Open the GitHub App install page (same URL the banner links to). */
     function welcomeInstallGitHubApp() {
+      // Never send the user to an install page when the block is operator-side:
+      // installing again cannot fix a key they do not control.
+      if (window._lastStatus && ghAppIsOperatorSide(window._lastStatus.githubAppState)) {
+        showToast('This hive is waiting on GitHub App credentials from the hub operator — installing the App again will not help. Contact your hub administrator.', 'info');
+        return;
+      }
       const url = (window._lastStatus && window._lastStatus.githubAppInstallURL) || '';
       if (url) { window.open(url, '_blank', 'noopener'); return; }
       const installed = !!(window._lastStatus) && window._lastStatus.githubAppRequired !== true;

--- a/v2/pkg/github/app_state.go
+++ b/v2/pkg/github/app_state.go
@@ -1,0 +1,369 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+// AppAuthState classifies WHY GitHub App authentication is not working, so the
+// UI can say the true thing instead of one catch-all "install the App" banner.
+//
+// The distinction that matters most is between the states a USER can fix
+// (install the App, correct installation_id) and the state only an OPERATOR can
+// fix (the private key this spoke signs with is missing or belongs to a
+// different App). Telling a user to "install the GitHub App" when the operator
+// has not delivered a usable key sends them to redo work they already did
+// correctly, and — via the journey nudges — can escalate to threatening
+// de-provisioning for our own failure.
+type AppAuthState int
+
+const (
+	// AppStateUnknown means classification was not attempted or could not
+	// reach a conclusion (network error, unparseable response). Callers must
+	// treat it as "we cannot tell" and never escalate on it.
+	AppStateUnknown AppAuthState = iota
+
+	// AppStateOK means the App authenticated and the installation resolved.
+	AppStateOK
+
+	// AppStateNotInstalled means the App is genuinely not installed on the
+	// target account. USER-ACTIONABLE: install the App.
+	AppStateNotInstalled
+
+	// AppStateWrongInstallation means the App authenticated fine, but the
+	// installation it resolved belongs to a different account than this hive
+	// targets. USER-ACTIONABLE: correct github.installation_id.
+	AppStateWrongInstallation
+
+	// AppStateInsufficientPerms means the App is installed on the right
+	// account but the org owner has not approved the permissions it needs.
+	// USER-ACTIONABLE (by an org owner): approve the permission update.
+	AppStateInsufficientPerms
+
+	// AppStateKeyMissing means no App private key is present on this spoke at
+	// all. OPERATOR-ACTIONABLE: the hub has not delivered the key.
+	AppStateKeyMissing
+
+	// AppStateKeyInvalid means a key IS present but GitHub rejected the JWT it
+	// signed — the key does not belong to the App this hive claims to be (the
+	// classic symptom of a public github.com key on a GitHub Enterprise hive).
+	// OPERATOR-ACTIONABLE: the hub must push the correct key.
+	AppStateKeyInvalid
+)
+
+// String returns the stable wire token for a state. These tokens cross the
+// heartbeat to the hub and into both dashboards, so they must not change
+// without updating the consumers.
+func (s AppAuthState) String() string {
+	switch s {
+	case AppStateOK:
+		return "ok"
+	case AppStateNotInstalled:
+		return "not-installed"
+	case AppStateWrongInstallation:
+		return "wrong-installation"
+	case AppStateInsufficientPerms:
+		return "insufficient-permissions"
+	case AppStateKeyMissing:
+		return "key-missing"
+	case AppStateKeyInvalid:
+		return "key-invalid"
+	default:
+		return "unknown"
+	}
+}
+
+// OperatorActionable reports whether this state can ONLY be fixed by whoever
+// operates the hub — never by the hive's owner. Warnings for these states must
+// not instruct the user to install anything or edit config, and the journey
+// nudges must never escalate against them.
+func (s AppAuthState) OperatorActionable() bool {
+	return s == AppStateKeyMissing || s == AppStateKeyInvalid
+}
+
+// UserActionable reports whether the hive's owner (or their org owner) can fix
+// this state themselves. Only these states justify a "do something" banner.
+func (s AppAuthState) UserActionable() bool {
+	switch s {
+	case AppStateNotInstalled, AppStateWrongInstallation, AppStateInsufficientPerms:
+		return true
+	default:
+		return false
+	}
+}
+
+// ParseAppAuthState turns a wire token back into a state. Unrecognised input
+// yields AppStateUnknown so an older spoke reporting a token we do not know
+// degrades to "cannot tell" rather than to a false accusation.
+func ParseAppAuthState(s string) AppAuthState {
+	switch strings.TrimSpace(s) {
+	case "ok":
+		return AppStateOK
+	case "not-installed":
+		return AppStateNotInstalled
+	case "wrong-installation":
+		return AppStateWrongInstallation
+	case "insufficient-permissions":
+		return AppStateInsufficientPerms
+	case "key-missing":
+		return AppStateKeyMissing
+	case "key-invalid":
+		return AppStateKeyInvalid
+	default:
+		return AppStateUnknown
+	}
+}
+
+// jwtUndecodableMarker is the message GitHub returns on
+// POST /app/installations/{id}/access_tokens (and GET /app/installations/{id})
+// when the JWT presented was signed by a key that does not belong to the App
+// named in its `iss` claim. It is the definitive signature of a key/App
+// mismatch, and is what distinguishes a broken KEY from a wrong INSTALLATION:
+// a wrong installation_id authenticates fine (the JWT decodes) and fails later
+// with 403/404 on the installation itself.
+const jwtUndecodableMarker = "a json web token could not be decoded"
+
+// Required issues permission for a hive to do any GitHub work.
+const requiredIssuesPerm = "write"
+
+// classifyAPIError maps a go-github error to an AppAuthState using the ACTUAL
+// HTTP status of the response, never a substring of a formatted error string.
+//
+// The three failure statuses mean genuinely different things on the App
+// endpoints:
+//
+//   - 401 Unauthorized — the JWT itself was rejected. On these endpoints the
+//     only credential is the App JWT, so a 401 means the signature did not
+//     verify against the App's registered public key: the private key is
+//     wrong. GitHub says "A JSON web token could not be decoded". This is
+//     OPERATOR-side; the user has no way to supply or correct this key.
+//   - 404 Not Found — the JWT verified (GitHub knows which App we are) but
+//     there is no such installation visible to this App. The App is not
+//     installed on the target.
+//   - 403 Forbidden — the JWT verified and the installation exists, but this
+//     App may not act on it ("Resource not accessible by integration"). That
+//     is a permissions/installation-mismatch problem, not a key problem.
+//
+// A nil resp (transport failure, DNS, timeout) yields AppStateUnknown: we did
+// not get an answer from GitHub and must not guess.
+func classifyAPIError(err error, resp *gh.Response) AppAuthState {
+	if err == nil {
+		return AppStateOK
+	}
+
+	status := 0
+	if resp != nil && resp.Response != nil {
+		status = resp.StatusCode
+	}
+	// go-github surfaces the parsed body on *gh.ErrorResponse even when the
+	// caller discarded the *gh.Response, so prefer it when we have one.
+	var ghErr *gh.ErrorResponse
+	if errors.As(err, &ghErr) && ghErr.Response != nil {
+		status = ghErr.Response.StatusCode
+	}
+
+	switch status {
+	case http.StatusUnauthorized:
+		// A 401 on an App endpoint is always a signing failure. The message
+		// check only refines the log/telemetry story; the status alone is
+		// sufficient to conclude the key is at fault.
+		return AppStateKeyInvalid
+	case http.StatusNotFound:
+		return AppStateNotInstalled
+	case http.StatusForbidden:
+		// 403 can also be a rate limit, which is transient and must never be
+		// reported as a credential problem.
+		if isRateLimitErr(err) {
+			return AppStateUnknown
+		}
+		return AppStateWrongInstallation
+	}
+
+	// No usable status. Fall back to the JWT marker, which some proxies
+	// surface without preserving the status code.
+	if strings.Contains(strings.ToLower(err.Error()), jwtUndecodableMarker) {
+		return AppStateKeyInvalid
+	}
+	return AppStateUnknown
+}
+
+// isRateLimitErr reports whether an error is a GitHub rate/abuse limit. These
+// are transient and must not latch a credential warning.
+func isRateLimitErr(err error) bool {
+	var rl *gh.RateLimitError
+	if errors.As(err, &rl) {
+		return true
+	}
+	var ab *gh.AbuseRateLimitError
+	return errors.As(err, &ab)
+}
+
+// AppAuthDiagnosis is the full result of checking this hive's GitHub App
+// credentials: what state they are in, and the supporting detail a caller
+// needs to compose accurate copy.
+type AppAuthDiagnosis struct {
+	State AppAuthState
+	// Account is the login the installation actually belongs to, when known.
+	Account string
+	// ExpectedAccount is the org/user this hive targets.
+	ExpectedAccount string
+	// InstallationID is the installation this hive is configured to use.
+	InstallationID int64
+	// IssuesPerm is the granted issues permission, when the installation
+	// resolved.
+	IssuesPerm string
+	// Err is the underlying error, for logs. Never rendered to a user
+	// verbatim, because it can carry raw API text.
+	Err error
+}
+
+// keyFileReadable reports whether path exists and holds non-empty content.
+// This is the cheap, pre-flight detection of AppStateKeyMissing: it needs no
+// API round-trip and is the clearest possible signal that the operator's key
+// push has not landed.
+func keyFileReadable(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	return info.Size() > 0
+}
+
+// DiagnoseAppAuth classifies this hive's GitHub App credential state against
+// expectedOwner (the org/user the hive targets).
+//
+// keyPaths are candidate private-key locations, checked in order. When NONE of
+// them holds content, the result is AppStateKeyMissing WITHOUT making any API
+// call — a missing key cannot possibly authenticate, and a failed round-trip
+// would only produce a less specific answer. Pass no paths to skip the
+// pre-flight and rely on the API classification alone.
+//
+// A nil receiver, or one with no loaded key, is AppStateKeyMissing: a hive
+// that cannot sign a JWT has no credentials, which is an operator problem.
+func (a *AppAuth) DiagnoseAppAuth(ctx context.Context, expectedOwner string, keyPaths ...string) AppAuthDiagnosis {
+	d := AppAuthDiagnosis{ExpectedAccount: expectedOwner}
+
+	if a == nil || !a.HasKey() {
+		d.State = AppStateKeyMissing
+		return d
+	}
+	d.InstallationID = a.InstallationID()
+
+	// Cheap pre-flight: if we were given key locations and none of them holds
+	// content, the key is missing. No API call needed.
+	if len(keyPaths) > 0 {
+		anyReadable := false
+		for _, p := range keyPaths {
+			if keyFileReadable(p) {
+				anyReadable = true
+				break
+			}
+		}
+		if !anyReadable {
+			d.State = AppStateKeyMissing
+			return d
+		}
+	}
+
+	jwtToken, err := a.generateJWT()
+	if err != nil {
+		// We hold a key but cannot sign with it — the key itself is unusable.
+		d.State = AppStateKeyInvalid
+		d.Err = fmt.Errorf("generating JWT: %w", err)
+		return d
+	}
+
+	jwtClient := gh.NewClient(nil).WithAuthToken(jwtToken)
+	setBaseURL(jwtClient, a.apiURL)
+	inst, resp, err := jwtClient.Apps.GetInstallation(ctx, a.installationID)
+	if err != nil {
+		d.State = classifyAPIError(err, resp)
+		d.Err = err
+		return d
+	}
+	if inst == nil {
+		d.State = AppStateUnknown
+		d.Err = errors.New("github returned no installation and no error")
+		return d
+	}
+
+	d.Account = inst.GetAccount().GetLogin()
+	d.IssuesPerm = inst.GetPermissions().GetIssues()
+
+	if expectedOwner != "" && d.Account != "" && !strings.EqualFold(d.Account, expectedOwner) {
+		d.State = AppStateWrongInstallation
+		return d
+	}
+	if d.IssuesPerm != requiredIssuesPerm {
+		d.State = AppStateInsufficientPerms
+		return d
+	}
+	d.State = AppStateOK
+	return d
+}
+
+// Message returns accurate, non-blaming, user-facing copy for a diagnosis.
+//
+// The contract for operator-side states is strict: say what is wrong, say that
+// an administrator fixes it, and do NOT ask the user to install anything or
+// edit any config. A user who has done everything right must never be sent
+// back to redo it.
+func (d AppAuthDiagnosis) Message() string {
+	owner := d.ExpectedAccount
+	if strings.TrimSpace(owner) == "" {
+		owner = "this hive's organization"
+	}
+
+	switch d.State {
+	case AppStateOK:
+		return ""
+
+	case AppStateKeyMissing:
+		return "This hive's GitHub App credentials have not been provisioned yet. " +
+			"The App private key is supplied by the hub operator, not by you — there is nothing to install or configure on your side. " +
+			"Agents will start working automatically once the key arrives. If this persists, contact your hub administrator."
+
+	case AppStateKeyInvalid:
+		return "This hive's GitHub App credentials are not valid for the GitHub instance it targets: " +
+			"the private key it holds does not match the App it authenticates as, so GitHub rejects its signed token. " +
+			"This key is distributed by the hub operator and cannot be supplied or corrected by you — " +
+			"your App installation and installation ID are not at fault. Please contact your hub administrator to have the correct key pushed to this hive."
+
+	case AppStateNotInstalled:
+		return fmt.Sprintf("The KubeStellar Hive GitHub App is not installed on %s. "+
+			"Until it is, agents cannot read issues or open pull requests. Install it from the link on this banner.", owner)
+
+	case AppStateWrongInstallation:
+		acct := d.Account
+		if strings.TrimSpace(acct) == "" {
+			acct = "a different account"
+		}
+		return fmt.Sprintf("This hive is authenticating as GitHub App installation %d, which belongs to '%s' — not '%s'. "+
+			"Check github.installation_id in the hive config.", d.InstallationID, acct, owner)
+
+	case AppStateInsufficientPerms:
+		granted := d.IssuesPerm
+		if granted == "" {
+			granted = "none"
+		}
+		acct := d.Account
+		if strings.TrimSpace(acct) == "" {
+			acct = owner
+		}
+		return fmt.Sprintf("The GitHub App is installed for '%s' but granted Issues: %s (Issues: Read & Write required). "+
+			"The org owner must approve the updated permissions at the app installation settings page.", acct, granted)
+
+	default:
+		return "Could not verify this hive's GitHub App credentials. This is usually transient — " +
+			"the check will run again automatically. No action is needed from you right now."
+	}
+}

--- a/v2/pkg/github/app_state_test.go
+++ b/v2/pkg/github/app_state_test.go
@@ -1,0 +1,320 @@
+package github
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// testKeyBits is deliberately small — these tests only need a signable key,
+// never a secure one, and 2048-bit generation dominates the runtime.
+const testKeyBits = 2048
+
+func appStateTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func testAuth(t *testing.T, apiURL string) *AppAuth {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, testKeyBits)
+	if err != nil {
+		t.Fatalf("generating test key: %v", err)
+	}
+	return &AppAuth{appID: 5686, installationID: 42980, key: key, logger: appStateTestLogger(), apiURL: apiURL}
+}
+
+// TestDiagnoseAppAuth_Classification is the core table: every failure mode the
+// banner copy depends on, driven by the ACTUAL HTTP status the API returns.
+func TestDiagnoseAppAuth_Classification(t *testing.T) {
+	tests := []struct {
+		name string
+		// status/body describe the canned GET /app/installations/{id} reply.
+		status int
+		body   string
+		// expectedOwner is the org the hive targets.
+		expectedOwner string
+		want          AppAuthState
+		wantOperator  bool
+		wantUser      bool
+		// wantMsgHas / wantMsgLacks assert the copy says the true thing.
+		wantMsgHas   []string
+		wantMsgLacks []string
+	}{
+		{
+			name:          "401 JWT undecodable is an operator key problem",
+			status:        http.StatusUnauthorized,
+			body:          `{"message":"A JSON web token could not be decoded","documentation_url":"https://docs.github.com/rest"}`,
+			expectedOwner: "katamari",
+			want:          AppStateKeyInvalid,
+			wantOperator:  true,
+			wantMsgHas:    []string{"hub operator", "administrator", "not at fault"},
+			// Must never send a user who did everything right back to redo it.
+			wantMsgLacks: []string{"Install it", "installation_id", "Check github"},
+		},
+		{
+			name:          "403 not accessible is a wrong installation",
+			status:        http.StatusForbidden,
+			body:          `{"message":"Resource not accessible by integration"}`,
+			expectedOwner: "katamari",
+			want:          AppStateWrongInstallation,
+			wantUser:      true,
+			wantMsgHas:    []string{"installation_id"},
+		},
+		{
+			name:          "404 means the app is not installed",
+			status:        http.StatusNotFound,
+			body:          `{"message":"Not Found"}`,
+			expectedOwner: "katamari",
+			want:          AppStateNotInstalled,
+			wantUser:      true,
+			wantMsgHas:    []string{"not installed", "katamari"},
+		},
+		{
+			name:          "installation belonging to another account",
+			status:        http.StatusOK,
+			body:          `{"id":42980,"account":{"login":"someone-else"},"permissions":{"issues":"write"}}`,
+			expectedOwner: "katamari",
+			want:          AppStateWrongInstallation,
+			wantUser:      true,
+			wantMsgHas:    []string{"someone-else", "katamari", "installation_id"},
+			wantMsgLacks:  []string{"administrator"},
+		},
+		{
+			name:          "installed on the right org but issues perm not granted",
+			status:        http.StatusOK,
+			body:          `{"id":42980,"account":{"login":"katamari"},"permissions":{"issues":"read"}}`,
+			expectedOwner: "katamari",
+			want:          AppStateInsufficientPerms,
+			wantUser:      true,
+			wantMsgHas:    []string{"Issues: read", "org owner"},
+		},
+		{
+			name:          "success",
+			status:        http.StatusOK,
+			body:          `{"id":42980,"account":{"login":"katamari"},"permissions":{"issues":"write"}}`,
+			expectedOwner: "katamari",
+			want:          AppStateOK,
+			wantMsgHas:    nil,
+		},
+		{
+			name:          "case-insensitive account match still succeeds",
+			status:        http.StatusOK,
+			body:          `{"id":42980,"account":{"login":"KataMari"},"permissions":{"issues":"write"}}`,
+			expectedOwner: "katamari",
+			want:          AppStateOK,
+		},
+		{
+			name:          "500 yields unknown, never an accusation",
+			status:        http.StatusInternalServerError,
+			body:          `{"message":"Server Error"}`,
+			expectedOwner: "katamari",
+			want:          AppStateUnknown,
+			wantMsgHas:    []string{"No action is needed"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer srv.Close()
+
+			auth := testAuth(t, srv.URL)
+			got := auth.DiagnoseAppAuth(context.Background(), tt.expectedOwner)
+
+			if got.State != tt.want {
+				t.Fatalf("State = %v (%s), want %v (%s)", got.State, got.State, tt.want, tt.want)
+			}
+			if got.State.OperatorActionable() != tt.wantOperator {
+				t.Errorf("OperatorActionable() = %v, want %v", got.State.OperatorActionable(), tt.wantOperator)
+			}
+			if got.State.UserActionable() != tt.wantUser {
+				t.Errorf("UserActionable() = %v, want %v", got.State.UserActionable(), tt.wantUser)
+			}
+
+			msg := got.Message()
+			if tt.want == AppStateOK && msg != "" {
+				t.Errorf("Message() = %q, want empty for the success state", msg)
+			}
+			for _, want := range tt.wantMsgHas {
+				if !strings.Contains(msg, want) {
+					t.Errorf("Message() = %q, want it to contain %q", msg, want)
+				}
+			}
+			for _, lack := range tt.wantMsgLacks {
+				if strings.Contains(msg, lack) {
+					t.Errorf("Message() = %q, must NOT contain %q", msg, lack)
+				}
+			}
+		})
+	}
+}
+
+// TestDiagnoseAppAuth_MissingKeyFileSkipsAPI proves the cheap pre-flight: when
+// no candidate key path holds content we conclude AppStateKeyMissing without
+// ever touching the API.
+func TestDiagnoseAppAuth_MissingKeyFileSkipsAPI(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "absent.pem")
+	empty := filepath.Join(dir, "empty.pem")
+	if err := os.WriteFile(empty, nil, 0o600); err != nil {
+		t.Fatalf("writing empty key: %v", err)
+	}
+
+	auth := testAuth(t, srv.URL)
+	got := auth.DiagnoseAppAuth(context.Background(), "katamari", missing, empty)
+
+	if got.State != AppStateKeyMissing {
+		t.Fatalf("State = %s, want key-missing", got.State)
+	}
+	if called {
+		t.Error("made an API call despite no readable key file — the pre-flight must short-circuit")
+	}
+	if !got.State.OperatorActionable() {
+		t.Error("key-missing must be operator-actionable")
+	}
+	msg := got.Message()
+	for _, lack := range []string{"Install", "installation_id"} {
+		if strings.Contains(msg, lack) {
+			t.Errorf("Message() = %q, must not tell the user to %q", msg, lack)
+		}
+	}
+	if !strings.Contains(msg, "hub administrator") {
+		t.Errorf("Message() = %q, want it to point at the hub administrator", msg)
+	}
+}
+
+// TestDiagnoseAppAuth_ReadableKeyStillCallsAPI is the counterpart: a present
+// key must not short-circuit, or a genuinely-uninstalled App would be misread
+// as a credential problem.
+func TestDiagnoseAppAuth_ReadableKeyStillCallsAPI(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	present := filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(present, []byte("-----BEGIN RSA PRIVATE KEY-----\nx\n-----END RSA PRIVATE KEY-----\n"), 0o600); err != nil {
+		t.Fatalf("writing key: %v", err)
+	}
+
+	auth := testAuth(t, srv.URL)
+	got := auth.DiagnoseAppAuth(context.Background(), "katamari", present)
+
+	if !called {
+		t.Error("did not call the API despite a readable key file")
+	}
+	if got.State != AppStateNotInstalled {
+		t.Fatalf("State = %s, want not-installed", got.State)
+	}
+}
+
+// TestDiagnoseAppAuth_NilAndKeylessAreOperatorSide guards the two degenerate
+// receivers: neither may produce a user-blaming warning.
+func TestDiagnoseAppAuth_NilAndKeylessAreOperatorSide(t *testing.T) {
+	var nilAuth *AppAuth
+	if got := nilAuth.DiagnoseAppAuth(context.Background(), "katamari"); got.State != AppStateKeyMissing {
+		t.Errorf("nil receiver State = %s, want key-missing", got.State)
+	}
+	keyless := &AppAuth{appID: 1, installationID: 2, logger: appStateTestLogger()}
+	if got := keyless.DiagnoseAppAuth(context.Background(), "katamari"); got.State != AppStateKeyMissing {
+		t.Errorf("keyless State = %s, want key-missing", got.State)
+	}
+}
+
+// TestAppAuthState_WireRoundTrip locks the tokens that cross the heartbeat.
+func TestAppAuthState_WireRoundTrip(t *testing.T) {
+	all := []AppAuthState{
+		AppStateUnknown, AppStateOK, AppStateNotInstalled, AppStateWrongInstallation,
+		AppStateInsufficientPerms, AppStateKeyMissing, AppStateKeyInvalid,
+	}
+	for _, s := range all {
+		if got := ParseAppAuthState(s.String()); got != s {
+			t.Errorf("ParseAppAuthState(%q) = %v, want %v", s.String(), got, s)
+		}
+	}
+	// An unrecognised token must degrade to unknown, never to an accusation.
+	for _, bogus := range []string{"", "  ", "not-a-state", "NOT-INSTALLED"} {
+		if got := ParseAppAuthState(bogus); got != AppStateUnknown {
+			t.Errorf("ParseAppAuthState(%q) = %v, want unknown", bogus, got)
+		}
+	}
+}
+
+// TestAppAuthState_ActionabilityIsExclusive asserts no state is ever claimed by
+// both sides — the journey nudges branch on exactly this.
+func TestAppAuthState_ActionabilityIsExclusive(t *testing.T) {
+	all := []AppAuthState{
+		AppStateUnknown, AppStateOK, AppStateNotInstalled, AppStateWrongInstallation,
+		AppStateInsufficientPerms, AppStateKeyMissing, AppStateKeyInvalid,
+	}
+	for _, s := range all {
+		if s.OperatorActionable() && s.UserActionable() {
+			t.Errorf("state %s claims to be both operator- and user-actionable", s)
+		}
+	}
+	if AppStateOK.OperatorActionable() || AppStateOK.UserActionable() {
+		t.Error("the OK state must be neither operator- nor user-actionable")
+	}
+	if AppStateUnknown.OperatorActionable() || AppStateUnknown.UserActionable() {
+		t.Error("the unknown state must not be actionable by anyone")
+	}
+}
+
+// TestClassifyAPIError_RateLimitIsNotACredentialProblem — a 403 rate limit is
+// transient and must never latch a credential warning.
+func TestClassifyAPIError_RateLimitIsNotACredentialProblem(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Limit", "60")
+		w.Header().Set("X-RateLimit-Reset", "9999999999")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"message":           "API rate limit exceeded",
+			"documentation_url": "https://docs.github.com/rest",
+		})
+	}))
+	defer srv.Close()
+
+	auth := testAuth(t, srv.URL)
+	got := auth.DiagnoseAppAuth(context.Background(), "katamari")
+	if got.State != AppStateUnknown {
+		t.Errorf("State = %s, want unknown for a rate-limited 403", got.State)
+	}
+}
+
+// TestClassifyAPIError_NoResponseIsUnknown — a transport failure yields no
+// status, and we must not guess.
+func TestClassifyAPIError_NoResponseIsUnknown(t *testing.T) {
+	// Port 1 is reserved and refuses connections.
+	auth := testAuth(t, "http://127.0.0.1:1")
+	got := auth.DiagnoseAppAuth(context.Background(), "katamari")
+	if got.State != AppStateUnknown {
+		t.Errorf("State = %s, want unknown when GitHub never answered", got.State)
+	}
+	if got.State.OperatorActionable() || got.State.UserActionable() {
+		t.Error("an unreachable API must not be reported as anyone's fault")
+	}
+}

--- a/v2/pkg/hub/drift.go
+++ b/v2/pkg/hub/drift.go
@@ -63,10 +63,15 @@ const (
 	DriftKindHeartbeatStale = "heartbeat-stale"
 	DriftKindAppMissing     = "app-missing"
 	DriftKindAppPermIssue   = "app-perm-issue"
-	DriftKindHealthDegraded = "health-degraded"
-	DriftKindUpgradeStuck   = "upgrade-stuck"
-	DriftKindACMMUnset      = "acmm-unset"
-	DriftKindNoAgents       = "no-agents"
+	// DriftKindAppCredsOperator marks a hive whose GitHub App credentials are
+	// broken in a way only the hub operator can repair. Kept distinct from
+	// app-missing/app-perm-issue so operator work is never filed as an
+	// owner-facing adoption problem.
+	DriftKindAppCredsOperator = "app-creds-operator"
+	DriftKindHealthDegraded   = "health-degraded"
+	DriftKindUpgradeStuck     = "upgrade-stuck"
+	DriftKindACMMUnset        = "acmm-unset"
+	DriftKindNoAgents         = "no-agents"
 )
 
 // DriftSignal is one detected deviation. Reason is a complete, human-readable
@@ -457,7 +462,21 @@ func computeDrift(h MyHiveEntry, norm fleetNorm, latestSHAs map[string]string, n
 	// the hives a human can actually fix.
 	if !placeholder {
 		if h.GitHubAppRequired {
-			if h.GitHubAppPermIssue != "" {
+			// Operator-side first: a hive whose App key we never delivered (or
+			// delivered wrong) is not an owner-facing "installed but under-
+			// permissioned" problem, and must not be described as one. It is
+			// still critical drift — the hive cannot work — but the text has to
+			// point at the operator so nobody chases the owner about an
+			// installation that is already correct.
+			if appStateIsOperatorSide(h.GitHubAppState) {
+				detail := "the App private key has not been delivered to this spoke"
+				if strings.TrimSpace(h.GitHubAppState) == appStateKeyInvalidToken {
+					detail = "the App private key on this spoke does not match the App it authenticates as, so GitHub rejects its JWT"
+				}
+				add(DriftKindAppCredsOperator, DriftCritical,
+					"GitHub App credentials are not valid and only an operator can fix it: "+detail+
+						" — the hive owner cannot supply or correct this key")
+			} else if h.GitHubAppPermIssue != "" {
 				add(DriftKindAppPermIssue, DriftCritical,
 					fmt.Sprintf("GitHub App is installed but its permissions are insufficient: %s", h.GitHubAppPermIssue))
 			} else {

--- a/v2/pkg/hub/drift_app_creds_test.go
+++ b/v2/pkg/hub/drift_app_creds_test.go
@@ -1,0 +1,111 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestComputeDrift_OperatorSideAppCredsAreNotBlamedOnTheOwner asserts drift
+// reports name the operator when the App key is the problem, and keep the
+// existing owner-facing text otherwise.
+func TestComputeDrift_OperatorSideAppCredsAreNotBlamedOnTheOwner(t *testing.T) {
+	tests := []struct {
+		name      string
+		state     string
+		permIssue string
+		wantKind  string
+		// wantDetailHas / wantDetailLacks assert the copy is accurate.
+		wantDetailHas   []string
+		wantDetailLacks []string
+	}{
+		{
+			name:            "missing key blames the operator",
+			state:           appStateKeyMissingToken,
+			permIssue:       "credentials not provisioned",
+			wantKind:        DriftKindAppCredsOperator,
+			wantDetailHas:   []string{"only an operator can fix", "not been delivered"},
+			wantDetailLacks: []string{"is not installed", "permissions are insufficient"},
+		},
+		{
+			name:            "invalid key blames the operator",
+			state:           appStateKeyInvalidToken,
+			permIssue:       "jwt rejected",
+			wantKind:        DriftKindAppCredsOperator,
+			wantDetailHas:   []string{"only an operator can fix", "does not match the App"},
+			wantDetailLacks: []string{"is not installed"},
+		},
+		{
+			name:          "a genuine permission issue keeps the existing text",
+			state:         "insufficient-permissions",
+			permIssue:     "Issues: read",
+			wantKind:      DriftKindAppPermIssue,
+			wantDetailHas: []string{"permissions are insufficient"},
+		},
+		{
+			name:          "a genuinely uninstalled App still says so",
+			state:         "not-installed",
+			permIssue:     "",
+			wantKind:      DriftKindAppMissing,
+			wantDetailHas: []string{"not installed"},
+		},
+		{
+			name:          "an old spoke reporting no state keeps the old behaviour",
+			state:         "",
+			permIssue:     "",
+			wantKind:      DriftKindAppMissing,
+			wantDetailHas: []string{"not installed"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := MyHiveEntry{Role: "owner"}
+			h.ID = "hive-1"
+			h.Name = "acme/widget"
+			h.GitHubAppRequired = true
+			h.GitHubAppPermIssue = tt.permIssue
+			h.GitHubAppState = tt.state
+			// Claimed (non-placeholder) so the App signals are evaluated.
+			h.Owner = "someone"
+			h.ACMMLevel = 3
+			h.AgentCount = 1
+
+			rep := computeDrift(h, fleetNorm{}, nil, time.Now())
+
+			var found *DriftSignal
+			for i := range rep.Signals {
+				if rep.Signals[i].Kind == tt.wantKind {
+					found = &rep.Signals[i]
+					break
+				}
+			}
+			if found == nil {
+				var kinds []string
+				for _, s := range rep.Signals {
+					kinds = append(kinds, s.Kind)
+				}
+				t.Fatalf("no %q signal; got kinds %v", tt.wantKind, kinds)
+			}
+			for _, want := range tt.wantDetailHas {
+				if !strings.Contains(found.Reason, want) {
+					t.Errorf("detail = %q, want it to contain %q", found.Reason, want)
+				}
+			}
+			for _, lack := range tt.wantDetailLacks {
+				if strings.Contains(found.Reason, lack) {
+					t.Errorf("detail = %q, must NOT contain %q", found.Reason, lack)
+				}
+			}
+			// An operator-side failure must never ALSO be filed as an
+			// owner-facing adoption problem.
+			if tt.wantKind == DriftKindAppCredsOperator {
+				for _, s := range rep.Signals {
+					if s.Kind == DriftKindAppMissing || s.Kind == DriftKindAppPermIssue {
+						t.Errorf("operator-side creds also produced an owner-facing %q signal: %q", s.Kind, s.Reason)
+					}
+				}
+			}
+		})
+	}
+}

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -247,10 +247,17 @@ type HeartbeatPayload struct {
 	// The hub cannot read this itself for firewalled spokes it reaches only by
 	// heartbeat, which is why it rides the payload. Empty when the spoke is
 	// not running in-cluster or the read failed — never a guess.
-	ImageRef                string                        `json:"image_ref,omitempty"`
-	Timestamp               string                        `json:"timestamp"`
-	GitHubAppRequired       bool                          `json:"github_app_required,omitempty"`
-	GitHubAppPermIssue      string                        `json:"github_app_perm_issue,omitempty"`
+	ImageRef           string `json:"image_ref,omitempty"`
+	Timestamp          string `json:"timestamp"`
+	GitHubAppRequired  bool   `json:"github_app_required,omitempty"`
+	GitHubAppPermIssue string `json:"github_app_perm_issue,omitempty"`
+	// GitHubAppState is the spoke's classification of WHY App auth is failing
+	// (a github.AppAuthState token: "key-missing", "key-invalid",
+	// "not-installed", "wrong-installation", "insufficient-permissions").
+	// The hub uses it to avoid nudging — let alone threatening de-provisioning
+	// — a hive whose credentials the OPERATOR has not delivered. Empty from a
+	// spoke too old to report it, which must be read as "cannot tell".
+	GitHubAppState          string                        `json:"github_app_state,omitempty"`
 	AutoUpgrade             bool                          `json:"auto_upgrade,omitempty"`
 	Upgrading               bool                          `json:"upgrading,omitempty"`
 	UpgradeTargetSHA        string                        `json:"upgrade_target_sha,omitempty"`

--- a/v2/pkg/hub/journey.go
+++ b/v2/pkg/hub/journey.go
@@ -302,6 +302,55 @@ func githubAppInstalled(h *RegistryEntry) bool {
 	return true
 }
 
+// githubAppBlockedByOperator reports whether this hive's GitHub App stage is
+// stalled for a reason ONLY the hub operator can fix — the App private key was
+// never delivered to the spoke, or the key it holds belongs to a different App
+// so GitHub rejects every JWT it signs.
+//
+// The owner cannot see, supply, or correct that key. Nudging them to "install
+// the GitHub App" is wrong, and escalating to a de-provision warning would
+// penalise a user for OUR failure. So when this is true the journey system
+// stays silent on stage 1 entirely: the hive is not on the adoption journey,
+// it is waiting on us.
+//
+// It reads the spoke-reported classification. An empty or unrecognised value
+// (a spoke too old to report it) is NOT treated as operator-blocked — that
+// would silence genuine "you have not installed the App" nudges for the whole
+// fleet. Unknown means "fall through to the existing behaviour".
+func githubAppBlockedByOperator(h *RegistryEntry) bool {
+	if h == nil {
+		return false
+	}
+	return appStateIsOperatorSide(h.GitHubAppState)
+}
+
+// appStateIsOperatorSide is the token-level predicate, so callers holding a
+// different entry type (MyHiveEntry in drift.go) share one definition.
+func appStateIsOperatorSide(state string) bool {
+	return operatorSideAppStates[strings.TrimSpace(state)]
+}
+
+// operatorSideAppStates are the github.AppAuthState wire tokens that describe
+// a credential failure only the hub operator can repair. Kept as literal
+// tokens rather than importing pkg/github so the hub does not take a
+// dependency on the spoke's GitHub client; pkg/github's
+// TestAppAuthState_WireRoundTrip locks the token strings on the other side.
+//
+//   - "key-missing" — no App private key reached this spoke at all.
+//   - "key-invalid" — a key is present but GitHub rejects the JWT it signs,
+//     i.e. it belongs to a different App than the hive claims to be.
+var operatorSideAppStates = map[string]bool{
+	appStateKeyMissingToken: true,
+	appStateKeyInvalidToken: true,
+}
+
+const (
+	// appStateKeyMissingToken / appStateKeyInvalidToken mirror
+	// github.AppStateKeyMissing.String() and github.AppStateKeyInvalid.String().
+	appStateKeyMissingToken = "key-missing"
+	appStateKeyInvalidToken = "key-invalid"
+)
+
 // methodModelAssigned reports whether any agent on this hive has a method
 // (backend) or model assigned.
 //
@@ -425,6 +474,14 @@ func nextNudge(h *RegistryEntry, now time.Time) nudge {
 
 	// ── Stage 1: GitHub App ────────────────────────────────────────────────
 	if !githubAppInstalled(h) {
+		// Never nudge — and above all never threaten de-provisioning — when
+		// the block is operator-side. The owner has done everything asked of
+		// them; the missing piece is a private key the hub distributes. Say
+		// nothing here and let the spoke's own banner explain that an admin is
+		// required.
+		if githubAppBlockedByOperator(h) {
+			return nudge{}
+		}
 		n := nudge{Stage: StageGitHubApp, Resend: stage1ResendInterval, StalledFor: age}
 		switch {
 		case age >= stage1WarnAfter:

--- a/v2/pkg/hub/journey_dispatch.go
+++ b/v2/pkg/hub/journey_dispatch.go
@@ -44,6 +44,16 @@ func (s *HubServer) journeyBannerFor(hiveID string, now time.Time) *HubBanner {
 			"hive_id", hiveID)
 		return nil
 	}
+	// Defence in depth for the same rule applied to operator-side failures: a
+	// hive blocked because WE have not delivered its GitHub App key must never
+	// receive a stage-1 nudge, and least of all a de-provision warning. This
+	// duplicates the check in nextNudge deliberately — the cost of a future
+	// edit getting it wrong is threatening a user for our own mistake.
+	if n.Stage == StageGitHubApp && githubAppBlockedByOperator(entry) {
+		s.logger.Error("journey: refusing to nudge a hive whose GitHub App credentials are operator-supplied and not yet valid",
+			"hive_id", hiveID, "app_state", entry.GitHubAppState, "severity", n.Severity.String())
+		return nil
+	}
 
 	s.journey.recordSent(hiveID, n, entry.ACMMLevel, now)
 	if err := s.journey.save(); err != nil {

--- a/v2/pkg/hub/journey_operator_block_test.go
+++ b/v2/pkg/hub/journey_operator_block_test.go
@@ -1,0 +1,143 @@
+package hub
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// appBlocked builds a stage-1-stalled hive that has been stalled long enough to
+// have crossed the de-provision threshold, reporting the given app state token.
+func appBlocked(state string, age time.Duration) *RegistryEntry {
+	return hive(age, func(h *RegistryEntry) {
+		h.GitHubAppRequired = true
+		h.GitHubAppPermIssue = "credentials not valid"
+		h.GitHubAppState = state
+	})
+}
+
+// TestGitHubAppBlockedByOperator locks which wire tokens count as operator-side.
+func TestGitHubAppBlockedByOperator(t *testing.T) {
+	tests := []struct {
+		name  string
+		state string
+		want  bool
+	}{
+		{"missing key is operator-side", "key-missing", true},
+		{"invalid key is operator-side", "key-invalid", true},
+		{"padded token still matches", "  key-invalid  ", true},
+		{"not installed is the user's to fix", "not-installed", false},
+		{"wrong installation is the user's to fix", "wrong-installation", false},
+		{"insufficient permissions is the org owner's to fix", "insufficient-permissions", false},
+		{"ok is not blocked", "ok", false},
+		// An old spoke that never reports the field must NOT be treated as
+		// operator-blocked, or genuine nudges go silent fleet-wide.
+		{"empty (old spoke) falls through", "", false},
+		{"unknown token falls through", "some-future-state", false},
+		{"unknown falls through", "unknown", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &RegistryEntry{GitHubAppState: tt.state}
+			if got := githubAppBlockedByOperator(h); got != tt.want {
+				t.Errorf("githubAppBlockedByOperator(%q) = %v, want %v", tt.state, got, tt.want)
+			}
+		})
+	}
+	if githubAppBlockedByOperator(nil) {
+		t.Error("nil entry must not be reported as operator-blocked")
+	}
+}
+
+// TestNextNudge_OperatorBlockedHiveIsNeverNudged is the core regression: a hive
+// whose App key the operator has not delivered must receive NO stage-1 nudge at
+// any age — least of all a de-provision warning.
+func TestNextNudge_OperatorBlockedHiveIsNeverNudged(t *testing.T) {
+	// Ages spanning gentle, firm and de-provision thresholds, plus far beyond.
+	ages := []time.Duration{
+		stage1GentleAfter, stage1FirmAfter, stage1WarnAfter,
+		stage1WarnAfter * 4,
+	}
+	for _, state := range []string{"key-missing", "key-invalid"} {
+		for _, age := range ages {
+			n := nextNudge(appBlocked(state, age), baseTime)
+			if n.Stage == StageGitHubApp {
+				t.Errorf("state=%s age=%s produced a stage-1 nudge (severity %s): %q",
+					state, age, n.Severity, n.Message)
+			}
+			if n.Severity == SeverityDeprovisionWarning {
+				t.Errorf("state=%s age=%s produced a DE-PROVISION WARNING for an operator-side failure: %q",
+					state, age, n.Message)
+			}
+			if strings.Contains(strings.ToLower(n.Message), "de-provision") {
+				t.Errorf("state=%s age=%s message threatens de-provisioning: %q", state, age, n.Message)
+			}
+		}
+	}
+}
+
+// TestNextNudge_UserBlockedHiveStillEscalates is the counterpart guard: the fix
+// must not weaken genuine warnings. A hive that truly has not installed the App
+// must still be told to, and must still escalate.
+func TestNextNudge_UserBlockedHiveStillEscalates(t *testing.T) {
+	tests := []struct {
+		name  string
+		state string
+	}{
+		// An old spoke that reports no state at all keeps the old behaviour.
+		{"unreported state", ""},
+		{"explicitly not installed", "not-installed"},
+		{"wrong installation id", "wrong-installation"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := nextNudge(appBlocked(tt.state, stage1WarnAfter), baseTime)
+			if n.Stage != StageGitHubApp {
+				t.Fatalf("Stage = %v, want the GitHub App stage to still fire", n.Stage)
+			}
+			if n.Severity != SeverityDeprovisionWarning {
+				t.Errorf("Severity = %v, want the de-provision warning to still escalate", n.Severity)
+			}
+			if n.Message == "" {
+				t.Error("a genuine stage-1 stall must still produce a message")
+			}
+		})
+	}
+}
+
+// TestNextNudge_OperatorBlockStillAllowsLaterStages proves the guard is scoped
+// to stage 1 only: it suppresses the GitHub App nudge, not the whole journey.
+func TestNextNudge_OperatorBlockedDoesNotSuppressOtherStages(t *testing.T) {
+	// A hive that is NOT stage-1 stalled but reports an operator-side token
+	// (e.g. a stale field) must still be evaluated for stages 2 and 3.
+	h := hive(stage2WarnAfter, func(e *RegistryEntry) {
+		e.GitHubAppState = "key-missing"
+		// Stage 1 satisfied — no perm issue recorded.
+		e.GitHubAppRequired = false
+		e.GitHubAppPermIssue = ""
+		// Stage 2 unsatisfied.
+		e.AgentsWithModel = intPtr(0)
+	})
+	n := nextNudge(h, baseTime)
+	if n.Stage != StageMethodModel {
+		t.Errorf("Stage = %v, want stage 2 to still be evaluated for an operator-blocked token", n.Stage)
+	}
+}
+
+// TestOperatorSideAppStateTokensMatchSpoke locks the duplicated wire tokens.
+// pkg/hub deliberately does not import pkg/github, so these literals must stay
+// in sync with github.AppAuthState.String() by test, not by compiler.
+func TestOperatorSideAppStateTokensMatchSpoke(t *testing.T) {
+	// These are exactly the tokens github.AppStateKeyMissing.String() and
+	// github.AppStateKeyInvalid.String() produce; pkg/github's
+	// TestAppAuthState_WireRoundTrip locks the other side.
+	want := map[string]bool{"key-missing": true, "key-invalid": true}
+	if len(operatorSideAppStates) != len(want) {
+		t.Fatalf("operatorSideAppStates = %v, want exactly %v", operatorSideAppStates, want)
+	}
+	for token := range want {
+		if !operatorSideAppStates[token] {
+			t.Errorf("operatorSideAppStates is missing the %q token", token)
+		}
+	}
+}

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -6462,6 +6462,23 @@ const dashboardHTML = `<!DOCTYPE html>
       var tips = {1:'L1 Assisted — Advisory only.',2:'L2 Instructed — Advisory beads, no GitHub writes.',3:'L3 Measured — Hold-gated PRs, CI gates.',4:'L4 Adaptive — Agents open issues, sec-check.',5:'L5 Semi-Automated — PRs with hold label, batch review.',6:'L6 Autonomous — Auto-merge on green CI.'};
       return '<span class="acmm-badge acmm-' + l + '" title="' + esc(tips[l] || '') + '">' + (ACMM_LABELS[l] || 'L' + l) + '</span>';
     }
+    /* Classified GitHub App auth states, matching github.AppAuthState.String()
+       on the spoke and operatorSideAppStates in journey.go. The two OPERATOR
+       states describe a failure the hive OWNER cannot fix: the App private key
+       is distributed by the hub, so a missing or mismatched key is our problem,
+       not theirs. The UI must never present these as something the user should
+       install or reconfigure. */
+    var GH_APP_STATE_KEY_MISSING = 'key-missing';
+    var GH_APP_STATE_KEY_INVALID = 'key-invalid';
+    var GH_APP_OPERATOR_STATES = {};
+    GH_APP_OPERATOR_STATES[GH_APP_STATE_KEY_MISSING] = true;
+    GH_APP_OPERATOR_STATES[GH_APP_STATE_KEY_INVALID] = true;
+    /* An unreported or unrecognised state is deliberately NOT operator-side:
+       a spoke too old to classify keeps the existing behaviour. */
+    function ghAppIsOperatorSide(state) {
+      return GH_APP_OPERATOR_STATES[String(state || '').trim()] === true;
+    }
+
     /* Labels for each journey stage, matching JourneyStage.String() on the hub. */
     var JOURNEY_STAGE_LABELS = {
       'none': 'On track',
@@ -6910,7 +6927,17 @@ const dashboardHTML = `<!DOCTYPE html>
         if (ck.detail) line += ': ' + ck.detail;
         lines.push(line);
       }
-      if (h.githubAppRequired && h.githubAppPermIssue) { lines.push('✓ GitHub App installed'); lines.push('⚠ GitHub App: permissions insufficient'); st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel; }
+      if (h.githubAppRequired && ghAppIsOperatorSide(h.githubAppState)) {
+        /* Operator-side: the key we distribute has not landed, or is for the
+           wrong App. Still degraded — the hive genuinely cannot work — but the
+           hover must name the real cause so an admin does not chase the user
+           about an installation that is already correct. */
+        lines.push(h.githubAppState === GH_APP_STATE_KEY_INVALID
+          ? '⚠ GitHub App: key does not match the App (operator must push the correct key)'
+          : '⚠ GitHub App: credentials not yet delivered by the hub (operator action)');
+        st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel;
+      }
+      else if (h.githubAppRequired && h.githubAppPermIssue) { lines.push('✓ GitHub App installed'); lines.push('⚠ GitHub App: permissions insufficient'); st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel; }
       else if (h.githubAppRequired) { lines.push('✕ GitHub App not installed'); st = 'degraded'; c = colors.degraded; ic = icons.degraded; statusLabel = 'Degraded'; lines[0] = statusLabel; }
       else if (!h.githubAppRequired) { lines.push('✓ GitHub App installed'); }
       if (!checks.length) lines.push('No check data');
@@ -7026,6 +7053,7 @@ const dashboardHTML = `<!DOCTYPE html>
       'heartbeat-stale': 'Heartbeat stale',
       'app-missing':     'GitHub App not installed',
       'app-perm-issue':  'GitHub App permissions',
+      'app-creds-operator': 'GitHub App key (operator)',
       'health-degraded': 'Health degraded',
       'upgrade-stuck':   'Upgrade stuck',
       'acmm-unset':      'ACMM level unset',

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -111,6 +111,7 @@ type RegistryEntry struct {
 	PRHistory                 []SparkPoint       `json:"prHistory,omitempty"`
 	GitHubAppRequired         bool               `json:"githubAppRequired,omitempty"`
 	GitHubAppPermIssue        string             `json:"githubAppPermIssue,omitempty"`
+	GitHubAppState            string             `json:"githubAppState,omitempty"`
 	PendingGitHubAppInstall   bool               `json:"pendingGitHubAppInstall,omitempty"`
 	PendingGitHubAppInstallAt time.Time          `json:"pendingGitHubAppInstallAt,omitempty"`
 	// Fleet contribution counts reported by the spoke (nil = not reported /
@@ -744,6 +745,7 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		Online:                  true,
 		GitHubAppRequired:       payload.GitHubAppRequired,
 		GitHubAppPermIssue:      sanitizeHeartbeatField(payload.GitHubAppPermIssue),
+		GitHubAppState:          sanitizeHeartbeatField(payload.GitHubAppState),
 		PendingGitHubAppInstall: payload.PendingGitHubAppInstall,
 		PendingGitHubAppInstallAt: func() time.Time {
 			if payload.PendingGitHubAppInstall {


### PR DESCRIPTION
## The problem

A user (`taylormgeorge91`, hive `hosted-available-vllmd-01`, org `katamari` on GitHub Enterprise) did everything asked of him: installed the GitHub App on his org, supplied the correct `installation_id: 42980`. His dashboard still told him to install the App and check `github.installation_id`.

The actual fault was on our side — his spoke holds the **public github.com** App key (`d5bead6a48…`) instead of the GHE key for `app_id: 5686` (`a394401d83…`), and `/data/gh-app-key.pem` does not exist, so the hub's key push never landed:

```
401 A JSON web token could not be decoded
  POST https://github.ibm.com/api/v3/app/installations/42980/access_tokens
```

That key is distributed by the **operator** via the hub (`/data/saas/app-keys/<clusterID>.pem`, #2185). A user cannot see, supply, or fix it. Sending them to re-install the App is misdirection.

## Root cause

The failure was classified by substring-matching the *formatted error string*:

```go
} else if strings.Contains(err.Error(), "403") || strings.Contains(err.Error(), "401") {
    githubAppRequired = true   // → renders "GitHub App Not Installed"
```

That cannot tell a signing failure from a missing installation, so every cause collapsed into one message.

## How state 3 is now distinguished from state 2

Classification is on the **actual HTTP status of the App API response** (`classifyAPIError`), never a string:

| Response | State | Whose problem | Reasoning |
|---|---|---|---|
| **401** | `key-invalid` | **Operator** | On App endpoints the only credential is the App JWT. A 401 means the signature did not verify against the App's registered public key — the private key is wrong. |
| **404** | `not-installed` | User | JWT verified (GitHub knows which App we are); no such installation exists. |
| **403** | `wrong-installation` | User | JWT verified and the installation exists, but this App may not act on it. Rate limits excluded as transient. |
| 200, account ≠ target | `wrong-installation` | User | Existing message retained verbatim. |
| 200, `issues != write` | `insufficient-permissions` | Org owner | |
| no status (transport) | `unknown` | Nobody | Never guess, never accuse. |

The key discriminator: **a wrong `installation_id` authenticates fine** — the JWT decodes and the failure comes later on the installation. A wrong *key* fails at signature verification, before any installation is consulted.

Additionally, a **missing key file is detected before any API call** (`keyFileReadable` over `/data/gh-app-key.pem` and `/secrets/gh-app-key.pem`) — the clearest signal of the operator-side state, at zero round-trip cost. A test asserts no HTTP request is made on that path.

## Warning sites and what each now shows

| Site | Operator-side (`key-missing` / `key-invalid`) | User-side |
|---|---|---|
| Spoke banner (`static/index.html`) | "GitHub App credentials pending — no action needed from you" + cause + contact admin. Neutral styling, **install link removed**, no config advice. | Unchanged: install prompt / `installation_id` / permissions copy. |
| Spoke welcome checklist | `auto` returns `null` ("cannot tell") — not marked as an unfinished user step; install button refuses and explains. | Unchanged. |
| Hub My Hives hover (`saas.go`) | "GitHub App: key does not match the App (operator must push the correct key)" / "credentials not yet delivered by the hub (operator action)". Still Degraded — the hive genuinely cannot work. | Unchanged. |
| Hub drift (`drift.go`) | New `app-creds-operator` kind: "only an operator can fix it… the hive owner cannot supply or correct this key". | Unchanged `app-missing` / `app-perm-issue`. |
| Logs | Structured `state` + `operator_actionable` at startup, recheck, advisory-digest. | Same. |

## Journey nudges — yes, they threatened de-provisioning

`nextNudge` escalated `StageGitHubApp` to `SeverityDeprovisionWarning`:

> "Spokes left in this state are candidates for de-provisioning by an administrator."

`githubAppInstalled()` returns false when `GitHubAppRequired && GitHubAppPermIssue != ""` — and the old diagnosis set that string for a key failure, so this user's hive **was** on the de-provision ladder for our mistake.

Fixed in two places: `nextNudge` returns an empty nudge for operator-side states, plus a defence-in-depth guard in `journey_dispatch.go` mirroring the existing ACMM one. Tested at every threshold (`gentle`, `firm`, `warn`, and 4×`warn`).

## Not weakening genuine warnings

A hive that truly has not installed the App still gets nudged and **still escalates to the de-provision warning** — asserted by `TestNextNudge_UserBlockedHiveStillEscalates`. An unreported or unrecognised state (an older spoke) deliberately falls through to existing behaviour rather than silencing nudges fleet-wide.

## Notes

- Org names render via `textContent` (spoke) and `esc()`-consistent paths (hub); all iteration nil-guarded; `String(x || '').trim()` on every state read.
- No magic values: states are named constants with comments on both sides. `pkg/hub` does not import `pkg/github`, so the two wire tokens are duplicated deliberately and locked in sync by tests on both sides.
- Backward compatible: `github_app_state` is `omitempty`; an empty value means "cannot tell".

## Verification

- `go build ./...` ✅ · `go vet ./...` ✅ · `gofmt` clean on every file touched
- `pkg/github`, `pkg/dashboard`, `pkg/config` full suites ✅
- `pkg/hub`: 2 failures (`TestFailingCheckSummaryEscapes/filter_chip_label_escaped`, `TestFilterComposition/clear_button_accounts_for_check_filter`) — **verified pre-existing on a clean `origin/v2`**; failure count is 2 before and 2 after.
- Brace-balance tests (#2177) pass. Script bodies extracted from both dashboards, `node --check` clean, and the extractions grepped to prove the new code is present (not a stale artifact).
- No literal `<body>` added to `index.html`; no backticks added to `dashboardHTML`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)