### PR TITLE
hub/landing: fix hero rotator overlap + inconsistent title font

### DIFF
--- a/v2/pkg/hub/static/index.html
+++ b/v2/pkg/hub/static/index.html
@@ -152,18 +152,40 @@
        stacked so the block height stays stable while they fade; a spacer sizes
        it to the tallest slide. Auto-rotation is JS-driven and disabled under
        prefers-reduced-motion (handled in JS, not just CSS). ── */
-    .hero-rotator { position: relative; }
+    /* Grid-stack crossfade: every slide (and the spacer) shares the same grid
+       cell, so the rotator auto-sizes to the TALLEST slide at any breakpoint.
+       This is what prevents a long lede from overflowing a fixed-height spacer
+       and colliding with the actions below (the old absolute+spacer approach
+       only reserved one slide's height). */
+    .hero-rotator { display: grid; }
+    .hero-rotator > .hero-slide,
+    .hero-rotator > .hero-slide-spacer { grid-area: 1 / 1; }
     .hero-slide {
-      position: absolute; inset: 0;
       opacity: 0; visibility: hidden;
       transition: opacity .6s ease;
     }
     .hero-slide.is-active { opacity: 1; visibility: visible; }
-    .hero-slide-spacer { visibility: hidden; }
-    /* Slides and the spacer must measure identically or the crossfade jumps —
-       but zeroing the margin let the h1's descenders (line-height .92) collide
-       with the lede below. Keep them equal, just not zero. */
-    .hero-slide h1, .hero-slide-spacer h1 { margin: 0 0 1.15rem; }
+    /* Spacer no longer reserves height (the grid does) — keep it fully hidden. */
+    .hero-slide-spacer { visibility: hidden; pointer-events: none; }
+    /* Pin the hero title's font, weight, and size identically on every slide.
+       Without an explicit weight the browser synthesizes bold from whatever
+       Inter weight is (or isn't) installed, so slides rendered subtly different
+       faces. Fixing font-family + font-weight + font-size here makes all slides
+       visually identical regardless of the viewer's installed fonts. */
+    .hero-slide h1, .hero-slide-spacer h1 {
+      margin: 0 0 1.15rem;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-weight: 800;
+      font-size: clamp(3.2rem, 7vw, 6.5rem);
+      line-height: .92;
+      letter-spacing: 0;
+      max-width: 16ch;
+      font-synthesis: none;
+    }
+    .hero-slide .hero-lede, .hero-slide-spacer .hero-lede {
+      font-weight: 400;
+      font-synthesis: none;
+    }
     @media (prefers-reduced-motion: reduce) {
       .hero-slide { transition: none; }
     }


### PR DESCRIPTION
Fixes two live bugs on the rotating hero (spotted on hive.kubestellar.io):

1. **Overlap** — a long lede overflowed the fixed-height spacer and collided with the action buttons. Now a **CSS grid-stack** (all slides in cell 1/1) auto-sizes the rotator to the tallest slide at any breakpoint — no overlap.
2. **Inconsistent title font** — hero h1 had no explicit weight, so the browser synthesized bold from whatever Inter weight was installed, making some slides' titles look like a different face. Pinned `font-family` + `font-weight:800` + `font-size` + `font-synthesis:none` on every slide → **same dimensions and fonts across all slides**.

Hub builds; landing JS parses. v2 (production hub).