### PR TITLE
💄 refactor(hub): color the GitHub-host pill and move it to Repos

### DIFF
--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -9821,7 +9821,6 @@ const dashboardHTML = `<!DOCTYPE html>
         var locationCell = '<div style="' + STACKED_CELL_STYLE + '">' +
           '<div style="' + STACKED_LINE_STYLE + '">' + locationBadge + '</div>' +
           '<div style="' + STACKED_LINE_STYLE + ';font-size:0.7rem">' + visibilityCell + '</div>' +
-          '<div style="' + STACKED_LINE_STYLE + '" title="GitHub instance this hive targets">' + githubHostPill(h.githubHost) + '</div>' +
           '</div>';
         var pendingExpandRow = '';
         if (h.pendingRequestCount > 0 && (h.role === 'owner' || h.role === 'read-write') && (h.pending_requests || []).length > 0) {
@@ -9852,7 +9851,15 @@ const dashboardHTML = `<!DOCTYPE html>
              but the COLUMN is no longer forced to the width of every part laid
              end to end. That nowrap was the main reason this column was wide. */
           '<td style="font-size:0.7rem">' + versionCell + '</td>' +
-          '<td title="' + esc((h.repos || []).join('\n')) + '" style="cursor:' + (repoCount > 0 ? 'help' : 'default') + '">' + repoCount + '</td>' +
+          /* Repo count over the GitHub-instance pill: the host qualifies WHICH
+             GitHub these repos live on, so the two belong together. Stacked
+             rather than inline to keep the numeric column narrow. */
+          '<td title="' + esc((h.repos || []).join('\n')) + '" style="cursor:' + (repoCount > 0 ? 'help' : 'default') + '">' +
+            '<div style="' + STACKED_CELL_STYLE + '">' +
+              '<div style="' + STACKED_LINE_STYLE + '">' + repoCount + '</div>' +
+              '<div style="' + STACKED_LINE_STYLE + '" title="GitHub instance these repos live on">' + githubHostPill(h.githubHost) + '</div>' +
+            '</div>' +
+          '</td>' +
           '<td>' + acmmBadge(h.acmmLevel) + '</td>' +
           /* AI Author: who this hive authors PRs as. aiAuthorEffective is the
              App bot ("<slug>[bot]") in App-authored mode, else the configured
@@ -10619,7 +10626,11 @@ const dashboardHTML = `<!DOCTYPE html>
     // reach it. Shared by the pending action cards and the Past Requests table
     // so the same concept does not drift into two different styles.
     function githubHostPill(githubHost) {
-      var border = githubHost ? 'var(--accent);color:var(--accent)' : 'var(--border);color:var(--muted)';
+      /* Public github.com reads green, GitHub Enterprise reads blue, so the
+         two instances are distinguishable at a glance without reading the
+         text. An absent host is treated as public, matching the label below. */
+      var isGHE = !!githubHost && githubHost !== PAST_REQUESTS_DEFAULT_GITHUB_HOST;
+      var border = isGHE ? 'var(--blue);color:var(--blue)' : 'var(--green);color:var(--green)';
       return '<span style="font-size:0.68rem;padding:1px 7px;border-radius:999px;border:1px solid ' + border + '">' +
         esc(githubHost || PAST_REQUESTS_DEFAULT_GITHUB_HOST) + '</span>';
     }


### PR DESCRIPTION
Follow-up to #2226.

## What changed

**Color by instance type.** Public `github.com` renders **green**, GitHub Enterprise renders **blue**, so the two are distinguishable at a glance without reading the pill text. Previously every host used the same amber accent, with only the text distinguishing them. An absent host is treated as public, matching the `github.com` label it already displays.

**Moved from Location / Public → Repos.** The host qualifies *which* GitHub the repos live on, so the two belong in the same cell. It sits stacked under the repo count, keeping that numeric column narrow.

`githubHostPill()` remains a single shared helper — the Past Requests table and the pending action cards pick up the new colors automatically, which is the intent of its existing doc comment.

## Verification

- `go build ./...` and `go vet ./pkg/hub/` clean; no `gofmt` drift on the touched file.
- **Column count unchanged at 17** — one `<td>` replaced, none added. Verified by diffing `<td` counts (1 added / 1 removed), not assumed.
- Dashboard JS extracted from the `dashboardHTML` raw string and brace-checked: brace delta `0`, `node --check` passes. The paren delta of `-1` is **pre-existing** — reproduced identically on clean `origin/v2` by stashing.
- Confirmed all three edits are present in the *extracted* script (`isGHE`, the blue style, the new title text) rather than trusting a stale file read.
- No backticks and no literal body tag introduced into the Go raw string.

## Ports

Needs porting to `mk`, `dd`, and `v3`.