### PR TITLE
🐛 fix(ui): AI author shows "—" when no usable GitHub App is installed

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -1254,7 +1254,13 @@ func (g GitHubConfig) ResolvedAppSlug() string {
 // actually authors PRs and commits when the hive authenticates as an
 // installation rather than a personal token.
 func (g GitHubConfig) BotLogin() string {
-	if g.AppID == 0 {
+	// Only a REAL, installed App has a bot that can author anything. A bare
+	// `AppID != 0` also passes for the placeholder sentinel (PlaceholderAppID)
+	// and for a real app_id that was never installed (installation_id: 0) —
+	// neither can mint a token or author a PR, so neither has a bot login. Using
+	// HasUsableApp() keeps EffectiveAIAuthor() empty for those, so the UI shows
+	// "-" (no author) rather than a phantom "<slug>[bot]" for an App-less hive.
+	if !g.HasUsableApp() {
 		return ""
 	}
 	return g.ResolvedAppSlug() + "[bot]"

--- a/v2/pkg/config/config_extra_test.go
+++ b/v2/pkg/config/config_extra_test.go
@@ -704,19 +704,27 @@ func TestAppAuthoredPRsEnabled_DefaultsOn(t *testing.T) {
 // is the App bot login; an explicit ai_author still wins; an explicit opt-out
 // yields no author.
 func TestEffectiveAIAuthor_AppBotDefault(t *testing.T) {
-	botHive := &Config{GitHub: GitHubConfig{AppID: 42, AppSlug: "acme-hive"}}
+	// A USABLE App (real app_id + installed) defaults to the bot author.
+	botHive := &Config{GitHub: GitHubConfig{AppID: 42, InstallationID: 7, AppSlug: "acme-hive"}}
 	if got := botHive.EffectiveAIAuthor(); got != "acme-hive[bot]" {
 		t.Errorf("EffectiveAIAuthor() default = %q, want acme-hive[bot]", got)
 	}
-	withAuthor := &Config{GitHub: GitHubConfig{AppID: 42, AppSlug: "acme-hive"}}
+	// An explicit ai_author always wins, App or not.
+	withAuthor := &Config{GitHub: GitHubConfig{AppID: 42, InstallationID: 7, AppSlug: "acme-hive"}}
 	withAuthor.Project.AIAuthor = "alice"
 	if got := withAuthor.EffectiveAIAuthor(); got != "alice" {
 		t.Errorf("EffectiveAIAuthor() with ai_author = %q, want alice", got)
 	}
+	// Explicit opt-out → no author.
 	f := false
-	optOut := &Config{GitHub: GitHubConfig{AppID: 42, AppSlug: "acme-hive", AppAuthoredPRs: &f}}
+	optOut := &Config{GitHub: GitHubConfig{AppID: 42, InstallationID: 7, AppSlug: "acme-hive", AppAuthoredPRs: &f}}
 	if got := optOut.EffectiveAIAuthor(); got != "" {
 		t.Errorf("EffectiveAIAuthor() opted out = %q, want empty", got)
+	}
+	// No usable App (app_id set but NOT installed) → no author, UI shows "—".
+	noApp := &Config{GitHub: GitHubConfig{AppID: 42, AppSlug: "acme-hive"}} // installation_id 0
+	if got := noApp.EffectiveAIAuthor(); got != "" {
+		t.Errorf("EffectiveAIAuthor() uninstalled App = %q, want empty (UI shows —)", got)
 	}
 }
 
@@ -794,5 +802,32 @@ func TestHostLabel_PrefersGHEFromAPIURLWhenBaseEmpty(t *testing.T) {
 	// base_url wins when set.
 	if got := (GitHubConfig{BaseURL: "https://github.ibm.com"}).HostLabel(); got != "github.ibm.com" {
 		t.Errorf("HostLabel() from base_url = %q, want github.ibm.com", got)
+	}
+}
+
+// A hive with no USABLE App (placeholder app_id, or a real app_id that was never
+// installed) has no bot and must yield an empty author, so the UI shows "—".
+func TestBotLogin_RequiresUsableApp(t *testing.T) {
+	// Real, installed App → bot login.
+	real := GitHubConfig{AppID: 5686, InstallationID: 42980, AppSlug: "kubestellar-hive-ghe"}
+	if got := real.BotLogin(); got != "kubestellar-hive-ghe[bot]" {
+		t.Errorf("installed App BotLogin() = %q, want kubestellar-hive-ghe[bot]", got)
+	}
+	// Placeholder sentinel app_id → no bot.
+	if got := (GitHubConfig{AppID: PlaceholderAppID, InstallationID: 42980}).BotLogin(); got != "" {
+		t.Errorf("placeholder-app BotLogin() = %q, want empty", got)
+	}
+	// Real app_id but NOT installed (installation_id 0) → no bot.
+	if got := (GitHubConfig{AppID: 3568013, InstallationID: 0}).BotLogin(); got != "" {
+		t.Errorf("uninstalled-app BotLogin() = %q, want empty", got)
+	}
+	// No App at all → no bot.
+	if got := (GitHubConfig{}).BotLogin(); got != "" {
+		t.Errorf("no-app BotLogin() = %q, want empty", got)
+	}
+	// EffectiveAIAuthor is empty for an App-less hive (→ UI shows "—").
+	c := &Config{GitHub: GitHubConfig{AppID: PlaceholderAppID}}
+	if got := c.EffectiveAIAuthor(); got != "" {
+		t.Errorf("App-less EffectiveAIAuthor() = %q, want empty (UI shows —)", got)
 	}
 }

--- a/v2/pkg/dashboard/static/index.html
+++ b/v2/pkg/dashboard/static/index.html
@@ -12128,7 +12128,10 @@ function burnAreaChart() {
       // Who agents author PRs/commits as — the App bot ("<slug>[bot]") when this
       // hive runs App-authored mode, else the configured ai_author. Surfaced on
       // the governor card so operators can see the write identity at a glance.
-      window._aiAuthor = cfg.ai_author_effective || cfg.ai_author || '';
+      // ai_author_effective already incorporates ai_author (else the App bot,
+      // else empty). Don't fall back to a raw ai_author — an App-less hive has
+      // no author and should render "—", not a stale personal value.
+      window._aiAuthor = cfg.ai_author_effective || '';
       const repoDisplay = cfg.org && cfg.primaryRepo && !cfg.primaryRepo.includes('/')
         ? cfg.org + '/' + cfg.primaryRepo
         : (cfg.primaryRepo || '');

--- a/v2/pkg/hub/saas.go
+++ b/v2/pkg/hub/saas.go
@@ -9888,7 +9888,11 @@ const dashboardHTML = `<!DOCTYPE html>
              App bot ("<slug>[bot]") in App-authored mode, else the configured
              ai_author (falls back to aiAuthor for spokes too old to report the
              effective value). A "[bot]" value is the informative case. */
-          '<td style="white-space:nowrap;font-size:0.75rem" title="GitHub identity for this hive\'s PRs/commits">' + esc(h.aiAuthorEffective || h.aiAuthor || '—') + '</td>' +
+          /* aiAuthorEffective already folds in ai_author (it returns ai_author
+             when set, else the App bot, else empty). Do NOT fall back to a raw
+             ai_author here: a hive with no usable GitHub App has no author and
+             must render "—", not a stale personal ai_author it can't act as. */
+          '<td style="white-space:nowrap;font-size:0.75rem" title="GitHub identity for this hive\'s PRs/commits (— = no GitHub App installed yet)">' + esc(h.aiAuthorEffective || '—') + '</td>' +
           '<td>' + journeyBadge(h.journey) + '</td>' +
           /* Drift sits immediately right of Journey: both answer "how healthy
              is this hive's configuration", so they read as one pair rather


### PR DESCRIPTION
## Problem
Hives with **no GitHub App installed** were showing a phantom AI author (`<slug>[bot]`) in the spokes table and governor card. `BotLogin()` gated on a bare `AppID != 0`, which is true for:
- the **placeholder sentinel** app_id (`999999999`), and
- a **real app_id that was never installed** (`installation_id: 0`).

Neither has a bot that can author anything.

## Fix
- `BotLogin()` now requires `HasUsableApp()` (real app_id, not the placeholder, **and** installed). App-less/uninstalled hives → empty `BotLogin` → empty `EffectiveAIAuthor()` → UI shows **`—`**.
- Dropped the `|| ai_author` display fallback in both the spokes-table AI-Author cell and the governor-card PR-author stat — `ai_author_effective` already folds in `ai_author`, so the fallback would leak a stale personal value onto an App-less hive.

Matches the write gate: **no App → no author → `—`**. Real installed App still shows `<slug>[bot]` (github.com or GHE).

## Tests
`BotLogin` empty for placeholder / uninstalled / no-app, non-empty only for a real installed App; `EffectiveAIAuthor` empty for an uninstalled App.

🤖 Generated with [Claude Code](https://claude.com/claude-code)