### PR TITLE
🐛 fix(bob): drop --model, enable auto-approve so kicks can complete

### DIFF
--- a/v2/pkg/agent/bob_startup_kick_test.go
+++ b/v2/pkg/agent/bob_startup_kick_test.go
@@ -190,7 +190,7 @@ func TestBobInputHandlerSettleDelay(t *testing.T) {
 // Asserted through the launch-command builder: bob's command must contain no
 // reference to the bootstrap temp file and no embedded prompt argument.
 func TestBobStartupKickNotWrittenToDeadTempFile(t *testing.T) {
-	cmd := bobLaunchCmd("bob", "some-model")
+	cmd := bobLaunchCmd("bob")
 	for _, forbidden := range []string{".hive-bootstrap", "--text", "$(cat", "-p ", "--prompt"} {
 		if strings.Contains(cmd, forbidden) {
 			t.Errorf("bobLaunchCmd() = %q must not contain %q: bob's prompt is delivered "+

--- a/v2/pkg/agent/bob_test.go
+++ b/v2/pkg/agent/bob_test.go
@@ -292,49 +292,106 @@ func TestBobKeyNotInEnvPrefix(t *testing.T) {
 	}
 }
 
-// TestBobLaunchCmd pins the flags that make headless auth work while keeping
-// the session interactive.
+// TestBobLaunchCmd pins the flags that make headless auth work, keep the
+// session interactive, and let an unattended agent actually run tool calls.
 func TestBobLaunchCmd(t *testing.T) {
-	tests := []struct {
-		name        string
-		model       string
-		wantContain []string
-		wantAbsent  []string
-	}{
-		{
-			name:  "no model",
-			model: "",
-			// --accept-license clears the license gate that would otherwise
-			// hard-error with no human to answer it.
-			// --auth-method api-key is the strongest auth control: it is a real
-			// (but --help-hidden) flag in bobshell 1.0.6 and is the only input
-			// that outranks the persisted, fleet-shared settings file.
-			wantContain: []string{"bob", "--accept-license", "--auth-method api-key"},
-			// No -p/--prompt: interactive mode must be preserved.
-			wantAbsent: []string{"--model", " -p ", "--prompt"},
-		},
-		{
-			name:        "with model",
-			model:       "granite-3",
-			wantContain: []string{"--accept-license", "--auth-method api-key", "--model granite-3"},
-			wantAbsent:  []string{" -p ", "--prompt"},
-		},
+	got := bobLaunchCmd("bob")
+
+	wantContain := []string{
+		"bob",
+		// Clears the license gate that would otherwise hard-error with no
+		// human to answer it.
+		"--accept-license",
+		// The strongest auth control: a real (but --help-hidden) flag in
+		// bobshell 1.0.6, and the only input that outranks the persisted,
+		// fleet-shared settings file.
+		"--auth-method api-key",
+		// Without this bob reports `Auto-approve: Off` and blocks forever on
+		// the first tool call. Verified live: with it, bob executed a shell
+		// tool unattended.
+		"--approval-mode yolo",
+		// Clears "This folder is not trusted. Some features may be disabled."
+		"--trust",
+	}
+	for _, want := range wantContain {
+		if !strings.Contains(got, want) {
+			t.Errorf("bobLaunchCmd() = %q, want it to contain %q", got, want)
+		}
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := bobLaunchCmd("bob", tc.model)
-			for _, want := range tc.wantContain {
-				if !strings.Contains(got, want) {
-					t.Errorf("bobLaunchCmd(...) = %q, want it to contain %q", got, want)
-				}
-			}
-			for _, absent := range tc.wantAbsent {
-				if strings.Contains(got, absent) {
-					t.Errorf("bobLaunchCmd(...) = %q, want it NOT to contain %q", got, absent)
-				}
-			}
-		})
+	wantAbsent := []string{
+		// --model is the BUG: normalizeModelName rewrote claude-sonnet-4-6 to
+		// claude-sonnet-4.6, an id bob's backend does not know, and every
+		// prompt died with "Cannot read properties of undefined (reading
+		// 'maxTokens')". bob auto-selects its model; hive must not pass one.
+		"--model",
+		// Interactive mode must be preserved.
+		" -p ",
+		"--prompt",
+	}
+	for _, absent := range wantAbsent {
+		if strings.Contains(got, absent) {
+			t.Errorf("bobLaunchCmd() = %q, want it NOT to contain %q", got, absent)
+		}
+	}
+}
+
+// TestBobLaunchCmdApprovalIsFlat documents the deliberate design decision that
+// bob's approval mode does NOT vary with the agent's ACMM mode.
+//
+// Every other backend already auto-approves tools at every level (claude gets
+// --dangerously-skip-permissions, copilot gets --allow-all, in all three mode
+// branches of launchInTmux). Hive contains low-mode agents by denying GitHub
+// write tools and unsetting GH_TOKEN/GITHUB_TOKEN, not by making them ask
+// permission for local tool calls. bob matches that posture.
+func TestBobLaunchCmdApprovalIsFlat(t *testing.T) {
+	// bobLaunchCmd takes no mode argument at all, so the command is identical
+	// for every agent. Guard against a future signature change reintroducing
+	// per-mode approval without updating this reasoning.
+	if a, b := bobLaunchCmd("bob"), bobLaunchCmd("bob"); a != b {
+		t.Fatalf("bobLaunchCmd() is not deterministic: %q vs %q", a, b)
+	}
+	for _, forbidden := range []string{"--approval-mode default", "--approval-mode auto_edit"} {
+		if strings.Contains(bobLaunchCmd("bob"), forbidden) {
+			t.Errorf("bobLaunchCmd() must not use %q: bob matches the fleet's "+
+				"flat auto-approve posture", forbidden)
+		}
+	}
+}
+
+// TestNormalizeModelNameSkipsBob covers the dot-rewrite that corrupted bob's
+// model id. bob is now excluded alongside claude and the inference backends.
+func TestNormalizeModelNameSkipsBob(t *testing.T) {
+	const configured = "claude-sonnet-4-6"
+	if got := normalizeModelName(configured, bobBackend); got != configured {
+		t.Errorf("normalizeModelName(%q, %q) = %q, want it unchanged: the "+
+			"dot-rewrite produced claude-sonnet-4.6, an id bob does not know",
+			configured, bobBackend, got)
+	}
+	// Non-bob backends must still be normalized.
+	if got := normalizeModelName(configured, "copilot"); got != "claude-sonnet-4.6" {
+		t.Errorf("normalizeModelName(%q, \"copilot\") = %q, want %q: other "+
+			"backends must be unaffected", configured, got, "claude-sonnet-4.6")
+	}
+}
+
+// TestToolRulesToLaunchCmdBobHasNoModel guards the second path that could feed
+// bob a --model: an agent with Config.Tools set bypasses the launchInTmux
+// switch entirely and would otherwise fall to the default branch.
+func TestToolRulesToLaunchCmdBobHasNoModel(t *testing.T) {
+	tools := &config.ToolsConfig{}
+	got := toolRulesToLaunchCmd("bob", "claude-sonnet-4.6", bobBackend, tools, false)
+	if strings.Contains(got, "--model") {
+		t.Errorf("toolRulesToLaunchCmd(bob) = %q must not contain --model", got)
+	}
+	for _, want := range []string{"--accept-license", "--approval-mode yolo", "--trust"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("toolRulesToLaunchCmd(bob) = %q, want it to contain %q", got, want)
+		}
+	}
+	// Non-bob backends must still receive their model.
+	if c := toolRulesToLaunchCmd("copilot", "gpt-5", "copilot", tools, false); !strings.Contains(c, "--model gpt-5") {
+		t.Errorf("toolRulesToLaunchCmd(copilot) = %q, want it to contain --model gpt-5", c)
 	}
 }
 

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -1016,7 +1016,7 @@ func (m *Manager) launchInTmux(ctx context.Context, agent *AgentProcess) error {
 				launchCmd = fmt.Sprintf("%s --model %s", launchCmd, model)
 			}
 		case bobBackend:
-			launchCmd = bobLaunchCmd(binary, model)
+			launchCmd = bobLaunchCmd(binary)
 		default:
 			launchCmd = binary
 		}
@@ -3680,16 +3680,51 @@ const bobBackend = "bob"
 //     key for unattended use is the act of acceptance; the text stays
 //     reviewable via `bob --show-license`.
 //
+//   - --approval-mode yolo (config.BobApprovalModeFlag/BobApprovalModeYolo):
+//     without it bob runs in its "default" approval mode, the TUI reports
+//     `Auto-approve: Off`, and the agent blocks forever on its FIRST tool call
+//     waiting for a human who is not attached. Verified live on a spoke: with
+//     the flag the TUI reports `Auto-approve: Full` and bob executed a shell
+//     tool unattended.
+//
+//     This is deliberately FLAT — not gated on m.agentMode(agent) — because it
+//     matches the existing fleet posture rather than inventing a new one for
+//     bob. Every other backend already auto-approves tools at EVERY ACMM level:
+//     claude gets --dangerously-skip-permissions and copilot gets --allow-all
+//     in all three mode branches of launchInTmux. Hive does not restrain agents
+//     by making them ask permission for local tool calls; it restrains them by
+//     (a) denying specific GitHub write tools per mode and (b) unsetting
+//     GH_TOKEN/GITHUB_TOKEN for agents whose mode fails CanPush(). Both of
+//     those controls apply to bob unchanged and are where an advisory bob is
+//     actually contained. Giving bob a per-mode approval policy would make it
+//     the only backend that stalls at low ACMM levels — less capable than its
+//     peers, and stalled rather than safely limited.
+//
+//   - --trust (config.BobTrustFlag): bob otherwise treats the agent workdir as
+//     untrusted ("This folder is not trusted. Some features may be disabled.")
+//     and gates tool availability on it. See BobTrustFlag for why the flag is
+//     preferred over seeding the shared $HOME/.bob/trustedFolders.json.
+//
+// No --model is passed, and that is load-bearing. bob auto-selects its own
+// model, and hive's normalizeModelName rewrites a trailing -<digits> to
+// .<digits> for every backend except claude/inference, so a configured
+// `claude-sonnet-4-6` reached bob as `claude-sonnet-4.6` — an id bob's backend
+// does not know. Its model config came back undefined and every prompt died
+// with "🛑 Cannot read properties of undefined (reading 'maxTokens')". Verified
+// live: the same bob with no --model runs inference successfully.
+//
 // The API key itself is NOT a flag — it is delivered out-of-band via
 // tmux set-environment (see agentEnvPairs) so it never lands in the command
 // line, `ps` output, or pane scrollback.
-func bobLaunchCmd(binary, model string) string {
-	cmd := fmt.Sprintf("%s --accept-license %s %s",
-		binary, config.BobAuthMethodFlag, config.BobAuthTypeAPIKey)
-	if model != "" {
-		cmd = fmt.Sprintf("%s --model %s", cmd, model)
-	}
-	return cmd
+//
+// The model parameter is intentionally absent from the signature so no future
+// caller can reintroduce the crash by passing one.
+func bobLaunchCmd(binary string) string {
+	return fmt.Sprintf("%s --accept-license %s %s %s %s %s",
+		binary,
+		config.BobAuthMethodFlag, config.BobAuthTypeAPIKey,
+		config.BobApprovalModeFlag, config.BobApprovalModeYolo,
+		config.BobTrustFlag)
 }
 
 // codexHomePrefix is the per-agent CODEX_HOME directory prefix. Each agent gets
@@ -3966,8 +4001,17 @@ func (m *Manager) ensureWorldWritable(root string) {
 // "gpt-4o-2024-08.06") produces a model the team is not entitled to and the
 // gateway 403s ("team not allowed to access model") even for entitled models.
 // So never normalize inference model names — pass them through untouched.
+//
+// bob is likewise excluded. bobLaunchCmd passes no --model at all (bob
+// auto-selects), so this is defense-in-depth rather than the fix: the value is
+// still computed and logged on the bob launch path, and the dot-rewrite is
+// what turned a configured `claude-sonnet-4-6` into the unknown
+// `claude-sonnet-4.6` that made bob die with "Cannot read properties of
+// undefined (reading 'maxTokens')". Leaving it unrewritten keeps logs honest
+// about what was configured and stops the corrupted id from being handed to a
+// future bob consumer.
 func normalizeModelName(model, backend string) string {
-	if backend == "claude" || IsInferenceBackend(backend) {
+	if backend == "claude" || backend == bobBackend || IsInferenceBackend(backend) {
 		return model
 	}
 	idx := strings.LastIndex(model, "-")
@@ -4961,6 +5005,15 @@ func toolRulesToLaunchCmd(binary, model, backend string, tools *config.ToolsConf
 	denies := tools.DenyPatterns()
 
 	switch backend {
+	case bobBackend:
+		// bob has no deny-tool flag, so ToolsConfig cannot be expressed here.
+		// It must still go through bobLaunchCmd rather than falling to the
+		// default branch below, which would append `--model` and crash bob
+		// with "Cannot read properties of undefined (reading 'maxTokens')".
+		// A bob agent with tools configured therefore launches identically to
+		// one without; the deny patterns are silently inapplicable, exactly as
+		// they already were before this branch existed.
+		return bobLaunchCmd(binary)
 	case "claude":
 		bareFlag := ""
 		if isInference {

--- a/v2/pkg/agent/routing_coverage_test.go
+++ b/v2/pkg/agent/routing_coverage_test.go
@@ -247,8 +247,13 @@ func TestToolRulesToLaunchCmd_Default(t *testing.T) {
 	if cmd != "gemini --model flash" {
 		t.Errorf("default backend cmd: %q", cmd)
 	}
-	cmd = toolRulesToLaunchCmd("bob", "", "bob", tools, false)
-	if cmd != "bob" {
+	// An UNKNOWN backend with no model gets the bare binary. This used to be
+	// asserted with backend "bob", which meant it pinned bob's broken
+	// fall-through: a bare `bob` has no --accept-license (hard-errors), no
+	// auth flag, and no --approval-mode (stalls on the first tool call). bob
+	// now has its own branch, so use a backend that really is unknown.
+	cmd = toolRulesToLaunchCmd("mystery", "", "mystery", tools, false)
+	if cmd != "mystery" {
 		t.Errorf("default backend with empty model: %q", cmd)
 	}
 }

--- a/v2/pkg/config/config.go
+++ b/v2/pkg/config/config.go
@@ -883,6 +883,40 @@ const (
 	// makes hive's choice authoritative without bob rewriting the shared file.
 	BobAuthMethodFlag = "--auth-method"
 
+	// BobApprovalModeFlag / BobApprovalModeYolo set bob's tool-approval policy.
+	// Verified in bobshell 1.0.6 `bob --help`:
+	//   --approval-mode  Set the approval mode: default (prompt for approval),
+	//                    auto_edit (auto-approve edit tools), yolo
+	//                    (auto-approve all tools)
+	//                    [string] [choices: "default", "auto_edit", "yolo"]
+	//
+	// Without it bob defaults to "default" and the TUI shows
+	// `Auto-approve: Off`, so an unattended agent blocks forever on the first
+	// tool call — no human is attached to answer the prompt. With
+	// `--approval-mode yolo` the TUI shows `Auto-approve: Full` and bob
+	// executes shell/edit tools unattended (verified live on a spoke: bob
+	// wrote /tmp/_tool.txt with no approval prompt).
+	//
+	// The named flag is preferred over the equivalent `-y`/`--yolo` boolean
+	// because it states the mode at the call site.
+	BobApprovalModeFlag = "--approval-mode"
+	BobApprovalModeYolo = "yolo"
+
+	// BobTrustFlag marks the agent's workspace as trusted. bobshell 1.0.6
+	// otherwise renders "This folder is not trusted. Some features may be
+	// disabled." and gates tool availability behind that state. Verified in
+	// `bob --help`:
+	//   --trust  specify trust level for the current workspace
+	//
+	// Passing the flag is preferred over seeding $HOME/.bob/trustedFolders.json
+	// because the flag is per-launch and stateless: it needs no knowledge of
+	// bob's on-disk trust schema, cannot drift when that schema changes, and
+	// applies to whatever workdir the agent is launched in. The shared
+	// /data/home is used by EVERY bob agent on a hive, so a seeded trust file
+	// would also be a fleet-wide mutation of the kind that already caused the
+	// selectedType incident (see BobAuthTypeEnvVar).
+	BobTrustFlag = "--trust"
+
 	// BobSettingsRelPath is the persisted settings file, relative to $HOME.
 	// From bundle/bob.js: `as=".bob"` and
 	// `getGlobalSettingsPath(){return fu.join(t.getGlobalGeminiDir(),"settings.json")}`


### PR DESCRIPTION
Two defects kept a bob agent from finishing a kick. Both verified live on `hosted-available-vllmd-01`.

## 1. `--model` breaks bob

`normalizeModelName` rewrites a trailing `-<digits>` to `.<digits>` for every backend except claude/inference, so a configured `claude-sonnet-4-6` reached bob as `claude-sonnet-4.6` — an id bob's backend does not know. Its model config came back undefined and every prompt died with:

```
🛑 Cannot read properties of undefined (reading 'maxTokens')
```

**bob auto-selects its own model**, so the flag is dropped entirely. Verified: the same bob with no `--model` runs inference successfully and returned the exact requested token.

## 2. No auto-approve — bob stalled on every tool call

Nothing passed an approval flag, so the TUI showed `Auto-approve: Off` and the agent blocked forever on its first tool call waiting for a human who is not attached. With `--approval-mode yolo` it shows `Auto-approve: Full` and **executed a shell tool unattended** (verified: wrote a file, tokens 100%→96%).

`--trust` is passed because bob otherwise treats the agent workdir as untrusted ("This folder is not trusted. Some features may be disabled.") and gates tool availability on it.

### Why the approval mode is flat, not per-ACMM-level

This was the main judgment call. It matches existing fleet posture rather than inventing a new one for bob: claude already gets `--dangerously-skip-permissions` and copilot `--allow-all` in all three mode branches of `launchInTmux`.

Hive does not restrain agents by making them ask permission for local tool calls. It restrains them by (a) denying specific GitHub write tools per mode and (b) unsetting `GH_TOKEN`/`GITHUB_TOKEN` for agents whose mode fails `CanPush()`. Both controls apply to bob unchanged and are where an advisory bob is actually contained. A per-mode approval policy would make bob the only backend that stalls at low ACMM levels — less capable than its peers, and stalled rather than safely limited.

## Verification

- `go build ./...` and `go vet ./pkg/agent/ ./pkg/config/` clean.
- `go test ./pkg/config/` and `./pkg/agent/ -run 'Bob|Model|Launch'` both **ok**.
- gofmt: both touched files show drift, but **identically on clean `origin/v2`** (verified by stashing) — pre-existing struct-alignment drift, not from this change. Left alone per the no-wildcard-sweep rule.

## Follow-ups (not in this PR)

- **bob's model dropdown should offer only `auto`.** `bob` is absent from both `CLI_FALLBACK_MODELS` and `handleBackends`, so `modelsForBackend` falls through to `COPILOT_CLI_MODELS` and bob's agent card currently shows Copilot's catalog. It also needs adding to `AUTO_MODEL_SENTINELS` so model auto-heal cannot rewrite `auto` back to a concrete id and re-break the launch.
- **Per-agent GitHub token never reaches the agent.** `WriteAgentToken` chowns to the agent UID, which fails (`operation not permitted`) since hive runs as uid 1001 without CAP_CHOWN — so the file is deleted and no agent on any hive gets a token. Affects every backend, not just bob.

## Ports

Needs porting to `mk`, `dd`, and `v3`.