### PR TITLE
🐛 fix(spoke): never hard-exit on a placeholder or unusable GitHub App

### DIFF
--- a/v2/cmd/hive/githubauth_test.go
+++ b/v2/cmd/hive/githubauth_test.go
@@ -1,0 +1,331 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+	"github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// quietLogger discards output: these tests assert on returned state, not on log
+// lines, and a hive booting degraded is expected to log loudly.
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// realAppID stands in for a genuine GitHub App ID. Any non-zero value that is
+// not config.PlaceholderAppID qualifies; this one is the App the production
+// fleet actually uses, so a reader can tell it apart from the sentinel at a
+// glance.
+const realAppID int64 = 3568013
+
+// realInstallationID is the installation_id observed on the hive that hit this
+// bug in production. Its only property that matters is being non-zero — that is
+// what flipped the old `AppID != 0 && InstallationID != 0` guard to true.
+const realInstallationID int64 = 149757667
+
+// isolateAppKeyLookup points both on-disk key fallbacks at an empty temp dir and
+// clears $GH_APP_KEY_FILE, so a test that means "no key anywhere" cannot
+// accidentally pick up a real key from /data or /secrets on a dev machine.
+func isolateAppKeyLookup(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	origData, origSecrets := spokeAppKeyPath, spokeProvisionedAppKeyPath
+	spokeAppKeyPath = filepath.Join(dir, "absent-data-key.pem")
+	spokeProvisionedAppKeyPath = filepath.Join(dir, "absent-secrets-key.pem")
+	t.Setenv("GH_APP_KEY_FILE", "")
+	t.Cleanup(func() {
+		spokeAppKeyPath, spokeProvisionedAppKeyPath = origData, origSecrets
+	})
+	return dir
+}
+
+// TestInitGitHubAuthPlaceholderAppIDBoots is the regression test that matters
+// most: it is the exact production failure, reproduced from config alone.
+//
+// A hosted hive was provisioned with the placeholder app_id 999999999 and no
+// GitHub App key. When its owner installed the App, the hub delivered a real
+// installation_id — and the hive's config became {placeholder app_id, real
+// installation_id, key_file pointing at a Secret mount with no PEM in it}.
+//
+// The old guard was `AppID != 0 && InstallationID != 0`. 999999999 is non-zero,
+// so that read as "App auth is configured", NewAppAuth failed to read the
+// absent PEM, and main() called os.Exit(1) — before the HTTP listener bound.
+// The pod crashlooped permanently (89 restarts on one, 24 on its replacement),
+// never heartbeated, showed offline on the hub, and wedged the rollout because
+// the new pod could never go Ready.
+//
+// Booting is the assertion. Nine more hives were carrying this exact config.
+func TestInitGitHubAuthPlaceholderAppIDBoots(t *testing.T) {
+	dir := isolateAppKeyLookup(t)
+
+	cfg := &config.Config{}
+	cfg.Project.Org = "jeejz"
+	cfg.GitHub.AppID = config.PlaceholderAppID
+	cfg.GitHub.InstallationID = realInstallationID
+	// A Secret mount that exists but holds no PEM — the state that made
+	// NewAppAuth fail. Pointing at a path inside the temp dir keeps the test
+	// hermetic.
+	cfg.GitHub.KeyFile = filepath.Join(dir, "gh-app-key.pem")
+
+	got := initGitHubAuth(context.Background(), cfg, quietLogger())
+
+	// The whole point: the placeholder must never be mistaken for a real App.
+	if got.AppAuth != nil {
+		t.Fatal("initialized GitHub App auth from the placeholder app_id; " +
+			"this is the crashloop bug — HasUsableApp() must reject the sentinel")
+	}
+	if got.Client != nil {
+		t.Error("built a GitHub client with no credentials; agents would act unauthenticated")
+	}
+	if got.Failure == "" {
+		t.Fatal("no failure reason recorded; the dashboard banner would show nothing " +
+			"and the owner could not tell why agents are idle")
+	}
+	if !strings.Contains(got.Failure, "placeholder") {
+		t.Errorf("failure reason does not identify the placeholder as the cause: %q", got.Failure)
+	}
+	// A placeholder hive genuinely has no App installed, and installing one is
+	// what the owner must do — so this must classify as user-actionable, not as
+	// an operator-side key fault.
+	if got.State != github.AppStateNotInstalled {
+		t.Errorf("State = %v, want AppStateNotInstalled", got.State)
+	}
+	if !got.State.UserActionable() {
+		t.Error("a placeholder hive's owner can fix this by installing the App; " +
+			"the state must be user-actionable or the banner will not tell them to")
+	}
+}
+
+// TestInitGitHubAuthPlaceholderWithoutInstallation covers the nine hives that
+// were armed but had not detonated yet: placeholder app_id, installation_id
+// still zero. This booted before the fix too, so the test guards against a
+// regression in the other direction — the degraded path must stay non-fatal and
+// must still explain itself.
+func TestInitGitHubAuthPlaceholderWithoutInstallation(t *testing.T) {
+	isolateAppKeyLookup(t)
+
+	cfg := &config.Config{}
+	cfg.Project.Org = "available-pool"
+	cfg.GitHub.AppID = config.PlaceholderAppID
+
+	got := initGitHubAuth(context.Background(), cfg, quietLogger())
+
+	if got.AppAuth != nil || got.Client != nil {
+		t.Fatal("a placeholder with no installation must yield no GitHub credentials")
+	}
+	if !strings.Contains(got.Failure, "placeholder") {
+		t.Errorf("failure reason = %q, want it to name the placeholder", got.Failure)
+	}
+}
+
+// TestInitGitHubAuthRealAppMissingKeyDegrades covers requirement 3: a hive whose
+// App is genuinely configured but whose private key is absent must NOT exit. It
+// must boot, and the message must be actionable enough to fix without reading
+// the source — the old "reading app key /secrets/gh-app-key.pem: no such file"
+// never revealed that four paths are consulted in a fixed order, so operators
+// routinely put the key in the wrong one.
+func TestInitGitHubAuthRealAppMissingKeyDegrades(t *testing.T) {
+	dir := isolateAppKeyLookup(t)
+	missing := filepath.Join(dir, "never-provisioned.pem")
+
+	cfg := &config.Config{}
+	cfg.Project.Org = "kubestellar"
+	cfg.GitHub.AppID = realAppID
+	cfg.GitHub.InstallationID = realInstallationID
+	cfg.GitHub.KeyFile = missing
+
+	got := initGitHubAuth(context.Background(), cfg, quietLogger())
+
+	if got.AppAuth != nil {
+		t.Fatal("App auth initialized without a readable private key")
+	}
+	if got.Client != nil {
+		t.Error("built a GitHub client despite unusable App credentials")
+	}
+	if got.Failure == "" {
+		t.Fatal("a real App with an unreadable key must record a diagnosable failure, not exit")
+	}
+	// The exact path tried, so the operator does not have to guess which of the
+	// four candidates won.
+	if !strings.Contains(got.Failure, missing) {
+		t.Errorf("failure reason omits the path actually tried (%q): %q", missing, got.Failure)
+	}
+	// The resolution order, named explicitly.
+	for _, want := range []string{"GH_APP_KEY_FILE", "github.key_file", spokeAppKeyPath, spokeProvisionedAppKeyPath} {
+		if !strings.Contains(got.Failure, want) {
+			t.Errorf("failure reason omits %q from the resolution order: %q", want, got.Failure)
+		}
+	}
+	// An absent key is the hub's failure to deliver, never the owner's. Telling
+	// them to "install the GitHub App" sends them to redo work they already did
+	// — and the journey nudges can escalate to threatening de-provisioning over
+	// it. That is exactly what OperatorActionable() guards against.
+	if got.State != github.AppStateKeyMissing {
+		t.Errorf("State = %v, want AppStateKeyMissing", got.State)
+	}
+	if !got.State.OperatorActionable() {
+		t.Error("a missing key is operator-actionable; classifying it otherwise blames the user " +
+			"for a credential the hub never delivered")
+	}
+}
+
+// TestInitGitHubAuthRealAppMalformedKeyIsKeyInvalid separates "no key" from "a
+// key that is not parseable". Both are operator-actionable, but the hub needs
+// the distinction to tell "never pushed" from "pushed something broken" — the
+// classic symptom being a public github.com key on a GitHub Enterprise hive.
+func TestInitGitHubAuthRealAppMalformedKeyIsKeyInvalid(t *testing.T) {
+	dir := isolateAppKeyLookup(t)
+	garbage := filepath.Join(dir, "not-a-pem.pem")
+	if err := os.WriteFile(garbage, []byte("this is not a PEM block"), 0o600); err != nil {
+		t.Fatalf("write garbage key: %v", err)
+	}
+
+	cfg := &config.Config{}
+	cfg.Project.Org = "kubestellar"
+	cfg.GitHub.AppID = realAppID
+	cfg.GitHub.InstallationID = realInstallationID
+	cfg.GitHub.KeyFile = garbage
+
+	got := initGitHubAuth(context.Background(), cfg, quietLogger())
+
+	if got.AppAuth != nil {
+		t.Fatal("App auth initialized from a file that is not a PEM key")
+	}
+	if got.State != github.AppStateKeyInvalid {
+		t.Errorf("State = %v, want AppStateKeyInvalid — a present-but-unparseable key is "+
+			"a different operator fault than a missing one", got.State)
+	}
+	if !got.State.OperatorActionable() {
+		t.Error("a broken key is operator-actionable, not the owner's to fix")
+	}
+}
+
+// TestInitGitHubAuthRealAppValidKey is the positive control: with a real app_id,
+// a real installation_id and a readable PEM, App auth must still initialize
+// normally. Without this, "never initialize App auth" would pass every other
+// test in this file.
+func TestInitGitHubAuthRealAppValidKey(t *testing.T) {
+	dir := isolateAppKeyLookup(t)
+	keyPath := filepath.Join(dir, "gh-app-key.pem")
+	writeTestKey(t, keyPath)
+
+	cfg := &config.Config{}
+	// Org is deliberately empty: healGitHubAppInstallation returns immediately
+	// on an empty org, so this test makes no network call.
+	cfg.GitHub.AppID = realAppID
+	cfg.GitHub.InstallationID = realInstallationID
+	cfg.GitHub.KeyFile = keyPath
+
+	got := initGitHubAuth(context.Background(), cfg, quietLogger())
+
+	if got.AppAuth == nil {
+		t.Fatal("App auth did not initialize with a real app_id and a valid key; " +
+			"the placeholder guard has over-rejected")
+	}
+	if got.Client == nil {
+		t.Error("no GitHub client built despite working App auth")
+	}
+	if got.Failure != "" {
+		t.Errorf("healthy App auth recorded a failure: %q", got.Failure)
+	}
+}
+
+// TestInitGitHubAuthTokenStillWorks guards the token-authenticated hives, which
+// share this code path and must be unaffected by the App changes.
+func TestInitGitHubAuthTokenStillWorks(t *testing.T) {
+	isolateAppKeyLookup(t)
+	t.Setenv("HIVE_GITHUB_TOKEN", "")
+
+	cfg := &config.Config{}
+	cfg.Project.Org = "kubestellar"
+	cfg.GitHub.Token = "ghp_exampletoken"
+
+	got := initGitHubAuth(context.Background(), cfg, quietLogger())
+
+	if got.Client == nil {
+		t.Fatal("token-authenticated hive got no GitHub client")
+	}
+	if got.AppAuth != nil {
+		t.Error("token auth must not produce App auth")
+	}
+	if got.Failure != "" {
+		t.Errorf("token auth recorded a failure: %q", got.Failure)
+	}
+}
+
+// TestInitGitHubAuthPlaceholderWithTokenPrefersToken covers a placeholder hive
+// that also carries a token: the token is real credentials and must win, rather
+// than the hive being parked in dashboard-only mode over a sentinel app_id.
+func TestInitGitHubAuthPlaceholderWithTokenPrefersToken(t *testing.T) {
+	isolateAppKeyLookup(t)
+	t.Setenv("HIVE_GITHUB_TOKEN", "")
+
+	cfg := &config.Config{}
+	cfg.Project.Org = "kubestellar"
+	cfg.GitHub.AppID = config.PlaceholderAppID
+	cfg.GitHub.Token = "ghp_exampletoken"
+
+	got := initGitHubAuth(context.Background(), cfg, quietLogger())
+
+	if got.Client == nil {
+		t.Fatal("a placeholder app_id suppressed a perfectly good token")
+	}
+	if got.Failure != "" {
+		t.Errorf("working token credentials recorded a failure: %q", got.Failure)
+	}
+}
+
+// TestInitGitHubAuthNoCredentialsDoesNotExit covers the last degraded shape.
+// config.validate() rejects this at load, so it is only reachable if the config
+// was mutated afterwards — but "unreachable" is exactly what the placeholder
+// path was assumed to be, and it still has to not kill the process.
+func TestInitGitHubAuthNoCredentialsDoesNotExit(t *testing.T) {
+	isolateAppKeyLookup(t)
+	t.Setenv("HIVE_GITHUB_TOKEN", "")
+
+	cfg := &config.Config{}
+	cfg.Project.Org = "kubestellar"
+
+	got := initGitHubAuth(context.Background(), cfg, quietLogger())
+
+	if got.Client != nil || got.AppAuth != nil {
+		t.Fatal("credentials materialized from an empty config")
+	}
+	if got.Failure == "" {
+		t.Error("no failure reason recorded for a hive with no credentials at all")
+	}
+}
+
+// TestDescribeAppKeyFailureNamesEnvOverride checks that an operator who set
+// $GH_APP_KEY_FILE sees that value echoed back, so a typo in the env var is
+// visible in the message rather than having to be inferred from the resolved
+// path.
+func TestDescribeAppKeyFailureNamesEnvOverride(t *testing.T) {
+	msg := describeAppKeyFailure("/secrets/gh-app-key.pem", "/tmp/typo.pem", "/tmp/typo.pem", os.ErrNotExist)
+
+	if !strings.Contains(msg, "/tmp/typo.pem") {
+		t.Errorf("message omits the env override value: %q", msg)
+	}
+	if !strings.Contains(msg, "/secrets/gh-app-key.pem") {
+		t.Errorf("message omits the configured key_file, so its precedence is unclear: %q", msg)
+	}
+	// With both sources set, nothing is "(unset)".
+	if strings.Contains(msg, "(unset)") {
+		t.Errorf("both key sources were set, so none should render as unset: %q", msg)
+	}
+
+	// With neither set, the message must say so rather than printing a bare
+	// "=" and leaving the operator to guess whether the value was empty or the
+	// message was truncated.
+	bare := describeAppKeyFailure("", "", spokeProvisionedAppKeyPath, os.ErrNotExist)
+	if strings.Count(bare, "(unset)") != 2 {
+		t.Errorf("both unset sources should render as (unset): %q", bare)
+	}
+}

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -158,6 +160,39 @@ func resolveAppKeyFile(configured, envOverride string) string {
 	return spokeProvisionedAppKeyPath
 }
 
+// describeAppKeyFailure turns a bare wrapped os error from github.NewAppAuth
+// into a message an operator can act on without reading the source: it names
+// the path actually tried, the full resolution order that produced it, and the
+// underlying cause.
+//
+// The generic "reading app key /secrets/gh-app-key.pem: no such file" that this
+// replaces gave no hint that key_file, $GH_APP_KEY_FILE, the PVC path and the
+// provisioning mount are all consulted in a fixed order — so the usual response
+// was to put the key in the wrong one of the four.
+func describeAppKeyFailure(configured, envOverride, resolved string, err error) string {
+	order := []string{
+		fmt.Sprintf("$GH_APP_KEY_FILE=%s", describeKeySource(envOverride)),
+		fmt.Sprintf("github.key_file=%s", describeKeySource(configured)),
+		fmt.Sprintf("PVC fallback %s", spokeAppKeyPath),
+		fmt.Sprintf("provisioning mount %s", spokeProvisionedAppKeyPath),
+	}
+	return fmt.Sprintf(
+		"GitHub App private key could not be loaded from %q: %v. "+
+			"Resolution order (first non-empty wins): %s. "+
+			"Write a PEM-encoded RSA private key to that path, or point github.key_file at one.",
+		resolved, err, strings.Join(order, " → "),
+	)
+}
+
+// describeKeySource renders an unset key-file source as "(unset)" so the
+// resolution order in describeAppKeyFailure reads unambiguously.
+func describeKeySource(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return "(unset)"
+	}
+	return v
+}
+
 // processStartedAt is when this hive process began. Reported over the heartbeat
 // so the hub can show an uptime pill — a hive that is 1/1 Running but restarting
 // every couple of minutes looks healthy in a pod listing and in My Hives, and a
@@ -248,14 +283,52 @@ func main() {
 
 	var ghClient *github.Client
 	var appAuth *github.AppAuth
-	if cfg.GitHub.AppID != 0 && cfg.GitHub.InstallationID != 0 {
-		keyFile := resolveAppKeyFile(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"))
+	// appAuthFailure, when non-empty, is the operator-facing reason App auth
+	// could not be initialized. It is surfaced through the existing
+	// GitHubAppRequired/PermIssue banner rather than killing the process — see
+	// the degraded-boot rationale below.
+	var appAuthFailure string
+	// appAuthState classifies appAuthFailure so the banner and the hub's
+	// journey nudges can tell an operator-side fault (no key was ever
+	// delivered) from a user-actionable one (the App is not installed).
+	appAuthState := github.AppStateUnknown
+	appKeyFile := resolveAppKeyFile(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"))
+	// HasUsableApp() rejects config.PlaceholderAppID. A placeholder paired with
+	// a real installation_id (which is what happens the instant an owner
+	// installs the App on a pre-provisioned hive) used to satisfy a bare
+	// `AppID != 0` test, commit the process to App auth, fail to read a PEM
+	// that was never provisioned, and os.Exit(1) BEFORE the listener bound —
+	// permanent CrashLoopBackOff with nothing visible in the dashboard.
+	if cfg.GitHub.HasUsableApp() {
 		var err error
-		appAuth, err = github.NewAppAuth(cfg.GitHub.AppID, cfg.GitHub.InstallationID, keyFile, logger, cfg.GitHub.ResolvedAPIURL())
+		appAuth, err = github.NewAppAuth(cfg.GitHub.AppID, cfg.GitHub.InstallationID, appKeyFile, logger, cfg.GitHub.ResolvedAPIURL())
 		if err != nil {
-			logger.Error("failed to init GitHub App auth", "error", err)
-			os.Exit(1)
+			// A genuinely-configured App whose key is missing or malformed is a
+			// real, actionable fault — but NOT a reason to refuse to boot. The
+			// dashboard is the only place an owner can see and fix it, so the
+			// hive comes up degraded (no ghClient, no agent work) and reports
+			// the fault through the banner the UI already renders.
+			appAuthFailure = describeAppKeyFailure(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), appKeyFile, err)
+			// Both states are operator-actionable: the hive's owner cannot
+			// deliver a key. Absent vs. unparseable is the distinction the hub
+			// needs to tell "never pushed" from "pushed something broken".
+			appAuthState = github.AppStateKeyInvalid
+			if errors.Is(err, fs.ErrNotExist) {
+				appAuthState = github.AppStateKeyMissing
+			}
+			logger.Error("GitHub App auth unavailable — starting in dashboard-only mode",
+				"app_id", cfg.GitHub.AppID,
+				"installation_id", cfg.GitHub.InstallationID,
+				"key_file", appKeyFile,
+				"state", appAuthState.String(),
+				"detail", appAuthFailure,
+				"error", err,
+			)
+			appAuth = nil
 		}
+	}
+	switch {
+	case appAuth != nil:
 		logger.Info("using GitHub App authentication", "app_id", cfg.GitHub.AppID)
 		// Correct a stale/wrong installation_id BEFORE building the client, so
 		// the very first token this process mints is scoped to the right org
@@ -266,7 +339,7 @@ func main() {
 		if cfg.GitHub.DocsInstallationID != 0 {
 			docsAuth, err := github.NewAppAuthWithCache(
 				cfg.GitHub.AppID, cfg.GitHub.DocsInstallationID,
-				keyFile, github.DocsTokenCachePath, logger, cfg.GitHub.ResolvedAPIURL(),
+				appKeyFile, github.DocsTokenCachePath, logger, cfg.GitHub.ResolvedAPIURL(),
 			)
 			if err != nil {
 				logger.Warn("failed to init docs org token", "error", err)
@@ -293,20 +366,40 @@ func main() {
 				}()
 			}
 		}
-	} else {
+	default:
 		ghToken := cfg.GitHub.Token
 		if ghToken == "" {
 			ghToken = os.Getenv("HIVE_GITHUB_TOKEN")
 		}
-		if ghToken == "" && cfg.GitHub.AppID != 0 {
+		switch {
+		case ghToken != "":
+			ghClient = github.NewClient(ghToken, cfg.Project.Org, cfg.Project.Repos, logger, cfg.GitHub.ResolvedAPIURL())
+		case appAuthFailure != "":
+			// Real App, unusable key. Already logged above; leave ghClient nil
+			// so nothing tries to act on GitHub with no credentials.
+		case cfg.GitHub.IsPlaceholderApp():
+			// User-actionable: this hive was provisioned ahead of its App, and
+			// installing the App is exactly what resolves it.
+			appAuthFailure = "This hive carries a placeholder github.app_id and is not yet linked to a GitHub App. Install the GitHub App on your org to enable agents."
+			appAuthState = github.AppStateNotInstalled
+			logger.Warn("placeholder github.app_id — hive starting in dashboard-only mode",
+				"placeholder_app_id", config.PlaceholderAppID,
+				"installation_id", cfg.GitHub.InstallationID,
+			)
+		case cfg.GitHub.AppID != 0:
+			appAuthFailure = "The GitHub App is configured but has no installation. Install the app on your org to enable agents."
+			appAuthState = github.AppStateNotInstalled
 			logger.Warn("GitHub App configured without credentials — hive starting in dashboard-only mode. Install the app and provide installation_id + key to enable agents.")
-		} else if ghToken == "" {
-			logger.Error("no GitHub token configured (set github.token or github.app_id in config)")
-			os.Exit(1)
+		default:
+			// Neither a token nor any app_id at all. config.validate() should
+			// already have rejected this, so it means the config was mutated
+			// after load. Still a degraded boot rather than an exit: the
+			// dashboard is where an operator fixes it.
+			appAuthFailure = "No GitHub credentials configured. Set github.token, or github.app_id plus an App installation."
+			logger.Error("no GitHub token configured (set github.token or github.app_id in config) — starting in dashboard-only mode")
 		}
-		ghClient = github.NewClient(ghToken, cfg.Project.Org, cfg.Project.Repos, logger, cfg.GitHub.ResolvedAPIURL())
 	}
-	if len(cfg.Governor.Labels.Exempt) > 0 {
+	if ghClient != nil && len(cfg.Governor.Labels.Exempt) > 0 {
 		ghClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 	}
 	// Load user token for advisory posting (comments on issues as the logged-in user)
@@ -437,17 +530,20 @@ func main() {
 	notifier := notify.New(cfg.Notifications, logger)
 	notifier.SetHiveID(cfg.HiveID)
 	acmmLevel := inferACMMLevel(cfg)
-	githubAppRequired := false
+	// A hive that booted without usable GitHub credentials raises the banner
+	// immediately, seeded with the classification made at startup. Otherwise
+	// these stay empty and are filled in later by the live probes below.
+	githubAppRequired := appAuthFailure != ""
 	// githubAppDiag/githubAppState carry the classified reason App auth failed,
 	// so the banner can name the true cause (and the hub can avoid escalating
 	// against a hive whose credentials the operator never delivered).
-	githubAppDiag := ""
-	githubAppState := github.AppStateUnknown
+	githubAppDiag := appAuthFailure
+	githubAppState := appAuthState
 
 	// Find or create the pinned advisory issue. Any level can have advisory
 	// agents whose findings should be posted to this issue.
 	advisoryIssues := map[string]int{}
-	if acmmLevel > 0 {
+	if acmmLevel > 0 && ghClient != nil {
 		primaryRepo := cfg.Project.PrimaryRepo
 		if primaryRepo == "" && len(cfg.Project.Repos) > 0 {
 			primaryRepo = cfg.Project.Repos[0]
@@ -1263,6 +1359,15 @@ func main() {
 		}
 		if recheckRepo != "" {
 			dashSrv.SetGitHubAppRecheckFn(func() bool {
+				// The Re-check button is the first thing an owner clicks on a
+				// degraded hive. Report the real cause instead of the generic
+				// "not accessible" — there is no client to check WITH, so the
+				// credentials themselves are what must be fixed.
+				if ghClient == nil {
+					logger.Warn("github app recheck: hive is running without GitHub credentials", "detail", appAuthFailure)
+					dashSrv.AuditLog("system", "github_app_check", "result=no GitHub client: "+appAuthFailure, "")
+					return false
+				}
 				num, err := ghClient.EnsureAdvisoryIssue(ctx, recheckRepo)
 				if err != nil {
 					logger.Debug("github app recheck: not accessible", "repo", recheckRepo, "error", err)
@@ -1481,7 +1586,7 @@ func main() {
 			prevGitHub.InstallationID != cfg.GitHub.InstallationID ||
 			prevGitHub.KeyFile != cfg.GitHub.KeyFile ||
 			prevGitHub.APIURL != cfg.GitHub.APIURL {
-			if cfg.GitHub.AppID != 0 && cfg.GitHub.InstallationID != 0 && cfg.GitHub.KeyFile != "" {
+			if cfg.GitHub.HasUsableApp() && cfg.GitHub.KeyFile != "" {
 				newAppAuth, appErr := github.NewAppAuth(cfg.GitHub.AppID, cfg.GitHub.InstallationID, cfg.GitHub.KeyFile, logger, cfg.GitHub.ResolvedAPIURL())
 				if appErr != nil {
 					logger.Error("github app auth rebuild after config reload failed", "error", appErr)
@@ -2093,7 +2198,12 @@ func main() {
 				}
 			}
 
-			if ghCfg.AppID != 0 {
+			// Adopt a hub-delivered app_id only when it names a REAL App. Zero
+			// means "not speaking to this field"; the placeholder sentinel is
+			// what a pre-provisioned hive already carries, so re-adopting it
+			// would overwrite a good app_id with a non-App on any heartbeat
+			// that echoed the original seed back.
+			if ghCfg.AppID != 0 && ghCfg.AppID != config.PlaceholderAppID {
 				cfg.GitHub.AppID = ghCfg.AppID
 			}
 			// A zero installation_id means "the hub is not speaking to this
@@ -2115,7 +2225,7 @@ func main() {
 				cfg.GitHub.AppSlug = ghCfg.AppSlug
 			}
 
-			if cfg.GitHub.AppID != 0 && cfg.GitHub.InstallationID != 0 && cfg.GitHub.KeyFile != "" {
+			if cfg.GitHub.HasUsableApp() && cfg.GitHub.KeyFile != "" {
 				newAppAuth, err := github.NewAppAuth(cfg.GitHub.AppID, cfg.GitHub.InstallationID, cfg.GitHub.KeyFile, logger, cfg.GitHub.ResolvedAPIURL())
 				if err != nil {
 					logger.Error("github app auth init via heartbeat failed", "error", err)
@@ -2545,6 +2655,15 @@ func runEvalCycle(
 	restartedAgents []string,
 	logger *slog.Logger,
 ) {
+	// A hive running without GitHub credentials (placeholder app_id, or a real
+	// App whose key could not be read) has nothing to enumerate. Return before
+	// the first API call rather than logging a misleading enumeration failure
+	// once per eval interval — the dashboard banner already states the cause.
+	if ghClient == nil {
+		logger.Debug("skipping eval cycle: hive is running without GitHub credentials")
+		return
+	}
+
 	if dashSrv.IsGitHubAppRequired() {
 		primaryRepo := cfg.Project.PrimaryRepo
 		if primaryRepo == "" && len(cfg.Project.Repos) > 0 {

--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -193,6 +193,155 @@ func describeKeySource(v string) string {
 	return v
 }
 
+// githubAuth is the outcome of resolving this hive's GitHub credentials at
+// startup. Every field is optional: a hive with no usable credentials is a
+// legitimate, bootable state.
+type githubAuth struct {
+	// Client is nil when no credentials could be resolved. Callers must treat a
+	// nil Client as "GitHub is unavailable", never as a fatal condition.
+	Client *github.Client
+	// AppAuth is non-nil only when App auth was successfully initialized.
+	AppAuth *github.AppAuth
+	// Failure, when non-empty, is the operator-facing reason there is no
+	// working GitHub client. It is shown in the dashboard's GitHub App banner.
+	Failure string
+	// State classifies Failure so the banner and the hub's journey nudges can
+	// tell an operator-side fault (a key that was never delivered) from a
+	// user-actionable one (the App is not installed). Escalating against an
+	// owner for a key WE failed to provision is precisely the mistake
+	// github.AppAuthState exists to prevent.
+	State github.AppAuthState
+}
+
+// initGitHubAuth resolves this hive's GitHub credentials.
+//
+// It NEVER exits the process. A hive that cannot authenticate to GitHub must
+// still boot and serve its dashboard, because the dashboard is the only place
+// its owner can see what is wrong and fix it. Exiting here — which is what this
+// code used to do on a key-read failure — happens before the HTTP listener
+// binds, so the pod crashloops with the diagnosis visible only in kubectl logs:
+// the hub shows the hive offline, the heartbeat never starts, and a rollout
+// hangs forever because the new pod never goes Ready.
+//
+// The placeholder app_id is the reason that path was reachable at all. See
+// config.PlaceholderAppID.
+func initGitHubAuth(ctx context.Context, cfg *config.Config, logger *slog.Logger) githubAuth {
+	var out githubAuth
+	appKeyFile := resolveAppKeyFile(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"))
+
+	// HasUsableApp() rejects config.PlaceholderAppID. A placeholder paired with
+	// a real installation_id — exactly what happens the instant an owner
+	// installs the App on a pre-provisioned hive — used to satisfy a bare
+	// `AppID != 0` test and commit this process to App auth it could never
+	// perform.
+	if cfg.GitHub.HasUsableApp() {
+		appAuth, err := github.NewAppAuth(cfg.GitHub.AppID, cfg.GitHub.InstallationID, appKeyFile, logger, cfg.GitHub.ResolvedAPIURL())
+		if err != nil {
+			// A genuinely-configured App whose key is missing or malformed is a
+			// real, actionable fault — but not a reason to refuse to boot.
+			out.Failure = describeAppKeyFailure(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), appKeyFile, err)
+			// Both states are operator-actionable: the hive's owner cannot
+			// deliver a key. Absent vs. unparseable is the distinction the hub
+			// needs to tell "never pushed" from "pushed something broken".
+			out.State = github.AppStateKeyInvalid
+			if errors.Is(err, fs.ErrNotExist) {
+				out.State = github.AppStateKeyMissing
+			}
+			logger.Error("GitHub App auth unavailable — starting in dashboard-only mode",
+				"app_id", cfg.GitHub.AppID,
+				"installation_id", cfg.GitHub.InstallationID,
+				"key_file", appKeyFile,
+				"state", out.State.String(),
+				"detail", out.Failure,
+				"error", err,
+			)
+		} else {
+			out.AppAuth = appAuth
+		}
+	}
+
+	if out.AppAuth != nil {
+		logger.Info("using GitHub App authentication", "app_id", cfg.GitHub.AppID)
+		// Correct a stale/wrong installation_id BEFORE building the client, so
+		// the very first token this process mints is scoped to the right org
+		// rather than 403ing on every write until the self-heal tick runs.
+		healGitHubAppInstallation(ctx, out.AppAuth, cfg, logger)
+		out.Client = github.NewClientFromApp(out.AppAuth, cfg.Project.Org, cfg.Project.Repos, logger)
+		startDocsTokenRefresh(ctx, cfg, appKeyFile, logger)
+		return out
+	}
+
+	ghToken := cfg.GitHub.Token
+	if ghToken == "" {
+		ghToken = os.Getenv("HIVE_GITHUB_TOKEN")
+	}
+	switch {
+	case ghToken != "":
+		out.Client = github.NewClient(ghToken, cfg.Project.Org, cfg.Project.Repos, logger, cfg.GitHub.ResolvedAPIURL())
+	case out.Failure != "":
+		// Real App, unusable key. Already logged; leave Client nil so nothing
+		// tries to act on GitHub with credentials that do not work.
+	case cfg.GitHub.IsPlaceholderApp():
+		// User-actionable: this hive was provisioned ahead of its App, and
+		// installing the App is exactly what resolves it.
+		out.Failure = "This hive carries a placeholder github.app_id and is not yet linked to a GitHub App. Install the GitHub App on your org to enable agents."
+		out.State = github.AppStateNotInstalled
+		logger.Warn("placeholder github.app_id — hive starting in dashboard-only mode",
+			"placeholder_app_id", config.PlaceholderAppID,
+			"installation_id", cfg.GitHub.InstallationID,
+		)
+	case cfg.GitHub.AppID != 0:
+		out.Failure = "The GitHub App is configured but has no installation. Install the app on your org to enable agents."
+		out.State = github.AppStateNotInstalled
+		logger.Warn("GitHub App configured without credentials — hive starting in dashboard-only mode. Install the app and provide installation_id + key to enable agents.")
+	default:
+		// Neither a token nor any app_id at all. config.validate() rejects this
+		// at load, so reaching it means the config was mutated afterwards.
+		// Still a degraded boot rather than an exit: the dashboard is where an
+		// operator fixes it.
+		out.Failure = "No GitHub credentials configured. Set github.token, or github.app_id plus an App installation."
+		logger.Error("no GitHub token configured (set github.token or github.app_id in config) — starting in dashboard-only mode")
+	}
+	return out
+}
+
+// startDocsTokenRefresh mints and periodically refreshes a token for the
+// separate docs-org installation, when one is configured. A failure here is
+// always non-fatal: the docs org is an add-on, not this hive's primary auth.
+func startDocsTokenRefresh(ctx context.Context, cfg *config.Config, appKeyFile string, logger *slog.Logger) {
+	if cfg.GitHub.DocsInstallationID == 0 {
+		return
+	}
+	docsAuth, err := github.NewAppAuthWithCache(
+		cfg.GitHub.AppID, cfg.GitHub.DocsInstallationID,
+		appKeyFile, github.DocsTokenCachePath, logger, cfg.GitHub.ResolvedAPIURL(),
+	)
+	if err != nil {
+		logger.Warn("failed to init docs org token", "error", err)
+		return
+	}
+	if _, err := docsAuth.Token(ctx); err != nil {
+		logger.Warn("failed to generate initial docs org token", "error", err)
+	} else {
+		logger.Info("docs org token cached", "installation_id", cfg.GitHub.DocsInstallationID)
+	}
+	go func() {
+		const docsTokenRefreshInterval = 45 * time.Minute
+		ticker := time.NewTicker(docsTokenRefreshInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if _, err := docsAuth.Token(ctx); err != nil {
+					logger.Warn("docs token refresh failed", "error", err)
+				}
+			}
+		}
+	}()
+}
+
 // processStartedAt is when this hive process began. Reported over the heartbeat
 // so the hub can show an uptime pill — a hive that is 1/1 Running but restarting
 // every couple of minutes looks healthy in a pod listing and in My Hives, and a
@@ -281,124 +430,16 @@ func main() {
 		cancel()
 	}()
 
-	var ghClient *github.Client
-	var appAuth *github.AppAuth
-	// appAuthFailure, when non-empty, is the operator-facing reason App auth
-	// could not be initialized. It is surfaced through the existing
-	// GitHubAppRequired/PermIssue banner rather than killing the process — see
-	// the degraded-boot rationale below.
-	var appAuthFailure string
-	// appAuthState classifies appAuthFailure so the banner and the hub's
-	// journey nudges can tell an operator-side fault (no key was ever
-	// delivered) from a user-actionable one (the App is not installed).
-	appAuthState := github.AppStateUnknown
-	appKeyFile := resolveAppKeyFile(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"))
-	// HasUsableApp() rejects config.PlaceholderAppID. A placeholder paired with
-	// a real installation_id (which is what happens the instant an owner
-	// installs the App on a pre-provisioned hive) used to satisfy a bare
-	// `AppID != 0` test, commit the process to App auth, fail to read a PEM
-	// that was never provisioned, and os.Exit(1) BEFORE the listener bound —
-	// permanent CrashLoopBackOff with nothing visible in the dashboard.
-	if cfg.GitHub.HasUsableApp() {
-		var err error
-		appAuth, err = github.NewAppAuth(cfg.GitHub.AppID, cfg.GitHub.InstallationID, appKeyFile, logger, cfg.GitHub.ResolvedAPIURL())
-		if err != nil {
-			// A genuinely-configured App whose key is missing or malformed is a
-			// real, actionable fault — but NOT a reason to refuse to boot. The
-			// dashboard is the only place an owner can see and fix it, so the
-			// hive comes up degraded (no ghClient, no agent work) and reports
-			// the fault through the banner the UI already renders.
-			appAuthFailure = describeAppKeyFailure(cfg.GitHub.KeyFile, os.Getenv("GH_APP_KEY_FILE"), appKeyFile, err)
-			// Both states are operator-actionable: the hive's owner cannot
-			// deliver a key. Absent vs. unparseable is the distinction the hub
-			// needs to tell "never pushed" from "pushed something broken".
-			appAuthState = github.AppStateKeyInvalid
-			if errors.Is(err, fs.ErrNotExist) {
-				appAuthState = github.AppStateKeyMissing
-			}
-			logger.Error("GitHub App auth unavailable — starting in dashboard-only mode",
-				"app_id", cfg.GitHub.AppID,
-				"installation_id", cfg.GitHub.InstallationID,
-				"key_file", appKeyFile,
-				"state", appAuthState.String(),
-				"detail", appAuthFailure,
-				"error", err,
-			)
-			appAuth = nil
-		}
-	}
-	switch {
-	case appAuth != nil:
-		logger.Info("using GitHub App authentication", "app_id", cfg.GitHub.AppID)
-		// Correct a stale/wrong installation_id BEFORE building the client, so
-		// the very first token this process mints is scoped to the right org
-		// rather than 403ing on every write until the self-heal tick runs.
-		healGitHubAppInstallation(ctx, appAuth, cfg, logger)
-		ghClient = github.NewClientFromApp(appAuth, cfg.Project.Org, cfg.Project.Repos, logger)
-
-		if cfg.GitHub.DocsInstallationID != 0 {
-			docsAuth, err := github.NewAppAuthWithCache(
-				cfg.GitHub.AppID, cfg.GitHub.DocsInstallationID,
-				appKeyFile, github.DocsTokenCachePath, logger, cfg.GitHub.ResolvedAPIURL(),
-			)
-			if err != nil {
-				logger.Warn("failed to init docs org token", "error", err)
-			} else {
-				if _, err := docsAuth.Token(ctx); err != nil {
-					logger.Warn("failed to generate initial docs org token", "error", err)
-				} else {
-					logger.Info("docs org token cached", "installation_id", cfg.GitHub.DocsInstallationID)
-				}
-				go func() {
-					const docsTokenRefreshInterval = 45 * time.Minute
-					ticker := time.NewTicker(docsTokenRefreshInterval)
-					defer ticker.Stop()
-					for {
-						select {
-						case <-ctx.Done():
-							return
-						case <-ticker.C:
-							if _, err := docsAuth.Token(ctx); err != nil {
-								logger.Warn("docs token refresh failed", "error", err)
-							}
-						}
-					}
-				}()
-			}
-		}
-	default:
-		ghToken := cfg.GitHub.Token
-		if ghToken == "" {
-			ghToken = os.Getenv("HIVE_GITHUB_TOKEN")
-		}
-		switch {
-		case ghToken != "":
-			ghClient = github.NewClient(ghToken, cfg.Project.Org, cfg.Project.Repos, logger, cfg.GitHub.ResolvedAPIURL())
-		case appAuthFailure != "":
-			// Real App, unusable key. Already logged above; leave ghClient nil
-			// so nothing tries to act on GitHub with no credentials.
-		case cfg.GitHub.IsPlaceholderApp():
-			// User-actionable: this hive was provisioned ahead of its App, and
-			// installing the App is exactly what resolves it.
-			appAuthFailure = "This hive carries a placeholder github.app_id and is not yet linked to a GitHub App. Install the GitHub App on your org to enable agents."
-			appAuthState = github.AppStateNotInstalled
-			logger.Warn("placeholder github.app_id — hive starting in dashboard-only mode",
-				"placeholder_app_id", config.PlaceholderAppID,
-				"installation_id", cfg.GitHub.InstallationID,
-			)
-		case cfg.GitHub.AppID != 0:
-			appAuthFailure = "The GitHub App is configured but has no installation. Install the app on your org to enable agents."
-			appAuthState = github.AppStateNotInstalled
-			logger.Warn("GitHub App configured without credentials — hive starting in dashboard-only mode. Install the app and provide installation_id + key to enable agents.")
-		default:
-			// Neither a token nor any app_id at all. config.validate() should
-			// already have rejected this, so it means the config was mutated
-			// after load. Still a degraded boot rather than an exit: the
-			// dashboard is where an operator fixes it.
-			appAuthFailure = "No GitHub credentials configured. Set github.token, or github.app_id plus an App installation."
-			logger.Error("no GitHub token configured (set github.token or github.app_id in config) — starting in dashboard-only mode")
-		}
-	}
+	ghAuth := initGitHubAuth(ctx, cfg, logger)
+	ghClient, appAuth := ghAuth.Client, ghAuth.AppAuth
+	// appAuthFailure, when non-empty, is the operator-facing reason GitHub auth
+	// is unavailable. It is surfaced through the existing
+	// GitHubAppRequired/PermIssue banner rather than killing the process.
+	appAuthFailure := ghAuth.Failure
+	// appAuthState classifies that failure so the banner and the hub's journey
+	// nudges can tell an operator-side fault (no key was ever delivered) from a
+	// user-actionable one (the App is not installed).
+	appAuthState := ghAuth.State
 	if ghClient != nil && len(cfg.Governor.Labels.Exempt) > 0 {
 		ghClient.SetExemptLabels(cfg.Governor.Labels.Exempt)
 	}

--- a/v2/docs/manual-provisioning.md
+++ b/v2/docs/manual-provisioning.md
@@ -93,6 +93,12 @@ Response:
 
 The generated ID is `hosted-<org>-<primary_repo>-<4char>`.
 
+> **`app_id: 999999999` above is the placeholder sentinel, not an arbitrary
+> number.** It is `config.PlaceholderAppID`, and the spoke recognises it as
+> "this hive has no GitHub App yet". Use exactly this value — any other
+> non-zero number is read as a real App ID and the hive will try (and fail) to
+> authenticate as it. See [Placeholder `app_id`](#placeholder-app_id) below.
+
 **`CreateHiveRequest` fields that matter:**
 
 | Field | Notes |
@@ -102,7 +108,7 @@ The generated ID is `hosted-<org>-<primary_repo>-<4char>`.
 | `acmm_level` | Starting autonomy. **Default new hives to `2`** (Instructed / advisory-only). |
 | `cluster_id` | `hive-oke` (the `defaultClusterID`). |
 | `auth_method` | `app` or a token. |
-| `app_id` / `installation_id` / `app_private_key` | Three auth shapes: **token** (`github_token` starts `ghp_`/`github_pat_`); **app now** (all three set); **app later** — `app_id` set, `installation_id` **and** `app_private_key` **empty**. The last is the placeholder case: the hive provisions, then 401s until the owner installs the App from the dashboard. |
+| `app_id` / `installation_id` / `app_private_key` | Three auth shapes: **token** (`github_token` starts `ghp_`/`github_pat_`); **app now** (all three set); **app later** — `app_id` set, `installation_id` **and** `app_private_key` **empty**. The last is the placeholder case: pass the sentinel `app_id: 999999999` (see [Placeholder `app_id`](#placeholder-app_id)) and the hive provisions into dashboard-only mode until the owner installs the App from the dashboard. |
 | `is_public` | Pointer. **Absent defaults to public.** Send `false` explicitly for a private hive. |
 
 > **Gotcha — `auth_method: app` with no key provisions but reports `error`.**
@@ -263,7 +269,7 @@ data:
         idle: { threshold: 0,  guide: 4h, scanner: 4h }
         busy: { threshold: 10, guide: 2h, scanner: 2h }
     github:
-      app_id: 999999999               # placeholder until the real App is installed
+      app_id: 999999999               # the placeholder sentinel (config.PlaceholderAppID)
       installation_id:
       key_file: /secrets/gh-app-key.pem
       oauth_client_id: Ov23ligE2p0gjXg6xAUf   # public device-flow client (no secret)
@@ -282,11 +288,36 @@ data:
 YAML
 ```
 
+<a id="placeholder-app_id"></a>
+
 > **Gotcha — `github.app_id` cannot be empty.** Config validation requires
 > **either** `github.token` **or** `github.app_id` to be set
 > (`pkg/config/config.go`: `github.token or github.app_id is required`). A hive
-> awaiting its real App must carry a **placeholder** `app_id` (e.g. `999999999`)
-> or it will refuse to boot.
+> awaiting its real App must carry the **placeholder sentinel**
+> `app_id: 999999999` or it will refuse to boot.
+
+> **Use `999999999` exactly — it is a recognised sentinel, not a spare number.**
+> It is declared as `config.PlaceholderAppID`, and `GitHubConfig.HasApp()`
+> reports a hive carrying it as having **no** GitHub App. Such a hive boots into
+> dashboard-only mode: the dashboard serves, the heartbeat runs, and the "GitHub
+> App required" banner shows the install link. Agents stay idle until a real App
+> is linked.
+>
+> Any *other* non-zero placeholder is read as a **real** App ID. The hive will
+> then try to authenticate as an App that does not exist — and once
+> `installation_id` also becomes non-zero (which happens the moment the owner
+> installs an App), it attempts to load a private key that was never
+> provisioned. Before this was fixed, that combination exited the process
+> **before the HTTP listener bound**: permanent `CrashLoopBackOff`, no
+> heartbeat, the hive shown offline on the hub, and any in-flight rollout stuck
+> forever because the new pod never went Ready. The spoke now degrades instead
+> of exiting, but the hive still cannot do any GitHub work until the `app_id` is
+> corrected.
+>
+> Replacing the placeholder with the real value is normally automatic — the hub
+> delivers `app_id`, `installation_id` and the private key over the heartbeat
+> when the App is installed. To do it by hand, patch the PVC overlay
+> (`/data/hive.yaml.dashboard`, **not** the ConfigMap) and restart the pod.
 
 > **Gotcha — `hub_proxied` must be `false` on vllm-d.** vllm-d has no hub nginx
 > auth proxy. If `hub_proxied` is `true`, dashboard sign-in enters an OAuth
@@ -670,7 +701,9 @@ kubectl --context hive-oke -n hive-hub exec "$HUB_POD" -- \
 | Pod `1/1 Running` but hive shows **offline**; no 401, heartbeat just stopped | Heartbeat goroutine died; liveness probe on `/api/health` can't detect it | Point livenessProbe at `/api/livez`; restart to revive now |
 | Pod restarting repeatedly (`RESTARTS` climbing) while the app looks fine; hub unreachable/firewalled | Old liveness probe failed on stale *heartbeat success* — a connectivity condition a restart can't fix | Redeploy to pick up the attempt-based `/api/livez` (+ `startupProbe`); check `/api/health/deep` → `hub_heartbeat` for the real connectivity state |
 | Pod `CrashLoopBackOff` exit 255, SCC `restricted-v2` | `hive-anyuid` RoleBinding subject points at the wrong namespace | Set `subjects[].namespace` to the hive's own `$NS`, delete the pod |
-| Pod won't boot: `github.token or github.app_id is required` | `github.app_id` empty in the seed | Set a placeholder `app_id` (e.g. `999999999`) |
+| Pod won't boot: `github.token or github.app_id is required` | `github.app_id` empty in the seed | Set the placeholder sentinel `app_id: 999999999` — exactly that value, see [Placeholder `app_id`](#placeholder-app_id). Any other stand-in number is treated as a real App |
+| Pod `CrashLoopBackOff` with `failed to init GitHub App auth` / `reading app key ...: no such file`, restarts climbing, hive offline on the hub, rollout stuck with two crashlooping pods | A non-sentinel placeholder `app_id` plus a real `installation_id`, and no private key at `key_file`. Older builds exited before the listener bound, so nothing was visible in the dashboard | Set `app_id` to the real App ID and install the PEM at `key_file` (or set `app_id` to the sentinel `999999999` to park the hive in dashboard-only mode). Patch `/data/hive.yaml.dashboard` and restart. Current builds boot degraded and show the reason in the GitHub App banner instead of crashlooping |
+| Dashboard banner: "GitHub App private key could not be loaded from ..." | A real `app_id` + `installation_id`, but no readable PEM at the resolved path | The banner names the exact path tried and the resolution order (`$GH_APP_KEY_FILE` → `github.key_file` → PVC `/data/gh-app-key.pem` → provisioning mount `/secrets/gh-app-key.pem`). Write the PEM to that path, or point `github.key_file` at one |
 | Dashboard sign-in redirect loop (vllm-d) | `hub_proxied: true` on a cluster with no hub auth proxy | Set `hub_proxied: false` on the PVC overlay |
 | Hive online but **Upgrade** → `hive not found` | No `meta.json` on the hub | Create `/data/saas/hives/<id>/meta.json` |
 | Not visible in My Hives | No `meta.json`, or `owner` doesn't match | Create/patch `meta.json` with the right `owner` |

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1096,6 +1096,23 @@ type GitHubConfig struct {
 	AppAuthoredPRs bool `yaml:"app_authored_prs"`
 }
 
+// PlaceholderAppID is the sentinel `github.app_id` written into a hive's config
+// when the hive is provisioned BEFORE its real GitHub App exists — a pooled
+// "available-*" placeholder, or a hive whose owner has not installed the App
+// yet. Config validation requires either github.token or github.app_id, so the
+// seed cannot leave app_id empty; this value fills the slot without ever naming
+// a real App.
+//
+// It is NOT a valid GitHub App ID and must never be handed to
+// github.NewAppAuth. Every test for "is a GitHub App configured?" must use
+// GitHubConfig.HasApp() rather than a bare `AppID != 0` — the sentinel is
+// non-zero, so a bare zero-test reports a placeholder as a real App. That is
+// exactly the bug that put hosted hives into permanent CrashLoopBackOff: the
+// moment installation_id became non-zero (the owner installed the App), the
+// spoke committed to App auth, failed to read a PEM that was never provisioned,
+// and exited before the HTTP listener bound — invisible from the dashboard.
+const PlaceholderAppID int64 = 999999999
+
 const (
 	// DefaultGitHubAPIURL is the default GitHub API endpoint (public github.com).
 	DefaultGitHubAPIURL = "https://api.github.com"
@@ -1104,6 +1121,30 @@ const (
 	// DefaultGitHubAppSlug is the public Hive GitHub App slug.
 	DefaultGitHubAppSlug = "kubestellar-hive"
 )
+
+// IsPlaceholderApp reports whether app_id is the "no real App yet" sentinel.
+func (g GitHubConfig) IsPlaceholderApp() bool {
+	return g.AppID == PlaceholderAppID
+}
+
+// HasApp reports whether a REAL GitHub App is configured — a non-zero app_id
+// that is not the placeholder sentinel. This is the only correct presence test
+// for App auth; `AppID != 0` treats a placeholder as real.
+//
+// It deliberately says nothing about installation_id or the key file: those are
+// separate readiness conditions (see HasUsableApp) that a hive can acquire
+// later, over the heartbeat or the config API.
+func (g GitHubConfig) HasApp() bool {
+	return g.AppID != 0 && !g.IsPlaceholderApp()
+}
+
+// HasUsableApp reports whether App auth can actually be attempted: a real
+// app_id AND an installation to mint tokens against. The key file is resolved
+// separately (config value, then $GH_APP_KEY_FILE, then the on-disk fallbacks),
+// so it is not part of this test.
+func (g GitHubConfig) HasUsableApp() bool {
+	return g.HasApp() && g.InstallationID != 0
+}
 
 // ResolvedAPIURL returns the configured API URL or the default for github.com.
 func (g GitHubConfig) ResolvedAPIURL() string {
@@ -2084,6 +2125,9 @@ func (c *Config) validate() error {
 	if len(c.Agents) == 0 {
 		return fmt.Errorf("at least one agent must be configured")
 	}
+	// Deliberately a bare zero-test, NOT HasApp(): PlaceholderAppID exists
+	// precisely so a hive awaiting its real App can satisfy this check and boot
+	// into dashboard-only mode. Everywhere else, use HasApp().
 	if c.GitHub.Token == "" && c.GitHub.AppID == 0 {
 		return fmt.Errorf("github.token or github.app_id is required")
 	}

--- a/v2/pkg/config/placeholder_appid_test.go
+++ b/v2/pkg/config/placeholder_appid_test.go
@@ -1,0 +1,92 @@
+package config
+
+import "testing"
+
+// TestHasAppRejectsPlaceholder pins the distinction the whole crashloop fix
+// rests on. A bare `AppID != 0` cannot tell a real App from the placeholder
+// sentinel, because the sentinel is non-zero — that is precisely how a hive
+// with no GitHub App talked itself into App auth and exited before its HTTP
+// listener bound.
+func TestHasAppRejectsPlaceholder(t *testing.T) {
+	const realAppID int64 = 3568013
+
+	cases := []struct {
+		name            string
+		appID           int64
+		installationID  int64
+		wantPlaceholder bool
+		wantHasApp      bool
+		wantUsable      bool
+	}{
+		{
+			name:  "no app at all",
+			appID: 0,
+		},
+		{
+			name:            "placeholder alone — a freshly provisioned pool hive",
+			appID:           PlaceholderAppID,
+			wantPlaceholder: true,
+		},
+		{
+			// The exact production config that crashlooped: the placeholder was
+			// never replaced, but installing the App delivered a real
+			// installation_id. Both HasApp and HasUsableApp must stay false.
+			name:            "placeholder plus a real installation — the crashloop case",
+			appID:           PlaceholderAppID,
+			installationID:  149757667,
+			wantPlaceholder: true,
+		},
+		{
+			name:       "real app, not yet installed",
+			appID:      realAppID,
+			wantHasApp: true,
+		},
+		{
+			name:           "real app, installed",
+			appID:          realAppID,
+			installationID: 149757667,
+			wantHasApp:     true,
+			wantUsable:     true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := GitHubConfig{AppID: tc.appID, InstallationID: tc.installationID}
+
+			if got := g.IsPlaceholderApp(); got != tc.wantPlaceholder {
+				t.Errorf("IsPlaceholderApp() = %v, want %v", got, tc.wantPlaceholder)
+			}
+			if got := g.HasApp(); got != tc.wantHasApp {
+				t.Errorf("HasApp() = %v, want %v", got, tc.wantHasApp)
+			}
+			if got := g.HasUsableApp(); got != tc.wantUsable {
+				t.Errorf("HasUsableApp() = %v, want %v", got, tc.wantUsable)
+			}
+		})
+	}
+}
+
+// TestPlaceholderAppIDSatisfiesValidation locks in the sentinel's reason for
+// existing. Config validation demands github.token or github.app_id, so a hive
+// awaiting its real App needs *something* in app_id to boot at all — and
+// validate() must therefore keep using a bare zero-test rather than HasApp(),
+// or every pre-provisioned hive would refuse to start.
+func TestPlaceholderAppIDSatisfiesValidation(t *testing.T) {
+	newCfg := func(appID int64) *Config {
+		c := &Config{}
+		c.Project.Org = "jeejz"
+		c.GitHub.AppID = appID
+		c.Agents = map[string]AgentConfig{
+			"guide": {Backend: "claude", Enabled: true},
+		}
+		return c
+	}
+
+	if err := newCfg(PlaceholderAppID).validate(); err != nil {
+		t.Fatalf("placeholder app_id must satisfy validation so the hive can boot: %v", err)
+	}
+	if err := newCfg(0).validate(); err == nil {
+		t.Fatal("a config with neither a token nor any app_id must still be rejected")
+	}
+}

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1302,7 +1302,7 @@ func (s *Server) handleBudgetIgnoreSet(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleGHAuth(w http.ResponseWriter, r *http.Request) {
 	cfg := s.deps.Config.GitHub
 	authType := "token"
-	if cfg.AppID != 0 {
+	if cfg.HasApp() {
 		authType = "app"
 	}
 	jsonResponse(w, map[string]interface{}{
@@ -4438,7 +4438,10 @@ func (s *Server) handleConfigGitHub(w http.ResponseWriter, r *http.Request) {
 		"key_file":        cfg.GitHub.KeyFile,
 	}
 
-	if cfg.GitHub.AppID != 0 && cfg.GitHub.InstallationID != 0 && cfg.GitHub.KeyFile != "" {
+	// HasUsableApp() rejects the placeholder sentinel: reinitializing App auth
+	// against it would fail on every save and, before this guard, could not
+	// succeed no matter what installation_id the operator supplied.
+	if cfg.GitHub.HasUsableApp() && cfg.GitHub.KeyFile != "" {
 		if s.deps.ReinitGitHubFunc != nil {
 			if err := s.deps.ReinitGitHubFunc(cfg.GitHub.AppID, cfg.GitHub.InstallationID, cfg.GitHub.KeyFile); err != nil {
 				s.logger.Error("github client reinit failed", "error", err)

--- a/v2/pkg/dashboard/api_acmm_eval.go
+++ b/v2/pkg/dashboard/api_acmm_eval.go
@@ -370,7 +370,13 @@ func (s *Server) prefetchDirectories(ctx context.Context, owner, repo string) ma
 		"docs/security",
 	}
 
+	// GoGitHub() is nil-receiver safe and returns nil, so the deref below would
+	// panic on a hive running without GitHub credentials. Sibling handlers
+	// guard the same way.
 	ghClient := s.deps.GHClient.GoGitHub()
+	if ghClient == nil {
+		return cache
+	}
 	for _, dir := range dirs {
 		_, dirContents, _, err := ghClient.Repositories.GetContents(ctx, owner, repo, dir, nil)
 		if err != nil {
@@ -422,6 +428,9 @@ func (s *Server) patternExists(ctx context.Context, owner, repo, path string, di
 	}
 
 	ghClient := s.deps.GHClient.GoGitHub()
+	if ghClient == nil {
+		return false
+	}
 	_, _, _, err := ghClient.Repositories.GetContents(ctx, owner, repo, cleanPath, nil)
 	return err == nil
 }

--- a/v2/pkg/dashboard/status_builder.go
+++ b/v2/pkg/dashboard/status_builder.go
@@ -1036,7 +1036,10 @@ func buildGHRateLimits(ghClient *github.Client, ctx context.Context, cfg *config
 
 	authType := "token"
 	authLabel := "unknown"
-	if cfg.GitHub.AppID != 0 {
+	// HasApp() so a placeholder app_id is not reported as App-authenticated
+	// identity in the rate-limit card — it has no installation and mints no
+	// tokens.
+	if cfg.GitHub.HasApp() {
 		authType = "app"
 		authLabel = cfg.Project.Org
 	} else if cfg.GitHub.Token != "" {

--- a/v2/pkg/github/advisory.go
+++ b/v2/pkg/github/advisory.go
@@ -20,6 +20,9 @@ const (
 // EnsureAdvisoryIssue finds or creates the pinned advisory issue for a repo.
 // Returns the issue number.
 func (c *Client) EnsureAdvisoryIssue(ctx context.Context, repo string) (int, error) {
+	if c == nil {
+		return 0, ErrNoGitHubClient
+	}
 	owner := c.org
 	if parts := strings.SplitN(repo, "/", 2); len(parts) == 2 {
 		owner = parts[0]
@@ -79,6 +82,9 @@ const (
 // PostAdvisoryDigest updates the existing digest comment on the advisory issue,
 // or creates one if none exists. This prevents duplicate comments on each eval cycle.
 func (c *Client) PostAdvisoryDigest(ctx context.Context, repo string, issueNum int, digest string) error {
+	if c == nil {
+		return ErrNoGitHubClient
+	}
 	owner, repoName := c.splitRepo(repo)
 
 	digest = truncateDigest(digest)

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
@@ -13,6 +14,15 @@ import (
 
 	gh "github.com/google/go-github/v72/github"
 )
+
+// ErrNoGitHubClient is returned by *Client methods invoked on a nil receiver.
+//
+// A nil *Client is a legitimate, expected runtime state: a hive whose GitHub
+// App key is missing or whose app_id is still the placeholder boots in
+// dashboard-only mode so its owner can see and fix the problem, and it runs
+// with no GitHub client at all. Callers must treat this as "GitHub is
+// unavailable right now", not as a bug — it is never a reason to exit.
+var ErrNoGitHubClient = errors.New("no github client configured (hive is running without GitHub credentials)")
 
 type Client struct {
 	client       *gh.Client
@@ -168,7 +178,15 @@ func NewClientForTest(serverURL string, org string, repos []string, logger *slog
 	return c
 }
 
+// SetRepos is nil-receiver safe. A hive that booted without usable GitHub
+// credentials runs with a nil *Client for the life of the process, and the
+// config-reload / project-claim / override-migration paths all re-sync the repo
+// list unconditionally. Making the setter a no-op on nil is safer than adding a
+// guard at each of those call sites, which a future one would forget.
 func (c *Client) SetRepos(repos []string) {
+	if c == nil {
+		return
+	}
 	c.reposMu.Lock()
 	defer c.reposMu.Unlock()
 	c.repos = repos
@@ -183,6 +201,9 @@ func (c *Client) getRepos() []string {
 }
 
 func (c *Client) EnumerateActionable(ctx context.Context) (*ActionableResult, error) {
+	if c == nil {
+		return nil, ErrNoGitHubClient
+	}
 	now := time.Now()
 	result := &ActionableResult{
 		GeneratedAt: now,
@@ -407,6 +428,9 @@ func (c *Client) fetchPRs(ctx context.Context, repo string) (actionable []PullRe
 // and sets the CIStatus field to "success", "failure", or "pending".
 // The "tide" check is skipped — it reports Prow merge-bot state, not CI.
 func (c *Client) EnrichCIStatus(ctx context.Context, prs []PullRequest) {
+	if c == nil {
+		return
+	}
 	const ciStatusSuccess = "success"
 	const ciStatusFailure = "failure"
 	const ciStatusPending = "pending"
@@ -502,7 +526,11 @@ func isHeld(labels []string) bool {
 	return false
 }
 
+// SetExemptLabels is nil-receiver safe for the same reason as SetRepos.
 func (c *Client) SetExemptLabels(labels []string) {
+	if c == nil {
+		return
+	}
 	c.exemptLabels = labels
 }
 
@@ -719,6 +747,9 @@ type SHAHoldResult struct {
 }
 
 func (c *Client) EnforceSHAHold(ctx context.Context, cfg SHAHoldConfig) (*SHAHoldResult, error) {
+	if c == nil {
+		return nil, ErrNoGitHubClient
+	}
 	result := &SHAHoldResult{}
 	owner, repo := c.splitRepo(cfg.PrimaryRepo)
 


### PR DESCRIPTION
## The bug

`v2/docs/manual-provisioning.md` instructed operators, in four places, to set a **placeholder** `app_id: 999999999` for hives that do not yet have a real GitHub App — including as the recommended remedy for the `github.app_id is required` boot failure. Config validation demands either `github.token` or `github.app_id`, so the seed genuinely cannot leave it empty.

Every "is a GitHub App configured?" test in the spoke was a bare `AppID != 0`. **999999999 is non-zero, so it passed.**

The moment `installation_id` also became non-zero — which is exactly what happens when a user installs the GitHub App on a pre-provisioned hive — the process committed to App auth, tried to read a PEM that was never provisioned, and called `os.Exit(1)`:

```go
if cfg.GitHub.AppID != 0 && cfg.GitHub.InstallationID != 0 {
    appAuth, err = github.NewAppAuth(...)
    if err != nil {
        logger.Error("failed to init GitHub App auth", "error", err)
        os.Exit(1)   // <-- before the HTTP listener binds
    }
```

That exit happens **before the HTTP listener binds**, which is what made this invisible: permanent `CrashLoopBackOff`, no heartbeat, the hub shows the hive offline, and any in-flight rollout hangs forever because the new pod never goes Ready — so the old ReplicaSet is never scaled down and you get *two* crashlooping pods.

## Evidence

Hit in production on hosted hive `hosted-available-oke-06-placeholder-04si` (org `jeejz`): overlay carried `app_id: 999999999`, a real `installation_id: 149757667`, and `key_file: /secrets/gh-app-key.pem` whose Secret contained only `dashboard-token`. 89 restarts on the old pod, 24 on the new. That instance was hand-repaired in-cluster; this PR is the code fix.

**Nine more hives are armed right now** and will hit this the instant their owner installs the App: `oke-07-placeholder-wlj4`, `oke-08-xf07`, `oke-09-iwth`, `oke-10-ncnd`, `oke-11-r05x`, `oke-12-2soo`, `oke-13-2aug`, `oke-14-jwgm`, `oke-15-iv1r` — all `app_id: 999999999`, `installation_id: 0`.

## What changed

**1. The sentinel is now a named constant, and unmistakable.** `config.PlaceholderAppID`, with `GitHubConfig.HasApp()` / `HasUsableApp()` / `IsPlaceholderApp()`. Every presence test now goes through `HasApp()`. The one remaining bare zero-test is in `validate()`, where the placeholder is *supposed* to pass — that is its entire reason to exist, and there is now a test pinning that.

Call sites swept across `v2/`: `cmd/hive/main.go` (startup + config-reload + heartbeat-delivery reinit), `pkg/dashboard/api.go` (auth-type report, config-save reinit), `pkg/dashboard/status_builder.go` (rate-limit identity). Also: the spoke no longer adopts a hub-delivered `app_id` that is itself the placeholder, which would otherwise overwrite a good value on any heartbeat echoing the original seed.

**2. Never hard-exit on a missing or invalid App key.** A hive that cannot do App auth now boots and serves its dashboard, because the dashboard is the only place its owner can *see* the problem. It reports through the **existing** `GitHubAppRequired` / `GitHubAppPermIssue` banner rather than a new mechanism.

This PR rebases onto #2224 and plugs into its `github.AppAuthState` classification, which turned out to be exactly the right vocabulary:
- placeholder `app_id`, or a real App with no installation → `AppStateNotInstalled` (**user-actionable** — install the App)
- key file absent → `AppStateKeyMissing` (**operator-actionable**)
- key present but unparseable → `AppStateKeyInvalid` (**operator-actionable**)

The operator/user split matters here for the reason #2224 introduced it: a key the hub never delivered must not produce a banner blaming the owner, and must not let the journey nudges escalate toward de-provisioning.

**3. Nil-tolerance, verified rather than assumed.** `ghClient`/`appAuth` can now be nil for the life of the process, so I audited every use. Roughly half were already guarded; the rest would have panicked. Fixed structurally in `pkg/github` so future call sites cannot reintroduce it:
- `SetRepos` / `SetExemptLabels` → no-op on nil receiver (the config-reload, project-claim and override-migration paths all re-sync unconditionally)
- `EnsureAdvisoryIssue` / `PostAdvisoryDigest` / `EnumerateActionable` / `EnforceSHAHold` → return the new `ErrNoGitHubClient`
- `EnrichCIStatus` → returns early
- `runEvalCycle` returns before its first API call, so a degraded hive does not log a misleading enumeration failure once per eval interval
- the dashboard Re-check button reports the real cause instead of "not accessible"
- guarded the two unguarded `GoGitHub()` derefs in `pkg/dashboard/api_acmm_eval.go` (`GoGitHub()` is nil-safe and returns nil, so the *next* line was the panic)

**4. Actionable preflight diagnostics.** A genuinely-configured App with an unreadable key previously produced `reading app key /secrets/gh-app-key.pem: no such file` — which never revealed that **four** paths are consulted in a fixed order, so operators routinely put the key in the wrong one. Now the message names the exact path tried and the full order: `$GH_APP_KEY_FILE` → `github.key_file` → PVC `/data/gh-app-key.pem` → provisioning mount `/secrets/gh-app-key.pem`.

**5. Docs.** `manual-provisioning.md` stops presenting `999999999` as "e.g." The value is a recognised sentinel; any *other* non-zero stand-in is read as a real App ID and produces this exact crashloop. Added an anchored section on what a placeholder hive does (dashboard-only mode, banner with install link, agents idle) and how the placeholder is normally replaced (hub heartbeat delivery, or by hand via the PVC overlay — **not** the ConfigMap). Rewrote the troubleshooting row that recommended it, and added rows for the CrashLoopBackOff signature and the new key-not-loadable banner.

## Tests

`v2/cmd/hive/githubauth_test.go` — the startup auth resolution is extracted into `initGitHubAuth` so the crashloop is reproducible from config alone rather than only in a live pod.

The regression test that matters is the jeejz case verbatim — placeholder `app_id` + real `installation_id` + a `key_file` with no PEM. **Booting is the assertion.** Also covered: the nine not-yet-detonated hives; real app + missing key (degrades, `KeyMissing`, message names path and order); real app + malformed key (`KeyInvalid`); real app + valid key still initializes App auth normally, so "never initialize App auth" cannot pass; token auth unaffected; placeholder alongside a real token (token wins); no credentials at all.

`v2/pkg/config/placeholder_appid_test.go` — table test across all five `app_id` shapes, plus one asserting the placeholder still satisfies `validate()`.

`go build`, `go vet`, and `go test` pass for `./cmd/hive/`, `./pkg/config/`, `./pkg/github/`, `./pkg/dashboard/`. Two failures in `./pkg/hub/` (`TestFailingCheckSummaryEscapes`, `TestFilterComposition`) are **pre-existing on a clean `origin/v2`** — verified in a separate worktree — and unrelated to these changes.

## One judgment call worth flagging

A hive with broken App credentials now **serves a degraded dashboard** rather than refusing to start. The alternative — keep exiting — is safer in the narrow sense that the hive cannot serve anything with stale or partial state, but it is what made this fault class undiagnosable: the only evidence lived in `kubectl logs` of a pod that no longer existed, and the hub could only report "offline".

The degraded hive holds a **nil** GitHub client, so it cannot perform *any* GitHub work — no reads, no writes, no agent activity. It is not operating with reduced credentials; it is operating with none, visibly, and saying so. I think that is clearly the right trade, but it is a behavior change and worth a second opinion.

## Porting

**This needs porting to `mk`, `dd`, and `v3`.** Four long-lived branches, and this is reliability- and security-relevant to all of them — `v3` especially, since that is what ks/console runs. The `pkg/github` nil-receiver guards and the `config.PlaceholderAppID` constant should port cleanly; the `main.go` changes will need the same conflict resolution against whatever each branch has of #2224's `AppAuthState`.
