### PR TITLE
pkg/forge: repo-host abstraction + GitLab read adapter

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	Agents        map[string]AgentConfig `yaml:"agents"`
 	Governor      GovernorConfig         `yaml:"governor"`
 	GitHub        GitHubConfig           `yaml:"github"`
+	GitLab        GitLabConfig           `yaml:"gitlab,omitempty"`
 	Notifications NotificationsConfig    `yaml:"notifications"`
 	Dashboard     DashboardConfig        `yaml:"dashboard"`
 	Data          DataConfig             `yaml:"data"`
@@ -258,6 +259,27 @@ type ProjectConfig struct {
 	AIAuthor    string   `yaml:"ai_author"`
 	PrimaryRepo string   `yaml:"primary_repo"`
 	OpenPRs     *bool    `yaml:"open_prs,omitempty"`
+	// Forge selects the source forge for this project: "github" (default) or
+	// "gitlab". It is additive — an absent value means GitHub, so existing
+	// GitHub-only configs are unaffected. Use ForgeKind() to read it with the
+	// default applied.
+	Forge string `yaml:"forge,omitempty"`
+}
+
+const (
+	// ForgeGitHub is the default forge kind (GitHub / GHE).
+	ForgeGitHub = "github"
+	// ForgeGitLab selects the GitLab forge (gitlab.com or self-managed).
+	ForgeGitLab = "gitlab"
+)
+
+// ForgeKind returns the configured forge kind, defaulting to ForgeGitHub when
+// unset so existing GitHub-only configs keep working unchanged.
+func (p *ProjectConfig) ForgeKind() string {
+	if p.Forge == "" {
+		return ForgeGitHub
+	}
+	return p.Forge
 }
 
 // PRsAllowed returns whether agents may open pull requests. Defaults to true.
@@ -1203,6 +1225,49 @@ const (
 	// still sign in with a github.com identity. No secret; safe to hardcode.
 	DefaultOAuthClientID = "Ov23ligE2p0gjXg6xAUf"
 )
+
+// GitLabConfig configures the GitLab forge (used when project.forge == "gitlab").
+// It is entirely additive: a config that never mentions gitlab is unaffected,
+// and the zero value points at public gitlab.com.
+//
+// The token itself is NOT stored here. Following Hive's no-hardcoded-secrets
+// rule, TokenEnv names the environment variable to read the GitLab access token
+// from at runtime (default GITLAB_TOKEN); the secret is never written to config.
+type GitLabConfig struct {
+	// URL is the GitLab instance root, e.g. "https://gitlab.com" (default) or a
+	// self-managed instance "https://gitlab.example.com". The "/api/v4" path is
+	// appended by the client.
+	URL string `yaml:"gitlab_url,omitempty"`
+	// TokenEnv is the environment variable holding the GitLab access token.
+	// Defaults to DefaultGitLabTokenEnv. The token value is resolved via
+	// os.Getenv at runtime and never persisted in config.
+	TokenEnv string `yaml:"token_env,omitempty"`
+}
+
+const (
+	// DefaultGitLabURL is the public GitLab SaaS instance root.
+	DefaultGitLabURL = "https://gitlab.com"
+	// DefaultGitLabTokenEnv is the default env var name for the GitLab token.
+	DefaultGitLabTokenEnv = "GITLAB_TOKEN"
+)
+
+// InstanceURL returns the configured GitLab instance root, defaulting to
+// DefaultGitLabURL when unset.
+func (g GitLabConfig) InstanceURL() string {
+	if g.URL == "" {
+		return DefaultGitLabURL
+	}
+	return g.URL
+}
+
+// TokenEnvName returns the env var name to read the GitLab token from,
+// defaulting to DefaultGitLabTokenEnv when unset.
+func (g GitLabConfig) TokenEnvName() string {
+	if g.TokenEnv == "" {
+		return DefaultGitLabTokenEnv
+	}
+	return g.TokenEnv
+}
 
 // IsPlaceholderApp reports whether app_id is the "no real App yet" sentinel.
 func (g GitHubConfig) IsPlaceholderApp() bool {

--- a/v2/pkg/config/forge_test.go
+++ b/v2/pkg/config/forge_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestProjectForgeKindDefault(t *testing.T) {
+	// Absent forge field defaults to github so existing configs are unaffected.
+	var p ProjectConfig
+	if got := p.ForgeKind(); got != ForgeGitHub {
+		t.Errorf("ForgeKind() default = %q, want %q", got, ForgeGitHub)
+	}
+
+	p.Forge = ForgeGitLab
+	if got := p.ForgeKind(); got != ForgeGitLab {
+		t.Errorf("ForgeKind() = %q, want %q", got, ForgeGitLab)
+	}
+}
+
+func TestForgeYAMLBackwardCompat(t *testing.T) {
+	// A GitHub-only config (no forge/gitlab keys) must parse cleanly and behave
+	// as github.
+	const doc = `
+project:
+  org: acme
+  name: widget
+  repos:
+    - acme/widget
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(doc), &cfg); err != nil {
+		t.Fatalf("unmarshal legacy config: %v", err)
+	}
+	if cfg.Project.ForgeKind() != ForgeGitHub {
+		t.Errorf("legacy config ForgeKind = %q, want github", cfg.Project.ForgeKind())
+	}
+	if cfg.GitLab.InstanceURL() != DefaultGitLabURL {
+		t.Errorf("default GitLab URL = %q, want %q", cfg.GitLab.InstanceURL(), DefaultGitLabURL)
+	}
+	if cfg.GitLab.TokenEnvName() != DefaultGitLabTokenEnv {
+		t.Errorf("default token env = %q, want %q", cfg.GitLab.TokenEnvName(), DefaultGitLabTokenEnv)
+	}
+}
+
+func TestForgeGitLabConfigParse(t *testing.T) {
+	const doc = `
+project:
+  org: acme
+  forge: gitlab
+gitlab:
+  gitlab_url: https://gitlab.example.com
+  token_env: MY_GL_TOKEN
+`
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(doc), &cfg); err != nil {
+		t.Fatalf("unmarshal gitlab config: %v", err)
+	}
+	if cfg.Project.ForgeKind() != ForgeGitLab {
+		t.Errorf("ForgeKind = %q, want gitlab", cfg.Project.ForgeKind())
+	}
+	if cfg.GitLab.InstanceURL() != "https://gitlab.example.com" {
+		t.Errorf("InstanceURL = %q", cfg.GitLab.InstanceURL())
+	}
+	if cfg.GitLab.TokenEnvName() != "MY_GL_TOKEN" {
+		t.Errorf("TokenEnvName = %q", cfg.GitLab.TokenEnvName())
+	}
+}

--- a/v2/pkg/forge/forge.go
+++ b/v2/pkg/forge/forge.go
@@ -1,0 +1,166 @@
+// Package forge provides a source-forge abstraction so Hive is not hardcoded
+// to GitHub. It defines a small, forge-neutral Forge interface and neutral data
+// types (Repo, Issue, ChangeRequest), plus concrete adapters for GitHub (a thin
+// wrapper over pkg/github) and GitLab (a stdlib net/http client for the REST v4
+// API).
+//
+// This is a FIRST SLICE: the read path (enumerate open issues / merge requests,
+// get a repo) is implemented and tested for both forges. The write path
+// (commenting, labelling, merging) is intentionally left as clearly-marked
+// TODOs on the interface rather than half-implemented — see the "Write path"
+// section of the Forge interface. Callers that need writes today should continue
+// to use *github.Client directly until those methods are filled in.
+package forge
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Kind identifies a supported forge implementation.
+type Kind string
+
+const (
+	// KindGitHub selects the GitHub adapter (wraps pkg/github).
+	KindGitHub Kind = "github"
+	// KindGitLab selects the GitLab adapter (REST API v4 over net/http).
+	KindGitLab Kind = "gitlab"
+)
+
+// Repo is a forge-neutral description of a repository / project.
+type Repo struct {
+	// FullName is the human "owner/name" (GitHub) or "namespace/path" (GitLab)
+	// slug that identifies the repo within its forge.
+	FullName string `json:"full_name"`
+	// Owner is the org/namespace portion of FullName.
+	Owner string `json:"owner"`
+	// Name is the repository/project name portion of FullName.
+	Name string `json:"name"`
+	// URL is the canonical web URL of the repo.
+	URL string `json:"url"`
+	// DefaultBranch is the repo's default branch (may be empty if unknown).
+	DefaultBranch string `json:"default_branch,omitempty"`
+	// Description is the repo's short description (may be empty).
+	Description string `json:"description,omitempty"`
+}
+
+// Issue is a forge-neutral issue. It maps GitHub issues and GitLab issues onto
+// one shape. Fields absent on a given forge are left at their zero value.
+type Issue struct {
+	Repo      string    `json:"repo"`
+	Number    int       `json:"number"`
+	Title     string    `json:"title"`
+	Author    string    `json:"author"`
+	Labels    []string  `json:"labels"`
+	Assignees []string  `json:"assignees"`
+	State     string    `json:"state"`
+	CreatedAt time.Time `json:"created_at"`
+	URL       string    `json:"url"`
+}
+
+// ChangeRequest is a forge-neutral pull request (GitHub) / merge request
+// (GitLab). The name is deliberately forge-neutral because "pull request" is a
+// GitHub term.
+type ChangeRequest struct {
+	Repo      string    `json:"repo"`
+	Number    int       `json:"number"`
+	Title     string    `json:"title"`
+	Author    string    `json:"author"`
+	Labels    []string  `json:"labels"`
+	Draft     bool      `json:"draft"`
+	State     string    `json:"state"`
+	CreatedAt time.Time `json:"created_at"`
+	URL       string    `json:"url"`
+	// SourceBranch / TargetBranch describe the change's direction. GitHub calls
+	// these head/base; GitLab calls them source/target. Empty when unknown.
+	SourceBranch string `json:"source_branch,omitempty"`
+	TargetBranch string `json:"target_branch,omitempty"`
+	// HeadSHA is the tip commit of the change (GitHub head SHA / GitLab sha).
+	HeadSHA string `json:"head_sha,omitempty"`
+}
+
+// Forge is the forge-neutral operation set Hive depends on. It is intentionally
+// minimal for this first slice.
+//
+// Read path — implemented by both the GitHub and GitLab adapters:
+//   - Kind
+//   - GetRepo
+//   - ListOpenIssues
+//   - ListOpenChangeRequests
+//
+// Write path — NOT part of this interface yet. Adding write operations
+// (comment, add/remove label, merge, hold/unhold) is deliberately deferred so
+// this slice compiles and is fully tested rather than broad-but-broken. When
+// added they should be forge-neutral, e.g.:
+//
+//	// TODO(forge write path): AddComment(ctx, repo string, number int, body string) error
+//	// TODO(forge write path): AddLabels(ctx, repo string, number int, labels []string) error
+//	// TODO(forge write path): RemoveLabel(ctx, repo string, number int, label string) error
+//	// TODO(forge write path): Merge(ctx, repo string, number int, opts MergeOptions) error
+//
+// GitHub already has concrete implementations of all of the above on
+// *github.Client; the write-path work is to lift those onto this interface and
+// implement the GitLab equivalents against the REST v4 API.
+type Forge interface {
+	// Kind reports which forge implementation this is.
+	Kind() Kind
+
+	// GetRepo fetches a single repo by its forge slug ("owner/name" for GitHub,
+	// "namespace/path" for GitLab).
+	GetRepo(ctx context.Context, repo string) (*Repo, error)
+
+	// ListOpenIssues returns the open issues for a repo. On GitHub this excludes
+	// pull requests (which the REST API models as issues); on GitLab issues and
+	// merge requests are already separate resources.
+	ListOpenIssues(ctx context.Context, repo string) ([]Issue, error)
+
+	// ListOpenChangeRequests returns the open pull requests (GitHub) / merge
+	// requests (GitLab) for a repo.
+	ListOpenChangeRequests(ctx context.Context, repo string) ([]ChangeRequest, error)
+}
+
+// Options configures a forge at construction time. All fields are optional; a
+// zero Options yields sensible defaults (public forge endpoints).
+type Options struct {
+	// BaseURL overrides the forge API base URL. For GitHub this is the REST API
+	// URL (e.g. GHE "https://github.example.com/api/v3"); empty uses the public
+	// default. For GitLab this is the instance root (e.g.
+	// "https://gitlab.example.com"); empty uses "https://gitlab.com". The GitLab
+	// adapter appends the "/api/v4" path itself.
+	BaseURL string
+	// Org is the default owner/namespace used when a repo slug has no "/" prefix.
+	Org string
+}
+
+// NewForge constructs a Forge of the given kind.
+//
+// token authenticates against the forge. It must be supplied by the caller
+// (typically from an environment variable such as GITHUB_TOKEN / GITLAB_TOKEN);
+// this package never reads or defaults secrets itself.
+//
+// For KindGitHub this builds a thin adapter over pkg/github.NewClient. For
+// KindGitLab this builds the stdlib REST v4 adapter.
+func NewForge(kind Kind, token string, opts Options) (Forge, error) {
+	switch kind {
+	case KindGitHub, Kind(""):
+		// Empty kind defaults to GitHub so existing GitHub-only configs keep
+		// working without naming a forge.
+		return newGitHubForge(token, opts), nil
+	case KindGitLab:
+		return newGitLabForge(token, opts)
+	default:
+		return nil, fmt.Errorf("unknown forge kind %q (want %q or %q)", kind, KindGitHub, KindGitLab)
+	}
+}
+
+// splitRepo splits an "owner/name" slug into its parts, falling back to
+// defaultOwner when no "/" is present. It is shared by the adapters.
+func splitRepo(repo, defaultOwner string) (owner, name string) {
+	for i := 0; i < len(repo); i++ {
+		if repo[i] == '/' {
+			return repo[:i], repo[i+1:]
+		}
+	}
+	return defaultOwner, repo
+}

--- a/v2/pkg/forge/forge_test.go
+++ b/v2/pkg/forge/forge_test.go
@@ -1,0 +1,158 @@
+package forge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v72/github"
+	"github.com/kubestellar/hive/v2/pkg/github"
+)
+
+func TestNewForge(t *testing.T) {
+	tests := []struct {
+		name     string
+		kind     Kind
+		wantKind Kind
+		wantErr  bool
+	}{
+		{"github", KindGitHub, KindGitHub, false},
+		{"gitlab", KindGitLab, KindGitLab, false},
+		{"empty defaults to github", Kind(""), KindGitHub, false},
+		{"unknown errors", Kind("bitbucket"), "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, err := NewForge(tt.kind, "token", Options{Org: "acme"})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewForge: %v", err)
+			}
+			if f.Kind() != tt.wantKind {
+				t.Errorf("Kind() = %q, want %q", f.Kind(), tt.wantKind)
+			}
+		})
+	}
+}
+
+func TestSplitRepo(t *testing.T) {
+	tests := []struct {
+		repo, defOwner, wantOwner, wantName string
+	}{
+		{"org/repo", "def", "org", "repo"},
+		{"repo", "def", "def", "repo"},
+		{"a/b/c", "def", "a", "b/c"},
+	}
+	for _, tt := range tests {
+		owner, name := splitRepo(tt.repo, tt.defOwner)
+		if owner != tt.wantOwner || name != tt.wantName {
+			t.Errorf("splitRepo(%q,%q) = %q,%q want %q,%q",
+				tt.repo, tt.defOwner, owner, name, tt.wantOwner, tt.wantName)
+		}
+	}
+}
+
+// stubGitHub implements githubReader for the GitHub adapter smoke test without
+// any network access.
+type stubGitHub struct {
+	repo   *gh.Repository
+	result *github.ActionableResult
+	err    error
+}
+
+func (s *stubGitHub) GetRepo(ctx context.Context, owner, repo string) (*gh.Repository, *gh.Response, error) {
+	if s.err != nil {
+		return nil, nil, s.err
+	}
+	return s.repo, &gh.Response{}, nil
+}
+
+func (s *stubGitHub) EnumerateActionable(ctx context.Context) (*github.ActionableResult, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.result, nil
+}
+
+func TestGitHubForgeGetRepo(t *testing.T) {
+	stub := &stubGitHub{
+		repo: &gh.Repository{
+			FullName:      gh.Ptr("acme/widget"),
+			HTMLURL:       gh.Ptr("https://github.com/acme/widget"),
+			DefaultBranch: gh.Ptr("main"),
+			Description:   gh.Ptr("a widget"),
+		},
+	}
+	f := newGitHubForgeWithReader(stub, "acme")
+
+	repo, err := f.GetRepo(context.Background(), "widget")
+	if err != nil {
+		t.Fatalf("GetRepo: %v", err)
+	}
+	if repo.FullName != "acme/widget" {
+		t.Errorf("FullName = %q", repo.FullName)
+	}
+	if repo.Owner != "acme" || repo.Name != "widget" {
+		t.Errorf("owner/name = %q/%q", repo.Owner, repo.Name)
+	}
+	if repo.DefaultBranch != "main" {
+		t.Errorf("DefaultBranch = %q", repo.DefaultBranch)
+	}
+}
+
+func TestGitHubForgeListIssuesAndCRs(t *testing.T) {
+	now := time.Now()
+	stub := &stubGitHub{
+		result: &github.ActionableResult{
+			Issues: github.IssueResult{
+				Count: 2,
+				Items: []github.Issue{
+					{Repo: "acme/widget", Number: 1, Title: "bug", Author: "alice", Labels: []string{"kind/bug"}, CreatedAt: now, URL: "u1"},
+					{Repo: "acme/other", Number: 2, Title: "elsewhere", Author: "bob", CreatedAt: now, URL: "u2"},
+				},
+			},
+			PRs: github.PRResult{
+				Count: 2,
+				Items: []github.PullRequest{
+					{Repo: "acme/widget", Number: 10, Title: "fix", Author: "carol", Draft: false, CreatedAt: now, URL: "p1", HeadSHA: "sha1"},
+					{Repo: "acme/other", Number: 11, Title: "other pr", Author: "dave", CreatedAt: now, URL: "p2"},
+				},
+			},
+		},
+	}
+	f := newGitHubForgeWithReader(stub, "acme")
+
+	issues, err := f.ListOpenIssues(context.Background(), "acme/widget")
+	if err != nil {
+		t.Fatalf("ListOpenIssues: %v", err)
+	}
+	// Filtered to the requested repo.
+	if len(issues) != 1 {
+		t.Fatalf("got %d issues, want 1 (filtered)", len(issues))
+	}
+	if issues[0].Number != 1 || issues[0].Author != "alice" || issues[0].State != "open" {
+		t.Errorf("issue = %+v", issues[0])
+	}
+
+	crs, err := f.ListOpenChangeRequests(context.Background(), "acme/widget")
+	if err != nil {
+		t.Fatalf("ListOpenChangeRequests: %v", err)
+	}
+	if len(crs) != 1 {
+		t.Fatalf("got %d change requests, want 1 (filtered)", len(crs))
+	}
+	if crs[0].Number != 10 || crs[0].HeadSHA != "sha1" || crs[0].State != "open" {
+		t.Errorf("cr = %+v", crs[0])
+	}
+
+	// Empty repo filter returns everything.
+	allIssues, _ := f.ListOpenIssues(context.Background(), "")
+	if len(allIssues) != 2 {
+		t.Errorf("unfiltered issues = %d, want 2", len(allIssues))
+	}
+}

--- a/v2/pkg/forge/github_forge.go
+++ b/v2/pkg/forge/github_forge.go
@@ -1,0 +1,133 @@
+package forge
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	gh "github.com/google/go-github/v72/github"
+	"github.com/kubestellar/hive/v2/pkg/github"
+)
+
+// githubReader is the subset of *github.Client the GitHub adapter needs for the
+// read path. Depending on an interface (rather than the concrete client) lets
+// tests inject a stub without real network calls, and keeps this adapter a thin
+// delegator over the existing client — no logic is duplicated here.
+type githubReader interface {
+	GetRepo(ctx context.Context, owner, repo string) (*gh.Repository, *gh.Response, error)
+	EnumerateActionable(ctx context.Context) (*github.ActionableResult, error)
+}
+
+// gitHubForge adapts the existing pkg/github client to the Forge interface.
+//
+// It is deliberately thin: read operations delegate to the underlying client
+// and translate its already-neutralized types (github.Issue/PullRequest) into
+// the forge-neutral types. The write path is not implemented here — callers that
+// need writes continue to use *github.Client directly until the Forge write
+// path (see TODOs on the Forge interface) lands.
+type gitHubForge struct {
+	client githubReader
+	org    string
+}
+
+// newGitHubForge builds a GitHub adapter backed by a real pkg/github client.
+func newGitHubForge(token string, opts Options) *gitHubForge {
+	// A single-repo enumeration is not what EnumerateActionable does, so the
+	// underlying client is constructed with no fixed repo list; per-repo reads
+	// go through the go-github client via GetRepo. The org is used to resolve
+	// bare repo names.
+	client := github.NewClient(token, opts.Org, nil, slog.Default(), opts.BaseURL)
+	return &gitHubForge{client: client, org: opts.Org}
+}
+
+// newGitHubForgeWithReader is a test seam: it builds the adapter over an
+// arbitrary githubReader (e.g. a stub), bypassing real client construction.
+func newGitHubForgeWithReader(r githubReader, org string) *gitHubForge {
+	return &gitHubForge{client: r, org: org}
+}
+
+func (f *gitHubForge) Kind() Kind { return KindGitHub }
+
+func (f *gitHubForge) GetRepo(ctx context.Context, repo string) (*Repo, error) {
+	owner, name := splitRepo(repo, f.org)
+	r, _, err := f.client.GetRepo(ctx, owner, name)
+	if err != nil {
+		return nil, fmt.Errorf("github: get repo %s/%s: %w", owner, name, err)
+	}
+	if r == nil {
+		return nil, fmt.Errorf("github: get repo %s/%s: empty response", owner, name)
+	}
+	return &Repo{
+		FullName:      r.GetFullName(),
+		Owner:         owner,
+		Name:          name,
+		URL:           r.GetHTMLURL(),
+		DefaultBranch: r.GetDefaultBranch(),
+		Description:   r.GetDescription(),
+	}, nil
+}
+
+// ListOpenIssues delegates to EnumerateActionable and filters to the requested
+// repo, reusing the existing client's issue-neutralization (author, labels,
+// assignees, PR exclusion) rather than re-implementing it here.
+func (f *gitHubForge) ListOpenIssues(ctx context.Context, repo string) ([]Issue, error) {
+	res, err := f.client.EnumerateActionable(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("github: list issues for %s: %w", repo, err)
+	}
+	if res == nil {
+		return nil, nil
+	}
+	out := make([]Issue, 0, len(res.Issues.Items))
+	for _, it := range res.Issues.Items {
+		if repo != "" && it.Repo != repo {
+			continue
+		}
+		out = append(out, Issue{
+			Repo:      it.Repo,
+			Number:    it.Number,
+			Title:     it.Title,
+			Author:    it.Author,
+			Labels:    it.Labels,
+			Assignees: it.Assignees,
+			State:     "open",
+			CreatedAt: it.CreatedAt,
+			URL:       it.URL,
+		})
+	}
+	return out, nil
+}
+
+// ListOpenChangeRequests delegates to EnumerateActionable and filters to the
+// requested repo.
+func (f *gitHubForge) ListOpenChangeRequests(ctx context.Context, repo string) ([]ChangeRequest, error) {
+	res, err := f.client.EnumerateActionable(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("github: list change requests for %s: %w", repo, err)
+	}
+	if res == nil {
+		return nil, nil
+	}
+	out := make([]ChangeRequest, 0, len(res.PRs.Items))
+	for _, pr := range res.PRs.Items {
+		if repo != "" && pr.Repo != repo {
+			continue
+		}
+		out = append(out, ChangeRequest{
+			Repo:      pr.Repo,
+			Number:    pr.Number,
+			Title:     pr.Title,
+			Author:    pr.Author,
+			Labels:    pr.Labels,
+			Draft:     pr.Draft,
+			State:     "open",
+			CreatedAt: pr.CreatedAt,
+			URL:       pr.URL,
+			HeadSHA:   pr.HeadSHA,
+		})
+	}
+	return out, nil
+}
+
+// Compile-time assertion that the adapter satisfies the interface.
+var _ Forge = (*gitHubForge)(nil)

--- a/v2/pkg/forge/gitlab_forge.go
+++ b/v2/pkg/forge/gitlab_forge.go
@@ -1,0 +1,344 @@
+package forge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// defaultGitLabBaseURL is the public GitLab SaaS instance root.
+	defaultGitLabBaseURL = "https://gitlab.com"
+	// gitLabAPIPath is the REST API v4 path appended to the instance root.
+	gitLabAPIPath = "/api/v4"
+	// gitLabPerPage is the page size requested from list endpoints.
+	gitLabPerPage = 100
+	// gitLabMaxPages caps pagination so a misbehaving server cannot loop us
+	// forever; 100 pages * 100 per page = 10k items, ample for a repo.
+	gitLabMaxPages = 100
+	// gitLabHTTPTimeout bounds a single HTTP request.
+	gitLabHTTPTimeout = 30 * time.Second
+	// gitLabTokenHeader is the GitLab personal/project access token header.
+	gitLabTokenHeader = "PRIVATE-TOKEN"
+)
+
+// gitLabForge implements Forge against the GitLab REST API v4 using only the
+// standard library. It covers the READ path (get project, list open issues,
+// list open merge requests). The write path is a TODO on the Forge interface.
+type gitLabForge struct {
+	baseURL string // instance root, no trailing slash, no /api/v4
+	token   string
+	org     string
+	http    *http.Client
+}
+
+// newGitLabForge constructs the GitLab adapter. token authenticates as a
+// PRIVATE-TOKEN header; it may be empty for unauthenticated reads of public
+// projects but is required for private ones. The caller supplies it (never read
+// from the environment here).
+func newGitLabForge(token string, opts Options) (*gitLabForge, error) {
+	base := strings.TrimRight(opts.BaseURL, "/")
+	if base == "" {
+		base = defaultGitLabBaseURL
+	}
+	if _, err := url.Parse(base); err != nil {
+		return nil, fmt.Errorf("gitlab: invalid base URL %q: %w", base, err)
+	}
+	return &gitLabForge{
+		baseURL: base,
+		token:   token,
+		org:     opts.Org,
+		http:    &http.Client{Timeout: gitLabHTTPTimeout},
+	}, nil
+}
+
+func (f *gitLabForge) Kind() Kind { return KindGitLab }
+
+// glProject is the subset of a GitLab project we map onto Repo.
+type glProject struct {
+	ID                int    `json:"id"`
+	PathWithNamespace string `json:"path_with_namespace"`
+	Path              string `json:"path"`
+	WebURL            string `json:"web_url"`
+	DefaultBranch     string `json:"default_branch"`
+	Description       string `json:"description"`
+	Namespace         struct {
+		FullPath string `json:"full_path"`
+		Path     string `json:"path"`
+	} `json:"namespace"`
+}
+
+// glUser is the author/assignee shape returned inline on issues and MRs.
+type glUser struct {
+	Username string `json:"username"`
+}
+
+// glIssue is the subset of a GitLab issue we map onto Issue.
+type glIssue struct {
+	IID       int       `json:"iid"`
+	Title     string    `json:"title"`
+	State     string    `json:"state"`
+	Labels    []string  `json:"labels"`
+	WebURL    string    `json:"web_url"`
+	CreatedAt time.Time `json:"created_at"`
+	Author    glUser    `json:"author"`
+	Assignees []glUser  `json:"assignees"`
+}
+
+// glMergeRequest is the subset of a GitLab merge request we map onto
+// ChangeRequest.
+type glMergeRequest struct {
+	IID          int       `json:"iid"`
+	Title        string    `json:"title"`
+	State        string    `json:"state"`
+	Labels       []string  `json:"labels"`
+	WebURL       string    `json:"web_url"`
+	CreatedAt    time.Time `json:"created_at"`
+	Draft        bool      `json:"draft"`
+	WorkInProg   bool      `json:"work_in_progress"`
+	SourceBranch string    `json:"source_branch"`
+	TargetBranch string    `json:"target_branch"`
+	SHA          string    `json:"sha"`
+	Author       glUser    `json:"author"`
+}
+
+// projectSlug resolves a repo argument into a GitLab project path. GitLab
+// namespaces can be nested ("group/subgroup/project"), so a bare name is only
+// prefixed with the default org when it contains no "/".
+func (f *gitLabForge) projectSlug(repo string) string {
+	if strings.Contains(repo, "/") {
+		return repo
+	}
+	if f.org != "" {
+		return f.org + "/" + repo
+	}
+	return repo
+}
+
+func (f *gitLabForge) GetRepo(ctx context.Context, repo string) (*Repo, error) {
+	slug := f.projectSlug(repo)
+	// GitLab requires the project path to be URL-encoded as a single path segment.
+	endpoint := fmt.Sprintf("/projects/%s", url.PathEscape(slug))
+	var p glProject
+	if err := f.getJSON(ctx, endpoint, nil, &p); err != nil {
+		return nil, fmt.Errorf("gitlab: get project %q: %w", slug, err)
+	}
+	full := p.PathWithNamespace
+	if full == "" {
+		full = slug
+	}
+	name := p.Path
+	if name == "" {
+		_, name = splitRepoLast(full)
+	}
+	owner := p.Namespace.FullPath
+	if owner == "" {
+		owner, _ = splitOwnerLast(full)
+	}
+	return &Repo{
+		FullName:      full,
+		Owner:         owner,
+		Name:          name,
+		URL:           p.WebURL,
+		DefaultBranch: p.DefaultBranch,
+		Description:   p.Description,
+	}, nil
+}
+
+func (f *gitLabForge) ListOpenIssues(ctx context.Context, repo string) ([]Issue, error) {
+	slug := f.projectSlug(repo)
+	endpoint := fmt.Sprintf("/projects/%s/issues", url.PathEscape(slug))
+	q := url.Values{}
+	q.Set("state", "opened")
+
+	var out []Issue
+	err := f.paginate(ctx, endpoint, q, func(body []byte) error {
+		var page []glIssue
+		if err := json.Unmarshal(body, &page); err != nil {
+			return fmt.Errorf("decoding issues page: %w", err)
+		}
+		for _, it := range page {
+			out = append(out, Issue{
+				Repo:      slug,
+				Number:    it.IID,
+				Title:     it.Title,
+				Author:    it.Author.Username,
+				Labels:    normalizeLabels(it.Labels),
+				Assignees: usernames(it.Assignees),
+				State:     it.State,
+				CreatedAt: it.CreatedAt,
+				URL:       it.WebURL,
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("gitlab: list issues for %q: %w", slug, err)
+	}
+	return out, nil
+}
+
+func (f *gitLabForge) ListOpenChangeRequests(ctx context.Context, repo string) ([]ChangeRequest, error) {
+	slug := f.projectSlug(repo)
+	endpoint := fmt.Sprintf("/projects/%s/merge_requests", url.PathEscape(slug))
+	q := url.Values{}
+	q.Set("state", "opened")
+
+	var out []ChangeRequest
+	err := f.paginate(ctx, endpoint, q, func(body []byte) error {
+		var page []glMergeRequest
+		if err := json.Unmarshal(body, &page); err != nil {
+			return fmt.Errorf("decoding merge_requests page: %w", err)
+		}
+		for _, mr := range page {
+			out = append(out, ChangeRequest{
+				Repo:         slug,
+				Number:       mr.IID,
+				Title:        mr.Title,
+				Author:       mr.Author.Username,
+				Labels:       normalizeLabels(mr.Labels),
+				Draft:        mr.Draft || mr.WorkInProg,
+				State:        mr.State,
+				CreatedAt:    mr.CreatedAt,
+				URL:          mr.WebURL,
+				SourceBranch: mr.SourceBranch,
+				TargetBranch: mr.TargetBranch,
+				HeadSHA:      mr.SHA,
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("gitlab: list merge requests for %q: %w", slug, err)
+	}
+	return out, nil
+}
+
+// pageFunc processes one page body and returns an error. The paginate loop
+// separately reads the X-Next-Page header to decide whether to continue.
+type pageFunc func(body []byte) error
+
+// paginate walks GitLab keyset/offset pagination via the X-Next-Page response
+// header, invoking fn for each page body.
+func (f *gitLabForge) paginate(ctx context.Context, endpoint string, q url.Values, fn pageFunc) error {
+	if q == nil {
+		q = url.Values{}
+	}
+	q.Set("per_page", strconv.Itoa(gitLabPerPage))
+	page := 1
+	for i := 0; i < gitLabMaxPages; i++ {
+		q.Set("page", strconv.Itoa(page))
+		body, nextPage, err := f.getRaw(ctx, endpoint, q)
+		if err != nil {
+			return err
+		}
+		if err := fn(body); err != nil {
+			return err
+		}
+		if nextPage == 0 {
+			return nil
+		}
+		page = nextPage
+	}
+	return nil
+}
+
+// getJSON issues a GET and decodes the response body into out.
+func (f *gitLabForge) getJSON(ctx context.Context, endpoint string, q url.Values, out any) error {
+	body, _, err := f.getRaw(ctx, endpoint, q)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("decoding response: %w", err)
+	}
+	return nil
+}
+
+// getRaw issues a GET against the API and returns the body plus the parsed
+// X-Next-Page header (0 when absent/last page).
+func (f *gitLabForge) getRaw(ctx context.Context, endpoint string, q url.Values) (body []byte, nextPage int, err error) {
+	u := f.baseURL + gitLabAPIPath + endpoint
+	if enc := q.Encode(); enc != "" {
+		u += "?" + enc
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, 0, fmt.Errorf("building request: %w", err)
+	}
+	if f.token != "" {
+		req.Header.Set(gitLabTokenHeader, f.token)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := f.http.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("request to %s: %w", endpoint, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, readErr := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, 0, fmt.Errorf("gitlab API %s returned status %d: %s", endpoint, resp.StatusCode, truncate(string(data), 200))
+	}
+	if readErr != nil {
+		return nil, 0, fmt.Errorf("reading body from %s: %w", endpoint, readErr)
+	}
+
+	if np := resp.Header.Get("X-Next-Page"); np != "" {
+		if parsed, convErr := strconv.Atoi(np); convErr == nil {
+			nextPage = parsed
+		}
+	}
+	return data, nextPage, nil
+}
+
+// normalizeLabels guards against a nil labels slice so downstream range/join
+// calls are always safe.
+func normalizeLabels(labels []string) []string {
+	if labels == nil {
+		return []string{}
+	}
+	return labels
+}
+
+// usernames extracts non-empty usernames from a slice of GitLab users.
+func usernames(users []glUser) []string {
+	out := make([]string, 0, len(users))
+	for _, u := range users {
+		if u.Username != "" {
+			out = append(out, u.Username)
+		}
+	}
+	return out
+}
+
+// splitRepoLast returns the owner and last path segment of a slug.
+func splitRepoLast(full string) (owner, name string) {
+	if i := strings.LastIndex(full, "/"); i >= 0 {
+		return full[:i], full[i+1:]
+	}
+	return "", full
+}
+
+// splitOwnerLast returns everything before the last "/" as owner.
+func splitOwnerLast(full string) (owner, name string) {
+	return splitRepoLast(full)
+}
+
+// truncate shortens s to at most n runes for error messages.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}
+
+// Compile-time assertion that the adapter satisfies the interface.
+var _ Forge = (*gitLabForge)(nil)

--- a/v2/pkg/forge/gitlab_forge_test.go
+++ b/v2/pkg/forge/gitlab_forge_test.go
@@ -1,0 +1,299 @@
+package forge
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newTestGitLab builds a gitLabForge pointed at a test server.
+func newTestGitLab(t *testing.T, serverURL, org string) *gitLabForge {
+	t.Helper()
+	f, err := newGitLabForge("test-token", Options{BaseURL: serverURL, Org: org})
+	if err != nil {
+		t.Fatalf("newGitLabForge: %v", err)
+	}
+	return f
+}
+
+const cankedProjectJSON = `{
+	"id": 42,
+	"path": "hive",
+	"path_with_namespace": "kubestellar/hive",
+	"web_url": "https://gitlab.com/kubestellar/hive",
+	"default_branch": "main",
+	"description": "Fleet automation",
+	"namespace": {"full_path": "kubestellar", "path": "kubestellar"}
+}`
+
+const cannedIssuesJSON = `[
+	{
+		"iid": 7,
+		"title": "Fix the widget",
+		"state": "opened",
+		"labels": ["kind/bug", "priority/high"],
+		"web_url": "https://gitlab.com/kubestellar/hive/-/issues/7",
+		"created_at": "2026-07-01T12:00:00Z",
+		"author": {"username": "alice"},
+		"assignees": [{"username": "bob"}, {"username": "carol"}]
+	},
+	{
+		"iid": 8,
+		"title": "Add docs",
+		"state": "opened",
+		"labels": [],
+		"web_url": "https://gitlab.com/kubestellar/hive/-/issues/8",
+		"created_at": "2026-07-02T09:30:00Z",
+		"author": {"username": "dave"},
+		"assignees": []
+	}
+]`
+
+const cannedMRsJSON = `[
+	{
+		"iid": 101,
+		"title": "Implement forge abstraction",
+		"state": "opened",
+		"labels": ["enhancement"],
+		"web_url": "https://gitlab.com/kubestellar/hive/-/merge_requests/101",
+		"created_at": "2026-07-05T08:00:00Z",
+		"draft": false,
+		"work_in_progress": false,
+		"source_branch": "feat-forge",
+		"target_branch": "main",
+		"sha": "abc123def",
+		"author": {"username": "erin"}
+	},
+	{
+		"iid": 102,
+		"title": "WIP: refactor",
+		"state": "opened",
+		"labels": [],
+		"web_url": "https://gitlab.com/kubestellar/hive/-/merge_requests/102",
+		"created_at": "2026-07-06T10:15:00Z",
+		"draft": true,
+		"work_in_progress": true,
+		"source_branch": "refactor",
+		"target_branch": "main",
+		"sha": "def456",
+		"author": {"username": "frank"}
+	}
+]`
+
+func TestGitLabGetRepo(t *testing.T) {
+	var gotAuth, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get(gitLabTokenHeader)
+		// RequestURI preserves the wire-level percent-encoding; r.URL.Path is
+		// already decoded by net/http and would hide the %2F.
+		gotPath = r.RequestURI
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(cankedProjectJSON))
+	}))
+	defer srv.Close()
+
+	f := newTestGitLab(t, srv.URL, "kubestellar")
+	repo, err := f.GetRepo(context.Background(), "hive")
+	if err != nil {
+		t.Fatalf("GetRepo: %v", err)
+	}
+
+	if gotAuth != "test-token" {
+		t.Errorf("PRIVATE-TOKEN header = %q, want test-token", gotAuth)
+	}
+	// Bare "hive" should be namespaced with org and URL-encoded as one segment.
+	if !strings.Contains(gotPath, "/api/v4/projects/") {
+		t.Errorf("path = %q, want /api/v4/projects/...", gotPath)
+	}
+	if !strings.Contains(gotPath, "kubestellar%2Fhive") {
+		t.Errorf("path = %q, want URL-encoded kubestellar%%2Fhive", gotPath)
+	}
+
+	if repo.FullName != "kubestellar/hive" {
+		t.Errorf("FullName = %q", repo.FullName)
+	}
+	if repo.Owner != "kubestellar" {
+		t.Errorf("Owner = %q", repo.Owner)
+	}
+	if repo.Name != "hive" {
+		t.Errorf("Name = %q", repo.Name)
+	}
+	if repo.DefaultBranch != "main" {
+		t.Errorf("DefaultBranch = %q", repo.DefaultBranch)
+	}
+	if repo.URL != "https://gitlab.com/kubestellar/hive" {
+		t.Errorf("URL = %q", repo.URL)
+	}
+	if repo.Description != "Fleet automation" {
+		t.Errorf("Description = %q", repo.Description)
+	}
+}
+
+func TestGitLabListOpenIssues(t *testing.T) {
+	var gotState string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/issues") {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		gotState = r.URL.Query().Get("state")
+		w.Header().Set("Content-Type", "application/json")
+		// No X-Next-Page header => single page.
+		_, _ = w.Write([]byte(cannedIssuesJSON))
+	}))
+	defer srv.Close()
+
+	f := newTestGitLab(t, srv.URL, "kubestellar")
+	issues, err := f.ListOpenIssues(context.Background(), "kubestellar/hive")
+	if err != nil {
+		t.Fatalf("ListOpenIssues: %v", err)
+	}
+
+	if gotState != "opened" {
+		t.Errorf("state query = %q, want opened", gotState)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("got %d issues, want 2", len(issues))
+	}
+
+	i0 := issues[0]
+	if i0.Number != 7 || i0.Title != "Fix the widget" || i0.Author != "alice" {
+		t.Errorf("issue[0] = %+v", i0)
+	}
+	if i0.State != "opened" {
+		t.Errorf("issue[0].State = %q", i0.State)
+	}
+	if len(i0.Labels) != 2 || i0.Labels[0] != "kind/bug" {
+		t.Errorf("issue[0].Labels = %v", i0.Labels)
+	}
+	if len(i0.Assignees) != 2 || i0.Assignees[0] != "bob" {
+		t.Errorf("issue[0].Assignees = %v", i0.Assignees)
+	}
+	if i0.Repo != "kubestellar/hive" {
+		t.Errorf("issue[0].Repo = %q", i0.Repo)
+	}
+	if i0.CreatedAt.IsZero() {
+		t.Error("issue[0].CreatedAt is zero")
+	}
+
+	// Empty labels must map to a non-nil slice (guard against nil range/join).
+	if issues[1].Labels == nil {
+		t.Error("issue[1].Labels should be non-nil empty slice")
+	}
+	if len(issues[1].Assignees) != 0 {
+		t.Errorf("issue[1].Assignees = %v, want empty", issues[1].Assignees)
+	}
+}
+
+func TestGitLabListOpenChangeRequests(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/merge_requests") {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(cannedMRsJSON))
+	}))
+	defer srv.Close()
+
+	f := newTestGitLab(t, srv.URL, "kubestellar")
+	crs, err := f.ListOpenChangeRequests(context.Background(), "kubestellar/hive")
+	if err != nil {
+		t.Fatalf("ListOpenChangeRequests: %v", err)
+	}
+	if len(crs) != 2 {
+		t.Fatalf("got %d change requests, want 2", len(crs))
+	}
+
+	c0 := crs[0]
+	if c0.Number != 101 || c0.Title != "Implement forge abstraction" || c0.Author != "erin" {
+		t.Errorf("cr[0] = %+v", c0)
+	}
+	if c0.Draft {
+		t.Error("cr[0].Draft should be false")
+	}
+	if c0.SourceBranch != "feat-forge" || c0.TargetBranch != "main" {
+		t.Errorf("cr[0] branches = %q -> %q", c0.SourceBranch, c0.TargetBranch)
+	}
+	if c0.HeadSHA != "abc123def" {
+		t.Errorf("cr[0].HeadSHA = %q", c0.HeadSHA)
+	}
+
+	// work_in_progress must be treated as draft.
+	if !crs[1].Draft {
+		t.Error("cr[1] (work_in_progress) should map to Draft=true")
+	}
+}
+
+func TestGitLabPagination(t *testing.T) {
+	// Two pages: first returns one issue with X-Next-Page: 2; second returns
+	// one issue with no next page.
+	page1 := `[{"iid":1,"title":"one","state":"opened","author":{"username":"a"}}]`
+	page2 := `[{"iid":2,"title":"two","state":"opened","author":{"username":"b"}}]`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Query().Get("page") {
+		case "1":
+			w.Header().Set("X-Next-Page", "2")
+			_, _ = w.Write([]byte(page1))
+		case "2":
+			// no X-Next-Page => last page
+			_, _ = w.Write([]byte(page2))
+		default:
+			t.Errorf("unexpected page %q", r.URL.Query().Get("page"))
+			_, _ = w.Write([]byte(`[]`))
+		}
+	}))
+	defer srv.Close()
+
+	f := newTestGitLab(t, srv.URL, "kubestellar")
+	issues, err := f.ListOpenIssues(context.Background(), "kubestellar/hive")
+	if err != nil {
+		t.Fatalf("ListOpenIssues: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("got %d issues across pages, want 2", len(issues))
+	}
+	if issues[0].Number != 1 || issues[1].Number != 2 {
+		t.Errorf("paginated issues = %d, %d", issues[0].Number, issues[1].Number)
+	}
+}
+
+func TestGitLabErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"404 Project Not Found"}`))
+	}))
+	defer srv.Close()
+
+	f := newTestGitLab(t, srv.URL, "kubestellar")
+	_, err := f.GetRepo(context.Background(), "kubestellar/missing")
+	if err == nil {
+		t.Fatal("expected error for 404, got nil")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("error should mention status: %v", err)
+	}
+}
+
+func TestGitLabProjectSlug(t *testing.T) {
+	tests := []struct {
+		name string
+		org  string
+		repo string
+		want string
+	}{
+		{"bare name with org", "kubestellar", "hive", "kubestellar/hive"},
+		{"already namespaced", "kubestellar", "other/hive", "other/hive"},
+		{"nested namespace", "kubestellar", "group/sub/proj", "group/sub/proj"},
+		{"bare name no org", "", "hive", "hive"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &gitLabForge{org: tt.org}
+			if got := f.projectSlug(tt.repo); got != tt.want {
+				t.Errorf("projectSlug(%q) = %q, want %q", tt.repo, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a small `pkg/forge` abstraction (Forge interface + neutral Repo/Issue/ChangeRequest types) with a thin GitHub adapter over the existing client and a GitLab REST read-path adapter (list issues/MRs, get repo; stdlib only, no new deps). Additive config: `forge:` defaults to github. Write path left as TODOs. Table tests via httptest. Build/vet/test green.