### PR TITLE
pkg/mint: short-lived token issuer + JWKS

### DIFF
--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -41,8 +41,28 @@ type Config struct {
 	HiveID        string                 `yaml:"hive_id"`
 	ACMMLevel     *int                   `yaml:"acmm_level,omitempty" json:"acmm_level"`
 	Variables     VariablesConfig        `yaml:"variables,omitempty"`
+	Mint          MintConfig             `yaml:"mint,omitempty"`
 
 	SourcePath string `yaml:"-" json:"-"`
+}
+
+// MintConfig configures the OIDC token mint service (pkg/mint). It is additive
+// and DISABLED by default: an absent `mint:` block, or Enabled=false, leaves
+// existing behavior byte-identical. When enabled, the mint issues short-lived
+// scoped JWTs (a Workload Identity Federation broker) that downstream cloud/
+// registry WIF providers can trust via Issuer + JWKS.
+type MintConfig struct {
+	// Enabled turns the mint service on. Default false (deny).
+	Enabled bool `yaml:"enabled,omitempty"`
+	// KeyPath is the PEM path of the signing key. If the file is absent the
+	// mint generates one and persists it with 0600 perms. Required when enabled.
+	KeyPath string `yaml:"key_path,omitempty"`
+	// Issuer is the `iss` claim and the identity WIF providers are configured to
+	// trust (typically the mint's public URL). Required when enabled.
+	Issuer string `yaml:"issuer,omitempty"`
+	// MaxTTLSeconds bounds a minted token's lifetime. 0 uses the package default
+	// (15m). The value is clamped to the package hard cap (1h) regardless.
+	MaxTTLSeconds int `yaml:"max_ttl_seconds,omitempty"`
 }
 
 // VariablesConfig declares operator-defined ${VAR} substitutions and the trust

--- a/v2/pkg/mint/mint.go
+++ b/v2/pkg/mint/mint.go
@@ -1,0 +1,353 @@
+// Package mint implements an OIDC-style token "mint" service for Hive.
+//
+// It issues short-lived, scoped OIDC (JWT) tokens that agents and spokes can
+// exchange for cloud/registry access via a Workload Identity Federation (WIF)
+// broker. This is the standards-based short-lived-credential path: instead of
+// distributing long-lived cloud keys, a caller proves its identity to the mint
+// (see server.go) and receives a narrowly-scoped, quickly-expiring JWT signed
+// by this hive. A downstream WIF provider (GCP/AWS/Azure/registry) is
+// configured to trust this hive's issuer + JWKS and swaps the JWT for a cloud
+// credential.
+//
+// This package ships the crypto core: signing, standard + scoped claims,
+// bounded TTL, verification (fail-closed), and a `.well-known/jwks.json` public
+// key set. The actual cloud-side WIF exchange is out of scope for the
+// foundation and lives on the provider (see the package README/TODOs).
+package mint
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+)
+
+const (
+	// DefaultMaxTTL is the default upper bound on a minted token's lifetime.
+	// Callers may request less; requests above this are clamped down.
+	DefaultMaxTTL = 15 * time.Minute
+
+	// HardCapTTL is the absolute ceiling on token lifetime regardless of the
+	// configured max_ttl. No minted token may ever live longer than this — it
+	// bounds the blast radius of a leaked short-lived credential.
+	HardCapTTL = 1 * time.Hour
+
+	// MinTTL is the smallest usable lifetime. A non-positive requested TTL
+	// falls back to the configured max.
+	MinTTL = 1 * time.Minute
+
+	// signingAlg is the JWT signing algorithm. RS256 matches the RSA key used
+	// elsewhere in hive (pkg/github/app.go) and is universally accepted by WIF
+	// providers.
+	signingAlg = "RS256"
+
+	// jwtKeyType / jwtUse describe the JWKS entry for an RSA signature key.
+	jwtKeyType = "RSA"
+	jwtUse     = "sig"
+
+	// clockSkewLeeway tolerates small clock differences between the mint and
+	// verifiers when checking exp/iat/nbf.
+	clockSkewLeeway = 30 * time.Second
+
+	// generatedKeyBits is the modulus size for keys this package generates.
+	generatedKeyBits = 2048
+
+	// keyFilePerms restricts a persisted private key to owner read/write only.
+	keyFilePerms = 0o600
+
+	// ScopesClaim is the custom JWT claim carrying the granted scope strings.
+	ScopesClaim = "scopes"
+	// HiveIDClaim carries the id of the hive that minted the token.
+	HiveIDClaim = "hive_id"
+)
+
+// Claims is the decoded payload of a minted token: the standard registered
+// claims (iss, sub, aud, exp, iat, jti) plus hive-specific scopes and hive id.
+type Claims struct {
+	jwt.RegisteredClaims
+	Scopes []string `json:"scopes,omitempty"`
+	HiveID string   `json:"hive_id,omitempty"`
+}
+
+// Minter signs and verifies scoped short-lived JWTs for a single issuer.
+type Minter struct {
+	key    *rsa.PrivateKey
+	issuer string
+	hiveID string
+	keyID  string
+	maxTTL time.Duration
+}
+
+// Option configures a Minter.
+type Option func(*Minter)
+
+// WithHiveID sets the hive id embedded in the hive_id claim.
+func WithHiveID(id string) Option { return func(m *Minter) { m.hiveID = id } }
+
+// WithMaxTTL sets the configured max TTL. It is silently clamped into
+// [MinTTL, HardCapTTL] so a misconfiguration can never widen the hard cap.
+func WithMaxTTL(d time.Duration) Option {
+	return func(m *Minter) {
+		if d <= 0 {
+			d = DefaultMaxTTL
+		}
+		if d < MinTTL {
+			d = MinTTL
+		}
+		if d > HardCapTTL {
+			d = HardCapTTL
+		}
+		m.maxTTL = d
+	}
+}
+
+// NewMinter builds a Minter from an existing RSA private key. issuer must be
+// non-empty (it is verified on every token and configured into WIF providers).
+func NewMinter(key *rsa.PrivateKey, issuer string, opts ...Option) (*Minter, error) {
+	if key == nil {
+		return nil, fmt.Errorf("mint: nil signing key")
+	}
+	if issuer == "" {
+		return nil, fmt.Errorf("mint: issuer is required")
+	}
+	m := &Minter{
+		key:    key,
+		issuer: issuer,
+		maxTTL: DefaultMaxTTL,
+		keyID:  keyIDFor(&key.PublicKey),
+	}
+	for _, o := range opts {
+		o(m)
+	}
+	return m, nil
+}
+
+// Mint issues a signed JWT for subject with the given audience and scopes.
+// The requested ttl is clamped into [MinTTL, min(maxTTL, HardCapTTL)]: a
+// non-positive ttl uses the configured max, and any ttl above the cap is
+// reduced to the cap (never denied — but never honored above the ceiling).
+func (m *Minter) Mint(subject, audience string, scopes []string, ttl time.Duration) (string, error) {
+	if subject == "" {
+		return "", fmt.Errorf("mint: subject is required")
+	}
+	if audience == "" {
+		return "", fmt.Errorf("mint: audience is required")
+	}
+
+	ttl = m.clampTTL(ttl)
+
+	now := time.Now()
+	claims := Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    m.issuer,
+			Subject:   subject,
+			Audience:  jwt.ClaimStrings{audience},
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now.Add(-clockSkewLeeway)),
+			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
+			ID:        uuid.NewString(),
+		},
+		Scopes: append([]string(nil), scopes...),
+		HiveID: m.hiveID,
+	}
+
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = m.keyID
+	signed, err := tok.SignedString(m.key)
+	if err != nil {
+		return "", fmt.Errorf("mint: signing token: %w", err)
+	}
+	return signed, nil
+}
+
+// clampTTL enforces the TTL policy. min(maxTTL, HardCapTTL) is the effective
+// ceiling; MinTTL is the floor; a non-positive request falls back to the max.
+func (m *Minter) clampTTL(ttl time.Duration) time.Duration {
+	ceiling := m.maxTTL
+	if ceiling > HardCapTTL {
+		ceiling = HardCapTTL
+	}
+	if ttl <= 0 || ttl > ceiling {
+		ttl = ceiling
+	}
+	if ttl < MinTTL {
+		ttl = MinTTL
+	}
+	return ttl
+}
+
+// MaxTTL returns the effective ceiling this minter will honor.
+func (m *Minter) MaxTTL() time.Duration {
+	if m.maxTTL > HardCapTTL {
+		return HardCapTTL
+	}
+	return m.maxTTL
+}
+
+// Verify validates a token's signature, algorithm, expiry, and issuer, and
+// returns the decoded claims. It fails closed: any parse/validation error, an
+// unexpected signing method, or an issuer mismatch yields a nil claims and a
+// non-nil error.
+func (m *Minter) Verify(token string) (*Claims, error) {
+	claims := &Claims{}
+	parsed, err := jwt.ParseWithClaims(token, claims,
+		func(t *jwt.Token) (interface{}, error) {
+			if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
+				return nil, fmt.Errorf("mint: unexpected signing method %q", t.Header["alg"])
+			}
+			return &m.key.PublicKey, nil
+		},
+		jwt.WithValidMethods([]string{signingAlg}),
+		jwt.WithIssuer(m.issuer),
+		jwt.WithLeeway(clockSkewLeeway),
+		jwt.WithExpirationRequired(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("mint: verifying token: %w", err)
+	}
+	if !parsed.Valid {
+		return nil, fmt.Errorf("mint: token invalid")
+	}
+	return claims, nil
+}
+
+// jwk is a single RSA public key in JSON Web Key form.
+type jwk struct {
+	Kty string `json:"kty"`
+	Use string `json:"use"`
+	Alg string `json:"alg"`
+	Kid string `json:"kid"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+type jwkSet struct {
+	Keys []jwk `json:"keys"`
+}
+
+// JWKS returns the public key set in standard `.well-known/jwks.json` shape so
+// verifiers (and WIF providers) can validate tokens this minter issues.
+func (m *Minter) JWKS() ([]byte, error) {
+	pub := &m.key.PublicKey
+	set := jwkSet{Keys: []jwk{{
+		Kty: jwtKeyType,
+		Use: jwtUse,
+		Alg: signingAlg,
+		Kid: m.keyID,
+		N:   base64.RawURLEncoding.EncodeToString(pub.N.Bytes()),
+		E:   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes()),
+	}}}
+	b, err := json.Marshal(set)
+	if err != nil {
+		return nil, fmt.Errorf("mint: marshaling JWKS: %w", err)
+	}
+	return b, nil
+}
+
+// keyIDFor derives a stable, deterministic key id from the public modulus.
+// A base64url SHA-256-free thumbprint is overkill for the foundation; we use a
+// short hash of the modulus so redeploys with the same key keep the same kid.
+func keyIDFor(pub *rsa.PublicKey) string {
+	sum := pub.N.Bytes()
+	const kidBytes = 8
+	if len(sum) > kidBytes {
+		sum = sum[:kidBytes]
+	}
+	return base64.RawURLEncoding.EncodeToString(sum)
+}
+
+// GenerateKey creates a fresh RSA signing key of generatedKeyBits.
+func GenerateKey() (*rsa.PrivateKey, error) {
+	key, err := rsa.GenerateKey(rand.Reader, generatedKeyBits)
+	if err != nil {
+		return nil, fmt.Errorf("mint: generating key: %w", err)
+	}
+	return key, nil
+}
+
+// LoadOrCreateKey reads a PKCS#8 PEM private key from path. If the file does
+// not exist it generates one, writes it with keyFilePerms (0600), and returns
+// it. This is the persistence helper for the mint's signing key. path must be
+// non-empty; secrets are never hardcoded — the caller supplies the path from
+// config/env.
+func LoadOrCreateKey(path string) (*rsa.PrivateKey, error) {
+	if path == "" {
+		return nil, fmt.Errorf("mint: key path is required")
+	}
+
+	data, err := os.ReadFile(path)
+	switch {
+	case err == nil:
+		key, perr := parsePEMKey(data)
+		if perr != nil {
+			return nil, fmt.Errorf("mint: parsing key %s: %w", path, perr)
+		}
+		return key, nil
+	case os.IsNotExist(err):
+		// fall through to generate + persist
+	default:
+		return nil, fmt.Errorf("mint: reading key %s: %w", path, err)
+	}
+
+	key, err := GenerateKey()
+	if err != nil {
+		return nil, err
+	}
+	if err := writeKeyPEM(path, key); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+func parsePEMKey(data []byte) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found")
+	}
+	if key, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
+		rsaKey, ok := key.(*rsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("PKCS8 key is not RSA")
+		}
+		return rsaKey, nil
+	}
+	// Fall back to PKCS1 for keys written by other tooling.
+	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing private key (PKCS8 and PKCS1 both failed): %w", err)
+	}
+	return key, nil
+}
+
+// writeKeyPEM writes key as a PKCS#8 PEM file with 0600 perms, atomically via a
+// temp file + rename so a partial write is never left in place.
+func writeKeyPEM(path string, key *rsa.PrivateKey) error {
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		return fmt.Errorf("mint: marshaling key: %w", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, pemBytes, keyFilePerms); err != nil {
+		return fmt.Errorf("mint: writing key %s: %w", tmp, err)
+	}
+	if err := os.Chmod(tmp, keyFilePerms); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("mint: chmod key %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("mint: renaming key into place: %w", err)
+	}
+	return nil
+}

--- a/v2/pkg/mint/mint_test.go
+++ b/v2/pkg/mint/mint_test.go
@@ -1,0 +1,317 @@
+package mint
+
+import (
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	testIssuer = "https://hive.example.test/mint"
+	testHiveID = "hive-test-1"
+	testSub    = "spoke-alpha"
+	testAud    = "//iam.googleapis.com/projects/123/locations/global/wif/providers/hive"
+)
+
+func newTestMinter(t *testing.T, opts ...Option) (*Minter, *rsa.PrivateKey) {
+	t.Helper()
+	key, err := GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	base := []Option{WithHiveID(testHiveID)}
+	m, err := NewMinter(key, testIssuer, append(base, opts...)...)
+	if err != nil {
+		t.Fatalf("NewMinter: %v", err)
+	}
+	return m, key
+}
+
+func TestMintVerifyRoundTrip(t *testing.T) {
+	m, _ := newTestMinter(t)
+	scopes := []string{"registry:pull", "gcs:read"}
+
+	tok, err := m.Mint(testSub, testAud, scopes, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+
+	claims, err := m.Verify(tok)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if claims.Issuer != testIssuer {
+		t.Errorf("issuer = %q, want %q", claims.Issuer, testIssuer)
+	}
+	if claims.Subject != testSub {
+		t.Errorf("subject = %q, want %q", claims.Subject, testSub)
+	}
+	if len(claims.Audience) != 1 || claims.Audience[0] != testAud {
+		t.Errorf("audience = %v, want [%q]", claims.Audience, testAud)
+	}
+	if claims.HiveID != testHiveID {
+		t.Errorf("hive_id = %q, want %q", claims.HiveID, testHiveID)
+	}
+	if claims.ID == "" {
+		t.Error("jti (ID) is empty")
+	}
+	if claims.ExpiresAt == nil || claims.IssuedAt == nil {
+		t.Fatal("exp/iat missing")
+	}
+}
+
+func TestScopesPreserved(t *testing.T) {
+	m, _ := newTestMinter(t)
+	scopes := []string{"a", "b", "c"}
+	tok, err := m.Mint(testSub, testAud, scopes, time.Minute)
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	claims, err := m.Verify(tok)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if strings.Join(claims.Scopes, ",") != "a,b,c" {
+		t.Errorf("scopes = %v, want [a b c]", claims.Scopes)
+	}
+}
+
+func TestExpiredTokenRejected(t *testing.T) {
+	m, key := newTestMinter(t)
+	// Hand-craft an already-expired token signed with the same key so we bypass
+	// Mint's TTL floor and test Verify's expiry enforcement directly.
+	now := time.Now()
+	claims := Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    testIssuer,
+			Subject:   testSub,
+			Audience:  jwt.ClaimStrings{testAud},
+			IssuedAt:  jwt.NewNumericDate(now.Add(-2 * time.Hour)),
+			ExpiresAt: jwt.NewNumericDate(now.Add(-1 * time.Hour)),
+			ID:        "expired-jti",
+		},
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	signed, err := tok.SignedString(key)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if _, err := m.Verify(signed); err == nil {
+		t.Fatal("expected expired token to be rejected")
+	}
+}
+
+func TestWrongIssuerRejected(t *testing.T) {
+	m, _ := newTestMinter(t)
+	// A second minter with the SAME key but a different issuer.
+	other, err := NewMinter(m.key, "https://evil.example/mint", WithHiveID(testHiveID))
+	if err != nil {
+		t.Fatalf("NewMinter: %v", err)
+	}
+	tok, err := other.Mint(testSub, testAud, nil, time.Minute)
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	if _, err := m.Verify(tok); err == nil {
+		t.Fatal("expected wrong-issuer token to be rejected")
+	}
+}
+
+func TestWrongSignatureRejected(t *testing.T) {
+	m, _ := newTestMinter(t)
+	// Token minted by a DIFFERENT key but claiming our issuer.
+	attacker, _ := newTestMinter(t)
+	attacker.issuer = testIssuer
+	tok, err := attacker.Mint(testSub, testAud, nil, time.Minute)
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	if _, err := m.Verify(tok); err == nil {
+		t.Fatal("expected wrong-signature token to be rejected")
+	}
+}
+
+func TestAlgNoneRejected(t *testing.T) {
+	m, _ := newTestMinter(t)
+	// Forge an alg=none token — must be rejected (fail closed).
+	claims := Claims{RegisteredClaims: jwt.RegisteredClaims{
+		Issuer:    testIssuer,
+		Subject:   testSub,
+		Audience:  jwt.ClaimStrings{testAud},
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	}}
+	tok := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+	signed, err := tok.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("sign none: %v", err)
+	}
+	if _, err := m.Verify(signed); err == nil {
+		t.Fatal("expected alg=none token to be rejected")
+	}
+}
+
+func TestTTLCapEnforced(t *testing.T) {
+	// Configure a small max; request far above the hard cap.
+	m, _ := newTestMinter(t, WithMaxTTL(10*time.Minute))
+	before := time.Now()
+	tok, err := m.Mint(testSub, testAud, nil, 999*time.Hour)
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	claims, err := m.Verify(tok)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	life := claims.ExpiresAt.Time.Sub(before)
+	if life > 10*time.Minute+clockSkewLeeway {
+		t.Errorf("token life %v exceeds configured max 10m", life)
+	}
+}
+
+func TestHardCapAlwaysWins(t *testing.T) {
+	// Even a misconfigured max above the hard cap is clamped.
+	m, _ := newTestMinter(t, WithMaxTTL(999*time.Hour))
+	if m.MaxTTL() != HardCapTTL {
+		t.Errorf("MaxTTL = %v, want hard cap %v", m.MaxTTL(), HardCapTTL)
+	}
+	before := time.Now()
+	tok, err := m.Mint(testSub, testAud, nil, 999*time.Hour)
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	claims, _ := m.Verify(tok)
+	life := claims.ExpiresAt.Time.Sub(before)
+	if life > HardCapTTL+clockSkewLeeway {
+		t.Errorf("token life %v exceeds hard cap %v", life, HardCapTTL)
+	}
+}
+
+func TestMintRequiresSubjectAndAudience(t *testing.T) {
+	m, _ := newTestMinter(t)
+	if _, err := m.Mint("", testAud, nil, time.Minute); err == nil {
+		t.Error("expected error for empty subject")
+	}
+	if _, err := m.Mint(testSub, "", nil, time.Minute); err == nil {
+		t.Error("expected error for empty audience")
+	}
+}
+
+func TestNewMinterValidation(t *testing.T) {
+	key, _ := GenerateKey()
+	if _, err := NewMinter(nil, testIssuer); err == nil {
+		t.Error("expected error for nil key")
+	}
+	if _, err := NewMinter(key, ""); err == nil {
+		t.Error("expected error for empty issuer")
+	}
+}
+
+func TestJWKSValidatesMintedToken(t *testing.T) {
+	m, _ := newTestMinter(t)
+	tok, err := m.Mint(testSub, testAud, []string{"x"}, time.Minute)
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+
+	jwksBytes, err := m.JWKS()
+	if err != nil {
+		t.Fatalf("JWKS: %v", err)
+	}
+
+	var set struct {
+		Keys []struct {
+			Kty, Use, Alg, Kid, N, E string
+		} `json:"keys"`
+	}
+	if err := json.Unmarshal(jwksBytes, &set); err != nil {
+		t.Fatalf("JWKS parse: %v", err)
+	}
+	if len(set.Keys) != 1 {
+		t.Fatalf("JWKS keys = %d, want 1", len(set.Keys))
+	}
+	k := set.Keys[0]
+	if k.Kty != "RSA" || k.Use != "sig" || k.Alg != "RS256" {
+		t.Errorf("unexpected JWKS entry: %+v", k)
+	}
+	if k.Kid == "" || k.N == "" || k.E == "" {
+		t.Errorf("JWKS entry missing kid/n/e: %+v", k)
+	}
+
+	// Reconstruct the public key from JWKS and verify the token independently.
+	pub := rebuildPublicKey(t, k.N, k.E)
+	parsed, err := jwt.Parse(tok, func(tk *jwt.Token) (interface{}, error) {
+		if _, ok := tk.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, jwt.ErrSignatureInvalid
+		}
+		return pub, nil
+	}, jwt.WithValidMethods([]string{"RS256"}))
+	if err != nil || !parsed.Valid {
+		t.Fatalf("token failed JWKS-reconstructed verification: err=%v valid=%v", err, parsed.Valid)
+	}
+
+	// kid in JWKS matches token header.
+	unverified, _, _ := jwt.NewParser().ParseUnverified(tok, jwt.MapClaims{})
+	if kid, _ := unverified.Header["kid"].(string); kid != k.Kid {
+		t.Errorf("token kid %q != JWKS kid %q", kid, k.Kid)
+	}
+}
+
+func rebuildPublicKey(t *testing.T, nB64, eB64 string) *rsa.PublicKey {
+	t.Helper()
+	nBytes := mustB64URL(t, nB64)
+	eBytes := mustB64URL(t, eB64)
+	n := new(big.Int).SetBytes(nBytes)
+	var e int
+	for _, b := range eBytes {
+		e = e<<8 | int(b)
+	}
+	return &rsa.PublicKey{N: n, E: e}
+}
+
+func mustB64URL(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		t.Fatalf("base64 decode %q: %v", s, err)
+	}
+	return b
+}
+
+func TestLoadOrCreateKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mint.pem")
+
+	// Create.
+	k1, err := LoadOrCreateKey(path)
+	if err != nil {
+		t.Fatalf("LoadOrCreateKey (create): %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("key perms = %o, want 600", perm)
+	}
+
+	// Load existing — must be the same key.
+	k2, err := LoadOrCreateKey(path)
+	if err != nil {
+		t.Fatalf("LoadOrCreateKey (load): %v", err)
+	}
+	if k1.N.Cmp(k2.N) != 0 {
+		t.Error("reloaded key differs from persisted key")
+	}
+
+	if _, err := LoadOrCreateKey(""); err == nil {
+		t.Error("expected error for empty key path")
+	}
+}

--- a/v2/pkg/mint/server.go
+++ b/v2/pkg/mint/server.go
@@ -1,0 +1,173 @@
+package mint
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	// MintPath is the endpoint that issues scoped tokens.
+	MintPath = "/mint"
+	// JWKSPath is the standard public-key discovery endpoint.
+	JWKSPath = "/.well-known/jwks.json"
+
+	// jwksCacheMaxAge advertises how long a verifier may cache the JWKS. Keys
+	// are long-lived so a generous cache is fine.
+	jwksCacheMaxAge = 5 * time.Minute
+
+	// maxMintBodyBytes bounds the request body to avoid unbounded reads.
+	maxMintBodyBytes = 16 << 10 // 16 KiB
+
+	// authScheme is the Authorization header scheme for the shared-secret gate.
+	authScheme = "Bearer "
+)
+
+// Server exposes the mint over HTTP.
+//
+// Caller authentication on /mint is, for this foundation, a shared-secret
+// bearer token (constant-time compared). This is deliberately minimal.
+//
+// TODO(caller-auth): replace the shared secret with real caller-identity
+// verification — e.g. validate a spoke/agent identity assertion (an inbound
+// OIDC token from the workload's own SA, or a mutual-TLS client cert), map it
+// to an allowed subject + scope set, and issue only scopes that identity is
+// entitled to. The shared secret proves "trusted network position", not "who".
+//
+// TODO(cloud-wif): the returned token is designed to be exchanged at a cloud
+// WIF provider (GCP STS / AWS AssumeRoleWithWebIdentity / Azure federated
+// credentials / registry token endpoint) configured to trust this issuer +
+// JWKS. That exchange is provider-side and out of scope here.
+type Server struct {
+	minter *Minter
+	secret string
+	logger *slog.Logger
+}
+
+// NewServer builds a mint HTTP server. secret is the shared bearer secret that
+// gates /mint; it must be non-empty (fail closed — an empty secret would allow
+// anyone to mint). The secret is supplied by config/env, never hardcoded.
+func NewServer(minter *Minter, secret string, logger *slog.Logger) (*Server, error) {
+	if minter == nil {
+		return nil, fmt.Errorf("mint: nil minter")
+	}
+	if secret == "" {
+		return nil, fmt.Errorf("mint: shared secret is required (fail closed)")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Server{minter: minter, secret: secret, logger: logger}, nil
+}
+
+// Handler returns an http.Handler serving MintPath and JWKSPath.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc(MintPath, s.handleMint)
+	mux.HandleFunc(JWKSPath, s.handleJWKS)
+	return mux
+}
+
+// MintRequest is the JSON body of a POST /mint call.
+type MintRequest struct {
+	Subject  string   `json:"subject"`
+	Audience string   `json:"audience"`
+	Scopes   []string `json:"scopes,omitempty"`
+	// TTLSeconds is the requested lifetime; 0 uses the configured max. Values
+	// above the cap are clamped down, never honored above the ceiling.
+	TTLSeconds int `json:"ttl_seconds,omitempty"`
+}
+
+// MintResponse is the JSON body returned on success.
+type MintResponse struct {
+	Token         string `json:"token"`
+	TokenType     string `json:"token_type"`
+	ExpiresInSecs int    `json:"expires_in"`
+	Issuer        string `json:"issuer"`
+}
+
+func (s *Server) handleMint(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeErr(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if !s.authorized(r) {
+		// Fail closed. Do not distinguish missing vs wrong secret.
+		writeErr(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxMintBodyBytes)
+	var req MintRequest
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	ttl := time.Duration(req.TTLSeconds) * time.Second
+	token, err := s.minter.Mint(req.Subject, req.Audience, req.Scopes, ttl)
+	if err != nil {
+		// Mint only errors on caller-supplied invalid input (missing
+		// subject/audience) — treat as a 400, never leak internals.
+		writeErr(w, http.StatusBadRequest, "cannot mint token")
+		return
+	}
+
+	// Re-derive the honored TTL for the response (Mint clamps internally).
+	honored := s.minter.clampTTL(ttl)
+	resp := MintResponse{
+		Token:         token,
+		TokenType:     "Bearer",
+		ExpiresInSecs: int(honored.Seconds()),
+		Issuer:        s.minter.issuer,
+	}
+	writeJSON(w, http.StatusOK, resp)
+	s.logger.Info("token minted",
+		"subject", req.Subject, "audience", req.Audience,
+		"scopes", req.Scopes, "ttl_seconds", int(honored.Seconds()))
+}
+
+func (s *Server) handleJWKS(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeErr(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	body, err := s.minter.JWKS()
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "jwks unavailable")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", int(jwksCacheMaxAge.Seconds())))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
+// authorized checks the shared-secret bearer token in constant time.
+func (s *Server) authorized(r *http.Request) bool {
+	h := r.Header.Get("Authorization")
+	if !strings.HasPrefix(h, authScheme) {
+		return false
+	}
+	presented := strings.TrimPrefix(h, authScheme)
+	// Constant-time compare; length-independent short-circuit is unavoidable
+	// but subtle.ConstantTimeCompare returns 0 on length mismatch without
+	// leaking which byte differed.
+	return subtle.ConstantTimeCompare([]byte(presented), []byte(s.secret)) == 1
+}
+
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeErr(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}

--- a/v2/pkg/mint/server_test.go
+++ b/v2/pkg/mint/server_test.go
@@ -1,0 +1,174 @@
+package mint
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const testSecret = "s3cret-shared-token"
+
+func newTestServer(t *testing.T) (*Server, *Minter) {
+	t.Helper()
+	m, _ := newTestMinter(t)
+	srv, err := NewServer(m, testSecret, nil)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	return srv, m
+}
+
+func TestNewServerRejectsEmptySecret(t *testing.T) {
+	m, _ := newTestMinter(t)
+	if _, err := NewServer(m, "", nil); err == nil {
+		t.Error("expected error for empty secret (fail closed)")
+	}
+	if _, err := NewServer(nil, testSecret, nil); err == nil {
+		t.Error("expected error for nil minter")
+	}
+}
+
+func TestMintHandlerReturnsToken(t *testing.T) {
+	srv, m := newTestServer(t)
+	h := srv.Handler()
+
+	body, _ := json.Marshal(MintRequest{
+		Subject:    testSub,
+		Audience:   testAud,
+		Scopes:     []string{"registry:pull"},
+		TTLSeconds: 300,
+	})
+	req := httptest.NewRequest(http.MethodPost, MintPath, bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+testSecret)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp MintResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Token == "" {
+		t.Fatal("empty token")
+	}
+	if resp.TokenType != "Bearer" {
+		t.Errorf("token_type = %q, want Bearer", resp.TokenType)
+	}
+	if resp.ExpiresInSecs != 300 {
+		t.Errorf("expires_in = %d, want 300", resp.ExpiresInSecs)
+	}
+	// Token must verify against the minter.
+	claims, err := m.Verify(resp.Token)
+	if err != nil {
+		t.Fatalf("Verify minted token: %v", err)
+	}
+	if len(claims.Scopes) != 1 || claims.Scopes[0] != "registry:pull" {
+		t.Errorf("scopes = %v", claims.Scopes)
+	}
+}
+
+func TestMintHandlerRejectsUnauthorized(t *testing.T) {
+	srv, _ := newTestServer(t)
+	h := srv.Handler()
+
+	cases := map[string]string{
+		"no header":    "",
+		"wrong secret": "Bearer wrong",
+		"wrong scheme": "Basic " + testSecret,
+	}
+	for name, auth := range cases {
+		t.Run(name, func(t *testing.T) {
+			body, _ := json.Marshal(MintRequest{Subject: testSub, Audience: testAud})
+			req := httptest.NewRequest(http.MethodPost, MintPath, bytes.NewReader(body))
+			if auth != "" {
+				req.Header.Set("Authorization", auth)
+			}
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+			if rr.Code != http.StatusUnauthorized {
+				t.Errorf("status = %d, want 401", rr.Code)
+			}
+		})
+	}
+}
+
+func TestMintHandlerBadRequest(t *testing.T) {
+	srv, _ := newTestServer(t)
+	h := srv.Handler()
+
+	// Missing subject/audience -> Mint errors -> 400.
+	body, _ := json.Marshal(MintRequest{Scopes: []string{"x"}})
+	req := httptest.NewRequest(http.MethodPost, MintPath, bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+testSecret)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rr.Code)
+	}
+
+	// Malformed JSON -> 400.
+	req2 := httptest.NewRequest(http.MethodPost, MintPath, strings.NewReader("{not json"))
+	req2.Header.Set("Authorization", "Bearer "+testSecret)
+	rr2 := httptest.NewRecorder()
+	h.ServeHTTP(rr2, req2)
+	if rr2.Code != http.StatusBadRequest {
+		t.Errorf("malformed status = %d, want 400", rr2.Code)
+	}
+}
+
+func TestMintHandlerMethodNotAllowed(t *testing.T) {
+	srv, _ := newTestServer(t)
+	h := srv.Handler()
+	req := httptest.NewRequest(http.MethodGet, MintPath, nil)
+	req.Header.Set("Authorization", "Bearer "+testSecret)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", rr.Code)
+	}
+}
+
+func TestJWKSHandlerServesKeys(t *testing.T) {
+	srv, m := newTestServer(t)
+	h := srv.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, JWKSPath, nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type = %q", ct)
+	}
+
+	var set struct {
+		Keys []map[string]string `json:"keys"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &set); err != nil {
+		t.Fatalf("decode JWKS: %v", err)
+	}
+	if len(set.Keys) != 1 {
+		t.Fatalf("keys = %d, want 1", len(set.Keys))
+	}
+
+	// JWKS is unauthenticated (public discovery) and validates a real token.
+	tok, err := m.Mint(testSub, testAud, nil, 60_000_000_000) // 60s
+	if err != nil {
+		t.Fatalf("Mint: %v", err)
+	}
+	pub := rebuildPublicKey(t, set.Keys[0]["n"], set.Keys[0]["e"])
+	if pub == nil {
+		t.Fatal("nil reconstructed key")
+	}
+	// Sanity: verify through the minter (JWKS-independence covered in mint_test).
+	if _, err := m.Verify(tok); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+}


### PR DESCRIPTION
Adds `pkg/mint` — issues signed, scoped, short-lived JWTs (RS256) with a TTL cap and a JWKS endpoint for verification. Off by default via additive `mint:` config; keys 0600, no hardcoded secrets. Caller-auth and cloud exchange left as TODOs. Round-trip + expiry + cap + handler tests.