### PR TITLE
pkg/agentsmd: read repo AGENTS.md into context

### DIFF
--- a/v2/pkg/agentsmd/agentsmd.go
+++ b/v2/pkg/agentsmd/agentsmd.go
@@ -1,0 +1,362 @@
+// Package agentsmd reads a maintained repository's AGENTS.md file (the emerging
+// cross-tool convention for per-repo agent instructions) and a lightweight
+// "skills" mechanism, turning both into text that Hive prepends to an agent's
+// kick prompt.
+//
+// # AGENTS.md format
+//
+// AGENTS.md is a plain Markdown file at the repository root. Hive supports two
+// additive extensions on top of ordinary Markdown:
+//
+//  1. Optional YAML front-matter: a block delimited by a line containing only
+//     "---" at the very top of the file, closed by a second "---" line. The only
+//     key Hive reads is an optional "skills:" list naming skills to request into
+//     the agent's context by default. Everything else in the block is ignored.
+//     Example:
+//
+//     ---
+//     skills:
+//       - go-testing
+//       - pr-etiquette
+//     ---
+//
+//  2. Inline skill sections: any section whose heading is "## Skill: <name>"
+//     defines a reusable, named instruction snippet. The section body runs from
+//     the heading to the next "## " heading (or end of file). Skills may also be
+//     defined as standalone files at "skills/<name>.md" relative to the repo
+//     root; when both a file and an inline section define the same name, the
+//     inline section wins.
+//
+// The "body" is the Markdown document with the front-matter block and all
+// "## Skill:" sections removed — the general instructions that always apply.
+//
+// # Nested AGENTS.md (closest-wins)
+//
+// A repository may carry per-directory AGENTS.md files. When resolving
+// instructions for a file at a relative path, ParseNearest walks from that
+// file's directory up to the repo root and uses the closest AGENTS.md it finds.
+// The root AGENTS.md is the required baseline; nested files override it for
+// their subtree.
+//
+// # Tolerance
+//
+// Parsing never fails a kick. A missing AGENTS.md yields an empty config and a
+// nil error. Malformed front-matter is logged and skipped (the body is still
+// used). Callers may safely ignore the returned error for injection purposes.
+package agentsmd
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// AgentsFileName is the conventional filename Hive looks for.
+	AgentsFileName = "AGENTS.md"
+
+	// SkillsDirName is the directory holding standalone "<name>.md" skill files.
+	SkillsDirName = "skills"
+
+	// SkillFileExt is the extension for standalone skill files.
+	SkillFileExt = ".md"
+
+	// frontMatterDelim is the line (trimmed) that opens and closes the optional
+	// YAML front-matter block.
+	frontMatterDelim = "---"
+
+	// skillHeadingPrefix marks an inline skill section. A heading of the form
+	// "## Skill: <name>" begins a named skill snippet.
+	skillHeadingPrefix = "## Skill:"
+
+	// sectionHeadingPrefix is any level-2 Markdown heading; it terminates a
+	// skill section.
+	sectionHeadingPrefix = "## "
+
+	// injectionHeader titles the injected AGENTS.md block in the kick prompt,
+	// mirroring the "# Relevant Knowledge" convention used by the Primer.
+	injectionHeader = "# Repository Agent Instructions (AGENTS.md)"
+
+	// injectionSkillsHeader titles the resolved-skills subsection.
+	injectionSkillsHeader = "## Requested Skills"
+)
+
+// AgentsConfig is the parsed contents of an AGENTS.md file (and any adjacent
+// skills/ directory).
+type AgentsConfig struct {
+	// Body is the Markdown document with front-matter and "## Skill:" sections
+	// removed — the general instructions that always apply.
+	Body string
+
+	// Skills maps a skill name to its instruction text.
+	Skills map[string]string
+
+	// RequestedSkills lists skill names named in the front-matter "skills:" key,
+	// in file order. These are the skills the repo asks Hive to include by
+	// default.
+	RequestedSkills []string
+}
+
+// frontMatter is the subset of the YAML front-matter block Hive reads.
+type frontMatter struct {
+	Skills []string `yaml:"skills"`
+}
+
+// logger returns lg or a discarding default so callers may pass nil.
+func logger(lg *slog.Logger) *slog.Logger {
+	if lg != nil {
+		return lg
+	}
+	return slog.New(slog.DiscardHandler)
+}
+
+// Parse finds and parses the root AGENTS.md under repoRoot. It is tolerant:
+// a missing file yields an empty (non-nil) config and a nil error; malformed
+// front-matter is logged and skipped rather than failing.
+func Parse(repoRoot string, lg *slog.Logger) (*AgentsConfig, error) {
+	return parseAt(repoRoot, filepath.Join(repoRoot, AgentsFileName), logger(lg))
+}
+
+// ParseNearest resolves the closest-wins AGENTS.md for a file at relPath
+// (relative to repoRoot). It walks from relPath's directory up to repoRoot and
+// parses the first AGENTS.md it finds; if none exist in the subtree, it falls
+// back to the root AGENTS.md. Behaves tolerantly like Parse.
+func ParseNearest(repoRoot, relPath string, lg *slog.Logger) (*AgentsConfig, error) {
+	lg = logger(lg)
+
+	// Normalize and confine relPath to the repo. A path escaping the root falls
+	// back to the root file.
+	clean := filepath.Clean(relPath)
+	dir := filepath.Dir(filepath.Join(repoRoot, clean))
+
+	rootAbs, err := filepath.Abs(repoRoot)
+	if err != nil {
+		rootAbs = repoRoot
+	}
+
+	for {
+		candidate := filepath.Join(dir, AgentsFileName)
+		if info, statErr := os.Stat(candidate); statErr == nil && !info.IsDir() {
+			return parseAt(dir, candidate, lg)
+		}
+
+		dirAbs, absErr := filepath.Abs(dir)
+		if absErr != nil {
+			break
+		}
+		if dirAbs == rootAbs || !strings.HasPrefix(dirAbs, rootAbs) {
+			break
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	// Fall back to the root baseline.
+	return Parse(repoRoot, lg)
+}
+
+// parseAt parses the AGENTS.md at agentsPath, treating baseDir as the directory
+// whose skills/ subdirectory supplies standalone skill files.
+func parseAt(baseDir, agentsPath string, lg *slog.Logger) (*AgentsConfig, error) {
+	cfg := &AgentsConfig{Skills: map[string]string{}}
+
+	raw, err := os.ReadFile(agentsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Missing file is not an error — empty config.
+			return cfg, nil
+		}
+		// Unreadable file: tolerate, log, return empty config.
+		lg.Warn("agentsmd: cannot read AGENTS.md, skipping", "path", agentsPath, "error", err)
+		return cfg, nil
+	}
+
+	content := string(raw)
+
+	// 1. Strip and parse optional front-matter.
+	fm, rest := splitFrontMatter(content)
+	if fm != "" {
+		var meta frontMatter
+		if yErr := yaml.Unmarshal([]byte(fm), &meta); yErr != nil {
+			// Malformed front-matter: log and skip, keep the body.
+			lg.Warn("agentsmd: malformed front-matter, ignoring", "path", agentsPath, "error", yErr)
+		} else {
+			for _, s := range meta.Skills {
+				if s = strings.TrimSpace(s); s != "" {
+					cfg.RequestedSkills = append(cfg.RequestedSkills, s)
+				}
+			}
+		}
+	}
+
+	// 2. Extract inline "## Skill: <name>" sections; the remainder is the body.
+	body, inline := extractSkillSections(rest)
+	cfg.Body = strings.TrimSpace(body)
+
+	// 3. Load standalone skills/<name>.md files first, then let inline sections
+	//    override them (inline wins on name collision).
+	loadSkillFiles(baseDir, cfg.Skills, lg)
+	for name, text := range inline {
+		cfg.Skills[name] = text
+	}
+
+	return cfg, nil
+}
+
+// splitFrontMatter returns the YAML front-matter (without delimiters) and the
+// remaining document. If no front-matter block is present, front-matter is ""
+// and the whole content is returned as rest.
+func splitFrontMatter(content string) (fm, rest string) {
+	// Front-matter must be at the very top (after an optional BOM/leading
+	// whitespace-free start). Tolerate a leading newline only.
+	trimmed := strings.TrimLeft(content, "\r\n")
+	lines := strings.Split(trimmed, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != frontMatterDelim {
+		return "", content
+	}
+
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == frontMatterDelim {
+			fm = strings.Join(lines[1:i], "\n")
+			rest = strings.Join(lines[i+1:], "\n")
+			return fm, rest
+		}
+	}
+
+	// Opening delimiter with no close: not valid front-matter, treat as body.
+	return "", content
+}
+
+// extractSkillSections splits a Markdown body into (body-without-skills, skills).
+// A skill section starts at a "## Skill: <name>" heading and runs until the next
+// "## " heading or end of document.
+func extractSkillSections(body string) (string, map[string]string) {
+	skills := map[string]string{}
+	lines := strings.Split(body, "\n")
+
+	var bodyLines []string
+	var curName string
+	var curLines []string
+
+	flush := func() {
+		if curName != "" {
+			skills[curName] = strings.TrimSpace(strings.Join(curLines, "\n"))
+		}
+		curName = ""
+		curLines = nil
+	}
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, skillHeadingPrefix) {
+			flush()
+			curName = strings.TrimSpace(strings.TrimPrefix(trimmed, skillHeadingPrefix))
+			continue
+		}
+		if curName != "" && strings.HasPrefix(line, sectionHeadingPrefix) {
+			// A new non-skill section ends the current skill.
+			flush()
+			bodyLines = append(bodyLines, line)
+			continue
+		}
+		if curName != "" {
+			curLines = append(curLines, line)
+			continue
+		}
+		bodyLines = append(bodyLines, line)
+	}
+	flush()
+
+	return strings.Join(bodyLines, "\n"), skills
+}
+
+// loadSkillFiles reads standalone "<name>.md" files from baseDir/skills into
+// dst. Unreadable files are skipped tolerantly.
+func loadSkillFiles(baseDir string, dst map[string]string, lg *slog.Logger) {
+	skillsDir := filepath.Join(baseDir, SkillsDirName)
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		// No skills dir (or unreadable) — nothing to load.
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, SkillFileExt) {
+			continue
+		}
+		text, rErr := os.ReadFile(filepath.Join(skillsDir, name))
+		if rErr != nil {
+			lg.Warn("agentsmd: cannot read skill file, skipping", "file", name, "error", rErr)
+			continue
+		}
+		skillName := strings.TrimSuffix(name, SkillFileExt)
+		dst[skillName] = strings.TrimSpace(string(text))
+	}
+}
+
+// Resolve concatenates the instruction text of the named skills, in the order
+// requested. Unknown names are silently skipped. Returns "" when nothing
+// resolves.
+func (c *AgentsConfig) Resolve(names []string) string {
+	if c == nil || len(names) == 0 {
+		return ""
+	}
+	var parts []string
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if n == "" {
+			continue
+		}
+		if text, ok := c.Skills[n]; ok && strings.TrimSpace(text) != "" {
+			parts = append(parts, "### "+n+"\n\n"+strings.TrimSpace(text))
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// InjectionText renders the config's body plus the resolved skills as a Markdown
+// block ready to prepend to an agent kick. requestedSkills are the skills the
+// caller wants included; when nil, the config's own RequestedSkills (from
+// front-matter) are used. Returns "" when there is nothing to inject.
+func (c *AgentsConfig) InjectionText(requestedSkills []string) string {
+	if c == nil {
+		return ""
+	}
+
+	skills := requestedSkills
+	if skills == nil {
+		skills = c.RequestedSkills
+	}
+	resolved := c.Resolve(skills)
+
+	if strings.TrimSpace(c.Body) == "" && resolved == "" {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString(injectionHeader)
+	b.WriteString("\n\n")
+	if body := strings.TrimSpace(c.Body); body != "" {
+		b.WriteString(body)
+		b.WriteString("\n")
+	}
+	if resolved != "" {
+		if strings.TrimSpace(c.Body) != "" {
+			b.WriteString("\n")
+		}
+		b.WriteString(injectionSkillsHeader)
+		b.WriteString("\n\n")
+		b.WriteString(resolved)
+		b.WriteString("\n")
+	}
+	return b.String()
+}

--- a/v2/pkg/agentsmd/agentsmd_test.go
+++ b/v2/pkg/agentsmd/agentsmd_test.go
@@ -1,0 +1,262 @@
+package agentsmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeFile writes content to path under dir, creating parent directories.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+const sampleAgents = `---
+skills:
+  - go-testing
+  - pr-etiquette
+---
+
+# Project Instructions
+
+Always run gofmt before committing.
+Use table-driven tests.
+
+## Skill: go-testing
+
+Prefer t.TempDir over manual temp dirs.
+Never hit the network in unit tests.
+
+## Style Guide
+
+Two-space indent in YAML.
+
+## Skill: pr-etiquette
+
+Keep PRs small and focused.
+`
+
+func TestParse_BodyAndSkills(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, AgentsFileName), sampleAgents)
+
+	cfg, err := Parse(dir, nil)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+
+	// Front-matter skills requested, in order.
+	want := []string{"go-testing", "pr-etiquette"}
+	if len(cfg.RequestedSkills) != len(want) {
+		t.Fatalf("RequestedSkills = %v, want %v", cfg.RequestedSkills, want)
+	}
+	for i, s := range want {
+		if cfg.RequestedSkills[i] != s {
+			t.Errorf("RequestedSkills[%d] = %q, want %q", i, cfg.RequestedSkills[i], s)
+		}
+	}
+
+	// Body keeps general instructions and non-skill sections, drops skills and FM.
+	if !strings.Contains(cfg.Body, "Always run gofmt") {
+		t.Errorf("body missing general instruction: %q", cfg.Body)
+	}
+	if !strings.Contains(cfg.Body, "## Style Guide") {
+		t.Errorf("body missing non-skill section: %q", cfg.Body)
+	}
+	if strings.Contains(cfg.Body, "## Skill:") {
+		t.Errorf("body should not contain skill headings: %q", cfg.Body)
+	}
+	if strings.Contains(cfg.Body, "Keep PRs small") {
+		t.Errorf("body should not contain skill text: %q", cfg.Body)
+	}
+	if strings.Contains(cfg.Body, "skills:") {
+		t.Errorf("body should not contain front-matter: %q", cfg.Body)
+	}
+
+	// Inline skills extracted.
+	if got := cfg.Skills["go-testing"]; !strings.Contains(got, "t.TempDir") {
+		t.Errorf("go-testing skill = %q", got)
+	}
+	if got := cfg.Skills["pr-etiquette"]; !strings.Contains(got, "Keep PRs small") {
+		t.Errorf("pr-etiquette skill = %q", got)
+	}
+}
+
+func TestParse_MissingFile(t *testing.T) {
+	dir := t.TempDir() // no AGENTS.md
+	cfg, err := Parse(dir, nil)
+	if err != nil {
+		t.Fatalf("missing file should not error, got %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("cfg should be non-nil for missing file")
+	}
+	if cfg.Body != "" || len(cfg.Skills) != 0 || len(cfg.RequestedSkills) != 0 {
+		t.Errorf("missing file should yield empty config, got %+v", cfg)
+	}
+}
+
+func TestParse_MalformedFrontMatter(t *testing.T) {
+	dir := t.TempDir()
+	// Invalid YAML in the front-matter block; body must still parse.
+	content := "---\nskills: [unterminated\n : : :\n---\n\n# Title\n\nBody text here.\n"
+	writeFile(t, filepath.Join(dir, AgentsFileName), content)
+
+	cfg, err := Parse(dir, nil)
+	if err != nil {
+		t.Fatalf("malformed front-matter should not error, got %v", err)
+	}
+	if len(cfg.RequestedSkills) != 0 {
+		t.Errorf("malformed front-matter should yield no requested skills, got %v", cfg.RequestedSkills)
+	}
+	if !strings.Contains(cfg.Body, "Body text here.") {
+		t.Errorf("body should survive malformed front-matter, got %q", cfg.Body)
+	}
+}
+
+func TestParse_NoFrontMatter(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, AgentsFileName), "# Just Markdown\n\nNo front matter.\n")
+
+	cfg, err := Parse(dir, nil)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if !strings.Contains(cfg.Body, "No front matter.") {
+		t.Errorf("body = %q", cfg.Body)
+	}
+	if len(cfg.RequestedSkills) != 0 {
+		t.Errorf("unexpected requested skills: %v", cfg.RequestedSkills)
+	}
+}
+
+func TestResolve_KnownAndUnknown(t *testing.T) {
+	cfg := &AgentsConfig{
+		Skills: map[string]string{
+			"a": "alpha text",
+			"b": "beta text",
+		},
+	}
+
+	out := cfg.Resolve([]string{"a", "missing", "b"})
+	if !strings.Contains(out, "alpha text") || !strings.Contains(out, "beta text") {
+		t.Errorf("resolve missing known skills: %q", out)
+	}
+	if strings.Contains(out, "missing") {
+		t.Errorf("unknown skill should be skipped, got %q", out)
+	}
+
+	if cfg.Resolve(nil) != "" {
+		t.Error("Resolve(nil) should be empty")
+	}
+	if cfg.Resolve([]string{"nope"}) != "" {
+		t.Error("Resolve of only-unknown should be empty")
+	}
+}
+
+func TestSkillFiles_AndInlineOverride(t *testing.T) {
+	dir := t.TempDir()
+	// Inline defines "shared"; a file also defines "shared" and a unique "fileskill".
+	agents := "---\nskills:\n  - shared\n  - fileskill\n---\n\n# Title\n\n## Skill: shared\n\ninline version\n"
+	writeFile(t, filepath.Join(dir, AgentsFileName), agents)
+	writeFile(t, filepath.Join(dir, SkillsDirName, "shared.md"), "file version")
+	writeFile(t, filepath.Join(dir, SkillsDirName, "fileskill.md"), "standalone skill")
+
+	cfg, err := Parse(dir, nil)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+
+	if got := cfg.Skills["shared"]; got != "inline version" {
+		t.Errorf("inline should override file, got %q", got)
+	}
+	if got := cfg.Skills["fileskill"]; got != "standalone skill" {
+		t.Errorf("file skill = %q", got)
+	}
+}
+
+func TestParseNearest_ClosestWins(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, AgentsFileName), "# Root\n\nroot baseline instructions\n")
+	writeFile(t, filepath.Join(root, "sub", "pkg", AgentsFileName), "# Sub\n\nnested instructions\n")
+
+	// A file deep under the nested AGENTS.md picks the nested one.
+	cfg, err := ParseNearest(root, filepath.Join("sub", "pkg", "deep", "file.go"), nil)
+	if err != nil {
+		t.Fatalf("ParseNearest error: %v", err)
+	}
+	if !strings.Contains(cfg.Body, "nested instructions") {
+		t.Errorf("expected nested, got %q", cfg.Body)
+	}
+
+	// A file only under root (no nested dir) falls back to the root baseline.
+	cfg2, err := ParseNearest(root, filepath.Join("other", "file.go"), nil)
+	if err != nil {
+		t.Fatalf("ParseNearest error: %v", err)
+	}
+	if !strings.Contains(cfg2.Body, "root baseline") {
+		t.Errorf("expected root baseline, got %q", cfg2.Body)
+	}
+}
+
+func TestParseNearest_MissingRoot(t *testing.T) {
+	root := t.TempDir() // no AGENTS.md anywhere
+	cfg, err := ParseNearest(root, filepath.Join("a", "b.go"), nil)
+	if err != nil {
+		t.Fatalf("should not error, got %v", err)
+	}
+	if cfg.Body != "" {
+		t.Errorf("expected empty body, got %q", cfg.Body)
+	}
+}
+
+func TestInjectionText(t *testing.T) {
+	cfg := &AgentsConfig{
+		Body: "Do the thing carefully.",
+		Skills: map[string]string{
+			"go-testing": "Use t.TempDir.",
+		},
+		RequestedSkills: []string{"go-testing"},
+	}
+
+	// nil requestedSkills -> use config's own front-matter skills.
+	out := cfg.InjectionText(nil)
+	if !strings.Contains(out, injectionHeader) {
+		t.Errorf("missing header: %q", out)
+	}
+	if !strings.Contains(out, "Do the thing carefully.") {
+		t.Errorf("missing body: %q", out)
+	}
+	if !strings.Contains(out, "Use t.TempDir.") {
+		t.Errorf("missing resolved skill: %q", out)
+	}
+	if !strings.Contains(out, injectionSkillsHeader) {
+		t.Errorf("missing skills subheader: %q", out)
+	}
+
+	// Explicit empty slice -> body only, no skills section.
+	bodyOnly := cfg.InjectionText([]string{})
+	if strings.Contains(bodyOnly, injectionSkillsHeader) {
+		t.Errorf("empty requestedSkills should omit skills section: %q", bodyOnly)
+	}
+	if !strings.Contains(bodyOnly, "Do the thing carefully.") {
+		t.Errorf("body should still be present: %q", bodyOnly)
+	}
+
+	// Empty config -> empty injection.
+	if got := (&AgentsConfig{}).InjectionText(nil); got != "" {
+		t.Errorf("empty config should inject nothing, got %q", got)
+	}
+	// nil receiver safe.
+	var nilCfg *AgentsConfig
+	if got := nilCfg.InjectionText(nil); got != "" {
+		t.Errorf("nil config should inject nothing, got %q", got)
+	}
+}

--- a/v2/pkg/scheduler/scheduler.go
+++ b/v2/pkg/scheduler/scheduler.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kubestellar/hive/v2/pkg/agentsmd"
 	"github.com/kubestellar/hive/v2/pkg/classify"
 	"github.com/kubestellar/hive/v2/pkg/config"
 	"github.com/kubestellar/hive/v2/pkg/github"
@@ -184,6 +185,17 @@ func (s *Scheduler) substituteTemplate(template string, actionable *github.Actio
 		agentIssues = actionable.Issues.Items
 	}
 	knowledgeSection := s.primeKnowledge(agentIssues)
+
+	// Additive: prepend the repo's AGENTS.md instructions + requested skills to
+	// the injected knowledge, when a local checkout root is available. This is a
+	// guarded, single call point — it returns "" (and never errors) when no
+	// AGENTS.md exists, so it is a no-op for repos that don't use the convention.
+	// TODO(agentsmd): thread a per-repo checkout root here (e.g. from the git
+	// source's LocalDir) and, once file-level targeting exists, prefer
+	// agentsmd.ParseNearest for closest-wins nested AGENTS.md.
+	if agentsSection := s.primeAgentsMd(s.agentsRepoRoot()); agentsSection != "" {
+		knowledgeSection = agentsSection + "\n" + knowledgeSection
+	}
 
 	inceptionIdea, inceptionPhase, inceptionMode, inceptionAnswers, inceptionSlug, inceptionRepoURL := s.inceptionVars()
 
@@ -837,6 +849,41 @@ func filterByLane(issues []github.Issue, lane string) []github.Issue {
 }
 
 const maxIssuesToPrime = 5
+
+// agentsRepoRoot returns the local filesystem root of the primary repo's
+// checkout, or "" if no local checkout is configured. Hive agents operate over
+// GitHub rather than local clones, so this is usually empty today; the hook
+// exists so that when a checkout root becomes available (e.g. a git source's
+// LocalDir) the AGENTS.md convention is honored without further wiring.
+func (s *Scheduler) agentsRepoRoot() string {
+	// Intentionally conservative: only wired sources expose a root. Returning ""
+	// makes primeAgentsMd a no-op. See the TODO(agentsmd) at the call site.
+	return ""
+}
+
+// primeAgentsMd reads the repository's AGENTS.md (the cross-tool convention for
+// per-repo agent instructions) plus its requested skills and returns text to
+// prepend to the kick. It is tolerant: a missing or malformed file yields "".
+func (s *Scheduler) primeAgentsMd(repoRoot string) string {
+	if repoRoot == "" {
+		return ""
+	}
+	cfg, err := agentsmd.Parse(repoRoot, s.logger)
+	if err != nil {
+		// Parse is tolerant and should not error; log defensively and skip.
+		s.logger.Warn("agentsmd: parse failed, skipping injection", "root", repoRoot, "error", err)
+		return ""
+	}
+	section := cfg.InjectionText(nil)
+	if section != "" {
+		s.logger.Info("agentsmd: injecting repo instructions into kick",
+			"root", repoRoot,
+			"requested_skills", len(cfg.RequestedSkills),
+			"chars", len(section),
+		)
+	}
+	return section
+}
 
 // primeKnowledge queries the wiki layers for facts relevant to the given issues
 // and returns a formatted section for injection into the kick message.


### PR DESCRIPTION
Adds `pkg/agentsmd` — tolerant parser for a repo AGENTS.md (optional front-matter + named skill sections) whose text can be prepended to agent context, alongside the existing knowledge primer. Guarded no-op when absent. No new deps. Tests via temp dirs.