### PR TITLE
✨ feat(auth): always use github.com for device-flow login (OAuth/App host split)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -448,7 +448,9 @@ func main() {
 	if tokenData, err := os.ReadFile("/data/gh-user-token"); err == nil {
 		userToken := strings.TrimSpace(string(tokenData))
 		if userToken != "" {
-			if username, err := github.ValidateToken(userToken, cfg.GitHub.ResolvedAPIURL()); err == nil {
+			// Identity check goes to github.com (the user token is a github.com
+			// OAuth token); the repo client stays on the per-hive host.
+			if username, err := github.ValidateToken(userToken, cfg.GitHub.OAuthAPIURL()); err == nil {
 				uc := github.NewClient(userToken, cfg.Project.Org, cfg.Project.Repos, logger, cfg.GitHub.ResolvedAPIURL())
 				userGHClient.Store(uc)
 				logger.Info("user GitHub token loaded for advisory posting", "username", username)
@@ -2019,7 +2021,9 @@ func main() {
 					if td, err := os.ReadFile("/data/gh-user-token"); err == nil {
 						tok := strings.TrimSpace(string(td))
 						if tok != "" {
-							if u, err := github.ValidateToken(tok, cfg.GitHub.ResolvedAPIURL()); err == nil {
+							// gh-user-token is a github.com OAuth token — validate its
+							// identity against github.com, not the (possibly GHE) repo host.
+							if u, err := github.ValidateToken(tok, cfg.GitHub.OAuthAPIURL()); err == nil {
 								return u.Login
 							}
 						}

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1120,6 +1120,11 @@ const (
 	DefaultGitHubBaseURL = "https://github.com"
 	// DefaultGitHubAppSlug is the public Hive GitHub App slug.
 	DefaultGitHubAppSlug = "kubestellar-hive"
+	// DefaultOAuthClientID is the PUBLIC github.com Hive App client ID used for
+	// device-flow login. Login is always github.com (see OAuthBaseURL), so this
+	// is the correct client for every hive — including GHE hives, whose users
+	// still sign in with a github.com identity. No secret; safe to hardcode.
+	DefaultOAuthClientID = "Ov23ligE2p0gjXg6xAUf"
 )
 
 // IsPlaceholderApp reports whether app_id is the "no real App yet" sentinel.
@@ -1165,6 +1170,33 @@ func (g GitHubConfig) ResolvedBaseURL() string {
 // IsGHE returns true if the configured base URL points to a GitHub Enterprise instance.
 func (g GitHubConfig) IsGHE() bool {
 	return g.BaseURL != "" && g.BaseURL != DefaultGitHubBaseURL
+}
+
+// OAuthBaseURL and OAuthAPIURL are the hosts used for DEVICE-FLOW LOGIN and
+// user-identity token validation. They are ALWAYS public github.com, decoupled
+// from the App/repo host (ResolvedBaseURL/ResolvedAPIURL, which may be GHE).
+//
+// Why the split: the Hive login OAuth app (oauth_client_id, default the public
+// "Ov23ligE2p0gjXg6xAUf") is a github.com app, and every user signs in with a
+// github.com identity — even on a hive whose REPOS and GitHub App live on GHE.
+// Pointing the device-flow endpoints at a GHE host (as ResolvedBaseURL does for
+// a GHE hive) makes GitHub return "Not Found" and the dashboard shows "could not
+// verify GitHub identity". Login must therefore use these fixed public hosts;
+// only the App-token / repo-API paths follow the per-hive (possibly GHE) host.
+func (g GitHubConfig) OAuthBaseURL() string { return DefaultGitHubBaseURL }
+func (g GitHubConfig) OAuthAPIURL() string  { return DefaultGitHubAPIURL }
+
+// OAuthClientIDResolved returns the client ID for device-flow login: the
+// configured oauth_client_id, or the public github.com default. Because login
+// is always github.com, the default is correct for every hive — a GHE hive must
+// not fall back to a GHE client ID here, or device flow against github.com fails
+// with an unknown-client error. A hive that has explicitly set oauth_client_id
+// to a github.com app keeps that; the default only fills a blank.
+func (g GitHubConfig) OAuthClientIDResolved() string {
+	if g.OAuthClientID != "" {
+		return g.OAuthClientID
+	}
+	return DefaultOAuthClientID
 }
 
 // ResolvedAppSlug returns the configured app slug or the default public Hive app slug.

--- a/v2/pkg/config/config_extra_test.go
+++ b/v2/pkg/config/config_extra_test.go
@@ -654,6 +654,36 @@ func TestResolvedBaseURL_Custom(t *testing.T) {
 	}
 }
 
+// OAuth login hosts are ALWAYS public github.com, even when the App/repo host is
+// GHE — this is the split that keeps device-flow login working on GHE hives.
+func TestOAuthURLs_AlwaysPublic_EvenOnGHE(t *testing.T) {
+	ghe := GitHubConfig{
+		APIURL:        "https://github.ibm.com/api/v3",
+		BaseURL:       "https://github.ibm.com",
+		OAuthClientID: "", // blank must fall back to the public github.com client
+	}
+	if got := ghe.OAuthAPIURL(); got != DefaultGitHubAPIURL {
+		t.Errorf("OAuthAPIURL() on GHE hive = %q, want github.com %q", got, DefaultGitHubAPIURL)
+	}
+	if got := ghe.OAuthBaseURL(); got != DefaultGitHubBaseURL {
+		t.Errorf("OAuthBaseURL() on GHE hive = %q, want github.com %q", got, DefaultGitHubBaseURL)
+	}
+	if got := ghe.OAuthClientIDResolved(); got != DefaultOAuthClientID {
+		t.Errorf("OAuthClientIDResolved() blank on GHE = %q, want public %q", got, DefaultOAuthClientID)
+	}
+	// Meanwhile the App/repo host must STILL be GHE — the split does not touch it.
+	if got := ghe.ResolvedAPIURL(); got != "https://github.ibm.com/api/v3" {
+		t.Errorf("ResolvedAPIURL() (App host) = %q, want GHE preserved", got)
+	}
+}
+
+func TestOAuthClientIDResolved_ConfiguredWins(t *testing.T) {
+	g := GitHubConfig{OAuthClientID: "Ov23liCUSTOM"}
+	if got := g.OAuthClientIDResolved(); got != "Ov23liCUSTOM" {
+		t.Errorf("OAuthClientIDResolved() = %q, want the configured value", got)
+	}
+}
+
 func TestRemoveAgentFile_PathTraversal(t *testing.T) {
 	dir := t.TempDir()
 	for _, bad := range []string{"../etc/passwd", "sub/agent", "back\\slash"} {

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -1343,7 +1343,7 @@ func (s *Server) handleGHUserAuthStatus(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	token := strings.TrimSpace(string(tokenData))
-	user, err := github.ValidateToken(token, s.deps.Config.GitHub.ResolvedAPIURL())
+	user, err := github.ValidateToken(token, s.deps.Config.GitHub.OAuthAPIURL())
 	if err != nil {
 		jsonResponse(w, map[string]interface{}{"logged_in": false, "error": "token expired or revoked"})
 		return
@@ -1352,16 +1352,15 @@ func (s *Server) handleGHUserAuthStatus(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) handleGHUserAuthStart(w http.ResponseWriter, r *http.Request) {
-	clientID := s.deps.Config.GitHub.OAuthClientID
-	if clientID == "" {
-		jsonError(w, "oauth_client_id not configured. Add 'oauth_client_id: Ov23ligE2p0gjXg6xAUf' to the github section of hive.yaml and restart the container. This is the public Hive GitHub App client ID used for the Device Flow login — no secret required.", http.StatusBadRequest)
-		return
-	}
+	// Always resolves to a github.com client ID (configured or the public
+	// default) — login is github.com even on GHE hives, so this never fails for
+	// a blank oauth_client_id and never uses a GHE client.
+	clientID := s.deps.Config.GitHub.OAuthClientIDResolved()
 
 	s.deviceFlowMu.Lock()
 	defer s.deviceFlowMu.Unlock()
 
-	state, err := github.StartDeviceFlow(clientID, s.deps.Config.GitHub.ResolvedBaseURL(), s.deps.Config.GitHub.ResolvedAPIURL())
+	state, err := github.StartDeviceFlow(clientID, s.deps.Config.GitHub.OAuthBaseURL(), s.deps.Config.GitHub.OAuthAPIURL())
 	if err != nil {
 		jsonError(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -1385,8 +1384,8 @@ func (s *Server) handleGHUserAuthPoll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clientID := s.deps.Config.GitHub.OAuthClientID
-	token, status, err := github.PollDeviceFlow(clientID, s.deviceFlowState.DeviceCode, s.deps.Config.GitHub.ResolvedBaseURL(), s.deps.Config.GitHub.ResolvedAPIURL())
+	clientID := s.deps.Config.GitHub.OAuthClientIDResolved()
+	token, status, err := github.PollDeviceFlow(clientID, s.deviceFlowState.DeviceCode, s.deps.Config.GitHub.OAuthBaseURL(), s.deps.Config.GitHub.OAuthAPIURL())
 	if err != nil {
 		s.deviceFlowState = nil
 		jsonResponse(w, map[string]interface{}{"status": "error", "error": err.Error()})
@@ -1405,7 +1404,7 @@ func (s *Server) handleGHUserAuthPoll(w http.ResponseWriter, r *http.Request) {
 	// user's token must never be written to disk or wired in as the hive's user
 	// client — otherwise a rejected login would still leak its token into the
 	// shared client and become the hive's identity.
-	user, err := github.ValidateToken(token, s.deps.Config.GitHub.ResolvedAPIURL())
+	user, err := github.ValidateToken(token, s.deps.Config.GitHub.OAuthAPIURL())
 	if err != nil || user == nil || user.Login == "" {
 		s.deviceFlowState = nil
 		// Audit the failed login so the owner can see attempts that never got
@@ -1619,7 +1618,7 @@ func (s *Server) restoreGHUserSession() {
 		return
 	}
 
-	user, err := github.ValidateToken(token, s.deps.Config.GitHub.ResolvedAPIURL())
+	user, err := github.ValidateToken(token, s.deps.Config.GitHub.OAuthAPIURL())
 	if err != nil {
 		s.deps.Logger.Warn("saved GitHub user token is invalid, removing", "error", err)
 		os.Remove(userTokenPath)

--- a/v2/pkg/dashboard/api_contribute.go
+++ b/v2/pkg/dashboard/api_contribute.go
@@ -626,7 +626,7 @@ func (s *Server) handleContributeReissueToken(w http.ResponseWriter, r *http.Req
 		token = ""
 	}
 
-	username := validateGitHubToken(token, s.deps.Config.GitHub.ResolvedAPIURL())
+	username := validateGitHubToken(token, s.deps.Config.GitHub.OAuthAPIURL())
 	if username == "" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
@@ -1845,7 +1845,7 @@ func (s *Server) handleAPIv1(w http.ResponseWriter, r *http.Request) {
 		token = r.URL.Query().Get("token")
 	}
 
-	username := validateGitHubToken(token, s.deps.Config.GitHub.ResolvedAPIURL())
+	username := validateGitHubToken(token, s.deps.Config.GitHub.OAuthAPIURL())
 	if username == "" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)


### PR DESCRIPTION
## Summary

Splits the GitHub host used for **login** from the host used for the **App / repo API**. Device-flow login + user-identity validation now **always target public github.com**, independent of `ResolvedBaseURL`/`ResolvedAPIURL` (which stay per-hive and may be GitHub Enterprise).

## The bug this fixes (live, urgent)

A GHE-placed hive inherits `api_url: https://github.ibm.com/api/v3`. Device flow was using that host → GitHub returns **Not Found** → dashboard shows **"could not verify GitHub identity."** Users on those hives cannot log in. Daniel Waddington hit this; a sweep found several GHE-placed hives (`hosted-available-vllmd-*`, osscar) in the same state — they'd all break device-flow login when users return.

## The fix

- New `GitHubConfig.OAuthBaseURL()` / `OAuthAPIURL()` → **always** `github.com` / `api.github.com`.
- New `OAuthClientIDResolved()` → configured `oauth_client_id` or the public github.com default (`Ov23ligE2p0gjXg6xAUf`); a GHE hive never falls back to a GHE client, and the device-flow handler no longer hard-fails on a blank value.
- Login/identity call sites use the OAuth hosts: device-flow start/poll, `ValidateToken` (login + saved user token), `validateGitHubToken` (contributor), `gh-user-token` identity lookups.
- **Unchanged (per-hive, GHE preserved):** `NewAppAuth` (App-token mint), `NewClient` (repo API), heartbeat `GitHubAPIURL`, `AppInstallURL`. A GHE hive keeps its GHE App; only login moves to github.com.

## Blast radius

For a **github.com hive**, OAuth* == Resolved* — no behavior change. For a **GHE hive**, login moves to github.com (the fix) while the App/repo host stays GHE. This is the intended OAuth/App decoupling.

## Tests
`TestOAuthURLs_AlwaysPublic_EvenOnGHE` — on a GHE-configured hive, OAuth hosts are github.com while `ResolvedAPIURL` stays GHE. `TestOAuthClientIDResolved_ConfiguredWins`.

## Note
Follow-up (not in this PR): repo-host consistency invariant (reject mixed github.com/github.ibm.com repos in one spoke, keyed off the primary repo) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)