### PR TITLE
🐛 fix(bob): relaunch agents parked for a missing API key when the key is saved

### DIFF
--- a/v2/pkg/agent/bob_key_relaunch_test.go
+++ b/v2/pkg/agent/bob_key_relaunch_test.go
@@ -1,0 +1,339 @@
+package agent
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kubestellar/hive/v2/pkg/config"
+)
+
+// newRelaunchManager builds a bare Manager with the given agents registered.
+// It deliberately does not touch tmux: these tests cover the selection rules
+// and the key gate, which is where the risk lives.
+func newRelaunchManager(agents map[string]*AgentProcess) *Manager {
+	m := &Manager{
+		agents:   make(map[string]*AgentProcess),
+		idToName: make(map[string]string),
+		logger:   discardLogger(),
+	}
+	for name, a := range agents {
+		a.Name = name
+		m.agents[name] = a
+	}
+	return m
+}
+
+// parkedBobAgent returns an agent in exactly the state launchInTmux leaves a
+// bob agent in when no API key is configured.
+func parkedBobAgent() *AgentProcess {
+	return &AgentProcess{
+		Config:         config.AgentConfig{Backend: bobBackend},
+		State:          StateFailed,
+		awaitingBobKey: true,
+	}
+}
+
+// TestLaunchParksBobAgentAwaitingKey pins the marker half of the fix: the
+// missing-key branch must set awaitingBobKey, because StateFailed alone is
+// ambiguous (missing binary, copilot auth timeout, hung diagnostic).
+func TestLaunchParksBobAgentAwaitingKey(t *testing.T) {
+	m := &Manager{logger: discardLogger()}
+	m.SetBobAPIKeyResolver(func() string { return "" })
+
+	agent := &AgentProcess{
+		Name:   "scanner",
+		Config: config.AgentConfig{Backend: bobBackend},
+	}
+	// launchInTmux bails on the key check before any tmux work when the
+	// backend binary resolves; if bob is absent it bails even earlier, in
+	// which case the marker must stay false rather than be wrongly set.
+	if _, err := backendBinary(bobBackend); err != nil {
+		t.Skipf("bob binary not present in this environment: %v", err)
+	}
+	if err := m.launchInTmux(context.Background(), agent); err != nil {
+		t.Fatalf("launchInTmux returned error, want nil so one agent never aborts the fleet: %v", err)
+	}
+	if agent.State != StateFailed {
+		t.Errorf("State = %q, want %q", agent.State, StateFailed)
+	}
+	if !agent.awaitingBobKey {
+		t.Error("awaitingBobKey = false, want true — the key-save relaunch cannot find this agent without the marker")
+	}
+}
+
+// TestBobAgentsAwaitingKeySelection is the core of the change: exactly the
+// agents parked for a missing key are eligible, and nothing else ever is.
+func TestBobAgentsAwaitingKeySelection(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent *AgentProcess
+		want  bool
+	}{
+		{
+			name:  "bob parked for missing key is selected",
+			agent: parkedBobAgent(),
+			want:  true,
+		},
+		{
+			name: "healthy running bob agent is not disturbed",
+			agent: &AgentProcess{
+				Config: config.AgentConfig{Backend: bobBackend},
+				State:  StateRunning,
+			},
+			want: false,
+		},
+		{
+			name: "running bob agent with a stale marker is still not disturbed",
+			agent: &AgentProcess{
+				Config:         config.AgentConfig{Backend: bobBackend},
+				State:          StateRunning,
+				awaitingBobKey: true,
+			},
+			want: false,
+		},
+		{
+			name: "operator-paused bob agent is not resumed by a key save",
+			agent: &AgentProcess{
+				Config:         config.AgentConfig{Backend: bobBackend, Paused: true},
+				State:          StatePaused,
+				Paused:         true,
+				PausedTrigger:  "dashboard-api",
+				awaitingBobKey: true,
+			},
+			want: false,
+		},
+		{
+			name: "claude agent is never touched",
+			agent: &AgentProcess{
+				Config: config.AgentConfig{Backend: "claude"},
+				State:  StateFailed,
+			},
+			want: false,
+		},
+		{
+			name: "failed claude agent with a spurious marker is rejected by the backend check",
+			agent: &AgentProcess{
+				Config:         config.AgentConfig{Backend: "claude"},
+				State:          StateFailed,
+				awaitingBobKey: true,
+			},
+			want: false,
+		},
+		{
+			name: "bob agent failed for another reason is not selected",
+			agent: &AgentProcess{
+				Config:    config.AgentConfig{Backend: bobBackend},
+				State:     StateFailed,
+				LastError: "backend binary not found",
+			},
+			want: false,
+		},
+		{
+			name: "agent overridden away from bob after parking is rejected",
+			agent: &AgentProcess{
+				Config:          config.AgentConfig{Backend: bobBackend},
+				BackendOverride: "claude",
+				State:           StateFailed,
+				awaitingBobKey:  true,
+			},
+			want: false,
+		},
+		{
+			name: "agent overridden TO bob and parked is selected",
+			agent: &AgentProcess{
+				Config:          config.AgentConfig{Backend: "claude"},
+				BackendOverride: bobBackend,
+				State:           StateFailed,
+				awaitingBobKey:  true,
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newRelaunchManager(map[string]*AgentProcess{"subject": tc.agent})
+			got := m.bobAgentsAwaitingKey()
+			if tc.want && len(got) != 1 {
+				t.Fatalf("bobAgentsAwaitingKey() = %v, want [subject]", got)
+			}
+			if !tc.want && len(got) != 0 {
+				t.Fatalf("bobAgentsAwaitingKey() = %v, want no candidates", got)
+			}
+		})
+	}
+}
+
+// TestRelaunchBobAgentsAwaitingKeyRequiresResolvedKey covers the clear path and
+// the not-yet-configured path: with no key, relaunching would just re-park
+// every agent on the same branch, so it must be a no-op.
+func TestRelaunchBobAgentsAwaitingKeyRequiresResolvedKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		inject  bool
+		key     string
+		wantNil bool
+	}{
+		{name: "no resolver injected", inject: false, wantNil: true},
+		{name: "key cleared", inject: true, key: "", wantNil: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newRelaunchManager(map[string]*AgentProcess{"scanner": parkedBobAgent()})
+			if tc.inject {
+				key := tc.key
+				m.SetBobAPIKeyResolver(func() string { return key })
+			}
+			if got := m.RelaunchBobAgentsAwaitingKey(context.Background()); len(got) != 0 {
+				t.Errorf("RelaunchBobAgentsAwaitingKey() = %v, want none — clearing a key must never launch anything", got)
+			}
+			// The agent must remain parked and eligible for a later real save.
+			if !m.agents["scanner"].awaitingBobKey {
+				t.Error("awaitingBobKey was cleared without a launch; a later key save would miss this agent")
+			}
+		})
+	}
+}
+
+// TestRelaunchIsIdempotentOnDoubleSave pins that saving a key twice cannot
+// double-launch. The first pass clears the marker (launchInTmux does this on
+// every launch attempt), so the second pass finds no candidates.
+func TestRelaunchIsIdempotentOnDoubleSave(t *testing.T) {
+	agent := parkedBobAgent()
+	m := newRelaunchManager(map[string]*AgentProcess{"scanner": agent})
+	m.SetBobAPIKeyResolver(func() string { return "bob-key-abc" })
+
+	if got := m.bobAgentsAwaitingKey(); len(got) != 1 {
+		t.Fatalf("first save: got %v candidates, want 1", got)
+	}
+
+	// Simulate what launchInTmux does at the top of every launch attempt.
+	agent.awaitingBobKey = false
+	agent.State = StateRunning
+
+	if got := m.bobAgentsAwaitingKey(); len(got) != 0 {
+		t.Errorf("second save: got %v, want none — a double save must not double-launch", got)
+	}
+}
+
+// TestRelaunchNoDeadlockUnderConcurrency exercises the lock discipline that
+// incident #1980→#1988 turned into a hard rule: m.mu is a NON-reentrant
+// RWMutex, and Start takes m.mu.Lock() itself, so candidate collection must
+// release the read lock before any launch. This test hammers the selection
+// path against concurrent writers holding the write lock; a re-entrant
+// acquisition anywhere in the path hangs here instead of in production.
+func TestRelaunchNoDeadlockUnderConcurrency(t *testing.T) {
+	const (
+		// concurrentWorkers is the number of goroutines per role (readers and
+		// writers). Enough to interleave lock acquisitions reliably without
+		// making the test slow.
+		concurrentWorkers = 8
+		// iterationsPerWorker is how many times each goroutine takes the lock.
+		iterationsPerWorker = 50
+		// deadlockTimeout bounds the run. The contended work below finishes in
+		// milliseconds, so anything approaching this means the lock is held,
+		// not that the machine is slow.
+		deadlockTimeout = 30 * time.Second
+	)
+
+	agents := map[string]*AgentProcess{
+		"parked":  parkedBobAgent(),
+		"running": {Config: config.AgentConfig{Backend: bobBackend}, State: StateRunning},
+		"claude":  {Config: config.AgentConfig{Backend: "claude"}, State: StateFailed},
+	}
+	m := newRelaunchManager(agents)
+	m.SetBobAPIKeyResolver(func() string { return "bob-key-abc" })
+
+	var wg sync.WaitGroup
+	for i := 0; i < concurrentWorkers; i++ {
+		wg.Add(2)
+		// Reader: the selection path under test.
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterationsPerWorker; j++ {
+				m.bobAgentsAwaitingKey()
+			}
+		}()
+		// Writer: contends for the write lock the way Start/Pause do.
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterationsPerWorker; j++ {
+				m.mu.Lock()
+				m.agents["running"].RestartCount++
+				m.mu.Unlock()
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(deadlockTimeout):
+		t.Fatal("deadlock: selection path did not complete under lock contention")
+	}
+}
+
+// TestKillSessionForRelaunchClearsRunningState pins the reason the relaunch
+// recreates the tmux session instead of just re-typing the launch command.
+//
+// BOBSHELL_API_KEY is Secret, so buildEnvPrefix omits it from the typed command
+// line and tmux set-environment is its only delivery path — and that is
+// inherited only by shells created afterwards. The pane's bash predates the
+// key, and reapAgentCLI kills the bob CLI but not that bash, so relaunching
+// into the same session hands bob a shell with no key (verified live on
+// hosted-available-vllmd-01: key present in the tmux session env, absent from
+// every bob /proc/<pid>/environ).
+//
+// The state reset matters too: Start refuses to launch an agent it thinks is
+// running, so leaving StateRunning after killing its session would make the
+// relaunch a silent no-op.
+func TestKillSessionForRelaunchClearsRunningState(t *testing.T) {
+	tests := []struct {
+		name  string
+		state ProcessState
+		want  ProcessState
+	}{
+		{name: "running is reset so Start will relaunch", state: StateRunning, want: StateStopped},
+		{name: "failed is left alone", state: StateFailed, want: StateFailed},
+		{name: "stopped is left alone", state: StateStopped, want: StateStopped},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			agent := parkedBobAgent()
+			agent.State = tc.state
+			// No tmuxSession set: tmuxCmd runs a kill-session that simply
+			// fails, which the helper ignores by design ("already gone" is a
+			// satisfied precondition, not an error).
+			m := newRelaunchManager(map[string]*AgentProcess{"scanner": agent})
+			if err := m.killSessionForRelaunch("scanner"); err != nil {
+				t.Fatalf("killSessionForRelaunch() error = %v, want nil", err)
+			}
+			if agent.State != tc.want {
+				t.Errorf("State = %q, want %q", agent.State, tc.want)
+			}
+		})
+	}
+}
+
+// TestKillSessionForRelaunchUnknownAgent ensures a vanished agent surfaces an
+// error rather than panicking the key-save request.
+func TestKillSessionForRelaunchUnknownAgent(t *testing.T) {
+	m := newRelaunchManager(nil)
+	if err := m.killSessionForRelaunch("ghost"); err == nil {
+		t.Error("killSessionForRelaunch() on an unknown agent = nil, want an error")
+	}
+}
+
+// TestRelaunchHandlesEmptyFleet guards the nil/empty cases the dashboard can
+// hit before any agent is registered.
+func TestRelaunchHandlesEmptyFleet(t *testing.T) {
+	m := newRelaunchManager(nil)
+	m.SetBobAPIKeyResolver(func() string { return "bob-key-abc" })
+	if got := m.RelaunchBobAgentsAwaitingKey(context.Background()); len(got) != 0 {
+		t.Errorf("RelaunchBobAgentsAwaitingKey() on empty fleet = %v, want none", got)
+	}
+}

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -93,6 +93,15 @@ type AgentProcess struct {
 	lastInferKickMarks  int       // no-action watchdog: tool-marker count in pane+scrollback just after kick delivery
 	actionNudgeSent     bool      // no-action watchdog: at most one action nudge per kick
 	ActionNudges        int       // total prose-only-response action nudges sent (surfaced to the dashboard)
+
+	// awaitingBobKey marks an agent that launchInTmux parked in StateFailed
+	// for the single, fully-recoverable reason "bob backend with no API key".
+	// It is what makes RelaunchBobAgentsAwaitingKey precise: StateFailed alone
+	// is ambiguous (a missing backend binary, a copilot auth timeout, and a
+	// hung diagnostic all land there too), and relaunching those on a bob-key
+	// save would restart agents whose problem the key does not fix.
+	// Set only on the missing-key branch, cleared on every launch attempt.
+	awaitingBobKey bool
 }
 
 // effectiveBackend returns the agent's backend accounting for any override.
@@ -838,9 +847,16 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 	// return nil so one misconfigured agent never aborts the fleet.
 	// The key VALUE is not bound to a local here — only its presence is checked.
 	// It is delivered to the CLI via tmux set-environment in agentEnvPairs.
+	// Any launch attempt supersedes a previous missing-key parking: either the
+	// key is present now (cleared below) or we re-park on this same branch.
+	// Clearing unconditionally keeps the flag from outliving the condition it
+	// describes — a stale true would make a later key-save relaunch an agent
+	// that is actually failed for some other reason.
+	agent.awaitingBobKey = false
 	if backend == bobBackend {
 		if m.bobAPIKey() == "" {
 			agent.State = StateFailed
+			agent.awaitingBobKey = true
 			m.logger.Warn("bob requires "+config.BobAPIKeyEnvVar+" for headless operation; ask your hub admin to configure it",
 				"name", agent.Name,
 				"backend", backend,
@@ -2129,6 +2145,139 @@ func (m *Manager) CheckAndRestartCrashedAgents(ctx context.Context) []string {
 		}
 	}
 	return restarted
+}
+
+// RelaunchBobAgentsAwaitingKey restarts the bob-backend agents that
+// launchInTmux parked in StateFailed because no API key was configured, and
+// returns their names. It is the "absent → present" half of the key lifecycle:
+// the resolver makes a newly-saved key visible to the NEXT launch, but nothing
+// carries it into a session whose shell already exists, so an agent parked for
+// a missing key would otherwise sit at bob's key prompt until someone
+// intervened.
+//
+// Each relaunch RECREATES the tmux session rather than just re-typing the
+// launch command — see killSessionForRelaunch for why that is required and not
+// merely tidy.
+//
+// Call it after a key is stored. It is a no-op — returning nil — when the key
+// still does not resolve, so a clear (or a failed save) never launches
+// anything.
+//
+// Selection is deliberately narrow: awaitingBobKey is set on exactly one
+// branch of launchInTmux and cleared on every launch attempt, so a running
+// agent, a non-bob agent, and an agent failed for any other reason are all
+// skipped. An operator-paused agent is skipped too — a key save must not
+// override a deliberate pause. That also makes a double save harmless: the
+// first relaunch clears the flag, so the second finds nothing to do.
+//
+// Locking: candidates are collected under RLock, the lock is RELEASED, and
+// only then is Start called — Start takes m.mu.Lock() itself, and m.mu is a
+// non-reentrant RWMutex, so calling it under the read lock would deadlock
+// (incident #1980→#1988). This mirrors CheckAndRestartCrashedAgents.
+func (m *Manager) RelaunchBobAgentsAwaitingKey(ctx context.Context) []string {
+	// The key must actually resolve now; otherwise every relaunch would just
+	// re-park on the same branch. Read lock-free via the atomic resolver, and
+	// never bind or log the value — only its presence matters here.
+	if m.bobAPIKey() == "" {
+		return nil
+	}
+
+	candidates := m.bobAgentsAwaitingKey()
+
+	var relaunched []string
+	for _, name := range candidates {
+		m.logger.Info("relaunching bob agent parked for missing API key", "name", name)
+		// Kill the stale tmux session FIRST. This is load-bearing, not
+		// hygiene: BOBSHELL_API_KEY is Secret, so buildEnvPrefix omits it from
+		// the typed command line and it is delivered ONLY by tmux
+		// set-environment — which updates the SESSION environment and is
+		// inherited just by shells created afterwards. The pane's bash was
+		// started before the key existed, so it does not have the variable and
+		// never will; reapAgentCLI kills the bob CLI but leaves that bash
+		// alive, so a plain relaunch retypes the command into the same
+		// key-less shell and bob prompts for a key again (observed on
+		// hosted-available-vllmd-01: BOBSHELL_API_KEY present in the tmux
+		// session env, absent from every bob /proc/<pid>/environ).
+		// Killing the session makes ensureTmuxSession build a new one and
+		// re-run set-environment before any shell exists, so the fresh bash —
+		// and the bob it spawns — inherit the key.
+		if err := m.killSessionForRelaunch(name); err != nil {
+			m.logger.Warn("could not kill stale session before bob relaunch; launching anyway",
+				"name", name, "error", err)
+		}
+		if err := m.Start(ctx, name); err != nil {
+			// One agent's failure must never abort the rest of the fleet,
+			// exactly as in the crash-restart loop above.
+			m.logger.Error("failed to relaunch bob agent after key save", "name", name, "error", err)
+			continue
+		}
+		relaunched = append(relaunched, name)
+	}
+	return relaunched
+}
+
+// killSessionForRelaunch tears down an agent's tmux session so the next
+// ensureTmuxSession creates a fresh one whose shell inherits the current
+// set-environment values (including a newly-saved BOBSHELL_API_KEY).
+//
+// This is KillSession's behaviour, but it deliberately does not call
+// KillSession: that method takes m.mu.Lock() and is a public entry point.
+// Keeping a private helper with the same lock discipline (acquire, act,
+// release — never held across Start) keeps the relaunch loop's locking
+// obvious and avoids any temptation to hold a lock across the launch, which
+// is the deadlock class from incident #1980→#1988.
+func (m *Manager) killSessionForRelaunch(name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	agent, ok := m.agents[name]
+	if !ok {
+		return fmt.Errorf("agent %s not found", name)
+	}
+	// Not an error if the session is already gone — the goal is "no stale
+	// shell", which a missing session already satisfies.
+	_ = m.tmuxCmd(agent, "kill-session", "-t", agent.tmuxSession).Run()
+	// State must not stay Running: Start refuses to launch a running agent,
+	// and the session backing that state no longer exists.
+	if agent.State == StateRunning {
+		agent.State = StateStopped
+	}
+	m.logger.Info("killed stale tmux session so the fresh shell inherits the bob key",
+		"name", name, "session", agent.tmuxSession)
+	return nil
+}
+
+// bobAgentsAwaitingKey returns the names of agents parked by launchInTmux for a
+// missing bob API key and eligible to be started now. Split out from
+// RelaunchBobAgentsAwaitingKey so the selection rules can be tested without
+// tmux: this is the part that must never pick up a running, paused, or non-bob
+// agent.
+//
+// Takes m.mu.RLock and releases it before returning; the caller must NOT hold
+// m.mu (non-reentrant RWMutex).
+func (m *Manager) bobAgentsAwaitingKey() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	var candidates []string
+	for name, agent := range m.agents {
+		if agent == nil || !agent.awaitingBobKey {
+			continue
+		}
+		// Defensive: awaitingBobKey is only ever set on the bob branch, but
+		// re-check the effective backend so a backend override applied after
+		// parking cannot smuggle a non-bob agent into this path.
+		if effectiveBackend(agent) != bobBackend {
+			continue
+		}
+		// Never disturb a healthy agent, and never override a pause — a key
+		// save is not a resume.
+		if agent.State == StateRunning || agent.Paused {
+			continue
+		}
+		candidates = append(candidates, name)
+	}
+	return candidates
 }
 
 func (m *Manager) SendKick(name string, message string) error {

--- a/v2/pkg/dashboard/api.go
+++ b/v2/pkg/dashboard/api.go
@@ -4161,9 +4161,26 @@ func (s *Server) handleGovernorBobKey(w http.ResponseWriter, r *http.Request) {
 	// No agent restart is required to ADOPT the key: main.go injected a
 	// resolver closure over the live config into the agent manager
 	// (SetBobAPIKeyResolver), and it re-reads the key file on every agent
-	// launch. A bob agent that is already paused for "no API key" still needs
-	// to be started/resumed once — it is not re-launched automatically — so
-	// the UI tells the user to start the agent rather than restart the pod.
+	// launch. Agents already parked in "failed: no API key" cannot pick it up
+	// on their own, though: the key is Secret, so it is delivered only by tmux
+	// set-environment, which is inherited by shells created AFTER it runs — and
+	// their pane shell predates the key. RelaunchBobAgentsAwaitingKey therefore
+	// recreates those sessions so a fresh shell inherits the key. Running,
+	// paused, and non-bob agents are untouched, and a second save finds nothing
+	// left to do.
+	// s.deps.Ctx, NOT r.Context(): the launch path derives the agent's
+	// long-lived pane-polling goroutine from this context, so a request-scoped
+	// one would cancel it the moment this response is written. Every other
+	// Start/Restart/Resume caller in the dashboard passes s.deps.Ctx too.
+	var relaunched []string
+	if s.deps != nil && s.deps.AgentMgr != nil {
+		relaunched = s.deps.AgentMgr.RelaunchBobAgentsAwaitingKey(s.deps.Ctx)
+	}
+	if len(relaunched) > 0 {
+		s.logger.Info("relaunched bob agents after api key save",
+			"count", len(relaunched), "agents", strings.Join(relaunched, ","))
+	}
+
 	jsonResponse(w, map[string]interface{}{
 		"ok":         true,
 		"configured": true,
@@ -4171,6 +4188,9 @@ func (s *Server) handleGovernorBobKey(w http.ResponseWriter, r *http.Request) {
 		"source": "file:" + keyFile,
 		// The pod does not need restarting; the resolver reads the key live.
 		"restartNeeded": false,
+		// How many parked bob agents were started by this save, so the UI can
+		// report what actually happened instead of telling the user to do it.
+		"relaunched": len(relaunched),
 	})
 }
 

--- a/v2/pkg/dashboard/bob_key_store_test.go
+++ b/v2/pkg/dashboard/bob_key_store_test.go
@@ -435,18 +435,22 @@ func TestBobKeyUIRemovedFromAgentCard(t *testing.T) {
 
 // TestBobKeyUIRestartCopyStaysAccurate pins the user-facing claim about
 // restarts. The resolver re-reads the key file at every agent launch, so no pod
-// restart is needed — but an agent already paused for a missing key is NOT
-// relaunched automatically. Copy that drops either half sends users to the
-// wrong remedy.
+// restart is needed — and since handleGovernorBobKey now calls
+// RelaunchBobAgentsAwaitingKey, an agent parked for a missing key IS relaunched
+// by the save. Copy that drops either half sends users to the wrong remedy.
 func TestBobKeyUIRestartCopyStaysAccurate(t *testing.T) {
 	html := indexHTML(t)
 	cases := []struct {
 		name    string
 		snippet string
 	}{
-		{"panel says no restart needed", "restart is needed — but a bob agent already paused for a missing key is not"},
-		{"panel says start the agent once", "relaunched automatically and must be started once."},
-		{"save toast says no restart, start the agent", "no restart needed; start any bob agent that is paused for a missing key"},
+		{"panel says no restart needed", "restart is needed — and any bob agent already parked for a missing key is"},
+		{"panel says restart is automatic", "restarted automatically as part of the save"},
+		// The fresh-session half is the actual fix: a relaunch into the stale
+		// pane shell would not pick the key up (secrets reach the CLI only via
+		// tmux set-environment, inherited by shells created afterwards).
+		{"panel says the session is fresh", "in a fresh session that picks"},
+		{"save toast reports the relaunched count", "Number(data.relaunched)"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -454,6 +458,24 @@ func TestBobKeyUIRestartCopyStaysAccurate(t *testing.T) {
 				t.Errorf("index.html is missing %q — the restart copy is no longer accurate", tc.snippet)
 			}
 		})
+	}
+}
+
+// TestBobKeyUINoLongerTellsUserToStartAgents guards the regression this change
+// closes: the old copy told operators to go start paused bob agents by hand.
+// Now that the save relaunches them, any resurfacing of that instruction (e.g.
+// via a backport from mk/dd/v3, where this fix has not landed yet) is a lie.
+func TestBobKeyUINoLongerTellsUserToStartAgents(t *testing.T) {
+	html := indexHTML(t)
+	stale := []string{
+		"must be started once",
+		"not\n            relaunched automatically",
+		"start any bob agent that is paused for a missing key",
+	}
+	for _, s := range stale {
+		if strings.Contains(html, s) {
+			t.Errorf("index.html still contains stale copy %q — the key save now relaunches parked bob agents", s)
+		}
 	}
 }
 

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -12967,8 +12967,9 @@ function burnAreaChart() {
             bob cannot complete browser sign-in inside a pod (its callback resolves to
             the pod, not your machine) and offers no device-code flow, so an API key is
             its only headless credential. Saving a key takes effect immediately — no pod
-            restart is needed — but a bob agent already paused for a missing key is not
-            relaunched automatically and must be started once.
+            restart is needed — and any bob agent already parked for a missing key is
+            restarted automatically as part of the save, in a fresh session that picks
+            up the new key.
           </div>
           <div id="bob-key-inline-status" style="font-size:0.74rem;min-height:18px;margin-top:8px"></div>
         </div>`;
@@ -16691,9 +16692,14 @@ function burnAreaChart() {
           }
           closeDialog();
           // The hive reads the key at each agent launch, so no pod restart is
-          // needed — but an agent already paused for a missing key must be
-          // started once to pick it up. Say which, so the user isn't guessing.
-          showToast('bob API key saved — no restart needed; start any bob agent that is paused for a missing key', 'success');
+          // needed — and the save also relaunches any bob agent that was parked
+          // for a missing key. Report the count the server actually relaunched
+          // rather than telling the user to go start agents by hand.
+          var relaunched = Number(data.relaunched) || 0;
+          showToast(relaunched > 0
+            ? 'bob API key saved — no restart needed; relaunched ' + relaunched +
+              ' bob agent' + (relaunched === 1 ? '' : 's') + ' that was waiting for a key'
+            : 'bob API key saved — no restart needed', 'success');
           refreshBobKeyPanel();
         } catch (e) {
           setStatus('Save failed: ' + e.message, 'var(--red)');


### PR DESCRIPTION
## The gap

A bob agent that failed to launch because no API key was configured stayed parked until an operator started it by hand — and the Governor's Bob tab told them to do exactly that. Saving a key now restarts those agents automatically.

## Root cause (this is the important part)

Relaunching the agent is **necessary but not sufficient**. The relaunch must **recreate the tmux session**.

`BOBSHELL_API_KEY` is `Secret: true`, so:
- `buildEnvPrefix` deliberately **omits** it from the typed command line (keeping it out of `ps`, bash history, and pane scrollback), and
- `applySecretEnv` delivers it **solely** via `tmux set-environment`.

`tmux set-environment` updates the **session** environment, which is inherited only by shells created *afterwards*. But the CLI is started by `send-keys` typing a command into the pane's **already-running bash**, whose environment was captured when the pane was created — before the key existed. `reapAgentCLI` kills the bob CLI but leaves that bash alive, so a plain relaunch retypes the launch command into the same key-less shell and bob prompts for a key again.

### Evidence

Observed live on `hosted-available-vllmd-01`:
- `BOBSHELL_API_KEY` **present** in the tmux session environment (153 chars, matching `/data/secrets/bob_api_key`)
- **absent** from every live bob `/proc/<pid>/environ`
- bob crash-looping at its interactive key prompt; restarting the agent did not help
- launch flags (`--auth-method api-key --accept-license`) were correct — not the problem

Reproduced the mechanism directly with tmux: `set-environment` followed by `send-keys printenv` into an existing pane shell finds **nothing**, while a newly created window sees the value.

## Changes

- **`AgentProcess.awaitingBobKey`** — set on the single `launchInTmux` branch that parks a bob agent for a missing key, cleared on every launch attempt. `StateFailed` alone is ambiguous: a missing backend binary, a copilot auth timeout, and a hung diagnostic all land there, and none are fixed by a key.
- **`Manager.RelaunchBobAgentsAwaitingKey`** — returns the names it restarted. No-ops when the key does not resolve, so a **clear never launches anything**. Running, paused, and non-bob agents are skipped, which also makes a **double save harmless** (the first pass clears the flag).
- **`killSessionForRelaunch`** — tears the session down so `ensureTmuxSession` rebuilds it, re-running `set-environment` *before* any shell exists and re-attaching the pluk `pipe-pane`. Also resets `StateRunning` → `StateStopped`, since `Start` refuses to launch an agent it believes is running.
- **`handleGovernorBobKey`** — calls it after the key is stored, reports `relaunched` (a count) in the JSON response, and guards a nil agent manager.
- **UI copy + stale comment** corrected; the toast now reports the actual count instead of instructing the user to go start agents.

### `respawn-pane -k` was evaluated and rejected

It does pick up the new environment and `pipe-pane` survives (verified: `pane_pipe=1`), but it leaves the session alive — so `ensureTmuxSession` early-returns and **never re-runs `set-environment`** for the fresh shell. `kill-session` forces the full, already-tested creation path.

## Security

The key value is never logged and gains **no new on-disk location** — only its source path is reported. An env-file approach was considered and rejected for that reason; `~/.bob` was never on the table.

## Locking

Follows `CheckAndRestartCrashedAgents`: candidates are collected under `RLock`, and the lock is **released before** `Start`, which takes `m.mu.Lock()` itself. `m.mu` is a non-reentrant RWMutex (incident #1980→#1988). Selection is split into `bobAgentsAwaitingKey` so it is testable without tmux, and a test exercises it under write-lock contention with a bounded timeout.

## Tests

New `v2/pkg/agent/bob_key_relaunch_test.go`:
- a parked agent **is** relaunched when the key appears (the core regression)
- a healthy running bob agent is **not** disturbed (including with a stale marker)
- non-bob agents are never touched (including a spurious marker, and backend overrides in both directions)
- a bob agent failed for another reason is not selected
- saving twice does not double-launch
- clearing the key relaunches nothing, and leaves the agent eligible for a later save
- session kill resets only `StateRunning`; unknown agent errors rather than panics
- no deadlock under concurrent write-lock contention

Updated `TestBobKeyUIRestartCopyStaysAccurate` and added a guard test so the old "must be started once" copy cannot silently return via a backport.

## Verification

`go build ./...`, `go vet`, and `gofmt` on touched files are clean; the new agent tests and the **full `pkg/dashboard` package** pass. The extracted inline script passes `node --check`, and both copy changes were confirmed present in the extraction.

`manager.go` has **pre-existing** gofmt drift on `origin/v2` (unrelated const/struct alignment); per repo convention I left it alone rather than sweeping it in — my own added lines are gofmt-clean.

Note: `v2` is currently red via `TestHiveTableColumnCount*` in `pkg/hub` (asserts 16, source is 17 after #2224). Pre-existing and unrelated to this PR.

## Ports

**mk, dd, and v3 all need this ported** — the same stale-shell behaviour and the same now-false UI copy exist on each.