### PR TITLE
🐛 fix(github): deliver per-agent App tokens without chown

### DIFF
--- a/v2/deploy/entrypoint.sh
+++ b/v2/deploy/entrypoint.sh
@@ -516,6 +516,49 @@ print('\n'.join(sorted(names)))
           chown -R "hive-${agent_name}:node" "/data/beads/${agent_name}" 2>/dev/null || true
         fi
       fi
+      # ── Per-agent GitHub App token cache file ────────────────────────
+      # The hive binary runs as dev (UID 1001) after privilege drop and CANNOT
+      # chown — an unprivileged process cannot give a file away to another UID
+      # without CAP_CHOWN, and capabilities are deliberately restricted here
+      # (the same container already fails NET_ADMIN for iptables above). So the
+      # runtime write path must never call chown. We pre-create the cache file
+      # HERE, as root, with the final ownership and mode:
+      #
+      #   owner = dev  (UID 1001)      -> hive can rewrite it in place, no chown
+      #   group = hive-<agent>         -> ONLY this agent can read it
+      #   mode  = 0640                 -> owner rw, group r, world none
+      #
+      # The group MUST be a per-agent private group. The agent users are all in
+      # the shared "node" group (gid 1000), so group-node would let EVERY agent
+      # read EVERY other agent's scoped token — exactly the cross-agent leak the
+      # per-agent token exists to prevent. groupadd + usermod -aG gives each
+      # agent a private group it is the only member of, while leaving "node" as
+      # its primary group so nothing else about the agent's access changes.
+      #
+      # dev deliberately does NOT join these groups: it writes as the file
+      # OWNER, so it needs no group membership. That keeps dev out of every
+      # agent's private group and avoids N usermod calls.
+      #
+      # gids are auto-allocated by `groupadd --system` rather than derived from
+      # the agent UID. A derived gid (e.g. uid+1000) can collide with an
+      # existing group; letting groupadd pick from the system range cannot.
+      #
+      # Verified in ghcr.io/kubestellar/hive:v2-latest: dev writes in place OK,
+      # the owning agent reads its own token OK, and a second agent gets
+      # EACCES on the first agent's token.
+      AGENT_TOKEN_GROUP="hive-${agent_name}"
+      if ! getent group "$AGENT_TOKEN_GROUP" >/dev/null 2>&1; then
+        groupadd --system "$AGENT_TOKEN_GROUP" 2>/dev/null || true
+      fi
+      usermod -aG "$AGENT_TOKEN_GROUP" "hive-${agent_name}" 2>/dev/null || true
+      AGENT_TOKEN_FILE="/var/run/hive-metrics/agent-tokens/gh-token-${agent_name}.cache"
+      # Create empty (never seeded with a value) — hive fills it at launch.
+      # touch is idempotent across restarts; chown/chmod re-assert the contract
+      # unconditionally in case a previous image left the file mis-owned.
+      touch "$AGENT_TOKEN_FILE" 2>/dev/null || true
+      chown "dev:${AGENT_TOKEN_GROUP}" "$AGENT_TOKEN_FILE" 2>/dev/null || true
+      chmod 640 "$AGENT_TOKEN_FILE" 2>/dev/null || true
+      echo "[entrypoint] Agent token cache: ${AGENT_TOKEN_FILE} (dev:${AGENT_TOKEN_GROUP} 0640)"
       echo "[entrypoint] Agent user: hive-${agent_name} (UID ${AGENT_UID})"
       UID_OFFSET=$((UID_OFFSET + 1))
     done

--- a/v2/pkg/agent/manager.go
+++ b/v2/pkg/agent/manager.go
@@ -590,7 +590,14 @@ func (m *Manager) Start(ctx context.Context, name string) error {
 	if m.appAuth != nil && agent.UID > 0 {
 		tier := m.agentMode(agent).TokenTier()
 		if err := m.appAuth.WriteAgentToken(ctx, agent.Name, tier, agent.UID); err != nil {
-			m.logger.Warn("failed to mint per-agent token, agent will use shared cache",
+			// Be precise about the blast radius. A shared-cache fallback does
+			// exist (gh-wrapper.sh / git-credential-hive.sh fall back to
+			// /var/run/hive-metrics/gh-app-token.cache), but it is the FULL
+			// installation token, not this agent's tier-scoped one — so the
+			// failure silently escalates privilege rather than degrading
+			// gracefully, and it only works at all if that shared cache is
+			// present and group-readable. Say that, don't imply it's fine.
+			m.logger.Warn("per-agent scoped token NOT delivered — agent falls back to the shared FULL-privilege App token (tier scoping lost); if the shared cache is also missing, all GitHub writes for this agent will fail",
 				"agent", agent.Name, "tier", tier, "error", err)
 		}
 	}

--- a/v2/pkg/github/agent_token_delivery_test.go
+++ b/v2/pkg/github/agent_token_delivery_test.go
@@ -1,0 +1,273 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Test constants — no magic numbers in the assertions below.
+const (
+	// testRSABits is the key size for the throwaway App signing key. 2048 is
+	// the minimum GitHub accepts and keeps test key generation fast.
+	testRSABits = 2048
+	// testTokenTTL is how far in the future the fake mint endpoint claims the
+	// token expires; any positive duration works.
+	testTokenTTL = time.Hour
+	// preCreatedMode mirrors what entrypoint.sh applies to a pre-created
+	// per-agent cache file: owner (dev) rw, owning agent's private group r.
+	preCreatedMode os.FileMode = 0o640
+	// otherAgentMode is a deliberately world-readable mode used to prove the
+	// isolation assertion is checking OUR file's mode, not a global umask.
+	otherAgentMode os.FileMode = 0o644
+)
+
+// newFakeAppAuth returns an AppAuth wired to a fake mint endpoint that always
+// returns the given token, plus a buffer capturing everything it logs.
+func newFakeAppAuth(t *testing.T, token string) (*AppAuth, *bytes.Buffer, func()) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"token":      token,
+			"expires_at": time.Now().Add(testTokenTTL).Format(time.RFC3339),
+		})
+	}))
+	key, err := rsa.GenerateKey(rand.Reader, testRSABits)
+	if err != nil {
+		t.Fatalf("generating test key: %v", err)
+	}
+	var logBuf bytes.Buffer
+	auth := &AppAuth{
+		appID:          1,
+		installationID: 2,
+		key:            key,
+		logger:         slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		apiURL:         server.URL,
+	}
+	return auth, &logBuf, server.Close
+}
+
+// useTempCacheDir redirects the package-level agent token cache dir at a temp
+// dir for the duration of the test.
+func useTempCacheDir(t *testing.T) string {
+	t.Helper()
+	orig := agentTokenCacheDir
+	dir := t.TempDir()
+	agentTokenCacheDir = dir
+	t.Cleanup(func() { agentTokenCacheDir = orig })
+	return dir
+}
+
+// TestWriteAgentToken_WritesInPlaceWithoutChown is the core regression test
+// for the fleet-wide delivery bug: WriteAgentToken must write the token into
+// the file entrypoint.sh pre-created, PRESERVING that file's mode, and must
+// never fail (or delete the token) because it cannot chown.
+func TestWriteAgentToken_WritesInPlaceWithoutChown(t *testing.T) {
+	const wantToken = "ghs-scoped-advisor"
+	auth, logBuf, closeFn := newFakeAppAuth(t, wantToken)
+	defer closeFn()
+	dir := useTempCacheDir(t)
+
+	// Simulate entrypoint.sh pre-creating the file as dev:hive-guide 0640.
+	path := AgentTokenCachePath("guide")
+	if err := os.WriteFile(path, nil, preCreatedMode); err != nil {
+		t.Fatalf("pre-creating cache file: %v", err)
+	}
+	if err := os.Chmod(path, preCreatedMode); err != nil {
+		t.Fatalf("chmod pre-created file: %v", err)
+	}
+
+	// A non-zero agent UID is the case that used to trigger the fatal chown.
+	if err := auth.WriteAgentToken(context.Background(), "guide", "advisor", 2001); err != nil {
+		t.Fatalf("WriteAgentToken returned error (must not chown): %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("token file missing after write — the old code deleted it: %v", err)
+	}
+	if string(got) != wantToken {
+		t.Errorf("token = %q, want %q", got, wantToken)
+	}
+
+	// The pre-created inode (and therefore its ownership) must survive: a
+	// write-temp-then-rename would reset the mode to the default.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != preCreatedMode {
+		t.Errorf("mode = %o, want %o (rename would have clobbered the entrypoint ownership)", info.Mode().Perm(), preCreatedMode)
+	}
+
+	// No leftover temp file — the old implementation used a .tmp sidecar.
+	if _, err := os.Stat(path + ".tmp"); err == nil {
+		t.Error("stray .tmp file left behind")
+	}
+
+	// The token value must never be logged.
+	if strings.Contains(logBuf.String(), wantToken) {
+		t.Error("token value leaked into logs")
+	}
+	// Pre-created path must NOT emit the degraded warning.
+	if strings.Contains(logBuf.String(), "not pre-created") {
+		t.Errorf("unexpected degraded warning on the healthy path: %s", logBuf.String())
+	}
+	// Fix the directory in the assertion so a path change is caught.
+	if !strings.HasPrefix(path, dir+"/") {
+		t.Errorf("cache path %q not under cache dir %q", path, dir)
+	}
+}
+
+// TestWriteAgentToken_DoesNotReplaceTheInode is the guard against
+// reintroducing a write-temp-then-rename. Verified in the real hive image: a
+// rename replaces the pre-created inode, the new one is created with the
+// writer's primary group (node, gid 1000) instead of the agent's private
+// group, and a DIFFERENT agent could then read the token. The inode number
+// must therefore be unchanged across a write.
+func TestWriteAgentToken_DoesNotReplaceTheInode(t *testing.T) {
+	auth, _, closeFn := newFakeAppAuth(t, "ghs-inode-check")
+	defer closeFn()
+	useTempCacheDir(t)
+
+	path := AgentTokenCachePath("stable")
+	if err := os.WriteFile(path, nil, preCreatedMode); err != nil {
+		t.Fatalf("pre-create: %v", err)
+	}
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat before: %v", err)
+	}
+
+	if err := auth.WriteAgentToken(context.Background(), "stable", "advisor", 2005); err != nil {
+		t.Fatalf("WriteAgentToken: %v", err)
+	}
+
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if !os.SameFile(before, after) {
+		t.Error("cache file inode was replaced — a rename would drop the per-agent group and leak the token to every agent in group node")
+	}
+}
+
+// TestWriteAgentToken_AdvisoryTierIsDelivered proves an ADVISORY agent — whose
+// mode fails CanPush() and is therefore deliberately kept GITHUB_TOKEN-less —
+// still receives its advisor-tier scoped token on disk. That file is the
+// advisory agent's only write path for posting ACMM L2 findings as comments.
+func TestWriteAgentToken_AdvisoryTierIsDelivered(t *testing.T) {
+	const wantToken = "ghs-advisor-comment-token"
+	auth, _, closeFn := newFakeAppAuth(t, wantToken)
+	defer closeFn()
+	useTempCacheDir(t)
+
+	path := AgentTokenCachePath("scanner")
+	if err := os.WriteFile(path, nil, preCreatedMode); err != nil {
+		t.Fatalf("pre-creating cache file: %v", err)
+	}
+
+	if err := auth.WriteAgentToken(context.Background(), "scanner", "advisor", 2002); err != nil {
+		t.Fatalf("advisory token delivery failed: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != wantToken {
+		t.Fatalf("advisor token not delivered: content=%q err=%v", got, err)
+	}
+}
+
+// TestWriteAgentToken_AgentsDoNotShareAFile asserts agent A's token never
+// lands in agent B's cache file, and that each agent's file keeps its own
+// mode. Cross-agent readability is prevented by per-agent GROUP ownership set
+// in entrypoint.sh, which cannot be asserted portably in a unit test without
+// root; what IS asserted here is that the code writes strictly per-agent paths
+// and never widens or reuses another agent's file.
+func TestWriteAgentToken_AgentsDoNotShareAFile(t *testing.T) {
+	const tokenA = "ghs-token-for-a"
+	authA, _, closeA := newFakeAppAuth(t, tokenA)
+	defer closeA()
+	useTempCacheDir(t)
+
+	pathA := AgentTokenCachePath("alpha")
+	pathB := AgentTokenCachePath("bravo")
+	if pathA == pathB {
+		t.Fatal("distinct agents resolved to the same cache path")
+	}
+	if err := os.WriteFile(pathA, nil, preCreatedMode); err != nil {
+		t.Fatalf("pre-create A: %v", err)
+	}
+	// Give B a deliberately different mode so we can prove A's write does not
+	// touch it in any way.
+	if err := os.WriteFile(pathB, []byte("bravo-existing"), otherAgentMode); err != nil {
+		t.Fatalf("pre-create B: %v", err)
+	}
+
+	if err := authA.WriteAgentToken(context.Background(), "alpha", "trusted", 2003); err != nil {
+		t.Fatalf("WriteAgentToken(alpha): %v", err)
+	}
+
+	bContents, err := os.ReadFile(pathB)
+	if err != nil {
+		t.Fatalf("read B: %v", err)
+	}
+	if string(bContents) != "bravo-existing" {
+		t.Errorf("agent alpha's write modified agent bravo's cache: %q", bContents)
+	}
+	if strings.Contains(string(bContents), tokenA) {
+		t.Error("agent alpha's token leaked into agent bravo's cache file")
+	}
+	infoB, err := os.Stat(pathB)
+	if err != nil {
+		t.Fatalf("stat B: %v", err)
+	}
+	if infoB.Mode().Perm() != otherAgentMode {
+		t.Errorf("bravo mode changed to %o", infoB.Mode().Perm())
+	}
+}
+
+// TestWriteAgentToken_MissingPreCreatedFileWarnsAccurately asserts the
+// degraded path produces a LOUD, accurate message. The old message claimed the
+// agent "will use shared cache" while having just DELETED the token; the
+// replacement must name the real consequence (privilege escalation to the
+// shared full token, or total failure) and must not claim things are fine.
+func TestWriteAgentToken_MissingPreCreatedFileWarnsAccurately(t *testing.T) {
+	const wantToken = "ghs-no-precreate"
+	auth, logBuf, closeFn := newFakeAppAuth(t, wantToken)
+	defer closeFn()
+	useTempCacheDir(t)
+
+	// Deliberately do NOT pre-create the file.
+	if err := auth.WriteAgentToken(context.Background(), "orphan", "newcomer", 2004); err != nil {
+		t.Fatalf("write should still succeed (best effort), got: %v", err)
+	}
+
+	logs := logBuf.String()
+	if !strings.Contains(logs, "not pre-created") {
+		t.Errorf("degraded path did not warn; logs: %s", logs)
+	}
+	if !strings.Contains(logs, "CANNOT read") {
+		t.Errorf("warning does not state the consequence; logs: %s", logs)
+	}
+	if strings.Contains(logs, wantToken) {
+		t.Error("token value leaked into logs")
+	}
+
+	// Whatever we did create must stay owner-only, never group-readable —
+	// group "node" contains every agent.
+	info, err := os.Stat(AgentTokenCachePath("orphan"))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		t.Errorf("degraded-path file mode %o is readable beyond the owner", info.Mode().Perm())
+	}
+}

--- a/v2/pkg/github/app.go
+++ b/v2/pkg/github/app.go
@@ -23,10 +23,23 @@ const (
 	DocsTokenCachePath = "/var/run/hive-metrics/gh-app-token-docs.cache"
 	tokenCachePerms    = 0o640
 
-	// Per-agent scoped token caches — only the owning agent UID can read.
-	agentTokenCacheDir   = "/var/run/hive-metrics/agent-tokens"
+	// Per-agent scoped token caches. entrypoint.sh pre-creates each file as
+	// dev:hive-<agent> mode 0640 so the hive process (dev) can rewrite it in
+	// place and ONLY the owning agent's private group can read it — no chown
+	// at runtime, which an unprivileged process cannot perform.
+	defaultAgentTokenCacheDir = "/var/run/hive-metrics/agent-tokens"
+	// Applied only when the file was NOT pre-created (degraded path): keep it
+	// owner-only rather than leaking a token to the shared "node" group.
 	agentTokenCachePerms = 0o600
+	// Directory must be traversable by every agent UID so each can open its
+	// own 0640 file; the files themselves carry the per-agent restriction.
+	agentTokenCacheDirPerms = 0o755
 )
+
+// agentTokenCacheDir is the directory holding per-agent token caches. It is a
+// variable rather than a constant solely so tests can redirect it to a temp
+// dir; production code never reassigns it.
+var agentTokenCacheDir = defaultAgentTokenCacheDir
 
 type AppAuth struct {
 	appID          int64
@@ -197,40 +210,72 @@ func AgentTokenCachePath(agentName string) string {
 	return agentTokenCacheDir + "/gh-token-" + agentName + ".cache"
 }
 
-// WriteAgentToken mints a scoped token for the given tier and writes it
-// to a per-agent cache file owned by agentUID with 0600 perms. The hive
-// binary (UID 1001) creates the file then chowns it to the agent UID so
-// only that agent can read it.
+// WriteAgentToken mints a tier-scoped token for the given agent and writes it
+// into that agent's pre-created cache file.
+//
+// Delivery model (no chown at runtime):
+//
+// The hive binary drops privileges to dev (UID 1001) and therefore CANNOT
+// chown — handing a file to a different UID requires CAP_CHOWN, which is not
+// granted in the hardened/OpenShift environments hive targets (the same
+// container already fails NET_ADMIN for iptables). The previous
+// implementation wrote a temp file and chowned it to the agent UID; that
+// chown ALWAYS failed with EPERM, the temp file was deleted, and no agent on
+// any hive ever received a token.
+//
+// Instead, entrypoint.sh pre-creates the cache file as root, before the
+// privilege drop, as dev:hive-<agent> mode 0640 (see the per-agent user loop
+// there). That gives us:
+//
+//   - owner dev  -> this process can rewrite the contents in place
+//   - group hive-<agent>, whose only member is that agent -> only the owning
+//     agent can read it (NOT group "node", which every agent shares)
+//
+// The write must therefore be IN PLACE. A write-temp-then-rename would
+// replace the pre-created inode with a fresh dev:node one and silently
+// destroy both the ownership and the isolation guarantee.
 func (a *AppAuth) WriteAgentToken(ctx context.Context, agentName, tier string, agentUID int) error {
 	token, err := a.ScopedToken(ctx, tier)
 	if err != nil {
 		return fmt.Errorf("minting scoped token for %s: %w", agentName, err)
 	}
 
-	if err := os.MkdirAll(agentTokenCacheDir, 0o755); err != nil {
+	if err := os.MkdirAll(agentTokenCacheDir, agentTokenCacheDirPerms); err != nil {
 		return fmt.Errorf("creating agent token dir: %w", err)
 	}
 
 	cachePath := AgentTokenCachePath(agentName)
-	tmpPath := cachePath + ".tmp"
-	if err := os.WriteFile(tmpPath, []byte(token), agentTokenCachePerms); err != nil {
-		return fmt.Errorf("writing agent token cache: %w", err)
+	preCreated := true
+	if _, statErr := os.Stat(cachePath); statErr != nil {
+		preCreated = false
 	}
 
-	if agentUID > 0 {
-		if err := os.Chown(tmpPath, agentUID, -1); err != nil {
-			a.logger.Warn("chown agent token cache failed — agent will use shared cache",
-				"agent", agentName, "uid", agentUID, "error", err)
-			os.Remove(tmpPath)
-			return fmt.Errorf("chown agent token: %w", err)
-		}
+	// O_TRUNC (not O_APPEND) so a shorter token fully replaces a longer one.
+	// The perm argument only applies if the file does not already exist; when
+	// entrypoint pre-created it, the existing 0640 dev:hive-<agent> mode wins.
+	f, err := os.OpenFile(cachePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, agentTokenCachePerms)
+	if err != nil {
+		return fmt.Errorf("opening agent token cache %s: %w", cachePath, err)
+	}
+	if _, err := f.WriteString(token); err != nil {
+		f.Close()
+		return fmt.Errorf("writing agent token cache %s: %w", cachePath, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("closing agent token cache %s: %w", cachePath, err)
 	}
 
-	if err := os.Rename(tmpPath, cachePath); err != nil {
-		return fmt.Errorf("rename agent token cache: %w", err)
+	if !preCreated && agentUID > 0 {
+		// The file did not exist, so we just created it as dev:node 0600 —
+		// the agent UID cannot read it. This is a real, silent-auth-failure
+		// condition, not a benign fallback: state it plainly and actionably.
+		// Do NOT attempt a chown here; it cannot succeed without CAP_CHOWN
+		// and the failure path is what caused this bug in the first place.
+		a.logger.Warn("agent token cache was not pre-created by entrypoint — the agent CANNOT read it and will fall back to the shared full-privilege token (least-privilege scoping lost); ensure entrypoint.sh created this file as dev:hive-<agent> 0640",
+			"agent", agentName, "uid", agentUID, "path", cachePath)
 	}
 
-	a.logger.Info("per-agent token cached", "agent", agentName, "tier", tier, "uid", agentUID)
+	a.logger.Info("per-agent token cached", "agent", agentName, "tier", tier, "uid", agentUID, "pre_created", preCreated)
 	return nil
 }
 


### PR DESCRIPTION
## The bug — fleet-wide and user-visible

The per-agent GitHub App token is minted on every agent launch but **never reaches any agent, on any hive**. No agent can write to GitHub using its scoped identity.

`WriteAgentToken` wrote the token to a temp file and then `chown`ed it to the agent UID. The hive binary drops privileges to `dev` (UID 1001), and an unprivileged process cannot give a file away to another UID without `CAP_CHOWN` — deliberately not granted in the hardened/OpenShift environments hive runs in (the same container already logs `WARN: iptables chain creation failed (need NET_ADMIN capability)`).

So the chown **always** failed, and the error path deleted the token. Live log from a fully-patched spoke:

```
INFO  scoped token minted  tier=advisor expires_at=2026-07-30T06:28:35Z
WARN  failed to mint per-agent token, agent will use shared cache  agent=guide tier=advisor
      error="chown agent token: chown .../gh-token-guide.cache.tmp: operation not permitted"
```

Result: `ls /var/run/hive-metrics/agent-tokens/` is empty. This affects **every backend** (claude, copilot, bob, …), not just one.

This is not fixable by requesting `CAP_CHOWN` — capabilities are restricted by design here.

## Why the obvious fixes don't work

Tested on a live spoke:

| Approach | Result |
|---|---|
| Per-agent dir owned by agent, `0700` | hive (1001) **cannot write** into it |
| Per-agent dir `0770`, group `node` | hive can write, but **leaks** — confirmed `hive-guide` read `scanner`'s token |
| Dir `0711` + file `0604` | blocks the owning agent too |

Every agent user shares primary group `node` (gid 1000):

```
uid=2004(hive-scanner) gid=1000(node) groups=1000(node)
uid=2002(hive-guide)   gid=1000(node) groups=1000(node)
```

So **group `node` can never isolate agents**, and making the token group-readable would hand every agent every other agent's scoped token.

## The fix — per-agent groups, pre-created at boot

`entrypoint.sh` runs as root before the privilege drop and already creates the `hive-<name>` users. The same loop now also:

1. creates a per-agent private group `hive-<agent>` and adds only that agent to it,
2. pre-creates the cache file as `dev:hive-<agent>` mode `0640`.

```
owner = dev (UID 1001)  -> hive rewrites it in place, no chown needed
group = hive-<agent>    -> only that agent can read it
mode  = 0640            -> owner rw, group r, world none
```

`dev` deliberately does **not** join these groups — it writes as the file **owner**, so it needs no membership. That keeps `dev` out of every agent's private group and avoids N `usermod` calls.

gids are auto-allocated by `groupadd --system` rather than derived from the agent UID; a derived gid (e.g. `uid+1000`) could collide with an existing group, whereas letting `groupadd` allocate cannot. `groupadd`/`usermod` ship in the same Debian `passwd` package as the `useradd` already used here — no new image dependency.

### The temp-file + rename had to go

`WriteAgentToken` now writes **in place** (`O_TRUNC`). This is load-bearing, not incidental: a rename replaces the pre-created inode with a fresh `dev:node` one, silently dropping the per-agent group. Verified in the real image — after a rename, a second agent could read the token. A test asserts the inode is unchanged across a write so this cannot regress.

## Log messages corrected

`"agent will use shared cache"` was false comfort that hid this bug. There was no token file at all, and the shared cache is the **full installation token**, not the agent's tier-scoped one — so falling back to it *escalates* privilege rather than degrading gracefully. Both messages now name the path, the UID, and the real consequence.

## Behavior preserved

- Mode-based restraint unchanged: `GH_TOKEN`/`GITHUB_TOKEN` stay unset for agents failing `CanPush()`.
- **ADVISORY agents still get their `advisor`-tier token** — it is their only write path for posting ACMM L2 findings as comments on the advisory issue.
- Token values are never logged.

## Verification

Ran in `ghcr.io/kubestellar/hive:v2-latest` with real UIDs:

```
dev writes scanner token in place: OK
scanner reads own token:           OK
guide reads scanner token:         Permission denied  <- isolated
mode after write:                  -rw-r----- 1 1001 <tok-gid>
```

Reverting to the `chown` reproduces the exact production error in the new tests:

```
chown agent token: chown .../gh-token-guide.cache: operation not permitted
```

New tests in `v2/pkg/github/agent_token_delivery_test.go`:

- writes in place without chown, preserving the pre-created mode
- inode is not replaced (rename-regression guard)
- advisory-tier token is delivered to an ADVISORY agent
- agent A's write cannot touch or leak into agent B's cache
- missing pre-created file produces a loud, accurate warning and stays owner-only

`go build ./...`, `go vet`, and `go test ./pkg/github/` pass. `gofmt` clean on touched files (`pkg/agent/manager.go` has PRE-EXISTING drift at HEAD, left untouched). The one `pkg/agent` test failure (`TestConcurrentPauseResume_NoPanic`) fails identically at HEAD without this change — it passes a nil context and needs local tmux.

## Porting

**mk, dd, and v3 all need this port.** ks/console's hive runs v3, so a v2-only merge will not reach it.

Confirmed there is **no path mismatch**: `agentTokenCacheDir` is `/var/run/hive-metrics/agent-tokens` and matches the logs. The chown was the sole failure.