### PR TITLE
✨ feat(hub): show the GitHub host as a pill in My Hives Location

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -1910,6 +1910,12 @@ func main() {
 				// SHA tag (which can never receive a rolling upgrade) from one
 				// riding <branch>-latest. Empty off-cluster — never guessed.
 				ImageRef:                hub.SelfDeploymentImage(),
+				// The GitHub instance this spoke actually runs against. Only
+				// the spoke knows this for certain: a hive's GitHub can differ
+				// from its cluster's default, so the hub cannot infer it.
+				// Reported as a bare hostname; empty base_url means public
+				// github.com, which githubHostLabel renders as such.
+				GitHubHost:              hub.GitHubHostLabel(cfg.GitHub.BaseURL),
 				GitHubAppRequired:       dashSrv.IsGitHubAppRequired(),
 				GitHubAppPermIssue:      dashSrv.GetGitHubAppPermIssue(),
 				GitHubAppState:          dashSrv.GetGitHubAppState(),

--- a/v2/pkg/hub/heartbeat.go
+++ b/v2/pkg/hub/heartbeat.go
@@ -254,7 +254,14 @@ type HeartbeatPayload struct {
 	// The hub cannot read this itself for firewalled spokes it reaches only by
 	// heartbeat, which is why it rides the payload. Empty when the spoke is
 	// not running in-cluster or the read failed — never a guess.
-	ImageRef           string `json:"image_ref,omitempty"`
+	ImageRef string `json:"image_ref,omitempty"`
+	// GitHubHost is the bare hostname of the GitHub instance this spoke is
+	// ACTUALLY configured against (github.com, github.ibm.com, …), derived
+	// from its own runtime github.base_url. This is the authoritative value:
+	// a hive's GitHub can differ from its cluster's default, so the cluster
+	// default is only ever a fallback for spokes too old to report this.
+	// Empty on such spokes — the hub falls back rather than guessing.
+	GitHubHost         string `json:"github_host,omitempty"`
 	Timestamp          string `json:"timestamp"`
 	GitHubAppRequired  bool   `json:"github_app_required,omitempty"`
 	GitHubAppPermIssue string `json:"github_app_perm_issue,omitempty"`

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -654,6 +654,12 @@ func githubHostLabel(baseURL string) string {
 	return strings.TrimRight(h, "/")
 }
 
+// GitHubHostLabel is the exported form of githubHostLabel, for the spoke to
+// normalize its own configured GitHub base URL before reporting it over the
+// heartbeat. Sharing one implementation keeps the value the spoke sends and
+// the value the hub renders from drifting into two different spellings.
+func GitHubHostLabel(baseURL string) string { return githubHostLabel(baseURL) }
+
 func (s *HubServer) handleListClusters(w http.ResponseWriter, r *http.Request) {
 	var entries []ClusterListEntry
 	for _, c := range s.clusters {
@@ -1537,6 +1543,7 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 	// Rule: take the meta level only for placeholders, or as a fallback when the
 	// live registry level is 0 (unknown) but meta has a real one. Otherwise the
 	// live registry level wins.
+
 	enrichFromSaaSMeta := func(entry *MyHiveEntry) {
 		sh := saasByID[entry.ID]
 		if sh == nil {
@@ -1578,6 +1585,43 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 			projectConfigForHiveID(entry.ID, entry.Org, entry.Repos, entry.PrimaryRepo, entry.ACMMLevel, entry.DashboardURL, "") != nil {
 			entry.Assigning = true
 			entry.AssigningTo = sh.Org
+		}
+	}
+
+	// resolveGitHubHost fills in the Location-column GitHub host pill when the
+	// spoke did not report one over the heartbeat.
+	//
+	// The spoke-reported value always wins: it is the hive's real runtime
+	// GitHub, and it is the only source that is correct when a hive's GitHub
+	// differs from its cluster's default (the enricom8 hive is the live
+	// example — its host had to be corrected by hand). Heartbeat-only and
+	// firewalled spokes upgrade slowly, so for those this falls back to the
+	// hive's recorded host, then its cluster's default. Anything still empty
+	// is left empty and rendered as "github.com" by the pill, so an old spoke
+	// shows a sane default rather than a wrong host.
+	resolveGitHubHost := func(entry *MyHiveEntry) {
+		if entry.GitHubHost != "" {
+			return // spoke-reported — authoritative
+		}
+		if sh := saasByID[entry.ID]; sh != nil {
+			if sh.GitHubHost != "" {
+				entry.GitHubHost = githubHostLabel(sh.GitHubHost)
+				return
+			}
+			if c := s.clusterForHive(sh); c != nil && c.GitHubBaseURL != "" {
+				entry.GitHubHost = githubHostLabel(c.GitHubBaseURL)
+				return
+			}
+		}
+		// No meta record: fall back to the cluster the registry entry reports.
+		// s.clusters is read unlocked here to match every other reader in this
+		// package (clusterForHive, clusterNameForID); it is effectively
+		// immutable after load, and taking s.mu here would nest inside callers
+		// that already hold it.
+		if entry.ClusterID != "" {
+			if c, ok := s.clusters[entry.ClusterID]; ok && c.GitHubBaseURL != "" {
+				entry.GitHubHost = githubHostLabel(c.GitHubBaseURL)
+			}
 		}
 	}
 
@@ -1699,6 +1743,10 @@ func (s *HubServer) handleMyHives(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(h.ID, "hosted-") || strings.HasPrefix(h.ID, "saas-") {
 			saasCount++
 		}
+		// Backfill the Location-column GitHub host for rows whose spoke is too
+		// old to report one. Done here, over the assembled set, so no entry
+		// construction site can be missed.
+		resolveGitHubHost(&result[i])
 		// Who-has-access is shown only to owners (and admin), matching
 		// handleAccessList's rule. A read/read-write member is deliberately not
 		// told who else shares the hive.
@@ -8073,7 +8121,12 @@ const dashboardHTML = `<!DOCTYPE html>
       if (!h) return '';
       var parts = [
         h.id, h.name, h.org, h.primaryRepo, h.clusterId, h.clusterName,
-        h.role, h.gitBranch, h.gitHash, h.dashboardUrl
+        h.role, h.gitBranch, h.gitHash, h.dashboardUrl,
+        /* The GitHub host is shown as a pill in the Location column, so it has
+           to be searchable too — "github.ibm.com" is how an admin narrows to
+           the GHE fleet. Absent means public GitHub, which is what the pill
+           renders, so search on that same default rather than nothing. */
+        h.githubHost || PAST_REQUESTS_DEFAULT_GITHUB_HOST
       ];
       (h.repos || []).forEach(function(r) { parts.push(r); });
       (h.access || []).forEach(function(a) {
@@ -8125,6 +8178,10 @@ const dashboardHTML = `<!DOCTYPE html>
     var FACET_ROLE = 'role';
     var FACET_STATUS = 'status';
     var FACET_BRANCH = 'branch';
+    /* GitHub instance the hive targets. Worth its own facet because the
+       GHE-vs-public split is a real operational boundary — a github.ibm.com
+       hive can only be reached from a cluster that can route to it. */
+    var FACET_GITHUB_HOST = 'github-host';
 
     /* Value shown when a hive has no value for a facet, so those rows stay
        reachable instead of silently dropping out of every facet count. */
@@ -8143,7 +8200,8 @@ const dashboardHTML = `<!DOCTYPE html>
       {key: FACET_ACMM, label: 'ACMM level'},
       {key: FACET_ROLE, label: 'Your role'},
       {key: FACET_STATUS, label: 'Status'},
-      {key: FACET_BRANCH, label: 'Branch'}
+      {key: FACET_BRANCH, label: 'Branch'},
+      {key: FACET_GITHUB_HOST, label: 'GitHub'}
     ];
 
     /* Selected facet values: {facetKey: {value: true}}. */
@@ -8257,6 +8315,10 @@ const dashboardHTML = `<!DOCTYPE html>
       f[FACET_ACMM] = (h.acmmLevel != null && h.acmmLevel !== '') ? ('L' + h.acmmLevel) : FACET_UNKNOWN;
       f[FACET_ROLE] = h.role || FACET_UNKNOWN;
       f[FACET_BRANCH] = h.gitBranch || FACET_UNKNOWN;
+      /* Absent host means public GitHub — bucket it under the same label the
+         pill renders, not FACET_UNKNOWN, so old spokes group with github.com
+         rather than forming a meaningless "—" bucket. */
+      f[FACET_GITHUB_HOST] = h.githubHost || PAST_REQUESTS_DEFAULT_GITHUB_HOST;
       var flags = hiveStatusFlags(h);
       f[FACET_STATUS] = flags.degraded ? 'Degraded' : (h.online ? 'Online' : 'Offline');
       return f;
@@ -9727,12 +9789,20 @@ const dashboardHTML = `<!DOCTYPE html>
           return pub ? '<span style="color:var(--green)">✓</span>' : '<span style="color:var(--muted)">—</span>';
         })();
         var locationBadge = isLocal ? '<span style="display:inline-block;padding:2px 8px;border-radius:9999px;font-size:0.65rem;font-weight:600;background:rgba(107,114,128,0.15);color:#9ca3af;border:1px solid rgba(107,114,128,0.3)">local</span>' : clusterBadge(h.clusterId, h.clusterName);
-        /* Location on top, visibility beneath — two stacked lines, matching the
-           three-line Version treatment. The owner toggle is a 36x20 switch and
-           keeps its own box on its own line, so it stays an easy tap target. */
+        /* Location on top, visibility beneath, GitHub host last — three stacked
+           lines, matching the three-line Version treatment. The owner toggle is
+           a 36x20 switch and keeps its own box on its own line, so it stays an
+           easy tap target.
+
+           The host line reuses githubHostPill — the same helper the pending
+           action cards and the Past Requests table use — so a GHE hive reads
+           identically wherever it appears. An absent host renders as
+           "github.com" rather than a blank chip, which is what an old
+           heartbeat-only spoke that cannot yet report its host should show. */
         var locationCell = '<div style="' + STACKED_CELL_STYLE + '">' +
           '<div style="' + STACKED_LINE_STYLE + '">' + locationBadge + '</div>' +
           '<div style="' + STACKED_LINE_STYLE + ';font-size:0.7rem">' + visibilityCell + '</div>' +
+          '<div style="' + STACKED_LINE_STYLE + '" title="GitHub instance this hive targets">' + githubHostPill(h.githubHost) + '</div>' +
           '</div>';
         var pendingExpandRow = '';
         if (h.pendingRequestCount > 0 && (h.role === 'owner' || h.role === 'read-write') && (h.pending_requests || []).length > 0) {

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -104,7 +104,18 @@ type RegistryEntry struct {
 	// upgrade — from one riding <branch>-latest. Empty on spokes that are not
 	// in-cluster or predate this field; drift detection skips the signal
 	// rather than guessing.
-	ImageRef                  string             `json:"imageRef,omitempty"`
+	ImageRef string `json:"imageRef,omitempty"`
+	// GitHubHost is the bare hostname of the GitHub instance this hive targets
+	// ("github.com", "github.ibm.com", …), rendered as a pill in the My Hives
+	// Location column. Resolution order, most to least authoritative:
+	//   1. the spoke's own reported runtime github.base_url (heartbeat), which
+	//      is the only source that is right when a hive's GitHub differs from
+	//      its cluster's default;
+	//   2. the hive's recorded SaaSHive.GitHubHost / its cluster default, for
+	//      spokes too old to report it;
+	//   3. "github.com" at render time, so a chip is never blank.
+	// Empty here means "not reported" — resolved on read, never guessed.
+	GitHubHost                string             `json:"githubHost,omitempty"`
 	Agents                    []AgentSummary     `json:"agents,omitempty"`
 	Leaderboard               []LeaderboardEntry `json:"leaderboard,omitempty"`
 	Online                    bool               `json:"online"`
@@ -729,6 +740,17 @@ func (s *HubServer) handleHeartbeat(w http.ResponseWriter, r *http.Request) {
 		GitHash:       shortSHA(sanitizeHeartbeatField(payload.GitHash)),
 		GitBranch:     sanitizeHeartbeatField(payload.GitBranch),
 		ImageRef:      sanitizeImageRef(payload.ImageRef),
+		// Normalize through githubHostLabel so "https://github.ibm.com/" and
+		// "github.ibm.com" persist identically, then sanitize as a hostname.
+		// A spoke that does not report the field leaves this empty rather
+		// than recording a fabricated "github.com" — empty is what lets the
+		// read path fall back to the hive's recorded/cluster host instead.
+		GitHubHost: func() string {
+			if strings.TrimSpace(payload.GitHubHost) == "" {
+				return ""
+			}
+			return sanitizeHeartbeatField(githubHostLabel(payload.GitHubHost))
+		}(),
 		Agents: func() []AgentSummary {
 			for i := range payload.Agents {
 				payload.Agents[i].Name = sanitizeHeartbeatField(payload.Agents[i].Name)


### PR DESCRIPTION
## What

Adds a GitHub-host pill (`github.com`, `github.ibm.com`, …) as a third stacked line in the **Location / Public** column of the hub's My Hives table.

## Why the data had to be plumbed

The pill looks like a one-line render change, but the value did not exist. A registry entry had **no** GitHub host field, and `ClusterListEntry.GitHubHost` is only the cluster **default** — which is not sufficient, because a hive's actual GitHub can differ from its cluster's default. The `enricom8` hive is the live example: its org/host had to be corrected by hand. Rendering the cluster default alone would have shown the **wrong** host for exactly the hives this pill is meant to disambiguate.

So the real per-hive value is plumbed from the spoke, which is the only component that knows it for certain.

## Resolution order

Most to least authoritative:

1. **Spoke-reported** runtime `github.base_url`, over the heartbeat — correct even when a hive's GitHub differs from its cluster default.
2. **Recorded / cluster default** — the hive's `SaaSHive.GitHubHost`, then its cluster's `GitHubBaseURL`, for spokes too old to report it.
3. **`github.com`** at render time, so a chip is never blank.

## Backward compatibility

Heartbeat-only and firewalled spokes (e.g. `vllm-d`) cannot be reached by kubectl and upgrade slowly. They simply do not send the new field, and the hub records **empty** rather than a fabricated default — which is precisely what lets the read path fall back instead of asserting a wrong host. Old spokes therefore keep working and never display an incorrect GitHub.

## Reuse, not duplication

The render path calls the **existing** `githubHostPill` helper — the same one the pending action cards and the Past Requests table use, exactly as its doc comment intends ("so the same concept does not drift into two different styles"). It is already a top-level sibling of the render site in the same script scope, so **no hoisting or copy was needed**; there is still exactly one definition.

On the Go side, `githubHostLabel` normalization is shared with the spoke through a thin exported `GitHubHostLabel` wrapper, so both ends spell the host identically (`https://github.ibm.com/` and `github.ibm.com` persist the same).

## Also included

- **Searchable** — the host joins the My Hives search blob, so `github.ibm.com` narrows to the GHE fleet.
- **New "GitHub" facet group** in the faceted-search tray. The facet system is fully data-driven, so this was two lines. Absent hosts bucket under `github.com` rather than a meaningless `—`.

## Column count

`TOTAL_COLUMNS` / `TOTAL_COLUMNS_HEADER` are **deliberately untouched, and verified unchanged** — this adds a line *inside* an existing cell, not a new column. Confirmed the diff adds zero `<td>`.

## Verification

- `go build ./...` and `go vet ./...` clean.
- `pkg/config` and `pkg/dashboard` tests pass.
- `pkg/hub`: 4 tests fail — `TestFailingCheckSummaryEscapes`, `TestFilterComposition`, `TestHiveTableColumnCountUnchanged`, `TestHiveTableColumnCountsAgree`. **All four reproduce identically on a clean `origin/v2` with none of these changes applied** (the last two expect `TOTAL_COLUMNS = 16`, which #2224 changed to 17). Pre-existing, not introduced here.
- Raw-string safety: the dashboard is an inline Go raw-string, so verified **no backtick** and **no literal `<body>`** was introduced inside it, and that it still contains exactly one `<body>` and one `githubHostPill` definition.
- Beyond `node --check`, the full dashboard script was **evaluated in a stubbed-DOM sandbox** and the new code exercised directly:
  - `githubHostPill('github.ibm.com')` → accent-styled `github.ibm.com`
  - `githubHostPill(undefined)` → muted **`github.com`** (never a blank chip)
  - facet bucket → `github.ibm.com` / `github.com`
  - search text → includes the host, defaulting to `github.com`

  This also empirically rules out a hoisting/TDZ problem, since the helper and the `var` default are both declared *after* their use sites.

## Ports

⚠️ This needs porting to **mk**, **dd**, and **v3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)