### PR TITLE
🔐 feat(hub): enforce per-agent ACMM + forge-resistance on the hive-opens-PR watcher

### DIFF
--- a/v2/cmd/hive/main.go
+++ b/v2/cmd/hive/main.go
@@ -694,7 +694,10 @@ func main() {
 	// as, and requests simply accumulate rather than opening under a wrong
 	// identity. ghClient uses the App installation token (see ghAuth wiring).
 	if ghClient != nil && cfg.GitHub.HasUsableApp() {
-		ghClient.StartPRRequestWatcher(ctx, nil)
+		// authz enforces the SAME per-agent ACMM write-gate + forge-resistance as
+		// the direct `gh pr create` path — the request-file route grants no extra
+		// privilege. A denied request is quarantined, never opened.
+		ghClient.StartPRRequestWatcher(ctx, agentMgr.AuthorizePROpen, nil)
 	}
 
 	go agent.StartPermissionsWatcher(logger)

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -4081,6 +4081,49 @@ func (m *Manager) agentCanWrite(agent *AgentProcess) bool {
 	return m.agentMode(agent).CanPush()
 }
 
+// AuthorizePROpen enforces the policy for the hive-opens-PR watcher: an agent
+// may open a PR (by dropping a request file) only if BOTH hold:
+//
+//  1. Forge-resistance — the request file's owning UID (fileUID) maps to the
+//     agent it claims to be (via the uid-map). One agent cannot open a PR "as"
+//     another, and a non-agent process (unknown UID) is refused. When per-agent
+//     UIDs are not in play (fileUID <= 0, e.g. shared-dev-UID mode with no map),
+//     ownership is unverifiable, so we fall back to the ACMM check alone rather
+//     than hard-failing — the same posture the credential helper takes.
+//  2. ACMM write-gate — the agent must be push-capable at the hive's current
+//     ACMM level, i.e. exactly the CanPush() check that governs `gh pr create`.
+//
+// Returns nil to authorize, or an error describing the denial. This mirrors the
+// direct PR path's policy so the request-file route grants no extra privilege.
+func (m *Manager) AuthorizePROpen(agentName string, fileUID int) error {
+	if strings.TrimSpace(agentName) == "" {
+		return fmt.Errorf("no agent named in the request")
+	}
+	// Forge check: when we have a UID map and a real owning UID, the file owner
+	// must BE this agent.
+	if m.uidMap != nil && fileUID > 0 {
+		owner := m.uidMap.LookupByUID(fileUID)
+		if owner == "" {
+			return fmt.Errorf("request file owned by unknown uid %d (not a registered agent)", fileUID)
+		}
+		if owner != agentName {
+			return fmt.Errorf("request claims agent %q but file is owned by agent %q (uid %d)", agentName, owner, fileUID)
+		}
+	}
+	// ACMM write-gate: resolve the agent and check CanPush.
+	m.mu.RLock()
+	agent := m.agents[agentName]
+	m.mu.RUnlock()
+	if agent == nil {
+		return fmt.Errorf("unknown agent %q", agentName)
+	}
+	if !m.agentMode(agent).CanPush() {
+		return fmt.Errorf("agent %q is not push-capable at this ACMM level (mode %s) — advisory agents may not open PRs",
+			agentName, m.agentMode(agent).String())
+	}
+	return nil
+}
+
 // filteredEnv returns os.Environ() with write-capable tokens removed for advisory agents.
 // COPILOT_GITHUB_TOKEN is kept for all agents (needed for AI auth); write access is
 // gated by --enable-all-github-mcp-tools flag. GH_TOKEN and GITHUB_TOKEN are stripped

--- a/v2/pkg/github/client.go
+++ b/v2/pkg/github/client.go
@@ -32,6 +32,10 @@ type Client struct {
 	exemptLabels []string
 	logger       *slog.Logger
 	appAuth      *AppAuth // nil for token-authenticated clients
+	// prAuthz gates PR-open requests from the request-file watcher against the
+	// per-agent ACMM write-policy + forge-resistance. nil fails closed. Set by
+	// StartPRRequestWatcher.
+	prAuthz PRRequestAuthorizer
 }
 
 // GoGitHub returns the underlying go-github client for direct API access.

--- a/v2/pkg/github/fileowner_other.go
+++ b/v2/pkg/github/fileowner_other.go
@@ -1,0 +1,10 @@
+//go:build !unix
+
+package github
+
+import "io/fs"
+
+// fileOwnerUID has no meaningful value off unix (dev/Windows builds); return -1
+// so the authorizer treats ownership as unverifiable. The production target is
+// Linux, which uses fileowner_unix.go.
+func fileOwnerUID(_ fs.FileInfo) int { return -1 }

--- a/v2/pkg/github/fileowner_unix.go
+++ b/v2/pkg/github/fileowner_unix.go
@@ -1,0 +1,18 @@
+//go:build unix
+
+package github
+
+import (
+	"io/fs"
+	"syscall"
+)
+
+// fileOwnerUID returns the owning UID of a file from its FileInfo on unix. The
+// container runs on Linux, where this is the agent's real UID — the trust anchor
+// for "an agent can only speak for itself" in the PR-request watcher.
+func fileOwnerUID(fi fs.FileInfo) int {
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+		return int(st.Uid)
+	}
+	return -1
+}

--- a/v2/pkg/github/pr_request_watcher.go
+++ b/v2/pkg/github/pr_request_watcher.go
@@ -59,17 +59,41 @@ type PRResponse struct {
 	At             string `json:"at"`
 }
 
+// PRRequestAuthorizer decides whether a PR-open request may proceed. It receives
+// the agent NAME claimed in the request and the UID that OWNS the request file
+// (from the file's stat), and returns nil to authorize or an error explaining
+// the denial. This is where the two policy checks live, implemented by the
+// caller (which has the manager + uid-map):
+//
+//  1. Forge-resistance: the fileUID must map to the claimed agent (an agent can
+//     only speak for ITSELF — one agent, or any non-agent process, cannot drop a
+//     request "as" another agent). The per-agent PR-request subdir is UID-owned,
+//     so this is the same UID trust anchor the git credential helper uses.
+//  2. ACMM write-gate: the agent must be push-capable at the hive's current ACMM
+//     level (the same CanPush()/mode check that governs `gh pr create` today) —
+//     an advisory-only agent must NOT be able to open a PR via this path.
+//
+// A nil authorizer DENIES everything (fail closed) — the watcher never opens a
+// PR without an authorizer, so a wiring mistake cannot silently bypass policy.
+type PRRequestAuthorizer func(agent string, fileUID int) error
+
 // StartPRRequestWatcher runs a loop that opens PRs for request files dropped in
 // PRRequestDir. It returns immediately; the loop runs until ctx is cancelled.
 // A nil client (no GitHub creds) makes this a no-op: requests accumulate rather
 // than being silently dropped, so the feature degrades to "nothing opens" not
 // "opened as the wrong identity".
 //
+// authz enforces the per-agent ACMM write-gate + forge-resistance (see
+// PRRequestAuthorizer). A nil authz fails closed (denies every request) — the
+// watcher must never open a PR that hasn't been authorized against the same
+// policy as the direct `gh pr create` path.
+//
 // nowFn is injectable for tests; pass nil for time.Now.
-func (c *Client) StartPRRequestWatcher(ctx context.Context, nowFn func() time.Time) {
+func (c *Client) StartPRRequestWatcher(ctx context.Context, authz PRRequestAuthorizer, nowFn func() time.Time) {
 	if c == nil {
 		return
 	}
+	c.prAuthz = authz
 	if nowFn == nil {
 		nowFn = time.Now
 	}
@@ -135,6 +159,21 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 		return
 	}
 
+	// AUTHORIZE before opening — the watcher must enforce the SAME policy as the
+	// direct `gh pr create` path: the request's agent must own the file (an agent
+	// can only speak for itself) AND be push-capable at the hive's ACMM level.
+	// The owning UID comes from the file's stat, which the requester cannot forge
+	// without actually running as that UID. A nil authorizer fails closed.
+	fileUID := statUID(data, path)
+	if c.prAuthz == nil {
+		c.denyPRRequest(path, req, "no authorizer configured (fail closed)", nowFn)
+		return
+	}
+	if err := c.prAuthz(req.Agent, fileUID); err != nil {
+		c.denyPRRequest(path, req, err.Error(), nowFn)
+		return
+	}
+
 	res, err := c.CreatePR(ctx, req.Repo, req.Head, req.Base, req.Title, req.Body)
 	resp := PRResponse{At: nowFn().UTC().Format(time.RFC3339)}
 	if err != nil {
@@ -159,6 +198,30 @@ func (c *Client) handleOnePRRequest(ctx context.Context, path string, nowFn func
 		slog.String("repo", req.Repo), slog.String("head", req.Head),
 		slog.Int("number", res.Number), slog.Bool("reused", res.AlreadyExisted),
 		slog.String("agent", req.Agent))
+}
+
+// denyPRRequest records an authorization failure and quarantines the request
+// (renamed .denied) so it is not retried forever. A denied request is a policy
+// event, not a transient error — retrying can never make an advisory agent
+// push-capable or change who owns the file.
+func (c *Client) denyPRRequest(path string, req PRRequest, reason string, nowFn func() time.Time) {
+	c.writePRResult(path, PRResponse{OK: false, Error: "authorization denied: " + reason, At: nowFn().UTC().Format(time.RFC3339)})
+	_ = os.Rename(path, path+".denied")
+	c.logger.Warn("pr-request watcher: DENIED (policy)",
+		slog.String("agent", req.Agent), slog.String("repo", req.Repo),
+		slog.String("head", req.Head), slog.String("reason", reason))
+}
+
+// statUID returns the UID that owns the request file. On the (Linux) container
+// this is a real UID that a forging process cannot fake without running as it.
+// data is unused but kept in the signature so a future non-stat proof (e.g. an
+// embedded signed token) can slot in without touching call sites.
+func statUID(_ []byte, path string) int {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return -1
+	}
+	return fileOwnerUID(fi)
 }
 
 func (c *Client) writePRResult(reqPath string, resp PRResponse) {

--- a/v2/pkg/github/pr_request_watcher_test.go
+++ b/v2/pkg/github/pr_request_watcher_test.go
@@ -50,9 +50,14 @@ func asString(v any) string {
 	return ""
 }
 
+// testClient returns a client whose PR authorizer ALLOWS everything, so the
+// watcher's open/dedupe/quarantine paths can be exercised. Authorization itself
+// is tested separately in TestPRRequestWatcher_Authz*.
 func testClient(t *testing.T, srvURL string) *Client {
 	t.Helper()
-	return NewClientForTest(srvURL, "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	c := NewClientForTest(srvURL, "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	c.prAuthz = func(agent string, uid int) error { return nil }
+	return c
 }
 
 // End-to-end: a request file is opened into a PR, consumed, and a result written.
@@ -137,5 +142,54 @@ func TestPRRequestWatcher_QuarantinesBadJSON(t *testing.T) {
 	}
 	if _, err := os.Stat(bad + ".bad"); err != nil {
 		t.Errorf("bad request should be quarantined as .bad: %v", err)
+	}
+}
+
+// A denying authorizer (e.g. advisory agent / UID mismatch) must NOT open a PR
+// and must quarantine the request as .denied (not retry it forever).
+func TestPRRequestWatcher_AuthzDenyQuarantines(t *testing.T) {
+	created := 0
+	srv := newPRMockServer(t, "", &created)
+	defer srv.Close()
+	c := NewClientForTest(srv.URL, "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	c.prAuthz = func(agent string, uid int) error { return context.DeadlineExceeded } // stand-in denial
+
+	dir := t.TempDir()
+	old := prRequestDirForTest
+	prRequestDirForTest = dir
+	defer func() { prRequestDirForTest = old }()
+
+	reqPath, _ := WritePRRequest(dir, PRRequest{Repo: "o/r", Head: "brainstorm/x", Title: "advisory tries to PR", Agent: "brainstorm"})
+	c.ProcessPRRequestsOnce(context.Background())
+
+	if created != 0 {
+		t.Errorf("denied request must NOT create a PR; got %d", created)
+	}
+	if _, err := os.Stat(reqPath); !os.IsNotExist(err) {
+		t.Errorf("denied request should be renamed away")
+	}
+	if _, err := os.Stat(reqPath + ".denied"); err != nil {
+		t.Errorf("denied request should be quarantined as .denied: %v", err)
+	}
+}
+
+// A nil authorizer fails closed: no PR opened.
+func TestPRRequestWatcher_NilAuthzFailsClosed(t *testing.T) {
+	created := 0
+	srv := newPRMockServer(t, "", &created)
+	defer srv.Close()
+	c := NewClientForTest(srv.URL, "o", []string{"r"}, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	// prAuthz deliberately left nil.
+
+	dir := t.TempDir()
+	old := prRequestDirForTest
+	prRequestDirForTest = dir
+	defer func() { prRequestDirForTest = old }()
+
+	_, _ = WritePRRequest(dir, PRRequest{Repo: "o/r", Head: "scanner/y", Title: "no authorizer", Agent: "scanner"})
+	c.ProcessPRRequestsOnce(context.Background())
+
+	if created != 0 {
+		t.Errorf("nil authorizer must fail closed (no PR); got %d", created)
 	}
 }


### PR DESCRIPTION
## Summary

Closes a policy gap in the hive-opens-PR watcher (#2247): it opened a PR for **any** request file, bypassing the per-agent ACMM write-gate and with no proof of who wrote the request. Now the watcher grants **no more privilege than the direct `gh pr create` path**.

## Authorization (both required)
1. **Forge-resistance** — the request file's owning **UID must map to the agent it claims** (via the uid-map). An agent can only speak for itself; an unknown/other UID is refused. (No per-agent UIDs → ownership unverifiable → fall back to the ACMM check alone, matching the credential helper.)
2. **ACMM write-gate** — the agent must be **push-capable at the hive's ACMM level** (`CanPush()`), exactly like the direct path. **Advisory agents cannot open PRs.**

- `PRRequestAuthorizer` + `Client.prAuthz`: **nil authorizer fails closed** — a wiring mistake can't silently bypass policy. Denied requests are quarantined (`.denied`), not retried.
- `Manager.AuthorizePROpen` implements both checks; wired in `cmd/hive/main.go`.

## MITM proxy note
The agent still does all its work (reads, code, **branch push**) through the proxy under its ACMM gate. Only the final `PullRequests.Create` is made by the **hive** (App token) — the same way the hive already opens advisory issues / posts digests / enforces SHA-holds. The security property (no ACMM bypass) is enforced by `AuthorizePROpen`; routing hive-originated API calls through the proxy too would be a separate, broader change.

## Still additive
No agent writes request files yet. The policy cutover (replace `gh pr create` with the request-file path, keeping `gh` as a fallback) is a **separate, carefully-rolled** change so the live queue is never at risk.

## Tests
Denied request opens no PR + quarantines `.denied`; nil authorizer fails closed; open/dedupe/bad-json paths pass with an allow-authorizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)