### PR TITLE
✨ feat(hub): enforce & display single-host-per-spoke (github.com or one GHE instance)

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -2063,9 +2063,11 @@ func main() {
 				// The GitHub instance this spoke actually runs against. Only
 				// the spoke knows this for certain: a hive's GitHub can differ
 				// from its cluster's default, so the hub cannot infer it.
-				// Reported as a bare hostname; empty base_url means public
-				// github.com, which githubHostLabel renders as such.
-				GitHubHost:              hub.GitHubHostLabel(cfg.GitHub.BaseURL),
+				// Reported as a bare hostname via HostLabel(), which reads BOTH
+				// base_url and api_url — a GHE placeholder with base_url:"" but
+				// api_url: github.ibm.com must report github.ibm.com, not be
+				// silently rendered as github.com in the spokes table.
+				GitHubHost:              cfg.GitHub.HostLabel(),
 				GitHubAppRequired:       dashSrv.IsGitHubAppRequired(),
 				GitHubAppPermIssue:      dashSrv.GetGitHubAppPermIssue(),
 				GitHubAppState:          dashSrv.GetGitHubAppState(),

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1176,6 +1176,32 @@ func (g GitHubConfig) IsGHE() bool {
 	return g.BaseURL != "" && g.BaseURL != DefaultGitHubBaseURL
 }
 
+// HostLabel returns the bare GitHub hostname this hive's App/repos live on:
+// "github.com" for public GitHub, or the GHE hostname (e.g. "github.ibm.com").
+//
+// It is the DEFINITIVE host for display and reporting, and deliberately looks at
+// BOTH base_url and api_url. Many hives (notably pooled placeholders) carry an
+// empty base_url but a GHE api_url (api_url: https://github.ibm.com/api/v3,
+// base_url: "") — reporting the host from base_url alone renders those as
+// github.com and under-counts GHE hives in the spokes table. Preferring base_url
+// when set, then falling back to the api_url's host, makes the reported host
+// match the GitHub the hive actually talks to.
+func (g GitHubConfig) HostLabel() string {
+	pick := g.BaseURL
+	if pick == "" {
+		pick = g.APIURL
+	}
+	pick = strings.TrimSpace(pick)
+	pick = strings.TrimPrefix(pick, "https://")
+	pick = strings.TrimPrefix(pick, "http://")
+	pick = strings.TrimSuffix(strings.Trim(pick, "/"), "/api/v3")
+	host := strings.SplitN(pick, "/", 2)[0]
+	if host == "" || strings.EqualFold(host, "api.github.com") {
+		return DefaultGitHubBaseURL[len("https://"):] // "github.com"
+	}
+	return host
+}
+
 // OAuthBaseURL and OAuthAPIURL are the hosts used for DEVICE-FLOW LOGIN and
 // user-identity token validation. They are ALWAYS public github.com, decoupled
 // from the App/repo host (ResolvedBaseURL/ResolvedAPIURL, which may be GHE).

--- a/v2/pkg/config/config_extra_test.go
+++ b/v2/pkg/config/config_extra_test.go
@@ -780,3 +780,19 @@ agents:
 		t.Error("scanner agent missing")
 	}
 }
+
+func TestHostLabel_PrefersGHEFromAPIURLWhenBaseEmpty(t *testing.T) {
+	// A GHE placeholder: base_url empty but api_url is GHE — must report GHE, not github.com.
+	g := GitHubConfig{APIURL: "https://github.ibm.com/api/v3", BaseURL: ""}
+	if got := g.HostLabel(); got != "github.ibm.com" {
+		t.Errorf("HostLabel() = %q, want github.ibm.com (from api_url when base_url empty)", got)
+	}
+	// Public: both empty.
+	if got := (GitHubConfig{}).HostLabel(); got != "github.com" {
+		t.Errorf("HostLabel() public = %q, want github.com", got)
+	}
+	// base_url wins when set.
+	if got := (GitHubConfig{BaseURL: "https://github.ibm.com"}).HostLabel(); got != "github.ibm.com" {
+		t.Errorf("HostLabel() from base_url = %q, want github.ibm.com", got)
+	}
+}

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -2602,7 +2602,7 @@
   <div class="cost-usage" id="cost-panel" style="margin-bottom: 24px;"></div>
 
   <div class="repos" id="repos-section">
-    <h2 class="section-header-toggle" onclick="toggleSection('repos-section')"><span class="section-chevron">▼</span> Repositories <button class="config-gear" onclick="event.stopPropagation();openConfigDialog('governor',null,'Repos')" title="Manage monitored repositories" style="font-size:0.7em;vertical-align:middle">⚙️</button></h2>
+    <h2 class="section-header-toggle" onclick="toggleSection('repos-section')"><span class="section-chevron">▼</span> Repositories <span id="repos-host-badge" title="Every repo in this hive is on this single GitHub host" style="font-size:0.62em;font-weight:600;vertical-align:middle;padding:2px 7px;border-radius:10px;margin-left:6px"></span> <button class="config-gear" onclick="event.stopPropagation();openConfigDialog('governor',null,'Repos')" title="Manage monitored repositories" style="font-size:0.7em;vertical-align:middle">⚙️</button></h2>
     <div class="section-body">
       <div class="repo-grid" id="repos"></div>
     </div>
@@ -5312,6 +5312,18 @@
 
     function renderRepos(repos) {
       const el = document.getElementById('repos');
+      // Definitive single-host badge in the section header: every repo in this
+      // hive is on ONE GitHub host (github.com or a GHE instance). Green =
+      // github.com, blue = GitHub Enterprise — matches the hub spokes-table pill.
+      const badge = document.getElementById('repos-host-badge');
+      if (badge) {
+        const base = (window._githubBaseUrl || 'https://github.com').replace(/^https?:\/\//, '').replace(/\/$/, '');
+        const isPublic = (base === 'github.com' || base === '');
+        badge.textContent = isPublic ? 'github.com' : base;
+        badge.style.background = isPublic ? 'rgba(34,197,94,0.15)' : 'rgba(59,130,246,0.15)';
+        badge.style.color = isPublic ? 'var(--green, #16a34a)' : 'var(--blue, #2563eb)';
+        badge.title = 'Every repo in this hive is on ' + (isPublic ? 'github.com' : base) + ' — this hive is single-host';
+      }
       setIfChanged(el, repos.map(r => {
         const iSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.issues ?? 0), 'var(--blue)');
         const pSpark = sparkSvg(historyData.map(s => s.repos?.[r.name]?.prs ?? 0), 'var(--purple)');

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -4690,6 +4690,15 @@ func (s *HubServer) handleRequestProvision(w http.ResponseWriter, r *http.Reques
 	if ghHost != "" {
 		body.GitHubHost = ghHost
 	}
+	// Single-host-per-spoke: every repo (and the primary) must be on the same
+	// GitHub host as the org. Check BEFORE normalizeRepoRef strips the host off
+	// each pasted repo. Reject a mixed request up front with a clear message —
+	// a spoke that mixed github.com and a GHE instance would silently fail to
+	// authenticate against half its repos, the onboarding footgun this removes.
+	if err := validateSingleRepoHost(body.GitHubHost, body.PrimaryRepo, strings.Split(body.Repos, ",")); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
 	{
 		var cleaned []string
 		for _, repo := range strings.Split(body.Repos, ",") {
@@ -5351,6 +5360,20 @@ func (s *HubServer) handleAssignHive(w http.ResponseWriter, r *http.Request) {
 	if body.Repos == "" {
 		http.Error(w, `{"error":"repos are required"}`, http.StatusBadRequest)
 		return
+	}
+	// Single-host-per-spoke (assign path — mirrors the request path). Every repo
+	// and the primary must share the spoke's host, checked on the raw pasted
+	// values before normalizeRepoRef strips the host. The "public" sentinel means
+	// github.com, so pass "" to the validator for it.
+	{
+		spokeHost := body.GitHubHost
+		if strings.EqualFold(spokeHost, githubHostPublic) {
+			spokeHost = ""
+		}
+		if err := validateSingleRepoHost(spokeHost, body.PrimaryRepo, strings.Split(body.Repos, ",")); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+			return
+		}
 	}
 	{
 		var cleaned []string

--- a/v2/pkg/hub/server.go
+++ b/v2/pkg/hub/server.go
@@ -257,6 +257,81 @@ func normalizeRepoRef(s string) string {
 	return parts[len(parts)-1]
 }
 
+// repoRefHost extracts the GitHub host a repo string was pasted with, or "" when
+// none was given (a bare name or "owner/repo" with no host = "belongs to the
+// spoke's host"). It parallels normalizeOrgRef's host detection: a leading
+// dotted segment is the hostname.
+//
+//	https://github.ibm.com/z-aiops-unite/ui -> "github.ibm.com"
+//	github.ibm.com/z-aiops-unite/ui         -> "github.ibm.com"
+//	z-aiops-unite/ui                        -> ""   (no explicit host)
+//	ui                                      -> ""
+//
+// This is what makes the single-host-per-spoke invariant enforceable: the
+// caller compares every repo's host (and the primary's) against the spoke host
+// and rejects any that differ, so a spoke can never mix github.com and a GHE
+// instance. Hosts are compared case-insensitively; "github.com" and "" both
+// mean public GitHub (see sameGitHubHost).
+func repoRefHost(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "http://")
+	s = strings.Trim(s, "/")
+	if s == "" {
+		return ""
+	}
+	parts := strings.Split(s, "/")
+	if len(parts) > 1 && strings.Contains(parts[0], ".") {
+		return parts[0]
+	}
+	return ""
+}
+
+// sameGitHubHost reports whether two host labels refer to the same GitHub. Both
+// "" and "github.com" mean public GitHub, so they are equal; a GHE host
+// ("github.ibm.com") equals only itself. Case-insensitive.
+func sameGitHubHost(a, b string) bool {
+	norm := func(h string) string {
+		h = strings.ToLower(strings.TrimSpace(h))
+		if h == "" || h == "github.com" {
+			return "github.com"
+		}
+		return h
+	}
+	return norm(a) == norm(b)
+}
+
+// validateSingleRepoHost enforces the single-host-per-spoke invariant: every
+// repo (and the primary repo) must live on the SAME GitHub host as the spoke.
+// spokeHost is the host derived from the org/primary (normalizeOrgRef); "" means
+// public github.com. repos is the raw, still-host-qualified list as the user
+// pasted it (parse the host BEFORE normalizeRepoRef strips it). Returns a
+// non-nil error naming the first offending repo, so the request/assign handler
+// can 400 with a clear, onboarding-friendly message.
+func validateSingleRepoHost(spokeHost, primaryRepo string, repos []string) error {
+	label := func(h string) string {
+		if h == "" || strings.EqualFold(h, "github.com") {
+			return "github.com"
+		}
+		return h
+	}
+	for _, ref := range append(append([]string{}, repos...), primaryRepo) {
+		ref = strings.TrimSpace(ref)
+		if ref == "" {
+			continue
+		}
+		rh := repoRefHost(ref)
+		if rh == "" {
+			continue // no explicit host — belongs to the spoke host by definition
+		}
+		if !sameGitHubHost(rh, spokeHost) {
+			return fmt.Errorf("repo %q is on %s but this hive is on %s — a hive's repos must all be on one GitHub host (github.com or a single GitHub Enterprise instance). Fix the mismatched repo or request a separate hive for it",
+				ref, label(rh), label(spokeHost))
+		}
+	}
+	return nil
+}
+
 // isValidRepoRef validates a repo entry, which may be a bare name ("repo")
 // or a cross-org "owner/repo" reference. Both segments must be safe names
 // (no path traversal); at most one slash is allowed. Cross-org repos are a

--- a/v2/pkg/hub/single_host_test.go
+++ b/v2/pkg/hub/single_host_test.go
@@ -1,0 +1,52 @@
+package hub
+
+import "testing"
+
+func TestRepoRefHost(t *testing.T) {
+	cases := map[string]string{
+		"https://github.ibm.com/z-aiops-unite/ui": "github.ibm.com",
+		"github.ibm.com/z-aiops-unite/ui":         "github.ibm.com",
+		"z-aiops-unite/ui":                        "",
+		"ui":                                      "",
+		"":                                        "",
+	}
+	for in, want := range cases {
+		if got := repoRefHost(in); got != want {
+			t.Errorf("repoRefHost(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSameGitHubHost(t *testing.T) {
+	if !sameGitHubHost("", "github.com") {
+		t.Error(`"" and "github.com" should be the same host`)
+	}
+	if !sameGitHubHost("GitHub.com", "") {
+		t.Error("host comparison should be case-insensitive and treat blank as public")
+	}
+	if sameGitHubHost("github.ibm.com", "github.com") {
+		t.Error("GHE and public must NOT be the same host")
+	}
+	if !sameGitHubHost("github.ibm.com", "github.ibm.com") {
+		t.Error("a GHE host equals itself")
+	}
+}
+
+func TestValidateSingleRepoHost(t *testing.T) {
+	// All repos on the spoke host (public) — bare names and matching hosts pass.
+	if err := validateSingleRepoHost("", "console", []string{"console", "docs", "github.com/kubestellar/kb"}); err != nil {
+		t.Errorf("all-public should pass, got %v", err)
+	}
+	// A GHE hive with all-GHE repos passes.
+	if err := validateSingleRepoHost("github.ibm.com", "github.ibm.com/org/a", []string{"github.ibm.com/org/a", "b"}); err != nil {
+		t.Errorf("all-GHE should pass, got %v", err)
+	}
+	// A public hive with a GHE repo mixed in must be REJECTED.
+	if err := validateSingleRepoHost("", "console", []string{"console", "github.ibm.com/org/secret"}); err == nil {
+		t.Error("mixed public+GHE must be rejected")
+	}
+	// A GHE hive with a github.com repo mixed in must be REJECTED.
+	if err := validateSingleRepoHost("github.ibm.com", "org/a", []string{"a", "github.com/other/pub"}); err == nil {
+		t.Error("mixed GHE+public must be rejected")
+	}
+}

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -349,16 +349,20 @@ func (s *Scheduler) BuildAgentMessageFromLastActionable(agentName string) string
 
 func (s *Scheduler) buildReposSection() string {
 	var b strings.Builder
-	b.WriteString("AUTHORIZED REPOS (you may ONLY interact with these):\n")
+	host := s.cfg.GitHub.ResolvedBaseURL() // always a full URL; github.com or the GHE instance
+	b.WriteString(fmt.Sprintf("AUTHORIZED REPOS (all on %s — you may ONLY interact with these):\n", host))
 	org := s.cfg.Project.Org
 	for _, repo := range s.cfg.Project.Repos {
-		if strings.Contains(repo, "/") {
-			b.WriteString(fmt.Sprintf("  %s\n", repo))
-		} else {
-			b.WriteString(fmt.Sprintf("  %s/%s\n", org, repo))
+		full := repo
+		if !strings.Contains(repo, "/") {
+			full = org + "/" + repo
 		}
+		// Print the fully-qualified URL so the host is unambiguous in the prompt —
+		// a github.ibm.com repo must never be mistaken for a github.com one.
+		b.WriteString(fmt.Sprintf("  %s/%s\n", strings.TrimRight(host, "/"), full))
 	}
 	b.WriteString("⛔ NEVER access, search, list, file issues in, or open PRs on repos not listed above.\n")
+	b.WriteString(fmt.Sprintf("⛔ Every repo above is on %s. This hive is single-host — never touch a repo on a different GitHub host.\n", host))
 	return b.String()
 }
 
@@ -629,11 +633,16 @@ func (s *Scheduler) ghAuthInstructions(agentName string) string {
 
 func (s *Scheduler) reposSection() string {
 	var b strings.Builder
-	b.WriteString("## Project Repositories\n\nYour role covers these repositories:\n")
+	host := s.cfg.GitHub.ResolvedBaseURL()
+	b.WriteString(fmt.Sprintf("## Project Repositories\n\nYour role covers these repositories, all on **%s** (this hive is single-host):\n", host))
 	for _, repo := range s.cfg.Project.Repos {
-		b.WriteString(fmt.Sprintf("  %s/%s\n", s.cfg.Project.Org, repo))
+		full := repo
+		if !strings.Contains(repo, "/") {
+			full = s.cfg.Project.Org + "/" + repo
+		}
+		b.WriteString(fmt.Sprintf("  %s/%s\n", strings.TrimRight(host, "/"), full))
 	}
-	b.WriteString("\nAll work should be scoped to these repos.\n\n")
+	b.WriteString(fmt.Sprintf("\nAll work should be scoped to these repos on %s.\n\n", host))
 	return b.String()
 }
 


### PR DESCRIPTION
## Summary

A hive's repos must all live on ONE GitHub host — github.com **or** a single GitHub Enterprise instance. Mixing them silently breaks auth against half the repos (an onboarding footgun). This makes the host **definitive and enforced end-to-end**.

## Enforce (reject mixed at request AND assign)
- `repoRefHost` / `sameGitHubHost` / `validateSingleRepoHost` (pkg/hub/server.go): parse each pasted repo's host; reject the request/assign if any repo (or the primary) is on a different host than the spoke, with a clear onboarding-friendly error.
- Wired into `handleRequestProvision` and `handleAssignHive`, **before** `normalizeRepoRef` strips the host. The `public` sentinel maps to github.com.

## Display (definitive host everywhere repos appear)
- **`GitHubConfig.HostLabel()`** (pkg/config): derive the bare host from `base_url` **or** `api_url`. Fixes the spokes-table under-count of GHE hives — pooled placeholders carry `base_url:""` + `api_url: github.ibm.com`, so reporting from base_url alone rendered them as github.com. The heartbeat now reports `HostLabel()` (cmd/hive), so `RegistryEntry.GitHubHost` and the spokes-table host pill are correct.
- **Spoke governor Repositories section**: a green(github.com)/blue(GHE) host badge in the header (pkg/dashboard/static/index.html).
- **Agent prompt repo sections**: print fully-qualified `<host>/<org>/<repo>` and state the single host explicitly (pkg/scheduler).

## Tests
`repoRefHost`, `sameGitHubHost`, `validateSingleRepoHost` (mixed rejected, same-host passes), `HostLabel` (GHE from api_url when base_url empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)