### PR TITLE
✨ feat(hub): hive opens PRs as the App bot (request-file watcher) — additive, no queue impact

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -687,6 +687,16 @@ func main() {
 		go agentMgr.StartAgentTokenRefresh(ctx)
 	}
 
+	// PR-open-as-the-App-bot: agents push their branch (App-token credential
+	// helper) then drop a request file; the hive opens the PR here with the App
+	// token so it is authored by "<slug>[bot]", not the Copilot login user.
+	// Gated on a real client + usable App — with no App there is no bot to author
+	// as, and requests simply accumulate rather than opening under a wrong
+	// identity. ghClient uses the App installation token (see ghAuth wiring).
+	if ghClient != nil && cfg.GitHub.HasUsableApp() {
+		ghClient.StartPRRequestWatcher(ctx, nil)
+	}
+
 	go agent.StartPermissionsWatcher(logger)
 
 	const statePath = "/data/hive-state.json"

--- a/v2/pkg/github/pr_request_watcher.go
+++ b/v2/pkg/github/pr_request_watcher.go
@@ -1,0 +1,203 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// PRRequestDir is where agents drop PR-open requests. An agent pushes its branch
+// (the credential helper uses the App token, so the push is already the App
+// identity) and then writes a request file here INSTEAD of running `gh pr
+// create`. The hive's watcher opens the PR with the App token, so the PR is
+// authored by the App bot — never the Copilot login user. This keeps PR
+// authorship deterministic without touching Copilot's auth/entitlement.
+const PRRequestDir = "/var/run/hive-metrics/pr-requests"
+
+// prRequestDirForTest lets tests point the watcher at a temp dir. Empty means
+// use PRRequestDir. Not for production use.
+var prRequestDirForTest string
+
+func prRequestDir() string {
+	if prRequestDirForTest != "" {
+		return prRequestDirForTest
+	}
+	return PRRequestDir
+}
+
+// prRequestPollInterval is how often the watcher scans PRRequestDir. PR opens
+// are not latency-critical (the agent has already pushed and moved on), so a
+// modest interval keeps the API/log noise low.
+const prRequestPollInterval = 10 * time.Second
+
+// PRRequest is the JSON an agent writes to PRRequestDir to ask the hive to open
+// a PR on its behalf. Repo may be "owner/repo" or a bare repo name; Base
+// defaults to "main".
+type PRRequest struct {
+	Repo   string `json:"repo"`
+	Head   string `json:"head"`
+	Base   string `json:"base,omitempty"`
+	Title  string `json:"title"`
+	Body   string `json:"body,omitempty"`
+	Agent  string `json:"agent,omitempty"`
+	IssueN []int  `json:"issues,omitempty"` // informational; the body already carries "Fixes #N"
+}
+
+// PRResponse is written back next to a consumed request (as <name>.result.json)
+// so the agent — or an operator debugging — can see what happened.
+type PRResponse struct {
+	OK             bool   `json:"ok"`
+	Number         int    `json:"number,omitempty"`
+	URL            string `json:"url,omitempty"`
+	AlreadyExisted bool   `json:"already_existed,omitempty"`
+	Error          string `json:"error,omitempty"`
+	At             string `json:"at"`
+}
+
+// StartPRRequestWatcher runs a loop that opens PRs for request files dropped in
+// PRRequestDir. It returns immediately; the loop runs until ctx is cancelled.
+// A nil client (no GitHub creds) makes this a no-op: requests accumulate rather
+// than being silently dropped, so the feature degrades to "nothing opens" not
+// "opened as the wrong identity".
+//
+// nowFn is injectable for tests; pass nil for time.Now.
+func (c *Client) StartPRRequestWatcher(ctx context.Context, nowFn func() time.Time) {
+	if c == nil {
+		return
+	}
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	if err := os.MkdirAll(prRequestDir(), 0o777); err != nil {
+		c.logger.Warn("pr-request watcher: cannot create request dir; disabled",
+			slog.String("dir", prRequestDir()), slog.String("error", err.Error()))
+		return
+	}
+	go func() {
+		t := time.NewTicker(prRequestPollInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				c.processPRRequests(ctx, nowFn)
+			}
+		}
+	}()
+	c.logger.Info("pr-request watcher started", slog.String("dir", prRequestDir()))
+}
+
+// processPRRequests handles one scan of the request dir. Exported-in-spirit for
+// tests via ProcessPRRequestsOnce.
+func (c *Client) processPRRequests(ctx context.Context, nowFn func() time.Time) {
+	entries, err := os.ReadDir(prRequestDir())
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		name := e.Name()
+		// Only consume request files; skip our own .result.json outputs.
+		if e.IsDir() || !strings.HasSuffix(name, ".json") || strings.HasSuffix(name, ".result.json") {
+			continue
+		}
+		path := filepath.Join(prRequestDir(), name)
+		c.handleOnePRRequest(ctx, path, nowFn)
+	}
+}
+
+// ProcessPRRequestsOnce runs a single scan+process pass. Test/CLI entry point.
+func (c *Client) ProcessPRRequestsOnce(ctx context.Context) {
+	if c == nil {
+		return
+	}
+	c.processPRRequests(ctx, time.Now)
+}
+
+func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func() time.Time) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return // vanished between ReadDir and here — fine
+	}
+	var req PRRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		// A malformed request can never succeed; move it aside so it stops being
+		// retried every tick, and leave a result explaining why.
+		c.writePRResult(path, PRResponse{OK: false, Error: "invalid JSON: " + err.Error(), At: nowFn().UTC().Format(time.RFC3339)})
+		_ = os.Rename(path, path+".bad")
+		c.logger.Warn("pr-request watcher: bad request file quarantined",
+			slog.String("path", path), slog.String("error", err.Error()))
+		return
+	}
+
+	res, err := c.CreatePR(ctx, req.Repo, req.Head, req.Base, req.Title, req.Body)
+	resp := PRResponse{At: nowFn().UTC().Format(time.RFC3339)}
+	if err != nil {
+		// Leave the request in place so the next tick retries (transient API
+		// errors, main not yet pushed, etc.), but record the last error.
+		resp.OK = false
+		resp.Error = err.Error()
+		c.writePRResult(path, resp)
+		c.logger.Warn("pr-request watcher: open failed, will retry",
+			slog.String("repo", req.Repo), slog.String("head", req.Head), slog.String("error", err.Error()))
+		return
+	}
+	resp.OK = true
+	resp.Number = res.Number
+	resp.URL = res.URL
+	resp.AlreadyExisted = res.AlreadyExisted
+	c.writePRResult(path, resp)
+	// Success (or reuse of an existing PR) — consume the request so it isn't
+	// reprocessed.
+	_ = os.Remove(path)
+	c.logger.Info("pr-request watcher: PR opened by App bot",
+		slog.String("repo", req.Repo), slog.String("head", req.Head),
+		slog.Int("number", res.Number), slog.Bool("reused", res.AlreadyExisted),
+		slog.String("agent", req.Agent))
+}
+
+func (c *Client) writePRResult(reqPath string, resp PRResponse) {
+	out := strings.TrimSuffix(reqPath, ".json") + ".result.json"
+	if b, err := json.MarshalIndent(resp, "", "  "); err == nil {
+		_ = os.WriteFile(out, b, 0o644)
+	}
+}
+
+// WritePRRequest is a helper (used by tests and any in-process caller) to drop a
+// well-formed request file into PRRequestDir.
+func WritePRRequest(dir string, req PRRequest) (string, error) {
+	if err := os.MkdirAll(dir, 0o777); err != nil {
+		return "", err
+	}
+	b, err := json.MarshalIndent(req, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	name := fmt.Sprintf("%s-%d.json", sanitizeAgentName(req.Agent), time.Now().UnixNano())
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func sanitizeAgentName(s string) string {
+	if s == "" {
+		return "agent"
+	}
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			b.WriteRune(r)
+		}
+	}
+	if b.Len() == 0 {
+		return "agent"
+	}
+	return b.String()
+}

--- a/v2/pkg/github/pr_request_watcher_test.go
+++ b/v2/pkg/github/pr_request_watcher_test.go
@@ -1,0 +1,141 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// mock GitHub API for PR create + list. created counts POST /pulls calls.
+func newPRMockServer(t *testing.T, existingHead string, created *int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/pulls"):
+			// dedupe list — return one PR only when the requested head matches.
+			head := r.URL.Query().Get("head") // "owner:branch"
+			if existingHead != "" && strings.HasSuffix(head, ":"+existingHead) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `[{"number":11,"html_url":"https://github.com/o/r/pull/11","head":{"ref":"`+existingHead+`"}}]`)
+				return
+			}
+			_, _ = io.WriteString(w, `[]`)
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/pulls"):
+			if created != nil {
+				*created++
+			}
+			body, _ := io.ReadAll(r.Body)
+			var np map[string]any
+			_ = json.Unmarshal(body, &np)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"number":42,"html_url":"https://github.com/o/r/pull/42","title":"`+
+				strings.ReplaceAll(asString(np["title"]), `"`, `\"`)+`"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func asString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+func testClient(t *testing.T, srvURL string) *Client {
+	t.Helper()
+	return NewClientForTest(srvURL, "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+// End-to-end: a request file is opened into a PR, consumed, and a result written.
+func TestPRRequestWatcher_OpensAndConsumes(t *testing.T) {
+	created := 0
+	srv := newPRMockServer(t, "", &created)
+	defer srv.Close()
+	c := testClient(t, srv.URL)
+
+	dir := t.TempDir()
+	old := prRequestDirForTest
+	prRequestDirForTest = dir
+	defer func() { prRequestDirForTest = old }()
+
+	reqPath, err := WritePRRequest(dir, PRRequest{Repo: "o/r", Head: "scanner/fix-1", Title: "[scanner] fix: thing", Body: "Fixes #1", Agent: "scanner"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.ProcessPRRequestsOnce(context.Background())
+
+	if created != 1 {
+		t.Fatalf("expected 1 PR created, got %d", created)
+	}
+	// request consumed
+	if _, err := os.Stat(reqPath); !os.IsNotExist(err) {
+		t.Errorf("request file should be removed after success")
+	}
+	// result written with the PR number
+	resBytes, err := os.ReadFile(strings.TrimSuffix(reqPath, ".json") + ".result.json")
+	if err != nil {
+		t.Fatalf("result file missing: %v", err)
+	}
+	var res PRResponse
+	if err := json.Unmarshal(resBytes, &res); err != nil {
+		t.Fatal(err)
+	}
+	if !res.OK || res.Number != 42 || res.AlreadyExisted {
+		t.Errorf("unexpected result: %+v", res)
+	}
+}
+
+// Dedupe: an existing open PR for the head is reused, no second PR created.
+func TestPRRequestWatcher_DedupesExistingPR(t *testing.T) {
+	created := 0
+	srv := newPRMockServer(t, "scanner/dup", &created)
+	defer srv.Close()
+	c := testClient(t, srv.URL)
+
+	dir := t.TempDir()
+	old := prRequestDirForTest
+	prRequestDirForTest = dir
+	defer func() { prRequestDirForTest = old }()
+
+	_, _ = WritePRRequest(dir, PRRequest{Repo: "o/r", Head: "scanner/dup", Title: "dup"})
+	c.ProcessPRRequestsOnce(context.Background())
+
+	if created != 0 {
+		t.Errorf("existing PR should be reused, not re-created; got %d creates", created)
+	}
+}
+
+// A malformed request is quarantined (renamed .bad), not retried forever.
+func TestPRRequestWatcher_QuarantinesBadJSON(t *testing.T) {
+	srv := newPRMockServer(t, "", nil)
+	defer srv.Close()
+	c := testClient(t, srv.URL)
+
+	dir := t.TempDir()
+	old := prRequestDirForTest
+	prRequestDirForTest = dir
+	defer func() { prRequestDirForTest = old }()
+
+	bad := filepath.Join(dir, "broken.json")
+	if err := os.WriteFile(bad, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c.ProcessPRRequestsOnce(context.Background())
+
+	if _, err := os.Stat(bad); !os.IsNotExist(err) {
+		t.Errorf("bad request should be renamed away")
+	}
+	if _, err := os.Stat(bad + ".bad"); err != nil {
+		t.Errorf("bad request should be quarantined as .bad: %v", err)
+	}
+}

--- a/v2/pkg/github/pullrequest.go
+++ b/v2/pkg/github/pullrequest.go
@@ -1,0 +1,102 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	gh "github.com/google/go-github/v72/github"
+)
+
+// CreatePRResult is what CreatePR returns: the opened (or pre-existing) PR.
+type CreatePRResult struct {
+	Number int
+	URL    string
+	// AlreadyExisted is true when an open PR for this head branch was already
+	// present, so we returned it instead of opening a duplicate.
+	AlreadyExisted bool
+}
+
+// CreatePR opens a pull request on behalf of THIS hive's GitHub App — so the PR
+// is authored by the App bot ("<slug>[bot]"), deterministically, regardless of
+// which agent/CLI produced the branch. This is the hive-opens-the-PR path: an
+// agent pushes its branch (the credential helper already uses the App token for
+// the push), then the hive opens the PR here rather than the agent running
+// `gh pr create` (which would attribute the PR to the Copilot login user).
+//
+// repo may be "owner/repo" or a bare repo name (owner defaults to the hive org).
+// head is the branch the agent pushed; base defaults to "main" when empty.
+//
+// It is idempotent: if an OPEN PR for head already exists, it returns that PR
+// with AlreadyExisted=true instead of erroring or opening a duplicate — this
+// makes the file-watcher safe to retry a request that partially succeeded.
+func (c *Client) CreatePR(ctx context.Context, repo, head, base, title, body string) (CreatePRResult, error) {
+	if c == nil || c.client == nil {
+		return CreatePRResult{}, ErrNoGitHubClient
+	}
+	owner := c.org
+	if parts := strings.SplitN(repo, "/", 2); len(parts) == 2 {
+		owner, repo = parts[0], parts[1]
+	}
+	head = strings.TrimSpace(head)
+	if head == "" {
+		return CreatePRResult{}, fmt.Errorf("CreatePR: head branch is required")
+	}
+	if base = strings.TrimSpace(base); base == "" {
+		base = "main"
+	}
+	if strings.TrimSpace(title) == "" {
+		return CreatePRResult{}, fmt.Errorf("CreatePR: title is required")
+	}
+
+	// Idempotency: don't open a second PR for a branch that already has an open
+	// one. GitHub itself 422s on a duplicate, but checking first lets us return
+	// the existing PR cleanly (the watcher may re-process a request after a
+	// crash between "PR opened" and "request file deleted").
+	if existing, err := c.findOpenPRForHead(ctx, owner, repo, head); err != nil {
+		c.logger.Warn("CreatePR: dedupe lookup failed, proceeding to create",
+			slog.String("repo", repo), slog.String("head", head), slog.String("error", err.Error()))
+	} else if existing != nil {
+		c.logger.Info("CreatePR: open PR already exists for head, reusing",
+			slog.String("repo", repo), slog.String("head", head), slog.Int("number", existing.GetNumber()))
+		return CreatePRResult{Number: existing.GetNumber(), URL: existing.GetHTMLURL(), AlreadyExisted: true}, nil
+	}
+
+	pr, _, err := c.client.PullRequests.Create(ctx, owner, repo, &gh.NewPullRequest{
+		Title: gh.Ptr(title),
+		Head:  gh.Ptr(head),
+		Base:  gh.Ptr(base),
+		Body:  gh.Ptr(body),
+	})
+	if err != nil {
+		// A concurrent creator may have raced us; treat an existing-PR 422 as a
+		// reuse rather than a hard failure.
+		if strings.Contains(err.Error(), "A pull request already exists") {
+			if existing, lookErr := c.findOpenPRForHead(ctx, owner, repo, head); lookErr == nil && existing != nil {
+				return CreatePRResult{Number: existing.GetNumber(), URL: existing.GetHTMLURL(), AlreadyExisted: true}, nil
+			}
+		}
+		return CreatePRResult{}, fmt.Errorf("creating PR %s/%s %s->%s: %w", owner, repo, head, base, err)
+	}
+	c.logger.Info("CreatePR: opened PR as the App bot",
+		slog.String("repo", repo), slog.String("head", head), slog.Int("number", pr.GetNumber()))
+	return CreatePRResult{Number: pr.GetNumber(), URL: pr.GetHTMLURL()}, nil
+}
+
+// findOpenPRForHead returns the open PR whose head branch matches, or nil. The
+// head filter is "owner:branch" per the GitHub API.
+func (c *Client) findOpenPRForHead(ctx context.Context, owner, repo, head string) (*gh.PullRequest, error) {
+	prs, _, err := c.client.PullRequests.List(ctx, owner, repo, &gh.PullRequestListOptions{
+		State:       "open",
+		Head:        owner + ":" + head,
+		ListOptions: gh.ListOptions{PerPage: 5},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(prs) > 0 {
+		return prs[0], nil
+	}
+	return nil, nil
+}


### PR DESCRIPTION
## Summary

Adds an **opt-in, side-effect-free** path for opening PRs authored by the **GitHub App bot** instead of the agent's Copilot-login user. **Purely additive**: with no request files present it does nothing, so the existing `gh pr create` agent flow — and the live issue/PR queue — is unaffected until an agent opts in.

## Mechanism
- `Client.CreatePR` (`pkg/github/pullrequest.go`): opens a PR with the hive's **App installation token** → authorship is `<slug>[bot]`. Idempotent: reuses an existing open PR for the same head branch instead of erroring/duplicating.
- Watcher (`pkg/github/pr_request_watcher.go`): scans `/var/run/hive-metrics/pr-requests` for JSON request files an agent drops after pushing its branch, opens the PR, writes a `.result.json`, and consumes the request. Transient failures retry; malformed requests are quarantined.
- Wired in `cmd/hive/main.go`, gated on a real client + `HasUsableApp()` — no App → requests accumulate, never opened under a wrong identity.

## Why not just set GITHUB_TOKEN?
The Copilot CLI creates PRs with its **stored login token** (the user). We can't inject `GITHUB_TOKEN`=App-token because Copilot **also accepts `GITHUB_TOKEN` as its own auth** (README: PAT with "Copilot Requests" permission) — that would break **model entitlement**. Having the hive open the PR sidesteps Copilot auth entirely.

## Safety / rollout
**No agent-policy change here.** The "agents write a request file instead of `gh pr create`" switch is a **separate follow-up**, so this deploys and is verified in isolation with **zero risk to the running queue**.

## Tests
Watcher opens+consumes a request, dedupes an existing PR, quarantines bad JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)