### PR TITLE
✨ feat(agent): default App-bot PR authorship ON + document journey/write-gate

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -656,7 +656,7 @@ func main() {
 		ACMMLevel:      acmmLevel,
 		PRsAllowed:     cfg.Project.PRsAllowed(),
 		PolicyDir:      policyDir,
-		AppAuthoredPRs: cfg.GitHub.AppAuthoredPRs,
+		AppAuthoredPRs: cfg.GitHub.AppAuthoredPRsEnabled(),
 	}
 	agentMgr := agent.NewManager(cfg.EnabledAgents(), logger, projectCtx)
 	// Resolve the bob API key at LAUNCH time, not here: cfg is the live config

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1087,13 +1087,17 @@ type GitHubConfig struct {
 	// BaseURL is the GitHub web base URL. Defaults to DefaultGitHubBaseURL.
 	// For GitHub Enterprise, set to e.g. "https://github.ibm.com".
 	BaseURL string `yaml:"base_url"`
-	// AppAuthoredPRs opts a hive into App-bot authorship: when true AND ai_author
-	// is empty, agents author PRs/commits as the GitHub App bot ("<slug>[bot]")
-	// via the App installation token, instead of the Copilot-login user. Default
-	// false — a hive with this unset behaves exactly as before (author = whatever
-	// the Copilot login / ai_author already produced), so enabling App-bot mode is
-	// strictly opt-in per hive and never changes an existing hive on upgrade.
-	AppAuthoredPRs bool `yaml:"app_authored_prs"`
+	// AppAuthoredPRs controls App-bot authorship: when enabled AND ai_author is
+	// empty, agents author PRs/commits as the GitHub App bot ("<slug>[bot]") via
+	// the App installation token, instead of the Copilot-login user.
+	//
+	// It is a *bool so absent (nil) is distinct from an explicit false. Default is
+	// ON (see AppAuthoredPRsEnabled): App-bot authorship is now the fleet norm, so
+	// a hive that says nothing gets it. Set `app_authored_prs: false` to opt a
+	// specific hive OUT. This only affects write-capable hives — the token is
+	// injected solely for agents whose tier CanPush() and only when a real App is
+	// installed (m.appAuth != nil), so an App-less or advisory hive is unaffected.
+	AppAuthoredPRs *bool `yaml:"app_authored_prs,omitempty"`
 }
 
 // PlaceholderAppID is the sentinel `github.app_id` written into a hive's config
@@ -1230,10 +1234,23 @@ func (c *Config) EffectiveAIAuthor() string {
 	if c.Project.AIAuthor != "" {
 		return c.Project.AIAuthor
 	}
-	if c.GitHub.AppAuthoredPRs {
+	if c.GitHub.AppAuthoredPRsEnabled() {
 		return c.GitHub.BotLogin()
 	}
 	return ""
+}
+
+// AppAuthoredPRsEnabled reports whether App-bot authorship is on for this hive.
+// The default is ON (nil == true): App-bot authorship is the fleet norm, so a
+// hive that never set app_authored_prs gets it. Only an explicit
+// `app_authored_prs: false` disables it. Note this is only the INTENT — the
+// token is still injected solely for CanPush() tiers with a real App installed,
+// so an App-less or advisory hive never actually writes regardless of this flag.
+func (g GitHubConfig) AppAuthoredPRsEnabled() bool {
+	if g.AppAuthoredPRs == nil {
+		return true
+	}
+	return *g.AppAuthoredPRs
 }
 
 // AppInstallURL returns the full URL to install the GitHub App.

--- a/v2/pkg/config/config_extra_test.go
+++ b/v2/pkg/config/config_extra_test.go
@@ -684,6 +684,42 @@ func TestOAuthClientIDResolved_ConfiguredWins(t *testing.T) {
 	}
 }
 
+// App-bot authorship defaults ON (nil == true, the fleet norm); only an explicit
+// false opts out.
+func TestAppAuthoredPRsEnabled_DefaultsOn(t *testing.T) {
+	if !(GitHubConfig{}).AppAuthoredPRsEnabled() {
+		t.Error("AppAuthoredPRsEnabled() with unset flag = false, want true (default on)")
+	}
+	f := false
+	if (GitHubConfig{AppAuthoredPRs: &f}).AppAuthoredPRsEnabled() {
+		t.Error("AppAuthoredPRsEnabled() with explicit false = true, want false")
+	}
+	tr := true
+	if !(GitHubConfig{AppAuthoredPRs: &tr}).AppAuthoredPRsEnabled() {
+		t.Error("AppAuthoredPRsEnabled() with explicit true = false, want true")
+	}
+}
+
+// With App-bot mode on (the default) and ai_author empty, the effective author
+// is the App bot login; an explicit ai_author still wins; an explicit opt-out
+// yields no author.
+func TestEffectiveAIAuthor_AppBotDefault(t *testing.T) {
+	botHive := &Config{GitHub: GitHubConfig{AppID: 42, AppSlug: "acme-hive"}}
+	if got := botHive.EffectiveAIAuthor(); got != "acme-hive[bot]" {
+		t.Errorf("EffectiveAIAuthor() default = %q, want acme-hive[bot]", got)
+	}
+	withAuthor := &Config{GitHub: GitHubConfig{AppID: 42, AppSlug: "acme-hive"}}
+	withAuthor.Project.AIAuthor = "alice"
+	if got := withAuthor.EffectiveAIAuthor(); got != "alice" {
+		t.Errorf("EffectiveAIAuthor() with ai_author = %q, want alice", got)
+	}
+	f := false
+	optOut := &Config{GitHub: GitHubConfig{AppID: 42, AppSlug: "acme-hive", AppAuthoredPRs: &f}}
+	if got := optOut.EffectiveAIAuthor(); got != "" {
+		t.Errorf("EffectiveAIAuthor() opted out = %q, want empty", got)
+	}
+}
+
 func TestRemoveAgentFile_PathTraversal(t *testing.T) {
 	dir := t.TempDir()
 	for _, bad := range []string{"../etc/passwd", "sub/agent", "back\\slash"} {

--- a/v2/pkg/hub/journey.go
+++ b/v2/pkg/hub/journey.go
@@ -9,18 +9,50 @@ import (
 // ─────────────────────────────────────────────────────────────────────────────
 // User-journey nudges.
 //
-// Every hive owner walks the same adoption path:
+// The full adoption path, in order. It has two phases: the HUB provisions and
+// assigns a placeholder, then — once the user TAKES POSSESSION of that assigned
+// placeholder — the remaining steps happen on the SPOKE.
 //
-//	Stage 1  Install the GitHub App          URGENT   — days, not weeks
-//	Stage 2  Assign a method/model, OR run   MEDIUM   — a few weeks
-//	         the contributor relay
-//	Stage 3  Raise the ACMM level            SLOW     — months, never forced
+//	── Hub-side (before the user takes possession) ──
+//	1. Request        — with a PRIMARY REPO on github.com OR github.ibm.com.
+//	                    The primary repo's host determines this hive's App host
+//	                    (step 4) and every other repo in the spoke MUST be on the
+//	                    same host — a spoke is single-host (see the repo-host
+//	                    consistency rule).
+//	2. Assign         — the hub assigns the requester to a placeholder hive.
 //
-// This file computes, server-side, which stage each hive is stalled on and
-// turns that into an escalating banner delivered over the existing per-hive
-// hub-banner channel (see hubBanners in server.go and the heartbeat response
-// assembly in handleHeartbeat). It NEVER de-provisions anything: the strongest
-// action it takes is warning that a human may de-provision the spoke.
+//	── Spoke-side (once the user has taken possession) ──
+//	3. Spoke login    — the owner signs into the dashboard via device flow. Login
+//	                    is ALWAYS github.com OAuth (GitHubConfig.OAuthBaseURL /
+//	                    OAuthAPIURL / OAuthClientIDResolved), decoupled from the
+//	                    App/repo host — a user signs in with a github.com identity
+//	                    even on a GHE hive.
+//	4. GH / GHE App   — install the GitHub App. github.com App for a github.com
+//	                    primary repo, GitHub Enterprise App for a github.ibm.com
+//	                    primary repo. THIS IS THE WRITE GATE (below).
+//	5. Setup agents   — assign methods + models (or run the contributor relay),
+//	                    then raise the ACMM level.
+//
+// The stall-detection stages below track the SPOKE-side steps (3-5): a
+// placeholder can be assigned yet sit un-logged-in, App-less, or agent-less.
+//
+// WRITE GATE — the App (step 4) is a hard prerequisite for ANY write. A hive
+// MUST have a real, installed GH/GHE App before an agent opens an issue or PR,
+// comments, or merges. This is enforced in code, not just policy: agent write
+// credentials (the GITHUB_TOKEN handed to the GitHub MCP server) are minted from
+// the App installation token, and that token only exists when
+// GitHubConfig.HasUsableApp() is true (real app_id + installation_id). No App →
+// m.appAuth is nil → no GITHUB_TOKEN is injected → the agent has no credential to
+// write with. Advisory work (reading, KB, beads) still runs App-less.
+//
+// The nudge STAGES below (1/2/3) are a compressed view of the same path used for
+// escalating banners — stage 1 = "install the App" (journey step 4), stage 2 =
+// "assign a method/model" (step 5), stage 3 = "raise the ACMM level". This file
+// computes, server-side, which stage each hive is stalled on and turns that into
+// an escalating banner delivered over the existing per-hive hub-banner channel
+// (see hubBanners in server.go and the heartbeat response assembly in
+// handleHeartbeat). It NEVER de-provisions anything: the strongest action it
+// takes is warning that a human may de-provision the spoke.
 // ─────────────────────────────────────────────────────────────────────────────
 
 // ── Tunable thresholds ──────────────────────────────────────────────────────

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -604,13 +604,22 @@ func (s *Scheduler) buildCIFailingList() string {
 func (s *Scheduler) ghAuthInstructions(agentName string) string {
 	return fmt.Sprintf(`## Project Authentication
 
-- git push / git fetch: run them normally. A credential helper supplies a
-  push-capable token automatically. Do NOT export GH_TOKEN for git and do
+- The GitHub App is the WRITE GATE. Every write to GitHub — opening or updating
+  an issue or PR, commenting, and merging — goes through this hive's GitHub App
+  (github.com or GitHub Enterprise, per the primary repo). If the App is not
+  installed you have NO write credential: stay advisory (read, KB, beads) and do
+  not attempt to write. Never substitute a personal user token to work around a
+  missing App. Login/identity is a separate concern and is always github.com.
+- Writes are authored by the App bot identity, not a personal account. Do not
+  set git user.name/user.email to a human, and do not pass 'gh pr create' or
+  'git commit' an explicit --author: let the App identity stand.
+- git push / git fetch: run them normally. A credential helper supplies the
+  App-scoped push token automatically. Do NOT export GH_TOKEN for git and do
   NOT use HIVE_GITHUB_TOKEN (it is read-only; overriding breaks pushes).
 - gh CLI: export your per-agent token first:
     export GH_TOKEN=$(cat /var/run/hive-metrics/agent-tokens/gh-token-%s.cache)
-  It is scoped to YOUR tier. Never read another agent's token file or the
-  shared gh-app-token.cache.
+  It is scoped to YOUR tier and is an App installation token. Never read another
+  agent's token file or the shared gh-app-token.cache.
 - A missing GH_TOKEN at session start is expected (the Copilot CLI owns that
   variable) — it is never a blocker. All GitHub traffic flows through the
   hive proxy either way.


### PR DESCRIPTION
## Summary

Makes **App-bot PR authorship the fleet default** (was opt-in per hive) and documents the adoption **journey** + the **write gate**.

### Default flip
- `github.app_authored_prs` is now `*bool`. **Absent (nil) = ON** via `AppAuthoredPRsEnabled()`; only an explicit `app_authored_prs: false` opts a hive out.
- Every hive authors PRs/commits as the App bot (`<slug>[bot]`) once it can write — no per-hive config needed. (Hand-setting the flag per hive doesn't survive restarts, since the running process re-serializes config; a code default is the only durable mechanism.)

### Why it's safe fleet-wide
The App token is injected **only** for `CanPush()` tiers (ACMM ≥5) **and** only when a real App is installed (`m.appAuth != nil`). App-less hives and advisory tiers get nothing — so the default flip changes behavior only on write-capable, App-installed hives (console today).

### Write gate (the requirement: every hive MUST have the App before any write)
Documented in `journey.go` and enforced in code: no real+installed App → `HasUsableApp()` false → `appAuth` nil → no `GITHUB_TOKEN` → the GitHub MCP has no credential to open issues/PRs, comment, or merge. Advisory work runs App-less.

### Journey (documented, two phases)
Hub-side: **request** (primary repo github.com|github.ibm.com) → **assign**. Spoke-side (after the user takes possession): **login** (always github.com OAuth) → **GH/GHE App** (host per primary repo) → **setup agents**. A spoke is single-host.

### Agent policy
`${GH_AUTH}` now states: no App → stay advisory, never substitute a personal token; writes are authored by the App bot identity (don't set a human git identity or `--author`).

### Tests
`AppAuthoredPRsEnabled` defaults on / explicit-false opts out; `EffectiveAIAuthor` returns the bot login by default, `ai_author` still wins, explicit opt-out yields none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)