### PR TITLE
🐛 fix(hub): realign four stale dashboard tests with the current table and facet tray

### DIFF
--- a/v2/pkg/hub/health_check_detail_test.go
+++ b/v2/pkg/hub/health_check_detail_test.go
@@ -74,7 +74,11 @@ func TestFailingCheckSummaryEscapes(t *testing.T) {
 		{"inline pill tooltip escaped", "'<span title=\"' + esc(full) + '\""},
 		{"inline pill label escaped", "esc(label) + '</span>';"},
 		{"filter chip tooltip escaped", "title=\"' + esc(tip) + '\""},
-		{"filter chip label escaped", "esc(nm) + '<span class=\"filter-chip-count\">'"},
+		// The failing-check picker moved from the old standalone chip bar into
+		// the facet tray, so the label now sits in its own facet-value-label
+		// span. The invariant is unchanged: the spoke-supplied check name is
+		// escaped before it reaches the DOM.
+		{"filter chip label escaped", "'<span class=\"facet-value-label\">' + esc(nm) + '</span>'"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -137,11 +141,14 @@ func TestFilterComposition(t *testing.T) {
 		// Placeholder scoping is unchanged and still splits before filtering.
 		{"placeholder split retained", "(isPlaceholderHive(allHives[_si]) ? unassignedAll : assignedAll)"},
 		{"filters applied to assigned only", "applyDashFilters(assignedAll).concat(unassignedAll)"},
-		// Any-active must account for the check filter so the Clear button shows.
-		// Trailing ';' omitted so additional filters can be OR'd into anyActive
-		// without tripping this guard; the invariant is that the check filter
-		// participates, not that it terminates the expression.
-		{"clear button accounts for check filter", "|| !!_dashFailingCheckFilter"},
+		// Any-active must account for the check filter so the Clear button
+		// shows. The per-filter OR chain was replaced by activeFilterCount(),
+		// which also drives the "N filters active" summary; the check filter now
+		// participates by being counted there. Both halves are asserted so the
+		// link cannot be broken at either end: the counter must include the
+		// check filter, and anyActive must be derived from the counter.
+		{"check filter is counted", "if (_dashFailingCheckFilter) n++;"},
+		{"clear button accounts for check filter", "var anyActive = activeN > 0;"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/v2/pkg/hub/hive_access_avatars_test.go
+++ b/v2/pkg/hub/hive_access_avatars_test.go
@@ -174,16 +174,19 @@ func TestHoverPanelReusesSharedRoleColor(t *testing.T) {
 }
 
 // TestHiveTableColumnCountUnchanged asserts the inline avatars did NOT add a
-// column. They live inside the existing name cell precisely so the 16-column
-// header, the section-header colspan and the pending-expand colspan all stay
-// correct; a stale count leaves the table visibly ragged.
+// column. They live inside the existing name cell precisely so the header, the
+// section-header colspan and the pending-expand colspan all stay correct; a
+// stale count leaves the table visibly ragged.
 //
-// 16, not 17: the standalone Public column was folded into Location, where
-// visibility now stacks beneath the location badge.
+// 17 = the 16 columns left after the standalone Public column was folded into
+// Location (visibility stacks beneath the location badge), plus the AI Author
+// column added with App-bot PR authorship. TestHiveTableColumnCountsAgree is
+// the authority on this number: it counts the emitted <th> and <td> cells
+// rather than trusting a literal, so update it first and follow it here.
 func TestHiveTableColumnCountUnchanged(t *testing.T) {
 	for _, snippet := range []string{
-		"var TOTAL_COLUMNS = 16;",
-		"var TOTAL_COLUMNS_HEADER = 16;",
+		"var TOTAL_COLUMNS = 17;",
+		"var TOTAL_COLUMNS_HEADER = 17;",
 	} {
 		if !strings.Contains(dashboardHTML, snippet) {
 			t.Errorf("dashboardHTML is missing %q — did the hive table gain or lose a column?", snippet)

--- a/v2/pkg/hub/saas_dashboard_facet_tray_test.go
+++ b/v2/pkg/hub/saas_dashboard_facet_tray_test.go
@@ -340,17 +340,19 @@ func TestHiveTableColumnCountsAgree(t *testing.T) {
 		t.Errorf("header emits %d <th> cells but a row emits %d cells — "+
 			"every column right of the mismatch is shifted", thCount, tdCount)
 	}
-	// 16 since the Public column was folded into Location (visibility stacks
-	// beneath the location badge) — see the Location cell in buildRow.
-	const wantColumns = 16
+	// 17: the Public column was folded into Location (visibility stacks beneath
+	// the location badge) leaving 16 — see the Location cell in buildRow — and
+	// the AI Author column was then added alongside ACMM to show the GitHub
+	// identity a hive's agents open PRs as.
+	const wantColumns = 17
 	if thCount != wantColumns {
 		t.Errorf("hive table has %d columns, want %d", thCount, wantColumns)
 	}
 	// The colspan constants span the whole table; a stale value leaves the
 	// section separators and the pending-requests row visibly short.
 	for _, decl := range []string{
-		"var TOTAL_COLUMNS = 16;",
-		"var TOTAL_COLUMNS_HEADER = 16;",
+		"var TOTAL_COLUMNS = 17;",
+		"var TOTAL_COLUMNS_HEADER = 17;",
 	} {
 		if !strings.Contains(html, decl) {
 			t.Errorf("missing or stale colspan constant: %s", decl)


### PR DESCRIPTION
`v2` is red in `pkg/hub` on four tests. All four are **stale assertions against implementation details that legitimate feature work had since moved** — none of them found a real defect. No production code is changed; the fix is entirely in `_test.go` files.

## Ground truth (verified by running, not assumed)

Reproduced on clean `origin/v2` (`2cb7ba16`) before changing anything:

```
--- FAIL: TestFailingCheckSummaryEscapes/filter_chip_label_escaped
--- FAIL: TestFilterComposition/clear_button_accounts_for_check_filter
--- FAIL: TestHiveTableColumnCountUnchanged
--- FAIL: TestHiveTableColumnCountsAgree
```

These turn out to be **two unrelated breakages**, from two different commits.

## 1. The column count: 17 is correct, and there is no off-by-one

The My Hives table genuinely has 17 columns. `#2223` (`d7feb04d`) added the **AI Author** column — one `<th>` beside ACMM, one `<td>` in `buildRow` — to surface the GitHub identity a hive's agents open PRs as. It correctly updated both `TOTAL_COLUMNS` and `TOTAL_COLUMNS_HEADER`; only the tests were left behind.

I checked this rather than bumping the literal, because bumping is exactly what would hide a rendering bug. Two independent pieces of evidence say 17 is real:

- `TestHiveTableColumnCountsAgree` already counts the emitted `<th>` and `<td>` cells and cross-checks header against body. **That comparison did not fire** — only its hardcoded `wantColumns` did. A genuine off-by-one would have tripped the agree-check first.
- A standalone probe over the built dashboard confirms **17 `<th>`** and **16 literal `<td>` + 1 from `bulkCheckboxCell` = 17**. Header and body agree, and the colspans spanning the section separators and the pending-requests row match both.

So: stale test, not a table bug.

Note the breakage was attributed to `#2224` when reported. `#2224` (`5391b0c8`) touches no `<th>`, `<td>` or `TOTAL_COLUMNS` at all; `git log -S` points at `#2223`, which merged three minutes earlier.

## 2. The escaping / filter tests: older fallout from `#2183`

Separate and older. `#2183` (`f7b44e6a`) folded the standalone status-filter bar into the collapsible facet tray. **Both behaviours survive that refactor** — only the markup the tests pinned did not. I confirmed each invariant still holds in the refactored source before touching the assertion:

- The failing-check label is still escaped, now as `'<span class="facet-value-label">' + esc(nm) + '</span>'`.
- The Clear button still accounts for the check filter, but via `activeFilterCount()` (which also drives the "N filters active" summary) instead of an OR chain. `activeFilterCount()` contains `if (_dashFailingCheckFilter) n++;` and `anyActive` is derived from it.

For the second I assert **both halves of the indirection** — that the counter includes the check filter, and that `anyActive` derives from the counter — so the link cannot be silently broken at either end. This is a test correction, not a behaviour decision.

## Verification

- `pkg/hub` suite: **green** (was 4 failures).
- Full `./...` test suite: **exit 0**, no other package affected.
- `go build ./...` and `go vet ./...`: clean.
- `gofmt`: clean on my hunks. `saas_dashboard_facet_tray_test.go` has pre-existing gofmt drift at line ~114 (unrelated comment alignment); left untouched rather than sweeping it into this PR.
- No changes to `saas.go`, so no risk to the `dashboardHTML` raw string.

## Porting to mk / dd / v3

Split — please do **not** cherry-pick this wholesale:

- **Column half: do NOT port.** `mk`, `dd` and `v3` lack `#2223`, so their source and tests are self-consistent at 16. Forcing 17 there would break them. It ports only when/if `#2223` does.
- **Facet-tray half: DOES need porting.** All three already carry the `#2183` refactor (`facet-value-label` present in `saas.go`) yet still contain both stale snippets, so `TestFailingCheckSummaryEscapes` and `TestFilterComposition` are very likely red on `mk`/`dd`/`v3` today for the same reason.