### PR TITLE
🐛 fix(agent): bob auth via BOBSHELL_DEFAULT_AUTH_TYPE, drop phantom --auth-method flag

### DIFF
--- a/v2/pkg/agent/bob_test.go
+++ b/v2/pkg/agent/bob_test.go
@@ -209,6 +209,67 @@ func TestBobEnvPairInjection(t *testing.T) {
 	}
 }
 
+// TestBobAuthTypeEnvPair is the regression guard for the "bob prompts for an
+// API key forever" bug: BOBSHELL_DEFAULT_AUTH_TYPE is the ONLY thing that
+// selects API-key auth (there is no --auth-method flag in bobshell 1.0.6), so
+// a bob agent must always carry it and no other backend should.
+func TestBobAuthTypeEnvPair(t *testing.T) {
+	tests := []struct {
+		name     string
+		backend  string
+		key      string
+		wantPair bool
+	}{
+		{"bob backend with key", "bob", "bob-key", true},
+		// The auth type is not a credential, so it does not depend on the key
+		// being resolvable — bob must still be told not to use SSO.
+		{"bob backend without key", "bob", "", true},
+		{"claude backend", "claude", "bob-key", false},
+		{"copilot backend", "copilot", "bob-key", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Manager{logger: discardLogger()}
+			key := tc.key
+			m.SetBobAPIKeyResolver(func() string { return key })
+
+			agent := &AgentProcess{
+				Name:   "tester",
+				Config: config.AgentConfig{Backend: tc.backend},
+			}
+
+			var found *agentEnvPair
+			for _, p := range m.agentEnvPairs(agent) {
+				if p.Key == config.BobAuthTypeEnvVar {
+					pair := p
+					found = &pair
+				}
+			}
+			if tc.wantPair != (found != nil) {
+				t.Fatalf("%s pair present = %v, want %v", config.BobAuthTypeEnvVar, found != nil, tc.wantPair)
+			}
+			if found == nil {
+				return
+			}
+			if found.Value != config.BobAuthTypeAPIKey {
+				t.Errorf("pair value = %q, want %q", found.Value, config.BobAuthTypeAPIKey)
+			}
+			// Must be NON-secret: secret pairs only reach a freshly-created
+			// pane via tmux set-environment, while non-secret pairs are
+			// re-applied on every launch through buildEnvPrefix. See #2228.
+			if found.Secret {
+				t.Error("auth type must not be Secret: it is not a credential and must be re-applied on every launch")
+			}
+			prefix := m.buildEnvPrefix(agent)
+			want := config.BobAuthTypeEnvVar + "="
+			if !strings.Contains(prefix, want) {
+				t.Errorf("env prefix = %q, want it to contain %q so every launch re-applies it", prefix, want)
+			}
+		})
+	}
+}
+
 // TestBobKeyNotInEnvPrefix is the regression guard for leaking the key onto the
 // shell command line, where it would show up in `ps` and pane scrollback.
 func TestBobKeyNotInEnvPrefix(t *testing.T) {
@@ -241,18 +302,20 @@ func TestBobLaunchCmd(t *testing.T) {
 		{
 			name:  "no model",
 			model: "",
-			// --auth-method api-key is what stops bob choosing the browser SSO
-			// flow in interactive mode; --accept-license clears the license gate
-			// that would otherwise hard-error with no human to answer it.
-			wantContain: []string{"bob", "--auth-method api-key", "--accept-license"},
+			// --accept-license clears the license gate that would otherwise
+			// hard-error with no human to answer it. It is the ONLY auth/gate
+			// flag we pass: --auth-method does not exist in bobshell 1.0.6, so
+			// passing it was a no-op that left bob on the SSO default.
+			wantContain: []string{"bob", "--accept-license"},
 			// No -p/--prompt: interactive mode must be preserved.
-			wantAbsent: []string{"--model", " -p ", "--prompt"},
+			// No --auth-method: phantom flag, regression guard.
+			wantAbsent: []string{"--model", " -p ", "--prompt", "--auth-method"},
 		},
 		{
 			name:        "with model",
 			model:       "granite-3",
-			wantContain: []string{"--auth-method api-key", "--accept-license", "--model granite-3"},
-			wantAbsent:  []string{" -p ", "--prompt"},
+			wantContain: []string{"--accept-license", "--model granite-3"},
+			wantAbsent:  []string{" -p ", "--prompt", "--auth-method"},
 		},
 	}
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -3592,21 +3592,17 @@ const bobBackend = "bob"
 //
 // The launch stays INTERACTIVE — no -p/--prompt — so the agent drives bob in a
 // tmux pane exactly like every other CLI backend and a human can attach to it.
-// Two flags make that work in a headless pod. Both were verified against the
-// installed bundle (bobshell 1.0.6 bundle/bob.js), not assumed:
 //
-//   - --auth-method api-key: bob computes its default auth type as "if
-//     BOBSHELL_API_KEY is set AND the session is non-interactive then api-key,
-//     else W3ID_SSO". So in interactive mode the env var ALONE is not enough —
-//     bob still selects SSO, opens a browser, and dies on the 3-minute
-//     callback timeout; it merely prints 'Existing API key detected
-//     (BOBSHELL_API_KEY). Select "Bob-Shell API Key" option to use it.' This
-//     flag sets globalThis.authMethodByCliArg, which takes precedence over both
-//     the computed default and the persisted security.auth.selectedType, so an
-//     interactive session authenticates with the key and never reaches the
-//     browser flow. The value is bob's own enum constant USE_BOBSHELL="api-key".
-//     This is why interactive mode remains available rather than being
-//     hard-switched to -p.
+// Auth type is NOT a flag. An earlier version of this function passed
+// `--auth-method api-key`, but bobshell 1.0.6 has no such flag — it exposes no
+// auth-related flags whatsoever — so bob ignored it, stayed on its W3ID SSO
+// default, and every bob agent parked at `awaiting_api_key_input` forever.
+// The real control is the BOBSHELL_DEFAULT_AUTH_TYPE env var, injected via
+// agentEnvPairs (see config.BobAuthTypeEnvVar). Verified live against a
+// running spoke: with that var exported, `bob --accept-license` boots straight
+// to its prompt and authenticates with the existing key.
+//
+// One flag remains, verified present in bobshell 1.0.6's help output:
 //
 //   - --accept-license: bob hard-errors ("A license agreement is required.
 //     Please accept the license terms before proceeding.") before doing any
@@ -3623,7 +3619,7 @@ const bobBackend = "bob"
 // tmux set-environment (see agentEnvPairs) so it never lands in the command
 // line, `ps` output, or pane scrollback.
 func bobLaunchCmd(binary, model string) string {
-	cmd := fmt.Sprintf("%s --auth-method %s --accept-license", binary, config.BobAuthMethodAPIKey)
+	cmd := fmt.Sprintf("%s --accept-license", binary)
 	if model != "" {
 		cmd = fmt.Sprintf("%s --model %s", cmd, model)
 	}
@@ -4190,6 +4186,16 @@ func (m *Manager) agentEnvPairs(agent *AgentProcess) []agentEnvPair {
 		if key := m.bobAPIKey(); key != "" {
 			vars = append(vars, agentEnvPair{config.BobAPIKeyEnvVar, key, true})
 		}
+		// BOBSHELL_DEFAULT_AUTH_TYPE is what actually selects API-key auth;
+		// without it bob defaults to W3ID SSO and parks at the interactive key
+		// prompt forever. Deliberately NOT Secret: the value is the literal
+		// non-credential string "api-key", and secret pairs only reach a
+		// freshly-created pane shell via tmux set-environment, whereas
+		// non-secret pairs are re-applied on EVERY launch through
+		// buildEnvPrefix. That asymmetry is exactly what caused the sibling
+		// bug fixed in #2228, so the auth type must ride the always-reapplied
+		// path or a relaunch into an existing session loses it.
+		vars = append(vars, agentEnvPair{config.BobAuthTypeEnvVar, config.BobAuthTypeAPIKey, false})
 	}
 	// BD_DIR tells the `bd` CLI where to read/write beads. Without this,
 	// bd falls back to cwd (/data/agents/<name>) instead of the configured

--- a/v2/pkg/config/bob_test.go
+++ b/v2/pkg/config/bob_test.go
@@ -121,9 +121,10 @@ func TestBobConfigNilReceiver(t *testing.T) {
 	}
 }
 
-// TestBobConstants pins the externally-defined names. BobAPIKeyEnvVar and
-// BobAuthMethodAPIKey are dictated by the bobshell bundle, not by us: changing
-// them silently breaks headless auth, so they are asserted rather than assumed.
+// TestBobConstants pins the externally-defined names. BobAPIKeyEnvVar,
+// BobAuthTypeEnvVar and BobAuthTypeAPIKey are dictated by the bobshell bundle,
+// not by us: changing them silently breaks headless auth, so they are asserted
+// rather than assumed.
 func TestBobConstants(t *testing.T) {
 	tests := []struct {
 		name string
@@ -131,7 +132,8 @@ func TestBobConstants(t *testing.T) {
 		want string
 	}{
 		{"bob's own env var name", BobAPIKeyEnvVar, "BOBSHELL_API_KEY"},
-		{"bob's api-key auth method value", BobAuthMethodAPIKey, "api-key"},
+		{"bob's auth-type env var name", BobAuthTypeEnvVar, "BOBSHELL_DEFAULT_AUTH_TYPE"},
+		{"bob's api-key auth type value", BobAuthTypeAPIKey, "api-key"},
 		{"hive-side default env var", DefaultBobAPIKeyEnv, "HIVE_BOB_API_KEY"},
 		{"k8s Secret mount default path", DefaultBobAPIKeyFile, "/secrets/bob_api_key"},
 		{"PVC default path", WritableBobAPIKeyFile, "/data/secrets/bob_api_key"},

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -846,10 +846,22 @@ const (
 	// WritableLiteLLMAPIKeyFile. Referenced by path only; never by value.
 	WritableBobAPIKeyFile = WritableSecretsDir + "/bob_api_key"
 
-	// BobAuthMethodAPIKey is the value bobshell's `--auth-method` flag expects
-	// to select API-key auth. Verified in bundle/bob.js, where the auth-type
-	// enum is defined as `USE_BOBSHELL="api-key"`.
-	BobAuthMethodAPIKey = "api-key"
+	// BobAuthTypeEnvVar is the env var bobshell reads to pick its auth type.
+	// There is NO `--auth-method` CLI flag: bobshell 1.0.6 exposes no auth
+	// flags at all (`bob --help` mentions none), and the only control point in
+	// bundle/bob.js is
+	//   let h = process.env.BOBSHELL_DEFAULT_AUTH_TYPE;
+	//   if (h && !Object.values(fr).includes(h)) { /* hard error */ }
+	// where `fr` is the auth-type enum. An unset/invalid value leaves bob on
+	// its W3ID SSO default, which in a pod parks at `awaiting_api_key_input`
+	// forever.
+	BobAuthTypeEnvVar = "BOBSHELL_DEFAULT_AUTH_TYPE"
+
+	// BobAuthTypeAPIKey selects API-key auth. It is bob's own enum constant
+	// `USE_BOBSHELL="api-key"` from bundle/bob.js (the sibling value being
+	// `W3ID_SSO="sso"`), so it is dictated by the vendor, not by us. Not a
+	// secret — it is the literal string "api-key" and carries no credential.
+	BobAuthTypeAPIKey = "api-key"
 )
 
 // BobConfig configures the IBM bobshell ("bob") CLI backend. Only the


### PR DESCRIPTION
## The bug (user-visible, affects every existing hive)

**bob agents on all existing hives are currently stuck at the API-key prompt.** They sit at `awaiting_api_key_input` forever and never do any work. The stored key was valid the whole time — it was simply never selected.

Root cause: we passed `--auth-method api-key` on every bob launch, but **bobshell 1.0.6 has no such flag**. `bob --help | grep -ci "auth-method"` returns `0`; there are no auth-related flags at all in its help output. bob ignored the unknown flag and fell through to its W3ID SSO default, which in a pod opens a browser nobody can answer.

The real control is an environment variable. From the installed bundle at `/usr/local/lib/node_modules/bobshell/bundle/bob.js`:

```js
let h = process.env.BOBSHELL_DEFAULT_AUTH_TYPE;
if (h && !Object.values(fr).includes(h)) {
  c(`Invalid value for BOBSHELL_DEFAULT_AUTH_TYPE: "${h}". Valid values are: ${Object.values(fr).join(", ")}.`);
  return
}
```

where the auth-type enum `fr` is literally `USE_BOBSHELL="api-key"` / `W3ID_SSO="sso"`.

## Verified live

On a running spoke, exporting `BOBSHELL_DEFAULT_AUTH_TYPE=api-key` and then running `bob --accept-license` boots **straight to bob's prompt with no API-key request**, showing a live token/billing readout — i.e. authenticated against the real account using the key that was already on disk.

## Changes

- **`bobLaunchCmd` no longer passes `--auth-method`.** `--accept-license` and `--model` are kept; both are real flags in 1.0.6.
- **`agentEnvPairs` injects `BOBSHELL_DEFAULT_AUTH_TYPE=api-key`** for bob-backend agents, through the same mechanism as `BOBSHELL_API_KEY`.
- **`config.BobAuthMethodAPIKey` replaced** by `config.BobAuthTypeEnvVar` + `config.BobAuthTypeAPIKey`, mirroring how `BobAPIKeyEnvVar` is defined. The old constant's comment claimed it was "the value bobshell's `--auth-method` flag expects" — factually wrong. New comments cite the bundle enum, not a flag.

### Why the auth-type pair is NON-secret

Deliberate, and the interesting design call here. The value is the literal string `api-key` — it carries no credential, so there is nothing to protect. More importantly the two paths are **not** equivalent:

- **Secret pairs** are delivered only via `tmux set-environment`, which reaches a *freshly-created* pane shell.
- **Non-secret pairs** are re-typed on the command line by `buildEnvPrefix` on **every** launch.

A relaunch into an existing session would therefore silently lose a secret-typed auth type. That asymmetry is exactly the class of bug fixed in #2228, so the auth type rides the always-reapplied non-secret path.

## Phantom-flag audit

`bobLaunchCmd` is the only place we pass flags to bob. After this change we pass `--accept-license` and `--model`, both confirmed real in bobshell 1.0.6. **`--auth-method` was the only phantom flag; no others found.**

## Tests

- Launch command asserted to contain **no** `--auth-method` (regression guard), with and without a model.
- New `TestBobAuthTypeEnvPair`: a bob-backend agent's env carries `BOBSHELL_DEFAULT_AUTH_TYPE=api-key` as a **non-secret** pair that is reachable through `buildEnvPrefix`; claude/copilot backends do not get it. Also asserts it is present even when no key resolves — bob must be told not to use SSO regardless.
- `TestBobConstants` updated to pin both new constants against the vendor bundle.

Ran locally from `v2/`: `go build ./...`, `go vet ./pkg/agent/... ./pkg/config/...`, `go test ./pkg/agent/... ./pkg/config/...` — all pass. My hunks are gofmt-clean (both touched non-test files carry pre-existing alignment drift in unrelated declarations, deliberately not swept into this PR).

## Follow-ups

- **Needs porting to `mk`, `dd`, and `v3`.** Notably ks/console's hive runs **v3**, so a v2-only merge will not reach it.
- No re-entrant `m.mu` acquisition is introduced; the change is confined to pure command-string construction and the existing `agentEnvPairs` slice append.